### PR TITLE
Remove any code related to the IL registrar.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -50,7 +50,6 @@ bool xamarin_disable_lldb_attach = false;
 // true if either OldDynamic or OldStatic (since the static registrar still needs
 // a dynamic registrar available too).
 bool xamarin_use_old_dynamic_registrar = false;
-bool xamarin_use_il_registrar = false;
 #if DEBUG
 bool xamarin_init_mono_debug = true;
 #else
@@ -139,7 +138,7 @@ enum InitializationFlags : int {
 	/* unused									= 0x01,*/
 	InitializationFlagsUseOldDynamicRegistrar	= 0x02,
 	InitializationFlagsDynamicRegistrar			= 0x04,
-	InitializationFlagsILRegistrar				= 0x08,
+	/* unused									= 0x08,*/
 	InitializationFlagsIsSimulator				= 0x10,
 };
 
@@ -1191,8 +1190,6 @@ xamarin_initialize ()
 	options.size = sizeof (options);
 	if (xamarin_use_new_assemblies && xamarin_use_old_dynamic_registrar)
 		options.flags = (enum InitializationFlags) (options.flags | InitializationFlagsUseOldDynamicRegistrar);
-	if (xamarin_use_il_registrar)
-		options.flags = (enum InitializationFlags) (options.flags | InitializationFlagsILRegistrar);
 #if MONOTOUCH && (defined(__i386__) || defined (__x86_64__))
 	options.flags = (enum InitializationFlags) (options.flags | InitializationFlagsIsSimulator);
 #endif

--- a/runtime/xamarin/main.h
+++ b/runtime/xamarin/main.h
@@ -44,7 +44,6 @@ extern bool xamarin_gc_pump;
 extern bool xamarin_debug_mode;
 extern bool xamarin_disable_lldb_attach;
 extern bool xamarin_use_old_dynamic_registrar;
-extern bool xamarin_use_il_registrar;
 extern bool xamarin_init_mono_debug;
 extern bool xamarin_compact_seq_points;
 extern int xamarin_log_level;

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -100,7 +100,7 @@ namespace XamCore.ObjCRuntime {
 			/* unused               = 0x01 */
 			UseOldDynamicRegistrar	= 0x02,
 			DynamicRegistrar		= 0x04,
-			ILRegistrar				= 0x08,
+			/* unused				= 0x08,*/
 			IsSimulator				= 0x10,
 		}
 

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -56,7 +56,6 @@ namespace Xamarin.Bundler {
 		Default,
 		Dynamic,
 		Static,
-		IL,
 	}
 
 	public static partial class Driver {
@@ -245,7 +244,7 @@ namespace Xamarin.Bundler {
 							registrar = RegistrarMode.Dynamic;
 							break;
 						case "il":
-							registrar = RegistrarMode.IL;
+							registrar = RegistrarMode.Dynamic;
 							break;
 						case "default":
 							registrar = RegistrarMode.Default;
@@ -907,7 +906,6 @@ namespace Xamarin.Bundler {
 					sw.WriteLine ("extern NSString* xamarin_custom_bundle_name;");
 					sw.WriteLine ("\txamarin_custom_bundle_name = @\"" + custom_bundle_name + "\";");
 				}
-				sw.WriteLine ("\txamarin_use_il_registrar = {0};", registrar == RegistrarMode.IL ? "true" : "false");
 				sw.WriteLine ("\txamarin_marshal_managed_exception_mode = MarshalManagedExceptionMode{0};", App.MarshalManagedExceptions);
 				sw.WriteLine ("\txamarin_marshal_objectivec_exception_mode = MarshalObjectiveCExceptionMode{0};", App.MarshalObjectiveCExceptions);
 				if (disable_lldb_attach)


### PR DESCRIPTION
We've used the dynamic registrar for years now when selecting the IL registrar
(and I've never heard about anybody doing it), so just remove all the related
(and in fact dead) code.