### PR TITLE
[mtouch] Quote the .dylib used for incremental builds. Fixes #42006

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1900,7 +1900,7 @@ namespace Xamarin.Bundler {
 			if (!App.EnableMarkerOnlyBitCode)
 				flags.AddOtherFlag ("-read_only_relocs suppress");
 			flags.LinkWithMono ();
-			flags.AddOtherFlag ($"-install_name @executable_path/{install_name}");
+			flags.AddOtherFlag ("-install_name " + Driver.Quote ($"@executable_path/{install_name}"));
 			flags.AddOtherFlag ("-fapplication-extension"); // fixes this: warning MT5203: Native linking warning: warning: linking against dylib not safe for use in application extensions: [..]/actionextension.dll.arm64.dylib
 		}
 		

--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -377,7 +377,7 @@ namespace Xamarin.Bundler {
 			var assembly = Path.Combine (build_dir, FileName);
 
 			if (App.FastDev)
-				Dylib = Path.Combine (App.AppDirectory, "lib" + Path.GetFileName (FullPath) + ".dylib");
+				Dylib = Path.Combine (App.AppDirectory, Driver.Quote ("lib" + Path.GetFileName (FullPath) + ".dylib"));
 
 			foreach (var abi in abis) {
 				var task = CreateManagedToAssemblyTasks (assembly, abi, build_dir);


### PR DESCRIPTION
Fix MT3001 AOT errors due to incorrect paths.

https://bugzilla.xamarin.com/show_bug.cgi?id=42006