### PR TITLE
[tests] Add NSMicrophoneUsageDescription to monotouch-test. Fixes #42544

### DIFF
--- a/tests/monotouch-test/Info.plist
+++ b/tests/monotouch-test/Info.plist
@@ -46,5 +46,7 @@
 	<string>Testing roofs</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Testing lens</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Testing mike</string>
 </dict>
 </plist>


### PR DESCRIPTION
New requirement for iOS10 on devices

https://bugzilla.xamarin.com/show_bug.cgi?id=42544