### PR TITLE
[msbuild] Touch the .dSYM Info.plist after stripping the native exe

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -800,7 +800,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		>
 		</DSymUtil>
 
-		<!--- strip the main executable -->
+		<!--- strip the debug symbols from the $(_NativeExecutable) -->
 		<SymbolStrip
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' And '$(MtouchDebug)' == 'false' And '$(MtouchNoSymbolStrip)' == 'false'"
@@ -809,6 +809,14 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			SymbolFile="$(_MtouchSymbolsList)"
 		>
 		</SymbolStrip>
+
+		<!-- touch the dSYM Info.plist so that its mtime is newer than the stripped $(_NativeExecutable) -->
+		<Touch
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true' And '$(MtouchDebug)' == 'false' And '$(MtouchNoSymbolStrip)' == 'false'"
+			Files="$(AppBundleDir).dSYM\Contents\Info.plist"
+		>
+		</Touch>
 
 		<!-- make sure spotlight indexes everything we've built -->
 		<SpotlightIndexer
@@ -867,7 +875,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			OutputImages="@(_PngImage -> '$(DeviceSpecificIntermediateOutputPath)optimized\%(LogicalName)')">
 			<Output TaskParameter="OutputImages" ItemName="FileWrites" />
 		</OptimizeImage>
-  </Target>
+	</Target>
 
 	<Target Name="_AfterCoreOptimizePngImages" Condition="'@(_PngImage)' != ''">
 		<ItemGroup>
@@ -1569,7 +1577,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<Touch
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' And '$(_RequireCodeSigning)' == 'true' And Exists ('$(AppBundleDir).dSYM\Contents\Info.plist')"
+			Condition="'$(IsMacEnabled)' == 'true' And '$(_RequireCodeSigning)' == 'true' And Exists ('$(AppBundleDir).dSYM\Contents\Info.plist')"
 			Files="$(AppBundleDir).dSYM\Contents\Info.plist"
 		/>
 	</Target>

--- a/msbuild/tests/MyReleaseBuild/AppDelegate.cs
+++ b/msbuild/tests/MyReleaseBuild/AppDelegate.cs
@@ -1,0 +1,83 @@
+﻿//
+// AppDelegate.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2016 Jeffrey Stedfast
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+using Foundation;
+using UIKit;
+
+namespace MyReleaseBuild
+{
+	// The UIApplicationDelegate for the application. This class is responsible for launching the
+	// User Interface of the application, as well as listening (and optionally responding) to application events from iOS.
+	[Register ("AppDelegate")]
+	public class AppDelegate : UIApplicationDelegate
+	{
+		// class-level declarations
+
+		public override UIWindow Window {
+			get;
+			set;
+		}
+
+		public override bool FinishedLaunching (UIApplication application, NSDictionary launchOptions)
+		{
+			// Override point for customization after application launch.
+			// If not required for your application you can safely delete this method
+
+			return true;
+		}
+
+		public override void OnResignActivation (UIApplication application)
+		{
+			// Invoked when the application is about to move from active to inactive state.
+			// This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) 
+			// or when the user quits the application and it begins the transition to the background state.
+			// Games should use this method to pause the game.
+		}
+
+		public override void DidEnterBackground (UIApplication application)
+		{
+			// Use this method to release shared resources, save user data, invalidate timers and store the application state.
+			// If your application supports background exection this method is called instead of WillTerminate when the user quits.
+		}
+
+		public override void WillEnterForeground (UIApplication application)
+		{
+			// Called as part of the transiton from background to active state.
+			// Here you can undo many of the changes made on entering the background.
+		}
+
+		public override void OnActivated (UIApplication application)
+		{
+			// Restart any tasks that were paused (or not yet started) while the application was inactive. 
+			// If the application was previously in the background, optionally refresh the user interface.
+		}
+
+		public override void WillTerminate (UIApplication application)
+		{
+			// Called when the application is about to terminate. Save data, if needed. See also DidEnterBackground.
+		}
+	}
+}
+

