### PR TITLE
[mtouch] Build extensions and the container app in the same mtouch process.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -365,6 +365,10 @@ A last-straw solution would be to use a different version of Xamarin.iOS, one th
 
 <h3><a name="MT0096"/>MT0096: No reference to Xamarin.iOS.dll was found.</h3>
 
+<h3><a name="MT0099"/>Internal error *. Please file a bug report with a test case (http://bugzilla.xamarin.com).</h3>
+
+This indicates a bug in Xamarin.iOS; please file a bug report at [http://bugzilla.xamarin.com](https://bugzilla.xamarin.com/enter_bug.cgi?product=iOS) with a test case.
+
 # MT1xxx: Project related error messages
 
 ### MT10xx: Installer / mtouch

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -209,11 +209,44 @@ namespace Xamarin
 		}
 
 		[Test]
+		public void MT0008 ()
+		{
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryAppDirectory ();
+				mtouch.CustomArguments = new string [] { "foo.exe", "bar.exe" };
+				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
+				mtouch.AssertError (8, "You should provide one root assembly only, found 2 assemblies: 'foo.exe', 'bar.exe'");
+			}
+		}
+
+		[Test]
 		public void MT0015 ()
 		{
 			Asserts.Throws<TestExecutionException> (() =>
 				ExecutionHelper.Execute (TestTarget.ToolPath, "--abi invalid-arm"),
 				"error MT0015: Invalid ABI: invalid-arm. Supported ABIs are: i386, x86_64, armv7, armv7+llvm, armv7+llvm+thumb2, armv7s, armv7s+llvm, armv7s+llvm+thumb2, armv7k, armv7k+llvm, arm64 and arm64+llvm.\n");
+		}
+
+		[Test]
+		public void MT0017 ()
+		{
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryAppDirectory ();
+				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
+				mtouch.AssertError (17, "You should provide a root assembly.");
+			}
+		}
+
+		[Test]
+		public void MT0018 ()
+		{
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CustomArguments = new string [] { "--unknown", "-unknown" };
+				mtouch.CreateTemporaryAppDirectory ();
+				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
+				mtouch.AssertError (18, "Unknown command line argument: '-unknown'");
+				mtouch.AssertError (18, "Unknown command line argument: '--unknown'");
+			}
 		}
 
 		[Test]

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -84,7 +84,7 @@ namespace Xamarin
 		public Profile Profile = Profile.iOS;
 		public bool NoPlatformAssemblyReference;
 		static XmlDocument device_list_cache;
-
+		public string [] CustomArguments; // Sometimes you want to pass invalid arguments to mtouch, in this case this array is used. No processing will be done, if quotes are required, they must be added to the arguments in the array.
 
 		public class DeviceInfo
 		{
@@ -309,6 +309,12 @@ namespace Xamarin
 
 			if (!string.IsNullOrEmpty (Device))
 				sb.Append (" --device:").Append (MTouch.Quote (Device));
+
+			if (CustomArguments != null) {
+				foreach (var arg in CustomArguments) {
+					sb.Append (" ").Append (arg);
+				}
+			}
 
 			return sb.ToString ();
 		}

--- a/tools/mmp/error.cs
+++ b/tools/mmp/error.cs
@@ -37,6 +37,7 @@ namespace Xamarin.Bundler {
 	//					MM0089	** Reserved mtouch **
 	//					MM0097	machine.config file '{0}' can not be found.
 	//					MM0098	AOT compilation is only available on Unified
+	//					MM0099	Internal error {0}. Please file a bug report with a test case (http://bugzilla.xamarin.com).
 	// MM1xxx	file copy / symlinks (project related)
 	//			MM14xx	Product assemblies
 	//					MM1401	The required '{0}' assembly is missing from the references

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -104,6 +104,7 @@ namespace Xamarin.Bundler {
 
 		public bool IsExtension;
 		public List<string> Extensions = new List<string> (); // A list of the extensions this app contains.
+		public List<Application> AppExtensions = new List<Application> ();
 
 		public bool FastDev;
 

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -590,6 +590,26 @@ namespace Xamarin.Bundler {
 
 		void Initialize ()
 		{
+			if (EnableDebug && IsLLVM)
+				ErrorHelper.Warning (3003, "Debugging is not supported when building with LLVM. Debugging has been disabled.");
+
+			if (!IsLLVM && (EnableAsmOnlyBitCode || EnableLLVMOnlyBitCode))
+				throw ErrorHelper.CreateError (3008, "Bitcode support requires the use of LLVM (--abi=arm64+llvm etc.)");
+
+			if (EnableDebug) {
+				if (!DebugTrack.HasValue) {
+					DebugTrack = IsSimulatorBuild;
+				}
+			} else {
+				if (DebugTrack.HasValue) {
+					ErrorHelper.Warning (32, "The option '--debugtrack' is ignored unless '--debug' is also specified.");
+				}
+				DebugTrack = false;
+			}
+
+			if (EnableAsmOnlyBitCode)
+				LLVMAsmWriter = true;
+
 			if (!File.Exists (RootAssembly))
 				throw new MonoTouchException (7, true, "The root assembly '{0}' does not exist", RootAssembly);
 			

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -105,6 +105,7 @@ namespace Xamarin.Bundler {
 	//					MT0096 No reference to Xamarin.iOS.dll was found.
 	//					MT0097 <used by mmp>
 	//					MT0098 <used by mmp>
+	//					MT0099	Internal error {0}. Please file a bug report with a test case (http://bugzilla.xamarin.com).
 	// MT1xxx	file copy / symlinks (project related)
 	//			MT10xx	installer.cs / mtouch.cs
 	//					MT1001	Could not find an application at the specified directory: {0}

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1289,26 +1289,6 @@ namespace Xamarin.Bundler
 			app.SetDefaultFramework ();
 			app.SetDefaultAbi ();
 
-			if (app.EnableDebug && app.IsLLVM)
-				ErrorHelper.Warning (3003, "Debugging is not supported when building with LLVM. Debugging has been disabled.");
-
-			if (!app.IsLLVM && (app.EnableAsmOnlyBitCode || app.EnableLLVMOnlyBitCode))
-				ErrorHelper.Error (3008, "Bitcode support requires the use of LLVM (--abi=arm64+llvm etc.)");
-
-			if (app.EnableDebug) {
-				if (!app.DebugTrack.HasValue) {
-					app.DebugTrack = app.IsSimulatorBuild;
-				}
-			} else {
-				if (app.DebugTrack.HasValue) {
-					ErrorHelper.Warning (32, "The option '--debugtrack' is ignored unless '--debug' is also specified.");
-				}
-				app.DebugTrack = false;
-			}
-
-			if (app.EnableAsmOnlyBitCode)
-				app.LLVMAsmWriter = true;
-
 			ErrorHelper.Verbosity = verbose;
 
 			app.RuntimeOptions = RuntimeOptions.Create (app, http_message_handler, tls_provider);


### PR DESCRIPTION
Build extensions and the container app in the same mtouch process, by
storing all the mtouch arguments when called to build extensions in a text
file, and then reloading those arguments when called to build the main app.

This is required if we want to share code between extensions and the
container.

This branch is also built on wrench: https://wrench.internalx.com/Wrench//ViewTable.aspx?lane_id=4203&host_id=306.