### PR TITLE
[mmp/btouch] Better error when bad xml linker input is given to mmp/mtouch

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -906,6 +906,10 @@ The `legacy` provider, which was a fully managed SSLv3 / TLSv1 only provider, is
 
 To fix this warning, open the project file in a text editor, and remove all `MtouchTlsProvider`` nodes from the XML.
 
+<h3><a name="MT2017"/>MT2017: Could not process XML description.</h3>
+
+This means there is an error on the [custom XML linker configuration file](https://developer.xamarin.com/guides/cross-platform/advanced/custom_linking/) you provided, please review your file.
+
 <h3><a name="MT202x"/>MT202x: Binding Optimizer failed processing `...`.</h3>
 
 Something unexpected occured when trying to optimize generated binding code. The element causing the issue is named in the error message. In order to fix this issue the assembly named (or containing the type or method named) will need to be provided in a [bug report](http://bugzilla.xamarin.com) along with a complete build log with verbosity enabled (i.e. `-v -v -v -v` in the **Additional mtouch arguments**).

--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -101,6 +101,8 @@ namespace MonoMac.Tuner {
 				TypeReference tr = (re.Member as TypeReference);
 				IMetadataScope scope = tr == null ? re.Member.DeclaringType.Scope : tr.Scope;
 				throw new MonoMacException (2002, true, re, "Failed to resolve \"{0}\" reference from \"{1}\"", re.Member, scope);
+			} catch (XmlResolutionException ex) {
+				throw new MonoMacException (2017, true, ex, "Could not process XML description: {0}", ex?.InnerException?.Message ?? ex.Message);
 			} catch (Exception e) {
 				throw new MonoMacException (2001, true, e, "Could not link assemblies. Reason: {0}", e.Message);
 			}

--- a/tools/mmp/error.cs
+++ b/tools/mmp/error.cs
@@ -71,6 +71,7 @@ namespace Xamarin.Bundler {
 	//				Warning	MM2014	Xamarin.Mac Extensions do not support linking. Request for linking will be ignored.
 	//					MM2015	*** Reserved mtouch ***
 	//				Warning	MM2016  Invalid TlsProvider `{0}` option. The only valid value `{1}` will be used.
+	//					MM2017  Could not process XML description: {0}
 	//					MM202x	Binding Optimizer failed processing `...`.
 	// MT3xxx	AOT
 	//			MT30xx	AOT (general) errors

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -89,6 +89,8 @@ namespace MonoTouch.Tuner {
 				TypeReference tr = (re.Member as TypeReference);
 				IMetadataScope scope = tr == null ? re.Member.DeclaringType.Scope : tr.Scope;
 				throw new MonoTouchException (2002, true, re, "Failed to resolve \"{0}\" reference from \"{1}\"", re.Member, scope);
+			} catch (XmlResolutionException ex) {
+				throw new MonoTouchException (2017, true, ex, "Could not process XML description: {0}", ex?.InnerException?.Message ?? ex.Message);
 			} catch (Exception e) {
 				throw new MonoTouchException (2001, true, e, "Could not link assemblies. Reason: {0}", e.Message);
 			}

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -212,6 +212,7 @@ namespace Xamarin.Bundler {
 	//					MT2014	** reserved Xamarin.Mac **
 	//		Warning		MT2015	Invalid HttpMessageHandler `{0}` for watchOS. The only valid value is NSUrlSessionHandler.
 	//		Warning		MT2016  Invalid TlsProvider `{0}` option. The only valid value `{1}` will be used.
+	//					MT2017  Could not process XML description: {0}
 	//					MT202x	Binding Optimizer failed processing `...`.
 	//					MT203x	Removing User Resources failed processing `...`.
 	//					MT204x	Default HttpMessageHandler setter failed processing `...`.


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=52238

If you give mtouch/mmp a linker xml file with bad input for
example a Xamarin.iOS app and the linker.xml has a reference
to Xamarin.Mac instead of X.I.dll i.e.

```
<?xml version="1.0" encoding="UTF-8" ?>
<linker>
	<assembly fullname="Xamarin.Mac">
    	<type fullname="ObjCRuntime.Constants"/>
	</assembly>
</linker>
```

You will get a not so helpful generic error

> MT2001 Could not link assemblies. Reason: Failed to process XML description: unspecified

It seems that when you use a xml file for linker you get a
`XmlResolutionException` from cecil when it fails to resolve
and the better error comes from the inner exception so we use
that instead.

New error output for `XmlResolutionException`:

> MT2017: Could not process XML description: Failed to resolve assembly: 'Xamarin.Mac, Culture=neutral, PublicKeyToken=null'