### PR TITLE
Allow profiling + incremental builds on bitcode-capable targets again.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -1371,9 +1371,7 @@ install-local:: install-iphoneos
 endif
 endif
 
-ifndef ENABLE_BITCODE_ON_IOS
 LIBMONO_PROFILER_IPHONEOS_DYLIB=$(IOS_DESTDIR)$(IPHONEOS_PREFIX)/lib/libmono-profiler-log.dylib
-endif
 
 IPHONEOS_TARGETS = \
 	$(IOS_DESTDIR)$(IPHONEOS_PREFIX)/lib/libmonosgen-2.0.a                                  \
@@ -1545,11 +1543,6 @@ WATCHOS_TARGETS =                                                             \
 	$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmono-profiler-log.a       \
 	$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks/Mono.framework/Mono       \
 	$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks/Mono.framework/Info.plist \
-
-# see https://github.com/mono/mono/commit/cfd9870f8345d2e3e6354e3deebced443809ee2f
-# I think it might still be possible to do this with bitcode, but more investigation
-# is needed, so just disable for now to make the build complete.
-WATCHOS_DISABLED_TARGETS = \
 	$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmono-profiler-log.dylib   \
 
 WATCHOS_DIRECTORIES = \
@@ -1713,15 +1706,13 @@ TVOS_TARGET_SHAREDLIBLOGPROFILER = $(BUILD_DESTDIR)/targettv/lib/libmono-profile
 
 device:: tvos
 
-# See WATCHOS_DISABLED_TARGETS
-TVOS_DISABLED_TARGETS=$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib/libmono-profiler-log.dylib
-
 TVOS_TARGETS =                                                             \
 	$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib/libmonosgen-2.0.a            \
 	$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib/libmonosgen-2.0.dylib        \
 	$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib/libmono-profiler-log.a       \
 	$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks/Mono.framework/Mono       \
 	$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks/Mono.framework/Info.plist \
+	$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib/libmono-profiler-log.dylib   \
 
 TVOS_DIRECTORIES = \
 	$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks/Mono.framework \

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -862,23 +862,6 @@ namespace Xamarin.Bundler {
 
 			Namespaces.Initialize ();
 
-			var hasBitcodeCapableRuntime = false;
-			switch (Platform) {
-			case ApplePlatform.iOS:
-#if ENABLE_BITCODE_ON_IOS
-				hasBitcodeCapableRuntime = true;
-#endif
-				break;
-			case ApplePlatform.TVOS:
-			case ApplePlatform.WatchOS:
-				hasBitcodeCapableRuntime = true;
-				break;
-			}
-			if (hasBitcodeCapableRuntime && EnableProfiling && FastDev) {
-				ErrorHelper.Warning (94, "Both profiling (--profiling) and incremental builds (--fastdev) are currently not supported when building for {0}, and incremental builds have been disabled (this will be fixed in a future release).", PlatformName);
-				FastDev = false;
-			}
-
 			InitializeCommon ();
 
 			Driver.Watch ("Resolve References", 1);

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -100,7 +100,7 @@ namespace Xamarin.Bundler {
 	//					MT0091	This version of Xamarin.iOS requires the {0} {1} SDK (shipped with Xcode {2}) when the managed linker is disabled. Either upgrade Xcode, or enable the managed linker. 
 	//					MT0092	<used by Xamarin.Launcher> The option '{0}' is required.
 	//					MT0093	Could not find 'mlaunch'.
-	//		Warning		MT0094	Both profiling (--profiling) and incremental builds (--fastdev) are currently not supported when building for {0}, and incremental builds have been disabled (this will be fixed in a future release).
+	//		Warning		MT0094	<unused> Both profiling (--profiling) and incremental builds (--fastdev) are currently not supported when building for {0}, and incremental builds have been disabled (this will be fixed in a future release).
 	// MT1xxx	file copy / symlinks (project related)
 	//			MT10xx	installer.cs / mtouch.cs
 	//					MT1001	Could not find an application at the specified directory: {0}


### PR DESCRIPTION
Mono bug [#41428](https://bugzilla.xamarin.com/show_bug.cgi?id=41428) has been fixed now,
which means we have profiler dylibs again, so we can enable profiling + incremental builds again.