### PR TITLE
Cherry-pick two commits to get greener results on wrench for xcode8.1 branch

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -87,21 +87,8 @@ run run-all run-tests run-test:
 	$(Q) $(MAKE) run-local
 
 # separate build-dev-* entries because some of them are build with debug other (llvm) with release
-build-dev-bots: build-test-libraries
-	# test LLVM armv6, this is Classic only because arm64 doesn't have llvm support.
-	$(MAKE) "build-ios-devclassic-dont link" CONFIG=Release
-	# test LLVM armv7, this is Classic only because arm64 doesn't have llvm support.
-	$(MAKE) "build-ios-devclassic-link all" CONFIG=Release
-	# test LLVM armv6 arm7 (fat), this is Classic only because arm64 doesn't have llvm support.
-	$(MAKE) "build-ios-devclassic-link sdk" CONFIG=Release
-	# test LLVM arm7 w/thumb2, this is Classic only because arm64 doesn't have llvm support.
-	$(MAKE) build-ios-devclassic-monotouch-test CONFIG=Release
-	# test BCL mscorlib
-	$(MAKE) build-ios-dev-mscorlib CONFIG=Release
-	# test BCL System.Core
-	$(MAKE) build-ios-dev-System.Core CONFIG=Release
-	# run any other scripted tests
-	$(MAKE) -C scripted
+build-dev-bots:
+	@echo "These tests are now in the mtouch test suite"
 
 build-% run-% exec-% install-%:
 	@echo ""

--- a/tests/common/ExecutionHelper.cs
+++ b/tests/common/ExecutionHelper.cs
@@ -287,14 +287,15 @@ namespace Xamarin.Tests
 		private static extern void kill (int pid, int sig);
 
 		public static string Execute (string fileName, string arguments, bool throwOnError = true, Dictionary<string,string> environmentVariables = null,
-			bool hide_output = false
+			bool hide_output = false, TimeSpan? timeout = null
 		)
 		{
 			StringBuilder output = new StringBuilder ();
-			int exitCode = Execute (fileName, arguments, environmentVariables, output, output);
+			int exitCode = Execute (fileName, arguments, environmentVariables, output, output, timeout);
 			if (!hide_output) {
 				Console.WriteLine ("{0} {1}", fileName, arguments);
 				Console.WriteLine (output);
+				Console.WriteLine ("Exit code: {0}", exitCode);
 			}
 			if (throwOnError && exitCode != 0)
 				throw new TestExecutionException (output.ToString ());

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1470,6 +1470,39 @@ namespace MTouchTests
 		}
 
 		[Test]
+		[TestCase (Target.Dev, Profile.Unified, "dont link", "Release")]
+		[TestCase (Target.Dev, Profile.Unified, "link all", "Release")]
+		[TestCase (Target.Dev, Profile.Unified, "link sdk", "Release")]
+		[TestCase (Target.Dev, Profile.Unified, "monotouch-test", "Release")]
+		[TestCase (Target.Dev, Profile.Unified, "mscorlib", "Release")]
+		[TestCase (Target.Dev, Profile.Unified, "System.Core", "Release")]
+		public void BuildTestProject (Target target, Profile profile, string testname, string configuration)
+		{
+			var subdir = string.Empty;
+			switch (testname) {
+			case "dont link":
+			case "link sdk":
+			case "link all":
+				subdir = "/linker-ios";
+				break;
+			case "monotouch-test":
+				break;
+			default:
+				subdir = "/bcl-test";
+				break;
+			}
+			var platform = target == Target.Dev ? "iPhone" : "iPhoneSimulator";
+			var csproj = Path.Combine (Configuration.SourceRoot, "tests" + subdir, testname, testname + GetProjectSuffix (profile) + ".csproj");
+			XBuild.Build (csproj, configuration, platform);
+		}
+
+		[Test]
+		public void ScriptedTests ()
+		{
+			ExecutionHelper.Execute ("make", string.Format ("-C \"{0}\"", Path.Combine (Configuration.SourceRoot, "tests", "scripted")));
+		}
+
+		[Test]
 		public void Registrar ()
 		{
 			var testDir = GetTempDirectory ();

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1499,7 +1499,7 @@ namespace MTouchTests
 		[Test]
 		public void ScriptedTests ()
 		{
-			ExecutionHelper.Execute ("make", string.Format ("-C \"{0}\"", Path.Combine (Configuration.SourceRoot, "tests", "scripted")));
+			ExecutionHelper.Execute ("make", string.Format ("-C \"{0}\"", Path.Combine (Configuration.SourceRoot, "tests", "scripted")), timeout: TimeSpan.FromMinutes (10));
 		}
 
 		[Test]


### PR DESCRIPTION
7d3adbc (Rolf Bjarne Kvinge, 5 days ago)
   [tests] Bump timeout for scripted tests to 10 minutes. (#960)

6c6798e (Rolf Bjarne Kvinge, 4 weeks ago)
   [tests] Move the 'build-dev-bots' tests to the mtouch tests and build/test
   Unified instead of Classic. (#818)

   This way all the tests are run even if one of them fails.