### PR TITLE
[monotouch-test] Fix permissions in Info.plist

### DIFF
--- a/tests/monotouch-test/Info.plist
+++ b/tests/monotouch-test/Info.plist
@@ -40,5 +40,11 @@
 	<true/>
 	<key>CFBundleName</key>
 	<string>MonoTouchTest</string>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>Testing tastes</string>
+	<key>NSHomeKitUsageDescription</key>
+	<string>Testing roofs</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Testing lens</string>
 </dict>
 </plist>


### PR DESCRIPTION
Tests using the iPod music library for instance, won't work on iOS 10 without those plist keys.