### PR TITLE
[tests][xtro] Fix category name mapping (e.g. casing)

### DIFF
--- a/tests/xtro-sharpie/Helpers.cs
+++ b/tests/xtro-sharpie/Helpers.cs
@@ -63,6 +63,8 @@ namespace Extrospection {
 			{ "UITableViewCellAccessoryType", "UITableViewCellAccessory" },
 			{ "UITableViewCellStateMask", "UITableViewCellState" },
 			{ "WatchKitErrorCode", "WKErrorCode" }, // WebKit already had that name
+			// not enums
+			{ "NSMutableURLRequest", "NSMutableUrlRequest" },
 		};
 
 		public static string GetManagedName (string nativeName)

--- a/tests/xtro-sharpie/SelectorCheck.cs
+++ b/tests/xtro-sharpie/SelectorCheck.cs
@@ -118,7 +118,7 @@ namespace Extrospection {
 				// we inlined this protocol in UIResponder but Apple has it on NSObject
 				return "UIResponder";
 			default:
-				return category.ClassInterface.Name;
+				return Helpers.GetManagedName (category.ClassInterface.Name);
 			}
 		}
 	}


### PR DESCRIPTION
reference:
!missing-selector! NSMutableURLRequest::bindToHotspotHelperCommand: not bound