### PR TITLE
[corelocation] Update for iOS 10 beta 2

### DIFF
--- a/src/CoreLocation/CLCompat.cs
+++ b/src/CoreLocation/CLCompat.cs
@@ -14,6 +14,26 @@ namespace XamCore.CoreLocation {
 		{
 		}
 	}
+
+#if !XAMCORE_4_0
+	public partial class CLHeading {
+
+		[Obsolete ("Use the Description property from NSObject")]
+		public new virtual string Description ()
+		{
+			return base.Description;
+		}
+	}
+
+	public partial class CLLocation {
+
+		[Obsolete ("Use the Description property from NSObject")]
+		public new virtual string Description ()
+		{
+			return base.Description;
+		}
+	}
+#endif
 }
 
 #endif

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -64,10 +64,6 @@ namespace XamCore.CoreLocation {
 
 		[Export ("timestamp", ArgumentSemantic.Copy)]
 		NSDate Timestamp { get;  }
-
-		[Export ("description")]
-		string Description ();
-	
 	}
 	
 	[BaseType (typeof (NSObject))]
@@ -101,9 +97,6 @@ namespace XamCore.CoreLocation {
 		[Export ("initWithCoordinate:altitude:horizontalAccuracy:verticalAccuracy:timestamp:")]
 		IntPtr Constructor (CLLocationCoordinate2D coordinate, double altitude, double hAccuracy, double vAccuracy, NSDate timestamp);
 
-		[Export ("description")]
-		string Description ();
-	
 #if !XAMCORE_2_0
 		[Export ("getDistanceFrom:")]
 		[Availability (Deprecated = Platform.iOS_3_2, Message = "Use DistanceFrom instead")]
@@ -179,7 +172,9 @@ namespace XamCore.CoreLocation {
 		[Export ("location", ArgumentSemantic.Copy)]
 		CLLocation Location { get;  }
 	
-		[NoWatch][NoTV]
+		 // __WATCHOS_PROHIBITED removed in Xcode 8.0 beta 2, assuming it's valid for 3.0+
+		[Watch (3,0)]
+		[NoTV]
 		[Export ("startUpdatingLocation")]
 		void StartUpdatingLocation ();
 	


### PR DESCRIPTION
* Removed Description method bindings (and added compatibility stubs);

* StartUpdatingLocation is now allowed on watchOS (assuming 3.0)