### PR TITLE
[AudioUnit] Fix bug 43829 - AudioUnit._AUImplementorStringFromValueCallback removed from XamMac.dll and Xamarin.Mac.dll

### DIFF
--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -2047,8 +2047,10 @@ namespace XamCore.AudioUnit
 		NetReceive 				= 0x6E726376, // 'nrcv'
 #endif
 	}
-#if !XAMCORE_4_0 && !MONOMAC && !COREBUILD
+#if !XAMCORE_4_0 && !COREBUILD
+#if XAMCORE_2_0 || !MONOMAC
 	[Obsolete ("Use AUImplementorStringFromValueCallback instead")]
 	public delegate NSString _AUImplementorStringFromValueCallback (AUParameter param, IntPtr value);
+#endif
 #endif
 }


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=43829

commit 1f207bd3f3df363cb5a74e59b93acd8eb6e1fec2 in xamarin/maccore
introduced some breaking changes, those were fixed in a later commit
but this was forgotten for Xamarin.Mac