### PR TITLE
[modelio] Add missing availability attributes on new API. Fixes #44192

### DIFF
--- a/src/ModelIO/MDLMesh.cs
+++ b/src/ModelIO/MDLMesh.cs
@@ -49,21 +49,25 @@ namespace XamCore.ModelIO {
 			InitializeHandle (InitMesh (mesh, submeshIndex, subdivisionLevels, allocator), "initMeshBySubdividingMesh:submeshIndex:subdivisionLevels:allocator:");
 		}
 
+		[iOS (10,0)][TV (10,0)][Mac (10,12)]
 		public static MDLMesh CreateSphere (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, IMDLMeshBufferAllocator allocator)
 		{
 			return new MDLMesh (dimensions, segments, inwardNormals, geometryType, allocator, null, null, null);
 		}
 
+		[iOS (10,0)][TV (10,0)][Mac (10,12)]
 		public static MDLMesh CreateHemisphere (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, bool cap, IMDLMeshBufferAllocator allocator)
 		{
 			return new MDLMesh (dimensions, segments, inwardNormals, geometryType, allocator, null, cap, false);
 		}
 
+		[iOS (10,0)][TV (10,0)][Mac (10,12)]
 		public static MDLMesh CreateCapsule (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, int hemisphereSegments, IMDLMeshBufferAllocator allocator)
 		{
 			return new MDLMesh (dimensions, segments, inwardNormals, geometryType, allocator, hemisphereSegments, null, null);
 		}
 
+		[iOS (10,0)][TV (10,0)][Mac (10,12)]
 		public static MDLMesh CreateCone (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, bool cap, IMDLMeshBufferAllocator allocator)
 		{
 			return new MDLMesh (dimensions, segments, inwardNormals, geometryType, allocator, null, cap, true);

--- a/tests/monotouch-test/ModelIO/MDLMesh.cs
+++ b/tests/monotouch-test/ModelIO/MDLMesh.cs
@@ -184,6 +184,8 @@ namespace MonoTouchFixtures.ModelIO {
 		[Test]
 		public void CreateSphereTest ()
 		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+
 			Vector3 V3 = new Vector3 (1, 2, 3);
 			Vector2i V2i = new Vector2i (4, 5);
 
@@ -201,6 +203,8 @@ namespace MonoTouchFixtures.ModelIO {
 		[Test]
 		public void CreateHemisphereTest ()
 		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+
 			Vector3 V3 = new Vector3 (1, 2, 3);
 			Vector2i V2i = new Vector2i (4, 5);
 
@@ -218,6 +222,8 @@ namespace MonoTouchFixtures.ModelIO {
 		[Test]
 		public void CreateCapsuleTest ()
 		{
+			TestRuntime.AssertXcodeVersion (8,0);
+
 			Vector3 V3 = new Vector3 (1, 2, 3);
 			Vector2i V2i = new Vector2i (4, 5);
 
@@ -235,6 +241,8 @@ namespace MonoTouchFixtures.ModelIO {
 		[Test]
 		public void CreateConeTest ()
 		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+
 			Vector3 V3 = new Vector3 (1, 2, 3);
 			Vector2i V2i = new Vector2i (4, 5);
 

--- a/tests/monotouch-test/ModelIO/MDLTransform.cs
+++ b/tests/monotouch-test/ModelIO/MDLTransform.cs
@@ -77,21 +77,24 @@ namespace MonoTouchFixtures.ModelIO {
 				Asserts.AreEqual (Vector3.One, obj.Scale, "Scale");
 				Asserts.AreEqual (Vector3.Zero, obj.Rotation, "Rotation");
 				Asserts.AreEqual (id, obj.Matrix, "Matrix");
-				Asserts.AreEqual (false, obj.ResetsTransform, "ResetsTransform");
+				if (TestRuntime.CheckXcodeVersion (8,0))
+					Asserts.AreEqual (false, obj.ResetsTransform, "ResetsTransform");
 
 				obj.Translation = V3;
 				Asserts.AreEqual (V3, obj.Translation, "Translation 2");
 			}
 
-			using (var obj = new MDLTransform (id, true)) {
-				Asserts.AreEqual (Vector3.Zero, obj.Translation, "Translation");
-				Asserts.AreEqual (Vector3.One, obj.Scale, "Scale");
-				Asserts.AreEqual (Vector3.Zero, obj.Rotation, "Rotation");
-				Asserts.AreEqual (id, obj.Matrix, "Matrix");
-				Asserts.AreEqual (true, obj.ResetsTransform, "ResetsTransform");
+			if (TestRuntime.CheckXcodeVersion (8, 0)) {
+				using (var obj = new MDLTransform (id, true)) {
+					Asserts.AreEqual (Vector3.Zero, obj.Translation, "Translation");
+					Asserts.AreEqual (Vector3.One, obj.Scale, "Scale");
+					Asserts.AreEqual (Vector3.Zero, obj.Rotation, "Rotation");
+					Asserts.AreEqual (id, obj.Matrix, "Matrix");
+					Asserts.AreEqual (true, obj.ResetsTransform, "ResetsTransform");
 
-				obj.Translation = V3;
-				Asserts.AreEqual (V3, obj.Translation, "Translation 2");
+					obj.Translation = V3;
+					Asserts.AreEqual (V3, obj.Translation, "Translation 2");
+				}
 			}
 
 			using (var obj = new MDLTransform (id)) {


### PR DESCRIPTION
and ignore them when running tests on older devices, e.g. iOS 9.3.x

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=44192