### PR TITLE
Use @rpath instead of @executable_path in dylibs.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -283,7 +283,7 @@ endef
 define lipo_template_dynamic
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/$1: mac32/$(2)/.libs/$(1) mac64/$(2)/.libs/$(1) | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib
 	$(QT_LIPO) lipo -create $$+ -output $$@
-	$(Q) install_name_tool -id @executable_path/$1 $$@
+	$(Q) install_name_tool -id @rpath/$1 $$@
 
 MAC_TARGETS += $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/$1
 endef
@@ -926,7 +926,7 @@ $(eval SIM_TARGET_SHAREDLIBLOGPROFILER:=$(SIM_TARGET_SHAREDLIBLOGPROFILER) $(BUI
 
 $(BUILD_DESTDIR)/$(2)/tmp-lib/libmono-profiler-log.0.dylib: $(BUILD_DESTDIR)/$(2)/lib/libmono-profiler-log.0.dylib | $(BUILD_DESTDIR)/$(2)/tmp-lib
 	$(Q) cp $$< $$@
-	$(Q) install_name_tool -id @executable_path/libmono-profiler-log.dylib -change $(BUILD_DESTDIR)/$(2)/lib/libmonosgen-2.0.1.dylib @executable_path/libmonosgen-2.0.dylib $$@
+	$(Q) install_name_tool -id @rpath/libmono-profiler-log.dylib -change $(BUILD_DESTDIR)/$(2)/lib/libmonosgen-2.0.1.dylib @rpath/libmonosgen-2.0.dylib $$@
 
 $(BUILD_DESTDIR)/$(2)/tmp-lib:
 	$$(Q) mkdir -p $$@
@@ -962,7 +962,7 @@ $(IOS_DESTDIR)$(IPHONESIMULATOR_PREFIX)/lib/libmonosgen-2.0.a: $(SIM_TARGET_LIBM
 
 $(IOS_DESTDIR)$(IPHONESIMULATOR_PREFIX)/lib/libmonosgen-2.0.dylib: $(SIM_TARGET_SHAREDMONOSGEN) | $(IOS_DESTDIR)$(IPHONESIMULATOR_PREFIX)/lib
 	$(Q) lipo $(SIM_TARGET_SHAREDMONOSGEN) -create -output $@
-	$(Q) install_name_tool -id @executable_path/libmonosgen-2.0.dylib $@
+	$(Q) install_name_tool -id @rpath/libmonosgen-2.0.dylib $@
 
 $(IOS_DESTDIR)$(IPHONESIMULATOR_PREFIX)/lib/libmono-profiler-log.a: $(SIM_TARGET_LIBLOGPROFILER) | $(IOS_DESTDIR)$(IPHONESIMULATOR_PREFIX)/lib
 	$(Q) lipo $(SIM_TARGET_LIBLOGPROFILER) -create -output $@
@@ -1102,14 +1102,14 @@ $(IOS_DESTDIR)$(XAMARIN_WATCHSIMULATOR_SDK)/usr/lib/libmonosgen-2.0.a: $(WATCHSI
 
 $(IOS_DESTDIR)$(XAMARIN_WATCHSIMULATOR_SDK)/usr/lib/libmonosgen-2.0.dylib: $(WATCHSIMULATOR_SHAREDMONOSGEN) | $(IOS_DESTDIR)$(XAMARIN_WATCHSIMULATOR_SDK)/usr/lib
 	$(Q) $(WATCHOS_BIN_PATH)/lipo $(WATCHSIMULATOR_SHAREDMONOSGEN) -create -output $@
-	$(Q) $(WATCHOS_BIN_PATH)/install_name_tool -id @executable_path/libmonosgen-2.0.dylib $@
+	$(Q) $(WATCHOS_BIN_PATH)/install_name_tool -id @rpath/libmonosgen-2.0.dylib $@
 
 $(IOS_DESTDIR)$(XAMARIN_WATCHSIMULATOR_SDK)/usr/lib/libmono-profiler-log.a: $(WATCHSIMULATOR_LIBLOGPROFILER) | $(IOS_DESTDIR)$(XAMARIN_WATCHSIMULATOR_SDK)/usr/lib
 	$(Q) $(WATCHOS_BIN_PATH)/lipo $(WATCHSIMULATOR_LIBLOGPROFILER) -create -output $@
 
 $(IOS_DESTDIR)$(XAMARIN_WATCHSIMULATOR_SDK)/usr/lib/libmono-profiler-log.dylib: $(WATCHSIMULATOR_SHAREDLIBLOGPROFILER) | $(IOS_DESTDIR)$(XAMARIN_WATCHSIMULATOR_SDK)/usr/lib
 	$(Q) $(WATCHOS_BIN_PATH)/lipo $(WATCHSIMULATOR_SHAREDLIBLOGPROFILER) -create -output $@
-	$(Q) $(WATCHOS_BIN_PATH)/install_name_tool -id @executable_path/libmono-profiler-log.dylib -change $(BUILD_DESTDIR)/watchsimulator/lib/libmonosgen-2.0.1.dylib @executable_path/libmonosgen-2.0.dylib $@
+	$(Q) $(WATCHOS_BIN_PATH)/install_name_tool -id @rpath/libmono-profiler-log.dylib -change $(BUILD_DESTDIR)/watchsimulator/lib/libmonosgen-2.0.1.dylib @rpath/libmonosgen-2.0.dylib $@
 
 $(WATCHSIMULATOR_DIRECTORIES):
 	$(Q) mkdir -p $@
@@ -1241,14 +1241,14 @@ $(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/usr/lib/libmonosgen-2.0.a: $(TVSIMULATO
 
 $(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/usr/lib/libmonosgen-2.0.dylib: $(TVSIMULATOR_SHAREDMONOSGEN) | $(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/usr/lib
 	$(Q) $(TVOS_BIN_PATH)/lipo $(TVSIMULATOR_SHAREDMONOSGEN) -create -output $@
-	$(Q) $(TVOS_BIN_PATH)/install_name_tool -id @executable_path/libmonosgen-2.0.dylib $@
+	$(Q) $(TVOS_BIN_PATH)/install_name_tool -id @rpath/libmonosgen-2.0.dylib $@
 
 $(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/usr/lib/libmono-profiler-log.a: $(TVSIMULATOR_LIBLOGPROFILER) | $(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/usr/lib
 	$(Q) $(TVOS_BIN_PATH)/lipo $(TVSIMULATOR_LIBLOGPROFILER) -create -output $@
 
 $(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/usr/lib/libmono-profiler-log.dylib: $(TVSIMULATOR_SHAREDLIBLOGPROFILER) | $(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/usr/lib
 	$(Q) $(TVOS_BIN_PATH)/lipo $(TVSIMULATOR_SHAREDLIBLOGPROFILER) -create -output $@
-	$(Q) $(TVOS_BIN_PATH)/install_name_tool -id @executable_path/libmono-profiler-log.dylib -change $(BUILD_DESTDIR)/tvsimulator/lib/libmonosgen-2.0.1.dylib @executable_path/libmonosgen-2.0.dylib $@
+	$(Q) $(TVOS_BIN_PATH)/install_name_tool -id @rpath/libmono-profiler-log.dylib -change $(BUILD_DESTDIR)/tvsimulator/lib/libmonosgen-2.0.1.dylib @rpath/libmonosgen-2.0.dylib $@
 
 $(TVSIMULATOR_DIRECTORIES):
 	$(Q) mkdir -p $@
@@ -1396,14 +1396,14 @@ $(BUILD_DESTDIR)/$(2)/tmp-lib/libmonosgen-2.0.dylib: $(BUILD_DESTDIR)/$(2)/lib/l
 	$$(Q) rm -Rf $$@.tmpdir
 	$$(Q) mkdir -p $$@.tmpdir
 	$$(Q) cd $$@.tmpdir && ar -x $$<
-	$$(Q) $$(IOS_CC) -arch $(1) -dynamiclib -o $$@ $$@.tmpdir/*.o -liconv -O2 -Wl,-application_extension -miphoneos-version-min=7.0 -isysroot $(PLATFORM_SDK) -install_name @executable_path/libmonosgen-2.0.dylib -compatibility_version 2 -current_version 2.0 -framework CoreFoundation -lobjc $(IOS_BITCODE_LDFLAGS) -Wl,-single_module
+	$$(Q) $$(IOS_CC) -arch $(1) -dynamiclib -o $$@ $$@.tmpdir/*.o -liconv -O2 -Wl,-application_extension -miphoneos-version-min=7.0 -isysroot $(PLATFORM_SDK) -install_name @rpath/libmonosgen-2.0.dylib -compatibility_version 2 -current_version 2.0 -framework CoreFoundation -lobjc $(IOS_BITCODE_LDFLAGS) -Wl,-single_module
 	$$(Q) rm -Rf $$@.tmpdir
 
 $(BUILD_DESTDIR)/$(2)/tmp-lib/libmono-profiler-log.0.dylib: $(BUILD_DESTDIR)/$(2)/lib/libmono-profiler-log.a $(BUILD_DESTDIR)/$(2)/tmp-lib/libmonosgen-2.0.dylib | $(BUILD_DESTDIR)/$(2)/tmp-lib
 	$$(Q) rm -Rf $$@.tmpdir
 	$$(Q) mkdir -p $$@.tmpdir
 	$$(Q) cd $$@.tmpdir && ar -x $$<
-	$$(Q) $$(IOS_CC) -arch $(1) -dynamiclib -o $$@ $$@.tmpdir/*.o -liconv -O2 -Wl,-application_extension -miphoneos-version-min=7.0 -isysroot $(PLATFORM_SDK) -install_name @executable_path/libmono-profiler-log.dylib -compatibility_version 2 -current_version 2.0 -framework CoreFoundation -lobjc -Wl,-single_module -L$(BUILD_DESTDIR)/$(2)/tmp-lib -lmonosgen-2.0 -lz
+	$$(Q) $$(IOS_CC) -arch $(1) -dynamiclib -o $$@ $$@.tmpdir/*.o -liconv -O2 -Wl,-application_extension -miphoneos-version-min=7.0 -isysroot $(PLATFORM_SDK) -install_name @rpath/libmono-profiler-log.dylib -compatibility_version 2 -current_version 2.0 -framework CoreFoundation -lobjc -Wl,-single_module -L$(BUILD_DESTDIR)/$(2)/tmp-lib -lmonosgen-2.0 -lz
 	$$(Q) rm -Rf $$@.tmpdir
 
 endef
@@ -1463,7 +1463,7 @@ $(IOS_DESTDIR)$(IPHONEOS_PREFIX)/lib/libmonosgen-2.0.a: $(TARGET_LIBMONOSGEN) | 
 
 $(IOS_DESTDIR)$(IPHONEOS_PREFIX)/lib/libmonosgen-2.0.dylib: $(TARGET_SHAREDMONOSGEN) | $(IOS_DESTDIR)$(IPHONEOS_PREFIX)/lib
 	$(Q) lipo $(TARGET_SHAREDMONOSGEN) -create -output $@
-	$(Q) install_name_tool -id @executable_path/libmonosgen-2.0.dylib $@
+	$(Q) install_name_tool -id @rpath/libmonosgen-2.0.dylib $@
 
 $(IOS_DESTDIR)$(IPHONEOS_PREFIX)/lib/libmono-profiler-log.a: $(TARGET_LIBLOGPROFILER) | $(IOS_DESTDIR)$(IPHONEOS_PREFIX)/lib
 	$(Q) lipo $(TARGET_LIBLOGPROFILER) -create -output $@
@@ -1627,21 +1627,21 @@ $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmonosgen-2.0.a: $(WATCHOS_TARGET
 
 $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmonosgen-2.0.dylib: $(WATCHOS_TARGET_SHAREDMONOSGEN) | $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib
 	$(Q_STRIP) $(WATCHOS_BIN_PATH)/bitcode_strip $(WATCHOS_TARGET_SHAREDMONOSGEN) -m -o $@
-	$(Q) $(WATCHOS_BIN_PATH)/install_name_tool -id @executable_path/libmonosgen-2.0.dylib $@
+	$(Q) $(WATCHOS_BIN_PATH)/install_name_tool -id @rpath/libmonosgen-2.0.dylib $@
 
 $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmono-profiler-log.a: $(WATCHOS_TARGET_LIBLOGPROFILER) | $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib
 	$(Q) $(WATCHOS_BIN_PATH)/lipo $(WATCHOS_TARGET_LIBLOGPROFILER) -create -output $@
 
 $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmono-profiler-log.dylib: $(WATCHOS_TARGET_SHAREDLIBLOGPROFILER) | $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib
 	$(Q) $(WATCHOS_BIN_PATH)/bitcode_strip $(WATCHOS_TARGET_SHAREDLIBLOGPROFILER) -m -o $@
-	$(Q) $(WATCHOS_BIN_PATH)/install_name_tool -id @executable_path/libmono-profiler-log.dylib -change $(BUILD_DESTDIR)/targetwatch/lib/libmonosgen-2.0.1.dylib @executable_path/libmonosgen-2.0.dylib $@
+	$(Q) $(WATCHOS_BIN_PATH)/install_name_tool -id @rpath/libmono-profiler-log.dylib -change $(BUILD_DESTDIR)/targetwatch/lib/libmonosgen-2.0.1.dylib @rpath/libmonosgen-2.0.dylib $@
 
 $(WATCHOS_DIRECTORIES):
 	$(Q) mkdir -p $@
 
 $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks/Mono.framework/Mono: $(WATCHOS_TARGET_SHAREDLIBLOGPROFILER) | $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks/Mono.framework
 	$(Q) cp $< $@
-	$(Q) $(WATCHOS_BIN_PATH)/install_name_tool -id @rpath/Mono.framework/Mono -change $(BUILD_DESTDIR)/targetwatch/lib/libmonosgen-2.0.1.dylib @executable_path/libmonosgen-2.0.dylib $@
+	$(Q) $(WATCHOS_BIN_PATH)/install_name_tool -id @rpath/Mono.framework/Mono -change $(BUILD_DESTDIR)/targetwatch/lib/libmonosgen-2.0.1.dylib @rpath/libmonosgen-2.0.dylib $@
 
 $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks/Mono.framework/Info.plist: Mono.framework-watchos.Info.plist | $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks/Mono.framework
 	$(Q) cp $< $@
@@ -1797,14 +1797,14 @@ $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib/libmonosgen-2.0.a: $(TVOS_TARGET_LIBMO
 
 $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib/libmonosgen-2.0.dylib: $(TVOS_TARGET_SHAREDMONOSGEN) | $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib
 	$(Q) $(TVOS_BIN_PATH)/lipo $(TVOS_TARGET_SHAREDMONOSGEN) -create -output $@
-	$(Q) $(TVOS_BIN_PATH)/install_name_tool -id @executable_path/libmonosgen-2.0.dylib $@
+	$(Q) $(TVOS_BIN_PATH)/install_name_tool -id @rpath/libmonosgen-2.0.dylib $@
 
 $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib/libmono-profiler-log.a: $(TVOS_TARGET_LIBLOGPROFILER) | $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib
 	$(Q) $(TVOS_BIN_PATH)/lipo $(TVOS_TARGET_LIBLOGPROFILER) -create -output $@
 
 $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib/libmono-profiler-log.dylib: $(TVOS_TARGET_SHAREDLIBLOGPROFILER) | $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib
 	$(Q) lipo $(TVOS_TARGET_SHAREDLIBLOGPROFILER) -create -output $@
-	$(Q) $(TVOS_BIN_PATH)/install_name_tool -id @executable_path/libmono-profiler-log.dylib -change $(BUILD_DESTDIR)/targettv/lib/libmonosgen-2.0.1.dylib @executable_path/libmonosgen-2.0.dylib $@
+	$(Q) $(TVOS_BIN_PATH)/install_name_tool -id @rpath/libmono-profiler-log.dylib -change $(BUILD_DESTDIR)/targettv/lib/libmonosgen-2.0.1.dylib @rpath/libmonosgen-2.0.dylib $@
 
 $(TVOS_DIRECTORIES):
 	$(Q) mkdir -p $@

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -30,7 +30,7 @@ define NativeCompilationTemplate
 
 .libs/ios/%$(1).x86.dylib: | .libs/ios
 	$$(call Q_2,LD,    [ios]) $(SIMULATOR_CC) $(SIMULATOR86_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/simulator86/lib -fapplication-extension
-	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/simulator86/lib/libmonosgen-2.0.dylib) @executable_path/libmonosgen-2.0.dylib $$@
+	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/simulator86/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
 
 .libs/ios/%$(1).x86_64.o: %.m $(EXTRA_DEPENDENCIES) | .libs/ios
 	$$(call Q_2,OBJC,  [ios]) $(SIMULATOR_CC) $(SIMULATOR64_OBJC_CFLAGS) $$(EXTRA_DEFINES) $(SIM64_I) -g $(2) -c $$< -o $$@
@@ -43,7 +43,7 @@ define NativeCompilationTemplate
 
 .libs/ios/%$(1).x86_64.dylib: | .libs/ios
 	$$(call Q_2,LD,    [ios]) $(SIMULATOR_CC) $(SIMULATOR64_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/simulator64/lib -fapplication-extension
-	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/simulator64/lib/libmonosgen-2.0.dylib) @executable_path/libmonosgen-2.0.dylib $$@
+	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/simulator64/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
 
 ## ios device
 
@@ -55,7 +55,7 @@ define NativeCompilationTemplate
 
 .libs/ios/%$(1).armv7.dylib: | .libs/ios
 	$$(call Q_2,LD,    [ios]) $(DEVICE_CC) $(DEVICE7_CFLAGS)       $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/target7/lib   -fapplication-extension
-	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/target7/lib/libmonosgen-2.0.dylib) @executable_path/libmonosgen-2.0.dylib $$@
+	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/target7/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
 
 .libs/ios/%$(1).armv7s.o: %.m $(EXTRA_DEPENDENCIES) | .libs/ios
 	$$(call Q_2,OBJC,  [ios]) $(DEVICE_CC) $(DEVICE7S_OBJC_CFLAGS) $$(EXTRA_DEFINES) $(DEV7s_I) -g $(2) -c $$< -o $$@ 
@@ -65,7 +65,7 @@ define NativeCompilationTemplate
 
 .libs/ios/%$(1).armv7s.dylib: | .libs/ios
 	$$(call Q_2,LD,    [ios]) $(DEVICE_CC) $(DEVICE7S_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/target7s/lib -fapplication-extension
-	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/target7s/lib/libmonosgen-2.0.dylib) @executable_path/libmonosgen-2.0.dylib $$@
+	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/target7s/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
 
 .libs/ios/%$(1).arm64.o: %.m $(EXTRA_DEPENDENCIES) | .libs/ios
 	$$(call Q_2,OBJC,  [ios]) $(DEVICE_CC) $(DEVICE64_OBJC_CFLAGS) $$(EXTRA_DEFINES) $(DEV64_I) -g $(2) -c $$< -o $$@ 
@@ -75,7 +75,7 @@ define NativeCompilationTemplate
 
 .libs/ios/%$(1).arm64.dylib: | .libs/ios
 	$$(call Q_2,LD,    [ios]) $(DEVICE_CC) $(DEVICE64_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/target64/lib -fapplication-extension
-	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/target64/lib/libmonosgen-2.0.dylib) @executable_path/libmonosgen-2.0.dylib $$@
+	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/target64/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
 
 ## watch simulator
 
@@ -90,7 +90,7 @@ define NativeCompilationTemplate
 
 .libs/watchos/%$(1).x86.dylib: | .libs/watchos
 	$$(call Q_2,LD,    [watchos]) $(SIMULATOR_CC) $(SIMULATORWATCH_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/watchsimulator/lib -fapplication-extension
-	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/watchsimulator/lib/libmonosgen-2.0.dylib) @executable_path/libmonosgen-2.0.dylib $$@
+	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/watchsimulator/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
 
 ## watch device
 
@@ -102,7 +102,7 @@ define NativeCompilationTemplate
 
 .libs/watchos/%$(1).armv7k.dylib: | .libs/watchos
 	$$(call Q_2,LD,    [watchos]) $(DEVICE_CC) $(DEVICEWATCH_CFLAGS)          $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/targetwatch/lib -fapplication-extension
-	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/targetwatch/lib/libmonosgen-2.0.dylib) @executable_path/libmonosgen-2.0.dylib $$@
+	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/targetwatch/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
 
 ## tv simulator
 
@@ -117,7 +117,7 @@ define NativeCompilationTemplate
 
 .libs/tvos/%$(1).x86_64.dylib: | .libs/tvos
 	$$(call Q_2,LD,    [tvos]) $(SIMULATOR_CC) $(SIMULATORTV_CFLAGS)         $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/tvsimulator/lib -fapplication-extension
-	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/tvsimulator/lib/libmonosgen-2.0.dylib) @executable_path/libmonosgen-2.0.dylib $$@
+	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/tvsimulator/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
 
 ## tv device
 
@@ -129,7 +129,7 @@ define NativeCompilationTemplate
 
 .libs/tvos/%$(1).arm64.dylib: | .libs/tvos
 	$$(call Q_2,LD,    [tvos]) $(DEVICE_CC)    $(DEVICETV_CFLAGS)            $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/targettv/lib -fapplication-extension
-	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/targettv/lib/libmonosgen-2.0.dylib) @executable_path/libmonosgen-2.0.dylib $$@
+	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/targettv/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
 
 endef
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -217,14 +217,14 @@ $$(foreach arch,$$($(2)_ARCHITECTURES),.libs/$(1)/tvextension-main.$$(arch).o): 
 .libs/$(1)/libxamarin-sim.dylib:  $$(foreach arch,$$($(2)_SIM_ARCHITECTURES),.libs/$(1)/libxamarin.$$(arch).dylib)
 	$(Q) rm -f $$@
 	$$(call Q_2,LIPO,  [$1]) $(DEVICE_BIN_PATH)/lipo $$^ -create -output $$@
-	$(Q) install_name_tool -id @executable_path/libxamarin.dylib $$@
-	$(Q) install_name_tool -change @executable_path/ @executable_path/libmonosgen-2.0.dylib $$@
+	$(Q) install_name_tool -id @rpath/libxamarin.dylib $$@
+	$(Q) install_name_tool -change @rpath/ @rpath/libmonosgen-2.0.dylib $$@
 
 .libs/$(1)/libxamarin-debug-sim.dylib:  $$(foreach arch,$$($(2)_SIM_ARCHITECTURES),.libs/$(1)/libxamarin-debug.$$(arch).dylib)
 	$(Q) rm -f $$@
 	$$(call Q_2,LIPO,  [$1]) $(DEVICE_BIN_PATH)/lipo $$^ -create -output $$@
-	$(Q) install_name_tool -id @executable_path/libxamarin-debug.dylib $$@
-	$(Q) install_name_tool -change @executable_path/ @executable_path/libmonosgen-2.0.dylib $$@
+	$(Q) install_name_tool -id @rpath/libxamarin-debug.dylib $$@
+	$(Q) install_name_tool -change @rpath/ @rpath/libmonosgen-2.0.dylib $$@
 
 .libs/$(1)/libxamarin-dev.dylib:  $$(foreach arch,$$($(2)_DEVICE_ARCHITECTURES),.libs/$(1)/libxamarin.$$(arch).dylib)
 	$(Q) rm -f $$@
@@ -233,8 +233,8 @@ ifeq (1,$$(words $$($(2)_DEVICE_ARCHITECTURES)))
 else
 	$$(call Q_2,LIPO,  [$1]) $(DEVICE_BIN_PATH)/lipo $$^ -create -output $$@
 endif
-	$(Q) install_name_tool -id @executable_path/libxamarin.dylib $$@
-	$(Q) install_name_tool -change @executable_path/ @executable_path/libmonosgen-2.0.dylib $$@
+	$(Q) install_name_tool -id @rpath/libxamarin.dylib $$@
+	$(Q) install_name_tool -change @rpath/ @rpath/libmonosgen-2.0.dylib $$@
 
 .libs/$(1)/libxamarin-debug-dev.dylib:  $$(foreach arch,$$($(2)_DEVICE_ARCHITECTURES),.libs/$(1)/libxamarin-debug.$$(arch).dylib)
 	$(Q) rm -f $$@
@@ -243,8 +243,8 @@ ifeq (1,$$(words $$($(2)_DEVICE_ARCHITECTURES)))
 else
 	$$(call Q_2,LIPO,  [$1]) $(DEVICE_BIN_PATH)/lipo $$^ -create -output $$@
 endif
-	$(Q) install_name_tool -id @executable_path/libxamarin-debug.dylib $$@
-	$(Q) install_name_tool -change @executable_path/ @executable_path/libmonosgen-2.0.dylib $$@
+	$(Q) install_name_tool -id @rpath/libxamarin-debug.dylib $$@
+	$(Q) install_name_tool -change @rpath/ @rpath/libmonosgen-2.0.dylib $$@
 
 .SECONDARY: $$(foreach arch,$$($(2)_ARCHITECTURES),.libs/$(1)/app-main.$$(arch).o)
 endef

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2042,7 +2042,7 @@ class Test {
 				var lines = otool_output.Split (new char [] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
 				for (int i = 0; i < lines.Length; i++) {
 					if (lines [i].Contains ("LC_ID_DYLIB")) {
-						Assert.That (lines [i + 2], Does.Contain ("name @executable_path/libpinvokes.dylib "), "LC_ID_DYLIB");
+						Assert.That (lines [i + 2], Does.Contain ("name @rpath/libpinvokes.dylib "), "LC_ID_DYLIB");
 						break;
 					}
 				}

--- a/tools/common/CompilerFlags.cs
+++ b/tools/common/CompilerFlags.cs
@@ -233,6 +233,9 @@ namespace Xamarin.Utils
 				if (Application.IsExtension)
 					args.Append (" -Xlinker -rpath -Xlinker @executable_path/../../Frameworks");
 			}
+
+			if (Application.FastDev)
+				args.Append (" -Xlinker -rpath -Xlinker @executable_path");
 		}
 
 		void ProcessFrameworkForArguments (StringBuilder args, string fw, bool is_weak, ref bool any_user_framework)

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1068,8 +1068,8 @@ namespace Xamarin.Bundler {
 
 				if (UseMonoFramework.Value) {
 					if (EnableProfiling)
-						Driver.XcodeRun ("install_name_tool", "-change @executable_path/libmonosgen-2.0.dylib @rpath/Mono.framework/Mono " + Driver.Quote (libprofiler_target));
-					Driver.XcodeRun ("install_name_tool", "-change @executable_path/libmonosgen-2.0.dylib @rpath/Mono.framework/Mono " + Driver.Quote (libxamarin_target));
+						Driver.XcodeRun ("install_name_tool", "-change @rpath/libmonosgen-2.0.dylib @rpath/Mono.framework/Mono " + Driver.Quote (libprofiler_target));
+					Driver.XcodeRun ("install_name_tool", "-change @rpath/libmonosgen-2.0.dylib @rpath/Mono.framework/Mono " + Driver.Quote (libxamarin_target));
 				}
 			}
 

--- a/tools/mtouch/BuildTasks.mtouch.cs
+++ b/tools/mtouch/BuildTasks.mtouch.cs
@@ -360,7 +360,7 @@ namespace Xamarin.Bundler
 			if (!App.EnableMarkerOnlyBitCode)
 				flags.AddOtherFlag ("-read_only_relocs suppress");
 			flags.LinkWithMono ();
-			flags.AddOtherFlag ("-install_name " + Driver.Quote ($"@executable_path/{install_name}"));
+			flags.AddOtherFlag ("-install_name " + Driver.Quote ($"@rpath/{install_name}"));
 			flags.AddOtherFlag ("-fapplication-extension"); // fixes this: warning MT5203: Native linking warning: warning: linking against dylib not safe for use in application extensions: [..]/actionextension.dll.arm64.dylib
 		}
 


### PR DESCRIPTION
Use @rpath instead of @executable_path in dylibs, since it allows us to be
more flexible when placing dylibs in the app.

In particular with this change it's trivial to put libmonosgen-2.0.dylib in
the container app, and reference it from extensions.