### PR TITLE
[mediaplayer] Enable MediaPlayer on macOS

### DIFF
--- a/src/Constants.mac.cs.in
+++ b/src/Constants.mac.cs.in
@@ -123,5 +123,6 @@ namespace MonoMac {
 		// macOS 10.12
 		public const string PhotosLibrary = "/System/Library/Frameworks/Photos.framework/Photos";
 		public const string IntentsLibrary = "/System/Library/Frameworks/Intents.framework/Intents";
+		public const string MediaPlayerLibrary = "/System/Library/Frameworks/MediaPlayer.framework/MediaPlayer";
 	}
 }

--- a/src/MediaPlayer/MPMediaItem.cs
+++ b/src/MediaPlayer/MPMediaItem.cs
@@ -9,7 +9,7 @@
 // Copyright 2011-2012 Xamarin, Inc
 //
 
-#if !TVOS
+#if !TVOS && !MONOMAC
 
 using System;
 using System.Collections;

--- a/src/MediaPlayer/MPMediaQuery.cs
+++ b/src/MediaPlayer/MPMediaQuery.cs
@@ -9,7 +9,7 @@
 // Copyright 2011-2012, 2014-2015 Xamarin, Inc
 //
 
-#if !TVOS
+#if !TVOS && !MONOMAC
 
 using System;
 using XamCore.Foundation; 

--- a/src/MediaPlayer/MPNowPlayingInfoCenter.cs
+++ b/src/MediaPlayer/MPNowPlayingInfoCenter.cs
@@ -7,7 +7,7 @@
 // Copyright 2011, Xamarin Inc
 //
 
-#if !TVOS
+#if !TVOS && !MONOMAC
 
 using XamCore.Foundation;
 using XamCore.ObjCRuntime;

--- a/src/MediaPlayer/MPPlayableContentDelegate.cs
+++ b/src/MediaPlayer/MPPlayableContentDelegate.cs
@@ -1,4 +1,4 @@
-﻿#if !XAMCORE_3_0
+﻿#if !XAMCORE_3_0 && !MONOMAC
 	
 using System;
 using XamCore.Foundation;

--- a/src/MediaPlayer/MPVolumeSettings.cs
+++ b/src/MediaPlayer/MPVolumeSettings.cs
@@ -6,7 +6,7 @@
 // Copyright 2011-2015 Xamarin, Inc.
 //
 
