### PR TITLE
[mediaplayer] Update for iOS 10 beta 3

### DIFF
--- a/src/MediaPlayer/MPMediaItem.cs
+++ b/src/MediaPlayer/MPMediaItem.cs
@@ -285,6 +285,13 @@ namespace XamCore.MediaPlayer {
 				return Int32ForProperty (IsExplicitProperty) != 0;
 			}
 		}
+
+		[iOS (10,0)]
+		public NSDate DateAdded {
+			get {
+				return (ValueForProperty (DateAddedProperty) as NSDate);
+			}
+		}
 	}
 }
 

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -238,6 +238,11 @@ namespace XamCore.MediaPlayer {
 		[Field ("MPMediaItemPropertyHasProtectedAsset")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString HasProtectedAssetProperty { get; }
+
+		[iOS (10, 0)]
+		[Field ("MPMediaItemPropertyDateAdded")]
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
+		NSString DateAddedProperty { get; }
 	}
 
 	[BaseType (typeof (NSObject))]

--- a/tests/monotouch-test/MediaPlayer/MediaItemTest.cs
+++ b/tests/monotouch-test/MediaPlayer/MediaItemTest.cs
@@ -75,8 +75,10 @@ namespace MonoTouchFixtures.MediaPlayer {
 					Assert.DoesNotThrow (() => dummy = i.UserGrouping, "UserGrouping");
 					if (nine_dot_two)
 						Assert.DoesNotThrow (() => dummy = i.HasProtectedAsset, "HasProtectedAsset");
-					if (ten_dot_oh)
+					if (ten_dot_oh) {
 						Assert.DoesNotThrow (() => dummy = i.IsExplicitItem, "IsExplicitItem");
+						Assert.DoesNotThrow (() => dummy = i.DateAdded, "DateAdded");
+					}
 				}
 			}
 		}


### PR DESCRIPTION
`monotouch-tests` updated to cover the new property and tests ran on **iOS 10 device**.