### PR TITLE
[Foundation] Ensure that the auth header is not null in the HttpClient.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -337,8 +337,8 @@ namespace Foundation {
 				// header, it means that we do not have the correct credentials, in any other case just do what it is expected.
 				
 				if (challenge.PreviousFailureCount == 0) {
-					var authHeader = GetInflightData (task).Request.Headers.Authorization;
-					if (!(string.IsNullOrEmpty (authHeader.Scheme) && string.IsNullOrEmpty (authHeader.Parameter))) {
+					var authHeader = GetInflightData (task)?.Request?.Headers?.Authorization;
+					if (!(string.IsNullOrEmpty (authHeader?.Scheme) && string.IsNullOrEmpty (authHeader?.Parameter))) {
 						completionHandler (NSUrlSessionAuthChallengeDisposition.RejectProtectionSpace, null);
 						return;
 					}


### PR DESCRIPTION
The auth header is not guaranteed not to be null and therefore we need
to be careful or an uncachable exception will be thrown.