### PR TITLE
[mmp] Preserve TransparentProxy::LoadRemoteFieldNew

### DIFF
--- a/tools/mmp/linker/Descriptors/mscorlib.xml
+++ b/tools/mmp/linker/Descriptors/mscorlib.xml
@@ -773,9 +773,12 @@
 			<method name="GetAppDomainTarget" />
 		</type>
 
-		<!-- domain.c: mono_defaults.transparent_proxy_class / removed with DISABLE_REMOTING
-		<type fullname="System.Runtime.Remoting.Proxies.TransparentProxy" />
-		-->
+		<!-- domain.c: mono_defaults.transparent_proxy_class -->
+		<type fullname="System.Runtime.Remoting.Proxies.TransparentProxy">
+			<!-- remoting.c: mono_marshal_get_ldfld_wrapper -->
+			<method name="LoadRemoteFieldNew" />
+		</type>
+
 
         <type fullname="System.Runtime.Remoting.RemotingServices">
             <method name="SerializeCallData" />


### PR DESCRIPTION
This fixes an assert that `tp_load != NULL` on osx when xamarin-macios is built
with mono master after mono/mono@787e34ae2d4fda3ee3b95dfb448d4ac1182d0254