### PR TITLE
[cloudkit] Fix some missing .ctor (breaking changes)

### DIFF
--- a/src/CloudKit/CKCompat.cs
+++ b/src/CloudKit/CKCompat.cs
@@ -1,13 +1,15 @@
 // Copyright 2016, Xamarin Inc. All rights reserved.
 
-#if !XAMCORE_4_0
+#if !COREBUILD
 
+using XamCore.CloudKit;
 using XamCore.ObjCRuntime;
 using XamCore.Foundation;
 using System;
 
 namespace XamCore.CloudKit {
-	
+
+#if !XAMCORE_4_0
 	public partial class CKOperation {
 
 		[Obsoleted (PlatformName.iOS, 9,3, message: "Do not use; this API was removed in iOS 9.3 and will always return 0")]
@@ -16,6 +18,49 @@ namespace XamCore.CloudKit {
 			return 0;
 		}
 	}
+
+	public partial class CKNotificationID {
+
+		[Obsolete ("This type is not meant to be created by user code")]
+		public CKNotificationID ()
+		{
+		}
+	}
+#endif
+
+#if XAMCORE_2_0
+	public partial class CKFetchNotificationChangesOperation {
+
+		// `init` does not work on watchOS but we can keep compatibility with a different init
+		public CKFetchNotificationChangesOperation () : this ((CKServerChangeToken) null)
+		{
+		}
+	}
+
+	public partial class CKModifyBadgeOperation {
+
+		// `init` does not work on watchOS but we can keep compatibility with a different init
+		public CKModifyBadgeOperation () : this (0)
+		{
+		}
+	}
+
+	public partial class CKModifyRecordZonesOperation {
+
+		// `init` does not work on watchOS but we can keep compatibility with a different init
+		public CKModifyRecordZonesOperation () : this (null, null)
+		{
+		}
+	}
+
+	public partial class CKModifyRecordsOperation {
+
+		// `init` does not work on watchOS but we can keep compatibility with a different init
+		public CKModifyRecordsOperation () : this (null, null)
+		{
+		}
+	}
+#endif
 }
 
 #endif

--- a/src/cloudkit.cs
+++ b/src/cloudkit.cs
@@ -382,6 +382,9 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (CKOperation))]
 	[DisableDefaultCtor]
