### PR TITLE
[Foundation] Add null check to NSObject.AddObserver overload

### DIFF
--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -828,6 +828,9 @@ namespace XamCore.Foundation {
 
 		public IDisposable AddObserver (NSString key, NSKeyValueObservingOptions options, Action<NSObservedChange> observer)
 		{
+			if (observer == null)
+				throw new ArgumentNullException ("observer");
+
 			var o = new Observer (this, key, observer);
 			AddObserver (o, key, options, o.Handle);
 			return o;


### PR DESCRIPTION
Currently NSObject throws `NullReferenceException` on first call to observer if callback provided by user is null:
https://github.com/xamarin/xamarin-macios/blob/master/src/Foundation/NSObject2.cs#L801

This PR adds null check for `observer` parameter and throws argument exception if it's null.

Supposed to fix https://bugzilla.xamarin.com/show_bug.cgi?id=40724