### PR TITLE
[src] Clear trace after printing it.

### DIFF
--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -2207,6 +2207,7 @@ namespace XamCore.Registrar {
 #if DEV
 				Console.WriteLine (trace.ToString ());
 #endif
+				trace.Clear ();
 			}
 		}
 


### PR DESCRIPTION
Makes the trace output less confusing since it will never be
printed twice (or more times).