### PR TITLE
[msbuild] Properly decide on when to re-codesign app bundle

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -302,6 +302,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			_EmbedMobileProvision;
 			_CodesignNativeLibraries;
 			_CodesignFrameworks;
+			_CalculateCodesignAppBundleInputs
 		</_CodesignAppBundleDependsOn>
 
 		<_CoreCodesignDependsOn>
@@ -1579,8 +1580,27 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</Touch>
 	</Target>
 
+	<Target Name="_CalculateCodesignAppBundleInputs" Condition="'$(_RequireCodeSigning)' == 'true'">
+		<ItemGroup>
+			<_CodesignAppBundleInput Include="$(_NativeExecutable)" />
+			<_CodesignAppBundleInput Include="$(_AppBundlePath)Info.plist" />
+			<_CodesignAppBundleInput Include="$(_AppBundlePath)embedded.mobileprovision" />
+			<_CodesignAppBundleInput Include="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent" />
+			<_CodesignAppBundleInput Include="@(_BundleResourceWithLogicalName)" />
+			<_CodesignAppBundleInput Include="@(_NativeLibrary)" />
+			<_CodesignAppBundleInput Include="@(_Frameworks)" />
+			<_CodesignAppBundleInput Include="@(_ResolvedAppExtensionReferences -> '$(_AppBundlePath)PlugIns\%(FileName)%(Extension)\_CodeSignature\CodeResources')" Condition="'$(IsAppExtension)' == 'false'" />
+
+			<!-- Include WatchOS1 App references -->
+			<_CodesignAppBundleInput Include="@(_ResolvedWatchAppReferences -> '$(_AppBundlePath)%(FileName)%(Extension)\_CodeSignature\CodeResources')" Condition="'$(IsAppExtension)' == 'true'" />
+
+			<!-- Include WatchOS2 App references -->
+			<_CodesignAppBundleInput Include="@(_ResolvedWatchAppReferences -> '$(_AppBundlePath)Watch\%(FileName)%(Extension)\_CodeSignature\CodeResources')" Condition="'$(OutputType)' == 'Exe'" />
+		</ItemGroup>
+	</Target>
+
 	<Target Name="_CodesignAppBundle" Condition="'$(_RequireCodeSigning)' == 'true'" DependsOnTargets="$(_CodesignAppBundleDependsOn)"
-		Inputs="$(_NativeExecutable);$(_AppBundlePath)Info.plist;$(_AppBundlePath)embedded.mobileprovision;$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent;@(_BundleResourceWithLogicalName);@(_NativeLibrary);@(_Frameworks)"
+		Inputs="@(_CodesignAppBundleInput)"
 		Outputs="$(DeviceSpecificIntermediateOutputPath)codesign\$(_AppBundleName)$(AppBundleExtension)">
 		<Codesign
 			SessionId="$(BuildSessionId)"


### PR DESCRIPTION
If the user makes changes to an App Extension or Watch app,
then those bundles would change within the main app bundle
but the main app bundle would not get re-codesigned because
it was not properly considering those files as inputs in the
_CodesignAppBundle target.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=52165