### PR TITLE
[xharness] Split the mscorlib/System test run for watchOS into multiple executions.

### DIFF
--- a/tests/watchos/Extension/InterfaceController.cs
+++ b/tests/watchos/Extension/InterfaceController.cs
@@ -74,7 +74,15 @@ namespace monotouchtestWatchKitExtension
 		void LoadTests ()
 		{
 			runner = new WatchOSRunner ();
-			runner.Filter = new NotFilter (new CategoryExpression ("MobileNotWorking,NotOnMac,NotWorking,ValueAdd,CAS,InetAccess,NotWorkingInterpreter,RequiresBSDSockets").Filter);
+			var categoryFilter = new NotFilter (new CategoryExpression ("MobileNotWorking,NotOnMac,NotWorking,ValueAdd,CAS,InetAccess,NotWorkingInterpreter,RequiresBSDSockets").Filter);
+			if (!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("NUNIT_FILTER_START"))) {
+				var firstChar = Environment.GetEnvironmentVariable ("NUNIT_FILTER_START") [0];
+				var lastChar = Environment.GetEnvironmentVariable ("NUNIT_FILTER_END") [0];
+				var nameFilter = new NameStartsWithFilter () { FirstChar = firstChar, LastChar = lastChar };
+				runner.Filter = new AndFilter (categoryFilter, nameFilter);
+			} else {
+				runner.Filter = categoryFilter;
+			}
 			runner.Add (GetType ().Assembly);
 			TestLoader.AddTestAssemblies (runner);
 			ThreadPool.QueueUserWorkItem ((v) =>
@@ -126,3 +134,34 @@ namespace monotouchtestWatchKitExtension
 	}
 }
 
+class NameStartsWithFilter : NUnit.Framework.Internal.TestFilter
+{
+	public char FirstChar;
+	public char LastChar;
+
+	public override bool Match (NUnit.Framework.Api.ITest test)
+	{
+		if (test is NUnit.Framework.Internal.TestAssembly)
+			return true;
+
+		var method = test as NUnit.Framework.Internal.TestMethod;
+		if (method != null)
+			return Match (method.Parent);
+		
+		var name = !string.IsNullOrEmpty (test.Name) ? test.Name : test.FullName;
+		bool rv;
+		if (string.IsNullOrEmpty (name)) {
+			rv = true;
+		} else {
+			var z = Char.ToUpperInvariant (name [0]);
+			rv = z >= Char.ToUpperInvariant (FirstChar) && z <= Char.ToUpperInvariant (LastChar);
+		}
+
+		return rv;
+	}
+
+	public override bool Pass (NUnit.Framework.Api.ITest test)
+	{
+		return Match (test);
+	}
+}

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -372,6 +372,9 @@ namespace xharness
 			args.AppendFormat (" -argument=-app-arg:-hostport:{0}", listener.Port);
 			args.AppendFormat (" -setenv=NUNIT_HOSTPORT={0}", listener.Port);
 
+			foreach (var kvp in Harness.EnvironmentVariables)
+				args.AppendFormat (" -setenv={0}={1}", kvp.Key, kvp.Value);
+
 			bool? success = null;
 			bool timed_out = false;
 

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -66,6 +66,7 @@ namespace xharness
 		public double LaunchTimeout { get; set; } // in minutes
 		public bool DryRun { get; set; } // Most things don't support this. If you need it somewhere, implement it!
 		public string JenkinsConfiguration { get; set; }
+		public Dictionary<string, string> EnvironmentVariables { get; set; } = new Dictionary<string, string> ();
 
 		public Harness ()
 		{

--- a/tests/xharness/Program.cs
+++ b/tests/xharness/Program.cs
@@ -48,6 +48,12 @@ namespace xharness
 					}
 				},
 				{ "dry-run", "Only print what would be done.", (v) => harness.DryRun = true },
+				{ "setenv:", "Set the specified environment variable when running apps.", (v) =>
+					{
+						var split = v.Split ('=');
+						harness.EnvironmentVariables [split [0]] = split [1];
+					}
+				},
 			};
 
 			showHelp = () => {


### PR DESCRIPTION
When running on a watch, the complete set of mscorlib and System tests use too
much memory, so they end up crashing the app.

So instead don't run all the tests in the same test run, but
instead split them up.

This splits the System tests in 5 different sets, based on the first
character of the test class name.

The mscorlib tests are split in 26 different sets, one for each
character (A-Z).