### PR TITLE
[src] Make sure to always set all variants of our conditional compilation symbols.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -101,6 +101,7 @@ $(IOS_BUILD_DIR)/$(1)/generator.exe: $$(GENERATOR_SOURCES) $(IOS_BUILD_DIR)/$(1)
 	$$(call Q_PROF_PMCS,ios/$(1)) PMCS_PROFILE=$(3) $$(IOS_PMCS) -out:$$@ -debug -unsafe \
 		$$(IOS_DEFINES) \
 		-r:$(IOS_BUILD_DIR)/$(1)/core.dll \
+		$$(GENERATOR_DEFINES)             \
 		$$(GENERATOR_SOURCES)
 
 # generated_sources
@@ -242,7 +243,7 @@ $(MONO_PATH)/mcs/class/lib/monotouch/compat/System.Net.Http.dll:    $(IOS_EXTRA_
 	$(Q) touch $@
 
 $(MONO_PATH)/mcs/class/lib/monotouch/reference/System.Net.Http.dll: $(IOS_EXTRA_SYSTEM_NET_HTTP_FILES) $(MONO_PATH)/mcs/class/lib/monotouch/System.Net.Http.dll $(IOS_BUILD_DIR)/reference/Xamarin.iOS.dll
-	$(call Q_PROF_MCS,ios/unified) $(MAKE) $(if $(V),,-s) -C $(MONO_PATH)/mcs/class/System.Net.Http PROFILE=monotouch LIBRARY_SUBDIR=reference EXTRA_LIB_MCS_FLAGS="-r:$(abspath $(IOS_BUILD_DIR)/reference/Xamarin.iOS.dll) $(IOS_EXTRA_SYSTEM_NET_HTTP_FILES) -D:XAMCORE_2_0 -D:XAMARIN_MODERN -D:SYSTEM_NET_HTTP -D:UNIFIED"
+	$(call Q_PROF_MCS,ios/unified) $(MAKE) $(if $(V),,-s) -C $(MONO_PATH)/mcs/class/System.Net.Http PROFILE=monotouch LIBRARY_SUBDIR=reference EXTRA_LIB_MCS_FLAGS="-r:$(abspath $(IOS_BUILD_DIR)/reference/Xamarin.iOS.dll) $(IOS_EXTRA_SYSTEM_NET_HTTP_FILES) -D:XAMCORE_2_0 -D:XAMARIN_MODERN -D:SYSTEM_NET_HTTP -D:UNIFIED -D:__UNIFIED__"
 	$(Q) touch $@
 
 $(MONO_PATH)/mcs/class/lib/monotouch/reference/System.Net.Http.dll.mdb: $(MONO_PATH)/mcs/class/lib/monotouch/reference/System.Net.Http.dll
@@ -395,7 +396,7 @@ MAC_WARNINGS_TO_FIX := $(MAC_WARNINGS_TO_FIX),4014
 
 MAC_COMMON_DEFINES = -define:NET_2_0,XAMARIN_MAC,MONOMAC
 MAC_BOOTSTRAP_DEFINES = $(MAC_COMMON_DEFINES),COREBUILD
-MAC_GENERATOR_DEFINES = $(MAC_COMMON_DEFINES)
+MAC_GENERATOR_DEFINES = $(MAC_COMMON_DEFINES) $(GENERATOR_DEFINES)
 
 SN_KEY = $(PRODUCT_KEY_PATH)
 
@@ -464,7 +465,7 @@ $(MAC_BUILD_DIR)/$(1)/core.dll: $(MAC_BUILD_DIR)/$(1)/pmcs $(MAC_CORE_SOURCES) f
 $(MAC_BUILD_DIR)/$(1)/_bmac.exe: $(MAC_BUILD_DIR)/$(1)/core.dll $(MAC_APIS) $(GENERATOR_SOURCES)
 	$$(call Q_PROF_PMCS,mac/$(1)) PMCS_PROFILE=$(6) $(MAC_BUILD_DIR)/$(1)/pmcs \
 		-out:$$@ -debug -unsafe \
-		$(MAC_COMMON_DEFINES) \
+		$(MAC_GENERATOR_DEFINES) \
 		-r:$$(@D)/core.dll \
 		$(7) \
 		$(GENERATOR_SOURCES)
@@ -503,10 +504,10 @@ $(MAC_BUILD_DIR)/$(1)/$(3): $(MAC_BUILD_DIR)/$(4)/generated-sources $(MAC_SOURCE
 endef
 
 $(eval $(call MAC_TARGETS_template,compat,--ns=MonoMac.ObjCRuntime,XamMac.dll,compat,-r:System.Drawing -lib:$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/4.5 $(MAC_CLASSIC_SOURCES),compat-mac))
-$(eval $(call MAC_TARGETS_template,mobile-32,--ns=ObjCRuntime -unified-mobile-profile,Xamarin.Mac.dll,mobile,-r:System.Net.Http -lib:$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/Xamarin.Mac $(MAC_CFNETWORK_SOURCES) $(MAC_MODERNHTTP_SOURCES) $(SHARED_SYSTEM_DRAWING_SOURCES) $(APPLETLS_DEFINES) -D:XAMARIN_MODERN -D:UNIFIED,mobile-32))
-$(eval $(call MAC_TARGETS_template,mobile-64,--ns=ObjCRuntime -unified-mobile-profile,Xamarin.Mac.dll,mobile,-r:System.Net.Http -lib:$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/Xamarin.Mac $(MAC_CFNETWORK_SOURCES) $(MAC_MODERNHTTP_SOURCES) $(SHARED_SYSTEM_DRAWING_SOURCES) $(APPLETLS_DEFINES) -D:XAMARIN_MODERN -D:UNIFIED,mobile-64))
-$(eval $(call MAC_TARGETS_template,full-32,--ns=ObjCRuntime -unified-full-profile,Xamarin.Mac.dll,full,-r:System.Net.Http -lib:$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/4.5 $(MAC_CFNETWORK_SOURCES) $(MAC_MODERNHTTP_SOURCES) -D:XAMARIN_MODERN -D:UNIFIED,full-32))
-$(eval $(call MAC_TARGETS_template,full-64,--ns=ObjCRuntime -unified-full-profile,Xamarin.Mac.dll,full,-r:System.Net.Http -lib:$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/4.5 $(MAC_CFNETWORK_SOURCES) $(MAC_MODERNHTTP_SOURCES) -D:XAMARIN_MODERN -D:UNIFIED,full-64))
+$(eval $(call MAC_TARGETS_template,mobile-32,--ns=ObjCRuntime -unified-mobile-profile,Xamarin.Mac.dll,mobile,-r:System.Net.Http -lib:$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/Xamarin.Mac $(MAC_CFNETWORK_SOURCES) $(MAC_MODERNHTTP_SOURCES) $(SHARED_SYSTEM_DRAWING_SOURCES) $(APPLETLS_DEFINES) -D:XAMARIN_MODERN -D:UNIFIED -D:__UNIFIED__,mobile-32))
+$(eval $(call MAC_TARGETS_template,mobile-64,--ns=ObjCRuntime -unified-mobile-profile,Xamarin.Mac.dll,mobile,-r:System.Net.Http -lib:$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/Xamarin.Mac $(MAC_CFNETWORK_SOURCES) $(MAC_MODERNHTTP_SOURCES) $(SHARED_SYSTEM_DRAWING_SOURCES) $(APPLETLS_DEFINES) -D:XAMARIN_MODERN -D:UNIFIED -D:__UNIFIED__,mobile-64))
+$(eval $(call MAC_TARGETS_template,full-32,--ns=ObjCRuntime -unified-full-profile,Xamarin.Mac.dll,full,-r:System.Net.Http -lib:$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/4.5 $(MAC_CFNETWORK_SOURCES) $(MAC_MODERNHTTP_SOURCES) -D:XAMARIN_MODERN -D:UNIFIED -D:__UNIFIED__,full-32))
+$(eval $(call MAC_TARGETS_template,full-64,--ns=ObjCRuntime -unified-full-profile,Xamarin.Mac.dll,full,-r:System.Net.Http -lib:$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/4.5 $(MAC_CFNETWORK_SOURCES) $(MAC_MODERNHTTP_SOURCES) -D:XAMARIN_MODERN -D:UNIFIED -D:__UNIFIED__,full-64))
 
 $(MAC_BUILD_DIR)/%-reference/Xamarin.Mac.dll: $(MAC_BUILD_DIR)/%-64/Xamarin.Mac.dll
 	@mkdir -p $(@D)
@@ -716,6 +717,7 @@ $(WATCH_BUILD_DIR)/watch/generator.exe: $(GENERATOR_SOURCES) $(WATCH_BUILD_DIR)/
 		-r:$(WATCH_BUILD_DIR)/watch/core.dll \
 		$(WATCH_DEFINES)                      \
 		$(GENERATOR_SOURCES)                  \
+		$(GENERATOR_DEFINES)                  \
 
 # generated_sources
 $(WATCH_BUILD_DIR)/watch/generated_sources: $(WATCH_BUILD_DIR)/watch/generator.exe $(WATCHOS_APIS)
@@ -775,7 +777,7 @@ WATCH_EXTRA_SYSTEM_NET_HTTP_FILES = \
 
 # build (into custom LIBRARY_SUBDIR)
 $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/reference/System.Net.Http.dll: $(WATCH_EXTRA_SYSTEM_NET_HTTP_FILES) $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/System.Net.Http.dll $(WATCH_BUILD_DIR)/reference/Xamarin.WatchOS.dll
-	$(call Q_PROF_MCS,watch) $(MAKE) $(if $(V),,-s) -C $(WATCH_MONO_PATH)/mcs/class/System.Net.Http PROFILE=monotouch_watch LIBRARY_SUBDIR=reference EXTRA_LIB_MCS_FLAGS="-r:$(abspath $(WATCH_BUILD_DIR)/reference/Xamarin.WatchOS.dll) $(WATCH_EXTRA_SYSTEM_NET_HTTP_FILES) -D:XAMCORE_2_0 -D:XAMCORE_3_0 -D:XAMARIN_MODERN -D:SYSTEM_NET_HTTP -D:UNIFIED"
+	$(call Q_PROF_MCS,watch) $(MAKE) $(if $(V),,-s) -C $(WATCH_MONO_PATH)/mcs/class/System.Net.Http PROFILE=monotouch_watch LIBRARY_SUBDIR=reference EXTRA_LIB_MCS_FLAGS="-r:$(abspath $(WATCH_BUILD_DIR)/reference/Xamarin.WatchOS.dll) $(WATCH_EXTRA_SYSTEM_NET_HTTP_FILES) -D:XAMCORE_2_0 -D:XAMCORE_3_0 -D:XAMARIN_MODERN -D:SYSTEM_NET_HTTP -D:UNIFIED -D:__UNIFIED__"
 	$(Q) touch $@
 
 $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/reference/System.Net.Http.dll.mdb: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/reference/System.Net.Http.dll
@@ -913,6 +915,7 @@ $(TVOS_BUILD_DIR)/tvos/generator.exe: $(GENERATOR_SOURCES) $(TVOS_BUILD_DIR)/tvo
 		-r:$(TVOS_BUILD_DIR)/tvos/core.dll \
 		$(TVOS_DEFINES)                      \
 		$(GENERATOR_SOURCES)                  \
+		$(GENERATOR_DEFINES)                  \
 
 # generated_sources
 $(TVOS_BUILD_DIR)/tvos/generated_sources: $(TVOS_BUILD_DIR)/tvos/generator.exe $(TVOS_APIS)
@@ -991,7 +994,7 @@ TVOS_EXTRA_SYSTEM_NET_HTTP_FILES = \
 
 # build (into custom LIBRARY_SUBDIR)
 $(MONO_PATH)/mcs/class/lib/monotouch_tv/reference/System.Net.Http.dll: $(TVOS_EXTRA_SYSTEM_NET_HTTP_FILES) $(MONO_PATH)/mcs/class/lib/monotouch_tv/System.Net.Http.dll $(TVOS_BUILD_DIR)/reference/Xamarin.TVOS.dll
-	$(call Q_PROF_MCS,tvos) $(MAKE) $(if $(V),,-s) -C $(MONO_PATH)/mcs/class/System.Net.Http PROFILE=monotouch_tv LIBRARY_SUBDIR=reference EXTRA_LIB_MCS_FLAGS="-r:$(abspath $(TVOS_BUILD_DIR)/reference/Xamarin.TVOS.dll) $(TVOS_EXTRA_SYSTEM_NET_HTTP_FILES) -D:XAMCORE_2_0 -D:XAMCORE_3_0 -D:XAMARIN_MODERN -D:SYSTEM_NET_HTTP -D:UNIFIED"
+	$(call Q_PROF_MCS,tvos) $(MAKE) $(if $(V),,-s) -C $(MONO_PATH)/mcs/class/System.Net.Http PROFILE=monotouch_tv LIBRARY_SUBDIR=reference EXTRA_LIB_MCS_FLAGS="-r:$(abspath $(TVOS_BUILD_DIR)/reference/Xamarin.TVOS.dll) $(TVOS_EXTRA_SYSTEM_NET_HTTP_FILES) -D:XAMCORE_2_0 -D:XAMCORE_3_0 -D:XAMARIN_MODERN -D:SYSTEM_NET_HTTP -D:UNIFIED -D:__UNIFIED__"
 	$(Q) touch $@
 
 $(MONO_PATH)/mcs/class/lib/monotouch_tv/reference/System.Net.Http.dll.mdb: $(MONO_PATH)/mcs/class/lib/monotouch_tv/reference/System.Net.Http.dll

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -7,6 +7,8 @@ GENERATOR_SOURCES =                                             \
 	$(TOP)/src/generator-filters.cs                    \
 	$(MONO_PATH)/mcs/class/Mono.Options/Mono.Options/Options.cs \
 
+GENERATOR_DEFINES = -d:GENERATOR -d:NET_4_0
+
 #
 # Xamarin.iOS (btouch)
 #
@@ -25,10 +27,10 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/%: %.in | $(IOS_DESTDIR)$(MONOTOUCH_PREFIX
 	$(Q) chmod +x $@
 
 $(IOS_BUILD_DIR)/btouch.exe: $(IOS_BUILD_DIR)/compat/monotouch.dll $(GENERATOR_SOURCES) Makefile.generator
-	$(call Q_PROF_PMCS,ios/compat) $(SYSTEM_MONO) --debug $(PMCS_EXE) -profile:"$(TOP)/src/pmcs-profiles/compat-ios" -compiler:$(IOS_CSC) -global-replace:"^XamCore=MonoTouch" -debug -define:NOTYPECONVERTER -define:IOS,NET_4_0             -out:$@ $(GENERATOR_SOURCES) -r:$<
+	$(call Q_PROF_PMCS,ios/compat) $(SYSTEM_MONO) --debug $(PMCS_EXE) -profile:"$(TOP)/src/pmcs-profiles/compat-ios" -compiler:$(IOS_CSC) -global-replace:"^XamCore=MonoTouch" -debug $(GENERATOR_DEFINES) -define:IOS,__IOS__             -out:$@ $(GENERATOR_SOURCES) -r:$<
 
 $(IOS_BUILD_DIR)/btouch-native.exe: $(IOS_BUILD_DIR)/reference/Xamarin.iOS.dll $(GENERATOR_SOURCES) Makefile.generator
-	$(call Q_PROF_PMCS,ios/native) $(SYSTEM_MONO) --debug $(PMCS_EXE) -profile:"$(TOP)/src/pmcs-profiles/native"     -compiler:$(IOS_CSC) -global-replace:"^XamCore.="         -debug -define:NOTYPECONVERTER -define:IOS,NET_4_0,XAMCORE_2_0 -out:$@ $(GENERATOR_SOURCES) -r:$<
+	$(call Q_PROF_PMCS,ios/native) $(SYSTEM_MONO) --debug $(PMCS_EXE) -profile:"$(TOP)/src/pmcs-profiles/native"     -compiler:$(IOS_CSC) -global-replace:"^XamCore.="         -debug $(GENERATOR_DEFINES) -define:IOS,__IOS__,XAMCORE_2_0,__UNIFIED__ -out:$@ $(GENERATOR_SOURCES) -r:$<
 
 $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/btouch/%.exe: $(IOS_BUILD_DIR)/%.exe | $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/btouch
 	$(Q) install -m 0755 $< $@
@@ -50,7 +52,7 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/bwatch: Makefile.generator
 	$(Q) chmod +x $@
 
 $(WATCH_BUILD_DIR)/bwatch.exe: $(WATCH_BUILD_DIR)/watch-32/Xamarin.WatchOS.dll $(GENERATOR_SOURCES) Makefile.generator
-	$(call Q_PROF_PMCS,watch) $(SYSTEM_MONO) --debug $(PMCS_EXE) -profile:"$(TOP)/src/pmcs-profiles/watch" -compiler:$(SYSTEM_MCS) -nostdlib -r:mscorlib -lib:$(WATCH_LIBDIR)/repl -global-replace:"^XamCore.=" -debug -define:NOTYPECONVERTER -define:NET_4_0,XAMCORE_2_0,XAMCORE_3_0 -d:WATCH -d:NO_SYSTEM_DRAWING -out:$@ $(GENERATOR_SOURCES) -r:$<
+	$(call Q_PROF_PMCS,watch) $(SYSTEM_MONO) --debug $(PMCS_EXE) -profile:"$(TOP)/src/pmcs-profiles/watch" -compiler:$(SYSTEM_MCS) -nostdlib -r:mscorlib -lib:$(WATCH_LIBDIR)/repl -global-replace:"^XamCore.=" -debug $(GENERATOR_DEFINES) -define:XAMCORE_2_0,XAMCORE_3_0,__UNIFIED__ -d:WATCH -d:__WATCHOS__ -d:NO_SYSTEM_DRAWING -out:$@ $(GENERATOR_SOURCES) -r:$<
 
 $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bwatch/%.exe: $(WATCH_BUILD_DIR)/%.exe | $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bwatch
 	$(Q) install -m 0755 $< $@
@@ -72,7 +74,7 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/btv: Makefile.generator
 	$(Q) chmod +x $@
 
 $(TVOS_BUILD_DIR)/btv.exe: $(TVOS_BUILD_DIR)/tvos-64/Xamarin.TVOS.dll $(GENERATOR_SOURCES) Makefile.generator
-	$(call Q_PROF_PMCS,tvos) $(SYSTEM_MONO) --debug $(PMCS_EXE) -profile:"$(TOP)/src/pmcs-profiles/tvos" -compiler:$(SYSTEM_MCS) -nostdlib -r:mscorlib.dll -lib:$(TVOS_LIBDIR)/repl -global-replace:"^XamCore.=" -debug -define:NOTYPECONVERTER -define:NET_4_0,XAMCORE_2_0,XAMCORE_3_0 -d:TVOS -out:$@ $(GENERATOR_SOURCES) -r:$<
+	$(call Q_PROF_PMCS,tvos) $(SYSTEM_MONO) --debug $(PMCS_EXE) -profile:"$(TOP)/src/pmcs-profiles/tvos" -compiler:$(SYSTEM_MCS) -nostdlib -r:mscorlib.dll -lib:$(TVOS_LIBDIR)/repl -global-replace:"^XamCore.=" -debug $(GENERATOR_DEFINES) -define:XAMCORE_2_0,XAMCORE_3_0,__UNIFIED__ -d:TVOS -d:__TVOS__ -out:$@ $(GENERATOR_SOURCES) -r:$<
 
 $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/btv/%.exe: $(TVOS_BUILD_DIR)/%.exe | $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/btv
 	$(Q) install -m 0755 $< $@
@@ -92,10 +94,10 @@ MAC_TARGETS += \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bmac/bmac-compat.exe     \
 
 $(MAC_BUILD_DIR)/bmac-%.exe: $(MAC_BUILD_DIR)/%-32/Xamarin.Mac.dll $(GENERATOR_SOURCES) $(SN_KEY) Makefile.generator
-	$(call Q_PROF_PMCS,mac/full)   PMCS_PROFILE=$*         $(MAC_BUILD_DIR)/$*/pmcs     -out:$@ -debug -unsafe $(MAC_GENERATOR_DEFINES) -keyfile:$(SN_KEY) -r:$< $(GENERATOR_SOURCES)
+	$(call Q_PROF_PMCS,mac/full)   PMCS_PROFILE=$*         $(MAC_BUILD_DIR)/$*/pmcs     -out:$@ -debug $(GENERATOR_DEFINES) -unsafe $(MAC_GENERATOR_DEFINES) -keyfile:$(SN_KEY) -r:$< $(GENERATOR_SOURCES)
 
 $(MAC_BUILD_DIR)/bmac-compat.exe: $(MAC_BUILD_DIR)/compat/XamMac.dll $(GENERATOR_SOURCES) $(SN_KEY) Makefile.generator
-	$(call Q_PROF_PMCS,mac/compat) PMCS_PROFILE=compat-mac $(MAC_BUILD_DIR)/compat/pmcs -out:$@ -debug -unsafe $(MAC_GENERATOR_DEFINES) -keyfile:$(SN_KEY) -r:$< $(GENERATOR_SOURCES) -r:System.Drawing
+	$(call Q_PROF_PMCS,mac/compat) PMCS_PROFILE=compat-mac $(MAC_BUILD_DIR)/compat/pmcs -out:$@ -debug $(GENERATOR_DEFINES) -unsafe $(MAC_GENERATOR_DEFINES) -keyfile:$(SN_KEY) -r:$< $(GENERATOR_SOURCES) -r:System.Drawing
 
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/bmac: bmac | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin
 	$(Q) install -m 0755 $< $@

--- a/tools/pmcs/BuiltinProfiles.cs
+++ b/tools/pmcs/BuiltinProfiles.cs
@@ -80,6 +80,7 @@ namespace Xamarin.Pmcs.Profiles
 		protected XamCore2Common (ArchDefine arch)
 		{
 			CompilerOptions.Add ("-define:XAMCORE_2_0");
+			CompilerOptions.Add ("-define:__UNIFIED__");
 
 			if (arch != ArchDefine.None)
 				CompilerOptions.Add ("-define:" + arch.ToString ());


### PR DESCRIPTION
For Unified, set XAMCORE_2_0, UNIFIED and __UNIFIED__.

For Xamarin.iOS/tvOS/watchOS set both the normal and underscored versions
(IOS and __IOS__, TVOS and __TVOS__, and WATCHOS and __WATCHOS__).

The underscored versions are the public symbols we're setting in the
corresponding projects, so we should use those everywhere to simplify our
code, but due to historical reasons we're still using the other variants in
existing code.

Making sure all the possible variants are set for all projects, makes it
possible to only use the underscored versions in new code.

Also define `GENERATOR` for the generator, so that we can easily share
files between the generator and platform assemblies.