### PR TITLE
[watchos][spritekit] Enable SpriteKit for watchOS

### DIFF
--- a/src/CoreVideo/CVPixelFormatType.cs
+++ b/src/CoreVideo/CVPixelFormatType.cs
@@ -1,0 +1,97 @@
+// 
+// CVPixelFormatType.cs
+//
+// Authors: Mono Team
+//     
+// Copyright 2011 Novell, Inc
+// Copyright 2011-2014, 2016 Xamarin Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+using XamCore.ObjCRuntime;
+
+namespace XamCore.CoreVideo {
+
+	// Note: CoreVideo is not supported in watchOS except for this enum
+	// for which ObjC API uses `int` instead of the enum
+	
+	// untyped enum, some are 4CC -> CVPixelBuffer.h
+	[Watch (3,0)]
+	public enum CVPixelFormatType : uint {
+		// FIXME: These all start with integers; what should we do here?
+		CV1Monochrome    = 0x00000001,
+		CV2Indexed       = 0x00000002,
+		CV4Indexed       = 0x00000004,
+		CV8Indexed       = 0x00000008,
+		CV1IndexedGray_WhiteIsZero = 0x00000021,
+		CV2IndexedGray_WhiteIsZero = 0x00000022,
+		CV4IndexedGray_WhiteIsZero = 0x00000024,
+		CV8IndexedGray_WhiteIsZero = 0x00000028,
+		CV16BE555        = 0x00000010,
+		CV24RGB          = 0x00000018,
+		CV32ARGB         = 0x00000020,
+		CV16LE555        = 0x4c353535,
+		CV16LE5551       = 0x35353531,
+		CV16BE565        = 0x42353635,
+		CV16LE565        = 0x4c353635,
+		CV24BGR          = 0x32344247,
+		CV32BGRA         = 0x42475241,
+		CV32ABGR         = 0x41424752,
+		CV32RGBA         = 0x52474241,
+		CV64ARGB         = 0x62363461,
+		CV48RGB          = 0x62343872,
+		CV32AlphaGray    = 0x62333261,
+		CV16Gray         = 0x62313667,
+		CV422YpCbCr8     = 0x32767579,
+		CV4444YpCbCrA8   = 0x76343038,
+		CV4444YpCbCrA8R  = 0x72343038,
+		CV444YpCbCr8     = 0x76333038,
+		CV422YpCbCr16    = 0x76323136,
+		CV422YpCbCr10    = 0x76323130,
+		CV444YpCbCr10    = 0x76343130,
+		CV420YpCbCr8Planar = 0x79343230,
+		CV420YpCbCr8PlanarFullRange    = 0x66343230,
+		CV422YpCbCr_4A_8BiPlanar = 0x61327679,
+		CV420YpCbCr8BiPlanarVideoRange = 0x34323076,
+		CV420YpCbCr8BiPlanarFullRange  = 0x34323066,
+		CV422YpCbCr8_yuvs = 0x79757673,
+		CV422YpCbCr8FullRange = 0x79757666,
+		CV30RGB = 0x5231306b,
+		CV4444AYpCbCr8   = 0x79343038,
+		CV4444AYpCbCr16  = 0x79343136,
+		// Since 5.1
+		OneComponent8 = 0x4C303038,
+		TwoComponent8 = 0x32433038,
+		// Since 6.0
+		OneComponent16Half	= 0x4C303068, // 'L00h'
+ 		OneComponent32Float = 0x4C303066, // 'L00f'
+		TwoComponent16Half  = 0x32433068, // '2C0h'
+		TwoComponent32Float = 0x32433066, // '2C0f'
+		CV64RGBAHalf		= 0x52476841, // 'RGhA'
+		CV128RGBAFloat		= 0x52476641, // 'RGfA'
+		// iOS 10
+		CV30RgbLePackedWideGamut = 0x77333072, // 'w30r'
+		CV14BayerGrbg = 0x67726234, // 'grb4',
+		CV14BayerRggb = 0x72676734, // 'rgg4',
+		CV14BayerBggr = 0x62676734, // 'bgg4',
+		CV14BayerGbrg = 0x67627234, // 'gbr4',
+	}
+}

