### PR TITLE
Fix monotouch-tests failures on older iOS versions

### DIFF
--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -764,18 +764,22 @@ namespace XamCore.Registrar {
 					// to not link it away anymore like we currently do.
 
 #if !COREBUILD && !MONOMAC && !WATCH
+					var major = -1;
 					switch (type.Name) {
 					case "PKObject":
 					case "CBAttribute":
 					case "CBPeer":
-						if (!UIDevice.CurrentDevice.CheckSystemVersion (8,0))
-							return;
+						major = 8;
 						break;
 					case "GKGameCenterViewController":
-						if (!UIDevice.CurrentDevice.CheckSystemVersion (6,0))
-							return;
+						major = 6;
+						break;
+					case "CBManager":
+						major = 10;
 						break;
 					}
+					if ((major > 0) && !UIDevice.CurrentDevice.CheckSystemVersion (major, 0))
+						return;
 #endif
 
 					// a missing [Model] attribute will cause this error on devices (e.g. bug #4864)

--- a/tests/monotouch-test/ImageIO/ImageMetadataTagTest.cs
+++ b/tests/monotouch-test/ImageIO/ImageMetadataTagTest.cs
@@ -87,7 +87,8 @@ namespace MonoTouchFixtures.ImageIO {
 				Assert.That (tag.Namespace.ToString (), Is.EqualTo ("http://ns.adobe.com/exif/1.0/"), "Namespace");
 				Assert.That (tag.Prefix.ToString (), Is.EqualTo ("exif"), "Prefix");
 				Assert.That (tag.Type, Is.EqualTo (CGImageMetadataType.ArrayOrdered), "Type");
-				Assert.That (tag.Value, Is.TypeOf<NSArray> (), "Value");
+				// an NSArray before iOS 10, NSMutableArray then
+				Assert.That (tag.Value, Is.InstanceOf<NSArray> (), "Value");
 				Assert.Null (tag.GetQualifiers (), "GetQualifiers");
 			}
 		}

--- a/tests/monotouch-test/MediaPlayer/MediaItemTest.cs
+++ b/tests/monotouch-test/MediaPlayer/MediaItemTest.cs
@@ -33,6 +33,8 @@ namespace MonoTouchFixtures.MediaPlayer {
 					Assert.Inconclusive ("This test needs music in the music library on the device.");
 
 				var six_dot_oh = TestRuntime.CheckSystemAndSDKVersion (6, 0);
+				var nine_dot_two = TestRuntime.CheckSystemAndSDKVersion (9, 2);
+				var ten_dot_oh = TestRuntime.CheckSystemAndSDKVersion (10, 0);
 
 				foreach (var i in items) {
 					object dummy;
@@ -71,8 +73,10 @@ namespace MonoTouchFixtures.MediaPlayer {
 					Assert.DoesNotThrow (() => dummy = i.SkipCount, "SkipCount");
 					Assert.DoesNotThrow (() => dummy = i.Title, "Title");
 					Assert.DoesNotThrow (() => dummy = i.UserGrouping, "UserGrouping");
-					Assert.DoesNotThrow (() => dummy = i.HasProtectedAsset, "HasProtectedAsset");
-					Assert.DoesNotThrow (() => dummy = i.IsExplicitItem, "IsExplicitItem");
+					if (nine_dot_two)
+						Assert.DoesNotThrow (() => dummy = i.HasProtectedAsset, "HasProtectedAsset");
+					if (ten_dot_oh)
+						Assert.DoesNotThrow (() => dummy = i.IsExplicitItem, "IsExplicitItem");
 				}
 			}
 		}

--- a/tests/monotouch-test/Messages/MSMessageTest.cs
+++ b/tests/monotouch-test/Messages/MSMessageTest.cs
@@ -26,6 +26,11 @@ namespace MonoTouchFixtures.Messages
 	[Preserve (AllMembers = true)]
 	public class MSMessageTest
 	{
+		[SetUp]
+		public void MinimumSdkCheck ()
+		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+		}
 
 		[Test]
 		public void InitWithSession ()

--- a/tests/monotouch-test/Metal/DeviceTest.cs
+++ b/tests/monotouch-test/Metal/DeviceTest.cs
@@ -19,6 +19,8 @@ namespace MonoTouchFixtures.Metal {
 		[Test]
 		public void System ()
 		{
+			TestRuntime.AssertXcodeVersion (6,0);
+
 			var d = MTLDevice.SystemDefault;
 			// some older hardware won't have a default
 			if (d == null)

--- a/tests/monotouch-test/MetalPerformanceShaders/KernelTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/KernelTest.cs
@@ -24,13 +24,13 @@ namespace MonoTouchFixtures.MetalPerformanceShaders {
 		[Test]
 		public void RectNoClip ()
 		{
+			TestRuntime.AssertXcodeVersion (7,0);
+
 			var d = MTLDevice.SystemDefault;
 			// some older hardware won't have a default
 			if (d == null)
 				Assert.Inconclusive ("Metal is not supported");
-			if (!UIDevice.CurrentDevice.CheckSystemVersion (9,0))
-				Assert.Inconclusive ("MetalPerformanceShaders requires iOS 9.0+");
-
+			
 			var r = MPSKernel.RectNoClip;
 			var o = r.Origin;
 			Assert.That (o.X, Is.EqualTo (0), "X");


### PR DESCRIPTION
Tested with iOS 7.1 on an iPad 3

- Dynamic registrar needs to ignore new CBManager base class;
- CGImageMetadataTag.Value returns a mutable array on iOS10;
- MPMediaItem properties needed 9.2 / 10.0 check;
- MSMessage not available before Xcode 8;
- Metal not available before Xcode 6;
- MetalPerformanceShaders not available before Xcode 7;