### PR TITLE
[avfoundation] Fix incorrect selector for AVPlayerItemVideoOutput .ctor. Fixes #48382

### DIFF
--- a/src/AVFoundation/AVPlayerItemVideoOutput.cs
+++ b/src/AVFoundation/AVPlayerItemVideoOutput.cs
@@ -13,16 +13,16 @@ namespace XamCore.AVFoundation {
 		enum InitMode {
 			PixelAttributes,
 			OutputSettings
-		} 
+		}
 
-		AVPlayerItemVideoOutput (NSDictionary data, AVPlayerItemVideoOutput.InitMode mode) : this (IntPtr.Zero)
+		AVPlayerItemVideoOutput (NSDictionary data, AVPlayerItemVideoOutput.InitMode mode) : base (NSObjectFlag.Empty)
 		{
 			switch (mode) {
 			case InitMode.PixelAttributes:
-				Handle = _FromPixelBufferAttributes (data);
+				InitializeHandle (_FromPixelBufferAttributes (data), "initWithPixelBufferAttributes:");
 				break;
 			case InitMode.OutputSettings:
-				Handle = _FromOutputSettings (data);
+				InitializeHandle (_FromOutputSettings (data), "initWithOutputSettings:");
 				break;
 			default:
 				throw new ArgumentException (nameof (mode));
@@ -30,7 +30,7 @@ namespace XamCore.AVFoundation {
 		}
 
 		[DesignatedInitializer]
-		[Advice ("Please use the constructor that uses one of the available StrongDictionaries. This constructor expects Pixelbugger attributes.")]
+		[Advice ("Please use the constructor that uses one of the available StrongDictionaries. This constructor expects PixelBuffer attributes.")]
 		protected AVPlayerItemVideoOutput (NSDictionary pixelBufferAttributes) : this (pixelBufferAttributes, InitMode.PixelAttributes) {}
 	}
 }

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -9656,11 +9656,11 @@ namespace XamCore.AVFoundation {
 		[Export ("delegateQueue"), NullAllowed]
 		DispatchQueue DelegateQueue { get;  }
 
-		[Internal, Static]
+		[Internal]
 		[Export ("initWithPixelBufferAttributes:")]
 		IntPtr _FromPixelBufferAttributes ([NullAllowed] NSDictionary pixelBufferAttributes);
 
-		[Internal, Static]
+		[Internal]
 		[Export ("initWithOutputSettings:")]
 		IntPtr _FromOutputSettings ([NullAllowed] NSDictionary outputSettings);
 

--- a/tests/monotouch-test/AVFoundation/PlayerItemVideoOutputTest.cs
+++ b/tests/monotouch-test/AVFoundation/PlayerItemVideoOutputTest.cs
@@ -1,0 +1,44 @@
+﻿//
+// Unit tests for AVPlayerItemVideoOutput
+//
+// Authors:
+//	Sebastien Pouliot <sebastien@xamarin.com>
+//
+// Copyright 2016 Xamarin Inc. All rights reserved.
+//
+
+#if !__WATCHOS__
+
+using System;
+#if XAMCORE_2_0
+using AVFoundation;
+using CoreVideo;
+using Foundation;
+using UIKit;
+#else
+using MonoTouch.AVFoundation;
+using MonoTouch.CoreVideo;
+using MonoTouch.Foundation;
+using MonoTouch.UIKit;
+#endif
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.AVFoundation {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class PlayerItemVideoOutputTest {
+
+		[Test]
+		public void Ctor_CVPixelBufferAttributes ()
+		{
+			var attributes = new CVPixelBufferAttributes () {
+				PixelFormatType = CVPixelFormatType.CV32BGRA
+			};
+			using (var output = new AVPlayerItemVideoOutput (attributes))
+				Assert.That (output.Handle, Is.Not.EqualTo (IntPtr.Zero), "valid");
+		}
+	}
+}
+
+#endif // !__WATCHOS__


### PR DESCRIPTION
Commit ba37aa44 workaround around a signature clash incorrectly and
turned the selector to static ones (and incorrectly set the handle)

Also fix a typo in the [Advice] attribute of the old API

https://bugzilla.xamarin.com/show_bug.cgi?id=48382