### PR TITLE
[mtouch][linker] Use correct error code for CoreOptimizeGeneratedCode

### DIFF
--- a/tools/linker/CoreOptimizeGeneratedCode.cs
+++ b/tools/linker/CoreOptimizeGeneratedCode.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Linker {
 	public abstract class CoreOptimizeGeneratedCode : ExceptionalSubStep {
 
 		protected override string Name { get; } = "Binding Optimizer";
-		protected override int ErrorCode { get; } = 2100;
+		protected override int ErrorCode { get; } = 2020;
 
 		protected bool HasGeneratedCode { get; private set; }
 		protected bool IsExtensionType { get; private set; }


### PR DESCRIPTION
Previous PR [1] has the right documentation but the wrong source code.

[1] https://github.com/xamarin/xamarin-macios/pull/903