### PR TITLE
[msbuild] Added ProcessEnums property for ObjC Binding projects

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -72,6 +72,7 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 			Namespace="$(Namespace)"
 			NoStdLib="$(NoStdLib)"
 			OutputAssembly="$(OutputAssembly)"
+			ProcessEnums="$(ProcessEnums)"
 			References="@(ReferencePath);@(BTouchReferencePath)"
 			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			FrameworkRoot="$(XamarinMacFrameworkRoot)"

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.props
@@ -38,6 +38,8 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 		<GeneratedSourcesDir Condition="'$(GeneratedSourcesDir)' == ''">$(IntermediateOutputPath)mac</GeneratedSourcesDir>
 		<GeneratedSourcesDir Condition="'$(GeneratedSourcesDir)' != '' and !HasTrailingSlash ('$(GeneratedSourcesDir)')">$(GeneratedSourcesDir)\</GeneratedSourcesDir>
+
+		<ProcessEnums Condition="'$(ProcessEnums)' == ''">False</ProcessEnums>
 	</PropertyGroup>
 
 	<!-- Make our Build Actions show up in MonoDevelop -->

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
@@ -52,6 +52,8 @@ namespace Xamarin.MacDev.Tasks {
 
 		public string OutputAssembly { get; set; }
 
+		public bool ProcessEnums { get; set; }
+
 		public ITaskItem[] References { get; set; }
 
 		public ITaskItem[] Resources { get; set; }
@@ -96,6 +98,9 @@ namespace Xamarin.MacDev.Tasks {
 				cmd.AppendSwitchIfNotNull ("/lib:", dir);
 				cmd.AppendSwitchIfNotNull ("/r:", Path.Combine (dir, "mscorlib.dll"));
 			}
+
+			if (ProcessEnums)
+				cmd.AppendSwitch ("/process-enums");
 
 			if (EmitDebugInformation)
 				cmd.AppendSwitch ("/debug");
@@ -180,13 +185,13 @@ namespace Xamarin.MacDev.Tasks {
 
 		public override bool Execute ()
 		{
-			this.ToolExe = this.BTouchToolExe;
-			this.ToolPath = this.BTouchToolPath;
+			ToolExe = BTouchToolExe;
+			ToolPath = BTouchToolPath;
 
-			if (!string.IsNullOrEmpty (this.SessionId) &&
-			    	!string.IsNullOrEmpty (this.GeneratedSourcesDir) &&
-			    	!Directory.Exists (this.GeneratedSourcesDir)) {
-				Directory.CreateDirectory (this.GeneratedSourcesDir);
+			if (!string.IsNullOrEmpty (SessionId) &&
+			    !string.IsNullOrEmpty (GeneratedSourcesDir) &&
+			    !Directory.Exists (GeneratedSourcesDir)) {
+				Directory.CreateDirectory (GeneratedSourcesDir);
 			}
 
 			Log.LogTaskName ("BTouch");
@@ -206,6 +211,7 @@ namespace Xamarin.MacDev.Tasks {
 			Log.LogTaskProperty ("NativeLibraries", NativeLibraries);
 			Log.LogTaskProperty ("NoStdLib", NoStdLib);
 			Log.LogTaskProperty ("OutputAssembly", OutputAssembly);
+			Log.LogTaskProperty ("ProcessEnums", ProcessEnums);
 			Log.LogTaskProperty ("References", References);
 			Log.LogTaskProperty ("Resources", Resources);
 			Log.LogTaskProperty ("Sources", Sources);

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
@@ -74,6 +74,7 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 			Namespace="$(Namespace)"
 			NoStdLib="$(NoStdLib)"
 			OutputAssembly="$(OutputAssembly)"
+			ProcessEnums="$(ProcessEnums)"
 			References="@(ReferencePath);@(BTouchReferencePath)"
 			BTouchToolPath="$(BTouchToolPath)"
 			BTouchToolExe="$(BTouchToolExe)">

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.props
@@ -46,6 +46,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<GeneratedSourcesDir Condition="'$(GeneratedSourcesDir)' == '' And '$(TargetFrameworkIdentifier)' == 'Xamarin.WatchOS'">$(IntermediateOutputPath)watchos</GeneratedSourcesDir>
 		<GeneratedSourcesDir Condition="'$(GeneratedSourcesDir)' == ''">$(IntermediateOutputPath)ios</GeneratedSourcesDir>
 		<GeneratedSourcesDir Condition="'$(GeneratedSourcesDir)' != '' and !HasTrailingSlash ('$(GeneratedSourcesDir)')">$(GeneratedSourcesDir)\</GeneratedSourcesDir>
+
+		<ProcessEnums Condition="'$(ProcessEnums)' == ''">False</ProcessEnums>
 	</PropertyGroup>
 
 	<!-- Make our Build Actions show up in MonoDevelop -->


### PR DESCRIPTION
The new ProcessEnums property specifies whether or not to
pass /process-enums to the btouch task for iOS/Mac binding
projects.

Part of the fix for https://bugzilla.xamarin.com/show_bug.cgi?id=51753