### PR TITLE
[Fix] Add missing C# events in the UIAdaptivePresentationControllerDelegate and UIPopoverPresentationControllerDelegate classes.

### DIFF
--- a/src/UIKit/UIAdaptivePresentationControllerDelegate.cs
+++ b/src/UIKit/UIAdaptivePresentationControllerDelegate.cs
@@ -1,0 +1,37 @@
+#if !WATCH
+using System;
+using XamCore.UIKit;
+using XamCore.ObjCRuntime;
+using XamCore.Foundation;
+
+namespace XamCore.UIKit {
+	public partial class UIAdaptivePresentationControllerDelegate
+	{
+		// this is a workaround to allow exposing the old API ()
+		[Export ("adaptivePresentationStyleForPresentationController:")]
+		public virtual UIModalPresentationStyle GetAdaptivePresentationStyle (UIPresentationController forPresentationController)
+		{
+			throw new You_Should_Not_Call_base_In_This_Method ();
+		}
+	}
+	
+	public static partial class UIAdaptivePresentationControllerDelegate_Extensions
+	{
+		public static UIModalPresentationStyle GetAdaptivePresentationStyle (this IUIAdaptivePresentationControllerDelegate This, UIPresentationController forPresentationController)
+		{
+			UIKit.UIApplication.EnsureUIThread ();
+			if (forPresentationController == null)
+				throw new ArgumentNullException ("forPresentationController");
+			UIModalPresentationStyle ret;
+			if (IntPtr.Size == 8) {
+				ret = (UIModalPresentationStyle) ObjCRuntime.Messaging.Int64_objc_msgSend_IntPtr (This.Handle, Selector.GetHandle ("adaptivePresentationStyleForPresentationController:"), forPresentationController.Handle);
+			} else {
+				ret = (UIModalPresentationStyle) ObjCRuntime.Messaging.int_objc_msgSend_IntPtr (This.Handle, Selector.GetHandle ("adaptivePresentationStyleForPresentationController:"), forPresentationController.Handle);
+			}
+			return ret;
+		}
+	}
+
+}
+
+#endif

--- a/src/UIKit/UIPopoverPresentationControllerDelegate.cs
+++ b/src/UIKit/UIPopoverPresentationControllerDelegate.cs
@@ -1,0 +1,18 @@
+
+#if !WATCH
+using XamCore.UIKit;
+using XamCore.Foundation;
+
+namespace XamCore.UIKit {
+	public partial class UIPopoverPresentationControllerDelegate 
+	{
+		// this is a workaround to allow exposing the old API ()
+		[Export ("adaptivePresentationStyleForPresentationController:")]
+		public virtual UIModalPresentationStyle GetAdaptivePresentationStyle (UIPresentationController forPresentationController)
+		{
+			throw new You_Should_Not_Call_base_In_This_Method ();
+		}
+	}
+}
+
+#endif

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1215,6 +1215,7 @@ UIKIT_SOURCES = \
 	UIKit/UIActionSheet.cs \
 	UIKit/UIActivityItemProvider.cs \
 	UIKit/UIActivityViewController.cs \
+	UIKit/UIAdaptivePresentationControllerDelegate.cs \
 	UIKit/UIAlertView.cs \
 	UIKit/UIAppearance.cs \
 	UIKit/UIApplication.cs \
@@ -1252,6 +1253,7 @@ UIKIT_SOURCES = \
 	UIKit/UIPickerView.cs \
 	UIKit/UIPopoverController.cs \
 	UIKit/UIPopoverPresentationController.cs \