--- a/msbuild/tests/MyReleaseBuild/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/msbuild/tests/MyReleaseBuild/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,157 @@
+{
+  "images": [
+    {
+      "idiom": "iphone",
+      "size": "29x29",
+      "scale": "1x"
+    },
+    {
+      "idiom": "iphone",
+      "size": "29x29",
+      "scale": "2x"
+    },
+    {
+      "idiom": "iphone",
+      "size": "29x29",
+      "scale": "3x"
+    },
+    {
+      "idiom": "iphone",
+      "size": "40x40",
+      "scale": "2x"
+    },
+    {
+      "idiom": "iphone",
+      "size": "40x40",
+      "scale": "3x"
+    },
+    {
+      "idiom": "iphone",
+      "size": "57x57",
+      "scale": "1x"
+    },
+    {
+      "idiom": "iphone",
+      "size": "57x57",
+      "scale": "2x"
+    },
+    {
+      "idiom": "iphone",
+      "size": "60x60",
+      "scale": "2x"
+    },
+    {
+      "idiom": "iphone",
+      "size": "60x60",
+      "scale": "3x"
+    },
+    {
+      "idiom": "ipad",
+      "size": "29x29",
+      "scale": "1x"
+    },
+    {
+      "idiom": "ipad",
+      "size": "29x29",
+      "scale": "2x"
+    },
+    {
+      "idiom": "ipad",
+      "size": "40x40",
+      "scale": "1x"
+    },
+    {
+      "idiom": "ipad",
+      "size": "40x40",
+      "scale": "2x"
+    },
+    {
+      "idiom": "ipad",
+      "size": "50x50",
+      "scale": "1x"
+    },
+    {
+      "idiom": "ipad",
+      "size": "50x50",
+      "scale": "2x"
+    },
+    {
+      "idiom": "ipad",
+      "size": "72x72",
+      "scale": "1x"
+    },
+    {
+      "idiom": "ipad",
+      "size": "72x72",
+      "scale": "2x"
+    },
+    {
+      "idiom": "ipad",
+      "size": "76x76",
+      "scale": "1x"
+    },
+    {
+      "idiom": "ipad",
+      "size": "76x76",
+      "scale": "2x"
+    },
+    {
+      "size": "24x24",
+      "idiom": "watch",
+      "scale": "2x",
+      "role": "notificationCenter",
+      "subtype": "38mm"
+    },
+    {
+      "size": "27.5x27.5",
+      "idiom": "watch",
+      "scale": "2x",
+      "role": "notificationCenter",
+      "subtype": "42mm"
+    },
+    {
+      "size": "29x29",
+      "idiom": "watch",
+      "role": "companionSettings",
+      "scale": "2x"
+    },
+    {
+      "size": "29x29",
+      "idiom": "watch",
+      "role": "companionSettings",
+      "scale": "3x"
+    },
+    {
+      "size": "40x40",
+      "idiom": "watch",
+      "scale": "2x",
+      "role": "appLauncher",
+      "subtype": "38mm"
+    },
+    {
+      "size": "44x44",
+      "idiom": "watch",
+      "scale": "2x",
+      "role": "longLook",
+      "subtype": "42mm"
+    },
+    {
+      "size": "86x86",
+      "idiom": "watch",
+      "scale": "2x",
+      "role": "quickLook",
+      "subtype": "38mm"
+    },
+    {
+      "size": "98x98",
+      "idiom": "watch",
+      "scale": "2x",
+      "role": "quickLook",
+      "subtype": "42mm"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/msbuild/tests/MyReleaseBuild/Assets.xcassets/Contents.json
+++ b/msbuild/tests/MyReleaseBuild/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+﻿{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/msbuild/tests/MyReleaseBuild/Entitlements.plist
+++ b/msbuild/tests/MyReleaseBuild/Entitlements.plist
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/msbuild/tests/MyReleaseBuild/Info.plist
+++ b/msbuild/tests/MyReleaseBuild/Info.plist
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>MyReleaseBuild</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.your-company.myreleasebuild</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>MinimumOSVersion</key>
+	<string>10.0</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>XSAppIconAssets</key>
+	<string>Assets.xcassets/AppIcon.appiconset</string>
+</dict>
+</plist>

--- a/msbuild/tests/MyReleaseBuild/LaunchScreen.storyboard
+++ b/msbuild/tests/MyReleaseBuild/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+	<dependencies>
+		<deployment identifier="iOS" />
+		<plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530" />
+	</dependencies>
+	<scenes>
+		<!--View Controller-->
+		<scene sceneID="EHf-IW-A2E">
+			<objects>
+				<viewController id="01J-lp-oVM" sceneMemberID="viewController">
+					<layoutGuides>
+						<viewControllerLayoutGuide type="top" id="Llm-lL-Icb" />
+						<viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok" />
+					</layoutGuides>
+					<view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+						<rect key="frame" x="0.0" y="0.0" width="600" height="600" />
+						<autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" />
+						<color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite" />
+					</view>
+				</viewController>
+				<placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder" />
+			</objects>
+			<point key="canvasLocation" x="53" y="375" />
+		</scene>
+	</scenes>
+</document>

--- a/msbuild/tests/MyReleaseBuild/Main.cs
+++ b/msbuild/tests/MyReleaseBuild/Main.cs
@@ -1,0 +1,40 @@
+﻿//
+// Main.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2016 Jeffrey Stedfast
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+using UIKit;
+
+namespace MyReleaseBuild
+{
+	public class Application
+	{
+		// This is the main entry point of the application.
+		static void Main (string[] args)
+		{
+			// if you want to use a different Application Delegate class from "AppDelegate"
+			// you can specify it here.
+			UIApplication.Main (args, null, "AppDelegate");
+		}
+	}
+}

--- a/msbuild/tests/MyReleaseBuild/Main.storyboard
+++ b/msbuild/tests/MyReleaseBuild/Main.storyboard
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+	<dependencies>
+		<plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204" />
+	</dependencies>
+	<scenes>
+		<!--View Controller-->
+		<scene sceneID="tne-QT-ifu">
+			<objects>
+				<viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+					<layoutGuides>
+						<viewControllerLayoutGuide type="top" id="y3c-jy-aDJ" />
+						<viewControllerLayoutGuide type="bottom" id="wfy-db-euE" />
+					</layoutGuides>
+					<view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+						<rect key="frame" x="0.0" y="0.0" width="600" height="600" />
+						<autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" />
+						<color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite" />
+					</view>
+				</viewController>
+				<placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder" />
+			</objects>
+		</scene>
+	</scenes>
+</document>

--- a/msbuild/tests/MyReleaseBuild/MyReleaseBuild.csproj
+++ b/msbuild/tests/MyReleaseBuild/MyReleaseBuild.csproj
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProjectGuid>{A5812C03-E0D0-448C-9DFD-5AAC6D1BFADC}</ProjectGuid>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MyReleaseBuild</RootNamespace>
+    <AssemblyName>MyReleaseBuild</AssemblyName>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG;ENABLE_TEST_CLOUD;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchFastDev>true</MtouchFastDev>
+    <MtouchProfiling>true</MtouchProfiling>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <IOSDebuggerPort>46280</IOSDebuggerPort>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;ENABLE_TEST_CLOUD;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchFastDev>true</MtouchFastDev>
+    <MtouchProfiling>true</MtouchProfiling>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\Contents.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <InterfaceDefinition Include="LaunchScreen.storyboard" />
+    <InterfaceDefinition Include="Main.storyboard" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+    <None Include="Entitlements.plist" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+    <Compile Include="AppDelegate.cs" />
+    <Compile Include="ViewController.cs" />
+    <Compile Include="ViewController.designer.cs">
+      <DependentUpon>ViewController.cs</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+</Project>

--- a/msbuild/tests/MyReleaseBuild/MyReleaseBuild.sln
+++ b/msbuild/tests/MyReleaseBuild/MyReleaseBuild.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyReleaseBuild", "MyReleaseBuild.csproj", "{A5812C03-E0D0-448C-9DFD-5AAC6D1BFADC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|iPhone = Release|iPhone
+		Release|iPhoneSimulator = Release|iPhoneSimulator
+		Debug|iPhone = Debug|iPhone
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A5812C03-E0D0-448C-9DFD-5AAC6D1BFADC}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{A5812C03-E0D0-448C-9DFD-5AAC6D1BFADC}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{A5812C03-E0D0-448C-9DFD-5AAC6D1BFADC}.Release|iPhone.ActiveCfg = Release|iPhone
+		{A5812C03-E0D0-448C-9DFD-5AAC6D1BFADC}.Release|iPhone.Build.0 = Release|iPhone
+		{A5812C03-E0D0-448C-9DFD-5AAC6D1BFADC}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{A5812C03-E0D0-448C-9DFD-5AAC6D1BFADC}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{A5812C03-E0D0-448C-9DFD-5AAC6D1BFADC}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{A5812C03-E0D0-448C-9DFD-5AAC6D1BFADC}.Debug|iPhone.Build.0 = Debug|iPhone
+	EndGlobalSection
+EndGlobal

--- a/msbuild/tests/MyReleaseBuild/ViewController.cs
+++ b/msbuild/tests/MyReleaseBuild/ViewController.cs
@@ -1,0 +1,51 @@
+﻿//
+// ViewController.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2016 Jeffrey Stedfast
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+using System;
+
+using UIKit;
+
+namespace MyReleaseBuild
+{
+	public partial class ViewController : UIViewController
+	{
+		protected ViewController (IntPtr handle) : base (handle)
+		{
+			// Note: this .ctor should not contain any initialization logic.
+		}
+
+		public override void ViewDidLoad ()
+		{
+			base.ViewDidLoad ();
+			// Perform any additional setup after loading the view, typically from a nib.
+		}
+
+		public override void DidReceiveMemoryWarning ()
+		{
+			base.DidReceiveMemoryWarning ();
+			// Release any cached data, images, etc that aren't in use.
+		}
+	}
+}

--- a/msbuild/tests/MyReleaseBuild/ViewController.designer.cs
+++ b/msbuild/tests/MyReleaseBuild/ViewController.designer.cs
@@ -1,0 +1,17 @@
+﻿//
+// This file has been generated automatically by MonoDevelop to store outlets and
+// actions made in the Xcode designer. If it is removed, they will be lost.
+// Manual changes to this file may not be handled correctly.
+//
+using Foundation;
+
+namespace MyReleaseBuild
+{
+	[Register ("ViewController")]
+	partial class ViewController
+	{
+		void ReleaseDesignerOutlets ()
+		{
+		}
+	}
+}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/Action.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/Action.cs
@@ -12,7 +12,7 @@ namespace Xamarin.iOS.Tasks {
 		[Test]
 		public void BasicTest ()
 		{
-			this.BuildExtension ("MyTabbedApplication", "MyActionExtension", Platform);
+			this.BuildExtension ("MyTabbedApplication", "MyActionExtension", Platform, "Debug");
 		}
 	}
 }

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/CustomKeyboard.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/CustomKeyboard.cs
@@ -24,7 +24,7 @@ namespace Xamarin.iOS.Tasks {
 				return;
 			}
 
-			this.BuildExtension ("MyMetalGame", "MyKeyboardExtension", Platform);
+			this.BuildExtension ("MyMetalGame", "MyKeyboardExtension", Platform, "Debug");
 			this.TestStoryboardC (AppBundlePath);
 		}
 

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/DocumentPicker.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/DocumentPicker.cs
@@ -13,7 +13,7 @@ namespace Xamarin.iOS.Tasks {
 		[Test]
 		public void BasicTest () 
 		{
-			this.BuildExtension ("MyWebViewApp", "MyDocumentPickerExtension", Platform);
+			this.BuildExtension ("MyWebViewApp", "MyDocumentPickerExtension", Platform, "Debug");
 			this.TestStoryboardC (AppBundlePath);
 		}
 	}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/ExtensionTestBase.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/ExtensionTestBase.cs
@@ -28,7 +28,7 @@ namespace Xamarin.iOS.Tasks
 
 		public void BuildExtension (string hostAppName, string extensionName, string bundlePath, string platform, string config, int expectedErrorCount = 0)
 		{
-			var mtouchPaths = SetupProjectPaths (hostAppName, "../", true, platform, config);
+			var mtouchPaths = SetupProjectPaths (hostAppName, "../", true, bundlePath, config);
 
 			var proj = SetupProject (Engine, mtouchPaths ["project_csprojpath"]);
 

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/ExtensionTestBase.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/ExtensionTestBase.cs
@@ -10,7 +10,8 @@ namespace Xamarin.iOS.Tasks
 
 		public ExtensionTestBase () { }
 
-		public ExtensionTestBase (string platform) {
+		public ExtensionTestBase (string platform)
+		{
 			Platform = platform;
 		}
 
@@ -20,20 +21,21 @@ namespace Xamarin.iOS.Tasks
 			Platform = platform;
 		}
 
-		public void BuildExtension (string hostAppName, string extensionName, string platform, int expectedErrorCount = 0)
+		public void BuildExtension (string hostAppName, string extensionName, string platform, string config, int expectedErrorCount = 0)
 		{
-			BuildExtension (hostAppName, extensionName, platform, platform, expectedErrorCount);
+			BuildExtension (hostAppName, extensionName, platform, platform, config, expectedErrorCount);
 		}
 
-		public void BuildExtension (string hostAppName, string extensionName, string bundlePath, string platform, int expectedErrorCount = 0)
+		public void BuildExtension (string hostAppName, string extensionName, string bundlePath, string platform, string config, int expectedErrorCount = 0)
 		{
-			var mtouchPaths = SetupProjectPaths (hostAppName, "../", true, bundlePath);
+			var mtouchPaths = SetupProjectPaths (hostAppName, "../", true, platform, config);
 
 			var proj = SetupProject (Engine, mtouchPaths ["project_csprojpath"]);
 
 			AppBundlePath = mtouchPaths ["app_bundlepath"];
 			string extensionPath = Path.Combine(AppBundlePath, "PlugIns", extensionName + ".appex");
 			Engine.GlobalProperties.SetProperty ("Platform", platform);
+			Engine.GlobalProperties.SetProperty ("Configuration", config);
 
 			RunTarget (proj, "Clean");
 			Assert.IsFalse (Directory.Exists (AppBundlePath), "{1}: App bundle exists after cleanup: {0} ", AppBundlePath, bundlePath);
@@ -55,14 +57,15 @@ namespace Xamarin.iOS.Tasks
 			TestFilesExists (AppBundlePath, ExpectedAppFiles);
 			TestFilesDoNotExist (AppBundlePath, UnexpectedAppFiles);
 
-			var coreFiles = platform == "iPhone" ? CoreAppFiles : CoreAppFiles.Union (new string [] { hostAppName + ".exe", hostAppName }).ToArray ();
-			if (IsTVOS)
+			var coreFiles = GetCoreAppFiles (platform, config, hostAppName + ".exe", hostAppName);
+			if (IsTVOS) {
 				TestFilesExists (platform == "iPhone" ? Path.Combine (AppBundlePath, ".monotouch-64") : AppBundlePath, coreFiles);
-			else if (IsWatchOS) {
-				coreFiles = platform == "iPhone" ? CoreAppFiles : CoreAppFiles.Union (new string [] { extensionName + ".dll", Path.GetFileNameWithoutExtension (extensionPath) }).ToArray ();
+			} else if (IsWatchOS) {
+				coreFiles = GetCoreAppFiles (platform, config, extensionName + ".dll", Path.GetFileNameWithoutExtension (extensionPath));
 				TestFilesExists (platform == "iPhone" ? Path.Combine (extensionPath, ".monotouch-32") : extensionPath, coreFiles);
-			} else
+			} else {
 				TestFilesExists (platform == "iPhone" ? Path.Combine (AppBundlePath, ".monotouch-32") : AppBundlePath, coreFiles);
+			}
 		}
 
 		public void SetupPaths (string appName, string platform) 

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/PhotoEditing.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/PhotoEditing.cs
@@ -12,7 +12,7 @@ namespace Xamarin.iOS.Tasks {
 		[Test]
 		public void BasicTest ()
 		{
-			this.BuildExtension ("MySpriteKitGame", "MyPhotoEditingExtension", Platform);
+			this.BuildExtension ("MySpriteKitGame", "MyPhotoEditingExtension", Platform, "Debug");
 		}
 	}
 }

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/Share.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/Share.cs
@@ -12,7 +12,7 @@ namespace Xamarin.iOS.Tasks {
 		[Test]
 		public void BasicTest ()
 		{
-			this.BuildExtension ("MyMasterDetailApp", "MyShareExtension", Platform);
+			this.BuildExtension ("MyMasterDetailApp", "MyShareExtension", Platform, "Debug");
 		}
 	}
 }

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/Today.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/Today.cs
@@ -12,7 +12,7 @@ namespace Xamarin.iOS.Tasks {
 		[Test]
 		public void BasicTest ()
 		{
-			this.BuildExtension ("MyOpenGLApp", "MyTodayExtension", Platform);
+			this.BuildExtension ("MyOpenGLApp", "MyTodayExtension", Platform, "Debug");
 		}
 	}
 }

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/WatchKit.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/WatchKit.cs
@@ -18,7 +18,7 @@ namespace Xamarin.iOS.Tasks {
 		[Test]
 		public void BasicTest () 
 		{
-			this.BuildExtension ("MyWatchApp", "MyWatchKitExtension", Platform);
+			this.BuildExtension ("MyWatchApp", "MyWatchKitExtension", Platform, "Debug");
 		}
 
 		[Test]

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/WatchKit2.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/WatchKit2.cs
@@ -20,7 +20,7 @@ namespace Xamarin.iOS.Tasks {
 			if (!Xamarin.Tests.Configuration.include_watchos)
 				Assert.Ignore ("WatchOS is not enabled");
 			
-			this.BuildExtension ("MyWatchApp2", "MyWatchKit2Extension", Platform);
+			this.BuildExtension ("MyWatchApp2", "MyWatchKit2Extension", Platform, "Debug");
 		}
 
 		public override string TargetFrameworkIdentifier {

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/IBToolLinking.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/IBToolLinking.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace Xamarin.iOS.Tasks
 {
@@ -16,7 +13,7 @@ namespace Xamarin.iOS.Tasks
 		[Test]
 		public void BuildTest ()
 		{
-			BuildProject ("MyIBToolLinkTest", Platform);
+			BuildProject ("MyIBToolLinkTest", Platform, "Debug");
 		}
 	}
 }

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectWithFrameworks.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectWithFrameworks.cs
@@ -13,7 +13,7 @@ namespace Xamarin.iOS.Tasks {
 		[Test]
 		public void BasicTest ()
 		{
-			this.BuildExtension ("MyMasterDetailApp", "MyShareExtension", Platform);
+			this.BuildExtension ("MyMasterDetailApp", "MyShareExtension", Platform, "Debug");
 
 			// Verify that Mono.frameworks is in the app
 			Assert.That (Directory.Exists (Path.Combine (AppBundlePath, "Frameworks")), "Frameworks exists");

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ReleaseBuild.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ReleaseBuild.cs
@@ -1,0 +1,18 @@
+﻿using NUnit.Framework;
+
+namespace Xamarin.iOS.Tasks
+{
+	[TestFixture ("iPhone")]
+	public class ReleaseBuild : ProjectTest
+	{
+		public ReleaseBuild (string platform) : base (platform)
+		{
+		}
+
+		[Test]
+		public void BuildTest ()
+		{
+			BuildProject ("MyReleaseBuild", Platform, "Release");
+		}
+	}
+}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/TVOS/TVApp.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/TVOS/TVApp.cs
@@ -13,7 +13,7 @@ namespace Xamarin.iOS.Tasks
 		[Test]
 		public void BasicTest()
 		{
-			BuildExtension("MyTVApp", "MyTVServicesExtension", BundlePath, Platform);
+			BuildExtension("MyTVApp", "MyTVServicesExtension", BundlePath, Platform, "Debug");
 		}
 
 		public override string TargetFrameworkIdentifier {

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/ValidateAppBundleTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/ValidateAppBundleTaskTests.cs
@@ -21,7 +21,7 @@ namespace Xamarin.iOS.Tasks
 			base.Setup ();
 
 			var extensionName = "MyActionExtension";
-			BuildExtension ("MyTabbedApplication", extensionName, "iPhoneSimulator");
+			BuildExtension ("MyTabbedApplication", extensionName, "iPhoneSimulator", "Debug");
 
 			task = CreateTask<ValidateAppBundleTask> ();
 			task.AppBundlePath = AppBundlePath;

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
@@ -29,35 +29,38 @@ namespace Xamarin.iOS.Tasks
 		public string [] ExpectedAppFiles = { };
 		public string [] UnexpectedAppFiles = { "monotouch.dll" };
 
-		public string[] CoreAppFiles {
-			get {
-				var xi = new string [] {
-					"Xamarin.iOS.dll",
-					"Xamarin.iOS.dll.mdb",
-					"mscorlib.dll",
-					"mscorlib.dll.mdb",
-				};
-				var xw = new string [] {
-					"Xamarin.WatchOS.dll",
-					"Xamarin.WatchOS.dll.mdb",
-					"mscorlib.dll",
-					"mscorlib.dll.mdb",
-				};
-				var xt = new string [] {
-					"Xamarin.TVOS.dll",
-					"Xamarin.TVOS.dll.mdb",
-					"mscorlib.dll",
-					"mscorlib.dll.mdb",
-				};
+		public string[] GetCoreAppFiles (string platform, string config, string managedExe, string nativeExe)
+		{
+			var coreFiles = new List<string> ();
 
-				if (TargetFrameworkIdentifier == "Xamarin.WatchOS") {
-					return xw;
-				} else if (TargetFrameworkIdentifier == "Xamarin.TVOS") {
-					return xt;
-				} else {
-					return xi;
-				}
+			if (TargetFrameworkIdentifier == "Xamarin.WatchOS") {
+				coreFiles.Add ("Xamarin.WatchOS.dll");
+				if (config == "Debug")
+					coreFiles.Add ("Xamarin.WatchOS.dll.mdb");
+			} else if (TargetFrameworkIdentifier == "Xamarin.TVOS") {
+				coreFiles.Add ("Xamarin.TVOS.dll");
+				if (config == "Debug")
+					coreFiles.Add ("Xamarin.TVOS.dll.mdb");
+			} else {
+				coreFiles.Add ("Xamarin.iOS.dll");
+				if (config == "Debug")
+					coreFiles.Add ("Xamarin.iOS.dll.mdb");
 			}
+
+			coreFiles.Add ("mscorlib.dll");
+			if (config == "Debug")
+				coreFiles.Add ("mscorlib.dll.mdb");
+
+			coreFiles.Add (managedExe);
+			if (config == "Debug")
+				coreFiles.Add (managedExe + ".mdb");
+
+			if (platform == "iPhone")
+				coreFiles.Add (Path.Combine ("..", nativeExe));
+			else
+				coreFiles.Add (nativeExe);
+
+			return coreFiles.ToArray ();
 		}
 
 		public Logger Logger {

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -106,6 +106,7 @@
     <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_iOS_WatchKitExtension.cs" />
     <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_watchOS_WatchKitExtension.cs" />
     <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_watchOS.cs" />
+    <Compile Include="ProjectsTests\ReleaseBuild.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
The idea here is to prevent future builds from calling dsymutil
if the native executable hasn't changed since the previous build.

The reason we need to touch the dSYM Info.plist after stripping
is because the SymbolStrip task *may* modify the native executable
thereby giving it a newer mtime timestamp than the dSYM Info.plist
which would cause later builds to re-run the dsymutil task on an
already-stripped native executable.

It should be noted, however, that the _CodesignAppBundle target
already updates the mtime timestamp of the dSYM Info.plist for
precisely the same reason and since it is run *after* the
_GenerateDebugSymbols target, the 'touch' should generally not
be needed in the _GenerateDebugSymbols target.