### PR TITLE
[avfoundation] Fix availability/visibility for AVAssetExportSessionPreset enum

### DIFF
--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -778,6 +778,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	// Convience enum for native string values 
+	[NoWatch]
 	public enum AVAssetExportSessionPreset {
 		[Mac(10,11)]
 		[Field ("AVAssetExportPresetLowQuality")]
@@ -796,12 +797,12 @@ namespace XamCore.AVFoundation {
 		Preset1280x720 = 5, // AVAssetExportPreset1280x720
 		[Field ("AVAssetExportPreset1920x1080")]
 		Preset1920x1080 = 6, // AVAssetExportPreset1920x1080
-	#if !MONOMAC
+
 		[iOS (9,0)]
 		[Mac (10,10)]
 		[Field ("AVAssetExportPreset3840x2160")]
 		Preset3840x2160 = 7, // AVAssetExportPreset3840x2160
-	#endif
+
 		[Field ("AVAssetExportPresetAppleM4A")]
 		AppleM4A = 8, // AVAssetExportPresetAppleM4A
 		[Field ("AVAssetExportPresetPassthrough")]


### PR DESCRIPTION
1. it's not available from watchOS

references (watchos.unclassified):
!unknown-field! AVAssetExportPreset1280x720 bound
!unknown-field! AVAssetExportPreset1920x1080 bound
!unknown-field! AVAssetExportPreset3840x2160 bound
!unknown-field! AVAssetExportPreset640x480 bound
!unknown-field! AVAssetExportPreset960x540 bound
!unknown-field! AVAssetExportPresetAppleM4A bound
!unknown-field! AVAssetExportPresetHighestQuality bound
!unknown-field! AVAssetExportPresetLowQuality bound
!unknown-field! AVAssetExportPresetMediumQuality bound
!unknown-field! AVAssetExportPresetPassthrough bound

2. AVAssetExportPreset3840x2160 was decorated with [Mac (10,10)] but
   inside a `#if !MONOMAC`

reference:
osx.unclassified:!missing-field! AVAssetExportPreset3840x2160 not bound