### PR TITLE
[mtouch] Fix BundleId.

### DIFF
--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -76,6 +76,8 @@ namespace Xamarin
 		public List<string> AppExtensions = new List<string> ();
 		public List<string> Frameworks = new List<string> ();
 		public string HttpMessageHandler;
+		public bool? PackageMdb;
+		public bool? MSym;
 #pragma warning restore 649
 
 		// These are a bit smarter
@@ -191,6 +193,12 @@ namespace Xamarin
 
 			if (FastDev.HasValue && FastDev.Value)
 				sb.Append (" --fastdev");
+
+			if (PackageMdb.HasValue)
+				sb.Append (" --package-mdb:").Append (PackageMdb.Value ? "true" : "false");
+
+			if (MSym.HasValue)
+				sb.Append (" --msym:").Append (MSym.Value ? "true" : "false");
 
 			if (Extension == true)
 				sb.Append (" --extension");

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -140,7 +140,6 @@ namespace Xamarin.Bundler {
 		// Bundle config
 		//
 		public string BundleDisplayName;
-		public string BundleId = "com.yourcompany.sample";
 		public string MainNib = "MainWindow";
 		public string Icon;
 		public string CertificateName;
@@ -308,9 +307,15 @@ namespace Xamarin.Bundler {
 			}
 		}
 
+		public string BundleId {
+			get {
+				return GetStringFromInfoPList ("CFBundleIdentifier");
+			}
+		}
+
 		string GetStringFromInfoPList (string key)
 		{
-			return GetStringFromInfoPList (AppDirectory, "Info.plist");
+			return GetStringFromInfoPList (AppDirectory, key);
 		}
 
 		string GetStringFromInfoPList (string directory, string key)

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1156,7 +1156,7 @@ namespace Xamarin.Bundler
 			// Bundle configuration
 			//
 			{ "displayname=", "Specifies the display name [Deprecated]", v => { app.BundleDisplayName = v; classic_only_arguments.Add ("--displayname"); }, true },
-			{ "bundleid=", "Specifies the bundle identifier (com.foo.exe) [Deprecated]", v => { app.BundleId = v; classic_only_arguments.Add ("--bundleid"); }, true },
+			{ "bundleid=", "Specifies the bundle identifier (com.foo.exe) [Deprecated]", v => { classic_only_arguments.Add ("--bundleid"); }, true },
 			{ "mainnib=", "Specifies the name of the main Nib file to load [Deprecated]", v => { app.MainNib = v; classic_only_arguments.Add ("--mainnib"); }, true },
 			{ "icon=", "Specifies the name of the icon to use [Deprecated]", v => { app.Icon = v; classic_only_arguments.Add ("--icon"); }, true },
 				


### PR DESCRIPTION
The BundleId property is used by the code that generates the mSYM directory,
but its value was always the default value 'com.yourcompany.sample' instead of
looked up in the app's Info.plist.

So fix the BundleId property to do the expected.

Also fix the mSYM test (SymbolicationData) to actually test mSYM stuff (it was
partially disabled when we disabled automatic mSYM generation for C8, and
never re-enabled), and port it to the new and better test syntax, and add a
few more asserts to check the manifest.xml generation.