### PR TITLE
Share the same block descriptors between copies of a block. Fixes #43592.

### DIFF
--- a/runtime/shared.h
+++ b/runtime/shared.h
@@ -36,7 +36,7 @@ struct Xamarin_block_descriptor {
     void (*dispose_helper)(void *src);             // IFF (1<<25)
     // required ABI.2010.3.16
     const char *signature;                         // IFF (1<<30)
-    int xamarin_size;
+    volatile int ref_count;
     // variable-length string
 };
 


### PR DESCRIPTION
In bug #43592 the following occurs:

* App calls an API that takes a block.
* We create a stack-based ObjC block based on the delegate the app provided.
  This block has a pointer to a block description, describing the block
  in question (including the signature of the block, as an ObjC-type
  encoded string). We allocate a new block description for every block.
* Apple's API stores the pointer to the signature string somewhere.
* Apple calls _Block_copy to get a heap-based block.
* We create a heap-based block, and copy the entire description into the
  new heap-based block (including a copy of the signature).
* Apple returns from the API, and then we free the stack-based block
  (and the descriptor, and thus the signature string in the descriptor).
* Apple uses the pointer to the signature stored previously to investigate
  the signature of the block, and crashes because this signature has been
  freed.

The assumption in Apple's code is that the description will never be freed,
which is true for any Xcode project (clang will always be able to create the
block description at compile-time and emit it in the binary, which means the
memory will never be freed). We could potentially do the same thing in the
static registrar, but we'd still need a solution when using the dynamic
registrar.

To fix this instead of copying the entire description structure when creating
a heap-based block from the stack-based block, we make the description ref-
counted, and just use the same description in the heap-based block.

The signature will now stay in memory until both the heap-based and stack-
based blocks have been freed, and we hope Apple doesn't have any API that
needs the signature after all the blocks for that signature have been freed.

https://bugzilla.xamarin.com/show_bug.cgi?id=43592