### PR TITLE
[msbuild] Rename and unify to IsMacEnabled

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -58,7 +58,7 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<MacTargetsEnabled>true</MacTargetsEnabled>
+		<IsMacEnabled>true</IsMacEnabled>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.props"

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -205,7 +205,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
-			Condition="'@(_NativeLibrary)' != '' And '$(MacTargetsEnabled)' == 'true'"
+			Condition="'@(_NativeLibrary)' != '' And '$(IsMacEnabled)' == 'true'"
 			CodesignAllocate="$(_CodesignAllocate)"
 			Keychain="$(CodesignKeychain)"
 			Resource="%(_NativeLibrary.Identity)"
@@ -219,7 +219,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<Target Name="_EmbedProvisionProfile" Condition="'$(_ProvisioningProfile)' != ''" DependsOnTargets="_GenerateBundleName"
 		Outputs="$(_AppBundlePath)Contents\embedded.provisionprofile">
 		<EmbedProvisionProfile
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			AppBundleDir="$(AppBundleDir)"
 			ProvisioningProfile="$(_ProvisioningProfile)"
@@ -230,7 +230,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<Target Name="_CompileEntitlements" Condition="'$(EnableCodeSigning)'" DependsOnTargets="_GenerateBundleName"
 		Outputs="$(IntermediateOutputPath)Entitlements.xcent">
 		<CompileEntitlements
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			AppBundleDir="$(AppBundleDir)"
 			AppIdentifier="$(_AppIdentifier)"
@@ -248,7 +248,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CodesignAppBundle" Condition="'$(EnableCodeSigning)'" DependsOnTargets="$(_CodesignAppBundleDependsOn)">
 		<Codesign
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
@@ -265,7 +265,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CodesignVerify" Condition="'$(EnableCodeSigning)'" DependsOnTargets="_CodesignAppBundle">
 		<CodesignVerify
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
@@ -280,7 +280,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		Inputs="@(_BundleResourceWithLogicalName)"
 		Outputs="@(_BundleResourceWithLogicalName -> '$(_AppResourcesPath)%(LogicalName)')">
 		<SmartCopy
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			SourceFiles = "@(_BundleResourceWithLogicalName)"
 			DestinationFiles = "@(_BundleResourceWithLogicalName -> '$(_AppResourcesPath)%(LogicalName)')"/>
@@ -288,7 +288,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CollectBundleResources" DependsOnTargets="$(_CollectBundleResourcesDependsOn)">
 		<CollectBundleResources
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			BundleResources="@(Content);@(BundleResource)"
 			ProjectDir="$(MSBuildProjectDirectory)"
@@ -327,7 +327,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_DetectSdkLocations">
 		<Metal
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			ProjectDir="$(MSBuildProjectDirectory)"
@@ -341,7 +341,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<Target Name="_ForgeMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(_SmeltedMetal)' != ''" DependsOnTargets="_SmeltMetal"
 		Inputs="@(_SmeltedMetal)" Outputs="$(IntermediateOutputPath)metal\default.metal-ar">
 		<ArTool
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			Items="@(_SmeltedMetal)"
 			Archive="$(IntermediateOutputPath)metal\default.metal-ar">
@@ -355,7 +355,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<Target Name="_TemperMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(_ForgedMetal)' != ''" DependsOnTargets="_ForgeMetal"
 		Inputs="@(_ForgedMetal)" Outputs="$(_AppBundlePath)default.metallib">
 		<MetalLib
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			Items="@(_ForgedMetal)"
 			SdkDevPath="$(_SdkDevPath)"
@@ -371,7 +371,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CoreCompileTextureAtlases">
 		<TextureAtlas
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(TextureAtlasExe)"
 			ToolPath="$(TextureAtlasPath)"
@@ -389,7 +389,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CreateInstaller" Condition="$(CreatePackage)" DependsOnTargets="Codesign">
 		<CreateInstallerPackage
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			OutputDirectory = "$(TargetDir)"
 			Name = "$(AssemblyName)"
@@ -406,7 +406,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_PackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'false'" DependsOnTargets="_CollectBundleResources">
 		<PackLibraryResources
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			Prefix="xammac"
 			BundleResourcesWithLogicalNames="@(_BundleResourceWithLogicalName)">
@@ -416,7 +416,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_UnpackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="ResolveReferences;_CollectBundleResources">
 		<UnpackLibraryResources
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			Prefix="xammac"
 			NoOverwrite="@(_BundleResourceWithLogicalName)"
@@ -429,7 +429,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_DetectSdkLocations">
 		<DetectSdkLocations
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			SdkVersion="$(MacOSXSdkVersion)">
 			<Output TaskParameter="SdkVersion" PropertyName="MacOSXSdkVersion" />
@@ -446,7 +446,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		</PropertyGroup>
 
 		<DetectSigningIdentity
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			AppBundleName="$(_AppBundleName)"
 			AppManifest="$(_AppManifest)"
@@ -478,7 +478,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		Inputs="$(_AppManifest);@(_PartialAppManifest)"
 		Outputs="$(_AppBundlePath)Contents\Info.plist" >
 		<CompileAppManifest
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			AppBundleName="$(_AppBundleName)"
 			AppBundleDir="$(AppBundleDir)"
@@ -494,7 +494,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		Inputs="$(TargetDir)$(TargetFileName)"
 		Outputs="$(_AppBundlePath)Contents\MacOS\$(TargetFileName)">
 		<Mmp
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			FrameworkRoot="$(XamarinMacFrameworkRoot)"
 			OutputPath="$(OutputPath)"
@@ -524,7 +524,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CollectColladaAssets">
 		<CollectBundleResources
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			BundleResources="@(Collada)"
 			ProjectDir="$(MSBuildProjectDirectory)"
@@ -540,7 +540,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		>
 
 		<ScnTool
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(ScnToolExe)"
 			ToolPath="$(ScnToolPath)"
@@ -561,7 +561,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CoreCompileImageAssets">
 		<ACTool
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(ACToolExe)"
 			ToolPath="$(ACToolPath)"
@@ -589,7 +589,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CoreCompileSceneKitAssets">
 		<CompileSceneKitAssets
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(CopySceneKitAssetsExe)"
 			ToolPath="$(CopySceneKitAssetsPath)"
@@ -609,7 +609,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CoreCompileInterfaceDefinitions">
 		<IBTool
-			Condition="'$(MacTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(IBToolExe)"
 			ToolPath="$(IBToolPath)"
@@ -631,11 +631,11 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CreatePkgInfo" DependsOnTargets="_GenerateBundleName" Outputs="$(_AppBundlePath)Contents\PkgInfo">
-		<CreatePkgInfo SessionId="$(BuildSessionId)" Condition="'$(MacTargetsEnabled)'" OutputPath="$(_AppBundlePath)Contents\PkgInfo" />
+		<CreatePkgInfo SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" OutputPath="$(_AppBundlePath)Contents\PkgInfo" />
 
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="'@(_ResolvedAppExtensionReferences)' != '' And '%(_ResolvedAppExtensionReferences.Identity)' != '' And '$(MacTargetsEnabled)' == 'true'"
+			Condition="'@(_ResolvedAppExtensionReferences)' != '' And '%(_ResolvedAppExtensionReferences.Identity)' != '' And '$(IsMacEnabled)' == 'true'"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="@(_ResolvedAppExtensionReferences)"
@@ -648,7 +648,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="'@(_ResolvedAppExtensionReferences)' != '' And '%(_ResolvedAppExtensionReferences.Identity)' != '' And '$(MacTargetsEnabled)' == 'true'"
+			Condition="'@(_ResolvedAppExtensionReferences)' != '' And '%(_ResolvedAppExtensionReferences.Identity)' != '' And '$(IsMacEnabled)' == 'true'"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="@(_ResolvedAppExtensionReferences)"

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -219,7 +219,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<Target Name="_EmbedProvisionProfile" Condition="'$(_ProvisioningProfile)' != ''" DependsOnTargets="_GenerateBundleName"
 		Outputs="$(_AppBundlePath)Contents\embedded.provisionprofile">
 		<EmbedProvisionProfile
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			AppBundleDir="$(AppBundleDir)"
 			ProvisioningProfile="$(_ProvisioningProfile)"
