### PR TITLE
[msbuild] Show proper build error when monotouch.dll doesn't exist

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -536,6 +536,9 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_DetectSdkLocations" DependsOnTargets="_ComputeTargetArchitectures">
+		<Error Text="Support for Classic applications (using monotouch.dll) is obsoleted in Xamarin.iOS 10.0+. Please migrate your project to Unified (Project > Migrate to Xamarin.iOS Unified API)."
+				Condition="'$(TargetFrameworkIdentifier)' == 'MonoTouch' And !Exists('$(MonoTouchSdkRoot)/lib/mono/2.1/monotouch.dll')"/>
+
 		<DetectSdkLocations
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"

--- a/msbuild/tests/MySingleView/AppDelegate.cs
+++ b/msbuild/tests/MySingleView/AppDelegate.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
+using Foundation;
+using UIKit;
 
 namespace MySingleView
 {

--- a/msbuild/tests/MySingleView/Main.cs
+++ b/msbuild/tests/MySingleView/Main.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
+using Foundation;
+using UIKit;
 using MyLibrary;
 
 namespace MySingleView

--- a/msbuild/tests/MySingleView/MyLibrary/MyLibrary.csproj
+++ b/msbuild/tests/MySingleView/MyLibrary/MyLibrary.csproj
@@ -6,11 +6,13 @@
     <ProductVersion>10.0.0</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{93788F78-16E5-432F-89D8-30F041C51974}</ProjectGuid>
-    <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>MyLibrary</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>MyLibrary</AssemblyName>
+    <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,13 +36,12 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
-    <Reference Include="monotouch" />
+    <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
     <Folder Include="MyLibraryFolder\" />
   </ItemGroup>
-  <Import Project="..\..\..\Xamarin.iOS.Tasks\bin\Debug\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>
     <Compile Include="TestFoo.cs" />
   </ItemGroup>
@@ -66,4 +67,5 @@
     <InterfaceDefinition Include="LibraryStoryboard.storyboard" />
     <InterfaceDefinition Include="LibrarySecondStoryboard.storyboard" />
   </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/msbuild/tests/MySingleView/MySingleView.csproj
+++ b/msbuild/tests/MySingleView/MySingleView.csproj
@@ -6,11 +6,13 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{8F2D37C2-BF1F-408A-8E7E-1B89D2126DFB}</ProjectGuid>
-    <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
     <RootNamespace>MySingleView</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>MySingleView</AssemblyName>
+    <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>
@@ -47,6 +49,7 @@
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchArch>ARMv7</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>full</DebugType>
@@ -57,6 +60,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <ConsolePause>false</ConsolePause>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
     <DebugType>full</DebugType>
@@ -69,6 +73,7 @@
     <ConsolePause>false</ConsolePause>
     <CodesignProvision>Automatic:AdHoc</CodesignProvision>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
     <DebugType>full</DebugType>
@@ -80,12 +85,13 @@
     <ConsolePause>false</ConsolePause>
     <CodesignProvision>Automatic:AppStore</CodesignProvision>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
-    <Reference Include="monotouch" />
+    <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
@@ -106,7 +112,6 @@
       <DependentUpon>MySingleViewViewController.cs</DependentUpon>
     </Compile>
   </ItemGroup>
-  <Import Project="..\..\Xamarin.iOS.Tasks\bin\Debug\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="MyLibrary\MyLibrary.csproj">
       <Project>{93788F78-16E5-432F-89D8-30F041C51974}</Project>
@@ -167,4 +172,5 @@
     <AtlasTexture Include="Resources\Archer\Archer_Attack.atlas\archer_attack_0009.png" />
     <AtlasTexture Include="Resources\Archer\Archer_Attack.atlas\archer_attack_0010.png" />
   </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/msbuild/tests/MySingleView/MySingleViewViewController.cs
+++ b/msbuild/tests/MySingleView/MySingleViewViewController.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Drawing;
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
+using CoreGraphics;
+using Foundation;
+using UIKit;
 
 namespace MySingleView
 {

--- a/msbuild/tests/MySingleView/MySingleViewViewController.designer.cs
+++ b/msbuild/tests/MySingleView/MySingleViewViewController.designer.cs
@@ -3,7 +3,7 @@
 // actions made in the Xcode designer. If it is removed, they will be lost.
 // Manual changes to this file may not be handled correctly.
 //
-using MonoTouch.Foundation;
+using Foundation;
 
 namespace MySingleView
 {

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/BindingProject.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/BindingProject.cs
@@ -13,10 +13,11 @@ namespace Xamarin.iOS.Tasks
 		{
 			Platform = platform;
 		}
+
 		[Test]
 		public void BuildTest ()
 		{
-			var mtouchPaths = SetupProjectPaths ("bindings-test", "../../../tests/", false, Platform);
+			var mtouchPaths = SetupProjectPaths ("bindings-test", "bindings-test-unified", "../../../tests/", false, Platform, "Any CPU/Debug-unified");
 
 			var proj = SetupProject (Engine, mtouchPaths ["project_csprojpath"]);
 
@@ -36,7 +37,7 @@ namespace Xamarin.iOS.Tasks
 		[Test]
 		public void FrameworkTest ()
 		{
-			var mtouchPaths = SetupProjectPaths ("bindings-test", "../../../tests/", false, Platform);
+			var mtouchPaths = SetupProjectPaths ("bindings-test", "bindings-test-unified", "../../../tests/", false, Platform, "Any CPU/Debug-unified");
 
 			var proj = SetupProject (Engine, mtouchPaths ["project_csprojpath"]);
 			AppBundlePath = mtouchPaths.AppBundlePath;

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/WatchKit.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/WatchKit.cs
@@ -26,7 +26,7 @@ namespace Xamarin.iOS.Tasks {
 		{
 			var mtouchPaths = SetupProjectPaths ("MyWatchApp", platform: Platform);
 			using (var xiproj = XIProject.Clone (mtouchPaths.ProjectPath, "MyWatchKitExtension", "MyWatchKitApp")) {
-				mtouchPaths = SetupProjectPaths ("MyWatchApp", xiproj.ProjectDirectory, platform: Platform);
+				mtouchPaths = SetupProjectPaths ("MyWatchApp", "MyWatchApp", xiproj.ProjectDirectory, platform: Platform);
 
 				var appInfoPath = Path.Combine (mtouchPaths.ProjectPath, "Info.plist");
 				var appInfoContents = File.ReadAllText (appInfoPath);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
@@ -79,8 +79,8 @@ namespace Xamarin.iOS.Tasks
 					"System.Xml.dll.mdb",
 					"System.dll",
 					"System.dll.mdb",
-					"monotouch.dll",
-					"monotouch.dll.mdb",
+					"Xamarin.iOS.dll",
+					"Xamarin.iOS.dll.mdb",
 					"mscorlib.dll",
 					"mscorlib.dll.mdb",
 					"runtime-options.plist",
@@ -145,7 +145,7 @@ namespace Xamarin.iOS.Tasks
 			Assert.IsTrue (references.Any (t => t.Include.Contains ("System.Xml")), "#3b");
 			Assert.IsTrue (references.Any (t => t.Include.Contains ("System.Core")), "#3c");
 			Assert.IsTrue (references.Any (t => t.Include.Contains ("mscorlib")), "#3d");
-			Assert.IsTrue (references.Any (t => t.Include.Contains ("monotouch")), "#3e");
+			Assert.IsTrue (references.Any (t => t.Include.Contains ("Xamarin.iOS")), "#3e");
 		}
 
 		[Test]
@@ -155,12 +155,11 @@ namespace Xamarin.iOS.Tasks
 			var references = LibraryProject.GetEvaluatedItemsByName ("ReferencePath").ToArray ();
 
 			Assert.AreEqual (5, references.Length, "#1");
-			Assert.IsTrue (references.All (t => t.Include.Contains ("2.1")), "#2");
-			Assert.IsTrue (references.Any (t => t.Include.Contains ("System")), "#3a");
-			Assert.IsTrue (references.Any (t => t.Include.Contains ("System.Xml")), "#3b");
-			Assert.IsTrue (references.Any (t => t.Include.Contains ("System.Core")), "#3c");
-			Assert.IsTrue (references.Any (t => t.Include.Contains ("mscorlib")), "#3d");
-			Assert.IsTrue (references.Any (t => t.Include.Contains ("monotouch")), "#3e");
+			Assert.IsTrue (references.Any (t => t.Include.Contains ("System")), "#2a");
+			Assert.IsTrue (references.Any (t => t.Include.Contains ("System.Xml")), "#2b");
+			Assert.IsTrue (references.Any (t => t.Include.Contains ("System.Core")), "#2c");
+			Assert.IsTrue (references.Any (t => t.Include.Contains ("mscorlib")), "#2d");
+			Assert.IsTrue (references.Any (t => t.Include.Contains ("Xamarin.iOS")), "#2e");
 		}
 
 		[Test]

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
@@ -92,7 +92,7 @@ namespace Xamarin.iOS.Tasks
 			get; set;
 		}
 
-		public ProjectPaths SetupProjectPaths (string projectName, string baseDir = "../", bool includePlatform = true, string platform = "iPhoneSimulator", string config = "Debug")
+		public ProjectPaths SetupProjectPaths (string projectName, string csprojName, string baseDir = "../", bool includePlatform = true, string platform = "iPhoneSimulator", string config = "Debug")
 		{
 			var projectPath = Path.Combine(baseDir, projectName);
 
@@ -103,9 +103,14 @@ namespace Xamarin.iOS.Tasks
 				ProjectPath = projectPath,
 				ProjectBinPath = binPath,
 				ProjectObjPath = objPath,
-				ProjectCSProjPath = Path.Combine (projectPath, projectName + ".csproj"),
+				ProjectCSProjPath = Path.Combine (projectPath, csprojName + ".csproj"),
 				AppBundlePath = Path.Combine (binPath, projectName + ".app"),
 			};
+		}
+
+		public ProjectPaths SetupProjectPaths (string projectName, string baseDir = "../", bool includePlatform = true, string platform = "iPhoneSimulator", string config = "Debug")
+		{
+			return SetupProjectPaths (projectName, projectName, baseDir, includePlatform, platform, config);
 		}
 
 		[SetUp]


### PR DESCRIPTION
Due to the deprecation of classic we needed to provide a better and single error message
rather than the countless msbuild errors you'd have because you'd be missing monotouch.dll