### PR TITLE
[foundation] Return an empty NSArray that is valid for both managed and native side

### DIFF
--- a/src/Foundation/NSArray.cs
+++ b/src/Foundation/NSArray.cs
@@ -32,10 +32,6 @@ using XamCore.ObjCRuntime;
 namespace XamCore.Foundation {
 
 	public partial class NSArray {
-		internal NSArray (bool empty)
-		{
-			Handle = IntPtr.Zero;
-		}
 
 		//
 		// Creates an array with the elements;   If the value passed is null, it
@@ -76,7 +72,7 @@ namespace XamCore.Foundation {
 		internal static NSArray From<T> (T[] items, long count = -1)
 		{
 			if ((items == null) || (count == 0))
-				return new NSArray (true);
+				return new NSArray ();
 
 			if (count == -1)
 				count = items.Length;
@@ -96,7 +92,7 @@ namespace XamCore.Foundation {
 		internal static NSArray FromNativeObjects (INativeObject[] items)
 		{
 			if (items == null)
-				return new NSArray (true);
+				return new NSArray ();
 
 			return FromNativeObjects (items, items.Length);
 		}
@@ -104,7 +100,7 @@ namespace XamCore.Foundation {
 		internal static NSArray FromNativeObjects (INativeObject [] items, nint count)
 		{
 			if (items == null)
-				return new NSArray (true);
+				return new NSArray ();
 
 			if (count > items.Length)
 				throw new ArgumentException ("count is larger than the number of items", "count");
@@ -123,7 +119,7 @@ namespace XamCore.Foundation {
 		internal static NSArray FromNSObjects (IList<NSObject> items)
 		{
 			if (items == null)
-				return new NSArray (true);
+				return new NSArray ();
 
 			int count = items.Count;
 			IntPtr buf = Marshal.AllocHGlobal (count * IntPtr.Size);

--- a/src/SceneKit/SCNSkinner.cs
+++ b/src/SceneKit/SCNSkinner.cs
@@ -33,7 +33,7 @@ namespace XamCore.SceneKit {
 		static NSArray ToNSArray (SCNMatrix4 [] items)
 		{
 			if (items == null)
-				return new NSArray (true);
+				return new NSArray ();
 
 			var count = items.Length;
 			var buf = Marshal.AllocHGlobal ((IntPtr)(count * IntPtr.Size));

--- a/tests/monotouch-test/Foundation/ArrayTest.cs
+++ b/tests/monotouch-test/Foundation/ArrayTest.cs
@@ -36,16 +36,14 @@ namespace MonoTouchFixtures.Foundation {
 	public class NSArrayTest {
 		
 		[Test]
-		public void FromStrings_NullItem ()
+		public void FromStrings_Null ()
 		{
-			try {
-				NSArray.FromStrings (new string [1]);
-			}
-			catch (Exception e) {
-				Assert.Fail ("Unexpected exception {0}", e);
-			}
+			Assert.Throws <ArgumentNullException> (() => NSArray.FromStrings (null), "null");
+
+			using (var a = NSArray.FromStrings (new string [1]))
+				Assert.That (a.Count, Is.EqualTo (1), "null item");
 		}
-		
+
 		int comparator_count;
 
 		// the new NSObject are often, but not always, in ascending order 
@@ -127,8 +125,8 @@ namespace MonoTouchFixtures.Foundation {
 			using (var a = NSArray.FromNSObjects (null)) {
 				// on the managed side we have an empty array
 				Assert.That (a.Count, Is.EqualTo ((nuint) 0), "Count");
-				// if we provide the handle to the ObjC it will be `nil`
-				Assert.That (a.Handle, Is.EqualTo (IntPtr.Zero), "Handle");
+				// and a valid native instance (or some other API might fail)
+				Assert.That (a.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
 			}
 		}
 	}


### PR DESCRIPTION
The existing code was cheating and returned a managed only instance with a `nil` handle. That was fine in many cases but some API (e.g. UISegmentedControl) don't like that (i.e. don't react like a normal, empty NSArray was supplied). It's also the right thing to do since the current behaviour is not guaranteed to remain identical on future updates of the OS.

Unit tests updated.