### PR TITLE
[linker] Inline BinaryCompatibility.TargetsAtLeast_Desktop_V4_5[_1]

### DIFF
--- a/tests/linker-ios/dont link/CanaryTest.cs
+++ b/tests/linker-ios/dont link/CanaryTest.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace DontLink {
+
+	[TestFixture]
+	public class CanaryTest {
+
+		static void AssertCallStaticReturnBool (Type t, string method, bool expected)
+		{
+			AssertCallStaticReturnBool (t, method, null, expected);
+		}
+
+		static void AssertCallStaticReturnBool (Type t, string method, object [] parameters, bool expected)
+		{
+			var m = t.GetMethod (method, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+			Assert.NotNull (m, $"{t.Name}::{method} is missing");
+			var result = (bool)m.Invoke (null, parameters);
+			Assert.That (result, Is.EqualTo (expected), $"{t.Name}::{method} returned `{result}` not the expected `{expected}`");
+		}
+
+		[Test]
+		public void Mscorlib ()
+		{
+			// type is internal - but we need to ensure it does not change the value it returns (without a corresponding update to InlinerSubStep.cs)
+			var bc = Type.GetType ("System.Runtime.Versioning.BinaryCompatibility, mscorlib");
+			Assert.IsNotNull (bc, "BinaryCompatibility");
+			AssertCallStaticReturnBool (bc, "get_TargetsAtLeast_Desktop_V4_5", true);
+			AssertCallStaticReturnBool (bc, "get_TargetsAtLeast_Desktop_V4_5_1", false);
+		}
+	}
+}

--- a/tests/linker-ios/dont link/dont link.csproj
+++ b/tests/linker-ios/dont link/dont link.csproj
@@ -150,6 +150,7 @@
     <Compile Include="DontLinkRegressionTests.cs" />
     <Compile Include="TableViewSourceTest.cs" />
     <Compile Include="CalendarTest.cs" />
+    <Compile Include="CanaryTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/tests/linker-ios/link sdk/CanaryTest.cs
+++ b/tests/linker-ios/link sdk/CanaryTest.cs
@@ -29,6 +29,7 @@ namespace LinkSdk {
 		{
 			// Not critical (on failure) but not optimal - the linker should be able to remove those types entirely
 			AssertAbsentType ("System.Security.SecurityManager, mscorlib");
+			AssertAbsentType ("System.Runtime.Versioning.BinaryCompatibility, mscorlib");
 		}
 	}
 }

--- a/tools/linker/MonoTouch.Tuner/InlinerSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/InlinerSubStep.cs
@@ -53,6 +53,17 @@ namespace Xamarin.Linker.Steps {
 							break;
 						}
 					}
