### PR TITLE
[registrar] Forward-declare ObjC classes. Fixes #42454.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2451,6 +2451,17 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 		}
 
+#if !XAMCORE_2_0
+		class Bug42454 : NSUrlProtocol
+		{
+			[Export ("initWithRequest:cachedResponse:client:")]
+			public Bug42454 (NSUrlRequest request, NSCachedUrlResponse response, NSUrlProtocolClient client)
+			{
+				throw new NotImplementedException ();
+			}
+		}
+#endif
+
 #if debug_code
 		static void DumpClass (Type type)
 		{

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2272,11 +2272,16 @@ namespace XamCore.Registrar {
 				var class_name = EncodeNonAsciiCharacters (@class.ExportedName);
 				var is_protocol = @class.IsProtocol;
 				if (@class.IsCategory) {
-					sb.Write ("@interface {0} ({1})", EncodeNonAsciiCharacters (@class.BaseType.ExportedName), @class.CategoryName);
+					var exportedName = EncodeNonAsciiCharacters (@class.BaseType.ExportedName);
+					sb.Write ("@interface {0} ({1})", exportedName, @class.CategoryName);
+					declarations.AppendFormat ("@class {0};\n", exportedName);
 				} else if (is_protocol) {
-					sb.Write ("@protocol ").Write (EncodeNonAsciiCharacters (@class.ProtocolName));
+					var exportedName = EncodeNonAsciiCharacters (@class.ProtocolName);
+					sb.Write ("@protocol ").Write (exportedName);
+					declarations.AppendFormat ("@protocol {0};\n", exportedName);
 				} else {
 					sb.Write ("@interface {0} : {1}", class_name, EncodeNonAsciiCharacters (@class.SuperType.ExportedName));
+					declarations.AppendFormat ("@class {0};\n", class_name);
 				}
 				bool any_protocols = false;
 				ObjCType tp = @class;


### PR DESCRIPTION
There can be circular dependencies between Objective-C classes,
so make sure we don't fail compilation when that occurs by
forward declaring any Objective-C classes/protocols.

The test case in question does not contain a circular dependency,
but the same issue occurs due to types not being generated in the
correct order (a correct order could be constructed for the test
case, but there's no general solution since circular dependencies
can exist).

https://bugzilla.xamarin.com/show_bug.cgi?id=42454