### PR TITLE
Add a nuget config file to ensure we have a valid feed.

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<packageSources>
+		<add key="Nuget Official" value ="https://www.nuget.org/api/v2/" />
+	</packageSources>
+</configuration>
+


### PR DESCRIPTION
This will hopefully fix a random build problem on some machines:

[5:14:32] cat ~/.config/NuGet/NuGet.Config || true
[5:14:32] <?xml version="1.0" encoding="utf-8"?>
[5:14:32] <configuration>
[5:14:32]   <packageSources>
[5:14:32]     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
[5:14:32]   </packageSources>
[5:14:32] </configuration>
[5:14:32] Targets files are valid XML
[5:14:33] Installing 'NUnit.Runners 2.6.4'.
[5:14:33] Installing 'NUnit 2.6.4'.
[5:14:33] Installing 'Newtonsoft.Json 6.0.8'.
[5:14:33] Successfully installed 'NUnit 2.6.4'.
[5:14:33] Successfully installed 'Newtonsoft.Json 6.0.8'.
[5:14:33] Successfully installed 'NUnit.Runners 2.6.4'.
[5:14:33] Unable to find version '0.9.5' of package 'Mono.Cecil'.