### PR TITLE
[mtouch] Tell Cecil to load assemblies in memory unless they're big assemblies.

### DIFF
--- a/tools/mtouch/AssemblyResolver.cs
+++ b/tools/mtouch/AssemblyResolver.cs
@@ -45,13 +45,18 @@ namespace MonoTouch.Tuner {
 		public bool EnableRepl { get; set; }
 
 		Dictionary<string, AssemblyDefinition> cache;
-		ReaderParameters parameters;
 
 		public MonoTouchResolver ()
 		{
 			cache = new Dictionary<string, AssemblyDefinition> (StringComparer.InvariantCultureIgnoreCase);
-			parameters = new ReaderParameters ();
+		}
+
+		ReaderParameters CreateParameters (string path)
+		{
+			var parameters = new ReaderParameters ();
 			parameters.AssemblyResolver = this;
+			parameters.InMemory = new FileInfo (path).Length < 1024 * 1024 * 100; // 100 MB.
+			return parameters;
 		}
 
 		public IDictionary ToResolverCache ()
@@ -88,7 +93,7 @@ namespace MonoTouch.Tuner {
 						fileName = archName;
 				}
 
-				assembly = ModuleDefinition.ReadModule (fileName, parameters).Assembly;
+				assembly = ModuleDefinition.ReadModule (fileName, CreateParameters (fileName)).Assembly;
 			}
 			catch (Exception e) {
 				throw new MonoTouchException (9, true, e, "Error while loading assemblies: {0}", fileName);
@@ -99,17 +104,17 @@ namespace MonoTouch.Tuner {
 
 		public AssemblyDefinition Resolve (string fullName)
 		{
-			return Resolve (AssemblyNameReference.Parse (fullName), parameters);
+			return Resolve (AssemblyNameReference.Parse (fullName), null);
 		}
 
 		public AssemblyDefinition Resolve (string fullName, ReaderParameters parameters)
 		{
-			return Resolve (AssemblyNameReference.Parse (fullName), parameters);
+			return Resolve (AssemblyNameReference.Parse (fullName), null);
 		}
 
 		public AssemblyDefinition Resolve (AssemblyNameReference reference)
 		{
-			return Resolve (reference, parameters);
+			return Resolve (reference, null);
 		}
 
 		public AssemblyDefinition Resolve (AssemblyNameReference name, ReaderParameters parameters)


### PR DESCRIPTION
In the recent Cecil update Cecil changed from loading assemblies in memory to
keep a FileStream around and read whenever necessary [1].

This is problematic for us, because we need all the AssemblyDefinitions in
memory at once, and if there are many assemblies, then we'll run into problems
due to the number of file descriptors in use.

So revert to the behavior for the old Cecil: loading assemblies in memory,
unless the assemblies are big, since in that case we might run out of memory
otherwise.

http://cecil.pe/post/149243207656/mono-cecil-010-beta-1