### PR TITLE
[linker] Update BaseSubStep subclasses to use ExceptionalSubStep

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -902,6 +902,27 @@ User resources are files included inside assemblies (as resources) that needs to
 * `__monotouch_content_*` and `__monotouch_pages_*` resources; and
 * Native libraries embedded inside a binding assembly;
 
+<h3><a name="MT2040"/>MT2040: Default HttpMessageHandler setter failed processing `...`.</h3>
+
+Something unexpected occured when trying to set the default `HttpMessageHandler` for the application. Please file a [bug report](http://bugzilla.xamarin.com) along with a complete build log with verbosity enabled (i.e. `-v -v -v -v` in the **Additional mtouch arguments**).
+
+<h3><a name="MT2050"/>MT2050: Code Remover failed processing `...`.</h3>
+
+Something unexpected occured when trying to remove code from BCL shipping with the application. Please file a [bug report](http://bugzilla.xamarin.com) along with a complete build log with verbosity enabled (i.e. `-v -v -v -v` in the **Additional mtouch arguments**).
+
+<h3><a name="MT2060"/>MT2060: Sealer failed processing `...`.</h3>
+
+Something unexpected occured when trying to seal types or methods (final) or when devirtualizing some methods. The assembly causing the issue is named in the error message. In order to fix this issue the assembly will need to be provided in a [bug report](http://bugzilla.xamarin.com) along with a complete build log with verbosity enabled (i.e. `-v -v -v -v` in the **Additional mtouch arguments**).
+
+<h3><a name="MT2070"/>MT2070: Metadata Reducer failed processing `...`.</h3>
+
+Something unexpected occured when trying to reduce the metadata from the application. The assembly causing the issue is named in the error message. In order to fix this issue the assembly will need to be provided in a [bug report](http://bugzilla.xamarin.com) along with a complete build log with verbosity enabled (i.e. `-v -v -v -v` in the **Additional mtouch arguments**).
+
+<h3><a name="MT2080"/>MT2080: MarkNSObjects failed processing `...`.</h3>
+
+Something unexpected occured when trying to mark `NSObject` subclasses from the application. The assembly causing the issue is named in the error message. In order to fix this issue the assembly will need to be provided in a [bug report](http://bugzilla.xamarin.com) along with a complete build log with verbosity enabled (i.e. `-v -v -v -v` in the **Additional mtouch arguments**).
+
+
 # MT3xxx: AOT error messages
 
 <!--

--- a/tools/linker/CoreHttpMessageHandler.cs
+++ b/tools/linker/CoreHttpMessageHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2015 Xamarin Inc. All rights reserved.
+﻿// Copyright 2015-2017 Xamarin Inc. All rights reserved.
 
 using System;
 using System.Linq;
@@ -21,7 +21,7 @@ using XamCore.ObjCRuntime;
 
 namespace Xamarin.Linker.Steps {
 
-	public class CoreHttpMessageHandler : BaseSubStep {
+	public class CoreHttpMessageHandler : ExceptionalSubStep {
 		
 		public CoreHttpMessageHandler (LinkerOptions options)
 		{
@@ -33,6 +33,9 @@ namespace Xamarin.Linker.Steps {
 		public override SubStepTargets Targets {
 			get { return SubStepTargets.Type; }
 		}
+
+		protected override string Name { get; } = "Default HttpMessageHandler setter";
+		protected override int ErrorCode { get; } = 2040;
 
 		public override bool IsActiveFor (AssemblyDefinition assembly)
 		{
@@ -50,7 +53,7 @@ namespace Xamarin.Linker.Steps {
 		}
 
 #if MONOMAC
-		public override void ProcessType (TypeDefinition type)
+		protected override void Process (TypeDefinition type)
 		{
 			if (!type.Is ("ObjCRuntime", "RuntimeOptions"))
 				return;
@@ -72,7 +75,7 @@ namespace Xamarin.Linker.Steps {
 			method.Body = body;
 		}
 #else
-		public override void ProcessType (TypeDefinition type)
+		protected override void Process (TypeDefinition type)
 		{
 			if (!type.Is ("System.Net.Http", "HttpClient"))
 				return;

--- a/tools/linker/MarkNSObjects.cs
+++ b/tools/linker/MarkNSObjects.cs
@@ -37,15 +37,18 @@ using Mono.Tuner;
 
 namespace Xamarin.Linker.Steps {
 
-	public class MarkNSObjects : BaseSubStep {
+	public class MarkNSObjects : ExceptionalSubStep {
 
 		static string ProductAssembly;
+
+		protected override string Name { get; } = "MarkNSObjects";
+		protected override int ErrorCode { get; } = 2080;
 
 		public override SubStepTargets Targets {
 			get { return SubStepTargets.Type; }
 		}
 
-		public override void ProcessType (TypeDefinition type)
+		protected override void Process (TypeDefinition type)
 		{
 			if (ProductAssembly == null)
 				ProductAssembly = (Profile.Current as BaseProfile).ProductAssembly;

--- a/tools/linker/MonoTouch.Tuner/MetadataReducerSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/MetadataReducerSubStep.cs
@@ -9,7 +9,10 @@ namespace Xamarin.Linker.Steps {
 
 	// The value of some metadata is very low, some is useful only when debugging
 	// and other can be replaced with different information
-	public class MetadataReducerSubStep : BaseSubStep {
+	public class MetadataReducerSubStep : ExceptionalSubStep {
+
+		protected override string Name { get; } = "Metadata Reducer";
+		protected override int ErrorCode { get; } = 2070;
 
 		public override SubStepTargets Targets {
 			get {
@@ -33,7 +36,7 @@ namespace Xamarin.Linker.Steps {
 			return Annotations.GetAction (assembly) == AssemblyAction.Link;
 		}
 
-		public override void ProcessMethod (MethodDefinition method)
+		protected override void Process (MethodDefinition method)
 		{
 			if (method.IsPInvokeImpl) {
 				// note: ObjCRuntime.Messaging - but also 3rd parties bindings (normally ApiDefinitions.Messaging)
@@ -41,7 +44,7 @@ namespace Xamarin.Linker.Steps {
 				var dt = method.DeclaringType;
 				if (!method.IsPublic || !dt.IsPublic) {
 					// Avoid hundreds of different strings for msgSend[Super] overloads
-					// C# requires different names (for methods with ifferent return values)
+					// C# requires different names (for methods with different return values)
 					// but it's not an issue in IL
 					if ((dt.Name == "Messaging") && (method.PInvokeInfo.Module.Name == "/usr/lib/libobjc.dylib"))
 						method.Name = method.PInvokeInfo.EntryPoint;

--- a/tools/linker/MonoTouch.Tuner/RemoveCode.cs
+++ b/tools/linker/MonoTouch.Tuner/RemoveCode.cs
@@ -7,7 +7,7 @@ using Xamarin.Linker;
 
 namespace MonoTouch.Tuner {
 
-	public class RemoveCode : BaseSubStep {
+	public class RemoveCode : ExceptionalSubStep {
 
 		MethodDefinition get_nse_def;
 		MethodReference get_nse;
@@ -18,6 +18,9 @@ namespace MonoTouch.Tuner {
 			Device = options.Device;
 			Debug = options.DebugBuild;
 		}
+
+		protected override string Name { get; } = "Code Remover";
+		protected override int ErrorCode { get; } = 2050;
 
 		public bool Device { get; set; }
 
@@ -44,7 +47,7 @@ namespace MonoTouch.Tuner {
 			}
 		}
 
-		public override void ProcessAssembly (AssemblyDefinition assembly)
+		protected override void Process (AssemblyDefinition assembly)
 		{
 			if (get_nse_def == null) {
 				var corlib = context.GetAssembly ("mscorlib");
@@ -62,7 +65,7 @@ namespace MonoTouch.Tuner {
 			get_nse = assembly.MainModule.ImportReference (get_nse_def);
 		}
 
-		public override void ProcessType (TypeDefinition type)
+		protected override void Process (TypeDefinition type)
 		{
 			// no code to remove in interfaces, skip processing
 			if (type.IsInterface)

--- a/tools/linker/MonoTouch.Tuner/SealerSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/SealerSubStep.cs
@@ -11,13 +11,15 @@ namespace Xamarin.Linker.Steps {
 	// at this stage we know everything that will be part of the .app and, due to JIT restrictions,
 	// we know the .app won't be extendable at runtime (downloading or generating extra code
 	// this opens up some possibilities to seal types, methods and devirtualize methods
-	public class SealerSubStep : BaseSubStep {
+	public class SealerSubStep : ExceptionalSubStep {
 
 #if DEBUG
 		int seal;
 		int final;
 		int devirtualize;
 #endif
+		protected override string Name { get; } = "Sealer";
+		protected override int ErrorCode { get; } = 2060;
 
 		public override SubStepTargets Targets {
 			get {
@@ -47,7 +49,7 @@ namespace Xamarin.Linker.Steps {
 			return false;
 		}
 
-		public override void ProcessType (TypeDefinition type)
+		protected override void Process (TypeDefinition type)
 		{
 			// interface members are virtual (and we cannot change this)
 			// we cannot seal interfaces either

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -212,6 +212,11 @@ namespace Xamarin.Bundler {
 	//		Warning		MT2016  Invalid TlsProvider `{0}` option. The only valid value `{1}` will be used.
 	//					MT202x	Binding Optimizer failed processing `...`.
 	//					MT203x	Removing User Resources failed processing `...`.
+	//					MT204x	Default HttpMessageHandler setter failed processing `...`.
+	//					MT205x	Code Remover failed processing `...`.
+	//					MT206x	Sealer failed processing `...`.
+	//					MT207x	Metadata Reducer failed processing `...`.
+	//					MT208x	MarkNSObjects failed processing `...`.
 	// MT3xxx	AOT
 	//			MT30xx	AOT (general) errors
 	//					MT3001	Could not AOT the assembly '{0}'


### PR DESCRIPTION
This allows mtouch to give better error message when something unexpected
occurs in the linker pipeline (at least for the sub-steps).

Practically it means fewer, contextless MT2001 errors. The replacements
error code are more precise, e.g.
* what was being done;
* what was being processed

and helps both diagnosing and, possibly, gives clues for workarounds