### PR TITLE
[intents] Use nicer `bool?` instead of NSNumber in the API

### DIFF
--- a/src/Intents/INRideOption.cs
+++ b/src/Intents/INRideOption.cs
@@ -1,0 +1,20 @@
+#if XAMCORE_2_0 && IOS
+
+using XamCore.Foundation;
+using XamCore.Intents;
+using XamCore.ObjCRuntime;
+
+namespace XamCore.Intents {
+
+	public partial class INRideOption {
+
+		// if/when we update the generator to allow this pattern we can move this back
+		// into bindings and making them virtual (not a breaking change)
+
+		public bool? UsesMeteredFare {
+			get { return _UsesMeteredFare == null ? null : (bool?) _UsesMeteredFare.BoolValue; }
+		}
+	}
+}
+
+#endif

--- a/src/Intents/INSetClimateSettingsInCarIntent.cs
+++ b/src/Intents/INSetClimateSettingsInCarIntent.cs
@@ -1,0 +1,39 @@
+#if XAMCORE_2_0 && IOS
+
+using XamCore.Foundation;
+using XamCore.Intents;
+using XamCore.ObjCRuntime;
+
+namespace XamCore.Intents {
+
+	public partial class INSetClimateSettingsInCarIntent {
+
+		public INSetClimateSettingsInCarIntent (bool? enableFan, bool? enableAirConditioner, bool? enableClimateControl, bool? enableAutoMode, INCarAirCirculationMode airCirculationMode, NSNumber fanSpeedIndex, NSNumber fanSpeedPercentage, INRelativeSetting relativeFanSpeedSetting, NSMeasurement<NSUnitTemperature> temperature, INRelativeSetting relativeTemperatureSetting, INCarSeat climateZone) :
+			this (enableFan.HasValue ? new NSNumber (enableFan.Value) : null, enableAirConditioner.HasValue ? new NSNumber (enableAirConditioner.Value) : null, 
+				enableClimateControl.HasValue ? new NSNumber (enableClimateControl.Value) : null, enableAutoMode.HasValue ? new NSNumber (enableAutoMode.Value) : null,
+				airCirculationMode, fanSpeedIndex, fanSpeedPercentage, relativeFanSpeedSetting, temperature, relativeTemperatureSetting, climateZone)
+		{
+		}
+
+		// if/when we update the generator to allow this pattern we can move this back
+		// into bindings and making them virtual (not a breaking change)
+
+		public bool? EnableFan {
+			get { return _EnableFan == null ? null : (bool?) _EnableFan.BoolValue; }
+		}
+
+		public bool? EnableAirConditioner {
+			get { return _EnableAirConditioner == null ? null : (bool?) _EnableAirConditioner.BoolValue; }
+		}
+
+		public bool? EnableClimateControl {
+			get { return _EnableClimateControl == null ? null : (bool?) _EnableClimateControl.BoolValue; }
+		}
+
+		public bool? EnableAutoMode {
+			get { return _EnableAutoMode == null ? null : (bool?) _EnableAutoMode.BoolValue; }
+		}
+	}
+}
+
+#endif

--- a/src/Intents/INSetDefrosterSettingsInCarIntent.cs
+++ b/src/Intents/INSetDefrosterSettingsInCarIntent.cs
@@ -1,0 +1,25 @@
+#if XAMCORE_2_0 && IOS
+
+using XamCore.Foundation;
+using XamCore.Intents;
+using XamCore.ObjCRuntime;
+
+namespace XamCore.Intents {
+
+	public partial class INSetDefrosterSettingsInCarIntent {
+
+		public INSetDefrosterSettingsInCarIntent (bool? enable, INCarDefroster defroster) :
+			this (enable.HasValue ? new NSNumber (enable.Value) : null, defroster)
+		{
+		}
+
+		// if/when we update the generator to allow this pattern we can move this back
+		// into bindings and making them virtual (not a breaking change)
+
+		public bool? Enable {
+			get { return _Enable == null ? null : (bool?) _Enable.BoolValue; }
+		}
+	}
+}
+
+#endif

