### PR TITLE
[cross] Bump Mono and update the AOT cross offsets generation paths.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -1925,7 +1925,7 @@ targetwatch/mono/arch/arm/arm_dpimacros.h: setup-targetwatch
 #  $(3): build
 define GenerateCrossOffsets
 $(3)/$(1).h: .stamp-configure-$(3) target7/mono/arch/arm/arm_dpimacros.h targetwatch/mono/arch/arm/arm_dpimacros.h $(4)/tools/offsets-tool/.stamp-clone $(4)/tools/offsets-tool/MonoAotOffsetsDumper.exe
-	$(Q) MONO_PATH=$(4)/tools/offsets-tool/CppSharp \
+	$(Q) MONO_PATH=$(4)/tools/offsets-tool/CppSharp/osx_32 \
 	$(SYSTEM_MONO) $(4)/tools/offsets-tool/MonoAotOffsetsDumper.exe --abi $(1) --out $(2) --mono $(abspath $(4)) --maccore $(abspath $(TOP))
 endef
 


### PR DESCRIPTION
Following https://github.com/mono/mono/pull/3927 this needs to be updated to work with latest Mono revisions.

Will send also a C9 analogue when this PR is processed.