### PR TITLE
[coreanimation] Fix typo AnimationDescrete

### DIFF
--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -919,8 +919,13 @@ namespace XamCore.CoreAnimation {
 		[Field ("kCAAnimationLinear")]
 		NSString AnimationLinear { get; }
 				
+#if !XAMCORE_4_0
 		[Field ("kCAAnimationDiscrete")]
+		[Obsolete ("The name has been fixed, use AnimationDiscrete instead")]
 		NSString AnimationDescrete { get; }
+#endif
+		[Field ("kCAAnimationDiscrete")]
+		NSString AnimationDiscrete { get; }
 		
 		[Field ("kCAAnimationPaced")]
 		NSString AnimationPaced { get; }


### PR DESCRIPTION
Fixes bug #42951: Typo in constant name "CAKeyFrameAnimation.AnimationDescrete"
https://bugzilla.xamarin.com/show_bug.cgi?id=42951