### PR TITLE
[gameplaykit] Remove defaultl ctor for GKQuadTreeNode

### DIFF
--- a/src/GameplayKit/GKCompat.cs
+++ b/src/GameplayKit/GKCompat.cs
@@ -15,6 +15,14 @@ namespace XamCore.GameplayKit {
 			return new GKQuadTree (min, max, minCellSize);
 		}
 	}
+
+	public partial class GKQuadTreeNode {
+
+		[Obsolete ("Valid instance of this type cannot be directly created")]
+		public GKQuadTreeNode ()
+		{
+		}
+	}
 }
 
 #endif

--- a/src/gameplaykit.cs
+++ b/src/gameplaykit.cs
@@ -1003,7 +1003,7 @@ namespace XamCore.GameplayKit {
 	[NoMac]
 	[iOS (9,1)][TV (9,0)]
 	[BaseType (typeof (NSObject))]
-	// [DisableDefaultCtor] // <quote>Used as a hint for faster removal via [GKQuadTree removeData:WithNode:]</quote>
+	[DisableDefaultCtor] // <quote>Used as a hint for faster removal via [GKQuadTree removeData:WithNode:]</quote>
 	interface GKQuadTreeNode {
 	}
 


### PR DESCRIPTION
That was committed, commented, in f2105210, likely a mistake for testing
something :| and it's not working when called in iOS 10

reference:
[FAIL] GameplayKit.GKQuadTreeNode : Handle