### PR TITLE
[externalaccessory] Small update for iOS 10 beta 1

### DIFF
--- a/src/externalaccessory.cs
+++ b/src/externalaccessory.cs
@@ -158,7 +158,6 @@ namespace XamCore.ExternalAccessory {
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(EAWiFiUnconfiguredAccessoryBrowserDelegate)})]
 	interface EAWiFiUnconfiguredAccessoryBrowser {
 
-		[DesignatedInitializer]
 		[Export ("initWithDelegate:queue:")]
 		IntPtr Constructor ([NullAllowed] IEAWiFiUnconfiguredAccessoryBrowserDelegate accessoryBrowserDelegate, [NullAllowed] DispatchQueue queue);
 


### PR DESCRIPTION
reference:
!extra-designated-initializer! EAWiFiUnconfiguredAccessoryBrowser::initWithDelegate:queue: is incorrectly decorated with an [DesignatedInitializer] attribute