### PR TITLE
[src] Make project templates MSBuild-compatible.

### DIFF
--- a/src/MonoTouch.Dialog-1.templ.csproj
+++ b/src/MonoTouch.Dialog-1.templ.csproj
@@ -13,46 +13,33 @@
     <UseMSBuildEngine>True</UseMSBuildEngine>
     <DefineConstants>XAMCORE_2_0</DefineConstants>
     <OutputPath>build\ios\reference</OutputPath>
+    <IntermediateOutputPath>$(OutputPath)</IntermediateOutputPath>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\product.snk</AssemblyOriginatorKeyFile>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Debug32' Or '$(Configuration)' == 'Debug64' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>build\ios\reference</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentation>True</GenerateDocumentation>
-    <NoWarn>3021,3014,3003</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' Or '$(Configuration)' == 'Release32' Or '$(Configuration)' == 'Release64' Or '$(Configuration)' == 'Release-bitcode'  ">
     <DebugType>none</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>build\ios\reference</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-bitcode|AnyCPU' ">
-    <DebugType>none</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>build\ios\reference</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Xamarin.iOS" />
     <Reference Include="System" />
     <Reference Include="System.Xml" />
-  </ItemGroup>
-  <PropertyGroup>
-    <CscToolExe>$(MSBuildProjectDirectory)\custom-make.sh</CscToolExe>
-  </PropertyGroup>
-  <ItemGroup>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Json" />
   </ItemGroup>
   <ItemGroup>
     <!--%FILES%-->

--- a/src/MonoTouch.Dialog-1.tvos.templ.csproj
+++ b/src/MonoTouch.Dialog-1.tvos.templ.csproj
@@ -5,7 +5,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{48585BC2-D604-4CF2-A827-D887BEA51FD6}</ProjectGuid>
+    <ProjectGuid>{114214A5-A95C-456A-85BA-1B3F23B7AA0C}</ProjectGuid>
     <ProjectTypeGuids>{06FA79CB-D6CD-4721-BB4B-1BD202089C55};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace></RootNamespace>
@@ -13,46 +13,33 @@
     <UseMSBuildEngine>True</UseMSBuildEngine>
     <DefineConstants>XAMCORE_2_0;XAMCORE_3_0</DefineConstants>
     <OutputPath>build\tvos\reference</OutputPath>
+    <IntermediateOutputPath>$(OutputPath)</IntermediateOutputPath>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\product.snk</AssemblyOriginatorKeyFile>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Debug32' Or '$(Configuration)' == 'Debug64' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>build\tvos\reference</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentation>True</GenerateDocumentation>
-    <NoWarn>3021,3014,3003</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' Or '$(Configuration)' == 'Release32' Or '$(Configuration)' == 'Release64' Or '$(Configuration)' == 'Release-bitcode'  ">
     <DebugType>none</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>build\tvos\reference</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-bitcode|AnyCPU' ">
-    <DebugType>none</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>build\tvos\reference</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Xamarin.TVOS" />
     <Reference Include="System" />
     <Reference Include="System.Xml" />
-  </ItemGroup>
-  <PropertyGroup>
-    <CscToolExe>$(MSBuildProjectDirectory)\custom-make.sh</CscToolExe>
-  </PropertyGroup>
-  <ItemGroup>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Json" />
   </ItemGroup>
   <ItemGroup>
     <!--%FILES%-->

--- a/src/MonoTouch.NUnitLite.templ.csproj
+++ b/src/MonoTouch.NUnitLite.templ.csproj
@@ -11,49 +11,37 @@
     <RootNamespace></RootNamespace>
     <AssemblyName>MonoTouch.NUnitLite</AssemblyName>
     <UseMSBuildEngine>True</UseMSBuildEngine>
-    <DefineConstants>XAMCORE_2_0</DefineConstants>
+    <DefineConstants>NUNITLITE;CLR_4_0;NET_4_5;XAMCORE_2_0;MONOTOUCH</DefineConstants>
     <OutputPath>build\ios\reference</OutputPath>
+    <IntermediateOutputPath>$(OutputPath)</IntermediateOutputPath>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\product.snk</AssemblyOriginatorKeyFile>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Debug32' Or '$(Configuration)' == 'Debug64' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>build\ios\reference</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentation>True</GenerateDocumentation>
-    <NoWarn>3021,3014,3003</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' Or '$(Configuration)' == 'Release32' Or '$(Configuration)' == 'Release64' Or '$(Configuration)' == 'Release-bitcode'  ">
     <DebugType>none</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>build\ios\reference</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-bitcode|AnyCPU' ">
-    <DebugType>none</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>build\ios\reference</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Xamarin.iOS" />
     <Reference Include="System" />
     <Reference Include="System.Xml" />
-    <Reference Include="MonoTouch.Dialog-1" />
-  </ItemGroup>
-  <PropertyGroup>
-    <CscToolExe>$(MSBuildProjectDirectory)\custom-make.sh</CscToolExe>
-  </PropertyGroup>
-  <ItemGroup>
+    <ProjectReference Include="MonoTouch.Dialog-1.csproj">
+      <Project>{48585BC2-D604-4CF2-A827-D887BEA51FD6}</Project>
+      <Name>MonoTouch.Dialog-1</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <!--%FILES%-->

