### PR TITLE
[runtime] Remove deprecated and ignored mono option.

### DIFF
--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -273,8 +273,6 @@ xamarin_main (int argc, char *argv[], bool is_extension)
 	// see http://bugzilla.xamarin.com/show_bug.cgi?id=820
 	// take this line out once the bug is fixed
 	mini_parse_debug_option ("no-gdb-backtrace");
-	if (xamarin_compact_seq_points)
-		mini_parse_debug_option ("gen-compact-seq-points");
 
 	DEBUG_LAUNCH_TIME_PRINT ("Spin-up time");
 

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -54,11 +54,6 @@ bool xamarin_init_mono_debug = true;
 #else
 bool xamarin_init_mono_debug = false;
 #endif
-#if DEBUG && (defined (__i386__) || defined (__x86_64__))
-bool xamarin_compact_seq_points = false;
-#else
-bool xamarin_compact_seq_points = true;
-#endif
 int xamarin_log_level = 0;
 const char *xamarin_executable_name = NULL;
 #if MONOMAC

--- a/runtime/xamarin/main.h
+++ b/runtime/xamarin/main.h
@@ -48,7 +48,6 @@ extern bool xamarin_gc_pump;
 extern bool xamarin_debug_mode;
 extern bool xamarin_disable_lldb_attach;
 extern bool xamarin_init_mono_debug;
-extern bool xamarin_compact_seq_points;
 extern int xamarin_log_level;
 extern const char *xamarin_executable_name;
 extern const char *xamarin_arch_name;

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -668,7 +668,6 @@ namespace Xamarin.Bundler
 					if (app.EnableDebug)
 						sw.WriteLine ("\txamarin_gc_pump = {0};", debug_track.Value ? "TRUE" : "FALSE");
 					sw.WriteLine ("\txamarin_init_mono_debug = {0};", app.PackageMdb ? "TRUE" : "FALSE");
-					sw.WriteLine ("\txamarin_compact_seq_points = {0};", app.EnableMSym ? "TRUE" : "FALSE");
 					sw.WriteLine ("\txamarin_executable_name = \"{0}\";", assembly_name);
 					sw.WriteLine ("\tmono_use_llvm = {0};", enable_llvm ? "TRUE" : "FALSE");
 					sw.WriteLine ("\txamarin_log_level = {0};", verbose);


### PR DESCRIPTION
Setting this option prints this to stdout:

> Mono Warning: option gen-compact-seq-points is deprecated.

and it's ignored, so just don't set this option.