### PR TITLE
[Fix] Ensure that symbolication contains the aotid subdirs that will contain the msym files.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -165,11 +165,20 @@ namespace MTouchTests
 				} else {
 					Assert.AreEqual (has_mdb, File.Exists (Path.Combine (appDir, ".monotouch-32", "mscorlib.dll.mdb")), "#mdb");
 				}
-				if (is_sim) {
-					Assert.AreEqual (has_msym, File.Exists (Path.Combine (msymDir, "mscorlib.dll.msym")), "#msym");
-				} else {
-					Assert.AreEqual (has_msym, File.Exists (Path.Combine (msymDir, "32", "mscorlib.dll.msym")), "#msym");
-				}
+
+				if (has_msym) {
+					// assert that we do have the msym in one of the subdirs. We do not know the AOTID so we
+					// get all present files in the subdirs.
+					var dirInfo = new DirectoryInfo (msymDir);
+					var subDirs = dirInfo.GetDirectories ();
+					var msymFiles = new List<string> ();
+					foreach (var dir in subDirs) {
+						foreach (var f in dir.GetFiles ()) {
+							msymFiles.Add (f.Name);
+						}
+					}
+					Assert.AreEqual (has_msym, msymFiles.Contains ("mscorlib.dll.msym"));
+				} 
 			} finally {
 				Directory.Delete (testDir, true);
 			}

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1398,6 +1398,16 @@ namespace Xamarin.Bundler {
 			Driver.WriteIfDifferent (manifestPath, root.ToString ());
 		}
 
+		void CopyAssemblyData (Assembly asm, string targetDir)
+		{
+			var mvid = asm.AssemblyDefinition.MainModule.Mvid.ToString ().ToUpperInvariant ();
+			var assemblyDir = Path.Combine (targetDir, mvid);
+			if (!Directory.Exists (assemblyDir))
+				Directory.CreateDirectory (assemblyDir);
+			asm.CopyToDirectory (assemblyDir, reload: false, only_copy: true);
+			asm.CopyMSymToDirectory (targetDir);
+		}
+
 		public void BuildMSymDirectory ()
 		{
 			if (!EnableMSym)
@@ -1409,11 +1419,7 @@ namespace Xamarin.Bundler {
 					Directory.CreateDirectory (target_directory);
 				GenerateMSymManifest (target, target_directory);
 				foreach (var asm in target.Assemblies) {
-					var msym_file = asm.FileName + ".msym";
-					var src = Path.Combine (target.BuildDirectory, msym_file);
-					if (File.Exists (src))
-						UpdateFile (src, Path.Combine (target_directory, msym_file));
-					asm.CopyToDirectory (target_directory, reload: false, only_copy: true);
+					CopyAssemblyData (asm, target_directory);
 				}
 			}
 		}

--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -94,6 +94,26 @@ namespace Xamarin.Bundler {
 				Application.UpdateFile (mdb_src, mdb_target);
 			}
 		}
+		
+		public void CopyMSymToDirectory (string directory)
+		{
+			string msym_src = FullPath + ".aotid.msym";
+			var dirInfo = new DirectoryInfo (msym_src);
+			if (!dirInfo.Exists) // got no aot data
+				return;
+			var subdirs = dirInfo.GetDirectories();
+			foreach (var subdir in subdirs) {
+				var destPath = Path.Combine (directory, subdir.Name.ToUpperInvariant ());
+				var destInfo = new DirectoryInfo (destPath);
+				if (!destInfo.Exists)
+					Directory.CreateDirectory (destPath);
+				var files = subdir.GetFiles ();
+				foreach (FileInfo file in files) {
+					string temppath = Path.Combine (destPath, file.Name);
+					file.CopyTo(temppath, true);
+				}
+			}
+		}
 
 		public void CopyConfigToDirectory (string directory)
 		{

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -528,8 +528,10 @@ namespace Xamarin.Bundler
 			if (!app.UseDlsym (filename))
 				args.Append ("direct-pinvoke,");
 
-			if (app.EnableMSym)
-				args.Append ("gen-seq-points-file,");
+			if (app.EnableMSym) {
+				var msymdir = Quote (Path.Combine (outputDir, $"{fname}.aotid.msym"));
+				args.Append ($"msym-dir={msymdir},");
+			}
 
 			if (enable_llvm)
 				args.Append ("llvm-path=").Append (MonoTouchDirectory).Append ("/LLVM/bin/,");


### PR DESCRIPTION
After the mono bump we have the aotid of the msym files. We can create the correct subdirectories for the aot that are expected according to the spec.