### PR TITLE
[generator] Fix bug 43579 - Generator emits invalid code when using the same method name (overload) in @delegates using events and C# delegates

### DIFF
--- a/docs/website/binding_types_reference_guide.md
+++ b/docs/website/binding_types_reference_guide.md
@@ -148,7 +148,7 @@ declaration in your Model class. For example:
 
 ```
 [BaseType (typeof (UINavigationControllerDelegate))]
-[Model]
+[Model][Protocol]
 public interface UIImagePickerControllerDelegate {
     [Export ("imagePickerController:didFinishPickingImage:editingInfo:"), EventArgs ("UIImagePickerImagePicked")]
     void FinishedPickingImage (UIImagePickerController picker, UIImage image, NSDictionary editingInfo);
@@ -180,7 +180,7 @@ himself. For example, the `ShouldScrollToTop` definition is this:
 
 ```
 [BaseType (typeof (NSObject))]
-[Model]
+[Model][Protocol]
 public interface UIScrollViewDelegate {
     [Export ("scrollViewShouldScrollToTop:"), DelegateName ("UIScrollViewCondition"), DefaultValue ("true")]
     bool ShouldScrollToTop (UIScrollView scrollView);
@@ -270,7 +270,7 @@ public interface UIAccelerometer {
 }
 
 [BaseType (typeof (NSObject))]
-[Model]
+[Model][Protocol]
 public interface UIAccelerometerDelegate {
 }
 ```
@@ -301,7 +301,7 @@ public interface UIActionSheet {
 }
 
 [BaseType (typeof (NSObject))]
-[Model]
+[Model][Protocol]
 public interface UIActionSheetDelegate {
     [Export ("actionSheet:didDismissWithButtonIndex:"), EventArgs ("UIButton")]
     void Dismissed (UIActionSheet actionSheet, nint buttonIndex);
@@ -443,7 +443,7 @@ The following is taken from Xamarin.iOS:
 
 ```
 [BaseType (typeof (NSObject))]
-[Model]
+[Model][Protocol]
 public interface UITableViewDataSource {
     [Export ("tableView:numberOfRowsInSection:")]
     [Abstract]
@@ -477,7 +477,7 @@ attribute:
 
 ```
 [BaseType (typeof (NSObject))]
-[Model]
+[Model][Protocol]
 interface CameraDelegate {
     [Export ("camera:shouldPromptForAction:"), DefaultValue (false)]
     bool ShouldUploadToServer (Camera camera, CameraAction action);
@@ -517,7 +517,7 @@ Example:
 
 ```
 [BaseType (typeof (NSObject))]
-[Model]
+[Model][Protocol]
 public interface NSAnimationDelegate {
     [Export ("animation:valueForProgress:"), DelegateName ("NSAnimationProgress"), DefaultValueFromArgumentAttribute ("progress")]
     float ComputeAnimationCurve (NSAnimation animation, nfloat progress);
@@ -536,6 +536,28 @@ also: [NoDefaultValueAttribute](#NoDefaultValueAttribute), [DefaultValueAttribut
 
 
 
+## IgnoredInDelegateAttribute
+
+Sometimes it makes sense not to expose an event or delegate property from a 
+Model class into the host class so adding this attribute will instruct the
+generator to avoid the generation of any method decorated with it.
+
+```
+[BaseType (typeof (UINavigationControllerDelegate))]
+[Model][Protocol]
+public interface UIImagePickerControllerDelegate {
+    [Export ("imagePickerController:didFinishPickingImage:editingInfo:"), EventArgs ("UIImagePickerImagePicked")]
+    void FinishedPickingImage (UIImagePickerController picker, UIImage image, NSDictionary editingInfo);
+    
+    [Export ("imagePickerController:didFinishPickingImage:"), IgnoredInDelegate)] // No event generated for this method
+    void FinishedPickingImage (UIImagePickerController picker, UIImage image);
+}
+```
+
+ <a name="IgnoredInDelegateAttribute" class="injected"></a>
+
+
+
 ## DelegateNameAttribute
 
 This attribute is used in Model methods that return values to set the name of
@@ -545,7 +567,7 @@ Example:
 
 ```
 [BaseType (typeof (NSObject))]
-[Model]
+[Model][Protocol]
 public interface NSAnimationDelegate {
     [Export ("animation:valueForProgress:"), DelegateName ("NSAnimationProgress"), DefaultValueFromArgumentAttribute ("progress")]
     float ComputeAnimationCurve (NSAnimation animation, float progress);
@@ -562,6 +584,38 @@ public delegate float NSAnimationProgress (MonoMac.AppKit.NSAnimation animation,
  <a name="EventArgsAttribute" class="injected"></a>
 
 
+
+## DelegateApiNameAttribute
+
+This attribute is used to allow the generator to change the name of the property generated
+in the host class. Sometimes it is useful when the name of the FooDelegate class method 
+makes sense for the Delegate class, but would look odd in the host class as a property.
+
+Also this is really useful (and needed) when you have two or more overload methods that makes
+sense to keep them named as is in the FooDelegate class but you want to expose them in the host
+class with a better given name.
+
+Example:
+
+```
+[BaseType (typeof (NSObject))]
+[Model][Protocol]
+public interface NSAnimationDelegate {
+    [Export ("animation:valueForProgress:"), DelegateApiName ("ComputeAnimationCurve"), DelegateName ("Func<NSAnimation, float, float>"), DefaultValueFromArgument ("progress")]
+    float GetValueForProgress (NSAnimation animation, float progress);
+}
+```
+
+With the above definition, the generator will produce the following public
+declaration in the host class:
+
+```
+public Func<NSAnimation, float, float> ComputeAnimationCurve { get; set; }
+```
+
+ <a name="DelegateApiNameAttribute" class="injected"></a>
+ 
+ 
 ## EventArgsAttribute
 
 For events that take more than one parameter (in Objective-C the convention
@@ -574,7 +628,7 @@ For example:
 
 ```
 [BaseType (typeof (UINavigationControllerDelegate))]
-[Model]
+[Model][Protocol]
 public interface UIImagePickerControllerDelegate {
     [Export ("imagePickerController:didFinishPickingImage:editingInfo:"), EventArgs ("UIImagePickerImagePicked")]
     void FinishedPickingImage (UIImagePickerController picker, UIImage image, NSDictionary editingInfo);
@@ -652,7 +706,7 @@ specified selector is implemented in this class.
 
 ```
 [BaseType (typeof (NSObject))]
-[Model]
+[Model][Protocol]
 interface CameraDelegate {
     [Export ("shouldDisplayPopup"), NoDefaultValoue]
     bool ShouldUploadToServer ();
@@ -1623,7 +1677,7 @@ interface Demo {
 }
 
 [BaseType (typeof (NSObject))]
-[Model]
+[Model][Protocol]
 interface DemoDelegate {
     [Export ("doDemo")]
     void DoDemo ();

--- a/src/error.cs
+++ b/src/error.cs
@@ -57,6 +57,8 @@ using System.Collections.Generic;
 //		BI1040 The selector {0} on type {1} is found multiple times with different argument out states on argument {2}.
 //		BI1041 The selector {0} on type {1} is found multiple times with different argument types on argument {2} - {3} : {4}.
 //		BI1042 Missing '[Field (LibraryName=value)]' for {field_pi.Name} (e.g."__Internal")
+//		BI1043 Repeated overload {mi.Name} and no [DelegateApiNameAttribute] provided to generate property name on host class.
+//		BI1044 Repeated name '{apiName.Name}' provided in [DelegateApiNameAttribute].
 //	BI11xx	warnings
 //		BI1101 Trying to use a string as a [Target]
 //		BI1102 Using the deprecated EventArgs for a delegate signature in {0}.{1}, please use DelegateName instead

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -13,7 +13,7 @@ include $(TOP)/Make.config
 
 IOS_CURRENT_DIR=$(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current
 IOS_GENERATOR = $(IOS_CURRENT_DIR)/bin/btouch /baselib:$(IOS_CURRENT_DIR)/lib/mono/2.1/monotouch.dll /unsafe /compiler:$(IOS_CURRENT_DIR)/bin/smcs
-IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts
+IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts bug43579
 IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176
 
 MAC_CURRENT_DIR=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current

--- a/tests/generator/bug43579.cs
+++ b/tests/generator/bug43579.cs
@@ -1,0 +1,48 @@
+using System;
+
+using MonoTouch.Foundation;
+using MonoTouch.ObjCRuntime;
+
+namespace bug43579 {
+
+	interface IFooDelegate { }
+
+	[BaseType (typeof (NSObject))]
+	[Model]
+	[Protocol]
+	interface FooDelegate {
+
+		// Events
+		[Export ("FooDidEndEditing:"), EventArgs ("FooDelegateEnded"), EventName ("Ended")]
+		void EditingEnded (Foo foo);
+
+		[Export ("FooDidEndEditing:after:"), EventArgs ("FooDelegateEndedTime"), EventName ("EndedAfter")]
+		void EditingEnded (Foo foo, double time);
+
+		[Export ("FooDidEndEditing:after:index:"), IgnoredInDelegate]
+		void EditingEnded (Foo foo, double time, int index);
+
+
+		// Using Func
+		[Export ("foo:dobar:"), DelegateName ("Func<Foo,int,bool>"), DefaultValue ("true")]
+		bool DoBar (Foo foo, int bar);
+
+		[Export ("foo:doBar:after:"), DelegateApiName ("DoBarAfter"), DelegateName ("Func<Foo,int,double,bool>"), DefaultValue ("true")]
+		bool DoBar (Foo foo, int bar, double time);
+
+
+		// Using an actual DelegateName
+		[Export ("foo:doAnotherBar:"), DelegateName ("FooDelegateAnotherBar"), DefaultValue ("true")]
+		bool DoAnotherBar (Foo foo, int bar);
+
+		[Export ("foo:doAnotherBar:after:"), DelegateApiName ("DoAnotherBarAfter"), DelegateName ("FooDelegateAnotherBarTime"), DefaultValue ("true")]
+		bool DoAnotherBar (Foo foo, int bar, double time);
+	}
+
+	[BaseType (typeof (NSObject), Delegates = new string [] { "Delegate" }, Events = new Type [] { typeof (FooDelegate) })]
+	interface Foo {
+
+		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
+		IFooDelegate Delegate { get; set; }
+	}
+}


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=43579

Bug Description:
Generator will emit invalid code when using the same name (overload)
in a method inside a @delegate (protocol) that is decorated
either with EventArgs or DelegateName

-----------------------------------------------------------------

This commit introduces a new attribute named `DelegateApiNameAttribute`
which mimics the `EventNameAttribute` but for delegate properties in
host classes

It is used to specify the delegate property name that will be created when
the generator creates the delegate property on the host
class that holds events and delegates.

This is really useful when you have two overload methods that makes
sense to keep them named as is but you want to expose them in the host class
with a better given name.

example:
```
 interface SomeDelegate {
     [Export ("foo"), DelegateApiName ("Confirmation"), DelegateName ("Func<bool>"), DefaultValue (false)]
     bool Confirm (Some source);
 }
```

 Generates propety in the host class:
	`Func<bool> Confirmation { get; set; }`

This also introduces two new BIXXXX errors:
- BI1043 Repeated overload {mi.Name} and no [DelegateApiNameAttribute]
provided to generate property name on host class.
- BI1044 Repeated name '{apiName.Name}' provided in [DelegateApiNameAttribute].

Which provides an error instead of generating invalid C# code.

Generator test included :D

Build Diff: https://gist.github.com/dalexsoto/647e3d4a97e07ef612475b56054b8e4e