### PR TITLE
[Fix] Reduce the API changes while adding the new valid methods.

### DIFF
--- a/src/Foundation/NSExpression.cs
+++ b/src/Foundation/NSExpression.cs
@@ -164,5 +164,14 @@ namespace XamCore.Foundation {
 				return _Operand;
 			}
 		}
+		
+#if !XAMCORE_4_0
+		[Obsolete("ValueWithObject is deprecated, please use EvaluateWith instead.")]
+		public virtual NSExpression ExpressionValueWithObject (NSObject obj, NSMutableDictionary context) {
+			var result = EvaluateWith (obj, context);
+			// if it can be casted, do return an NSEXpression else null
+			return result as NSExpression;
+		}
+#endif
 	}
 }

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -3181,7 +3181,7 @@ namespace XamCore.Foundation
 
 #if !XAMCORE_4_0
 		[Obsolete("FromFormat (string, NSExpression[]) is deprecated, please use FromFormat (string, NSObject[]) instead.")]
-		[Sealed, Static, Export ("expressionWithFormat:argumentArray:")]
+		[Static, Export ("expressionWithFormat:argumentArray:")]
 		NSExpression FromFormat (string format, NSExpression [] parameters);
 #endif
 
@@ -3210,7 +3210,7 @@ namespace XamCore.Foundation
 
 #if !XAMCORE_4_0
 		[Obsolete("FromFunction (NSExpressionHandler, NSExpression[]) is deprecated, please use FromFunction (NSExpressionCallbackHandler, NSExpression[]) instead.")]
-		[Sealed, Static, Export ("expressionForBlock:arguments:")]
+		[Static, Export ("expressionForBlock:arguments:")]
 		NSExpression FromFunction (NSExpressionHandler target, NSExpression[] parameters);
 #endif
 
@@ -3279,12 +3279,6 @@ namespace XamCore.Foundation
 		[Sealed, Internal, Export ("falseExpression")]
 		NSExpression _FalseExpression { get; }
 		
-#if !XAMCORE_4_0
-		[Obsolete("ValueWithObject is deprecated, please use EvaluateWith instead.")]
-		[Sealed, Export ("expressionValueWithObject:context:")]
-		NSExpression ExpressionValueWithObject (NSObject object1, NSMutableDictionary context);
-#endif
-
 		[Export ("expressionValueWithObject:context:")]
 		NSObject EvaluateWith ([NullAllowed] NSObject obj, [NullAllowed] NSMutableDictionary context);
 	}


### PR DESCRIPTION
Please do run the API diff to double check the changes. You should get the proper obsolete methods but no changes in their definitions (virtual, static etc..)