### PR TITLE
[mtouch] Bring back PreBuildDirectory

### DIFF
--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Bundler {
 		}
 
 		// returns false if the assembly was not copied (because it was already up-to-date).
-		bool CopyAssembly (string source, string target, bool copy_mdb = true)
+		public bool CopyAssembly (string source, string target, bool copy_mdb = true)
 		{
 			var copied = false;
 

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -639,12 +639,9 @@ namespace Xamarin.Bundler
 
 			foreach (var a in Assemblies) {
 				var target = Path.Combine (BuildDirectory, a.FileName);
-				if (!Application.IsUptodate (a.FullPath, target)) {
-					a.CopyToDirectory (target);
-				} else {
-					a.FullPath = target;
+				if (!a.CopyAssembly (a.FullPath, target))
 					Driver.Log (3, "Target '{0}' is up-to-date.", target);
-				}
+				a.FullPath = target;
 			}
 
 			Driver.GatherFrameworks (this, Frameworks, WeakFrameworks);


### PR DESCRIPTION
Some mtouch unit tests failed because of timestamp checks. It's not clear
it's always a win (it's not in my original test case) not to copy (to
target) as it means we have to copy earlier (PreBuild + Build).

More investigation needed, there's probably a better way to achieve both.
In the mean time this should fix the failing tests cases.