### PR TITLE
Fix FetchString change from PR335, other (wrong) cases and reduce code duplication

### DIFF
--- a/src/CoreFoundation/CFBundle.cs
+++ b/src/CoreFoundation/CFBundle.cs
@@ -435,7 +435,7 @@ namespace XamCore.CoreFoundation {
 			using (CFString cfKey = new CFString (key),
 					cfValue = new CFString (defaultValue),
 					cfTable = new CFString (tableName)) {
-				return CFString.FetchString (CFBundleCopyLocalizedString (handle, cfKey.Handle, cfValue.Handle, cfTable.Handle));
+				return CFString.FetchString (CFBundleCopyLocalizedString (handle, cfKey.Handle, cfValue.Handle, cfTable.Handle), releaseHandle: true);
 			}
 		}
 

--- a/src/CoreFoundation/CFException.cs
+++ b/src/CoreFoundation/CFException.cs
@@ -105,11 +105,11 @@ namespace XamCore.CoreFoundation {
 				throw new ArgumentException ("cfErrorHandle must not be null.", "cfErrorHandle");
 
 			var e = new CFException (
-					ToString (CFErrorCopyDescription (cfErrorHandle)),
+					CFString.FetchString (CFErrorCopyDescription (cfErrorHandle), releaseHandle: true),
 					(NSString) Runtime.GetNSObject (CFErrorGetDomain (cfErrorHandle)),
 					CFErrorGetCode (cfErrorHandle),
-					ToString (CFErrorCopyFailureReason (cfErrorHandle)),
-					ToString (CFErrorCopyRecoverySuggestion (cfErrorHandle)));
+					CFString.FetchString (CFErrorCopyFailureReason (cfErrorHandle), releaseHandle: true),
+					CFString.FetchString (CFErrorCopyRecoverySuggestion (cfErrorHandle), releaseHandle: true));
 
 			var cfUserInfo = CFErrorCopyUserInfo (cfErrorHandle);
 			if (cfUserInfo != IntPtr.Zero) {
@@ -127,19 +127,6 @@ namespace XamCore.CoreFoundation {
 		public NSString Domain {get; private set;}
 		public string FailureReason {get; private set;}
 		public string RecoverySuggestion {get; private set;}
-
-		static string ToString (IntPtr cfStringRef)
-		{
-			return ToString (cfStringRef, true);
-		}
-
-		static string ToString (IntPtr cfStringRef, bool release)
-		{
-			var r = CFString.FetchString (cfStringRef);
-			if (release && (cfStringRef != IntPtr.Zero))
-				CFObject.CFRelease (cfStringRef);
-			return r;
-		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		static extern IntPtr CFErrorCopyDescription (IntPtr err);

--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -180,6 +180,7 @@ namespace XamCore.CoreFoundation {
 				CFObject.CFRetain (handle);
 		}
 
+		// to be used when an API like CF*Get* returns a CFString
 		internal static string FetchString (IntPtr handle)
 		{
 			if (handle == IntPtr.Zero)
@@ -205,7 +206,16 @@ namespace XamCore.CoreFoundation {
 
 			return str;
 		}
-		
+
+		// to be used when an API like CF*Copy* returns a CFString
+		internal static string FetchString (IntPtr handle, bool releaseHandle)
+		{
+			var s = FetchString (handle);
+			if (releaseHandle && (handle != IntPtr.Zero))
+				CFObject.CFRelease (handle);
+			return s;
+		}
+
 		public static implicit operator string (CFString x)
 		{
 			if (x.str == null)

--- a/src/CoreGraphics/CGFont.cs
+++ b/src/CoreGraphics/CGFont.cs
@@ -144,7 +144,7 @@ namespace XamCore.CoreGraphics {
 
 		public string PostScriptName {
 			get {
-				return CFString.FetchString (CGFontCopyPostScriptName (handle));
+				return CFString.FetchString (CGFontCopyPostScriptName (handle), releaseHandle: true);
 			}
 		}
 		
@@ -153,7 +153,7 @@ namespace XamCore.CoreGraphics {
 
 		public string FullName {
 			get {
-				return CFString.FetchString (CGFontCopyFullName (handle));
+				return CFString.FetchString (CGFontCopyFullName (handle), releaseHandle: true);
 			}
 		}
 		
@@ -258,7 +258,7 @@ namespace XamCore.CoreGraphics {
 
 		public string GlyphNameForGlyph (ushort glyph)
 		{
-			return CFString.FetchString (CGFontCopyGlyphNameForGlyph (handle, glyph));
+			return CFString.FetchString (CGFontCopyGlyphNameForGlyph (handle, glyph), releaseHandle: true);
 		}
 		
 		//[DllImport (Constants.CoreGraphicsLibrary)]

--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -1742,18 +1742,10 @@ namespace XamCore.CoreText {
 #endregion
 
 #region Font Names
-		static string GetStringAndRelease (IntPtr cfStringRef)
-		{
-			if (cfStringRef == IntPtr.Zero)
-				return null;
-			using (var s = new CFString (cfStringRef, true))
-				return s;
-		}
-
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCopyPostScriptName (IntPtr font);
 		public string PostScriptName {
-			get {return GetStringAndRelease (CTFontCopyPostScriptName (handle));}
+			get { return CFString.FetchString (CTFontCopyPostScriptName (handle), releaseHandle: true); }
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -1761,7 +1753,7 @@ namespace XamCore.CoreText {
 			/* CTFontRef __nonnull */ IntPtr font);
 		
 		public string FamilyName {
-			get {return GetStringAndRelease (CTFontCopyFamilyName (handle));}
+			get { return CFString.FetchString (CTFontCopyFamilyName (handle), releaseHandle: true); }
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -1769,7 +1761,7 @@ namespace XamCore.CoreText {
 			/* CTFontRef __nonnull */ IntPtr font);
 		
 		public string FullName {
-			get {return GetStringAndRelease (CTFontCopyFullName (handle));}
+			get { return CFString.FetchString (CTFontCopyFullName (handle), releaseHandle: true); }
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -1777,14 +1769,14 @@ namespace XamCore.CoreText {
 			/* CTFontRef __nonnull */ IntPtr font);
 		
 		public string DisplayName {
-			get {return GetStringAndRelease (CTFontCopyDisplayName (handle));}
+			get { return CFString.FetchString (CTFontCopyDisplayName (handle), releaseHandle: true); }
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern IntPtr CTFontCopyName (IntPtr font, IntPtr nameKey);
 		public string GetName (CTFontNameKey nameKey)
 		{
-			return GetStringAndRelease (CTFontCopyName (handle, CTFontNameKeyId.ToId (nameKey).Handle));
+			return CFString.FetchString (CTFontCopyName (handle, CTFontNameKeyId.ToId (nameKey).Handle), releaseHandle: true);
 		}
 
 		[DllImport (Constants.CoreTextLibrary)]
@@ -1799,8 +1791,8 @@ namespace XamCore.CoreText {
 		public string GetLocalizedName (CTFontNameKey nameKey, out string actualLanguage)
 		{
 			IntPtr actual;
-			var ret = GetStringAndRelease (CTFontCopyLocalizedName (handle, CTFontNameKeyId.ToId (nameKey).Handle, out actual));
-			actualLanguage = GetStringAndRelease (actual);
+			var ret = CFString.FetchString (CTFontCopyLocalizedName (handle, CTFontNameKeyId.ToId (nameKey).Handle, out actual), releaseHandle: true);
+			actualLanguage = CFString.FetchString (actual, releaseHandle: true);
 			return ret;
 		}
 #endregion

--- a/src/MediaToolbox/MTFormatNames.cs
+++ b/src/MediaToolbox/MTFormatNames.cs
@@ -19,7 +19,7 @@ namespace XamCore.MediaToolbox {
 		[iOS (9,0)][Mac (10,11)]
 		static public string GetLocalizedName (this CMMediaType mediaType)
 		{
-			return CFString.FetchString (MTCopyLocalizedNameForMediaType (mediaType));
+			return CFString.FetchString (MTCopyLocalizedNameForMediaType (mediaType), releaseHandle: true);
 		}
 
 		[iOS (9,0)][Mac (10,11)]
@@ -30,7 +30,7 @@ namespace XamCore.MediaToolbox {
 		[iOS (9,0)][Mac (10,11)]
 		static public string GetLocalizedName (this CMMediaType mediaType, uint mediaSubType)
 		{
-			return CFString.FetchString (MTCopyLocalizedNameForMediaSubType (mediaType, mediaSubType));
+			return CFString.FetchString (MTCopyLocalizedNameForMediaSubType (mediaType, mediaSubType), releaseHandle: true);
 		}
 	}
 }

--- a/src/SearchKit/SearchKit.cs
+++ b/src/SearchKit/SearchKit.cs
@@ -679,35 +679,25 @@ namespace XamCore.SearchKit
 
 		[DllImport (Constants.SearchKitLibrary)]
 		extern static IntPtr /*NSString*/  SKSummaryCopyParagraphSummaryString (IntPtr summary, nint maxParagraphs);
-		
-		static string ReturnString (IntPtr newStringHandle)
-		{
-			if (newStringHandle == IntPtr.Zero)
-				return null;
-			var ret =  CFString.FetchString (newStringHandle);
-			CFObject.CFRelease (newStringHandle);
-			return ret;
-					
-		}
-		
+
 		public string GetSentence (nint idx)
 		{
-			return ReturnString (SKSummaryCopySentenceAtIndex (handle, idx));
+			return CFString.FetchString (SKSummaryCopySentenceAtIndex (handle, idx), releaseHandle: true);
 		}
 
 		public string GetParagraph (nint idx)
 		{
-			return ReturnString (SKSummaryCopyParagraphAtIndex (handle, idx));
+			return CFString.FetchString (SKSummaryCopyParagraphAtIndex (handle, idx), releaseHandle: true);
 		}
 
 		public string GetSentenceSummary (nint maxSentences)
 		{
-			return ReturnString (SKSummaryCopySentenceSummaryString (handle, maxSentences));
+			return CFString.FetchString (SKSummaryCopySentenceSummaryString (handle, maxSentences), releaseHandle: true);
 		}
 
 		public string GetParagraphSummary (nint maxParagraphs)
 		{
-			return ReturnString (SKSummaryCopyParagraphSummaryString (handle, maxParagraphs));
+			return CFString.FetchString (SKSummaryCopyParagraphSummaryString (handle, maxParagraphs), releaseHandle: true);
 		}
 		
 	}

--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -138,10 +138,7 @@ namespace XamCore.Security {
 				if (handle == IntPtr.Zero)
 					throw new ObjectDisposedException ("SecCertificate");
 				
-				IntPtr cfstr = SecCertificateCopySubjectSummary (handle);
-				string ret = CFString.FetchString (cfstr);
-				CFObject.CFRelease (cfstr);
-				return ret;
+				return CFString.FetchString (SecCertificateCopySubjectSummary (handle), releaseHandle: true);
 			}
 		}
 


### PR DESCRIPTION
PR335 [1] caused a leak and, upon verification, the same pattern was used
elsewhere too. There were also other (good) cases that now share the same
code.

[1] https://github.com/xamarin/xamarin-macios/pull/335