### PR TITLE
[tests][introspection] Ignore Sublocality as a typo

### DIFF
--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -283,6 +283,7 @@ namespace Introspection
 			"Subcardioid",
 			"Subentities",
 			"Subheadline",
+			"Sublocality",
 			"Submesh",
 			"Submeshes",
 			"Subpixel",


### PR DESCRIPTION
Fix test for a previous commit. This is what Apple use as the API name
even if it's not perfect English.