### PR TITLE
[registrar] Mark our generated code as 'extern C'.

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3681,8 +3681,11 @@ namespace XamCore.Registrar {
 							methods = mthds;
 
 							mthds.WriteLine ($"#include \"{Path.GetFileName (header_path)}\"");
+							mthds.StringBuilder.AppendLine ("extern \"C\" {");
 
 							Specialize (sb);
+
+							mthds.StringBuilder.AppendLine ("} /* extern \"C\" */");
 
 							header = null;	
 							declarations = null;


### PR DESCRIPTION
This makes the function names smaller, saving a tiny bit of space (about 700
bytes for the dont link test app).

It also looks nicer in crash reports.