### PR TITLE
Bind FIFinderSync correctly (has both class and protocol with same name)

### DIFF
--- a/src/findersync.cs
+++ b/src/findersync.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using XamCore.Foundation;
 using XamCore.ObjCRuntime;
 using XamCore.AppKit;
@@ -30,12 +30,8 @@ namespace XamCore.FinderSync {
 	}
 
 	[Mac (10, 10, onlyOn64: true)]
-	interface IFIFinderSync { }
-
-	[Mac (10, 10, onlyOn64: true)]
-	[BaseType (typeof(NSObject))]
-	[Model, Protocol]
-	interface FIFinderSync : NSExtensionRequestHandling
+	[Protocol (Name = "FIFinderSync")]
+	interface FIFinderSyncProtocol
 	{
 		[Export ("menuForMenuKind:")]
 		[return: NullAllowed]
@@ -59,5 +55,11 @@ namespace XamCore.FinderSync {
 		[Export ("toolbarItemToolTip")]
 		string ToolbarItemToolTip { get; }
 	}	
+
+	[Mac (10, 10, onlyOn64: true)]
+	[BaseType (typeof(NSObject))]
+	interface FIFinderSync : NSExtensionRequestHandling, FIFinderSyncProtocol
+	{
+	}
 }
 #endif


### PR DESCRIPTION
FIFinderSync in apple's headers is a Protocol with the methods that is then implemented by a class of the same name.  Our bindings had them combined into one class, which worked for running a project, but failed the tests.  The tests were fixed by adding [Model, Protocol] attributes to the class, which then passed the tests but failed when running a project.

This fixes it to actually work correctly by binding the protocol as a separate name (FIFinderSyncProtocol), but specifying the correct name in the protocol attribute, then declaring a class of the correct name (FIFinderSync) that implements the protocol.  This both passes the tests and works when running a project.