### PR TITLE
[pushkit] Small update for iOS 10 beta 1

### DIFF
--- a/src/pushkit.cs
+++ b/src/pushkit.cs
@@ -44,6 +44,7 @@ namespace XamCore.PushKit
 		[Export ("pushTokenForType:")]
 		NSData PushToken (string type);
 
+		[DesignatedInitializer]
 		[Export ("initWithQueue:")]
 		IntPtr Constructor (DispatchQueue queue);
 	}


### PR DESCRIPTION
Other changes are due to the introduction of a PKPushType to offer
some type safety.

    typedef NSString *PKPushType NS_STRING_ENUM;

We already use a type (or the same name) to hold the constants.