### PR TITLE
[runtime] Parse unions in objc encodings correctly. Fixes #42452.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1359,6 +1359,10 @@ objc_skip_type (const char *type)
 			return ++type;
 		}
 		case _C_UNION_B: {
+			do {
+				type++;
+			} while (*type != '=');
+
 			type ++;
 			do {
 				type = objc_skip_type (type);
@@ -1441,6 +1445,10 @@ xamarin_objc_type_size (const char *type)
 		}
 		case _C_UNION_B: {
 			int size = 0;
+
+			do {
+				type++;
+			} while (*type != '=');
 
 			++type;
 

--- a/tests/monotouch-test/GLKit/BaseEffectTest.cs
+++ b/tests/monotouch-test/GLKit/BaseEffectTest.cs
@@ -37,6 +37,10 @@ namespace MonoTouchFixtures.GLKit {
 			var effect = new GLKBaseEffect ();
 			Assert.That (effect.LightModelAmbientColor.ToString (), Is.EqualTo ("(0.2, 0.2, 0.2, 1)"), "LightModelAmbientColor");
 			Assert.That (effect.ConstantColor.ToString (), Is.EqualTo ("(1, 1, 1, 1)"), "ConstantColor");
+
+			effect.Light0.Enabled = true;
+			effect.Light0.DiffuseColor = new Vector4 (1.0f, 0.4f, 0.4f, 1.0f);
+			Assert.That (effect.Light0.DiffuseColor.ToString (), Is.EqualTo ("(1, 0.4, 0.4, 1)"), "Light0");
 		}
 	}
 }


### PR DESCRIPTION
Unions are defined as follows:

    (name=type...)

and we were not correctly parsing the 'name=' part.

https://bugzilla.xamarin.com/show_bug.cgi?id=42452