@@ -230,7 +230,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<Target Name="_CompileEntitlements" Condition="'$(EnableCodeSigning)'" DependsOnTargets="_GenerateBundleName"
 		Outputs="$(IntermediateOutputPath)Entitlements.xcent">
 		<CompileEntitlements
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			AppBundleDir="$(AppBundleDir)"
 			AppIdentifier="$(_AppIdentifier)"
@@ -248,7 +248,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CodesignAppBundle" Condition="'$(EnableCodeSigning)'" DependsOnTargets="$(_CodesignAppBundleDependsOn)">
 		<Codesign
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
@@ -265,7 +265,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CodesignVerify" Condition="'$(EnableCodeSigning)'" DependsOnTargets="_CodesignAppBundle">
 		<CodesignVerify
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
@@ -280,7 +280,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		Inputs="@(_BundleResourceWithLogicalName)"
 		Outputs="@(_BundleResourceWithLogicalName -> '$(_AppResourcesPath)%(LogicalName)')">
 		<SmartCopy
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			SourceFiles = "@(_BundleResourceWithLogicalName)"
 			DestinationFiles = "@(_BundleResourceWithLogicalName -> '$(_AppResourcesPath)%(LogicalName)')"/>
@@ -288,7 +288,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CollectBundleResources" DependsOnTargets="$(_CollectBundleResourcesDependsOn)">
 		<CollectBundleResources
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			BundleResources="@(Content);@(BundleResource)"
 			ProjectDir="$(MSBuildProjectDirectory)"
@@ -327,7 +327,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_DetectSdkLocations">
 		<Metal
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			ProjectDir="$(MSBuildProjectDirectory)"
@@ -341,7 +341,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<Target Name="_ForgeMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(_SmeltedMetal)' != ''" DependsOnTargets="_SmeltMetal"
 		Inputs="@(_SmeltedMetal)" Outputs="$(IntermediateOutputPath)metal\default.metal-ar">
 		<ArTool
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			Items="@(_SmeltedMetal)"
 			Archive="$(IntermediateOutputPath)metal\default.metal-ar">
@@ -355,7 +355,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<Target Name="_TemperMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(_ForgedMetal)' != ''" DependsOnTargets="_ForgeMetal"
 		Inputs="@(_ForgedMetal)" Outputs="$(_AppBundlePath)default.metallib">
 		<MetalLib
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			Items="@(_ForgedMetal)"
 			SdkDevPath="$(_SdkDevPath)"
@@ -371,7 +371,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CoreCompileTextureAtlases">
 		<TextureAtlas
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(TextureAtlasExe)"
 			ToolPath="$(TextureAtlasPath)"
@@ -389,7 +389,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CreateInstaller" Condition="$(CreatePackage)" DependsOnTargets="Codesign">
 		<CreateInstallerPackage
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			OutputDirectory = "$(TargetDir)"
 			Name = "$(AssemblyName)"
@@ -406,7 +406,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_PackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'false'" DependsOnTargets="_CollectBundleResources">
 		<PackLibraryResources
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			Prefix="xammac"
 			BundleResourcesWithLogicalNames="@(_BundleResourceWithLogicalName)">
@@ -416,7 +416,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_UnpackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="ResolveReferences;_CollectBundleResources">
 		<UnpackLibraryResources
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			Prefix="xammac"
 			NoOverwrite="@(_BundleResourceWithLogicalName)"
@@ -429,7 +429,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_DetectSdkLocations">
 		<DetectSdkLocations
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			SdkVersion="$(MacOSXSdkVersion)">
 			<Output TaskParameter="SdkVersion" PropertyName="MacOSXSdkVersion" />
@@ -446,7 +446,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		</PropertyGroup>
 
 		<DetectSigningIdentity
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			AppBundleName="$(_AppBundleName)"
 			AppManifest="$(_AppManifest)"
@@ -478,7 +478,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		Inputs="$(_AppManifest);@(_PartialAppManifest)"
 		Outputs="$(_AppBundlePath)Contents\Info.plist" >
 		<CompileAppManifest
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			AppBundleName="$(_AppBundleName)"
 			AppBundleDir="$(AppBundleDir)"
@@ -494,7 +494,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		Inputs="$(TargetDir)$(TargetFileName)"
 		Outputs="$(_AppBundlePath)Contents\MacOS\$(TargetFileName)">
 		<Mmp
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			FrameworkRoot="$(XamarinMacFrameworkRoot)"
 			OutputPath="$(OutputPath)"
@@ -524,7 +524,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CollectColladaAssets">
 		<CollectBundleResources
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			BundleResources="@(Collada)"
 			ProjectDir="$(MSBuildProjectDirectory)"
@@ -540,7 +540,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		>
 
 		<ScnTool
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(ScnToolExe)"
 			ToolPath="$(ScnToolPath)"
@@ -561,7 +561,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CoreCompileImageAssets">
 		<ACTool
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(ACToolExe)"
 			ToolPath="$(ACToolPath)"
@@ -589,7 +589,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CoreCompileSceneKitAssets">
 		<CompileSceneKitAssets
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(CopySceneKitAssetsExe)"
 			ToolPath="$(CopySceneKitAssetsPath)"
@@ -609,7 +609,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CoreCompileInterfaceDefinitions">
 		<IBTool
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(IBToolExe)"
 			ToolPath="$(IBToolPath)"
@@ -631,7 +631,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CreatePkgInfo" DependsOnTargets="_GenerateBundleName" Outputs="$(_AppBundlePath)Contents\PkgInfo">
-		<CreatePkgInfo SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" OutputPath="$(_AppBundlePath)Contents\PkgInfo" />
+		<CreatePkgInfo SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" OutputPath="$(_AppBundlePath)Contents\PkgInfo" />
 
 		<Ditto
 			SessionId="$(BuildSessionId)"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.Common.targets
@@ -53,7 +53,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 
 	<Target Name="_ResolveNativeWatchApp" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName">
 		<ResolveNativeWatchApp
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			SdkVersion="$(MtouchSdkVersion)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
@@ -75,25 +75,25 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		Outputs="$(_NativeExecutable);$(_AppBundlePath)_WatchKitStub\WK">
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="$(IsMacEnabled)"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="$(_NativeWatchApp)"
 			Destination="$(_AppBundlePath)$(AssemblyName)"
 		/>
 
-		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(_AppBundlePath)_WatchKitStub" />
+		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(_AppBundlePath)_WatchKitStub" />
 
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="$(IsMacEnabled)"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="$(_NativeWatchApp)"
 			Destination="$(_AppBundlePath)_WatchKitStub\WK"
 		/>
 
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(AppBundleDir).dSYM" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(AppBundleDir).dSYM" />
 	</Target>
 
 	<Target Name="CopyFilesToOutputDirectory" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.Common.targets
@@ -53,7 +53,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 
 	<Target Name="_ResolveNativeWatchApp" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName">
 		<ResolveNativeWatchApp
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			SdkVersion="$(MtouchSdkVersion)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
@@ -75,25 +75,25 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		Outputs="$(_NativeExecutable);$(_AppBundlePath)_WatchKitStub\WK">
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="$(MtouchTargetsEnabled)"
+			Condition="$(IsMacEnabled)"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="$(_NativeWatchApp)"
 			Destination="$(_AppBundlePath)$(AssemblyName)"
 		/>
 
-		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Directories="$(_AppBundlePath)_WatchKitStub" />
+		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(_AppBundlePath)_WatchKitStub" />
 
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="$(MtouchTargetsEnabled)"
+			Condition="$(IsMacEnabled)"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="$(_NativeWatchApp)"
 			Destination="$(_AppBundlePath)_WatchKitStub\WK"
 		/>
 
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Directories="$(AppBundleDir).dSYM" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(AppBundleDir).dSYM" />
 	</Target>
 
 	<Target Name="CopyFilesToOutputDirectory" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
@@ -51,7 +51,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<MtouchUseThumb Condition="'$(MtouchUseThumb)' == ''">False</MtouchUseThumb>
 		<MtouchProjectDirectory>$(MSBuildProjectDirectory)</MtouchProjectDirectory>
 
