### PR TITLE
[mtouch] Automatically disable incremental builds if building to bitcode and any third-party bindings were found. Works around bug #51710.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -358,6 +358,15 @@ A last-straw solution would be to use a different version of Xamarin.iOS, one th
 <h3><a name="MT0093"/>MT0093: Aot symbolication files could not be copied to the destination directory. Symbolication will not work with the application.</h3>
 
 <h3><a name="MT0096"/>MT0096: No reference to Xamarin.iOS.dll was found.</h3>
+
+<h3><a name="MT0110"/>MT0110: Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include third-party binding libraries and that compiles to bitcode.</h3>
+
+Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include third-party binding libraries and that compiles to bitcode (tvOS and watchOS projects).
+
+No action is required on your part, this message is purely informational.
+
+For further information see bug #[51710](https://bugzilla.xamarin.com/show_bug.cgi?id=51710).
+
 <!--
  MT1xxx file copy / symlinks (project related)
   MT10xx installer.cs / mtouch.cs

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -60,6 +60,13 @@ namespace Xamarin.Bundler {
 			foreach (var a in Assemblies) {
 				try {
 					a.ExtractNativeLinkInfo ();
+
+#if MTOUCH
+					if (App.FastDev && a.HasLinkWithAttributes && App.EnableBitCode) {
+						ErrorHelper.Warning (110, "Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include third-party binding libraries and that compiles to bitcode.");
+						App.FastDev = false;
+					}
+#endif
 				} catch (Exception e) {
 					exceptions.Add (e);
 				}

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -104,6 +104,7 @@ namespace Xamarin.Bundler {
 	//					MT0095 Aot files could not be copied to the destination directory.
 	//					MT0096 No reference to Xamarin.iOS.dll was found.
 	//					MT0097 <used by mmp>
+	//		Warning		MT0110  Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include third-party binding libraries and that compiles to bitcode.
 	// MT1xxx	file copy / symlinks (project related)
 	//			MT10xx	installer.cs / mtouch.cs
 	//					MT1001	Could not find an application at the specified directory: {0}


### PR DESCRIPTION
Most projects building to bitcode (any kind of bitcode, this includes the
marker-only version as well), will fail to link when linking with third-party
libraries and incremental builds are enabled.

So automatically disable incremental builds when we detect this scenario.

This is only a workaround until we can make this scenario build correctly.

https://bugzilla.xamarin.com/show_bug.cgi?id=51710