### PR TITLE
[metalperformanceshaders] Remove [DesignatedInitializer] from MPSMatrixMultiplication

### DIFF
--- a/src/metalperformanceshaders.cs
+++ b/src/metalperformanceshaders.cs
@@ -1119,7 +1119,6 @@ namespace XamCore.MetalPerformanceShaders {
 		[Export ("rightMatrixOrigin", ArgumentSemantic.Assign)]
 		MTLOrigin RightMatrixOrigin { get; set; }
 
-		[DesignatedInitializer]
 		[Export ("initWithDevice:transposeLeft:transposeRight:resultRows:resultColumns:interiorColumns:alpha:beta:")]
 		IntPtr Constructor (IMTLDevice device, bool transposeLeft, bool transposeRight, nuint resultRows, nuint resultColumns, nuint interiorColumns, double alpha, double beta);
 


### PR DESCRIPTION
It's the only one, so it's kind of designated, but it's not marked as
such in the header files and it's better matching them (xtro test wise)

reference:
!extra-designated-initializer! MPSMatrixMultiplication::initWithDevice:transposeLeft:transposeRight:resultRows:resultColumns:interiorColumns:alpha:beta: is incorrectly decorated with an [DesignatedInitializer] attribute