### PR TITLE
[watchos][cloudkit] Complete support of CloudKit on watchOS

### DIFF
--- a/src/CloudKit/Enums.cs
+++ b/src/CloudKit/Enums.cs
@@ -6,6 +6,7 @@ using System;
 namespace XamCore.CloudKit
 {
 	// NSInteger -> CKContainer.h
+	[Watch (3,0)]
 	[iOS (8,0)]
 	[Availability (Platform.Mac_10_10)]
 	[Native]
@@ -17,6 +18,7 @@ namespace XamCore.CloudKit
 	}
 
 	// NSUInteger -> CKContainer.h
+	[Watch (3,0)]
 	[iOS (8,0)]
 	[Availability (Platform.Mac_10_10)]
 	[Native]
@@ -26,6 +28,7 @@ namespace XamCore.CloudKit
 	}
 
 	// NSInteger -> CKContainer.h
+	[Watch (3,0)]
 	[iOS (8,0)]
 	[Availability (Platform.Mac_10_10)]
 	[Native]
@@ -37,6 +40,7 @@ namespace XamCore.CloudKit
 	}
 
 	// NSInteger -> CKError.h
+	[Watch (3,0)]
 	[iOS (8,0)]
 	[Availability (Platform.Mac_10_10)]
 	[Native]
@@ -71,14 +75,15 @@ namespace XamCore.CloudKit
 		ZoneNotFound = 26,
 		LimitExceeded  = 27,
 		UserDeletedZone = 28,
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12)] TooManyParticipants = 29,
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12)] AlreadyShared = 30,
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12)] ReferenceViolation = 31,
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12)] ManagedAccountRestricted = 32,
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12)] ParticipantMayNeedVerification = 33,
+		[iOS (10,0), TV (10,0), Mac (10,12)] TooManyParticipants = 29,
+		[iOS (10,0), TV (10,0), Mac (10,12)] AlreadyShared = 30,
+		[iOS (10,0), TV (10,0), Mac (10,12)] ReferenceViolation = 31,
+		[iOS (10,0), TV (10,0), Mac (10,12)] ManagedAccountRestricted = 32,
+		[iOS (10,0), TV (10,0), Mac (10,12)] ParticipantMayNeedVerification = 33,
 	}
 
 	// NSInteger -> CKModifyRecordsOperation.h
+	[Watch (3,0)]
 	[iOS (8,0)]
 	[Availability (Platform.Mac_10_10)]
 	[Native]
@@ -89,6 +94,7 @@ namespace XamCore.CloudKit
 	}
 
 	// NSInteger -> CKNotification.h
+	[Watch (3,0)]
 	[iOS (8,0)]
 	[Availability (Platform.Mac_10_10)]
 	[Native]
@@ -100,6 +106,7 @@ namespace XamCore.CloudKit
 	}
 
 	// NSInteger -> CKNotification.h
+	[Watch (3,0)]
 	[iOS (8,0)]
 	[Availability (Platform.Mac_10_10)]
 	[Native]
@@ -110,6 +117,7 @@ namespace XamCore.CloudKit
 	}
 
 	// NSUInteger -> CKRecordZone.h
+	[Watch (3,0)]
 	[iOS (8,0)]
 	[Availability (Platform.Mac_10_10)]
 	[Flags]
@@ -121,6 +129,7 @@ namespace XamCore.CloudKit
 	}
 
 	// NSUInteger -> CKReference.h
+	[Watch (3,0)]
 	[iOS (8,0)]
 	[Availability (Platform.Mac_10_10)]
 	[Native]
@@ -130,6 +139,7 @@ namespace XamCore.CloudKit
 	}
 
 	// NSInteger -> CKSubscription.h
+	[NoWatch]
 	[iOS (8,0)]
 	[Availability (Platform.Mac_10_10)]
 	[Native]
@@ -140,7 +150,8 @@ namespace XamCore.CloudKit
 	}
 
 	// NSInteger -> CKSubscription.h
