### PR TITLE
AppKit: allow null to NSFont.SetUser* (bxc#42789)

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -5612,11 +5612,11 @@ namespace XamCore.AppKit {
 
 		[Static]
 		[Export ("setUserFont:")]
-		void SetUserFont (NSFont aFont);
+		void SetUserFont ([NullAllowed] NSFont aFont);
 
 		[Static]
 		[Export ("setUserFixedPitchFont:")]
-		void SetUserFixedPitchFont (NSFont aFont);
+		void SetUserFixedPitchFont ([NullAllowed] NSFont aFont);
 
 		[Static]
 		[Export ("systemFontOfSize:")]


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=42789