### PR TITLE
[watchos][watchkit] Small updates for Xcode 8.2 beta 1

### DIFF
--- a/src/watchkit.cs
+++ b/src/watchkit.cs
@@ -66,7 +66,8 @@ namespace XamCore.WatchKit {
 		[Export ("handleActionWithIdentifier:forLocalNotification:")]
 		void HandleLocalNotificationAction ([NullAllowed] string identifier, UILocalNotification localNotification);
 
-		[Watch (3,0)][iOS (10,0)]
+		[iOS (10,0)]
+		[NoWatch]
 		[Export ("handleActionWithIdentifier:forNotification:")]
 		void HandleAction ([NullAllowed] string identifier, UNNotification notification);
 
@@ -1020,7 +1021,7 @@ namespace XamCore.WatchKit {
 		bool ReturnToDefaultState { get; }
 
 		[Export ("setTaskCompletedWithDefaultStateRestored:estimatedSnapshotExpiration:userInfo:")]
-		void SetTaskCompleted (bool restoredDefaultState, NSDate estimatedSnapshotExpiration, [NullAllowed] INSSecureCoding userInfo);
+		void SetTaskCompleted (bool restoredDefaultState, [NullAllowed] NSDate estimatedSnapshotExpiration, [NullAllowed] INSSecureCoding userInfo);
 	}
 
 	[Watch (3,0)][NoiOS]


### PR DESCRIPTION
Normally the removal of `HandleAction` would be a breaking change (and
require a stub). However Xamarin.WatchOS.dll is not final before C9 so
this fix will be backported to `master` and `cycle9` branches.