### PR TITLE
[Intents] Fixes bug 43205 - SiriKit API Inconsistencies

### DIFF
--- a/src/Intents/INIntentResolutionResult.cs
+++ b/src/Intents/INIntentResolutionResult.cs
@@ -23,5 +23,26 @@ namespace XamCore.Intents {
 		{
 		}
 	}
+
+	public partial class INIntentResolutionResult {
+
+		public static INIntentResolutionResult NeedsValue {
+			get {
+				throw new NotImplementedException ("All subclasses of INIntentResolutionResult must re-implement this property");
+			}
+		}
+
+		public static INIntentResolutionResult NotRequired {
+			get {
+				throw new NotImplementedException ("All subclasses of INIntentResolutionResult must re-implement this property");
+			}
+		}
+
+		public static INIntentResolutionResult Unsupported {
+			get {
+				throw new NotImplementedException ("All subclasses of INIntentResolutionResult must re-implement this property");
+			}
+		}
+	}
 }
 #endif // XAMCORE_2_0

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -897,6 +897,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithValueToConfirm:")]
 		INBooleanResolutionResult GetConfirmationRequired ([NullAllowed] NSNumber valueToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INBooleanResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INBooleanResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INBooleanResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -912,6 +930,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithValueToConfirm:")]
 		INCallRecordTypeResolutionResult GetConfirmationRequired (INCallRecordType valueToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INCallRecordTypeResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INCallRecordTypeResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INCallRecordTypeResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -970,6 +1006,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithValueToConfirm:")]
 		INCarAirCirculationModeResolutionResult GetConfirmationRequired (INCarAirCirculationMode valueToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INCarAirCirculationModeResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INCarAirCirculationModeResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INCarAirCirculationModeResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -985,6 +1039,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithValueToConfirm:")]
 		INCarAudioSourceResolutionResult GetConfirmationRequired (INCarAudioSource valueToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INCarAudioSourceResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INCarAudioSourceResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INCarAudioSourceResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -1000,6 +1072,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithValueToConfirm:")]
 		INCarDefrosterResolutionResult GetConfirmationRequired (INCarDefroster valueToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INCarDefrosterResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INCarDefrosterResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INCarDefrosterResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -1015,6 +1105,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithValueToConfirm:")]
 		INCarSeatResolutionResult GetConfirmationRequired (INCarSeat valueToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INCarSeatResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INCarSeatResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INCarSeatResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -1051,6 +1159,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithCurrencyAmountToConfirm:")]
 		INCurrencyAmountResolutionResult GetConfirmationRequired ([NullAllowed] INCurrencyAmount currencyAmountToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INCurrencyAmountResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INCurrencyAmountResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INCurrencyAmountResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -1087,6 +1213,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithDateComponentsRangeToConfirm:")]
 		INDateComponentsRangeResolutionResult GetConfirmationRequired ([NullAllowed] INDateComponentsRange dateComponentsRangeToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INDateComponentsRangeResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INDateComponentsRangeResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INDateComponentsRangeResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -1150,6 +1294,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithValueToConfirm:")]
 		INDoubleResolutionResult GetConfirmationRequired ([NullAllowed] NSNumber valueToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INDoubleResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INDoubleResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INDoubleResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -1169,6 +1331,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithDateComponentsToConfirm:")]
 		INDateComponentsResolutionResult GetConfirmationRequired ([NullAllowed] NSDateComponents componentsToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INDateComponentsResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INDateComponentsResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INDateComponentsResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -1531,6 +1711,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithValueToConfirm:")]
 		INIntegerResolutionResult GetConfirmationRequired ([NullAllowed] NSNumber valueToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INIntegerResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INIntegerResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INIntegerResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -1550,21 +1748,25 @@ namespace XamCore.Intents {
 
 	[Introduced (PlatformName.iOS, 10, 0)]
 	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
+	[Abstract]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface INIntentResolutionResult {
 
-		[Static]
-		[Export ("needsValue")]
-		INIntentResolutionResult NeedsValue { get; }
+		// Needs to be overriden in subclasses
+		// we provide a basic, managed, implementation that throws
 
-		[Static]
-		[Export ("notRequired")]
-		INIntentResolutionResult NotRequired { get; }
+		//[Static]
+		//[Export ("needsValue")]
+		//INIntentResolutionResult NeedsValue { get; }
 
-		[Static]
-		[Export ("unsupported")]
-		INIntentResolutionResult Unsupported { get; }
+		//[Static]
+		//[Export ("notRequired")]
+		//INIntentResolutionResult NotRequired { get; }
+
+		//[Static]
+		//[Export ("unsupported")]
+		//INIntentResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -1724,6 +1926,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithValueToConfirm:")]
 		INMessageAttributeOptionsResolutionResult GetConfirmationRequired (INMessageAttributeOptions valueToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INMessageAttributeOptionsResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INMessageAttributeOptionsResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INMessageAttributeOptionsResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -1736,10 +1956,27 @@ namespace XamCore.Intents {
 		[Export ("successWithResolvedValue:")]
 		INMessageAttributeResolutionResult GetSuccess (INMessageAttribute resolvedValue);
 
-
 		[Static]
 		[Export ("confirmationRequiredWithValueToConfirm:")]
 		INMessageAttributeResolutionResult GetConfirmationRequired (INMessageAttribute valueToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INMessageAttributeResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INMessageAttributeResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INMessageAttributeResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -1921,6 +2158,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithPersonToConfirm:")]
 		INPersonResolutionResult GetConfirmationRequired ([NullAllowed] INPerson personToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INPersonResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INPersonResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INPersonResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -1940,6 +2195,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithPlacemarkToConfirm:")]
 		INPlacemarkResolutionResult GetConfirmationRequired ([NullAllowed] CLPlacemark placemarkToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INPlacemarkResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INPlacemarkResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INPlacemarkResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -2005,6 +2278,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithValueToConfirm:")]
 		INRadioTypeResolutionResult GetConfirmationRequired (INRadioType valueToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INRadioTypeResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INRadioTypeResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INRadioTypeResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -2020,6 +2311,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithValueToConfirm:")]
 		INRelativeReferenceResolutionResult GetConfirmationRequired (INRelativeReference valueToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INRelativeReferenceResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INRelativeReferenceResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INRelativeReferenceResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -2035,6 +2344,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithValueToConfirm:")]
 		INRelativeSettingResolutionResult GetConfirmationRequired (INRelativeSetting valueToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INRelativeSettingResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INRelativeSettingResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INRelativeSettingResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -2247,6 +2574,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithRestaurantGuestToConfirm:")]
 		INRestaurantGuestResolutionResult GetConfirmationRequired ([NullAllowed] INRestaurantGuest restaurantGuestToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INRestaurantGuestResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INRestaurantGuestResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INRestaurantGuestResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -2355,6 +2700,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithRestaurantToConfirm:")]
 		INRestaurantResolutionResult GetConfirmationRequired ([NullAllowed] INRestaurant restaurantToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INRestaurantResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INRestaurantResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INRestaurantResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -3507,6 +3870,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithStringToConfirm:")]
 		INSpeakableStringResolutionResult GetConfirmationRequired ([NullAllowed] INSpeakableString stringToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INSpeakableStringResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INSpeakableStringResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INSpeakableStringResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -3758,6 +4139,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithStringToConfirm:")]
 		INStringResolutionResult GetConfirmationRequired ([NullAllowed] string stringToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INStringResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INStringResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INStringResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -3777,6 +4176,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithTemperatureToConfirm:")]
 		INTemperatureResolutionResult GetConfirmationRequired ([NullAllowed] NSMeasurement<NSUnitTemperature> temperatureToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INTemperatureResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INTemperatureResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INTemperatureResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -3830,6 +4247,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithValueToConfirm:")]
 		INWorkoutGoalUnitTypeResolutionResult GetConfirmationRequired (INWorkoutGoalUnitType valueToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INWorkoutGoalUnitTypeResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INWorkoutGoalUnitTypeResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INWorkoutGoalUnitTypeResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -3845,6 +4280,24 @@ namespace XamCore.Intents {
 		[Static]
 		[Export ("confirmationRequiredWithValueToConfirm:")]
 		INWorkoutLocationTypeResolutionResult GetConfirmationRequired (INWorkoutLocationType valueToConfirm);
+
+		// Fixes bug 43205. We need to return the inherited type not the base type
+		// because users won't be able to downcast easily
+
+		[New]
+		[Static]
+		[Export ("needsValue")]
+		INWorkoutLocationTypeResolutionResult NeedsValue { get; }
+
+		[New]
+		[Static]
+		[Export ("notRequired")]
+		INWorkoutLocationTypeResolutionResult NotRequired { get; }
+
+		[New]
+		[Static]
+		[Export ("unsupported")]
+		INWorkoutLocationTypeResolutionResult Unsupported { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]

--- a/tests/monotouch-test/Intents/INIntentResolutionResultTests.cs
+++ b/tests/monotouch-test/Intents/INIntentResolutionResultTests.cs
@@ -1,0 +1,434 @@
+﻿//
+// Unit tests for INIntentResolutionResult
+//
+// Authors:
+//	Alex Soto <alexsoto@microsoft.com>
+//	
+//
+// Copyright 2016 Xamarin Inc. All rights reserved.
+//
+
+#if !__TVOS__ && !__WATCHOS__ && XAMCORE_2_0
+
+using System;
+using NUnit.Framework;
+
+using Foundation;
+using Intents;
+
+namespace MonoTouchFixtures.Intents {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class INIntentResolutionResultTests {
+
+		[Test]
+		public void INIntentResolutionResultIsAbstractTest ()
+		{
+			Assert.Throws<NotImplementedException> (() => { var needsValue = INIntentResolutionResult.NeedsValue; }, "Base type must implement NeedsValue");
+			Assert.Throws<NotImplementedException> (() => { var notRequired = INIntentResolutionResult.NotRequired; }, "Base type must implement NotRequired");
+			Assert.Throws<NotImplementedException> (() => { var unsupported = INIntentResolutionResult.Unsupported; }, "Base type must implement Unsupported");
+		}
+
+		[Test]
+		public void INBooleanResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INBooleanResolutionResult.NeedsValue)
+			using (var notRequired = INBooleanResolutionResult.NotRequired)
+			using (var unsupported = INBooleanResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INBooleanResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INBooleanResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INBooleanResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INCallRecordTypeResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INCallRecordTypeResolutionResult.NeedsValue)
+			using (var notRequired = INCallRecordTypeResolutionResult.NotRequired)
+			using (var unsupported = INCallRecordTypeResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INCallRecordTypeResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INCallRecordTypeResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INCallRecordTypeResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INCarAirCirculationModeResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INCarAirCirculationModeResolutionResult.NeedsValue)
+			using (var notRequired = INCarAirCirculationModeResolutionResult.NotRequired)
+			using (var unsupported = INCarAirCirculationModeResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INCarAirCirculationModeResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INCarAirCirculationModeResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INCarAirCirculationModeResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INCarAudioSourceResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INCarAudioSourceResolutionResult.NeedsValue)
+			using (var notRequired = INCarAudioSourceResolutionResult.NotRequired)
+			using (var unsupported = INCarAudioSourceResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INCarAudioSourceResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INCarAudioSourceResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INCarAudioSourceResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INCarDefrosterResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INCarDefrosterResolutionResult.NeedsValue)
+			using (var notRequired = INCarDefrosterResolutionResult.NotRequired)
+			using (var unsupported = INCarDefrosterResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INCarDefrosterResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INCarDefrosterResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INCarDefrosterResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INCarSeatResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INCarSeatResolutionResult.NeedsValue)
+			using (var notRequired = INCarSeatResolutionResult.NotRequired)
+			using (var unsupported = INCarSeatResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INCarSeatResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INCarSeatResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INCarSeatResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INCurrencyAmountResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INCurrencyAmountResolutionResult.NeedsValue)
+			using (var notRequired = INCurrencyAmountResolutionResult.NotRequired)
+			using (var unsupported = INCurrencyAmountResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INCurrencyAmountResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INCurrencyAmountResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INCurrencyAmountResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INDateComponentsRangeResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INDateComponentsRangeResolutionResult.NeedsValue)
+			using (var notRequired = INDateComponentsRangeResolutionResult.NotRequired)
+			using (var unsupported = INDateComponentsRangeResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INDateComponentsRangeResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INDateComponentsRangeResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INDateComponentsRangeResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INDoubleResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INDoubleResolutionResult.NeedsValue)
+			using (var notRequired = INDoubleResolutionResult.NotRequired)
+			using (var unsupported = INDoubleResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INDoubleResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INDoubleResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INDoubleResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INDateComponentsResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INDateComponentsResolutionResult.NeedsValue)
+			using (var notRequired = INDateComponentsResolutionResult.NotRequired)
+			using (var unsupported = INDateComponentsResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INDateComponentsResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INDateComponentsResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INDateComponentsResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INIntegerResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INIntegerResolutionResult.NeedsValue)
+			using (var notRequired = INIntegerResolutionResult.NotRequired)
+			using (var unsupported = INIntegerResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INIntegerResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INIntegerResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INIntegerResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INMessageAttributeOptionsResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INMessageAttributeOptionsResolutionResult.NeedsValue)
+			using (var notRequired = INMessageAttributeOptionsResolutionResult.NotRequired)
+			using (var unsupported = INMessageAttributeOptionsResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INMessageAttributeOptionsResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INMessageAttributeOptionsResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INMessageAttributeOptionsResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INMessageAttributeResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INMessageAttributeResolutionResult.NeedsValue)
+			using (var notRequired = INMessageAttributeResolutionResult.NotRequired)
+			using (var unsupported = INMessageAttributeResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INMessageAttributeResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INMessageAttributeResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INMessageAttributeResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INPersonResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INPersonResolutionResult.NeedsValue)
+			using (var notRequired = INPersonResolutionResult.NotRequired)
+			using (var unsupported = INPersonResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INPersonResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INPersonResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INPersonResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INPlacemarkResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INPlacemarkResolutionResult.NeedsValue)
+			using (var notRequired = INPlacemarkResolutionResult.NotRequired)
+			using (var unsupported = INPlacemarkResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INPlacemarkResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INPlacemarkResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INPlacemarkResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INRadioTypeResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INRadioTypeResolutionResult.NeedsValue)
+			using (var notRequired = INRadioTypeResolutionResult.NotRequired)
+			using (var unsupported = INRadioTypeResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INRadioTypeResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INRadioTypeResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INRadioTypeResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INRelativeReferenceResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INRelativeReferenceResolutionResult.NeedsValue)
+			using (var notRequired = INRelativeReferenceResolutionResult.NotRequired)
+			using (var unsupported = INRelativeReferenceResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INRelativeReferenceResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INRelativeReferenceResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INRelativeReferenceResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INRelativeSettingResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INRelativeSettingResolutionResult.NeedsValue)
+			using (var notRequired = INRelativeSettingResolutionResult.NotRequired)
+			using (var unsupported = INRelativeSettingResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INRelativeSettingResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INRelativeSettingResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INRelativeSettingResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INRestaurantGuestResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INRestaurantGuestResolutionResult.NeedsValue)
+			using (var notRequired = INRestaurantGuestResolutionResult.NotRequired)
+			using (var unsupported = INRestaurantGuestResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INRestaurantGuestResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INRestaurantGuestResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INRestaurantGuestResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INRestaurantResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INRestaurantResolutionResult.NeedsValue)
+			using (var notRequired = INRestaurantResolutionResult.NotRequired)
+			using (var unsupported = INRestaurantResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INRestaurantResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INRestaurantResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INRestaurantResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INSpeakableStringResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INSpeakableStringResolutionResult.NeedsValue)
+			using (var notRequired = INSpeakableStringResolutionResult.NotRequired)
+			using (var unsupported = INSpeakableStringResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INSpeakableStringResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INSpeakableStringResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INSpeakableStringResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INStringResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INStringResolutionResult.NeedsValue)
+			using (var notRequired = INStringResolutionResult.NotRequired)
+			using (var unsupported = INStringResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INStringResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INStringResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INStringResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INTemperatureResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INTemperatureResolutionResult.NeedsValue)
+			using (var notRequired = INTemperatureResolutionResult.NotRequired)
+			using (var unsupported = INTemperatureResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INTemperatureResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INTemperatureResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INTemperatureResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INWorkoutGoalUnitTypeResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INWorkoutGoalUnitTypeResolutionResult.NeedsValue)
+			using (var notRequired = INWorkoutGoalUnitTypeResolutionResult.NotRequired)
+			using (var unsupported = INWorkoutGoalUnitTypeResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INWorkoutGoalUnitTypeResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INWorkoutGoalUnitTypeResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INWorkoutGoalUnitTypeResolutionResult), unsupported, "Unsupported");
+			}
+		}
+
+		[Test]
+		public void INWorkoutLocationTypeResolutionResultPropertyTest ()
+		{
+			using (var needsValue = INWorkoutLocationTypeResolutionResult.NeedsValue)
+			using (var notRequired = INWorkoutLocationTypeResolutionResult.NotRequired)
+			using (var unsupported = INWorkoutLocationTypeResolutionResult.Unsupported) {
+				Assert.NotNull (needsValue, "NeedsValue Null");
+				Assert.NotNull (notRequired, "NotRequired Null");
+				Assert.NotNull (unsupported, "Unsupported Null");
+
+				Assert.IsInstanceOfType (typeof (INWorkoutLocationTypeResolutionResult), needsValue, "NeedsValue");
+				Assert.IsInstanceOfType (typeof (INWorkoutLocationTypeResolutionResult), notRequired, "NotRequired");
+				Assert.IsInstanceOfType (typeof (INWorkoutLocationTypeResolutionResult), unsupported, "Unsupported");
+			}
+		}
+	}
+}
+#endif

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -559,6 +559,7 @@
     <Compile Include="CoreGraphics\ColorConversionInfoTest.cs" />
     <Compile Include="Foundation\DimensionTest.cs" />
     <Compile Include="UIKit\GraphicsRendererTest.cs" />
+    <Compile Include="Intents\INIntentResolutionResultTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>
@@ -621,6 +622,7 @@
     <Folder Include="CoreAudioKit\" />
     <Folder Include="Messages\" />
     <Folder Include="CloudKit\" />
+    <Folder Include="Intents\" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="AudioToolbox\1.caf" />


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=43205

Per [documentation](1) INIntentResolutionResult is an abstract class
and now we honor that, also we now provide the right return type
on each of the properties (NeedsValue, NotRequired and Unsupported)
in all subclasses of INIntentResolutionResult.

Unit tests added for all INIntentResolutionResult subclasses.

[1]: https://developer.apple.com/reference/intents/inintentresolutionresult?language=objc