-	
+
+	[NoWatch]
 	[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_10 , Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12, Message = "Use CKQuerySubscriptionOptions instead")]
 	[Flags]
 	[Native]
@@ -151,6 +162,7 @@ namespace XamCore.CloudKit
 		FiresOnce = 1 << 3,
 	}
 	
+	[Watch (3,0)]
 	[iOS (10,0), Mac (10,12)]
 	[Native]
 	public enum CKDatabaseScope : nint
@@ -160,6 +172,7 @@ namespace XamCore.CloudKit
 		Shared,
 	}
 	
+	[Watch (3,0)]
 	[iOS (10,0), Mac (10,12)]
 	[Native]
 	public enum CKShareParticipantAcceptanceStatus : nint
@@ -170,6 +183,7 @@ namespace XamCore.CloudKit
 		Removed,
 	}
 
+	[Watch (3,0)]
 	[iOS (10,0), Mac (10,12)]
 	[Native]
 	public enum CKShareParticipantPermission : nint
@@ -180,6 +194,7 @@ namespace XamCore.CloudKit
 		ReadWrite,
 	}
 
+	[Watch (3,0)]
 	[iOS (10,10), Mac (10,12)]
 	[Native]
 	public enum CKShareParticipantType : nint
@@ -189,7 +204,8 @@ namespace XamCore.CloudKit
 		PrivateUser = 3,
 		PublicUser = 4,
 	}
-	
+
+	[NoWatch]
 	[iOS (10,0), Mac(10,12)]
 	[Native]
 	public enum CKQuerySubscriptionOptions : nuint

--- a/src/cloudkit.cs
+++ b/src/cloudkit.cs
@@ -8,6 +8,7 @@ using XamCore.Contacts;
 
 namespace XamCore.CloudKit {
 
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: You must call -[CKAsset initWithFileURL:] or -[CKAsset initWithData:]
 	[BaseType (typeof (NSObject))]
@@ -136,6 +137,20 @@ namespace XamCore.CloudKit {
 		[Export ("removeParticipant:")]
 		void Remove (CKShareParticipant participant);
 	}
+
+	[Static]
+	[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+	partial interface CKShareKeys {
+		
+		[Field ("CKShareTitleKey")]
+		NSString Title { get; }
+
+		[Field ("CKShareThumbnailImageDataKey")]
+		NSString ThumbnailImageData { get; }
+
+		[Field ("CKShareTypeKey")]
+		NSString Type { get; }
+	}
 	
 	[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(NSObject))]
@@ -155,16 +170,18 @@ namespace XamCore.CloudKit {
 		CKShareParticipantPermission Permission { get; set; }
 	}
 
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[DisableDefaultCtor] // NSInternalInconsistencyException Reason: Use +[CKContainer privateCloudDatabase] or +[CKContainer publicCloudDatabase] instead of creating your own
 	[BaseType (typeof (NSObject))]
 	interface CKContainer {
 
+		[NoWatch]
 		[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_10 , Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12, Message = "Use CurrentUserDefaultName instead")]
 		[Field ("CKOwnerDefaultName")]
 		NSString OwnerDefaultName { get; }
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Field ("CKCurrentUserDefaultName")]
 		NSString CurrentUserDefaultName { get; }
 
@@ -191,7 +208,7 @@ namespace XamCore.CloudKit {
 		[Export ("sharedCloudDatabase")]
 		CKDatabase SharedCloudDatabase { get; }
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Export ("databaseWithDatabaseScope:")]
 		CKDatabase GetDatabase (CKDatabaseScope databaseScope);
 
@@ -211,7 +228,7 @@ namespace XamCore.CloudKit {
 		[Async]
 		void FetchUserRecordId (Action<CKRecordID, NSError> completionHandler);
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12)]
+		[iOS (10,0), TV (10,0), Mac (10,12)]
 		[NoTV]
 		[Export ("discoverAllIdentitiesWithCompletionHandler:")]
 		[Async]
