### PR TITLE
[tests] Subset of the classic removal fix to green'ify the branch

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1458,18 +1458,6 @@ namespace MTouchTests
 		}
 
 		[Test]
-		public void BuildMonoTouchTests_StaticRegistrar ()
-		{
-			BuildMonotouchTests ("static --compiler:clang", "DEBUG;STATICREGISTRAR");
-		}
-		
-		[Test]
-		public void BuildMonoTouchTests_OldStaticRegistrar ()
-		{
-			BuildMonotouchTests ("oldstatic", "DEBUG;OLDSTATICREGISTRAR");
-		}
-
-		[Test]
 		[TestCase (Target.Dev, Profile.Unified, "dont link", "Release")]
 		[TestCase (Target.Dev, Profile.Unified, "link all", "Release")]
 		[TestCase (Target.Dev, Profile.Unified, "link sdk", "Release")]


### PR DESCRIPTION
Subset of:

commit 0863e412b4f4be1febd5396d119b5674cd535e68
Author: Rolf Bjarne Kvinge <rolf@xamarin.com>
Date:   Fri Sep 30 21:02:17 2016 +0200

    Remove XI/Classic support (#926)

    * [tests] Remove Classic SDK tests.

    * Remove XI/Classic support.

    This also means we can remove support for the legacy registrars.

    * [monotouch-test] Remove legacy registrar tests.

    * [tests/mtouch] Remove Classic tests (and legacy registrar logic).

    * [tests/scripted] Fix tests to reference Xamarin.iOS.dll.