### PR TITLE
[tvos][avfoundation] Adjust API for tvOS

### DIFF
--- a/src/AVFoundation/AVAssetDownloadTask.cs
+++ b/src/AVFoundation/AVAssetDownloadTask.cs
@@ -11,7 +11,7 @@ using System;
 using XamCore.Foundation;
 
 namespace XamCore.AVFoundation {
-#if !MONOMAC && !WATCH
+#if !MONOMAC && !WATCH && !TVOS
 	public partial class AVAssetDownloadTask : NSUrlSessionTask {
 
 		// NSURLRequest and NSURLResponse objects are not available for AVAssetDownloadTask

--- a/src/AVFoundation/AVCompat.cs
+++ b/src/AVFoundation/AVCompat.cs
@@ -1,10 +1,13 @@
-// Copyright 2014-2015 Xamarin Inc. All rights reserved.
+// Copyright 2014-2016 Xamarin Inc. All rights reserved.
 
 #if !WATCH
 
 using System;
+using System.ComponentModel;
+using OpenTK;
 using XamCore.CoreMedia;
 using XamCore.Foundation;
+using XamCore.ObjCRuntime;
 
 namespace XamCore.AVFoundation {
 
@@ -80,7 +83,409 @@ namespace XamCore.AVFoundation {
 		{
 		}
 	}
-#endif
+
+#if TVOS
+	// tvOS removed some types - we need to keep stubs of them for binary compatibility
+	[Obsolete ("Removed in tvOS 10")]
+	[Deprecated (PlatformName.TvOS, 10, 0, PlatformArchitecture.None, "Removed in tvOS 10")]
+	public class AVAssetDownloadDelegate : NSObject, IAVAssetDownloadDelegate {
+		public AVAssetDownloadDelegate ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
+		protected AVAssetDownloadDelegate (NSObjectFlag t)
+		{
+			throw new NotImplementedException ();
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
+		protected internal AVAssetDownloadDelegate (IntPtr handle)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public virtual void DidCompleteWithError (NSUrlSession session, NSUrlSessionTask task, NSError error)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public virtual void DidFinishCollectingMetrics (NSUrlSession session, NSUrlSessionTask task, NSUrlSessionTaskMetrics metrics)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public virtual void DidFinishDownloadingToUrl (NSUrlSession session, AVAssetDownloadTask assetDownloadTask, NSUrl location)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public virtual void DidLoadTimeRange (NSUrlSession session, AVAssetDownloadTask assetDownloadTask, CMTimeRange timeRange, NSValue[] loadedTimeRanges, CMTimeRange timeRangeExpectedToLoad)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public virtual void DidReceiveChallenge (NSUrlSession session, NSUrlSessionTask task, NSUrlAuthenticationChallenge challenge, [BlockProxy (typeof(Trampolines.NIDActionArity2V0))] Action<NSUrlSessionAuthChallengeDisposition, NSUrlCredential> completionHandler)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public virtual void DidResolveMediaSelection (NSUrlSession session, AVAssetDownloadTask assetDownloadTask, AVMediaSelection resolvedMediaSelection)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public virtual void DidSendBodyData (NSUrlSession session, NSUrlSessionTask task, long bytesSent, long totalBytesSent, long totalBytesExpectedToSend)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public virtual void NeedNewBodyStream (NSUrlSession session, NSUrlSessionTask task, [BlockProxy (typeof(Trampolines.NIDActionArity1V0))] Action<NSInputStream> completionHandler)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public virtual void WillPerformHttpRedirection (NSUrlSession session, NSUrlSessionTask task, NSHttpUrlResponse response, NSUrlRequest newRequest, [BlockProxy (typeof(Trampolines.NIDActionArity1V1))] Action<NSUrlRequest> completionHandler)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+
+	[Obsolete ("Removed in tvOS 10")]
+	[Deprecated (PlatformName.TvOS, 10, 0, PlatformArchitecture.None, "Removed in tvOS 10")]
+	public interface IAVAssetDownloadDelegate : INativeObject, IDisposable, INSUrlSessionTaskDelegate, INSUrlSessionDelegate {
+	}
+
+	[Obsolete ("Removed in tvOS 10")]
+	[Deprecated (PlatformName.TvOS, 10, 0, PlatformArchitecture.None, "Removed in tvOS 10")]
+	public static class AVAssetDownloadDelegate_Extensions {
+
+		public static void DidFinishDownloadingToUrl (this IAVAssetDownloadDelegate This, NSUrlSession session, AVAssetDownloadTask assetDownloadTask, NSUrl location)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public static void DidLoadTimeRange (this IAVAssetDownloadDelegate This, NSUrlSession session, AVAssetDownloadTask assetDownloadTask, CMTimeRange timeRange, NSValue[] loadedTimeRanges, CMTimeRange timeRangeExpectedToLoad)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public static void DidResolveMediaSelection (this IAVAssetDownloadDelegate This, NSUrlSession session, AVAssetDownloadTask assetDownloadTask, AVMediaSelection resolvedMediaSelection)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+
+	[Obsolete ("Removed in tvOS 10")]
+	[Deprecated (PlatformName.TvOS, 10, 0, PlatformArchitecture.None, "Removed in tvOS 10")]
+	public class AVAssetDownloadTask : NSUrlSessionTask {
+
+		public override IntPtr ClassHandle {
+			get {
+				throw new NotImplementedException ();
+			}
+		}
+
+		public override NSUrlRequest CurrentRequest {
+			get {
+				throw new NotImplementedException ();
+			}
+		}
+
+		public virtual NSUrl DestinationUrl {
+			get {
+				throw new NotImplementedException ();
+			}
+		}
+
+		public virtual NSValue[] LoadedTimeRanges {
+			get {
+				throw new NotImplementedException ();
+			}
+		}
+
+		public virtual NSDictionary<NSString, NSObject> Options {
+			get {
+				throw new NotImplementedException ();
+			}
+		}
+
+		public override NSUrlRequest OriginalRequest {
+			get {
+				throw new NotImplementedException ();
+			}
+		}
+
+		public override NSUrlResponse Response {
+			get {
+				throw new NotImplementedException ();
+			}
+		}
+
+		public virtual AVUrlAsset UrlAsset {
+			get {
+				throw new NotImplementedException ();
+			}
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Advanced),]
+		protected AVAssetDownloadTask (NSObjectFlag t)
+		{
+			throw new NotImplementedException ();
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
+		protected internal AVAssetDownloadTask (IntPtr handle)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+
+	[Obsolete ("Removed in tvOS 10")]
+	[Deprecated (PlatformName.TvOS, 10, 0, PlatformArchitecture.None, "Removed in tvOS 10")]
+	public class AVAssetDownloadUrlSession : NSUrlSession {
+
+		public new static NSUrlSession SharedSession {
+			get {
+				throw new NotImplementedException ();
+			}
+		}
+
+		public override IntPtr ClassHandle {
+			get {
+				throw new NotImplementedException ();
+			}
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
+		protected internal AVAssetDownloadUrlSession (IntPtr handle) : base (handle)
+		{
+			throw new NotImplementedException ();
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
+		protected AVAssetDownloadUrlSession (NSObjectFlag t) : base (t)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public static AVAssetDownloadUrlSession CreateSession (NSUrlSessionConfiguration configuration, IAVAssetDownloadDelegate @delegate, NSOperationQueue delegateQueue)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public new static NSUrlSession FromConfiguration (NSUrlSessionConfiguration configuration)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public new static NSUrlSession FromConfiguration (NSUrlSessionConfiguration configuration, NSUrlSessionDelegate sessionDelegate, NSOperationQueue delegateQueue)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public new static NSUrlSession FromWeakConfiguration (NSUrlSessionConfiguration configuration, NSObject weakDelegate, NSOperationQueue delegateQueue)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override NSUrlSessionDataTask CreateDataTask (NSUrlRequest request)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override NSUrlSessionDataTask CreateDataTask (NSUrl url)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override NSUrlSessionDataTask CreateDataTask (NSUrlRequest request, NSUrlSessionResponse completionHandler)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override NSUrlSessionDataTask CreateDataTask (NSUrl url, NSUrlSessionResponse completionHandler)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override NSUrlSessionDownloadTask CreateDownloadTask (NSUrlRequest request, NSUrlDownloadSessionResponse completionHandler)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override NSUrlSessionDownloadTask CreateDownloadTask (NSUrl url, NSUrlDownloadSessionResponse completionHandler)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override NSUrlSessionDownloadTask CreateDownloadTask (NSData resumeData)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override NSUrlSessionDownloadTask CreateDownloadTask (NSUrl url)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override NSUrlSessionDownloadTask CreateDownloadTask (NSUrlRequest request)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override NSUrlSessionDownloadTask CreateDownloadTaskFromResumeData (NSData resumeData, NSUrlDownloadSessionResponse completionHandler)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request, NSUrl fileURL)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request, NSData bodyData)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request, NSUrl fileURL, NSUrlSessionResponse completionHandler)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request, NSData bodyData, NSUrlSessionResponse completionHandler)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public virtual AVAssetDownloadTask GetAssetDownloadTask (AVUrlAsset urlAsset, NSUrl destinationUrl, NSDictionary options)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public AVAssetDownloadTask GetAssetDownloadTask (AVUrlAsset urlAsset, NSUrl destinationUrl, AVAssetDownloadOptions options)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public virtual AVAssetDownloadTask GetAssetDownloadTask (AVUrlAsset urlAsset, string title, NSData artworkData, NSDictionary options)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public AVAssetDownloadTask GetAssetDownloadTask (AVUrlAsset urlAsset, string title, NSData artworkData, AVAssetDownloadOptions options)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+
+	[Obsolete ("Removed in tvOS 10")]
+	[Deprecated (PlatformName.TvOS, 10, 0, PlatformArchitecture.None, "Removed in tvOS 10")]
+	public class AVAudioInputNode : AVAudioIONode, IAVAudio3DMixing, IAVAudioMixing, IAVAudioStereoMixing {
+
+		public override IntPtr ClassHandle {
+			get {
+				throw new NotImplementedException ();
+			}
+		}
+
+		public virtual float Obstruction {
+			get {
+				throw new NotImplementedException ();
+			}
+			set {
+				throw new NotImplementedException ();
+			}
+		}
+
+		public virtual float Occlusion {
+			get {
+				throw new NotImplementedException ();
+			}
+			set {
+				throw new NotImplementedException ();
+			}
+		}
+
+		public virtual float Pan {
+			get {
+				throw new NotImplementedException ();
+			}
+			set {
+				throw new NotImplementedException ();
+			}
+		}
+
+		public virtual Vector3 Position {
+			get {
+				throw new NotImplementedException ();
+			}
+			set {
+				throw new NotImplementedException ();
+			}
+		}
+
+		public virtual float Rate {
+			get {
+				throw new NotImplementedException ();
+			}
+			set {
+				throw new NotImplementedException ();
+			}
+		}
+
+		public virtual AVAudio3DMixingRenderingAlgorithm RenderingAlgorithm {
+			get {
+				throw new NotImplementedException ();
+			}
+			set {
+				throw new NotImplementedException ();
+			}
+		}
+
+		public virtual float ReverbBlend {
+			get {
+				throw new NotImplementedException ();
+			}
+			set {
+				throw new NotImplementedException ();
+			}
+		}
+
+		public virtual float Volume {
+			get {
+				throw new NotImplementedException ();
+			}
+			set {
+				throw new NotImplementedException ();
+			}
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
+		protected AVAudioInputNode (NSObjectFlag t) : base (t)
+		{
+			throw new NotImplementedException ();
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
+		protected internal AVAudioInputNode (IntPtr handle) : base (handle)
+		{
+		}
+
+		public virtual AVAudioMixingDestination DestinationForMixer (AVAudioNode mixer, nuint bus)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+#endif // TVOS
+#endif // !XAMCORE_4_0
 }
 
 #endif

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -401,11 +401,11 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoCodecJPEG")]
 		NSString CodecJPEG { get; }
 		
-		[NoiOS, Mac (10,7)]
+		[NoiOS, NoTV, Mac (10,7)]
 		[Field ("AVVideoCodecAppleProRes4444")]
 		NSString AppleProRes4444 { get; }
 
-		[NoiOS, Mac (10,7)]
+		[NoiOS, NoTV, Mac (10,7)]
 		[Field ("AVVideoCodecAppleProRes422")]
 		NSString AppleProRes422 { get; }
 		
@@ -1024,6 +1024,7 @@ namespace XamCore.AVFoundation {
 
 	}	
 
+	[NoTV]
 	[NoWatch]
 	[iOS (8,0)][Mac (10,10)]
 	[BaseType (typeof (AVAudioIONode))]
@@ -9327,7 +9328,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoColorPrimaries_ITU_R_709_2")]
 		NSString Itu_R_709_2 { get; }
 
-		[NoiOS]
+		[NoiOS, NoTV]
 		[Field ("AVVideoColorPrimaries_EBU_3213")]
 		NSString Ebu_3213 { get; }
 
@@ -9347,7 +9348,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoTransferFunction_ITU_R_709_2")]
 		NSString AVVideoTransferFunction_Itu_R_709_2 { get; }
 
-		[NoiOS, Mac (10,12)]
+		[NoiOS, NoTV, Mac (10,12)]
 		[Field ("AVVideoTransferFunction_SMPTE_240M_1995")]
 		NSString AVVideoTransferFunction_Smpte_240M_1995 { get; }
 	}
@@ -9364,7 +9365,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoYCbCrMatrix_ITU_R_601_4")]
 		NSString Itu_R_601_4 { get; }
 
-		[NoiOS, Mac (10,12)]
+		[NoiOS, NoTV, Mac (10,12)]
 		[Field ("AVVideoYCbCrMatrix_SMPTE_240M_1995")]
 		NSString Smpte_240M_1995 { get; }
 
@@ -10309,6 +10310,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
+	[NoTV]
 	[iOS (9,0)]
 	[NoMac]
 	[BaseType (typeof (NSUrlSessionTask))]
@@ -10349,9 +10351,7 @@ namespace XamCore.AVFoundation {
 		AVMediaSelection MediaSelection { get; }
 	}
 
-#if XAMCORE_4_0
 	[NoTV]
-#endif
 	[NoWatch]
 	[iOS (9,0)]
 	[DisableDefaultCtor]
@@ -10382,9 +10382,7 @@ namespace XamCore.AVFoundation {
 
 	interface IAVAssetDownloadDelegate {}
 
-#if XAMCORE_4_0
 	[NoTV]
-#endif
 	[NoWatch]
 	[iOS (9,0)]
 	[Protocol, Model]

--- a/tests/xtro-sharpie/tvos.ignore
+++ b/tests/xtro-sharpie/tvos.ignore
@@ -9,6 +9,88 @@
 !missing-selector! AVFragmentedAsset::tracksWithMediaCharacteristic: not bound
 !missing-selector! AVFragmentedAsset::tracksWithMediaType: not bound
 
+## AVCaptureDevice_AVCaptureDeviceAuthorization category over AVCaptureDevice - not in tvOS
+!missing-selector! +AVCaptureDevice::authorizationStatusForMediaType: not bound
+!missing-selector! +AVCaptureDevice::requestAccessForMediaType:completionHandler: not bound
+
+## AVCaptureDevice_AVCaptureDeviceColorSpaceSupport category over AVCaptureDevice - not in tvOS
+!missing-selector! AVCaptureDevice::activeColorSpace not bound
+!missing-selector! AVCaptureDevice::setActiveColorSpace: not bound
+
+## AVCaptureDevice_AVCaptureDeviceExposure category over AVCaptureDevice - not in tvOS
+!missing-selector! AVCaptureDevice::ISO not bound
+!missing-selector! AVCaptureDevice::exposureDuration not bound
+!missing-selector! AVCaptureDevice::exposureTargetBias not bound
+!missing-selector! AVCaptureDevice::exposureTargetOffset not bound
+!missing-selector! AVCaptureDevice::lensAperture not bound
+!missing-selector! AVCaptureDevice::maxExposureTargetBias not bound
+!missing-selector! AVCaptureDevice::minExposureTargetBias not bound
+!missing-selector! AVCaptureDevice::setExposureTargetBias:completionHandler: not bound
+!missing-selector! AVCaptureDevice::setExposureModeCustomWithDuration:ISO:completionHandler: not bound
+
+## AVCaptureDevice_AVCaptureDeviceFlash
+!missing-selector! AVCaptureDevice::flashMode not bound
+!missing-selector! AVCaptureDevice::isFlashActive not bound
+!missing-selector! AVCaptureDevice::isFlashAvailable not bound
+!missing-selector! AVCaptureDevice::isFlashModeSupported: not bound
+!missing-selector! AVCaptureDevice::setFlashMode: not bound
+
+## AVCaptureDevice_AVCaptureDeviceFocus category over AVCaptureDevice - not in tvOS
+!missing-selector! AVCaptureDevice::autoFocusRangeRestriction not bound
+!missing-selector! AVCaptureDevice::isAutoFocusRangeRestrictionSupported not bound
+!missing-selector! AVCaptureDevice::isSmoothAutoFocusEnabled not bound
+!missing-selector! AVCaptureDevice::isSmoothAutoFocusSupported not bound
+!missing-selector! AVCaptureDevice::lensPosition not bound
+!missing-selector! AVCaptureDevice::setAutoFocusRangeRestriction: not bound
+!missing-selector! AVCaptureDevice::setFocusModeLockedWithLensPosition:completionHandler: not bound
+!missing-selector! AVCaptureDevice::setSmoothAutoFocusEnabled: not bound
+
+## AVCaptureDevice_AVCaptureDeviceHighDynamicRangeSupport
+!missing-selector! AVCaptureDevice::automaticallyAdjustsVideoHDREnabled not bound
+!missing-selector! AVCaptureDevice::isVideoHDREnabled not bound
+!missing-selector! AVCaptureDevice::setAutomaticallyAdjustsVideoHDREnabled: not bound
+!missing-selector! AVCaptureDevice::setVideoHDREnabled: not bound
+
+## AVCaptureDevice_AVCaptureDeviceLowLightBoost
+!missing-selector! AVCaptureDevice::automaticallyEnablesLowLightBoostWhenAvailable not bound
+!missing-selector! AVCaptureDevice::isLowLightBoostEnabled not bound
+!missing-selector! AVCaptureDevice::isLowLightBoostSupported not bound
+!missing-selector! AVCaptureDevice::setAutomaticallyEnablesLowLightBoostWhenAvailable: not bound
+
+## AVCaptureDevice_AVCaptureDeviceSubjectAreaChangeMonitoring
+!missing-selector! AVCaptureDevice::isSubjectAreaChangeMonitoringEnabled not bound
+!missing-selector! AVCaptureDevice::setSubjectAreaChangeMonitoringEnabled: not bound
+
+## AVCaptureDevice_AVCaptureDeviceTorch
+!missing-selector! AVCaptureDevice::isTorchActive not bound
+!missing-selector! AVCaptureDevice::isTorchAvailable not bound
+!missing-selector! AVCaptureDevice::setTorchModeOnWithLevel:error: not bound
+!missing-selector! AVCaptureDevice::torchLevel not bound
+
+## AVCaptureDevice_AVCaptureDeviceVideoZoom
+!missing-selector! AVCaptureDevice::isRampingVideoZoom not bound
+!missing-selector! AVCaptureDevice::rampToVideoZoomFactor:withRate: not bound
+!missing-selector! AVCaptureDevice::videoZoomFactor not bound
+!missing-selector! AVCaptureDevice::setVideoZoomFactor: not bound
+
+## AVCaptureDevice_AVCaptureDeviceWhiteBalance
+!missing-selector! AVCaptureDevice::chromaticityValuesForDeviceWhiteBalanceGains: not bound
+!missing-selector! AVCaptureDevice::deviceWhiteBalanceGains not bound
+!missing-selector! AVCaptureDevice::deviceWhiteBalanceGainsForChromaticityValues: not bound
+!missing-selector! AVCaptureDevice::deviceWhiteBalanceGainsForTemperatureAndTintValues: not bound
+!missing-selector! AVCaptureDevice::grayWorldDeviceWhiteBalanceGains not bound
+!missing-selector! AVCaptureDevice::maxWhiteBalanceGain not bound
+!missing-selector! AVCaptureDevice::setWhiteBalanceModeLockedWithDeviceWhiteBalanceGains:completionHandler: not bound
+!missing-selector! AVCaptureDevice::temperatureAndTintValuesForDeviceWhiteBalanceGains: not bound
+
+## AVCaptureStillImageOutput_BracketedCaptureMethods category over AVCaptureStillImageOutput - not in tvOS (and deprecated)
+!missing-selector! AVCaptureStillImageOutput::captureStillImageBracketAsynchronouslyFromConnection:withSettingsArray:completionHandler: not bound
+!missing-selector! AVCaptureStillImageOutput::isLensStabilizationDuringBracketedCaptureEnabled not bound
+!missing-selector! AVCaptureStillImageOutput::isLensStabilizationDuringBracketedCaptureSupported not bound
+!missing-selector! AVCaptureStillImageOutput::maxBracketedCaptureStillImageCount not bound
+!missing-selector! AVCaptureStillImageOutput::prepareToCaptureStillImageBracketFromConnection:withSettingsArray:completionHandler: not bound
+!missing-selector! AVCaptureStillImageOutput::setLensStabilizationDuringBracketedCaptureEnabled: not bound
+
 
 # CloudKit
 


### PR DESCRIPTION
Some types were removed in tvOS 10, including:

!unknown-protocol! AVAssetDownloadDelegate bound
!unknown-type! AVAssetDownloadTask bound
!unknown-type! AVAssetDownloadURLSession bound
!unknown-type! AVAudioInputNode bound

and we're replacing them with stubs so our binaries won't contain any of
the selectors that could be rejected by Apple on the app store

Some (new) fields are also not part of tvOS (and were not in iOS either)

!unknown-field! AVVideoCodecAppleProRes422 bound
!unknown-field! AVVideoCodecAppleProRes4444 bound
!unknown-field! AVVideoColorPrimaries_EBU_3213 bound
!unknown-field! AVVideoTransferFunction_SMPTE_240M_1995 bound
!unknown-field! AVVideoYCbCrMatrix_SMPTE_240M_1995 bound