### PR TITLE
[Security] Fix bug 43430 - Obj-C Exception when accessing a SecRecord created by Flurry library.

### DIFF
--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -805,29 +805,29 @@ namespace XamCore.Security {
 
 		NSObject FetchObject (IntPtr key)
 		{
-			return Runtime.GetNSObject<NSObject> (Fetch (key));
+			return Runtime.GetNSObject (Fetch (key));
 		}
 
 		string FetchString (IntPtr key)
 		{
-			return NSString.FromHandle (Fetch (key));
+			return (NSString) FetchObject (key);
 		}
 
 		int FetchInt (IntPtr key)
 		{
-			var obj = Runtime.GetNSObject<NSNumber> (Fetch (key));
+			var obj = (NSNumber) FetchObject (key);
 			return obj == null ? -1 : obj.Int32Value;
 		}
 
 		bool FetchBool (IntPtr key, bool defaultValue)
 		{
-			var obj = Runtime.GetNSObject<NSNumber> (Fetch (key));
+			var obj = (NSNumber) FetchObject (key);
 			return obj == null ? defaultValue : obj.Int32Value != 0;
 		}
 
 		T Fetch<T> (IntPtr key) where T : NSObject
 		{
-			return Runtime.GetNSObject<T> (Fetch (key));
+			return (T) FetchObject (key);
 		}
 		
 


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=43430

We used to bypass type safety on FetchString by just creating a
NSString object from the returned ptr of the underlying dictionary
and in some cases the object contained in the dictionary does not
contain what we expect just like in this bug report

I refactored similar methods to avoid the same issue from happening
now if we get a different object from what we expect we throw an
`InvalidCastException` instead of crashing the app due to unrecognized
selectors performed on it

----------------------------------------------------------------------

For the record I did try some other approaches on solving this like having `CFType` checks like

```
var ret = Fetch (key);

if (CFType.GetTypeID (ret) != CFString.GetTypeID ())
	throw new InvalidCastException ("The retrieved object is not a string");

return (NSString) Runtime.GetNSObject (Fetch (key));
```

But in my opinion this does not escalates very well since we need to check against several others posible `CFTypes` (like mutable types) and some other types like`CFNumber` which we do not provide bindings due to we have the toll free objects like `NSNumber`. And it is also possible that Apple adds new `CF` types in the future and we would need to remember to check against those too.

Also thought about surrounding the call in a `try/catch` block and throw a more explained exception but I do not think it buys us something much better than `InvalidCastException` currently provides. On a similar idea I tested throwing the same exception but with some custom message in the `Data` property like `The retrieved object is not a string` but that also isn't very common to do unless we provide some kind of visualisation support on our XS debug window.

I think this is the best approach since the code is very succinct and easy to follow IMHO 

```
(NSString) Runtime.GetNSObject (Fetch (key));
```
Get an NSObject from the dict, can't cast to the expected class? -> InvalidCastException

I feel this is a more natural approach since you get a managed exception that you can surround with a try/catch that won't crash your app and will let you do your thing.

Feel free to give your comments on it 😄 