### PR TITLE
[msbuild] Optimized provisioning profile lookups

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/EmbedProvisionProfileTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/EmbedProvisionProfileTaskBase.cs
@@ -24,27 +24,16 @@ namespace Xamarin.Mac.Tasks
 
 		#endregion
 
-		static MobileProvision GetMobileProvision (MobileProvisionPlatform platform, string uuid)
-		{
-			var extension = MobileProvision.GetFileExtension (platform);
-			var path = Path.Combine (MobileProvision.ProfileDirectory, uuid + extension);
-
-			if (File.Exists (path))
-				return MobileProvision.LoadFromFile (path);
-
-			return MobileProvision.GetAllInstalledProvisions (platform, true).FirstOrDefault (x => x.Uuid == uuid);
-		}
-
 		public override bool Execute ()
 		{
 			Log.LogTaskName ("EmbedProvisionProfile");
 			Log.LogTaskProperty ("AppBundleDir", AppBundleDir);
 			Log.LogTaskProperty ("ProvisioningProfile", ProvisioningProfile);
 
-			var profile = GetMobileProvision (MobileProvisionPlatform.MacOS, ProvisioningProfile);
+			var profile = MobileProvisionIndex.GetMobileProvision (MobileProvisionPlatform.MacOS, ProvisioningProfile);
 
 			if (profile == null) {
-				Log.LogError ("Could not locate the provisioning profile with a UUID of {0}.", ProvisioningProfile);
+				Log.LogError ("Could not locate the provisioning profile with a Name or UUID of {0}.", ProvisioningProfile);
 				return false;
 			}
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using System.Collections.Generic;
 
 using Microsoft.Build.Framework;
@@ -250,15 +249,9 @@ namespace Xamarin.MacDev.Tasks
 			return archived;
 		}
 
-		protected virtual MobileProvision GetMobileProvision (MobileProvisionPlatform platform, string uuid)
+		protected virtual MobileProvision GetMobileProvision (MobileProvisionPlatform platform, string name)
 		{
-			var extension = MobileProvision.GetFileExtension (platform);
-			var path = Path.Combine (MobileProvision.ProfileDirectory, uuid + extension);
-
-			if (File.Exists (path))
-				return MobileProvision.LoadFromFile (path);
-
-			return MobileProvision.GetAllInstalledProvisions (platform, true).FirstOrDefault (x => x.Uuid == uuid);
+			return MobileProvisionIndex.GetMobileProvision (platform, name);
 		}
 
 		public override bool Execute ()
@@ -281,7 +274,7 @@ namespace Xamarin.MacDev.Tasks
 
 			if (!string.IsNullOrEmpty (ProvisioningProfile)) {
 				if ((profile = GetMobileProvision (Platform, ProvisioningProfile)) == null) {
-					Log.LogError ("Could not locate the provisioning profile with a UUID of {0}.", ProvisioningProfile);
+					Log.LogError ("Could not locate the provisioning profile with a Name or UUID of {0}.", ProvisioningProfile);
 					return false;
 				}
 			} else if (Platform == MobileProvisionPlatform.iOS) {

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/EmbedMobileProvisionTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/EmbedMobileProvisionTaskBase.cs
@@ -24,24 +24,13 @@ namespace Xamarin.iOS.Tasks
 
 		#endregion
 
-		public static MobileProvision GetMobileProvision (MobileProvisionPlatform platform, string name)
-		{
-			var extension = MobileProvision.GetFileExtension (platform);
-			var path = Path.Combine (MobileProvision.ProfileDirectory, name + extension);
-
-			if (File.Exists (path))
-				return MobileProvision.LoadFromFile (path);
-
-			return MobileProvisionIndex.GetMobileProvision (platform, name);
-		}
-
 		public override bool Execute ()
 		{
 			Log.LogTaskName ("EmbedMobileProvision");
 			Log.LogTaskProperty ("AppBundleDir", AppBundleDir);
 			Log.LogTaskProperty ("ProvisioningProfile", ProvisioningProfile);
 
-			var profile = GetMobileProvision (MobileProvisionPlatform.iOS, ProvisioningProfile);
+			var profile = MobileProvisionIndex.GetMobileProvision (MobileProvisionPlatform.iOS, ProvisioningProfile);
 
 			if (profile == null) {
 				Log.LogError ("Could not locate the provisioning profile with a Name or UUID of {0}.", ProvisioningProfile);


### PR DESCRIPTION
Fixes the Mac EmbedProvisionProfile task to not load every
single provisioning profile from disk in order to find the
requested provisioning profile.

Drops the need for wrappers around the use of MobileProvisionIndex
since it turns out that MobileProvisionIndex.GetMobileProvision()
already does the File.Exists() on name + ".mobileprovision" to
avoid needing to scan the index of provisioning profiles.