### PR TITLE
Make sure to install msbuild symlinks properly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,7 @@ endif
 endif
 
 install-system: install-system-ios install-system-mac
+	$(Q) $(MAKE) install-symlinks MAC_DESTDIR=/ MAC_INSTALL_VERSION=Current IOS_DESTDIR=/ IOS_INSTALL_VERSION=Current -C msbuild V=$(V)
 
 install-system-ios:
 	@if ! test -s "$(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)/buildinfo"; then echo "The Xamarin.iOS build seems incomplete. Did you run \"make install\"?"; exit 1; fi


### PR DESCRIPTION
This line got lost somewhere when migrating to the xamarin-macios repo.