### PR TITLE
[system-dependencies] Ignore ignore commands we don't understand.

### DIFF
--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -56,6 +56,10 @@ while ! test -z $1; do
 			IGNORE_CMAKE=1
 			shift
 			;;
+		--ignore-*)
+			echo "Unknown ignore argument: $1"
+			exit 0
+			;;
 		*)
 			echo "Unknown argument: $1"
 			exit 1


### PR DESCRIPTION
So that if we introduce new dependencies and want to ignore them,
the ignore command is ignored by current scripts (makes CI setup easier).