### PR TITLE
[safariservices] Add missing [DesignatedInitializer] on SFSafariViewController

### DIFF
--- a/src/safariservices.cs
+++ b/src/safariservices.cs
@@ -69,6 +69,7 @@ namespace XamCore.SafariServices {
 		[PostGet ("NibBundle")]
 		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
+		[DesignatedInitializer]
 		[Export ("initWithURL:entersReaderIfAvailable:")]
 		IntPtr Constructor (NSUrl url, bool entersReaderIfAvailable);
 


### PR DESCRIPTION
reference:
!missing-designated-initializer! SFSafariViewController::initWithURL:entersReaderIfAvailable: is missing an [DesignatedInitializer] attribute