### PR TITLE
[linker] Adjust RemoveCode.cs not to remove MonoMethodMessage

### DIFF
--- a/tools/linker/Descriptors/mscorlib.xml
+++ b/tools/linker/Descriptors/mscorlib.xml
@@ -604,6 +604,8 @@
 			<method name="StaticGetterAdapterFrame" />
 		</type>
 		<type fullname="System.Reflection.ParameterInfo" preserve="fields" />
+		<!-- reflection.c: ves_icall_get_parameter_info -->
+		<type fullname="System.Reflection.MonoParameterInfo" preserve="fields" />
 
 		<!-- object.c: mono_field_get_value_object and mono_runtime_invoke_array -->
 		<type fullname="System.Reflection.Pointer" >

--- a/tools/linker/MonoTouch.Tuner/RemoveCode.cs
+++ b/tools/linker/MonoTouch.Tuner/RemoveCode.cs
@@ -173,7 +173,8 @@ namespace MonoTouch.Tuner {
 			case "System.Runtime.Remoting.Proxies":
 				return true;
 			case "System.Runtime.Remoting.Messaging":
-				return type.Name != "AsyncResult" && type.Name != "LogicalCallContext";
+				return type.Name != "AsyncResult" && type.Name != "LogicalCallContext"
+					&& type.Name != "MonoMethodMessage";
 			case "System.Security.AccessControl":
 			case "System.Security.Permissions":
 			case "System.Security.Policy":

--- a/tools/mmp/linker/Descriptors/mscorlib.xml
+++ b/tools/mmp/linker/Descriptors/mscorlib.xml
@@ -616,6 +616,8 @@
 			<method name="StaticGetterAdapterFrame" />
 		</type>
 		<type fullname="System.Reflection.ParameterInfo" preserve="fields" />
+		<!-- reflection.c: ves_icall_get_parameter_info -->
+		<type fullname="System.Reflection.MonoParameterInfo" preserve="fields" />
 
 		<type fullname="System.Reflection.Emit.AssemblyBuilder" preserve="fields">
 			<method name="AddPermissionRequests" />


### PR DESCRIPTION
Followup to #172, apparently there's a custom linker step that removes all the code from `System.Runtime.Remoting.Messaging` except for a few exceptions.

Fixes Bug5354 in linker-ios/dont link/AotBugs.cs when xamarin-macios is compiled with Mono master.