### PR TITLE
[Security] Fix bug 44062 - SecRecord is missing a property to enable password access control

### DIFF
--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -1051,6 +1051,20 @@ namespace XamCore.Security {
 			}
 		}
 
+#if XAMCORE_2_0 && !WATCH && !TVOS
+		[iOS (9, 0), Mac (10, 11)]
+		public XamCore.LocalAuthentication.LAContext AuthenticationContext {
+			get {
+				return Fetch<XamCore.LocalAuthentication.LAContext> (SecItem.UseAuthenticationContext);
+			}
+			set {
+				if (value == null)
+					throw new ArgumentNullException (nameof (value));
+				SetValue (value.Handle, SecItem.UseAuthenticationContext);
+			}
+		}
+#endif
+
 		// Must store the _secAccessControl here, since we have no way of inspecting its values if
 		// it is ever returned from a dictionary, so return what we cached.
 		SecAccessControl _secAccessControl;

--- a/src/security.cs
+++ b/src/security.cs
@@ -614,6 +614,10 @@ namespace XamCore.Security {
 		[iOS (9,0)][Mac (10,11)]
 		[Field ("kSecUseAuthenticationUI")]
 		IntPtr UseAuthenticationUI { get; }
+
+		[iOS (9,0)][Mac (10,11)]
+		[Field ("kSecUseAuthenticationContext")]
+		IntPtr UseAuthenticationContext { get; }
 	}
 
 	[NoiOS][NoTV][NoWatch]


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=44062

Added missing kSecUseAuthenticationContext to our SecRecord wrapper