### PR TITLE
[msbuild] Remove improper .0 at the end of package version

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/packages.config
+++ b/msbuild/Xamarin.MacDev.Tasks/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mono.Cecil" version="0.9.5.0" targetFramework="net45" />
+  <package id="Mono.Cecil" version="0.9.5" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
For whatever reason, VS added it even if the package version is
0.9.5, but VS happily finds it and everything builds fine but
it breaks on xbuild/mono/mac??