### PR TITLE
Provide .editorconfig support for easier contributor formatting

### DIFF
--- a/msbuild/.editorconfig
+++ b/msbuild/.editorconfig
@@ -1,0 +1,15 @@
+; EditorConfig to support per-solution formatting.
+; Use the EditorConfig VS add-in to make this work.
+; http://editorconfig.org/
+
+[*.{cs}]
+indent_style = tab
+indent_size = 4
+
+[*.{props,targets}]
+indent_style = tab
+indent_size = 4
+
+[*.{csproj}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Scoped to the msbuild folder for now which has consistent C# and
MSBuild formatting. The rest of the repo seems to be using different
formatting, so I didn't want to have to decide one way or the other.