### PR TITLE
NSSliderTouchBarItem.ValueAccesoryWidth should be nfloat, not double

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -13344,7 +13344,7 @@ namespace XamCore.AppKit {
 		NSSliderAccessory MaximumValueAccessory { get; set; }
 
 		[Export ("valueAccessoryWidth")]
-		double ValueAccessoryWidth { get; set; }
+		nfloat ValueAccessoryWidth { get; set; }
 
 		[NullAllowed, Export ("target", ArgumentSemantic.Weak)]
 		NSObject Target { get; set; }


### PR DESCRIPTION
This needs to go into Cycle 9 with the rest of the TouchBar APIs