@@ -224,12 +241,12 @@ namespace XamCore.CloudKit {
 		[Async]
 		void DiscoverAllContactUserInfos (Action<CKDiscoveredUserInfo[], NSError> completionHandler);
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Export ("discoverUserIdentityWithEmailAddress:completionHandler:")]
 		[Async]
 		void DiscoverUserIdentityWithEmailAddress (string email, Action<CKUserIdentity, NSError> completionHandler);
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Export ("discoverUserIdentityWithPhoneNumber:completionHandler:")]
 		[Async]
 		void DiscoverUserIdentityWithPhoneNumber (string phoneNumber, Action<CKUserIdentity, NSError> completionHandler);
@@ -240,7 +257,7 @@ namespace XamCore.CloudKit {
 		[Async]
 		void DiscoverUserInfo (string email, Action<CKDiscoveredUserInfo, NSError> completionHandler);
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Export ("discoverUserIdentityWithUserRecordID:completionHandler:")]
 		[Async]
 		void DiscoverUserIdentity (CKRecordID userRecordID, Action<CKUserIdentity, NSError> completionHandler);
@@ -268,24 +285,35 @@ namespace XamCore.CloudKit {
 		[Async]
 		void FetchLongLivedOperation (string[] operationID, Action<NSDictionary<NSString,NSOperation>, NSError> completionHandler);
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Export ("fetchShareParticipantWithEmailAddress:completionHandler:")]
 		[Async]
 		void FetchShareParticipantWithEmailAddress (string emailAddress, Action<CKShareParticipant, NSError> completionHandler);
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Export ("fetchShareParticipantWithPhoneNumber:completionHandler:")]
 		[Async]
 		void FetchShareParticipantWithPhoneNumber (string phoneNumber, Action<CKShareParticipant, NSError> completionHandler);
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Export ("fetchShareParticipantWithUserRecordID:completionHandler:")]
 		[Async]
 		void FetchShareParticipant (CKRecordID userRecordID, Action<CKShareParticipant, NSError> completionHandler);
+
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[Export ("fetchShareMetadataWithURL:completionHandler:")]
+		[Async]
+		void FetchShareMetadata (NSUrl url, Action<CKShareMetadata, NSError> completionHandler);
+
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[Export ("acceptShareMetadata:completionHandler:")]
+		[Async]
+		void AcceptShareMetadata (CKShareMetadata metadata, Action<CKShare, NSError> completionHandler);
 	}
 
 	delegate void CKDatabaseDeleteSubscriptionHandler (string subscriptionId, NSError error);
 
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[DisableDefaultCtor] // *** Assertion failure in -[CKDatabase init]
 	[BaseType (typeof (NSObject))]
@@ -293,7 +321,7 @@ namespace XamCore.CloudKit {
 		[Export ("addOperation:")]
 		void AddOperation (CKDatabaseOperation operation);
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Export ("databaseScope", ArgumentSemantic.Assign)]
 		CKDatabaseScope DatabaseScope { get; }
 
@@ -334,10 +362,12 @@ namespace XamCore.CloudKit {
 		[Async]
 		void FetchSubscription (string subscriptionId, Action<CKSubscription, NSError> completionHandler);
 
+		[NoWatch]
 		[Export ("fetchAllSubscriptionsWithCompletionHandler:")]
 		[Async]
 		void FetchAllSubscriptions (Action<CKSubscription[], NSError> completionHandler);
 
+		[NoWatch]
 		[Export ("saveSubscription:completionHandler:")]
 		[Async]
 		void SaveSubscription (CKSubscription subscription, Action<CKSubscription, NSError> completionHandler);
@@ -348,6 +378,7 @@ namespace XamCore.CloudKit {
 		void DeleteSubscription (string subscriptionID, CKDatabaseDeleteSubscriptionHandler completionHandler);
 	}
 
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (CKOperation))]
 	[DisableDefaultCtor]
@@ -395,6 +426,7 @@ namespace XamCore.CloudKit {
 #endif // XAMCORE_2_0
 	}
 
