### PR TITLE
[runtime] Blocks must be copied, not just assigned. Fixes #44568.

### DIFF
--- a/runtime/monotouch-debug.m
+++ b/runtime/monotouch-debug.m
@@ -181,7 +181,7 @@ static volatile int http_connect_counter = 0;
 	int http_sockets[2];
 	volatile int http_send_counter;
 }
-	@property void (^completion_handler)(bool);
+	@property (copy) void (^completion_handler)(bool);
 	@property (copy) NSString* ip;
 	@property int id;
 	@property bool uniqueRequest;


### PR DESCRIPTION
The completion handler block must be copied to the XamarinHttpConnection
instance, otherwise we'll just store a pointer to a stack block, and once we
invoke the block we'll access stack memory (probably from another thread),
which is really not what we want to do.

https://bugzilla.xamarin.com/show_bug.cgi?id=44568