### PR TITLE
[msbuild] Update classic build error

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -538,7 +538,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<Target Name="_DetectSdkLocations" DependsOnTargets="_ComputeTargetArchitectures">
 		<Error Text="Support for Classic applications (using monotouch.dll) is obsoleted in Xamarin.iOS 10.0+. Please migrate your project to Unified (Project > Migrate to Xamarin.iOS Unified API)."
-				Condition="'$(TargetFrameworkIdentifier)' == 'MonoTouch' And !Exists('$(MonoTouchSdkRoot)/lib/mono/2.1/monotouch.dll')"/>
+				Condition="'$(TargetFrameworkIdentifier)' == 'MonoTouch'"/>
 
 		<DetectSdkLocations
 			SessionId="$(BuildSessionId)"


### PR DESCRIPTION
We now want the build error to always show up.
monotouch.dll will be shipped with XI 10 to allow migration (dependent on the dll being available).
Therefore the check wasn't valid anymore because it was only applying the error if monotouch.dll wasn't there.
This was done to avoid breaking our internal tests but we should actually be fine, if not we'll update the tests.