### PR TITLE
[metal] Fix MTLHeapDescriptor and test it only on devices

### DIFF
--- a/src/metal.cs
+++ b/src/metal.cs
@@ -1819,7 +1819,7 @@ namespace XamCore.Metal {
 
 	[iOS (10, 0), TV (10,0), NoWatch, NoMac]
 	[BaseType (typeof(NSObject))]
-	[DisableDefaultCtor]
+	// note: type works only on devices, symbol is missing on the simulator
 	public interface MTLHeapDescriptor : NSCopying
 	{
 		[Export ("size")]

--- a/tests/introspection/iOS/iOSApiCtorInitTest.cs
+++ b/tests/introspection/iOS/iOSApiCtorInitTest.cs
@@ -176,6 +176,10 @@ namespace Introspection {
 			case "MPMediaItemArtwork":
 				// NSInvalidArgumentException Reason: image must be non-nil
 				return true;
+
+			// iOS 10 - this works only on devices, so we skip the simulator
+			case "MTLHeapDescriptor":
+				return Runtime.Arch == Arch.SIMULATOR;
 			default:
 				return base.Skip (type);
 			}

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -90,6 +90,11 @@ namespace Introspection {
 			case "CAMetalLayer":
 				return (Runtime.Arch == Arch.SIMULATOR);
 
+			// iOS 10 - this type can only be instantiated on devices, but the selectors are forwarded
+			//  to a MTLHeapDescriptorInternal and don't respond - so we'll add unit tests for them
+			case "MTLHeapDescriptor":
+				return Runtime.Arch == Arch.DEVICE;
+
 			default:
 				return base.Skip (type);
 			}

--- a/tests/monotouch-test/Metal/HeapDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/HeapDescriptorTest.cs
@@ -1,0 +1,49 @@
+﻿#if !__WATCHOS__
+
+using System;
+
+#if XAMCORE_2_0
+using ObjCRuntime;
+using Metal;
+#else
+using MonoTouch.ObjCRuntime;
+using MonoTouch.Metal;
+#endif
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.Metal {
+
+	[TestFixture]
+	public class HeapDescriptorTest {
+
+		[Test]
+		public void Properties ()
+		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+
+			if (Runtime.Arch == Arch.SIMULATOR)
+				Assert.Ignore ("Type is missing on the simulator");
+
+			using (var hd = new MTLHeapDescriptor ()) {
+				Assert.That (hd.CpuCacheMode, Is.EqualTo (MTLCpuCacheMode.DefaultCache), "CpuCacheMode");
+				hd.CpuCacheMode = MTLCpuCacheMode.WriteCombined;
+				Assert.That (hd.StorageMode, Is.EqualTo (MTLStorageMode.Private), "StorageMode");
+				hd.StorageMode = MTLStorageMode.Memoryless;
+				Assert.That (hd.Size, Is.EqualTo (0), "Size");
+				hd.Size = 16;
+
+				using (var hd2 = (MTLHeapDescriptor) hd.Copy ()) {
+					Assert.That (hd2.CpuCacheMode, Is.EqualTo (MTLCpuCacheMode.WriteCombined), "CpuCacheMode");
+					Assert.That (hd2.StorageMode, Is.EqualTo (MTLStorageMode.Memoryless), "StorageMode");
+					Assert.That (hd2.Size, Is.EqualTo (16), "Size");
+
+					// NSCopying
+					Assert.That (hd2.Handle, Is.Not.EqualTo (hd.Handle), "Handle");
+				}
+			}
+		}
+	}
+}
+
+#endif // !__WATCHOS__

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -573,6 +573,7 @@
     <Compile Include="GameplayKit\GKNoiseTests.cs" />
     <Compile Include="CoreMidi\MidiEndpointTest.cs" />
     <Compile Include="HealthKit\CdaDocumentSampleTest.cs" />
+    <Compile Include="AVFoundation\CapturePhotoOutputTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -573,7 +573,7 @@
     <Compile Include="GameplayKit\GKNoiseTests.cs" />
     <Compile Include="CoreMidi\MidiEndpointTest.cs" />
     <Compile Include="HealthKit\CdaDocumentSampleTest.cs" />
-    <Compile Include="AVFoundation\CapturePhotoOutputTest.cs" />
+    <Compile Include="Metal\HeapDescriptorTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
It turns out `MTLHeapDescriptor` does not exists on the simulator.

```Undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$_MTLHeapDescriptor", referenced from:
      objc-class-ref in AppDelegate.o
ld: symbol(s) not found for architecture x86_64```

A `[DisableDefaultCtor]` was used (by mistake / lack of documentation)
and this was hiding the issue (on our bots).

However on device introspection was not happy:

iOSApiSelectorTest
[FAIL] Selector not found for Metal.MTLHeapDescriptor : cpuCacheMode
[FAIL] Selector not found for Metal.MTLHeapDescriptor : setCpuCacheMode:
[FAIL] Selector not found for Metal.MTLHeapDescriptor : size
[FAIL] Selector not found for Metal.MTLHeapDescriptor : setSize:
[FAIL] Selector not found for Metal.MTLHeapDescriptor : storageMode
[FAIL] Selector not found for Metal.MTLHeapDescriptor : setStorageMode:
    [FAIL] iOSApiSelectorTest.ApiSelectorTest.InstanceMethods :   6 errors found in 18339 instance selector validated

Note that these are the properties, not the `init` that's mentioned here.

So first `init` is possible, on devices, from Xcode:

	MTLHeapDescriptor *hd = [[MTLHeapDescriptor alloc] init];
	NSLog (@"%@", [hd description]);

gives

	<MTLHeapDescriptorInternal: 0x17401da50>
	{
		cpuCacheMode = MTLCPUCacheModeDefaultCache;
		size = 0;
		storageMode = MTLStorageModePrivate;
		}

so we need to remove our `[DisableDefaultCtor]`.

That does not fix the selectors above... but note the *Internal type
returned, they are forwarded and that's generally something that
respondToSelector (that introspection uses) does not cover.

But, to be sure, we add unit tests showing all the properties are
working like expected :-)