### PR TITLE
[mtouch] Include extracted frameworks from binding assemblies when listing the frameworks an extension needs. Fixes #45800.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -612,6 +612,19 @@ namespace Xamarin
 			return fn;
 		}
 
+		static string GetFrameworksBindingLibrary (Profile profile)
+		{
+			// Path.Combine (Configuration.SourceRoot, "tests/bindings-framework-test/bin/Any CPU/Debug-unified/bindings-framework-test.dll"),
+			var fn = Path.Combine (Configuration.SourceRoot, "tests", "bindings-framework-test", "bin", "Any CPU", GetConfiguration (profile), "bindings-framework-test.dll");
+
+			if (!File.Exists (fn)) {
+				var csproj = Path.Combine (Configuration.SourceRoot, "tests", "bindings-framework-test", "bindings-framework-test" + GetProjectSuffix (profile) + ".csproj");
+				XBuild.Build (csproj, platform: "AnyCPU");
+			}
+
+			return fn;
+		}
+
 		public static string GetBaseLibrary (Profile profile)
 		{
 			switch (profile) {
@@ -2072,7 +2085,7 @@ class C {
 				exttool.Extension = true;
 				exttool.References = new string []
 				{
-					Path.Combine (Configuration.SourceRoot, "tests/bindings-framework-test/bin/Any CPU/Debug-unified/bindings-framework-test.dll"),
+					GetFrameworksBindingLibrary (exttool.Profile),
 				};
 				exttool.CreateTemporararyServiceExtension (code: @"using UserNotifications;
 [Foundation.Register (""NotificationService"")]

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2065,7 +2065,7 @@ class C {
 			// if an extension references a framework (from a binding library, and the main app does not,
 			// the framework should still be copied to the main app's Framework directory.
 			using (var exttool = new MTouchTool ()) {
-				exttool.Profile = Profile.Unified;
+				exttool.Profile = Profile.iOS;
 				exttool.CreateTemporaryCacheDirectory ();
 				exttool.Verbosity = 5;
 
@@ -2086,7 +2086,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 				exttool.AssertExecute (MTouchAction.BuildSim, "build extension");
 
 				using (var apptool = new MTouchTool ()) {
-					apptool.Profile = Profile.Unified;
+					apptool.Profile = Profile.iOS;
 					apptool.CreateTemporaryCacheDirectory ();
 					apptool.Verbosity = exttool.Verbosity;
 					apptool.CreateTemporaryApp ();

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2060,6 +2060,46 @@ class C {
 		}
 
 		[Test]
+		public void OnlyExtensionWithBindingFramework ()
+		{
+			// if an extension references a framework (from a binding library, and the main app does not,
+			// the framework should still be copied to the main app's Framework directory.
+			using (var exttool = new MTouchTool ()) {
+				exttool.Profile = Profile.Unified;
+				exttool.CreateTemporaryCacheDirectory ();
+				exttool.Verbosity = 5;
+
+				exttool.Extension = true;
+				exttool.References = new string []
+				{
+					Path.Combine (Configuration.SourceRoot, "tests/bindings-framework-test/bin/Any CPU/Debug-unified/bindings-framework-test.dll"),
+				};
+				exttool.CreateTemporararyServiceExtension (code: @"using UserNotifications;
+[Foundation.Register (""NotificationService"")]
+public partial class NotificationService : UNNotificationServiceExtension
+{
+	protected NotificationService (System.IntPtr handle) : base (handle)
+	{
+		System.Console.WriteLine (Bindings.Test.CFunctions.theUltimateAnswer ());
+	}
+}", extraArg: Quote ("-r:" + exttool.References [0]));
+				exttool.AssertExecute (MTouchAction.BuildSim, "build extension");
+
+				using (var apptool = new MTouchTool ()) {
+					apptool.Profile = Profile.Unified;
+					apptool.CreateTemporaryCacheDirectory ();
+					apptool.Verbosity = exttool.Verbosity;
+					apptool.CreateTemporaryApp ();
+					apptool.AppExtensions.Add (exttool.AppPath);
+					apptool.AssertExecute (MTouchAction.BuildSim, "build app");
+
+					Assert.IsTrue (Directory.Exists (Path.Combine (apptool.AppPath, "Frameworks", "XTest.framework")), "framework exists");
+					Assert.IsFalse (Directory.Exists (Path.Combine (exttool.AppPath, "Frameworks")), "extension framework inexistence");
+				}
+			}
+		}
+
+		[Test]
 		[TestCase (MTouchLinker.DontLink)]
 		[TestCase (MTouchLinker.LinkAll)]
 		// There shouldn't be a need to test LinkSdk as well.

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -439,7 +439,7 @@ namespace Xamarin
 				File.WriteAllText (Path.Combine (app, "Info.plist"), CreatePlist (Profile, appName));
 		}
 
-		public void CreateTemporararyServiceExtension (string code = null)
+		public void CreateTemporararyServiceExtension (string code = null, string extraArg = null)
 		{
 			var testDir = CreateTemporaryDirectory ();
 			var app = Path.Combine (testDir, "testApp.appex");
@@ -455,7 +455,7 @@ public partial class NotificationService : UNNotificationServiceExtension
 			}
 
 			AppPath = app;
-			Executable = MTouch.CompileTestAppLibrary (testDir, code: code, profile: Profile);
+			Executable = MTouch.CompileTestAppLibrary (testDir, code: code, profile: Profile, extraArg: extraArg);
 
 			File.WriteAllText (Path.Combine (app, "Info.plist"),
 @"<?xml version=""1.0"" encoding=""UTF-8""?>

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1095,7 +1095,20 @@ namespace Xamarin.Bundler {
 			} else {
 				if (!IsWatchExtension) {
 					// In extensions we need to save a list of the frameworks we need so that the main app can get them.
-					var all_frameworks = Frameworks.Union (WeakFrameworks);
+					var all_frameworks = new HashSet<string> ();
+					all_frameworks.UnionWith (Frameworks);
+					all_frameworks.UnionWith (WeakFrameworks);
+					foreach (var t in Targets) {
+						all_frameworks.UnionWith (t.Frameworks);
+						all_frameworks.UnionWith (t.WeakFrameworks);
+						foreach (var a in t.Assemblies) {
+							if (a.Frameworks != null)
+								all_frameworks.UnionWith (a.Frameworks);
+							if (a.WeakFrameworks != null)
+								all_frameworks.UnionWith (a.WeakFrameworks);
+						}
+					}
+					all_frameworks.RemoveWhere ((v) => !v.EndsWith (".framework", StringComparison.Ordinal));
 					if (all_frameworks.Count () > 0)
 						Driver.WriteIfDifferent (Path.Combine (Path.GetDirectoryName (AppDirectory), "frameworks.txt"), string.Join ("\n", all_frameworks.ToArray ()));
 				}

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1095,8 +1095,7 @@ namespace Xamarin.Bundler {
 			} else {
 				if (!IsWatchExtension) {
 					// In extensions we need to save a list of the frameworks we need so that the main app can get them.
-					var all_frameworks = new HashSet<string> ();
-					all_frameworks.UnionWith (Frameworks);
+					var all_frameworks = new HashSet<string> (Frameworks);
 					all_frameworks.UnionWith (WeakFrameworks);
 					foreach (var t in Targets) {
 						all_frameworks.UnionWith (t.Frameworks);


### PR DESCRIPTION
Include extracted frameworks from binding assemblies when listing the
frameworks an extension needs.

Fixes #45800 - comments 8-13.

https://bugzilla.xamarin.com/show_bug.cgi?id=45800