### PR TITLE
Fixes Bug #44724 - Failed to read file attributes for "/Users/admin/Assets.xcassets"

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/BundleResource.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/BundleResource.cs
@@ -55,7 +55,7 @@ namespace Xamarin.MacDev
 				.ToList ();
 		}
 
-		public static string GetVirtualProjectPath (string projectDir, ITaskItem item)
+		public static string GetVirtualProjectPath (string projectDir, ITaskItem item, bool isVSBuild)
 		{
 			var link = item.GetMetadata ("Link");
 
@@ -68,7 +68,7 @@ namespace Xamarin.MacDev
 			}
 
 			// HACK: This is for Visual Studio iOS projects
-			if (!Directory.Exists (projectDir))
+			if (isVSBuild)
 				return item.ItemSpec;
 
 			var definingProjectFullPath = item.GetMetadata ("DefiningProjectFullPath");
@@ -87,7 +87,7 @@ namespace Xamarin.MacDev
 			return PathUtils.AbsoluteToRelative (baseDir, path);
 		}
 
-		public static string GetLogicalName (string projectDir, IList<string> prefixes, ITaskItem item)
+		public static string GetLogicalName (string projectDir, IList<string> prefixes, ITaskItem item, bool isVSBuild)
 		{
 			var logicalName = item.GetMetadata ("LogicalName");
 
@@ -98,7 +98,7 @@ namespace Xamarin.MacDev
 				return logicalName;
 			}
 
-			var vpath = GetVirtualProjectPath (projectDir, item);
+			var vpath = GetVirtualProjectPath (projectDir, item, isVSBuild);
 			int matchlen = 0;
 
 			foreach (var prefix in prefixes) {

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
@@ -276,7 +276,7 @@ namespace Xamarin.MacDev.Tasks
 			}
 
 			foreach (var asset in ImageAssets) {
-				var vpath = BundleResource.GetVirtualProjectPath (ProjectDir, asset);
+				var vpath = BundleResource.GetVirtualProjectPath (ProjectDir, asset, !string.IsNullOrEmpty(SessionId));
 				if (Path.GetFileName (vpath) != "Contents.json")
 					continue;
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CollectBundleResourcesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CollectBundleResourcesTaskBase.cs
@@ -56,7 +56,7 @@ namespace Xamarin.MacDev.Tasks
 
 			if (BundleResources != null) {
 				foreach (var item in BundleResources) {
-					var logicalName = BundleResource.GetLogicalName (ProjectDir, prefixes, item);
+					var logicalName = BundleResource.GetLogicalName (ProjectDir, prefixes, item, !string.IsNullOrEmpty(SessionId));
 					// We need a physical path here, ignore the Link element
 					var path = item.GetMetadata ("FullPath");
 					string illegal;

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
@@ -171,7 +171,7 @@ namespace Xamarin.MacDev.Tasks
 				if (!string.IsNullOrEmpty (metadata))
 					asset.SetMetadata ("LogicalName", string.Empty);
 
-				var bundleName = BundleResource.GetLogicalName (ProjectDir, prefixes, asset);
+				var bundleName = BundleResource.GetLogicalName (ProjectDir, prefixes, asset, !string.IsNullOrEmpty(SessionId));
 				var output = new TaskItem (Path.Combine (intermediate, bundleName));
 
 				if (!modified.Contains (scnassets) && (!File.Exists (output.ItemSpec) || File.GetLastWriteTime (asset.ItemSpec) > File.GetLastWriteTime (output.ItemSpec))) {
@@ -199,7 +199,7 @@ namespace Xamarin.MacDev.Tasks
 				Directory.CreateDirectory (intermediate);
 
 			foreach (var item in items) {
-				var bundleDir = BundleResource.GetLogicalName (ProjectDir, prefixes, new TaskItem (item));
+				var bundleDir = BundleResource.GetLogicalName (ProjectDir, prefixes, new TaskItem (item), !string.IsNullOrEmpty(SessionId));
 				var output = Path.Combine (intermediate, bundleDir);
 
 				if (CopySceneKitAssets (item.ItemSpec, output, intermediate) == -1)

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindItemWithLogicalNameTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/FindItemWithLogicalNameTaskBase.cs
@@ -43,7 +43,7 @@ namespace Xamarin.MacDev.Tasks
 				var prefixes = BundleResource.SplitResourcePrefixes (ResourcePrefix);
 
 				foreach (var item in Items) {
-					var logical = BundleResource.GetLogicalName (ProjectDir, prefixes, item);
+					var logical = BundleResource.GetLogicalName (ProjectDir, prefixes, item, !string.IsNullOrEmpty(SessionId));
 
 					if (logical == LogicalName) {
 						Log.LogMessage (MessageImportance.Low, "  {0} found at: {1}", LogicalName, item.ItemSpec);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
@@ -61,7 +61,7 @@ namespace Xamarin.MacDev.Tasks
 		{
 			var prefixes = BundleResource.SplitResourcePrefixes (ResourcePrefix);
 			var intermediate = Path.Combine (IntermediateOutputPath, ToolName);
-			var logicalName = BundleResource.GetLogicalName (ProjectDir, prefixes, SourceFile);
+			var logicalName = BundleResource.GetLogicalName (ProjectDir, prefixes, SourceFile, !string.IsNullOrEmpty(SessionId));
 			var path = Path.Combine (intermediate, logicalName);
 			var args = new ProcessArgumentBuilder ();
 			var dir = Path.GetDirectoryName (path);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/TextureAtlasTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/TextureAtlasTaskBase.cs
@@ -86,7 +86,7 @@ namespace Xamarin.MacDev.Tasks
 
 			// group the atlas textures by their parent .atlas directories
 			foreach (var item in AtlasTextures) {
-				var atlas = Path.GetDirectoryName (BundleResource.GetVirtualProjectPath (ProjectDir, item));
+				var atlas = Path.GetDirectoryName (BundleResource.GetVirtualProjectPath (ProjectDir, item, !string.IsNullOrEmpty(SessionId)));
 				List<ITaskItem> items;
 
 				if (!atlases.TryGetValue (atlas, out items)) {

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeToolTaskBase.cs
@@ -77,7 +77,7 @@ namespace Xamarin.MacDev.Tasks
 
 		protected virtual string GetBundleRelativeOutputPath (IList<string> prefixes, ITaskItem input)
 		{
-			return BundleResource.GetLogicalName (ProjectDir, prefixes, input);
+			return BundleResource.GetLogicalName (ProjectDir, prefixes, input, !string.IsNullOrEmpty(SessionId));
 		}
 
 		protected virtual IEnumerable<ITaskItem> GetCompiledBundleResources (ITaskItem input, ITaskItem output)


### PR DESCRIPTION
The ProjectDir could exist under certain circumstances (e.g. referenced assemblies are being copied to the Mac in the same folder path that those are located in Windows) so we cannot assume the existence or not of ProjectDir means the build comes from VS.

The only way to ensure we're building from VS is to check the SessionId parameter.

https://bugzilla.xamarin.com/show_bug.cgi?id=44724