### PR TITLE
[mtouch] Remove the code to reset the resolver as it does nothing

### DIFF
--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -413,11 +413,6 @@ namespace Xamarin.Bundler
 
 			MonoTouch.Tuner.Linker.Process (LinkerOptions, out link_context, out assemblies);
 
-			// reset resolver
-			foreach (var file in assemblies) {
-				/*				var assembly = */Resolver.Load (file);
-				// FIXME assembly.MainModule.AssemblyResolver = Resolver;
-			}
 			Driver.Watch ("Link Assemblies", 1);
 		}
 


### PR DESCRIPTION
IIRC this used to be needed with a (rather old) version of Cecil.
The current code does nothing as the Load will only hit the cache
and not other properties are changed (compared to the old commented
code)
