### PR TITLE
[Foundation] Fix NSMeasurement generic type inheritance

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -12029,7 +12029,7 @@ namespace XamCore.Foundation
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	[DisableDefaultCtor] // base type has a designated initializer
-	interface NSUnitTemperature : NSSecureCoding {
+	interface NSUnitTemperature : NSUnit, NSSecureCoding {
 		// inline from base type
 		[Export ("initWithSymbol:converter:")]
 		[DesignatedInitializer]
@@ -12051,6 +12051,10 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("baseUnit")]
 		NSDimension BaseUnit { get; }
+
+		[Override]
+		[Export ("symbol")]
+		new string Symbol { get; }
 	}
 
 #if MONOMAC
@@ -13976,9 +13980,8 @@ namespace XamCore.Foundation
 #if !XAMCORE_2_0
 	interface NSMeasurement : NSCopying, NSSecureCoding {
 #else
-	interface NSMeasurement<UnitType> : NSCopying, NSSecureCoding {
-// FIXME pending generator fix
-//		where UnitType : NSUnit {
+	interface NSMeasurement<UnitType> : NSCopying, NSSecureCoding
+		where UnitType : NSUnit {
 #endif
 		[Export ("unit", ArgumentSemantic.Copy)]
 		NSUnit Unit { get; }


### PR DESCRIPTION
Our temp.dll won't compile because
NSMeasurement<NSUnitTemperature> temperature is used in intents and
NSUnitTemperature does not conform (inherit) yet from its parent class
NSDimension which inherits from NSUnit. But at this stage the generator
has not run yet and the temp.dll cannot be compiled because the above
informations is expressed in attributes.

So wee get a compiler error:

 The type `Foundation.NSUnitTemperature' cannot be used as
type parameter `UnitType' in the generic type or method
`Foundation.NSMeasurement<UnitType>'.
There is no implicit reference conversion from
`Foundation.NSUnitTemperature' to `Foundation.NSUnit'

Which is totally correct because that info is not available yet. The
fix is simple we just let interface NSUnitTemperature : NSUnit so our
intermediate temp.dll builds and let the generator do its thing, this
will end up adding the Symbol property to NSUnitTemperature which is
correct (already double checked with an ObjC sample).

build diff: https://gist.github.com/dalexsoto/b9ecc467e08ec1a48ab34b83cbfb8a90