### PR TITLE
[XM] Add release value option to msbuild/mmp to resolve XM 4.5 assemb…

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.XM45.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.XM45.targets
@@ -18,7 +18,7 @@ Copyright (C) 2015 Xamarin Inc. All rights reserved.
 	<!-- These hacks will need to be rewritten if/when we move from xbuild to msbuild. Most likely to use FrameworkPathOverride, which should hopefully work.-->
 	<!-- This lets us bypass the standard MSBuild framework resolution and point to our copy. -->
 	<!-- Without this, we'll resolve System.dll and such from the system mono  -->
-	<PropertyGroup Condition="!$(MonoBundlingExtraArgs.Contains('--allow_unsafe_gac_resolution'))" >
+	<PropertyGroup Condition="!$(MonoBundlingExtraArgs.Contains('--allow-unsafe-gac-resolution'))" >
 		<AssemblySearchPaths>$([System.String]::Copy('$(AssemblySearchPaths)').Replace('{GAC}',''))</AssemblySearchPaths>
 	</PropertyGroup>
 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.XM45.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.XM45.targets
@@ -18,7 +18,7 @@ Copyright (C) 2015 Xamarin Inc. All rights reserved.
 	<!-- These hacks will need to be rewritten if/when we move from xbuild to msbuild. Most likely to use FrameworkPathOverride, which should hopefully work.-->
 	<!-- This lets us bypass the standard MSBuild framework resolution and point to our copy. -->
 	<!-- Without this, we'll resolve System.dll and such from the system mono  -->
-	<PropertyGroup>
+	<PropertyGroup Condition="!$(MonoBundlingExtraArgs.Contains('--allow_unsafe_gac_resolution'))" >
 		<AssemblySearchPaths>$([System.String]::Copy('$(AssemblySearchPaths)').Replace('{GAC}',''))</AssemblySearchPaths>
 	</PropertyGroup>
 

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -306,5 +306,23 @@ namespace Xamarin.MMP.Tests
 				TI.BuildUnifiedExecutable (test, shouldFail: false);
 			});
 		}
+
+		[Test]
+		public void UnsafeGACResolutionOptions_AllowsWindowsBaseResolution ()
+		{
+			RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir)
+				{
+					XM45 = true,
+					TestCode = "System.Console.WriteLine (typeof (System.Windows.DependencyObject));",
+					References = "<Reference Include=\"WindowsBase\" />"
+				};
+
+				TI.TestUnifiedExecutable (test, shouldFail : true);
+
+				test.CSProjConfig = "<MonoBundlingExtraArgs>--allow-unsafe-gac-resolution</MonoBundlingExtraArgs>";
+				TI.TestUnifiedExecutable (test, shouldFail : false);
+			});
+		}
 	}
 }

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -284,7 +284,7 @@ namespace Xamarin.Bundler {
 				{ "tls-provider=", "Specify the default TLS provider", v => { tls_provider = v; }},
 				{ "http-message-handler=", "Specify the default HTTP Message Handler", v => { http_message_provider = v; }},
 				{ "extension", "Specifies an app extension", v => is_extension = true },
-				{ "allow_unsafe_gac_resolution", "Allow msbuild to resolve from the System GAC", v => {} , true }, // Used in Xamarin.Mac.XM45.targets and must be ignored here. Hidden since it is a total hack. If you can use it, you don't need support
+				{ "allow-unsafe-gac-resolution", "Allow MSBuild to resolve from the System GAC", v => {} , true }, // Used in Xamarin.Mac.XM45.targets and must be ignored here. Hidden since it is a total hack. If you can use it, you don't need support
 			};
 
 			AddSharedOptions (os);

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -284,6 +284,7 @@ namespace Xamarin.Bundler {
 				{ "tls-provider=", "Specify the default TLS provider", v => { tls_provider = v; }},
 				{ "http-message-handler=", "Specify the default HTTP Message Handler", v => { http_message_provider = v; }},
 				{ "extension", "Specifies an app extension", v => is_extension = true },
+				{ "allow_unsafe_gac_resolution", "Allow msbuild to resolve from the System GAC", v => {} , true }, // Used in Xamarin.Mac.XM45.targets and must be ignored here. Hidden since it is a total hack. If you can use it, you don't need support
 			};
 
 			AddSharedOptions (os);


### PR DESCRIPTION
…lies from system GAC

- This option "reverts" a C7 fix that prevented resovling assemblies from the GAC, which is unsafe
- If you use this option, you need to know what you are doing. The mono BCL and the XM BCL need to be compatible
- Use strictly puts you in the no support "you get to keep the pieces if it breaks" category