### PR TITLE
[watchos] Remove several [Obsolete] API when alternatives exists

### DIFF
--- a/src/CloudKit/CKCompat.cs
+++ b/src/CloudKit/CKCompat.cs
@@ -9,7 +9,7 @@ using System;
 
 namespace XamCore.CloudKit {
 
-#if !XAMCORE_4_0
+#if !XAMCORE_4_0 && !WATCH
 	public partial class CKOperation {
 
 		[Obsoleted (PlatformName.iOS, 9,3, message: "Do not use; this API was removed in iOS 9.3 and will always return 0")]

--- a/src/CoreLocation/CLCompat.cs
+++ b/src/CoreLocation/CLCompat.cs
@@ -15,9 +15,9 @@ namespace XamCore.CoreLocation {
 	}
 #endif
 
-#if !XAMCORE_4_0
+#if !XAMCORE_4_0 && !WATCH
 
-#if !WATCH && !TVOS
+#if !TVOS
 	public partial class CLHeading {
 
 		[Obsolete ("Use the Description property from NSObject")]

--- a/src/Foundation/Compat.cs
+++ b/src/Foundation/Compat.cs
@@ -22,7 +22,7 @@ namespace XamCore.Foundation {
 	}
 #endif
 
-#if !XAMCORE_4_0 && (XAMCORE_2_0 || !MONOMAC)
+#if !XAMCORE_4_0 && (XAMCORE_2_0 || !MONOMAC) && !WATCH
 	public partial class NSUserActivity {
 
 		[Obsolete ("Use the constructor that allows you to set an activity type")]

--- a/src/Foundation/NSExpression.cs
+++ b/src/Foundation/NSExpression.cs
@@ -165,7 +165,7 @@ namespace XamCore.Foundation {
 			}
 		}
 		
-#if !XAMCORE_4_0
+#if !XAMCORE_4_0 && !WATCH
 		[Obsolete("ValueWithObject is deprecated, please use EvaluateWith instead.")]
 		public virtual NSExpression ExpressionValueWithObject (NSObject obj, NSMutableDictionary context) {
 			var result = EvaluateWith (obj, context);

--- a/src/Foundation/NSObject.iOS.cs
+++ b/src/Foundation/NSObject.iOS.cs
@@ -18,7 +18,7 @@ namespace XamCore.Foundation {
 	{
 #if !COREBUILD
 
-#if !XAMCORE_4_0
+#if !XAMCORE_4_0 && !WATCH
 		[Obsolete ("Use PlatformAssembly for easier code sharing across platforms")]
 		public readonly static Assembly MonoTouchAssembly = typeof (NSObject).Assembly;
 #endif

--- a/src/GameKit/GKLocalPlayerListener.cs
+++ b/src/GameKit/GKLocalPlayerListener.cs
@@ -1,4 +1,4 @@
-#if !MONOMAC
+#if !MONOMAC && !WATCH
 using System;
 using XamCore.Foundation;
 using XamCore.ObjCRuntime;

--- a/src/HomeKit/HMEnums.cs
+++ b/src/HomeKit/HMEnums.cs
@@ -537,8 +537,13 @@ namespace XamCore.HomeKit {
 		Door,
 		DoorLock,
 		Fan,
+#if !WATCH
 		[Obsolete ("Use GarageDoorOpener instead")]
 		DoorOpener,
+		GarageDoorOpener = DoorOpener,
+#else
+		GarageDoorOpener,
+#endif
 		Lightbulb,
 		Outlet,
 		ProgrammableSwitch,
@@ -547,7 +552,6 @@ namespace XamCore.HomeKit {
 		Thermostat,
 		Window,
 		WindowCovering,
-		GarageDoorOpener = DoorOpener,
 		[iOS (10,0), Watch (3,0), TV (10,0)]
 		RangeExtender,
 		[iOS (10,0), Watch (3,0), TV (10,0)]

--- a/src/ObjCRuntime/OldDynamicRegistrar.cs
+++ b/src/ObjCRuntime/OldDynamicRegistrar.cs
@@ -245,7 +245,7 @@ namespace XamCore.Registrar {
 				RegisterAttribute parent_attr = (RegisterAttribute) Attribute.GetCustomAttribute (parent_type, typeof (RegisterAttribute), false);
 				parent_name = parent_attr == null ? parent_type.FullName : parent_attr.Name ?? parent_type.FullName;
 				parent = Class.objc_getClass (parent_name);
-				if (parent == IntPtr.Zero && parent_type.Assembly != NSObject.MonoTouchAssembly) {
+				if (parent == IntPtr.Zero && parent_type.Assembly != NSObject.PlatformAssembly) {
 					bool parent_is_wrapper = parent_attr == null ? false : parent_attr.IsWrapper;
 					// Its possible as we scan that we might be derived from a type that isn't reigstered yet.
 					Register (parent_type, parent_name, parent_is_wrapper);
@@ -329,10 +329,10 @@ namespace XamCore.Registrar {
 					bool is_conforms_to_protocol;
 					bool is_model = false;
 					
-					is_conforms_to_protocol = minfo.DeclaringType.Assembly == NSObject.MonoTouchAssembly && minfo.DeclaringType.Name == "NSObject" && minfo.Name == "ConformsToProtocol";
+					is_conforms_to_protocol = minfo.DeclaringType.Assembly == NSObject.PlatformAssembly && minfo.DeclaringType.Name == "NSObject" && minfo.Name == "ConformsToProtocol";
 					
 					if (!is_conforms_to_protocol)
-						is_model = minfo.IsVirtual && ((minfo.DeclaringType != type && minfo.DeclaringType.Assembly == NSObject.MonoTouchAssembly) || (Attribute.IsDefined (minfo.DeclaringType, typeof (ModelAttribute), false)));
+						is_model = minfo.IsVirtual && ((minfo.DeclaringType != type && minfo.DeclaringType.Assembly == NSObject.PlatformAssembly) || (Attribute.IsDefined (minfo.DeclaringType, typeof (ModelAttribute), false)));
 					
 					if (is_model)
 						continue;

--- a/src/Security/SslContext.cs
+++ b/src/Security/SslContext.cs
@@ -537,6 +537,7 @@ namespace XamCore.Security {
 			return SSLContextGetTypeID ();
 		}
 
+#if !WATCH
 		[iOS(9,0)][Mac (10,11)]
 		// TODO: Headers say /* Deprecated, does nothing */ but we are not completly sure about it since there is no deprecation macro
 		// Plus they added new members to SslSessionStrengthPolicy enum opened radar://23379052 https://trello.com/c/NbdTLVD3
@@ -548,6 +549,7 @@ namespace XamCore.Security {
 			Console.WriteLine ("SetSessionStrengthPolicy is not available anymore.");
 			return SslStatus.Success;
 		}
+#endif
 
 		[iOS (10,0)][Mac (10,12)]
 		[DllImport (Constants.SecurityLibrary)]

--- a/src/UIKit/Compat.cs
+++ b/src/UIKit/Compat.cs
@@ -69,7 +69,7 @@ namespace XamCore.UIKit {
 	}
 #endif
 
-#if !XAMCORE_4_0
+#if !XAMCORE_4_0 && !WATCH
 	public partial class UIPresentationController {
 
 		[Obsolete ("Removed in iOS10. Use .ctor(UIViewController,UIViewController)")]

--- a/src/contacts.cs
+++ b/src/contacts.cs
@@ -451,7 +451,7 @@ namespace XamCore.Contacts {
 		[Protected] // we cannot use ICNKeyDescriptor as Apple (and others) can adopt it from categories
 		NSObject GetUnifiedMeContact (NSArray keys, out NSError error);
 
-#if !XAMCORE_4_0
+#if !XAMCORE_4_0 && !WATCH
 		[Obsolete ("Use the overload that takes CNContactStoreListContactsHandler instead")]
 		[Export ("enumerateContactsWithFetchRequest:error:usingBlock:")]
 		bool EnumerateContacts (CNContactFetchRequest fetchRequest, out NSError error, CNContactStoreEnumerateContactsHandler handler);

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -186,7 +186,6 @@ namespace XamCore.CoreData
 
 		[Static, Export ("insertNewObjectForEntityForName:inManagedObjectContext:")]
 #if !XAMCORE_4_0
-		[Obsolete ("Method InsertNewObjectForEntityForName is deprecated, please use InsertNewObject instead")]
 		NSObject InsertNewObjectForEntityForName (string entityName, NSManagedObjectContext context);
 #else
 		NSManagedObject InsertNewObject (string entityName, NSManagedObjectContext context);

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -3184,7 +3184,7 @@ namespace XamCore.Foundation
 		string[] CallStackSymbols { get; }
 	}
 
-#if !XAMCORE_4_0
+#if !XAMCORE_4_0 && !WATCH
 	[Obsolete("NSExpressionHandler is deprecated, please use FromFormat (string, NSObject[]) instead.")]
 	public delegate void NSExpressionHandler (NSObject evaluatedObject, NSExpression [] expressions, NSMutableDictionary context);
 #endif
@@ -3211,7 +3211,7 @@ namespace XamCore.Foundation
 		[Static, Export ("expressionWithFormat:")]
 		NSExpression FromFormat (string expressionFormat);
 
-#if !XAMCORE_4_0
+#if !XAMCORE_4_0 && !WATCH
 		[Obsolete("FromFormat (string, NSExpression[]) is deprecated, please use FromFormat (string, NSObject[]) instead.")]
 		[Static, Export ("expressionWithFormat:argumentArray:")]
 		NSExpression FromFormat (string format, NSExpression [] parameters);
@@ -3240,7 +3240,7 @@ namespace XamCore.Foundation
 		[Static, Export ("expressionForFunction:selectorName:arguments:")]
 		NSExpression FromFunction (NSExpression target, string name, NSExpression[] parameters);
 
-#if !XAMCORE_4_0
+#if !XAMCORE_4_0 && !WATCH
 		[Obsolete("FromFunction (NSExpressionHandler, NSExpression[]) is deprecated, please use FromFunction (NSExpressionCallbackHandler, NSExpression[]) instead.")]
 		[Static, Export ("expressionForBlock:arguments:")]
 		NSExpression FromFunction (NSExpressionHandler target, NSExpression[] parameters);

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -674,7 +674,7 @@ namespace XamCore.HealthKit {
 		[Export ("identifier")]
 		NSString Identifier { get; }
 
-#if XAMCORE_4_0
+#if XAMCORE_4_0 || WATCH
 		[Internal]
 #else
 		[Obsolete ("Use HKQuantityType.Create (HKQuantityTypeIdentifier)")]
@@ -684,7 +684,7 @@ namespace XamCore.HealthKit {
 		[return: NullAllowed]
 		HKQuantityType GetQuantityType (NSString hkTypeIdentifier);
 
-#if XAMCORE_4_0
+#if XAMCORE_4_0 || WATCH
 		[Internal]
 #else
 		[Obsolete ("Use HKCategoryType.Create (HKCategoryTypeIdentifier)")]
@@ -694,7 +694,7 @@ namespace XamCore.HealthKit {
 		[return: NullAllowed]
 		HKCategoryType GetCategoryType (NSString hkCategoryTypeIdentifier);
 
-#if XAMCORE_4_0
+#if XAMCORE_4_0 || WATCH
 		[Internal]
 #else
 		[Obsolete ("Use HKCharacteristicType.Create (HKCharacteristicTypeIdentifier)")]
@@ -704,7 +704,7 @@ namespace XamCore.HealthKit {
 		[return: NullAllowed]
 		HKCharacteristicType GetCharacteristicType (NSString hkCharacteristicTypeIdentifier);
 
-#if XAMCORE_4_0
+#if XAMCORE_4_0 || WATCH
 		[Internal]
 #else
 		[Obsolete ("Use HKCorrelationType.Create (HKCorrelationTypeIdentifier)")]

--- a/tests/monotouch-test/HealthKit/AnchoredObjectQueryTest.cs
+++ b/tests/monotouch-test/HealthKit/AnchoredObjectQueryTest.cs
@@ -39,7 +39,7 @@ namespace MonoTouchFixtures.HealthKit {
 		{
 			TestRuntime.AssertXcodeVersion (6, 0);
 
-			using (var t = HKObjectType.GetCategoryType (HKCategoryTypeIdentifierKey.SleepAnalysis))
+			using (var t = HKCategoryType.Create (HKCategoryTypeIdentifier.SleepAnalysis))
 #if __WATCHOS__
 			using (var aoq = new HKAnchoredObjectQuery (t, null, HKQueryAnchor.Create (HKAnchoredObjectQuery.NoAnchor), 0, delegate (HKAnchoredObjectQuery query, HKSample [] addedObjects, HKDeletedObject [] deletedObjects, HKQueryAnchor newAnchor, NSError error) {
 #else


### PR DESCRIPTION
As alternative exists it does not reduce code sharing potential but
encourage developers to use the latest (and best) API.