### PR TITLE
[mtouch] MVID for symblication ought to be lower case and with no -

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1059,7 +1059,7 @@ namespace Xamarin.Bundler {
 			}
 		}
 
-		public static void CopyMsymData (string src, string dest)
+		public static void CopyMSymData (string src, string dest)
 		{
 			if (string.IsNullOrEmpty (src) || string.IsNullOrEmpty (dest))
 				return;
@@ -1079,7 +1079,7 @@ namespace Xamarin.Bundler {
 					if (p.ExitCode == 0)
 						return;
 					else {
-						ErrorHelper.Warning (95, $"Aot files could not be copied to the destination directory: {dest}"); 
+						ErrorHelper.Warning (95, $"Aot files could not be copied to the destination directory {dest}: {error}"); 
 						return;
 					}
 				}
@@ -1416,14 +1416,32 @@ namespace Xamarin.Bundler {
 			Driver.WriteIfDifferent (manifestPath, root.ToString ());
 		}
 
-		void CopyAssemblyData (Assembly asm, string targetDir)
+		void CopyAotData (string src, string dest)
 		{
-			var mvid = asm.AssemblyDefinition.MainModule.Mvid.ToString ().ToUpperInvariant ();
-			var assemblyDir = Path.Combine (targetDir, mvid);
-			if (!Directory.Exists (assemblyDir))
-				Directory.CreateDirectory (assemblyDir);
-			asm.CopyToDirectory (assemblyDir, reload: false, only_copy: true);
-			asm.CopyMSymToDirectory (targetDir);
+			if (string.IsNullOrEmpty (src) || string.IsNullOrEmpty (dest)) {
+				ErrorHelper.Warning (95, $"Aot files could not be copied to the destination directory {dest}"); 
+				return;
+			}
+				
+			var dir = new DirectoryInfo(src);
+			var dirs = dir.GetDirectories();
+
+			if (!dir.Exists) 
+				ErrorHelper.Warning (95, $"Aot files could not be copied to the destination directory {dest}"); 
+
+			if (!Directory.Exists(dest))
+				Directory.CreateDirectory(dest);
+				
+			var files = dir.GetFiles();
+			foreach (var file in files) {
+				var tmp = Path.Combine(dest, file.Name);
+				file.CopyTo(tmp, true);
+			}
+
+			foreach (var subdir in dirs) {
+				var tmp = Path.Combine(dest, subdir.Name);
+				CopyAotData (subdir.FullName, tmp);
+			}
 		}
 
 		public void BuildMSymDirectory ()
@@ -1432,13 +1450,25 @@ namespace Xamarin.Bundler {
 				return;
 
 			var target_directory = string.Format ("{0}.msym", AppDirectory);
+			if (!Directory.Exists (target_directory))
+				Directory.CreateDirectory (target_directory);
+
 			foreach (var target in Targets) {
-				if (!Directory.Exists (target_directory))
-					Directory.CreateDirectory (target_directory);
 				GenerateMSymManifest (target, target_directory);
+				var msymdir = Path.Combine (target.BuildDirectory, "Msym");
+				// copy aot data must be done BEFORE we do copy the msym one
+				CopyAotData (msymdir, target_directory);
+				
+				// copy all assemblies under mvid and with the dll and mdb
+				var tmpdir =  Path.Combine (msymdir, "Msym", "tmp");
+				if (!Directory.Exists (tmpdir))
+					Directory.CreateDirectory (tmpdir);
+					
 				foreach (var asm in target.Assemblies) {
-					CopyAssemblyData (asm, target_directory);
+					asm.CopyToDirectory (tmpdir, reload: false, only_copy: true);
 				}
+				// mono-symbolicate knows best
+				CopyMSymData (target_directory, tmpdir);
 			}
 		}
 

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1423,23 +1423,24 @@ namespace Xamarin.Bundler {
 				return;
 			}
 				
-			var dir = new DirectoryInfo(src);
-			var dirs = dir.GetDirectories();
-
-			if (!dir.Exists) 
+			var dir = new DirectoryInfo (src);
+			if (!dir.Exists) {
 				ErrorHelper.Warning (95, $"Aot files could not be copied to the destination directory {dest}"); 
+				return;
+			}
 
-			if (!Directory.Exists(dest))
-				Directory.CreateDirectory(dest);
+			var dirs = dir.GetDirectories ();
+			if (!Directory.Exists (dest))
+				Directory.CreateDirectory (dest);
 				
-			var files = dir.GetFiles();
+			var files = dir.GetFiles ();
 			foreach (var file in files) {
-				var tmp = Path.Combine(dest, file.Name);
-				file.CopyTo(tmp, true);
+				var tmp = Path.Combine (dest, file.Name);
+				file.CopyTo (tmp, true);
 			}
 
 			foreach (var subdir in dirs) {
-				var tmp = Path.Combine(dest, subdir.Name);
+				var tmp = Path.Combine (dest, subdir.Name);
 				CopyAotData (subdir.FullName, tmp);
 			}
 		}

