### PR TITLE
[UserNotification] Fix bug 43787 localizedUserNotificationStringForKey:arguments: not bound properly

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -7139,6 +7139,12 @@ namespace XamCore.Foundation
 
 		[Export ("hasSuffix:")]
 		bool HasSuffix (NSString suffix);
+
+		// UNUserNotificationCenterSupport category
+		[iOS (10,0), Watch (3,0), NoTV, NoMac]
+		[Static]
+		[Export ("localizedUserNotificationStringForKey:arguments:")]
+		string GetLocalizedUserNotificationString (string key, [NullAllowed] NSObject [] arguments);
 	}
 
 	[StrongDictionary ("NSString")]

--- a/src/usernotifications.cs
+++ b/src/usernotifications.cs
@@ -115,18 +115,6 @@ namespace XamCore.UserNotifications {
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
-	[Unavailable (PlatformName.TvOS)]
-	[Category]
-	[BaseType (typeof (NSString))]
-	interface NSString_UNUserNotificationCenterSupport {
-
-		[Static]
-		[Export ("localizedUserNotificationStringForKey:arguments:")]
-		string GetLocalizedUserNotificationString (string key, [NullAllowed] NSObject [] arguments);
-	}
-
-	[Introduced (PlatformName.iOS, 10, 0)]
 	[Introduced (PlatformName.TvOS, 10, 0)]
 	[Introduced (PlatformName.WatchOS, 3, 0)]
 	[BaseType (typeof (NSObject))]


### PR DESCRIPTION
From https://bugzilla.xamarin.com/show_bug.cgi?id=43787:

!missing-selector! +NSString::localizedUserNotificationStringForKey:arguments: not bound

	[Category]
	[BaseType (typeof (NSString))]
	interface NSString_UNUserNotificationCenterSupport {

		[Static]
		[Export ("localizedUserNotificationStringForKey:arguments:")]
		string GetLocalizedUserNotificationString (string key, [NullAllowed] NSObject [] arguments);
	}

^ that's a static method in a category