### PR TITLE
[CoreData][Fix] Change the enum to use the correct value used in the apple headers

### DIFF
--- a/src/CoreData/Enums.cs
+++ b/src/CoreData/Enums.cs
@@ -33,8 +33,8 @@ namespace XamCore.CoreData {
 		Custom = 0x01,
 		Add = 0x02,
 		Remove = 0x03,
-		Copy = 0x05,
-		Transform = 0x06
+		Copy = 0x04,
+		Transform = 0x05
 	}
 
 	// NUInteger -> NSAttributeDescription.h


### PR DESCRIPTION
As per apple headers:

typedef NS_ENUM(NSUInteger, NSEntityMappingType) {
    NSUndefinedEntityMappingType    = 0x00,
    NSCustomEntityMappingType       = 0x01,         /* developer handles destination instance creation */
    NSAddEntityMappingType          = 0x02,         /* new entity in destination */
    NSRemoveEntityMappingType       = 0x03,         /* source instances aren't mapped to destination */
    NSCopyEntityMappingType         = 0x04,         /* migrate instances as-is */
    NSTransformEntityMappingType    = 0x05,         /* entity exists in source and destination and is mapped */
};
