### PR TITLE
[msbuild/tests] Add TVServicesExtension test

### DIFF
--- a/msbuild/tests/MyActionExtension/Info.plist
+++ b/msbuild/tests/MyActionExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>1.0</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/msbuild/tests/MyMasterDetailApp/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
+++ b/msbuild/tests/MyMasterDetailApp/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
@@ -94,11 +94,6 @@
       "size": "76x76",
       "scale": "2x",
       "idiom": "ipad"
-    },
-    {
-      "size": "120x120",
-      "scale": "1x",
-      "idiom": "car"
     }
   ],
   "info": {

--- a/msbuild/tests/MyMetalGame/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
+++ b/msbuild/tests/MyMetalGame/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
@@ -94,11 +94,6 @@
       "size": "76x76",
       "scale": "2x",
       "idiom": "ipad"
-    },
-    {
-      "size": "120x120",
-      "scale": "1x",
-      "idiom": "car"
     }
   ],
   "info": {

--- a/msbuild/tests/MyOpenGLApp/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
+++ b/msbuild/tests/MyOpenGLApp/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
@@ -94,11 +94,6 @@
       "size": "76x76",
       "scale": "2x",
       "idiom": "ipad"
-    },
-    {
-      "size": "120x120",
-      "scale": "1x",
-      "idiom": "car"
     }
   ],
   "info": {

--- a/msbuild/tests/MyTVApp/MyTVApp.csproj
+++ b/msbuild/tests/MyTVApp/MyTVApp.csproj
@@ -83,6 +83,13 @@
       <DependentUpon>MySingleViewViewController.cs</DependentUpon>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MyTVServicesExtension\MyTVServicesExtension.csproj">
+      <IsAppExtension>true</IsAppExtension>
+      <Project>{0F124570-8B79-4593-B618-A90E51F339DF}</Project>
+      <Name>MyTVServicesExtension</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\TVOS\Xamarin.TVOS.CSharp.targets" />
   <ItemGroup>
     <InterfaceDefinition Include="MainStoryboard.storyboard" />

--- a/msbuild/tests/MyTVServicesExtension/Entitlements.plist
+++ b/msbuild/tests/MyTVServicesExtension/Entitlements.plist
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/msbuild/tests/MyTVServicesExtension/Info.plist
+++ b/msbuild/tests/MyTVServicesExtension/Info.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>MyTVServicesExtension</string>
+	<key>CFBundleName</key>
+	<string>MyTVServicesExtension</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.xamarin.mytvapp.mytvservicesextension</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>MinimumOSVersion</key>
+	<string>9.2</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>TVExtensionProtocols</key>
+			<array>
+				<string>TVTopShelfProvider</string>
+			</array>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.tv-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>ServiceProvider</string>
+	</dict>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+</dict>
+</plist>

--- a/msbuild/tests/MyTVServicesExtension/MyTVServicesExtension.csproj
+++ b/msbuild/tests/MyTVServicesExtension/MyTVServicesExtension.csproj
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProjectGuid>{0F124570-8B79-4593-B618-A90E51F339DF}</ProjectGuid>
+    <ProjectTypeGuids>{53F59511-8024-45F7-9A2A-2739F70C7A80};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>MyTVServicesExtension</RootNamespace>
+    <AssemblyName>MyTVServicesExtension</AssemblyName>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchFastDev>true</MtouchFastDev>
+    <MtouchProfiling>true</MtouchProfiling>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>x86_64</MtouchArch>
+    <DeviceSpecificBuild>false</DeviceSpecificBuild>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <DefineConstants></DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchUseLlvm>true</MtouchUseLlvm>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchFloat32>true</MtouchFloat32>
+    <MtouchEnableBitcode>true</MtouchEnableBitcode>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchArch>ARM64</MtouchArch>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <DefineConstants></DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>x86_64</MtouchArch>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <DeviceSpecificBuild>true</DeviceSpecificBuild>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchFastDev>true</MtouchFastDev>
+    <MtouchProfiling>true</MtouchProfiling>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <IOSDebuggerPort>10001</IOSDebuggerPort>
+    <MtouchArch>ARM64</MtouchArch>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.TVOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+    <None Include="Entitlements.plist" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ServiceProvider.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\TVOS\Xamarin.TVOS.AppExtension.CSharp.targets" />
+</Project>

--- a/msbuild/tests/MyTVServicesExtension/ServiceProvider.cs
+++ b/msbuild/tests/MyTVServicesExtension/ServiceProvider.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Foundation;
+using TVServices;
+
+namespace MyTVServicesExtension
+{
+	public class ServiceProvider : NSObject, ITVTopShelfProvider
+	{
+		protected ServiceProvider (IntPtr handle) : base (handle)
+		{
+			// Note: this .ctor should not contain any initialization logic.
+		}
+
+		public TVContentItem [] TopShelfItems {
+			[Export ("topShelfItems")]
+			get;
+		}
+
+		public TVTopShelfContentStyle TopShelfStyle {
+			[Export ("topShelfStyle")]
+			get;
+		}
+	}
+}
+

--- a/msbuild/tests/MyTabbedApplication/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
+++ b/msbuild/tests/MyTabbedApplication/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
@@ -94,11 +94,6 @@
       "size": "76x76",
       "scale": "2x",
       "idiom": "ipad"
-    },
-    {
-      "size": "120x120",
-      "scale": "1x",
-      "idiom": "car"
     }
   ],
   "info": {

--- a/msbuild/tests/MyWatch2Container/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
+++ b/msbuild/tests/MyWatch2Container/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
@@ -96,11 +96,6 @@
       "scale": "2x"
     },
     {
-      "idiom": "car",
-      "size": "120x120",
-      "scale": "1x"
-    },
-    {
       "size": "24x24",
       "idiom": "watch",
       "scale": "2x",

--- a/msbuild/tests/MyWatchApp/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
+++ b/msbuild/tests/MyWatchApp/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
@@ -94,11 +94,6 @@
       "size": "76x76",
       "scale": "2x",
       "idiom": "ipad"
-    },
-    {
-      "size": "120x120",
-      "scale": "1x",
-      "idiom": "car"
     }
   ],
   "info": {

--- a/msbuild/tests/MyWatchApp2/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
+++ b/msbuild/tests/MyWatchApp2/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
@@ -96,11 +96,6 @@
       "scale" : "2x"
     },
     {
-      "idiom" : "car",
-      "size" : "120x120",
-      "scale" : "1x"
-    },
-    {
       "size" : "24x24",
       "idiom" : "watch",
       "scale" : "2x",

--- a/msbuild/tests/MyWebViewApp/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
+++ b/msbuild/tests/MyWebViewApp/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
@@ -94,11 +94,6 @@
       "size": "76x76",
       "scale": "2x",
       "idiom": "ipad"
-    },
-    {
-      "size": "120x120",
-      "scale": "1x",
-      "idiom": "car"
     }
   ],
   "info": {

--- a/msbuild/tests/MyiOSAppWithBinding/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
+++ b/msbuild/tests/MyiOSAppWithBinding/Resources/Images.xcassets/AppIcons.appiconset/Contents.json
@@ -96,11 +96,6 @@
       "scale": "2x"
     },
     {
-      "idiom": "car",
-      "size": "120x120",
-      "scale": "1x"
-    },
-    {
       "size": "24x24",
       "idiom": "watch",
       "scale": "2x",

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/TVOS/TVApp.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/TVOS/TVApp.cs
@@ -4,16 +4,16 @@ namespace Xamarin.iOS.Tasks
 {
 	[TestFixture("TV", "iPhone")]
 	[TestFixture("TVSimulator", "iPhoneSimulator")]
-	public class MyTVAppTests : ProjectTest
+	public class TVAppTests : ExtensionTestBase
 	{
-		public MyTVAppTests(string bundlePath, string platform) : base(bundlePath, platform)
+		public TVAppTests (string bundlePath, string platform) : base(bundlePath, platform)
 		{
 		}
 
 		[Test]
 		public void BasicTest()
 		{
-			BuildProject("MyTVApp", BundlePath, Platform);
+			BuildExtension("MyTVApp", "MyTVServicesExtension", BundlePath, Platform);
 		}
 
 		public override string TargetFrameworkIdentifier {

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -92,7 +92,7 @@
     <Compile Include="..\..\..\tests\common\Configuration.cs">
       <Link>Configuration.cs</Link>
     </Compile>
-    <Compile Include="ProjectsTests\TVOS\MyTVApp.cs" />
+    <Compile Include="ProjectsTests\TVOS\TVApp.cs" />
     <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_iOS.cs" />
     <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_Core.cs" />
     <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_iOS_AppExtension.cs" />


### PR DESCRIPTION
Not only we test the `MyTVApp` tvOS project but
also the `MyTVServicesExtension` tvOS extension project.

Also:

- Add `MyActionExtension` version number fix.
- Remove the car idiom from `Contents.json` files to avoid actool warning message.