--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -94,17 +94,6 @@ namespace Xamarin.Bundler {
 				Application.UpdateFile (mdb_src, mdb_target);
 			}
 		}
-		
-		public void CopyMSymToDirectory (string directory)
-		{
-			string msym_src = FullPath + ".aotid.msym";
-			if (!Directory.Exists (msym_src)) // got no aot data
-				return;
-			if (!Directory.Exists (directory)) {
-				Directory.CreateDirectory (directory);
-			}
-			Application.CopyMsymData (msym_src, directory);
-		}
 
 		public void CopyConfigToDirectory (string directory)
 		{

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -529,7 +529,7 @@ namespace Xamarin.Bundler
 				args.Append ("direct-pinvoke,");
 
 			if (app.EnableMSym) {
-				var msymdir = Quote (Path.Combine (outputDir, $"{fname}.aotid.msym"));
+				var msymdir = Quote (Path.Combine (outputDir, "Msym"));
 				args.Append ($"msym-dir={msymdir},");
 			}
 


### PR DESCRIPTION
The situation was the following. Initially we were not using the mono-symbolicate tool to copy the .dll and .mdbs to the destination directory. This change does the following:

* Ensures that we generate the aot files in the same dir rather than a dir per target.
* Copies the aot files to the final directory "{AppName}.app.msym"
* Uses the mono-symbolicate tool to copy the dlls and mdb files to the final directory.
* The manifest generation has not been changed.

With this fix we ensure that the MVID expected by mono-symbolication is correct fixing bug [43417](https://bugzilla.xamarin.com/show_bug.cgi?id=43417).

An example of the final dir is as follows:

Mandels-Pro-Work:xamarin-macios mandel$ tree ~/Desktop/HelloWorld_iPhone.app.msym/
/Users/mandel/Desktop/HelloWorld_iPhone.app.msym/
├── 0e8c5537972d4672985f1d5ec5980638
│   ├── Xamarin.iOS.dll
│   └── Xamarin.iOS.dll.mdb
├── 1a76169a10a8ef934b8a73aeb5977ee0
│   └── System.dll.msym
├── 38b7aaed099d03b5b7e227188c400225
│   └── mscorlib.dll.msym
├── 4fc7e750559cc63ebdc63bf107929edc
│   └── Xamarin.iOS.dll.msym
├── 6364756423e18f6b1824349299a8cb1f
│   └── System.dll.msym
├── 79cb41f6065be17b296773a55e1c62d2
│   └── HelloWorld_iPhone.exe.msym
├── 81ff3ca87ab43fc35042b6ba84fe72a2
│   └── mscorlib.dll.msym
├── 8f5231942fba4592b4727661a67f3b3a
│   ├── HelloWorld_iPhone.exe
│   └── HelloWorld_iPhone.exe.mdb
├── 958ce760f60ff918715a9366c0ccb2ce
│   └── Xamarin.iOS.dll.msym
├── bd26ee5c4c2f43a5b917f38a229cf5ed
│   ├── System.dll
│   └── System.dll.mdb
├── c124e0f181a342f6a521b25ce0d57683
│   ├── Xamarin.iOS.dll
│   └── Xamarin.iOS.dll.mdb
├── cb9a0f07476243578f1298f8c19ba9de
│   ├── mscorlib.dll
│   └── mscorlib.dll.mdb
├── cf04013685d212bcafc795dcd643f643
│   └── HelloWorld_iPhone.exe.msym
└── manifest.xml