### PR TITLE
[Fix] Ensure that strong dictionaries can work with templated dictioaries as property types.

### DIFF
--- a/src/Foundation/DictionaryContainer.cs
+++ b/src/Foundation/DictionaryContainer.cs
@@ -33,6 +33,7 @@ using System.Runtime.InteropServices;
 #if !COREBUILD
 using XamCore.CoreFoundation;
 using XamCore.ObjCRuntime;
+using XamCore.Foundation;
 #endif
 
 namespace XamCore.Foundation {
@@ -211,6 +212,20 @@ namespace XamCore.Foundation {
 			Dictionary.TryGetValue (key, out value);
 			return value as NSDictionary;
 		}
+		
+#if XAMCORE_2_0
+		protected NSDictionary <TKey, TValue> GetNSDictionary <TKey, TValue> (NSString key)
+			where TKey : class, INativeObject
+			where TValue : class, INativeObject
+		{
+			if (key == null)
+				throw new ArgumentNullException ("key");
+
+			NSObject value;
+			Dictionary.TryGetValue (key, out value);
+			return value as NSDictionary <TKey, TValue>;
+		}
+#endif
 
 		protected T GetStrongDictionary<T> (NSString key) where T : DictionaryContainer
 		{

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3181,8 +3181,14 @@ public partial class Generator : IMemberGatherer {
 						} else if (pi.PropertyType == typeof (string)){
 							getter = "GetStringValue ({0})";
 							setter = "SetStringValue ({0}, value)";
-						} else if (pi.PropertyType.Name == "NSDictionary"){
-							getter = "GetNSDictionary ({0})";
+						} else if (pi.PropertyType.Name.StartsWith ("NSDictionary")){
+							if (pi.PropertyType.IsGenericType) {
+								var genericParameters = pi.PropertyType.GetGenericArguments ();
+								// we want to keep {0} for later yet add the params for the template.
+								getter = $"GetNSDictionary <{FormatType (dictType, genericParameters [0])}, {FormatType (dictType, genericParameters [1])}> " + "({0})";  
+							} else {
+								getter = "GetNSDictionary ({0})";
+							}
 							setter = "SetNativeValue ({0}, value)";
 						} else if (IsDictionaryContainerType (pi.PropertyType) || pi.GetCustomAttributes (typeof (StrongDictionaryAttribute), true).Length > 0 ) {
 							var strType = pi.PropertyType.Name;

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -13,7 +13,7 @@ include $(TOP)/Make.config
 
 IOS_CURRENT_DIR=$(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current
 IOS_GENERATOR = $(IOS_CURRENT_DIR)/bin/btouch /baselib:$(IOS_CURRENT_DIR)/lib/mono/2.1/monotouch.dll /unsafe /compiler:$(IOS_CURRENT_DIR)/bin/smcs
-IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events
+IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts
 IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176
 
 MAC_CURRENT_DIR=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current

--- a/tests/generator/strong-dict-support-templated-dicts.cs
+++ b/tests/generator/strong-dict-support-templated-dicts.cs
@@ -1,0 +1,33 @@
+#if !XAMCORE_2_0
+#if MONOMAC
+using MonoMac.Foundation;
+using MonoMac.ObjCRuntime;
+#else
+using MonoTouch.Foundation;
+using MonoTouch.ObjCRuntime;
+#endif
+#else
+using Foundation;
+using ObjCRuntime;
+#endif
+
+namespace Test
+{
+	
+	[StrongDictionary ("AdvertisementDataKeys")]
+	interface AdvertisementData {
+#if XAMCORE_2_0
+		// property under tests, the generator should create a compilable property
+		NSDictionary <CBUUID, NSData> ServiceData { get; set; }
+#else
+		// ensure that the generator continues to work with classic
+		NSDictionary ServiceData { get; set; }
+#endif
+	}
+
+	[Static, Internal]
+	interface AdvertisementDataKeys {
+		[Field ("MyFooFieldA", "libFoo.a")]
+		NSString ServiceDataKey { get; }
+	}
+}


### PR DESCRIPTION
This pull request allows the generator to understand the usage of templated NSDictionary classes as the return type of properties in strong dictionaries.

The added test ensures that the strong dict is generated and can be compiled.