### PR TITLE
Correct delegate signature on CNContactStoreEnumerateContactsHandler

### DIFF
--- a/src/contacts.cs
+++ b/src/contacts.cs
@@ -414,7 +414,7 @@ namespace XamCore.Contacts {
 	}
 
 	public delegate void CNContactStoreRequestAccessHandler (bool granted, NSError error);
-	public delegate void CNContactStoreEnumerateContactsHandler (CNContact contact, bool stop);
+	public delegate void CNContactStoreEnumerateContactsHandler (CNContact contact, ref bool stop);
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]


### PR DESCRIPTION
The signature on  `CNContactStoreEnumerateContactsHandler` should include a `ref`on the `bool stop` parameter in order to have the ability to early exit the enumeration.

Ref: http://stackoverflow.com/questions/36992982/early-exit-a-cncontactstoreenumeratecontactshandler-enumeration