### PR TITLE
[spritekit] Replace incorrect TV (it's TVOS) condition to fix SKNode

### DIFF
--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -113,7 +113,7 @@ namespace XamCore.SpriteKit {
 	[Mac (10,9, onlyOn64 : true)]
 	[BaseType (typeof (NSResponder))]
 	partial interface SKNode : NSCoding, NSCopying {
-#elif IOS || TV
+#elif IOS || TVOS
 	[Since (7,0)]
 	[BaseType (typeof (UIResponder))]
 	partial interface SKNode : NSCoding, NSCopying, UIFocusItem {

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -15633,6 +15633,9 @@ namespace XamCore.UIKit {
 	[iOS (9,0)]
 	[Protocol]
 	public interface UIFocusEnvironment {
+		// Apple moved this member to @optional since they deprecated it
+		// but that's a breaking change for us, so it remains [Abstract]
+		// and we need to teach the intro and xtro tests about it
 		[Abstract]
 		[NullAllowed, Export ("preferredFocusedView", ArgumentSemantic.Weak)]
 		[Availability (Deprecated = Platform.iOS_10_0, Message = "Use PreferredFocusEnvironments instead")]

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -172,12 +172,9 @@ namespace Introspection {
 				break;
 			case "SKNode":
 				switch (name) {
-				case "didUpdateFocusInContext:withAnimationCoordinator:":
-				case "setNeedsFocusUpdate":
-				case "shouldUpdateFocusInContext:":
-				case "updateFocusIfNeeded":
+				// skip for tvOS 10+
 				case "preferredFocusedView":
-					if (!TestRuntime.CheckXcodeVersion (8, 0))
+					if (TestRuntime.CheckXcodeVersion (8, 0))
 						return true;
 					break;
 				}

--- a/tests/xtro-sharpie/common.ignore
+++ b/tests/xtro-sharpie/common.ignore
@@ -52,3 +52,6 @@
 ## no point in having p/invoke calls that can be implement with a type cast (byte vs nint)
 !missing-pinvoke! NSTextAlignmentFromCTTextAlignment is not bound
 !missing-pinvoke! NSTextAlignmentToCTTextAlignment is not bound
+
+## this was (pre iOS10) a required member that was deprecated and made optional
+!incorrect-protocol-member! UIFocusEnvironment::preferredFocusedView is OPTIONAL and should NOT be abstract


### PR DESCRIPTION
references:
!missing-protocol-conformance! SKNode should conform to UIFocusItem
!wrong-base-type! SKNode expected UIResponder actual NSObject