### PR TITLE
Copy watchOS app dll to output directory

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.Common.targets
@@ -96,7 +96,6 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(AppBundleDir).dSYM" />
 	</Target>
 
-	<Target Name="CopyFilesToOutputDirectory" />
 	<Target Name="CreateIpa"/>
 
 	<ItemGroup>


### PR DESCRIPTION
If the watchOS dll app is not copied to the output directory, the watchOS app project will be outdated for VS and it'll be built all the time. That will also cause the iOS app project to be built.