### PR TITLE
[CoreVideo] Fix memory leak in CVPixelBuffer.Create for planar bytes.

### DIFF
--- a/src/CoreVideo/CVPixelBuffer.cs
+++ b/src/CoreVideo/CVPixelBuffer.cs
@@ -301,14 +301,15 @@ namespace XamCore.CoreVideo {
 			}
 			data_handle = GCHandle.Alloc (data);
 
+			IntPtr data_handle_ptr = GCHandle.ToIntPtr (data_handle);
 			status = CVPixelBufferCreateWithPlanarBytes (IntPtr.Zero, 
 			                                             width, height, pixelFormatType, IntPtr.Zero, 0, 
 			                                             planeCount, addresses, planeWidths, planeHeights, planeBytesPerRow, 
-			                                             releasePlanarBytesCallback, GCHandle.ToIntPtr (data_handle), 
+			                                             releasePlanarBytesCallback, data_handle_ptr,
 			                                             DictionaryContainerHelper.GetHandle (pixelBufferAttributes), out handle);
 
 			if (status != CVReturn.Success) {
-				data_handle.Free ();
+				ReleasePlanarBytesCallback (data_handle_ptr, IntPtr.Zero, 0, 0, IntPtr.Zero);
 				return null;
 			}
 


### PR DESCRIPTION
When creating a CVPixelBuffer with planar bytes, we create one GCHandle for
every byte[] of planar data, as well as one GCHandle for a custom object that
has an array of all the other GCHandles.

All these GCHandles were freed properly if the CFPixelBuffer was successfully
created, but in the case of failure, only the GCHandle for the custom object
was freed.

So make sure to free all the GCHandles even in the case of failures by calling
the free callback function.