### PR TITLE
Added MtouchTargetsEnabled property to build

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -57,6 +57,10 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 		<IsAppExtension Condition="'$(IsAppExtension)' == ''">False</IsAppExtension>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<MtouchTargetsEnabled>true</MtouchTargetsEnabled>
+	</PropertyGroup>
+
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.props"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.props')"/>
 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -205,7 +205,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
-			Condition="'@(_NativeLibrary)' != ''"
+			Condition="'@(_NativeLibrary)' != '' And '$(MtouchTargetsEnabled)' == 'true'"
 			CodesignAllocate="$(_CodesignAllocate)"
 			Keychain="$(CodesignKeychain)"
 			Resource="%(_NativeLibrary.Identity)"
@@ -219,6 +219,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<Target Name="_EmbedProvisionProfile" Condition="'$(_ProvisioningProfile)' != ''" DependsOnTargets="_GenerateBundleName"
 		Outputs="$(_AppBundlePath)Contents\embedded.provisionprofile">
 		<EmbedProvisionProfile
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			AppBundleDir="$(AppBundleDir)"
 			ProvisioningProfile="$(_ProvisioningProfile)"
@@ -229,6 +230,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<Target Name="_CompileEntitlements" Condition="'$(EnableCodeSigning)'" DependsOnTargets="_GenerateBundleName"
 		Outputs="$(IntermediateOutputPath)Entitlements.xcent">
 		<CompileEntitlements
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			AppBundleDir="$(AppBundleDir)"
 			AppIdentifier="$(_AppIdentifier)"
@@ -246,6 +248,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CodesignAppBundle" Condition="'$(EnableCodeSigning)'" DependsOnTargets="$(_CodesignAppBundleDependsOn)">
 		<Codesign
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
@@ -262,6 +265,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CodesignVerify" Condition="'$(EnableCodeSigning)'" DependsOnTargets="_CodesignAppBundle">
 		<CodesignVerify
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
@@ -276,6 +280,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		Inputs="@(_BundleResourceWithLogicalName)"
 		Outputs="@(_BundleResourceWithLogicalName -> '$(_AppResourcesPath)%(LogicalName)')">
 		<SmartCopy
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			SourceFiles = "@(_BundleResourceWithLogicalName)"
 			DestinationFiles = "@(_BundleResourceWithLogicalName -> '$(_AppResourcesPath)%(LogicalName)')"/>
@@ -283,6 +288,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CollectBundleResources" DependsOnTargets="$(_CollectBundleResourcesDependsOn)">
 		<CollectBundleResources
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			BundleResources="@(Content);@(BundleResource)"
 			ProjectDir="$(MSBuildProjectDirectory)"
@@ -321,6 +327,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_DetectSdkLocations">
 		<Metal
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			ProjectDir="$(MSBuildProjectDirectory)"
@@ -334,6 +341,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<Target Name="_ForgeMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(_SmeltedMetal)' != ''" DependsOnTargets="_SmeltMetal"
 		Inputs="@(_SmeltedMetal)" Outputs="$(IntermediateOutputPath)metal\default.metal-ar">
 		<ArTool
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			Items="@(_SmeltedMetal)"
 			Archive="$(IntermediateOutputPath)metal\default.metal-ar">
@@ -347,6 +355,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<Target Name="_TemperMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(_ForgedMetal)' != ''" DependsOnTargets="_ForgeMetal"
 		Inputs="@(_ForgedMetal)" Outputs="$(_AppBundlePath)default.metallib">
 		<MetalLib
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			Items="@(_ForgedMetal)"
 			SdkDevPath="$(_SdkDevPath)"
@@ -362,6 +371,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CoreCompileTextureAtlases">
 		<TextureAtlas
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(TextureAtlasExe)"
 			ToolPath="$(TextureAtlasPath)"
@@ -379,6 +389,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CreateInstaller" Condition="$(CreatePackage)" DependsOnTargets="Codesign">
 		<CreateInstallerPackage
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			OutputDirectory = "$(TargetDir)"
 			Name = "$(AssemblyName)"
