### PR TITLE
[msbuild] Make sure CFBundleShortVersionString is set to something.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -148,6 +148,7 @@ namespace Xamarin.iOS.Tasks
 			if (!plist.ContainsKey (ManifestKeys.CFBundleSupportedPlatforms))
 				plist[ManifestKeys.CFBundleSupportedPlatforms] = new PArray { SdkPlatform };
 			plist.SetIfNotPresent (ManifestKeys.CFBundleVersion, "1.0");
+			plist.SetIfNotPresent (ManifestKeys.CFBundleShortVersionString, plist.GetCFBundleVersion ());
 
 			if (!SdkIsSimulator) {
 				SetValue (plist, "DTCompiler", sdkSettings.DTCompiler);


### PR DESCRIPTION
This prevents the watch from getting mightily confused when re-installing
watch apps/extensions.

Not having a CFBundleShortVersionString would cause the following:

* Build & install & run would work fine the first time.
* The second build & install would confuse the watch so that the
  app wouldn't launch. Removing the app and reinstalling wouldn't
  work; the potential options would be to either reboot the device,
  or add a CFBundleShortVersionString to the Info.plists and install
  that build twice.