### PR TITLE
Start migrating monotouch-test to also run for mac

### DIFF
--- a/tests/monotouch-test/Foundation/AttributedStringTest.cs
+++ b/tests/monotouch-test/Foundation/AttributedStringTest.cs
@@ -2,7 +2,12 @@ using System;
 using NUnit.Framework;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+using UIColor = AppKit.NSColor;
+#else
 using UIKit;
+#endif
 using CoreGraphics;
 using ObjCRuntime;
 #if !__WATCHOS__
@@ -154,6 +159,7 @@ namespace MonoTouchFixtures.Foundation {
 					Assert.That (copy.RetainCount, Is.EqualTo ((nint) 1), "Copy retaincount 1");
 				using (var copy = ((INSMutableCopying) s1).MutableCopy (NSZone.Default))
 					Assert.That (copy.RetainCount, Is.EqualTo ((nint) 1), "Copy retaincount 2");
+
 			}
 		}
 

--- a/tests/monotouch-test/Foundation/AttributedStringTest.cs
+++ b/tests/monotouch-test/Foundation/AttributedStringTest.cs
@@ -159,7 +159,6 @@ namespace MonoTouchFixtures.Foundation {
 					Assert.That (copy.RetainCount, Is.EqualTo ((nint) 1), "Copy retaincount 1");
 				using (var copy = ((INSMutableCopying) s1).MutableCopy (NSZone.Default))
 					Assert.That (copy.RetainCount, Is.EqualTo ((nint) 1), "Copy retaincount 2");
-
 			}
 		}
 

--- a/tests/monotouch-test/Foundation/BundleTest.cs
+++ b/tests/monotouch-test/Foundation/BundleTest.cs
@@ -11,7 +11,11 @@ using System;
 using System.Net;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using ObjCRuntime;
 #else
 using MonoTouch.Foundation;
