### PR TITLE
[Doc] Introduce xamarin-analysis-doc-tool

### DIFF
--- a/docs/website/Makefile
+++ b/docs/website/Makefile
@@ -7,11 +7,13 @@ diff:
 	-diff -u $(WEBSITE_DOCS)/guides/ios/troubleshooting/mtouch-errors/index.md mtouch-errors.md
 	-diff -u $(WEBSITE_DOCS)/guides/ios/advanced_topics/binding_objective-c/binding_objc_libs/index.md binding_objc_libs.md
 	-diff -u $(WEBSITE_DOCS)/guides/ios/advanced_topics/binding_objective-c/binding_types_reference_guide/index.md binding_types_reference_guide.md 
+	-diff -u $(WEBSITE_DOCS)/guides/ios/troubleshooting/xamarin-ios-analysis/index.md xamarin-ios-analysis.md
 
-all:
+all: xamarin-analysis-doc
 	cp mtouch-errors.md $(WEBSITE_DOCS)/guides/ios/troubleshooting/mtouch-errors/index.md
 	cp binding_objc_libs.md $(WEBSITE_DOCS)/guides/ios/advanced_topics/binding_objective-c/binding_objc_libs/index.md
-	cp binding_types_reference_guide.md $(WEBSITE_DOCS)/guides/ios/advanced_topics/binding_objective-c/binding_types_reference_guide/index.md 
+	cp binding_types_reference_guide.md $(WEBSITE_DOCS)/guides/ios/advanced_topics/binding_objective-c/binding_types_reference_guide/index.md
+	cp xamarin-ios-analysis.md $(WEBSITE_DOCS)/guides/ios/troubleshooting/xamarin-ios-analysis/index.md
 
 xamarin-analysis-doc:
 	msbuild xamarin-analysis-doc-tool/xamarin-analysis-doc.sln

--- a/docs/website/Makefile
+++ b/docs/website/Makefile
@@ -1,5 +1,7 @@
 TOP=../../..
 WEBSITE_DOCS ?= $(TOP)/documentation
+XAMARIN_ANALYSIS ?=$(TOP)/xamarin-analysis/shared/Xamarin.Analysis
+XAMARIN_ANALYSIS_DOC = xamarin-analysis-doc-tool/bin/Debug
 
 diff: 
 	-diff -u $(WEBSITE_DOCS)/guides/ios/troubleshooting/mtouch-errors/index.md mtouch-errors.md
@@ -10,4 +12,7 @@ all:
 	cp mtouch-errors.md $(WEBSITE_DOCS)/guides/ios/troubleshooting/mtouch-errors/index.md
 	cp binding_objc_libs.md $(WEBSITE_DOCS)/guides/ios/advanced_topics/binding_objective-c/binding_objc_libs/index.md
 	cp binding_types_reference_guide.md $(WEBSITE_DOCS)/guides/ios/advanced_topics/binding_objective-c/binding_types_reference_guide/index.md 
-	
+
+xamarin-analysis-doc:
+	msbuild xamarin-analysis-doc-tool/xamarin-analysis-doc.sln
+	mono $(XAMARIN_ANALYSIS_DOC)/xamarin-analysis-doc.exe $(XAMARIN_ANALYSIS)/Xamarin.iOS.Analysis.targets

--- a/docs/website/xamarin-analysis-doc-tool/xamarin-analysis-doc.cs
+++ b/docs/website/xamarin-analysis-doc-tool/xamarin-analysis-doc.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Xml.Linq;
+using System.IO;
+
+namespace XamarinAnalysisDoc
+{
+	class MainClass
+	{
+		static string analysis_path;
+
+		public static int Main (string [] args)
+		{
+			if (args.Length < 1) {
+				Console.WriteLine ("Usage: mono xamarin-analysis-doc.exe /path/to/Xamarin.iOS.Analysis.targets");
+				return 1;
+			}
+
+			analysis_path = args [0];
+
+			if (!File.Exists (analysis_path)) {
+				Console.WriteLine ($"Cannot find {analysis_path}");
+				return 1;
+			}
+
+			GenerateAnalysisDoc (analysis_path);
+
+			return 0;
+		}
+
+		static void GenerateAnalysisDoc (string path)
+		{
+			var section = "id:{c29b69f5-08e4-4dcc-831e-7fd692ab0886}\n";
+			section += "title:Xamarin Analysis rules\n\n";
+			section += "[//]: # (The original file resides under https://github.com/xamarin/xamarin-macios/tree/master/docs/website/)\n";
+			section += "[//]: # (This allows all contributors (including external) to submit, using a PR, updates to the documentation that match the tools changes)\n";
+			section += "[//]: # (Modifications outside of xamarin-macios/master will be lost on future updates)\n\n";
+
+			var root = XDocument.Load (path);
+
+			XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
+
+			foreach (XElement target in root.Descendants (ns + "Target")) {
+				var nameAttr = target.Attribute ("Name").Value;
+				var rule = nameAttr.Split ('_');
+				var ruleID = rule [0];
+				var ruleName = rule [1];
+
+				section += $"<h3><a name=\"{ruleID}\"/>{ruleID}: {ruleName}</h3>\n\n";
+
+				foreach (var xpaResult in target.Descendants (ns + "XamarinProjectAnalysisResult").Elements ()) {
+					if (xpaResult.Name.LocalName != "Category") {
+						section += "* **" + xpaResult.Name.LocalName + ":** ";
+						section += xpaResult.Value + "\n";
+					}
+				}
+				section += "\n";
+			}
+
+			File.WriteAllText ("xamarin-analysis.md", section);
+		}
+	}
+}

