### PR TITLE
[msbuild] Refactor the IBTool task to be cleaner and more efficient

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
@@ -373,12 +373,10 @@ namespace Xamarin.MacDev.Tasks
 				specs.Save (outputSpecs, true);
 			}
 
-			var output = new TaskItem (intermediateBundleDir);
-
 			Directory.CreateDirectory (intermediateBundleDir);
 
 			// Note: Compile() will set the PartialAppManifest property if it is used...
-			if ((Compile (catalogs.ToArray (), output, manifest)) != 0)
+			if ((Compile (catalogs.ToArray (), intermediateBundleDir, manifest)) != 0)
 				return false;
 
 			if (PartialAppManifest != null && !File.Exists (PartialAppManifest.GetMetadata ("FullPath")))

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
@@ -272,7 +272,7 @@ namespace Xamarin.MacDev.Tasks
 
 			// Make sure that `Main.storyboardc` is listed *before* `Main~ipad.storyboardc` and `Main~iphone.storyboardc`,
 			// this is important for the next step to filter out the device-specific storyboards based on the same source.
-			storyboards.Sort ((x, y) => string.Compare (x.ItemSpec, y.ItemSpec, StringComparison.InvariantCultureIgnoreCase));
+			storyboards.Sort ((x, y) => string.Compare (x.ItemSpec, y.ItemSpec, StringComparison.Ordinal));
 
 			// Populate our metadata mapping table so we can properly restore the metadata to the linked items.
 			//

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
@@ -381,8 +381,6 @@ namespace Xamarin.MacDev.Tasks
 			yield break;
 		}
 
-		// TODO: add a unit test that includes multiple storyboards that get linked
-		// TODO: add a unit test that includes storyboards within *.lproj dirs
 		public override bool Execute ()
 		{
 			Log.LogTaskName ("IBTool");

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeCompilerToolTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeCompilerToolTask.cs
@@ -124,7 +124,7 @@ namespace Xamarin.MacDev.Tasks
 			return startInfo;
 		}
 
