### PR TITLE
Replace pinned GCHandles with unsafe code.

### DIFF
--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -1102,6 +1102,10 @@ namespace XamCore.AudioUnit
 				throw new ArgumentNullException (nameof (audioFiles));
 
 			int count = audioFiles.Length;
+
+			if (count == 0)
+				return AudioUnitSetProperty (Handle, AudioUnitPropertyIDType.ScheduledFileIDs, AudioUnitScopeType.Global, 0, IntPtr.Zero, 0);
+
 			IntPtr[] handles = new IntPtr[count];
 			for (int i = 0; i < count; i++)
 				handles [i] = audioFiles [i].Handle;

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -1093,7 +1093,7 @@ namespace XamCore.AudioUnit
 		static extern AudioUnitStatus AudioUnitSetProperty (IntPtr inUnit, AudioUnitPropertyIDType inID, AudioUnitScopeType inScope, uint inElement,
 			IntPtr inData, int inDataSize);
 
-		public AudioUnitStatus SetScheduledFiles (AudioFile[] audioFiles)
+		public unsafe AudioUnitStatus SetScheduledFiles (AudioFile[] audioFiles)
 		{
 			if (Handle == IntPtr.Zero)
 				throw new ObjectDisposedException ("AudioUnit");
@@ -1106,13 +1106,8 @@ namespace XamCore.AudioUnit
 			for (int i = 0; i < count; i++)
 				handles [i] = audioFiles [i].Handle;
 
-			GCHandle gch = GCHandle.Alloc (handles, GCHandleType.Pinned);
-			IntPtr ptr = gch.AddrOfPinnedObject ();
-
-			var status = AudioUnitSetProperty (Handle, AudioUnitPropertyIDType.ScheduledFileIDs, AudioUnitScopeType.Global, 0, ptr,  Marshal.SizeOf (ptr) * count);
-
-			gch.Free ();
-			return status;
+			fixed (IntPtr* ptr = &handles [0])
+				return AudioUnitSetProperty (Handle, AudioUnitPropertyIDType.ScheduledFileIDs, AudioUnitScopeType.Global, 0, (IntPtr) ptr,  IntPtr.Size * count);
 		}
 
 #endif // !COREBUILD

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -1102,15 +1102,11 @@ namespace XamCore.AudioUnit
 				throw new ArgumentNullException (nameof (audioFiles));
 
 			int count = audioFiles.Length;
-
-			if (count == 0)
-				return AudioUnitSetProperty (Handle, AudioUnitPropertyIDType.ScheduledFileIDs, AudioUnitScopeType.Global, 0, IntPtr.Zero, 0);
-
 			IntPtr[] handles = new IntPtr[count];
 			for (int i = 0; i < count; i++)
 				handles [i] = audioFiles [i].Handle;
 
-			fixed (IntPtr* ptr = &handles [0])
+			fixed (IntPtr* ptr = handles)
 				return AudioUnitSetProperty (Handle, AudioUnitPropertyIDType.ScheduledFileIDs, AudioUnitScopeType.Global, 0, (IntPtr) ptr,  IntPtr.Size * count);
 		}
 

--- a/src/CoreFoundation/CFDataBuffer.cs
+++ b/src/CoreFoundation/CFDataBuffer.cs
@@ -43,12 +43,8 @@ namespace XamCore.CoreFoundation {
 			/*
 			 * Copy the buffer to allow the native side to take ownership.
 			 */
-			if (buffer.Length == 0) {
-				data = CFData.FromData (IntPtr.Zero, 0);
-			} else {
-				fixed (byte* ptr = &buffer [0])
-					data = CFData.FromData ((IntPtr) ptr, buffer.Length);
-			}
+			fixed (byte* ptr = buffer)
+				data = CFData.FromData ((IntPtr) ptr, buffer.Length);
 		}
 
 		public CFDataBuffer (IntPtr ptr)