-		<MtouchTargetsEnabled>true</MtouchTargetsEnabled>
+		<IsMacEnabled>true</IsMacEnabled>
+		<MtouchTargetsEnabled>$(IsMacEnabled)</MtouchTargetsEnabled>
 
 		<IsAppExtension Condition="'$(IsAppExtension)' == ''">False</IsAppExtension>
 		<IsWatchApp Condition="'$(IsWatchApp)' == ''">False</IsWatchApp>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -326,32 +326,32 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="CreateIpa" Condition="'$(_CanArchive)' == 'true'" DependsOnTargets="$(CreateIpaDependsOn)" />
 
 	<Target Name="_CleanAppBundle" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_GenerateBundleName">
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Directories="$(_AppBundlePath)" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(_AppBundlePath)" />
 	</Target>
 
 	<Target Name="_CleanUploaded" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_GenerateBundleName">
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Files="$(DeviceSpecificOutputPath).uploaded" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Files="$(DeviceSpecificOutputPath).uploaded" />
 	</Target>
 
 	<Target Name="_CleanDebugSymbols" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_GenerateBundleName">
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Directories="$(AppBundleDir).dSYM" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(AppBundleDir).dSYM" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
 	</Target>
 
 	<Target Name="_CleanITunesArtwork" Condition="'$(_CanArchive)' == 'true'">
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Files="$(DeviceSpecificOutputPath)iTunesMetadata.plist;$(DeviceSpecificOutputPath)iTunesArtwork@2x;$(DeviceSpecificOutputPath)iTunesArtwork" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Files="$(DeviceSpecificOutputPath)iTunesMetadata.plist;$(DeviceSpecificOutputPath)iTunesArtwork@2x;$(DeviceSpecificOutputPath)iTunesArtwork" />
 	</Target>
 	
 	<Target Name="_CleanDeviceSpecificOutput" Condition="'$(_CanOutputAppBundle)' == 'true'">
 		<RemoveDir SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			Directories="$(IntermediateOutputPath)build-*;
 					$(OutputPath)build-*" />
 	</Target>
 
 	<Target Name="_CleanIntermediateToolOutput">
 		<RemoveDir SessionId="$(BuildSessionId)" 
-			Condition="'$(MtouchTargetsEnabled)'" 
+			Condition="'$(IsMacEnabled)'" 
 			Directories="$(DeviceSpecificIntermediateOutputPath)actool;
 					$(DeviceSpecificIntermediateOutputPath)assetpacks;
 					$(DeviceSpecificIntermediateOutputPath)ibtool;
@@ -364,7 +364,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 					$(DeviceSpecificIntermediateOutputPath)TextureAtlas;
 					$(DeviceSpecificIntermediateOutputPath)mtouch-cache;
 					$(DeviceSpecificIntermediateOutputPath)" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Files="$(DeviceSpecificOutputPath)*.ipa" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Files="$(DeviceSpecificOutputPath)*.ipa" />
 	</Target>
 
 	<PropertyGroup>
@@ -381,7 +381,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_ComputeBundleResourceOutputPaths" DependsOnTargets="_CollectBundleResources;_GenerateBundleName;_DetectSigningIdentity">
 		<ComputeBundleResourceOutputPaths
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			AppBundleDir="$(AppBundleDir)"
 			BundleIdentifier="$(_BundleIdentifier)"
 			BundleResources="@(_BundleResourceWithLogicalName)"
@@ -397,7 +397,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Outputs = "@(_BundleResourceWithOutputPath -> '%(OutputPath)')" >
 		<SmartCopy
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SourceFiles = "@(_BundleResourceWithOutputPath)"
 			DestinationFiles = "@(_BundleResourceWithOutputPath -> '%(OutputPath)')"
 		/>
@@ -406,7 +406,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CreateAssetPackManifest" DependsOnTargets="_CopyResourcesToBundle">
 		<CreateAssetPackManifest
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			AppBundleDir="$(AppBundleDir)"
 			InitialInstallTags="$(OnDemandResourcesInitialInstallTags)"
 			PrefetchOrder="$(OnDemandResourcesPrefetchOrder)"
@@ -417,7 +417,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CollectBundleResources" DependsOnTargets="$(_CollectBundleResourcesDependsOn)">
 		<CollectBundleResources
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			OptimizePropertyLists="$(OptimizePropertyLists)"
 			OptimizePNGs="$(OptimizePNGs)"
 			BundleResources="@(Content);@(BundleResource)"
@@ -462,7 +462,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<Metal
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(IPhoneResourcePrefix)"
@@ -476,7 +476,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Inputs="@(_SmeltedMetal)" Outputs="$(DeviceSpeficicIntermediateOutputPath)metal\default.metal-ar">
 		<ArTool
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			Items="@(_SmeltedMetal)"
 			Archive="$(DeviceSpecificIntermediateOutputPath)metal\default.metal-ar">
 		</ArTool>
@@ -490,7 +490,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Inputs="@(_ForgedMetal)" Outputs="$(_AppBundlePath)default.metallib">
 		<MetalLib
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			Items="@(_ForgedMetal)"
 			SdkDevPath="$(_SdkDevPath)"
 			OutputLibrary="$(_AppBundlePath)default.metallib">
@@ -504,7 +504,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_PackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'false'" DependsOnTargets="_CollectBundleResources">
 		<PackLibraryResources
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			Prefix="monotouch"
 			BundleResourcesWithLogicalNames="@(_BundleResourceWithLogicalName)">
 			<Output TaskParameter="EmbeddedResources" ItemName="EmbeddedResource" />
@@ -514,7 +514,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_UnpackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="ResolveReferences;_CollectBundleResources">
 		<UnpackLibraryResources
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			Prefix="monotouch"
 			NoOverwrite="@(_BundleResourceWithLogicalName)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
@@ -526,7 +526,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_DetectSdkLocations" DependsOnTargets="_ComputeTargetArchitectures">
 		<DetectSdkLocations
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SdkVersion="$(MtouchSdkVersion)"
 			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			TargetArchitectures="$(TargetArchitectures)"
@@ -545,7 +545,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_DetectSigningIdentity" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations">
 		<DetectSigningIdentity
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			AppBundleName="$(_AppBundleName)"
 			AppManifest="$(_AppManifest)"
 			Keychain="$(CodesignKeychain)"
@@ -587,7 +587,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Outputs="$(_AppBundlePath)Info.plist" >
 		<CompileAppManifest
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			AppBundleName="$(_AppBundleName)"
 			AppBundleDir="$(AppBundleDir)"
 			AppManifest="$(_AppManifest)"
@@ -606,8 +606,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			>
 		</CompileAppManifest>
 
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Directories="$(AppBundleDir).dSYM" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(AppBundleDir).dSYM" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
 	</Target>
 
 	<Target Name="_CompileITunesMetadata" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'"
@@ -616,7 +616,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Outputs="$(DeviceSPecificOutputPath)iTunesMetadata.plist" >
 		<CompileITunesMetadata
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			AppBundleDir="$(AppBundleDir)"
 			ITunesMetadata="@(ITunesMetadata)"
 			OutputPath="$(DeviceSpecificOutputPath)iTunesMetadata.plist"
@@ -626,7 +626,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CollectITunesArtwork" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'">
 		<CollectITunesArtwork
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			ITunesArtwork="@(ITunesArtwork)"
 			>
 			<Output TaskParameter="ITunesArtworkWithLogicalNames" ItemName="_ITunesArtworkWithLogicalName"/>
@@ -638,7 +638,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Inputs="@(_ITunesArtworkWithLogicalName)" Outputs="$(DeviceSpecificOutputPath)%(_ITunesArtworkWithLogicalName.LogicalName)">
 		<Copy
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SourceFiles="@(_ITunesArtworkWithLogicalName)"
 			DestinationFiles="$(DeviceSpecificOutputPath)%(_ITunesArtworkWithLogicalName.LogicalName)"
 		/>
@@ -647,7 +647,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_GetNativeExecutableName" DependsOnTargets="_DetectAppManifest;_GenerateBundleName;_CompileAppManifest">
 		<GetNativeExecutableName
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			AppManifest="$(_AppBundlePath)Info.plist"
 			>
 			<Output TaskParameter="ExecutableName" PropertyName="_ExecutableName" />
@@ -681,7 +681,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<MTouch
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(MtouchExe)"
 			ToolPath="$(MtouchPath)"
 			AppBundleDir="$(AppBundleDir)"
