### PR TITLE
[mtouch][linker] Remove type forwarders. Fixes #51805 (#1589)

### DIFF
--- a/tools/linker/MonoTouch.Tuner/MonoTouchSweepStep.cs
+++ b/tools/linker/MonoTouch.Tuner/MonoTouchSweepStep.cs
@@ -16,6 +16,19 @@ namespace MonoTouch.Tuner {
 
 			if (assembly.HasCustomAttributes)
 				SweepAttributes (assembly.CustomAttributes);
+
+			// type forwarders are all resolved (and saved back even if non-linked)
+			// and since there's no code loading/generation we can eliminate them
+			foreach (var module in assembly.Modules) {
+				if (!module.HasExportedTypes)
+					continue;
+				var exported = module.ExportedTypes;
+				for (int i = 0; i < exported.Count; i++) {
+					var et = exported [i];
+					if (et.IsForwarder)
+						exported.RemoveAt (i--);
+				}
+			}
 		}
 
 		void SweepAttributes (IList<CustomAttribute> attributes)


### PR DESCRIPTION
a. System.Net.Http.Primitives.dll is user code *and* contains type
forwarders (it's like a facade) to another facade assembly,
System.Net.Primitives.dll, that ships with the SDK;

b. The former, System.Net.Http.Primitives.dll, is not processed by
the linker, e.g. no code is removed and the assembly cannot be deleted.
However we save back (as much as we can [1]) the result of any type
being resolved;

c. It also means the later, System.Net.Primitives.dll, is fully linked
and (in many cases) can be removed from the final application (as it's
mostly forwarders).

d. This means the final, re-saved, System.Net.Http.Primitives.dll binary
could point to non-existing metadata, i.e. the removed
System.Net.Primitives.dll, because of [1].

Because we resolve (and save) the forwarders *and* because we do not
allow code downloads or generation (Apple restriction) it is possible to
remove the forwarders, which will fix the issue for XI.

[1] The scope of exported types cannot be updated
https://github.com/jbevain/cecil/blob/abb4e902da25fb4c23b6a9bfc6e5f9a034d04b3e/Mono.Cecil/ExportedType.cs#L41

There is also a enhancement bug, #11165, about this but it predated our
PCL support and the resolve-n-save that we now do for forwarders. This
is now _fully_ fixed.

References:
* https://bugzilla.xamarin.com/show_bug.cgi?id=11165 (enhancement)
* https://bugzilla.xamarin.com/show_bug.cgi?id=51805