### PR TITLE
[messages] Fix missleading binding

### DIFF
--- a/src/messages.cs
+++ b/src/messages.cs
@@ -260,7 +260,7 @@ namespace XamCore.Messages {
 
 		[Abstract]
 		[Export ("stickerBrowserView:stickerAtIndex:")]
-		MSSticker GetStickerBrowserView (MSStickerBrowserView stickerBrowserView, nint index);
+		MSSticker GetSticker (MSStickerBrowserView stickerBrowserView, nint index);
 	}
 
 	[iOS (10,0)]


### PR DESCRIPTION
Reported in bug #42635:
"IMSStickerBrowserViewDataSource.GetStickerBrowserView() should be GetSticker()"
https://bugzilla.xamarin.com/show_bug.cgi?id=42635

Indeed since the method returns an MSSticker there's no reason to keep
BrowserView in the method's name.