### PR TITLE
Disable managed exception marshaling when the debugger is attached. Fixes #45116.

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -377,6 +377,8 @@
 			"int", "generation"
 		),
 
+		new Export ("mono_bool", "mono_is_debugger_attached"),
+
 		#endregion
 
 		#region metadata/mono-config.h

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2367,6 +2367,31 @@ xamarin_get_is_debug ()
 	return xamarin_debug_mode;
 }
 
+bool
+xamarin_is_managed_exception_marshaling_disabled ()
+{
+#if DEBUG
+	if (xamarin_is_gc_coop)
+		return false;
+
+	switch (xamarin_marshal_managed_exception_mode) {
+	case MarshalManagedExceptionModeDefault:
+		// If all of the following are true:
+		// * In debug mode
+		// * Using the default exception marshaling mode
+		// * The debugger is attached
+		// Then disable managed exception marshaling.
+		return mono_is_debugger_attached ();
+	case MarshalManagedExceptionModeDisable:
+		return true;
+	default:
+		return false;
+	}
+#else
+	return false;
+#endif
+}
+
 /*
  * XamarinGCHandle
  */

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -32,7 +32,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 	MONO_ASSERT_GC_SAFE_OR_DETACHED;
 
 	MonoObject *exception = NULL;
-	MonoObject **exception_ptr = xamarin_marshal_managed_exception_mode == MarshalManagedExceptionModeDisable ? NULL : &exception;
+	MonoObject **exception_ptr = xamarin_is_managed_exception_marshaling_disabled () ? NULL : &exception;
 	guint32 exception_gchandle = 0;
 	bool is_static = (type & Tramp_Static) == Tramp_Static;
 	bool is_ctor = type == Tramp_Ctor;

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -156,6 +156,8 @@ void			xamarin_throw_product_exception (int code, const char *message);
 
 id				xamarin_invoke_objc_method_implementation (id self, SEL sel, IMP xamarin_impl);
 
+bool			xamarin_is_managed_exception_marshaling_disabled ();
+
 // this functions support NSLog/NSString-style format specifiers.
 void			xamarin_printf (const char *format, ...);
 void			xamarin_vprintf (const char *format, va_list args);

--- a/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
@@ -28,10 +28,10 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 #if __WATCHOS__
 		MarshalObjectiveCExceptionMode defaultObjectiveCExceptionMode = MarshalObjectiveCExceptionMode.ThrowManagedException;
-		MarshalManagedExceptionMode defaultManagedExceptionMode = MarshalManagedExceptionMode.ThrowObjectiveCException;
+		MarshalManagedExceptionMode defaultManagedExceptionMode = MarshalManagedExceptionMode.Default;
 #else
 		MarshalObjectiveCExceptionMode defaultObjectiveCExceptionMode = MarshalObjectiveCExceptionMode.UnwindManagedCode;
-		MarshalManagedExceptionMode defaultManagedExceptionMode = MarshalManagedExceptionMode.UnwindNativeCode;
+		MarshalManagedExceptionMode defaultManagedExceptionMode = MarshalManagedExceptionMode.Default;
 #endif
 
 		static List<MarshalObjectiveCExceptionEventArgs> objcEventArgs;

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -48,6 +48,7 @@ namespace Xamarin.Bundler {
 		public bool? EnableCoopGC;
 		public MarshalObjectiveCExceptionMode MarshalObjectiveCExceptions;
 		public MarshalManagedExceptionMode MarshalManagedExceptions;
+		public bool IsDefaultMarshalManagedExceptionMode;
 
 		public bool RequiresPInvokeWrappers {
 			get {
@@ -389,6 +390,7 @@ namespace Xamarin.Bundler {
 				} else {
 					MarshalManagedExceptions = isSimulatorOrDesktopDebug ? MarshalManagedExceptionMode.UnwindNativeCode : MarshalManagedExceptionMode.Disable;
 				}
+				IsDefaultMarshalManagedExceptionMode = true;
 			}
 		}
 	}

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3148,7 +3148,12 @@ namespace XamCore.Registrar {
 			var marshal_exception = "NULL";
 			if (App.MarshalManagedExceptions != MarshalManagedExceptionMode.Disable) {
 				body_setup.AppendLine ("MonoObject *exception = NULL;");
-				marshal_exception = "&exception";
+				if (App.EnableDebug && App.IsDefaultMarshalManagedExceptionMode) {
+					body_setup.AppendLine ("MonoObject **exception_ptr = xamarin_is_managed_exception_marshaling_disabled () ? NULL : &exception;");
+					marshal_exception = "exception_ptr";
+				} else {
+					marshal_exception = "&exception";
+				}
 			}
 
 			if (!isVoid) {

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -908,7 +908,8 @@ namespace Xamarin.Bundler {
 					sw.WriteLine ("extern NSString* xamarin_custom_bundle_name;");
 					sw.WriteLine ("\txamarin_custom_bundle_name = @\"" + custom_bundle_name + "\";");
 				}
-				sw.WriteLine ("\txamarin_marshal_managed_exception_mode = MarshalManagedExceptionMode{0};", App.MarshalManagedExceptions);
+				if (!App.IsDefaultMarshalManagedExceptionMode)
+					sw.WriteLine ("\txamarin_marshal_managed_exception_mode = MarshalManagedExceptionMode{0};", App.MarshalManagedExceptions);
 				sw.WriteLine ("\txamarin_marshal_objectivec_exception_mode = MarshalObjectiveCExceptionMode{0};", App.MarshalObjectiveCExceptions);
 				if (disable_lldb_attach)
 					sw.WriteLine ("\txamarin_disable_lldb_attach = true;");

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -672,7 +672,8 @@ namespace Xamarin.Bundler
 					sw.WriteLine ("\tmono_use_llvm = {0};", enable_llvm ? "TRUE" : "FALSE");
 					sw.WriteLine ("\txamarin_log_level = {0};", verbose);
 					sw.WriteLine ("\txamarin_arch_name = \"{0}\";", abi.AsArchString ());
-					sw.WriteLine ("\txamarin_marshal_managed_exception_mode = MarshalManagedExceptionMode{0};", app.MarshalManagedExceptions);
+					if (!app.IsDefaultMarshalManagedExceptionMode)
+						sw.WriteLine ("\txamarin_marshal_managed_exception_mode = MarshalManagedExceptionMode{0};", app.MarshalManagedExceptions);
 					sw.WriteLine ("\txamarin_marshal_objectivec_exception_mode = MarshalObjectiveCExceptionMode{0};", app.MarshalObjectiveCExceptions);
 					if (app.EnableDebug)
 						sw.WriteLine ("\txamarin_debug_mode = TRUE;");


### PR DESCRIPTION
Managed exception marshaling interferes with the debugger, because it adds
exception handlers to executing code, which makes the Mono runtime think an
exception is handled when logically it's not (although technically it is).

The consequence is that the IDEs will only be notified when we re-throw the
exception after catching it, making it impossible for the IDEs to stop when
the exception is thrown (they will instead stop when we re-throw the
exception).

So disable managed exception marshaling (unless the user changed the default
behavior) when a debugger is attached.

This is the same behavior as Xamarin.Android.

https://bugzilla.xamarin.com/show_bug.cgi?id=45116