### PR TITLE
[XM] Teach XM to add fobjc-runtime=macosx to clang 64-bit builds

### DIFF
--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1011,6 +1011,8 @@ namespace Xamarin.Bundler {
 					args.Append ("-g ");
 				args.Append ("-mmacosx-version-min=").Append (minos.ToString ()).Append (' ');
 				args.Append ("-arch ").Append (arch).Append (' ');
+				if (arch == "x86_64")
+					args.Append ("-fobjc-runtime=macosx ");
 				foreach (var assembly in BuildTarget.Assemblies) {
 					if (assembly.LinkWith != null) {
 						foreach (var linkWith in assembly.LinkWith) {


### PR DESCRIPTION
- As requested by Rolf here https://bugzilla.xamarin.com/show_bug.cgi?id=42889