### PR TITLE
[mtouch] Add missing HasParameters check inside linker and static registrar

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -292,8 +292,8 @@ namespace XamCore.Registrar {
 			if (!TypeMatch (candidate.ReturnType, method.ReturnType))
 				return false;
 
-			if (!candidate.HasParameters || !method.HasParameters)
-				return false;
+			if (!candidate.HasParameters)
+				return !method.HasParameters;
 
 			if (candidate.Parameters.Count != method.Parameters.Count)
 				return false;

--- a/tools/linker/MonoTouch.Tuner/MonoTouchMarkStep.cs
+++ b/tools/linker/MonoTouch.Tuner/MonoTouchMarkStep.cs
@@ -61,6 +61,8 @@ namespace MonoTouch.Tuner {
 					MarkMethod (method);
 
 				// look for the special serialization constructor
+				if (!method.HasParameters)
+					continue;
 				var parameters = method.Parameters;
 				if (parameters.Count != 2)
 					continue;


### PR DESCRIPTION
Without the checks new, empty collections can be allocated and their
whole and only purpose will be to iterate up to 0 (nop).

The checks saves a small amount of memory (collections) and time.
