### PR TITLE
[mtouch] It's no longer necessary to set MONO_GC_PARAMS during AOT-compilation.

### DIFF
--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -520,7 +520,6 @@ namespace Xamarin.Bundler
 			info.RedirectStandardError = true;
 
 			info.EnvironmentVariables ["MONO_PATH"] = mono_path;
-			info.EnvironmentVariables ["MONO_GC_PARAMS"] = app.MonoGCParams;
 			if (mono_debug != null)
 				info.EnvironmentVariables ["MONO_DEBUG"] = mono_debug;
 


### PR DESCRIPTION
According to Vlad it's not necessary to set MONO_GC_PARAMS during AOT-
compilation, since all MONO_GC_PARAMS options can be changed at runtime:

Rolf Kvinge [16:35] @vlad.brezae is this true for all the different options MONO_GC_PARAMS take: https://github.com/xamarin/xamarin-macios/pull/1546#discussion_r97318092?
Rolf Kvinge [16:36] I remember this: https://bugzilla.xamarin.com/show_bug.cgi?id=35414#c14
Rofl Kvinge [16:36] which apparently you changed here, so that it can be changed at runtime: https://bugzilla.xamarin.com/show_bug.cgi?id=35414#c27
Rolf Kvinge [16:36] but I don't know if this is true for all the options you can pass using MONO_GC_PARAMS
Vlad Brezae [16:41] yes, it should be true for all of them, that was a bug
Rolf Kvinge [16:41] ok, that's great news :smile: