### PR TITLE
[msbuild] Require Xcode >= 7.2 in order to make use of ibtool --link

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
@@ -42,7 +42,7 @@ namespace Xamarin.MacDev.Tasks
 		}
 
 		protected bool CanLinkStoryboards {
-			get { return AppleSdkSettings.XcodeVersion.Major >= 7; }
+			get { return AppleSdkSettings.XcodeVersion.Major > 7 || (AppleSdkSettings.XcodeVersion.Major == 7 && AppleSdkSettings.XcodeVersion.Minor >= 2); }
 		}
 
 		protected override void AppendCommandLineArguments (IDictionary<string, string> environment, ProcessArgumentBuilder args, ITaskItem[] items)


### PR DESCRIPTION
I'm not 100% sure when --link was added to ibtool, but since our
release notes say that we now require Xcode >= 7.2 anyway, might
as well make that version a requirement for ibtool --link

(Based on forum comments, we know it didn't exist in Xcode 7.0 Beta 3)