### PR TITLE
NSSliderTouchBarItem.ValueAccesoryWidth should be nfloat, not double …

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -13341,7 +13341,7 @@ namespace XamCore.AppKit {
 		NSSliderAccessory MaximumValueAccessory { get; set; }
 
 		[Export ("valueAccessoryWidth")]
-		double ValueAccessoryWidth { get; set; }
+		nfloat ValueAccessoryWidth { get; set; }
 
 		[NullAllowed, Export ("target", ArgumentSemantic.Weak)]
 		NSObject Target { get; set; }


### PR DESCRIPTION
…(#1585)

Cherrypicks the binding change from master.  Needs to go in cycle9 alongside the new bindings since it'd be a breaking change to fix later.