@@ -727,8 +727,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<Output TaskParameter="NativeLibraries" ItemName="_NativeLibrary" />
 		</MTouch>
 
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Directories="$(AppBundleDir).dSYM" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(AppBundleDir).dSYM" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
 	</Target>
 
 	<Target Name="_GenerateFrameworkDebugSymbols" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsWatchApp)' != 'true'" DependsOnTargets="_CompileToNative;_CollectFrameworks"
@@ -739,7 +739,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!-- run dsymutil on embedded frameworks -->
 		<DSymUtil
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			AppBundleDir="$(AppBundleDir)"
 			Architectures=""
 			DSymDir="$(AppBundleDir)\..\%(_Frameworks.Filename).framework.dSYM"
@@ -751,7 +751,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!--- strip embedded frameworks -->
 		<SymbolStrip
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '$(MtouchDebug)' != 'true'"
+			Condition="'$(IsMacEnabled)' And '$(MtouchDebug)' != 'true'"
 			Executable="%(_Frameworks.Identity)"
 			IsFramework="true"
 			SymbolFile=""
@@ -778,7 +778,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!--- run dsymutil on the main bundle -->
 		<DSymUtil
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '$(MtouchNoDSymUtil)' == 'false'"
+			Condition="'$(IsMacEnabled)' And '$(MtouchNoDSymUtil)' == 'false'"
 			AppBundleDir="$(AppBundleDir)"
 			Architectures="$(_CompiledArchitectures)"
 			DSymDir="$(AppBundleDir).dSYM"
@@ -791,7 +791,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!--- strip the main executable -->
 		<SymbolStrip
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '$(MtouchDebug)' == 'false' And '$(MtouchNoSymbolStrip)' == 'false'"
+			Condition="'$(IsMacEnabled)' And '$(MtouchDebug)' == 'false' And '$(MtouchNoSymbolStrip)' == 'false'"
 			Executable="$(_NativeExecutable)"
 			IsFramework="false"
 			SymbolFile="$(_MtouchSymbolsList)"
@@ -801,7 +801,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!-- make sure spotlight indexes everything we've built -->
 		<SpotlightIndexer
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '$(MtouchNoDSymUtil)' == 'false'"
+			Condition="'$(IsMacEnabled)' And '$(MtouchNoDSymUtil)' == 'false'"
 			Input="$(AppBundleDir)/../"
 		>
 		</SpotlightIndexer>
@@ -812,7 +812,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Outputs="$(_AppBundlePath)Settings.bundle\Root.plist" >
 		<CreateDebugSettings
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			AppBundleDir="$(AppBundleDir)"
 			DebuggerPort="$(IOSDebuggerPort)"
 			>
@@ -824,7 +824,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Outputs="$(_AppBundlePath)MonoTouchDebugConfiguration.txt" >
 		<CreateDebugConfiguration
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			AppBundleDir="$(AppBundleDir)"
 			DebugOverWiFi="$(IOSDebugOverWiFi)"
 			DebuggerHosts="$(IOSDebuggerHosts)"
@@ -847,7 +847,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<OptimizeImage
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(PngCrushExe)"
 			ToolPath="$(PngCrushPath)"
 			SdkDevPath="$(_SdkDevPath)"
@@ -884,7 +884,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<OptimizePropertyList
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(PlUtilExe)"
 			ToolPath="$(PlUtilPath)"
 			Input="%(_PropertyList.Identity)"
@@ -919,7 +919,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<OptimizePropertyList
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(PlUtilExe)"
 			ToolPath="$(PlUtilPath)"
 			Input="%(_LocalizationFile.Identity)"
@@ -955,7 +955,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<ScnTool
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(ScnToolExe)"
 			ToolPath="$(ScnToolPath)"
 			SdkRoot="$(_SdkRoot)"
@@ -1009,7 +1009,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		
 		<ACTool
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '@(ImageAsset)' != ''"
+			Condition="'$(IsMacEnabled)' And '@(ImageAsset)' != ''"
 			ToolExe="$(ACToolExe)"
 			ToolPath="$(ACToolPath)"
 			AppManifest="$(_AppManifest)"
@@ -1076,7 +1076,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<CompileSceneKitAssets
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(CopySceneKitAssetsExe)"
 			ToolPath="$(CopySceneKitAssetsPath)"
 			SceneKitAssets="@(SceneKitAsset)"
@@ -1129,7 +1129,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		
 		<IBTool
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(IBToolExe)"
 			ToolPath="$(IBToolPath)"
 			AppManifest="$(_AppManifest)"
@@ -1191,7 +1191,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<TextureAtlas
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(TextureAtlasExe)"
 			ToolPath="$(TextureAtlasPath)"
 			AtlasTextures="@(AtlasTexture)"
@@ -1215,14 +1215,14 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CreatePkgInfo" Condition="'$(IsAppExtension)' == 'false'" DependsOnTargets="_GenerateBundleName" Outputs="$(_AppBundlePath)PkgInfo">
-		<CreatePkgInfo SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" OutputPath="$(_AppBundlePath)PkgInfo" />
+		<CreatePkgInfo SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" OutputPath="$(_AppBundlePath)PkgInfo" />
 	</Target>
 
 	<Target Name="_EmbedMobileProvision" DependsOnTargets="_GenerateBundleName;_DetectSigningIdentity"
 		Outputs="$(_AppBundlePath)embedded.mobileprovision">
 		<EmbedMobileProvision
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			AppBundleDir="$(AppBundleDir)"
 			ProvisioningProfile="$(_ProvisioningProfile)"
 			>
@@ -1233,7 +1233,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Outputs="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent">
 		<CompileEntitlements
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			AppBundleDir="$(AppBundleDir)"
 			AppIdentifier="$(_AppIdentifier)"
 			BundleIdentifier="$(_BundleIdentifier)"
@@ -1251,7 +1251,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_PrepareResourceRules" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName">
 		<PrepareResourceRules
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '$(CodesignResourceRules)' != '' And '$(ComputedPlatform)' == 'iPhone'"
+			Condition="'$(IsMacEnabled)' And '$(CodesignResourceRules)' != '' And '$(ComputedPlatform)' == 'iPhone'"
 			AppBundleDir="$(AppBundleDir)"
 			ResourceRules="$(CodesignResourceRules)"
 			SdkVersion="$(MtouchSdkVersion)"
@@ -1334,7 +1334,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_DetectBundleIdentifier" DependsOnTargets="_DetectAppManifest">
 		<DetectBundleIdentifier
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			AppBundleName="$(_AppBundleName)"
 			AppManifest="$(_AppManifest)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
@@ -1345,11 +1345,11 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CopyAppExtensionsToBundle" Condition="'$(IsAppExtension)' == 'false'" DependsOnTargets="_ResolveAppExtensionReferences">
-		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)' And '@(_ResolvedAppExtensionReferences)' != ''" Directories="$(_AppBundlePath)PlugIns" />
+		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' And '@(_ResolvedAppExtensionReferences)' != ''" Directories="$(_AppBundlePath)PlugIns" />
 
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '@(_ResolvedAppExtensionReferences)' != '' And '%(_ResolvedAppExtensionReferences.Identity)' != ''"
+			Condition="'$(IsMacEnabled)' And '@(_ResolvedAppExtensionReferences)' != '' And '%(_ResolvedAppExtensionReferences.Identity)' != ''"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="@(_ResolvedAppExtensionReferences)"
@@ -1359,7 +1359,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<Target Name="_ValidateAppBundle" Condition="'$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'" DependsOnTargets="_DetectSdkLocations">
 		<ValidateAppBundleTask
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			AppBundlePath="$(_AppBundlePath)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
@@ -1445,7 +1445,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CopyWatchAppsToBundle" Condition="'$(IsAppExtension)' == 'true'" DependsOnTargets="_ResolveWatchAppReferences">
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '@(_ResolvedWatchAppReferences)' != '' And '%(_ResolvedWatchAppReferences.Identity)' != ''"
+			Condition="'$(IsMacEnabled)' And '@(_ResolvedWatchAppReferences)' != '' And '%(_ResolvedWatchAppReferences.Identity)' != ''"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="@(_ResolvedWatchAppReferences)"
@@ -1456,7 +1456,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CopyWatch2AppsToBundle" Condition="'$(OutputType)' == 'Exe'" DependsOnTargets="_ResolveWatchAppReferences">
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '@(_ResolvedWatchAppReferences)' != '' And '%(_ResolvedWatchAppReferences.Identity)' != ''"
+			Condition="'$(IsMacEnabled)' And '@(_ResolvedWatchAppReferences)' != '' And '%(_ResolvedWatchAppReferences.Identity)' != ''"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="@(_ResolvedWatchAppReferences)"
@@ -1467,7 +1467,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CollectFrameworks" Condition="'$(_IsContainerApp)' == 'true'" DependsOnTargets="_CompileToNative">
 		<CollectFrameworks
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			AppBundlePath="$(_AppBundlePath)"
 			>
 
