### PR TITLE
Force mac-binding-projec to build non-parallel

### DIFF
--- a/tests/mac-binding-project/Makefile
+++ b/tests/mac-binding-project/Makefile
@@ -1,4 +1,7 @@
 TOP=../..
+
+.NOTPARALLEL:
+
 include $(TOP)/Make.config
 
 export MD_APPLE_SDK_ROOT=$(shell dirname `dirname $(XCODE_DEVELOPER_ROOT)`)


### PR DESCRIPTION
- Try to fix https://bugzilla.xamarin.com/show_bug.cgi?id=50634
- Unable to reproduce locally
- Increases build time from about 20s to 60s :(