### PR TITLE
[watchos] Remove AudioUnit from profile

### DIFF
--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -92,7 +92,7 @@ namespace XamCore.AudioUnit
 		Audiofile	= 3,
 		EXS24		= 4
 	}
-	
+
 	public class AudioUnitException : Exception {
 		static string Lookup (int k)
 		{
@@ -157,8 +157,6 @@ namespace XamCore.AudioUnit
 		{
 		}
 	}
-
-#if !WATCH
 
 #if !COREBUILD
 	public delegate AudioUnitStatus RenderDelegate (AudioUnitRenderActionFlags actionFlags, AudioTimeStamp timeStamp, uint busNumber, uint numberFrames, AudioBuffers data);
@@ -2080,6 +2078,4 @@ namespace XamCore.AudioUnit
 	[Obsolete ("Use AUImplementorStringFromValueCallback instead")]
 	public delegate NSString _AUImplementorStringFromValueCallback (AUParameter param, IntPtr value);
 #endif
-
-#endif // !WATCH
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -683,7 +683,6 @@ WATCHOS_EXTRA_CORE_SOURCES = \
     $(IOS_OPENTK_1_0_CORE_SOURCES)     \
     CoreVideo/CVPixelFormatType.cs     \
     AudioToolbox/AudioType.cs          \
-    AudioUnit/AudioUnit.cs             \
 
 WATCHOS_CORE_SOURCES +=           \
     $(WATCHOS_EXTRA_CORE_SOURCES) \


### PR DESCRIPTION
The types were, finally, not needed once the final AVFoundation (and
AudioToolkit / CoreAudio) API was completed.