### PR TITLE
[tests] Fix a couple of registrar tests to work on device.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2549,7 +2549,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			static internal readonly DActionArity1V1 Handler = Invoke;
 
 			[MonoPInvokeCallback (typeof (DActionArity1V1))]
-			static unsafe void Invoke (IntPtr block, IntPtr obj)
+			public static unsafe void Invoke (IntPtr block, IntPtr obj)
 			{
 				throw new NotImplementedException ();
 			}
@@ -2563,7 +2563,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			static internal readonly DActionArity1V2 Handler = Invoke;
 
 			[MonoPInvokeCallback (typeof (DActionArity1V2))]
-			static unsafe void Invoke (IntPtr block, IntPtr obj)
+			public static unsafe void Invoke (IntPtr block, IntPtr obj)
 			{
 				throw new NotImplementedException ();
 			}
@@ -2575,12 +2575,12 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			BlockDescriptor2* descptr = (BlockDescriptor2*) blockptr->block_descriptor;
 			return Marshal.PtrToStringAuto (descptr->signature);
 		}
-
+	
 		[Test]
 		public void WithoutUserDelegateTypeAttribute ()
 		{
 			var block = new BlockLiteral ();
-			var tramp = new DActionArity1V1 ((IntPtr a, IntPtr b) => { });
+			var tramp = new DActionArity1V1 (SDActionArity1V1.Invoke);
 			Action<NSObject> del = (v) => { };
 			block.SetupBlock (tramp, del);
 			Assert.AreEqual ("v@:^v^v", GetBlockSignature (block), "a");
@@ -2591,7 +2591,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		public void WithUserDelegateTypeAttribute ()
 		{
 			var block = new BlockLiteral ();
-			var tramp = new DActionArity1V2 ((IntPtr a, IntPtr b) => { });
+			var tramp = new DActionArity1V2 (SDActionArity1V2.Invoke);
 			Action<NSObject> del = (v) => { };
 			block.SetupBlock (tramp, del);
 			Assert.AreEqual ("v@?@", GetBlockSignature (block), "a");


### PR DESCRIPTION
Fixes the following test failures:

    [FAIL] BlockSignatureTest.WithoutUserDelegateTypeAttribute : System.ExecutionEngineException : Attempting to JIT compile method '(wrapper native-to-managed) MonoTouchFixtures.ObjCRuntime.BlockSignatureTest:<WithoutUserDelegateTypeAttribute>m__0 (intptr,intptr)' while running with --aot-only. See http://docs.xamarin.com/ios/about/limitations for more information.
    	  at (wrapper managed-to-native) System.Runtime.InteropServices.Marshal:GetFunctionPointerForDelegateInternal (System.Delegate)
    	  at System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate (System.Delegate d) [0x00011] in /work/maccore/xcode8/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/src/mono/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs:1714
    	  at ObjCRuntime.BlockLiteral.SetupBlock (System.Delegate trampoline, System.Delegate userDelegate) [0x0000b] in /work/maccore/xcode8/xamarin-macios/src/ObjCRuntime/Blocks.cs:92
    	  at MonoTouchFixtures.ObjCRuntime.BlockSignatureTest.WithoutUserDelegateTypeAttribute () [0x00049] in /work/maccore/xcode8/xamarin-macios/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs:2585
    	  at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
    	  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00038] in /work/maccore/xcode8/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/src/mono/mcs/class/corlib/System.Reflection/MonoMethod.cs:309

    [FAIL] BlockSignatureTest.WithUserDelegateTypeAttribute : System.ExecutionEngineException : Attempting to JIT compile method '(wrapper native-to-managed) MonoTouchFixtures.ObjCRuntime.BlockSignatureTest:<WithUserDelegateTypeAttribute>m__2 (intptr,intptr)' while running with --aot-only. See http://docs.xamarin.com/ios/about/limitations for more information.
    	  at (wrapper managed-to-native) System.Runtime.InteropServices.Marshal:GetFunctionPointerForDelegateInternal (System.Delegate)
    	  at System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate (System.Delegate d) [0x00011] in /work/maccore/xcode8/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/src/mono/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs:1714
    	  at ObjCRuntime.BlockLiteral.SetupBlock (System.Delegate trampoline, System.Delegate userDelegate) [0x0000b] in /work/maccore/xcode8/xamarin-macios/src/ObjCRuntime/Blocks.cs:92
    	  at MonoTouchFixtures.ObjCRuntime.BlockSignatureTest.WithUserDelegateTypeAttribute () [0x00049] in /work/maccore/xcode8/xamarin-macios/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs:2596
    	  at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
    	  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00038] in /work/maccore/xcode8/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/src/mono/mcs/class/corlib/System.Reflection/MonoMethod.cs:309