### PR TITLE
[tests] Update monotouch-test to add version checks when executing on older iOS versions. Fixes #43920

### DIFF
--- a/tests/monotouch-test/CloudKit/CKDiscoverUserInfosOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKDiscoverUserInfosOperationTest.cs
@@ -23,6 +23,7 @@ namespace MonoTouchFixtures.CloudKit
 		[SetUp]
 		public void SetUp ()
 		{
+			TestRuntime.AssertXcodeVersion (6, 0);
 			op = new CKDiscoverUserInfosOperation (emails, recordIDs);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKFetchNotificationChangesOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKFetchNotificationChangesOperationTest.cs
@@ -21,6 +21,7 @@ namespace MonoTouchFixtures.CloudKit
 		[SetUp]
 		public void SetUp ()
 		{
+			TestRuntime.AssertXcodeVersion (6, 0);
 			op = new CKFetchNotificationChangesOperation (token);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKFetchRecordChangesOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKFetchRecordChangesOperationTest.cs
@@ -22,6 +22,7 @@ namespace MonoTouchFixtures.CloudKit
 		[SetUp]
 		public void SetUp ()
 		{
+			TestRuntime.AssertXcodeVersion (6, 0);
 			zoneID = new CKRecordZoneID ("foo", "xamarin");
 			op = new CKFetchRecordChangesOperation (zoneID, null);
 		}

--- a/tests/monotouch-test/CloudKit/CKFetchRecordZonesOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKFetchRecordZonesOperationTest.cs
@@ -21,6 +21,7 @@ namespace MonoTouchFixtures.CloudKit
 		[SetUp]
 		public void SetUp ()
 		{
+			TestRuntime.AssertXcodeVersion (6, 0);
 			op = new CKFetchRecordZonesOperation (zoneIDs);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKFetchRecordsOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKFetchRecordsOperationTest.cs
@@ -21,6 +21,7 @@ namespace MonoTouchFixtures.CloudKit
 		[SetUp]
 		public void SetUp ()
 		{
+			TestRuntime.AssertXcodeVersion (6, 0);
 			op = new CKFetchRecordsOperation (recordIDs);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKFetchSubscriptionsOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKFetchSubscriptionsOperationTest.cs
@@ -22,6 +22,7 @@ namespace MonoTouchFixtures.CloudKit
 		[SetUp]
 		public void SetUp ()
 		{
+			TestRuntime.AssertXcodeVersion (6, 0);
 			op = new CKFetchSubscriptionsOperation (ids);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKMarkNotificationsReadOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKMarkNotificationsReadOperationTest.cs
@@ -21,6 +21,7 @@ namespace MonoTouchFixtures.CloudKit
 		[SetUp]
 		public void SetUp ()
 		{
+			TestRuntime.AssertXcodeVersion (6, 0);
 			op = new CKMarkNotificationsReadOperation (notificationIDs);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKModifyBadgeOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKModifyBadgeOperationTest.cs
@@ -20,6 +20,7 @@ namespace MonoTouchFixtures.CloudKit
 		[SetUp]
 		public void SetUp ()
 		{
+			TestRuntime.AssertXcodeVersion (6, 0);
 			op = new CKModifyBadgeOperation (3);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKModifyRecordZonesOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKModifyRecordZonesOperationTest.cs
@@ -20,6 +20,7 @@ namespace MonoTouchFixtures.CloudKit
 		[SetUp]
 		public void SetUp ()
 		{
+			TestRuntime.AssertXcodeVersion (6, 0);
 			op = new CKModifyRecordZonesOperation (null, null);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKModifyRecordsOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKModifyRecordsOperationTest.cs
@@ -20,6 +20,7 @@ namespace MonoTouchFixtures.CloudKit
 		[SetUp]
 		public void SetUp ()
 		{
+			TestRuntime.AssertXcodeVersion (6, 0);
 			op = new CKModifyRecordsOperation (null, null);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKModifySubscriptionsOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKModifySubscriptionsOperationTest.cs
@@ -21,6 +21,7 @@ namespace MonoTouchFixtures.CloudKit
 		[SetUp]
 		public void SetUp ()
 		{
+			TestRuntime.AssertXcodeVersion (6, 0);
 			op = new CKModifySubscriptionsOperation (null, null);
 		}
 

--- a/tests/monotouch-test/CloudKit/CKQueryOperationTest.cs
+++ b/tests/monotouch-test/CloudKit/CKQueryOperationTest.cs
@@ -21,6 +21,7 @@ namespace MonoTouchFixtures.CloudKit
 		[SetUp]
 		public void SetUp ()
 		{
+			TestRuntime.AssertXcodeVersion (6, 0);
 			q = new CKQuery ("Foo", NSPredicate.FromFormat ("email = '@xamarin'"));
 			op = new CKQueryOperation (q);
 		}

--- a/tests/monotouch-test/Foundation/DimensionTest.cs
+++ b/tests/monotouch-test/Foundation/DimensionTest.cs
@@ -25,6 +25,12 @@ namespace MonoTouchFixtures.Foundation {
 	[Preserve (AllMembers = true)]
 	public class DimensionTest {
 
+		[SetUp]
+		public void Setup ()
+		{
+			TestRuntime.AssertXcodeVersion (8,0);
+		}
+
 		[Test]
 		public void BaseUnit ()
 		{

--- a/tests/monotouch-test/HealthKit/QuantityTypeIdentifierTest.cs
+++ b/tests/monotouch-test/HealthKit/QuantityTypeIdentifierTest.cs
@@ -43,6 +43,10 @@ namespace MonoTouchFixtures.HealthKit {
 					if (!TestRuntime.CheckXcodeVersion (7, 0))
 						continue;
 					break;
+				case HKQuantityTypeIdentifier.AppleExerciseTime:
+					if (!TestRuntime.CheckXcodeVersion (7, 3))
+						continue;
+					break;
 				case HKQuantityTypeIdentifier.DistanceWheelchair:
 				case HKQuantityTypeIdentifier.PushCount:
 					if (!TestRuntime.CheckXcodeVersion (8, 0))

--- a/tests/monotouch-test/Intents/INIntentResolutionResultTests.cs
+++ b/tests/monotouch-test/Intents/INIntentResolutionResultTests.cs
@@ -22,6 +22,12 @@ namespace MonoTouchFixtures.Intents {
 	[Preserve (AllMembers = true)]
 	public class INIntentResolutionResultTests {
 
+		[SetUp]
+		public void Setup ()
+		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+		}
+
 		[Test]
 		public void INIntentResolutionResultIsAbstractTest ()
 		{

--- a/tests/monotouch-test/Metal/MTLAttributeDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLAttributeDescriptorTest.cs
@@ -19,6 +19,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+			TestRuntime.AssertXcodeVersion (8, 0);
 			descriptor = new MTLAttributeDescriptor  ();
 		}
 		

--- a/tests/monotouch-test/Metal/MTLAttributeTest.cs
+++ b/tests/monotouch-test/Metal/MTLAttributeTest.cs
@@ -19,6 +19,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+			TestRuntime.AssertXcodeVersion (8, 0);
 			attr = new MTLAttribute ();
 		}
 		

--- a/tests/monotouch-test/Metal/MTLBufferLayoutDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLBufferLayoutDescriptorTest.cs
@@ -14,6 +14,13 @@ namespace MonoTouchFixtures.Metal {
 	
 	[TestFixture]
 	public class MTLBufferLayoutDescriptorTest {
+
+		[SetUp]
+		public void Setup ()
+		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+		}
+
 		[Test]
 		public void GetSetStrideTest ()
 		{

--- a/tests/monotouch-test/Metal/MTLFunctionConstantTest.cs
+++ b/tests/monotouch-test/Metal/MTLFunctionConstantTest.cs
@@ -14,6 +14,13 @@ namespace MonoTouchFixtures.Metal {
 	
 	[TestFixture]
 	public class MTLFunctionConstantTest {
+		
+		[SetUp]
+		public void Setup ()
+		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+		}
+
 		[Test]
 		public void GetNameTest ()
 		{

--- a/tests/monotouch-test/Metal/MTLStageInputOutputDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLStageInputOutputDescriptorTest.cs
@@ -19,6 +19,7 @@ namespace MonoTouchFixtures.Metal {
 		[SetUp]
 		public void SetUp ()
 		{
+			TestRuntime.AssertXcodeVersion (8, 0);
 			descriptor = MTLStageInputOutputDescriptor.Create ();
 		}
 		

--- a/tests/monotouch-test/UIKit/GraphicsRendererTest.cs
+++ b/tests/monotouch-test/UIKit/GraphicsRendererTest.cs
@@ -26,6 +26,12 @@ namespace MonoTouchFixtures.UIKit {
 	[Preserve (AllMembers = true)]
 	public class GraphicsRendererTest {
 
+		[SetUp]
+		public void Setup ()
+		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+		}
+
 		[Test]
 		public void BaseDefaultFormat ()
 		{


### PR DESCRIPTION
Tested with iOS 9.3, 8.4 and 6.1.

https://bugzilla.xamarin.com/show_bug.cgi?id=43920