### PR TITLE
[tests][monotouch] Generalize some tests to be independent of iOS version. Fixes #51801

### DIFF
--- a/tests/monotouch-test/ModelIO/MDLMesh.cs
+++ b/tests/monotouch-test/ModelIO/MDLMesh.cs
@@ -174,16 +174,7 @@ namespace MonoTouchFixtures.ModelIO {
 
 			using (var obj = MDLMesh.CreateEllipticalCone (5, V2, 3, 1, MDLGeometryType.Triangles, true, null)) {
 				Assert.IsNotNull (obj, "obj");
-				if (TestRuntime.CheckXcodeVersion (8, 2)) {
-					Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (0.433012783f, 4.5f, 0.5f), MinBounds = new Vector3 (-0.433012783f, -0.5f, -0.25f) }, obj.BoundingBox, "BoundingBox");
-					Assert.AreEqual (31, obj.VertexBuffers.Length, "VertexBuffers Count");
-				} else if (TestRuntime.CheckXcodeVersion (8, 0)) {
-					Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (0.433012783f, 4.5f, 0.5f), MinBounds = new Vector3 (-0.433012783f, -0.5f, -0.25f) }, obj.BoundingBox, "BoundingBox");
-					Assert.AreEqual (3, obj.VertexBuffers.Length, "VertexBuffers Count");
-				} else {
-					Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (0.866025448f, 0f, 1f), MinBounds = new Vector3 (-0.866025388f, -5f, -0.50000006f) }, obj.BoundingBox, "BoundingBox");
-					Assert.AreEqual (1, obj.VertexBuffers.Length, "VertexBuffers Count");
-				}
+				Assert.That (obj.VertexBuffers.Length, Is.GreaterThanOrEqualTo (1), "VertexBuffers Length");
 				Assert.AreEqual (1, obj.Submeshes.Count, "Submeshes Count");
 				Assert.AreEqual (13, obj.VertexCount, "VertexCount");
 				Assert.AreEqual (31, obj.VertexDescriptor.Attributes.Count, "VertexDescriptor Attributes Count");
@@ -233,15 +224,9 @@ namespace MonoTouchFixtures.ModelIO {
 
 			using (var obj = MDLMesh.CreateCapsule (V3, V2i, MDLGeometryType.Triangles, true, 10, null)) {
 				Assert.IsNotNull (obj, "obj");
-				if (TestRuntime.CheckXcodeVersion (8, 2)) {
-					Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (0.6f, 1.166666f, 1.8f), MinBounds = new Vector3 (-0.6f, -0.83333f, -1.8f) }, obj.BoundingBox, "BoundingBox");
-					Assert.AreEqual (122, obj.VertexCount, "VertexCount");
-				} else {
-					Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (0.6f, 1.333333f, 1.8f), MinBounds = new Vector3 (-0.6f, -1, -1.8f) }, obj.BoundingBox, "BoundingBox");
-					Assert.AreEqual (152, obj.VertexCount, "VertexCount");
-				}
+				Assert.That (obj.VertexCount, Is.GreaterThanOrEqualTo (122), "VertexCount");
 				Assert.AreEqual (1, obj.Submeshes.Count, "Submeshes Count");
-				Assert.AreEqual (3, obj.VertexBuffers.Length, "VertexBuffers Count");
+				Assert.That (obj.VertexBuffers.Length, Is.GreaterThanOrEqualTo (3), "VertexBuffers Count");
 				Assert.AreEqual (31, obj.VertexDescriptor.Attributes.Count, "VertexDescriptor Attributes Count");
 				Assert.AreEqual (31, obj.VertexDescriptor.Layouts.Count, "VertexDescriptor Layouts Count");
 			}
@@ -255,9 +240,8 @@ namespace MonoTouchFixtures.ModelIO {
 
 			using (var obj = MDLMesh.CreateCone (V3, V2i, MDLGeometryType.Triangles, true, true, null)) {
 				Assert.IsNotNull (obj, "obj");
-				Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (0.5f, -0.5f, 1.5f), MinBounds = new Vector3 (-0.5f, -2.5f, -1.5f) }, obj.BoundingBox, "BoundingBox");
 				Assert.AreEqual (1, obj.Submeshes.Count, "Submeshes Count");
-				Assert.AreEqual (3, obj.VertexBuffers.Length, "VertexBuffers Count");
+				Assert.That (obj.VertexBuffers.Length, Is.GreaterThanOrEqualTo (3), "VertexBuffers Count");
 				Assert.AreEqual (36, obj.VertexCount, "VertexCount");
 				Assert.AreEqual (31, obj.VertexDescriptor.Attributes.Count, "VertexDescriptor Attributes Count");
 				Assert.AreEqual (31, obj.VertexDescriptor.Layouts.Count, "VertexDescriptor Layouts Count");

--- a/tests/monotouch-test/Security/KeyTest.cs
+++ b/tests/monotouch-test/Security/KeyTest.cs
@@ -221,13 +221,9 @@ namespace MonoTouchFixtures.Security {
 				Assert.That (public_key.RawVerify (SecPadding.PKCS1SHA1, hash, sign), Is.EqualTo (SecStatusCode.Success), "RawVerify");
 
 				var empty = new byte [0];
-				if (TestRuntime.CheckXcodeVersion (8, 0)) {
-					Assert.That (private_key.RawSign (SecPadding.PKCS1SHA1, empty, out sign), Is.EqualTo (SecStatusCode.Success), "RawSign-empty");
-					Assert.That (public_key.RawVerify (SecPadding.PKCS1SHA1, empty, empty), Is.EqualTo (SecStatusCode.Success), "RawVerify-empty");
-				} else {
-					Assert.That (private_key.RawSign (SecPadding.PKCS1SHA1, empty, out sign), Is.EqualTo (SecStatusCode.Param), "RawSign-empty");
-					Assert.That (public_key.RawVerify (SecPadding.PKCS1SHA1, empty, empty), Is.EqualTo (SecStatusCode.Param), "RawVerify-empty");
-				}
+				Assert.That (private_key.RawSign (SecPadding.PKCS1, empty, out sign), Is.EqualTo (SecStatusCode.Success), "RawSign-empty");
+				// results vary per iOS version - but that's out of our control and we only care that it does not crash
+				public_key.RawVerify (SecPadding.PKCS1SHA1, empty, empty);
 
 				private_key.Dispose ();
 				public_key.Dispose ();
@@ -254,12 +250,8 @@ namespace MonoTouchFixtures.Security {
 				var empty = new byte [0];
 				// there does not seem to be a length-check on PKCS1, likely because not knowning the hash algorithm makes it harder
 				Assert.That (private_key.RawSign (SecPadding.PKCS1, empty, out sign), Is.EqualTo (SecStatusCode.Success), "RawSign-empty");
-				if (TestRuntime.CheckXcodeVersion (8, 0)) {
-					Assert.That (public_key.RawVerify (SecPadding.PKCS1, empty, empty), Is.EqualTo (SecStatusCode.Success), "RawVerify-empty");
-				} else {
-					// but that does not work at verification time
-					Assert.That (public_key.RawVerify (SecPadding.PKCS1, empty, empty), Is.EqualTo ((SecStatusCode)(-9809)), "RawVerify-empty");
-				}
+				// results vary per iOS version - but that's out of our control and we only care that it does not crash
+				public_key.RawVerify (SecPadding.PKCS1, empty, empty);
 
 				private_key.Dispose ();
 				public_key.Dispose ();


### PR DESCRIPTION
The exact values are not what we need to test for and varies with
different OS versions - making tests fails for no good reason (i.e.
they are not canary used to detect changes)

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=51801