### PR TITLE
Bump to mono 4.4 to get a 64-bit capable mono.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -53,9 +53,9 @@ XCODE_URL=http://storage.bos.xamarin.com/bot-provisioning/Xcode_7.3.dmg
 XCODE_DEVELOPER_ROOT=/Applications/Xcode73.app/Contents/Developer
 
 # Minimum Mono version
-MIN_MONO_VERSION=4.0
+MIN_MONO_VERSION=4.4.0.148
 MAX_MONO_VERSION=4.4.99
-MIN_MONO_URL=http://download.mono-project.com/archive/4.0.4/macos-10-x86/MonoFramework-MDK-4.0.4.4.macos10.xamarin.x86.pkg
+MIN_MONO_URL=http://download.mono-project.com/archive/4.4.0/macos-10-universal/MonoFramework-MDK-4.4.0.148.macos10.xamarin.universal.pkg
 
 # Minimum Xamarin Studio version
 MIN_XAMARIN_STUDIO_URL=https://files.xamarin.com/~rolf/XamarinStudio-6.0.0.5104-0-1.dmg

--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -287,8 +287,8 @@ function check_mono () {
 	MIN_MONO_VERSION=`grep MIN_MONO_VERSION= Make.config | sed 's/.*=//'`
 	MAX_MONO_VERSION=`grep MAX_MONO_VERSION= Make.config | sed 's/.*=//'`
 
-	ACTUAL_MONO_VERSION=`$PKG_CONFIG_PATH --modversion mono`
-	if ! $PKG_CONFIG_PATH --atleast-version $MIN_MONO_VERSION mono; then
+	ACTUAL_MONO_VERSION=`$PKG_CONFIG_PATH --modversion mono`.`cat /Library/Frameworks/Mono.framework/Home/updateinfo | cut -d' ' -f2 | rev | cut -c-3 | rev | awk '{print(int($0))}'`
+	if ! is_at_least_version $ACTUAL_MONO_VERSION $MIN_MONO_VERSION; then
 		if ! test -z $PROVISION_MONO; then
 			install_mono
 			ACTUAL_MONO_VERSION=`$PKG_CONFIG_PATH --modversion mono`
@@ -298,10 +298,10 @@ function check_mono () {
 		fi
 	elif [[ "$ACTUAL_MONO_VERSION" == "$MAX_MONO_VERSION" ]]; then
 		: # this is ok
-	elif $PKG_CONFIG_PATH --atleast-version $MAX_MONO_VERSION mono; then
+	elif is_at_least_version $ACTUAL_MONO_VERSION $MAX_MONO_VERSION; then
 		if ! test -z $PROVISION_MONO; then
 			install_mono
-			ACTUAL_MONO_VERSION=`$PKG_CONFIG_PATH --modversion mono`
+			ACTUAL_MONO_VERSION=`$PKG_CONFIG_PATH --modversion mono`.`cat /Library/Frameworks/Mono.framework/Home/updateinfo | cut -d' ' -f2 | rev | cut -c-3 | rev | awk '{print(int($0))}'`
 		else
 			fail "Your mono version is too new, max version is $MAX_MONO_VERSION, found $ACTUAL_MONO_VERSION."
 			fail "You may edit Make.config and change MAX_MONO_VERSION to your actual version to continue the"


### PR DESCRIPTION
mdtool from Xamarin Studio 6.0 is a 64-bit process,
and thus requires a 64-bit capable system mono.