### PR TITLE
[XM] Teach XM resolver to load all of assemblies into memory

### DIFF
--- a/tools/mmp/resolver.cs
+++ b/tools/mmp/resolver.cs
@@ -69,7 +69,11 @@ namespace Xamarin.Bundler {
 			if (cache.TryGetValue (name, out assembly))
 				return assembly;
 
-			assembly = AssemblyDefinition.ReadAssembly (fileName, new ReaderParameters { AssemblyResolver = this });
+			assembly = AssemblyDefinition.ReadAssembly (fileName, new ReaderParameters 
+				{
+					AssemblyResolver = this,
+					InMemory = new FileInfo (fileName).Length < 1024 * 1024 * 100 // 100 MB
+				});
 			cache.Add (name, assembly);
 			return assembly;
 		}


### PR DESCRIPTION
- Profiling suggesting that loading all of sub-100 MB assemblies into
 memory is a performance win, and mtouch already does it.