### PR TITLE
[msbuild] Added support for <Link>'d ImageAsset project files

### DIFF
--- a/msbuild/tests/MyLinkedAssets/AppDelegate.cs
+++ b/msbuild/tests/MyLinkedAssets/AppDelegate.cs
@@ -1,0 +1,82 @@
+﻿//
+// AppDelegate.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using Foundation;
+using UIKit;
+
+namespace MyLinkedAssets
+{
+	// The UIApplicationDelegate for the application. This class is responsible for launching the
+	// User Interface of the application, as well as listening (and optionally responding) to application events from iOS.
+	[Register ("AppDelegate")]
+	public class AppDelegate : UIApplicationDelegate
+	{
+		// class-level declarations
+
+		public override UIWindow Window {
+			get;
+			set;
+		}
+
+		public override bool FinishedLaunching (UIApplication application, NSDictionary launchOptions)
+		{
+			// Override point for customization after application launch.
+			// If not required for your application you can safely delete this method
+
+			return true;
+		}
+
+		public override void OnResignActivation (UIApplication application)
+		{
+			// Invoked when the application is about to move from active to inactive state.
+			// This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) 
+			// or when the user quits the application and it begins the transition to the background state.
+			// Games should use this method to pause the game.
+		}
+
+		public override void DidEnterBackground (UIApplication application)
+		{
+			// Use this method to release shared resources, save user data, invalidate timers and store the application state.
+			// If your application supports background exection this method is called instead of WillTerminate when the user quits.
+		}
+
+		public override void WillEnterForeground (UIApplication application)
+		{
+			// Called as part of the transiton from background to active state.
+			// Here you can undo many of the changes made on entering the background.
+		}
+
+		public override void OnActivated (UIApplication application)
+		{
+			// Restart any tasks that were paused (or not yet started) while the application was inactive. 
+			// If the application was previously in the background, optionally refresh the user interface.
+		}
+
+		public override void WillTerminate (UIApplication application)
+		{
+			// Called when the application is about to terminate. Save data, if needed. See also DidEnterBackground.
+		}
+	}
+}
+

