### PR TITLE
[gamekit] Fix breaking change in GKLocalPlayerListener for classic

### DIFF
--- a/src/GameKit/GKLocalPlayerListener.cs
+++ b/src/GameKit/GKLocalPlayerListener.cs
@@ -1,4 +1,4 @@
-#if !MONOMAC && XAMCORE_2_0
+#if !MONOMAC
 using System;
 using XamCore.Foundation;
 using XamCore.ObjCRuntime;


### PR DESCRIPTION
reference: apidiff

Namespace MonoTouch.GameKit

Type Changed: MonoTouch.GameKit.GKLocalPlayerListener

Removed method:

	public virtual void DidRequestMatchWithPlayers (GKPlayer player, string[] playerIDsToInvite);