### PR TITLE
[NS(mutable)Dictionary] Fixes bug 41343 NSDictionary<TKey, TValue>.FromObjectsAndKeys keys and values are twisted up

### DIFF
--- a/src/Foundation/NSDictionary_2.cs
+++ b/src/Foundation/NSDictionary_2.cs
@@ -147,7 +147,28 @@ namespace XamCore.Foundation {
 			return Runtime.GetNSObject<NSDictionary<TKey,TValue>> (_FromObjectsAndKeysInternal (objects.Handle, keys.Handle));
 		}
 
-		public static NSDictionary<TKey,TValue> FromObjectsAndKeys (TKey [] objects, TValue [] keys)
+		public static NSDictionary<TKey, TValue> FromObjectsAndKeys (TValue [] objects, TKey [] keys, nint count)
+		{
+			if (objects == null)
+				throw new ArgumentNullException (nameof (objects));
+			if (keys == null)
+				throw new ArgumentNullException (nameof (keys));
+			if (objects.Length != keys.Length)
+				throw new ArgumentException (nameof (objects) + " and " + nameof (keys) + " arrays have different sizes");
+			if (count < 1 || objects.Length < count)
+				throw new ArgumentException (nameof (count));
+
+			using (var no = NSArray.FromNativeObjects (objects, count))
+			using (var nk = NSArray.FromNativeObjects (keys, count))
+				return GenericFromObjectsAndKeysInternal (no, nk);
+		}
+
+#if XAMCORE_4_0
+		public static NSDictionary<TKey, TValue> FromObjectsAndKeys (TValue [] objects, TKey [] keys)
+#else
+		[Obsolete ("TKey and TValue are inversed and won't work unless both types are identical. Use the generic overload that takes a count parameter instead")]
+		public static NSDictionary<TKey, TValue> FromObjectsAndKeys (TKey [] objects, TValue [] keys)
+#endif
 		{
 			if (objects == null)
 				throw new ArgumentNullException (nameof (objects));

--- a/src/Foundation/NSMutableDictionary_2.cs
+++ b/src/Foundation/NSMutableDictionary_2.cs
@@ -211,7 +211,28 @@ namespace XamCore.Foundation {
 			return Runtime.GetNSObject<NSMutableDictionary<TKey,TValue>> (_FromObjectsAndKeysInternal (objects.Handle, keys.Handle));
 		}
 
-		public static NSMutableDictionary<TKey,TValue> FromObjectsAndKeys (TKey [] objects, TValue [] keys)
+		public static NSMutableDictionary<TKey, TValue> FromObjectsAndKeys (TValue [] objects, TKey [] keys, nint count)
+		{
+			if (objects == null)
+				throw new ArgumentNullException (nameof (objects));
+			if (keys == null)
+				throw new ArgumentNullException (nameof (keys));
+			if (objects.Length != keys.Length)
+				throw new ArgumentException (nameof (objects) + " and " + nameof (keys) + " arrays have different sizes");
+			if (count < 1 || objects.Length < count)
+				throw new ArgumentException (nameof (count));
+
+			using (var no = NSArray.FromNSObjects (objects))
+			using (var nk = NSArray.FromNSObjects (keys))
+				return GenericFromObjectsAndKeysInternal (no, nk);
+		}
+
+#if XAMCORE_4_0
+		public static NSMutableDictionary<TKey, TValue> FromObjectsAndKeys (TValue [] objects, TKey [] keys)
+#else
+		[Obsolete ("TKey and TValue are inversed and won't work unless both types are identical. Use the generic overload that takes a count parameter instead")]
+		public static NSMutableDictionary<TKey, TValue> FromObjectsAndKeys (TKey [] objects, TValue [] keys)
+#endif
 		{
 			if (objects == null)
 				throw new ArgumentNullException (nameof (objects));

--- a/tests/monotouch-test/Foundation/NSDictionary2Test.cs
+++ b/tests/monotouch-test/Foundation/NSDictionary2Test.cs
@@ -70,6 +70,30 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
+		public void FromObjectsAndKeysGenericTest ()
+		{
+			var keys = new [] {
+				new NSString ("Key1"),
+				new NSString ("Key2"),
+				new NSString ("Key3"),
+				new NSString ("Key4"),
+				new NSString ("Key5"),
+			};
+			var values = new [] {
+				NSNumber.FromByte (0x1),
+				NSNumber.FromFloat (8.5f),
+				NSNumber.FromDouble (10.5),
+				NSNumber.FromInt32 (42),
+				NSNumber.FromBoolean (true),
+			};
+
+			var dict = NSDictionary<NSString, NSNumber>.FromObjectsAndKeys (values, keys, values.Length);
+			Assert.AreEqual (dict.Count, 5, "count");
+			for (int i = 0; i < values.Length; i++)
+				Assert.AreEqual (dict [keys [i]], values [i], $"key lookup, Iteration: {i}");
+		}
+
+		[Test]
 		public void KeyValue_Autorelease ()
 		{
 			using (var k = new NSString ("keyz")) 

--- a/tests/monotouch-test/Foundation/NSMutableDictionary2Test.cs
+++ b/tests/monotouch-test/Foundation/NSMutableDictionary2Test.cs
@@ -44,6 +44,30 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
+		public void FromObjectsAndKeysGenericTest ()
+		{
+			var keys = new [] {
+				new NSString ("Key1"),
+				new NSString ("Key2"),
+				new NSString ("Key3"),
+				new NSString ("Key4"),
+				new NSString ("Key5"),
+			};
+			var values = new [] {
+				NSNumber.FromByte (0x1),
+				NSNumber.FromFloat (8.5f),
+				NSNumber.FromDouble (10.5),
+				NSNumber.FromInt32 (42),
+				NSNumber.FromBoolean (true),
+			};
+
+			var dict = NSMutableDictionary<NSString, NSNumber>.FromObjectsAndKeys (values, keys, values.Length);
+			Assert.AreEqual (dict.Count, 5, "count");
+			for (int i = 0; i < values.Length; i++)
+				Assert.AreEqual (dict [keys [i]], values [i], $"key lookup, Iteration: {i}");
+		}
+
+		[Test]
 		public void KeyValue_Autorelease ()
 		{
 			using (var k = new NSString ("keyz")) 


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=41343

* NSDictionary<TKey, TValue>.FromObjectsAndKeys keys and values are twisted up
* Fixed it in XAMCORE_4_0
* Obsoleted the 2 existing methods
* introduced FromObjectsAndKeys (TValue [] objects, TKey [] keys, nint count)
* Added unit tests with different types for TKey and TValue