### PR TITLE
[CoreFoundation] Fix bug 44399 - ArgumentNullException in AddObserver

### DIFF
--- a/tests/api-shared/CoreFoundation/CFNotificationCenterTest.cs
+++ b/tests/api-shared/CoreFoundation/CFNotificationCenterTest.cs
@@ -86,6 +86,72 @@ namespace MonoTouchFixtures.CoreFoundation
 			Assert.AreEqual (1, count);
 		}
 
+		[Test]
+		public void TestNullNameAndObserver ()
+		{
+			var d = CFNotificationCenter.Local;
+			bool mornNotification = false;
+
+			var token = d.AddObserver (null, null, (n, i) => mornNotification = n == "MornNotification");
+
+			// When not listening for a specific name nor observing an specific object
+			// we will get all notifications posted to NSNotificationCenter/Local CFNotificationCenter
+			NSNotificationCenter.DefaultCenter.PostNotificationName ("MornNotification", null);
+
+			d.RemoveObserver (token);
+			Assert.IsTrue (mornNotification);
+		}
+
+		[Test]
+		public void TestObservers2 ()
+		{
+			var d = CFNotificationCenter.Local;
+			int count = 0;
+			int count2 = 0;
+			CFNotificationObserverToken o2 = null;
+			var o1 = d.AddObserver (null, null, (x, dd) => {
+				count++;
+				if (count == 1)
+					o2 = d.AddObserver (null, null, (y, ee) => {
+						count2++;
+					});
+			});
+			d.PostNotification ("hello", null, null, deliverImmediately: true);
+			Assert.AreEqual (1, count);
+			NSNotificationCenter.DefaultCenter.PostNotificationName ("hello", null);
+			Assert.AreEqual (2, count);
+			Assert.AreEqual (1, count2);
+
+			// Remove the first observer, count should not be updated
+			d.RemoveObserver (o1);
+			d.PostNotification ("hello", null, null);
+			Assert.AreEqual (2, count);
+			Assert.AreEqual (2, count2);
+
+			// Remove the last observer, there should be no change in count
+			d.RemoveObserver (o2);
+			NSNotificationCenter.DefaultCenter.PostNotificationName ("hello", null);
+			Assert.AreEqual (2, count);
+			Assert.AreEqual (2, count2);
+
+			// Test removing all observers
+			count = 0;
+			o1 = d.AddObserver (null, null, (x, dd) => {
+				count++;
+			});
+			o2 = d.AddObserver (null, null, (y, ee) => { count++; });
+			d.RemoveEveryObserver ();
+			NSNotificationCenter.DefaultCenter.PostNotificationName ("hello", null);
+			Assert.AreEqual (0, count);
+
+			// Test removing from a callback
+			count = 0;
+			o2 = d.AddObserver (null , null, (y, ee) => { count++; d.RemoveObserver (o2); });
+			d.PostNotification ("hello", null, null);
+			Assert.AreEqual (1, count);
+			NSNotificationCenter.DefaultCenter.PostNotificationName ("hello", null);
+			Assert.AreEqual (1, count);
+		}
 	}
 }
 


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=44399

We did not fully support passing null to name and objectToObserve in
CFNotificationCenter::AddObserver an  ArgumentNullException was thrown

The use case of sending null to both name and objectToObserve is to
observe all notifications posted to the notification center, this
won't work using darwing notification center, it is restricted
by apple.