### PR TITLE
[XM] Fix APIBreaks (#1638)

### DIFF
--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -576,7 +576,10 @@ namespace XamCore.AVFoundation {
 		Off, Standard, Cinematic, Auto = -1
 	}
 
-	[NoTV, NoMac, NoWatch, iOS (8,0)]
+#if XAMCORE_4_0
+	[NoMac]
+#endif
+	[NoTV, NoWatch, iOS (8,0)]
 	[Native]
 	public enum AVCaptureAutoFocusSystem : nint {
 		None,

--- a/src/SceneKit/SCNCompat.cs
+++ b/src/SceneKit/SCNCompat.cs
@@ -32,4 +32,22 @@ namespace XamCore.SceneKit {
 		}
 	}
 #endif
+
+#if MONOMAC && !XAMCORE_4_0
+	partial class SCNScene {
+		[Obsolete ("Use the ISCNSceneExportDelegate overload instead")]
+		[Mac (10, 9)]
+		public virtual bool WriteToUrl (NSUrl url, SCNSceneLoadingOptions options, SCNSceneExportDelegate handler, SCNSceneExportProgressHandler exportProgressHandler)
+		{
+			return WriteToUrl (url: url, options: options == null ? null : options.Dictionary, aDelegate: handler, exportProgressHandler: exportProgressHandler);
+		}
+
+		[Obsolete ("Use the ISCNSceneExportDelegate overload instead")]
+		[Mac (10, 9)]
+		public virtual bool WriteToUrl (NSUrl url, NSDictionary options, SCNSceneExportDelegate handler, SCNSceneExportProgressHandler exportProgressHandler)
+		{
+			return WriteToUrl (url: url, options: options, aDelegate: handler, exportProgressHandler: exportProgressHandler);
+		}
+	}
+#endif
 }

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -22992,7 +22992,9 @@ namespace XamCore.AppKit {
 		bool IsAccessibilitySelectorAllowed (Selector selector);
 
 		[Mac (10, 12)]
+#if XAMCORE_4_0
 		[Abstract]
+#endif
 		[Export ("accessibilityRequired")]
 		bool AccessibilityRequired { [Bind ("isAccessibilityRequired")] get; set; }
 

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -1675,7 +1675,7 @@ namespace XamCore.GameKit {
 		[Export ("handleMatchEnded:")]
 		void HandleMatchEnded (GKTurnBasedMatch match);
 
-#if XAMCORE_2_0
+#if (XAMCORE_2_0 && !MONOMAC) || XAMCORE_4_0
 		[Abstract]
 #endif
 		[Since (6,0)]

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -1617,7 +1617,9 @@ namespace XamCore.Metal {
 		void SetVertexTextures (IMTLTexture [] textures, NSRange range);
 
 		[NoiOS, NoTV, NoWatch, Mac (10,11)]
+#if XAMCORE_4_0
 		[Abstract]
+#endif
 		[Export ("textureBarrier")]
 		void TextureBarrier ();
 
@@ -1657,7 +1659,9 @@ namespace XamCore.Metal {
 		void DrawPatches (nuint numberOfPatchControlPoints, nuint patchStart, nuint patchCount, [NullAllowed] IMTLBuffer patchIndexBuffer, nuint patchIndexBufferOffset, nuint instanceCount, nuint baseInstance);
 
 		[NoiOS, NoTV, NoWatch, Mac (10,12)]
+#if XAMCORE_4_0
 		[Abstract]
+#endif
 		[Export ("drawPatches:patchIndexBuffer:patchIndexBufferOffset:indirectBuffer:indirectBufferOffset:")]
 		void DrawPatches (nuint numberOfPatchControlPoints, [NullAllowed] IMTLBuffer patchIndexBuffer, nuint patchIndexBufferOffset, IMTLBuffer indirectBuffer, nuint indirectBufferOffset);
 
@@ -1669,7 +1673,9 @@ namespace XamCore.Metal {
 		void DrawIndexedPatches (nuint numberOfPatchControlPoints, nuint patchStart, nuint patchCount, [NullAllowed] IMTLBuffer patchIndexBuffer, nuint patchIndexBufferOffset, IMTLBuffer controlPointIndexBuffer, nuint controlPointIndexBufferOffset, nuint instanceCount, nuint baseInstance);
 
 		[NoiOS, NoTV, NoWatch, Mac (10,12)]
+#if XAMCORE_4_0
 		[Abstract]
+#endif
 		[Export ("drawIndexedPatches:patchIndexBuffer:patchIndexBufferOffset:controlPointIndexBuffer:controlPointIndexBufferOffset:indirectBuffer:indirectBufferOffset:")]
 		void DrawIndexedPatches (nuint numberOfPatchControlPoints, [NullAllowed] IMTLBuffer patchIndexBuffer, nuint patchIndexBufferOffset, IMTLBuffer controlPointIndexBuffer, nuint controlPointIndexBufferOffset, IMTLBuffer indirectBuffer, nuint indirectBufferOffset);
 	}

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -1833,17 +1833,6 @@ namespace XamCore.SceneKit {
 		[Wrap ("WriteToUrl (url, options == null ? null : options.Dictionary, handler, exportProgressHandler)")]
 		bool WriteToUrl (NSUrl url, SCNSceneLoadingOptions options, ISCNSceneExportDelegate handler, SCNSceneExportProgressHandler exportProgressHandler);
 
-#if MONOMAC && !XAMCORE_4_0 // Add this overloads for binary compat only on macOS
-		[Obsolete ("Use the ISCNSceneExportDelegate overload instead")]
-		[Mac (10, 9)]
-		[Wrap ("WriteToUrl (url: url, options: options == null ? null : options.Dictionary, aDelegate: handler, exportProgressHandler: exportProgressHandler)")]
-		bool WriteToUrl (NSUrl url, SCNSceneLoadingOptions options, SCNSceneExportDelegate handler, SCNSceneExportProgressHandler exportProgressHandler);
-
-		[Obsolete ("Use the ISCNSceneExportDelegate overload instead")]
-		[Mac (10, 9)]
-		[Wrap ("WriteToUrl (url: url, options: options, aDelegate: handler, exportProgressHandler: exportProgressHandler)")]
-		bool WriteToUrl (NSUrl url, NSDictionary options, SCNSceneExportDelegate handler, SCNSceneExportProgressHandler exportProgressHandler);
-#endif
 		#region SCNParticleSystemSupport (SCNNode) category
 
 		[Mac (10,10)]
@@ -2586,7 +2575,9 @@ namespace XamCore.SceneKit {
 #else
 		new EAGLContext Context { get; set; }
 #endif
+#endif
 
+#if !WATCH
 		[iOS (9,0)][Mac (10,11)]
 		[Wrap ("this (frame, options != null ? options.Dictionary : null)")]
 		IntPtr Constructor (CGRect frame, [NullAllowed] SCNRenderingOptions options);


### PR DESCRIPTION
AVCaptureAutoFocusSystem was removed in:

	commit 65ffc88
	Author: Manuel de la Pena v-mandel@microsoft.com
	Date: Thu Aug 11 14:22:59 2016 +0200

	[AVFoundation] Update bindings for XCode8. Focus on enums and structs. (#591)

public virtual bool WriteToUrl (Foundation.NSUrl url, Foundation.NSDictionary options, SCNSceneExportDelegate handler, SCNSceneExportProgressHandler exportProgressHandler) was in:

	commit 58a0e61
	Author: Alex Soto dalexsoto@gmail.com
	Date: Fri Aug 5 07:23:02 2016 -0500

	[Scenekit] Update SceneKit to Xcode8 Beta 4 (#552)

public SCNView (CoreGraphics.CGRect frame, SCNRenderingOptions options); was in:

	commit 921b254
	Author: Sebastien Pouliot sebastien.pouliot@gmail.com
	Date: Sat Aug 6 10:59:16 2016 -0400

	[watchos][scenekit] Enable SceneKit on watchOS (#563)

Also fixing

Type Changed: AppKit.INSAccessibility

Added property:

	public virtual bool AccessibilityRequired { get; set; }

Type Changed: GameKit.IGKTurnBasedEventHandlerDelegate

Added method:

	public virtual void HandleTurnEvent (GKTurnBasedMatch match, bool activated);

Type Changed: Metal.IMTLRenderCommandEncoder

Added methods:

	public virtual void DrawIndexedPatches (uint numberOfPatchControlPoints, IMTLBuffer patchIndexBuffer, uint patchIndexBufferOffset, IMTLBuffer controlPointIndexBuffer, uint controlPointIndexBufferOffset, IMTLBuffer indirectBuffer, uint indirectBufferOffset);
	public virtual void DrawPatches (uint numberOfPatchControlPoints, IMTLBuffer patchIndexBuffer, uint patchIndexBufferOffset, IMTLBuffer indirectBuffer, uint indirectBufferOffset);
	public virtual void TextureBarrier ();