### PR TITLE
[msbuild] Ensure that `BuildOnlySettings` is the first target to run for

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -116,6 +116,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<PropertyGroup>
 		<BuildDependsOn>
+			BuildOnlySettings;
 			_CollectBundleResources;
 			_PackLibraryResources;
 			_UnpackLibraryResources;

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.targets
@@ -32,6 +32,7 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 	<!-- Add our own pre-build steps -->
 	<PropertyGroup>
 		<BuildDependsOn>
+			BuildOnlySettings;
 			_CreateGeneratedSourcesDir;
 			_CreateEmbeddedResources;
 			$(BuildDependsOn)

--- a/msbuild/Xamarin.ObjcBinding.Tasks/Xamarin.ObjcBinding.Common.targets
+++ b/msbuild/Xamarin.ObjcBinding.Tasks/Xamarin.ObjcBinding.Common.targets
@@ -48,6 +48,7 @@ Copyright (C) 2011 Xamarin Inc. All rights reserved.
   <!-- Add our own pre-build steps -->
   <PropertyGroup>
     <BuildDependsOn>
+      BuildOnlySettings;
       _CreateGeneratedSourcesDir;
       _CreateEmbeddedResources;
       $(BuildDependsOn)

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.targets
@@ -35,6 +35,7 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 	<!-- Add our own pre-build steps -->
 	<PropertyGroup>
 		<BuildDependsOn>
+			BuildOnlySettings;
 			_CreateGeneratedSourcesDir;
 			_CreateEmbeddedResources;
 			$(BuildDependsOn)


### PR DESCRIPTION
.. a `Build`.

When building the `inspector` project with msbuild, the build fails
because of a missing `System.Runtime` reference,
-> which can be traced to the `ResolveAssemblyReferences` task not resolving dependencies.
	-> which can be traced to `$(_FindDependencies)` property being set to false
		-> which is false, because `$(BuildingProject)` is false, which should
		   have been set by the `BuildOnlySettings` target, run as a dependency of
		   `CoreBuild`.

We override `$(BuildDependsOn)` as:
```
  <BuildDependsOn>
     ...
     _UnpackLibraryResources;
     $(BuildDependsOn);
     ...
  </BuildDependsOn>
```
.. so, `_UnpackLibraryResources` runs before `BuildOnlySettings`. And
`_UnpackLibraryResources` depends on `ResolveReferences`, so the
`ResolveAssemblyReferences` task runs with the incorrect properties. And
later, during the build when `ResolveAssemblyReferences` is invoked
again, it gets skipped and the incorrect outputs get used.

`$(BuildingProject)` should be true for a project build. So,
`Xamarin.Mac.Common.targets` are fixed for that. And other similar
target files are also fixed.

Note: `Xamarin.iOS.Common.targets` already does this correctly.
Note: `$(BuildingProject)` is not used in xbuild, so this bug is seen
only when building with msbuild.