### PR TITLE
Changes GetVirtualProjectPath to make relative paths when building from VS

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/BundleResource.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/BundleResource.cs
@@ -68,8 +68,14 @@ namespace Xamarin.MacDev
 			}
 
 			// HACK: This is for Visual Studio iOS projects
-			if (isVSBuild)
-				return item.ItemSpec;
+			if (isVSBuild) {
+				if (item.GetMetadata("DefiningProjectFullPath") != item.GetMetadata("MSBuildProjectFullPath")) {
+					return item.GetMetadata("FullPath").Replace(item.GetMetadata ("DefiningProjectDirectory"), string.Empty);
+				}
+				else {
+					return item.ItemSpec;
+				}
+			}
 
 			var definingProjectFullPath = item.GetMetadata ("DefiningProjectFullPath");
 			var path = item.GetMetadata ("FullPath");


### PR DESCRIPTION
This change fixes the build of solutions that contain Shared Projects with BundleResources from VS. In that case the ItemSpec of the BundleResource is the full Windows path, so we ended up with an invalid path.

Fixes Bug #47570 - On building "FilterDemoApp", it gives "path's format is not supported" build error.

https://bugzilla.xamarin.com/show_bug.cgi?id=47570