### PR TITLE
[xharness] Determine additional tests to run based on the modified files in a pull request.

### DIFF
--- a/tests/xharness/GitHub.cs
+++ b/tests/xharness/GitHub.cs
@@ -40,5 +40,73 @@ namespace xharness
 
 			return File.ReadAllLines (path);
 		}
+
+		public static IEnumerable<string> GetModifiedFiles (Harness harness, int pull_request)
+		{
+			var path = Path.Combine (harness.LogDirectory, "pr" + pull_request + "-files.log");
+			if (!File.Exists (path)) {
+				Directory.CreateDirectory (harness.LogDirectory);
+				using (var client = new WebClient ()) {
+					var rv = new List<string> ();
+					var url = $"https://api.github.com/repos/xamarin/xamarin-macios/pulls/{pull_request}/files?per_page=100"; // 100 items per page is max
+					do {
+						byte [] data;
+						try {
+							client.Headers.Add (HttpRequestHeader.UserAgent, "xamarin");
+							data = client.DownloadData (url);
+						} catch (WebException we) {
+							harness.Log ("Could not load pull request files: {0}\n{1}", we, new StreamReader (we.Response.GetResponseStream ()).ReadToEnd ());
+							File.WriteAllText (path, string.Empty);
+							return new string [] { };
+						}
+						var reader = JsonReaderWriterFactory.CreateJsonReader (data, new XmlDictionaryReaderQuotas ());
+						var doc = new XmlDocument ();
+						doc.Load (reader);
+						foreach (XmlNode node in doc.SelectNodes ("/root/item/filename")) {
+							rv.Add (node.InnerText);
+						}
+
+						url = null;
+
+						var link = client.ResponseHeaders ["Link"];
+						try {
+							if (link != null) {
+								var ltIdx = link.IndexOf ('<');
+								var gtIdx = link.IndexOf ('>', ltIdx + 1);
+								while (ltIdx >= 0 && gtIdx > ltIdx) {
+									var linkUrl = link.Substring (ltIdx + 1, gtIdx - ltIdx - 1);
+									if (link [gtIdx + 1] != ';')
+										break;
+									var commaIdx = link.IndexOf (',', gtIdx + 1);
+									string rel;
+									if (commaIdx != -1) {
+										rel = link.Substring (gtIdx + 3, commaIdx - gtIdx - 3);
+									} else {
+										rel = link.Substring (gtIdx + 3);
+									}
+
+									if (rel == "rel=\"next\"") {
+										url = linkUrl;
+										break;
+									}
+
+									if (commaIdx == -1)
+										break;
+
+									ltIdx = link.IndexOf ('<', commaIdx);
+									gtIdx = link.IndexOf ('>', ltIdx + 1);
+								}
+							}
+						} catch (Exception e) {
+							harness.Log ("Could not paginate github response: {0}: {1}", link, e.Message);
+						}
+					} while (url != null);
+					File.WriteAllLines (path, rv.ToArray ());
+					return rv;
+				}
+			}
+
+			return File.ReadAllLines (path);
+		}
 	}
 }

--- a/tests/xharness/Log.cs
+++ b/tests/xharness/Log.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace xharness
 {
-	public abstract class Log : IDisposable
+	public abstract class Log : TextWriter
 	{
 		public string Description;
 		public bool Timestamp;
@@ -34,19 +34,19 @@ namespace xharness
 			throw new NotSupportedException ();
 		}
 
-		public void Write (string value)
+		public override void Write (string value)
 		{
 			if (Timestamp)
 				value = DateTime.Now.ToString ("HH:mm:ss.fffffff") + " " + value;
 			WriteImpl (value);
 		}
 
-		public void WriteLine (string value)
+		public override void WriteLine (string value)
 		{
 			Write (value + "\n");
 		}
 
-		public void WriteLine (string format, params object [] args)
+		public override void WriteLine (string format, params object [] args)
 		{
 			Write (string.Format (format, args) + "\n");
 		}
@@ -56,20 +56,15 @@ namespace xharness
 			return Description;
 		}
 
-		public virtual void Flush ()
+		public override void Flush ()
 		{
 		}
 
-#region IDisposable Support
-		protected virtual void Dispose (bool disposing)
-		{
+		public override Encoding Encoding {
+			get {
+				return System.Text.Encoding.UTF8;
+			}
 		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-		}
-#endregion
 	}
 
 	public class LogFile : Log


### PR DESCRIPTION
Example log output when bumping mono:

```
Found 1 modified file(s) in the pull request #1161.
    external/mono
Enabled 'mtouch' tests because the modified file 'external/mono' matches prefix 'external/mono'
Enabled 'mmp' tests because the modified file 'external/mono' matches prefix 'external/mono'
Enabled 'bcl' tests because the modified file 'external/mono' matches prefix 'external/mono'
Found 1 label(s) in the pull request #1161: cla-already-signed
```

Or when changing the static registrar:

```
Found 1 modified file(s) in the pull request #1164.
    tools/common/StaticRegistrar.cs
Enabled 'mtouch' tests because the modified file 'tools/common/StaticRegistrar.cs' matches prefix 'tools/common'
Enabled 'mmp' tests because the modified file 'tools/common/StaticRegistrar.cs' matches prefix 'tools/common'
Found 2 label(s) in the pull request #1164: cla-already-signed, run-mmp-tests
Enabled 'mmp' tests because the label 'run-mmp-tests' is set.
```
