### PR TITLE
Improve UIScreen Capture() support for complex views

### DIFF
--- a/src/UIKit/UIScreen.cs
+++ b/src/UIKit/UIScreen.cs
@@ -37,31 +37,43 @@ namespace XamCore.UIKit {
 
 		public UIImage Capture ()
 		{
-			// This is from: https://developer.apple.com/library/ios/#qa/qa2010/qa1703.html
-			var selScreen = new Selector ("screen");
-			var size = Bounds.Size;
-
-			UIGraphics.BeginImageContextWithOptions (size, false, 0);
-
-			try {
-				var context = UIGraphics.GetCurrentContext ();
-
-				foreach (var window in UIApplication.SharedApplication.Windows) {
-					if (window.RespondsToSelector (selScreen) && window.Screen != this)
-						continue;
-
-					context.SaveState ();
-					context.TranslateCTM (window.Center.X, window.Center.Y);
-					context.ConcatCTM (window.Transform);
-					context.TranslateCTM (-window.Bounds.Size.Width * window.Layer.AnchorPoint.X, -window.Bounds.Size.Height * window.Layer.AnchorPoint.Y);
-
-					window.Layer.RenderInContext (context);
-					context.RestoreState ();
+			if (UIDevice.CurrentDevice.CheckSystemVersion(7, 0)) {
+				// This is from https://developer.apple.com/library/content/qa/qa1817/_index.html
+				try {
+					var view = UIApplication.SharedApplication.KeyWindow;
+					UIGraphics.BeginImageContextWithOptions(view.Bounds.Size, view.Opaque, 0);
+					view.DrawViewHierarchy(view.Bounds, true);
+					return UIGraphics.GetImageFromCurrentImageContext();
+				} finally {
+					UIGraphics.EndImageContext();
 				}
+			} else {
+				// This is from: https://developer.apple.com/library/ios/#qa/qa2010/qa1703.html
+				var selScreen = new Selector("screen");
+				var size = Bounds.Size;
 
-				return UIGraphics.GetImageFromCurrentImageContext ();
-			} finally {
-				UIGraphics.EndImageContext ();
+				UIGraphics.BeginImageContextWithOptions(size, false, 0);
+
+				try {
+					var context = UIGraphics.GetCurrentContext();
+
+					foreach (var window in UIApplication.SharedApplication.Windows) {
+						if (window.RespondsToSelector(selScreen) && window.Screen != this)
+							continue;
+
+						context.SaveState();
+						context.TranslateCTM(window.Center.X, window.Center.Y);
+						context.ConcatCTM(window.Transform);
+						context.TranslateCTM(-window.Bounds.Size.Width * window.Layer.AnchorPoint.X, -window.Bounds.Size.Height * window.Layer.AnchorPoint.Y);
+
+						window.Layer.RenderInContext(context);
+						context.RestoreState();
+					}
+
+					return UIGraphics.GetImageFromCurrentImageContext();
+				} finally {
+					UIGraphics.EndImageContext ();
+				}
 			}
 		}
 	}

--- a/src/UIKit/UIScreen.cs
+++ b/src/UIKit/UIScreen.cs
@@ -37,43 +37,43 @@ namespace XamCore.UIKit {
 
 		public UIImage Capture ()
 		{
-			if (UIDevice.CurrentDevice.CheckSystemVersion(7, 0)) {
+			if (UIDevice.CurrentDevice.CheckSystemVersion (7, 0)) {
 				// This is from https://developer.apple.com/library/content/qa/qa1817/_index.html
 				try {
 					var view = UIApplication.SharedApplication.KeyWindow;
-					UIGraphics.BeginImageContextWithOptions(view.Bounds.Size, view.Opaque, 0);
-					view.DrawViewHierarchy(view.Bounds, true);
-					return UIGraphics.GetImageFromCurrentImageContext();
-				} finally {
-					UIGraphics.EndImageContext();
-				}
-			} else {
-				// This is from: https://developer.apple.com/library/ios/#qa/qa2010/qa1703.html
-				var selScreen = new Selector("screen");
-				var size = Bounds.Size;
-
-				UIGraphics.BeginImageContextWithOptions(size, false, 0);
-
-				try {
-					var context = UIGraphics.GetCurrentContext();
-
-					foreach (var window in UIApplication.SharedApplication.Windows) {
-						if (window.RespondsToSelector(selScreen) && window.Screen != this)
-							continue;
-
-						context.SaveState();
-						context.TranslateCTM(window.Center.X, window.Center.Y);
-						context.ConcatCTM(window.Transform);
-						context.TranslateCTM(-window.Bounds.Size.Width * window.Layer.AnchorPoint.X, -window.Bounds.Size.Height * window.Layer.AnchorPoint.Y);
-
-						window.Layer.RenderInContext(context);
-						context.RestoreState();
-					}
-
-					return UIGraphics.GetImageFromCurrentImageContext();
+					UIGraphics.BeginImageContextWithOptions (view.Bounds.Size, view.Opaque, 0);
+					view.DrawViewHierarchy (view.Bounds, true);
+					return UIGraphics.GetImageFromCurrentImageContext ();
 				} finally {
 					UIGraphics.EndImageContext ();
 				}
+			} 
+
+			// This is from: https://developer.apple.com/library/ios/#qa/qa2010/qa1703.html
+			var selScreen = new Selector ("screen");
+			var size = Bounds.Size;
+
+			UIGraphics.BeginImageContextWithOptions (size, false, 0);
+
+			try {
+				var context = UIGraphics.GetCurrentContext ();
+
+				foreach (var window in UIApplication.SharedApplication.Windows) {
+					if (window.RespondsToSelector (selScreen) && window.Screen != this)
+						continue;
+
+					context.SaveState ();
+					context.TranslateCTM (window.Center.X, window.Center.Y);
+					context.ConcatCTM (window.Transform);
+					context.TranslateCTM (-window.Bounds.Size.Width * window.Layer.AnchorPoint.X, -window.Bounds.Size.Height * window.Layer.AnchorPoint.Y);
+
+					window.Layer.RenderInContext (context);
+					context.RestoreState ();
+				}
+
+				return UIGraphics.GetImageFromCurrentImageContext ();
+			} finally {
+				UIGraphics.EndImageContext ();
 			}
 		}
 	}


### PR DESCRIPTION
The current UIScreen Capture() method doesn't support complex views with multiple CA Layers (for example iCarousel). The changes here are in use in our apps in the AppStore with over half a million daily active users and no one has ever reported a bug regarding it. I kept the original code for backward compatibility as [drawViewHierarchyInRect:afterScreenUpdates:](https://developer.apple.com/reference/uikit/uiview/1622589-drawviewhierarchyinrect) was introduced in iOS 7.0. My changes were based from https://developer.apple.com/library/content/qa/qa1817/_index.html

Screenshot using original Capture() implementation:
![Alt text](https://dl.dropboxusercontent.com/u/18352048/Xamarin/iCarouselScreenCaptureBrokenCropped.png)

Screenshot using the changes in this pull request:
![Alt text](https://dl.dropboxusercontent.com/u/18352048/Xamarin/iCarouselScreenCaptureFixCropped.png)

The images above are from an app with a screen using iCarousel with 8 items containing both images and texts. I used the UIScreen Capture() method to capture this screen before opening another screen where I show it as the background image. 

I unfortunately had to crop out the rest of the image due to corporate reasons, but the images provided above are enough to illustrate the problem. I can provide a video of the problem if needed as long as this video is not shared with the general public