### PR TITLE
[CoreImage] Add missing property ColorSpace to CIImage

### DIFF
--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -1588,10 +1588,9 @@ namespace XamCore.CoreImage {
 		[NullAllowed, Export ("url")]
 		NSUrl Url { get; }
 
-		// WARNING: "CF_RETURNS_NOT_RETAINED", so not surfacing for now, until we research
-		//[iOS (9,0)]
-		//[NullAllowed, Export ("colorSpace")]
-		//CGColorSpace ColorSpace { get; }
+		[iOS (9,0)]
+		[NullAllowed, Export ("colorSpace")]
+		CGColorSpace ColorSpace { get; }
 
 		[iOS (9,0)]
 		[Static, Internal]

--- a/tests/monotouch-test/CoreImage/ImageTest.cs
+++ b/tests/monotouch-test/CoreImage/ImageTest.cs
@@ -93,6 +93,19 @@ namespace MonoTouchFixtures.CoreImage {
 				Assert.That (h.Extent.Height, Is.EqualTo ((nfloat) 1), "Height");
 			}
 		}
+
+		[Test]
+		public void CIImageColorSpaceTest ()
+		{
+			if (!TestRuntime.CheckXcodeVersion (7, 0))
+				Assert.Inconclusive ("requires iOS9+");
+
+			using (var cgimage = new CIImage (NSUrl.FromFilename ("xamarin1.png")))
+			using (var cs = cgimage.ColorSpace) {
+				Assert.NotNull (cs, "ColorSpace should not be null");
+				Assert.That (cs.Name, Is.EqualTo ("kCGColorSpaceSRGB"));
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=44438

The ColorSpace property is decorated with the CF_RETURNS_NOT_RETAINED
macro, this means it returns an object that follows the CoreFoundation
[Ownership Policy](1) but it does not follow the naming convention
documented in the policy.

The [CF_RETURNS_NOT_RETAINED](2) indicates that the object reference
returned is not owned by the caller, so we should definitely call
CGColorSpaceRetain when obtaining a handle.

Since CGColorSpace is considered into the [MarshalType list](3) the
generated code ends up calling the IntPtr ctor which does the right
thing, [calling CGColorSpaceRetain](4) in the given ptr.

And last but not least, we already bind another property decorated
with [CF_RETURNS_NOT_RETAINED](2) in [CIColor::ColorSpace](5).

[1]: https://developer.apple.com/library/content/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html
[2]: http://clang-analyzer.llvm.org/annotations.html#attr_cf_returns_not_retained
[3]: https://github.com/xamarin/xamarin-macios/blob/0bc23b379a57a7329e4c75887d5ab5b4be25414e/src/generator.cs#L2642
[4]: https://github.com/xamarin/xamarin-macios/blob/xcode8/src/CoreGraphics/CGColorSpace.cs#L77-L80
[5]: https://github.com/xamarin/xamarin-macios/blob/xcode8/src/coreimage.cs#L112-L113