### PR TITLE
[xharness] Rename variable to fix compiler warning.

### DIFF
--- a/tests/xharness/SimpleHttpListener.cs
+++ b/tests/xharness/SimpleHttpListener.cs
@@ -9,7 +9,7 @@ namespace xharness
 	public class SimpleHttpListener : SimpleListener
 	{
 		HttpListener server;
-		bool connected;
+		bool connected_once;
 
 		public override void Initialize ()
 		{
@@ -78,8 +78,8 @@ namespace xharness
 
 			switch (request.RawUrl) {
 			case "/Start":
-				if (!connected) {
-					connected = true;
+				if (!connected_once) {
+					connected_once = true;
 					Connected (request.RemoteEndPoint.ToString ());
 				}
 				break;


### PR DESCRIPTION
Fixes this warning:

    SimpleHttpListener.cs(12,8): warning CS0108: `xharness.SimpleHttpListener.connected' hides inherited member `xharness.SimpleListener.connected'. Use the new keyword if hiding was intended