### PR TITLE
[generator] Add more control over generated enums/fields

### DIFF
--- a/docs/website/binding_objc_libs.md
+++ b/docs/website/binding_objc_libs.md
@@ -779,6 +779,67 @@ interface LonelyClass {
  <a name="Binding_Notifications" class="injected"></a>
 
 
+## Binding Enums
+
+You can add `enum` directly in your binding files to makes it easier
+to use them inside API definitions - without using a different source
+file (that needs to be compiled in both the bindings and the final 
+project).
+
+Example:
+
+```
+[Native] // needed for enums defined as NSInteger in ObjC
+enum MyEnum {}
+
+interface MyType {
+	[Export ("initWithEnum:")]
+	Int Constructor (MyEnum value);
+}
+```
+
+It is also possible to create your own enums to replace `NSString`
+constants. In this case the generator will **automatically** create the
+methods to convert enums values and NSString constants for you.
+
+Example:
+
+```
+enum NSRunLoopMode {
+
+	[DefaultEnumValue]
+	[Field ("NSDefaultRunLoopMode")]
+	Default,
+
+	[Field ("NSRunLoopCommonModes")]
+	Common,
+	
+	[Field (null)]
+	Other = 1000
+}
+
+interface MyType {
+	[Export ("performForMode:")]
+	void Perform (NSString mode);
+ 
+	[Wrap ("Perform (mode.GetConstant ())")]
+	void Perform (NSRunLoopMode mode);
+}
+```
+
+In the above example you could decide to decorate `void Perform (NSString mode);`
+with an `[Internal]` attribute. This will **hide** the constant-based API
+from your binding consumers.
+
+However this would limit subclassing the type as the nicer API alternative
+uses a `[Wrap]` attribute. Those generated methods are not `virtual`, i.e.
+you won't be able to override them - which may, or not, be a good choice.
+
+An alternative is to mark the original, `NSString`-based, definition as 
+`[Protected]`. This will allow subclassing to work, when required, and 
+the wrap'ed version will still work and call the overriden method.
+
+
 ## Binding Notifications
 
 Notifications are messages that are posted to the

--- a/docs/website/binding_objc_libs.md
+++ b/docs/website/binding_objc_libs.md
@@ -794,7 +794,7 @@ enum MyEnum {}
 
 interface MyType {
 	[Export ("initWithEnum:")]
-	Int Constructor (MyEnum value);
+	IntPtr Constructor (MyEnum value);
 }
 ```
 

--- a/src/error.cs
+++ b/src/error.cs
@@ -59,6 +59,7 @@ using System.Collections.Generic;
 //		BI1042 Missing '[Field (LibraryName=value)]' for {field_pi.Name} (e.g."__Internal")
 //		BI1043 Repeated overload {mi.Name} and no [DelegateApiNameAttribute] provided to generate property name on host class.
 //		BI1044 Repeated name '{apiName.Name}' provided in [DelegateApiNameAttribute].
+//		BI1045 Only a single [DefaultEnumValue] attribute can be used inside enum {type.Name}.
 //	BI11xx	warnings
 //		BI1101 Trying to use a string as a [Target]
 //		BI1102 Using the deprecated EventArgs for a delegate signature in {0}.{1}, please use DelegateName instead

--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -21,6 +21,14 @@ public class ErrorDomainAttribute : Attribute {
 	public string ErrorDomain { get; set; }
 }
 
+[AttributeUsage (AttributeTargets.Field)]
+public class DefaultEnumValueAttribute : Attribute {
+
+	public DefaultEnumValueAttribute ()
+	{
+	}
+}
+
 public partial class Generator {
 
 	static string GetCSharpTypeName (Type type)
@@ -64,6 +72,8 @@ public partial class Generator {
 		}
 
 		var fields = new Dictionary<FieldInfo, FieldAttribute> ();
+		Tuple<FieldInfo, FieldAttribute> null_field = null;
+		Tuple<FieldInfo, FieldAttribute> default_symbol = null;
 		print ("public enum {0} : {1} {{", type.Name, GetCSharpTypeName (Enum.GetUnderlyingType (type)));
 		indent++;
 		foreach (var f in type.GetFields ()) {
@@ -77,7 +87,15 @@ public partial class Generator {
 				continue;
 			if (f.IsUnavailable ())
 				continue;
-			fields.Add (f, fa);
+			if (fa.SymbolName == null)
+				null_field = new Tuple<FieldInfo, FieldAttribute> (f, fa);
+			else
+				fields.Add (f, fa);
+			if (GetAttribute<DefaultEnumValueAttribute> (f) != null) {
+				if (default_symbol != null)
+					throw new BindingException (1045, true, $"Only a single [DefaultEnumValue] attribute can be used inside enum {type.Name}.");
+				default_symbol = new Tuple<FieldInfo, FieldAttribute> (f, fa);
+			}
 		}
 		indent--;
 		print ("}");
@@ -146,13 +164,22 @@ public partial class Generator {
 			print ("public static NSString GetConstant (this {0} self)", type.Name);
 			print ("{");
 			indent++;
+			print ("switch (self) {");
+			var default_symbol_name = default_symbol?.Item2.SymbolName;
 			foreach (var kvp in fields) {
-				print ("if (self == {0}.{1})", type.Name, kvp.Key.Name);
+				print ("case {0}.{1}:", type.Name, kvp.Key.Name);
+				var sn = kvp.Value.SymbolName;
+				if (sn == default_symbol_name)
+					print ("default:");
 				indent++;
-				print ("return {0};", kvp.Value.SymbolName);
+				print ("return {0};", sn);
 				indent--;
 			}
-			print ("return null;");
+			print ("}");
+			if (default_symbol_name == null) {
+				// note: a `[Field (null)]` does not need extra code
+				print ("return null;");
+			}
 			indent--;
 			print ("}");
 			
@@ -163,7 +190,11 @@ public partial class Generator {
 			indent++;
 			print ("if (constant == null)");
 			indent++;
-			print ("throw new ArgumentNullException (nameof (constant));");
+			// if we do not have a enum value that maps to a null field then we throw
+			if (null_field == null)
+				print ("throw new ArgumentNullException (nameof (constant));");
+			else
+				print ("return {0}.{1};", type.Name, null_field.Item1.Name);
 			indent--;
 			foreach (var kvp in fields) {
 				print ("else if (constant == {0})", kvp.Value.SymbolName);
@@ -171,7 +202,11 @@ public partial class Generator {
 				print ("return {0}.{1};", type.Name, kvp.Key.Name);
 				indent--;
 			}
-			print ("throw new NotSupportedException (constant + \" has no associated enum value in \" + nameof ({0}) + \" on this platform.\");", type.Name);
+			// if there's no default then we throw on unknown constants
+			if (default_symbol == null)
+				print ("throw new NotSupportedException (constant + \" has no associated enum value in \" + nameof ({0}) + \" on this platform.\");", type.Name);
+			else
+				print ("return {0}.{1};", type.Name, default_symbol.Item1.Name);
 			indent--;
 			print ("}");
 		}

--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -107,7 +107,7 @@ public partial class Generator {
 			// the *Extensions has the same version requirement as the enum itself
 			PrintPlatformAttributes (type);
 			print ("[CompilerGenerated]");
-			print ("static public class {0}Extensions {{", type.Name);
+			print ("static public partial class {0}Extensions {{", type.Name);
 			indent++;
 
 			// note: not every binding namespace will start with ns.Prefix (e.g. MonoTouch.)


### PR DESCRIPTION
This allows us to convert some existing manual conversion code into
generated code and never miss a new constant being added [1].

The additional control comes in two forms:

* allow [Field (null)]: a null NSString constant will return this
  enum value instead of throwing an ArgumentNullException;

* a new `[DefaultEnumValue]` attribute allow marking the constant to be
  returned if the enum value is not known;

[1] Vincent found some missing in HomeKit when adding the new ones
from iOS 10.

This commits also adds documentation for the existing (missing) and
new attributes.