### PR TITLE
[mtouch] Update mdb files even if the corresponding assembly didn't change. Fixes #39535.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2015,6 +2015,48 @@ class C {
 			}
 		}
 
+		[Test]
+		[TestCase (MTouchLinker.DontLink)]
+		[TestCase (MTouchLinker.LinkAll)]
+		// There shouldn't be a need to test LinkSdk as well.
+		public void OnlyDebugFileChange (MTouchLinker linker_options)
+		{
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.Profile = Profile.Unified;
+				mtouch.Verbosity = 23;
+				var tmp = mtouch.CreateTemporaryDirectory ();
+				mtouch.CreateTemporaryCacheDirectory ();
+
+				// Create a sample exe
+				var code = "public class TestApp { static void Main () { System.Console.WriteLine (typeof (ObjCRuntime.Runtime).ToString ()); } }";
+				var exe = MTouch.CompileTestAppExecutable (tmp, code, "/debug:full");
+
+				mtouch.AppPath = mtouch.CreateTemporaryDirectory ();
+				mtouch.Executable = exe;
+				mtouch.Debug = true;
+				mtouch.Linker = linker_options;
+
+				// Build app
+				mtouch.AssertExecute (MTouchAction.BuildSim);
+
+				var exePath = Path.Combine (mtouch.AppPath, Path.GetFileName (exe));
+				var mdbPath = exePath + ".mdb";
+				var exeStamp = File.GetLastWriteTimeUtc (exePath);
+				var mdbStamp = File.GetLastWriteTimeUtc (mdbPath);
+
+				// Recompile the exe, adding only whitespace. This will only change the debuf files
+				MTouch.CompileTestAppExecutable (tmp, "\n\n" + code + "\n\n", "/debug:full");
+
+				// Rebuild the app
+				mtouch.AssertExecute (MTouchAction.BuildSim);
+
+				// The mdb files should be updated, but the exe should not.
+				Assert.AreEqual (exeStamp, File.GetLastWriteTimeUtc (exePath), "exe no change");
+				Assert.IsTrue (File.Exists (mdbPath), "mdb existence");
+				Assert.AreNotEqual (mdbStamp, File.GetLastWriteTimeUtc (mdbPath), "mdb changed");
+			}
+		}
+
 #region Helper functions
 		static string CompileUnifiedTestAppExecutable (string targetDirectory, string code = null, string extraArg = "")
 		{

--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -72,11 +72,11 @@ namespace Xamarin.Bundler {
 				if (!Application.IsUptodate (source, target) && !Cache.CompareAssemblies (source, target)) {
 					copied = true;
 					Application.CopyFile (source, target);
-
-					// Do not update the .mdb unless the assembly is also copied.
-					if (copy_mdb && File.Exists (source + ".mdb"))
-						Application.UpdateFile (source + ".mdb", target + ".mdb");
 				}
+
+				// Update the mdb even if the assembly didn't change.
+				if (copy_mdb && File.Exists (source + ".mdb"))
+					Application.UpdateFile (source + ".mdb", target + ".mdb");
 
 				CopyConfigToDirectory (Path.GetDirectoryName (target));
 			} catch (Exception e) {

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -446,10 +446,18 @@ namespace Xamarin.Bundler
 						cached_loaded.Add (a.FullPath);
 						input.Add (a.FullPath);
 						output.Add (Path.Combine (PreBuildDirectory, a.FileName));
+						if (File.Exists (a.FullPath + ".mdb")) {
+							// Debug files can change without the assemblies themselves changing
+							// This should also invalidate the cached linker results, since the non-linked mdbs can't be copied.
+							input.Add (a.FullPath + ".mdb");
+							output.Add (Path.Combine (PreBuildDirectory, a.FileName) + ".mdb");
+						}
+						
 						if (a.Satellites != null) {
 							foreach (var s in a.Satellites) {
 								input.Add (s);
 								output.Add (Path.Combine (PreBuildDirectory, Path.GetFileName (Path.GetDirectoryName (s)), Path.GetFileName (s)));
+								// No need to copy satellite mdb files, satellites are resource-only assemblies.
 							}
 						}
 					}


### PR DESCRIPTION
Update mdb files even if the corresponding assembly didn't change, because the
mdb can change even if the assembly didn't (if whitespace was modified in the
source code, causing code lines to move).

https://bugzilla.xamarin.com/show_bug.cgi?id=39535