### PR TITLE
[mmp] Implement support for finding the local XamMac prefix when running from Xamarin Studio.

### DIFF
--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -807,11 +807,20 @@ namespace Xamarin.Bundler {
 
 		static string GetXamMacPrefix ()
 		{
-			var path = System.Reflection.Assembly.GetExecutingAssembly ().Location;
-
 			var envFrameworkPath = Environment.GetEnvironmentVariable ("XAMMAC_FRAMEWORK_PATH");
 			if (!String.IsNullOrEmpty (envFrameworkPath) && Directory.Exists (envFrameworkPath))
 				return envFrameworkPath;
+
+			var path = System.Reflection.Assembly.GetExecutingAssembly ().Location;
+
+#if DEBUG
+			var localPath = Path.GetDirectoryName (path);
+			while (localPath.Length > 1) {
+				if (Directory.Exists (Path.Combine (localPath, "_mac-build")))
+					return Path.Combine (localPath, "_mac-build", "Library", "Frameworks", "Xamarin.Mac.framework", "Versions", "Current");
+				localPath = Path.GetDirectoryName (localPath);
+			}
+#endif
 
 			path = GetRealPath (path);
 			return Path.GetDirectoryName (Path.GetDirectoryName (Path.GetDirectoryName (path)));

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -15,7 +15,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>MONOMAC;MMP</DefineConstants>
+    <DefineConstants>MONOMAC;MMP;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Traverse directories to find the locally build XamMac directory
when DEBUG is defined (which is only defined in the csproj, which
is only built when running from Xamarin Studio, since the mmp we
ship is built manually in the Makefile).