### PR TITLE
[msbuild] Fix how UnpackLibraryResources handles mscorlib.dll (and potentially other framework assemblies)

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -432,6 +432,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			Prefix="xammac"
 			NoOverwrite="@(_BundleResourceWithLogicalName)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
+			TargetFrameworkDirectory="$(TargetFrameworkDirectory)"
 			ReferencedLibraries="@(ResolvedFiles)">
 			<Output TaskParameter="BundleResourcesWithLogicalNames" ItemName="_BundleResourceWithLogicalName" />
 			<Output TaskParameter="BundleResourcesWithLogicalNames" ItemName="FileWrites" />

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/UnpackLibraryResourcesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/UnpackLibraryResourcesTaskBase.cs
@@ -91,8 +91,9 @@ namespace Xamarin.MacDev.Tasks
 
 		bool IsFrameworkAssembly (ITaskItem asm)
 		{
+			var asm_path = asm.GetMetadata ("FullPath");
 			foreach (var dir in TargetFrameworkDirectory) {
-				if (asm.ItemSpec.StartsWith (dir.ItemSpec, StringComparison.Ordinal))
+				if (asm_path.StartsWith (dir.GetMetadata ("FullPath"), StringComparison.OrdinalIgnoreCase))
 					return true;
 			}
 			return false;

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -531,6 +531,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			Prefix="monotouch"
 			NoOverwrite="@(_BundleResourceWithLogicalName)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
+			TargetFrameworkDirectory="$(TargetFrameworkDirectory)"
 			ReferencedLibraries="@(ReferencePath);@(ReferenceDependencyPaths)">
 			<Output TaskParameter="BundleResourcesWithLogicalNames" ItemName="_BundleResourceWithLogicalName" />
 		</UnpackLibraryResources>


### PR DESCRIPTION
```
Target _UnpackLibraryResources:
    Task "UnpackLibraryResources"
        Using task UnpackLibraryResources from Xamarin.MacDev.Tasks.UnpackLibraryResources, Xamarin.MacDev.Tasks, Version=1.0.6128.15885, Culture=neutral, PublicKeyToken=null
        UnpackLibraryResources Task
          Prefix: monotouch
          IntermediateOutputPath: obj/iPhone/Debug/
          NoOverwrite:
            obj/iPhone/Debug/ibtool-link/LaunchScreen.storyboardc/01J-lp-oVM-view-Ze5-6b-2t3.nib
            obj/iPhone/Debug/ibtool-link/LaunchScreen.storyboardc/Info.plist
            obj/iPhone/Debug/ibtool-link/LaunchScreen.storyboardc/UIViewController-01J-lp-oVM.nib
            obj/iPhone/Debug/ibtool-link/Main.storyboardc/BYZ-38-t0r-view-8bC-Xf-vdC.nib
            obj/iPhone/Debug/ibtool-link/Main.storyboardc/Info.plist
            obj/iPhone/Debug/ibtool-link/Main.storyboardc/UIViewController-BYZ-38-t0r.nib
          ReferencedLibraries:
            /Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/System.dll
            /Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/System.Xml.dll
            /Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/System.Core.dll
            /Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/Xamarin.iOS.dll
            /Users/poupou/Downloads/LinkingTest-2/RMSDKWrapper/bin/Debug//RMSDKWrapper.dll
            /Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS//mscorlib.dll
            /Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS//mscorlib.dll
          Skipping framework assembly: /Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/System.dll
          Skipping framework assembly: /Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/System.Xml.dll
          Skipping framework assembly: /Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/System.Core.dll
          Skipping framework assembly: /Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/Xamarin.iOS.dll
          Inspecting assembly: /Users/poupou/Downloads/LinkingTest-2/RMSDKWrapper/bin/Debug//RMSDKWrapper.dll
          Inspecting assembly: /Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS//mscorlib.dll
          Inspecting assembly: /Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS//mscorlib.dll
    Done executing task "UnpackLibraryResources"
    Done building target "_UnpackLibraryResources" in project "/Users/poupou/Downloads/LinkingTest-2/LinkingTest/LinkingTest.csproj".
```

The above log excerpt shows two issues:
1. mscorlib.dll is needlessly inspected as it's **not** considered a
   "framework" assembly.
   
   The current check was checking _how_ it was resolved and not _where_
   it was resolved to. The later is the most important as it's possible
   for other assemblies to have direct paths references and we do not
   want to process them.
   
   This is fixed by comparing each assembly path with the (now) provided
   `TargetFrameworkDirectory`
2. mscorlib.dll is inspected twice
   
   That's because it's present two times in the task's input. That issue
   is upstream (not sure why) of the current task but it makes #1 twice
   as costly. The fix for #1 indirectly fix that too.
## Future

It's worth investigating to move that logic into `mtouch`. The later must
already load all assemblies and is in charge of removing other embedded
data (e.g. native code from bindings) from the assemblies (so they are not
shipped both inside and outside the .dll in the final .app). This makes
this task seems extraneous work.

Considering that my current test case, `RMSDKWrapper.dll`, is 1.3GB in
size it's easy to see that the extra load (which has nothing to be
extracted wrt resources*) is quite visible in build time.

>  3268.201 ms  UnpackLibraryResources                                  1 calls
- it has for bindings but that's already handled by mtouch
