### PR TITLE
[runtime] Use printf on watchOS, NSLog doesn't shown up (by default)

### DIFF
--- a/runtime/mono-runtime.m.t4
+++ b/runtime/mono-runtime.m.t4
@@ -22,6 +22,8 @@
 #include "xamarin/main.h"
 #include "xamarin/mono-runtime.h"
 #include "xamarin/runtime.h"
+#include "product.h"
+#include "runtime-internal.h"
 
 <# foreach (var export in exports) { #>
 typedef <#= export.ReturnType #> (* <#= export.EntryPoint #>_def) (<#= export.ArgumentSignature #>);
@@ -97,7 +99,7 @@ xamarin_initialize_dynamic_runtime (const char *mono_runtime_prefix)
 	if (libmono == NULL) {
 		const char *dlopen_err = dlerror ();
 		if (dlopen_err != NULL)
-			NSLog (@": dlopen error: %s", dlopen_err);
+			PRINT (PRODUCT ": dlopen error: %s", dlopen_err);
 		return "This application requires the Mono framework.";
 	}
 

--- a/runtime/monotouch-debug.m
+++ b/runtime/monotouch-debug.m
@@ -363,7 +363,7 @@ void sdb_connect (const char *address)
 	MONO_EXIT_GC_UNSAFE;
 	
 	if (!shaked)
-		NSLog (@PRODUCT ": Handshake error with IDE.");
+		PRINT (PRODUCT ": Handshake error with IDE.");
 
 	return;
 }
@@ -453,7 +453,7 @@ int monotouch_connect_wifi (NSMutableArray *ips)
 	long flags;
 	
 	if (ip_count == 0) {
-		NSLog (@PRODUCT ": No IPs to connect to.");
+		PRINT (PRODUCT ": No IPs to connect to.");
 		return 2;
 	}
 	
@@ -485,13 +485,13 @@ int monotouch_connect_wifi (NSMutableArray *ips)
 				sin6->sin6_port = htons (listen_port);
 				family_str = "IPv6";
 			} else {
-				NSLog (@PRODUCT ": Error parsing '%s': %s", ip, errno ? strerror (errno) : "unsupported address type");
+				PRINT (PRODUCT ": Error parsing '%s': %s", ip, errno ? strerror (errno) : "unsupported address type");
 				sockets[i] = -1;
 				continue;
 			}
 			
 			if ((sockets[i] = socket (family, SOCK_STREAM, IPPROTO_TCP)) == -1) {
-				NSLog (@PRODUCT ": Failed to create %s socket: %s", family_str, strerror (errno));
+				PRINT (PRODUCT ": Failed to create %s socket: %s", family_str, strerror (errno));
 				continue;
 			}
 			
@@ -507,7 +507,7 @@ int monotouch_connect_wifi (NSMutableArray *ips)
 			}
 			
 			if (rv < 0 && errno != EINPROGRESS) {
-				NSLog (@PRODUCT ": Failed to connect to %s on port %d: %s", ip, listen_port, strerror (errno));
+				PRINT (PRODUCT ": Failed to connect to %s on port %d: %s", ip, listen_port, strerror (errno));
 				close (sockets[i]);
 				sockets[i] = -1;
 				continue;
@@ -553,7 +553,7 @@ int monotouch_connect_wifi (NSMutableArray *ips)
 					continue;
 				
 				// irrecoverable error
-				NSLog (@PRODUCT ": Error while waiting for connections: %s", strerror (errno));
+				PRINT (PRODUCT ": Error while waiting for connections: %s", strerror (errno));
 				free (sockets);
 				return 1;
 			}
@@ -577,7 +577,7 @@ int monotouch_connect_wifi (NSMutableArray *ips)
 				
 				// okay, this socket is ready for reading or writing...
 				if (getsockopt (sockets[i], SOL_SOCKET, SO_ERROR, &error, &optlen) < 0) {
-					NSLog (@PRODUCT ": Error while trying to get socket options for %s: %s", [[ips objectAtIndex:i] UTF8String], strerror (errno));
+					PRINT (PRODUCT ": Error while trying to get socket options for %s: %s", [[ips objectAtIndex:i] UTF8String], strerror (errno));
 					close (sockets[i]);
 					sockets[i] = -1;
 					waiting--;
@@ -585,7 +585,7 @@ int monotouch_connect_wifi (NSMutableArray *ips)
 				}
 				
 				if (error != 0) {
-					NSLog (@PRODUCT ": Socket error while connecting to IDE on %s:%d: %s", [[ips objectAtIndex:i] UTF8String], listen_port, strerror (error));
+					PRINT (PRODUCT ": Socket error while connecting to IDE on %s:%d: %s", [[ips objectAtIndex:i] UTF8String], listen_port, strerror (error));
 					close (sockets[i]);
 					sockets[i] = -1;
 					waiting--;
@@ -640,13 +640,13 @@ int monotouch_connect_usb ()
 	// Create the listen socket and set it up
 	listen_socket = socket (PF_INET, SOCK_STREAM, IPPROTO_TCP);
 	if (listen_socket == -1) {
-		NSLog (@PRODUCT ": Could not create socket for the IDE to connect to: %s", strerror (errno));
+		PRINT (PRODUCT ": Could not create socket for the IDE to connect to: %s", strerror (errno));
 		return 1;
 	}
 	
 	flags = 1;
 	if (setsockopt (listen_socket, SOL_SOCKET, SO_REUSEADDR, &flags, sizeof (flags)) == -1) {
-		NSLog (@PRODUCT ": Could not set SO_REUSEADDR on the listening socket (%s)", strerror (errno));
+		PRINT (PRODUCT ": Could not set SO_REUSEADDR on the listening socket (%s)", strerror (errno));
 		// not a fatal failure
 	}
 	
@@ -657,7 +657,7 @@ int monotouch_connect_usb ()
 	listen_addr.sin_addr.s_addr = INADDR_ANY;
 	rv = bind (listen_socket, (struct sockaddr *) &listen_addr, sizeof (listen_addr));
 	if (rv == -1) {
-		NSLog (@PRODUCT ": Could not bind to address: %s", strerror (errno));
+		PRINT (PRODUCT ": Could not bind to address: %s", strerror (errno));
 		rv = 2;
 		goto cleanup;
 	}
@@ -669,7 +669,7 @@ int monotouch_connect_usb ()
 
 	rv = listen (listen_socket, 1);
 	if (rv == -1) {
-		NSLog (@PRODUCT ": Could not listen for the IDE: %s", strerror (errno));
+		PRINT (PRODUCT ": Could not listen for the IDE: %s", strerror (errno));
 		rv = 2;
 		goto cleanup;
 	}
@@ -712,7 +712,7 @@ int monotouch_connect_usb ()
 		} while (rv == -1 && errno == EINTR);
 
 		if (rv == -1) {
-			NSLog (@PRODUCT ": Failed while waiting for the IDE to connect: %s", strerror (errno));
+			PRINT (PRODUCT ": Failed while waiting for the IDE to connect: %s", strerror (errno));
 			rv = 2;
 			goto cleanup;
 		}
