### PR TITLE
[foundation] Use a smart enum for NSStringTransform

### DIFF
--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -1191,26 +1191,6 @@ namespace XamCore.Foundation  {
 		Abbreviated
 	}
 
-	// Xamarin specific
-	public enum NSStringTransform {
-		LatinToKatakana,
-		LatinToHiragana,
-		LatinToHangul,
-		LatinToArabic,
-		LatinToHebrew,
-		LatinToThai,
-		LatinToCyrillic,
-		LatinToGreek,
-		ToLatin,
-		MandarinToLatin,
-		HiraganaToKatakana,
-		FullwidthToHalfwidth,
-		ToXmlHex,
-		ToUnicodeName,
-		StripCombiningMarks,
-		StripDiacritics,
-	}
-
 #if MONOMAC
 	[Mac(10,11)]
 	[Native]

--- a/src/Foundation/Enums.cs
+++ b/src/Foundation/Enums.cs
@@ -65,4 +65,55 @@ namespace XamCore.Foundation {
 		[Field ("NSMetadataUbiquitousItemDownloadingStatusNotDownloaded")]
 		NotDownloaded,
 	}
+
+	[iOS (9,0)][Mac (10,11)]
+	public enum NSStringTransform {
+		[Field ("NSStringTransformLatinToKatakana")]
+		LatinToKatakana,
+
+		[Field ("NSStringTransformLatinToHiragana")]
+		LatinToHiragana,
+
+		[Field ("NSStringTransformLatinToHangul")]
+		LatinToHangul,
+
+		[Field ("NSStringTransformLatinToArabic")]
+		LatinToArabic,
+
+		[Field ("NSStringTransformLatinToHebrew")]
+		LatinToHebrew,
+
+		[Field ("NSStringTransformLatinToThai")]
+		LatinToThai,
+
+		[Field ("NSStringTransformLatinToCyrillic")]
+		LatinToCyrillic,
+
+		[Field ("NSStringTransformLatinToGreek")]
+		LatinToGreek,
+
+		[Field ("NSStringTransformToLatin")]
+		ToLatin,
+
+		[Field ("NSStringTransformMandarinToLatin")]
+		MandarinToLatin,
+
+		[Field ("NSStringTransformHiraganaToKatakana")]
+		HiraganaToKatakana,
+
+		[Field ("NSStringTransformFullwidthToHalfwidth")]
+		FullwidthToHalfwidth,
+
+		[Field ("NSStringTransformToXMLHex")]
+		ToXmlHex,
+
+		[Field ("NSStringTransformToUnicodeName")]
+		ToUnicodeName,
+
+		[Field ("NSStringTransformStripCombiningMarks")]
+		StripCombiningMarks,
+
+		[Field ("NSStringTransformStripDiacritics")]
+		StripDiacritics,
+	}
 }

--- a/src/Foundation/NSMutableString.cs
+++ b/src/Foundation/NSMutableString.cs
@@ -19,10 +19,5 @@ namespace XamCore.Foundation {
 			if (index < 0 || index > Length)
 				throw new ArgumentOutOfRangeException ("index");
 		}
-
-		public bool ApplyTransform (NSStringTransform transform, bool reverse, NSRange range, out NSRange resultingRange)
-		{
-			return ApplyTransform (NSString.NSStringTransformToCode (transform), reverse, range, out resultingRange);
-		}
 	}
 }

--- a/src/Foundation/NSString.cs
+++ b/src/Foundation/NSString.cs
@@ -208,45 +208,6 @@ namespace XamCore.Foundation {
 			return Equals (this, obj as NSString);
 		}
 
-		static internal NSString NSStringTransformToCode (NSStringTransform transform)
-		{
-			switch (transform){
-			case NSStringTransform.LatinToKatakana:
-				return NSString.NSStringTransformLatinToKatakana;
-			case NSStringTransform.LatinToHiragana:
-				return NSString.NSStringTransformLatinToHiragana;
-			case NSStringTransform.LatinToHangul:
-				return NSString.NSStringTransformLatinToHangul;
-			case NSStringTransform.LatinToArabic:
-				return NSString.NSStringTransformLatinToArabic;
-			case NSStringTransform.LatinToHebrew:
-				return NSString.NSStringTransformLatinToHebrew;
-			case NSStringTransform.LatinToThai:
-				return NSString.NSStringTransformLatinToThai;
-			case NSStringTransform.LatinToCyrillic:
-				return NSString.NSStringTransformLatinToCyrillic;
-			case NSStringTransform.LatinToGreek:
-				return NSString.NSStringTransformLatinToGreek;
-			case NSStringTransform.ToLatin:
-				return NSString.NSStringTransformToLatin;
-			case NSStringTransform.MandarinToLatin:
-				return NSString.NSStringTransformMandarinToLatin;
-			case NSStringTransform.HiraganaToKatakana:
-				return NSString.NSStringTransformHiraganaToKatakana;
-			case NSStringTransform.FullwidthToHalfwidth:
-				return NSString.NSStringTransformFullwidthToHalfwidth;
-			case NSStringTransform.ToXmlHex:
-				return NSString.NSStringTransformToXMLHex;
-			case NSStringTransform.ToUnicodeName:
-				return NSString.NSStringTransformToUnicodeName;
-			case NSStringTransform.StripCombiningMarks:
-				return NSString.NSStringTransformStripCombiningMarks;
-			case NSStringTransform.StripDiacritics:
-				return NSString.NSStringTransformStripDiacritics;
-			}
-			return null;
-		}
-
 		[DllImport ("__Internal")]
 		extern static IntPtr xamarin_localized_string_format (IntPtr fmt);
 		[DllImport ("__Internal")]
