### PR TITLE
NSErrorException should not accept null error, as it will throw later

### DIFF
--- a/src/Foundation/NSErrorException.cs
+++ b/src/Foundation/NSErrorException.cs
@@ -31,6 +31,8 @@ namespace XamCore.Foundation {
 
 		public NSErrorException (NSError error)
 		{
+			if (error == null)
+				throw new System.ArgumentNullException ("error");
 			this.error = error;
 		}
 		

--- a/src/Foundation/NSErrorException.cs
+++ b/src/Foundation/NSErrorException.cs
@@ -32,7 +32,7 @@ namespace XamCore.Foundation {
 		public NSErrorException (NSError error)
 		{
 			if (error == null)
-				throw new System.ArgumentNullException ("error");
+				throw new ArgumentNullException (nameof(error));
 			this.error = error;
 		}
 		


### PR DESCRIPTION
- https://bugzilla.xamarin.com/show_bug.cgi?id=42033
- Multiple proerties would poke the NSError reference, and NullReferenceException if a null was passed in.