### PR TITLE
[watchos][gamekit] Add missing API and adjust xtro data files for deprecations

### DIFF
--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -1355,7 +1355,6 @@ namespace XamCore.GameKit {
 		[Export ("showsCompletionBanner", ArgumentSemantic.Assign)]
 		bool ShowsCompletionBanner { get; set;  }
 
-		[NoWatch]
 		[iOS (6,0), Mac (10,8)]
 		[Static]
 		[Export ("reportAchievements:withCompletionHandler:")]

--- a/tests/xtro-sharpie/watchos.ignore
+++ b/tests/xtro-sharpie/watchos.ignore
@@ -16,9 +16,10 @@
 
 # GameKit
 
-## All members of the protocol sare not available on watchOS (but the protocols are not decorated)
+## All members of the protocol are marked as not available on watchOS (but the protocols themselves are not decorated)
 !missing-protocol! GKChallengeListener not bound
 !missing-protocol! GKInviteEventListener not bound
+!missing-protocol! GKGameSessionEventListener not bound
 
 ## types/members marked as deprecated in watchOS 2.0 (even if the framework was not available before 3.0)
 ## or deprecated well before that (and have alternatives). The last ones might be there but it seems better
@@ -51,6 +52,8 @@
 !missing-selector! GKLeaderboard::category not bound
 !missing-selector! GKLeaderboard::initWithPlayerIDs: not bound
 !missing-selector! GKLeaderboard::setCategory: not bound
+!missing-selector! +GKLeaderboard::loadCategoriesWithCompletionHandler: not bound
+!missing-selector! +GKLeaderboard::setDefaultLeaderboard:withCompletionHandler: not bound
 !missing-selector! GKLocalPlayer::authenticateWithCompletionHandler: not bound
 !missing-selector! GKLocalPlayer::friends not bound
 !missing-selector! GKLocalPlayer::loadDefaultLeaderboardCategoryIDWithCompletionHandler: not bound

--- a/tests/xtro-sharpie/watchos.pending
+++ b/tests/xtro-sharpie/watchos.pending
@@ -102,6 +102,10 @@
 
 # UIKit
 
+## UITraitCollection is not exposed in watchOS but those API are - rdar #27785753
+!missing-selector! +UIFont::preferredFontForTextStyle:compatibleWithTraitCollection: not bound
+!missing-selector! +UIFontDescriptor::preferredFontDescriptorWithTextStyle:compatibleWithTraitCollection: not bound
+
 ## Apple renamed it from UILineBreakMode and we kept the old name
 !missing-enum! NSLineBreakMode not bound
 !unknown-native-enum! UILineBreakMode bound


### PR DESCRIPTION
reference (missing)
!missing-selector! +GKAchievement::reportAchievements:withCompletionHandler: not bound