### PR TITLE
[tests] Fix UIColor unit tests (in classic only)

### DIFF
--- a/tests/monotouch-test/MapKit/PinAnnotationViewTest.cs
+++ b/tests/monotouch-test/MapKit/PinAnnotationViewTest.cs
@@ -61,7 +61,7 @@ namespace MonoTouchFixtures.MapKit {
 					return;
 				Assert.That (av.PinColor, Is.EqualTo (MKPinAnnotationColor.Red), "PinColor");
 				if (UIDevice.CurrentDevice.CheckSystemVersion (10,0))
-					Assert.That (av.PinTintColor, Is.EqualTo (UIColor.FromRGBA (255, 59, 48, 255)), "PinTintColor");
+					Assert.That (av.PinTintColor.ToString (), Is.EqualTo (UIColor.FromRGBA (255, 59, 48, 255).ToString ()), "PinTintColor");
 				else
 					Assert.Null (av.PinTintColor, "PinTintColor"); // differs from the other init call
 			}


### PR DESCRIPTION
Does not affect the Jenkins bots (which don't run classic tests) but
fails on wrench (who still runs them right now). There's a difference
in how equality is checked between classic and unified and that expose
a, not really important, change in iOS10.