### PR TITLE
[uikit] Add UIFontTextStyle enum to ease UIFont[Descriptor].GetPreferred* API usage. Fixes #42967

### DIFF
--- a/src/UIKit/UIFont.cs
+++ b/src/UIKit/UIFont.cs
@@ -29,70 +29,70 @@ namespace XamCore.UIKit {
 		[iOS (7,0)]
 		public static UIFont PreferredHeadline {
 			get {
-				return GetPreferredFontForTextStyle (UIFont.TextStyleHeadline);
+				return GetPreferredFontForTextStyle (UIFontTextStyle.Headline);
 			}
 		}
 		
 		[iOS (7,0)]
 		public static UIFont PreferredBody {
 			get {
-				return GetPreferredFontForTextStyle (UIFont.TextStyleBody);
+				return GetPreferredFontForTextStyle (UIFontTextStyle.Body);
 			}
 		}
 		
 		[iOS (7,0)]
 		public static UIFont PreferredSubheadline {
 			get {
-				return GetPreferredFontForTextStyle (UIFont.TextStyleSubheadline);
+				return GetPreferredFontForTextStyle (UIFontTextStyle.Subheadline);
 			}
 		}
 		
 		[iOS (7,0)]
 		public static UIFont PreferredFootnote {
 			get {
-				return GetPreferredFontForTextStyle (UIFont.TextStyleFootnote);
+				return GetPreferredFontForTextStyle (UIFontTextStyle.Footnote);
 			}
 		}
 		
 		[iOS (7,0)]
 		public static UIFont PreferredCaption1 {
 			get {
-				return GetPreferredFontForTextStyle (UIFont.TextStyleCaption1);
+				return GetPreferredFontForTextStyle (UIFontTextStyle.Caption1);
 			}
 		}
 		
 		[iOS (7,0)]
 		public static UIFont PreferredCaption2 {
 			get {
-				return GetPreferredFontForTextStyle (UIFont.TextStyleCaption2);
+				return GetPreferredFontForTextStyle (UIFontTextStyle.Caption2);
 			}
 		}
 
 		[iOS (9,0)]
 		public static UIFont PreferredTitle1 {
 			get {
-				return GetPreferredFontForTextStyle (UIFont.TextStyleTitle1);
+				return GetPreferredFontForTextStyle (UIFontTextStyle.Title1);
 			}
 		}
 		
 		[iOS (9,0)]
 		public static UIFont PreferredTitle2 {
 			get {
-				return GetPreferredFontForTextStyle (UIFont.TextStyleTitle2);
+				return GetPreferredFontForTextStyle (UIFontTextStyle.Title2);
 			}
 		}
 		
 		[iOS (9,0)]
 		public static UIFont PreferredTitle3 {
 			get {
-				return GetPreferredFontForTextStyle (UIFont.TextStyleTitle3);
+				return GetPreferredFontForTextStyle (UIFontTextStyle.Title3);
 			}
 		}
 		
 		[iOS (9,0)]
 		public static UIFont PreferredCallout {
 			get {
-				return GetPreferredFontForTextStyle (UIFont.TextStyleCallout);
+				return GetPreferredFontForTextStyle (UIFontTextStyle.Callout);
 			}
 		}
 
@@ -152,12 +152,24 @@ namespace XamCore.UIKit {
 			return ptr == IntPtr.Zero ? null : new UIFont (ptr);
 		}
 
+		[Availability (Introduced = Platform.iOS_7_0)]
+		public static UIFont GetPreferredFontForTextStyle (UIFontTextStyle uiFontTextStyle)
+		{
+			return GetPreferredFontForTextStyle (uiFontTextStyle.GetConstant ());
+		}
+
 #if !WATCH
 		[Availability (Introduced = Platform.iOS_7_0)]
 		public static UIFont GetPreferredFontForTextStyle (NSString uiFontTextStyle, UITraitCollection traitCollection)
 		{
 			var ptr = _GetPreferredFontForTextStyle (uiFontTextStyle, traitCollection);
 			return ptr == IntPtr.Zero ? null : new UIFont (ptr);
+		}
+
+		[Availability (Introduced = Platform.iOS_7_0)]
+		public static UIFont GetPreferredFontForTextStyle (UIFontTextStyle uiFontTextStyle, UITraitCollection traitCollection)
+		{
+			return GetPreferredFontForTextStyle (uiFontTextStyle.GetConstant (), traitCollection);
 		}
 #endif
 

--- a/src/UIKit/UIFontDescriptor.cs
+++ b/src/UIKit/UIFontDescriptor.cs
@@ -205,65 +205,65 @@ namespace XamCore.UIKit {
 	public partial class UIFontDescriptor {
 		public static UIFontDescriptor PreferredHeadline {
 			get {
-				return GetPreferredDescriptorForTextStyle (UIFont.TextStyleHeadline);
+				return GetPreferredDescriptorForTextStyle (UIFontTextStyle.Headline);
 			}
 		}
 		
 		public static UIFontDescriptor PreferredBody {
 			get {
-				return GetPreferredDescriptorForTextStyle (UIFont.TextStyleBody);
+				return GetPreferredDescriptorForTextStyle (UIFontTextStyle.Body);
 			}
 		}
 		
 		public static UIFontDescriptor PreferredSubheadline {
 			get {
-				return GetPreferredDescriptorForTextStyle (UIFont.TextStyleSubheadline);
+				return GetPreferredDescriptorForTextStyle (UIFontTextStyle.Subheadline);
 			}
 		}
 		
 		public static UIFontDescriptor PreferredFootnote {
 			get {
-				return GetPreferredDescriptorForTextStyle (UIFont.TextStyleFootnote);
+				return GetPreferredDescriptorForTextStyle (UIFontTextStyle.Footnote);
 			}
 		}
 		
 		public static UIFontDescriptor PreferredCaption1 {
 			get {
-				return GetPreferredDescriptorForTextStyle (UIFont.TextStyleCaption1);
+				return GetPreferredDescriptorForTextStyle (UIFontTextStyle.Caption1);
 			}
 		}
 		
 		public static UIFontDescriptor PreferredCaption2 {
 			get {
-				return GetPreferredDescriptorForTextStyle (UIFont.TextStyleCaption2);
+				return GetPreferredDescriptorForTextStyle (UIFontTextStyle.Caption2);
 			}
 		}
 
 		[iOS (9,0)]
 		public static UIFontDescriptor PreferredTitle1 {
 			get {
-				return GetPreferredDescriptorForTextStyle (UIFont.TextStyleTitle1);
+				return GetPreferredDescriptorForTextStyle (UIFontTextStyle.Title1);
 			}
 		}
 		
 		[iOS (9,0)]
 		public static UIFontDescriptor PreferredTitle2 {
 			get {
-				return GetPreferredDescriptorForTextStyle (UIFont.TextStyleTitle2);
+				return GetPreferredDescriptorForTextStyle (UIFontTextStyle.Title2);
 			}
 		}
 		
 		[iOS (9,0)]
 		public static UIFontDescriptor PreferredTitle3 {
 			get {
-				return GetPreferredDescriptorForTextStyle (UIFont.TextStyleTitle3);
+				return GetPreferredDescriptorForTextStyle (UIFontTextStyle.Title3);
 			}
 		}
 		
 		[iOS (9,0)]
 		public static UIFontDescriptor PreferredCallout {
 			get {
-				return GetPreferredDescriptorForTextStyle (UIFont.TextStyleCallout);
+				return GetPreferredDescriptorForTextStyle (UIFontTextStyle.Callout);
 			}
 		}
 	

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -5230,46 +5230,48 @@ namespace XamCore.UIKit {
 		[Internal]
 		IntPtr _GetPreferredFontForTextStyle (NSString uiFontTextStyle, [NullAllowed] UITraitCollection traitCollection);
 #endif
-	
+	}
+
+	public enum UIFontTextStyle {
 		[Since (7,0)]
-		[Internal, Field ("UIFontTextStyleHeadline")]
-		NSString TextStyleHeadline { get; }
+		[Field ("UIFontTextStyleHeadline")]
+		Headline,
 
 		[Since (7,0)]
-		[Internal, Field ("UIFontTextStyleBody")]
-		NSString TextStyleBody { get; }
+		[Field ("UIFontTextStyleBody")]
+		Body,
 
 		[Since (7,0)]
-		[Internal, Field ("UIFontTextStyleSubheadline")]
-		NSString TextStyleSubheadline { get; }
+		[Field ("UIFontTextStyleSubheadline")]
+		Subheadline,
 
 		[Since (7,0)]
-		[Internal, Field ("UIFontTextStyleFootnote")]
-		NSString TextStyleFootnote { get; }
+		[Field ("UIFontTextStyleFootnote")]
+		Footnote,
 
 		[Since (7,0)]
-		[Internal, Field ("UIFontTextStyleCaption1")]
-		NSString TextStyleCaption1 { get; }
+		[Field ("UIFontTextStyleCaption1")]
+		Caption1,
 
 		[Since (7,0)]
-		[Internal, Field ("UIFontTextStyleCaption2")]
-		NSString TextStyleCaption2 { get; }
+		[Field ("UIFontTextStyleCaption2")]
+		Caption2,
 
 		[Since (9,0)]
-		[Internal, Field ("UIFontTextStyleTitle1")]
-		NSString TextStyleTitle1 { get; }
+		[Field ("UIFontTextStyleTitle1")]
+		Title1,
 		
 		[Since (9,0)]
-		[Internal, Field ("UIFontTextStyleTitle2")]
-		NSString TextStyleTitle2 { get; }
+		[Field ("UIFontTextStyleTitle2")]
+		Title2,
 		
 		[Since (9,0)]
-		[Internal, Field ("UIFontTextStyleTitle3")]
-		NSString TextStyleTitle3 { get; }
+		[Field ("UIFontTextStyleTitle3")]
+		Title3,
 		
 		[Since (9,0)]
-		[Internal, Field ("UIFontTextStyleCallout")]
-		NSString TextStyleCallout { get; }
+		[Field ("UIFontTextStyleCallout")]
+		Callout,
 	}
 
 	[Since (7,0)]
@@ -5316,12 +5318,21 @@ namespace XamCore.UIKit {
 		[Static, Export ("preferredFontDescriptorWithTextStyle:")]
 		UIFontDescriptor GetPreferredDescriptorForTextStyle (NSString uiFontTextStyle);
 
+		[Static]
+		[Wrap ("GetPreferredDescriptorForTextStyle (uiFontTextStyle.GetConstant ())")]
+		UIFontDescriptor GetPreferredDescriptorForTextStyle (UIFontTextStyle uiFontTextStyle);
+
 		// FIXME [Watch (3,0)] the API is present but UITraitCollection is not exposed / rdar #27785753
 #if !WATCH
 		[iOS (10,0), TV (10,0)]
 		[Static]
 		[Export ("preferredFontDescriptorWithTextStyle:compatibleWithTraitCollection:")]
 		UIFontDescriptor GetPreferredDescriptorForTextStyle (NSString uiFontTextStyle, [NullAllowed] UITraitCollection traitCollection);
+
+		[iOS (10,0), TV (10,0)]
+		[Static]
+		[Wrap ("GetPreferredDescriptorForTextStyle (uiFontTextStyle.GetConstant (), traitCollection)")]
+		UIFontDescriptor GetPreferredDescriptorForTextStyle (UIFontTextStyle uiFontTextStyle, [NullAllowed] UITraitCollection traitCollection);
 #endif
 	
 		[DesignatedInitializer]


### PR DESCRIPTION
New enum UIFontTextStyle maps to UIFontTextStyle* fields. Allows easier use of
* UIFont.GetPreferredFontForTextStyle
* UIFontDescriptor.GetPreferredDescriptorForTextStyle

https://bugzilla.xamarin.com/show_bug.cgi?id=42967