### PR TITLE
Remove wrong System.Private.* facades from Sdk check

### DIFF
--- a/tools/linker/MobileProfile.cs
+++ b/tools/linker/MobileProfile.cs
@@ -115,8 +115,6 @@ namespace Xamarin.Linker {
 			"System.Net.WebSockets.Client",
 			"System.Net.WebSockets",
 			"System.ObjectModel",
-			"System.Private.CoreLib.InteropServices",
-			"System.Private.CoreLib.Threading",
 			"System.Reflection.Extensions",
 			"System.Reflection.Primitives",
 			"System.Reflection.TypeExtensions",


### PR DESCRIPTION
They are no longer shipped since https://github.com/mono/mono/commit/c8c09310f9f05df8fec908adf94b5ed8e46ea2f0 and https://github.com/mono/mono/commit/c75dcf579fc29bb003bbfd9e0922bd1d9780ed28.

My understanding is that having them in the list doesn't hurt, so I didn't backport to C8, but it's good to be consistent.