### PR TITLE
[coregraphics] Re-enable CGColorConverterCreateSimple API and tests

### DIFF
--- a/src/CoreGraphics/CGColorConverter.cs
+++ b/src/CoreGraphics/CGColorConverter.cs
@@ -110,21 +110,25 @@ namespace XamCore.CoreGraphics {
 				throw new Exception ("Failed to create CGColorConverter");
 		}
 
-#if false
-		// Apple has not yet (beta 3) provided this API for devices (only works on simulator)
+		// Added in 9.3 but it only works on simulator (not devices). Fixed in iOS 10 beta 1
 		// https://trello.com/c/Rwko9Wef/37-24734681-cgcolorconvertercreatesimple-is-missing-for-device-builds
-
+		[iOS (10,0)]
 		[DllImport(Constants.CoreGraphicsLibrary)]
 		extern static IntPtr CGColorConverterCreateSimple (/* __nullable CGColorSpaceRef */ IntPtr from, /* __nullable CGColorSpaceRef */ IntPtr to);
 
+		[iOS (10,0)]
 		public CGColorConverter (CGColorSpace from, CGColorSpace to)
 		{
-			handle = CGColorConverterCreateSimple (NativeObjectHelper.GetHandle (from), NativeObjectHelper.GetHandle (to));
+			// API accept null arguments but returns null, which we can't use
+			if (from == null)
+				throw new ArgumentNullException (nameof (from));
+			if (from == to)
+				throw new ArgumentNullException (nameof (to));
+			handle = CGColorConverterCreateSimple (from.Handle, to.Handle);
 
 			if (handle == IntPtr.Zero)
 				throw new Exception ("Failed to create CGColorConverter");
 		}
-#endif
 
 		~CGColorConverter ()
 		{

--- a/tests/monotouch-test/CoreGraphics/ColorConverterTest.cs
+++ b/tests/monotouch-test/CoreGraphics/ColorConverterTest.cs
@@ -30,7 +30,8 @@ namespace MonoTouchFixtures.CoreGraphics
 		{
 			TestRuntime.AssertXcodeVersion (7, 3);
 
-			Assert.Throws<ArgumentNullException> (() => new CGColorConverter (null, null), "null");
+			Assert.Throws<ArgumentNullException> (() => new CGColorConverter (null, (CGColorSpace) null), "null");
+			Assert.Throws<ArgumentNullException> (() => new CGColorConverter (null, (CGColorConverterTriple[]) null), "null-2");
 			Assert.Throws<ArgumentNullException> (() => new CGColorConverter (null, new CGColorConverterTriple [0]), "empty");
 		}
 
@@ -99,11 +100,10 @@ namespace MonoTouchFixtures.CoreGraphics
 			Assert.Throws<ArgumentException> (() => new CGColorConverter (null, new CGColorConverterTriple [4]));
 		}
 
-#if false
 		[Test]
 		public void CreateSimple ()
 		{
-			TestRuntime.AssertXcodeVersion (7, 3);
+			TestRuntime.AssertXcodeVersion (8,0);
 
 			using (var from = CGColorSpace.CreateGenericGray ())
 			using (var to = CGColorSpace.CreateGenericRgb ())
@@ -118,7 +118,7 @@ namespace MonoTouchFixtures.CoreGraphics
 		[Test]
 		public void CreateSimple_GetINativeObject ()
 		{
-			TestRuntime.AssertXcodeVersion (7, 3);
+			TestRuntime.AssertXcodeVersion (8,0);
 
 			using (var from = CGColorSpace.CreateGenericGray ())
 			using (var to = CGColorSpace.CreateGenericRgb ()) {
@@ -133,7 +133,7 @@ namespace MonoTouchFixtures.CoreGraphics
 		[Test]
 		public void CreateSimple_DeviceColorSpace ()
 		{
-			TestRuntime.AssertXcodeVersion (7, 3);
+			TestRuntime.AssertXcodeVersion (8,0);
 
 			// Requirements: CG color spaces must be calibrated
 			// (no Device{Gray,RGB,CMYK}, Indexed or DeviceN).
@@ -143,7 +143,6 @@ namespace MonoTouchFixtures.CoreGraphics
 				Assert.Throws<Exception> (() => new CGColorConverter (from, to));
 			}
 		}
-#endif
 	}
 }
 


### PR DESCRIPTION
This was added in iOS 9.3 SDK but only worked on the simulator as the
calls were not present on the device libraries.

This is fixed in iOS 10 beta 1.

https://trello.com/c/Rwko9Wef/37-24734681-cgcolorconvertercreatesimple-is-missing-for-device-builds