-#if !TVOS
+#if !TVOS && !MONOMAC
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/MediaPlayer/MediaPlayer.cs
+++ b/src/MediaPlayer/MediaPlayer.cs
@@ -16,6 +16,7 @@ namespace XamCore.MediaPlayer {
 
 	// NSInteger -> MPMoviePlayerController.h
 	[Native]
+	[NoMac]
 	[NoTV]
 	public enum MPMoviePlaybackState : nint {
 		Stopped,
@@ -28,6 +29,7 @@ namespace XamCore.MediaPlayer {
 
 	// NSInteger -> MPMoviePlayerController.h
 	[Native]
+	[NoMac]
 	[NoTV]
 	public enum MPMovieLoadState : nint {
 		Unknown        = 0,
@@ -37,6 +39,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	// NSInteger -> MPMoviePlayerController.h
+	[NoMac]
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[Native]
@@ -46,6 +49,7 @@ namespace XamCore.MediaPlayer {
 
 	// NSInteger -> MPMoviePlayerController.h
 	[Native]
+	[NoMac]
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	public enum MPMovieControlStyle : nint {
@@ -53,6 +57,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	// NSInteger -> MPMoviePlayerController.h
+	[NoMac]
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[Native]
@@ -61,6 +66,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	// NSInteger -> MPMoviePlayerController.h
+	[NoMac]
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[Native]
@@ -72,6 +78,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	// NSInteger -> MPMoviePlayerController.h
+	[NoMac]
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[Native]
@@ -80,6 +87,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	// NSInteger -> MPMoviePlayerController.h
+	[NoMac]
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[Native]
@@ -89,6 +97,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	// NSUInteger -> MPMediaItem.h
+	[NoMac]
 	[Native]
 	[Flags]
 	[NoTV]
@@ -131,6 +140,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	// NSInteger -> MPMediaPlaylist.h
+	[NoMac]
 	[Native]
 	[Flags]
 	[NoTV]
@@ -143,6 +153,7 @@ namespace XamCore.MediaPlayer {
 			
 	// NSInteger -> MPMediaQuery.h
 	[Native]
+	[NoMac]
 	[NoTV]
 	public enum MPMediaGrouping : nint {
 		Title,
@@ -157,6 +168,7 @@ namespace XamCore.MediaPlayer {
 
 	// NSInteger -> MPMediaQuery.h
 	[Native]
+	[NoMac]
 	[NoTV]
 	public enum MPMediaPredicateComparison : nint {
 		EqualsTo,
@@ -164,6 +176,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	// NSInteger -> MPMoviePlayerController.h
+	[NoMac]
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[Native]
@@ -175,6 +188,7 @@ namespace XamCore.MediaPlayer {
 	}
 	
 	// untyped enum -> MPMoviePlayerController.h
+	[NoMac]
 	public enum MPMovieControlMode {
 		Default, 
 		VolumeOnly,
@@ -182,6 +196,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	// NSInteger -> /MPMusicPlayerController.h
+	[NoMac]
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[Native]
@@ -196,6 +211,7 @@ namespace XamCore.MediaPlayer {
 	
 	// NSInteger -> /MPMusicPlayerController.h
 	[Native]
+	[NoMac]
 	[NoTV]
 	public enum MPMusicRepeatMode : nint {
 		Default,
@@ -206,6 +222,7 @@ namespace XamCore.MediaPlayer {
 	
 	// NSInteger -> /MPMusicPlayerController.h
 	[Native]
+	[NoMac]
 	[NoTV]
 	public enum MPMusicShuffleMode : nint {
 		Default,
@@ -216,6 +233,7 @@ namespace XamCore.MediaPlayer {
 
 	public delegate void MPMediaItemEnumerator (string property, NSObject value, ref bool stop);
 
+	[Mac (10,12,2)]
 	[Native]
 	public enum MPShuffleType : nint
 	{
@@ -224,6 +242,7 @@ namespace XamCore.MediaPlayer {
 		Collections
 	}
 
+	[Mac (10,12,2)]
 	[Native]
 	public enum MPRepeatType : nint
 	{
@@ -232,6 +251,7 @@ namespace XamCore.MediaPlayer {
 		All
 	}
 
+	[Mac (10,12,2)]
 	[iOS (10,0)]
 	[Native]
 	public enum MPChangeLanguageOptionSetting : nint
@@ -243,6 +263,7 @@ namespace XamCore.MediaPlayer {
 
 	// NSInteger -> MPRemoteCommand.h
 	[Native]
+	[Mac (10,12,2)]
 	[iOS (7,1)]
 	public enum MPRemoteCommandHandlerStatus : nint {
 		Success = 0,
@@ -254,12 +275,14 @@ namespace XamCore.MediaPlayer {
 
 	// NSUInteger -> MPRemoteCommandEvent.h
 	[Native]
+	[Mac (10,12,2)]
 	[iOS (7,1)]
 	public enum MPSeekCommandEventType : nuint_compat_int {
 		BeginSeeking,
 		EndSeeking
 	}
 
+	[Mac (10,12,2)]
 	[iOS (9,0)]
 	[Native]
 	public enum MPNowPlayingInfoLanguageOptionType : nuint {
@@ -267,6 +290,7 @@ namespace XamCore.MediaPlayer {
 		Legible
 	}
 
+	[NoMac]
 	[iOS (9,3)]
 	[Native]
 	[ErrorDomain ("MPErrorDomain")]
@@ -281,6 +305,7 @@ namespace XamCore.MediaPlayer {
 		Cancelled,
 	}
 
+	[NoMac]
 	[NoTV]
 	[iOS (9,3)]
 	[Native]
@@ -291,6 +316,7 @@ namespace XamCore.MediaPlayer {
 		Authorized
 	}
 
+	[Mac (10,12,2)]
 	[iOS (10,0)]
 	[Native]
 	public enum MPNowPlayingInfoMediaType : nuint
@@ -298,6 +324,19 @@ namespace XamCore.MediaPlayer {
 		None = 0,
 		Audio,
 		Video
+	}
+
+	[Mac (10,12,2)]
+	[NoiOS]
+	[NoTV]
+	[Native]
+	public enum MPNowPlayingPlaybackState : nuint
+	{
+		Unknown = 0,
+		Playing,
+		Paused,
+		Stopped,
+		Interrupted,
 	}
 
 }

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1537,6 +1537,7 @@ MAC_FRAMEWORKS =            \
 	MapKit                  \
 	MediaAccessibility      \
 	MediaLibrary 		\
+	MediaPlayer             \
 	MediaToolbox            \
 	Metal                   \
 	MetalKit                \

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -13,11 +13,16 @@ using XamCore.Foundation;
 using XamCore.CoreFoundation;
 using XamCore.CoreGraphics;
 using XamCore.CoreLocation;
+#if MONOMAC
+using XamCore.AppKit;
+#else
 using XamCore.UIKit;
+#endif
 using System;
 
 namespace XamCore.MediaPlayer {
 
+	[NoMac]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
 #if XAMCORE_2_0
@@ -47,6 +52,7 @@ namespace XamCore.MediaPlayer {
 #if XAMCORE_2_0
 	}
 
+	[NoMac]
 	[NoTV]
 	[BaseType (typeof (MPMediaEntity))]
 	interface MPMediaItem {
@@ -245,9 +251,11 @@ namespace XamCore.MediaPlayer {
 		NSString DateAddedProperty { get; }
 	}
 
+	[Mac (10,12,2)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface MPMediaItemArtwork {
+#if !MONOMAC
 		[iOS (10,0)]
 		[TV (10,0)]
 		[Export ("initWithBoundsSize:requestHandler:")]
@@ -261,15 +269,26 @@ namespace XamCore.MediaPlayer {
 		[Export ("imageWithSize:")]
 		[return: NullAllowed]
 		UIImage ImageWithSize (CGSize size);
+#else
+		[Export ("initWithBoundsSize:requestHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (CGSize boundsSize, Func<CGSize, NSImage> requestHandler);
+
+		[Export ("imageWithSize:")]
+		[return: NullAllowed]
+		NSImage ImageWithSize (CGSize size);
+#endif
 
 		[Export ("bounds")]
 		CGRect Bounds { get; }
 
+		[NoMac]
 		[Deprecated (PlatformName.iOS, 10, 0)]
 		[Export ("imageCropRect")]
 		CGRect ImageCropRectangle { get; }
 	}
 
+	[NoMac]
 	[NoTV]
 	// Objective-C exception thrown.  Name: MPMediaItemCollectionInitException Reason: -init is not supported, use -initWithItems:
 	[DisableDefaultCtor]
@@ -306,6 +325,7 @@ namespace XamCore.MediaPlayer {
 		MPMediaType MediaTypes { get; }
 	}
 
+	[NoMac]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
 	interface MPMediaLibrary : NSSecureCoding {
@@ -352,6 +372,7 @@ namespace XamCore.MediaPlayer {
 		void GetPlaylist (NSUuid uuid, [NullAllowed] MPMediaPlaylistCreationMetadata creationMetadata, Action<MPMediaPlaylist, NSError> completionHandler);
 	}
 
+#if !MONOMAC
 	[NoTV]
 	[BaseType (typeof (UIViewController), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(MPMediaPickerControllerDelegate)})]
 	interface MPMediaPickerController {
@@ -396,7 +417,9 @@ namespace XamCore.MediaPlayer {
 		[Export ("mediaPickerDidCancel:"), EventArgs ("MPMediaPickerController"), EventName ("DidCancel")]
 		void MediaPickerDidCancel (MPMediaPickerController sender);
 	}
+#endif
 
+	[NoMac]
 	[NoTV]
 	[BaseType (typeof (MPMediaItemCollection))]
 	// Objective-C exception thrown.  Name: MPMediaItemCollectionInitException Reason: -init is not supported, use -initWithItems:
@@ -438,6 +461,7 @@ namespace XamCore.MediaPlayer {
 		void AddMediaItems (MPMediaItem[] mediaItems, [NullAllowed] Action<NSError> completionHandler);
 	}
 
+	[NoMac]
 	[Static]
 	interface MPMediaPlaylistProperty {
 		[Field ("MPMediaPlaylistPropertyPersistentID")]
@@ -463,6 +487,7 @@ namespace XamCore.MediaPlayer {
 		NSString AuthorDisplayName { get; }
 	}
 
+	[NoMac]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
 	interface MPMediaQuery : NSSecureCoding, NSCopying {
@@ -552,11 +577,13 @@ namespace XamCore.MediaPlayer {
 		MPMediaQuerySection [] ItemSections { get; }
 	}
 
+	[NoMac]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
 	interface MPMediaPredicate : NSSecureCoding {
 	}
 
+	[NoMac]
 	[NoTV]
 	[BaseType (typeof (MPMediaPredicate))]
 	interface MPMediaPropertyPredicate {
@@ -576,6 +603,7 @@ namespace XamCore.MediaPlayer {
 		MPMediaPredicateComparison ComparisonType { get; }
 	}
 
+	[NoMac]
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[BaseType (typeof (NSObject))]
@@ -590,6 +618,7 @@ namespace XamCore.MediaPlayer {
 		NSData ExtendedLogData { get; }
 	}
 
+	[NoMac]
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[BaseType (typeof (NSObject))]
@@ -604,6 +633,7 @@ namespace XamCore.MediaPlayer {
 		NSData ExtendedLogData { get; }
 	}
 
+	[NoMac]
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[BaseType (typeof (NSObject))]
@@ -651,6 +681,7 @@ namespace XamCore.MediaPlayer {
 		nint DroppedVideoFrameCount { get; }
 	}
 
+	[NoMac]
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[BaseType (typeof (NSObject))]
@@ -677,12 +708,14 @@ namespace XamCore.MediaPlayer {
 		string ErrorComment { get; }
 	}
 
+	[NoMac]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	interface MPMoviePlayerFinishedEventArgs {
 		[Export ("MPMoviePlayerPlaybackDidFinishReasonUserInfoKey")]
 		MPMovieFinishReason FinishReason { get; }
 	}
 
+#if !MONOMAC
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	interface MPMoviePlayerFullScreenEventArgs {
 		[Export ("MPMoviePlayerFullscreenAnimationDurationUserInfoKey")]
@@ -703,7 +736,9 @@ namespace XamCore.MediaPlayer {
 		[Export ("MPMoviePlayerThumbnailErrorKey")]
 		NSError Error { get; }
 	}
+#endif
 
+	[NoMac]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	interface MPMoviePlayerTimedMetadataEventArgs {
 		[Export ("MPMoviePlayerTimedMetadataUserInfoKey")]
@@ -711,6 +746,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	// no [Model] yet... it can be easily created in user code (all abstract) if needed
+	[NoMac]
 	[Protocol]
 	interface MPMediaPlayback {
 		[Abstract]
@@ -762,6 +798,7 @@ namespace XamCore.MediaPlayer {
 		void EndSeeking ();
 	}
 
+#if !MONOMAC
 	[NoTV]
 	[Availability (Deprecated = Platform.iOS_9_0)]
 	[BaseType (typeof (NSObject))]
@@ -1032,7 +1069,9 @@ namespace XamCore.MediaPlayer {
 		[Notification]
 		NSString MPMoviePlayerIsAirPlayVideoActiveDidChangeNotification { get; }
 	}
+#endif
 
+	[NoMac]
 	[NoTV]
 	[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_9_0)]
 	[BaseType (typeof (NSObject))]
@@ -1059,6 +1098,7 @@ namespace XamCore.MediaPlayer {
 		NSDictionary AllMetadata { get;  }
 	}
 
+#if !MONOMAC
 	[NoTV]
 	[BaseType (typeof (UIViewController))]
 	[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_9_0)]
@@ -1075,7 +1115,9 @@ namespace XamCore.MediaPlayer {
 		[Export ("shouldAutorotateToInterfaceOrientation:")]
 		bool ShouldAutorotateToInterfaceOrientation (UIInterfaceOrientation orientation);
 	}
+#endif
 
+	[NoMac]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
 	interface MPMusicPlayerController : MPMediaPlayback {
@@ -1157,6 +1199,7 @@ namespace XamCore.MediaPlayer {
 		NSString VolumeDidChangeNotification { get; }
 	}
 
+#if !MONOMAC
 	[NoTV]
 	[BaseType (typeof (UIView))]
 	interface MPVolumeView {
@@ -1234,7 +1277,9 @@ namespace XamCore.MediaPlayer {
 		[Field ("MPVolumeViewWirelessRouteActiveDidChangeNotification")]
 		NSString WirelessRouteActiveDidChangeNotification { get; }
 	}	
+#endif
 
+	[NoMac]
 	[NoTV]
 	[Since (4,2)]
 	[BaseType (typeof (NSObject))]
@@ -1248,6 +1293,7 @@ namespace XamCore.MediaPlayer {
 		string Title { get; }
 	}
 
+	[Mac (10,12,2)]
 	[Since (5,0)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: -init is not supported, use +defaultCenter
@@ -1259,6 +1305,11 @@ namespace XamCore.MediaPlayer {
 		[Static]
 		[Export ("defaultCenter")]
 		MPNowPlayingInfoCenter DefaultCenter { get; }
+
+		[NoiOS]
+		[NoTV]
+		[Export ("playbackState", ArgumentSemantic.Assign)]
+		MPNowPlayingPlaybackState PlaybackState { get; set; }
 
 		[Internal]
  		[Field ("MPNowPlayingInfoPropertyElapsedPlaybackTime")]
@@ -1330,6 +1381,7 @@ namespace XamCore.MediaPlayer {
 		NSString PropertyIsLiveStream { get; }
 	}
 
+	[Mac (10,12,2)]
 	[Since (7,1)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // crash if used
@@ -1354,11 +1406,13 @@ namespace XamCore.MediaPlayer {
 		[Export ("title")]
 		string Title { get; set; }
 
+		[NoMac]
 		[iOS (10,0)]
 		[TV (10,0)]
 		[Export ("streamingContent")]
 		bool StreamingContent { [Bind ("isStreamingContent")] get; set; }
 
+		[NoMac]
 		[iOS (10,0)]
 		[TV (10,0)]
 		[Export ("explicitContent")]
@@ -1371,6 +1425,7 @@ namespace XamCore.MediaPlayer {
 		bool Playable { [Bind ("isPlayable")] get; set; }
 	}
 
+	[NoMac]
 	[NoTV]
 	[Since (7,1)]
 	[BaseType (typeof (NSObject))]
@@ -1400,6 +1455,7 @@ namespace XamCore.MediaPlayer {
 		[Export ("numberOfChildItemsAtIndexPath:")]
 		nint NumberOfChildItems (NSIndexPath indexPath);
 
+		[NoMac]
 		[iOS (10,0)]
 		[Async]
 		[Export ("contentItemForIdentifier:completionHandler:")]
@@ -1409,6 +1465,7 @@ namespace XamCore.MediaPlayer {
 	interface IMPPlayableContentDataSource {
 	}
 
+	[NoMac]
 	[NoTV]
 	[Since (7,1)]
 	[BaseType (typeof (NSObject))]
@@ -1432,6 +1489,7 @@ namespace XamCore.MediaPlayer {
 		void InitializePlaybackQueue (MPPlayableContentManager contentManager, [NullAllowed] MPContentItem[] contentItems, Action<NSError> completionHandler);
 	}
 
+	[NoMac]
 	[NoTV]
 	[Since (7,1)]
 	[BaseType (typeof (NSObject))]
@@ -1474,6 +1532,7 @@ namespace XamCore.MediaPlayer {
 		string[] NowPlayingIdentifiers { get; set; }
 	}
 
+	[NoMac]
 	[NoTV]
 	[iOS (8,4)]
 	[BaseType (typeof(NSObject))]
@@ -1497,6 +1556,7 @@ namespace XamCore.MediaPlayer {
 		bool EndpointAvailable { get; }
 	}
 
+	[Mac (10,12,2)]
 	[Since (7,1)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPRemoteCommands cannot be initialized externally.
@@ -1518,6 +1578,7 @@ namespace XamCore.MediaPlayer {
 		void RemoveTarget ([NullAllowed] NSObject target, Selector action);
 	}
 
+	[Mac (10,12,2)]
 	[Since (7,1)]
 	[BaseType (typeof (MPRemoteCommand))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPChangePlaybackRateCommands cannot be initialized externally.
@@ -1527,6 +1588,7 @@ namespace XamCore.MediaPlayer {
 		NSNumber[] SupportedPlaybackRates { get; set; }
 	}
 
+	[Mac (10,12,2)]
 	[iOS (8,0)]
 	[BaseType (typeof(MPRemoteCommand))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPChangeShuffleModeCommand cannot be initialized externally.
@@ -1536,6 +1598,7 @@ namespace XamCore.MediaPlayer {
 		MPShuffleType CurrentShuffleType { get; set; }
 	}
 
+	[Mac (10,12,2)]
 	[iOS (8,0)]
 	[BaseType (typeof(MPRemoteCommand))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPChangeRepeatModeCommand cannot be initialized externally.
@@ -1545,6 +1608,7 @@ namespace XamCore.MediaPlayer {
 		MPRepeatType CurrentRepeatType { get; set; }
 	}
 
+	[Mac (10,12,2)]
 	[Since (7,1)]
 	[BaseType (typeof (MPRemoteCommand))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPFeedbackCommands cannot be initialized externally.
@@ -1556,11 +1620,13 @@ namespace XamCore.MediaPlayer {
 		[Export ("localizedTitle")]
 		string LocalizedTitle { get; set; }
 
+		[NoMac]
 		[iOS (8,2)] // added in 8.2, shown as NS_AVAILABLE_IOS(8_0)
 		[Export ("localizedShortTitle")]
 		string LocalizedShortTitle { get; set; }
 	}
 
+	[Mac (10,12,2)]
 	[Since (7,1)]
 	[BaseType (typeof (MPRemoteCommand))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPRatingCommands cannot be initialized externally.
@@ -1573,6 +1639,7 @@ namespace XamCore.MediaPlayer {
 		float MinimumRating { get; set; } /* float, not CGFloat */
 	}
 
+	[Mac (10,12,2)]
 	[Since (7,1)]
 	[BaseType (typeof (MPRemoteCommand))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPSkipIntervalCommands cannot be initialized externally.
@@ -1585,6 +1652,7 @@ namespace XamCore.MediaPlayer {
 		NSArray _PreferredIntervals { get; set; }
 	}
 
+	[Mac (10,12,2)]
 	[Since (7,1)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -1660,6 +1728,7 @@ namespace XamCore.MediaPlayer {
 		MPChangePlaybackPositionCommand ChangePlaybackPositionCommand { get; }
 	}
 	
+	[Mac (10,12,2)]
 	[Since (7,1)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPRemoteCommandEvents cannot be initialized externally.
@@ -1672,6 +1741,7 @@ namespace XamCore.MediaPlayer {
 		double /* NSTimeInterval */ Timestamp { get; }
 	}
 
+	[Mac (10,12,2)]
 	[Since (7,1)]
 	[BaseType (typeof (MPRemoteCommandEvent))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPChangePlaybackRateCommandEvents cannot be initialized externally.
@@ -1681,6 +1751,7 @@ namespace XamCore.MediaPlayer {
 		float PlaybackRate { get; } // float, not CGFloat
 	}
 
+	[Mac (10,12,2)]
 	[Since (7,1)]
 	[BaseType (typeof (MPRemoteCommandEvent))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPRatingCommandEvents cannot be initialized externally.
@@ -1690,6 +1761,7 @@ namespace XamCore.MediaPlayer {
 		float Rating { get; } // float, not CGFloat
 	}
 
+	[Mac (10,12,2)]
 	[Since (7,1)]
 	[BaseType (typeof (MPRemoteCommandEvent))]
 	[DisableDefaultCtor] // Name: NSGenericException Reason: MPSeekCommandEvents cannot be initialized externally.
@@ -1699,6 +1771,7 @@ namespace XamCore.MediaPlayer {
 		MPSeekCommandEventType Type { get; }
 	}
 
+	[Mac (10,12,2)]
 	[Since (7,1)]
 	[BaseType (typeof (MPRemoteCommandEvent))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPSkipIntervalCommandEvents cannot be initialized externally.
@@ -1708,6 +1781,7 @@ namespace XamCore.MediaPlayer {
 		double /* NSTimeInterval */ Interval { get; }
 	}
 
+	[Mac (10,12,2)]
 	[Since (7,1)]
 	[BaseType (typeof (MPRemoteCommandEvent))]
 	[DisableDefaultCtor]
@@ -1717,6 +1791,7 @@ namespace XamCore.MediaPlayer {
 		bool Negative { [Bind ("isNegative")] get; }
 	}
 
+	[Mac (10,12,2)]
 	[iOS (9,0)]
 	[BaseType (typeof (MPRemoteCommandEvent))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPChangeLanguageOptionCommandEvents cannot be initialized externally.
@@ -1730,6 +1805,7 @@ namespace XamCore.MediaPlayer {
 		MPChangeLanguageOptionSetting Setting { get; }
 	}
 
+	[Mac (10,12,2)]
 	[iOS (8,0)]
 	[BaseType (typeof(MPRemoteCommandEvent))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPChangeShuffleModeCommandEvent cannot be initialized externally.
@@ -1744,6 +1820,7 @@ namespace XamCore.MediaPlayer {
 		bool PreservesShuffleMode { get; }
 	}
 
+	[Mac (10,12,2)]
 	[iOS (8,0)]
 	[BaseType (typeof(MPRemoteCommandEvent))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPChangeRepeatModeCommandEvent cannot be initialized externally.
@@ -1758,6 +1835,7 @@ namespace XamCore.MediaPlayer {
 		bool PreservesRepeatMode { get; }
 	}
 
+	[Mac (10,12,2)]
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // pre-emptive
@@ -1790,6 +1868,7 @@ namespace XamCore.MediaPlayer {
 		bool IsAutomaticAudibleLanguageOption { get; }
 	}
 
+	[Mac (10,12,2)]
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // pre-emptive
@@ -1807,6 +1886,7 @@ namespace XamCore.MediaPlayer {
 		bool AllowEmptySelection { get; }
 	}
 
+	[Mac (10,12,2)]
 	[iOS (9,0)]
 	[Static]
 	// not [Internal] since they are exposed as an NSString[] property in MPNowPlayingInfoLanguageOption
@@ -1842,12 +1922,14 @@ namespace XamCore.MediaPlayer {
 		NSString VoiceOverTranslation { get; }
 	}
 
+	[Mac (10,12,2)]
 	[iOS (9,1)]
 	[BaseType (typeof (MPRemoteCommand))]
 	[DisableDefaultCtor] // Objective-C exception thrown.  Name: NSGenericException Reason: MPChangePlaybackPositionCommands cannot be initialized externally.
 	interface MPChangePlaybackPositionCommand {
 	}
 
+	[Mac (10,12,2)]
 	[iOS (9,1)]
 	[BaseType (typeof (MPRemoteCommandEvent))]
 	[DisableDefaultCtor] // Objective-C exception thrown.  Name: NSGenericException Reason: MPChangePlaybackPositionCommandEvents cannot be initialized externally.
@@ -1856,6 +1938,7 @@ namespace XamCore.MediaPlayer {
 		double PositionTime { get; }
 	}
 
+	[NoMac]
 	[NoTV][iOS (9,3)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -1875,11 +1958,13 @@ namespace XamCore.MediaPlayer {
 		string DescriptionText { get; set; }
 	}
 
+	[NoMac]
 	[NoTV]
 	[iOS (10,1)]
 	[BaseType (typeof (NSObject))]
 	interface MPMusicPlayerQueueDescriptor : NSSecureCoding {}
 
+	[NoMac]
 	[NoTV]
 	[iOS (10,1)]
 	[BaseType (typeof(MPMusicPlayerQueueDescriptor))]
@@ -1907,6 +1992,7 @@ namespace XamCore.MediaPlayer {
 		void SetEndTime (double endTime, MPMediaItem mediaItem);
 	}
 
+	[NoMac]
 	[NoTV]
 	[iOS (10,1)]
 	[BaseType (typeof(MPMusicPlayerQueueDescriptor))]

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -1162,10 +1162,12 @@ namespace XamCore.MediaPlayer {
 		[Export ("setQueueWithStoreIDs:")]
 		void SetQueue (string[] storeIDs);
 
+		[TV (10,1)]
 		[iOS (10,1)]
 		[Export ("setQueueWithDescriptor:")]
 		void SetQueue (MPMusicPlayerQueueDescriptor descriptor);
 
+		[TV (10,1)]
 		[iOS (10,1)]
 		[Async]
 		[Export ("prepareToPlayWithCompletionHandler:")]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -13108,11 +13108,13 @@ namespace XamCore.UIKit {
 		UIModalPresentationStyle ModalPresentationStyle { get; set; }
 
 		// 3.2 extensions from MoviePlayer
+		[NoMac]
 		[NoTV]
 		[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_9_0)]
 		[Export ("presentMoviePlayerViewControllerAnimated:")]
 		void PresentMoviePlayerViewController (MPMoviePlayerViewController moviePlayerViewController);
 
+		[NoMac]
 		[NoTV]
 		[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_9_0)]
 		[Export ("dismissMoviePlayerViewControllerAnimated")]

--- a/tests/xtro-sharpie/osx.pending
+++ b/tests/xtro-sharpie/osx.pending
@@ -203,3 +203,59 @@
 !missing-type! SFSafariExtensionManager not bound
 !missing-selector! SFSafariExtensionState::isEnabled not bound
 !missing-type! SFSafariExtensionState not bound
+
+# MediaPlayer API macOS 10.12.2
+
+# These are not available on macOS even if xtro says so.
+!missing-type! MPMediaEntity not bound
+!missing-type! MPMediaItem not bound
+
+!missing-enum! MPErrorCode not bound
+!missing-enum! MPMediaType not bound
+
+!missing-field! MPErrorDomain not bound
+!missing-field! MPMediaEntityPropertyPersistentID not bound
+
+!missing-field! MPMediaItemPropertyAlbumArtist not bound
+!missing-field! MPMediaItemPropertyAlbumArtistPersistentID not bound
+!missing-field! MPMediaItemPropertyAlbumPersistentID not bound
+!missing-field! MPMediaItemPropertyAlbumTitle not bound
+!missing-field! MPMediaItemPropertyAlbumTrackCount not bound
+!missing-field! MPMediaItemPropertyAlbumTrackNumber not bound
+!missing-field! MPMediaItemPropertyArtist not bound
+!missing-field! MPMediaItemPropertyArtistPersistentID not bound
+!missing-field! MPMediaItemPropertyArtwork not bound
+!missing-field! MPMediaItemPropertyAssetURL not bound
+!missing-field! MPMediaItemPropertyBeatsPerMinute not bound
+!missing-field! MPMediaItemPropertyBookmarkTime not bound
+!missing-field! MPMediaItemPropertyComments not bound
+!missing-field! MPMediaItemPropertyComposer not bound
+!missing-field! MPMediaItemPropertyComposerPersistentID not bound
+!missing-field! MPMediaItemPropertyDateAdded not bound
+!missing-field! MPMediaItemPropertyDiscCount not bound
+!missing-field! MPMediaItemPropertyDiscNumber not bound
+!missing-field! MPMediaItemPropertyGenre not bound
+!missing-field! MPMediaItemPropertyGenrePersistentID not bound
+!missing-field! MPMediaItemPropertyHasProtectedAsset not bound
+!missing-field! MPMediaItemPropertyIsCloudItem not bound
+!missing-field! MPMediaItemPropertyIsCompilation not bound
+!missing-field! MPMediaItemPropertyIsExplicit not bound
+!missing-field! MPMediaItemPropertyLastPlayedDate not bound
+!missing-field! MPMediaItemPropertyLyrics not bound
+!missing-field! MPMediaItemPropertyMediaType not bound
+!missing-field! MPMediaItemPropertyPersistentID not bound
+!missing-field! MPMediaItemPropertyPlayCount not bound
+!missing-field! MPMediaItemPropertyPlaybackDuration not bound
+!missing-field! MPMediaItemPropertyPodcastPersistentID not bound
+!missing-field! MPMediaItemPropertyPodcastTitle not bound
+!missing-field! MPMediaItemPropertyRating not bound
+!missing-field! MPMediaItemPropertyReleaseDate not bound
+!missing-field! MPMediaItemPropertySkipCount not bound
+!missing-field! MPMediaItemPropertyTitle not bound
+!missing-field! MPMediaItemPropertyUserGrouping not bound
+
+!missing-selector! +MPMediaEntity::canFilterByProperty: not bound
+!missing-selector! MPMediaEntity::enumerateValuesForProperties:usingBlock: not bound
+!missing-selector! MPMediaEntity::objectForKeyedSubscript: not bound
+!missing-selector! MPMediaEntity::valueForProperty: not bound
+!missing-selector! MPMediaItemArtwork::imageCropRect not bound

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -17,25 +17,30 @@ public class Frameworks : Dictionary <string, Framework>
 {
 	public void Add (string @namespace, int major_version)
 	{
-		Add (@namespace, @namespace, major_version, 0);
+		Add (@namespace, @namespace, major_version, 0, 0);
 	}
 
 	public void Add (string @namespace, string framework, int major_version)
 	{
-		Add (@namespace, framework, major_version, 0);
+		Add (@namespace, framework, major_version, 0, 0);
 	}
 
 	public void Add (string @namespace, int major_version, int minor_version)
 	{
-		Add (@namespace, @namespace, major_version, minor_version);
+		Add (@namespace, @namespace, major_version, minor_version, 0);
 	}
 
 	public void Add (string @namespace, string framework, int major_version, int minor_version)
 	{
+		Add(@namespace, framework, major_version, minor_version, 0);
+	}
+
+	public void Add (string @namespace, string framework, int major_version, int minor_version, int build_version)
+	{
 		var fr = new Framework () {
 			Namespace = Driver.IsUnified ? @namespace : XamCore.Registrar.Registrar.CompatNamespace + "." + @namespace,
 			Name = framework,
-			Version = new Version (major_version, minor_version)
+			Version = new Version (major_version, minor_version, build_version)
 		};
 		base.Add (fr.Namespace, fr);
 	}
@@ -127,6 +132,7 @@ public class Frameworks : Dictionary <string, Framework>
 
 					{ "Intents", 10, 12 },
 					{ "SafariServices", "SafariServices", 10, 12 },
+					{ "MediaPlayer", "MediaPlayer", 10, 12, 1 },
 				};
 			}
 			return mac_frameworks;


### PR DESCRIPTION
- Enable some MediaPlayer-related UIKit APIs.
- tools/common/Frameworks.cs fix to handle build version digit.
- Lots of [NoMac] and [Mac (10,12,2)].