### PR TITLE
[linker] Add temporary workaround for bug #43658.

### DIFF
--- a/tools/linker/Descriptors/mscorlib.xml
+++ b/tools/linker/Descriptors/mscorlib.xml
@@ -808,6 +808,9 @@
 		<!-- by convention (and see #34671) -->
 		<type fullname="Mono.Runtime" />
 
+		<!--  this is a temporary workaround for bug #43658 -->
+		<type fullname="Mono.RuntimeStructs" preserve="fields" />
+
 		<!-- marshal.c (mono_marshal_get_native_wrapper) -->
 		<type fullname="Mono.RuntimeStructs/HandleStackMark" />
 		<!-- marshal.c (mono_marshal_get_native_wrapper) -->


### PR DESCRIPTION
The real fix for bug #43658 is in mono master, but the current
version of mono master doesn't build for us, so implement this
workaround instead.

The problem is that the linker doesn't preserve fields of nested types marked
in xml descriptions unless the declaring type is marked. So the workaround
(until we can bump mono) is to mark the declaring type.

https://bugzilla.xamarin.com/show_bug.cgi?id=43658