### PR TITLE
[CoreAnimation] Re-mark CALayerDelegate as informal to fix #43585.

### DIFF
--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -846,7 +846,7 @@ namespace XamCore.CoreAnimation {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Protocol] // not informal as of iOS 10+
+	[Protocol (IsInformal = true)] // not informal as of iOS 10+, but removing the IsInformal value breaks when building with older SDKs (see bug #43585).
 	public interface CALayerDelegate {
 		[Export ("displayLayer:")]
 		void DisplayLayer (CALayer layer);


### PR DESCRIPTION
CALayerDelegate was an informal protocol in earlier versions
of iOS, but elevated to protocol in iOS 10 [1]. Unfortunately this causes
problems with the static registrar, since it needs to know if a protocol
is informal or not to generate the right code, but there's no way
with the current set of attributes we have to express the fact that
CALayerDelegate was an informal protocol until iOS 10, so the static
registrar don't know to treat it correctly when building with earlier
SDKs.

This is the error that results when using CALayerDelegate with an earlier SDK:

    /work/monotouch-samples/ZoomingPdfViewer/obj/iPhone/Debug/mtouch-cache/registrar.m:1336:51: error: no type or protocol named 'CALayerDelegate'
    @interface ZoomingPdfViewer_TiledPdfView : UIView<CALayerDelegate> {
                                                      ^
So we temporarily revert the change to make CALayerDelegate formal,
until we have enough metadata for the static registrar to do the
right thing (which is filed as bug #43780 [2])

[1] https://github.com/xamarin/xamarin-macios/commit/0178aa04
[2] https://bugzilla.xamarin.com/show_bug.cgi?id=43780

https://bugzilla.xamarin.com/show_bug.cgi?id=43585