### PR TITLE
[mtouch] Always require a SDK version when building.

### DIFF
--- a/tests/common/ExecutionHelper.cs
+++ b/tests/common/ExecutionHelper.cs
@@ -148,6 +148,40 @@ namespace Xamarin.Tests
 			Assert.Fail (string.Format ("The error '{0}{1:0000}: {2}' was not found in the output:\n{3}", prefix, number, message, string.Join ("\n", details.ToArray ())));
 		}
 
+		public void AssertWarningPattern (int number, string messagePattern)
+		{
+			AssertWarningPattern ("MT", number, messagePattern);
+		}
+
+		public void AssertWarningPattern (string prefix, int number, string messagePattern)
+		{
+			if (!messages.Any ((msg) => msg.Prefix == prefix && msg.Number == number))
+				Assert.Fail (string.Format ("The warning '{0}{1:0000}' was not found in the output.", prefix, number));
+
+			if (messages.Any ((msg) => Regex.IsMatch (msg.Message, messagePattern)))
+				return;
+
+			var details = messages.Where ((msg) => msg.Prefix == prefix && msg.Number == number && !Regex.IsMatch (msg.Message, messagePattern)).Select ((msg) => string.Format ("\tThe message '{0}' did not match the pattern '{1}'.", msg.Message, messagePattern));
+			Assert.Fail (string.Format ("The warning '{0}{1:0000}: {2}' was not found in the output:\n{3}", prefix, number, messagePattern, string.Join ("\n", details.ToArray ())));
+		}
+
+		public void AssertWarning (int number, string message)
+		{
+			AssertWarning ("MT", number, message);
+		}
+
+		public void AssertWarning (string prefix, int number, string message)
+		{
+			if (!messages.Any ((msg) => msg.Prefix == prefix && msg.Number == number))
+				Assert.Fail (string.Format ("The warning '{0}{1:0000}' was not found in the output.", prefix, number));
+
+			if (messages.Any ((msg) => msg.Message == message))
+				return;
+
+			var details = messages.Where ((msg) => msg.Prefix == prefix && msg.Number == number && msg.Message != message).Select ((msg) => string.Format ("\tMessage #{2} did not match:\n\t\tactual:   '{0}'\n\t\texpected: '{1}'", msg.Message, message, messages.IndexOf (msg) + 1));
+			Assert.Fail (string.Format ("The warning '{0}{1:0000}: {2}' was not found in the output:\n{3}", prefix, number, message, string.Join ("\n", details.ToArray ())));
+		}
+
 		public bool HasOutput (string line)
 		{
 			return OutputLines.Contains (line);

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -410,36 +410,29 @@ namespace Xamarin
 		[Test]
 		public void MT0060 ()
 		{
-			var msg = string.Empty;
-			if (!Directory.Exists ("/Applications/Xcode.app")) {
-				msg = "warning MT0060: Could not find the currently selected Xcode on the system. 'xcode-select --print-path' returned '/dir/that/does/not/exist', but that directory does not exist.\n" +
-				"error MT0056: Cannot find Xcode in the default location ./Applications/Xcode.app.. Please install Xcode, or pass a custom path using --sdkroot <path>.\n";
-			} else {
-				msg = "warning MT0060: Could not find the currently selected Xcode on the system. 'xcode-select --print-path' returned '/dir/that/does/not/exist', but that directory does not exist.\n" +
-				"warning MT0062: No Xcode.app specified .using --sdkroot or 'xcode-select --print-path'., using the default Xcode instead: /Applications/Xcode.app\n" +
-				"Xamarin.iOS .* using framework: .*\n" +
-				"error MT0052: No command specified.";
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.EnvironmentVariables = new Dictionary<string, string> { { "DEVELOPER_DIR", "/dir/that/does/not/exist" } };
+				mtouch.SdkRoot = MTouchTool.None;
+				mtouch.AssertExecuteFailure (MTouchAction.None, "build");
+				mtouch.AssertWarning (60, "Could not find the currently selected Xcode on the system. 'xcode-select --print-path' returned '/dir/that/does/not/exist', but that directory does not exist.");
+				if (!Directory.Exists ("/Applications/Xcode.app")) {
+					mtouch.AssertError (56, "Cannot find Xcode in the default location (/Applications/Xcode.app). Please install Xcode, or pass a custom path using --sdkroot <path>.");
+				} else {
+					mtouch.AssertWarning (62, "No Xcode.app specified (using --sdkroot or 'xcode-select --print-path'), using the default Xcode instead: /Applications/Xcode.app");
+					mtouch.AssertError (52, "No command specified.");
+				}
 			}
-
-			Asserts.ThrowsPattern<TestExecutionException> (() => {
-				var envvars = new Dictionary<string, string> 
-				{
-					{ "DEVELOPER_DIR", "/dir/that/does/not/exist" }
-				};
-				ExecutionHelper.Execute (TestTarget.ToolPath, "", environmentVariables: envvars);
-			},  msg);
 		}
 
 		[Test]
 		public void MT0061 ()
 		{
-			// The MT0070 warning depends on system configuration, so it's optional in the regexp
-			Asserts.ThrowsPattern<TestExecutionException> (() => {
-				ExecutionHelper.Execute (TestTarget.ToolPath, "");
-			}, "warning MT0061: No Xcode.app specified .using --sdkroot., using the system Xcode as reported by 'xcode-select --print-path': .*\n" +
-				"(warning MT0078: The recommended Xcode version for Xamarin.iOS [0-9.]* is Xcode [0-9.]* or later. The current Xcode version .found in .* is .*)?\\s?" +
-				"Xamarin.iOS .* using framework: .*\n" +
-				"error MT0052: No command specified.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.SdkRoot = MTouchTool.None;
+				mtouch.AssertExecuteFailure (MTouchAction.None, "build");
+				mtouch.AssertWarningPattern (61, "No Xcode.app specified .using --sdkroot., using the system Xcode as reported by 'xcode-select --print-path': .*");
+				mtouch.AssertError (52, "No command specified.");
+			}
 		}
 
 		public void MT0062 ()

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -363,6 +363,25 @@ namespace Xamarin
 				Directory.Delete (testDir, true);
 			}
 		}
