### PR TITLE
[tests] Ensure monotouch-test runs fine down to iOS 6.1

### DIFF
--- a/tests/monotouch-test/CoreText/FontTest.cs
+++ b/tests/monotouch-test/CoreText/FontTest.cs
@@ -42,72 +42,56 @@ namespace MonoTouchFixtures.CoreText {
 		[Test]
 		public void CTFontCreateWithNameAndOptions ()
 		{
-			// Apple documents CTFontCreateWithNameAndOptions as availble since 3.2 but it does not work before 7.0 (e.g. 6.1)
-			// it seems to be a known issue, http://stackoverflow.com/q/4419283 but I still left feedback to Apple to fix it
-			try {
-				using (var font = new CTFont ("HoeflerText-Regular", 10, CTFontOptions.Default)) {
-					Assert.That (font.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
-				}
-			}
-			catch (EntryPointNotFoundException) {
-				Assert.True (!UIDevice.CurrentDevice.CheckSystemVersion (7, 0), "< iOS 7.0");
+			TestRuntime.AssertXcodeVersion (5,0);
+
+			using (var font = new CTFont ("HoeflerText-Regular", 10, CTFontOptions.Default)) {
+				Assert.That (font.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
 			}
 		}
 
 		[Test]
 		public void CTFontCreateWithFontDescriptorAndOptions ()
 		{
-			// Apple documents CTFontCreateWithFontDescriptorAndOptions as availble since 3.2 but it does not work before 7.0 (e.g. 6.1)
-			// it seems to be a known issue, http://stackoverflow.com/q/4419283 but I still left feedback to Apple to fix it
-			try {
-				CTFontDescriptorAttributes fda = new CTFontDescriptorAttributes () {
-					FamilyName = "Courier",
-					StyleName = "Bold",
-					Size = 16.0f
-				};
-				using (var fd = new CTFontDescriptor (fda))
-				using (var font = new CTFont (fd, 10, CTFontOptions.Default)) {
-					Assert.That (font.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
-				}
-			}
-			catch (EntryPointNotFoundException) {
-				Assert.True (!UIDevice.CurrentDevice.CheckSystemVersion (7, 0), "< iOS 7.0");
+			TestRuntime.AssertXcodeVersion (5,0);
+
+			CTFontDescriptorAttributes fda = new CTFontDescriptorAttributes () {
+				FamilyName = "Courier",
+				StyleName = "Bold",
+				Size = 16.0f
+			};
+			using (var fd = new CTFontDescriptor (fda))
+			using (var font = new CTFont (fd, 10, CTFontOptions.Default)) {
+				Assert.That (font.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
 			}
 		}
 
 		[Test]
 		public void GetCascadeList ()
 		{
-			try {
-				using (var font = new CTFont ("HoeflerText-Regular", 10, CTFontOptions.Default)) {
-					Assert.NotNull (font.GetDefaultCascadeList (null), "null");
-				}
-			}
-			catch (EntryPointNotFoundException) {
-				Assert.True (!UIDevice.CurrentDevice.CheckSystemVersion (7, 0), "< iOS 7.0");
+			TestRuntime.AssertXcodeVersion (5,0);
+
+			using (var font = new CTFont ("HoeflerText-Regular", 10, CTFontOptions.Default)) {
+				Assert.NotNull (font.GetDefaultCascadeList (null), "null");
 			}
 		}
 
 		[Test]
 		public void GetLocalizedName ()
 		{
-			try {
-				using (var font = new CTFont ("HoeflerText-Regular", 10, CTFontOptions.Default)) {
-					Assert.NotNull (font.GetLocalizedName (CTFontNameKey.Copyright), "1");
+			TestRuntime.AssertXcodeVersion (5, 0);
 
-					// We need to check if we are using english as our main language since this is the known case
-					// that the following code works. It fails with spanish for example but it is a false positive
-					// because the localized name for this font Full option does not have a spanish representation
-					var language = NSLocale.PreferredLanguages [0];
-					if (language == "en") {
-						string str;
-						Assert.NotNull (font.GetLocalizedName (CTFontNameKey.Full, out str), "2");
-						Assert.NotNull (str, "out str");
-					}
+			using (var font = new CTFont ("HoeflerText-Regular", 10, CTFontOptions.Default)) {
+				Assert.NotNull (font.GetLocalizedName (CTFontNameKey.Copyright), "1");
+
+				// We need to check if we are using english as our main language since this is the known case
+				// that the following code works. It fails with spanish for example but it is a false positive
+				// because the localized name for this font Full option does not have a spanish representation
+				var language = NSLocale.PreferredLanguages [0];
+				if (language == "en") {
+					string str;
+					Assert.NotNull (font.GetLocalizedName (CTFontNameKey.Full, out str), "2");
+					Assert.NotNull (str, "out str");
 				}
-			}
-			catch (EntryPointNotFoundException) {
-				Assert.True (!UIDevice.CurrentDevice.CheckSystemVersion (7, 0), "< iOS 7.0");
 			}
 		}
 

--- a/tests/monotouch-test/Foundation/NSExpressionTest.cs
+++ b/tests/monotouch-test/Foundation/NSExpressionTest.cs
@@ -221,6 +221,8 @@ namespace MonoTouchFixtures.Foundation
 		[Test]
 		public void AnyKeyPropertiesTest ()
 		{
+			TestRuntime.AssertXcodeVersion (5, 0);
+
 			var availableProperties = new List<string> { };
 			using (var expression = NSExpression.FromAnyKey ()) {
 				Assert.AreEqual (NSExpressionType.AnyKey, expression.ExpressionType);

--- a/tests/monotouch-test/MediaPlayer/NowPlayingInfoCenterTest.cs
+++ b/tests/monotouch-test/MediaPlayer/NowPlayingInfoCenterTest.cs
@@ -27,11 +27,19 @@ namespace MonoTouchFixtures.MediaPlayer
 	{
 		MPNowPlayingInfo NowPlayingInfo;
 
+		bool v8_0 = TestRuntime.CheckSystemAndSDKVersion (8, 0);
+		bool v9_0 = TestRuntime.CheckSystemAndSDKVersion (9, 0);
+		bool v10_0 = TestRuntime.CheckSystemAndSDKVersion (10, 0);
+
 		[SetUp]
 		public void SetUp ()
 		{
-			var languageOption = new MPNowPlayingInfoLanguageOption (MPNowPlayingInfoLanguageOptionType.Audible, "en", null, "English", "en");
-			var languageOptionGroup = new MPNowPlayingInfoLanguageOptionGroup (new MPNowPlayingInfoLanguageOption [] { languageOption }, languageOption, false);
+			MPNowPlayingInfoLanguageOption languageOption = null;
+			MPNowPlayingInfoLanguageOptionGroup languageOptionGroup = null;
+			if (v9_0) {
+				languageOption = new MPNowPlayingInfoLanguageOption (MPNowPlayingInfoLanguageOptionType.Audible, "en", null, "English", "en");
+				languageOptionGroup = new MPNowPlayingInfoLanguageOptionGroup (new MPNowPlayingInfoLanguageOption [] { languageOption }, languageOption, false);
+			}
 			string file = Path.Combine (NSBundle.MainBundle.ResourcePath, "basn3p08.png");
 			using (var img = UIImage.FromFile (file)) {
 				NowPlayingInfo = new MPNowPlayingInfo {
@@ -43,8 +51,8 @@ namespace MonoTouchFixtures.MediaPlayer
 					PlaybackQueueCount = 10,
 					ChapterNumber = 1,
 					ChapterCount = 10,
-					AvailableLanguageOptions = new MPNowPlayingInfoLanguageOptionGroup [] { languageOptionGroup },
-					CurrentLanguageOptions = new MPNowPlayingInfoLanguageOption [] { new MPNowPlayingInfoLanguageOption (MPNowPlayingInfoLanguageOptionType.Audible, "en", null, "English", "en") },
+					AvailableLanguageOptions = v9_0 ? new MPNowPlayingInfoLanguageOptionGroup [] { languageOptionGroup } : null,
+					CurrentLanguageOptions = v9_0 ? new MPNowPlayingInfoLanguageOption [] { new MPNowPlayingInfoLanguageOption (MPNowPlayingInfoLanguageOptionType.Audible, "en", null, "English", "en") } : null,
 					CollectionIdentifier = "Collection",
 					ExternalContentIdentifier = "ExternalContent",
 					ExternalUserProfileIdentifier = "ExternalUserProfile",
@@ -75,10 +83,6 @@ namespace MonoTouchFixtures.MediaPlayer
 			using (var dc = MPNowPlayingInfoCenter.DefaultCenter) {
 				dc.NowPlaying = NowPlayingInfo; // internal NSDictionary ToDictionary ()
 				var np = dc.NowPlaying; // internal MPNowPlayingInfo (NSDictionary source)
-
-				var v8_0 = TestRuntime.CheckSystemAndSDKVersion (8, 0);
-				var v9_0 = TestRuntime.CheckSystemAndSDKVersion (9, 0);
-				var v10_0 = TestRuntime.CheckSystemAndSDKVersion (10, 0);
 
 				Assert.IsInstanceOfType (typeof (double), np.ElapsedPlaybackTime, "#1");
 				Assert.IsInstanceOfType (typeof (double), np.PlaybackRate, "#2");


### PR DESCRIPTION
* Mostly missing checks

* FontTest: Apple never fixed that and the way we link now, without
  dlsym, makes the test crash

dyld: lazy symbol binding failed: Symbol not found: _CTFontCreateWithFontDescriptorAndOptions
  Referenced from: /var/mobile/Applications/6025D222-F50E-46E0-8BF5-9C45D4C7DACB/monotouchtest.app/monotouchtest
  Expected in: /System/Library/Frameworks/CoreText.framework/CoreText