### PR TITLE
[foundation] Add missing helper properties on NSMetadataItem. Fixes #34248

### DIFF
--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -1114,11 +1114,6 @@ namespace XamCore.Foundation  {
 		Contains, Same, Other
 	}
 
-	public enum NSItemDownloadingStatus {
-		Unknown = -1,
-		Current, Downloaded, NotDownloaded
-	}
-
 	// NSTextCheckingResult.h:typedef NS_OPTIONS(uint64_t, NSTextCheckingType)
 	public enum NSTextCheckingType : ulong {
 		Orthography   = 1 << 0,

--- a/src/Foundation/Enums.cs
+++ b/src/Foundation/Enums.cs
@@ -49,4 +49,20 @@ namespace XamCore.Foundation {
 		[Field (null)]
 		Other = 1000
 	}
+
+	[Mac (10,9)]
+	[iOS (7,0)]
+	public enum NSItemDownloadingStatus {
+		[Field (null)]
+		Unknown = -1,
+
+		[Field ("NSMetadataUbiquitousItemDownloadingStatusCurrent")]
+		Current,
+
+		[Field ("NSMetadataUbiquitousItemDownloadingStatusDownloaded")]
+		Downloaded,
+
+		[Field ("NSMetadataUbiquitousItemDownloadingStatusNotDownloaded")]
+		NotDownloaded,
+	}
 }

--- a/src/Foundation/NSMetadataItem.cs
+++ b/src/Foundation/NSMetadataItem.cs
@@ -1,130 +1,180 @@
 //
 // Convenience methods for NSMetadataItem
 //
-// Copyright 2014 Xamarin Inc
+// Copyright 2014, 2016 Xamarin Inc
 //
 // Author:
 //   Miguel de Icaza
 //
 using System;
