### PR TITLE
[jenkins] Automatically detect mono bumps and enable device build.

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -13,8 +13,10 @@ else
 		cat .tmp-files | sed 's/^/    /' || true
 		if grep 'external/mono' .tmp-files > /dev/null; then
 			echo "Enabling device build because mono was bumped."
+		elif grep 'external/llvm' .tmp-files > /dev/null; then
+			echo "Enabling device build because llvm was bumped."
 		else
-			echo "Not enabling device build; mono was not bumped."
+			echo "Not enabling device build; neither mono nor llvm was bumped."
 		fi
 	fi
 	rm -f .tmp-files

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -7,20 +7,34 @@ ENABLE_DEVICE_BUILD=
 if test -z $ghprbPullId; then
 	echo "Could not find the environment variable ghprbPullId, so won't check if we're doing a device build."
 else
-	echo "Downloading labels for pull request #$ghprbPullId..."
-	if curl https://api.github.com/repos/xamarin/xamarin-macios/issues/$ghprbPullId/labels > .tmp-labels; then
-		echo "Labels found:"
-		cat .tmp-labels | grep "\"name\":" | sed 's/name": \"//' | sed 's/.*\"\(.*\)\".*/    \1/' || true
-		if grep '\"enable-device-build\"' .tmp-labels >/dev/null; then
-			ENABLE_DEVICE_BUILD=1
-			echo "Enabling device build because the label 'enable-device-build' was found."
+	echo "Listing modified files for pull request #$ghprbPullId..."
+	if git diff-tree --no-commit-id --name-only -r "origin/pr/$ghprbPullId/merge^..origin/pr/$ghprbPullId/merge" > .tmp-files; then
+		echo "Modified files found":
+		cat .tmp-files | sed 's/^/    /' || true
+		if grep 'external/mono' .tmp-files > /dev/null; then
+			echo "Enabling device build because mono was bumped."
 		else
-			echo "Not enabling device build; no label named 'enable-device-build' was found."
+			echo "Not enabling device build; mono was not bumped."
 		fi
-	else
-		echo "Failed to fetch labels for the pull request $ghprbPullId, so won't check if we're doing a device build."
 	fi
-	rm -f .tmp-labels
+	rm -f .tmp-files
+
+	if test -z $ENABLE_DEVICE_BUILD; then
+		echo "Downloading labels for pull request #$ghprbPullId..."
+		if curl https://api.github.com/repos/xamarin/xamarin-macios/issues/$ghprbPullId/labels > .tmp-labels; then
+			echo "Labels found:"
+			cat .tmp-labels | grep "\"name\":" | sed 's/name": \"//' | sed 's/.*\"\(.*\)\".*/    \1/' || true
+			if grep '\"enable-device-build\"' .tmp-labels >/dev/null; then
+				ENABLE_DEVICE_BUILD=1
+				echo "Enabling device build because the label 'enable-device-build' was found."
+			else
+				echo "Not enabling device build; no label named 'enable-device-build' was found."
+			fi
+		else
+			echo "Failed to fetch labels for the pull request $ghprbPullId, so won't check if we're doing a device build."
+		fi
+		rm -f .tmp-labels
+	fi
 fi
 
 if test -n "$ENABLE_DEVICE_BUILD"; then

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -137,6 +137,7 @@ namespace xharness
 				"tools/linker",
 				"src/ObjCRuntime/Registrar.cs",
 				"external/mono",
+				"external/llvm",
 			};
 			var mmp_prefixes = new string [] {
 				"tests/mmptest",
@@ -149,6 +150,7 @@ namespace xharness
 			var bcl_prefixes = new string [] {
 				"tests/bcl-test",
 				"external/mono",
+				"external/llvm",
 			};
 
 			SetEnabled (files, mtouch_prefixes, "mtouch", ref IncludeMtouch);


### PR DESCRIPTION
And do this before fetching labels, so that we can skip fetching labels if we
know we're already enabling the device build.