### PR TITLE
Use ExceptionDispatchInfo to keep stack traces when unhandled exceptions are marshaled. Improves bug #45742 a bit.

### DIFF
--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -22,6 +22,10 @@
 			ExceptionHandling = false,
 		},
 
+		new XDelegate ("void", "void", "xamarin_rethrow_managed_exception",
+			"guint32", "uint", "original_exception_gchandle"
+		) { WrappedManagedFunction = "RethrowManagedException" },
+
 		new XDelegate ("int", "int", "xamarin_create_ns_exception",
 			"NSException *", "IntPtr", "exc"
 		) { WrappedManagedFunction = "CreateNSException" },

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2073,7 +2073,32 @@ xamarin_process_managed_exception (MonoObject *exception)
 	case MarshalManagedExceptionModeUnwindNativeCode:
 		if (xamarin_is_gc_coop)
 			xamarin_assertion_message ("Cannot unwind native frames for managed exceptions when the GC is in cooperative mode.");
+
+		//
+		// We want to maintain the original stack trace of the exception, but unfortunately
+		// calling mono_raise_exception directly with the original exception will overwrite
+		// the original stack trace.
+		//
+		// The good news is that the managed ExceptionDispatchInfo class is able to capture
+		// a stack trace for an exception and show it later.
+		//
+		// The xamarin_rethrow_managed_exception method will use ExceptionDispatchInfo
+		// to throw an exception that contains the original stack trace.
+		//
+
+		handle = mono_gchandle_new (exception, false);
+		xamarin_rethrow_managed_exception (handle, &exception_gchandle);
+		mono_gchandle_free (handle);
+
+		if (exception_gchandle == 0) {
+			PRINT (PRODUCT ": Did not get a rethrow exception, will throw the original exception. The original stack trace will be lost.");
+		} else {
+			exception = mono_gchandle_get_target (exception_gchandle);
+			mono_gchandle_free (exception_gchandle);
+		}
+
 		mono_raise_exception ((MonoException *) exception);
+
 		break;
 	case MarshalManagedExceptionModeThrowObjectiveCException: {
 		int handle = mono_gchandle_new (exception, false);

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -106,6 +106,7 @@ void			xamarin_set_nsobject_handle (MonoObject *obj, id handle);
 uint8_t         xamarin_get_nsobject_flags (MonoObject *obj);
 void			xamarin_set_nsobject_flags (MonoObject *obj, uint8_t flags);
 void			xamarin_throw_nsexception (MonoException *exc);
+void			xamarin_rethrow_managed_exception (guint32 original_gchandle, guint32 *exception_gchandle);
 MonoException *	xamarin_create_exception (const char *msg);
 id				xamarin_get_handle (MonoObject *obj, guint32 *exception_gchandle);
 char *			xamarin_strdup_printf (const char *msg, ...);

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -311,6 +311,12 @@ namespace XamCore.ObjCRuntime {
 #endif
 		}
 
+		static void RethrowManagedException (uint exception_gchandle)
+		{
+			var e = (Exception) GCHandle.FromIntPtr ((IntPtr) exception_gchandle).Target;
+			System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture (e).Throw ();
+		}
+
 		static int CreateNSException (IntPtr ns_exception)
 		{
 			Exception ex;


### PR DESCRIPTION
Example code:

	public override void ViewDidLoad ()
	{
		throw new Exception ("USELESS");
	}

Current output with unhandled exceptions that are marshaled:

    Unhandled Exception:
    System.Exception: USELESS
      at (wrapper managed-to-native) AppKit.NSApplication:NSApplicationMain (int,string[])
      at AppKit.NSApplication.Main (System.String[] args) [0x00041] in /work/maccore/master/xamarin-macios/src/AppKit/NSApplication.cs:98
      at UselessExceptions.MainClass.Main (System.String[] args) [0x00007] in /Users/rolf/Downloads/filed-bug-test-cases-master/Xamarin/bxc45742/Main.cs:10
    [ERROR] FATAL UNHANDLED EXCEPTION: UselessExceptions.CustomException: USELESS
      at (wrapper managed-to-native) AppKit.NSApplication:NSApplicationMain (int,string[])
      at AppKit.NSApplication.Main (System.String[] args) [0x00041] in /work/maccore/master/xamarin-macios/src/AppKit/NSApplication.cs:98
      at UselessExceptions.MainClass.Main (System.String[] args) [0x00007] in /Users/rolf/Downloads/filed-bug-test-cases-master/Xamarin/bxc45742/Main.cs:10

Note how the managed frame where the exception was thrown does not show up.

This is because we technically catch exceptions when marshaling them, and then
later we call mono_raise_exception to raise the same exception. Unfortunately
that leads to overwriting the initial stack trace, and we end up with a stack
trace that does not include the location where the original exception was
thrown.

So instead of calling mono_raise_exception to rethrow the same exception, we
use ExceptionDispatchInfo, which is able to capture the stack trace for both
the original exception and the new exception, producing the following output:

    System.Exception: USELESS
      at UselessExceptions.ViewController.ViewDidLoad () [0x0000c] in /Users/rolf/Downloads/filed-bug-test-cases-master/Xamarin/bxc45742/ViewController.cs:27
    --- End of stack trace from previous location where exception was thrown ---
      at (wrapper managed-to-native) AppKit.NSApplication:NSApplicationMain (int,string[])
      at AppKit.NSApplication.Main (System.String[] args) [0x00041] in /work/maccore/master/xamarin-macios/src/AppKit/NSApplication.cs:98
      at UselessExceptions.MainClass.Main (System.String[] args) [0x00007] in /Users/rolf/Downloads/filed-bug-test-cases-master/Xamarin/bxc45742/Main.cs:10
    [ERROR] FATAL UNHANDLED EXCEPTION: UselessExceptions.CustomException: USELESS
      at UselessExceptions.ViewController.ViewDidLoad () [0x0000c] in /Users/rolf/Downloads/filed-bug-test-cases-master/Xamarin/bxc45742/ViewController.cs:27
    --- End of stack trace from previous location where exception was thrown ---
      at (wrapper managed-to-native) AppKit.NSApplication:NSApplicationMain (int,string[])
      at AppKit.NSApplication.Main (System.String[] args) [0x00041] in /work/maccore/master/xamarin-macios/src/AppKit/NSApplication.cs:98
      at UselessExceptions.MainClass.Main (System.String[] args) [0x00007] in /Users/rolf/Downloads/filed-bug-test-cases-master/Xamarin/bxc45742/Main.cs:10

Incidently this is how Xamarin.Android does it [1].

[1]: https://github.com/xamarin/Java.Interop/commit/9387f2fe16300ea8eb3d5270e50f0513d251bd62

https://bugzilla.xamarin.com/show_bug.cgi?id=45742