### PR TITLE
[xharness] Add support for re-reading console output.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -413,6 +413,7 @@ namespace xharness
 					if (!listener.WaitForConnection (TimeSpan.FromMinutes (Harness.LaunchTimeout))) {
 						cancellation_source.Cancel ();
 						main_log.WriteLine ("Test launch timed out after {0} minute(s).", Harness.LaunchTimeout);
+						timed_out = true;
 					} else {
 						main_log.WriteLine ("Test run started");
 					}

--- a/tests/xharness/Log.cs
+++ b/tests/xharness/Log.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.IO;
+using System.Text;
 
 namespace xharness
 {
@@ -200,8 +201,11 @@ namespace xharness
 
 	public class ConsoleLog : Log
 	{
+		StringBuilder captured = new StringBuilder ();
+
 		protected override void WriteImpl (string value)
 		{
+			captured.Append (value);
 			Console.Write (value);
 		}
 
@@ -214,6 +218,12 @@ namespace xharness
 		public override TextWriter GetWriter ()
 		{
 			return Console.Out;
+		}
+
+		public override StreamReader GetReader ()
+		{
+			var str = new MemoryStream (System.Text.Encoding.UTF8.GetBytes (captured.ToString ()));
+			return new StreamReader (str, System.Text.Encoding.UTF8, false);
 		}
 	}
 


### PR DESCRIPTION
Fixes a confusing exception/error message when a test run times out:

```
System.AggregateException: One or more errors occurred. ---> System.NotSupportedException: Specified method is not supported.
  at xharness.Log.GetReader () [0x00001] in /Users/poupou/git/xcode8/xamarin-macios/tests/xharness/Log.cs:28 
  at xharness.AppRunner+<RunAsync>c__async0.MoveNext () [0x00955] in /Users/poupou/git/xcode8/xamarin-macios/tests/xharness/AppRunner.cs:436 
  --- End of inner exception stack trace ---
  at System.Threading.Tasks.Task.ThrowIfExceptional (Boolean includeTaskCanceledExceptions) [0x00014] in /private/tmp/source-mono-4.4.0/bockbuild-mono-4.4.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/external/referencesource/mscorlib/system/threading/Tasks/Task.cs:2157 
  at System.Threading.Tasks.Task`1[TResult].GetResultCore (Boolean waitCompletionNotification) [0x00034] in /private/tmp/source-mono-4.4.0/bockbuild-mono-4.4.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/external/referencesource/mscorlib/system/threading/Tasks/Future.cs:562 
  at System.Threading.Tasks.Task`1[TResult].get_Result () [0x00000] in /private/tmp/source-mono-4.4.0/bockbuild-mono-4.4.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/external/referencesource/mscorlib/system/threading/Tasks/Future.cs:532 
  at xharness.Harness.Run () [0x0005f] in /Users/poupou/git/xcode8/xamarin-macios/tests/xharness/Harness.cs:437 
  at xharness.Harness.Execute () [0x00032] in /Users/poupou/git/xcode8/xamarin-macios/tests/xharness/Harness.cs:498 
  at xharness.MainClass.Main (System.String[] args) [0x002b9] in /Users/poupou/git/xcode8/xamarin-macios/tests/xharness/Program.cs:63 
---> (Inner Exception #0) System.NotSupportedException: Specified method is not supported.
  at xharness.Log.GetReader () [0x00001] in /Users/poupou/git/xcode8/xamarin-macios/tests/xharness/Log.cs:28 
  at xharness.AppRunner+<RunAsync>c__async0.MoveNext () [0x00955] in /Users/poupou/git/xcode8/xamarin-macios/tests/xharness/AppRunner.cs:436 <---
```