### PR TITLE
[mtouch] Don't copy mdb files if they haven't changed.

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -80,7 +80,7 @@ namespace Xamarin.Bundler {
 			}
 		}
 
-		public static bool IsUptodate (string source, string target)
+		public static bool IsUptodate (string source, string target, bool check_contents = false)
 		{
 			if (Driver.Force)
 				return false;
@@ -97,10 +97,15 @@ namespace Xamarin.Bundler {
 			if (sfi.LastWriteTimeUtc <= tfi.LastWriteTimeUtc) {
 				Driver.Log (3, "Prerequisite '{0}' is older than the target '{1}'.", source, target);
 				return true;
-			} else {
-				Driver.Log (3, "Prerequisite '{0}' is newer than the target '{1}'.", source, target);
-				return false;
 			}
+
+			if (check_contents && Cache.CompareFiles (source, target)) {
+				Driver.Log (3, "Prerequisite '{0}' is newer than the target '{1}', but the contents are identical.", source, target);
+				return true;
+			}
+
+			Driver.Log (3, "Prerequisite '{0}' is newer than the target '{1}'.", source, target);
+			return false;
 		}
 
 		public static void RemoveResource (ModuleDefinition module, string name)
@@ -257,9 +262,9 @@ namespace Xamarin.Bundler {
 			}
 		}
 
-		public static void UpdateFile (string source, string target)
+		public static void UpdateFile (string source, string target, bool check_contents = false)
 		{
-			if (!Application.IsUptodate (source, target))
+			if (!Application.IsUptodate (source, target, check_contents))
 				CopyFile (source, target);
 			else
 				Driver.Log (3, "Target '{0}' is up-to-date", target);

--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Bundler {
 
 				// Update the mdb even if the assembly didn't change.
 				if (copy_mdb && File.Exists (source + ".mdb"))
-					Application.UpdateFile (source + ".mdb", target + ".mdb");
+					Application.UpdateFile (source + ".mdb", target + ".mdb", true);
 
 				CopyConfigToDirectory (Path.GetDirectoryName (target));
 			} catch (Exception e) {


### PR DESCRIPTION
This fixes an mtouch test:

```
1) Failed : Xamarin.MTouch.RebuildTest("debug","-sdkroot {2} -v -v -v -v --dev {0} -sdk {3} --targetver 6.0 {1} -r:{4} --cache={5}/cache --debug")
  debug-rebuilt
/var/folders/9t/bhhqghxd4131b5k43v0yk7yc0000gn/T/tmp3fef2cc4.tmp/testApp.app/.monotouch-32/System.dll.mdb is modified, timestamp: 11/12/2016 1:17:59 AM
/var/folders/9t/bhhqghxd4131b5k43v0yk7yc0000gn/T/tmp3fef2cc4.tmp/testApp.app/.monotouch-32/Xamarin.iOS.dll.mdb is modified, timestamp: 11/12/2016 1:17:59 AM
/var/folders/9t/bhhqghxd4131b5k43v0yk7yc0000gn/T/tmp3fef2cc4.tmp/testApp.app/.monotouch-32/mscorlib.dll.mdb is modified, timestamp: 11/12/2016 1:17:59 AM
```