### PR TITLE
[registrar] Managed characters are equivalent to shorts in native code.

### DIFF
--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -2066,7 +2066,7 @@ namespace XamCore.Registrar {
 			case "System.IntPtr": return "^v";
 			case "System.SByte": return "c";
 			case "System.Byte": return "C";
-			case "System.Char": return "c";
+			case "System.Char": return "s";
 			case "System.Int16": return "s";
 			case "System.UInt16": return "S";
 			case "System.Int32": return "i";

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -1334,7 +1334,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			var cl = new Class (typeof (TestTypeEncodingsClass));
 			var sig = Runtime.GetNSObject<NSMethodSignature> (Messaging.IntPtr_objc_msgSend_IntPtr (cl.Handle, Selector.GetHandle ("methodSignatureForSelector:"), Selector.GetHandle ("foo::::::::::::::::")));
 			var boolEncoding = IntPtr.Size == 8 ? "B" : "c";
-			var exp = new string [] { "@", ":", "^v", "C", "c", "c", "s", "S", "i", "I", "q", "Q", "f", "d", boolEncoding, "@", ":", "#" };
+			var exp = new string [] { "@", ":", "^v", "C", "c", "s", "s", "S", "i", "I", "q", "Q", "f", "d", boolEncoding, "@", ":", "#" };
 
 			Assert.AreEqual (exp.Length, sig.NumberOfArguments, "NumberOfArguments");
 //			for (uint i = 0; i < exp.Length; i++) {

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -432,7 +432,7 @@ namespace XamCore.Registrar {
 			case "System.IntPtr": return "void *";
 			case "System.SByte": return "unsigned char";
 			case "System.Byte": return "signed char";
-			case "System.Char": return "signed char";
+			case "System.Char": return "signed short";
 			case "System.Int16": return "short";
 			case "System.UInt16": return "unsigned short";
 			case "System.Int32": return "int";
@@ -572,7 +572,7 @@ namespace XamCore.Registrar {
 		public static int GetValueTypeSize (TypeDefinition type, bool is_64_bits)
 		{
 			switch (type.FullName) {
-				case "System.Char":
+				case "System.Char": return 2;
 				case "System.Boolean":
 				case "System.SByte":
 				case "System.Byte": return 1;
@@ -1811,8 +1811,8 @@ namespace XamCore.Registrar {
 		{
 			switch (structure.FullName) {
 			case "System.Char":
-				name.Append ('c');
-				body.AppendLine ("char v{0};", size);
+				name.Append ('s');
+				body.AppendLine ("short v{0};", size);
 				size += 1;
 				break;
 			case "System.Boolean": // map managed 'bool' to ObjC BOOL
@@ -1941,7 +1941,7 @@ namespace XamCore.Registrar {
 			case "System.IntPtr": return "void *";
 			case "System.SByte": return "signed char";
 			case "System.Byte": return "unsigned char";
-			case "System.Char": return "signed char";
+			case "System.Char": return "signed short";
 			case "System.Int16": return "short";
 			case "System.UInt16": return "unsigned short";
 			case "System.Int32": return "int";


### PR DESCRIPTION
Fixes NSCharacterSetTest.NSMutableCharacterSet_TestStaticSets when
running with the P/Invoke wrapper (for exceptions) enabled (i.e.
watchOS), since otherwise the wrapper would truncate char parameters
to byte.