### PR TITLE
[watchos][scenekit] Enable SceneKit on watchOS

### DIFF
--- a/src/SceneKit/Defs.cs
+++ b/src/SceneKit/Defs.cs
@@ -17,6 +17,7 @@ using Vector4 = global::OpenTK.Vector4;
 
 namespace XamCore.SceneKit {
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_8 | Platform.iOS_8_0)]
 	[Native] // untyped enum (SceneKitTypes.h) but described as the value of `code` for `NSError` which is an NSInteger
 	[ErrorDomain ("SCNErrorDomain")]
@@ -24,6 +25,7 @@ namespace XamCore.SceneKit {
 		ProgramCompilationError = 1,
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_8 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNGeometryPrimitiveType : nint {
@@ -35,6 +37,7 @@ namespace XamCore.SceneKit {
 		Polygon
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_8 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNTransparencyMode : nint {
@@ -42,12 +45,14 @@ namespace XamCore.SceneKit {
 		RgbZero
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_8 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNCullMode : nint {
 		Back, Front
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_8 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNFilterMode : nint {
@@ -56,6 +61,7 @@ namespace XamCore.SceneKit {
 		Linear
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_8 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNWrapMode : nint {
@@ -66,6 +72,7 @@ namespace XamCore.SceneKit {
 		Mirror
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_8 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNSceneSourceStatus : nint {
@@ -76,6 +83,7 @@ namespace XamCore.SceneKit {
 		Complete = 16
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_9 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNChamferMode : nint {
@@ -84,6 +92,7 @@ namespace XamCore.SceneKit {
 		Back
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_9 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNMorpherCalculationMode : nint {
@@ -91,6 +100,7 @@ namespace XamCore.SceneKit {
 		Additive
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNActionTimingMode : nint {
@@ -100,6 +110,7 @@ namespace XamCore.SceneKit {
 		EaseInEaseOut
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNShadowMode : nint {
@@ -108,6 +119,7 @@ namespace XamCore.SceneKit {
 		Modulated
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNPhysicsBodyType : nint {
@@ -116,6 +128,7 @@ namespace XamCore.SceneKit {
 		Kinematic
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNPhysicsFieldScope : nint {
@@ -123,6 +136,7 @@ namespace XamCore.SceneKit {
 		OutsideExtent
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleSortingMode : nint {
@@ -133,6 +147,7 @@ namespace XamCore.SceneKit {
 		YoungestFirst
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleBlendMode : nint {
@@ -144,6 +159,7 @@ namespace XamCore.SceneKit {
 		Replace
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleOrientationMode : nint {
@@ -153,6 +169,7 @@ namespace XamCore.SceneKit {
 		BillboardYAligned
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleBirthLocation : nint {
@@ -161,6 +178,7 @@ namespace XamCore.SceneKit {
 		Vertex
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleBirthDirection : nint {
@@ -169,6 +187,7 @@ namespace XamCore.SceneKit {
 		Random
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleImageSequenceAnimationMode : nint {
@@ -177,6 +196,7 @@ namespace XamCore.SceneKit {
 		AutoReverse
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleInputMode : nint {
@@ -185,6 +205,7 @@ namespace XamCore.SceneKit {
 		OverOtherProperty
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleModifierStage : nint {
@@ -194,6 +215,7 @@ namespace XamCore.SceneKit {
 		PostCollision
 	}
 
+	[Watch (3,0)]
 	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleEvent : nint {
@@ -231,6 +253,7 @@ namespace XamCore.SceneKit {
 		Any, Closest, All, 
 	}
 
+	[Watch (3,0)]
 	[Native]
 	public enum SCNAntialiasingMode : nuint {
 		None,
@@ -242,6 +265,7 @@ namespace XamCore.SceneKit {
 #endif
 	}
 
+	[Watch (3,0)]
 	[Native]
 	public enum SCNPhysicsCollisionCategory : nuint {
 		None	= 0,
@@ -254,6 +278,7 @@ namespace XamCore.SceneKit {
 #endif
 	}
 
+	[Watch (3,0)]
 	[iOS (9,0)][Mac (10,11)]
 	[Native]
 	public enum SCNBillboardAxis : nuint {
@@ -263,6 +288,7 @@ namespace XamCore.SceneKit {
 		All = (X | Y | Z)
 	}
 
+	[Watch (3,0)]
 	[iOS (9,0)][Mac (10,11)]
 	[Native]
 	public enum SCNReferenceLoadingPolicy : nint {
@@ -270,6 +296,7 @@ namespace XamCore.SceneKit {
 		OnDemand = 1
 	}
 
+	[Watch (3,0)]
 	[iOS (9,0)][Mac (10,11)]
 	[Native]
 	public enum SCNBlendMode : nint
@@ -282,6 +309,7 @@ namespace XamCore.SceneKit {
 		Replace = 5
 	}
 
+	[Watch (3,0)]
 	[iOS (9,0)][Mac (10,11)]
 	[Native]
 	[Flags]
@@ -296,6 +324,7 @@ namespace XamCore.SceneKit {
 		ShowWireframe = 1 << 5
 	}
 
+	[Watch (3,0)]
 	[iOS (9,0)][Mac (10,11)]
 	[Native]
 	public enum SCNRenderingApi : nuint
@@ -310,6 +339,7 @@ namespace XamCore.SceneKit {
 #endif
 	}
 
+	[Watch (3,0)]
 	[iOS (9,0)][Mac (10,11)]
 	[Native]
 	public enum SCNBufferFrequency : nint
@@ -319,6 +349,7 @@ namespace XamCore.SceneKit {
 		Shadable = 2,
 	}
 
+	[Watch (3,0)]
 	[TV (10, 0), Mac (10, 12), iOS (10, 0)]
 	[Native]
 	public enum SCNMovabilityHint : nint {

--- a/src/SceneKit/SCNAnimatable.cs
+++ b/src/SceneKit/SCNAnimatable.cs
@@ -7,6 +7,8 @@
 // Copyright 2014 Xamarin Inc. All rights reserved.
 //
 
+#if !WATCH
+
 using System;
 using System.Runtime.InteropServices;
 using XamCore.Foundation;
@@ -26,3 +28,5 @@ namespace XamCore.SceneKit
 		}
 	}
 }
+
+#endif

--- a/src/SceneKit/SCNGeometrySource.cs
+++ b/src/SceneKit/SCNGeometrySource.cs
@@ -11,7 +11,7 @@ using System;
 
 using XamCore.CoreGraphics;
 using XamCore.Foundation;
-#if XAMCORE_2_0 || !MONOMAC
+#if (XAMCORE_2_0 || !MONOMAC) && !WATCH
 using XamCore.Metal;
 #endif
 
@@ -74,7 +74,7 @@ namespace XamCore.SceneKit {
 			return FromData (data, SemanticToToken (semantic), vectorCount, floatComponents, componentsPerVector, bytesPerComponent, offset, stride);
 		}
 
-#if XAMCORE_2_0 || !MONOMAC
+#if (XAMCORE_2_0 || !MONOMAC) && !WATCH
 		public static SCNGeometrySource FromMetalBuffer (IMTLBuffer mtlBuffer, MTLVertexFormat vertexFormat, SCNGeometrySourceSemantics semantic, nint vertexCount, nint offset, nint stride)
 		{
 			return FromMetalBuffer (mtlBuffer, vertexFormat, SemanticToToken (semantic), vertexCount, offset, stride);

--- a/src/SceneKit/SCNJavaScript.cs
+++ b/src/SceneKit/SCNJavaScript.cs
@@ -7,6 +7,8 @@
 // Copyright 2014 Xamarin Inc. All rights reserved.
 //
 
+#if (XAMCORE_2_0 || !MONOMAC) && !WATCH
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -15,7 +17,6 @@ using XamCore.JavaScriptCore;
 
 namespace XamCore.SceneKit
 {
-#if XAMCORE_2_0 || !MONOMAC
 	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
 	public static class SCNJavaScript
 	{
@@ -30,5 +31,6 @@ namespace XamCore.SceneKit
 			SCNExportJavaScriptModule (context.Handle);
 		}
 	}
-#endif
 }
+
+#endif

--- a/src/SceneKit/SCNMatrix4.cs
+++ b/src/SceneKit/SCNMatrix4.cs
@@ -127,13 +127,15 @@ namespace XamCore.SceneKit
             Row3 = new SCNVector4(m30, m31, m32, m33);
         }
 
-	public SCNMatrix4 (XamCore.CoreAnimation.CATransform3D transform)
-	{
-		Row0 = new SCNVector4 ((pfloat)transform.m11, (pfloat)transform.m12, (pfloat)transform.m13, (pfloat)transform.m14);
-		Row1 = new SCNVector4 ((pfloat)transform.m21, (pfloat)transform.m22, (pfloat)transform.m23, (pfloat)transform.m24);
-		Row2 = new SCNVector4 ((pfloat)transform.m31, (pfloat)transform.m32, (pfloat)transform.m33, (pfloat)transform.m34);
-		Row3 = new SCNVector4 ((pfloat)transform.m41, (pfloat)transform.m42, (pfloat)transform.m43, (pfloat)transform.m44);
-	}
+#if !WATCH
+		public SCNMatrix4 (XamCore.CoreAnimation.CATransform3D transform)
+		{
+			Row0 = new SCNVector4 ((pfloat)transform.m11, (pfloat)transform.m12, (pfloat)transform.m13, (pfloat)transform.m14);
+			Row1 = new SCNVector4 ((pfloat)transform.m21, (pfloat)transform.m22, (pfloat)transform.m23, (pfloat)transform.m24);
+			Row2 = new SCNVector4 ((pfloat)transform.m31, (pfloat)transform.m32, (pfloat)transform.m33, (pfloat)transform.m34);
+			Row3 = new SCNVector4 ((pfloat)transform.m41, (pfloat)transform.m42, (pfloat)transform.m43, (pfloat)transform.m44);
+		}
+#endif
 	
         #endregion
 

--- a/src/SceneKit/SCNNode.cs
+++ b/src/SceneKit/SCNNode.cs
@@ -11,7 +11,9 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#if !WATCH
 using XamCore.CoreAnimation;
+#endif
 using XamCore.Foundation;
 
 namespace XamCore.SceneKit
@@ -42,6 +44,7 @@ namespace XamCore.SceneKit
 			return GetEnumerator ();
 		}
 
+#if !WATCH
 		public void AddAnimation (CAAnimation animation, string key)
 		{
 			if (key == null) {
@@ -128,5 +131,7 @@ namespace XamCore.SceneKit
 			EnumerateChildNodes (predHandler);
 		}
 #endif
+
+#endif // !WATCH
 	}
 }

--- a/src/SceneKit/SCNParticleSystem.cs
+++ b/src/SceneKit/SCNParticleSystem.cs
@@ -11,7 +11,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
-using XamCore.CoreAnimation;
 using XamCore.Foundation;
 
 namespace XamCore.SceneKit

--- a/src/SceneKit/SCNRenderingOptions.cs
+++ b/src/SceneKit/SCNRenderingOptions.cs
@@ -1,3 +1,5 @@
+#if !WATCH
+
 using System;
 using XamCore.ObjCRuntime;
 
@@ -22,3 +24,5 @@ namespace XamCore.SceneKit
 		}
 	}
 }
+
+#endif

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -37,9 +37,9 @@ using XamCore.Foundation;
 using XamCore.CoreGraphics;
 #if !WATCH
 using XamCore.CoreMedia;
-using XamCore.SceneKit;
 using XamCore.CloudKit;
 #endif
+using XamCore.SceneKit;
 using XamCore.Security;
 #if IOS
 using XamCore.CoreSpotlight;
@@ -9232,7 +9232,6 @@ namespace XamCore.Foundation
 		XamCore.CoreAnimation.CATransform3D CATransform3DValue { get; }
 #endif
 
-#if !WATCH
 		#region SceneKit Additions
 
 		[Mac (10,8), iOS (8,0)]
@@ -9260,7 +9259,6 @@ namespace XamCore.Foundation
 		SCNMatrix4 SCNMatrix4Value { get; }
 
 		#endregion
-#endif
 	}
 
 	[BaseType (typeof (NSObject))]

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1472,6 +1472,7 @@ COMMON_FRAMEWORKS =         \
 	CoreFoundation          \
 	Foundation              \
 	GameKit                 \
+	SceneKit                \
 	SpriteKit               \
 
 MAC_FRAMEWORKS =            \
@@ -1530,7 +1531,6 @@ MAC_FRAMEWORKS =            \
 	QuickLook               \
 	QuickLookUI             \
 	SafariServices          \
-	SceneKit                \
 	ScriptingBridge         \
 	SearchKit               \
 	Security                \
@@ -1609,7 +1609,6 @@ IOS_FRAMEWORKS =         \
 	QuickLook \
 	ReplayKit \
 	SafariServices \
-	SceneKit \
 	Security \
 	Social \
 	Speech \
@@ -1689,7 +1688,6 @@ TVOS_FRAMEWORKS =           \
 	OpenGLES                \
 	Photos                  \
 	ReplayKit               \
-	SceneKit                \
 	Security                \
 	StoreKit                \
 	SystemConfiguration     \

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1409,6 +1409,7 @@ public class NamespaceManager
 			Get ("Foundation"),
 			Get ("ObjCRuntime"),
 			Get ("CoreGraphics"),
+			Get ("SceneKit"),
 #if !WATCH
 			Get ("AudioUnit"),
 			Get ("CoreAnimation"),
@@ -1418,7 +1419,6 @@ public class NamespaceManager
 			Get ("CoreVideo"),
 			Get ("CoreMedia"),
 			Get ("Security"),
-			Get ("SceneKit"),
 			Get ("AVFoundation"),
 #endif
 #if MONOMAC

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -31,13 +31,17 @@ using System.ComponentModel;
 using XamCore.CoreFoundation;
 using XamCore.Foundation;
 using XamCore.ObjCRuntime;
-using XamCore.CoreAnimation;
-using XamCore.CoreGraphics;
-using XamCore.CoreImage;
-using XamCore.SpriteKit;
+
+#if !WATCH
 using XamCore.AVFoundation;
+using XamCore.CoreAnimation;
+using XamCore.CoreImage;
+#endif
+
+using XamCore.CoreGraphics;
+using XamCore.SpriteKit;
 // MonoMac (classic) does not support those 64bits only frameworks
-#if XAMCORE_2_0 || !MONOMAC
+#if (XAMCORE_2_0 || !MONOMAC) && !WATCH
 using XamCore.ModelIO;
 using XamCore.Metal;
 #endif
@@ -46,16 +50,45 @@ using XamCore.Metal;
 using XamCore.AppKit;
 using OpenTK;
 #else
+
+#if WATCH
+using NSView = global::XamCore.Foundation.NSObject; // won't be used -> [NoWatch] but must compile
+#else
 using XamCore.OpenGLES;
 
-using NSColor = global::XamCore.UIKit.UIColor;
 using NSView = global::XamCore.UIKit.UIView;
+#endif
+
+using NSColor = global::XamCore.UIKit.UIColor;
 using NSFont = global::XamCore.UIKit.UIFont;
 using NSImage = global::XamCore.UIKit.UIImage;
 using NSBezierPath = global::XamCore.UIKit.UIBezierPath;
 #endif
 
 namespace XamCore.SceneKit {
+
+#if WATCH
+	// stubs to limit the number of preprocessor directives in the source file
+	public interface CAAnimation {}
+	interface CALayer {}
+	interface CAMediaTimingFunction {}
+	interface MDLAsset {}
+	interface MDLCamera {}
+	interface MDLLight {}
+	interface MDLMaterial {}
+	interface MDLMesh {}
+	interface MDLObject {}
+	interface MDLSubmesh {}
+	enum MTLPixelFormat {}
+	enum MTLVertexFormat {}
+	interface IMTLBuffer {}
+	interface IMTLCommandBuffer {}
+	interface IMTLCommandQueue {}
+	interface IMTLDevice {}
+	interface IMTLLibrary {}
+	interface IMTLRenderCommandEncoder {}
+	interface MTLRenderPassDescriptor {}
+#endif
 
 	[Mac (10,8), iOS (8,0)]
 	delegate void SCNSceneSourceStatusHandler (float /* float, not CGFloat */ totalProgress, SCNSceneSourceStatus status, NSError error, ref bool stopLoading);
@@ -67,6 +100,7 @@ namespace XamCore.SceneKit {
 #if XAMCORE_2_0
 		[Abstract]
 #endif
+		[NoWatch]
 		[Export ("addAnimation:forKey:")]
 		void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
 
@@ -91,6 +125,7 @@ namespace XamCore.SceneKit {
 #if XAMCORE_2_0
 		[Abstract]
 #endif
+		[NoWatch]
 		[Export ("animationForKey:")]
 		CAAnimation GetAnimation (NSString key);
 
@@ -136,6 +171,7 @@ namespace XamCore.SceneKit {
 		[DesignatedInitializer]
 		IntPtr Constructor (SCNAudioSource source);
 	
+#if !WATCH // FIXME AVFoundation not yet enabled
 		[Export ("initWithAVAudioNode:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (AVAudioNode audioNode);
@@ -156,6 +192,7 @@ namespace XamCore.SceneKit {
 	
 		[NullAllowed, Export ("audioNode")]
 		AVAudioNode AudioNode { get; }
+#endif
 	
 		[NullAllowed, Export ("audioSource")]
 		SCNAudioSource AudioSource { get; }
@@ -392,6 +429,7 @@ namespace XamCore.SceneKit {
 		nuint CategoryBitMask { get; set; }
 
 #if XAMCORE_2_0
+		[NoWatch]
 		[iOS (9,0), Mac(10,11)]
 		[Static]
 		[Export ("cameraWithMDLCamera:")]
@@ -565,6 +603,7 @@ namespace XamCore.SceneKit {
 		SCNGeometrySource EdgeCreasesSource { get; set; }
 
 #if XAMCORE_2_0
+		[NoWatch]
 		[iOS (9,0), Mac(10,11)]
 		[Static]
 		[Export ("geometryWithMDLMesh:")]
@@ -616,6 +655,7 @@ namespace XamCore.SceneKit {
 		SCNGeometrySource FromTextureCoordinates (IntPtr texcoords, nint count);
 
 #if XAMCORE_2_0 || !MONOMAC
+		[NoWatch]
 		[iOS (9,0)][Mac (10,11)]
 		[Static]
 		[Export ("geometrySourceWithBuffer:vertexFormat:semantic:vertexCount:dataOffset:dataStride:")]
@@ -679,6 +719,7 @@ namespace XamCore.SceneKit {
 		SCNGeometryElement FromData ([NullAllowed] NSData data, SCNGeometryPrimitiveType primitiveType, nint primitiveCount, nint bytesPerIndex);
 
 #if XAMCORE_2_0
+		[NoWatch]
 		[iOS (9,0), Mac(10,11)]
 		[Static]
 		[Export ("geometryElementWithMDLSubmesh:")]
@@ -892,6 +933,7 @@ namespace XamCore.SceneKit {
 		nuint CategoryBitMask { get; set; }
 
 #if XAMCORE_2_0
+		[NoWatch]
 		[iOS (9,0), Mac(10,11)]
 		[Static]
 		[Export ("lightWithMDLLight:")]
@@ -1060,6 +1102,7 @@ namespace XamCore.SceneKit {
 		SCNMaterialProperty Roughness { get; }
 
 #if XAMCORE_2_0
+		[NoWatch]
 		[iOS (9,0), Mac(10,11)]
 		[Static]
 		[Export ("materialWithMDLMaterial:")]
@@ -1107,6 +1150,7 @@ namespace XamCore.SceneKit {
 		[Wrap ("Contents")]
 		NSImage ContentImage { get; set; }
 
+		[NoWatch]
 		[Wrap ("Contents")]
 		CALayer ContentLayer { get; set; }
 
@@ -1140,10 +1184,13 @@ namespace XamCore.SceneKit {
 		SCNMaterialProperty Create (NSObject contents);
 	}
 
+#if !WATCH
+	[NoWatch]
 	[StrongDictionary ("SCNProgram")]
 	interface SCNProgramSemanticOptions {
 		nuint MappingChannel { get; set; }
 	}
+#endif
 
 	[StrongDictionary ("SCNHitTest")]
 	interface SCNHitTestOptions {
@@ -1169,11 +1216,14 @@ namespace XamCore.SceneKit {
 		[TV (10, 0), Mac (10, 12), iOS (10, 0)]
 		[Export ("SCNSceneSourceLoading.OptionPreserveOriginalTopology")]
 		bool PreserveOriginalTopology { get; set; }
-#if !TVOS
+
+#if !TVOS && !WATCH
 		// note: generator's StrongDictionary does not support No* attributes yet
 		[NoTV]
+		[NoWatch]
 		float ConvertUnitsToMeters { get; set; } /* 'floating value encapsulated in a NSNumber' probably a float since it's a graphics framework */
 		[NoTV]
+		[NoWatch]
 		bool ConvertToYUp { get; set; }
 #endif
 
@@ -1238,9 +1288,11 @@ namespace XamCore.SceneKit {
 		[Export ("name", ArgumentSemantic.Copy)]
 		string Name { get; set;  }
 
+		[NoWatch]
 		[Export ("rendererDelegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakRendererDelegate { get; set;  }
 
+		[NoWatch]
 		[Wrap ("WeakRendererDelegate")]
 		[Protocolize]
 		SCNNodeRendererDelegate RendererDelegate { get; set; }
@@ -1405,6 +1457,7 @@ namespace XamCore.SceneKit {
 		#endregion
 
 #if XAMCORE_2_0
+		[NoWatch]
 		[iOS (9,0), Mac(10,11)]
 		[Static]
 		[Export ("nodeWithMDLObject:")]
@@ -1412,6 +1465,7 @@ namespace XamCore.SceneKit {
 #endif
 	}
 
+	[NoWatch]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[Model, Protocol]
@@ -1488,8 +1542,11 @@ namespace XamCore.SceneKit {
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		void SetSemantic (NSString geometrySourceSemantic, string symbol, [NullAllowed] NSDictionary options);
 
+#if !WATCH
+		[NoWatch]
 		[Wrap ("SetSemantic (geometrySourceSemantic, symbol, options == null ? null : options.Dictionary)")]
 		void SetSemantic (NSString geometrySourceSemantic, string symbol, SCNProgramSemanticOptions options);
+#endif
 
 		[Export ("semanticForSymbol:")]
 #if XAMCORE_4_0
@@ -1508,6 +1565,7 @@ namespace XamCore.SceneKit {
 		bool Opaque { [Bind ("isOpaque")] get; set; }
 
 #if XAMCORE_2_0
+		[NoWatch]
 		[iOS (9,0)][Mac (10,11)]
 		[NullAllowed]
 		[Export ("library", ArgumentSemantic.Retain)]
@@ -1606,11 +1664,13 @@ namespace XamCore.SceneKit {
 		double NextFrameTimeInSeconds { get; }
 
 #if XAMCORE_2_0 || !MONOMAC
+		[NoWatch]
 		[iOS (9,0)][Mac (10,11)]
 		[Static]
 		[Export ("rendererWithDevice:options:")]
 		SCNRenderer FromDevice ([NullAllowed] IMTLDevice device, [NullAllowed] NSDictionary options);
 
+		[NoWatch]
 		[iOS (9,0)][Mac (10,11)]
 		[Export ("renderAtTime:viewport:commandBuffer:passDescriptor:")]
 		void Render (double timeInSeconds, CGRect viewport, IMTLCommandBuffer commandBuffer, MTLRenderPassDescriptor renderPassDescriptor);
@@ -1780,6 +1840,7 @@ namespace XamCore.SceneKit {
 		NSString UpAxisAttributeKey { get; }
 
 #if XAMCORE_2_0
+		[NoWatch]
 		[iOS (9,0), Mac(10,11)]
 		[Static]
 		[Export ("sceneWithMDLAsset:")]
@@ -2156,6 +2217,7 @@ namespace XamCore.SceneKit {
 	#if XAMCORE_4_0
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 	#endif
+		[NoWatch]
 		[iOS (9,0)][Mac (10,11, onlyOn64 : true)] // IMTLRenderCommandEncoder -> Metal -> only on 64 bits
 		[NullAllowed, Export ("currentRenderCommandEncoder")]
 		IMTLRenderCommandEncoder CurrentRenderCommandEncoder { get; }
@@ -2163,6 +2225,7 @@ namespace XamCore.SceneKit {
 	#if XAMCORE_4_0
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 	#endif
+		[NoWatch]
 		[iOS (9,0)][Mac (10,11, onlyOn64 : true)]
 		[NullAllowed, Export ("device")]
 		IMTLDevice Device { get; }
@@ -2170,6 +2233,7 @@ namespace XamCore.SceneKit {
 	#if XAMCORE_4_0
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 	#endif
+		[NoWatch]
 		[iOS (9,0)][Mac (10,11, onlyOn64 : true)]
 		[Export ("colorPixelFormat")]
 		MTLPixelFormat ColorPixelFormat { get; }
@@ -2177,6 +2241,7 @@ namespace XamCore.SceneKit {
 	#if XAMCORE_4_0
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 	#endif
+		[NoWatch]
 		[iOS (9,0)][Mac (10,11, onlyOn64 : true)]
 		[Export ("depthPixelFormat")]
 		MTLPixelFormat DepthPixelFormat { get; }
@@ -2184,6 +2249,7 @@ namespace XamCore.SceneKit {
 	#if XAMCORE_4_0
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 	#endif
+		[NoWatch]
 		[iOS (9,0)][Mac (10,11, onlyOn64 : true)]
 		[Export ("stencilPixelFormat")]
 		MTLPixelFormat StencilPixelFormat { get; }
@@ -2191,10 +2257,13 @@ namespace XamCore.SceneKit {
 	#if XAMCORE_4_0
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
 	#endif
+		[NoWatch]
 		[iOS (9,0)][Mac (10,11, onlyOn64 : true)]
 		[NullAllowed, Export ("commandQueue")]
 		IMTLCommandQueue CommandQueue { get; }
 #endif
+
+#if !WATCH // FIXME: AVFoundation not yet enabled
 
 #if XAMCORE_4_0
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
@@ -2209,6 +2278,8 @@ namespace XamCore.SceneKit {
 		[iOS (9,0)][Mac (10,11, onlyOn64 : true)]
 		[Export ("audioEnvironmentNode")]
 		AVAudioEnvironmentNode AudioEnvironmentNode { get; }
+
+#endif // FIXME
 
 #if XAMCORE_4_0
 		[Abstract] // this protocol existed before iOS 9 (or OSX 10.11) and we cannot add abstract members to it (breaking changes)
@@ -2404,12 +2475,12 @@ namespace XamCore.SceneKit {
 		SCNTube Create (nfloat innerRadius, nfloat outerRadius, nfloat height);
 	}
 
+	[NoWatch]
 	[iOS (9,0)][Mac (10,11)]
 	[Static]
 	[Internal] // we'll make it public if there's a need for them (beside the strong dictionary we provide)
 	interface SCNRenderingOptionsKeys {
 
-		[NoWatch]
 		[Field ("SCNPreferredRenderingAPIKey")]
 		NSString RenderingApiKey { get; }
 
@@ -2420,6 +2491,8 @@ namespace XamCore.SceneKit {
 		NSString LowPowerDeviceKey { get; }
 	}
 
+#if !WATCH
+	[NoWatch]
 	[iOS (9,0)][Mac (10,11)]
 	[StrongDictionary ("SCNRenderingOptionsKeys")]
 	interface SCNRenderingOptions
@@ -2433,6 +2506,7 @@ namespace XamCore.SceneKit {
 
 		bool LowPowerDevice { get; set; }
 	}
+#endif
 
 	[Mac (10,8), iOS (8,0), NoWatch]
 	[BaseType (typeof (NSView))]
@@ -2456,18 +2530,18 @@ namespace XamCore.SceneKit {
 
 		[Export ("pixelFormat", ArgumentSemantic.Retain)]
 		NSOpenGLPixelFormat PixelFormat { get; set;  }
-#else
+#elif !WATCH
 		[Export ("eaglContext", ArgumentSemantic.Retain)]
 #if XAMCORE_2_0
 		EAGLContext EAGLContext { get; set; }
 #else
 		new EAGLContext Context { get; set; }
 #endif
-#endif
 
 		[iOS (9,0)][Mac (10,11)]
 		[Wrap ("this (frame, options != null ? options.Dictionary : null)")]
 		IntPtr Constructor (CGRect frame, [NullAllowed] SCNRenderingOptions options);
+#endif
 
 		[Export ("initWithFrame:options:")]
 		IntPtr Constructor (CGRect frame, [NullAllowed] NSDictionary options);
@@ -2505,6 +2579,7 @@ namespace XamCore.SceneKit {
 	[Mac (10,9), iOS (8,0)]
 	public delegate void SCNAnimationEventHandler (CAAnimation animation, NSObject animatedObject, bool playingBackward);
 
+	[NoWatch]
 	[Mac (10,9), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -2919,6 +2994,7 @@ namespace XamCore.SceneKit {
 		[Static, Export ("techniqueBySequencingTechniques:")]
 		SCNTechnique Create (SCNTechnique [] techniques);
 
+		[NoWatch]
 		[Export ("handleBindingOfSymbol:usingBlock:")]
 		void HandleBinding (string symbol, [NullAllowed] SCNBindingHandler handler);
 
@@ -3801,9 +3877,11 @@ namespace XamCore.SceneKit {
 	[DisableDefaultCtor]
 	interface SCNParticlePropertyController : NSSecureCoding, NSCopying {
 
+		[NoWatch]
 		[Static, Export ("controllerWithAnimation:")]
 		SCNParticlePropertyController Create (CAAnimation animation);
 
+		[NoWatch]
 		[Export ("animation", ArgumentSemantic.Retain)]
 		CAAnimation Animation { get; set; }
 

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -92,7 +92,8 @@ namespace XamCore.SceneKit {
 
 	[Mac (10,8), iOS (8,0)]
 	delegate void SCNSceneSourceStatusHandler (float /* float, not CGFloat */ totalProgress, SCNSceneSourceStatus status, NSError error, ref bool stopLoading);
-	
+
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[Model, Protocol]
 	[BaseType (typeof (NSObject))]
@@ -162,6 +163,7 @@ namespace XamCore.SceneKit {
 		void SetSpeed (nfloat speed, NSString key);
 	}
 
+	[Watch (3,0)]
 	[iOS(9,0),Mac(10,11)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
@@ -198,6 +200,7 @@ namespace XamCore.SceneKit {
 		SCNAudioSource AudioSource { get; }
 	}
 	
+	[Watch (3,0)]
 	[iOS (9,0), Mac(10,11)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
@@ -238,6 +241,7 @@ namespace XamCore.SceneKit {
 	}
 		
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[Model, Protocol]
 	[BaseType (typeof (NSObject))]
@@ -260,6 +264,7 @@ namespace XamCore.SceneKit {
 		bool GetBoundingSphere (ref SCNVector3 center, ref nfloat radius);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (SCNGeometry))]
 	interface SCNBox {
@@ -291,6 +296,7 @@ namespace XamCore.SceneKit {
 		SCNBox Create (nfloat width, nfloat height, nfloat length, nfloat chamferRadius);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	interface SCNCamera : SCNAnimatable, SCNTechniqueSupport, NSCopying, NSSecureCoding {
@@ -437,6 +443,7 @@ namespace XamCore.SceneKit {
 #endif
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (SCNGeometry))]
 	interface SCNCapsule {
@@ -459,6 +466,7 @@ namespace XamCore.SceneKit {
 		SCNCapsule Create (nfloat capRadius, nfloat height);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (SCNGeometry))]
 	interface SCNCone {
@@ -481,6 +489,7 @@ namespace XamCore.SceneKit {
 		SCNCone Create (nfloat topRadius, nfloat bottomRadius, nfloat height);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (SCNGeometry))]
 	interface SCNCylinder {
@@ -500,6 +509,7 @@ namespace XamCore.SceneKit {
 		SCNCylinder Create (nfloat radius, nfloat height);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (SCNGeometry))]
 	interface SCNFloor {
@@ -532,6 +542,7 @@ namespace XamCore.SceneKit {
 		SCNFloor Create ();
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] 
@@ -611,6 +622,7 @@ namespace XamCore.SceneKit {
 #endif
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	interface SCNGeometrySource : NSSecureCoding {
@@ -663,6 +675,7 @@ namespace XamCore.SceneKit {
 #endif
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[Static]
 	interface SCNGeometrySourceSemantic {
@@ -699,6 +712,7 @@ namespace XamCore.SceneKit {
 		NSString BoneIndices { get; }
 	}
 	
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	interface SCNGeometryElement : NSSecureCoding {
@@ -727,6 +741,7 @@ namespace XamCore.SceneKit {
 #endif
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[Static]
 	interface SCNHitTest {
@@ -766,6 +781,7 @@ namespace XamCore.SceneKit {
 		NSString OptionCategoryBitMaskKey { get; }
 	}
 	
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	// quote: The SCNHitTestResult class is exposed as the return object from the hitTest:options: method, as an array of SCNHitTestResult objects.
@@ -813,6 +829,7 @@ namespace XamCore.SceneKit {
 	}
 #endif
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	interface SCNLight : SCNAnimatable, SCNTechniqueSupport, NSCopying, NSSecureCoding {
@@ -941,6 +958,7 @@ namespace XamCore.SceneKit {
 #endif
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[Static]
 	interface SCNLightType {
@@ -992,6 +1010,7 @@ namespace XamCore.SceneKit {
 	}
 #endif
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[Static]
 	interface SCNLightingModel {
@@ -1012,6 +1031,7 @@ namespace XamCore.SceneKit {
 		NSString PhysicallyBased { get; }
 	}
 	
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	interface SCNMaterial : SCNAnimatable, SCNShadable, NSCopying, NSSecureCoding {
@@ -1110,6 +1130,7 @@ namespace XamCore.SceneKit {
 #endif
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // runtime -> [SCNKit ERROR] Do not instantiate SCNMaterialProperty objects directly
@@ -1192,6 +1213,7 @@ namespace XamCore.SceneKit {
 	}
 #endif
 
+	[Watch (3,0)]
 	[StrongDictionary ("SCNHitTest")]
 	interface SCNHitTestOptions {
 		bool FirstFoundOnly { get; set; }
@@ -1203,6 +1225,7 @@ namespace XamCore.SceneKit {
 		SCNNode RootNode { get; set; }
 	}
 
+	[Watch (3,0)]
 	[StrongDictionary ("SCNSceneSourceLoading")]
 	interface SCNSceneLoadingOptions {
 		NSUrl [] AssetDirectoryUrls { get; set; }
@@ -1237,6 +1260,7 @@ namespace XamCore.SceneKit {
 	[Mac (10, 8), iOS (8, 0)]
 	delegate void SCNNodeHandler (SCNNode node, out bool stop);
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	interface SCNNode : SCNAnimatable, SCNBoundingVolume, SCNActionable, NSCopying, NSSecureCoding {
@@ -1474,6 +1498,7 @@ namespace XamCore.SceneKit {
 		void Render (SCNNode node, SCNRenderer renderer, [NullAllowed] NSDictionary arguments);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (SCNGeometry))]
 	interface SCNPlane {
@@ -1607,6 +1632,7 @@ namespace XamCore.SceneKit {
 #endif
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (SCNGeometry))]
 	interface SCNPyramid {
@@ -1680,6 +1706,7 @@ namespace XamCore.SceneKit {
 		void Update (SCNNode [] lightProbes, double time);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[Static]
 	interface SCNRenderingArguments {
@@ -1705,6 +1732,7 @@ namespace XamCore.SceneKit {
 	[Mac (10,9), iOS (8,0)]
 	delegate void SCNSceneExportProgressHandler (float /* float, not CGFloat */ totalProgress, NSError error, out bool stop);
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	interface SCNScene : NSSecureCoding {
@@ -1860,6 +1888,7 @@ namespace XamCore.SceneKit {
 		NSUrl WriteImage (NSImage image, NSUrl documentUrl, [NullAllowed] NSUrl originalImageUrl);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -1933,6 +1962,7 @@ namespace XamCore.SceneKit {
 	}
 	public delegate bool SCNSceneSourceFilter (NSObject entry, NSString identifier, ref bool stop);
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[Static]
 	interface SCNSceneSourceLoading {
@@ -2006,6 +2036,7 @@ namespace XamCore.SceneKit {
 		NSString OptionPreserveOriginalTopology { get; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[Static]
 	interface SCNSceneSourceLoadErrors {
@@ -2022,6 +2053,7 @@ namespace XamCore.SceneKit {
 		NSString DetailedErrorsKey { get; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[Static]
 	interface SCNSceneSourceProperties {
@@ -2053,6 +2085,7 @@ namespace XamCore.SceneKit {
 		NSString AssetUnitMeterKey { get; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
@@ -2289,6 +2322,7 @@ namespace XamCore.SceneKit {
 		SCNNode AudioListener { get; set; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
@@ -2313,6 +2347,7 @@ namespace XamCore.SceneKit {
 		void DidSimulatePhysics ([Protocolize]SCNSceneRenderer renderer, double timeInSeconds);
 	}	
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (SCNGeometry))]
 	[DisableDefaultCtor] 
@@ -2331,6 +2366,7 @@ namespace XamCore.SceneKit {
 
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (SCNGeometry))]
 	[DisableDefaultCtor] 
@@ -2383,6 +2419,7 @@ namespace XamCore.SceneKit {
 		nfloat Flatness { get; set; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (SCNGeometry))]
 	[DisableDefaultCtor] 
@@ -2403,6 +2440,7 @@ namespace XamCore.SceneKit {
 		SCNTorus Create (nfloat ringRadius, nfloat pipeRadius);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	interface SCNTransaction {
@@ -2453,6 +2491,7 @@ namespace XamCore.SceneKit {
 		bool DisableActions { get; set; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[BaseType (typeof (SCNGeometry))]
 	interface SCNTube {
@@ -2588,6 +2627,7 @@ namespace XamCore.SceneKit {
 		SCNAnimationEvent Create (nfloat keyTime, SCNAnimationEventHandler eventHandler);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,9), iOS (8,0)]
 	[BaseType (typeof (SCNGeometry))]
 	public partial interface SCNShape {
@@ -2612,6 +2652,7 @@ namespace XamCore.SceneKit {
 		SCNShape Create (NSBezierPath path, nfloat extrusionDepth);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,9), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	interface SCNMorpher : SCNAnimatable, NSSecureCoding {
@@ -2629,6 +2670,7 @@ namespace XamCore.SceneKit {
 		nfloat GetWeight (nuint targetIndex);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,9), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -2665,6 +2707,7 @@ namespace XamCore.SceneKit {
 			SCNGeometrySource boneWeights, SCNGeometrySource boneIndices);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,9), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[Abstract]
@@ -2675,6 +2718,7 @@ namespace XamCore.SceneKit {
 		nfloat InfluenceFactor { get; set; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[BaseType (typeof (SCNConstraint))]
 	[DisableDefaultCtor]
@@ -2701,6 +2745,7 @@ namespace XamCore.SceneKit {
 		
 	}
 
+	[Watch (3,0)]
 	[Mac (10,9), iOS (8,0)]
 	[BaseType (typeof (SCNConstraint))]
 #if !MONOMAC || XAMCORE_2_0
@@ -2720,6 +2765,7 @@ namespace XamCore.SceneKit {
 	[Mac (10,9), iOS (8,0)]
 	delegate SCNMatrix4 SCNTransformConstraintHandler (SCNNode node, SCNMatrix4 transform);
 
+	[Watch (3,0)]
 	[Mac (10,9), iOS (8,0)]
 	[BaseType (typeof (SCNConstraint))]
 	[DisableDefaultCtor]
@@ -2728,6 +2774,7 @@ namespace XamCore.SceneKit {
 		SCNTransformConstraint Create (bool inWorldSpace, SCNTransformConstraintHandler transformHandler);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,9), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -2748,6 +2795,7 @@ namespace XamCore.SceneKit {
 		SCNLevelOfDetail CreateWithWorldSpaceDistance ([NullAllowed] SCNGeometry geometry, nfloat worldSpaceDistance);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,9), iOS (8,0)]
 	[Static]
 	interface _SCNShaderModifiers {
@@ -2765,6 +2813,7 @@ namespace XamCore.SceneKit {
 	}
 
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
@@ -2828,6 +2877,7 @@ namespace XamCore.SceneKit {
 	[Mac (10,10), iOS (8,0)]
 	delegate void SCNActionNodeWithElapsedTimeHandler (SCNNode node, nfloat elapsedTime);
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	interface SCNAction : NSCopying, NSSecureCoding {
@@ -2938,6 +2988,7 @@ namespace XamCore.SceneKit {
 	[Mac (10,8), iOS (8,0)]
 	delegate void SCNBindingHandler (uint /* unsigned int */ programId, uint /* unsigned int */ location, SCNNode renderedNode, SCNRenderer renderer);
 
+	[Watch (3,0)]
 	[StrongDictionary ("_SCNShaderModifiers")]
 	interface SCNShaderModifiers {
 		string EntryPointGeometry { get; set; }
@@ -2946,6 +2997,7 @@ namespace XamCore.SceneKit {
 		string EntryPointFragment { get; set; }
 	}
 	
+	[Watch (3,0)]
 	[Mac (10,9), iOS (8,0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
@@ -2974,7 +3026,7 @@ namespace XamCore.SceneKit {
 		void HandleUnbinding (string symbol, SCNBindingHandler handler);
 	}
 
-
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3008,6 +3060,7 @@ namespace XamCore.SceneKit {
 		void _SetObject ([NullAllowed] NSObject obj, INSCopying key);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
@@ -3018,6 +3071,7 @@ namespace XamCore.SceneKit {
 		SCNTechnique Technique { get; [NullAllowed] set; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[Static]
 	interface SCNPhysicsTestKeys {
@@ -3032,6 +3086,7 @@ namespace XamCore.SceneKit {
 		NSString BackfaceCullingKey { get; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[Static]
 	interface SCNPhysicsTestSearchModeKeys {
@@ -3046,6 +3101,7 @@ namespace XamCore.SceneKit {
 		NSString All { get; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3150,6 +3206,7 @@ namespace XamCore.SceneKit {
 	[Mac (10,10), iOS (8,0)]
 	delegate SCNVector3 SCNFieldForceEvaluator (SCNVector3 position, SCNVector3 velocity, float /* float, not CGFloat */ mass, float /* float, not CGFloat */ charge, double timeInSeconds);
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3219,6 +3276,7 @@ namespace XamCore.SceneKit {
 		nuint CategoryBitMask { get; set; }
 	}
 
+	[Watch (3,0)]
 	[StrongDictionary ("SCNPhysicsTestKeys")]
 	interface SCNPhysicsTest {
 		nuint CollisionBitMask { get; set; }
@@ -3229,6 +3287,7 @@ namespace XamCore.SceneKit {
 		NSString _SearchMode { get; set; }
 	}
 	
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[BaseType (typeof (NSObject),
 		Delegates = new [] { "WeakContactDelegate" },
@@ -3298,6 +3357,7 @@ namespace XamCore.SceneKit {
 		void UpdateCollisionPairs ();
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3327,6 +3387,7 @@ namespace XamCore.SceneKit {
 		NSValue[] Transforms { get; }		
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[Static]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
@@ -3346,6 +3407,7 @@ namespace XamCore.SceneKit {
 		NSString Type { get; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[Static]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
@@ -3361,6 +3423,7 @@ namespace XamCore.SceneKit {
 		NSString ConcavePolyhedron { get; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3385,6 +3448,7 @@ namespace XamCore.SceneKit {
 		nfloat PenetrationDistance { get; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
@@ -3400,6 +3464,7 @@ namespace XamCore.SceneKit {
 		void DidEndContact (SCNPhysicsWorld world, SCNPhysicsContact contact);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[Abstract]
@@ -3408,6 +3473,7 @@ namespace XamCore.SceneKit {
 
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[BaseType (typeof (SCNPhysicsBehavior))]
 	[DisableDefaultCtor]
@@ -3439,6 +3505,7 @@ namespace XamCore.SceneKit {
 		SCNVector3 AnchorB { get; set; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[BaseType (typeof (SCNPhysicsBehavior))]
 	[DisableDefaultCtor]
@@ -3463,6 +3530,7 @@ namespace XamCore.SceneKit {
 		SCNVector3 AnchorB { get; set; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[BaseType (typeof (SCNPhysicsBehavior))]
 	[DisableDefaultCtor]
@@ -3518,6 +3586,7 @@ namespace XamCore.SceneKit {
 		nfloat MotorMaximumTorque { get; set; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[BaseType (typeof (SCNPhysicsBehavior))]
 	[DisableDefaultCtor]
@@ -3545,6 +3614,7 @@ namespace XamCore.SceneKit {
 		void ApplyBrakingForce (nfloat value, nint index);
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3590,6 +3660,7 @@ namespace XamCore.SceneKit {
 		nfloat SuspensionRestLength { get; set; }
 	}
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3799,6 +3870,7 @@ namespace XamCore.SceneKit {
 		
 	}
 
+	[Watch (3,0)]
 	[Static]
 	interface SCNParticleProperty {
 		[Mac (10,10), iOS (8,0)]
@@ -3872,6 +3944,7 @@ namespace XamCore.SceneKit {
 	[Mac (10,10), iOS (8,0)]
 	delegate void SCNParticleModifierHandler (IntPtr data, IntPtr dataStride, nint start, nint end, float /* float, not CGFloat */ deltaTime);
 
+	[Watch (3,0)]
 	[Mac (10,10), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3901,6 +3974,7 @@ namespace XamCore.SceneKit {
 		NSString InputProperty { get; set; }
 	}
 
+	[Watch (3,0)]
 	[iOS (9,0)][Mac (10,11)]
 	[BaseType (typeof (SCNConstraint))]
 	interface SCNBillboardConstraint {
@@ -3912,6 +3986,7 @@ namespace XamCore.SceneKit {
 		SCNBillboardAxis FreeAxes { get; set; }
 	}
 
+	[Watch (3,0)]
 	[iOS (9,0)][Mac (10,11)]
 	[BaseType (typeof (SCNNode))]
 	[DisableDefaultCtor]
@@ -3942,6 +4017,7 @@ namespace XamCore.SceneKit {
 
 	interface ISCNBufferStream { }
 
+	[Watch (3,0)]
 	[iOS (9,0)][Mac (10,11)]
 	[Protocol]
 	interface SCNBufferStream {

--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -20,10 +20,7 @@ using XamCore.Foundation;
 using XamCore.CoreFoundation;
 using XamCore.CoreGraphics;
 using XamCore.CoreVideo;
-
-#if !WATCH // FIXME: scenekit not yet enabled
 using XamCore.SceneKit;
-#endif
 
 using Vector2 = global::OpenTK.Vector2;
 using Vector3 = global::OpenTK.Vector3;
@@ -70,7 +67,6 @@ namespace XamCore.SpriteKit {
 		[Export ("viewportSize")]
 		CGSize ViewportSize { get; set; }
 
-#if !WATCH // FIXME SceneKit not yet enabled on watch profile
 		[NullAllowed] // by default this property is null
 		[Export ("scnScene", ArgumentSemantic.Retain)]
 		SCNScene ScnScene { get; set; }
@@ -100,7 +96,6 @@ namespace XamCore.SpriteKit {
 
 		[Wrap ("HitTest (thePoint, options == null ? null : options.Dictionary)")]
 		SCNHitTestResult [] HitTest (CGPoint thePoint, SCNHitTestOptions options);
-#endif
 
 		[Export ("projectPoint:")]
 		/* vector_float3 */

--- a/src/watchkit.cs
+++ b/src/watchkit.cs
@@ -15,6 +15,7 @@ using XamCore.HealthKit;
 using XamCore.HomeKit;
 using XamCore.PassKit;
 using XamCore.SpriteKit;
+using XamCore.SceneKit;
 using XamCore.UIKit;
 using XamCore.MapKit;
 using XamCore.UserNotifications;
@@ -1180,15 +1181,12 @@ namespace XamCore.WatchKit {
 	interface WKInterfacePaymentButton {
 	}
 
-#if false // FIXME SceneKit not yet enabled on platform
 	[Watch (3,0)][NoiOS]
 	[BaseType (typeof (WKInterfaceObject))]
 	[DisableDefaultCtor] // Do not subclass or create instances of this class yourself. -> Handle is nil if init is called
-	interface WKInterfaceSCNScene : ISCNSceneRenderer {
+	interface WKInterfaceSCNScene : SCNSceneRenderer {
 
-		[NullAllowed, Export ("scene", ArgumentSemantic.Retain)]
-		SCNScene Scene { get; set; }
-
+		[Export ("snapshot")]
 		UIImage GetSnapshot ();
 
 		[Export ("preferredFramesPerSecond")]
@@ -1197,7 +1195,6 @@ namespace XamCore.WatchKit {
 		[Export ("antialiasingMode", ArgumentSemantic.Assign)]
 		SCNAntialiasingMode AntialiasingMode { get; set; }
 	}
-#endif
 
 	[Watch (3,0)][NoiOS]
 	[BaseType (typeof (WKInterfaceObject))]

--- a/tests/xtro-sharpie/watchos.pending
+++ b/tests/xtro-sharpie/watchos.pending
@@ -15,6 +15,25 @@
 !missing-selector! HMCameraStream::setAudioStreamSetting: not bound
 
 
+# SceneKit
+
+## CoreAnimation (CAAAnimation) is not in available watchOS 3
+!missing-type! SCNAnimationEvent not bound
+!missing-selector! SCNParticlePropertyController::animation not bound
+!missing-selector! SCNParticlePropertyController::setAnimation: not bound
+!missing-protocol-member! SCNAnimatable::addAnimation:forKey: not found
+!missing-protocol-member! SCNAnimatable::animationForKey: not found
+
+## JavaScriptCore is not available in watchOS 3
+!missing-pinvoke! SCNExportJavaScriptModule is not bound
+
+## SCNNodeRenderer is not available on watchOS 3
+!missing-protocol! SCNNodeRendererDelegate not bound
+!missing-selector! SCNNode::rendererDelegate not bound
+!missing-selector! SCNNode::setRendererDelegate: not bound
+!missing-selector! SCNTechnique::handleBindingOfSymbol:usingBlock: not bound
+
+
 # UIKit
 
 ## Apple renamed it from UILineBreakMode and we kept the old name

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -262,6 +262,8 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "WatchKit", "WatchKit", 2 },
 
 					{ "GameKit", "GameKit", 3 },
+					{ "SceneKit", "SceneKit", 3 },
+					{ "SpriteKit", "SpriteKit", 3 },
 					{ "UserNotifications", "UserNotifications", 3 },
 				};
 			}


### PR DESCRIPTION
* Enable some SceneKit-related WatchKit API
* Enable some SceneKit-related SpriteKit API
* Enable some SceneKit-related Foundation API
* Fix generator to include `using SceneKit;` on watchOS
* Adjust xtro tests since watchOS headers include some stuff that's not available in reality

missing / coming:
* Lots of [Watch (3,0)] attributes