### PR TITLE
[tvos][mediaplayer] Update xtro definitions

### DIFF
--- a/tests/xtro-sharpie/tvos.ignore
+++ b/tests/xtro-sharpie/tvos.ignore
@@ -202,6 +202,7 @@
 !missing-field! MPMediaItemPropertyUserGrouping not bound
 !missing-field! MPMediaItemPropertyDateAdded not bound
 !missing-field! MPMediaItemPropertyIsExplicit not bound
+!missing-field! MPMediaItemPropertyPlaybackStoreID not bound
 
 ## shown as available in iOS 9.3 in tvOS header files (from Xcode 7.3) so normally available in tvOS 9.2 
 ## In reality it's only available in the simulator, not on AppleTV devices (all fields are null)
@@ -274,6 +275,8 @@
 !missing-selector! MPMusicPlayerController::volume not bound
 !missing-selector! MPMusicPlayerController::prepareToPlayWithCompletionHandler: not bound
 !missing-selector! MPMusicPlayerController::setQueueWithDescriptor: not bound
+!missing-selector! MPMusicPlayerController::appendQueueDescriptor: not bound
+!missing-selector! MPMusicPlayerController::prependQueueDescriptor: not bound
 
 ## from (unmarked) MPMediaItem_MPMediaQueryAdditions but MPMediaItem is not in tvOS
 !missing-selector! +MPMediaItem::persistentIDPropertyForGroupingType: not bound


### PR DESCRIPTION
The new field and both selectors are not really part of tvOS.

The field is not used anywhere (from available API).

The selectors are on a category on a type that is not part of tvOS.
Sadly they do not get annotated directly and require external data.