### PR TITLE
[tvos][photosui] Enable on tvOS (new in beta 4)

### DIFF
--- a/src/PhotosUI/PHEnums.cs
+++ b/src/PhotosUI/PHEnums.cs
@@ -3,6 +3,7 @@ using XamCore.ObjCRuntime;
 
 namespace XamCore.PhotosUI {
 
+	[TV (10,0)]
 	[iOS (9,1)]
 	[Native]
 	public enum PHLivePhotoViewPlaybackStyle : nint
@@ -12,6 +13,7 @@ namespace XamCore.PhotosUI {
 		Hint
 	}
 
+	[TV (10,0)]
 	[iOS (9,1)]
 	[Native]
 	[Flags] // NS_OPTIONS

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1687,6 +1687,7 @@ TVOS_FRAMEWORKS =           \
 	MultipeerConnectivity   \
 	OpenGLES                \
 	Photos                  \
+	PhotosUI                \
 	ReplayKit               \
 	Security                \
 	StoreKit                \

--- a/src/photosui.cs
+++ b/src/photosui.cs
@@ -7,6 +7,7 @@ using System;
 
 namespace XamCore.PhotosUI
 {
+	[NoTV]
 	[iOS (8,0)]
 	[Protocol]
 	[Model]
@@ -34,6 +35,7 @@ namespace XamCore.PhotosUI
 		bool ShouldShowCancelConfirmation { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (9,1)]
 	[BaseType (typeof (UIView))]
 	interface PHLivePhotoView {
@@ -70,6 +72,7 @@ namespace XamCore.PhotosUI
 		void StopPlayback ();
 	}
 
+	[TV (10,0)]
 	[iOS (9,1)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]


### PR DESCRIPTION
Header files were not clear but xtro catch them all :)

references:
!missing-enum! PHLivePhotoBadgeOptions not bound
!missing-enum! PHLivePhotoViewPlaybackStyle not bound
!missing-protocol! PHLivePhotoViewDelegate not bound
!missing-selector! PHLivePhotoView::delegate not bound
!missing-selector! PHLivePhotoView::isMuted not bound
!missing-selector! PHLivePhotoView::livePhoto not bound
!missing-selector! PHLivePhotoView::playbackGestureRecognizer not bound
!missing-selector! PHLivePhotoView::setDelegate: not bound
!missing-selector! PHLivePhotoView::setLivePhoto: not bound
!missing-selector! PHLivePhotoView::setMuted: not bound
!missing-selector! PHLivePhotoView::startPlaybackWithStyle: not bound
!missing-type! PHLivePhotoView not bound