### PR TITLE
Bug/ios networkextension

### DIFF
--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -1332,7 +1332,6 @@ namespace XamCore.NetworkExtension {
 
 	[iOS (9,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NETunnelProvider))]
-	[DisableDefaultCtor] // no valid handle when `init` is called
 	interface NEPacketTunnelProvider {
 		[Export ("startTunnelWithOptions:completionHandler:")]
 		[Async]

--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -1294,6 +1294,9 @@ namespace XamCore.NetworkExtension {
 	[iOS (9,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NETunnelNetworkSettings))]
 	interface NEPacketTunnelNetworkSettings {
+		[Export ("initWithTunnelRemoteAddress:")]
+		IntPtr Constructor (string address);
+
 		[Export ("IPv4Settings", ArgumentSemantic.Copy)]
 		[NullAllowed]
 		NEIPv4Settings IPv4Settings { get; set; }

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -74,7 +74,10 @@ namespace Introspection {
 			// even if we specify an NSUserActivityTypes in the Info.plist - might be a bug or there's a new (undocumented) requirement
 			case "NSUserActivity":
 				return true;
+			case "NEPacketTunnelProvider":
+				return true;
 			}
+
 			return SkipDueToAttribute (type);
 		}
 


### PR DESCRIPTION
This is similar to the issue I found here:

https://bugzilla.xamarin.com/show_bug.cgi?id=44874

I am trying to create a custom VPN iOS app with Xamarin, with these two commits it's possible to bring up the VPN.