### PR TITLE
[avfoundation] Add overloads to AVCaptureDevice that accept an enum. Fixes #32535

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -135,7 +135,47 @@ namespace XamCore.AVFoundation {
 		[Export ("finishCancelledRequest")]
 		void FinishCancelledRequest ();
 	}
-		
+
+	// values are manually given since not some are platform specific
+	[NoWatch]
+	enum AVMediaTypes {
+		[Field ("AVMediaTypeVideo")]
+		Video = 0,
+
+		[Field ("AVMediaTypeAudio")]
+		Audio = 1,
+
+		[Field ("AVMediaTypeText")]
+		Text = 2,
+
+		[Field ("AVMediaTypeClosedCaption")]
+		ClosedCaption = 3,
+
+		[Field ("AVMediaTypeSubtitle")]
+		Subtitle = 4,
+
+		[Field ("AVMediaTypeTimecode")]
+		Timecode = 5,
+
+		[NoTV]
+		[Availability (Obsoleted = Platform.iOS_6_0 | Platform.Mac_10_8)]
+		[Field ("AVMediaTypeTimedMetadata")] // last header where I can find this: iOS 5.1 SDK, 10.7 only on Mac
+		TimedMetadata = 6,
+
+		[Field ("AVMediaTypeMuxed")]
+		Muxed = 7,
+
+		[iOS (9,0)][NoMac]
+		[Field ("AVMediaTypeMetadataObject")]
+		MetadataObject = 8,
+
+		[Since (6,0)][Mac (10,8)]
+		[Field ("AVMediaTypeMetadata")]
+		Metadata = 9,
+	}
+
+#if !XAMCORE_4_0
+	[Obsolete ("Use AVMediaTypes enum values")]
 	[NoWatch]
 	[Since (4,0)]
 	[BaseType (typeof (NSObject))][Static]
@@ -174,6 +214,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMediaTypeMetadata")]
 		NSString Metadata { get; }
 	}
+#endif
 
 	[NoWatch]
 	[iOS (9,0), Mac(10,11)]
@@ -8276,7 +8317,18 @@ namespace XamCore.AVFoundation {
 
 		[Static]
 		[Export ("defaultDeviceWithMediaType:")]
+		AVCaptureDevice GetDefaultDevice (NSString mediaType);
+
+		[Static]
+		[Wrap ("GetDefaultDevice (mediaType.GetConstant ())")]
+		AVCaptureDevice GetDefaultDevice (AVMediaTypes mediaType);
+
+#if !XAMCORE_4_0
+		[Obsolete ("Use GetDefaultDevice(AVMediaTypes)")]
+		[Static]
+		[Wrap ("GetDefaultDevice ((NSString) mediaType)")]
 		AVCaptureDevice DefaultDeviceWithMediaType (string mediaType);
+#endif
 
 		[Static]
 		[Export ("deviceWithUniqueID:")]
@@ -8284,6 +8336,9 @@ namespace XamCore.AVFoundation {
 
 		[Export ("hasMediaType:")]
 		bool HasMediaType (string mediaType);
+
+		[Wrap ("HasMediaType ((string) mediaType.GetConstant ())")]
+		bool HasMediaType (AVMediaTypes mediaType);
 
 		[Export ("lockForConfiguration:")]
 		bool LockForConfiguration (out NSError error);

--- a/tests/monotouch-test/AVFoundation/CaptureDeviceTest.cs
+++ b/tests/monotouch-test/AVFoundation/CaptureDeviceTest.cs
@@ -1,0 +1,41 @@
+﻿#if !__WATCHOS__
+using System;
+#if XAMCORE_2_0
+using Foundation;
+using AVFoundation;
+#else
+using MonoTouch.AVFoundation;
+using MonoTouch.Foundation;
+#endif
+using NUnit.Framework;
+namespace MonoTouchFixtures.AVFoundation {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class CaptureDeviceTest {
+
+		void Compare (NSString constant, AVMediaTypes value)
+		{
+			Assert.That (AVCaptureDevice.GetDefaultDevice (constant), Is.EqualTo (AVCaptureDevice.GetDefaultDevice (value)), value.ToString ());
+#if !XAMCORE_4_0
+			Assert.That (AVCaptureDevice.GetDefaultDevice (constant), Is.EqualTo (AVCaptureDevice.DefaultDeviceWithMediaType ((string) constant)), value.ToString () + ".compat");
+#endif
+		}
+
+		[Test]
+		public void CompareConstantEnum ()
+		{
+			Compare (AVMediaType.Audio, AVMediaTypes.Audio);
+			Compare (AVMediaType.ClosedCaption, AVMediaTypes.ClosedCaption);
+			Compare (AVMediaType.Metadata, AVMediaTypes.Metadata);
+			Compare (AVMediaType.MetadataObject, AVMediaTypes.MetadataObject);
+			Compare (AVMediaType.Muxed, AVMediaTypes.Muxed);
+			Compare (AVMediaType.Subtitle, AVMediaTypes.Subtitle);
+			Compare (AVMediaType.Text, AVMediaTypes.Text);
+			Compare (AVMediaType.Timecode, AVMediaTypes.Timecode);
+			Compare (AVMediaType.TimedMetadata, AVMediaTypes.TimedMetadata);
+			Compare (AVMediaType.Video, AVMediaTypes.Video);
+		}
+	}
+}
+#endif

--- a/tests/monotouch-test/AVFoundation/CaptureDeviceTest.cs
+++ b/tests/monotouch-test/AVFoundation/CaptureDeviceTest.cs
@@ -1,4 +1,4 @@
-﻿#if !__WATCHOS__
+﻿#if __IOS__
 using System;
 #if XAMCORE_2_0
 using Foundation;

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -596,6 +596,7 @@
     <Compile Include="HealthKit\CdaDocumentSampleTest.cs" />
     <Compile Include="Metal\HeapDescriptorTest.cs" />
     <Compile Include="CoreMedia\CMClockOrTimebaseTest.cs" />
+    <Compile Include="AVFoundation\CaptureDeviceTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
The current API use `string`, not `NSString` is added as a step forward.
The `NSString` is more correct but it does not ease discoverability (e.g.
code completion) so an enum-based overload is added (as the preferred API).

https://bugzilla.xamarin.com/show_bug.cgi?id=32535