### PR TITLE
[Foundation] Adds single object notifications to Notifications class

### DIFF
--- a/docs/website/binding_types_reference_guide.md
+++ b/docs/website/binding_types_reference_guide.md
@@ -1377,6 +1377,7 @@ public class MyClass {
    [..]
    public Notifications {
       public static NSObject ObserveDidStart (EventHandler<NSNotificationEventArgs> handler)
+      public static NSObject ObserveDidStart (NSObject objectToObserve, EventHandler<NSNotificationEventArgs> handler)
    }
 }
 ```
@@ -1389,6 +1390,14 @@ by using code like this:
 ```
 var token = MyClass.Notifications.ObserverDidStart ((notification) => { 
     Console.WriteLine ("Observed the 'DidStart' event!");
+});
+```
+
+Or to set a specific object to observe. If you pass `null` to `objectToObserve` this method will behave just like its other peer.
+
+```
+var token = MyClass.Notifications.ObserverDidStart (objectToObserve, (notification) => { 
+    Console.WriteLine ("Observed the 'DidStart' event on objectToObserve!");
 });
 ```
 

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -6371,6 +6371,9 @@ public partial class Generator : IMemberGatherer {
 					if (Generator.HasAttribute (field_pi, typeof (AdvancedAttribute))){
 						print ("[EditorBrowsable (EditorBrowsableState.Advanced)]");
 					}
+					// Check if this is a notification and print Advice to use our Notification API
+					if (HasAttribute (field_pi, typeof (NotificationAttribute)))
+						print ($"[Advice (\"Use {type.Name}.Notifications.Observe{GetNotificationName (field_pi)} helper method instead.\")]");
 					
 					print ("{0} static unsafe {1} {2}{3} {{", field_pi.IsInternal () ? "internal" : "public", fieldTypeName,
 					       field_pi.Name,
@@ -6957,6 +6960,10 @@ public partial class Generator : IMemberGatherer {
 						print ("\tpublic static NSObject Observe{0} (EventHandler<{1}> handler)", notification_name, event_name);
 						print ("\t{");
 						print ("\t\treturn {0}.AddObserver ({1}, notification => handler (null, new {2} (notification)));", notification_center, property.Name, event_name);
+						print ("\t}");
+						print ("\tpublic static NSObject Observe{0} (NSObject objectToObserve, EventHandler<{1}> handler)", notification_name, event_name);
+						print ("\t{");
+						print ("\t\treturn {0}.AddObserver ({1}, notification => handler (null, new {2} (notification)), objectToObserve);", notification_center, property.Name, event_name);
 						print ("\t}");
 					}
 				}

--- a/tests/monotouch-test/Foundation/NotificationCenter.cs
+++ b/tests/monotouch-test/Foundation/NotificationCenter.cs
@@ -98,5 +98,21 @@ namespace MonoTouchFixtures.Foundation {
 			}
 	
 		}
+
+#if XAMCORE_2_0 && __IOS__
+		[Test]
+		public void TargetedNotificationsTest ()
+		{
+			bool called = false;
+			using (var txt = new global::UIKit.UITextField ())
+			using (var notification = global::UIKit.UITextField.Notifications.ObserveTextFieldTextDidChange (txt, (sender, e) => called = true)) {
+				NSNotificationCenter.DefaultCenter.PostNotificationName (global::UIKit.UITextField.TextFieldTextDidChangeNotification, null);
+				Assert.False (called, "Notification should not be called");
+
+				NSNotificationCenter.DefaultCenter.PostNotificationName (global::UIKit.UITextField.TextFieldTextDidChangeNotification, txt);
+				Assert.True (called,  "Notification should have been called");
+			}
+		}
+#endif
 	}
 }


### PR DESCRIPTION
Trello: https://trello.com/c/mKsUDti8

This adds a new overload to our Notifications class

Current:

public static NSObject ObserveDidStart (EventHandler<NSNotificationEventArgs> handler)

New overload:

public static NSObject ObserveDidStart (NSObject objectToObserve, EventHandler<NSNotificationEventArgs> handler)

This allows our users to have single object subscription to our
easy to find notifications.

Build diff: https://gist.github.com/dalexsoto/e8063081adff44e03642726646648582