### PR TITLE
[uikit] Fix issues found with introspection tests

### DIFF
--- a/src/UIKit/Compat.cs
+++ b/src/UIKit/Compat.cs
@@ -68,4 +68,14 @@ namespace XamCore.UIKit {
 		}
 	}
 #endif
+
+#if !XAMCORE_4_0
+	public partial class UIPresentationController {
+
+		[Obsolete ("Removed in iOS10. Use .ctor(UIViewController,UIViewController)")]
+		public UIPresentationController ()
+		{
+		}
+	}
+#endif
 }

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -5287,6 +5287,7 @@ namespace XamCore.UIKit {
 
 	[iOS (10,0)]
 	[BaseType (typeof(UIGraphicsRendererFormat))]
+	[DisableDefaultCtor] // returns nil
 	interface UIGraphicsPdfRendererFormat
 	{
 		[Export ("documentInfo", ArgumentSemantic.Copy)]
@@ -5296,6 +5297,7 @@ namespace XamCore.UIKit {
 
 	[iOS (10,0)]
 	[BaseType (typeof(UIGraphicsRendererContext))]
+	[DisableDefaultCtor] // returns nil
 	interface UIGraphicsPdfRendererContext
 	{
 		[Export ("pdfContextBounds")]
@@ -5320,6 +5322,7 @@ namespace XamCore.UIKit {
 
 	[iOS (10,0)]
 	[BaseType (typeof(UIGraphicsRenderer))]
+	[DisableDefaultCtor] // returns nil
 	interface UIGraphicsPdfRenderer
 	{
 		[Export ("initWithBounds:format:")]
@@ -8407,6 +8410,7 @@ namespace XamCore.UIKit {
 	
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor] // NSInvalidArgumentException Reason: Don't call -[UIPresentationController init].
 	public partial interface UIPresentationController : UIAppearanceContainer, UITraitEnvironment, UIContentContainer, UIFocusEnvironment {
 		[Export ("initWithPresentedViewController:presentingViewController:")]
 		IntPtr Constructor (UIViewController presentedViewController, [NullAllowed] UIViewController presentingViewController);


### PR DESCRIPTION
Some types can't call `init` and return valid instances, some returns
nil and gives an invalid handle and one fails (throws) [1]

references:
[FAIL] UIKit.UIGraphicsPdfRenderer : Handle
[FAIL] UIKit.UIGraphicsPdfRendererContext : Handle
[FAIL] UIKit.UIGraphicsPdfRendererFormat : Handle
[FAIL] Default constructor not allowed for UIKit.UIPresentationController : Objective-C exception thrown. Name: NSInvalidArgumentException Reason: Don't call -[UIPresentationController init].