### PR TITLE
[Mtouch] Use the mono tools to copy over the msym files.

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Xml.Linq;
 using System.IO;
@@ -1078,8 +1077,7 @@ namespace Xamarin.Bundler {
 
 		public static void CopyMsymData (string src, string dest)
 		{
-			var dirInfo = new DirectoryInfo (src);
-			if (!dirInfo.Exists) // got no aot data
+			if (!DirectoryInfo.Exists (src)) // got no aot data
 				return;
 			var copyProcess = new MsymCopyTask (src, dest);
 			copyProcess.Execute ();
@@ -1850,7 +1848,8 @@ namespace Xamarin.Bundler {
 		public string Source { get; set; }
 		public string Destination { get; set; }
 		
-		public MsymCopyTask (string source, string destination) {
+		public MsymCopyTask (string source, string destination)
+		{
 			Source = source;
 			Destination = destination;
 			ProcessStartInfo.FileName = "mono-symbolicate";
@@ -1859,15 +1858,6 @@ namespace Xamarin.Bundler {
 		
 		protected override void Build ()
 		{
-			if (String.IsNullOrEmpty (Source)) {
-				Console.Error.WriteLine ("Symbolcation error, could not copy msym files because the source directory is missing.");
-				throw new ArgumentNullException (nameof (Source));
-			}
-			if (String.IsNullOrEmpty (Destination)) {
-				Console.Error.WriteLine ("Symbolcation error, could not copy msym files because the destination directory is missing.");
-				throw new ArgumentNullException (nameof (Source));
-			}
-			
 			var exit_code = base.Start ();
 			if (exit_code == 0)
 				return;

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1078,7 +1078,7 @@ namespace Xamarin.Bundler {
 
 		public static void CopyMsymData (string src, string dest)
 		{
-			if (!DirectoryInfo.Exists (src)) // got no aot data
+			if (!Directory.Exists (src)) // got no aot data
 				return;
 			var copyProcess = new MsymCopyTask (src, dest);
 			copyProcess.Execute ();

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Xml.Linq;
 using System.IO;

--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright 2013 Xamarin Inc. All rights reserved.
 
 using System;
-using System.Diagnostics;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2013 Xamarin Inc. All rights reserved.
 
 using System;
+using System.Diagnostics;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -101,18 +102,7 @@ namespace Xamarin.Bundler {
 			var dirInfo = new DirectoryInfo (msym_src);
 			if (!dirInfo.Exists) // got no aot data
 				return;
-			var subdirs = dirInfo.GetDirectories();
-			foreach (var subdir in subdirs) {
-				var destPath = Path.Combine (directory, subdir.Name.ToUpperInvariant ());
-				var destInfo = new DirectoryInfo (destPath);
-				if (!destInfo.Exists)
-					Directory.CreateDirectory (destPath);
-				var files = subdir.GetFiles ();
-				foreach (FileInfo file in files) {
-					string temppath = Path.Combine (destPath, file.Name);
-					file.CopyTo(temppath, true);
-				}
-			}
+			Application.CopyMsymData (msym_src, directory);
 		}
 
 		public void CopyConfigToDirectory (string directory)


### PR DESCRIPTION
Use the mono tools, that way we are sure the files are correctly copied AND we do no have to keep track of any possible changes in the tree structure.