### PR TITLE
[coretext] Update for iOS 10 beta1

### DIFF
--- a/src/CoreText/CTParagraphStyle.cs
+++ b/src/CoreText/CTParagraphStyle.cs
@@ -81,6 +81,7 @@ namespace XamCore.CoreText {
 		LineHeightMultiple      = 7,
 		MaximumLineHeight       = 8,
 		MinimumLineHeight       = 9,
+		[Availability (Introduced = Platform.iOS_3_2 | Platform.Mac_10_5, Deprecated = Platform.iOS_6_0 | Platform.Mac_10_8, Message="Please use MaximumLineSpacing")]
 		LineSpacing             = 10,
 		ParagraphSpacing        = 11,
 		ParagraphSpacingBefore  = 12,

--- a/src/CoreText/CTStringAttributes.cs
+++ b/src/CoreText/CTStringAttributes.cs
@@ -79,6 +79,7 @@ namespace XamCore.CoreText {
 		public static readonly NSString KerningAdjustment;
 		public static readonly NSString LigatureFormation;
 		public static readonly NSString ForegroundColor;
+		public static readonly NSString BackgroundColor;
 		public static readonly NSString ParagraphStyle;
 		public static readonly NSString StrokeWidth;
 		public static readonly NSString StrokeColor;
@@ -86,6 +87,7 @@ namespace XamCore.CoreText {
 		public static readonly NSString Superscript;
 		public static readonly NSString UnderlineColor;
 		public static readonly NSString VerticalForms;
+		public static readonly NSString HorizontalInVerticalForms;
 		public static readonly NSString GlyphInfo;
 		public static readonly NSString CharacterShape;
 		public static readonly NSString RunDelegate;
@@ -106,6 +108,7 @@ namespace XamCore.CoreText {
 				KerningAdjustment           = Dlfcn.GetStringConstant (handle, "kCTKernAttributeName");
 				LigatureFormation           = Dlfcn.GetStringConstant (handle, "kCTLigatureAttributeName");
 				ForegroundColor             = Dlfcn.GetStringConstant (handle, "kCTForegroundColorAttributeName");
+				BackgroundColor             = Dlfcn.GetStringConstant (handle, "kCTBackgroundColorAttributeName");
 				ParagraphStyle              = Dlfcn.GetStringConstant (handle, "kCTParagraphStyleAttributeName");
 				StrokeWidth                 = Dlfcn.GetStringConstant (handle, "kCTStrokeWidthAttributeName");
 				StrokeColor                 = Dlfcn.GetStringConstant (handle, "kCTStrokeColorAttributeName");
@@ -113,6 +116,7 @@ namespace XamCore.CoreText {
 				Superscript                 = Dlfcn.GetStringConstant (handle, "kCTSuperscriptAttributeName");
 				UnderlineColor              = Dlfcn.GetStringConstant (handle, "kCTUnderlineColorAttributeName");
 				VerticalForms               = Dlfcn.GetStringConstant (handle, "kCTVerticalFormsAttributeName");
+				HorizontalInVerticalForms   = Dlfcn.GetStringConstant (handle, "kCTHorizontalInVerticalFormsAttributeName");
 				GlyphInfo                   = Dlfcn.GetStringConstant (handle, "kCTGlyphInfoAttributeName");
 				CharacterShape              = Dlfcn.GetStringConstant (handle, "kCTCharacterShapeAttributeName");
 				RunDelegate                 = Dlfcn.GetStringConstant (handle, "kCTRunDelegateAttributeName");
@@ -191,6 +195,15 @@ namespace XamCore.CoreText {
 				return h == IntPtr.Zero ? null : new CGColor (h);
 			}
 			set {Adapter.SetNativeValue (Dictionary, CTStringAttributeKey.ForegroundColor, value);}
+		}
+
+		[iOS (10,0)][Mac(10,12)]
+		public CGColor BackgroundColor {
+			get {
+				var h = CFDictionary.GetValue (Dictionary.Handle, CTStringAttributeKey.BackgroundColor.Handle);
+				return h == IntPtr.Zero ? null : new CGColor (h);
+			}
+			set {Adapter.SetNativeValue (Dictionary, CTStringAttributeKey.BackgroundColor, value);}
 		}
 
 		public CTParagraphStyle ParagraphStyle {
@@ -279,6 +292,12 @@ namespace XamCore.CoreText {
 				CFMutableDictionary.SetValue (Dictionary.Handle,
 						CTStringAttributeKey.VerticalForms.Handle, value);
 			}
+		}
+
+		[iOS (10,0)][Mac(10,12)]
+		public int? HorizontalInVerticalForms {
+			get {return Adapter.GetInt32Value (Dictionary, CTStringAttributeKey.HorizontalInVerticalForms);}
+			set {Adapter.SetValue (Dictionary, CTStringAttributeKey.HorizontalInVerticalForms, value);}
 		}
 
 		public CTGlyphInfo GlyphInfo {

--- a/src/CoreText/CTStringAttributes.cs
+++ b/src/CoreText/CTStringAttributes.cs
@@ -197,13 +197,20 @@ namespace XamCore.CoreText {
 			set {Adapter.SetNativeValue (Dictionary, CTStringAttributeKey.ForegroundColor, value);}
 		}
 
-		[iOS (10,0)][Mac(10,12)]
+		[iOS (10,0)][Mac (10,12)]
 		public CGColor BackgroundColor {
 			get {
-				var h = CFDictionary.GetValue (Dictionary.Handle, CTStringAttributeKey.BackgroundColor.Handle);
+				var h = IntPtr.Zero;
+				var x = CTStringAttributeKey.BackgroundColor;
+				if (x != null)
+					h = CFDictionary.GetValue (Dictionary.Handle, x.Handle);
 				return h == IntPtr.Zero ? null : new CGColor (h);
 			}
-			set {Adapter.SetNativeValue (Dictionary, CTStringAttributeKey.BackgroundColor, value);}
+			set {
+				var x = CTStringAttributeKey.BackgroundColor;
+				if (x != null)
+					Adapter.SetNativeValue (Dictionary, x, value);
+			}
 		}
 
 		public CTParagraphStyle ParagraphStyle {
@@ -294,10 +301,17 @@ namespace XamCore.CoreText {
 			}
 		}
 
-		[iOS (10,0)][Mac(10,12)]
+		[iOS (10,0)][Mac (10,12)]
 		public int? HorizontalInVerticalForms {
-			get {return Adapter.GetInt32Value (Dictionary, CTStringAttributeKey.HorizontalInVerticalForms);}
-			set {Adapter.SetValue (Dictionary, CTStringAttributeKey.HorizontalInVerticalForms, value);}
+			get {
+				var x = CTStringAttributeKey.HorizontalInVerticalForms;
+				return x != null ? Adapter.GetInt32Value (Dictionary, x) : null;
+			}
+			set {
+				var x = CTStringAttributeKey.HorizontalInVerticalForms;
+				if (x != null)
+					Adapter.SetValue (Dictionary, x, value);
+			}
 		}
 
 		public CTGlyphInfo GlyphInfo {

--- a/tests/monotouch-test/CoreText/StringAttributes.cs
+++ b/tests/monotouch-test/CoreText/StringAttributes.cs
@@ -75,6 +75,22 @@ namespace MonoTouchFixtures.CoreText
 
 			UIGraphics.EndImageContext ();
 		}
+
+		[Test]
+		public void BackgroundColor ()
+		{
+			var sa = new CTStringAttributes ();
+			Assert.DoesNotThrow (() => { sa.BackgroundColor = UIColor.Blue.CGColor; }, "#0");
+			Assert.DoesNotThrow (() => { var x = sa.BackgroundColor; }, "#1");
+		}
+
+		[Test]
+		public void HorizontalInVerticalForms ()
+		{
+			var sa = new CTStringAttributes ();
+			Assert.DoesNotThrow (() => { sa.HorizontalInVerticalForms = 1; }, "#0");
+			Assert.DoesNotThrow (() => { var x = sa.HorizontalInVerticalForms; }, "#1");
+		}
 	}
 }
 


### PR DESCRIPTION
Here's the diff to explain why `HorizontalInVerticalForms` is an int (:

-extern const CFStringRef kCTVerticalFormsAttributeName CT_AVAILABLE(10_5, 4_3);
+CT_EXPORT const CFStringRef kCTVerticalFormsAttributeName CT_AVAILABLE(10_5, 4_3);

+    @const      kCTHorizontalInVerticalFormsAttributeName
+    @abstract   Setting text in tate-chu-yoko form (horizontal numerals in vertical text).
+    @discussion Value must be a CFNumberRef. Default is int value 0. A value of 1
+                to 4 indicates the number of digits or letters to set in horizontal
+                form. This is to apply the correct feature settings for the text.
+                This attribute only works when kCTVerticalFormsAttributeName is set to true.