### PR TITLE
[mmp] Don't process SDK assemblies for external symbols unless we're embedding mono. Fixes #45902.

### DIFF
--- a/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
+++ b/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
@@ -20,10 +20,12 @@ namespace MonoTouch.Tuner
 	public class ListExportedSymbols : BaseStep
 	{
 		PInvokeWrapperGenerator state;
+		bool skip_sdk_assemblies;
 
-		internal ListExportedSymbols (PInvokeWrapperGenerator state)
+		internal ListExportedSymbols (PInvokeWrapperGenerator state, bool skip_sdk_assemblies = false)
 		{
 			this.state = state;
+			this.skip_sdk_assemblies = skip_sdk_assemblies;
 		}
 
 		protected override void ProcessAssembly (AssemblyDefinition assembly)
@@ -31,6 +33,9 @@ namespace MonoTouch.Tuner
 			base.ProcessAssembly (assembly);
 
 			if (Context.Annotations.GetAction (assembly) == AssemblyAction.Delete)
+				return;
+
+			if (skip_sdk_assemblies && Profile.IsSdkAssembly (assembly))
 				return;
 
 			if (!assembly.MainModule.HasTypes)

--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -32,6 +32,7 @@ namespace MonoMac.Tuner {
 		public string Architecture { get; set; }
 		internal PInvokeWrapperGenerator MarshalNativeExceptionsState { get; set; }
 		internal RuntimeOptions RuntimeOptions { get; set; }
+		public bool SkipExportedSymbolsInSdkAssemblies { get; set; }
 
 		public static I18nAssemblies ParseI18nAssemblies (string i18n)
 		{
@@ -178,7 +179,7 @@ namespace MonoMac.Tuner {
 				pipeline.AppendStep (new RegenerateGuidStep ());
 			}
 
-			pipeline.AppendStep (new ListExportedSymbols (options.MarshalNativeExceptionsState));
+			pipeline.AppendStep (new ListExportedSymbols (options.MarshalNativeExceptionsState, options.SkipExportedSymbolsInSdkAssemblies));
 
 			pipeline.AppendStep (new OutputStep ());
 

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1203,6 +1203,7 @@ namespace Xamarin.Bundler {
 					HeaderPath = Path.Combine (Cache.Location, "pinvokes.h"),
 					Registrar = (StaticRegistrar) BuildTarget.StaticRegistrar,
 				},
+				SkipExportedSymbolsInSdkAssemblies = !embed_mono,
 			};
 
 			linker_options = options;


### PR DESCRIPTION
SDK assemblies might contain P/Invokes to libmono, but unless we link with
mono (which we don't do if we're not embedding mono), the native linker will
complain if we ask it to keep those symbols (using `-u symbol`).

So don't look for __Internal P/Invokes in SDK assemblies in that case.

https://bugzilla.xamarin.com/show_bug.cgi?id=45902