### PR TITLE
[Tests] Avoid NRE in MediaItemTest.DefaultValues test

### DIFF
--- a/tests/monotouch-test/MediaPlayer/MediaItemTest.cs
+++ b/tests/monotouch-test/MediaPlayer/MediaItemTest.cs
@@ -29,6 +29,8 @@ namespace MonoTouchFixtures.MediaPlayer {
 
 			using (var q = new MPMediaQuery ()) {
 				var items = q.Items;
+				if (items == null)
+					Assert.Inconclusive ("This test needs media library privacy permission to be executed.");
 				if (items.Length == 0)
 					Assert.Inconclusive ("This test needs music in the music library on the device.");
 


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=49978

MPMediaQuery.Item will be null if Media Library privacy access dialog
is not granted