### PR TITLE
[mtouch] Fix NullReferenceException in PInvoke wrapper generation. Fixes #44763.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1971,7 +1971,7 @@ class Test {
 				tool.CreateTemporaryWatchKitExtension ();
 
 				tool.FastDev = true;
-				Assert.AreEqual (0, tool.Execute (MTouchAction.BuildDev));
+				Assert.AreEqual (0, tool.Execute (MTouchAction.BuildDev), "build");
 
 				Assert.IsTrue (File.Exists (Path.Combine (tool.AppPath, "libpinvokes.dylib")), "libpinvokes.dylib existence");
 
@@ -1985,6 +1985,8 @@ class Test {
 						break;
 					}
 				}
+
+				Assert.AreEqual (0, tool.Execute (MTouchAction.BuildDev), "cached build");
 			}
 		}
 

--- a/tools/common/PInvokeWrapperGenerator.cs
+++ b/tools/common/PInvokeWrapperGenerator.cs
@@ -28,6 +28,12 @@ namespace Xamarin.Bundler
 
 		bool first;
 
+		public bool Started {
+			get {
+				return first;
+			}
+		}
+
 		public void Start ()
 		{							
 			if (Driver.EnableDebug)
@@ -48,6 +54,9 @@ namespace Xamarin.Bundler
 
 		public void End ()
 		{
+			if (!first)
+				throw new Exception ("Generator not started");
+
 			sb.WriteLine ("}");
 
 			Registrar.GeneratePInvokeWrappersEnd ();


### PR DESCRIPTION
Fix NullReferenceException in PInvoke wrapper generation when incremental
builds are enabled and the linker didn't run because cached results were
found.

https://bugzilla.xamarin.com/show_bug.cgi?id=44763