### PR TITLE
[mtouch] Fix incremental builds when generating P/Invoke wrappers. Fixes #44048.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -885,6 +885,10 @@ Either disable Bitcode support or enable LLVM.
 
 An error occurred when generating main.m. Please file a bug at http://bugzilla.xamarin.com.
 
+<h3><a name="MT4002"/>MT4002 Failed to compile the generated code for P/Invoke methods. Please file a bug report at http://bugzilla.xamarin.com</h3>
+
+Failed to compile the generated code for P/Invoke methods. Please file a bug report at [http://bugzilla.xamarin.com](https://bugzilla.xamarin.com/enter_bug.cgi?product=iOS).
+
 <!--
   MT41xx registrar.m
   -->

--- a/tools/common/CompilerFlags.cs
+++ b/tools/common/CompilerFlags.cs
@@ -97,6 +97,14 @@ namespace Xamarin.Utils
 			AddOtherFlag ("-lz");
 		}
 
+		public void LinkWithPInvokes (Abi abi)
+		{
+			if (!Driver.App.FastDev || !Driver.App.RequiresPInvokeWrappers)
+				return;
+
+			AddOtherFlag (Path.Combine (Cache.Location, "pinvokes." + abi.AsArchString () + ".dylib"));
+		}
+
 		public void AddFramework (string framework)
 		{
 			if (Frameworks == null)

--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -310,6 +310,7 @@ namespace Xamarin.Bundler {
 				compiler_flags.AddOtherFlags (LinkerFlags);
 				if (Target.GetEntryPoints ().ContainsKey ("UIApplicationMain"))
 					compiler_flags.AddFramework ("UIKit");
+				compiler_flags.LinkWithPInvokes (abi);
 			}
 
 			link_task = new LinkTask ()

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -618,7 +618,14 @@ namespace Xamarin.Bundler
 				// Write P/Invokes
 				var state = LinkerOptions.MarshalNativeExceptionsState;
 				state.End ();
-				RegistrarTask.Create (compile_tasks, Abis, this, state.SourcePath);
+				PinvokesTask.Create (compile_tasks, Abis, this, state.SourcePath);
+
+				if (App.FastDev) {
+					// In this case assemblies must link with the resulting dylib,
+					// so we can't compile the pinvoke dylib in parallel with later
+					// stuff.
+					compile_tasks.ExecuteInParallel ();
+				}
 			}
 
 			// Now the assemblies are in PreBuildDirectory.

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -217,6 +217,7 @@ namespace Xamarin.Bundler {
 	// MT4xxx	code generation
 	// 			MT40xx	main.m
 	//					MT4001	The main template could not be expanded to `{0}`.
+	//					MT4002	Failed to compile the generated code for P/Invoke methods. Please file a bug report at http://bugzilla.xamarin.com
 	//			MT41xx	registrar.m
 	//					MT4101	The registrar cannot build a signature for type `{0}`.
 	//					MT4102	The registrar found an invalid type `{0}` in signature for method `{2}`. Use `{1}` instead.


### PR DESCRIPTION
We need to compile the generated P/Invoke wrappers to a dylib, and link the
dylib for the product assembly (Xamarin.WatchOS.dll) with the generated
P/Invoke wrappers.

Since there might be P/Invokes in any assembly, just link in the P/Invoke
wrapper dylib for every assembly.

https://bugzilla.xamarin.com/show_bug.cgi?id=44048