### PR TITLE
[cloudkit] Fix some API removal from monotouch.dll (classic)

### DIFF
--- a/tests/monotouch-test/HealthKit/CdaDocumentSampleTest.cs
+++ b/tests/monotouch-test/HealthKit/CdaDocumentSampleTest.cs
@@ -1,0 +1,45 @@
+﻿//
+// Unit tests for HKCdaDocumentSample
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@xamarin.com>
+//
+// Copyright 2016 Xamarin Inc. All rights reserved.
+//
+#if !__TVOS__
+
+using System;
+
+#if XAMCORE_2_0
+using Foundation;
+using HealthKit;
+using UIKit;
+#else
+using MonoTouch.Foundation;
+using MonoTouch.HealthKit;
+using MonoTouch.UIKit;
+#endif
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.HealthKit {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class CdaDocumentSampleTest {
+
+		[Test]
+		public void Error ()
+		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+
+			NSError error;
+			using (var d = new NSData ())
+			using (var s = HKCdaDocumentSample.Create (d, NSDate.DistantPast, NSDate.DistantFuture, null, out error)) {
+				Assert.NotNull (error, "error");
+				var details = new HKDetailedCdaErrors (error.UserInfo);
+			}
+		}
+	}
+}
+
+#endif // __TVOS__


### PR DESCRIPTION
Unit tests failed to compile for monotouch-test/classic. Those are still
compiled by mtouch-test on wrench (even if the profile is now dead)