### PR TITLE
[Fix] Ensure that tests do not fail on iOS 8.

### DIFF
--- a/tests/introspection/ApiCMAttachmentTest.cs
+++ b/tests/introspection/ApiCMAttachmentTest.cs
@@ -229,6 +229,7 @@ namespace Introspection {
 			case "MidiDevice":
 			case "MidiEndpoint":
 			case "ABMultiValue":
+			case "ABMutableMultiValue":
 				return true;
 			default:
  				return false;


### PR DESCRIPTION
The tests had to be updated to skip a type that does not support the CMAttachment API.

Please do run the tests on a sim of iOS 8 (no matter the device).