### PR TITLE
[generator] Copy [Obsolete] attributes on smart enums. Fixes #46292

### DIFF
--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -55,6 +55,12 @@ public partial class Generator {
 		}
 	}
 
+	void CopyObsolete (ICustomAttributeProvider provider)
+	{
+		foreach (ObsoleteAttribute oa in provider.GetCustomAttributes (typeof (ObsoleteAttribute), false))
+			print ("[Obsolete (\"{0}\", {1})]", oa.Message, oa.IsError ? "true" : "false");
+	}
+
 	// caller already:
 	//	- setup the header and namespace
 	//	- call/emit PrintPlatformAttributes on the type
@@ -70,6 +76,7 @@ public partial class Generator {
 			else
 				print ("[Native (\"{0}\")]", native.NativeName);
 		}
+		CopyObsolete (type);
 
 		var unique_constants = new HashSet<string> ();
 		var fields = new Dictionary<FieldInfo, FieldAttribute> ();
@@ -83,6 +90,7 @@ public partial class Generator {
 			if (f.IsSpecialName)
 				continue;
 			PrintPlatformAttributes (f);
+			CopyObsolete (f);
 			print ("{0} = {1},", f.Name, f.GetRawConstantValue ());
 			var fa = GetAttribute<FieldAttribute> (f);
 			if (fa == null)

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -121,6 +121,17 @@ bug35176:
 		echo "Error: Expected 4 Introduced attributes in generated code."; exit 1; \
 	fi
 
+bug46292:
+	@rm -Rf $@.tmpdir
+	@mkdir -p $@.tmpdir
+	$(if $(V),,@echo "$@";) $(IOS_GENERATOR) --sourceonly:$@.source -tmpdir=$@.tmpdir $@.cs --process-enums
+	@if ! grep -r Obsolete bug46292.tmpdir/BindingTests > /dev/null; then \
+		echo "error: Could not find Obsolete attribute in generated code."; exit 1; \
+	fi
+	@if [ `grep -r Obsolete bug46292.tmpdir/BindingTests | wc -l` -ne 2 ]; then \
+		echo "Error: Expected 2 Obsolete attributes in generated code."; exit 1; \
+	fi
+
 forcedtype:
 	@rm -Rf $@.tmpdir
 	@mkdir -p $@.tmpdir

--- a/tests/generator/bug46292.cs
+++ b/tests/generator/bug46292.cs
@@ -1,0 +1,13 @@
+using System;
+using MonoTouch.Foundation;
+
+namespace BindingTests {
+	[Obsolete ("Type level obsolete must also be copied")]
+	public enum HMAccessoryCategoryType : int {
+		[Field ("HMAccessoryCategoryTypeGarageDoorOpener")]
+		GarageDoorOpener = 0,
+
+		[Obsolete ("Use GarageDoorOpener")]
+		DoorOpener = GarageDoorOpener,
+	}
+}


### PR DESCRIPTION
Covers attributes on the type itself and on its members.

Reference:
* https://bugzilla.xamarin.com/show_bug.cgi?id=46292