### PR TITLE
[runtime] Set base directory and config file name for extensions. Fixes #42784.

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -322,6 +322,12 @@
 
 		new Export ("MonoDomain *", "mono_get_root_domain"),
 
+		new Export ("void", "mono_domain_set_config", 
+			"MonoDomain *", "domain",
+			"const char *", "base_dir",
+			"const char *", "config_file_name"
+		),
+
 		#endregion
 
 		#region metadata/reflection.h

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -472,6 +472,14 @@ xamarin_main (int argc, char *argv[], bool is_extension)
 
 	int rv = 0;
 	if (is_extension) {
+		char base_dir [1024];
+		char config_file_name [1024];
+
+		snprintf (base_dir, sizeof (base_dir), "%s/" ARCH_SUBDIR, xamarin_get_bundle_path ());
+		snprintf (config_file_name, sizeof (config_file_name), "%s/%s.config", base_dir, xamarin_executable_name); // xamarin_executable_name should never be NULL for extensions.
+
+		mono_domain_set_config (mono_domain_get (), base_dir, config_file_name);
+
 		MONO_ENTER_GC_SAFE;
 		rv = xamarin_extension_main (argc, argv);
 		MONO_EXIT_GC_SAFE;


### PR DESCRIPTION
The base directory and config file name is normally set automatically
when we ask Mono to execute the Main function, but in the case of extensions,
there is no Main function, so these values are not set, causing some
features (reflection-only assembly load) to not work correctly.

https://bugzilla.xamarin.com/show_bug.cgi?id=42784