### PR TITLE
[xharness] Fix log stream handling.

### DIFF
--- a/tests/xharness/Log.cs
+++ b/tests/xharness/Log.cs
@@ -29,7 +29,7 @@ namespace xharness
 			throw new NotSupportedException ();
 		}
 
-		public virtual TextWriter GetWriter ()
+		public virtual StreamWriter GetWriter ()
 		{
 			throw new NotSupportedException ();
 		}
@@ -72,22 +72,18 @@ namespace xharness
 		public string Path;
 		StreamWriter writer;
 
-		public LogFile (string description, string path)
+		public LogFile (string description, string path, bool append = true)
 			: base (description)
 		{
 			Path = path;
+
+			writer = new StreamWriter (new FileStream (Path, append ? FileMode.Append : FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read));
+			writer.AutoFlush = true;
 		}
 
 		protected override void WriteImpl (string value)
 		{
-			lock (this) {
-				using (var str = new FileStream (Path, FileMode.Append, FileAccess.Write, FileShare.Read)) {
-					using (var writer = new StreamWriter (str)) {
-						writer.Write (value);
-						writer.Flush ();
-					}
-				}
-			}
+			writer.Write (value);
 		}
 
 		public override string FullPath {
@@ -101,9 +97,9 @@ namespace xharness
 			return new StreamReader (new FileStream (Path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
 		}
 
-		public override TextWriter GetWriter ()
+		public override StreamWriter GetWriter ()
 		{
-			return writer ?? (writer = new StreamWriter (new FileStream (Path, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read)));
+			return writer;
 		}
 
 		protected override void Dispose (bool disposing)
@@ -134,9 +130,9 @@ namespace xharness
 			return new StreamReader (new FileStream (path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
 		}
 
-		public override TextWriter GetWriter ()
+		public override StreamWriter GetWriter ()
 		{
-			return writer ?? (writer = new StreamWriter (fs));
+			return writer ?? (writer = new StreamWriter (fs) { AutoFlush = true });
 		}
 
 		public LogStream (string description, string path)
@@ -210,9 +206,9 @@ namespace xharness
 			}
 		}
 
-		public override TextWriter GetWriter ()
+		public override StreamWriter GetWriter ()
 		{
-			return Console.Out;
+			return new StreamWriter (Console.OpenStandardOutput ());
 		}
 
 		public override StreamReader GetReader ()

--- a/tests/xharness/SimpleHttpListener.cs
+++ b/tests/xharness/SimpleHttpListener.cs
@@ -85,10 +85,8 @@ namespace xharness
 				break;
 			case "/Finish":
 				if (!finished) {
-					using (var writer = new StreamWriter (OutputStream)) {
-						writer.Write (data);
-						writer.Flush ();
-					}
+					OutputWriter.Write (data);
+					OutputWriter.Flush ();
 					finished = true;
 				}
 				break;

--- a/tests/xharness/SimpleTcpListener.cs
+++ b/tests/xharness/SimpleTcpListener.cs
@@ -53,11 +53,11 @@ namespace xharness
 		bool Processing (TcpClient client)
 		{
 			Connected (client.Client.RemoteEndPoint.ToString ());
-			FileStream fs = OutputStream;
 			// now simply copy what we receive
 			int i;
 			int total = 0;
 			NetworkStream stream = client.GetStream ();
+			var fs = OutputWriter.BaseStream;
 			while ((i = stream.Read (buffer, 0, buffer.Length)) != 0) {
 				fs.Write (buffer, 0, i);
 				fs.Flush ();
@@ -69,7 +69,6 @@ namespace xharness
 				// the ip address we're reachable on.
 				return false;
 			}
-			fs.Flush ();
 			return true;
 		}
 	}


### PR DESCRIPTION
Don't create multiple writer streams for the same underlying file, instead
store the writer stream on the log instance, and return it whenever needed.

This fixes an issue where there would be multiple writer streams, which could
cause exceptions when creating more writer streams (access defined errors
because the file is already open).