### PR TITLE
[mediaplayer] Update for iOS 10 beta 1 - Part 2

### DIFF
--- a/src/MediaPlayer/MPRemoteCommandCenter.cs
+++ b/src/MediaPlayer/MPRemoteCommandCenter.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace XamCore.MediaPlayer {
+	public partial class MPRemoteCommandCenter {
+
+		[Obsolete ("Use MPRemoteCommandCenter.Shared")]
+		public MPRemoteCommandCenter ()
+		{
+		}
+	}
+}

--- a/src/MediaPlayer/MediaPlayer.cs
+++ b/src/MediaPlayer/MediaPlayer.cs
@@ -216,6 +216,31 @@ namespace XamCore.MediaPlayer {
 
 	public delegate void MPMediaItemEnumerator (string property, NSObject value, ref bool stop);
 
+	[Native]
+	public enum MPShuffleType : nint
+	{
+		Off,
+		Items,
+		Collections
+	}
+
+	[Native]
+	public enum MPRepeatType : nint
+	{
+		Off,
+		One,
+		All
+	}
+
+	[iOS (10,0)]
+	[Native]
+	public enum MPChangeLanguageOptionSetting : nint
+	{
+		None,
+		NowPlayingItemOnly,
+		Permanent
+	}
+
 	// NSInteger -> MPRemoteCommand.h
 	[Native]
 	[iOS (7,1)]

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -860,6 +860,7 @@ MEDIAPLAYER_SOURCES = \
 	MediaPlayer/MPMoviePlayerController.cs \
 	MediaPlayer/MPNowPlayingInfoCenter.cs \
 	MediaPlayer/MPPlayableContentDelegate.cs \
+	MediaPlayer/MPRemoteCommandCenter.cs \
 	MediaPlayer/MPSkipIntervalCommand.cs \
 	MediaPlayer/MPVolumeSettings.cs \
 

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -1360,7 +1360,11 @@ namespace XamCore.MediaPlayer {
 		[Abstract]
 #endif
 		[Export ("contentItemAtIndexPath:")]
+#if XAMCORE_4_0
+		MPContentItem GetContentItem (NSIndexPath indexPath);
+#else
 		MPContentItem ContentItem (NSIndexPath indexPath);
+#endif
 
 		[Export ("beginLoadingChildItemsAtIndexPath:completionHandler:")]
 		void BeginLoadingChildItems (NSIndexPath indexPath, Action<NSError> completionHandler);
@@ -1373,6 +1377,11 @@ namespace XamCore.MediaPlayer {
 #endif
 		[Export ("numberOfChildItemsAtIndexPath:")]
 		nint NumberOfChildItems (NSIndexPath indexPath);
+
+		[iOS (10,0)]
+		[Async]
+		[Export ("contentItemForIdentifier:completionHandler:")]
+		void GetContentItem (string identifier, Action<MPContentItem, NSError> completionHandler);
 	}
 
 	interface IMPPlayableContentDataSource {
@@ -1392,8 +1401,13 @@ namespace XamCore.MediaPlayer {
 		void ContextUpdated (MPPlayableContentManager contentManager, MPPlayableContentManagerContext context);
 
 		[iOS (9,0)]
+		[Deprecated (PlatformName.iOS, 9, 3, message: "Use InitializePlaybackQueue (MPPlayableContentManager, MPContentItem[], Action<NSError>) instead")]
 		[Export ("playableContentManager:initializePlaybackQueueWithCompletionHandler:")]
 		void InitializePlaybackQueue (MPPlayableContentManager contentManager, Action<NSError> completionHandler);
+
+		[iOS (9,3)]
+		[Export ("playableContentManager:initializePlaybackQueueWithContentItems:completionHandler:")]
+		void InitializePlaybackQueue (MPPlayableContentManager contentManager, [NullAllowed] MPContentItem[] contentItems, Action<NSError> completionHandler);
 	}
 
 	[NoTV]
@@ -1432,6 +1446,10 @@ namespace XamCore.MediaPlayer {
 		[iOS (8,4)]
 		[Export ("context")]
 		MPPlayableContentManagerContext Context { get; }
+
+		[iOS (10,0)]
+		[Export ("nowPlayingIdentifiers", ArgumentSemantic.Strong)]
+		string[] NowPlayingIdentifiers { get; set; }
 	}
 
 	[NoTV]
@@ -1487,6 +1505,24 @@ namespace XamCore.MediaPlayer {
 		NSNumber[] SupportedPlaybackRates { get; set; }
 	}
 
+	[iOS (8,0)]
+	[BaseType (typeof(MPRemoteCommand))]
+	[DisableDefaultCtor] // NSGenericException Reason: MPChangeShuffleModeCommand cannot be initialized externally.
+	interface MPChangeShuffleModeCommand
+	{
+		[Export ("currentShuffleType", ArgumentSemantic.Assign)]
+		MPShuffleType CurrentShuffleType { get; set; }
+	}
+
+	[iOS (8,0)]
+	[BaseType (typeof(MPRemoteCommand))]
+	[DisableDefaultCtor] // NSGenericException Reason: MPChangeRepeatModeCommand cannot be initialized externally.
+	interface MPChangeRepeatModeCommand
+	{
+		[Export ("currentRepeatType", ArgumentSemantic.Assign)]
+		MPRepeatType CurrentRepeatType { get; set; }
+	}
+
 	[Since (7,1)]
 	[BaseType (typeof (MPRemoteCommand))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPFeedbackCommands cannot be initialized externally.
@@ -1529,6 +1565,7 @@ namespace XamCore.MediaPlayer {
 
 	[Since (7,1)]
 	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor]
 	interface MPRemoteCommandCenter {
 
 		[Static]
@@ -1540,6 +1577,12 @@ namespace XamCore.MediaPlayer {
 
 		[Export ("changePlaybackRateCommand")]
 		MPChangePlaybackRateCommand ChangePlaybackRateCommand { get; }
+
+		[Export ("changeRepeatModeCommand")]
+		MPChangeRepeatModeCommand ChangeRepeatModeCommand { get; }
+
+		[Export ("changeShuffleModeCommand")]
+		MPChangeShuffleModeCommand ChangeShuffleModeCommand { get; }
 
 		[Export ("dislikeCommand")]
 		MPFeedbackCommand DislikeCommand { get; }
@@ -1656,6 +1699,36 @@ namespace XamCore.MediaPlayer {
 	interface MPChangeLanguageOptionCommandEvent {
 		[Export ("languageOption")]
 		MPNowPlayingInfoLanguageOption LanguageOption { get; }
+
+		[iOS (10,0)]
+		[Export ("setting")]
+		MPChangeLanguageOptionSetting Setting { get; }
+	}
+
+	[iOS (8,0)]
+	[BaseType (typeof(MPRemoteCommandEvent))]
+	[DisableDefaultCtor] // NSGenericException Reason: MPChangeShuffleModeCommandEvent cannot be initialized externally.
+	interface MPChangeShuffleModeCommandEvent
+	{
+		[Export ("shuffleType")]
+		MPShuffleType ShuffleType { get; }
+
+		[iOS (10,0)]
+		[Export ("preservesShuffleMode")]
+		bool PreservesShuffleMode { get; }
+	}
+
+	[iOS (8,0)]
+	[BaseType (typeof(MPRemoteCommandEvent))]
+	[DisableDefaultCtor] // NSGenericException Reason: MPChangeRepeatModeCommandEvent cannot be initialized externally.
+	interface MPChangeRepeatModeCommandEvent
+	{
+		[Export ("repeatType")]
+		MPRepeatType RepeatType { get; }
+
+		[iOS (10,0)]
+		[Export ("preservesRepeatMode")]
+		bool PreservesRepeatMode { get; }
 	}
 
 	[iOS (9,0)]

--- a/tests/monotouch-test/MediaPlayer/NowPlayingInfoCenterTest.cs
+++ b/tests/monotouch-test/MediaPlayer/NowPlayingInfoCenterTest.cs
@@ -23,7 +23,7 @@ namespace MonoTouchFixtures.MediaPlayer
 
 	[TestFixture]
 	[Preserve (AllMembers = true)]
-	public class MPNowPlayingInfoCenterTest
+	public class NowPlayingInfoCenterTest
 	{
 		MPNowPlayingInfo NowPlayingInfo;
 

--- a/tests/monotouch-test/MediaPlayer/RemoteCommandCenterTest.cs
+++ b/tests/monotouch-test/MediaPlayer/RemoteCommandCenterTest.cs
@@ -36,6 +36,8 @@ namespace MonoTouchFixtures.MediaPlayer {
 			MPRemoteCommandCenter shared = MPRemoteCommandCenter.Shared;
 			Assert.NotNull (shared.BookmarkCommand, "BookmarkCommand");
 			Assert.NotNull (shared.ChangePlaybackRateCommand, "ChangePlaybackRateCommand");
+			Assert.NotNull (shared.ChangeRepeatModeCommand, "ChangeRepeatModeCommand");
+			Assert.NotNull (shared.ChangeShuffleModeCommand, "ChangeShuffleModeCommand");
 			Assert.NotNull (shared.DislikeCommand, "DislikeCommand");
 			Assert.NotNull (shared.LikeCommand, "LikeCommand");
 			Assert.NotNull (shared.NextTrackCommand, "NextTrackCommand");

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -535,7 +535,7 @@
     <Compile Include="..\common\TestRuntime.cs">
       <Link>TestRuntime.cs</Link>
     </Compile>
-    <Compile Include="MediaPlayer\MPNowPlayingInfoCenterTest.cs" />
+    <Compile Include="MediaPlayer\NowPlayingInfoCenterTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
I did fix the code according to the `introspection` tests ran on iOS 9.3 however they seem to be broken anyway (crash).

Here are the logs, at this point I *think* it's not related to my changes.

```
 Marker - Jul 15, 2016, 9:27:48 AM
Jul 15 09:27:50 --- last message repeated 6 times ---
Jul 15 09:27:50 MacBook-Pro-2 introspection[31138]: [Runner executing:	Run Everything]
Jul 15 09:27:50 MacBook-Pro-2 introspection[31138]: [MonoTouch Version:	9.99.0]
Jul 15 09:27:50 MacBook-Pro-2 introspection[31138]: [Assembly:	monotouch.dll (32 bits)]
Jul 15 09:27:50 MacBook-Pro-2 introspection[31138]: [GC:	sgen]
Jul 15 09:27:50 MacBook-Pro-2 introspection[31138]: [iPhone:	iPhone OS v9.3]
Jul 15 09:27:50 MacBook-Pro-2 introspection[31138]: [Device Name:	iPhone Simulator]
Jul 15 09:27:50 MacBook-Pro-2 containermanagerd[26950]: 0x70000019a000 systemGroupContainerPath: com.apple.containermanagerd.internal is not entitled for system group identifier: systemgroup.com.apple.lsd
Jul 15 09:27:50 --- last message repeated 1 time ---
Jul 15 09:27:50 MacBook-Pro-2 introspection[31138]: [Device UDID:	FFFFFFFF8E557FA51D08464687712402AFC3E473]
Jul 15 09:27:50 MacBook-Pro-2 introspection[31138]: [Device Locale:	en_US]
Jul 15 09:27:50 MacBook-Pro-2 introspection[31138]: [Device Date/Time:	7/15/2016 9:27:50 AM]
Jul 15 09:27:50 MacBook-Pro-2 introspection[31138]: [Bundle:	com.xamarin.introspection]
Jul 15 09:27:50 MacBook-Pro-2 introspection[31138]: introspection.exe
Jul 15 09:27:50 MacBook-Pro-2 introspection[31138]: ApiCMAttachmentTest
Jul 15 09:27:50 MacBook-Pro-2 introspection[31138]: 	[PASS] ApiCMAttachmentTest.CheckAttachments
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]:  SecTrustEvaluate  [leaf AnchorTrusted]
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: CoreText performance note: Client called CTFontCreateWithName() using name "Arial" and got font with PostScript name "ArialMT". For best performance, only use PostScript names when calling this API.
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: CoreText performance note: Set a breakpoint on CTFontLogSuboptimalRequest to debug.
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: CoreText performance note: Client called CTFontCreateWithName() using name "Arial" and got font with PostScript name "ArialMT". For best performance, only use PostScript names when calling this API.
Jul 15 09:27:51 --- last message repeated 3 times ---
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: nw_endpoint_create_address Changing endpoint address length from 28 to 16, too long for family AF_INET
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: nw_endpoint_create_address Fixing endpoint address with non-zero sin_zero field
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: 	[PASS] ApiCMAttachmentTest.CheckFailAttachments
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: ApiCMAttachmentTest : 257 ms
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: ApiStructTest
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: 	[PASS] ApiStructTest.Structs
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: ApiStructTest : 10 ms
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: iOSApiClassPtrTest
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: CGDataConsumer(url_close): write failed.
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiClassPtrTest.ApiClassPtrTest.VerifyClassPtr
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiClassPtrTest.ApiClassPtrTest.VerifyClassPtrCategories
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: iOSApiClassPtrTest : 180 ms
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: iOSApiCtorInitTest
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: Attempting to load the view of a view controller while it is deallocating is not allowed and may result in undefined behavior (<UISearchController: 0x7c6123e0>)
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=31138
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=31138
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: (Error) MC: MobileContainerManager gave us a path we weren't expecting; file a radar against them
	Expected: /private/var/containers/Shared/SystemGroup/systemgroup.com.apple.configurationprofiles
	Actual: /Users/Vince/Library/Developer/CoreSimulator/Devices/92C5FAEF-1619-4549-9122-FFB4A25FF9D5/data/Containers/Shared/SystemGroup/systemgroup.com.apple.configurationprofiles
	Overriding MCM with the one true path
Jul 15 09:27:51 MacBook-Pro-2 webinspectord[26981]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:51 MacBook-Pro-2 webinspectord[26981]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:51 MacBook-Pro-2 webinspectord[26981]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:51 MacBook-Pro-2 webinspectord[26981]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=31138
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: Normal message received by listener connection. Ignoring.
Jul 15 09:27:51 --- last message repeated 1 time ---
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: Could not successfully update network info during initialization.
Jul 15 09:27:51 MacBook-Pro-2 cloudd[26987]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:51 MacBook-Pro-2 cloudd[26987]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:51 MacBook-Pro-2 cloudd[26987]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:51 MacBook-Pro-2 cloudd[26987]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:51 MacBook-Pro-2 cloudd[26987]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:51 MacBook-Pro-2 cloudd[26987]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:51 MacBook-Pro-2 cloudd[26987]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:51 MacBook-Pro-2 cloudd[26987]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: 2016-07-15 09:27:51.673+0200|31138|0x7be1b350|EventKitUI: EKAlarmsViewModel was initialized with a nil calendarItem.
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: 2016-07-15 09:27:51.674+0200|31138|0x7be1b350|EventKitUI: EKEventViewController: Getting event before setting it
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: 2016-07-15 09:27:51.674+0200|31138|0x7be1b350|EventKitUI: EKAlarmsViewModel was initialized with a nil calendarItem.
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: 2016-07-15 09:27:51.674+0200|31138|0x7be1b350|EventKitUI: EKEventViewController: Getting event before setting it
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: 2016-07-15 09:27:51.674+0200|31138|0x7be1b350|EventKitUI: EKAlarmsViewModel was initialized with a nil calendarItem.
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: 2016-07-15 09:27:51.674+0200|31138|0x7be1b350|EventKitUI: EKEventViewController: Getting event before setting it
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: 2016-07-15 09:27:51.675+0200|31138|0x7be1b350|EventKitUI: EKAlarmsViewModel was initialized with a nil calendarItem.
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: 2016-07-15 09:27:51.675+0200|31138|0x7be1b350|EventKitUI: EKEventViewController: Getting event before setting it
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: 2016-07-15 09:27:51.675+0200|31138|0x7be1b350|EventKitUI: EKAlarmsViewModel was initialized with a nil calendarItem.
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: 2016-07-15 09:27:51.675+0200|31138|0x7be1b350|EventKitUI: EKEventViewController: Getting event before setting it
Jul 15 09:27:51 MacBook-Pro-2 introspection[31138]: 2016-07-15 09:27:51.676+0200|31138|0x7be1b350|EventKitUI: EKAlarmsViewModel was initialized with a nil calendarItem.
Jul 15 09:27:52 MacBook-Pro-2 introspection[31138]: WAC: Browser: ERROR: Unable to load EA WAC UI bundle.
Jul 15 09:27:52 MacBook-Pro-2 ExternalAccessory.framework[31138]: Wireless Accessory Configuration is not supported in the simulator.
Jul 15 09:27:52 MacBook-Pro-2 assertiond[26933]: assertion failed: 15F34 13E233: assertiond + 15801 [3C808658-78EC-3950-A264-79A64E0E463B]: 0x1
Jul 15 09:27:52 --- last message repeated 3 times ---
Jul 15 09:27:52 MacBook-Pro-2 StoreKitUIService[26988]: Failed to inherit CoreMedia permissions from 31138: (null)
Jul 15 09:27:52 MacBook-Pro-2 introspection[31138]: nw_path_get_status called with null path, dumping backtrace:
	        [i386] libnetcore-583.41.1
	    0   libsystem_network.dylib             0x0956a73f __nw_create_backtrace_string + 139
	    1   libsystem_network.dylib             0x0957e663 nw_path_get_status + 34
	    2   Network                             0x14b4d68a -[NWPath status] + 53
	    3   Network                             0x14b4cd1d -[NWPath statusAsString] + 41
	    4   Network                             0x14b4cd8e -[NWPath descriptionWithIndent:showFullContent:] + 84
	    5   Network                             0x14b4d596 -[NWPath description] + 49
	    6   introspection                       0x0035ee06 xamarin_dyn_objc_msgSend + 102
	    7   ???                                 0x18cf7c04 0x0 + 416250884
	    8   ???                                 0x1b7b630c 0x0 + 461071116
	    9   ???                                 0x1b7b621a 0x0 + 461070874
	    10  ???                                 0x1b7b6120 0x0 + 461070624
	    11  ???                                 0x1b7b605c 0x0 + 461070428
	    12  ???                                 0x1b7b26b4 0x0 + 461055668
	    13  ???                                 0x199c8b15 0x0 + 429689621
	    14  introspection                       0x001a8c82 mono_jit_runtime_invoke + 1458
	    15  introspection                       0x002730c2 do_runtime_invoke + 114
	    16  introspection                       0x002769d7 mono_runtime_try_invoke_array + 1255
	    17  introspection                       0x00276ea9 mono_runtime_invoke_array_checked + 57
	    18  introspection                       0x0021be18 ves_icall_InternalInvoke + 696
	    19  ???                                 0x1b49c1e4 0x0 + 457818596
	    20  ???                                 0x1b49bf6c 0x0 + 457817964
	    21  ???                                 0x1b49bd9a 0x0 + 457817498
	    22  ???                                 0x1b49bb64 0x0 + 457816932
	    23  ???                                 0x1b49baa4 0x0 + 457816740
	    24  ???                                 0x1b49ae14 0x0 + 457813524
	    25  ???                                 0x1b49ac20 0x0 + 457813024
	    26  ???                                 0x1b49a8c9 0x0 + 457812169
	    27  ???                                 0x1b49a7db 0x0 + 457811931
	    28  ???                                 0x1b4962fc 0x0 + 457794300
	    29  ???                                 0x1b495c84 0x0 + 457792644
	    30  ???                                 0x1b4982e3 0x0 + 457802467
	    31  ???                                 0x1b497024 0x0 + 457797668
	    32  ???                                 0x1b4962fc 0x0 + 457794300
	    33  ???                                 0x1b495c84 0x0 + 457792644
	    34  ???                                 0x1b4982e3 0x0 + 457802467
	    35  ???                                 0x1b497024 0x0 + 457797668
	    36  ???                                 0x1b4962fc 0x0 + 457794300
	    37  ???                                 0x1b495c84 0x0 + 457792644
	    38  ???                                 0x1b4982e3 0x0 + 457802467
	    39  ???                                 0x1b497024 0x0 + 457797668
	    40  ???                                 0x1b4962fc 0x0 + 457794300
	    41  ???                                 0x1b495c84 0x0 + 457792644
	    42  ???                                 0x1b493681 0x0 + 457782913
	    43  ???                                 0x1b2f7ac0 0x0 + 456096448
	    44  ???                                 0x1b2f79d5 0x0 + 456096213
	    45  ???                                 0x1b2f795d 0x0 + 456096093
	    46  ???                                 0x1b2f75e3 0x0 + 456095203
	    47  ???                                 0x1b2f7814 0x0 + 456095764
	    48  introspection                       0x001a8c82 mono_jit_runtime_invoke + 1458
	    49  introspection                       0x002730c2 do_runtime_invoke + 114
	    50  introspection                       0x00273027 mono_runtime_invoke + 231
	    51  introspection                       0x0035701a xamarin_invoke_trampoline + 6906
	    52  introspection                       0x0035e5fc xamarin_arch_trampoline + 156
	    53  introspection                       0x0035ecd6 xamarin_i386_common_trampoline + 36
	    54  UIKit                               0x037dd8dc -[UITableView _selectRowAtIndexPath:animated:scrollPosition:notifyDelegate:] + 1915
	    55  UIKit                               0x037ddb7d -[UITableView _userSelectRowAtPendingSelectionIndexPath:] + 455
	    56  UIKit                               0x037e3c7f __38-[UITableView touchesEnded:withEvent:]_block_invoke + 57
	    57  UIKit                               0x036777cb _runAfterCACommitDeferredBlocks + 337
	    58  UIKit                               0x0368da60 _cleanUpAfterCAFlushAndRunDeferredBlocks + 103
	    59  UIKit                               0x0369bef6 _afterCACommitHandler + 102
	    60  CoreFoundation                      0x0072075e __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 30
	    61  CoreFoundation                      0x007206be __CFRunLoopDoObservers + 398
	    62  CoreFoundation                      0x0071603c __CFRunLoopRun + 1340
	    63  CoreFoundation                      0x00715846 CFRunLoopRunSpecific + 470
	    64  CoreFoundation                      0x0071565b CFRunLoopRunInMode + 123
	    65  GraphicsServices                    0x0b673664 GSEventRunModal + 192
	    66  GraphicsServices                    0x0b6734a1 GSEventRun + 104
	    67  UIKit                               0x03669eb9 UIApplicationMain + 160
	    68  ???                                 0x199c5b0c 0x0 + 429677324
	    69  ???                                 0x199c58bc 0x0 + 429676732
	    70  ???                                 0x18cf7618 0x0 + 416249368
	    71  ???                                 0x18cf72a4 0x0 + 416248484
	    72  ???                                 0x18cf749b 0x0 + 416248987
	    73  introspection                       0x001a8c82 mono_jit_runtime_invoke + 1458
	    74  introspection                       0x002730c2 do_runtime_invoke + 114
	    75  introspection                       0x002758cd mono_runtime_exec_main + 1005
	    76  introspection                       0x0027540c mono_runtime_run_main + 876
	    77  introspection                       0x00122519 mono_jit_exec + 265
	    78  introspection                       0x0035da33 xamarin_main + 2611
	    79  introspection                       0x0035f0e1 main + 65
	    80  libdyld.dylib                       0x09363a25 start + 1
Jul 15 09:27:52 MacBook-Pro-2 introspection[31138]: nw_path_get_reason called with null path, dumping backtrace:
	        [i386] libnetcore-583.41.1
	    0   libsystem_network.dylib             0x0956a73f __nw_create_backtrace_string + 139
	    1   libsystem_network.dylib             0x0957f53d nw_path_get_reason + 34
	    2   Network                             0x14b4ea5f -[NWPath reason] + 53
	    3   Network                             0x14b4cde7 -[NWPath descriptionWithIndent:showFullContent:] + 173
	    4   Network                             0x14b4d596 -[NWPath description] + 49
	    5   introspection                       0x0035ee06 xamarin_dyn_objc_msgSend + 102
	    6   ???                                 0x18cf7c04 0x0 + 416250884
	    7   ???                                 0x1b7b630c 0x0 + 461071116
	    8   ???                                 0x1b7b621a 0x0 + 461070874
	    9   ???                                 0x1b7b6120 0x0 + 461070624
	    10  ???                                 0x1b7b605c 0x0 + 461070428
	    11  ???                                 0x1b7b26b4 0x0 + 461055668
	    12  ???                                 0x199c8b15 0x0 + 429689621
	    13  introspection                       0x001a8c82 mono_jit_runtime_invoke + 1458
	    14  introspection                       0x002730c2 do_runtime_invoke + 114
	    15  introspection                       0x002769d7 mono_runtime_try_invoke_array + 1255
	    16  introspection                       0x00276ea9 mono_runtime_invoke_array_checked + 57
	    17  introspection                       0x0021be18 ves_icall_InternalInvoke + 696
	    18  ???                                 0x1b49c1e4 0x0 + 457818596
	    19  ???                                 0x1b49bf6c 0x0 + 457817964
	    20  ???                                 0x1b49bd9a 0x0 + 457817498
	    21  ???                                 0x1b49bb64 0x0 + 457816932
	    22  ???                                 0x1b49baa4 0x0 + 457816740
	    23  ???                                 0x1b49ae14 0x0 + 457813524
	    24  ???                                 0x1b49ac20 0x0 + 457813024
	    25  ???                                 0x1b49a8c9 0x0 + 457812169
	    26  ???                                 0x1b49a7db 0x0 + 457811931
	    27  ???                                 0x1b4962fc 0x0 + 457794300
	    28  ???                                 0x1b495c84 0x0 + 457792644
	    29  ???                                 0x1b4982e3 0x0 + 457802467
	    30  ???                                 0x1b497024 0x0 + 457797668
	    31  ???                                 0x1b4962fc 0x0 + 457794300
	    32  ???                                 0x1b495c84 0x0 + 457792644
	    33  ???                                 0x1b4982e3 0x0 + 457802467
	    34  ???                                 0x1b497024 0x0 + 457797668
	    35  ???                                 0x1b4962fc 0x0 + 457794300
	    36  ???                                 0x1b495c84 0x0 + 457792644
	    37  ???                                 0x1b4982e3 0x0 + 457802467
	    38  ???                                 0x1b497024 0x0 + 457797668
	    39  ???                                 0x1b4962fc 0x0 + 457794300
	    40  ???                                 0x1b495c84 0x0 + 457792644
	    41  ???                                 0x1b493681 0x0 + 457782913
	    42  ???                                 0x1b2f7ac0 0x0 + 456096448
	    43  ???                                 0x1b2f79d5 0x0 + 456096213
	    44  ???                                 0x1b2f795d 0x0 + 456096093
	    45  ???                                 0x1b2f75e3 0x0 + 456095203
	    46  ???                                 0x1b2f7814 0x0 + 456095764
	    47  introspection                       0x001a8c82 mono_jit_runtime_invoke + 1458
	    48  introspection                       0x002730c2 do_runtime_invoke + 114
	    49  introspection                       0x00273027 mono_runtime_invoke + 231
	    50  introspection                       0x0035701a xamarin_invoke_trampoline + 6906
	    51  introspection                       0x0035e5fc xamarin_arch_trampoline + 156
	    52  introspection                       0x0035ecd6 xamarin_i386_common_trampoline + 36
	    53  UIKit                               0x037dd8dc -[UITableView _selectRowAtIndexPath:animated:scrollPosition:notifyDelegate:] + 1915
	    54  UIKit                               0x037ddb7d -[UITableView _userSelectRowAtPendingSelectionIndexPath:] + 455
	    55  UIKit                               0x037e3c7f __38-[UITableView touchesEnded:withEvent:]_block_invoke + 57
	    56  UIKit                               0x036777cb _runAfterCACommitDeferredBlocks + 337
	    57  UIKit                               0x0368da60 _cleanUpAfterCAFlushAndRunDeferredBlocks + 103
	    58  UIKit                               0x0369bef6 _afterCACommitHandler + 102
	    59  CoreFoundation                      0x0072075e __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 30
	    60  CoreFoundation                      0x007206be __CFRunLoopDoObservers + 398
	    61  CoreFoundation                      0x0071603c __CFRunLoopRun + 1340
	    62  CoreFoundation                      0x00715846 CFRunLoopRunSpecific + 470
	    63  CoreFoundation                      0x0071565b CFRunLoopRunInMode + 123
	    64  GraphicsServices                    0x0b673664 GSEventRunModal + 192
	    65  GraphicsServices                    0x0b6734a1 GSEventRun + 104
	    66  UIKit                               0x03669eb9 UIApplicationMain + 160
	    67  ???                                 0x199c5b0c 0x0 + 429677324
	    68  ???                                 0x199c58bc 0x0 + 429676732
	    69  ???                                 0x18cf7618 0x0 + 416249368
	    70  ???                                 0x18cf72a4 0x0 + 416248484
	    71  ???                                 0x18cf749b 0x0 + 416248987
	    72  introspection                       0x001a8c82 mono_jit_runtime_invoke + 1458
	    73  introspection                       0x002730c2 do_runtime_invoke + 114
	    74  introspection                       0x002758cd mono_runtime_exec_main + 1005
	    75  introspection                       0x0027540c mono_runtime_run_main + 876
	    76  introspection                       0x00122519 mono_jit_exec + 265
	    77  introspection                       0x0035da33 xamarin_main + 2611
	    78  introspection                       0x0035f0e1 main + 65
	    79  libdyld.dylib                       0x09363a25 start + 1
Jul 15 09:27:52 MacBook-Pro-2 introspection[31138]: nw_path_get_reason_description called with null path, dumping backtrace:
	        [i386] libnetcore-583.41.1
	    0   libsystem_network.dylib             0x0956a73f __nw_create_backtrace_string + 139
	    1   libsystem_network.dylib             0x0957f5ae nw_path_get_reason_description + 34
	    2   Network                             0x14b4eaa8 -[NWPath reasonDescription] + 54
	    3   Network                             0x14b4ce23 -[NWPath descriptionWithIndent:showFullContent:] + 233
	    4   Network                             0x14b4d596 -[NWPath description] + 49
	    5   introspection                       0x0035ee06 xamarin_dyn_objc_msgSend + 102
	    6   ???                                 0x18cf7c04 0x0 + 416250884
	    7   ???                                 0x1b7b630c 0x0 + 461071116
	    8   ???                                 0x1b7b621a 0x0 + 461070874
	    9   ???                                 0x1b7b6120 0x0 + 461070624
	    10  ???                                 0x1b7b605c 0x0 + 461070428
	    11  ???                                 0x1b7b26b4 0x0 + 461055668
	    12  ???                                 0x199c8b15 0x0 + 429689621
	    13  introspection                       0x001a8c82 mono_jit_runtime_invoke + 1458
	    14  introspection                       0x002730c2 do_runtime_invoke + 114
	    15  introspection                       0x002769d7 mono_runtime_try_invoke_array + 1255
	    16  introspection                       0x00276ea9 mono_runtime_invoke_array_checked + 57
	    17  introspection                       0x0021be18 ves_icall_InternalInvoke + 696
	    18  ???                                 0x1b49c1e4 0x0 + 457818596
	    19  ???                                 0x1b49bf6c 0x0 + 457817964
	    20  ???                                 0x1b49bd9a 0x0 + 457817498
	    21  ???                                 0x1b49bb64 0x0 + 457816932
	    22  ???                                 0x1b49baa4 0x0 + 457816740
	    23  ???                                 0x1b49ae14 0x0 + 457813524
	    24  ???                                 0x1b49ac20 0x0 + 457813024
	    25  ???                                 0x1b49a8c9 0x0 + 457812169
	    26  ???                                 0x1b49a7db 0x0 + 457811931
	    27  ???                                 0x1b4962fc 0x0 + 457794300
	    28  ???                                 0x1b495c84 0x0 + 457792644
	    29  ???                                 0x1b4982e3 0x0 + 457802467
	    30  ???                                 0x1b497024 0x0 + 457797668
	    31  ???                                 0x1b4962fc 0x0 + 457794300
	    32  ???                                 0x1b495c84 0x0 + 457792644
	    33  ???                                 0x1b4982e3 0x0 + 457802467
	    34  ???                                 0x1b497024 0x0 + 457797668
	    35  ???                                 0x1b4962fc 0x0 + 457794300
	    36  ???                                 0x1b495c84 0x0 + 457792644
	    37  ???                                 0x1b4982e3 0x0 + 457802467
	    38  ???                                 0x1b497024 0x0 + 457797668
	    39  ???                                 0x1b4962fc 0x0 + 457794300
	    40  ???                                 0x1b495c84 0x0 + 457792644
	    41  ???                                 0x1b493681 0x0 + 457782913
	    42  ???                                 0x1b2f7ac0 0x0 + 456096448
	    43  ???                                 0x1b2f79d5 0x0 + 456096213
	    44  ???                                 0x1b2f795d 0x0 + 456096093
	    45  ???                                 0x1b2f75e3 0x0 + 456095203
	    46  ???                                 0x1b2f7814 0x0 + 456095764
	    47  introspection                       0x001a8c82 mono_jit_runtime_invoke + 1458
	    48  introspection                       0x002730c2 do_runtime_invoke + 114
	    49  introspection                       0x00273027 mono_runtime_invoke + 231
	    50  introspection                       0x0035701a xamarin_invoke_trampoline + 6906
	    51  introspection                       0x0035e5fc xamarin_arch_trampoline + 156
	    52  introspection                       0x0035ecd6 xamarin_i386_common_trampoline + 36
	    53  UIKit                               0x037dd8dc -[UITableView _selectRowAtIndexPath:animated:scrollPosition:notifyDelegate:] + 1915
	    54  UIKit                               0x037ddb7d -[UITableView _userSelectRowAtPendingSelectionIndexPath:] + 455
	    55  UIKit                               0x037e3c7f __38-[UITableView touchesEnded:withEvent:]_block_invoke + 57
	    56  UIKit                               0x036777cb _runAfterCACommitDeferredBlocks + 337
	    57  UIKit                               0x0368da60 _cleanUpAfterCAFlushAndRunDeferredBlocks + 103
	    58  UIKit                               0x0369bef6 _afterCACommitHandler + 102
	    59  CoreFoundation                      0x0072075e __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 30
	    60  CoreFoundation                      0x007206be __CFRunLoopDoObservers + 398
	    61  CoreFoundation                      0x0071603c __CFRunLoopRun + 1340
	    62  CoreFoundation                      0x00715846 CFRunLoopRunSpecific + 470
	    63  CoreFoundation                      0x0071565b CFRunLoopRunInMode + 123
	    64  GraphicsServices                    0x0b673664 GSEventRunModal + 192
	    65  GraphicsServices                    0x0b6734a1 GSEventRun + 104
	    66  UIKit                               0x03669eb9 UIApplicationMain + 160
	    67  ???                                 0x199c5b0c 0x0 + 429677324
	    68  ???                                 0x199c58bc 0x0 + 429676732
	    69  ???                                 0x18cf7618 0x0 + 416249368
	    70  ???                                 0x18cf72a4 0x0 + 416248484
	    71  ???                                 0x18cf749b 0x0 + 416248987
	    72  introspection                       0x001a8c82 mono_jit_runtime_invoke + 1458
	    73  introspection                       0x002730c2 do_runtime_invoke + 114
	    74  introspection                       0x002758cd mono_runtime_exec_main + 1005
	    75  introspection                       0x0027540c mono_runtime_run_main + 876
	    76  introspection                       0x00122519 mono_jit_exec + 265
	    77  introspection                       0x0035da33 xamarin_main + 2611
	    78  introspection                       0x0035f0e1 main + 65
	    79  libdyld.dylib                       0x09363a25 start + 1
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:52 MacBook-Pro-2 passd[26974]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:52 MacBook-Pro-2 introspection[31138]: Payment request is invalid: Error Domain=PKPassKitErrorDomain Code=1 "Invalid in-app payment request" UserInfo={NSUnderlyingError=0x8310ba50 {Error Domain=PKPassKitErrorDomain Code=1 "PKPaymentRequest must contain a property 'merchantIdentifier' of type 'NSString'" UserInfo={NSLocalizedDescription=PKPaymentRequest must contain a property 'merchantIdentifier' of type 'NSString'}}, NSLocalizedDescription=Invalid in-app payment request}
Jul 15 09:27:52 --- last message repeated 1 time ---
Jul 15 09:27:52 MacBook-Pro-2 tccd[26949]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:52 MacBook-Pro-2 tccd[26949]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:52 MacBook-Pro-2 assertiond[26933]: assertion failed: 15F34 13E233: assertiond + 15801 [3C808658-78EC-3950-A264-79A64E0E463B]: 0x1
Jul 15 09:27:52 --- last message repeated 2 times ---
Jul 15 09:27:52 MacBook-Pro-2 MusicUIService[26992]: Failed to inherit CoreMedia permissions from 31138: (null)
Jul 15 09:27:52 MacBook-Pro-2 tccd[26949]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:52 MacBook-Pro-2 tccd[26949]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:52 MacBook-Pro-2 assertiond[26933]: assertion failed: 15F34 13E233: assertiond + 15801 [3C808658-78EC-3950-A264-79A64E0E463B]: 0x1
Jul 15 09:27:52 --- last message repeated 2 times ---
Jul 15 09:27:52 MacBook-Pro-2 quicklookd[26990]: Failed to inherit CoreMedia permissions from 31138: (null)
Jul 15 09:27:52 MacBook-Pro-2 introspection[31138]: Use -removeDeferredKeyObserver: instead of -removeKeyObserver:
Jul 15 09:27:52 MacBook-Pro-2 introspection[31138]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=31138
Jul 15 09:27:52 MacBook-Pro-2 introspection[31138]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:52 MacBook-Pro-2 assertiond[26933]: assertion failed: 15F34 13E233: assertiond + 15801 [3C808658-78EC-3950-A264-79A64E0E463B]: 0x1
Jul 15 09:27:52 --- last message repeated 1 time ---
Jul 15 09:27:52 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiCtorInitTest.ApiCtorInitTest.DefaultCtorAllowed
Jul 15 09:27:52 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiCtorInitTest.ApiCtorInitTest.DesignatedInitializer
Jul 15 09:27:52 MacBook-Pro-2 introspection[31138]: iOSApiCtorInitTest : 1190 ms
Jul 15 09:27:52 MacBook-Pro-2 introspection[31138]: iOSApiFieldTest
Jul 15 09:27:52 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiFieldTest.ApiFieldTest.FieldExists
Jul 15 09:27:53 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiFieldTest.ApiFieldTest.NonNullNSStringFields
Jul 15 09:27:53 MacBook-Pro-2 introspection[31138]: iOSApiFieldTest : 774 ms
Jul 15 09:27:53 MacBook-Pro-2 introspection[31138]: iOSApiPInvokeTest
Jul 15 09:27:53 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiPInvokeTest.ApiPInvokeTest.Corlib
Jul 15 09:27:53 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiPInvokeTest.ApiPInvokeTest.Product
Jul 15 09:27:53 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiPInvokeTest.ApiPInvokeTest.Signatures
Jul 15 09:27:53 MacBook-Pro-2 syncdefaultsd[26965]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:53 MacBook-Pro-2 syncdefaultsd[26965]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:53 MacBook-Pro-2 syncdefaultsd[26965]: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
Jul 15 09:27:53 MacBook-Pro-2 syncdefaultsd[26965]: SecTaskCopyDebugDescription: introspection[31138]
Jul 15 09:27:53 MacBook-Pro-2 syncdefaultsd[26965]: (Error) can't find app for bundleID com.xamarin.introspection
Jul 15 09:27:53 MacBook-Pro-2 syncdefaultsd[26965]: (Error) Can't register com.xamarin.introspection
Jul 15 09:27:53 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiPInvokeTest.ApiPInvokeTest.SymbolExists
Jul 15 09:27:53 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiPInvokeTest.ApiPInvokeTest.System
Jul 15 09:27:53 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiPInvokeTest.ApiPInvokeTest.SystemCore
Jul 15 09:27:53 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiPInvokeTest.MonoTouchDialog
Jul 15 09:27:53 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiPInvokeTest.NUnitLite
Jul 15 09:27:53 MacBook-Pro-2 introspection[31138]: iOSApiPInvokeTest : 649 ms
Jul 15 09:27:53 MacBook-Pro-2 introspection[31138]: iOSApiProtocolTest
Jul 15 09:27:53 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiProtocolTest.ApiProtocolTest.Coding
Jul 15 09:27:54 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiProtocolTest.ApiProtocolTest.Copying
Jul 15 09:27:54 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiProtocolTest.ApiProtocolTest.GeneralCase
Jul 15 09:27:54 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiProtocolTest.ApiProtocolTest.MutableCopying
Jul 15 09:27:54 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiProtocolTest.SecureCoding
Jul 15 09:27:54 MacBook-Pro-2 introspection[31138]: 	[PASS] iOSApiProtocolTest.SupportsSecureCoding
Jul 15 09:27:54 MacBook-Pro-2 introspection[31138]: iOSApiProtocolTest : 600 ms
Jul 15 09:27:54 MacBook-Pro-2 introspection[31138]: iOSApiSelectorTest
Jul 15 09:27:55 MacBook-Pro-2 CoreSimulatorBridge[26937]: Requesting launch of com.xamarin.introspection with options: {
	    arguments =     (
	        "-monodevelop-port",
	        54464
	    );
	    environment =     {
	        "DYLD_INSERT_LIBRARIES" = "/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/monotouch-fixes.dylib";
	        "__XAMARIN_DEBUG_PORT__" = 54464;
	    };
	}
Jul 15 09:27:55 MacBook-Pro-2 CoreSimulatorBridge[26937]: Error Launching: Error Domain=NSPOSIXErrorDomain Code=51 "Network is unreachable" UserInfo={NSLocalizedDescription=Application launch failed., NSLocalizedFailureReason=A connection to the system service could not be established.}
Jul 15 09:27:55 MacBook-Pro-2 assertiond[26933]: assertion failed: 15F34 13E233: assertiond + 15801 [3C808658-78EC-3950-A264-79A64E0E463B]: 0x1
Jul 15 09:27:55 MacBook-Pro-2 SpringBoard[26929]: HW kbd: Failed to set (null) as keyboard focus
Jul 15 09:27:55 MacBook-Pro-2 assertiond[26933]: assertion failed: 15F34 13E233: assertiond + 15801 [3C808658-78EC-3950-A264-79A64E0E463B]: 0x1
 ```