### PR TITLE
[system-dependencies] Handle monos updateinfo

### DIFF
--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -380,7 +380,7 @@ function check_mono () {
 	MIN_MONO_VERSION=`grep MIN_MONO_VERSION= Make.config | sed 's/.*=//'`
 	MAX_MONO_VERSION=`grep MAX_MONO_VERSION= Make.config | sed 's/.*=//'`
 
-	ACTUAL_MONO_VERSION=`$PKG_CONFIG_PATH --modversion mono`.`cat /Library/Frameworks/Mono.framework/Home/updateinfo | cut -d' ' -f2 | rev | cut -c-3 | rev | awk '{print(int($0))}'`
+	ACTUAL_MONO_VERSION=`$PKG_CONFIG_PATH --modversion mono`.`cat /Library/Frameworks/Mono.framework/Home/updateinfo | cut -d' ' -f2 | cut -c6- | awk '{print(int($0))}'`
 	if ! is_at_least_version $ACTUAL_MONO_VERSION $MIN_MONO_VERSION; then
 		if ! test -z $PROVISION_MONO; then
 			install_mono
@@ -394,7 +394,7 @@ function check_mono () {
 	elif is_at_least_version $ACTUAL_MONO_VERSION $MAX_MONO_VERSION; then
 		if ! test -z $PROVISION_MONO; then
 			install_mono
-			ACTUAL_MONO_VERSION=`$PKG_CONFIG_PATH --modversion mono`.`cat /Library/Frameworks/Mono.framework/Home/updateinfo | cut -d' ' -f2 | rev | cut -c-3 | rev | awk '{print(int($0))}'`
+			ACTUAL_MONO_VERSION=`$PKG_CONFIG_PATH --modversion mono`.`cat /Library/Frameworks/Mono.framework/Home/updateinfo | cut -d' ' -f2 | cut -c6- | awk '{print(int($0))}'`
 		else
 			fail "Your mono version is too new, max version is $MAX_MONO_VERSION, found $ACTUAL_MONO_VERSION."
 			fail "You may edit Make.config and change MAX_MONO_VERSION to your actual version to continue the"


### PR DESCRIPTION
Current mono master is versioned as `409001455` in it's updateinfo
which (technically) violates the format. Rewrite the parser to take
an arbitrary number of digits in the final slot instead of assuming
it's always going to be 3.

Now you can provision mono/master:
```
$ cat /Library/Frameworks/Mono.framework/Home/updateinfo
964ebddd-1ffe-47e7-8128-5ce17ffffb05 409001455

$ cat /Library/Frameworks/Mono.framework/Home/updateinfo | cut -d' ' -f2 | cut -c6- | awk '{print(int($0))}'
1455
```