### PR TITLE
[mtouch] Disable fastdev if profiling+fastdev is enabled on a bitcode-capable platform.

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -855,6 +855,23 @@ namespace Xamarin.Bundler {
 
 			Namespaces.Initialize ();
 
+			var hasBitcodeCapableRuntime = false;
+			switch (Platform) {
+			case ApplePlatform.iOS:
+#if ENABLE_BITCODE_ON_IOS
+				hasBitcodeCapableRuntime = true;
+#endif
+				break;
+			case ApplePlatform.TVOS:
+			case ApplePlatform.WatchOS:
+				hasBitcodeCapableRuntime = true;
+				break;
+			}
+			if (hasBitcodeCapableRuntime && EnableProfiling && FastDev) {
+				ErrorHelper.Warning (94, "Both profiling (--profiling) and incremental builds (--fastdev) is not supported when building for {0}. Incremental builds have ben disabled.", PlatformName);
+				FastDev = false;
+			}
+
 			InitializeCommon ();
 
 			Driver.Watch ("Resolve References", 1);

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -100,6 +100,7 @@ namespace Xamarin.Bundler {
 	//					MT0091	This version of Xamarin.iOS requires the {0} {1} SDK (shipped with Xcode {2}) when the managed linker is disabled. Either upgrade Xcode, or enable the managed linker. 
 	//					MT0092	<used by Xamarin.Launcher> The option '{0}' is required.
 	//					MT0093	Could not find 'mlaunch'.
+	//		Warning		MT0094	Both profiling (--profiling) and incremental builds (--fastdev) is not supported when building for {0}. Incremental builds have ben disabled.
 	// MT1xxx	file copy / symlinks (project related)
 	//			MT10xx	installer.cs / mtouch.cs
 	//					MT1001	Could not find an application at the specified directory: {0}


### PR DESCRIPTION
This is because Mono doesn't build a libmono-profiler-log.dylib when
bitcode is enabled, so we can't support profiling + fastdev at the same
time.

Hopefully mono will fix this (see bug#41428) soon, in which case
this code can be removed.

https://bugzilla.xamarin.com/show_bug.cgi?id=41428