### PR TITLE
[mtouch tests] Adjust FastDev_LinkWithTest after fe17d5db9f7.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -851,11 +851,17 @@ namespace Xamarin
 				};
 				Assert.AreEqual (0, mtouch.Execute (MTouchAction.BuildDev), "build");
 
-				var symbols = ExecutionHelper.Execute ("nm", Quote (mtouch.NativeExecutablePath), hide_output: true).Split ('\n');
-				Assert.That (symbols, Has.None.EndsWith (" T _theUltimateAnswer"), "Binding symbol not in executable");
+				bool workaround_for_bug51710 = profile != Profile.Unified; // see fe17d5db9f7c
+				if (workaround_for_bug51710) {
+					var symbols = ExecutionHelper.Execute ("nm", Quote (mtouch.NativeExecutablePath), hide_output: true).Split ('\n');
+					Assert.That (symbols, Has.Some.EndsWith (" T _theUltimateAnswer"), "Binding symbol not in executable");
+				} else {
+					var symbols = ExecutionHelper.Execute ("nm", Quote (mtouch.NativeExecutablePath), hide_output: true).Split ('\n');
+					Assert.That (symbols, Has.None.EndsWith (" T _theUltimateAnswer"), "Binding symbol not in executable");
 
-				symbols = ExecutionHelper.Execute ("nm", Quote (Path.Combine (mtouch.AppPath, "libbindings-test.dll.dylib")), hide_output: true).Split ('\n');
-				Assert.That (symbols, Has.Some.EndsWith (" T _theUltimateAnswer"), "Binding symbol in binding library");
+					symbols = ExecutionHelper.Execute ("nm", Quote (Path.Combine (mtouch.AppPath, "libbindings-test.dll.dylib")), hide_output: true).Split ('\n');
+					Assert.That (symbols, Has.Some.EndsWith (" T _theUltimateAnswer"), "Binding symbol in binding library");
+				}
 			} finally {
 				Directory.Delete (testDir, true);
 			}


### PR DESCRIPTION
We disabled fastdev for tvOS/watchOS projects with binding projects in
fe17d5db9f7, and that broke the FastDev_LinkWithTest:

    Errors and Failures:
    1) Test Failure : Xamarin.MTouch.FastDev_LinkWithTest(TVOS)
         Binding symbol not in executable
      Expected: no item String ending with " T _theUltimateAnswer"
      But was:  < ... >

So adjust the test to match the new behavior.