### PR TITLE
[uikit] Remove [BaseType] from type are that only [Protocol]

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -6149,7 +6149,6 @@ namespace XamCore.UIKit {
 	
 	[iOS (10,0)]
 	[Protocol]
-	[BaseType (typeof(NSObject))]
 	public interface UIRefreshControlHosting
 	{
 		[NoTV]
@@ -10632,7 +10631,6 @@ namespace XamCore.UIKit {
 	public interface IUITableViewDataSourcePrefetching {}
 	[iOS (10,0)]
 	[Protocol]
-	[BaseType (typeof(NSObject))]
 	public interface UITableViewDataSourcePrefetching
 	{
 		[Abstract]


### PR DESCRIPTION
and not a [Model] as it's not required and also cause failures,
which we need to investigate (and report an error or fix).

* UIRefreshControlHosting
* UITableViewDataSourcePrefetching

reference:
[FAIL] iOSApiProtocolTest.ApiProtocolTest.GeneralCase : 2 types do not really conform to the protocol interfaces