### PR TITLE
[mtouch] Set default for dlsym to false for iOS (like tvOS and watchOS)

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -220,7 +220,6 @@ namespace Xamarin.Bundler {
 
 			switch (Platform) {
 			case ApplePlatform.iOS:
-				return true;
 			case ApplePlatform.TVOS:
 			case ApplePlatform.WatchOS:
 				return false;


### PR DESCRIPTION
In cycle 7 we turned off, by default, the `dlsym` option (i.e. looking
up symbols for p/invoke) for tvOS and watchOS.

However we decided to wait for iOS to see if this caused issues for
existing code base. There has not been such reports (for tvOS) so,
for cycle 8, we'll turn it off (and use direct calls) for iOS.

If problems arise during the alpha/beta of C8 then we still can
revert this change easily.