### PR TITLE
[xharness] Fix listing modified files for pull requests.

### DIFF
--- a/tests/xharness/GitHub.cs
+++ b/tests/xharness/GitHub.cs
@@ -131,12 +131,8 @@ namespace xharness
 
 		static IEnumerable<string> GetModifiedFilesLocally (Harness harness, int pull_request)
 		{
-			var doc = FetchPullRequest (harness, pull_request);
-			if (doc == null)
-				return null;
-
-			var base_commit = doc.SelectSingleNode ("/root/base/sha")?.InnerText;
-			var head_commit = doc.SelectSingleNode ("/root/head/sha")?.InnerText;
+			var base_commit = $"origin/pr/{pull_request}/merge^";
+			var head_commit = $"origin/pr/{pull_request}/merge";
 
 			harness.Log ("Fetching modified files for commit range {0}..{1}", base_commit, head_commit);
 


### PR DESCRIPTION
The previous method of getting the base and head sha from the pull request
doesn't work if the pull request has been rebased.

Example: https://github.com/xamarin/xamarin-macios/pull/1238

Resulted in this [1]:

    Fetching modified files for commit range cf07825667aa444c988c82b7e29cefc5f8ba7bcd..6aa2b9517ac35374dfa4ded41d1e2ff52778da07
    git diff-tree --no-commit-id --name-only -r cf07825667aa444c988c82b7e29cefc5f8ba7bcd..6aa2b9517ac35374dfa4ded41d1e2ff52778da07
    Found 20 modified file(s) in the pull request #1238.
        Makefile
        Versions-ios.plist.in
        Versions-mac.plist.in
        external/llvm
        external/mono
        msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
        msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
        msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
        msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
        msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
        msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
        src/Makefile
        src/UIKit/UIScreen.cs
        src/appkit.cs
        src/generator-diff.mk
        tests/introspection/ApiTypoTest.cs
        tests/introspection/Mac/MacApiTypoTest.cs
        tests/introspection/Mac/introspection-mac.csproj
        tests/xharness/Harness.cs
        versions-check.csharp

which is listing way too many files.

[1]: https://jenkins.mono-project.com/job/xamarin-macios-pr-builder/2118/Test_Report/Harness.log