### PR TITLE
[generator] Fix bug 17232 - Invalid class name generated in the Libraries.g.cs file.

### DIFF
--- a/src/error.cs
+++ b/src/error.cs
@@ -56,6 +56,7 @@ using System.Collections.Generic;
 //		BI1039 The selector {0} on type {1} is found multiple times with different argument length {2} : {3}.
 //		BI1040 The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
 //		BI1041 The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.
+//		BI1042 Missing '[Field (LibraryName=value)]' for {field_pi.Name} (e.g."__Internal")
 //	BI11xx	warnings
 //		BI1101 Trying to use a string as a [Target]
 //		BI1102 Using the deprecated EventArgs for a delegate signature in {0}.{1}, please use DelegateName instead

--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using XamCore.Foundation;
 using XamCore.ObjCRuntime;
@@ -96,8 +97,8 @@ public partial class Generator {
 				library_name = library_name.Substring (ns.Prefix.Length + 1);
 
 			// there might not be any other fields in the framework
-			if (!libraries.Contains (library_name))
-				libraries.Add (library_name);
+			if (!libraries.ContainsKey (library_name))
+				libraries.Add (library_name, null);
 		}
 
 		if (error != null) {


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=17232

* Added support for specifying library path in FieldAttribute
* Fixed generator error when Namespaces contains dots `.`
* Added error BI1042 Missing '[Field (LibraryName=value)]' for {field_pi.Name} (e.g."__Internal")
  instead of generating invalid c# code when no LibraryName is provided
  in 3rd party bindings
* Kept support for just using the system library name in FieldAttribute
  (i.e. [Field ("UnboundFooSymbol", "UIKit")]

This does not change our current generated code at all:
https://gist.github.com/dalexsoto/338464a260bc6971e7b665ca9463e8b9