### PR TITLE
[msbuild] Add missing iOS+tvOS 10 Extension points

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
@@ -170,6 +170,13 @@ namespace Xamarin.iOS.Tasks
 							case "com.apple.spotlight.index": // iOS
 							case "com.apple.AudioUnit-UI": // iOS
 							case "com.apple.tv-services": // tvOS
+							case "com.apple.broadcast-services": // iOS+tvOS
+							case "com.apple.callkit.call-directory": // iOS
+							case "com.apple.message-payload-provider": // iOS
+							case "com.apple.intents-service": // iOS
+							case "com.apple.intents-ui-service": // iOS
+							case "com.apple.usernotifications.content-extension": // iOS
+							case "com.apple.usernotifications.service": // iOS
 								break;
 							case "com.apple.watchkit": // iOS8.2
 								if (nsExtensionAttributes == null) {


### PR DESCRIPTION
This avoid hitting https://github.com/VincentDondain/xamarin-macios/blob/544db65a8efb187e80481a0baef50fc06f8085ce/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs#L248