### PR TITLE
Add System.IdentityModel to Sdk assemblies

### DIFF
--- a/tools/linker/MobileProfile.cs
+++ b/tools/linker/MobileProfile.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Linker {
 			"System.Core",
 			"System.Data",
 			"System.Data.Services.Client",
+			"System.IdentityModel",
 			"System.IO.Compression.FileSystem",
 			"System.IO.Compression",
 			"System.Json",


### PR DESCRIPTION
Fixes the following mtouch test failure:

```
Xamarin.Linker.SdkTest.iOS_Classic :   BCL
  Expected:
  But was:  < "System.IdentityModel" >

at NUnit.Framework.CollectionAssert.IsEmpty (IEnumerable collection, System.String message, System.Object[] args) <0x47bec88 + 0x00047> in :0
at NUnit.Framework.CollectionAssert.IsEmpty (IEnumerable collection, System.String message) <0x47bec58 + 0x0001f> in :0
at Xamarin.Linker.SdkTest.BCL (System.String path) <0x47bccf0 + 0x003f3> in :0
at Xamarin.Linker.SdkTest.iOS_Classic () <0x47bcc50 + 0x0001b> in :0
```