### PR TITLE
[uikit] Cover null arrays in new UISegmentedControl.ctor

### DIFF
--- a/src/UIKit/UISegmentedControl.cs
+++ b/src/UIKit/UISegmentedControl.cs
@@ -71,8 +71,9 @@ namespace XamCore.UIKit {
 
 		static NSArray FromNSObjects (NSObject [] items)
 		{
-			// items will never be null / empty as the callers have `params`
-			if ((items.Length == 1) && (items [0] == null))
+			// if the caller used an array [] then items can be null
+			// if the caller used only null then we get an array with a null item
+			if ((items == null) || ((items.Length == 1) && (items [0] == null)))
 				throw new ArgumentNullException (nameof (items));
 
 			return NSArray.FromNSObjects (items);
@@ -84,8 +85,9 @@ namespace XamCore.UIKit {
 
 		static NSArray FromStrings (string [] strings)
 		{
-			// strings will never be null / empty as the caller has `params`
-			if ((strings.Length == 1) && (strings [0] == null))
+			// if the caller used an array [] then items can be null
+			// if the caller used only null then we get an array with a null item
+			if ((strings == null) || ((strings.Length == 1) && (strings[0] == null)))
 				throw new ArgumentNullException (nameof (strings));
 			
 			return NSArray.FromStrings (strings);

--- a/tests/monotouch-test/UIKit/SegmentedControlTest.cs
+++ b/tests/monotouch-test/UIKit/SegmentedControlTest.cs
@@ -90,6 +90,7 @@ namespace MonoTouchFixtures.UIKit {
 		public void CtorNSString ()
 		{
 			Assert.Throws<ArgumentNullException> (() => new UISegmentedControl ((NSString) null), "null");
+			Assert.Throws<ArgumentNullException> (() => new UISegmentedControl ((NSString[]) null), "null array");
 
 			using (var ns = new NSString ("NSString"))
 			using (UISegmentedControl sc = new UISegmentedControl (ns)) {
@@ -101,6 +102,7 @@ namespace MonoTouchFixtures.UIKit {
 		public void CtorString ()
 		{
 			Assert.Throws<ArgumentNullException> (() => new UISegmentedControl ((string) null), "null");
+			Assert.Throws<ArgumentNullException> (() => new UISegmentedControl ((string[]) null), "null array");
 
 			using (UISegmentedControl sc = new UISegmentedControl ("one", "two")) {
 				Assert.That (sc.NumberOfSegments, Is.EqualTo (2), "NumberOfSegments");
@@ -111,6 +113,7 @@ namespace MonoTouchFixtures.UIKit {
 		public void CtorUIImage ()
 		{
 			Assert.Throws<ArgumentNullException> (() => new UISegmentedControl ((UIImage) null), "null");
+			Assert.Throws<ArgumentNullException> (() => new UISegmentedControl ((UIImage[]) null), "null array");
 
 			using (var img = UIImage.FromFile ("basn3p08.png"))
 			using (UISegmentedControl sc = new UISegmentedControl (img)) {


### PR DESCRIPTION
Follow up to PR1477 [1] to cover case [2] for bug #33163 [3]

[1] https://github.com/xamarin/xamarin-macios/pull/1477
[2] https://github.com/xamarin/xamarin-macios/pull/1477#pullrequestreview-16295268
[3] https://bugzilla.xamarin.com/show_bug.cgi?id=33163