### PR TITLE
[Foundation] Provide a public version of the get and set property methods for the NSStream

### DIFF
--- a/src/Foundation/NSStream.cs
+++ b/src/Foundation/NSStream.cs
@@ -61,10 +61,10 @@ namespace XamCore.Foundation {
 	public partial class NSStream {
 		public NSObject this [NSString key] {
 			get {
-				return PropertyForKey (key);
+				return GetProperty (key);
 			}
 			set {
-				SetPropertyForKey (value, key);
+				SetProperty (value, key);
 			}
 		}
 

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -6777,11 +6777,17 @@ namespace XamCore.Foundation
 		[Protocolize]
 		NSStreamDelegate Delegate { get; set; }
 
-		[Export ("propertyForKey:"), Internal]
-		NSObject PropertyForKey (NSString key);
+#if XAMCORE_4_0
+		[Abstract]
+#endif
+		[Export ("propertyForKey:")]
+		NSObject GetProperty (NSString key);
 	
-		[Export ("setProperty:forKey:"), Internal]
-		bool SetPropertyForKey ([NullAllowed] NSObject property, NSString key);
+#if XAMCORE_4_0
+		[Abstract]
+#endif
+		[Export ("setProperty:forKey:")]
+		bool SetProperty ([NullAllowed] NSObject property, NSString key);
 	
 #if XAMCORE_4_0
 		[Export ("scheduleInRunLoop:forMode:")]
@@ -7286,6 +7292,16 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("inputStreamWithURL:")]
 		NSInputStream FromUrl (NSUrl url);
+
+#if XAMCORE_4_0
+		[Export ("propertyForKey:"), Override]
+		NSObject GetProperty (NSString key);
+
+		[Export ("setProperty:forKey:"), Override]
+		bool SetProperty ([NullAllowed] NSObject property, NSString key);
+
+#endif
+
 	}
 
 	//
@@ -8058,6 +8074,15 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("outputStreamToFileAtPath:append:")]
 		NSOutputStream CreateFile (string path, bool shouldAppend);
+
+#if XAMCORE_4_0
+		[Export ("propertyForKey:"), Override]
+		NSObject GetProperty (NSString key);
+
+		[Export ("setProperty:forKey:"), Override]
+		bool SetProperty ([NullAllowed] NSObject property, NSString key);
+
+#endif
 	}
 
 	[BaseType (typeof (NSObject), Name="NSHTTPCookie")]

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -6779,12 +6779,16 @@ namespace XamCore.Foundation
 
 #if XAMCORE_4_0
 		[Abstract]
+#else
+		[Protected]
 #endif
 		[Export ("propertyForKey:")]
 		NSObject GetProperty (NSString key);
 	
 #if XAMCORE_4_0
 		[Abstract]
+#else
+		[Protected]
 #endif
 		[Export ("setProperty:forKey:")]
 		bool SetProperty ([NullAllowed] NSObject property, NSString key);

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -6779,17 +6779,15 @@ namespace XamCore.Foundation
 
 #if XAMCORE_4_0
 		[Abstract]
-#else
-		[Protected]
 #endif
+		[Protected]
 		[Export ("propertyForKey:")]
 		NSObject GetProperty (NSString key);
 	
 #if XAMCORE_4_0
 		[Abstract]
-#else
-		[Protected]
 #endif
+		[Protected]
 		[Export ("setProperty:forKey:")]
 		bool SetProperty ([NullAllowed] NSObject property, NSString key);
 	


### PR DESCRIPTION
This fixes bug [50891](https://bugzilla.xamarin.com/show_bug.cgi?id=50891) where the handler crashes because the methods are
protected. Also, we add the AbstractAttribute to those methods in the
base class for whenever we are allowed to change the API to ensue that
the inheritors do provide the required methods as per Apple
documentation.