### PR TITLE
Resource files for mac should be copied to the app bundle

### DIFF
--- a/tests/EmbeddedResources/ResourcesTest.cs
+++ b/tests/EmbeddedResources/ResourcesTest.cs
@@ -34,6 +34,7 @@ namespace EmbeddedResources {
 			var manager = new ResourceManager ("xammac_tests.EmbeddedResources.Welcome", typeof (ResourcesTest).Assembly);
 #else
 			var manager = new ResourceManager ("EmbeddedResources.Welcome", typeof(ResourcesTest).Assembly);
+#endif
 
 			Assert.AreEqual ("Welcome", manager.GetString ("String1", new CultureInfo ("en")), "en");
 			Assert.AreEqual ("G'day", manager.GetString ("String1", new CultureInfo ("en-AU")), "en-AU");

--- a/tests/EmbeddedResources/ResourcesTest.cs
+++ b/tests/EmbeddedResources/ResourcesTest.cs
@@ -30,8 +30,11 @@ namespace EmbeddedResources {
 		[Test]
 		public void Embedded ()
 		{
-			var manager = new ResourceManager ("xammac_tests.EmbeddedResources.Welcome", typeof(ResourcesTest).Assembly);
-			
+#if MONOMAC
+			var manager = new ResourceManager ("xammac_tests.EmbeddedResources.Welcome", typeof (ResourcesTest).Assembly);
+#else
+			var manager = new ResourceManager ("EmbeddedResources.Welcome", typeof(ResourcesTest).Assembly);
+
 			Assert.AreEqual ("Welcome", manager.GetString ("String1", new CultureInfo ("en")), "en");
 			Assert.AreEqual ("G'day", manager.GetString ("String1", new CultureInfo ("en-AU")), "en-AU");
 			Assert.AreEqual ("Willkommen", manager.GetString ("String1", new CultureInfo ("de")), "de");

--- a/tests/EmbeddedResources/ResourcesTest.cs
+++ b/tests/EmbeddedResources/ResourcesTest.cs
@@ -30,7 +30,7 @@ namespace EmbeddedResources {
 		[Test]
 		public void Embedded ()
 		{
-			var manager = new ResourceManager ("EmbeddedResources.Welcome", typeof(ResourcesTest).Assembly);
+			var manager = new ResourceManager ("xammac_tests.EmbeddedResources.Welcome", typeof(ResourcesTest).Assembly);
 			
 			Assert.AreEqual ("Welcome", manager.GetString ("String1", new CultureInfo ("en")), "en");
 			Assert.AreEqual ("G'day", manager.GetString ("String1", new CultureInfo ("en-AU")), "en-AU");

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -55,9 +55,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="GuiUnit">
-      <HintPath>..\..\external\guiunit\bin\net_4_5\GuiUnit.exe</HintPath>
-    </Reference>
     <Reference Include="Xamarin.Mac">
       <HintPath>..\..\_mac-build\Library\Frameworks\Xamarin.Mac.framework\Versions\git\lib\reference\mobile\Xamarin.Mac.dll</HintPath>
     </Reference>
@@ -1046,6 +1043,9 @@
     <Compile Include="..\monotouch-test\NativeTypesTest.cs">
       <Link>NativeTypesTest.cs</Link>
     </Compile>
+    <Compile Include="..\EmbeddedResources\ResourcesTest.cs">
+      <Link>EmbeddedResources\ResourcesTest.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />
@@ -1097,6 +1097,27 @@
     <EmbeddedResource Include="..\monotouch-test\Security\openssl_crt.der">
       <Link>Security\openssl_crt.der</Link>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\EmbeddedResources\Welcome.resx">
+      <Link>EmbeddedResources\Welcome.resx</Link>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\EmbeddedResources\Welcome.de.resx">
+      <Link>EmbeddedResources\Welcome.de.resx</Link>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\EmbeddedResources\Welcome.en-AU.resx">
+      <Link>EmbeddedResources\Welcome.en-AU.resx</Link>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\EmbeddedResources\Welcome.es.resx">
+      <Link>EmbeddedResources\Welcome.es.resx</Link>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="EmbeddedResources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\external\guiunit\src\framework\GuiUnit_xammac_mobile.csproj">
+      <Project>{EACFD119-769E-4E6C-89B7-A6CE3757C431}</Project>
+      <Name>GuiUnit_xammac_mobile</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -416,5 +416,52 @@ namespace Xamarin.Bundler {
 					yield return satellite;
 			}
 		}
+
+		public void ComputeSatellites ()
+		{
+			var path = Path.GetDirectoryName (FullPath);
+			var satellite_name = Path.GetFileNameWithoutExtension (FullPath) + ".resources.dll";
+
+			foreach (var subdir in Directory.GetDirectories (path)) {
+				var culture_name = Path.GetFileName (subdir);
+				CultureInfo ci;
+
+				if (culture_name.IndexOf ('.') >= 0)
+					continue; // cultures can't have dots. This way we don't check every *.app directory
+
+				try {
+					ci = CultureInfo.GetCultureInfo (culture_name);
+				} catch {
+					// nope, not a resource language
+					continue;
+				}
+
+				if (ci == null)
+					continue;
+
+				var satellite = Path.Combine (subdir, satellite_name);
+				if (File.Exists (satellite)) {
+					if (Satellites == null)
+						Satellites = new List<string> ();
+					Satellites.Add (satellite);
+				}
+			}
+		}
+
+		public void CopySatellitesToDirectory (string directory)
+		{
+			if (Satellites == null)
+				return;
+
+			foreach (var a in Satellites) {
+				string target_dir = Path.Combine (directory, Path.GetFileName (Path.GetDirectoryName (a)));
+				string target_s = Path.Combine (target_dir, Path.GetFileName (a));
+
+				if (!Directory.Exists (target_dir))
+					Directory.CreateDirectory (target_dir);
+
+				CopyAssembly (a, target_s);
+			}
+		}
 	}
 }

--- a/tools/mmp/Assembly.cs
+++ b/tools/mmp/Assembly.cs
@@ -1,9 +1,13 @@
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 
 namespace Xamarin.Bundler {
 	public partial class Assembly
 	{
+		public List<string> Satellites;
+
 		// returns false if the assembly was not copied (because it was already up-to-date).
 		bool CopyAssembly (string source, string target)
 		{
@@ -20,6 +24,53 @@ namespace Xamarin.Bundler {
 			}
 
 			return copied;
+		}
+
+		public void ComputeSatellites ()
+		{
+			var path = Path.GetDirectoryName (FullPath);
+			var satellite_name = Path.GetFileNameWithoutExtension (FullPath) + ".resources.dll";
+
+			foreach (var subdir in Directory.GetDirectories (path)) {
+				var culture_name = Path.GetFileName (subdir);
+				CultureInfo ci;
+
+				if (culture_name.IndexOf ('.') >= 0)
+					continue; // cultures can't have dots. This way we don't check every *.app directory
+
+				try {
+					ci = CultureInfo.GetCultureInfo (culture_name);
+				} catch {
+					// nope, not a resource language
+					continue;
+				}
+
+				if (ci == null)
+					continue;
+
+				var satellite = Path.Combine (subdir, satellite_name);
+				if (File.Exists (satellite)) {
+					if (Satellites == null)
+						Satellites = new List<string> ();
+					Satellites.Add (satellite);
+				}
+			}
+		}
+
+		public void CopySatellitesToDirectory (string directory)
+		{
+			if (Satellites == null)
+				return;
+
+			foreach (var a in Satellites) {
+				string target_dir = Path.Combine (directory, Path.GetFileName (Path.GetDirectoryName (a)));
+				string target_s = Path.Combine (target_dir, Path.GetFileName (a));
+
+				if (!Directory.Exists (target_dir))
+					Directory.CreateDirectory (target_dir);
+
+				CopyAssembly (a, target_s);
+			}
 		}
 	}
 }

--- a/tools/mmp/Assembly.cs
+++ b/tools/mmp/Assembly.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 
 namespace Xamarin.Bundler {

--- a/tools/mmp/Assembly.cs
+++ b/tools/mmp/Assembly.cs
@@ -6,8 +6,6 @@ using System.IO;
 namespace Xamarin.Bundler {
 	public partial class Assembly
 	{
-		public List<string> Satellites;
-
 		// returns false if the assembly was not copied (because it was already up-to-date).
 		bool CopyAssembly (string source, string target)
 		{
@@ -24,53 +22,6 @@ namespace Xamarin.Bundler {
 			}
 
 			return copied;
-		}
-
-		public void ComputeSatellites ()
-		{
-			var path = Path.GetDirectoryName (FullPath);
-			var satellite_name = Path.GetFileNameWithoutExtension (FullPath) + ".resources.dll";
-
-			foreach (var subdir in Directory.GetDirectories (path)) {
-				var culture_name = Path.GetFileName (subdir);
-				CultureInfo ci;
-
-				if (culture_name.IndexOf ('.') >= 0)
-					continue; // cultures can't have dots. This way we don't check every *.app directory
-
-				try {
-					ci = CultureInfo.GetCultureInfo (culture_name);
-				} catch {
-					// nope, not a resource language
-					continue;
-				}
-
-				if (ci == null)
-					continue;
-
-				var satellite = Path.Combine (subdir, satellite_name);
-				if (File.Exists (satellite)) {
-					if (Satellites == null)
-						Satellites = new List<string> ();
-					Satellites.Add (satellite);
-				}
-			}
-		}
-
-		public void CopySatellitesToDirectory (string directory)
-		{
-			if (Satellites == null)
-				return;
-
-			foreach (var a in Satellites) {
-				string target_dir = Path.Combine (directory, Path.GetFileName (Path.GetDirectoryName (a)));
-				string target_s = Path.Combine (target_dir, Path.GetFileName (a));
-
-				if (!Directory.Exists (target_dir))
-					Directory.CreateDirectory (target_dir);
-
-				CopyAssembly (a, target_s);
-			}
 		}
 	}
 }

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1742,8 +1742,7 @@ namespace Xamarin.Bundler {
 
 				// The linker later gets angry if you copy in a read only assembly
 				CopyFileAndRemoveReadOnly (asm, Path.Combine (mmp_dir, filename));
-				foreach (var assembly in BuildTarget.Assemblies)
-					assembly.CopySatellitesToDirectory (mmp_dir);
+
 				if (verbose > 0)
 					Console.WriteLine ("Added assembly {0}", asm);
 
@@ -1752,6 +1751,9 @@ namespace Xamarin.Bundler {
 				if (File.Exists (configfile))
 					File.Copy (configfile, Path.Combine (mmp_dir, Path.GetFileName (configfile)), true);
 			}
+
+			foreach (var assembly in BuildTarget.Assemblies)
+				assembly.CopySatellitesToDirectory (mmp_dir);
 		}
 
 		static void CopyResources () {

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1742,9 +1742,10 @@ namespace Xamarin.Bundler {
 
 				// The linker later gets angry if you copy in a read only assembly
 				CopyFileAndRemoveReadOnly (asm, Path.Combine (mmp_dir, filename));
+				foreach (var assembly in BuildTarget.Assemblies)
+					assembly.CopySatellitesToDirectory (mmp_dir);
 				if (verbose > 0)
 					Console.WriteLine ("Added assembly {0}", asm);
-
 				if (App.EnableDebug && File.Exists (mdbfile))
 					File.Copy (mdbfile, Path.Combine (mmp_dir, Path.GetFileName (mdbfile)), true);
 				if (File.Exists (configfile))
@@ -1778,7 +1779,9 @@ namespace Xamarin.Bundler {
 			if (resolved_assemblies.Contains (fqname))
 				return;
 
-			BuildTarget.Assemblies.Add (new Assembly (BuildTarget, assembly));
+			var asm = new Assembly (BuildTarget, assembly);
+			asm.ComputeSatellites ();
+			BuildTarget.Assemblies.Add (asm);
 
 			resolved_assemblies.Add (fqname);
 

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1746,7 +1746,7 @@ namespace Xamarin.Bundler {
 					assembly.CopySatellitesToDirectory (mmp_dir);
 				if (verbose > 0)
 					Console.WriteLine ("Added assembly {0}", asm);
-				
+
 				if (App.EnableDebug && File.Exists (mdbfile))
 					File.Copy (mdbfile, Path.Combine (mmp_dir, Path.GetFileName (mdbfile)), true);
 				if (File.Exists (configfile))

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1746,6 +1746,7 @@ namespace Xamarin.Bundler {
 					assembly.CopySatellitesToDirectory (mmp_dir);
 				if (verbose > 0)
 					Console.WriteLine ("Added assembly {0}", asm);
+				
 				if (App.EnableDebug && File.Exists (mdbfile))
 					File.Copy (mdbfile, Path.Combine (mmp_dir, Path.GetFileName (mdbfile)), true);
 				if (File.Exists (configfile))

--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -123,22 +123,6 @@ namespace Xamarin.Bundler {
 			}
 		}
 
-		public void CopySatellitesToDirectory (string directory)
-		{
-			if (Satellites == null)
-				return;
-
-			foreach (var a in Satellites) {
-				string target_dir = Path.Combine (directory, Path.GetFileName (Path.GetDirectoryName (a)));
-				string target_s = Path.Combine (target_dir, Path.GetFileName (a));
-
-				if (!Directory.Exists (target_dir))
-					Directory.CreateDirectory (target_dir);
-
-				CopyAssembly (a, target_s);
-			}
-		}
-
 		// returns false if the assembly was not copied (because it was already up-to-date).
 		public bool CopyToDirectory (string directory, bool reload = true, bool check_case = false, bool only_copy = false, bool copy_mdb = true)
 		{
@@ -435,37 +419,6 @@ namespace Xamarin.Bundler {
 			} catch (Exception e) {
 				// cecil might not be able to load the assembly, e.g. bug #758
 				throw new MonoTouchException (1010, true, e, "Could not load the assembly '{0}': {1}", FullPath, e.Message);
-			}
-		}
-
-		public void ComputeSatellites ()
-		{
-			var path = Path.GetDirectoryName (FullPath);
-			var satellite_name = Path.GetFileNameWithoutExtension (FullPath) + ".resources.dll";
-
-			foreach (var subdir in Directory.GetDirectories (path)) {
-				var culture_name = Path.GetFileName (subdir);
-				CultureInfo ci;
-
-				if (culture_name.IndexOf ('.') >= 0)
-					continue; // cultures can't have dots. This way we don't check every *.app directory
-
-				try {
-					ci = CultureInfo.GetCultureInfo (culture_name);
-				} catch {
-					// nope, not a resource language
-					continue;
-				}
-
-				if (ci == null)
-					continue;
-
-				var satellite = Path.Combine (subdir, satellite_name);
-				if (File.Exists (satellite)) {
-					if (Satellites == null)
-						Satellites = new List<string> ();
-					Satellites.Add (satellite);
-				}
 			}
 		}
 	}


### PR DESCRIPTION
For https://bugzilla.xamarin.com/show_bug.cgi?id=45696

Resource files are compiled into the bin folder but not copied into the actual app folder currently.  This copies them to where they need to be.