### PR TITLE
[generator] Add BindAs support

### DIFF
--- a/docs/website/binding_objc_libs.md
+++ b/docs/website/binding_objc_libs.md
@@ -842,9 +842,9 @@ the wrap'ed version will still work and call the overriden method.
 
 ## Binding NSValue NSNumber and NSString to a better type
 
-The [[BindAs]](/guides/ios/advanced_topics/binding_objective-c/binding_types_reference_guide#BindAsAttribute) attribute allows binding `NSNumber` `NSValue` and `NSString`(enums) into more accurate C# types this allows an easy way to create better .NET API.
+The [[BindAs]](/guides/ios/advanced_topics/binding_objective-c/binding_types_reference_guide#BindAsAttribute) attribute allows binding `NSNumber`, `NSValue` and `NSString`(enums) into more accurate C# types. The attribute can be used to create better, more accurate, .NET API over the native API.
 
-It can be used in methods, parameters and properties. The only restriction is that your member **mustn't** be inside a `[Protocol]` or `[Model]` interface.
+You can decorate methods (on return value), parameters and properties with [[BindAs]](/guides/ios/advanced_topics/binding_objective-c/binding_types_reference_guide#BindAsAttribute). The only restriction is that your member **must not** be inside a `[Protocol]` or `[Model]` interface.
 
 For example:
 
@@ -882,7 +882,7 @@ CAScroll [] SupportedScrollModes { get; set; }
 
 `CAScroll` is a `NSString` backed enum, we will fetch the right `NSString` value and handle the type conversion.
 
-Please see [NSNumber](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSNumber/#Public_Properties) and [NSValue] (https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSValue/#Public_Properties) documentation to see supported conversion types.
+Please see [[BindAs] documentation](/guides/ios/advanced_topics/binding_objective-c/binding_types_reference_guide#BindAsAttribute) to see supported conversion types.
 
 
 ## Binding Notifications

--- a/docs/website/binding_objc_libs.md
+++ b/docs/website/binding_objc_libs.md
@@ -840,6 +840,51 @@ An alternative is to mark the original, `NSString`-based, definition as
 the wrap'ed version will still work and call the overriden method.
 
 
+## Binding NSValue NSNumber and NSString to a better type
+
+The [[BindAs]](/guides/ios/advanced_topics/binding_objective-c/binding_types_reference_guide#BindAsAttribute) attribute allows binding `NSNumber` `NSValue` and `NSString`(enums) into more accurate C# types this allows an easy way to create better .NET API.
+
+It can be used in methods, parameters and properties. The only restriction is that your member **mustn't** be inside a `[Protocol]` or `[Model]` interface.
+
+For example:
+
+```
+[return: BindAs (typeof (bool?))]
+[Export ("shouldDrawAt:")]
+NSNumber ShouldDraw ([BindAs (typeof (CGRect))] NSValue rect);
+```
+
+Would output:
+
+```
+[Export ("shouldDrawAt:")]
+bool? ShouldDraw (CGRect rect) { ... }
+```
+
+Internally we will do the `bool?` <-> `NSNumber` and `CGRect` <-> `NSValue` conversions.
+
+[[BindAs]](/guides/ios/advanced_topics/binding_objective-c/binding_types_reference_guide#BindAsAttribute) also supports arrays of `NSNumber` `NSValue` and `NSString`(enums).
+
+For example:
+
+```
+[BindAs (typeof (CAScroll []))]
+[Export ("supportedScrollModes")]
+NSString [] SupportedScrollModes { get; set; }
+```
+
+Would output:
+
+```
+[Export ("supportedScrollModes")]
+CAScroll [] SupportedScrollModes { get; set; }
+```
+
+`CAScroll` is a `NSString` backed enum, we will fetch the right `NSString` value and handle the type conversion.
+
+Please see [NSNumber](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSNumber/#Public_Properties) and [NSValue] (https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSValue/#Public_Properties) documentation to see supported conversion types.
+
+
 ## Binding Notifications
 
 Notifications are messages that are posted to the

--- a/docs/website/binding_types_reference_guide.md
+++ b/docs/website/binding_types_reference_guide.md
@@ -2083,6 +2083,52 @@ Example:
 You can then call the extension method `GetDomain` to get the domain constant of
 any error.
 
+
+## BindAsAttribute
+
+The `BindAsAttribute` allows binding `NSNumber` `NSValue` and `NSString`(enums) into more accurate C# types this allows an easy way to create better .NET API.
+
+It can be used in methods, parameters and properties. The only restriction is that your member **mustn't** be inside a `[Protocol]` or `[Model]` interface.
+
+For example:
+
+```
+[return: BindAs (typeof (bool?))]
+[Export ("shouldDrawAt:")]
+NSNumber ShouldDraw ([BindAs (typeof (CGRect))] NSValue rect);
+```
+
+Would output:
+
+```
+[Export ("shouldDrawAt:")]
+bool? ShouldDraw (CGRect rect) { ... }
+```
+
+Internally we will do the `bool?` <-> `NSNumber` and `CGRect` <-> `NSValue` conversions.
+
+`BindAsAttribute` also supports arrays of `NSNumber` `NSValue` and `NSString`(enums).
+
+For example:
+
+```
+[BindAs (typeof (CAScroll []))]
+[Export ("supportedScrollModes")]
+NSString [] SupportedScrollModes { get; set; }
+```
+
+Would output:
+
+```
+[Export ("supportedScrollModes")]
+CAScroll [] SupportedScrollModes { get; set; }
+```
+
+`CAScroll` is a `NSString` backed enum, we will fetch the right `NSString` value and handle the type conversion.
+
+Please see [NSNumber](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSNumber/#Public_Properties) and [NSValue] (https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSValue/#Public_Properties) documentation to see supported conversion types.
+
+
 ## FieldAttribute
 
 This is the same `[Field]` attribute used for constants inside type. It can also

--- a/docs/website/binding_types_reference_guide.md
+++ b/docs/website/binding_types_reference_guide.md
@@ -1002,6 +1002,120 @@ for **Core Foundation** objects.
 The `ForcedTypeAttribute` is only valid on `parameters`, `properties` and `return value`. 
 
 
+<a name="BindAsAttribute" class="injected"></a>
+
+
+## BindAsAttribute
+
+The `BindAsAttribute` allows binding `NSNumber`, `NSValue` and `NSString`(enums) into more accurate C# types. The attribute can be used to create better, more accurate, .NET API over the native API.
+
+You can decorate methods (on return value), parameters and properties with `BindAs`. The only restriction is that your member **must not** be inside a `[Protocol]` or `[Model]` interface.
+
+For example:
+
+```
+[return: BindAs (typeof (bool?))]
+[Export ("shouldDrawAt:")]
+NSNumber ShouldDraw ([BindAs (typeof (CGRect))] NSValue rect);
+```
+
+Would output:
+
+```
+[Export ("shouldDrawAt:")]
+bool? ShouldDraw (CGRect rect) { ... }
+```
+
+Internally we will do the `bool?` <-> `NSNumber` and `CGRect` <-> `NSValue` conversions.
+
+The current supported encapsulation types are:
+
+* `NSValue`
+* `NSNumber`
+* `NSString`
+
+### NSValue
+
+The following C# data types are supported to be encapsulated from/into `NSValue`:
+
+* CGAffineTransform
+* NSRange
+* CGVector
+* SCNMatrix4
+* CLLocationCoordinate2D
+* SCNVector3
+* SCNVector4
+* CGPoint / PointF
+* CGRect / RectangleF
+* CGSize / SizeF
+* UIEdgeInsets
+* UIOffset
+* MKCoordinateSpan
+* CMTimeRange
+* CMTime
+* CMTimeMapping
+* CATransform3D
+
+### NSNumber
+
+The following C# data types are supported to be encapsulated from/into `NSNumber`:
+
+* bool
+* byte
+* double
+* float
+* short
+* int
+* long
+* sbyte
+* ushort
+* uint
+* ulong
+* nfloat
+* nint
+* nuint
+* Enums
+
+### NSString
+
+`[BindAs]` works in conjuntion with [enums backed by a NSString constant](#enum-attributes) so you can create better .NET API, for example:
+
+```
+[BindAs (typeof (CAScroll))]
+[Export ("supportedScrollMode")]
+NSString SupportedScrollMode { get; set; }
+```
+
+Would output:
+
+```
+[Export ("supportedScrollMode")]
+CAScroll SupportedScrollMode { get; set; }
+```
+
+We will handle the `enum` <-> `NSString` conversion only if the provided enum type to `[BindAs]` is [backed by a NSString constant](#enum-attributes).
+
+### Arrays
+
+`[BindAs]` also supports arrays of any of the supported types, you can have the following API definition as an example:
+
+```
+[return: BindAs (typeof (CAScroll []))]
+[Export ("getScrollModesAt:")]
+NSString [] GetScrollModes ([BindAs (typeof (CGRect []))] NSValue [] rects);
+```
+
+Would output:
+
+```
+[Export ("getScrollModesAt:")]
+CAScroll? [] GetScrollModes (CGRect [] rects) { ... }
+```
+
+The `rects` parameter will be encapsulated into a `NSArray` that contains an `NSValue` for each `CGRect` and in return you will get an array of `CAScroll?` which has been created using the values of the returned `NSArray` containing `NSStrings`.
+
+
+
  <a name="BindAttribute" class="injected"></a>
 
 
@@ -2082,51 +2196,6 @@ Example:
 
 You can then call the extension method `GetDomain` to get the domain constant of
 any error.
-
-
-## BindAsAttribute
-
-The `BindAsAttribute` allows binding `NSNumber` `NSValue` and `NSString`(enums) into more accurate C# types this allows an easy way to create better .NET API.
-
-It can be used in methods, parameters and properties. The only restriction is that your member **mustn't** be inside a `[Protocol]` or `[Model]` interface.
-
-For example:
-
-```
-[return: BindAs (typeof (bool?))]
-[Export ("shouldDrawAt:")]
-NSNumber ShouldDraw ([BindAs (typeof (CGRect))] NSValue rect);
-```
-
-Would output:
-
-```
-[Export ("shouldDrawAt:")]
-bool? ShouldDraw (CGRect rect) { ... }
-```
-
-Internally we will do the `bool?` <-> `NSNumber` and `CGRect` <-> `NSValue` conversions.
-
-`BindAsAttribute` also supports arrays of `NSNumber` `NSValue` and `NSString`(enums).
-
-For example:
-
-```
-[BindAs (typeof (CAScroll []))]
-[Export ("supportedScrollModes")]
-NSString [] SupportedScrollModes { get; set; }
-```
-
-Would output:
-
-```
-[Export ("supportedScrollModes")]
-CAScroll [] SupportedScrollModes { get; set; }
-```
-
-`CAScroll` is a `NSString` backed enum, we will fetch the right `NSString` value and handle the type conversion.
-
-Please see [NSNumber](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSNumber/#Public_Properties) and [NSValue] (https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSValue/#Public_Properties) documentation to see supported conversion types.
 
 
 ## FieldAttribute

--- a/src/Foundation/NSArray.cs
+++ b/src/Foundation/NSArray.cs
@@ -59,6 +59,16 @@ namespace XamCore.Foundation {
 			return FromNativeObjects (items, count);
 		}
 
+		public static NSArray FromNSObjects<T> (Func<T, NSObject> nsobjectificator, params T [] items)
+		{
+			var arr = new NSObject [items.Length];
+			for (int i = 0; i < items.Length; i++) {
+				arr [i] = nsobjectificator (items [i]);
+			}
+
+			return FromNativeObjects (arr);
+		}
+
 		public static NSArray FromObjects (params object [] items)
 		{
 			return From<object> (items);

--- a/src/Foundation/NSArray.cs
+++ b/src/Foundation/NSArray.cs
@@ -61,6 +61,11 @@ namespace XamCore.Foundation {
 
 		public static NSArray FromNSObjects<T> (Func<T, NSObject> nsobjectificator, params T [] items)
 		{
+			if (nsobjectificator == null)
+				throw new ArgumentNullException (nameof (nsobjectificator));
+			if (items == null)
+				throw new ArgumentNullException (nameof (items));
+
 			var arr = new NSObject [items.Length];
 			for (int i = 0; i < items.Length; i++) {
 				arr [i] = nsobjectificator (items [i]);

--- a/src/Foundation/NSNumber.mac.cs
+++ b/src/Foundation/NSNumber.mac.cs
@@ -14,6 +14,7 @@ namespace XamCore.Foundation
 {
 	public partial class NSNumber
 	{
+#if !COREBUILD
 		public static NSNumber FromObject (object value)
 		{
 			if (value is float) {
@@ -50,6 +51,7 @@ namespace XamCore.Foundation
 
 			return null;
 		}
+#endif
 	}
 }
 

--- a/src/Foundation/NSNumber2.cs
+++ b/src/Foundation/NSNumber2.cs
@@ -11,7 +11,11 @@ using System.Runtime.InteropServices;
 using XamCore.ObjCRuntime;
 
 namespace XamCore.Foundation {
-	public partial class NSNumber : NSValue, IComparable, IComparable<NSNumber>, IEquatable<NSNumber> {
+	public partial class NSNumber : NSValue
+#if COREBUILD
+	{
+#else
+	, IComparable, IComparable<NSNumber>, IEquatable<NSNumber> {
 
 		public static implicit operator NSNumber (float value)
 		{
@@ -199,5 +203,6 @@ namespace XamCore.Foundation {
 			// something that's really not obvious
 			return StringValue.GetHashCode ();
 		}
+#endif
 	}
 }

--- a/src/error.cs
+++ b/src/error.cs
@@ -68,6 +68,8 @@ using ProductException=BindingException;
 //		BI1045 Only a single [DefaultEnumValue] attribute can be used inside enum {type.Name}.
 //		BI1046 The [Field] constant {fa.SymbolName} cannot only be used once inside enum {type.Name}.
 //		BI1047 Unsupported platform: {0}. Please file a bug report (http://bugzilla.xamarin.com) with a test case.
+//		BI1048 Unsupported type {0} decorated with [BindAsAttribute].
+//		BI1049 Could not unbox type {0} from {1} container used on {2} member decorated with [BindAsAttribute].
 //	BI11xx	warnings
 //		BI1101 Trying to use a string as a [Target]
 //		BI1102 Using the deprecated EventArgs for a delegate signature in {0}.{1}, please use DelegateName instead

--- a/src/error.cs
+++ b/src/error.cs
@@ -68,8 +68,8 @@ using ProductException=BindingException;
 //		BI1045 Only a single [DefaultEnumValue] attribute can be used inside enum {type.Name}.
 //		BI1046 The [Field] constant {fa.SymbolName} cannot only be used once inside enum {type.Name}.
 //		BI1047 Unsupported platform: {0}. Please file a bug report (http://bugzilla.xamarin.com) with a test case.
-//		BI1048 Unsupported type {0} decorated with [BindAsAttribute].
-//		BI1049 Could not unbox type {0} from {1} container used on {2} member decorated with [BindAsAttribute].
+//		BI1048 Unsupported type {0} decorated with [BindAs].
+//		BI1049 Could not unbox type {0} from {1} container used on {2} member decorated with [BindAs].
 //	BI11xx	warnings
 //		BI1101 Trying to use a string as a [Target]
 //		BI1102 Using the deprecated EventArgs for a delegate signature in {0}.{1}, please use DelegateName instead

--- a/src/error.cs
+++ b/src/error.cs
@@ -70,6 +70,7 @@ using ProductException=BindingException;
 //		BI1047 Unsupported platform: {0}. Please file a bug report (http://bugzilla.xamarin.com) with a test case.
 //		BI1048 Unsupported type {0} decorated with [BindAs].
 //		BI1049 Could not unbox type {0} from {1} container used on {2} member decorated with [BindAs].
+//		BI1050 [BindAs] cannot be used inside Protocol or Model types. Type: {0}
 //	BI11xx	warnings
 //		BI1101 Trying to use a string as a [Target]
 //		BI1102 Using the deprecated EventArgs for a delegate signature in {0}.{1}, please use DelegateName instead

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -613,6 +613,8 @@ FOUNDATION_CORE_SOURCES = \
 	Foundation/NSDecimal.cs \
 	Foundation/NSDimension.cs \
 	Foundation/NSError.cs \
+	Foundation/NSNumber.mac.cs \
+	Foundation/NSNumber2.cs \
 	Foundation/NSObject2.cs \
 	Foundation/NSRange.cs \
 	Foundation/NSString.cs \
@@ -682,8 +684,6 @@ FOUNDATION_SOURCES = \
 	Foundation/NSMutableUrlRequest.cs \
 	Foundation/NSNetService.cs \
 	Foundation/NSNotificationCenter.cs \
-	Foundation/NSNumber.mac.cs \
-	Foundation/NSNumber2.cs \
 	Foundation/NSOrderedSet.cs \
 	Foundation/NSOrderedSet_1.cs \
 	Foundation/NSOutputStream.cs \

--- a/src/generator-attributes.cs
+++ b/src/generator-attributes.cs
@@ -45,6 +45,24 @@ public class ForcedTypeAttribute : Attribute {
 	public bool Owns;
 }
 
+//
+// BindAsAttribute
+//
+// // TODO Alex: finish documenting this
+// The BindAsAttribute allows binding a container type (i.e. NSNumber) into a more accurate types
+// like bool?.
+//
+[AttributeUsage (AttributeTargets.ReturnValue | AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false)]
+public class BindAsAttribute : Attribute {
+	public BindAsAttribute (Type type)
+	{
+		Type = type;
+		IsNullable = Nullable.GetUnderlyingType (type) != null;
+	}
+	public Type Type;
+	internal readonly bool IsNullable;
+}
+
 // Used to flag a type as needing to be turned into a protocol on output for Unified
 // For example:
 //   [Protocolize, Wrap ("WeakDelegate")]

--- a/src/generator-attributes.cs
+++ b/src/generator-attributes.cs
@@ -57,10 +57,13 @@ public class BindAsAttribute : Attribute {
 	public BindAsAttribute (Type type)
 	{
 		Type = type;
-		IsNullable = Nullable.GetUnderlyingType (type) != null;
+		var nullable = type.IsArray ? Nullable.GetUnderlyingType (type.GetElementType ()) : Nullable.GetUnderlyingType (type);
+		IsNullable = nullable != null;
+		IsValueType = IsNullable ? nullable.IsValueType : type.IsValueType;
 	}
 	public Type Type;
 	internal readonly bool IsNullable;
+	internal readonly bool IsValueType;
 }
 
 // Used to flag a type as needing to be turned into a protocol on output for Unified

--- a/src/generator-attributes.cs
+++ b/src/generator-attributes.cs
@@ -48,8 +48,8 @@ public class ForcedTypeAttribute : Attribute {
 //
 // BindAsAttribute
 //
-// The BindAsAttribute allows binding NSNumber|NSValue|NSString(enums) into more accurate C# types.
-// It can be used in methods, parameters and properties. The only restriction is that your member mustn't
+// The BindAsAttribute allows binding NSNumber, NSValue and NSString(enums) into more accurate C# types.
+// It can be used in methods, parameters and properties. The only restriction is that your member must not
 // be inside a [Protocol] or [Model] interface.
 //
 // For example:

--- a/src/generator-attributes.cs
+++ b/src/generator-attributes.cs
@@ -48,9 +48,37 @@ public class ForcedTypeAttribute : Attribute {
 //
 // BindAsAttribute
 //
-// // TODO Alex: finish documenting this
-// The BindAsAttribute allows binding a container type (i.e. NSNumber) into a more accurate types
-// like bool?.
+// The BindAsAttribute allows binding NSNumber|NSValue|NSString(enums) into more accurate C# types.
+// It can be used in methods, parameters and properties. The only restriction is that your member mustn't
+// be inside a [Protocol] or [Model] interface.
+//
+// For example:
+//
+//	[return: BindAs (typeof (bool?))]
+//	[Export ("shouldDrawAt:")]
+//	NSNumber ShouldDraw ([BindAs (typeof (CGRect))] NSValue rect);
+//
+// Would output:
+//
+//	[Export ("shouldDrawAt:")]
+//	bool? ShouldDraw (CGRect rect) { ... }
+//
+// Internally we will do the bool? <-> NSNumber and CGRect <-> NSValue conversions.
+//
+// BindAs also supports arrays of NSNumber|NSValue|NSString(enums)
+//
+// For example:
+//
+//	[BindAs (typeof (CAScroll []))]
+//	[Export ("supportedScrollModes")]
+//	NSString [] SupportedScrollModes { get; set; }
+//
+// Would output:
+//
+//	[Export ("supportedScrollModes")]
+//	CAScroll [] SupportedScrollModes { get; set; }
+//
+// CAScroll is a NSString backed enum, we will fetch the right NSString value and handle the type conversion.
 //
 [AttributeUsage (AttributeTargets.ReturnValue | AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false)]
 public class BindAsAttribute : Attribute {

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1255,14 +1255,14 @@ public partial class Generator : IMemberGatherer {
 				append = ".UInt32Value";
 			else if (retType == typeof (ulong))
 				append = ".UInt64Value";
-			#if XAMCORE_2_0
-			            else if (retType == typeof (nfloat))
-                append = ".NFloatValue";
-            else if (retType == typeof (nint))
-                append = ".NIntValue";
-            else if (retType == typeof (nuint))
-                append = ".NUIntValue";
-    #endif
+#if XAMCORE_2_0
+			else if (retType == typeof (nfloat))
+				append = ".NFloatValue";
+			else if (retType == typeof (nint))
+				append = ".NIntValue";
+			else if (retType == typeof (nuint))
+				append = ".NUIntValue";
+#endif
 			else
 				throw new BindingException (1049, true, "Could not unbox type {0} from {1} container used on {2} member decorated with [BindAsAttribute].", retType.Name, "NSNumber", minfo.mi.Name);
 

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1152,75 +1152,53 @@ public partial class Generator : IMemberGatherer {
 		else if (className == "NSValue") {
 			switch (retType.Name) {
 			case "CATransform3D":
-				temp = string.Format ("NSValue.FromCATransform3D ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "CGAffineTransform":
-				temp = string.Format ("NSValue.FromCGAffineTransform ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "CGPoint":
-				temp = string.Format ("NSValue.FromCGPoint ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "CGRect":
-				temp = string.Format ("NSValue.FromCGRect ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "CGSize":
-				temp = string.Format ("NSValue.FromCGSize ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "CGVector":
-				temp = string.Format ("NSValue.FromCGVector ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "CMTimeMapping":
-				temp = string.Format ("NSValue.FromCMTimeMapping ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "CMTimeRange":
-				temp = string.Format ("NSValue.FromCMTimeRange ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "CMTime":
-				temp = string.Format ("NSValue.FromCMTime ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "MKCoordinateSpan":
-				temp = string.Format ("NSValue.FromMKCoordinateSpan ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "CLLocationCoordinate2D":
-				temp = string.Format ("NSValue.FromCLLocationCoordinate2D ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "PointF":
-				temp = string.Format ("NSValue.FromPointF ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
-			case "NSRange":
-				temp = string.Format ("NSValue.FromRange ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "RectangleF":
-				temp = string.Format ("NSValue.FromRectangleF ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "SCNMatrix4":
-				temp = string.Format ("NSValue.FromSCNMatrix4 ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "SizeF":
-				temp = string.Format ("NSValue.FromSizeF ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "UIEdgeInsets":
-				temp = string.Format ("NSValue.FromUIEdgeInsets ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "UIOffset":
-				temp = string.Format ("NSValue.FromUIOffset ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
+				temp = string.Format ("NSValue.From{0} ({{1}}{{0}});", retType.Name);
+				break;
 			case "SCNVector3":
-				temp = string.Format ("NSValue.FromVector ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
 			case "SCNVector4":
-				temp = string.Format ("NSValue.FromVector ({1}{0});", isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
-			break;
+				temp = "NSValue.FromVector ({1}{0});";
+				break;
+			case "NSRange":
+				temp = "NSValue.FromRange ({1}{0});";
+				break;
 			default:
-				throw new BindingException (1049, true, "Could not box type {0} into {1} container used on {2} member decorated with [BindAsAtrribute].", retType.Name, "NSValue", minfo?.mi?.Name ?? pi?.Name);
+				throw new BindingException (1049, true, "Could not box type {0} into {1} container used on {2} member decorated with [BindAs].", retType.Name, "NSValue", minfo?.mi?.Name ?? pi?.Name);
 			}
+
+			temp = string.Format (temp, isNullable ? ".Value" : string.Empty, pi != null ? pi.Name.GetSafeParamName () : "value");
 		} else if (isValueType) {
 			// Magic for enums/smart enums
 		} else
-			throw new BindingException (1048, true, "Unsupported type {0} decorated with [BindAsAttribute]", retType.Name);
+			throw new BindingException (1048, true, "Unsupported type {0} decorated with [BindAs]", retType.Name);
 
 		return temp;
 	}
+
+	static Dictionary<Type,string> NSNumberReturnMap = new Dictionary<Type, string> {
+		{ typeof (bool), ".BoolValue" }, { typeof (byte), ".ByteValue" }, { typeof (double), ".DoubleValue" },
+		{ typeof (float), ".FloatValue" }, { typeof (short), ".Int16Value" }, { typeof (int), ".Int32Value" },
+		{ typeof (long), ".Int64Value" }, { typeof (sbyte), ".SByteValue" }, { typeof (ushort), ".UInt16Value" },
+		{ typeof (uint), ".UInt32Value" }, { typeof (ulong), ".UInt64Value" },
+#if XAMCORE_2_0
+		{ typeof (nfloat), ".NFloatValue" }, { typeof (nint), ".NIntValue" }, { typeof (nuint), ".NUIntValue" },
+#endif
+	};
 
 	string GetFromBindAsWrapper (MemberInformation minfo)
 	{
@@ -1232,109 +1210,50 @@ public partial class Generator : IMemberGatherer {
 		var method = minfo.mi as MethodInfo;
 
 		if (method?.ReturnType?.Name == "NSNumber" || property?.PropertyType?.Name == "NSNumber") {
-			// I wish C# 7 was a thing today :)
-			if (retType == typeof (bool))
-				append = ".BoolValue";
-			else if (retType == typeof (byte))
-				append = ".ByteValue";
-			else if (retType == typeof (double))
-				append = ".DoubleValue";
-			else if (retType == typeof (float))
-				append = ".FloatValue";
-			else if (retType == typeof (short))
-				append = ".Int16Value";
-			else if (retType == typeof (int))
-				append = ".Int32Value";
-			else if (retType == typeof (long))
-				append = ".Int64Value";
-			else if (retType == typeof (sbyte))
-				append = ".SByteValue";
-			else if (retType == typeof (ushort))
-				append = ".UInt16Value";
-			else if (retType == typeof (uint))
-				append = ".UInt32Value";
-			else if (retType == typeof (ulong))
-				append = ".UInt64Value";
-#if XAMCORE_2_0
-			else if (retType == typeof (nfloat))
-				append = ".NFloatValue";
-			else if (retType == typeof (nint))
-				append = ".NIntValue";
-			else if (retType == typeof (nuint))
-				append = ".NUIntValue";
-#endif
-			else
-				throw new BindingException (1049, true, "Could not unbox type {0} from {1} container used on {2} member decorated with [BindAsAttribute].", retType.Name, "NSNumber", minfo.mi.Name);
+			if (!NSNumberReturnMap.TryGetValue (retType, out append))
+				throw new BindingException (1049, true, "Could not unbox type {0} from {1} container used on {2} member decorated with [BindAs].", retType.Name, "NSNumber", minfo.mi.Name);
 
 		} else if (method?.ReturnType.Name == "NSValue" || property?.PropertyType.Name == "NSValue") {
 			switch (retType.Name) {
 			case "CATransform3D":
-				append = ".CATransform3DValue";
-			break;
 			case "CGAffineTransform":
-				append = ".CGAffineTransformValue";
-			break;
 			case "CGPoint":
-				append = ".CGPointValue";
-			break;
 			case "CGRect":
-				append = ".CGRectValue";
-			break;
 			case "CGSize":
-				append = ".CGSizeValue";
-			break;
 			case "CGVector":
-				append = ".CGVectorValue";
-			break;
 			case "CMTimeMapping":
-				append = ".CMTimeMappingValue";
-			break;
 			case "CMTimeRange":
-				append = ".CMTimeRangeValue";
-			break;
 			case "CMTime":
-				append = ".CMTimeValue";
-			break;
+			case "PointF":
+			case "RectangleF":
+			case "SCNMatrix4":
+			case "SizeF":
+			case "UIEdgeInsets":
+			case "UIOffset":
+				append = string.Format (".{0}Value", retType.Name);
+				break;
 			case "MKCoordinateSpan":
 				append = ".CoordinateSpanValue";
-			break;
+				break;
 			case "CLLocationCoordinate2D":
 				append = ".CoordinateValue";
-			break;
-			case "PointF":
-				append = ".PointFValue";
-			break;
+				break;
 			case "NSRange":
 				append = ".RangeValue";
-			break;
-			case "RectangleF":
-				append = ".RectangleFValue";
-			break;
-			case "SCNMatrix4":
-				append = ".SCNMatrix4Value";
-			break;
-			case "SizeF":
-				append = ".SizeFValue";
-			break;
-			case "UIEdgeInsets":
-				append = ".UIEdgeInsetsValue";
-			break;
-			case "UIOffset":
-				append = ".UIOffsetValue";
-			break;
+				break;
 			case "SCNVector3":
 				append = ".Vector3Value";
-			break;
+				break;
 			case "SCNVector4":
 				append = ".Vector4Value";
-			break;
+				break;
 			default:
-				throw new BindingException (1049, true, "Could not unbox type {0} from {1} container used on {2} member decorated with [BindAsAttribute].", retType.Name, "NSValue", minfo.mi.Name);
+				throw new BindingException (1049, true, "Could not unbox type {0} from {1} container used on {2} member decorated with [BindAs].", retType.Name, "NSValue", minfo.mi.Name);
 			}
 		} else if (isValueType) {
 			// Magic for enums/smart enums
 		} else
-			throw new BindingException (1048, true, "Unsupported type {0} decorated with [BindAsAttribute]", retType.Name);
+			throw new BindingException (1048, true, "Unsupported type {0} decorated with [BindAs]", retType.Name);
 		return append;
 	}
 
@@ -1635,7 +1554,7 @@ public partial class Generator : IMemberGatherer {
 		if (HasAttribute (pi, typeof (NullAllowedAttribute)))
 			return false;
 
-		if (mi.IsSpecialName && mi.Name.StartsWith ("set_", StringComparison.Ordinal)){
+		if (IsSetter (mi)) {
 			if (HasAttribute (mi, typeof (NullAllowedAttribute))){
 				return false;
 			}

--- a/src/generator.csproj
+++ b/src/generator.csproj
@@ -51,5 +51,6 @@
     <Compile Include="..\external\mono\mcs\class\Mono.Options\Mono.Options\Options.cs">
       <Link>Options.cs</Link>
     </Compile>
+    <Compile Include="generator-attributes.cs" />
   </ItemGroup>
 </Project>

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -13,7 +13,7 @@ include $(TOP)/Make.config
 
 IOS_CURRENT_DIR=$(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current
 IOS_GENERATOR = $(IOS_CURRENT_DIR)/bin/btouch /baselib:$(IOS_CURRENT_DIR)/lib/mono/2.1/monotouch.dll /unsafe /compiler:$(IOS_CURRENT_DIR)/bin/smcs
-IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts bug43579
+IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts bug43579 bindastests
 IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046
 
 MAC_CURRENT_DIR=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -14,7 +14,7 @@ include $(TOP)/Make.config
 IOS_CURRENT_DIR=$(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current
 IOS_GENERATOR = $(IOS_CURRENT_DIR)/bin/btouch /baselib:$(IOS_CURRENT_DIR)/lib/mono/2.1/monotouch.dll /unsafe /compiler:$(IOS_CURRENT_DIR)/bin/smcs
 IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts bug43579 bindastests
-IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046
+IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error
 
 MAC_CURRENT_DIR=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
 MAC_GENERATOR = $(MAC_CURRENT_DIR)/bin/bmac
@@ -51,6 +51,14 @@ $(eval $(call ProtocolTestTemplate,protocol-duplicate-method-diff-length,1039))
 $(eval $(call ProtocolTestTemplate,protocol-duplicate-method-diff-out,1040))
 $(eval $(call ProtocolTestTemplate,protocol-duplicate-method-diff-type,1041))
 $(eval $(call ProtocolTestTemplate,protocol-duplicate-method-diff-return,1038))
+
+define iOSErrorCodeTestTemplate
+$(1):
+	$(if $(V),,@echo "$@";) $(IOS_GENERATOR) $(1).cs 2>&1 | grep BI$(2) > /dev/null
+endef
+
+$(eval $(call iOSErrorCodeTestTemplate,bindas1048error,1048))
+$(eval $(call iOSErrorCodeTestTemplate,bindas1049error,1049))
 
 classNameCollision:
 	@rm -Rf $@.tmpdir

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -14,7 +14,7 @@ include $(TOP)/Make.config
 IOS_CURRENT_DIR=$(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current
 IOS_GENERATOR = $(IOS_CURRENT_DIR)/bin/btouch /baselib:$(IOS_CURRENT_DIR)/lib/mono/2.1/monotouch.dll /unsafe /compiler:$(IOS_CURRENT_DIR)/bin/smcs
 IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts bug43579 bindastests
-IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error
+IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror
 
 MAC_CURRENT_DIR=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
 MAC_GENERATOR = $(MAC_CURRENT_DIR)/bin/bmac
@@ -59,6 +59,8 @@ endef
 
 $(eval $(call iOSErrorCodeTestTemplate,bindas1048error,1048))
 $(eval $(call iOSErrorCodeTestTemplate,bindas1049error,1049))
+$(eval $(call iOSErrorCodeTestTemplate,bindas1050modelerror,1050))
+$(eval $(call iOSErrorCodeTestTemplate,bindas1050protocolerror,1050))
 
 classNameCollision:
 	@rm -Rf $@.tmpdir

--- a/tests/generator/bindas1048error.cs
+++ b/tests/generator/bindas1048error.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Drawing;
+using MonoTouch.Foundation;
+using MonoTouch.CoreMedia;
+
+namespace BindAs1048ErrorTests {
+
+	[BaseType (typeof (NSObject))]
+	interface MyFooClass {
+
+		[return: BindAs (typeof (string))]
+		[Export ("stringMethod:")]
+		NSString StringMethod (int arg1);
+		
+	}
+}

--- a/tests/generator/bindas1049error.cs
+++ b/tests/generator/bindas1049error.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Drawing;
+using MonoTouch.Foundation;
+using MonoTouch.CoreMedia;
+
+namespace BindAs1049ErrorTests {
+
+	[BaseType (typeof (NSObject))]
+	interface MyFooClass {
+
+		[return: BindAs (typeof (string))]
+		[Export ("stringMethod:")]
+		NSNumber StringMethod (int arg1);
+		
+	}
+}

--- a/tests/generator/bindas1050modelerror.cs
+++ b/tests/generator/bindas1050modelerror.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Drawing;
+using MonoTouch.Foundation;
+using MonoTouch.CoreAnimation;
+
+namespace BindAs1050ModelErrorTests {
+
+	[Model]
+	[BaseType (typeof (NSObject))]
+	interface MyFooClass {
+
+		[return: BindAs (typeof (CAScroll? []))]
+		[Export ("getScrollArrayEnum2:")]
+		NSNumber [] GetScrollArrayFooEnumArray2 ([BindAs (typeof (CAScroll []))] NSNumber [] arg1);
+		
+	}
+}

--- a/tests/generator/bindas1050protocolerror.cs
+++ b/tests/generator/bindas1050protocolerror.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Drawing;
+using MonoTouch.Foundation;
+using MonoTouch.CoreAnimation;
+
+namespace BindAs1050ProtocolErrorTests {
+
+	[Protocol]
+	interface MyFooClass {
+
+		[return: BindAs (typeof (CAScroll? []))]
+		[Export ("getScrollArrayEnum2:")]
+		NSNumber [] GetScrollArrayFooEnumArray2 ([BindAs (typeof (CAScroll []))] NSNumber [] arg1);
+		
+	}
+}

--- a/tests/generator/bindastests.cs
+++ b/tests/generator/bindastests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Drawing;
+using MonoTouch.Foundation;
+using MonoTouch.CoreMedia;
+
+namespace BindAsTests {
+
+    [BaseType (typeof (NSObject))]
+	interface MyFooClass {
+
+		[return: BindAs (typeof (bool?))]
+		[Export ("boolMethod:a:b:c:d:")]
+		NSNumber BoolMethod (int arg0, string arg1, [BindAs (typeof (RectangleF))] NSValue arg2, [BindAs (typeof (bool?))] NSNumber arg3, int arg4);
+
+		[Export ("stringMethod:a:b:c:d:")]
+		string stringMethod (int arg0, string arg1, [BindAs (typeof (RectangleF))] NSValue arg2, [BindAs (typeof (bool?))] NSNumber arg3, int arg4);
+
+		[return: BindAs (typeof (bool?))]
+		[Export ("boolMethod:")]
+		NSNumber BoolMethod (int arg1);
+
+		[return: BindAs (typeof (int?))]
+		[Export ("intMethod")]
+		NSNumber IntMethod ();
+
+		[return: BindAs (typeof (sbyte?))]
+		[Export ("sbyteMethod")]
+		NSNumber SbyteMethod ();
+
+		[return: BindAs (typeof (bool?))]
+		[Static, Export ("boolMethodS")]
+		NSNumber BoolMethodS ();
+
+		[return: BindAs (typeof (int?))]
+		[Static, Export ("intMethodS")]
+		NSNumber IntMethodS ();
+
+		[return: BindAs (typeof (sbyte))]
+		[Static, Export ("sbyteMethodS")]
+		NSNumber SbyteMethodS ();
+
+		[return: BindAs (typeof (CMTime))]
+		[Export ("cmtimeMethod")]
+		NSValue CMTimeMethod ();
+
+		[return: BindAs (typeof (PointF))]
+		[Static, Export ("pointMethodS:")]
+		NSValue PointFMethodS (sbyte arg1);
+
+		[BindAs (typeof (bool?))]
+		[Export ("boolProperty")]
+		NSNumber BoolProperty { get; }
+
+		[BindAs (typeof (double?))]
+		[Export ("doubleProperty")]
+		NSNumber DoubleProperty { get; set; }
+
+		[BindAs (typeof (RectangleF?))]
+		[Static, Export ("rectangleFPropertyS")]
+		NSValue RectangleFPropertyS { get; set; }
+
+		[BindAs (typeof (SizeF))]
+		[Export ("sizeFFProperty")]
+		NSValue SizeFProperty { get; set; }
+
+		[BindAs (typeof (CMTimeRange))]
+		[Export ("cmTimeRangeProperty")]
+		NSValue CMTimeRangeProperty { get; }
+
+		[BindAs (typeof (long))]
+		[Export ("longProperty")]
+		NSNumber LongProperty { get; set; }
+	}
+}

--- a/tests/generator/bindastests.cs
+++ b/tests/generator/bindastests.cs
@@ -5,7 +5,7 @@ using MonoTouch.CoreMedia;
 
 namespace BindAsTests {
 
-    [BaseType (typeof (NSObject))]
+	[BaseType (typeof (NSObject))]
 	interface MyFooClass {
 
 		[return: BindAs (typeof (bool?))]

--- a/tests/generator/bindastests.cs
+++ b/tests/generator/bindastests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Drawing;
 using MonoTouch.Foundation;
 using MonoTouch.CoreMedia;
+using MonoTouch.CoreAnimation;
 
 namespace BindAsTests {
 
@@ -70,5 +71,53 @@ namespace BindAsTests {
 		[BindAs (typeof (long))]
 		[Export ("longProperty")]
 		NSNumber LongProperty { get; set; }
+
+		[BindAs (typeof (CAScroll []))]
+		[Export ("scrollEnumArray")]
+		NSString [] ScrollEnumArray { get; set; }
+
+		[return: BindAs (typeof (CAScroll []))]
+		[Export ("getScrollArrayEnum:")]
+		NSString [] GetScrollArrayEnum ([BindAs (typeof (CAScroll []))] NSString [] arg1);
+
+		[return: BindAs (typeof (CAScroll? []))]
+		[Export ("getScrollArrayNullableEnum:")]
+		NSString [] GetScrollArrayEnumNullable ([BindAs (typeof (CAScroll? []))] NSString [] arg1);
+
+		[BindAs (typeof (CAScroll []))]
+		[Export ("scrollEnumArray2")]
+		NSNumber [] ScrollEnumArray2 { get; set; }
+
+		[return: BindAs (typeof (CAScroll []))]
+		[Export ("getScrollArrayEnum2:")]
+		NSNumber [] GetScrollArrayEnum2 ([BindAs (typeof (CAScroll []))] NSNumber [] arg1);
+
+		[return: BindAs (typeof (CAScroll? []))]
+		[Export ("getScrollArrayNullableEnum2:")]
+		NSNumber [] GetScrollArrayNullableEnum2 ([BindAs (typeof (CAScroll? []))] NSNumber [] arg1);
+
+		[BindAs (typeof (CMTime []))]
+		[Export ("timeEnumArray")]
+		NSValue [] TimeEnumArray { get; set; }
+
+		[return: BindAs (typeof (CMTime []))]
+		[Export ("getTimeEnumArray:")]
+		NSValue [] GetTimeEnumArray ([BindAs (typeof (CMTime []))] NSValue [] arg1);
+
+		[return: BindAs (typeof (CMTime? []))]
+		[Export ("getTimeEnumNullableArray:")]
+		NSValue [] GetTimeEnumNullableArray ([BindAs (typeof (CMTime? []))] NSValue [] arg1);
+
+		[BindAs (typeof (CAScroll))]
+		[Export ("scrollFooEnum")]
+		NSString ScrollFooEnum { get; set; }
+
+		[BindAs (typeof (CAScroll?))]
+		[Export ("scrollFooEnum2")]
+		NSString ScrollFooEnum2 { get; set; }
+
+		[return: BindAs (typeof (CAScroll))]
+		[Export ("getScrollEnum3:arg2:")]
+		NSString GetScrollEnum ([BindAs (typeof (CAScroll))] NSString arg1, [BindAs (typeof (CAScroll?))] NSString arg2);
 	}
 }

--- a/tests/generator/bindastests.cs
+++ b/tests/generator/bindastests.cs
@@ -119,5 +119,17 @@ namespace BindAsTests {
 		[return: BindAs (typeof (CAScroll))]
 		[Export ("getScrollEnum3:arg2:")]
 		NSString GetScrollEnum ([BindAs (typeof (CAScroll))] NSString arg1, [BindAs (typeof (CAScroll?))] NSString arg2);
+
+		[BindAs (typeof (CAScroll))]
+		[Export ("scrollEnum")]
+		NSNumber ScrollEnum2 { get; set; }
+
+		[return: BindAs (typeof (CAScroll))]
+		[Export ("getScrollEnum:")]
+		NSNumber GetScrollEnum2 ([BindAs (typeof (CAScroll))] NSNumber arg1);
+
+		[return: BindAs (typeof (CAScroll?))]
+		[Export ("getScrollEnumNullable:")]
+		NSNumber GetScrollEnumNullable2 ([BindAs (typeof (CAScroll?))] NSNumber arg1);
 	}
 }


### PR DESCRIPTION
The intent of BindAs attribute is to have a binding definition as

	[return: BindAs (typeof (bool?))]
	[Export ("boolMethod:")]
	NSNumber BoolMethod (int arg1);

and our generator outputs

	[Export ("boolMethod:")]
	public virtual global::System.Nullable<bool> BoolMethod (int arg1) { ...  }

So we internally do the NSNumber <-> bool conversion, this also
applies to parameters, properties and methods.

TODO:
- [x] Properties, Methods and Parameters support
- [x] NSNumber support
- [x] NSValue support
- [x] Smart enum/enum support
- [x] Arrays support
- [x] Tests
- [x] Documentation