### PR TITLE
[Make.config] Update Mono and XS max version

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -54,13 +54,13 @@ XCODE_DEVELOPER_ROOT=/Applications/Xcode8-beta4.app/Contents/Developer
 
 # Minimum Mono version
 MIN_MONO_VERSION=4.4.0.148
-MAX_MONO_VERSION=4.4.99
+MAX_MONO_VERSION=4.7.99
 MIN_MONO_URL=http://download.mono-project.com/archive/4.4.0/macos-10-universal/MonoFramework-MDK-4.4.0.148.macos10.xamarin.universal.pkg
 
 # Minimum Xamarin Studio version
 MIN_XAMARIN_STUDIO_URL=https://files.xamarin.com/~rolf/XamarinStudio-6.1.0.4373.dmg
 MIN_XAMARIN_STUDIO_VERSION=6.1.0.4373
-MAX_XAMARIN_STUDIO_VERSION=6.1.0.9999
+MAX_XAMARIN_STUDIO_VERSION=6.2.0.9999
 
 # Minimum OSX versions
 MIN_OSX_BUILD_VERSION=10.11


### PR DESCRIPTION
I had to install more recent versions or Mono/XS and `make world` in `xamarin-macios` works just fine with them.