### PR TITLE
[registrar] Use the correct parameters when generating category methods. Fixes #42489.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -47,10 +47,12 @@ using Bindings.Test;
 using RectangleF=CoreGraphics.CGRect;
 using SizeF=CoreGraphics.CGSize;
 using PointF=CoreGraphics.CGPoint;
+using CategoryAttribute=ObjCRuntime.CategoryAttribute;
 #else
 using nfloat=global::System.Single;
 using nint=global::System.Int32;
 using nuint=global::System.UInt32;
+using CategoryAttribute=MonoTouch.ObjCRuntime.CategoryAttribute;
 #endif
 
 using XamarinTests.ObjCRuntime;
@@ -2489,4 +2491,16 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		static extern IntPtr method_getName (IntPtr method);
 #endif
 	}
+
+#if !__WATCHOS__
+	[Category (typeof (CALayer))]
+	static class CALayerColorsHelpers
+	{
+		[Export ("setBorderUIColor:")]
+		static void BorderUIColor (this CALayer self, UIColor borderColor)
+		{
+			self.BorderColor = borderColor.CGColor;
+		}
+	}
+#endif // !__WATCHOS__
 }

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2058,12 +2058,13 @@ namespace XamCore.Registrar {
 				sb.Append (' ');
 				sb.Append (split [0]);
 			} else {
+				var indexOffset = method.IsCategoryInstance ? 1 : 0;
 				for (int i = 0; i < split.Length - 1; i++) {
 					sb.Append (' ');
 					sb.Append (split [i]);
 					sb.Append (':');
 					sb.Append ('(');
-					sb.Append (ToObjCParameterType (method.Parameters [i], method.DescriptiveMethodName, exceptions, method.Method));
+					sb.Append (ToObjCParameterType (method.Parameters [i + indexOffset], method.DescriptiveMethodName, exceptions, method.Method));
 					sb.Append (')');
 					sb.AppendFormat ("p{0}", i);
 				}


### PR DESCRIPTION
Category methods are exposed like extension methods, and the first parameter
specifies the class, which means we need to skip the first type when generating
the ObjC signature.

https://bugzilla.xamarin.com/show_bug.cgi?id=42489