### PR TITLE
[uikit] Fix new UICollectionViewDataSourcePrefetching and UIContentSizeCategoryAdjusting protocols

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -2886,7 +2886,6 @@ namespace XamCore.UIKit {
 
 	[iOS (10,0)]
 	[Protocol]
-	[BaseType (typeof(NSObject))]
 	public interface UIContentSizeCategoryAdjusting
 	{
 		[Abstract]
@@ -3627,7 +3626,6 @@ namespace XamCore.UIKit {
 	interface IUICollectionViewDataSourcePrefetching {}
 	
 	[Protocol]
-	[BaseType (typeof(NSObject))]
 	interface UICollectionViewDataSourcePrefetching
 	{
 		[iOS (10,0)]

--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -299,7 +299,7 @@ namespace Introspection {
 
 					var klass = new Class (t);
 					if (klass.Handle == IntPtr.Zero) {
-						AddErrorLine ("Could not load {0}", t.FullName);
+						AddErrorLine ("[FAIL] Could not load {0}", t.FullName);
 					} else if (t.IsPublic && !ConformTo (klass.Handle, protocol)) {
 						// note: some internal types, e.g. like UIAppearance subclasses, return false (and there's not much value in changing this)
 						ReportError ("Type {0} (native: {1}) does not conform {2}", t.FullName, klass.Name, protocolName);


### PR DESCRIPTION
The two later failure reports (references) were not prefixed with [FAIL]
so they were filtered out by in the bot results.

references:
	[FAIL] iOSApiProtocolTest.ApiProtocolTest.GeneralCase : 2 types do not really conform to the protocol interfaces
[FAIL] Could not load UIKit.UICollectionViewDataSourcePrefetching
[FAIL] Could not load UIKit.UIContentSizeCategoryAdjusting