### PR TITLE
[HomeKit] Fix compiler warning.

### DIFF
--- a/src/HomeKit/HMEnums.cs
+++ b/src/HomeKit/HMEnums.cs
@@ -971,15 +971,12 @@ namespace XamCore.HomeKit {
 		[Field ("HMAccessoryCategoryTypeFan")]
 		Fan,
 
-#if !WATCH && !TVOS
-		[Obsolete ("Use GarageDoorOpener instead")]
-		DoorOpener,
-
-		[Field ("HMAccessoryCategoryTypeGarageDoorOpener")]
-		GarageDoorOpener = DoorOpener,
-#else
 		[Field ("HMAccessoryCategoryTypeGarageDoorOpener")]
 		GarageDoorOpener,
+
+#if !WATCH && !TVOS
+		[Obsolete ("Use GarageDoorOpener instead")]
+		DoorOpener = GarageDoorOpener,
 #endif
 
 		[Field ("HMAccessoryCategoryTypeLightbulb")]


### PR DESCRIPTION
Fix this compiler warning:

	src/HomeKit/HMEnums.cs(979,22): warning CS0618: `HomeKit.HMAccessoryCategoryType.DoorOpener' is obsolete: `Use GarageDoorOpener instead'

by rearranging fields a bit.