### PR TITLE
[generator] Fix bug 37175 and bug 44322

### DIFF
--- a/docs/website/binding_types_reference_guide.md
+++ b/docs/website/binding_types_reference_guide.md
@@ -961,6 +961,41 @@ as your thread did not return control to the main loop. Uf your thread was some
 sort of background downloader that is always alive and waiting for work, the
 images would never be released.
 
+
+<a name="ForcedTypeAttribute" class="injected"></a>
+
+
+## ForcedTypeAttribute
+
+The `ForcedTypeAttribute` is used to enforce the creation of a managed type even
+if the returned unmanaged object does not match the type described in the binding
+definition.
+
+This is useful when the type described in a header does not match the returned type
+of the native method for example take the following Objective-C definition from `NSURLSession`:
+
+`- (NSURLSessionDownloadTask *)downloadTaskWithRequest:(NSURLRequest *)request`
+
+It clearly states that it will return an `NSURLSessionDownloadTask` instance, but yet it
+**returns** a `NSURLSessionTask`, which is a superclass and thus not convertible to 
+`NSURLSessionDownloadTask`. Since we are in a type-safe context an `InvalidCastException`
+will happen.
+
+In order to comply with the header description and avoid the `InvalidCastException`, the
+`ForcedTypeAttribute` is used.
+
+```
+[BaseType (typeof (NSObject), Name="NSURLSession")]
+interface NSUrlSession {
+
+	[Export ("downloadTaskWithRequest:")]
+	[ForcedType]
+	NSUrlSessionDownloadTask CreateDownloadTask (NSUrlRequest request);
+}
+```
+
+
+
  <a name="BindAttribute" class="injected"></a>
 
 

--- a/docs/website/binding_types_reference_guide.md
+++ b/docs/website/binding_types_reference_guide.md
@@ -972,7 +972,7 @@ if the returned unmanaged object does not match the type described in the bindin
 definition.
 
 This is useful when the type described in a header does not match the returned type
-of the native method for example take the following Objective-C definition from `NSURLSession`:
+of the native method, for example take the following Objective-C definition from `NSURLSession`:
 
 `- (NSURLSessionDownloadTask *)downloadTaskWithRequest:(NSURLRequest *)request`
 
@@ -989,11 +989,17 @@ In order to comply with the header description and avoid the `InvalidCastExcepti
 interface NSUrlSession {
 
 	[Export ("downloadTaskWithRequest:")]
-	[ForcedType]
+	[return: ForcedType]
 	NSUrlSessionDownloadTask CreateDownloadTask (NSUrlRequest request);
 }
 ```
 
