### PR TITLE
[XM] Ignore linking requests for extension projects

### DIFF
--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -386,6 +386,11 @@ namespace Xamarin.Bundler {
 				throw new MonoMacException (2007, true,
 					"Xamarin.Mac Unified API against a full .NET framework does not support linking. Pass the -nolink flag.");
 
+			if (App.LinkMode != LinkMode.None && is_extension) {
+				App.LinkMode = LinkMode.None;
+				ErrorHelper.Warning (2014, "Xamarin.Mac Extensions do not support linking. Request for linking will be ignored.");
+			}
+
 			if (!IsUnifiedMobile && tls_provider != null)
 				throw new MonoMacException (2011, true, "Selecting a TLS Provider is only supported in the Unified Mobile profile");
 

--- a/tools/mmp/error.cs
+++ b/tools/mmp/error.cs
@@ -64,7 +64,8 @@ namespace Xamarin.Bundler {
 	//					MM2010	Unknown HttpMessageHandler `{0}`. Valid values are HttpClientHandler (default), CFNetworkHandler or NSUrlSessionHandler
 	//					MM2011  Unknown TLSProvider `{0}.  Valid values are default, legacy or appletls
 	//					MM2012   Only first {0} of {1} "Referenced by" warnings shown. ** This message related to 2009 **
-	//			Warning	MM2013	Failed to resolve the reference to "{0}", referenced in "{1}". The app will not include the referenced assembly, and may fail at runtime.
+	//				Warning	MM2013	Failed to resolve the reference to "{0}", referenced in "{1}". The app will not include the referenced assembly, and may fail at runtime.
+	//				Warning	MT2014	Xamarin.Mac Extensions do not support linking. Request for linking will be ignored.
 	// MM4xxx	code generation
 	// 			MM40xx	driver.m
 	//					MM4001	The main template could not be expansed to `{0}`.

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -202,6 +202,7 @@ namespace Xamarin.Bundler {
 	//					MT2011	Unknown TlsProvider `{0}`.  Valid values are default, legacy or appletls.
 	//					MT2012  ** reserved Xamarin.Mac **
 	//					MT2013	** reserved Xamarin.Mac **
+	//					MT2014	** reserved Xamarin.Mac **
 	// MT3xxx	AOT
 	//			MT30xx	AOT (general) errors
 	//					MT3001	Could not AOT the assembly '{0}'


### PR DESCRIPTION
- Linking breaks extensions for as long as we have the "extensions must be use static registrar" hack.
- So let's ignore it with a warning. Better that random brokeness.