### PR TITLE
[networkextension] Mark NEPacketTunnelNetworkSettings default .ctor obsolete

### DIFF
--- a/src/NetworkExtension/NECompat.cs
+++ b/src/NetworkExtension/NECompat.cs
@@ -1,0 +1,19 @@
+#if XAMCORE_2_0 || !MONOMAC
+
+using System;
+using XamCore.Foundation;
+
+namespace XamCore.NetworkExtension {
+
+#if !XAMCORE_4_0
+	public partial class NEPacketTunnelNetworkSettings {
+
+		[Obsolete ("This constructor does not create a valid instance of the type")]
+		public NEPacketTunnelNetworkSettings () : base (NSObjectFlag.Empty)
+		{
+		}
+	}
+#endif
+}
+
+#endif

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -971,6 +971,7 @@ NETWORKEXTENSION_CORE_SOURCES = \
 	NetworkExtension/NEVpnConnectionStartOptions.cs \
 
 NETWORKEXTENSION_SOURCES = \
+	NetworkExtension/NECompat.cs \
 	NetworkExtension/NEFilterFlow.cs \
 	NetworkExtension/NEFilterProvider.cs \
 

--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -1293,6 +1293,7 @@ namespace XamCore.NetworkExtension {
 				
 	[iOS (9,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NETunnelNetworkSettings))]
+	[DisableDefaultCtor]
 	interface NEPacketTunnelNetworkSettings {
 		[Export ("initWithTunnelRemoteAddress:")]
 		IntPtr Constructor (string address);


### PR DESCRIPTION
The returned instance cannot be used [1]. However removing it would be
a breaking change so we're obsoleting the API (until a new version of
the profile).

[1] https://github.com/xamarin/xamarin-macios/pull/1158#discussion_r90044577