### PR TITLE
[modelio] All properties for MDLVertexAttributeData were turned read-only in iOS10

### DIFF
--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -1338,16 +1338,40 @@ namespace XamCore.ModelIO {
 	interface MDLVertexAttributeData
 	{
 		[Export ("map", ArgumentSemantic.Retain), NullAllowed]
-		MDLMeshBufferMap Map { get; set; }
+		MDLMeshBufferMap Map {
+			get;
+#if !XAMCORE_4_0
+			[NotImplemented]
+			set;
+#endif
+		}
 
 		[Export ("dataStart", ArgumentSemantic.Assign)]
-		IntPtr DataStart { get; set; }
+		IntPtr DataStart {
+			get;
+#if !XAMCORE_4_0
+			[NotImplemented]
+			set;
+#endif
+		}
 
 		[Export ("stride", ArgumentSemantic.Assign)]
-		nuint Stride { get; set; }
+		nuint Stride {
+			get;
+#if !XAMCORE_4_0
+			[NotImplemented]
+			set;
+#endif
+		}
 
 		[Export ("format", ArgumentSemantic.Assign)]
-		MDLVertexFormat Format { get; set; }
+		MDLVertexFormat Format {
+			get;
+#if !XAMCORE_4_0
+			[NotImplemented]
+			set;
+#endif
+		}
 	}
 
 	[iOS (9,0)][Mac (10,11, onlyOn64 : true)]


### PR DESCRIPTION
The iOS 10 beta API diff (over 9.3 SDK) shows:

-@property (nonatomic, retain) MDLMeshBufferMap *map;
-@property (nonatomic) void *dataStart;
-@property (nonatomic) NSUInteger stride;
-@property (nonatomic) MDLVertexFormat format;
+@property (nonatomic, retain, readonly) MDLMeshBufferMap *map;
+@property (nonatomic, readonly) void *dataStart;
+@property (nonatomic, readonly) NSUInteger stride;
+@property (nonatomic, readonly) MDLVertexFormat format;

The commit fix this without introducing a API incompatibility.

references:
[FAIL] Selector not found for ModelIO.MDLVertexAttributeData : setDataStart:
[FAIL] Selector not found for ModelIO.MDLVertexAttributeData : setFormat:
[FAIL] Selector not found for ModelIO.MDLVertexAttributeData : setMap:
[FAIL] Selector not found for ModelIO.MDLVertexAttributeData : setStride: