### PR TITLE
Remove the watch-mono repository, and use a single mono repository.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,7 +29,3 @@
 [submodule "external/guiunit"]
 	path = external/guiunit
 	url = ../../mono/guiunit.git
-[submodule "external/watch-mono"]
-	path = external/watch-mono
-	url = ../../mono/mono.git
-	branch = master

--- a/Make.config
+++ b/Make.config
@@ -215,7 +215,7 @@ DEVICETV_OBJC_CFLAGS       = $(DEVICETV_CFLAGS) $(DEVICE_OBJC_CFLAGS)
 # paths to the modules we depend on, as variables, so people can put
 # things in other places if they absolutely must.
 MONO_PATH=$(TOP)/external/mono
-WATCH_MONO_PATH=$(TOP)/external/watch-mono
+WATCH_MONO_PATH=$(TOP)/external/mono
 LLVM_PATH=$(TOP)/external/llvm
 FSHARP_PATH=$(TOP)/external/fsharp
 MONOTOUCH_DIALOG_PATH=$(TOP)/external/MonoTouch.Dialog

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -346,8 +346,10 @@ endif
 $(MONO_PATH)/configure: $(MONO_PATH)/configure.ac $(BUILDS_MAKEFILE_DEP)
 	$(Q) ./wrap-autogen.sh $(MONO_PATH) mono $(XAMARIN_AUTOGEN_FLAGS)
 
+ifneq ($(WATCH_MONO_PATH),$(MONO_PATH))
 $(WATCH_MONO_PATH)/configure: $(WATCH_MONO_PATH)/configure.ac $(BUILDS_MAKEFILE_DEP)
 	$(Q) ./wrap-autogen.sh $(WATCH_MONO_PATH) mono
+endif
 
 configure-mono:
 	rm -f $(MONO_PATH)/configure
@@ -1871,15 +1873,21 @@ install-llvm64: .stamp-build-llvm64 $(LLVM_TARGETS)
 llvm: setup-llvm build-llvm install-llvm
 llvm64: install-llvm64
 
+ifneq ($(WATCH_MONO_PATH),$(MONO_PATH))
 $(MONO_PATH)/tools/offsets-tool/.stamp-clone $(WATCH_MONO_PATH)/tools/offsets-tool/.stamp-clone:
+else
+$(MONO_PATH)/tools/offsets-tool/.stamp-clone:
+endif
 	@echo Cloning for offsets-tool in $(dir $@)
 	$(Q) $(MAKE) -C $(dir $@) .stamp-clone
 
 $(MONO_PATH)/tools/offsets-tool/MonoAotOffsetsDumper.exe: $(MONO_PATH)/tools/offsets-tool/.stamp-clone $(wildcard $(MONO_PATH)/tools/offsets-tool/*.cs)
 	$(Q) $(MAKE) -C $(dir $@) MonoAotOffsetsDumper.exe
 
+ifneq ($(WATCH_MONO_PATH),$(MONO_PATH))
 $(WATCH_MONO_PATH)/tools/offsets-tool/MonoAotOffsetsDumper.exe: $(WATCH_MONO_PATH)/tools/offsets-tool/.stamp-clone $(wildcard $(WATCH_MONO_PATH)/tools/offsets-tool/*.cs)
 	$(Q) $(MAKE) -C $(dir $@) MonoAotOffsetsDumper.exe
+endif
 
 target7/mono/arch/arm/arm_dpimacros.h: setup-target7
 	$(Q) $(MAKE) -C $(dir $@) $(notdir $@)

--- a/mk/versions.mk
+++ b/mk/versions.mk
@@ -59,7 +59,6 @@ endef
 $(shell rm -f .check-versions-failure)
 $(eval $(call CheckSubmoduleTemplate,llvm,LLVM))
 $(eval $(call CheckSubmoduleTemplate,mono,MONO))
-$(eval $(call CheckSubmoduleTemplate,watch-mono,WATCH_MONO))
 $(eval $(call CheckSubmoduleTemplate,fsharp,FSHARP))
 $(eval $(call CheckSubmoduleTemplate,MonoTouch.Dialog,MONOTOUCH_DIALOG))
 $(eval $(call CheckSubmoduleTemplate,Touch.Unit,TOUCH_UNIT))


### PR DESCRIPTION
Still keeping some of the logic so that it's easy to switch back if we wish
to.