+	[NoWatch]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	delegate void CKDiscoverUserInfosCompletionHandler (NSDictionary emailsToUserInfos, NSDictionary userRecordIdsToUserInfos, NSError operationError);
 
@@ -424,6 +456,7 @@ namespace XamCore.CloudKit {
 	}
 
 	// CKError.h Fields
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[Static]
 	interface CKErrorFields {
@@ -481,6 +514,7 @@ namespace XamCore.CloudKit {
 		}
 	}
 
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[DisableDefaultCtor] // Objective-C exception thrown.  Name: CKException Reason: You can't call init on CKServerChangeToken
 	[BaseType (typeof (NSObject))]
@@ -488,6 +522,7 @@ namespace XamCore.CloudKit {
 	
 	}
 
+	[NoWatch]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	delegate void CKFetchRecordChangesHandler (CKServerChangeToken serverChangeToken, NSData clientChangeTokenData, NSError operationError);
 
@@ -665,6 +700,7 @@ namespace XamCore.CloudKit {
 		CKFetchRecordZonesOperation FetchAllRecordZonesOperation ();
 	}
 
+	[NoWatch]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	delegate void CKFetchSubscriptionsCompleteHandler (NSDictionary subscriptionsBySubscriptionId, NSError operationError);
 
@@ -707,6 +743,7 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	delegate void CKMarkNotificationsReadHandler (CKNotificationID[] notificationIDsMarkedRead, NSError operationError);
 
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (CKOperation))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: You must call -[CKMarkNotificationsReadOperation initWithNotificationIDsToMarkRead:]
@@ -859,6 +896,7 @@ namespace XamCore.CloudKit {
 
 	}
 
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: CKNotification is not meant for direct instantiation
 	[BaseType (typeof (NSObject))]
@@ -922,6 +960,7 @@ namespace XamCore.CloudKit {
 		string Category { get; }
 	}
 
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: CKQueryNotification is not meant for direct instantiation
 	[BaseType (typeof (CKNotification))]
@@ -949,6 +988,7 @@ namespace XamCore.CloudKit {
 		CKDatabaseScope DatabaseScope { get; }
 	}
 
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[DisableDefaultCtor] // objc_exception_throw on CKNotification init
 	[BaseType (typeof (CKNotification))]
@@ -971,6 +1011,7 @@ namespace XamCore.CloudKit {
 		CKDatabaseScope DatabaseScope { get; }
 	}
 
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSOperation))]
 	[DisableDefaultCtor] // Assertion failure in -[CKOperation init], /SourceCache/CloudKit/CloudKit-175.3/Framework/Operations/CKOperation.m:65
@@ -984,6 +1025,7 @@ namespace XamCore.CloudKit {
 		[NullAllowed, Export ("container", ArgumentSemantic.Retain)]
 		CKContainer Container { get; set; }
 
+		[NoWatch]
 		[Deprecated (PlatformName.iOS, 9,0, message: "Use QualityOfService property")]
 		[Deprecated (PlatformName.MacOSX, 10,11, message: "Use QualityOfService property")]
 		[Export ("usesBackgroundSession", ArgumentSemantic.UnsafeUnretained)]
@@ -1002,11 +1044,11 @@ namespace XamCore.CloudKit {
 		[Export ("longLived")]
 		bool LongLived { [Bind ("isLongLived")] get; set; }
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Export ("timeoutIntervalForRequest")]
 		double TimeoutIntervalForRequest { get; set; }
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Export ("timeoutIntervalForResource")]
 		double TimeoutIntervalForResource { get; set; }
 
@@ -1016,6 +1058,7 @@ namespace XamCore.CloudKit {
 		Action LongLivedOperationWasPersistedCallback { get; set; }		
 	}
 
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: You must call -[CKQuery initWithRecordType:predicate:sortDescriptors:]
 	[BaseType (typeof (NSObject))]
@@ -1082,6 +1125,7 @@ namespace XamCore.CloudKit {
 		}
 	}
 
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -1090,6 +1134,7 @@ namespace XamCore.CloudKit {
 
 	}
 
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[DisableDefaultCtor] // Crashes [CKRecord init] objc_exception_throw
 	[BaseType (typeof (NSObject))]
