### PR TITLE
Revert "Fix binding project LinkWithAttributes generation to prevent rebuilds"

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/PrepareNativeReferencesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/PrepareNativeReferencesTaskBase.cs
@@ -137,16 +137,9 @@ namespace Xamarin.MacDev.Tasks
 				text.AppendLine ();
 			}
 
-			bool skipLinkWithGeneration = false;
 			var linkWith = Path.Combine (IntermediateOutputPath, "LinkWithAttributes.cs");
-			if (File.Exists (linkWith)) {
-				string existingLinkWithText = File.ReadAllText (linkWith);
-				skipLinkWithGeneration = String.Equals (existingLinkWithText, text.ToString (), StringComparison.Ordinal);
-			}
-			if (!skipLinkWithGeneration) {
-				Directory.CreateDirectory (Path.GetDirectoryName (linkWith));
-				File.WriteAllText (linkWith, text.ToString ());
-			}
+			Directory.CreateDirectory (Path.GetDirectoryName (linkWith));
+			File.WriteAllText (linkWith, text.ToString ());
 
 			EmbeddedResources = embeddedResources.ToArray ();
 			NativeFrameworks = nativeFrameworks.ToArray ();

--- a/tests/msbuild-mac/src/MSBuild-Smoke.cs
+++ b/tests/msbuild-mac/src/MSBuild-Smoke.cs
@@ -151,25 +151,5 @@ namespace Xamarin.MMP.Tests
 				}
 			});
 		}
-
-		[Test]
-		public void BuildingSameBindingProject_TwoTimes_ShallNotInvokeMMPTwoTimes ()
-		{
-			const string nativeRefItemGroup = "<ItemGroup><NativeReference Include = \"\\usr\\lib\\libz.dylib\"><Kind>Dynamic</Kind><SmartLink>False</SmartLink></NativeReference></ItemGroup>";
-
-			RunMSBuildTest (tmpDir =>
-			{
-				foreach (string project in new[] { "XM45Binding.csproj", "MobileBinding.csproj", "BindingProjectWithNoTag.csproj" })
-				{
-					var config = new TI.UnifiedTestConfig (tmpDir) { ProjectName = project, ItemGroup = nativeRefItemGroup };
-					string projectPath = TI.GenerateBindingLibraryProject (config);
-					string buildOutput = TI.BuildProject (projectPath, isUnified: true, diagnosticMSBuild: true);
-					Assert.IsTrue (buildOutput.Contains ("Target CoreCompile needs to be built"));
-
-					string secondBuildOutput = TI.BuildProject (projectPath, isUnified: true, diagnosticMSBuild: true);
-					Assert.IsFalse (secondBuildOutput.Contains ("Target CoreCompile needs to be built"));
-				}
-			});
-		}
 	}
 }


### PR DESCRIPTION
Reverts xamarin/xamarin-macios#1017

It depends on #1014, which hasn't been merged yet, so it doesn't build:

    src/MSBuild-Smoke.cs(166,74): error CS1739: The best overloaded method match for `Xamarin.MMP.Tests.TI.BuildProject(string, bool, bool)' does not contain a parameter named `diagnosticMSBuild'