### PR TITLE
[generator] Let us use [Wrap] on properties returning value types (e.g. bool)

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -4794,8 +4794,10 @@ public partial class Generator : IMemberGatherer {
 				} else {
 					if (IsArrayOfWrappedType (pi.PropertyType))
 						print ("return NSArray.FromArray<{0}>({1} as NSArray);", FormatType (pi.DeclaringType, pi.PropertyType.GetElementType ()), wrap);
-					else 
-						print ("return {0} as {1}{2};", wrap, minfo.protocolize ? "I" : "/**/", FormatType (pi.DeclaringType, pi.PropertyType));
+					else if (pi.PropertyType.IsValueType)
+						print ("return ({0}) ({1});", FormatType (pi.DeclaringType, pi.PropertyType), wrap);
+					else
+						print ("return {0} as {1}{2};", wrap, minfo.protocolize ? "I" : String.Empty, FormatType (pi.DeclaringType, pi.PropertyType));
 				}
 				indent--;
 				print ("}");


### PR DESCRIPTION
The current code would not generate code that compiles. e.g.

	[Wrap ("ActionIdentifier == UNNotificationActionIdentifier.Default")]
	bool IsDefaultAction { get; }