### PR TITLE
[XM] Dynamically look up NSExtensionMain to unbreak pre-10.10 XM apps

### DIFF
--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -587,12 +587,12 @@ int xamarin_main (int argc, char **argv, bool is_extension)
 
 			typedef int (*extension_main)(int argc, char * argv[]);
 
-			extension_main extensionMain = (extension_main)dlsym (libExtensionHandle, "NSExtensionMain");
+			extension_main extensionMain = (extension_main) dlsym (libExtensionHandle, "NSExtensionMain");
 
 			if (extensionMain == nil)
 				exit_with_message ("Unable to load NSExtensionMain", data.basename, false);
 
-			rv =  (*extensionMain) (new_argc, new_argv);
+			rv = (*extensionMain) (new_argc, new_argv);
 			dlclose (libExtensionHandle);
 		} else {
 			rv = mono_main (new_argc, new_argv);

--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -581,7 +581,19 @@ int xamarin_main (int argc, char **argv, bool is_extension)
 		*ptr = NULL;
 
 		if (is_extension) {
-			rv = NSExtensionMain (new_argc, new_argv);
+			void * libExtensionHandle = dlopen ("/usr/lib/libextension.dylib", RTLD_LAZY);
+			if (libExtensionHandle == nil)
+				exit_with_message ("Unable to load libextension.dylib", data.basename, false);
+
+			typedef int (*extension_main)(int argc, char * argv[]);
+
+			extension_main extensionMain = (extension_main)dlsym (libExtensionHandle, "NSExtensionMain");
+
+			if (extensionMain == nil)
+				exit_with_message ("Unable to load NSExtensionMain", data.basename, false);
+
+			rv =  (*extensionMain) (new_argc, new_argv);
+			dlclose (libExtensionHandle);
 		} else {
 			rv = mono_main (new_argc, new_argv);
 		}


### PR DESCRIPTION
- So having a simple reference to NSExtensionMain is enough for /usr/lib/libextension.dylib to get added as a reference to libxammac.dylib
- If you have a reference to /usr/lib/libextension.dylib then any XM app (including our tests) bomb out on startup. This is suboptimal.
- So dlopen/dysm our way to victory.