### PR TITLE
[mtouch] Update the timestamp for the simlauncher when copying it into the app.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1065,6 +1065,22 @@ namespace Xamarin
 		}
 
 		[Test]
+		[TestCase (Profile.Unified)]
+		public void FastSim (Profile profile)
+		{
+			using (var tool = new MTouchTool ()) {
+				tool.Verbosity = 1;
+				tool.Profile = profile;
+				tool.CreateTemporaryApp ();
+				tool.Linker = MTouchLinker.DontLink;
+				tool.Debug = true;
+				tool.AssertExecute (MTouchAction.BuildSim);
+				tool.AssertOutputPattern ("was built using fast-path for simulator"); // This is just to ensure we're actually testing fastsim. If this fails, modify the mtouch options to make this test use fastsim again.
+				Assert.That (File.GetLastWriteTimeUtc (tool.Executable), Is.LessThan (File.GetLastWriteTimeUtc (tool.NativeExecutablePath)), "simlauncher timestamp");
+			}
+		}
+
+		[Test]
 		[TestCase (Target.Dev, "armv7")]
 		[TestCase (Target.Dev, "armv7s")]
 		[TestCase (Target.Dev, "armv7,armv7s")]

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -929,6 +929,7 @@ namespace Xamarin.Bundler
 					launcher.Append ("64");
 				launcher.Append ("-sgen");
 				File.Copy (launcher.ToString (), Executable);
+				File.SetLastWriteTime (Executable, DateTime.Now);
 			} catch (MonoTouchException) {
 				throw;
 			} catch (Exception ex) {


### PR DESCRIPTION
This makes sure that the final executable has a timestamp after the .exe,
which makes the MSBuild tasks able to avoid unnecessary rebuilds.