### PR TITLE
Bump MAX_MONO_VERSION

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -54,7 +54,7 @@ XCODE_DEVELOPER_ROOT=/Applications/Xcode8-GM.app/Contents/Developer
 
 # Minimum Mono version
 MIN_MONO_VERSION=4.4.0.148
-MAX_MONO_VERSION=4.7.99
+MAX_MONO_VERSION=4.9.99
 MIN_MONO_URL=http://download.mono-project.com/archive/4.4.0/macos-10-universal/MonoFramework-MDK-4.4.0.148.macos10.xamarin.universal.pkg
 
 # Minimum Xamarin Studio version


### PR DESCRIPTION
We're using 4.9.x in mono master now.