### PR TITLE
[registrar] Teach the dynamic registrar to skip GKBasePlayer before iOS 10. Fixes #43654

### DIFF
--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -775,6 +775,7 @@ namespace XamCore.Registrar {
 						major = 6;
 						break;
 					case "CBManager":
+					case "GKBasePlayer":
 						major = 10;
 						break;
 					}


### PR DESCRIPTION
GKBasePlayer is new in iOS 10 but it's part of an existing hierarchy so
it must be ignore before (iOS 10).

https://bugzilla.xamarin.com/show_bug.cgi?id=43654