### PR TITLE
[watchos][spritekit] Add part of SKVideoNode

### DIFF
--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -1224,44 +1224,60 @@ namespace XamCore.SpriteKit {
 		uint CategoryBitMask { get; set; } /* uint32_t */
 	}
 
-	[NoWatch]
+	[Watch (3,2)]
 	[Mac (10,9, onlyOn64 : true)]
 	[Since (7,0)]
 	[BaseType (typeof (SKNode))]
 	partial interface SKVideoNode {
 
-		[NoWatch]
+		[NoWatch] // documented as available but AVPlayer it not part of watchOS
 		[Static, Export ("videoNodeWithAVPlayer:")]
 		SKVideoNode FromPlayer (AVPlayer player);
 
+		[NoWatch] // documented as available but already marked deprecated
 		[Static, Export ("videoNodeWithVideoFileNamed:"), Internal]
 		SKVideoNode VideoNodeWithVideoFileNamed (string videoFile);
 
 		[Static, Export ("videoNodeWithFileNamed:"), Internal]
 		SKVideoNode VideoNodeWithFileNamed (string videoFile);
 
+		[NoWatch] // documented as available but already marked deprecated
 		[Static, Export ("videoNodeWithVideoURL:"), Internal]
 		SKVideoNode VideoNodeWithVideoURL (NSUrl videoURL);
 
 		[Static, Export ("videoNodeWithURL:"), Internal]
 		SKVideoNode VideoNodeWithURL (NSUrl videoURL);
 
-		[NoWatch]
+		[NoWatch] // documented as available but AVPlayer it not part of watchOS
 		[DesignatedInitializer]
 		[Export ("initWithAVPlayer:")]
 		IntPtr Constructor (AVPlayer player);
 
+#if WATCH
+		// avoid workaround of init* selectors with same signature
+
+		[DesignatedInitializer]
+		[Export ("initWithFileNamed:")]
+		IntPtr Constructor (string videoFile);
+
+		[DesignatedInitializer]
+		[Export ("initWithURL:")]
+		IntPtr Constructor (NSUrl url);
+#else
+		[NoWatch]
 		[Export ("initWithVideoFileNamed:"), Internal]
 		IntPtr InitWithVideoFileNamed (string videoFile);
 
 		[Export ("initWithFileNamed:"), Internal]
 		IntPtr InitWithFileNamed (string videoFile);
 
+		[NoWatch]
 		[Export ("initWithVideoURL:"), Internal]
 		IntPtr InitWithVideoURL (NSUrl url);
 
 		[Export ("initWithURL:"), Internal]
 		IntPtr InitWithURL (NSUrl url);
+#endif
 
 		[Export ("play")]
 		void Play ();

--- a/tests/xtro-sharpie/watchos.ignore
+++ b/tests/xtro-sharpie/watchos.ignore
@@ -116,6 +116,20 @@
 !missing-enum! PKPaymentButtonType not bound
 
 
+# SpriteKit
+
+## AVPlayer is not available on watchOS
+!missing-selector! +SKVideoNode::videoNodeWithAVPlayer: not bound
+!missing-selector! SKVideoNode::initWithAVPlayer: not bound
+
+## Those API are already deprecated - so we're not adding them
+## from a managed point-of-view that's invisible (same .ctor)
+!missing-selector! SKVideoNode::initWithVideoFileNamed: not bound
+!missing-selector! SKVideoNode::initWithVideoURL: not bound
+!missing-selector! +SKVideoNode::videoNodeWithVideoFileNamed: not bound
+!missing-selector! +SKVideoNode::videoNodeWithVideoURL: not bound
+
+
 # UIKit
 
 ## Implemented in managed code


### PR DESCRIPTION
`SKVideoNode` was added but its situation is a bit confusing since it
expose API that refers to the, non available, `AVPlayer`. That's
likely an oversight from Apple and those API are, for now, ignored
from xtro tests [1].

Also some API are already deprecated and are not added [2]

[1] AVPlayer related
!missing-selector! +SKVideoNode::videoNodeWithAVPlayer: not bound
!missing-selector! SKVideoNode::initWithAVPlayer: not bound

[2]
!missing-selector! +SKVideoNode::videoNodeWithVideoFileNamed: not bound
!missing-selector! +SKVideoNode::videoNodeWithVideoURL: not bound
!missing-selector! SKVideoNode::initWithVideoFileNamed: not bound
!missing-selector! SKVideoNode::initWithVideoURL: not bound