+using XamCore.ObjCRuntime;
 
 namespace XamCore.Foundation {
 	public partial class NSMetadataItem {
+
+		bool GetBool (NSString key)
+		{
+			var n = Runtime.GetNSObject<NSNumber> (GetHandle (key));
+			return n == null ? false : n.BoolValue;
+		}
+
+		double GetDouble (NSString key)
+		{
+			var n = Runtime.GetNSObject<NSNumber> (GetHandle (key));
+			return n == null ? 0 : n.DoubleValue;
+		}
+
+		// same order as NSMetadataAttributes.h
+
 		public NSString FileSystemName {
 			get {
-				return ValueForAttribute (NSMetadataQuery.ItemFSNameKey) as NSString;
+				return Runtime.GetNSObject<NSString> (GetHandle (NSMetadataQuery.ItemFSNameKey));
 			}
 		}
+
 		public NSString DisplayName {
 			get {
-				return ValueForAttribute (NSMetadataQuery.ItemDisplayNameKey) as NSString;
+				return Runtime.GetNSObject<NSString> (GetHandle (NSMetadataQuery.ItemDisplayNameKey));
 			}
 		}
 
 		public NSUrl Url {
 			get {
-				return ValueForAttribute (NSMetadataQuery.ItemURLKey) as NSUrl;
+				return Runtime.GetNSObject<NSUrl> (GetHandle (NSMetadataQuery.ItemURLKey));
 			}
 		}
 
 		public NSString Path {
 			get {
-				return ValueForAttribute (NSMetadataQuery.ItemPathKey) as NSString;
+				return Runtime.GetNSObject<NSString> (GetHandle (NSMetadataQuery.ItemPathKey));
 			}
 		}
 
 		public NSNumber FileSystemSize {
 			get {
-				return ValueForAttribute (NSMetadataQuery.ItemFSSizeKey) as NSNumber;
+				return Runtime.GetNSObject<NSNumber> (GetHandle (NSMetadataQuery.ItemFSSizeKey));
 			}
 		}
 
 		public NSDate FileSystemCreationDate {
 			get {
-				return ValueForAttribute (NSMetadataQuery.ItemFSCreationDateKey) as NSDate;
-			}			
+				return Runtime.GetNSObject<NSDate> (GetHandle (NSMetadataQuery.ItemFSCreationDateKey));
+			}
 		}
 
 		public NSDate FileSystemContentChangeDate {
 			get {
-				return ValueForAttribute (NSMetadataQuery.ItemFSContentChangeDateKey) as NSDate;
+				return Runtime.GetNSObject<NSDate> (GetHandle (NSMetadataQuery.ItemFSContentChangeDateKey));
 			}
 		}
+
+		[iOS (8,0)][Mac (10,9)]
+		public NSString ContentType {
+			get {
+				return Runtime.GetNSObject<NSString> (GetHandle (NSMetadataQuery.ContentTypeKey));
+			}
+		}
+
+		[iOS (8,0)][Mac (10,9)]
+		public NSString[] ContentTypeTree {
+			get {
+				using (var a = Runtime.GetNSObject<NSArray> (GetHandle (NSMetadataQuery.ContentTypeTreeKey)))
+					return NSArray.FromArray<NSString> (a);
+			}
+		}
+
 		public bool IsUbiquitous {
 			get {
-				var b =  ValueForAttribute (NSMetadataQuery.ItemIsUbiquitousKey) as NSNumber;
-				return b != null && b.Int32Value != 0;
+				return GetBool (NSMetadataQuery.ItemIsUbiquitousKey);
 			}
 		}
 
 		public bool UbiquitousItemHasUnresolvedConflicts {
 			get {
-				var b =  ValueForAttribute (NSMetadataQuery.UbiquitousItemHasUnresolvedConflictsKey) as NSNumber;
-				return b != null && b.Int32Value != 0;
+				return GetBool (NSMetadataQuery.UbiquitousItemHasUnresolvedConflictsKey);
 			}
 		}
-		
+
+		[iOS (7,0)][Mac (10,9)]
+#if XAMCORE_4_0
+		public NSItemDownloadingStatus UbiquitousItemDownloadingStatus {
+#else
+		public NSItemDownloadingStatus DownloadingStatus {
+#endif
+			get {
+				return NSItemDownloadingStatusExtensions.GetValue (Runtime.GetNSObject<NSString> (GetHandle (NSMetadataQuery.UbiquitousItemDownloadingStatusKey)));
+			}
+		}
+
 		public bool UbiquitousItemIsDownloading {
 			get {
-				var b =  ValueForAttribute (NSMetadataQuery.UbiquitousItemIsDownloadingKey) as NSNumber;
-				return b != null && b.Int32Value != 0;
+				return GetBool (NSMetadataQuery.UbiquitousItemIsDownloadingKey);
 			}
 		}
 
 		public bool UbiquitousItemIsUploaded {
 			get {
-				var b =  ValueForAttribute (NSMetadataQuery.UbiquitousItemIsUploadedKey) as NSNumber;
-				return b != null && b.Int32Value != 0;
+				return GetBool (NSMetadataQuery.UbiquitousItemIsUploadedKey);
 			}
 		}
 
 		public bool UbiquitousItemIsUploading {
 			get {
-				var b =  ValueForAttribute (NSMetadataQuery.UbiquitousItemIsUploadingKey) as NSNumber;
-				return b != null && b.Int32Value != 0;
+				return GetBool (NSMetadataQuery.UbiquitousItemIsUploadingKey);
 			}
 		}
 
 		public double UbiquitousItemPercentDownloaded {
 			get {
-				var b =  ValueForAttribute (NSMetadataQuery.UbiquitousItemPercentDownloadedKey) as NSNumber;
-				if (b == null)
-					return 0;
-				return b.DoubleValue;
+				return GetDouble (NSMetadataQuery.UbiquitousItemPercentDownloadedKey);
 			}
 		}
 
 		public double UbiquitousItemPercentUploaded {
 			get {
-				var b =  ValueForAttribute (NSMetadataQuery.UbiquitousItemPercentUploadedKey) as NSNumber;
-				if (b == null)
-					return 0;
-				return b.DoubleValue;
+				return GetDouble (NSMetadataQuery.UbiquitousItemPercentUploadedKey);
 			}
 		}
 
-		public NSItemDownloadingStatus DownloadingStatus {
-			get {
-				var b = ValueForAttribute (NSMetadataQuery.UbiquitousItemDownloadingStatusKey) as NSString;
-				if (b == _StatusDownloaded)
-					return NSItemDownloadingStatus.Downloaded;
-				if (b == _StatusCurrent)
-					return NSItemDownloadingStatus.Current;
-				if (b == _NotDownloaded)
-					return NSItemDownloadingStatus.NotDownloaded;
-				return NSItemDownloadingStatus.Unknown;
-			}
-		}
-
+		[iOS (7,0)][Mac (10,9)]
 		public NSError UbiquitousItemDownloadingError {
 			get {
-				return ValueForAttribute (NSMetadataQuery.UbiquitousItemDownloadingErrorKey) as NSError;
+				return Runtime.GetNSObject<NSError> (GetHandle (NSMetadataQuery.UbiquitousItemDownloadingErrorKey));
 			}
 		}
-		
+
+		[iOS (7,0)][Mac (10,9)]
 		public NSError UbiquitousItemUploadingError {
 			get {
-				return ValueForAttribute (NSMetadataQuery.UbiquitousItemUploadingErrorKey) as NSError;
+				return Runtime.GetNSObject<NSError> (GetHandle (NSMetadataQuery.UbiquitousItemUploadingErrorKey));
+			}
+		}
+
+		[iOS (8,0)][Mac (10,10)]
+		public bool UbiquitousItemDownloadRequested {
+			get {
+				return GetBool (NSMetadataQuery.UbiquitousItemDownloadRequestedKey);
+			}
+		}
+
+		[iOS (8,0)][Mac (10,10)]
+		public bool UbiquitousItemIsExternalDocument {
+			get {
+				return GetBool (NSMetadataQuery.UbiquitousItemIsExternalDocumentKey);
+			}
+		}
+
+		[iOS (8,0)][Mac (10,9)]
+		public NSString UbiquitousItemContainerDisplayName {
+			get {
+				return Runtime.GetNSObject<NSString> (GetHandle (NSMetadataQuery.UbiquitousItemContainerDisplayNameKey));
+			}
+		}
+
+		[iOS (8,0)][Mac (10,9)]
+		public NSUrl UbiquitousItemUrlInLocalContainer {
+			get {
+				return Runtime.GetNSObject<NSUrl> (GetHandle (NSMetadataQuery.UbiquitousItemURLInLocalContainerKey));
 			}
 		}
 	}

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -2501,6 +2501,7 @@ namespace XamCore.Foundation
 		[Field ("NSMetadataUbiquitousItemHasUnresolvedConflictsKey")]
 		NSString UbiquitousItemHasUnresolvedConflictsKey { get; }
 
+		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9, Message="Use UbiquitousItemDownloadingStatusKey")]
 		[Field ("NSMetadataUbiquitousItemIsDownloadedKey")]
 		NSString UbiquitousItemIsDownloadedKey { get; }
 