@@ -720,14 +720,14 @@ int monotouch_connect_usb ()
 		len = sizeof (struct sockaddr_in);
 		fd = accept (listen_socket, (struct sockaddr *) &listen_addr, &len);
 		if (fd == -1) {
-			NSLog (@PRODUCT ": Failed to accept connection from the IDE: %s", strerror (errno));
+			PRINT (PRODUCT ": Failed to accept connection from the IDE: %s", strerror (errno));
 			rv = 3;
 			goto cleanup;
 		}
 
 		flags = 1;
 		if (setsockopt (fd, IPPROTO_TCP, TCP_NODELAY, (char *) &flags, sizeof (flags)) < 0) {
-			NSLog (@PRODUCT ": Could not set TCP_NODELAY on socket (%s)", strerror (errno));
+			PRINT (PRODUCT ": Could not set TCP_NODELAY on socket (%s)", strerror (errno));
 			// not a fatal failure
 		}
 
@@ -960,12 +960,12 @@ int monotouch_debug_listen (int debug_port, int output_port)
 	// Create the listen socket and set it up
 	listen_socket = socket (PF_INET, SOCK_STREAM, IPPROTO_TCP);
 	if (listen_socket == -1) {
-		NSLog (@PRODUCT ": Could not create socket for the IDE to connect to: %s", strerror (errno));
+		PRINT (PRODUCT ": Could not create socket for the IDE to connect to: %s", strerror (errno));
 		return 1;
 	} else {
 		flag = 1;
 		if (setsockopt (listen_socket, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof (flag)) == -1) {
-			NSLog (@PRODUCT ": Could not set SO_REUSEADDR on the listening socket (%s)", strerror (errno));
+			PRINT (PRODUCT ": Could not set SO_REUSEADDR on the listening socket (%s)", strerror (errno));
 			// not a fatal failure
 		}
 
@@ -975,7 +975,7 @@ int monotouch_debug_listen (int debug_port, int output_port)
 		listen_addr.sin_addr.s_addr = INADDR_ANY;
 		rv = bind (listen_socket, (struct sockaddr *) &listen_addr, sizeof (listen_addr));
 		if (rv == -1) {
-			NSLog (@PRODUCT ": Could not bind to address: %s", strerror (errno));
+			PRINT (PRODUCT ": Could not bind to address: %s", strerror (errno));
 			close (listen_socket);
 			return 2;
 		} else {
@@ -986,7 +986,7 @@ int monotouch_debug_listen (int debug_port, int output_port)
 
 			rv = listen (listen_socket, 1);
 			if (rv == -1) {
-				NSLog (@PRODUCT ": Could not listen for the IDE: %s", strerror (errno));
+				PRINT (PRODUCT ": Could not listen for the IDE: %s", strerror (errno));
 				close (listen_socket);
 				return 2;
 			} else {
@@ -1004,14 +1004,14 @@ int monotouch_debug_listen (int debug_port, int output_port)
 	do {
 		if ((rv = select (listen_socket + 1, &rset, NULL, NULL, &tv)) == 0) {
 			// timeout hit, no connections available.
-			NSLog (@PRODUCT ": Listened for connections from the IDE for 2 seconds, nobody connected.");
+			PRINT (PRODUCT ": Listened for connections from the IDE for 2 seconds, nobody connected.");
 			close (listen_socket);
 			return 3;
 		}
 	} while (rv == -1 && errno == EINTR);
 	
 	if (rv == -1) {
-		NSLog (@PRODUCT ": Failed while waiting for the IDE to connect: %s", strerror (errno));
+		PRINT (PRODUCT ": Failed while waiting for the IDE to connect: %s", strerror (errno));
 		close (listen_socket);
 		return 2;
 	}
@@ -1019,14 +1019,14 @@ int monotouch_debug_listen (int debug_port, int output_port)
 	len = sizeof (struct sockaddr_in);
 	output_socket = accept (listen_socket, (struct sockaddr *) &listen_addr, &len);
 	if (output_socket == -1) {
-		NSLog (@PRODUCT ": Failed to accept connection from the IDE: %s", strerror (errno));
+		PRINT (PRODUCT ": Failed to accept connection from the IDE: %s", strerror (errno));
 		close (listen_socket);
 		return 3;
 	}
 
 	flag = 1;
 	if (setsockopt (output_socket, IPPROTO_TCP, TCP_NODELAY, (char *) &flag, sizeof (flag)) < 0) {
-		NSLog (@PRODUCT ": Could not set TCP_NODELAY on socket (%s)", strerror (errno));
+		PRINT (PRODUCT ": Could not set TCP_NODELAY on socket (%s)", strerror (errno));
 		// not a fatal failure
 	}
 		
@@ -1065,7 +1065,7 @@ int monotouch_debug_connect (NSMutableArray *ips, int debug_port, int output_por
 	long flags;
 	
 	if (ip_count == 0) {
-		NSLog (@PRODUCT ": No IPs to connect to.");
+		PRINT (PRODUCT ": No IPs to connect to.");
 		return 2;
 	}
 	
@@ -1092,13 +1092,13 @@ int monotouch_debug_connect (NSMutableArray *ips, int debug_port, int output_por
 			sin6->sin6_port = htons (output_port);
 			family_str = "IPv6";
 		} else {
-			NSLog (@PRODUCT ": Error parsing '%s': %s", ip, errno ? strerror (errno) : "unsupported address type");
+			PRINT (PRODUCT ": Error parsing '%s': %s", ip, errno ? strerror (errno) : "unsupported address type");
 			sockets[i] = -1;
 			continue;
 		}
 		
 		if ((sockets[i] = socket (family, SOCK_STREAM, IPPROTO_TCP)) == -1) {
-			NSLog (@PRODUCT ": Failed to create %s socket: %s", family_str, strerror (errno));
+			PRINT (PRODUCT ": Failed to create %s socket: %s", family_str, strerror (errno));
 			continue;
 		}
 		
@@ -1114,7 +1114,7 @@ int monotouch_debug_connect (NSMutableArray *ips, int debug_port, int output_por
 		}
 		
 		if (rv < 0 && errno != EINPROGRESS) {
-			NSLog (@PRODUCT ": Failed to connect to %s on port %d: %s", ip, output_port, strerror (errno));
+			PRINT (PRODUCT ": Failed to connect to %s on port %d: %s", ip, output_port, strerror (errno));
 			close (sockets[i]);
 			sockets[i] = -1;
 			continue;
@@ -1160,7 +1160,7 @@ int monotouch_debug_connect (NSMutableArray *ips, int debug_port, int output_por
 				continue;
 			
 			// irrecoverable error
-			NSLog (@PRODUCT ": Error while waiting for connections: %s", strerror (errno));
+			PRINT (PRODUCT ": Error while waiting for connections: %s", strerror (errno));
 			free (sockets);
 			return 1;
 		}
@@ -1184,7 +1184,7 @@ int monotouch_debug_connect (NSMutableArray *ips, int debug_port, int output_por
 			
 			// okay, this socket is ready for reading or writing...
 			if (getsockopt (sockets[i], SOL_SOCKET, SO_ERROR, &error, &optlen) < 0) {
-				NSLog (@PRODUCT ": Error while trying to get socket options for %s: %s", [[ips objectAtIndex:i] UTF8String], strerror (errno));
+				PRINT (PRODUCT ": Error while trying to get socket options for %s: %s", [[ips objectAtIndex:i] UTF8String], strerror (errno));
 				close (sockets[i]);
 				sockets[i] = -1;
 				waiting--;
@@ -1192,7 +1192,7 @@ int monotouch_debug_connect (NSMutableArray *ips, int debug_port, int output_por
 			}
 			
 			if (error != 0) {
-				NSLog (@PRODUCT ": Socket error while connecting to the IDE on %s:%d: %s", [[ips objectAtIndex:i] UTF8String], output_port, strerror (error));
+				PRINT (PRODUCT ": Socket error while connecting to the IDE on %s:%d: %s", [[ips objectAtIndex:i] UTF8String], output_port, strerror (error));
 				close (sockets[i]);
 				sockets[i] = -1;
 				waiting--;

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -160,7 +160,7 @@ void debug_launch_time_print (const char *msg)
 		date = startDate;
 	}
 
-	NSLog (@"%s: %llu us Total: %llu us", msg, unow - date, unow - startDate);
+	PRINT ("%s: %llu us Total: %llu us", msg, unow - date, unow - startDate);
 
 	date = unow;
 }
@@ -349,7 +349,7 @@ xamarin_main (int argc, char *argv[], bool is_extension)
 				if (value) {
 					monotouch_set_monodevelop_port (strtol (value, NULL, 10));
 				} else {
-					NSLog (@"MonoTouch: --%s requires an argument.", name);
+					PRINT ("MonoTouch: --%s requires an argument.", name);
 				}
 			} else if (!strcmp (name, "connection-mode")) {
 				if (!value && argc > i + 1)
@@ -357,7 +357,7 @@ xamarin_main (int argc, char *argv[], bool is_extension)
 				if (value) {
 					monotouch_set_connection_mode (value);
 				} else {
-					NSLog (@"MonoTouch: --%s requires an argument.", name);
+					PRINT ("MonoTouch: --%s requires an argument.", name);
 				}
 			} 
 #endif /* DEBUG */
@@ -368,7 +368,7 @@ xamarin_main (int argc, char *argv[], bool is_extension)
 				if (value) {
 					managed_argv [managed_argc++] = value;
 				} else {
-					NSLog (@"MonoTouch: --%s requires an argument.", name);
+					PRINT ("MonoTouch: --%s requires an argument.", name);
 				}
 			} else if (!strcmp (name, "setenv")) {
 				if (!value && argc > i + 1)
@@ -384,7 +384,7 @@ xamarin_main (int argc, char *argv[], bool is_extension)
 					}
 					free (k);
 				} else {
-					NSLog (@"MonoTouch: --%s requires an argument.", name);
+					PRINT ("MonoTouch: --%s requires an argument.", name);
 				}
 			}
 			

--- a/runtime/runtime-internal.h
+++ b/runtime/runtime-internal.h
@@ -13,7 +13,8 @@
 
 #include "xamarin/xamarin.h"
 
-#define LOG(...) do { if (xamarin_log_level > 0) NSLog (@ __VA_ARGS__); } while (0);
+#define PRINT(...) do { xamarin_printf (__VA_ARGS__); } while (0);
+#define LOG(...) do { if (xamarin_log_level > 0) xamarin_printf (__VA_ARGS__); } while (0);
 
 // #define DEBUG_LAUNCH_TIME
 

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2163,6 +2163,33 @@ xamarin_insert_dllmap ()
 #endif // defined (__i386__) || defined (__x86_64__)
 }
 
+void
+xamarin_printf (const char *format, ...)
+{
+	va_list list;
+	va_start (list, format);
+	xamarin_vprintf (format, list);
+	va_end (list);
+}
+
+void
+xamarin_vprintf (const char *format, va_list args)
+{
+	NSString *message = [[NSString alloc] initWithFormat: [NSString stringWithUTF8String: format] arguments: args];
+	
+#if TARGET_OS_WATCH && defined (__arm__) // maybe make this configurable somehow?
+	const char *msg = [message UTF8String];
+	int len = strlen (msg);
+	fwrite (msg, 1, len, stdout);
+	if (len == 0 || msg [len - 1] != '\n')
+		fwrite ("\n", 1, 1, stdout);
+	fflush (stdout);
+#else
+	NSLog (@"%@", message);	
+#endif
+
+	[message release];
+}
 /*
  * Object unregistration:
  *

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -675,7 +675,7 @@ gc_register_toggleref (MonoObject *obj, id self, bool isCustomType)
 #ifdef DEBUG_TOGGLEREF
 	id handle = xamarin_get_nsobject_handle (obj);
 
-	NSLog (@"**Registering object %p handle %p RC %d flags: %i",
+	PRINT ("**Registering object %p handle %p RC %d flags: %i",
 		obj,
 		handle,
 		(int) (handle ? [handle retainCount] : 0),
@@ -733,7 +733,7 @@ gc_toggleref_callback (MonoObject *object)
 	} else {
 		cn = object_getClassName (handle);
 	}
-	NSLog (@"\tinspecting %p handle:%p %s flags: %i RC %d -> %s\n", object, handle, cn, (int) flags, (int) (handle ? [handle retainCount] : 0), rv);
+	PRINT ("\tinspecting %p handle:%p %s flags: %i RC %d -> %s\n", object, handle, cn, (int) flags, (int) (handle ? [handle retainCount] : 0), rv);
 #endif
 
 	return res;
@@ -810,7 +810,7 @@ xamarin_open_assembly (const char *name)
 	if (xamarin_get_is_mkbundle ()) {
 		assembly = mono_assembly_open (name, NULL);
 		if (assembly == NULL) {
-			NSLog (@ PRODUCT ": Could not find the required assembly '%s' in the app. This is usually fixed by cleaning and rebuilding your project; if that doesn't work, please file a bug report: http://bugzilla.xamarin.com", name);
+			PRINT (PRODUCT ": Could not find the required assembly '%s' in the app. This is usually fixed by cleaning and rebuilding your project; if that doesn't work, please file a bug report: http://bugzilla.xamarin.com", name);
 			exit (1);
 		}
 		return assembly;
@@ -839,19 +839,19 @@ xamarin_open_assembly (const char *name)
 		if (assembly)
 			return assembly;
 		
-		NSLog (@ PRODUCT ": Could not find the assembly '%s' in the app nor as an already loaded assembly. This is usually fixed by cleaning and rebuilding your project; if that doesn't work, please file a bug report: http://bugzilla.xamarin.com", name);
+		PRINT (PRODUCT ": Could not find the assembly '%s' in the app nor as an already loaded assembly. This is usually fixed by cleaning and rebuilding your project; if that doesn't work, please file a bug report: http://bugzilla.xamarin.com", name);
 		exit (1);
 	}
 #endif
 
 	if (!xamarin_file_exists (path)) {
-		NSLog (@ PRODUCT ": Could not find the assembly '%s' in the app. This is usually fixed by cleaning and rebuilding your project; if that doesn't work, please file a bug report: http://bugzilla.xamarin.com", name);
+		PRINT (PRODUCT ": Could not find the assembly '%s' in the app. This is usually fixed by cleaning and rebuilding your project; if that doesn't work, please file a bug report: http://bugzilla.xamarin.com", name);
 		exit (1);
 	}
 
 	assembly = mono_assembly_open (path, NULL);
 	if (assembly == NULL) {
-		NSLog (@ PRODUCT ": Could not find the required assembly '%s' in the app. This is usually fixed by cleaning and rebuilding your project; if that doesn't work, please file a bug report: http://bugzilla.xamarin.com", name);
+		PRINT (PRODUCT ": Could not find the required assembly '%s' in the app. This is usually fixed by cleaning and rebuilding your project; if that doesn't work, please file a bug report: http://bugzilla.xamarin.com", name);
 		exit (1);
 	}
 		
@@ -888,7 +888,7 @@ is_class_finalization_aware (MonoClass *cls)
 	if (nsobject_class)
 		rv = cls == nsobject_class || mono_class_is_assignable_from (nsobject_class, cls);
 
-	//NSLog (@"IsClass %s.%s finalization aware: %i\n", mono_class_get_namespace (cls), mono_class_get_name (cls), rv);
+	//PRINT ("IsClass %s.%s finalization aware: %i\n", mono_class_get_namespace (cls), mono_class_get_name (cls), rv);
 
 	return rv;
 }
@@ -900,7 +900,7 @@ object_queued_for_finalization (MonoObject *object)
 	
 	/* This is called with the GC lock held, so it can only use signal-safe code */
 	struct Managed_NSObject *obj = (struct Managed_NSObject *) object;
-	//NSLog (@"In finalization response for %s.%s %p (handle: %p class_handle: %p flags: %i)\n", 
+	//PRINT ("In finalization response for %s.%s %p (handle: %p class_handle: %p flags: %i)\n", 
 	obj->flags |= NSObjectFlagsInFinalizerQueue;
 }
 
