### PR TITLE
[mtouch/tests] BuildAndLaunchTime + RegistrarTime test

### DIFF
--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -17,7 +17,7 @@ namespace MTouchTests
 		LaunchSim,
 	}
 
-	enum MTouchLinker
+	public enum MTouchLinker
 	{
 		Unspecified,
 		LinkAll,

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -25,7 +25,7 @@ namespace MTouchTests
 		DontLink,
 	}
 
-	enum MTouchRegistrar
+	public enum MTouchRegistrar
 	{
 		Unspecified,
 		Dynamic,
@@ -250,7 +250,7 @@ namespace MTouchTests
 			case MTouchRegistrar.Unspecified:
 				break;
 			case MTouchRegistrar.Dynamic:
-				sb.Append (" --registrar:static");
+				sb.Append (" --registrar:dynamic");
 				break;
 			case MTouchRegistrar.Static:
 				sb.Append (" --registrar:static");

--- a/tests/mtouch/TimingTests.cs
+++ b/tests/mtouch/TimingTests.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using MTouchTests;
 using NUnit.Framework;
+using System.Text;
 
 namespace Xamarin.Profiler
 {
@@ -10,6 +11,17 @@ namespace Xamarin.Profiler
 	public class TimingTests
 	{
 		MTouch.Profile profile;
+		StringBuilder sb;
+		int starsLenght;
+
+		[TestFixtureSetUp]
+		public void Init ()
+		{
+			sb = new StringBuilder ();
+			var title = $"**** TimingTests ({profile}) ****";
+			starsLenght = title.Length;
+			sb.AppendLine (title);
+		}
 
 		public TimingTests (MTouch.Profile profile)
 		{
@@ -28,29 +40,47 @@ namespace Xamarin.Profiler
 		}
 
 		/// <summary>
-		/// Time to launch an application on the simulators.</summary>
+		/// Time to build and launch an application on the simulators.</summary>
 		/// <remarks>
-		/// Note: the measurement is being done with the simulator already open and the app not yet installed.</remarks>
-		[Test]
-		public void AppLaunchTime ()
+		/// Note: the measurement is being done with the simulator already open and, on the bots, the app not yet installed.
+		/// Warning: If you're running those tests multiple times locally, you may want to reset the simulator manually each time.</remarks>
+		[TestCase (MTouchLinker.DontLink)]
+		[TestCase (MTouchLinker.LinkSdk)]
+		[TestCase (MTouchLinker.LinkAll)]
+		public void BuildAndLaunchTime (MTouchLinker linkerMode)
 		{
 			using (var buildTool = new MTouchTool ()) {
+				var linkerModeName = Enum.GetName (typeof (MTouchLinker), linkerMode);
 				buildTool.Profile = profile;
-				buildTool.CreateTemporaryApp (profile, true, "AppLaunchTime" + profile);
-
-				buildTool.Execute (MTouchAction.BuildSim);
+				buildTool.Linker = linkerMode;
+				buildTool.CreateTemporaryApp (profile, true, "BuildAndLaunchTime" + linkerModeName + profile);
 
 				var sw = new Stopwatch ();
+				sw.Start ();
+				buildTool.Execute (MTouchAction.BuildSim);
+				sw.Stop ();
+				var buildTime = sw.Elapsed.TotalSeconds;
+
 				var launchTool = new MLaunchTool ();
 				launchTool.AppPath = buildTool.AppPath;
 				launchTool.Profile = profile;
 
+				sw.Reset ();
 				sw.Start ();
 				launchTool.Execute ();
 				sw.Stop ();
+				var launchTime = sw.Elapsed.TotalSeconds;
 
-				Console.WriteLine ("TimingTests - AppLaunchTime ({0}): {1} seconds", profile, sw.Elapsed.TotalSeconds.ToString ("#.000"));
+				var totalTime = buildTime + launchTime;
+				sb.AppendLine (string.Format ("BuildAndLaunchTime - {0}: {1} seconds [build time], {2} seconds [launch time], {3} seconds [total time]", linkerModeName, buildTime.ToString ("#.000"), launchTime.ToString ("#.000"), totalTime.ToString ("#.000")));
 			}
+		}
+
+		[TestFixtureTearDown]
+		public void PrintLogs ()
+		{
+			sb.AppendLine (new string ('*', starsLenght));
+			Console.WriteLine (sb);
 		}
 	}
 }

--- a/tests/mtouch/TimingTests.cs
+++ b/tests/mtouch/TimingTests.cs
@@ -76,6 +76,38 @@ namespace Xamarin.Profiler
 			}
 		}
 
