### PR TITLE
[msbuild] Redefine the Exec task to prepare for remote execution from VS

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -41,6 +41,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="Mono.Cecil, Version=0.9.5.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756">
       <Private>True</Private>
+      <HintPath Condition=" Exists('..\packages\Mono.Cecil.0.9.5.0\lib\net40\Mono.Cecil.dll') ">..\packages\Mono.Cecil.0.9.5.0\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -78,6 +79,8 @@
     <Compile Include="Tasks\ReadItemsFromFile.cs" />
     <Compile Include="Tasks\Zip.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/msbuild/Xamarin.MacDev.Tasks/packages.config
+++ b/msbuild/Xamarin.MacDev.Tasks/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Mono.Cecil" version="0.9.5.0" targetFramework="net45" />
+</packages>

--- a/msbuild/Xamarin.iOS.Tasks.Core/MsBuildTasks/ExecBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/MsBuildTasks/ExecBase.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.Build.Tasks
+{
+    public abstract class ExecBase : Microsoft.Build.Tasks.Exec
+    {
+        public string SessionId { get; set; }
+    }
+}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -70,6 +70,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<UsingTask TaskName="Xamarin.iOS.Tasks.ValidateAppBundleTask" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.iOS.Tasks.WriteAssetPackManifest" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 
+	<UsingTask TaskName="Microsoft.Build.Tasks.Exec" AssemblyFile="Xamarin.iOS.Tasks.dll"/>
 	<UsingTask TaskName="Microsoft.Build.Tasks.Copy" AssemblyFile="Xamarin.iOS.Tasks.dll"/>
 	<UsingTask TaskName="Microsoft.Build.Tasks.MakeDir" AssemblyFile="Xamarin.iOS.Tasks.dll"/>
 	<UsingTask TaskName="Microsoft.Build.Tasks.RemoveDir" AssemblyFile="Xamarin.iOS.Tasks.dll"/>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -54,6 +54,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MsBuildTasks\ExecBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MsBuildTasks\CopyBase.cs" />
     <Compile Include="MsBuildTasks\DeleteBase.cs" />

--- a/msbuild/Xamarin.iOS.Tasks/MsBuildTasks/Exec.cs
+++ b/msbuild/Xamarin.iOS.Tasks/MsBuildTasks/Exec.cs
@@ -1,0 +1,6 @@
+﻿namespace Microsoft.Build.Tasks
+{
+	public class Exec : ExecBase
+	{
+	}
+}

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -33,6 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MsBuildTasks\Copy.cs" />
+    <Compile Include="MsBuildTasks\Exec.cs" />
     <Compile Include="MsBuildTasks\Delete.cs" />
     <Compile Include="MsBuildTasks\MakeDir.cs" />
     <Compile Include="MsBuildTasks\RemoveDir.cs" />


### PR DESCRIPTION
Like the Copy/Delete/MakeDir/RemoveDir/Touch tasks, we need to override
this one so we can allow customer targets to also execute Mac tools
remotely when building from Windows, bringing parity to the build
customizations allowed on XS/xbuild since they build locally and Exec
"just works" there of course.