### PR TITLE
[metal] Fix API based on api-diff and xtro

### DIFF
--- a/src/Metal/MTLCompat.cs
+++ b/src/Metal/MTLCompat.cs
@@ -1,0 +1,22 @@
+#if XAMCORE_2_0 || !MONOMAC
+
+using XamCore.ObjCRuntime;
+
+namespace XamCore.Metal {
+
+#if IOS || TVOS
+	public static partial class MTLRenderCommandEncoder_Extensions {
+
+		// Apple removed this in Xcode 8
+		[Introduced (PlatformName.iOS, 9,0)]
+		[Deprecated (PlatformName.iOS, 10,0, message: "Removed in iOS 10")]
+		[Introduced (PlatformName.TvOS, 9,1)]
+		[Deprecated (PlatformName.TvOS, 10,0, message: "Removed in tvOS 10")]
+		public static void SetDepthClipMode (IMTLRenderCommandEncoder This, MTLDepthClipMode depthClipMode)
+		{
+		}
+	}
+#endif
+}
+
+#endif

--- a/src/Metal/MTLEnums.cs
+++ b/src/Metal/MTLEnums.cs
@@ -670,6 +670,7 @@ namespace XamCore.Metal {
 		OpaqueWhite = 2
 	}
 
+	[NoTV]
 	[NoiOS, Mac (10,11)]
 	[Native]
 	public enum MTLPrimitiveTopologyClass : nuint {

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -900,6 +900,7 @@ METAL_CORE_SOURCES = \
 	Metal/Defs.cs \
 
 METAL_SOURCES = \
+	Metal/MTLCompat.cs \
 	Metal/MTLDevice.cs \
 	Metal/MTLArrays.cs \
 	Metal/MTLVertexDescriptor.cs \

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -1448,7 +1448,9 @@ namespace XamCore.Metal {
 		[Abstract, Export ("setCullMode:")]
 		void SetCullMode (MTLCullMode cullMode);
 
-		[iOS (9,0)][Mac (10,11, onlyOn64 : true)]
+		[Mac (10,11, onlyOn64 : true)]
+		[NoTV]
+		[NoiOS] // it was [iOS (9,0)] but now it's marked as not available on iOS in Xcode 8
 #if XAMCORE_4_0
 		// Apple added a new required member in iOS 9, but that breaks our binary compat, so we can't do that in our existing code.
 		[Abstract]


### PR DESCRIPTION
It turns out `setDepthClipMode` was removed in Xcode 8, so this needs
some manual code to maintain binary compatibility

references:
!extra-protocol-member! unexpected selector MTLRenderCommandEncoder::setDepthClipMode: found
!unknown-native-enum! MTLPrimitiveTopologyClass bound