### PR TITLE
[mtouch] Add workarounds for file descriptor leak in System.Diagnostics.Process.

### DIFF
--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -1376,6 +1376,8 @@ class CTP4 : CTP3 {
 				};
 				p.WaitForExit ();
 				
+				GC.Collect (); // Workaround for: https://bugzilla.xamarin.com/show_bug.cgi?id=43462#c14
+
 				Console.WriteLine (output);
 				
 				if (p.ExitCode != 0)

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -172,6 +172,8 @@ namespace Xamarin.Bundler {
 				stderr_completed.WaitOne (TimeSpan.FromSeconds (1));
 				stdout_completed.WaitOne (TimeSpan.FromSeconds (1));
 
+				GC.Collect (); // Workaround for: https://bugzilla.xamarin.com/show_bug.cgi?id=43462#c14
+
 				if (p.ExitCode != 0) {
 					// note: this repeat the failing command line. However we can't avoid this since we're often
 					// running commands in parallel (so the last one printed might not be the one failing)

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1741,6 +1741,8 @@ namespace Xamarin.Bundler {
 				stderr_completed.WaitOne (TimeSpan.FromSeconds (1));
 				stdout_completed.WaitOne (TimeSpan.FromSeconds (1));
 
+				GC.Collect (); // Workaround for: https://bugzilla.xamarin.com/show_bug.cgi?id=43462#c14
+
 				if (p.ExitCode != 0)
 					return p.ExitCode;
 

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1590,6 +1590,9 @@ namespace Xamarin.Bundler
 				RedirectStream (p.StandardError, new StreamWriter (Console.OpenStandardError ()));
 
 				p.WaitForExit ();
+
+				GC.Collect (); // Workaround for: https://bugzilla.xamarin.com/show_bug.cgi?id=43462#c14
+
 				return p.ExitCode;
 			}
 		}


### PR DESCRIPTION
This is a backport of these commits from master: 4d06d05c, 1fdd17e6 and 39ec76e.

It fixes this mtouch test:

    1) Test Error : MTouchTests.MTouch.ScriptedTests

        [...]
        error MT0000: Unexpected error - Please file a bug report at http://bugzilla.xamarin.com
        System.IO.IOException: Too many open files
          at System.Diagnostics.Process.CreatePipe (System.IntPtr& read, System.IntPtr& write, System.Boolean writeDirection) [0x00094] in /private/tmp/source-mono-4.6.0-c8sr0/bockbuild-mono-4.6.0-branch-c8sr0/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/System/System.Diagnostics/Process.cs:659
          at System.Diagnostics.Process.StartWithCreateProcess (System.Diagnostics.ProcessStartInfo startInfo) [0x0012c] in /private/tmp/source-mono-4.6.0-c8sr0/bockbuild-mono-4.6.0-branch-c8sr0/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/System/System.Diagnostics/Process.cs:716