### PR TITLE
Use dlsym for user assemblies on iOS.

### DIFF
--- a/tests/linker-ios/dont link/DontLinkRegressionTests.cs
+++ b/tests/linker-ios/dont link/DontLinkRegressionTests.cs
@@ -170,5 +170,13 @@ namespace DontLink {
 			}
 		}
 #endif // __TVOS__ || __WATCHOS__
+
+
+#if __IOS__
+		// Test that we allow P/Invokes to functions that don't exist
+		// for functions in platform libraries.
+		[DllImport ("/usr/lib/libsqlite3.dylib")]
+		static extern void foo ();
+#endif
 	}
 }

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -221,6 +221,7 @@ namespace Xamarin.Bundler {
 
 			switch (Platform) {
 			case ApplePlatform.iOS:
+				return !Profile.IsSdkAssembly (Path.GetFileNameWithoutExtension (assembly));
 			case ApplePlatform.TVOS:
 			case ApplePlatform.WatchOS:
 				return false;


### PR DESCRIPTION
We tried disabling dlsym for all assemblies on iOS, but it turned
out to break a significant amount of customer code [1].

So re-enable it, but only for user assemblies (since we control
all assemblies we ship and can thus make sure those work with
dlsym disabled).

https://trello.com/c/guig1MF2/623-re-enable-dlsym-for-ios