### PR TITLE
[link all] Ignore tests that uses our networking stack for watchOS. Fixes #41539.

### DIFF
--- a/tests/linker-ios/link all/LinkAllTest.cs
+++ b/tests/linker-ios/link all/LinkAllTest.cs
@@ -160,6 +160,9 @@ namespace LinkAll {
 		[Test]
 		public void TrustUsingOldPolicy ()
 		{
+#if __WATCHOS__
+			Assert.Ignore ("WatchOS doesn't support BSD sockets, which our network stack currently requires.");
+#endif
 			// Three similar tests exists in dontlink, linkall and linksdk to test 3 different cases
 			// untrusted, custom ICertificatePolicy and ServerCertificateValidationCallback without
 			// having caching issues (in S.Net or the SSL handshake cache)


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=41539