### PR TITLE
[xharness] Improve cleaning by removing saved simulator state and the CoreSimulatorService.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -396,6 +396,7 @@ namespace xharness
 
 				Task.Run (async () =>
 				{
+					await SimDevice.KillEverythingAsync (MainLog);
 					await PopulateTasksAsync ();
 				}).Wait ();
 				var tasks = new List<Task> ();


### PR DESCRIPTION
Also do this at the very start, to make sure no stale CoreSimulatorService is
around at build time. This will hopefully fix bug #[46097][1].

[1]: https://bugzilla.xamarin.com/show_bug.cgi?id=46097