### PR TITLE
[msbuild] Clean the $(AppBundleDir).mSYM directory

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -220,7 +220,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			_CleanAppBundle;
 			_CleanDebugSymbols;
 			_CleanITunesArtwork;
-			_CleanDeviceSpecificOutput;
 			_CleanIntermediateToolOutput;
 		</CleanDependsOn>
 	</PropertyGroup>
@@ -355,20 +354,13 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CleanDebugSymbols" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_GenerateBundleName">
-		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(AppBundleDir).dSYM" />
+		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(AppBundleDir).dSYM;$(AppBundleDir).mSYM" />
 		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '$(IsAppExtension)' == 'false'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
 		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '$(IsAppExtension)' == 'true'" Files="$(AppBundleDir)\..\dsym.items" />
 	</Target>
 
 	<Target Name="_CleanITunesArtwork" Condition="'$(_CanArchive)' == 'true'">
 		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)iTunesMetadata.plist;$(DeviceSpecificOutputPath)iTunesArtwork@2x;$(DeviceSpecificOutputPath)iTunesArtwork" />
-	</Target>
-	
-	<Target Name="_CleanDeviceSpecificOutput" Condition="'$(_CanOutputAppBundle)' == 'true'">
-		<RemoveDir SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true'"
-			Directories="$(IntermediateOutputPath)build-*;
-					$(OutputPath)build-*" />
 	</Target>
 
 	<Target Name="_CleanIntermediateToolOutput">

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectTest.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectTest.cs
@@ -46,6 +46,8 @@ namespace Xamarin.iOS.Tasks
 			if (clean) {
 				RunTarget (proj, "Clean");
 				Assert.IsFalse (Directory.Exists (AppBundlePath), "App bundle exists after cleanup: {0} ", AppBundlePath);
+				Assert.IsFalse (Directory.Exists (AppBundlePath + ".dSYM"), "App bundle .dSYM exists after cleanup: {0} ", AppBundlePath + ".dSYM");
+				Assert.IsFalse (Directory.Exists (AppBundlePath + ".mSYM"), "App bundle .mSYM exists after cleanup: {0} ", AppBundlePath + ".mSYM");
 			}
 
 			proj = SetupProject (Engine, mtouchPaths.ProjectCSProjPath);


### PR DESCRIPTION
This patch also drops the _CleanDeviceSpecificOutput target since it doesn't actually
do anything of value (MSBuild does not expand wildcards in task parameters and
there is no way to use wildcards with ItemGroups to match directories - wildcards
only work with files).