### PR TITLE
[tvos] Fix introspection tests for tvOS

### DIFF
--- a/src/tvmlkit.cs
+++ b/src/tvmlkit.cs
@@ -726,7 +726,10 @@ namespace XamCore.TVMLKit {
 		string AutoHighlightIdentifier { get; }
 
 		[Export ("disabled")]
-		bool Disabled { [Bind ("isDisabled")] get; set; }
+		bool Disabled {
+			[Bind ("isDisabled")] get;
+			[NotImplemented] set; // made read-only in 10.0
+		}
 
 		[Export ("updateType")]
 		TVElementUpdateType UpdateType { get; }

--- a/tests/introspection/iOS/iOSApiCtorInitTest.cs
+++ b/tests/introspection/iOS/iOSApiCtorInitTest.cs
@@ -295,7 +295,7 @@ namespace Introspection {
 			case "AVAudioSessionPortDescription":
 			case "CLBeacon":
 			case "CLCircularRegion":
-				if (CheckiOSSystemVersion (10, 0))
+				if (CheckiOSOrTVOSSystemVersion (10, 0))
 					return;
 				break;
 			default:


### PR DESCRIPTION
Wrong check for version

[FAIL] Default constructor not allowed for CoreLocation.CLCircularRegion : Can only check iOS system version on iOS.
[FAIL] Default constructor not allowed for AVFoundation.AVAudioSessionDataSourceDescription : Can only check iOS system version on iOS.
[FAIL] Default constructor not allowed for AVFoundation.AVAudioSessionPortDescription : Can only check iOS system version on iOS.

and a change in tvOS 10 SDK

[FAIL] Selector not found for TVMLKit.TVViewElement : setDisabled: