### PR TITLE
[msbuild] Remove TLSProvider option

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
@@ -48,9 +48,6 @@ namespace Xamarin.Mac.Tasks
 		public string TargetFrameworkVersion { get; set; }
 
 		[Required]
-		public string TLSProvider {	get; set; }
-
-		[Required]
 		public string SdkRoot {	get; set; }
 
 		[Required]
@@ -149,9 +146,6 @@ namespace Xamarin.Mac.Tasks
 					Log.LogWarning (null, null, null, AppManifest.ItemSpec, 0, 0, 0, 0, "Error loading '{0}': {1}", AppManifest.ItemSpec, ex.Message);
 				}
 			}
-
-			if (TargetFrameworkIdentifier == "Xamarin.Mac" && !string.IsNullOrEmpty (TLSProvider))
-				args.Add (string.Format ("--tls-provider={0}", TLSProvider.ToLowerInvariant()));
 
 			if (Profiling)
 				args.Add ("/profiling");
@@ -256,7 +250,6 @@ namespace Xamarin.Mac.Tasks
 			Log.LogTaskProperty ("SdkRoot", SdkRoot);
 			Log.LogTaskProperty ("TargetFrameworkIdentifier", TargetFrameworkIdentifier);
 			Log.LogTaskProperty ("TargetFrameworkVersion", TargetFrameworkVersion);
-			Log.LogTaskProperty ("TLSProvider", TLSProvider);
 			Log.LogTaskProperty ("UseXamMacFullFramework", UseXamMacFullFramework);
 			Log.LogTaskProperty ("Profiling", Profiling);
 			Log.LogTaskProperty ("AppManifest", AppManifest);

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -49,7 +49,6 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 		<I18n Condition="'$(I18n)' == ''"></I18n>
 		<IncludeMonoRuntime Condition="'$(IncludeMonoRuntime)' == ''">true</IncludeMonoRuntime>
 		<MonoBundlingExtraArgs Condition="'$(MonoBundlingExtraArgs)' == ''"></MonoBundlingExtraArgs>
-		<TlsProvider Condition="'$(TlsProvider)' == ''">Default</TlsProvider>
 		<LinkMode Condition="'$(LinkMode)' == ''">None</LinkMode>
 		<XamMacArch Condition="'$(XamMacArch)' == ''">x86_64</XamMacArch>
 		<MonoMacResourcePrefix Condition="'$(MonoMacResourcePrefix)' == ''">Resources</MonoMacResourcePrefix>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -517,7 +517,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			LinkMode="$(LinkMode)"
 			Debug="$(DebugSymbols)"
 			HttpClientHandler="$(HttpClientHandler)"
-			TLSProvider="$(TlsProvider)"
 			I18n="$(I18n)"
 			Profiling="$(Profiling)"
 			ExtraArguments="$(MonoBundlingExtraArgs)"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -149,9 +149,6 @@ namespace Xamarin.iOS.Tasks
 		public string TargetFrameworkVersion { get; set; }
 
 		[Required]
-		public string TLSProvider { get; set; }
-
-		[Required]
 		public bool UseLlvm { get; set; }
 
 		[Required]
@@ -453,9 +450,6 @@ namespace Xamarin.iOS.Tasks
 			if (!string.IsNullOrEmpty (HttpClientHandler))
 				args.Add (string.Format ("--http-message-handler={0}", HttpClientHandler));
 
-			if (!string.IsNullOrEmpty (TLSProvider))
-				args.Add (string.Format ("--tls-provider={0}", TLSProvider.ToLowerInvariant()));
-
 			string thumb = UseThumb && UseLlvm ? "+thumb2" : "";
 			string llvm = UseLlvm ? "+llvm" : "";
 			string abi = "";
@@ -667,7 +661,6 @@ namespace Xamarin.iOS.Tasks
 			Log.LogTaskProperty ("SdkVersion", SdkVersion);
 			Log.LogTaskProperty ("SymbolsList", SymbolsList);
 			Log.LogTaskProperty ("TargetFrameworkIdentifier", TargetFrameworkIdentifier);
-			Log.LogTaskProperty ("TLSProvider", TLSProvider);
 			Log.LogTaskProperty ("UseFloat32", UseFloat32);
 			Log.LogTaskProperty ("UseLlvm", UseLlvm);
 			Log.LogTaskProperty ("UseThumb", UseThumb);

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
@@ -40,7 +40,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<MtouchEnableGenericValueTypeSharing Condition="'$(MtouchEnableGenericValueTypeSharing)' == ''">True</MtouchEnableGenericValueTypeSharing>
 		<MtouchFastDev Condition="'$(MtouchFastDev)' == ''">False</MtouchFastDev>
 		<MtouchHttpClientHandler Condition="'$(MtouchHttpClientHandler)' == ''">HttpClientHandler</MtouchHttpClientHandler>
-		<MtouchTlsProvider Condition="'$(MtouchTlsProvider)' == ''">Default</MtouchTlsProvider>
 		<MtouchProfiling Condition="'$(MtouchProfiling)' == ''">False</MtouchProfiling>
 		<MtouchLinkerDumpDependencies Condition="'$(MtouchLinkerDumpDependencies)' == ''">False</MtouchLinkerDumpDependencies>
 		<MtouchLink Condition="'$(MtouchLink)' == ''">SdkOnly</MtouchLink>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -708,7 +708,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			ExtraArgs="$(MtouchExtraArgs)"
 			FastDev="$(MtouchFastDev)"
 			HttpClientHandler="$(MtouchHttpClientHandler)"
-			TLSProvider="$(MtouchTlsProvider)"
 			I18n="$(MtouchI18n)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)mtouch-cache"
 			IsAppExtension="$(IsAppExtension)"


### PR DESCRIPTION
* AppleTLS is the default since C7 and support up to TLS 1.2.

* MonoTLS is limited to SSLv3 and TLSv1: both are being deprecated.

* Note: C9 release notes already mention MonoTLS is deprecated and that it will be removed in the future.