### PR TITLE
[XM] - Fix protocol bindings that had BaseType but no Model

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -23528,13 +23528,8 @@ namespace XamCore.AppKit {
 		[Export ("fileType")]
 		string FileType { get; set; }
 
-		[Wrap ("WeakDelegate")]
-		[NullAllowed]
-		[Protocolize]
-		NSFilePromiseProviderDelegate Delegate { get; set; }
-
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
-		NSObject WeakDelegate { get; set; }
+		INSFilePromiseProviderDelegate Delegate { get; set; }
 
 		[NullAllowed, Export ("userInfo", ArgumentSemantic.Strong)]
 		NSObject UserInfo { get; set; }
@@ -23545,7 +23540,6 @@ namespace XamCore.AppKit {
 
 	[Mac (10,12)]
 	[Protocol]
-	[BaseType (typeof(NSObject))]
 	interface NSFilePromiseProviderDelegate
 	{
 		[Abstract]

--- a/src/safariservices.cs
+++ b/src/safariservices.cs
@@ -156,7 +156,6 @@ namespace XamCore.SafariServices {
 
 	[Mac (10,12)]
 	[Protocol]
-	[BaseType (typeof(NSObject))]
 	interface SFSafariExtensionHandling
 	{
 		[Export ("messageReceivedWithName:fromPage:userInfo:")]

--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -318,7 +318,8 @@ namespace Introspection {
 
 					var klass = new Class (t);
 					if (klass.Handle == IntPtr.Zero) {
-						// See https://trello.com/c/9JANewiM/607-apiprotocoltest-generalcase-assumes-every-protocol-has-model
+						// This can often by caused by [Protocol] classes with no [Model] but having a [BaseType].
+						// Either have both a Model and BaseType or neither
 						AddErrorLine ("[FAIL] Could not load {0}", t.FullName);
 					} else if (t.IsPublic && !ConformTo (klass.Handle, protocol)) {
 						// note: some internal types, e.g. like UIAppearance subclasses, return false (and there's not much value in changing this)

--- a/tests/introspection/Mac/MacApiProtocolTest.cs
+++ b/tests/introspection/Mac/MacApiProtocolTest.cs
@@ -177,8 +177,6 @@ namespace Introspection {
 #if !XAMCORE_3_0
 			case "NSRemoteSavePanel":
 			case "NSRemoteOpenPanel":
-			case "NSFilePromiseProviderDelegate": // We do not want Model - https://trello.com/c/9JANewiM/607-apiprotocoltest-generalcase-assumes-every-protocol-has-model
-			case "SFSafariExtensionHandling": // We do not want Model
 				return true; // These two classes don't show up in any documentation.
 #endif
 			}


### PR DESCRIPTION
- https://trello.com/c/9JANewiM
- My analysis was incorrect, the binding was wrong and the test caught it.
- If you have [Model] you must have [BaseType], and if you don't want [Model] you must not use [BaseType]