### PR TITLE
[tests][link sdk] Exclude CFNetwork test from watchOS

### DIFF
--- a/tests/linker-ios/link sdk/HttpClientHandlerTest.cs
+++ b/tests/linker-ios/link sdk/HttpClientHandlerTest.cs
@@ -40,6 +40,7 @@ namespace LinkSdk.Net.Http {
 			}
 		}
 
+#if !__WATCHOS__
 		[Test]
 		public void CFNetwork ()
 		{
@@ -50,6 +51,7 @@ namespace LinkSdk.Net.Http {
 				Assert.False (handler.UseSystemProxy, "UseSystemProxy");
 			}
 		}
+#endif
 
 		[Test]
 		public void NSUrlSession ()


### PR DESCRIPTION
- framework not supported on watchOS
- fix build of "link sdk" under watchOS