@@ -82,7 +86,12 @@ namespace MonoTouchFixtures.Foundation {
 		[Test]
 		public void LoadNibWithOptions ()
 		{
+#if MONOMAC
+			NSArray objects;
+			Assert.NotNull (main.LoadNibNamed ("EmptyNib", main, out objects));
+#else
 			Assert.NotNull (main.LoadNib ("EmptyNib", main, null));
+#endif
 		}
 #endif // !__WATCHOS__
 

--- a/tests/monotouch-test/Foundation/CalendarTest.cs
+++ b/tests/monotouch-test/Foundation/CalendarTest.cs
@@ -18,6 +18,10 @@ using nint=global::System.Int32;
 using nuint=global::System.UInt32;
 #endif
 
+#if MONOMAC
+using MonoTouchException = Foundation.ObjCException;
+#endif
+
 namespace MonoTouchFixtures.Foundation {
 	
 	[TestFixture]

--- a/tests/monotouch-test/Foundation/DimensionTest.cs
+++ b/tests/monotouch-test/Foundation/DimensionTest.cs
@@ -10,7 +10,11 @@
 using System;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using ObjCRuntime;
 #else
 using MonoTouch.Foundation;

--- a/tests/monotouch-test/Foundation/FileManagerTest.cs
+++ b/tests/monotouch-test/Foundation/FileManagerTest.cs
@@ -12,7 +12,11 @@ using System.IO;
 using System.Threading;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using ObjCRuntime;
 #else
 using MonoTouch.Foundation;
@@ -36,8 +40,10 @@ namespace MonoTouchFixtures.Foundation {
 		[Test]
 		public void GetUrlForUbiquityContainer ()
 		{
+#if !MONOMAC
 			if ((Runtime.Arch == Arch.SIMULATOR) && RunningOnSnowLeopard)
 				Assert.Inconclusive ("sometimes crash under the iOS simulator (generally on the SL/iOS5 bots)");
+#endif
 
 			NSFileManager fm = new NSFileManager ();
 			if (TestRuntime.CheckXcodeVersion (4, 5) && fm.UbiquityIdentityToken == null) {
@@ -81,13 +87,15 @@ namespace MonoTouchFixtures.Foundation {
 				// aborting is evil, so don't bother aborting the thread, just let it run its course
 			}
 		}
-		
+
+		//GetSkipBackupAttribute doesn't exist on Mac
+#if !MONOMAC
 		[Test]
 		public void GetSkipBackupAttribute ()
 		{
 			if ((Runtime.Arch == Arch.SIMULATOR) && RunningOnSnowLeopard)
 				Assert.Inconclusive ("iOS simulator did not get libsystem_kernel.dylib before Lion");
-			
+
 			Assert.False (NSFileManager.GetSkipBackupAttribute (NSBundle.MainBundle.ExecutableUrl.ToString ()), "MainBundle");
 
 			string filename = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), "DoNotBackupMe-NSFileManager");
@@ -111,6 +119,7 @@ namespace MonoTouchFixtures.Foundation {
 				File.Delete (filename);
 			}
 		}
+#endif
 
 		[Test]
 		public void DefaultManager ()
@@ -120,6 +129,9 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
+#if MONOMAC
+		[Ignore ("DocumentsDirectory and MyDocuments point to different locations on mac")]
+#endif
 		public void DocumentDirectory ()
 		{
 			var path = NSFileManager.DefaultManager.GetUrls (NSSearchPathDirectory.DocumentDirectory, NSSearchPathDomain.User) [0].Path;
@@ -137,6 +149,9 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
+#if MONOMAC
+		[Ignore ("Environment.SpecialFolder.Resources is empty string on mac")]
+#endif
 		public void LibraryDirectory ()
 		{
 			var path = NSFileManager.DefaultManager.GetUrls (NSSearchPathDirectory.LibraryDirectory, NSSearchPathDomain.User) [0].Path;

--- a/tests/monotouch-test/Foundation/FileManagerTest.cs
+++ b/tests/monotouch-test/Foundation/FileManagerTest.cs
@@ -87,15 +87,15 @@ namespace MonoTouchFixtures.Foundation {
 				// aborting is evil, so don't bother aborting the thread, just let it run its course
 			}
 		}
-
 		//GetSkipBackupAttribute doesn't exist on Mac
 #if !MONOMAC
+		
 		[Test]
 		public void GetSkipBackupAttribute ()
 		{
 			if ((Runtime.Arch == Arch.SIMULATOR) && RunningOnSnowLeopard)
 				Assert.Inconclusive ("iOS simulator did not get libsystem_kernel.dylib before Lion");
-
+			
 			Assert.False (NSFileManager.GetSkipBackupAttribute (NSBundle.MainBundle.ExecutableUrl.ToString ()), "MainBundle");
 
 			string filename = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), "DoNotBackupMe-NSFileManager");

--- a/tests/monotouch-test/Foundation/FormatterTests.cs
+++ b/tests/monotouch-test/Foundation/FormatterTests.cs
@@ -1,4 +1,4 @@
-using System.Drawing;
+﻿using System.Drawing;
 #if XAMCORE_2_0
 using Foundation;
 #if MONOMAC

--- a/tests/monotouch-test/Foundation/FormatterTests.cs
+++ b/tests/monotouch-test/Foundation/FormatterTests.cs
@@ -1,7 +1,11 @@
-﻿using System.Drawing;
+using System.Drawing;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 #else
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;

--- a/tests/monotouch-test/Foundation/KeyedUnarchiverTest.cs
+++ b/tests/monotouch-test/Foundation/KeyedUnarchiverTest.cs
@@ -14,8 +14,13 @@ using System.IO;
 #if XAMCORE_2_0
 using Foundation;
 using ObjCRuntime;
+#if MONOMAC
+using AppKit;
+using MonoTouchException=Foundation.ObjCException;
+#else
 using UIKit;
 using MonoTouchException=Foundation.MonoTouchException;
+#endif
 #else
 using MonoTouch.Foundation;
 using MonoTouch.ObjCRuntime;

--- a/tests/monotouch-test/Foundation/LocaleTest.cs
+++ b/tests/monotouch-test/Foundation/LocaleTest.cs
@@ -11,7 +11,11 @@ using System;
 using System.Globalization;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 #else
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;

--- a/tests/monotouch-test/Foundation/MutableAttributedStringTest.cs
+++ b/tests/monotouch-test/Foundation/MutableAttributedStringTest.cs
@@ -48,7 +48,7 @@ namespace MonoTouchFixtures.Foundation {
 			}
 		}
 
-#if !__WATCHOS__
+#if !__WATCHOS__ && !MONOMAC // No foregroundColor parameter for mac
 		[Test]
 		public void IndirectNullDictionary ()
 		{

--- a/tests/monotouch-test/Foundation/MutableDataTest.cs
+++ b/tests/monotouch-test/Foundation/MutableDataTest.cs
@@ -10,7 +10,11 @@
 using System;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 #else
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;

--- a/tests/monotouch-test/Foundation/MutableStringTest.cs
+++ b/tests/monotouch-test/Foundation/MutableStringTest.cs
@@ -11,7 +11,11 @@ using System;
 using System.Drawing;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 #else
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;

--- a/tests/monotouch-test/Foundation/NSCharacterSetTest.cs
+++ b/tests/monotouch-test/Foundation/NSCharacterSetTest.cs
@@ -1,8 +1,12 @@
-﻿using System;
+using System;
 using System.Drawing;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 #else
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;

--- a/tests/monotouch-test/Foundation/NSDataTest.cs
+++ b/tests/monotouch-test/Foundation/NSDataTest.cs
@@ -13,7 +13,11 @@ using System.IO;
 using System.Runtime.InteropServices;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 #else
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
@@ -78,7 +82,11 @@ namespace MonoTouchFixtures.Foundation {
 		public void FromFile ()
 		{
 			Assert.Null (NSData.FromFile ("does not exists"), "unexisting");
+#if MONOMAC // Info.Plist isn't there to load from the same location on mac
+			Assert.NotNull (NSData.FromFile ("machine.config"), "Machine.Config");
+#else
 			Assert.NotNull (NSData.FromFile ("Info.plist"), "Info.plist");
+#endif
 		}
 
 		[Test]

--- a/tests/monotouch-test/Foundation/NSDataTest.cs
+++ b/tests/monotouch-test/Foundation/NSDataTest.cs
@@ -83,7 +83,7 @@ namespace MonoTouchFixtures.Foundation {
 		{
 			Assert.Null (NSData.FromFile ("does not exists"), "unexisting");
 #if MONOMAC // Info.Plist isn't there to load from the same location on mac
-			Assert.NotNull (NSData.FromFile ("machine.config"), "Machine.Config");
+			Assert.NotNull (NSData.FromFile (NSBundle.MainBundle.PathForResource ("runtime-options", "plist")), "runtime-options.plist");
 #else
 			Assert.NotNull (NSData.FromFile ("Info.plist"), "Info.plist");
 #endif

--- a/tests/monotouch-test/Foundation/NSDictionary2Test.cs
+++ b/tests/monotouch-test/Foundation/NSDictionary2Test.cs
@@ -557,7 +557,6 @@ namespace MonoTouchFixtures.Foundation {
 			Assert.AreEqual (2, c, "Enumerator Count");
 		}
 
-#if !MONOMAC // TODO: Messaging is internal on mac
 		[Test]
 		public void InvalidType ()
 		{
@@ -579,7 +578,6 @@ namespace MonoTouchFixtures.Foundation {
 			Assert.Throws<InvalidCastException> (() => GC.KeepAlive (dictK.Keys), "K Keys");
 			Assert.Throws<InvalidCastException> (() => dictK.KeysForObject (kv), "K KeysForObject");
 		}
-#endif
 	}
 }
 

--- a/tests/monotouch-test/Foundation/NSDictionary2Test.cs
+++ b/tests/monotouch-test/Foundation/NSDictionary2Test.cs
@@ -557,6 +557,7 @@ namespace MonoTouchFixtures.Foundation {
 			Assert.AreEqual (2, c, "Enumerator Count");
 		}
 
+#if !MONOMAC // TODO: Messaging is internal on mac
 		[Test]
 		public void InvalidType ()
 		{
@@ -578,6 +579,7 @@ namespace MonoTouchFixtures.Foundation {
 			Assert.Throws<InvalidCastException> (() => GC.KeepAlive (dictK.Keys), "K Keys");
 			Assert.Throws<InvalidCastException> (() => dictK.KeysForObject (kv), "K KeysForObject");
 		}
+#endif
 	}
 }
 

--- a/tests/monotouch-test/Foundation/NSDictionaryTest.cs
+++ b/tests/monotouch-test/Foundation/NSDictionaryTest.cs
@@ -222,6 +222,8 @@ namespace MonoTouchFixtures.Foundation {
 			}
 		}
 
+		//Messaging is internal on mac, so unavailable
+#if !MONOMAC
 		[Test]
 		public void IndexerTest ()
 		{
@@ -272,5 +274,6 @@ namespace MonoTouchFixtures.Foundation {
 				Marshal.FreeHGlobal (strobjptr);
 			}
 		}
+#endif
 	}
 }

