### PR TITLE
[runtime] Add MonoMethodMessage::InitMessage to linker descriptors

### DIFF
--- a/tools/linker/Descriptors/mscorlib.xml
+++ b/tools/linker/Descriptors/mscorlib.xml
@@ -701,7 +701,10 @@
 		-->
 		
 		<!-- domain.c: mono_defaults.mono_method_message_class -->
-		<type fullname="System.Runtime.Remoting.Messaging.MonoMethodMessage" preserve="fields" />
+		<type fullname="System.Runtime.Remoting.Messaging.MonoMethodMessage" preserve="fields">
+			<!-- object.c: mono_message_init -->
+			<method name="InitMessage" />
+		</type>
 		
 		<!-- domain.c: mono_defaults.real_proxy_class / removed with DISABLE_REMOTING
 		<type fullname="System.Runtime.Remoting.Proxies.RealProxy">

--- a/tools/mmp/linker/Descriptors/mscorlib.xml
+++ b/tools/mmp/linker/Descriptors/mscorlib.xml
@@ -760,7 +760,10 @@
 		</type>
 
 		<!-- domain.c: mono_defaults.mono_method_message_class -->
-		<type fullname="System.Runtime.Remoting.Messaging.MonoMethodMessage" preserve="fields" />
+		<type fullname="System.Runtime.Remoting.Messaging.MonoMethodMessage" preserve="fields">
+			<!-- object.c: mono_message_init -->
+			<method name="InitMessage" />
+		</type>
 
 		<!-- domain.c: mono_defaults.real_proxy_class -->
 		<type fullname="System.Runtime.Remoting.Proxies.RealProxy" >


### PR DESCRIPTION
It's called from the runtime mono_message_init method since
 Mono commit mono/mono@83f37161192b7735ffd04a4235253d790eefff99