### PR TITLE
[XM] Fix introspection test by patching PHLivePhoto

### DIFF
--- a/src/photos.cs
+++ b/src/photos.cs
@@ -1005,9 +1005,15 @@ namespace XamCore.Photos
 
 	[iOS (9,1)]
 	[TV (10,0)]
+#if MONOMAC
+	[DisableDefaultCtor] // NS_UNAVAILABLE
+#endif
 	[Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(NSObject))]
-	public interface PHLivePhoto : NSSecureCoding, NSCopying
+	public interface PHLivePhoto
+#if !MONOMAC
+	: NSSecureCoding, NSCopying
+#endif
 	{
 		[Export ("size")]
 		CGSize Size { get; }
@@ -1016,11 +1022,11 @@ namespace XamCore.Photos
 		[Static]
 		[Export ("requestLivePhotoWithResourceFileURLs:placeholderImage:targetSize:contentMode:resultHandler:")]
 		int RequestLivePhoto (NSUrl[] fileUrls, [NullAllowed] UIImage image, CGSize targetSize, PHImageContentMode contentMode, Action<PHLivePhoto, NSDictionary> resultHandler);
-#endif
 
 		[Static]
 		[Export ("cancelLivePhotoRequestWithRequestID:")]
 		void CancelLivePhotoRequest (int requestID);
+#endif
 	}
 
 	[iOS (9,1)]

--- a/tests/introspection/Mac/MacApiSelectorTest.cs
+++ b/tests/introspection/Mac/MacApiSelectorTest.cs
@@ -116,6 +116,20 @@ namespace Introspection {
 				return true;
 			
 			switch (selectorName) {
+			case "encodeWithCoder:":
+				switch (type.Name) {
+				case "CNContactFetchRequest":
+				case "NWEndpoint":
+				case "GKEntity":
+				case "GKPolygonObstacle":
+				case "GKComponent":
+				case "GKGraph":
+				case "GKGraphNode":
+					if (!Mac.CheckSystemVersion (10, 12)) // NSCoding was added in 10.12
+						return true;
+					break;
+				}
+				break;
 			case "accessibilityNotifiesWhenDestroyed":
 				// The header declares this on an NSObject category but 
 				// it doesn't even respondsToSelector on NSView/NSCell...
@@ -155,8 +169,19 @@ namespace Introspection {
 				break;
 			// some types had NSCopying added after they were first introduced
 			case "copyWithZone:":
-				if (type.Name == "CBPeripheral" && !Mac.CheckSystemVersion (10, 9))
-					return true;
+				switch (type.Name) {
+				case "MDLTransform":
+				case "NWEndpoint":
+				case "GKBehavior":
+				case "GKGraph":
+					if (!Mac.CheckSystemVersion (10, 12)) // NSCopying was added in 10.12
+						return true;
+					break;
+				case "CBPeripheral":
+					if (!Mac.CheckSystemVersion (10, 9))
+						return true;
+					break;
+				}
 				break;
 			case "readingOptionsForType:pasteboard:":
 			case "writingOptionsForType:pasteboard:":


### PR DESCRIPTION
NS_CLASS_AVAILABLE(10_12, 9_1) @interface PHLivePhoto : NSObject

- (instancetype)init NS_UNAVAILABLE;

/// The dimensions of the live photo measured in pixels.
@property (readonly, nonatomic) CGSize size;

@end