### PR TITLE
[ReplayKit] Fix RPBroadcastConfiguration.VideoCompressionProperties to have the right type and provide a strongly typed version as well.

### DIFF
--- a/src/ReplayKit/RPBroadcastConfiguration.cs
+++ b/src/ReplayKit/RPBroadcastConfiguration.cs
@@ -1,0 +1,55 @@
+// 
+// RPBroadcastConfiguration.cs:
+//
+// Authors: Rolf Bjarne Kvinge <rolf@xamarin.com>
+//     
+// Copyright 2016 Xamarin Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Drawing;
+using System.Diagnostics;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+using XamCore.Foundation;
+using XamCore.AVFoundation;
+
+namespace XamCore.ReplayKit {
+	public partial class RPBroadcastConfiguration {
+		public AVVideoCodecSettings VideoCompressionProperties {
+			get {
+				var weak = WeakVideoCompressionProperties; 
+				return weak == null ? null : new AVVideoCodecSettings (new NSMutableDictionary (weak));
+			}
+			set {
+#if XAMCORE_2_0
+				WeakVideoCompressionProperties = value == null ? null : new NSDictionary<NSString, INSSecureCoding> (value.Dictionary.Handle);
+#else
+				WeakVideoCompressionProperties = value == null ? null : new NSDictionary (value.Dictionary.Handle);
+#endif
+			}
+		}		
+	}
+}

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1097,6 +1097,9 @@ QUICKLOOKUI_SOURCES = \
 REPLAYKIT_API_SOURCES = \
 	ReplayKit/RPEnums.cs \
 
+REPLAYKIT_SOURCES = \
+	ReplayKit/RPBroadcastConfiguration.cs \
+
 # SafariServices
 
 SAFARISERVICES_API_SOURCES = \

--- a/src/replaykit.cs
+++ b/src/replaykit.cs
@@ -8,6 +8,7 @@
 //
 
 using System;
+using XamCore.AVFoundation;
 using XamCore.CoreMedia;
 using XamCore.ObjCRuntime;
 using XamCore.Foundation;
@@ -203,9 +204,8 @@ namespace XamCore.ReplayKit {
 		[Export ("clipDuration")]
 		double ClipDuration { get; set; }
 
-		// TODO review, once API documentation is available, if we can provide an easier to use strongdictionary
 		[NullAllowed, Export ("videoCompressionProperties", ArgumentSemantic.Strong)]
-		NSDictionary<NSNumber, INSSecureCoding> VideoCompressionProperties { get; set; }
+		NSDictionary<NSString, INSSecureCoding> WeakVideoCompressionProperties { get; set; }
 	}
 
 	delegate void LoadBroadcastingHandler (string bundleID, string displayName, UIImage appIcon);


### PR DESCRIPTION
The video compression property is defined as this in the headers:

    NSDictionary <NSString *, NSObject <NSCoding, NSSecureCoding> *>

so I'm not sure how it ended up being bound as NSDictionary<NSNumber,
NSSecureCoding> (maybe something from an earlier beta?).

I'm also adding a strongly typed version of the dictionary, since the header
documentation says "AVVideoCompressionPropertiesKey in
<AVFoundation/AVVideoSettings.h> for available properties.".

The manual binding is required because the generator doesn't like generic weak
dictionaries (it generates invalid code).