### PR TITLE
[AudioToolbox] Add missing MusicSequence.SetUserCallback method

### DIFF
--- a/src/AudioToolbox/MusicSequence.cs
+++ b/src/AudioToolbox/MusicSequence.cs
@@ -294,12 +294,8 @@ namespace XamCore.AudioToolbox {
 
 		public void SetUserCallback (MusicSequenceUserCallback callback)
 		{
-			lock (userCallbackHandles) {
-				if (userCallbackHandles.ContainsKey (handle))
-					userCallbackHandles[handle] = callback;
-				else
-					userCallbackHandles.Add (handle, callback);
-			}
+			lock (userCallbackHandles)
+				userCallbackHandles [handle] = callback;
 
 			MusicSequenceSetUserCallback (handle, userCallbackProxy, IntPtr.Zero);
 		}

--- a/src/AudioToolbox/MusicTrack.cs
+++ b/src/AudioToolbox/MusicTrack.cs
@@ -133,11 +133,11 @@ namespace XamCore.AudioToolbox {
 		internal MusicEventUserData (IntPtr handle)
 		{
 			if (handle == IntPtr.Zero)
-				throw new ArgumentNullException (nameof(handle));
+				throw new ArgumentNullException (nameof (handle));
 
 			int length = Marshal.ReadInt32 (handle);
 
-			var buffer = new byte[length];
+			var buffer = new byte [length];
 			Marshal.Copy (handle + 4, buffer, 0, length);
 
 			len = length;

--- a/src/AudioToolbox/MusicTrack.cs
+++ b/src/AudioToolbox/MusicTrack.cs
@@ -129,6 +129,20 @@ namespace XamCore.AudioToolbox {
 
 	public class MusicEventUserData : MidiRawData {
 		public MusicEventUserData () {}
+
+		internal MusicEventUserData (IntPtr handle)
+		{
+			var buffer = new byte[sizeof(int)];
+			Marshal.Copy (handle, buffer, 0, sizeof(int));
+			int length = BitConverter.ToInt32 (buffer, 0);
+
+			var dataPtr = IntPtr.Add (handle, sizeof (int));
+			buffer = new byte[length];
+			Marshal.Copy (dataPtr, buffer, 0, length);
+
+			len = length;
+			data = buffer;
+		}
 	}
 
 	//

--- a/src/AudioToolbox/MusicTrack.cs
+++ b/src/AudioToolbox/MusicTrack.cs
@@ -132,13 +132,13 @@ namespace XamCore.AudioToolbox {
 
 		internal MusicEventUserData (IntPtr handle)
 		{
-			var buffer = new byte[sizeof(int)];
-			Marshal.Copy (handle, buffer, 0, sizeof(int));
-			int length = BitConverter.ToInt32 (buffer, 0);
+			if (handle == IntPtr.Zero)
+				throw new ArgumentNullException (nameof(handle));
 
-			var dataPtr = IntPtr.Add (handle, sizeof (int));
-			buffer = new byte[length];
-			Marshal.Copy (dataPtr, buffer, 0, length);
+			int length = Marshal.ReadInt32 (handle);
+
+			var buffer = new byte[length];
+			Marshal.Copy (handle + 4, buffer, 0, length);
 
 			len = length;
 			data = buffer;


### PR DESCRIPTION
Add: 
* Missing MusicSequence.SetUserCallback method
* Internal .ctor for MusicEventUserData which takes IntPtr

Questions:
* Original [MusicEventUserData](https://developer.apple.com/library/mac/documentation/AudioToolbox/Reference/MusicTrack_Reference/#//apple_ref/c/tdef/MusicEventUserData) has `length` and `data`. So users of the API can explore the contents of MusicEventUserData. In our version of API we also have both length and data but they're not exposed. Do you think we should make them available for the user?