### PR TITLE
[test][harness] Fix exception when running tests more than once

### DIFF
--- a/tests/xharness/Log.cs
+++ b/tests/xharness/Log.cs
@@ -249,7 +249,7 @@ namespace xharness
 		public void StopCapture ()
 		{
 			if (entire_file) {
-				File.Copy (CapturePath, Path);
+				File.Copy (CapturePath, Path, true);
 				return;
 			}
 


### PR DESCRIPTION
e.g. running twice

> make run-ios-sim32-introspection

results in

Unhandled Exception:
System.AggregateException: One or more errors occurred. ---> System.IO.IOException: /Users/poupou/git/master/xamarin-macios/tests/logs/exec-ios-sim32-introspection/iPhone 5.log already exists
  at System.IO.File.Copy (System.String sourceFileName, System.String destFileName, System.Boolean overwrite) [0x001bd] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/corlib/System.IO/File.cs:109
  at System.IO.File.Copy (System.String sourceFileName, System.String destFileName) [0x00000] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/corlib/System.IO/File.cs:69
  at xharness.CaptureLog.StopCapture () [0x00019] in /Users/poupou/git/master/xamarin-macios/tests/xharness/Log.cs:252