@@ -314,7 +275,7 @@ namespace XamCore.Foundation {
 
 		public NSString TransliterateString (NSStringTransform transform, bool reverse)
 		{
-			return TransliterateString (NSStringTransformToCode (transform), reverse);
+			return TransliterateString (transform.GetConstant (), reverse);
 		}
 		
 		public override int GetHashCode ()

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -7149,70 +7149,6 @@ namespace XamCore.Foundation
 		[return: NullAllowed]
 		NSString TransliterateString (NSString transform, bool reverse);
 
-		[iOS(9,0), Mac(10,11)]
-		[Field ("NSStringTransformLatinToKatakana"), Internal]
-		NSString NSStringTransformLatinToKatakana { get; }
-		
-		[iOS(9,0), Mac(10,11)]
-		[Field ("NSStringTransformLatinToHiragana"), Internal]
-		NSString NSStringTransformLatinToHiragana { get; }
-		
-		[iOS(9,0), Mac(10,11)]
-		[Field ("NSStringTransformLatinToHangul"), Internal]
-		NSString NSStringTransformLatinToHangul { get; }
-		
-		[iOS(9,0), Mac(10,11)]
-		[Field ("NSStringTransformLatinToArabic"), Internal]
-		NSString NSStringTransformLatinToArabic { get; }
-		
-		[iOS(9,0), Mac(10,11)]
-		[Field ("NSStringTransformLatinToHebrew"), Internal]
-		NSString NSStringTransformLatinToHebrew { get; }
-		
-		[iOS(9,0), Mac(10,11)]
-		[Field ("NSStringTransformLatinToThai"), Internal]
-		NSString NSStringTransformLatinToThai { get; }
-		
-		[iOS(9,0), Mac(10,11)]
-		[Field ("NSStringTransformLatinToCyrillic"), Internal]
-		NSString NSStringTransformLatinToCyrillic { get; }
-		
-		[iOS(9,0), Mac(10,11)]
-		[Field ("NSStringTransformLatinToGreek"), Internal]
-		NSString NSStringTransformLatinToGreek { get; }
-		
-		[iOS(9,0), Mac(10,11)]
-		[Field ("NSStringTransformToLatin"), Internal]
-		NSString NSStringTransformToLatin { get; }
-		
-		[iOS(9,0), Mac(10,11)]
-		[Field ("NSStringTransformMandarinToLatin"), Internal]
-		NSString NSStringTransformMandarinToLatin { get; }
-		
-		[iOS(9,0), Mac(10,11)]
-		[Field ("NSStringTransformHiraganaToKatakana"), Internal]
-		NSString NSStringTransformHiraganaToKatakana { get; }
-		
-		[iOS(9,0), Mac(10,11)]
-		[Field ("NSStringTransformFullwidthToHalfwidth"), Internal]
-		NSString NSStringTransformFullwidthToHalfwidth { get; }
-		
-		[iOS(9,0), Mac(10,11)]
-		[Field ("NSStringTransformToXMLHex"), Internal]
-		NSString NSStringTransformToXMLHex { get; }
-		
-		[iOS(9,0), Mac(10,11)]
-		[Field ("NSStringTransformToUnicodeName"), Internal]
-		NSString NSStringTransformToUnicodeName { get; }
-		
-		[iOS(9,0), Mac(10,11)]
-		[Field ("NSStringTransformStripCombiningMarks"), Internal]
-		NSString NSStringTransformStripCombiningMarks { get; }
-		
-		[iOS(9,0), Mac(10,11)]
-		[Field ("NSStringTransformStripDiacritics"), Internal]
-		NSString NSStringTransformStripDiacritics { get; }
-
 		[Export ("hasPrefix:")]
 		bool HasPrefix (NSString prefix);
 
@@ -7262,8 +7198,13 @@ namespace XamCore.Foundation
 		nuint ReplaceOcurrences (NSString target, NSString replacement, NSStringCompareOptions options, NSRange range);
 
 		[iOS (9,0), Mac(10,11)]
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("applyTransform:reverse:range:updatedRange:")]
 		bool ApplyTransform (NSString transform, bool reverse, NSRange range, out NSRange resultingRange);
+
+		[iOS (9,0)][Mac (10,11)]
+		[Wrap ("ApplyTransform (transform.GetConstant (), reverse, range, out resultingRange)")]
+		bool ApplyTransform (NSStringTransform transform, bool reverse, NSRange range, out NSRange resultingRange);
 
 		[Export ("replaceCharactersInRange:withString:")]
 		void ReplaceCharactersInRange (NSRange range, NSString aString);


### PR DESCRIPTION
and reduce the amount of manual code required.