### PR TITLE
AppKit: NSWindowController.Document is nullable (bxc#42791)

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -18708,6 +18708,7 @@ namespace XamCore.AppKit {
 		bool ShouldCascadeWindows  { get; set; }
 	
 		[Export ("document")]
+		[NullAllowed]
 		NSDocument Document { get; set; }
 	
 		[Export ("setDocumentEdited:")]


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=42791