### PR TITLE
[homekit] Remove bugzilla comments

### DIFF
--- a/src/HomeKit/HMEnums.cs
+++ b/src/HomeKit/HMEnums.cs
@@ -935,10 +935,7 @@ namespace XamCore.HomeKit {
 		Fan,
 
 #if !WATCH && !TVOS
-		//https://bugzilla.xamarin.com/show_bug.cgi?id=46292: [generator] Obsolete attribute doesn't make it to generated file for smart enums
 		[Obsolete ("Use GarageDoorOpener instead")]
-		//https://bugzilla.xamarin.com/show_bug.cgi?id=46285: [generator] Smart enum does not handle 2 equal values
-		//[Field ("HMAccessoryCategoryTypeGarageDoorOpener")]
 		DoorOpener,
 
 		[Field ("HMAccessoryCategoryTypeGarageDoorOpener")]


### PR DESCRIPTION
Since bug #46292: "[generator] Obsolete attribute doesn't make it to generated file for smart enums" and #46285: "[generator] Smart enum does not handle 2 equal values" are both fixed, the comments can be removed.

Also we don't need to have the `[Field]` attribute on 2 enum values anymore.

*Note: verified the generated code and the smart enum fixes work as expected.*