### PR TITLE
[apitest] Modify a couple of test to not take a screen image just to get an image.

### DIFF
--- a/tests/apitest/src/CoreAnimation/CAKeyFrameAnimation.cs
+++ b/tests/apitest/src/CoreAnimation/CAKeyFrameAnimation.cs
@@ -29,13 +29,15 @@ namespace Xamarin.Mac.Tests
 			NSNumber arrayNumber = (NSNumber)keyFrameAni.Values[0];
 			Assert.AreEqual (5, arrayNumber.Int32Value);
 
-			CGRect frame = new CGRect (10, 10, 0, 0);
-			CGImage image = CGImage.ScreenImage (0, frame);
-
-			keyFrameAni.SetValues (new CGImage [] {image, image});
-			Assert.AreEqual (2, keyFrameAni.Values.Length);
-			CGImage arrayImage = (CGImage)keyFrameAni.GetValuesAs<CGImage> ()[1];
-			Assert.AreEqual (image.Handle, arrayImage.Handle);
+			CGRect frame = new CGRect (10, 10, 10, 10);
+			using (var provider = new CGDataProvider (new byte [(int) frame.Width * (int) frame.Height * 4 ])) {
+				using (var image = new CGImage ((int) frame.Width, (int) frame.Height, 8, 32, (int) frame.Width * 4, CGColorSpace.CreateDeviceRGB (), CGBitmapFlags.None, provider, null, false, CGColorRenderingIntent.Default)) {
+					keyFrameAni.SetValues (new CGImage [] {image, image});
+					Assert.AreEqual (2, keyFrameAni.Values.Length);
+					CGImage arrayImage = (CGImage)keyFrameAni.GetValuesAs<CGImage> ()[1];
+					Assert.AreEqual (image.Handle, arrayImage.Handle);
+				}
+			}
 		}
 	}
 }

--- a/tests/apitest/src/CoreAnimation/CALayer.cs
+++ b/tests/apitest/src/CoreAnimation/CALayer.cs
@@ -24,20 +24,23 @@ namespace Xamarin.Mac.Tests
 		public void CALayer_ValuesTests ()
 		{
 			CALayer layer = new CALayer ();
-			CGRect frame = new CGRect (10, 10, 0, 0);
-			CGImage image = CGImage.ScreenImage (0, frame);
-			NSImage NSImage = new NSImage ();
+			CGRect frame = new CGRect (10, 10, 10, 10);
+			using (var provider = new CGDataProvider (new byte [(int) frame.Width * (int) frame.Height * 4 ])) {
+				using (var image = new CGImage ((int) frame.Width, (int) frame.Height, 8, 32, (int) frame.Width * 4, CGColorSpace.CreateDeviceRGB (), CGBitmapFlags.None, provider, null, false, CGColorRenderingIntent.Default)) {
+					NSImage NSImage = new NSImage ();
 
-			layer.Contents = image;
-			CGImage arrayImage = layer.Contents;
-			Assert.AreEqual (image.Handle, arrayImage.Handle);
-			
-			layer.SetContents (NSImage);
-			NSImage arrayNSImage = layer.GetContentsAs<NSImage> ();
-			Assert.AreEqual (NSImage.Handle, arrayNSImage.Handle);
+					layer.Contents = image;
+					CGImage arrayImage = layer.Contents;
+					Assert.AreEqual (image.Handle, arrayImage.Handle);
+					
+					layer.SetContents (NSImage);
+					NSImage arrayNSImage = layer.GetContentsAs<NSImage> ();
+					Assert.AreEqual (NSImage.Handle, arrayNSImage.Handle);
 
-			layer.SetContents (null); // Should not throw
-			layer.Contents = null; // Should not throw
+					layer.SetContents (null); // Should not throw
+					layer.Contents = null; // Should not throw
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Taking a screen image does not work unless there's a window server
running, which may not always be the case on bots.

So instead just create an image manually, since these tests do
not seem to be requiring any particular type of image.