### PR TITLE
Fix some 10.12.2 APIs marked as 10.12.1

### DIFF
--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -417,7 +417,7 @@ namespace XamCore.ModelIO {
 		[return: NullAllowed]
 		MDLMaterialProperty GetProperty (MDLMaterialSemantic semantic);
 
-		[iOS (10,2), Mac (10,12,1)]
+		[iOS (10,2), Mac (10,12,2)]
 		[Export ("propertiesWithSemantic:")]
 		MDLMaterialProperty[] GetProperties (MDLMaterialSemantic semantic);
 
@@ -653,7 +653,7 @@ namespace XamCore.ModelIO {
 		[Export ("vertexBuffers", ArgumentSemantic.Retain)]
 		IMDLMeshBuffer[] VertexBuffers {
 			get;
-			[iOS (10,2), Mac (10,12,1), TV (10,1)]
+			[iOS (10,2), Mac (10,12,2), TV (10,1)]
 			set;
 		}
 


### PR DESCRIPTION
See https://developer.apple.com/reference/modelio/mdlmaterial/2715830-propertieswithsemantic for example.

Test failures here: https://wrench.internalx.com/Wrench/WebServices/Download.aspx?workfile_id=17667075