### PR TITLE
[imageio] Update for beta 2

### DIFF
--- a/src/ImageIO/CGImageDestination.cs
+++ b/src/ImageIO/CGImageDestination.cs
@@ -66,6 +66,9 @@ namespace XamCore.ImageIO {
 		[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0)]
 		public bool ShouldExcludeGPS { get; set; }
 
+		[iOS (9,3)][Mac (10,12)]
+		public bool OptimizeColorForSharing { get; set; }
+
 		internal NSMutableDictionary ToDictionary ()
 		{
 			var dict = new NSMutableDictionary ();
@@ -107,6 +110,9 @@ namespace XamCore.ImageIO {
 			// new in iOS 8 and 10.10 - default is false
 			if (ShouldExcludeGPS && (kShouldExcludeGPS != IntPtr.Zero))
 				dict.LowlevelSetObject (CFBoolean.True.Handle, kShouldExcludeGPS);
+
+			if (OptimizeColorForSharing && (kOptimizeColorForSharing != IntPtr.Zero))
+				dict.LowlevelSetObject (CFBoolean.True.Handle, kOptimizeColorForSharing);
 
 			return dict;
 		}

--- a/src/imageio.cs
+++ b/src/imageio.cs
@@ -606,6 +606,67 @@ namespace XamCore.ImageIO {
 		[Field ("kCGImagePropertyDNGLensInfo")]
 		NSString DNGLensInfo { get; }
 
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGBlackLevel")]
+		NSString DNGBlackLevel { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGWhiteLevel")]
+		NSString DNGWhiteLevel { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGCalibrationIlluminant1")]
+		NSString DNGCalibrationIlluminant1 { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGCalibrationIlluminant2")]
+		NSString DNGCalibrationIlluminant2 { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGColorMatrix1")]
+		NSString DNGColorMatrix1 { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGColorMatrix2")]
+		NSString DNGColorMatrix2 { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGCameraCalibration1")]
+		NSString DNGCameraCalibration1 { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGCameraCalibration2")]
+		NSString DNGCameraCalibration2 { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGAsShotNeutral")]
+		NSString DNGAsShotNeutral { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGAsShotWhiteXY")]
+		NSString DNGAsShotWhiteXY { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGBaselineExposure")]
+		NSString DNGBaselineExposure { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGBaselineNoise")]
+		NSString DNGBaselineNoise { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGBaselineSharpness")]
+		NSString DNGBaselineSharpness { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGPrivateData")]
+		NSString DNGPrivateData { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGCameraCalibrationSignature")]
+		NSString DNGCameraCalibrationSignature { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGProfileCalibrationSignature")]
+		NSString DNGProfileCalibrationSignature { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGNoiseProfile")]
+		NSString DNGNoiseProfile { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGWarpRectilinear")]
+		NSString DNGWarpRectilinear { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGWarpFisheye")]
+		NSString DNGWarpFisheye { get; }
+		[iOS (10,0)][Mac (12,0)]
+		[Field ("kCGImagePropertyDNGFixVignetteRadial")]
+		NSString DNGFixVignetteRadial { get; }
+
 		// 8BIM Dictionary Keys
 
 		[Field ("kCGImageProperty8BIMLayerNames")]
@@ -874,6 +935,10 @@ namespace XamCore.ImageIO {
 		[iOS (8,0)][Mac (10,10)]
 		[Internal][Field ("kCGImageMetadataShouldExcludeGPS")]
 		IntPtr kShouldExcludeGPS { get; }
+
+		[iOS (9,3)][Mac (10,12)]
+		[Internal][Field ("kCGImageDestinationOptimizeColorForSharing")]
+		IntPtr kOptimizeColorForSharing { get; }
 	}
 #else
 
@@ -898,6 +963,10 @@ namespace XamCore.ImageIO {
 		[iOS (8,0)][Mac (10,10)]
 		[Export ("EmbedThumbnail")]
 		bool EmbedThumbnail { get; set; }
+
+		[iOS (9,3)][Mac (10,12)]
+		[Export ("OptimizeColorForSharing")]
+		bool OptimizeColorForSharing { get; set; }
 
 		[StrongDictionary]
 		[Export ("TIFFDictionary")]
@@ -958,6 +1027,10 @@ namespace XamCore.ImageIO {
 		[iOS (8,0)][Mac (10,10)]
 		[Field ("kCGImageDestinationEmbedThumbnail")]
 		NSString EmbedThumbnail { get; }
+
+		[iOS (9,3)][Mac (10,12)]
+		[Field ("kCGImageDestinationOptimizeColorForSharing")]
+		NSString OptimizeColorForSharing { get; }
 
 		// [Field ("kCGImagePropertyTIFFDictionary")]
 		[Static][Wrap ("CGImageProperties.TIFFDictionary")]


### PR DESCRIPTION
kCGImageDestinationOptimizeColorForSharing has been verified to be
present on iOS 9.3 (like mentioned in the headers)