### PR TITLE
[msbuild] Allow Provisioning Profile lookups by name and use only the…

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
@@ -448,13 +448,13 @@ namespace Xamarin.MacDev.Tasks
 
 			if (identity.BundleId != null) {
 				if (certs.Count > 0)
-					profiles = MobileProvisionIndex.GetMobileProvisions (platform, identity.BundleId, type, certs);
+					profiles = MobileProvisionIndex.GetMobileProvisions (platform, identity.BundleId, type, certs, unique: true);
 				else
-					profiles = MobileProvisionIndex.GetMobileProvisions (platform, identity.BundleId, type);
+					profiles = MobileProvisionIndex.GetMobileProvisions (platform, identity.BundleId, type, unique: true);
 			} else if (certs.Count > 0) {
-				profiles = MobileProvisionIndex.GetMobileProvisions (platform, type, certs);
+				profiles = MobileProvisionIndex.GetMobileProvisions (platform, type, certs, unique: true);
 			} else {
-				profiles = MobileProvisionIndex.GetMobileProvisions (platform, type);
+				profiles = MobileProvisionIndex.GetMobileProvisions (platform, type, unique: true);
 			}
 
 			List<CodeSignIdentity> pairs;


### PR DESCRIPTION
… most recent version

Use the 'unique' argument to MobileProvisionIndex's lookup methods
to only get back the most recent versions of each provisioning
profile so that we don't accidentally pick an older version.