### PR TITLE
[generator] Don't output ArgumentSemantic when they are not required

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -5221,7 +5221,7 @@ public partial class Generator : IMemberGatherer {
 		// it does not make sense on every properties, depending on the their types
 		if (output_semantics && (minfo.mi is PropertyInfo)) {
 			var t = minfo.property.PropertyType;
-			output_semantics = t.IsPrimitive ? t == typeof (IntPtr) : t != typeof (string);
+			output_semantics = !t.IsPrimitive || t == typeof (IntPtr);
 		}
 		
 		if (output_semantics)

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -4855,7 +4855,7 @@ public partial class Generator : IMemberGatherer {
 
 			if (!minfo.is_sealed || !minfo.is_wrapper) {
 				PrintDelegateProxy (pi.GetGetMethod ());
-				PrintExport (sel, export.ArgumentSemantic);
+				PrintExport (minfo, sel, export.ArgumentSemantic);
 			}
 
 			PrintPreserveAttribute (pi.GetGetMethod());
@@ -4907,7 +4907,7 @@ public partial class Generator : IMemberGatherer {
 			PrintPlatformAttributes (pi.GetSetMethod ());
 
 			if (not_implemented_attr == null && (!minfo.is_sealed || !minfo.is_wrapper))
-				PrintExport (sel, export.ArgumentSemantic);
+				PrintExport (minfo, sel, export.ArgumentSemantic);
 
 			PrintPreserveAttribute (pi.GetSetMethod());
 			if (minfo.is_abstract){
@@ -5210,14 +5210,21 @@ public partial class Generator : IMemberGatherer {
 			print ("[Export (\"{0}\"{1})]", minfo.selector, minfo.is_variadic ? ", IsVariadic = true" : string.Empty);
 	}
 
-	void PrintExport (ExportAttribute ea)
+	void PrintExport (MemberInformation minfo, ExportAttribute ea)
 	{
-		PrintExport (ea.Selector, ea.ArgumentSemantic);
+		PrintExport (minfo, ea.Selector, ea.ArgumentSemantic);
 	}
 
-	void PrintExport (string sel, ArgumentSemantic semantic)
+	void PrintExport (MemberInformation minfo, string sel, ArgumentSemantic semantic)
 	{
-		if (semantic != ArgumentSemantic.None)
+		bool output_semantics = semantic != ArgumentSemantic.None;
+		// it does not make sense on every properties, depending on the their types
+		if (output_semantics && (minfo.mi is PropertyInfo)) {
+			var t = minfo.property.PropertyType;
+			output_semantics = t.IsPrimitive ? t == typeof (IntPtr) : t != typeof (string);
+		}
+		
+		if (output_semantics)
 			print ("[Export (\"{0}\", ArgumentSemantic.{1})]", sel, semantic);
 		else
 			print ("[Export (\"{0}\")]", sel);
@@ -5614,15 +5621,15 @@ public partial class Generator : IMemberGatherer {
 				PrintDelegateProxy (pi.GetGetMethod ());
 				if (!HasAttribute (pi.GetGetMethod (), typeof (NotImplementedAttribute))) {
 					if (ba != null)
-						PrintExport (ba.Selector, ea.ArgumentSemantic);
+						PrintExport (minfo, ba.Selector, ea.ArgumentSemantic);
 					else
-						PrintExport (ea);
+						PrintExport (minfo, ea);
 				}
 				print ("get;");
 			}
 			if (pi.CanWrite) {
 				if (!HasAttribute (pi.GetSetMethod (), typeof (NotImplementedAttribute)))
-					PrintExport (GetSetterExportAttribute (pi));
+					PrintExport (minfo, GetSetterExportAttribute (pi));
 				print ("set;");
 			}
 			indent--;

--- a/tests/introspection/ApiWeakPropertyTest.cs
+++ b/tests/introspection/ApiWeakPropertyTest.cs
@@ -39,6 +39,11 @@ namespace Introspection {
 		/// <param name="property">Property candidate.</param>
 		protected virtual bool Skip (PropertyInfo property)
 		{
+			switch (property.Name) {
+			// the selector starts with `weak`
+			case "WeakRelatedUniqueIdentifier":
+				return property.DeclaringType.Name == "CSSearchableItemAttributeSet";
+			}
 			return false;
 		}
 
@@ -68,7 +73,7 @@ namespace Introspection {
 						continue;
 
 					string name = p.Name;
-					if (!name.StartsWith ("Weak"))
+					if (!name.StartsWith ("Weak", StringComparison.Ordinal))
 						continue;
 
 					string error;


### PR DESCRIPTION
This reduce the metadata size and this information, even if part of the
header files, is not required (as some types are just not refcounted)

E.g.

	public bool MicrophoneEnabled {
		[Export ("isMicrophoneEnabled", ArgumentSemantic.UnsafeUnretained)]

should be

	public bool MicrophoneEnabled {
		[Export ("isMicrophoneEnabled")]

This could have been done in different places but not generating them has
the smallest impact versus:

1. Check bindings input and report them as errors
	- con: break existing binding code;
	- con: sharpie outputs them;

2. Removed by the linker
	- con: linking not always enabled, e.g. 3rd party bindings
	- con: extra logic == extra time for each build