### PR TITLE
[Foundation] NSUbiquitousKeyValueStore is not available on watchOS.

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -4071,6 +4071,9 @@ namespace XamCore.Foundation
 
 	[Since (5,0)]
 	[BaseType (typeof (NSObject))]
+#if WATCH
+	[DisableDefaultCtor] // "NSUbiquitousKeyValueStore is unavailable" is printed to the log.
+#endif
 	interface NSUbiquitousKeyValueStore {
 		[Static]
 		[Export ("defaultStore")]

--- a/tests/monotouch-test/Foundation/UbiquitousKeyValueStoreTest.cs
+++ b/tests/monotouch-test/Foundation/UbiquitousKeyValueStoreTest.cs
@@ -25,15 +25,14 @@ namespace MonoTouchFixtures.Foundation {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class NSUbiquitousKeyValueStoreTest {
+#if !__WATCHOS__
+		// Looks like NSUbiquitousKeyValueStore doesn't work on watchOS:
+		// http://stackoverflow.com/questions/37412775/nsubiquitouskeyvaluestore-is-unavailable-watchos-2
+		// https://forums.developer.apple.com/thread/47564
 		[Test]
 		public void Indexer ()
 		{
-#if __WATCHOS__
-			// Looks like NSUbiquitousKeyValueStore doesn't work on watchOS:
-			// http://stackoverflow.com/questions/37412775/nsubiquitouskeyvaluestore-is-unavailable-watchos-2
-			// https://forums.developer.apple.com/thread/47564
 			Assert.Ignore ("Doesn't work on watchOS");
-#endif
 
 			using (var store = new NSUbiquitousKeyValueStore ()) {
 				using (var key = new NSString ("key")) {
@@ -48,5 +47,6 @@ namespace MonoTouchFixtures.Foundation {
 				}
 			}
 		}
+#endif
 	}
 }


### PR DESCRIPTION
Fixes an issue found by the introspection tests when running on a
watchOS device.