### PR TITLE
[docs] Remove mention of old Xamarin.iOS version.

### DIFF
--- a/docs/website/binding_types_reference_guide.md
+++ b/docs/website/binding_types_reference_guide.md
@@ -2103,10 +2103,10 @@ attributes.
 
 ## LinkWithAttribute
 
-This is an assembly-level attribute which is being introduced with Xamarin.iOS
-5.2 and allows developers to specify the linking flags required to reuse a bound
-library without forcing the consumer of the library to manually configure the
-gcc_flags and extra mtouch arguments passed to a library.
+This is an assembly-level attribute which allows developers to specify the
+linking flags required to reuse a bound library without forcing the consumer
+of the library to manually configure the gcc_flags and extra mtouch arguments
+passed to a library.
 
 Syntax:
 


### PR DESCRIPTION
There's no need to mention that something was introduced in Xamarin.iOS 5.2.