### PR TITLE
[tests] Fix timeout in BuildTestProject.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1245,12 +1245,12 @@ namespace MTouchTests
 		}
 
 		[Test]
-		[TestCase (Target.Dev, Profile.Unified, "dont link", "Release")]
-		[TestCase (Target.Dev, Profile.Unified, "link all", "Release")]
-		[TestCase (Target.Dev, Profile.Unified, "link sdk", "Release")]
-		[TestCase (Target.Dev, Profile.Unified, "monotouch-test", "Release")]
-		[TestCase (Target.Dev, Profile.Unified, "mscorlib", "Release")]
-		[TestCase (Target.Dev, Profile.Unified, "System.Core", "Release")]
+		[TestCase (Target.Dev, Profile.Unified, "dont link", "Release64")]
+		[TestCase (Target.Dev, Profile.Unified, "link all", "Release64")]
+		[TestCase (Target.Dev, Profile.Unified, "link sdk", "Release64")]
+		[TestCase (Target.Dev, Profile.Unified, "monotouch-test", "Release64")]
+		[TestCase (Target.Dev, Profile.Unified, "mscorlib", "Release64")]
+		[TestCase (Target.Dev, Profile.Unified, "System.Core", "Release64")]
 		public void BuildTestProject (Target target, Profile profile, string testname, string configuration)
 		{
 			var subdir = string.Empty;


### PR DESCRIPTION
In 9d4be4c we started building fat applications when building for device in
our test projects. That causes the BuildTestProject to take twice as long,
thus hitting a 5 min timeout value, causing the test to fail.

So change the test to the previous behavior: we were only building test
projects for ARM64 previously, so do that.