--- a/src/CoreVideo/CoreVideo.cs
+++ b/src/CoreVideo/CoreVideo.cs
@@ -92,66 +92,6 @@ namespace XamCore.CoreVideo {
 		Last = -6699,
 	}
 
-	// untyped enum, some are 4CC -> CVPixelBuffer.h
-	public enum CVPixelFormatType : uint {
-		// FIXME: These all start with integers; what should we do here?
-		CV1Monochrome    = 0x00000001,
-		CV2Indexed       = 0x00000002,
-		CV4Indexed       = 0x00000004,
-		CV8Indexed       = 0x00000008,
-		CV1IndexedGray_WhiteIsZero = 0x00000021,
-		CV2IndexedGray_WhiteIsZero = 0x00000022,
-		CV4IndexedGray_WhiteIsZero = 0x00000024,
-		CV8IndexedGray_WhiteIsZero = 0x00000028,
-		CV16BE555        = 0x00000010,
-		CV24RGB          = 0x00000018,
-		CV32ARGB         = 0x00000020,
-		CV16LE555        = 0x4c353535,
-		CV16LE5551       = 0x35353531,
-		CV16BE565        = 0x42353635,
-		CV16LE565        = 0x4c353635,
-		CV24BGR          = 0x32344247,
-		CV32BGRA         = 0x42475241,
-		CV32ABGR         = 0x41424752,
-		CV32RGBA         = 0x52474241,
-		CV64ARGB         = 0x62363461,
-		CV48RGB          = 0x62343872,
-		CV32AlphaGray    = 0x62333261,
-		CV16Gray         = 0x62313667,
-		CV422YpCbCr8     = 0x32767579,
-		CV4444YpCbCrA8   = 0x76343038,
-		CV4444YpCbCrA8R  = 0x72343038,
-		CV444YpCbCr8     = 0x76333038,
-		CV422YpCbCr16    = 0x76323136,
-		CV422YpCbCr10    = 0x76323130,
-		CV444YpCbCr10    = 0x76343130,
-		CV420YpCbCr8Planar = 0x79343230,
-		CV420YpCbCr8PlanarFullRange    = 0x66343230,
-		CV422YpCbCr_4A_8BiPlanar = 0x61327679,
-		CV420YpCbCr8BiPlanarVideoRange = 0x34323076,
-		CV420YpCbCr8BiPlanarFullRange  = 0x34323066,
-		CV422YpCbCr8_yuvs = 0x79757673,
-		CV422YpCbCr8FullRange = 0x79757666,
-		CV30RGB = 0x5231306b,
-		CV4444AYpCbCr8   = 0x79343038,
-		CV4444AYpCbCr16  = 0x79343136,
-		// Since 5.1
-		OneComponent8 = 0x4C303038,
-		TwoComponent8 = 0x32433038,
-		// Since 6.0
-		OneComponent16Half	= 0x4C303068, // 'L00h'
- 		OneComponent32Float = 0x4C303066, // 'L00f'
-		TwoComponent16Half  = 0x32433068, // '2C0h'
-		TwoComponent32Float = 0x32433066, // '2C0f'
-		CV64RGBAHalf		= 0x52476841, // 'RGhA'
-		CV128RGBAFloat		= 0x52476641, // 'RGfA'
-		// iOS 10
-		CV30RgbLePackedWideGamut = 0x77333072, // 'w30r'
-		CV14BayerGrbg = 0x67726234, // 'grb4',
-		CV14BayerRggb = 0x72676734, // 'rgg4',
-		CV14BayerBggr = 0x62676734, // 'bgg4',
-		CV14BayerGbrg = 0x67627234, // 'gbr4',
-	}
 
 	// uint64_t -> CVBase.h
 	public enum CVOptionFlags : long {

--- a/src/Makefile
+++ b/src/Makefile
@@ -680,6 +680,8 @@ WATCH_BMONO = MONO_PATH=$(WATCH_LIBDIR)/repl $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/b
 WATCHOS_EXTRA_CORE_SOURCES = \
     $(WATCH_BUILD_DIR)/Constants.cs    \
     $(WATCH_BUILD_DIR)/AssemblyInfo.cs \
+    $(IOS_OPENTK_1_0_CORE_SOURCES)     \
+    CoreVideo/CVPixelFormatType.cs     \
 
 WATCHOS_CORE_SOURCES +=           \
     $(WATCHOS_EXTRA_CORE_SOURCES) \

--- a/src/SpriteKit/SKUniform.cs
+++ b/src/SpriteKit/SKUniform.cs
@@ -18,7 +18,7 @@ using Matrix2 = global::OpenTK.Matrix2;
 using Matrix3 = global::OpenTK.Matrix3;
 using Matrix4 = global::OpenTK.Matrix4;
 
-#if XAMCORE_2_0 || !MONOMAC
+#if (XAMCORE_2_0 || !MONOMAC) && !WATCH
 namespace XamCore.SpriteKit {
 	public partial class SKUniform {
 

--- a/src/SpriteKit/SKVideoNode.cs
+++ b/src/SpriteKit/SKVideoNode.cs
@@ -11,7 +11,7 @@ using System;
 using XamCore.Foundation;
 using XamCore.ObjCRuntime;
 
-#if XAMCORE_2_0 || !MONOMAC
+#if (XAMCORE_2_0 || !MONOMAC) && !WATCH
 namespace XamCore.SpriteKit {
 	public partial class SKVideoNode : SKNode {
 

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -538,6 +538,7 @@ CORETELEPHONY_CORE_SOURCES = \
 
 COREVIDEO_CORE_SOURCES = \
 	CoreVideo/CoreVideo.cs \
+	CoreVideo/CVPixelFormatType.cs \
 	CoreVideo/CVBuffer.cs \
 	CoreVideo/CVImageBuffer.cs \
 	CoreVideo/CVPixelBuffer.cs \
@@ -1471,6 +1472,7 @@ COMMON_FRAMEWORKS =         \
 	CoreFoundation          \
 	Foundation              \
 	GameKit                 \
+	SpriteKit               \
 
 MAC_FRAMEWORKS =            \
 	$(COMMON_FRAMEWORKS)    \
@@ -1533,7 +1535,6 @@ MAC_FRAMEWORKS =            \
 	SearchKit               \
 	Security                \
 	Social                  \
-	SpriteKit               \
 	StoreKit                \
 	SystemConfiguration     \
 	VideoToolbox            \
@@ -1612,7 +1613,6 @@ IOS_FRAMEWORKS =         \
 	Security \
 	Social \
 	Speech \
-	SpriteKit \
 	StoreKit \
 	SystemConfiguration \
 	Twitter \
@@ -1691,7 +1691,6 @@ TVOS_FRAMEWORKS =           \
 	ReplayKit               \
 	SceneKit                \
 	Security                \
-	SpriteKit               \
 	StoreKit                \
 	SystemConfiguration     \
 	TVMLKit                 \


### PR DESCRIPTION
A few things are left partially disabled as they requires SceneKit and AVFoundation

!missing-selector! SK3DNode::autoenablesDefaultLighting not bound
!missing-selector! SK3DNode::hitTest:options: not bound
!missing-selector! SK3DNode::isPlaying not bound
!missing-selector! SK3DNode::loops not bound
!missing-selector! SK3DNode::pointOfView not bound
!missing-selector! SK3DNode::sceneTime not bound
!missing-selector! SK3DNode::scnScene not bound
!missing-selector! SK3DNode::setAutoenablesDefaultLighting: not bound
!missing-selector! SK3DNode::setLoops: not bound
!missing-selector! SK3DNode::setPlaying: not bound
!missing-selector! SK3DNode::setPointOfView: not bound
!missing-selector! SK3DNode::setSceneTime: not bound
!missing-selector! SK3DNode::setScnScene: not bound
!missing-selector! SKAudioNode::avAudioNode not bound
!missing-selector! SKAudioNode::initWithAVAudioNode: not bound
!missing-selector! SKAudioNode::initWithFileNamed: not bound
!missing-selector! SKAudioNode::initWithURL: not bound
!missing-selector! SKAudioNode::setAvAudioNode: not bound
!missing-selector! SKScene::audioEngine not bound