--- a/tests/monotouch-test/Foundation/NSDictionaryTest.cs
+++ b/tests/monotouch-test/Foundation/NSDictionaryTest.cs
@@ -222,8 +222,6 @@ namespace MonoTouchFixtures.Foundation {
 			}
 		}
 
-		//Messaging is internal on mac, so unavailable
-#if !MONOMAC
 		[Test]
 		public void IndexerTest ()
 		{
@@ -274,6 +272,5 @@ namespace MonoTouchFixtures.Foundation {
 				Marshal.FreeHGlobal (strobjptr);
 			}
 		}
-#endif
 	}
 }

--- a/tests/monotouch-test/Foundation/NSLocaleTest.cs
+++ b/tests/monotouch-test/Foundation/NSLocaleTest.cs
@@ -13,7 +13,8 @@ using MonoTouch.ObjCRuntime;
 using NUnit.Framework;
 
 namespace MonoTouchFixtures.Foundation {
-	
+
+#if !MONOMAC //TODO: Messaging is internal on mac
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class NSLocaleTest {
@@ -59,4 +60,5 @@ namespace MonoTouchFixtures.Foundation {
 #endif
 		}
 	}
+#endif
 }

--- a/tests/monotouch-test/Foundation/NSLocaleTest.cs
+++ b/tests/monotouch-test/Foundation/NSLocaleTest.cs
@@ -13,8 +13,7 @@ using MonoTouch.ObjCRuntime;
 using NUnit.Framework;
 
 namespace MonoTouchFixtures.Foundation {
-
-#if !MONOMAC //TODO: Messaging is internal on mac
+	
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class NSLocaleTest {
@@ -60,5 +59,4 @@ namespace MonoTouchFixtures.Foundation {
 #endif
 		}
 	}
-#endif
 }

