### PR TITLE
[homekit] Add iOS 10 beta 2 missing bindings

### DIFF
--- a/src/HomeKit/HMAccessoryCategory.cs
+++ b/src/HomeKit/HMAccessoryCategory.cs
@@ -47,6 +47,8 @@ namespace XamCore.HomeKit {
 				// iOS 10.0
 				if (s == HMAccessoryCategoryTypesInternal.IPCamera)
 					return HMAccessoryCategoryType.IPCamera;
+				if (s == HMAccessoryCategoryTypesInternal.VideoDoorbell)
+					return HMAccessoryCategoryType.VideoDoorbell;
 				return HMAccessoryCategoryType.Other;
 			}
 		}

--- a/src/HomeKit/HMEnums.cs
+++ b/src/HomeKit/HMEnums.cs
@@ -552,6 +552,8 @@ namespace XamCore.HomeKit {
 		RangeExtender,
 		[iOS (10,0), Watch (3,0), TV (10,0)]
 		IPCamera,
+		[iOS (10,0), Watch (3,0), TV (10,0)]
+		VideoDoorbell,
 	}
 
 	[iOS (9,0)]

--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -982,7 +982,6 @@ namespace XamCore.HomeKit {
 		[Export ("manageUsersWithCompletionHandler:")]
 		void ManageUsers (Action<NSError> completion);
 
-		[NoTV]
 		[iOS (9,0)]
 		[Export ("homeAccessControlForUser:")]
 		HMHomeAccessControl GetHomeAccessControl (HMUser user);
@@ -1553,6 +1552,10 @@ namespace XamCore.HomeKit {
 		[Field ("HMAccessoryCategoryTypeThermostat")]
 		NSString Thermostat { get; }
 
+		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[Field ("HMAccessoryCategoryTypeVideoDoorbell")]
+		NSString VideoDoorbell { get; }
+
 		[Field ("HMAccessoryCategoryTypeWindow")]
 		NSString Window { get; }
 
@@ -1600,7 +1603,6 @@ namespace XamCore.HomeKit {
 		[NoTV]
 		[NoWatch]
 		[Export ("initWithName:events:predicate:")]
-		[DesignatedInitializer]
 		IntPtr Constructor (string name, HMEvent[] events, [NullAllowed] NSPredicate predicate);
 
 		[Export ("events", ArgumentSemantic.Copy)]

--- a/tests/xtro-sharpie/ios.pending
+++ b/tests/xtro-sharpie/ios.pending
@@ -30,6 +30,28 @@
 !unknown-type! GKQuadTreeNode bound
 
 
+# HomeKit
+
+# This was added and deprecated at the same time recommending the use of UpdateAudioStreamSetting.
+# We decided not to bind it, as it could be that Apple is just keeping it around because it's needed
+# somewhere else.
+!missing-selector! HMCameraStream::setAudioStreamSetting: not bound
+
+
+# Messages
+
+# No enum to attach the domain with.
+!missing-field! MSStickersErrorDomain not bound
+
+
+# MessageUI
+
+# [Native] available on XAMCORE_4_0
+!missing-enum-native! MFMailComposeErrorCode
+!missing-enum-native! MFMailComposeResult
+!missing-enum-native! MessageComposeResult
+
+
 # Speech
 ## iOS 10 beta 1 - use a non-public type in the signature https://trello.com/c/s6s6YKua
 !missing-selector! SFSpeechRecognizer::prepareWithRequest: not bound


### PR DESCRIPTION
- Made an API available for tvOS.
- Annotated ios.pending with things already bound.