--- a/src/Intents/INSetProfileInCarIntent.cs
+++ b/src/Intents/INSetProfileInCarIntent.cs
@@ -1,0 +1,25 @@
+#if XAMCORE_2_0 && IOS
+
+using XamCore.Foundation;
+using XamCore.Intents;
+using XamCore.ObjCRuntime;
+
+namespace XamCore.Intents {
+
+	public partial class INSetProfileInCarIntent {
+
+		public INSetProfileInCarIntent (NSNumber profileNumber, string profileLabel, bool? defaultProfile) :
+			this (profileNumber, profileLabel, defaultProfile.HasValue ? new NSNumber (defaultProfile.Value) : null)
+		{
+		}
+
+		// if/when we update the generator to allow this pattern we can move this back
+		// into bindings and making them virtual (not a breaking change)
+
+		public bool? DefaultProfile {
+			get { return _DefaultProfile == null ? null : (bool?) _DefaultProfile.BoolValue; }
+		}
+	}
+}
+
+#endif

--- a/src/Intents/INSetSeatSettingsInCarIntent.cs
+++ b/src/Intents/INSetSeatSettingsInCarIntent.cs
@@ -1,0 +1,33 @@
+#if XAMCORE_2_0 && IOS
+
+using XamCore.Foundation;
+using XamCore.Intents;
+using XamCore.ObjCRuntime;
+
+namespace XamCore.Intents {
+
+	public partial class INSetSeatSettingsInCarIntent {
+
+		public INSetSeatSettingsInCarIntent (bool? enableHeating, bool? enableCooling, bool? enableMassage, INCarSeat seat, NSNumber level, INRelativeSetting relativeLevelSetting) :
+			this (enableHeating.HasValue ? new NSNumber (enableHeating.Value) : null, enableCooling.HasValue ? new NSNumber (enableCooling.Value) : null, enableMassage.HasValue ? new NSNumber (enableMassage.Value) : null, seat, level, relativeLevelSetting)
+		{
+		}
+
+		// if/when we update the generator to allow this pattern we can move this back
+		// into bindings and making them virtual (not a breaking change)
+
+		public bool? EnableCooling {
+			get { return _EnableCooling == null ? null : (bool?) _EnableCooling.BoolValue; }
+		}
+
+		public bool? EnableHeating {
+			get { return _EnableHeating == null ? null : (bool?) _EnableHeating.BoolValue; }
+		}
+
+		public bool? EnableMassage {
+			get { return _EnableMassage == null ? null : (bool?) _EnableMassage.BoolValue; }
+		}
+	}
+}
+
+#endif

--- a/src/Intents/INStartWorkoutIntent.cs
+++ b/src/Intents/INStartWorkoutIntent.cs
@@ -1,0 +1,25 @@
+#if XAMCORE_2_0 && IOS
+
+using XamCore.Foundation;
+using XamCore.Intents;
+using XamCore.ObjCRuntime;
+
+namespace XamCore.Intents {
+
+	public partial class INStartWorkoutIntent {
+
+		public INStartWorkoutIntent (INSpeakableString workoutName, NSNumber goalValue, INWorkoutGoalUnitType workoutGoalUnitType, INWorkoutLocationType workoutLocationType, bool? isOpenEnded) :
+			this (workoutName, goalValue, workoutGoalUnitType, workoutLocationType, isOpenEnded.HasValue ? new NSNumber (isOpenEnded.Value) : null)
+		{
+		}
+
+		// if/when we update the generator to allow this pattern we can move this back
+		// into bindings and making them virtual (not a breaking change)
+
+		public bool? IsOpenEnded {
+			get { return _IsOpenEnded == null ? null : (bool?) _IsOpenEnded.BoolValue; }
+		}
+	}
+}
+
+#endif

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -821,6 +821,12 @@ IMAGEKIT_CORE_SOURCES = \
 INTENTS_SOURCES = \
 	Intents/INIntentResolutionResult.cs \
 	Intents/INPriceRange.cs \
