### PR TITLE
[foundation] Fix NSDimension.BaseUnit on subclasses. Fixes #43444

### DIFF
--- a/src/Foundation/NSDimension.cs
+++ b/src/Foundation/NSDimension.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace XamCore.Foundation {
+	
+	public partial class NSDimension {
+
+		// this is something that need to be overridden by subclasses, which is not something we _usually_ do in C#
+		// it is exposed here so we can throw a managed exception if some subclasses (e.g. user code) fails to override
+		// (re-declare with `new`) the static property
+		public static NSDimension BaseUnit {
+
+			get {
+				throw new NotImplementedException ("All subclasses of NSDimension must re-implement this property");
+			}
+		}
+	}
+}

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -12002,6 +12002,7 @@ namespace XamCore.Foundation
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSUnit))]
+	[Abstract] // abstract subclass of NSUnit
 	[DisableDefaultCtor] // there's a designated initializer
 	interface NSDimension : NSSecureCoding {
 		[Export ("converter", ArgumentSemantic.Copy)]
@@ -12011,9 +12012,12 @@ namespace XamCore.Foundation
 		[DesignatedInitializer]
 		IntPtr Constructor (string symbol, NSUnitConverter converter);
 
-		[Static]
-		[Export ("baseUnit")]
-		NSDimension BaseUnit { get; }
+		// needs to be overriden in suubclasses
+		//	NSInvalidArgumentException Reason: *** You must override baseUnit in your class NSDimension to define its base unit.
+		// we provide a basic, managed, implementation that throws with a similar message
+		//[Static]
+		//[Export ("baseUnit")]
+		//NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -12036,6 +12040,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("fahrenheit", ArgumentSemantic.Copy)]
 		NSUnitTemperature Fahrenheit { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 #if MONOMAC
@@ -13003,6 +13012,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("gravity", ArgumentSemantic.Copy)]
 		NSUnitAcceleration Gravity { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13036,6 +13050,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("revolutions", ArgumentSemantic.Copy)]
 		NSUnitAngle Revolutions { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13101,6 +13120,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("hectares", ArgumentSemantic.Copy)]
 		NSUnitArea Hectares { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13122,6 +13146,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("millimolesPerLiterWithGramsPerMole:")]
 		NSUnitConcentrationMass GetMillimolesPerLiter (double gramsPerMole);
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13135,6 +13164,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("partsPerMillion", ArgumentSemantic.Copy)]
 		NSUnitDispersion PartsPerMillion { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13156,6 +13190,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("hours", ArgumentSemantic.Copy)]
 		NSUnitDuration Hours { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13189,6 +13228,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("microampereHours", ArgumentSemantic.Copy)]
 		NSUnitElectricCharge MicroampereHours { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13218,6 +13262,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("microamperes", ArgumentSemantic.Copy)]
 		NSUnitElectricCurrent Microamperes { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13247,6 +13296,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("microvolts", ArgumentSemantic.Copy)]
 		NSUnitElectricPotentialDifference Microvolts { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13276,6 +13330,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("microohms", ArgumentSemantic.Copy)]
 		NSUnitElectricResistance Microohms { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13305,6 +13364,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("kilowattHours", ArgumentSemantic.Copy)]
 		NSUnitEnergy KilowattHours { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13346,6 +13410,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("nanohertz", ArgumentSemantic.Copy)]
 		NSUnitFrequency Nanohertz { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13367,6 +13436,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("milesPerGallon", ArgumentSemantic.Copy)]
 		NSUnitFuelEfficiency MilesPerGallon { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13464,6 +13538,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("parsecs", ArgumentSemantic.Copy)]
 		NSUnitLength Parsecs { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13477,6 +13556,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("lux", ArgumentSemantic.Copy)]
 		NSUnitIlluminance Lux { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13550,6 +13634,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("slugs", ArgumentSemantic.Copy)]
 		NSUnitMass Slugs { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13603,6 +13692,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("horsepower", ArgumentSemantic.Copy)]
 		NSUnitPower Horsepower { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13652,6 +13746,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("poundsForcePerSquareInch", ArgumentSemantic.Copy)]
 		NSUnitPressure PoundsForcePerSquareInch { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13677,6 +13776,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("knots", ArgumentSemantic.Copy)]
 		NSUnitSpeed Knots { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
@@ -13810,6 +13914,11 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("metricCups", ArgumentSemantic.Copy)]
 		NSUnitVolume MetricCups { get; }
+
+		[New] // kind of overloading a static member
+		[Static]
+		[Export ("baseUnit")]
+		NSDimension BaseUnit { get; }
 	}
 
 	[iOS (10,0)]

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -602,6 +602,7 @@ FOUNDATION_CORE_SOURCES = \
 	Foundation/NSAction.cs \
 	Foundation/NSAutoreleasePool.cs \
 	Foundation/NSDecimal.cs \
+	Foundation/NSDimension.cs \
 	Foundation/NSError.cs \
 	Foundation/NSNumber.cs \
 	Foundation/NSObject2.cs \

