### PR TITLE
Fix NSOpenGLPixelFormat ConvertToAttributes method (#1539)

### DIFF
--- a/src/AppKit/NSOpenGLPixelFormat.cs
+++ b/src/AppKit/NSOpenGLPixelFormat.cs
@@ -54,67 +54,96 @@ namespace XamCore.AppKit {
 			}
 		}
 
-		static NSOpenGLPixelFormatAttribute [] ConvertToAttributes (object [] args)
+		public NSOpenGLPixelFormat (uint [] attribs) : base (NSObjectFlag.Empty)
 		{
-			var list = new List<NSOpenGLPixelFormatAttribute> ();
+			if (attribs == null)
+				throw new ArgumentNullException ("attribs");
+
+			unsafe
+			{
+				uint [] copy = new uint [attribs.Length + 1];
+				Array.Copy (attribs, 0, copy, 0, attribs.Length);
+
+				fixed (uint* pArray = copy) {
+					if (IsDirectBinding) {
+						InitializeHandle (XamCore.ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (this.Handle, selInitWithAttributes, new IntPtr ((void*)pArray)));
+					} else {
+						InitializeHandle (XamCore.ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper_IntPtr (this.SuperHandle, selInitWithAttributes, new IntPtr ((void*)pArray)));
+					}
+				}
+
+			}
+		}
+
+		static uint [] ConvertToAttributes (object [] args)
+		{
+			
+			var list = new List<uint> ();
 			for (int i = 0; i < args.Length; i++){
-				var v = (NSOpenGLPixelFormatAttribute) args [i];
-				switch (v){
-				case NSOpenGLPixelFormatAttribute.AllRenderers:
-				case NSOpenGLPixelFormatAttribute.DoubleBuffer:
-				case NSOpenGLPixelFormatAttribute.Stereo:
-				case NSOpenGLPixelFormatAttribute.MinimumPolicy:
-				case NSOpenGLPixelFormatAttribute.MaximumPolicy:
-				case NSOpenGLPixelFormatAttribute.OffScreen:
-				case NSOpenGLPixelFormatAttribute.FullScreen:
-				case NSOpenGLPixelFormatAttribute.SingleRenderer:
-				case NSOpenGLPixelFormatAttribute.NoRecovery:
-				case NSOpenGLPixelFormatAttribute.Accelerated:
-				case NSOpenGLPixelFormatAttribute.ClosestPolicy:
-				case NSOpenGLPixelFormatAttribute.Robust:
-				case NSOpenGLPixelFormatAttribute.BackingStore:
-				case NSOpenGLPixelFormatAttribute.Window:
-				case NSOpenGLPixelFormatAttribute.MultiScreen:
-				case NSOpenGLPixelFormatAttribute.Compliant:
-				case NSOpenGLPixelFormatAttribute.PixelBuffer:
+				if (args [i] is NSOpenGLPixelFormatAttribute) {
+					NSOpenGLPixelFormatAttribute v = (NSOpenGLPixelFormatAttribute)args [i];
+					switch (v) {
+					case NSOpenGLPixelFormatAttribute.AllRenderers:
+					case NSOpenGLPixelFormatAttribute.DoubleBuffer:
+					case NSOpenGLPixelFormatAttribute.Stereo:
+					case NSOpenGLPixelFormatAttribute.MinimumPolicy:
+					case NSOpenGLPixelFormatAttribute.MaximumPolicy:
+					case NSOpenGLPixelFormatAttribute.OffScreen:
+					case NSOpenGLPixelFormatAttribute.FullScreen:
+					case NSOpenGLPixelFormatAttribute.SingleRenderer:
+					case NSOpenGLPixelFormatAttribute.NoRecovery:
+					case NSOpenGLPixelFormatAttribute.Accelerated:
+					case NSOpenGLPixelFormatAttribute.ClosestPolicy:
+					case NSOpenGLPixelFormatAttribute.Robust:
+					case NSOpenGLPixelFormatAttribute.BackingStore:
+					case NSOpenGLPixelFormatAttribute.Window:
+					case NSOpenGLPixelFormatAttribute.MultiScreen:
+					case NSOpenGLPixelFormatAttribute.Compliant:
+					case NSOpenGLPixelFormatAttribute.PixelBuffer:
 
 					// Not listed in the docs, but header file implies it
-				case NSOpenGLPixelFormatAttribute.RemotePixelBuffer:
-				case NSOpenGLPixelFormatAttribute.AuxDepthStencil:
-				case NSOpenGLPixelFormatAttribute.ColorFloat:
-				case NSOpenGLPixelFormatAttribute.Multisample:
-				case NSOpenGLPixelFormatAttribute.Supersample:
-				case NSOpenGLPixelFormatAttribute.SampleAlpha:
-				case NSOpenGLPixelFormatAttribute.AllowOfflineRenderers:
-				case NSOpenGLPixelFormatAttribute.AcceleratedCompute:
-				case NSOpenGLPixelFormatAttribute.MPSafe:
-					list.Add (v);
-					break;
-					
-				case NSOpenGLPixelFormatAttribute.AuxBuffers:
-				case NSOpenGLPixelFormatAttribute.ColorSize:
-				case NSOpenGLPixelFormatAttribute.AlphaSize:
-				case NSOpenGLPixelFormatAttribute.DepthSize:
-				case NSOpenGLPixelFormatAttribute.StencilSize:
-				case NSOpenGLPixelFormatAttribute.AccumSize:
-				case NSOpenGLPixelFormatAttribute.RendererID:
-				case NSOpenGLPixelFormatAttribute.ScreenMask:
+					case NSOpenGLPixelFormatAttribute.RemotePixelBuffer:
+					case NSOpenGLPixelFormatAttribute.AuxDepthStencil:
+					case NSOpenGLPixelFormatAttribute.ColorFloat:
+					case NSOpenGLPixelFormatAttribute.Multisample:
+					case NSOpenGLPixelFormatAttribute.Supersample:
+					case NSOpenGLPixelFormatAttribute.SampleAlpha:
+					case NSOpenGLPixelFormatAttribute.AllowOfflineRenderers:
+					case NSOpenGLPixelFormatAttribute.AcceleratedCompute:
+					case NSOpenGLPixelFormatAttribute.MPSafe:
+						list.Add ((uint) v);
+						break;
+
+					case NSOpenGLPixelFormatAttribute.AuxBuffers:
+					case NSOpenGLPixelFormatAttribute.ColorSize:
+					case NSOpenGLPixelFormatAttribute.AlphaSize:
+					case NSOpenGLPixelFormatAttribute.DepthSize:
+					case NSOpenGLPixelFormatAttribute.StencilSize:
+					case NSOpenGLPixelFormatAttribute.AccumSize:
+					case NSOpenGLPixelFormatAttribute.RendererID:
+					case NSOpenGLPixelFormatAttribute.ScreenMask:
+					case NSOpenGLPixelFormatAttribute.OpenGLProfile:
 
 					// not listed in the docs, but header file implies it
-				case NSOpenGLPixelFormatAttribute.SampleBuffers:
-				case NSOpenGLPixelFormatAttribute.Samples:
-				case NSOpenGLPixelFormatAttribute.VirtualScreenCount:
-					list.Add (v);
-					i++;
-					if (i >= args.Length)
-						throw new ArgumentException ("Attribute " + v + " needs a value");
-					if (args[i] is NSOpenGLPixelFormatAttribute)
-						list.Add ((NSOpenGLPixelFormatAttribute) args [i]);
-					else
-						list.Add ((NSOpenGLPixelFormatAttribute) (int)args [i]);
-					break;
-				}
+					case NSOpenGLPixelFormatAttribute.SampleBuffers:
+					case NSOpenGLPixelFormatAttribute.Samples:
+					case NSOpenGLPixelFormatAttribute.VirtualScreenCount:
+						list.Add ((uint) (int) v);
+						i++;
+						if (i >= args.Length)
+							throw new ArgumentException ("Attribute " + v + " needs a value");
+						list.Add ((uint) (int) args [i]);
+						break;
+					}
+				} else if (args [i] is int && (int) args [i] == 0 && i == args.Length - 1) 
+					list.Add (0);
+				else
+					throw new ArgumentException ($"The specified attribute is not of type NSOpenGLPixelFormatAttribute: {args [i]}");
 			}
+
+			if (args.Length == 0 || !(args[args.Length - 1] is int) || ((int)args [args.Length - 1]) != 0)
+				list.Add (0);
+			
 			return list.ToArray ();
 		}
 		

