### PR TITLE
Revert "Enable logging during mac introspection tests (#510)"

### DIFF
--- a/tests/introspection/Mac/MacApiCtorInitTest.cs
+++ b/tests/introspection/Mac/MacApiCtorInitTest.cs
@@ -26,7 +26,7 @@ namespace Introspection {
 
 		public MacApiCtorInitTest ()
 		{
-			LogProgress = true;
+			//LogProgress = true;
 			ContinueOnFailure = true;
 		}
 


### PR DESCRIPTION
- This reverts commit 9e731e842c2b1584c3b353a83a6f5a0a85973f07.
- We've hopefully nailed down the test failure.