### PR TITLE
[runtime] Support binding NSObjects as IntPtr. Fixes #41132.

### DIFF
--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -238,16 +238,17 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 				}
 				case _C_ID: {
 					id id_arg = (id) arg;
-					if (!id_arg) {
+					MonoClass *p_klass = mono_class_from_mono_type (p);
+					if (p_klass == mono_get_intptr_class ()) {
+						arg_frame [ofs] = id_arg;
+						arg_ptrs [i + mofs] = &arg_frame [frameofs];
+						LOGZ (" argument %i is IntPtr: %p\n", i + 1, id_arg);
+						break;
+					} else if (!id_arg) {
 						arg_ptrs [i + mofs] = NULL;
 						break;
 					} else {
-						MonoClass *p_klass = mono_class_from_mono_type (p);
-						if (p_klass == mono_get_intptr_class ()) {
-							arg_frame [ofs] = id_arg;
-							arg_ptrs [i + mofs] = &arg_frame [frameofs];
-							LOGZ (" argument %i is IntPtr: %p\n", i + 1, id_arg);
-						} else if (p_klass == mono_get_string_class ()) {
+						if (p_klass == mono_get_string_class ()) {
 							NSString *str = (NSString *) id_arg;
 							arg_ptrs [i + mofs] = mono_string_new (mono_domain_get (), [str UTF8String]);
 							LOGZ (" argument %i is NSString: %p = %s\n", i + 1, id_arg, [str UTF8String]);

--- a/tests/bindings-test/ApiDefinition.cs
+++ b/tests/bindings-test/ApiDefinition.cs
@@ -203,6 +203,9 @@ namespace Bindings.Test {
 		[Export ("testBlocks")]
 		bool TestBlocks ();
 
+		[Export ("idAsIntPtr:")]
+		void IdAsIntPtr (IntPtr id);
+
 	}
 
 	[BaseType (typeof (NSObject))]
@@ -234,6 +237,15 @@ namespace Bindings.Test {
 
 		[Export ("initCallsInit:")]
 		IntPtr Constructor (int value);
+	}
+
+	[BaseType (typeof (NSObject))]
+	[Model]
+	[Protocol]
+	interface ObjCProtocolTest
+	{
+		[Export ("idAsIntPtr:")]
+		void IdAsIntPtr (IntPtr p1);
 	}
 }
 

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -1822,6 +1822,23 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		{
 		}
 
+		[Test]
+		public void IdAsIntPtrTest ()
+		{
+			using (var obj = new IdAsIntPtrClass ()) {
+				Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("idAsIntPtr:"), IntPtr.Zero);
+			}
+		}
+
+		public class IdAsIntPtrClass : ObjCProtocolTest
+		{
+			[Export ("idAsIntPtr:")]
+			public new void IdAsIntPtr (IntPtr id)
+			{
+				Assert.AreEqual (IntPtr.Zero, id, "Zero");
+			}
+		}
+
 #if !__TVOS__ && !__WATCHOS__
 		class Test24970 : UIApplicationDelegate {
 			// This method uses the [Transient] attribute.

--- a/tests/test-libraries/libtest.h
+++ b/tests/test-libraries/libtest.h
@@ -109,6 +109,8 @@ typedef unsigned int (^RegistrarTestBlock) (unsigned int magic);
 	-(RegistrarTestBlock) methodReturningBlock;
 	@property (nonatomic, readonly) RegistrarTestBlock propertyReturningBlock;
 	-(bool) testBlocks;
+
+	-(void) idAsIntPtr: (id)p1;
 @end
 
 /*
@@ -121,6 +123,18 @@ typedef unsigned int (^RegistrarTestBlock) (unsigned int magic);
 	-(void) invokeManagedExceptionThrower;
 	-(void) invokeManagedExceptionThrowerAndRethrow;
 	-(void) invokeManagedExceptionThrowerAndCatch;
+@end
+
+@protocol ObjCProtocolTest
+@required
+	-(void) idAsIntPtr: (id)p1;
+@end
+
+// We need this class so that the ObjCProtocolTest protocol
+// actually ends up in the library.
+@interface ObjCProtocolClassTest : NSObject<ObjCProtocolTest> {
+}
+-(void) idAsIntPtr: (id)p1;
 @end
 
 #ifdef __cplusplus

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -185,6 +185,11 @@ static UltimateMachine *shared;
 
 		return true;
 	}
+
+	-(void) idAsIntPtr: (id)p1
+	{
+		// Nothing to do here.
+	}
 @end
 
 @implementation ObjCExceptionTest
@@ -239,5 +244,12 @@ static UltimateMachine *shared;
 {
 	self.initCallsInitCalled = YES;
 	return [self init];
+}
+@end
+
+@implementation ObjCProtocolClassTest
+-(void) idAsIntPtr: (id)p1
+{
+	// Do nothing
 }
 @end


### PR DESCRIPTION
Support binding NSObjects as IntPtr. This is usually not
a problem, because when we fetch the ObjC signature for a
method, we usually get the signature as exported by us,
(in which case a parameter bound as 'IntPtr' would be treated
as 'void *' in the dynamic registrar) *except* when the
selector corresponds with a protocol the type implements,
in which case we get the signature as defined in the protocol.

https://bugzilla.xamarin.com/show_bug.cgi?id=41132