### PR TITLE
[watchkit] Update for beta 4

### DIFF
--- a/src/watchkit.cs
+++ b/src/watchkit.cs
@@ -1004,9 +1004,6 @@ namespace XamCore.WatchKit {
 	[Watch (3,0)][NoiOS]
 	[BaseType (typeof (WKRefreshBackgroundTask))]
 	interface WKApplicationRefreshBackgroundTask {
-
-		[Export ("setTaskCompleted")]
-		void SetTaskCompleted ();
 	}
 
 	[Watch (3,0)][NoiOS]
@@ -1021,22 +1018,16 @@ namespace XamCore.WatchKit {
 	}
 
 	[Watch (3,0)][NoiOS]
-	[BaseType (typeof (WKRefreshBackgroundTask))]
-	interface WKURLSessionRefreshBackgroundTask {
+	[BaseType (typeof (WKRefreshBackgroundTask), Name = "WKURLSessionRefreshBackgroundTask")]
+	interface WKUrlSessionRefreshBackgroundTask {
 
 		[Export ("sessionIdentifier")]
 		string SessionIdentifier { get; }
-
-		[Export ("setTaskCompleted")]
-		void SetTaskCompleted ();
 	}
 
 	[Watch (3,0)][NoiOS]
 	[BaseType (typeof (WKRefreshBackgroundTask))]
 	interface WKWatchConnectivityRefreshBackgroundTask {
-
-		[Export ("setTaskCompleted")]
-		void SetTaskCompleted ();
 	}
 
 	[Watch (3,0)][NoiOS]


### PR DESCRIPTION
* Remove `setTaskCompleted` from 3 types as it's already defined in the
  base type;

* Fix `URL` to `Url` in WKUrlSessionRefreshBackgroundTask type name