### PR TITLE
Set max mono version to Cycle 9's mono.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -54,7 +54,7 @@ XCODE_DEVELOPER_ROOT=/Applications/Xcode81.app/Contents/Developer
 
 # Minimum Mono version
 MIN_MONO_VERSION=4.8.0.269
-MAX_MONO_VERSION=4.9.99
+MAX_MONO_VERSION=4.8.99
 MIN_MONO_URL=http://bosstoragemirror.blob.core.windows.net/wrench/mono-4.8.0/e5/e51aa0a7043a8185e264d6332ac7bc1f8f87cd39/MonoFramework-MDK-4.8.0.269.macos10.xamarin.universal.pkg
 
 # Minimum Xamarin Studio version


### PR DESCRIPTION
That way we don't have to worry about any breaking changes in later versions
of Mono interfering with this release branch.