### PR TITLE
[xharness] Make sure a project reference's Name matches the file name of the reference. Fixes #43181.

### DIFF
--- a/tests/xharness/ProjectFileExtensions.cs
+++ b/tests/xharness/ProjectFileExtensions.cs
@@ -333,6 +333,8 @@ namespace xharness
 				var include = n.Attributes ["Include"];
 				include.Value = include.Value.Replace (".csproj", suffix + ".csproj");
 				include.Value = include.Value.Replace (".fsproj", suffix + ".fsproj");
+				var nameElement = n ["Name"];
+				nameElement.InnerText = System.IO.Path.GetFileNameWithoutExtension (include.Value);
 			}
 		}
 


### PR DESCRIPTION
Apparently XS can't find referenced project (to build them) otherwise.

It works fine when building using xbuild though.

https://bugzilla.xamarin.com/show_bug.cgi?id=43181