### PR TITLE
[uikit] Add convenience constructors for UISegmentedControl. Fixes #33163

### DIFF
--- a/src/UIKit/UISegmentedControl.cs
+++ b/src/UIKit/UISegmentedControl.cs
@@ -24,29 +24,71 @@ using TextAttributes = XamCore.UIKit.UITextAttributes;
 
 namespace XamCore.UIKit {
 	public partial class UISegmentedControl {
-		public UISegmentedControl (object [] args) : base (NSObjectFlag.Empty)
+		public UISegmentedControl (params object [] args) : this (FromObjects (args))
+		{
+		}
+
+		static NSArray FromObjects (object[] args)
 		{
 			if (args == null)
-				throw new ArgumentNullException ("args");
+				throw new ArgumentNullException (nameof (args));
 
 			NSObject [] nsargs = new NSObject [args.Length];
 			
 			for (int i = 0; i < args.Length; i++){
 				object a = args [i];
-
 				if (a == null)
-					throw new ArgumentNullException (String.Format ("Element {0} in args is null", i));
-				
-				if (a is string)
-					nsargs [i] = new NSString ((string) a);
-				else if (a is UIImage)
-					nsargs [i] = (UIImage) a;
+					throw new ArgumentNullException ($"Element {i} in args is null");
+
+				var s = (a as string);
+				if (s != null) {
+					nsargs [i] = new NSString (s);
+					continue;
+				}
+
+				var ns = (a as NSString);
+				if (ns != null) {
+					nsargs [i] = ns;
+					continue;
+				}
+
+				var img = (a as UIImage);
+				if (img != null)
+					nsargs [i] = img;
 				else
-					throw new ArgumentException (String.Format ("non-string or UIImage at position {0} with type {1}", i, a.GetType ()));
+					throw new ArgumentException ("Non-string or UIImage at position {i} with type {a.GetType ()}");
 			}
-			using (NSArray nsa = NSArray.FromNSObjects (nsargs)){
-				Handle = InitWithItems (nsa.Handle);
-			}
+			return NSArray.FromNSObjects (nsargs);
+		}
+
+		public UISegmentedControl (params UIImage [] images) : this (FromNSObjects (images))
+		{
+		}
+
+		public UISegmentedControl (params NSString [] strings) : this (FromNSObjects (strings))
+		{
+		}
+
+		static NSArray FromNSObjects (NSObject [] items)
+		{
+			// items will never be null / empty as the callers have `params`
+			if ((items.Length == 1) && (items [0] == null))
+				throw new ArgumentNullException (nameof (items));
+
+			return NSArray.FromNSObjects (items);
+		}
+
+		public UISegmentedControl (params string [] strings) : this (FromStrings (strings))
+		{
+		}
+
+		static NSArray FromStrings (string [] strings)
+		{
+			// strings will never be null / empty as the caller has `params`
+			if ((strings.Length == 1) && (strings [0] == null))
+				throw new ArgumentNullException (nameof (strings));
+			
+			return NSArray.FromStrings (strings);
 		}
 
 		public void SetTitleTextAttributes (TextAttributes attributes, UIControlState state)

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -10098,9 +10098,8 @@ namespace XamCore.UIKit {
 	
 	[BaseType (typeof(UIControl))]
 	interface UISegmentedControl {
-		// Not exposed as we need to wrap the NSArray
-		[Export ("initWithItems:")][Internal]
-		IntPtr InitWithItems (IntPtr v);
+		[Export ("initWithItems:")]
+		IntPtr Constructor (NSArray items);
 
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);

--- a/tests/monotouch-test/UIKit/SegmentedControlTest.cs
+++ b/tests/monotouch-test/UIKit/SegmentedControlTest.cs
@@ -54,6 +54,69 @@ namespace MonoTouchFixtures.UIKit {
 			// ref: https://bugzilla.xamarin.com/show_bug.cgi?id=13286
 			UISegmentedControl.Appearance.TintColor = UIColor.Blue;
 		}
+
+		[Test]
+		public void CtorObjects ()
+		{
+			Assert.Throws<ArgumentNullException> (() => new UISegmentedControl ((object []) null), "null");
+			Assert.Throws<ArgumentNullException> (() => new UISegmentedControl ((object []) new [] { String.Empty, null }), "null element");
+			Assert.Throws<ArgumentException> (() => new UISegmentedControl ((object []) new [] { NSZone.Default }), "invalid type");
+
+			using (var ns = new NSString ("NSString"))
+			using (var img = UIImage.FromFile ("basn3p08.png"))
+			using (UISegmentedControl sc = new UISegmentedControl ("string", ns, img)) {
+				Assert.That (sc.NumberOfSegments, Is.EqualTo (3), "NumberOfSegments");
+			}
+		}
+
+		[Test]
+		public void CtorNSArray ()
+		{
+			Assert.Throws<ArgumentNullException> (() => new UISegmentedControl ((NSArray) null), "null");
+
+			using (UISegmentedControl sc = new UISegmentedControl (new NSArray ())) {
+				Assert.That(sc.NumberOfSegments, Is.EqualTo (0), "Empty");
+			}
+
+			using (var ns = new NSString ("NSString"))
+			using (var img = UIImage.FromFile ("basn3p08.png"))
+			using (var a = NSArray.FromObjects ("string", ns, img))
+			using (UISegmentedControl sc = new UISegmentedControl (a)) {
+				Assert.That (sc.NumberOfSegments, Is.EqualTo (3), "NumberOfSegments");
+			}
+		}
+
+		[Test]
+		public void CtorNSString ()
+		{
+			Assert.Throws<ArgumentNullException> (() => new UISegmentedControl ((NSString) null), "null");
+
+			using (var ns = new NSString ("NSString"))
+			using (UISegmentedControl sc = new UISegmentedControl (ns)) {
+				Assert.That (sc.NumberOfSegments, Is.EqualTo (1), "NumberOfSegments");
+			}
+		}
+
+		[Test]
+		public void CtorString ()
+		{
+			Assert.Throws<ArgumentNullException> (() => new UISegmentedControl ((string) null), "null");
+
+			using (UISegmentedControl sc = new UISegmentedControl ("one", "two")) {
+				Assert.That (sc.NumberOfSegments, Is.EqualTo (2), "NumberOfSegments");
+			}
+		}
+
+		[Test]
+		public void CtorUIImage ()
+		{
+			Assert.Throws<ArgumentNullException> (() => new UISegmentedControl ((UIImage) null), "null");
+
+			using (var img = UIImage.FromFile ("basn3p08.png"))
+			using (UISegmentedControl sc = new UISegmentedControl (img)) {
+				Assert.That (sc.NumberOfSegments, Is.EqualTo (1), "NumberOfSegments");
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
* Existing `.ctor(object[])` now
    * changed to `params` (not a breaking change);
    * accept `NSString`, along with `string` and `UIImage`;
* Added `.ctor (NSArray)` (exposing the generated code to ease subclassing)
* Added `.ctor (params NSString[])`
* Added `.ctor (params string[])`
* Added `.ctor (params UIImage[])`

Also adds unit tests for all of them.

https://bugzilla.xamarin.com/show_bug.cgi?id=33163