### PR TITLE
[linker] Update mscorlib.xml to preserve generic collection interfaces. Fixes #50290

### DIFF
--- a/tools/linker/Descriptors/mscorlib.xml
+++ b/tools/linker/Descriptors/mscorlib.xml
@@ -477,6 +477,9 @@
 		<!-- class.c: generic_icollection_class -->		
 		<type fullname="System.Collections.Generic.ICollection`1" />
 		<type fullname="System.Collections.Generic.IEnumerable`1" />
+		<type fullname="System.Collections.Generic.IEnumerator`1" />
+		<type fullname="System.Collections.Generic.IReadOnlyList`1" />
+		<type fullname="System.Collections.Generic.IReadOnlyCollection`1" />
 		
 		<!-- domain.c: mono_defaults.generic_ilist_class -->		
 		<type fullname="System.Collections.Generic.IList`1" />


### PR DESCRIPTION
The `generic_icollection_class` condition (in class.c) does not match the mscorlib.xml descriptor file.

+ IEnumerator`1
+ IReadOnlyList`1
+ IReadOnlyCollection`1

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=50290