### PR TITLE
[healthkit] Remove HKDocumentType from watchOS builds

### DIFF
--- a/src/HealthKit/HKObjectType.cs
+++ b/src/HealthKit/HKObjectType.cs
@@ -314,12 +314,13 @@ namespace XamCore.HealthKit
 		}
 	}
 
+#if !WATCH
 	public partial class HKDocumentType {
 		public static HKDocumentType Create (HKDocumentTypeIdentifier kind)
 		{
 			return HKObjectType._GetDocumentType (kind.GetConstant ());
 		}
 	}
-	
+#endif
 }
 

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -213,6 +213,7 @@ namespace XamCore.HealthKit {
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKDocumentSample
 	interface HKDocumentSample
 	{
+		[NoWatch] // HKDocumentType is iOS only, rdar #27865614
 		[Export ("documentType", ArgumentSemantic.Strong)]
 		HKDocumentType DocumentType { get; }
 	}
@@ -712,7 +713,8 @@ namespace XamCore.HealthKit {
 		[return: NullAllowed]
 		HKCorrelationType GetCorrelationType (NSString hkCorrelationTypeIdentifier);
 
-		[Watch (3,0), iOS (10,0)]
+		[NoWatch] // HKDocumentType is iOS only, rdar #27865614
+		[iOS (10,0)]
 		[Internal]
 		[Static]
 		[Export ("documentTypeForIdentifier:")]
@@ -760,7 +762,7 @@ namespace XamCore.HealthKit {
 
 	}
 
-	[Watch (3,0)] // marked as iOS-only but some watchOS 3 API returns this type, rdar #27865614
+	[NoWatch] // marked as iOS-only (confirmed by Apple) even if some watchOS 3 API returns this type, rdar #27865614
 	[iOS (10,0)]
 	[BaseType (typeof (HKSampleType))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKDocumentType


### PR DESCRIPTION
It's marked as iOS only

> HK_CLASS_AVAILABLE_IOS_ONLY(10_0)

even if some other API, marked as available on watchOS 3, are exposing
the type. Those API are now removed from the watch platform assembly.

From Apple:

    You want to use this API on watchOS that we explicitly decided to restrict this to iOS only.

    Thank you for your feedback. Engineering has determined that this issue behaves as intended.

reference:
* radar #27865614
* https://trello.com/c/4soJeYEr