+The `ForcedTypeAttribute` also accepts a boolean value named `Owns` that is `false`
+by default `[ForcedType (owns: true)]`. The owns parameter is used to follow
+the [Ownership Policy](https://developer.apple.com/library/content/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html)
+for **Core Foundation** objects.
+
+The `ForcedTypeAttribute` is only valid on `parameters`, `properties` and `return value`. 
 
 
  <a name="BindAttribute" class="injected"></a>

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -10453,6 +10453,7 @@ namespace XamCore.AVFoundation {
 	[BaseType (typeof (NSUrlSession), Name = "AVAssetDownloadURLSession")]
 	interface AVAssetDownloadUrlSession {
 		[Static]
+		[ForcedType]
 		[Export ("sessionWithConfiguration:assetDownloadDelegate:delegateQueue:")]
 		AVAssetDownloadUrlSession CreateSession (NSUrlSessionConfiguration configuration, [NullAllowed] IAVAssetDownloadDelegate @delegate, [NullAllowed] NSOperationQueue delegateQueue);
 

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -10453,7 +10453,7 @@ namespace XamCore.AVFoundation {
 	[BaseType (typeof (NSUrlSession), Name = "AVAssetDownloadURLSession")]
 	interface AVAssetDownloadUrlSession {
 		[Static]
-		[ForcedType]
+		[return: ForcedType]
 		[Export ("sessionWithConfiguration:assetDownloadDelegate:delegateQueue:")]
 		AVAssetDownloadUrlSession CreateSession (NSUrlSessionConfiguration configuration, [NullAllowed] IAVAssetDownloadDelegate @delegate, [NullAllowed] NSOperationQueue delegateQueue);
 

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -5855,69 +5855,69 @@ namespace XamCore.Foundation
 #endif
 
 		[Export ("dataTaskWithRequest:")]
-		[ForcedType]
+		[return: ForcedType]
 		NSUrlSessionDataTask CreateDataTask (NSUrlRequest request);
 	
 		[Export ("dataTaskWithURL:")]
-		[ForcedType]
+		[return: ForcedType]
 		NSUrlSessionDataTask CreateDataTask (NSUrl url);
 	
 		[Export ("uploadTaskWithRequest:fromFile:")]
-		[ForcedType]
+		[return: ForcedType]
 		NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request, NSUrl fileURL);
 	
 		[Export ("uploadTaskWithRequest:fromData:")]
-		[ForcedType]
+		[return: ForcedType]
 		NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request, NSData bodyData);
 	
 		[Export ("uploadTaskWithStreamedRequest:")]
-		[ForcedType]
+		[return: ForcedType]
 		NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request);
 	
 		[Export ("downloadTaskWithRequest:")]
-		[ForcedType]
+		[return: ForcedType]
 		NSUrlSessionDownloadTask CreateDownloadTask (NSUrlRequest request);
 	
 		[Export ("downloadTaskWithURL:")]
-		[ForcedType]
+		[return: ForcedType]
 		NSUrlSessionDownloadTask CreateDownloadTask (NSUrl url);
 	
 		[Export ("downloadTaskWithResumeData:")]
-		[ForcedType]
+		[return: ForcedType]
 		NSUrlSessionDownloadTask CreateDownloadTask (NSData resumeData);
 
 		[Export ("dataTaskWithRequest:completionHandler:")]
-		[ForcedType]
+		[return: ForcedType]
 		[Async (ResultTypeName="NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();")]
 		NSUrlSessionDataTask CreateDataTask (NSUrlRequest request, [NullAllowed] NSUrlSessionResponse completionHandler);
 	
 		[Export ("dataTaskWithURL:completionHandler:")]
-		[ForcedType]
+		[return: ForcedType]
 		[Async(ResultTypeName="NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();")]
 		NSUrlSessionDataTask CreateDataTask (NSUrl url, [NullAllowed] NSUrlSessionResponse completionHandler);
 	
 		[Export ("uploadTaskWithRequest:fromFile:completionHandler:")]
-		[ForcedType]
+		[return: ForcedType]
 		[Async(ResultTypeName="NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();")]
 		NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request, NSUrl fileURL, NSUrlSessionResponse completionHandler);
 	
 		[Export ("uploadTaskWithRequest:fromData:completionHandler:")]
-		[ForcedType]
+		[return: ForcedType]
 		[Async(ResultTypeName="NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();")]
 		NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request, NSData bodyData, NSUrlSessionResponse completionHandler);
 	
 		[Export ("downloadTaskWithRequest:completionHandler:")]
-		[ForcedType]
+		[return: ForcedType]
 		[Async(ResultTypeName="NSUrlSessionDownloadTaskRequest", PostNonResultSnippet = "result.Resume ();")]
 		NSUrlSessionDownloadTask CreateDownloadTask (NSUrlRequest request, [NullAllowed] NSUrlDownloadSessionResponse completionHandler);
 	
 		[Export ("downloadTaskWithURL:completionHandler:")]
-		[ForcedType]
+		[return: ForcedType]
 		[Async(ResultTypeName="NSUrlSessionDownloadTaskRequest", PostNonResultSnippet = "result.Resume ();")]
 		NSUrlSessionDownloadTask CreateDownloadTask (NSUrl url, [NullAllowed] NSUrlDownloadSessionResponse completionHandler);
 
 		[Export ("downloadTaskWithResumeData:completionHandler:")]
