### PR TITLE
[modelio] Update for iOS 10 beta 1

### DIFF
--- a/runtime/bindings-generator.cs
+++ b/runtime/bindings-generator.cs
@@ -1389,6 +1389,101 @@ namespace Xamarin.BindingMethods.Generator
 				}
 			);
 
+			// Required for ModelIO
+			data.Add (
+				new FunctionData {
+					Comment = " // IntPtr func (Vector3, Vector2i, bool, IntPtr, IntPtr)",
+					Prefix = "simd__",
+					Variants = Variants.NonStret,
+					ReturnType = Types.IntPtr,
+					Parameters = new ParameterData[] {
+						new ParameterData { TypeData = Types.Vector3 },
+						new ParameterData { TypeData = Types.Vector2i },
+						new ParameterData { TypeData = Types.Bool },
+						new ParameterData { TypeData = Types.IntPtr },
+						new ParameterData { TypeData = Types.IntPtr },
+					},
+				}
+			);
+
+			data.Add (
+				new FunctionData {
+					Comment = " // IntPtr func (Matrix4, bool);",
+					Prefix = "simd__",
+					Variants = Variants.NonStret,
+					ReturnType = Types.IntPtr,
+					Parameters = new ParameterData[] {
+						new ParameterData { TypeData = Types.Matrix4f },
+						new ParameterData { TypeData = Types.Bool },
+					},
+				}
+			);
+
+			data.Add (
+				new FunctionData {
+					Comment = " // IntPtr func (Vector3, Vector2i, bool, nint, IntPtr)",
+					Prefix = "simd__",
+					Variants = Variants.NonStret,
+					ReturnType = Types.IntPtr,
+					Parameters = new ParameterData[] {
+						new ParameterData { TypeData = Types.Vector3 },
+						new ParameterData { TypeData = Types.Vector2i },
+						new ParameterData { TypeData = Types.Bool },
+						new ParameterData { TypeData = Types.NInt },
+						new ParameterData { TypeData = Types.IntPtr },
+					},
+				}
+			);
+
+			data.Add (
+				new FunctionData {
+					Comment = " // IntPtr func (IntPtr, nint, UInt32, IntPtr)",
+					Prefix = "simd__",
+					Variants = Variants.NonStret,
+					ReturnType = Types.IntPtr,
+					Parameters = new ParameterData[] {
+						new ParameterData { TypeData = Types.IntPtr },
+						new ParameterData { TypeData = Types.NInt },
+						new ParameterData { TypeData = Types.UInt32 },
+						new ParameterData { TypeData = Types.IntPtr },
+					},
+				}
+			);
+
+			data.Add (
+				new FunctionData {
+					Comment = " // IntPtr func (Vector3, Vector2i, bool, bool, nint, IntPtr)",
+					Prefix = "simd__",
+					Variants = Variants.NonStret,
+					ReturnType = Types.IntPtr,
+					Parameters = new ParameterData[] {
+						new ParameterData { TypeData = Types.Vector3 },
+						new ParameterData { TypeData = Types.Vector2i },
+						new ParameterData { TypeData = Types.Bool },
+						new ParameterData { TypeData = Types.Bool },
+						new ParameterData { TypeData = Types.NInt },
+						new ParameterData { TypeData = Types.IntPtr },
+					},
+				}
+			);
+
+			data.Add (
+				new FunctionData {
+					Comment = " // IntPtr func (Vector3, Vector2i, int, bool, nint, IntPtr)",
+					Prefix = "simd__",
+					Variants = Variants.NonStret,
+					ReturnType = Types.IntPtr,
+					Parameters = new ParameterData[] {
+						new ParameterData { TypeData = Types.Vector3 },
+						new ParameterData { TypeData = Types.Vector2i },
+						new ParameterData { TypeData = Types.Int32 },
+						new ParameterData { TypeData = Types.Bool },
+						new ParameterData { TypeData = Types.NInt },
+						new ParameterData { TypeData = Types.IntPtr },
+					},
+				}
+			);
+
 			// We must expand functions with native types to their actual type as well.
 			for (int i = data.Count - 1; i >= 0; i--) {
 				if (!data [i].HasNativeType)

--- a/src/ModelIO/MDLMesh.cs
+++ b/src/ModelIO/MDLMesh.cs
@@ -14,6 +14,7 @@ using XamCore.Foundation;
 using XamCore.CoreFoundation;
 using XamCore.CoreGraphics;
 using XamCore.ObjCRuntime;
+using Vector2i = global::OpenTK.Vector2i;
 using Vector2 = global::OpenTK.Vector2;
 using Vector3 = global::OpenTK.Vector3;
 using Vector4 = global::OpenTK.Vector4;
@@ -26,6 +27,53 @@ using MathHelper = global::OpenTK.MathHelper;
 namespace XamCore.ModelIO {
 
 	partial class MDLMesh {
+		internal MDLMesh (Vector3 extent, Vector2i segments, bool inwardNormals, MDLGeometryType geometryType, IMDLMeshBufferAllocator allocator, int? hemisphereSegments, bool? cap, bool? isCone)
+		{
+			if (hemisphereSegments.HasValue) {
+				// initCapsule
+				InitializeHandle (InitCapsule (extent, segments, hemisphereSegments.Value, inwardNormals, geometryType, allocator), "initCapsuleWithExtent:cylinderSegments:hemisphereSegments:inwardNormals:geometryType:allocator:");
+			} else if (cap.HasValue && isCone.HasValue) {
+				// initHemisphere || initCone
+				if (isCone.Value)
+					InitializeHandle (InitCone (extent, segments, inwardNormals, cap.Value, geometryType, allocator), "initConeWithExtent:segments:inwardNormals:cap:geometryType:allocator:");
+				else
+					InitializeHandle (InitHemisphere (extent, segments, inwardNormals, cap.Value, geometryType, allocator), "initHemisphereWithExtent:segments:inwardNormals:cap:geometryType:allocator:");
+			} else {
+				// initSphere
+				InitializeHandle (InitSphere (extent, segments, inwardNormals, geometryType, allocator), "initSphereWithExtent:segments:inwardNormals:geometryType:allocator:");
+			}
+		}
+
+		internal MDLMesh (MDLMesh mesh, int submeshIndex, uint subdivisionLevels, IMDLMeshBufferAllocator allocator)
+		{
+			InitializeHandle (InitMesh (mesh, submeshIndex, subdivisionLevels, allocator), "initMeshBySubdividingMesh:submeshIndex:subdivisionLevels:allocator:");
+		}
+
+		public MDLMesh CreateSphere (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, IMDLMeshBufferAllocator allocator)
+		{
+			return new MDLMesh (dimensions, segments, inwardNormals, geometryType, allocator, null, null, null);
+		}
+
+		public MDLMesh CreateHemisphere (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, bool cap, IMDLMeshBufferAllocator allocator)
+		{
+			return new MDLMesh (dimensions, segments, inwardNormals, geometryType, allocator, null, cap, false);
+		}
+
+		public MDLMesh CreateCapsule (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, int hemisphereSegments, IMDLMeshBufferAllocator allocator)
+		{
+			return new MDLMesh (dimensions, segments, inwardNormals, geometryType, allocator, hemisphereSegments, null, null);
+		}
+
+		public MDLMesh CreateCone (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, bool cap, IMDLMeshBufferAllocator allocator)
+		{
+			return new MDLMesh (dimensions, segments, inwardNormals, geometryType, allocator, null, cap, true);
+		}
+
+		public MDLMesh CreateSubdividedMesh (MDLMesh mesh, int submeshIndex, uint subdivisionLevels, IMDLMeshBufferAllocator allocator)
+		{
+			return new MDLMesh (mesh, submeshIndex, subdivisionLevels, allocator);
+		}
+
 		public MDLVertexAttributeData AnisotropyVertexData {
 			get {
 				return GetVertexAttributeDataForAttribute (MDLVertexAttributes.Anisotropy);

--- a/src/ModelIO/MDLMesh.cs
+++ b/src/ModelIO/MDLMesh.cs
@@ -49,27 +49,27 @@ namespace XamCore.ModelIO {
 			InitializeHandle (InitMesh (mesh, submeshIndex, subdivisionLevels, allocator), "initMeshBySubdividingMesh:submeshIndex:subdivisionLevels:allocator:");
 		}
 
-		public MDLMesh CreateSphere (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, IMDLMeshBufferAllocator allocator)
+		public static MDLMesh CreateSphere (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, IMDLMeshBufferAllocator allocator)
 		{
 			return new MDLMesh (dimensions, segments, inwardNormals, geometryType, allocator, null, null, null);
 		}
 
-		public MDLMesh CreateHemisphere (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, bool cap, IMDLMeshBufferAllocator allocator)
+		public static MDLMesh CreateHemisphere (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, bool cap, IMDLMeshBufferAllocator allocator)
 		{
 			return new MDLMesh (dimensions, segments, inwardNormals, geometryType, allocator, null, cap, false);
 		}
 
-		public MDLMesh CreateCapsule (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, int hemisphereSegments, IMDLMeshBufferAllocator allocator)
+		public static MDLMesh CreateCapsule (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, int hemisphereSegments, IMDLMeshBufferAllocator allocator)
 		{
 			return new MDLMesh (dimensions, segments, inwardNormals, geometryType, allocator, hemisphereSegments, null, null);
 		}
 
-		public MDLMesh CreateCone (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, bool cap, IMDLMeshBufferAllocator allocator)
+		public static MDLMesh CreateCone (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, bool cap, IMDLMeshBufferAllocator allocator)
 		{
 			return new MDLMesh (dimensions, segments, inwardNormals, geometryType, allocator, null, cap, true);
 		}
 
-		public MDLMesh CreateSubdividedMesh (MDLMesh mesh, int submeshIndex, uint subdivisionLevels, IMDLMeshBufferAllocator allocator)
+		public static MDLMesh CreateSubdividedMesh (MDLMesh mesh, int submeshIndex, uint subdivisionLevels, IMDLMeshBufferAllocator allocator)
 		{
 			return new MDLMesh (mesh, submeshIndex, subdivisionLevels, allocator);
 		}

--- a/src/ModelIO/MIEnums.cs
+++ b/src/ModelIO/MIEnums.cs
@@ -259,5 +259,27 @@ namespace XamCore.ModelIO {
 		}
 		public Vector4 MinimumExtent, MaximumExtent;
 	}
+
+	[Native]
+	public enum MDLCameraProjection : nuint
+	{
+		Perspective = 0,
+		Orthographic = 1,
+	}
+
+	[Native]
+	public enum MDLMaterialFace : nuint
+	{
+		Front = 0,
+		Back,
+		DoubleSided,
+	}
+
+	[Native]
+	public enum MDLProbePlacement : nint
+	{
+		UniformGrid = 0,
+		IrradianceDistribution,
+	}
 }
 #endif

--- a/src/mobilecoreservices.cs
+++ b/src/mobilecoreservices.cs
@@ -574,6 +574,11 @@ namespace XamCore.MobileCoreServices {
 		[Field ("kUTTypeStereolithography", "ModelIO")]
 		NSString Stereolithography { get; }
 
+		[NoWatch]
+		[iOS (10,0)][Mac(10,12, onlyOn64 : true)]
+		[Field ("kUTTypeUniversalSceneDescription", "ModelIO")]
+		NSString UniversalSceneDescription { get; }
+
 		[Watch (2,2)]
 		[iOS (9,1)][TV (9,0)]
 		[NoMac]

--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -67,6 +67,8 @@ namespace XamCore.ModelIO {
 		[Export ("initWithURL:vertexDescriptor:bufferAllocator:")]
 		IntPtr Constructor (NSUrl url, [NullAllowed] MDLVertexDescriptor vertexDescriptor, [NullAllowed] IMDLMeshBufferAllocator bufferAllocator);
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[NoMac]
 		[Export ("initWithBufferAllocator:")]
 		IntPtr Constructor ([NullAllowed] IMDLMeshBufferAllocator bufferAllocator);
 
@@ -85,6 +87,8 @@ namespace XamCore.ModelIO {
 		[Export ("canExportFileExtension:")]
 		bool CanExportFileExtension (string extension);
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("childObjectsOfClass:")]
 		MDLObject[] GetChildObjects (Class objectClass);
 
@@ -140,6 +144,8 @@ namespace XamCore.ModelIO {
 		MDLAsset FromScene (SCNScene scene, [NullAllowed] IMDLMeshBufferAllocator bufferAllocator);
 	}
 
+	// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+	[Mac (10,12)]
 	[Protocol, Model]
 	[BaseType (typeof(NSObject))]
 	interface MDLLightProbeIrradianceDataSource
@@ -165,6 +171,8 @@ namespace XamCore.ModelIO {
 			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")] get;
 		}
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("projection", ArgumentSemantic.Assign)]
 		MDLCameraProjection Projection { get; set; }
 
@@ -412,6 +420,8 @@ namespace XamCore.ModelIO {
 		[Export ("count")]
 		nuint Count { get; }
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("materialFace", ArgumentSemantic.Assign)]
 		MDLMaterialFace MaterialFace { get; set; }
 
@@ -510,6 +520,8 @@ namespace XamCore.ModelIO {
 			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")] set;
 		}
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("luminance")]
 		float Luminance { get; set; }
 	}
@@ -569,6 +581,8 @@ namespace XamCore.ModelIO {
 	[BaseType (typeof(MDLObject))]
 	interface MDLMesh
 	{
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("initWithBufferAllocator:")]
 		IntPtr Constructor ([NullAllowed] IMDLMeshBufferAllocator bufferAllocator);
 
@@ -583,6 +597,8 @@ namespace XamCore.ModelIO {
 		[return: NullAllowed]
 		MDLVertexAttributeData GetVertexAttributeDataForAttribute (string attributeName);
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("vertexAttributeDataForAttributeNamed:asFormat:")]
 		[return: NullAllowed]
 		MDLVertexAttributeData GetVertexAttributeData (string attributeName, MDLVertexFormat format);
@@ -596,15 +612,27 @@ namespace XamCore.ModelIO {
 		MDLVertexDescriptor VertexDescriptor { get; set; }
 
 		[Export ("vertexCount")]
-		nuint VertexCount { get; set; }
+		nuint VertexCount {
+			get;
+			// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+			[Mac (10,12)]
+			set;
+		}
 
 		[Export ("vertexBuffers", ArgumentSemantic.Retain)]
 		IMDLMeshBuffer[] VertexBuffers { get; }
 
 		[NullAllowed]
 		[Export ("submeshes", ArgumentSemantic.Copy)]
-		NSMutableArray<MDLSubmesh> Submeshes { get; set; }
+		NSMutableArray<MDLSubmesh> Submeshes {
+			get;
+			// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+			[Mac (10,12)]
+			set;
+		}
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("allocator", ArgumentSemantic.Retain)]
 		IMDLMeshBufferAllocator Allocator { get; }
 
@@ -613,9 +641,13 @@ namespace XamCore.ModelIO {
 		[Export ("addAttributeWithName:format:")]
 		void AddAttribute (string name, MDLVertexFormat format);
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("addAttributeWithName:format:type:data:stride:")]
 		void AddAttribute (string name, MDLVertexFormat format, string type, NSData data, nint stride);
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("addAttributeWithName:format:type:data:stride:time:")]
 		void AddAttribute (string name, MDLVertexFormat format, string type, NSData data, nint stride, double time);
 
@@ -628,44 +660,52 @@ namespace XamCore.ModelIO {
 		[Export ("addTangentBasisForTextureCoordinateAttributeNamed:normalAttributeNamed:tangentAttributeNamed:")]
 		void AddTangentBasisWithNormals (string textureCoordinateAttributeName, string normalAttributeName, string tangentAttributeName);
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("addUnwrappedTextureCoordinatesForAttributeNamed:")]
 		void AddUnwrappedTextureCoordinates (string textureCoordinateAttributeName);
 
 		[Export ("makeVerticesUnique")]
 		void MakeVerticesUnique ();
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("replaceAttributeNamed:withData:")]
 		void ReplaceAttribute (string name, MDLVertexAttributeData newData);
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("updateAttributeNamed:withData:")]
 		void UpdateAttribute (string name, MDLVertexAttributeData newData);
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("removeAttributeNamed:")]
 		void RemoveAttribute (string name);
 
 		// MDLMesh_Generators (category)
 