@@ -1477,7 +1477,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<Target Name="_CodesignNativeLibraries" Condition="'$(_RequireCodeSigning)' == 'true'" DependsOnTargets="_DetectSigningIdentity;">
 		<Codesign
-			Condition="'$(MtouchTargetsEnabled)' And '@(_NativeLibrary)' != ''"
+			Condition="'$(IsMacEnabled)' And '@(_NativeLibrary)' != ''"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
@@ -1492,7 +1492,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<Target Name="_CodesignFrameworks" Condition="'$(_RequireCodeSigning)' == 'true'" DependsOnTargets="_DetectSigningIdentity;_CollectFrameworks">
 		<Codesign
-			Condition="'$(MtouchTargetsEnabled)' And '@(_Frameworks)' != ''"
+			Condition="'$(IsMacEnabled)' And '@(_Frameworks)' != ''"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
@@ -1508,7 +1508,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CodesignAppBundle" Condition="'$(_RequireCodeSigning)' == 'true'" DependsOnTargets="$(_CodesignAppBundleDependsOn)">
 		<Codesign
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
 			CodesignAllocate="$(_CodesignAllocate)"
@@ -1523,7 +1523,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<Touch
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And Exists ('$(AppBundleDir).dSYM\Contents\Info.plist')"
+			Condition="'$(IsMacEnabled)' And Exists ('$(AppBundleDir).dSYM\Contents\Info.plist')"
 			Files="$(AppBundleDir).dSYM\Contents\Info.plist"
 		/>
 	</Target>
@@ -1531,7 +1531,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CodesignVerify" Condition="'$(_RequireCodeSigning)' == 'true'" DependsOnTargets="_CodesignAppBundle">
 		<CodesignVerify
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
 			CodesignAllocate="$(_CodesignAllocate)"
@@ -1541,9 +1541,9 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CoreCreateIpa" Condition="'$(BuildIpa)' == 'true'" DependsOnTargets="$(Codesign)">
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Directories="$(DeviceSpecificIntermediateOutputPath)ipa" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(DeviceSpecificIntermediateOutputPath)ipa" />
 
-		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Directories="$(DeviceSpecificIntermediateOutputPath)ipa\Payload" />
+		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(DeviceSpecificIntermediateOutputPath)ipa\Payload" />
 
 		<PropertyGroup>
 			<_IpaAppBundleDir>$(DeviceSpecificIntermediateOutputPath)ipa\Payload\$(_AppBundleName).app\</_IpaAppBundleDir>
@@ -1552,7 +1552,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!-- Clone the compiled app bundle into the IPA's Payload directory... -->
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="$(AppBundleDir)"
@@ -1561,7 +1561,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<FindWatchOS1AppExtensionBundle
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '@(_ResolvedAppExtensionReferences)' != ''"
+			Condition="'$(IsMacEnabled)' And '@(_ResolvedAppExtensionReferences)' != ''"
 			AppExtensionReferences="@(_ResolvedAppExtensionReferences)"
 			>
 			<Output TaskParameter="WatchOS1AppExtensionBundle" PropertyName="_WatchOS1AppExtensionBundle"/>
@@ -1569,14 +1569,14 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<Copy
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '$(_WatchOS1AppExtensionBundle)' != ''"
+			Condition="'$(IsMacEnabled)' And '$(_WatchOS1AppExtensionBundle)' != ''"
 			SourceFiles="$(_WatchOS1AppExtensionBundle)\_WatchKitStub\WK"
 			DestinationFolder="$(DeviceSpecificIntermediateOutputPath)ipa\WatchKitSupport"
 		/>
 
 		<FindWatchOS2AppBundle
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '@(_ResolvedWatchAppReferences)' != ''"
+			Condition="'$(IsMacEnabled)' And '@(_ResolvedWatchAppReferences)' != ''"
 			WatchAppReferences="@(_ResolvedWatchAppReferences)"
 			>
 			<Output TaskParameter="WatchOS2AppBundle" PropertyName="_WatchOS2AppBundle"/>
@@ -1584,14 +1584,14 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<Copy
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '$(_WatchOS2AppBundle)' != ''"
+			Condition="'$(IsMacEnabled)' And '$(_WatchOS2AppBundle)' != ''"
 			SourceFiles="$(_WatchOS2AppBundle)\_WatchKitStub\WK"
 			DestinationFolder="$(DeviceSpecificIntermediateOutputPath)ipa\WatchKitSupport2"
 		/>
 
 		<CollectITunesSourceFiles
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			OutputPath="$(DeviceSpecificOutputPath)"
 			>
 			<Output TaskParameter="ITunesSourceFiles" ItemName="_ITunesSourceFile"/>
@@ -1599,7 +1599,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<Copy
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '@(_ITunesSourceFile)' != ''"
+			Condition="'$(IsMacEnabled)' And '@(_ITunesSourceFile)' != ''"
 			SourceFiles="@(_ITunesSourceFile)"
 			DestinationFolder="$(DeviceSpecificIntermediateOutputPath)ipa"
 		/>
@@ -1638,13 +1638,13 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<IsStreamable Condition="$(EmbedOnDemandResources) == 'false'">true</IsStreamable>
 		</PropertyGroup>
 		
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Directories="$(_IntermediateODRDir)" />
-		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)' And Exists('$(DeviceSpecificOutputPath)OnDemandResources\')" Directories="$(_IntermediateODRDir)" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(_IntermediateODRDir)" />
+		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' And Exists('$(DeviceSpecificOutputPath)OnDemandResources\')" Directories="$(_IntermediateODRDir)" />
 
 		<!-- Clone the compiled assetpack bundle... -->
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And Exists('$(DeviceSpecificOutputPath)OnDemandResources\')"
+			Condition="'$(IsMacEnabled)' And Exists('$(DeviceSpecificOutputPath)OnDemandResources\')"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="$(DeviceSpecificOutputPath)OnDemandResources\"
@@ -1654,7 +1654,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!-- Look for the *.assetpack folders in the ODR folder -->
 		<CollectAssetPacks
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And Exists('$(_IntermediateODRDir)')"
+			Condition="'$(IsMacEnabled)' And Exists('$(_IntermediateODRDir)')"
 			OnDemandResourcesPath="$(_IntermediateODRDir)"
 			>
 
@@ -1673,7 +1673,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!-- Sign assetpacks -->
 		<Codesign
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '@(_AssetPack)' != '' And '$(_DistributionType)' == 'AppStore'"
+			Condition="'$(IsMacEnabled)' And '@(_AssetPack)' != '' And '$(_DistributionType)' == 'AppStore'"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
 			CodesignAllocate="$(_CodesignAllocate)"
@@ -1687,19 +1687,19 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<WriteAssetPackManifest
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '$(_DistributionType)' == 'AdHoc' And Exists('$(_IntermediateODRDir)')"
+			Condition="'$(IsMacEnabled)' And '$(_DistributionType)' == 'AdHoc' And Exists('$(_IntermediateODRDir)')"
 			TemplatePath="$(_IpaAppBundleDir)AssetPackManifestTemplate.plist"
 			OutputFile="$(_IpaAppBundleDir)AssetPackManifest.plist"
 			OnDemandResourceUrl="$(OnDemandResourcesUrl)"
 			IsStreamable="$(IsStreamable)"
 			/>
 
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)' And '$(_DistributionType)' == 'AdHoc' And Exists('$(_IntermediateODRDir)')" Files="$(_IpaAppBundleDir)AssetPackManifestTemplate.plist" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' And '$(_DistributionType)' == 'AdHoc' And Exists('$(_IntermediateODRDir)')" Files="$(_IpaAppBundleDir)AssetPackManifestTemplate.plist" />
 
 		<!-- Re-sign app bundle if anything changed inside of it -->
 		<Codesign
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '$(_DistributionType)' == 'AdHoc' And Exists('$(_IntermediateODRDir)')"
+			Condition="'$(IsMacEnabled)' And '$(_DistributionType)' == 'AdHoc' And Exists('$(_IntermediateODRDir)')"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
 			CodesignAllocate="$(_CodesignAllocate)"