-		[ForcedType]
+		[return: ForcedType]
 		[Async(ResultTypeName="NSUrlSessionDownloadTaskRequest", PostNonResultSnippet = "result.Resume ();")]
 		NSUrlSessionDownloadTask CreateDownloadTaskFromResumeData (NSData resumeData, [NullAllowed] NSUrlDownloadSessionResponse completionHandler);
 

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -5855,54 +5855,69 @@ namespace XamCore.Foundation
 #endif
 
 		[Export ("dataTaskWithRequest:")]
+		[ForcedType]
 		NSUrlSessionDataTask CreateDataTask (NSUrlRequest request);
 	
 		[Export ("dataTaskWithURL:")]
+		[ForcedType]
 		NSUrlSessionDataTask CreateDataTask (NSUrl url);
 	
 		[Export ("uploadTaskWithRequest:fromFile:")]
+		[ForcedType]
 		NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request, NSUrl fileURL);
 	
 		[Export ("uploadTaskWithRequest:fromData:")]
+		[ForcedType]
 		NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request, NSData bodyData);
 	
 		[Export ("uploadTaskWithStreamedRequest:")]
+		[ForcedType]
 		NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request);
 	
 		[Export ("downloadTaskWithRequest:")]
+		[ForcedType]
 		NSUrlSessionDownloadTask CreateDownloadTask (NSUrlRequest request);
 	
 		[Export ("downloadTaskWithURL:")]
+		[ForcedType]
 		NSUrlSessionDownloadTask CreateDownloadTask (NSUrl url);
 	
 		[Export ("downloadTaskWithResumeData:")]
+		[ForcedType]
 		NSUrlSessionDownloadTask CreateDownloadTask (NSData resumeData);
 
 		[Export ("dataTaskWithRequest:completionHandler:")]
+		[ForcedType]
 		[Async (ResultTypeName="NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();")]
 		NSUrlSessionDataTask CreateDataTask (NSUrlRequest request, [NullAllowed] NSUrlSessionResponse completionHandler);
 	
 		[Export ("dataTaskWithURL:completionHandler:")]
+		[ForcedType]
 		[Async(ResultTypeName="NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();")]
 		NSUrlSessionDataTask CreateDataTask (NSUrl url, [NullAllowed] NSUrlSessionResponse completionHandler);
 	
 		[Export ("uploadTaskWithRequest:fromFile:completionHandler:")]
+		[ForcedType]
 		[Async(ResultTypeName="NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();")]
 		NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request, NSUrl fileURL, NSUrlSessionResponse completionHandler);
 	
 		[Export ("uploadTaskWithRequest:fromData:completionHandler:")]
+		[ForcedType]
 		[Async(ResultTypeName="NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();")]
 		NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request, NSData bodyData, NSUrlSessionResponse completionHandler);
 	
 		[Export ("downloadTaskWithRequest:completionHandler:")]
+		[ForcedType]
 		[Async(ResultTypeName="NSUrlSessionDownloadTaskRequest", PostNonResultSnippet = "result.Resume ();")]
 		NSUrlSessionDownloadTask CreateDownloadTask (NSUrlRequest request, [NullAllowed] NSUrlDownloadSessionResponse completionHandler);
 	
 		[Export ("downloadTaskWithURL:completionHandler:")]
+		[ForcedType]
 		[Async(ResultTypeName="NSUrlSessionDownloadTaskRequest", PostNonResultSnippet = "result.Resume ();")]
 		NSUrlSessionDownloadTask CreateDownloadTask (NSUrl url, [NullAllowed] NSUrlDownloadSessionResponse completionHandler);
 
 		[Export ("downloadTaskWithResumeData:completionHandler:")]
+		[ForcedType]
 		[Async(ResultTypeName="NSUrlSessionDownloadTaskRequest", PostNonResultSnippet = "result.Resume ();")]
 		NSUrlSessionDownloadTask CreateDownloadTaskFromResumeData (NSData resumeData, [NullAllowed] NSUrlDownloadSessionResponse completionHandler);
 

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -279,6 +279,39 @@ public static class StringExtensions
 	};
 }
 
