### PR TITLE
[CoreMidi] Make FindByUniqueId public

### DIFF
--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -494,7 +494,7 @@ namespace XamCore.CoreMidi {
 			}
 		}
 
-		static MidiError FindByUniqueId (int uniqueId, out MidiObject result)
+		static public MidiError FindByUniqueId (int uniqueId, out MidiObject result)
 		{
 			MidiObjectRef handle;
 			MidiObjectType type;


### PR DESCRIPTION
Makes MidiObject.FindByUniqueId public.

Passes apitest-unified and dontlink-mac-unified