### PR TITLE
[mtouch] Automatically disable incremental builds if building to bitcode and any third-party bindings were found. Works around bug #51710.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -369,6 +369,14 @@ A last-straw solution would be to use a different version of Xamarin.iOS, one th
 
 This indicates a bug in Xamarin.iOS; please file a bug report at [http://bugzilla.xamarin.com](https://bugzilla.xamarin.com/enter_bug.cgi?product=iOS) with a test case.
 
+<h3><a name="MT0110"/>MT0110: Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include third-party binding libraries and that compiles to bitcode.</h3>
+
+Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include third-party binding libraries and that compiles to bitcode (tvOS and watchOS projects).
+
+No action is required on your part, this message is purely informational.
+
+For further information see bug #[51710](https://bugzilla.xamarin.com/show_bug.cgi?id=51710).
+
 # MT1xxx: Project related error messages
 
 ### MT10xx: Installer / mtouch

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -60,6 +60,13 @@ namespace Xamarin.Bundler {
 			foreach (var a in Assemblies) {
 				try {
 					a.ExtractNativeLinkInfo ();
+
+#if MTOUCH
+					if (App.FastDev && a.HasLinkWithAttributes && App.EnableBitCode) {
+						ErrorHelper.Warning (110, "Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include third-party binding libraries and that compiles to bitcode.");
+						App.FastDev = false;
+					}
+#endif
 				} catch (Exception e) {
 					exceptions.Add (e);
 				}

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -106,6 +106,7 @@ namespace Xamarin.Bundler {
 	//					MT0097 <used by mmp>
 	//					MT0098 <used by mmp>
 	//					MT0099	Internal error {0}. Please file a bug report with a test case (http://bugzilla.xamarin.com).
+	//		Warning		MT0110  Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include third-party binding libraries and that compiles to bitcode.
 	// MT1xxx	file copy / symlinks (project related)
 	//			MT10xx	installer.cs / mtouch.cs
 	//					MT1001	Could not find an application at the specified directory: {0}


### PR DESCRIPTION
Most projects building to bitcode (any kind of bitcode, this includes the
marker-only version as well), will fail to link when linking with third-party
libraries and incremental builds are enabled.

So automatically disable incremental builds when we detect this scenario.

This is only a workaround until we can make this scenario build correctly.

https://bugzilla.xamarin.com/show_bug.cgi?id=51710