### PR TITLE
[mediaplayer] Fixes due to xtro tests

### DIFF
--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -451,6 +451,14 @@ namespace XamCore.MediaPlayer {
 		MPMediaItem [] SeedItems { get; }		
 
 		[iOS (9,3)]
+		[NullAllowed, Export ("descriptionText")]
+		string DescriptionText { get; }
+
+		[iOS (9,3)]
+		[NullAllowed, Export ("authorDisplayName")]
+		string AuthorDisplayName { get; }
+
+		[iOS (9,3)]
 		[Async]
 		[Export ("addItemWithProductID:completionHandler:")]
 		void AddItem (string productID, [NullAllowed] Action<NSError> completionHandler);
@@ -1162,12 +1170,10 @@ namespace XamCore.MediaPlayer {
 		[Export ("setQueueWithStoreIDs:")]
 		void SetQueue (string[] storeIDs);
 
-		[TV (10,1)]
 		[iOS (10,1)]
 		[Export ("setQueueWithDescriptor:")]
 		void SetQueue (MPMusicPlayerQueueDescriptor descriptor);
 
-		[TV (10,1)]
 		[iOS (10,1)]
 		[Async]
 		[Export ("prepareToPlayWithCompletionHandler:")]

--- a/tests/xtro-sharpie/tvos.ignore
+++ b/tests/xtro-sharpie/tvos.ignore
@@ -272,6 +272,8 @@
 !missing-selector! MPMusicPlayerController::setQueueWithStoreIDs: not bound
 !missing-selector! MPMusicPlayerController::setVolume: not bound
 !missing-selector! MPMusicPlayerController::volume not bound
+!missing-selector! MPMusicPlayerController::prepareToPlayWithCompletionHandler: not bound
+!missing-selector! MPMusicPlayerController::setQueueWithDescriptor: not bound
 
 ## from (unmarked) MPMediaItem_MPMediaQueryAdditions but MPMediaItem is not in tvOS
 !missing-selector! +MPMediaItem::persistentIDPropertyForGroupingType: not bound


### PR DESCRIPTION
- MPMusicPlayerController_MPPlaybackControl category isn't available on tvOS.
- Add missing `MPMediaPlaylist` selectors.