### PR TITLE
Enables CoreCompile target for WatchOS App projects

### DIFF
--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -105,6 +105,7 @@ endif
 WATCH_TARGETS =                                                  \
 	$(wildcard Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.*.props)   \
 	$(wildcard Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.*.targets) \
+	Xamarin.iOS.Tasks.Core/NoCode.cs                             \
 
 WATCH_DIRECTORIES =                                                                                             \
 	$(IOS_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild-frameworks/Xamarin.WatchOS/v1.0/RedistList \

--- a/msbuild/Xamarin.iOS.Tasks.Core/NoCode.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/NoCode.cs
@@ -1,0 +1,1 @@
+﻿//This is file is used to avoid a Build Error in Xbuild and a Build Warning in MSBuild.

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.Common.targets
@@ -99,6 +99,10 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 	<Target Name="CopyFilesToOutputDirectory" />
 	<Target Name="CreateIpa"/>
 
+	<ItemGroup>
+		<Compile Include="$(MSBuildThisFileDirectory)NoCode.cs" />
+	</ItemGroup>
+
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.Common.targets
@@ -97,7 +97,6 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="CopyFilesToOutputDirectory" />
-	<Target Name="CoreCompile" />
 	<Target Name="CreateIpa"/>
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
@@ -54,6 +54,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="NoCode.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Tasks\ACToolTaskBase.cs" />
     <Compile Include="Tasks\ArchiveTaskBase.cs" />


### PR DESCRIPTION
The iOS Designer depends on Roslyn Workspace APIs to inspect and get notified of project changes, which needs CoreCompile target to work.

Fixes Bug #41766 (https://bugzilla.xamarin.com/show_bug.cgi?id=41766)