### PR TITLE
[msbuild] Don't use a timestamped directory for the IPA

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ZipTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ZipTaskBase.cs
@@ -12,6 +12,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public string SessionId { get; set; }
 
+		[Output]
 		[Required]
 		public ITaskItem OutputFile { get; set; }
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -2023,7 +2023,9 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			Sources="@(_IpaPackageSource)"
 			OutputFile="$(IpaPackagePath)"
 			WorkingDirectory="$(DeviceSpecificIntermediateOutputPath)ipa"
-		/>
+			>
+			<Output TaskProperty="OutputFile" ItemName="FileWrites" />
+		</Zip>
 	</Target>
 
 	<Target Name="_CoreArchive" Condition="'$(ArchiveOnBuild)' == 'true'" DependsOnTargets="$(Codesign)">

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -2024,7 +2024,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			OutputFile="$(IpaPackagePath)"
 			WorkingDirectory="$(DeviceSpecificIntermediateOutputPath)ipa"
 			>
-			<Output TaskProperty="OutputFile" ItemName="FileWrites" />
+			<Output TaskParameter="OutputFile" ItemName="FileWrites" />
 		</Zip>
 	</Target>
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1878,10 +1878,10 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<!-- Calculate IpaPackageDir and IpaPackageName based on IpaPackagePath, if defined. -->
 			<IpaPackageDir Condition="'$(IpaPackagePath)' != ''">$([System.Path]::GetDirectoryName('$(IpaPackagePath)'))</IpaPackageDir>
 			<IpaPackageName Condition="'$(IpaPackagePath)' != ''">$([System.Path]::GetFileName('$(IpaPackagePath)'))</IpaPackageName>
-			
+
 			<!-- Calculate an IPA package directory path if not already defined by the developer. -->
 			<!--<IpaPackageDir Condition="'$(IpaPackageDir)' == ''">$([System.Environment]::GetEnvironmentVariable('IPA_PACKAGE_DIR'))</IpaPackageDir>-->
-			<IpaPackageDir Condition="'$(IpaPackageDir)' == ''">$(DeviceSpecificOutputPath)$(_AppBundleName) $([System.DateTime]::Now.ToString('yyyy-MM-dd HH-mm-ss'))</IpaPackageDir>
+			<IpaPackageDir Condition="'$(IpaPackageDir)' == ''">$(DeviceSpecificOutputPath)$(_AppBundleName)</IpaPackageDir>
 
 			<!-- Calculate an IPA package name if not already defined by the developer. -->
 			<!--<IpaPackageName Condition="'$(IpaPackageName)' == ''">$([System.Environment]::GetEnvironmentVariable('IPA_PACKAGE_NAME'))</IpaPackageName>-->
@@ -1898,7 +1898,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<PropertyGroup>
 			<_PayloadDir>$(DeviceSpecificIntermediateOutputPath)ipa\Payload\</_PayloadDir>
 			<_IpaAppBundleDir>$(_PayloadDir)$(_AppBundleName).app\</_IpaAppBundleDir>
-	
+
 			<_IntermediateODRDir Condition="'$(_DistributionType)' == 'AppStore'">$(_PayloadDir)OnDemandResources\</_IntermediateODRDir>
 			<_IntermediateODRDir Condition="'$(_DistributionType)' == 'AdHoc' And '$(EmbedOnDemandResources)' == 'true'">$(_IpaAppBundleDir)OnDemandResources\</_IntermediateODRDir>
 			<_IntermediateODRDir Condition="'$(_DistributionType)' == 'AdHoc' And '$(EmbedOnDemandResources)' == 'false'">$(DeviceSpecificIntermediateOutputPath)OnDemandResourcesPackage\OnDemandResources\</_IntermediateODRDir>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -387,7 +387,12 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 					$(DeviceSpecificIntermediateOutputPath)TextureAtlas;
 					$(DeviceSpecificIntermediateOutputPath)mtouch-cache;
 					$(DeviceSpecificIntermediateOutputPath)" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)*.ipa" />
+
+		<ItemGroup>
+			<_IpaPackageFile Include="$(DeviceSpecificOutputPath)*.ipa" />
+		</ItemGroup>
+
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="@(_IpaPackageFile)" />
 	</Target>
 
 	<PropertyGroup>

--- a/msbuild/tests/MyWatchKitExtension/Info.plist
+++ b/msbuild/tests/MyWatchKitExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>1.0</string>
 	<key>MinimumOSVersion</key>
 	<string>8.2</string>
 	<key>NSExtension</key>

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/WatchKit.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/WatchKit.cs
@@ -77,8 +77,7 @@ namespace Xamarin.iOS.Tasks {
 			Assert.IsNotEmpty (((PString)plist["CFBundleExecutable"]).Value);
 			Assert.IsNotEmpty (((PString)plist["CFBundleVersion"]).Value);
 
-			var ipaOutputDir = Directory.EnumerateDirectories (mtouchPaths.ProjectBinPath, hostAppName + " *").FirstOrDefault ();
-			var ipaPath = Path.Combine (ipaOutputDir, hostAppName +  ".ipa");
+			var ipaPath = Path.Combine (mtouchPaths.ProjectBinPath, hostAppName +  ".ipa");
 			var payloadPath = "Payload/";
 			var watchkitSupportPath = "WatchKitSupport/";
 
@@ -104,7 +103,5 @@ namespace Xamarin.iOS.Tasks {
 			var ipaIncludeArtwork = proj.GetEvaluatedProperty ("IpaIncludeArtwork");
 			Assert.IsTrue (output.Contains ("iTunesMetadata.plist"), string.Format ("The ipa should contain at least one iTunesMetadata.plist file if we are using an AppStore config and IpaIncludeArtwork is true. IpaIncludeArtwork: {0}", ipaIncludeArtwork));
 		}
-
 	}
 }
-

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/WatchKit.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/WatchKit.cs
@@ -81,7 +81,7 @@ namespace Xamarin.iOS.Tasks {
 			var payloadPath = "Payload/";
 			var watchkitSupportPath = "WatchKitSupport/";
 
-			Assert.IsTrue (File.Exists (ipaPath));
+			Assert.IsTrue (File.Exists (ipaPath), "IPA package does not exist: {0}", ipaPath);
 
 			var startInfo = new ProcessStartInfo ("/usr/bin/zipinfo", "-1 \"" + ipaPath + "\"");
 			startInfo.RedirectStandardOutput = true;
@@ -102,6 +102,9 @@ namespace Xamarin.iOS.Tasks {
 
 			var ipaIncludeArtwork = proj.GetEvaluatedProperty ("IpaIncludeArtwork");
 			Assert.IsTrue (output.Contains ("iTunesMetadata.plist"), string.Format ("The ipa should contain at least one iTunesMetadata.plist file if we are using an AppStore config and IpaIncludeArtwork is true. IpaIncludeArtwork: {0}", ipaIncludeArtwork));
+
+			RunTarget (proj, "Clean");
+			Assert.IsFalse (File.Exists (ipaPath), "IPA package still exists after Clean: {0}", ipaPath);
 		}
 	}
 }


### PR DESCRIPTION
After discussion with Mikayla Hutchinson and Madhuri Gummalla,
this naming convention is annoying to customers so just put
the *.ipa in the bin directory. This also has the added
benefit that the *.ipa will be cleaned up with /t:Clean