### PR TITLE
Modifying the way GAC elimination works so it will work in MSBuild

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -65,7 +65,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<!-- Do not resolve from the GAC under any circumstances in Mobile or XM45 -->
 	<PropertyGroup Condition="(('$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(UseXamMacFullFramework)' == 'true') Or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac') And !$(MonoBundlingExtraArgs.Contains('--allow-unsafe-gac-resolution'))" >
-		<AssemblySearchPaths>$([System.String]::Copy('$(AssemblySearchPaths)').Replace('{GAC}',''))</AssemblySearchPaths>
+		<AssemblySearchPaths>$([System.String]::Copy('$(AssemblySearchPaths)').Replace('{GAC}','').Split(';'))</AssemblySearchPaths>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
I'm re-splitting the string after removing GAC to make MSBuild work correctly. If I don't, then it complains about wrong characters because of the semi-colons that get added.