### PR TITLE
[XM] Mark CITextFeature as 64-bit only

### DIFF
--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -2253,7 +2253,7 @@ namespace XamCore.CoreImage {
 	}
 
 	[iOS (9,0)]
-	[Mac (10,12)]
+	[Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof (CIFeature))]
 	interface CITextFeature {
 		[Export ("bounds")]


### PR DESCRIPTION
- Behind #if __OBJC2__ and verified via
 nm --arch=i386 /System/Library/Frameworks/CoreImage.framework/CoreImage | grep CITextFeature
 nm --arch=x86_64 /System/Library/Frameworks/CoreImage.framework/CoreImage | grep CITextFeature
 00000000000eb2e2 t -[CITextFeature bottomLeft]