### PR TITLE
[registrar] Rewrite ctor's super call to invoke objc_msgSendSuper directly. Fixes #41319.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2444,6 +2444,19 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 		}
 
+		class Bug41319 : NSObject, INSCoding
+		{
+			[Export ("initWithCoder:")]
+			public Bug41319 (NSCoder coder)
+			{
+			}
+
+			public override void EncodeTo (NSCoder coder)
+			{
+				base.EncodeTo (coder);
+			}
+		}
+
 #if debug_code
 		static void DumpClass (Type type)
 		{


### PR DESCRIPTION
There's a clang bug [2] where if a selector is marked as unavailable,
it's marked as unavailable for every class, not just the class where
the unavailable selector is.

This means that we can't do `[super initWithCoder:x]` anywhere,
because `initWithCoder:` is marked as unavailable for UIActivityViewController.

So instead rewrite the call to super to call objc_msgSendSuper
directly, circumventing clang's broken availability checks.

[1] https://bugzilla.xamarin.com/show_bug.cgi?id=41319
[2] https://llvm.org/bugs/show_bug.cgi?id=28058