### PR TITLE
[tests][macos][intro] Fix crash with NSTouch

### DIFF
--- a/tests/introspection/Mac/MacApiCtorInitTest.cs
+++ b/tests/introspection/Mac/MacApiCtorInitTest.cs
@@ -177,6 +177,8 @@ namespace Introspection {
 			switch (obj.GetType ().FullName) {
 			// Crashes on 10.12
 			case "Contacts.CNContainer":
+			case "AppKit.NSTouch":
+			case "MonoMac.AppKit.NSTouch":
 			// native crash calling MonoMac.Foundation.NSObject.get_Description ()
 			case "WebKit.WKNavigationAction":
 			case "WebKit.WKFrameInfo": //  EXC_BAD_ACCESS (code=1, address=0x0)


### PR DESCRIPTION
The following assert happens when calling the `description` selector
on a vanilla NSTouch using Sierra.

2017-01-30 22:03:54.454 introspection[605:11053168] *** Assertion failure in -[NSTouch locationInView:], /Library/Caches/com.apple.xbs/Sources/AppKit/AppKit-1504.81.100/AppKit.subproj/NSTouch.m:97
2017-01-30 22:03:54.458 introspection[605:11053168] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Cannot get locationInView: for this type of NSTouch'