### PR TITLE
[linker] Use ordinal instead of invariant comparison.

### DIFF
--- a/tools/mtouch/AssemblyResolver.cs
+++ b/tools/mtouch/AssemblyResolver.cs
@@ -48,7 +48,7 @@ namespace MonoTouch.Tuner {
 
 		public MonoTouchResolver ()
 		{
-			cache = new Dictionary<string, AssemblyDefinition> (StringComparer.InvariantCultureIgnoreCase);
+			cache = new Dictionary<string, AssemblyDefinition> (StringComparer.OrdinalIgnoreCase);
 		}
 
 		ReaderParameters CreateParameters (string path)
@@ -61,7 +61,7 @@ namespace MonoTouch.Tuner {
 
 		public IDictionary ToResolverCache ()
 		{
-			var resolver_cache = new Hashtable (StringComparer.InvariantCultureIgnoreCase);
+			var resolver_cache = new Hashtable (StringComparer.OrdinalIgnoreCase);
 			foreach (var pair in cache)
 				resolver_cache.Add (pair.Key, pair.Value);
 


### PR DESCRIPTION
Profiled when running the partial static registrar on Xamarin.iOS.dll

```
Duration before: 1,60s
Duration after:  1,41s
Difference:     -0,19s = -11,9%
```

```
Memory usage before: 541.887.736 bytes
Memory usage after:  509.111.944 bytes
Difference:          -32.775.792 bytes = -6,0%
```

```
Method calls before: 86.720.379
Method calls after:  63.073.602
Difference:         -23.646.777 = -27,3%
```