@@ -1098,15 +1143,15 @@ namespace XamCore.CloudKit {
 		[Field ("CKRecordTypeUserRecord")]
 		NSString TypeUserRecord { get; }
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Field ("CKRecordParentKey")]
 		NSString RecordParentKey { get; }
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Field ("CKRecordShareKey")]
 		NSString RecordShareKey { get; }
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Field ("CKRecordTypeShare")]
 		NSString TypeShare { get; }
 
@@ -1170,23 +1215,24 @@ namespace XamCore.CloudKit {
 		[Export ("encodeSystemFieldsWithCoder:")]
 		void EncodeSystemFields (NSCoder coder);
 		
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[NullAllowed, Export ("share", ArgumentSemantic.Copy)]
 		CKReference Share { get; }
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[NullAllowed, Export ("parent", ArgumentSemantic.Copy)]
 		CKReference Parent { get; set; }
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Export ("setParentReferenceFromRecord:")]
 		void SetParent ([NullAllowed] CKRecord parentRecord);
 
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Export ("setParentReferenceFromRecordID:")]
 		void SetParent ([NullAllowed] CKRecordID parentRecordID);
 	}
 
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException You must call -[CKRecordID initWithRecordName:] or -[CKRecordID initWithRecordName:zoneID:]
@@ -1232,6 +1278,7 @@ namespace XamCore.CloudKit {
 		CKRecordZone DefaultRecordZone ();
 	}
 
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException You must call -[CKRecordZoneID initWithZoneName:ownerName:]
@@ -1248,6 +1295,7 @@ namespace XamCore.CloudKit {
 		string OwnerName { get; }
 	}
 
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: You must call -[CKReference initWithRecordID:] or -[CKReference initWithRecord:] or -[CKReference initWithAsset:]
 	[BaseType (typeof (NSObject))]
@@ -1267,7 +1315,8 @@ namespace XamCore.CloudKit {
 		CKRecordID RecordId { get; }
 	}
 
