### PR TITLE
[security][tvos] Remove SecSharedCredential API

### DIFF
--- a/src/Security/SecSharedCredential.cs
+++ b/src/Security/SecSharedCredential.cs
@@ -1,4 +1,4 @@
-#if !MONOMAC && !WATCH
+#if IOS
 
 using System;
 using System.ComponentModel;

--- a/src/security.cs
+++ b/src/security.cs
@@ -83,6 +83,7 @@ namespace XamCore.Security {
 	
 	[Static]
 	[Since (8,0), NoMac, NoWatch]
+	[NoTV] // removed in tvOS 10
 	interface SecSharedCredential {
 		[Field ("kSecSharedPassword")]
 		NSString SharedPassword { get; }

--- a/tests/monotouch-test/Security/SecSharedCredentialTest.cs
+++ b/tests/monotouch-test/Security/SecSharedCredentialTest.cs
@@ -1,4 +1,4 @@
-#if !__WATCHOS__
+#if __IOS__
 using System;
 using System.Threading;
 
@@ -139,4 +139,4 @@ namespace MonoTouchFixtures.Security {
 
  	}
 }
-#endif // !__WATCHOS__
+#endif // __IOS__

--- a/tests/xtro-sharpie/ios.pending
+++ b/tests/xtro-sharpie/ios.pending
@@ -49,11 +49,6 @@
 # static methods in protocols are problematic
 !missing-selector! +UIViewControllerRestoration::viewControllerWithRestorationIdentifierPath:coder: not bound
 
-## added in iOS 8.0
-!missing-pinvoke! SecAddSharedWebCredential is not bound
-!missing-pinvoke! SecCreateSharedWebCredentialPassword is not bound
-!missing-pinvoke! SecRequestSharedWebCredential is not bound
-!missing-field! kSecSharedPassword not bound
 
 # the only member exists in OSX 10.11 - but there are empty protocols so it must be reported (and ignored)
 !missing-protocol! AVFragmentMinding not bound

--- a/tests/xtro-sharpie/tvos.ignore
+++ b/tests/xtro-sharpie/tvos.ignore
@@ -338,15 +338,6 @@
 !duplicate-type-name! VertexAttribPointerType enum exists as both OpenTK.Graphics.ES30.VertexAttribPointerType and OpenTK.Graphics.ES20.VertexAttribPointerType
 
 
-# Security
-
-## added in iOS 8.0
-!missing-pinvoke! SecAddSharedWebCredential is not bound
-!missing-pinvoke! SecCreateSharedWebCredentialPassword is not bound
-!missing-pinvoke! SecRequestSharedWebCredential is not bound
-!missing-field! kSecSharedPassword not bound
-
-
 # Non-Apple
 
 ## Xamarin (not Apple) type

--- a/tests/xtro-sharpie/tvos.pending
+++ b/tests/xtro-sharpie/tvos.pending
@@ -45,6 +45,15 @@
 !unknown-type! GKQuadTreeNode bound
 
 
+# Security
+
+## Xcode 8 beta (tvOS 10) marked them with __TVOS_UNAVAILABLE so we'll not expose them in 9.x
+!missing-pinvoke! SecAddSharedWebCredential is not bound
+!missing-pinvoke! SecCreateSharedWebCredentialPassword is not bound
+!missing-pinvoke! SecRequestSharedWebCredential is not bound
+!missing-field! kSecSharedPassword not bound
+
+
 # UIKit
 
 ## Apple docs: This property is inherited from the UIView parent class. This class changes the default value of this property to NO.


### PR DESCRIPTION
Xcode8 SDK (for tvOS 10) marked those API with __TVOS_UNAVAILABLE making
them only available on iOS.

Since the API are not yet released in stable (C8) so we can removing
them  proactively. It will be easier to add them back later (if the
situation change) than removing/obsoleting them.