### PR TITLE
[XM] Fix crash when closing new NSWindow() due to ReleasedWhenClosed

### DIFF
--- a/src/AppKit/NSWindow.cs
+++ b/src/AppKit/NSWindow.cs
@@ -24,10 +24,15 @@ using System;
 using XamCore.CoreFoundation;
 using XamCore.Foundation;
 using XamCore.ObjCRuntime;
+using XamCore.CoreGraphics;
 
 namespace XamCore.AppKit {
 
 	public partial class NSWindow {
+
+		public static bool ForceReleasedWhenClosed = true;
+
+		static IntPtr selInit = Selector.GetHandle ("init");
 		static IntPtr selInitWithWindowRef = Selector.GetHandle ("initWithWindowRef:");
 
 		// Do not actually export because NSObjectFlag is not exportable.
@@ -41,6 +46,33 @@ namespace XamCore.AppKit {
 			} else {
 				Handle = XamCore.ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper (this.SuperHandle, selInitWithWindowRef);
 			}
+			if (ForceReleasedWhenClosed)
+				ReleasedWhenClosed = false;
+		}
+
+		public NSWindow ()  : base (NSObjectFlag.Empty)
+		{
+			if (IsDirectBinding) {
+				Handle = XamCore.ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, selInit);
+			} else {
+				Handle = XamCore.ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper (this.SuperHandle, selInit);
+			}
+			if (ForceReleasedWhenClosed)
+				ReleasedWhenClosed = false;
+		}
+
+		public NSWindow (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation)  : base (NSObjectFlag.Empty)
+		{
+			Handle = _Init (contentRect, aStyle, bufferingType, deferCreation);
+			if (ForceReleasedWhenClosed)
+				ReleasedWhenClosed = false;
+		}
+
+		public NSWindow (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation, NSScreen screen)  : base (NSObjectFlag.Empty)
+		{
+			Handle = _Init (contentRect, aStyle, bufferingType, deferCreation, screen);
+			if (ForceReleasedWhenClosed)
+				ReleasedWhenClosed = false;
 		}
 
 		static public NSWindow FromWindowRef (IntPtr windowRef)

--- a/src/AppKit/NSWindow.cs
+++ b/src/AppKit/NSWindow.cs
@@ -24,7 +24,6 @@ using System;
 using XamCore.CoreFoundation;
 using XamCore.Foundation;
 using XamCore.ObjCRuntime;
