### PR TITLE
Fix NSFormatter.IsPartialStringValid

### DIFF
--- a/src/Foundation/NSFormatter.cs
+++ b/src/Foundation/NSFormatter.cs
@@ -3,7 +3,7 @@
 namespace XamCore.Foundation {
 	public partial class NSFormatter {
 #if !XAMCORE_4_0
-		[Obsolete ("Use IsPartialStringValid (ref NSString partialString, out NSRange proposedSelRange, string origString, NSRange origSelRange, out NSString error); instead")]
+		[Obsolete ("Use IsPartialStringValid (ref string partialString, out NSRange proposedSelRange, string origString, NSRange origSelRange, out string error) instead")]
 		public virtual bool IsPartialStringValid (out string partialString, out NSRange proposedSelRange, string origString, NSRange origSelRange, out NSString error)
 		{
 			partialString = origString;

--- a/src/Foundation/NSFormatter.cs
+++ b/src/Foundation/NSFormatter.cs
@@ -4,7 +4,7 @@ namespace XamCore.Foundation {
 	public partial class NSFormatter {
 #if !XAMCORE_4_0
 		[Obsolete ("Use IsPartialStringValid (ref NSString partialString, out NSRange proposedSelRange, string origString, NSRange origSelRange, out NSString error); instead")]
-		public unsafe virtual bool IsPartialStringValid (out string partialString, out NSRange proposedSelRange, string origString, NSRange origSelRange, out NSString error)
+		public virtual bool IsPartialStringValid (out string partialString, out NSRange proposedSelRange, string origString, NSRange origSelRange, out NSString error)
 		{
 			partialString = origString;
 			proposedSelRange = origSelRange;

--- a/src/Foundation/NSFormatter.cs
+++ b/src/Foundation/NSFormatter.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace XamCore.Foundation {
+	public partial class NSFormatter {
+#if !XAMCORE_4_0
+		[Obsolete ("Use IsPartialStringValid (ref NSString partialString, out NSRange proposedSelRange, string origString, NSRange origSelRange, out NSString error); instead")]
+		public unsafe virtual bool IsPartialStringValid (out string partialString, out NSRange proposedSelRange, string origString, NSRange origSelRange, out NSString error)
+		{
+			partialString = origString;
+			proposedSelRange = origSelRange;
+			error = null;
+
+			return true;
+		}
+	}
+#endif
+}

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -2130,11 +2130,8 @@ namespace XamCore.Foundation
 		[Export ("isPartialStringValid:newEditingString:errorDescription:")]
 		bool IsPartialStringValid (string partialString, out string newString, out NSString error);
 
-		//[Export ("isPartialStringValid:proposedSelectedRange:originalString:originalSelectedRange:errorDescription:")]
-		//unsafe bool IsPartialStringValid (out string partialString, out NSRange proposedSelRange, string origString, NSRange origSelRange, out NSString error);
-
 		[Export ("isPartialStringValid:proposedSelectedRange:originalString:originalSelectedRange:errorDescription:")]
-		unsafe bool IsPartialStringValid (ref NSString partialString, out NSRange proposedSelRange, string origString, NSRange origSelRange, out NSString error);
+		bool IsPartialStringValid (ref string partialString, out NSRange proposedSelRange, string origString, NSRange origSelRange, out string error);
 	}
 
 	[BaseType (typeof (NSObject))]

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -2130,8 +2130,11 @@ namespace XamCore.Foundation
 		[Export ("isPartialStringValid:newEditingString:errorDescription:")]
 		bool IsPartialStringValid (string partialString, out string newString, out NSString error);
 
+		//[Export ("isPartialStringValid:proposedSelectedRange:originalString:originalSelectedRange:errorDescription:")]
+		//unsafe bool IsPartialStringValid (out string partialString, out NSRange proposedSelRange, string origString, NSRange origSelRange, out NSString error);
+
 		[Export ("isPartialStringValid:proposedSelectedRange:originalString:originalSelectedRange:errorDescription:")]
-		unsafe bool IsPartialStringValid (out string partialString, out NSRange proposedSelRange, string origString, NSRange origSelRange, out NSString error);
+		unsafe bool IsPartialStringValid (ref NSString partialString, out NSRange proposedSelRange, string origString, NSRange origSelRange, out NSString error);
 	}
 
 	[BaseType (typeof (NSObject))]

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -653,6 +653,7 @@ FOUNDATION_SOURCES = \
 	Foundation/NSFileManager.cs \
 	Foundation/NSFileManager.iOS.cs \
 	Foundation/NSFileManagerDelegate.cs \
+	Foundation/NSFormatter.cs \
 	Foundation/NSHost.cs \
 	Foundation/NSHttpCookie.cs \
 	Foundation/NSHttpCookieStorage.cs \


### PR DESCRIPTION
First Parameter (partialString) should be a ref, not an out.  

Moved the old version to a stubbed method in NSFormatter.cs that returns true and just sets the out parameters to the original values.  This method won't work correctly, but the old version with 'out partialString' doesn't work anyway, this will at least still build.

Added a new binding for the export with the correct 'ref' instead of 'out'.