### PR TITLE
[XM] Revert mac test packages script changes, as we are not running m…

### DIFF
--- a/tests/package-mac-tests.sh
+++ b/tests/package-mac-tests.sh
@@ -18,10 +18,6 @@ cp -p Makefile-mac.inc $DIR/tests
 cp -p common.mk $DIR/tests
 cp -p Makefile $DIR/tests
 cp -p ../Make.config $DIR
-mkdir -p $DIR/tests/common/mac
-cp -pR common/mac/ $DIR/tests/common/mac/
-mkdir -p $DIR/tests/mac-binding-project/bin
-cp -pR mac-binding-project/bin/ $DIR/tests/mac-binding-project/bin/
 mkdir -p $DIR/mk
 cp -p ../Make.config $DIR
 cp -p ../mk/subdirs.mk $DIR/mk


### PR DESCRIPTION
…mp/msbuild tests on test bots

This reverts commit e780e28f5c6b620ce4109a9e31612cd4434d2eae and 35b26be50c7a82dc3d356e7b01517f0f5f87fd16

Since we aren't planning on running mmp/msbuild tests on bots, no need for this work anymore.