### PR TITLE
[msbuild][fsharp] Copy .mdb files when building with msbuild

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.FSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.FSharp.targets
@@ -19,6 +19,11 @@
 		<FSharpTargets Condition="'$(FSharpTargets)' == '' And Exists('$(MSBuildFrameworkToolsPath32)\Microsoft.FSharp.Targets')">$(MSBuildFrameworkToolsPath32)\Microsoft.FSharp.Targets</FSharpTargets>
 		<FSharpTargets Condition="'$(FSharpTargets)' == ''">$(MSBuildBinPath)\Microsoft.FSharp.Targets</FSharpTargets>
 
+		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
+		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can
+		     remove this -->
+		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
+		<_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
 	</PropertyGroup>
 
 	<Import Project="$(FSharpTargets)" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.FSharp.targets
@@ -22,6 +22,12 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 		<DefineConstants>__UNIFIED__;__MOBILE__;__TVOS__;$(DefineConstants)</DefineConstants>
+
+		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
+		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can
+		     remove this -->
+		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
+		<_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
 	</PropertyGroup>
 
 	<Import Project="Xamarin.TVOS.AppExtension.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.FSharp.targets
@@ -22,6 +22,12 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 		<DefineConstants>__UNIFIED__;__MOBILE__;__TVOS__;$(DefineConstants)</DefineConstants>
+
+		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
+		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can
+		     remove this -->
+		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
+		<_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
 	</PropertyGroup>
 
 	<!-- xbuild searches multiple MSBuildExtensionsPath32, but only in the Import element so we can't determine this with a variable -->

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.FSharp.targets
@@ -22,6 +22,12 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 		<DefineConstants>__UNIFIED__;__MOBILE__;__WATCHOS__;$(DefineConstants)</DefineConstants>
+
+		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
+		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can
+		     remove this -->
+		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
+		<_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
 	</PropertyGroup>
 
 	<!-- xbuild searches multiple MSBuildExtensionsPath32, but only in the Import element so we can't determine this with a variable -->

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.FSharp.targets
@@ -22,6 +22,12 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 		<DefineConstants>__UNIFIED__;__MOBILE__;__WATCHOS__;$(DefineConstants)</DefineConstants>
+
+		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
+		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can
+		     remove this -->
+		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
+		<_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
 	</PropertyGroup>
 
 	<!-- xbuild searches multiple MSBuildExtensionsPath32, but only in the Import element so we can't determine this with a variable -->

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.FSharp.targets
@@ -22,6 +22,12 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 		<DefineConstants>__UNIFIED__;__MOBILE__;__WATCHOS__;$(DefineConstants)</DefineConstants>
+
+		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
+		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can
+		     remove this -->
+		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
+		<_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
 	</PropertyGroup>
 	<Import Project="Xamarin.WatchOS.Common.targets" />
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.FSharp.targets
@@ -22,6 +22,12 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 		<DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;$(DefineConstants)</DefineConstants>
+
+		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
+		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can
+		     remove this -->
+		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
+		<_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
 	</PropertyGroup>
 
 	<Import Project="Xamarin.iOS.AppExtension.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.FSharp.targets
@@ -22,6 +22,12 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 		<DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;$(DefineConstants)</DefineConstants>
+
+		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
+		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can
+		     remove this -->
+		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
+		<_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
 	</PropertyGroup>
 
 	<!-- xbuild searches multiple MSBuildExtensionsPath32, but only in the Import element so we can't determine this with a variable -->


### PR DESCRIPTION
Mono's fork of msbuild uses a `$(_DebugFileExt)` property to specify
the debug file extension (.pdb/.mdb) to use. It defaults to .pdb. So,
with XI/XM, .mdb files don't get copied to the output folder.

We also add a `$(FscDebugFileExt)` property, which allows our default of
`.mdb` to be overridden.

But the `$(_DebugFileExt)` support  is not in upstream msbuild yet. So,
we can't ask the F# upstream to add it. Hence, this is being added to
our FSharp target files. Once, all this is upstream, we can remove the
overrides from our files.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=51148