### PR TITLE
[msbuild] Don't rm -rf the .dSYM dir in the _CompileToNative target

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -738,9 +738,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<Output TaskParameter="CompiledArchitectures" PropertyName="_CompiledArchitectures" />
 			<Output TaskParameter="NativeLibraries" ItemName="_NativeLibrary" />
 		</MTouch>
-
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(AppBundleDir).dSYM" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
 	</Target>
 
 	<Target Name="_GenerateFrameworkDebugSymbols" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsWatchApp)' != 'true'" DependsOnTargets="_CompileToNative;_CollectFrameworks"
@@ -787,7 +784,11 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_GenerateDebugSymbols" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsWatchApp)' == 'false'" DependsOnTargets="_CompileToNative;_ParseExtraMtouchArgs;_GenerateFrameworkDebugSymbols"
 		Inputs="$(_NativeExecutable)"
 		Outputs="$(AppBundleDir).dSYM\Contents\Info.plist">
-		<!--- run dsymutil on the main bundle -->
+
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(AppBundleDir).dSYM" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
+
+		<!-- run dsymutil on the main bundle -->
 		<DSymUtil
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' And '$(MtouchNoDSymUtil)' == 'false'"
@@ -800,7 +801,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		>
 		</DSymUtil>
 
-		<!--- strip the debug symbols from the $(_NativeExecutable) -->
+		<!-- strip the debug symbols from the $(_NativeExecutable) -->
 		<SymbolStrip
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' And '$(MtouchDebug)' == 'false' And '$(MtouchNoSymbolStrip)' == 'false'"


### PR DESCRIPTION
That logic wrongly assumed that mtouch will always output a new
native executable file and that the dSYMs will need to be regenerated,
but that is not the case.

Move the rm -rf logic into the _GenerateDebugSymbols target instead,
so that we only delete the dSYMs if we've already committed to
regenerating them.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=41231

For a walk-through of the problem, see
https://bugzilla.xamarin.com/show_bug.cgi?id=47803#c9