### PR TITLE
[gameplaykit] Setter for GKGridGraphNode.GridPosition was removed in iOS 10 beta 1

### DIFF
--- a/src/gameplaykit.cs
+++ b/src/gameplaykit.cs
@@ -516,8 +516,10 @@ namespace XamCore.GameplayKit {
 		Vector2i GridPosition { 
 			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 			get; 
-			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+#if !XAMCORE_4_0
+			[NotImplemented]
 			set; 
+#endif
 		}
 
 		[Static]


### PR DESCRIPTION
The iOS 10 beta API diff (over 9.3 SDK) shows:

	-@property (nonatomic) vector_int2 gridPosition;
	+@property (nonatomic, readonly) vector_int2 gridPosition;

The commit fix this without introducing a API incompatibility.