### PR TITLE
[Foundation] Add null check for Observer cback

### DIFF
--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -788,6 +788,9 @@ namespace XamCore.Foundation {
 			
 			public Observer (NSObject obj, NSString key, Action<NSObservedChange> cback)
 			{
+				if (cback == null)
+					throw new ArgumentNullException ("cback");
+
 				this.obj = new WeakReference (obj);
 				this.key = key;
 				this.cback = cback;

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -786,14 +786,14 @@ namespace XamCore.Foundation {
 			Action<NSObservedChange> cback;
 			NSString key;
 			
-			public Observer (NSObject obj, NSString key, Action<NSObservedChange> cback)
+			public Observer (NSObject obj, NSString key, Action<NSObservedChange> observer)
 			{
-				if (cback == null)
-					throw new ArgumentNullException ("cback");
+				if (observer == null)
+					throw new ArgumentNullException (nameof(observer));
 
 				this.obj = new WeakReference (obj);
 				this.key = key;
-				this.cback = cback;
+				this.cback = observer;
 				IsDirectBinding = false;
 			}
 


### PR DESCRIPTION
Currently NSObject throws NullReferenceException on first call to observer if callback provided by user is null:
https://github.com/xamarin/xamarin-macios/blob/master/src/Foundation/NSObject2.cs#L801

This PR adds null check for observer parameter and throws argument exception if it's null.

Supposed to fix https://bugzilla.xamarin.com/show_bug.cgi?id=40724

Original version of this PR can be found here #4