--- a/src/CoreFoundation/CFDataBuffer.cs
+++ b/src/CoreFoundation/CFDataBuffer.cs
@@ -36,7 +36,7 @@ namespace XamCore.CoreFoundation {
 		byte[] buffer;
 		CFData data;
 
-		public CFDataBuffer (byte[] buffer)
+		public unsafe CFDataBuffer (byte[] buffer)
 		{
 			this.buffer = buffer;
 
@@ -44,9 +44,8 @@ namespace XamCore.CoreFoundation {
 			 * Copy the buffer to allow the native side to take ownership.
 			 */
 
-			var gch = GCHandle.Alloc (buffer, GCHandleType.Pinned);
-			data = CFData.FromData (gch.AddrOfPinnedObject (), buffer.Length);
-			gch.Free ();
+			fixed (byte* ptr = &buffer [0])
+				data = CFData.FromData ((IntPtr) ptr, buffer.Length);
 		}
 
 		public CFDataBuffer (IntPtr ptr)

--- a/src/CoreFoundation/CFDataBuffer.cs
+++ b/src/CoreFoundation/CFDataBuffer.cs
@@ -43,9 +43,12 @@ namespace XamCore.CoreFoundation {
 			/*
 			 * Copy the buffer to allow the native side to take ownership.
 			 */
-
-			fixed (byte* ptr = &buffer [0])
-				data = CFData.FromData ((IntPtr) ptr, buffer.Length);
+			if (buffer.Length == 0) {
+				data = CFData.FromData (IntPtr.Zero, 0);
+			} else {
+				fixed (byte* ptr = &buffer [0])
+					data = CFData.FromData ((IntPtr) ptr, buffer.Length);
+			}
 		}
 
 		public CFDataBuffer (IntPtr ptr)

--- a/src/CoreFoundation/CFReadStream.cs
+++ b/src/CoreFoundation/CFReadStream.cs
@@ -140,7 +140,7 @@ namespace XamCore.CoreFoundation {
 			return Read (buffer, 0, buffer.Length);
 		}
 
-		public nint Read (byte[] buffer, int offset, int count)
+		public unsafe nint Read (byte[] buffer, int offset, int count)
 		{
 			if (buffer == null)
 				throw new ArgumentNullException ("buffer");
@@ -151,14 +151,8 @@ namespace XamCore.CoreFoundation {
 				throw new ArgumentException ();
 			if (offset + count > buffer.Length)
 				throw new ArgumentException ();
-			var gch = GCHandle.Alloc (buffer, GCHandleType.Pinned);
-			try {
-				var addr = gch.AddrOfPinnedObject ();
-				var ptr = new IntPtr (addr.ToInt64 () + offset);
-				return CFReadStreamRead (Handle, ptr, count);
-			} finally {
-				gch.Free ();
-			}
+			fixed (byte* ptr = &buffer [0])
+				return CFReadStreamRead (Handle, ((IntPtr) ptr) + offset, count);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]

--- a/src/CoreFoundation/CFReadStream.cs
+++ b/src/CoreFoundation/CFReadStream.cs
@@ -151,7 +151,7 @@ namespace XamCore.CoreFoundation {
 				throw new ArgumentException ();
 			if (offset + count > buffer.Length)
 				throw new ArgumentException ();
-			fixed (byte* ptr = &buffer [0])
+			fixed (byte* ptr = buffer)
 				return CFReadStreamRead (Handle, ((IntPtr) ptr) + offset, count);
 		}
 

--- a/src/CoreFoundation/CFWriteStream.cs
+++ b/src/CoreFoundation/CFWriteStream.cs
@@ -100,7 +100,7 @@ namespace XamCore.CoreFoundation {
 			return Write (buffer, 0, buffer.Length);
 		}
 
-		public int Write (byte[] buffer, nint offset, nint count)
+		public unsafe int Write (byte[] buffer, nint offset, nint count)
 		{
 			if (buffer == null)
 				throw new ArgumentNullException ("buffer");
@@ -111,14 +111,8 @@ namespace XamCore.CoreFoundation {
 				throw new ArgumentException ();
 			if (offset + count > buffer.Length)
 				throw new ArgumentException ();
-			var gch = GCHandle.Alloc (buffer, GCHandleType.Pinned);
-			try {
-				var addr = gch.AddrOfPinnedObject ();
-				var ptr = new IntPtr (addr.ToInt64 () + offset);
-				return (int) CFWriteStreamWrite (Handle, ptr, count);
-			} finally {
-				gch.Free ();
-			}
+			fixed (byte* ptr = &buffer [0])
+				return (int) CFWriteStreamWrite (Handle, ((IntPtr) ptr) + (int) offset, count);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]

--- a/src/CoreFoundation/CFWriteStream.cs
+++ b/src/CoreFoundation/CFWriteStream.cs
@@ -111,7 +111,7 @@ namespace XamCore.CoreFoundation {
 				throw new ArgumentException ();
 			if (offset + count > buffer.Length)
 				throw new ArgumentException ();
-			fixed (byte* ptr = &buffer [0])
+			fixed (byte* ptr = buffer)
 				return (int) CFWriteStreamWrite (Handle, ((IntPtr) ptr) + (int) offset, count);
 		}
 

--- a/src/CoreMedia/CMBlockBuffer.cs
+++ b/src/CoreMedia/CMBlockBuffer.cs
@@ -190,6 +190,10 @@ namespace XamCore.CoreMedia {
 				throw new ObjectDisposedException ("BlockBuffer");
 
 			destination = new byte [dataLength];
+
+			if (dataLength == 0)
+				return CMBlockBufferError.None;
+
 			CMBlockBufferError error;
 			fixed (byte* ptr = &destination [0])
 				error = CMBlockBufferCopyDataBytes (handle, offsetToData, dataLength, (IntPtr) ptr);
@@ -219,6 +223,9 @@ namespace XamCore.CoreMedia {
 				throw new ObjectDisposedException ("BlockBuffer");
 			if (sourceBytes == null)
 				throw new ArgumentNullException (nameof (sourceBytes));
+
+			if (sourceBytes.Length == 0)
+				return ReplaceDataBytes (IntPtr.Zero, offsetIntoDestination, 0);
 
 			fixed (byte* ptr = &sourceBytes [0])
 				return ReplaceDataBytes ((IntPtr) ptr, offsetIntoDestination, (nuint) sourceBytes.Length);

--- a/src/CoreMedia/CMBlockBuffer.cs
+++ b/src/CoreMedia/CMBlockBuffer.cs
@@ -191,11 +191,8 @@ namespace XamCore.CoreMedia {
 
 			destination = new byte [dataLength];
 
-			if (dataLength == 0)
-				return CMBlockBufferError.None;
-
 			CMBlockBufferError error;
-			fixed (byte* ptr = &destination [0])
+			fixed (byte* ptr = destination)
 				error = CMBlockBufferCopyDataBytes (handle, offsetToData, dataLength, (IntPtr) ptr);
 			if (error != CMBlockBufferError.None)
 				destination = default (byte []);
@@ -224,10 +221,7 @@ namespace XamCore.CoreMedia {
 			if (sourceBytes == null)
 				throw new ArgumentNullException (nameof (sourceBytes));
 
-			if (sourceBytes.Length == 0)
-				return ReplaceDataBytes (IntPtr.Zero, offsetIntoDestination, 0);
-
-			fixed (byte* ptr = &sourceBytes [0])
+			fixed (byte* ptr = sourceBytes)
 				return ReplaceDataBytes ((IntPtr) ptr, offsetIntoDestination, (nuint) sourceBytes.Length);
 		}
 

--- a/src/SpriteKit/SKWarpGeometryGrid.cs
+++ b/src/SpriteKit/SKWarpGeometryGrid.cs
@@ -18,7 +18,7 @@ namespace XamCore.SpriteKit
 {
 	public partial class SKWarpGeometryGrid
 	{
-		public static SKWarpGeometryGrid Create (nint cols, nint rows, Vector2 [] sourcePositions, Vector2 [] destPositions)
+		public unsafe static SKWarpGeometryGrid Create (nint cols, nint rows, Vector2 [] sourcePositions, Vector2 [] destPositions)
 		{
 			if (cols < 1 || rows < 1)
 				throw new InvalidOperationException ("cols and rows should be >= 1");
@@ -29,30 +29,13 @@ namespace XamCore.SpriteKit
 			if (destPositions.Length < ((cols + 1) * (rows + 1)))
 				throw new InvalidOperationException ("destPositions should have a minimum lenght of (cols + 1) * (rows + 1)");
 
-			IntPtr spPtr = IntPtr.Zero;
-			GCHandle spGch = new GCHandle ();
-			if (sourcePositions != null) {
-				spGch = GCHandle.Alloc (sourcePositions, GCHandleType.Pinned);
-				spPtr = spGch.AddrOfPinnedObject ();
-			}
-
-			IntPtr dpPtr = IntPtr.Zero;
-			GCHandle dpGch = new GCHandle ();
-			if (destPositions != null) {
-				dpGch = GCHandle.Alloc (destPositions, GCHandleType.Pinned);
-				dpPtr = dpGch.AddrOfPinnedObject ();
-			}
-
-			var grid = GridWithColumns (cols, rows, spPtr, dpPtr);
-
-			spGch.Free ();
-			dpGch.Free ();
-
-			return grid;
+			fixed (Vector2* source_ptr = &sourcePositions [0])
+				fixed (Vector2* dest_ptr = &destPositions [0])
+					return GridWithColumns (cols, rows, (IntPtr) source_ptr, (IntPtr) dest_ptr);
 		}
 
 		[DesignatedInitializer]
-		public SKWarpGeometryGrid (nint cols, nint rows, Vector2 [] sourcePositions, Vector2 [] destPositions)
+		public unsafe SKWarpGeometryGrid (nint cols, nint rows, Vector2 [] sourcePositions, Vector2 [] destPositions)
 		{
 			if (cols < 1 || rows < 1)
 				throw new InvalidOperationException ("cols and rows should be >= 1");
@@ -63,27 +46,12 @@ namespace XamCore.SpriteKit
 			if (destPositions.Length < ((cols + 1) * (rows + 1)))
 				throw new InvalidOperationException ("destPositions should have a minimum lenght of (cols + 1) * (rows + 1)");
 
-			IntPtr spPtr = IntPtr.Zero;
-			GCHandle spGch = new GCHandle ();
-			if (sourcePositions != null) {
-				spGch = GCHandle.Alloc (sourcePositions, GCHandleType.Pinned);
-				spPtr = spGch.AddrOfPinnedObject ();
-			}
-
-			IntPtr dpPtr = IntPtr.Zero;
-			GCHandle dpGch = new GCHandle ();
-			if (destPositions != null) {
-				dpGch = GCHandle.Alloc (destPositions, GCHandleType.Pinned);
-				dpPtr = dpGch.AddrOfPinnedObject ();
-			}
-
-			InitializeHandle (InitWithColumns (cols, rows, spPtr, dpPtr), "initWithColumns:rows:sourcePositions:destPositions:");
-
-			spGch.Free ();
-			dpGch.Free ();
+			fixed (Vector2* source_ptr = &sourcePositions [0])
+				fixed (Vector2* dest_ptr = &destPositions [0])
+					InitializeHandle (InitWithColumns (cols, rows, (IntPtr) source_ptr, (IntPtr) dest_ptr), "initWithColumns:rows:sourcePositions:destPositions:");
 		}
 
-		public SKWarpGeometryGrid GetGridByReplacingSourcePositions (Vector2 [] sourcePositions)
+		public unsafe SKWarpGeometryGrid GetGridByReplacingSourcePositions (Vector2 [] sourcePositions)
 		{
 			if (sourcePositions == null)
 				throw new ArgumentNullException ("sourcePositions");
@@ -91,17 +59,11 @@ namespace XamCore.SpriteKit
 			if (sourcePositions.Length < ((NumberOfColumns + 1) * (NumberOfRows + 1)))
 				throw new InvalidOperationException ("sourcePositions should have a minimum lenght of (NumberOfColumns + 1) * (NumberOfRows + 1)");
 
-			var gch = GCHandle.Alloc (sourcePositions, GCHandleType.Pinned);
-			var ptr = gch.AddrOfPinnedObject ();
-
-			var grid = _GridByReplacingSourcePositions (ptr);
-
-			gch.Free ();
-
-			return grid;
+			fixed (Vector2* ptr = &sourcePositions [0])
+				return _GridByReplacingSourcePositions ((IntPtr) ptr);
 		}
 
-		public SKWarpGeometryGrid GetGridByReplacingDestPositions (Vector2 [] destPositions)
+		public unsafe SKWarpGeometryGrid GetGridByReplacingDestPositions (Vector2 [] destPositions)
 		{
 			if (destPositions == null)
 				throw new ArgumentNullException ("destPositions");
@@ -109,14 +71,8 @@ namespace XamCore.SpriteKit
 			if (destPositions.Length < ((NumberOfColumns + 1) * (NumberOfRows + 1)))
 				throw new InvalidOperationException ("destPositions should have a minimum lenght of (NumberOfColumns + 1) * (NumberOfRows + 1)");
 
-			var gch = GCHandle.Alloc (destPositions, GCHandleType.Pinned);
-			var ptr = gch.AddrOfPinnedObject ();
-
-			var grid = _GridByReplacingDestPositions (ptr);
-
-			gch.Free ();
-
-			return grid;
+			fixed (Vector2* ptr = &destPositions [0])
+				return _GridByReplacingDestPositions ((IntPtr) ptr);
 		}
 	}
 }

--- a/src/SpriteKit/SKWarpGeometryGrid.cs
+++ b/src/SpriteKit/SKWarpGeometryGrid.cs
@@ -29,8 +29,8 @@ namespace XamCore.SpriteKit
 			if (destPositions.Length < ((cols + 1) * (rows + 1)))
 				throw new InvalidOperationException ("destPositions should have a minimum lenght of (cols + 1) * (rows + 1)");
 
-			fixed (Vector2* source_ptr = &sourcePositions [0])
-				fixed (Vector2* dest_ptr = &destPositions [0])
+			fixed (Vector2* source_ptr = sourcePositions)
+				fixed (Vector2* dest_ptr = destPositions)
 					return GridWithColumns (cols, rows, (IntPtr) source_ptr, (IntPtr) dest_ptr);
 		}
 
@@ -46,8 +46,8 @@ namespace XamCore.SpriteKit
 			if (destPositions.Length < ((cols + 1) * (rows + 1)))
 				throw new InvalidOperationException ("destPositions should have a minimum lenght of (cols + 1) * (rows + 1)");
 
-			fixed (Vector2* source_ptr = &sourcePositions [0])
-				fixed (Vector2* dest_ptr = &destPositions [0])
+			fixed (Vector2* source_ptr = sourcePositions)
+				fixed (Vector2* dest_ptr = destPositions)
 					InitializeHandle (InitWithColumns (cols, rows, (IntPtr) source_ptr, (IntPtr) dest_ptr), "initWithColumns:rows:sourcePositions:destPositions:");
 		}
 
@@ -59,7 +59,7 @@ namespace XamCore.SpriteKit
 			if (sourcePositions.Length < ((NumberOfColumns + 1) * (NumberOfRows + 1)))
 				throw new InvalidOperationException ("sourcePositions should have a minimum lenght of (NumberOfColumns + 1) * (NumberOfRows + 1)");
 
-			fixed (Vector2* ptr = &sourcePositions [0])
+			fixed (Vector2* ptr = sourcePositions)
 				return _GridByReplacingSourcePositions ((IntPtr) ptr);
 		}
 
@@ -71,7 +71,7 @@ namespace XamCore.SpriteKit
 			if (destPositions.Length < ((NumberOfColumns + 1) * (NumberOfRows + 1)))
 				throw new InvalidOperationException ("destPositions should have a minimum lenght of (NumberOfColumns + 1) * (NumberOfRows + 1)");
 
-			fixed (Vector2* ptr = &destPositions [0])
+			fixed (Vector2* ptr = destPositions)
 				return _GridByReplacingDestPositions ((IntPtr) ptr);
 		}
 	}


### PR DESCRIPTION
Creating/freeing GCHandles is much slower than using unsafe code,
so just avoid it when we can.