### PR TITLE
[msbuild] Only use File.GetLastWriteTimeUtc

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
@@ -174,7 +174,7 @@ namespace Xamarin.MacDev.Tasks
 				var bundleName = BundleResource.GetLogicalName (ProjectDir, prefixes, asset, !string.IsNullOrEmpty(SessionId));
 				var output = new TaskItem (Path.Combine (intermediate, bundleName));
 
-				if (!modified.Contains (scnassets) && (!File.Exists (output.ItemSpec) || File.GetLastWriteTime (asset.ItemSpec) > File.GetLastWriteTime (output.ItemSpec))) {
+				if (!modified.Contains (scnassets) && (!File.Exists (output.ItemSpec) || File.GetLastWriteTimeUtc (asset.ItemSpec) > File.GetLastWriteTimeUtc (output.ItemSpec))) {
 					var item = new TaskItem (scnassets);
 
 					metadata = asset.GetMetadata ("DefiningProjectFullPath");

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateAssetPackManifestTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateAssetPackManifestTaskBase.cs
@@ -45,10 +45,10 @@ namespace Xamarin.MacDev.Tasks
 			var manifestPath = Path.Combine (AppBundleDir.ItemSpec, "AssetPackManifestTemplate.plist");
 			var onDemandResourcesPath = Path.Combine (AppBundleDir.ItemSpec, "OnDemandResources.plist");
 			var onDemandResourcesDir = Path.Combine (OutputPath, "OnDemandResources");
-			var onDemandResourcesStamp = File.GetLastWriteTime (onDemandResourcesPath);
+			var onDemandResourcesStamp = File.GetLastWriteTimeUtc (onDemandResourcesPath);
 			var initialInstallTags = new HashSet<string> (AssetPackUtils.ParseTags (InitialInstallTags));
 			var prefetchOrder = AssetPackUtils.ParseTags (PrefetchOrder);
-			var manifestStamp = File.GetLastWriteTime (manifestPath);
+			var manifestStamp = File.GetLastWriteTimeUtc (manifestPath);
 			var onDemandResources = new PDictionary ();
 			var requestTags = new PDictionary ();
 			bool updateOnDemandResources = false;
@@ -78,7 +78,7 @@ namespace Xamarin.MacDev.Tasks
 				if (!File.Exists (path))
 					continue;
 
-				var mtime = File.GetLastWriteTime (path);
+				var mtime = File.GetLastWriteTimeUtc (path);
 
 				updateOnDemandResources = updateOnDemandResources || mtime > onDemandResourcesStamp;
 				updateManifest = updateManifest || mtime > manifestStamp;

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
@@ -167,7 +167,7 @@ namespace Xamarin.MacDev.Tasks
 
 		static bool InterfaceDefinitionChanged (ITaskItem interfaceDefinition, ITaskItem log)
 		{
-			return !LogExists (log.ItemSpec) || File.GetLastWriteTime (log.ItemSpec) < File.GetLastWriteTime (interfaceDefinition.ItemSpec);
+			return !LogExists (log.ItemSpec) || File.GetLastWriteTimeUtc (log.ItemSpec) < File.GetLastWriteTimeUtc (interfaceDefinition.ItemSpec);
 		}
 
 		bool CompileInterfaceDefinitions (string baseManifestDir, string baseOutputDir, List<ITaskItem> compiled, IList<ITaskItem> manifests, out bool changed)

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/SmartCopyTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/SmartCopyTaskBase.cs
@@ -39,7 +39,7 @@ namespace Xamarin.MacDev.Tasks
 			var sourceInfo = new FileInfo (source);
 			var targetInfo = new FileInfo (target);
 
-			return sourceInfo.Length != targetInfo.Length || File.GetLastWriteTime (source) > File.GetLastWriteTime (target);
+			return sourceInfo.Length != targetInfo.Length || File.GetLastWriteTimeUtc (source) > File.GetLastWriteTimeUtc (target);
 		}
 
 		void EnsureDirectoryExists (string path)

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/TextureAtlasTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/TextureAtlasTaskBase.cs
@@ -72,7 +72,7 @@ namespace Xamarin.MacDev.Tasks
 			var items = atlases[input.ItemSpec];
 
 			foreach (var item in items) {
-				if (File.GetLastWriteTime (item.ItemSpec) > File.GetLastWriteTime (plist))
+				if (File.GetLastWriteTimeUtc (item.ItemSpec) > File.GetLastWriteTimeUtc (plist))
 					return true;
 			}
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/UnpackLibraryResourcesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/UnpackLibraryResourcesTaskBase.cs
@@ -124,7 +124,7 @@ namespace Xamarin.MacDev.Tasks
 				var path = Path.Combine (intermediatePath, rpath);
 				var file = new FileInfo (path);
 
-				if (file.Exists && file.LastWriteTime >= asmWriteTime) {
+				if (file.Exists && file.LastWriteTimeUtc >= asmWriteTime) {
 					Log.LogMessage ("    Up to date: {0}", rpath);
 				} else {
 					Log.LogMessage ("    Unpacking: {0}", rpath);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/UnpackLibraryResourcesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/UnpackLibraryResourcesTaskBase.cs
@@ -106,7 +106,7 @@ namespace Xamarin.MacDev.Tasks
 			if (!File.Exists (assembly))
 				yield break;
 
-			var asmWriteTime = File.GetLastWriteTime (assembly);
+			var asmWriteTime = File.GetLastWriteTimeUtc (assembly);
 
 			foreach (var embedded in GetAssemblyManifestResources (assembly)) {
 				string rpath;

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeToolTaskBase.cs
@@ -90,7 +90,7 @@ namespace Xamarin.MacDev.Tasks
 			var dest = output.GetMetadata ("FullPath");
 			var src = input.GetMetadata ("FullPath");
 
-			return !File.Exists (dest) || File.GetLastWriteTime (src) > File.GetLastWriteTime (dest);
+			return !File.Exists (dest) || File.GetLastWriteTimeUtc (src) > File.GetLastWriteTimeUtc (dest);
 		}
 
 		string GetFullPathToTool ()

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectTest.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectTest.cs
@@ -90,7 +90,7 @@ namespace Xamarin.iOS.Tasks
 				var nativeExecutable = Path.Combine (AppBundlePath, appName);
 
 				Assert.IsTrue (File.Exists (dSYMInfoPlist), "dSYM Info.plist file does not exist");
-				Assert.IsTrue (File.GetLastWriteTime (dSYMInfoPlist) >= File.GetLastWriteTime (nativeExecutable), "dSYM Info.plist should be newer than the native executable");
+				Assert.IsTrue (File.GetLastWriteTimeUtc (dSYMInfoPlist) >= File.GetLastWriteTimeUtc (nativeExecutable), "dSYM Info.plist should be newer than the native executable");
 			}
 
 			return csproj;

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ReleaseBuild.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ReleaseBuild.cs
@@ -52,7 +52,7 @@ namespace Xamarin.iOS.Tasks
 			File.Copy (csproj, bak, true);
 			try {
 				File.Copy (llvm, csproj, true);
-				File.SetLastWriteTime (csproj, DateTime.Now);
+				File.SetLastWriteTimeUtc (csproj, DateTime.UtcNow);
 
 				BuildProject ("MyReleaseBuild", Platform, "Release", clean: false);
 			} finally {

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
@@ -280,7 +280,7 @@ namespace Xamarin.iOS.Tasks
 			if (!File.Exists (file))
 				Assert.Fail ("Expected file '{0}' did not exist", file);
 
-			return File.GetLastWriteTime (file);
+			return File.GetLastWriteTimeUtc (file);
 		}
 
 		protected void RemoveItemsByName (Project project, string itemName)

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
@@ -188,9 +188,9 @@ namespace Xamarin.iOS.Tasks
 
 			// Reset all the write times as we deliberately set some in the future for our tests
 			foreach (var file in Directory.GetFiles (MonoTouchProjectPath, "*.*", SearchOption.AllDirectories))
-				File.SetLastWriteTime (file, DateTime.Now);
+				File.SetLastWriteTimeUtc (file, DateTime.UtcNow);
 			foreach (var file in Directory.GetFiles (LibraryProjectPath, "*.*", SearchOption.AllDirectories))
-				File.SetLastWriteTime (file, DateTime.Now);
+				File.SetLastWriteTimeUtc (file, DateTime.UtcNow);
 		}
 
 		protected void SafeDelete (string path)
@@ -309,7 +309,7 @@ namespace Xamarin.iOS.Tasks
 		{
 			if (!File.Exists (file))
 				Assert.Fail ("Expected file '{0}' did not exist", file);
-			File.SetLastWriteTime (file, DateTime.Now.AddDays (1));
+			File.SetLastWriteTimeUtc (file, DateTime.UtcNow.AddDays (1));
 			System.Threading.Thread.Sleep (1000);
 		}
 


### PR DESCRIPTION
Instead of just using File.GetLastWriteTime.
Fixes bug #51694: Use File.GetLastWriteTimeUtc not File.GetLastWriteTime
https://bugzilla.xamarin.com/show_bug.cgi?id=51694