### PR TITLE
[tests] Add missing version check on AUViewController tests. Fixes #42440

### DIFF
--- a/tests/monotouch-test/CoreAudioKit/AUViewController.cs
+++ b/tests/monotouch-test/CoreAudioKit/AUViewController.cs
@@ -26,6 +26,13 @@ namespace MonoTouchFixtures.CoreAudioKit {
 	[Preserve (AllMembers = true)]
 	public class AUViewControllerTest
 	{
+		[SetUp]
+		public void MinimumSdkCheck ()
+		{
+			// AUViewController was added in iOS 9
+			TestRuntime.AssertXcodeVersion (7, 0);
+		}
+
 		[Test]
 		public void Ctor ()
 		{


### PR DESCRIPTION
Type was introduced in iOS 9, so it fails on earlier versions.

https://bugzilla.xamarin.com/show_bug.cgi?id=42440