### PR TITLE
[messageui] Review (and add test) the enum breaking change from Apple. Fixes #42682

### DIFF
--- a/tests/monotouch-test/MessageUI/MailComposeViewControllerTest.cs
+++ b/tests/monotouch-test/MessageUI/MailComposeViewControllerTest.cs
@@ -43,6 +43,19 @@ namespace MonoTouchFixtures.MessageUI {
 				Assert.That (mail.Handle, Is.Not.EqualTo (IntPtr.Zero));
 			}
 		}
+
+		[Test]
+		public void MailComposeDelegate ()
+		{
+			if (!MFMailComposeViewController.CanSendMail)
+				Assert.Inconclusive ("Not configured to send emails");
+
+			using (var mail = new MFMailComposeViewController ()) {
+				Assert.Null (mail.MailComposeDelegate, "MailComposeDelegate");
+				mail.Finished += (sender, e) => { };
+				Assert.NotNull (mail.MailComposeDelegate, "MailComposeDelegate");
+			}
+		}
 	}
 }
 

--- a/tests/monotouch-test/MessageUI/MessageComposeViewControllerTest.cs
+++ b/tests/monotouch-test/MessageUI/MessageComposeViewControllerTest.cs
@@ -1,0 +1,48 @@
+﻿//
+// Unit tests for MFMessageComposeViewController
+//
+// Authors:
+//	Sebastien Pouliot <sebastien@xamarin.com>
+//
+// Copyright 2016 Xamarin Inc. All rights reserved.
+//
+
+#if !__TVOS__ && !__WATCHOS__
+
+using System;
+using System.Drawing;
+#if XAMCORE_2_0
+using Foundation;
+using UIKit;
+
+using MessageUI;
+#else
+using MonoTouch.Foundation;
+using MonoTouch.MessageUI;
+using MonoTouch.UIKit;
+#endif
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.MessageUI {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class MessageComposeViewControllerTest {
+
+		[Test]
+		public void MessageComposeDelegate ()
+		{
+			if (!MFMessageComposeViewController.CanSendText)
+				Assert.Inconclusive ("Not configured to send text");
+
+			using (var mail = new MFMessageComposeViewController ()) {
+				Assert.Null (mail.MessageComposeDelegate, "MessageComposeDelegate");
+				mail.Finished += (sender, e) => { };
+				Assert.NotNull (mail.MessageComposeDelegate, "MessageComposeDelegate");
+			}
+		}
+	}
+}
+
+#endif // !__TVOS__ && !__WATCHOS__
+

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -565,6 +565,7 @@
     <Compile Include="Foundation\DimensionTest.cs" />
     <Compile Include="UIKit\GraphicsRendererTest.cs" />
     <Compile Include="Intents\INIntentResolutionResultTests.cs" />
+    <Compile Include="MessageUI\MessageComposeViewControllerTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>

--- a/tests/xtro-sharpie/ios.pending
+++ b/tests/xtro-sharpie/ios.pending
@@ -139,6 +139,9 @@
 !missing-enum-native! MFMailComposeErrorCode
 !missing-enum-native! MFMailComposeResult
 !missing-enum-native! MessageComposeResult
+!wrong-enum-size! MFMailComposeErrorCode managed 4 vs native 8
+!wrong-enum-size! MFMailComposeResult managed 4 vs native 8
+!wrong-enum-size! MessageComposeResult managed 4 vs native 8
 
 
 # Speech


### PR DESCRIPTION
Xcode8 SDK changed untyped enums (always 32 bits) into NSInteger. In this
case we can continue with the existing API (and ignore them in xtro)

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=42682