+
+		[Test]
+		[TestCase (Profile.iOS)]
+		[TestCase (Profile.watchOS)]
+		[TestCase (Profile.tvOS)]
+		public void MT0025 (Profile profile)
+		{
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.Profile = profile;
+				mtouch.CreateTemporaryApp ();
+				mtouch.Sdk = MTouchTool.None;
+
+				mtouch.AssertExecuteFailure (MTouchAction.BuildDev, "build dev");
+				mtouch.AssertError (25, $"No SDK version was provided. Please add --sdk=X.Y to specify which {GetPlatformSimpleName (profile)} SDK should be used to build your application.");
+
+				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build dev");
+				mtouch.AssertError (25, $"No SDK version was provided. Please add --sdk=X.Y to specify which {GetPlatformSimpleName (profile)} SDK should be used to build your application.");
+			}
+		}
 			
 		[Test]
 		public void MT0051 ()
@@ -689,6 +708,20 @@ namespace Xamarin
 				return "Xamarin.TVOS";
 			case Profile.watchOS:
 				return "Xamarin.WatchOS";
+			default:
+				throw new NotImplementedException ();
+			}
+		}
+
+		static string GetPlatformSimpleName (Profile profile)
+		{
+			switch (profile) {
+			case Profile.iOS:
+				return "iOS";
+			case Profile.tvOS:
+				return "tvOS";
+			case Profile.watchOS:
+				return "watchOS";
 			default:
 				throw new NotImplementedException ();
 			}

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1910,9 +1910,6 @@ namespace Xamarin.Bundler {
 		{
 			GetCompilerFlags (flags, ifile, language);
 
-			if (Driver.SDKVersion == new Version ())
-				throw new MonoTouchException (25, true, "No SDK version was provided. Please add --sdk=X.Y to specify which iOS SDK should be used to build your application.");
-
 			string sim_platform = Driver.PlatformDirectory;
 			string plist = Path.Combine (sim_platform, "Info.plist");
 

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -123,7 +123,7 @@ namespace Xamarin.Bundler
 		//
 		// iPhone Developer platform
 		static string framework_dir;
-		static Version sdk_version = new Version ();
+		static Version sdk_version;
 		static string compiler = string.Empty;
 		static string compiler_path;
 		static bool xcode_version_check = true;
@@ -1390,6 +1390,9 @@ namespace Xamarin.Bundler
 			case Action.ListSimulators:
 				return CallMlaunch ();
 			}
+
+			if (sdk_version == null)
+				throw new MonoTouchException (25, true, "No SDK version was provided. Please add --sdk=X.Y to specify which {0} SDK should be used to build your application.", app.PlatformName);
 
 			framework_dir = GetFrameworkDir (Platform, sdk_version);
 			Driver.Log ("Xamarin.iOS {0}{1} using framework: {2}", Constants.Version, verbose > 1 ? "." + Constants.Revision : string.Empty, framework_dir);


### PR DESCRIPTION
Technically it was required before too, but the error messages were
non-optimal: it could for instance complain that the user is using an iOS
framework that was introduced in iOS 2.0.