@@ -950,7 +950,7 @@ fetch_exception_property (MonoObject *obj, const char *name, bool is_virtual)
 
 		return (MonoObject *) mono_runtime_invoke (get, obj, NULL, &exc);
 	} else {
-		NSLog (@"Could not find the property System.Exception.%s", name);
+		PRINT ("Could not find the property System.Exception.%s", name);
 	}
 	
 	return NULL;
@@ -1037,7 +1037,7 @@ xamarin_process_managed_exception_gchandle (guint32 gchandle)
 void
 xamarin_unhandled_exception_handler (MonoObject *exc, gpointer user_data)
 {
-	NSLog (@"%@", print_all_exceptions (exc));
+	PRINT ("%@", print_all_exceptions (exc));
 
 	abort ();
 }
@@ -1049,7 +1049,7 @@ exception_handler (NSException *exc)
 	LOG (PRODUCT ": Received unhandled ObjectiveC exception: %@ %@", [exc name], [exc reason]);
 
 	if (xamarin_is_gc_coop) {
-		NSLog (@"Uncaught Objective-C exception: %@", exc);
+		PRINT ("Uncaught Objective-C exception: %@", exc);
 		assert (false); // Re-throwing the Objective-C exception will probably just end up with infinite recursion
 	}
 
@@ -1105,7 +1105,7 @@ static void
 log_callback (const char *log_domain, const char *log_level, const char *message, mono_bool fatal, void *user_data)
 {
 	// COOP: Not accessing managed memory: any mode
-	NSLog (@"%s: %s", log_level, message);
+	PRINT ("%s: %s", log_level, message);
 
 	if (fatal)
 		abort ();
@@ -1115,7 +1115,7 @@ static void
 print_callback (const char *string, mono_bool is_stdout)
 {
 	// COOP: Not accessing managed memory: any mode
-	NSLog (@"%s", string);
+	PRINT ("%s", string);
 }
 
 void
@@ -1302,7 +1302,7 @@ xamarin_assertion_message (const char *msg, ...)
 	va_start (args, msg);
 	vasprintf (&formatted, msg, args);
 	if (formatted) {
-		NSLog (@ PRODUCT ": %s", formatted);
+		PRINT ( PRODUCT ": %s", formatted);
 		free (formatted);
 	}
 	va_end (args);
@@ -1582,7 +1582,7 @@ xamarin_create_gchandle (id self, void *managed_object, int flags, bool force_we
 	assert ((gchandle & GCHANDLE_MASK) == 0); // Make sure we don't create too many gchandles...
 	set_raw_gchandle (self, gchandle | flags);
 #if defined(DEBUG_REF_COUNTING)
-	NSLog (@"\tGCHandle created for %p: %d (flags: %p) = %d %s\n", self, gchandle, GINT_TO_POINTER (flags), get_raw_gchandle (self), weak ? "weak" : "strong");
+	PRINT ("\tGCHandle created for %p: %d (flags: %p) = %d %s\n", self, gchandle, GINT_TO_POINTER (flags), get_raw_gchandle (self), weak ? "weak" : "strong");
 #endif
 }
 
@@ -1606,7 +1606,7 @@ xamarin_switch_gchandle (id self, bool to_weak)
 		if (to_weak == is_weak) {
 			// we already have the GCHandle we need
 #if defined(DEBUG_REF_COUNTING)
-			NSLog (@"Object %p already has a %s GCHandle = %d\n", self, to_weak ? "weak" : "strong", old_gchandle);
+			PRINT ("Object %p already has a %s GCHandle = %d\n", self, to_weak ? "weak" : "strong", old_gchandle);
 #endif
 			return;
 		}
@@ -1620,7 +1620,7 @@ xamarin_switch_gchandle (id self, bool to_weak)
 		// if we do, managed ctors end up being executed at a different moment,
 		// which breaks implicit assumptions in people's code.)
 #if defined(DEBUG_REF_COUNTING)
-		NSLog (@"Object %p has no managed object to create a %s GCHandle for\n", self, to_weak ? "weak" : "strong");
+		PRINT ("Object %p has no managed object to create a %s GCHandle for\n", self, to_weak ? "weak" : "strong");
 #endif
 		return;
 	}
