### PR TITLE
[linker] Fix debugging of watchOS apps when link all is used. Fixes #40641

### DIFF
--- a/tools/linker/MobileResolveMainAssemblyStep.cs
+++ b/tools/linker/MobileResolveMainAssemblyStep.cs
@@ -27,6 +27,7 @@ namespace Xamarin.Linker.Steps {
 			// we have a watch extension which main project is a .dll and we have to tell the
 			// linker where to start (by marking the first, entry method)
 			Context.Resolver.CacheAssembly (assembly);
+			Context.SafeReadSymbols (assembly);
 
 			Annotations.Push (assembly);
 


### PR DESCRIPTION
Watch apps are inside .dll (not .exe) and needs to be processed
differently (e.g. to register their content). The issue was that the
debugging symbols were not loaded by that code so it was not part of
the .appex for debugging.

https://bugzilla.xamarin.com/show_bug.cgi?id=40641
