### PR TITLE
[foundation] Fix generic constraint for NSMeasurement

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -13976,9 +13976,8 @@ namespace XamCore.Foundation
 #if !XAMCORE_2_0
 	interface NSMeasurement : NSCopying, NSSecureCoding {
 #else
-	interface NSMeasurement<UnitType> : NSCopying, NSSecureCoding {
-// FIXME pending generator fix
-//		where UnitType : NSUnit {
+	interface NSMeasurement<UnitType> : NSCopying, NSSecureCoding
+		where UnitType : NSUnit {
 #endif
 		[Export ("unit", ArgumentSemantic.Copy)]
 		NSUnit Unit { get; }

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -3456,6 +3456,10 @@ namespace XamCore.Intents {
 		INSetAudioSourceInCarIntentResponseCode Code { get; }
 	}
 
+	// HACK only to please the generator - which does not (normally) know the type hierarchy in the
+	// binding files. The lack of namespace will generate the correct code for the C# compiler
+	interface NSUnitTemperature : NSUnit {}
+
 	[Introduced (PlatformName.iOS, 10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntent))]


### PR DESCRIPTION
The generator does not currently offer flexibility for constraints.

That's made harder since binding files uses attributes, [BaseType], to
define the type hierarchy.

Here we cheat as we can add, non-decorated, interfaces in the bindings
that won't generate anything - they are only to please the compiler or,
in this case, it let us fool the generator into producing the code we
need (because it does not consider the namespace)

Based on Alex elegant attempt to fix this in:
https://github.com/xamarin/xamarin-macios/pull/780

Generated code diff:
https://gist.github.com/spouliot/eeef3491a6e08d9344a19e9bbc632848