### PR TITLE
[tests] Sleep a bit to work around HFS' lack of sub-second timestamp values.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2169,7 +2169,6 @@ public partial class NotificationService : UNNotificationServiceExtension
 		{
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.Profile = Profile.iOS;
-				mtouch.Verbosity = 23;
 				var tmp = mtouch.CreateTemporaryDirectory ();
 				mtouch.CreateTemporaryCacheDirectory ();
 
@@ -2190,7 +2189,8 @@ public partial class NotificationService : UNNotificationServiceExtension
 				var exeStamp = File.GetLastWriteTimeUtc (exePath);
 				var mdbStamp = File.GetLastWriteTimeUtc (mdbPath);
 
-				// Recompile the exe, adding only whitespace. This will only change the debuf files
+				System.Threading.Thread.Sleep (1000); // HFS does not have sub-second timestamp resolution, so make sure the timestamps actually change...
+				// Recompile the exe, adding only whitespace. This will only change the debug files
 				MTouch.CompileTestAppExecutable (tmp, "\n\n" + code + "\n\n", "/debug:full");
 
 				// Rebuild the app


### PR DESCRIPTION
HFS timestamp resolution is 1 second, which means that we can't distinguish
files modified again within 1 second. This means that this test will fail more
often the faster we make mtouch, so add a forced sleep to make sure we don't
do things faster than the file system can keep track of.