### PR TITLE
[msbuild] Support ibtool output when it adds ~ipad or ~iphone modifiers

### DIFF
--- a/msbuild/tests/MyIBToolLinkTest/AppDelegate.cs
+++ b/msbuild/tests/MyIBToolLinkTest/AppDelegate.cs
@@ -1,0 +1,57 @@
+﻿using Foundation;
+using UIKit;
+
+namespace MyIBToolLinkTest
+{
+    // The UIApplicationDelegate for the application. This class is responsible for launching the
+    // User Interface of the application, as well as listening (and optionally responding) to application events from iOS.
+    [Register ("AppDelegate")]
+    public class AppDelegate : UIApplicationDelegate
+    {
+        // class-level declarations
+
+        public override UIWindow Window
+        {
+            get; set;
+        }
+
+        public override bool FinishedLaunching (UIApplication application, NSDictionary launchOptions)
+        {
+            // Override point for customization after application launch.
+            // If not required for your application you can safely delete this method
+
+            return true;
+        }
+
+        public override void OnResignActivation (UIApplication application)
+        {
+            // Invoked when the application is about to move from active to inactive state.
+            // This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) 
+            // or when the user quits the application and it begins the transition to the background state.
+            // Games should use this method to pause the game.
+        }
+
+        public override void DidEnterBackground (UIApplication application)
+        {
+            // Use this method to release shared resources, save user data, invalidate timers and store the application state.
+            // If your application supports background exection this method is called instead of WillTerminate when the user quits.
+        }
+
+        public override void WillEnterForeground (UIApplication application)
+        {
+            // Called as part of the transiton from background to active state.
+            // Here you can undo many of the changes made on entering the background.
+        }
+
+        public override void OnActivated (UIApplication application)
+        {
+            // Restart any tasks that were paused (or not yet started) while the application was inactive. 
+            // If the application was previously in the background, optionally refresh the user interface.
+        }
+
+        public override void WillTerminate (UIApplication application)
+        {
+            // Called when the application is about to terminate. Save data, if needed. See also DidEnterBackground.
+        }
+    }
+}

