### PR TITLE
[msbuild] Reorder imports for F# watchOS extensions so that it compiles correctly.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.FSharp.targets
@@ -27,8 +27,8 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 
 		<DefineConstants>__UNIFIED__;__MOBILE__;__WATCHOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
-	<Import Project="Xamarin.WatchOS.AppExtension.Common.targets" />
 	<Import Project="$(FSharpTargets)" />
+	<Import Project="Xamarin.WatchOS.AppExtension.Common.targets" />
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>


### PR DESCRIPTION
Otherwise extensions would just compile like a normal .NET class library
project and produce a .dll.