### PR TITLE
[Mac] Fix notificationcenter.cs warnings

### DIFF
--- a/src/notificationcenter.cs
+++ b/src/notificationcenter.cs
@@ -72,6 +72,7 @@ namespace XamCore.NotificationCenter {
 	interface NCWidgetListViewController
 	{
 		[Wrap ("WeakDelegate")]
+		[Protocolize]
 		NCWidgetListViewDelegate Delegate { get; set; }
 
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
@@ -131,6 +132,7 @@ namespace XamCore.NotificationCenter {
 	interface NCWidgetSearchViewController
 	{
 		[Wrap ("WeakDelegate")]
+		[Protocolize]
 		NCWidgetSearchViewDelegate Delegate { get; set; }
 
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]


### PR DESCRIPTION
Fixes:

warning BI1110: bmac: The property NotificationCenter.NCWidgetListViewController.Delegate exposes a model (NotificationCenter.NCWidgetListViewDelegate). Please expose the corresponding protocol type instead (NotificationCenter.INCWidgetListViewDelegate).
warning BI1110: bmac: The property NotificationCenter.NCWidgetSearchViewController.Delegate exposes a model (NotificationCenter.NCWidgetSearchViewDelegate). Please expose the corresponding protocol type instead (NotificationCenter.INCWidgetSearchViewDelegate).