### PR TITLE
Allow using LinkWith attribute without a native library.

### DIFF
--- a/docs/website/binding_types_reference_guide.md
+++ b/docs/website/binding_types_reference_guide.md
@@ -2122,6 +2122,7 @@ public enum LinkTarget {
 
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple=true)]
 public class LinkWithAttribute : Attribute {
+    public LinkWithAttribute ();
     public LinkWithAttribute (string libraryName);
     public LinkWithAttribute (string libraryName, LinkTarget target);
     public LinkWithAttribute (string libraryName, LinkTarget target, string linkerFlags);
@@ -2149,6 +2150,13 @@ into the resulting assembly, allowing users to ship a single DLL that contains
 both the unmanaged dependencies as well as the command line flags necessary to
 properly consume the library from Xamarin.iOS.
 
+It' s also possible to not provide a `libraryName`, in which case the
+`LinkWith` attribute can be used to only specify additional linker flags:
+
+ ``` csharp
+[assembly: LinkWith (LinkerFlags = "-lsqlite3")]
+ ```
+
  <a name="LinkWithAttribute_Constructors" class="injected"></a>
 
 
@@ -2163,6 +2171,9 @@ Note that the LinkTarget argument is inferred by Xamarin.iOS and does not need t
 Examples:
 
 ```
+// Specify additional linker:
+[assembly: LinkWith (LinkerFlags = "-sqlite3")]
+
 // Specify library name for the constructor:
 [assembly: LinkWith ("libDemo.a");
 

--- a/src/ObjCRuntime/LinkWithAttribute.cs
+++ b/src/ObjCRuntime/LinkWithAttribute.cs
@@ -40,6 +40,13 @@ namespace XamCore.ObjCRuntime {
 		x86_64 = Simulator64
 	}
 	
+	public enum DlsymOption
+	{
+		Default,
+		Required,
+		Disabled,
+	}
+
 	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple=true)]
 #if XAMCORE_2_0
 	sealed
@@ -61,6 +68,10 @@ namespace XamCore.ObjCRuntime {
 		public LinkWithAttribute (string libraryName)
 		{
 			LibraryName = libraryName;
+		}
+
+		public LinkWithAttribute ()
+		{
 		}
 		
 		public bool ForceLoad {
@@ -96,6 +107,10 @@ namespace XamCore.ObjCRuntime {
 		}
 
 		public bool SmartLink {
+			get; set;
+		}
+
+		public DlsymOption Dlsym {
 			get; set;
 		}
 	}

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -134,6 +134,7 @@ namespace Introspection
 			"dlerror",
 			"Dlfcn",
 			"dlopen",
+			"Dlsym",
 			"dlsym",
 			"Dng",
 			"Dns",

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1990,6 +1990,31 @@ class Test {
 			}
 		}
 
+		[Test]
+		public void LinkWithNoLibrary ()
+		{
+			using (var tool = new MTouchTool ()) {
+				tool.Profile = Profile.Unified;
+				tool.CreateTemporaryApp (@"
+using System;
+using System.Runtime.InteropServices;
+using ObjCRuntime;
+[assembly: LinkWith (Dlsym = DlsymOption.Required)]
+class C {
+	[DllImport (""libsqlite3"")]
+	static extern void sqlite3_column_database_name16 ();
+	static void Main ()
+	{
+	}
+}
+");
+				tool.NoFastSim = true;
+				tool.Dlsym = false;
+				tool.Linker = MTouchLinker.LinkSdk;
+				Assert.AreEqual (0, tool.Execute (MTouchAction.BuildDev), "build");
+			}
+		}
+
 #region Helper functions
 		static string CompileUnifiedTestAppExecutable (string targetDirectory, string code = null, string extraArg = "")
 		{

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -155,6 +155,16 @@ namespace Xamarin.Bundler {
 		List<Abi> abis;
 		HashSet<Abi> all_architectures; // all Abis used in the app, including extensions.
 
+		public void SetDlsymOption (string asm, bool dlsym)
+		{
+			if (DlsymAssemblies == null)
+				DlsymAssemblies = new List<Tuple<string, bool>> ();
+
+			DlsymAssemblies.Add (new Tuple<string, bool> (Path.GetFileNameWithoutExtension (asm), dlsym));
+
+			DlsymOptions = DlsymOptions.Custom;
+		}
+
 		public void ParseDlsymOptions (string options)
 		{
 			bool dlsym;
@@ -186,19 +196,19 @@ namespace Xamarin.Bundler {
 		{
 			string asm;
 
-			switch (DlsymOptions) {
-			case DlsymOptions.All:
-				return true;
-			case DlsymOptions.None:
-				return false;
-			}
-
 			if (DlsymAssemblies != null) {
 				asm = Path.GetFileNameWithoutExtension (assembly);
 				foreach (var tuple in DlsymAssemblies) {
 					if (string.Equals (tuple.Item1, asm, StringComparison.Ordinal))
 						return tuple.Item2;
 				}
+			}
+
+			switch (DlsymOptions) {
+			case DlsymOptions.All:
+				return true;
+			case DlsymOptions.None:
+				return false;
 			}
 
 			if (EnableLLVMOnlyBitCode)


### PR DESCRIPTION
This makes it possible to set linker flags per assembly:

    [assembly: LinkWith (LinkerFlags = "-lsqlite3")]

Which is required when incremental builds is enabled and a particular assembly
needs special linker flags (because we don't propagate the global -gcc_flags
to each dylib we build when doing incremental builds).

Also add an option to set the dlsym mode for an assembly (using the LinkWith
attribute).