### PR TITLE
[watchconnectivity] Small update for iOS 10 beta 1

### DIFF
--- a/src/watchconnectivity.cs
+++ b/src/watchconnectivity.cs
@@ -95,6 +95,14 @@ namespace XamCore.WatchConnectivity {
 		[Watch (2,2)][iOS (9, 3)]
 		[Export ("activationState")]
 		WCSessionActivationState ActivationState { get; }
+
+		[Watch (3,0)][iOS (10,0)]
+		[Export ("hasContentPending")]
+		bool HasContentPending { get; }
+
+		[NoWatch][iOS (10,0)]
+		[Export ("remainingComplicationUserInfoTransfers")]
+		nuint RemainingComplicationUserInfoTransfers { get; }
 	}
 
 	interface IWCSessionDelegate { }
@@ -139,14 +147,23 @@ namespace XamCore.WatchConnectivity {
 		[Export ("session:didReceiveFile:")]
 		void DidReceiveFile (WCSession session, WCSessionFile file);
 
+#if XAMCORE_4_0
+		[Abstract] // OS 10 beta 1 SDK made this required
+#endif
 		[Watch (2,2)][iOS (9,3)]
 		[Export ("session:activationDidCompleteWithState:error:")]
 		void ActivationDidComplete (WCSession session, WCSessionActivationState activationState, [NullAllowed] NSError error);
 
+#if XAMCORE_4_0
+		[Abstract] // OS 10 beta 1 SDK made this required
+#endif
 		[NoWatch][iOS (9,3)]
 		[Export ("sessionDidBecomeInactive:")]
 		void DidBecomeInactive (WCSession session);
 
+#if XAMCORE_4_0
+		[Abstract] // OS 10 beta 1 SDK made this required
+#endif
 		[NoWatch][iOS (9,3)]
 		[Export ("sessionDidDeactivate:")]
 		void DidDeactivate (WCSession session);

--- a/tests/xtro-sharpie/ios.ignore
+++ b/tests/xtro-sharpie/ios.ignore
@@ -58,6 +58,15 @@
 !missing-selector! UIToolbar::setTintColor: not bound
 !missing-selector! UIToolbar::tintColor not bound
 
+
+# WatchConnectivity
+
+## They were _upgraded_ to required in iOS 10 beta 1
+!incorrect-protocol-member! WCSessionDelegate::session:activationDidCompleteWithState:error: is REQUIRED and should be abstract
+!incorrect-protocol-member! WCSessionDelegate::sessionDidBecomeInactive: is REQUIRED and should be abstract
+!incorrect-protocol-member! WCSessionDelegate::sessionDidDeactivate: is REQUIRED and should be abstract
+
+
 ## methods are [Sealed] so we can't reflect the selector
 ### Docs: This method is intended to be called, not overridden.
 !missing-selector! UIGestureRecognizer::ignorePress:forEvent: not bound

--- a/tests/xtro-sharpie/watchos.ignore
+++ b/tests/xtro-sharpie/watchos.ignore
@@ -31,6 +31,12 @@
 !missing-selector! UIImageDeprecated::topCapHeight not bound
 
 
+# WatchConnectivity
+
+## It was _upgraded_ to required in iOS 10 beta 1
+!incorrect-protocol-member! WCSessionDelegate::session:activationDidCompleteWithState:error: is REQUIRED and should be abstract
+
+
 # Apple internals (we do not expose them)
 
 !missing-field! _NSConstantStringClassReference not bound


### PR DESCRIPTION
WCSessionDelegate members added in iOS 9.3 were turned into **required**
members in iOS 10 (beta 1). That's a breaking change so it's only enabled
for XAMCORE_4_0