### PR TITLE
[xharness] Add support for using the system's Xamarin.iOS/Xamarin.Mac instead of a locally build one.

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -28,6 +28,7 @@ Info-*.plist
 Makefile.inc
 *.stamp
 test.config
+test-system.config
 mac-test-package
 .nuget
 logs

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -68,6 +68,15 @@ test.config: Makefile $(TOP)/Make.config
 	@echo "JENKINS_RESULTS_DIRECTORY=$(abspath $(JENKINS_RESULTS_DIRECTORY))" >> $@
 	@echo "INCLUDE_DEVICE=$(INCLUDE_DEVICE)" >> $@
 
+test-system.config:
+	@rm -f $@
+	@echo "MONOTOUCH_PREFIX=$(IOS_FRAMEWORK_DIR)/Versions/Current" >> $@
+	@echo "IOS_DESTDIR=/" >> $@
+	@echo "MAC_DESTDIR=/" >> $@
+	@echo "WATCH_MONO_PATH=$(abspath $(WATCH_MONO_PATH))" >> $@
+	@echo "JENKINS_RESULTS_DIRECTORY=$(abspath $(JENKINS_RESULTS_DIRECTORY))" >> $@
+	@echo "INCLUDE_DEVICE=$(INCLUDE_DEVICE)" >> $@
+
 clean-local::
 	$(Q) $(SYSTEM_XBUILD) /t:Clean /p:Platform=iPhoneSimulator /p:Configuration=$(CONFIG) $(XBUILD_VERBOSITY) tests.sln
 	$(Q) $(SYSTEM_XBUILD) /t:Clean /p:Platform=iPhone /p:Configuration=$(CONFIG) $(XBUILD_VERBOSITY) tests.sln
@@ -160,7 +169,7 @@ $(TOP)/tools/mtouch/SdkVersions.cs: $(TOP)/tools/mtouch/SdkVersions.cs.in
 	@$(MAKE) -C $(TOP)/src project-files
 	@touch $@
 
-xharness/xharness.exe: $(wildcard xharness/*.cs) xharness/xharness.csproj $(TOP)/tools/mtouch/SdkVersions.cs test.config .stamp-src-project-files
+xharness/xharness.exe: $(wildcard xharness/*.cs) xharness/xharness.csproj $(TOP)/tools/mtouch/SdkVersions.cs test.config test-system.config .stamp-src-project-files
 	$(Q_GEN) $(SYSTEM_XBUILD) $(XBUILD_VERBOSITY_QUIET) xharness/xharness.csproj
 
 killall:

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -217,15 +217,27 @@ namespace Xamarin.Tests
 			}
 		}
 
+		public static string TargetDirectoryXI {
+			get {
+				return make_config ["IOS_DESTDIR"];
+			}
+		}
+
+		public static string TargetDirectoryXM {
+			get {
+				return make_config ["MAC_DESTDIR"];
+			}
+		}
+
 		public static string BinDirXI {
 			get {
-				return Path.Combine (RootPath, "_ios-build", "Library", "Frameworks", "Xamarin.iOS.framework", "Versions", "Current", "bin");
+				return Path.Combine (TargetDirectoryXI, "Library", "Frameworks", "Xamarin.iOS.framework", "Versions", "Current", "bin");
 			}
 		}
 
 		public static string BinDirXM {
 			get {
-				return Path.Combine (RootPath, "_mac-build", "Library", "Frameworks", "Xamarin.Mac.framework", "Versions", "Current", "bin");
+				return Path.Combine (TargetDirectoryXM, "Library", "Frameworks", "Xamarin.Mac.framework", "Versions", "Current", "bin");
 			}
 		}
 

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -25,6 +25,7 @@ namespace xharness
 		public HarnessAction Action { get; set; }
 		public int Verbosity { get; set; }
 		public Log HarnessLog { get; set; }
+		public bool UseSystem { get; set; } // if the system XI/XM should be used, or the locally build XI/XM.
 
 		// This is the maccore/tests directory.
 		string root_directory;
@@ -313,7 +314,7 @@ namespace xharness
 
 		void ParseConfigFiles ()
 		{
-			ParseConfigFiles (FindConfigFiles ("test.config"));
+			ParseConfigFiles (FindConfigFiles (UseSystem ? "test-system.config" : "test.config"));
 			ParseConfigFiles (FindConfigFiles ("Make.config.local"));
 			ParseConfigFiles (FindConfigFiles ("Make.config"));
 		}

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -30,8 +30,21 @@ namespace xharness
 		string root_directory;
 		public string RootDirectory {
 			get {
-				if (root_directory == null)
-					root_directory = Environment.CurrentDirectory;
+				if (root_directory == null) {
+					var testAssemblyDirectory = Path.GetDirectoryName (System.Reflection.Assembly.GetExecutingAssembly ().Location);
+					var dir = testAssemblyDirectory;
+					var path = Path.Combine (testAssemblyDirectory, ".git");
+					while (!Directory.Exists (path) && path.Length > 3) {
+						dir = Path.GetDirectoryName (dir);
+						path = Path.Combine (dir, ".git");
+					}
+					if (!Directory.Exists (path))
+						throw new Exception ("Could not find the xamarin-macios repo.");
+					path = Path.Combine (Path.GetDirectoryName (path), "tests");
+					if (!Directory.Exists (path))
+						throw new Exception ("Could not find the tests directory.");
+					root_directory = path;
+				}
 				return root_directory;
 			}
 			set {

--- a/tests/xharness/Program.cs
+++ b/tests/xharness/Program.cs
@@ -14,6 +14,7 @@ namespace xharness
 			var os = new OptionSet () {
 				{ "h|?|help", "Displays the help", (v) => showHelp () },
 				{ "v|verbose", "Show verbose output", (v) => harness.Verbosity++ },
+				{ "use-system:", "Use the system version of Xamarin.iOS/Xamarin.Mac or the locally build version. Default: the locally build version.", (v) => harness.UseSystem = v == "1" || v == "true" || string.IsNullOrEmpty (v) },
 				// Configure
 				{ "mac", "Configure for Xamarin.Mac instead of iOS.", (v) => harness.Mac = true },
 				{ "configure", "Creates project files and makefiles.", (v) => harness.Action = HarnessAction.Configure },


### PR DESCRIPTION
Tests run on our QA bots might want to run using the system version instead of
building their own.