### PR TITLE
[Passkit] Fix bug 43263 paymentAuthorizationController:didAuthorizePayment:completion: bound to class name, not DidAuthorizePayment

### DIFF
--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -747,13 +747,14 @@ namespace XamCore.PassKit {
 
 	interface IPKPaymentAuthorizationControllerDelegate {}
 
+	[Watch (3,0)][iOS (10,0)]
 	[Protocol][Model]
 	[BaseType (typeof (NSObject))]
 	interface PKPaymentAuthorizationControllerDelegate {
 
 		[Abstract]
 		[Export ("paymentAuthorizationController:didAuthorizePayment:completion:")]
-		void PaymentAuthorizationController (PKPaymentAuthorizationController controller, PKPayment payment, Action<PKPaymentAuthorizationStatus> completion);
+		void DidAuthorizePayment (PKPaymentAuthorizationController controller, PKPayment payment, Action<PKPaymentAuthorizationStatus> completion);
 
 		[Abstract]
 		[Export ("paymentAuthorizationControllerDidFinish:")]


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=43263

Using the right method name DidAuthorizePayment amd availability