### PR TITLE
[msbuild] Moved _CompileToNative so it runs after importing the app e…

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -281,8 +281,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			_PrepareResourceRules;
 			_CompileEntitlements;
 			_CompileAppManifest;
-			_GetNativeExecutableName;
-			_CompileToNative;
 			_CompileITunesMetadata;
 			_CollectITunesArtwork;
 			_CopyITunesArtwork;
@@ -292,6 +290,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			_CopyAppExtensionsToBundle;
 			_CopyWatchOS1AppsToBundle;
 			_CopyWatchOS2AppsToBundle;
+			_GetNativeExecutableName;
+			_CompileToNative;
 			_GenerateDebugSymbols;
 			_ValidateAppBundle;
 		</CreateAppBundleDependsOn>


### PR DESCRIPTION
…xtensions

Once @rolfkvinge finishes implementing support in mtouch
for code-sharing between main app and app extensions, the
mtouch command will need to run *after* the app extensions
have been copied into the app bundle.