### PR TITLE
[API] Add a new Capture method to the UIView

### DIFF
--- a/src/UIKit/UIView.cs
+++ b/src/UIKit/UIView.cs
@@ -176,6 +176,20 @@ namespace XamCore.UIKit {
 		{
 			return AnimateNotifyAsync (duration, animation);
 		}
+
+		public UIImage Capture (bool afterScreenUpdates = true)
+		{
+			UIImage snapshot = null;
+			var bounds = Bounds; // try to access objc the smalles amount of times.
+			try {
+				UIGraphics.BeginImageContextWithOptions (bounds.Size, Opaque, 0.0f);
+				DrawViewHierarchy (bounds, afterScreenUpdates);
+				snapshot = UIGraphics.GetImageFromCurrentImageContext ();
+			} finally {
+				UIGraphics.EndImageContext ();
+			}
+			return snapshot;
+		}
 	}
 }
 


### PR DESCRIPTION
The new capture method allows to create a screenshot of the contents of the UIView and store them in a UIImage. The afterUpdates follows the same logic used in DrawViewHierarchy:

> A Boolean value that indicates whether the snapshot should be rendered after recent changes have been incorporated. Specify the value NO if you want to render a snapshot in the view hierarchy’s current state, which might not include recent changes.

I'm curious regarding the default value of the parameters, comments are welcome about it.