### PR TITLE
[tests][harness] Add kTCCServiceMediaLibrary to avoid privacy popup

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -215,6 +215,7 @@ namespace xharness
 			var sim_services = new string [] {
 					"kTCCServiceAddressBook",
 					"kTCCServicePhotos",
+					"kTCCServiceMediaLibrary",
 					"kTCCServiceUbiquity",
 					"kTCCServiceWillow"
 				};


### PR DESCRIPTION
Running some API without permission can crash some tests.