### PR TITLE
Use a separate mono clone for watchOS.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,7 @@
 [submodule "external/guiunit"]
 	path = external/guiunit
 	url = ../../mono/guiunit.git
+[submodule "external/watch-mono"]
+	path = external/watch-mono
+	url = ../../mono/mono.git
+	branch = master

--- a/Make.config
+++ b/Make.config
@@ -213,6 +213,7 @@ DEVICETV_OBJC_CFLAGS       = $(DEVICETV_CFLAGS) $(DEVICE_OBJC_CFLAGS)
 # paths to the modules we depend on, as variables, so people can put
 # things in other places if they absolutely must.
 MONO_PATH=$(TOP)/external/mono
+WATCH_MONO_PATH=$(TOP)/external/watch-mono
 LLVM_PATH=$(TOP)/external/llvm
 FSHARP_PATH=$(TOP)/external/fsharp
 CECIL_PATH=$(TOP)/external/cecil

--- a/builds/.gitignore
+++ b/builds/.gitignore
@@ -19,3 +19,5 @@ target7s
 target64
 targettv
 targetwatch
+watchbcl
+

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -497,7 +497,7 @@ build-tools: build-watchbcl
 build-watchbcl: .stamp-build-watchbcl
 	$(MAKE) $(WATCH_BCL_TARGETS)
 
-.stamp-build-watchbcl: .stamp-configure-watchbcl
+.stamp-build-watchbcl: .stamp-configure-watchbcl .stamp-build-tools64
 	$(MAKE) -C watchbcl all EXTERNAL_MCS=$(SYSTEM_MCS) EXTERNAL_RUNTIME=$(SYSTEM_MONO)
 	$(MAKE) -C watchbcl install EXTERNAL_MCS=$(SYSTEM_MCS) EXTERNAL_RUNTIME=$(SYSTEM_MONO)
 	$(Q) touch $@

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -355,7 +355,7 @@ TOOLS64_LDFLAGS=-arch x86_64 -mmacosx-version-min=$(MIN_OSX_SDK_VERSION)
 
 TOOLS64_CONFIGURE_FLAGS=	--build=x86_64-apple-darwin10 \
 			--with-monotouch_tv=yes \
-			--with-monotouch_watch=yes \
+			--with-monotouch_watch=no \
 			--prefix=$(BUILD_DESTDIR)/tools64 \
 			--enable-maintainer-mode \
 			--cache-file=../tools64.config.cache \

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -858,7 +858,7 @@ clean-iphonesimulator:: clean-$(2)
 
 $(eval SIM_TARGET_LIBMONOSGEN:=$(SIM_TARGET_LIBMONOSGEN) $(BUILD_DESTDIR)/$(2)/lib/libmonosgen-2.0.a)
 $(eval SIM_TARGET_SHAREDMONOSGEN:=$(SIM_TARGET_SHAREDMONOSGEN) $(BUILD_DESTDIR)/$(2)/lib/libmonosgen-2.0.dylib)
-$(eval SIM_TARGET_LIBLOGPROFILER:=$(SIM_TARGET_LIBLOGPROFILER) $(BUILD_DESTDIR)/$(2)/lib/libmono-profiler-log.a)
+$(eval SIM_TARGET_LIBLOGPROFILER:=$(SIM_TARGET_LIBLOGPROFILER) $(BUILD_DESTDIR)/$(2)/lib/libmono-profiler-log-static.a)
 $(eval SIM_TARGET_SHAREDLIBLOGPROFILER:=$(SIM_TARGET_SHAREDLIBLOGPROFILER) $(BUILD_DESTDIR)/$(2)/tmp-lib/libmono-profiler-log.0.dylib)
 
 $(BUILD_DESTDIR)/$(2)/tmp-lib/libmono-profiler-log.0.dylib: $(BUILD_DESTDIR)/$(2)/lib/libmono-profiler-log.0.dylib | $(BUILD_DESTDIR)/$(2)/tmp-lib
@@ -1012,7 +1012,7 @@ clean-watchsimulator:
 
 WATCHSIMULATOR_LIBMONOSGEN          = $(BUILD_DESTDIR)/watchsimulator/lib/libmonosgen-2.0.a
 WATCHSIMULATOR_SHAREDMONOSGEN       = $(BUILD_DESTDIR)/watchsimulator/lib/libmonosgen-2.0.dylib
