### PR TITLE
[tests][macos][intro] Fix XM classic introspection tests. Fixes #52065

### DIFF
--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -2248,7 +2248,7 @@ namespace XamCore.CoreImage {
 	}
 
 	[iOS (9,0)]
-	[Mac (10,12)]
+	[Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof (CIFeature))]
 	interface CITextFeature {
 		[Export ("bounds")]

--- a/tests/introspection/Mac/MacApiCtorInitTest.cs
+++ b/tests/introspection/Mac/MacApiCtorInitTest.cs
@@ -148,6 +148,11 @@ namespace Introspection {
 				if (!Mac.CheckSystemVersion (10, 8) || IntPtr.Size != 8)
 					return true;
 				break;
+			case "MediaPlayer":
+			case "MonoMac.MediaPlayer":
+				if (!Mac.CheckSystemVersion (10, 12) || IntPtr.Size != 8)
+					return true;
+				break;
 			}
 
 			return base.Skip (type);

--- a/tests/introspection/Mac/MacApiFieldTest.cs
+++ b/tests/introspection/Mac/MacApiFieldTest.cs
@@ -53,9 +53,13 @@ namespace Introspection {
 			case "SceneKit":
 			case "MonoMac.SceneKit":
 				return !Mac.CheckSystemVersion (10, 8) || IntPtr.Size != 8;
-			default:
-				return false;
+			case "MediaPlayer":
+			case "MonoMac.MediaPlayer":
+				if (!Mac.CheckSystemVersion (10, 12) || IntPtr.Size != 8)
+					return true;
+				break;
 			}
+			return false;
 		}
 
 		protected override bool Skip (PropertyInfo p)

--- a/tests/introspection/Mac/MacApiSelectorTest.cs
+++ b/tests/introspection/Mac/MacApiSelectorTest.cs
@@ -101,6 +101,11 @@ namespace Introspection {
 				if (!Mac.CheckSystemVersion (10, 8) || IntPtr.Size != 8)
 					return true;
 				break;
+			case "MediaPlayer":
+			case "MonoMac.MediaPlayer":
+				if (!Mac.CheckSystemVersion (10, 12) || IntPtr.Size != 8)
+					return true;
+				break;
 			// not installed by default
 			case "MonoMac.Growl":
 			case "Growl":


### PR DESCRIPTION
The latest Sierra had a few surprises:

* CITextFeature is now 64bits only;
* The MediaPlayer framework is now 64bits only [1]

Both made the classic tests fails for XM.

[1] https://bugzilla.xamarin.com/show_bug.cgi?id=52065