### PR TITLE
Build with path to the exact SDK version. Fixes #41597.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -190,11 +190,11 @@ XAMARIN_IPHONEOS_SDK     = $(MONOTOUCH_DEVICE_SDK)
 XAMARIN_WATCHSIMULATOR_SDK = $(MONOTOUCH_PREFIX)/SDKs/Xamarin.WatchSimulator.sdk
 XAMARIN_WATCHOS_SDK        = $(MONOTOUCH_PREFIX)/SDKs/Xamarin.WatchOS.sdk
 
-SIMULATORWATCH_SDK         = $(XCODE_DEVELOPER_ROOT)/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator.sdk
+SIMULATORWATCH_SDK         = $(XCODE_DEVELOPER_ROOT)/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator$(WATCH_SDK_VERSION).sdk
 SIMULATORWATCH_CFLAGS      = -arch i386 -mwatchos-simulator-version-min=$(MIN_WATCHOS_SDK_VERSION) -isysroot $(SIMULATORWATCH_SDK) $(CFLAGS) -g $(IOS_COMMON_DEFINES)
 SIMULATORWATCH_OBJC_CFLAGS = $(SIMULATORWATCH_CFLAGS) $(COMMON_SIMULATOR_OBJC_CFLAGS) 
 
-DEVICEWATCH_SDK         = $(XCODE_DEVELOPER_ROOT)/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk
+DEVICEWATCH_SDK         = $(XCODE_DEVELOPER_ROOT)/Platforms/WatchOS.platform/Developer/SDKs/WatchOS$(WATCH_SDK_VERSION).sdk
 DEVICEWATCH_CFLAGS      = -arch armv7k -mwatchos-version-min=$(MIN_WATCHOS_SDK_VERSION) -isysroot $(DEVICEWATCH_SDK) $(CFLAGS) -fembed-bitcode $(IOS_COMMON_DEFINES)
 DEVICEWATCH_OBJC_CFLAGS = $(DEVICEWATCH_CFLAGS) $(DEVICE_OBJC_CFLAGS)
 
@@ -203,11 +203,11 @@ DEVICEWATCH_OBJC_CFLAGS = $(DEVICEWATCH_CFLAGS) $(DEVICE_OBJC_CFLAGS)
 XAMARIN_TVSIMULATOR_SDK    = $(MONOTOUCH_PREFIX)/SDKs/Xamarin.AppleTVSimulator.sdk
 XAMARIN_TVOS_SDK           = $(MONOTOUCH_PREFIX)/SDKs/Xamarin.AppleTVOS.sdk
 
-SIMULATORTV_SDK            = $(XCODE_DEVELOPER_ROOT)/Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator.sdk
+SIMULATORTV_SDK            = $(XCODE_DEVELOPER_ROOT)/Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator$(TVOS_SDK_VERSION).sdk
 SIMULATORTV_CFLAGS         = -arch x86_64 -mtvos-simulator-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(SIMULATORTV_SDK) $(CFLAGS) -g $(IOS_COMMON_DEFINES)
 SIMULATORTV_OBJC_CFLAGS    = $(SIMULATORTV_CFLAGS) $(COMMON_SIMULATOR_OBJC_CFLAGS) 
 
-DEVICETV_SDK               = $(XCODE_DEVELOPER_ROOT)/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk
+DEVICETV_SDK               = $(XCODE_DEVELOPER_ROOT)/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS$(TVOS_SDK_VERSION).sdk
 DEVICETV_CFLAGS            = -arch arm64 -mtvos-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(DEVICETV_SDK) $(CFLAGS) -fembed-bitcode $(IOS_COMMON_DEFINES)
 DEVICETV_OBJC_CFLAGS       = $(DEVICETV_CFLAGS) $(DEVICE_OBJC_CFLAGS)
 

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -917,7 +917,7 @@ install-iphonesimulator:: $(IPHONESIMULATOR_TARGETS)
 # Watch simulator build
 #
 
-WATCHSIMULATOR_SDK      = $(XCODE_DEVELOPER_ROOT)/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator.sdk
+WATCHSIMULATOR_SDK      = $(SIMULATORWATCH_SDK)
 WATCHSIMULATOR_BIN_PATH = $(XCODE_DEVELOPER_ROOT)/Platforms/WatchSimulator.platform/Developer/usr/bin
 WATCHSIMULATOR_CC       = $(IOS_CC)
 
@@ -1053,7 +1053,7 @@ install-watchsimulator: $(WATCHSIMULATOR_TARGETS)
 # TV simulator build
 #
 
-TVSIMULATOR_SDK      = $(XCODE_DEVELOPER_ROOT)/Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator.sdk
+TVSIMULATOR_SDK      = $(SIMULATORTV_SDK)
 TVSIMULATOR_BIN_PATH = $(XCODE_DEVELOPER_ROOT)/Platforms/AppleTVSimulator.platform/Developer/usr/bin
 TVSIMULATOR_CC       = $(IOS_CC)
 TVOS_BIN_PATH        = $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin
@@ -1192,9 +1192,8 @@ install-tvsimulator: $(TVSIMULATOR_TARGETS)
 # we end up with a sizeof-compatible built (since all current arms are 32b)
 #
 
-PLATFORM_ROOT=$(XCODE_DEVELOPER_ROOT)/Platforms/iPhoneOS.platform
 PLATFORM_BIN=$(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin
-PLATFORM_SDK=$(PLATFORM_ROOT)/Developer/SDKs/iPhoneOS${IOS_SDK_VERSION}.sdk/
+PLATFORM_SDK=$(DEVICE_SDK)
 
 # usage $(call PlatformBuildTemplate (armv7,target7,<platform suffix>,<configure flags>,<unused>))
 
@@ -1409,7 +1408,7 @@ install-iphoneos:: $(IPHONEOS_TARGETS)
 # Watch device build
 # 
 
-WATCHOS_SDK      = $(XCODE_DEVELOPER_ROOT)/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk
+WATCHOS_SDK      = $(DEVICEWATCH_SDK)
 WATCHOS_BIN_PATH = $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin
 WATCHOS_CC       = $(IOS_CC)
 
@@ -1580,7 +1579,7 @@ install-watchos: $(WATCHOS_TARGETS)
 # TV device build
 # 
 
-TVOS_SDK      = $(XCODE_DEVELOPER_ROOT)/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk
+TVOS_SDK      = $(DEVICETV_SDK)
 TVOS_BIN_PATH = $(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/bin
 TVOS_CC       = $(IOS_CC)
 


### PR DESCRIPTION
If no sdk version (-sdk_version) is passed to the native
linker, it tries to infer the SDK version from the
path to the -syslibroot argument.

In our case we use a versioned path to Xcode, but a general
symlink without the SDK version:

/Applications/Xcode73.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk

which means ld picked up the Xcode version as the SDK version,
since that's the first number part of the path [1], so we'd
end up with libraries whose SDK version was 73.

So instead use an SDK path with the SDK version, so that ld
finds the SDK version instead of the Xcode version.

[1] https://github.com/rolfbjarne/ld64/blob/266f4401b94ee73be4f4c18a0a220110c7fe71f0/src/ld/Options.cpp#L4005-L4020

https://bugzilla.xamarin.com/show_bug.cgi?id=41597