### PR TITLE
[linker] Ensure we do not devirtualize methods that needs to be called from a base class to satisfy an interface. Fixes #34308

### DIFF
--- a/tools/linker/MonoTouch.Tuner/SealerSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/SealerSubStep.cs
@@ -85,11 +85,15 @@ namespace Xamarin.Linker.Steps {
 					continue;
 				}
 
-				// we can seal the method (final in IL)
+				// we can seal the method (final in IL / !virtual in C#)
 				method.IsFinal = true;
 #if DEBUG
 				Console.WriteLine ("Final {0} ({1})", method, ++final);
 #endif
+				// subclasses might need this method to satisfy an interface requirement
+				// and requires dispatch/virtual support
+				if (!type.IsSealed)
+					continue;
 
 				var bases = Annotations.GetBaseMethods (method);
 				// look if this method is an override to existing _marked_ methods


### PR DESCRIPTION
Update unit tests to catch this case and be more precise in others.

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=43408