### PR TITLE
[msbuild] Fixed the Inputs for the _CodesignAppBundle target

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1740,7 +1740,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CodesignAppBundle" Condition="'$(_RequireCodeSigning)' == 'true' And '$(IsAppExtension)' == 'false'" DependsOnTargets="$(_CodesignAppBundleDependsOn);_PrepareCodesignAppBundle"
-		Inputs="%(_NativeExecutable.Identity);$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent;@(_BundleResourceWithLogicalName)"
+		Inputs="$(_NativeExecutable);$(_AppBundlePath)Info.plist;$(_AppBundlePath)embedded.mobileprovision;$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent;@(_BundleResourceWithLogicalName);@(_NativeLibrary);@(_Frameworks)"
 		Outputs="$(DeviceSpecificIntermediateOutputPath)codesign\$(_AppBundleName)$(AppBundleExtension)">
 		<Codesign
 			SessionId="$(BuildSessionId)"

--- a/msbuild/tests/MyReleaseBuild/MyReleaseBuildLlvm.csproj
+++ b/msbuild/tests/MyReleaseBuild/MyReleaseBuildLlvm.csproj
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProjectGuid>{A5812C03-E0D0-448C-9DFD-5AAC6D1BFADC}</ProjectGuid>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MyReleaseBuild</RootNamespace>
+    <AssemblyName>MyReleaseBuild</AssemblyName>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG;ENABLE_TEST_CLOUD;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchFastDev>true</MtouchFastDev>
+    <MtouchProfiling>true</MtouchProfiling>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <IOSDebuggerPort>46280</IOSDebuggerPort>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
+    <PlatformTarget>x86</PlatformTarget>
+    <MtouchUseLlvm>true</MtouchUseLlvm>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;ENABLE_TEST_CLOUD;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchFastDev>true</MtouchFastDev>
+    <MtouchProfiling>true</MtouchProfiling>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\Contents.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <InterfaceDefinition Include="LaunchScreen.storyboard" />
+    <InterfaceDefinition Include="Main.storyboard" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+    <None Include="Entitlements.plist" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+    <Compile Include="AppDelegate.cs" />
+    <Compile Include="ViewController.cs" />
+    <Compile Include="ViewController.designer.cs">
+      <DependentUpon>ViewController.cs</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+</Project>

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectTest.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectTest.cs
@@ -33,11 +33,12 @@ namespace Xamarin.iOS.Tasks
 			SetupEngine ();
 		}
 
-		public void BuildProject (string appName, string platform, string config, int expectedErrorCount = 0, bool clean = true) 
+		public string BuildProject (string appName, string platform, string config, int expectedErrorCount = 0, bool clean = true)
 		{
 			var mtouchPaths = SetupProjectPaths (appName, "../", true, platform, config);
+			var csproj = mtouchPaths["project_csprojpath"];
 
-			var proj = SetupProject (Engine, mtouchPaths ["project_csprojpath"]);
+			var proj = SetupProject (Engine, csproj);
 
 			AppBundlePath = mtouchPaths ["app_bundlepath"];
 			Engine.GlobalProperties.SetProperty("Platform", platform);
@@ -54,7 +55,7 @@ namespace Xamarin.iOS.Tasks
 			RunTarget (proj, "Build", expectedErrorCount);
 
 			if (expectedErrorCount > 0)
-				return;
+				return csproj;
 
 			Assert.IsTrue (Directory.Exists (AppBundlePath), "App Bundle does not exist: {0} ", AppBundlePath);
 
@@ -91,6 +92,8 @@ namespace Xamarin.iOS.Tasks
 				Assert.IsTrue (File.Exists (dSYMInfoPlist), "dSYM Info.plist file does not exist");
 				Assert.IsTrue (File.GetLastWriteTime (dSYMInfoPlist) >= File.GetLastWriteTime (nativeExecutable), "dSYM Info.plist should be newer than the native executable");
 			}
+
+			return csproj;
 		}
 	}
 }

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ReleaseBuild.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ReleaseBuild.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Threading;
 
@@ -22,7 +23,9 @@ namespace Xamarin.iOS.Tasks
 		[Test]
 		public void RebuildTest ()
 		{
-			BuildProject ("MyReleaseBuild", Platform, "Release", clean: true);
+			var csproj = BuildProject ("MyReleaseBuild", Platform, "Release", clean: true);
+			var bak = Path.Combine (Path.GetDirectoryName (csproj), "MyReleaseBuild.csproj.bak");
+			var llvm = Path.Combine (Path.GetDirectoryName (csproj), "MyReleaseBuildLlvm.csproj");
 
 			var dsymDir = Path.GetFullPath (Path.Combine (AppBundlePath, "..", Path.GetFileName (AppBundlePath) + ".dSYM"));
 
@@ -31,6 +34,7 @@ namespace Xamarin.iOS.Tasks
 
 			Thread.Sleep (1000);
 
+			// Rebuild w/ no changes
 			BuildProject ("MyReleaseBuild", Platform, "Release", clean: false);
 
 			var newTimestamps = Directory.EnumerateFiles (AppBundlePath, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
@@ -41,6 +45,36 @@ namespace Xamarin.iOS.Tasks
 
 			foreach (var file in dsymTimestamps.Keys)
 				Assert.AreEqual (dsymTimestamps[file], newDSymTimestamps[file], "#2: " + file);
+
+			Thread.Sleep (1000);
+
+			// Rebuild after changing MtouchUseLlvm
+			File.Copy (csproj, bak, true);
+			try {
+				File.Copy (llvm, csproj, true);
+				File.SetLastWriteTime (csproj, DateTime.Now);
+
+				BuildProject ("MyReleaseBuild", Platform, "Release", clean: false);
+			} finally {
+				File.Copy (bak, csproj, true);
+				File.Delete (bak);
+			}
+
+			newTimestamps = Directory.EnumerateFiles (AppBundlePath, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
+			newDSymTimestamps = Directory.EnumerateFiles (dsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
+
+			foreach (var file in timestamps.Keys) {
+				var dirName = Path.GetFileName (Path.GetDirectoryName (file));
+				var fileName = Path.GetFileName (file);
+
+				if (fileName == "MyReleaseBuild" || fileName == "CodeResources" || dirName == ".monotouch-32" || dirName == ".monotouch-64")
+					Assert.AreNotEqual (timestamps[file], newTimestamps[file], "#3: " + file);
+				else
+					Assert.AreEqual (timestamps[file], newTimestamps[file], "#3: " + file);
+			}
+
+			foreach (var file in dsymTimestamps.Keys)
+				Assert.AreNotEqual (dsymTimestamps[file], newDSymTimestamps[file], "#4: " + file);
 		}
 	}
 }


### PR DESCRIPTION
The Inputs need to include the Info.plist, embedded.mobileprovision,
and the native libs/frameworks since those files also get included
in the _CodeSignature/CodeResources.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=50791