### PR TITLE
[introspection] Show what fails in error messages.

### DIFF
--- a/tests/introspection/ApiBaseTest.cs
+++ b/tests/introspection/ApiBaseTest.cs
@@ -94,6 +94,13 @@ namespace Introspection {
 			set { logProgress.Value = value; }
 		}
 
+		StringBuilder error_data;
+		protected StringBuilder ErrorData {
+			get {
+				return error_data ?? (error_data = new StringBuilder ());
+			}
+		}
+
 		protected TextWriter Writer {
 #if MONOMAC
 			get { return Console.Out; }
@@ -112,6 +119,7 @@ namespace Introspection {
 			else {
 				Writer.Write ("[FAIL] ");
 				Writer.WriteLine (s, parameters);
+				ErrorData.AppendFormat (s, parameters).AppendLine ();
 				Errors++;
 			}
 		}

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -177,6 +177,7 @@ namespace Introspection {
 		public void DefaultCtorAllowed ()
 		{
 			Errors = 0;
+			ErrorData.Clear ();
 			int n = 0;
 			
 			foreach (Type t in Assembly.GetTypes ()) {
@@ -221,7 +222,7 @@ namespace Introspection {
 				}
 				n++;
 			}
-			Assert.AreEqual (0, Errors, "{0} potential errors found in {1} default ctor validated", Errors, n);
+			Assert.AreEqual (0, Errors, "{0} potential errors found in {1} default ctor validated{2}", Errors, n, Errors == 0 ? string.Empty : ":\n" + ErrorData.ToString () + "\n");
 		}
 
 		// .NET constructors are not virtual, so we need to re-expose the base class .ctor when a subclass is created.

--- a/tests/introspection/ApiPInvokeTest.cs
+++ b/tests/introspection/ApiPInvokeTest.cs
@@ -165,6 +165,7 @@ namespace Introspection
 		protected void Check (Assembly a)
 		{
 			Errors = 0;
+			ErrorData.Clear ();
 			int n = 0;
 			foreach (var t in a.GetTypes ()) {
 				foreach (var m in t.GetMethods (BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)) {
@@ -202,7 +203,7 @@ namespace Introspection
 					n++;
 				}
 			}
-			Assert.AreEqual (0, Errors, "{0} errors found in {1} symbol lookups", Errors, n);
+			Assert.AreEqual (0, Errors, "{0} errors found in {1} symbol lookups{2}", Errors, n, Errors == 0 ? string.Empty : ":\n" + ErrorData.ToString () + "\n");
 		}
 
 		protected abstract bool SkipAssembly (Assembly a);

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -243,6 +243,7 @@ namespace Introspection {
 		public void InstanceMethods ()
 		{
 			Errors = 0;
+			ErrorData.Clear ();
 			int n = 0;
 			
 			foreach (Type t in Assembly.GetTypes ()) {
@@ -265,7 +266,7 @@ namespace Introspection {
 					Process (class_ptr, t, m, ref n);
 				}
 			}
-			Assert.AreEqual (0, Errors, "{0} errors found in {1} instance selector validated", Errors, n);
+			Assert.AreEqual (0, Errors, "{0} errors found in {1} instance selector validated{2}", Errors, n, Errors == 0 ? string.Empty : ":\n" + ErrorData.ToString () + "\n");
 		}
 
 		void Process (IntPtr class_ptr, Type t, MethodBase m, ref int n)
@@ -364,6 +365,7 @@ namespace Introspection {
 		public void StaticMethods ()
 		{
 			Errors = 0;
+			ErrorData.Clear ();
 			int n = 0;
 			
 			IntPtr responds_handle = Selector.GetHandle ("respondsToSelector:");
@@ -400,7 +402,7 @@ namespace Introspection {
 					}
 				}
 			}
-			Assert.AreEqual (0, Errors, "{0} errors found in {1} static selector validated", Errors, n);
+			Assert.AreEqual (0, Errors, "{0} errors found in {1} static selector validated{2}", Errors, n, Errors == 0 ? string.Empty : ":\n" + ErrorData.ToString () + "\n");
 		}
 	}
 }

--- a/tests/introspection/ApiSignatureTest.cs
+++ b/tests/introspection/ApiSignatureTest.cs
@@ -187,6 +187,7 @@ namespace Introspection {
 		{
 			int n = 0;
 			Errors = 0;
+			ErrorData.Clear ();
 			
 			foreach (Type t in Assembly.GetTypes ()) {
 
@@ -209,7 +210,7 @@ namespace Introspection {
 				foreach (MethodBase m in t.GetConstructors (Flags)) 
 					CheckMemberSignature (m, t, class_ptr, ref n);
 			}
-			AssertIfErrors ("{0} errors found in {1} signatures validated", Errors, n);
+			AssertIfErrors ("{0} errors found in {1} signatures validated{2}", Errors, n, Errors == 0 ? string.Empty : ":\n" + ErrorData.ToString () + "\n");
 		}
 
 		void CheckMemberSignature (MethodBase m, Type t, IntPtr class_ptr, ref int n)


### PR DESCRIPTION
So that we're not clueless when Console.WriteLines go looking for dragons
instead of showing up somewhere we can read.