### PR TITLE
[msbuild/tests] Add ValidateAppBundleTaskTests

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/ExtensionTestBase.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/ExtensionTestBase.cs
@@ -8,6 +8,8 @@ namespace Xamarin.iOS.Tasks
 		public string BundlePath;
 		public string Platform;
 
+		public ExtensionTestBase () { }
+
 		public ExtensionTestBase (string platform) {
 			Platform = platform;
 		}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/ValidateAppBundleTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/ValidateAppBundleTaskTests.cs
@@ -1,0 +1,76 @@
+using System.IO;
+using NUnit.Framework;
+using Xamarin.MacDev;
+
+namespace Xamarin.iOS.Tasks
+{
+	[TestFixture]
+	public class ValidateAppBundleTaskTests : ExtensionTestBase
+	{
+		ValidateAppBundleTask task;
+
+		string extensionBundlePath;
+
+		string mainAppPlistPath;
+		string extensionPlistPath;
+
+		PDictionary sourcePlist;
+
+		public override void Setup ()
+		{
+			base.Setup ();
+
+			var extensionName = "MyActionExtension";
+			BuildExtension ("MyTabbedApplication", extensionName, "iPhoneSimulator");
+
+			task = CreateTask<ValidateAppBundleTask> ();
+			task.AppBundlePath = AppBundlePath;
+			task.SdkIsSimulator = true;
+			task.TargetFrameworkIdentifier = "Xamarin.iOS";
+
+			extensionBundlePath = Path.Combine (AppBundlePath, "PlugIns", extensionName + ".appex");
+
+			mainAppPlistPath = Path.Combine (AppBundlePath, "Info.plist");
+			extensionPlistPath = Path.Combine (extensionBundlePath, "Info.plist");
+
+			sourcePlist = PDictionary.FromFile (mainAppPlistPath);
+		}
+
+		[Test]
+		public void MissingPlist_MainApp ()
+		{
+			File.Delete (mainAppPlistPath);
+			Assert.IsFalse (task.Execute (), "#1");
+			Assert.IsTrue (Engine.Logger.ErrorEvents.Count > 0, "#2");
+		}
+
+		[Test]
+		public void MissingPlist_Extension ()
+		{
+			File.Delete (extensionPlistPath);
+			Assert.IsFalse (task.Execute (), "#1");
+			Assert.IsTrue (Engine.Logger.ErrorEvents.Count > 0, "#2");
+		}
+
+		[Test (Description = "Xambug #38673")]
+		public void NotMatching_VersionBuildNumbers ()
+		{
+			var warningCount = Engine.Logger.WarningsEvents.Count;
+
+			// Warning: The App Extension has a CFBundleShortVersionString
+			// that does not match the main app bundle's CFBundleShortVersionString.
+			sourcePlist.SetCFBundleShortVersionString ("1");
+			warningCount++;
+
+			// Warning: The App Extension has a CFBundleVersion
+			// that does not match the main app bundle's CFBundleVersion.
+			sourcePlist.SetCFBundleVersion ("1");
+			warningCount++;
+
+			sourcePlist.Save (mainAppPlistPath);
+			Assert.True (task.Execute (), "#1"); // No build error.
+			Assert.AreEqual (warningCount, Engine.Logger.WarningsEvents.Count, "#2");
+		}
+	}
+}
+

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_watchOS_WatchKitApp.cs" />
     <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_tvOS.cs" />
     <Compile Include="TaskTests\SymbolStripTaskTests.cs" />
+    <Compile Include="TaskTests\ValidateAppBundleTaskTests.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Includes regression test for bug #38673:
https://bugzilla.xamarin.com/show_bug.cgi?id=38673

Description:
"Validate that CFBundleVersion and CFBundleShortVersionString
match across main app and all extensions".