### PR TITLE
[generator] Allow the use of [Async] attribute on [Abstract] decorated methods. Fixes #43165

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -4326,9 +4326,12 @@ public partial class Generator : IMemberGatherer {
 			extra += "out " + FormatType (minfo.MethodInfo.DeclaringType, minfo.MethodInfo.ReturnType) + " " + minfo.GetUniqueParamName ("result");
 		}
 
+		// async wrapper don't have to be abstract (it's counter productive)
+		var modifier = minfo.GetModifiers ().Replace ("abstract ", String.Empty);
+
 		print ("{0} {1}{2} {3}",
 		       minfo.GetVisibility (),
-		       minfo.GetModifiers (),
+		       modifier,
 		       GetReturnType (minfo),
 		       MakeSignature (minfo, true, minfo.async_initial_params, extra),
 		       minfo.is_abstract ? ";" : "");
@@ -4342,8 +4345,6 @@ public partial class Generator : IMemberGatherer {
 		PrintMethodAttributes (minfo);
 
 		PrintAsyncHeader (minfo, asyncKind);
-		if (minfo.is_abstract)
-			return;
 
 		print ("{");
 		indent++;

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -2222,6 +2222,7 @@ namespace XamCore.SceneKit {
 		[Abstract]
 #endif
 		[Mac (10,10)]
+		[Async]
 		[Export ("prepareObjects:withCompletionHandler:")]
 		void Prepare (NSObject [] objects, [NullAllowed] Action<bool> completionHandler);
 


### PR DESCRIPTION
Fixing the compilation was not enough [1] as it would still require to implement the async variant when subclassing. That could already be done outside the bindings (no saving).

The good news is that the generated `*Async` method does not need to be `abstract` even if it calls an `abstract` method. We already have enough information (from the `abstract` signature) to generated the async wrapper method.

Ideally (too late for the current profile) the `*Async` method should not be virtual, the async wrapper does not need to be overridden, just the binding call -> XAMCORE_4_0.

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=43165

[1] it was missing a `;` - but also caused other compilation issues