### PR TITLE
[tests] Update MT1017 test after 7c6d04f1.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1604,8 +1604,7 @@ public class TestApp {
 				var cache = Path.Combine (testDir, "mtouch-cache");
 
 				var args = string.Format ("-sdkroot " + Configuration.xcode_root + " --nolink --dev {0} -sdk {4} -targetver {4} --abi=armv7 {1} --cache={2} --r:{3}", app, exe, cache, Configuration.XamarinIOSDll, Configuration.sdk_version);
-				Asserts.ThrowsPattern<TestExecutionException> (() => ExecutionHelper.Execute (TestTarget.ToolPath, args, hide_output: false), 
-					"Xamarin.iOS .* using framework:.*\nerror MT1017: Failed to create the NOTICE file: Access to the path \".*/testApp.app/NOTICE\" is denied.\n");
+				ExecutionHelper.Execute (TestTarget.ToolPath, args, hide_output: false);
 			} finally {
 				Directory.Delete (testDir, true);
 			}


### PR DESCRIPTION
In 7c6d04f1 the code to create the NOTICE file was simplified, and the new
implementation is writing to a temporary file and then replacing the existing
file.

This makes the scenario that MT1017 was testing (failure if a readonly NOTICE
file already exists) go away, since we don't write to the existing file
anymore (so the build succeeds).