### PR TITLE
[DONT MERGE] Test how much time is saved by not rebuilding fsharp for each PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TOP=.
-SUBDIRS=builds runtime fsharp src tools msbuild
+SUBDIRS=builds runtime src tools msbuild
 include $(TOP)/Make.config
 include $(TOP)/mk/versions.mk
 


### PR DESCRIPTION
Current build time (no tests) is about 29 minutes.

If it's worth it then we could make fsharp build optional, for PR,
based on a bump on it's repo, it's unit tests or our tooling.