### PR TITLE
[Mac] fix dontlink and apitests

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -14781,11 +14781,11 @@ namespace XamCore.AppKit {
 		[Export ("storyboard", ArgumentSemantic.Strong)]
 		NSStoryboard Storyboard { get; }
 
+#if XAMCORE_2_0
 		[Mac (10,10)]
 		[Export ("presentViewControllerInWidget:")]
 		void PresentViewControllerInWidget (NSViewController viewController);
 
-#if XAMCORE_2_0
 		[Mac (10, 10, onlyOn64: true)]
 		[NullAllowed, Export ("extensionContext", ArgumentSemantic.Retain)]
 		NSExtensionContext ExtensionContext { get; }

--- a/src/findersync.cs
+++ b/src/findersync.cs
@@ -7,7 +7,7 @@ using XamCore.AppKit;
 namespace XamCore.FinderSync {
 	[Mac (10, 10, onlyOn64: true)]
 	[BaseType (typeof(NSExtensionContext))]
-	interface FIFinderSyncController
+	interface FIFinderSyncController : NSSecureCoding, NSCopying
 	{
 		[Static]
 		[Export("defaultController")]
@@ -34,6 +34,7 @@ namespace XamCore.FinderSync {
 
 	[Mac (10, 10, onlyOn64: true)]
 	[BaseType (typeof(NSObject))]
+	[Model, Protocol]
 	interface FIFinderSync : NSExtensionRequestHandling
 	{
 		[Export ("menuForMenuKind:")]

--- a/src/notificationcenter.cs
+++ b/src/notificationcenter.cs
@@ -10,7 +10,7 @@ using XamCore.AppKit;
 #endif
 
 namespace XamCore.NotificationCenter {
-
+#if XAMCORE_2_0 || !MONOMAC
 	[iOS (8,0)][Mac (10,10)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // not meant to be user created
@@ -168,5 +168,6 @@ namespace XamCore.NotificationCenter {
 		[Export ("widgetSearch:resultSelected:"), EventArgs ("NSWidgetSearchResultSelected"), DefaultValue (false)]
 		void ResultSelected (NCWidgetSearchViewController controller, NSObject obj);
 	}
+#endif
 #endif
 }


### PR DESCRIPTION
Fix dontlink and apitest failures introduced by new bindings added for os x extensions