### PR TITLE
[networkextension] Enable default contructor on NETunnelProviderManager

### DIFF
--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -735,7 +735,6 @@ namespace XamCore.NetworkExtension {
 
 	[iOS (9,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof(NEVpnManager))]
-	[DisableDefaultCtor] // init returns nil
 	interface NETunnelProviderManager
 	{
 		[Static]


### PR DESCRIPTION
Fixes bug [#44874](https://bugzilla.xamarin.com/show_bug.cgi?id=44874): Problems with NetworkExtension.NETunnelProviderManager

Using the default constructor doesn't return null anymore, this might be a change we missed in one of the betas.