### PR TITLE
[mk] Make sure we're on the right hash after cloning maccore.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -86,6 +86,7 @@ endef
 
 $(MACCORE_PATH):
 	$(Q) git clone --recursive $(MACCORE_MODULE) $(MACCORE_PATH)
+	$(Q) $(MAKE) reset-maccore
 
 $(eval $(call CheckVersionTemplate,maccore,MACCORE))
 -include $(MACCORE_PATH)/mk/versions.mk


### PR DESCRIPTION
This fixes the following problem:

* xamarin-macios is cloned
* xamarin mode is enabled
* make world is executed
  * The maccore repo will be cloned immediately
  * make reset-versions will be executed, which will reset the maccore version.
    If this brings a new version of maccore, maccore dependencies might be
    out of date.
  * make all will be executed, which may fail because some dependencies
    are out of date.