### PR TITLE
Create iOS 32-bit dylibs with min iOS version 8.0. Fixes #43102.

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -270,10 +270,10 @@ $$(foreach arch,$$($(2)_ARCHITECTURES),$$(eval $$(call LibXamarinArchTemplate,$(
 .libs/$(1)/libxamarin$(4).x86_64.dylib: EXTRA_FLAGS=$$($(1)$(3)_COMMON_DYLIB_FLAGS)
 .libs/$(1)/libxamarin$(4).x86_64.dylib: $$(x86_64_$(1)$(3)_OBJECTS)
 
-.libs/$(1)/libxamarin$(4).armv7.dylib: EXTRA_FLAGS=$$($(1)$(3)_COMMON_DYLIB_FLAGS)
+.libs/$(1)/libxamarin$(4).armv7.dylib: EXTRA_FLAGS=$$($(1)$(3)_COMMON_DYLIB_FLAGS) -miphoneos-version-min=8.0
 .libs/$(1)/libxamarin$(4).armv7.dylib: $$(armv7_$(1)$(3)_OBJECTS)
 
-.libs/$(1)/libxamarin$(4).armv7s.dylib: EXTRA_FLAGS=$$($(1)$(3)_COMMON_DYLIB_FLAGS)
+.libs/$(1)/libxamarin$(4).armv7s.dylib: EXTRA_FLAGS=$$($(1)$(3)_COMMON_DYLIB_FLAGS) -miphoneos-version-min=8.0
 .libs/$(1)/libxamarin$(4).armv7s.dylib: $$(armv7s_$(1)$(3)_OBJECTS)
 
 .libs/$(1)/libxamarin$(4).arm64.dylib: EXTRA_FLAGS=$$($(1)$(3)_COMMON_DYLIB_FLAGS)


### PR DESCRIPTION
64-bit iOS 9+ devices have a pagesize of 16kb (even when running 32-bit apps).
This means all executable code must have sectors aligned to 16kb when running
on such devices.

The native linker uses the min iOS version to determine the sector alignment;
if min iOS version is < 8.0, then the sector alignment is 4k, otherwise 16k.

This means that when we create our 32-bit dylibs we must link them with a min
iOS version of 8.0, or they won't work on a 64-bit device in a 32-bit app (bug #43102)

So change our makefiles to link armv7[s] dylibs with min iOS version 8.0.

[1] https://bugzilla.xamarin.com/show_bug.cgi?id=43102