### PR TITLE
[foundation] Fix possible abort when using NSUrlSessionHandler. Fix #50891

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -611,6 +611,17 @@ namespace Foundation {
 				return base.GetBuffer (out buffer, out len);
 			}
 
+			// NSInvalidArgumentException Reason: *** -propertyForKey: only defined for abstract class.  Define -[System_Net_Http_NSUrlSessionHandler_WrappedNSInputStream propertyForKey:]!
+			protected override NSObject GetProperty (NSString key)
+			{
+				return null;
+			}
+
+			protected override bool SetProperty (NSObject property, NSString key)
+			{
+				return false;
+			}
+
 			protected override bool SetCFClientFlags (CFStreamEventType inFlags, IntPtr inCallback, IntPtr inContextPtr)
 			{
 				// Just call the base implementation, which knows how to handle everything.


### PR DESCRIPTION
PR 1435 did not fix bug #50891. The default (native) implementation till
get called and abort the process. The right way to solve this is to
override the members (easier now that it's not internal anymore) and
return `false` (or `null`) so the caller (the OS) knows it's not
supported (that's fine)

references:
* https://bugzilla.xamarin.com/show_bug.cgi?id=50891
* https://github.com/xamarin/xamarin-macios/pull/1435