### PR TITLE
[tests] Some fix for monotouch-test needed wrt iOS 10

### DIFF
--- a/tests/monotouch-test/AddressBookUI/AddressFormattingTest.cs
+++ b/tests/monotouch-test/AddressBookUI/AddressFormattingTest.cs
@@ -62,6 +62,12 @@ namespace MonoTouchFixtures.AddressBookUI {
 				if (!UIDevice.CurrentDevice.CheckSystemVersion (8,2))
 					return;
 
+				// iOS 10 beta 1 also differs (country not specified)
+				if (UIDevice.CurrentDevice.CheckSystemVersion (10, 0)) {
+					Assert.That (s.Length, Is.EqualTo (expected.Length), "no country");
+					return;
+				}
+
 				Assert.That (s [expected.Length], Is.EqualTo ('\n'), "newline");
 				Assert.That (s.Length > expected.Length + 1, "country");
 			}

--- a/tests/monotouch-test/Asserts.cs
+++ b/tests/monotouch-test/Asserts.cs
@@ -20,9 +20,9 @@ public static class Asserts
 
 	public static void AreEqual (Vector3 expected, Vector3 actual, string message)
 	{
-		Assert.AreEqual (expected.X, actual.X, message + " (X)");
-		Assert.AreEqual (expected.Y, actual.Y, message + " (Y)");
-		Assert.AreEqual (expected.Z, actual.Z, message + " (Z)");
+		Assert.AreEqual (expected.X, actual.X, 0.001, message + " (X)");
+		Assert.AreEqual (expected.Y, actual.Y, 0.001, message + " (Y)");
+		Assert.AreEqual (expected.Z, actual.Z, 0.001, message + " (Z)");
 	}
 
 	public static void AreEqual (Vector4 expected, Vector4 actual, string message)

--- a/tests/monotouch-test/Contacts/ContactTest.cs
+++ b/tests/monotouch-test/Contacts/ContactTest.cs
@@ -45,7 +45,8 @@ namespace MonoTouchFixtures.Contacts {
 			// the output is opaque and an internal type
 			// note: this is not very robust - but I want to know if this changes during the next betas
 			Assert.True (keys.Description.StartsWith ("<CNAggregateKeyDescriptor:", StringComparison.Ordinal), "type");
-			Assert.True (keys.Description.Contains ("kind=Formatter style: 1002"), "kind");
+			Assert.True (keys.Description.Contains (" kind=Formatter "), "kind");
+			Assert.True (keys.Description.Contains (" style: 100"), "style"); // 1002 before iOS 10, 1003 after
 		}
 
 		[Test]

