### PR TITLE
[mtouch] Remove RemoveSelector step for XI

### DIFF
--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -171,7 +171,6 @@ namespace MonoTouch.Tuner {
 				if (!options.DebugBuild)
 					pipeline.AppendStep (GetPostLinkOptimizations (options));
 
-				pipeline.AppendStep (new RemoveSelectors ());
 				pipeline.AppendStep (new FixModuleFlags ());
 			} else {
 				SubStepDispatcher sub = new SubStepDispatcher () {

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -202,9 +202,6 @@
     <Compile Include="..\linker\ObjCExtensions.cs">
       <Link>Xamarin.Linker\ObjCExtensions.cs</Link>
     </Compile>
-    <Compile Include="..\linker\RemoveSelectors.cs">
-      <Link>Xamarin.Linker\RemoveSelectors.cs</Link>
-    </Compile>
     <Compile Include="..\linker\ApplyPreserveAttribute.cs">
       <Link>Xamarin.Linker\ApplyPreserveAttribute.cs</Link>
     </Compile>


### PR DESCRIPTION
We're not storing selectors in fields anymore so this step does nothing
expect iterating over the code.