### PR TITLE
[mk] Don't use a stamp file to detect if maccore has been cloned.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -84,13 +84,10 @@ DEPENDENCY_DIRECTORIES += $($(2)_PATH)
 
 endef
 
-builds/.stamp-cloned-maccore:
-	@# we need to touch the stamp first, otherwise we'll 
-	@# go into an infinite loop when we re-launch make.
-	@touch $@
-	$(Q) $(MAKE) reset-maccore || rm -f $@
+$(MACCORE_PATH):
+	$(Q) $(MAKE) reset-maccore
 
 $(eval $(call CheckVersionTemplate,maccore,MACCORE))
 -include $(MACCORE_PATH)/mk/versions.mk
-$(MACCORE_PATH)/mk/versions.mk: | builds/.stamp-cloned-maccore
+$(MACCORE_PATH)/mk/versions.mk: | $(MACCORE_PATH)
 endif


### PR DESCRIPTION
Instead check if the maccore directory exists.

This prevents an issue where if the stamp file did not exist and
the maccore directory did, we'd reset the maccore directory even
for make targets that shouldn't change anything (such as 'check-versions').