--- a/msbuild/tests/MyIBToolLinkTest/Assets.xcassets/AppIcons.appiconset/Contents.json
+++ b/msbuild/tests/MyIBToolLinkTest/Assets.xcassets/AppIcons.appiconset/Contents.json
@@ -1,0 +1,162 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "57x57",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "57x57",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "50x50",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "50x50",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "72x72",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "72x72",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "size" : "24x24",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "notificationCenter",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "27.5x27.5",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "notificationCenter",
+      "subtype" : "42mm"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "2x"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "3x"
+    },
+    {
+      "size" : "40x40",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "appLauncher",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "44x44",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "longLook",
+      "subtype" : "42mm"
+    },
+    {
+      "size" : "86x86",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "98x98",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "42mm"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/msbuild/tests/MyIBToolLinkTest/Assets.xcassets/Contents.json
+++ b/msbuild/tests/MyIBToolLinkTest/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/msbuild/tests/MyIBToolLinkTest/Assets.xcassets/LaunchImage.launchimage/Contents.json
+++ b/msbuild/tests/MyIBToolLinkTest/Assets.xcassets/LaunchImage.launchimage/Contents.json
@@ -1,0 +1,7 @@
+{
+  "images": [],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/msbuild/tests/MyIBToolLinkTest/Entitlements.plist
+++ b/msbuild/tests/MyIBToolLinkTest/Entitlements.plist
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/msbuild/tests/MyIBToolLinkTest/Info.plist
+++ b/msbuild/tests/MyIBToolLinkTest/Info.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>MyIBToolLinkTest</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.your-company.myibtoollinktest</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>MinimumOSVersion</key>
+	<string>7.0</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>XSAppIconAssets</key>
+	<string>Assets.xcassets/AppIcons.appiconset</string>
+</dict>
+</plist>

--- a/msbuild/tests/MyIBToolLinkTest/Main.cs
+++ b/msbuild/tests/MyIBToolLinkTest/Main.cs
@@ -1,0 +1,15 @@
+﻿using UIKit;
+
+namespace MyIBToolLinkTest
+{
+    public class Application
+    {
+        // This is the main entry point of the application.
+        static void Main (string[] args)
+        {
+            // if you want to use a different Application Delegate class from "AppDelegate"
+            // you can specify it here.
+            UIApplication.Main (args, null, "AppDelegate");
+        }
+    }
+}

--- a/msbuild/tests/MyIBToolLinkTest/Main.storyboard
+++ b/msbuild/tests/MyIBToolLinkTest/Main.storyboard
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello World" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nO7-AV-XF2">
+                                <rect key="frame" x="20" y="28" width="88.5" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="nO7-AV-XF2" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="8" symbolic="YES" id="CwG-Oa-Dr9"/>
+                            <constraint firstItem="nO7-AV-XF2" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" constant="20" symbolic="YES" id="cNu-N1-dlh"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/msbuild/tests/MyIBToolLinkTest/MyIBToolLinkTest.csproj
+++ b/msbuild/tests/MyIBToolLinkTest/MyIBToolLinkTest.csproj
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProjectGuid>{05E76504-33DF-400F-8527-3BBAC7E9FDF1}</ProjectGuid>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MyIBToolLinkTest</RootNamespace>
+    <AssemblyName>MyIBToolLinkTest</AssemblyName>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG;ENABLE_TEST_CLOUD;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchFastDev>true</MtouchFastDev>
+    <MtouchProfiling>true</MtouchProfiling>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>i386</MtouchArch>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>i386</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;ENABLE_TEST_CLOUD;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <DeviceSpecificBuild>true</DeviceSpecificBuild>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchFastDev>true</MtouchFastDev>
+    <MtouchProfiling>true</MtouchProfiling>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <ImageAsset Include="Assets.xcassets\AppIcons.appiconset\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Contents.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <InterfaceDefinition Include="Main.storyboard" />
+    <InterfaceDefinition Include="Resources\LaunchScreen.xib" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+    <None Include="Entitlements.plist" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+    <Compile Include="AppDelegate.cs" />
+    <Compile Include="ViewController.cs" />
+    <Compile Include="ViewController.designer.cs">
+      <DependentUpon>ViewController.cs</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+</Project>

--- a/msbuild/tests/MyIBToolLinkTest/MyIBToolLinkTest.sln
+++ b/msbuild/tests/MyIBToolLinkTest/MyIBToolLinkTest.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyIBToolLinkTest", "MyIBToolLinkTest.csproj", "{05E76504-33DF-400F-8527-3BBAC7E9FDF1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|iPhone = Release|iPhone
+		Release|iPhoneSimulator = Release|iPhoneSimulator
+		Debug|iPhone = Debug|iPhone
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{05E76504-33DF-400F-8527-3BBAC7E9FDF1}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{05E76504-33DF-400F-8527-3BBAC7E9FDF1}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{05E76504-33DF-400F-8527-3BBAC7E9FDF1}.Release|iPhone.ActiveCfg = Release|iPhone
+		{05E76504-33DF-400F-8527-3BBAC7E9FDF1}.Release|iPhone.Build.0 = Release|iPhone
+		{05E76504-33DF-400F-8527-3BBAC7E9FDF1}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{05E76504-33DF-400F-8527-3BBAC7E9FDF1}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{05E76504-33DF-400F-8527-3BBAC7E9FDF1}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{05E76504-33DF-400F-8527-3BBAC7E9FDF1}.Debug|iPhone.Build.0 = Debug|iPhone
+	EndGlobalSection
+EndGlobal

--- a/msbuild/tests/MyIBToolLinkTest/Resources/LaunchScreen.xib
+++ b/msbuild/tests/MyIBToolLinkTest/Resources/LaunchScreen.xib
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="1">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="img_splascreen_1136.png" translatesAutoresizingMaskIntoConstraints="NO" id="mnI-ii-6Tv">
+                    <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                </imageView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="mnI-ii-6Tv" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="LoX-h9-0Oc"/>
+                <constraint firstAttribute="trailing" secondItem="mnI-ii-6Tv" secondAttribute="trailing" id="U1t-Zy-Gi4"/>
+                <constraint firstAttribute="bottom" secondItem="mnI-ii-6Tv" secondAttribute="bottom" id="bNi-FY-y2C"/>
+                <constraint firstItem="mnI-ii-6Tv" firstAttribute="top" secondItem="1" secondAttribute="top" id="l8v-XT-csc"/>
+            </constraints>
+        </view>
+    </objects>
+    <resources>
+        <image name="img_splascreen_1136.png" width="640" height="1136"/>
+    </resources>
+</document>

--- a/msbuild/tests/MyIBToolLinkTest/ViewController.cs
+++ b/msbuild/tests/MyIBToolLinkTest/ViewController.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+using UIKit;
+
+namespace MyIBToolLinkTest
+{
+    public partial class ViewController : UIViewController
+    {
+        protected ViewController (IntPtr handle) : base (handle)
+        {
+            // Note: this .ctor should not contain any initialization logic.
+        }
+
+        public override void ViewDidLoad ()
+        {
+            base.ViewDidLoad ();
+            // Perform any additional setup after loading the view, typically from a nib.
+        }
+
+        public override void DidReceiveMemoryWarning ()
+        {
+            base.DidReceiveMemoryWarning ();
+            // Release any cached data, images, etc that aren't in use.
+        }
+    }
+}

--- a/msbuild/tests/MyIBToolLinkTest/ViewController.designer.cs
+++ b/msbuild/tests/MyIBToolLinkTest/ViewController.designer.cs
@@ -1,0 +1,17 @@
+﻿//
+// This file has been generated automatically by MonoDevelop to store outlets and
+// actions made in the Xcode designer. If it is removed, they will be lost.
+// Manual changes to this file may not be handled correctly.
+//
+using Foundation;
+
+namespace MyProj.iOS
+{
+    [Register ("ViewController")]
+    partial class ViewController
+    {
+        void ReleaseDesignerOutlets ()
+        {
+        }
+    }
+}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/IBToolLinking.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/IBToolLinking.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.IO;
+
+using NUnit.Framework;
+
+namespace Xamarin.iOS.Tasks
+{
+	[TestFixture ("iPhone")]
+	[TestFixture ("iPhoneSimulator")]
+	public class IBToolLinking : ProjectTest
+	{
+		public IBToolLinking (string platform) : base (platform)
+		{
+		}
+
+		[Test]
+		public void BuildTest ()
+		{
+			BuildProject ("MyIBToolLinkTest", Platform);
+		}
+	}
+}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectTest.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectTest.cs
@@ -30,9 +30,9 @@ namespace Xamarin.iOS.Tasks
 			SetupEngine ();
 		}
 
-		public void BuildProject (string appName, string bundlePath, string platform, int expectedErrorCount = 0) 
+		public void BuildProject (string appName, string platform, int expectedErrorCount = 0) 
 		{
-			var mtouchPaths = SetupProjectPaths (appName, "../", true, bundlePath);
+			var mtouchPaths = SetupProjectPaths (appName, "../", true, platform);
 
 			var proj = SetupProject (Engine, mtouchPaths ["project_csprojpath"]);
 
@@ -40,7 +40,7 @@ namespace Xamarin.iOS.Tasks
 			Engine.GlobalProperties.SetProperty("Platform", platform);
 
 			RunTarget (proj, "Clean");
-			Assert.IsFalse (Directory.Exists (AppBundlePath), "{1}: App bundle exists after cleanup: {0} ", AppBundlePath, bundlePath);
+			Assert.IsFalse (Directory.Exists (AppBundlePath), "App bundle exists after cleanup: {0} ", AppBundlePath);
 
 			proj = SetupProject (Engine, mtouchPaths.ProjectCSProjPath);
 			RunTarget (proj, "Build", expectedErrorCount);
@@ -48,7 +48,7 @@ namespace Xamarin.iOS.Tasks
 			if (expectedErrorCount > 0)
 				return;
 
-			Assert.IsTrue (Directory.Exists (AppBundlePath), "{1} App Bundle does not exist: {0} ", AppBundlePath, bundlePath);
+			Assert.IsTrue (Directory.Exists (AppBundlePath), "App Bundle does not exist: {0} ", AppBundlePath);
 
 			TestFilesExists (AppBundlePath, ExpectedAppFiles);
 			TestFilesDoNotExist (AppBundlePath, UnexpectedAppFiles);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_tvOS.cs" />
     <Compile Include="TaskTests\SymbolStripTaskTests.cs" />
     <Compile Include="TaskTests\ValidateAppBundleTaskTests.cs" />
+    <Compile Include="ProjectsTests\IBToolLinking.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
When targetting older iOS versions (such as iOS 7) for multiple
device targets (e.g. iphone, ipad, etc), ibtool will output
multiple directories using the basename of the original ib file
and add ~ipad or ~iphone blurbs to the filename.

This was causing the linking step to fail due to paths not being
found at the expected locations.