### PR TITLE
[generator] Remove internal *Wrapper.ctor(IntPtr) constructors

### DIFF
--- a/src/Metal/MTLDevice.cs
+++ b/src/Metal/MTLDevice.cs
@@ -32,7 +32,7 @@ namespace XamCore.Metal {
 					try {
 						var h = MTLCreateSystemDefaultDevice ();
 						if (h != IntPtr.Zero)
-							system_default = new MTLDeviceWrapper (h);
+							system_default = new MTLDeviceWrapper (h, false);
 					}
 					catch (EntryPointNotFoundException) {
 					}

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -4932,12 +4932,6 @@ public partial class Generator : IMemberGatherer {
 		PrintPreserveAttribute (type);
 		print ("internal sealed class {0}Wrapper : BaseWrapper, I{0} {{", TypeName);
 		indent++;
-		// ctor (IntPtr)
-		print ("public {0}Wrapper (IntPtr handle)", TypeName);
-		print ("\t: base (handle, false)");
-		print ("{");
-		print ("}");
-		print ("");
 		// ctor (IntPtr, bool)
 		print ("[Preserve (Conditional = true)]");
 		print ("public {0}Wrapper (IntPtr handle, bool owns)", TypeName);


### PR DESCRIPTION
The registrar code looks for `.ctor(IntPtr,bool)` so we end up with
unneeded extra code and metadata.

	Xamarin.iOS.dll before	12656640
	Xamarin.iOS.dll after	12643840

Saves 12.5kb (25kb for iOS 32/64) + native code. Final result will vary
(linker).