### PR TITLE
[coregraphics] Add managed validation to CGPath.FromRoundedRect to avoid native assertion/crash. Fixes #40230

### DIFF
--- a/src/CoreGraphics/CGPath.cs
+++ b/src/CoreGraphics/CGPath.cs
@@ -662,16 +662,25 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		unsafe extern static /* CGPathRef */ IntPtr CGPathCreateWithRoundedRect (CGRect rect, /* CGFloat */ nfloat cornerWidth, /* CGFloat */ nfloat cornerHeight, CGAffineTransform *transform);
 
-		[Mac(10,9)][iOS (7,0)]
-		static public unsafe CGPath FromRoundedRect (CGRect rectangle, nfloat cornerWidth, nfloat cornerHeight)
+		static unsafe CGPath _FromRoundedRect (CGRect rectangle, nfloat cornerWidth, nfloat cornerHeight, CGAffineTransform *transform)
 		{
-			return MakeMutable (CGPathCreateWithRoundedRect (rectangle, cornerWidth, cornerHeight, null));
+			if ((cornerWidth < 0) || (2 * cornerWidth > rectangle.Width))
+				throw new ArgumentException ("cornerWidth");
+			if ((cornerHeight < 0) || (2 * cornerHeight > rectangle.Height))
+				throw new ArgumentException ("cornerHeight");
+			return MakeMutable (CGPathCreateWithRoundedRect (rectangle, cornerWidth, cornerHeight, transform));
+		}
+
+		[Mac(10,9)][iOS (7,0)]
+		static unsafe public CGPath FromRoundedRect (CGRect rectangle, nfloat cornerWidth, nfloat cornerHeight)
+		{
+			return _FromRoundedRect (rectangle, cornerWidth, cornerHeight, null);
 		}
 
 		[Mac(10,9)][iOS (7,0)]
 		static public unsafe CGPath FromRoundedRect (CGRect rectangle, nfloat cornerWidth, nfloat cornerHeight, CGAffineTransform transform)
 		{
-			return MakeMutable (CGPathCreateWithRoundedRect (rectangle, cornerWidth, cornerHeight, &transform));
+			return _FromRoundedRect (rectangle, cornerWidth, cornerHeight, &transform);
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]

--- a/tests/monotouch-test/CoreGraphics/PathTest.cs
+++ b/tests/monotouch-test/CoreGraphics/PathTest.cs
@@ -246,5 +246,18 @@ namespace MonoTouchFixtures.CoreGraphics {
 				Assert.IsFalse (p2.IsEmpty, "IsEmpty");
 			}
 		}
+
+		[Test]
+		public void Bug40230 ()
+		{
+			var rect = new CGRect (1, 1, 25, 25);
+			// Assertion failed: (corner_width >= 0 && 2 * corner_width <= CGRectGetWidth(rect)), function CGPathCreateWithRoundedRect
+			Assert.Throws<ArgumentException> (() => CGPath.FromRoundedRect (rect, 13.5f, 1), "width");
+			// Assertion failed: (corner_height >= 0 && 2 * corner_height <= CGRectGetHeight(rect)), function CGPathRef CGPathCreateWithRoundedRect
+			Assert.Throws<ArgumentException> (() => CGPath.FromRoundedRect (rect, 1, 13.5f), "height");
+			using (var path = CGPath.FromRoundedRect (rect, 1, 1)) {
+				Assert.IsNotNull (path, "path");
+			}
+		}
 	}
 }


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=40230