+		[TestCase (MTouchRegistrar.Dynamic)]
+		[TestCase (MTouchRegistrar.Static)]
+		public void RegistrarTime (MTouchRegistrar registrarMode)
+		{
+			using (var buildTool = new MTouchTool ()) {
+				var registrarModeName = Enum.GetName (typeof (MTouchRegistrar), registrarMode);
+				buildTool.Profile = profile;
+				buildTool.Registrar = registrarMode;
+				buildTool.NoFastSim = true;
+				buildTool.CreateTemporaryApp (profile, true, "RegistrarTime" + registrarModeName + profile);
+
+				var sw = new Stopwatch ();
+				sw.Start ();
+				buildTool.Execute (MTouchAction.BuildSim);
+				sw.Stop ();
+				var buildTime = sw.Elapsed.TotalSeconds;
+
+				var launchTool = new MLaunchTool ();
+				launchTool.AppPath = buildTool.AppPath;
+				launchTool.Profile = profile;
+
+				sw.Reset ();
+				sw.Start ();
+				launchTool.Execute ();
+				sw.Stop ();
+				var launchTime = sw.Elapsed.TotalSeconds;
+
+				var totalTime = buildTime + launchTime;
+				sb.AppendLine (string.Format ("RegistrarTime - {0}: {1} seconds [build time], {2} seconds [launch time], {3} seconds [total time]", registrarModeName, buildTime.ToString ("#.000"), launchTime.ToString ("#.000"), totalTime.ToString ("#.000")));
+			}
+		}
+
 		[TestFixtureTearDown]
 		public void PrintLogs ()
 		{

--- a/tests/mtouch/TimingTests.cs
+++ b/tests/mtouch/TimingTests.cs
@@ -40,7 +40,9 @@ namespace Xamarin.Profiler
 		}
 
 		/// <summary>
-		/// Time to build and launch an application on the simulators.</summary>
+		/// Time to build and launch an app on the simulators with different linker modes.</summary>
+		/// <param name="linkerMode">
+		/// Set the linker to DontLink, LinkSdk or LinkAll.</param>
 		/// <remarks>
 		/// Note: the measurement is being done with the simulator already open and, on the bots, the app not yet installed.
 		/// Warning: If you're running those tests multiple times locally, you may want to reset the simulator manually each time.</remarks>
@@ -76,6 +78,13 @@ namespace Xamarin.Profiler
 			}
 		}
 
+		/// <summary>
+		/// Time to build and launch an app on the simulators with different registrar modes.</summary>
+		/// <param name="registrarMode">
+		/// Use the dynamic or static registrar.</param>
+		/// <remarks>
+		/// Note: the measurement is being done with the simulator already open and, on the bots, the app not yet installed.
+		/// Warning: If you're running those tests multiple times locally, you may want to reset the simulator manually each time.</remarks>
 		[TestCase (MTouchRegistrar.Dynamic)]
 		[TestCase (MTouchRegistrar.Static)]
 		public void RegistrarTime (MTouchRegistrar registrarMode)


### PR DESCRIPTION
- BuildAndLaunchTime is replacing AppLaunchTime as it calculates both build time and launch time for different linker modes.
- Add RegistrarTime test.
- Also fix MTouchTool --registrar:dynamic.