### PR TITLE
[corespotlight] Disable CoreSpotlight.CSCustomAttributeKey default constructor

### DIFF
--- a/src/CoreSpotlight/CSCompat.cs
+++ b/src/CoreSpotlight/CSCompat.cs
@@ -1,0 +1,18 @@
+// Compatibility stubs
+
+#if !XAMCORE_4_0 && IOS
+
+using System;
+
+namespace XamCore.CoreSpotlight {
+
+	partial class CSCustomAttributeKey {
+
+		[Obsolete ("Use .ctor(string)")]
+		public CSCustomAttributeKey () : this (String.Empty)
+		{
+		}
+	}
+}
+
+#endif

--- a/src/corespotlight.cs
+++ b/src/corespotlight.cs
@@ -167,6 +167,7 @@ namespace XamCore.CoreSpotlight {
 	[NoTV] // CS_TVOS_UNAVAILABLE
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor] // NSInvalidArgumentException Reason: You must call -[CSCustomAttributeKey initWithKeyName...]
 	public interface CSCustomAttributeKey : NSCopying, NSSecureCoding {
 
 		[Export ("initWithKeyName:")]

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -488,6 +488,7 @@ CORESPOTLIGHT_API_SOURCES = \
 	CoreSpotlight/CSEnums.cs \
 	
 CORESPOTLIGHT_SOURCES = \
+	CoreSpotlight/CSCompat.cs \
 	CoreSpotlight/CSSearchableIndex.cs \
 	CoreSpotlight/CSSearchableItemAttributeSet.cs \
 


### PR DESCRIPTION
as it fails (throw) on iOS 10. Provide a managed stub to replace it and
maintain API compatibility.

reference:
* [FAIL] Default constructor not allowed for CoreSpotlight.CSCustomAttributeKey : Objective-C exception thrown. Name: NSInvalidArgumentException Reason: You must call -[CSCustomAttributeKey initWithKeyName...]