### PR TITLE
[tests] Split mscorlib into two test assemblies. Fixes #41746.

### DIFF
--- a/tests/bcl-test/AppDelegate.cs
+++ b/tests/bcl-test/AppDelegate.cs
@@ -14,6 +14,16 @@ using NUnit.Framework.Internal.Filters;
 
 #if !__WATCHOS__
 
+public static partial class TestLoader
+{
+	static partial void AddTestAssembliesImpl (BaseTouchRunner runner);
+
+	public static void AddTestAssemblies (BaseTouchRunner runner)
+	{
+		AddTestAssembliesImpl (runner);
+	}
+}
+
 namespace BCL.Tests
 {
 	// The UIApplicationDelegate for the application. This class is responsible for launching the 
@@ -42,6 +52,7 @@ namespace BCL.Tests
 
 			// register every tests included in the main application/assembly
 			runner.Add (System.Reflection.Assembly.GetExecutingAssembly ());
+			TestLoader.AddTestAssemblies (runner);
 
 			window.RootViewController = new UINavigationController (runner.GetViewController ());
 			

--- a/tests/bcl-test/mscorlib/TestLoader.cs
+++ b/tests/bcl-test/mscorlib/TestLoader.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using MonoTouch.NUnit.UI;
+using NUnit.Framework.Internal.Filters;
+
+public static partial class TestLoader
+{
+	static partial void AddTestAssembliesImpl (BaseTouchRunner runner)
+	{
+		var assemblies = new HashSet<Assembly> ();
+		// Test files are sorted by namespace, so since we have two assemblies,
+		// pick something at the top (Mono) and at the bottom (System.Text) to
+		// make sure we get both assemblies.
+		assemblies.Add (typeof (MonoTests.Mono.DataConverterTest).Assembly);
+		assemblies.Add (typeof (MonoTests.System.Text.UTF8EncodingTest).Assembly);
+		if (assemblies.Count != 2)
+			throw new Exception ("Should have found two test assemblies");
+		foreach (var asm in assemblies)
+			runner.Add (asm);
+	}
+}

--- a/tests/bcl-test/mscorlib/mscorlib-split.csproj.template
+++ b/tests/bcl-test/mscorlib/mscorlib-split.csproj.template
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{6f47c092-2f85-43d6-#SPLIT##SPLIT##SPLIT##SPLIT#-e687426f6bf3}</ProjectGuid>
+    <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>BCL.Tests</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>mscorlibtests#SPLIT#</AssemblyName>
+    <NoWarn>168,169,219,414,612,618,649,672</NoWarn>
+    <TargetFrameworkIdentifier>MonoTouch</TargetFrameworkIdentifier>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Any CPU\Debug</OutputPath>
+    <DefineConstants>DEBUG;INSIDE_CORLIB;LIBC;NET_1_1;NET_2_0;NET_3_0;NET_3_5;NET_4_0;NET_4_5;MONO_DATACONVERTER_STATIC_METHODS;NET_2_1;MOBILE;MONOTOUCH;DISABLE_CAS_USE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>False</ConsolePause>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugType>none</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Any CPU\Release</OutputPath>
+    <DefineConstants>INSIDE_CORLIB;LIBC;NET_1_1;NET_2_0;NET_3_0;NET_3_5;NET_4_0;NET_4_5;MONO_DATACONVERTER_STATIC_METHODS;NET_2_1;MOBILE;MONOTOUCH;DISABLE_CAS_USE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="monotouch" />
+    <Reference Include="MonoTouch.NUnitLite" />
+  </ItemGroup>
+  <ItemGroup>
+#FILES#
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
+</Project>

--- a/tests/bcl-test/mscorlib/mscorlib.csproj.template
+++ b/tests/bcl-test/mscorlib/mscorlib.csproj.template
@@ -115,7 +115,8 @@
     </Compile>  
     <Compile Include="..\AppDelegate.cs">
       <Link>AppDelegate.cs</Link>
-    </Compile>  
+    </Compile>
+    <Compile Include="TestLoader.cs" />
   </ItemGroup>
   <ItemGroup>
 #FILES#
@@ -135,4 +136,14 @@
       <LogicalName>Resources.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>  
+  <ItemGroup>
+    <ProjectReference Include="mscorlib-0.csproj">
+      <Project>{6f47c092-2f85-43d6-1111-e687426f6bf3}</Project>
+      <Name>mscorlibtests0</Name>
+    </ProjectReference>
+    <ProjectReference Include="mscorlib-1.csproj">
+      <Project>{6f47c092-2f85-43d6-2222-e687426f6bf3}</Project>
+      <Name>mscorlibtests1</Name>
+    </ProjectReference>
+  </ItemGroup>
 </Project>

--- a/tests/watchos/Extension/InterfaceController.cs
+++ b/tests/watchos/Extension/InterfaceController.cs
@@ -9,6 +9,16 @@ using Foundation;
 using NUnit.Framework.Internal.Filters;
 using MonoTouch.NUnit.UI;
 
+public static partial class TestLoader
+{
+	static partial void AddTestAssembliesImpl (BaseTouchRunner runner);
+
+	public static void AddTestAssemblies (BaseTouchRunner runner)
+	{
+		AddTestAssembliesImpl (runner);
+	}
+}
+
 namespace monotouchtestWatchKitExtension
 {
 	[Register ("InterfaceController")]
@@ -66,6 +76,7 @@ namespace monotouchtestWatchKitExtension
 			runner = new WatchOSRunner ();
 			runner.Filter = new NotFilter (new CategoryExpression ("MobileNotWorking,NotOnMac,NotWorking,ValueAdd,CAS,InetAccess,NotWorkingInterpreter").Filter);
 			runner.Add (GetType ().Assembly);
+			TestLoader.AddTestAssemblies (runner);
 			ThreadPool.QueueUserWorkItem ((v) =>
 			{
 				runner.LoadSync ();

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -223,6 +223,8 @@ namespace xharness
 			var fsharp_test_suites = new string [] { "fsharp" };
 			var fsharp_library_projects = new string [] { "fsharplibrary" };
 			var bcl_suites = new string [] { "mscorlib", "System", "System.Core", "System.Data", "System.Net.Http", "System.Numerics", "System.Runtime.Serialization", "System.Transactions", "System.Web.Services", "System.Xml", "System.Xml.Linq", "Mono.Security", "System.ComponentModel.DataAnnotations", "System.Json", "System.ServiceModel.Web", "Mono.Data.Sqlite" };
+			IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bcl-test/mscorlib/mscorlib-0.csproj")), false));
+			IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bcl-test/mscorlib/mscorlib-1.csproj")), false));
 			foreach (var p in test_suites)
 				IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".csproj"))));
 			foreach (var p in fsharp_test_suites)


### PR DESCRIPTION
On watchOS we can't include all the tests for device in a single
assembly, because the native object code becomes too big.

So instead split the tests into two assemblies. Luckily this
is fairly easy for test projects, since they have few dependencies
between source files (there are some however, so source files
are grouped per directory so that files in the same directory do
not end up in different test projects). There is also some hard-coded
logic.

https://bugzilla.xamarin.com/show_bug.cgi?id=41746