--- a/src/MonoTouch.NUnitLite.tvos.templ.csproj
+++ b/src/MonoTouch.NUnitLite.tvos.templ.csproj
@@ -11,36 +11,27 @@
     <RootNamespace></RootNamespace>
     <AssemblyName>MonoTouch.NUnitLite</AssemblyName>
     <UseMSBuildEngine>True</UseMSBuildEngine>
+    <DefineConstants>NUNITLITE;CLR_4_0;NET_4_5;XAMCORE_2_0;XAMCORE_3_0;MONOTOUCH</DefineConstants>
     <OutputPath>build\tvos\reference</OutputPath>
+    <IntermediateOutputPath>$(OutputPath)</IntermediateOutputPath>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\product.snk</AssemblyOriginatorKeyFile>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Debug32' Or '$(Configuration)' == 'Debug64' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>build\tvos\reference</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentation>True</GenerateDocumentation>
-    <NoWarn>3021,3014,3003</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' Or '$(Configuration)' == 'Release32' Or '$(Configuration)' == 'Release64' Or '$(Configuration)' == 'Release-bitcode'  ">
     <DebugType>none</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>build\tvos\reference</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-bitcode|AnyCPU' ">
-    <DebugType>none</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>build\tvos\reference</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
@@ -48,14 +39,9 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <ProjectReference Include="MonoTouch.Dialog-1.tvos.csproj">
-      <Project>{48585BC2-D604-4CF2-A827-D887BEA51FD6}</Project>
+      <Project>{114214A5-A95C-456A-85BA-1B3F23B7AA0C}</Project>
       <Name>MonoTouch.Dialog-1</Name>
     </ProjectReference>
-  </ItemGroup>
-  <PropertyGroup>
-    <CscToolExe>$(MSBuildProjectDirectory)\custom-make.sh</CscToolExe>
-  </PropertyGroup>
-  <ItemGroup>
   </ItemGroup>
   <ItemGroup>
     <!--%FILES%-->

--- a/src/MonoTouch.NUnitLite.watchos.templ.csproj
+++ b/src/MonoTouch.NUnitLite.watchos.templ.csproj
@@ -11,48 +11,33 @@
     <RootNamespace></RootNamespace>
     <AssemblyName>MonoTouch.NUnitLite</AssemblyName>
     <UseMSBuildEngine>True</UseMSBuildEngine>
-    <DefineConstants>XAMCORE_2_0;__UNIFIED__;__WATCHOS__</DefineConstants>
+    <DefineConstants>NUNITLITE;CLR_4_0;NET_4_5;XAMCORE_2_0;XAMCORE_3_0;MONOTOUCH</DefineConstants>
     <OutputPath>build\watch\reference</OutputPath>
+    <IntermediateOutputPath>$(OutputPath)</IntermediateOutputPath>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\product.snk</AssemblyOriginatorKeyFile>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Debug32' Or '$(Configuration)' == 'Debug64' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>build\watch\reference</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentation>True</GenerateDocumentation>
-    <NoWarn>3021,3014,3003</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' Or '$(Configuration)' == 'Release32' Or '$(Configuration)' == 'Release64' Or '$(Configuration)' == 'Release-bitcode'  ">
     <DebugType>none</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>build\watch\reference</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-bitcode|AnyCPU' ">
-    <DebugType>none</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>build\watch\reference</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Xamarin.WatchOS" />
     <Reference Include="System" />
     <Reference Include="System.Xml" />
-  </ItemGroup>
-  <PropertyGroup>
-    <CscToolExe>$(MSBuildProjectDirectory)\custom-make.sh</CscToolExe>
-  </PropertyGroup>
-  <ItemGroup>
   </ItemGroup>
   <ItemGroup>
     <!--%FILES%-->

--- a/src/xamios.tmpl.csproj
+++ b/src/xamios.tmpl.csproj
@@ -10,6 +10,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>monotouch</RootNamespace>
     <AssemblyName>monotouch</AssemblyName>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/xammac.tmpl.csproj
+++ b/src/xammac.tmpl.csproj
@@ -7,6 +7,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>src</RootNamespace>
     <AssemblyName>src</AssemblyName>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/xamtvos.tmpl.csproj
+++ b/src/xamtvos.tmpl.csproj
@@ -10,6 +10,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>xamtvos</RootNamespace>
     <AssemblyName>xamtvos</AssemblyName>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/xamwatch.tmpl.csproj
+++ b/src/xamwatch.tmpl.csproj
@@ -10,6 +10,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>xamwatch</RootNamespace>
     <AssemblyName>xamwatch</AssemblyName>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
MSBuild wants to copy from IntermediateOutputPath to OutputPath, even if the
assembly doesn't exist in IntermediateOutputPath (and it already exists in
OutputPath). So just set IntermediateOutputPath=OutputPath, which seems to
work fine.

Also make these project files build correctly without custom scripts (custom-
make.sh), since that makes it easier to transform these project files in
xharness (copy them to a different directory).

This is a partial backport of PR #1444 to fix bug #51482.

https://bugzilla.xamarin.com/show_bug.cgi?id=51482