### PR TITLE
[XM] Teach XM's mmp tool to handle read only assemblies/native libs

### DIFF
--- a/tools/mmp/error.cs
+++ b/tools/mmp/error.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Bundler {
 	//					MM2010	Unknown HttpMessageHandler `{0}`. Valid values are HttpClientHandler (default), CFNetworkHandler or NSUrlSessionHandler
 	//					MM2011  Unknown TLSProvider `{0}.  Valid values are default, legacy or appletls
 	//					MM2012   Only first {0} of {1} "Referenced by" warnings shown. ** This message related to 2009 **
-	//			Warning	MM2013	Failed to resolve the reference to "{0}", referenced in "{1}". The app will not include the referenced assembly, and may fail at runtime.
+	//					Warning	MM2013	Failed to resolve the reference to "{0}", referenced in "{1}". The app will not include the referenced assembly, and may fail at runtime.
 	// MM4xxx	code generation
 	// 			MM40xx	driver.m
 	//					MM4001	The main template could not be expansed to `{0}`.
@@ -96,6 +96,7 @@ namespace Xamarin.Bundler {
 	//					MM5306	Missing dependencies. Please install Xcode 'Command-Line Tools' component
 	//					MM5308  Xcode license agreement may not have been accepted.  Please launch Xcode.
 	//					MM5309	Native linking failed with error code 1.  Check build log for details.
+	//					MT5310  install_name_tool failed with an error code '{0}'. Check build log for details. 
 	// MM6xxx	mmp internal tools
 	// MM7xxx	reserved
 	// MM8xxx	runtime

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -305,6 +305,7 @@ namespace Xamarin.Bundler {
 	//					MT5307  Failed to sign the executable. Please review the build log.
 	//					MT5308  ** reserved Xamarin.Mac **
 	//					MT5309  ** reserved Xamarin.Mac **
+	//					MT5310  ** reserved Xamarin.Mac **
 	// MT6xxx	mtouch internal tools
 	//			MT600x	Stripper
 	//					MT6001	Running version of Cecil doesn't support assembly stripping


### PR DESCRIPTION
- https://bugzilla.xamarin.com/show_bug.cgi?id=41037
- mmp should also promote any install_name_tool errors to "real" errors