### PR TITLE
recognize networkextension app extension

### DIFF
--- a/Versions-ios.plist.in
+++ b/Versions-ios.plist.in
@@ -73,6 +73,8 @@
 			<string>9.0</string>
 			<key>com.apple.spotlight.index</key>
 			<string>9.0</string>
+			<key>com.apple.networkextension.packet-tunnel</key>
+			<string>9.0</string>
 			<key>com.apple.callkit.call-directory</key>
 			<string>10.0</string>
 			<key>com.apple.intents-service</key>

--- a/Versions-mac.plist.in
+++ b/Versions-mac.plist.in
@@ -26,6 +26,8 @@
 			<string>10.10</string>
 			<key>com.apple.widget-extension</key>
 			<string>10.10</string>
+			<key>com.apple.networkextension.packet-tunnel</key>
+			<string>10.11</string>
 		</dict>
 	</dict>
 </dict>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
@@ -112,6 +112,7 @@ namespace Xamarin.iOS.Tasks
 			case "com.apple.intents-ui-service": // iOS
 			case "com.apple.usernotifications.content-extension": // iOS
 			case "com.apple.usernotifications.service": // iOS
+			case "com.apple.networkextension.packet-tunnel": // iOS+OSX
 				break;
 			case "com.apple.watchkit": // iOS8.2
 				var attributes = extension.Get<PDictionary> ("NSExtensionAttributes");


### PR DESCRIPTION
Get rid of the warning

```
/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/iOS/Xamarin.iOS.Common.targets:  warning : The App Extension 'packettunnel' has an unrecognized NSExtensionPointIdentifier value ('com.apple.networkextension.packet-tunnel').
```

when compiling.