+	Intents/INRideOption.cs \
+	Intents/INSetClimateSettingsInCarIntent.cs \
+	Intents/INSetDefrosterSettingsInCarIntent.cs \
+	Intents/INSetProfileInCarIntent.cs \
+	Intents/INSetSeatSettingsInCarIntent.cs \
+	Intents/INStartWorkoutIntent.cs \
 
 # JavaScriptCore
 

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -22,11 +22,6 @@ using UIImage = XamCore.Foundation.NSObject;
 using XamCore.UIKit;
 #endif
 
-// TODO: 	Review all FIXME [Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)] with Introspection tests on macOS 10.12
-//			Once we have this ^ we can add the same availability metadata to enums
-// TODO: 	Enhance API marked with NS_REFINED_FOR_SWIFT, we should match what Swift exposes https://gist.github.com/dalexsoto/44e363dbeeac96e67849e7c56d9fcca0
-//			This ^ will make the API prettier i.e. hiding `NSNumber EnableFan { get; }` and exposing a `bool? EnableFan { get; }` instead
-//			We could add some generator support for that instead of manually fixing case by case something like WrapAttribute but also that works on getters/setters props
 namespace XamCore.Intents {
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -2895,8 +2890,9 @@ namespace XamCore.Intents {
 		[NullAllowed, Export ("priceRange", ArgumentSemantic.Copy)]
 		INPriceRange PriceRange { get; set; }
 
+		[Internal]
 		[NullAllowed, Export ("usesMeteredFare", ArgumentSemantic.Copy)]
-		NSNumber UsesMeteredFare { get; set; }
+		NSNumber _UsesMeteredFare { get; set; }
 
 		[NullAllowed, Export ("disclaimerMessage")]
 		string DisclaimerMessage { get; set; }
@@ -3465,21 +3461,26 @@ namespace XamCore.Intents {
 	[BaseType (typeof (INIntent))]
 	interface INSetClimateSettingsInCarIntent {
 
+		[Protected]
 		[Export ("initWithEnableFan:enableAirConditioner:enableClimateControl:enableAutoMode:airCirculationMode:fanSpeedIndex:fanSpeedPercentage:relativeFanSpeedSetting:temperature:relativeTemperatureSetting:climateZone:")]
 		[DesignatedInitializer]
 		IntPtr Constructor ([NullAllowed] NSNumber enableFan, [NullAllowed] NSNumber enableAirConditioner, [NullAllowed] NSNumber enableClimateControl, [NullAllowed] NSNumber enableAutoMode, INCarAirCirculationMode airCirculationMode, [NullAllowed] NSNumber fanSpeedIndex, [NullAllowed] NSNumber fanSpeedPercentage, INRelativeSetting relativeFanSpeedSetting, [NullAllowed] NSMeasurement<NSUnitTemperature> temperature, INRelativeSetting relativeTemperatureSetting, INCarSeat climateZone);
 
+		[Internal]
 		[NullAllowed, Export ("enableFan", ArgumentSemantic.Copy)]
-		NSNumber EnableFan { get; }
+		NSNumber _EnableFan { get; }
 
+		[Internal]
 		[NullAllowed, Export ("enableAirConditioner", ArgumentSemantic.Copy)]
-		NSNumber EnableAirConditioner { get; }
+		NSNumber _EnableAirConditioner { get; }
 
+		[Internal]
 		[NullAllowed, Export ("enableClimateControl", ArgumentSemantic.Copy)]
-		NSNumber EnableClimateControl { get; }
+		NSNumber _EnableClimateControl { get; }
 
+		[Internal]
 		[NullAllowed, Export ("enableAutoMode", ArgumentSemantic.Copy)]
-		NSNumber EnableAutoMode { get; }
+		NSNumber _EnableAutoMode { get; }
 
 		[Export ("airCirculationMode", ArgumentSemantic.Assign)]
 		INCarAirCirculationMode AirCirculationMode { get; }
@@ -3568,12 +3569,14 @@ namespace XamCore.Intents {
 	[BaseType (typeof (INIntent))]
 	interface INSetDefrosterSettingsInCarIntent {
 
+		[Protected]
 		[Export ("initWithEnable:defroster:")]
 		[DesignatedInitializer]
 		IntPtr Constructor ([NullAllowed] NSNumber enable, INCarDefroster defroster);
 
+		[Internal]
 		[NullAllowed, Export ("enable", ArgumentSemantic.Copy)]
-		NSNumber Enable { get; }
+		NSNumber _Enable { get; }
 
 		[Export ("defroster", ArgumentSemantic.Assign)]
 		INCarDefroster Defroster { get; }
@@ -3663,6 +3666,7 @@ namespace XamCore.Intents {
 	[BaseType (typeof (INIntent))]
 	interface INSetProfileInCarIntent {
 
+		[Protected]
 		[Export ("initWithProfileNumber:profileLabel:defaultProfile:")]
 		[DesignatedInitializer]
 		IntPtr Constructor ([NullAllowed] NSNumber profileNumber, [NullAllowed] string profileLabel, [NullAllowed] NSNumber defaultProfile);
@@ -3673,8 +3677,9 @@ namespace XamCore.Intents {
 		[NullAllowed, Export ("profileLabel")]
 		string ProfileLabel { get; }
 
+		[Internal]
 		[NullAllowed, Export ("defaultProfile", ArgumentSemantic.Copy)]
-		NSNumber DefaultProfile { get; }
+		NSNumber _DefaultProfile { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -3782,18 +3787,22 @@ namespace XamCore.Intents {
 	[BaseType (typeof (INIntent))]
 	interface INSetSeatSettingsInCarIntent {
 
+		[Protected] // allow subclassing
 		[Export ("initWithEnableHeating:enableCooling:enableMassage:seat:level:relativeLevelSetting:")]
 		[DesignatedInitializer]
 		IntPtr Constructor ([NullAllowed] NSNumber enableHeating, [NullAllowed] NSNumber enableCooling, [NullAllowed] NSNumber enableMassage, INCarSeat seat, [NullAllowed] NSNumber level, INRelativeSetting relativeLevelSetting);
 
+		[Internal]
 		[NullAllowed, Export ("enableHeating", ArgumentSemantic.Copy)]
-		NSNumber EnableHeating { get; }
+		NSNumber _EnableHeating { get; }
 
+		[Internal]
 		[NullAllowed, Export ("enableCooling", ArgumentSemantic.Copy)]
-		NSNumber EnableCooling { get; }
+		NSNumber _EnableCooling { get; }
 
+		[Internal]
 		[NullAllowed, Export ("enableMassage", ArgumentSemantic.Copy)]
-		NSNumber EnableMassage { get; }
+		NSNumber _EnableMassage { get; }
 
 		[Export ("seat", ArgumentSemantic.Assign)]
 		INCarSeat Seat { get; }
@@ -4086,6 +4095,7 @@ namespace XamCore.Intents {
 	[BaseType (typeof (INIntent))]
 	interface INStartWorkoutIntent {
 
+		[Protected]
 		[Export ("initWithWorkoutName:goalValue:workoutGoalUnitType:workoutLocationType:isOpenEnded:")]
 		[DesignatedInitializer]
 		IntPtr Constructor ([NullAllowed] INSpeakableString workoutName, [NullAllowed] NSNumber goalValue, INWorkoutGoalUnitType workoutGoalUnitType, INWorkoutLocationType workoutLocationType, [NullAllowed] NSNumber isOpenEnded);
@@ -4102,8 +4112,9 @@ namespace XamCore.Intents {
 		[Export ("workoutLocationType", ArgumentSemantic.Assign)]
 		INWorkoutLocationType WorkoutLocationType { get; }
 
+		[Internal]
 		[NullAllowed, Export ("isOpenEnded", ArgumentSemantic.Copy)]
-		NSNumber IsOpenEnded { get; }
+		NSNumber _IsOpenEnded { get; }
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]


### PR DESCRIPTION
Note: using [Wrap] on the constructors generated incorrect (and non
compilable) code. Ideally this will be moved into the generator in
a future release and we could make the `bool?` properties virtual
then (it's not a breaking change to do so)