### PR TITLE
[ObjCRuntime] Remove the IDynamicRegistrar interface.

### DIFF
--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -67,7 +67,7 @@ namespace XamCore.Registrar {
 		}
 	}
 
-	class DynamicRegistrar : Registrar, IDynamicRegistrar {
+	class DynamicRegistrar : Registrar {
 		Dictionary<IntPtr, ObjCType> type_map;
 		Dictionary <IntPtr, LazyMapEntry> lazy_map;
 		Dictionary <Type, Dictionary <IntPtr, MethodDescription>> method_map;

--- a/src/ObjCRuntime/IDynamicRegistrar.cs
+++ b/src/ObjCRuntime/IDynamicRegistrar.cs
@@ -20,23 +20,6 @@ namespace XamCore.Registrar {
 		public string Typename;
 		public bool IsCustomType;
 	}
-
-	interface IDynamicRegistrar {
-		void RegisterAssembly (Assembly assembly);
-		UnmanagedMethodDescription GetMethodDescription (Type type, IntPtr selptr);
-		UnmanagedMethodDescription GetMethodDescriptionAndObject (Type type, IntPtr sel, IntPtr obj, ref IntPtr mthis);
-		Type Lookup (IntPtr klass, bool throw_on_error);
-		IntPtr Register (Type Type);
-		void Register (Type gype, ref List<Exception> exceptions);
-		Dictionary<IntPtr, LazyMapEntry> GetRegistrationMap (int initial_capacity);
-		void SetAssemblyRegistered (string assembly);
-		Dictionary<IntPtr, MethodDescription> GetMethods (Type type);
-		void RegisterMethods (Type type, Dictionary<IntPtr, MethodDescription> methods);
-		bool IsCustomType (Type type);
-		void RegisterMethod (Type type, MethodInfo minfo, ExportAttribute ea);
-		IEnumerable<Assembly> GetAssemblies ();
-		string ComputeSignature (MethodInfo minfo, bool isBlockSignature);
-	}
 #endif
 }
 

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -48,8 +48,7 @@ namespace XamCore.ObjCRuntime {
 		internal static IntPtrEqualityComparer IntPtrEqualityComparer;
 		internal static TypeEqualityComparer TypeEqualityComparer;
 
-		// note: must stay a field (or the linker must be modified)
-		internal static IDynamicRegistrar Registrar;
+		internal static DynamicRegistrar Registrar;
 
 		internal unsafe struct RegistrationData {
 			public MTRegistrationMap *map;


### PR DESCRIPTION
Remove the IDynamicRegistrar interface, since it's no longer needed (there's
no OldDynamicRegistrar anymore, which means having an interface for a single
type (DynamicRegistrar) is just code bloat at this point).