@@ -1711,12 +1711,12 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			ExtraArgs="$(CodesignExtraArgs)"
 			/>
 
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)' And '$(EmbedOnDemandResources)' == 'false'" Directories="$(_IpaOutputDir)OnDemandResources\" />
-		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)' And '$(EmbedOnDemandResources)' == 'false'" Directories="$(_IpaOutputDir)OnDemandResources\" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' And '$(EmbedOnDemandResources)' == 'false'" Directories="$(_IpaOutputDir)OnDemandResources\" />
+		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' And '$(EmbedOnDemandResources)' == 'false'" Directories="$(_IpaOutputDir)OnDemandResources\" />
 
 		<CreateAssetPack
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '$(EmbedOnDemandResources)' == 'false'"
+			Condition="'$(IsMacEnabled)' And '$(EmbedOnDemandResources)' == 'false'"
 			ToolExe="$(ZipExe)"
 			ToolPath="$(ZipPath)"
 			Source="%(_AssetPack.Identity)"
@@ -1725,19 +1725,19 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<Copy
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '$(EmbedOnDemandResources)' == 'false'"
+			Condition="'$(IsMacEnabled)' And '$(EmbedOnDemandResources)' == 'false'"
 			SourceFiles="$(_IpaAppBundleDir)AssetPackManifest.plist"
 			DestinationFolder="$(_IpaOutputDir)OnDemandResources\"
 			/>
 	</Target>
 
 	<Target Name="_ZipIpa" Condition="'$(BuildIpa)' == 'true'">
-		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Directories="$(_IpaOutputPath)" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Files="$(_IpaOutputDir)$(IpaPackageName)" />
+		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(_IpaOutputPath)" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Files="$(_IpaOutputDir)$(IpaPackageName)" />
 
 		<Zip
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(ZipExe)"
 			ToolPath="$(ZipPath)"
 			Recursive="true"
@@ -1751,7 +1751,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CoreArchive" Condition="'$(ArchiveOnBuild)' == 'true'" DependsOnTargets="$(Codesign)">
 		<CollectITunesSourceFiles
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)' And '@(_ITunesSourceFile)' == ''"
+			Condition="'$(IsMacEnabled)' And '@(_ITunesSourceFile)' == ''"
 			OutputPath="$(DeviceSpecificOutputPath)"
 			>
 			<Output TaskParameter="ITunesSourceFiles" PropertyName="_ITunesSourceFile"/>
@@ -1759,7 +1759,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<Archive
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			AppBundleDir="$(AppBundleDir)"
 			AppExtensionReferences="@(_ResolvedAppExtensionReferences)"
 			ITunesSourceFiles="@(_ITunesSourceFile)"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -326,32 +326,32 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="CreateIpa" Condition="'$(_CanArchive)' == 'true'" DependsOnTargets="$(CreateIpaDependsOn)" />
 
 	<Target Name="_CleanAppBundle" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_GenerateBundleName">
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(_AppBundlePath)" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(_AppBundlePath)" />
 	</Target>
 
 	<Target Name="_CleanUploaded" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_GenerateBundleName">
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Files="$(DeviceSpecificOutputPath).uploaded" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath).uploaded" />
 	</Target>
 
 	<Target Name="_CleanDebugSymbols" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_GenerateBundleName">
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(AppBundleDir).dSYM" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(AppBundleDir).dSYM" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
 	</Target>
 
 	<Target Name="_CleanITunesArtwork" Condition="'$(_CanArchive)' == 'true'">
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Files="$(DeviceSpecificOutputPath)iTunesMetadata.plist;$(DeviceSpecificOutputPath)iTunesArtwork@2x;$(DeviceSpecificOutputPath)iTunesArtwork" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)iTunesMetadata.plist;$(DeviceSpecificOutputPath)iTunesArtwork@2x;$(DeviceSpecificOutputPath)iTunesArtwork" />
 	</Target>
 	
 	<Target Name="_CleanDeviceSpecificOutput" Condition="'$(_CanOutputAppBundle)' == 'true'">
 		<RemoveDir SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			Directories="$(IntermediateOutputPath)build-*;
 					$(OutputPath)build-*" />
 	</Target>
 
 	<Target Name="_CleanIntermediateToolOutput">
 		<RemoveDir SessionId="$(BuildSessionId)" 
-			Condition="'$(IsMacEnabled)'" 
+			Condition="'$(IsMacEnabled)' == 'true'" 
 			Directories="$(DeviceSpecificIntermediateOutputPath)actool;
 					$(DeviceSpecificIntermediateOutputPath)assetpacks;
 					$(DeviceSpecificIntermediateOutputPath)ibtool;
@@ -364,7 +364,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 					$(DeviceSpecificIntermediateOutputPath)TextureAtlas;
 					$(DeviceSpecificIntermediateOutputPath)mtouch-cache;
 					$(DeviceSpecificIntermediateOutputPath)" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Files="$(DeviceSpecificOutputPath)*.ipa" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)*.ipa" />
 	</Target>
 
 	<PropertyGroup>
@@ -381,7 +381,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_ComputeBundleResourceOutputPaths" DependsOnTargets="_CollectBundleResources;_GenerateBundleName;_DetectSigningIdentity">
 		<ComputeBundleResourceOutputPaths
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleDir="$(AppBundleDir)"
 			BundleIdentifier="$(_BundleIdentifier)"
 			BundleResources="@(_BundleResourceWithLogicalName)"
@@ -397,7 +397,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Outputs = "@(_BundleResourceWithOutputPath -> '%(OutputPath)')" >
 		<SmartCopy
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SourceFiles = "@(_BundleResourceWithOutputPath)"
 			DestinationFiles = "@(_BundleResourceWithOutputPath -> '%(OutputPath)')"
 		/>
@@ -406,7 +406,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CreateAssetPackManifest" DependsOnTargets="_CopyResourcesToBundle">
 		<CreateAssetPackManifest
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleDir="$(AppBundleDir)"
 			InitialInstallTags="$(OnDemandResourcesInitialInstallTags)"
 			PrefetchOrder="$(OnDemandResourcesPrefetchOrder)"
@@ -417,7 +417,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CollectBundleResources" DependsOnTargets="$(_CollectBundleResourcesDependsOn)">
 		<CollectBundleResources
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			OptimizePropertyLists="$(OptimizePropertyLists)"
 			OptimizePNGs="$(OptimizePNGs)"
 			BundleResources="@(Content);@(BundleResource)"
@@ -462,7 +462,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<Metal
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(IPhoneResourcePrefix)"
@@ -476,7 +476,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Inputs="@(_SmeltedMetal)" Outputs="$(DeviceSpeficicIntermediateOutputPath)metal\default.metal-ar">
 		<ArTool
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			Items="@(_SmeltedMetal)"
 			Archive="$(DeviceSpecificIntermediateOutputPath)metal\default.metal-ar">
 		</ArTool>
@@ -490,7 +490,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Inputs="@(_ForgedMetal)" Outputs="$(_AppBundlePath)default.metallib">
 		<MetalLib
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			Items="@(_ForgedMetal)"
 			SdkDevPath="$(_SdkDevPath)"
 			OutputLibrary="$(_AppBundlePath)default.metallib">
@@ -504,7 +504,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_PackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'false'" DependsOnTargets="_CollectBundleResources">
 		<PackLibraryResources
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			Prefix="monotouch"
 			BundleResourcesWithLogicalNames="@(_BundleResourceWithLogicalName)">
 			<Output TaskParameter="EmbeddedResources" ItemName="EmbeddedResource" />
@@ -514,7 +514,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_UnpackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="ResolveReferences;_CollectBundleResources">
 		<UnpackLibraryResources
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			Prefix="monotouch"
 			NoOverwrite="@(_BundleResourceWithLogicalName)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
