### PR TITLE
[Foundation] Fix 401s in the NSUrlHandler.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -336,10 +336,12 @@ namespace Foundation {
 				// check if we are in the first attempt, if we are (PreviousFailureCount == 0), we check the headers of the request and if we do have the Auth 
 				// header, it means that we do not have the correct credentials, in any other case just do what it is expected.
 				
-				var authHeader = GetInflightData (task).Request.Headers.Authorization;
-				if (challenge.PreviousFailureCount == 0 && (!string.IsNullOrEmpty (authHeader.Scheme) || !string.IsNullOrEmpty (authHeader.Parameter))) {
-					completionHandler (NSUrlSessionAuthChallengeDisposition.RejectProtectionSpace, null);
-					return;
+				if (challenge.PreviousFailureCount == 0) {
+					var authHeader = GetInflightData (task).Request.Headers.Authorization;
+					if (!(string.IsNullOrEmpty (authHeader.Scheme) && string.IsNullOrEmpty (authHeader.Parameter))) {
+						completionHandler (NSUrlSessionAuthChallengeDisposition.RejectProtectionSpace, null);
+						return;
+					}
 				}
 
 				if (challenge.ProtectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodNTLM) {


### PR DESCRIPTION
The NSUrlSessionHandler is not dealing with 40s correctly, unfortunatly
we are modifying the Authorization header which is a reserved header as
per apple documentation. We need to hide this issue by dealing with the
challenge in the handler.

The fix checks if it is the very first failure of the challenge and we
do have the header, in that case, reject the request and continue with
the handler execution.