### PR TITLE
[mtouch] Do not use the process task to execute the copy of aot files…

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1082,8 +1082,26 @@ namespace Xamarin.Bundler {
 				return;
 			if (!Directory.Exists (src)) // got no aot data
 				return;
-			var copyProcess = new MsymCopyTask (src, dest);
-			copyProcess.Execute ();
+
+			var p = new Process ();
+			p.StartInfo.UseShellExecute = false;
+			p.StartInfo.RedirectStandardOutput = true;
+			p.StartInfo.RedirectStandardError = true;
+			p.StartInfo.FileName = "mono-symbolicate";
+			p.StartInfo.Arguments = $"store-symbols \"{src}\" \"{dest}\"";
+
+			if (p.Start ()) {
+				var error = p.StandardError.ReadToEnd();
+				p.WaitForExit ();
+				if (p.ExitCode == 0)
+					return;
+				else {
+					Console.Error.WriteLine ($"Msym files could not be copied from {src} to {dest}: {error}.");
+					return;
+				}
+			}
+
+			Console.Error.WriteLine ($"Msym files could not be copied from {src} to {dest}: Could not start process.");
 		}
 
 		void BuildFinalExecutable ()
@@ -1843,29 +1861,6 @@ namespace Xamarin.Bundler {
 
 			if (Compile () != 0)
 				throw new MonoTouchException (4109, true, "Failed to compile the generated registrar code. Please file a bug report at http://bugzilla.xamarin.com");
-		}
-	}
-
-	public class MsymCopyTask : ProcessTask {
-		
-		public string Source { get; set; }
-		public string Destination { get; set; }
-		
-		public MsymCopyTask (string source, string destination)
-		{
-			Source = source;
-			Destination = destination;
-			ProcessStartInfo.FileName = "mono-symbolicate";
-			ProcessStartInfo.Arguments = $"store-symbols \"{Source}\" \"{Destination}\"";
-		}
-		
-		protected override void Build ()
-		{
-			var exit_code = base.Start ();
-			if (exit_code == 0)
-				return;
-			
-			Console.Error.WriteLine ("Msym files could not be copied from {Source} to {Destination}");
 		}
 	}
 

--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -98,9 +98,11 @@ namespace Xamarin.Bundler {
 		public void CopyMSymToDirectory (string directory)
 		{
 			string msym_src = FullPath + ".aotid.msym";
-			var dirInfo = new DirectoryInfo (msym_src);
-			if (!dirInfo.Exists) // got no aot data
+			if (!Directory.Exists (msym_src)) // got no aot data
 				return;
+			if (!Directory.Exists (directory)) {
+				Directory.CreateDirectory (directory);
+			}
 			Application.CopyMsymData (msym_src, directory);
 		}
 


### PR DESCRIPTION
Use a normal child process that blocks. Adds very little overhead since it is similar to the copy we had in c#. As you can see in the following [gist](https://gist.github.com/mandel-macaque/eb918ce3931dd30a1d847c773cfa0804) all tests pass locally as long as mono 4.6 is the system mono with the correct symbolicate command.