### PR TITLE
[mtouch] [C9] Automatically enable bitcode if LLVM is enabled. Fixes #52241.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -367,6 +367,14 @@ No action is required on your part, this message is purely informational.
 
 For further information see bug #[51710](https://bugzilla.xamarin.com/show_bug.cgi?id=51710).
 
+<h3><a name="MT0111"/>MT0111: Bitcode has been enabled because this version of Xamarin.iOS does not support building watchOS projects using LLVM without enabling bitcode.</h3>
+
+Bitcode has been enabled automatically because this version of Xamarin.iOS does not support building watchOS projects using LLVM without enabling bitcode.
+
+No action is required on your part, this message is purely informational.
+
+For further information see bug #[51634](https://bugzilla.xamarin.com/show_bug.cgi?id=51634).
+
 <!--
  MT1xxx file copy / symlinks (project related)
   MT10xx installer.cs / mtouch.cs

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -637,6 +637,11 @@ namespace Xamarin.Bundler {
 
 		void Initialize ()
 		{
+			if (IsLLVM && Platform == ApplePlatform.WatchOS && BitCodeMode != BitCodeMode.LLVMOnly) {
+				ErrorHelper.Warning (111, "Bitcode has been enabled because this version of Xamarin.iOS does not support building watchOS projects using LLVM without enabling bitcode.");
+				BitCodeMode = BitCodeMode.LLVMOnly;
+			}
+
 			if (!File.Exists (RootAssembly))
 				throw new MonoTouchException (7, true, "The root assembly '{0}' does not exist", RootAssembly);
 			

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -105,6 +105,7 @@ namespace Xamarin.Bundler {
 	//					MT0096 No reference to Xamarin.iOS.dll was found.
 	//					MT0097 <used by mmp>
 	//		Warning		MT0110  Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include third-party binding libraries and that compiles to bitcode.
+	//		Warning		MT0111	Bitcode has been enabled because this version of Xamarin.iOS does not support building watchOS projects using LLVM without enabling bitcode.
 	// MT1xxx	file copy / symlinks (project related)
 	//			MT10xx	installer.cs / mtouch.cs
 	//					MT1001	Could not find an application at the specified directory: {0}


### PR DESCRIPTION
Currently we can't build watchOS projects if LLVM is enabled, but bitcode is
not (see bug #51634).

Additionally the IDEs do not have UI to select if bitcode is enabled or not,
so automatically enable it if LLVM is enabled (since most likely people will
be building for the App Store if LLVM is enabled).

https://bugzilla.xamarin.com/show_bug.cgi?id=51634
https://bugzilla.xamarin.com/show_bug.cgi?id=52241