### PR TITLE
[mtouch] Don't set Force when the cache is invalid (as it will be deleted)

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -541,8 +541,10 @@ namespace Xamarin.Bundler {
 			if (Driver.Force) {
 				Driver.Log (3, "A full rebuild has been forced by the command line argument -f.");
 				Cache.Clean ();
-			} else if (!Cache.VerifyCache ()) {
-				Driver.Force = true;
+			} else {
+				// this will destroy the cache if invalid, which makes setting Driver.Force to true mostly unneeded
+				// in fact setting it means some actions (like extract native resource) gets duplicate for fat builds
+				Cache.VerifyCache ();
 			}
 
 			Initialize ();


### PR DESCRIPTION
If the cache is invalid we print a warning:

> A full rebuild will be performed because the cache is either incomplete or entirely missing.

and set `Driver.Force = true;` (in Application.cs).

This later means that extracting the native code is done on each target:

```
        public static bool IsUptodate (string source, string target)
        {
            if (Driver.Force)
                return false;
```

even if this is identical between 32 and 64 bits (targets). That's
inefficient and, for large binding libraries (e.g. > 1GB), has a
noticable impact on build time (see timestamps).

Considering that the cache is cleaned (when detected as invalid) then
this Force condition is not really needed.

E.g. in `IsUptodate`
- the first time (arch) it's called will have to extract the native library;
- if a 2nd arch is built (fat) then it will be found as present and will
  not be extracted again

Removing the `Driver.Force = true;` in this condition let the `-f` option
continue to extract it twice, which can be useful in debugging and testing.
As such the check is not removed from `IsUptodate`

Timestamps (before)

```
    Setup: 25 ms
    Resolve References: 1605 ms
    Extracted native link info: 10465 ms
    ...
```

Timestamps (after)

```
    Setup: 24 ms
    Resolve References: 1560 ms
    Extracted native link info: 5473 ms
    ...
```

Total build times (from XS) was around 90-100 seconds so 5 seconds is
about 10%. The actual savings will depend on how much native code needs
to be extracted, but it should help most release builds (almost always
fat builds).
