### PR TITLE
[watchos][passkit] Small update for Xcode 8.2 beta 1

### DIFF
--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -113,7 +113,7 @@ namespace XamCore.PassKit {
 		bool CanAddPaymentPass (string primaryAccountIdentifier);
 
 		[iOS (10,1)]
-		[NoWatch] // Radar: https://trello.com/c/MvaHEZlc
+		[Watch (3,1)]
 		[Export ("canAddFelicaPass")]
 		bool CanAddFelicaPass { get; }
 


### PR DESCRIPTION
As suspected CanAddFelicaPass is part of watchOS 3.1, closing our
reported rdar 28608634