### PR TITLE
[messages] MSMessageLayout should be an abstract type

### DIFF
--- a/src/messages.cs
+++ b/src/messages.cs
@@ -167,6 +167,7 @@ namespace XamCore.Messages {
 
 	[iOS (10,0)]
 	[BaseType (typeof(NSObject))]
+	[Abstract] // as per docs
 	[DisableDefaultCtor]
 	interface MSMessageLayout : NSCopying {}
 


### PR DESCRIPTION
> The MSMessageLayout class is an abstract base class that defines

reference:
https://developer.apple.com/reference/messages/msmessagelayout?language=objc