### PR TITLE
[mtouch] Auto-install locally after building in the IDE.

### DIFF
--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -430,6 +430,12 @@ install-local:: $(TARGETS)
 all-local:: $(TARGETS)
 endif
 
+mtouch: \
+	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/mtouch                                          \
+	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mtouch/mtouch.exe                               \
+	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mtouch/Mono.Cecil.dll                           \
+	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mtouch/Mono.Cecil.Mdb.dll
+
 clean-local::
 	rm -Rf bin obj
 	rm -f $(SIMLAUNCHERS)

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -356,4 +356,7 @@
       <LogicalName>mscorlib.xml</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
+  <Target Name="AfterBuild">
+    <Exec Command="make mtouch" />
+  </Target>
 </Project>


### PR DESCRIPTION
Auto-install locally after building in the IDE, so that running mtouch tests
after running the mtouch project doesn't require switching to the command
line.