### PR TITLE
Fix ObjC encoding of block signatures. Fixes #43592.

### DIFF
--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -1139,9 +1139,9 @@ namespace XamCore.Registrar {
 			RegisterType (type, ref exceptions);
 		}
 
-		public string ComputeSignature (MethodInfo method)
+		public string ComputeSignature (MethodInfo method, bool isBlockSignature)
 		{
-			return base.ComputeSignature (method.DeclaringType, method);
+			return base.ComputeSignature (method.DeclaringType, method, isBlockSignature: isBlockSignature);
 		}
 	}
 }

--- a/src/ObjCRuntime/IDynamicRegistrar.cs
+++ b/src/ObjCRuntime/IDynamicRegistrar.cs
@@ -35,7 +35,7 @@ namespace XamCore.Registrar {
 		bool IsCustomType (Type type);
 		void RegisterMethod (Type type, MethodInfo minfo, ExportAttribute ea);
 		IEnumerable<Assembly> GetAssemblies ();
-		string ComputeSignature (MethodInfo minfo);
+		string ComputeSignature (MethodInfo minfo, bool isBlockSignature);
 	}
 #endif
 }

--- a/src/ObjCRuntime/OldDynamicRegistrar.cs
+++ b/src/ObjCRuntime/OldDynamicRegistrar.cs
@@ -556,7 +556,7 @@ namespace XamCore.Registrar {
 			}
 		}
 
-		public string ComputeSignature (MethodInfo minfo)
+		public string ComputeSignature (MethodInfo minfo, bool isBlockSignature)
 		{
 			return Method.Signature (minfo);
 		}

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -1950,7 +1950,7 @@ namespace XamCore.Registrar {
 			}
 		}
 
