### PR TITLE
[VideoSubscriberAccount] Remove 'virtual' from methods that shouldn't be overridden

### DIFF
--- a/src/VideoSubscriberAccount/VSAccountManager.cs
+++ b/src/VideoSubscriberAccount/VSAccountManager.cs
@@ -14,7 +14,7 @@ using XamCore.Foundation;
 namespace XamCore.VideoSubscriberAccount {
 	public partial class VSAccountManager {
 
-		public virtual void CheckAccessStatus (VSAccountManagerAccessOptions accessOptions, Action<VSAccountAccessStatus, NSError> completionHandler)
+		public void CheckAccessStatus (VSAccountManagerAccessOptions accessOptions, Action<VSAccountAccessStatus, NSError> completionHandler)
 		{
 			if (accessOptions == null)
 				throw new ArgumentNullException (nameof (accessOptions));
@@ -24,7 +24,7 @@ namespace XamCore.VideoSubscriberAccount {
 			CheckAccessStatus (accessOptions.Dictionary, completionHandler);
 		}
 
-		public virtual Task<VSAccountAccessStatus> CheckAccessStatusAsync (VSAccountManagerAccessOptions accessOptions)
+		public Task<VSAccountAccessStatus> CheckAccessStatusAsync (VSAccountManagerAccessOptions accessOptions)
 		{
 			if (accessOptions == null)
 				throw new ArgumentNullException (nameof (accessOptions));


### PR DESCRIPTION
Methods that override a virtual method that doesn't have an `[Export]`
attribute will not be called by Objective-C, so make those methods non-virtual
to prevent confusion.

CC @dalexsoto (since you implemented this framework): any other reason for these methods to be virtual?