### PR TITLE
[XM] Allow 64-bit system mono in XM apps

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
@@ -105,23 +105,18 @@ namespace Xamarin.Mac.Tasks
 			else if (TargetFrameworkVersion.StartsWith ("v", StringComparison.Ordinal))
 				args.Add ("/profile:" + TargetFrameworkVersion.Substring (1));
 
-			if (TargetFrameworkIdentifier == "Xamarin.Mac" || UseXamMacFullFramework) {
-				XamMacArch arch;
-				if (!Enum.TryParse<XamMacArch> (Architecture, true, out arch))
-					arch = XamMacArch.Default;
+			XamMacArch arch;
+			if (!Enum.TryParse<XamMacArch> (Architecture, true, out arch))
+				arch = XamMacArch.Default;
 
-				if (arch == XamMacArch.Default)
-					arch = XamMacArch.x86_64;
+			if (arch == XamMacArch.Default)
+				arch = XamMacArch.x86_64;
 
-				if (arch.HasFlag (XamMacArch.i386))
-					args.Add ("/arch:i386");
-
-				if (arch.HasFlag (XamMacArch.x86_64))
-					args.Add ("/arch:x86_64");
-			}
-			else {
+			if (arch.HasFlag (XamMacArch.i386))
 				args.Add ("/arch:i386");
-			}
+
+			if (arch.HasFlag (XamMacArch.x86_64))
+				args.Add ("/arch:x86_64");
 
 			if (!string.IsNullOrEmpty (ArchiveSymbols) && bool.TryParse (ArchiveSymbols.Trim (), out msym))
 				args.Add ("--msym:" + (msym ? "yes" : "no"));


### PR DESCRIPTION
- Back when this check was added, 64-bit mono was not standard/shipped. Now it is.