### PR TITLE
[mtouch] Set install_name for libpinvokes.dylib. Fixes #44775.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1974,6 +1974,17 @@ class Test {
 				Assert.AreEqual (0, tool.Execute (MTouchAction.BuildDev));
 
 				Assert.IsTrue (File.Exists (Path.Combine (tool.AppPath, "libpinvokes.dylib")), "libpinvokes.dylib existence");
+
+				var otool_output = ExecutionHelper.Execute ("otool", $"-l {Quote (Path.Combine (tool.AppPath, "libpinvokes.dylib"))}", hide_output: true);
+				Assert.That (otool_output, Is.StringContaining ("LC_ID_DYLIB"), "output contains LC_ID_DYLIB");
+
+				var lines = otool_output.Split (new char [] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+				for (int i = 0; i < lines.Length; i++) {
+					if (lines [i].Contains ("LC_ID_DYLIB")) {
+						Assert.That (lines [i + 2], Is.StringContaining ("name @executable_path/libpinvokes.dylib "), "LC_ID_DYLIB");
+						break;
+					}
+				}
 			}
 		}
 

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1787,6 +1787,7 @@ namespace Xamarin.Bundler {
 					Language = "objective-c++",
 				};
 				if (Driver.App.FastDev) {
+					task.InstallName = "lib" + Path.GetFileNameWithoutExtension (ifile) + ext;
 					task.CompilerFlags.AddFramework ("Foundation");
 					task.CompilerFlags.LinkWithXamarin ();
 				}
@@ -1978,6 +1979,9 @@ namespace Xamarin.Bundler {
 		
 		void GetSharedCompilerFlags (CompilerFlags flags, string install_name)
 		{
+			if (string.IsNullOrEmpty (install_name))
+				throw new ArgumentNullException (nameof (install_name));
+
 			flags.AddOtherFlag ("-shared");
 			if (!App.EnableMarkerOnlyBitCode)
 				flags.AddOtherFlag ("-read_only_relocs suppress");


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=44775