### PR TITLE
[msbuild] Use Xcode-specific versions of some command-line tools

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ArToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ArToolTaskBase.cs
@@ -31,7 +31,7 @@ namespace Xamarin.MacDev.Tasks
 			if (!string.IsNullOrEmpty (ToolPath))
 				return Path.Combine (ToolPath, ToolExe);
 
-			var path = Path.Combine ("/usr/bin", ToolExe);
+			var path = Path.Combine (AppleSdkSettings.DeveloperRoot, "Toolchains", "XcodeDefault.xctoolchain", "usr", "bin", ToolExe);
 
 			return File.Exists (path) ? path : ToolExe;
 		}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DSymUtilTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DSymUtilTaskBase.cs
@@ -50,7 +50,7 @@ namespace Xamarin.MacDev.Tasks
 			if (!string.IsNullOrEmpty (ToolPath))
 				return Path.Combine (ToolPath, ToolExe);
 
-			var path = Path.Combine ("/usr/bin", ToolExe);
+			var path = Path.Combine (AppleSdkSettings.DeveloperRoot, "Toolchains", "XcodeDefault.xctoolchain", "usr", "bin", ToolExe);
 
 			return File.Exists (path) ? path : ToolExe;
 		}


### PR DESCRIPTION
The `strip` command was already doing this, but `ar` and `dsymutil`
were using /usr/bin versions (which might not exist, depending on
the Xcode installation).