### PR TITLE
[registrar] Look up the right type when getting the constrained type for a generic type. Fixes #44309.

### DIFF
--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -455,6 +455,15 @@ namespace XamCore.Registrar {
 
 			if (type.IsGenericParameter) {
 				if (typeof (NSObject).IsAssignableFrom (type)) {
+					// First look for a more specific constraint
+					var constraints = type.GetGenericParameterConstraints ();
+					foreach (var constraint in constraints) {
+						if (constraint.IsSubclassOf (typeof (NSObject))) {
+							constrained_type = constraint;
+							return true;
+						}
+					}
+					// Fallback to NSObject.
 					constrained_type = typeof(NSObject);
 					return true;
 				}

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2501,6 +2501,14 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[DllImport ("/usr/lib/libobjc.dylib")]
 		static extern IntPtr method_getName (IntPtr method);
 #endif
+
+		[Test]
+		public void TestConstrainedGenericType2 ()
+		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+			using (var m = new NSMeasurement<NSUnitTemperature> (2, NSUnitTemperature.Fahrenheit)) {
+			}
+		}
 	}
 
 #if !__WATCHOS__


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=44309