### PR TITLE
Revert "[mtouch] Don't use nested Parallel.ForEach loops."

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1,7 +1,6 @@
 // Copyright 2013 Xamarin Inc. All rights reserved.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -1695,29 +1694,19 @@ namespace Xamarin.Bundler {
 
 	public class BuildTasks : List<BuildTask>
 	{
-		static void AddToBuildList (ConcurrentBag<BuildTask> build_list, IEnumerable<BuildTask> list)
+		static void Execute (BuildTask v)
 		{
-			if (list == null)
-				return;
-			foreach (var item in list)
-				build_list.Add (item);
-		}
-
-		static void Execute (ConcurrentBag<BuildTask> build_list, BuildTask v)
-		{
-			AddToBuildList (build_list, v.Execute ());
+			var next = v.Execute ();
+			if (next != null)
+				Parallel.ForEach (next, new ParallelOptions () { MaxDegreeOfParallelism = Driver.Concurrency }, Execute);
 		}
 
 		public void ExecuteInParallel ()
 		{
 			if (Count == 0)
 				return;
-
-			var build_list = new ConcurrentBag<BuildTask> ();
-			AddToBuildList (build_list, this);
-			Parallel.ForEach (build_list, new ParallelOptions () { MaxDegreeOfParallelism = Driver.Concurrency }, (v) => {
-				Execute (build_list, v);
-			});
+			
+			Parallel.ForEach (this, new ParallelOptions () { MaxDegreeOfParallelism = Driver.Concurrency }, Execute);
 
 			Clear ();
 		}


### PR DESCRIPTION
Reverts xamarin/xamarin-macios#881

It breaks device builds.