### PR TITLE
[msbuild] Remove empty UIDeviceRequiredCapabilities array

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -177,13 +177,6 @@ namespace Xamarin.iOS.Tasks
 
 			SetDeviceFamily (plist);
 
-			if (IsWatchExtension) {
-				PObject capabilities;
-
-				if (!plist.TryGetValue (ManifestKeys.UIRequiredDeviceCapabilities, out capabilities))
-					plist[ManifestKeys.UIRequiredDeviceCapabilities] = capabilities = new PArray ();
-			}
-
 			plist.SetIfNotPresent (ManifestKeys.MinimumOSVersion, minimumOSVersion.ToString ());
 
 			// Remove any Xamarin Studio specific keys


### PR DESCRIPTION
Looks like Xcode isn't generating any `UIDeviceRequiredCapabilities`
for watchOS 1 extensions.

It used to have `UIRequiredDeviceCapabilities = 'watch-companion'`
but that *might* not be required anymore.
Commit 94e35a8570a52c5a927e24830b65a857a7986d8d on xamarin-macios/master comes from those same assumptions.

Now regarding bug [#41204](https://bugzilla.xamarin.com/show_bug.cgi?id=41204):
User is getting error "ERROR ITMS-90563: "Missing UIRequiredDeviceCapabilities value"
when publish WatchKitCatalog sample.

This might happen because we're still creating an empty array for the
`UIDeviceRequiredCapabilities` key.

In any case there's **no need** to create it.