--- a/msbuild/tests/MyLinkedAssets/Assets.xcassets/Contents.json
+++ b/msbuild/tests/MyLinkedAssets/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+﻿{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/msbuild/tests/MyLinkedAssets/Entitlements.plist
+++ b/msbuild/tests/MyLinkedAssets/Entitlements.plist
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/msbuild/tests/MyLinkedAssets/Info.plist
+++ b/msbuild/tests/MyLinkedAssets/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>MyLinkedAssets</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.your-company.mylinkedassets</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>MinimumOSVersion</key>
+	<string>10.2</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>XSAppIconAssets</key>
+	<string>Assets.xcassets/AppIcon.appiconset</string>
+</dict>
+</plist>

--- a/msbuild/tests/MyLinkedAssets/LaunchScreen.storyboard
+++ b/msbuild/tests/MyLinkedAssets/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+	<dependencies>
+		<deployment identifier="iOS" />
+		<plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530" />
+	</dependencies>
+	<scenes>
+		<!--View Controller-->
+		<scene sceneID="EHf-IW-A2E">
+			<objects>
+				<viewController id="01J-lp-oVM" sceneMemberID="viewController">
+					<layoutGuides>
+						<viewControllerLayoutGuide type="top" id="Llm-lL-Icb" />
+						<viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok" />
+					</layoutGuides>
+					<view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+						<rect key="frame" x="0.0" y="0.0" width="600" height="600" />
+						<autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" />
+						<color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite" />
+					</view>
+				</viewController>
+				<placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder" />
+			</objects>
+			<point key="canvasLocation" x="53" y="375" />
+		</scene>
+	</scenes>
+</document>

--- a/msbuild/tests/MyLinkedAssets/Main.cs
+++ b/msbuild/tests/MyLinkedAssets/Main.cs
@@ -1,0 +1,39 @@
+﻿//
+// Main.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using UIKit;
+
+namespace MyLinkedAssets
+{
+	public class Application
+	{
+		// This is the main entry point of the application.
+		static void Main (string[] args)
+		{
+			// if you want to use a different Application Delegate class from "AppDelegate"
+			// you can specify it here.
+			UIApplication.Main (args, null, "AppDelegate");
+		}
+	}
+}

--- a/msbuild/tests/MyLinkedAssets/Main.storyboard
+++ b/msbuild/tests/MyLinkedAssets/Main.storyboard
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+	<dependencies>
+		<plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106" />
+		<capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0" />
+	</dependencies>
+	<scenes>
+		<!--View Controller-->
+		<scene sceneID="tne-QT-ifu">
+			<objects>
+				<viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+					<layoutGuides>
+						<viewControllerLayoutGuide type="top" id="y3c-jy-aDJ" />
+						<viewControllerLayoutGuide type="bottom" id="wfy-db-euE" />
+					</layoutGuides>
+					<view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+						<rect key="frame" x="0.0" y="0.0" width="375" height="667" />
+						<autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" />
+						<color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB" />
+					</view>
+				</viewController>
+				<placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder" />
+			</objects>
+		</scene>
+	</scenes>
+</document>

--- a/msbuild/tests/MyLinkedAssets/MyLinkedAssets.csproj
+++ b/msbuild/tests/MyLinkedAssets/MyLinkedAssets.csproj
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProjectGuid>{440392A2-298D-41CE-8353-59C6CFCE1A2D}</ProjectGuid>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MyLinkedAssets</RootNamespace>
+    <AssemblyName>MyLinkedAssets</AssemblyName>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG;ENABLE_TEST_CLOUD;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <DeviceSpecificBuild>true</DeviceSpecificBuild>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchFastDev>true</MtouchFastDev>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <IOSDebuggerPort>47997</IOSDebuggerPort>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>i386, x86_64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <DeviceSpecificBuild>true</DeviceSpecificBuild>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>i386, x86_64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;ENABLE_TEST_CLOUD;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <DeviceSpecificBuild>true</DeviceSpecificBuild>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchFastDev>true</MtouchFastDev>
+    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <ImageAsset Include="..\MySingleView\Resources\Images.xcassets\AppIcons.appiconset\Contents.json">
+      <Link>Assets.xcassets\AppIcon.appiconset\Contents.json</Link>
+    </ImageAsset>
+    <ImageAsset Include="..\MySingleView\Resources\Images.xcassets\AppIcons.appiconset\Icon.png">
+      <Link>Assets.xcassets\AppIcon.appiconset\Icon.png</Link>
+    </ImageAsset>
+    <ImageAsset Include="..\MySingleView\Resources\Images.xcassets\AppIcons.appiconset\Icon%402x.png">
+      <Link>Assets.xcassets\AppIcon.appiconset\Icon%402x.png</Link>
+    </ImageAsset>
+    <ImageAsset Include="..\MySingleView\Resources\Images.xcassets\AppIcons.appiconset\Icon-60%402x.png">
+      <Link>Assets.xcassets\AppIcon.appiconset\Icon-60%402x.png</Link>
+    </ImageAsset>
+    <ImageAsset Include="..\MySingleView\Resources\Images.xcassets\AppIcons.appiconset\Icon-Small.png">
+      <Link>Assets.xcassets\AppIcon.appiconset\Icon-Small.png</Link>
+    </ImageAsset>
+    <ImageAsset Include="..\MySingleView\Resources\Images.xcassets\AppIcons.appiconset\Icon-Small%402x.png">
+      <Link>Assets.xcassets\AppIcon.appiconset\Icon-Small%402x.png</Link>
+    </ImageAsset>
+    <ImageAsset Include="..\MySingleView\Resources\Images.xcassets\AppIcons.appiconset\Icon-Small-40%402x.png">
+      <Link>Assets.xcassets\AppIcon.appiconset\Icon-Small-40%402x.png</Link>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\Contents.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <InterfaceDefinition Include="LaunchScreen.storyboard" />
+    <InterfaceDefinition Include="Main.storyboard" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+    <None Include="Entitlements.plist" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+    <Compile Include="AppDelegate.cs" />
+    <Compile Include="ViewController.cs" />
+    <Compile Include="ViewController.designer.cs">
+      <DependentUpon>ViewController.cs</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+</Project>

--- a/msbuild/tests/MyLinkedAssets/MyLinkedAssets.sln
+++ b/msbuild/tests/MyLinkedAssets/MyLinkedAssets.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyLinkedAssets", "MyLinkedAssets.csproj", "{440392A2-298D-41CE-8353-59C6CFCE1A2D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|iPhone = Release|iPhone
+		Release|iPhoneSimulator = Release|iPhoneSimulator
+		Debug|iPhone = Debug|iPhone
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{440392A2-298D-41CE-8353-59C6CFCE1A2D}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{440392A2-298D-41CE-8353-59C6CFCE1A2D}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{440392A2-298D-41CE-8353-59C6CFCE1A2D}.Release|iPhone.ActiveCfg = Release|iPhone
+		{440392A2-298D-41CE-8353-59C6CFCE1A2D}.Release|iPhone.Build.0 = Release|iPhone
+		{440392A2-298D-41CE-8353-59C6CFCE1A2D}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{440392A2-298D-41CE-8353-59C6CFCE1A2D}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{440392A2-298D-41CE-8353-59C6CFCE1A2D}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{440392A2-298D-41CE-8353-59C6CFCE1A2D}.Debug|iPhone.Build.0 = Debug|iPhone
+	EndGlobalSection
+EndGlobal

--- a/msbuild/tests/MyLinkedAssets/ViewController.cs
+++ b/msbuild/tests/MyLinkedAssets/ViewController.cs
@@ -1,0 +1,50 @@
+﻿//
+// ViewController.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+using UIKit;
+
+namespace MyLinkedAssets
+{
+	public partial class ViewController : UIViewController
+	{
+		protected ViewController (IntPtr handle) : base (handle)
+		{
+			// Note: this .ctor should not contain any initialization logic.
+		}
+
+		public override void ViewDidLoad ()
+		{
+			base.ViewDidLoad ();
+			// Perform any additional setup after loading the view, typically from a nib.
+		}
+
+		public override void DidReceiveMemoryWarning ()
+		{
+			base.DidReceiveMemoryWarning ();
+			// Release any cached data, images, etc that aren't in use.
+		}
+	}
+}

--- a/msbuild/tests/MyLinkedAssets/ViewController.designer.cs
+++ b/msbuild/tests/MyLinkedAssets/ViewController.designer.cs
@@ -1,0 +1,17 @@
+﻿//
+// This file has been generated automatically by MonoDevelop to store outlets and
+// actions made in the Xcode designer. If it is removed, they will be lost.
+// Manual changes to this file may not be handled correctly.
+//
+using Foundation;
+
+namespace MyLinkedAssets
+{
+	[Register ("ViewController")]
+	partial class ViewController
+	{
+		void ReleaseDesignerOutlets ()
+		{
+		}
+	}
+}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/LinkedAssets.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/LinkedAssets.cs
@@ -1,0 +1,29 @@
+﻿using System.IO;
+
+using NUnit.Framework;
+
+namespace Xamarin.iOS.Tasks
+{
+	[TestFixture ("iPhone")]
+	[TestFixture ("iPhoneSimulator")]
+	public class LinkedAssets : ProjectTest
+	{
+		static readonly string[] IconNames = { "AppIcon29x29.png", "AppIcon29x29@2x.png", "AppIcon40x40@2x.png", "AppIcon57x57.png", "AppIcon57x57@2x.png", "AppIcon60x60@2x.png" };
+
+		public LinkedAssets (string platform) : base (platform)
+		{
+		}
+
+		[Test]
+		public void BuildTest ()
+		{
+			BuildProject ("MyLinkedAssets", Platform, "Debug");
+
+			foreach (var name in IconNames) {
+				var path = Path.Combine (AppBundlePath, name);
+
+				Assert.IsTrue (File.Exists (path), "The expected icon `{0}' does not exist.", name);
+			}
+		}
+	}
+}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectTest.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectTest.cs
@@ -65,7 +65,7 @@ namespace Xamarin.iOS.Tasks
 			var coreFiles = GetCoreAppFiles (platform, config, appName + ".exe", appName);
 			if (IsTVOS) {
 				TestFilesExists (platform == "iPhone" ? Path.Combine (AppBundlePath, ".monotouch-64") : AppBundlePath, coreFiles);
-			} else if (platform == "iPhone") {
+			} else {
 				bool exists = false;
 
 				var baseDir = Path.Combine (AppBundlePath, ".monotouch-32");
@@ -80,9 +80,8 @@ namespace Xamarin.iOS.Tasks
 					exists = true;
 				}
 
-				Assert.IsTrue (exists, "No .monotouch-32 or .monotouch-64 directories found");
-			} else {
-				TestFilesExists (AppBundlePath, coreFiles);
+				if (!exists)
+					TestFilesExists (AppBundlePath, coreFiles);
 			}
 
 			if (platform == "iPhone") {

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="ProjectsTests\ReleaseBuild.cs" />
     <Compile Include="TaskTests\PropertyListEditorTaskTests.cs" />
     <Compile Include="TaskTests\IBToolTaskTests.cs" />
+    <Compile Include="ProjectsTests\LinkedAssets.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Added support for properly building ImageAsset items within
a project that use the <Link> feature to point to files outside
of the project directory.

The build logic now handles the possibility of some (or all) ImageAsset
files within a .xcassets folder being linked from outside the project by
first copying these files into an intermediate directory such that the
actool program will be able to find all of the input files.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=28106