--- a/tests/monotouch-test/Foundation/DimensionTest.cs
+++ b/tests/monotouch-test/Foundation/DimensionTest.cs
@@ -1,0 +1,223 @@
+﻿//
+// Unit tests for NSDimension
+//
+// Authors:
+//	Sebastien Pouliot <sebastien@xamarin.com>
+//
+// Copyright 2016 Xamarin Inc. All rights reserved.
+//
+
+using System;
+#if XAMCORE_2_0
+using Foundation;
+using UIKit;
+using ObjCRuntime;
+#else
+using MonoTouch.Foundation;
+using MonoTouch.ObjCRuntime;
+using MonoTouch.UIKit;
+#endif
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.Foundation {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class DimensionTest {
+
+		[Test]
+		public void BaseUnit ()
+		{
+			Assert.Throws<NotImplementedException> (() => { var bu = NSDimension.BaseUnit; }, "Base type must implement this");
+		}
+
+		[Test]
+		public void NSUnitAcceleration_BaseUnit ()
+		{
+			using (var bu = NSUnitAcceleration.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitAcceleration), bu, "type");
+				Assert.That ("m/s²", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitAngle_BaseUnit ()
+		{
+			using (var bu = NSUnitAngle.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitAngle), bu, "type");
+				Assert.That ("°", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitArea_BaseUnit ()
+		{
+			using (var bu = NSUnitArea.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitArea), bu, "type");
+				Assert.That ("m²", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitConcentrationMass_BaseUnit ()
+		{
+			using (var bu = NSUnitConcentrationMass.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitConcentrationMass), bu, "type");
+				Assert.That ("g/L", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitDispersion_BaseUnit ()
+		{
+			using (var bu = NSUnitDispersion.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitDispersion), bu, "type");
+				Assert.That ("ppm", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitDuration_BaseUnit ()
+		{
+			using (var bu = NSUnitDuration.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitDuration), bu, "type");
+				Assert.That ("s", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitElectricCharge_BaseUnit ()
+		{
+			using (var bu = NSUnitElectricCharge.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitElectricCharge), bu, "type");
+				Assert.That ("C", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitElectricCurrent_BaseUnit ()
+		{
+			using (var bu = NSUnitElectricCurrent.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitElectricCurrent), bu, "type");
+				Assert.That ("A", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitElectricPotentialDifference_BaseUnit ()
+		{
+			using (var bu = NSUnitElectricPotentialDifference.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitElectricPotentialDifference), bu, "type");
+				Assert.That ("V", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitElectricResistance_BaseUnit ()
+		{
+			using (var bu = NSUnitElectricResistance.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitElectricResistance), bu, "type");
+				Assert.That ("Ω", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitEnergy_BaseUnit ()
+		{
+			using (var bu = NSUnitEnergy.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitEnergy), bu, "type");
+				Assert.That ("J", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitFrequency_BaseUnit ()
+		{
+			using (var bu = NSUnitFrequency.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitFrequency), bu, "type");
+				Assert.That ("Hz", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitFuelEfficiency_BaseUnit ()
+		{
+			using (var bu = NSUnitFuelEfficiency.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitFuelEfficiency), bu, "type");
+				Assert.That ("L/100km", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitIlluminance_BaseUnit ()
+		{
+			using (var bu = NSUnitIlluminance.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitIlluminance), bu, "type");
+				Assert.That ("lx", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitLength_BaseUnit ()
+		{
+			using (var bu = NSUnitLength.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitLength), bu, "type");
+				Assert.That ("m", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitMass_BaseUnit ()
+		{
+			using (var bu = NSUnitMass.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitMass), bu, "type");
+				Assert.That ("kg", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitPower_BaseUnit ()
+		{
+			using (var bu = NSUnitPower.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitPower), bu, "type");
+				Assert.That ("W", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitPressure_BaseUnit ()
+		{
+			using (var bu = NSUnitPressure.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitPressure), bu, "type");
+				Assert.That ("N/m²", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitSpeed_BaseUnit ()
+		{
+			using (var bu = NSUnitSpeed.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitSpeed), bu, "type");
+				Assert.That ("m/s", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitTemperature_BaseUnit ()
+		{
+			using (var bu = NSUnitTemperature.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitTemperature), bu, "type");
+				Assert.That ("K", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+
+		[Test]
+		public void NSUnitVolume_BaseUnit ()
+		{
+			using (var bu = NSUnitVolume.BaseUnit) {
+				Assert.IsInstanceOfType (typeof (NSUnitVolume), bu, "type");
+				Assert.That ("L", Is.EqualTo (bu.Symbol), "Symbol");
+			}
+		}
+	}
+}

--- a/tests/monotouch-test/Info.plist
+++ b/tests/monotouch-test/Info.plist
@@ -48,5 +48,7 @@
 	<string>Testing lens</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Testing mike</string>
+	<key>NSContactsUsageDescription</key>
+	<string>Testing friends</string>
 </dict>
 </plist>

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -557,6 +557,7 @@
     <Compile Include="CloudKit\CKQueryOperationTest.cs" />
     <Compile Include="CloudKit\CKUserIdentityLookupInfoTest.cs" />
     <Compile Include="CoreGraphics\ColorConversionInfoTest.cs" />
+    <Compile Include="Foundation\DimensionTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
This is a static selector that needs to be overridden, which is not the
usual pattern in C#. We re-define it using [New] on subclasses.

Unit tests added for all NSDimension subclasses.

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=43444