@@ -1662,7 +1662,7 @@ xamarin_switch_gchandle (id self, bool to_weak)
 	MONO_THREAD_DETACH; // COOP: this will switch to GC_SAFE
 
 #if defined(DEBUG_REF_COUNTING)
-	NSLog (@"Switched object %p to %s GCHandle = %d\n", self, to_weak ? "weak" : "strong", new_gchandle);
+	PRINT ("Switched object %p to %s GCHandle = %d\n", self, to_weak ? "weak" : "strong", new_gchandle);
 #endif
 
 	xamarin_process_managed_exception_gchandle (exception_gchandle);
@@ -1674,14 +1674,14 @@ xamarin_free_gchandle (id self, int gchandle)
 	// COOP: no managed memory access, but calls mono function mono_gc_handle_free. Assuming that function can be called with any mode: this function can be called with any mode as well
 	if (gchandle) {
 #if defined(DEBUG_REF_COUNTING)
-		NSLog (@"\tGCHandle %i destroyed for object %p\n", gchandle, self);
+		PRINT ("\tGCHandle %i destroyed for object %p\n", gchandle, self);
 #endif
 		mono_gchandle_free (gchandle);
 
 		set_raw_gchandle (self, 0);
 	} else {
 #if defined(DEBUG_REF_COUNTING)
-		NSLog (@"\tNo GCHandle for the object %p\n", self);
+		PRINT ("\tNo GCHandle for the object %p\n", self);
 #endif
 	}
 }
