### PR TITLE
[macos][appkit] Fix typo in NSSpellCheckerCan[d]idates

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -13669,7 +13669,7 @@ namespace XamCore.AppKit {
 		bool IsAutomaticTextCompletionEnabled { get; }
 
 		[Mac (10,12,1)]
-		[Async (ResultTypeName="NSSpellCheckerCanidates")]
+		[Async (ResultTypeName="NSSpellCheckerCandidates")]
 		[Export ("requestCandidatesForSelectedRange:inString:types:options:inSpellDocumentWithTag:completionHandler:")]
 		nint RequestCandidates (NSRange selectedRange, string stringToCheck, ulong checkingTypes, [NullAllowed] NSDictionary<NSString, NSObject> options, nint tag, [NullAllowed] Action<nint, NSTextCheckingResult []> completionHandler);
 


### PR DESCRIPTION
Wrench bots missed it as typo test is OS version dependent, i.e.
the dictionary is updated on each new OS release - making it difficult
not to introduce failures in earlier versions.