@@ -2598,31 +2599,29 @@ namespace XamCore.Foundation
 
 	[Since (5,0)]
 	[BaseType (typeof (NSObject))]
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // points to nothing so access properties crash the apps
+#endif
 	interface NSMetadataItem {
+
+		[NoiOS][NoTV][NoWatch]
+		[Mac (10,9)]
+		[DesignatedInitializer]
+		[Export ("initWithURL:")]
+		IntPtr Constructor (NSUrl url);
+
 		[Export ("valueForAttribute:")]
 		NSObject ValueForAttribute (string key);
 
+		[Sealed]
+		[Internal]
+		[Export ("valueForAttribute:")]
+		IntPtr GetHandle (NSString key);
 		[Export ("valuesForAttributes:")]
 		NSDictionary ValuesForAttributes (NSArray keys);
 
 		[Export ("attributes")]
 		NSObject [] Attributes { get; }
-
-		[Mac(10,9),iOS(7,0)]
-		[Internal]
-		[Field ("NSMetadataUbiquitousItemDownloadingStatusCurrent")]
-		NSString _StatusCurrent { get; }
-
-		[Mac(10,9),iOS(7,0)]
-		[Internal]
-		[Field ("NSMetadataUbiquitousItemDownloadingStatusDownloaded")]
-		NSString _StatusDownloaded { get; }
-
-		[Mac(10,9),iOS(7,0)]
-		[Internal]
-		[Field ("NSMetadataUbiquitousItemDownloadingStatusNotDownloaded")]
-		NSString _NotDownloaded { get; }
-		
 	}
 
 	[Since (5,0)]

--- a/tests/apitest/apitest.csproj
+++ b/tests/apitest/apitest.csproj
@@ -148,6 +148,10 @@
     <Compile Include="..\common\mac\MacTestMain.cs">
       <Link>shared\MacTestMain.cs</Link>
     </Compile>
