### PR TITLE
[corebluetooth] Update availability attributes for some obsolete (removed) API

### DIFF
--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -247,10 +247,12 @@ namespace XamCore.CoreBluetooth {
 		void UpdatedState (CBCentralManager central);
 
 		[NoTV]
+		[Availability (Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_8_4)] // Available in iOS 5.0 through iOS 8.4. Deprecated in iOS 7.0.
 		[Export ("centralManager:didRetrievePeripherals:"), EventArgs ("CBPeripherals")]
 		void RetrievedPeripherals (CBCentralManager central, CBPeripheral [] peripherals);
 
 		[NoTV]
+		[Availability (Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_8_4)] // Available in iOS 5.0 through iOS 8.4. Deprecated in iOS 7.0.
 		[Export ("centralManager:didRetrieveConnectedPeripherals:"), EventArgs ("CBPeripherals")]
 		void RetrievedConnectedPeripherals (CBCentralManager central, CBPeripheral [] peripherals);
 
@@ -559,7 +561,7 @@ namespace XamCore.CoreBluetooth {
 		void WroteDescriptorValue (CBPeripheral peripheral, CBDescriptor descriptor, NSError error);
 
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_7_0)]
+		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_8_4)]
 		[Export ("peripheralDidInvalidateServices:")]
 		void InvalidatedService (CBPeripheral peripheral);	
 

--- a/tests/xtro-sharpie/ios.ignore
+++ b/tests/xtro-sharpie/ios.ignore
@@ -9,6 +9,16 @@
 !unknown-native-enum! ALAssetsGroupType bound
 
 
+# CoreBluetooth
+
+## obsoleted (removed from headers) in iOS 8.4
+!extra-protocol-member! unexpected selector CBCentralManagerDelegate::centralManager:didRetrieveConnectedPeripherals: found
+!extra-protocol-member! unexpected selector CBCentralManagerDelegate::centralManager:didRetrievePeripherals: found
+
+## obsoleted (removed from headers) in iOS 8.4
+!extra-protocol-member! unexpected selector CBPeripheralDelegate::peripheralDidInvalidateServices: found
+
+
 # CoreImage
 
 ## OSX-only API, rdar #22524785
@@ -66,6 +76,11 @@
 !missing-selector! UITableViewHeaderFooterView::tintColor not bound
 !missing-selector! UIToolbar::setTintColor: not bound
 !missing-selector! UIToolbar::tintColor not bound
+
+## static members cannot be abstract (@required) in .NET
+!incorrect-protocol-member! +UIPopoverBackgroundViewMethods::arrowBase is REQUIRED and should be abstract
+!incorrect-protocol-member! +UIPopoverBackgroundViewMethods::arrowHeight is REQUIRED and should be abstract
+!incorrect-protocol-member! +UIPopoverBackgroundViewMethods::contentViewInsets is REQUIRED and should be abstract
 
 
 # WatchConnectivity


### PR DESCRIPTION
references:
!extra-protocol-member! unexpected selector CBCentralManagerDelegate::centralManager:didRetrieveConnectedPeripherals: found
!extra-protocol-member! unexpected selector CBCentralManagerDelegate::centralManager:didRetrievePeripherals: found
!extra-protocol-member! unexpected selector CBPeripheralDelegate::peripheralDidInvalidateServices: found