### PR TITLE
[runtime] Specify if MONO_REGISTRY_PATH points to a directory or not. Fixes #37794.

### DIFF
--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -347,7 +347,7 @@ update_environment (xamarin_initialize_data *data)
 		NSString *appBundleID = [[NSBundle mainBundle] bundleIdentifier];
 		NSURL *appSupport = [appSupportDirectories objectAtIndex: 0];
 		if (appSupport != nil && appBundleID != nil) {
-			NSURL *appDirectory = [appSupport URLByAppendingPathComponent:appBundleID];
+			NSURL *appDirectory = [appSupport URLByAppendingPathComponent:appBundleID isDirectory: YES];
 			setenv ("MONO_REGISTRY_PATH", [[appDirectory path] UTF8String], 1);
 		}
 	}


### PR DESCRIPTION
The [NSURL URLByAppendingPathComponent:] will try and check if a file:///
url is point to a directory or not, and in that process it will read metadata
about the file, which strangely enough makes macOS create a new thread.

Just after calling URLByAppendingPathComponent: we will call setenv to set
MONO_REGISTRY_PATH to the calculated path.

At the same time (sometimes _exactly_ at the same time) the new thread will
read the current environment variables.

Since getenv/setenv isn't thread-safe (!!!), there's a race condition here
that may once in a while cause a crash (bug #37794).

So instead of calling URLByAppendingPathComponent: we call
URLByAppendingPathComponent:isDirectory:, thus telling the API
if the resulting path is a directory or not, which means it doesn't
have to check (and won't create any new threads).

So with this change Xamarin.Mac apps are effectively single-threaded
until we're done setting environment variables.

https://bugzilla.xamarin.com/show_bug.cgi?id=37794