### PR TITLE
[healthkit] Change binding for HKDetailedCdaErrors

### DIFF
--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -171,7 +171,8 @@ namespace XamCore.HealthKit {
 		NSString CdaCustodianName { get; }
 	}
 
-	[Watch (3,0), iOS (10,0)]
+	[NoWatch] // headers says it's available but it's only usable from another, unavailable, type
+	[iOS (10,0)]
 	[Static]
 	[Internal]
 	public interface HKDetailedCdaErrorKeys {
@@ -179,7 +180,8 @@ namespace XamCore.HealthKit {
 		NSString ValidationErrorKey { get; }
 	}
 
-	[Watch (3,0), iOS (10,0)]
+	[NoWatch]
+	[iOS (10,0)]
 	[StrongDictionary ("HKDetailedCdaErrorKeys")]
 	[Internal]
 	public interface HKDetailedCdaErrors {

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -173,11 +173,19 @@ namespace XamCore.HealthKit {
 
 	[Watch (3,0), iOS (10,0)]
 	[Static]
-	public interface HKDetailedCdaErrors {
+	[Internal]
+	public interface HKDetailedCdaErrorKeys {
 		[Field ("HKDetailedCDAValidationErrorKey")]
 		NSString ValidationErrorKey { get; }
 	}
-	
+
+	[Watch (3,0), iOS (10,0)]
+	[StrongDictionary ("HKDetailedCdaErrorKeys")]
+	[Internal]
+	public interface HKDetailedCdaErrors {
+		NSString ValidationError { get; }
+	}
+
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;

--- a/tests/monotouch-test/HealthKit/CdaDocumentSampleTest.cs
+++ b/tests/monotouch-test/HealthKit/CdaDocumentSampleTest.cs
@@ -1,0 +1,46 @@
+﻿//
+// Unit tests for HKCdaDocumentSample
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@xamarin.com>
+//
+// Copyright 2016 Xamarin Inc. All rights reserved.
+//
+#if !__TVOS__
+
+using System;
+
+#if XAMCORE_2_0
+using Foundation;
+using HealthKit;
+using UIKit;
+#else
+using MonoTouch.Foundation;
+using MonoTouch.HealthKit;
+using MonoTouch.UIKit;
+#endif
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.HealthKit {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class CdaDocumentSampleTest {
+
+		[Test]
+		public void Error ()
+		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+
+			NSError error;
+			using (var d = new NSData ())
+			using (var s = HKCdaDocumentSample.Create (d, NSDate.DistantPast, NSDate.DistantFuture, (NSDictionary) null, out error)) {
+				Assert.NotNull (error, "error");
+				var details = new HKDetailedCdaErrors (error.UserInfo);
+				Assert.That (details.ValidationError.Length, Is.EqualTo (0), "Length");
+			}
+		}
+	}
+}
+
+#endif // __TVOS__

--- a/tests/monotouch-test/HealthKit/CdaDocumentSampleTest.cs
+++ b/tests/monotouch-test/HealthKit/CdaDocumentSampleTest.cs
@@ -6,7 +6,7 @@
 //
 // Copyright 2016 Xamarin Inc. All rights reserved.
 //
-#if !__TVOS__
+#if __IOS__
 
 using System;
 
@@ -43,4 +43,4 @@ namespace MonoTouchFixtures.HealthKit {
 	}
 }
 
-#endif // __TVOS__
+#endif // __IOS__

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -572,6 +572,7 @@
     <Compile Include="GameplayKit\GKNoiseMapTests.cs" />
     <Compile Include="GameplayKit\GKNoiseTests.cs" />
     <Compile Include="CoreMidi\MidiEndpointTest.cs" />
+    <Compile Include="HealthKit\CdaDocumentSampleTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
* Hide [Fields]
* Easier access to the information from NSError
* Unit test (mostly to make sure of the returned type)