### PR TITLE
[Fix] Ensure NSExpression tests do run in the device ensuring that all members of the type are preserved.

### DIFF
--- a/tests/monotouch-test/Foundation/NSExpressionTest.cs
+++ b/tests/monotouch-test/Foundation/NSExpressionTest.cs
@@ -9,11 +9,12 @@ using MonoTouch.Foundation;
 #endif
 using NUnit.Framework;
 
+[assembly: Preserve (typeof (NSExpression), AllMembers = true)]
+
 namespace MonoTouchFixtures.Foundation
 {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
-	[assembly: Preserve (typeof (NSExpression))]
 	public class NSExpressionTest
 	{
 		List<string> properties = new List<string> { "Block", "ConstantValue", "KeyPath",  "Function", 


### PR DESCRIPTION
Simple change, the attr has to be outside of the namespace.