### PR TITLE
[registrar] Remove tvOS/simulator hack for ExternalAccessory

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -1801,12 +1801,6 @@ namespace XamCore.Registrar {
 					return; // 10.12 removed the header files for QTKit
 #endif
 				goto default;
-			case "ExternalAccessory":
-#if !MONOMAC
-				if (IsSimulator && Driver.App.Platform == Xamarin.Utils.ApplePlatform.TVOS)
-					return; // No headers provided for AppleTV/simulator.
-#endif
-				goto default;
 			default:
 				h = string.Format ("<{0}/{0}.h>", ns);
 				break;
@@ -2186,7 +2180,6 @@ namespace XamCore.Registrar {
 			return ns == nsToMatch;
 		}
 
-		static bool IsExternalAccessoryType (ObjCType type) => IsTypeCore (type, "ExternalAccessory");
 		static bool IsQTKitType (ObjCType type) => IsTypeCore (type, "QTKit");
 		static bool IsMapKitType (ObjCType type) => IsTypeCore (type, "MapKit");
 		static bool IsIntentsType (ObjCType type) => IsTypeCore (type, "Intents");
@@ -2235,9 +2228,6 @@ namespace XamCore.Registrar {
 
 				if (isPlatformType && IsSimulatorOrDesktop && IsMetalType (@class))
 					continue; // Metal isn't supported in the simulator.
-
-				if (IsSimulatorOrDesktop && Driver.App.Platform == Xamarin.Utils.ApplePlatform.TVOS && IsExternalAccessoryType (@class))
-					continue; // ExternalAccessory's headers aren't available for tvOS/Simulator.
 #else
 				// Don't register 64-bit only API on 32-bit XM
 				if (!Is64Bits)


### PR DESCRIPTION
Apple now ships the required ExternalAccessory header files

references:
* commit 1190aac04c1166dbc587fbf17b79d1f878d034fe
  Author: Sebastien Pouliot <sebastien.pouliot@gmail.com>
  Date:   Sun Jul 24 10:44:19 2016 -0400
* rdar#27476259 https://trello.com/c/Okdw58IO