### PR TITLE
[xharness] Fix the name of referenced projects in derived projects.

### DIFF
--- a/tests/xharness/ProjectFileExtensions.cs
+++ b/tests/xharness/ProjectFileExtensions.cs
@@ -374,7 +374,7 @@ namespace xharness
 				include.Value = include.Value.Replace (".csproj", suffix + ".csproj");
 				include.Value = include.Value.Replace (".fsproj", suffix + ".fsproj");
 				var nameElement = n ["Name"];
-				nameElement.InnerText = System.IO.Path.GetFileNameWithoutExtension (include.Value);
+				nameElement.InnerText = System.IO.Path.GetFileNameWithoutExtension (include.Value.Replace ('\\', '/'));
 			}
 		}
 


### PR DESCRIPTION
System.IO.Path expects unix-style directory separators, but MSBuild expects
window-style directory separators, so make sure to not confuse those.