### PR TITLE
[generator] Remove support for [Alpha].

### DIFF
--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -141,9 +141,6 @@ class BindingTouch {
 	{
 		bool show_help = false;
 		bool zero_copy = false;
-#if !XAMCORE_2_0
-		bool alpha = false;
-#endif
 		string basedir = null;
 		string tmpdir = null;
 		string ns = null;
@@ -183,9 +180,7 @@ class BindingTouch {
 
 		var os = new OptionSet () {
 			{ "h|?|help", "Displays the help", v => show_help = true },
-#if !XAMCORE_2_0
-			{ "a", "Include alpha bindings", v => alpha = true },
-#endif
+			{ "a", "Include alpha bindings (Obsolete).", v => {}, true },
 			{ "outdir=", "Sets the output directory for the temporary binding files", v => { basedir = v; }},
 			{ "o|out=", "Sets the name of the output library", v => outfile = v },
 			{ "tmpdir=", "Sets the working directory for temp files", v => { tmpdir = v; delete_temp = false; }},
@@ -263,11 +258,6 @@ class BindingTouch {
 			return 1;
 		}
 
-#if !XAMCORE_2_0
-		if (alpha)
-			defines.Add ("ALPHA");
-#endif
-		
 		if (tmpdir == null)
 			tmpdir = GetWorkDir ();
 
@@ -429,9 +419,6 @@ class BindingTouch {
 				OnlyDesktop = true,
 #endif
 				Compat = !Unified,
-#if !XAMCORE_2_0
-				Alpha = alpha,
-#endif
 				InlineSelectors = inline_selectors,
 				SkipSystemDrawing = addSystemDrawingReferences
 			};

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1578,9 +1578,6 @@ public partial class Generator : IMemberGatherer {
 	//
 	Dictionary<string,MethodInfo> delegate_types = new Dictionary<string,MethodInfo> ();
 
-#if !XAMCORE_2_0
-	public bool Alpha;
-#endif
 	public bool OnlyDesktop;
 	public bool Compat;
 	public bool SkipSystemDrawing;
@@ -2512,11 +2509,6 @@ public partial class Generator : IMemberGatherer {
 
 	bool SkipGenerationOfType (Type t)
 	{
-#if !XAMCORE_2_0
-		if (HasAttribute (t, typeof (AlphaAttribute)) && Alpha == false)
-			return true;
-#endif
-
 		if (t.IsUnavailable ())
 			return true;
 
@@ -2632,11 +2624,6 @@ public partial class Generator : IMemberGatherer {
 			var tselectors = new List<string> ();
 			
 			foreach (var pi in GetTypeContractProperties (t)){
-#if !XAMCORE_2_0
-				if (HasAttribute (pi, typeof (AlphaAttribute)) && Alpha == false)
-					continue;
-#endif
-
 				if (pi.IsUnavailable ())
 					continue;
 
@@ -2689,10 +2676,6 @@ public partial class Generator : IMemberGatherer {
 				if (mi.IsSpecialName)
 					continue;
 
-#if !XAMCORE_2_0
-				if (HasAttribute (mi, typeof (AlphaAttribute)) && Alpha == false)
-					continue;
-#endif
 				if (mi.IsUnavailable ())
 					continue;
 
@@ -2728,10 +2711,6 @@ public partial class Generator : IMemberGatherer {
 					} else if (attr is NoDefaultValueAttribute) {
 						seenNoDefaultValue = true;
 						continue;
-#if !XAMCORE_2_0
-					} else if (attr is AlphaAttribute) {
-						continue;
-#endif
 					} else if (attr is SealedAttribute || attr is EventArgsAttribute || attr is DelegateNameAttribute || attr is EventNameAttribute || attr is IgnoredInDelegateAttribute || attr is ObsoleteAttribute || attr is NewAttribute || attr is PostGetAttribute || attr is NullAllowedAttribute || attr is CheckDisposedAttribute || attr is SnippetAttribute || attr is AppearanceAttribute || attr is ThreadSafeAttribute || attr is AutoreleaseAttribute || attr is EditorBrowsableAttribute || attr is AdviceAttribute || attr is OverrideAttribute || attr is DelegateApiNameAttribute || attr is ForcedTypeAttribute)
 						continue;
 					else if (attr is MarshalNativeExceptionsAttribute)
@@ -2775,10 +2754,6 @@ public partial class Generator : IMemberGatherer {
 			}
 
 			foreach (var pi in t.GatherProperties (BindingFlags.Instance | BindingFlags.Public)){
-#if !XAMCORE_2_0
-				if (HasAttribute (pi, typeof (AlphaAttribute)) && Alpha == false)
-					continue;
-#endif
 				if (pi.IsUnavailable ())
 					continue;
 
@@ -6194,11 +6169,6 @@ public partial class Generator : IMemberGatherer {
 						}
 #endif
 
-#if !XAMCORE_2_0
-				if (HasAttribute (mi, typeof (AlphaAttribute)) && Alpha == false)
-					continue;
-#endif
-
 				if (mi.IsUnavailable ())
 					continue;
 
@@ -6257,11 +6227,6 @@ public partial class Generator : IMemberGatherer {
 			var generated_properties = new List<string> (); // All properties that have been generated
 
 			foreach (var pi in GetTypeContractProperties (type).OrderBy (p => p.Name, StringComparer.Ordinal)) {
-
-#if !XAMCORE_2_0
-				if (HasAttribute (pi, typeof (AlphaAttribute)) && Alpha == false)
-					continue;
-#endif
 
 				if (pi.IsUnavailable ())
 					continue;
@@ -7171,11 +7136,6 @@ public partial class Generator : IMemberGatherer {
 		var customAttrs = mi.GetCustomAttributes (true);
 		if (customAttrs.OfType<IgnoredInDelegateAttribute> ().Any ())
 			return true;
-#if !XAMCORE_2_0
-		if (customAttrs.OfType<AlphaAttribute> ().Any ())
-			return true;
-#endif
-
 		return false;
 	}
 


### PR DESCRIPTION
* We don't use it.
* It's not documented.
* It's not in Unified.
* I've never seen a customer project using it.

So remove it to simplify our code.