-WATCHSIMULATOR_LIBLOGPROFILER       = $(BUILD_DESTDIR)/watchsimulator/lib/libmono-profiler-log.a
+WATCHSIMULATOR_LIBLOGPROFILER       = $(BUILD_DESTDIR)/watchsimulator/lib/libmono-profiler-log-static.a
 WATCHSIMULATOR_SHAREDLIBLOGPROFILER = $(BUILD_DESTDIR)/watchsimulator/lib/libmono-profiler-log.0.dylib
 
 WATCHSIMULATOR_TARGETS = \
@@ -1148,7 +1148,7 @@ clean-tvsimulator:
 
 TVSIMULATOR_LIBMONOSGEN          = $(BUILD_DESTDIR)/tvsimulator/lib/libmonosgen-2.0.a
 TVSIMULATOR_SHAREDMONOSGEN       = $(BUILD_DESTDIR)/tvsimulator/lib/libmonosgen-2.0.dylib
-TVSIMULATOR_LIBLOGPROFILER       = $(BUILD_DESTDIR)/tvsimulator/lib/libmono-profiler-log.a
+TVSIMULATOR_LIBLOGPROFILER       = $(BUILD_DESTDIR)/tvsimulator/lib/libmono-profiler-log-static.a
 TVSIMULATOR_SHAREDLIBLOGPROFILER = $(BUILD_DESTDIR)/tvsimulator/lib/libmono-profiler-log.0.dylib
 
 TVSIMULATOR_TARGETS = \
@@ -1532,7 +1532,7 @@ clean-watchos: clean-targetwatch
 
 WATCHOS_TARGET_LIBMONOSGEN          = $(BUILD_DESTDIR)/targetwatch/lib/libmonosgen-2.0.a
 WATCHOS_TARGET_SHAREDMONOSGEN       = $(BUILD_DESTDIR)/targetwatch/lib/libmonosgen-2.0.dylib
-WATCHOS_TARGET_LIBLOGPROFILER       = $(BUILD_DESTDIR)/targetwatch/lib/libmono-profiler-log.a
+WATCHOS_TARGET_LIBLOGPROFILER       = $(BUILD_DESTDIR)/targetwatch/lib/libmono-profiler-log-static.a
 WATCHOS_TARGET_SHAREDLIBLOGPROFILER = $(BUILD_DESTDIR)/targetwatch/lib/libmono-profiler-log.0.dylib
 
 device:: watchos
@@ -1703,7 +1703,7 @@ clean-tvos: clean-targettv
 
 TVOS_TARGET_LIBMONOSGEN          = $(BUILD_DESTDIR)/targettv/lib/libmonosgen-2.0.a
 TVOS_TARGET_SHAREDMONOSGEN       = $(BUILD_DESTDIR)/targettv/lib/libmonosgen-2.0.dylib
-TVOS_TARGET_LIBLOGPROFILER       = $(BUILD_DESTDIR)/targettv/lib/libmono-profiler-log.a
+TVOS_TARGET_LIBLOGPROFILER       = $(BUILD_DESTDIR)/targettv/lib/libmono-profiler-log-static.a
 TVOS_TARGET_SHAREDLIBLOGPROFILER = $(BUILD_DESTDIR)/targettv/lib/libmono-profiler-log.0.dylib
 
 device:: tvos

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -700,12 +700,12 @@ $(BUILD_DESTDIR)/watchos/bcl/repl/%.dll: $(WATCH_MONO_PATH)/mcs/class/lib/monoto
 	$(Q) cp $< $@
 	$(Q_SN) MONO_CFG_DIR=$(TOP) $(SYSTEM_SN) -q -R $@ $(PRODUCT_KEY_PATH)
 
