### PR TITLE
[registrar] Don't return from trampolines without going through proper state handling code.

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3234,7 +3234,7 @@ namespace XamCore.Registrar {
 				body.WriteLine ("if (exception_gchandle != 0) goto exception_handling;");
 				body.WriteLine ("if (has_nsobject) {");
 				body.WriteLine ("*call_super = true;");
-				body.WriteLine ("return self;");
+				body.WriteLine ("goto exception_handling;");
 				body.WriteLine ("}");
 			}
 


### PR DESCRIPTION
Fixes a COOP crash due to invalid state.