### PR TITLE
[avfoundation] Add missing setters on AVAssetDownloadOptions properties. Fixes #44201

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -10442,8 +10442,8 @@ namespace XamCore.AVFoundation {
 	[NoWatch]
 	[StrongDictionary ("AVAssetDownloadTaskKeys")]
 	interface AVAssetDownloadOptions {
-		NSNumber MinimumRequiredMediaBitrate { get; }
-		AVMediaSelection MediaSelection { get; }
+		NSNumber MinimumRequiredMediaBitrate { get; set; }
+		AVMediaSelection MediaSelection { get; set; }
 	}
 
 	[NoTV]


### PR DESCRIPTION
AVAssetDownloadOptions is a strong dictionary.

https://bugzilla.xamarin.com/show_bug.cgi?id=44201