@@ -395,6 +406,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_PackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'false'" DependsOnTargets="_CollectBundleResources">
 		<PackLibraryResources
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			Prefix="xammac"
 			BundleResourcesWithLogicalNames="@(_BundleResourceWithLogicalName)">
@@ -404,6 +416,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_UnpackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="ResolveReferences;_CollectBundleResources">
 		<UnpackLibraryResources
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			Prefix="xammac"
 			NoOverwrite="@(_BundleResourceWithLogicalName)"
@@ -416,6 +429,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_DetectSdkLocations">
 		<DetectSdkLocations
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			SdkVersion="$(MacOSXSdkVersion)">
 			<Output TaskParameter="SdkVersion" PropertyName="MacOSXSdkVersion" />
@@ -432,6 +446,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		</PropertyGroup>
 
 		<DetectSigningIdentity
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			AppBundleName="$(_AppBundleName)"
 			AppManifest="$(_AppManifest)"
@@ -463,6 +478,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		Inputs="$(_AppManifest);@(_PartialAppManifest)"
 		Outputs="$(_AppBundlePath)Contents\Info.plist" >
 		<CompileAppManifest
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			AppBundleName="$(_AppBundleName)"
 			AppBundleDir="$(AppBundleDir)"
@@ -478,6 +494,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		Inputs="$(TargetDir)$(TargetFileName)"
 		Outputs="$(_AppBundlePath)Contents\MacOS\$(TargetFileName)">
 		<Mmp
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			FrameworkRoot="$(XamarinMacFrameworkRoot)"
 			OutputPath="$(OutputPath)"
@@ -507,6 +524,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CollectColladaAssets">
 		<CollectBundleResources
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			BundleResources="@(Collada)"
 			ProjectDir="$(MSBuildProjectDirectory)"
@@ -522,6 +540,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		>
 
 		<ScnTool
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(ScnToolExe)"
 			ToolPath="$(ScnToolPath)"
@@ -542,6 +561,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CoreCompileImageAssets">
 		<ACTool
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(ACToolExe)"
 			ToolPath="$(ACToolPath)"
@@ -569,6 +589,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CoreCompileSceneKitAssets">
 		<CompileSceneKitAssets
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(CopySceneKitAssetsExe)"
 			ToolPath="$(CopySceneKitAssetsPath)"
@@ -588,6 +609,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CoreCompileInterfaceDefinitions">
 		<IBTool
+			Condition="'$(MtouchTargetsEnabled)'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(IBToolExe)"
 			ToolPath="$(IBToolPath)"
@@ -609,11 +631,11 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CreatePkgInfo" DependsOnTargets="_GenerateBundleName" Outputs="$(_AppBundlePath)Contents\PkgInfo">
-		<CreatePkgInfo OutputPath="$(_AppBundlePath)Contents\PkgInfo" />
+		<CreatePkgInfo SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" OutputPath="$(_AppBundlePath)Contents\PkgInfo" />
 
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="'@(_ResolvedAppExtensionReferences)' != '' And '%(_ResolvedAppExtensionReferences.Identity)' != ''"
+			Condition="'@(_ResolvedAppExtensionReferences)' != '' And '%(_ResolvedAppExtensionReferences.Identity)' != '' And '$(MtouchTargetsEnabled)' == 'true'"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="@(_ResolvedAppExtensionReferences)"
@@ -626,7 +648,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="'@(_ResolvedAppExtensionReferences)' != '' And '%(_ResolvedAppExtensionReferences.Identity)' != ''"
+			Condition="'@(_ResolvedAppExtensionReferences)' != '' And '%(_ResolvedAppExtensionReferences.Identity)' != '' And '$(MtouchTargetsEnabled)' == 'true'"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="@(_ResolvedAppExtensionReferences)"


### PR DESCRIPTION
This lets us ignore Mac targets when disconnected from the Mac. The default in props is to _always_ do the Mac side of the build. We override that in our targets.