### PR TITLE
[messages] Fixes wrt xtro-sharpie errors

### DIFF
--- a/src/messages.cs
+++ b/src/messages.cs
@@ -35,6 +35,7 @@ namespace XamCore.Messages {
 	}
 
 	[Native]
+	[ErrorDomain ("MSMessagesErrorDomain")]
 	public enum MSMessageErrorCode : nint
 	{
 		FileNotFound = 1,
@@ -295,7 +296,7 @@ namespace XamCore.Messages {
 
 	[iOS (10,0)]
 	[BaseType (typeof(UIViewController))]
-	interface MSStickerBrowserViewController : IMSStickerBrowserViewDataSource
+	interface MSStickerBrowserViewController : MSStickerBrowserViewDataSource
 	{
 		[Export ("initWithStickerSize:")]
 		[DesignatedInitializer]


### PR DESCRIPTION
1. !missing-field! MSMessagesErrorDomain not bound
2. !missing-protocol-conformance! MSStickerBrowserViewController should conform to MSStickerBrowserViewDataSource