-		[Internal, Static]
+		[Internal]
 		[Export ("initSphereWithExtent:segments:inwardNormals:geometryType:allocator:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		IntPtr InitSphere (Vector3 extent, Vector2i segments, bool inwardNormals, MDLGeometryType geometryType, [NullAllowed] IMDLMeshBufferAllocator allocator);
 
-		[Internal, Static]
+		[Internal]
 		[Export ("initHemisphereWithExtent:segments:inwardNormals:cap:geometryType:allocator:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		IntPtr InitHemisphere (Vector3 extent, Vector2i segments, bool inwardNormals, bool cap, MDLGeometryType geometryType, [NullAllowed] IMDLMeshBufferAllocator allocator);
 
-		[Internal, Static]
+		[Internal]
 		[Export ("initCapsuleWithExtent:cylinderSegments:hemisphereSegments:inwardNormals:geometryType:allocator:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		IntPtr InitCapsule (Vector3 extent, Vector2i segments, int hemisphereSegments, bool inwardNormals, MDLGeometryType geometryType, [NullAllowed] IMDLMeshBufferAllocator allocator);
 
-		[Internal, Static]
+		[Internal]
 		[Export ("initConeWithExtent:segments:inwardNormals:cap:geometryType:allocator:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		IntPtr InitCone (Vector3 extent, Vector2i segments, bool inwardNormals, bool cap, MDLGeometryType geometryType, [NullAllowed] IMDLMeshBufferAllocator allocator);
 
-		[Internal, Static]
+		[Internal]
 		[Export ("initMeshBySubdividingMesh:submeshIndex:subdivisionLevels:allocator:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		IntPtr InitMesh (MDLMesh mesh, int submeshIndex, uint subdivisionLevels, [NullAllowed] IMDLMeshBufferAllocator allocator);
@@ -894,6 +934,8 @@ namespace XamCore.ModelIO {
 		[NullAllowed, Export ("parent", ArgumentSemantic.Weak)]
 		MDLObject Parent { get; set; }
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("path")]
 		string Path { get; }
 
@@ -1189,6 +1231,8 @@ namespace XamCore.ModelIO {
 		[Export ("indexBuffer", ArgumentSemantic.Retain)]
 		IMDLMeshBuffer IndexBuffer { get; }
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("indexBufferAsIndexType:")]
 		IMDLMeshBuffer GetIndexBuffer (MDLIndexBitDepth indexType);
 
@@ -1295,6 +1339,8 @@ namespace XamCore.ModelIO {
 		[Export ("isCube")]
 		bool IsCube { get; set; }
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("hasAlphaValues")]
 		bool HasAlphaValues { get; set; }
 	}
@@ -1342,6 +1388,8 @@ namespace XamCore.ModelIO {
 		[Export ("initWithTransformComponent:")]
 		IntPtr Constructor (IMDLTransformComponent component);
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("initWithTransformComponent:resetsTransform:")]
 		IntPtr Constructor (IMDLTransformComponent component, bool resetsTransform);
 
@@ -1349,6 +1397,8 @@ namespace XamCore.ModelIO {
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		IntPtr Constructor (Matrix4 matrix);
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("initWithMatrix:resetsTransform:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		IntPtr Constructor (Matrix4 matrix, bool resetsTransform);
@@ -1437,7 +1487,11 @@ namespace XamCore.ModelIO {
 			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")] set;
 		}
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
+#if XAMCORE_4_0
 		[Abstract]
+#endif
 		[Export ("resetsTransform")]
 		bool ResetsTransform { get; set; }
 
@@ -1449,7 +1503,11 @@ namespace XamCore.ModelIO {
 		[Export ("maximumTime")]
 		double MaximumTime { get; }
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
+#if XAMCORE_4_0
 		[Abstract]
+#endif
 		[Export ("keyTimes", ArgumentSemantic.Copy)]
 		NSNumber[] KeyTimes { get; }
 
@@ -1581,6 +1639,8 @@ namespace XamCore.ModelIO {
 		[Export ("addOrReplaceAttribute:")]
 		void AddOrReplaceAttribute (MDLVertexAttribute attribute);
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("removeAttributeNamed:")]
 		void RemoveAttribute (string name);
 
@@ -1601,21 +1661,29 @@ namespace XamCore.ModelIO {
 	}
 
 	[iOS (9,0),Mac(10,11, onlyOn64 : true)]
-	[BaseType (typeof(MDLObject))]
+	[BaseType (
+#if MONOMAC
+		typeof(NSObject)
+#else
+		typeof(MDLObject)
+#endif
+	)]
 	[DisableDefaultCtor]
 	interface MDLVoxelArray
 	{
 
-		[Deprecated (PlatformName.MacOSX, 10, 12)]
-		[Obsoleted (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 12, message: "Use new MDLVoxelArray (MDLAsset, int, float)")]
+		[Obsoleted (PlatformName.iOS, 10, 0, message: "Use new MDLVoxelArray (MDLAsset, int, float)")]
 		[Export ("initWithAsset:divisions:interiorShells:exteriorShells:patchRadius:")]
 		IntPtr Constructor (MDLAsset asset, int divisions, int interiorShells, int exteriorShells, float patchRadius);
 
-		[Deprecated (PlatformName.MacOSX, 10, 12)]
-		[Obsoleted (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 12, message: "Use new MDLVoxelArray (MDLAsset, int, float)")]
+		[Obsoleted (PlatformName.iOS, 10, 0, message: "Use new MDLVoxelArray (MDLAsset, int, float)")]
 		[Export ("initWithAsset:divisions:interiorNBWidth:exteriorNBWidth:patchRadius:")]
 		IntPtr Constructor (MDLAsset asset, int divisions, float interiorNBWidth, float exteriorNBWidth, float patchRadius);
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("initWithAsset:divisions:patchRadius:")]
 		IntPtr Constructor (MDLAsset asset, int divisions, float patchRadius);
 
@@ -1634,6 +1702,8 @@ namespace XamCore.ModelIO {
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		void SetVoxel (Vector4i index);
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("setVoxelsForMesh:divisions:patchRadius:")]
 		void SetVoxels (MDLMesh mesh, int divisions, float patchRadius);
 
@@ -1685,22 +1755,34 @@ namespace XamCore.ModelIO {
 		[Export ("boundingBox")]
 		MDLAxisAlignedBoundingBox BoundingBox { get; }
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("convertToSignedShellField")]
 		void ConvertToSignedShellField ();
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("isValidSignedShellField")]
 		bool IsValidSignedShellField { get; }
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("shellFieldInteriorThickness")]
 		float ShellFieldInteriorThickness { get; set; }
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("shellFieldExteriorThickness")]
 		float ShellFieldExteriorThickness { get; set; }
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("coarseMesh")]
 		[return: NullAllowed]
 		MDLMesh GetCoarseMesh ();
 
+		// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
+		[Mac (10,12)]
 		[Export ("coarseMeshUsingAllocator:")]
 		[return: NullAllowed]
 		MDLMesh GetCoarseMeshUsingAllocator ([NullAllowed] IMDLMeshBufferAllocator allocator);

--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -73,10 +73,6 @@ namespace Introspection {
 				case "GKScore":
 				// new in iOS8 and 10.0
 				case "NSExtensionContext":
-				// TODO: MDLMaterialProperty has NSCopying defined but copyWithZone doesn't work
-				// filled radar://26939747 with Apple
-				// https://trello.com/c/6aIzLH4a
-				case "MDLMaterialProperty":
 				case "NSLayoutAnchor`1":
 				case "NSLayoutDimension":
 				case "NSLayoutXAxisAnchor":

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -156,6 +156,16 @@ namespace Introspection {
 					return true;
 				}
 				break;
+			case "MDLMesh":
+				switch (selectorName) {
+				case "initCapsuleWithExtent:cylinderSegments:hemisphereSegments:inwardNormals:geometryType:allocator:":
+				case "initConeWithExtent:segments:inwardNormals:cap:geometryType:allocator:":
+				case "initHemisphereWithExtent:segments:inwardNormals:cap:geometryType:allocator:":
+				case "initMeshBySubdividingMesh:submeshIndex:subdivisionLevels:allocator:":
+				case "initSphereWithExtent:segments:inwardNormals:geometryType:allocator:":
+					return true;
+				}
+				break;
 			case "NSImage":
 				switch (selectorName) {
 				case "initByReferencingFile:":

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -122,6 +122,13 @@ namespace Introspection {
 					return true;
 				}
 				break;
+			case "MDLMaterialProperty":
+				switch (selectorName) {
+				case "copyWithZone:":
+					// not working before iOS 10, macOS 10.12
+					return !TestRuntime.CheckXcodeVersion (8, 0);
+				}
+				break;
 			// Xcode 8 beta 2
 			case "GKGraph":
 			case "NEFlowMetaData":

--- a/tests/monotouch-test/Asserts.cs
+++ b/tests/monotouch-test/Asserts.cs
@@ -12,6 +12,11 @@ using NUnit.Framework;
 public static class Asserts
 {
 #if !__WATCHOS__
+	public static void AreEqual (bool expected, bool actual, string message)
+	{
+		Assert.AreEqual (expected, actual, message + " (M)");
+	}
+
 	public static void AreEqual (float expected, float actual, string message)
 	{
 		Assert.AreEqual (expected, actual, message + " (M)");

--- a/tests/monotouch-test/ModelIO/MDLMaterialProperty.cs
+++ b/tests/monotouch-test/ModelIO/MDLMaterialProperty.cs
@@ -193,7 +193,6 @@ namespace MonoTouchFixtures.ModelIO {
 		}
 
 		[Test]
-		[Ignore ("MDLMaterialProperty has NSCopying defined but copyWithZone doesn't work. radar://26939747 - https://trello.com/c/6aIzLH4a")]
 		public void Copy ()
 		{
 			using (var obj = new MDLMaterialProperty ("name", MDLMaterialSemantic.AmbientOcclusion)) {

--- a/tests/monotouch-test/ModelIO/MDLMesh.cs
+++ b/tests/monotouch-test/ModelIO/MDLMesh.cs
@@ -74,6 +74,14 @@ namespace MonoTouchFixtures.ModelIO {
 				}
 				using (var obj = MDLMesh.CreatePlane (new Vector2 (1, 1), new Vector2i (1, 1), MDLGeometryType.Triangles, null)) {
 				}
+				using (var obj = MDLMesh.CreateSphere (new Vector3 (1, 2, 3), new Vector2i (4, 5), MDLGeometryType.Triangles, true, null)) {
+				}
+				using (var obj = MDLMesh.CreateHemisphere (new Vector3 (1, 2, 3), new Vector2i (4, 5), MDLGeometryType.Triangles, true, true, null)) {
+				}
+				using (var obj = MDLMesh.CreateCapsule (new Vector3 (1, 2, 3), new Vector2i (4, 5), MDLGeometryType.Triangles, true, 10, null)) {
+				}
+				using (var obj = MDLMesh.CreateCone (new Vector3 (1, 2, 3), new Vector2i (4, 5), MDLGeometryType.Triangles, true, true, null)) {
+				}
 //				using (var obj = MDLMesh.CreateSubdividedMesh (new MDLMesh (), 0, 0)) {
 //				}
 
@@ -168,6 +176,74 @@ namespace MonoTouchFixtures.ModelIO {
 				}
 				Assert.AreEqual (1, obj.Submeshes.Count, "Submeshes Count");
 				Assert.AreEqual (13, obj.VertexCount, "VertexCount");
+				Assert.AreEqual (31, obj.VertexDescriptor.Attributes.Count, "VertexDescriptor Attributes Count");
+				Assert.AreEqual (31, obj.VertexDescriptor.Layouts.Count, "VertexDescriptor Layouts Count");
+			}
+		}
+
+		[Test]
+		public void CreateSphereTest ()
+		{
+			Vector3 V3 = new Vector3 (1, 2, 3);
+			Vector2i V2i = new Vector2i (4, 5);
+
+			using (var obj = MDLMesh.CreateSphere (V3, V2i, MDLGeometryType.Triangles, true, null)) {
+				Assert.IsNotNull (obj, "obj");
+				Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (0.9510565f, 2, 2.85317f), MinBounds = new Vector3 (-0.9510565f, -2, -2.85317f) }, obj.BoundingBox, "BoundingBox");
+				Assert.AreEqual (1, obj.Submeshes.Count, "Submeshes Count");
+				Assert.AreEqual (1, obj.VertexBuffers.Length, "VertexBuffers Count");
+				Assert.AreEqual (22, obj.VertexCount, "VertexCount");
+				Assert.AreEqual (31, obj.VertexDescriptor.Attributes.Count, "VertexDescriptor Attributes Count");
+				Assert.AreEqual (31, obj.VertexDescriptor.Layouts.Count, "VertexDescriptor Layouts Count");
+			}
+		}
+
+		[Test]
+		public void CreateHemisphereTest ()
+		{
+			Vector3 V3 = new Vector3 (1, 2, 3);
+			Vector2i V2i = new Vector2i (4, 5);
+
+			using (var obj = MDLMesh.CreateHemisphere (V3, V2i, MDLGeometryType.Triangles, true, true, null)) {
+				Assert.IsNotNull (obj, "obj");
+				Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (0.9510565f, 2, 2.85317f), MinBounds = new Vector3 (-0.9510565f, 0.6180339f, -2.85317f) }, obj.BoundingBox, "BoundingBox");
+				Assert.AreEqual (1, obj.Submeshes.Count, "Submeshes Count");
+				Assert.AreEqual (1, obj.VertexBuffers.Length, "VertexBuffers Count");
+				Assert.AreEqual (16, obj.VertexCount, "VertexCount");
+				Assert.AreEqual (31, obj.VertexDescriptor.Attributes.Count, "VertexDescriptor Attributes Count");
+				Assert.AreEqual (31, obj.VertexDescriptor.Layouts.Count, "VertexDescriptor Layouts Count");
+			}
+		}
+
+		[Test]
+		public void CreateCapsuleTest ()
+		{
+			Vector3 V3 = new Vector3 (1, 2, 3);
+			Vector2i V2i = new Vector2i (4, 5);
+
+			using (var obj = MDLMesh.CreateCapsule (V3, V2i, MDLGeometryType.Triangles, true, 10, null)) {
+				Assert.IsNotNull (obj, "obj");
+				Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (0.6f, 1.333333f, 1.8f), MinBounds = new Vector3 (-0.6f, -1, -1.8f) }, obj.BoundingBox, "BoundingBox");
+				Assert.AreEqual (1, obj.Submeshes.Count, "Submeshes Count");
+				Assert.AreEqual (3, obj.VertexBuffers.Length, "VertexBuffers Count");
+				Assert.AreEqual (152, obj.VertexCount, "VertexCount");
+				Assert.AreEqual (31, obj.VertexDescriptor.Attributes.Count, "VertexDescriptor Attributes Count");
+				Assert.AreEqual (31, obj.VertexDescriptor.Layouts.Count, "VertexDescriptor Layouts Count");
+			}
+		}
+
+		[Test]
+		public void CreateConeTest ()
+		{
+			Vector3 V3 = new Vector3 (1, 2, 3);
+			Vector2i V2i = new Vector2i (4, 5);
+
+			using (var obj = MDLMesh.CreateCone (V3, V2i, MDLGeometryType.Triangles, true, true, null)) {
+				Assert.IsNotNull (obj, "obj");
+				Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (0.5f, -0.5f, 1.5f), MinBounds = new Vector3 (-0.5f, -2.5f, -1.5f) }, obj.BoundingBox, "BoundingBox");
+				Assert.AreEqual (1, obj.Submeshes.Count, "Submeshes Count");
+				Assert.AreEqual (3, obj.VertexBuffers.Length, "VertexBuffers Count");
+				Assert.AreEqual (36, obj.VertexCount, "VertexCount");
 				Assert.AreEqual (31, obj.VertexDescriptor.Attributes.Count, "VertexDescriptor Attributes Count");
 				Assert.AreEqual (31, obj.VertexDescriptor.Layouts.Count, "VertexDescriptor Layouts Count");
 			}

--- a/tests/monotouch-test/ModelIO/MDLTransform.cs
+++ b/tests/monotouch-test/ModelIO/MDLTransform.cs
@@ -77,6 +77,18 @@ namespace MonoTouchFixtures.ModelIO {
 				Asserts.AreEqual (Vector3.One, obj.Scale, "Scale");
 				Asserts.AreEqual (Vector3.Zero, obj.Rotation, "Rotation");
 				Asserts.AreEqual (id, obj.Matrix, "Matrix");
+				Asserts.AreEqual (false, obj.ResetsTransform, "ResetsTransform");
+
+				obj.Translation = V3;
+				Asserts.AreEqual (V3, obj.Translation, "Translation 2");
+			}
+
+			using (var obj = new MDLTransform (id, true)) {
+				Asserts.AreEqual (Vector3.Zero, obj.Translation, "Translation");
+				Asserts.AreEqual (Vector3.One, obj.Scale, "Scale");
+				Asserts.AreEqual (Vector3.Zero, obj.Rotation, "Rotation");
+				Asserts.AreEqual (id, obj.Matrix, "Matrix");
+				Asserts.AreEqual (true, obj.ResetsTransform, "ResetsTransform");
 
 				obj.Translation = V3;
 				Asserts.AreEqual (V3, obj.Translation, "Translation 2");


### PR DESCRIPTION
Notes:

- `initBoxWithExtent:segments:inwardNormals:geometryType:allocator:` == `newBoxWithDimensions:segments:geometryType:inwardNormals:allocator:`
- `initCylinderWithExtent:segments:inwardNormals:topCap:bottomCap:geometryType:allocator:` == `newCylinderWithHeight:radii:radialSegments:verticalSegments:geometryType:inwardNormals:allocator:`
- `initPlaneWithExtent:segments:geometryType:allocator:` == `newPlaneWithDimensions:segments:geometryType:allocator:`
- `initIcosahedronWithExtent:inwardNormals:geometryType:allocator:` == `newIcosahedronWithRadius:inwardNormals:allocator:`

Changed MDLVoxelArray base type to MDLObject (available on all platforms).

radar://26939747 fixed by Apple. https://trello.com/c/6aIzLH4a updated accordingly. MDLMaterialProperty "Copy" test re-enabled and it now passes.

Misses monotouch-tests [incoming].