### PR TITLE
[cloudkit] Some fixes after auditing

### DIFF
--- a/src/CloudKit/CKUserIdentityLookupInfo.cs
+++ b/src/CloudKit/CKUserIdentityLookupInfo.cs
@@ -10,37 +10,24 @@ namespace XamCore.CloudKit
 
 	public partial class CKUserIdentityLookupInfo
 	{
-		enum CKUserIdentityLookupInfoParamType {
-			EmailAddress,
-			PhoneNumber
-		};
-
-		CKUserIdentityLookupInfo (string data, CKUserIdentityLookupInfoParamType type)
+		// extra, unused, parameter to get a unique signature
+		CKUserIdentityLookupInfo (IntPtr handle, int unused)
 		{
-			switch (type) {
-			case CKUserIdentityLookupInfoParamType.EmailAddress:
-				Handle = _FromEmail (data);
-				break;
-			case CKUserIdentityLookupInfoParamType.PhoneNumber:
-				Handle = _FromPhoneNumber (data);
-				break;
-			default:
-				throw new ArgumentException ("type");
-			}
+			InitializeHandle (handle);
 		}
 
 		public static CKUserIdentityLookupInfo FromEmail (string email)
 		{
 			if (string.IsNullOrEmpty (email))
 				throw new ArgumentNullException (nameof (email));
-			return new CKUserIdentityLookupInfo (email, CKUserIdentityLookupInfoParamType.EmailAddress);
+			return new CKUserIdentityLookupInfo (_FromEmail (email), 0);
 		}
 
 		public static CKUserIdentityLookupInfo FromPhoneNumber (string phoneNumber)
 		{
 			if (string.IsNullOrEmpty (phoneNumber))
 				throw new ArgumentNullException (nameof (phoneNumber));
-			return new CKUserIdentityLookupInfo (phoneNumber, CKUserIdentityLookupInfoParamType.PhoneNumber);
+			return new CKUserIdentityLookupInfo (_FromPhoneNumber (phoneNumber), 0);
 		}
 	}
 #endif

--- a/src/CloudKit/CKUserIdentityLookupInfo.cs
+++ b/src/CloudKit/CKUserIdentityLookupInfo.cs
@@ -10,24 +10,25 @@ namespace XamCore.CloudKit
 
 	public partial class CKUserIdentityLookupInfo
 	{
-		// extra, unused, parameter to get a unique signature
-		CKUserIdentityLookupInfo (IntPtr handle, int unused)
+		// extra parameter to get a unique signature for a string argument
+		CKUserIdentityLookupInfo (string id, int type)
 		{
-			InitializeHandle (handle);
+			var h = type == 0 ? _FromEmail (id) : _FromPhoneNumber (id);
+			InitializeHandle (h);
 		}
 
 		public static CKUserIdentityLookupInfo FromEmail (string email)
 		{
 			if (string.IsNullOrEmpty (email))
 				throw new ArgumentNullException (nameof (email));
-			return new CKUserIdentityLookupInfo (_FromEmail (email), 0);
+			return new CKUserIdentityLookupInfo (email, 0);
 		}
 
 		public static CKUserIdentityLookupInfo FromPhoneNumber (string phoneNumber)
 		{
 			if (string.IsNullOrEmpty (phoneNumber))
 				throw new ArgumentNullException (nameof (phoneNumber));
-			return new CKUserIdentityLookupInfo (_FromPhoneNumber (phoneNumber), 0);
+			return new CKUserIdentityLookupInfo (phoneNumber, 1);
 		}
 	}
 #endif

--- a/src/CloudKit/Enums.cs
+++ b/src/CloudKit/Enums.cs
@@ -102,7 +102,7 @@ namespace XamCore.CloudKit
 		Query = 1,
 		RecordZone = 2,
 		ReadNotification = 3,
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12)] Database = 4,
+		[iOS (10,0), TV (10,0), Mac (10,12)] Database = 4,
 	}
 
 	// NSInteger -> CKNotification.h
@@ -146,7 +146,7 @@ namespace XamCore.CloudKit
 	public enum CKSubscriptionType : nint {
 		Query = 1,
 		RecordZone = 2,
-		[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12)] Database = 3,
+		[iOS (10,0), TV (10,0), Mac (10,12)] Database = 3,
 	}
 
 	// NSInteger -> CKSubscription.h

--- a/src/cloudkit.cs
+++ b/src/cloudkit.cs
@@ -1162,11 +1162,11 @@ namespace XamCore.CloudKit {
 
 		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Field ("CKRecordParentKey")]
-		NSString RecordParentKey { get; }
+		NSString ParentKey { get; }
 
 		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Field ("CKRecordShareKey")]
-		NSString RecordShareKey { get; }
+		NSString ShareKey { get; }
 
 		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Field ("CKRecordTypeShare")]


### PR DESCRIPTION
* Fix and simplify CKUserIdentityLookupInfo creation from email / phone#
	* Call InitializeHandle to "handle" null handles (and throw instead of
	  crashing)
	* Reduce internal metadata (and code) to create them

* CKNotificationType: Remove extra [Watch (3,0)] on member (all new in 3.0)

* CKSubscriptionType: Fix inconsistency in wrt watchOS (type not available)

* CKRecord: Remove `Record` prefix from new fields (consistency)