### PR TITLE
[generator] Support [Sealed] on types. Fixes #43995

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -28,6 +28,8 @@ include ./OpenGLES/Makefile.include
 include ./OpenGLES/Makefile-1.0.include
 include ./Makefile.generator
 
+include ./generator-diff.mk
+
 COMMON_TARGET_DIRS = \
 	build/common             \
 	build/common/NativeTypes \

--- a/src/avkit.cs
+++ b/src/avkit.cs
@@ -23,7 +23,9 @@ namespace XamCore.AVKit {
 	[iOS (9,0)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
+#if XAMCORE_4_0
 	[Sealed] // Apple docs: Do not subclass AVPictureInPictureController. Overriding this class’s methods is unsupported and results in undefined behavior.
+#endif
 	interface AVPictureInPictureController
 	{
 		[Static]

--- a/src/generator-diff.mk
+++ b/src/generator-diff.mk
@@ -1,0 +1,21 @@
+.generated_copy = rsync -qavz --exclude=*.dll --exclude=*.exe --exclude=*.mdb build generator-reference
+
+generator-reference:
+	@rm -rf $@
+	@rm -rf src/build
+	$(MAKE) all -j
+	@$(.generated_copy)
+	@cd $@ && git init . && git add --all && git commit -m init
+
+generator-diff:
+	@if [ ! -d generator-reference/.git ]; then \
+		echo "No generator reference built. Run 'make generator-reference' first."; \
+		exit 1; \
+	fi
+	@rm -rf generator-reference/*
+	@git clean -fxdq -e generator-reference
+	$(MAKE) all -j
+	@$(.generated_copy)
+	@cd generator-reference && git diff
+
+.PHONY: generator-reference generator-diff

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1249,6 +1249,7 @@ public class MemberInformation
 	public readonly Type type;
 	public readonly Type category_extension_type;
 	public readonly bool is_abstract, is_protected, is_internal, is_unified_internal, is_override, is_new, is_sealed, is_static, is_thread_static, is_autorelease, is_wrapper, is_forced;
+	public readonly bool is_type_sealed;
 	public readonly Generator.ThreadCheck threadCheck;
 	public bool is_unsafe, is_virtual_method, is_export, is_category_extension, is_variadic, is_interface_impl, is_extension_method, is_appearance, is_model, is_ctor;
 	public bool is_return_release;
@@ -1274,6 +1275,7 @@ public class MemberInformation
 		is_thread_static = Generator.HasAttribute (mi, typeof (IsThreadStaticAttribute));
 		is_autorelease = Generator.HasAttribute (mi, typeof (AutoreleaseAttribute));
 		is_wrapper = !Generator.HasAttribute (mi.DeclaringType, typeof(SyntheticAttribute));
+		is_type_sealed = Generator.HasAttribute (mi.DeclaringType, typeof (SealedAttribute));
 		is_return_release = method != null && Generator.HasAttribute (method.ReturnTypeCustomAttributes, typeof (ReleaseAttribute));
 		is_forced = Generator.HasForcedAttribute (mi, out is_forced_owns);
 
@@ -1291,7 +1293,7 @@ public class MemberInformation
 		this.is_model = is_model;
 		this.mi = mi;
 		
-		if (is_interface_impl || is_extension_method || Generator.HasAttribute (type, typeof (SealedAttribute))) {
+		if (is_interface_impl || is_extension_method || is_type_sealed) {
 			is_abstract = false;
 			is_virtual_method = false;
 		}
@@ -1359,7 +1361,7 @@ public class MemberInformation
 		if (category_extension_type != null)
 			is_category_extension = true;
 
-		if (is_static || is_category_extension || is_interface_impl || is_extension_method || Generator.HasAttribute (type, typeof (SealedAttribute)))
+		if (is_static || is_category_extension || is_interface_impl || is_extension_method || is_type_sealed)
 			is_virtual_method = false;
 	}
 
@@ -1373,7 +1375,7 @@ public class MemberInformation
 		if (export != null)
 			selector = export.Selector;
 
-		if (wrap_method != null || is_interface_impl || Generator.HasAttribute (type, typeof (SealedAttribute)))
+		if (wrap_method != null || is_interface_impl || is_type_sealed)
 			is_virtual_method = false;
 		else
 			is_virtual_method = !is_static;

--- a/src/replaykit.cs
+++ b/src/replaykit.cs
@@ -52,6 +52,9 @@ namespace XamCore.ReplayKit {
 	[TV (10,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
+#if XAMCORE_4_0
+	[Sealed]
+#endif
 	interface RPScreenRecorder {
 
 		[Static]


### PR DESCRIPTION
* Add `sealed` on types decorated with `[Sealed]` as it's already a valid
  target for the attribute [1];

* Do not generated `protected .ctor (NSObjectFlag)` on sealed types;

* Do not generate virtual methods inside sealed types, which simplifies
  their implementation [2]

* Add [Sealed] for RPScreenRecorder (mentioned in bug report) under
  `XAMCORE_4_0`

[1] `AVPictureInPictureController` was already using `[Sealed]` even if
it was **not** supported so this has been moved under `XAMCORE_4_0`.

[2] Some of the advantages (reduced ize and registrar time) might not be
very visible as the linker/optimizer already does the same (in most cases)

References
* https://bugzilla.xamarin.com/show_bug.cgi?id=43995