### PR TITLE
[tvos][storekit] Small update for Xcode 8.2 beta 1

### DIFF
--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -473,7 +473,8 @@ namespace XamCore.StoreKit {
 		NSString CloudServiceCapabilitiesDidChangeNotification { get; }
 	}
 
-	[NoTV, iOS (10,1)]
+	[iOS (10,1)]
+	[NoTV] // __TVOS_PROHIBITED
 	[BaseType (typeof(UIViewController))]
 	interface SKCloudServiceSetupViewController
 	{
@@ -491,7 +492,8 @@ namespace XamCore.StoreKit {
 
 	interface ISKCloudServiceSetupViewControllerDelegate {}
 
-	[NoTV, iOS (10,1)]
+	[iOS (10,1)]
+	[NoTV] // __TVOS_PROHIBITED on the only member + SKCloudServiceSetupViewController is not in tvOS
 	[Protocol, Model]
 	[BaseType (typeof(NSObject))]
 	interface SKCloudServiceSetupViewControllerDelegate

--- a/tests/xtro-sharpie/tvos.ignore
+++ b/tests/xtro-sharpie/tvos.ignore
@@ -284,6 +284,13 @@
 ## but the delegate itself is not marked (so it's reported as missing)
 !missing-protocol! SKStoreProductViewControllerDelegate not bound
 
+## SKCloudServiceSetupViewController is not in tvOS and the only member of the delegate is not either
+## but the delegate itself is not marked (so it's reported as missing)
+!missing-field! SKCloudServiceSetupActionSubscribe not bound
+!missing-field! SKCloudServiceSetupOptionsActionKey not bound
+!missing-field! SKCloudServiceSetupOptionsITunesItemIdentifierKey not bound
+!missing-protocol! SKCloudServiceSetupViewControllerDelegate not bound
+
 
 # UIKit
 


### PR DESCRIPTION
Effectively there's no API change, but a new (for tvOS) header was added
even if it does not include stuff added to tvOS. This requires a few
updates for xtro to gives correct results.

Also added comments in bindings since this makes things clearer.