### PR TITLE
[homekit] Update for tvOS 10.1 beta 1

### DIFF
--- a/src/HomeKit/HMEnums.cs
+++ b/src/HomeKit/HMEnums.cs
@@ -514,6 +514,10 @@ namespace XamCore.HomeKit {
 		[iOS (10,2), Watch (3,1,1), TV (10,1)]
 		[Field ("HMCharacteristicTypeHumidifierThreshold")]
 		HumidifierThreshold,
+
+		[iOS (9,0), Watch (2,0), TV (10,0)]
+		[Field ("HMCharacteristicTypeSecuritySystemAlarmType")]
+		SecuritySystemAlarmType,
 	}
 
 	// conveniance enum (ObjC uses NSString)

--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -1343,7 +1343,7 @@ namespace XamCore.HomeKit {
 		[Export ("cameraSnapshotControl:didTakeSnapshot:error:")]
 		void DidTakeSnapshot (HMCameraSnapshotControl cameraSnapshotControl, [NullAllowed] HMCameraSnapshot snapshot, [NullAllowed] NSError error);
 
-		[iOS (10,1)][Watch (3,1)][NoTV]
+		[iOS (10,1)][Watch (3,1)][TV (10,1)]
 		[Export ("cameraSnapshotControlDidUpdateMostRecentSnapshot:")]
 		void DidUpdateMostRecentSnapshot (HMCameraSnapshotControl cameraSnapshotControl);
 	}


### PR DESCRIPTION
- Also add missing HMCharacteristicTypeSecuritySystemAlarmType.