### PR TITLE
[src] Bump Touch.Unit dependency to get HttpTextWriter addition.

### DIFF
--- a/src/touch-unit.sources
+++ b/src/touch-unit.sources
@@ -271,6 +271,7 @@ NUNITLITE_SOURCES = \
 
 IOS_TOUCHUNIT_SOURCES = \
 	$(NUNITLITE_SOURCES) \
+	$(TOUCH_UNIT_PATH)/NUnitLite/TouchRunner/HttpTextWriter.cs \
 	$(TOUCH_UNIT_PATH)/NUnitLite/TouchRunner/Options.cs \
 	$(TOUCH_UNIT_PATH)/NUnitLite/TouchRunner/NUnitOutputTextWriter.cs \
 	$(TOUCH_UNIT_PATH)/NUnitLite/TouchRunner/TestCaseElement.cs \
@@ -289,6 +290,7 @@ TVOS_TOUCHUNIT_SOURCES = \
 
 WATCHOS_TOUCHUNIT_SOURCES = \
 	$(NUNITLITE_SOURCES) \
+	$(TOUCH_UNIT_PATH)/NUnitLite/TouchRunner/HttpTextWriter.cs \
 	$(TOUCH_UNIT_PATH)/NUnitLite/TouchRunner/Options.cs \
 	$(TOUCH_UNIT_PATH)/NUnitLite/TouchRunner/NUnitOutputTextWriter.cs \
 	$(TOUCH_UNIT_PATH)/NUnitLite/TouchRunner/TouchRunner.cs \


### PR DESCRIPTION
And add the new file to the build.

commit spouliot/Touch.Unit@ffe2a6dcffd1dcfd11b5acf1af6f2b807701b882
Author: Rolf Bjarne Kvinge <rolf@xamarin.com>
Date:   Wed May 25 18:11:59 2016 +0200

    Add a HttpTextWriter that can send logs over http.

    There is no public API to create raw sockets with watchOS, so
    we can't use Tcp directly, thus the need for using Http.