--- a/tests/monotouch-test/CoreLocation/BeaconRegionTest.cs
+++ b/tests/monotouch-test/CoreLocation/BeaconRegionTest.cs
@@ -40,7 +40,7 @@ namespace MonoTouchFixtures.CoreLocation {
 				Assert.Null (br.Major, "Major");
 				Assert.Null (br.Minor, "Minor");
 				Assert.False (br.NotifyEntryStateOnDisplay, "NotifyEntryStateOnDisplay");
-				Assert.AreSame (uuid, br.ProximityUuid, "ProximityUuid");
+				Assert.That (uuid.AsString (), Is.EqualTo (br.ProximityUuid.AsString ()), "ProximityUuid");
 				// CLRegion
 				Assert.That (br.Identifier, Is.EqualTo ("identifier"), "identifier");
 				Assert.True (br.NotifyOnEntry, "NotifyOnEntry");
@@ -60,7 +60,7 @@ namespace MonoTouchFixtures.CoreLocation {
 				Assert.That (br.Major.Int32Value, Is.EqualTo (0), "Major");
 				Assert.Null (br.Minor, "Minor");
 				Assert.False (br.NotifyEntryStateOnDisplay, "NotifyEntryStateOnDisplay");
-				Assert.AreSame (uuid, br.ProximityUuid, "ProximityUuid");
+				Assert.That (uuid.AsString (), Is.EqualTo (br.ProximityUuid.AsString ()), "ProximityUuid");
 				// CLRegion
 				Assert.That (br.Identifier, Is.EqualTo ("identifier"), "identifier");
 				Assert.True (br.NotifyOnEntry, "NotifyOnEntry");
@@ -79,7 +79,7 @@ namespace MonoTouchFixtures.CoreLocation {
 				Assert.That (br.Major.Int32Value, Is.EqualTo (2), "Major");
 				Assert.That (br.Minor.Int32Value, Is.EqualTo (3), "Minor");
 				Assert.False (br.NotifyEntryStateOnDisplay, "NotifyEntryStateOnDisplay");
-				Assert.AreSame (uuid, br.ProximityUuid, "ProximityUuid");
+				Assert.That (uuid.AsString (), Is.EqualTo (br.ProximityUuid.AsString ()), "ProximityUuid");
 				// CLRegion
 				Assert.That (br.Identifier, Is.EqualTo ("identifier"), "identifier");
 				Assert.True (br.NotifyOnEntry, "NotifyOnEntry");

--- a/tests/monotouch-test/MapKit/MapRectTest.cs
+++ b/tests/monotouch-test/MapKit/MapRectTest.cs
@@ -42,7 +42,10 @@ namespace MonoTouchFixtures.MapKit {
 		{
 			MKMapRect rect = new MKMapRect ();
 			MKMapPoint point = new MKMapPoint ();
-			Assert.False (rect.Contains (point), "default");
+			if (UIDevice.CurrentDevice.CheckSystemVersion (10, 0))
+				Assert.True (rect.Contains (point), "default");
+			else
+				Assert.False (rect.Contains (point), "default");
 		}
 
 		[Test]

--- a/tests/monotouch-test/MapKit/PinAnnotationViewTest.cs
+++ b/tests/monotouch-test/MapKit/PinAnnotationViewTest.cs
@@ -60,7 +60,10 @@ namespace MonoTouchFixtures.MapKit {
 				if (!UIDevice.CurrentDevice.CheckSystemVersion (9, 0))
 					return;
 				Assert.That (av.PinColor, Is.EqualTo (MKPinAnnotationColor.Red), "PinColor");
-				Assert.Null (av.PinTintColor, "PinTintColor"); // differs from the other init call
+				if (UIDevice.CurrentDevice.CheckSystemVersion (10,0))
+					Assert.That (av.PinTintColor, Is.EqualTo (UIColor.FromRGBA (255, 59, 48, 255)), "PinTintColor");
+				else
+					Assert.Null (av.PinTintColor, "PinTintColor"); // differs from the other init call
 			}
 		}
 	}

--- a/tests/monotouch-test/Security/KeyTest.cs
+++ b/tests/monotouch-test/Security/KeyTest.cs
@@ -170,8 +170,13 @@ namespace MonoTouchFixtures.Security {
 				Assert.That (public_key.RawVerify (SecPadding.PKCS1SHA1, hash, sign), Is.EqualTo (SecStatusCode.Success), "RawVerify");
 
 				var empty = new byte [0];
-				Assert.That (private_key.RawSign (SecPadding.PKCS1SHA1, empty, out sign), Is.EqualTo (SecStatusCode.Param), "RawSign-empty");
-				Assert.That (public_key.RawVerify (SecPadding.PKCS1SHA1, empty, empty), Is.EqualTo (SecStatusCode.Param), "RawVerify-empty");
+				if (UIDevice.CurrentDevice.CheckSystemVersion (10, 0)) {
+					Assert.That (private_key.RawSign (SecPadding.PKCS1SHA1, empty, out sign), Is.EqualTo (SecStatusCode.Success), "RawSign-empty");
+					Assert.That (public_key.RawVerify (SecPadding.PKCS1SHA1, empty, empty), Is.EqualTo (SecStatusCode.Success), "RawVerify-empty");
+				} else {
+					Assert.That (private_key.RawSign (SecPadding.PKCS1SHA1, empty, out sign), Is.EqualTo (SecStatusCode.Param), "RawSign-empty");
+					Assert.That (public_key.RawVerify (SecPadding.PKCS1SHA1, empty, empty), Is.EqualTo (SecStatusCode.Param), "RawVerify-empty");
+				}
 
 				private_key.Dispose ();
 				public_key.Dispose ();
@@ -198,8 +203,12 @@ namespace MonoTouchFixtures.Security {
 				var empty = new byte [0];
 				// there does not seem to be a length-check on PKCS1, likely because not knowning the hash algorithm makes it harder
 				Assert.That (private_key.RawSign (SecPadding.PKCS1, empty, out sign), Is.EqualTo (SecStatusCode.Success), "RawSign-empty");
-				// but that does not work at verification time
-				Assert.That (public_key.RawVerify (SecPadding.PKCS1, empty, empty), Is.EqualTo ((SecStatusCode)(-9809)), "RawVerify-empty");
+				if (UIDevice.CurrentDevice.CheckSystemVersion (10, 0)) {
+					Assert.That (public_key.RawVerify (SecPadding.PKCS1, empty, empty), Is.EqualTo (SecStatusCode.Success), "RawVerify-empty");
+				} else {
+					// but that does not work at verification time
+					Assert.That (public_key.RawVerify (SecPadding.PKCS1, empty, empty), Is.EqualTo ((SecStatusCode)(-9809)), "RawVerify-empty");
+				}
 
 				private_key.Dispose ();
 				public_key.Dispose ();

--- a/tests/monotouch-test/Security/PolicyTest.cs
+++ b/tests/monotouch-test/Security/PolicyTest.cs
@@ -137,17 +137,17 @@ namespace MonoTouchFixtures.Security {
 			}
 		}
 
-		void CreatePolicy (NSString oid)
+		void CreatePolicy (NSString oid, NSString propertyOid = null)
 		{
 			string name = oid + ".";
 			using (var policy = SecPolicy.CreatePolicy (oid, null)) {
 				Assert.That (CFGetRetainCount (policy.Handle), Is.EqualTo ((nint) 1), name + "RetainCount");
-				Assert.That (policy.GetProperties ().Values [0], Is.EqualTo (oid), name + "SecPolicyOid");
+				Assert.That (policy.GetProperties ().Values [0], Is.EqualTo (propertyOid ?? oid), name + "SecPolicyOid");
 			}
 		}
 
 		[Test]
-		public void CreatWellKnownPolicies ()
+		public void CreateWellKnownPolicies ()
 		{
 			if (!TestRuntime.CheckSystemAndSDKVersion (7, 0))
 				Assert.Inconclusive ("requires iOS7");
@@ -159,7 +159,8 @@ namespace MonoTouchFixtures.Security {
 			// CreatePolicy (SecPolicyIdentifier.AppleEAP);
 			CreatePolicy (SecPolicyIdentifier.AppleIPsec);
 			CreatePolicy (SecPolicyIdentifier.AppleCodeSigning);
-			CreatePolicy (SecPolicyIdentifier.AppleIDValidation);
+			var oid = UIDevice.CurrentDevice.CheckSystemVersion (10, 0) ? "1.2.840.113635.100.1.61" : null; 
+			CreatePolicy (SecPolicyIdentifier.AppleIDValidation, (NSString) oid);
 			// invalid handle ? not yet supported ?!?
 			// CreatePolicy (SecPolicyIdentifier.AppleTimeStamping);
 			CreatePolicy (SecPolicyIdentifier.AppleRevocation);


### PR DESCRIPTION
* Adjust ever changing AddressFormatingTest for iOS 10, which does
  not output the country;

* Adjust Contact's ICNKeyDescriptor internal check;

* CLBeaconRegion.ProximityUuid does not return the original instance
  anymore, but a different one with the same uuid;

* Add a small delta for Vector3 comparison in ModelIO tests;

* Adjust MapKit tests for pin color change and MapRect corner case;

* SecKeyTest with corner cases now pass (they failed before);

* SecPolicyIdentifier.AppleIDValidation does not report the OID it's
  created from (migration?)

Note: some might be bugs that Apple will fix in later seeds