### PR TITLE
[localauthentication] Update to beta 5

### DIFF
--- a/src/LocalAuthentication/LAEnums.cs
+++ b/src/LocalAuthentication/LAEnums.cs
@@ -15,6 +15,7 @@ namespace XamCore.LocalAuthentication {
 	[iOS (8,0)]
 	[Availability (Platform.Mac_10_10)]
 	[Native]
+	[ErrorDomain ("LAErrorDomain")]
 	public enum LAStatus : nint {
 		Success = 0,
 		/// Authentication was not successful, because user failed to provide valid credentials.
@@ -51,6 +52,10 @@ namespace XamCore.LocalAuthentication {
 		CreateItem,
 		UseItem,
 		CreateKey,
-		UseKeySign
+		UseKeySign,
+		[iOS (10,0)][Mac (10,12)]
+		UseKeyDecrypt,
+		[iOS (10,0)][Mac (10,12)]
+		UseKeyKeyExchange,
 	}
 }

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -821,7 +821,7 @@ JAVASCRIPTCORE_SOURCES = \
 
 # LocalAuthentication
 
-LOCALAUTHENTICATION_CORE_SOURCES = \
+LOCALAUTHENTICATION_API_SOURCES = \
 	Localauthentication/LAEnums.cs \
 
 # MapKit

--- a/src/localauthentication.cs
+++ b/src/localauthentication.cs
@@ -15,9 +15,11 @@ namespace XamCore.LocalAuthentication {
 		[Export ("localizedFallbackTitle")]
 		string LocalizedFallbackTitle { get; set; }
 
+#if !XAMCORE_4_0
 		[iOS (8,3), Mac (10,10)]
 		[Field ("LAErrorDomain")]
 		NSString ErrorDomain { get; }
+#endif
 
 		[Export ("canEvaluatePolicy:error:")]
 		bool CanEvaluatePolicy (LAPolicy policy, out NSError error);
@@ -49,6 +51,10 @@ namespace XamCore.LocalAuthentication {
 		[Export ("evaluatedPolicyDomainState")]
 		[NullAllowed]
 		NSData EvaluatedPolicyDomainState { get; }
+
+		[iOS (10,0)][Mac (10,12)]
+		[NullAllowed, Export ("localizedCancelTitle")]
+		string LocalizedCancelTitle { get; set; }
 
 #if !MONOMAC
 		[Availability (Introduced = Platform.iOS_8_3, Deprecated = Platform.iOS_9_0)]


### PR DESCRIPTION
Notes:

1. Availability macros were added for tvOS and watchOS but this framework
   was not added to those platforms.

2. Xcode 8 beta 1 added new constants

+// Credential types
+#define kLACredentialTypePasscode                          -1
+#define kLACredentialTypePassphrase                        -2
+#define kLACredentialCTKPIN                                -3

which don't match the existing LACredentialType enum -> rdar #27805510

ref: https://trello.com/c/pikF1BP2/55-27805510-lacredentialtype-enum-and-lacredentialtype-constants-don-t-match