### PR TITLE
Fix block warning on RegisterCloudKitShare

### DIFF
--- a/src/Foundation/Enums.cs
+++ b/src/Foundation/Enums.cs
@@ -4,7 +4,7 @@ using XamCore.CloudKit;
 namespace XamCore.Foundation {
 
 #if MONOMAC
-	delegate void CloudKitRegistrationPreparationAction (CloudKitRegistrationPreparationHandler handler);
+	delegate void CloudKitRegistrationPreparationAction ([BlockCallback] CloudKitRegistrationPreparationHandler handler);
 	delegate void CloudKitRegistrationPreparationHandler (CKShare share, CKContainer container, NSError error);
 #endif
 

--- a/src/Foundation/Enums.cs
+++ b/src/Foundation/Enums.cs
@@ -3,11 +3,6 @@ using XamCore.CloudKit;
 
 namespace XamCore.Foundation {
 
-#if MONOMAC
-	delegate void CloudKitRegistrationPreparationAction ([BlockCallback] CloudKitRegistrationPreparationHandler handler);
-	delegate void CloudKitRegistrationPreparationHandler (CKShare share, CKContainer container, NSError error);
-#endif
-
 	// Utility enum, ObjC uses NSString
 	[NoMac]
 	[iOS (7,0)]

--- a/src/Foundation/Enums.cs
+++ b/src/Foundation/Enums.cs
@@ -1,5 +1,4 @@
 using XamCore.ObjCRuntime;
-using XamCore.CloudKit;
 
 namespace XamCore.Foundation {
 

--- a/src/Foundation/Enums.cs
+++ b/src/Foundation/Enums.cs
@@ -1,6 +1,12 @@
 using XamCore.ObjCRuntime;
+using XamCore.CloudKit;
 
 namespace XamCore.Foundation {
+
+#if MONOMAC
+	delegate void CloudKitRegistrationPreparationAction (CloudKitRegistrationPreparationHandler handler);
+	delegate void CloudKitRegistrationPreparationHandler (CKShare share, CKContainer container, NSError error);
+#endif
 
 	// Utility enum, ObjC uses NSString
 	[NoMac]

--- a/src/Foundation/NSItemProvider.cs
+++ b/src/Foundation/NSItemProvider.cs
@@ -8,14 +8,14 @@ namespace XamCore.Foundation
 	public partial class NSItemProvider
 	{
 #if !XAMCORE_4_0
-		public unsafe virtual void RegisterCloudKitShare (Action<CloudKitRegistrationPreparationHandler> preparationHandler)
+		public virtual void RegisterCloudKitShare (Action<CloudKitRegistrationPreparationHandler> preparationHandler)
 		{
 			CloudKitRegistrationPreparationAction action = handler => preparationHandler (handler);
 			RegisterCloudKitShare (action);
 		}
 #endif
 		
-		public unsafe virtual Task<CloudKitRegistrationPreparationHandler> RegisterCloudKitShareAsync ()
+		public virtual Task<CloudKitRegistrationPreparationHandler> RegisterCloudKitShareAsync ()
 		{
 			var tcs = new TaskCompletionSource<CloudKitRegistrationPreparationHandler> ();
 			CloudKitRegistrationPreparationAction action = (handler) => {

--- a/src/Foundation/NSItemProvider.cs
+++ b/src/Foundation/NSItemProvider.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using XamCore.CloudKit;
+
+namespace XamCore.Foundation 
+{
+#if MONOMAC && XAMCORE_2_0 // Only 64-bit on mac
+	public partial class NSItemProvider
+	{
+#if !XAMCORE_4_0
+		public unsafe virtual void RegisterCloudKitShare (Action<CloudKitRegistrationPreparationHandler> preparationHandler)
+		{
+			CloudKitRegistrationPreparationAction action = handler => preparationHandler (handler);
+			RegisterCloudKitShare (action);
+		}
+#endif
+		
+		public unsafe virtual Task<CloudKitRegistrationPreparationHandler> RegisterCloudKitShareAsync ()
+		{
+			var tcs = new TaskCompletionSource<CloudKitRegistrationPreparationHandler> ();
+			CloudKitRegistrationPreparationAction action = (handler) => {
+				tcs.SetResult (handler);
+			};
+			RegisterCloudKitShare (action);
+			return tcs.Task;
+		}
+	}
+#endif
+}

--- a/src/Foundation/NSItemProvider.cs
+++ b/src/Foundation/NSItemProvider.cs
@@ -8,6 +8,7 @@ namespace XamCore.Foundation
 	public partial class NSItemProvider
 	{
 #if !XAMCORE_4_0
+		[Obsolete ("Use RegisterCloudKitShare (CloudKitRegistrationPreparationAction) instead")]
 		public virtual void RegisterCloudKitShare (Action<CloudKitRegistrationPreparationHandler> preparationHandler)
 		{
 			CloudKitRegistrationPreparationAction action = handler => preparationHandler (handler);

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -94,6 +94,7 @@ namespace XamCore.Foundation
 	delegate void EnumerateDatesCallback (NSDate date, bool exactMatch, ref bool stop);
 	delegate void EnumerateIndexSetCallback (nuint idx, ref bool stop);
 #if MONOMAC
+	delegate void CloudKitRegistrationPreparationAction ([BlockCallback]CloudKitRegistrationPreparationHandler handler);
 	delegate void CloudKitRegistrationPreparationHandler (CKShare share, CKContainer container, NSError error);
 #endif
 
@@ -8752,7 +8753,7 @@ namespace XamCore.Foundation
 
 		[Mac (10,12)][Async]
 		[Export ("registerCloudKitShareWithPreparationHandler:")]
-		void RegisterCloudKitShare ([BlockCallback] Action<CloudKitRegistrationPreparationHandler> preparationHandler);
+		void RegisterCloudKitShare (CloudKitRegistrationPreparationAction preparationHandler);
 
 		[Mac (10,12)]
 		[Export ("registerCloudKitShare:container:")]

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -93,10 +93,6 @@ namespace XamCore.Foundation
 	delegate void NSItemProviderLoadHandler ([BlockCallback] NSItemProviderCompletionHandler completionHandler, Class expectedValueClass, NSDictionary options);
 	delegate void EnumerateDatesCallback (NSDate date, bool exactMatch, ref bool stop);
 	delegate void EnumerateIndexSetCallback (nuint idx, ref bool stop);
-#if MONOMAC
-	delegate void CloudKitRegistrationPreparationAction ([BlockCallback]CloudKitRegistrationPreparationHandler handler);
-	delegate void CloudKitRegistrationPreparationHandler (CKShare share, CKContainer container, NSError error);
-#endif
 
 	interface NSArray<TValue> : NSArray {}
 
@@ -8751,13 +8747,10 @@ namespace XamCore.Foundation
 		[Export ("preferredPresentationSize")]
 		CGSize PreferredPresentationSize { get; }
 
-		[Mac (10,12)][Async]
+		[Mac (10,12)] // [Async] handled by NSItemProvider.cs for backwords compat reasons
 		[Export ("registerCloudKitShareWithPreparationHandler:")]
-#if XAMCORE_4_0
 		void RegisterCloudKitShare (CloudKitRegistrationPreparationAction preparationHandler);
-#else
-		void RegisterCloudKitShare ([BlockCallback] Action<CloudKitRegistrationPreparationHandler preparationHandler);
-#endif
+		
 		[Mac (10,12)]
 		[Export ("registerCloudKitShare:container:")]
 		void RegisterCloudKitShare (CKShare share, CKContainer container);

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -8750,7 +8750,7 @@ namespace XamCore.Foundation
 		[Mac (10,12)] // [Async] handled by NSItemProvider.cs for backwords compat reasons
 		[Export ("registerCloudKitShareWithPreparationHandler:")]
 		void RegisterCloudKitShare (CloudKitRegistrationPreparationAction preparationHandler);
-		
+
 		[Mac (10,12)]
 		[Export ("registerCloudKitShare:container:")]
 		void RegisterCloudKitShare (CKShare share, CKContainer container);

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -8753,8 +8753,11 @@ namespace XamCore.Foundation
 
 		[Mac (10,12)][Async]
 		[Export ("registerCloudKitShareWithPreparationHandler:")]
+#if XAMCORE_4_0
 		void RegisterCloudKitShare (CloudKitRegistrationPreparationAction preparationHandler);
-
+#else
+		void RegisterCloudKitShare ([BlockCallback] Action<CloudKitRegistrationPreparationHandler preparationHandler);
+#endif
 		[Mac (10,12)]
 		[Export ("registerCloudKitShare:container:")]
 		void RegisterCloudKitShare (CKShare share, CKContainer container);

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -8747,7 +8747,7 @@ namespace XamCore.Foundation
 		[Export ("preferredPresentationSize")]
 		CGSize PreferredPresentationSize { get; }
 
-		[Mac (10,12)] // [Async] handled by NSItemProvider.cs for backwords compat reasons
+		[Mac (10,12)] // [Async] handled by NSItemProvider.cs for backwards compat reasons
 		[Export ("registerCloudKitShareWithPreparationHandler:")]
 		void RegisterCloudKitShare (CloudKitRegistrationPreparationAction preparationHandler);
 

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -93,6 +93,10 @@ namespace XamCore.Foundation
 	delegate void NSItemProviderLoadHandler ([BlockCallback] NSItemProviderCompletionHandler completionHandler, Class expectedValueClass, NSDictionary options);
 	delegate void EnumerateDatesCallback (NSDate date, bool exactMatch, ref bool stop);
 	delegate void EnumerateIndexSetCallback (nuint idx, ref bool stop);
+#if MONOMAC
+	delegate void CloudKitRegistrationPreparationAction ([BlockCallback] CloudKitRegistrationPreparationHandler handler);
+	delegate void CloudKitRegistrationPreparationHandler (CKShare share, CKContainer container, NSError error);
+#endif
 
 	interface NSArray<TValue> : NSArray {}
 
@@ -8700,10 +8704,6 @@ namespace XamCore.Foundation
 		NSMethodSignature MethodSignature { get; }
 	}
 
-#if MONOMAC
-	delegate void CloudKitRegistrationPreparationAction ([BlockCallback] CloudKitRegistrationPreparationHandler handler);
-	delegate void CloudKitRegistrationPreparationHandler (CKShare share, CKContainer container, NSError error);
-#endif
 
 	[iOS (8,0)][Mac (10,10, onlyOn64 : true)] // Not defined in 32-bit
 	[BaseType (typeof (NSObject))]

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -8700,6 +8700,11 @@ namespace XamCore.Foundation
 		NSMethodSignature MethodSignature { get; }
 	}
 
+#if MONOMAC
+	delegate void CloudKitRegistrationPreparationAction ([BlockCallback] CloudKitRegistrationPreparationHandler handler);
+	delegate void CloudKitRegistrationPreparationHandler (CKShare share, CKContainer container, NSError error);
+#endif
+
 	[iOS (8,0)][Mac (10,10, onlyOn64 : true)] // Not defined in 32-bit
 	[BaseType (typeof (NSObject))]
 	partial interface NSItemProvider : NSCopying {

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -719,6 +719,7 @@ FOUNDATION_SOURCES = \
 	Foundation/NSUuid.cs \
 	Foundation/ObjCException.cs \
 	Foundation/ToString.cs \
+	Foundation/NSItemProvider.cs \
 
 # GameController
 


### PR DESCRIPTION
- [BlockCallback] Action<CloudKitRegistrationPreparationHandler> was not good enough to fix the warning