### PR TITLE
[intents] Add obsoleted default ctor for INRideDriver and INRideStatus

### DIFF
--- a/src/Intents/INCompat.cs
+++ b/src/Intents/INCompat.cs
@@ -1,0 +1,29 @@
+// Compatibility stubs
+
+#if XAMCORE_2_0 && IOS
+
+using System;
+using XamCore.Foundation;
+using XamCore.ObjCRuntime;
+
+namespace XamCore.Intents {
+
+#if !XAMCORE_4_0
+	public partial class INRideDriver {
+
+		[Obsolete ("This constructor does not create a valid instance of the type")]
+		public INRideDriver () : base (NSObjectFlag.Empty)
+		{
+		}
+	}
+
+	public partial class INRideStatus {
+
+		[Obsolete ("This constructor does not create a valid instance of the type")]
+		public INRideStatus ()
+		{
+		}
+	}
+#endif
+}
+#endif

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -819,6 +819,7 @@ IMAGEKIT_CORE_SOURCES = \
 # Intents
 
 INTENTS_SOURCES = \
+	Intents/INCompat.cs \
 	Intents/INIntentResolutionResult.cs \
 	Intents/INPriceRange.cs \
 	Intents/INRideOption.cs \


### PR DESCRIPTION
Xcode 8.2 (beta 1) changed the default `init` to throw the following

`NSInvalidArgumentException Reason: *** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[1]`

So we introduce compatibility stubs to avoid the native exception, warn
the developers and maintain binary compatibility