### PR TITLE
[CoreMidi] Fix MidiEndpoint dispose handle

### DIFF
--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -1867,8 +1867,9 @@ namespace XamCore.CoreMidi {
 				if (owns)
 					MIDIEndpointDispose (handle);
 				handle = MidiObject.InvalidRef;
-				gch.Free ();
 			}
+			if (gch.IsAllocated)
+				gch.Free ();
 		}
 
 		public string EndpointName { get; private set; }


### PR DESCRIPTION
Fix MidiEndpoint dispose handle, now it throws exception:
https://gist.github.com/olegoid/1c884816f56dd2f9fd3164c23e8aa8ff