### PR TITLE
[tests] Give tests that build for device a bit more time.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1275,7 +1275,7 @@ namespace Xamarin
 			}
 			var platform = target == Target.Dev ? "iPhone" : "iPhoneSimulator";
 			var csproj = Path.Combine (Configuration.SourceRoot, "tests" + subdir, testname, testname + GetProjectSuffix (profile) + ".csproj");
-			XBuild.Build (csproj, configuration, platform, timeout: TimeSpan.FromMinutes (10));
+			XBuild.Build (csproj, configuration, platform, timeout: TimeSpan.FromMinutes (15));
 		}
 
 		[Test]


### PR DESCRIPTION
dontlink/64-bit release times out on our Sierra bots, so try to bump the
timeout to see if this is working on other bots because those other bots are
faster.