### PR TITLE
[XM] Change mmp defaults to static registrar and disable lldb attach …

### DIFF
--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -196,14 +196,20 @@ namespace Xamarin.MMP.Tests
 		{
 			RunMMPTest (tmpDir => {
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir);
+
+				// Due to https://bugzilla.xamarin.com/show_bug.cgi?id=48311 we can get warnings related to the registrar
+				// So ignore anything with registrar.m or gl3.h in the line
+				Func<string, bool> hasLegitWarning = results =>
+					results.Split (Environment.NewLine.ToCharArray ()).Any (x => x.Contains ("warning") && !x.Contains ("registrar.m") && !x.Contains ("gl3.h"));
+
 				// Mobile
 				string buildResults = TI.TestUnifiedExecutable (test).BuildOutput;
-				Assert.IsTrue (!buildResults.Contains ("warning"), "Unified_HelloWorld_ShouldHaveNoWarnings - Mobile had warning: \n" + buildResults);
+				Assert.IsTrue (!hasLegitWarning (buildResults), "Unified_HelloWorld_ShouldHaveNoWarnings - Mobile had warning: \n" + buildResults);
 
 				// XM45
 				test.XM45 = true;
 				buildResults = TI.TestUnifiedExecutable (test).BuildOutput;
-				Assert.IsTrue (!buildResults.Contains ("warning"), "Unified_HelloWorld_ShouldHaveNoWarnings - XM45 had warning: \n" + buildResults);
+				Assert.IsTrue (!hasLegitWarning (buildResults), "Unified_HelloWorld_ShouldHaveNoWarnings - XM45 had warning: \n" + buildResults);
 			});
 		}
 

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -80,7 +80,7 @@ namespace Xamarin.Bundler {
 		static bool? thread_check = null;
 		static string link_flags = null;
 		static LinkerOptions linker_options;
-		static bool disable_lldb_attach = false;
+		static bool? disable_lldb_attach = null;
 		static string machine_config_path = null;
 
 		static bool arch_set = false;
@@ -504,7 +504,7 @@ namespace Xamarin.Bundler {
 			HashSet<string> internalSymbols = new HashSet<string> ();
 
 			if (registrar == RegistrarMode.Default)
-				registrar = RegistrarMode.Dynamic;
+				registrar = App.EnableDebug ? RegistrarMode.Dynamic : RegistrarMode.Static;
 			if (is_extension)
 				registrar = RegistrarMode.Static;
 			
@@ -917,7 +917,7 @@ namespace Xamarin.Bundler {
 				if (!App.IsDefaultMarshalManagedExceptionMode)
 					sw.WriteLine ("\txamarin_marshal_managed_exception_mode = MarshalManagedExceptionMode{0};", App.MarshalManagedExceptions);
 				sw.WriteLine ("\txamarin_marshal_objectivec_exception_mode = MarshalObjectiveCExceptionMode{0};", App.MarshalObjectiveCExceptions);
-				if (disable_lldb_attach)
+				if (disable_lldb_attach.HasValue ? disable_lldb_attach.Value : !App.EnableDebug)
 					sw.WriteLine ("\txamarin_disable_lldb_attach = true;");
 				sw.WriteLine ();
 				if (Driver.registrar == RegistrarMode.Static)


### PR DESCRIPTION
…in release mode

- Static registrar is now proven and can be flipped on for default on release
- LLDB attach isn't very helpful in release mode and pops up the install xcode dialog