+//
+// ForcedTypeAttribute
+//
+// The ForcedTypeAttribute is used to enforce the creation of a managed type even
+// if the returned unmanaged object does not match the type described in the binding definition.
+//
+// This is useful when the type described in a header does not match the returned type
+// of the native method for example take the following Objective-C definition from NSURLSession:
+//
+//	- (NSURLSessionDownloadTask *)downloadTaskWithRequest:(NSURLRequest *)request
+//
+// It clearly states that it will return an NSURLSessionDownloadTask instance, but yet
+// it returns a NSURLSessionTask, which is a superclass and thus not convertible to 
+// NSURLSessionDownloadTask. Since we are in a type-safe context an InvalidCastException will happen.
+//
+// In order to comply with the header description and avoid the InvalidCastException, 
+// the ForcedTypeAttribute is used.
+//
+//	[BaseType (typeof (NSObject), Name="NSURLSession")]
+//	interface NSUrlSession {
+//		[Export ("downloadTaskWithRequest:")]
+//		[return: ForcedType]
+//		NSUrlSessionDownloadTask CreateDownloadTask (NSUrlRequest request);
+//	}
+//
+// The `ForcedTypeAttribute` also accepts a boolean value named `Owns` that is `false`
+// by default `[ForcedType (owns: true)]`. The owns parameter could be used to follow
+// the Ownership Policy[1] for Core Foundation objects.
+//
+// [1]: https://developer.apple.com/library/content/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html
+//
+
+[AttributeUsage (AttributeTargets.ReturnValue | AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false)]
 public class ForcedTypeAttribute : Attribute {
 	public ForcedTypeAttribute (bool owns = false)
 	{
@@ -1215,12 +1248,12 @@ public class MemberInformation
 	public readonly MemberInfo mi;
 	public readonly Type type;
 	public readonly Type category_extension_type;
-	public readonly bool is_abstract, is_protected, is_internal, is_unified_internal, is_override, is_new, is_sealed, is_static, is_thread_static, is_autorelease, is_wrapper, is_forced, is_forced_owns;
+	public readonly bool is_abstract, is_protected, is_internal, is_unified_internal, is_override, is_new, is_sealed, is_static, is_thread_static, is_autorelease, is_wrapper, is_forced;
 	public readonly Generator.ThreadCheck threadCheck;
 	public bool is_unsafe, is_virtual_method, is_export, is_category_extension, is_variadic, is_interface_impl, is_extension_method, is_appearance, is_model, is_ctor;
 	public bool is_return_release;
 	public bool protocolize;
-	public string selector, wrap_method;
+	public string selector, wrap_method, is_forced_owns;
 
 	public MethodInfo method { get { return (MethodInfo) mi; } }
 	public PropertyInfo property { get { return (PropertyInfo) mi; } }
@@ -1242,10 +1275,7 @@ public class MemberInformation
 		is_autorelease = Generator.HasAttribute (mi, typeof (AutoreleaseAttribute));
 		is_wrapper = !Generator.HasAttribute (mi.DeclaringType, typeof(SyntheticAttribute));
 		is_return_release = method != null && Generator.HasAttribute (method.ReturnTypeCustomAttributes, typeof (ReleaseAttribute));
-		is_forced = Generator.HasAttribute (mi, typeof (ForcedTypeAttribute));
-
-		var forcedType = Generator.GetAttribute<ForcedTypeAttribute> (mi);
-		is_forced_owns = forcedType != null && forcedType.Owns;
+		is_forced = Generator.HasForcedAttribute (mi, out is_forced_owns);
 
 		var tsa = Generator.GetAttribute<ThreadSafeAttribute> (mi);
 		// if there's an attribute then it overrides the parent (e.g. type attribute) or namespace default
@@ -1852,6 +1882,19 @@ public partial class Generator : IMemberGatherer {
 		return "I" + type.Name;
 	}
 
+	public static bool HasForcedAttribute (ICustomAttributeProvider cu, out string owns)
+	{
+		var att = GetAttribute<ForcedTypeAttribute> (cu) ?? GetAttribute<ForcedTypeAttribute> ((cu as MethodInfo)?.ReturnParameter);
+
+		if (att == null) {
+			owns = "false";
+			return false;
+		}
+
+		owns = att.Owns ? "true" : "false";
+		return true;
+	}
+
 	public string MakeTrampolineName (Type t)
 	{
 		var trampoline_name = t.Name.Replace ("`", "Arity");
@@ -1907,6 +1950,9 @@ public partial class Generator : IMemberGatherer {
 		pars.Append ("IntPtr block");
 		var parameters = mi.GetParameters ();
 		foreach (var pi in parameters){
+			string isForcedOwns;
+			var isForced = HasForcedAttribute (pi, out isForcedOwns);
+
 			pars.Append (", ");
 			if (pi != parameters [0])
 				invoke.Append (", ");
@@ -1915,6 +1961,8 @@ public partial class Generator : IMemberGatherer {
 				pars.AppendFormat ("IntPtr {0}", pi.Name.GetSafeParamName ());
 				if (IsProtocolInterface (pi.ParameterType)) {
 					invoke.AppendFormat (" Runtime.GetINativeObject<{1}> ({0}, false)", pi.Name.GetSafeParamName (), pi.ParameterType);
+				} else if (isForced) {
+					invoke.AppendFormat (" Runtime.GetINativeObject<{1}> ({0}, {2})", pi.Name.GetSafeParamName (), RenderType (pi.ParameterType), isForcedOwns);
 				} else {
 					invoke.AppendFormat (" Runtime.GetNSObject<{1}> ({0})", pi.Name.GetSafeParamName (), RenderType (pi.ParameterType));
 				}
@@ -2150,6 +2198,9 @@ public partial class Generator : IMemberGatherer {
 	
 	public static T GetAttribute<T> (ICustomAttributeProvider mi) where T: class
 	{
+		if (mi == null)
+			return null;
+
 		object [] a = mi.GetCustomAttributes (typeof (T), true);
 		if (a.Length > 0)
 			return (T) a [0];
@@ -3922,7 +3973,7 @@ public partial class Generator : IMemberGatherer {
 				cast_b = ", false)";
 			} else if (minfo != null && minfo.is_forced) {
 				cast_a = " Runtime.GetINativeObject<" + FormatType (declaringType, GetCorrectGenericType (mi.ReturnType)) + "> (";
-				cast_b = string.Format (", {0})", minfo.is_forced_owns ? "true" : "false");
+				cast_b = $", {minfo.is_forced_owns})";
 			} else {
 				cast_a = " Runtime.GetNSObject<" + FormatType (declaringType, GetCorrectGenericType (mi.ReturnType)) + "> (";
 				cast_b = ")";
@@ -4345,11 +4396,15 @@ public partial class Generator : IMemberGatherer {
 
 			// Handle ByRef
 			if (mai.Type.IsByRef && mai.Type.GetElementType ().IsValueType == false){
+				string isForcedOwns;
+				var isForced = HasForcedAttribute (pi, out isForcedOwns);
 				by_ref_init.AppendFormat ("IntPtr {0}Value = IntPtr.Zero;\n", pi.Name.GetSafeParamName ());
 
 				by_ref_processing.AppendLine();
 				if (mai.Type.GetElementType () == typeof (string)){
 					by_ref_processing.AppendFormat("{0} = {0}Value != IntPtr.Zero ? NSString.FromHandle ({0}Value) : null;", pi.Name.GetSafeParamName ());
+				} else if (isForced) {
+					by_ref_processing.AppendFormat("{0} = {0}Value != IntPtr.Zero ? Runtime.GetINativeObject<{1}> ({0}Value, {2}) : null;", pi.Name.GetSafeParamName (), RenderType (mai.Type.GetElementType ()), isForcedOwns);
 				} else {
 					by_ref_processing.AppendFormat("{0} = {0}Value != IntPtr.Zero ? Runtime.GetNSObject<{1}> ({0}Value) : null;", pi.Name.GetSafeParamName (), RenderType (mai.Type.GetElementType ()));
 				}

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -121,6 +121,17 @@ bug35176:
 		echo "Error: Expected 4 Introduced attributes in generated code."; exit 1; \
 	fi
 
+forcedtype:
+	@rm -Rf $@.tmpdir
+	@mkdir -p $@.tmpdir
+	$(if $(V),,@echo "$@";) $(IOS_GENERATOR) --sourceonly:$@.source -tmpdir=$@.tmpdir $@.cs
+	@if ! grep -r GetINativeObject forcedtype.tmpdir > /dev/null; then \
+		echo "error: Could not find GetINativeObject usage in generated code."; exit 1; \
+	fi
+	@if [ `grep -r GetINativeObject forcedtype.tmpdir | wc -l` -ne 12 ]; then \
+		echo "Error: Expected 12 GetINativeObject usages in generated code."; exit 1; \
+	fi
+
 bi1036:
 	$(if $(V),,@echo "$@";) $(IOS_GENERATOR) $@.cs | grep BI1036 >/dev/null 2>&1
 

--- a/tests/generator/forcedtype.cs
+++ b/tests/generator/forcedtype.cs
@@ -1,0 +1,35 @@
+using System;
+using MonoTouch.Foundation;
+using MonoTouch.CoreFoundation;
+using MonoTouch.UIKit;
+
+namespace Forced {
+	delegate void SomethingDelegate ([ForcedType] UIButton button);
+
+	[BaseType (typeof (NSObject))]
+	interface Foo {
+
+		[Export ("barButton")]
+		[ForcedType]
+		UIButton BarButton { get; set; }
+
+		[Static]
+		[return: ForcedType]
+		[Export ("fooType:")]
+		UIButton FromFoo (string fooType);
+
+		[Export ("getBar:")]
+		[return: ForcedType]
+		UIButton GetBar (string bar);
+
+		[Export ("getSomething:")]
+		UIButton GetSomething (SomethingDelegate handler);
+
+		[Export ("getSomethingElse:label:view:")]
+		UIButton GetSomethingElse ([ForcedType] out UIButton button, [ForcedType] ref UILabel label, ref UIView view);
+
+		[Export ("getAll:label:view:")]
+		[return: ForcedType (true)]
+		UIButton GetAll ([ForcedType (true)] out UIButton button, [ForcedType] ref UILabel label, ref UIView view);
+	}
+}

--- a/tests/monotouch-test/AVFoundation/AVAssetDownloadUrlSessionTests.cs
+++ b/tests/monotouch-test/AVFoundation/AVAssetDownloadUrlSessionTests.cs
@@ -11,6 +11,7 @@
 #if !__WATCHOS__ && !__TVOS__
 
 using System;
+using ObjCRuntime;
 
 #if XAMCORE_2_0
 using Foundation;
@@ -36,6 +37,20 @@ namespace monotouchtest {
 			Assert.Throws <NotSupportedException> (() => AVAssetDownloadUrlSession.FromConfiguration (NSUrlSessionConfiguration.DefaultSessionConfiguration), "FromConfiguration should throw NotSupportedException");
 			Assert.Throws <NotSupportedException> (() => AVAssetDownloadUrlSession.FromConfiguration (NSUrlSessionConfiguration.DefaultSessionConfiguration, new NSUrlSessionDelegate (), null), "FromConfiguration should throw NotSupportedException");
 			Assert.Throws <NotSupportedException> (() => AVAssetDownloadUrlSession.FromWeakConfiguration (NSUrlSessionConfiguration.DefaultSessionConfiguration, new NSObject (), null), "FromWeakConfiguration should throw NotSupportedException");
+		}
+
+		[Test]
+		public void CreateSessionTest ()
+		{
+			if (!TestRuntime.CheckXcodeVersion (7, 0))
+				Assert.Ignore ("Ignoring AVAssetDownloadUrlSession tests: Requires iOS9+");
+
+			if (Runtime.Arch == Arch.DEVICE)
+				Assert.Ignore ("Ignoring CreateSessionTest tests: Requires com.apple.developer.media-asset-download entitlement");
+
+			using (var backgroundConfiguration = NSUrlSessionConfiguration.CreateBackgroundSessionConfiguration ("HLS-Identifier")) {
+				Assert.DoesNotThrow (() => AVAssetDownloadUrlSession.CreateSession (backgroundConfiguration, null, NSOperationQueue.MainQueue), "Should not throw InvalidCastException");
+			}
 		}
 
 		// FIXME: Disabling this test from now, will reenable once apple releases docs on what is ecpected to have this entitlement key

--- a/tests/monotouch-test/Foundation/UrlSessionTaskTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTaskTest.cs
@@ -50,5 +50,118 @@ namespace MonoTouchFixtures.Foundation {
 				Assert.That (task.TaskIdentifier, Is.GreaterThanOrEqualTo (0), "taskIdentifier");
 			}
 		}
+
+		[Test]
+		public void NSUrlSessionDownloadTaskTest ()
+		{
+			TestRuntime.AssertXcodeVersion (6, 0);
+
+			using (var ur = new NSUrlRequest ()) {
+				NSUrlSessionDownloadTask task = null;
+				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateDownloadTask (ur), "Should not throw InvalidCastException");
+				Assert.IsNotNull (task, "task should not be null");
+				Assert.IsInstanceOfType (typeof (NSUrlSessionDownloadTask), task, "task should be an instance of NSUrlSessionDownloadTask");
+			}
+
+			using (var ur = new NSUrlRequest ()) {
+				NSUrlSessionDownloadTask task = null;
+				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateDownloadTask (ur, null), "Should not throw InvalidCastException 2");
+				Assert.IsNotNull (task, "task should not be null 2");
+				Assert.IsInstanceOfType (typeof (NSUrlSessionDownloadTask), task, "task should be an instance of NSUrlSessionDownloadTask 2");
+			}
+
+			using (var ur = new NSUrl ("https://www.microsoft.com")) {
+				NSUrlSessionDownloadTask task = null;
+				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateDownloadTask (ur), "Should not throw InvalidCastException 3");
+				Assert.IsNotNull (task, "task should not be null 3");
+				Assert.IsInstanceOfType (typeof (NSUrlSessionDownloadTask), task, "task should be an instance of NSUrlSessionDownloadTask 3");
+			}
+
+			using (var ur = new NSUrl ("https://www.microsoft.com")) {
+				NSUrlSessionDownloadTask task = null;
+				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateDownloadTask (ur, null), "Should not throw InvalidCastException 4");
+				Assert.IsNotNull (task, "task should not be null 4");
+				Assert.IsInstanceOfType (typeof (NSUrlSessionDownloadTask), task, "task should be an instance of NSUrlSessionDownloadTask 4");
+			}
+		}
+
+		[Test]
+		public void NSUrlSessionDataTaskTest ()
+		{
+			TestRuntime.AssertXcodeVersion (6, 0);
+
+			using (var ur = new NSUrlRequest ()) {
+				NSUrlSessionDataTask task = null;
+				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateDataTask (ur), "Should not throw InvalidCastException");
+				Assert.IsNotNull (task, "task should not be null");
+				Assert.IsInstanceOfType (typeof (NSUrlSessionDataTask), task, "task should be an instance of NSUrlSessionDataTask");
+			}
+
+			using (var ur = new NSUrlRequest ()) {
+				NSUrlSessionDataTask task = null;
+				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateDataTask (ur, null), "Should not throw InvalidCastException 2");
+				Assert.IsNotNull (task, "task should not be null 2");
+				Assert.IsInstanceOfType (typeof (NSUrlSessionDataTask), task, "task should be an instance of NSUrlSessionDataTask 2");
+			}
+
+			using (var ur = new NSUrl ("https://www.microsoft.com")) {
+				NSUrlSessionDataTask task = null;
+				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateDataTask (ur), "Should not throw InvalidCastException 3");
+				Assert.IsNotNull (task, "task should not be null 3");
+				Assert.IsInstanceOfType (typeof (NSUrlSessionDataTask), task, "task should be an instance of NSUrlSessionDataTask 3");
+			}
+
+			using (var ur = new NSUrl ("https://www.microsoft.com")) {
+				NSUrlSessionDataTask task = null;
+				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateDataTask (ur, null), "Should not throw InvalidCastException 4");
+				Assert.IsNotNull (task, "task should not be null 4");
+				Assert.IsInstanceOfType (typeof (NSUrlSessionDataTask), task, "task should be an instance of NSUrlSessionDataTask 4");
+			}
+		}
+
+		[Test]
+		public void NSUrlSessionUploadTaskTest ()
+		{
+			TestRuntime.AssertXcodeVersion (6, 0);
+
+			using (var ur = new NSUrlRequest ()) {
+				NSUrlSessionUploadTask task = null;
+				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateUploadTask (ur), "Should not throw InvalidCastException");
+				Assert.IsNotNull (task, "task should not be null");
+				Assert.IsInstanceOfType (typeof (NSUrlSessionUploadTask), task, "task should be an instance of NSUrlSessionUploadTask");
+			}
+
+			using (var data = NSData.FromString ("Hola"))
+			using (var ur = new NSUrlRequest ()) {
+				NSUrlSessionUploadTask task = null;
+				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateUploadTask (ur, data), "Should not throw InvalidCastException 2");
+				Assert.IsNotNull (task, "task should not be null 2");
+				Assert.IsInstanceOfType (typeof (NSUrlSessionUploadTask), task, "task should be an instance of NSUrlSessionUploadTask 2");
+			}
+
+			using (var ur = new NSUrlRequest ())
+			using (var url = new NSUrl ("https://www.microsoft.com")) {
+				NSUrlSessionUploadTask task = null;
+				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateUploadTask (ur, url), "Should not throw InvalidCastException 3");
+				Assert.IsNotNull (task, "task should not be null 3");
+				Assert.IsInstanceOfType (typeof (NSUrlSessionUploadTask), task, "task should be an instance of NSUrlSessionUploadTask 3");
+			}
+
+			using (var ur = new NSUrlRequest ())
+			using (var url = new NSUrl ("https://www.microsoft.com")) {
+				NSUrlSessionUploadTask task = null;
+				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateUploadTask (ur, url, (data, response, error) => { }), "Should not throw InvalidCastException 4");
+				Assert.IsNotNull (task, "task should not be null 4");
+				Assert.IsInstanceOfType (typeof (NSUrlSessionUploadTask), task, "task should be an instance of NSUrlSessionUploadTask 4");
+			}
+
+			using (var ur = new NSUrlRequest ())
+			using (var data = NSData.FromString ("Hola")) {
+				NSUrlSessionUploadTask task = null;
+				Assert.DoesNotThrow (() => task = NSUrlSession.SharedSession.CreateUploadTask (ur, data, (d, response, error) => { }), "Should not throw InvalidCastException 5");
+				Assert.IsNotNull (task, "task should not be null 5");
+				Assert.IsInstanceOfType (typeof (NSUrlSessionUploadTask), task, "task should be an instance of NSUrlSessionUploadTask 5");
+			}
+		}
 	}
 }


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=37175
https://bugzilla.xamarin.com/show_bug.cgi?id=44322

Sometimes iOS API is returning objects of the wrong type for example

- (NSURLSessionDownloadTask *)downloadTaskWithRequest:(NSURLRequest *)request

It clearly states that it will return an NSURLSessionDownloadTask
instance, but yet it returns a NSURLSessionTask and we throw an
InvalidCastException when creating the managed object. This is
fine in ObjC but for us in a type-safety context is not.

Introducing ForcedTypeAttribute when applying this attribute
we will use GetINativeObject instead of GetNSObject which
the former does not perfom a type check on the underlying object

API diff: https://gist.github.com/dalexsoto/0d2c7c551105e5bda803790fde62bb9d