### PR TITLE
[HomeKit] Put availability attribute for tvOS on the type, never the member

### DIFF
--- a/src/HomeKit/HMAccessoryCategory.cs
+++ b/src/HomeKit/HMAccessoryCategory.cs
@@ -7,6 +7,7 @@ namespace XamCore.HomeKit {
 	partial class HMAccessoryCategory {
 
 		[iOS (9,0)]
+		[TV (10,0)]
 		public HMAccessoryCategoryType CategoryType {
 			get {
 				var s = _CategoryType;

--- a/src/HomeKit/HMActionSet.cs
+++ b/src/HomeKit/HMActionSet.cs
@@ -7,6 +7,7 @@ namespace XamCore.HomeKit {
 	partial class HMActionSet {
 
 		[iOS (9,0)]
+		[TV (10,0)]
 		public HMActionSetType ActionSetType {
 			get {
 				var s = _ActionSetType;

--- a/src/HomeKit/HMCharacteristic.cs
+++ b/src/HomeKit/HMCharacteristic.cs
@@ -5,6 +5,7 @@ using XamCore.Foundation;
 namespace XamCore.HomeKit {
 
 	[iOS (8,0)]
+	[TV (10,0)]
 	partial class HMCharacteristic 
 	{
 		public HMCharacteristicType CharacteristicType {
@@ -217,6 +218,7 @@ namespace XamCore.HomeKit {
 		}
 
 		[iOS (9,3)][Watch (2,2)]
+		[TV (10,0)]
 		public bool Hidden {
 			get {
 				foreach (var p in Properties) {

--- a/src/HomeKit/HMCharacteristicMetadata.cs
+++ b/src/HomeKit/HMCharacteristicMetadata.cs
@@ -4,6 +4,7 @@ using XamCore.Foundation;
 
 namespace XamCore.HomeKit {
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	public partial class HMCharacteristicMetadata
 	{

--- a/src/HomeKit/HMCharacteristicProperties.cs
+++ b/src/HomeKit/HMCharacteristicProperties.cs
@@ -5,6 +5,7 @@ using XamCore.Foundation;
 namespace XamCore.HomeKit {
 
 	[iOS (8,0)]
+	[TV (10,0)]
 	public class HMCharacteristicProperties {
 
 		public bool SupportsChangeNumber { get; set; }

--- a/src/HomeKit/HMEnums.cs
+++ b/src/HomeKit/HMEnums.cs
@@ -5,6 +5,7 @@ using XamCore.Foundation;
 namespace XamCore.HomeKit {
 
 	[iOS (8,0)]
+	[TV (10,0)]
 	[Native]
 	public enum HMError : nint {
 		AlreadyExists                           = 1,
@@ -103,6 +104,7 @@ namespace XamCore.HomeKit {
 	
 	// conveniance enum (ObjC uses NSString)
 	[iOS (8,0)]
+	[TV (10,0)]
 	public enum HMCharacteristicType {
 		None,
 		PowerState,
@@ -212,36 +214,37 @@ namespace XamCore.HomeKit {
 		TargetPosition,
 		[iOS (9,0)]
 		TargetVerticalTilt,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		StreamingStatus,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		SetupStreamEndpoint,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		SupportedVideoStreamConfiguration,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		SupportedAudioStreamConfiguration,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		SupportedRtpConfiguration,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		SelectedStreamConfiguration,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		Volume,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		Mute,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		NightVision,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		OpticalZoom,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		DigitalZoom,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		ImageRotation,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		ImageMirroring,
 	}
 
 	// conveniance enum (ObjC uses NSString)
 	[iOS (8,0)]
+	[TV (10,0)]
 	public enum HMCharacteristicMetadataUnits {
 		None,
 		Celsius,
@@ -252,14 +255,15 @@ namespace XamCore.HomeKit {
 		Seconds,
 		[iOS (9,3)][Watch(2,2)]
 		Lux,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		PartsPerMillion,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		MicrogramsPerCubicMeter,
 	}
 
 	// conveniance enum (ObjC uses NSString)
 	[iOS (8,0)]
+	[TV (10,0)]
 	[Flags]
 	public enum HMServiceType {
 		None,
@@ -308,20 +312,21 @@ namespace XamCore.HomeKit {
 		Window,
 		[iOS (9,0)]
 		WindowCovering,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		CameraRtpStreamManagement,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		CameraControl,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		Microphone,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		Speaker,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		Doorbell,
 	}
 
 	// conveniance enum (ObjC uses NSString)
 	[iOS (8,0)]
+	[TV (10,0)]
 	public enum HMCharacteristicMetadataFormat {
 		None,
 		Bool,
@@ -339,6 +344,7 @@ namespace XamCore.HomeKit {
 	}
 
 	[iOS (8,0)]
+	[TV (10,0)]
 	[Native]
 	public enum HMCharacteristicValueDoorState : nint {
 		Open = 0,
@@ -349,6 +355,7 @@ namespace XamCore.HomeKit {
 	}
 
 	[iOS (8,0)]
+	[TV (10,0)]
 	[Native]
 	public enum HMCharacteristicValueHeatingCooling : nint {
 		Off = 0,
@@ -358,6 +365,7 @@ namespace XamCore.HomeKit {
 	}
 
 	[iOS (8,0)]
+	[TV (10,0)]
 	[Native]
 	public enum HMCharacteristicValueRotationDirection : nint {
 		Clockwise = 0,
@@ -365,6 +373,7 @@ namespace XamCore.HomeKit {
 	}
 
 	[iOS (8,0)]
+	[TV (10,0)]
 	[Native]
 	public enum HMCharacteristicValueTemperatureUnit : nint {
 		Celsius = 0,
@@ -372,6 +381,7 @@ namespace XamCore.HomeKit {
 	}
 
 	[iOS (8,0)]
+	[TV (10,0)]
 	[Native]
 	public enum HMCharacteristicValueLockMechanismState : nint {
 		Unsecured = 0,
@@ -381,6 +391,7 @@ namespace XamCore.HomeKit {
 	}
 
 	[iOS (8,0)]
+	[TV (10,0)]
 	[Native]
 	// in iOS 8.3 this was renamed HMCharacteristicValueLockMechanismLastKnownAction but that would be a breaking change for us
 	public enum HMCharacteristicValueLockMechanism : nint {
@@ -398,6 +409,7 @@ namespace XamCore.HomeKit {
 	}
 
 	[iOS (9,0)]
+	[TV (10,0)]
 	[Native]
 	public enum HMCharacteristicValueAirParticulate : nint {
 		Size2_5 = 0,
@@ -405,6 +417,7 @@ namespace XamCore.HomeKit {
 	}
 
 	[iOS (9,0)]
+	[TV (10,0)]
 	[Native]
 	public enum HMCharacteristicValueCurrentSecuritySystemState : nint {
 		StayArm = 0,
@@ -415,6 +428,7 @@ namespace XamCore.HomeKit {
 	}
 
 	[iOS (9,0)]
+	[TV (10,0)]
 	[Native]
 	public enum HMCharacteristicValuePositionState : nint {
 		Closing = 0,
@@ -423,6 +437,7 @@ namespace XamCore.HomeKit {
 	}
 
 	[iOS (9,0)]
+	[TV (10,0)]
 	[Native]
 	public enum HMCharacteristicValueTargetSecuritySystemState : nint {
 		StayArm = 0,
@@ -517,6 +532,7 @@ namespace XamCore.HomeKit {
 
 	// conveniance enum (ObjC uses NSString)
 	[iOS (9,0)]
+	[TV (10,0)]
 	public enum HMActionSetType {
 		Unknown = -1,
 		WakeUp,
@@ -524,11 +540,12 @@ namespace XamCore.HomeKit {
 		HomeDeparture,
 		HomeArrival,
 		UserDefined,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		TriggerOwned,
 	}
 
 	[iOS (9,0)]
+	[TV (10,0)]
 	// conveniance enum (ObjC uses NSString)
 	public enum HMAccessoryCategoryType {
 		Other = 0,
@@ -537,7 +554,7 @@ namespace XamCore.HomeKit {
 		Door,
 		DoorLock,
 		Fan,
-#if !WATCH
+#if !WATCH && !TVOS
 		[Obsolete ("Use GarageDoorOpener instead")]
 		DoorOpener,
 		GarageDoorOpener = DoorOpener,
@@ -552,15 +569,16 @@ namespace XamCore.HomeKit {
 		Thermostat,
 		Window,
 		WindowCovering,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		RangeExtender,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		IPCamera,
-		[iOS (10,0), Watch (3,0), TV (10,0)]
+		[iOS (10,0), Watch (3,0)]
 		VideoDoorbell,
 	}
 
 	[iOS (9,0)]
+	[TV (10,0)]
 	// conveniance enum (ObjC uses NSString)
 	public enum HMSignificantEvent {
 		Sunrise,
@@ -568,6 +586,7 @@ namespace XamCore.HomeKit {
 	}
 
 	[iOS (9,0)]
+	[TV (10,0)]
 	[Native]
 	public enum HMCharacteristicValueAirQuality : nint {
 		Unknown = 0,
@@ -579,6 +598,7 @@ namespace XamCore.HomeKit {
 	}
 
 	[iOS (10,0)]
+	[TV (10,0)]
 	[Native]
 	public enum HMCameraStreamState : nuint
 	{
@@ -589,6 +609,7 @@ namespace XamCore.HomeKit {
 	}
 
 	[iOS (10,0)]
+	[TV (10,0)]
 	[Native]
 	public enum HMCameraAudioStreamSetting : nuint
 	{

--- a/src/HomeKit/HMHome.cs
+++ b/src/HomeKit/HMHome.cs
@@ -6,6 +6,7 @@ using XamCore.Foundation;
 namespace XamCore.HomeKit {
 
 	[iOS (8,0)]
+	[TV (10,0)]
 	public partial class HMHome
 	{
 		public HMService [] GetServices (HMServiceType serviceTypes) 

--- a/src/HomeKit/HMService.cs
+++ b/src/HomeKit/HMService.cs
@@ -5,6 +5,7 @@ using XamCore.Foundation;
 
 namespace XamCore.HomeKit {
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	public partial class HMService {
 

--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -12,6 +12,7 @@ interface UIView {}
 
 namespace XamCore.HomeKit {
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[Static]
 	public partial interface HMErrors {
@@ -76,6 +77,7 @@ namespace XamCore.HomeKit {
 		void DidRemoveHome (HMHomeManager manager, HMHome home);
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject), Delegates=new string[] {"WeakDelegate"}, Events=new Type[] {typeof(HMAccessoryDelegate)})]
 	public partial interface HMAccessory {
@@ -142,11 +144,12 @@ namespace XamCore.HomeKit {
 
 		// HMAccessory(Camera)
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[NullAllowed, Export ("cameraProfiles", ArgumentSemantic.Copy)]
 		HMCameraProfile [] CameraProfiles { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[Model, Protocol]
 	[BaseType (typeof (NSObject))]
@@ -225,6 +228,7 @@ namespace XamCore.HomeKit {
 		HMAccessory Accessory { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	public partial interface HMAction {
@@ -234,6 +238,7 @@ namespace XamCore.HomeKit {
 		NSUuid UniqueIdentifier { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
@@ -275,11 +280,12 @@ namespace XamCore.HomeKit {
 		[Export ("uniqueIdentifier", ArgumentSemantic.Copy)]
 		NSUuid UniqueIdentifier { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Export ("lastExecutionDate", ArgumentSemantic.Copy)]
 		NSDate LastExecutionDate { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (9,0)]
 	[Static]
 	[Internal]
@@ -299,11 +305,12 @@ namespace XamCore.HomeKit {
 		[Field ("HMActionSetTypeUserDefined")]
 		NSString UserDefined { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMActionSetTypeTriggerOwned")]
 		NSString TriggerOwned { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]	
 	[BaseType (typeof (NSObject))]
 	public partial interface HMCharacteristic {
@@ -362,6 +369,7 @@ namespace XamCore.HomeKit {
 		NSString ValueKeyPath { get; }
 	}
 
+	[TV (10,0)]
 	[iOS(8,0)]
 	[Static]
 	[Internal]
@@ -381,6 +389,7 @@ namespace XamCore.HomeKit {
 		NSString SupportsEventNotification { get; }		
 	}
 
+	[TV (10,0)]
 	[iOS(8,0)]
 	[Static]
 	[Internal]
@@ -635,59 +644,60 @@ namespace XamCore.HomeKit {
 		[Field ("HMCharacteristicTypeTargetSecuritySystemState")]
 		NSString TargetSecuritySystemState { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMCharacteristicTypeStreamingStatus")]
 		NSString StreamingStatus { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMCharacteristicTypeSetupStreamEndpoint")]
 		NSString SetupStreamEndpoint { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMCharacteristicTypeSupportedVideoStreamConfiguration")]
 		NSString SupportedVideoStreamConfiguration { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMCharacteristicTypeSupportedAudioStreamConfiguration")]
 		NSString SupportedAudioStreamConfiguration { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMCharacteristicTypeSupportedRTPConfiguration")]
 		NSString SupportedRtpConfiguration { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMCharacteristicTypeSelectedStreamConfiguration")]
 		NSString SelectedStreamConfiguration { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMCharacteristicTypeVolume")]
 		NSString Volume { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMCharacteristicTypeMute")]
 		NSString Mute { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMCharacteristicTypeNightVision")]
 		NSString NightVision { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMCharacteristicTypeOpticalZoom")]
 		NSString OpticalZoom { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMCharacteristicTypeDigitalZoom")]
 		NSString DigitalZoom { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMCharacteristicTypeImageRotation")]
 		NSString ImageRotation { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMCharacteristicTypeImageMirroring")]
 		NSString ImageMirroring { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[Static]
 	[Internal]
@@ -712,15 +722,16 @@ namespace XamCore.HomeKit {
 		[Field ("HMCharacteristicMetadataUnitsLux")]
 		NSString Lux { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMCharacteristicMetadataUnitsPartsPerMillion")]
 		NSString PartsPerMillion { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMCharacteristicMetadataUnitsMicrogramsPerCubicMeter")]
 		NSString MicrogramsPerCubicMeter { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	public partial interface HMCharacteristicMetadata {
@@ -748,11 +759,12 @@ namespace XamCore.HomeKit {
 		[Export ("manufacturerDescription")]
 		string ManufacturerDescription { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[NullAllowed, Export ("validValues", ArgumentSemantic.Copy)]
 		NSNumber[] ValidValues { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (HMAction))]
@@ -996,6 +1008,7 @@ namespace XamCore.HomeKit {
 		NSString UserFailedAccessoriesKey { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[Model, Protocol]
 	[BaseType (typeof (NSObject))]
@@ -1089,6 +1102,7 @@ namespace XamCore.HomeKit {
 		void DidEncounterError (HMHome home, NSError error, HMAccessory accessory);
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
@@ -1111,6 +1125,7 @@ namespace XamCore.HomeKit {
 		NSUuid UniqueIdentifier { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[Static]
 	[Internal]
@@ -1158,7 +1173,7 @@ namespace XamCore.HomeKit {
 		[Field ("HMServiceTypeDoor")]
 		NSString Door { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMServiceTypeDoorbell")]
 		NSString Doorbell { get; }
 
@@ -1218,23 +1233,24 @@ namespace XamCore.HomeKit {
 		[Field ("HMServiceTypeSecuritySystem")]
 		NSString SecuritySystem { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMServiceTypeCameraRTPStreamManagement")]
 		NSString CameraRtpStreamManagement { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMServiceTypeCameraControl")]
 		NSString CameraControl { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMServiceTypeMicrophone")]
 		NSString Microphone { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Field ("HMServiceTypeSpeaker")]
 		NSString Speaker { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	public partial interface HMService { 
@@ -1280,15 +1296,16 @@ namespace XamCore.HomeKit {
 		[Export ("uniqueIdentifier", ArgumentSemantic.Copy)]
 		NSUuid UniqueIdentifier { get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[Export ("primaryService")]
 		bool PrimaryService { [Bind ("isPrimaryService")] get; }
 
-		[Watch (3,0), TV (10,0), iOS (10,0)]
+		[Watch (3,0), iOS (10,0)]
 		[NullAllowed, Export ("linkedServices", ArgumentSemantic.Copy)]
 		HMService[] LinkedServices { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
@@ -1323,6 +1340,7 @@ namespace XamCore.HomeKit {
 		NSUuid UniqueIdentifier { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (HMTrigger))]
@@ -1365,6 +1383,7 @@ namespace XamCore.HomeKit {
 		void UpdateRecurrence ([NullAllowed] NSDateComponents recurrence, Action<NSError> completion);
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
@@ -1411,6 +1430,7 @@ namespace XamCore.HomeKit {
 		NSUuid UniqueIdentifier { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
@@ -1447,6 +1467,7 @@ namespace XamCore.HomeKit {
 
 	[Static, Internal]
 	[iOS (8,0)]
+	[TV (10,0)]
 	interface HMCharacteristicMetadataFormatKeys {
 		[Field ("HMCharacteristicMetadataFormatBool")]
 		NSString _Bool { get; }
@@ -1485,6 +1506,7 @@ namespace XamCore.HomeKit {
 		NSString _Tlv8 { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -1497,6 +1519,7 @@ namespace XamCore.HomeKit {
 		NSUuid UniqueIdentifier { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInternalInconsistencyException Reason: init is unavailable
@@ -1509,6 +1532,7 @@ namespace XamCore.HomeKit {
 		string LocalizedDescription { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (9,0)]
 	[Static]
 	[Internal]
@@ -1571,6 +1595,7 @@ namespace XamCore.HomeKit {
 		NSString RangeExtender { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (9,0)]
 	[BaseType (typeof (HMEvent))]
 	[DisableDefaultCtor]
@@ -1593,6 +1618,7 @@ namespace XamCore.HomeKit {
 		void UpdateTriggerValue ([NullAllowed] INSCopying triggerValue, Action<NSError> completion);
 	}
 
+	[TV (10,0)]
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
 	interface HMEvent {
@@ -1600,6 +1626,7 @@ namespace XamCore.HomeKit {
 		NSUuid UniqueIdentifier { get; }
 	}
 
+	[TV (10,0)]
 	[iOS (9,0)]
 	[BaseType (typeof (HMTrigger))]
 	[DisableDefaultCtor]
@@ -1658,6 +1685,7 @@ namespace XamCore.HomeKit {
 	[Static]
 	[Internal]
 	[iOS (9,0)]
+	[TV (10,0)]
 	partial interface HMSignificantEventInternal {
 		
 		[Field ("HMSignificantEventSunrise")]
@@ -1668,6 +1696,7 @@ namespace XamCore.HomeKit {
 	}
 
 	[iOS (9,0)]
+	[TV (10,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	public interface HMHomeAccessControl {
@@ -1676,6 +1705,7 @@ namespace XamCore.HomeKit {
 	}
 
 	[iOS (9,0)]
+	[TV (10,0)]
 	[BaseType (typeof (HMEvent))]
 	[DisableDefaultCtor]
 	interface HMLocationEvent {


### PR DESCRIPTION
HomeKit was added to tvOS in tvOS 10, which means every type was
introduced in tvOS 10, which means we only need availability attributes
on the types, never the individual members.