--- a/tests/apitest/src/AppKit/NSOpenGLPixelFormat.cs
+++ b/tests/apitest/src/AppKit/NSOpenGLPixelFormat.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using NUnit.Framework;
+
+#if !XAMCORE_2_0
+using MonoMac.AppKit;
+#else
+using AppKit;
+#endif
+
+namespace Xamarin.Mac.Tests {
+	[TestFixture]
+	public class NSOpenGLPixelFormatTests {
+		[Test]
+		public void NSOpenGLPixelFormatAttributesShouldPassWith0Terminate ()
+		{
+			var _attribs = new object [] { NSOpenGLPixelFormatAttribute.DoubleBuffer,
+				NSOpenGLPixelFormatAttribute.DepthSize,
+				24,
+				NSOpenGLPixelFormatAttribute.OpenGLProfile,
+				NSOpenGLProfile.Version3_2Core,
+				0
+			};
+			NSOpenGLPixelFormat pixelFormat = new NSOpenGLPixelFormat (_attribs);
+
+			Assert.NotNull (pixelFormat);
+		}
+
+		[Test]
+		public void NSOpenGLPixelFormatAttributesShouldWorkWithEmptyAttributes ()
+		{
+			var _attribs = new object [] {
+			};
+			NSOpenGLPixelFormat pixelFormat = new NSOpenGLPixelFormat (_attribs);
+
+			Assert.NotNull (pixelFormat);
+		}
+
+		[Test]
+		public void NSOpenGLPixelFormatAttributesShouldPassWithout0Terminate ()
+		{
+			var _attribs = new object [] { NSOpenGLPixelFormatAttribute.DoubleBuffer,
+				NSOpenGLPixelFormatAttribute.DepthSize,
+				24,
+				NSOpenGLPixelFormatAttribute.OpenGLProfile,
+				NSOpenGLProfile.Version3_2Core,
+			};
+			Assert.DoesNotThrow (() => { NSOpenGLPixelFormat pixelFormat = new NSOpenGLPixelFormat (_attribs); });
+		}
+
+		[Test]
+		public void NSOpenGLPixelFormatAttributesOpenGLProfileShouldThrowForMissingValue ()
+		{
+			var missingValue = new object [] { NSOpenGLPixelFormatAttribute.DoubleBuffer,
+				NSOpenGLPixelFormatAttribute.DepthSize,
+				24,
+				NSOpenGLPixelFormatAttribute.OpenGLProfile
+			};
+			Assert.Throws <ArgumentException> (() => { NSOpenGLPixelFormat pixelFormat = new NSOpenGLPixelFormat (missingValue); });
+		}
+
+		[Test]
+		public void NSOpenGLPixelFormatAttributesShouldThrowForInvalidArgument ()
+		{
+			var _attribs = new object [] { NSOpenGLPixelFormatAttribute.DoubleBuffer,
+				NSOpenGLPixelFormatAttribute.DepthSize,
+				24,
+				45,
+				NSOpenGLPixelFormatAttribute.OpenGLProfile,
+				NSOpenGLProfile.Version3_2Core,
+				0
+			};
+
+			Assert.Throws <ArgumentException> (() => { NSOpenGLPixelFormat pixelFormat = new NSOpenGLPixelFormat (_attribs); });
+		}
+	}
+}


### PR DESCRIPTION
Cherry-pick the NSOpenGLPixelFormat fix to cycle9

Fix NSOpenGLPixelFormat ConvertToAttributes

* Add OpenGLProfile to list of NSOpenGLPixelFormatAttributes that require a value.  Check for 0 terminating the array
* Use InitializeHandle instead of 'Handle = '
* Add tests