### PR TITLE
[runtime] Add dummy _stret symbols for iOS/ARM64

### DIFF
--- a/runtime/monotouch-support.h
+++ b/runtime/monotouch-support.h
@@ -15,7 +15,7 @@ void           xamarin_start_wwan (const char *uri);
 const char *   xamarin_GetFolderPath (int folder);
 #endif
 
-#if defined (TARGET_OS_TV) && defined (__arm64__)
+#if defined (__arm64__)
 void objc_msgSend_stret (id self, SEL op, ...);
 void objc_msgSendSuper_stret (struct objc_super *super, SEL op, ...);
 #endif

--- a/runtime/xamarin-support.m
+++ b/runtime/xamarin-support.m
@@ -101,7 +101,7 @@ xamarin_GetFolderPath (int folder)
 }
 #endif /* defined (MONOTOUCH) */
 
-#if TARGET_OS_TV && defined (__arm64__)
+#if defined (__arm64__)
 
 // there are no objc_msgSend[Super]_stret functions on ARM64 but the managed
 // code might have (e.g. linker is off) references to the symbol, which makes


### PR DESCRIPTION
The `_stret` API are not included in the ARM64 version of iOS (not
needed) but the removal of `dlsym` cause build failures*

So we're providing dummy symbols, just like what we did for tvOS,
to please the native linker (so nothing is undefined) and keep the
benefits of not using dlsym.

* Xamarin.iOS.dll (or other bindings) when the linker is disabled.
Normally the linker would remove the 32bits parts of the bindings
on a 64bits slice (and that would not be noticed). However we can
not assume this will be done for all binding projects, hence this
workaround.