### PR TITLE
[tests][macos][apitest] Fix MediaPlayerLibrary for unified. Fixes #51799

### DIFF
--- a/src/Foundation/NSObject.mac.cs
+++ b/src/Foundation/NSObject.mac.cs
@@ -94,6 +94,7 @@ namespace XamCore.Foundation {
 		static IntPtr io = Dlfcn.dlopen (Constants.ModelIOLibrary, 1);
 		static IntPtr nc = Dlfcn.dlopen (Constants.NotificationCenterLibrary, 1);
 		static IntPtr pl = Dlfcn.dlopen (Constants.PhotosLibrary, 1);
+		static IntPtr mp = Dlfcn.dlopen (Constants.MediaPlayerLibrary, 1);
 #endif
 
 #if !XAMCORE_4_0


### PR DESCRIPTION
Previous fix covered classic but missed the fact that `xcode8.3` branch,
being old, did not load `MediaPlayer.framework` which made the unified
version of the tests (both 64bits) fail.

Newer branch already had the framework loaded and did not fail.

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=51799