@@ -1734,7 +1734,7 @@ xamarin_release_managed_ref (id self, MonoObject *managed_obj)
 	guint32 exception_gchandle = 0;
 	
 #if defined(DEBUG_REF_COUNTING)
-	NSLog (@"monotouch_release_managed_ref (%s Handle=%p) retainCount=%d; HasManagedRef=%i GCHandle=%i IsUserType=%i\n", 
+	PRINT ("monotouch_release_managed_ref (%s Handle=%p) retainCount=%d; HasManagedRef=%i GCHandle=%i IsUserType=%i\n", 
 		class_getName (object_getClass (self)), self, (int32_t) [self retainCount], user_type ? xamarin_has_managed_ref (self) : 666, user_type ? get_gchandle (self) : 666, user_type);
 #endif
 
@@ -1771,7 +1771,7 @@ xamarin_create_managed_ref (id self, gpointer managed_object, bool retain)
 	bool user_type = is_user_type (self);
 	
 #if defined(DEBUG_REF_COUNTING)
-	NSLog (@"monotouch_create_managed_ref (%s Handle=%p) retainCount=%d; HasManagedRef=%i GCHandle=%i IsUserType=%i\n", 
+	PRINT ("monotouch_create_managed_ref (%s Handle=%p) retainCount=%d; HasManagedRef=%i GCHandle=%i IsUserType=%i\n", 
 		class_getName ([self class]), self, get_safe_retainCount (self), user_type ? xamarin_has_managed_ref (self) : 666, user_type ? get_gchandle (self) : 666, user_type);
 #endif
 	
@@ -1840,7 +1840,7 @@ get_method_block_wrapper_creator (MonoMethod *method, int par, guint32 *exceptio
 	mp.method = method;
 	mp.par = par;
 
-	// NSLog (@"Looking up method and par (%x and %d)", (int) method, par);
+	// PRINT ("Looking up method and par (%x and %d)", (int) method, par);
 	MONO_ENTER_GC_SAFE;
 	pthread_mutex_lock (&wrapper_hash_lock);
 	MONO_EXIT_GC_SAFE;
@@ -1855,14 +1855,14 @@ get_method_block_wrapper_creator (MonoMethod *method, int par, guint32 *exceptio
 	res = (MonoObject *) mono_g_hash_table_lookup (xamarin_wrapper_hash, &mp);
 	pthread_mutex_unlock (&wrapper_hash_lock);
 	if (res != NULL){
-		// NSLog (@"Found match: %x", (int) res);
+		// PRINT ("Found match: %x", (int) res);
 		return res;
 	}
 
 	res = xamarin_get_block_wrapper_creator ((MonoObject *) mono_method_get_object (mono_domain_get (), method, NULL), par, exception_gchandle);
 	if (*exception_gchandle != 0)
 		return NULL;
-	// NSLog (@"New value: %x", (int) res);
+	// PRINT ("New value: %x", (int) res);
 
 	nmp = (MethodAndPar *) malloc (sizeof (MethodAndPar));
 	*nmp = mp;
@@ -2003,8 +2003,8 @@ xamarin_process_nsexception_using_mode (NSException *ns_exception, bool throwMan
 	mode = xamarin_on_marshal_objectivec_exception (ns_exception, throwManagedAsDefault, &exception_gchandle);
 
 	if (exception_gchandle != 0) {
-		NSLog (@PRODUCT ": Got an exception while executing the MarshalObjectiveCException event (this exception will be ignored):");
-		NSLog (@"%@", print_all_exceptions (mono_gchandle_get_target (exception_gchandle)));
+		PRINT (PRODUCT ": Got an exception while executing the MarshalObjectiveCException event (this exception will be ignored):");
+		PRINT ("%@", print_all_exceptions (mono_gchandle_get_target (exception_gchandle)));
 		mono_gchandle_free (exception_gchandle);
 		exception_gchandle = 0;
 	}
@@ -2027,8 +2027,8 @@ xamarin_process_nsexception_using_mode (NSException *ns_exception, bool throwMan
 		} else {
 			int handle = xamarin_create_ns_exception (ns_exception, &exception_gchandle);
 			if (exception_gchandle != 0) {
-				NSLog (@PRODUCT ": Got an exception while creating a managed NSException wrapper (will throw this exception instead):");
-				NSLog (@"%@", print_all_exceptions (mono_gchandle_get_target (exception_gchandle)));
+				PRINT (PRODUCT ": Got an exception while creating a managed NSException wrapper (will throw this exception instead):");
+				PRINT ("%@", print_all_exceptions (mono_gchandle_get_target (exception_gchandle)));
 				handle = exception_gchandle;
 				exception_gchandle = 0;
 			}
@@ -2060,8 +2060,8 @@ xamarin_process_managed_exception (MonoObject *exception)
 	mono_gchandle_free (handle);
 
 	if (exception_gchandle != 0) {
-		NSLog (@PRODUCT ": Got an exception while executing the MarshalManagedCException event (this exception will be ignored):");
-		NSLog (@"%@", print_all_exceptions (mono_gchandle_get_target (exception_gchandle)));
+		PRINT (PRODUCT ": Got an exception while executing the MarshalManagedCException event (this exception will be ignored):");
+		PRINT ("%@", print_all_exceptions (mono_gchandle_get_target (exception_gchandle)));
 		mono_gchandle_free (exception_gchandle);
 		exception_gchandle = 0;
 		mode = MarshalManagedExceptionModeDefault;
@@ -2082,8 +2082,8 @@ xamarin_process_managed_exception (MonoObject *exception)
 		NSException *ns_exc = xamarin_unwrap_ns_exception (handle, &exception_gchandle);
 		
 		if (exception_gchandle != 0) {
-			NSLog (@PRODUCT ": Got an exception while unwrapping a managed NSException wrapper (this exception will be ignored):");
-			NSLog (@"%@", print_all_exceptions (mono_gchandle_get_target (exception_gchandle)));
+			PRINT (PRODUCT ": Got an exception while unwrapping a managed NSException wrapper (this exception will be ignored):");
+			PRINT ("%@", print_all_exceptions (mono_gchandle_get_target (exception_gchandle)));
 			mono_gchandle_free (exception_gchandle);
 			exception_gchandle = 0;
 			ns_exc = NULL;
@@ -2105,8 +2105,8 @@ xamarin_process_managed_exception (MonoObject *exception)
 			
 			fullname = xamarin_type_get_full_name (mono_class_get_type (mono_object_get_class (exception)), &exception_gchandle);
 			if (exception_gchandle != 0) {
-				NSLog (@PRODUCT ": Got an exception when trying to get the typename for an exception (this exception will be ignored):");
-				NSLog (@"%@", print_all_exceptions (mono_gchandle_get_target (exception_gchandle)));
+				PRINT (PRODUCT ": Got an exception when trying to get the typename for an exception (this exception will be ignored):");
+				PRINT ("%@", print_all_exceptions (mono_gchandle_get_target (exception_gchandle)));
 				mono_gchandle_free (exception_gchandle);
 				exception_gchandle = 0;
 				fullname = "Unknown";

--- a/runtime/trampolines-varargs.m
+++ b/runtime/trampolines-varargs.m
@@ -37,7 +37,7 @@ create_mt_exception (char *msg)
 static void
 dump_state (struct CallState *state)
 {
-	NSLog (@"type: %u is_stret: %i self: %p SEL: %s -- double_ret: %f float_ret: %f longlong_ret: %llu ptr_ret: %p\n",
+	PRINT ("type: %u is_stret: %i self: %p SEL: %s -- double_ret: %f float_ret: %f longlong_ret: %llu ptr_ret: %p\n",
 		state->type, (state->type & Tramp_Stret) == Tramp_Stret, state->self, sel_getName (state->sel),
 		state->double_ret, state->float_ret, state->longlong_ret, state->ptr_ret);
 }

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -383,7 +383,7 @@ xamarin_copyWithZone_trampoline1 (id self, SEL sel, NSZone *zone)
 	struct objc_super sup;
 
 #if defined (DEBUG_REF_COUNTING)
-	NSLog (@"xamarin_copyWithZone_trampoline1 (%p, %s, %p)\n", self, sel_getName (sel), zone);
+	PRINT ("xamarin_copyWithZone_trampoline1 (%p, %s, %p)\n", self, sel_getName (sel), zone);
 #endif
 
 	// Clear out our own GCHandle
@@ -413,7 +413,7 @@ xamarin_copyWithZone_trampoline2 (id self, SEL sel, NSZone *zone)
 	int gchandle;
 
 #if defined (DEBUG_REF_COUNTING)
-	NSLog (@"xamarin_copyWithZone_trampoline2 (%p, %s, %p)\n", self, sel_getName (sel), zone);
+	PRINT ("xamarin_copyWithZone_trampoline2 (%p, %s, %p)\n", self, sel_getName (sel), zone);
 #endif
 
 	// Clear out our own GCHandle
@@ -447,7 +447,7 @@ xamarin_release_trampoline (id self, SEL sel)
 	ref_count = [self retainCount];
 
 #if defined(DEBUG_REF_COUNTING)
-	NSLog (@"xamarin_release_trampoline (%s Handle=%p) retainCount=%d; HasManagedRef=%i GCHandle=%i\n", 
+	PRINT ("xamarin_release_trampoline (%s Handle=%p) retainCount=%d; HasManagedRef=%i GCHandle=%i\n", 
 		class_getName ([self class]), self, ref_count, xamarin_has_managed_ref (self), xamarin_get_gchandle (self));
 #endif
 	
@@ -484,7 +484,7 @@ xamarin_notify_dealloc (id self, int gchandle)
 	/* Object is about to die. Unregister it and free any gchandles we may have */
 	MonoObject *mobj = mono_gchandle_get_target (gchandle);
 #if defined(DEBUG_REF_COUNTING)
-	NSLog (@"xamarin_notify_dealloc (%p, %i) target: %p\n", self, gchandle, mobj);
+	PRINT ("xamarin_notify_dealloc (%p, %i) target: %p\n", self, gchandle, mobj);
 #endif
 	xamarin_free_gchandle (self, gchandle);
 	xamarin_unregister_nsobject (self, mobj, &exception_gchandle);
@@ -524,7 +524,7 @@ xamarin_retain_trampoline (id self, SEL sel)
 	self = xamarin_invoke_objc_method_implementation (self, sel, (IMP) xamarin_retain_trampoline);
 	
 #if defined(DEBUG_REF_COUNTING)
-	NSLog (@"xamarin_retain_trampoline  (%s Handle=%p) initial retainCount=%d; new retainCount=%d HadManagedRef=%i HasManagedRef=%i old GCHandle=%i new GCHandle=%i\n", 
+	PRINT ("xamarin_retain_trampoline  (%s Handle=%p) initial retainCount=%d; new retainCount=%d HadManagedRef=%i HasManagedRef=%i old GCHandle=%i new GCHandle=%i\n", 
 		class_getName ([self class]), self, ref_count, (int) [self retainCount], had_managed_ref, xamarin_has_managed_ref (self), pre_gchandle, xamarin_get_gchandle (self));
 #endif
 

--- a/runtime/xamarin-support.m
+++ b/runtime/xamarin-support.m
@@ -84,7 +84,7 @@ xamarin_start_wwan (const char *uri)
 	
 	if (CFReadStreamOpen (stream)) {
 		// CFStreamStatus status = CFReadStreamGetStatus (stream);
-		// NSLog (@"CFStreamStatus %i", status);
+		// PRINT ("CFStreamStatus %i", status);
 		// note: some earlier iOS7 beta returned 1 (Opening) instead of 2 (Open) - a bit more time was needed or
 		// CFReadStreamRead blocks (and never return)
 		CFReadStreamRead (stream, buf, 1);
@@ -124,13 +124,13 @@ xamarin_GetFolderPath (int folder)
 
 void objc_msgSend_stret (id self, SEL op, ...)
 {
-	NSLog (@"Unimplemented objc_msgSend_stret %s", sel_getName (op));
+	PRINT ("Unimplemented objc_msgSend_stret %s", sel_getName (op));
 	abort ();
 }
 
 void objc_msgSendSuper_stret (struct objc_super *super, SEL op, ...)
 {
-	NSLog (@"Unimplemented objc_msgSendSuper_stret %s", sel_getName (op));
+	PRINT ("Unimplemented objc_msgSendSuper_stret %s", sel_getName (op));
 	abort ();
 }
 

--- a/runtime/xamarin-support.m
+++ b/runtime/xamarin-support.m
@@ -2,8 +2,10 @@
 #include <objc/objc.h>
 #include <objc/runtime.h>
 #include <objc/message.h>
+#include <iconv.h>
 
 #include "xamarin/xamarin.h"
+#include "runtime-internal.h"
 #include "monotouch-support.h"
 
 const char *
@@ -19,7 +21,13 @@ void
 xamarin_log (const unsigned short *unicodeMessage)
 {
 	// COOP: no managed memory access: any mode.
-	NSLog (@"%S", unicodeMessage); 
+	int length = 0;
+	const unsigned short *ptr = unicodeMessage;
+	while (*ptr++)
+		length += sizeof (unsigned short);
+	NSString *msg = [[NSString alloc] initWithBytes: unicodeMessage length: length encoding: NSUTF16LittleEndianStringEncoding];
+	xamarin_printf ([msg UTF8String]);
+	[msg release];
 }
 
 void*

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -155,6 +155,10 @@ void			xamarin_throw_product_exception (int code, const char *message);
 
 id				xamarin_invoke_objc_method_implementation (id self, SEL sel, IMP xamarin_impl);
 
+// this functions support NSLog/NSString-style format specifiers.
+void			xamarin_printf (const char *format, ...);
+void			xamarin_vprintf (const char *format, va_list args);
+
 #if defined(__arm__) || defined(__aarch64__)
 void mono_aot_register_module (void *aot_info);
 #endif


### PR DESCRIPTION
Don't use NSLog on watchOS, since it's not printed by default anywhere (starting with watchOS 3).

Instead use printf, which shows up in the IDE (if launched from the IDE) or in the device log (if not launched from the IDE).

This also makes Console.WriteLine work on a watchOS 3 device (since it ends up calling xamarin_log).