### PR TITLE
[cecil] Bump mono to get the latest Cecil's revision. Fixes #51336

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -847,7 +847,7 @@ namespace XamCore.Registrar {
 			}
 
 			if (corlib == null) {
-				corlib = first.MainModule.AssemblyResolver.Resolve ("mscorlib");
+				corlib = first.MainModule.AssemblyResolver.Resolve (AssemblyNameReference.Parse ("mscorlib"));
 			}
 			foreach (var type in corlib.MainModule.Types) {
 				if (type.Namespace == "System" && type.Name == "Void")

--- a/tools/mtouch/AssemblyResolver.cs
+++ b/tools/mtouch/AssemblyResolver.cs
@@ -37,6 +37,20 @@ namespace MonoTouch.Tuner {
 		}
 	}
 
+	// recent cecil removed some overloads - https://github.com/mono/cecil/commit/42db79cc16f1cbe8dbab558904e188352dba2b41
+	public static class AssemblyResolverRocks {
+
+		static ReaderParameters defaults = new ReaderParameters ();
+
+		public static AssemblyDefinition Resolve (this IAssemblyResolver self, string fullName)
+		{
+			if (fullName == null)
+				throw new ArgumentNullException (nameof (fullName));
+			
+			return self.Resolve (AssemblyNameReference.Parse (fullName), defaults);
+		}
+	}
+
 	public class MonoTouchResolver : IAssemblyResolver {
 
 		public string FrameworkDirectory { get; set; }


### PR DESCRIPTION
This includes [1] which fix the parsing of broken .mdb as seen in [2]

Also fix mtouch's resolver and the static registrar to match some Cecil
API changes.

references:
[1] https://github.com/jbevain/cecil/commit/045b0f9729905dd456d46e33436a2dadc9e2a52d
[2] https://bugzilla.xamarin.com/show_bug.cgi?id=51336