### PR TITLE
Revert "[tests] Disable the docs tests until the documentation process is fixed. (#965)"

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -302,8 +302,7 @@ endif
 wrench-docs:
 ifdef ENABLE_XAMARIN
 ifdef INCLUDE_IOS
-	@echo "Documentation process must be ported to not use XI/Classic, and not use system XI. In the meantime disable the docs tests."
-	@#$(MAKE) -C $(MACCORE_PATH) update-docs
+	$(MAKE) -C $(MACCORE_PATH) update-docs
 else
 	@echo "iOS tests have been disabled [$@]"
 endif


### PR DESCRIPTION
Test have been fixed in maccore/master/7284688c05cd1420274858a57b7c7616dfbe1d0b

This reverts commit 0a0503a6e90cbb28558e5c3999eb0d9abfd64db5.