### PR TITLE
[mtouch] Don't link native libraries into the main executable if we're doing an incremental build. Fixes #42473.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -825,6 +825,12 @@ namespace Xamarin
 					Registrar = MTouchRegistrar.Static,
 				};
 				Assert.AreEqual (0, mtouch.Execute (MTouchAction.BuildDev), "build");
+
+				var symbols = ExecutionHelper.Execute ("nm", Quote (mtouch.NativeExecutablePath), hide_output: true).Split ('\n');
+				Assert.That (symbols, Has.None.EndsWith (" T _theUltimateAnswer"), "Binding symbol not in executable");
+
+				symbols = ExecutionHelper.Execute ("nm", Quote (Path.Combine (mtouch.AppPath, "libbindings-test.dll.dylib")), hide_output: true).Split ('\n');
+				Assert.That (symbols, Has.Some.EndsWith (" T _theUltimateAnswer"), "Binding symbol in binding library");
 			} finally {
 				Directory.Delete (testDir, true);
 			}

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -803,7 +803,8 @@ namespace Xamarin.Bundler
 			// Collect all LinkWith flags and frameworks from all assemblies.
 			foreach (var a in Assemblies) {
 				compiler_flags.AddFrameworks (a.Frameworks, a.WeakFrameworks);
-				compiler_flags.AddLinkWith (a.LinkWith, a.ForceLoad);
+				if (!App.FastDev)
+					compiler_flags.AddLinkWith (a.LinkWith, a.ForceLoad);
 				compiler_flags.AddOtherFlags (a.LinkerFlags);
 			}
 


### PR DESCRIPTION
Native libraries are already linked into the dylib for the binding assembly,
which means that if we also link it into the main executable, the native code
ends up twice in the app (which is bad for many reasons).

https://bugzilla.xamarin.com/show_bug.cgi?id=42473