### PR TITLE
[xharness] Clean targets are named 'Clean', not 'clean'.

### DIFF
--- a/tests/xharness/MakefileGenerator.cs
+++ b/tests/xharness/MakefileGenerator.cs
@@ -133,7 +133,7 @@ namespace xharness
 						writer.WriteLine ();
 
 						writer.WriteTarget (MakeMacClassicTargetName (target, MacTargetNameType.Clean), "");
-						writer.WriteLine ("\t$(Q) $(MDTOOL) build -t:clean {0}", fileToBuild);
+						writer.WriteLine ("\t$(Q) $(MDTOOL) build -t:Clean {0}", fileToBuild);
 						writer.WriteLine ();
 
 						writer.WriteTarget (MakeMacClassicTargetName (target, MacTargetNameType.Exec), "");


### PR DESCRIPTION
At least according to mdtool.

Fixes this:

    [...]
    Target 'clean not supported
    make[4]: *** [clean-mac-classic-introspection] Error 1