### PR TITLE
[CoreAnimation] Remove [Protocol] from CAAnimationDelegate. Fixes #43825.

### DIFF
--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -991,7 +991,8 @@ namespace XamCore.CoreAnimation {
 		#endregion
 	}
 
-	[Protocol] // since iOS10
+	// Adding [Protocol] breaks when building with older SDKs (see bug #43825)
+	//[Protocol] // since iOS10
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Synthetic]


### PR DESCRIPTION
See cd96e255 for a detailed description, it's the same issue with
a different type.

https://bugzilla.xamarin.com/show_bug.cgi?id=43825