+	UIKit/UIPopoverPresentationControllerDelegate.cs \
 	UIKit/UIPrint.cs \
 	UIKit/UIPushBehavior.cs \
 	UIKit/UIResponder.cs \

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -13596,7 +13596,9 @@ namespace XamCore.UIKit {
 
 	[NoTV]
 	[iOS (8,0)]
-	[BaseType (typeof (UIPresentationController))]
+	[BaseType (typeof (UIPresentationController),
+		Delegates=new string [] {"WeakDelegate"},
+		Events=new Type [] { typeof (UIPopoverPresentationControllerDelegate) })]
 	[DisableDefaultCtor] // NSGenericException Reason: -[UIPopoverController init] is not a valid initializer. You must call -[UIPopoverController initWithContentViewController:]
 	public partial interface UIPopoverPresentationController {
 		// re-exposed from base class
@@ -13652,18 +13654,18 @@ namespace XamCore.UIKit {
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	public partial interface UIAdaptivePresentationControllerDelegate {
-		[Export ("adaptivePresentationStyleForPresentationController:")]
-		UIModalPresentationStyle GetAdaptivePresentationStyle (UIPresentationController forPresentationController);
-	
-		[Export ("presentationController:viewControllerForAdaptivePresentationStyle:")]
+		[Export ("presentationController:viewControllerForAdaptivePresentationStyle:"),
+			DelegateName ("AdaptivePresentationRequestedWithStyle"), DefaultValue (null)]
 		UIViewController GetViewControllerForAdaptivePresentation (UIPresentationController controller, UIModalPresentationStyle style);
 
 		[iOS (8,3)]
-		[Export ("adaptivePresentationStyleForPresentationController:traitCollection:")]
+		[Export ("adaptivePresentationStyleForPresentationController:traitCollection:"),
+			DelegateName ("AdaptivePresentationStyleWithTraitsRequested"), DefaultValue (UIModalPresentationStyle.None)]
 		UIModalPresentationStyle GetAdaptivePresentationStyle (UIPresentationController controller, UITraitCollection traitCollection);
 
 		[iOS (8,3)]
-		[Export ("presentationController:willPresentWithAdaptiveStyle:transitionCoordinator:")]
+		[Export ("presentationController:willPresentWithAdaptiveStyle:transitionCoordinator:"),
+			DelegateName ("WillPresentController"), EventArgs ("WillPresentAdaptiveStyle")]
 		void WillPresent (UIPresentationController presentationController, UIModalPresentationStyle style, IUIViewControllerTransitionCoordinator transitionCoordinator);
 	}
 
@@ -13671,16 +13673,17 @@ namespace XamCore.UIKit {
 	[Protocol, Model]
 	[BaseType (typeof (UIAdaptivePresentationControllerDelegate))]
 	public partial interface UIPopoverPresentationControllerDelegate {
-		[Export ("prepareForPopoverPresentation:")]
+		[Export ("prepareForPopoverPresentation:"), DelegateName ("PrepareForPresentation")]
 		void PrepareForPopoverPresentation (UIPopoverPresentationController popoverPresentationController);
 		
-		[Export ("popoverPresentationControllerShouldDismissPopover:")]
+		[Export ("popoverPresentationControllerShouldDismissPopover:"), DelegateName ("ShouldDismiss"), DefaultValue (true)]
 		bool ShouldDismissPopover (UIPopoverPresentationController popoverPresentationController);
 
-		[Export ("popoverPresentationControllerDidDismissPopover:")]
+		[Export ("popoverPresentationControllerDidDismissPopover:"), DelegateName ("DidDismiss")]
 		void DidDismissPopover (UIPopoverPresentationController popoverPresentationController);
 		
-		[Export ("popoverPresentationController:willRepositionPopoverToRect:inView:")]
+		[Export ("popoverPresentationController:willRepositionPopoverToRect:inView:"),
+			DelegateName ("WillReposition"), EventArgs ("UIPopoverPresentationControllerReposition")]
 		void WillRepositionPopover (UIPopoverPresentationController popoverPresentationController, ref CGRect targetRect, ref UIView inView);
 	}
 	


### PR DESCRIPTION
In order to understand this PR you need to know the following details:

* UIAdaptivePresentationControllerDelegate: This class contains GetAdaptivePresentationStyle as an overloaded method. This means that the generator cannot generate the C# events for both implementations of the method.
* GetAdaptivePresentationStyle (UIPresentationController controller) as per apple documentation should not be used if the method that takes the trait collection can be used:  `In iOS 8.3 and later, use the adaptivePresentationStyleForPresentationController:traitCollection:`
* The C# event added is using the recommended method by apple will only be present in the 8.3 version. Older versions won't have the event and will have to implement the GetAdaptivePresentationStyle (UIPresentationController controller) on in a subclass.
* The extension method that used to be generated won't be present since the generator will ignore it.

Taking into account the above, I moved the old method implementation to a diff file so that it is not picked up by the generator, that way the generator can create all the C# events without change and will ignore the old method. The old API is maintained + we add the new events only for version of ios 8.3 +
