### PR TITLE
[msbuild] Fixed logic to properly codesign *.appex's inside watch apps

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -303,15 +303,20 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<_CodesignAppBundleDependsOn>
 			_EmbedMobileProvision;
 			_CodesignNativeLibraries;
+			_CollectFrameworks;
 			_CodesignFrameworks;
+			_ReadAppExtensionCodesignProperties;
 			_CodesignAppExtensions;
+			_PrepareCodesignAppBundle;
 		</_CodesignAppBundleDependsOn>
 
 		<_CoreCodesignDependsOn>
 			_CodesignNativeLibraries;
 			_CollectFrameworks;
 			_CodesignFrameworks;
+			_ReadAppExtensionCodesignProperties;
 			_CodesignAppExtensions;
+			_PrepareCodesignAppBundle;
 			_CodesignAppBundle;
 			_CodesignVerify;
 		</_CoreCodesignDependsOn>
@@ -1745,7 +1750,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		/>
 	</Target>
 
-	<Target Name="_CodesignAppBundle" Condition="'$(_RequireCodeSigning)' == 'true' And '$(IsAppExtension)' == 'false'" DependsOnTargets="$(_CodesignAppBundleDependsOn);_PrepareCodesignAppBundle"
+	<Target Name="_CodesignAppBundle" Condition="'$(_RequireCodeSigning)' == 'true' And '$(IsAppExtension)' == 'false'" DependsOnTargets="$(_CodesignAppBundleDependsOn)"
 		Inputs="$(_NativeExecutable);$(_AppBundlePath)Info.plist;$(_AppBundlePath)embedded.mobileprovision;$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent;@(_BundleResourceWithLogicalName);@(_NativeLibrary);@(_Frameworks)"
 		Outputs="$(DeviceSpecificIntermediateOutputPath)codesign\$(_AppBundleName)$(AppBundleExtension)">
 		<Codesign
@@ -1785,11 +1790,11 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CodesignVerify" Condition="'$(_RequireCodeSigning)' == 'true' And '$(IsAppExtension)' == 'false'" DependsOnTargets="_CodesignAppBundle">
 		<CodesignVerify
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true' And '@(_AppExtensionCodesignProperties)' != ''"
+			Condition="'$(IsMacEnabled)' == 'true' And '@(_ResolvedAppExtensionReferences)' != ''"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
 			CodesignAllocate="$(_CodesignAllocate)"
-			Resource="$(_AppBundlePath)PlugIns\%(_AppExtensionCodesignProperties.Identity)"
+			Resource="$(_AppBundlePath)PlugIns\%(_ResolvedAppExtensionReferences.Filename)%(_ResolvedAppExtensionReferences.Extension)"
 		>
 		</CodesignVerify>
 


### PR DESCRIPTION
Several dependency targets were not being properly run because the Condition
expressions on e.g. the _CodesignAppExtensions target depended on variables
that were empty until the dependencies set them. But dependencies are only
executed if the parent target's Conditions were met.

Also changed the _CodesignVerify target to use the _ResolvedAppExtensions
variable instead of the _AppExtensionCodesignProperties variable. This means
that the _CodesignVerify target no longer depends on the
_ReadCodesignAppExtensionProperties target being executed and thus makes it
less likely that bugs like that will slip by in the future.