### PR TITLE
[mtouch] Require deployment target to be 8+ for incremental builds.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -315,11 +315,11 @@ This usually indicates a bug in Xamarin.iOS; please file a bug report at http://
 
 This usually indicates a bug in Xamarin.iOS; please file a bug report at http://bugzilla.xamarin.com with a test case.
 
-<h3><a name="MT0078"/>MT0077: Incremental builds are enabled with a deployment target < 7.0 (currently *). This is not supported (the resulting application will not launch on iOS 9), so the deployment target will be set to 7.0.</h3>
+<h3><a name="MT0078"/>MT0077: Incremental builds are enabled with a deployment target < 8.0 (currently *). This is not supported (the resulting application will not launch on iOS 9), so the deployment target will be set to 8.0.</h3>
 
-This is a warning informing that the deployment target has been set to 7.0 for this build so that incremental builds work properly.
+This is a warning informing that the deployment target has been set to 8.0 for this build so that incremental builds work properly.
 
-Incremental builds are only supported when the deployment target is at least 7.0 (because the resulting application will not launch on iOS 9 otherwise).
+Incremental builds are only supported when the deployment target is at least 8.0 (because the resulting application will not launch on iOS 9 otherwise).
 
 <h3><a name="MT0079"/>MT0078: The recommended Xcode version for Xamarin.iOS * is Xcode * or later. The current Xcode version (found in *) is *.</h3>
 

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -762,9 +762,9 @@ namespace Xamarin.Bundler {
 				throw new MonoTouchException (74, true, "Xamarin.iOS {0} does not support a deployment target of {1} for {3} (the maximum is {2}). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of Xamarin.iOS.", Constants.Version, DeploymentTarget, Xamarin.SdkVersions.GetVersion (Platform), PlatformName);
 			}
 
-			if (Platform == ApplePlatform.iOS && FastDev && DeploymentTarget.Major < 7) {
-				ErrorHelper.Warning (78, "Incremental builds are enabled with a deployment target < 7.0 (currently {0}). This is not supported (the resulting application will not launch on iOS 9), so the deployment target will be set to 7.0.", DeploymentTarget);
-				DeploymentTarget = new Version (7, 0);
+			if (Platform == ApplePlatform.iOS && FastDev && DeploymentTarget.Major < 8) {
+				ErrorHelper.Warning (78, "Incremental builds are enabled with a deployment target < 8.0 (currently {0}). This is not supported (the resulting application will not launch on iOS 9), so the deployment target will be set to 8.0.", DeploymentTarget);
+				DeploymentTarget = new Version (8, 0);
 			}
 
 			if (Driver.classic_only_arguments.Count > 0) {

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -85,7 +85,7 @@ namespace Xamarin.Bundler {
 	//					MT0075	Invalid architecture '{0}' for {1} projects. Valid architectures are: {2}
 	//					MT0076	No architecture specified (using the --abi argument). An architecture is required for {0} projects.
 	//					MT0077	WatchOS projects must be extensions.
-	//					MT0078	Incremental builds are enabled with a deployment target < 7.0 (currently {0}). This is not supported (the resulting application will not launch on iOS 9), so the deployment target will be set to 7.0.
+	//					MT0078	Incremental builds are enabled with a deployment target < 8.0 (currently {0}). This is not supported (the resulting application will not launch on iOS 9), so the deployment target will be set to 8.0.
 	//		Warning		MT0079	The recommended Xcode version for Xamarin.iOS {0} is Xcode 7.0 or later. The current Xcode version (found in {2}) is {1}.
 	//		Warning		MT0080  Disabling NewRefCount, --new-refcount:false, is deprecated.
 	//					MT0081	The command line argument --download-crash-report also requires --download-crash-report-to.


### PR DESCRIPTION
This is something that changed with 70f1346b: our libxamarin.dylib now
requires iOS 8+, which means the app itself must require iOS 8+ when using
libxamarin.dylib.

This fixes an msbuild failure (Xamarin.iOS.Tasks.IBToolLinking("iPhone").BuildTest):

    Process exited with code 1, command:
    /Applications/Xcode73.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang  -framework Foundation -framework UIKit /Users/builder/data/lanes/1381/5f73edaa/source/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/MonoTouch.iphoneos.sdk/usr/lib/libmonosgen-2.0.dylib /Users/builder/data/lanes/1381/5f73edaa/source/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/MonoTouch.iphoneos.sdk/usr/lib/libxamarin-debug.dylib -lz -isysroot /Applications/Xcode73.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk -Qunused-arguments -miphoneos-version-min=7.0 -arch armv7 -shared -read_only_relocs suppress -install_name @executable_path/libXamarin.iOS.dll.dylib -fapplication-extension -o /Users/builder/data/lanes/1381/5f73edaa/source/xamarin-macios/msbuild/tests/MyIBToolLinkTest/obj/iPhone/Debug/mtouch-cache/Xamarin.iOS.dll.armv7.dylib -x assembler /Users/builder/data/lanes/1381/5f73edaa/source/xamarin-macios/msbuild/tests/MyIBToolLinkTest/obj/iPhone/Debug/mtouch-cache/Xamarin.iOS.dll.armv7.s -DDEBUG
    ld: warning: embedded dylibs/frameworks only run on iOS 8 or later
    ld: embedded dylibs/frameworks are only supported on iOS 8.0 and later (@executable_path/libxamarin-debug.dylib) for architecture armv7
    clang: error: linker command failed with exit code 1 (use -v to see invocation)