### PR TITLE
Enable CloudKit APIs and remove all unnecessary public in bindings

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -126,7 +126,7 @@ automatically for Objective-C APIs by the generator).
 
 **Objective-C Binding**
 ```csharp
-public interface Fooable {
+interface Fooable {
 	[Export ("foo:")]
 	void Foo (NSTableViewDropOperation dropOp);
 }

--- a/src/UIKit/UIEnums.cs
+++ b/src/UIKit/UIEnums.cs
@@ -995,7 +995,7 @@ namespace XamCore.UIKit {
 	}
 
 #if !WATCH
-	public delegate void UIPrintInteractionCompletionHandler (UIPrintInteractionController printInteractionController, bool completed, NSError error);
+	delegate void UIPrintInteractionCompletionHandler (UIPrintInteractionController printInteractionController, bool completed, NSError error);
 #endif
 
 	// untyped (and unamed) enum -> UIPrintError.h

--- a/src/accounts.cs
+++ b/src/accounts.cs
@@ -65,8 +65,8 @@ namespace XamCore.Accounts {
 		string OAuthToken { get; set;  }
 	}
 
-	public delegate void ACAccountStoreSaveCompletionHandler (bool success, NSError error);
-	public delegate void ACRequestCompletionHandler (bool granted, NSError error);
+	delegate void ACAccountStoreSaveCompletionHandler (bool success, NSError error);
+	delegate void ACRequestCompletionHandler (bool granted, NSError error);
 	
 	[Since (5,0)]
 	[Mac (10,8, onlyOn64 : true)]

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -53,7 +53,7 @@ namespace XamCore.AppKit {
 	//}
 	
 	[BaseType (typeof (NSCell))]
-	public interface NSActionCell {
+	interface NSActionCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
 	
@@ -73,16 +73,16 @@ namespace XamCore.AppKit {
 
 	[Protocol, Model]
 	[BaseType (typeof(NSObject))]
-	public interface NSAlignmentFeedbackToken
+	interface NSAlignmentFeedbackToken
 	{
 	}
 
-	public interface INSAlignmentFeedbackToken { }
+	interface INSAlignmentFeedbackToken { }
 
 	// @interface NSAlignmentFeedbackFilter : NSObject
 	[Mac (10,11)]
 	[BaseType (typeof(NSObject))]
-	public interface NSAlignmentFeedbackFilter
+	interface NSAlignmentFeedbackFilter
 	{
 		[Static]
 		[Export ("inputEventMask")]
@@ -113,7 +113,7 @@ namespace XamCore.AppKit {
 	//
 	// Inlined, not really an object implementation
 	//
-	public interface NSAnimatablePropertyContainer {
+	interface NSAnimatablePropertyContainer {
 		[Export ("animator")]
 		NSObject Animator { [return: Proxy] get; }
 	
@@ -127,13 +127,13 @@ namespace XamCore.AppKit {
 		NSObject DefaultAnimationFor (NSString key);
 	}
 	
-	public interface NSAnimationProgressMarkEventArgs {
+	interface NSAnimationProgressMarkEventArgs {
 		[Export ("NSAnimationProgressMark")]
 		float Progress { get; } /* float, not CGFloat */
 	}
 
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (NSAnimationDelegate)})]
-	public interface NSAnimation : NSCoding, NSCopying {
+	interface NSAnimation : NSCoding, NSCopying {
 		[Export ("initWithDuration:animationCurve:")]
 		[Sealed] // Just to avoid the duplicate selector error
 		IntPtr Constructor (double duration, NSAnimationCurve animationCurve);
@@ -218,7 +218,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSAnimationDelegate {
+	interface NSAnimationDelegate {
 		[Export ("animationShouldStart:"), DelegateName ("NSAnimationPredicate"), DefaultValue (true)]
 		bool AnimationShouldStart (NSAnimation animation);
 	
@@ -236,7 +236,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public partial interface NSAnimationContext {
+	partial interface NSAnimationContext {
 		[Static]
 		[Export ("beginGrouping")]
 		void BeginGrouping ();
@@ -268,7 +268,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (NSAlertDelegate)})]
-	public interface NSAlert {
+	interface NSAlert {
 		[Static, Export ("alertWithError:")]
 		NSAlert WithError (NSError  error);
 	
@@ -340,12 +340,12 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSAlertDelegate {
+	interface NSAlertDelegate {
 		[Export ("alertShowHelp:"), DelegateName ("NSAlertPredicate"), DefaultValue (false)]
 		bool ShowHelp (NSAlert  alert);
 	}
 
-	public interface NSApplicationDidFinishLaunchingEventArgs {
+	interface NSApplicationDidFinishLaunchingEventArgs {
 		[Export ("NSApplicationLaunchIsDefaultLaunchKey")]
 		bool IsLaunchDefault { get; }
 
@@ -355,7 +355,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,9)]
 	[BaseType (typeof (NSObject))]
-	public interface NSAppearance : NSCoding {
+	interface NSAppearance : NSCoding {
 		[Export ("initWithAppearanceNamed:bundle:")]
 		IntPtr Constructor (string name, [NullAllowed] NSBundle bundle);
 
@@ -393,7 +393,7 @@ namespace XamCore.AppKit {
 	[Mac (10,9)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public interface NSAppearanceCustomization {
+	interface NSAppearanceCustomization {
 
 		[Mac (10,9)]
 		[Export ("appearance", ArgumentSemantic.Strong)]
@@ -407,7 +407,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSResponder), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (NSApplicationDelegate) })]
 	[DisableDefaultCtor] // An uncaught exception was raised: Creating more than one Application
-	public interface NSApplication : NSAccessibilityElementProtocol, NSAccessibility {
+	interface NSApplication : NSAccessibilityElementProtocol, NSAccessibility {
 		[Export ("sharedApplication"), Static, ThreadSafe]
 		NSApplication SharedApplication { get; }
 	
@@ -758,13 +758,13 @@ namespace XamCore.AppKit {
 		void EnumerateWindows (NSWindowListOptions options, NSApplicationEnumerateWindowsHandler block);
 	}
 
-	public delegate void NSApplicationEnumerateWindowsHandler (NSWindow window, ref bool stop);
-	public delegate void ContinueUserActivityRestorationHandler (NSObject [] restorableObjects);
+	delegate void NSApplicationEnumerateWindowsHandler (NSWindow window, ref bool stop);
+	delegate void ContinueUserActivityRestorationHandler (NSObject [] restorableObjects);
 	
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSApplicationDelegate {
+	interface NSApplicationDelegate {
 		[Export ("applicationShouldTerminate:"), DelegateName ("NSApplicationTermination"), DefaultValue (NSApplicationTerminateReply.Now)]
 		NSApplicationTerminateReply ApplicationShouldTerminate (NSApplication  sender);
 	
@@ -905,7 +905,7 @@ namespace XamCore.AppKit {
 	}
 		
 	[BaseType (typeof (NSObjectController))]
-	public interface NSArrayController {
+	interface NSArrayController {
 		[Export ("rearrangeObjects")]
 		void RearrangeObjects ();
 
@@ -1026,7 +1026,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSBezierPath : NSCoding, NSCopying {
+	interface NSBezierPath : NSCoding, NSCopying {
 
 		[Static]
 		[Export ("bezierPathWithRect:")]
@@ -1219,7 +1219,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSImageRep))]
 	[DisableDefaultCtor] // An uncaught exception was raised: -[NSBitmapImageRep init]: unrecognized selector sent to instance 0x686880
-	public partial interface NSBitmapImageRep : NSSecureCoding {
+	partial interface NSBitmapImageRep : NSSecureCoding {
 		[Export ("initWithFocusedViewRect:")]
 		IntPtr Constructor (CGRect rect);
 
@@ -1384,7 +1384,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSView))]
-	public interface NSBox {
+	interface NSBox {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -1448,7 +1448,7 @@ namespace XamCore.AppKit {
 		
 	[BaseType (typeof (NSControl))]
 		// , Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSBrowserDelegate)})]
-	public partial interface NSBrowser {
+	partial interface NSBrowser {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -1735,7 +1735,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSBrowserDelegate {
+	interface NSBrowserDelegate {
 		[Export ("browser:numberOfRowsInColumn:"), EventArgs ("NSBrowserColumn")]
 		nint RowsInColumn (NSBrowser sender, nint column);
 
@@ -1846,7 +1846,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSCell))]
-	public interface NSBrowserCell {
+	interface NSBrowserCell {
 		[Mac (10,12)]
 		[Export ("initTextCell:")]
 		[DesignatedInitializer]
@@ -1890,7 +1890,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSActionCell))]
-	public interface NSButtonCell {
+	interface NSButtonCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
 	
@@ -2009,7 +2009,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSControl))]
-	public interface NSButton : NSAccessibilityButton {
+	interface NSButton : NSAccessibilityButton {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -2140,7 +2140,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSImageRep))]
 	[DisableDefaultCtor] // An uncaught exception was raised: -[NSCachedImageRep init]: unrecognized selector sent to instance 0x14890e0
 	[Availability (Deprecated = Platform.Mac_10_6)]
-	public interface NSCachedImageRep {
+	interface NSCachedImageRep {
 		[Availability (Deprecated = Platform.Mac_10_6)]
 		[Export ("initWithWindow:rect:")]
 		IntPtr Constructor (NSWindow win, CGRect rect);
@@ -2159,7 +2159,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSCell : NSUserInterfaceItemIdentification, NSCoding, NSCopying, NSAccessibilityElementProtocol, NSAccessibility, NSObjectAccessibilityExtensions {
+	interface NSCell : NSUserInterfaceItemIdentification, NSCoding, NSCopying, NSAccessibilityElementProtocol, NSAccessibility, NSObjectAccessibilityExtensions {
 		[Static, Export ("prefersTrackingUntilMouseUp")]
 		bool PrefersTrackingUntilMouseUp { get; }
 	
@@ -2484,7 +2484,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSImageRep))]
 	[DisableDefaultCtor] // An uncaught exception was raised: -[NSCIImageRep init]: unrecognized selector sent to instance 0x1b682a0
-	public interface NSCIImageRep {
+	interface NSCIImageRep {
 		[Static]
 		[Export ("imageRepWithCIImage:")]
 		NSCIImageRep FromCIImage (CIImage image);
@@ -2498,7 +2498,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[BaseType (typeof (NSGestureRecognizer))]
-	public interface NSClickGestureRecognizer : NSCoding {
+	interface NSClickGestureRecognizer : NSCoding {
 		[Export ("initWithTarget:action:")]
 		IntPtr Constructor (NSObject target, Selector action);
 
@@ -2510,7 +2510,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSView))]
-	public interface NSClipView {
+	interface NSClipView {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -2568,14 +2568,14 @@ namespace XamCore.AppKit {
 	}
 
 	[Category, BaseType (typeof (NSCoder))]
-	public partial interface NSCoderAppKitAddons {
+	partial interface NSCoderAppKitAddons {
 		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_9)]
 		[Export ("decodeNXColor")]
 		NSColor DecodeNXColor ();
 	}
 
 	[BaseType (typeof (NSViewController))]
-	public interface NSCollectionViewItem : NSCopying {
+	interface NSCollectionViewItem : NSCopying {
 		[Export ("initWithNibName:bundle:")]
 		IntPtr Constructor ([NullAllowed] string nibNameOrNull, [NullAllowed] NSBundle nibBundleOrNull);
 
@@ -2601,7 +2601,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSView))]
-	public interface NSCollectionView : NSDraggingSource, NSDraggingDestination {
+	interface NSCollectionView : NSDraggingSource, NSDraggingDestination {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -2847,7 +2847,7 @@ namespace XamCore.AppKit {
 	// @protocol NSCollectionViewDataSource <NSObject>
 	[Protocol, Model]
 	[BaseType (typeof(NSObject))]
-	public interface NSCollectionViewDataSource
+	interface NSCollectionViewDataSource
 	{
 		[Mac (10,11)]
 		[Abstract]
@@ -2870,7 +2870,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public partial interface NSCollectionViewDelegate {
+	partial interface NSCollectionViewDelegate {
 		[Export ("collectionView:canDragItemsAtIndexes:withEvent:")]
 		bool CanDragItems (NSCollectionView collectionView, NSIndexSet indexes, NSEvent evt);
 
@@ -2971,12 +2971,12 @@ namespace XamCore.AppKit {
 		NSCollectionViewTransitionLayout TransitionLayout (NSCollectionView collectionView, NSCollectionViewLayout fromLayout, NSCollectionViewLayout toLayout);
 	}
 
-	public interface INSCollectionViewElement {}
+	interface INSCollectionViewElement {}
 
 	[Mac (10,11)]
 	[Protocol, Model]
 	[BaseType (typeof(NSObject))]
-	public interface NSCollectionViewElement : NSUserInterfaceItemIdentification
+	interface NSCollectionViewElement : NSUserInterfaceItemIdentification
 	{
 		[Export ("prepareForReuse")]
 		void PrepareForReuse ();
@@ -2995,7 +2995,7 @@ namespace XamCore.AppKit {
 	}
 
 	[Static]
-	public interface NSCollectionElementKind
+	interface NSCollectionElementKind
 	{
 		[Mac (10,11)]
 		[Field ("NSCollectionElementKindInterItemGapIndicator")]
@@ -3012,7 +3012,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,11)]
 	[BaseType (typeof(NSObject))]
-	public interface NSCollectionViewLayoutAttributes : NSCopying
+	interface NSCollectionViewLayoutAttributes : NSCopying
 	{
 		[Export ("frame", ArgumentSemantic.Assign)]
 		CGRect Frame { get; set; }
@@ -3057,7 +3057,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,11)]
 	[BaseType (typeof(NSObject))]
-	public interface NSCollectionViewUpdateItem
+	interface NSCollectionViewUpdateItem
 	{
 		[NullAllowed, Export ("indexPathBeforeUpdate")]
 		NSIndexPath IndexPathBeforeUpdate { get; }
@@ -3071,7 +3071,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,11)]
 	[BaseType (typeof(NSObject))]
-	public interface NSCollectionViewLayoutInvalidationContext
+	interface NSCollectionViewLayoutInvalidationContext
 	{
 		[Export ("invalidateEverything")]
 		bool InvalidateEverything { get; }
@@ -3106,7 +3106,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,11)]
 	[BaseType (typeof(NSObject))]
-	public interface NSCollectionViewLayout : NSCoding
+	interface NSCollectionViewLayout : NSCoding
 	{
 		[NullAllowed, Export ("collectionView", ArgumentSemantic.Weak)]
 		NSCollectionView CollectionView { get; }
@@ -3253,7 +3253,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,11)]
 	[BaseType (typeof(NSCollectionViewLayoutInvalidationContext))]
-	public interface NSCollectionViewFlowLayoutInvalidationContext
+	interface NSCollectionViewFlowLayoutInvalidationContext
 	{
 		[Export ("invalidateFlowLayoutDelegateMetrics")]
 		bool InvalidateFlowLayoutDelegateMetrics { get; set; }
@@ -3265,7 +3265,7 @@ namespace XamCore.AppKit {
 	[Mac (10,11)]
 	[BaseType (typeof (NSObject))]
 	[Protocol, Model]
-	public interface NSCollectionViewDelegateFlowLayout: NSCollectionViewDelegate
+	interface NSCollectionViewDelegateFlowLayout: NSCollectionViewDelegate
 	{
 		[Export ("collectionView:layout:sizeForItemAtIndexPath:")]
 		CGSize SizeForItem (NSCollectionView collectionView, NSCollectionViewLayout collectionViewLayout, NSIndexPath indexPath);
@@ -3288,7 +3288,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,11)]
 	[BaseType (typeof(NSCollectionViewLayout))]
-	public interface NSCollectionViewFlowLayout
+	interface NSCollectionViewFlowLayout
 	{
 		[Export ("minimumLineSpacing", ArgumentSemantic.Assign)]
 		nfloat MinimumLineSpacing { get; set; }
@@ -3337,7 +3337,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,11)]
 	[BaseType (typeof(NSCollectionViewLayout))]
-	public interface NSCollectionViewGridLayout
+	interface NSCollectionViewGridLayout
 	{
 		[Export ("margins", ArgumentSemantic.Assign)]
 		NSEdgeInsets Margins { get; set; }
@@ -3366,7 +3366,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,11)]
 	[BaseType (typeof(NSCollectionViewLayout))]
-	public interface NSCollectionViewTransitionLayout
+	interface NSCollectionViewTransitionLayout
 	{
 		[Export ("transitionProgress", ArgumentSemantic.Assign)]
 		nfloat TransitionProgress { get; set; }
@@ -3390,7 +3390,7 @@ namespace XamCore.AppKit {
 	[ThreadSafe]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // -colorSpaceName not valid for the NSColor <NSColor: 0x1b94780>; need to first convert colorspace.
-	public partial interface NSColor : NSCoding, NSCopying, NSSecureCoding, NSPasteboardReading, NSPasteboardWriting
+	partial interface NSColor : NSCoding, NSCopying, NSSecureCoding, NSPasteboardReading, NSPasteboardWriting
 	{
 		[Static]
 		[Export ("colorWithCalibratedWhite:alpha:")]
@@ -3802,7 +3802,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSColorList : NSSecureCoding {
+	interface NSColorList : NSSecureCoding {
 		[Static]
 		[Export ("availableColorLists")]
 		NSColorList [] AvailableColorLists { get; }
@@ -3850,7 +3850,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSPanel))]
-	public partial interface NSColorPanel {
+	partial interface NSColorPanel {
 		[Static, Export ("sharedColorPanel")]
 		NSColorPanel SharedColorPanel { get; }
 
@@ -3904,7 +3904,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSColorPicker {
+	interface NSColorPicker {
 		[Export ("initWithPickerMask:colorPanel:")]
 		IntPtr Constructor (NSColorPanelFlags mask, NSColorPanel owningColorPanel);
 
@@ -3937,7 +3937,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSColorSpace : NSCoding, NSSecureCoding {
+	interface NSColorSpace : NSCoding, NSSecureCoding {
 		[Export ("initWithICCProfileData:")]
 		IntPtr Constructor (NSData iccData);
 
@@ -4053,7 +4053,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSControl))]
-	public interface NSColorWell {
+	interface NSColorWell {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -4085,7 +4085,7 @@ namespace XamCore.AppKit {
 		Delegates = new [] { "Delegate" },
 		Events = new [] { typeof (NSComboBoxDelegate) }
 	)]
-	public partial interface NSComboBox {
+	partial interface NSComboBox {
 
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
@@ -4197,7 +4197,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSComboBoxDataSource {
+	interface NSComboBoxDataSource {
 		[Export ("comboBox:objectValueForItemAtIndex:")]
 		NSObject ObjectValueForItem (NSComboBox comboBox, nint index);
 		
@@ -4212,7 +4212,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSTextFieldCell))]
-	public partial interface NSComboBoxCell {
+	partial interface NSComboBoxCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
 
@@ -4311,7 +4311,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public partial interface NSComboBoxCellDataSource {
+	partial interface NSComboBoxCellDataSource {
 		[Export ("comboBoxCell:objectValueForItemAtIndex:")]
 		NSObject ObjectValueForItem (NSComboBoxCell comboBox, nint index);
 
@@ -4326,7 +4326,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSView))]
-	public partial interface NSControl {
+	partial interface NSControl {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -4517,7 +4517,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSController : NSCoding {
+	interface NSController : NSCoding {
 		[Export ("objectDidBeginEditing:")]
 		void ObjectDidBeginEditing (NSObject editor);
 
@@ -4539,7 +4539,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSCursor : NSCoding {
+	interface NSCursor : NSCoding {
 		[Static]
 		[Export ("currentCursor")]
 		NSCursor CurrentCursor { get; }
@@ -4680,7 +4680,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSImageRep))]
 	[DisableDefaultCtor] // An uncaught exception was raised: -[NSCustomImageRep init]: unrecognized selector sent to instance 0x54a870
-	public partial interface NSCustomImageRep {
+	partial interface NSCustomImageRep {
 		[Export ("initWithDrawSelector:delegate:")]
 		IntPtr Constructor (Selector drawSelectorMethod, NSObject delegateObject);
 
@@ -4714,7 +4714,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSControl), Delegates=new string [] {"WeakDelegate"}, Events=new Type [] {typeof (NSDatePickerCellDelegate)})]
-	public interface NSDatePicker {
+	interface NSDatePicker {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -4776,7 +4776,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSActionCell), Delegates=new string [] {"WeakDelegate"}, Events=new Type [] {typeof (NSDatePickerCellDelegate)})]
-	public interface NSDatePickerCell {
+	interface NSDatePickerCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
 	
@@ -4835,7 +4835,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSDatePickerCellDelegate {
+	interface NSDatePickerCellDelegate {
 		[Export ("datePickerCell:validateProposedDateValue:timeInterval:"), EventArgs ("NSDatePickerValidator")]
 		void ValidateProposedDateValue (NSDatePickerCell aDatePickerCell, ref NSDate proposedDateValue, double proposedTimeInterval);
 	}
@@ -4887,7 +4887,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSDockTile {
+	interface NSDockTile {
 		[Export ("size")]
 		CGSize Size { get; }
 
@@ -4911,7 +4911,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSDockTilePlugIn {
+	interface NSDockTilePlugIn {
 		[Abstract]
 		[Export ("setDockTile:")]
 		void SetDockTile (NSDockTile dockTile);
@@ -4921,10 +4921,10 @@ namespace XamCore.AppKit {
 		NSMenu DockMenu ();
 	}
 
-	public delegate void NSDocumentCompletionHandler (IntPtr nsErrorPointerOrZero);
+	delegate void NSDocumentCompletionHandler (IntPtr nsErrorPointerOrZero);
 	
 	[BaseType (typeof (NSObject))]
-	public partial interface NSDocument {
+	partial interface NSDocument {
 		[Export ("initWithType:error:")]
 		IntPtr Constructor (string typeName, out NSError outError);
 
@@ -5271,10 +5271,10 @@ namespace XamCore.AppKit {
 		void StopBrowsingVersions (Action completionHandler);
 	}
 
-	public delegate void OpenDocumentCompletionHandler (NSDocument document, bool documentWasAlreadyOpen, NSError error);
+	delegate void OpenDocumentCompletionHandler (NSDocument document, bool documentWasAlreadyOpen, NSError error);
 
 	[BaseType (typeof (NSObject))]
-	public partial interface NSDocumentController : NSWindowRestoration, NSCoding {
+	partial interface NSDocumentController : NSWindowRestoration, NSCoding {
 		[Static, Export ("sharedDocumentController")]
 		NSDocumentController SharedDocumentController { get; }
 
@@ -5396,7 +5396,7 @@ namespace XamCore.AppKit {
 
 	[Lion]
 	[BaseType (typeof (NSObject))]
-	public interface NSDraggingImageComponent {
+	interface NSDraggingImageComponent {
 		[Export ("key", ArgumentSemantic.Copy)]
 		string Key { get; set;  }
 
@@ -5421,10 +5421,10 @@ namespace XamCore.AppKit {
 		NSString LabelKey { get; }
 	}
 
-	public delegate NSDraggingImageComponent [] NSDraggingItemImagesContentProvider ();
+	delegate NSDraggingImageComponent [] NSDraggingItemImagesContentProvider ();
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSDraggingItem {
+	interface NSDraggingItem {
 		[Export ("item", ArgumentSemantic.Strong)]
 		NSObject Item { get;  }
 
@@ -5450,7 +5450,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 #endif
 	[Protocol] // Apple docs say: "you never need to create a class that implements the NSDraggingInfo protocol.", so don't add [Model]
-	public interface NSDraggingInfo  {
+	interface NSDraggingInfo  {
 #if XAMCORE_4_0
 		[Abstract]
 #endif
@@ -5556,7 +5556,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSDraggingDestination {
+	interface NSDraggingDestination {
 		[Export ("draggingEntered:"), DefaultValue (NSDragOperation.None)]
 		NSDragOperation DraggingEntered ([Protocolize (4)] NSDraggingInfo sender);
 
@@ -5583,11 +5583,11 @@ namespace XamCore.AppKit {
 		bool WantsPeriodicDraggingUpdates { get; }
 	}
 
-	public delegate void NSDraggingEnumerator (NSDraggingItem draggingItem, nint idx, ref bool stop);
+	delegate void NSDraggingEnumerator (NSDraggingItem draggingItem, nint idx, ref bool stop);
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // warning on dispose - created using NSView.BeginDraggingSession
-	public interface NSDraggingSession {
+	interface NSDraggingSession {
 		[Export ("draggingFormation")]
 		NSDraggingFormation DraggingFormation { get; set;  }
 
@@ -5614,7 +5614,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSDraggingSource {
+	interface NSDraggingSource {
 		[Export ("draggingSourceOperationMaskForLocal:"), DefaultValue (NSDragOperation.None)]
 		NSDragOperation DraggingSourceOperationMaskForLocal (bool flag);
 
@@ -5639,7 +5639,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSResponder), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (NSDrawerDelegate)})]
-	public partial interface NSDrawer : NSAccessibilityElementProtocol, NSAccessibility {
+	partial interface NSDrawer : NSAccessibilityElementProtocol, NSAccessibility {
 		[Export ("initWithContentSize:preferredEdge:")]
 		IntPtr Constructor (CGSize contentSize, NSRectEdge edge);
 
@@ -5702,7 +5702,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSDrawerDelegate {
+	interface NSDrawerDelegate {
 		[Export ("drawerDidClose:"), EventArgs ("NSNotification")]
 		void DrawerDidClose (NSNotification notification);
 		
@@ -5728,7 +5728,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // crash at runtime (e.g. description). Documentation state: "You don’t create NSFont objects using the alloc and init methods."
-	public partial interface NSFont : NSSecureCoding, NSCopying {
+	partial interface NSFont : NSSecureCoding, NSCopying {
 		[Static]
 		[Export ("fontWithName:size:")]
 		NSFont FromFontName (string fontName, nfloat fontSize);
@@ -6011,7 +6011,7 @@ namespace XamCore.AppKit {
 	}
 
 	[Lion]
-	public interface NSFontCollectionChangedEventArgs {
+	interface NSFontCollectionChangedEventArgs {
 		[Internal, Export ("NSFontCollectionActionKey")]
 		NSString _Action { get; }
 
@@ -6172,7 +6172,7 @@ namespace XamCore.AppKit {
 	}	
 
 	[BaseType (typeof (NSObject))]
-	public interface NSFontDescriptor : NSSecureCoding, NSCopying {
+	interface NSFontDescriptor : NSSecureCoding, NSCopying {
 		[Export ("postscriptName")]
 		string PostscriptName { get; }
 
@@ -6232,7 +6232,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSFontManager {
+	interface NSFontManager {
 		[Static, Export ("setFontPanelFactory:")]
 		void SetFontPanelFactory (Class factoryId);
 
@@ -6376,7 +6376,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSPanel))]
-	public interface NSFontPanel {
+	interface NSFontPanel {
 		[Static]
 		[Export ("sharedFontPanel")]
 		NSFontPanel SharedFontPanel { get; }
@@ -6407,7 +6407,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,11)]
 	[Static]
-	public interface NSFontWeight {
+	interface NSFontWeight {
 		[Field ("NSFontWeightUltraLight")]
 		nfloat UltraLight { get; }
 
@@ -6438,7 +6438,7 @@ namespace XamCore.AppKit {
 
 	[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
 	[BaseType (typeof (NSMatrix))]
-	public partial interface NSForm  {
+	partial interface NSForm  {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -6507,7 +6507,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSActionCell))]
-	public partial interface NSFormCell {
+	partial interface NSFormCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
 	
@@ -6551,7 +6551,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSGlyphGenerator {
+	interface NSGlyphGenerator {
 		[Export ("generateGlyphsForGlyphStorage:desiredNumberOfCharacters:glyphIndex:characterIndex:")]
 		void GenerateGlyphs (NSObject nsGlyphStorageOrNSLayoutManager, nuint nchars, ref nuint glyphIndex, ref nuint charIndex);
 
@@ -6560,7 +6560,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSGradient : NSCoding, NSCopying {
+	interface NSGradient : NSCoding, NSCopying {
 		[Export ("initWithStartingColor:endingColor:")]
 		IntPtr Constructor  (NSColor startingColor, NSColor endingColor);
 
@@ -6604,7 +6604,7 @@ namespace XamCore.AppKit {
 
 	[ThreadSafe] // CurrentContext returns a context that can be used from the current thread
 	[BaseType (typeof (NSObject))]
-	public interface NSGraphicsContext {
+	interface NSGraphicsContext {
 		[Static, Export ("graphicsContextWithAttributes:")]
 		NSGraphicsContext FromAttributes (NSDictionary attributes);
 	
@@ -6873,12 +6873,12 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSGraphicsContext))]
 	[DisableDefaultCtor]
-	public interface NSPrintPreviewGraphicsContext {
+	interface NSPrintPreviewGraphicsContext {
 	}
 
 	[BaseType (typeof (NSImageRep))]
 	[DisableDefaultCtor] // An uncaught exception was raised: -[NSEPSImageRep init]: unrecognized selector sent to instance 0x1db2d90
-	public interface NSEPSImageRep {
+	interface NSEPSImageRep {
 		[Static]
 		[Export ("imageRepWithData:")]
 		NSObject FromData (NSData epsData);
@@ -6897,12 +6897,12 @@ namespace XamCore.AppKit {
 		CGRect BoundingBox { get; }
 	}
 
-	public delegate void GlobalEventHandler (NSEvent theEvent);
-	public delegate NSEvent LocalEventHandler (NSEvent theEvent);
-	public delegate void NSEventTrackHandler (nfloat gestureAmount, NSEventPhase eventPhase, bool isComplete, ref bool stop);
+	delegate void GlobalEventHandler (NSEvent theEvent);
+	delegate NSEvent LocalEventHandler (NSEvent theEvent);
+	delegate void NSEventTrackHandler (nfloat gestureAmount, NSEventPhase eventPhase, bool isComplete, ref bool stop);
 
 	[BaseType (typeof (NSObject))]
-	public interface NSEvent : NSCoding, NSCopying {
+	interface NSEvent : NSCoding, NSCopying {
 		[Export ("type")]
 		NSEventType Type { get; }
 
@@ -7211,7 +7211,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[BaseType (typeof (NSObject), Delegates=new string [] {"WeakDelegate"}, Events=new Type[] {typeof (NSGestureRecognizerDelegate)})]
-	public interface NSGestureRecognizer : NSCoding {
+	interface NSGestureRecognizer : NSCoding {
 		[Export ("initWithTarget:action:")]
 		IntPtr Constructor (NSObject target, Selector action);
 
@@ -7333,7 +7333,7 @@ namespace XamCore.AppKit {
 	[Mac (10,10)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public interface NSGestureRecognizerDelegate {
+	interface NSGestureRecognizerDelegate {
 		[Export ("gestureRecognizerShouldBegin:"), DelegateName ("NSGestureProbe"), DefaultValue (true)]
 		bool ShouldBegin (NSGestureRecognizer gestureRecognizer);
 
@@ -7360,7 +7360,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe] // Not documented anywhere, but their Finder extension sample uses it on non-ui thread
 	[Dispose ("__mt_items_var = null;")]
-	public partial interface NSMenu : NSCoding, NSCopying, NSAccessibility, NSAccessibilityElement, NSUserInterfaceItemIdentification  {
+	partial interface NSMenu : NSCoding, NSCopying, NSAccessibility, NSAccessibilityElement, NSUserInterfaceItemIdentification  {
 		[Export ("initWithTitle:")]
 		IntPtr Constructor (string aTitle);
 
@@ -7520,12 +7520,12 @@ namespace XamCore.AppKit {
 		NSUserInterfaceLayoutDirection UserInterfaceLayoutDirection { get; set; }
 	}
 
-	public interface INSMenuDelegate { }
+	interface INSMenuDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSMenuDelegate {
+	interface NSMenuDelegate {
 		[Export ("menuNeedsUpdate:")]
 		void NeedsUpdate (NSMenu menu);
 
@@ -7556,7 +7556,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe] // Not documented anywhere, but their Finder extension sample uses it on non-ui thread
-	public interface NSMenuItem : NSCoding, NSCopying, NSAccessibility, NSAccessibilityElement, NSUserInterfaceItemIdentification {
+	interface NSMenuItem : NSCoding, NSCopying, NSAccessibility, NSAccessibilityElement, NSUserInterfaceItemIdentification {
 		[Static]
 		[Export ("separatorItem")]
 		NSMenuItem SeparatorItem { get; }
@@ -7656,7 +7656,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSButtonCell))]
-	public interface NSMenuItemCell {
+	interface NSMenuItemCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
 	
@@ -7725,7 +7725,7 @@ namespace XamCore.AppKit {
 
 	[Availability (Introduced = Platform.Mac_10_0 | Platform.Mac_Arch32)]
 	[BaseType (typeof (NSView))]
-	public interface NSMenuView {
+	interface NSMenuView {
 		[Static]
 		[Export ("menuBarHeight")]
 		nfloat MenuBarHeight { get; }
@@ -7840,7 +7840,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public partial interface NSNib : NSCoding {
+	partial interface NSNib : NSCoding {
 		[Export ("initWithContentsOfURL:")]
 		IntPtr Constructor (NSUrl nibFileUrl);
 
@@ -7860,7 +7860,7 @@ namespace XamCore.AppKit {
 	}	
 
 	[BaseType (typeof (NSController))]
-	public interface NSObjectController {
+	interface NSObjectController {
 		[Export ("initWithContent:")]
 		IntPtr Constructor (NSObject content);
 
@@ -7939,7 +7939,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSOpenGLPixelFormat : NSCoding {
+	interface NSOpenGLPixelFormat : NSCoding {
 		[Export ("initWithData:")]
 		IntPtr Constructor (NSData attribs);
 
@@ -7959,7 +7959,7 @@ namespace XamCore.AppKit {
 
 	[Availability (Introduced = Platform.Mac_10_2, Deprecated = Platform.Mac_10_7)]
 	[BaseType (typeof (NSObject))]
-	public interface NSOpenGLPixelBuffer {
+	interface NSOpenGLPixelBuffer {
 		[Export ("initWithTextureTarget:textureInternalFormat:textureMaxMipMapLevel:pixelsWide:pixelsHigh:")]
 		IntPtr Constructor (NSGLTextureTarget targetGlEnum, NSGLFormat format, int /* GLint = int32_t */ maxLevel, int /* GLsizei = int32_t */ pixelsWide, int /* GLsizei = int32_t */ pixelsHigh);
 
@@ -7988,7 +7988,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // warns with "invalid context" at runtime
-	public interface NSOpenGLContext {
+	interface NSOpenGLContext {
 		[Export ("initWithFormat:shareContext:")]
 		IntPtr Constructor (NSOpenGLPixelFormat format, [NullAllowed] NSOpenGLContext shareContext);
 
@@ -8077,7 +8077,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSView))]
-	public partial interface NSOpenGLView {
+	partial interface NSOpenGLView {
 		[Static]
 		[Export ("defaultPixelFormat")]
 		NSOpenGLPixelFormat DefaultPixelFormat { get; }
@@ -8109,7 +8109,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSSavePanel))]
-	public interface NSOpenPanel {
+	interface NSOpenPanel {
 		[Export ("URLs")]
 		NSUrl [] Urls { get; }
 
@@ -8153,13 +8153,13 @@ namespace XamCore.AppKit {
 	// This class doesn't show up in any documentation
 	[BaseType (typeof (NSOpenPanel))]
 	[DisableDefaultCtor] // should not be created by (only returned to) user code
-	public interface NSRemoteOpenPanel {}
+	interface NSRemoteOpenPanel {}
 #endif
 
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSOpenSavePanelDelegate {
+	interface NSOpenSavePanelDelegate {
 		[Export ("panel:shouldEnableURL:"), DelegateName ("NSOpenSavePanelUrl"), DefaultValue (true)]
 		bool ShouldEnableUrl (NSSavePanel panel, NSUrl url);
 
@@ -8196,7 +8196,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSTableView))]
-	public partial interface NSOutlineView {
+	partial interface NSOutlineView {
 		[Export ("outlineTableColumn"), NullAllowed]
 		NSTableColumn OutlineTableColumn { get; set; }
 
@@ -8298,7 +8298,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public partial interface NSOutlineViewDelegate {
+	partial interface NSOutlineViewDelegate {
 		[Export ("outlineView:willDisplayCell:forTableColumn:item:")]
 		void WillDisplayCell (NSOutlineView outlineView, NSObject cell, [NullAllowed] NSTableColumn tableColumn, NSObject item);
 	
@@ -8412,7 +8412,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public partial interface NSOutlineViewDataSource {
+	partial interface NSOutlineViewDataSource {
 		[Export ("outlineView:child:ofItem:")]
 		NSObject GetChild (NSOutlineView outlineView, nint childIndex, [NullAllowed] NSObject item);
 	
@@ -8452,18 +8452,18 @@ namespace XamCore.AppKit {
 
 	[Protocol, Model]
 	[BaseType (typeof(NSObject))]
-	public interface NSHapticFeedbackPerformer
+	interface NSHapticFeedbackPerformer
 	{
 		[Abstract]
 		[Export ("performFeedbackPattern:performanceTime:")]
 		void PerformFeedback (NSHapticFeedbackPattern pattern, NSHapticFeedbackPerformanceTime performanceTime);
 	}
 
-	public interface INSHapticFeedbackPerformer { }
+	interface INSHapticFeedbackPerformer { }
 
 	[Mac (10,11)]
 	[BaseType (typeof(NSObject))]
-	public interface NSHapticFeedbackManager
+	interface NSHapticFeedbackManager
 	{
 		[Static]
 		[Export ("defaultPerformer")]
@@ -8471,7 +8471,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public partial interface NSHelpManager {
+	partial interface NSHelpManager {
 		[Static]
 		[Export ("sharedHelpManager")]
 		NSHelpManager SharedHelpManager ();
@@ -8506,7 +8506,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (NSImageDelegate)})]
 	[Dispose ("__mt_reps_var = null;")]
 	[ThreadSafe]
-	public partial interface NSImage : NSCoding, NSCopying, NSSecureCoding, NSPasteboardReading, NSPasteboardWriting {
+	partial interface NSImage : NSCoding, NSCopying, NSSecureCoding, NSPasteboardReading, NSPasteboardWriting {
 		[Static]
 		[Export ("imageNamed:")]
 		NSImage ImageNamed (string name);
@@ -8848,7 +8848,7 @@ namespace XamCore.AppKit {
 		
 	}
 
-	public interface NSStringAttributes {
+	interface NSStringAttributes {
 
 	}
 
@@ -8867,7 +8867,7 @@ namespace XamCore.AppKit {
 	}
 
 	[Category, BaseType (typeof (NSString))]
-	public interface NSStringDrawing_NSString {
+	interface NSStringDrawing_NSString {
 		[Export ("sizeWithAttributes:")]
 		CGSize StringSize (NSDictionary attributes);
 
@@ -8888,7 +8888,7 @@ namespace XamCore.AppKit {
 	}
 
 	[Category, BaseType (typeof (NSAttributedString))]
-	public interface NSStringDrawing_NSAttributedString {
+	interface NSStringDrawing_NSAttributedString {
 		[Export ("size")]
 		CGSize GetSize ();
 
@@ -8935,7 +8935,7 @@ namespace XamCore.AppKit {
 	// Pending: @interface NSAttributedString (NSExtendedStringDrawing)
 
 	[Category, BaseType (typeof (NSMutableAttributedString))]
-	public interface NSMutableAttributedStringAppKitAddons {
+	interface NSMutableAttributedStringAppKitAddons {
 		[Export ("readFromURL:options:documentAttributes:error:")]
 		bool ReadFromURL (NSUrl url, NSDictionary options, out NSDictionary returnOptions, out NSError error);
 
@@ -8994,7 +8994,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSImageDelegate {
+	interface NSImageDelegate {
 		[Export ("imageDidNotDraw:inRect:"), DelegateName ("NSImageRect"), DefaultValue (null)]
 		NSImage ImageDidNotDraw (NSObject sender, CGRect aRect);
 
@@ -9012,7 +9012,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSCell))]
-	public interface NSImageCell {
+	interface NSImageCell {
 		//Detected properties
 		[Export ("imageAlignment")]
 		NSImageAlignment ImageAlignment { get; set; }
@@ -9025,7 +9025,7 @@ namespace XamCore.AppKit {
 	}
 
 	[Static]
-	public partial interface NSImageHint {
+	partial interface NSImageHint {
 		[Field ("NSImageHintCTM")]
 		NSString Ctm { get; }
 
@@ -9038,7 +9038,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public partial interface NSImageRep : NSCoding, NSCopying {
+	partial interface NSImageRep : NSCoding, NSCopying {
 		[Export ("draw")]
 		bool Draw ();
 
@@ -9175,7 +9175,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSControl))]
-	public interface NSImageView : NSAccessibilityImage {
+	interface NSImageView : NSAccessibilityImage {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -9208,7 +9208,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSControl), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (NSMatrixDelegate)})]
-	public partial interface NSMatrix {
+	partial interface NSMatrix {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -9453,7 +9453,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSControl))]
-	public interface NSLevelIndicator {
+	interface NSLevelIndicator {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -9490,7 +9490,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSActionCell))]
-	public interface NSLevelIndicatorCell {
+	interface NSLevelIndicatorCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
 	
@@ -9537,7 +9537,7 @@ namespace XamCore.AppKit {
 #if MONOMAC
 	[Protocol (IsInformal = true)]
 	[Mac (10, 7)]
-	public interface NSLayerDelegateContentsScaleUpdating {
+	interface NSLayerDelegateContentsScaleUpdating {
 		[Export ("layer:shouldInheritContentsScale:fromWindow:")]
 		bool ShouldInheritContentsScale (CALayer layer, nfloat newScale, NSWindow fromWindow);
 	}
@@ -9547,7 +9547,7 @@ namespace XamCore.AppKit {
 	[Mac (10,11)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor] // Handle is nil
-	public interface NSLayoutAnchor<AnchorType> : NSCoding, NSCopying
+	interface NSLayoutAnchor<AnchorType> : NSCoding, NSCopying
 	{
 		[Export ("constraintEqualToAnchor:")]
 		NSLayoutConstraint ConstraintEqualToAnchor (NSLayoutAnchor<AnchorType> anchor);
@@ -9572,21 +9572,21 @@ namespace XamCore.AppKit {
 	[Mac (10,11)]
 	[BaseType (typeof(NSLayoutAnchor<NSLayoutXAxisAnchor>))]
 	[DisableDefaultCtor] // Handle is nil
-	public interface NSLayoutXAxisAnchor
+	interface NSLayoutXAxisAnchor
 	{
 	}
 
 	[Mac (10,11)]
 	[BaseType (typeof(NSLayoutAnchor<NSLayoutYAxisAnchor>))]
 	[DisableDefaultCtor] // Handle is nil
-	public interface NSLayoutYAxisAnchor
+	interface NSLayoutYAxisAnchor
 	{
 	}
 
 	[Mac (10,11)]
 	[BaseType (typeof(NSLayoutAnchor<NSLayoutDimension>))]
 	[DisableDefaultCtor] // Handle is nil
-	public interface NSLayoutDimension
+	interface NSLayoutDimension
 	{
 		[Export ("constraintEqualToConstant:")]
 		NSLayoutConstraint ConstraintEqualToConstant (nfloat constant);
@@ -9619,7 +9619,7 @@ namespace XamCore.AppKit {
 
 	[Lion]
 	[BaseType (typeof (NSObject))]
-	public interface NSLayoutConstraint : NSAnimatablePropertyContainer {
+	interface NSLayoutConstraint : NSAnimatablePropertyContainer {
 		[Static]
 		[Export ("constraintsWithVisualFormat:options:metrics:views:")]
 		NSLayoutConstraint [] FromVisualFormat (string format, NSLayoutFormatOptions formatOptions, [NullAllowed] NSDictionary metrics, NSDictionary views);
@@ -9680,7 +9680,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,11)]
 	[BaseType (typeof(NSObject))]
-	public interface NSLayoutGuide : NSCoding, NSUserInterfaceItemIdentification
+	interface NSLayoutGuide : NSCoding, NSUserInterfaceItemIdentification
 	{
 		[Export ("frame")]
 		CGRect Frame { get; }
@@ -9729,11 +9729,11 @@ namespace XamCore.AppKit {
 		NSLayoutConstraint [] GetConstraintsAffectingLayout (NSLayoutConstraintOrientation orientation);
 	}
 
-	public delegate void NSTextLayoutEnumerateLineFragments (CGRect rect, CGRect usedRectangle, NSTextContainer textContainer, NSRange glyphRange, out bool stop);
-	public delegate void NSTextLayoutEnumerateEnclosingRects (CGRect rect, out bool stop);
+	delegate void NSTextLayoutEnumerateLineFragments (CGRect rect, CGRect usedRectangle, NSTextContainer textContainer, NSRange glyphRange, out bool stop);
+	delegate void NSTextLayoutEnumerateEnclosingRects (CGRect rect, out bool stop);
 	
 	[BaseType (typeof (NSObject))]
-	public partial interface NSLayoutManager : NSCoding {
+	partial interface NSLayoutManager : NSCoding {
 		[Export ("attributedString")]
 		NSAttributedString AttributedString { get; }
 
@@ -10137,7 +10137,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSLayoutManagerDelegate {
+	interface NSLayoutManagerDelegate {
 		[Export ("layoutManagerDidInvalidateLayout:")]
 		void LayoutInvalidated (NSLayoutManager sender);
 
@@ -10186,7 +10186,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[BaseType (typeof (NSGestureRecognizer))]
-	public interface NSMagnificationGestureRecognizer {
+	interface NSMagnificationGestureRecognizer {
 		[Export ("initWithTarget:action:")]
 		IntPtr Constructor (NSObject target, Selector action);
 
@@ -10198,9 +10198,9 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Protocol]
 #if XAMCORE_2_0
-	public interface NSMatrixDelegate : NSControlTextEditingDelegate {
+	interface NSMatrixDelegate : NSControlTextEditingDelegate {
 #else
-	public interface NSMatrixDelegate {
+	interface NSMatrixDelegate {
 		[Export ("control:textShouldBeginEditing:"), DelegateName ("NSControlText"), DefaultValue (true)]
 		bool TextShouldBeginEditing (NSControl control, NSText fieldEditor);
 
@@ -10227,7 +10227,7 @@ namespace XamCore.AppKit {
 	[Model]
 	[BaseType (typeof (NSObject))]
 	[Protocol]
-	public interface NSControlTextEditingDelegate {
+	interface NSControlTextEditingDelegate {
 		[Export ("control:textShouldBeginEditing:"), DelegateName ("NSControlText"), DefaultValue (true)]
 		bool TextShouldBeginEditing (NSControl control, NSText fieldEditor);
 
@@ -10252,7 +10252,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSObject))]
 	[Dispose ("__mt_accessory_var = null;")]
-	public interface NSPageLayout {
+	interface NSPageLayout {
 		[Static]
 		[Export ("pageLayout")]
 		NSPageLayout PageLayout { get; }
@@ -10282,7 +10282,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSWindow))]
-	public interface NSPanel {
+	interface NSPanel {
 		//Detected properties
 		[Export ("floatingPanel")]
 		bool FloatingPanel { [Bind ("isFloatingPanel")]get; set; }
@@ -10296,7 +10296,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSParagraphStyle : NSSecureCoding, NSMutableCopying {
+	interface NSParagraphStyle : NSSecureCoding, NSMutableCopying {
 		[Static]
 		[Export ("defaultParagraphStyle")]
 		NSParagraphStyle DefaultParagraphStyle { get; [NotImplemented] set; }
@@ -10369,7 +10369,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSParagraphStyle))]
-	public interface NSMutableParagraphStyle {
+	interface NSMutableParagraphStyle {
 
 		[Export ("addTabStop:")]
 		[PostGet ("TabStops")]
@@ -10464,7 +10464,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[BaseType (typeof (NSGestureRecognizer))]
-	public interface NSPanGestureRecognizer : NSCoding {
+	interface NSPanGestureRecognizer : NSCoding {
 		[Export ("initWithTarget:action:")]
 		IntPtr Constructor (NSObject target, Selector action);
 
@@ -10483,7 +10483,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[BaseType (typeof (NSGestureRecognizer))]
-	public interface NSPressGestureRecognizer {
+	interface NSPressGestureRecognizer {
 		[Export ("initWithTarget:action:")]
 		IntPtr Constructor (NSObject target, Selector action);
 
@@ -10499,7 +10499,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // An uncaught exception was raised: +[NSPasteboard alloc]: unrecognized selector sent to class 0xac3dcbf0
-	public partial interface NSPasteboard // NSPasteboard does _not_ implement NSPasteboardReading/NSPasteboardWriting
+	partial interface NSPasteboard // NSPasteboard does _not_ implement NSPasteboardReading/NSPasteboardWriting
 	{
 		[Static]
 		[Export ("generalPasteboard")]
@@ -10712,7 +10712,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSPasteboardWriting {
+	interface NSPasteboardWriting {
 		[Export ("writableTypesForPasteboard:")]
 		string [] GetWritableTypesForPasteboard (NSPasteboard pasteboard);
 
@@ -10724,7 +10724,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSPasteboardItem : NSPasteboardWriting, NSPasteboardReading {
+	interface NSPasteboardItem : NSPasteboardWriting, NSPasteboardReading {
 		[Export ("types")]
 		string [] Types { get; }
 
@@ -10756,7 +10756,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSPasteboardItemDataProvider {
+	interface NSPasteboardItemDataProvider {
 		[Abstract]
 		[Export ("pasteboard:item:provideDataForType:")]
 		void ProvideDataForType (NSPasteboard pasteboard, NSPasteboardItem item, string type);
@@ -10766,8 +10766,8 @@ namespace XamCore.AppKit {
 		void FinishedWithDataProvider (NSPasteboard pasteboard);
 	}
 
-	public interface INSPasteboardReading {}
-	public interface INSPasteboardWriting {}
+	interface INSPasteboardReading {}
+	interface INSPasteboardWriting {}
 
 	[BaseType (typeof (NSObject))]
 #if !XAMCORE_3_0
@@ -10776,7 +10776,7 @@ namespace XamCore.AppKit {
 	[Model]
 #endif
 	[Protocol]
-	public interface NSPasteboardReading {
+	interface NSPasteboardReading {
 		[Static]
 		[Export ("readableTypesForPasteboard:")]
 		string [] GetReadableTypesForPasteboard (NSPasteboard pasteboard);
@@ -10798,7 +10798,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSActionCell), Events=new Type [] { typeof (NSPathCellDelegate) }, Delegates=new string [] { "WeakDelegate" })]
-	public interface NSPathCell {
+	interface NSPathCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
 	
@@ -10864,7 +10864,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSPathCellDelegate {
+	interface NSPathCellDelegate {
 		[Export ("pathCell:willDisplayOpenPanel:"), EventArgs ("NSPathCellDisplayPanel")]
 		void WillDisplayOpenPanel (NSPathCell pathCell, NSOpenPanel openPanel);
 
@@ -10873,7 +10873,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSTextFieldCell))]
-	public interface NSPathComponentCell {
+	interface NSPathComponentCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
 
@@ -10886,7 +10886,7 @@ namespace XamCore.AppKit {
 
 
 	[BaseType (typeof (NSControl))]
-	public interface NSPathControl {
+	interface NSPathControl {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -10953,7 +10953,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSPathControlDelegate {
+	interface NSPathControlDelegate {
 		#if !XAMCORE_2_0
 		[Abstract]
 		#endif
@@ -10991,7 +10991,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[BaseType (typeof (NSObject))]
-	public interface NSPathControlItem 
+	interface NSPathControlItem 
 	{
 		[Export ("title", ArgumentSemantic.Copy)]
 		string Title { get; set; }
@@ -11071,7 +11071,7 @@ namespace XamCore.AppKit {
 		bool Detached { [Bind ("isDetached")] get; }
 	}
 
-	public partial interface NSPopoverCloseEventArgs {
+	partial interface NSPopoverCloseEventArgs {
 		[Internal, Export ("NSPopoverCloseReasonKey")]
 		NSString _Reason { get; }
 	}
@@ -11104,7 +11104,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSButton))]
-	public partial interface NSPopUpButton {
+	partial interface NSPopUpButton {
 		[Export ("initWithFrame:pullsDown:")]
 		IntPtr Constructor (CGRect buttonFrame, bool pullsDown);
 
@@ -11210,7 +11210,7 @@ namespace XamCore.AppKit {
 
 
 	[BaseType (typeof (NSMenuItemCell))]
-	public partial interface NSPopUpButtonCell {
+	partial interface NSPopUpButtonCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
 	
@@ -11339,7 +11339,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSPrinter : NSCoding, NSCopying {
+	interface NSPrinter : NSCoding, NSCopying {
 		[Static]
 		[Export ("printerNames")]
 		string [] PrinterNames{ get; }
@@ -11400,7 +11400,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSPrintInfo : NSCoding, NSCopying {
+	interface NSPrintInfo : NSCoding, NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithDictionary:")]
 		IntPtr Constructor (NSDictionary attributes);
@@ -11493,7 +11493,7 @@ namespace XamCore.AppKit {
 
 
 	[BaseType (typeof (NSObject))]
-	public partial interface NSPrintOperation {
+	partial interface NSPrintOperation {
 		[Static]
 		[Export ("printOperationWithView:printInfo:")]
 		NSPrintOperation FromView (NSView view, NSPrintInfo printInfo);
@@ -11589,7 +11589,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSPrintPanelAccessorizing {
+	interface NSPrintPanelAccessorizing {
 		[Abstract]
 		[Export ("localizedSummaryItems")]
 		NSDictionary [] LocalizedSummaryItems ();
@@ -11601,7 +11601,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSObject))]
 	[Dispose ("__mt_accessory_var = null;")] 
-	public interface NSPrintPanel {
+	interface NSPrintPanel {
 		[Static]
 		[Export ("printPanel")]
 		NSPrintPanel PrintPanel { get; }
@@ -11644,7 +11644,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSView))]
-	public interface NSProgressIndicator : NSAccessibilityProgressIndicator {
+	interface NSProgressIndicator : NSAccessibilityProgressIndicator {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -11693,7 +11693,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public partial interface NSResponder : NSCoding {
+	partial interface NSResponder : NSCoding {
 		[Export ("tryToPerform:with:")]
 		bool TryToPerformwith (Selector anAction, [NullAllowed] NSObject anObject);
 
@@ -11883,7 +11883,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSRulerMarker : NSCoding, NSCopying {
+	interface NSRulerMarker : NSCoding, NSCopying {
 		[Export ("initWithRulerView:markerLocation:image:imageOrigin:")]
 		IntPtr Constructor (NSRulerView ruler, nfloat location, NSImage image, CGPoint imageOrigin);
 
@@ -11926,7 +11926,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSView))]
-	public partial interface NSRulerView {
+	partial interface NSRulerView {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -12001,10 +12001,10 @@ namespace XamCore.AppKit {
 		NSView AccessoryView { get; set; }
 	}
 
-	public delegate void NSSavePanelComplete (nint result);
+	delegate void NSSavePanelComplete (nint result);
 	
 	[BaseType (typeof (NSPanel), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSOpenSavePanelDelegate)})]
-	public interface NSSavePanel {
+	interface NSSavePanel {
 		[Export ("URL")]
 		NSUrl Url { get; }
 
@@ -12113,11 +12113,11 @@ namespace XamCore.AppKit {
 	// This class doesn't show up in any documentation.
 	[BaseType (typeof (NSSavePanel))]
 	[DisableDefaultCtor] // should not be created by (only returned to) user code
-	public interface NSRemoteSavePanel {}
+	interface NSRemoteSavePanel {}
 #endif
 
 	[BaseType (typeof (NSObject))]
-	public partial interface NSScreen {
+	partial interface NSScreen {
 		[Static]
 		[Export ("screens")]
 		NSScreen [] Screens { get; }
@@ -12174,7 +12174,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSControl))]
-	public interface NSScroller {
+	interface NSScroller {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -12262,7 +12262,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSView))]
-	public partial interface NSScrollView : NSTextFinderBarContainer {
+	partial interface NSScrollView : NSTextFinderBarContainer {
 		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_7)]
 		[Static]
 		[Export ("frameSizeForContentSize:hasHorizontalScroller:hasVerticalScroller:borderType:")]
@@ -12436,7 +12436,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSTextField), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (NSSearchFieldDelegate)})]
-	public interface NSSearchField {
+	interface NSSearchField {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -12492,7 +12492,7 @@ namespace XamCore.AppKit {
 		
 	[BaseType (typeof (NSObject))]
 	[Protocol, Model]
-	public interface NSSearchFieldDelegate : NSTextFieldDelegate
+	interface NSSearchFieldDelegate : NSTextFieldDelegate
 	{
 		[Mac (10,11)]
 		[Export ("searchFieldDidStartSearching:")]
@@ -12504,7 +12504,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSTextFieldCell))]
-	public interface NSSearchFieldCell {
+	interface NSSearchFieldCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
 
@@ -12549,7 +12549,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSControl))]
-	public interface NSSegmentedControl {
+	interface NSSegmentedControl {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -12634,7 +12634,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSActionCell))]
-	public interface NSSegmentedCell {
+	interface NSSegmentedCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
 	
@@ -12723,7 +12723,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSControl))]
-	public interface NSSlider : NSAccessibilitySlider {
+	interface NSSlider : NSAccessibilitySlider {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -12813,7 +12813,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSActionCell))]
-	public interface NSSliderCell {
+	interface NSSliderCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
 	
@@ -12904,7 +12904,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSSpeechRecognizer {
+	interface NSSpeechRecognizer {
 		[Export ("startListening")]
 		void StartListening ();
 
@@ -12935,13 +12935,13 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSSpeechRecognizerDelegate {
+	interface NSSpeechRecognizerDelegate {
 		[Export ("speechRecognizer:didRecognizeCommand:")]
 		void DidRecognizeCommand (NSSpeechRecognizer sender, string command);
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSSpeechSynthesizer {
+	interface NSSpeechSynthesizer {
 		[Export ("initWithVoice:")]
 		IntPtr Constructor (string voice);
 
@@ -13021,7 +13021,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSSpeechSynthesizerDelegate {
+	interface NSSpeechSynthesizerDelegate {
 		[Export ("speechSynthesizer:didFinishSpeaking:")]
 		void DidFinishSpeaking (NSSpeechSynthesizer sender, bool finishedSpeaking);
 
@@ -13039,7 +13039,7 @@ namespace XamCore.AppKit {
 	}
 
 	[StrongDictionary ("NSTextCheckingKey")]
-	public interface NSTextCheckingOptions {
+	interface NSTextCheckingOptions {
 		NSOrthography Orthography { get; set; }
 		string [] Quotes { get; set; }
 		NSDictionary Replacements { get; set; }
@@ -13071,7 +13071,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public partial interface NSSpellChecker {
+	partial interface NSSpellChecker {
 		[Static]
 		[Export ("sharedSpellChecker")]
 		NSSpellChecker SharedSpellChecker { get; }
@@ -13213,7 +13213,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (NSSoundDelegate) })]
 	[DisableDefaultCtor] // no valid handle is returned
-	public partial interface NSSound : NSCoding, NSCopying, NSPasteboardReading, NSPasteboardWriting
+	partial interface NSSound : NSCoding, NSCopying, NSPasteboardReading, NSPasteboardWriting
 	{
 		[Static]
 		[Export ("soundNamed:")]
@@ -13293,13 +13293,13 @@ namespace XamCore.AppKit {
 
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
-	public interface NSSoundDelegate {
+	interface NSSoundDelegate {
 		[Export ("sound:didFinishPlaying:"), EventArgs ("NSSoundFinished")]
 		void DidFinishPlaying (NSSound sound, bool finished);
 	}
 
 	[BaseType (typeof (NSView))]
-	public partial interface NSSplitView {
+	partial interface NSSplitView {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -13383,11 +13383,11 @@ namespace XamCore.AppKit {
 		NSString NSSplitViewDidResizeSubviewsNotification { get; }
 	}
 
-	public interface INSSplitViewDelegate {}
+	interface INSSplitViewDelegate {}
 
 	[Mac (10,10)]
 	[BaseType (typeof (NSViewController))]
-	public interface NSSplitViewController : NSSplitViewDelegate {
+	interface NSSplitViewController : NSSplitViewDelegate {
 		[Export ("splitView", ArgumentSemantic.Strong)]
 		NSSplitView SplitView { get; set; }
 
@@ -13421,7 +13421,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[BaseType (typeof (NSObject))]
-	public interface NSSplitViewItem : NSAnimatablePropertyContainer, NSCoding {
+	interface NSSplitViewItem : NSAnimatablePropertyContainer, NSCoding {
 		[Export ("viewController", ArgumentSemantic.Strong)]
 		NSViewController ViewController { get; set; }
 
@@ -13478,7 +13478,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model, Protocol]
-	public interface NSSplitViewDelegate {
+	interface NSSplitViewDelegate {
 		[Export ("splitView:canCollapseSubview:") ] [DefaultValue (true)]
 		bool CanCollapse (NSSplitView splitView, NSView subview);
 
@@ -13544,7 +13544,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,9)]
 	[BaseType (typeof (NSView))]
-	public interface NSStackView {
+	interface NSStackView {
 		[Export ("delegate", ArgumentSemantic.Weak)][NullAllowed]
 		NSObject WeakDelegate { get; set; }
 
@@ -13644,7 +13644,7 @@ namespace XamCore.AppKit {
 
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public interface NSStackViewDelegate {
+	interface NSStackViewDelegate {
 		[Export ("stackView:willDetachViews:"), DelegateName ("NSStackViewEvent")]
 		void WillDetachViews (NSStackView stackView, NSView [] views);
 
@@ -13653,7 +13653,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public partial interface NSStatusBar {
+	partial interface NSStatusBar {
 		[Static, Export ("systemStatusBar")]
 		NSStatusBar SystemStatusBar { get; }
 
@@ -13672,7 +13672,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[BaseType (typeof (NSButton))]
-	public interface NSStatusBarButton {
+	interface NSStatusBarButton {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -13682,7 +13682,7 @@ namespace XamCore.AppKit {
 	
 	[BaseType (typeof (NSObject))]
 	[PrivateDefaultCtor]
-	public partial interface NSStatusItem {
+	partial interface NSStatusItem {
 		[Export ("statusBar")]
 		NSStatusBar StatusBar { get; }
 
@@ -13768,7 +13768,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSShadow : NSCoding, NSCopying {
+	interface NSShadow : NSCoding, NSCopying {
 		[Export ("set")]
 		void Set ();
 
@@ -13785,7 +13785,7 @@ namespace XamCore.AppKit {
 	}
 
 	[Static]
-	public interface NSStringAttributeKey {
+	interface NSStringAttributeKey {
 		[Field ("NSFontAttributeName")]
 		NSString Font { get; }
 
@@ -13944,7 +13944,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[BaseType (typeof (NSObject))]
-	public interface NSStoryboard {
+	interface NSStoryboard {
 		[Static, Export ("storyboardWithName:bundle:")]
 		NSStoryboard FromName (string name, [NullAllowed] NSBundle storyboardBundleOrNil);
 
@@ -13957,7 +13957,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[BaseType (typeof (NSObject))]
-	public interface NSStoryboardSegue {
+	interface NSStoryboardSegue {
 		[Export ("initWithIdentifier:source:destination:")]
 		IntPtr Constructor (string identifier, NSObject sourceController, NSObject destinationController);
 
@@ -13980,7 +13980,7 @@ namespace XamCore.AppKit {
 	[Mac (10,10)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public interface NSSeguePerforming {
+	interface NSSeguePerforming {
 		[Export ("prepareForSegue:sender:")]
 		void PrepareForSegue (NSStoryboardSegue segue, NSObject sender);
 
@@ -13992,7 +13992,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSController))]
-	public interface NSUserDefaultsController {
+	interface NSUserDefaultsController {
 		[Export ("initWithDefaults:initialValues:")]
 		IntPtr Constructor ([NullAllowed] NSUserDefaults defaults, [NullAllowed] NSDictionary initialValues);
 //
@@ -14027,10 +14027,10 @@ namespace XamCore.AppKit {
 		void RevertToInitialValues (NSObject sender);
 	}
 
-	public interface INSUserInterfaceItemIdentification {}
+	interface INSUserInterfaceItemIdentification {}
 
 	[Protocol]
-	public interface NSUserInterfaceItemIdentification {
+	interface NSUserInterfaceItemIdentification {
 		[Lion, Export ("identifier", ArgumentSemantic.Copy)]
 		string Identifier { get; set; }
 	}
@@ -14041,7 +14041,7 @@ namespace XamCore.AppKit {
 	[Model]
 	[BaseType (typeof (NSObject))]
 #endif
-	public partial interface NSTextFinderClient {
+	partial interface NSTextFinderClient {
 #if !XAMCORE_3_0
 		[Abstract]
 #endif
@@ -14140,7 +14140,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject)), Model, Protocol]
-	public partial interface NSTextFinderBarContainer {
+	partial interface NSTextFinderBarContainer {
 		[Abstract, Export ("findBarVisible"), Lion]
 		bool FindBarVisible { [Bind ("isFindBarVisible")] get; set;  }
 
@@ -14156,7 +14156,7 @@ namespace XamCore.AppKit {
 
 	[Lion]
 	[BaseType (typeof (NSObject))]
-	public partial interface NSTextFinder : NSCoding {
+	partial interface NSTextFinder : NSCoding {
 		[Export ("client", ArgumentSemantic.Assign)]
 		[Protocolize]
 		NSTextFinderClient Client { set; }
@@ -14193,7 +14193,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSResponder))]
 	[Dispose ("__mt_tracking_var = null;")]
-	public partial interface NSView : NSDraggingDestination, NSAnimatablePropertyContainer, NSUserInterfaceItemIdentification, NSAppearanceCustomization, NSAccessibilityElementProtocol, NSAccessibility, NSObjectAccessibilityExtensions {
+	partial interface NSView : NSDraggingDestination, NSAnimatablePropertyContainer, NSUserInterfaceItemIdentification, NSAppearanceCustomization, NSAccessibilityElementProtocol, NSAccessibility, NSObjectAccessibilityExtensions {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -15058,7 +15058,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSAnimation))]
-	public interface NSViewAnimation { 
+	interface NSViewAnimation { 
 		[Export ("initWithViewAnimations:")]
 		IntPtr Constructor (NSDictionary [] viewAnimations);
 	
@@ -15099,7 +15099,7 @@ namespace XamCore.AppKit {
 	
 
 	[BaseType (typeof (NSResponder))]
-	public interface NSViewController : NSUserInterfaceItemIdentification, NSCoding, NSSeguePerforming
+	interface NSViewController : NSUserInterfaceItemIdentification, NSCoding, NSSeguePerforming
 #if XAMCORE_2_0
 	, NSExtensionRequestHandling 
 #endif
@@ -15277,7 +15277,7 @@ namespace XamCore.AppKit {
 	[Mac (10,10)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public interface NSViewControllerPresentationAnimator {
+	interface NSViewControllerPresentationAnimator {
 		[Export ("animatePresentationOfViewController:fromViewController:")]
 		[Abstract]
 		void AnimatePresentation (NSViewController viewController, NSViewController fromViewController);
@@ -15287,13 +15287,13 @@ namespace XamCore.AppKit {
 		void AnimateDismissal (NSViewController viewController, NSViewController fromViewController);
 	}
 
-	public interface INSViewControllerPresentationAnimator {}
+	interface INSViewControllerPresentationAnimator {}
 
 	[MountainLion]
 	[BaseType (typeof (NSViewController),
 		Delegates = new [] { "WeakDelegate" },
 		Events = new [] { typeof (NSPageControllerDelegate) })]
-	public partial interface NSPageController : NSAnimatablePropertyContainer {
+	partial interface NSPageController : NSAnimatablePropertyContainer {
 
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -15331,7 +15331,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject)), Model, Protocol]
-	public partial interface NSPageControllerDelegate {
+	partial interface NSPageControllerDelegate {
 
 		[Export ("pageController:identifierForObject:"), DelegateName ("NSPageControllerGetIdentifier"), DefaultValue ("String.Empty")]
 		string GetIdentifier (NSPageController pageController, NSObject targetObject);
@@ -15375,7 +15375,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public partial interface NSTableColumn : NSUserInterfaceItemIdentification, NSCoding {
+	partial interface NSTableColumn : NSUserInterfaceItemIdentification, NSCoding {
 		[Lion, Export ("initWithIdentifier:")]
 		[Sealed]
 		IntPtr Constructor (string identifier);
@@ -15436,7 +15436,7 @@ namespace XamCore.AppKit {
 
 	[Lion]
 	[BaseType (typeof (NSView))]
-	public interface NSTableRowView : NSAccessibilityRow {
+	interface NSTableRowView : NSAccessibilityRow {
 		[Export ("selectionHighlightStyle")]
 		NSTableViewSelectionHighlightStyle SelectionHighlightStyle { get; set;  }
 
@@ -15496,7 +15496,7 @@ namespace XamCore.AppKit {
 
 	[Lion]
 	[BaseType (typeof (NSView))]
-	public partial interface NSTableCellView {
+	partial interface NSTableCellView {
 		[Export ("backgroundStyle")]
 		NSBackgroundStyle BackgroundStyle {
 			get; set;
@@ -15528,10 +15528,10 @@ namespace XamCore.AppKit {
 		}
 	}
 
-	public delegate void NSTableViewRowHandler (NSTableRowView rowView, nint row);
+	delegate void NSTableViewRowHandler (NSTableRowView rowView, nint row);
 	
 	[BaseType (typeof (NSControl), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSTableViewDelegate)})]
-	public partial interface NSTableView : NSDraggingSource, NSAccessibilityTable {
+	partial interface NSTableView : NSDraggingSource, NSAccessibilityTable {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -15919,7 +15919,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public partial interface NSTableViewDelegate {
+	partial interface NSTableViewDelegate {
 		[Export ("tableView:willDisplayCell:forTableColumn:row:"), EventArgs ("NSTableViewCell")]
 		void WillDisplayCell (NSTableView tableView, NSObject cell, NSTableColumn tableColumn, nint row);
 	
@@ -16014,7 +16014,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSTableViewDataSource {
+	interface NSTableViewDataSource {
 		[Export ("numberOfRowsInTableView:")]
 		nint GetRowCount (NSTableView tableView);
 	
@@ -16065,7 +16065,7 @@ namespace XamCore.AppKit {
 	//
 	[Model]
 	[BaseType (typeof (NSObject))]
-	public interface NSTableViewSource {
+	interface NSTableViewSource {
 		//
 		// These come form NSTableViewDataSource
 		//
@@ -16205,7 +16205,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSTextFieldCell))]
-	public interface NSTableHeaderCell {
+	interface NSTableHeaderCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
 
@@ -16217,7 +16217,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSView))]
-	public interface NSTableHeaderView {
+	interface NSTableHeaderView {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -16243,7 +16243,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,11)]
 	[BaseType (typeof(NSObject))]
-	public interface NSTableViewRowAction : NSCopying
+	interface NSTableViewRowAction : NSCopying
 	{
 		[Static]
 		[Export ("rowActionWithStyle:title:handler:")]
@@ -16265,7 +16265,7 @@ namespace XamCore.AppKit {
 	}
 		
 	[BaseType (typeof (NSView), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSTabViewDelegate)})]
-	public partial interface NSTabView {
+	partial interface NSTabView {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -16362,7 +16362,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[BaseType (typeof (NSViewController))]
-	public interface NSTabViewController : NSTabViewDelegate, NSToolbarDelegate {
+	interface NSTabViewController : NSTabViewDelegate, NSToolbarDelegate {
 		[Export ("tabStyle")]
 		NSTabViewControllerTabStyle TabStyle { get; set; }
 
@@ -16402,7 +16402,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model, Protocol]
-	public interface NSTabViewDelegate {
+	interface NSTabViewDelegate {
 		[Export ("tabView:shouldSelectTabViewItem:"), DelegateName ("NSTabViewPredicate"), DefaultValue (true)]
 		bool ShouldSelectTabViewItem (NSTabView tabView, NSTabViewItem item);
 		
@@ -16417,7 +16417,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSTabViewItem : NSCoding {
+	interface NSTabViewItem : NSCoding {
 		[Export ("initWithIdentifier:")]
 		IntPtr Constructor (NSObject identifier);
 
@@ -16466,7 +16466,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSView), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSTextDelegate)})]
-	public partial interface NSText {
+	partial interface NSText {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -16632,7 +16632,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSTextDelegate {
+	interface NSTextDelegate {
 		[Export ("textShouldBeginEditing:"), DelegateName ("NSTextPredicate"), DefaultValue (true)]
 		bool TextShouldBeginEditing (NSText textObject);
 
@@ -16650,7 +16650,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSCell))]
-	public interface NSTextAttachmentCell {
+	interface NSTextAttachmentCell {
 		[Export ("initImageCell:")]
 		IntPtr Constructor (NSImage  image);
 
@@ -16690,7 +16690,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSTextAttachment : NSCoding {
+	interface NSTextAttachment : NSCoding {
 		[Export ("initWithFileWrapper:")]
 		IntPtr Constructor (NSFileWrapper fileWrapper);
 
@@ -16739,7 +16739,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSTextBlock : NSCoding, NSCopying {
+	interface NSTextBlock : NSCoding, NSCopying {
 		[Export ("setValue:type:forDimension:")]
 		void SetValue (nfloat val, NSTextBlockValueType type, NSTextBlockDimension dimension);
 
@@ -16798,7 +16798,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSControl), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSTextFieldDelegate)})]
-	public partial interface NSTextField : NSAccessibilityNavigableStaticText {
+	partial interface NSTextField : NSAccessibilityNavigableStaticText {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 		
@@ -16902,17 +16902,17 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSTextField))]
-	public interface NSSecureTextField {
+	interface NSSecureTextField {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 	}
 
-	public interface INSTextFieldDelegate { }
+	interface INSTextFieldDelegate { }
 
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSTextFieldDelegate {
+	interface NSTextFieldDelegate {
 		[Export ("control:textShouldBeginEditing:"), DelegateName ("NSControlText"), DefaultValue (true)]
 		bool TextShouldBeginEditing (NSControl control, NSText fieldEditor);
 
@@ -16947,7 +16947,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSTextFieldDelegate))]
 	[Model]
 	[Protocol]
-	public interface NSComboBoxDelegate {
+	interface NSComboBoxDelegate {
 		[Export ("comboBoxWillPopUp:")]
 		void WillPopUp (NSNotification notification);
 
@@ -16962,7 +16962,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSActionCell))]
-	public interface NSTextFieldCell {
+	interface NSTextFieldCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
 	
@@ -17000,7 +17000,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSTextFieldCell))]
-	public interface NSSecureTextFieldCell {
+	interface NSSecureTextFieldCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
 
@@ -17008,10 +17008,10 @@ namespace XamCore.AppKit {
 		bool EchosBullets { get; set; }
 	}  
 
-	public interface INSTextInputClient {}
+	interface INSTextInputClient {}
 
 	[BaseType (typeof (NSObject))]
-	public partial interface NSTextInputContext {
+	partial interface NSTextInputContext {
 		[Export ("initWithClient:")]
 		[DesignatedInitializer]
 		IntPtr Constructor ([Protocolize]NSTextInputClient client);
@@ -17056,7 +17056,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSTextList : NSCoding, NSCopying {
+	interface NSTextList : NSCoding, NSCopying {
 		[Export ("initWithMarkerFormat:options:")]
 		IntPtr Constructor (string format, NSTextListOptions mask);
 
@@ -17077,7 +17077,7 @@ namespace XamCore.AppKit {
 	
 	[BaseType (typeof (NSTextBlock))]
 	[DisableDefaultCtor]
-	public interface NSTextTableBlock {
+	interface NSTextTableBlock {
 		[Export ("initWithTable:startingRow:rowSpan:startingColumn:columnSpan:")]
 		IntPtr Constructor (NSTextTable table, nint row, nint rowSpan, nint col, nint colSpan);
 
@@ -17098,7 +17098,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSTextBlock))]
-	public interface NSTextTable {
+	interface NSTextTable {
 		[Export ("rectForBlock:layoutAtPoint:inRect:textContainer:characterRange:")]
 		CGRect GetRectForBlock (NSTextTableBlock block, CGPoint startingPoint, CGRect rect, NSTextContainer textContainer, NSRange charRange);
 
@@ -17123,7 +17123,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public partial interface NSTextContainer : NSCoding {
+	partial interface NSTextContainer : NSCoding {
 		[Export ("initWithContainerSize:"), Internal]
 		[Sealed]
 		IntPtr InitWithContainerSize (CGSize size);
@@ -17189,7 +17189,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSMutableAttributedString), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSTextStorageDelegate)})]
-	public partial interface NSTextStorage {
+	partial interface NSTextStorage {
 		[Export ("initWithString:")]
 		IntPtr Constructor (string str);
 
@@ -17243,7 +17243,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSTextStorageDelegate {
+	interface NSTextStorageDelegate {
 		[Availability (Deprecated = Platform.Mac_10_11, Message = "Use WillProcessEditing instead")]
 		[Export ("textStorageWillProcessEditing:")]
 		void TextStorageWillProcessEditing (NSNotification notification);
@@ -17262,7 +17262,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSTextTab : NSSecureCoding, NSCopying {
+	interface NSTextTab : NSSecureCoding, NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithTextAlignment:location:options:")]
 		IntPtr Constructor (NSTextAlignment alignment, nfloat loc, NSDictionary options);
@@ -17289,7 +17289,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSText), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSTextViewDelegate)})]
-	public partial interface NSTextView : NSTextInputClient, NSDraggingSource, NSTextFinderClient, NSAccessibilityNavigableStaticText {
+	partial interface NSTextView : NSTextInputClient, NSDraggingSource, NSTextFinderClient, NSAccessibilityNavigableStaticText {
 		[Export ("initWithFrame:textContainer:")]
 		IntPtr Constructor (CGRect frameRect, NSTextContainer container);
 
@@ -17779,7 +17779,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSObject))]
 	[Protocol, Model]
-	public interface NSTextInputClient
+	interface NSTextInputClient
 	{
 		[Export ("insertText:replacementRange:")]
 		void InsertText (NSObject text, NSRange replacementRange);
@@ -17831,7 +17831,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSTextDelegate))]
 	[Model]
 	[Protocol]
-	public partial interface NSTextViewDelegate {
+	partial interface NSTextViewDelegate {
 		[Export ("textView:clickedOnLink:atIndex:"), DelegateName ("NSTextViewLink"), DefaultValue (false)]
 		bool LinkClicked (NSTextView textView, NSObject link, nuint charIndex);
 
@@ -17899,7 +17899,7 @@ namespace XamCore.AppKit {
 	
 	
 	[BaseType (typeof (NSTextField))]
-	public interface NSTokenField {
+	interface NSTokenField {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -17932,7 +17932,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSTokenFieldDelegate {
+	interface NSTokenFieldDelegate {
 		[Export ("tokenField:completionsForSubstring:indexOfToken:indexOfSelectedItem:")]
 		string [] GetCompletionStrings (NSTokenField tokenField, string substring, nint tokenIndex, nint selectedIndex);
 
@@ -17969,7 +17969,7 @@ namespace XamCore.AppKit {
 #if XAMCORE_2_0
 	[DisableDefaultCtor]
 #endif
-	public partial interface NSToolbar {
+	partial interface NSToolbar {
 		[Export ("initWithIdentifier:")]
 		IntPtr Constructor (string identifier);
 
@@ -18068,7 +18068,7 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model, Protocol]
-	public interface NSToolbarDelegate {
+	interface NSToolbarDelegate {
 		[Export ("toolbar:itemForItemIdentifier:willBeInsertedIntoToolbar:"), DelegateName ("NSToolbarWillInsert"), DefaultValue (null)]
 		NSToolbarItem WillInsertItem (NSToolbar toolbar, string itemIdentifier, bool willBeInserted);
 
@@ -18089,7 +18089,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSToolbarItem : NSCopying {
+	interface NSToolbarItem : NSCopying {
 		[Export ("initWithItemIdentifier:")]
 		IntPtr Constructor (string itemIdentifier);
 
@@ -18150,7 +18150,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSTouch : NSCopying {
+	interface NSTouch : NSCopying {
 		[Export ("identity", ArgumentSemantic.Retain)]
 		NSObject Identity { get; }
 
@@ -18171,7 +18171,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSTrackingArea : NSCoding, NSCopying {
+	interface NSTrackingArea : NSCoding, NSCopying {
 		[Export ("initWithRect:options:owner:userInfo:")]
 		IntPtr Constructor (CGRect rect, NSTrackingAreaOptions options, NSObject owner, [NullAllowed] NSDictionary userInfo);
 		
@@ -18189,7 +18189,7 @@ namespace XamCore.AppKit {
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSTreeNode {
+	interface NSTreeNode {
 		[Static, Export ("treeNodeWithRepresentedObject:")]
 		NSTreeNode FromRepresentedObject (NSObject modelObject);
 
@@ -18223,7 +18223,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObjectController))]
-	public interface NSTreeController {
+	interface NSTreeController {
 		[Export ("rearrangeObjects")]
 		void RearrangeObjects ();
 
@@ -18334,14 +18334,14 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public partial interface NSTypesetter {
+	partial interface NSTypesetter {
 
 	}
 
-	public delegate void NSWindowTrackEventsMatchingCompletionHandler (NSEvent evt, ref bool stop);
+	delegate void NSWindowTrackEventsMatchingCompletionHandler (NSEvent evt, ref bool stop);
 	
 	[BaseType (typeof (NSResponder), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSWindowDelegate)})]
-	public partial interface NSWindow : NSAnimatablePropertyContainer, NSUserInterfaceItemIdentification, NSAppearanceCustomization, NSAccessibilityElementProtocol, NSAccessibility {
+	partial interface NSWindow : NSAnimatablePropertyContainer, NSUserInterfaceItemIdentification, NSAppearanceCustomization, NSAccessibilityElementProtocol, NSAccessibility {
 		[Static, Export ("frameRectForContentRect:styleMask:")]
 		CGRect FrameRectFor (CGRect contectRect, NSWindowStyle styleMask);
 	
@@ -19167,7 +19167,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[BaseType (typeof (NSViewController))]
-	public interface NSTitlebarAccessoryViewController : NSAnimationDelegate, NSAnimatablePropertyContainer {
+	interface NSTitlebarAccessoryViewController : NSAnimationDelegate, NSAnimatablePropertyContainer {
 		[Export ("layoutAttribute")]
 		NSLayoutAttribute LayoutAttribute { get; set; }
 
@@ -19190,7 +19190,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[BaseType (typeof (NSView))]
-	public interface NSVisualEffectView {
+	interface NSVisualEffectView {
 		[Export ("material")]
 		NSVisualEffectMaterial Material { get; set; }
 
@@ -19217,13 +19217,13 @@ namespace XamCore.AppKit {
 		bool Emphasized { [Bind ("isEmphasized")] get; set; }
 	}
 	
-	public delegate void NSWindowCompletionHandler (NSWindow window, NSError error);
+	delegate void NSWindowCompletionHandler (NSWindow window, NSError error);
 	
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
 	[Lion]
-	public partial interface NSWindowRestoration {
+	partial interface NSWindowRestoration {
 		[Static]
 		[Export ("restoreWindowWithIdentifier:state:completionHandler:")]
 		void RestoreWindow (string identifier, NSCoder state, NSWindowCompletionHandler onCompletion);
@@ -19231,7 +19231,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSResponder))]
-	public interface NSWindowController : NSCoding, NSSeguePerforming {
+	interface NSWindowController : NSCoding, NSSeguePerforming {
 		[Export ("initWithWindow:")]
 		IntPtr Constructor (NSWindow  window);
 	
@@ -19309,7 +19309,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSWindowDelegate {
+	interface NSWindowDelegate {
 		[Export ("windowShouldClose:"), DelegateName ("NSObjectPredicate"), DefaultValue (true)]
 		bool WindowShouldClose (NSObject sender);
 	
@@ -19492,10 +19492,10 @@ namespace XamCore.AppKit {
 		nint FileType { get; }
 	}
 	
-	public delegate void NSWorkspaceUrlHandler (NSDictionary newUrls, NSError error);
+	delegate void NSWorkspaceUrlHandler (NSDictionary newUrls, NSError error);
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSWorkspace : NSWorkspaceAccessibilityExtensions {
+	interface NSWorkspace : NSWorkspaceAccessibilityExtensions {
 		[Static]
 		[Export ("sharedWorkspace"), ThreadSafe]
 		NSWorkspace SharedWorkspace { get; }
@@ -19787,7 +19787,7 @@ namespace XamCore.AppKit {
 	
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe] // NSRunningApplication is documented to be thread-safe.
-	public partial interface NSRunningApplication {
+	partial interface NSRunningApplication {
 		[Export ("terminated")]
 		bool Terminated { [Bind ("isTerminated")] get;  }
 		
@@ -19859,7 +19859,7 @@ namespace XamCore.AppKit {
 	}	
 
 	[BaseType (typeof (NSControl))]
-	public interface NSStepper : NSAccessibilityStepper {
+	interface NSStepper : NSAccessibilityStepper {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
@@ -19902,7 +19902,7 @@ namespace XamCore.AppKit {
 
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSPredicateEditorRowTemplate : NSCoding, NSCopying {
+	interface NSPredicateEditorRowTemplate : NSCoding, NSCopying {
 		[Export ("matchForPredicate:")]
 		double MatchForPredicate (NSPredicate predicate);
 
@@ -19959,7 +19959,7 @@ namespace XamCore.AppKit {
 
 	[Mac(10,10,3)]
 	[BaseType (typeof (NSObject))]
-	public interface NSPressureConfiguration
+	interface NSPressureConfiguration
 	{
 		[Export ("pressureBehavior")]
 		NSPressureBehavior PressureBehavior { get; }
@@ -19972,7 +19972,7 @@ namespace XamCore.AppKit {
 	}
    
 	[BaseType (typeof (NSControl), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSRuleEditorDelegate)})]
-	public partial interface NSRuleEditor {
+	partial interface NSRuleEditor {
 		[Export ("reloadCriteria")]
 		void ReloadCriteria ();
 
@@ -20076,7 +20076,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSRuleEditorDelegate {
+	interface NSRuleEditorDelegate {
 		[Abstract]
 		[Export ("ruleEditor:numberOfChildrenForCriterion:withRowType:"), DelegateName ("NSRuleEditorNumberOfChildren"), DefaultValue(0)]
 		nint NumberOfChildren (NSRuleEditor editor, NSObject criterion, NSRuleEditorRowType rowType);
@@ -20109,7 +20109,7 @@ namespace XamCore.AppKit {
 	}
    
 	[BaseType (typeof (NSRuleEditor))]
-	public interface NSPredicateEditor {
+	interface NSPredicateEditor {
 		//Detected properties
 		[Export ("rowTemplates", ArgumentSemantic.Copy)]
 		NSPredicateEditorRowTemplate[] RowTemplates { get; set; }
@@ -20119,13 +20119,13 @@ namespace XamCore.AppKit {
 	// Start of NSSharingService.h
 	
 	[MountainLion]
-	public delegate void NSSharingServiceHandler ();
+	delegate void NSSharingServiceHandler ();
 	
 	[MountainLion]
 	[BaseType (typeof (NSObject),
 	           Delegates=new string [] {"WeakDelegate"},
 	Events=new Type [] { typeof (NSSharingServiceDelegate) })]
-	public interface NSSharingService 
+	interface NSSharingService 
 	{
 		
 		[Export ("delegate", ArgumentSemantic.Assign)][NullAllowed]
@@ -20243,7 +20243,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSSharingServiceDelegate 
+	interface NSSharingServiceDelegate 
 	{
 		[Export ("sharingService:willShareItems:"), EventArgs ("NSSharingServiceItems")]
 		void WillShareItems (NSSharingService sharingService, NSObject [] items);
@@ -20268,7 +20268,7 @@ namespace XamCore.AppKit {
 		NSView CreateAnchoringView (NSSharingService sharingService, ref CGRect positioningRect, ref NSRectEdge preferredEdge);
 	}
 
-	public interface INSSharingServiceDelegate {}
+	interface INSSharingServiceDelegate {}
 
 	[Protocol, Model]
 	[Mac (10, 12, onlyOn64: true)]
@@ -20293,7 +20293,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject),
 	           Delegates=new string [] {"WeakDelegate"},
 	Events=new Type [] { typeof (NSSharingServicePickerDelegate) })]
-	public interface NSSharingServicePicker 
+	interface NSSharingServicePicker 
 	{
 		[Export ("delegate", ArgumentSemantic.Assign)][NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -20313,7 +20313,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSSharingServicePickerDelegate 
+	interface NSSharingServicePickerDelegate 
 	{
 		[Export ("sharingServicePicker:sharingServicesForItems:proposedSharingServices:"), DelegateName ("NSSharingServicePickerSharingServicesForItems"), DefaultValueFromArgument ("proposedServices")]
 		NSSharingService [] SharingServicesForItems (NSSharingServicePicker sharingServicePicker, NSObject [] items, NSSharingService [] proposedServices);
@@ -20336,7 +20336,7 @@ namespace XamCore.AppKit {
 		NSATSTypesetter SharedTypesetter { get; }
 	}
 
-	public partial interface NSTypesetter {
+	partial interface NSTypesetter {
 		[Export ("substituteFontForFont:")]
 		NSFont GetSubstituteFont (NSFont originalFont);
 
@@ -20522,7 +20522,7 @@ namespace XamCore.AppKit {
 		void SetBidiLevels (IntPtr levels, NSRange glyphRange);
 	}
 
-	public partial interface NSCollectionViewDelegate {
+	partial interface NSCollectionViewDelegate {
 		[Lion, Export ("collectionView:pasteboardWriterForItemAtIndex:")]
 #if XAMCORE_2_0
 		INSPasteboardWriting PasteboardWriterForItem (NSCollectionView collectionView, nuint index);
@@ -20542,7 +20542,7 @@ namespace XamCore.AppKit {
 			CGPoint screenPoint, NSDragOperation dragOperation);
 	}
 
-	public partial interface NSColor {
+	partial interface NSColor {
 		[Lion, Static, Export ("colorWithGenericGamma22White:alpha:")]
 		NSColor FromGamma22White (nfloat white, nfloat alpha);
 
@@ -20553,7 +20553,7 @@ namespace XamCore.AppKit {
 		NSString SystemColorsChanged { get; }
 	}
 
-	public partial interface NSDocumentController {
+	partial interface NSDocumentController {
 		[Lion, Export ("duplicateDocumentWithContentsOfURL:copying:displayName:error:")]
 		NSDocument DuplicateDocumentWithContentsOfUrl (NSUrl url, bool duplicateByCopying,
 			[NullAllowed] string displayName, out NSError error);
@@ -20572,12 +20572,12 @@ namespace XamCore.AppKit {
 	}
 
 	[Lion, Model]
-	public interface NSTextLayoutOrientationProvider {
+	interface NSTextLayoutOrientationProvider {
 		[Export ("layoutOrientation")]
 		NSTextLayoutOrientation LayoutOrientation { get; }
 	}
 
-	public partial interface NSLayoutManager {
+	partial interface NSLayoutManager {
 		// FIXME: This may need some generator work, or use IntPtr for glyphs?
 		//
 		//   ./AppKit/NSLayoutManager.g.cs(1015,44): error CS1503: Argument `#1'
@@ -20588,7 +20588,7 @@ namespace XamCore.AppKit {
 		// 	NSAffineTransform textMatrix, NSDictionary attributes, NSGraphicsContext graphicsContext);
 	}
 
-	public partial interface NSViewColumnMoveEventArgs {
+	partial interface NSViewColumnMoveEventArgs {
 		[Export ("NSOldColumn")]
 		nint OldColumn { get; }
 
@@ -20596,7 +20596,7 @@ namespace XamCore.AppKit {
 		nint NewColumn { get; }
 	}
 
-	public partial interface NSViewColumnResizeEventArgs {
+	partial interface NSViewColumnResizeEventArgs {
 		[Export ("NSTableColumn")]
 		NSTableColumn Column { get; }
 
@@ -20604,12 +20604,12 @@ namespace XamCore.AppKit {
 		nint OldWidth { get; }
 	}
 
-	public partial interface NSOutlineViewItemEventArgs {
+	partial interface NSOutlineViewItemEventArgs {
 		[Export ("NSObject")]
 		NSObject Item { get; }
 	}
 
-	public partial interface NSOutlineView : NSAccessibilityOutline {
+	partial interface NSOutlineView : NSAccessibilityOutline {
 
 		[Notification, Field ("NSOutlineViewSelectionDidChangeNotification")]
 		NSString SelectionDidChangeNotification { get; }
@@ -20684,7 +20684,7 @@ namespace XamCore.AppKit {
 		void MoveRow (nint oldIndex, nint newIndex);
 	}
 
-	public partial interface NSOutlineViewDataSource {
+	partial interface NSOutlineViewDataSource {
 		// - (id <NSPasteboardWriting>)outlineView:(NSOutlineView *)outlineView pasteboardWriterForItem:(id)item NS_AVAILABLE_MAC(10_7);
 		[Lion, Export ("outlineView:pasteboardWriterForItem:")]
 #if XAMCORE_2_0
@@ -20719,7 +20719,7 @@ namespace XamCore.AppKit {
 		NSColorSpace OldColorSpace { get; }
 	}
 
-	public partial interface NSWindow {
+	partial interface NSWindow {
 		//
 		// Fields + Notifications
 		//
@@ -20886,18 +20886,18 @@ namespace XamCore.AppKit {
 		NSUserInterfaceLayoutDirection WindowTitlebarLayoutDirection { get; }
 	}
 
-	public partial interface NSPrintOperation {
+	partial interface NSPrintOperation {
 		[Lion, Export ("preferredRenderingQuality")]
 		NSPrintRenderingQuality PreferredRenderingQuality { get; }
 	}
 
 	[Category, BaseType (typeof (NSResponder))]
-	public partial interface NSControlEditingSupport {
+	partial interface NSControlEditingSupport {
 		[Lion, Export ("validateProposedFirstResponder:forEvent:")]
 		bool ValidateProposedFirstResponder (NSResponder responder, [NullAllowed] NSEvent forEvent);
 	}
 
-	public partial interface NSResponder {
+	partial interface NSResponder {
 		[Lion, Export ("wantsScrollEventsForSwipeTrackingOnAxis:")]
 		bool WantsScrollEventsForSwipeTrackingOnAxis (NSEventGestureAxis axis);
 
@@ -20912,13 +20912,13 @@ namespace XamCore.AppKit {
 	}
 
 	[Category, BaseType (typeof (NSResponder))]
-	public partial interface NSStandardKeyBindingMethods {
+	partial interface NSStandardKeyBindingMethods {
 		[MountainLion, Export ("quickLookPreviewItems:")]
 		void QuickLookPreviewItems (NSObject sender);
 	}
 
 	[Category, BaseType (typeof (NSView))]
-	public partial interface NSRulerMarkerClientViewDelegation {
+	partial interface NSRulerMarkerClientViewDelegation {
 		[Lion, Export ("rulerView:locationForPoint:")]
 		nfloat RulerViewLocation (NSRulerView ruler, CGPoint locationForPoint);
 
@@ -20927,24 +20927,24 @@ namespace XamCore.AppKit {
 	}
 
 	[Category, BaseType (typeof (NSResponder))]
-	public partial interface NSTextFinderSupport {
+	partial interface NSTextFinderSupport {
 		[Lion, Export ("performTextFinderAction:")]
 		void PerformTextFinderAction ([NullAllowed] NSObject sender);
 	}
 
-	public partial interface NSRunningApplication {
+	partial interface NSRunningApplication {
 		[Lion, Static, Export ("terminateAutomaticallyTerminableApplications")]
 		void TerminateAutomaticallyTerminableApplications ();
 	}
 
-	public partial interface NSPasteboard {
+	partial interface NSPasteboard {
 		[Lion, Field ("NSPasteboardTypeTextFinderOptions")]
 		NSString PasteboardTypeTextFinderOptions { get; }
 	}
 
-	public delegate void NSSpellCheckerShowCorrectionIndicatorOfTypeHandler (string acceptedString);
+	delegate void NSSpellCheckerShowCorrectionIndicatorOfTypeHandler (string acceptedString);
 
-	public partial interface NSSpellChecker {
+	partial interface NSSpellChecker {
 		[Lion, Export ("correctionForWordRange:inString:language:inSpellDocumentWithTag:")]
 		string GetCorrection (NSRange forWordRange, string inString, string language, nint inSpellDocumentWithTag);
 
@@ -21015,13 +21015,13 @@ namespace XamCore.AppKit {
 		NSString DidChangeAutomaticPeriodSubstitutionNotification { get; }
 	}
 
-	public partial interface NSTextViewDidChangeSelectionEventArgs {
+	partial interface NSTextViewDidChangeSelectionEventArgs {
 		// FIXME: verify property type "NSValue object containing an NSRange structure"
 		[Export ("NSOldSelectedCharacterRange")]
 		NSValue OldSelectedCharacterRange { get; }
 	}
 
-	public partial interface NSTextViewWillChangeNotifyingTextViewEventArgs {
+	partial interface NSTextViewWillChangeNotifyingTextViewEventArgs {
 		[Export ("NSOldNotifyingTextView")]
 		NSTextView OldView { get; }
 
@@ -21029,7 +21029,7 @@ namespace XamCore.AppKit {
 		NSTextView NewView { get; }
 	}
 
-	public partial interface NSTextView : NSTextLayoutOrientationProvider {
+	partial interface NSTextView : NSTextLayoutOrientationProvider {
 		[Lion, Export ("setLayoutOrientation:")]
 		void SetLayoutOrientation (NSTextLayoutOrientation theOrientation);
 
@@ -21063,7 +21063,7 @@ namespace XamCore.AppKit {
 		NSString DidChangeTypingAttributesNotification { get; }
 	}
 
-	public partial interface NSView {
+	partial interface NSView {
 
 		[MountainLion, Export ("wantsUpdateLayer")]
 		bool WantsUpdateLayer { get; }
@@ -21076,18 +21076,18 @@ namespace XamCore.AppKit {
 	}
 
 	[Category, BaseType (typeof (NSApplication))]
-	public partial interface NSRemoteNotifications_NSApplication {
+	partial interface NSRemoteNotifications_NSApplication {
 
 		[MountainLion, Field ("NSApplicationLaunchUserNotificationKey", "AppKit")]
 		NSString NSApplicationLaunchUserNotificationKey { get; }
 	}
 
-	public partial interface NSControlTextEditingEventArgs {
+	partial interface NSControlTextEditingEventArgs {
 		[Export ("NSFieldEditor")]
 		NSTextView FieldEditor { get; }
 	}
 
-	public partial interface NSControl {
+	partial interface NSControl {
 
 		[Notification (typeof (NSControlTextEditingEventArgs))]
 		[Field ("NSControlTextDidBeginEditingNotification")]
@@ -21105,25 +21105,25 @@ namespace XamCore.AppKit {
 		bool AllowsExpansionToolTips { get; set; }
 	}
 
-	public partial interface NSMatrix {
+	partial interface NSMatrix {
 
 		[MountainLion, Export ("autorecalculatesCellSize")]
 		bool AutoRecalculatesCellSize { get; set; }
 	}
 
-	public partial interface NSForm {
+	partial interface NSForm {
 
 		[MountainLion, Export ("preferredTextFieldWidth")]
 		nfloat PreferredTextFieldWidth { get; set; }
 	}
 
-	public partial interface NSFormCell {
+	partial interface NSFormCell {
 
 		[MountainLion, Export ("preferredTextFieldWidth")]
 		nfloat PreferredTextFieldWidth { get; set; }
 	}
 
-	public partial interface NSColor {
+	partial interface NSColor {
 
 		[MountainLion, Static, Export ("underPageBackgroundColor")]
 		NSColor UnderPageBackgroundColor { get; }
@@ -21132,9 +21132,9 @@ namespace XamCore.AppKit {
 		NSColor FromCGColor (CGColor cgColor);
 	}
 
-	public delegate bool NSCustomImageRepDrawingHandler (CGRect dstRect);
+	delegate bool NSCustomImageRepDrawingHandler (CGRect dstRect);
 
-	public partial interface NSCustomImageRep {
+	partial interface NSCustomImageRep {
 
 		[MountainLion, Export ("initWithSize:flipped:drawingHandler:")]
 		IntPtr Constructor (CGSize size, bool flipped, NSCustomImageRepDrawingHandler drawingHandler);
@@ -21143,14 +21143,14 @@ namespace XamCore.AppKit {
 		NSCustomImageRepDrawingHandler DrawingHandler { get; }
 	}
 
-	public delegate void NSDocumentMoveCompletionHandler (bool didMove);
-	public delegate void NSDocumentMoveToUrlCompletionHandler (NSError error);
-	public delegate void NSDocumentLockDocumentCompletionHandler (bool didLock);
-	public delegate void NSDocumentUnlockDocumentCompletionHandler (bool didUnlock);
-	public delegate void NSDocumentLockCompletionHandler (NSError error);
-	public delegate void NSDocumentUnlockCompletionHandler (NSError error);
+	delegate void NSDocumentMoveCompletionHandler (bool didMove);
+	delegate void NSDocumentMoveToUrlCompletionHandler (NSError error);
+	delegate void NSDocumentLockDocumentCompletionHandler (bool didLock);
+	delegate void NSDocumentUnlockDocumentCompletionHandler (bool didUnlock);
+	delegate void NSDocumentLockCompletionHandler (NSError error);
+	delegate void NSDocumentUnlockCompletionHandler (NSError error);
 
-	public partial interface NSDocument {
+	partial interface NSDocument {
 
 		[MountainLion, Export ("draft")]
 		bool IsDraft { [Bind ("isDraft")] get; set; }
@@ -21207,10 +21207,10 @@ namespace XamCore.AppKit {
 		bool UsesUbiquitousStorage { get; }
 	}
 
-	public delegate void NSDocumentControllerOpenPanelWithCompletionHandler (NSArray urlsToOpen);
-	public delegate void NSDocumentControllerOpenPanelResultHandler (nint result);
+	delegate void NSDocumentControllerOpenPanelWithCompletionHandler (NSArray urlsToOpen);
+	delegate void NSDocumentControllerOpenPanelResultHandler (nint result);
 
-	public partial interface NSDocumentController {
+	partial interface NSDocumentController {
 
 		[MountainLion, Export ("beginOpenPanelWithCompletionHandler:")]
 		void BeginOpenPanelWithCompletionHandler (NSDocumentControllerOpenPanelWithCompletionHandler completionHandler);
@@ -21219,7 +21219,7 @@ namespace XamCore.AppKit {
 		void BeginOpenPanel (NSOpenPanel openPanel, NSArray inTypes, NSDocumentControllerOpenPanelResultHandler completionHandler);
 	}
 
-	public partial interface NSImage {
+	partial interface NSImage {
 
 		[MountainLion, Static, Export ("imageWithSize:flipped:drawingHandler:")]
 #if XAMCORE_2_0
@@ -21229,13 +21229,13 @@ namespace XamCore.AppKit {
 #endif
 	}
 
-	public partial interface NSNib {
+	partial interface NSNib {
 
 		[MountainLion, Export ("initWithNibData:bundle:")]
 		IntPtr Constructor (NSData nibData, NSBundle bundle);
 	}
 
-	public partial interface NSSplitViewDividerIndexEventArgs {
+	partial interface NSSplitViewDividerIndexEventArgs {
 		// FIXME: The generator can't handle Nullable<int>, and
 		// the key may or may not exist; if it doesn't exist, then
 		// the generator will have this property always return 0,
@@ -21248,7 +21248,7 @@ namespace XamCore.AppKit {
 	}
 
 	[Category, BaseType (typeof (NSSegmentedCell))]
-	public partial interface NSSegmentBackgroundStyle_NSSegmentedCell {
+	partial interface NSSegmentBackgroundStyle_NSSegmentedCell {
 
 		[MountainLion, Field ("NSSharingServiceNamePostOnFacebook")]
 		NSString SharingServiceNamePostOnFacebook { get; }
@@ -21297,26 +21297,26 @@ namespace XamCore.AppKit {
 	}
 
 	[Category, BaseType (typeof (NSTextView))]
-	public partial interface NSTextView_SharingService {
+	partial interface NSTextView_SharingService {
 
 		[MountainLion, Export ("orderFrontSharingServicePicker:")]
 		void OrderFrontSharingServicePicker (NSObject sender);
 	}
 
-	/*public partial interface NSTextViewDelegate {
+	/*partial interface NSTextViewDelegate {
 
 		[MountainLion, Export ("textView:willShowSharingServicePicker:forItems:"), DelegateName (...)]
 		NSSharingServicePicker WillShowSharingService (NSTextView textView,
 			NSSharingServicePicker servicePicker, NSArray forItems);
 	}*/
 
-	public interface NSTextAlternativesSelectedAlternativeStringEventArgs {
+	interface NSTextAlternativesSelectedAlternativeStringEventArgs {
 		[Export ("NSAlternativeString")]
 		string AlternativeString { get; }
 	}
 
 	[MountainLion, BaseType (typeof (NSObject))]
-	public partial interface NSTextAlternatives {
+	partial interface NSTextAlternatives {
 
 		[Export ("initWithPrimaryString:alternativeStrings:")]
 		IntPtr Constructor (string primaryString, NSArray alternativeStrings);
@@ -21336,7 +21336,7 @@ namespace XamCore.AppKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public partial interface NSGlyphInfo : NSCoding, NSCopying, NSSecureCoding {
+	partial interface NSGlyphInfo : NSCoding, NSCopying, NSSecureCoding {
 
 		[Static, Export ("glyphInfoWithGlyphName:forFont:baseString:")]
 		NSGlyphInfo Get (string glyphName, NSFont forFont, string baseString);
@@ -21357,23 +21357,23 @@ namespace XamCore.AppKit {
 		NSCharacterCollection CharacterCollection { get; }
 	}
 
-	public partial interface NSTableViewDelegate {
+	partial interface NSTableViewDelegate {
 
 		[Export ("tableView:toolTipForCell:rect:tableColumn:row:mouseLocation:"), DelegateName ("NSTableViewToolTip"), DefaultValue ("null")]
 		NSString GetToolTip (NSTableView tableView, NSCell cell, ref CGRect rect, NSTableColumn tableColumn, nint row, CGPoint mouseLocation);
 	}
 
-	public partial interface NSBrowser {
+	partial interface NSBrowser {
 		[Notification, Field ("NSBrowserColumnConfigurationDidChangeNotification")]
 		NSString ColumnConfigurationChangedNotification { get; }
 	}
 
-	public partial interface NSColorPanel {
+	partial interface NSColorPanel {
 		[Notification, Field ("NSColorPanelColorDidChangeNotification")]
 		NSString ColorChangedNotification { get; }
 	}
 
-	public partial interface NSFont {
+	partial interface NSFont {
 		[Notification, Field ("NSAntialiasThresholdChangedNotification")]
 		NSString AntialiasThresholdChangedNotification { get; }
 
@@ -21381,7 +21381,7 @@ namespace XamCore.AppKit {
 		NSString FontSetChangedNotification { get; }
 	}
 
-	public partial interface NSHelpManager {
+	partial interface NSHelpManager {
 		[Notification, Field ("NSContextHelpModeDidActivateNotification")]
 		NSString ContextHelpModeDidActivateNotification { get; }
 
@@ -21389,7 +21389,7 @@ namespace XamCore.AppKit {
 		NSString ContextHelpModeDidDeactivateNotification { get; }
 	}
 
-	public partial interface NSDrawer {
+	partial interface NSDrawer {
 		[Notification, Field ("NSDrawerWillOpenNotification")]
 		NSString WillOpenNotification { get; }
 
@@ -21403,17 +21403,17 @@ namespace XamCore.AppKit {
 		NSString DidCloseNotification { get; }
 	}
 
-	public partial interface NSMenuItemIndexEventArgs {
+	partial interface NSMenuItemIndexEventArgs {
 		[Export ("NSMenuItemIndex")]
 		nint MenuItemIndex { get; }
 	}
 
-	public partial interface NSMenuItemEventArgs {
+	partial interface NSMenuItemEventArgs {
 		[Export ("MenuItem")]
 		NSMenu MenuItem { get; }
 	}
 
-	public partial interface NSMenu {
+	partial interface NSMenu {
 		[Notification (typeof (NSMenuItemEventArgs))]
 		[Field ("NSMenuWillSendActionNotification")]
 		NSString WillSendActionNotification { get; }
@@ -21441,27 +21441,27 @@ namespace XamCore.AppKit {
 		NSString DidEndTrackingNotification { get; }
 	}
 
-	public partial interface NSPopUpButtonCell {
+	partial interface NSPopUpButtonCell {
 		[Notification, Field ("NSPopUpButtonCellWillPopUpNotification")]
 		NSString WillPopUpNotification { get; }
 	}
 
-	public partial interface NSPopUpButton {
+	partial interface NSPopUpButton {
 		[Notification, Field ("NSPopUpButtonWillPopUpNotification")]
 		NSString WillPopUpNotification { get; }
 	}
 
-	public partial interface NSRuleEditor {
+	partial interface NSRuleEditor {
 		[Notification, Field ("NSRuleEditorRowsDidChangeNotification")]
 		NSString RowsDidChangeNotification { get; }
 	}
 
-	public partial interface NSScreen {
+	partial interface NSScreen {
 		[Notification, Field ("NSScreenColorSpaceDidChangeNotification")]
 		NSString ColorSpaceDidChangeNotification { get; }
 	}
 
-	public partial interface NSTableView {
+	partial interface NSTableView {
 		[Notification, Field ("NSTableViewSelectionDidChangeNotification")]
 		NSString SelectionDidChangeNotification { get; }
 
@@ -21477,7 +21477,7 @@ namespace XamCore.AppKit {
 		NSString ColumnDidResizeNotification { get; }
 	}
 
-	public partial interface NSTextDidEndEditingEventArgs {
+	partial interface NSTextDidEndEditingEventArgs {
 		// FIXME: I think this is essentially a flags value
 		// of movements and characters. The docs are a bit
 		// confusing.
@@ -21485,7 +21485,7 @@ namespace XamCore.AppKit {
 		nint Movement { get; }
 	}
 
-	public partial interface NSText {
+	partial interface NSText {
 		[Notification, Field ("NSTextDidBeginEditingNotification")]
 		NSString DidBeginEditingNotification { get; }
 
@@ -21497,12 +21497,12 @@ namespace XamCore.AppKit {
 		NSString DidChangeNotification { get; }
 	}
 
-	public partial interface NSTextInputContext {
+	partial interface NSTextInputContext {
 		[Notification, Field ("NSTextInputContextKeyboardSelectionDidChangeNotification")]
 		NSString KeyboardSelectionDidChangeNotification { get; }
 	}
 
-	public partial interface NSTextStorage {
+	partial interface NSTextStorage {
 		[Notification, Field ("NSTextStorageWillProcessEditingNotification")]
 		NSString WillProcessEditingNotification { get; }
 
@@ -21510,12 +21510,12 @@ namespace XamCore.AppKit {
 		NSString DidProcessEditingNotification { get; }
 	}
 
-	public partial interface NSToolbarItemEventArgs {
+	partial interface NSToolbarItemEventArgs {
 		[Export ("item")]
 		NSToolbarItem Item { get; }
 	}
 
-	public partial interface NSToolbar {
+	partial interface NSToolbar {
 		[Notification (typeof (NSToolbarItemEventArgs))]
 		[Field ("NSToolbarWillAddItemNotification")]
 		NSString NSToolbarWillAddItemNotification { get; }
@@ -21525,14 +21525,14 @@ namespace XamCore.AppKit {
 		NSString NSToolbarDidRemoveItemNotification { get; }
 	}
 
-	public partial interface NSImageRep {
+	partial interface NSImageRep {
 		[Notification, Field ("NSImageRepRegistryDidChangeNotification")]
 		NSString RegistryDidChangeNotification { get; }
 	}
 
 	[Mac (10,10)]
 	[Protocol]
-	public interface NSAccessibility
+	interface NSAccessibility
 	{
 		[Mac (10, 10)]
 		[Abstract]
@@ -22274,7 +22274,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10, 10)]
 	[BaseType (typeof (NSObject))]
-	public interface NSAccessibilityElement : NSAccessibility {
+	interface NSAccessibilityElement : NSAccessibility {
 		[Export ("accessibilityAddChildElement:")]
 		void AccessibilityAddChildElement (NSAccessibilityElement childElement);
 
@@ -22781,7 +22781,7 @@ namespace XamCore.AppKit {
 	}
 
 	[Static]
-	public interface NSAccessibilityFontKeys {
+	interface NSAccessibilityFontKeys {
 		[Field ("NSAccessibilityFontNameKey")]
 		NSString FontNameKey { get; }
 
@@ -22796,7 +22796,7 @@ namespace XamCore.AppKit {
 	}
 
 	[Static]
-	public interface NSAccessibilityRoles {
+	interface NSAccessibilityRoles {
 		[Field ("NSAccessibilityUnknownRole")]
 		NSString UnknownRole { get; }
 
@@ -22970,7 +22970,7 @@ namespace XamCore.AppKit {
 	}
 
 	[Static]
-	public interface NSAccessibilitySubroles {
+	interface NSAccessibilitySubroles {
 		[Field ("NSAccessibilityUnknownSubrole")]
 		NSString UnknownSubrole { get; }
 
@@ -23069,7 +23069,7 @@ namespace XamCore.AppKit {
 	}
 
 	[Static]
-	public interface NSAccessibilityNotifications {
+	interface NSAccessibilityNotifications {
 		[Field ("NSAccessibilityMainWindowChangedNotification")]
 		NSString MainWindowChangedNotification { get; }
 
@@ -23178,14 +23178,14 @@ namespace XamCore.AppKit {
 	}
 
 	[Static]
-	public interface NSWorkspaceAccessibilityNotifications {
+	interface NSWorkspaceAccessibilityNotifications {
 		[Mac (10, 10)]
 		[Field ("NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification")]
 		NSString DisplayOptionsDidChangeNotification { get; }
 	}
 
 	[Static]
-	public interface NSAccessibilityNotificationUserInfoKeys {
+	interface NSAccessibilityNotificationUserInfoKeys {
 		[Introduced (PlatformName.MacOSX, 10, 9)]
 		[Field ("NSAccessibilityUIElementsKey")]
 		NSString UIElementsKey { get; }
@@ -23199,7 +23199,7 @@ namespace XamCore.AppKit {
 	}
 
 	[Static]
-	public interface NSAccessibilityActions {
+	interface NSAccessibilityActions {
 		[Field ("NSAccessibilityPressAction")]
 		NSString PressAction { get; }
 
@@ -23238,7 +23238,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[Protocol (Name = "NSAccessibilityElement")] // exists both as a type and a protocol in ObjC, Swift uses NSAccessibilityElementProtocol
-	public interface NSAccessibilityElementProtocol {
+	interface NSAccessibilityElementProtocol {
 		[Abstract]
 		[Export ("accessibilityFrame")]
 		CGRect AccessibilityFrame { get; }
@@ -23256,12 +23256,12 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[Protocol]
-	public interface NSAccessibilityGroup : NSAccessibilityElementProtocol {
+	interface NSAccessibilityGroup : NSAccessibilityElementProtocol {
 	}
 
 	[Mac (10,10)]
 	[Protocol]
-	public interface NSAccessibilityButton : NSAccessibilityElementProtocol {
+	interface NSAccessibilityButton : NSAccessibilityElementProtocol {
 		[Abstract]
 		[NullAllowed, Export ("accessibilityLabel")]
 		string AccessibilityLabel { get; }
@@ -23273,7 +23273,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[Protocol]
-	public interface NSAccessibilitySwitch : NSAccessibilityButton {
+	interface NSAccessibilitySwitch : NSAccessibilityButton {
 		[Abstract]
 		[NullAllowed, Export ("accessibilityValue")]
 		string AccessibilityValue { get; }
@@ -23287,7 +23287,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[Protocol]
-	public interface NSAccessibilityRadioButton : NSAccessibilityButton {
+	interface NSAccessibilityRadioButton : NSAccessibilityButton {
 		[Abstract]
 		[NullAllowed, Export ("accessibilityValue")]
 		NSNumber AccessibilityValue { get; }
@@ -23295,7 +23295,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[Protocol]
-	public interface NSAccessibilityStaticText : NSAccessibilityElementProtocol {
+	interface NSAccessibilityStaticText : NSAccessibilityElementProtocol {
 		[Abstract]
 		[NullAllowed, Export ("accessibilityValue")]
 		string AccessibilityValue { get; }
@@ -23310,7 +23310,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[Protocol]
-	public interface NSAccessibilityNavigableStaticText : NSAccessibilityStaticText {
+	interface NSAccessibilityNavigableStaticText : NSAccessibilityStaticText {
 		[Abstract]
 		[Export ("accessibilityStringForRange:")]
 		[return: NullAllowed]
@@ -23331,7 +23331,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[Protocol]
-	public interface NSAccessibilityProgressIndicator : NSAccessibilityGroup {
+	interface NSAccessibilityProgressIndicator : NSAccessibilityGroup {
 		[Abstract]
 		[NullAllowed, Export ("accessibilityValue")]
 		NSNumber AccessibilityValue { get; }
@@ -23339,7 +23339,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[Protocol]
-	public interface NSAccessibilityStepper : NSAccessibilityElementProtocol {
+	interface NSAccessibilityStepper : NSAccessibilityElementProtocol {
 		[Abstract]
 		[NullAllowed, Export ("accessibilityLabel")]
 		string AccessibilityLabel { get; }
@@ -23358,7 +23358,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[Protocol]
-	public interface NSAccessibilitySlider : NSAccessibilityElementProtocol {
+	interface NSAccessibilitySlider : NSAccessibilityElementProtocol {
 		[Abstract]
 		[NullAllowed, Export ("accessibilityLabel")]
 		string AccessibilityLabel { get; }
@@ -23378,7 +23378,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[Protocol]
-	public interface NSAccessibilityImage : NSAccessibilityElementProtocol {
+	interface NSAccessibilityImage : NSAccessibilityElementProtocol {
 		[Abstract]
 		[NullAllowed, Export ("accessibilityLabel")]
 		string AccessibilityLabel { get; }
@@ -23386,7 +23386,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[Protocol]
-	public interface NSAccessibilityContainsTransientUI : NSAccessibilityElementProtocol {
+	interface NSAccessibilityContainsTransientUI : NSAccessibilityElementProtocol {
 		[Abstract]
 		[Export ("accessibilityPerformShowAlternateUI")]
 		bool AccessibilityPerformShowAlternateUI ();
@@ -23400,11 +23400,11 @@ namespace XamCore.AppKit {
 		bool IsAccessibilityAlternateUIVisible { get; }
 	}
 
-	public interface INSAccessibilityRow {}
+	interface INSAccessibilityRow {}
 
 	[Mac (10,10)]
 	[Protocol]
-	public interface NSAccessibilityTable : NSAccessibilityGroup {
+	interface NSAccessibilityTable : NSAccessibilityGroup {
 		[Abstract]
 		[NullAllowed, Export ("accessibilityLabel")]
 		string AccessibilityLabel { get; }
@@ -23445,16 +23445,16 @@ namespace XamCore.AppKit {
 	}
 
 	[Mac (10,10)]
-	public interface NSAccessibilityOutline : NSAccessibilityTable {
+	interface NSAccessibilityOutline : NSAccessibilityTable {
 	}
 
 	[Mac (10,10)]
-	public interface NSAccessibilityList : NSAccessibilityTable {
+	interface NSAccessibilityList : NSAccessibilityTable {
 	}
 
 	[Mac (10,10)]
 	[Protocol]
-	public interface NSAccessibilityRow : NSAccessibilityGroup {
+	interface NSAccessibilityRow : NSAccessibilityGroup {
 		[Abstract]
 		[Export ("accessibilityIndex")]
 		nint AccessibilityIndex { get; }
@@ -23465,7 +23465,7 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[Protocol]
-	public interface NSAccessibilityLayoutArea : NSAccessibilityGroup {
+	interface NSAccessibilityLayoutArea : NSAccessibilityGroup {
 		[Abstract]
 		[Export ("accessibilityLabel")]
 		string AccessibilityLabel { get; }
@@ -23485,12 +23485,12 @@ namespace XamCore.AppKit {
 
 	[Mac (10,10)]
 	[Protocol]
-	public interface NSAccessibilityLayoutItem : NSAccessibilityGroup {
+	interface NSAccessibilityLayoutItem : NSAccessibilityGroup {
 		[Export ("setAccessibilityFrame:")]
 		void SetAccessibilityFrame (CGRect frame);
 	}
 
-	public interface NSObjectAccessibilityExtensions {
+	interface NSObjectAccessibilityExtensions {
 		[Availability (Obsoleted = Platform.Mac_10_10, Message = "Use the NSAccessibility protocol methods instead")]
 		[Export ("accessibilityAttributeNames")]
 		NSArray AccessibilityAttributeNames { get; }
@@ -23553,7 +23553,7 @@ namespace XamCore.AppKit {
 	}
 
 	[Mac (10, 10)]
-	public interface NSWorkspaceAccessibilityExtensions {
+	interface NSWorkspaceAccessibilityExtensions {
 		[Export ("accessibilityDisplayShouldIncreaseContrast")]
 		bool AccessibilityDisplayShouldIncreaseContrast { get; }
 
@@ -23572,7 +23572,7 @@ namespace XamCore.AppKit {
 		bool AccessibilityDisplayShouldReduceMotion { get; }
 	}
 	
-	public interface INSFilePromiseProviderDelegate {}
+	interface INSFilePromiseProviderDelegate {}
 
 	[Mac (10,12)]
 	[BaseType (typeof(NSObject))]
@@ -23623,17 +23623,28 @@ namespace XamCore.AppKit {
 		[Export ("receivePromisedFilesAtDestination:options:operationQueue:reader:")]
 		void ReceivePromisedFiles (NSUrl destinationDir, NSDictionary options, NSOperationQueue operationQueue, Action<NSUrl, NSError> reader);
 	}
+/*
+	[Protocol]
+	interface NSValidatedUserInterfaceItem
+	{
+		[Abstract]
+		[NullAllowed, Export ("action")]
+		Selector Action { get; }
 
-	//TODO - Waiting on CloudKit binding
-	//[Protocol]
-	//[Mac (10,12)]
-	//interface NSCloudSharingValidation
-	//{
-	//	[Abstract]
-	//	[Export ("cloudShareForUserInterfaceItem:")]
-	//	[return: NullAllowed]
-	//	CKShare GetCloudShare (NSValidatedUserInterfaceItem item);
-	//}
+		[Abstract]
+		[Export ("tag")]
+		nint Tag { get; }
+	}
+
+	[Protocol]
+	[Mac (10,12)]
+	interface NSCloudSharingValidation
+	{
+		[Abstract]
+		[Export ("cloudShareForUserInterfaceItem:")]
+		[return: NullAllowed]
+		CKShare GetCloudShare (NSValidatedUserInterfaceItem item);
+	}*/
 
 	[Mac (10,6)]
 	[BaseType (typeof(CAOpenGLLayer))]

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -900,7 +900,7 @@ namespace XamCore.AppKit {
 
 		[Mac (10,12, onlyOn64 : true)]
 		[Export ("application:userDidAcceptCloudKitShareWithMetadata:"), EventArgs ("NSApplicationUserAcceptedCloudKitShare")]
-		void UserDidAcceptedCloudKitShare (NSApplication application, CKShareMetadata metadata);
+		void UserDidAcceptCloudKitShare (NSApplication application, CKShareMetadata metadata);
 #endif
 	}
 		

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -39,6 +39,7 @@ using XamCore.CoreAnimation;
 using XamCore.CoreData;
 using XamCore.OpenGL;
 using XamCore.CoreVideo;
+using XamCore.CloudKit;
 
 using CGGlyph = System.UInt16;
 
@@ -896,12 +897,11 @@ namespace XamCore.AppKit {
 		[Mac (10,10, onlyOn64 : true)]
 		[Export ("application:didUpdateUserActivity:"), EventArgs ("NSApplicationUpdatedUserActivity"), DefaultValue (false)]
 		void UpdatedUserActivity (NSApplication application, NSUserActivity userActivity);
-#endif
 
-		//TODO - Waiting on CloudKit binding
-		//[Mac (10,12)]
-		//[Export ("application:userDidAcceptCloudKitShareWithMetadata:")]
-		//void UserDidAcceptedCloudKitShare (NSApplication application, CKShareMetadata metadata);
+		[Mac (10,12, onlyOn64 : true)]
+		[Export ("application:userDidAcceptCloudKitShareWithMetadata:"), EventArgs ("NSApplicationUserAcceptedCloudKitShare")]
+		void UserDidAcceptedCloudKitShare (NSApplication application, CKShareMetadata metadata);
+#endif
 	}
 		
 	[BaseType (typeof (NSObjectController))]
@@ -20281,12 +20281,11 @@ namespace XamCore.AppKit {
 		[Export ("optionsForSharingService:shareProvider:")]
 		NSCloudKitSharingServiceOptions Options (NSSharingService cloudKitSharingService, NSItemProvider provider);
 
-		// TODO - Add when CloudKit bindings are done
-		//[Export ("sharingService:didSaveShare:")]
-		//void Saved (NSSharingService sharingService, CKShare share);
+		[Export ("sharingService:didSaveShare:")]
+		void Saved (NSSharingService sharingService, CKShare share);
 
-		//[Export ("sharingService:didStopSharing:")]
-		//void Stopped (NSSharingService sharingService, CKShare share);
+		[Export ("sharingService:didStopSharing:")]
+		void Stopped (NSSharingService sharingService, CKShare share);
 	}
 
 	[MountainLion]

--- a/src/contacts.cs
+++ b/src/contacts.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Contacts bindings
 //
 // Authors:
@@ -16,17 +16,17 @@ namespace XamCore.Contacts {
 
 #if XAMCORE_2_0 // The Contacts framework uses generics heavily, which is only supported in Unified (for now at least)
 
-	public interface ICNKeyDescriptor {}
+	interface ICNKeyDescriptor {}
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Protocol]
 	// Headers say "This protocol is reserved for Contacts framework usage.", so don't create a model
-	public interface CNKeyDescriptor : NSObjectProtocol, NSSecureCoding, NSCopying {
+	interface CNKeyDescriptor : NSObjectProtocol, NSSecureCoding, NSCopying {
 	}
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
-	public interface CNContact : NSCopying, NSMutableCopying, NSSecureCoding {
+	interface CNContact : NSCopying, NSMutableCopying, NSSecureCoding {
 
 		[Export ("identifier")]
 		string Identifier { get; }
@@ -182,7 +182,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Static]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	public interface CNContactKey {
+	interface CNContactKey {
 
 		[Field ("CNContactIdentifierKey")]
 		NSString Identifier { get; }
@@ -281,7 +281,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // using init raises an exception according to docs
-	public interface CNContactFetchRequest : NSSecureCoding {
+	interface CNContactFetchRequest : NSSecureCoding {
 
 		[DesignatedInitializer]
 		[Export ("initWithKeysToFetch:")]
@@ -310,7 +310,7 @@ namespace XamCore.Contacts {
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSFormatter))]
-	public interface CNContactFormatter {
+	interface CNContactFormatter {
 
 		[Static]
 		[Export ("descriptorForRequiredKeysForStyle:")]
@@ -347,7 +347,7 @@ namespace XamCore.Contacts {
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
-	public interface CNContactProperty : NSCopying, NSSecureCoding {
+	interface CNContactProperty : NSCopying, NSSecureCoding {
 
 		[Export ("contact", ArgumentSemantic.Copy)]
 		CNContact Contact { get; }
@@ -370,7 +370,7 @@ namespace XamCore.Contacts {
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
-	public interface CNContactRelation : NSCopying, NSSecureCoding, INSCopying, INSSecureCoding {
+	interface CNContactRelation : NSCopying, NSSecureCoding, INSCopying, INSSecureCoding {
 
 		[Static]
 		[Export ("contactRelationWithName:")]
@@ -386,7 +386,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Static]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	public interface CNLabelContactRelationKey {
+	interface CNLabelContactRelationKey {
 
 		[Field ("CNLabelContactRelationFather")]
 		NSString Father { get; }
@@ -422,15 +422,15 @@ namespace XamCore.Contacts {
 		NSString Manager { get; }
 	}
 
-	public delegate void CNContactStoreRequestAccessHandler (bool granted, NSError error);
+	delegate void CNContactStoreRequestAccessHandler (bool granted, NSError error);
 #if !XAMCORE_4_0
-	public delegate void CNContactStoreEnumerateContactsHandler (CNContact contact, bool stop);
+	delegate void CNContactStoreEnumerateContactsHandler (CNContact contact, bool stop);
 #endif
-	public delegate void CNContactStoreListContactsHandler (CNContact contact, ref bool stop);
+	delegate void CNContactStoreListContactsHandler (CNContact contact, ref bool stop);
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
-	public interface CNContactStore {
+	interface CNContactStore {
 
 		[Static]
 		[Export ("authorizationStatusForEntityType:")]
@@ -485,7 +485,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe (false)]
-	public interface CNContactsUserDefaults {
+	interface CNContactsUserDefaults {
 
 		[Static]
 		[Export ("sharedDefaults")]
@@ -500,7 +500,7 @@ namespace XamCore.Contacts {
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
-	public interface CNContactVCardSerialization {
+	interface CNContactVCardSerialization {
 
 		[Static]
 		[Export ("descriptorForRequiredKeys")]
@@ -518,7 +518,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Category]
 	[BaseType (typeof (CNContainer))]
-	public interface CNContainer_PredicatesExtension {
+	interface CNContainer_PredicatesExtension {
 
 		[Static]
 		[Export ("predicateForContainersWithIdentifiers:")]
@@ -535,7 +535,7 @@ namespace XamCore.Contacts {
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
-	public interface CNContainer : NSCopying, NSSecureCoding {
+	interface CNContainer : NSCopying, NSSecureCoding {
 
 		[Export ("identifier")]
 		string Identifier { get; }
@@ -550,7 +550,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Static]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	public interface CNContainerKey { // Can be used in KVO
+	interface CNContainerKey { // Can be used in KVO
 
 		[Field ("CNContainerIdentifierKey")]
 		NSString Identifier { get; }
@@ -565,7 +565,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Static]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	public interface CNErrorUserInfoKey {
+	interface CNErrorUserInfoKey {
 
 		[Field ("CNErrorUserInfoAffectedRecordsKey")]
 		NSString AffectedRecords { get; }
@@ -583,7 +583,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Category]
 	[BaseType (typeof (CNGroup))]
-	public interface CNGroup_PredicatesExtension {
+	interface CNGroup_PredicatesExtension {
 
 		[Static]
 		[Export ("predicateForGroupsWithIdentifiers:")]
@@ -601,7 +601,7 @@ namespace XamCore.Contacts {
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
-	public interface CNGroup : NSCopying, NSMutableCopying, NSSecureCoding {
+	interface CNGroup : NSCopying, NSMutableCopying, NSSecureCoding {
 
 		[Export ("identifier")]
 		string Identifier { get; }
@@ -613,7 +613,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Static]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	public interface CNGroupKey { // Can be used in KVO
+	interface CNGroupKey { // Can be used in KVO
 
 		[Field ("CNGroupIdentifierKey")]
 		NSString Identifier { get; }
@@ -624,7 +624,7 @@ namespace XamCore.Contacts {
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
-	public interface CNInstantMessageAddress : NSCopying, NSSecureCoding, INSCopying, INSSecureCoding {
+	interface CNInstantMessageAddress : NSCopying, NSSecureCoding, INSCopying, INSSecureCoding {
 
 		[Export ("initWithUsername:service:")]
 		IntPtr Constructor (string username, string service);
@@ -647,7 +647,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Static]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	public interface CNInstantMessageAddressKey { // Can be used in KVO
+	interface CNInstantMessageAddressKey { // Can be used in KVO
 
 		[Field ("CNInstantMessageAddressUsernameKey")]
 		NSString Username { get; }
@@ -659,7 +659,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Static]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	public interface CNInstantMessageServiceKey {
+	interface CNInstantMessageServiceKey {
 
 		[Field ("CNInstantMessageServiceAIM")]
 		NSString Aim { get; }
@@ -694,7 +694,7 @@ namespace XamCore.Contacts {
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
-	public interface CNLabeledValue<ValueType> : NSCopying, NSSecureCoding
+	interface CNLabeledValue<ValueType> : NSCopying, NSSecureCoding
 		where ValueType : INSCopying, INSSecureCoding
 	{
 
@@ -733,7 +733,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Static]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	public interface CNLabelKey {
+	interface CNLabelKey {
 
 		[Field ("CNLabelHome")]
 		NSString Home { get; }
@@ -756,7 +756,7 @@ namespace XamCore.Contacts {
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (CNContact))]
-	public interface CNMutableContact {
+	interface CNMutableContact {
 
 		[New]
 		[Export ("contactType")]
@@ -874,7 +874,7 @@ namespace XamCore.Contacts {
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (CNGroup))]
-	public interface CNMutableGroup {
+	interface CNMutableGroup {
 
 		[New]
 		[Export ("name")]
@@ -883,7 +883,7 @@ namespace XamCore.Contacts {
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (CNPostalAddress))]
-	public interface CNMutablePostalAddress {
+	interface CNMutablePostalAddress {
 
 		[New]
 		[Export ("street")]
@@ -913,7 +913,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // Apple doc: no handle (nil) if no string (or nil string) is given
-	public interface CNPhoneNumber : NSCopying, NSSecureCoding, INSCopying, INSSecureCoding {
+	interface CNPhoneNumber : NSCopying, NSSecureCoding, INSCopying, INSSecureCoding {
 
 		// @required + (instancetype)phoneNumberWithStringValue:(NSString *)stringValue;
 		[Static, Export ("phoneNumberWithStringValue:")]
@@ -931,7 +931,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Static]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	public interface CNLabelPhoneNumberKey {
+	interface CNLabelPhoneNumberKey {
 
 		[Field ("CNLabelPhoneNumberiPhone")]
 		NSString iPhone { get; }
@@ -957,7 +957,7 @@ namespace XamCore.Contacts {
 
 	[iOS (9,0)] [Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
-	public interface CNPostalAddress : NSCopying, NSMutableCopying, NSSecureCoding, INSCopying, INSSecureCoding {
+	interface CNPostalAddress : NSCopying, NSMutableCopying, NSSecureCoding, INSCopying, INSSecureCoding {
 
 		[Export ("street")]
 		string Street { get; }
@@ -985,7 +985,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Static]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	public interface CNPostalAddressKey { // Can be used in KVO
+	interface CNPostalAddressKey { // Can be used in KVO
 
 		[Field ("CNPostalAddressStreetKey")]
 		NSString Street { get; }
@@ -1008,7 +1008,7 @@ namespace XamCore.Contacts {
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSFormatter))]
-	public interface CNPostalAddressFormatter {
+	interface CNPostalAddressFormatter {
 
 		[Static]
 		[Export ("stringFromPostalAddress:style:")]
@@ -1037,7 +1037,7 @@ namespace XamCore.Contacts {
 #if !WATCH
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
-	public interface CNSaveRequest {
+	interface CNSaveRequest {
 
 		[Export ("addContact:toContainerWithIdentifier:")]
 		void AddContact (CNMutableContact contact, [NullAllowed] string identifier);
@@ -1075,7 +1075,7 @@ namespace XamCore.Contacts {
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
-	public interface CNSocialProfile : NSCopying, NSSecureCoding, INSCopying, INSSecureCoding {
+	interface CNSocialProfile : NSCopying, NSSecureCoding, INSCopying, INSSecureCoding {
 
 		[Export ("urlString")]
 		string UrlString { get; }
@@ -1104,7 +1104,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Static]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	public interface CNSocialProfileKey { // Can be used in KVO
+	interface CNSocialProfileKey { // Can be used in KVO
 
 		[Field ("CNSocialProfileURLStringKey")]
 		NSString UrlString { get; }
@@ -1122,7 +1122,7 @@ namespace XamCore.Contacts {
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Static]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	public interface CNSocialProfileServiceKey {
+	interface CNSocialProfileServiceKey {
 
 		[Field ("CNSocialProfileServiceFacebook")]
 		NSString Facebook { get; }

--- a/src/contactsui.mac.cs
+++ b/src/contactsui.mac.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using XamCore.ObjCRuntime;
 using XamCore.Foundation;
@@ -26,7 +26,7 @@ namespace XamCore.ContactsUI {
 		void Close ();
 	}
 
-	public interface ICNContactPickerDelegate { }
+	interface ICNContactPickerDelegate { }
 
 	[Mac (10,11, onlyOn64: true)]
 	[Protocol, Model]

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -52,7 +52,7 @@ namespace XamCore.CoreAnimation {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface CAMediaTiming {
+	interface CAMediaTiming {
 #if XAMCORE_2_0
 		[Abstract]
 #endif
@@ -102,18 +102,18 @@ namespace XamCore.CoreAnimation {
 		string FillMode { get; set; }
 	}
 
-	public interface ICAMediaTiming {}
+	interface ICAMediaTiming {}
 
 #if MONOMAC
 	[BaseType (typeof (NSObject))]
-	public interface CAConstraintLayoutManager : NSCoding {
+	interface CAConstraintLayoutManager : NSCoding {
 		[Static]
 		[Export ("layoutManager")]
 		CAConstraintLayoutManager LayoutManager { get; }
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public interface CAConstraint : NSCoding {
+	interface CAConstraint : NSCoding {
 		[Export ("attribute")]
 		CAConstraintAttribute Attribute { get;  }
 
@@ -144,7 +144,7 @@ namespace XamCore.CoreAnimation {
 	
 #else
 	[BaseType (typeof (NSObject))]
-	public interface CADisplayLink {
+	interface CADisplayLink {
 		[Export ("displayLinkWithTarget:selector:")][Static]
 		CADisplayLink Create (NSObject target, Selector sel);
 	
@@ -200,7 +200,7 @@ namespace XamCore.CoreAnimation {
 
 	[BaseType (typeof (NSObject))]
 	[Dispose ("OnDispose ();")]
-	public interface CALayer : CAMediaTiming, NSCoding {
+	interface CALayer : CAMediaTiming, NSCoding {
 		[Export ("layer")][Static]
 		CALayer Create ();
 
@@ -630,7 +630,7 @@ namespace XamCore.CoreAnimation {
 #endif
 
 	[BaseType (typeof (CALayer))]
-	public interface CATiledLayer {
+	interface CATiledLayer {
 		[Export ("layer"), New, Static]
 		CALayer Create ();
 		
@@ -648,7 +648,7 @@ namespace XamCore.CoreAnimation {
 	}
 
 	[BaseType (typeof (CALayer))]
-	public interface CAReplicatorLayer {
+	interface CAReplicatorLayer {
 		[Export ("layer"), New, Static]
 		CALayer Create ();
 
@@ -682,7 +682,7 @@ namespace XamCore.CoreAnimation {
 
 
 	[BaseType (typeof (CALayer))]
-	public interface CAScrollLayer {
+	interface CAScrollLayer {
 		[Export ("layer"), New, Static]
 		CALayer Create ();
 
@@ -709,7 +709,7 @@ namespace XamCore.CoreAnimation {
 	}
 	
 	[BaseType (typeof (CALayer))]
-	public interface CAShapeLayer {
+	interface CAShapeLayer {
 		[Export ("layer"), New, Static]
 		CALayer Create ();
 
@@ -777,7 +777,7 @@ namespace XamCore.CoreAnimation {
 	}
 
 	[BaseType (typeof (CALayer))]
-	public interface CATransformLayer {
+	interface CATransformLayer {
 		[Export ("layer"), New, Static]
 		CALayer Create ();
 
@@ -787,7 +787,7 @@ namespace XamCore.CoreAnimation {
 
 	[Since (3,2)]
 	[BaseType (typeof (CALayer))]
-	public interface CATextLayer {
+	interface CATextLayer {
 		[Export ("layer"), New, Static]
 		CALayer Create ();
 
@@ -853,7 +853,7 @@ namespace XamCore.CoreAnimation {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol (IsInformal = true)] // not informal as of iOS 10+, but removing the IsInformal value breaks when building with older SDKs (see bug #43585).
-	public interface CALayerDelegate {
+	interface CALayerDelegate {
 		[Export ("displayLayer:")]
 		void DisplayLayer (CALayer layer);
 
@@ -873,7 +873,7 @@ namespace XamCore.CoreAnimation {
 	
 #if !MONOMAC
 	[BaseType (typeof (CALayer))]
-	public interface CAEAGLLayer : EAGLDrawable {
+	interface CAEAGLLayer : EAGLDrawable {
 		[Export ("layer"), New, Static]
 		CALayer Create ();
 
@@ -887,7 +887,7 @@ namespace XamCore.CoreAnimation {
 	[Model]
 	[Protocol]
 	[DisableDefaultCtor]
-	public interface CAAction {
+	interface CAAction {
 #if XAMCORE_2_0
 		[Abstract]
 #endif
@@ -896,7 +896,7 @@ namespace XamCore.CoreAnimation {
 	}
 	
 	[BaseType (typeof (NSObject), Delegates=new string [] {"WeakDelegate"}, Events=new Type [] { typeof (CAAnimationDelegate)})]
-	public interface CAAnimation : CAAction, CAMediaTiming, NSCoding, NSMutableCopying {
+	interface CAAnimation : CAAction, CAMediaTiming, NSCoding, NSMutableCopying {
 		[Export ("animation"), Static]
 		CAAnimation CreateAnimation ();
 	
@@ -1007,7 +1007,7 @@ namespace XamCore.CoreAnimation {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Synthetic]
-	public interface CAAnimationDelegate {
+	interface CAAnimationDelegate {
 		[Export ("animationDidStart:")]
 		void AnimationStarted ([NullAllowed] CAAnimation anim);
 	
@@ -1017,7 +1017,7 @@ namespace XamCore.CoreAnimation {
 	}
 	
 	[BaseType (typeof (CAAnimation))]
-	public interface CAPropertyAnimation {
+	interface CAPropertyAnimation {
 		[Static]
 		[Export ("animationWithKeyPath:")]
 		CAPropertyAnimation FromKeyPath ([NullAllowed] string path);
@@ -1038,7 +1038,7 @@ namespace XamCore.CoreAnimation {
 	}
 	
 	[BaseType (typeof (CAPropertyAnimation))]
-	public interface CABasicAnimation {
+	interface CABasicAnimation {
 		[Static, New, Export ("animationWithKeyPath:")]
 		CABasicAnimation FromKeyPath ([NullAllowed] string path);
 
@@ -1084,7 +1084,7 @@ namespace XamCore.CoreAnimation {
 	}
 	
 	[BaseType (typeof (CAPropertyAnimation), Name="CAKeyframeAnimation")]
-	public interface CAKeyFrameAnimation {
+	interface CAKeyFrameAnimation {
 		[Static, Export ("animationWithKeyPath:")]
 #if XAMCORE_2_0
 		CAKeyFrameAnimation FromKeyPath ([NullAllowed] string path);
@@ -1144,7 +1144,7 @@ namespace XamCore.CoreAnimation {
 	}
 	
 	[BaseType (typeof (CAAnimation))]
-	public interface CATransition {
+	interface CATransition {
 		[Export ("animation"), Static, New]
 		CATransition CreateAnimation ();
 
@@ -1176,7 +1176,7 @@ namespace XamCore.CoreAnimation {
 #else
 	[Partial] // keep default .ctor for API compatibility
 #endif
-	public interface CAFillMode {
+	interface CAFillMode {
 		[Field ("kCAFillModeForwards")]
 		NSString Forwards { get; }
 
@@ -1197,7 +1197,7 @@ namespace XamCore.CoreAnimation {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface CATransaction {
+	interface CATransaction {
 		[Static]
 		[Export ("begin")]
 		void Begin ();
@@ -1256,7 +1256,7 @@ namespace XamCore.CoreAnimation {
 	}
 
 	[BaseType (typeof (CAAnimation))]
-	public interface CAAnimationGroup {
+	interface CAAnimationGroup {
 		[NullAllowed] // by default this property is null
 		[Export ("animations", ArgumentSemantic.Copy)]
 		CAAnimation [] Animations { get; set; }
@@ -1266,7 +1266,7 @@ namespace XamCore.CoreAnimation {
 	}
 
 	[BaseType (typeof (CALayer))]
-	public interface CAGradientLayer {
+	interface CAGradientLayer {
 		[Export ("layer"), New, Static]
 		CALayer Create ();
 
@@ -1293,7 +1293,7 @@ namespace XamCore.CoreAnimation {
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface CAMediaTimingFunction : NSCoding {
+	interface CAMediaTimingFunction : NSCoding {
 		[Export ("functionWithName:")][Static]
 		CAMediaTimingFunction FromName (NSString  name);
 
@@ -1324,7 +1324,7 @@ namespace XamCore.CoreAnimation {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface CAValueFunction : NSCoding {
+	interface CAValueFunction : NSCoding {
 		[Export ("functionWithName:"), Static]
 		CAValueFunction FromName (string name);
 

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -14,7 +14,7 @@ using XamCore.ObjCRuntime;
 namespace XamCore.CoreData
 {
 	[StrongDictionary ("UserInfoKeys")]
-	public interface UserInfo {
+	interface UserInfo {
 		NSError [] DetailedErrors { get; set; }
 		NSManagedObject ObjectForValidationError { get; set; }
 		NSString KeyForValidationError { get; set; }
@@ -71,7 +71,7 @@ namespace XamCore.CoreData
 	[BaseType (typeof (NSPersistentStore))]
 	// Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: NSMappedObjectStore must be initialized with initWithPersistentStoreCoordinator:configurationName:URL:options
 	[DisableDefaultCtor]
-	public interface NSAtomicStore {
+	interface NSAtomicStore {
 
 		[Export ("initWithPersistentStoreCoordinator:configurationName:URL:options:")]
 		IntPtr Constructor (NSPersistentStoreCoordinator coordinator, string configurationName, NSUrl url, [NullAllowed] NSDictionary options);
@@ -127,7 +127,7 @@ namespace XamCore.CoreData
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: NSAtomicStoreCacheNodes must be initialized using initWithObjectID:(NSManagedObjectID *)
 	[DisableDefaultCtor]
-	public interface NSAtomicStoreCacheNode {
+	interface NSAtomicStoreCacheNode {
 
 		[Export ("initWithObjectID:")]
 		IntPtr Constructor (NSManagedObjectID moid);
@@ -151,7 +151,7 @@ namespace XamCore.CoreData
 
 	}
 	[BaseType (typeof (NSPropertyDescription))]
-	public interface NSAttributeDescription {
+	interface NSAttributeDescription {
 
 		[Export ("attributeType")]
 		NSAttributeType AttributeType { get; set; }
@@ -178,7 +178,7 @@ namespace XamCore.CoreData
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSEntityDescription : NSCoding, NSCopying {
+	interface NSEntityDescription : NSCoding, NSCopying {
 
 		[Static, Export ("entityForName:inManagedObjectContext:")]
 		[return: NullAllowed]
@@ -272,7 +272,7 @@ namespace XamCore.CoreData
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSEntityMapping {
+	interface NSEntityMapping {
 
 		[Export ("name")]
 		string Name { get; set; }
@@ -316,7 +316,7 @@ namespace XamCore.CoreData
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSEntityMigrationPolicy {
+	interface NSEntityMigrationPolicy {
 
 		[Export ("beginEntityMapping:manager:error:")]
 		bool BeginEntityMapping (NSEntityMapping mapping, NSMigrationManager manager, out NSError error);
@@ -341,7 +341,7 @@ namespace XamCore.CoreData
 	}
 
 	[BaseType (typeof (NSPropertyDescription))]
-	public interface NSExpressionDescription {
+	interface NSExpressionDescription {
 
 		[NullAllowed, Export ("expression", ArgumentSemantic.Strong)]
 		NSExpression Expression { get; set; }
@@ -351,7 +351,7 @@ namespace XamCore.CoreData
 	}
 
 	[BaseType (typeof (NSPropertyDescription))]
-	public interface NSFetchedPropertyDescription {
+	interface NSFetchedPropertyDescription {
 
 		[NullAllowed] // by default this property is null
 		[Export ("fetchRequest", ArgumentSemantic.Retain)]
@@ -360,7 +360,7 @@ namespace XamCore.CoreData
 
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSExpression))]
-	public interface NSFetchRequestExpression {
+	interface NSFetchRequestExpression {
 
 		[Internal]
 		[DesignatedInitializer]
@@ -380,14 +380,14 @@ namespace XamCore.CoreData
 		bool IsCountOnly { [Bind ("isCountOnlyRequest")] get;}
 	}
 
-	public interface INSFetchRequestResult {}
+	interface INSFetchRequestResult {}
 
 	[Watch (3,0), TV (10,0), iOS (10,0), Mac (10,12)]
 	[Protocol]
-	public interface NSFetchRequestResult {}
+	interface NSFetchRequestResult {}
 
 	[BaseType (typeof (NSPersistentStoreRequest))]
-	public interface NSFetchRequest : NSCoding {
+	interface NSFetchRequest : NSCoding {
 
 		[Export ("entity", ArgumentSemantic.Retain)]
 		[NullAllowed]
@@ -672,7 +672,7 @@ namespace XamCore.CoreData
 	// 'init' issues a warning: CoreData: error: Failed to call designated initializer on NSManagedObject class 'NSManagedObject' 
 	// then crash while disposing the instance
 	[DisableDefaultCtor]
-	public interface NSManagedObject {
+	interface NSManagedObject {
 		[DesignatedInitializer]
 		[Export ("initWithEntity:insertIntoManagedObjectContext:")]
 		IntPtr Constructor (NSEntityDescription entity, [NullAllowed] NSManagedObjectContext context);
@@ -844,14 +844,14 @@ namespace XamCore.CoreData
 
 	[Watch (3,0), TV (10,0), iOS (10,0), Mac (10,12)]
 	[BaseType (typeof(NSObject))]
-	public interface NSQueryGenerationToken : NSCopying
+	interface NSQueryGenerationToken : NSCopying
 	{
 		[Static, Export ("currentQueryGenerationToken", ArgumentSemantic.Strong)]
 		NSQueryGenerationToken CurrentToken { get; }
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSManagedObjectContext : NSCoding
+	interface NSManagedObjectContext : NSCoding
 #if !WATCH && !TVOS
 	, NSLocking
 #endif // !WATCH
@@ -1067,7 +1067,7 @@ namespace XamCore.CoreData
 		void RefreshAllObjects ();
 	}
 
-	public interface NSManagedObjectChangeEventArgs {
+	interface NSManagedObjectChangeEventArgs {
 		[Export ("NSInsertedObjectsKey")]
 		NSSet InsertedObjects { get; }
 
@@ -1091,7 +1091,7 @@ namespace XamCore.CoreData
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -URIRepresentation cannot be sent to an abstract object of class NSManagedObjectID: Create a concrete instance!
 	[DisableDefaultCtor]
-	public interface NSManagedObjectID : NSCopying {
+	interface NSManagedObjectID : NSCopying {
 
 		[Export ("entity", ArgumentSemantic.Strong)]
 		NSEntityDescription Entity { get; }
@@ -1108,7 +1108,7 @@ namespace XamCore.CoreData
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSManagedObjectModel : NSCoding, NSCopying {
+	interface NSManagedObjectModel : NSCoding, NSCopying {
 
 		[Static, Export ("mergedModelFromBundles:")]
 		[return: NullAllowed]
@@ -1210,7 +1210,7 @@ namespace XamCore.CoreData
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSMappingModel {
+	interface NSMappingModel {
 
 		[Static, Export ("mappingModelFromBundles:forSourceModel:destinationModel:")]
 		[return: NullAllowed]
@@ -1242,7 +1242,7 @@ namespace XamCore.CoreData
 	[Since(5,0)][Lion]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface NSMergeConflict {
+	interface NSMergeConflict {
 		[Export ("sourceObject", ArgumentSemantic.Retain)]
 		NSManagedObject SourceObject { get;  }
 
@@ -1330,7 +1330,7 @@ namespace XamCore.CoreData
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSMigrationManager {
+	interface NSMigrationManager {
 
 		[Export ("initWithSourceModel:destinationModel:")]
 		IntPtr Constructor (NSManagedObjectModel sourceModel, NSManagedObjectModel destinationModel);
@@ -1399,7 +1399,7 @@ namespace XamCore.CoreData
 	// make our managed version [Abstract].
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface NSPersistentStore {
+	interface NSPersistentStore {
 
 		[Static, Export ("metadataForPersistentStoreWithURL:error:")]
 		[return: NullAllowed]
@@ -1470,7 +1470,7 @@ namespace XamCore.CoreData
 	[Watch (3,0), TV (10,0), iOS (10,0), Mac (10,12)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
-	public interface NSPersistentStoreDescription : NSCopying
+	interface NSPersistentStoreDescription : NSCopying
 	{
 		[Static]
 		[Export ("persistentStoreDescriptionWithURL:")]
@@ -1520,7 +1520,7 @@ namespace XamCore.CoreData
 	[Watch (3,0), TV (10,0), iOS (10,0), Mac (10,12)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
-	public interface NSPersistentContainer
+	interface NSPersistentContainer
 	{
 		[Static]
 		[Export ("persistentContainerWithName:")]
@@ -1569,7 +1569,7 @@ namespace XamCore.CoreData
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // iOS8 -> Core Data: warning: client failed to call designated initializer on NSPersistentStoreCoordinator
-	public partial interface NSPersistentStoreCoordinator
+	partial interface NSPersistentStoreCoordinator
 #if !WATCH && !TVOS
 		: NSLocking
 #endif // !WATCH
@@ -1849,7 +1849,7 @@ namespace XamCore.CoreData
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSPersistentStoreRequest : NSCopying {
+	interface NSPersistentStoreRequest : NSCopying {
 		[Export ("requestType")]
 		NSPersistentStoreRequestType RequestType { get; }
 
@@ -1875,7 +1875,7 @@ namespace XamCore.CoreData
 
 	[iOS (8,0), Mac (10,10)]
 	[BaseType (typeof (NSObject))]
-	public interface NSPersistentStoreResult {
+	interface NSPersistentStoreResult {
 
 	}
 
@@ -1919,7 +1919,7 @@ namespace XamCore.CoreData
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSPropertyDescription : NSCoding, NSCopying {
+	interface NSPropertyDescription : NSCoding, NSCopying {
 
 		[Export ("entity")]
 		NSEntityDescription Entity { get; }
@@ -1970,7 +1970,7 @@ namespace XamCore.CoreData
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSPropertyMapping {
+	interface NSPropertyMapping {
 
 		[NullAllowed] // by default this property is null
 		[Export ("name")]
@@ -1986,7 +1986,7 @@ namespace XamCore.CoreData
 	}
 
 	[BaseType (typeof (NSPropertyDescription))]
-	public interface NSRelationshipDescription {
+	interface NSRelationshipDescription {
 
 		[NullAllowed] // by default this property is null
 		[Export ("destinationEntity")]

--- a/src/corefoundation.cs
+++ b/src/corefoundation.cs
@@ -11,7 +11,7 @@ using XamCore.ObjCRuntime;
 namespace XamCore.CoreFoundation {
 
 	[Partial]
-	public interface CFAllocator {
+	interface CFAllocator {
 
 		[Internal][Field ("kCFAllocatorDefault")]
 		IntPtr default_ptr { get; }
@@ -30,7 +30,7 @@ namespace XamCore.CoreFoundation {
 	}
 
 	[Partial]
-	public interface CFRunLoop {
+	interface CFRunLoop {
 
 		[Field ("kCFRunLoopDefaultMode")]
 		NSString ModeDefault { get; }
@@ -41,7 +41,7 @@ namespace XamCore.CoreFoundation {
 
 #if !WATCH
 	[Partial]
-	public interface CFNetwork {
+	interface CFNetwork {
 
 		[Field ("kCFErrorDomainCFNetwork", "CFNetwork")]
 		NSString ErrorDomain { get; }

--- a/src/coregraphics.cs
+++ b/src/coregraphics.cs
@@ -76,7 +76,7 @@ namespace XamCore.CoreGraphics {
 
 	[Static]
 	[iOS (9,0)]
-	public interface CGColorSpaceNames {
+	interface CGColorSpaceNames {
 		[Field ("kCGColorSpaceGenericGray")]
 		NSString GenericGray { get; }
 

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -47,7 +47,7 @@ namespace XamCore.CoreImage {
 	[BaseType (typeof (NSObject))]
 	[Since (5,0)]
 	[DisableDefaultCtor]
-	public interface CIColor : NSSecureCoding, NSCopying {
+	interface CIColor : NSSecureCoding, NSCopying {
 		[Static]
 		[Export ("colorWithCGColor:")]
 		CIColor FromCGColor (CGColor c);
@@ -200,7 +200,7 @@ namespace XamCore.CoreImage {
 	[BaseType (typeof (NSObject))]
 	[Since (5,0)]
 	[DisableDefaultCtor]
-	public interface CIContext {
+	interface CIContext {
 		// When we bind OpenGL add these:
 		//[Export ("contextWithCGLContext:pixelFormat:colorSpace:options:")]
 		//CIContext ContextWithCGLContextpixelFormatcolorSpaceoptions (CGLContextObj ctx, CGLPixelFormatObj pf, CGColorSpaceRef cs, NSDictionary dict, );
@@ -407,7 +407,7 @@ namespace XamCore.CoreImage {
 	[BaseType (typeof (NSObject))]
 	[Since (5,0)]
 	[DisableDefaultCtor] //  In iOS8 they expose custom filters, we expose a protected one in CIFilter.cs
-	public interface CIFilter : NSSecureCoding, NSCopying {
+	interface CIFilter : NSSecureCoding, NSCopying {
 		[Export ("inputKeys")]
 		string [] InputKeys { get; }
 
@@ -662,7 +662,7 @@ namespace XamCore.CoreImage {
 
 	[TV (10,0)]
 	[StrongDictionary ("CIRawFilterKeys")]
-	public interface CIRawFilterOptions {
+	interface CIRawFilterOptions {
 
 		[iOS (10,0)]
 		bool AllowDraftMode { get; set; }
@@ -749,14 +749,14 @@ namespace XamCore.CoreImage {
 
 	[Since (5,0)]
 	[Static]
-	public interface CIFilterOutputKey {
+	interface CIFilterOutputKey {
 		[Field ("kCIOutputImageKey", "+CoreImage")]
 		NSString Image  { get; }
 	}
 	
 	[Since (5,0)]
 	[Static]
-	public interface CIFilterInputKey {
+	interface CIFilterInputKey {
 		[Field ("kCIInputBackgroundImageKey", "+CoreImage")]
 		NSString BackgroundImage  { get; }
 
@@ -862,7 +862,7 @@ namespace XamCore.CoreImage {
 		
 	[Since (5,0)]
 	[Static]
-	public interface CIFilterAttributes {
+	interface CIFilterAttributes {
 		[Field ("kCIAttributeFilterName", "+CoreImage")]
 		NSString FilterName  { get; }
 
@@ -978,7 +978,7 @@ namespace XamCore.CoreImage {
 
 	[Since (5,0)]
 	[Static]
-	public interface CIFilterCategory {
+	interface CIFilterCategory {
 		[Field ("kCICategoryDistortionEffect", "+CoreImage")]
 		NSString DistortionEffect  { get; }
 
@@ -1044,11 +1044,11 @@ namespace XamCore.CoreImage {
 		NSString FilterGenerator  { get; }
 	}
 
-	public interface ICIFilterConstructor {}
+	interface ICIFilterConstructor {}
 
 	[iOS (9,0)]
 	[Protocol]
-	public interface CIFilterConstructor
+	interface CIFilterConstructor
 	{
 		// @required -(CIFilter * __nullable)filterWithName:(NSString * __nonnull)name;
 		[Abstract]
@@ -1059,7 +1059,7 @@ namespace XamCore.CoreImage {
 	
 	[Static]
 	[iOS (9,0)]
-	public interface CIUIParameterSet {
+	interface CIUIParameterSet {
 		[Field ("kCIUISetBasic", "+CoreImage")]
 		NSString Basic  { get; }
 
@@ -1075,7 +1075,7 @@ namespace XamCore.CoreImage {
 
 #if MONOMAC
 	[Static]
-	public interface CIFilterApply {
+	interface CIFilterApply {
 		[Field ("kCIApplyOptionExtent", "+CoreImage")]
 		NSString OptionExtent  { get; }
 
@@ -1149,7 +1149,7 @@ namespace XamCore.CoreImage {
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	[iOS(9,0)]
-	public interface CIFilterShape : NSCopying {
+	interface CIFilterShape : NSCopying {
 		[Static]
 		[Export ("shapeWithRect:")]
 		CIFilterShape FromRect (CGRect rect);
@@ -1182,7 +1182,7 @@ namespace XamCore.CoreImage {
 	[BaseType (typeof (NSObject))]
 	[Since (5,0)]
 	[DisableDefaultCtor]
-	public interface CIImage : NSSecureCoding, NSCopying {
+	interface CIImage : NSSecureCoding, NSCopying {
 		[Static]
 		[Export ("imageWithCGImage:")]
 		CIImage FromCGImage (CGImage image);
@@ -1663,7 +1663,7 @@ namespace XamCore.CoreImage {
 		CGImage CGImage { get; }
 	}
 
-	public interface ICIImageProcessorInput {}
+	interface ICIImageProcessorInput {}
 
 	[iOS (10,0)][Mac (10,12)]
 	[Protocol]
@@ -1695,7 +1695,7 @@ namespace XamCore.CoreImage {
 #endif
 	}
 
-	public interface ICIImageProcessorOutput {}
+	interface ICIImageProcessorOutput {}
 
 	[iOS (10,0)][Mac (10,12)]
 	[Protocol]
@@ -1749,7 +1749,7 @@ namespace XamCore.CoreImage {
 		NSString UserInfoKey { get; } 
 	}
 	
-	public interface ICIImageProvider {}
+	interface ICIImageProvider {}
 
 	// Informal protocol
 	[Protocol (IsInformal = true)]
@@ -1759,12 +1759,12 @@ namespace XamCore.CoreImage {
 		unsafe void ProvideImageData (IntPtr data, nuint rowbytes, nuint x, nuint y, nuint width, nuint height, [NullAllowed] NSObject info);
 	}
 	
-	public delegate CGRect CIKernelRoiCallback (int /* int, not NSInteger */ index, CGRect rect);
+	delegate CGRect CIKernelRoiCallback (int /* int, not NSInteger */ index, CGRect rect);
 
 	[iOS (8,0), Mac (10,10)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // avoid crashes
-	public interface CIKernel {
+	interface CIKernel {
 #if !XAMCORE_2_0
 		[Obsolete ("Use FromProgramSingle")] // better API
 		[Static, Export ("kernelWithString:")]
@@ -1820,7 +1820,7 @@ namespace XamCore.CoreImage {
 
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
-	public interface CIImageAccumulator {
+	interface CIImageAccumulator {
 		[Static]
 		[Export ("imageAccumulatorWithExtent:format:")]
 #if !MONOMAC
@@ -1862,7 +1862,7 @@ namespace XamCore.CoreImage {
 
 #if MONOMAC
 	[BaseType (typeof (NSObject))]
-	public interface CIPlugIn {
+	interface CIPlugIn {
 		[Static]
 		[Export ("loadAllPlugIns")]
 		void LoadAllPlugIns ();
@@ -1880,7 +1880,7 @@ namespace XamCore.CoreImage {
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface CISampler : NSCopying {
+	interface CISampler : NSCopying {
 		[Static, Export ("samplerWithImage:")]
 		CISampler FromImage (CIImage sourceImage);
 
@@ -1930,7 +1930,7 @@ namespace XamCore.CoreImage {
 	[BaseType (typeof (NSObject))]
 	[Since (5,0)]
 	[DisableDefaultCtor]
-	public interface CIVector : NSSecureCoding, NSCopying {
+	interface CIVector : NSSecureCoding, NSCopying {
 		[Static, Internal, Export ("vectorWithValues:count:")]
 		CIVector _FromValues (IntPtr values, nint count);
 
@@ -2231,7 +2231,7 @@ namespace XamCore.CoreImage {
 	[iOS (8,0)]
 	[Mac (10,12)]
 	[BaseType (typeof (CIFeature))]
-	public partial interface CIQRCodeFeature {
+	partial interface CIQRCodeFeature {
 
 		[Export ("bounds", ArgumentSemantic.Assign)]
 		CGRect Bounds { get; }

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -501,7 +501,7 @@ namespace XamCore.CoreLocation {
 	[Mac (10,7)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // will crash, see CoreLocation.cs for compatibility stubs
-	public partial interface CLRegion : NSSecureCoding, NSCopying {
+	partial interface CLRegion : NSSecureCoding, NSCopying {
 		[NoTV]
 		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use CLCircularRegion instead")]
 		[Export ("center")]
@@ -600,7 +600,7 @@ namespace XamCore.CoreLocation {
 #if MONOMAC
 	[DisableDefaultCtor]
 #endif
-	public partial interface CLCircularRegion {
+	partial interface CLCircularRegion {
 
 		[Export ("initWithCenter:radius:identifier:")]
 		IntPtr Constructor (CLLocationCoordinate2D center, double radius, string identifier);
@@ -619,7 +619,7 @@ namespace XamCore.CoreLocation {
 	[NoWatch][NoMac][NoTV]
 	[Since (7,0), BaseType (typeof (CLRegion))]
 	[DisableDefaultCtor] // nil-Handle on iOS8 if 'init' is used
-	public partial interface CLBeaconRegion {
+	partial interface CLBeaconRegion {
 
 		[Export ("initWithProximityUUID:identifier:")]
 		IntPtr Constructor (NSUuid proximityUuid, string identifier);
@@ -648,7 +648,7 @@ namespace XamCore.CoreLocation {
 
 	[NoWatch][NoMac][NoTV]
 	[Since (7,0), BaseType (typeof (NSObject))]
-	public partial interface CLBeacon : NSCopying, NSSecureCoding {
+	partial interface CLBeacon : NSCopying, NSSecureCoding {
 
 		[Export ("proximityUUID", ArgumentSemantic.Copy)]
 		NSUuid ProximityUuid { get; }

--- a/src/coremotion.cs
+++ b/src/coremotion.cs
@@ -217,7 +217,7 @@ namespace XamCore.CoreMotion {
 	[BaseType (typeof (CMLogItem))]
 	[Since (5,0)]
 	[DisableDefaultCtor] // will crash, see Extra.cs for compatibility stubs
-	public interface CMMagnetometerData : NSSecureCoding {
+	interface CMMagnetometerData : NSSecureCoding {
 		[Export ("magneticField")]
 		CMMagneticField MagneticField { get; }
 	}

--- a/src/corespotlight.cs
+++ b/src/corespotlight.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // CoreSpotlight bindings
 //
 // Authors:
@@ -17,14 +17,14 @@ namespace XamCore.CoreSpotlight {
 	[NoTV] // CS_TVOS_UNAVAILABLE
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
-	public interface CSIndexExtensionRequestHandler : NSExtensionRequestHandling, CSSearchableIndexDelegate {
+	interface CSIndexExtensionRequestHandler : NSExtensionRequestHandling, CSSearchableIndexDelegate {
 
 	}
 
 	[NoTV] // CS_TVOS_UNAVAILABLE
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
-	public interface CSPerson : NSSecureCoding, NSCopying {
+	interface CSPerson : NSSecureCoding, NSCopying {
 
 		[Export ("initWithDisplayName:handles:handleIdentifier:")]
 		IntPtr Constructor ([NullAllowed] string displayName, string [] handles, NSString handleIdentifier);
@@ -47,7 +47,7 @@ namespace XamCore.CoreSpotlight {
 	[NoTV] // CS_TVOS_UNAVAILABLE
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
-	public interface CSSearchableIndex {
+	interface CSSearchableIndex {
 
 		[Export ("indexDelegate", ArgumentSemantic.Weak)][NullAllowed]
 		ICSSearchableIndexDelegate IndexDelegate { get; set; }
@@ -81,13 +81,13 @@ namespace XamCore.CoreSpotlight {
 		void DeleteAll ([NullAllowed] Action<NSError> completionHandler);
 	}
 
-	public delegate void CSSearchableIndexFetchHandler (NSData clientState, NSError error);
+	delegate void CSSearchableIndexFetchHandler (NSData clientState, NSError error);
 
 	[NoTV] // CS_TVOS_UNAVAILABLE
 	[iOS (9,0)]
 	[Category]
 	[BaseType (typeof (CSSearchableIndex))]
-	public interface CSSearchableIndex_CSOptionalBatchingExtension {
+	interface CSSearchableIndex_CSOptionalBatchingExtension {
 
 		[Export ("beginIndexBatch")]
 		void BeginIndexBatch ();
@@ -99,13 +99,13 @@ namespace XamCore.CoreSpotlight {
 		void FetchLastClientState (CSSearchableIndexFetchHandler completionHandler);
 	}
 
-	public interface ICSSearchableIndexDelegate {}
+	interface ICSSearchableIndexDelegate {}
 
 	[NoTV] // CS_TVOS_UNAVAILABLE
 	[iOS (9,0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public interface CSSearchableIndexDelegate {
+	interface CSSearchableIndexDelegate {
 
 		[Abstract]
 		[Export ("searchableIndex:reindexAllSearchableItemsWithAcknowledgementHandler:")]
@@ -125,7 +125,7 @@ namespace XamCore.CoreSpotlight {
 	[NoTV] // CS_TVOS_UNAVAILABLE
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
-	public interface CSSearchableItem : NSSecureCoding, NSCopying {
+	interface CSSearchableItem : NSSecureCoding, NSCopying {
 
 		[Field ("CSSearchableItemActionType")]
 		NSString ActionType { get; }
@@ -163,7 +163,7 @@ namespace XamCore.CoreSpotlight {
 	[iOS (9,0)]
 	[BaseType (typeof (NSString))]
 	// hack: it seems that generator.cs can't track NSCoding correctly ? maybe because the type is named NSString2 at that time
-	public interface CSLocalizedString : NSCoding {
+	interface CSLocalizedString : NSCoding {
 
 		[Export ("initWithLocalizedStrings:")]
 		IntPtr Constructor (NSDictionary localizedStrings);
@@ -176,7 +176,7 @@ namespace XamCore.CoreSpotlight {
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: You must call -[CSCustomAttributeKey initWithKeyName...]
-	public interface CSCustomAttributeKey : NSCopying, NSSecureCoding {
+	interface CSCustomAttributeKey : NSCopying, NSSecureCoding {
 
 		[Export ("initWithKeyName:")]
 		IntPtr Constructor (string keyName);
@@ -204,7 +204,7 @@ namespace XamCore.CoreSpotlight {
 	[iOS (9,0)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
 	[Static]
-	public interface CSMailboxKey {
+	interface CSMailboxKey {
 
 		[Field ("CSMailboxInbox")]
 		NSString Inbox { get; }
@@ -228,12 +228,12 @@ namespace XamCore.CoreSpotlight {
 	[NoTV]
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
-	public interface CSSearchableItemAttributeSet : NSCopying, NSSecureCoding {
+	interface CSSearchableItemAttributeSet : NSCopying, NSSecureCoding {
 
 		[Export ("initWithItemContentType:")]
 		IntPtr Constructor (string itemContentType);
 
-		// FIXME: Should we keep all the following Categories inline? or should we make them actual [Category] public interfaces
+		// FIXME: Should we keep all the following Categories inline? or should we make them actual [Category] interfaces
 		// There are no methods on any of the following categories, just properties
 
 		// CSSearchableItemAttributeSet_Documents.h

--- a/src/coretelephony.cs
+++ b/src/coretelephony.cs
@@ -129,17 +129,17 @@ namespace XamCore.CoreTelephony {
 
 	[BaseType (typeof (NSObject))]
 	[Since (7,0)]
-	public partial interface CTSubscriber {
+	partial interface CTSubscriber {
 		[Since (7,0), Export ("carrierToken")]
 		NSData CarrierToken { get; }
 	}
 
 #if !XAMCORE_2_0
-	public delegate void SimAuthenticationCallback (NSDictionary dictionary);
+	delegate void SimAuthenticationCallback (NSDictionary dictionary);
 #endif
 
 	[Since (6,0), BaseType (typeof (NSObject))]
-	public partial interface CTSubscriberInfo {
+	partial interface CTSubscriberInfo {
 		[Static]
 		[Export ("subscriber")]
 		CTSubscriber Subscriber { get; }

--- a/src/corevideo.cs
+++ b/src/corevideo.cs
@@ -11,7 +11,7 @@ using XamCore.ObjCRuntime;
 namespace XamCore.CoreVideo {
 
 	[Partial]
-	public interface CVPixelBufferPoolAllocationSettings {
+	interface CVPixelBufferPoolAllocationSettings {
 
 		[Internal][Field ("kCVPixelBufferPoolAllocationThresholdKey")]
 		NSString ThresholdKey { get; }
@@ -19,7 +19,7 @@ namespace XamCore.CoreVideo {
 
 #if XAMCORE_2_0
 	[Partial]
-	public interface CVBuffer {
+	interface CVBuffer {
 
 		[Field ("kCVBufferMovieTimeKey")]
 		NSString MovieTimeKey { get; }
@@ -38,7 +38,7 @@ namespace XamCore.CoreVideo {
 	}
 
 	[Partial]
-	public interface CVImageBuffer : CVBuffer {
+	interface CVImageBuffer : CVBuffer {
 
 		[Field ("kCVImageBufferCGColorSpaceKey")]
 		NSString CGColorSpaceKey  { get; }
@@ -222,7 +222,7 @@ namespace XamCore.CoreVideo {
 	}
 
 	[Partial]
-	public interface CVPixelBuffer {
+	interface CVPixelBuffer {
 
 		[Field ("kCVPixelBufferPixelFormatTypeKey")]
 		NSString PixelFormatTypeKey{ get; }
@@ -289,9 +289,9 @@ namespace XamCore.CoreVideo {
 
 	[Partial]
 #if XAMCORE_3_0
-	public interface CVPixelBufferPool {
+	interface CVPixelBufferPool {
 #else
-	public interface CVPixelBufferPool : CVImageBuffer {
+	interface CVPixelBufferPool : CVImageBuffer {
 #endif
 		[Field ("kCVPixelBufferPoolMinimumBufferCountKey")]
 		NSString MinimumBufferCountKey { get; }
@@ -302,7 +302,7 @@ namespace XamCore.CoreVideo {
 
 #if !MONOMAC
 	[Partial]
-	public interface CVMetalTextureCache {
+	interface CVMetalTextureCache {
 		[Internal]
 		[Field ("kCVMetalTextureCacheMaximumTextureAgeKey")]
 		IntPtr MaxTextureAge { get; }
@@ -310,7 +310,7 @@ namespace XamCore.CoreVideo {
 
 	// CVOpenGLESTextureCache is bound (manually) in OpenTK[-1.0].dll.
 	// [Partial]
-	// public interface CVOpenGLESTextureCache {
+	// interface CVOpenGLESTextureCache {
 	// 	[Internal]
 	// 	[Field ("kCVOpenGLESTextureCacheMaximumTextureAgeKey")]
 	// 	IntPtr MaxTextureAge { get; }

--- a/src/externalaccessory.cs
+++ b/src/externalaccessory.cs
@@ -158,7 +158,7 @@ namespace XamCore.ExternalAccessory {
 	}
 
 
-	public interface IEAWiFiUnconfiguredAccessoryBrowserDelegate {}
+	interface IEAWiFiUnconfiguredAccessoryBrowserDelegate {}
 	
 	// This class is exposed for tvOS in the headers, but there's no available initializer (so it can't be constructed)
 	// The API is also clearly unusable (you can list the unconfigured accessories, but you can't search for them first...)

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -93,6 +93,9 @@ namespace XamCore.Foundation
 	delegate void NSItemProviderLoadHandler ([BlockCallback] NSItemProviderCompletionHandler completionHandler, Class expectedValueClass, NSDictionary options);
 	delegate void EnumerateDatesCallback (NSDate date, bool exactMatch, ref bool stop);
 	delegate void EnumerateIndexSetCallback (nuint idx, ref bool stop);
+#if MONOMAC
+	delegate void CloudKitRegistrationPreparationHandler (CKShare share, CKContainer container, NSError error);
+#endif
 
 	interface NSArray<TValue> : NSArray {}
 
@@ -8718,16 +8721,15 @@ namespace XamCore.Foundation
 		[Mac (10,10)]
 		[Export ("preferredPresentationSize")]
 		CGSize PreferredPresentationSize { get; }
+
+		[Mac (10,12)][Async]
+		[Export ("registerCloudKitShareWithPreparationHandler:")]
+		void RegisterCloudKitShare (Action<CloudKitRegistrationPreparationHandler> preparationHandler);
+
+		[Mac (10,12)]
+		[Export ("registerCloudKitShare:container:")]
+		void RegisterCloudKitShare (CKShare share, CKContainer container);
 #endif
-
-		// TODO - Needs CloudKit bound
-		//[Mac (10,12)][Async]
-		//[Export ("registerCloudKitShareWithPreparationHandler:")]
-		//void RegisterCloudKitShare (Action<Action<CKShare, CKContainer, NSError>> preparationHandler);
-
-		//[Mac (10,12)]
-		//[Export ("registerCloudKitShare:container:")]
-		//void RegisterCloudKitShare (CKShare share, CKContainer container);
 	}
 
 #if XAMCORE_2_0

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -74,30 +74,30 @@ namespace XamCore.Foundation {
 #else
 namespace XamCore.UIKit {
 #endif
-	public delegate void NSFilePresenterReacquirer ([BlockCallback] Action reacquirer);
+	delegate void NSFilePresenterReacquirer ([BlockCallback] Action reacquirer);
 }
 
 namespace XamCore.Foundation
 {
 #if XAMCORE_2_0
-	public delegate NSComparisonResult NSComparator (NSObject obj1, NSObject obj2);
+	delegate NSComparisonResult NSComparator (NSObject obj1, NSObject obj2);
 #else
-	public delegate int /* !XAMCORE_2_0 */ NSComparator (NSObject obj1, NSObject obj2);
+	delegate int /* !XAMCORE_2_0 */ NSComparator (NSObject obj1, NSObject obj2);
 #endif
-	public delegate void NSAttributedRangeCallback (NSDictionary attrs, NSRange range, ref bool stop);
-	public delegate void NSAttributedStringCallback (NSObject value, NSRange range, ref bool stop);
+	delegate void NSAttributedRangeCallback (NSDictionary attrs, NSRange range, ref bool stop);
+	delegate void NSAttributedStringCallback (NSObject value, NSRange range, ref bool stop);
 
-	public delegate bool NSEnumerateErrorHandler (NSUrl url, NSError error);
-	public delegate void NSMetadataQueryEnumerationCallback (NSObject result, nuint idx, ref bool stop);
-	public delegate void NSItemProviderCompletionHandler (NSObject itemBeingLoaded, NSError error);
-	public delegate void NSItemProviderLoadHandler ([BlockCallback] NSItemProviderCompletionHandler completionHandler, Class expectedValueClass, NSDictionary options);
-	public delegate void EnumerateDatesCallback (NSDate date, bool exactMatch, ref bool stop);
-	public delegate void EnumerateIndexSetCallback (nuint idx, ref bool stop);
+	delegate bool NSEnumerateErrorHandler (NSUrl url, NSError error);
+	delegate void NSMetadataQueryEnumerationCallback (NSObject result, nuint idx, ref bool stop);
+	delegate void NSItemProviderCompletionHandler (NSObject itemBeingLoaded, NSError error);
+	delegate void NSItemProviderLoadHandler ([BlockCallback] NSItemProviderCompletionHandler completionHandler, Class expectedValueClass, NSDictionary options);
+	delegate void EnumerateDatesCallback (NSDate date, bool exactMatch, ref bool stop);
+	delegate void EnumerateIndexSetCallback (nuint idx, ref bool stop);
 
-	public interface NSArray<TValue> : NSArray {}
+	interface NSArray<TValue> : NSArray {}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSArray : NSSecureCoding, NSMutableCopying, INSFastEnumeration {
+	interface NSArray : NSSecureCoding, NSMutableCopying, INSFastEnumeration {
 		[Export ("count")]
 		nuint Count { get; }
 
@@ -155,12 +155,12 @@ namespace XamCore.Foundation
 	}
 
 #if MONOMAC
-	public interface NSAttributedStringDocumentAttributes { }
+	interface NSAttributedStringDocumentAttributes { }
 #endif
 
 	[Since (3,2)]
 	[BaseType (typeof (NSObject))]
-	public partial interface NSAttributedString : NSCoding, NSMutableCopying, NSSecureCoding
+	partial interface NSAttributedString : NSCoding, NSMutableCopying, NSSecureCoding
 	#if MONOMAC
 		, NSPasteboardReading, NSPasteboardWriting
 	#endif
@@ -497,7 +497,7 @@ namespace XamCore.Foundation
 		   Delegates=new string [] { "WeakDelegate" },
 		   Events=new Type [] { typeof (NSCacheDelegate)} )]
 	[Since (4,0)]
-	public interface NSCache {
+	interface NSCache {
 		[Export ("objectForKey:")]
 		NSObject ObjectForKey (NSObject key);
 
@@ -537,7 +537,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSCacheDelegate {
+	interface NSCacheDelegate {
 		[Export ("cache:willEvictObject:"), EventArgs ("NSObject")]
 		void WillEvictObject (NSCache cache, NSObject obj);
 	}
@@ -545,7 +545,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject), Name="NSCachedURLResponse")]
 	// instance created with 'init' will crash when Dispose is called
 	[DisableDefaultCtor]
-	public interface NSCachedUrlResponse : NSCoding, NSSecureCoding, NSCopying {
+	interface NSCachedUrlResponse : NSCoding, NSSecureCoding, NSCopying {
 		[Export ("initWithResponse:data:userInfo:storagePolicy:")]
 		IntPtr Constructor (NSUrlResponse response, NSData data, [NullAllowed] NSDictionary userInfo, NSUrlCacheStoragePolicy storagePolicy);
 
@@ -568,7 +568,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject))]
 	// 'init' returns NIL - `init` now marked as NS_UNAVAILABLE
 	[DisableDefaultCtor]
-	public interface NSCalendar : NSSecureCoding, NSCopying {
+	interface NSCalendar : NSSecureCoding, NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithCalendarIdentifier:")]
 		IntPtr Constructor (NSString identifier);
@@ -955,7 +955,7 @@ namespace XamCore.Foundation
 
 	[Since (3,2)]
 	[BaseType (typeof (NSObject))]
-	public interface NSCharacterSet : NSSecureCoding, NSMutableCopying {
+	interface NSCharacterSet : NSSecureCoding, NSMutableCopying {
 		[Static, Export ("alphanumericCharacterSet", ArgumentSemantic.Copy)]
 		NSCharacterSet Alphanumerics {get;}
 
@@ -1067,7 +1067,7 @@ namespace XamCore.Foundation
 	// Already exists in MonoMac: from from foundation-desktop?
 	
 	[BaseType (typeof (NSCharacterSet))]
-	public interface NSMutableCharacterSet {
+	interface NSMutableCharacterSet {
 		[Export ("addCharactersInRange:")]
 		void AddCharacters (NSRange aRange);
 		
@@ -1168,7 +1168,7 @@ namespace XamCore.Foundation
 #endif
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSCoder {
+	interface NSCoder {
 
 		//
 		// Encoding and decoding
@@ -1287,7 +1287,7 @@ namespace XamCore.Foundation
 	}
 	
 	[BaseType (typeof (NSPredicate))]
-	public interface NSComparisonPredicate : NSSecureCoding {
+	interface NSComparisonPredicate : NSSecureCoding {
 		[Static, Export ("predicateWithLeftExpression:rightExpression:modifier:type:options:")]
 		NSComparisonPredicate Create (NSExpression leftExpression, NSExpression rightExpression, NSComparisonPredicateModifier comparisonModifier, NSPredicateOperatorType operatorType, NSComparisonPredicateOptions comparisonOptions);
 
@@ -1323,7 +1323,7 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSPredicate))]
 	[DisableDefaultCtor] // An uncaught exception was raised: Can't have a NOT predicate with no subpredicate.
-	public interface NSCompoundPredicate : NSCoding {
+	interface NSCompoundPredicate : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithType:subpredicates:")]
 		IntPtr Constructor (NSCompoundPredicateType type, NSPredicate[] subpredicates);
@@ -1348,10 +1348,10 @@ namespace XamCore.Foundation
 
 	}
 
-	public delegate void NSDataByteRangeEnumerator (IntPtr bytes, NSRange range, ref bool stop);
+	delegate void NSDataByteRangeEnumerator (IntPtr bytes, NSRange range, ref bool stop);
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSData : NSSecureCoding, NSMutableCopying {
+	interface NSData : NSSecureCoding, NSMutableCopying {
 		[Export ("dataWithContentsOfURL:")]
 		[Static]
 		NSData FromUrl (NSUrl url);
@@ -1443,7 +1443,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSRegularExpression))]
-	public interface NSDataDetector : NSCopying, NSCoding {
+	interface NSDataDetector : NSCopying, NSCoding {
 		// Invalid parent ctor: -[NSDataDetector initWithPattern:options:error:]: Not valid for NSDataDetector
 //		[Export ("initWithPattern:options:error:")]
 //		IntPtr Constructor (NSString pattern, NSRegularExpressionOptions options, out NSError error);
@@ -1456,7 +1456,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSDateComponents : NSSecureCoding, NSCopying, INSCopying, INSSecureCoding, INativeObject {
+	interface NSDateComponents : NSSecureCoding, NSCopying, INSCopying, INSSecureCoding, INativeObject {
 		[Since (4,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("timeZone", ArgumentSemantic.Copy)]
@@ -1584,7 +1584,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSFormatter))]
-	public interface NSDateFormatter {
+	interface NSDateFormatter {
 		[Export ("stringFromDate:")]
 		string ToString (NSDate date);
 
@@ -1820,10 +1820,10 @@ namespace XamCore.Foundation
 	}
 
 #if !XAMCORE_2_0
-	public delegate void NSFileHandleUpdateHandler (NSFileHandle handle);
+	delegate void NSFileHandleUpdateHandler (NSFileHandle handle);
 #endif
 
-	public interface NSFileHandleReadEventArgs {
+	interface NSFileHandleReadEventArgs {
 		[Export ("NSFileHandleNotificationDataItem")]
 		NSData AvailableData { get; }
 
@@ -1831,7 +1831,7 @@ namespace XamCore.Foundation
 		nint UnixErrorCode { get; }
 	}
 
-	public interface NSFileHandleConnectionAcceptedEventArgs {
+	interface NSFileHandleConnectionAcceptedEventArgs {
 		[Export ("NSFileHandleNotificationFileHandleItem")]
 		NSFileHandle NearSocketConnection { get; }
 		
@@ -1841,7 +1841,7 @@ namespace XamCore.Foundation
 	
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // return invalid handle
-	public interface NSFileHandle : NSSecureCoding {
+	interface NSFileHandle : NSSecureCoding {
 		[Export ("availableData")]
 		NSData AvailableData ();
 		
@@ -2080,7 +2080,7 @@ namespace XamCore.Foundation
 	
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSPipe {
+	interface NSPipe {
 		
 		[Export ("fileHandleForReading")]
 		NSFileHandle ReadHandle { get; }
@@ -2094,7 +2094,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSFormatter : NSCoding, NSCopying {
+	interface NSFormatter : NSCoding, NSCopying {
 		[Export ("stringForObjectValue:")]
 		string StringFor ([NullAllowed] NSObject value);
 
@@ -2134,7 +2134,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSCoding {
+	interface NSCoding {
 #if XAMCORE_2_0
 		// [Abstract]
 		[Export ("initWithCoder:")]
@@ -2147,14 +2147,14 @@ namespace XamCore.Foundation
 	}
 
 	[Protocol]
-	public interface NSSecureCoding : NSCoding {
+	interface NSSecureCoding : NSCoding {
 		// note: +supportsSecureCoding being static it is not a good "generated" binding candidate
 	}
 
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSCopying {
+	interface NSCopying {
 #if XAMCORE_2_0
 		[Abstract]
 #endif
@@ -2165,7 +2165,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSMutableCopying : NSCopying {
+	interface NSMutableCopying : NSCopying {
 #if XAMCORE_2_0
 		[Abstract]
 #endif
@@ -2174,12 +2174,12 @@ namespace XamCore.Foundation
 		NSObject MutableCopy ([NullAllowed] NSZone zone);
 	}
 
-	public interface INSMutableCopying {}
+	interface INSMutableCopying {}
 
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSKeyedArchiverDelegate {
+	interface NSKeyedArchiverDelegate {
 		[Export ("archiver:didEncodeObject:"), EventArgs ("NSObject")]
 		void EncodedObject (NSKeyedArchiver archiver, NSObject obj);
 		
@@ -2199,7 +2199,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSKeyedUnarchiverDelegate {
+	interface NSKeyedUnarchiverDelegate {
 		[Export ("unarchiver:didDecodeObject:"), DelegateName ("NSDecoderCallback"), DefaultValue (null)]
 		NSObject DecodedObject (NSKeyedUnarchiver unarchiver, NSObject obj);
 		
@@ -2221,7 +2221,7 @@ namespace XamCore.Foundation
 		   Events=new Type [] { typeof (NSKeyedArchiverDelegate) })]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[NSKeyedArchiver init]: cannot use -init for initialization
 	[DisableDefaultCtor]
-	public interface NSKeyedArchiver {
+	interface NSKeyedArchiver {
 
 		// hack so we can decorate the default .ctor with availability attributes
 		[iOS (10,0)][TV (10,0)][Watch (3,0)][Mac (10,12)]
@@ -2280,7 +2280,7 @@ namespace XamCore.Foundation
 		   Events=new Type [] { typeof (NSKeyedUnarchiverDelegate) })]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[NSKeyedUnarchiver init]: cannot use -init for initialization
 	[DisableDefaultCtor]
-	public interface NSKeyedUnarchiver {
+	interface NSKeyedUnarchiver {
 		[Export ("initForReadingWithData:")]
 		[MarshalNativeExceptions]
 		IntPtr Constructor (NSData data);
@@ -2326,7 +2326,7 @@ namespace XamCore.Foundation
 
 	[Since (5,0)]
 	[BaseType (typeof (NSObject), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSMetadataQueryDelegate)})]
-	public interface NSMetadataQuery {
+	interface NSMetadataQuery {
 		[Export ("startQuery")]
 		bool StartQuery ();
 
@@ -2585,7 +2585,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSMetadataQueryDelegate {
+	interface NSMetadataQueryDelegate {
 		[Export ("metadataQuery:replacementObjectForResultObject:"), DelegateName ("NSMetadataQueryObject"), DefaultValue(null)]
 		NSObject ReplacementObjectForResultObject (NSMetadataQuery query, NSMetadataItem result);
 
@@ -2595,7 +2595,7 @@ namespace XamCore.Foundation
 
 	[Since (5,0)]
 	[BaseType (typeof (NSObject))]
-	public interface NSMetadataItem {
+	interface NSMetadataItem {
 		[Export ("valueForAttribute:")]
 		NSObject ValueForAttribute (string key);
 
@@ -2624,7 +2624,7 @@ namespace XamCore.Foundation
 
 	[Since (5,0)]
 	[BaseType (typeof (NSObject))]
-	public interface NSMetadataQueryAttributeValueTuple {
+	interface NSMetadataQueryAttributeValueTuple {
 		[Export ("attribute")]
 		string Attribute { get; }
 
@@ -2637,7 +2637,7 @@ namespace XamCore.Foundation
 
 	[Since (5,0)]
 	[BaseType (typeof (NSObject))]
-	public interface NSMetadataQueryResultGroup {
+	interface NSMetadataQueryResultGroup {
 		[Export ("attribute")]
 		string Attribute { get; }
 
@@ -2662,7 +2662,7 @@ namespace XamCore.Foundation
 	// Apple has now surfaced it on a few methods.   So we need to take the Obsolete
 	// out, and we will have to fully support it.
 	[BaseType (typeof (NSArray))]
-	public interface NSMutableArray {
+	interface NSMutableArray {
 		[DesignatedInitializer]
 		[Export ("initWithCapacity:")]
 		IntPtr Constructor (nuint capacity);
@@ -2724,11 +2724,11 @@ namespace XamCore.Foundation
 		
 	}
 	
-	public interface NSMutableArray<TValue> : NSMutableArray {}
+	interface NSMutableArray<TValue> : NSMutableArray {}
 
 	[Since (3,2)]
 	[BaseType (typeof (NSAttributedString))]
-	public interface NSMutableAttributedString {
+	interface NSMutableAttributedString {
 		[Export ("initWithString:")]
 		IntPtr Constructor (string str);
 		
@@ -2820,7 +2820,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSData))]
-	public interface NSMutableData {
+	interface NSMutableData {
 		[Static, Export ("dataWithCapacity:")] [Autorelease]
 		[PreSnippet ("if (capacity < 0 || capacity > nint.MaxValue) throw new ArgumentOutOfRangeException ();")]
 		NSMutableData FromCapacity (nint capacity);
@@ -2864,7 +2864,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSDate : NSSecureCoding, NSCopying {
+	interface NSDate : NSSecureCoding, NSCopying {
 		[Export ("timeIntervalSinceReferenceDate")]
 		double SecondsSinceReferenceDate { get; }
 
@@ -2911,7 +2911,7 @@ namespace XamCore.Foundation
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSDictionary : NSSecureCoding, NSMutableCopying {
+	interface NSDictionary : NSSecureCoding, NSMutableCopying {
 		[Export ("dictionaryWithContentsOfFile:")]
 		[Static]
 		NSDictionary FromFile (string path);
@@ -3021,17 +3021,17 @@ namespace XamCore.Foundation
 
 	}
 
-	public interface NSDictionary<K,V> : NSDictionary {}
+	interface NSDictionary<K,V> : NSDictionary {}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSEnumerator {
+	interface NSEnumerator {
 		[Export ("nextObject")]
 		NSObject NextObject (); 
 	}
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface NSError : NSSecureCoding, NSCopying {
+	interface NSError : NSSecureCoding, NSCopying {
 		[Static, Export ("errorWithDomain:code:userInfo:")]
 		NSError FromDomain (NSString domain, nint code, [NullAllowed] NSDictionary userInfo);
 
@@ -3170,12 +3170,12 @@ namespace XamCore.Foundation
 #endif
 	}
 
-	public delegate NSObject NSErrorUserInfoValueProvider (NSError error, NSString userInfoKey);	
+	delegate NSObject NSErrorUserInfoValueProvider (NSError error, NSString userInfoKey);	
 
 	[BaseType (typeof (NSObject))]
 	// 'init' returns NIL
 	[DisableDefaultCtor]
-	public interface NSException : NSCoding, NSCopying {
+	interface NSException : NSCoding, NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithName:reason:userInfo:")]
 		IntPtr Constructor (string name, string reason, [NullAllowed] NSDictionary userInfo);
@@ -3198,13 +3198,13 @@ namespace XamCore.Foundation
 
 #if !XAMCORE_4_0 && !WATCH
 	[Obsolete("NSExpressionHandler is deprecated, please use FromFormat (string, NSObject[]) instead.")]
-	public delegate void NSExpressionHandler (NSObject evaluatedObject, NSExpression [] expressions, NSMutableDictionary context);
+	delegate void NSExpressionHandler (NSObject evaluatedObject, NSExpression [] expressions, NSMutableDictionary context);
 #endif
-	public delegate NSObject NSExpressionCallbackHandler (NSObject evaluatedObject, NSExpression [] expressions, NSMutableDictionary context);
+	delegate NSObject NSExpressionCallbackHandler (NSObject evaluatedObject, NSExpression [] expressions, NSMutableDictionary context);
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -predicateFormat cannot be sent to an abstract object of class NSExpression: Create a concrete instance!
 	[DisableDefaultCtor]
-	public interface NSExpression : NSSecureCoding, NSCopying {
+	interface NSExpression : NSSecureCoding, NSCopying {
 		[Static, Export ("expressionForConstantValue:")]
 		NSExpression FromConstant (NSObject obj);
 
@@ -3330,7 +3330,7 @@ namespace XamCore.Foundation
 
 	[iOS (8,0)][Mac (10,10, onlyOn64 : true)] // Not defined in 32-bit
 	[BaseType (typeof (NSObject))]
-	public partial interface NSExtensionContext {
+	partial interface NSExtensionContext {
 
 		[Export ("inputItems", ArgumentSemantic.Copy)]
 		NSExtensionItem [] InputItems { get; }
@@ -3373,7 +3373,7 @@ namespace XamCore.Foundation
 
 	[iOS (8,0)][Mac (10,10, onlyOn64 : true)] // Not defined in 32-bit
 	[BaseType (typeof (NSObject))]
-	public partial interface NSExtensionItem : NSCopying, NSSecureCoding {
+	partial interface NSExtensionItem : NSCopying, NSSecureCoding {
 
 		[NullAllowed] // by default this property is null
 		[Export ("attributedTitle", ArgumentSemantic.Copy)]
@@ -3401,7 +3401,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSNull : NSSecureCoding, NSCopying {
+	interface NSNull : NSSecureCoding, NSCopying {
 		[Export ("null"), Static]
 		NSNull Null { get; }
 	}
@@ -3483,7 +3483,7 @@ namespace XamCore.Foundation
 
 	[Since (5,0)]
 	[Static]
-	public interface NSLinguisticTag {
+	interface NSLinguisticTag {
 		[Field ("NSLinguisticTagSchemeTokenType")]
 		NSString SchemeTokenType { get; }
 
@@ -3603,7 +3603,7 @@ namespace XamCore.Foundation
 	// 'init' returns NIL so it's not usable evenif it does not throw an ObjC exception
 	// funnily it was "added" in iOS 7 and header files says "do not invoke; not a valid initializer for this class"
 	[DisableDefaultCtor]
-	public interface NSLocale : NSSecureCoding, NSCopying {
+	interface NSLocale : NSSecureCoding, NSCopying {
 		[Static]
 		[Export ("systemLocale", ArgumentSemantic.Copy)]
 		NSLocale SystemLocale { get; }
@@ -3743,13 +3743,13 @@ namespace XamCore.Foundation
 		string GetLocalizedCalendarIdentifier (string calendarIdentifier);
 	}
 
-	public delegate void NSMatchEnumerator (NSTextCheckingResult result, NSMatchingFlags flags, ref bool stop);
+	delegate void NSMatchEnumerator (NSTextCheckingResult result, NSMatchingFlags flags, ref bool stop);
 
 	// This API surfaces NSString instead of strings, because we already have the .NET version that uses
 	// strings, so it makes sense to use NSString here (and also, the replacing functionality operates on
 	// NSMutableStrings)
 	[BaseType (typeof (NSObject))]
-	public interface NSRegularExpression : NSCopying, NSSecureCoding {
+	interface NSRegularExpression : NSCopying, NSSecureCoding {
 		[DesignatedInitializer]
 		[Export ("initWithPattern:options:error:")]
 		IntPtr Constructor (NSString pattern, NSRegularExpressionOptions options, out NSError error);
@@ -3799,7 +3799,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject))]
 	// init returns NIL
 	[DisableDefaultCtor]
-	public interface NSRunLoop {
+	interface NSRunLoop {
 		[Export ("currentRunLoop", ArgumentSemantic.Strong)][Static][IsThreadStatic]
 		NSRunLoop Current { get; }
 
@@ -3883,7 +3883,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSSet : NSSecureCoding, NSMutableCopying {
+	interface NSSet : NSSecureCoding, NSMutableCopying {
 		[Export ("set")][Static]
 		NSSet CreateSet ();
 
@@ -3969,10 +3969,10 @@ namespace XamCore.Foundation
 #endif
 	}
 
-	public interface NSSet<TKey> : NSSet {}
+	interface NSSet<TKey> : NSSet {}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSSortDescriptor : NSSecureCoding, NSCopying {
+	interface NSSortDescriptor : NSSecureCoding, NSCopying {
 		[Export ("initWithKey:ascending:")]
 		IntPtr Constructor (string key, bool ascending);
 
@@ -4003,7 +4003,7 @@ namespace XamCore.Foundation
 	}
 	
 	[Category, BaseType (typeof (NSOrderedSet))]
-	public partial interface NSKeyValueSorting_NSOrderedSet {
+	partial interface NSKeyValueSorting_NSOrderedSet {
 		[Since (5,0)]
 		[Export ("sortedArrayUsingDescriptors:")]
 		NSObject [] GetSortedArray (NSSortDescriptor [] sortDescriptors);
@@ -4012,13 +4012,13 @@ namespace XamCore.Foundation
 #pragma warning disable 618
 	[Category, BaseType (typeof (NSMutableArray))]
 #pragma warning restore 618
-	public partial interface NSSortDescriptorSorting_NSMutableArray {
+	partial interface NSSortDescriptorSorting_NSMutableArray {
 		[Since (5,0), Export ("sortUsingDescriptors:")]
 		void SortUsingDescriptors (NSSortDescriptor [] sortDescriptors);
 	}
 
 	[Category, BaseType (typeof (NSMutableOrderedSet))]
-	public partial interface NSKeyValueSorting_NSMutableOrderedSet {
+	partial interface NSKeyValueSorting_NSMutableOrderedSet {
 		[Since (5,0), Export ("sortUsingDescriptors:")]
 		void SortUsingDescriptors (NSSortDescriptor [] sortDescriptors);
 	}
@@ -4027,7 +4027,7 @@ namespace XamCore.Foundation
 	[Dispose ("if (disposing) { Invalidate (); } ")]
 	// init returns NIL
 	[DisableDefaultCtor]
-	public interface NSTimer {
+	interface NSTimer {
 
 		[Static, Export ("scheduledTimerWithTimeInterval:target:selector:userInfo:repeats:")]
 		NSTimer CreateScheduledTimer (double seconds, NSObject target, Selector selector, [NullAllowed] NSObject userInfo, bool repeats);
@@ -4081,7 +4081,7 @@ namespace XamCore.Foundation
 	// NSTimeZone is an abstract class that defines the behavior of time zone objects. -> http://developer.apple.com/library/ios/#documentation/Cocoa/Reference/Foundation/Classes/NSTimeZone_Class/Reference/Reference.html
 	// calling 'init' returns a NIL pointer, i.e. an unusable instance
 	[DisableDefaultCtor]
-	public interface NSTimeZone : NSSecureCoding, NSCopying {
+	interface NSTimeZone : NSSecureCoding, NSCopying {
 		[Export ("initWithName:")]
 		IntPtr Constructor (string name);
 		
@@ -4247,7 +4247,7 @@ namespace XamCore.Foundation
 
 	[Since (6,0)]
 	[BaseType (typeof (NSObject), Name="NSUUID")]
-	public interface NSUuid : NSSecureCoding, NSCopying {
+	interface NSUuid : NSSecureCoding, NSCopying {
 		[Export ("initWithUUIDString:")]
 		IntPtr Constructor (string str);
 
@@ -4265,7 +4265,7 @@ namespace XamCore.Foundation
 	[iOS (8,0)][Mac (10,10, onlyOn64 : true)] // .objc_class_name_NSUserActivity", referenced from '' not found
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // xcode 8 beta 4 marks it as API_DEPRECATED
-	public partial interface NSUserActivity {
+	partial interface NSUserActivity {
 	
 		[DesignatedInitializer]
 		[Export ("initWithActivityType:")]
@@ -4354,7 +4354,7 @@ namespace XamCore.Foundation
 
 	[iOS (8,0)][Mac (10,10, onlyOn64 : true)] // same as NSUserActivity
 	[Static]
-	public partial interface NSUserActivityType {
+	partial interface NSUserActivityType {
 		[Field ("NSUserActivityTypeBrowsingWeb")]
 		NSString BrowsingWeb { get; }
 	}
@@ -4362,7 +4362,7 @@ namespace XamCore.Foundation
 	[iOS (8,0)][Mac (10,10, onlyOn64 : true)] // same as NSUserActivity
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public partial interface NSUserActivityDelegate {
+	partial interface NSUserActivityDelegate {
 		[Export ("userActivityWillSave:")]
 		void UserActivityWillSave (NSUserActivity userActivity);
 	
@@ -4374,7 +4374,7 @@ namespace XamCore.Foundation
 	}
 		
 	[BaseType (typeof (NSObject))]
-	public interface NSUserDefaults {
+	interface NSUserDefaults {
 		[Mac (10,6)][iOS (4,0)]
 		[Export ("URLForKey:")]
 		[return: NullAllowed]
@@ -4540,7 +4540,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject), Name="NSURL")]
 	// init returns NIL
 	[DisableDefaultCtor]
-	public partial interface NSUrl : NSSecureCoding, NSCopying
+	partial interface NSUrl : NSSecureCoding, NSCopying
 #if MONOMAC
 	, NSPasteboardReading, NSPasteboardWriting
 #endif
@@ -5164,7 +5164,7 @@ namespace XamCore.Foundation
 	// Just a category so we can document the three methods together
 	//
 	[Category, BaseType (typeof (NSUrl))]
-	public partial interface NSUrl_PromisedItems {
+	partial interface NSUrl_PromisedItems {
 		[Mac (10,10), iOS (8,0)]
 		[Export ("checkPromisedItemIsReachableAndReturnError:")]
 		bool CheckPromisedItemIsReachable (out NSError error);
@@ -5181,7 +5181,7 @@ namespace XamCore.Foundation
 
 	[iOS (8,0), Mac (10,10)]
 	[BaseType (typeof (NSObject), Name="NSURLQueryItem")]
-	public interface NSUrlQueryItem : NSSecureCoding, NSCopying {
+	interface NSUrlQueryItem : NSSecureCoding, NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithName:value:")]
 		IntPtr Constructor (string name, string value);
@@ -5194,7 +5194,7 @@ namespace XamCore.Foundation
 	}
 
 	[Category, BaseType (typeof (NSCharacterSet))]
-	public partial interface NSUrlUtilities_NSCharacterSet {
+	partial interface NSUrlUtilities_NSCharacterSet {
 		[Since (7,0), Static, Export ("URLUserAllowedCharacterSet", ArgumentSemantic.Copy)]
 		NSCharacterSet UrlUserAllowedCharacterSet { get; }
 	
@@ -5215,7 +5215,7 @@ namespace XamCore.Foundation
 	}
 		
 	[BaseType (typeof (NSObject), Name="NSURLCache")]
-	public interface NSUrlCache {
+	interface NSUrlCache {
 		[Export ("sharedURLCache", ArgumentSemantic.Strong), Static]
 		NSUrlCache SharedCache { get; set; }
 
@@ -5266,7 +5266,7 @@ namespace XamCore.Foundation
 	
 	[Since (7,0), Mavericks]
 	[BaseType (typeof (NSObject), Name="NSURLComponents")]
-	public partial interface NSUrlComponents : NSCopying {
+	partial interface NSUrlComponents : NSCopying {
 		[Export ("initWithURL:resolvingAgainstBaseURL:")]
 		IntPtr Constructor (NSUrl url, bool resolveAgainstBaseUrl);
 	
@@ -5386,7 +5386,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject), Name="NSURLAuthenticationChallenge")]
 	// 'init' returns NIL
 	[DisableDefaultCtor]
-	public interface NSUrlAuthenticationChallenge : NSSecureCoding {
+	interface NSUrlAuthenticationChallenge : NSSecureCoding {
 		[Export ("initWithProtectionSpace:proposedCredential:previousFailureCount:failureResponse:error:sender:")]
 		IntPtr Constructor (NSUrlProtectionSpace space, NSUrlCredential credential, nint previousFailureCount, NSUrlResponse response, [NullAllowed] NSError error, NSUrlConnection sender);
 		
@@ -5414,11 +5414,11 @@ namespace XamCore.Foundation
 
 	[Protocol (Name = "NSURLAuthenticationChallengeSender")]
 #if XAMCORE_4_0
-	public interface NSUrlAuthenticationChallengeSender {
+	interface NSUrlAuthenticationChallengeSender {
 #else
 	[Model]
 	[BaseType (typeof (NSObject))]
-	public interface NSURLAuthenticationChallengeSender {
+	interface NSURLAuthenticationChallengeSender {
 #endif
 		[Abstract]
 		[Export ("useCredential:forAuthenticationChallenge:")]
@@ -5460,10 +5460,10 @@ namespace XamCore.Foundation
 	}
 
 
-	public delegate void NSUrlConnectionDataResponse (NSUrlResponse response, NSData data, NSError error);
+	delegate void NSUrlConnectionDataResponse (NSUrlResponse response, NSData data, NSError error);
 	
 	[BaseType (typeof (NSObject), Name="NSURLConnection")]
-	public interface NSUrlConnection : 
+	interface NSUrlConnection : 
 #if XAMCORE_4_0
 		NSUrlAuthenticationChallengeSender
 #else
@@ -5538,7 +5538,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject), Name="NSURLConnectionDelegate")]
 	[Model]
 	[Protocol]
-	public interface NSUrlConnectionDelegate {
+	interface NSUrlConnectionDelegate {
 #if !XAMCORE_2_0
 		// part of NSURLConnectionDataDelegate
 		[Export ("connection:willSendRequest:redirectResponse:")]
@@ -5619,7 +5619,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSUrlConnectionDelegate), Name="NSURLConnectionDownloadDelegate")]
 	[Model]
 	[Protocol]
-	public interface NSUrlConnectionDownloadDelegate {
+	interface NSUrlConnectionDownloadDelegate {
 		[Export ("connection:didWriteData:totalBytesWritten:expectedTotalBytes:")]
 		void WroteData (NSUrlConnection connection, long bytesWritten, long totalBytesWritten, long expectedTotalBytes);
 		
@@ -5634,7 +5634,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject), Name="NSURLCredential")]
 	// crash when calling NSObjecg.get_Description (and likely other selectors)
 	[DisableDefaultCtor]
-	public interface NSUrlCredential : NSSecureCoding, NSCopying {
+	interface NSUrlCredential : NSSecureCoding, NSCopying {
 
 		[Export ("initWithTrust:")]
 		IntPtr Constructor (SecTrust trust);
@@ -5695,7 +5695,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject), Name="NSURLCredentialStorage")]
 	// init returns NIL -> SharedCredentialStorage
 	[DisableDefaultCtor]
-	public interface NSUrlCredentialStorage {
+	interface NSUrlCredentialStorage {
 		[Static]
 		[Export ("sharedCredentialStorage", ArgumentSemantic.Strong)]
 		NSUrlCredentialStorage SharedCredentialStorage { get; }
@@ -5753,18 +5753,18 @@ namespace XamCore.Foundation
 	}
 
 #if XAMCORE_4_0
-	public delegate void NSUrlSessionPendingTasks (NSUrlSessionTask [] dataTasks, NSUrlSessionTask [] uploadTasks, NSUrlSessionTask[] downloadTasks);
+	delegate void NSUrlSessionPendingTasks (NSUrlSessionTask [] dataTasks, NSUrlSessionTask [] uploadTasks, NSUrlSessionTask[] downloadTasks);
 #elif XAMCORE_3_0
-	public delegate void NSUrlSessionPendingTasks2 (NSUrlSessionTask [] dataTasks, NSUrlSessionTask [] uploadTasks, NSUrlSessionTask[] downloadTasks);
+	delegate void NSUrlSessionPendingTasks2 (NSUrlSessionTask [] dataTasks, NSUrlSessionTask [] uploadTasks, NSUrlSessionTask[] downloadTasks);
 #else
-	public delegate void NSUrlSessionPendingTasks (NSUrlSessionDataTask [] dataTasks, NSUrlSessionUploadTask [] uploadTasks, NSUrlSessionDownloadTask[] downloadTasks);
-	public delegate void NSUrlSessionPendingTasks2 (NSUrlSessionTask [] dataTasks, NSUrlSessionTask [] uploadTasks, NSUrlSessionTask[] downloadTasks);
+	delegate void NSUrlSessionPendingTasks (NSUrlSessionDataTask [] dataTasks, NSUrlSessionUploadTask [] uploadTasks, NSUrlSessionDownloadTask[] downloadTasks);
+	delegate void NSUrlSessionPendingTasks2 (NSUrlSessionTask [] dataTasks, NSUrlSessionTask [] uploadTasks, NSUrlSessionTask[] downloadTasks);
 #endif
-	public delegate void NSUrlSessionAllPendingTasks (NSUrlSessionTask [] tasks);
-	public delegate void NSUrlSessionResponse (NSData data, NSUrlResponse response, NSError error);
-	public delegate void NSUrlSessionDownloadResponse (NSUrl data, NSUrlResponse response, NSError error);
+	delegate void NSUrlSessionAllPendingTasks (NSUrlSessionTask [] tasks);
+	delegate void NSUrlSessionResponse (NSData data, NSUrlResponse response, NSError error);
+	delegate void NSUrlSessionDownloadResponse (NSUrl data, NSUrlResponse response, NSError error);
 
-	public delegate void NSUrlDownloadSessionResponse (NSUrl location, NSUrlResponse response, NSError error);
+	delegate void NSUrlDownloadSessionResponse (NSUrl location, NSUrlResponse response, NSError error);
 
 	//
 	// Some of the XxxTaskWith methods that take a completion were flagged as allowing a null in
@@ -5784,7 +5784,7 @@ namespace XamCore.Foundation
 #if XAMCORE_2_0
 	[DisableDefaultCtorAttribute]
 #endif
-	public partial interface NSUrlSession {
+	partial interface NSUrlSession {
 	
 		[Static, Export ("sharedSession", ArgumentSemantic.Strong)]
 		NSUrlSession SharedSession { get; }
@@ -5923,7 +5923,7 @@ namespace XamCore.Foundation
 	[Since(9,0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSUrlSessionTaskDelegate), Name="NSURLSessionStreamDelegate")]
-	public interface NSUrlSessionStreamDelegate
+	interface NSUrlSessionStreamDelegate
 	{
 		[Export ("URLSession:readClosedForStreamTask:")]
 		void ReadClosed (NSUrlSession session, NSUrlSessionStreamTask streamTask);
@@ -5943,11 +5943,11 @@ namespace XamCore.Foundation
 		void CompletedTaskCaptureStreams (NSUrlSession session, NSUrlSessionStreamTask streamTask, NSInputStream inputStream, NSOutputStream outputStream);
 	}
 	
-	public delegate void NSUrlSessionDataRead (NSData data, bool atEof, NSError error);
+	delegate void NSUrlSessionDataRead (NSData data, bool atEof, NSError error);
 	[iOS (9,0), Mac(10,11)]
 	[BaseType (typeof(NSUrlSessionTask), Name="NSURLSessionStreamTask")]
 	[DisableDefaultCtor]
-	public interface NSUrlSessionStreamTask
+	interface NSUrlSessionStreamTask
 	{
 		[Export ("readDataOfMinLength:maxLength:timeout:completionHandler:")]
 		[Async (ResultTypeName="NSUrlSessionStreamDataRead")]
@@ -5976,7 +5976,7 @@ namespace XamCore.Foundation
 	[Since (7,0)]
 	[Availability (Introduced = Platform.Mac_10_9)]
 	[BaseType (typeof (NSObject), Name="NSURLSessionTask")]
-	public partial interface NSUrlSessionTask : NSCopying {
+	partial interface NSUrlSessionTask : NSCopying {
 	
 		[Export ("taskIdentifier")]
 		nuint TaskIdentifier { get; }
@@ -6058,17 +6058,17 @@ namespace XamCore.Foundation
 	[Since (7,0)]
 	[Availability (Introduced = Platform.Mac_10_9)]
 	[BaseType (typeof (NSUrlSessionTask), Name="NSURLSessionDataTask")]
-	public partial interface NSUrlSessionDataTask {}
+	partial interface NSUrlSessionDataTask {}
 
 	[Since (7,0)]
 	[Availability (Introduced = Platform.Mac_10_9)]
 	[BaseType (typeof (NSUrlSessionDataTask), Name="NSURLSessionUploadTask")]
-	public partial interface NSUrlSessionUploadTask {}
+	partial interface NSUrlSessionUploadTask {}
 
 	[Since (7,0)]
 	[Availability (Introduced = Platform.Mac_10_9)]
 	[BaseType (typeof (NSUrlSessionTask), Name="NSURLSessionDownloadTask")]
-	public partial interface NSUrlSessionDownloadTask {
+	partial interface NSUrlSessionDownloadTask {
 		[Export ("cancelByProducingResumeData:")]
 		void Cancel (Action<NSData> resumeCallback);
 	}
@@ -6080,7 +6080,7 @@ namespace XamCore.Foundation
 #if XAMCORE_2_0
 	[DisableDefaultCtorAttribute]
 #endif
-	public partial interface NSUrlSessionConfiguration : NSCopying {
+	partial interface NSUrlSessionConfiguration : NSCopying {
 	
 		[Static, Export ("defaultSessionConfiguration", ArgumentSemantic.Strong)]
 		NSUrlSessionConfiguration DefaultSessionConfiguration { get; }
@@ -6176,7 +6176,7 @@ namespace XamCore.Foundation
 	[Availability (Introduced = Platform.Mac_10_9)]
 	[Model, BaseType (typeof (NSObject), Name="NSURLSessionDelegate")]
 	[Protocol]
-	public partial interface NSUrlSessionDelegate {
+	partial interface NSUrlSessionDelegate {
 		[Export ("URLSession:didBecomeInvalidWithError:")]
 		void DidBecomeInvalid (NSUrlSession session, NSError error);
 	
@@ -6219,7 +6219,7 @@ namespace XamCore.Foundation
 	[Model]
 	[BaseType (typeof (NSUrlSessionTaskDelegate), Name="NSURLSessionDataDelegate")]
 	[Protocol]
-	public partial interface NSUrlSessionDataDelegate {
+	partial interface NSUrlSessionDataDelegate {
 		[Export ("URLSession:dataTask:didReceiveResponse:completionHandler:")]
 		void DidReceiveResponse (NSUrlSession session, NSUrlSessionDataTask dataTask, NSUrlResponse response, Action<NSUrlSessionResponseDisposition> completionHandler);
 	
@@ -6242,7 +6242,7 @@ namespace XamCore.Foundation
 	[Model]
 	[BaseType (typeof (NSUrlSessionTaskDelegate), Name="NSURLSessionDownloadDelegate")]
 	[Protocol]
-	public partial interface NSUrlSessionDownloadDelegate {
+	partial interface NSUrlSessionDownloadDelegate {
 	
 #if XAMCORE_2_0
 		[Abstract]
@@ -6268,7 +6268,7 @@ namespace XamCore.Foundation
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSUndoManager {
+	interface NSUndoManager {
 		[Export ("beginUndoGrouping")]
 		void BeginUndoGrouping ();
 		
@@ -6418,7 +6418,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject), Name="NSURLProtectionSpace")]
 	// 'init' returns NIL
 	[DisableDefaultCtor]
-	public interface NSUrlProtectionSpace : NSSecureCoding, NSCopying {
+	interface NSUrlProtectionSpace : NSSecureCoding, NSCopying {
 		
 		[Internal]
 		[Export ("initWithHost:port:protocol:realm:authenticationMethod:")]
@@ -6513,7 +6513,7 @@ namespace XamCore.Foundation
 	}
 	
 	[BaseType (typeof (NSObject), Name="NSURLRequest")]
-	public interface NSUrlRequest : NSSecureCoding, NSMutableCopying {
+	interface NSUrlRequest : NSSecureCoding, NSMutableCopying {
 		[Export ("initWithURL:")]
 		IntPtr Constructor (NSUrl url);
 
@@ -6563,7 +6563,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSDictionary))]
-	public interface NSMutableDictionary {
+	interface NSMutableDictionary {
 		[Export ("dictionaryWithContentsOfFile:")]
 		[Static]
 		NSMutableDictionary FromFile (string path);
@@ -6627,7 +6627,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSSet))]
-	public interface NSMutableSet {
+	interface NSMutableSet {
 		[Export ("initWithArray:")]
 		IntPtr Constructor (NSArray other);
 
@@ -6673,7 +6673,7 @@ namespace XamCore.Foundation
 	}
 	
 	[BaseType (typeof (NSUrlRequest), Name="NSMutableURLRequest")]
-	public interface NSMutableUrlRequest {
+	interface NSMutableUrlRequest {
 		[Export ("initWithURL:")]
 		IntPtr Constructor (NSUrl url);
 
@@ -6724,7 +6724,7 @@ namespace XamCore.Foundation
 	}
 	
 	[BaseType (typeof (NSObject), Name="NSURLResponse")]
-	public interface NSUrlResponse : NSSecureCoding, NSCopying {
+	interface NSUrlResponse : NSSecureCoding, NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithURL:MIMEType:expectedContentLength:textEncodingName:")]
 		IntPtr Constructor (NSUrl url, string mimetype, nint expectedContentLength, [NullAllowed] string textEncodingName);
@@ -6746,7 +6746,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (NSStreamDelegate)} )]
-	public interface NSStream {
+	interface NSStream {
 		[Export ("open")]
 		void Open ();
 
@@ -6881,13 +6881,13 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSStreamDelegate {
+	interface NSStreamDelegate {
 		[Export ("stream:handleEvent:"), EventArgs ("NSStream"), EventName ("OnEvent")]
 		void HandleEvent (NSStream theStream, NSStreamEvent streamEvent);
 	}
 
 	[BaseType (typeof (NSObject)), Bind ("NSString")]
-	public interface NSString2 : NSSecureCoding, NSMutableCopying
+	interface NSString2 : NSSecureCoding, NSMutableCopying
 	#if MONOMAC
 		, NSPasteboardReading, NSPasteboardWriting // Documented that it implements NSPasteboard protocols even if header doesn't show it
 	#endif
@@ -7209,7 +7209,7 @@ namespace XamCore.Foundation
 	}
 
 	[StrongDictionary ("NSString")]
-	public interface EncodingDetectionOptions {
+	interface EncodingDetectionOptions {
 		NSStringEncoding [] EncodingDetectionSuggestedEncodings { get; set; }
 		NSStringEncoding [] EncodingDetectionDisallowedEncodings { get; set; }
 		bool EncodingDetectionUseOnlySuggestedEncodings { get; set; }
@@ -7221,7 +7221,7 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSString))]
 	// hack: it seems that generator.cs can't track NSCoding correctly ? maybe because the type is named NSString2 at that time
-	public interface NSMutableString : NSCoding {
+	interface NSMutableString : NSCoding {
 		[Export ("initWithCapacity:")]
 		IntPtr Constructor (nint capacity);
 
@@ -7253,9 +7253,9 @@ namespace XamCore.Foundation
 	
 	[Category, BaseType (typeof (NSString))]
 #if XAMCORE_2_0
-	public partial interface NSUrlUtilities_NSString {
+	partial interface NSUrlUtilities_NSString {
 #else
-	public partial interface NSURLUtilities_NSString {
+	partial interface NSURLUtilities_NSString {
 #endif
 		[Since (7,0)]
 		[Export ("stringByAddingPercentEncodingWithAllowedCharacters:")]
@@ -7277,7 +7277,7 @@ namespace XamCore.Foundation
 	// This comes from UIKit.framework/Headers/NSStringDrawing.h
 	[Since (6,0)]
 	[BaseType (typeof (NSObject))]
-	public interface NSStringDrawingContext {
+	interface NSStringDrawingContext {
 		[Export ("minimumScaleFactor")]
 		nfloat MinimumScaleFactor { get; set;  }
 
@@ -7301,7 +7301,7 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSStream))]
 	[DefaultCtorVisibility (Visibility.Protected)]
-	public interface NSInputStream {
+	interface NSInputStream {
 		[Export ("hasBytesAvailable")]
 		bool HasBytesAvailable ();
 	
@@ -7335,7 +7335,7 @@ namespace XamCore.Foundation
 	// calls being made and the keys are mostly tokens
 	//
 	[BaseType (typeof (NSObject)), Bind ("NSObject")]
-	public interface NSObject2 : NSObjectProtocol {
+	interface NSObject2 : NSObjectProtocol {
 
 		// those are to please the compiler while creating the definition .dll
 		// but, for the final binary, we'll be using manually bounds alternatives
@@ -7532,7 +7532,7 @@ namespace XamCore.Foundation
 	}
 
 	[Protocol (Name = "NSObject")] // exists both as a type and a protocol in ObjC, Swift uses NSObjectProtocol
-	public interface NSObjectProtocol {
+	interface NSObjectProtocol {
 
 		[Abstract]
 		[Export ("description")]
@@ -7636,7 +7636,7 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSObject))]
 	[Since (4,0)]
-	public interface NSOperation {
+	interface NSOperation {
 		[Export ("start")]
 		void Start ();
 
@@ -7700,7 +7700,7 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSOperation))]
 	[Since (4,0)]
-	public interface NSBlockOperation {
+	interface NSBlockOperation {
 		[Static]
 		[Export ("blockOperationWithBlock:")]
 		NSBlockOperation Create (/* non null */ NSAction method);
@@ -7714,7 +7714,7 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSObject))]
 	[Since (4,0)]
-	public interface NSOperationQueue {
+	interface NSOperationQueue {
 		[Export ("addOperation:")][PostGet ("Operations")]
 		void AddOperation ([NullAllowed] NSOperation op);
 
@@ -7766,12 +7766,12 @@ namespace XamCore.Foundation
 	}
 
 #if XAMCORE_2_0
-	public interface NSOrderedSet<TKey> : NSOrderedSet {}
+	interface NSOrderedSet<TKey> : NSOrderedSet {}
 #endif
 
 	[Since (5,0)]
 	[BaseType (typeof (NSObject))]
-	public interface NSOrderedSet : NSSecureCoding, NSMutableCopying {
+	interface NSOrderedSet : NSSecureCoding, NSMutableCopying {
 		[Export ("initWithObject:")]
 		IntPtr Constructor (NSObject start);
 
@@ -7861,12 +7861,12 @@ namespace XamCore.Foundation
 	}
 
 #if XAMCORE_2_0
-	public interface NSMutableOrderedSet<TKey> : NSMutableOrderedSet {}
+	interface NSMutableOrderedSet<TKey> : NSMutableOrderedSet {}
 #endif
 
 	[Since (5,0)]
 	[BaseType (typeof (NSOrderedSet))]
-	public interface NSMutableOrderedSet {
+	interface NSMutableOrderedSet {
 		[Export ("initWithObject:")]
 		IntPtr Constructor (NSObject start);
 
@@ -8004,7 +8004,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[__NSArrayM insertObject:atIndex:]: object cannot be nil
 	[DisableDefaultCtor]
-	public interface NSOrthography : NSSecureCoding, NSCopying {
+	interface NSOrthography : NSSecureCoding, NSCopying {
 		[Export ("dominantScript")]
 		string DominantScript { get;  }
 
@@ -8033,7 +8033,7 @@ namespace XamCore.Foundation
 	
 	[BaseType (typeof (NSStream))]
 	[DisableDefaultCtor] // crash when used
-	public interface NSOutputStream {
+	interface NSOutputStream {
 		[Export ("initToMemory")]
 		IntPtr Constructor ();
 
@@ -8066,7 +8066,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject), Name="NSHTTPCookie")]
 	// default 'init' crash both simulator and devices
 	[DisableDefaultCtor]
-	public interface NSHttpCookie {
+	interface NSHttpCookie {
 		[Export ("initWithProperties:")]
 		IntPtr Constructor (NSDictionary properties);
 
@@ -8163,7 +8163,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject), Name="NSHTTPCookieStorage")]
 	// NSHTTPCookieStorage implements a singleton object -> use SharedStorage since 'init' returns NIL
 	[DisableDefaultCtor]
-	public interface NSHttpCookieStorage {
+	interface NSHttpCookieStorage {
 		[Export ("sharedHTTPCookieStorage", ArgumentSemantic.Strong), Static]
 		NSHttpCookieStorage SharedStorage { get; }
 
@@ -8220,7 +8220,7 @@ namespace XamCore.Foundation
 	}
 	
 	[BaseType (typeof (NSUrlResponse), Name="NSHTTPURLResponse")]
-	public interface NSHttpUrlResponse {
+	interface NSHttpUrlResponse {
 		[Export ("initWithURL:MIMEType:expectedContentLength:textEncodingName:")]
 		IntPtr Constructor (NSUrl url, string mimetype, nint expectedContentLength, [NullAllowed] string textEncodingName);
 
@@ -8242,7 +8242,7 @@ namespace XamCore.Foundation
 #if MONOMAC
 	[DisableDefaultCtor] // An uncaught exception was raised: -[__NSCFDictionary removeObjectForKey:]: attempt to remove nil key
 #endif
-	public partial interface NSBundle {
+	partial interface NSBundle {
 		[Export ("mainBundle")][Static]
 		NSBundle MainBundle { get; }
 
@@ -8496,7 +8496,7 @@ namespace XamCore.Foundation
 #endif
 		
 	[BaseType (typeof (NSObject))]
-	public interface NSIndexPath : NSCoding, NSSecureCoding, NSCopying {
+	interface NSIndexPath : NSCoding, NSSecureCoding, NSCopying {
 		[Export ("indexPathWithIndex:")][Static]
 		NSIndexPath FromIndex (nuint index);
 
@@ -8570,10 +8570,10 @@ namespace XamCore.Foundation
 		nint Item { get; }
 	}
 
-	public delegate void NSRangeIterator (NSRange range, ref bool stop);
+	delegate void NSRangeIterator (NSRange range, ref bool stop);
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSIndexSet : NSCoding, NSSecureCoding, NSMutableCopying {
+	interface NSIndexSet : NSCoding, NSSecureCoding, NSMutableCopying {
 		[Static, Export ("indexSetWithIndex:")]
 		NSIndexSet FromIndex (nint idx);
 
@@ -8641,7 +8641,7 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // from the docs: " you should not create these objects using alloc and init."
-	public interface NSInvocation {
+	interface NSInvocation {
 
 		[Export ("selector")]
 		Selector Selector { get; set; }
@@ -8674,7 +8674,7 @@ namespace XamCore.Foundation
 
 	[iOS (8,0)][Mac (10,10, onlyOn64 : true)] // Not defined in 32-bit
 	[BaseType (typeof (NSObject))]
-	public partial interface NSItemProvider : NSCopying {
+	partial interface NSItemProvider : NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithItem:typeIdentifier:")]
 		IntPtr Constructor ([NullAllowed] NSObject item, string typeIdentifier);
@@ -8734,7 +8734,7 @@ namespace XamCore.Foundation
 	[Static]
 #endif
 	[iOS (8,0), Mac (10,10, onlyOn64: true)]
-	public partial interface NSJavaScriptExtension {
+	partial interface NSJavaScriptExtension {
 		[Field ("NSExtensionJavaScriptPreprocessingResultsKey")]
 		NSString PreprocessingResultsKey { get; }
 
@@ -8743,7 +8743,7 @@ namespace XamCore.Foundation
 	}
 
 	[iOS (8,0), Mac (10,10)]
-	public interface NSTypeIdentifier {
+	interface NSTypeIdentifier {
 		[Field ("NSTypeIdentifierDateText")]
 		NSString DateText { get; }
 
@@ -8759,7 +8759,7 @@ namespace XamCore.Foundation
 		
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // `init` returns a null handle
-	public interface NSMethodSignature {
+	interface NSMethodSignature {
 		[Static]
 		[Export ("signatureWithObjCTypes:")]
 		NSMethodSignature FromObjcTypes (IntPtr utf8objctypes);
@@ -8811,7 +8811,7 @@ namespace XamCore.Foundation
 	}
 	
 	[BaseType (typeof (NSIndexSet))]
-	public interface NSMutableIndexSet : NSSecureCoding {
+	interface NSMutableIndexSet : NSSecureCoding {
 		[Export ("initWithIndex:")]
 		IntPtr Constructor (nuint index);
 
@@ -8848,7 +8848,7 @@ namespace XamCore.Foundation
 	[DisableDefaultCtor] // the instance just crash when trying to call selectors
 #endif
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (NSNetServiceDelegate)})]
-	public interface NSNetService {
+	interface NSNetService {
 		[DesignatedInitializer]
 		[Export ("initWithDomain:type:name:port:")]
 		IntPtr Constructor (string domain, string type, string name, int /* int, not NSInteger */ port);
@@ -8950,7 +8950,7 @@ namespace XamCore.Foundation
 	[NoWatch]
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
-	public interface NSNetServiceDelegate {
+	interface NSNetServiceDelegate {
 		[Export ("netServiceWillPublish:")]
 		void WillPublish (NSNetService sender);
 
@@ -8984,7 +8984,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject),
 		   Delegates=new string [] {"WeakDelegate"},
 		   Events=new Type [] {typeof (NSNetServiceBrowserDelegate)})]
-	public interface NSNetServiceBrowser {
+	interface NSNetServiceBrowser {
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDelegate { get; set; }
 
@@ -9034,7 +9034,7 @@ namespace XamCore.Foundation
 	[NoWatch]
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
-	public interface NSNetServiceBrowserDelegate {
+	interface NSNetServiceBrowserDelegate {
 		[Export ("netServiceBrowserWillSearch:")]
 		void SearchStarted (NSNetServiceBrowser sender);
 		
@@ -9060,7 +9060,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: *** -[NSConcreteNotification init]: should never be used
 	[DisableDefaultCtor] // added in iOS7 but header files says "do not invoke; not a valid initializer for this class"
-	public interface NSNotification : NSCoding, NSCopying {
+	interface NSNotification : NSCoding, NSCopying {
 		[Export ("name")]
 		// Null not allowed
 		string Name { get; }
@@ -9082,7 +9082,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSNotificationCenter {
+	interface NSNotificationCenter {
 		[Static][Export ("defaultCenter", ArgumentSemantic.Strong)]
 		NSNotificationCenter DefaultCenter { get; }
 	
@@ -9120,7 +9120,7 @@ namespace XamCore.Foundation
 	[Mac (10, 10)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
-	public interface NSDistributedLock
+	interface NSDistributedLock
 	{
 		[Static]
 		[Export ("lockWithPath:")]
@@ -9145,7 +9145,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSNotificationCenter))]
-	public interface NSDistributedNotificationCenter {
+	interface NSDistributedNotificationCenter {
 		[Static]
 		[Export ("defaultCenter")]
 		NSObject DefaultCenter { get; }
@@ -9181,7 +9181,7 @@ namespace XamCore.Foundation
 #endif
 	
 	[BaseType (typeof (NSObject))]
-	public interface NSNotificationQueue {
+	interface NSNotificationQueue {
 		[Static][IsThreadStatic]
 		[Export ("defaultQueue", ArgumentSemantic.Strong)]
 		NSNotificationQueue DefaultQueue { get; }
@@ -9208,13 +9208,13 @@ namespace XamCore.Foundation
 	}
 
 #if !XAMCORE_2_0
-	public delegate void NSNotificationHandler (NSNotification notification);
+	delegate void NSNotificationHandler (NSNotification notification);
 #endif
 
 	[BaseType (typeof (NSObject))]
 	// init returns NIL
 	[DisableDefaultCtor]
-	public partial interface NSValue : NSSecureCoding, NSCopying {
+	partial interface NSValue : NSSecureCoding, NSCopying {
 		[Export ("getValue:")]
 		void StoreValueAtAddress (IntPtr value);
 
@@ -9505,7 +9505,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSValue))]
 	// init returns NIL
 	[DisableDefaultCtor]
-	public interface NSNumber {
+	interface NSNumber {
 		[Export ("charValue")]
 		sbyte SByteValue { get; }
 	
@@ -9902,7 +9902,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSNumber))]
-	public interface NSDecimalNumber : NSSecureCoding {
+	interface NSDecimalNumber : NSSecureCoding {
 		[Export ("initWithMantissa:exponent:isNegative:")]
 		IntPtr Constructor (long mantissa, short exponent, bool isNegative);
 		
@@ -9994,7 +9994,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSThread {
+	interface NSThread {
 		[Static, Export ("currentThread", ArgumentSemantic.Strong)]
 		NSThread Current { get; }
 
@@ -10070,7 +10070,7 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface NSPort : NSCoding, NSCopying {
+	interface NSPort : NSCoding, NSCopying {
 		[Static, Export ("port")]
 		NSPort Create ();
 
@@ -10111,13 +10111,13 @@ namespace XamCore.Foundation
 
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
-	public interface NSPortDelegate {
+	interface NSPortDelegate {
 		[Export ("handlePortMessage:")]
 		void MessageReceived (NSPortMessage message);
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSPortMessage {
+	interface NSPortMessage {
 #if MONOMAC
 		[Export ("initWithSendPort:receivePort:components:")]
 		IntPtr Constructor (NSPort sendPort, NSPort recvPort, NSArray components);
@@ -10145,7 +10145,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSPort))]
-	public interface NSMachPort {
+	interface NSMachPort {
 		[DesignatedInitializer]
 		[Export ("initWithMachPort:")]
 		IntPtr Constructor (uint /* uint32_t */ machPort);
@@ -10186,13 +10186,13 @@ namespace XamCore.Foundation
 
 	[Model, BaseType (typeof (NSPortDelegate))]
 	[Protocol]
-	public interface NSMachPortDelegate {
+	interface NSMachPortDelegate {
 		[Export ("handleMachMessage:")]
 		void MachMessageReceived (IntPtr msgHeader);
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSProcessInfo {
+	interface NSProcessInfo {
 		[Export ("processInfo", ArgumentSemantic.Strong)][Static]
 		NSProcessInfo ProcessInfo { get; }
 
@@ -10315,7 +10315,7 @@ namespace XamCore.Foundation
 
 	[Since (7,0), Mavericks]
 	[BaseType (typeof (NSObject))]
-	public partial interface NSProgress {
+	partial interface NSProgress {
 	
 		[Static, Export ("currentProgress")]
 		NSProgress CurrentProgress { get; }
@@ -10486,11 +10486,11 @@ namespace XamCore.Foundation
 	
 	[BaseType (typeof (NSMutableData))]
 	[Since (4,0)]
-	public interface NSPurgeableData : NSSecureCoding, NSMutableCopying, NSDiscardableContent {
+	interface NSPurgeableData : NSSecureCoding, NSMutableCopying, NSDiscardableContent {
 	}
 
 	[Protocol]
-	public interface NSDiscardableContent {
+	interface NSDiscardableContent {
 		[Abstract]
 		[Export ("beginContentAccess")]
 		bool BeginContentAccess ();
@@ -10509,9 +10509,9 @@ namespace XamCore.Foundation
 	}
 
 #if !XAMCORE_2_0
-	public delegate void NSFileCoordinatorWorker (NSUrl newUrl);
+	delegate void NSFileCoordinatorWorker (NSUrl newUrl);
 #endif
-	public delegate void NSFileCoordinatorWorkerRW (NSUrl newReadingUrl, NSUrl newWritingUrl);
+	delegate void NSFileCoordinatorWorkerRW (NSUrl newReadingUrl, NSUrl newWritingUrl);
 
 	[Since (5,0)]
 	[BaseType (typeof (NSObject))]
@@ -10590,7 +10590,7 @@ namespace XamCore.Foundation
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public partial interface NSFileManager {
+	partial interface NSFileManager {
 		[Field("NSFileType")]
 		NSString NSFileType { get; }
 
@@ -10927,7 +10927,7 @@ namespace XamCore.Foundation
 	[BaseType(typeof(NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSFileManagerDelegate {
+	interface NSFileManagerDelegate {
 		[Export("fileManager:shouldCopyItemAtPath:toPath:")]
 		bool ShouldCopyItemAtPath(NSFileManager fm, NSString srcPath, NSString dstPath);
 
@@ -11148,7 +11148,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSFileWrapper : NSCoding {
+	interface NSFileWrapper : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithURL:options:error:")]
 		IntPtr Constructor (NSUrl url, NSFileWrapperReadingOptions options, out NSError outError);
@@ -11231,7 +11231,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSEnumerator))]
-	public interface NSDirectoryEnumerator {
+	interface NSDirectoryEnumerator {
 		[Export ("fileAttributes")]
 		NSDictionary FileAttributes { get; }
 
@@ -11313,13 +11313,13 @@ namespace XamCore.Foundation
 #endif
 	}
 
-	public delegate bool NSPredicateEvaluator (NSObject evaluatedObject, NSDictionary bindings);
+	delegate bool NSPredicateEvaluator (NSObject evaluatedObject, NSDictionary bindings);
 	
 	[BaseType (typeof (NSObject))]
 	[Since (4,0)]
 	// 'init' returns NIL
 	[DisableDefaultCtor]
-	public interface NSPredicate : NSSecureCoding, NSCopying {
+	interface NSPredicate : NSSecureCoding, NSCopying {
 		[Static]
 		[Internal]
 		[Export ("predicateWithFormat:argumentArray:")]
@@ -11355,21 +11355,21 @@ namespace XamCore.Foundation
 	}
 
 	[Category, BaseType (typeof (NSOrderedSet))]
-	public partial interface NSPredicateSupport_NSOrderedSet {
+	partial interface NSPredicateSupport_NSOrderedSet {
 		[Since (5,0)]
 		[Export ("filteredOrderedSetUsingPredicate:")]
 		NSOrderedSet FilterUsingPredicate (NSPredicate p);
 	}
 	
 	[Category, BaseType (typeof (NSMutableOrderedSet))]
-	public partial interface NSPredicateSupport_NSMutableOrderedSet {
+	partial interface NSPredicateSupport_NSMutableOrderedSet {
 		[Since (5,0)]
 		[Export ("filterUsingPredicate:")]
 		void FilterUsingPredicate (NSPredicate p);
 	}
 
 	[Category, BaseType (typeof (NSArray))]
-	public partial interface NSPredicateSupport_NSArray {
+	partial interface NSPredicateSupport_NSArray {
 		[Export ("filteredArrayUsingPredicate:")]
 		NSArray FilterUsingPredicate (NSArray array);
 	}
@@ -11377,26 +11377,26 @@ namespace XamCore.Foundation
 #pragma warning disable 618
 	[Category, BaseType (typeof (NSMutableArray))]
 #pragma warning restore 618
-	public partial interface NSPredicateSupport_NSMutableArray {
+	partial interface NSPredicateSupport_NSMutableArray {
 		[Export ("filterUsingPredicate:")]
 		void FilterUsingPredicate (NSPredicate predicate);
 	}
 	
 	[Category, BaseType (typeof (NSSet))]
-	public partial interface NSPredicateSupport_NSSet {
+	partial interface NSPredicateSupport_NSSet {
 		[Export ("filteredSetUsingPredicate:")]
 		NSSet FilterUsingPredicate (NSPredicate predicate);
 	}
 
 	[Category, BaseType (typeof (NSMutableSet))]
-	public partial interface NSPredicateSupport_NSMutableSet {
+	partial interface NSPredicateSupport_NSMutableSet {
 		[Export ("filterUsingPredicate:")]
 		void FilterUsingPredicate (NSPredicate predicate);
 	}
 	
 #if MONOMAC
 	[BaseType (typeof (NSObject), Name="NSURLDownload")]
-	public interface NSUrlDownload {
+	interface NSUrlDownload {
 		[Static, Export ("canResumeDownloadDecodedWithEncodingMIMEType:")]
 		bool CanResumeDownloadDecodedWithEncodingMimeType (string mimeType);
 
@@ -11425,7 +11425,7 @@ namespace XamCore.Foundation
     	[BaseType (typeof (NSObject))]
     	[Model]
 	[Protocol (Name = "NSURLDownloadDelegate")]
-	public interface NSUrlDownloadDelegate {
+	interface NSUrlDownloadDelegate {
 		[Export ("downloadDidBegin:")]
 		void DownloadBegan (NSUrlDownload download);
 
@@ -11601,7 +11601,7 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
-	public interface NSPropertyListSerialization {
+	interface NSPropertyListSerialization {
 		[Static, Export ("dataWithPropertyList:format:options:error:")]
 		NSData DataWithPropertyList (NSObject plist, NSPropertyListFormat format,
 			NSPropertyListWriteOptions options, out NSError error);
@@ -11623,12 +11623,12 @@ namespace XamCore.Foundation
 	}
 
 #if XAMCORE_2_0 || !MONOMAC
-	public interface INSExtensionRequestHandling { }
+	interface INSExtensionRequestHandling { }
 
 	[iOS (8,0)][Mac (10,10)] // Not defined in 32-bit
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public interface NSExtensionRequestHandling {
+	interface NSExtensionRequestHandling {
 		[Abstract]
 		[Mac (10,10, onlyOn64 : true)] 
 		// @required - (void)beginRequestWithExtensionContext:(NSExtensionContext *)context;
@@ -11639,7 +11639,7 @@ namespace XamCore.Foundation
 	[iOS (8,0)][Mac (10,10, onlyOn64:true)] // Not defined in 32-bit
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public interface NSExtensionRequestHandling {
+	interface NSExtensionRequestHandling {
 		[Abstract]
 		// @required - (void)beginRequestWithExtensionContext:(NSExtensionContext *)context;
 		[Export ("beginRequestWithExtensionContext:")]
@@ -11648,7 +11648,7 @@ namespace XamCore.Foundation
 #endif
 
 	[Protocol]
-	public interface NSLocking {
+	interface NSLocking {
 
 		[Abstract]
 		[Export ("lock")]
@@ -11662,7 +11662,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // An uncaught exception was raised: *** -range cannot be sent to an abstract object of class NSTextCheckingResult: Create a concrete instance!
 	[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
-	public interface NSTextCheckingResult : NSSecureCoding, NSCopying {
+	interface NSTextCheckingResult : NSSecureCoding, NSCopying {
 		[Export ("resultType")]
 		NSTextCheckingType ResultType { get;  }
 
@@ -11811,7 +11811,7 @@ namespace XamCore.Foundation
 	}
 
 	[StrongDictionary ("NSTextChecking")]
-	public interface NSTextCheckingTransitComponents {
+	interface NSTextCheckingTransitComponents {
 		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7)]
 		string Airline { get; }
 
@@ -11820,7 +11820,7 @@ namespace XamCore.Foundation
 	}
 
 	[StrongDictionary ("NSTextChecking")]
-	public interface NSTextCheckingAddressComponents {
+	interface NSTextCheckingAddressComponents {
 		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
 		string Name { get; }
 
@@ -11851,7 +11851,7 @@ namespace XamCore.Foundation
 	}
 
 	[Static]
-	public interface NSTextChecking {
+	interface NSTextChecking {
 		[Field ("NSTextCheckingNameKey")]
 		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
 		NSString NameKey { get; }
@@ -11977,24 +11977,24 @@ namespace XamCore.Foundation
 
 // Not yet, the IntPtr[] argument isn't handled correctly by the generator (it tries to convert to NSArray, while the native method expects a C array).
 //	[Protocol]
-//	public interface NSFastEnumeration {
+//	interface NSFastEnumeration {
 //		[Abstract]
 //		[Export ("countByEnumeratingWithState:objects:count:")]
 //		nuint Enumerate (ref NSFastEnumerationState state, IntPtr[] objects, nuint count);
 //	}
 
 	// Placeholer, just so we can start flagging things
-	public interface INSFastEnumeration {}
+	interface INSFastEnumeration {}
 	
 #if MONOMAC
-	public partial interface NSBundle {
+	partial interface NSBundle {
 		// - (NSImage *)imageForResource:(NSString *)name NS_AVAILABLE_MAC(10_7);
 		[Lion, Export ("imageForResource:")]
 		NSImage ImageForResource (string name);
 	}
 #endif
 
-	public partial interface NSAttributedString {
+	partial interface NSAttributedString {
 
 #if MONOMAC
 		[Lion, Field ("NSTextLayoutSectionOrientation", "AppKit")]
@@ -12181,7 +12181,7 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public partial interface NSHost {
+	partial interface NSHost {
 
 		[Static, Internal, Export ("currentHost")]
 		NSHost _Current { get;}
@@ -12231,7 +12231,7 @@ namespace XamCore.Foundation
 
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
-	public partial interface NSScriptCommand : NSCoding {
+	partial interface NSScriptCommand : NSCoding {
 
 		[Internal]
 		[Export ("initWithCommandDescription:")]
@@ -12253,14 +12253,14 @@ namespace XamCore.Foundation
 	}
 
 	[StrongDictionary ("NSScriptCommandArgumentDescriptionKeys")]
-	public partial interface NSScriptCommandArgumentDescription {
+	partial interface NSScriptCommandArgumentDescription {
 		string AppleEventCode { get; set; }
 		string Type { get; set;}
 		string Optional { get; set; }
 	}
 
 	[StrongDictionary ("NSScriptCommandDescriptionDictionaryKeys")]
-	public partial interface NSScriptCommandDescriptionDictionary {
+	partial interface NSScriptCommandDescriptionDictionary {
 		string CommandClass { get; set; } 
 		string AppleEventCode { get; set; } 
 		string AppleEventClassCode { get; set; }
@@ -12271,7 +12271,7 @@ namespace XamCore.Foundation
 
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
-	public partial interface NSScriptCommandDescription : NSCoding {
+	partial interface NSScriptCommandDescription : NSCoding {
 
 		[Internal]
 		[Export ("initWithSuiteName:commandName:dictionary:")]
@@ -12322,7 +12322,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSAffineTransform : NSSecureCoding, NSCopying {
+	interface NSAffineTransform : NSSecureCoding, NSCopying {
 		[Export ("initWithTransform:")]
 		IntPtr Constructor (NSAffineTransform transform);
 
@@ -12371,7 +12371,7 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface NSConnection {
+	interface NSConnection {
 		[Static, Export ("connectionWithReceivePort:sendPort:")]
 		NSConnection Create ([NullAllowed] NSPort receivePort, [NullAllowed] NSPort sendPort);
 
@@ -12475,7 +12475,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSConnectionDelegate {
+	interface NSConnectionDelegate {
 		[Export ("authenticateComponents:withData:")]
 		bool AuthenticateComponents (NSArray components, NSData authenticationData);
 
@@ -12497,7 +12497,7 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface NSDistantObjectRequest {
+	interface NSDistantObjectRequest {
 		[Export ("connection")]
 		NSConnection Connection { get; }
 
@@ -12513,7 +12513,7 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface NSPortNameServer {
+	interface NSPortNameServer {
 		[Static, Export ("systemDefaultPortNameServer")]
 		NSPortNameServer SystemDefault { get; }
 
@@ -12537,7 +12537,7 @@ namespace XamCore.Foundation
 	//}
 
 	[BaseType (typeof (NSCharacterSet))]
-	public interface NSMutableCharacterSet {
+	interface NSMutableCharacterSet {
 		[Export ("removeCharactersInRange:")]
 		void RemoveCharacters (NSRange aRange);
 
@@ -12559,7 +12559,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSAppleEventDescriptor : NSSecureCoding, NSCopying {
+	interface NSAppleEventDescriptor : NSSecureCoding, NSCopying {
 		[Static]
 		[Export ("nullDescriptor")]
 		NSAppleEventDescriptor NullDescriptor { get; }
@@ -12772,7 +12772,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSAppleEventManager {
+	interface NSAppleEventManager {
 		[Static]
 		[Export ("sharedAppleEventManager")]
 		NSAppleEventManager SharedAppleEventManager { get; }
@@ -12812,7 +12812,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface NSTask {
+	interface NSTask {
 		[Export ("launch")]
 		void Launch ();
 
@@ -12876,7 +12876,7 @@ namespace XamCore.Foundation
 
 	[MountainLion]
 	[BaseType (typeof (NSObject))]
-	public interface NSUserNotification : NSCoding, NSCopying {
+	interface NSUserNotification : NSCoding, NSCopying {
 		[Export ("title", ArgumentSemantic.Copy)]
 		string Title { get; set; }
 		
@@ -12956,7 +12956,7 @@ namespace XamCore.Foundation
 
 	[Mac (10,10)]
 	[BaseType (typeof(NSObject))]
-	public interface NSUserNotificationAction : NSCopying
+	interface NSUserNotificationAction : NSCopying
 	{
 		[Static]
 		[Export ("actionWithIdentifier:title:")]
@@ -12974,7 +12974,7 @@ namespace XamCore.Foundation
 	           Delegates=new string [] {"WeakDelegate"},
 	Events=new Type [] { typeof (NSUserNotificationCenterDelegate) })]
 	[DisableDefaultCtor] // crash with: NSUserNotificationCenter designitated initializer is _centerForBundleIdentifier
-	public interface NSUserNotificationCenter 
+	interface NSUserNotificationCenter 
 	{
 		[Export ("defaultUserNotificationCenter")][Static]
 		NSUserNotificationCenter DefaultUserNotificationCenter { get; }
@@ -13012,7 +13012,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface NSUserNotificationCenterDelegate 
+	interface NSUserNotificationCenterDelegate 
 	{
 		[Export ("userNotificationCenter:didDeliverNotification:"), EventArgs ("UNCDidDeliverNotification")]
 		void DidDeliverNotification (NSUserNotificationCenter center, NSUserNotification notification);

--- a/src/gamecontroller.cs
+++ b/src/gamecontroller.cs
@@ -22,7 +22,7 @@ namespace XamCore.GameController {
 	[Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // The GCControllerElement class is never instantiated directly.
-	public partial interface GCControllerElement {
+	partial interface GCControllerElement {
 
 		// NOTE: ArgumentSemantic.Weak if ARC, ArgumentSemantic.Assign otherwise;
 		// currently MonoTouch is not ARC, neither is Xammac, so go with assign.
@@ -33,13 +33,13 @@ namespace XamCore.GameController {
 		bool IsAnalog { [Bind ("isAnalog")] get; }
 	}
 
-	public delegate void GCControllerAxisValueChangedHandler (GCControllerAxisInput axis, float /* float, not CGFloat */ value);
+	delegate void GCControllerAxisValueChangedHandler (GCControllerAxisInput axis, float /* float, not CGFloat */ value);
 
 	[Since (7,0)]
 	[Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (GCControllerElement))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
-	public partial interface GCControllerAxisInput {
+	partial interface GCControllerAxisInput {
 
 		[Export ("valueChangedHandler", ArgumentSemantic.Copy)]
 		GCControllerAxisValueChangedHandler ValueChangedHandler { get; set; }
@@ -48,12 +48,12 @@ namespace XamCore.GameController {
 		float Value { get; } /* float, not CGFloat */
 	}
 
-	public delegate void GCControllerButtonValueChanged (GCControllerButtonInput button, float /* float, not CGFloat */ buttonValue, bool pressed);
+	delegate void GCControllerButtonValueChanged (GCControllerButtonInput button, float /* float, not CGFloat */ buttonValue, bool pressed);
 
 	[Since (7,0), Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (GCControllerElement))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
-	public partial interface GCControllerButtonInput {
+	partial interface GCControllerButtonInput {
 
 		[Export ("setValueChangedHandler:", ArgumentSemantic.Copy)]
 		void SetValueChangedHandler (GCControllerButtonValueChanged handler);
@@ -69,13 +69,13 @@ namespace XamCore.GameController {
 		void SetPressedChangedHandler (GCControllerButtonValueChanged handler);
 	}
 
-	public delegate void GCControllerDirectionPadValueChangedHandler (GCControllerDirectionPad dpad, float /* float, not CGFloat */ xValue, float /* float, not CGFloat */ yValue);
+	delegate void GCControllerDirectionPadValueChangedHandler (GCControllerDirectionPad dpad, float /* float, not CGFloat */ xValue, float /* float, not CGFloat */ yValue);
 
 	[Since (7,0)]
 	[Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (GCControllerElement))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
-	public partial interface GCControllerDirectionPad {
+	partial interface GCControllerDirectionPad {
 
 		[Export ("valueChangedHandler", ArgumentSemantic.Copy)]
 		GCControllerDirectionPadValueChangedHandler ValueChangedHandler { get; set; }
@@ -99,13 +99,13 @@ namespace XamCore.GameController {
 		GCControllerButtonInput Right { get; }
 	}
 
-	public delegate void GCGamepadValueChangedHandler (GCGamepad gamepad, GCControllerElement element);
+	delegate void GCGamepadValueChangedHandler (GCGamepad gamepad, GCControllerElement element);
 
 	[Since (7,0)]
 	[Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
-	public partial interface GCGamepad {
+	partial interface GCGamepad {
 
 		[Export ("controller", ArgumentSemantic.Assign)]
 		GCController Controller { get; }
@@ -142,7 +142,7 @@ namespace XamCore.GameController {
 	[Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (GCGamepad))]
 	[DisableDefaultCtor]
-	public partial interface GCGamepadSnapshot {
+	partial interface GCGamepadSnapshot {
 
 		[Export ("snapshotData", ArgumentSemantic.Copy)]
 		NSData SnapshotData { get; set; }
@@ -154,13 +154,13 @@ namespace XamCore.GameController {
 		IntPtr Constructor (GCController controller, NSData data);
 	}
 
-	public delegate void GCExtendedGamepadValueChangedHandler (GCExtendedGamepad gamepad, GCControllerElement element);
+	delegate void GCExtendedGamepadValueChangedHandler (GCExtendedGamepad gamepad, GCControllerElement element);
 
 	[Since (7,0)]
 	[Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
-	public partial interface GCExtendedGamepad {
+	partial interface GCExtendedGamepad {
 
 		[Export ("controller", ArgumentSemantic.Assign)]
 		GCController Controller { get; }
@@ -209,7 +209,7 @@ namespace XamCore.GameController {
 	[Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (GCExtendedGamepad))]
 	[DisableDefaultCtor]
-	public partial interface GCExtendedGamepadSnapshot {
+	partial interface GCExtendedGamepadSnapshot {
 
 		[Export ("snapshotData", ArgumentSemantic.Copy)]
 		NSData SnapshotData { get; set; }
@@ -222,12 +222,12 @@ namespace XamCore.GameController {
 	}
 
 #if !XAMCORE_2_0
-	public delegate void GCControllerPausedHandler (GCController controller);
+	delegate void GCControllerPausedHandler (GCController controller);
 #endif
 
 	[Since (7,0), Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
-	public partial interface GCController {
+	partial interface GCController {
 
 		[Export ("controllerPausedHandler", ArgumentSemantic.Copy)]
 #if XAMCORE_2_0
@@ -288,7 +288,7 @@ namespace XamCore.GameController {
 	[iOS (8,0), Mac (10,10, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // access thru GCController.Motion - returns a nil Handle
-	public partial interface GCMotion {
+	partial interface GCMotion {
 
 		[Export ("controller", ArgumentSemantic.Assign)]
 		GCController Controller { get; }
@@ -314,14 +314,14 @@ namespace XamCore.GameController {
 	[NoMac]
 	[iOS (10,0)]
 	[TV (9,0)]
-	public delegate void GCMicroGamepadValueChangedHandler (GCMicroGamepad gamepad, GCControllerElement element);
+	delegate void GCMicroGamepadValueChangedHandler (GCMicroGamepad gamepad, GCControllerElement element);
 
 	[NoMac]
 	[iOS (10,0)]
 	[TV (9,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface GCMicroGamepad {
+	interface GCMicroGamepad {
 		[Export ("controller", ArgumentSemantic.Assign)]
 		GCController Controller { get; }
 
@@ -351,7 +351,7 @@ namespace XamCore.GameController {
 	[iOS (10,0)]
 	[TV (9,0)]
 	[BaseType (typeof (GCMicroGamepad))]
-	public interface GCMicroGamepadSnapshot {
+	interface GCMicroGamepadSnapshot {
 		[Export ("snapshotData", ArgumentSemantic.Copy)]
 		NSData SnapshotData { get; set; }
 

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -42,12 +42,12 @@ namespace XamCore.GameKit {
 
 #if MONOMAC
 	delegate void GKImageLoadedHandler  (NSImage image, NSError error);
-	public delegate void GKPlayerPhotoLoaded (NSImage photo, NSError error);
+	delegate void GKPlayerPhotoLoaded (NSImage photo, NSError error);
 	delegate void GKChallengeComposeHandler (NSViewController composeController, bool issuedChallenge, string [] sentPlayerIDs);
 #else
 	delegate void GKLeaderboardSetsHandler (GKLeaderboardSet [] leaderboardSets, NSError error);
 	delegate void GKImageLoadedHandler  (UIImage image, NSError error);
-	public delegate void GKPlayerPhotoLoaded (UIImage photo, NSError error);
+	delegate void GKPlayerPhotoLoaded (UIImage photo, NSError error);
 	delegate void GKChallengeComposeHandler (UIViewController composeController, bool issuedChallenge, string [] sentPlayerIDs);
 #endif
 
@@ -1623,7 +1623,7 @@ namespace XamCore.GameKit {
 	[NoWatch]
 	[Since (5,0)]
 	[BaseType(typeof(NSObject))]
-	public partial interface GKNotificationBanner {
+	partial interface GKNotificationBanner {
 		[Static, Export ("showBannerWithTitle:message:completionHandler:")]
 		[Async]
 		void Show ([NullAllowed] string title, [NullAllowed] string message, [NullAllowed] NSAction onCompleted);

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1454,6 +1454,7 @@ public class NamespaceManager
 			Get ("OpenGL"),
 			Get ("QTKit"),
 			Get ("AppKit"),
+			Get ("CloudKit"),
 #else
 #if !WATCH && !TVOS
 			Get ("CoreMotion"),

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -60,21 +60,21 @@ namespace XamCore.HealthKit {
 		Paused,
 	}
 
-	public delegate void HKAnchoredObjectResultHandler2 (HKAnchoredObjectQuery query, HKSample[] results, nuint newAnchor, NSError error);
+	delegate void HKAnchoredObjectResultHandler2 (HKAnchoredObjectQuery query, HKSample[] results, nuint newAnchor, NSError error);
 #if XAMCORE_2_0
 	[Obsolete ("Use HKAnchoredObjectResultHandler2 instead")]
-	public delegate void HKAnchoredObjectResultHandler (HKAnchoredObjectQuery query, HKSampleType[] results, nuint newAnchor, NSError error);
+	delegate void HKAnchoredObjectResultHandler (HKAnchoredObjectQuery query, HKSampleType[] results, nuint newAnchor, NSError error);
 #else
-	public delegate void HKAnchoredObjectResultHandler (HKAnchoredObjectQuery query, NSObject[] results, nuint newAnchor, NSError error);
+	delegate void HKAnchoredObjectResultHandler (HKAnchoredObjectQuery query, NSObject[] results, nuint newAnchor, NSError error);
 #endif
 
-	public delegate void HKAnchoredObjectUpdateHandler (HKAnchoredObjectQuery query, HKSample[] addedObjects, HKDeletedObject[] deletedObjects, HKQueryAnchor newAnchor, NSError error);
+	delegate void HKAnchoredObjectUpdateHandler (HKAnchoredObjectQuery query, HKSample[] addedObjects, HKDeletedObject[] deletedObjects, HKQueryAnchor newAnchor, NSError error);
 
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (HKQuery))]
 	[DisableDefaultCtor] // NSInvalidArgumentException: The -init method is not available on HKAnchoredObjectQuery
-	public interface HKAnchoredObjectQuery {
+	interface HKAnchoredObjectQuery {
 
 		[NoWatch]
 #if XAMCORE_2_0
@@ -102,7 +102,7 @@ namespace XamCore.HealthKit {
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[Static]
-	public interface HKPredicateKeyPath {
+	interface HKPredicateKeyPath {
 		[Field ("HKPredicateKeyPathCategoryValue")]
 		NSString CategoryValue { get; }
 
@@ -179,7 +179,7 @@ namespace XamCore.HealthKit {
 	[iOS (10,0)]
 	[Static]
 	[Internal]
-	public interface HKDetailedCdaErrorKeys {
+	interface HKDetailedCdaErrorKeys {
 		[Field ("HKDetailedCDAValidationErrorKey")]
 		NSString ValidationErrorKey { get; }
 	}
@@ -188,7 +188,7 @@ namespace XamCore.HealthKit {
 	[iOS (10,0)]
 	[StrongDictionary ("HKDetailedCdaErrorKeys")]
 	[Internal]
-	public interface HKDetailedCdaErrors {
+	interface HKDetailedCdaErrors {
 		NSString ValidationError { get; }
 	}
 
@@ -196,7 +196,7 @@ namespace XamCore.HealthKit {
 	[iOS (8,0)]
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;
 	[BaseType (typeof (HKSample))]
-	public interface HKCategorySample {
+	interface HKCategorySample {
 		[Export ("categoryType")]
 		HKCategoryType CategoryType { get; }
 
@@ -276,7 +276,7 @@ namespace XamCore.HealthKit {
 	[iOS (8,0)]
 	[BaseType (typeof (HKSample))]
 	[DisableDefaultCtor] // NSInvalidArgumentException: The -init method is not available on HKCorrelation
-	public interface HKCorrelation : NSSecureCoding {
+	interface HKCorrelation : NSSecureCoding {
 
 		[Export ("objects")]
 		NSSet Objects { get; }
@@ -303,13 +303,13 @@ namespace XamCore.HealthKit {
 		HKCorrelation Create (HKCorrelationType correlationType, NSDate startDate, NSDate endDate, NSSet<HKSample> objects, [NullAllowed] HKDevice device, [NullAllowed] NSDictionary<NSString,NSObject> metadata);
 	}
 
-	public delegate void HKCorrelationQueryResultHandler (HKCorrelationQuery query, HKCorrelation[] correlations, NSError error);
+	delegate void HKCorrelationQueryResultHandler (HKCorrelationQuery query, HKCorrelation[] correlations, NSError error);
 
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (HKQuery))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKCorrelationQuery
-	public interface HKCorrelationQuery {
+	interface HKCorrelationQuery {
 		[Export ("initWithType:predicate:samplePredicates:completion:")]
 		IntPtr Constructor (HKCorrelationType correlationType, [NullAllowed] NSPredicate predicate, [NullAllowed] NSDictionary samplePredicates, HKCorrelationQueryResultHandler completion);
 
@@ -324,14 +324,14 @@ namespace XamCore.HealthKit {
 	[iOS (8,0)]
 	[BaseType (typeof (HKSampleType))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKCorrelationType
-	public interface HKCorrelationType {
+	interface HKCorrelationType {
 
 	}
 
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public interface HKHealthStore {
+	interface HKHealthStore {
 		// FIXME NS_EXTENSION_UNAVAILABLE("Not available to extensions") ;
 		[Static]
 		[Export ("isHealthDataAvailable")]
@@ -474,12 +474,12 @@ namespace XamCore.HealthKit {
 		NSString UserPreferencesDidChangeNotification { get; }
 	}
 
-	public delegate void HKStoreSampleAddedCallback (bool success, NSError error);
+	delegate void HKStoreSampleAddedCallback (bool success, NSError error);
 	
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public interface HKBiologicalSexObject : NSCopying, NSSecureCoding {
+	interface HKBiologicalSexObject : NSCopying, NSSecureCoding {
 		[Export ("biologicalSex")]
 		HKBiologicalSex BiologicalSex { get; }
 	}
@@ -487,13 +487,13 @@ namespace XamCore.HealthKit {
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public interface HKBloodTypeObject : NSCopying, NSSecureCoding {
+	interface HKBloodTypeObject : NSCopying, NSSecureCoding {
 		[Export ("bloodType")]
 		HKBloodType BloodType { get; }
 	}
 
 	[StrongDictionary ("HKMetadataKey")]
-	public interface HKMetadata {
+	interface HKMetadata {
 		[Export ("FoodType")]
 		string FoodType { get; set; }
 
@@ -587,7 +587,7 @@ namespace XamCore.HealthKit {
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[Static]
-	public interface HKMetadataKey {
+	interface HKMetadataKey {
 		[Field ("HKMetadataKeyDeviceSerialNumber")]
 		NSString DeviceSerialNumber { get; }
 
@@ -685,7 +685,7 @@ namespace XamCore.HealthKit {
 #endif
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;
 	[BaseType (typeof (NSObject))]
-	public interface HKObject : NSSecureCoding {
+	interface HKObject : NSSecureCoding {
 		[Export ("UUID", ArgumentSemantic.Strong)]
 		NSUuid Uuid { get; }
 
@@ -715,7 +715,7 @@ namespace XamCore.HealthKit {
 #endif
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;
 	[BaseType (typeof (NSObject))]
-	public interface HKObjectType : NSSecureCoding, NSCopying {
+	interface HKObjectType : NSSecureCoding, NSCopying {
 		// These identifiers come from HKTypeIdentifiers
 		[Export ("identifier")]
 		NSString Identifier { get; }
@@ -785,7 +785,7 @@ namespace XamCore.HealthKit {
 	[iOS (8,0)]
 	[BaseType (typeof (HKObjectType))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKCharacteristicType
-	public interface HKCharacteristicType {
+	interface HKCharacteristicType {
 
 	}
 
@@ -796,7 +796,7 @@ namespace XamCore.HealthKit {
 #if XAMCORE_2_0
 	[Abstract] // The HKSampleType class is an abstract subclass of the HKObjectType class, used to represent data samples. Never instantiate an HKSampleType object directly. Instead, you should always work with one of its concrete subclasses [...]
 #endif
-	public interface HKSampleType {
+	interface HKSampleType {
 
 	}
 
@@ -804,7 +804,7 @@ namespace XamCore.HealthKit {
 	[iOS (8,0)]
 	[BaseType (typeof (HKSampleType))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKCategoryType
-	public interface HKCategoryType {
+	interface HKCategoryType {
 
 	}
 
@@ -812,7 +812,7 @@ namespace XamCore.HealthKit {
 	[iOS (10,0)]
 	[BaseType (typeof (HKSampleType))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKDocumentType
-	public interface HKDocumentType {
+	interface HKDocumentType {
 
 	}
 
@@ -820,7 +820,7 @@ namespace XamCore.HealthKit {
 	[iOS (8,0)]
 	[BaseType (typeof (HKSampleType))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKQuantityType
-	public interface HKQuantityType {
+	interface HKQuantityType {
 		[Export ("aggregationStyle")]
 		HKQuantityAggregationStyle AggregationStyle { get; }
 
@@ -829,10 +829,10 @@ namespace XamCore.HealthKit {
 	}
 
 #if XAMCORE_2_0
-	public delegate void HKObserverQueryUpdateHandler (HKObserverQuery query, [BlockCallback] Action completion, NSError error);
+	delegate void HKObserverQueryUpdateHandler (HKObserverQuery query, [BlockCallback] Action completion, NSError error);
 #else
-	public delegate void HKObserverQueryCompletionHandler ();
-	public delegate void HKObserverQueryUpdateHandler (HKObserverQuery query, [BlockCallback] HKObserverQueryCompletionHandler completion, NSError error);
+	delegate void HKObserverQueryCompletionHandler ();
+	delegate void HKObserverQueryUpdateHandler (HKObserverQuery query, [BlockCallback] HKObserverQueryCompletionHandler completion, NSError error);
 #endif
 
 	[Watch (2,0)]
@@ -842,7 +842,7 @@ namespace XamCore.HealthKit {
 	[Abstract]
 #endif
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKObserverQuery
-	public interface HKObserverQuery {
+	interface HKObserverQuery {
 		[Export ("initWithSampleType:predicate:updateHandler:")]
 		IntPtr Constructor (HKSampleType sampleType, [NullAllowed] NSPredicate predicate, HKObserverQueryUpdateHandler updateHandler);
 	}
@@ -851,7 +851,7 @@ namespace XamCore.HealthKit {
 	[iOS (8,0)]
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;
 	[BaseType (typeof (NSObject))]
-	public interface HKQuantity : NSSecureCoding, NSCopying {
+	interface HKQuantity : NSSecureCoding, NSCopying {
 		[Static]
 		[Export ("quantityWithUnit:doubleValue:")]
 		HKQuantity FromQuantity (HKUnit unit, double value);
@@ -870,7 +870,7 @@ namespace XamCore.HealthKit {
 	[iOS (8,0)]
 	[BaseType (typeof (HKSample))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKQuantitySample
-	public interface HKQuantitySample {
+	interface HKQuantitySample {
 		[Export ("quantityType", ArgumentSemantic.Strong)]
 		HKQuantityType QuantityType { get; }
 
@@ -900,7 +900,7 @@ namespace XamCore.HealthKit {
 	[iOS (8,0)]
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;
 	[BaseType (typeof (NSObject))]
-	public interface HKQuery {
+	interface HKQuery {
 		[iOS (9,3), Watch (2,2)]
 		[NullAllowed, Export ("objectType", ArgumentSemantic.Strong)]
 		HKObjectType ObjectType { get; }
@@ -1024,7 +1024,7 @@ namespace XamCore.HealthKit {
 	[Abstract]
 #endif
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKSample
-	public interface HKSample {
+	interface HKSample {
 
 		[Export ("sampleType", ArgumentSemantic.Strong)]
 		HKSampleType SampleType { get; }
@@ -1045,13 +1045,13 @@ namespace XamCore.HealthKit {
 
 	}
 
-	public delegate void HKSampleQueryResultsHandler (HKSampleQuery query, HKSample [] results, NSError error);
+	delegate void HKSampleQueryResultsHandler (HKSampleQuery query, HKSample [] results, NSError error);
 
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (HKQuery))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKSampleQuery
-	public interface HKSampleQuery {
+	interface HKSampleQuery {
 
 		[Export ("limit")]
 		nuint Limit { get; }
@@ -1067,7 +1067,7 @@ namespace XamCore.HealthKit {
 	[iOS (8,0)]
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;
 	[BaseType (typeof (NSObject))]
-	public interface HKSource : NSSecureCoding, NSCopying {
+	interface HKSource : NSSecureCoding, NSCopying {
 		[Export ("name")]
 		string Name { get; }
 
@@ -1079,13 +1079,13 @@ namespace XamCore.HealthKit {
 		HKSource GetDefaultSource { get; }
 	}
 
-	public delegate void HKSourceQueryCompletionHandler (HKSourceQuery query, NSSet sources, NSError error);
+	delegate void HKSourceQueryCompletionHandler (HKSourceQuery query, NSSet sources, NSError error);
 
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (HKQuery))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKSourceQuery
-	public interface HKSourceQuery {
+	interface HKSourceQuery {
 
 		[Export ("initWithSampleType:samplePredicate:completionHandler:")]
 		IntPtr Constructor (HKSampleType sampleType, [NullAllowed] NSPredicate objectPredicate, HKSourceQueryCompletionHandler completionHandler);
@@ -1095,7 +1095,7 @@ namespace XamCore.HealthKit {
 	[iOS (8,0)]
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;
 	[BaseType (typeof (NSObject))]
-	public interface HKStatistics : NSSecureCoding, NSCopying {
+	interface HKStatistics : NSSecureCoding, NSCopying {
 		[Export ("quantityType", ArgumentSemantic.Strong)]
 		HKQuantityType QuantityType { get; }
 
@@ -1133,13 +1133,13 @@ namespace XamCore.HealthKit {
 		HKQuantity SumQuantity ();
 	}
 
-	public delegate void HKStatisticsCollectionEnumerator (HKStatistics result, bool stop);
+	delegate void HKStatisticsCollectionEnumerator (HKStatistics result, bool stop);
 
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;
 	[BaseType (typeof (NSObject))]
-	public interface HKStatisticsCollection {
+	interface HKStatisticsCollection {
 
 		[Export ("statisticsForDate:")]
 		HKStatistics GetStatistics (NSDate date);
@@ -1154,15 +1154,15 @@ namespace XamCore.HealthKit {
 		NSSet Sources { get; }
 	}
 
-	public delegate void HKStatisticsCollectionQueryInitialResultsHandler (HKStatisticsCollectionQuery query, HKStatisticsCollection result, NSError error);
-	public delegate void HKStatisticsCollectionQueryStatisticsUpdateHandler (HKStatisticsCollectionQuery query, HKStatistics statistics, HKStatisticsCollection collection, NSError error);
+	delegate void HKStatisticsCollectionQueryInitialResultsHandler (HKStatisticsCollectionQuery query, HKStatisticsCollection result, NSError error);
+	delegate void HKStatisticsCollectionQueryStatisticsUpdateHandler (HKStatisticsCollectionQuery query, HKStatistics statistics, HKStatisticsCollection collection, NSError error);
 
 
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (HKQuery))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKStatisticsCollectionQuery
-	public interface HKStatisticsCollectionQuery {
+	interface HKStatisticsCollectionQuery {
 
 		[Export ("anchorDate", ArgumentSemantic.Strong)]
 		NSDate AnchorDate { get; }
@@ -1183,13 +1183,13 @@ namespace XamCore.HealthKit {
 		IntPtr Constructor (HKQuantityType quantityType, [NullAllowed] NSPredicate quantitySamplePredicate, HKStatisticsOptions options, NSDate anchorDate, NSDateComponents intervalComponents);
 	}
 
-	public delegate void HKStatisticsQueryHandler (HKStatisticsQuery query, HKStatistics result, NSError error);
+	delegate void HKStatisticsQueryHandler (HKStatisticsQuery query, HKStatistics result, NSError error);
 
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (HKQuery))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKStatisticsQuery
-	public interface HKStatisticsQuery {
+	interface HKStatisticsQuery {
 
 		[Export ("initWithQuantityType:quantitySamplePredicate:options:completionHandler:")]
 		IntPtr Constructor (HKQuantityType quantityType, [NullAllowed] NSPredicate quantitySamplePredicate, HKStatisticsOptions options, HKStatisticsQueryHandler handler);
@@ -1198,7 +1198,7 @@ namespace XamCore.HealthKit {
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[Static]
-	public interface HKQuantityTypeIdentifierKey {
+	interface HKQuantityTypeIdentifierKey {
 
 		[Field ("HKQuantityTypeIdentifierBodyMassIndex")]
 		NSString BodyMassIndex { get; }
@@ -1436,7 +1436,7 @@ namespace XamCore.HealthKit {
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[Static]
-	public interface HKCorrelationTypeKey {
+	interface HKCorrelationTypeKey {
 		[Field ("HKCorrelationTypeIdentifierBloodPressure")]
 		NSString IdentifierBloodPressure { get; }
 		
@@ -1449,7 +1449,7 @@ namespace XamCore.HealthKit {
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[Static]
-	public interface HKCategoryTypeIdentifierKey
+	interface HKCategoryTypeIdentifierKey
 	{
 		/**** HKCategoryType Identifiers ****/
 
@@ -1490,7 +1490,7 @@ namespace XamCore.HealthKit {
 	[Watch (2,0)]
 	[iOS (8,0)]
 	[Static]
-	public interface HKCharacteristicTypeIdentifierKey
+	interface HKCharacteristicTypeIdentifierKey
 	{
 		/**** HKCharacteristicType Identifiers ****/
 
@@ -1518,7 +1518,7 @@ namespace XamCore.HealthKit {
 	[iOS (8,0)]
 	[DisableDefaultCtor] // - (instancetype)init NS_UNAVAILABLE;
 	[BaseType (typeof (NSObject))]
-	public interface HKUnit : NSCopying, NSSecureCoding {
+	interface HKUnit : NSCopying, NSSecureCoding {
 
 		[Export ("unitString")]
 		string UnitString { get; }
@@ -1757,7 +1757,7 @@ namespace XamCore.HealthKit {
 	[iOS (8,0)]
 	[BaseType (typeof (HKSample))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKWorkout
-	public interface HKWorkout {
+	interface HKWorkout {
 		[Export ("workoutActivityType")]
 		HKWorkoutActivityType WorkoutActivityType { get; }
 
@@ -1845,7 +1845,7 @@ namespace XamCore.HealthKit {
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface HKWorkoutEvent : NSSecureCoding, NSCopying {
+	interface HKWorkoutEvent : NSSecureCoding, NSCopying {
 		[Export ("type")]
 		HKWorkoutEventType Type { get; }
 
@@ -1879,7 +1879,7 @@ namespace XamCore.HealthKit {
 	[iOS (8,0)]
 	[BaseType (typeof (HKSampleType))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKWorkoutType
-	public interface HKWorkoutType {
+	interface HKWorkoutType {
 		[Field ("HKWorkoutTypeIdentifier")]
 		NSString Identifier { get; }
 	}
@@ -1888,7 +1888,7 @@ namespace XamCore.HealthKit {
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface HKDeletedObject : NSSecureCoding {
+	interface HKDeletedObject : NSSecureCoding {
 		[Export ("UUID", ArgumentSemantic.Strong)]
 		NSUuid Uuid { get; }
 	}
@@ -1897,7 +1897,7 @@ namespace XamCore.HealthKit {
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface HKDevice : NSSecureCoding, NSCopying {
+	interface HKDevice : NSSecureCoding, NSCopying {
 		[NullAllowed]
 		[Export ("name")]
 		string Name { get; }
@@ -1981,14 +1981,14 @@ namespace XamCore.HealthKit {
 	[Watch (2,0)]
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
-	public interface HKFitzpatrickSkinTypeObject : NSCopying, NSSecureCoding {
+	interface HKFitzpatrickSkinTypeObject : NSCopying, NSSecureCoding {
 		[Export ("skinType")]
 		HKFitzpatrickSkinType SkinType { get; }
 	}
 
 	[Watch (3,0), iOS (10,0)]
 	[BaseType (typeof(NSObject))]
-	public interface HKWheelchairUseObject : NSCopying, NSSecureCoding {
+	interface HKWheelchairUseObject : NSCopying, NSSecureCoding {
 		[Export ("wheelchairUse")]
 		HKWheelchairUse WheelchairUse { get; }
 	}
@@ -1997,7 +1997,7 @@ namespace XamCore.HealthKit {
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface HKSourceRevision : NSSecureCoding, NSCopying {
+	interface HKSourceRevision : NSSecureCoding, NSCopying {
 		[Export ("source")]
 		HKSource Source { get; }
 
@@ -2012,7 +2012,7 @@ namespace XamCore.HealthKit {
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface HKQueryAnchor : NSSecureCoding, NSCopying {
+	interface HKQueryAnchor : NSSecureCoding, NSCopying {
 		[Static]
 		[Export ("anchorFromValue:")]
 		HKQueryAnchor Create (nuint value);
@@ -2023,7 +2023,7 @@ namespace XamCore.HealthKit {
 	[Watch (2,0)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
-	public interface HKWorkoutSession : NSSecureCoding {
+	interface HKWorkoutSession : NSSecureCoding {
 		[Deprecated (PlatformName.WatchOS, 3, 0, message: "Use WorkoutConfiguration")]
 		[Export ("activityType")]
 		HKWorkoutActivityType ActivityType { get; }
@@ -2066,7 +2066,7 @@ namespace XamCore.HealthKit {
 	[Watch (2,0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public interface HKWorkoutSessionDelegate {
+	interface HKWorkoutSessionDelegate {
 		[Abstract]
 		[Export ("workoutSession:didChangeToState:fromState:date:")]
 		void DidChangeToState (HKWorkoutSession workoutSession, HKWorkoutSessionState toState, HKWorkoutSessionState fromState, NSDate date);
@@ -2119,12 +2119,12 @@ namespace XamCore.HealthKit {
 	[iOS (9,3), Watch (2,2)]
 	[BaseType (typeof (HKObjectType))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: The -init method is not available on HKActivitySummaryType
-	public interface HKActivitySummaryType {
+	interface HKActivitySummaryType {
 	}
 
 	[Watch (3,0)][iOS (10,0)]
 	[BaseType (typeof (NSObject))]
-	public interface HKWorkoutConfiguration : NSCopying, NSSecureCoding {
+	interface HKWorkoutConfiguration : NSCopying, NSSecureCoding {
 
 		[Export ("activityType", ArgumentSemantic.Assign)]
 		HKWorkoutActivityType ActivityType { get; set; }

--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -15,7 +15,7 @@ namespace XamCore.HomeKit {
 	[TV (10,0)]
 	[iOS (8,0)]
 	[Static]
-	public partial interface HMErrors {
+	partial interface HMErrors {
 		[Field ("HMErrorDomain")]
 		NSString HMErrorDomain { get; }
 	}
@@ -23,7 +23,7 @@ namespace XamCore.HomeKit {
 	[TV (10,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject), Delegates=new string[] {"WeakDelegate"}, Events=new Type[] {typeof(HMHomeManagerDelegate)})]
-	public partial interface HMHomeManager {
+	partial interface HMHomeManager {
 
 		[Export ("delegate", ArgumentSemantic.Weak)]
 		[NullAllowed]
@@ -62,7 +62,7 @@ namespace XamCore.HomeKit {
 	[iOS (8,0)]
 	[Model, Protocol]
 	[BaseType (typeof (NSObject))]
-	public partial interface HMHomeManagerDelegate {
+	partial interface HMHomeManagerDelegate {
 
 		[Export ("homeManagerDidUpdateHomes:")]
 		void DidUpdateHomes (HMHomeManager manager);
@@ -80,7 +80,7 @@ namespace XamCore.HomeKit {
 	[TV (10,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject), Delegates=new string[] {"WeakDelegate"}, Events=new Type[] {typeof(HMAccessoryDelegate)})]
-	public partial interface HMAccessory {
+	partial interface HMAccessory {
 
 		[Export ("name")]
 		string Name { get; }
@@ -153,7 +153,7 @@ namespace XamCore.HomeKit {
 	[iOS (8,0)]
 	[Model, Protocol]
 	[BaseType (typeof (NSObject))]
-	public partial interface HMAccessoryDelegate {
+	partial interface HMAccessoryDelegate {
 
 		[Export ("accessoryDidUpdateName:")]
 		void DidUpdateName (HMAccessory accessory);
@@ -179,7 +179,7 @@ namespace XamCore.HomeKit {
 	[NoTV]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject), Delegates=new string[] {"WeakDelegate"}, Events=new Type[] {typeof(HMAccessoryBrowserDelegate)})]
-	public partial interface HMAccessoryBrowser {
+	partial interface HMAccessoryBrowser {
 
 		[Export ("delegate", ArgumentSemantic.Weak)]
 		[NullAllowed]
@@ -203,7 +203,7 @@ namespace XamCore.HomeKit {
 	[iOS (8,0)]
 	[Model, Protocol]
 	[BaseType (typeof (NSObject))]
-	public partial interface HMAccessoryBrowserDelegate {
+	partial interface HMAccessoryBrowserDelegate {
 
 		[Export ("accessoryBrowser:didFindNewAccessory:"), EventArgs ("HMAccessoryBrowser")]
 		void DidFindNewAccessory (HMAccessoryBrowser browser, HMAccessory accessory);
@@ -231,7 +231,7 @@ namespace XamCore.HomeKit {
 	[TV (10,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface HMAction {
+	partial interface HMAction {
 
 		[iOS (9,0)]
 		[Export ("uniqueIdentifier", ArgumentSemantic.Copy)]
@@ -242,7 +242,7 @@ namespace XamCore.HomeKit {
 	[iOS (8,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
-	public partial interface HMActionSet {
+	partial interface HMActionSet {
 
 		[Export ("name")]
 		string Name { get; }
@@ -289,7 +289,7 @@ namespace XamCore.HomeKit {
 	[iOS (9,0)]
 	[Static]
 	[Internal]
-	public interface HMActionSetTypesInternal {
+	interface HMActionSetTypesInternal {
 		[Field ("HMActionSetTypeWakeUp")]
 		NSString WakeUp { get; }
 
@@ -313,7 +313,7 @@ namespace XamCore.HomeKit {
 	[TV (10,0)]
 	[iOS (8,0)]	
 	[BaseType (typeof (NSObject))]
-	public partial interface HMCharacteristic {
+	partial interface HMCharacteristic {
 
 		[Internal]
 		[Export ("characteristicType", ArgumentSemantic.Copy)]
@@ -373,7 +373,7 @@ namespace XamCore.HomeKit {
 	[iOS(8,0)]
 	[Static]
 	[Internal]
-	public interface HMCharacteristicPropertyInternal {
+	interface HMCharacteristicPropertyInternal {
 
 		[Field ("HMCharacteristicPropertyReadable")]
 		NSString Readable { get; }
@@ -393,7 +393,7 @@ namespace XamCore.HomeKit {
 	[iOS(8,0)]
 	[Static]
 	[Internal]
-	public interface HMCharacteristicTypeInternal {
+	interface HMCharacteristicTypeInternal {
 		[Field ("HMCharacteristicTypePowerState")]
 		NSString PowerState { get; }
 
@@ -734,7 +734,7 @@ namespace XamCore.HomeKit {
 	[TV (10,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface HMCharacteristicMetadata {
+	partial interface HMCharacteristicMetadata {
 
 		[Export ("minimumValue")]
 		NSNumber MinimumValue { get; }
@@ -768,7 +768,7 @@ namespace XamCore.HomeKit {
 	[iOS (8,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (HMAction))]
-	public partial interface HMCharacteristicWriteAction {
+	partial interface HMCharacteristicWriteAction {
 
 		[NoTV]
 		[NoWatch]
@@ -805,7 +805,7 @@ namespace XamCore.HomeKit {
 	[iOS (8,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject), Delegates=new string[] {"WeakDelegate"}, Events=new Type[] {typeof(HMHomeDelegate)})]
-	public partial interface HMHome { 
+	partial interface HMHome { 
 
 		[Export ("delegate", ArgumentSemantic.Weak)]
 		[NullAllowed]
@@ -1012,7 +1012,7 @@ namespace XamCore.HomeKit {
 	[iOS (8,0)]
 	[Model, Protocol]
 	[BaseType (typeof (NSObject))]
-	public partial interface HMHomeDelegate {
+	partial interface HMHomeDelegate {
 
 		[Export ("homeDidUpdateName:")]
 		void DidUpdateNameForHome (HMHome home);
@@ -1106,7 +1106,7 @@ namespace XamCore.HomeKit {
 	[iOS (8,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
-	public partial interface HMRoom {
+	partial interface HMRoom {
 
 		[Export ("name")]
 		string Name { get; }
@@ -1129,7 +1129,7 @@ namespace XamCore.HomeKit {
 	[iOS (8,0)]
 	[Static]
 	[Internal]
-	public interface HMServiceTypeInternal {
+	interface HMServiceTypeInternal {
 		[Field ("HMServiceTypeLightbulb")]
 		NSString LightBulb { get; }
 
@@ -1253,7 +1253,7 @@ namespace XamCore.HomeKit {
 	[TV (10,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface HMService { 
+	partial interface HMService { 
 
 		[Export ("accessory", ArgumentSemantic.Weak)]
 		HMAccessory Accessory { get; }
@@ -1309,7 +1309,7 @@ namespace XamCore.HomeKit {
 	[iOS (8,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
-	public partial interface HMServiceGroup {
+	partial interface HMServiceGroup {
 
 		[Export ("name")]
 		string Name { get; }
@@ -1344,7 +1344,7 @@ namespace XamCore.HomeKit {
 	[iOS (8,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (HMTrigger))]
-	public partial interface HMTimerTrigger { 
+	partial interface HMTimerTrigger { 
 
 		[NoTV]
 		[NoWatch]
@@ -1387,7 +1387,7 @@ namespace XamCore.HomeKit {
 	[iOS (8,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
-	public partial interface HMTrigger { 
+	partial interface HMTrigger { 
 
 		[Export ("name")]
 		string Name { get; }
@@ -1434,7 +1434,7 @@ namespace XamCore.HomeKit {
 	[iOS (8,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
-	public partial interface HMZone { 
+	partial interface HMZone { 
 
 		[Export ("name")]
 		string Name { get; }
@@ -1510,7 +1510,7 @@ namespace XamCore.HomeKit {
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface HMUser {
+	interface HMUser {
 		[Export ("name")]
 		string Name { get; }
 
@@ -1523,7 +1523,7 @@ namespace XamCore.HomeKit {
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInternalInconsistencyException Reason: init is unavailable
-	public interface HMAccessoryCategory {
+	interface HMAccessoryCategory {
 		[Internal]
 		[Export ("categoryType")]
 		NSString _CategoryType { get; }
@@ -1536,7 +1536,7 @@ namespace XamCore.HomeKit {
 	[iOS (9,0)]
 	[Static]
 	[Internal]
-	public interface HMAccessoryCategoryTypesInternal {
+	interface HMAccessoryCategoryTypesInternal {
 		[Field ("HMAccessoryCategoryTypeOther")]
 		NSString Other { get; }
 
@@ -1699,7 +1699,7 @@ namespace XamCore.HomeKit {
 	[TV (10,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface HMHomeAccessControl {
+	interface HMHomeAccessControl {
 		[Export ("administrator")]
 		bool Administrator { [Bind ("isAdministrator")] get; }
 	}
@@ -1744,7 +1744,7 @@ namespace XamCore.HomeKit {
 	[Watch (3,0), TV (10,0), iOS (10,0)]
 	[BaseType (typeof(HMAccessoryProfile))]
 	[DisableDefaultCtor]
-	public interface HMCameraProfile
+	interface HMCameraProfile
 	{
 		[NullAllowed, Export ("streamControl", ArgumentSemantic.Strong)]
 		HMCameraStreamControl StreamControl { get; }
@@ -1768,7 +1768,7 @@ namespace XamCore.HomeKit {
 
 	[Watch (3,0), TV (10,0), iOS (10,0)]
 	[BaseType (typeof(HMCameraControl))]
-	public interface HMCameraStreamControl
+	interface HMCameraStreamControl
 	{
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		IHMCameraStreamControlDelegate Delegate { get; set; }
@@ -1786,7 +1786,7 @@ namespace XamCore.HomeKit {
 		void StopStream ();
 	}
 
-	public interface IHMCameraStreamControlDelegate {}
+	interface IHMCameraStreamControlDelegate {}
 
 	[Watch (3,0), TV (10,0), iOS (10,0)]
 	[Protocol, Model]
@@ -1803,7 +1803,7 @@ namespace XamCore.HomeKit {
 	// TODO: Type still available for tvOS even if everything in it is __TVOS_PROHIBITED.
 	[Watch (3,0), TV (10,0), iOS (10,0)]
 	[BaseType (typeof(HMCameraSource))]
-	public interface HMCameraStream
+	interface HMCameraStream
 	{
 		[NoTV]
 		[Export ("audioStreamSetting", ArgumentSemantic.Assign)]
@@ -1817,7 +1817,7 @@ namespace XamCore.HomeKit {
 
 	[Watch (3,0), TV (10,0), iOS (10,0)]
 	[BaseType (typeof(HMCameraControl))]
-	public interface HMCameraSnapshotControl
+	interface HMCameraSnapshotControl
 	{
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		IHMCameraSnapshotControlDelegate Delegate { get; set; }
@@ -1829,12 +1829,12 @@ namespace XamCore.HomeKit {
 		void TakeSnapshot ();
 	}
 
-	public interface IHMCameraSnapshotControlDelegate {}
+	interface IHMCameraSnapshotControlDelegate {}
 
 	[Watch (3,0), TV (10,0), iOS (10,0)]
 	[Protocol, Model]
 	[BaseType (typeof(NSObject))]
-	public interface HMCameraSnapshotControlDelegate
+	interface HMCameraSnapshotControlDelegate
 	{
 		[Export ("cameraSnapshotControl:didTakeSnapshot:error:")]
 		void DidTakeSnapshot (HMCameraSnapshotControl cameraSnapshotControl, [NullAllowed] HMCameraSnapshot snapshot, [NullAllowed] NSError error);
@@ -1842,7 +1842,7 @@ namespace XamCore.HomeKit {
 
 	[Watch (3,0), TV (10,0), iOS (10,0)]
 	[BaseType (typeof(HMCameraSource))]
-	public interface HMCameraSnapshot
+	interface HMCameraSnapshot
 	{
 		[Export ("captureDate", ArgumentSemantic.Copy)]
 		NSDate CaptureDate { get; }
@@ -1851,7 +1851,7 @@ namespace XamCore.HomeKit {
 	[Watch (3,0), TV (10,0), iOS (10,0)]
 	[BaseType (typeof(HMCameraControl))]
 	[DisableDefaultCtor]
-	public interface HMCameraSettingsControl
+	interface HMCameraSettingsControl
 	{
 		[NullAllowed, Export ("nightVision", ArgumentSemantic.Strong)]
 		HMCharacteristic NightVision { get; }
@@ -1884,7 +1884,7 @@ namespace XamCore.HomeKit {
 	[Watch (3,0), TV (10,0), iOS (10,0)]
 	[BaseType (typeof(HMCameraControl))]
 	[DisableDefaultCtor]
-	public interface HMCameraAudioControl
+	interface HMCameraAudioControl
 	{
 		[NullAllowed, Export ("mute", ArgumentSemantic.Strong)]
 		HMCharacteristic Mute { get; }

--- a/src/iad.cs
+++ b/src/iad.cs
@@ -173,7 +173,7 @@ namespace XamCore.iAd {
 	}
 
 	[Category, BaseType (typeof (MPMoviePlayerController))]
-	public partial interface IAdPreroll {
+	partial interface IAdPreroll {
 
 #if XAMCORE_2_0
 		[Internal]
@@ -195,12 +195,12 @@ namespace XamCore.iAd {
 	}
 
 #if !XAMCORE_2_0
-	public delegate void PlayPrerollAdCompletionHandler (NSError error);
+	delegate void PlayPrerollAdCompletionHandler (NSError error);
 #endif
 
 	[Deprecated (PlatformName.iOS, 10, 0)]
 	[Category, BaseType (typeof (UIViewController))]
-	public partial interface IAdAdditions {
+	partial interface IAdAdditions {
 
 #if XAMCORE_2_0
 		[Internal]
@@ -238,12 +238,12 @@ namespace XamCore.iAd {
 		bool ShouldPresentInterstitialAd ();
 	}
 
-	public delegate void ADConversionDetails (NSDate appPurchaseDate, NSDate iAdImpressionDate);
+	delegate void ADConversionDetails (NSDate appPurchaseDate, NSDate iAdImpressionDate);
 	
 	[Since (7,1)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface ADClient {
+	interface ADClient {
 		[Static]
 		[Export ("sharedClient")]
 		ADClient SharedClient { get; }
@@ -272,7 +272,7 @@ namespace XamCore.iAd {
 #endif
 	}
 
-	public delegate void AttributedToiAdCompletionHandler (bool attributedToiAd);
+	delegate void AttributedToiAdCompletionHandler (bool attributedToiAd);
 
 	[Category]
 	[BaseType (typeof (AVPlayerViewController))]

--- a/src/imagekit.cs
+++ b/src/imagekit.cs
@@ -38,7 +38,7 @@ using XamCore.CoreAnimation;
 namespace XamCore.ImageKit {
 
 	[BaseType (typeof (NSView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (IKCameraDeviceViewDelegate)})]
-	public interface IKCameraDeviceView {
+	interface IKCameraDeviceView {
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDelegate { get; set; }
 
@@ -117,7 +117,7 @@ namespace XamCore.ImageKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface IKCameraDeviceViewDelegate {
+	interface IKCameraDeviceViewDelegate {
 		[Export ("cameraDeviceViewSelectionDidChange:"), EventArgs ("IKCameraDeviceView")]
 		void SelectionDidChange (IKCameraDeviceView cameraDeviceView);
 
@@ -130,7 +130,7 @@ namespace XamCore.ImageKit {
 	}
 
 	[BaseType (typeof (NSView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (IKDeviceBrowserViewDelegate)})]
-	public interface IKDeviceBrowserView {
+	interface IKDeviceBrowserView {
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDelegate { get; set; }
 
@@ -161,7 +161,7 @@ namespace XamCore.ImageKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface IKDeviceBrowserViewDelegate {
+	interface IKDeviceBrowserViewDelegate {
 //		FIXME need ImageCaptureCore;
 //		[Abstract]
 //		[Export ("deviceBrowserView:selectionDidChange:"), EventArgs ("IKDeviceBrowserViewICDevice")]
@@ -172,7 +172,7 @@ namespace XamCore.ImageKit {
 	}
 
 	[BaseType (typeof (NSPanel))]
-	public interface IKFilterBrowserPanel {
+	interface IKFilterBrowserPanel {
 		[Static]
 		[Export ("filterBrowserPanelWithStyleMask:")]
 		IKFilterBrowserPanel Create (IKFilterBrowserPanelStyleMask styleMask);
@@ -224,7 +224,7 @@ namespace XamCore.ImageKit {
 	}
 
 	[BaseType (typeof (NSView))]
-	public interface IKFilterBrowserView {
+	interface IKFilterBrowserView {
 		[Export ("setPreviewState:")]
 		void SetPreviewState (bool showPreview);
 
@@ -236,7 +236,7 @@ namespace XamCore.ImageKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface IKFilterCustomUIProvider {
+	interface IKFilterCustomUIProvider {
 		// The Apple documentation says the native implementation of CIFilter.GetFilterUIView will call
 		// this method (if it exists). This means that This method should not be called GetFilterUIView
 		// (because it seems like you shouldn't override CIFilter.GetFilterUIView, and implementing
@@ -271,7 +271,7 @@ namespace XamCore.ImageKit {
 	}
 
 	[BaseType (typeof (NSView))]
-	public interface IKFilterUIView {
+	interface IKFilterUIView {
 		[Export ("initWithFrame:filter:")]
 		IntPtr Constructor (CGRect frame, CIFilter filter);
 
@@ -283,7 +283,7 @@ namespace XamCore.ImageKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface IKImageBrowserCell {
+	interface IKImageBrowserCell {
 		[Export ("imageBrowserView")]
 		IKImageBrowserView ImageBrowserView  { get; }
 
@@ -341,7 +341,7 @@ namespace XamCore.ImageKit {
 	}
 
 	[BaseType (typeof (NSView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (IKImageBrowserDelegate)})]
-	public interface IKImageBrowserView {
+	interface IKImageBrowserView {
 		//@category IKImageBrowserView (IKMainMethods)
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
@@ -497,7 +497,7 @@ namespace XamCore.ImageKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface IKImageBrowserDataSource {
+	interface IKImageBrowserDataSource {
 		[Abstract]
 		[Export ("numberOfItemsInImageBrowser:")]
 		nint ItemCount (IKImageBrowserView aBrowser);
@@ -548,7 +548,7 @@ namespace XamCore.ImageKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface IKImageBrowserItem {
+	interface IKImageBrowserItem {
 		[Abstract]
 		[Export ("imageUID")]
 		string ImageUID { get; }
@@ -620,12 +620,12 @@ namespace XamCore.ImageKit {
 		bool IsSelectable { get; }
 	}
 
-	public interface IIKImageBrowserItem {}
+	interface IIKImageBrowserItem {}
 
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol (IsInformal = true)]
-	public interface IKImageBrowserDelegate {
+	interface IKImageBrowserDelegate {
 		[Export ("imageBrowserSelectionDidChange:"), EventArgs ("IKImageBrowserView")]
 		void SelectionDidChange (IKImageBrowserView browser);
 
@@ -641,7 +641,7 @@ namespace XamCore.ImageKit {
 
 	[BaseType (typeof (NSPanel))]
 	[DisableDefaultCtor] // crash when disposed, sharedImageEditPanel must be used
-	public interface IKImageEditPanel {
+	interface IKImageEditPanel {
 		[Static]
 		[Export ("sharedImageEditPanel")]
 		IKImageEditPanel SharedPanel { get; }
@@ -660,7 +660,7 @@ namespace XamCore.ImageKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface IKImageEditPanelDataSource {
+	interface IKImageEditPanelDataSource {
 		[Abstract]
 		[Export ("image")]
 		CGImage Image { get; }
@@ -686,7 +686,7 @@ namespace XamCore.ImageKit {
 	}
 
 	[BaseType (typeof (NSView))]
-	public interface IKImageView {
+	interface IKImageView {
 		//There is no protocol for this delegate.  used to respond to messages in the responder chain
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject Delegate { get; set; }
@@ -804,7 +804,7 @@ namespace XamCore.ImageKit {
 	}
 
 	[BaseType (typeof (NSPanel))]
-	public interface IKPictureTaker {
+	interface IKPictureTaker {
 		[Static]
 		[Export ("pictureTaker")]
 		IKPictureTaker SharedPictureTaker { get; }
@@ -873,7 +873,7 @@ namespace XamCore.ImageKit {
 	}
 
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (IKSaveOptionsDelegate)})]
-	public interface IKSaveOptions {
+	interface IKSaveOptions {
 		[Export ("imageProperties")]
 		NSDictionary ImageProperties { get;  }
 
@@ -903,13 +903,13 @@ namespace XamCore.ImageKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol (IsInformal = true)]
-	public interface IKSaveOptionsDelegate {
+	interface IKSaveOptionsDelegate {
 		[Export ("saveOptions:shouldShowUTType:"), DelegateName ("SaveOptionsShouldShowUTType"), DefaultValue (false)]
 		bool ShouldShowType (IKSaveOptions saveOptions, string imageUTType);
 	}
 
 	[BaseType (typeof (NSView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (IKScannerDeviceViewDelegate)})]
-	public interface IKScannerDeviceView {
+	interface IKScannerDeviceView {
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDelegate { get; set; }
 
@@ -958,7 +958,7 @@ namespace XamCore.ImageKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface IKScannerDeviceViewDelegate {
+	interface IKScannerDeviceViewDelegate {
 		[Export ("scannerDeviceView:didScanToURL:fileData:error:"), EventArgs ("IKScannerDeviceViewScan")]
 		void DidScan (IKScannerDeviceView scannerDeviceView, NSUrl url, NSData data, NSError error);
 
@@ -967,7 +967,7 @@ namespace XamCore.ImageKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface IKSlideshow {
+	interface IKSlideshow {
 		[Static]
 		[Export ("sharedSlideshow")]
 		IKSlideshow SharedSlideshow { get; }
@@ -1048,7 +1048,7 @@ namespace XamCore.ImageKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface IKSlideshowDataSource {
+	interface IKSlideshowDataSource {
 		[Abstract]
 		[Export ("numberOfSlideshowItems")]
 		nint ItemCount { get; }

--- a/src/inputmethodkit.cs
+++ b/src/inputmethodkit.cs
@@ -17,7 +17,7 @@ using XamCore.AppKit;
 
 namespace XamCore.InputMethodKit {
 
-	public partial interface IMKGlobal {
+	partial interface IMKGlobal {
 		[Field ("kIMKCommandMenuItemName")]
 		NSString CommandMenuItemName { get; }
 
@@ -26,7 +26,7 @@ namespace XamCore.InputMethodKit {
 	}
 
 	[Model]
-	public partial interface IMKServerProxy {
+	partial interface IMKServerProxy {
 		[Field ("IMKModeDictionary")]
 		NSString ModeDictionary { get; }
 
@@ -38,7 +38,7 @@ namespace XamCore.InputMethodKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public partial interface IMKServer : IMKServerProxy {
+	partial interface IMKServer : IMKServerProxy {
 
 		[Export ("initWithName:bundleIdentifier:")]
 		IntPtr Constructor (string name, string bundleIdentifier);
@@ -57,7 +57,7 @@ namespace XamCore.InputMethodKit {
 	}
 
 	[Category, BaseType (typeof (NSObject))]
-	public partial interface IMKServerInput_NSObject {
+	partial interface IMKServerInput_NSObject {
 
 		[Export ("inputText:key:modifiers:client:")]
 		bool InputText (string str, nint keyCode, nuint flags, NSObject sender);
@@ -85,7 +85,7 @@ namespace XamCore.InputMethodKit {
 	}
 
 	[Protocol]
-	public partial interface IMKStateSetting {
+	partial interface IMKStateSetting {
 		[Abstract]
 		[Export ("activateServer:")]
 		void ActivateServer (NSObject sender);
@@ -116,7 +116,7 @@ namespace XamCore.InputMethodKit {
 	}
 
 	[Model]
-	public partial interface IMKMouseHandling {
+	partial interface IMKMouseHandling {
 
 		[Export ("mouseDownOnCharacterIndex:coordinate:withModifier:continueTracking:client:")]
 		bool MouseDown (nuint index, NSPoint point, nuint flags, out bool keepTracking, NSObject sender);
@@ -129,7 +129,7 @@ namespace XamCore.InputMethodKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public partial interface IMKInputController : IMKStateSetting, IMKMouseHandling {
+	partial interface IMKInputController : IMKStateSetting, IMKMouseHandling {
 
 		[Export ("initWithServer:delegate:client:")]
 		IntPtr Constructor (IMKServer server, NSObject delegateObject, NSObject inputClient);
@@ -184,7 +184,7 @@ namespace XamCore.InputMethodKit {
 	}
 
 	[BaseType (typeof (NSResponder))]
-	public partial interface IMKCandidates {
+	partial interface IMKCandidates {
 
 		[Export ("initWithServer:panelType:")]
 		IntPtr Constructor (IMKServer server, IMKCandidatePanelType panelType);

--- a/src/javascriptcore.cs
+++ b/src/javascriptcore.cs
@@ -13,12 +13,12 @@ using XamCore.CoreGraphics;
 
 namespace XamCore.JavaScriptCore {
 
-	public delegate void JSContextExceptionHandler (JSContext context, JSValue exception);
+	delegate void JSContextExceptionHandler (JSContext context, JSValue exception);
 
 	[Mac (10,9, onlyOn64: true), iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public partial interface JSContext {
+	partial interface JSContext {
 
 		[Export ("init")]
 		IntPtr Constructor ();
@@ -89,7 +89,7 @@ namespace XamCore.JavaScriptCore {
 	[Mac (10,9, onlyOn64: true), iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // invalid (null) Handle is returned
-	public partial interface JSValue {
+	partial interface JSValue {
 		[Static, Export ("valueWithObject:inContext:")]
 		JSValue From (NSObject value, JSContext context);
 
@@ -285,7 +285,7 @@ namespace XamCore.JavaScriptCore {
 #if XAMCORE_3_0
 	[DisableDefaultCtor]
 #endif
-	public partial interface JSManagedValue {
+	partial interface JSManagedValue {
 		[Static, Export ("managedValueWithValue:")]
 		JSManagedValue Get (JSValue value);
 
@@ -303,7 +303,7 @@ namespace XamCore.JavaScriptCore {
 	[Mac (10,9, onlyOn64: true), iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public partial interface JSVirtualMachine {
+	partial interface JSVirtualMachine {
 
 		[Export ("init")]
 		IntPtr Constructor ();

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -1452,7 +1452,7 @@ namespace XamCore.MapKit {
 	[TV (9,2)]
 	[Since (7,0), BaseType (typeof (NSObject))]
 	[Mac (10,9, onlyOn64 : true)]
-	public partial interface MKMapCamera : NSCopying, NSSecureCoding {
+	partial interface MKMapCamera : NSCopying, NSSecureCoding {
 
 		[Export ("centerCoordinate")]
 		CLLocationCoordinate2D CenterCoordinate { get; set; }

--- a/src/mediaaccessibility.cs
+++ b/src/mediaaccessibility.cs
@@ -7,7 +7,7 @@ namespace XamCore.MediaAccessibility {
 
 #if XAMCORE_4_0
 	[Static]
-	public interface MACaptionAppearance {
+	interface MACaptionAppearance {
 		[iOS (7,0)][Mac (10,9)]
 		[Notification]
 		[Field ("kMACaptionAppearanceSettingsChangedNotification")]
@@ -16,7 +16,7 @@ namespace XamCore.MediaAccessibility {
 #endif
 
 	[Static]
-	public interface MAAudibleMedia {
+	interface MAAudibleMedia {
 		[iOS (8,0)][Mac (10,10)]
 		[Notification]
 		[Field ("kMAAudibleMediaSettingsChangedNotification")]
@@ -24,7 +24,7 @@ namespace XamCore.MediaAccessibility {
 	}
 
 	[Static]
-	public interface MAMediaCharacteristic {
+	interface MAMediaCharacteristic {
 		[iOS (7,0)][Mac (10,9)]
 		[Field ("MAMediaCharacteristicDescribesMusicAndSoundForAccessibility")]
 		NSString DescribesMusicAndSoundForAccessibility { get; }

--- a/src/medialibrary.cs
+++ b/src/medialibrary.cs
@@ -30,7 +30,7 @@ using XamCore.ObjCRuntime;
 namespace XamCore.MediaLibrary {
 	[Static]
 	[Mac (10,9, onlyOn64 : true)]
-	public interface MediaLibraryTypeIdentifierKey {
+	interface MediaLibraryTypeIdentifierKey {
 		[Field ("MLFolderRootGroupTypeIdentifier")]
 		NSString FolderRootGroupTypeIdentifier { get; }
 

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -22,9 +22,9 @@ namespace XamCore.MediaPlayer {
 	[BaseType (typeof (NSObject))]
 #if XAMCORE_2_0
 	// introduced in 4.2
-	public interface MPMediaEntity : NSSecureCoding {
+	interface MPMediaEntity : NSSecureCoding {
 #else
-	public interface MPMediaItem : NSSecureCoding {
+	interface MPMediaItem : NSSecureCoding {
 #endif
 		[Static]
 		[Export ("canFilterByProperty:")]
@@ -49,7 +49,7 @@ namespace XamCore.MediaPlayer {
 
 	[NoTV]
 	[BaseType (typeof (MPMediaEntity))]
-	public interface MPMediaItem {
+	interface MPMediaItem {
 #endif
 		[Since (4,2)]
 		[Export ("persistentIDPropertyForGroupingType:")][Static]
@@ -247,7 +247,7 @@ namespace XamCore.MediaPlayer {
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface MPMediaItemArtwork {
+	interface MPMediaItemArtwork {
 		[iOS (10,0)]
 		[TV (10,0)]
 		[Export ("initWithBoundsSize:requestHandler:")]
@@ -280,10 +280,10 @@ namespace XamCore.MediaPlayer {
 	[BaseType (typeof (NSObject))]
 #endif
 #if XAMCORE_3_0 || !XAMCORE_2_0
-	public interface MPMediaItemCollection : NSSecureCoding {
+	interface MPMediaItemCollection : NSSecureCoding {
 #else
 	// part of the bug is that we inlined MPMediaEntity needlessly
-	public interface MPMediaItemCollection : MPMediaEntity, NSSecureCoding {
+	interface MPMediaItemCollection : MPMediaEntity, NSSecureCoding {
 #endif
 		[Static]
 		[Export ("collectionWithItems:")]
@@ -308,7 +308,7 @@ namespace XamCore.MediaPlayer {
 
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	public interface MPMediaLibrary : NSSecureCoding {
+	interface MPMediaLibrary : NSSecureCoding {
 		[Static, Export ("defaultMediaLibrary")]
 		MPMediaLibrary DefaultMediaLibrary { get; }
 
@@ -354,7 +354,7 @@ namespace XamCore.MediaPlayer {
 
 	[NoTV]
 	[BaseType (typeof (UIViewController), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(MPMediaPickerControllerDelegate)})]
-	public interface MPMediaPickerController {
+	interface MPMediaPickerController {
 		[DesignatedInitializer]
 		[Export ("initWithMediaTypes:")]
 		IntPtr Constructor (MPMediaType mediaTypes);
@@ -389,7 +389,7 @@ namespace XamCore.MediaPlayer {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface MPMediaPickerControllerDelegate {
+	interface MPMediaPickerControllerDelegate {
 		[Export ("mediaPicker:didPickMediaItems:"), EventArgs ("ItemsPicked"), EventName ("ItemsPicked")]
 		void MediaItemsPicked (MPMediaPickerController sender, MPMediaItemCollection mediaItemCollection);
 		
@@ -401,7 +401,7 @@ namespace XamCore.MediaPlayer {
 	[BaseType (typeof (MPMediaItemCollection))]
 	// Objective-C exception thrown.  Name: MPMediaItemCollectionInitException Reason: -init is not supported, use -initWithItems:
 	[DisableDefaultCtor]
-	public interface MPMediaPlaylist : NSSecureCoding {
+	interface MPMediaPlaylist : NSSecureCoding {
 		[Export ("initWithItems:")]
 		IntPtr Constructor (MPMediaItem [] items);
 
@@ -439,7 +439,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	[Static]
-	public interface MPMediaPlaylistProperty {
+	interface MPMediaPlaylistProperty {
 		[Field ("MPMediaPlaylistPropertyPersistentID")]
 		NSString PersistentID { get; }
 
@@ -465,7 +465,7 @@ namespace XamCore.MediaPlayer {
 
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	public interface MPMediaQuery : NSSecureCoding, NSCopying {
+	interface MPMediaQuery : NSSecureCoding, NSCopying {
 		[DesignatedInitializer]
 		[Export ("initWithFilterPredicates:")]
 		IntPtr Constructor ([NullAllowed] NSSet filterPredicates);
@@ -554,12 +554,12 @@ namespace XamCore.MediaPlayer {
 
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	public interface MPMediaPredicate : NSSecureCoding {
+	interface MPMediaPredicate : NSSecureCoding {
 	}
 
 	[NoTV]
 	[BaseType (typeof (MPMediaPredicate))]
-	public interface MPMediaPropertyPredicate {
+	interface MPMediaPropertyPredicate {
 		[Static, Export ("predicateWithValue:forProperty:")]
 		MPMediaPropertyPredicate PredicateWithValue ([NullAllowed] NSObject value, string property);
 
@@ -579,7 +579,7 @@ namespace XamCore.MediaPlayer {
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[BaseType (typeof (NSObject))]
-	public interface MPMovieAccessLog : NSCopying {
+	interface MPMovieAccessLog : NSCopying {
 		[Export ("events")]
 		MPMovieAccessLogEvent [] Events { get; }
 
@@ -593,7 +593,7 @@ namespace XamCore.MediaPlayer {
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[BaseType (typeof (NSObject))]
-	public interface MPMovieErrorLog : NSCopying {
+	interface MPMovieErrorLog : NSCopying {
 		[Export ("events")]
 		MPMovieErrorLogEvent [] Events { get; }
 
@@ -607,7 +607,7 @@ namespace XamCore.MediaPlayer {
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[BaseType (typeof (NSObject))]
-	public interface MPMovieAccessLogEvent : NSCopying {
+	interface MPMovieAccessLogEvent : NSCopying {
 		[Export ("numberOfSegmentsDownloaded")]
 		nint SegmentedDownloadedCount { get; }
 
@@ -654,7 +654,7 @@ namespace XamCore.MediaPlayer {
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[BaseType (typeof (NSObject))]
-	public interface MPMovieErrorLogEvent : NSCopying {
+	interface MPMovieErrorLogEvent : NSCopying {
 		[Export ("date")]
 		NSDate Date { get; }
 
@@ -712,7 +712,7 @@ namespace XamCore.MediaPlayer {
 
 	// no [Model] yet... it can be easily created in user code (all abstract) if needed
 	[Protocol]
-	public interface MPMediaPlayback {
+	interface MPMediaPlayback {
 		[Abstract]
 		[Export ("play")]
 		void Play ();
@@ -765,7 +765,7 @@ namespace XamCore.MediaPlayer {
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[BaseType (typeof (NSObject))]
-	public interface MPMoviePlayerController : MPMediaPlayback {
+	interface MPMoviePlayerController : MPMediaPlayback {
 		[DesignatedInitializer]
 		[Export ("initWithContentURL:")]
 		IntPtr Constructor (NSUrl url);
@@ -1038,7 +1038,7 @@ namespace XamCore.MediaPlayer {
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: MPTimedMetadata cannot be created directly
 	[DisableDefaultCtor]
-	public interface MPTimedMetadata {
+	interface MPTimedMetadata {
 		[Export ("key")]
 		string Key { get;  }
 
@@ -1062,7 +1062,7 @@ namespace XamCore.MediaPlayer {
 	[NoTV]
 	[BaseType (typeof (UIViewController))]
 	[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_9_0)]
-	public interface MPMoviePlayerViewController {
+	interface MPMoviePlayerViewController {
 		[DesignatedInitializer]
 		[Export ("initWithContentURL:")]
 		IntPtr Constructor (NSUrl url);
@@ -1078,7 +1078,7 @@ namespace XamCore.MediaPlayer {
 
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	public interface MPMusicPlayerController : MPMediaPlayback {
+	interface MPMusicPlayerController : MPMediaPlayback {
 		[Static, Export ("applicationMusicPlayer")]
 		MPMusicPlayerController ApplicationMusicPlayer { get; }
 
@@ -1150,7 +1150,7 @@ namespace XamCore.MediaPlayer {
 
 	[NoTV]
 	[BaseType (typeof (UIView))]
-	public interface MPVolumeView {
+	interface MPVolumeView {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -1231,7 +1231,7 @@ namespace XamCore.MediaPlayer {
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: MPMediaQuerySection is a read-only object
 	[DisableDefaultCtor]
-	public interface MPMediaQuerySection : NSSecureCoding, NSCopying {
+	interface MPMediaQuerySection : NSSecureCoding, NSCopying {
 		[Export ("range", ArgumentSemantic.Assign)]	
 		NSRange Range { get; }
 
@@ -1850,7 +1850,7 @@ namespace XamCore.MediaPlayer {
 	[NoTV][iOS (9,3)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface MPMediaPlaylistCreationMetadata {
+	interface MPMediaPlaylistCreationMetadata {
 		[Export ("initWithName:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (string name);

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -25,15 +25,15 @@ using XamCore.ObjCRuntime;
 
 namespace XamCore.Metal {
 
-	public delegate void MTLDeallocator (IntPtr pointer, nuint length);
+	delegate void MTLDeallocator (IntPtr pointer, nuint length);
 
-	public delegate void MTLNewComputePipelineStateWithReflectionCompletionHandler (IMTLComputePipelineState computePipelineState, MTLComputePipelineReflection reflection, NSError error);
+	delegate void MTLNewComputePipelineStateWithReflectionCompletionHandler (IMTLComputePipelineState computePipelineState, MTLComputePipelineReflection reflection, NSError error);
 	
-	public interface IMTLCommandEncoder {}
+	interface IMTLCommandEncoder {}
 	
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public interface MTLArgument {
+	interface MTLArgument {
 		[Export ("name")]
 		string Name { get; }
 
@@ -84,7 +84,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public interface MTLArrayType {
+	interface MTLArrayType {
 		[Export ("arrayLength")]
 		nuint Length { get; }
 
@@ -103,7 +103,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public partial interface MTLCommandEncoder {
+	partial interface MTLCommandEncoder {
 		[Abstract, Export ("device")]
 		IMTLDevice Device { get; }
 
@@ -123,11 +123,11 @@ namespace XamCore.Metal {
 		void PopDebugGroup ();
 	}
 
-	public interface IMTLBuffer {}
+	interface IMTLBuffer {}
 	
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public partial interface MTLBuffer : MTLResource {
+	partial interface MTLBuffer : MTLResource {
 		[Abstract, Export ("length")]
 		nuint Length { get; }
 
@@ -158,7 +158,7 @@ namespace XamCore.Metal {
 	
 	[iOS (10,0), TV (10,0), NoWatch, Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(NSObject))]
-	public interface MTLBufferLayoutDescriptor : NSCopying
+	interface MTLBufferLayoutDescriptor : NSCopying
 	{
 		[Export ("stride")]
 		nuint Stride { get; set; }
@@ -172,7 +172,7 @@ namespace XamCore.Metal {
 
 	[iOS (10,0), TV (10,0), NoWatch, Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(NSObject))]
-	public interface MTLBufferLayoutDescriptorArray
+	interface MTLBufferLayoutDescriptorArray
 	{
 		[Internal]
 		[Export ("objectAtIndexedSubscript:")]
@@ -184,11 +184,11 @@ namespace XamCore.Metal {
 	}
 	
 
-	public interface IMTLCommandBuffer {}
+	interface IMTLCommandBuffer {}
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public partial interface MTLCommandBuffer {
+	partial interface MTLCommandBuffer {
 
 		[Abstract, Export ("device")]
 		IMTLDevice Device { get; }
@@ -260,11 +260,11 @@ namespace XamCore.Metal {
 		IMTLRenderCommandEncoder CreateRenderCommandEncoder (MTLRenderPassDescriptor renderPassDescriptor);
 	}
 
-	public interface IMTLCommandQueue {}
+	interface IMTLCommandQueue {}
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public partial interface MTLCommandQueue {
+	partial interface MTLCommandQueue {
 
 		[Abstract, Export ("label")]
 		string Label { get; set; }
@@ -284,11 +284,11 @@ namespace XamCore.Metal {
 		void InsertDebugCaptureBoundary ();
 	}
 
-	public interface IMTLComputeCommandEncoder {}
+	interface IMTLComputeCommandEncoder {}
 	
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public partial interface MTLComputeCommandEncoder : MTLCommandEncoder {
+	partial interface MTLComputeCommandEncoder : MTLCommandEncoder {
 		[Abstract, Export ("setComputePipelineState:")]
 		void SetComputePipelineState (IMTLComputePipelineState state);
 
@@ -379,7 +379,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public interface MTLComputePipelineReflection {
+	interface MTLComputePipelineReflection {
 		[Export ("arguments")]
 #if XAMCORE_4_0
 		MTLArgument [] Arguments { get; }
@@ -388,10 +388,10 @@ namespace XamCore.Metal {
 #endif
 	}
 
-	public interface IMTLComputePipelineState {}
+	interface IMTLComputePipelineState {}
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public partial interface MTLComputePipelineState {
+	partial interface MTLComputePipelineState {
 		[Abstract, Export ("device")]
 		IMTLDevice Device { get; }
 
@@ -402,11 +402,11 @@ namespace XamCore.Metal {
 		nuint ThreadExecutionWidth { get; }
 	}
 
-	public interface IMTLBlitCommandEncoder {}
+	interface IMTLBlitCommandEncoder {}
 	
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public partial interface MTLBlitCommandEncoder : MTLCommandEncoder {
+	partial interface MTLBlitCommandEncoder : MTLCommandEncoder {
 
 #if MONOMAC
 		[Abstract, Export ("synchronizeResource:")]
@@ -465,11 +465,11 @@ namespace XamCore.Metal {
 		void Wait (IMTLFence fence);
 	}
 	
-	public interface IMTLFence {}
+	interface IMTLFence {}
 
 	[iOS (10,0), TV (10,0), NoWatch, NoMac]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public interface MTLFence
+	interface MTLFence
 	{
 		[Abstract]
 		[Export ("device")]
@@ -480,11 +480,11 @@ namespace XamCore.Metal {
 		string Label { get; set; }
 	}
 
-	public interface IMTLDevice {}
+	interface IMTLDevice {}
 	
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public partial interface MTLDevice {
+	partial interface MTLDevice {
 
 		[Abstract, Export ("name")]
 		string Name { get; }
@@ -657,11 +657,11 @@ namespace XamCore.Metal {
 		bool SupportsTextureSampleCount (nuint sampleCount);
 	}
 
-	public interface IMTLDrawable {}
+	interface IMTLDrawable {}
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public partial interface MTLDrawable {
+	partial interface MTLDrawable {
 		[Abstract, Export ("present")]
 		void Present ();
 		
@@ -669,13 +669,13 @@ namespace XamCore.Metal {
 		void Present (double presentationTime);
 	}
 
-	public interface IMTLTexture {}
+	interface IMTLTexture {}
 
 	// Apple added several new *required* members in iOS 9,
 	// but that breaks our binary compat, so we can't do that in our existing code.
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public partial interface MTLTexture : MTLResource {
+	partial interface MTLTexture : MTLResource {
 		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0)]
 		[Abstract, Export ("rootResource")]
 		IMTLResource RootResource { get; }
@@ -794,7 +794,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public partial interface MTLTextureDescriptor : NSCopying {
+	partial interface MTLTextureDescriptor : NSCopying {
 
 		[Export ("textureType", ArgumentSemantic.Assign)]
 		MTLTextureType TextureType { get; set; }
@@ -844,7 +844,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public partial interface MTLSamplerDescriptor : NSCopying {
+	partial interface MTLSamplerDescriptor : NSCopying {
 
 		[Export ("minFilter", ArgumentSemantic.Assign)]
 		MTLSamplerMinMagFilter MinFilter { get; set; }
@@ -896,10 +896,10 @@ namespace XamCore.Metal {
 		string Label { get; set; }
 	}
 
-	public interface IMTLSamplerState {}
+	interface IMTLSamplerState {}
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public partial interface MTLSamplerState  {
+	partial interface MTLSamplerState  {
 
 		[Abstract, Export ("label")]
 		string Label { get; }
@@ -910,7 +910,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public partial interface MTLRenderPipelineDescriptor : NSCopying {
+	partial interface MTLRenderPipelineDescriptor : NSCopying {
 
 		// [NullAllowed] we can't allow setting null - even if the default value is null
 		// /SourceCache/AcceleratorKit/AcceleratorKit-14.9/Framework/MTLRenderPipeline.mm:627: failed assertion `label must not be nil.'
@@ -987,7 +987,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public interface MTLRenderPipelineColorAttachmentDescriptorArray {
+	interface MTLRenderPipelineColorAttachmentDescriptorArray {
 
 		[Export ("objectAtIndexedSubscript:"), Internal]
 		MTLRenderPipelineColorAttachmentDescriptor ObjectAtIndexedSubscript (nuint attachmentIndex);
@@ -996,11 +996,11 @@ namespace XamCore.Metal {
 		void SetObject (MTLRenderPipelineColorAttachmentDescriptor attachment, nuint attachmentIndex);
 	}
 
-	public interface IMTLRenderPipelineState {}
+	interface IMTLRenderPipelineState {}
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public partial interface MTLRenderPipelineState {
+	partial interface MTLRenderPipelineState {
 
 		[Abstract, Export ("label")]
 		string Label { get; }
@@ -1011,7 +1011,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public interface MTLVertexBufferLayoutDescriptor : NSCopying {
+	interface MTLVertexBufferLayoutDescriptor : NSCopying {
 		[Export ("stride", ArgumentSemantic.UnsafeUnretained)]
 		nuint Stride { get; set; }
 
@@ -1024,7 +1024,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public interface MTLVertexBufferLayoutDescriptorArray {
+	interface MTLVertexBufferLayoutDescriptorArray {
 		[Export ("objectAtIndexedSubscript:"), Internal]
 		MTLVertexBufferLayoutDescriptor ObjectAtIndexedSubscript (nuint index);
 
@@ -1034,7 +1034,7 @@ namespace XamCore.Metal {
 
 	[iOS (10,0), TV (10,0), NoWatch, Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(NSObject))]
-	public interface MTLAttribute
+	interface MTLAttribute
 	{
 		[NullAllowed, Export ("name")]
 		string Name { get; }
@@ -1057,7 +1057,7 @@ namespace XamCore.Metal {
 	
 	[iOS (10,0), TV (10,0), NoWatch, Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(NSObject))]
-	public interface MTLAttributeDescriptor : NSCopying
+	interface MTLAttributeDescriptor : NSCopying
 	{
 		[Export ("format", ArgumentSemantic.Assign)]
 		MTLAttributeFormat Format { get; set; }
@@ -1071,7 +1071,7 @@ namespace XamCore.Metal {
 
 	[iOS (10,0), TV (10,0), NoWatch, Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(NSObject))]
-	public interface MTLAttributeDescriptorArray
+	interface MTLAttributeDescriptorArray
 	{
 		[Internal]
 		[Export ("objectAtIndexedSubscript:")]
@@ -1084,7 +1084,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public interface MTLVertexAttributeDescriptor : NSCopying {
+	interface MTLVertexAttributeDescriptor : NSCopying {
 		[Export ("format", ArgumentSemantic.Assign)]
 		MTLVertexFormat Format { get; set; }
 
@@ -1097,7 +1097,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public interface MTLVertexAttributeDescriptorArray {
+	interface MTLVertexAttributeDescriptorArray {
 		[Export ("objectAtIndexedSubscript:"), Internal]
 		MTLVertexAttributeDescriptor ObjectAtIndexedSubscript (nuint index);
 
@@ -1107,7 +1107,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public partial interface MTLVertexDescriptor : NSCopying {
+	partial interface MTLVertexDescriptor : NSCopying {
 		[Static, Export ("vertexDescriptor")]
 		MTLVertexDescriptor Create ();
 
@@ -1123,7 +1123,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public partial interface MTLVertexAttribute {
+	partial interface MTLVertexAttribute {
 		[Export ("attributeIndex")]
 		nuint AttributeIndex { get; }
 
@@ -1149,7 +1149,7 @@ namespace XamCore.Metal {
 	[iOS (10,0), TV (10,0), NoWatch, Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
-	public interface MTLFunctionConstantValues : NSCopying
+	interface MTLFunctionConstantValues : NSCopying
 	{
 		[Export ("setConstantValue:type:atIndex:")]
 		void SetConstantValue (IntPtr value, MTLDataType type, nuint index);
@@ -1166,7 +1166,7 @@ namespace XamCore.Metal {
 	
 	[iOS (10,0), TV (10,0), NoWatch, Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(NSObject))]
-	public interface MTLFunctionConstant
+	interface MTLFunctionConstant
 	{
 		[Export ("name")]
 		string Name { get; }
@@ -1181,10 +1181,10 @@ namespace XamCore.Metal {
 		bool IsRequired { get; }
 	}
 
-	public interface IMTLFunction {}
+	interface IMTLFunction {}
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public partial interface MTLFunction  {
+	partial interface MTLFunction  {
 
 		[iOS (10, 0), TV (10,0), NoWatch, Mac (10,12)]
 #if XAMCORE_4_0
@@ -1234,11 +1234,11 @@ namespace XamCore.Metal {
 		NSDictionary<NSString, MTLFunctionConstant> FunctionConstants { get; }
 	}
 
-	public interface IMTLLibrary {}
+	interface IMTLLibrary {}
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public partial interface MTLLibrary  {
+	partial interface MTLLibrary  {
 
 		[Abstract, Export ("label")]
 		string Label { get; set; }
@@ -1273,7 +1273,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public partial interface MTLCompileOptions : NSCopying {
+	partial interface MTLCompileOptions : NSCopying {
 
 		[NullAllowed] // by default this property is null
 		[Export ("preprocessorMacros", ArgumentSemantic.Copy)]
@@ -1289,7 +1289,7 @@ namespace XamCore.Metal {
 	
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public partial interface MTLStencilDescriptor : NSCopying {
+	partial interface MTLStencilDescriptor : NSCopying {
 		[Export ("stencilCompareFunction")]
 		MTLCompareFunction StencilCompareFunction { get; set; }
 
@@ -1311,7 +1311,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public interface MTLStructMember {
+	interface MTLStructMember {
 		[Export ("name")]
 		string Name { get; }
 
@@ -1338,7 +1338,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public interface MTLStructType {
+	interface MTLStructType {
 		[Export ("members")]
 		MTLStructMember [] Members { get; }
 
@@ -1346,11 +1346,11 @@ namespace XamCore.Metal {
 		MTLStructMember Lookup (string name);
 	}
 
-	public interface IMTLDepthStencilState {}
+	interface IMTLDepthStencilState {}
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public partial interface MTLDepthStencilState  {
+	partial interface MTLDepthStencilState  {
 #if XAMCORE_2_0
 		[Abstract]
 #endif
@@ -1366,7 +1366,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public partial interface MTLDepthStencilDescriptor : NSCopying {
+	partial interface MTLDepthStencilDescriptor : NSCopying {
 
 		[Export ("depthCompareFunction")]
 		MTLCompareFunction DepthCompareFunction { get; set; }
@@ -1386,11 +1386,11 @@ namespace XamCore.Metal {
 		string Label { get; set; }
 	}
 
-	public interface IMTLParallelRenderCommandEncoder {}
+	interface IMTLParallelRenderCommandEncoder {}
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public interface MTLParallelRenderCommandEncoder : MTLCommandEncoder {
+	interface MTLParallelRenderCommandEncoder : MTLCommandEncoder {
 		[Abstract]
 		[Export ("renderCommandEncoder")]
 		[Autorelease]
@@ -1418,11 +1418,11 @@ namespace XamCore.Metal {
 		void SetStencilStoreAction (MTLStoreAction storeAction);
 	}
 
-	public interface IMTLRenderCommandEncoder {}
+	interface IMTLRenderCommandEncoder {}
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public partial interface MTLRenderCommandEncoder : MTLCommandEncoder {
+	partial interface MTLRenderCommandEncoder : MTLCommandEncoder {
 
 		[Abstract, Export ("setRenderPipelineState:")]
 		void SetRenderPipelineState (IMTLRenderPipelineState pipelineState);
@@ -1667,7 +1667,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public interface MTLRenderPipelineColorAttachmentDescriptor : NSCopying {
+	interface MTLRenderPipelineColorAttachmentDescriptor : NSCopying {
 
 		[Export ("pixelFormat", ArgumentSemantic.Assign)]
 		MTLPixelFormat PixelFormat { get; set; }
@@ -1699,7 +1699,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public interface MTLRenderPipelineReflection {
+	interface MTLRenderPipelineReflection {
 		[Export ("vertexArguments")]
 #if XAMCORE_4_0
 		MTLArgument [] VertexArguments { get; }
@@ -1754,14 +1754,14 @@ namespace XamCore.Metal {
 	
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (MTLRenderPassAttachmentDescriptor))]
-	public interface MTLRenderPassColorAttachmentDescriptor {
+	interface MTLRenderPassColorAttachmentDescriptor {
 		[Export ("clearColor")]
 		MTLClearColor ClearColor { get; set; }
 	}
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (MTLRenderPassAttachmentDescriptor))]
-	public interface MTLRenderPassDepthAttachmentDescriptor {
+	interface MTLRenderPassDepthAttachmentDescriptor {
 
 		[Export ("clearDepth")]
 		double ClearDepth { get; set; }
@@ -1774,7 +1774,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (MTLRenderPassAttachmentDescriptor))]
-	public interface MTLRenderPassStencilAttachmentDescriptor {
+	interface MTLRenderPassStencilAttachmentDescriptor {
 
 		[Export ("clearStencil")]
 		uint ClearStencil { get; set; } /* uint32_t */
@@ -1782,7 +1782,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public interface MTLRenderPassColorAttachmentDescriptorArray {
+	interface MTLRenderPassColorAttachmentDescriptorArray {
 		[Export ("objectAtIndexedSubscript:"), Internal]
 		MTLRenderPassColorAttachmentDescriptor ObjectAtIndexedSubscript (nuint attachmentIndex);
 
@@ -1792,7 +1792,7 @@ namespace XamCore.Metal {
 
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
-	public interface MTLRenderPassDescriptor : NSCopying {
+	interface MTLRenderPassDescriptor : NSCopying {
 
 		[Export ("colorAttachments")]
 		MTLRenderPassColorAttachmentDescriptorArray ColorAttachments { get; }
@@ -1821,7 +1821,7 @@ namespace XamCore.Metal {
 	[iOS (10, 0), TV (10,0), NoWatch, NoMac]
 	[BaseType (typeof(NSObject))]
 	// note: type works only on devices, symbol is missing on the simulator
-	public interface MTLHeapDescriptor : NSCopying
+	interface MTLHeapDescriptor : NSCopying
 	{
 		[Export ("size")]
 		nuint Size { get; set; }
@@ -1835,7 +1835,7 @@ namespace XamCore.Metal {
 	
 	[iOS (10, 0), TV (10,0), NoWatch, NoMac]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public interface MTLHeap
+	interface MTLHeap
 	{
 		[Abstract]
 		[NullAllowed, Export ("label")]
@@ -1878,11 +1878,11 @@ namespace XamCore.Metal {
 		MTLPurgeableState SetPurgeableState (MTLPurgeableState state);
 	}
 	
-	public interface IMTLResource {}
-	public interface IMTLHeap {}
+	interface IMTLResource {}
+	interface IMTLHeap {}
 	[iOS (8,0)][Mac (10,11, onlyOn64 : true)]
 	[Protocol] // From Apple Docs: Your app does not define classes that implement this protocol. Model is not needed
-	public partial interface MTLResource  {
+	partial interface MTLResource  {
 
 		[Abstract, Export ("label")]
 		string Label { get; set; }
@@ -1927,7 +1927,7 @@ namespace XamCore.Metal {
 
 	[iOS (9,0)][Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
-	public interface MTLComputePipelineDescriptor : NSCopying {
+	interface MTLComputePipelineDescriptor : NSCopying {
 		// it's marked as `nullable` but it asserts with
 		// /BuildRoot/Library/Caches/com.apple.xbs/Sources/Metal/Metal-54.18/Framework/MTLComputePipeline.mm:216: failed assertion `label must not be nil.'
 		[Export ("label")]
@@ -1951,7 +1951,7 @@ namespace XamCore.Metal {
 	
 	[iOS (10,0), TV (10,0), NoWatch, Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(NSObject))]
-	public interface MTLStageInputOutputDescriptor : NSCopying
+	interface MTLStageInputOutputDescriptor : NSCopying
 	{
 		[Static]
 		[Export ("stageInputOutputDescriptor")]

--- a/src/multipeerconnectivity.cs
+++ b/src/multipeerconnectivity.cs
@@ -23,7 +23,7 @@ namespace XamCore.MultipeerConnectivity {
 	[Since (7,0)][Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: -[MCPeerID init]: unrecognized selector sent to instance 0x7d721090
-	public partial interface MCPeerID : NSCopying, NSSecureCoding {
+	partial interface MCPeerID : NSCopying, NSSecureCoding {
 
 		[DesignatedInitializer]
 		[Export ("initWithDisplayName:")]
@@ -33,13 +33,13 @@ namespace XamCore.MultipeerConnectivity {
 		string DisplayName { get; }
 	}
 
-	public delegate void MCSessionNearbyConnectionDataForPeerCompletionHandler (NSData connectionData, NSError error);
+	delegate void MCSessionNearbyConnectionDataForPeerCompletionHandler (NSData connectionData, NSError error);
 
 	[TV (10,0)]
 	[Since (7,0)][Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // crash when calling `description` selector
-	public partial interface MCSession {
+	partial interface MCSession {
 
 		[Export ("initWithPeer:")]
 		IntPtr Constructor (MCPeerID myPeerID);
@@ -109,7 +109,7 @@ namespace XamCore.MultipeerConnectivity {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public partial interface MCSessionDelegate {
+	partial interface MCSessionDelegate {
 		[Abstract]
 		[Export ("session:peer:didChangeState:")]
 		void DidChangeState (MCSession session, MCPeerID peerID, MCSessionState state);
@@ -138,7 +138,7 @@ namespace XamCore.MultipeerConnectivity {
 	[Since (7,0)][Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException -[MCNearbyServiceAdvertiser init]: unrecognized selector sent to instance 0x19195e50
-	public partial interface MCNearbyServiceAdvertiser {
+	partial interface MCNearbyServiceAdvertiser {
 
 		[DesignatedInitializer]
 		[Export ("initWithPeer:discoveryInfo:serviceType:")]
@@ -167,14 +167,14 @@ namespace XamCore.MultipeerConnectivity {
 		string ServiceType { get; }
 	}
 
-	public delegate void MCNearbyServiceAdvertiserInvitationHandler (bool accept, [NullAllowed] MCSession session);
+	delegate void MCNearbyServiceAdvertiserInvitationHandler (bool accept, [NullAllowed] MCSession session);
 
 	[TV (10,0)]
 	[Since (7,0)][Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public partial interface MCNearbyServiceAdvertiserDelegate {
+	partial interface MCNearbyServiceAdvertiserDelegate {
 
 #if XAMCORE_2_0
 		[Abstract]
@@ -190,7 +190,7 @@ namespace XamCore.MultipeerConnectivity {
 	[Since (7,0)][Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException -[MCNearbyServiceBrowser init]: unrecognized selector sent to instance 0x15519a70
-	public partial interface MCNearbyServiceBrowser {
+	partial interface MCNearbyServiceBrowser {
 
 		[DesignatedInitializer]
 		[Export ("initWithPeer:serviceType:")]
@@ -224,7 +224,7 @@ namespace XamCore.MultipeerConnectivity {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public partial interface MCNearbyServiceBrowserDelegate {
+	partial interface MCNearbyServiceBrowserDelegate {
 
 #if XAMCORE_2_0
 		[Abstract]
@@ -245,7 +245,7 @@ namespace XamCore.MultipeerConnectivity {
 		void DidNotStartBrowsingForPeers (MCNearbyServiceBrowser browser, NSError error);
 	}
 
-	public interface IMCNearbyServiceBrowserDelegate {}
+	interface IMCNearbyServiceBrowserDelegate {}
 
 #if MONOMAC
 	[Mac (10,10, onlyOn64 : true)]
@@ -256,7 +256,7 @@ namespace XamCore.MultipeerConnectivity {
 	[BaseType (typeof (UIViewController))]
 #endif
 	[DisableDefaultCtor] // NSInvalidArgumentException -[MCPeerPickerViewController initWithNibName:bundle:]: unrecognized selector sent to instance 0x15517b90
-	public partial interface MCBrowserViewController : MCNearbyServiceBrowserDelegate {
+	partial interface MCBrowserViewController : MCNearbyServiceBrowserDelegate {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
 		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
@@ -293,7 +293,7 @@ namespace XamCore.MultipeerConnectivity {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public partial interface MCBrowserViewControllerDelegate {
+	partial interface MCBrowserViewControllerDelegate {
 
 #if XAMCORE_2_0
 		[Abstract]

--- a/src/newsstandkit.cs
+++ b/src/newsstandkit.cs
@@ -16,7 +16,7 @@ namespace XamCore.NewsstandKit {
 	// <quote>You create an NKAssetDownload instance using the NKIssue method addAssetWithRequest:</quote> -> http://developer.apple.com/library/ios/#documentation/StoreKit/Reference/NKAssetDownload_Class/NKAssetDownload/NKAssetDownload.html
 	// init returns NIL
 	[DisableDefaultCtor]
-	public interface NKAssetDownload {
+	interface NKAssetDownload {
 		[Export ("issue", ArgumentSemantic.Weak)]
 		NKIssue Issue { get;  }
 
@@ -39,7 +39,7 @@ namespace XamCore.NewsstandKit {
 	// http://developer.apple.com/library/ios/#documentation/StoreKit/Reference/NKIssue_Class/NKIssue/NKIssue.html#//apple_ref/occ/cl/NKIssue
 	// init returns NIL
 	[DisableDefaultCtor]
-	public interface NKIssue {
+	interface NKIssue {
 		[Export ("downloadingAssets", ArgumentSemantic.Copy)]
 		NKAssetDownload [] DownloadingAssets { get;  }
 

--- a/src/notificationcenter.cs
+++ b/src/notificationcenter.cs
@@ -138,7 +138,7 @@ namespace XamCore.NotificationCenter {
 		nuint GetRow (NSViewController viewController);
 	}
 
-	public interface INCWidgetListViewDelegate {}
+	interface INCWidgetListViewDelegate {}
 
 	[Mac (10, 10)]
 	[Protocol, Model]
@@ -185,7 +185,7 @@ namespace XamCore.NotificationCenter {
 		string SearchResultKeyPath { get; set; }
 	}
 
-	public interface INCWidgetSearchViewDelegate {}
+	interface INCWidgetSearchViewDelegate {}
 
 	[Mac (10,10)]
 	[Protocol, Model]

--- a/src/opengles.cs
+++ b/src/opengles.cs
@@ -20,7 +20,7 @@ namespace XamCore.OpenGLES {
 	[BaseType (typeof (NSObject))]
 	// <quote>It is created when an EAGLContext object is initialized and disposed of when the last EAGLContext object that references it is released.</quote>
 	[DisableDefaultCtor]
-	public interface EAGLSharegroup {
+	interface EAGLSharegroup {
 
 		[iOS (6,0)]
 		[Export ("debugLabel")]
@@ -29,7 +29,7 @@ namespace XamCore.OpenGLES {
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // init now marked with NS_UNAVAILABLE
-	public interface EAGLContext {
+	interface EAGLContext {
 		[Export ("initWithAPI:")]
 		IntPtr Constructor (EAGLRenderingAPI api);
 
@@ -75,7 +75,7 @@ namespace XamCore.OpenGLES {
 
 	[Protocol]
 	// no [Model] because "The EAGLDrawable protocol is not intended to be implemented by objects outside of the iOS."
-	public interface EAGLDrawable {
+	interface EAGLDrawable {
 		[Abstract]
 		[NullAllowed] // by default this property is null
 		[Export ("drawableProperties", ArgumentSemantic.Copy)]

--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -191,8 +191,8 @@ namespace XamCore.PassKit {
 	}
 
 #if !WATCH
-	public delegate void PKPaymentShippingAddressSelected (PKPaymentAuthorizationStatus status, PKShippingMethod [] shippingMethods, PKPaymentSummaryItem [] summaryItems);
-	public delegate void PKPaymentShippingMethodSelected (PKPaymentAuthorizationStatus status, PKPaymentSummaryItem[] summaryItems);
+	delegate void PKPaymentShippingAddressSelected (PKPaymentAuthorizationStatus status, PKShippingMethod [] shippingMethods, PKPaymentSummaryItem [] summaryItems);
+	delegate void PKPaymentShippingMethodSelected (PKPaymentAuthorizationStatus status, PKPaymentSummaryItem[] summaryItems);
 
 #if !XAMCORE_2_0
 	delegate void PKPaymentAuthorizationHandler (PKPaymentAuthorizationStatus status);
@@ -273,7 +273,7 @@ namespace XamCore.PassKit {
 	[Watch (3,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public interface PKPaymentSummaryItem {
+	interface PKPaymentSummaryItem {
 		[NullAllowed] // by default this property is null
 		[Export ("label")]
 		string Label { get; set; }
@@ -298,7 +298,7 @@ namespace XamCore.PassKit {
 	[Watch (3,0)]
 	[iOS (8,0)]
 	[BaseType (typeof (PKPaymentSummaryItem))]
-	public interface PKShippingMethod {
+	interface PKShippingMethod {
 		[NullAllowed] // by default this property is null
 		[Export ("identifier")]
 		string Identifier { get; set; }
@@ -630,7 +630,7 @@ namespace XamCore.PassKit {
 	
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface PKObject : NSCoding, NSSecureCoding, NSCopying {
+	partial interface PKObject : NSCoding, NSSecureCoding, NSCopying {
 		//Empty class in header file
 	}
 

--- a/src/pdfkit.cs
+++ b/src/pdfkit.cs
@@ -44,7 +44,7 @@ namespace XamCore.PdfKit {
 #if XAMCORE_2_0
 	[Abstract]
 #endif
-	public interface PdfAction : NSCopying {
+	interface PdfAction : NSCopying {
 		//This is an abstract superclass with no public init - should it have a private constructor??
 		//As it is, I can create instances, that segfault when you access the type method.
 		//marking the method as [Abstract] doesn't work because the subclasses do not explictly
@@ -54,7 +54,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (PdfAction), Name="PDFActionGoTo")]
-	public interface PdfActionGoTo {
+	interface PdfActionGoTo {
 		[Export ("initWithDestination:")]
 		IntPtr Constructor (PdfDestination destination);
 
@@ -63,7 +63,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (PdfAction), Name="PDFActionNamed")]
-	public interface PdfActionNamed {
+	interface PdfActionNamed {
 		[Export ("initWithName:")]
 		IntPtr Constructor (PdfActionNamedName name);
 
@@ -72,7 +72,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (PdfAction), Name="PDFActionRemoteGoTo")]
-	public interface PdfActionRemoteGoTo {
+	interface PdfActionRemoteGoTo {
 		[Export ("initWithPageIndex:atPoint:fileURL:")]
 		IntPtr Constructor (nint pageIndex, CGPoint point, NSUrl fileUrl);
 
@@ -87,7 +87,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (PdfAction), Name="PDFActionResetForm")]
-	public interface PdfActionResetForm {
+	interface PdfActionResetForm {
 		//has a public Init ???
 		
 		//NSArray of NSString
@@ -99,7 +99,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (PdfAction), Name="PDFActionURL")]
-	public interface PdfActionUrl {
+	interface PdfActionUrl {
 		[Export ("initWithURL:")]
 		IntPtr Constructor (NSUrl url);
 
@@ -108,7 +108,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (NSObject), Name="PDFAnnotation")]
-	public interface PdfAnnotation : NSCoding, NSCopying {
+	interface PdfAnnotation : NSCoding, NSCopying {
 		[Export ("initWithBounds:")]
 		IntPtr Constructor (CGRect bounds);
 
@@ -162,7 +162,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (PdfAnnotation), Name="PDFAnnotationButtonWidget")]
-	public interface PdfAnnotationButtonWidget {
+	interface PdfAnnotationButtonWidget {
 		[Export ("controlType")]
 		PdfWidgetControlType ControlType { get; set; }
 		
@@ -195,7 +195,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (PdfAnnotation), Name="PDFAnnotationChoiceWidget")]
-	public interface PdfAnnotationChoiceWidget {
+	interface PdfAnnotationChoiceWidget {
 		[Export ("stringValue")]
 		string Text { get; set; }
 
@@ -220,13 +220,13 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (PdfAnnotation), Name="PDFAnnotationCircle")]
-	public interface PdfAnnotationCircle {
+	interface PdfAnnotationCircle {
 		[Export ("interiorColor")]
 		NSColor InteriorColor { get; set; }
 	}
 
 	[BaseType (typeof (PdfAnnotation), Name="PDFAnnotationFreeText")]
-	public interface PdfAnnotationFreeText {
+	interface PdfAnnotationFreeText {
 		[Export ("font")]
 		NSFont Font { get; set; }
 
@@ -238,7 +238,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (PdfAnnotation), Name="PDFAnnotationInk")]
-	public interface PdfAnnotationInk {
+	interface PdfAnnotationInk {
 		[Export ("paths")]
 		NSBezierPath [] Paths { get; }
 
@@ -250,7 +250,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (PdfAnnotation), Name="PDFAnnotationLine")]
-	public interface PdfAnnotationLine {
+	interface PdfAnnotationLine {
 		[Export ("startPoint")]
 		CGPoint StartPoint { get; set; }
 
@@ -268,7 +268,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (PdfAnnotation), Name="PDFAnnotationLink")]
-	public interface PdfAnnotationLink {
+	interface PdfAnnotationLink {
 		[Export ("destination")]
 		PdfDestination Destination { get; set; }
 
@@ -280,7 +280,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (PdfAnnotation), Name="PDFAnnotationMarkup")]
-	public interface PdfAnnotationMarkup {
+	interface PdfAnnotationMarkup {
 		[Export ("quadrilateralPoints", ArgumentSemantic.Assign), NullAllowed]
 #if XAMCORE_2_0
 		NSArray WeakQuadrilateralPoints { get; set; }
@@ -293,31 +293,31 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (PdfAnnotation), Name="PDFAnnotationPopup")]
-	public interface PdfAnnotationPopup {
+	interface PdfAnnotationPopup {
 		[Export ("isOpen")]
 		bool IsOpen { get; set; }
 	}
 
 	[BaseType (typeof (PdfAnnotation), Name="PDFAnnotationSquare")]
-	public interface PdfAnnotationSquare {
+	interface PdfAnnotationSquare {
 		[Export ("interiorColor")]
 		NSColor InteriorColor { get; set; }
 	}
 
 	[BaseType (typeof (PdfAnnotation), Name="PDFAnnotationStamp")]
-	public interface PdfAnnotationStamp {
+	interface PdfAnnotationStamp {
 		[Export ("name")]
 		string Name { get; set; }
 	}
 
 	[BaseType (typeof (PdfAnnotation), Name="PDFAnnotationText")]
-	public interface PdfAnnotationText {
+	interface PdfAnnotationText {
 		[Export ("iconType")]
 		PdfTextAnnotationIconType IconType { get; set; }
 	}
 
 	[BaseType (typeof (PdfAnnotation), Name="PDFAnnotationTextWidget")]
-	public interface PdfAnnotationTextWidget {
+	interface PdfAnnotationTextWidget {
 		[Export ("stringValue")]
 		string StringValue { get; set; }
 
@@ -344,7 +344,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (NSObject), Name="PDFBorder")]
-	public interface PdfBorder : NSCoding, NSCopying {
+	interface PdfBorder : NSCoding, NSCopying {
 		[Export ("style")]
 		PdfBorderStyle Style { get; set; }
 
@@ -369,7 +369,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (NSObject), Name="PDFDestination")]
-	public interface PdfDestination : NSCopying {
+	interface PdfDestination : NSCopying {
 		[Export ("initWithPage:atPoint:")]
 		IntPtr Constructor (PdfPage page, CGPoint point);
 
@@ -386,7 +386,7 @@ namespace XamCore.PdfKit {
 
 	//Add attributes for delegates/events
 	[BaseType (typeof (NSObject), Name="PDFDocument", Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (PdfDocumentDelegate)})]
-	public interface PdfDocument : NSCopying {
+	interface PdfDocument : NSCopying {
 		[Export ("initWithURL:")]
 		IntPtr Constructor (NSUrl url);
 
@@ -514,7 +514,7 @@ namespace XamCore.PdfKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol (IsInformal = true)]
-	public interface PdfDocumentDelegate {
+	interface PdfDocumentDelegate {
 		[Export ("didMatchString:"), EventArgs ("PdfSelection")]
 		void DidMatchString (PdfSelection sender);
 
@@ -539,7 +539,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (NSObject), Name="PDFOutline")]
-	public interface PdfOutline {
+	interface PdfOutline {
 		// Why did this have a special init????
 		// Constructor/class needs special documentation on how to use one that is created (not obtained from another object).
 
@@ -578,7 +578,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (NSObject), Name="PDFPage")]
-	public interface PdfPage : NSCopying {
+	interface PdfPage : NSCopying {
 		[Export ("initWithImage:")]
 		IntPtr Constructor (NSImage image);
 
@@ -660,7 +660,7 @@ namespace XamCore.PdfKit {
 
 	[BaseType (typeof (NSObject), Name="PDFSelection")]
 	[DisableDefaultCtor] // An uncaught exception was raised: init: not a valid initializer for PDFSelection
-	public interface PdfSelection : NSCopying {
+	interface PdfSelection : NSCopying {
 		[Export ("initWithDocument:")]
 		IntPtr Constructor (PdfDocument document);
 
@@ -704,7 +704,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (NSView), Name="PDFThumbnailView")]
-	public interface PdfThumbnailView {
+	interface PdfThumbnailView {
 		[Export ("PDFView")]
 		PdfView PdfView { get; set; }
 
@@ -732,7 +732,7 @@ namespace XamCore.PdfKit {
 	}
 
 	[BaseType (typeof (NSView), Name="PDFView", Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (PdfViewDelegate)})]
-	public interface PdfView : NSMenuDelegate {
+	interface PdfView : NSMenuDelegate {
 		[Export ("document")]
 		PdfDocument Document { get; set; }
 
@@ -968,7 +968,7 @@ namespace XamCore.PdfKit {
 		NSString DisplayBoxChangedNotification { get; }
 	}
 	
-	public interface PdfViewAnnotationHitEventArgs {
+	interface PdfViewAnnotationHitEventArgs {
 		[Export ("PDFAnnotationHit")]
 		PdfAnnotation AnnotationHit { get; }
 	}
@@ -978,7 +978,7 @@ namespace XamCore.PdfKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol (IsInformal = true)]
-	public interface PdfViewDelegate {
+	interface PdfViewDelegate {
 		//from docs: 'By default, the scale factor is restricted to a range between 0.1 and 10.0 inclusive.'
 		[Export ("PDFViewWillChangeScaleFactor:toScale:"), DelegateName ("PdfViewScale"), DefaultValueFromArgument ("scale")]
 		nfloat WillChangeScaleFactor (PdfView sender, nfloat scale);

--- a/src/photos.cs
+++ b/src/photos.cs
@@ -1017,7 +1017,7 @@ namespace XamCore.Photos
 #endif
 	[Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(NSObject))]
-	public interface PHLivePhoto
+	interface PHLivePhoto
 #if !MONOMAC
 	: NSSecureCoding, NSCopying
 #endif

--- a/src/qtkit.cs
+++ b/src/qtkit.cs
@@ -544,7 +544,7 @@ namespace XamCore.QTKit
 	}
 
 	[Static]
-	public interface QTErrorKey {
+	interface QTErrorKey {
 		[Field ("QTKitErrorDomain")]
 		NSString Domain { get; }
 

--- a/src/safariservices.cs
+++ b/src/safariservices.cs
@@ -43,7 +43,7 @@ namespace XamCore.SafariServices {
 	[Since (7,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSGenericException Misuse of SSReadingList interface. Use class method defaultReadingList.
-	public partial interface SSReadingList {
+	partial interface SSReadingList {
 
 		[NullAllowed]
 		[Static, Export ("defaultReadingList")]

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -69,7 +69,7 @@ namespace XamCore.SceneKit {
 
 #if WATCH
 	// stubs to limit the number of preprocessor directives in the source file
-	public interface CAAnimation {}
+	interface CAAnimation {}
 	interface CALayer {}
 	interface CAMediaTimingFunction {}
 	interface MDLAsset {}
@@ -1958,7 +1958,7 @@ namespace XamCore.SceneKit {
 		[Export ("entriesPassingTest:")]
 		NSObject [] EntriesPassingTest (SCNSceneSourceFilter predicate);		
 	}
-	public delegate bool SCNSceneSourceFilter (NSObject entry, NSString identifier, ref bool stop);
+	delegate bool SCNSceneSourceFilter (NSObject entry, NSString identifier, ref bool stop);
 
 	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
@@ -2611,13 +2611,13 @@ namespace XamCore.SceneKit {
 	}
 
 	[Mac (10,9), iOS (8,0)]
-	public delegate void SCNAnimationEventHandler (CAAnimation animation, NSObject animatedObject, bool playingBackward);
+	delegate void SCNAnimationEventHandler (CAAnimation animation, NSObject animatedObject, bool playingBackward);
 
 	[NoWatch]
 	[Mac (10,9), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	public interface SCNAnimationEvent {
+	interface SCNAnimationEvent {
 		[Static, Export ("animationEventWithKeyTime:block:")]
 		SCNAnimationEvent Create (nfloat keyTime, SCNAnimationEventHandler eventHandler);
 	}
@@ -2625,7 +2625,7 @@ namespace XamCore.SceneKit {
 	[Watch (3,0)]
 	[Mac (10,9), iOS (8,0)]
 	[BaseType (typeof (SCNGeometry))]
-	public partial interface SCNShape {
+	partial interface SCNShape {
 		[NullAllowed] // by default this property is null
 		[Export ("path", ArgumentSemantic.Copy)]
 		NSBezierPath Path { get; set; }

--- a/src/searchkit.cs
+++ b/src/searchkit.cs
@@ -8,7 +8,7 @@ using XamCore.ObjCRuntime;
 
 namespace XamCore.SearchKit {
 	[Static]
-	public interface SKTextAnalysisKeys {
+	interface SKTextAnalysisKeys {
 		[Field ("kSKMinTermLength")]
 		NSString MinTermLengthKey { get; }
 		

--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -21,7 +21,7 @@ namespace XamCore.StoreKit {
 
 	[Since(6,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface SKDownload {
+	partial interface SKDownload {
 #if MONOMAC
 		[Export ("state")]
 		SKDownloadState DownloadState { get;  }
@@ -72,7 +72,7 @@ namespace XamCore.StoreKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public partial interface SKPayment : NSMutableCopying {
+	partial interface SKPayment : NSMutableCopying {
 		[Static]
 		[Export("paymentWithProduct:")]
 		SKPayment CreateFrom (SKProduct product);
@@ -104,7 +104,7 @@ namespace XamCore.StoreKit {
 	}
 
 	[BaseType (typeof (SKPayment))]
-	public interface SKMutablePayment {
+	interface SKMutablePayment {
 		[Static]
 		[Export("paymentWithProduct:")]
 		SKMutablePayment PaymentWithProduct (SKProduct product);
@@ -139,7 +139,7 @@ namespace XamCore.StoreKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface SKPaymentQueue {
+	interface SKPaymentQueue {
 		[Export ("defaultQueue")][Static]
 		SKPaymentQueue DefaultQueue { get; }
 
@@ -191,7 +191,7 @@ namespace XamCore.StoreKit {
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public interface SKProduct {
+	interface SKProduct {
 		[Export ("localizedDescription")]
 		string LocalizedDescription { get; }
 
@@ -238,7 +238,7 @@ namespace XamCore.StoreKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface SKPaymentTransactionObserver {
+	interface SKPaymentTransactionObserver {
 
 		[Export ("paymentQueue:updatedTransactions:")][Abstract]
 		void UpdatedTransactions (SKPaymentQueue queue, SKPaymentTransaction [] transactions);
@@ -258,7 +258,7 @@ namespace XamCore.StoreKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface SKPaymentTransaction {
+	interface SKPaymentTransaction {
 		[Export ("error")]
 		NSError Error { get; }
 
@@ -289,7 +289,7 @@ namespace XamCore.StoreKit {
 	}
 
 	[BaseType (typeof (NSObject), Delegates=new string [] {"WeakDelegate"}, Events=new Type [] {typeof (SKRequestDelegate)})]
-	public interface SKRequest {
+	interface SKRequest {
 		[Export ("delegate", ArgumentSemantic.Assign)][NullAllowed]
 		NSObject WeakDelegate { get; [NullAllowed] set; }
 
@@ -307,7 +307,7 @@ namespace XamCore.StoreKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface SKRequestDelegate {
+	interface SKRequestDelegate {
 		[Export ("requestDidFinish:")]
 		void RequestFinished (SKRequest request);
 		
@@ -318,7 +318,7 @@ namespace XamCore.StoreKit {
 	[Since (7,0)]
 	[Mac (10,9)]
 	[BaseType (typeof (SKRequest))]
-	public interface SKReceiptRefreshRequest {
+	interface SKReceiptRefreshRequest {
 		[Export ("initWithReceiptProperties:")]
 		IntPtr Constructor ([NullAllowed] NSDictionary properties);
 
@@ -347,7 +347,7 @@ namespace XamCore.StoreKit {
 	}
 
 	[BaseType (typeof (SKRequest), Delegates=new string [] {"WeakDelegate"}, Events=new Type [] {typeof (SKProductsRequestDelegate)})]
-	public interface SKProductsRequest {
+	interface SKProductsRequest {
 		[Export ("initWithProductIdentifiers:")]
 		IntPtr Constructor (NSSet productIdentifiersStringSet);
 		
@@ -360,7 +360,7 @@ namespace XamCore.StoreKit {
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public interface SKProductsResponse {
+	interface SKProductsResponse {
 		[Export ("products")]
 		SKProduct [] Products { get; }
 
@@ -371,7 +371,7 @@ namespace XamCore.StoreKit {
 	[BaseType (typeof (SKRequestDelegate))]
 	[Model]
 	[Protocol]
-	public interface SKProductsRequestDelegate {
+	interface SKProductsRequestDelegate {
 		[Export ("productsRequest:didReceiveResponse:")][Abstract][EventArgs ("SKProductsRequestResponse")]
 		void ReceivedResponse (SKProductsRequest request, SKProductsResponse response);
 	}

--- a/src/twitter.cs
+++ b/src/twitter.cs
@@ -14,10 +14,10 @@ using XamCore.Accounts;
 
 namespace XamCore.Twitter {
 
-	public delegate void TWRequestHandler (NSData responseData, NSHttpUrlResponse urlResponse, NSError error);
+	delegate void TWRequestHandler (NSData responseData, NSHttpUrlResponse urlResponse, NSError error);
 
 #if !XAMCORE_2_0
-	public delegate void TWTweetComposeHandler (TWTweetComposeViewControllerResult result);
+	delegate void TWTweetComposeHandler (TWTweetComposeViewControllerResult result);
 #endif
 	
 	[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_6_0, Message = "Use the Social framework")]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -109,25 +109,25 @@ namespace XamCore.UIKit {
 
 #if WATCH
 	// hacks to ease compilation
-	public interface CIColor {}
+	interface CIColor {}
 #else
-	public delegate void NSTextLayoutEnumerateLineFragments (CGRect rect, CGRect usedRectangle, NSTextContainer textContainer, NSRange glyphRange, ref bool stop);
-	public delegate void NSTextLayoutEnumerateEnclosingRects (CGRect rect, ref bool stop);
-	public delegate void UICompletionHandler (bool finished);
-	public delegate void UIOperationHandler (bool success);
-	public delegate void UICollectionViewLayoutInteractiveTransitionCompletion (bool completed, bool finished);
-	public delegate void UIPrinterContactPrinterHandler (bool available);
-	public delegate void UIPrinterPickerCompletionHandler (UIPrinterPickerController printerPickerController, bool userDidSelect, NSError error);
+	delegate void NSTextLayoutEnumerateLineFragments (CGRect rect, CGRect usedRectangle, NSTextContainer textContainer, NSRange glyphRange, ref bool stop);
+	delegate void NSTextLayoutEnumerateEnclosingRects (CGRect rect, ref bool stop);
+	delegate void UICompletionHandler (bool finished);
+	delegate void UIOperationHandler (bool success);
+	delegate void UICollectionViewLayoutInteractiveTransitionCompletion (bool completed, bool finished);
+	delegate void UIPrinterContactPrinterHandler (bool available);
+	delegate void UIPrinterPickerCompletionHandler (UIPrinterPickerController printerPickerController, bool userDidSelect, NSError error);
 
-	public delegate UISplitViewControllerDisplayMode UISplitViewControllerFetchTargetForActionHandler (UISplitViewController svc);
-	public delegate bool UISplitViewControllerDisplayEvent (UISplitViewController splitViewController, UIViewController vc, NSObject sender);
-	public delegate UIViewController UISplitViewControllerGetViewController (UISplitViewController splitViewController);
-	public delegate bool UISplitViewControllerCanCollapsePredicate (UISplitViewController splitViewController, UIViewController secondaryViewController, UIViewController primaryViewController);
-	public delegate UIViewController UISplitViewControllerGetSecondaryViewController (UISplitViewController splitViewController, UIViewController primaryViewController);
-	public delegate void UIActivityViewControllerCompletion (NSString activityType, bool completed, NSExtensionItem [] returnedItems, NSError error);
+	delegate UISplitViewControllerDisplayMode UISplitViewControllerFetchTargetForActionHandler (UISplitViewController svc);
+	delegate bool UISplitViewControllerDisplayEvent (UISplitViewController splitViewController, UIViewController vc, NSObject sender);
+	delegate UIViewController UISplitViewControllerGetViewController (UISplitViewController splitViewController);
+	delegate bool UISplitViewControllerCanCollapsePredicate (UISplitViewController splitViewController, UIViewController secondaryViewController, UIViewController primaryViewController);
+	delegate UIViewController UISplitViewControllerGetSecondaryViewController (UISplitViewController splitViewController, UIViewController primaryViewController);
+	delegate void UIActivityViewControllerCompletion (NSString activityType, bool completed, NSExtensionItem [] returnedItems, NSError error);
 
 	// In the hopes that the parameter is self document: this array  can contain either UIDocuments or UIResponders
-	public delegate void UIApplicationRestorationHandler (NSObject [] uidocumentOrResponderObjects);
+	delegate void UIApplicationRestorationHandler (NSObject [] uidocumentOrResponderObjects);
 
 #if !XAMCORE_3_0
 	[NoWatch]
@@ -280,7 +280,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface NSFileProviderExtension {
+	partial interface NSFileProviderExtension {
 	    [Static, Export ("writePlaceholderAtURL:withMetadata:error:")]
 	    bool WritePlaceholder (NSUrl placeholderUrl, NSDictionary metadata, ref NSError error);
 	
@@ -328,7 +328,7 @@ namespace XamCore.UIKit {
 	[iOS (9,0)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor] // Handle is nil
-	public interface NSLayoutAnchor<AnchorType>
+	interface NSLayoutAnchor<AnchorType>
 	{
 		[Export ("constraintEqualToAnchor:")]
 		NSLayoutConstraint ConstraintEqualTo (NSLayoutAnchor<AnchorType> anchor);
@@ -353,7 +353,7 @@ namespace XamCore.UIKit {
 	[iOS (9,0)]
 	[BaseType (typeof(NSLayoutAnchor<NSLayoutXAxisAnchor>))]
 	[DisableDefaultCtor] // Handle is nil
-	public interface NSLayoutXAxisAnchor
+	interface NSLayoutXAxisAnchor
 	{
 	}
 
@@ -361,7 +361,7 @@ namespace XamCore.UIKit {
 	[iOS (9,0)]
 	[BaseType (typeof(NSLayoutAnchor<NSLayoutYAxisAnchor>))]
 	[DisableDefaultCtor] // Handle is nil
-	public interface NSLayoutYAxisAnchor
+	interface NSLayoutYAxisAnchor
 	{
 	}
 
@@ -369,7 +369,7 @@ namespace XamCore.UIKit {
 	[iOS (9,0)]
 	[BaseType (typeof(NSLayoutAnchor<NSLayoutDimension>))]
 	[DisableDefaultCtor] // Handle is nil
-	public interface NSLayoutDimension
+	interface NSLayoutDimension
 	{
 		[Export ("constraintEqualToConstant:")]
 		NSLayoutConstraint ConstraintEqualTo (nfloat constant);
@@ -403,7 +403,7 @@ namespace XamCore.UIKit {
 	[NoWatch]
 	[Since (6,0)]
 	[BaseType (typeof (NSObject))]
-	public interface NSLayoutConstraint {
+	interface NSLayoutConstraint {
 		[Static]
 		[Export ("constraintsWithVisualFormat:options:metrics:views:")]
 		NSLayoutConstraint [] FromVisualFormat (string format, NSLayoutFormatOptions formatOptions, [NullAllowed] NSDictionary metrics, NSDictionary views);
@@ -467,7 +467,7 @@ namespace XamCore.UIKit {
 	[NoWatch]
 	[iOS (7,0)] // Yup, it is declared as appearing in 7.0, even if it shipped with 8.0
 	[Category, BaseType(typeof(NSLayoutConstraint))]
-	public interface NSIdentifier {
+	interface NSIdentifier {
 		[Export ("identifier")]
 		string GetIdentifier ();
 
@@ -667,7 +667,7 @@ namespace XamCore.UIKit {
 	[Model]
 	[Protocol]
 	[BaseType (typeof (NSObject))]
-	public partial interface NSTextAttachmentContainer {
+	partial interface NSTextAttachmentContainer {
 #if XAMCORE_2_0
 		[Abstract]
 #endif
@@ -683,7 +683,7 @@ namespace XamCore.UIKit {
 
 	[Since (7,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface NSTextAttachment : NSTextAttachmentContainer, NSCoding {
+	partial interface NSTextAttachment : NSTextAttachmentContainer, NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithData:ofType:")]
 		[PostGet ("Contents")]
@@ -712,7 +712,7 @@ namespace XamCore.UIKit {
 	[Protocol]
 	// no [Model] since it's not exposed in any API 
 	// only NSTextContainer conforms to it but it's only queried by iOS itself
-	public interface NSTextLayoutOrientationProvider {
+	interface NSTextLayoutOrientationProvider {
 
 		[Abstract]
 		[Export ("layoutOrientation")]
@@ -726,7 +726,7 @@ namespace XamCore.UIKit {
 
 	[Since (7,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface NSTextContainer : NSTextLayoutOrientationProvider, NSCoding {
+	partial interface NSTextContainer : NSTextLayoutOrientationProvider, NSCoding {
 
 		[DesignatedInitializer]
 		[Export ("initWithSize:")]
@@ -773,7 +773,7 @@ namespace XamCore.UIKit {
 
 	[Since (7,0)]
 	[BaseType (typeof (NSMutableAttributedString), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSTextStorageDelegate)})]
-	public partial interface NSTextStorage {
+	partial interface NSTextStorage {
 		[Export ("layoutManagers")]
 		NSObject [] LayoutManagers { get; }
 
@@ -836,7 +836,7 @@ namespace XamCore.UIKit {
 	[Model]
 	[BaseType (typeof (NSObject))]
 	[Protocol]
-	public partial interface NSTextStorageDelegate {
+	partial interface NSTextStorageDelegate {
 		[Export ("textStorage:willProcessEditing:range:changeInLength:")][EventArgs ("NSTextStorage")]
 		void WillProcessEditing (NSTextStorage textStorage, NSTextStorageEditActions editedMask, NSRange editedRange, nint delta);
 
@@ -847,7 +847,7 @@ namespace XamCore.UIKit {
 
 	[Since (7,0)]
 	[BaseType (typeof (NSObject))]
-	public interface NSLayoutManager : NSCoding {
+	interface NSLayoutManager : NSCoding {
 		[NullAllowed] // by default this property is null
 		[Export ("textStorage", ArgumentSemantic.Assign)]
 		NSTextStorage TextStorage { get; set; }
@@ -1129,7 +1129,7 @@ namespace XamCore.UIKit {
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
 	[Since (7,0)]
-	public partial interface NSLayoutManagerDelegate {
+	partial interface NSLayoutManagerDelegate {
 		[Export ("layoutManager:shouldGenerateGlyphs:properties:characterIndexes:font:forGlyphRange:")]
 		nuint ShouldGenerateGlyphs (NSLayoutManager layoutManager, IntPtr glyphBuffer, IntPtr props, IntPtr charIndexes, UIFont aFont, NSRange glyphRange);
 	
@@ -1221,7 +1221,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[BaseType (typeof (NSObject))]
 	[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_5_0, Message = "Deprecated in iOS 5, use the CoreMotion instead")]
-	public interface UIAcceleration {
+	interface UIAcceleration {
 		[Export ("timestamp")]
 		double Time { get; }
 
@@ -1238,7 +1238,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIAccelerometerDelegate)})]
 	[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_5_0, Message = "Deprecated in iOS 5, use the CoreMotion instead")]
-	public interface UIAccelerometer {
+	interface UIAccelerometer {
 		[Static] [Export ("sharedAccelerometer")]
 		UIAccelerometer SharedAccelerometer { get; }
 
@@ -1257,7 +1257,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UIAccelerometerDelegate {
+	interface UIAccelerometerDelegate {
 #pragma warning disable 618
 		[Export ("accelerometer:didAccelerate:"), EventArgs ("UIAccelerometer"), EventName ("Acceleration")]
 		void DidAccelerate (UIAccelerometer accelerometer, UIAcceleration acceleration);
@@ -1265,7 +1265,7 @@ namespace XamCore.UIKit {
 	}
 #endif // !WATCH
 
-	public interface UIAccessibility {
+	interface UIAccessibility {
 		[Export ("isAccessibilityElement")]
 		bool IsAccessibilityElement { get; set; }
 
@@ -1586,7 +1586,7 @@ namespace XamCore.UIKit {
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Please use the designated initializer
-	public partial interface UIAccessibilityCustomAction {
+	partial interface UIAccessibilityCustomAction {
 	    [Export ("initWithName:target:selector:")]
 	    IntPtr Constructor (string name, NSObject target, Selector selector);
 	
@@ -1696,7 +1696,7 @@ namespace XamCore.UIKit {
 		CGRect AccessibilityFrameInContainerSpace { get; set; }
 	}
 
-	public interface UIAccessibilityFocus {
+	interface UIAccessibilityFocus {
 		[Export ("accessibilityElementDidBecomeFocused")]
 		void AccessibilityElementDidBecomeFocused ();
 
@@ -1711,7 +1711,7 @@ namespace XamCore.UIKit {
 		NSSet<NSString> AccessibilityAssistiveTechnologyFocusedIdentifiers { get; }
 	}
 
-	public interface UIAccessibilityAction {
+	interface UIAccessibilityAction {
 #if !XAMCORE_2_0
 		[New] // To avoid the warning that we are overwriting the method in NSObject.   
 #endif
@@ -1746,7 +1746,7 @@ namespace XamCore.UIKit {
 
 	[NoTV]
 	[BaseType (typeof (UIView), KeepRefUntil="Dismissed", Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIActionSheetDelegate)})]
-	public interface UIActionSheet {
+	interface UIActionSheet {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -1810,13 +1810,13 @@ namespace XamCore.UIKit {
 		void ShowFrom (CGRect rect, UIView inView, bool animated);
 	}
 
-	public interface IUIActionSheetDelegate {}
+	interface IUIActionSheetDelegate {}
 
 	[NoTV]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UIActionSheetDelegate {
+	interface UIActionSheetDelegate {
 
 		[Export ("actionSheet:clickedButtonAtIndex:"), EventArgs ("UIButton")]
 		void Clicked (UIActionSheet actionSheet, nint buttonIndex);
@@ -2014,7 +2014,7 @@ namespace XamCore.UIKit {
 
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface UIAlertAction : NSCopying {
+	partial interface UIAlertAction : NSCopying {
 		[Export ("title")]
 		string Title { get; }
 		
@@ -2030,7 +2030,7 @@ namespace XamCore.UIKit {
 	
 	[iOS (8,0)]
 	[BaseType (typeof (UIViewController))]
-	public partial interface UIAlertController {
+	partial interface UIAlertController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
 		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
@@ -2068,7 +2068,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[BaseType (typeof (UIView), KeepRefUntil="Dismissed", Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIAlertViewDelegate)})]
 	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use UIAlertController with a UIAlertControllerStyle.Alert type instead")]
-	public interface UIAlertView : NSCoding {
+	interface UIAlertView : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
@@ -2137,7 +2137,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UIAlertViewDelegate {
+	interface UIAlertViewDelegate {
 		[Export ("alertView:clickedButtonAtIndex:"), EventArgs ("UIButton")]
 		void Clicked (UIAlertView alertview, nint buttonIndex);
 
@@ -2173,7 +2173,7 @@ namespace XamCore.UIKit {
 	[Model]
 	[DisableDefaultCtor]
 	[Protocol]
-	public interface UIAppearance {
+	interface UIAppearance {
 	}
 
 	[Since (9,0)]
@@ -2229,7 +2229,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UIStateRestoring {
+	interface UIStateRestoring {
 		[Export ("restorationParent")]
 		IUIStateRestoring RestorationParent { get;  }
 
@@ -2246,7 +2246,7 @@ namespace XamCore.UIKit {
 		void ApplicationFinishedRestoringState ();
 	}
 
-	public interface IUIStateRestoring {}
+	interface IUIStateRestoring {}
 
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -2264,7 +2264,7 @@ namespace XamCore.UIKit {
 
 	[iOS(10,0)]
 	[Protocol]
-	public interface UIViewAnimating
+	interface UIViewAnimating
 	{
 		[Abstract]
 		[Export ("state")]
@@ -2303,10 +2303,10 @@ namespace XamCore.UIKit {
 		void FinishAnimation (UIViewAnimatingPosition finalPosition);
 	}
 
-	public interface IUIViewImplicitlyAnimating {}
+	interface IUIViewImplicitlyAnimating {}
 	[iOS(10,0)]
 	[Protocol]
-	public interface UIViewImplicitlyAnimating : UIViewAnimating
+	interface UIViewImplicitlyAnimating : UIViewAnimating
 	{
 		[Export ("addAnimations:delayFactor:")]
 		void AddAnimations (Action animation, nfloat delayFactor);
@@ -2361,7 +2361,7 @@ namespace XamCore.UIKit {
 		UIViewPropertyAnimator CreateRunningPropertyAnimator (double duration, double delay, UIViewAnimationOptions options, [NullAllowed] Action animations, [NullAllowed] Action<UIViewAnimatingPosition> completion);
 	}
 	
-	public interface IUIViewControllerPreviewing {}
+	interface IUIViewControllerPreviewing {}
 	[Protocol]
 	[iOS (9,0)]
 	interface UIViewControllerPreviewing {
@@ -2390,7 +2390,7 @@ namespace XamCore.UIKit {
 		CGRect SourceRect { get; set; }
 	}
 
-	public interface IUIViewControllerPreviewingDelegate {}
+	interface IUIViewControllerPreviewingDelegate {}
 	
 	[Protocol]
 	[Model]
@@ -2448,7 +2448,7 @@ namespace XamCore.UIKit {
 	}
 
 	[StrongDictionary ("UIApplicationOpenUrlOptionKeys")]
-	public interface UIApplicationOpenUrlOptions {
+	interface UIApplicationOpenUrlOptions {
 		NSObject Annotation { get; set; }
 		string SourceApplication { get; set; }
 		bool OpenInPlace { get; set; }
@@ -2460,7 +2460,7 @@ namespace XamCore.UIKit {
 	[iOS (9,0)]
 	[Static]
 	[Internal] // we'll make it public if there's a need for them (beside the strong dictionary we provide)
-	public interface UIApplicationOpenUrlOptionKeys {
+	interface UIApplicationOpenUrlOptionKeys {
 		[Field ("UIApplicationOpenURLOptionsAnnotationKey")]
 		NSString AnnotationKey { get; }
 
@@ -2956,7 +2956,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[iOS (9,0)]
 	[BaseType (typeof(NSObject))]
-	public interface UIApplicationShortcutIcon : NSCopying
+	interface UIApplicationShortcutIcon : NSCopying
 	{
 		[Static]
 		[Export ("iconWithType:")]
@@ -2978,7 +2978,7 @@ namespace XamCore.UIKit {
 	[iOS (9,0)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
-	public interface UIApplicationShortcutItem : NSMutableCopying
+	interface UIApplicationShortcutItem : NSMutableCopying
 	{
 		[Export ("initWithType:localizedTitle:localizedSubtitle:icon:userInfo:")]
 		[DesignatedInitializer]
@@ -3111,7 +3111,7 @@ namespace XamCore.UIKit {
 
 	[iOS (10,0), TV (10,0)]
 	[Protocol]
-	public interface UIContentSizeCategoryAdjusting {
+	interface UIContentSizeCategoryAdjusting {
 		[Abstract]
 		[iOS (10,0), TV (10,0)] // Repeated because of generator bug
 		[Export ("adjustsFontForContentSizeCategory")]
@@ -3168,14 +3168,14 @@ namespace XamCore.UIKit {
 		AccessibilityExtraExtraExtraLarge
 	}
 
-	public interface IUICoordinateSpace {}
+	interface IUICoordinateSpace {}
 	
 	[Protocol]
 	[Model]
 	[BaseType (typeof (NSObject))]
 	[Abstract]
 	[iOS (8,0)]
-	public interface UICoordinateSpace {
+	interface UICoordinateSpace {
 		[Abstract]
 		[Export ("bounds")]
 		CGRect Bounds { get; }
@@ -3423,14 +3423,14 @@ namespace XamCore.UIKit {
 	}
 
 	[Static]
-	public interface UIExtensionPointIdentifier {
+	interface UIExtensionPointIdentifier {
 		[iOS (8,0)]
 		[Field ("UIApplicationKeyboardExtensionPointIdentifier")]
 		NSString Keyboard { get; }
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public interface UIBarItem : NSCoding, UIAppearance, UIAccessibility, UIAccessibilityIdentification {
+	interface UIBarItem : NSCoding, UIAppearance, UIAccessibility, UIAccessibilityIdentification {
 		[Export ("enabled")][Abstract]
 		bool Enabled { [Bind ("isEnabled")] get; set; }
 
@@ -3469,7 +3469,7 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof (UIBarItem))]
-	public interface UIBarButtonItem : NSCoding {
+	interface UIBarButtonItem : NSCoding {
 		[Export ("initWithImage:style:target:action:")]
 		[PostGet ("Image")]
 		[PostGet ("Target")]
@@ -3620,7 +3620,7 @@ namespace XamCore.UIKit {
 
 	[iOS (9,0)]
 	[BaseType (typeof(NSObject))]
-	public interface UIBarButtonItemGroup : NSCoding
+	interface UIBarButtonItemGroup : NSCoding
 	{
 		[DesignatedInitializer]
 		[Export ("initWithBarButtonItems:representativeItem:")]
@@ -4385,7 +4385,7 @@ namespace XamCore.UIKit {
 	
 	[Since (7,0)]
 	[BaseType (typeof (UICollectionViewLayoutInvalidationContext))]
-	public partial interface UICollectionViewFlowLayoutInvalidationContext {
+	partial interface UICollectionViewFlowLayoutInvalidationContext {
 		[Export ("invalidateFlowLayoutDelegateMetrics")]
 		bool InvalidateFlowLayoutDelegateMetrics { get; set; }
 	
@@ -4451,7 +4451,7 @@ namespace XamCore.UIKit {
 	// returns NIL handle causing exceptions in further calls, e.g. ToString
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -CGColor not defined for the UIColor <UIPlaceholderColor: 0x114f5ad0>; need to first convert colorspace.
 	[DisableDefaultCtor]
-	public interface UIColor : NSSecureCoding, NSCopying {
+	interface UIColor : NSSecureCoding, NSCopying {
 		[Export ("colorWithWhite:alpha:")][Static]
 		UIColor FromWhiteAlpha (nfloat white, nfloat alpha);
 
@@ -4892,7 +4892,7 @@ namespace XamCore.UIKit {
 
 	[Since (7,0)]
 	[BaseType (typeof (UIDynamicBehavior))]
-	public interface UIDynamicItemBehavior {
+	interface UIDynamicItemBehavior {
 		[DesignatedInitializer]
 		[Export ("initWithItems:")]
 		IntPtr Constructor ([Params] IUIDynamicItem [] items);
@@ -4951,7 +4951,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Protocol]
 	[Model]
-	public interface UIDynamicItem {
+	interface UIDynamicItem {
 		[Abstract]
 		[Export ("center")]
 		CGPoint Center { get; set;  }
@@ -4985,7 +4985,7 @@ namespace XamCore.UIKit {
 	}
 	
 
-	public interface IUIDynamicItem {}
+	interface IUIDynamicItem {}
 
 	[Since (7,0)]
 	[BaseType (typeof (NSObject))]
@@ -5100,7 +5100,7 @@ namespace XamCore.UIKit {
 	
 	[Static][Internal]
 	[iOS (8,2)]
-	public interface UIFontWeightConstants {
+	interface UIFontWeightConstants {
 		[Field ("UIFontWeightUltraLight")]
 		nfloat UltraLight { get; }
 		[Field ("UIFontWeightThin")]
@@ -5125,7 +5125,7 @@ namespace XamCore.UIKit {
 	[ThreadSafe]
 	[DisableDefaultCtor] // iOS7 -> Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: -[UIFont ctFontRef]: unrecognized selector sent to instance 0x15b283c0
 	// note: because of bug 25511 (managed Dispose / native semi-factory) we need to return a copy of the UIFont for every static method that returns an UIFont
-	public interface UIFont : NSCopying {
+	interface UIFont : NSCopying {
 		[Static] [Export ("systemFontOfSize:")]
 		[Internal] // bug 25511
 		IntPtr _SystemFontOfSize (nfloat size);
@@ -5275,7 +5275,7 @@ namespace XamCore.UIKit {
 	[Since (7,0)]
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
-	public partial interface UIFontDescriptor : NSSecureCoding, NSCopying {
+	partial interface UIFontDescriptor : NSSecureCoding, NSCopying {
 	
 		[Export ("postscriptName")]
 		string PostscriptName { get; }
@@ -5423,7 +5423,7 @@ namespace XamCore.UIKit {
 #if !WATCH
 	[Since (3,2)]
 	[BaseType (typeof(NSObject), Delegates=new string [] {"WeakDelegate"}, Events=new Type[] {typeof (UIGestureRecognizerDelegate)})]
-	public interface UIGestureRecognizer {
+	interface UIGestureRecognizer {
 		[DesignatedInitializer]
 		[Export ("initWithTarget:action:")]
 		IntPtr Constructor (NSObject target, Selector action);
@@ -5567,7 +5567,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof(NSObject))]
 	[Model][Since (3,2)]
 	[Protocol]
-	public interface UIGestureRecognizerDelegate {
+	interface UIGestureRecognizerDelegate {
 		[Export ("gestureRecognizer:shouldReceiveTouch:"), DefaultValue (true), DelegateName ("UITouchEventArgs")]
 		bool ShouldReceiveTouch (UIGestureRecognizer recognizer, UITouch touch);
 
@@ -5670,7 +5670,7 @@ namespace XamCore.UIKit {
 
 	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof(UIGraphicsRendererFormat))]
-	public interface UIGraphicsImageRendererFormat
+	interface UIGraphicsImageRendererFormat
 	{
 		[Export ("scale")]
 		nfloat Scale { get; set; }
@@ -5813,7 +5813,7 @@ namespace XamCore.UIKit {
 	// Even more confusing it that respondToSelecttor return NO on them
 	// even if it works in _real_ life (compare unit and introspection tests)
 	[Protocol]
-	public interface UITextInputTraits {
+	interface UITextInputTraits {
 		[Abstract]
 		[Export ("autocapitalizationType")]
 		UITextAutocapitalizationType AutocapitalizationType { get; set; }
@@ -5871,7 +5871,7 @@ namespace XamCore.UIKit {
 	
 	[NoTV]
 	[Static]
-	public interface UIKeyboard {
+	interface UIKeyboard {
 		[NoTV]
 		[Field ("UIKeyboardWillShowNotification")]
 		[Notification (typeof (UIKeyboardEventArgs))]
@@ -5955,7 +5955,7 @@ namespace XamCore.UIKit {
 
 	[Since (7,0)]
 	[BaseType (typeof (NSObject))]
-	public interface UIKeyCommand : NSCopying, NSSecureCoding {
+	interface UIKeyCommand : NSCopying, NSSecureCoding {
 		[Export ("input")]
 		NSString Input { get; }
 
@@ -5993,7 +5993,7 @@ namespace XamCore.UIKit {
 
 	[Since (5,0)]
 	[Protocol]
-	public interface UIKeyInput : UITextInputTraits {
+	interface UIKeyInput : UITextInputTraits {
 		[Abstract]
 		[Export ("hasText")]
 		bool HasText { get; }
@@ -6008,11 +6008,11 @@ namespace XamCore.UIKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface UITextPosition {
+	interface UITextPosition {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface UITextRange {
+	interface UITextRange {
 		[Export ("isEmpty")]
 		bool IsEmpty { get; }
 
@@ -6037,10 +6037,10 @@ namespace XamCore.UIKit {
 #endif
 	}
 
-	public interface IUITextInput {}
+	interface IUITextInput {}
 
 	[Protocol]
-	public interface UITextInput : UIKeyInput {
+	interface UITextInput : UIKeyInput {
 		[Abstract]
 		[NullAllowed] // by default this property is null
 		[Export ("selectedTextRange", ArgumentSemantic.Copy)]
@@ -6234,7 +6234,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[iOS (9,0)]
 	[BaseType (typeof(NSObject))]
-	public interface UITextInputAssistantItem
+	interface UITextInputAssistantItem
 	{
 		[Export ("allowsHidingShortcuts")]
 		bool AllowsHidingShortcuts { get; set; }
@@ -6249,7 +6249,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UITextInputTokenizer {
+	interface UITextInputTokenizer {
 		[Abstract]
 		[Export ("rangeEnclosingPosition:withGranularity:inDirection:")]
 		UITextRange GetRangeEnclosingPosition (UITextPosition position, UITextGranularity granularity, UITextDirection direction);
@@ -6271,10 +6271,10 @@ namespace XamCore.UIKit {
 	[Since (5,0)]
 #if XAMCORE_2_0
 	[BaseType (typeof (NSObject))]
-	public interface UITextInputStringTokenizer : UITextInputTokenizer{
+	interface UITextInputStringTokenizer : UITextInputTokenizer{
 #else
 	[BaseType (typeof (UITextInputTokenizer))]
-	public interface UITextInputStringTokenizer {
+	interface UITextInputStringTokenizer {
 #endif
 		[Export ("initWithTextInput:")]
 #if XAMCORE_2_0
@@ -6287,7 +6287,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UITextInputDelegate {
+	interface UITextInputDelegate {
 		[Abstract]
 		[Export ("selectionWillChange:")]
 #if XAMCORE_2_0
@@ -6323,7 +6323,7 @@ namespace XamCore.UIKit {
 
 	[Since (6,0)]
 	[BaseType (typeof (NSObject))]
-	public interface UITextSelectionRect {
+	interface UITextSelectionRect {
 		[Export ("rect")]
 		CGRect Rect { get; }
 		
@@ -6343,7 +6343,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface UILexicon : NSCopying {
+	partial interface UILexicon : NSCopying {
 	
 	    [Export ("entries")]
 	    UILexiconEntry [] Entries { get; }
@@ -6352,7 +6352,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface UILexiconEntry : NSCopying {
+	partial interface UILexiconEntry : NSCopying {
 	
 	    [Export ("documentText")]
 	    string DocumentText { get; }
@@ -6363,7 +6363,7 @@ namespace XamCore.UIKit {
 
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	public interface UILocalizedIndexedCollation {
+	interface UILocalizedIndexedCollation {
 		[Export ("sectionTitles")]
 		string [] SectionTitles { get;  }
 
@@ -6389,7 +6389,7 @@ namespace XamCore.UIKit {
 	[Since (4,0)]
 	[BaseType (typeof (NSObject))]
 	[Availability (Deprecated = Platform.iOS_10_0, Message = "Soft deprecated in iOS 10, use UserNotifications.UNNotificationRequest instead")]
-	public interface UILocalNotification : NSCoding, NSCopying {
+	interface UILocalNotification : NSCoding, NSCopying {
 		[Export ("fireDate", ArgumentSemantic.Copy)]
 		[NullAllowed]
 		NSDate FireDate { get; set;  }
@@ -6458,7 +6458,7 @@ namespace XamCore.UIKit {
 #if !WATCH
 	[Since (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
-	public interface UILongPressGestureRecognizer {
+	interface UILongPressGestureRecognizer {
 		[Export ("initWithTarget:action:")]
 		IntPtr Constructor (NSObject target, Selector action);
 
@@ -6478,7 +6478,7 @@ namespace XamCore.UIKit {
 
 	[Since (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
-	public interface UITapGestureRecognizer {
+	interface UITapGestureRecognizer {
 		[Export ("initWithTarget:action:")]
 		IntPtr Constructor (NSObject target, Selector action);
 
@@ -6492,7 +6492,7 @@ namespace XamCore.UIKit {
 
 	[Since (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
-	public interface UIPanGestureRecognizer {
+	interface UIPanGestureRecognizer {
 		[Export ("initWithTarget:action:")]
 		IntPtr Constructor (NSObject target, Selector action);
 
@@ -6517,7 +6517,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[Since (7,0)]
 	[BaseType (typeof (UIPanGestureRecognizer))]
-	public interface UIScreenEdgePanGestureRecognizer {
+	interface UIScreenEdgePanGestureRecognizer {
 
 		// inherit .ctor
 		[Export ("initWithTarget:action:")]
@@ -6534,7 +6534,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[Since(6,0)]
 	[BaseType (typeof (UIControl))]
-	public interface UIRefreshControl : UIAppearance {
+	interface UIRefreshControl : UIAppearance {
 		[Export ("refreshing")]
 		bool Refreshing { [Bind ("isRefreshing")] get;  }
 
@@ -6582,7 +6582,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[Since (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
-	public interface UIRotationGestureRecognizer {
+	interface UIRotationGestureRecognizer {
 		[Export ("initWithTarget:action:")]
 		IntPtr Constructor (NSObject target, Selector action);
 
@@ -6596,7 +6596,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[Since (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
-	public interface UIPinchGestureRecognizer {
+	interface UIPinchGestureRecognizer {
 		[Export ("initWithTarget:action:")]
 		IntPtr Constructor (NSObject target, Selector action);
 
@@ -6609,7 +6609,7 @@ namespace XamCore.UIKit {
 
 	[Since (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
-	public interface UISwipeGestureRecognizer {
+	interface UISwipeGestureRecognizer {
 		[Export ("initWithTarget:action:")]
 		IntPtr Constructor (NSObject target, Selector action);
 
@@ -6622,7 +6622,7 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof(UIView))]
-	public interface UIActivityIndicatorView : NSCoding {
+	interface UIActivityIndicatorView : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
@@ -6654,7 +6654,7 @@ namespace XamCore.UIKit {
 #endif // !WATCH
 
 	[BaseType (typeof (NSObject))]
-	public interface UIImage : NSSecureCoding
+	interface UIImage : NSSecureCoding
 #if !WATCH
 		, UIAccessibility, UIAccessibilityIdentification
 #endif // !WATCH
@@ -6912,7 +6912,7 @@ namespace XamCore.UIKit {
 #if !WATCH
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface UIImageAsset : NSSecureCoding {
+	partial interface UIImageAsset : NSSecureCoding {
 		[Export ("imageWithTraitCollection:")]
 		UIImage FromTraitCollection (UITraitCollection traitCollection);
 		
@@ -6924,7 +6924,7 @@ namespace XamCore.UIKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface UIEvent {
+	interface UIEvent {
 		[Export ("type")]
 		UIEventType Type { get; }
 
@@ -6961,7 +6961,7 @@ namespace XamCore.UIKit {
 	// that's one of the few enums based on CGFloat - we expose the [n]float directly in the API
 	// but we need a way to give access to the constants to developers
 	[Static]
-	public interface UIWindowLevel {
+	interface UIWindowLevel {
 		[Field ("UIWindowLevelNormal")]
 		nfloat Normal { get; }
 
@@ -6974,7 +6974,7 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof (UIView))]
-	public interface UIWindow {
+	interface UIWindow {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -7047,7 +7047,7 @@ namespace XamCore.UIKit {
 	}
 
 	[BaseType (typeof (UIView))]
-	public interface UIControl {
+	interface UIControl {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -7123,7 +7123,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UIBarPositioning {
+	interface UIBarPositioning {
 #if XAMCORE_2_0
 		[Abstract]
 #endif
@@ -7132,13 +7132,13 @@ namespace XamCore.UIKit {
 		UIBarPosition BarPosition { get; }
 	}
 
-	public interface IUIBarPositioning {}
+	interface IUIBarPositioning {}
 
 	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UIBarPositioningDelegate {
+	interface UIBarPositioningDelegate {
 		[Export ("positionForBar:")][DelegateName ("Func<IUIBarPositioning,UIBarPosition>"), NoDefaultValue]
 		UIBarPosition GetPositionForBar (IUIBarPositioning barPositioning);
 	}
@@ -7147,7 +7147,7 @@ namespace XamCore.UIKit {
 	[Since (3,2)]
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
-	public interface UIBezierPath : NSCoding, NSCopying {
+	interface UIBezierPath : NSCoding, NSCopying {
 		// initWithFrame: --> unrecognized selector
 
 		[Export ("bezierPath"), Static]
@@ -7262,7 +7262,7 @@ namespace XamCore.UIKit {
 	
 #if !WATCH
 	[BaseType (typeof (UIControl))]
-	public interface UIButton {
+	interface UIButton {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -7400,7 +7400,7 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof (UIView))]
-	public interface UILabel : UIContentSizeCategoryAdjusting {
+	interface UILabel : UIContentSizeCategoryAdjusting {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -7490,7 +7490,7 @@ namespace XamCore.UIKit {
 	}
 
 	[BaseType (typeof (UIView))]
-	public interface UIImageView {
+	interface UIImageView {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -7546,7 +7546,7 @@ namespace XamCore.UIKit {
 
 	[NoTV]
 	[BaseType (typeof (UIControl))]
-	public interface UIDatePicker {
+	interface UIDatePicker {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -7586,7 +7586,7 @@ namespace XamCore.UIKit {
 
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
-	public interface UIDevice {
+	interface UIDevice {
 		[Static]
 		[Export ("currentDevice")]
 		UIDevice CurrentDevice { get; }
@@ -7685,7 +7685,7 @@ namespace XamCore.UIKit {
 	
 	[Since (5,1)]
 	[BaseType (typeof (NSObject))]
-	public interface UIDictationPhrase {
+	interface UIDictationPhrase {
 		[Export ("alternativeInterpretations")]
 		string[] AlternativeInterpretations { get; }
 		
@@ -7696,7 +7696,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[Since (3,2)]
 	[BaseType (typeof (NSObject), Delegates=new string [] {"WeakDelegate"}, Events=new Type [] {typeof (UIDocumentInteractionControllerDelegate)})]
-	public interface UIDocumentInteractionController {
+	interface UIDocumentInteractionController {
 		[Export ("interactionControllerWithURL:"), Static]
 		UIDocumentInteractionController FromUrl (NSUrl url);
 
@@ -7756,7 +7756,7 @@ namespace XamCore.UIKit {
 	[Model]
 	[Since (3,2)]
 	[Protocol]
-	public interface UIDocumentInteractionControllerDelegate {
+	interface UIDocumentInteractionControllerDelegate {
 		[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_6_0)]
 		[Export ("documentInteractionController:canPerformAction:"), DelegateName ("UIDocumentInteractionProbe"), DefaultValue (false)]
 		bool CanPerformAction (UIDocumentInteractionController controller, [NullAllowed] Selector action);
@@ -7803,7 +7803,7 @@ namespace XamCore.UIKit {
 
 	[NoTV]
 	[BaseType (typeof (UINavigationController), Delegates=new string [] { "Delegate" }, Events=new Type [] {typeof(UIImagePickerControllerDelegate)})]
-	public interface UIImagePickerController {
+	interface UIImagePickerController {
 		[Export ("isSourceTypeAvailable:")][Static]
 		bool IsSourceTypeAvailable (UIImagePickerControllerSourceType sourceType);
 		
@@ -7909,7 +7909,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[Model]
 	[Protocol]
-	public interface UIImagePickerControllerDelegate {
+	interface UIImagePickerControllerDelegate {
 #if !XAMCORE_3_0
 		[Availability (Introduced = Platform.iOS_2_0, Obsoleted = Platform.iOS_3_0)]
 		[Export ("imagePickerController:didFinishPickingImage:editingInfo:"), EventArgs ("UIImagePickerImagePicked")]
@@ -7969,7 +7969,7 @@ namespace XamCore.UIKit {
 
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	public interface UIMenuController {
+	interface UIMenuController {
 		[Static, Export ("sharedMenuController")]
 		UIMenuController SharedMenuController { get; }
 
@@ -8021,7 +8021,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[Since (3,2)]
 	[BaseType (typeof (NSObject))]
-	public interface UIMenuItem {
+	interface UIMenuItem {
 		[DesignatedInitializer] // TODO: Add an overload that takes an Action maybe?
 		[Export ("initWithTitle:action:")]
 		IntPtr Constructor (string title, Selector action);
@@ -8036,7 +8036,7 @@ namespace XamCore.UIKit {
 	}
 
 	[BaseType (typeof (UIView))]
-	public interface UINavigationBar : UIBarPositioning, NSCoding {
+	interface UINavigationBar : UIBarPositioning, NSCoding {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -8160,7 +8160,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (UIBarPositioningDelegate))]
 	[Model]
 	[Protocol]
-	public interface UINavigationBarDelegate {
+	interface UINavigationBarDelegate {
 		[Export ("navigationBar:didPopItem:")]
 		void DidPopItem (UINavigationBar navigationBar, UINavigationItem item);
 
@@ -8175,7 +8175,7 @@ namespace XamCore.UIKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface UINavigationItem : NSCoding {
+	interface UINavigationItem : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithTitle:")]
 		IntPtr Constructor (string title);
@@ -8253,7 +8253,7 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof (UIViewController))]
-	public interface UINavigationController {
+	interface UINavigationController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("ViewControllers")] // that will PostGet TopViewController and VisibleViewController too
 		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
@@ -8376,7 +8376,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UINavigationControllerDelegate {
+	interface UINavigationControllerDelegate {
 
 		[Export ("navigationController:willShowViewController:animated:"), EventArgs ("UINavigationController")]
 		void WillShowViewController (UINavigationController navigationController, [Transient] UIViewController viewController, bool animated);
@@ -8412,7 +8412,7 @@ namespace XamCore.UIKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface UINib {
+	interface UINib {
 		// note: the default `init` does not seems to create anything that can be used - but it does not crash when used
 		
 		[Static]
@@ -8431,7 +8431,7 @@ namespace XamCore.UIKit {
 	}
 
 	[BaseType (typeof (UIControl))]
-	public interface UIPageControl : UIAppearance {
+	interface UIPageControl : UIAppearance {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -8587,7 +8587,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: Calling -[UIPasteboard init] is not allowed.
 	[DisableDefaultCtor]
-	public interface UIPasteboard {
+	interface UIPasteboard {
 		[Export ("generalPasteboard")][Static]
 		UIPasteboard General { get; }
 
@@ -8757,7 +8757,7 @@ namespace XamCore.UIKit {
 #if !TVOS
 	[NoWatch, NoTV, iOS (10, 0)]
 	[StrongDictionary ("UIPasteboardOptionKeys")]
-	public interface UIPasteboardOptions {
+	interface UIPasteboardOptions {
 		NSDate ExpirationDate { get; set; }
 		bool LocalOnly { get; set; }
 	}
@@ -8774,7 +8774,7 @@ namespace XamCore.UIKit {
 
 	[NoTV]
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" })]
-	public interface UIPickerView {
+	interface UIPickerView {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -8830,7 +8830,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UIPickerViewDelegate {
+	interface UIPickerViewDelegate {
 		[Export ("pickerView:rowHeightForComponent:")]
 		nfloat GetRowHeight (UIPickerView pickerView, nint component);
 
@@ -8866,7 +8866,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UIPickerViewDataSource {
+	interface UIPickerViewDataSource {
 		[Export ("numberOfComponentsInPickerView:")]
 		[Abstract]
 		nint GetComponentCount (UIPickerView pickerView);
@@ -8880,14 +8880,14 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol (IsInformal = true)]
-	public interface UIPickerViewModel : UIPickerViewDataSource, UIPickerViewDelegate {
+	interface UIPickerViewModel : UIPickerViewDataSource, UIPickerViewDelegate {
 	}
 
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public partial interface UIContentContainer {
+	partial interface UIContentContainer {
 		[Abstract]
 		[Export ("preferredContentSize")]
 		CGSize PreferredContentSize { get; }
@@ -8915,13 +8915,13 @@ namespace XamCore.UIKit {
 
 	[iOS(8,0),Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public partial interface UIAppearanceContainer {
+	partial interface UIAppearanceContainer {
 	}
 	
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: Don't call -[UIPresentationController init].
-	public partial interface UIPresentationController : UIAppearanceContainer, UITraitEnvironment, UIContentContainer, UIFocusEnvironment {
+	partial interface UIPresentationController : UIAppearanceContainer, UITraitEnvironment, UIContentContainer, UIFocusEnvironment {
 		[Export ("initWithPresentedViewController:presentingViewController:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (UIViewController presentedViewController, [NullAllowed] UIViewController presentingViewController);
@@ -9007,7 +9007,7 @@ namespace XamCore.UIKit {
 		UIPreviewActionGroup Create (string title, UIPreviewActionStyle style, UIPreviewAction [] actions);
 	}
 	
-	public interface IUIPreviewActionItem {}
+	interface IUIPreviewActionItem {}
 	
 	[iOS (9,0)]
 	[Protocol]
@@ -9018,7 +9018,7 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof (UIView))]
-	public interface UIProgressView : NSCoding {
+	interface UIProgressView : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
@@ -9068,7 +9068,7 @@ namespace XamCore.UIKit {
 
 	[Since (7,0)]
 	[BaseType (typeof (UIDynamicBehavior))]
-	public partial interface UIPushBehavior {
+	partial interface UIPushBehavior {
 		[DesignatedInitializer]
 		[Export ("initWithItems:mode:")]
 		IntPtr Constructor (IUIDynamicItem [] items, UIPushBehaviorMode mode);
@@ -9113,7 +9113,7 @@ namespace XamCore.UIKit {
 	[Since (7,0)]
 	[BaseType (typeof (UIDynamicBehavior))]
 	[DisableDefaultCtor] // Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: init is undefined for objects of type UISnapBehavior
-	public partial interface UISnapBehavior {
+	partial interface UISnapBehavior {
 		[DesignatedInitializer]
 		[Export ("initWithItem:snapToPoint:")]
 		IntPtr Constructor (IUIDynamicItem dynamicItem, CGPoint point);
@@ -9132,7 +9132,7 @@ namespace XamCore.UIKit {
 	// iOS6 returns the following (confusing) message with the default .ctor:
 	// Objective-C exception thrown.  Name: NSGenericException Reason: -[UIReferenceLibraryViewController initWithNibName:bundle:] is not a valid initializer. You must call -[UIReferenceLibraryViewController initWithTerm:].
 	[DisableDefaultCtor]
-	public partial interface UIReferenceLibraryViewController : NSCoding {
+	partial interface UIReferenceLibraryViewController : NSCoding {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
 		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
@@ -9148,7 +9148,7 @@ namespace XamCore.UIKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	public interface UIResponder : UIAccessibilityAction, UIAccessibilityFocus {
+	interface UIResponder : UIAccessibilityAction, UIAccessibilityFocus {
 
 		[Export ("nextResponder")]
 		UIResponder NextResponder { get; } 
@@ -9338,7 +9338,7 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public interface UIScreen : UITraitEnvironment {
+	interface UIScreen : UITraitEnvironment {
 		[Export ("bounds")]
 		CGRect Bounds { get; }
 
@@ -9456,7 +9456,7 @@ namespace XamCore.UIKit {
 	}
 
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIScrollViewDelegate)})]
-	public interface UIScrollView {
+	interface UIScrollView {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -9600,7 +9600,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UIScrollViewDelegate {
+	interface UIScrollViewDelegate {
 
 		[Export ("scrollViewDidScroll:"), EventArgs ("UIScrollView")]
 		void Scrolled (UIScrollView scrollView);
@@ -9656,7 +9656,7 @@ namespace XamCore.UIKit {
 #if TVOS
 	[DisableDefaultCtor] // - (instancetype)init __TVOS_PROHIBITED;
 #endif
-	public interface UISearchBar : UIBarPositioning, UITextInputTraits
+	interface UISearchBar : UIBarPositioning, UITextInputTraits
 #if !TVOS
 		, NSCoding
 #endif
@@ -9852,7 +9852,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (UIBarPositioningDelegate))]
 	[Model]
 	[Protocol]
-	public interface UISearchBarDelegate {
+	interface UISearchBarDelegate {
 		[Export ("searchBarShouldBeginEditing:"), DefaultValue (true), DelegateName ("UISearchBarPredicate")]
 		bool ShouldBeginEditing (UISearchBar searchBar);
 
@@ -9909,7 +9909,7 @@ namespace XamCore.UIKit {
 	
 	[iOS (8,0)]
 	[BaseType (typeof (UIViewController))]
-	public partial interface UISearchController : UIViewControllerTransitioningDelegate, UIViewControllerAnimatedTransitioning {
+	partial interface UISearchController : UIViewControllerTransitioningDelegate, UIViewControllerAnimatedTransitioning {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
 		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
@@ -9955,7 +9955,7 @@ namespace XamCore.UIKit {
 
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public partial interface UISearchControllerDelegate {
+	partial interface UISearchControllerDelegate {
 	    [Export ("willPresentSearchController:")]
 	    void WillPresentSearchController (UISearchController searchController);
 	
@@ -9975,7 +9975,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Availability (Deprecated = Platform.iOS_8_0, Message="Use UISearchController starting with iOS 8.0")]
 	[NoTV]
-	public interface UISearchDisplayController {
+	interface UISearchDisplayController {
 		[Export ("initWithSearchBar:contentsController:")]
 		[PostGet ("SearchBar")]
 		[PostGet ("SearchContentsController")]
@@ -10034,7 +10034,7 @@ namespace XamCore.UIKit {
 	[Model]
 	[Protocol]
 	[NoTV]
-	public interface UISearchDisplayDelegate {
+	interface UISearchDisplayDelegate {
 		
 		[Export ("searchDisplayControllerWillBeginSearch:")]
 		[Availability (Deprecated = Platform.iOS_8_0, Message="Deprecated on iOS 8")]		
@@ -10087,7 +10087,7 @@ namespace XamCore.UIKit {
 	
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public partial interface UISearchResultsUpdating {
+	partial interface UISearchResultsUpdating {
 #if XAMCORE_2_0
 		[Abstract]
 #endif
@@ -10096,7 +10096,7 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof(UIControl))]
-	public interface UISegmentedControl {
+	interface UISegmentedControl {
 		// Not exposed as we need to wrap the NSArray
 		[Export ("initWithItems:")][Internal]
 		IntPtr InitWithItems (IntPtr v);
@@ -10207,7 +10207,7 @@ namespace XamCore.UIKit {
 
 	[NoTV]
 	[BaseType (typeof(UIControl))]
-	public interface UISlider {
+	interface UISlider {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -10306,7 +10306,7 @@ namespace XamCore.UIKit {
 
 	[Since (6,0)]
 	[Static]
-	public interface UIStringAttributeKey {
+	interface UIStringAttributeKey {
 		[Field ("NSFontAttributeName")]
 		NSString Font { get; }
 
@@ -10461,7 +10461,7 @@ namespace XamCore.UIKit {
 #if !WATCH
 	[NoTV]
 	[BaseType (typeof(UIControl))]
-	public interface UISwitch : NSCoding {
+	interface UISwitch : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
@@ -10498,7 +10498,7 @@ namespace XamCore.UIKit {
 	}
 
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UITabBarDelegate)})]
-	public interface UITabBar {
+	interface UITabBar {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -10597,7 +10597,7 @@ namespace XamCore.UIKit {
 	}
 
 	[BaseType (typeof (UIViewController), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UITabBarControllerDelegate)})]
-	public interface UITabBarController : UITabBarDelegate {
+	interface UITabBarController : UITabBarDelegate {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
 		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
@@ -10643,7 +10643,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UITabBarDelegate {
+	interface UITabBarDelegate {
 		[Export ("tabBar:didSelectItem:"), EventArgs ("UITabBarItem")]
 		void ItemSelected (UITabBar tabbar, UITabBarItem item);
 
@@ -10667,7 +10667,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UITabBarControllerDelegate {
+	interface UITabBarControllerDelegate {
 
 		[Export ("tabBarController:shouldSelectViewController:"), DefaultValue (true), DelegateName ("UITabBarSelection")]
 		bool ShouldSelectViewController (UITabBarController tabBarController, UIViewController viewController);
@@ -10714,7 +10714,7 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof (UIBarItem))]
-	public interface UITabBarItem : NSCoding {
+	interface UITabBarItem : NSCoding {
 		[Export ("enabled")][Override]
 		bool Enabled { [Bind ("isEnabled")] get; set; }
 
@@ -10798,7 +10798,7 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof(UIScrollView))]
-	public interface UITableView : NSCoding {
+	interface UITableView : NSCoding {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -11090,10 +11090,10 @@ namespace XamCore.UIKit {
 		
 	}
 
-	public interface IUITableViewDataSourcePrefetching {}
+	interface IUITableViewDataSourcePrefetching {}
 	[iOS (10,0)]
 	[Protocol]
-	public interface UITableViewDataSourcePrefetching
+	interface UITableViewDataSourcePrefetching
 	{
 		[Abstract]
 		[Export ("tableView:prefetchRowsAtIndexPaths:")]
@@ -11109,7 +11109,7 @@ namespace XamCore.UIKit {
 	[Model]
 	[BaseType (typeof (UIScrollViewDelegate))]
 	[Synthetic]
-	public interface UITableViewSource {
+	interface UITableViewSource {
 		[Export ("tableView:numberOfRowsInSection:")]
 		[Abstract]
 		nint RowsInSection (UITableView tableview, nint section);
@@ -11293,7 +11293,7 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof (UIView))]
-	public interface UITableViewCell : NSCoding, UIGestureRecognizerDelegate {
+	interface UITableViewCell : NSCoding, UIGestureRecognizerDelegate {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -11401,7 +11401,7 @@ namespace XamCore.UIKit {
 	}
 
 	[BaseType (typeof (UIViewController))]
-	public interface UITableViewController : UITableViewDataSource, UITableViewDelegate {
+	interface UITableViewController : UITableViewDataSource, UITableViewDelegate {
 		[DesignatedInitializer]
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
@@ -11426,7 +11426,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UITableViewDataSource {
+	interface UITableViewDataSource {
 
 		[Export ("tableView:numberOfRowsInSection:")]
 		[Abstract]
@@ -11469,7 +11469,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (UIScrollViewDelegate))]
 	[Model]
 	[Protocol]	
-	public interface UITableViewDelegate {
+	interface UITableViewDelegate {
 
 		[Export ("tableView:willDisplayCell:forRowAtIndexPath:")]
 		void WillDisplay (UITableView tableView, UITableViewCell cell, NSIndexPath indexPath);
@@ -11616,7 +11616,7 @@ namespace XamCore.UIKit {
 
 	[Since (6,0)]
 	[BaseType (typeof (UIView))]
-	public interface UITableViewHeaderFooterView : UIAppearance, NSCoding {
+	interface UITableViewHeaderFooterView : UIAppearance, NSCoding {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -11648,7 +11648,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public interface UITableViewRowAction : NSCopying {
+	interface UITableViewRowAction : NSCopying {
 		[Export ("style")]
 		UITableViewRowActionStyle Style { get; }
 
@@ -11669,7 +11669,7 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof (UIControl), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UITextFieldDelegate)})]
-	public interface UITextField : UITextInput, UIContentSizeCategoryAdjusting {
+	interface UITextField : UITextInput, UIContentSizeCategoryAdjusting {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -11820,7 +11820,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UITextFieldDelegate {
+	interface UITextFieldDelegate {
 
 		[Export ("textFieldShouldBeginEditing:"), DelegateName ("UITextFieldCondition"), DefaultValue (true)]
 		bool ShouldBeginEditing (UITextField textField);
@@ -11849,7 +11849,7 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof (UIScrollView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UITextViewDelegate)})]
-	public interface UITextView : UITextInput, NSCoding, UIContentSizeCategoryAdjusting {
+	interface UITextView : UITextInput, NSCoding, UIContentSizeCategoryAdjusting {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -11970,7 +11970,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof(UIScrollViewDelegate))]
 	[Model]
 	[Protocol]
-	public interface UITextViewDelegate {
+	interface UITextViewDelegate {
 
 		[Export ("textViewShouldBeginEditing:"), DelegateName ("UITextViewCondition"), DefaultValue ("true")]
 		bool ShouldBeginEditing (UITextView textView);
@@ -12014,7 +12014,7 @@ namespace XamCore.UIKit {
 	
 	[NoTV]
 	[BaseType (typeof (UIView))]
-	public interface UIToolbar : UIBarPositioning {
+	interface UIToolbar : UIBarPositioning {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -12066,7 +12066,7 @@ namespace XamCore.UIKit {
 		UIToolbarDelegate Delegate { get; set; }
 	}
 
-	public interface IUITimingCurveProvider {}
+	interface IUITimingCurveProvider {}
 
 	[iOS (10,0)]
 	[Protocol]
@@ -12088,11 +12088,11 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (UIBarPositioningDelegate))]
 	[Model]
 	[Protocol]
-	public interface UIToolbarDelegate {
+	interface UIToolbarDelegate {
 	}
 	
 	[BaseType (typeof (NSObject))]
-	public interface UITouch {
+	interface UITouch {
 		[Export ("locationInView:")]
 		CGPoint LocationInView ([NullAllowed] UIView view);
 
@@ -12184,7 +12184,7 @@ namespace XamCore.UIKit {
 
 	[NoTV]
 	[BaseType (typeof (UINavigationController), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIVideoEditorControllerDelegate)})]
-	public interface UIVideoEditorController {
+	interface UIVideoEditorController {
 		[Export ("canEditVideoAtPath:")][Static]
 		bool CanEditVideoAtPath (string path);
 
@@ -12211,7 +12211,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[Model]
 	[Protocol]
-	public interface UIVideoEditorControllerDelegate {
+	interface UIVideoEditorControllerDelegate {
 		[Export ("videoEditorController:didSaveEditedVideoToPath:"), EventArgs ("UIPath"), EventName ("Saved")]
 		void VideoSaved (UIVideoEditorController editor, [EventName ("path")] string editedVideoPath);
 	
@@ -12223,7 +12223,7 @@ namespace XamCore.UIKit {
 	}
 		
 	[BaseType (typeof (UIResponder))]
-	public interface UIView : UIAppearance, UIAppearanceContainer, UIAccessibility, UIDynamicItem, NSCoding, UIAccessibilityIdentification, UITraitEnvironment, UICoordinateSpace, UIFocusItem, CALayerDelegate {
+	interface UIView : UIAppearance, UIAppearanceContainer, UIAccessibility, UIDynamicItem, NSCoding, UIAccessibilityIdentification, UITraitEnvironment, UICoordinateSpace, UIFocusItem, CALayerDelegate {
 		[DesignatedInitializer]
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
@@ -12902,7 +12902,7 @@ namespace XamCore.UIKit {
 	}
 
 	[Category, BaseType (typeof (UIView))]
-	public interface UIView_UITextField {
+	interface UIView_UITextField {
 		[Export ("endEditing:")]
 		bool EndEditing (bool force);
 	}
@@ -12919,10 +12919,10 @@ namespace XamCore.UIKit {
 		bool GetHasAmbiguousLayout ();
 	}
 
-	public interface IUIContentContainer {}
+	interface IUIContentContainer {}
 	
 	[BaseType (typeof (UIResponder))]
-	public interface UIViewController : NSCoding, UIAppearanceContainer, UIContentContainer, UITraitEnvironment, UIFocusEnvironment {
+	interface UIViewController : NSCoding, UIAppearanceContainer, UIContentContainer, UITraitEnvironment, UIFocusEnvironment {
 		[DesignatedInitializer]
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
@@ -13478,7 +13478,7 @@ namespace XamCore.UIKit {
 
 	[Since (7,0)]
 	[Protocol, Model, BaseType (typeof (NSObject))]
-	public partial interface UIViewControllerContextTransitioning {
+	partial interface UIViewControllerContextTransitioning {
 		[Abstract]
 		[Export ("containerView")]
 		UIView ContainerView { get; }
@@ -13548,15 +13548,15 @@ namespace XamCore.UIKit {
 		void PauseInteractiveTransition ();
 	}
 
-	public interface IUIViewControllerContextTransitioning {
+	interface IUIViewControllerContextTransitioning {
 	}
 
-	public interface IUITraitEnvironment {}
+	interface IUITraitEnvironment {}
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
 	[iOS (8,0)]
-	public partial interface UITraitEnvironment {
+	partial interface UITraitEnvironment {
 #if XAMCORE_2_0
 		[Abstract]
 #endif
@@ -13574,7 +13574,7 @@ namespace XamCore.UIKit {
 	
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface UITraitCollection : NSCopying, NSSecureCoding {
+	partial interface UITraitCollection : NSCopying, NSSecureCoding {
 		[Export ("userInterfaceIdiom")]
 		UIUserInterfaceIdiom UserInterfaceIdiom { get; }
 
@@ -13653,7 +13653,7 @@ namespace XamCore.UIKit {
 	
 	[Since (7,0)]
 	[Static]
-	public partial interface UITransitionContext {
+	partial interface UITransitionContext {
 		[Field ("UITransitionContextFromViewControllerKey")]
 		NSString FromViewControllerKey { get; }
 
@@ -13672,7 +13672,7 @@ namespace XamCore.UIKit {
 	[Since (7,0)]
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
-	public partial interface UIViewControllerAnimatedTransitioning {
+	partial interface UIViewControllerAnimatedTransitioning {
 		[Abstract]
 		[Export ("transitionDuration:")]
 		double TransitionDuration (IUIViewControllerContextTransitioning transitionContext);
@@ -13688,12 +13688,12 @@ namespace XamCore.UIKit {
 		[Export ("animationEnded:")]
 		void AnimationEnded (bool transitionCompleted);
 	}
-	public interface IUIViewControllerAnimatedTransitioning {}
+	interface IUIViewControllerAnimatedTransitioning {}
 
 	[Since (7,0)]
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
-	public partial interface UIViewControllerInteractiveTransitioning {
+	partial interface UIViewControllerInteractiveTransitioning {
 		[Abstract]
 		[Export ("startInteractiveTransition:")]
 		void StartInteractiveTransition (IUIViewControllerContextTransitioning transitionContext);
@@ -13708,11 +13708,11 @@ namespace XamCore.UIKit {
 		[Export ("wantsInteractiveStart")]
 		bool WantsInteractiveStart { get; }
 	}
-	public interface IUIViewControllerInteractiveTransitioning {}
+	interface IUIViewControllerInteractiveTransitioning {}
 			
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
-	public partial interface UIViewControllerTransitioningDelegate {
+	partial interface UIViewControllerTransitioningDelegate {
 		[Export ("animationControllerForPresentedController:presentingController:sourceController:")]
 #if XAMCORE_2_0
 		IUIViewControllerAnimatedTransitioning GetAnimationControllerForPresentedController (UIViewController presented, UIViewController presenting, UIViewController source);
@@ -13736,7 +13736,7 @@ namespace XamCore.UIKit {
 	
 	[Since (7,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface UIPercentDrivenInteractiveTransition : UIViewControllerInteractiveTransitioning {
+	partial interface UIPercentDrivenInteractiveTransition : UIViewControllerInteractiveTransitioning {
 		[Export ("duration")]
 		nfloat Duration { get; }
 	
@@ -13779,7 +13779,7 @@ namespace XamCore.UIKit {
 	//
 	[Since (7,0)]
 	[Protocol]
-	public partial interface UIViewControllerTransitionCoordinatorContext {
+	partial interface UIViewControllerTransitionCoordinatorContext {
 		[Abstract]
 		[Export ("isAnimated")]
 		bool IsAnimated { get; }
@@ -13846,7 +13846,7 @@ namespace XamCore.UIKit {
 		[Export ("isInterruptible")]
 		bool IsInterruptible { get; }
 	}
-	public interface IUIViewControllerTransitionCoordinatorContext {}
+	interface IUIViewControllerTransitionCoordinatorContext {}
 
 	//
 	// This protocol is only for consumption (there is no API to set a transition coordinator,
@@ -13854,7 +13854,7 @@ namespace XamCore.UIKit {
 	//
 	[Since (7,0)]
 	[Protocol]
-	public partial interface UIViewControllerTransitionCoordinator : UIViewControllerTransitionCoordinatorContext {
+	partial interface UIViewControllerTransitionCoordinator : UIViewControllerTransitionCoordinatorContext {
 		[Abstract]
 		[Export ("animateAlongsideTransition:completion:")]
 		bool AnimateAlongsideTransition (Action<IUIViewControllerTransitionCoordinatorContext> animate,
@@ -13876,17 +13876,17 @@ namespace XamCore.UIKit {
 		[Export ("notifyWhenInteractionChangesUsingBlock:")]
 		void NotifyWhenInteractionChanges (Action<IUIViewControllerTransitionCoordinatorContext> handler);
 	}
-	public interface IUIViewControllerTransitionCoordinator {}
+	interface IUIViewControllerTransitionCoordinator {}
 
 	[Category, BaseType (typeof (UIViewController))]
-	public partial interface TransitionCoordinator_UIViewController {
+	partial interface TransitionCoordinator_UIViewController {
 		[Export ("transitionCoordinator")]
 		IUIViewControllerTransitionCoordinator GetTransitionCoordinator ();
 	}
 
 	[NoTV]
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIWebViewDelegate)})]
-	public interface UIWebView : UIScrollViewDelegate {
+	interface UIWebView : UIScrollViewDelegate {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -13996,7 +13996,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UIWebViewDelegate {
+	interface UIWebViewDelegate {
 		[Export ("webView:shouldStartLoadWithRequest:navigationType:"), DelegateName ("UIWebLoaderControl"), DefaultValue ("true")]
 		bool ShouldStartLoad (UIWebView webView, NSUrlRequest request, UIWebViewNavigationType navigationType);
 
@@ -14012,7 +14012,7 @@ namespace XamCore.UIKit {
 
 	[Since (3,2)]
 	[BaseType (typeof (NSObject))]
-	public interface UITextChecker {
+	interface UITextChecker {
 		[Export ("rangeOfMisspelledWordInString:range:startingAt:wrap:language:")]
 		NSRange RangeOfMisspelledWordInString (string stringToCheck, NSRange range, nint startingOffset, bool wrapFlag, string language);
 
@@ -14121,7 +14121,7 @@ namespace XamCore.UIKit {
 	
 	[Since (3,2)]
 	[BaseType (typeof (UIViewController), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UISplitViewControllerDelegate)})]
-	public interface UISplitViewController {
+	interface UISplitViewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
 		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
@@ -14193,7 +14193,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UISplitViewControllerDelegate {
+	interface UISplitViewControllerDelegate {
 		[NoTV]
 		[Since (7,0)]  // While introduced in 7.0, it was not made public, it was only publicized in iOS 8 and made retroactively supported
 		[Export ("splitViewControllerSupportedInterfaceOrientations:"), DelegateName("Func<UISplitViewController,UIInterfaceOrientationMask>"), DefaultValue(UIInterfaceOrientationMask.All)]
@@ -14260,7 +14260,7 @@ namespace XamCore.UIKit {
 
 	[Category]
 	[BaseType (typeof (UIViewController))]
-	public partial interface UISplitViewController_UIViewController {
+	partial interface UISplitViewController_UIViewController {
 		[iOS (8,0)]
 		[Export ("splitViewController", ArgumentSemantic.Retain)]
 		UISplitViewController GetSplitViewController ();
@@ -14349,7 +14349,7 @@ namespace XamCore.UIKit {
 
 	[Since (5,0)]
 	[BaseType (typeof (NSObject))]
-	public interface UIStoryboard {
+	interface UIStoryboard {
 		[Static]
 		[Export ("storyboardWithName:bundle:")]
 		UIStoryboard FromName (string name, [NullAllowed] NSBundle storyboardBundleOrNil);
@@ -14384,7 +14384,7 @@ namespace XamCore.UIKit {
 	[Since (5,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: Don't call -[UIStoryboardSegue init]
-	public interface UIStoryboardSegue {
+	interface UIStoryboardSegue {
 		[DesignatedInitializer]
 		[Export ("initWithIdentifier:source:destination:"), PostGet ("SourceViewController"), PostGet ("DestinationViewController")]
 		IntPtr Constructor ([NullAllowed] string identifier, UIViewController source, UIViewController destination);
@@ -14411,7 +14411,7 @@ namespace XamCore.UIKit {
 	[Since (9,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] 
-	public interface UIStoryboardUnwindSegueSource {
+	interface UIStoryboardUnwindSegueSource {
 		[Export ("sourceViewController")]
 		UIViewController SourceViewController { get; }
 
@@ -14425,7 +14425,7 @@ namespace XamCore.UIKit {
 	
 	[Since (8,0)]
 	[Protocol]
-	public interface UIPopoverBackgroundViewMethods {
+	interface UIPopoverBackgroundViewMethods {
 		//
 		// These must be overwritten by users, using the [Export ("...")] on the
 		// static method
@@ -14442,7 +14442,7 @@ namespace XamCore.UIKit {
 	
 	[Since (5,0)]
 	[BaseType (typeof (UIView))]
-	public interface UIPopoverBackgroundView : UIPopoverBackgroundViewMethods {
+	interface UIPopoverBackgroundView : UIPopoverBackgroundViewMethods {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -14462,7 +14462,7 @@ namespace XamCore.UIKit {
 	[Since (3,2)]
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIPopoverControllerDelegate)})]
 	[DisableDefaultCtor] // bug #1786
-	public interface UIPopoverController : UIAppearanceContainer {
+	interface UIPopoverController : UIAppearanceContainer {
 		[Export ("initWithContentViewController:")][PostGet ("ContentViewController")]
 		IntPtr Constructor (UIViewController viewController);
 
@@ -14521,7 +14521,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UIPopoverControllerDelegate {
+	interface UIPopoverControllerDelegate {
 		[Export ("popoverControllerDidDismissPopover:"), EventArgs ("UIPopoverController")]
 		void DidDismiss (UIPopoverController popoverController);
 
@@ -14538,7 +14538,7 @@ namespace XamCore.UIKit {
 		Delegates=new string [] {"WeakDelegate"},
 		Events=new Type [] { typeof (UIPopoverPresentationControllerDelegate) })]
 	[DisableDefaultCtor] // NSGenericException Reason: -[UIPopoverController init] is not a valid initializer. You must call -[UIPopoverController initWithContentViewController:]
-	public partial interface UIPopoverPresentationController {
+	partial interface UIPopoverPresentationController {
 		// re-exposed from base class
 		[Export ("initWithPresentedViewController:presentingViewController:")]
 		IntPtr Constructor (UIViewController presentedViewController, [NullAllowed] UIViewController presentingViewController);
@@ -14591,7 +14591,7 @@ namespace XamCore.UIKit {
 
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public partial interface UIAdaptivePresentationControllerDelegate {
+	partial interface UIAdaptivePresentationControllerDelegate {
 		[IgnoredInDelegate]
 		[Export ("adaptivePresentationStyleForPresentationController:")]
 		UIModalPresentationStyle GetAdaptivePresentationStyle (UIPresentationController forPresentationController);
@@ -14614,7 +14614,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[Protocol, Model]
 	[BaseType (typeof (UIAdaptivePresentationControllerDelegate))]
-	public partial interface UIPopoverPresentationControllerDelegate {
+	partial interface UIPopoverPresentationControllerDelegate {
 		[Export ("prepareForPopoverPresentation:"), EventName ("PrepareForPresentation")]
 		void PrepareForPopoverPresentation (UIPopoverPresentationController popoverPresentationController);
 		
@@ -14631,7 +14631,7 @@ namespace XamCore.UIKit {
 	
 	[Since (3,2)]
 	[BaseType (typeof (NSObject))]
-	public interface UIScreenMode {
+	interface UIScreenMode {
 		[Export ("pixelAspectRatio")]
 		nfloat PixelAspectRatio { get; }
 
@@ -14641,7 +14641,7 @@ namespace XamCore.UIKit {
 
 	[Since (4,2)]
 	[BaseType (typeof (NSObject))]
-	public interface UITextInputMode : NSSecureCoding {
+	interface UITextInputMode : NSSecureCoding {
 		[Export ("currentInputMode"), NullAllowed][Static]
 		[Availability (Introduced = Platform.iOS_4_2, Deprecated = Platform.iOS_7_0)]
 		[NoTV]
@@ -14664,7 +14664,7 @@ namespace XamCore.UIKit {
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSGenericException Reason: -[UIPrinter init] not allowed
-	public partial interface UIPrinter {
+	partial interface UIPrinter {
 		[Export ("URL", ArgumentSemantic.Copy)]
 		NSUrl Url { get; }
 	
@@ -14697,7 +14697,7 @@ namespace XamCore.UIKit {
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSGenericException Reason: -[UIPrinterPickerController init] not allowed
-	public partial interface UIPrinterPickerController {
+	partial interface UIPrinterPickerController {
 		[Export ("selectedPrinter")]
 		UIPrinter SelectedPrinter { get; }
 	
@@ -14727,7 +14727,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public partial interface UIPrinterPickerControllerDelegate {
+	partial interface UIPrinterPickerControllerDelegate {
 	
 		[Export ("printerPickerControllerParentViewController:")]
 		UIViewController GetParentViewController (UIPrinterPickerController printerPickerController);
@@ -14754,7 +14754,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[Since (4,2)]
 	[BaseType (typeof (NSObject))]
-	public interface UIPrintPaper {
+	interface UIPrintPaper {
 		[Export ("bestPaperForPageSize:withPapersFromArray:")][Static]
 		UIPrintPaper ForPageSize (CGSize pageSize, UIPrintPaper [] paperList);
 
@@ -14768,7 +14768,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[Since (4,2)]
 	[BaseType (typeof (NSObject))]
-	public interface UIPrintPageRenderer {
+	interface UIPrintPageRenderer {
 		[Export ("footerHeight")]
 		nfloat FooterHeight { get; set; }
 
@@ -14817,7 +14817,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	public interface UIPrintInteractionControllerDelegate {
+	interface UIPrintInteractionControllerDelegate {
 		[Export ("printInteractionControllerParentViewController:"), DefaultValue (null), DelegateName ("UIPrintInteraction")]
 		UIViewController GetViewController (UIPrintInteractionController printInteractionController);
 
@@ -14861,7 +14861,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIPrintInteractionControllerDelegate)})]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: -[UIPrintInteractionController init] not allowed
 	[DisableDefaultCtor]
-	public interface UIPrintInteractionController {
+	interface UIPrintInteractionController {
 		[Wrap ("WeakDelegate")]
 		[Protocolize]
 		UIPrintInteractionControllerDelegate Delegate { get; set; }
@@ -14957,7 +14957,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: -[UIPrintInfo init] not allowed
 	[DisableDefaultCtor]
-	public interface UIPrintInfo : NSCoding, NSCopying {
+	interface UIPrintInfo : NSCoding, NSCopying {
 		[Export ("duplex")]
 		UIPrintInfoDuplex Duplex { get; set; }
 
@@ -14986,33 +14986,33 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[Since (4,2)]
 	[BaseType (typeof (UIPrintFormatter))]
-	public interface UIViewPrintFormatter {
+	interface UIViewPrintFormatter {
 		[Export ("view")]
 		UIView View { get; }
 	}
 
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface UIVisualEffect : NSCopying, NSSecureCoding {
+	partial interface UIVisualEffect : NSCopying, NSSecureCoding {
 	}
 
 	[iOS (8,0)]
 	[BaseType (typeof (UIVisualEffect))]
-	public partial interface UIBlurEffect {
+	partial interface UIBlurEffect {
 	    [Static, Export ("effectWithStyle:")]
 	    UIBlurEffect FromStyle (UIBlurEffectStyle style);
 	}
 
 	[iOS (8,0)]
 	[BaseType (typeof (UIVisualEffect))]
-	public partial interface UIVibrancyEffect {
+	partial interface UIVibrancyEffect {
 	    [Static, Export ("effectForBlurEffect:")]
 	    UIVibrancyEffect FromBlurEffect (UIBlurEffect blurEffect);
 	}
 		
 	[iOS (8,0)]
 	[BaseType (typeof (UIView))]
-	public partial interface UIVisualEffectView : NSSecureCoding {
+	partial interface UIVisualEffectView : NSSecureCoding {
 	
 		[DesignatedInitializer]
 		[Export ("initWithEffect:")]
@@ -15032,7 +15032,7 @@ namespace XamCore.UIKit {
 	// accessing the properties fails with 7.0GM if the default `init` is used to create the instance, e.g. 
 	// [UISimpleTextPrintFormatter color]: unrecognized selector sent to instance 0x18bd70d0
 	[DisableDefaultCtor]
-	public interface UISimpleTextPrintFormatter {
+	interface UISimpleTextPrintFormatter {
 		[NullAllowed]
 		[Export ("color", ArgumentSemantic.Retain)]
 		UIColor Color { get; set; }
@@ -15064,7 +15064,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[Since (4,2)]
 	[BaseType (typeof (NSObject))]
-	public interface UIPrintFormatter : NSCopying {
+	interface UIPrintFormatter : NSCopying {
 
 		[Deprecated (PlatformName.iOS, 10, 0, message:"Use PerPageContentInsets instead")]
 		[Export ("contentInsets")]
@@ -15105,7 +15105,7 @@ namespace XamCore.UIKit {
 #if XAMCORE_4_0
 	[DisableDefaultCtor] // nonfunctional (and it doesn't show up in the header anyway)
 #endif
-	public interface UIMarkupTextPrintFormatter {
+	interface UIMarkupTextPrintFormatter {
 		[NullAllowed] // by default this property is null
 		[Export ("markupText", ArgumentSemantic.Copy)]
 		string MarkupText { get; set; }
@@ -15116,7 +15116,7 @@ namespace XamCore.UIKit {
 
 	[Since(7,0)]
 	[BaseType (typeof (NSObject))]
-	public interface UIMotionEffect : NSCoding, NSCopying {
+	interface UIMotionEffect : NSCoding, NSCopying {
 		[Export ("keyPathsAndRelativeValuesForViewerOffset:")]
 		NSDictionary ComputeKeyPathsAndRelativeValues (UIOffset viewerOffset);
 	}
@@ -15299,7 +15299,7 @@ namespace XamCore.UIKit {
 	[NoWatch]
 	[Since (7,0)]
 	[BaseType (typeof (UIView))]
-	public interface UIInputView : NSCoding {
+	interface UIInputView : NSCoding {
 		[DesignatedInitializer]
 		[Export ("initWithFrame:inputViewStyle:")]
 		IntPtr Constructor (CGRect frame, UIInputViewStyle inputViewStyle);
@@ -15312,15 +15312,15 @@ namespace XamCore.UIKit {
 		bool AllowsSelfSizing { get; set; }
 	}
 
-	public interface IUITextInputDelegate {
+	interface IUITextInputDelegate {
 	}
 
-	public interface IUITextDocumentProxy {}
+	interface IUITextDocumentProxy {}
 	
 	[NoWatch]
 	[iOS (8,0)]
 	[BaseType (typeof (UIViewController))]
-	public partial interface UIInputViewController : UITextInputDelegate {
+	partial interface UIInputViewController : UITextInputDelegate {
 
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
@@ -15356,7 +15356,7 @@ namespace XamCore.UIKit {
 	[iOS (8,0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public partial interface UITextDocumentProxy : UIKeyInput {
+	partial interface UITextDocumentProxy : UIKeyInput {
 		[Abstract]
 		[Export ("documentContextBeforeInput")]
 		string DocumentContextBeforeInput { get; }
@@ -15382,7 +15382,7 @@ namespace XamCore.UIKit {
 	[NoWatch]
 	[iOS (9,0)]
 	[BaseType (typeof(NSObject))]
-	public interface UILayoutGuide : NSCoding
+	interface UILayoutGuide : NSCoding
 	{
 		[Export ("layoutFrame")]
 		CGRect LayoutFrame { get; }
@@ -15431,7 +15431,7 @@ namespace XamCore.UIKit {
 	[Protocol]
 	[Model]
 	[BaseType (typeof (NSObject))]
-	public interface UILayoutSupport {
+	interface UILayoutSupport {
 		[Export ("length")]
 		[Abstract]
 		nfloat Length { get; }
@@ -15463,7 +15463,7 @@ namespace XamCore.UIKit {
 #endif // XAMCORE_2_0
 	}
 
-	public interface IUILayoutSupport {}
+	interface IUILayoutSupport {}
 
 	// This protocol is supposed to be an aggregate to existing classes,
 	// at the moment there is no API that require a specific UIAccessibilityIdentification
@@ -15471,7 +15471,7 @@ namespace XamCore.UIKit {
 	[NoWatch]
 	[Since (5, 0)]
 	[Protocol]
-	public interface UIAccessibilityIdentification {
+	interface UIAccessibilityIdentification {
 		[Abstract]
 		[NullAllowed] // by default this property is null
 		[Export ("accessibilityIdentifier", ArgumentSemantic.Copy)]
@@ -15485,7 +15485,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface UIUserNotificationSettings : NSCoding, NSSecureCoding, NSCopying {
+	partial interface UIUserNotificationSettings : NSCoding, NSSecureCoding, NSCopying {
 
 		[Export ("types")]
 		UIUserNotificationType Types { get; }
@@ -15502,7 +15502,7 @@ namespace XamCore.UIKit {
 	[iOS (8,0)]
 	[Deprecated (PlatformName.iOS, 10, 0, message: "Soft deprecated in iOS 10, use UserNotifications.UNNotificationCategory")]
 	[BaseType (typeof (NSObject))]
-	public partial interface UIUserNotificationCategory : NSCopying, NSMutableCopying, NSSecureCoding {
+	partial interface UIUserNotificationCategory : NSCopying, NSMutableCopying, NSSecureCoding {
 
 		[Export ("identifier")]
 		string Identifier { get; }
@@ -15516,7 +15516,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[iOS (8,0)]
 	[BaseType (typeof (UIUserNotificationCategory))]
-	public partial interface UIMutableUserNotificationCategory {
+	partial interface UIMutableUserNotificationCategory {
 
 		[NullAllowed] // by default this property is null
 		[Export ("identifier")]
@@ -15531,7 +15531,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
-	public partial interface UIUserNotificationAction : NSCopying, NSMutableCopying, NSSecureCoding {
+	partial interface UIUserNotificationAction : NSCopying, NSMutableCopying, NSSecureCoding {
 
 		[Export ("identifier")]
 		string Identifier { get; }
@@ -15583,7 +15583,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[iOS (8,0)]
 	[BaseType (typeof (UIUserNotificationAction))]
-	public partial interface UIMutableUserNotificationAction {
+	partial interface UIMutableUserNotificationAction {
 
 		[NullAllowed] // by default this property is null
 		[Export ("identifier", ArgumentSemantic.Copy)]
@@ -15617,7 +15617,7 @@ namespace XamCore.UIKit {
 	[iOS (8,0)]
 	[BaseType (typeof (UIViewController), Delegates=new string [] {"Delegate"}, Events=new Type [] {typeof (UIDocumentMenuDelegate)})]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: You cannot initialize a UIDocumentMenuViewController except by the initWithDocumentTypes:inMode: and initWithURL:inMode: initializers.
-	public partial interface UIDocumentMenuViewController : NSCoding {
+	partial interface UIDocumentMenuViewController : NSCoding {
 
 		[DesignatedInitializer]
 		[Export ("initWithDocumentTypes:inMode:")]
@@ -15643,7 +15643,7 @@ namespace XamCore.UIKit {
 	[iOS (8,0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public partial interface UIDocumentMenuDelegate {
+	partial interface UIDocumentMenuDelegate {
 		[Abstract]
 		[Export ("documentMenu:didPickDocumentPicker:"), EventArgs ("UIDocumentMenuDocumentPicked")]
 		void DidPickDocumentPicker (UIDocumentMenuViewController documentMenu, UIDocumentPickerViewController documentPicker);
@@ -15660,7 +15660,7 @@ namespace XamCore.UIKit {
 	[iOS (8,0)]
 	[BaseType (typeof (UIViewController), Delegates=new string [] {"Delegate"}, Events=new Type [] {typeof (UIDocumentPickerDelegate)})]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: You cannot initialize a UIDocumentPickerViewController except by the initWithDocumentTypes:inMode: and initWithURL:inMode: initializers
-	public partial interface UIDocumentPickerViewController : NSCoding {
+	partial interface UIDocumentPickerViewController : NSCoding {
 
 		[DesignatedInitializer]
 		[Export ("initWithDocumentTypes:inMode:")]
@@ -15686,7 +15686,7 @@ namespace XamCore.UIKit {
 	[iOS (8,0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
-	public partial interface UIDocumentPickerDelegate {
+	partial interface UIDocumentPickerDelegate {
 		[Abstract]
 		[Export ("documentPicker:didPickDocumentAtURL:"), EventArgs ("UIDocumentPicked")]
 		void DidPickDocument (UIDocumentPickerViewController controller, NSUrl url);
@@ -15699,7 +15699,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[iOS (8,0)]
 	[BaseType (typeof (UIViewController))]
-	public partial interface UIDocumentPickerExtensionViewController {
+	partial interface UIDocumentPickerExtensionViewController {
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
 		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
@@ -15822,7 +15822,7 @@ namespace XamCore.UIKit {
 	[NoWatch]
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
-	public interface UIFocusAnimationCoordinator {
+	interface UIFocusAnimationCoordinator {
 		[Export ("addCoordinatedAnimations:completion:")]
 		void AddCoordinatedAnimations ([NullAllowed] Action animations, [NullAllowed] Action completion);
 	}
@@ -15843,10 +15843,10 @@ namespace XamCore.UIKit {
 		IUIFocusEnvironment[] PreferredFocusEnvironments { get; set; }
 	}
 
-	public interface IUIFocusItem {}
+	interface IUIFocusItem {}
 	[iOS (10,0)]
 	[Protocol]
-	public interface UIFocusItem : UIFocusEnvironment
+	interface UIFocusItem : UIFocusEnvironment
 	{
 		[Abstract]
 		[Export ("canBecomeFocused")]
@@ -15856,7 +15856,7 @@ namespace XamCore.UIKit {
 	[NoWatch]
 	[iOS (9,0)]
 	[BaseType (typeof(NSObject))]
-	public interface UIFocusUpdateContext {
+	interface UIFocusUpdateContext {
 		[NullAllowed, Export ("previouslyFocusedView", ArgumentSemantic.Weak)]
 		UIView PreviouslyFocusedView { get; }
 
@@ -15878,7 +15878,7 @@ namespace XamCore.UIKit {
 	[NoWatch]
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
-	public interface UIPress {
+	interface UIPress {
 		[Export ("timestamp")]
 		double /* NSTimeInterval */ Timestamp { get; }
 
@@ -15904,7 +15904,7 @@ namespace XamCore.UIKit {
 	[NoWatch]
 	[iOS (9,0)]
 	[BaseType (typeof (UIEvent))]
-	public interface UIPressesEvent {
+	interface UIPressesEvent {
 		[Export ("allPresses")]
 		NSSet<UIPress> AllPresses { get; }
 
@@ -15962,7 +15962,7 @@ namespace XamCore.UIKit {
 	[NoWatch]
 	[iOS (9,0)]
 	[BaseType (typeof (UIFocusUpdateContext))]
-	public interface UITableViewFocusUpdateContext {
+	interface UITableViewFocusUpdateContext {
 		
 		[Export ("previouslyFocusedIndexPath", ArgumentSemantic.Strong)]
 		NSIndexPath PreviouslyFocusedIndexPath { [return: NullAllowed] get; }
@@ -15971,11 +15971,11 @@ namespace XamCore.UIKit {
 		NSIndexPath NextFocusedIndexPath { [return: NullAllowed] get; }
 	}
 
-	public interface IUIFocusEnvironment {}
+	interface IUIFocusEnvironment {}
 	[NoWatch]
 	[iOS (9,0)]
 	[Protocol]
-	public interface UIFocusEnvironment {
+	interface UIFocusEnvironment {
 		// Apple moved this member to @optional since they deprecated it
 		// but that's a breaking change for us, so it remains [Abstract]
 		// and we need to teach the intro and xtro tests about it

--- a/src/videosubscriberaccount.cs
+++ b/src/videosubscriberaccount.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // VideoSubscriberAccount bindings
 //
 // Authors:
@@ -60,7 +60,7 @@ namespace XamCore.VideoSubscriberAccount {
 	[Introduced (PlatformName.TvOS, 10, 0)]
 	[Unavailable (PlatformName.WatchOS)]
 	[StrongDictionary ("VSErrorInfoKeys")]
-	public interface VSErrorInfo {
+	interface VSErrorInfo {
 
 		string SamlResponse { get; }
 

--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -1319,7 +1319,7 @@ namespace XamCore.WebKit {
 		[Export ("handleEvent:")]
 		void HandleEvent (DomEvent evt);
 	}
-	public interface IDomEventListener {}
+	interface IDomEventListener {}
 	
 	[BaseType (typeof (DomCharacterData), Name="DOMProcessingInstruction")]
 	[DisableDefaultCtor] // An uncaught exception was raised: +[DOMProcessingInstruction init]: should never be used
@@ -2043,7 +2043,7 @@ namespace XamCore.WebKit {
 		void Cancel ();
 	}
 
-	public interface IWebOpenPanelResultListener {}
+	interface IWebOpenPanelResultListener {}
 
 	[BaseType (typeof (NSObject))]
 	[Model]

--- a/src/wkwebkit.cs
+++ b/src/wkwebkit.cs
@@ -513,7 +513,7 @@ namespace XamCore.WebKit
 		SecTrust ServerTrust { get; }
 	}
 
-	public delegate void WKJavascriptEvaluationResult (NSObject result, NSError error);
+	delegate void WKJavascriptEvaluationResult (NSObject result, NSError error);
 
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)] // Not defined in 32-bit
 	[BaseType (typeof (NSObject))]


### PR DESCRIPTION
This PR was originally going to be just the commenting in / fixing of the macOS specific CloudKit APIs that were waiting on CloudKit bindings.

However, significant pain occurred when I tried to comment them in due to the fact that AppKit/Foundation had public bindings and CloudKit did not. I could not have a public w\ a non-public API.

I looked at adding public to just the bits of CloudKit, but it would quickly spread to most the API. Removing public piecemeal was even worse, due to this chain:

NSItemProvider -> NSExtensionItem -> NSExtensionContext -> {NS,UI}ViewController

So I bit the bullet and removed ALL the public interfaces / partial interface / delegates in the generated code.