+    <Compile Include="src\Foundation\NSMetadataItem.cs" />
+    <Compile Include="..\common\TestRuntime.cs">
+      <Link>shared\TestRuntime.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/apitest/src/Foundation/NSMetadataItem.cs
+++ b/tests/apitest/src/Foundation/NSMetadataItem.cs
@@ -1,0 +1,52 @@
+﻿#if !XAMCORE_2_0
+using MonoMac.Foundation;
+#else
+using AppKit;
+using Foundation;
+#endif
+using NUnit.Framework;
+
+namespace Xamarin.Mac.Tests {
+
+	[TestFixture]
+	public class NSMetadataItemTest {
+		
+		[Test]
+		public void CtorUrl ()
+		{
+			var url = NSRunningApplication.CurrentApplication.BundleUrl;
+			using (var mi = new NSMetadataItem (url)) {
+				Assert.That (mi.DisplayName.ToString (), Is.EqualTo ("apitest"), "DisplayName");
+				Assert.NotNull (mi.FileSystemContentChangeDate, "FileSystemContentChangeDate");
+				Assert.NotNull (mi.FileSystemCreationDate, "FileSystemCreationDate");
+				Assert.That (mi.FileSystemName.ToString (), Is.EqualTo ("apitest.app"), "FileSystemName");
+				Assert.That (mi.FileSystemSize.UInt64Value, Is.GreaterThan (0), "FileSystemSize");
+				Assert.False (mi.IsUbiquitous, "IsUbiquitous");
+				Assert.That (mi.Path.ToString (), Is.StringEnding ("/apitest.app"), "Path");
+				Assert.False (mi.UbiquitousItemHasUnresolvedConflicts, "UbiquitousItemHasUnresolvedConflicts");
+				Assert.False (mi.UbiquitousItemIsDownloading, "UbiquitousItemIsDownloading");
+				Assert.False (mi.UbiquitousItemIsUploaded, "UbiquitousItemIsUploaded");
+				Assert.False (mi.UbiquitousItemIsUploading, "UbiquitousItemIsUploading");
+				Assert.That (mi.UbiquitousItemPercentDownloaded, Is.EqualTo (0), "UbiquitousItemPercentDownloaded");
+				Assert.That (mi.UbiquitousItemPercentUploaded, Is.EqualTo (0), "UbiquitousItemPercentUploaded");
+				Assert.Null (mi.Url, "Url");
+
+				// 10.9
+				if (TestRuntime.CheckXcodeVersion (5,1)) {
+					Assert.That (mi.ContentType.ToString (), Is.EqualTo ("com.apple.application-bundle"), "ContentType");
+					Assert.That (mi.ContentTypeTree.Length, Is.GreaterThan (1), "ContentTypeTree");
+					Assert.That (mi.DownloadingStatus, Is.EqualTo (NSItemDownloadingStatus.Unknown), "DownloadingStatus");
+					Assert.Null (mi.UbiquitousItemDownloadingError, "UbiquitousItemDownloadingError");
+					Assert.Null (mi.UbiquitousItemUploadingError, "UbiquitousItemUploadingError");
+					Assert.Null (mi.UbiquitousItemContainerDisplayName, "UbiquitousItemContainerDisplayName");
+					Assert.Null (mi.UbiquitousItemUrlInLocalContainer, "UbiquitousItemUrlInLocalContainer");
+				}
+				// 10.10
+				if (TestRuntime.CheckXcodeVersion (6,0)) {
+					Assert.False (mi.UbiquitousItemDownloadRequested, "UbiquitousItemDownloadRequested");
+					Assert.False (mi.UbiquitousItemIsExternalDocument, "UbiquitousItemIsExternalDocument");
+				}
+			}
+		}
+	}
+}

--- a/tests/apitest/src/Foundation/NSMetadataItem.cs
+++ b/tests/apitest/src/Foundation/NSMetadataItem.cs
@@ -21,7 +21,9 @@ namespace Xamarin.Mac.Tests {
 				Assert.NotNull (mi.FileSystemContentChangeDate, "FileSystemContentChangeDate");
 				Assert.NotNull (mi.FileSystemCreationDate, "FileSystemCreationDate");
 				Assert.That (mi.FileSystemName.ToString (), Is.EqualTo ("apitest.app"), "FileSystemName");
+#if XAMCORE_2_0
 				Assert.That (mi.FileSystemSize.UInt64Value, Is.GreaterThan (0), "FileSystemSize");
+#endif
 				Assert.False (mi.IsUbiquitous, "IsUbiquitous");
 				Assert.That (mi.Path.ToString (), Is.StringEnding ("/apitest.app"), "Path");
 				Assert.False (mi.UbiquitousItemHasUnresolvedConflicts, "UbiquitousItemHasUnresolvedConflicts");

--- a/tests/apitest/src/Foundation/NSMetadataItem.cs
+++ b/tests/apitest/src/Foundation/NSMetadataItem.cs
@@ -1,4 +1,5 @@
 ﻿#if !XAMCORE_2_0
+using MonoMac.AppKit;
 using MonoMac.Foundation;
 #else
 using AppKit;


### PR DESCRIPTION
* Added missing helper properties for iOS
* Made NSItemDownloadingStatus a "smart enum", i.e. field aware;
* Disable default .ctor for XAMCORE_4_0, such instances are unusable;
* Added `initWithURL:` for macOS [2] as it made it easier to test the
  changes since macOS it allows creating instances of `NSMetadataItem`
  from an URL.

references:
[1] https://bugzilla.xamarin.com/show_bug.cgi?id=34248
[2] osx.unclassified:!missing-selector! NSMetadataItem::initWithURL: not bound