-$(BUILD_DESTDIR)/watchos/bcl/%.mdb: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/%.mdb .stamp-build-watchbcl | $(BUILD_DESTDIR)/watchos/bcl
+$(BUILD_DESTDIR)/watchos/bcl/%.mdb: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/%.mdb .stamp-build-watchbcl .stamp-build-tools64 | $(BUILD_DESTDIR)/watchos/bcl
 	@# mdb-rebase the mdb
 	$(Q) cp $< $@
 	$(Q_MDB) $(MDB_REBASE) -q -i $(abspath $(MONO_PATH))/ -o $(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/src/mono/ $@
 
-$(BUILD_DESTDIR)/watchos/bcl/repl/%.mdb: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch_runtime/%.mdb .stamp-build-watchbcl | $(BUILD_DESTDIR)/watchos/bcl/repl
+$(BUILD_DESTDIR)/watchos/bcl/repl/%.mdb: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch_runtime/%.mdb .stamp-build-watchbcl .stamp-build-tools64 | $(BUILD_DESTDIR)/watchos/bcl/repl
 	@# mdb-rebase the mdb
 	$(Q) cp $< $@
 	$(Q_MDB) $(MDB_REBASE) -q -i $(abspath $(MONO_PATH))/ -o $(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/src/mono/ $@
@@ -1826,11 +1826,14 @@ install-llvm64: .stamp-build-llvm64 $(LLVM_TARGETS)
 llvm: setup-llvm build-llvm install-llvm
 llvm64: install-llvm64
 
-OFFSETS_TOOLPATH=$(MONO_PATH)/tools/offsets-tool
-$(OFFSETS_TOOLPATH)/.stamp-clone:
+$(MONO_PATH)/tools/offsets-tool/.stamp-clone $(WATCH_MONO_PATH)/tools/offsets-tool/.stamp-clone:
+	@echo Cloning for offsets-tool in $(dir $@)
 	$(Q) $(MAKE) -C $(dir $@) .stamp-clone
 
-$(OFFSETS_TOOLPATH)/MonoAotOffsetsDumper.exe: $(OFFSETS_TOOLPATH)/.stamp-clone $(wildcard $(OFFSETS_TOOLPATH)/*.cs)
+$(MONO_PATH)/tools/offsets-tool/MonoAotOffsetsDumper.exe: $(MONO_PATH)/tools/offsets-tool/.stamp-clone $(wildcard $(MONO_PATH)/tools/offsets-tool/*.cs)
+	$(Q) $(MAKE) -C $(dir $@) MonoAotOffsetsDumper.exe
+
+$(WATCH_MONO_PATH)/tools/offsets-tool/MonoAotOffsetsDumper.exe: $(WATCH_MONO_PATH)/tools/offsets-tool/.stamp-clone $(wildcard $(WATCH_MONO_PATH)/tools/offsets-tool/*.cs)
 	$(Q) $(MAKE) -C $(dir $@) MonoAotOffsetsDumper.exe
 
 target7/mono/arch/arm/arm_dpimacros.h: setup-target7
@@ -1845,9 +1848,9 @@ targetwatch/mono/arch/arm/arm_dpimacros.h: setup-targetwatch
 #  $(2): output directory
 #  $(3): build
 define GenerateCrossOffsets
-$(3)/$(1).h: .stamp-configure-$(3) target7/mono/arch/arm/arm_dpimacros.h targetwatch/mono/arch/arm/arm_dpimacros.h $(OFFSETS_TOOLPATH)/.stamp-clone $(OFFSETS_TOOLPATH)/MonoAotOffsetsDumper.exe
-	$(Q) MONO_PATH=$(OFFSETS_TOOLPATH)/CppSharp \
-	$(SYSTEM_MONO) $(OFFSETS_TOOLPATH)/MonoAotOffsetsDumper.exe --abi $(1) --out $(2) --mono $(abspath $(MONO_PATH)) --maccore $(abspath $(TOP))
+$(3)/$(1).h: .stamp-configure-$(3) target7/mono/arch/arm/arm_dpimacros.h targetwatch/mono/arch/arm/arm_dpimacros.h $(4)/tools/offsets-tool/.stamp-clone $(4)/tools/offsets-tool/MonoAotOffsetsDumper.exe
+	$(Q) MONO_PATH=$(4)/tools/offsets-tool/CppSharp \
+	$(SYSTEM_MONO) $(4)/tools/offsets-tool/MonoAotOffsetsDumper.exe --abi $(1) --out $(2) --mono $(abspath $(4)) --maccore $(abspath $(TOP))
 endef
 
 CROSS_BASE_CFLAGS=-DMONOTOUCH $(CROSS_BUILD_CFLAGS) $(CCACHE_CFLAGS)
@@ -1907,7 +1910,7 @@ setup-cross: .stamp-configure-cross
 .stamp-configure-cross: $(MONO_PATH)/configure .stamp-build-llvm
 	$(Q) $(CROSS_CONFIGURE_ENVIRONMENT) ./wrap-configure.sh cross $(abspath $(MONO_PATH)/configure) $(CROSS_CONFIGURE_FLAGS)
 
-$(eval $(call GenerateCrossOffsets,arm-apple-darwin10,$(TOP)/builds/cross/,cross))
+$(eval $(call GenerateCrossOffsets,arm-apple-darwin10,$(TOP)/builds/cross/,cross,$(MONO_PATH)))
 
 build-cross: setup-cross cross/arm-apple-darwin10.h
 	$(MAKE) -C cross/eglib
@@ -1975,7 +1978,7 @@ install-directories:
 .stamp-configure-cross64: $(MONO_PATH)/configure .stamp-build-llvm64
 	$(Q) $(CROSS64_CONFIGURE_ENVIRONMENT) ./wrap-configure.sh cross64 $(abspath $(MONO_PATH)/configure) $(CROSS64_CONFIGURE_FLAGS)
 
-$(eval $(call GenerateCrossOffsets,aarch64-apple-darwin10,$(TOP)/builds/cross64/,cross64))
+$(eval $(call GenerateCrossOffsets,aarch64-apple-darwin10,$(TOP)/builds/cross64/,cross64,$(MONO_PATH)))
 
 build-cross64: setup-cross64 cross64/aarch64-apple-darwin10.h
 	$(MAKE) -C cross64/eglib
@@ -2036,7 +2039,7 @@ setup-cross-watch: .stamp-configure-cross-watch
 
 build-cross: setup-cross
 
-$(eval $(call GenerateCrossOffsets,armv7k-apple-darwin,$(TOP)/builds/cross-watch/,cross-watch))
+$(eval $(call GenerateCrossOffsets,armv7k-apple-darwin,$(TOP)/builds/cross-watch/,cross-watch,$(WATCH_MONO_PATH)))
 
 build-cross-watch: setup-cross-watch cross-watch/armv7k-apple-darwin.h
 	$(MAKE) -C cross-watch/eglib
@@ -2094,7 +2097,7 @@ setup-crosstv: .stamp-configure-crosstv
 .stamp-configure-crosstv: $(MONO_PATH)/configure .stamp-build-llvm64
 	$(Q) $(TV_CROSS_CONFIGURE_ENVIRONMENT) ./wrap-configure.sh crosstv $(abspath $(MONO_PATH)/configure) $(TV_CROSS_CONFIGURE_FLAGS)
 
-$(eval $(call GenerateCrossOffsets,aarch64-apple-darwin10,$(TOP)/builds/crosstv/,crosstv))
+$(eval $(call GenerateCrossOffsets,aarch64-apple-darwin10,$(TOP)/builds/crosstv/,crosstv,$(MONO_PATH)))
 
 build-crosstv: setup-crosstv crosstv/aarch64-apple-darwin10.h
 	$(MAKE) -C crosstv/eglib

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -1541,10 +1541,15 @@ WATCHOS_TARGETS =                                                             \
 	$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmonosgen-2.0.a            \
 	$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmonosgen-2.0.dylib        \
 	$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmono-profiler-log.a       \
-	$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmono-profiler-log.dylib   \
 	$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks/Mono.framework/Mono       \
 	$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks/Mono.framework/Info.plist \
 
+# see https://github.com/mono/mono/commit/cfd9870f8345d2e3e6354e3deebced443809ee2f
+# I think it might still be possible to do this with bitcode, but more investigation
+# is needed, so just disable for now to make the build complete.
+WATCHOS_DISABLED_TARGETS = \
+	$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmono-profiler-log.dylib   \
+	
 WATCHOS_DIRECTORIES = \
 	$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks/Mono.framework \
 	$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib                   \

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -325,6 +325,9 @@ endif
 $(MONO_PATH)/configure: $(MONO_PATH)/configure.ac $(BUILDS_MAKEFILE_DEP)
 	$(Q) ./wrap-autogen.sh $(MONO_PATH) mono $(XAMARIN_AUTOGEN_FLAGS)
 
+$(WATCH_MONO_PATH)/configure: $(WATCH_MONO_PATH)/configure.ac $(BUILDS_MAKEFILE_DEP)
+	$(Q) ./wrap-autogen.sh $(WATCH_MONO_PATH) mono
+
 configure-mono:
 	rm -f $(MONO_PATH)/configure
 	$(MAKE) $(MONO_PATH)/configure
@@ -414,9 +417,6 @@ endif
 ifdef INCLUDE_TVOS
 	$(MAKE) $(TVOS_BCL_TARGETS)
 endif
-ifdef INCLUDE_WATCH
-	$(MAKE) $(WATCH_BCL_TARGETS)
-endif
 	$(MAKE) $(MAC_BCL_TARGETS)
 
 clean-tools64:
@@ -429,8 +429,81 @@ install-tools:: install-tools-watch
 endif
 ifdef INCLUDE_TVOS
 install-local:: install-tools-tvos
-install-tols:: install-tools-tvos
+install-tools:: install-tools-tvos
 endif
+
+#
+# Xamarin.WatchOS BCL assemblies
+#
+# We need to build the WatchOS BCL using the same mono checkout as we're using for the
+# corresponding Mono runtimes, which means we can't use the normal tools64 build
+#
+# Also we can't reuse the existing watchsimulator/targetwatch builds, since their
+# monos don't run (correctly) on desktop OSX.
+#
+# So we build an entire Mono just to build the WatchOS BCL.
+#
+
+WATCHBCL_CFLAGS=-arch x86_64 -mmacosx-version-min=$(MIN_OSX_SDK_VERSION)
+WATCHBCL_CXXFLAGS=-arch x86_64 -mmacosx-version-min=$(MIN_OSX_SDK_VERSION)
+WATCHBCL_LDFLAGS=-arch x86_64 -mmacosx-version-min=$(MIN_OSX_SDK_VERSION)
+
+WATCHBCL_CONFIGURE_FLAGS=	--build=x86_64-apple-darwin10 \
+			--prefix=$(BUILD_DESTDIR)/watchbcl \
+			--enable-maintainer-mode \
+			--cache-file=../watchbcl.config.cache \
+			--with-glib=embedded \
+			--enable-minimal=com	\
+			--with-profile2=no \
+			--with-profile4=no \
+			--with-profile4_x=no \
+			--with-profile4_5=no \
+			--with-monotouch=no \
+			--with-monotouch_watch=yes \
+			--with-monotouch_tv=no \
+			--with-xammac=no \
+			--with-mcs-docs=no \
+			--disable-shared-handles \
+			--disable-nls \
+			--disable-iconv	\
+			--disable-boehm \
+			--enable-extension-module
+
+WATCHBCL_CONFIGURE_ENVIRONMENT = \
+	CFLAGS="$(WATCHBCL_CFLAGS)" \
+	CXXFLAGS="$(WATCHBCL_CXXFLAGS)" \
+	LDFLAGS="$(WATCHBCL_LDFLAGS)" \
+	CC="$(MAC_CC)" \
+	CXX="$(MAC_CXX)" \
+
+tools:: build-watchbcl install-tools-watch
+
+ifdef INCLUDE_WATCH
+setup:: setup-watchbcl
+build:: build-watchbcl
+clean-local:: clean-watchbcl
+endif
+
+watchbcl: build-watchbcl install-tools-watch
+
+setup-watchbcl: .stamp-configure-watchbcl
+
+.stamp-configure-watchbcl: $(WATCH_MONO_PATH)/configure
+	$(Q) $(WATCHBCL_CONFIGURE_ENVIRONMENT) ./wrap-configure.sh watchbcl ../$(WATCH_MONO_PATH)/configure $(WATCHBCL_CONFIGURE_FLAGS)
+
+build-tools-bcl: build-watchbcl
+build-tools: build-watchbcl
+
+build-watchbcl: .stamp-build-watchbcl
+	$(MAKE) $(WATCH_BCL_TARGETS)
+
+.stamp-build-watchbcl: .stamp-configure-watchbcl
+	$(MAKE) -C watchbcl all EXTERNAL_MCS=$(SYSTEM_MCS) EXTERNAL_RUNTIME=$(SYSTEM_MONO)
+	$(MAKE) -C watchbcl install EXTERNAL_MCS=$(SYSTEM_MCS) EXTERNAL_RUNTIME=$(SYSTEM_MONO)
+	$(Q) touch $@
+
+clean-watchbcl:
+	rm -rf watchbcl .stamp-configure-watchbcl watchbcl.config.cache
 
 #
 # Xamarin.iOS/WatchOS/TVOS BCL assemblies
@@ -466,10 +539,13 @@ ios-facade-check:
 	$(Q) rm -f .$@*
 
 watch-facade-check:
+	@true
+
+disabled-watch-facade-check:
 	$(Q) rm -f .$@*
 	$(Q) echo $(WATCHOS_FACADE_ASSEMBLIES) | tr ' ' '\n' | sort > .$@1
-	$(Q) ls -1 $(MONO_PATH)/mcs/class/lib/monotouch_watch/Facades | grep dll | sed 's/[.]dll//' | sort > .$@2
-	$(Q) if ! diff -u .$@1 .$@2; then echo "\n*** There are Facade assemblies in "$(MONO_PATH)/mcs/class/lib/monotouch_watch/Facades" not defined in "$(FACADE_SUBDIRS_MK)" ***\n"; exit 1; fi
+	$(Q) ls -1 $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/Facades | grep dll | sed 's/[.]dll//' | sort > .$@2
+	$(Q) if ! diff -u .$@1 .$@2; then echo "\n*** There are Facade assemblies in "$(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/Facades" not defined in "$(FACADE_SUBDIRS_MK)" ***\n"; exit 1; fi
 	$(Q) rm -f .$@*
 
 tvos-facade-check:
@@ -609,27 +685,27 @@ $(BUILD_DESTDIR)/ios/bcl/repl/%.mdb: $(MONO_PATH)/mcs/class/lib/monotouch_runtim
 	$(Q) cp $< $@
 	$(Q_MDB) $(MDB_REBASE) -q -i $(abspath $(MONO_PATH))/ -o $(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/src/mono/ $@
 
-$(BUILD_DESTDIR)/watchos/bcl/Facades/%.dll: $(MONO_PATH)/mcs/class/lib/monotouch_watch/Facades/%.dll | $(BUILD_DESTDIR)/watchos/bcl/Facades
+$(BUILD_DESTDIR)/watchos/bcl/Facades/%.dll: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/Facades/%.dll | $(BUILD_DESTDIR)/watchos/bcl/Facades
 	@# sign the Facade assembly
 	$(Q) cp $< $@
 	$(Q_SN) MONO_CFG_DIR=$(TOP) $(SYSTEM_SN) -q -R $@ $(PRODUCT_KEY_PATH)
 
-$(BUILD_DESTDIR)/watchos/bcl/%.dll: $(MONO_PATH)/mcs/class/lib/monotouch_watch/%.dll | $(BUILD_DESTDIR)/watchos/bcl
+$(BUILD_DESTDIR)/watchos/bcl/%.dll: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/%.dll | $(BUILD_DESTDIR)/watchos/bcl
 	@# sign the BCL assembly
 	$(Q) cp $< $@
 	$(Q_SN) MONO_CFG_DIR=$(TOP) $(SYSTEM_SN) -q -R $@ $(PRODUCT_KEY_PATH)
 
-$(BUILD_DESTDIR)/watchos/bcl/repl/%.dll: $(MONO_PATH)/mcs/class/lib/monotouch_watch_runtime/%.dll | $(BUILD_DESTDIR)/watchos/bcl/repl
+$(BUILD_DESTDIR)/watchos/bcl/repl/%.dll: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch_runtime/%.dll | $(BUILD_DESTDIR)/watchos/bcl/repl
 	@# sign the BCL assembly
 	$(Q) cp $< $@
 	$(Q_SN) MONO_CFG_DIR=$(TOP) $(SYSTEM_SN) -q -R $@ $(PRODUCT_KEY_PATH)
 
-$(BUILD_DESTDIR)/watchos/bcl/%.mdb: $(MONO_PATH)/mcs/class/lib/monotouch_watch/%.mdb .stamp-build-tools64 | $(BUILD_DESTDIR)/watchos/bcl
+$(BUILD_DESTDIR)/watchos/bcl/%.mdb: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/%.mdb .stamp-build-watchbcl | $(BUILD_DESTDIR)/watchos/bcl
 	@# mdb-rebase the mdb
 	$(Q) cp $< $@
 	$(Q_MDB) $(MDB_REBASE) -q -i $(abspath $(MONO_PATH))/ -o $(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/src/mono/ $@
 
-$(BUILD_DESTDIR)/watchos/bcl/repl/%.mdb: $(MONO_PATH)/mcs/class/lib/monotouch_watch_runtime/%.mdb .stamp-build-tools64 | $(BUILD_DESTDIR)/watchos/bcl/repl
+$(BUILD_DESTDIR)/watchos/bcl/repl/%.mdb: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch_runtime/%.mdb .stamp-build-watchbcl | $(BUILD_DESTDIR)/watchos/bcl/repl
 	@# mdb-rebase the mdb
 	$(Q) cp $< $@
 	$(Q_MDB) $(MDB_REBASE) -q -i $(abspath $(MONO_PATH))/ -o $(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/src/mono/ $@
@@ -919,8 +995,8 @@ endif
 
 setup-watchsimulator: .stamp-configure-watchsimulator
 
-.stamp-configure-watchsimulator: $(MONO_PATH)/configure
-	$(Q) $(WATCHSIMULATOR_ENVIRONMENT) ./wrap-configure.sh watchsimulator $(abspath $(MONO_PATH)/configure) $(WATCHSIMULATOR_CONFIGURE_FLAGS)
+.stamp-configure-watchsimulator: $(WATCH_MONO_PATH)/configure
+	$(Q) $(WATCHSIMULATOR_ENVIRONMENT) ./wrap-configure.sh watchsimulator $(abspath $(WATCH_MONO_PATH)/configure) $(WATCHSIMULATOR_CONFIGURE_FLAGS)
 
 build-watchsimulator: export DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT)
 build-watchsimulator: export PATH:="$(WATCHSIMULATOR_BIN_PATH):$(PATH)"
@@ -1436,8 +1512,8 @@ endif
 
 setup-targetwatch: .stamp-configure-targetwatch
 
-.stamp-configure-targetwatch: $(MONO_PATH)/configure
-	$(Q) $(WATCHOS_ENVIRONMENT) ./wrap-configure.sh targetwatch $(abspath $(MONO_PATH)/configure) $(WATCHOS_CONFIGURE_FLAGS)
+.stamp-configure-targetwatch: $(WATCH_MONO_PATH)/configure
+	$(Q) $(WATCHOS_ENVIRONMENT) ./wrap-configure.sh targetwatch $(abspath $(WATCH_MONO_PATH)/configure) $(WATCHOS_CONFIGURE_FLAGS)
 
 build-targetwatch: export DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT)
 build-targetwatch: export PATH:="$(WATCHOS_BIN_PATH):$(PATH)"
@@ -1955,8 +2031,8 @@ cross-watch: build-cross-watch install-cross-watch
 
 setup-cross-watch: .stamp-configure-cross-watch
 
-.stamp-configure-cross-watch: $(MONO_PATH)/configure .stamp-build-llvm
-	$(Q) $(WATCH_CONFIGURE_ENVIRONMENT) ./wrap-configure.sh cross-watch $(abspath $(MONO_PATH)/configure) $(WATCH_CROSS_CONFIGURE_FLAGS)
+.stamp-configure-cross-watch: $(WATCH_MONO_PATH)/configure .stamp-build-llvm
+	$(Q) $(WATCH_CONFIGURE_ENVIRONMENT) ./wrap-configure.sh cross-watch $(abspath $(WATCH_MONO_PATH)/configure) $(WATCH_CROSS_CONFIGURE_FLAGS)
 
 build-cross: setup-cross
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -691,7 +691,7 @@ $(WATCH_BUILD_DIR)/watch/generated_sources: $(WATCH_BUILD_DIR)/watch/generator.e
 		-no-mono-path                                            \
 		-tmpdir=$(WATCH_BUILD_DIR)/watch                         \
 		-baselib=$(WATCH_BUILD_DIR)/watch/core.dll               \
-		-r=$(MONO_PATH)/mcs/class/lib/monotouch_watch/System.dll \
+		-r=$(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/System.dll \
 		-ns=MonoTouch.ObjCRuntime                                \
 		-native-exception-marshalling                            \
 		-d:WATCH                                                 \
@@ -731,7 +731,7 @@ $(WATCH_BUILD_DIR)/reference/MonoTouch.NUnitLite.dll.mdb: $(WATCH_BUILD_DIR)/ref
 # System.Net.Http.dll is special. See comment in src/Makefile
 
 WATCH_EXTRA_SYSTEM_NET_HTTP_FILES = \
-	$(abspath $(MONO_PATH)/mcs/class/System.Net.Http/HttpClientEx.cs) \
+	$(abspath $(WATCH_MONO_PATH)/mcs/class/System.Net.Http/HttpClientEx.cs) \
 	$(abspath $(MODERNHTTPCLIENT_PATH)/src/ModernHttpClient/ProgressStreamContent.cs) \
 	$(abspath $(MODERNHTTPCLIENT_PATH)/src/ModernHttpClient/iOS/AsyncLock.cs) \
 	$(abspath $(MODERNHTTPCLIENT_PATH)/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs) \
@@ -742,23 +742,23 @@ WATCH_EXTRA_SYSTEM_NET_HTTP_FILES = \
 # code will be included here.
 
 # build (into custom LIBRARY_SUBDIR)
-$(MONO_PATH)/mcs/class/lib/monotouch_watch/reference/System.Net.Http.dll: $(WATCH_EXTRA_SYSTEM_NET_HTTP_FILES) $(MONO_PATH)/mcs/class/lib/monotouch_watch/System.Net.Http.dll $(WATCH_BUILD_DIR)/reference/Xamarin.WatchOS.dll
-	$(call Q_PROF_MCS,watch) $(MAKE) $(if $(V),,-s) -C $(MONO_PATH)/mcs/class/System.Net.Http PROFILE=monotouch_watch LIBRARY_SUBDIR=reference EXTRA_LIB_MCS_FLAGS="-r:$(abspath $(WATCH_BUILD_DIR)/reference/Xamarin.WatchOS.dll) $(WATCH_EXTRA_SYSTEM_NET_HTTP_FILES) -D:XAMCORE_2_0 -D:XAMCORE_3_0 -D:XAMARIN_MODERN -D:SYSTEM_NET_HTTP -D:UNIFIED"
+$(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/reference/System.Net.Http.dll: $(WATCH_EXTRA_SYSTEM_NET_HTTP_FILES) $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/System.Net.Http.dll $(WATCH_BUILD_DIR)/reference/Xamarin.WatchOS.dll
+	$(call Q_PROF_MCS,watch) $(MAKE) $(if $(V),,-s) -C $(WATCH_MONO_PATH)/mcs/class/System.Net.Http PROFILE=monotouch_watch LIBRARY_SUBDIR=reference EXTRA_LIB_MCS_FLAGS="-r:$(abspath $(WATCH_BUILD_DIR)/reference/Xamarin.WatchOS.dll) $(WATCH_EXTRA_SYSTEM_NET_HTTP_FILES) -D:XAMCORE_2_0 -D:XAMCORE_3_0 -D:XAMARIN_MODERN -D:SYSTEM_NET_HTTP -D:UNIFIED"
 	$(Q) touch $@
 
-$(MONO_PATH)/mcs/class/lib/monotouch_watch/reference/System.Net.Http.dll.mdb: $(MONO_PATH)/mcs/class/lib/monotouch_watch/reference/System.Net.Http.dll
+$(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/reference/System.Net.Http.dll.mdb: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/reference/System.Net.Http.dll
 	@touch $@
 
 # sign dll
-$(WATCH_BUILD_DIR)/reference/System.Net.Http.dll: $(MONO_PATH)/mcs/class/lib/monotouch_watch/reference/System.Net.Http.dll
+$(WATCH_BUILD_DIR)/reference/System.Net.Http.dll: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/reference/System.Net.Http.dll
 	$(Q) cp $< $@
 	$(call Q_PROF_SN,watch) MONO_CFG_DIR=$(TOP) $(SYSTEM_SN) -q -R $@ $(PRODUCT_KEY_PATH)
 
 # mdb rebase
-$(WATCH_BUILD_DIR)/reference/System.Net.Http.dll.mdb: $(MONO_PATH)/mcs/class/lib/monotouch_watch/reference/System.Net.Http.dll.mdb
+$(WATCH_BUILD_DIR)/reference/System.Net.Http.dll.mdb: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/reference/System.Net.Http.dll.mdb
 	@# mdb-rebase the mdb
 	$(Q) cp $< $@
-	$(call Q_PROF_GEN,watch) $(MDB_REBASE) -i $(abspath $(MONO_PATH))/ -o $(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/src/mono/ $@
+	$(call Q_PROF_GEN,watch) $(MDB_REBASE) -i $(abspath $(WATCH_MONO_PATH))/ -o $(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/src/mono/ $@
 
 .SECONDARY: $(WATCH_BUILD_DIR)/reference/System.Net.Http.dll
 


### PR DESCRIPTION
Use a separate mono clone for watchOS so that we can track the
fast-changing mono/master for watchOS while still keeping things
stable for Mac/iOS/tvOS (which will continue to track mono/mono-4.5.0-branch).