### PR TITLE
[XM] Fix crash in mmp when native reference path matches dllimport found

### DIFF
--- a/tests/common/mac/SimpleClass.h
+++ b/tests/common/mac/SimpleClass.h
@@ -1,5 +1,7 @@
 #import <Cocoa/Cocoa.h>
 
+int GetFour ();
+
 @interface SimpleClass : NSObject
 
 - (int) doIt;

--- a/tests/common/mac/SimpleClass.m
+++ b/tests/common/mac/SimpleClass.m
@@ -1,5 +1,10 @@
 #import "SimpleClass.h"
 
+int GetFour ()
+{
+	return 4;
+}
+
 @implementation SimpleClass
 
 - (int)doIt {

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -612,10 +612,16 @@ namespace Xamarin.Bundler {
 				var linked_native_libs = Link ();
 				foreach (var kvp in linked_native_libs) {
 					List<MethodDefinition> methods;
-					if (native_libs.TryGetValue (kvp.Key, out methods))
+					if (native_libs.TryGetValue (kvp.Key, out methods)) {
+						if (methods == null) {
+							methods = new List<MethodDefinition> (); 
+							native_libs [kvp.Key] = methods;
+						}
 						methods.AddRange (kvp.Value);
-					else
+					}
+					else {
 						native_libs.Add (kvp.Key, kvp.Value);
+					}
 				}
 				internalSymbols.UnionWith (BuildTarget.LinkContext.RequiredSymbols.Keys);
 				Watch (string.Format ("Linking (mode: '{0}')", App.LinkMode), 1);


### PR DESCRIPTION
- When native_libs.Add (nr, null) was hit above and then we later matched
 we would call methods.AddRange (kvp.Value) on an empty methods