### PR TITLE
[msbuild] Fixed IsWatchExtension state property (#913)

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.Common.props
@@ -24,10 +24,6 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<_XamarinWatchOSAppExtensionCommonPropsHasBeenImported>true</_XamarinWatchOSAppExtensionCommonPropsHasBeenImported>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<_IsWatchExtension>true</_IsWatchExtension>
-	</PropertyGroup>
-
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.props"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.props')"/>
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.Common.targets
@@ -17,6 +17,7 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<IsAppExtension>True</IsAppExtension>
+		<IsWatchExtension>True</IsWatchExtension>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)..\iOS\Xamarin.iOS.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.Common.targets
@@ -17,6 +17,7 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<IsAppExtension>True</IsAppExtension>
+		<IsWatchExtension>False</IsWatchExtension>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
@@ -55,6 +55,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<MtouchTargetsEnabled>$(IsMacEnabled)</MtouchTargetsEnabled>
 
 		<IsAppExtension Condition="'$(IsAppExtension)' == ''">False</IsAppExtension>
+		<IsWatchExtension Condition="'$(IsWatchExtension)' == ''">False</IsWatchExtension>
 		<IsWatchApp Condition="'$(IsWatchApp)' == ''">False</IsWatchApp>
 		<OptimizePNGs Condition="'$(OptimizePNGs)' == ''">True</OptimizePNGs>
 		<OptimizePropertyLists Condition="'$(OptimizePropertyLists)' == ''">True</OptimizePropertyLists>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -593,10 +593,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<Target Name="GetAppBundleDir" DependsOnTargets="_GenerateBundleName" Returns="$(AppBundleDir)"/>
 
-	<PropertyGroup>
-		<_IsWatchExtension Condition="'$(_IsWatchExtension)' == ''">false</_IsWatchExtension>
-	</PropertyGroup>
-
 	<Target Name="_CompileAppManifest"
 		DependsOnTargets="_DetectSdkLocations;_DetectAppManifest;_GenerateBundleName;_DetectSigningIdentity;_PrepareResourceRules;_ResolveWatchAppReferences;_DetectDebugNetworkConfiguration"
 		Inputs="$(_AppManifest);@(_PartialAppManifest)"
@@ -614,7 +610,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			DefaultSdkVersion="$(MtouchSdkVersion)"
 			IsAppExtension="$(IsAppExtension)"
 			IsWatchApp="$(IsWatchApp)"
-			IsWatchExtension="$(_IsWatchExtension)"
+			IsWatchExtension="$(IsWatchExtension)"
 			PartialAppManifests="@(_PartialAppManifest)"
 			ResourceRules="$(_PreparedResourceRules)"
 			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
@@ -1469,7 +1465,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			 Condition="'@(_WatchAppReferenceWithConfigurationNonExistent)' != ''"/>
 
 		<PropertyGroup>
-			<_IsWatchExtension Condition="'@(_ResolvedWatchAppReferences)' != ''">true</_IsWatchExtension>
+			<IsWatchExtension Condition="'$(IsAppExtension)' == 'true' And '@(_ResolvedWatchAppReferences)' != ''">True</IsWatchExtension>
 		</PropertyGroup>
 	</Target>
 

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/WatchKit.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/WatchKit.cs
@@ -38,7 +38,7 @@ namespace Xamarin.iOS.Tasks {
 				Engine.GlobalProperties.SetProperty ("Platform", Platform);
 				AppBundlePath = mtouchPaths ["app_bundlepath"];
 				RunTarget (proj, "Build", 2);
-				Assert.AreEqual ("The App Extension WatchExtension has an invalid CFBundleIdentifier (com.xamarin.MyWatchApp.WatchExtension), it does not begin with the main app bundle's CFBundleIdentifier (com.xamarin.MyWatchAppX).", Engine.Logger.ErrorEvents [0].Message, "#1");
+				Assert.AreEqual ("The App Extension 'WatchExtension' has an invalid CFBundleIdentifier (com.xamarin.MyWatchApp.WatchExtension), it does not begin with the main app bundle's CFBundleIdentifier (com.xamarin.MyWatchAppX).", Engine.Logger.ErrorEvents [0].Message, "#1");
 				Assert.AreEqual ("The Watch App 'WatchApp' has an invalid WKCompanionAppBundleIdentifier value ('com.xamarin.MyWatchApp'), it does not match the main app bundle's CFBundleIdentifier ('com.xamarin.MyWatchAppX').", Engine.Logger.ErrorEvents [1].Message, "#2");
 			}
 		}


### PR DESCRIPTION
The problem was that this property was evaluating to True for the main app bundle because it assumed that if the project contained a Watch app, that it was the WatchExtension.

This logic only holds true for WatchOS1, but not WatchOS2.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=44841

Also fixes https://bugzilla.xamarin.com/show_bug.cgi?id=46266 because this fix wasn't backported to cycle8.