### PR TITLE
[generator][WIP] Add BindAs support

### DIFF
--- a/src/error.cs
+++ b/src/error.cs
@@ -68,6 +68,8 @@ using ProductException=BindingException;
 //		BI1045 Only a single [DefaultEnumValue] attribute can be used inside enum {type.Name}.
 //		BI1046 The [Field] constant {fa.SymbolName} cannot only be used once inside enum {type.Name}.
 //		BI1047 Unsupported platform: {0}. Please file a bug report (http://bugzilla.xamarin.com) with a test case.
+//		BI1048 Unsupported type {0} decorated with [BindAsAttribute].
+//		BI1049 Could not unbox type {0} from {1} container used on {2} member decorated with [BindAsAttribute].
 //	BI11xx	warnings
 //		BI1101 Trying to use a string as a [Target]
 //		BI1102 Using the deprecated EventArgs for a delegate signature in {0}.{1}, please use DelegateName instead

--- a/src/generator-attributes.cs
+++ b/src/generator-attributes.cs
@@ -45,6 +45,24 @@ public class ForcedTypeAttribute : Attribute {
 	public bool Owns;
 }
 
+//
+// BindAsAttribute
+//
+// // TODO Alex: finish documenting this 
+// The BindAsAttribute allows binding a container type (i.e. NSNumber) into a more accurate types
+// like bool?.
+//
+[AttributeUsage (AttributeTargets.ReturnValue | AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false)]
+public class BindAsAttribute : Attribute {
+	public BindAsAttribute (Type type)
+	{
+		Type = type;
+		IsNullable = Nullable.GetUnderlyingType (type) != null;
+	}
+	public Type Type;
+	internal readonly bool IsNullable;
+}
+
 // Used to flag a type as needing to be turned into a protocol on output for Unified
 // For example:
 //   [Protocolize, Wrap ("WeakDelegate")]

--- a/src/generator.csproj
+++ b/src/generator.csproj
@@ -51,5 +51,6 @@
     <Compile Include="..\external\mono\mcs\class\Mono.Options\Mono.Options\Options.cs">
       <Link>Options.cs</Link>
     </Compile>
+    <Compile Include="generator-attributes.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The intent of BindAs attribute is to have a binding definition as

	[return: BindAs (typeof (bool?))]
	[Export ("boolMethod:")]
	NSNumber BoolMethod (int arg1);

and our generator outputs

	[Export ("boolMethod:")]
	public virtual global::System.Nullable<bool> BoolMethod (int arg1) { ...  }

So we internally do the NSNumber <-> bool conversion, this also
applies to parameters, properties and methods.

TODO:
- [x] Properties, Methods and Parameters support
- [x] NSNumber support
- [x] NSValue support
- [ ] Smart enum/enum support
- [ ] Tests
