### PR TITLE
[msbuild] Add AudioUnit key to ValidateAppBundleTaskBase

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
@@ -168,6 +168,7 @@ namespace Xamarin.iOS.Tasks
 							case "com.apple.Safari.content-blocker": // iOS
 							case "com.apple.Safari.sharedlinks-service": // iOS
 							case "com.apple.spotlight.index": // iOS
+							case "com.apple.AudioUnit-UI": // iOS
 							case "com.apple.tv-services": // tvOS
 								break;
 							case "com.apple.watchkit": // iOS8.2


### PR DESCRIPTION
This key is required by the new Audio Unit Extension template for iOS.

_It avoids getting a warning._