### PR TITLE
[uikit] Small update for Xcode 8.2 beta 1

### DIFF
--- a/src/UIKit/UIEnums.cs
+++ b/src/UIKit/UIEnums.cs
@@ -1949,7 +1949,13 @@ namespace XamCore.UIKit {
 		Next
 	}
 
-	[iOS (10,0), TV (10,0), NoWatch]
+#if XAMCORE_4_0
+	[NoTV]
+#else
+	// Xcode 8.2 beta 1 added __TVOS_PROHIBITED but we need to keep it for binary compatibility
+	[TV (10,0)]
+#endif
+	[iOS (10,0)][NoWatch]
 	[Native]
 	[Flags]
 	public enum UICloudSharingPermissionOptions : nuint {

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -217,7 +217,7 @@ namespace XamCore.UIKit {
 	[iOS (10,0), NoTV, NoWatch]
 	delegate void UICloudSharingControllerPreparationCompletionHandler ([NullAllowed] CKShare share, [NullAllowed] CKContainer container, [NullAllowed] NSError error);
 
-	[iOS (10,0), NoTV, NoWatch] //TODO: This is marked as available on tvOS 10 but it isn't radar: 27929711
+	[iOS (10,0), NoTV, NoWatch]
 	[BaseType (typeof (UIViewController))]
 	interface UICloudSharingController {
 


### PR DESCRIPTION
* UICloudSharingPermissionOptions is not part in watchOS. It's an enum so
  it's not a big issue (worth a breaking change) -> XAMCORE_4_0

* Remove TODO on UICloudSharingController as Apple fixed our rdar 27929711