### PR TITLE
[CoreGraphics] CGWindowListCreateImage can return null, in which case return a null CGImage.

### DIFF
--- a/src/CoreGraphics/CGImage.cs
+++ b/src/CoreGraphics/CGImage.cs
@@ -200,6 +200,8 @@ namespace XamCore.CoreGraphics {
 		{                    
 			IntPtr imageRef = CGWindowListCreateImage(bounds, CGWindowListOption.IncludingWindow, (uint)windownumber,
 								  CGWindowImageOption.Default);
+			if (imageRef == IntPtr.Zero)
+				return null;
 			return new CGImage(imageRef, true);                              
 		}
 #elif !WATCH


### PR DESCRIPTION
Instead of returning a managed CGImage instance wrapping IntPtr.Zero.