### PR TITLE
[tests] Use a different bundle id for different apps that can be installed on the same device.

### DIFF
--- a/tests/monotouch-test/CoreFoundation/BundleTest.cs
+++ b/tests/monotouch-test/CoreFoundation/BundleTest.cs
@@ -74,7 +74,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		{
 			var main = CFBundle.GetMain ();
 #if __WATCHOS__
-			var expectedBundleId = "com.xamarin.monotouch-test.watchkitapp.watchkitextension";
+			var expectedBundleId = "com.xamarin.monotouch-test-watch.watchkitapp.watchkitextension";
 #elif MONOMAC
 			var expectedBundleId = "com.xamarin.xammac_tests";
 #else

--- a/tests/xharness/WatchOSTarget.cs
+++ b/tests/xharness/WatchOSTarget.cs
@@ -91,6 +91,8 @@ namespace xharness
 			var target_info_plist = Path.Combine (TargetDirectory, "Info-watchos-extension.plist");
 			info_plist.LoadWithoutNetworkAccess (Path.Combine (TargetDirectory, "Info.plist"));
 			BundleIdentifier = info_plist.GetCFBundleIdentifier () + "-watch";
+			if (BundleIdentifier.Length >= 58)
+				BundleIdentifier = BundleIdentifier.Substring (0, 57); // If the main app's bundle id is 58 characters (or sometimes more), then the watch extension crashes at launch. radar #29847128.
 			info_plist.SetCFBundleIdentifier (BundleIdentifier + ".watchkitapp.watchkitextension");
 			info_plist.SetMinimumOSVersion ("2.0");
 			info_plist.SetUIDeviceFamily (4);

--- a/tests/xharness/WatchOSTarget.cs
+++ b/tests/xharness/WatchOSTarget.cs
@@ -90,7 +90,7 @@ namespace xharness
 			XmlDocument info_plist = new XmlDocument ();
 			var target_info_plist = Path.Combine (TargetDirectory, "Info-watchos-extension.plist");
 			info_plist.LoadWithoutNetworkAccess (Path.Combine (TargetDirectory, "Info.plist"));
-			BundleIdentifier = info_plist.GetCFBundleIdentifier ();
+			BundleIdentifier = info_plist.GetCFBundleIdentifier () + "-watch";
 			info_plist.SetCFBundleIdentifier (BundleIdentifier + ".watchkitapp.watchkitextension");
 			info_plist.SetMinimumOSVersion ("2.0");
 			info_plist.SetUIDeviceFamily (4);


### PR DESCRIPTION
Using a different bundle id for watchOS tests and iOS tests makes us able to
run watchOS and iOS tests in parallel (and does not complicate the xharness
code that runs device tests in parallel, since watchOS devices and iOS devices
can be considered completley separate).