### PR TITLE
[msbuild] Don't rewrite embedded.mobileprovision or archived-expanded…

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
@@ -149,11 +149,24 @@ namespace Xamarin.MacDev.Tasks
 			return result;
 		}
 
+		static bool AreEqual (byte[] x, byte[] y)
+		{
+			if (x.Length != y.Length)
+				return false;
+
+			for (int i = 0; i < x.Length; i++) {
+				if (x[i] != y[i])
+					return false;
+			}
+
+			return true;
+		}
+
 		static void WriteXcent (PObject doc, string path)
 		{
 			var buf = doc.ToByteArray (false);
 
-			using (var stream = File.Open (path, FileMode.Create)) {
+			using (var stream = new MemoryStream ()) {
 				if (AppleSdkSettings.XcodeVersion < new Version (4, 4, 1)) {
 					// write the xcent file with the magic header, length, and the plist
 					var length = Mono.DataConverter.BigEndian.GetBytes ((uint) buf.Length + 8); // 8 = magic.length + magicLen.Length
@@ -163,6 +176,21 @@ namespace Xamarin.MacDev.Tasks
 				}
 
 				stream.Write (buf, 0, buf.Length);
+
+				var src = stream.ToArray ();
+				bool save;
+
+				// Note: if the destination file already exists, only re-write it if the content will change
+				if (File.Exists (path)) {
+					var dest = File.ReadAllBytes (path);
+
+					save = !AreEqual (src, dest);
+				} else {
+					save = true;
+				}
+
+				if (save)
+					File.WriteAllBytes (path, src);
 			}
 		}
 
@@ -278,6 +306,7 @@ namespace Xamarin.MacDev.Tasks
 			PDictionary compiled;
 			PDictionary archived;
 			string path;
+			bool save;
 
 			if (!string.IsNullOrEmpty (ProvisioningProfile)) {
 				if ((profile = GetMobileProvision (Platform, ProvisioningProfile)) == null) {
@@ -320,11 +349,25 @@ namespace Xamarin.MacDev.Tasks
 				return false;
 			}
 
-			try {
-				archived.Save (Path.Combine (EntitlementBundlePath, "archived-expanded-entitlements.xcent"), true);
-			} catch (Exception ex) {
-				Log.LogError ("Error writing archived-expanded-entitlements.xcent file: {0}", ex.Message);
-				return false;
+			path = Path.Combine (EntitlementBundlePath, "archived-expanded-entitlements.xcent");
+
+			if (File.Exists (path)) {
+				var plist = PDictionary.FromFile (path);
+				var src = archived.ToXml ();
+				var dest = plist.ToXml ();
+
+				save = src != dest;
+			} else {
+				save = true;
+			}
+
+			if (save) {
+				try {
+					archived.Save (path, true);
+				} catch (Exception ex) {
+					Log.LogError ("Error writing archived-expanded-entitlements.xcent file: {0}", ex.Message);
+					return false;
+				}
 			}
 
 			return !Log.HasLoggedErrors;

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/EmbedMobileProvisionTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/EmbedMobileProvisionTaskBase.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -49,6 +47,13 @@ namespace Xamarin.iOS.Tasks
 			}
 
 			var embedded = Path.Combine (AppBundleDir, "embedded.mobileprovision");
+
+			if (File.Exists (embedded)) {
+				var embeddedProfile = MobileProvision.LoadFromFile (embedded);
+
+				if (embeddedProfile.Uuid == profile.Uuid)
+					return true;
+			}
 
 			Directory.CreateDirectory (AppBundleDir);
 			profile.Save (embedded);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
@@ -263,7 +263,6 @@ namespace Xamarin.iOS.Tasks
 		}
 
 		[Test]
-		[Ignore ("This test fails due to bugs in our implementation")]
 		public void RebuildExecutable_NoModifications ()
 		{
 			// Put a thread.sleep so that the initial build happens a noticable amount of time after we copy
@@ -272,11 +271,11 @@ namespace Xamarin.iOS.Tasks
 			// execution of the test fixture 'setup' method.
 			Thread.Sleep (1000);
 			RunTarget (MonoTouchProject, TargetName.Build);
-			var timestamps = ExpectedExecutableFiles.ToDictionary (file => file, file => GetLastModified (file));
+			var timestamps = Directory.EnumerateFiles (AppBundlePath, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
 
 			Thread.Sleep (1000);
 			RunTarget (MonoTouchProject, TargetName.Build);
-			var newTimestamps = ExpectedExecutableFiles.ToDictionary (file => file, file => GetLastModified (file));
+			var newTimestamps = Directory.EnumerateFiles (AppBundlePath, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
 
 			foreach (var file in timestamps.Keys)
 				Assert.AreEqual (timestamps [file], newTimestamps [file], "#1: " + file);


### PR DESCRIPTION
…-entitlements.xcent

This patch prevents those 2 files from being rewritten in
cases where the contents would not change from what was
already there previously.

This is a partial fix for https://bugzilla.xamarin.com/show_bug.cgi?id=49097