### PR TITLE
[msbuild] Add msbuild error code logic

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -1,11 +1,13 @@
 id:{9F76162B-D622-45DA-996B-2FBF8017E208}  
-title:mtouch errors  
+title:Xamarin.iOS errors
 
 [//]: # (The original file resides under https://github.com/xamarin/xamarin-macios/tree/master/docs/website/)
 [//]: # (This allows all contributors (including external) to submit, using a PR, updates to the documentation that match the tools changes)
 [//]: # (Modifications outside of xamarin-macios/master will be lost on future updates)
 
-# mtouch error messages
+# MT0xxx: mtouch error messages
+
+E.g. parameters, environment, missing tools.
 
 <!-- 
  MT0xxx mtouch itself, e.g. parameters, environment (e.g. missing tools)
@@ -358,6 +360,11 @@ A last-straw solution would be to use a different version of Xamarin.iOS, one th
 <h3><a name="MT0093"/>MT0093: Aot symbolication files could not be copied to the destination directory. Symbolication will not work with the application.</h3>
 
 <h3><a name="MT0096"/>MT0096: No reference to Xamarin.iOS.dll was found.</h3>
+
+# MT1xxx: Project related error messages
+
+### MT10xx: Installer / mtouch
+
 <!--
  MT1xxx file copy / symlinks (project related)
   MT10xx installer.cs / mtouch.cs
@@ -537,6 +544,8 @@ It's recommended to pass the path to the app to launch on device instead of just
 
 Please unlock the device and try again.
 
+### MT11xx: Debug Service
+
 <!--
   MT11xx DebugService.cs
   -->
@@ -591,6 +600,8 @@ Please check if your device is locked.
 
 If you're deploying an enterprise app or using a free provisioning profile, you might have trust the developer (this is explained <a href="http://stackoverflow.com/a/30726375/183422">here</a>).
 
+### MT12xx: Simulator
+
 <!--
   MT12xx simcontroller.cs
   -->
@@ -630,6 +641,8 @@ When launching a WatchOS app in a WatchOS simulator, there must be a paired iOS 
 
 Watch simulators can be paired with iOS Simulators using Xcode's Devices UI (menu Window -> Devices).
 
+### MT13xx: [LinkWith]
+
 <!--
   MT13xx [LinkWith]
   -->
@@ -658,6 +671,8 @@ Please make sure the framework is valid.
 The specified binding library contains an embedded framework, but Xamarin.iOS only supports embedded frameworks on iOS 8.0 or later.
 
 Please set the deployment target in the Info.plist file to at least 8.0 to solve this error (or don't use embedded frameworks).
+
+### MT14xx: Crash Reports
 
 <!--
   MT14xx	CrashReports.cs
@@ -747,6 +762,8 @@ Things to try to solve this:
 * Reboot the Mac.
 * Synchronize the device with iTunes (this will remove any crash reports from the device).
 
+### MT16xx: MachO
+
 <!--
   MT16xx	MachO.cs
   -->
@@ -800,6 +817,8 @@ Please make sure the file is a valid Mach-O dynamic library.
 The format of a file can be verified using the `file` command from a terminal:
 
     file -arch all -l /path/to/file
+
+# MT2xxx: Linker error messages
 
 <!--
  MT2xxx Linker
@@ -875,6 +894,8 @@ User resources are files included inside assemblies (as resources) that needs to
 * `__monotouch_content_*` and `__monotouch_pages_*` resources; and
 * Native libraries embedded inside a binding assembly;
 
+# MT3xxx: AOT error messages
+
 <!--
  MT3xxx AOT
   MT30xx AOT (general) errors
@@ -916,6 +937,10 @@ Bitcode support requires the use of the LLVM AOT backend (--llvm).
 
 Either disable Bitcode support or enable LLVM.
 
+# MT4xxx: Code generation error messages
+
+### MT40xx: Main
+
 <!--
  MT4xxx code generation
   MT40xx main.m
@@ -928,6 +953,8 @@ An error occurred when generating main.m. Please file a bug at [http://bugzilla.
 <h3><a name="MT4002"/>MT4002 Failed to compile the generated code for P/Invoke methods. Please file a bug report at http://bugzilla.xamarin.com</h3>
 
 Failed to compile the generated code for P/Invoke methods. Please file a bug report at [http://bugzilla.xamarin.com](https://bugzilla.xamarin.com/enter_bug.cgi?product=iOS).
+
+### MT41xx: Registrar
 
 <!--
   MT41xx registrar.m
@@ -1171,6 +1198,10 @@ This usually indicates a bug in Xamarin.iOS; please file a bug at [http://bugzil
 
 This usually indicates a bug in Xamarin.iOS; please file a bug at [http://bugzilla.xamarin.com](https://bugzilla.xamarin.com/enter_bug.cgi?product=iOS).
 
+# MT5xxx: GCC and toolchain error messages
+
+### MT51xx: Compilation
+
 <!--
  MT5xxx GCC and toolchain
   MT51xx compilation
@@ -1190,6 +1221,7 @@ This usually indicates a bug in Xamarin.iOS; please file a bug at [http://bugzil
 
 <h3><a name="MT5104"/>MT5104 Could not find neither the '*' nor the '*' compiler. Please install Xcode 'Command-Line Tools' component</h3>
 
+### MT52xx: Linking
 
 <!--
   MT52xx linking
@@ -1340,6 +1372,8 @@ There are a few possible solutions:
 
 This is a warning, indicating that a P/Invoke was detected to reference the library in question, but the app is not linking with it.
 
+### MT53xx: Other tools
+
 <!--
   MT53xx other tools
   -->
@@ -1375,6 +1409,10 @@ An error occurred when signing the application. Please review the build log to s
 <!-- 5308 is used by mmp -->
 <!-- 5309 is used by mmp -->
 
+# MT6xxx: mtouch internal tools error messages
+
+### MT600x: Stripper
+
 <!--
  MT6xxx mtouch internal tools
   MT600x Stripper
@@ -1389,6 +1427,8 @@ An error occurred when stripping managed code(removing the IL code) from the ass
 <h3><a name="MT6003"/>MT6003: [UnauthorizedAccessException message]</h3>
 
 A security error ocurred while stripping debugging symbols from the application.
+
+# MT7xxx: MSBuild error messages
 
 <!--
  MT7xxx msbuild errors
@@ -1488,6 +1528,8 @@ In some cases, it's a "local network" issue and it can be addressed by adding th
 <h3><a name="MT7043"/>MT7043: Main Info.plist path does not specify a CFBundleSupportedPlatforms.</h3>
 
 <h3><a name="MT7044"/>MT7044: Main Info.plist path does not specify a UIDeviceFamily.</h3>
+
+# MT8xxx: Runtime error messages
 
 <!--
  MT8xxx runtime

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -1391,8 +1391,103 @@ An error occurred when stripping managed code(removing the IL code) from the ass
 A security error ocurred while stripping debugging symbols from the application.
 
 <!--
- MT7xxx reserved
+ MT7xxx msbuild errors
   -->
+
+<h3><a name="MT7001"/>MT7001: Could not resolve host IPs for WiFi debugger settings.</h3>
+
+Troubleshooting steps:  
+
+- try to run `csharp -e 'System.Net.Dns.GetHostEntry (System.Net.Dns.GetHostName ()).AddressList'` (that should give you an IP address and not an error obviously).
+- try to run "ping \`hostname\`" which might give you more information, like: `cannot resolve MyHost.local: Unknown host`
+
+In some cases, it's a "local network" issue and it can be addressed by adding the unknown host `127.0.0.1	MyHost.local` in `/etc/hosts`.
+
+<h3><a name="MT7002"/>MT7002: This machine does not have any network adapters. This is required when debugging or profiling on device over WiFi.</h3>
+
+<h3><a name="MT7003"/>MT7003: The App Extension '*' does not contain an Info.plist.</h3>
+
+<h3><a name="MT7004"/>MT7004: The App Extension '*' does not specify a CFBundleIdentifier.</h3>
+
+<h3><a name="MT7005"/>MT7005: The App Extension '*' does not specify a CFBundleExecutable.</h3>
+
+<h3><a name="MT7006"/>MT7006: The App Extension '*' has an invalid CFBundleIdentifier (*), it does not begin with the main app bundle's CFBundleIdentifier (*).</h3>
+
+<h3><a name="MT7007"/>MT7007: The App Extension '*' has a CFBundleIdentifier (*) that ends with the illegal suffix ".key".</h3>
+
+<h3><a name="MT7008"/>MT7008: The App Extension '*' does not specify a CFBundleShortVersionString.</h3>
+
+<h3><a name="MT7009"/>MT7009: The App Extension '*' has an invalid Info.plist: it does not contain an NSExtension dictionary.</h3>
+
+<h3><a name="MT7010"/>MT7010: The App Extension '*' has an invalid Info.plist: the NSExtension dictionary does not contain an NSExtensionPointIdentifier value.</h3>
+
+<h3><a name="MT7011"/>MT7011: The WatchKit Extension '*' has an invalid Info.plist: the NSExtension dictionary does not contain an NSExtensionAttributes dictionary.</h3>
+
+<h3><a name="MT7012"/>MT7012: The WatchKit Extension '*' does not have exactly one watch app.</h3>
+
+<h3><a name="MT7013"/>MT7013: The WatchKit Extension '*' has an invalid Info.plist: UIRequiredDeviceCapabilities must contain the 'watch-companion' capability.</h3>
+
+<h3><a name="MT7014"/>MT7014: The Watch App '*' does not contain an Info.plist.</h3>
+
+<h3><a name="MT7015"/>MT7015: The Watch App '*' does not specify a CFBundleIdentifier.</h3>
+
+<h3><a name="MT7016"/>MT7016: The Watch App '*' has an invalid CFBundleIdentifier (*), it does not begin with the main app bundle's CFBundleIdentifier (*).</h3>
+
+<h3><a name="MT7017"/>MT7017: The Watch App '*' does not have a valid UIDeviceFamily value. Expected 'Watch (4)' but found '* (*)'.</h3>
+
+<h3><a name="MT7018"/>MT7018: The Watch App '*' does not specify a CFBundleExecutable</h3>
+
+<h3><a name="MT7019"/>MT7019: The Watch App '*' has an invalid WKCompanionAppBundleIdentifier value ('*'), it does not match the main app bundle's CFBundleIdentifier ('*').</h3>
+
+<h3><a name="MT7020"/>MT7020: The Watch App '*' has an invalid Info.plist: the WKWatchKitApp key must be present and have a value of 'true'.</h3>
+
+<h3><a name="MT7021"/>MT7021: The Watch App '*' has an invalid Info.plist: the LSRequiresIPhoneOS key must not be present.</h3>
+
+<h3><a name="MT7022"/>MT7022: The Watch App '*' does not contain a Watch Extension.</h3>
+
+<h3><a name="MT7023"/>MT7023: The Watch Extension '*' does not contain an Info.plist.</h3>
+
+<h3><a name="MT7024"/>MT7024: The Watch Extension '*' does not specify a CFBundleIdentifier.</h3>
+
+<h3><a name="MT7025"/>MT7025: The Watch Extension '*' does not specify a CFBundleExecutable.</h3>
+
+<h3><a name="MT7026"/>MT7026: The Watch Extension '*' has an invalid CFBundleIdentifier (*), it does not begin with the main app bundle's CFBundleIdentifier (*).</h3>
+
+<h3><a name="MT7027"/>MT7027: The Watch Extension '*' has a CFBundleIdentifier (*) that ends with the illegal suffix ".key".</h3>
+
+<h3><a name="MT7028"/>MT7028: The Watch Extension '*' has an invalid Info.plist: it does not contain an NSExtension dictionary.</h3>
+
+<h3><a name="MT7029"/>MT7029: The Watch Extension '*' has an invalid Info.plist: the NSExtensionPointIdentifier must be "com.apple.watchkit".</h3>
+
+<h3><a name="MT7030"/>MT7030: The Watch Extension '*' has an invalid Info.plist: the NSExtension dictionary must contain NSExtensionAttributes.</h3>
+
+<h3><a name="MT7031"/>MT7031: The Watch Extension '*' has an invalid Info.plist: the NSExtensionAttributes dictionary must contain a WKAppBundleIdentifier.</h3>
+
+<h3><a name="MT7032"/>MT7032: The WatchKit Extension '*' has an invalid Info.plist: UIRequiredDeviceCapabilities should not contain the 'watch-companion' capability.</h3>
+
+<h3><a name="MT7033"/>MT7033: The Watch App '*' does not contain an Info.plist.</h3>
+
+<h3><a name="MT7034"/>MT7034: The Watch App '*' does not specify a CFBundleIdentifier.</h3>
+
+<h3><a name="MT7035"/>MT7035: The Watch App '*' does not have a valid UIDeviceFamily value. Expected '*' but found '* (*)'.</h3>
+
+<h3><a name="MT7036"/>MT7036: The Watch App '*' does not specify a CFBundleExecutable.</h3>
+
+<h3><a name="MT7037"/>MT7037: The WatchKit Extension '{extensionName}' has an invalid WKAppBundleIdentifier value ('*'), it does not match the Watch App's CFBundleIdentifier ('*').</h3>
+
+<h3><a name="MT7038"/>MT7038: The Watch App '*' has an invalid Info.plist: the WKCompanionAppBundleIdentifier must exist and must match the main app bundle's CFBundleIdentifier.</h3>
+
+<h3><a name="MT7039"/>MT7039: The Watch App '*' has an invalid Info.plist: the LSRequiresIPhoneOS key must not be present.</h3>
+
+<h3><a name="MT7040"/>MT7040: The app bundle {AppBundlePath} does not contain an Info.plist.</h3>
+
+<h3><a name="MT7041"/>MT7041: Main Info.plist path does not specify a CFBundleIdentifier.</h3>
+
+<h3><a name="MT7042"/>MT7042: Main Info.plist path does not specify a CFBundleExecutable.</h3>
+
+<h3><a name="MT7043"/>MT7043: Main Info.plist path does not specify a CFBundleSupportedPlatforms.</h3>
+
+<h3><a name="MT7044"/>MT7044: Main Info.plist path does not specify a UIDeviceFamily.</h3>
 
 <!--
  MT8xxx runtime

--- a/msbuild/Xamarin.MacDev.Tasks.Core/LoggingExtensions.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/LoggingExtensions.cs
@@ -55,5 +55,17 @@ namespace Xamarin.MacDev.Tasks
 		{
 			log.LogMessage (TaskPropertyImportance, "{0} Task", taskName);
 		}
+
+		/// <summary>
+		/// Creates an MSBuild error following our MTErrors convention.</summary>
+		/// <remarks>
+		/// For every new error we need to update "docs/website/mtouch-errors.md" and "tools/mtouch/error.cs".</remarks>
+		/// <param name="errorCode">In the 7xxx range for MSBuild error.</param>
+		/// <param name="message">The error's message to be displayed in the error pad.</param>
+		/// <param name="filePath">Path to the known guilty file or MSBuild by default so we display something nice in the error pad.</param>
+		public static void MTError (this TaskLoggingHelper log, int errorCode, string message, string filePath = "MSBuild")
+		{
+			log.LogError (null, $"MT{errorCode}", null, filePath, 0, 0, 0, 0, message);
+		}
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectDebugNetworkConfigurationTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectDebugNetworkConfigurationTaskBase.cs
@@ -56,7 +56,7 @@ namespace Xamarin.iOS.Tasks
 					try {
 						ips.AddRange (Dns.GetHostEntry (Dns.GetHostName ()).AddressList.Select ((v) => v.ToString ()));
 					} catch {
-						Log.LogError ("Could not resolve host IPs for WiFi debugger settings");
+						Log.MTError (7001, "Could not resolve host IPs for WiFi debugger settings.");
 						return false;
 					}
 				} else {
@@ -69,7 +69,7 @@ namespace Xamarin.iOS.Tasks
 				}
 
 				if (ips == null || ips.Count == 0) {
-					Log.LogError ("This machine does not have any network adapters. This is required when debugging or profiling on device over WiFi.");
+					Log.MTError (7002, "This machine does not have any network adapters. This is required when debugging or profiling on device over WiFi.");
 					return false;
 				}
 			}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
@@ -36,7 +36,7 @@ namespace Xamarin.iOS.Tasks
 			var name = Path.GetFileNameWithoutExtension (path);
 			var info = Path.Combine (path, "Info.plist");
 			if (!File.Exists (info)) {
-				Log.LogError ("The App Extension '{0}' does not contain an Info.plist", name);
+				Log.MTError (7003, $"The App Extension '{name}' does not contain an Info.plist.");
 				return;
 			}
 
@@ -44,7 +44,7 @@ namespace Xamarin.iOS.Tasks
 
 			var bundleIdentifier = plist.GetCFBundleIdentifier ();
 			if (string.IsNullOrEmpty (bundleIdentifier)) {
-				Log.LogError ("The App Extension '{0}' does not specify a CFBundleIdentifier.", name);
+				Log.MTError (7004, $"The App Extension '{name}' does not specify a CFBundleIdentifier.");
 				return;
 			}
 
@@ -54,17 +54,17 @@ namespace Xamarin.iOS.Tasks
 
 			var executable = plist.GetCFBundleExecutable ();
 			if (string.IsNullOrEmpty (executable))
-				Log.LogError ("The App Extension '{0}' does not specify a CFBundleExecutable", name);
+				Log.MTError (7005, $"The App Extension '{name}' does not specify a CFBundleExecutable.");
 
 			if (!bundleIdentifier.StartsWith (mainBundleIdentifier + ".", StringComparison.Ordinal))
-				Log.LogError ("The App Extension '{0}' has an invalid CFBundleIdentifier ({1}), it does not begin with the main app bundle's CFBundleIdentifier ({2}).", name, bundleIdentifier, mainBundleIdentifier);
+				Log.MTError (7006, $"The App Extension '{name}' has an invalid CFBundleIdentifier ({bundleIdentifier}), it does not begin with the main app bundle's CFBundleIdentifier ({mainBundleIdentifier}).");
 
 			if (bundleIdentifier.EndsWith (".key", StringComparison.Ordinal))
-				Log.LogError ("The App Extension '{0}' has a CFBundleIdentifier ({1}) that ends with the illegal suffix \".key\".", name, bundleIdentifier);
+				Log.MTError (7007, $"The App Extension '{name}' has a CFBundleIdentifier ({bundleIdentifier}) that ends with the illegal suffix \".key\".");
 
 			var shortVersionString = plist.GetCFBundleShortVersionString ();
 			if (string.IsNullOrEmpty (shortVersionString))
-				Log.LogWarning ("The App Extension '{0}' does not specify a CFBundleShortVersionString", name);
+				Log.MTError (7008, $"The App Extension '{name}' does not specify a CFBundleShortVersionString.");
 
 			if (shortVersionString != mainShortVersionString)
 				Log.LogWarning ("The App Extension '{0}' has a CFBundleShortVersionString ({1}) that does not match the main app bundle's CFBundleShortVersionString ({2})", name, shortVersionString, mainShortVersionString);
@@ -78,14 +78,14 @@ namespace Xamarin.iOS.Tasks
 
 			var extension = plist.Get<PDictionary> ("NSExtension");
 			if (extension == null) {
-				Log.LogError ("The App Extension '{0}' has an invalid Info.plist: it does not contain an NSExtension dictionary.", name);
+				Log.MTError (7009, $"The App Extension '{name}' has an invalid Info.plist: it does not contain an NSExtension dictionary.");
 				return;
 			}
 
 			var extensionPointIdentifier = extension.GetString ("NSExtensionPointIdentifier").Value;
 
 			if (string.IsNullOrEmpty (extensionPointIdentifier)) {
-				Log.LogError ("The App Extension '{0}' has an invalid Info.plist: the NSExtension dictionary does not contain an NSExtensionPointIdentifier value.", name);
+				Log.MTError (7010, $"The App Extension '{name}' has an invalid Info.plist: the NSExtension dictionary does not contain an NSExtensionPointIdentifier value.");
 				return;
 			}
 
@@ -117,16 +117,16 @@ namespace Xamarin.iOS.Tasks
 				var attributes = extension.Get<PDictionary> ("NSExtensionAttributes");
 
 				if (attributes == null) {
-					Log.LogError ("The WatchKit Extension '{0}' has an invalid Info.plist: The NSExtension dictionary does not contain an NSExtensionAttributes dictionary.", name);
+					Log.MTError (7011, $"The WatchKit Extension '{name}' has an invalid Info.plist: the NSExtension dictionary does not contain an NSExtensionAttributes dictionary.");
 					return;
 				}
 
 				var wkAppBundleIdentifier = attributes.GetString ("WKAppBundleIdentifier").Value;
 				var apps = Directory.GetDirectories (path, "*.app");
 				if (apps.Length == 0) {
-					Log.LogError ("The WatchKit Extension '{0}' does not contain any watch apps.", name);
+					Log.MTError (7012, $"The WatchKit Extension '{name}' does not contain any watch apps.");
 				} else if (apps.Length > 1) {
-					Log.LogError ("The WatchKit Extension '{0}' contain more than one watch apps.", name);
+					Log.MTError (7012, $"The WatchKit Extension '{name}' contain more than one watch apps.");
 				} else {
 					PObject requiredDeviceCapabilities;
 
@@ -138,15 +138,15 @@ namespace Xamarin.iOS.Tasks
 							PBoolean watchCompanion;
 
 							if (!requiredDeviceCapabilitiesDictionary.TryGetValue ("watch-companion", out watchCompanion) || !watchCompanion.Value)
-								Log.LogError ("The WatchKit Extension '{0}' has an invalid Info.plist: the UIRequiredDeviceCapabilities dictionary must contain the 'watch-companion' capability with a value of 'true'.", name);
+								Log.MTError (7013, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities dictionary must contain the 'watch-companion' capability with a value of 'true'.");
 						} else if (requiredDeviceCapabilitiesArray != null) {
 							if (!requiredDeviceCapabilitiesArray.OfType<PString> ().Any (x => x.Value == "watch-companion"))
-								Log.LogError ("The WatchKit Extension '{0}' has an invalid Info.plist: the UIRequiredDeviceCapabilities array must contain the 'watch-companion' capability.", name);
+								Log.MTError (7013, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities array must contain the 'watch-companion' capability.");
 						} else {
-							Log.LogError ("The WatchKit Extension '{0}' has an invalid Info.plist: the UIRequiredDeviceCapabilities key must be present and contain the 'watch-companion' capability.", name);
+							Log.MTError (7013, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities key must be present and contain the 'watch-companion' capability.");
 						}
 					} else {
-						Log.LogError ("The WatchKit Extension '{0}' has an invalid Info.plist: the UIRequiredDeviceCapabilities key must be present and contain the 'watch-companion' capability.", name);
+						Log.MTError (7013, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities key must be present and contain the 'watch-companion' capability.");
 					}
 
 					ValidateWatchOS1App (apps[0], name, mainBundleIdentifier, wkAppBundleIdentifier);
@@ -163,19 +163,19 @@ namespace Xamarin.iOS.Tasks
 			var name = Path.GetFileNameWithoutExtension (path);
 			var info = Path.Combine (path, "Info.plist");
 			if (!File.Exists (info)) {
-				Log.LogError ("The Watch App '{0}' does not contain an Info.plist", name);
+				Log.MTError (7014, $"The Watch App '{name}' does not contain an Info.plist.");
 				return;
 			}
 
 			var plist = PDictionary.FromFile (info);
 			var bundleIdentifier = plist.GetCFBundleIdentifier ();
 			if (string.IsNullOrEmpty (bundleIdentifier)) {
-				Log.LogError ("The Watch App '{0}' does not specify a CFBundleIdentifier.", name);
+				Log.MTError (7015, $"The Watch App '{name}' does not specify a CFBundleIdentifier.");
 				return;
 			}
 
 			if (!bundleIdentifier.StartsWith (mainBundleIdentifier + ".", StringComparison.Ordinal))
-				Log.LogError ("The Watch App '{0}' has an invalid CFBundleIdentifier ({1}), it does not begin with the main app bundle's CFBundleIdentifier ({2}).", name, bundleIdentifier, mainBundleIdentifier);
+				Log.MTError (7016, $"The Watch App '{name}' has an invalid CFBundleIdentifier ({bundleIdentifier}), it does not begin with the main app bundle's CFBundleIdentifier ({mainBundleIdentifier}).");
 
 			var shortVersionString = plist.GetCFBundleShortVersionString ();
 			if (string.IsNullOrEmpty (shortVersionString))
@@ -193,26 +193,26 @@ namespace Xamarin.iOS.Tasks
 
 			var watchDeviceFamily = plist.GetUIDeviceFamily ();
 			if (watchDeviceFamily != IPhoneDeviceType.Watch)
-				Log.LogError ("The Watch App '{0}' does not have a valid UIDeviceFamily value. Expected 'Watch (4)' but found '{1} ({2})'.", name, watchDeviceFamily.ToString (), (int) watchDeviceFamily);
+				Log.MTError (7017, $"The Watch App '{name}' does not have a valid UIDeviceFamily value. Expected 'Watch (4)' but found '{watchDeviceFamily.ToString ()} ({(int)watchDeviceFamily})'.");
 
 			var watchExecutable = plist.GetCFBundleExecutable ();
 			if (string.IsNullOrEmpty (watchExecutable))
-				Log.LogError ("The Watch App '{0}' does not specify a CFBundleExecutable", name);
+				Log.MTError (7018, $"The Watch App '{name}' does not specify a CFBundleExecutable");
 
 			var wkCompanionAppBundleIdentifier = plist.GetString ("WKCompanionAppBundleIdentifier").Value;
 			if (wkCompanionAppBundleIdentifier != mainBundleIdentifier)
-				Log.LogError ("The Watch App '{0}' has an invalid WKCompanionAppBundleIdentifier value ('{1}'), it does not match the main app bundle's CFBundleIdentifier ('{2}').", name, wkCompanionAppBundleIdentifier, mainBundleIdentifier);
+				Log.MTError (7019, $"The Watch App '{name}' has an invalid WKCompanionAppBundleIdentifier value ('{wkCompanionAppBundleIdentifier}'), it does not match the main app bundle's CFBundleIdentifier ('{mainBundleIdentifier}').");
 
 			PBoolean watchKitApp;
 			if (!plist.TryGetValue ("WKWatchKitApp", out watchKitApp) || !watchKitApp.Value)
-				Log.LogError ("The Watch App '{0}' has an invalid Info.plist: The WKWatchKitApp key must be present and have a value of 'true'.", name);
+				Log.MTError (7020, $"The Watch App '{name}' has an invalid Info.plist: the WKWatchKitApp key must be present and have a value of 'true'.");
 
 			if (plist.ContainsKey ("LSRequiresIPhoneOS"))
-				Log.LogError ("The Watch App '{0}' has an invalid Info.plist: the LSRequiresIPhoneOS key must not be present.", name);
+				Log.MTError (7021, $"The Watch App '{name}' has an invalid Info.plist: the LSRequiresIPhoneOS key must not be present.");
 
 			var pluginsDir = Path.Combine (path, "PlugIns");
 			if (!Directory.Exists (pluginsDir)) {
-				Log.LogError ("The Watch App '{0}' does not contain any Watch Extensions.", name);
+				Log.MTError (7022, $"The Watch App '{name}' does not contain any Watch Extensions.");
 				return;
 			}
 
@@ -223,7 +223,7 @@ namespace Xamarin.iOS.Tasks
 			}
 
 			if (count == 0)
-				Log.LogError ("The Watch App '{0}' does not contan a Watch Extension.", name);
+				Log.MTError (7022, $"The Watch App '{name}' does not contain a Watch Extension.");
 		}
 
 		void ValidateWatchExtension (string path, string watchAppBundleIdentifier, string mainShortVersionString, string mainVersion)
@@ -231,7 +231,7 @@ namespace Xamarin.iOS.Tasks
 			var name = Path.GetFileNameWithoutExtension (path);
 			var info = Path.Combine (path, "Info.plist");
 			if (!File.Exists (info)) {
-				Log.LogError ("The Watch Extension '{0}' does not contain an Info.plist", name);
+				Log.MTError (7023, $"The Watch Extension '{name}' does not contain an Info.plist.");
 				return;
 			}
 
@@ -239,7 +239,7 @@ namespace Xamarin.iOS.Tasks
 
 			var bundleIdentifier = plist.GetCFBundleIdentifier ();
 			if (string.IsNullOrEmpty (bundleIdentifier)) {
-				Log.LogError ("The Watch Extension '{0}' does not specify a CFBundleIdentifier.", name);
+				Log.MTError (7024, $"The Watch Extension '{name}' does not specify a CFBundleIdentifier.");
 				return;
 			}
 
@@ -249,13 +249,13 @@ namespace Xamarin.iOS.Tasks
 
 			var executable = plist.GetCFBundleExecutable ();
 			if (string.IsNullOrEmpty (executable))
-				Log.LogError ("The Watch Extension '{0}' does not specify a CFBundleExecutable", name);
+				Log.MTError (7025, $"The Watch Extension '{name}' does not specify a CFBundleExecutable.");
 
 			if (!bundleIdentifier.StartsWith (watchAppBundleIdentifier + ".", StringComparison.Ordinal))
-				Log.LogError ("The Watch Extension '{0}' has an invalid CFBundleIdentifier ({1}), it does not begin with the main app bundle's CFBundleIdentifier ({2}).", name, bundleIdentifier, watchAppBundleIdentifier);
+				Log.MTError (7026, $"The Watch Extension '{name}' has an invalid CFBundleIdentifier ({bundleIdentifier}), it does not begin with the main app bundle's CFBundleIdentifier ({watchAppBundleIdentifier}).");
 
 			if (bundleIdentifier.EndsWith (".key", StringComparison.Ordinal))
-				Log.LogError ("The Watch Extension '{0}' has a CFBundleIdentifier ({1}) that ends with the illegal suffix \".key\".", name, bundleIdentifier);
+				Log.MTError (7027, $"The Watch Extension '{name}' has a CFBundleIdentifier ({bundleIdentifier}) that ends with the illegal suffix \".key\".");
 
 			var shortVersionString = plist.GetCFBundleShortVersionString ();
 			if (string.IsNullOrEmpty (shortVersionString))
@@ -273,30 +273,30 @@ namespace Xamarin.iOS.Tasks
 
 			var extension = plist.Get<PDictionary> ("NSExtension");
 			if (extension == null) {
-				Log.LogError ("The Watch Extension '{0}' has an invalid Info.plist: it does not contain an NSExtension dictionary.", name);
+				Log.MTError (7028, $"The Watch Extension '{name}' has an invalid Info.plist: it does not contain an NSExtension dictionary.");
 				return;
 			}
 
 			var extensionPointIdentifier = extension.Get<PString> ("NSExtensionPointIdentifier");
 			if (extensionPointIdentifier != null) {
 				if (extensionPointIdentifier.Value != "com.apple.watchkit")
-					Log.LogError ("The Watch Extension '{0}' has an invalid Info.plist: the NSExtensionPointIdentifier must be \"com.apple.watchkit\".", name);
+					Log.MTError (7029, $"The Watch Extension '{name}' has an invalid Info.plist: the NSExtensionPointIdentifier must be \"com.apple.watchkit\".");
 			} else {
-				Log.LogError ("The Watch Extension '{0}' has an invalid Info.plist: the NSExtension dictionary must contain an NSExtensionPointIdentifier.", name);
+				Log.MTError (7029, $"The Watch Extension '{name}' has an invalid Info.plist: the NSExtension dictionary must contain an NSExtensionPointIdentifier.");
 			}
 
 			PDictionary attributes;
 			if (!extension.TryGetValue ("NSExtensionAttributes", out attributes)) {
-				Log.LogError ("The Watch Extension '{0}' has an invalid Info.plist: the NSExtension dictionary must contain NSExtensionAttributes.", name);
+				Log.MTError (7030, $"The Watch Extension '{name}' has an invalid Info.plist: the NSExtension dictionary must contain NSExtensionAttributes.");
 				return;
 			}
 
 			var appBundleIdentifier = attributes.Get<PString> ("WKAppBundleIdentifier");
 			if (appBundleIdentifier != null) {
 				if (appBundleIdentifier.Value != watchAppBundleIdentifier)
-					Log.LogError ("The Watch Extension '{0}' has an invalid WKAppBundleIdentifier value ('{1}'), it does not match the parent Watch App bundle's CFBundleIdentifier ('{2}').", name, appBundleIdentifier.Value, watchAppBundleIdentifier);
+					Log.MTError (7031, $"The Watch Extension '{name}' has an invalid WKAppBundleIdentifier value ('{appBundleIdentifier.Value}'), it does not match the parent Watch App bundle's CFBundleIdentifier ('{watchAppBundleIdentifier}').");
 			} else {
-				Log.LogError ("The Watch Extension '{0}' has an invalid Info.plist: the NSExtensionAttributes dictionary must contain a WKAppBundleIdentifier.", name);
+				Log.MTError (7031, $"The Watch Extension '{name}' has an invalid Info.plist: the NSExtensionAttributes dictionary must contain a WKAppBundleIdentifier.");
 			}
 
 			PObject requiredDeviceCapabilities;
@@ -309,10 +309,10 @@ namespace Xamarin.iOS.Tasks
 					PBoolean watchCompanion;
 
 					if (requiredDeviceCapabilitiesDictionary.TryGetValue ("watch-companion", out watchCompanion))
-						Log.LogError ("The WatchKit Extension '{0}' has an invalid Info.plist: the UIRequiredDeviceCapabilities dictionary should not contain the 'watch-companion' capability.", name);
+						Log.MTError (7032, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities dictionary should not contain the 'watch-companion' capability.");
 				} else if (requiredDeviceCapabilitiesArray != null) {
 					if (requiredDeviceCapabilitiesArray.OfType<PString> ().Any (x => x.Value == "watch-companion"))
-						Log.LogError ("The WatchKit Extension '{0}' has an invalid Info.plist: the UIRequiredDeviceCapabilities array should not contain the 'watch-companion' capability.", name);
+						Log.MTError (7032, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities array should not contain the 'watch-companion' capability.");
 				}
 			}
 		}
@@ -322,14 +322,14 @@ namespace Xamarin.iOS.Tasks
 			var name = Path.GetFileNameWithoutExtension (path);
 			var info = Path.Combine (path, "Info.plist");
 			if (!File.Exists (info)) {
-				Log.LogError ("The Watch App '{0}' does not contain an Info.plist", name);
+				Log.MTError (7033, $"The Watch App '{name}' does not contain an Info.plist.");
 				return;
 			}
 
 			var plist = PDictionary.FromFile (info);
 			var bundleIdentifier = plist.GetCFBundleIdentifier ();
 			if (string.IsNullOrEmpty (bundleIdentifier)) {
-				Log.LogError ("The Watch App '{0}' does not specify a CFBundleIdentifier.", name);
+				Log.MTError (7034, $"The Watch App '{name}' does not specify a CFBundleIdentifier.");
 				return;
 			}
 
@@ -345,25 +345,25 @@ namespace Xamarin.iOS.Tasks
 			}
 
 			if (deviceFamily != expectedDeviceFamily)
-				Log.LogError ("The Watch App '{0}' does not have a valid UIDeviceFamily value. Expected '{1}' but found '{2} ({3})'.", name, expectedDeviceFamilyString, deviceFamily.ToString (), (int) deviceFamily);
+				Log.MTError (7035, $"The Watch App '{name}' does not have a valid UIDeviceFamily value. Expected '{expectedDeviceFamilyString}' but found '{deviceFamily.ToString ()} ({(int)deviceFamily})'.");
 
 			var executable = plist.GetCFBundleExecutable ();
 			if (string.IsNullOrEmpty (executable))
-				Log.LogError ("The Watch App '{0}' does not specify a CFBundleExecutable", name);
+				Log.MTError (7036, $"The Watch App '{name}' does not specify a CFBundleExecutable.");
 
 			if (bundleIdentifier != wkAppBundleIdentifier)
-				Log.LogError ("The WatchKit Extension '{0}' has an invalid WKAppBundleIdentifier value ('{1}'), it does not match the Watch App's CFBundleIdentifier ('{2}').", extensionName, wkAppBundleIdentifier, bundleIdentifier);
+				Log.MTError (7037, $"The WatchKit Extension '{extensionName}' has an invalid WKAppBundleIdentifier value ('{wkAppBundleIdentifier}'), it does not match the Watch App's CFBundleIdentifier ('{bundleIdentifier}').");
 
 			var companionAppBundleIdentifier = plist.Get<PString> ("WKCompanionAppBundleIdentifier");
 			if (companionAppBundleIdentifier != null) {
 				if (companionAppBundleIdentifier.Value != mainBundleIdentifier)
-					Log.LogError ("The Watch App '{0}' has an invalid WKCompanionAppBundleIdentifier value ('{1}'), it does not match the main app bundle's CFBundleIdentifier ('{2}').", name, companionAppBundleIdentifier.Value, mainBundleIdentifier);
+					Log.MTError (7038, $"The Watch App '{name}' has an invalid WKCompanionAppBundleIdentifier value ('{companionAppBundleIdentifier.Value}'), it does not match the main app bundle's CFBundleIdentifier ('{mainBundleIdentifier}').");
 			} else {
-				Log.LogError ("The Watch App '{0}' has an invalid Info.plist: the WKCompanionAppBundleIdentifier must exist and must match the main app bundle's CFBundleIdentifier.", name);
+				Log.MTError (7038, $"The Watch App '{name}' has an invalid Info.plist: the WKCompanionAppBundleIdentifier must exist and must match the main app bundle's CFBundleIdentifier.");
 			}
 
 			if (plist.ContainsKey ("LSRequiresIPhoneOS"))
-				Log.LogError ("The Watch App '{0}' has an invalid Info.plist: the LSRequiresIPhoneOS key must not be present.", name);
+				Log.MTError (7039, $"The Watch App '{name}' has an invalid Info.plist: the LSRequiresIPhoneOS key must not be present.");
 		}
 
 		public override bool Execute ()
@@ -375,7 +375,7 @@ namespace Xamarin.iOS.Tasks
 
 			var mainInfoPath = Path.Combine (AppBundlePath, "Info.plist");
 			if (!File.Exists (mainInfoPath)) {
-				Log.LogError ("The app bundle {0} does not contain an Info.plist.", AppBundlePath);
+				Log.MTError (7040, $"The app bundle {AppBundlePath} does not contain an Info.plist.");
 				return false;
 			}
 
@@ -383,18 +383,18 @@ namespace Xamarin.iOS.Tasks
 
 			var bundleIdentifier = plist.GetCFBundleIdentifier ();
 			if (string.IsNullOrEmpty (bundleIdentifier)) {
-				Log.LogError ("{0} does not specify a CFBundleIdentifier.", mainInfoPath);
+				Log.MTError (7041, $"{mainInfoPath} does not specify a CFBundleIdentifier.");
 				return false;
 			}
 
 			var executable = plist.GetCFBundleExecutable ();
 			if (string.IsNullOrEmpty (executable))
-				Log.LogError ("{0} does not specify a CFBundleExecutable", mainInfoPath);
+				Log.MTError (7042, $"{mainInfoPath} does not specify a CFBundleExecutable.");
 
 			var supportedPlatforms = plist.GetArray (ManifestKeys.CFBundleSupportedPlatforms);
 			var platform = string.Empty;
 			if (supportedPlatforms == null || supportedPlatforms.Count == 0) {
-				Log.LogError ("{0} does not specify a CFBundleSupportedPlatforms.", mainInfoPath);
+				Log.MTError (7043, $"{mainInfoPath} does not specify a CFBundleSupportedPlatforms.");
 			} else {
 				platform = (PString) supportedPlatforms[0];
 			}
@@ -425,11 +425,11 @@ namespace Xamarin.iOS.Tasks
 
 			if (validFamilies != null) {
 				if (validFamilies.Length == 0) {
-					Log.LogError ("{0} does not specify a UIDeviceFamily.", mainInfoPath);
+					Log.MTError (7044, $"{mainInfoPath} does not specify a UIDeviceFamily.");
 				} else {
 					foreach (var family in deviceFamilies) {
 						if (Array.IndexOf (validFamilies, family) == -1) {
-							Log.LogError ("{0} is invalid: the UIDeviceFamily key must contain a value for '{1}'.", mainInfoPath, family);
+							Log.MTError (7044, $"{mainInfoPath} is invalid: the UIDeviceFamily key must contain a value for '{family}'.");
 						}
 					}
 				}

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -324,7 +324,52 @@ namespace Xamarin.Bundler {
 	//					MT6001	Running version of Cecil doesn't support assembly stripping
 	//					MT6002	Could not strip assembly `{0}`.
 	//					MT6003  [UnauthorizedAccessException message]
-	// MT7xxx	reserved
+	// MT7xxx	msbuild reserved
+	//			MT700x	misc
+	//					MT7001	Could not resolve host IPs for WiFi debugger settings.
+	//					MT7002	This machine does not have any network adapters. This is required when debugging or profiling on device over WiFi.
+	//					MT7003	The App Extension '*' does not contain an Info.plist.
+	//					MT7004	The App Extension '*' does not specify a CFBundleIdentifier.
+	//					MT7005	The App Extension '*' does not specify a CFBundleExecutable.
+	//					MT7006	The App Extension '*' has an invalid CFBundleIdentifier (*), it does not begin with the main app bundle's CFBundleIdentifier (*).
+	//					MT7007	The App Extension '*' has a CFBundleIdentifier (*) that ends with the illegal suffix ".key".
+	//					MT7008	The App Extension '*' does not specify a CFBundleShortVersionString.
+	//					MT7009	The App Extension '*' has an invalid Info.plist: it does not contain an NSExtension dictionary.
+	//					MT7010	The App Extension '*' has an invalid Info.plist: the NSExtension dictionary does not contain an NSExtensionPointIdentifier value.
+	//					MT7011	The WatchKit Extension '*' has an invalid Info.plist: the NSExtension dictionary does not contain an NSExtensionAttributes dictionary.
+	//					MT7012	The WatchKit Extension '*' does not have exactly one watch app.
+	//					MT7013	The WatchKit Extension '*' has an invalid Info.plist: UIRequiredDeviceCapabilities must contain the 'watch-companion' capability.
+	//					MT7014	The Watch App '*' does not contain an Info.plist.
+	//					MT7015	The Watch App '*' does not specify a CFBundleIdentifier.
+	//					MT7016	The Watch App '*' has an invalid CFBundleIdentifier (*), it does not begin with the main app bundle's CFBundleIdentifier (*).
+	//					MT7017	The Watch App '*' does not have a valid UIDeviceFamily value. Expected 'Watch (4)' but found '* (*)'.
+	//					MT7018	The Watch App '*' does not specify a CFBundleExecutable
+	//					MT7019	The Watch App '*' has an invalid WKCompanionAppBundleIdentifier value ('*'), it does not match the main app bundle's CFBundleIdentifier ('*').
+	//					MT7020	The Watch App '*' has an invalid Info.plist: the WKWatchKitApp key must be present and have a value of 'true'.
+	//					MT7021	The Watch App '*' has an invalid Info.plist: the LSRequiresIPhoneOS key must not be present.
+	//					MT7022	The Watch App '*' does not contain a Watch Extension.
+	//					MT7023	The Watch Extension '*' does not contain an Info.plist.
+	//					MT7024	The Watch Extension '*' does not specify a CFBundleIdentifier.
+	//					MT7025	The Watch Extension '*' does not specify a CFBundleExecutable.
+	//					MT7026	The Watch Extension '*' has an invalid CFBundleIdentifier (*), it does not begin with the main app bundle's CFBundleIdentifier (*).
+	//					MT7027	The Watch Extension '*' has a CFBundleIdentifier (*) that ends with the illegal suffix ".key".
+	//					MT7028	The Watch Extension '*' has an invalid Info.plist: it does not contain an NSExtension dictionary.
+	//					MT7029	The Watch Extension '*' has an invalid Info.plist: the NSExtensionPointIdentifier must be "com.apple.watchkit".
+	//					MT7030	The Watch Extension '*' has an invalid Info.plist: the NSExtension dictionary must contain NSExtensionAttributes.
+	//					MT7031	The Watch Extension '*' has an invalid Info.plist: the NSExtensionAttributes dictionary must contain a WKAppBundleIdentifier.
+	//					MT7032	The WatchKit Extension '*' has an invalid Info.plist: UIRequiredDeviceCapabilities should not contain the 'watch-companion' capability.
+	//					MT7033	The Watch App '*' does not contain an Info.plist.
+	//					MT7034	The Watch App '*' does not specify a CFBundleIdentifier.
+	//					MT7035	The Watch App '*' does not have a valid UIDeviceFamily value. Expected '*' but found '* (*)'.
+	//					MT7036	The Watch App '*' does not specify a CFBundleExecutable.
+	//					MT7037	The WatchKit Extension '{extensionName}' has an invalid WKAppBundleIdentifier value ('*'), it does not match the Watch App's CFBundleIdentifier ('*').
+	//					MT7038	The Watch App '*' has an invalid Info.plist: the WKCompanionAppBundleIdentifier must exist and must match the main app bundle's CFBundleIdentifier.
+	//					MT7039	The Watch App '*' has an invalid Info.plist: the LSRequiresIPhoneOS key must not be present.
+	//					MT7040	The app bundle {AppBundlePath} does not contain an Info.plist.
+	//					MT7041	Main Info.plist path does not specify a CFBundleIdentifier.
+	//					MT7042	Main Info.plist path does not specify a CFBundleExecutable.
+	//					MT7043	Main Info.plist path does not specify a CFBundleSupportedPlatforms.
+	//					MT7044	Main Info.plist path does not specify a UIDeviceFamily.
 	// MT8xxx	runtime
 	//			MT800x	misc
 	//					MT8001	Version mismatch between the native Xamarin.iOS runtime and monotouch.dll. Please reinstall Xamarin.iOS.


### PR DESCRIPTION
- `LoggingExtensions` has a new `MTError` extension method that helps generate an msbuild error with the proper MTxxx format.
- Added error codes for 44 msbuild errors.
- Updated `docs/website/mtouch-errors.md` and `tools/mtouch/error.cs` accordingly.
- MT7001 contains some extra documentation (troubleshooting steps).