### PR TITLE
[msbuild] Fixed the IpaPackageDir

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1708,7 +1708,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 			<!-- Calculate an IPA package directory path if not already defined by the developer. -->
 			<!--<IpaPackageDir Condition="'$(IpaPackageDir)' == ''">$([System.Environment]::GetEnvironmentVariable('IPA_PACKAGE_DIR'))</IpaPackageDir>-->
-			<IpaPackageDir Condition="'$(IpaPackageDir)' == ''">$(DeviceSpecificOutputPath)$(_AppBundleName)</IpaPackageDir>
+			<IpaPackageDir Condition="'$(IpaPackageDir)' == ''">$(DeviceSpecificOutputPath)</IpaPackageDir>
 
 			<!-- Calculate an IPA package name if not already defined by the developer. -->
 			<!--<IpaPackageName Condition="'$(IpaPackageName)' == ''">$([System.Environment]::GetEnvironmentVariable('IPA_PACKAGE_NAME'))</IpaPackageName>-->


### PR DESCRIPTION
Originally, the IpaPackagePath would default to something
like:

bin/Debug/iPhone/MyProjectName $(DateTime)/MyProjectName.ipa

It was recently changed to not have the timestamp, but I
seem to have forgotten to do away with the subdirectory
completely. In other words, w/o this fix, we'd get:

bin/Debug/iPhone/MyProjectName/MyProjectName.ipa

When what we *really* want is:

bin/Debug/iPhone/MyProjectName.ipa