-		protected int Compile (ITaskItem[] items, ITaskItem output, ITaskItem manifest)
+		protected int Compile (ITaskItem[] items, string output, ITaskItem manifest)
 		{
 			var environment = new Dictionary<string, string> ();
 			var args = new ProcessArgumentBuilder ();
@@ -147,7 +147,7 @@ namespace Xamarin.MacDev.Tasks
 			else
 				args.Add ("--compile");
 
-			args.AddQuoted (output.GetMetadata ("FullPath"));
+			args.AddQuoted (Path.GetFullPath (output));
 
 			foreach (var item in items)
 				args.AddQuoted (item.GetMetadata ("FullPath"));

--- a/msbuild/tests/IBToolTaskTests/LinkedAndTranslated/Base.lproj/LaunchScreen.storyboard
+++ b/msbuild/tests/IBToolTaskTests/LinkedAndTranslated/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/msbuild/tests/IBToolTaskTests/LinkedAndTranslated/Base.lproj/Linked.storyboard
+++ b/msbuild/tests/IBToolTaskTests/LinkedAndTranslated/Base.lproj/Linked.storyboard
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="5xv-Yx-H4r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="lP3-9c-L6b">
+            <objects>
+                <viewController storyboardIdentifier="MyLinkedViewController" id="5xv-Yx-H4r" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="vTD-aw-nUj"/>
+                        <viewControllerLayoutGuide type="bottom" id="IyX-Ik-oKG"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="gMo-tm-chA">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Linked!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gd9-6P-3AQ">
+                                <rect key="frame" x="159" y="323" width="56" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="J6q-Vo-r8c" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="201" y="102"/>
+        </scene>
+    </scenes>
+</document>

--- a/msbuild/tests/IBToolTaskTests/LinkedAndTranslated/Base.lproj/Main.storyboard
+++ b/msbuild/tests/IBToolTaskTests/LinkedAndTranslated/Base.lproj/Main.storyboard
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="suC-9c-gGU">
+                                <rect key="frame" x="164" y="318" width="46" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <connections>
+                                    <segue destination="Xa5-w5-hXO" kind="show" id="1S1-fR-EBd"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+        <!--Linked-->
+        <scene sceneID="brE-JR-pH9">
+            <objects>
+                <viewControllerPlaceholder storyboardIdentifier="MyLinkedViewController" storyboardName="Linked" id="Xa5-w5-hXO" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="C8X-qd-oxE" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="522" y="94"/>
+        </scene>
+    </scenes>
+</document>

--- a/msbuild/tests/IBToolTaskTests/LinkedAndTranslated/Info.plist
+++ b/msbuild/tests/IBToolTaskTests/LinkedAndTranslated/Info.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>IBToolTaskTest</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.your-company.ibtooltasktest</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>IBToolTaskTest</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>MinimumOSVersion</key>
+	<string>10.1</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/msbuild/tests/IBToolTaskTests/LinkedAndTranslated/en.lproj/Linked.storyboard
+++ b/msbuild/tests/IBToolTaskTests/LinkedAndTranslated/en.lproj/Linked.storyboard
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="5xv-Yx-H4r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="lP3-9c-L6b">
+            <objects>
+                <viewController storyboardIdentifier="MyLinkedViewController" id="5xv-Yx-H4r" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="vTD-aw-nUj"/>
+                        <viewControllerLayoutGuide type="bottom" id="IyX-Ik-oKG"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="gMo-tm-chA">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Linked!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gd9-6P-3AQ">
+                                <rect key="frame" x="159" y="323" width="56" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="J6q-Vo-r8c" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="201" y="102"/>
+        </scene>
+    </scenes>
+</document>

--- a/msbuild/tests/IBToolTaskTests/LinkedAndTranslated/en.lproj/Main.storyboard
+++ b/msbuild/tests/IBToolTaskTests/LinkedAndTranslated/en.lproj/Main.storyboard
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="suC-9c-gGU">
+                                <rect key="frame" x="164" y="318" width="46" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <connections>
+                                    <segue destination="Xa5-w5-hXO" kind="show" id="1S1-fR-EBd"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+        <!--Linked-->
+        <scene sceneID="brE-JR-pH9">
+            <objects>
+                <viewControllerPlaceholder storyboardIdentifier="MyLinkedViewController" storyboardName="Linked" id="Xa5-w5-hXO" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="C8X-qd-oxE" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="522" y="94"/>
+        </scene>
+    </scenes>
+</document>

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
@@ -437,9 +437,10 @@ namespace Xamarin.iOS.Tasks
 			var plist = PDictionary.FromFile (path);
 			string ibtool;
 
-			if (AppleSdkSettings.XcodeVersion.Major >= 7)
-				ibtool = Path.Combine ("obj", "iPhoneSimulator", "Debug", "ibtool-link");
-			else
+			// Note: the files will only be in ibtool-link if there is more than 1 storyboard that *could* be linked
+			//if (AppleSdkSettings.XcodeVersion.Major >= 7)
+			//	ibtool = Path.Combine ("obj", "iPhoneSimulator", "Debug", "ibtool-link");
+			//else
 				ibtool = Path.Combine ("obj", "iPhoneSimulator", "Debug", "ibtool");
 
 			plist.SetMinimumOSVersion ("6.1");

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
@@ -433,15 +433,9 @@ namespace Xamarin.iOS.Tasks
 		public void BundleResources ()
 		{
 			var actool = Path.Combine ("obj", "iPhoneSimulator", "Debug", "actool", "bundle");
+			var ibtool = Path.Combine ("obj", "iPhoneSimulator", "Debug", "ibtool");
 			var path = Path.Combine (MonoTouchProjectPath, "Info.plist");
 			var plist = PDictionary.FromFile (path);
-			string ibtool;
-
-			// Note: the files will only be in ibtool-link if there is more than 1 storyboard that *could* be linked
-			//if (AppleSdkSettings.XcodeVersion.Major >= 7)
-			//	ibtool = Path.Combine ("obj", "iPhoneSimulator", "Debug", "ibtool-link");
-			//else
-				ibtool = Path.Combine ("obj", "iPhoneSimulator", "Debug", "ibtool");
 
 			plist.SetMinimumOSVersion ("6.1");
 			plist.Save (path, true);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/IBToolTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/IBToolTaskTests.cs
@@ -62,7 +62,7 @@ namespace Xamarin.iOS.Tasks
 		[Test]
 		public void TestBasicIBToolFunctionality ()
 		{
-			var tmp = Path.GetTempPath ();
+			var tmp = Path.Combine (Path.GetTempPath (), Path.GetTempFileName ());
 
 			Directory.CreateDirectory (tmp);
 
@@ -110,7 +110,7 @@ namespace Xamarin.iOS.Tasks
 		[Test]
 		public void TestAdvancedIBToolFunctionality ()
 		{
-			var tmp = Path.GetTempPath ();
+			var tmp = Path.Combine (Path.GetTempPath (), Path.GetTempFileName ());
 			IBTool ibtool;
 
 			Directory.CreateDirectory (tmp);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/IBToolTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/IBToolTaskTests.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using NUnit.Framework;
+
+using Xamarin.MacDev;
+using Xamarin.MacDev.Tasks;
+
+namespace Xamarin.iOS.Tasks
+{
+	[TestFixture]
+	public class IBToolTaskTests
+	{
+		static IBTool CreateIBToolTask (PlatformFramework framework, string projectDir, string intermediateOutputPath)
+		{
+			var interfaceDefinitions = new List<ITaskItem> ();
+			var sdk = IPhoneSdks.GetSdk (framework);
+			var version = IPhoneSdkVersion.GetDefault (sdk, false);
+			var root = sdk.GetSdkPath (version, false);
+			var usr = Path.Combine (sdk.DeveloperRoot, "usr");
+			var bin = Path.Combine (usr, "bin");
+			string platform;
+
+			switch (framework) {
+			case PlatformFramework.WatchOS:
+				platform = "WatchOS";
+				break;
+			case PlatformFramework.TVOS:
+				platform = "AppleTVOS";
+				break;
+			default:
+				platform = "iPhoneOS";
+				break;
+			}
+
+			foreach (var item in Directory.EnumerateFiles (projectDir, "*.storyboard", SearchOption.AllDirectories))
+				interfaceDefinitions.Add (new TaskItem (item));
+
+			foreach (var item in Directory.EnumerateFiles (projectDir, "*.xib", SearchOption.AllDirectories))
+				interfaceDefinitions.Add (new TaskItem (item));
+
+			return new IBTool {
+				AppManifest = new TaskItem (Path.Combine (projectDir, "Info.plist")),
+				InterfaceDefinitions = interfaceDefinitions.ToArray (),
+				IntermediateOutputPath = intermediateOutputPath,
+				BuildEngine = new TestEngine (),
+				ResourcePrefix = "Resources",
+				ProjectDir = projectDir,
+				SdkPlatform = platform,
+				SdkVersion = version.ToString (),
+				SdkUsrPath = usr,
+				SdkBinPath = bin,
+				SdkRoot = root,
+			};
+		}
+
+		[Test]
+		public void TestBasicIBToolFunctionality ()
+		{
+			var tmp = Path.GetTempPath ();
+
+			Directory.CreateDirectory (tmp);
+
+			try {
+				var ibtool = CreateIBToolTask (PlatformFramework.iOS, "../MyIBToolLinkTest", tmp);
+				var bundleResources = new HashSet<string> ();
+
+				Assert.IsTrue (ibtool.Execute (), "Execution of IBTool task failed.");
+
+				foreach (var bundleResource in ibtool.BundleResources) {
+					Assert.IsTrue (File.Exists (bundleResource.ItemSpec), "File does not exist: {0}", bundleResource.ItemSpec);
+					Assert.IsNotNullOrEmpty (bundleResource.GetMetadata ("LogicalName"), "The 'LogicalName' metadata must be set.");
+					Assert.IsNotNullOrEmpty (bundleResource.GetMetadata ("Optimize"), "The 'Optimize' metadata must be set.");
+
+					bundleResources.Add (bundleResource.GetMetadata ("LogicalName"));
+				}
+
+				string[] expected = { "LaunchScreen~ipad.nib/objects-8.0+.nib",
+					"LaunchScreen~ipad.nib/runtime.nib",
+					"LaunchScreen~iphone.nib/objects-8.0+.nib",
+					"LaunchScreen~iphone.nib/runtime.nib",
+					"Main.storyboardc/BYZ-38-t0r-view-8bC-Xf-vdC~ipad.nib/objects-8.0+.nib",
+					"Main.storyboardc/BYZ-38-t0r-view-8bC-Xf-vdC~ipad.nib/runtime.nib",
+					"Main.storyboardc/BYZ-38-t0r-view-8bC-Xf-vdC~iphone.nib/objects-8.0+.nib",
+					"Main.storyboardc/BYZ-38-t0r-view-8bC-Xf-vdC~iphone.nib/runtime.nib",
+					"Main.storyboardc/UIViewController-BYZ-38-t0r~ipad.nib/objects-8.0+.nib",
+					"Main.storyboardc/UIViewController-BYZ-38-t0r~ipad.nib/runtime.nib",
+					"Main.storyboardc/UIViewController-BYZ-38-t0r~iphone.nib/objects-8.0+.nib",
+					"Main.storyboardc/UIViewController-BYZ-38-t0r~iphone.nib/runtime.nib",
+					"Main~ipad.storyboardc/Info-8.0+.plist",
+					"Main~ipad.storyboardc/Info.plist",
+					"Main~iphone.storyboardc/Info-8.0+.plist",
+					"Main~iphone.storyboardc/Info.plist"
+				};
+
+				foreach (var bundleResource in expected)
+					Assert.IsTrue (bundleResources.Contains (bundleResource), "BundleResources should include '{0}'", bundleResource);
+
+				Assert.AreEqual (expected.Length, bundleResources.Count, "Unexpected number of BundleResources");
+			} finally {
+				Directory.Delete (tmp, true);
+			}
+		}
+	}
+}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/IBToolTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/IBToolTaskTests.cs
@@ -62,7 +62,7 @@ namespace Xamarin.iOS.Tasks
 		[Test]
 		public void TestBasicIBToolFunctionality ()
 		{
-			var tmp = Path.Combine (Path.GetTempPath (), Path.GetTempFileName ());
+			var tmp = Path.Combine (Path.GetTempPath (), "basic-ibtool");
 
 			Directory.CreateDirectory (tmp);
 
@@ -110,7 +110,7 @@ namespace Xamarin.iOS.Tasks
 		[Test]
 		public void TestAdvancedIBToolFunctionality ()
 		{
-			var tmp = Path.Combine (Path.GetTempPath (), Path.GetTempFileName ());
+			var tmp = Path.Combine (Path.GetTempPath (), "advanced-ibtool");
 			IBTool ibtool;
 
 			Directory.CreateDirectory (tmp);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="TaskTests\GeneratePlistTaskTests\GeneratePlistTaskTests_watchOS.cs" />
     <Compile Include="ProjectsTests\ReleaseBuild.cs" />
     <Compile Include="TaskTests\PropertyListEditorTaskTests.cs" />
+    <Compile Include="TaskTests\IBToolTaskTests.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Besides making the IBTool task cleaner and easier to understand,
a side-effect of this refactor was also to optimize the collecting
of the compiled outputs because we now only need to scan the
obj/ibtool directory once to collect each of the outputs.