### PR TITLE
[mtouch][linker] Provide a more specific error code when OptimizeGeneratedCodeSubStep fails

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -839,6 +839,15 @@ This generally indicates that there is a problem with your Xamarin.iOS installat
 
 <h3><a name="MT2015"/>MT2015: Invalid HttpMessageHandler `*` for watchOS. The only valid value is NSUrlSessionHandler.</h3>
 
+<h3><a name="MT202x"/>MT202x: Binding Optimizer failed processing `...`.</h3>
+
+Something unexpected occured when trying to optimize generated binding code. The element causing the issue is named in the error message. In order to fix this issue the assembly named (or containing the type or method named) will need to be provided in a [bug report](http://bugzilla.xamarin.com) along with a complete build log with verbosity enabled (i.e. `-v -v -v -v` in the **Additional mtouch arguments**).
+
+The last digit `x` will be:
+* `0` for an assembly name;
+* `1` for a type name;
+* `3` for a method name;
+
 <!--
  MT3xxx AOT
   MT30xx AOT (general) errors

--- a/tools/linker/ExceptionalSubStep.cs
+++ b/tools/linker/ExceptionalSubStep.cs
@@ -1,0 +1,136 @@
+﻿// Copyright 2016 Xamarin Inc.
+
+using System;
+using Mono.Cecil;
+using Mono.Tuner;
+using Xamarin.Bundler;
+
+namespace Xamarin.Linker {
+
+	public abstract class ExceptionalSubStep : BaseSubStep {
+
+		public override sealed void ProcessAssembly (AssemblyDefinition assembly)
+		{
+			try {
+				Process (assembly);
+			} catch (Exception e) {
+				throw Fail (assembly, e);
+			}
+		}
+
+		public override sealed void ProcessType (TypeDefinition type)
+		{
+			try {
+				Process (type);
+			} catch (Exception e) {
+				throw Fail (type, e);
+			}
+		}
+
+		public override sealed void ProcessField (FieldDefinition field)
+		{
+			try {
+				Process (field);
+			} catch (Exception e) {
+				throw Fail (field, e);
+			}
+		}
+
+		public override sealed void ProcessMethod (MethodDefinition method)
+		{
+			try {
+				Process (method);
+			} catch (Exception e) {
+				throw Fail (method, e);
+			}
+		}
+
+		public override sealed void ProcessProperty (PropertyDefinition property)
+		{
+			try {
+				Process (property);
+			} catch (Exception e) {
+				throw Fail (property, e);
+			}
+		}
+
+		public override sealed void ProcessEvent (EventDefinition @event)
+		{
+			try {
+				Process (@event);
+			} catch (Exception e) {
+				throw Fail (@event, e);
+			}
+		}
+
+		// state-aware versions to be subclassed
+
+		protected virtual void Process (AssemblyDefinition assembly)
+		{
+		}
+
+		protected virtual void Process (TypeDefinition type)
+		{
+		}
+
+		protected virtual void Process (FieldDefinition field)
+		{
+		}
+
+		protected virtual void Process (MethodDefinition method)
+		{
+		}
+
+		protected virtual void Process (PropertyDefinition property)
+		{
+		}
+
+		protected virtual void Process (EventDefinition @event)
+		{
+		}
+
+		// failure overrides, with defaults
+
+		protected virtual Exception Fail (AssemblyDefinition assembly, Exception e)
+		{
+			var message = $"{Name} failed processing `{assembly?.FullName}`.";
+			return ErrorHelper.CreateError (ErrorCode, e, message);
+		}
+
+		protected virtual Exception Fail (TypeDefinition type, Exception e)
+		{
+			var message = $"{Name} failed processing {type?.FullName}.";
+			return ErrorHelper.CreateError (ErrorCode | 1, e, message);
+		}
+
+		protected virtual Exception Fail (FieldDefinition field, Exception e)
+		{
+			var message = $"{Name} failed processing `{field?.FullName}`.";
+			return ErrorHelper.CreateError (ErrorCode | 2, e, message);
+		}
+
+		protected virtual Exception Fail (MethodDefinition method, Exception e)
+		{
+			var message = $"{Name} failed processing `{method?.FullName}`.";
+			return ErrorHelper.CreateError (ErrorCode | 3, e, message);
+		}
+
+		protected virtual Exception Fail (PropertyDefinition property, Exception e)
+		{
+			var message = $"{Name} failed processing {property?.FullName}.";
+			return ErrorHelper.CreateError (ErrorCode | 4, e, message);
+		}
+
+		protected virtual Exception Fail (EventDefinition @event, Exception e)
+		{
+			var message = $"{Name} failed processing {@event?.FullName}.";
+			return ErrorHelper.CreateError (ErrorCode | 5, e, message);
+		}
+
+		// abstracts
+
+		protected abstract string Name { get; }
+
+		protected abstract int ErrorCode { get; }
+	}
+}

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -84,6 +84,7 @@ tuner_sources = \
 	$(TOP)/tools/linker/MobileRemoveAttributes.cs		\
 	$(TOP)/tools/linker/MobileSweepStep.cs			\
 	$(TOP)/tools/linker/RemoveSelectors.cs			\
+	$(TOP)/tools/linker/ExceptionalSubStep.cs		\
 	../linker/MonoTouch.Tuner/RemoveMonoTouchResources.cs	\
 	../linker/MonoTouch.Tuner/Extensions.cs	\
 	../linker/MonoTouch.Tuner/ListExportedSymbols.cs	\

--- a/tools/mmp/error.cs
+++ b/tools/mmp/error.cs
@@ -66,6 +66,7 @@ namespace Xamarin.Bundler {
 	//					MM2012   Only first {0} of {1} "Referenced by" warnings shown. ** This message related to 2009 **
 	//				Warning	MM2013	Failed to resolve the reference to "{0}", referenced in "{1}". The app will not include the referenced assembly, and may fail at runtime.
 	//				Warning	MT2014	Xamarin.Mac Extensions do not support linking. Request for linking will be ignored.
+	//					MM202x	Binding Optimizer failed processing `...`.
 	// MM4xxx	code generation
 	// 			MM40xx	driver.m
 	//					MM4001	The main template could not be expansed to `{0}`.

--- a/tools/mmp/linker/MonoMac.Tuner/OptimizeGeneratedCodeSubStep.cs
+++ b/tools/mmp/linker/MonoMac.Tuner/OptimizeGeneratedCodeSubStep.cs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 Xamarin Inc. All rights reserved.
+// Copyright 2012-2013,2016 Xamarin Inc. All rights reserved.
 
 using System;
 using Mono.Cecil;
@@ -26,8 +26,13 @@ namespace MonoMac.Tuner {
 			return base.IsActiveFor (assembly);
 		}
 		
-		public override void ProcessMethod (MethodDefinition method)
+		protected override void Process (MethodDefinition method)
 		{
+			// special processing on generated methods from NSObject-inherited types
+			// it would be too risky to apply on user-generated code
+			if (!method.HasBody || !method.IsGeneratedCode () || (!IsExtensionType && !IsExport (method)))
+				return;
+			
 			var instructions = method.Body.Instructions;
 			for (int i = 0; i < instructions.Count; i++) {
 				switch (instructions [i].OpCode.Code) {

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -320,6 +320,9 @@
     <Compile Include="..\common\PInvokeWrapperGenerator.cs">
       <Link>external\PInvokeWrapperGenerator.cs</Link>
     </Compile>
+    <Compile Include="..\linker\ExceptionalSubStep.cs">
+      <Link>Xamarin.Linker\ExceptionalSubStep.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -77,6 +77,7 @@ LINKER_SOURCES = \
 	$(TOP)/tools/linker/CorePreserveCode.cs		\
 	$(TOP)/tools/linker/CoreRemoveAttributes.cs		\
 	$(TOP)/tools/linker/CoreRemoveSecurity.cs		\
+	$(TOP)/tools/linker/ExceptionalSubStep.cs		\
 	$(TOP)/tools/linker/MarkNSObjects.cs			\
 	$(TOP)/tools/linker/MobileExtensions.cs		\
 	$(TOP)/tools/linker/MobileMarkStep.cs			\

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -205,6 +205,7 @@ namespace Xamarin.Bundler {
 	//					MT2013	** reserved Xamarin.Mac **
 	//					MT2014	** reserved Xamarin.Mac **
 	//					MT2015	Invalid HttpMessageHandler `{0}` for watchOS. The only valid value is NSUrlSessionHandler.
+	//					MT202x	Binding Optimizer failed processing `...`.
 	// MT3xxx	AOT
 	//			MT30xx	AOT (general) errors
 	//					MT3001	Could not AOT the assembly '{0}'

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -323,6 +323,9 @@
     <Compile Include="..\common\PInvokeWrapperGenerator.cs">
       <Link>common\PInvokeWrapperGenerator.cs</Link>
     </Compile>
+    <Compile Include="..\linker\ExceptionalSubStep.cs">
+      <Link>Xamarin.Linker\ExceptionalSubStep.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Core" />


### PR DESCRIPTION
The MT2001 error is a general, something went bad, in the linker code
base. The stack trace is often enough to track down issues but in some
cases it would be easier to ask customers for a specific assembly
(rather than their complete project) to investigate an issue.

Example:

```
error MT2103: Binding Optimizer failed processing `System.Void GoogleConversionTracking.Unified.GoogleConversionPing::.ctor()`.
--- inner exception
System.NullReferenceException: Object reference not set to an instance of an object
  at MonoTouch.Tuner.OptimizeGeneratedCodeSubStep.ProcessIsDirectBinding (Mono.Cecil.MethodDefinition caller, Mono.Cecil.Cil.Instruction ins) [0x00026] in /Users/poupou/git/xamarin/xamarin-macios/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs:264
  at MonoTouch.Tuner.OptimizeGeneratedCodeSubStep.ProcessCalls (Mono.Cecil.MethodDefinition caller, Int32 i) [0x00337] in /Users/poupou/git/xamarin/xamarin-macios/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs:197
  at MonoTouch.Tuner.OptimizeGeneratedCodeSubStep.Process (Mono.Cecil.MethodDefinition method) [0x0007b] in /Users/poupou/git/xamarin/xamarin-macios/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs:81
  at Xamarin.Linker.StateSubStep.ProcessMethod (Mono.Cecil.MethodDefinition method) [0x00004] in /Users/poupou/git/xamarin/xamarin-macios/tools/linker/CoreOptimizeGeneratedCode.cs:48
---
  at Xamarin.Linker.StateSubStep.ProcessMethod (Mono.Cecil.MethodDefinition method) [0x00014] in /Users/poupou/git/xamarin/xamarin-macios/tools/linker/CoreOptimizeGeneratedCode.cs:50
  at Mono.Tuner.SubStepDispatcher.DispatchMethod (Mono.Cecil.MethodDefinition method) [0x0001d] in /Users/poupou/git/xamarin/xamarin-macios/external/mono/mcs/tools/tuner/Mono.Tuner/Dispatcher.cs:215
  at Mono.Tuner.SubStepDispatcher.BrowseMethods (ICollection methods) [0x0001c] in /Users/poupou/git/xamarin/xamarin-macios/external/mono/mcs/tools/tuner/Mono.Tuner/Dispatcher.cs:167
  at Mono.Tuner.SubStepDispatcher.BrowseTypes (ICollection types) [0x0006b] in /Users/poupou/git/xamarin/xamarin-macios/external/mono/mcs/tools/tuner/Mono.Tuner/Dispatcher.cs:145
  at Mono.Tuner.SubStepDispatcher.BrowseAssemblies (IEnumerable`1 assemblies) [0x00050] in /Users/poupou/git/xamarin/xamarin-macios/external/mono/mcs/tools/tuner/Mono.Tuner/Dispatcher.cs:123
  at Mono.Tuner.SubStepDispatcher.Process (Mono.Linker.LinkContext context) [0x0000f] in /Users/poupou/git/xamarin/xamarin-macios/external/mono/mcs/tools/tuner/Mono.Tuner/Dispatcher.cs:104
  at Mono.Linker.Pipeline.Process (Mono.Linker.LinkContext context) [0x00027] in /Users/poupou/git/xamarin/xamarin-macios/external/mono/mcs/tools/linker/Mono.Linker/Pipeline.cs:118
  at MonoTouch.Tuner.Linker.Process (MonoTouch.Tuner.LinkerOptions options, MonoTouch.Tuner.MonoTouchLinkContext& context, System.Collections.Generic.List`1& assemblies) [0x000ac] in /Users/poupou/git/xamarin/xamarin-macios/tools/mtouch/Tuning.cs:79
```

Right now the MT2001 would only include the inner exception, which does
not include any clue to which assembly caused the exception.

Note: The same pattern to be applied to other BaseSubStep subclasses in
separate commits.

Related to (but not the fix for) https://bugzilla.xamarin.com/show_bug.cgi?id=44701