@@ -526,7 +526,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_DetectSdkLocations" DependsOnTargets="_ComputeTargetArchitectures">
 		<DetectSdkLocations
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SdkVersion="$(MtouchSdkVersion)"
 			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			TargetArchitectures="$(TargetArchitectures)"
@@ -545,7 +545,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_DetectSigningIdentity" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations">
 		<DetectSigningIdentity
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleName="$(_AppBundleName)"
 			AppManifest="$(_AppManifest)"
 			Keychain="$(CodesignKeychain)"
@@ -587,7 +587,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Outputs="$(_AppBundlePath)Info.plist" >
 		<CompileAppManifest
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleName="$(_AppBundleName)"
 			AppBundleDir="$(AppBundleDir)"
 			AppManifest="$(_AppManifest)"
@@ -606,8 +606,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			>
 		</CompileAppManifest>
 
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(AppBundleDir).dSYM" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(AppBundleDir).dSYM" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
 	</Target>
 
 	<Target Name="_CompileITunesMetadata" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'"
@@ -616,7 +616,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Outputs="$(DeviceSPecificOutputPath)iTunesMetadata.plist" >
 		<CompileITunesMetadata
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleDir="$(AppBundleDir)"
 			ITunesMetadata="@(ITunesMetadata)"
 			OutputPath="$(DeviceSpecificOutputPath)iTunesMetadata.plist"
@@ -626,7 +626,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CollectITunesArtwork" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'">
 		<CollectITunesArtwork
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			ITunesArtwork="@(ITunesArtwork)"
 			>
 			<Output TaskParameter="ITunesArtworkWithLogicalNames" ItemName="_ITunesArtworkWithLogicalName"/>
@@ -638,7 +638,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Inputs="@(_ITunesArtworkWithLogicalName)" Outputs="$(DeviceSpecificOutputPath)%(_ITunesArtworkWithLogicalName.LogicalName)">
 		<Copy
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SourceFiles="@(_ITunesArtworkWithLogicalName)"
 			DestinationFiles="$(DeviceSpecificOutputPath)%(_ITunesArtworkWithLogicalName.LogicalName)"
 		/>
@@ -647,7 +647,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_GetNativeExecutableName" DependsOnTargets="_DetectAppManifest;_GenerateBundleName;_CompileAppManifest">
 		<GetNativeExecutableName
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			AppManifest="$(_AppBundlePath)Info.plist"
 			>
 			<Output TaskParameter="ExecutableName" PropertyName="_ExecutableName" />
@@ -681,7 +681,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<MTouch
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			ToolExe="$(MtouchExe)"
 			ToolPath="$(MtouchPath)"
 			AppBundleDir="$(AppBundleDir)"
@@ -727,8 +727,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<Output TaskParameter="NativeLibraries" ItemName="_NativeLibrary" />
 		</MTouch>
 
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(AppBundleDir).dSYM" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(AppBundleDir).dSYM" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
 	</Target>
 
 	<Target Name="_GenerateFrameworkDebugSymbols" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsWatchApp)' != 'true'" DependsOnTargets="_CompileToNative;_CollectFrameworks"
@@ -739,7 +739,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!-- run dsymutil on embedded frameworks -->
 		<DSymUtil
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleDir="$(AppBundleDir)"
 			Architectures=""
 			DSymDir="$(AppBundleDir)\..\%(_Frameworks.Filename).framework.dSYM"
@@ -812,7 +812,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Outputs="$(_AppBundlePath)Settings.bundle\Root.plist" >
 		<CreateDebugSettings
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleDir="$(AppBundleDir)"
 			DebuggerPort="$(IOSDebuggerPort)"
 			>
@@ -824,7 +824,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Outputs="$(_AppBundlePath)MonoTouchDebugConfiguration.txt" >
 		<CreateDebugConfiguration
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleDir="$(AppBundleDir)"
 			DebugOverWiFi="$(IOSDebugOverWiFi)"
 			DebuggerHosts="$(IOSDebuggerHosts)"
@@ -847,7 +847,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<OptimizeImage
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			ToolExe="$(PngCrushExe)"
 			ToolPath="$(PngCrushPath)"
 			SdkDevPath="$(_SdkDevPath)"
@@ -884,7 +884,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<OptimizePropertyList
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			ToolExe="$(PlUtilExe)"
 			ToolPath="$(PlUtilPath)"
 			Input="%(_PropertyList.Identity)"
@@ -919,7 +919,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<OptimizePropertyList
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			ToolExe="$(PlUtilExe)"
 			ToolPath="$(PlUtilPath)"
 			Input="%(_LocalizationFile.Identity)"
@@ -955,7 +955,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<ScnTool
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			ToolExe="$(ScnToolExe)"
 			ToolPath="$(ScnToolPath)"
 			SdkRoot="$(_SdkRoot)"
@@ -1076,7 +1076,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<CompileSceneKitAssets
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			ToolExe="$(CopySceneKitAssetsExe)"
 			ToolPath="$(CopySceneKitAssetsPath)"
 			SceneKitAssets="@(SceneKitAsset)"
@@ -1129,7 +1129,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		
 		<IBTool
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			ToolExe="$(IBToolExe)"
 			ToolPath="$(IBToolPath)"
 			AppManifest="$(_AppManifest)"
@@ -1191,7 +1191,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<TextureAtlas
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			ToolExe="$(TextureAtlasExe)"
 			ToolPath="$(TextureAtlasPath)"
 			AtlasTextures="@(AtlasTexture)"
@@ -1215,14 +1215,14 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CreatePkgInfo" Condition="'$(IsAppExtension)' == 'false'" DependsOnTargets="_GenerateBundleName" Outputs="$(_AppBundlePath)PkgInfo">
-		<CreatePkgInfo SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" OutputPath="$(_AppBundlePath)PkgInfo" />
+		<CreatePkgInfo SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" OutputPath="$(_AppBundlePath)PkgInfo" />
 	</Target>
 
 	<Target Name="_EmbedMobileProvision" DependsOnTargets="_GenerateBundleName;_DetectSigningIdentity"
 		Outputs="$(_AppBundlePath)embedded.mobileprovision">
 		<EmbedMobileProvision
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleDir="$(AppBundleDir)"
 			ProvisioningProfile="$(_ProvisioningProfile)"
 			>
@@ -1233,7 +1233,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Outputs="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent">
 		<CompileEntitlements
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleDir="$(AppBundleDir)"
 			AppIdentifier="$(_AppIdentifier)"
 			BundleIdentifier="$(_BundleIdentifier)"
@@ -1334,7 +1334,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_DetectBundleIdentifier" DependsOnTargets="_DetectAppManifest">
 		<DetectBundleIdentifier
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleName="$(_AppBundleName)"
 			AppManifest="$(_AppManifest)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
@@ -1359,7 +1359,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<Target Name="_ValidateAppBundle" Condition="'$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'" DependsOnTargets="_DetectSdkLocations">
 		<ValidateAppBundleTask
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			AppBundlePath="$(_AppBundlePath)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
@@ -1467,7 +1467,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CollectFrameworks" Condition="'$(_IsContainerApp)' == 'true'" DependsOnTargets="_CompileToNative">
 		<CollectFrameworks
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundlePath="$(_AppBundlePath)"
 			>
 
@@ -1508,7 +1508,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CodesignAppBundle" Condition="'$(_RequireCodeSigning)' == 'true'" DependsOnTargets="$(_CodesignAppBundleDependsOn)">
 		<Codesign
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
 			CodesignAllocate="$(_CodesignAllocate)"
@@ -1531,7 +1531,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CodesignVerify" Condition="'$(_RequireCodeSigning)' == 'true'" DependsOnTargets="_CodesignAppBundle">
 		<CodesignVerify
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
 			CodesignAllocate="$(_CodesignAllocate)"
@@ -1541,9 +1541,9 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CoreCreateIpa" Condition="'$(BuildIpa)' == 'true'" DependsOnTargets="$(Codesign)">
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(DeviceSpecificIntermediateOutputPath)ipa" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(DeviceSpecificIntermediateOutputPath)ipa" />
 
