### PR TITLE
[ObjCRuntime] Fix NSLog P/Invoke on Sierra.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1278,8 +1278,21 @@ namespace XamCore.ObjCRuntime {
 			ConnectMethod (method.DeclaringType, method, selector);
 		}
 
+#if MONOMAC
+		[DllImport (Constants.FoundationLibrary, EntryPoint = "NSLog")]
+		extern static void NSLog_impl (IntPtr format, [MarshalAs (UnmanagedType.LPStr)] string s);
+		static void NSLog (IntPtr format, string s)
+		{
+			if (PlatformHelper.CheckSystemVersion (10, 12)) {
+				Console.WriteLine (s);
+			} else {
+				NSLog_impl (format, s);
+			}
+		}
+#else
 		[DllImport (Constants.FoundationLibrary)]
 		extern static void NSLog (IntPtr format, [MarshalAs (UnmanagedType.LPStr)] string s);
+#endif
 
 		[DllImport (Constants.FoundationLibrary, EntryPoint = "NSLog")]
 		extern static void NSLog_arm64 (IntPtr format, IntPtr p2, IntPtr p3, IntPtr p4, IntPtr p5, IntPtr p6, IntPtr p7, IntPtr p8, [MarshalAs (UnmanagedType.LPStr)] string s);


### PR DESCRIPTION
Not a real fix (since the bug is in Apple's code), but we've already run into this several times:

https://bugzilla.xamarin.com/show_bug.cgi?id=43541
https://trello.com/c/lGa2jHM6/57-28082586-macos-sierra-nslog-crashes-when-called-from-jit-frame