### PR TITLE
[cloudkit] Fix some API removal from monotouch.dll (classic)

### DIFF
--- a/src/CloudKit/CKCompat.cs
+++ b/src/CloudKit/CKCompat.cs
@@ -28,7 +28,7 @@ namespace XamCore.CloudKit {
 	}
 #endif
 
-#if XAMCORE_2_0
+#if XAMCORE_2_0 || !MONOMAC
 	public partial class CKFetchNotificationChangesOperation {
 
 		// `init` does not work on watchOS but we can keep compatibility with a different init


### PR DESCRIPTION
Unit tests failed to compile for monotouch-test/classic. Those are still
compiled by mtouch-test on wrench (even if the profile is now dead)