+#if XAMCORE_4_0 || WATCH
+	[Abstract] // as per docs
+#endif
 	interface CKDatabaseOperation {
 
 		[Export ("database", ArgumentSemantic.Retain)] [NullAllowed]
@@ -483,7 +486,7 @@ namespace XamCore.CloudKit {
 	}
 
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
-	[DisableDefaultCtor]
+	[DisableDefaultCtor] // does not work on watchOS, working stub provided to ease source compatibility
 	[BaseType (typeof (CKOperation))]
 	interface CKFetchNotificationChangesOperation {
 		[Export ("initWithPreviousServerChangeToken:")]
@@ -633,7 +636,9 @@ namespace XamCore.CloudKit {
 	delegate void CKFetchRecordsCompletedHandler (NSDictionary recordsByRecordId, NSError error);
 
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
+#if XAMCORE_4_0 || WATCH // does not work on watchOS, existiong init* does not allow null to be used to fake it
 	[DisableDefaultCtor]
+#endif
 	[BaseType (typeof (CKDatabaseOperation))]
 	interface CKFetchRecordsOperation {
 
@@ -678,7 +683,9 @@ namespace XamCore.CloudKit {
 	delegate void CKRecordZoneCompleteHandler (NSDictionary recordZonesByZoneId, NSError operationError);
 
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
+#if XAMCORE_4_0 || WATCH // does not work on watchOS, existiong init* does not allow null to be used to fake it
 	[DisableDefaultCtor]
+#endif
 	[BaseType (typeof (CKDatabaseOperation))]
 	interface CKFetchRecordZonesOperation {
 		[Export ("initWithRecordZoneIDs:")]
@@ -729,7 +736,9 @@ namespace XamCore.CloudKit {
 	}
 
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
+#if XAMCORE_4_0 || WATCH // does not work on watchOS, existiong init* does not allow null to be used to fake it
 	[DisableDefaultCtor]
+#endif
 	[BaseType (typeof (NSSortDescriptor))]
 	interface CKLocationSortDescriptor : NSSecureCoding {
 		[DesignatedInitializer]
@@ -764,7 +773,7 @@ namespace XamCore.CloudKit {
 	}
 
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
-	[DisableDefaultCtor]
+	[DisableDefaultCtor] // does not work on watchOS, working stub provided to ease source compatibility
 	[BaseType (typeof (CKOperation))]
 	interface CKModifyBadgeOperation {
 
@@ -786,7 +795,7 @@ namespace XamCore.CloudKit {
 	delegate void CKModifyRecordsOperationHandler (CKRecord [] savedRecords, CKRecordID [] deletedRecordIds, NSError operationError);
 
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
-	[DisableDefaultCtor]
+	[DisableDefaultCtor] // does not work on watchOS, working stub provided to ease source compatibility
 	[BaseType (typeof (CKDatabaseOperation))]
 	interface CKModifyRecordsOperation {
 
@@ -838,7 +847,7 @@ namespace XamCore.CloudKit {
 	delegate void CKModifyRecordZonesHandler (CKRecordZone [] savedRecordZones, CKRecordZoneID [] deletedRecordZoneIds, NSError operationError);
 
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
-	[DisableDefaultCtor]
+	[DisableDefaultCtor] // does not work on watchOS, working stub provided to ease source compatibility
 	[BaseType (typeof (CKDatabaseOperation))]
 	interface CKModifyRecordZonesOperation {
 
@@ -890,7 +899,7 @@ namespace XamCore.CloudKit {
 	}
 
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
-	[DisableDefaultCtor]
+	[DisableDefaultCtor] // doc: <quote>You do not create notification IDs directly.</quote>
 	[BaseType (typeof (NSObject))]
 	interface CKNotificationID : NSCopying, NSSecureCoding, NSCoding {
 
@@ -900,6 +909,9 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: CKNotification is not meant for direct instantiation
 	[BaseType (typeof (NSObject))]
+#if XAMCORE_4_0 || WATCH
+	[Abstract] // as per doc
+#endif
 	interface CKNotification : NSSecureCoding {
 
 		[Export ("notificationType", ArgumentSemantic.Assign)]
@@ -1015,6 +1027,9 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSOperation))]
 	[DisableDefaultCtor] // Assertion failure in -[CKOperation init], /SourceCache/CloudKit/CloudKit-175.3/Framework/Operations/CKOperation.m:65
+#if XAMCORE_4_0 || WATCH
+	[Abstract] // as per docs
+#endif
 	interface CKOperation {
 
 		// Apple removed, without deprecation, this property in iOS 9.3 SDK
@@ -1079,7 +1094,9 @@ namespace XamCore.CloudKit {
 	}
 
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
+#if XAMCORE_4_0 || WATCH // does not work on watchOS, existiong init* does not allow null to be used to fake it
 	[DisableDefaultCtor]
+#endif
 	[BaseType (typeof (CKDatabaseOperation))]
 	interface CKQueryOperation {
 
@@ -1254,7 +1271,9 @@ namespace XamCore.CloudKit {
 
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[Watch (3,0)]
+#if XAMCORE_4_0 || WATCH // does not work on watchOS, existiong init* does not allow null to be used to fake it
 	[DisableDefaultCtor]
+#endif
 	[BaseType (typeof (NSObject))]
 	interface CKRecordZone : NSSecureCoding, NSCopying {
 
@@ -1500,7 +1519,9 @@ namespace XamCore.CloudKit {
 	[iOS (9,2), Mac (10,11,2, onlyOn64 : true)]
 	[TV (9,1)]
 	[Watch (3,0)]
+#if XAMCORE_4_0 || WATCH // does not work on watchOS - existiong init* does not allow null to be used to fake it
 	[DisableDefaultCtor]
+#endif
 	[BaseType (typeof (CKDatabaseOperation))]
 	interface CKFetchWebAuthTokenOperation {
 

--- a/tests/monotouch-test/CloudKit/CKFetchNotificationChangesOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKFetchNotificationChangesOperationTest.cs
@@ -30,16 +30,30 @@ namespace MonoTouchFixtures.CloudKit
 			op?.Dispose ();
 		}
 
+		[Test]
 		public void TestNotificationChangedSetter ()
 		{
 			op.NotificationChanged = (obj) => { Console.WriteLine ("Notification");};
 			Assert.NotNull (op.NotificationChanged);
 		}
 
+		[Test]
 		public void TestCompletedSetter ()
 		{
 			op.Completed = (arg1, arg2) => { Console.WriteLine ("Completed");};
 			Assert.NotNull (op.Completed);
+		}
+
+		[Test]
+		public void Default ()
+		{
+			// watchOS does not allow `init` so we need to ensure that our default .ctor
+			// match the existing `init*` with null values (so we can remove it)
+			using (var mrzo = new CKFetchNotificationChangesOperation ()) {
+				Assert.That (op.PreviousServerChangeToken, Is.EqualTo (mrzo.PreviousServerChangeToken), "PreviousServerChangeToken");
+				Assert.That (op.Completed, Is.EqualTo (mrzo.Completed), "Completed");
+				Assert.That (op.NotificationChanged, Is.EqualTo (mrzo.NotificationChanged), "NotificationChanged");
+			}
 		}
 	}
 }

--- a/tests/monotouch-test/CloudKit/CKModifyBadgeOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKModifyBadgeOperationTest.cs
@@ -35,5 +35,17 @@ namespace MonoTouchFixtures.CloudKit
 			op.Completed = (e) => { Console.WriteLine ("Completed");};
 			Assert.NotNull (op.Completed);
 		}
+
+		[Test]
+		public void Default ()
+		{
+			// watchOS does not allow `init` so we need to ensure that our default .ctor
+			// match the existing `init*` with null values (so we can remove it)
+			using (var def = new CKModifyBadgeOperation ())
+			using (var zr0 = new CKModifyBadgeOperation (0)) {
+				Assert.That (def.BadgeValue, Is.EqualTo (zr0.BadgeValue), "BadgeValue");
+				Assert.That (def.Completed, Is.EqualTo (zr0.Completed), "Completed");
+			}
+		}
 	}
 }

--- a/tests/monotouch-test/CloudKit/CKModifyRecordZonesOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKModifyRecordZonesOperationTest.cs
@@ -35,5 +35,17 @@ namespace MonoTouchFixtures.CloudKit
 			op.Completed = (saved, deleted, e) => { Console.WriteLine ("Completed");};
 			Assert.NotNull (op.Completed);
 		}
+
+		[Test]
+		public void Default ()
+		{
+			// watchOS does not allow `init` so we need to ensure that our default .ctor
+			// match the existing `init*` with null values (so we can remove it)
+			using (var mrzo = new CKModifyRecordZonesOperation ()) {
+				Assert.That (op.RecordZonesToSave, Is.EqualTo (mrzo.RecordZonesToSave), "RecordZonesToSave");
+				Assert.That (op.RecordZoneIdsToDelete, Is.EqualTo (mrzo.RecordZoneIdsToDelete), "RecordZoneIdsToDelete");
+				Assert.That (op.Completed, Is.EqualTo (mrzo.Completed), "Completed");
+			}
+		}
 	}
 }

--- a/tests/monotouch-test/CloudKit/CKModifyRecordsOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKModifyRecordsOperationTest.cs
@@ -49,5 +49,22 @@ namespace MonoTouchFixtures.CloudKit
 			op.Completed = (saved, deleted, e) => { Console.WriteLine ("Completed");};
 			Assert.NotNull (op.Completed);
 		}
+
+		[Test]
+		public void Default ()
+		{
+			// watchOS does not allow `init` so we need to ensure that our default .ctor
+			// match the existing `init*` with null values (so we can remove it)
+			using (var mro = new CKModifyRecordsOperation ()) {
+				Assert.That (op.Atomic, Is.EqualTo (mro.Atomic), "Atomic");
+				Assert.That (op.RecordsToSave, Is.EqualTo (mro.RecordsToSave), "RecordsToSave");
+				Assert.That (op.RecordIdsToDelete, Is.EqualTo (mro.RecordIdsToDelete), "RecordIdsToDelete");
+				Assert.That (op.SavePolicy, Is.EqualTo (mro.SavePolicy), "SavePolicy");
+				Assert.That (op.ClientChangeTokenData, Is.EqualTo (mro.ClientChangeTokenData), "ClientChangeTokenData");
+				Assert.That (op.PerRecordProgress, Is.EqualTo (mro.PerRecordProgress), "PerRecordProgress");
+				Assert.That (op.PerRecordCompletion, Is.EqualTo (mro.PerRecordCompletion), "PerRecordCompletion");
+				Assert.That (op.Completed, Is.EqualTo (mro.Completed), "Completed");
+			}
+		}
 	}
 }


### PR DESCRIPTION
Enabling CloudKit on watchOS required to remove some default .ctor that
watchOS does not _support_.

This commit fix this by either

* replacing the default .ctor with something that works across all
  platforms (best); or

* removing the default .ctor only on watchOS;

The commit also mark as abstract three existing types for watchOS (and
for XAMCORE_4_0) that were found reviewing the bindings.