### PR TITLE
[security] Remove port number from TLS Server Name Identification (SNI). Fixes #45994

### DIFF
--- a/src/Security/Tls/AppleTlsContext.cs
+++ b/src/Security/Tls/AppleTlsContext.cs
@@ -320,7 +320,7 @@ namespace XamCore.Security.Tls
 			IPAddress address;
 			if (!IsServer && !string.IsNullOrEmpty (TargetHost) &&
 			    !IPAddress.TryParse (TargetHost, out address)) {
-				PeerDomainName = TargetHost;
+				PeerDomainName = ServerName;
 			}
 		}
 


### PR DESCRIPTION
The port number should not be included along the host name. Otherwise
the server will refuse the connection (and we'll throw). This is a
problem when servers are not using the default (443) SSL/TLS port.

ref: https://bugzilla.xamarin.com/show_bug.cgi?id=45994

Another PR [1] was made to fix MonoTLS in mono/master [2]. While
disable in C19 (master) we'll need this fixed when backporting to C9

[1] https://github.com/mono/mono/pull/4120
[2] https://bugzilla.xamarin.com/show_bug.cgi?id=46549