### PR TITLE
[CallKit] Removing CXCallDirectoryProvider.BeginRequest no need for it

### DIFF
--- a/src/callkit.cs
+++ b/src/callkit.cs
@@ -251,16 +251,6 @@ namespace XamCore.CallKit {
 	[BaseType (typeof (NSObject))]
 	interface CXCallDirectoryProvider : NSExtensionRequestHandling {
 
-		// HACK: Wrapped since this will come from INSExtensionRequestHandling protocol
-		// and we avoid exporting the same selector twice
-		// From NSExtensionRequestHandling.h:
-		// 	- (void)beginRequestWithExtensionContext:(NSExtensionContext *)context;
-		// From CXCallDirectoryProvider.h:
-		// 	- (void)beginRequestWithExtensionContext:(CXCallDirectoryExtensionContext *)context;
-		// CXCallDirectoryExtensionContext is a subclass of NSExtensionContext so
-		// not an issue and we give it a better name
-		[Wrap ("BeginRequestWithExtensionContext (context)")]
-		void BeginRequest (CXCallDirectoryExtensionContext context);
 	}
 
 	interface ICXCallObserverDelegate { }


### PR DESCRIPTION
Per apple docs[1] BeginRequestWithExtensionContext is meant to be a hook
and not to be called so exposing a non virtual version of it is useless

[1]: https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSExtensionRequestHandling_Protocol/