### PR TITLE
[runtime] Disable the GC pump for Xamarin.Mac.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -35,7 +35,7 @@ bool xamarin_detect_unified_build = true;
 bool xamarin_detect_unified_build = false;
 #endif
 bool xamarin_use_new_assemblies = false;
-#if DEBUG && (defined (__i386__) || defined (__x86_64__))
+#if MONOTOUCH && DEBUG && (defined (__i386__) || defined (__x86_64__))
 bool xamarin_gc_pump = true;
 #else
 bool xamarin_gc_pump = false;


### PR DESCRIPTION
[runtime] Disable the GC pump for Xamarin.Mac.

It seems it prevents the app from exiting; Mono will wait
for the GC pump thread to exit, which never happens.

The GC pump was never enabled for Xamarin.Mac apps
until recently (d9677714a), so this will just revert
to the previous behavior.

    thread 1: tid = 0x2ab2bf5, 0x00007fff97815eb2 libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'tid_50f', queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
      frame 0: 0x00007fff97815eb2 libsystem_kernel.dylib`__psynch_cvwait + 10
      frame 1: 0x00007fff89015150 libsystem_pthread.dylib`_pthread_cond_wait + 767
      frame 2: 0x000000010ceb1283 MobileTestApp`_wapi_handle_timedwait_signal_handle [inlined] mono_os_cond_wait(cond=<unavailable>, mutex=<unavailable>) + 8 at mono-os-mutex.h:107 [opt]
      frame 3: 0x000000010ceb127b MobileTestApp`_wapi_handle_timedwait_signal_handle [inlined] mono_os_cond_timedwait(cond=<unavailable>, mutex=0x00007fb085016210, timeout_ms=<unavailable>) at mono-os-mutex.h:122 [opt]
      frame 4: 0x000000010ceb127b MobileTestApp`_wapi_handle_timedwait_signal_handle(handle=0x0000000000000400, timeout=<unavailable>, alertable=1, poll=0, alerted=0x00007fff52fb4984) + 1003 at handles.c:1555 [opt]
      frame 5: 0x000000010cec3d87 MobileTestApp`wapi_WaitForMultipleObjectsEx(numobjects=2, handles=<unavailable>, waitall=0, timeout=4294967295, alertable=<unavailable>) + 1527 at wait.c:615 [opt]
      frame 6: 0x000000010ce692b6 MobileTestApp`mono_thread_manage + 57 at threads.c:2956 [opt]
      frame 7: 0x000000010ce6927d MobileTestApp`mono_thread_manage + 301 at threads.c:3162 [opt]
      frame 8: 0x000000010ccbb533 MobileTestApp`mono_main(argc=<unavailable>, argv=<unavailable>) + 7987 at driver.g.c:2181 [opt]
      frame 9: 0x000000010cc61c67 MobileTestApp`main(argc=1, argv=0x00007fff52fb5268) + 775 at launcher.m:562
      frame 10: 0x000000010cc63150 MobileTestApp`start + 52

    thread 2: tid = 0x2ab2bf7, 0x00007fff97816ff6 libsystem_kernel.dylib`kevent_qos + 10, queue = 'com.apple.libdispatch-manager'
      frame 0: 0x00007fff97816ff6 libsystem_kernel.dylib`kevent_qos + 10
      frame 1: 0x00007fff88f18099 libdispatch.dylib`_dispatch_mgr_invoke + 216
      frame 2: 0x00007fff88f17d01 libdispatch.dylib`_dispatch_mgr_thread + 52

    thread 3: tid = 0x2ab2bfa, 0x00007fff97815eb2 libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'SGen worker'
      frame 0: 0x00007fff97815eb2 libsystem_kernel.dylib`__psynch_cvwait + 10
      frame 1: 0x00007fff89015150 libsystem_pthread.dylib`_pthread_cond_wait + 767
      frame 2: 0x000000010ceab31c MobileTestApp`thread_func [inlined] mono_os_cond_wait(mutex=0x000000010d02e190) + 15 at mono-os-mutex.h:107 [opt]
      frame 3: 0x000000010ceab30d MobileTestApp`thread_func(thread_data=0x0000000000000000) + 333 at sgen-thread-pool.c:110 [opt]
      frame 4: 0x00007fff89014c13 libsystem_pthread.dylib`_pthread_body + 131
      frame 5: 0x00007fff89014b90 libsystem_pthread.dylib`_pthread_start + 168
      frame 6: 0x00007fff89012375 libsystem_pthread.dylib`thread_start + 13

    thread 4: tid = 0x2ab2bfb, 0x00007fff978103c2 libsystem_kernel.dylib`semaphore_wait_trap + 10, name = 'Finalizer'
      frame 0: 0x00007fff978103c2 libsystem_kernel.dylib`semaphore_wait_trap + 10
      frame 1: 0x000000010cdb847b MobileTestApp`finalizer_thread [inlined] mono_os_sem_wait(flags=MONO_SEM_FLAGS_ALERTABLE) + 11 at mono-os-semaphore.h:72 [opt]
      frame 2: 0x000000010cdb8470 MobileTestApp`finalizer_thread + 11 at mono-coop-semaphore.h:40 [opt]
      frame 3: 0x000000010cdb8465 MobileTestApp`finalizer_thread(unused=<unavailable>) + 181 at gc.c:770 [opt]
      frame 4: 0x000000010ce6bb05 MobileTestApp`start_wrapper [inlined] start_wrapper_internal + 548 at threads.c:738 [opt]
      frame 5: 0x000000010ce6b8e1 MobileTestApp`start_wrapper(data=<unavailable>) + 49 at threads.c:785 [opt]
      frame 6: 0x000000010ced50f6 MobileTestApp`inner_start_thread(arg=<unavailable>) + 406 at mono-threads-posix.c:92 [opt]
      frame 7: 0x00007fff89014c13 libsystem_pthread.dylib`_pthread_body + 131
      frame 8: 0x00007fff89014b90 libsystem_pthread.dylib`_pthread_start + 168
      frame 9: 0x00007fff89012375 libsystem_pthread.dylib`thread_start + 13

    thread 5: tid = 0x2ab2c07, 0x00007fff97816206 libsystem_kernel.dylib`__semwait_signal + 10, name = 'tid_320b'
      frame 0: 0x00007fff97816206 libsystem_kernel.dylib`__semwait_signal + 10
      frame 1: 0x00007fff82df1d17 libsystem_c.dylib`nanosleep + 199
      frame 2: 0x00007fff82df1c0a libsystem_c.dylib`usleep + 54
      frame 3: 0x000000010cc5bc60 MobileTestApp`pump_gc(context=0x0000000000000000) + 64 at runtime.m:904
      frame 4: 0x00007fff89014c13 libsystem_pthread.dylib`_pthread_body + 131
      frame 5: 0x00007fff89014b90 libsystem_pthread.dylib`_pthread_start + 168
      frame 6: 0x00007fff89012375 libsystem_pthread.dylib`thread_start + 13