### PR TITLE
Enable logging during mac introspection tests on wrench

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -294,7 +294,7 @@ wrench-mac-binding-project:
 	cd mac-binding-project && git clean -xfdq
 
 wrench-mac-introspection:
-	$(Q) API_TEST_LOG_PROGRESS=1 $(MAKE) run-mac-introspection
+	$(Q) $(MAKE) run-mac-introspection
 	$(Q) $(MAKE) clean-mac-introspection
 
 else

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -294,7 +294,7 @@ wrench-mac-binding-project:
 	cd mac-binding-project && git clean -xfdq
 
 wrench-mac-introspection:
-	$(Q) $(MAKE) run-mac-introspection
+	$(Q) API_TEST_LOG_PROGRESS=1 $(MAKE) run-mac-introspection
 	$(Q) $(MAKE) clean-mac-introspection
 
 else

--- a/tests/introspection/Mac/MacApiCtorInitTest.cs
+++ b/tests/introspection/Mac/MacApiCtorInitTest.cs
@@ -26,7 +26,7 @@ namespace Introspection {
 
 		public MacApiCtorInitTest ()
 		{
-			//LogProgress = true;
+			LogProgress = true;
 			ContinueOnFailure = true;
 		}
 


### PR DESCRIPTION
- API_TEST_LOG_PROGRESS=1 on wrench introspection tests
- Try to track down a random crash
- https://bugzilla.xamarin.com/show_bug.cgi?id=42267