--- a/tests/monotouch-test/Foundation/NSMutableDictionaryTest.cs
+++ b/tests/monotouch-test/Foundation/NSMutableDictionaryTest.cs
@@ -25,7 +25,8 @@ namespace monotouchtest
 {
 	[TestFixture]
 	public class NSMutableDictionaryTest {
-		
+		//Messaging is unavailable on mac
+#if !MONOMAC
 		[Test]
 		public void IndexerTest ()
 		{
@@ -82,6 +83,7 @@ namespace monotouchtest
 				Marshal.FreeHGlobal (strobjptr);
 			}
 		}
+#endif
 
 		[Test]
 		public void Bug39993 ()

--- a/tests/monotouch-test/Foundation/NSMutableDictionaryTest.cs
+++ b/tests/monotouch-test/Foundation/NSMutableDictionaryTest.cs
@@ -25,8 +25,7 @@ namespace monotouchtest
 {
 	[TestFixture]
 	public class NSMutableDictionaryTest {
-		//Messaging is unavailable on mac
-#if !MONOMAC
+		
 		[Test]
 		public void IndexerTest ()
 		{
@@ -83,7 +82,6 @@ namespace monotouchtest
 				Marshal.FreeHGlobal (strobjptr);
 			}
 		}
-#endif
 
 		[Test]
 		public void Bug39993 ()

--- a/tests/monotouch-test/Foundation/NSTimeZoneTest.cs
+++ b/tests/monotouch-test/Foundation/NSTimeZoneTest.cs
@@ -49,10 +49,12 @@ namespace MonoTouchFixtures.Foundation {
 			foreach (var name in NSTimeZone.KnownTimeZoneNames) {
 				// simulator uses OSX to get timezones which might have some holes,
 				// e.g. @"Pacific/Bougainville" does not seems to be available in Mavericks
+#if !MONOMAC
 				if (Runtime.Arch == Arch.SIMULATOR) {
 					if (!File.Exists (Path.Combine ("/usr/share/zoneinfo/", name)))
 						continue;
 				}
+#endif
 				TimeZoneInfo tzi = TimeZoneInfo.FindSystemTimeZoneById (name);
 				Assert.NotNull (tzi.GetUtcOffset (DateTime.Now), name);
 			}

--- a/tests/monotouch-test/Foundation/NetServiceTest.cs
+++ b/tests/monotouch-test/Foundation/NetServiceTest.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Unit tests for NSNetService
 //
 // Authors:
@@ -12,7 +12,11 @@
 using System;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 #else
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
@@ -28,7 +32,14 @@ namespace MonoTouchFixtures.Foundation {
 		[Test]
 		public void DefaultCtor ()
 		{
-			using (var ns = new NSNetService ("d", "_test._tcp", UIDevice.CurrentDevice.Name, 1234)) {
+			using (var ns = new NSNetService ("d", 
+			                                  "_test._tcp",
+#if MONOMAC
+			                                  "DeviceName",
+#else
+											  UIDevice.CurrentDevice.Name, 
+#endif
+			                                  1234)) {
 				Assert.That (ns.Domain, Is.EqualTo ("d"), "Domain");
 				Assert.That (ns.Type, Is.EqualTo ("_test._tcp"), "Type");
 				Assert.That (ns.Port, Is.EqualTo (1234), "Port");

--- a/tests/monotouch-test/Foundation/NetServiceTest.cs
+++ b/tests/monotouch-test/Foundation/NetServiceTest.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Unit tests for NSNetService
 //
 // Authors:

--- a/tests/monotouch-test/Foundation/ObjectTest.cs
+++ b/tests/monotouch-test/Foundation/ObjectTest.cs
@@ -16,9 +16,15 @@ using System.Threading;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
-using MonoTouchException=Foundation.MonoTouchException;
 using Security;
+#if MONOMAC
+using AppKit;
+using MonoTouchException = Foundation.ObjCException;
+using UIView = AppKit.NSView;
+#else
 using UIKit;
+using MonoTouchException=Foundation.MonoTouchException;
+#endif
 #else
 using MonoTouch.CoreGraphics;
 using MonoTouch.Foundation;

--- a/tests/monotouch-test/Foundation/StringTest.cs
+++ b/tests/monotouch-test/Foundation/StringTest.cs
@@ -13,7 +13,13 @@ using System.Drawing;
 #endif
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+using UIFont = AppKit.NSFont;
+using UIStringAttributes = AppKit.NSStringAttributes;
+#else
 using UIKit;
+#endif
 #else
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
@@ -109,8 +115,9 @@ namespace MonoTouchFixtures.Foundation {
 					Is.EqualTo (NSComparisonResult.Same), "Replace");
 			}
 		}
-		
-#if !__TVOS__ && !__WATCHOS__
+
+		//No Mac version of DrawString with those parameters
+#if !__TVOS__ && !__WATCHOS__ && !MONOMAC
 		[Test]
 		[Culture ("en")] // fails for some cultures, e.g. ar-AE
 		public void DrawString_7 ()
@@ -136,6 +143,7 @@ namespace MonoTouchFixtures.Foundation {
 			}
 		}
 
+		//No Mac ersion of StringSize with those parmaters
 		[Test]
 		[Culture ("en")] // fails for some cultures, e.g. ar-AE
 		public void StringSize_5 ()
@@ -160,7 +168,7 @@ namespace MonoTouchFixtures.Foundation {
 				throw;
 			}
 		}
-#endif // !__TVOS__ && !__WATCHOS__
+#endif // !__TVOS__ && !__WATCHOS__ && !MONOMAC
 
 		[Test]
 		public void PathExtensions ()
@@ -189,8 +197,10 @@ namespace MonoTouchFixtures.Foundation {
 					Assert.DoesNotThrow (() => s.WeakGetBoundingRect (new SizeF (5, 5), options, dict, null), "WeakGetBoundingRect 1");
 					Assert.DoesNotThrow (() => s.DrawString (new RectangleF (0, 0, 10, 10), options, attrib, null), "DrawString 1");
 					Assert.DoesNotThrow (() => s.WeakDrawString (new RectangleF (0, 0, 10, 10), options, dict, null), "WeakDrawString 1");
+#if !MONOMAC //WeakDrawString on mac doesn't have versions with these parameters
 					Assert.DoesNotThrow (() => s.WeakDrawString (new RectangleF (0, 0, 10, 10), dict), "WeakDrawString 2");
 					Assert.DoesNotThrow (() => s.WeakDrawString (new PointF (0, 0), dict), "WeakDrawString 3");
+#endif
 				}
 			}
 		}
@@ -229,6 +239,7 @@ namespace MonoTouchFixtures.Foundation {
 			}
 		}
 
+#if !MONOMAC // NSImage uses different methods
 		[Test]
 		public void FromData ()
 		{
@@ -242,5 +253,6 @@ namespace MonoTouchFixtures.Foundation {
 				NSString.FromData (null, NSStringEncoding.UTF8);
 			}, "NSDataNull");
 		}
+#endif
 	}
 }

--- a/tests/monotouch-test/Foundation/UrlConnectionTest.cs
+++ b/tests/monotouch-test/Foundation/UrlConnectionTest.cs
@@ -10,7 +10,11 @@
 using System;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using ObjCRuntime;
 #else
 using MonoTouch.Foundation;

--- a/tests/monotouch-test/Foundation/UrlCredentialTest.cs
+++ b/tests/monotouch-test/Foundation/UrlCredentialTest.cs
@@ -12,7 +12,11 @@ using System.Security.Cryptography.X509Certificates;
 #if XAMCORE_2_0
 using Foundation;
 using Security;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 #else
 using MonoTouch.Foundation;
 using MonoTouch.Security;

--- a/tests/monotouch-test/Foundation/UrlProtectionSpaceTest.cs
+++ b/tests/monotouch-test/Foundation/UrlProtectionSpaceTest.cs
@@ -12,7 +12,11 @@ using System.Security.Cryptography.X509Certificates;
 #if XAMCORE_2_0
 using Foundation;
 using Security;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 #else
 using MonoTouch.Foundation;
 using MonoTouch.Security;

--- a/tests/monotouch-test/Foundation/UrlProtocolTest.cs
+++ b/tests/monotouch-test/Foundation/UrlProtocolTest.cs
@@ -11,7 +11,11 @@ using System;
 using System.IO;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using ObjCRuntime;
 #else
 using MonoTouch.Foundation;

