### PR TITLE
[mtouch] Fix issue where we'd incorrectly compute the target executable name.

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -320,6 +320,8 @@ namespace Xamarin.Bundler {
 				return null;
 
 			var plist = Driver.FromPList (info_plist);
+			if (!plist.ContainsKey (key))
+				return null;
 			return plist.GetString (key);
 		}
 


### PR DESCRIPTION
When reading a plist using NSDictionary, getting a value for a key
that doesn't exist returns null.

This changed when we switched to using our own managed plist reader,
which returns an empty string if a key doesn't exist.

Unfortunately we have code that checks if CFBundleExecutable is null,
in which case we compute the executable name using the executable
assembly, but since we started getting an empty string for
CFBundleExecutable if the key wasn't available, we now ended up wanting
to create an executable named as an empty string.

This broke our bug-13945 test case.

The fix is to continue returning null if the plist key isn't present.