### PR TITLE
TargetFramework: be case-insensitive for the identifier when computing the hash code.

### DIFF
--- a/tools/common/TargetFramework.cs
+++ b/tools/common/TargetFramework.cs
@@ -122,7 +122,7 @@ namespace Xamarin.Utils
 		{
 			var hash = 0;
 			if (Identifier != null)
-				hash ^= Identifier.GetHashCode ();
+				hash ^= Identifier.ToLowerInvariant ().GetHashCode ();
 			if (Version != null)
 				hash ^= Version.GetHashCode ();
 			return hash;


### PR DESCRIPTION
Be case-insensitive for the identifier when computing the hash code,
since we compare the identifier case-insensitively in Equals.