### PR TITLE
[mtouch] Rework the linker to not reload assemblies after linking.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -888,6 +888,10 @@ The `legacy` provider, which was a fully managed SSLv3 / TLSv1 only provider, is
 
 To fix this warning, open the project file in a text editor, and remove all `MtouchTlsProvider`` nodes from the XML.
 
+<h3><a name="MT2017"/>MT2017: The assembly '*' is referenced from two different locations: '*' and '*'.</h3>
+
+The assembly mentioned in the error message is loaded from multiple locations. Make sure to always use the same version of an assembly.
+
 <h3><a name="MT202x"/>MT202x: Binding Optimizer failed processing `...`.</h3>
 
 Something unexpected occured when trying to optimize generated binding code. The element causing the issue is named in the error message. In order to fix this issue the assembly named (or containing the type or method named) will need to be provided in a [bug report](http://bugzilla.xamarin.com) along with a complete build log with verbosity enabled (i.e. `-v -v -v -v` in the **Additional mtouch arguments**).

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -435,14 +435,14 @@ namespace Xamarin
 			return plist;
 		}
 
-		public void CreateTemporaryApp (bool hasPlist = false, string appName = "testApp", string code = null)
+		public void CreateTemporaryApp (bool hasPlist = false, string appName = "testApp", string code = null, string extraArg = "")
 		{
 			var testDir = CreateTemporaryDirectory ();
 			var app = Path.Combine (testDir, appName + ".app");
 			Directory.CreateDirectory (app);
 
 			AppPath = app;
-			Executable = MTouch.CompileTestAppExecutable (testDir, code, "", Profile, appName);
+			Executable = MTouch.CompileTestAppExecutable (testDir, code, extraArg, Profile, appName);
 
 			if (hasPlist)
 				File.WriteAllText (Path.Combine (app, "Info.plist"), CreatePlist (Profile, appName));

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -40,6 +41,18 @@ namespace Xamarin.Bundler {
 			}
 		}
 		public string FileName { get { return Path.GetFileName (FullPath); } }
+		public string Identity { get { return GetIdentity (FullPath); } }
+
+		public static string GetIdentity (AssemblyDefinition ad)
+		{
+			return Path.GetFileNameWithoutExtension (ad.MainModule.FileName);
+		}
+
+		public static string GetIdentity (string path)
+		{
+			return Path.GetFileNameWithoutExtension (path);
+		}
+
 		public bool EnableCxx;
 		public bool NeedsGccExceptionHandling;
 		public bool ForceLoad;
@@ -416,5 +429,76 @@ namespace Xamarin.Bundler {
 					yield return satellite;
 			}
 		}
+	}
+
+	public class AssemblyCollection : IEnumerable<Assembly>
+	{
+		Dictionary<string, Assembly> HashedAssemblies = new Dictionary<string, Assembly> (StringComparer.OrdinalIgnoreCase);
+
+		public void Add (Assembly assembly)
+		{
+			Assembly other;
+			if (HashedAssemblies.TryGetValue (assembly.Identity, out other))
+				throw ErrorHelper.CreateError (2017, "The assembly '{0}' is referenced from two different locations: '{1}' and '{2}'.", assembly.Identity, other.FullPath, assembly.FullPath);
+			HashedAssemblies.Add (assembly.Identity, assembly);
+		}
+
+		public void AddRange (AssemblyCollection assemblies)
+		{
+			if (Count == 0) {
+				HashedAssemblies = new Dictionary<string, Assembly> (assemblies.HashedAssemblies);
+			} else {
+				foreach (var a in assemblies)
+					Add (a);
+			}
+		}
+
+		public int Count {
+			get {
+				return HashedAssemblies.Count;
+			}
+		}
+
+		public IDictionary<string, Assembly> Hashed {
+			get { return HashedAssemblies; }
+		}
+
+		public bool TryGetValue (string identity, out Assembly assembly)
+		{
+			return HashedAssemblies.TryGetValue (identity, out assembly);
+		}
+
+		public bool ContainsKey (string identity)
+		{
+			return HashedAssemblies.ContainsKey (identity);
+		}
+
+		public void Remove (string identity)
+		{
+			HashedAssemblies.Remove (identity);
+		}
+
+		public void Remove (Assembly assembly)
+		{
+			Remove (assembly.Identity);
+		}
+
+		public Assembly this [string key] {
+			get { return HashedAssemblies [key]; }
+			set { HashedAssemblies [key] = value; }
+		}
+
+#region Interface implementations
+		IEnumerator IEnumerable.GetEnumerator ()
+		{
+			return GetEnumerator ();
+		}
+
+		public IEnumerator<Assembly> GetEnumerator ()
+		{
+			return HashedAssemblies.Values.GetEnumerator ();
+		}
+
+#endregion
 	}
 }

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -488,6 +488,26 @@ namespace Xamarin.Bundler {
 			set { HashedAssemblies [key] = value; }
 		}
 
+		public void Update (Target target, IEnumerable<AssemblyDefinition> assemblies)
+		{
+			// This function will remove any assemblies not in 'assemblies', and add any new assemblies.
+			var current = new HashSet<string> (HashedAssemblies.Keys);
+			foreach (var assembly in assemblies) {
+				var identity = Assembly.GetIdentity (assembly);
+				if (!current.Remove (identity)) {
+					// new assembly
+					var asm = new Assembly (target, assembly);
+					Add (asm);
+					Driver.Log (1, "The linker added the assembly '{0}'.", asm.Identity);
+				}
+			}
+
+			foreach (var removed in current) {
+				Driver.Log (1, "The linker linked away the assembly '{0}'.", this [removed].Identity);
+				Remove (removed);
+			}
+		}
+
 #region Interface implementations
 		IEnumerator IEnumerable.GetEnumerator ()
 		{

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -34,7 +34,7 @@ using PlatformLinkContext = MonoMac.Tuner.MonoMacLinkContext;
 namespace Xamarin.Bundler {
 	public partial class Target {
 		public Application App;
-		public List<Assembly> Assemblies = new List<Assembly> ();
+		public AssemblyCollection Assemblies = new AssemblyCollection ();
 
 		public PlatformLinkContext LinkContext;
 		public LinkerOptions LinkerOptions;

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -473,10 +473,9 @@ namespace Xamarin.Bundler
 
 					if (Application.IsUptodate (input, output)) {
 						cached_link = true;
-						for (int i = Assemblies.Count - 1; i >= 0; i--) {
-							var a = Assemblies [i];
+						foreach (var a in Assemblies.ToList ()) {
 							if (!cached_output.Contains (a.FullPath)) {
-								Assemblies.RemoveAt (i);
+								Assemblies.Remove (a);
 								continue;
 							}
 							// Load the cached assembly
@@ -516,12 +515,11 @@ namespace Xamarin.Bundler
 			removed.ExceptWith (linked_assemblies);
 
 			foreach (var assembly in removed) {
-				for (int i = Assemblies.Count - 1; i >= 0; i--) {
-					var ad = Assemblies [i];
+				foreach (var ad in Assemblies.ToList ()) {
 					if (assembly != ad.FullPath)
 						continue;
 
-					Assemblies.RemoveAt (i);
+					Assemblies.Remove (ad);
 				}
 			}
 

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -376,7 +376,7 @@ namespace Xamarin.Bundler
 			return new Assembly (this, assembly);
 		}
 
-		public void LinkAssemblies (string main, ref List<string> assemblies, string output_dir, out MonoTouchLinkContext link_context)
+		public void LinkAssemblies (string main, out List<AssemblyDefinition> assemblies, string output_dir, out MonoTouchLinkContext link_context)
 		{
 			if (Driver.Verbosity > 0)
 				Console.WriteLine ("Linking {0} into {1} using mode '{2}'", main, output_dir, App.LinkMode);
@@ -505,9 +505,11 @@ namespace Xamarin.Bundler
 			var assemblies = new List<string> ();
 			foreach (var a in Assemblies)
 				assemblies.Add (a.FullPath);
-			var linked_assemblies = new List<string> (assemblies);
+			List<AssemblyDefinition> linked_assemblies_definitions;
 
-			LinkAssemblies (App.RootAssembly, ref linked_assemblies, PreBuildDirectory, out LinkContext);
+			LinkAssemblies (App.RootAssembly, out linked_assemblies_definitions, PreBuildDirectory, out LinkContext);
+
+			List<string> linked_assemblies = linked_assemblies_definitions.Select ((v) => v.MainModule.FileName).ToList ();
 
 			// Remove assemblies that were linked away
 			var removed = new HashSet<string> (assemblies);

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -61,7 +61,7 @@ namespace MonoTouch.Tuner {
 
 	class Linker {
 
-		public static void Process (LinkerOptions options, out MonoTouchLinkContext context, out List<string> assemblies)
+		public static void Process (LinkerOptions options, out MonoTouchLinkContext context, out List<AssemblyDefinition> assemblies)
 		{
 			var pipeline = CreatePipeline (options);
 
@@ -190,22 +190,17 @@ namespace MonoTouch.Tuner {
 			return pipeline;
 		}
 
-		static List<string> ListAssemblies (MonoTouchLinkContext context)
+		static List<AssemblyDefinition> ListAssemblies (MonoTouchLinkContext context)
 		{
-			var list = new List<string> ();
+			var list = new List<AssemblyDefinition> ();
 			foreach (var assembly in context.GetAssemblies ()) {
 				if (context.Annotations.GetAction (assembly) == AssemblyAction.Delete)
 					continue;
 
-				list.Add (GetFullyQualifiedName (assembly));
+				list.Add (assembly);
 			}
 
 			return list;
-		}
-
-		static string GetFullyQualifiedName (AssemblyDefinition assembly)
-		{
-			return assembly.MainModule.FileName;
 		}
 
 		static ResolveFromXmlStep GetResolveStep (string filename)

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -211,6 +211,7 @@ namespace Xamarin.Bundler {
 	//					MT2014	** reserved Xamarin.Mac **
 	//		Warning		MT2015	Invalid HttpMessageHandler `{0}` for watchOS. The only valid value is NSUrlSessionHandler.
 	//		Warning		MT2016  Invalid TlsProvider `{0}` option. The only valid value `{1}` will be used.
+	//					MT2017	The assembly '{0}' is referenced from two different locations: '{1}' and '{2}'.
 	//					MT202x	Binding Optimizer failed processing `...`.
 	//					MT203x	Removing User Resources failed processing `...`.
 	//					MT204x	Default HttpMessageHandler setter failed processing `...`.


### PR DESCRIPTION
Make the linker return a list of AssemblyDefinitions (instead of paths where
those were stored on-disk), so that we can use those to avoid re-loading those
assemblies after linking: move the code to update the list of assemblies after
linking into AssemblyCollection (so that it's re-usable, which it will be
later), and rewrite it to take advantage of the fact that the input is the
actual AssemblyDefinitions, and not their paths.