-using XamCore.CoreGraphics;
 
 namespace XamCore.AppKit {
 

--- a/src/AppKit/NSWindow.cs
+++ b/src/AppKit/NSWindow.cs
@@ -30,7 +30,7 @@ namespace XamCore.AppKit {
 
 	public partial class NSWindow {
 
-		public static bool ForceReleasedWhenClosed = true;
+		public static bool DisableReleasedWhenClosedInConstructor;
 
 		static IntPtr selInit = Selector.GetHandle ("init");
 		static IntPtr selInitWithWindowRef = Selector.GetHandle ("initWithWindowRef:");
@@ -46,32 +46,7 @@ namespace XamCore.AppKit {
 			} else {
 				Handle = XamCore.ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper (this.SuperHandle, selInitWithWindowRef);
 			}
-			if (ForceReleasedWhenClosed)
-				ReleasedWhenClosed = false;
-		}
-
-		public NSWindow ()  : base (NSObjectFlag.Empty)
-		{
-			if (IsDirectBinding) {
-				Handle = XamCore.ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, selInit);
-			} else {
-				Handle = XamCore.ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper (this.SuperHandle, selInit);
-			}
-			if (ForceReleasedWhenClosed)
-				ReleasedWhenClosed = false;
-		}
-
-		public NSWindow (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation)  : base (NSObjectFlag.Empty)
-		{
-			Handle = _Init (contentRect, aStyle, bufferingType, deferCreation);
-			if (ForceReleasedWhenClosed)
-				ReleasedWhenClosed = false;
-		}
-
-		public NSWindow (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation, NSScreen screen)  : base (NSObjectFlag.Empty)
-		{
-			Handle = _Init (contentRect, aStyle, bufferingType, deferCreation, screen);
-			if (ForceReleasedWhenClosed)
+			if (!DisableReleasedWhenClosedInConstructor)
 				ReleasedWhenClosed = false;
 		}
 

--- a/src/AppKit/NSWindow.cs
+++ b/src/AppKit/NSWindow.cs
@@ -32,7 +32,6 @@ namespace XamCore.AppKit {
 
 		public static bool DisableReleasedWhenClosedInConstructor;
 
-		static IntPtr selInit = Selector.GetHandle ("init");
 		static IntPtr selInitWithWindowRef = Selector.GetHandle ("initWithWindowRef:");
 
 		// Do not actually export because NSObjectFlag is not exportable.

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -18380,7 +18380,7 @@ namespace XamCore.AppKit {
 		[Export ("contentRectForFrameRect:")]
 		CGRect ContentRectFor (CGRect frameRect);
 
-		[Export ("init:")]
+		[Export ("init")]
 		[PostSnippet ("if (!DisableReleasedWhenClosedInConstructor) { ReleasedWhenClosed = false; }")]
 		IntPtr Constructor ();
 

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -18357,6 +18357,7 @@ namespace XamCore.AppKit {
 	delegate void NSWindowTrackEventsMatchingCompletionHandler (NSEvent evt, ref bool stop);
 	
 	[BaseType (typeof (NSResponder), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSWindowDelegate)})]
+	[DisableDefaultCtor] // Handled in NSWindow.cs
 	partial interface NSWindow : NSAnimatablePropertyContainer, NSUserInterfaceItemIdentification, NSAppearanceCustomization, NSAccessibilityElementProtocol, NSAccessibility {
 		[Static, Export ("frameRectForContentRect:styleMask:")]
 		CGRect FrameRectFor (CGRect contectRect, NSWindowStyle styleMask);
@@ -18378,12 +18379,14 @@ namespace XamCore.AppKit {
 	
 		[Export ("contentRectForFrameRect:")]
 		CGRect ContentRectFor (CGRect frameRect);
-	
+
+		[Internal]
 		[Export ("initWithContentRect:styleMask:backing:defer:")]
-		IntPtr Constructor (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation);
+		IntPtr _Init (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation);
 	
+		[Internal]
 		[Export ("initWithContentRect:styleMask:backing:defer:screen:")]
-		IntPtr Constructor (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation, NSScreen  screen);
+		IntPtr _Init (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation, NSScreen  screen);
 	
 		[Export ("title")]
 		string Title  { get; set; }

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -18357,7 +18357,7 @@ namespace XamCore.AppKit {
 	delegate void NSWindowTrackEventsMatchingCompletionHandler (NSEvent evt, ref bool stop);
 	
 	[BaseType (typeof (NSResponder), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSWindowDelegate)})]
-	[DisableDefaultCtor] // Handled in NSWindow.cs
+	[DisableDefaultCtor]
 	partial interface NSWindow : NSAnimatablePropertyContainer, NSUserInterfaceItemIdentification, NSAppearanceCustomization, NSAccessibilityElementProtocol, NSAccessibility {
 		[Static, Export ("frameRectForContentRect:styleMask:")]
 		CGRect FrameRectFor (CGRect contectRect, NSWindowStyle styleMask);
@@ -18380,13 +18380,17 @@ namespace XamCore.AppKit {
 		[Export ("contentRectForFrameRect:")]
 		CGRect ContentRectFor (CGRect frameRect);
 
-		[Internal]
+		[Export ("init:")]
+		[PostSnippet ("if (!DisableReleasedWhenClosedInConstructor) { ReleasedWhenClosed = false; }")]
+		IntPtr Constructor ();
+
 		[Export ("initWithContentRect:styleMask:backing:defer:")]
-		IntPtr _Init (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation);
+		[PostSnippet ("if (!DisableReleasedWhenClosedInConstructor) { ReleasedWhenClosed = false; }")]
+		IntPtr Constructor (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation);
 	
-		[Internal]
 		[Export ("initWithContentRect:styleMask:backing:defer:screen:")]
-		IntPtr _Init (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation, NSScreen  screen);
+		[PostSnippet ("if (!DisableReleasedWhenClosedInConstructor) { ReleasedWhenClosed = false; }")]
+		IntPtr Constructor (CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation, NSScreen  screen);
 	
 		[Export ("title")]
 		string Title  { get; set; }


### PR DESCRIPTION
- https://bugzilla.xamarin.com/show_bug.cgi?id=45298
- Cocoa defaults new NSWindow () to have ReleasedWhenClosed = True but
  this is incompatible with our memory management.
- By forcing it to be false during constructors, we prevent this crash.
- Since this is techincally a behavior change, I added a static to change
  the behavior back.