### PR TITLE
[bmac] Parse --new-style again.

### DIFF
--- a/src/bmac
+++ b/src/bmac
@@ -15,6 +15,7 @@ fi
 
 ROOT_DIR=$BMAC_DIR/..
 
+btouch_arguments=()
 for arg in "$@"; do
 	if [[ $sdk == next-arg ]]; then
 		sdk=$arg
@@ -23,6 +24,10 @@ for arg in "$@"; do
 		if [[ $sdk == $arg ]]; then
 			sdk=next-arg
 		fi
+	elif [[ $arg =~ ^(/|-{1,2})new-style$ ]]; then
+		new_style=1
+		mobile_profile=1
+		continue
 	elif [[ $arg =~ ^(/|-{1,2})unified-full-profile$ ]]; then
 		full_profile=1
 		new_style=1
@@ -30,6 +35,7 @@ for arg in "$@"; do
 		mobile_profile=1
 		new_style=1
 	fi
+	btouch_arguments+=("${arg}")
 done
 
 sdk=$(echo $sdk | tr '[:upper:]' '[:lower:]')
@@ -60,4 +66,4 @@ mobile|xamarin.mac|xammac)
 	;;
 esac
 
-$mono $MONO_OPTIONS $ROOT_DIR/lib/bmac/$bmac $refs "$@"
+$mono $MONO_OPTIONS $ROOT_DIR/lib/bmac/$bmac $refs "${btouch_arguments[@]}"


### PR DESCRIPTION
This was changed in 1b1e345d7259 since bmac.exe says --new-style is
deprecated.

However some users (MonoTouch.Hosting) manually call bmac (instead of going
through a binding project), and with 1b1e345d7259 we changed the behavior when
--new-style was passed, so that it ended up trying to build Classic instead
(which is clearly not right for --new-style).

So make the bmac script understand --new-style again (to not break
compatibility), but don't forward the flag to bmac.exe (to avoid the
deprecation warning).