### PR TITLE
[XM] Fix Argument Semantics on NSTextContainer.TextView

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -17664,7 +17664,7 @@ namespace XamCore.AppKit {
 		[Export ("layoutManager")]
 		NSLayoutManager LayoutManager { get; set; }
 
-		[Export ("textView", ArgumentSemantic.Retain)]
+		[Export ("textView", ArgumentSemantic.Weak)]
 		NSTextView TextView { get; set; }
 
 		[Export ("widthTracksTextView")]


### PR DESCRIPTION
- https://bugzilla.xamarin.com/show_bug.cgi?id=43236
- In Xcode 8b3, Apple changed this property to depend on the deployment target
  for weak/strong'ness

  +#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_12
   @property (nullable, strong) NSTextView *textView;
   +#else
   +@property (nullable, weak) NSTextView *textView;
   +#endif
    @end
- We could parse the MacO headers to get this and change
 strong/weak'ness but:
- It is easier to default to weak, the "safe" option. It introduces a possible
 leak but you can null it out in that rare case.
- If Apple does this more regularly, we may have to readdress