### PR TITLE
[mtouch tests] Rename Profile.Unified to Profile.iOS.

### DIFF
--- a/tests/mtouch/MLaunchTool.cs
+++ b/tests/mtouch/MLaunchTool.cs
@@ -25,7 +25,7 @@ namespace Xamarin
 
 		// These are a bit smarter
 		public MLaunchAction Action = MLaunchAction.Sim;
-		public MTouch.Profile Profile = MTouch.Profile.Unified;
+		public MTouch.Profile Profile = MTouch.Profile.iOS;
 
 		string GetVerbosity ()
 		{
@@ -79,11 +79,11 @@ namespace Xamarin
 			string simType = null;
 
 			switch (Profile) {
-			case MTouch.Profile.Unified:
+			case MTouch.Profile.iOS:
 				platformName = "iOS";
 				simType = "iPhone-SE";
 				break;
-			case MTouch.Profile.TVOS:
+			case MTouch.Profile.tvOS:
 				platformName = "tvOS";
 				simType = "Apple-TV-1080p";
 				break;

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -90,7 +90,7 @@ namespace Xamarin
 		public void RebuildTest_Intl ()
 		{
 			using (var tool = new MTouchTool ()) {
-				tool.Profile = Profile.Unified;
+				tool.Profile = Profile.iOS;
 				tool.I18N = I18N.West;
 				tool.Verbosity = 5;
 				tool.Cache = Path.Combine (tool.CreateTemporaryDirectory (), "mtouch-test-cache");
@@ -115,7 +115,7 @@ namespace Xamarin
 		public enum Config { Debug, Release }
 		public enum PackageMdb { Default, WithMdb, WoutMdb }
 		public enum MSym { Default, WithMSym, WoutMSym }
-		public enum Profile { Unified, TVOS, WatchOS }
+		public enum Profile { iOS, tvOS, watchOS }
 
 		[Test]
 		// Simulator
@@ -231,7 +231,7 @@ namespace Xamarin
 
 
 			try {
-				var exe = CompileTestAppExecutable (testDir, profile: MTouch.Profile.Unified);
+				var exe = CompileTestAppExecutable (testDir, profile: MTouch.Profile.iOS);
 				var args = string.Format (string.Join (" ", deprecated_list), app);
 
 				Asserts.ThrowsPattern<TestExecutionException> (() =>
@@ -261,12 +261,12 @@ namespace Xamarin
 		}
 
 		[Test]
-		[TestCase (Profile.Unified, Profile.TVOS)]
-		[TestCase (Profile.Unified, Profile.WatchOS)]
-		[TestCase (Profile.TVOS, Profile.Unified)]
-		[TestCase (Profile.TVOS, Profile.WatchOS)]
-		[TestCase (Profile.WatchOS, Profile.Unified)]
-		[TestCase (Profile.WatchOS, Profile.TVOS)]
+		[TestCase (Profile.iOS, Profile.tvOS)]
+		[TestCase (Profile.iOS, Profile.watchOS)]
+		[TestCase (Profile.tvOS, Profile.iOS)]
+		[TestCase (Profile.tvOS, Profile.watchOS)]
+		[TestCase (Profile.watchOS, Profile.iOS)]
+		[TestCase (Profile.watchOS, Profile.tvOS)]
 		public void MT0041 (Profile profile, Profile other)
 		{
 			using (var mtouch = new MTouchTool ()) {
@@ -291,7 +291,7 @@ namespace Xamarin
 			Directory.CreateDirectory (app);
 
 			try {
-				var exe = CompileTestAppExecutable (testDir, profile: MTouch.Profile.Unified);
+				var exe = CompileTestAppExecutable (testDir, profile: MTouch.Profile.iOS);
 
 				Asserts.ThrowsPattern<TestExecutionException> (() =>
 					ExecutionHelper.Execute (TestTarget.ToolPath, string.Format ("-sdkroot " + Configuration.xcode_root + " --dev {0} -sdk " + Configuration.sdk_version + " --targetver 3.1 --abi=armv7s,arm64 {1} -debug -r:" + Configuration.XamarinIOSDll, app, exe)),
@@ -321,7 +321,7 @@ namespace Xamarin
 			Directory.CreateDirectory (app);
 
 			try {
-				var exe = CompileTestAppExecutable (testDir, profile: MTouch.Profile.Unified);
+				var exe = CompileTestAppExecutable (testDir, profile: MTouch.Profile.iOS);
 
 				Asserts.ThrowsPattern<TestExecutionException> (() =>
 					ExecutionHelper.Execute (TestTarget.ToolPath, string.Format ("-sdkroot " + Configuration.xcode_root + " --dev {0} -sdk " + Configuration.sdk_version + " --targetver 400.0.0 --abi=armv7s,arm64 {1} -debug -r:" + Configuration.XamarinIOSDll, app, exe)),
@@ -339,7 +339,7 @@ namespace Xamarin
 			Directory.CreateDirectory (app);
 
 			try {
-				var exe = CompileTestAppExecutable (testDir, profile: MTouch.Profile.Unified);
+				var exe = CompileTestAppExecutable (testDir, profile: MTouch.Profile.iOS);
 
 				Asserts.ThrowsPattern<TestExecutionException> (() => ExecutionHelper.Execute (TestTarget.ToolPath, string.Format ("-sdkroot " + Configuration.xcode_root + " --dev {0} -sdk " + Configuration.sdk_version + " --targetver 6.0 --abi=armv7s {1} -debug -r:{2} --crashreporting-api-key APIKEY", app, exe, Configuration.XamarinIOSDll), hide_output: false),
 					"error MT0016: The option '--crashreporting-api-key' has been deprecated.");
@@ -349,12 +349,12 @@ namespace Xamarin
 		}
 
 		[Test]
-		[TestCase (Profile.Unified, Profile.TVOS)]
-		[TestCase (Profile.Unified, Profile.WatchOS)]
-		[TestCase (Profile.TVOS, Profile.Unified)]
-		[TestCase (Profile.TVOS, Profile.WatchOS)]
-		[TestCase (Profile.WatchOS, Profile.Unified)]
-		[TestCase (Profile.WatchOS, Profile.TVOS)]
+		[TestCase (Profile.iOS, Profile.tvOS)]
+		[TestCase (Profile.iOS, Profile.watchOS)]
+		[TestCase (Profile.tvOS, Profile.iOS)]
+		[TestCase (Profile.tvOS, Profile.watchOS)]
+		[TestCase (Profile.watchOS, Profile.iOS)]
+		[TestCase (Profile.watchOS, Profile.tvOS)]
 		public void MT0034 (Profile exe_profile, Profile dll_profile)
 		{
 			using (var mtouch = new MTouchTool ()) {
@@ -399,7 +399,7 @@ namespace Xamarin
 			Directory.CreateDirectory (app);
 
 			try {
-				var exe = CompileTestAppExecutable (testDir, profile: MTouch.Profile.Unified);
+				var exe = CompileTestAppExecutable (testDir, profile: MTouch.Profile.iOS);
 
 				Asserts.ThrowsPattern<TestExecutionException> (() =>
 					ExecutionHelper.Execute (TestTarget.ToolPath, string.Format ("-sdkroot " + Configuration.xcode_root + " --dev {0} -sdk " + Configuration.sdk_version + " --registrar:oldstatic --targetver 6.0 --abi=arm64 {1} -debug -r:{2} ", app, exe, Configuration.XamarinIOSDll)),
@@ -535,13 +535,13 @@ namespace Xamarin
 			Directory.CreateDirectory (app);
 
 			try {
-				var exe = CompileTestAppExecutable (testDir, profile: MTouch.Profile.WatchOS);
+				var exe = CompileTestAppExecutable (testDir, profile: MTouch.Profile.watchOS);
 
 				Asserts.ThrowsPattern<TestExecutionException> (() =>
 					ExecutionHelper.Execute (TestTarget.ToolPath, string.Format ("-sdkroot {3} --dev {0} -sdk {4} -r:{2} {1} --target-framework Xamarin.WatchOS,v1.0", app, exe, Configuration.XamarinWatchOSDll, Configuration.xcode_root, Configuration.watchos_sdk_version), hide_output: false),
 					"error MT0076: No architecture specified .using the --abi argument.. An architecture is required for Xamarin.WatchOS projects.");
 				
-				exe = CompileTestAppExecutable (testDir, profile: MTouch.Profile.TVOS);
+				exe = CompileTestAppExecutable (testDir, profile: MTouch.Profile.tvOS);
 
 				Asserts.ThrowsPattern<TestExecutionException> (() =>
 					ExecutionHelper.Execute (TestTarget.ToolPath, string.Format ("-sdkroot {3} --dev {0} -sdk {4} -r:{2} {1} --target-framework Xamarin.TVOS,v1.0", app, exe, Configuration.XamarinTVOSDll, Configuration.xcode_root, Configuration.tvos_sdk_version), hide_output: false),
@@ -562,7 +562,7 @@ namespace Xamarin
 			Directory.CreateDirectory (app);
 
 			try {
-				var exe = CompileTestAppExecutable (testDir, profile: MTouch.Profile.WatchOS);
+				var exe = CompileTestAppExecutable (testDir, profile: MTouch.Profile.watchOS);
 
 				Asserts.ThrowsPattern<TestExecutionException> (() =>
 					ExecutionHelper.Execute (TestTarget.ToolPath, string.Format ("-sdkroot {3} --dev {0} -sdk {4} -r:{2} {1} --target-framework Xamarin.WatchOS,v1.0 --abi armv7k", app, exe, Configuration.XamarinWatchOSDll, Configuration.xcode_root, Configuration.watchos_sdk_version), hide_output: false),
@@ -573,9 +573,9 @@ namespace Xamarin
 		}
 
 		[Test]
-		[TestCase (Profile.TVOS)]
+		[TestCase (Profile.tvOS)]
 		//[TestCase (Profile.WatchOS)] MT0077 interferring.
-		[TestCase (Profile.Unified)]
+		[TestCase (Profile.iOS)]
 		public void MT0085 (Profile profile)
 		{
 			using (var mtouch = new MTouchTool ()) {
@@ -588,8 +588,8 @@ namespace Xamarin
 		}
 
 		[Test]
-		[TestCase (Profile.TVOS)]
-		[TestCase (Profile.WatchOS)]
+		[TestCase (Profile.tvOS)]
+		[TestCase (Profile.watchOS)]
 		public void MT0086 (Profile profile)
 		{
 			using (var mtouch = new MTouchTool ()) {
@@ -601,8 +601,8 @@ namespace Xamarin
 		}
 
 		[Test]
-		[TestCase (Profile.TVOS, "tvOS")]
-		[TestCase (Profile.Unified, "iOS")]
+		[TestCase (Profile.tvOS, "tvOS")]
+		[TestCase (Profile.iOS, "iOS")]
 		public void MT0091 (Profile profile, string name)
 		{
 			// Any old Xcode would do.
@@ -664,11 +664,11 @@ namespace Xamarin
 		public static string GetBaseLibrary (Profile profile)
 		{
 			switch (profile) {
-			case Profile.Unified:
+			case Profile.iOS:
 				return Configuration.XamarinIOSDll;
-			case Profile.TVOS:
+			case Profile.tvOS:
 				return Configuration.XamarinTVOSDll;
-			case Profile.WatchOS:
+			case Profile.watchOS:
 				return Configuration.XamarinWatchOSDll;
 			default:
 				throw new NotImplementedException ();
@@ -684,11 +684,11 @@ namespace Xamarin
 		static string GetConfiguration (Profile profile)
 		{
 			switch (profile) {
-			case Profile.Unified:
+			case Profile.iOS:
 				return "Debug-unified";
-			case Profile.TVOS:
+			case Profile.tvOS:
 				return "Debug-tvos";
-			case Profile.WatchOS:
+			case Profile.watchOS:
 				return "Debug-watchos";
 			default:
 				throw new NotImplementedException ();
@@ -698,11 +698,11 @@ namespace Xamarin
 		public static string GetTargetFramework (Profile profile)
 		{
 			switch (profile) {
-			case Profile.Unified:
+			case Profile.iOS:
 				return "Xamarin.iOS,v1.0";
-			case Profile.TVOS:
+			case Profile.tvOS:
 				return "Xamarin.TVOS,v1.0";
-			case Profile.WatchOS:
+			case Profile.watchOS:
 				return "Xamarin.WatchOS,v1.0";
 			default:
 				throw new NotImplementedException ();
@@ -712,11 +712,11 @@ namespace Xamarin
 		public static string GetDeviceArchitecture (Profile profile)
 		{
 			switch (profile) {
-			case Profile.Unified:
+			case Profile.iOS:
 				return "armv7";
-			case Profile.TVOS:
+			case Profile.tvOS:
 				return "arm64";
-			case Profile.WatchOS:
+			case Profile.watchOS:
 				return "armv7k";
 			default:
 				throw new NotImplementedException ();
@@ -726,10 +726,10 @@ namespace Xamarin
 		public static string GetSimulatorArchitecture (Profile profile)
 		{
 			switch (profile) {
-			case Profile.Unified:
-			case Profile.WatchOS:
+			case Profile.iOS:
+			case Profile.watchOS:
 				return "i386";
-			case Profile.TVOS:
+			case Profile.tvOS:
 				return "x86_64";
 			default:
 				throw new NotImplementedException ();
@@ -744,11 +744,11 @@ namespace Xamarin
 		static string GetPlatformName (Profile profile)
 		{
 			switch (profile) {
-			case Profile.Unified:
+			case Profile.iOS:
 				return "Xamarin.iOS";
-			case Profile.TVOS:
+			case Profile.tvOS:
 				return "Xamarin.TVOS";
-			case Profile.WatchOS:
+			case Profile.watchOS:
 				return "Xamarin.WatchOS";
 			default:
 				throw new NotImplementedException ();
@@ -758,11 +758,11 @@ namespace Xamarin
 		static string GetProjectSuffix (Profile profile)
 		{
 			switch (profile) {
-			case Profile.Unified:
+			case Profile.iOS:
 				return string.Empty;
-			case Profile.TVOS:
+			case Profile.tvOS:
 				return "-tvos";
-			case Profile.WatchOS:
+			case Profile.watchOS:
 				return "-watchos";
 			default:
 				throw new NotImplementedException ();
@@ -772,11 +772,11 @@ namespace Xamarin
 		public static string GetSdkVersion (Profile profile)
 		{
 			switch (profile) {
-			case Profile.Unified:
+			case Profile.iOS:
 				return Configuration.sdk_version;
-			case Profile.TVOS:
+			case Profile.tvOS:
 				return Configuration.tvos_sdk_version;
-			case Profile.WatchOS:
+			case Profile.watchOS:
 				return Configuration.watchos_sdk_version;
 			default:
 				throw new NotImplementedException ();
@@ -809,8 +809,8 @@ namespace Xamarin
 		}
 
 		[Test]
-		[TestCase (Profile.Unified)]
-		[TestCase (Profile.TVOS)]
+		[TestCase (Profile.iOS)]
+		[TestCase (Profile.tvOS)]
 		//[TestCase (Profile.WatchOS)] // needs testing improvement
 		public void FastDev_LinkWithTest (Profile profile)
 		{
@@ -844,8 +844,8 @@ namespace Xamarin
 		}
 
 		[Test]
-		[TestCase (Profile.Unified)]
-		[TestCase (Profile.TVOS)]
+		[TestCase (Profile.iOS)]
+		[TestCase (Profile.tvOS)]
 		//[TestCase (Profile.WatchOS)] // needs testing improvement
 		public void FastDev_NoFastSim_NoLink (Profile profile)
 		{
@@ -873,8 +873,8 @@ namespace Xamarin
 		}
 		
 		[Test]
-		[TestCase (Profile.Unified)]
-		[TestCase (Profile.TVOS)]
+		[TestCase (Profile.iOS)]
+		[TestCase (Profile.tvOS)]
 		//[TestCase (Profile.WatchOS)] // needs testing improvement
 		public void FastDev_NoFastSim_LinkAll (Profile profile)
 		{
@@ -901,8 +901,8 @@ namespace Xamarin
 		}
 		
 		[Test]
-		[TestCase (Profile.Unified)]
-		[TestCase (Profile.TVOS)]
+		[TestCase (Profile.iOS)]
+		[TestCase (Profile.tvOS)]
 		//[TestCase (Profile.WatchOS)] // needs testing improvement
 		public void FastDev_NoFastSim_LinkSDK (Profile profile)
 		{
@@ -930,8 +930,8 @@ namespace Xamarin
 		}
 
 		[Test]
-		[TestCase (Profile.Unified)]
-		[TestCase (Profile.TVOS)]
+		[TestCase (Profile.iOS)]
+		[TestCase (Profile.tvOS)]
 		//[TestCase (Profile.WatchOS)] // needs testing improvement
 		public void FastDev_Sim (Profile profile)
 		{
@@ -957,8 +957,8 @@ namespace Xamarin
 		}
 
 		[Test]
-		[TestCase (Profile.Unified)]
-		[TestCase (Profile.TVOS)]
+		[TestCase (Profile.iOS)]
+		[TestCase (Profile.tvOS)]
 		//[TestCase (Profile.WatchOS)] // needs testing improvement
 		public void FastDev_LinkAll (Profile profile)
 		{
@@ -975,8 +975,8 @@ namespace Xamarin
 		}
 		
 		[Test]
-		[TestCase (Profile.Unified)]
-		[TestCase (Profile.TVOS)]
+		[TestCase (Profile.iOS)]
+		[TestCase (Profile.tvOS)]
 		//[TestCase (Profile.WatchOS)] // needs testing improvement
 		public void FastDev_NoLink (Profile profile)
 		{
@@ -996,8 +996,8 @@ namespace Xamarin
 		}
 		
 		[Test]
-		[TestCase (Profile.Unified)]
-		[TestCase (Profile.TVOS)]
+		[TestCase (Profile.iOS)]
+		[TestCase (Profile.tvOS)]
 		//[TestCase (Profile.WatchOS)] // needs testing improvement
 		public void FastDev_LinkAll_Then_NoLink (Profile profile)
 		{
@@ -1020,8 +1020,8 @@ namespace Xamarin
 		}
 
 		[Test]
-		[TestCase (Profile.Unified)]
-		[TestCase (Profile.TVOS)]
+		[TestCase (Profile.iOS)]
+		[TestCase (Profile.tvOS)]
 		//[TestCase (Profile.WatchOS)] // needs testing improvement
 		public void FastDev_LinkSDK (Profile profile)
 		{
@@ -1045,7 +1045,7 @@ namespace Xamarin
 		{
 			using (var mtouch = new MTouchTool ()
 			{
-				Profile = Profile.Unified,
+				Profile = Profile.iOS,
 				FastDev = true,
 				Abi = "armv7,arm64",
 			}) {
@@ -1065,7 +1065,7 @@ namespace Xamarin
 		}
 
 		[Test]
-		[TestCase (Profile.Unified)]
+		[TestCase (Profile.iOS)]
 		public void FastSim (Profile profile)
 		{
 			using (var tool = new MTouchTool ()) {
@@ -1094,7 +1094,7 @@ namespace Xamarin
 		public void Architectures_Unified (Target target, string abi)
 		{
 			using (var mtouch = new MTouchTool ()) {
-				mtouch.Profile = Profile.Unified;
+				mtouch.Profile = Profile.iOS;
 				mtouch.CreateTemporaryApp ();
 
 				mtouch.Abi = abi;
@@ -1111,7 +1111,7 @@ namespace Xamarin
 		public void Architectures_Unified_FatSimulator ()
 		{
 			using (var mtouch = new MTouchTool ()) {
-				mtouch.Profile = Profile.Unified;
+				mtouch.Profile = Profile.iOS;
 				mtouch.CreateTemporaryApp ();
 
 				mtouch.Abi = "i386,x86_64";
@@ -1132,7 +1132,7 @@ namespace Xamarin
 		public void Architectures_Unified_Invalid ()
 		{
 			using (var mtouch = new MTouchTool ()) {
-				mtouch.Profile = Profile.Unified;
+				mtouch.Profile = Profile.iOS;
 				mtouch.CreateTemporaryApp ();
 
 				mtouch.Abi = "armv6";
@@ -1154,7 +1154,7 @@ namespace Xamarin
 			AssertDeviceAvailable ();
 
 			using (var mtouch = new MTouchTool ()) {
-				mtouch.Profile = MTouch.Profile.TVOS;
+				mtouch.Profile = MTouch.Profile.tvOS;
 				mtouch.Abi = abi;
 				mtouch.CreateTemporaryApp ();
 				      
@@ -1171,7 +1171,7 @@ namespace Xamarin
 			AssertDeviceAvailable ();
 
 			using (var mtouch = new MTouchTool ()) {
-				mtouch.Profile = Profile.TVOS;
+				mtouch.Profile = Profile.tvOS;
 				mtouch.CreateTemporaryApp ();
 
 				mtouch.Abi = "armv7";
@@ -1189,7 +1189,7 @@ namespace Xamarin
 			Directory.CreateDirectory (app);
 			try {
 				var code = "public class TestApp { static void Main () { System.Console.WriteLine (typeof (UIKit.UIWindow).ToString ()); } }";
-				var exe = CompileTestAppExecutable (testDir, code: code, profile: MTouch.Profile.Unified);
+				var exe = CompileTestAppExecutable (testDir, code: code, profile: MTouch.Profile.iOS);
 				var bin = Path.Combine (app, Path.GetFileNameWithoutExtension (exe));
 				var common_args = string.Format ("-sdkroot " + Configuration.xcode_root + " --sim {0} -sdk " + Configuration.sdk_version + " --targetver 6.0 --abi=i386 {1} -debug -gcc_flags -Wl,-w ", app, exe);
 				var newstyle_args = common_args + "-r:" + Configuration.XamarinIOSDll;
@@ -1249,12 +1249,12 @@ namespace Xamarin
 		}
 
 		[Test]
-		[TestCase (Target.Dev, Profile.Unified, "dont link", "Release64")]
-		[TestCase (Target.Dev, Profile.Unified, "link all", "Release64")]
-		[TestCase (Target.Dev, Profile.Unified, "link sdk", "Release64")]
-		[TestCase (Target.Dev, Profile.Unified, "monotouch-test", "Release64")]
-		[TestCase (Target.Dev, Profile.Unified, "mscorlib", "Release64")]
-		[TestCase (Target.Dev, Profile.Unified, "System.Core", "Release64")]
+		[TestCase (Target.Dev, Profile.iOS, "dont link", "Release64")]
+		[TestCase (Target.Dev, Profile.iOS, "link all", "Release64")]
+		[TestCase (Target.Dev, Profile.iOS, "link sdk", "Release64")]
+		[TestCase (Target.Dev, Profile.iOS, "monotouch-test", "Release64")]
+		[TestCase (Target.Dev, Profile.iOS, "mscorlib", "Release64")]
+		[TestCase (Target.Dev, Profile.iOS, "System.Core", "Release64")]
 		public void BuildTestProject (Target target, Profile profile, string testname, string configuration)
 		{
 			if (target == Target.Dev)
@@ -1741,7 +1741,7 @@ class Test {
 	}
 }
 ";
-				var exe = CompileTestAppExecutable (testDir, code, profile: MTouch.Profile.Unified);
+				var exe = CompileTestAppExecutable (testDir, code, profile: MTouch.Profile.iOS);
 				var cache = Path.Combine (testDir, "mtouch-cache");
 
 				var mtouch = new MTouchTool ();
@@ -1968,7 +1968,7 @@ class Test {
 		}
 
 		[Test]
-		[TestCase (Profile.Unified)]
+		[TestCase (Profile.iOS)]
 		public void DlsymDisabled (Profile profile)
 		{
 			using (var tool = new MTouchTool ()) {
@@ -1987,7 +1987,7 @@ class Test {
 		public void PInvokeWrapperGenerationTest ()
 		{
 			using (var tool = new MTouchTool ()) {
-				tool.Profile = Profile.WatchOS;
+				tool.Profile = Profile.watchOS;
 				tool.CreateTemporaryCacheDirectory ();
 				tool.Verbosity = 5;
 				tool.Extension = true;
@@ -2017,7 +2017,7 @@ class Test {
 		public void LinkWithNoLibrary ()
 		{
 			using (var tool = new MTouchTool ()) {
-				tool.Profile = Profile.Unified;
+				tool.Profile = Profile.iOS;
 				tool.CreateTemporaryApp (code: @"
 using System;
 using System.Runtime.InteropServices;
@@ -2042,7 +2042,7 @@ class C {
 		public void WatchExtensionWithFramework ()
 		{
 			using (var exttool = new MTouchTool ()) {
-				exttool.Profile = Profile.WatchOS;
+				exttool.Profile = Profile.watchOS;
 				exttool.CreateTemporaryCacheDirectory ();
 				exttool.Verbosity = 5;
 
@@ -2052,7 +2052,7 @@ class C {
 				exttool.AssertExecute (MTouchAction.BuildSim, "build extension");
 
 				using (var apptool = new MTouchTool ()) {
-					apptool.Profile = Profile.Unified;
+					apptool.Profile = Profile.iOS;
 					apptool.CreateTemporaryCacheDirectory ();
 					apptool.Verbosity = exttool.Verbosity;
 					apptool.CreateTemporaryApp ();
@@ -2071,7 +2071,7 @@ class C {
 			// if an extension references a framework, and the main app does not,
 			// the framework should still be copied to the main app's Framework directory.
 			using (var exttool = new MTouchTool ()) {
-				exttool.Profile = Profile.Unified;
+				exttool.Profile = Profile.iOS;
 				exttool.CreateTemporaryCacheDirectory ();
 				exttool.Verbosity = 5;
 
@@ -2081,7 +2081,7 @@ class C {
 				exttool.AssertExecute (MTouchAction.BuildSim, "build extension");
 
 				using (var apptool = new MTouchTool ()) {
-					apptool.Profile = Profile.Unified;
+					apptool.Profile = Profile.iOS;
 					apptool.CreateTemporaryCacheDirectory ();
 					apptool.Verbosity = exttool.Verbosity;
 					apptool.CreateTemporaryApp ();
@@ -2101,7 +2101,7 @@ class C {
 		public void OnlyDebugFileChange (MTouchLinker linker_options)
 		{
 			using (var mtouch = new MTouchTool ()) {
-				mtouch.Profile = Profile.Unified;
+				mtouch.Profile = Profile.iOS;
 				mtouch.Verbosity = 23;
 				var tmp = mtouch.CreateTemporaryDirectory ();
 				mtouch.CreateTemporaryCacheDirectory ();
@@ -2136,8 +2136,8 @@ class C {
 			}
 		}
 
-		[TestCase (Profile.Unified)]
-		[TestCase (Profile.TVOS)]
+		[TestCase (Profile.iOS)]
+		[TestCase (Profile.tvOS)]
 		public void MT2010 (Profile profile)
 		{
 			using (var mtouch = new MTouchTool ()) {
@@ -2154,7 +2154,7 @@ class C {
 		public void MT2015 ()
 		{
 			using (var mtouch = new MTouchTool ()) {
-				mtouch.Profile = Profile.WatchOS;
+				mtouch.Profile = Profile.watchOS;
 				mtouch.CreateTemporaryWatchKitExtension ();
 				mtouch.Extension = true;
 
@@ -2175,10 +2175,10 @@ class C {
 #region Helper functions
 		static string CompileUnifiedTestAppExecutable (string targetDirectory, string code = null, string extraArg = "")
 		{
-			return CompileTestAppExecutable (targetDirectory, code, extraArg, profile: MTouch.Profile.Unified);
+			return CompileTestAppExecutable (targetDirectory, code, extraArg, profile: MTouch.Profile.iOS);
 		}
 
-		public static string CompileTestAppExecutable (string targetDirectory, string code = null, string extraArg = "", Profile profile = Profile.Unified, string appName = "testApp")
+		public static string CompileTestAppExecutable (string targetDirectory, string code = null, string extraArg = "", Profile profile = Profile.iOS, string appName = "testApp")
 		{
 			if (code == null)
 				code = "public class TestApp { static void Main () { System.Console.WriteLine (typeof (ObjCRuntime.Runtime).ToString ()); } }";
@@ -2186,12 +2186,12 @@ class C {
 			return CompileTestAppCode ("exe", targetDirectory, code, extraArg, profile, appName);
 		}
 
-		public static string CompileTestAppLibrary (string targetDirectory, string code, string extraArg = null, Profile profile = Profile.Unified)
+		public static string CompileTestAppLibrary (string targetDirectory, string code, string extraArg = null, Profile profile = Profile.iOS)
 		{
 			return CompileTestAppCode ("library", targetDirectory, code, extraArg, profile);
 		}
 
-		public static string CompileTestAppCode (string target, string targetDirectory, string code, string extraArg = "", Profile profile = Profile.Unified, string appName = "testApp")
+		public static string CompileTestAppCode (string target, string targetDirectory, string code, string extraArg = "", Profile profile = Profile.iOS, string appName = "testApp")
 		{
 			var ext = target == "exe" ? "exe" : "dll";
 			var cs = Path.Combine (targetDirectory, "testApp.cs");
@@ -2288,7 +2288,7 @@ using ObjCRuntime;
 		}
 
 		static Dictionary<Profile, string> compiled_linkwith_apps = new Dictionary<Profile, string> ();
-		public static string CompileTestAppExecutableLinkWith (string targetDirectory, Profile profile = Profile.Unified)
+		public static string CompileTestAppExecutableLinkWith (string targetDirectory, Profile profile = Profile.iOS)
 		{
 			string compiled_linkwith_app;
 			if (compiled_linkwith_apps.TryGetValue (profile, out compiled_linkwith_app) && File.Exists (compiled_linkwith_app))

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -79,7 +79,7 @@ namespace Xamarin
 #pragma warning restore 649
 
 		// These are a bit smarter
-		public MTouch.Profile Profile = MTouch.Profile.Unified;
+		public MTouch.Profile Profile = MTouch.Profile.iOS;
 		public bool NoPlatformAssemblyReference;
 		static XmlDocument device_list_cache;
 
@@ -222,11 +222,11 @@ namespace Xamarin
 			} else if (!NoPlatformAssemblyReference) {
 				// make the implicit default the way tests have been running until now, and at the same time the very minimum to make apps build.
 				switch (Profile) {
-				case MTouch.Profile.Unified:
+				case MTouch.Profile.iOS:
 					sb.Append (" -r:").Append (MTouch.Quote (Configuration.XamarinIOSDll));
 					break;
-				case MTouch.Profile.TVOS:
-				case MTouch.Profile.WatchOS:
+				case MTouch.Profile.tvOS:
+				case MTouch.Profile.watchOS:
 					sb.Append (" --target-framework ").Append (MTouch.GetTargetFramework (Profile));
 					sb.Append (" -r:").Append (MTouch.Quote (MTouch.GetBaseLibrary (Profile)));
 					break;
@@ -239,12 +239,12 @@ namespace Xamarin
 				sb.Append (" --abi ").Append (Abi);
 			} else {
 				switch (Profile) {
-				case MTouch.Profile.Unified:
+				case MTouch.Profile.iOS:
 					break; // not required
-				case MTouch.Profile.TVOS:
+				case MTouch.Profile.tvOS:
 					sb.Append (isDevice ? " --abi arm64" : " --abi x86_64");
 					break;
-				case MTouch.Profile.WatchOS:
+				case MTouch.Profile.watchOS:
 					sb.Append (isDevice ? " --abi armv7k" : " --abi i386");
 					break;
 				default:
@@ -361,7 +361,7 @@ namespace Xamarin
 			string plist = null;
 
 			switch (profile) {
-			case MTouch.Profile.Unified:
+			case MTouch.Profile.iOS:
 				plist = string.Format (@"<?xml version=""1.0"" encoding=""UTF-8""?>
 <!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
 <plist version=""1.0"">
@@ -390,7 +390,7 @@ namespace Xamarin
 </plist>
 ", appName, MTouch.GetSdkVersion (Profile));
 				break;
-			case MTouch.Profile.TVOS:
+			case MTouch.Profile.tvOS:
 				plist = string.Format (@"<?xml version=""1.0"" encoding=""UTF-8""?>
 <!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
 <plist version=""1.0"">

--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -204,7 +204,7 @@ class MyObjectErr : NSObject, IFoo1, IFoo2
 				Assert.Ignore ("Xcode 6 ({0}) is required for this test.", Configuration.xcode6_root);
 			
 			// This test will have to be updated when new frameworks are introduced.
-			VerifyWithXcode (R.Static, MTouch.Profile.Unified, string.Empty, false, Configuration.xcode6_root, "8.0",
+			VerifyWithXcode (R.Static, MTouch.Profile.iOS, string.Empty, false, Configuration.xcode6_root, "8.0",
 				"warning MT0079: The recommended Xcode version for Xamarin.iOS .* is Xcode .* or later. The current Xcode version .found in " + Configuration.xcode6_root + ". is 6.*.",
 				"error MT4134: Your application is using the 'Contacts' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS 9.0, while you're building with the iOS 8.0 SDK.) This configuration is only supported with the legacy registrar (pass --registrar:legacy as an additional mtouch argument in your project's iOS Build option to select). Alternatively select a newer SDK in your app's iOS Build options.",
 				"error MT4134: Your application is using the 'CoreSpotlight' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS 9.0, while you're building with the iOS 8.0 SDK.) This configuration is only supported with the legacy registrar (pass --registrar:legacy as an additional mtouch argument in your project's iOS Build option to select). Alternatively select a newer SDK in your app's iOS Build options.",
@@ -531,8 +531,8 @@ public struct FooF { public NSObject Obj; }
 
 
 		[Test]
-		[TestCase (MTouch.Profile.Unified, "iOS")]
-		[TestCase (MTouch.Profile.TVOS, "tvOS")]
+		[TestCase (MTouch.Profile.iOS, "iOS")]
+		[TestCase (MTouch.Profile.tvOS, "tvOS")]
 		//[TestCase (MTouch.Profile.WatchOS, "watchOS")] // MT0077 interferes
 		public void MT4162 (MTouch.Profile profile, string name)
 		{
@@ -646,7 +646,7 @@ public struct FooF { public NSObject Obj; }
 	}
 ";
 
-			Verify (R.Static, MTouch.Profile.Unified, code, false, MTouch.Target.Sim,
+			Verify (R.Static, MTouch.Profile.iOS, code, false, MTouch.Target.Sim,
 			        ".*/Test.cs(.*): error MT4164: Cannot export the property 'Auto' because its selector 'auto' is an Objective-C keyword. Please use a different name.",
 			        ".*/Test.cs(.*): error MT4164: Cannot export the property 'Break' because its selector 'break' is an Objective-C keyword. Please use a different name.",
 			        ".*/Test.cs(.*): error MT4164: Cannot export the property 'Case' because its selector 'case' is an Objective-C keyword. Please use a different name.",
@@ -727,7 +727,7 @@ class H : G {
 
 		void Verify (R registrars, string code, bool success, params string [] expected_messages)
 		{
-			VerifyWithXcode (registrars,  MTouch.Profile.Unified, code, success, Configuration.xcode_root, Configuration.sdk_version, expected_messages);
+			VerifyWithXcode (registrars,  MTouch.Profile.iOS, code, success, Configuration.xcode_root, Configuration.sdk_version, expected_messages);
 		}
 
 		void Verify (R registrars, MTouch.Profile profile, string code, bool success, params string [] expected_messages)
@@ -742,12 +742,12 @@ class H : G {
 
 		void VerifyWithXode (R registrars, string code, bool success, params string [] expected_messages)
 		{
-			VerifyWithXcode (registrars, MTouch.Profile.Unified, code, success, Configuration.xcode_root, Configuration.sdk_version, expected_messages);
+			VerifyWithXcode (registrars, MTouch.Profile.iOS, code, success, Configuration.xcode_root, Configuration.sdk_version, expected_messages);
 		}
 
 		void VerifyWithXcode (R registrars, string code, bool success, string xcode, string sdk_version, params string [] expected_messages)
 		{
-			VerifyWithXcode (registrars, MTouch.Profile.Unified, code, success, xcode, sdk_version, expected_messages);
+			VerifyWithXcode (registrars, MTouch.Profile.iOS, code, success, xcode, sdk_version, expected_messages);
 		}
 
 		void VerifyWithXcode (R registrars, MTouch.Profile profile, string code, bool success, string xcode, string sdk_version, params string [] expected_messages)
@@ -1191,7 +1191,7 @@ class CTP4 : CTP3 {
 
 		// Compile the filename with mcs
 		// Does not clean up anything.
-		static void Compile (string filename, MTouch.Profile profile = MTouch.Profile.Unified)
+		static void Compile (string filename, MTouch.Profile profile = MTouch.Profile.iOS)
 		{			
 			StringBuilder output = new StringBuilder ();
 			using (var p = new Process ()) {

--- a/tests/mtouch/TimingTests.cs
+++ b/tests/mtouch/TimingTests.cs
@@ -6,8 +6,8 @@ using System.Text;
 
 namespace Xamarin.Profiler
 {
-	[TestFixture (MTouch.Profile.Unified)]
-	[TestFixture (MTouch.Profile.TVOS)]
+	[TestFixture (MTouch.Profile.iOS)]
+	[TestFixture (MTouch.Profile.tvOS)]
 	public class TimingTests
 	{
 		MTouch.Profile profile;


### PR DESCRIPTION
Rename Profile.Unified to Profile.iOS to better match the other values in the enum (tvOS/watchOS).