### PR TITLE
[tests] Fix introspection failures when running on iOS 9.3

### DIFF
--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -760,8 +760,8 @@ namespace XamCore.HealthKit {
 
 	}
 
-	[Watch (2,0)]
-	[iOS (8,0)]
+	[Watch (3,0)] // marked as iOS-only but some watchOS 3 API returns this type, rdar #27865614
+	[iOS (10,0)]
 	[BaseType (typeof (HKSampleType))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKDocumentType
 	public interface HKDocumentType {

--- a/tests/introspection/ApiCMAttachmentTest.cs
+++ b/tests/introspection/ApiCMAttachmentTest.cs
@@ -230,6 +230,8 @@ namespace Introspection {
 			case "MidiEndpoint":
 			case "ABMultiValue":
 			case "ABMutableMultiValue":
+			// type was removed in iOS 10 (and replaced) and never consumed by other API
+			case "CGColorConverter":
 				return true;
 			default:
  				return false;
@@ -281,13 +283,6 @@ namespace Introspection {
 				var filename = Environment.GetFolderPath (Environment.SpecialFolder.CommonDocuments) + "/t.pdf";
 				using (var url = new NSUrl (filename))
 					return new CGContextPDF (url);
-			case "CGColorConverter":
-				var cvt = new CGColorConverterTriple () {
-					Space = CGColorSpace.CreateGenericRgb (),
-					Intent = CGColorRenderingIntent.Default,
-					Transform = CGColorConverterTransformType.ApplySpace
-				};
-				return new CGColorConverter (null, cvt, cvt, cvt);
 			case "CGColorConversionInfo":
 				var cci = new GColorConversionInfoTriple () {
 					Space = CGColorSpace.CreateGenericRgb (),

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -172,11 +172,23 @@ namespace Introspection {
 				break;
 			case "SKNode":
 				switch (name) {
+#if __TV__
 				// skip for tvOS 10+
 				case "preferredFocusedView":
-					if (TestRuntime.CheckXcodeVersion (8, 0))
+					if (!TestRuntime.CheckXcodeVersion (8, 0))
 						return true;
 					break;
+#else
+				// UIFocus protocol conformance on iOS10+
+				case "didUpdateFocusInContext:withAnimationCoordinator:":
+				case "setNeedsFocusUpdate":
+				case "shouldUpdateFocusInContext:":
+				case "updateFocusIfNeeded":
+				case "preferredFocusedView":
+					if (!TestRuntime.CheckXcodeVersion (8, 0))
+						return true;
+					break;
+#endif
 				}
 				break;
 			}
@@ -527,6 +539,8 @@ namespace Introspection {
 				case "HKBiologicalSexObject":
 				case "HKBloodTypeObject":
 					return !TestRuntime.CheckXcodeVersion (7, 0);
+				case "HKWorkoutEvent":
+					return !TestRuntime.CheckXcodeVersion (8, 0);
 				}
 				break;
 

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -172,10 +172,10 @@ namespace Introspection {
 				break;
 			case "SKNode":
 				switch (name) {
-#if __TV__
+#if __TVOS__
 				// skip for tvOS 10+
 				case "preferredFocusedView":
-					if (!TestRuntime.CheckXcodeVersion (8, 0))
+					if (TestRuntime.CheckXcodeVersion (8, 0))
 						return true;
 					break;
 #else


### PR DESCRIPTION
* ApiCMAttachmentTest
 	[FAIL] ApiCMAttachmentTest.CheckFailAttachments :   CGColorConverter.Handle

* SKNode added conformance to new (in iOS10) UIFocus protocol.
	[FAIL] Selector not found for SpriteKit.SKNode : didUpdateFocusInContext:withAnimationCoordinator:
	[FAIL] Selector not found for SpriteKit.SKNode : setNeedsFocusUpdate
	[FAIL] Selector not found for SpriteKit.SKNode : shouldUpdateFocusInContext:
	[FAIL] Selector not found for SpriteKit.SKNode : updateFocusIfNeeded
	[FAIL] Selector not found for SpriteKit.SKNode : preferredFocusedView

* HKWorkoutEvent conformance to NSCopying is new in iOS10
	[FAIL] Selector not found for HealthKit.HKWorkoutEvent : copyWithZone:

* HKDocumentType was added in iOS 10 (not iOS 8) and not watchOS 2 or 3

	ref: +HK_CLASS_AVAILABLE_IOS_ONLY(10_0)

	[FAIL] iOSApiProtocolTest.ApiProtocolTest.Coding : ObjCRuntime.RuntimeException : Wrapper type 'HealthKit.HKDocumentType' is missing its native ObjectiveC class 'HKDocumentType'.