### PR TITLE
[tests] Fix monotouch-test to execute when Link All is used

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/CategoryTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/CategoryTest.cs
@@ -51,6 +51,7 @@ using CatAttrib=MonoTouch.ObjCRuntime.CategoryAttribute;
 
 namespace MonoTouchFixtures {
 	[CatAttrib (typeof (NSString))]
+	[Preserve (AllMembers = true)]
 	public static class MyStringCategory
 	{
 		[Export ("toUpper")]
@@ -139,6 +140,7 @@ namespace MonoTouchFixtures {
 
 #if !__WATCHOS__
 	[CatAttrib (typeof (UINavigationController))]
+	[Preserve (AllMembers = true)]
 	static class Rotation_IOS6 {
 		public static Action ShouldAutoRotateCallback;
 		[Export ("shouldAutorotate")]


### PR DESCRIPTION
Code inside the category needs to be preserved, since it's not
directly used by C# code.

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=51335