--- a/tests/monotouch-test/Foundation/UrlRequestTest.cs
+++ b/tests/monotouch-test/Foundation/UrlRequestTest.cs
@@ -39,6 +39,7 @@ namespace MonoTouchFixtures.Foundation {
 				// that a bit like lying, we still consider it an NSMutableDictionary but it't not mutable
 				Assert.That (mur.Headers, Is.TypeOf (typeof (NSMutableDictionary)), "NSMutableDictionary");
 
+#if !MONOMAC // No Simulator for mac
 				// that would crash on devices
 				// NSInternalInconsistencyException -[__NSCFDictionary setObject:forKey:]: mutating method sent to immutable object
 				if (Runtime.Arch == Arch.SIMULATOR) {
@@ -61,6 +62,7 @@ namespace MonoTouchFixtures.Foundation {
 
 					Assert.AreNotSame (md, mur.Headers, "!same");
 				}
+#endif
 
 				// https://www.bignerdranch.com/blog/about-mutability/
 				Assert.That (mur.Headers.Class.Name, Is.EqualTo ("__NSCFDictionary"), "__NSCFDictionary");

--- a/tests/monotouch-test/Foundation/UrlSessionConfigurationTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionConfigurationTest.cs
@@ -12,7 +12,11 @@ using System;
 using Foundation;
 using Security;
 using ObjCRuntime;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 #else
 using MonoTouch.Foundation;
 using MonoTouch.ObjCRuntime;

--- a/tests/monotouch-test/Foundation/UrlSessionTaskMetricsTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTaskMetricsTest.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Unit tests for NSUrlSessionTaskMetrics
 //
 // Authors:

--- a/tests/monotouch-test/Foundation/UrlSessionTaskMetricsTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTaskMetricsTest.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Unit tests for NSUrlSessionTaskMetrics
 //
 // Authors:
@@ -10,7 +10,11 @@
 using System;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using ObjCRuntime;
 #else
 using MonoTouch.Foundation;

--- a/tests/monotouch-test/Foundation/UrlSessionTaskTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTaskTest.cs
@@ -10,7 +10,11 @@
 using System;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using ObjCRuntime;
 #else
 using MonoTouch.Foundation;
@@ -24,7 +28,7 @@ namespace MonoTouchFixtures.Foundation {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class UrlSessionTaskTest {
-
+		
 		[Test]
 		public void Properties ()
 		{

--- a/tests/monotouch-test/Foundation/UrlSessionTaskTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTaskTest.cs
@@ -28,7 +28,7 @@ namespace MonoTouchFixtures.Foundation {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class UrlSessionTaskTest {
-		
+
 		[Test]
 		public void Properties ()
 		{

--- a/tests/monotouch-test/Foundation/UrlSessionTaskTransactionMetricsTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTaskTransactionMetricsTest.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Unit tests for NSUrlSessionTaskTransactionMetrics
 //
 // Authors:
@@ -10,7 +10,11 @@
 using System;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using ObjCRuntime;
 #else
 using MonoTouch.Foundation;

--- a/tests/monotouch-test/Foundation/UrlSessionTaskTransactionMetricsTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTaskTransactionMetricsTest.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Unit tests for NSUrlSessionTaskTransactionMetrics
 //
 // Authors:

--- a/tests/monotouch-test/Foundation/UrlSessionTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTest.cs
@@ -12,7 +12,11 @@ using System.IO;
 
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using ObjCRuntime;
 #else
 using MonoTouch.Foundation;
@@ -27,6 +31,8 @@ namespace MonoTouchFixtures.Foundation {
 	[Preserve (AllMembers = true)]
 	public class UrlSessionTest {
 
+		//TODO: TestRuntime.RunAsync is not on mac currently
+#if !MONOMAC
 		// FIXME all test cases are failing on bots with Xcode 8 / watchOS 3
 #if !__WATCHOS__
 		[Test]
@@ -136,6 +142,7 @@ namespace MonoTouchFixtures.Foundation {
 			Assert.IsNull (ex, "Exception");
 			Assert.AreEqual (-1, failed_iteration, "Failed");
 		}
+#endif
 
 		[Test]
 		public void SharedSession ()

--- a/tests/monotouch-test/Foundation/UrlTest.cs
+++ b/tests/monotouch-test/Foundation/UrlTest.cs
@@ -11,7 +11,11 @@ using System;
 using System.IO;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using ObjCRuntime;
 #else
 using MonoTouch.Foundation;

--- a/tests/monotouch-test/Foundation/UserDefaultsTest.cs
+++ b/tests/monotouch-test/Foundation/UserDefaultsTest.cs
@@ -10,7 +10,11 @@
 using System;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using ObjCRuntime;
 #else
 using MonoTouch.Foundation;

--- a/tests/monotouch-test/Foundation/UuidTest.cs
+++ b/tests/monotouch-test/Foundation/UuidTest.cs
@@ -11,7 +11,11 @@ using System;
 using System.IO;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using ObjCRuntime;
 #else
 using MonoTouch.Foundation;

--- a/tests/monotouch-test/GameKit/LeaderboardTest.cs
+++ b/tests/monotouch-test/GameKit/LeaderboardTest.cs
@@ -12,7 +12,11 @@
 using System;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using GameKit;
 #else
 using MonoTouch.Foundation;

--- a/tests/monotouch-test/GameKit/LeaderboardViewControllerTest.cs
+++ b/tests/monotouch-test/GameKit/LeaderboardViewControllerTest.cs
@@ -14,7 +14,11 @@ using System.IO;
 using System.Threading;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using GameKit;
 #else
 using MonoTouch.Foundation;

--- a/tests/monotouch-test/GameKit/ScoreTest.cs
+++ b/tests/monotouch-test/GameKit/ScoreTest.cs
@@ -14,7 +14,11 @@ using System.IO;
 using System.Threading;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using GameKit;
 #else
 using MonoTouch.Foundation;

--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -534,9 +534,18 @@ namespace MonoTouchFixtures.Security {
 		}
 
 		[Test]
+#if MONOMAC
+		[Ignore ("For some reason cert.Handle is coming back as IntPtr.Zero in test.  Works fine in a normal mac app.")]
+#endif
 		public void MailX1 ()
 		{
-			using (var cert = new X509Certificate (mail_google_com)) {
+#if MONOMAC // Not disposable on mac
+
+			var cert = new X509Certificate (mail_google_com);
+#else
+			using (var cert = new X509Certificate (mail_google_com)) 
+#endif
+			{
 				/*
 				 * This X509Certificate constructor will use SecCertificateCreateWithData() and
 				 * store the SecCertificateRef in its Handle.
@@ -555,7 +564,12 @@ namespace MonoTouchFixtures.Security {
 		[Ignore ("https://bugzilla.xamarin.com/show_bug.cgi?id=39952")]
 		public void MailX2 ()
 		{
-			using (var cert = new X509Certificate2 (mail_google_com)) {
+#if MONOMAC // Not disposable on mac
+			var cert = new X509Certificate2 (mail_google_com);
+#else
+			using (var cert = new X509Certificate2 (mail_google_com)) 
+#endif
+			{
 				/*
 				 * FIXME: This X509Certificate2 constructor will use Mono.Security to parse the
 				 *        certificate, but also call the base class'es .ctor with the byte array.

--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -534,17 +534,9 @@ namespace MonoTouchFixtures.Security {
 		}
 
 		[Test]
-#if MONOMAC
-		[Ignore ("For some reason cert.Handle is coming back as IntPtr.Zero in test.  Works fine in a normal mac app.")]
-#endif
 		public void MailX1 ()
 		{
-#if MONOMAC // Not disposable on mac
-
-			var cert = new X509Certificate (mail_google_com);
-#else
 			using (var cert = new X509Certificate (mail_google_com)) 
-#endif
 			{
 				/*
 				 * This X509Certificate constructor will use SecCertificateCreateWithData() and
@@ -564,11 +556,8 @@ namespace MonoTouchFixtures.Security {
 		[Ignore ("https://bugzilla.xamarin.com/show_bug.cgi?id=39952")]
 		public void MailX2 ()
 		{
-#if MONOMAC // Not disposable on mac
-			var cert = new X509Certificate2 (mail_google_com);
-#else
+
 			using (var cert = new X509Certificate2 (mail_google_com)) 
-#endif
 			{
 				/*
 				 * FIXME: This X509Certificate2 constructor will use Mono.Security to parse the

--- a/tests/monotouch-test/Security/KeyChainTest.cs
+++ b/tests/monotouch-test/Security/KeyChainTest.cs
@@ -41,6 +41,7 @@ namespace MonoTouchFixtures.Security {
 			Assert.IsTrue (rc == SecStatusCode.Success || rc == SecStatusCode.DuplicateItem, "Add_Certificate");
 		}
 
+#if !MONOMAC // No QueryAsConcreteType on Mac
 		[Test]
 		public void AddQueryRemove_Identity ()
 		{
@@ -71,6 +72,7 @@ namespace MonoTouchFixtures.Security {
 				Assert.Null (match, "match-3");
 			}
 		}
+#endif
 
 		[DllImport ("/System/Library/Frameworks/Security.framework/Security")]
 		internal extern static SecStatusCode SecItemAdd (IntPtr cfDictRef, IntPtr result);

--- a/tests/monotouch-test/Security/KeyTest.cs
+++ b/tests/monotouch-test/Security/KeyTest.cs
@@ -15,7 +15,11 @@ using System.Security.Cryptography.X509Certificates;
 #if XAMCORE_2_0
 using Foundation;
 using Security;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 #else
 using MonoTouch.Foundation;
 using MonoTouch.Security;

--- a/tests/monotouch-test/Security/PolicyTest.cs
+++ b/tests/monotouch-test/Security/PolicyTest.cs
@@ -13,7 +13,11 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using Security;
 using ObjCRuntime;
 #else

--- a/tests/monotouch-test/Security/RecordTest.cs
+++ b/tests/monotouch-test/Security/RecordTest.cs
@@ -4,7 +4,11 @@ using System;
 #if XAMCORE_2_0
 using Foundation;
 using Security;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 #else
 using MonoTouch.Foundation;
 using MonoTouch.Security;
@@ -293,6 +297,7 @@ namespace MonoTouchFixtures.Security {
 			}
 		}
 
+#if !MONOMAC // Works different on Mac
 		[Test]
 		public void SecRecordRecordTest ()
 		{
@@ -331,5 +336,6 @@ namespace MonoTouchFixtures.Security {
 				}
 			}
 		}
+#endif
 	}
 }

--- a/tests/monotouch-test/Security/SecureTransportTest.cs
+++ b/tests/monotouch-test/Security/SecureTransportTest.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // SecureTransport Unit Tests
 //
 // Authors:

--- a/tests/monotouch-test/Security/SecureTransportTest.cs
+++ b/tests/monotouch-test/Security/SecureTransportTest.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // SecureTransport Unit Tests
 //
 // Authors:
@@ -15,7 +15,11 @@ using System.Threading;
 using Foundation;
 using Security;
 using ObjCRuntime;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 #else
 using MonoTouch.Foundation;
 using MonoTouch.Security;

--- a/tests/monotouch-test/Security/TrustTest.cs
+++ b/tests/monotouch-test/Security/TrustTest.cs
@@ -15,7 +15,11 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 #if XAMCORE_2_0
 using Foundation;
+#if MONOMAC
+using AppKit;
+#else
 using UIKit;
+#endif
 using Security;
 using ObjCRuntime;
 #else

--- a/tests/tests-mac.sln
+++ b/tests/tests-mac.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GuiUnit_xammac_mobile", "..
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "apitest-unified", "apitest\apitest-unified.csproj", "{7A0EDA95-30A6-43E1-AD43-368AD95AC48B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xammac_tests", "xammac_tests\xammac_tests.csproj", "{22BF080C-AFAD-445B-8BB5-42B9E7FDBC68}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -81,5 +83,17 @@ Global
 		{7A0EDA95-30A6-43E1-AD43-368AD95AC48B}.Debug|x86.Build.0 = Debug|x86
 		{7A0EDA95-30A6-43E1-AD43-368AD95AC48B}.Release|x86.ActiveCfg = Release|x86
 		{7A0EDA95-30A6-43E1-AD43-368AD95AC48B}.Release|x86.Build.0 = Release|x86
+		{22BF080C-AFAD-445B-8BB5-42B9E7FDBC68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22BF080C-AFAD-445B-8BB5-42B9E7FDBC68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22BF080C-AFAD-445B-8BB5-42B9E7FDBC68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22BF080C-AFAD-445B-8BB5-42B9E7FDBC68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22BF080C-AFAD-445B-8BB5-42B9E7FDBC68}.Default|Any CPU.ActiveCfg = Debug|Any CPU
+		{22BF080C-AFAD-445B-8BB5-42B9E7FDBC68}.Default|Any CPU.Build.0 = Debug|Any CPU
+		{22BF080C-AFAD-445B-8BB5-42B9E7FDBC68}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{22BF080C-AFAD-445B-8BB5-42B9E7FDBC68}.AppStore|Any CPU.Build.0 = Debug|Any CPU
+		{22BF080C-AFAD-445B-8BB5-42B9E7FDBC68}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{22BF080C-AFAD-445B-8BB5-42B9E7FDBC68}.Debug|x86.Build.0 = Debug|Any CPU
+		{22BF080C-AFAD-445B-8BB5-42B9E7FDBC68}.Release|x86.ActiveCfg = Release|Any CPU
+		{22BF080C-AFAD-445B-8BB5-42B9E7FDBC68}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/tests/xammac_tests/Info.plist
+++ b/tests/xammac_tests/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>xammac_tests</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.xamarin.xammac_tests</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.7</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>LSUIElement</key>
+	<string>1</string>
+	<key>CFBundleName</key>
+	<string>xammac_tests</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+</dict>
+</plist>

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{22BF080C-AFAD-445B-8BB5-42B9E7FDBC68}</ProjectGuid>
+    <ProjectTypeGuids>{42C0BBD9-55CE-4FC1-8D90-A7348ABAFB23};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>dontlink</RootNamespace>
+    <AssemblyName>xammac_tests</AssemblyName>
+    <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>__UNIFIED__;DEBUG;MONOMAC;XAMCORE_2_0</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <EnableCodeSigning>false</EnableCodeSigning>
+    <CreatePackage>false</CreatePackage>
+    <EnablePackageSigning>false</EnablePackageSigning>
+    <IncludeMonoRuntime>false</IncludeMonoRuntime>
+    <UseSGen>false</UseSGen>
+    <HttpClientHandler>HttpClientHandler</HttpClientHandler>
+    <TlsProvider>Default</TlsProvider>
+    <LinkMode>None</LinkMode>
+    <XamMacArch>x86_64</XamMacArch>
+    <CodeSigningKey>Mac Developer</CodeSigningKey>
+    <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <DefineConstants></DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <EnableCodeSigning>false</EnableCodeSigning>
+    <CreatePackage>false</CreatePackage>
+    <EnablePackageSigning>false</EnablePackageSigning>
+    <IncludeMonoRuntime>false</IncludeMonoRuntime>
+    <UseSGen>false</UseSGen>
+    <HttpClientHandler>HttpClientHandler</HttpClientHandler>
+    <TlsProvider>Default</TlsProvider>
+    <LinkMode>None</LinkMode>
+    <XamMacArch></XamMacArch>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="GuiUnit">
+      <HintPath>..\..\external\guiunit\bin\net_4_5\GuiUnit.exe</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Mac">
+      <HintPath>..\..\..\..\..\..\..\..\Library\Frameworks\Xamarin.Mac.framework\Versions\2.10.0.113\lib\reference\mobile\Xamarin.Mac.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Drawing" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\monotouch-test\GameKit\LeaderboardTest.cs">
+      <Link>GameKit\LeaderboardTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\GameKit\LeaderboardViewControllerTest.cs">
+      <Link>GameKit\LeaderboardViewControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\GameKit\NotificationBannerTest.cs">
+      <Link>GameKit\NotificationBannerTest.cs</Link>
+    </Compile>
+    <Compile Include="..\common\TestRuntime.cs">
+      <Link>TestRuntime.cs</Link>
+    </Compile>
+    <Compile Include="..\common\mac\MacTestMain.cs">
+      <Link>MacTestMain.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\ArrayTest.cs">
+      <Link>Foundation\ArrayTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\AttributedStringTest.cs">
+      <Link>Foundation\AttributedStringTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\BlockOperationTest.cs">
+      <Link>Foundation\BlockOperationTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\BundleTest.cs">
+      <Link>Foundation\BundleTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\CachedUrlResponseTest.cs">
+      <Link>Foundation\CachedUrlResponseTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\CalendarTest.cs">
+      <Link>Foundation\CalendarTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\CoderTest.cs">
+      <Link>Foundation\CoderTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\CookieTest.cs">
+      <Link>Foundation\CookieTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\DateFormatterTest.cs">
+      <Link>Foundation\DateFormatterTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\DateTest.cs">
+      <Link>Foundation\DateTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\DecimalNumberTest.cs">
+      <Link>Foundation\DecimalNumberTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\DecimalTest.cs">
+      <Link>Foundation\DecimalTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\DictionaryContainerTest.cs">
+      <Link>Foundation\DictionaryContainerTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\DimensionTest.cs">
+      <Link>Foundation\DimensionTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\EncodingDetectionOptionsTest.cs">
+      <Link>Foundation\EncodingDetectionOptionsTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\FileCoordinatorTest.cs">
+      <Link>Foundation\FileCoordinatorTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\FileHandleTest.cs">
+      <Link>Foundation\FileHandleTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\FileManagerTest.cs">
+      <Link>Foundation\FileManagerTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\FormatterTests.cs">
+      <Link>Foundation\FormatterTests.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\IndexPathTest.cs">
+      <Link>Foundation\IndexPathTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\KeyedUnarchiverTest.cs">
+      <Link>Foundation\KeyedUnarchiverTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\LocaleTest.cs">
+      <Link>Foundation\LocaleTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\MutableAttributedStringTest.cs">
+      <Link>Foundation\MutableAttributedStringTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\MutableDataTest.cs">
+      <Link>Foundation\MutableDataTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\MutableStringTest.cs">
+      <Link>Foundation\MutableStringTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSArray1Test.cs">
+      <Link>Foundation\NSArray1Test.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSCharacterSetTest.cs">
+      <Link>Foundation\NSCharacterSetTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSDataTest.cs">
+      <Link>Foundation\NSDataTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSDictionary2Test.cs">
+      <Link>Foundation\NSDictionary2Test.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSDictionaryTest.cs">
+      <Link>Foundation\NSDictionaryTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSExpressionTest.cs">
+      <Link>Foundation\NSExpressionTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSLocaleTest.cs">
+      <Link>Foundation\NSLocaleTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSMutableArray1Test.cs">
+      <Link>Foundation\NSMutableArray1Test.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSMutableDictionary2Test.cs">
+      <Link>Foundation\NSMutableDictionary2Test.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSMutableDictionaryTest.cs">
+      <Link>Foundation\NSMutableDictionaryTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSMutableOrderedSet1Test.cs">
+      <Link>Foundation\NSMutableOrderedSet1Test.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSMutableOrderedSetTest.cs">
+      <Link>Foundation\NSMutableOrderedSetTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSMutableSet1Test.cs">
+      <Link>Foundation\NSMutableSet1Test.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSMutableSetTest.cs">
+      <Link>Foundation\NSMutableSetTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSOrderedSet1Test.cs">
+      <Link>Foundation\NSOrderedSet1Test.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSOrderedSetTest.cs">
+      <Link>Foundation\NSOrderedSetTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSSet1Test.cs">
+      <Link>Foundation\NSSet1Test.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSSetTest.cs">
+      <Link>Foundation\NSSetTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSStreamTest.cs">
+      <Link>Foundation\NSStreamTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSStringTest.cs">
+      <Link>Foundation\NSStringTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NSTimeZoneTest.cs">
+      <Link>Foundation\NSTimeZoneTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NetServiceTest.cs">
+      <Link>Foundation\NetServiceTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NotificationCenter.cs">
+      <Link>Foundation\NotificationCenter.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NotificationQueueTest.cs">
+      <Link>Foundation\NotificationQueueTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\NumberTest.cs">
+      <Link>Foundation\NumberTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\ObjectTest.cs">
+      <Link>Foundation\ObjectTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\OperationQueueTest.cs">
+      <Link>Foundation\OperationQueueTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\ProtocolAttributeTest.cs">
+      <Link>Foundation\ProtocolAttributeTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\StringTest.cs">
+      <Link>Foundation\StringTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\ThreadTest.cs">
+      <Link>Foundation\ThreadTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\TimerTest.cs">
+      <Link>Foundation\TimerTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\UbiquitousKeyValueStoreTest.cs">
+      <Link>Foundation\UbiquitousKeyValueStoreTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\UrlConnectionTest.cs">
+      <Link>Foundation\UrlConnectionTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\UrlCredentialTest.cs">
+      <Link>Foundation\UrlCredentialTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\UrlProtectionSpaceTest.cs">
+      <Link>Foundation\UrlProtectionSpaceTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\UrlProtocolTest.cs">
+      <Link>Foundation\UrlProtocolTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\UrlRequestTest.cs">
+      <Link>Foundation\UrlRequestTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\UrlSessionConfigurationTest.cs">
+      <Link>Foundation\UrlSessionConfigurationTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\UrlSessionTaskMetricsTest.cs">
+      <Link>Foundation\UrlSessionTaskMetricsTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\UrlSessionTaskTest.cs">
+      <Link>Foundation\UrlSessionTaskTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\UrlSessionTaskTransactionMetricsTest.cs">
+      <Link>Foundation\UrlSessionTaskTransactionMetricsTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\UrlSessionTest.cs">
+      <Link>Foundation\UrlSessionTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\UrlTest.cs">
+      <Link>Foundation\UrlTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\UserDefaultsTest.cs">
+      <Link>Foundation\UserDefaultsTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\UuidTest.cs">
+      <Link>Foundation\UuidTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Foundation\ZoneTest.cs">
+      <Link>Foundation\ZoneTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\Security\CertificateTest.cs">
+      <Link>Security\CertificateTest.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
+</Project>

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -4,12 +4,13 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{22BF080C-AFAD-445B-8BB5-42B9E7FDBC68}</ProjectGuid>
-    <ProjectTypeGuids>{42C0BBD9-55CE-4FC1-8D90-A7348ABAFB23};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
     <RootNamespace>dontlink</RootNamespace>
     <AssemblyName>xammac_tests</AssemblyName>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -54,9 +55,8 @@
       <HintPath>..\..\external\guiunit\bin\net_4_5\GuiUnit.exe</HintPath>
     </Reference>
     <Reference Include="Xamarin.Mac">
-      <HintPath>..\..\..\..\..\..\..\..\Library\Frameworks\Xamarin.Mac.framework\Versions\2.10.0.113\lib\reference\mobile\Xamarin.Mac.dll</HintPath>
+      <HintPath>..\..\_mac-build\Library\Frameworks\Xamarin.Mac.framework\Versions\git\lib\reference\mobile\Xamarin.Mac.dll</HintPath>
     </Reference>
-    <Reference Include="System.Drawing" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\monotouch-test\GameKit\LeaderboardTest.cs">
@@ -289,6 +289,9 @@
     </Compile>
     <Compile Include="..\monotouch-test\Security\CertificateTest.cs">
       <Link>Security\CertificateTest.cs</Link>
+    </Compile>
+    <Compile Include="..\monotouch-test\ObjCRuntime\Messaging.cs">
+      <Link>ObjCRuntime\Messaging.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Migrates the Foundation and GameKit (and a required file from Security for foundation) tests from monotouch-tests to be run for mac.