### PR TITLE
[mtouch] Tell Cecil to load assemblies in memory.

### DIFF
--- a/tools/mtouch/AssemblyResolver.cs
+++ b/tools/mtouch/AssemblyResolver.cs
@@ -52,6 +52,7 @@ namespace MonoTouch.Tuner {
 			cache = new Dictionary<string, AssemblyDefinition> (StringComparer.InvariantCultureIgnoreCase);
 			parameters = new ReaderParameters ();
 			parameters.AssemblyResolver = this;
+			parameters.InMemory = true;
 		}
 
 		public IDictionary ToResolverCache ()


### PR DESCRIPTION
In the recent Cecil update Cecil changed from loading assemblies in memory to
keep a FileStream around and read whenever necessary [1].

This is problematic for us, because we need all the AssemblyDefinitions in
memory at once, and if there are many assemblies, then we'll run into problems
due to the number of file descriptors in use.

So revert to the behavior for the old Cecil: loading assemblies in memory.

http://cecil.pe/post/149243207656/mono-cecil-010-beta-1