-		public string ComputeSignature (TType DeclaringType, TMethod Method, ObjCMember member = null, bool isCategoryInstance = false)
+		public string ComputeSignature (TType DeclaringType, TMethod Method, ObjCMember member = null, bool isCategoryInstance = false, bool isBlockSignature = false)
 		{
 			var success = true;
 			var signature = new StringBuilder ();
@@ -1972,7 +1972,7 @@ namespace XamCore.Registrar {
 					throw CreateException (4104, Method, "The registrar cannot marshal the return value of type `{0}` in the method `{1}.{2}`.", GetTypeFullName (ReturnType), GetTypeFullName (DeclaringType), GetDescriptiveMethodName (Method));
 			}
 
-			signature.Append ("@:");
+			signature.Append (isBlockSignature ? "@?" : "@:");
 
 			TType[] parameters;
 			if (Method != null) {

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -430,9 +430,9 @@ namespace XamCore.ObjCRuntime {
 			return Registrar.GetAssemblies ();
 		}
 
-		internal static string ComputeSignature (MethodInfo method)
+		internal static string ComputeSignature (MethodInfo method, bool isBlockSignature)
 		{
-			return Registrar.ComputeSignature (method);
+			return Registrar.ComputeSignature (method, isBlockSignature);
 		}
 
 		public static void RegisterAssembly (Assembly a)

--- a/src/ObjCRuntime/UserDelegateTypeAttribute.cs
+++ b/src/ObjCRuntime/UserDelegateTypeAttribute.cs
@@ -1,0 +1,51 @@
+//
+// UserDelegateTypeAttribute.cs: Attribute applied to block delegates
+// to specify the type of the user-supplied delegate.
+//
+// Authors:
+//   Rolf Bjarne Kvinge <rolf@xamarin.com>
+//
+// Copyright 2016 Xamarin Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace XamCore.ObjCRuntime {
+
+	// This attribute is emitted by the generator and used at runtime.
+	// It's not supposed to be used by manually written code.
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	[AttributeUsage (AttributeTargets.Delegate, AllowMultiple = false)]
+	public sealed class UserDelegateTypeAttribute : Attribute
+	{
+		public UserDelegateTypeAttribute (Type userDelegateType)
+		{
+			UserDelegateType = userDelegateType;
+		}
+
+		public Type UserDelegateType {
+			get; private set;
+		}
+	}
+}

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1459,6 +1459,7 @@ SHARED_SOURCES = \
 	ObjCRuntime/ThreadSafeAttribute.cs \
 	ObjCRuntime/TransientAttribute.cs \
 	ObjCRuntime/TypeConverter.cs \
+	ObjCRuntime/UserDelegateTypeAttribute.cs \
 	$(APPLETLS_SOURCES)
 
 #

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1077,6 +1077,7 @@ public class Tuple<A,B> {
 //
 public class TrampolineInfo {
 	public string UserDelegate, DelegateName, TrampolineName, Parameters, Invoke, ReturnType, DelegateReturnType, ReturnFormat, Clear, OutReturnType;
+	public string UserDelegateTypeAttribute;
 	public Type Type;
 	
 	public TrampolineInfo (string userDelegate, string delegateName, string trampolineName, string pars, string invoke, string returnType, string delegateReturnType, string returnFormat, string clear, Type type)
@@ -1977,6 +1978,7 @@ public partial class Generator : IMemberGatherer {
 					     type: t);
 					     
 
+		ti.UserDelegateTypeAttribute = FormatType (null, t);
 		trampolines [t] = ti;
 			
 		return ti;
@@ -2908,6 +2910,7 @@ public partial class Generator : IMemberGatherer {
 
 			print ("");
 			print ("[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]");
+			print ("[UserDelegateType (typeof ({0}))]", ti.UserDelegate);
 			print ("internal delegate {0} {1} ({2});", ti.ReturnType, ti.DelegateName, ti.Parameters);
 			print ("");
 			print ("//\n// This class bridges native block invocations that call into C#\n//");

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2514,4 +2514,88 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		}
 	}
 #endif // !__WATCHOS__
+
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class BlockSignatureTest
+	{
+		[StructLayout (LayoutKind.Sequential)]
+		struct BlockDescriptor2
+		{
+			public IntPtr reserved;
+			public IntPtr size;
+			public IntPtr copy_helper;
+			public IntPtr dispose;
+			public IntPtr signature;
+		}
+
+		[StructLayout (LayoutKind.Sequential)]
+		struct BlockLiteral2
+		{
+			public IntPtr isa;
+			public /*BlockFlags*/ int flags;
+			public int reserved;
+			public IntPtr invoke;
+			public IntPtr block_descriptor;
+			public IntPtr local_handle;
+			public IntPtr global_handle;
+		}
+
+		[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
+		internal delegate void DActionArity1V1 (IntPtr block, IntPtr obj);
+		static internal class SDActionArity1V1
+		{
+			static internal readonly DActionArity1V1 Handler = Invoke;
+
+			[MonoPInvokeCallback (typeof (DActionArity1V1))]
+			static unsafe void Invoke (IntPtr block, IntPtr obj)
+			{
+				throw new NotImplementedException ();
+			}
+		}
+
+		[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
+		[UserDelegateType (typeof (Action<NSObject>))]
+		internal delegate void DActionArity1V2 (IntPtr block, IntPtr obj);
+		static internal class SDActionArity1V2
+		{
+			static internal readonly DActionArity1V2 Handler = Invoke;
+
+			[MonoPInvokeCallback (typeof (DActionArity1V2))]
+			static unsafe void Invoke (IntPtr block, IntPtr obj)
+			{
+				throw new NotImplementedException ();
+			}
+		}
+
+		unsafe string GetBlockSignature (BlockLiteral block)
+		{
+			BlockLiteral2* blockptr = (BlockLiteral2*) &block;
+			BlockDescriptor2* descptr = (BlockDescriptor2*) blockptr->block_descriptor;
+			return Marshal.PtrToStringAuto (descptr->signature);
+		}
+
+		[Test]
+		public void WithoutUserDelegateTypeAttribute ()
+		{
+			var block = new BlockLiteral ();
+			var tramp = new DActionArity1V1 ((IntPtr a, IntPtr b) => { });
+			Action<NSObject> del = (v) => { };
+			block.SetupBlock (tramp, del);
+			Assert.AreEqual ("v@:^v^v", GetBlockSignature (block), "a");
+			block.CleanupBlock ();
+		}
+
+		[Test]
+		public void WithUserDelegateTypeAttribute ()
+		{
+			var block = new BlockLiteral ();
+			var tramp = new DActionArity1V2 ((IntPtr a, IntPtr b) => { });
+			Action<NSObject> del = (v) => { };
+			block.SetupBlock (tramp, del);
+			Assert.AreEqual ("v@?@", GetBlockSignature (block), "a");
+			block.CleanupBlock ();
+		}
+	}
 }


### PR DESCRIPTION
The P/Invoke callback method that's called by native code
has a simpler function signature than what the user delegate
has.

Example P/Invoke callback signature:

    static unsafe void Invoke (IntPtr block, IntPtr obj)

which ends up calling this delegate:

    System.Action<NSDictionary>

The NSDictionary parameter has been simplifed to just IntPtr.

The problem is that we need to encode the block signature according
to the signature of the user delegate (Apple uses the signature
in some cases, and fails/aborts if the signature doesn't match
what the code expects).

So add more metadata to make it possible to find the signature
of the user delegate at runtime.

The generator generates code like this:

    block_scheduledCompletion.SetupBlock (Trampolines.SDActionArity1V2.Handler, scheduledCompletion);

where SDActionArity1V2.Handler is defined as this:

    static internal readonly DActionArity1V2 Handler = Invoke;

this means we can get the type of `Trampolines.SDActionArity1V2.Handler` at runtime
(which would be `DActionArity1V2` in this case), so put a new attribute (`UserDelegateTypeAttribute`)
at that type:

    [UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
    [UserDelegateType (typeof (global::System.Action<NSDictionary>))]
    internal delegate void DActionArity1V2 (IntPtr block, IntPtr obj);

Then at runtime we check if the target delegate's type has this attribute,
and then we use the type specified by this new attribute instead when
computing the ObjC signature of the block.

https://bugzilla.xamarin.com/show_bug.cgi?id=43592