### PR TITLE
[registrar] Cache the System.Void type.

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -827,8 +827,12 @@ namespace XamCore.Registrar {
 			return method.ReturnType;
 		}
 
+		TypeReference system_void;
 		protected override TypeReference GetSystemVoidType ()
 		{
+			if (system_void != null)
+				return system_void;
+			
 			// find corlib
 			AssemblyDefinition corlib = null;
 			AssemblyDefinition first = null;
@@ -847,7 +851,7 @@ namespace XamCore.Registrar {
 			}
 			foreach (var type in corlib.MainModule.Types) {
 				if (type.Namespace == "System" && type.Name == "Void")
-					return type;
+					return system_void = type;
 			}
 
 			throw new Exception ("Couldn't find System.Void");


### PR DESCRIPTION
```
Duration before: 1,60s
Duration after:  1,54s
Difference:     -0,06s = -3,8%
```

Memory usage hardly changed (-21 kb of 540 MB), but the number of method calls
shrunk significantly.

```
Method calls before: 86.720.379
Method calls after:  74.390.061
Difference:         -12.330.318 = -14,2%
```

The call to `GetSystemVoidType` was #2 on the list of method calls (whens
sorted by 'self'), called 1072 times taking 1429 ms each time. After this
change it's only called once (and obviously pushed way down the list).