### PR TITLE
[mtouch] Fix an unnecessary re-link when the linker copies assemblies without processing them.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -118,6 +118,22 @@ namespace Xamarin
 		}
 
 		[Test]
+		public void RebuildTest_DontLink ()
+		{
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.NoFastSim = true;
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.CreateTemporaryApp ();
+				mtouch.Verbosity = 4;
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.AssertExecute (MTouchAction.BuildSim, "build 1");
+				mtouch.AssertOutputPattern ("Linking .*/testApp.exe into .*/PreBuild using mode 'None'");
+				mtouch.AssertExecute (MTouchAction.BuildSim, "build 2");
+				mtouch.AssertOutputPattern ("Cached assemblies reloaded.");
+			}
+		}
+
+		[Test]
 		// Simulator
 		[TestCase (Target.Sim, Config.Release, PackageMdb.Default, MSym.Default,  false, false, "")]
 		[TestCase (Target.Sim, Config.Debug,   PackageMdb.Default, MSym.Default,  true,  false, "")]

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -18,6 +18,7 @@ using PlatformException = Xamarin.Bundler.MonoMacException;
 namespace Xamarin.Bundler {
 	public partial class Assembly
 	{
+		public List<string> Satellites;
 		public Application App { get { return Target.App; } }
 
 		string full_path;
@@ -391,6 +392,29 @@ namespace Xamarin.Bundler {
 		public override string ToString ()
 		{
 			return FileName;
+		}
+
+		// This returns the path to all related files:
+		// * The assembly itself
+		// * Any debug files (mdb/pdb)
+		// * Any config files
+		// * Any satellite assemblies
+		public IEnumerable<string> GetRelatedFiles ()
+		{
+			yield return FullPath;
+			var mdb = FullPath + ".mdb";
+			if (File.Exists (mdb))
+				yield return mdb;
+			var pdb = Path.ChangeExtension (FullPath, ".pdb");
+			if (File.Exists (pdb))
+				yield return pdb;
+			var config = FullPath + ".config";
+			if (File.Exists (config))
+				yield return config;
+			if (Satellites != null) {
+				foreach (var satellite in Satellites)
+					yield return satellite;
+			}
 		}
 	}
 }

--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -13,7 +13,6 @@ using Xamarin.Utils;
 namespace Xamarin.Bundler {
 	public partial class Assembly
 	{
-		public List<string> Satellites;
 		List<string> dylibs;
 		public string Dylib;
 

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -751,6 +751,14 @@ namespace Xamarin.Bundler
 			return true;
 		}
 
+		public static void Touch (IEnumerable<string> filenames, DateTime? timestamp = null)
+		{
+			if (timestamp == null)
+				timestamp = DateTime.Now;
+			foreach (var filename in filenames)
+				new FileInfo (filename).LastWriteTime = timestamp.Value;
+		}
+
 		public static string Quote (string f)
 		{
 			if (f.IndexOf (' ') == -1 && f.IndexOf ('\'') == -1 && f.IndexOf (',') == -1 && f.IndexOf ('$') == -1)


### PR DESCRIPTION
Event sequence:

* mtouch is executed with the linker disabled.
* The linker pipeline copies all input assemblies (since the linker is
  disabled the assemblies don't change) into the PreBuild directory. This will
  keep the original timestamps of the input assemblies.
* mtouch is executed again, when none of the input assemblies changed.
* The linker pipeline will re-execute, because it will see that at least one
  of the input assemblies (at least the .exe) is newer than at least one of
  the assemblies in the PreBuild directory (usually a framework assembly,
  because those have the original timestamp from their install location).

Fix:

Touch all the assemblies in the PreBuild directory after the linker pipeline
executes the first time. This way the second time mtouch is executed, it will
find that all assemblies in the PreBuild directory have timestamps later than
all the input assemblies, so it will load the cached linked assemblies,
instead of re-executing the linker pipeline.