### PR TITLE
[tests][introspection] Fix protocol tests for SafariServices

### DIFF
--- a/tests/introspection/iOS/iOSApiProtocolTest.cs
+++ b/tests/introspection/iOS/iOSApiProtocolTest.cs
@@ -156,6 +156,9 @@ namespace Introspection {
 				case "MKMapSnapshotOptions":
 				case "WCSessionFile":
 				case "WCSessionFileTransfer":
+				// iOS 10
+				case "SFContentBlockerState":
+				case "SFSafariViewControllerConfiguration":
 					return true;
 				}
 				break;
@@ -197,6 +200,9 @@ namespace Introspection {
 				case "NSTextTab":
 				case "WCSessionFile":
 				case "WCSessionFileTransfer":
+				// iOS 10
+				case "SFContentBlockerState":
+				case "SFSafariViewControllerConfiguration":
 					return true;
 				}
 				break;
@@ -221,6 +227,9 @@ namespace Introspection {
 				case "HKQuantitySample":
 				case "HKSample":
 				case "HKWorkout":
+					return true;
+				// iOS 10
+				case "SFSafariViewControllerConfiguration":
 					return true;
 				}
 				break;


### PR DESCRIPTION
The types are not _publicly_ conforming to the protocols (i.e. the header
files don't mention them). However they do conform at runtime, which is
what the test check (so we must ignore them)