### PR TITLE
[UIKit] Tweak UIAlertView constructors.

### DIFF
--- a/src/UIKit/UIAlertView.cs
+++ b/src/UIKit/UIAlertView.cs
@@ -27,11 +27,18 @@ namespace XamCore.UIKit {
 				AddButton (otherButtons [i]);
 		}
 
+		public UIAlertView (string title, string message, string cancelButtonTitle, params string [] otherButtons)
+			: this (title, message, (IUIAlertViewDelegate) null, cancelButtonTitle, otherButtons)
+		{
+		}
+
+#if !XAMCORE_4_0
 		[Obsolete ("Use overload with a IUIAlertViewDelegate parameter")]
 		public UIAlertView (string title, string message, UIAlertViewDelegate del, string cancelButtonTitle, params string [] otherButtons)
 			: this (title, message, (IUIAlertViewDelegate) del, cancelButtonTitle, otherButtons)
 		{
 		}
+#endif
 	}
 }
 


### PR DESCRIPTION
* Add an additional UIAlertView constructor that doesn't take a delegate
  parameter.

	This code that wants to passes a null delegate:

		new UIAlertView ("title", "message", null, "cancel title")

	shows a warning now: "Use overload with a IUIAlertViewDelegate parameter"

	and the only way to fix the warning, is to do this:

		new UIAlertView ("title", "message", (IUIAlertViewDelegate) null, "cancel title")

	which looks ugly.

	So add an overload that doesn't take a delegate at all, which makes this
	possible:

		new UIAlertView ("title", "message", "cancel title")

* Also remove the obsolete constructor from XAMCORE_4_0, no need to keep
  obsolete API when we can break API.