### PR TITLE
Fix install-system when current master is installed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,12 @@ endif
 endif
 
 install-system: install-system-ios install-system-mac
+	@# Clean up some old files
+	$(Q) rm -Rf /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/iOS
+	$(Q) rm -Rf /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Xamarin.ObjcBinding.CSharp.targets
+	$(Q) rm -Rf /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Xamarin.Common.CSharp.targets
+	$(Q) rm -Rf /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Xamarin.ObjcBinding.Tasks.dll
+	$(Q) rm -Rf /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac
 	$(Q) $(MAKE) install-symlinks MAC_DESTDIR=/ MAC_INSTALL_VERSION=Current IOS_DESTDIR=/ IOS_INSTALL_VERSION=Current -C msbuild V=$(V)
 ifdef ENABLE_XAMARIN
 	$(Q) $(MAKE) install-symlinks MAC_DESTDIR=/ MAC_INSTALL_VERSION=Current IOS_DESTDIR=/ IOS_INSTALL_VERSION=Current -C $(MACCORE_PATH) V=$(V)


### PR DESCRIPTION
In master's c4b5fa5f we changed how the symlinks in
/Library/Frameworks/Mono.framework/External/xbuild point to the current XI,
which causes problems if master is currently installed into the system, and
then someone runs `install-system` on branch without that change (instead of
installing properly into /Library/Frameworks/Mono.framework/External/xbuild,
`install-system` would modify the files directly in the master checkout's
`_ios-build` directory).

Which would probably work just fine, until some ran `install-system` in the
master checkout, and would now get the MSBuild files from the older branch,
causing obvious confusion and probable headache.