### PR TITLE
[XM] Fix dontlink by fixing some NSAccessibility binding mistakes

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -22369,7 +22369,7 @@ namespace XamCore.AppKit {
 
 		[Mac (10, 7)]
 		[Field ("NSAccessibilityFullScreenButtonSubrole")]
-		NSString FullscreenButtonSubrole { get; }
+		NSString FullScreenButtonSubrole { get; }
 
 		[Mac (10, 9)]
 		[Field ("NSAccessibilityToggleSubrole")]

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -22008,7 +22008,7 @@ namespace XamCore.AppKit {
 		NSString ColumnIndexRangeAttribute { get; }
 
 		[Mac (10, 6)]
-		[Field ("NSAccessibilityHoriztonalUnitsAttribute")]
+		[Field ("NSAccessibilityHorizontalUnitsAttribute")]
 		NSString HorizontalUnitsAttribute { get; }
 
 		[Mac (10, 6)]
@@ -22049,7 +22049,7 @@ namespace XamCore.AppKit {
 		[Field ("NSAccessibilityDisclosedRowsAttribute")]
 		NSString DisclosedRowsAttribute { get; }
 
-		[Field ("NSAccessibilityDisclosedByRowsAttribute")]
+		[Field ("NSAccessibilityDisclosedByRowAttribute")]
 		NSString DisclosedByRowsAttribute { get; }
 
 		[Field ("NSAccessibilityDisclosureLevelAttribute")]
@@ -22368,7 +22368,7 @@ namespace XamCore.AppKit {
 		NSString DefinitionListSubrole { get; }
 
 		[Mac (10, 7)]
-		[Field ("NSAccessibilityFullscreenButtonSubrole")]
+		[Field ("NSAccessibilityFullScreenButtonSubrole")]
 		NSString FullscreenButtonSubrole { get; }
 
 		[Mac (10, 9)]
@@ -22392,8 +22392,8 @@ namespace XamCore.AppKit {
 		[Field ("NSAccessibilityFocusedWindowChangedNotification")]
 		NSString FocusedWindowChangedNotification { get; }
 
-		[Field ("NSAccessibilityUIElementChangedNotification")]
-		NSString UIElementChangedNotification { get; }
+		[Field ("NSAccessibilityFocusedUIElementChangedNotification")]
+		NSString UIElementFocusedChangedNotification { get; }
 
 		[Field ("NSAccessibilityApplicationActivatedNotification")]
 		NSString ApplicationActivatedNotification { get; }
@@ -22804,11 +22804,13 @@ namespace XamCore.AppKit {
 		void SetAccessibilityFrame (CGRect frame);
 	}
 
-	[Protocol, BaseType (typeof (NSObject))]
-	public interface NSObjectAccessibilityExtensions {
+	[BaseType (typeof (NSView))]
+	[Category]
+	public interface NSObjectAccessibilityViewExtensions {
+		// Please note the neary copy in NSObjectAccessibilityCellExtensions and update there as well
 		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
 		[Export ("accessibilityAttributeNames")]
-		NSArray AccessibilityAttributeNames { get; }
+		NSArray GetAccessibilityAttributeNames ();
 
 		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
 		[Export ("accessibilityAttributeValue:")]
@@ -22824,7 +22826,7 @@ namespace XamCore.AppKit {
 
 		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
 		[Export ("accessibilityParameterizedAttributeNames")]
-		NSArray AccessibilityParameterizedAttributeNames { get; }
+		NSArray GetAccessibilityParameterizedAttributeNames ();
 
 		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
 		[Export ("accessibilityAttributeValue:forParameter:")]
@@ -22832,7 +22834,7 @@ namespace XamCore.AppKit {
 
 		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
 		[Export ("accessibilityActionNames")]
-		NSArray AccessibilityActionNames { get; }
+		NSArray GetAccessibilityActionNames ();
 
 		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
 		[Export ("accessibilityActionDescription:")]
@@ -22844,7 +22846,7 @@ namespace XamCore.AppKit {
 
 		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
 		[Export ("accessibilityIsIgnored")]
-		bool AccessibilityIsIgnored { get; }
+		bool GetAccessibilityIsIgnored ();
 
 		[Export ("accessibilityHitTest:")]
 		NSObject GetAccessibilityHitTest (CGPoint point);
@@ -22863,19 +22865,85 @@ namespace XamCore.AppKit {
 
 		[Mac (10,9)]
 		[Export ("accessibilityNotifiesWhenDestroyed")]
-		bool AccessibilityNotifiesWhenDestroyed { get; }
+		bool GetAccessibilityNotifiesWhenDestroyed ();
+	}
+
+
+	[BaseType (typeof (NSCell))]
+	[Category]
+	public interface NSObjectAccessibilityCellExtensions {
+		// Please note the neary copy in NSObjectAccessibilityViewExtensions and update there as well
+		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
+		[Export ("accessibilityAttributeNames")]
+		NSArray GetAccessibilityAttributeNames ();
+
+		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
+		[Export ("accessibilityAttributeValue:")]
+		NSObject GetAccessibilityValue (NSString attribute);
+
+		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
+		[Export ("accessibilityIsAttributeSettable:")]
+		bool IsAccessibilityAttributeSettable (NSString attribute);
+
+		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
+		[Export ("accessibilitySetValue:forAttribute:")]
+		void SetAccessibilityValue (NSString attribute, NSObject value);
+
+		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
+		[Export ("accessibilityParameterizedAttributeNames")]
+		NSArray GetAccessibilityParameterizedAttributeNames ();
+
+		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
+		[Export ("accessibilityAttributeValue:forParameter:")]
+		NSObject GetAccessibilityValue (NSString attribute, NSObject parameter);
+
+		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
+		[Export ("accessibilityActionNames")]
+		NSArray GetAccessibilityActionNames ();
+
+		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
+		[Export ("accessibilityActionDescription:")]
+		NSString GetAccessibilityActionDescription (NSString action);
+
+		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
+		[Export ("accessibilityPerformAction:")]
+		void AccessibilityPerformAction (NSString action);
+
+		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
+		[Export ("accessibilityIsIgnored")]
+		bool GetAccessibilityIsIgnored ();
+
+		[Export ("accessibilityHitTest:")]
+		NSObject GetAccessibilityHitTest (CGPoint point);
+
+		[Export ("getAccessibilityFocusedUIElement")]
+		NSObject GetAccessibilityFocusedUIElement ();
+
+		[Export ("accessibilityIndexOfChild:")]
+		nuint GetAccessibilityIndexOfChild (NSObject child);
+
+		[Export ("accessibilityArrayAttributeCount:")]
+		nuint GetAccessibilityArrayAttributeCount (NSString attribute);
+
+		[Export ("accessibilityArrayAttributeValues:index:maxCount:")]
+		NSObject[] GetAccessibilityArrayAttributeValues (NSString attribute, nuint index, nuint maxCount);
+
+		[Mac (10,9)]
+		[Export ("accessibilityNotifiesWhenDestroyed")]
+		bool GetAccessibilityNotifiesWhenDestroyed ();
 	}
 
 	[Mac (10, 10)]
-	[Protocol, BaseType (typeof (NSWorkspace))]
+	[BaseType (typeof (NSWorkspace))]
+	[Category]
 	public interface NSWorkspaceAccessibilityExtensions {
 		[Export ("accessibilityDisplayShouldIncreaseContract")]
-		bool AccessibilityDisplayShouldIncreaseContract { get; }
+		bool GetAccessibilityDisplayShouldIncreaseContract ();
 
 		[Export ("accessibilityDisplayShouldDifferentiateWithoutColor")]
-		bool AccessibilityDisplayShouldDifferentiateWithoutColor { get; }
+		bool GetAccessibilityDisplayShouldDifferentiateWithoutColor ();
 
 		[Export ("accessibilityDisplayShouldReduceTransparency")]
-		bool AccessibilityDisplayShouldReduceTransparency { get; }
+		bool GetAccessibilityDisplayShouldReduceTransparency ();
 	}
 }

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -22849,7 +22849,7 @@ namespace XamCore.AppKit {
 		NSObject GetAccessibilityHitTest (CGPoint point);
 
 		[Export ("accessibilityFocusedUIElement")]
-		NSObject AccessibilityFocusedUIElement ();
+		NSObject GetAccessibilityFocusedUIElement ();
 
 		[Export ("accessibilityIndexOfChild:")]
 		nuint GetAccessibilityIndexOfChild (NSObject child);

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -22849,7 +22849,7 @@ namespace XamCore.AppKit {
 		NSObject GetAccessibilityHitTest (CGPoint point);
 
 		[Export ("accessibilityFocusedUIElement")]
-		NSObject AccessibilityFocusedUIElement { get; }
+		NSObject AccessibilityFocusedUIElement ();
 
 		[Export ("accessibilityIndexOfChild:")]
 		nuint GetAccessibilityIndexOfChild (NSObject child);

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -2088,7 +2088,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSCell : NSUserInterfaceItemIdentification, NSCoding, NSCopying, NSAccessibilityElement, NSAccessibility {
+	public interface NSCell : NSUserInterfaceItemIdentification, NSCoding, NSCopying, NSAccessibilityElement, NSAccessibility, NSObjectAccessibilityViewExtensions {
 		[Static, Export ("prefersTrackingUntilMouseUp")]
 		bool PrefersTrackingUntilMouseUp { get; }
 	
@@ -13727,7 +13727,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSResponder))]
 	[Dispose ("__mt_tracking_var = null;")]
-	public partial interface NSView : NSDraggingDestination, NSAnimatablePropertyContainer, NSUserInterfaceItemIdentification, NSAppearanceCustomization, NSAccessibilityElement, NSAccessibility {
+	public partial interface NSView : NSDraggingDestination, NSAnimatablePropertyContainer, NSUserInterfaceItemIdentification, NSAppearanceCustomization, NSAccessibilityElement, NSAccessibility, NSObjectAccessibilityViewExtensions {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -18941,7 +18941,7 @@ namespace XamCore.AppKit {
 	public delegate void NSWorkspaceUrlHandler (NSDictionary newUrls, NSError error);
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSWorkspace {
+	public interface NSWorkspace : NSWorkspaceAccessibilityExtensions {
 		[Static]
 		[Export ("sharedWorkspace"), ThreadSafe]
 		NSWorkspace SharedWorkspace { get; }
@@ -22050,7 +22050,7 @@ namespace XamCore.AppKit {
 		NSString DisclosedRowsAttribute { get; }
 
 		[Field ("NSAccessibilityDisclosedByRowAttribute")]
-		NSString DisclosedByRowsAttribute { get; }
+		NSString DisclosedByRowAttribute { get; }
 
 		[Field ("NSAccessibilityDisclosureLevelAttribute")]
 		NSString DisclosureLevelAttribute { get; }
@@ -22804,13 +22804,11 @@ namespace XamCore.AppKit {
 		void SetAccessibilityFrame (CGRect frame);
 	}
 
-	[BaseType (typeof (NSView))]
-	[Category]
 	public interface NSObjectAccessibilityViewExtensions {
 		// Please note the neary copy in NSObjectAccessibilityCellExtensions and update there as well
 		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
 		[Export ("accessibilityAttributeNames")]
-		NSArray GetAccessibilityAttributeNames ();
+		NSArray AccessibilityAttributeNames { get; }
 
 		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
 		[Export ("accessibilityAttributeValue:")]
@@ -22826,7 +22824,7 @@ namespace XamCore.AppKit {
 
 		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
 		[Export ("accessibilityParameterizedAttributeNames")]
-		NSArray GetAccessibilityParameterizedAttributeNames ();
+		NSArray AccessibilityParameterizedAttributeNames { get; }
 
 		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
 		[Export ("accessibilityAttributeValue:forParameter:")]
@@ -22834,7 +22832,7 @@ namespace XamCore.AppKit {
 
 		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
 		[Export ("accessibilityActionNames")]
-		NSArray GetAccessibilityActionNames ();
+		NSArray AccessibilityActionNames { get; }
 
 		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
 		[Export ("accessibilityActionDescription:")]
@@ -22846,13 +22844,13 @@ namespace XamCore.AppKit {
 
 		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
 		[Export ("accessibilityIsIgnored")]
-		bool GetAccessibilityIsIgnored ();
+		bool AccessibilityIsIgnored { get; }
 
 		[Export ("accessibilityHitTest:")]
 		NSObject GetAccessibilityHitTest (CGPoint point);
 
-		[Export ("getAccessibilityFocusedUIElement")]
-		NSObject GetAccessibilityFocusedUIElement ();
+		[Export ("accessibilityFocusedUIElement")]
+		NSObject AccessibilityFocusedUIElement { get; }
 
 		[Export ("accessibilityIndexOfChild:")]
 		nuint GetAccessibilityIndexOfChild (NSObject child);
@@ -22865,85 +22863,18 @@ namespace XamCore.AppKit {
 
 		[Mac (10,9)]
 		[Export ("accessibilityNotifiesWhenDestroyed")]
-		bool GetAccessibilityNotifiesWhenDestroyed ();
-	}
-
-
-	[BaseType (typeof (NSCell))]
-	[Category]
-	public interface NSObjectAccessibilityCellExtensions {
-		// Please note the neary copy in NSObjectAccessibilityViewExtensions and update there as well
-		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
-		[Export ("accessibilityAttributeNames")]
-		NSArray GetAccessibilityAttributeNames ();
-
-		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
-		[Export ("accessibilityAttributeValue:")]
-		NSObject GetAccessibilityValue (NSString attribute);
-
-		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
-		[Export ("accessibilityIsAttributeSettable:")]
-		bool IsAccessibilityAttributeSettable (NSString attribute);
-
-		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
-		[Export ("accessibilitySetValue:forAttribute:")]
-		void SetAccessibilityValue (NSString attribute, NSObject value);
-
-		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
-		[Export ("accessibilityParameterizedAttributeNames")]
-		NSArray GetAccessibilityParameterizedAttributeNames ();
-
-		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
-		[Export ("accessibilityAttributeValue:forParameter:")]
-		NSObject GetAccessibilityValue (NSString attribute, NSObject parameter);
-
-		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
-		[Export ("accessibilityActionNames")]
-		NSArray GetAccessibilityActionNames ();
-
-		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
-		[Export ("accessibilityActionDescription:")]
-		NSString GetAccessibilityActionDescription (NSString action);
-
-		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
-		[Export ("accessibilityPerformAction:")]
-		void AccessibilityPerformAction (NSString action);
-
-		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
-		[Export ("accessibilityIsIgnored")]
-		bool GetAccessibilityIsIgnored ();
-
-		[Export ("accessibilityHitTest:")]
-		NSObject GetAccessibilityHitTest (CGPoint point);
-
-		[Export ("getAccessibilityFocusedUIElement")]
-		NSObject GetAccessibilityFocusedUIElement ();
-
-		[Export ("accessibilityIndexOfChild:")]
-		nuint GetAccessibilityIndexOfChild (NSObject child);
-
-		[Export ("accessibilityArrayAttributeCount:")]
-		nuint GetAccessibilityArrayAttributeCount (NSString attribute);
-
-		[Export ("accessibilityArrayAttributeValues:index:maxCount:")]
-		NSObject[] GetAccessibilityArrayAttributeValues (NSString attribute, nuint index, nuint maxCount);
-
-		[Mac (10,9)]
-		[Export ("accessibilityNotifiesWhenDestroyed")]
-		bool GetAccessibilityNotifiesWhenDestroyed ();
+		bool AccessibilityNotifiesWhenDestroyed { get; }
 	}
 
 	[Mac (10, 10)]
-	[BaseType (typeof (NSWorkspace))]
-	[Category]
 	public interface NSWorkspaceAccessibilityExtensions {
-		[Export ("accessibilityDisplayShouldIncreaseContract")]
-		bool GetAccessibilityDisplayShouldIncreaseContract ();
+		[Export ("accessibilityDisplayShouldIncreaseContrast")]
+		bool AccessibilityDisplayShouldIncreaseContrast { get; }
 
 		[Export ("accessibilityDisplayShouldDifferentiateWithoutColor")]
-		bool GetAccessibilityDisplayShouldDifferentiateWithoutColor ();
+		bool AccessibilityDisplayShouldDifferentiateWithoutColor { get; }
 
 		[Export ("accessibilityDisplayShouldReduceTransparency")]
-		bool GetAccessibilityDisplayShouldReduceTransparency ();
+		bool AccessibilityDisplayShouldReduceTransparency { get; }
 	}
 }

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -2088,7 +2088,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSCell : NSUserInterfaceItemIdentification, NSCoding, NSCopying, NSAccessibilityElement, NSAccessibility, NSObjectAccessibilityViewExtensions {
+	public interface NSCell : NSUserInterfaceItemIdentification, NSCoding, NSCopying, NSAccessibilityElement, NSAccessibility, NSObjectAccessibilityExtensions {
 		[Static, Export ("prefersTrackingUntilMouseUp")]
 		bool PrefersTrackingUntilMouseUp { get; }
 	
@@ -13727,7 +13727,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSResponder))]
 	[Dispose ("__mt_tracking_var = null;")]
-	public partial interface NSView : NSDraggingDestination, NSAnimatablePropertyContainer, NSUserInterfaceItemIdentification, NSAppearanceCustomization, NSAccessibilityElement, NSAccessibility, NSObjectAccessibilityViewExtensions {
+	public partial interface NSView : NSDraggingDestination, NSAnimatablePropertyContainer, NSUserInterfaceItemIdentification, NSAppearanceCustomization, NSAccessibilityElement, NSAccessibility, NSObjectAccessibilityExtensions {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -22804,8 +22804,7 @@ namespace XamCore.AppKit {
 		void SetAccessibilityFrame (CGRect frame);
 	}
 
-	public interface NSObjectAccessibilityViewExtensions {
-		// Please note the neary copy in NSObjectAccessibilityCellExtensions and update there as well
+	public interface NSObjectAccessibilityExtensions {
 		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
 		[Export ("accessibilityAttributeNames")]
 		NSArray AccessibilityAttributeNames { get; }

--- a/tests/dontlink-mac/MacApiSelectorTest.cs
+++ b/tests/dontlink-mac/MacApiSelectorTest.cs
@@ -113,6 +113,10 @@ namespace MonoMacFixtures {
 		protected override bool Skip (Type type, string selectorName)
 		{
 			switch (selectorName) {
+			case "accessibilityNotifiesWhenDestroyed":
+				// The header declares this on an NSObject category but 
+				// it doesn't even respondsToSelector on NSView/NSCell...
+				return true;
 #if !XAMCORE_4_0
 			case "xamarinselector:removed:":
 				return true;


### PR DESCRIPTION
This commit was not run against dontlink and sadness occurred: https://github.com/xamarin/xamarin-macios/commit/f535df6168690e7016460fc6f0b7b73bcbca0c71

This fixes things up.

I did not want to expose the previously named NSObjectAccessibilityExtensions on NSObject, even if that's what the header says, since that will really dirty up auto complete. Oh and:

   BOOL oDoes = [o respondsToSelector:@selector(accessibilityHitTest:)]; // NSObject * o - NO
   BOOL vDoes = [v respondsToSelector:@selector(accessibilityHitTest:)]; // NSView * v - YES

So I did a copy/paste. Which is terrible. Not sure a better way (open to suggestions).