### PR TITLE
Modifying the way GAC elimination works so it will work in MSBuild

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -65,7 +65,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<!-- Do not resolve from the GAC under any circumstances in Mobile or XM45 -->
 	<PropertyGroup Condition="(('$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(UseXamMacFullFramework)' == 'true') Or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac') And !$(MonoBundlingExtraArgs.Contains('--allow-unsafe-gac-resolution'))" >
-		<AssemblySearchPaths>$([System.String]::Copy('$(AssemblySearchPaths)').Replace('{GAC}',''))</AssemblySearchPaths>
+		<AssemblySearchPaths>$(AssemblySearchPaths).Replace('{GAC}','').Split(';')</AssemblySearchPaths>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
In MSBuild treating the property as a string will end up producing extra semicolon characters, which the build doesn't like. By re-splitting the string by the semicolons I let the engine rejoin them however it pleases, and that plays nicely with MSBuild.

This PR is sent for verification in xBuild. If that works, then it should be ok to merge.