### PR TITLE
[msbuild] Fix Metal project builds with msbuild for XI/XM

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -338,13 +338,13 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_DetectSdkLocations">
 		<Metal
-			Condition="'$(IsMacEnabled)' == 'true'"
+			Condition="'$(IsMacEnabled)' == 'true' and '%(Metal.Identity)' != ''"
 			SessionId="$(BuildSessionId)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(XamMacResourcePrefix)"
 			SdkDevPath="$(_SdkDevPath)"
-			SourceFile="%(Metal.Identity)">
+			SourceFile="@(Metal)">
 			<Output TaskParameter="OutputFile" ItemName="_SmeltedMetal" />
 		</Metal>
 	</Target>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -476,12 +476,12 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<Metal
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true'"
+			Condition="'$(IsMacEnabled)' == 'true' and '%(Metal.Identity)' != ''"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(IPhoneResourcePrefix)"
 			SdkDevPath="$(_SdkDevPath)"
-			SourceFile="%(Metal.Identity)">
+			SourceFile="@(Metal)">
 			<Output TaskParameter="OutputFile" ItemName="_SmeltedMetal" />
 		</Metal>
 	</Target>


### PR DESCRIPTION
Building `MetalKitEssentials.Mac` project from `mac-ios-samples` repo with
msbuild fails with:

```
"/Users/ankit/dev/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.Mac/MetalKitEssentials.Mac.csproj" (default target) (1) ->
(_SmeltMetal target) ->
  /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/Xamarin.Mac.Common.targets : error : Tool exited with code: 1. Output: warning: unable to open file obj/Debug/metal/../../../../../../../Users/ankit/dev/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.Mac/Resources/Shaders.dia for serializing diagnostics (Error opening output file 'obj/Debug/metal/../../../../../../../Users/ankit/dev/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.Mac/Resources/Shaders.dia': No such file or directory) [-Wserialized-diagnostics] [/Users/ankit/dev/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.Mac/MetalKitEssentials.Mac.csproj]
/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/Xamarin.Mac.Common.targets : error : warning: '-std=osx-metal1.0' is equivalent to '-std=osx-metal1.1' [/Users/ankit/dev/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.Mac/MetalKitEssentials.Mac.csproj]
/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/Xamarin.Mac.Common.targets : error : error: unable to open output file 'obj/Debug/metal/../../../../../../../Users/ankit/dev/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.Mac/Resources/Shaders.air': 'Error opening output file 'obj/Debug/metal/../../../../../../../Users/ankit/dev/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.Mac/Resources/Shaders.air': No such file or directory' [/Users/ankit/dev/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.Mac/MetalKitEssentials.Mac.csproj]
```

The path
`obj/Debug/metal/../../../../../../../Users/ankit/dev/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.Mac/Resources/Shaders.dia`
should be just `Resources/Shaders.dia`. This is from the `@(Metal)` item
passed to the `Metal` task as:

	<Metal SourceFile="%(Metal.Identity)" ..

- This item is defined in the user's project file.
- And the task invocation is in
	`/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/Xamarin.Mac.Common.targets`.

- The `Metal` task (indirectly[2]) uses the `DefiningProjectFullPath`
  metadata from that `SoureFile`, and expects to get the path to the
  file that defined that `@(Metal)` item. But since we are using
  `%(Metal.Identity)`, to use task batching, msbuild converts the
  `%(Metal.Identity)` to a string and then "boxes" that as an ITaskItem,
  and thus newly created item passed to `SourceFile` will have
  `DefiningProjectFullPath` set to the `Xamarin.Mac.Common.targets`!

- And trying to create a relative path using that gives us
  `obj/Debug/metal/../../../../../../../Users/ankit/dev/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.Mac/Resources/Shaders.dia`

- The fix is to use `'%(Metal.Identity)` in the `Condition` to cause
  task batching, but use `SourceFile="@(Metal)"` so that we get the
  original item!

- Fixed for iOS targets too

---
1. The actual code is in `BundleResources.GetVirtualProjectPath`.
   Other tasks using this were looked at and they are all using
   `ITaskItem[]` and so passing `@(Items)` and thus get the original
   items.

2. And the build works in xbuild, because it has `DefiningProjectFullPath`
   for the "boxed" item set to `""`. And `GetVirtualProjectPath` works
   around that.