### PR TITLE
[tests] Fix a couple of compiler warnings.

### DIFF
--- a/tests/mtouch/TimingTests.cs
+++ b/tests/mtouch/TimingTests.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Profiler
 		StringBuilder sb;
 		int starsLenght;
 
-		[TestFixtureSetUp]
+		[OneTimeSetUp]
 		public void Init ()
 		{
 			sb = new StringBuilder ();
@@ -117,7 +117,7 @@ namespace Xamarin.Profiler
 			}
 		}
 
-		[TestFixtureTearDown]
+		[OneTimeTearDown]
 		public void PrintLogs ()
 		{
 			sb.AppendLine (new string ('*', starsLenght));


### PR DESCRIPTION
Fixes:

	TimingTests.cs(17,4): warning CS0618: `NUnit.Framework.TestFixtureSetUpAttribute' is obsolete: `Use OneTimeSetUpAttribute'
	TimingTests.cs(120,4): warning CS0618: `NUnit.Framework.TestFixtureTearDownAttribute' is obsolete: `Use OneTimeTearDownAttribute'