### PR TITLE
[tests] Fix intro failures reported from iOS 6.1 and 7.1 devices

### DIFF
--- a/src/CoreImage/CIContext.cs
+++ b/src/CoreImage/CIContext.cs
@@ -123,6 +123,7 @@ namespace XamCore.CoreImage {
 	
 	public partial class CIContext {
 
+		[iOS (8,0)]
 		public CIContext (CIContextOptions options) :
 			this (options?.Dictionary)
 		{

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -203,9 +203,11 @@ namespace XamCore.CoreBluetooth {
 		[Field ("CBAdvertisementDataTxPowerLevelKey")]
 		NSString TxPowerLevelKey { get; }
 
+		[Since (7,0), Mac (10,9)]
 		[Field ("CBAdvertisementDataIsConnectable")]
 		NSString IsConnectableKey { get; }
 
+		[Since (7,0), Mac (10,9)]
 		[Field ("CBAdvertisementDataSolicitedServiceUUIDsKey")]
 		NSString SolicitedServiceUuidsKey { get; }
 	}
@@ -223,12 +225,15 @@ namespace XamCore.CoreBluetooth {
 
 	[Static, Internal]
 	interface RestoredStateKeys {
+		[Since (7,0)]
 		[Field ("CBCentralManagerRestoredStatePeripheralsKey")]
 		NSString PeripheralsKey { get; }
 
+		[Since (7,0)]
 		[Field ("CBCentralManagerRestoredStateScanServicesKey")]
 		NSString ScanServicesKey { get; }
 
+		[Since (7,0)]
 		[Field ("CBCentralManagerRestoredStateScanOptionsKey")]
 		NSString ScanOptionsKey { get; }
 	}

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -220,6 +220,7 @@ namespace XamCore.CoreImage {
 		[Export ("contextWithOptions:")]
 		CIContext FromOptions ([NullAllowed] NSDictionary dictionary);
 
+		[iOS (8,0)] // documented as earlier but missing
 		[Internal]
 		[Export ("initWithOptions:")]
 		IntPtr Constructor ([NullAllowed] NSDictionary options);

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -1583,9 +1583,11 @@ namespace XamCore.MediaPlayer {
 		[Export ("changePlaybackRateCommand")]
 		MPChangePlaybackRateCommand ChangePlaybackRateCommand { get; }
 
+		[iOS (8,0)]
 		[Export ("changeRepeatModeCommand")]
 		MPChangeRepeatModeCommand ChangeRepeatModeCommand { get; }
 
+		[iOS (8,0)]
 		[Export ("changeShuffleModeCommand")]
 		MPChangeShuffleModeCommand ChangeShuffleModeCommand { get; }
 

--- a/tests/introspection/ApiCMAttachmentTest.cs
+++ b/tests/introspection/ApiCMAttachmentTest.cs
@@ -230,6 +230,7 @@ namespace Introspection {
 			case "MidiEndpoint":
 			case "ABMultiValue":
 			case "ABMutableMultiValue":
+			case "ABSource": // not skipped when running on iOS 6.1
 			// type was removed in iOS 10 (and replaced) and never consumed by other API
 			case "CGColorConverter":
 				return true;
@@ -328,13 +329,13 @@ namespace Introspection {
 				return new CTTypesetter (new NSAttributedString ("Hello, world",
 					new CTStringAttributes () {
 						ForegroundColorFromContext =  true,
-						Font = new CTFont ("Arial", 24)
+						Font = new CTFont ("ArialMT", 24)
 					}));
 			case "CTFrame":
 				var framesetter = new CTFramesetter (new NSAttributedString ("Hello, world",
 					new CTStringAttributes () {
 						ForegroundColorFromContext =  true,
-						Font = new CTFont ("Arial", 24)
+						Font = new CTFont ("ArialMT", 24)
 					}));
 				var bPath = UIBezierPath.FromRect (new RectangleF (0, 0, 3, 3));
 				return framesetter.GetFrame (new NSRange (0, 0), bPath.CGPath, null);
@@ -342,15 +343,15 @@ namespace Introspection {
 				return new CTFramesetter (new NSAttributedString ("Hello, world",
 					new CTStringAttributes () {
 						ForegroundColorFromContext =  true,
-						Font = new CTFont ("Arial", 24)
+						Font = new CTFont ("ArialMT", 24)
 					}));
 			case "CTGlyphInfo":
-				return new CTGlyphInfo ("Zapfino", new CTFont ("Arial", 24), "Foo");	
+				return new CTGlyphInfo ("Zapfino", new CTFont ("ArialMT", 24), "Foo");
 			case "CTLine":
 				return new CTLine (new NSAttributedString ("Hello, world",
 					new CTStringAttributes () {
 						ForegroundColorFromContext =  true,
-						Font = new CTFont ("Arial", 24)
+						Font = new CTFont ("ArialMT", 24)
 					}));
 			case "CGImageDestination":
 				var storage = new NSMutableData ();
@@ -398,7 +399,7 @@ namespace Introspection {
 			case "DispatchGroup":
 				return DispatchGroup.Create ();
 			case "CGColorSpace":
-				return CGColorSpace.CreateAcesCGLinear ();
+				return CGColorSpace.CreateDeviceCmyk ();
 			case "CGGradient":
 				CGColor[] cArray = { UIColor.Black.CGColor, UIColor.Clear.CGColor, UIColor.Blue.CGColor };
 				return new CGGradient (null, cArray);

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -575,6 +575,15 @@ namespace Introspection {
 				}
 				break;
 
+			case "preferredFocusedView":
+				switch (declaredType.Name) {
+				// UIFocusGuide (added in iOS 9.0 and deprecated in iOS 10)
+				case "UIView":
+				case "UIViewController":
+					return !TestRuntime.CheckXcodeVersion (7,0);
+				}
+				break;
+
 #if XAMCORE_2_0
 			// some types adopted NS[Secure]Coding after the type was added
 			// and for unified that's something we generate automatically (so we can't put [iOS] on them)


### PR DESCRIPTION
Also fix warnings printed while executing:

> CoreText performance note: Client called CTFontCreateWithName() using name "Arial" and got font with PostScript name "ArialMT". For best performance, only use PostScript names when calling this API.
> CoreText performance note: Set a breakpoint on CTFontLogSuboptimalRequest to debug.