### PR TITLE
[msbuild] Parse the mmp ExtraArgs to get the custom mono bundle dir name

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
@@ -203,6 +203,38 @@ namespace Xamarin.Mac.Tasks
 			return args.ToString ();
 		}
 
+		string GetMonoBundleDirName ()
+		{
+			var args = ProcessArgumentBuilder.Parse (ExtraArguments);
+
+			for (int i = 0; i < args.Length; i++) {
+				string arg;
+
+				if (string.IsNullOrEmpty (args[i]))
+					continue;
+
+				if (args[i][0] == '/') {
+					arg = args[i].Substring (1);
+				} else if (args[i][0] == '-') {
+					if (args[i].Length >= 2 && args[i][1] == '-')
+						arg = args[i].Substring (2);
+					else
+						arg = args[i].Substring (1);
+				} else {
+					continue;
+				}
+
+				if (arg.StartsWith ("custom_bundle_name:", StringComparison.Ordinal) ||
+				    arg.StartsWith ("custom_bundle_name=", StringComparison.Ordinal))
+					return arg.Substring ("custom_bundle_name=".Length);
+
+				if (arg == "custom_bundle_name" && i + 1 < args.Length)
+					return args[i + 1];
+			}
+
+			return "MonoBundle";
+		}
+
 		public override bool Execute ()
 		{
 			Log.LogTaskName ("Mmp");
@@ -233,24 +265,20 @@ namespace Xamarin.Mac.Tasks
 			if (!base.Execute ())
 				return false;
 
-			var monoBundleDir = Path.Combine (AppBundleDir, "Contents", "MonoBundle");
+			var monoBundleDir = Path.Combine (AppBundleDir, "Contents", GetMonoBundleDirName ());
 
-			if (Directory.Exists (monoBundleDir)) {
-				try {
-					var nativeLibrariesPath = Directory.EnumerateFiles (monoBundleDir, "*.dylib", SearchOption.AllDirectories);
-					var nativeLibraryItems = new List<ITaskItem> ();
+			try {
+				var nativeLibrariesPath = Directory.EnumerateFiles (monoBundleDir, "*.dylib", SearchOption.AllDirectories);
+				var nativeLibraryItems = new List<ITaskItem> ();
 
-					foreach (var nativeLibrary in nativeLibrariesPath) {
-						nativeLibraryItems.Add (new TaskItem (nativeLibrary));
-					}
-
-					NativeLibraries = nativeLibraryItems.ToArray ();
-				} catch (Exception ex) {
-					Log.LogError (null, null, null, AppBundleDir, 0, 0, 0, 0, "Could not get native libraries: {0}", ex.Message);
-					return false;
+				foreach (var nativeLibrary in nativeLibrariesPath) {
+					nativeLibraryItems.Add (new TaskItem (nativeLibrary));
 				}
-			} else {
-				NativeLibraries = new ITaskItem[0];
+
+				NativeLibraries = nativeLibraryItems.ToArray ();
+			} catch (Exception ex) {
+				Log.LogError (null, null, null, AppBundleDir, 0, 0, 0, 0, "Could not get native libraries: {0}", ex.Message);
+				return false;
 			}
 
 			return !Log.HasLoggedErrors;


### PR DESCRIPTION
The mmp utility allows users to pass -custom_bundle_name to specify
a custom directory name to use instead of MonoBundle, so we need to
parse the extra args to extract this value so that we can scan that
directory for dylibs to codesign.