### PR TITLE
Fix XM dependency tracking of mmp bundle to prevent rebuilds

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -500,7 +500,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_CompileToNative" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_GenerateBundleName;ResolveReferences;_CompileEntitlements;_CompileAppManifest"
 		Inputs="$(TargetDir)$(TargetFileName)"
-		Outputs="$(_AppBundlePath)Contents\MacOS\$(TargetFileName)">
+		Outputs="$(_AppBundlePath)Contents\MonoBundle\$(TargetFileName)">
 		<Mmp
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"

--- a/tests/common/mac/ProjectTestHelpers.cs
+++ b/tests/common/mac/ProjectTestHelpers.cs
@@ -32,6 +32,7 @@ namespace Xamarin.MMP.Tests
 			// Not necessarly required
 			public bool FSharp { get; set; }
 			public bool XM45 { get; set; }
+			public bool DiagnosticMSBuild { get; set; }
 			public string ProjectName { get; set; }
 			public string TestCode { get; set; }
 			public string CSProjConfig { get; set; }
@@ -92,7 +93,7 @@ namespace Xamarin.MMP.Tests
 			return output.ToString ();
 		}
 
-		public static string BuildProject (string csprojTarget, bool isUnified, bool shouldFail = false)
+		public static string BuildProject (string csprojTarget, bool isUnified, bool diagnosticMSBuild = false, bool shouldFail = false)
 		{
 			string rootDirectory = FindRootDirectory ();
 
@@ -104,7 +105,7 @@ namespace Xamarin.MMP.Tests
 			// This is to force build to use our mmp and not system mmp
 			StringBuilder buildArgs = new StringBuilder ();
 			if (isUnified) {
-				buildArgs.Append (" /verbosity:normal ");
+				buildArgs.Append (diagnosticMSBuild ? " /verbosity:diagnostic " : " /verbosity:normal ");
 				buildArgs.Append (" /property:XamarinMacFrameworkRoot=" + rootDirectory + "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current ");
 			} else
 				buildArgs.Append (" build ");
@@ -186,7 +187,7 @@ namespace Xamarin.MMP.Tests
 			config.ProjectName = projectName + projectExtension;
 			string csprojTarget = GenerateEXEProject (config);
 
-			return BuildProject (csprojTarget, isUnified: true, shouldFail: shouldFail);
+			return BuildProject (csprojTarget, isUnified: true, diagnosticMSBuild: config.DiagnosticMSBuild,  shouldFail: shouldFail);
 		}
 
 		public static OutputText TestUnifiedExecutable (UnifiedTestConfig config, bool shouldFail = false)
@@ -203,7 +204,7 @@ namespace Xamarin.MMP.Tests
 			config.ProjectName = projectName + projectExtension;
 			string csprojTarget = GenerateEXEProject (config);
 
-			string buildOutput = BuildProject (csprojTarget, isUnified : true, shouldFail : shouldFail);
+			string buildOutput = BuildProject (csprojTarget, isUnified : true, diagnosticMSBuild: config.DiagnosticMSBuild, shouldFail : shouldFail);
 			if (shouldFail)
 				return new OutputText (buildOutput, "");
 
@@ -217,7 +218,7 @@ namespace Xamarin.MMP.Tests
 		{
 			Guid guid = Guid.NewGuid ();
 			string csprojTarget = GenerateClassicEXEProject (tmpDir, "ClassicExample.csproj", testCode + GenerateOuputCommand (tmpDir,guid), csprojConfig, "");
-			string buildOutput = BuildProject (csprojTarget, isUnified : false, shouldFail : shouldFail);
+			string buildOutput = BuildProject (csprojTarget, isUnified : false, diagnosticMSBuild: false, shouldFail : shouldFail);
 			if (shouldFail)
 				return new OutputText (buildOutput, "");
 
@@ -234,7 +235,7 @@ namespace Xamarin.MMP.Tests
 			config.ProjectName = $"{projectName}.csproj";
 			string csprojTarget = GenerateSystemMonoEXEProject (config);
 
-			string buildOutput = BuildProject (csprojTarget, isUnified : true, shouldFail : shouldFail);
+			string buildOutput = BuildProject (csprojTarget, isUnified : true, diagnosticMSBuild: config.DiagnosticMSBuild, shouldFail : shouldFail);
 			if (shouldFail)
 				return new OutputText (buildOutput, "");
 

--- a/tests/mmptest/src/ExtensionTests.cs
+++ b/tests/mmptest/src/ExtensionTests.cs
@@ -21,7 +21,7 @@ namespace Xamarin.MMP.Tests
 			RunMMPTest (tmpDir =>
 			{
 				string testPath = Path.Combine (TI.FindSourceDirectory (), @"Today/TodayExtensionTest.csproj");
-				TI.BuildProject (testPath, true, false);
+				TI.BuildProject (testPath, isUnified: true);
 			});
 		}
 
@@ -34,7 +34,7 @@ namespace Xamarin.MMP.Tests
 			RunMMPTest (tmpDir =>
 			{
 				string testPath = Path.Combine (TI.FindSourceDirectory (), @"Finder/FinderExtensionTest.csproj");
-				TI.BuildProject (testPath, true, false);
+				TI.BuildProject (testPath, isUnified: true);
 			});
 		}
 
@@ -47,7 +47,7 @@ namespace Xamarin.MMP.Tests
 			RunMMPTest (tmpDir =>
 			{
 				string testPath = Path.Combine (TI.FindSourceDirectory (), @"Share/ShareExtensionTest.csproj");
-				TI.BuildProject (testPath, true, false);
+				TI.BuildProject (testPath, isUnified: true);
 			});
 		}
 	}

--- a/tests/msbuild-mac/src/MSBuild-Smoke.cs
+++ b/tests/msbuild-mac/src/MSBuild-Smoke.cs
@@ -151,5 +151,23 @@ namespace Xamarin.MMP.Tests
 				}
 			});
 		}
+
+		[Test]
+		public void BuildingSameProject_TwoTimes_ShallNotInvokeMMPTwoTimes ()
+		{
+			RunMSBuildTest (tmpDir =>
+			{
+				foreach (var project in new string[] { "UnifiedExample.csproj", "XM45Example.csproj" })
+				{
+					var config = new TI.UnifiedTestConfig (tmpDir) { ProjectName = project };
+					string projectPath = TI.GenerateEXEProject (config);
+					string buildOutput = TI.BuildProject (projectPath, isUnified: true, diagnosticMSBuild: true);
+					Assert.IsTrue (buildOutput.Contains ("Target _CompileToNative needs to be built"));
+
+					string secondBuildOutput = TI.BuildProject (projectPath, isUnified: true, diagnosticMSBuild: true);
+					Assert.IsFalse (secondBuildOutput.Contains ("Target _CompileToNative needs to be built"));
+				}
+			});
+		}
 	}
 }


### PR DESCRIPTION
- https://bugzilla.xamarin.com/show_bug.cgi?id=45764
- _CompileToNative's output in msbuild was incorrectly set to:
 $(_AppBundlePath)Contents\MacOS\$(TargetFileName) when the generated
 file lives at $(_AppBundlePath)Contents\MonoBundle\$(TargetFileName).
- This means we'd always try to rebuild, which can be rather time consuming.
- The XI target file is just different enough to require a seperate fix.