### PR TITLE
[mtouch] Reduce the number of file lookups inside AssemblyResolver

### DIFF
--- a/tools/mtouch/AssemblyResolver.cs
+++ b/tools/mtouch/AssemblyResolver.cs
@@ -155,19 +155,18 @@ namespace MonoTouch.Tuner {
 			if (assembly != null)
 				return assembly;
 
+			assembly = SearchDirectory (aname, RootDirectory, ".exe");
+			if (assembly != null)
+				return assembly;
+
 			return null;
 		}
 
-		AssemblyDefinition SearchDirectory (string name, string directory)
+		AssemblyDefinition SearchDirectory (string name, string directory, string extension = ".dll")
 		{
-			var file = DirectoryGetFile (directory, name + ".dll");
+			var file = DirectoryGetFile (directory, name + extension);
 			if (file.Length > 0)
 				return Load (file);
-
-			file = DirectoryGetFile (directory, name + ".exe");
-			if (file.Length > 0)
-				return Load (file);
-
 			return null;
 		}
 


### PR DESCRIPTION
The SDK does not ship any, non-tool, .exe files. In fact .exe _should_
never need to be resolved since the main .exe is always given as an input
to mtouch.

Still it's possible (if quite uncommon) to refer to other .exe assemblies
just like if they were .dll. However those can only come from the
RootDirectory (and not the other places that ship with the SDK).

This "fix" ensure lookups for *.exe is done only inside the RootDirectory
location, speeding up (a bit) resolving assemblies.
