### PR TITLE
[Speech] Fix bug 43182 - SFSpeechRecognizer.GetRecognitionTaskAsync() can trigger multiple callbacks

### DIFF
--- a/src/speech.cs
+++ b/src/speech.cs
@@ -197,7 +197,6 @@ namespace XamCore.Speech {
 		[Export ("defaultTaskHint", ArgumentSemantic.Assign)]
 		SFSpeechRecognitionTaskHint DefaultTaskHint { get; set; }
 
-		[Async]
 		[Export ("recognitionTaskWithRequest:resultHandler:")]
 		SFSpeechRecognitionTask GetRecognitionTask (SFSpeechRecognitionRequest request, Action<SFSpeechRecognitionResult, NSError> resultHandler);
 


### PR DESCRIPTION
Bug: https://bugzilla.xamarin.com/show_bug.cgi?id=43182

Removing Async method GetRecognitionTaskAsync because it gets called
multiple times which leads to an exception