### PR TITLE
[gameplaykit] Replace QuadTreeWithMinPosition by managed code

### DIFF
--- a/src/GameplayKit/GKCompat.cs
+++ b/src/GameplayKit/GKCompat.cs
@@ -1,0 +1,20 @@
+// Compatibility stubs
+
+using System;
+using OpenTK;
+
+#if !XAMCORE_4_0 && !MONOMAC
+
+namespace XamCore.GameplayKit {
+
+	public partial class GKQuadTree {
+
+		[Obsolete ("Use constructor with the same signature")]
+		public static GKQuadTree QuadTreeWithMinPosition (Vector2 min, Vector2 max, float minCellSize)
+		{
+			return new GKQuadTree (min, max, minCellSize);
+		}
+	}
+}
+
+#endif

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -725,6 +725,7 @@ GAMEKIT_SOURCES = \
 
 GAMEPLAYKIT_SOURCES = \
 	GameplayKit/GKBehavior.cs \
+	GameplayKit/GKCompat.cs \
 	GameplayKit/GKComponentSystem.cs \
 	GameplayKit/GKEntity.cs \
 	GameplayKit/GKGameModel.cs \

--- a/src/gameplaykit.cs
+++ b/src/gameplaykit.cs
@@ -1010,10 +1010,6 @@ namespace XamCore.GameplayKit {
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor] // crash (endless recursion)
 	interface GKQuadTree {
-		[Static]
-		[Export ("quadTreeWithMinPosition:maxPosition:minCellSize:")]
-		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		GKQuadTree QuadTreeWithMinPosition (Vector2 min, Vector2 max, float minCellSize);
 
 		[Export ("initWithMinPosition:maxPosition:minCellSize:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]


### PR DESCRIPTION
Looks like it was an API added in 9.x but removed (in later betas?). The
introspection tests did find (in 9.x) the selector so it was not reported
as an error but it's not part of iOS 10 (so it fails now)

This removes the binding and replace it with a managed alternative
so there is no breaking change.

references:
[FAIL] GameplayKit.GKQuadTree : quadTreeWithMinPosition:maxPosition:minCellSize: