### PR TITLE
[CoreFoundation] Store strings in the exception data when converting CFError to CFException. Fixes #46626.

### DIFF
--- a/src/CoreFoundation/CFException.cs
+++ b/src/CoreFoundation/CFException.cs
@@ -115,7 +115,7 @@ namespace XamCore.CoreFoundation {
 			if (cfUserInfo != IntPtr.Zero) {
 				using (var userInfo = new NSDictionary (cfUserInfo)) {
 					foreach (var i in userInfo)
-						e.Data.Add (i.Key, i.Value);
+						e.Data.Add (i.Key?.ToString (), i.Value?.ToString ());
 				}
 			}
 			if (release)

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -1,0 +1,53 @@
+﻿//
+// MessageHandlers.cs
+//
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Net;
+using System.Net.Http;
+using System.Linq;
+using System.IO;
+
+using NUnit.Framework;
+
+namespace MonoTests.System.Net.Http
+{
+	[TestFixture]
+	public class MessageHandlerTest
+	{
+		HttpMessageHandler GetHandler (Type handler_type)
+		{
+			return (HttpMessageHandler) Activator.CreateInstance (handler_type);
+		}
+
+		[Test]
+#if !__WATCHOS__
+		[TestCase (typeof (HttpClientHandler))]
+		[TestCase (typeof (CFNetworkHandler))]
+#endif
+		[TestCase (typeof (NSUrlSessionHandler))]
+		public void DnsFailure (Type handlerType)
+		{
+			bool done = false;
+			Exception ex = null;
+
+			TestRuntime.RunAsync (DateTime.Now.AddSeconds (30), async () =>
+			{
+				try {
+					HttpClient client = new HttpClient (GetHandler (handlerType));
+					var s = await client.GetStringAsync ("http://doesnotexist.xamarin.com");
+				} catch (Exception e) {
+					ex = e;
+				} finally {
+					done = true;
+				}
+			}, () => done);
+
+			Assert.IsNotNull (ex, "Exception");
+			// The handlers throw different types of exceptions, so we can't assert much more than that something went wrong.
+		}
+	}}

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -147,6 +147,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="MonoTouch.NUnitLite" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist">
@@ -642,6 +643,7 @@
     <Compile Include="CoreMedia\CMClockOrTimebaseTest.cs" />
     <Compile Include="AVFoundation\CaptureDeviceTest.cs" />
     <Compile Include="PassKit\LabeledValueTest.cs" />
+    <Compile Include="System.Net.Http\MessageHandlers.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
@@ -705,6 +707,7 @@
     <Folder Include="Messages\" />
     <Folder Include="CloudKit\" />
     <Folder Include="Intents\" />
+    <Folder Include="System.Net.Http\" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="AudioToolbox\1.caf" />


### PR DESCRIPTION
Store strings in the exception data when converting CFError to CFException, to
make sure the data stored is serializable (which is apparently a requirement
with the reference sources).

https://bugzilla.xamarin.com/show_bug.cgi?id=46626