### PR TITLE
[Mac][45526] Add missing NSUserNotificationActivationType enum types

### DIFF
--- a/src/Foundation/EnumDesktop.cs
+++ b/src/Foundation/EnumDesktop.cs
@@ -99,7 +99,9 @@ namespace XamCore.Foundation {
 	public enum NSUserNotificationActivationType : nint {
 		None = 0,
 		ContentsClicked = 1,
-		ActionButtonClicked = 2
+		ActionButtonClicked = 2,
+		Replied = 3,
+		AdditionalActionClicked = 4
 	}
 
 	[Mac (10,11)]


### PR DESCRIPTION
Add missing enum types.  Bug 45526