### PR TITLE
[generator] Optimize smart enums support

### DIFF
--- a/src/ObjCRuntime/Dlfcn.cs
+++ b/src/ObjCRuntime/Dlfcn.cs
@@ -29,6 +29,7 @@
 //
 //
 using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 #if !COREBUILD
 using XamCore.Foundation;
@@ -409,5 +410,12 @@ namespace XamCore.ObjCRuntime {
 			}
 		}
 #endif // !COREBUILD
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
+		public static unsafe IntPtr CachePointer (IntPtr handle, string constant, IntPtr* storage)
+		{
+			if (*storage == IntPtr.Zero)
+				*storage = Dlfcn.GetIntPtr (handle, constant);
+			return *storage;
+		}
 	}
 }

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -6988,7 +6988,8 @@ namespace XamCore.Foundation
 		[Export ("length")]
 		nint Length {get;}
 
-		[Export ("isEqualToString:"), Internal]
+		[Sealed]
+		[Export ("isEqualToString:")]
 		bool IsEqualTo (IntPtr handle);
 		
 		[Export ("compare:")]


### PR DESCRIPTION
* Reduce the required metadata, i.e. from one field per constant to a
  single array of `IntPtr`;

* Don't store/create the `NSString` unless required, i.e. keep `IntPtr`
  for comparison (but still compare them as `NSString`, not pointers);

* Avoid `NSString ==` as it will do a null check for the first paramater
  everytime, and there's a (single) check already in place for this;

Size						before		after
---------------------------	--------	--------
Xamarin.iOS.dll (32bits)	12507136	12502528
Xamarin.iOS.dll (64bits)	12507648	12503040
Xamarin.TVOS.dll			 8819712	 8815104
Xamarin.WatchOS.dll			 4781568	 4773888

Not a huge difference *yet* but we're only starting to use, and replace
manual code with, smart enums.