### PR TITLE
[mtouch] Update script to use mono64. Fixes #44122 and others

### DIFF
--- a/tools/mtouch/mtouch.in
+++ b/tools/mtouch/mtouch.in
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/Library/Frameworks/Mono.framework/Commands/mono --debug @MONOTOUCH_PREFIX@/lib/mtouch/mtouch.exe "$@"
+/Library/Frameworks/Mono.framework/Commands/mono64 --debug @MONOTOUCH_PREFIX@/lib/mtouch/mtouch.exe "$@"


### PR DESCRIPTION
Our move to open source and the mtouch/mlaunch split changed mtouch from
a 64bits to a 32bits application (because mono is, by default, still
32bits on OSX).

That's the cause for several recent bugs

* https://bugzilla.xamarin.com/show_bug.cgi?id=44122
* https://bugzilla.xamarin.com/show_bug.cgi?id=44521
* https://bugzilla.xamarin.com/show_bug.cgi?id=44518
* https://bugzilla.xamarin.com/show_bug.cgi?id=44516