### PR TITLE
[UIKit] Remove 3 protocol members until bug 43579 is fixed

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -11779,9 +11779,11 @@ namespace XamCore.UIKit {
 		[Export ("textFieldDidEndEditing:"), EventArgs ("UITextField"), EventName ("Ended")]
 		void EditingEnded (UITextField textField);
 
-		[iOS (10, 0)] //HACK: We have a generator bug(?) that won't allow overloads (AmbiguousMatchException) in protocols this is the why of Foo2 naming below
-		[Export ("textFieldDidEndEditing:reason:"), EventArgs ("UITextFieldEditingEnded"), EventName ("Ended2")]
-		void EditingEnded2 (UITextField textField, UITextFieldDidEndEditingReason reason);
+		//TODO: Until we fix the below bug (hopefuly SR0) and get better names we will have this out of the API
+		// We have a generator bug (https://bugzilla.xamarin.com/show_bug.cgi?id=43579) that won't allow overloads (AmbiguousMatchException) in protocols this is the why of Foo2 naming below
+		//[iOS (10, 0)]
+		//[Export ("textFieldDidEndEditing:reason:"), EventArgs ("UITextFieldEditingEnded"), EventName ("Ended2")]
+		//void EditingEnded2 (UITextField textField, UITextFieldDidEndEditingReason reason);
 		
 		[Export ("textFieldShouldClear:"), DelegateName ("UITextFieldCondition"), DefaultValue ("true")]
 		bool ShouldClear (UITextField textField);
@@ -11948,14 +11950,15 @@ namespace XamCore.UIKit {
 		[Export ("textView:shouldInteractWithTextAttachment:inRange:"), DelegateName ("Func<UITextView,NSTextAttachment,NSRange,bool>"), DefaultValue ("true")]
 		bool ShouldInteractWithTextAttachment (UITextView textView, NSTextAttachment textAttachment, NSRange characterRange);
 
-		//HACK: We have a generator bug(?) that won't allow overloads (AmbiguousMatchException) in protocols this is the why of Foo2 naming bellow, Need to investigate more
-		[iOS (10,0)]
-		[Export ("textView:shouldInteractWithURL:inRange:interaction:"), DelegateName ("UITextViewDelegateShouldInteractUrlDelegate"), DefaultValue ("true")]
-		bool ShouldInteractWithUrl2 (UITextView textView, NSUrl url, NSRange characterRange, UITextItemInteraction interaction);
+		//TODO: Until we fix the below bug (hopefuly SR0) and get better names we will have this out of the API
+		// We have a generator bug (https://bugzilla.xamarin.com/show_bug.cgi?id=43579) that won't allow overloads (AmbiguousMatchException) in protocols this is the why of Foo2 naming below
+		//[iOS (10, 0)]
+		//[Export ("textView:shouldInteractWithURL:inRange:interaction:"), DelegateName ("UITextViewDelegateShouldInteractUrlDelegate"), DefaultValue ("true")]
+		//bool ShouldInteractWithUrl2 (UITextView textView, NSUrl url, NSRange characterRange, UITextItemInteraction interaction);
 
-		[iOS (10,0)]
-		[Export ("textView:shouldInteractWithTextAttachment:inRange:interaction:"), DelegateName ("UITextViewDelegateShouldInteractTextDelegate"), DefaultValue ("true")]
-		bool ShouldInteractWithTextAttachment2 (UITextView textView, NSTextAttachment textAttachment, NSRange characterRange, UITextItemInteraction interaction);
+		//[iOS (10,0)]
+		//[Export ("textView:shouldInteractWithTextAttachment:inRange:interaction:"), DelegateName ("UITextViewDelegateShouldInteractTextDelegate"), DefaultValue ("true")]
+		//bool ShouldInteractWithTextAttachment2 (UITextView textView, NSTextAttachment textAttachment, NSRange characterRange, UITextItemInteraction interaction);
 	}
 	
 	[NoTV]

--- a/tests/xtro-sharpie/ios.pending
+++ b/tests/xtro-sharpie/ios.pending
@@ -264,6 +264,11 @@
 
 # UIKit
 
+# TODO: MUST BE FIXED by SR0 or SR1 of iOS 10 related bug https://bugzilla.xamarin.com/show_bug.cgi?id=43579
+!missing-protocol-member! UITextFieldDelegate::textFieldDidEndEditing:reason: not found
+!missing-protocol-member! UITextViewDelegate::textView:shouldInteractWithTextAttachment:inRange:interaction: not found
+!missing-protocol-member! UITextViewDelegate::textView:shouldInteractWithURL:inRange:interaction: not found
+
 ## HACK: those members are not *required* in ObjC but we made them
 ## abstract to have them inlined in UITextField and UITextView
 ## Even more confusing it that respondToSelecttor return NO on them

--- a/tests/xtro-sharpie/tvos.pending
+++ b/tests/xtro-sharpie/tvos.pending
@@ -70,6 +70,11 @@
 
 # UIKit
 
+# TODO: MUST BE FIXED by SR0 or SR1 of iOS 10 related bug https://bugzilla.xamarin.com/show_bug.cgi?id=43579
+!missing-protocol-member! UITextFieldDelegate::textFieldDidEndEditing:reason: not found
+!missing-protocol-member! UITextViewDelegate::textView:shouldInteractWithTextAttachment:inRange:interaction: not found
+!missing-protocol-member! UITextViewDelegate::textView:shouldInteractWithURL:inRange:interaction: not found
+
 ## Apple docs: This property is inherited from the UIView parent class. This class changes the default value of this property to NO.
 !missing-selector! UIImageView::isUserInteractionEnabled not bound
 !missing-selector! UIImageView::setUserInteractionEnabled: not bound


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=43579

We are removing the following 3 protocol members
- UITextFieldDelegate.EditingEnded2 (UITextField textField, UITextFieldDidEndEditingReason reason)
- UITextViewDelegate.ShouldInteractWithUrl2 (UITextView textView, NSUrl url, NSRange characterRange, UITextItemInteraction interaction)
- UITextViewDelegate.ShouldInteractWithTextAttachment2 (UITextView textView, NSTextAttachment textAttachment, NSRange characterRange, UITextItemInteraction interaction)

Reasons:
- We need to fix bug https://bugzilla.xamarin.com/show_bug.cgi?id=43579
- Bad naming, we do not want 2 suffix

Hopefully we can have this ready for C8SR0 or C8SR1