### PR TITLE
[tests][introspection] Re-apply special case from 05bedce3068046ca41a00c5a776625b17d764ca3

### DIFF
--- a/tests/introspection/Mac/MacApiSelectorTest.cs
+++ b/tests/introspection/Mac/MacApiSelectorTest.cs
@@ -112,6 +112,10 @@ namespace Introspection {
 		protected override bool Skip (Type type, string selectorName)
 		{
 			switch (selectorName) {
+			case "accessibilityNotifiesWhenDestroyed":
+				// The header declares this on an NSObject category but 
+				// it doesn't even respondsToSelector on NSView/NSCell...
+				return true;
 #if !XAMCORE_4_0
 			case "xamarinselector:removed:":
 				return true;


### PR DESCRIPTION
[FAIL] Selector not found for AppKit.NSCell : accessibilityNotifiesWhenDestroyed
[FAIL] Selector not found for AppKit.NSView : accessibilityNotifiesWhenDestroyed

Location changed and the duplicated files were removed (but I missed this
change on dontlink-mac)