### PR TITLE
[avfoundation] Remove default ctor from AVAudioChannelLayout and AVAudioConnectionPoint

### DIFF
--- a/src/AVFoundation/AVCompat.cs
+++ b/src/AVFoundation/AVCompat.cs
@@ -61,4 +61,22 @@ namespace XamCore.AVFoundation {
 		}
 	}
 #endif
+
+#if !XAMCORE_4_0
+	partial class AVAudioChannelLayout {
+
+		[Obsolete ("Valid instance of this type cannot be directly created")]
+		public AVAudioChannelLayout ()
+		{
+		}
+	}
+
+	partial class AVAudioConnectionPoint {
+
+		[Obsolete ("Valid instance of this type cannot be directly created")]
+		public AVAudioConnectionPoint ()
+		{
+		}
+	}
+#endif
 }

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -473,6 +473,7 @@ namespace XamCore.AVFoundation {
 
 	[iOS (8,0)][Mac (10,10)]
 	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor] // fails (nil handle on iOS 10)
 	interface AVAudioChannelLayout : NSSecureCoding {
 		[Export ("initWithLayoutTag:")]
 		IntPtr Constructor (/* UInt32 */ uint layoutTag);
@@ -523,6 +524,7 @@ namespace XamCore.AVFoundation {
 
 	[iOS (9,0), Mac(10,11)]
 	[BaseType (typeof(NSObject))]
+	[DisableDefaultCtor] // fails (nil handle on iOS 10)
 	interface AVAudioConnectionPoint
 	{
 		[Export ("initWithNode:bus:")]


### PR DESCRIPTION
They return invalid (nil) instances in iOS 10.

references:
[FAIL] AVFoundation.AVAudioChannelLayout : Handle
[FAIL] AVFoundation.AVAudioConnectionPoint : Handle