### PR TITLE
[UIKit] Updated UIKit to xcode8-beta6

### DIFF
--- a/src/UIKit/UIAccessibility.cs
+++ b/src/UIKit/UIAccessibility.cs
@@ -317,9 +317,10 @@ namespace XamCore.UIKit {
 			}
 		}
 
+		[iOS (10,0), TV (10,0)]
 		[DllImport (Constants.UIKitLibrary)]
 		static extern bool UIAccessibilityIsAssistiveTouchRunning ();
-		[iOS (10,0)]
+		[iOS (10,0), TV (10,0)]
 		public static bool IsAssistiveTouchRunning {
 			get {
 				return UIAccessibilityIsAssistiveTouchRunning ();
@@ -327,6 +328,7 @@ namespace XamCore.UIKit {
 		}
 
 #if !TVOS
+		[iOS (10,0)]
 		[DllImport (Constants.UIKitLibrary)]
 		static extern nuint UIAccessibilityHearingDevicePairedEar ();
 

--- a/src/UIKit/UIEnums.cs
+++ b/src/UIKit/UIEnums.cs
@@ -484,6 +484,7 @@ namespace XamCore.UIKit {
 		DecimalPad,
 		Twitter,
 		WebSearch,
+		[iOS (10, 0)]
 		AsciiCapableNumberPad
 	} 
 
@@ -1618,8 +1619,11 @@ namespace XamCore.UIKit {
 	[iOS (8,0)]
 	public enum UIBlurEffectStyle : nint {
 		ExtraLight, Light, Dark,
-		// Notice: value 3 is skipped
+		[TV (10,0), NoiOS, NoWatch]
+		ExtraDark,
+		[iOS (10,0)]
 		Regular = 4,
+		[iOS (10,0)]
 		Prominent = 5,
 	}
 
@@ -1640,6 +1644,7 @@ namespace XamCore.UIKit {
 
 	[NoTV][NoWatch]
 	[iOS (8,0)]
+	[Deprecated (PlatformName.iOS, 10, 0, message:"Use UNAuthorizationOptions instead")]
 	[Native]
 	[Flags]
 	public enum UIUserNotificationType : nuint {
@@ -1651,6 +1656,7 @@ namespace XamCore.UIKit {
 	
 	[NoTV][NoWatch]
 	[iOS (8, 0)]
+	[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNNotificationActionOptions instead")]
 	[Native]
 	public enum UIUserNotificationActivationMode : nuint {
 		Foreground,
@@ -1659,6 +1665,7 @@ namespace XamCore.UIKit {
 
 	[NoTV][NoWatch]
 	[iOS (8, 0)]
+	[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNNotificationCategory.Actions instead")]
 	[Native]
 	public enum UIUserNotificationActionContext : nuint {
 		Default,
@@ -1774,6 +1781,7 @@ namespace XamCore.UIKit {
 
 	[NoTV][NoWatch]
 	[iOS (9,0)]
+	[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNNotificationAction or UNTextInputNotificationAction instead")]
 	[Native]
 	public enum UIUserNotificationActionBehavior : nuint
 	{
@@ -1939,5 +1947,24 @@ namespace XamCore.UIKit {
 	{
 		Previous,
 		Next
+	}
+
+	[iOS (10,0), TV (10,0), NoWatch]
+	[Native]
+	[Flags]
+	public enum UICloudSharingPermissionOptions : nuint {
+		Standard = 0,
+		AllowPublic = 1 << 0,
+		AllowPrivate = 1 << 1,
+		AllowReadOnly = 1 << 2,
+		AllowReadWrite = 1 << 3
+	}
+
+	[iOS (10,0), TV (10,0), NoWatch]
+	[Native]
+	public enum UITextFieldDidEndEditingReason : nint {
+		Committed,
+		[NoiOS]
+		Cancelled
 	}
 }

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -13,6 +13,7 @@ using XamCore.Foundation;
 using XamCore.CoreGraphics;
 using XamCore.CoreLocation;
 using XamCore.UIKit;
+using XamCore.CloudKit;
 #if !TVOS
 using XamCore.Contacts;
 #endif
@@ -48,7 +49,7 @@ namespace XamCore.UIKit {
 		Restricted, Denied, Available
 	}
 
-	[NoTV][NoWatch]
+	[TV (10,0)][NoWatch]
 	[Native] // NSUInteger -> UIApplication.h
 	public enum UIBackgroundFetchResult : nuint_compat_int {
 		NewData, NoData, Failed
@@ -125,6 +126,69 @@ namespace XamCore.UIKit {
 		NSAttributedString FromTextAttachment (NSTextAttachment attachment);
 	}
 #endif
+
+	interface IUICloudSharingControllerDelegate { }
+
+	[iOS (10,0), NoTV, NoWatch]
+	[Protocol, Model]
+	[BaseType (typeof (NSObject))]
+	interface UICloudSharingControllerDelegate {
+		[Abstract]
+		[Export ("cloudSharingController:failedToSaveShareWithError:")]
+		void FailedToSaveShare (UICloudSharingController csc, NSError error);
+
+		[Abstract]
+		[Export ("itemTitleForCloudSharingController:")]
+		[return: NullAllowed]
+		string GetItemTitle (UICloudSharingController csc);
+
+		[Export ("itemThumbnailDataForCloudSharingController:")]
+		[return: NullAllowed]
+		NSData GetItemThumbnailData (UICloudSharingController csc);
+
+		[Export ("itemTypeForCloudSharingController:")]
+		[return: NullAllowed]
+		string GetItemType (UICloudSharingController csc);
+
+		[Export ("cloudSharingControllerDidSaveShare:")]
+		void DidSaveShare (UICloudSharingController csc);
+
+		[Export ("cloudSharingControllerDidStopSharing:")]
+		void DidStopSharing (UICloudSharingController csc);
+	}
+
+	[iOS (10,0), NoTV, NoWatch]
+	delegate void UICloudSharingControllerPreparationHandler (UICloudSharingController controller, [BlockCallback] UICloudSharingControllerPreparationCompletionHandler completion);
+
+	[iOS (10,0), NoTV, NoWatch]
+	delegate void UICloudSharingControllerPreparationCompletionHandler ([NullAllowed] CKShare share, [NullAllowed] CKContainer container, [NullAllowed] NSError error);
+
+	[iOS (10,0), NoTV, NoWatch] //TODO: This is marked as available on tvOS 10 but it isn't radar: 27929711
+	[BaseType (typeof (UIViewController))]
+	interface UICloudSharingController {
+
+		[Export ("initWithNibName:bundle:")]
+		[PostGet ("NibBundle")]
+		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
+
+		[Export ("initWithPreparationHandler:")]
+		IntPtr Constructor (UICloudSharingControllerPreparationHandler preparationHandler);
+
+		[Export ("initWithShare:container:")]
+		IntPtr Constructor (CKShare share, CKContainer container);
+
+		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
+		IUICloudSharingControllerDelegate Delegate { get; set; }
+
+		[NullAllowed, Export ("share", ArgumentSemantic.Strong)]
+		CKShare Share { get; }
+
+		[Export ("availablePermissions", ArgumentSemantic.Assign)]
+		UICloudSharingPermissionOptions AvailablePermissions { get; set; }
+
+		[Export ("activityItemSource")]
+		IUIActivityItemSource ActivityItemSource { get; }
+	}
 
 	[NoWatch]
 	[Category]
@@ -334,12 +398,12 @@ namespace XamCore.UIKit {
 		void DeactivateConstraints (NSLayoutConstraint [] constraints);
 
 #if XAMCORE_2_0
-		[iOS (10, 0)]
+		[iOS (10,0), TV (10,0)]
 		[Export ("firstAnchor", ArgumentSemantic.Copy)]
 		[Internal]
 		IntPtr _FirstAnchor<AnchorType> ();
 	
-		[iOS (10, 0)]
+		[iOS (10,0), TV (10,0)]
 		[NullAllowed, Export ("secondAnchor", ArgumentSemantic.Copy)]
 		[Internal]
 		IntPtr _SecondAnchor<AnchorType> ();
@@ -1248,7 +1312,7 @@ namespace XamCore.UIKit {
 		long TraitCausesPageTurn { get; }
 
 
-		[iOS (10,0)]
+		[iOS (10,0), TV (10,0), Watch (3,0)]
 		[Field ("UIAccessibilityTraitTabBar")]
 		long TraitTabBar { get; }
 	
@@ -1430,7 +1494,7 @@ namespace XamCore.UIKit {
 		NSString HearingDevicePairedEarDidChangeNotification { get; }
 
 		[NoWatch]
-		[iOS (10,0)]
+		[iOS (10,0), TV (10,0)]
 		[Notification]
 		[Field ("UIAccessibilityAssistiveTouchStatusDidChangeNotification")]
 		NSString AssistiveTouchStatusDidChangeNotification { get; }
@@ -1487,7 +1551,7 @@ namespace XamCore.UIKit {
 
 	delegate UIAccessibilityCustomRotorItemResult UIAccessibilityCustomRotorSearch (UIAccessibilityCustomRotorSearchPredicate predicate);
 	
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof (NSObject))]
 	interface UIAccessibilityCustomRotor {
 
@@ -1501,7 +1565,7 @@ namespace XamCore.UIKit {
 		UIAccessibilityCustomRotorSearch ItemSearchHandler { get; set; }
 	}
 
-	[iOS (10, 0)]
+	[iOS (10,0), TV (10,0)]
 	[Category]
 	[BaseType (typeof (NSObject))]
 	interface NSObject_UIAccessibilityCustomRotor {
@@ -1514,7 +1578,7 @@ namespace XamCore.UIKit {
 		void SetAccessibilityCustomRotors ([NullAllowed] UIAccessibilityCustomRotor [] customRotors);
 	}
 	
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof(NSObject))]
 	interface UIAccessibilityCustomRotorItemResult {
 
@@ -1528,7 +1592,7 @@ namespace XamCore.UIKit {
 		UITextRange TargetRange { get; set; }
 	}
 	
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof(NSObject))]
 	interface UIAccessibilityCustomRotorSearchPredicate {
 
@@ -1573,7 +1637,7 @@ namespace XamCore.UIKit {
 		[Export ("accessibilityTraits", ArgumentSemantic.UnsafeUnretained)]
 		ulong AccessibilityTraits { get; set; }
 
-		[iOS (10, 0)]
+		[iOS (10,0), TV (10,0)]
 		[Export ("accessibilityFrameInContainerSpace", ArgumentSemantic.Assign)]
 		CGRect AccessibilityFrameInContainerSpace { get; set; }
 	}
@@ -1842,6 +1906,8 @@ namespace XamCore.UIKit {
 		
 	}
 
+	interface IUIActivityItemSource { }
+
 	[NoTV]
 	[Since (6,0)]
 	[BaseType (typeof (NSObject))]
@@ -2060,6 +2126,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (UIView))]
 	interface UIStackView {
 		[Export ("initWithFrame:")]
+		[DesignatedInitializer]
 		IntPtr Constructor (CGRect frame);
 
 		[Export ("initWithArrangedSubviews:")]
@@ -2143,7 +2210,7 @@ namespace XamCore.UIKit {
 
 	[iOS(10,0)]
 	[Protocol]
-	interface UIViewAnimating
+	public interface UIViewAnimating
 	{
 		[Abstract]
 		[Export ("state")]
@@ -2166,6 +2233,10 @@ namespace XamCore.UIKit {
 		void StartAnimation ();
 
 		[Abstract]
+		[Export ("startAnimationAfterDelay:")]
+		void StartAnimation (double delay);
+
+		[Abstract]
 		[Export ("pauseAnimation")]
 		void PauseAnimation ();
 
@@ -2175,13 +2246,13 @@ namespace XamCore.UIKit {
 
 		[Abstract]
 		[Export ("finishAnimationAtPosition:")]
-		void FinishAnimationAtPosition (UIViewAnimatingPosition finalPosition);
+		void FinishAnimation (UIViewAnimatingPosition finalPosition);
 	}
 
-	interface IUIViewImplicitlyAnimating {}
+	public interface IUIViewImplicitlyAnimating {}
 	[iOS(10,0)]
 	[Protocol]
-	interface UIViewImplicitlyAnimating : UIViewAnimating
+	public interface UIViewImplicitlyAnimating : UIViewAnimating
 	{
 		[Export ("addAnimations:delayFactor:")]
 		void AddAnimations (Action animation, nfloat delayFactor);
@@ -2196,7 +2267,7 @@ namespace XamCore.UIKit {
 		void ContinueAnimation ([NullAllowed] IUITimingCurveProvider parameters, nfloat durationFactor);
 	}
 		
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof(NSObject))]
 	interface UIViewPropertyAnimator : UIViewImplicitlyAnimating, NSCopying
 	{
@@ -2205,9 +2276,15 @@ namespace XamCore.UIKit {
 	
 		[Export ("duration")]
 		double Duration { get; }
+
+		[Export ("delay")]
+		double Delay { get; }
 	
 		[Export ("userInteractionEnabled")]
 		bool UserInteractionEnabled { [Bind ("isUserInteractionEnabled")] get; set; }
+
+		[Export ("manualHitTestingEnabled")]
+		bool ManualHitTestingEnabled { [Bind ("isManualHitTestingEnabled")] get; set; }
 	
 		[Export ("interruptible")]
 		bool Interruptible { [Bind ("isInterruptible")] get; set; }
@@ -2227,10 +2304,7 @@ namespace XamCore.UIKit {
 	
 		[Static]
 		[Export ("runningPropertyAnimatorWithDuration:delay:options:animations:completion:")]
-		UIViewPropertyAnimator CreateRunningProperty (double duration, double delay, UIViewAnimationOptions options, [NullAllowed] Action animations, [NullAllowed] Action<UIViewAnimatingPosition> completion);
-	
-		[Export ("continueAnimationWithTimingParameters:durationFactor:")]
-		void ContinueAnimation ([NullAllowed] IUITimingCurveProvider timingParameters, nfloat durationFactor);
+		UIViewPropertyAnimator CreateRunningPropertyAnimator (double duration, double delay, UIViewAnimationOptions options, [NullAllowed] Action animations, [NullAllowed] Action<UIViewAnimatingPosition> completion);
 	}
 	
 	public interface IUIViewControllerPreviewing {}
@@ -2324,6 +2398,9 @@ namespace XamCore.UIKit {
 		NSObject Annotation { get; set; }
 		string SourceApplication { get; set; }
 		bool OpenInPlace { get; set; }
+
+		[iOS (10, 0)]
+		bool UniversalLinksOnly { get; set; }
 	}
 
 	[iOS (9,0)]
@@ -2337,13 +2414,17 @@ namespace XamCore.UIKit {
 		NSString SourceApplicationKey { get; }
 
 		[Field ("UIApplicationOpenURLOptionsOpenInPlaceKey")]
-		NSString OpenInPlaceKey { get; } 
+		NSString OpenInPlaceKey { get; }
+
+		[iOS (10,0), TV (10,0)]
+		[Field ("UIApplicationOpenURLOptionUniversalLinksOnly")]
+		NSString UniversalLinksOnlyKey { get; }
 	}
 
 	[NoWatch]
 	[iOS (2,0)]
 	[BaseType (typeof (UIResponder))]
-	public interface UIApplication {
+	interface UIApplication {
 		[Static, ThreadSafe]
 		[Export ("sharedApplication")]
 		UIApplication SharedApplication { get; }
@@ -2367,13 +2448,17 @@ namespace XamCore.UIKit {
 		[Export ("idleTimerDisabled")]
 		bool IdleTimerDisabled { [Bind ("isIdleTimerDisabled")] get; set; }
 
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Please use the overload instead")]
 		[Export ("openURL:")]
 		bool OpenUrl (NSUrl url);
 
-		[iOS (10,0)]
+		[iOS (10,0), TV (10,0)]
 		[Export ("openURL:options:completionHandler:")]
-		void OpenUrl (NSUrl url, NSDictionary<NSString, NSObject> options, [NullAllowed] Action<bool> completion);
-		
+		void OpenUrl (NSUrl url, NSDictionary options, [NullAllowed] Action<bool> completion);
+
+		[iOS (10,0), TV (10,0)]
+		[Wrap ("OpenUrl (url, options?.Dictionary, completion)")]
+		void OpenUrl (NSUrl url, UIApplicationOpenUrlOptions options, [NullAllowed] Action<bool> completion);
 
 		[Export ("canOpenURL:")]
 		bool CanOpenUrl ([NullAllowed] NSUrl url);
@@ -2434,7 +2519,7 @@ namespace XamCore.UIKit {
 		[Export ("statusBarFrame")]
 		CGRect StatusBarFrame { get; }
 		
-		[NoTV]
+		[TV (10, 0)]
 		[Export ("applicationIconBadgeNumber")]
 		nint ApplicationIconBadgeNumber { get; set; }
 
@@ -2444,7 +2529,7 @@ namespace XamCore.UIKit {
 
 		// From @interface UIApplication (UIRemoteNotifications)
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use RegisterUserNotifications and RegisterForNotifications instead")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use RegisterUserNotifications and RegisterForNotifications instead or if iOS 10+ UNUserNotificationCenter.RequestAuthorization")]
 		[Export ("registerForRemoteNotificationTypes:")]
 		void RegisterForRemoteNotificationTypes (UIRemoteNotificationType types);
 
@@ -2454,7 +2539,7 @@ namespace XamCore.UIKit {
 
 		// From @interface UIApplication (UIRemoteNotifications)
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use CurrentUserNotificationSettings instead")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use CurrentUserNotificationSettings instead or if iOS 10+ UNUserNotificationCenter.GetNotificationSettings")]
 		[Export ("enabledRemoteNotificationTypes")]
 		UIRemoteNotificationType EnabledRemoteNotificationTypes { get; }
 
@@ -2556,6 +2641,7 @@ namespace XamCore.UIKit {
 		// from @interface UIApplication (UILocalNotifications)
 		[NoTV]
 		[Since (4,0)]
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNUserNotificationCenter.AddNotificationRequest instead")]
 		[Export ("presentLocalNotificationNow:")]
 #if XAMCORE_2_0
 		void PresentLocalNotificationNow (UILocalNotification notification);
@@ -2566,24 +2652,28 @@ namespace XamCore.UIKit {
 		// from @interface UIApplication (UILocalNotifications)
 		[NoTV]
 		[Since (4,0)]
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNUserNotificationCenter.AddNotificationRequest instead")]
 		[Export ("scheduleLocalNotification:")]
 		void ScheduleLocalNotification (UILocalNotification notification);
 
 		// from @interface UIApplication (UILocalNotifications)
 		[NoTV]
 		[Since (4,0)]
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNUserNotificationCenter.RemovePendingNotificationRequests instead")]
 		[Export ("cancelLocalNotification:")]
 		void CancelLocalNotification (UILocalNotification notification);
 
 		// from @interface UIApplication (UILocalNotifications)
 		[NoTV]
 		[Since (4,0)]
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNUserNotificationCenter.RemoveAllPendingNotificationRequests instead")]
 		[Export ("cancelAllLocalNotifications")]
 		void CancelAllLocalNotifications ();
 
 		// from @interface UIApplication (UILocalNotifications)
 		[NoTV]
 		[Since (4,0)]
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNUserNotificationCenter.GetPendingNotificationRequests instead")]
 		[Export ("scheduledLocalNotifications", ArgumentSemantic.Copy)]
 		UILocalNotification [] ScheduledLocalNotifications { get; set; }
 
@@ -2631,6 +2721,7 @@ namespace XamCore.UIKit {
 		
 		[NoTV]
 		[Since (4,0)]
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNUserNotificationCenterDelegate.DidReceiveNotificationResponse instead")]
 		[Field ("UIApplicationLaunchOptionsLocalNotificationKey")]
 		NSString LaunchOptionsLocalNotificationKey { get; }
 
@@ -2641,9 +2732,9 @@ namespace XamCore.UIKit {
 		// from @interface UIApplication (UINewsstand)
 		[NoTV]
 		[Since (5,0)]
+		[Deprecated (PlatformName.iOS, 9, 0)]
 		[Export ("setNewsstandIconImage:")]
-		[NullAllowed]
-		void SetNewsstandIconImage (UIImage image);
+		void SetNewsstandIconImage ([NullAllowed] UIImage image);
 
 		[NoTV]
 		[Since (5,0)]
@@ -2796,6 +2887,10 @@ namespace XamCore.UIKit {
 		[iOS (8,0)]
 		[Field ("UIApplicationLaunchOptionsUserActivityTypeKey")]
 		NSString LaunchOptionsUserActivityTypeKey { get; }
+
+		[iOS (10,0), NoTV, NoWatch]
+		[Field ("UIApplicationLaunchOptionsCloudKitShareMetadataKey")]
+		NSString LaunchOptionsCloudKitShareMetadataKey { get; }
 
 		[NoTV]
 		[iOS (9,0)]
@@ -2960,12 +3055,11 @@ namespace XamCore.UIKit {
 		nfloat FrictionTorque { get; set; }
 	}
 
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	[Protocol]
-	public interface UIContentSizeCategoryAdjusting
-	{
-		[iOS (10,0)]
+	public interface UIContentSizeCategoryAdjusting {
 		[Abstract]
+		[iOS (10,0), TV (10,0)] // Repeated because of generator bug
 		[Export ("adjustsFontForContentSizeCategory")]
 		bool AdjustsFontForContentSizeCategory { get; set; }
 	}
@@ -2979,6 +3073,10 @@ namespace XamCore.UIKit {
 	[Static]
 	[NoWatch]
 	public enum UIContentSizeCategory {
+		[iOS (10,0), TV (10,0)]
+		[Field ("UIContentSizeCategoryUnspecified")]
+		Unspecified,
+
 		[Field ("UIContentSizeCategoryExtraSmall")]
 		ExtraSmall,
 		
@@ -3048,7 +3146,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UIApplicationDelegate {
+	interface UIApplicationDelegate {
 
 		[Export ("applicationDidFinishLaunching:")]
 		void FinishedLaunching (UIApplication application);
@@ -3098,11 +3196,13 @@ namespace XamCore.UIKit {
 		[Export ("application:didFailToRegisterForRemoteNotificationsWithError:")]
 		void FailedToRegisterForRemoteNotifications (UIApplication application, NSError error);
 
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNUserNotificationCenterDelegate.WillPresentNotification/DidReceiveNotificationResponse for user visible notifications and ReceivedRemoteNotification for silent remote notifications.")]
 		[Export ("application:didReceiveRemoteNotification:")]
 		void ReceivedRemoteNotification (UIApplication application, NSDictionary userInfo);
 
 		[NoTV]
 		[Since (4,0)]
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNUserNotificationCenterDelegate.WillPresentNotification/DidReceiveNotificationResponse instead.")]
 		[Export ("application:didReceiveLocalNotification:")]
 		void ReceivedLocalNotification (UIApplication application, UILocalNotification notification);
 
@@ -3180,7 +3280,7 @@ namespace XamCore.UIKit {
 		[Export ("accessibilityPerformMagicTap")]
 		bool AccessibilityPerformMagicTap ();
 
-		[NoTV]
+		[TV (10, 0)]
 		[Since (7,0)]
 		[Export ("application:didReceiveRemoteNotification:fetchCompletionHandler:")]
 		void DidReceiveRemoteNotification (UIApplication application, NSDictionary userInfo, Action<UIBackgroundFetchResult> completionHandler);
@@ -3216,21 +3316,25 @@ namespace XamCore.UIKit {
 
 		[NoTV]
 		[iOS (8,0)]
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNUserNotificationCenterDelegate.DidReceiveNotificationResponse instead")]
 		[Export ("application:handleActionWithIdentifier:forLocalNotification:completionHandler:")]
 		void HandleAction (UIApplication application, string actionIdentifier, UILocalNotification localNotification, Action completionHandler);
 
 		[NoTV]
 		[iOS (9,0)]
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNUserNotificationCenterDelegate.DidReceiveNotificationResponse instead")]
 		[Export ("application:handleActionWithIdentifier:forLocalNotification:withResponseInfo:completionHandler:")]
 		void HandleAction (UIApplication application, string actionIdentifier, UILocalNotification localNotification, NSDictionary responseInfo, Action completionHandler);
 		
 		[NoTV]
 		[iOS (8,0)]
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNUserNotificationCenterDelegate.DidReceiveNotificationResponse instead")]
 		[Export ("application:handleActionWithIdentifier:forRemoteNotification:completionHandler:")]
 		void HandleAction (UIApplication application, string actionIdentifier, NSDictionary remoteNotificationInfo, Action completionHandler);
 
 		[NoTV]
 		[iOS (9,0)]
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNUserNotificationCenterDelegate.DidReceiveNotificationResponse instead")]
 		[Export ("application:handleActionWithIdentifier:forRemoteNotification:withResponseInfo:completionHandler:")]
 		void HandleAction (UIApplication application, string actionIdentifier, NSDictionary remoteNotificationInfo, NSDictionary responseInfo, Action completionHandler);
 
@@ -3258,6 +3362,10 @@ namespace XamCore.UIKit {
 		[iOS (9,0)]
 		[Export ("applicationShouldRequestHealthAuthorization:")]
 		void ShouldRequestHealthAuthorization (UIApplication application);
+
+		[iOS (10,0), TV (10,0), NoWatch]
+		[Export ("application:userDidAcceptCloudKitShareWithMetadata:")]
+		void UserDidAcceptCloudKitShare (UIApplication application, CKShareMetadata cloudKitShareMetadata);
 	}
 
 	[Static]
@@ -3676,6 +3784,7 @@ namespace XamCore.UIKit {
 
 
 		[iOS (9,0)]
+		[return : NullAllowed]
 		[Export ("supplementaryViewForElementKind:atIndexPath:")]
 		UICollectionReusableView GetSupplementaryView (NSString elementKind, NSIndexPath indexPath);
 
@@ -3691,11 +3800,11 @@ namespace XamCore.UIKit {
 		[Export ("remembersLastFocusedIndexPath")]
 		bool RemembersLastFocusedIndexPath { get; set; }
 
-		[iOS (10, 0)]
+		[iOS (10,0), TV (10,0)]
 		[NullAllowed, Export ("prefetchDataSource", ArgumentSemantic.Weak)]
 		IUICollectionViewDataSourcePrefetching PrefetchDataSource { get; set; }
 
-		[iOS (10, 0)]
+		[iOS (10,0), TV (10,0)]
 		[Export ("prefetchingEnabled")]
 		bool PrefetchingEnabled { [Bind ("isPrefetchingEnabled")] get; set; }
 	}
@@ -3703,14 +3812,13 @@ namespace XamCore.UIKit {
 	interface IUICollectionViewDataSourcePrefetching {}
 	
 	[Protocol]
-	interface UICollectionViewDataSourcePrefetching
-	{
-		[iOS (10,0)]
+	[iOS (10, 0)]
+	interface UICollectionViewDataSourcePrefetching {
+		
 		[Abstract]
 		[Export ("collectionView:prefetchItemsAtIndexPaths:")]
 		void PrefetchItems (UICollectionView collectionView, NSIndexPath[] indexPaths);
 	
-		[iOS (10,0)]
 		[Export ("collectionView:cancelPrefetchingForItemsAtIndexPaths:")]
 		void CancelPrefetching (UICollectionView collectionView, NSIndexPath[] indexPaths);
 	}
@@ -3957,9 +4065,9 @@ namespace XamCore.UIKit {
 		[Export ("sectionFootersPinToVisibleBounds")]
 		bool SectionFootersPinToVisibleBounds { get; set; }
 
-		[iOS (10, 0)]
+		[iOS (10,0), TV (10,0)]
 		[Field ("UICollectionViewFlowLayoutAutomaticSize")]
-		CGSize UICollectionViewFlowLayoutAutomaticSize { get; }
+		CGSize AutomaticSize { get; }
 	}
 
 	[Since (6,0)]
@@ -4302,7 +4410,7 @@ namespace XamCore.UIKit {
 		[Export ("colorWithCGColor:")][Static]
 		UIColor FromCGColor (CGColor color);
 
-		[iOS (10,0)]
+		[iOS (10,0), TV (10,0), Watch (3,0)]
 		[Static]
 		[Export ("colorWithDisplayP3Red:green:blue:alpha:")]
 		UIColor FromDisplayP3 (nfloat red, nfloat green, nfloat blue, nfloat alpha);
@@ -5062,7 +5170,7 @@ namespace XamCore.UIKit {
 
 		// FIXME [Watch (3,0)] the API is present but UITraitCollection is not exposed / rdar 27785753
 #if !WATCH
-		[iOS (10,0)]
+		[iOS (10,0), TV (10,0)]
 		[Static]
 		[Export ("preferredFontForTextStyle:compatibleWithTraitCollection:")]
 		[Internal]
@@ -5156,7 +5264,7 @@ namespace XamCore.UIKit {
 
 		// FIXME [Watch (3,0)] the API is present but UITraitCollection is not exposed / rdar #27785753
 #if !WATCH
-		[iOS (10,0)]
+		[iOS (10,0), TV (10,0)]
 		[Static]
 		[Export ("preferredFontDescriptorWithTextStyle:compatibleWithTraitCollection:")]
 		UIFontDescriptor GetPreferredDescriptorForTextStyle (NSString uiFontTextStyle, [NullAllowed] UITraitCollection traitCollection);
@@ -5379,6 +5487,10 @@ namespace XamCore.UIKit {
 		[Export ("allowedPressTypes", ArgumentSemantic.Copy)]
 		NSNumber[] AllowedPressTypes { get; set; }
 
+		[iOS (9,2)]
+		[Export ("requiresExclusiveTouchType")]
+		bool RequiresExclusiveTouchType { get; set; }
+
 		[iOS (9,0)]
 		[Export ("pressesBegan:withEvent:")]
 		void PressesBegan (NSSet<UIPress> presses, UIPressesEvent evt);
@@ -5423,7 +5535,7 @@ namespace XamCore.UIKit {
 		bool ShouldReceivePress (UIGestureRecognizer gestureRecognizer, UIPress press);
 	}
 
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof(NSObject))]
 	interface UIGraphicsRendererFormat : NSCopying
 	{
@@ -5435,7 +5547,7 @@ namespace XamCore.UIKit {
 		CGRect Bounds { get; }
 	}
 
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof(NSObject))]
 	interface UIGraphicsRendererContext
 	{
@@ -5461,7 +5573,7 @@ namespace XamCore.UIKit {
 		void ClipToRect (CGRect rect);
 	}
 
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof(NSObject))]
 	interface UIGraphicsRenderer
 	{
@@ -5477,12 +5589,30 @@ namespace XamCore.UIKit {
 	
 		[Export ("allowsImageOutput")]
 		bool AllowsImageOutput { get; }
+
+		// From UIGraphicsRenderer (UIGraphicsRendererProtected) category
+
+		[Static]
+		[Export ("rendererContextClass")]
+		Class RendererContextClass { get; }
+
+		[Static]
+		[Export ("contextWithFormat:")]
+		[return: NullAllowed]
+		CGContext GetContext (UIGraphicsRendererFormat format);
+
+		[Static]
+		[Export ("prepareCGContext:withRendererContext:")]
+		void PrepareContext (CGContext context, UIGraphicsRendererContext rendererContext);
+
+		[Export ("runDrawingActions:completionActions:error:")]
+		bool Run (Action<UIGraphicsRendererContext> drawingActions, [NullAllowed] Action<UIGraphicsRendererContext> completionActions, [NullAllowed] out NSError error);
 	}
 			
 	// Not worth it, Action<UIGraphicsImageRendererContext> conveys more data
 	//delegate void UIGraphicsImageDrawingActions (UIGraphicsImageRendererContext context);
 
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof(UIGraphicsRendererFormat))]
 	public interface UIGraphicsImageRendererFormat
 	{
@@ -5496,7 +5626,7 @@ namespace XamCore.UIKit {
 		bool PrefersExtendedRange { get; set; }
 	}
 
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof(UIGraphicsRendererContext))]
 	interface UIGraphicsImageRendererContext
 	{
@@ -5504,7 +5634,7 @@ namespace XamCore.UIKit {
 		UIImage CurrentImage { get; }
 	}
 
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof(UIGraphicsRenderer))]
 	interface UIGraphicsImageRenderer
 	{
@@ -5533,7 +5663,7 @@ namespace XamCore.UIKit {
 	//delegate void UIGraphicsPdfDrawingActions (UIGraphicsPdfRendererContext context);
 	// Action<UIGraphicsPdfRendererContext>
 
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof (UIGraphicsRendererFormat), Name="UIGraphicsPDFRendererFormat")]
 	interface UIGraphicsPdfRendererFormat
 	{
@@ -5542,7 +5672,7 @@ namespace XamCore.UIKit {
 		NSDictionary<NSString, NSObject> DocumentInfo { get; set; }
 	}
 
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof (UIGraphicsRendererContext), Name="UIGraphicsPDFRendererContext")]
 	interface UIGraphicsPdfRendererContext
 	{
@@ -5566,7 +5696,7 @@ namespace XamCore.UIKit {
 	}
 
 
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof (UIGraphicsRenderer), Name = "UIGraphicsPDFRenderer")]
 	interface UIGraphicsPdfRenderer
 	{
@@ -5651,7 +5781,7 @@ namespace XamCore.UIKit {
 		[Export ("spellCheckingType")]
 		UITextSpellCheckingType SpellCheckingType { get; set; }
 
-		[iOS (10, 0)]
+		[iOS (10, 0)] // Did not add abstract here breaking change, anyways this is optional in objc
 		[Export ("textContentType")]
 		NSString TextContentType { get; set; }
 	}
@@ -6235,6 +6365,7 @@ namespace XamCore.UIKit {
 		[NullAllowed]
 		NSDictionary UserInfo { get; set;  }
 
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNNotificationSound.DefaultSound instead")]
 		[Field ("UILocalNotificationDefaultSoundName")]
 		NSString DefaultSoundName { get; }
 
@@ -6702,9 +6833,13 @@ namespace XamCore.UIKit {
 		bool FlipsForRightToLeftLayoutDirection { get; }
 
 #if !WATCH
-		[iOS (10, 0)]
+		[iOS (10,0), TV (10,0)]
 		[Export ("imageRendererFormat")]
 		UIGraphicsImageRendererFormat ImageRendererFormat { get; }
+
+		[iOS (10,0), TV (10,0)]
+		[Export ("imageWithHorizontallyFlippedOrientation")]
+		UIImage GetImageWithHorizontallyFlippedOrientation ();
 #endif
 	}
 
@@ -8403,7 +8538,8 @@ namespace XamCore.UIKit {
 		void Remove (string name);
 		
 		[Export ("persistent")]
-		bool Persistent { [Bind ("isPersistent")] get; set; }
+		bool Persistent { [Bind ("isPersistent")] get;
+			[Deprecated (PlatformName.iOS, 10, 0, message:"Soft deprecated in iOS 10")] set; }
 
 		[Export ("changeCount")]
 		nint ChangeCount { get; } 
@@ -8429,9 +8565,13 @@ namespace XamCore.UIKit {
 		[Export ("numberOfItems")]
 		nint Count { get; }
 
+#if XAMCORE_4_0
+		[Export ("pasteboardTypesForItemSet:")]
+		NSArray<NSString> [] GetPasteBoardTypes (NSIndexSet itemSet);
+#else
 		[Export ("pasteboardTypesForItemSet:")]
 		NSArray [] PasteBoardTypesForSet (NSIndexSet itemSet);
-
+#endif
 		[Export ("containsPasteboardTypes:inItemSet:")]
 		bool Contains (string [] pasteboardTypes, [NullAllowed] NSIndexSet itemSet);
 		
@@ -8477,6 +8617,10 @@ namespace XamCore.UIKit {
 		[Field ("UIPasteboardTypeListColor")]
 		NSArray TypeListColor { get; }
 
+		[iOS (10,0), NoWatch]
+		[Field ("UIPasteboardTypeAutomatic")]
+		NSString Automatic { get; }
+
 		[NullAllowed]
 		[Export ("string", ArgumentSemantic.Copy)]
 		string String { get; set; }
@@ -8509,15 +8653,20 @@ namespace XamCore.UIKit {
 
 		[iOS (10,0)]
 		[Export ("setItems:options:")]
-		void SetItems (NSDictionary<NSString, NSObject>[] items, NSDictionary<NSString, NSObject> options);
+		void SetItems (NSDictionary<NSString, NSObject>[] items, NSDictionary options);
 		
+#if !TVOS
+		[iOS (10,0)]
+		[Wrap ("SetItems (items, pasteboardOptions?.Dictionary)")]
+		void SetItems (NSDictionary<NSString, NSObject> [] items, UIPasteboardOptions pasteboardOptions);
+#endif
 		[NoWatch, NoTV, iOS (10, 0)]
 		[Export ("hasStrings")]
 		bool HasStrings { get; }
 
 		[NoWatch, NoTV, iOS (10, 0)]
 		[Export ("hasURLs")]
-		bool HasURLs { get; }
+		bool HasUrls { get; }
 
 		[NoWatch, NoTV, iOS (10, 0)]
 		[Export ("hasImages")]
@@ -8534,10 +8683,28 @@ namespace XamCore.UIKit {
 		[Field ("UIPasteboardNameGeneral")]
 		NSString General { get; }
 
+		[Deprecated (PlatformName.iOS, 10, 0, message: "The Find pasteboard is no longer available.")]
 		[Field ("UIPasteboardNameFind")]
 		NSString Find { get; }
 	}
 
+#if !TVOS
+	[NoWatch, NoTV, iOS (10, 0)]
+	[StrongDictionary ("UIPasteboardOptionKeys")]
+	public interface UIPasteboardOptions {
+		NSDate ExpirationDate { get; set; }
+		bool LocalOnly { get; set; }
+	}
+#endif
+	[NoWatch, NoTV, iOS (10,0)]
+	[Static]
+	interface UIPasteboardOptionKeys {
+		[Field ("UIPasteboardOptionExpirationDate")]
+		NSString ExpirationDateKey { get; }
+
+		[Field ("UIPasteboardOptionLocalOnly")]
+		NSString LocalOnlyKey { get; }
+	}
 
 	[NoTV]
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" })]
@@ -8690,6 +8857,7 @@ namespace XamCore.UIKit {
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: Don't call -[UIPresentationController init].
 	public partial interface UIPresentationController : UIAppearanceContainer, UITraitEnvironment, UIContentContainer, UIFocusEnvironment {
 		[Export ("initWithPresentedViewController:presentingViewController:")]
+		[DesignatedInitializer]
 		IntPtr Constructor (UIViewController presentedViewController, [NullAllowed] UIViewController presentingViewController);
 
 		[Export ("presentingViewController", ArgumentSemantic.Retain)]
@@ -9184,6 +9352,7 @@ namespace XamCore.UIKit {
 		NSString DidConnectNotification { get; }
 
 		[Since (7,0)]
+		[return: NullAllowed]
 		[Export ("snapshotViewAfterScreenUpdates:")]
 		UIView SnapshotView (bool afterScreenUpdates);
 
@@ -10267,7 +10436,7 @@ namespace XamCore.UIKit {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
-		[Export ("delegate", ArgumentSemantic.Assign)][NullAllowed]
+		[Export ("delegate", ArgumentSemantic.Weak)][NullAllowed]
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")][NullAllowed]
@@ -10279,7 +10448,7 @@ namespace XamCore.UIKit {
 		[PostGet ("SelectedItem")]
 		UITabBarItem [] Items { get; set; }
 
-		[Export ("selectedItem", ArgumentSemantic.Assign), NullAllowed]
+		[Export ("selectedItem", ArgumentSemantic.Weak), NullAllowed]
 		UITabBarItem SelectedItem { get; set; }
 		
 		[Export ("setItems:animated:")]
@@ -10356,7 +10525,7 @@ namespace XamCore.UIKit {
 		[Export ("translucent")]
 		bool Translucent { [Bind ("isTranslucent")] get; set; }
 
-		[iOS (10, 0)]
+		[iOS (10,0), TV (10,0)]
 		[NullAllowed, Export ("unselectedItemTintColor", ArgumentSemantic.Copy)]
 		UIColor UnselectedItemTintColor { get; set; }
 	}
@@ -10539,25 +10708,25 @@ namespace XamCore.UIKit {
 		[Export ("selectedImage", ArgumentSemantic.Retain)][NullAllowed]
 		UIImage SelectedImage { get; set; }
 
-		[iOS (10, 0)]
+		[iOS (10,0), TV (10,0)]
 		[NullAllowed, Export ("badgeColor", ArgumentSemantic.Copy)]
 		UIColor BadgeColor { get; set; }
 
-		[iOS (10,0)]
+		[iOS (10,0), TV (10,0)]
 		[Export ("setBadgeTextAttributes:forState:")]
 		[Internal]
 		void SetBadgeTextAttributes ([NullAllowed] NSDictionary textAttributes, UIControlState state);
 
-		[iOS (10,0)]
+		[iOS (10,0), TV (10,0)]
 		[Wrap ("SetBadgeTextAttributes (textAttributes == null ? null : textAttributes.Dictionary, state)")]
 		void SetBadgeTextAttributes (UIStringAttributes textAttributes, UIControlState state);
 
-		[iOS (10,0)]
+		[iOS (10,0), TV (10,0)]
 		[Export ("badgeTextAttributesForState:")]
 		[Internal]
 		NSDictionary<NSString, NSObject> _GetBadgeTextAttributes (UIControlState state);
 
-		[iOS (10,0)]
+		[iOS (10,0), TV (10,0)]
 		[Wrap ("new UIStringAttributes (_GetBadgeTextAttributes(state))")]
 		UIStringAttributes GetBadgeTextAttributes (UIControlState state);
 	}
@@ -10849,7 +11018,7 @@ namespace XamCore.UIKit {
 		[Export ("remembersLastFocusedIndexPath")]
 		bool RemembersLastFocusedIndexPath { get; set; }
 
-		[iOS (10, 0)]
+		[iOS (10,0), TV (10,0)]
 		[NullAllowed, Export ("prefetchDataSource", ArgumentSemantic.Weak)]
 		IUITableViewDataSourcePrefetching PrefetchDataSource { get; set; }
 		
@@ -10966,7 +11135,7 @@ namespace XamCore.UIKit {
 		
 		[NoTV]
 		[Export ("tableView:didEndEditingRowAtIndexPath:")]
-		void DidEndEditing (UITableView tableView, NSIndexPath indexPath);
+		void DidEndEditing (UITableView tableView, [NullAllowed] NSIndexPath indexPath);
 		
 		[Export ("tableView:targetIndexPathForMoveFromRowAtIndexPath:toProposedIndexPath:")]
 		NSIndexPath CustomizeMoveTarget (UITableView tableView, NSIndexPath sourceIndexPath, NSIndexPath proposedIndexPath);
@@ -11434,7 +11603,7 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof (UIControl), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UITextFieldDelegate)})]
-	public interface UITextField : UITextInput {
+	public interface UITextField : UITextInput, UIContentSizeCategoryAdjusting {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -11546,6 +11715,10 @@ namespace XamCore.UIKit {
 		[Notification]
 		NSString TextFieldTextDidChangeNotification { get; }
 
+		[iOS (10,0), TV (10,0)]
+		[Field ("UITextFieldDidEndEditingReasonKey")]
+		NSString DidEndEditingReasonKey { get; }
+
 		//
 		// 6.0
 		//
@@ -11594,6 +11767,10 @@ namespace XamCore.UIKit {
 		
 		[Export ("textFieldDidEndEditing:"), EventArgs ("UITextField"), EventName ("Ended")]
 		void EditingEnded (UITextField textField);
+
+		[iOS (10, 0)] //HACK: We have a generator bug(?) that won't allow overloads (AmbiguousMatchException) in protocols this is the why of Foo2 naming below
+		[Export ("textFieldDidEndEditing:reason:"), EventArgs ("UITextFieldEditingEnded"), EventName ("Ended2")]
+		void EditingEnded2 (UITextField textField, UITextFieldDidEndEditingReason reason);
 		
 		[Export ("textFieldShouldClear:"), DelegateName ("UITextFieldCondition"), DefaultValue ("true")]
 		bool ShouldClear (UITextField textField);
@@ -11606,7 +11783,7 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof (UIScrollView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UITextViewDelegate)})]
-	public interface UITextView : UITextInput, NSCoding {
+	public interface UITextView : UITextInput, NSCoding, UIContentSizeCategoryAdjusting {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -11751,13 +11928,23 @@ namespace XamCore.UIKit {
 		void SelectionChanged (UITextView textView);
 
 		[Since (7,0)]
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use ShouldInteractWithUrl2 instead")]
 		[Export ("textView:shouldInteractWithURL:inRange:"), DelegateName ("Func<UITextView,NSUrl,NSRange,bool>"), DefaultValue ("true")]
 		bool ShouldInteractWithUrl (UITextView textView, NSUrl URL, NSRange characterRange);
 
 		[Since (7,0)]
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use ShouldInteractWithTextAttachment2 instead")]
 		[Export ("textView:shouldInteractWithTextAttachment:inRange:"), DelegateName ("Func<UITextView,NSTextAttachment,NSRange,bool>"), DefaultValue ("true")]
 		bool ShouldInteractWithTextAttachment (UITextView textView, NSTextAttachment textAttachment, NSRange characterRange);
-		
+
+		//HACK: We have a generator bug(?) that won't allow overloads (AmbiguousMatchException) in protocols this is the why of Foo2 naming bellow, Need to investigate more
+		[iOS (10,0)]
+		[Export ("textView:shouldInteractWithURL:inRange:interaction:"), DelegateName ("UITextViewDelegateShouldInteractUrlDelegate"), DefaultValue ("true")]
+		bool ShouldInteractWithUrl2 (UITextView textView, NSUrl url, NSRange characterRange, UITextItemInteraction interaction);
+
+		[iOS (10,0)]
+		[Export ("textView:shouldInteractWithTextAttachment:inRange:interaction:"), DelegateName ("UITextViewDelegateShouldInteractTextDelegate"), DefaultValue ("true")]
+		bool ShouldInteractWithTextAttachment2 (UITextView textView, NSTextAttachment textAttachment, NSRange characterRange, UITextItemInteraction interaction);
 	}
 	
 	[NoTV]
@@ -11806,7 +11993,7 @@ namespace XamCore.UIKit {
 		UIColor BarTintColor { get; set; }
 
 		[Since (7,0)]
-		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
+		[Export ("delegate", ArgumentSemantic.Weak), NullAllowed]
 		NSObject WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
@@ -11815,9 +12002,10 @@ namespace XamCore.UIKit {
 	}
 
 	public interface IUITimingCurveProvider {}
+
+	[iOS (10,0)]
 	[Protocol]
-	interface UITimingCurveProvider : NSCoding, NSCopying
-	{
+	interface UITimingCurveProvider : NSCoding, NSCopying {
 		[Abstract]
 		[Export ("timingCurveType")]
 		UITimingCurveType TimingCurveType { get; }
@@ -11970,7 +12158,7 @@ namespace XamCore.UIKit {
 	}
 		
 	[BaseType (typeof (UIResponder))]
-	public interface UIView : UIAppearance, UIAppearanceContainer, UIAccessibility, UIDynamicItem, NSCoding, UIAccessibilityIdentification, UITraitEnvironment, UICoordinateSpace, UIFocusEnvironment {
+	public interface UIView : UIAppearance, UIAppearanceContainer, UIAccessibility, UIDynamicItem, NSCoding, UIAccessibilityIdentification, UITraitEnvironment, UICoordinateSpace, UIFocusItem, CALayerDelegate {
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
@@ -12510,6 +12698,7 @@ namespace XamCore.UIKit {
 
 		[Since (7,0)]
 		[Export ("resizableSnapshotViewFromRect:afterScreenUpdates:withCapInsets:")]
+		[return: NullAllowed]
 		UIView ResizableSnapshotView (CGRect rect, bool afterScreenUpdates, UIEdgeInsets capInsets);
 
 		[Since (7,0)]
@@ -12549,6 +12738,15 @@ namespace XamCore.UIKit {
 		[Static]
 		[Export ("userInterfaceLayoutDirectionForSemanticContentAttribute:")]
 		UIUserInterfaceLayoutDirection GetUserInterfaceLayoutDirection (UISemanticContentAttribute attribute);
+
+		[iOS (10,0), TV (10,0)]
+		[Static]
+		[Export ("userInterfaceLayoutDirectionForSemanticContentAttribute:relativeToLayoutDirection:")]
+		UIUserInterfaceLayoutDirection GetUserInterfaceLayoutDirection (UISemanticContentAttribute semanticContentAttribute, UIUserInterfaceLayoutDirection layoutDirection);
+
+		[iOS (10,0), TV (10,0)]
+		[Export ("effectiveUserInterfaceLayoutDirection")]
+		UIUserInterfaceLayoutDirection EffectiveUserInterfaceLayoutDirection { get; }
 
 		[iOS (9,0)]
 		[Export ("semanticContentAttribute", ArgumentSemantic.Assign)]
@@ -12635,13 +12833,25 @@ namespace XamCore.UIKit {
 
 		[iOS (9,0)] // added in Xcode 7.1 / iOS 9.1 SDK
 		[Export ("canBecomeFocused")]
-		bool CanBecomeFocused { get; }
+		new bool CanBecomeFocused { get; }
 	}
 
 	[Category, BaseType (typeof (UIView))]
 	public interface UIView_UITextField {
 		[Export ("endEditing:")]
 		bool EndEditing (bool force);
+	}
+
+	[iOS (10,0), TV (10,0)]
+	[Category]
+	[BaseType (typeof (UILayoutGuide))]
+	interface UILayoutGuide_UIConstraintBasedLayoutDebugging {
+
+		[Export ("constraintsAffectingLayoutForAxis:")]
+		NSLayoutConstraint [] GetConstraintsAffectingLayout (UILayoutConstraintAxis axis);
+
+		[Export ("hasAmbiguousLayout")]
+		bool GetHasAmbiguousLayout ();
 	}
 
 	public interface IUIContentContainer {}
@@ -12851,7 +13061,7 @@ namespace XamCore.UIKit {
 		[Export ("modalInPopover")]
 		bool ModalInPopover { [Bind ("isModalInPopover")] get; set; }
 
-		[Since (4,3)]
+		[Since (4,3)] // It seems apple added a setter now but seems it is a mistake on new property radar:27929872
 		[Export ("disablesAutomaticKeyboardDismissal")]
 		bool DisablesAutomaticKeyboardDismissal { get; }
 
@@ -13196,7 +13406,7 @@ namespace XamCore.UIKit {
 		[Field ("UIViewControllerHierarchyInconsistencyException")]
 		NSString HierarchyInconsistencyException { get; }
 
-		[iOS (10, 0)]
+		[iOS (10,0), TV (10,0)]
 		[Export ("restoresFocusAfterTransition")]
 		bool RestoresFocusAfterTransition { get; set; }
 	}
@@ -13263,6 +13473,14 @@ namespace XamCore.UIKit {
 #endif
 		[Export ("targetTransform")]
 		CGAffineTransform TargetTransform { get; }
+
+
+#if XAMCORE_4_0 // Can't break the world right now
+		[Abstract]
+#endif
+		[iOS (10,0), TV (10,0)]
+		[Export ("pauseInteractiveTransition")]
+		void PauseInteractiveTransition ();
 	}
 
 	public interface IUIViewControllerContextTransitioning {
@@ -13295,6 +13513,10 @@ namespace XamCore.UIKit {
 		[Export ("userInterfaceIdiom")]
 		UIUserInterfaceIdiom UserInterfaceIdiom { get; }
 
+		[TV (10, 0), NoWatch, NoiOS]
+		[Export ("userInterfaceStyle")]
+		UIUserInterfaceStyle UserInterfaceStyle { get; }
+
 		[Export ("displayScale")]
 		nfloat DisplayScale { get; }
 
@@ -13326,17 +13548,22 @@ namespace XamCore.UIKit {
 		[Static, Export ("traitCollectionWithForceTouchCapability:")]
 		UITraitCollection FromForceTouchCapability (UIForceTouchCapability capability);
 
-		[iOS (10,0)]
+		[TV (10, 0), NoWatch, NoiOS]
+		[Static]
+		[Export ("traitCollectionWithUserInterfaceStyle:")]
+		UITraitCollection FromUserInterfaceStyle (UIUserInterfaceStyle userInterfaceStyle);
+
+		[iOS (10,0), TV (10,0)]
 		[Static]
 		[Export ("traitCollectionWithDisplayGamut:")]
 		UITraitCollection FromDisplayGamut (UIDisplayGamut displayGamut);
 		
-		[iOS (10,0)]
+		[iOS (10,0), TV (10,0)]
 		[Static]
 		[Export ("traitCollectionWithLayoutDirection:")]
 		UITraitCollection FromLayoutDirection (UITraitEnvironmentLayoutDirection layoutDirection);
 
-		[iOS (10,0)]
+		[iOS (10,0), TV (10,0)]
 		[Static]
 		[Export ("traitCollectionWithPreferredContentSizeCategory:")]
 		[Internal]
@@ -13346,15 +13573,15 @@ namespace XamCore.UIKit {
 		[Export ("forceTouchCapability")]
 		UIForceTouchCapability ForceTouchCapability { get; }
 
-		[iOS (10, 0)]
+		[iOS (10,0), TV (10,0)]
 		[Export ("displayGamut")]
 		UIDisplayGamut DisplayGamut { get; }
 
-		[iOS (10, 0)]
+		[iOS (10,0), TV (10,0)]
 		[Export ("preferredContentSizeCategory")]
 		string PreferredContentSizeCategory { get; }
 
-		[iOS (10, 0)]
+		[iOS (10,0), TV (10,0)]
 		[Export ("layoutDirection")]
 		UITraitEnvironmentLayoutDirection LayoutDirection { get; }
 	}
@@ -13389,6 +13616,10 @@ namespace XamCore.UIKit {
 		[Export ("animateTransition:")]
 		void AnimateTransition (IUIViewControllerContextTransitioning transitionContext);
 		
+		[iOS (10, 0)]
+		[Export ("interruptibleAnimatorForTransition:")]
+		IUIViewImplicitlyAnimating GetInterruptibleAnimator (IUIViewControllerContextTransitioning transitionContext);
+
 		[Export ("animationEnded:")]
 		void AnimationEnded (bool transitionCompleted);
 	}
@@ -13407,6 +13638,10 @@ namespace XamCore.UIKit {
 	
 		[Export ("completionCurve")]
 		UIViewAnimationCurve CompletionCurve { get; }
+
+		[iOS (10,0), TV (10,0)]
+		[Export ("wantsInteractiveStart")]
+		bool WantsInteractiveStart { get; }
 	}
 	public interface IUIViewControllerInteractiveTransitioning {}
 			
@@ -13431,7 +13666,7 @@ namespace XamCore.UIKit {
 
 		[iOS (8,0)]
 		[Export ("presentationControllerForPresentedViewController:presentingViewController:sourceViewController:")]
-		UIPresentationController GetPresentationControllerForPresentedViewController (UIViewController presentedViewController, UIViewController presentingViewController, UIViewController sourceViewController);
+		UIPresentationController GetPresentationControllerForPresentedViewController (UIViewController presentedViewController, [NullAllowed] UIViewController presentingViewController, UIViewController sourceViewController);
 	}
 	
 	[Since (7,0)]
@@ -13448,6 +13683,20 @@ namespace XamCore.UIKit {
 	
 		[Export ("completionCurve", ArgumentSemantic.Assign)]
 		new UIViewAnimationCurve CompletionCurve { get; set; }
+
+		[iOS (10,0), TV (10,0)]
+		[NullAllowed, Export ("timingCurve", ArgumentSemantic.Strong)]
+		IUITimingCurveProvider TimingCurve { get; set; }
+
+		// getter comes from UIViewControllerInteractiveTransitioning but
+		// headers declares a setter here
+		[iOS (10,0), TV (10,0)]
+		[Export ("wantsInteractiveStart")]
+		new bool WantsInteractiveStart { get; set; }
+
+		[iOS (10,0), TV (10,0)]
+		[Export ("pauseInteractiveTransition")]
+		void PauseInteractiveTransition ();
 	
 		[Export ("updateInteractiveTransition:")]
 		void UpdateInteractiveTransition (nfloat percentComplete);
@@ -13525,6 +13774,12 @@ namespace XamCore.UIKit {
 		[EditorBrowsable (EditorBrowsableState.Advanced)] // this is not the one we want to be seen (compat only)
 		UIView GetTransitionViewControllerForKey (NSString key);
 
+#if XAMCORE_4_0 // This is abstract in headers but is a breaking change
+		[Abstract]
+#endif
+		[iOS (10, 0)]
+		[Export ("isInterruptible")]
+		bool IsInterruptible { get; }
 	}
 	public interface IUIViewControllerTransitionCoordinatorContext {}
 
@@ -13545,8 +13800,16 @@ namespace XamCore.UIKit {
 		bool AnimateAlongsideTransitionInView (UIView view, Action<IUIViewControllerTransitionCoordinatorContext> animation, [NullAllowed] Action<IUIViewControllerTransitionCoordinatorContext> completion);
 	
 		[Abstract]
+		[Deprecated (PlatformName.iOS, 10, 0, message:"use NotifyWhenInteractionChanges instead")]
 		[Export ("notifyWhenInteractionEndsUsingBlock:")]
 		void NotifyWhenInteractionEndsUsingBlock (Action<IUIViewControllerTransitionCoordinatorContext> handler);
+
+#if XAMCORE_4_0 // This is abstract in headers but is a breaking change
+		[Abstract]
+#endif
+		[iOS (10,0)]
+		[Export ("notifyWhenInteractionChangesUsingBlock:")]
+		void NotifyWhenInteractionChanges (Action<IUIViewControllerTransitionCoordinatorContext> handler);
 	}
 	public interface IUIViewControllerTransitionCoordinator {}
 
@@ -13719,76 +13982,76 @@ namespace XamCore.UIKit {
 	}
 
 	[Static]
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	interface UITextContentType {
 		[Field ("UITextContentTypeName")]
-		NSString Name { get; } 
+		NSString Name { get; }
 
 		[Field ("UITextContentTypeNamePrefix")]
-                NSString NamePrefix { get; } 
+		NSString NamePrefix { get; }
 
 		[Field ("UITextContentTypeGivenName")]
-		NSString GivenName { get; } 
+		NSString GivenName { get; }
 
 		[Field ("UITextContentTypeMiddleName")]
-                NSString MiddleName { get; } 
+		NSString MiddleName { get; }
 
 		[Field ("UITextContentTypeFamilyName")]
-                NSString FamilyName { get; } 
+		NSString FamilyName { get; }
 
 		[Field ("UITextContentTypeNameSuffix")]
-                NSString NameSuffix { get; } 
+		NSString NameSuffix { get; }
 
 		[Field ("UITextContentTypeNickname")]
-		NSString Nickname { get; } 
+		NSString Nickname { get; }
 
 		[Field ("UITextContentTypeJobTitle")]
-		NSString JobTitle { get; } 
+		NSString JobTitle { get; }
 
 		[Field ("UITextContentTypeOrganizationName")]
-		NSString OrganizationName { get; } 
+		NSString OrganizationName { get; }
 
 		[Field ("UITextContentTypeLocation")]
-		NSString Location { get; } 
+		NSString Location { get; }
 
 		[Field ("UITextContentTypeFullStreetAddress")]
-		NSString FullStreetAddress { get; } 
+		NSString FullStreetAddress { get; }
 
 		[Field ("UITextContentTypeStreetAddressLine1")]
-		NSString StreetAddressLine1 { get; } 
+		NSString StreetAddressLine1 { get; }
 
 		[Field ("UITextContentTypeStreetAddressLine2")]
-		NSString StreetAddressLine2 { get; } 
+		NSString StreetAddressLine2 { get; }
 
 		[Field ("UITextContentTypeAddressCity")]
-		NSString AddressCity { get; } 
+		NSString AddressCity { get; }
 
 		[Field ("UITextContentTypeAddressState")]
-		NSString AddressState { get; } 
+		NSString AddressState { get; }
 
 		[Field ("UITextContentTypeAddressCityAndState")]
-		NSString AddressCityAndState { get; } 
+		NSString AddressCityAndState { get; }
 
 		[Field ("UITextContentTypeSublocality")]
-		NSString Sublocality { get; } 
+		NSString Sublocality { get; }
 
 		[Field ("UITextContentTypeCountryName")]
-		NSString CountryName { get; } 
+		NSString CountryName { get; }
 
 		[Field ("UITextContentTypePostalCode")]
-                NSString PostalCode { get; } 
+		NSString PostalCode { get; }
 
 		[Field ("UITextContentTypeTelephoneNumber")]
-		NSString TelephoneNumber { get; } 
+		NSString TelephoneNumber { get; }
 
 		[Field ("UITextContentTypeEmailAddress")]
-		NSString EmailAddress { get; } 
+		NSString EmailAddress { get; }
 
 		[Field ("UITextContentTypeURL")]
-		NSString Url { get; } 
+		NSString Url { get; }
 
 		[Field ("UITextContentTypeCreditCardNumber")]
-		NSString CreditCardNumber { get; } 
+		NSString CreditCardNumber { get; }
 	}
 	
 	[Since (3,2)]
@@ -14523,6 +14786,9 @@ namespace XamCore.UIKit {
 #endif
 		nfloat CutLengthForPaper (UIPrintInteractionController printInteractionController, UIPrintPaper paper);
 
+		[iOS (9, 0)]
+		[Export ("printInteractionController:chooseCutterBehavior:"), DefaultValue ("UIPrinterCutterBehavior.NoCut"), DelegateName ("UIPrintInteractionCutterBehavior")]
+		UIPrinterCutterBehavior ChooseCutterBehavior (UIPrintInteractionController printInteractionController, NSNumber [] availableBehaviors);
 	}
 
 	[NoTV]
@@ -14556,6 +14822,7 @@ namespace XamCore.UIKit {
 		[Export ("printPaper")]
 		UIPrintPaper PrintPaper { get; }
 
+		[Deprecated (PlatformName.iOS, 10, 0, message:"Page range is always shown")]
 		[Export ("showsPageRange")]
 		bool ShowsPageRange { get; set; }
 
@@ -14734,6 +15001,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	public interface UIPrintFormatter : NSCopying {
 
+		[Deprecated (PlatformName.iOS, 10, 0, message:"Use PerPageContentInsets instead")]
 		[Export ("contentInsets")]
 		UIEdgeInsets ContentInsets { get; set; }
 
@@ -14818,7 +15086,7 @@ namespace XamCore.UIKit {
 		UIMotionEffect [] MotionEffects { get; set; }
 	}
 
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof(NSObject))]
 	interface UISpringTimingParameters : UITimingCurveProvider
 	{
@@ -15014,7 +15282,7 @@ namespace XamCore.UIKit {
 		[Export ("primaryLanguage")]
 		string PrimaryLanguage { get; set; }
 
-		[iOS (10,0)]
+		[iOS (10,0), TV (10,0)]
 		[Export ("handleInputModeListFromView:withEvent:")]
 		void HandleInputModeList (UIView fromView, UIEvent withEvent);
 	}
@@ -15038,7 +15306,9 @@ namespace XamCore.UIKit {
 
 		// Another abstract that was introduced on this released, breaking ABI
 		// Radar: 26867207
-		//[Abstract]
+#if XAMCORE_4_0
+		[Abstract]
+#endif
 		[iOS (10, 0)]
 		[NullAllowed, Export ("documentInputMode")]
 		UITextInputMode DocumentInputMode { get; }
@@ -15165,6 +15435,7 @@ namespace XamCore.UIKit {
 	[NoWatch]
 	[NoTV]
 	[iOS (8,0)]
+	[Deprecated (PlatformName.iOS, 10, 0, message: "Soft deprecated in iOS 10, use UserNotifications.UNNotificationCategory")]
 	[BaseType (typeof (NSObject))]
 	public partial interface UIUserNotificationCategory : NSCopying, NSMutableCopying, NSSecureCoding {
 
@@ -15175,7 +15446,7 @@ namespace XamCore.UIKit {
 		UIUserNotificationAction [] GetActionsForContext (UIUserNotificationActionContext context);
 	}
 
-	[Deprecated (PlatformName.iOS, 10, 0, message: "Soft deprecated in iOS 10, use UserNotifications.UNNotificationAction or UserNotifications.UNTextInputNotificationAction")]
+	[Deprecated (PlatformName.iOS, 10, 0, message: "Soft deprecated in iOS 10, use UserNotifications.UNNotificationCategory")]
 	[NoWatch]
 	[NoTV]
 	[iOS (8,0)]
@@ -15190,7 +15461,7 @@ namespace XamCore.UIKit {
 		void SetActions (UIUserNotificationAction [] actions, UIUserNotificationActionContext context);
 	}
 
-	[Deprecated (PlatformName.iOS, 10, 0, message: "Soft deprecated in iOS 10, use UserNotifications.UNNotificationAction or UserNotifications.UNTextInputNotificationAction")]
+	[Deprecated (PlatformName.iOS, 10, 0, message: "Soft deprecated in iOS 10, use UserNotifications.UNNotificationAction")]
 	[NoWatch]
 	[NoTV]
 	[iOS (8,0)]
@@ -15221,11 +15492,13 @@ namespace XamCore.UIKit {
 		UIUserNotificationActionBehavior Behavior { get; [NotImplemented] set;}
 
 		[iOS (9,0)]
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNTextInputNotificationAction.TextInputButtonTitle instead")]
 		[Field ("UIUserNotificationTextInputActionButtonTitleKey")]
 		NSString TextInputActionButtonTitleKey { get; }
 
 		// note: defined twice, where watchOS is defined it says it's not in iOS, the other one (for iOS 9) says it's not in tvOS
 		[iOS (9,0)]
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Use UNTextInputNotificationResponse.UserText instead")]
 		[Field ("UIUserNotificationActionResponseTypedTextKey")]
 		NSString ResponseTypedTextKey { get; }
 	}
@@ -15240,7 +15513,7 @@ namespace XamCore.UIKit {
 	}
 #endif
 
-	[Deprecated (PlatformName.iOS, 10, 0, message: "Soft deprecated in iOS 10, use UserNotifications.UNNotificationAction or UserNotifications.UNTextInputNotificationAction")]
+	[Deprecated (PlatformName.iOS, 10, 0, message: "Soft deprecated in iOS 10, use UserNotifications.UNNotificationAction")]
 	[NoWatch]
 	[NoTV]
 	[iOS (8,0)]
@@ -15459,7 +15732,7 @@ namespace XamCore.UIKit {
 		NSIndexPath NextFocusedIndexPath { [return: NullAllowed] get; }
 	}
 
-	[iOS (10,0)]
+	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof(NSObject))]
 	interface UICubicTimingParameters : UITimingCurveProvider
 	{
@@ -15500,8 +15773,8 @@ namespace XamCore.UIKit {
 		[NullAllowed, Export ("preferredFocusedView", ArgumentSemantic.Weak)]
 		UIView PreferredFocusedView { get; set; }
 
-		[iOS (10, 0)]
-		[Export ("preferredFocusEnvironments", ArgumentSemantic.Copy)]
+		[iOS (10,0), TV (10,0)]
+		[Export ("preferredFocusEnvironments", ArgumentSemantic.Copy), NullAllowed] // null_resettable
 		IUIFocusEnvironment[] PreferredFocusEnvironments { get; set; }
 	}
 
@@ -15528,11 +15801,11 @@ namespace XamCore.UIKit {
 		[Export ("focusHeading", ArgumentSemantic.Assign)]
 		UIFocusHeading FocusHeading { get; }
 
-		[iOS (10, 0)]
+		[iOS (10,0), TV (10,0)]
 		[NullAllowed, Export ("previouslyFocusedItem", ArgumentSemantic.Weak)]
 		IUIFocusItem PreviouslyFocusedItem { get; }
 
-		[iOS (10, 0)]
+		[iOS (10,0), TV (10,0)]
 		[NullAllowed, Export ("nextFocusedItem", ArgumentSemantic.Weak)]
 		IUIFocusItem NextFocusedItem { get; }
 	}
@@ -15666,9 +15939,12 @@ namespace XamCore.UIKit {
 		// FIXME: declared as a @required, but this breaks compatibility
 		// Radar: 26825293
 		//
+#if XAMCORE_4_0
+		[Abstract]
+#endif
 		[iOS (10, 0)]
 		[Export ("preferredFocusEnvironments", ArgumentSemantic.Copy)]
-		IUIFocusEnvironment[] PreferredFocusEnvironments { get; set; }
+		IUIFocusEnvironment[] PreferredFocusEnvironments { get; }
 		
 	}
 #endif // !WATCH

--- a/tests/introspection/iOS/iOSApiProtocolTest.cs
+++ b/tests/introspection/iOS/iOSApiProtocolTest.cs
@@ -410,6 +410,125 @@ namespace Introspection {
 					return !TestRuntime.CheckXcodeVersion (8,0);
 				}
 				break;
+
+			case "CALayerDelegate": // UIView now conforms to CALayerDelegate in iOS 10
+				switch (type.Name) {
+				case "UISearchBar":
+				case "UISegmentedControl":
+				case "UITableView":
+				case "UITableViewCell":
+				case "UITextField":
+				case "UITextView":
+				case "UIToolbar":
+				case "UIView":
+				case "MKPinAnnotationView":
+				case "UIImageView":
+				case "PHLivePhotoView":
+				case "UIInputView":
+				case "UILabel":
+				case "UIActionSheet":
+				case "UIButton":
+				case "UICollectionView":
+				case "UINavigationBar":
+				case "UIControl":
+				case "UIPickerView":
+				case "UIPageControl":
+				case "MPVolumeView":
+				case "UIPopoverBackgroundView":
+				case "UIProgressView":
+				case "UIRefreshControl":
+				case "HKActivityRingView":
+				case "UIScrollView":
+				case "CAInterAppAudioSwitcherView":
+				case "CAInterAppAudioTransportView":
+				case "UISlider":
+				case "UIStackView":
+				case "SCNView":
+				case "UIStepper":
+				case "UISwitch":
+				case "UITabBar":
+				case "UITableViewHeaderFooterView":
+				case "GLKView":
+				case "SKView":
+				case "MKMapView":
+				case "MKAnnotationView":
+				case "PKAddPassButton":
+				case "PKPaymentButton":
+				case "UIActivityIndicatorView":
+				case "UICollectionReusableView":
+				case "UIWebView":
+				case "UICollectionViewCell":
+				case "UIWindow":
+				case "UIDatePicker":
+				case "UIVisualEffectView":
+				case "WKWebView":
+				case "ADBannerView":
+					return !TestRuntime.CheckXcodeVersion (8, 0);
+				}
+				break;
+
+			case "UIFocusItem": // UIView now conforms to UIFocusItem in iOS 10
+				switch (type.Name) {
+				case "UIButton":
+				case "UICollectionReusableView":
+				case "UICollectionView":
+				case "UICollectionViewCell":
+				case "MKAnnotationView":
+				case "UIControl":
+				case "MKMapView":
+				case "UISearchBar":
+				case "UISegmentedControl":
+				case "UITableView":
+				case "UITableViewCell":
+				case "UITextField":
+				case "UITextView":
+				case "MKPinAnnotationView":
+				case "UIView":
+				case "SKNode":
+				case "SKShapeNode":
+				case "SKVideoNode":
+				case "UIImageView":
+				case "UIInputView":
+				case "UILabel":
+				case "UINavigationBar":
+				case "UIPageControl":
+				case "UIPopoverBackgroundView":
+				case "UIProgressView":
+				case "SCNView":
+				case "UIScrollView":
+				case "SK3DNode":
+				case "MTKView":
+				case "SKAudioNode":
+				case "SKCameraNode":
+				case "SKCropNode":
+				case "SKEffectNode":
+				case "SKEmitterNode":
+				case "SKFieldNode":
+				case "SKLabelNode":
+				case "SKLightNode":
+				case "UIStackView":
+				case "UITabBar":
+				case "SKReferenceNode":
+				case "GLKView":
+				case "SKScene":
+				case "SKSpriteNode":
+				case "SKView":
+				case "UITableViewHeaderFooterView":
+				case "UIActivityIndicatorView":
+				case "UIVisualEffectView":
+				case "UIWindow":
+					return !TestRuntime.CheckXcodeVersion (8, 0);
+				}
+				break;
+
+			case "UIContentSizeCategoryAdjusting": // new conformations of UIContentSizeCategoryAdjusting in iOS 10
+				switch (type.Name) {
+				case "UITextField":
+				case "UITextView":
+				case "UILabel":
+					return !TestRuntime.CheckXcodeVersion (8, 0);
+				}
+				break;
 			}
 			return base.Skip (type, protocolName);
 		}

--- a/tests/xtro-sharpie/ios.pending
+++ b/tests/xtro-sharpie/ios.pending
@@ -161,3 +161,52 @@
 !missing-selector! INRideDriver::initWithHandle:nameComponents:image:rating:phoneNumber: not bound
 !missing-selector! INRideOption::identifier not bound
 !missing-selector! INRideOption::setIdentifier: not bound
+
+# UIKit
+
+## HACK: those members are not *required* in ObjC but we made them
+## abstract to have them inlined in UITextField and UITextView
+## Even more confusing it that respondToSelecttor return NO on them
+## even if it works in _real_ life (compare unit and introspection tests)
+!incorrect-protocol-member! UITextInputTraits::autocapitalizationType is OPTIONAL and should NOT be abstract
+!incorrect-protocol-member! UITextInputTraits::autocorrectionType is OPTIONAL and should NOT be abstract
+!incorrect-protocol-member! UITextInputTraits::enablesReturnKeyAutomatically is OPTIONAL and should NOT be abstract
+!incorrect-protocol-member! UITextInputTraits::isSecureTextEntry is OPTIONAL and should NOT be abstract
+!incorrect-protocol-member! UITextInputTraits::keyboardAppearance is OPTIONAL and should NOT be abstract
+!incorrect-protocol-member! UITextInputTraits::keyboardType is OPTIONAL and should NOT be abstract
+!incorrect-protocol-member! UITextInputTraits::returnKeyType is OPTIONAL and should NOT be abstract
+!incorrect-protocol-member! UITextInputTraits::spellCheckingType is OPTIONAL and should NOT be abstract
+
+## it's technically optional but there's no point in adopting the protocol if you do not provide the implemenation
+## We should review the above ^ if we want to keep this when XAMCORE_4_0 becomes a thing
+!incorrect-protocol-member! UIInputViewAudioFeedback::enableInputClicksWhenVisible is OPTIONAL and should NOT be abstract
+
+## Obsoleted selectors in very early versions of iOS (3.0) and removed in XAMCORE_3_0
+!extra-protocol-member! unexpected selector UIImagePickerControllerDelegate::imagePickerController:didFinishPickingImage:editingInfo: found
+!extra-protocol-member! unexpected selector UITableViewDelegate::tableView:accessoryTypeForRowWithIndexPath: found
+
+## Special case from UIAccessibilityAction. We added it (completly) on UIResponser but magic tap is also available on app delegate according to docs
+## See comments is uikit.cs for more info
+!extra-protocol-member! unexpected selector UIApplicationDelegate::accessibilityPerformMagicTap found
+
+## Protocol Inlined Maybe we want to change this in XAMCORE_4_0 since this predates our Category support
+!missing-protocol! UIResponderStandardEditActions not bound
+!missing-protocol-conformance! UIResponder should conform to UIResponderStandardEditActions
+
+## @required members added to exixting interfaces (breaking change), fixed on XAMCORE_4_0
+!incorrect-protocol-member! UIViewControllerContextTransitioning::pauseInteractiveTransition is REQUIRED and should be abstract
+!incorrect-protocol-member! UIViewControllerTransitionCoordinator::notifyWhenInteractionChangesUsingBlock: is REQUIRED and should be abstract
+!incorrect-protocol-member! UIViewControllerTransitionCoordinatorContext::isInterruptible is REQUIRED and should be abstract
+!incorrect-protocol-member! UIFocusEnvironment::preferredFocusEnvironments is REQUIRED and should be abstract
+!incorrect-protocol-member! UITextDocumentProxy::documentInputMode is REQUIRED and should be abstract
+!incorrect-protocol-member! UILayoutSupport::bottomAnchor is REQUIRED and should be abstract
+!incorrect-protocol-member! UILayoutSupport::heightAnchor is REQUIRED and should be abstract
+!incorrect-protocol-member! UILayoutSupport::topAnchor is REQUIRED and should be abstract
+
+## Not bound intentionally, Factory method FromDisplayP3 is available and adding this as a ctor would make the api usage ugly since signature matches colorWithRed:green:blue:alpha:
+!missing-selector! UIColor::initWithDisplayP3Red:green:blue:alpha: not bound
+
+## It seems that Apple added a setter but it seems it is a mistake on the newly added property radar:27929872
+!missing-selector! UIViewController::setDisablesAutomaticKeyboardDismissal: not bound
+
+

--- a/tests/xtro-sharpie/tvos.pending
+++ b/tests/xtro-sharpie/tvos.pending
@@ -145,3 +145,21 @@
 !incorrect-protocol-member! UITextInputTraits::keyboardType is OPTIONAL and should NOT be abstract
 !incorrect-protocol-member! UITextInputTraits::returnKeyType is OPTIONAL and should NOT be abstract
 !incorrect-protocol-member! UITextInputTraits::spellCheckingType is OPTIONAL and should NOT be abstract
+
+## Headers says it is available but none of its members or implementor class are available
+!missing-protocol! UIPreviewInteractionDelegate not bound
+
+## Header says they are available in tvOS but intro says nope nope nope radar:27929711
+## Undefined _OBJC_CLASS_$_UICloudSharingController
+!missing-protocol! UICloudSharingControllerDelegate not bound
+!missing-type! UICloudSharingController not bound
+!missing-selector! UICloudSharingController::availablePermissions not bound
+!missing-selector! UICloudSharingController::delegate not bound
+!missing-selector! UICloudSharingController::initWithPreparationHandler: not bound
+!missing-selector! UICloudSharingController::initWithShare:container: not bound
+!missing-selector! UICloudSharingController::setAvailablePermissions: not bound
+!missing-selector! UICloudSharingController::setDelegate: not bound
+!missing-selector! UICloudSharingController::share not bound
+
+## It seems that Apple added a setter but it seems it is a mistake on the newly added property radar:27929872
+!missing-selector! UIViewController::setDisablesAutomaticKeyboardDismissal: not bound

--- a/tests/xtro-sharpie/watchos.pending
+++ b/tests/xtro-sharpie/watchos.pending
@@ -117,6 +117,9 @@
 !missing-enum! NSTextAlignment not bound
 !unknown-native-enum! UITextAlignment bound
 
+## Not bound intentionally, Factory method FromDisplayP3 is available and adding this as a ctor would make the api usage ugly since signature matches colorWithRed:green:blue:alpha:
+!missing-selector! UIColor::initWithDisplayP3Red:green:blue:alpha: not bound
+
 
 # others
 


### PR DESCRIPTION
## Expected extrospection test failures:

- ios.unclassified:!missing-field! UIApplicationInvalidInterfaceOrientationException not bound

## Some Generator bugs encountered:

- HACK: We have a generator bug(?) that won't allow overloads (AmbiguousMatchException) in protocols

tvOS/iOS 9 Introspection Expected failures (UIKit Only):

- [FAIL] UIKit.UIContentSizeCategoryExtensions.UIContentSizeCategoryUnspecified

Generated enum extensions do not honor availability on NSString properties

## API Diff, expected changes (verified and correct):

Type Changed: UIKit.UIContentSizeCategory

Modified fields:

	ExtraExtraExtraLarge = 6 7
	ExtraExtraLarge = 5 6
	ExtraLarge = 4 5
	ExtraSmall = 0 1
	Large = 3 4
	Medium = 2 3
	Small = 1 2

Added values:

	AccessibilityExtraExtraExtraLarge = 12,
	AccessibilityExtraExtraLarge = 11,
	AccessibilityExtraLarge = 10,
	AccessibilityLarge = 9,
	AccessibilityMedium = 8,
	Unspecified = 0,