### PR TITLE
[ObjCRuntime] Simplify dynamic registrar creation a little bit.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -190,7 +190,7 @@ namespace XamCore.ObjCRuntime {
 
 			NSObjectClass = NSObject.Initialize (ref options);
 
-			CreateRegistrar (options);
+			Registrar = new DynamicRegistrar ();
 			RegisterDelegates (ref options);
 			Method.Initialize (ref options);
 			Class.Initialize (ref options);

--- a/src/ObjCRuntime/Runtime.iOS.cs
+++ b/src/ObjCRuntime/Runtime.iOS.cs
@@ -53,12 +53,6 @@ namespace XamCore.ObjCRuntime {
 			UIApplication.Initialize ();
 		}
 
-		// moved into it's own method to make it easier /safer to be re-written by the linker
-		static void CreateRegistrar (InitializationOptions options)
-		{
-			Registrar = new DynamicRegistrar ();
-		}
-
 		// This method is documented to be for diagnostic purposes only,
 		// and should not be considered stable API.
 		[EditorBrowsable (EditorBrowsableState.Advanced)]

--- a/src/ObjCRuntime/Runtime.mac.cs
+++ b/src/ObjCRuntime/Runtime.mac.cs
@@ -137,11 +137,6 @@ namespace XamCore.ObjCRuntime {
 			ResourcesPath = Path.Combine (basePath, "Resources");
 			FrameworksPath = Path.Combine (basePath, "Frameworks");
 		}
-
-		static void CreateRegistrar (InitializationOptions options)
-		{
-			Registrar = new DynamicRegistrar ();
-		}
 #endif // !COREBUILD
 	}
 }


### PR DESCRIPTION
There's only one dynamic registrar now, so no need to make it complicated (nor
does the linker process this code anymore).