-		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(DeviceSpecificIntermediateOutputPath)ipa\Payload" />
+		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(DeviceSpecificIntermediateOutputPath)ipa\Payload" />
 
 		<PropertyGroup>
 			<_IpaAppBundleDir>$(DeviceSpecificIntermediateOutputPath)ipa\Payload\$(_AppBundleName).app\</_IpaAppBundleDir>
@@ -1552,7 +1552,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!-- Clone the compiled app bundle into the IPA's Payload directory... -->
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="$(AppBundleDir)"
@@ -1591,7 +1591,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<CollectITunesSourceFiles
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			OutputPath="$(DeviceSpecificOutputPath)"
 			>
 			<Output TaskParameter="ITunesSourceFiles" ItemName="_ITunesSourceFile"/>
@@ -1638,7 +1638,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<IsStreamable Condition="$(EmbedOnDemandResources) == 'false'">true</IsStreamable>
 		</PropertyGroup>
 		
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(_IntermediateODRDir)" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(_IntermediateODRDir)" />
 		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' And Exists('$(DeviceSpecificOutputPath)OnDemandResources\')" Directories="$(_IntermediateODRDir)" />
 
 		<!-- Clone the compiled assetpack bundle... -->
@@ -1732,12 +1732,12 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_ZipIpa" Condition="'$(BuildIpa)' == 'true'">
-		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(_IpaOutputPath)" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Files="$(_IpaOutputDir)$(IpaPackageName)" />
+		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(_IpaOutputPath)" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(_IpaOutputDir)$(IpaPackageName)" />
 
 		<Zip
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			ToolExe="$(ZipExe)"
 			ToolPath="$(ZipPath)"
 			Recursive="true"
@@ -1759,7 +1759,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<Archive
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleDir="$(AppBundleDir)"
 			AppExtensionReferences="@(_ResolvedAppExtensionReferences)"
 			ITunesSourceFiles="@(_ITunesSourceFile)"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
@@ -100,7 +100,7 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 	<Target Name="_CompressNativeFrameworkResources" Inputs="@(_NativeFrameworkResource)" Outputs="$(IntermediateOutputPath)%(_NativeFramework.Filename)%(_NativeFramework.Extension)" DependsOnTargets="_CollectNativeFrameworkResources" > 
 		<Zip
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			ToolExe="$(ZipExe)"
 			ToolPath="$(ZipPath)"
 			Recursive="true"
@@ -125,7 +125,7 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 	<Target Name="_CompressObjCBindingNativeFrameworkResources" Inputs="@(_ObjCBindingNativeFrameworkResource)" Outputs="$(IntermediateOutputPath)%(ObjCBindingNativeFramework.Filename)%(ObjCBindingNativeFramework.Extension)" DependsOnTargets="_CollectObjCBindingNativeFrameworkResources" > 
 		<Zip
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			ToolExe="$(ZipExe)"
 			ToolPath="$(ZipPath)"
 			Recursive="true"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
@@ -100,7 +100,7 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 	<Target Name="_CompressNativeFrameworkResources" Inputs="@(_NativeFrameworkResource)" Outputs="$(IntermediateOutputPath)%(_NativeFramework.Filename)%(_NativeFramework.Extension)" DependsOnTargets="_CollectNativeFrameworkResources" > 
 		<Zip
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(ZipExe)"
 			ToolPath="$(ZipPath)"
 			Recursive="true"
@@ -125,7 +125,7 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 	<Target Name="_CompressObjCBindingNativeFrameworkResources" Inputs="@(_ObjCBindingNativeFrameworkResource)" Outputs="$(IntermediateOutputPath)%(ObjCBindingNativeFramework.Filename)%(ObjCBindingNativeFramework.Extension)" DependsOnTargets="_CollectObjCBindingNativeFrameworkResources" > 
 		<Zip
 			SessionId="$(BuildSessionId)"
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(ZipExe)"
 			ToolPath="$(ZipPath)"
 			Recursive="true"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.props
@@ -26,7 +26,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<!-- This is used to determine if VS is connected to mac. -->
 	<PropertyGroup>
-		<MtouchTargetsEnabled>true</MtouchTargetsEnabled>
+		<IsMacEnabled>true</IsMacEnabled>
+		<MtouchTargetsEnabled>$(IsMacEnabled)</MtouchTargetsEnabled>
 	</PropertyGroup>
 
 	<!-- When looking for related files to copy, look for Mono debugging files as well -->

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.Common.targets
@@ -54,7 +54,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 
 	<Target Name="_ResolveNativeWatchApp" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName">
 		<ResolveNativeWatchApp
-			Condition="'$(MtouchTargetsEnabled)'"
+			Condition="'$(IsMacEnabled)'"
 			SessionId="$(BuildSessionId)"
 			SdkVersion="$(MtouchSdkVersion)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
@@ -74,7 +74,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 	<Target Name="_CompileToNative" DependsOnTargets="$(_CompileToNativeDependsOn)" >
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="$(MtouchTargetsEnabled)"
+			Condition="$(IsMacEnabled)"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="$(_NativeWatchApp)"
@@ -85,20 +85,20 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 			must be installed or not depending on the timestamp of the main executable (this means
 			that if any other file is modified, we must at least touch the main executable as well).
 		-->
-		<Touch SessionId="$(BuildSessionId)" Condition="$(MtouchTargetsEnabled)" Files="$(_AppBundlePath)$(AssemblyName)"/>
+		<Touch SessionId="$(BuildSessionId)" Condition="$(IsMacEnabled)" Files="$(_AppBundlePath)$(AssemblyName)"/>
 
-		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Directories="$(_AppBundlePath)_WatchKitStub" />
+		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(_AppBundlePath)_WatchKitStub" />
 
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="$(MtouchTargetsEnabled)"
+			Condition="$(IsMacEnabled)"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="$(_NativeWatchApp)"
 			Destination="$(_AppBundlePath)_WatchKitStub\WK"
 		/>
 
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(MtouchTargetsEnabled)'" Directories="$(AppBundleDir).dSYM" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(AppBundleDir).dSYM" />
 	</Target>
 
 	<Target Name="CopyFilesToOutputDirectory" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.Common.targets
@@ -54,7 +54,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 
 	<Target Name="_ResolveNativeWatchApp" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName">
 		<ResolveNativeWatchApp
-			Condition="'$(IsMacEnabled)'"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			SdkVersion="$(MtouchSdkVersion)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
@@ -74,7 +74,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 	<Target Name="_CompileToNative" DependsOnTargets="$(_CompileToNativeDependsOn)" >
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="$(IsMacEnabled)"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="$(_NativeWatchApp)"
@@ -85,20 +85,20 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 			must be installed or not depending on the timestamp of the main executable (this means
 			that if any other file is modified, we must at least touch the main executable as well).
 		-->
-		<Touch SessionId="$(BuildSessionId)" Condition="$(IsMacEnabled)" Files="$(_AppBundlePath)$(AssemblyName)"/>
+		<Touch SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Files="$(_AppBundlePath)$(AssemblyName)"/>
 
-		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(_AppBundlePath)_WatchKitStub" />
+		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(_AppBundlePath)_WatchKitStub" />
 
 		<Ditto
 			SessionId="$(BuildSessionId)"
-			Condition="$(IsMacEnabled)"
+			Condition="'$(IsMacEnabled)'"
 			ToolExe="$(DittoExe)"
 			ToolPath="$(DittoPath)"
 			Source="$(_NativeWatchApp)"
 			Destination="$(_AppBundlePath)_WatchKitStub\WK"
 		/>
 
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)'" Directories="$(AppBundleDir).dSYM" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(AppBundleDir).dSYM" />
 	</Target>
 
 	<Target Name="CopyFilesToOutputDirectory" />


### PR DESCRIPTION
We previously had an MtouchTargetsEnabled and a separate
IsMacTargetsEnabled for iOS and XM, when both actually
meant the same thing: is a Mac enabled for building this
project?

Note that instead of "targets", we make it more generic,
since the condition can be used in a task, a property
group or whatever really, not just to enable/disable
certain targets.

Also, we call it Enabled, rather than Connected or
Available, since it's more natural to think that all such
tasks/targets are enabled when you're building locally
on the Mac. Connected wouldn't have been appropriate, and
Available would be confusing.

For backwards compatibility I've kept the old MtouchTargetsEnabled
pointing to IsMacEnabled. We'll change our Windows targets
accordingly to also unify this property and how/where it's
set.