+					// this removes System.Runtime.Versioning's BinaryCompatibility / BinaryCompatibilityMap / CompatibilitySwitch / TargetFrameworkId
+					if (!mr.HasParameters && mr.DeclaringType.Is ("System.Runtime.Versioning", "BinaryCompatibility")) {
+						switch (mr.Name) {
+						case "get_TargetsAtLeast_Desktop_V4_5":
+							il.OpCode = OpCodes.Ldc_I4_1;
+							break;
+						case "get_TargetsAtLeast_Desktop_V4_5_1":
+							il.OpCode = OpCodes.Ldc_I4_0;
+							break;
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This is a more interesting case since the inlining of 2 property getters
has a deeper impact and removes other types/methods from the final app.

Here we don't care what's inside the code we replace - only that it
always return a constant boolean after evaluation. That _constant_ is
something we can add tests to ensure we continue to behave identically.

```
--- before	2017-01-16 14:58:12.000000000 -0500
+++ after	2017-01-16 14:58:09.000000000 -0500
@@ -1580,7 +1580,6 @@
 System.String System.AppDomain::get_BaseDirectory()
 System.String System.AppDomain::get_FriendlyName()
 System.String System.AppDomain::getFriendlyName()
-System.String System.AppDomain::GetTargetFrameworkName()
 System.String System.AppDomain::ToString()
 System.UnhandledExceptionEventHandler System.AppDomain::UnhandledException
 System.UnhandledExceptionEventHandler System.AppDomain::UnhandledException
@@ -11949,54 +11948,12 @@
 System.Reflection.FieldInfo System.Runtime.Serialization.ValueTypeFixupInfo::ParentField()
 System.Runtime.Serialization.ValueTypeFixupInfo
 System.Void System.Runtime.Serialization.ValueTypeFixupInfo::.ctor(System.Int64,System.Reflection.FieldInfo,System.Int32[])
-System.Runtime.Versioning.BinaryCompatibility
-System.Boolean System.Runtime.Versioning.BinaryCompatibility/BinaryCompatibilityMap::TargetsAtLeast_Desktop_V4_5
-System.Boolean System.Runtime.Versioning.BinaryCompatibility/BinaryCompatibilityMap::TargetsAtLeast_Desktop_V4_5_1
-System.Boolean System.Runtime.Versioning.BinaryCompatibility/BinaryCompatibilityMap::TargetsAtLeast_Desktop_V4_5_2
-System.Boolean System.Runtime.Versioning.BinaryCompatibility/BinaryCompatibilityMap::TargetsAtLeast_Desktop_V4_5_3
-System.Boolean System.Runtime.Versioning.BinaryCompatibility/BinaryCompatibilityMap::TargetsAtLeast_Desktop_V4_5_4
-System.Boolean System.Runtime.Versioning.BinaryCompatibility/BinaryCompatibilityMap::TargetsAtLeast_Desktop_V5_0
-System.Boolean System.Runtime.Versioning.BinaryCompatibility/BinaryCompatibilityMap::TargetsAtLeast_Phone_V7_1
-System.Boolean System.Runtime.Versioning.BinaryCompatibility/BinaryCompatibilityMap::TargetsAtLeast_Phone_V8_0
-System.Boolean System.Runtime.Versioning.BinaryCompatibility/BinaryCompatibilityMap::TargetsAtLeast_Silverlight_V4
-System.Boolean System.Runtime.Versioning.BinaryCompatibility/BinaryCompatibilityMap::TargetsAtLeast_Silverlight_V5
-System.Boolean System.Runtime.Versioning.BinaryCompatibility/BinaryCompatibilityMap::TargetsAtLeast_Silverlight_V6
-System.Boolean System.Runtime.Versioning.BinaryCompatibility::get_TargetsAtLeast_Desktop_V4_5()
-System.Boolean System.Runtime.Versioning.BinaryCompatibility::get_TargetsAtLeast_Desktop_V4_5_1()
-System.Boolean System.Runtime.Versioning.BinaryCompatibility::ParseTargetFrameworkMonikerIntoEnum(System.String,System.Runtime.Versioning.TargetFrameworkId&,System.Int32&)
-System.Boolean System.Runtime.Versioning.BinaryCompatibility::TargetsAtLeast_Desktop_V4_5()
-System.Boolean System.Runtime.Versioning.BinaryCompatibility::TargetsAtLeast_Desktop_V4_5_1()
-System.Int32 System.Runtime.Versioning.BinaryCompatibility::AppWasBuiltForVersion()
-System.Int32 System.Runtime.Versioning.BinaryCompatibility::get_AppWasBuiltForVersion()
-System.Int32 System.Runtime.Versioning.BinaryCompatibility::s_AppWasBuiltForVersion
-System.Runtime.Versioning.BinaryCompatibility/BinaryCompatibilityMap
-System.Runtime.Versioning.BinaryCompatibility/BinaryCompatibilityMap System.Runtime.Versioning.BinaryCompatibility::s_map
-System.Runtime.Versioning.TargetFrameworkId System.Runtime.Versioning.BinaryCompatibility::AppWasBuiltForFramework()
-System.Runtime.Versioning.TargetFrameworkId System.Runtime.Versioning.BinaryCompatibility::get_AppWasBuiltForFramework()
-System.Runtime.Versioning.TargetFrameworkId System.Runtime.Versioning.BinaryCompatibility::s_AppWasBuiltForFramework
-System.Void System.Runtime.Versioning.BinaryCompatibility/BinaryCompatibilityMap::.ctor()
-System.Void System.Runtime.Versioning.BinaryCompatibility/BinaryCompatibilityMap::AddQuirksForFramework(System.Runtime.Versioning.TargetFrameworkId,System.Int32)
-System.Void System.Runtime.Versioning.BinaryCompatibility::.cctor()
-System.Void System.Runtime.Versioning.BinaryCompatibility::ParseFrameworkName(System.String,System.String&,System.Int32&,System.String&)
-System.Void System.Runtime.Versioning.BinaryCompatibility::ReadTargetFrameworkId()
-System.Runtime.Versioning.CompatibilitySwitch
-System.String System.Runtime.Versioning.CompatibilitySwitch::GetValueInternal(System.String)
 System.Runtime.Versioning.TargetFrameworkAttribute
 System.String System.Runtime.Versioning.TargetFrameworkAttribute::_frameworkDisplayName
 System.String System.Runtime.Versioning.TargetFrameworkAttribute::_frameworkName
 System.String System.Runtime.Versioning.TargetFrameworkAttribute::FrameworkDisplayName()
 System.Void System.Runtime.Versioning.TargetFrameworkAttribute::.ctor(System.String)
 System.Void System.Runtime.Versioning.TargetFrameworkAttribute::set_FrameworkDisplayName(System.String)
-System.Int32 System.Runtime.Versioning.TargetFrameworkId::value__
-System.Runtime.Versioning.TargetFrameworkId
-System.Runtime.Versioning.TargetFrameworkId System.Runtime.Versioning.TargetFrameworkId::NetCore
-System.Runtime.Versioning.TargetFrameworkId System.Runtime.Versioning.TargetFrameworkId::NetFramework
-System.Runtime.Versioning.TargetFrameworkId System.Runtime.Versioning.TargetFrameworkId::NotYetChecked
-System.Runtime.Versioning.TargetFrameworkId System.Runtime.Versioning.TargetFrameworkId::Phone
-System.Runtime.Versioning.TargetFrameworkId System.Runtime.Versioning.TargetFrameworkId::Portable
-System.Runtime.Versioning.TargetFrameworkId System.Runtime.Versioning.TargetFrameworkId::Silverlight
-System.Runtime.Versioning.TargetFrameworkId System.Runtime.Versioning.TargetFrameworkId::Unrecognized
-System.Runtime.Versioning.TargetFrameworkId System.Runtime.Versioning.TargetFrameworkId::Unspecified
 System.IntPtr System.RuntimeArgumentHandle::args
 System.RuntimeArgumentHandle
 System.Boolean System.RuntimeFieldHandle::Equals(System.Object)
```

```
Statistics

Native subtotal           35,729,800   35,728,760       -1,040       0.00 %
    Executable            29,270,272   29,270,240          -32       0.00 %
    AOT data *.aotdata     6,459,528    6,458,520       -1,008      -0.02 %

Managed *.dll/exe          4,537,344    4,532,736       -4,608      -0.10 %

TOTAL                     40,581,685   40,576,037       -5,648      -0.01 %
```