### PR TITLE
[mtouch] Remove incorrect comment and extraneous call to LoadSymbols

### DIFF
--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -122,7 +122,6 @@ namespace Xamarin.Bundler {
 			FullPath = target;
 		}
 
-		// Executed in parallel
 		public void ExtractNativeLinkInfo ()
 		{
 			// ignore framework assemblies, they won't have any LinkWith attributes
@@ -155,9 +154,6 @@ namespace Xamarin.Bundler {
 				if (!type.IsPlatformType ("ObjCRuntime", "LinkWithAttribute"))
 					continue;
 				
-				// we know we'll modify this assembly, so load its symbols to keep them in sync
-				LoadSymbols ();
-
 				// Let the linker remove it the attribute from the assembly
 				
 				LinkWithAttribute linkWith = GetLinkWithAttribute (attr);


### PR DESCRIPTION
- Comment is wrong: the code is never executed in parallel
- If reached then RemoveResources will be called and already check for
  symbols (and load them when needed). Just a simplification (it won't
  really save time as it's not loaded twice)