--- a/docs/website/xamarin-analysis-doc-tool/xamarin-analysis-doc.cs
+++ b/docs/website/xamarin-analysis-doc-tool/xamarin-analysis-doc.cs
@@ -30,7 +30,7 @@ namespace XamarinAnalysisDoc
 		static void GenerateAnalysisDoc (string path)
 		{
 			var section = "id:{c29b69f5-08e4-4dcc-831e-7fd692ab0886}\n";
-			section += "title:Xamarin Analysis rules\n\n";
+			section += "title:Xamarin.iOS Analysis Rules\n\n";
 			section += "[//]: # (The original file resides under https://github.com/xamarin/xamarin-macios/tree/master/docs/website/)\n";
 			section += "[//]: # (This allows all contributors (including external) to submit, using a PR, updates to the documentation that match the tools changes)\n";
 			section += "[//]: # (Modifications outside of xamarin-macios/master will be lost on future updates)\n\n";
@@ -56,7 +56,7 @@ namespace XamarinAnalysisDoc
 				section += "\n";
 			}
 
-			File.WriteAllText ("xamarin-analysis.md", section);
+			File.WriteAllText ("xamarin-ios-analysis.md", section);
 		}
 	}
 }

--- a/docs/website/xamarin-analysis-doc-tool/xamarin-analysis-doc.csproj
+++ b/docs/website/xamarin-analysis-doc-tool/xamarin-analysis-doc.csproj
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{D2502AC9-4265-481A-B9A1-57F42EF9CF58}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>XamarinAnalysisDoc</RootNamespace>
+    <AssemblyName>xamarin-analysis-doc</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="xamarin-analysis-doc.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/docs/website/xamarin-analysis-doc-tool/xamarin-analysis-doc.sln
+++ b/docs/website/xamarin-analysis-doc-tool/xamarin-analysis-doc.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xamarin-analysis-doc", "xamarin-analysis-doc.csproj", "{D2502AC9-4265-481A-B9A1-57F42EF9CF58}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D2502AC9-4265-481A-B9A1-57F42EF9CF58}.Debug|x86.ActiveCfg = Debug|x86
+		{D2502AC9-4265-481A-B9A1-57F42EF9CF58}.Debug|x86.Build.0 = Debug|x86
+		{D2502AC9-4265-481A-B9A1-57F42EF9CF58}.Release|x86.ActiveCfg = Release|x86
+		{D2502AC9-4265-481A-B9A1-57F42EF9CF58}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+EndGlobal

--- a/docs/website/xamarin-analysis.md
+++ b/docs/website/xamarin-analysis.md
@@ -1,0 +1,23 @@
+id:{c29b69f5-08e4-4dcc-831e-7fd692ab0886}
+title:Xamarin Analysis rules
+
+[//]: # (The original file resides under https://github.com/xamarin/xamarin-macios/tree/master/docs/website/)
+[//]: # (This allows all contributors (including external) to submit, using a PR, updates to the documentation that match the tools changes)
+[//]: # (Modifications outside of xamarin-macios/master will be lost on future updates)
+
+<h3><a name="XIA0001"/>XIA0001: DisabledLinkerRule</h3>
+
+* **Problem:** The linker is disabled on device for the debug mode.
+* **Fix:** You should try to run your code with the linker to avoid any surprises.
+To set it up, go to Project > iOS Build > Linker Behavior.
+
+<h3><a name="XIA0002"/>XIA0002: TestCloudAgentReleaseRule</h3>
+
+* **Problem:** App builds that initialize the Test Cloud agent will be rejected by Apple when submitted, as they use private API.
+* **Fix:** Add or fix the necessary #if and defines in code.
+
+<h3><a name="XIA0003"/>XIA0003: IPADebugBuildsRule</h3>
+
+* **Problem:** Debug configuration that uses developer signing keys should not generate an IPA as it is only needed for distribution, which now uses the Publishing Wizard.
+* **Fix:** Disable IPA build in Project Options for the Debug configuration.
+

--- a/docs/website/xamarin-ios-analysis.md
+++ b/docs/website/xamarin-ios-analysis.md
@@ -1,5 +1,5 @@
 id:{c29b69f5-08e4-4dcc-831e-7fd692ab0886}
-title:Xamarin Analysis rules
+title:Xamarin.iOS Analysis Rules
 
 [//]: # (The original file resides under https://github.com/xamarin/xamarin-macios/tree/master/docs/website/)
 [//]: # (This allows all contributors (including external) to submit, using a PR, updates to the documentation that match the tools changes)


### PR DESCRIPTION
This tool is responsible of producing the `xamarin-analysis.md` file which is our Xamarin.Analysis rules documentation.

It will **always override** the content of the previous xamarin-analysis.md file.

We generate the documentation based on the existing rules in `xamarin-analysis/shared/Xamarin.Analysis/Xamarin.iOS.Analysis.targets`