### PR TITLE
[generator] Fix some CWL warnings that generator emits

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -2386,6 +2386,9 @@ public partial class Generator : IMemberGatherer {
 
 	void DeclareInvoker (MethodInfo mi)
 	{
+		if (HasAttribute (mi, typeof (WrapAttribute)))
+			return;
+
 		try {
 			if (Compat) {
 				bool arm_stret = ArmNeedStret (mi);
@@ -2421,9 +2424,8 @@ public partial class Generator : IMemberGatherer {
 					}
 				}
 			}
-		} catch {
-			string m = mi.ToString ();
-			Console.WriteLine ("   in Method: {0}::{1}", mi.DeclaringType.FullName, m.Substring (m.IndexOf (' ') + 1));
+		} catch (BindingException ex) {
+			throw ex;
 		}
 	}
 	static char [] invalid_selector_chars = new char [] { '*', '^', '(', ')' };


### PR DESCRIPTION
When using WrapAttribute on methods generator still tries to create
signatures to interop with ObjC which is incorrect since the pruppose
of Wrap attribute is to create nicer signatures on top of an "ugly"
API so user gets a delightful coding experience.

When generator tries to create a signature for a decorated method with
WrapAttribute to interop with objc and the signature contains a NET Type
(i.e System.Type) it throws a BindingException but it was swallowed
by a try/catch that only printed a not so useful description of the
the problem. Now it throws the actual BindingException when it really
does not know how to create a signature to interop with ObjC on a
*not* decorated method with WrapAttribute.

This change will remove some unused Dllimports that were incorrectly generated by
the old behaviour. (already double checked)

build diff: https://gist.github.com/dalexsoto/b24fb3308e6c82a7e8e50c398bde706f