### PR TITLE
[coretelephony] Re-enable CTCallCenter default ctor. Fixes #43329

### DIFF
--- a/src/coretelephony.cs
+++ b/src/coretelephony.cs
@@ -92,7 +92,6 @@ namespace XamCore.CoreTelephony {
 
 	[BaseType (typeof (NSObject))]
 	[Since (4,0)]
-	[DisableDefaultCtor] // FIXME: SIGILL in iOS 10 beta 2
 	interface CTCallCenter {
 		[Availability (Deprecated = Platform.iOS_10_0, Message = "Use CallKit")]
 		[NullAllowed] // by default this property is null

--- a/tests/introspection/iOS/iOSApiCtorInitTest.cs
+++ b/tests/introspection/iOS/iOSApiCtorInitTest.cs
@@ -295,6 +295,8 @@ namespace Introspection {
 			case "AVAudioSessionPortDescription":
 			case "CLBeacon":
 			case "CLCircularRegion":
+			// beta 2
+			case "CTCallCenter":
 			// beta 3
 			case "CNContainer":
 				if (TestRuntime.CheckXcodeVersion (8, 0))


### PR DESCRIPTION
reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=43329

It was disable as it crashed our test suite and the crash report from
the simulators were not very helpful. The issue becomes clear from
device builds...

Application Specific Information:
BUG IN CLIENT OF LIBDISPATCH: dispatch_barrier_sync called on queue already owned by current thread
Abort Cause 6244246656

Filtered syslog:
None found

Thread 0 name:  tid_a07  Dispatch queue: CTCallCenter
Thread 0 Crashed:
0   libdispatch.dylib             	0x00000001839fdf60 _dispatch_barrier_sync_f_slow + 596
1   CoreTelephony                 	0x000000018756e7ec -[CTCallCenter callEventHandler] + 128
2   CoreTelephony                 	0x000000018756e7ec -[CTCallCenter callEventHandler] + 128
3   CoreTelephony                 	0x000000018756f51c __27-[CTCallCenter description]_block_invoke + 60
4   CoreTelephony                 	0x000000018756f79c ___ZN8dispatch9sync_implIU13block_pointerFP8NSStringvEEENSt3__15decayIDTclfp0_EEE4typeEP16dispatch_queue_sOT_NS5_17integral_constantIbLb0EEE_block_invoke + 32
5   libdispatch.dylib             	0x00000001839ed1c0 _dispatch_client_callout + 16
6   libdispatch.dylib             	0x00000001839fa860 _dispatch_barrier_sync_f_invoke + 84
7   libdispatch.dylib             	0x00000001839fde9c _dispatch_barrier_sync_f_slow + 400
8   CoreTelephony                 	0x000000018756f4d0 -[CTCallCenter description] + 128
9   introspection                 	0x000000010192b7b8 wrapper_managed_to_native_ObjCRuntime_Messaging_IntPtr_objc_msgSend_intptr_intptr (/<unknown>:1)
10  introspection                 	0x00000001012dbff8 Foundation_NSObject_get_Description (NSObject.g.cs:717)
11  introspection                 	0x00000001012d8e34 Foundation_NSObject_ToString (NSObject2.cs:703)

so calling `description` is broken and we need to exclude this from our
introspection tests for the type.