-	[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+	[NoWatch]
+	[iOS (10,0)][TV (10,0), Mac (10,12, onlyOn64 : true)]
 	[DisableDefaultCtor]
 	[BaseType (typeof(CKSubscription))]
 	interface CKQuerySubscription : NSSecureCoding, NSCopying
@@ -1291,8 +1340,9 @@ namespace XamCore.CloudKit {
 		[Export ("querySubscriptionOptions", ArgumentSemantic.Assign)]
 		CKQuerySubscriptionOptions SubscriptionOptions { get; }
 	}
-	
-	[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+
+	[NoWatch]
+	[iOS (10,0)][TV (10,0), Mac (10,12, onlyOn64 : true)]
 	[DisableDefaultCtor]
 	[BaseType (typeof(CKSubscription))]
 	interface CKRecordZoneSubscription : NSSecureCoding, NSCopying
@@ -1305,13 +1355,15 @@ namespace XamCore.CloudKit {
 		IntPtr Constructor (CKRecordZoneID zoneID, string subscriptionID);
 
 		[Export ("zoneID", ArgumentSemantic.Copy)]
-		CKRecordZoneID ZoneID { get; }
+		// we need the setter since it was bound in the base type
+		CKRecordZoneID ZoneID { get; [NotImplemented] set; }
 
 		[NullAllowed, Export ("recordType")]
 		string RecordType { get; set; }
 	}
-	
-	[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
+
+	[NoWatch]
+	[iOS (10,0)][TV (10,0), Mac (10,12, onlyOn64 : true)]
 	[DisableDefaultCtor]
 	[BaseType (typeof(CKSubscription))]
 	interface CKDatabaseSubscription : NSSecureCoding, NSCopying
@@ -1324,21 +1376,30 @@ namespace XamCore.CloudKit {
 		string RecordType { get; set; }
 	}
 
+	[NoWatch]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[DisableDefaultCtor] // objc_exception_throw on [CKSubscription init]
 	[BaseType (typeof (NSObject))]
 	interface CKSubscription : NSSecureCoding, NSCopying {
 
+		[Deprecated (PlatformName.iOS, 10,0, message: "Use CKQuerySubscription")]
+		[Deprecated (PlatformName.MacOSX, 10,12, message: "Use CKQuerySubscription")]
 		[Export ("initWithRecordType:predicate:options:")]
 		IntPtr Constructor (string recordType, NSPredicate predicate, CKSubscriptionOptions subscriptionOptions);
 
+		[Deprecated (PlatformName.iOS, 10,0, message: "Use CKQuerySubscription")]
+		[Deprecated (PlatformName.MacOSX, 10,12, message: "Use CKQuerySubscription")]
 		[DesignatedInitializer]
 		[Export ("initWithRecordType:predicate:subscriptionID:options:")]
 		IntPtr Constructor (string recordType, NSPredicate predicate, string subscriptionId, CKSubscriptionOptions subscriptionOptions);
 
+		[Deprecated (PlatformName.iOS, 10,0, message: "Use CKRecordZoneSubscription")]
+		[Deprecated (PlatformName.MacOSX, 10,12, message: "Use CKRecordZoneSubscription")]
 		[Export ("initWithZoneID:options:")]
 		IntPtr Constructor (CKRecordZoneID zoneId, CKSubscriptionOptions subscriptionOptions);
 
+		[Deprecated (PlatformName.iOS, 10,0, message: "Use CKRecordZoneSubscription")]
+		[Deprecated (PlatformName.MacOSX, 10,12, message: "Use CKRecordZoneSubscription")]
 		[DesignatedInitializer]
 		[Export ("initWithZoneID:subscriptionID:options:")]
 		IntPtr Constructor (CKRecordZoneID zoneId, string subscriptionId, CKSubscriptionOptions subscriptionOptions);
@@ -1349,24 +1410,33 @@ namespace XamCore.CloudKit {
 		[Export ("subscriptionType", ArgumentSemantic.UnsafeUnretained)]
 		CKSubscriptionType SubscriptionType { get; }
 
+		[Deprecated (PlatformName.iOS, 10,0, message: "Use CKQuerySubscription")]
+		[Deprecated (PlatformName.MacOSX, 10,12, message: "Use CKQuerySubscription")]
 		[Export ("recordType")]
 		string RecordType { get; }
 
+		[Deprecated (PlatformName.iOS, 10,0, message: "Use CKQuerySubscription")]
+		[Deprecated (PlatformName.MacOSX, 10,12, message: "Use CKQuerySubscription")]
 		[Export ("predicate", ArgumentSemantic.Copy)]
 		NSPredicate Predicate { get; }
 
+		[Deprecated (PlatformName.iOS, 10,0, message: "Use CKQuerySubscriptionOptions")]
+		[Deprecated (PlatformName.MacOSX, 10,12, message: "Use CKQuerySubscriptionOptions")]
 		[Export ("subscriptionOptions", ArgumentSemantic.UnsafeUnretained)]
 		CKSubscriptionOptions SubscriptionOptions { get; }
 
-		[Watch (3,0), TV (10,0)]
+		[TV (10,0)]
 		[Export ("notificationInfo", ArgumentSemantic.Copy)]
 		CKNotificationInfo NotificationInfo { get; set; }
 
+		[Deprecated (PlatformName.iOS, 10,0, message: "Use CKRecordZoneSubscription")]
+		[Deprecated (PlatformName.MacOSX, 10,12, message: "Use CKRecordZoneSubscription")]
 		[Export ("zoneID", ArgumentSemantic.Copy)]
 		CKRecordZoneID ZoneID { get; set; }
 	}
 
-	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
+	[NoWatch]
+	[iOS (8,0)][TV (10,0), Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	interface CKNotificationInfo : NSSecureCoding, NSCopying, NSCoding {
 
@@ -1408,7 +1478,6 @@ namespace XamCore.CloudKit {
 		[Export ("shouldBadge", ArgumentSemantic.UnsafeUnretained)]
 		bool ShouldBadge { get; set; }
 
-		[NoTV]
 		[Export ("shouldSendContentAvailable")]
 		bool ShouldSendContentAvailable { get; set; }
 
@@ -1418,6 +1487,7 @@ namespace XamCore.CloudKit {
 		string Category { get; set; }
 	}
 	
+	[Watch (3,0)]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[DisableDefaultCtor] // Name: CKException Reason: You can't call init on CKQueryCursor
 	[BaseType (typeof (NSObject))]

--- a/tests/xtro-sharpie/common.ignore
+++ b/tests/xtro-sharpie/common.ignore
@@ -41,6 +41,15 @@
 !missing-field! GKSessionErrorDomain not bound
 
 
+# CloudKit
+
+## default init does not work, there's no init in base types, so it's a defacto designated initializer
+!extra-designated-initializer! CKMarkNotificationsReadOperation::initWithNotificationIDsToMarkRead: is incorrectly decorated with an [DesignatedInitializer] attribute
+## we offer a better managed API using another selector
+!missing-selector! CKRecord::objectForKeyedSubscript: not bound
+!missing-selector! CKRecord::setObject:forKeyedSubscript: not bound
+
+
 # ModelIO
 
 ## we only export the overload that expose an NSError

--- a/tests/xtro-sharpie/watchos.pending
+++ b/tests/xtro-sharpie/watchos.pending
@@ -1,6 +1,63 @@
 # TO BE FIXED - but maybe only in the far future / profiles
 
 
+# CloudKit
+
+## Types (and members) added and deprecated in the same version (iOS headers are already cleaned in most cases)
+!missing-type! CKDiscoverAllContactsOperation not bound
+!missing-selector! CKDiscoverAllContactsOperation::discoverAllContactsCompletionBlock not bound
+!missing-selector! CKDiscoverAllContactsOperation::setDiscoverAllContactsCompletionBlock: not bound
+!missing-type! CKDiscoverUserInfosOperation not bound
+!missing-selector! CKDiscoverUserInfosOperation::discoverUserInfosCompletionBlock not bound
+!missing-selector! CKDiscoverUserInfosOperation::emailAddresses not bound
+!missing-selector! CKDiscoverUserInfosOperation::initWithEmailAddresses:userRecordIDs: not bound
+!missing-selector! CKDiscoverUserInfosOperation::setDiscoverUserInfosCompletionBlock: not bound
+!missing-selector! CKDiscoverUserInfosOperation::setEmailAddresses: not bound
+!missing-selector! CKDiscoverUserInfosOperation::setUserRecordIDs: not bound
+!missing-selector! CKDiscoverUserInfosOperation::userRecordIDs not bound
+!missing-type! CKDiscoveredUserInfo not bound
+!missing-selector! CKDiscoveredUserInfo::firstName not bound
+!missing-selector! CKDiscoveredUserInfo::lastName not bound
+!missing-selector! CKDiscoveredUserInfo::userRecordID not bound
+!missing-type! CKFetchRecordChangesOperation not bound
+!missing-selector! CKFetchRecordChangesOperation::desiredKeys not bound
+!missing-selector! CKFetchRecordChangesOperation::fetchRecordChangesCompletionBlock not bound
+!missing-selector! CKFetchRecordChangesOperation::initWithRecordZoneID:previousServerChangeToken: not bound
+!missing-selector! CKFetchRecordChangesOperation::moreComing not bound
+!missing-selector! CKFetchRecordChangesOperation::previousServerChangeToken not bound
+!missing-selector! CKFetchRecordChangesOperation::recordChangedBlock not bound
+!missing-selector! CKFetchRecordChangesOperation::recordWithIDWasDeletedBlock not bound
+!missing-selector! CKFetchRecordChangesOperation::recordZoneID not bound
+!missing-selector! CKFetchRecordChangesOperation::resultsLimit not bound
+!missing-selector! CKFetchRecordChangesOperation::setDesiredKeys: not bound
+!missing-selector! CKFetchRecordChangesOperation::setFetchRecordChangesCompletionBlock: not bound
+!missing-selector! CKFetchRecordChangesOperation::setPreviousServerChangeToken: not bound
+!missing-selector! CKFetchRecordChangesOperation::setRecordChangedBlock: not bound
+!missing-selector! CKFetchRecordChangesOperation::setRecordWithIDWasDeletedBlock: not bound
+!missing-selector! CKFetchRecordChangesOperation::setRecordZoneID: not bound
+!missing-selector! CKFetchRecordChangesOperation::setResultsLimit: not bound
+!missing-selector! CKContainer::discoverAllContactUserInfosWithCompletionHandler: not bound
+!missing-selector! CKContainer::discoverUserInfoWithEmailAddress:completionHandler: not bound
+!missing-selector! CKContainer::discoverUserInfoWithUserRecordID:completionHandler: not bound
+!missing-selector! CKOperation::setUsesBackgroundSession: not bound
+!missing-selector! CKOperation::usesBackgroundSession not bound
+!missing-field! CKOwnerDefaultName not bound
+
+
+## lots of stuff moved into CKSubscription_CKSubscriptionDeprecated which we won't bring into watchOS
+!missing-selector! CKSubscription::initWithCoder: not bound
+!missing-selector! CKSubscription::initWithRecordType:predicate:options: not bound
+!missing-selector! CKSubscription::initWithRecordType:predicate:subscriptionID:options: not bound
+!missing-selector! CKSubscription::initWithZoneID:options: not bound
+!missing-selector! CKSubscription::initWithZoneID:subscriptionID:options: not bound
+!missing-selector! CKSubscription::predicate not bound
+!missing-selector! CKSubscription::recordType not bound
+!missing-selector! CKSubscription::setZoneID: not bound
+!missing-selector! CKSubscription::subscriptionOptions not bound
+!missing-selector! CKSubscription::zoneID not bound
+
+
+
 # CoreMotion
 
 ## NSFastEnumeration - see bug https://bugzilla.xamarin.com/show_bug.cgi?id=34555


### PR DESCRIPTION
Also apply fixes based on xtro results. Most of them are likely because the iOS frameworks contains out-dated headers wrt watchOS.

references:

* Missing fields /API
!missing-field! CKShareThumbnailImageDataKey not bound
!missing-field! CKShareTitleKey not bound
!missing-field! CKShareTypeKey not bound
!missing-selector! CKContainer::acceptShareMetadata:completionHandler: not bound
!missing-selector! CKContainer::fetchShareMetadataWithURL:completionHandler: not bound

* tvOS: enabled
!missing-selector! CKNotificationInfo::setShouldSendContentAvailable: not bound
!missing-selector! CKNotificationInfo::shouldSendContentAvailable not bound

* watchOS: xtro fixes for additions/removal in the same release
!missing-type! CKFetchRecordChangesOperation not bound
!missing-type! CKDiscoverAllContactsOperation not bound
!missing-type! CKDiscoverUserInfosOperation not bound
!missing-type! CKDiscoveredUserInfo not bound
!missing-selector! CKContainer::discoverAllContactUserInfosWithCompletionHandler: not bound
!missing-selector! CKContainer::discoverUserInfoWithEmailAddress:completionHandler: not bound
!missing-selector! CKContainer::discoverUserInfoWithUserRecordID:completionHandler: not bound

* watchOS: missing [NoWatch] on some types
!unknown-native-enum! CKQuerySubscriptionOptions bound
!unknown-native-enum! CKSubscriptionOptions bound
!unknown-native-enum! CKSubscriptionType bound
!unknown-type! CKDatabaseSubscription bound
!unknown-type! CKNotificationInfo bound
!unknown-type! CKQuerySubscription bound
!unknown-type! CKRecordZoneSubscription bound
!unknown-type! CKSubscription bound