### PR TITLE
[tests] Disable PassLibraryTest.Default on watchOS as it hangs the process

### DIFF
--- a/tests/monotouch-test/PassKit/PassLibraryTest.cs
+++ b/tests/monotouch-test/PassKit/PassLibraryTest.cs
@@ -27,6 +27,7 @@ namespace MonoTouchFixtures.PassKit {
 	[Preserve (AllMembers = true)]
 	public class PassLibraryTest {
 
+#if !__WATCHOS__ // hangs on watchOS 3 beta 2 simulator
 		[Test]
 		public void Defaults ()
 		{
@@ -59,7 +60,8 @@ namespace MonoTouchFixtures.PassKit {
 				library.Remove (pass);
 			}
 		}
-
+#endif
+		
 		[Test]
 		public void Fields ()
 		{


### PR DESCRIPTION
Jul 15 15:44:26 castor monotouchtest[42732]: [default] [ERROR] error while getting ubiquityIdentityToken: Error Domain=NSCocoaErrorDomain Code=4099 "The connection to service named com.apple.bird.token was invalidated." UserInfo={NSDebugDescription=The connection to service named com.apple.bird.token was invalidated.}

^ the above is printed several times after this