### PR TITLE
[security/tls] Fix support for HTTPS server with virtual domains. Fixes #42796 and #44225

### DIFF
--- a/src/Security/Tls/AppleTlsContext.cs
+++ b/src/Security/Tls/AppleTlsContext.cs
@@ -317,6 +317,12 @@ namespace XamCore.Security.Tls
 
 			if (AskForClientCertificate)
 				SetClientSideAuthenticate (SslAuthenticate.Try);
+
+			IPAddress address;
+			if (!IsServer && !string.IsNullOrEmpty (TargetHost) &&
+			    !IPAddress.TryParse (TargetHost, out address)) {
+				PeerDomainName = TargetHost;
+			}
 		}
 
 		void InitializeSession ()


### PR DESCRIPTION
PR 525 was never applied to master so it's not in cycle8.
https://github.com/xamarin/maccore/pull/525

references:
https://bugzilla.xamarin.com/show_bug.cgi?id=44225
https://bugzilla.xamarin.com/show_bug.cgi?id=42796