### PR TITLE
[appkit] Add NSImage lazy initialization

### DIFF
--- a/src/AppKit/NSImage.cs
+++ b/src/AppKit/NSImage.cs
@@ -88,6 +88,14 @@ namespace XamCore.AppKit {
 			}
 		}
 
+		public NSImage (string fileName, bool lazy)
+		{
+			if (lazy)
+				Handle = InitByReferencingFile (fileName);
+			else
+				Handle = new NSImage (fileName).Handle;
+		}
+
 		public NSImage (NSData data, bool ignoresOrientation)
 		{
 			if (ignoresOrientation) {

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -8183,14 +8183,15 @@ namespace XamCore.AppKit {
 		[Export ("initWithContentsOfURL:")]
 		IntPtr Constructor (NSUrl url);
 
-		//[Export ("initByReferencingFile:")]
-		//IntPtr Constructor (string fileName);
 		//[Export ("initByReferencingURL:")]
 		//IntPtr Constructor (NSUrl url);
 
 		// FIXME: need IconRec
 		//[Export ("initWithIconRef:")]
 		//IntPtr Constructor (IconRef iconRef);
+
+		[Export ("initByReferencingFile:"), Internal]
+		IntPtr InitByReferencingFile (string name);
 
 		[Export ("initWithPasteboard:")]
 		IntPtr Constructor (NSPasteboard pasteboard);


### PR DESCRIPTION
We were missing `initByReferencingFile:` which initializes
the image object lazily.

The non working use case was:

```
var iconFile = NSBundle.MainBundle.PathForResource ("AppIcons", "icns");
NSApplication.SharedApplication.ApplicationIconImage = new NSImage (iconFile);
```

Here the constructor is calling `initWithContentsOfFile:` which will
not load the right icon from the `.icns` file.

That fixes https://bugzilla.xamarin.com/show_bug.cgi?id=40349.