### PR TITLE
[linker] Remove static state, and put the state inside DerivedLinkContext instead.

### DIFF
--- a/tools/common/DerivedLinkContext.cs
+++ b/tools/common/DerivedLinkContext.cs
@@ -14,6 +14,41 @@ namespace Xamarin.Tuner
 		List<MethodDefinition> marshal_exception_pinvokes;
 		Dictionary<string, TypeDefinition> objectivec_classes;
 
+		// SDK candidates - they will be preserved only if the application (not the SDK) uses it
+		List<ICustomAttributeProvider> srs_data_contract = new List<ICustomAttributeProvider> ();
+		List<ICustomAttributeProvider> xml_serialization = new List<ICustomAttributeProvider> ();
+
+		HashSet<TypeDefinition> cached_isnsobject;
+		HashSet<TypeDefinition> needs_isdirectbinding_check;
+		HashSet<MethodDefinition> generated_code;
+
+		public HashSet<TypeDefinition> CachedIsNSObject {
+			get { return cached_isnsobject; }
+			set { cached_isnsobject = value; }
+		}
+
+		public HashSet<TypeDefinition> NeedsIsDirectBindingCheck {
+			get { return needs_isdirectbinding_check; }
+			set { needs_isdirectbinding_check = value; }
+		}
+
+		public HashSet<MethodDefinition> GeneratedCode {
+			get { return generated_code; }
+			set { generated_code = value; }
+		}
+
+		public IList<ICustomAttributeProvider> DataContract {
+			get {
+				return srs_data_contract;
+			}
+		}
+
+		public IList<ICustomAttributeProvider> XmlSerialization {
+			get {
+				return xml_serialization;
+			}
+		}
+
 		public List<MemberReference> GetRequiredSymbolList (string symbol)
 		{
 			List<MemberReference> rv;

--- a/tools/linker/CoreMarkStep.cs
+++ b/tools/linker/CoreMarkStep.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Linker.Steps {
 				if (!Annotations.IsMarked (od))
 					continue;
 				// we do NOT process non-generated code - we could break user code
-				if (!od.IsGeneratedCode ())
+				if (!od.IsGeneratedCode (LinkContext))
 					continue;
 
 				ProcessDispose (skip ? bd : cd, od);
@@ -142,7 +142,7 @@ namespace Xamarin.Linker.Steps {
 		{
 			if (!method.IsFamily || !method.IsVirtual || method.IsNewSlot || !method.HasParameters || !method.HasBody)
 				return false;
-			return ((method.Name == "Dispose") && method.IsGeneratedCode ());
+			return ((method.Name == "Dispose") && method.IsGeneratedCode (LinkContext));
 		}
 
 		protected override void ProcessMethod (MethodDefinition method)
@@ -235,7 +235,7 @@ namespace Xamarin.Linker.Steps {
 					var td = i.Module.GetType (i.Namespace, i.Name.Substring (1) + "_Extensions");
 					if (td != null && td.HasMethods) {
 						foreach (var m in td.Methods) {
-							if (!m.HasParameters || (m.Name != name) || !m.IsGeneratedCode ())
+							if (!m.HasParameters || (m.Name != name) || !m.IsGeneratedCode (LinkContext))
 							    continue;
 							bool proxy = false;
 							match = method.Parameters.Count == m.Parameters.Count - 1;

--- a/tools/linker/CoreOptimizeGeneratedCode.cs
+++ b/tools/linker/CoreOptimizeGeneratedCode.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Linker {
 			// if 'type' inherits from NSObject inside an assembly that has [GeneratedCode]
 			// or for static types used for optional members (using extensions methods), they can be optimized too
 			IsExtensionType = type.IsSealed && type.IsAbstract && type.Name.EndsWith ("_Extensions", StringComparison.Ordinal);
-			ProcessMethods = HasGeneratedCode || (!type.IsNSObject () && !IsExtensionType);
+			ProcessMethods = HasGeneratedCode || (!type.IsNSObject (LinkContext) && !IsExtensionType);
 		}
 
 		// [GeneratedCode] is not enough - e.g. it's used for anonymous delegates even if the 

--- a/tools/linker/ExceptionalSubStep.cs
+++ b/tools/linker/ExceptionalSubStep.cs
@@ -5,9 +5,17 @@ using Mono.Cecil;
 using Mono.Tuner;
 using Xamarin.Bundler;
 
+using Xamarin.Tuner;
+
 namespace Xamarin.Linker {
 
 	public abstract class ExceptionalSubStep : BaseSubStep {
+
+		protected DerivedLinkContext LinkContext {
+			get {
+				return (DerivedLinkContext) base.context;
+			}
+		}
 
 		public override sealed void ProcessAssembly (AssemblyDefinition assembly)
 		{

--- a/tools/linker/MarkNSObjects.cs
+++ b/tools/linker/MarkNSObjects.cs
@@ -53,7 +53,7 @@ namespace Xamarin.Linker.Steps {
 			if (ProductAssembly == null)
 				ProductAssembly = (Profile.Current as BaseProfile).ProductAssembly;
 
-			bool nsobject = type.IsNSObject ();
+			bool nsobject = type.IsNSObject (LinkContext);
 			if (!nsobject && !type.IsNativeObject ())
 				return;
 

--- a/tools/linker/MobileExtensions.cs
+++ b/tools/linker/MobileExtensions.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using Mono.Cecil;
 using Mono.Tuner;
 
+using Xamarin.Tuner;
+
 namespace Xamarin.Linker {
 
 	public static class MobileExtensions {
@@ -35,12 +37,10 @@ namespace Xamarin.Linker {
 			return null;
 		}
 
-		internal static HashSet<MethodDefinition> generated_code;
-
-		public static bool IsGeneratedCode (this MethodDefinition self)
+		public static bool IsGeneratedCode (this MethodDefinition self, DerivedLinkContext link_context)
 		{
-			if (generated_code != null)
-				return generated_code.Contains (self);
+			if (link_context.GeneratedCode != null)
+				return link_context.GeneratedCode.Contains (self);
 
 			// check the property too
 			if (self.IsGetter || self.IsSetter) {

--- a/tools/linker/MobileMarkStep.cs
+++ b/tools/linker/MobileMarkStep.cs
@@ -9,6 +9,8 @@ using Mono.Linker;
 using Mono.Linker.Steps;
 using Mono.Tuner;
 
+using Xamarin.Tuner;
+
 namespace Xamarin.Linker.Steps {
 
 	// XML definition files have their limits, i.e. they are good to keep stuff around unconditionnally
@@ -19,6 +21,12 @@ namespace Xamarin.Linker.Steps {
 	public class MobileMarkStep : MarkStep {
 
 		protected virtual bool DebugBuild { get; set; }
+
+		protected DerivedLinkContext LinkContext {
+			get {
+				return (DerivedLinkContext) base._context;
+			}
+		}
 
 		public override void Process (LinkContext context)
 		{
@@ -478,7 +486,7 @@ namespace Xamarin.Linker.Steps {
 				system_runtime_serialization = true;
 				// if we're keeping this assembly and use the Serialization namespace inside user code then we
 				// must bring the all the members decorated with [Data[Contract|Member]] attributes from the SDK
-				var members = ApplyPreserveAttribute.DataContract;
+				var members = LinkContext.DataContract;
 				foreach (var member in members)
 					MarkMetadata (member);
 				members.Clear ();
@@ -543,7 +551,7 @@ namespace Xamarin.Linker.Steps {
 					// if we're keeping this assembly and use the Serialization namespace inside user code
 					// then we must bring the all the members decorated with [Xml*] attributes from the SDK
 					system_xml_serialization = true;
-					var members = ApplyPreserveAttribute.XmlSerialization;
+					var members = LinkContext.XmlSerialization;
 					foreach (var member in members)
 						MarkMetadata (member);
 					members.Clear ();

--- a/tools/linker/MonoTouch.Tuner/Extensions.cs
+++ b/tools/linker/MonoTouch.Tuner/Extensions.cs
@@ -4,18 +4,18 @@ using Mono.Cecil;
 
 using Mono.Tuner;
 
+using Xamarin.Tuner;
+
 namespace MonoTouch.Tuner {
 
 	public static class Extensions {
 		
-		internal static HashSet<TypeDefinition> needs_isdirectbinding_check;
-		
-		public static bool IsDirectBindingCheckRequired (this TypeDefinition type)
+		public static bool IsDirectBindingCheckRequired (this TypeDefinition type, DerivedLinkContext link_context)
 		{
-			if (needs_isdirectbinding_check == null)
+			if (link_context.NeedsIsDirectBindingCheck == null)
 				return true;
 			
-			return needs_isdirectbinding_check.Contains (type);
+			return link_context.NeedsIsDirectBindingCheck.Contains (type);
 		}
 
 		public static bool IsPlatformType (this TypeReference type, string @namespace, string name)

--- a/tools/linker/MonoTouch.Tuner/MonoTouchTypeMap.cs
+++ b/tools/linker/MonoTouch.Tuner/MonoTouchTypeMap.cs
@@ -16,34 +16,28 @@ using Mono.Linker.Steps;
 using Mono.Tuner;
 
 using Xamarin.Linker;
+using Xamarin.Tuner;
 
 namespace MonoTouch.Tuner {
 
 	public class MonoTouchTypeMapStep : TypeMapStep {
-		
-		static HashSet<TypeDefinition> cached_isnsobject;
-		static HashSet<TypeDefinition> needs_isdirectbinding_check;
-		static HashSet<MethodDefinition> generated_code;
+		HashSet<TypeDefinition> cached_isnsobject = new HashSet<TypeDefinition> ();
+		HashSet<TypeDefinition> needs_isdirectbinding_check = new HashSet<TypeDefinition> ();
+		HashSet<MethodDefinition> generated_code = new HashSet<MethodDefinition> ();
 
-		public MonoTouchTypeMapStep ()
-		{
-			// FIXME: this won't work if we ever want to be able to run the linker for 32 and 64bit in parallel.
-			ObjCExtensions.cached_isnsobject = null;
-			Extensions.needs_isdirectbinding_check = null;
-			MobileExtensions.generated_code = null;
-
-			cached_isnsobject = new HashSet<TypeDefinition> ();
-			needs_isdirectbinding_check = new HashSet<TypeDefinition> ();
-			generated_code = new HashSet<MethodDefinition> ();
+		DerivedLinkContext LinkContext {
+			get {
+				return (DerivedLinkContext) base.Context;
+			}
 		}
 
 		protected override void EndProcess ()
 		{
 			base.EndProcess ();
-			
-			ObjCExtensions.cached_isnsobject = cached_isnsobject;
-			Extensions.needs_isdirectbinding_check = needs_isdirectbinding_check;
-			MobileExtensions.generated_code = generated_code;
+
+			LinkContext.CachedIsNSObject = cached_isnsobject;
+			LinkContext.NeedsIsDirectBindingCheck = needs_isdirectbinding_check;
+			LinkContext.GeneratedCode = generated_code;
 		}
 
 		protected override void MapType (TypeDefinition type)
@@ -54,7 +48,7 @@ namespace MonoTouch.Tuner {
 			// when processing Dispose methods in MonoTouchMarkStep
 			if (type.HasMethods) {
 				foreach (MethodDefinition m in type.Methods) {
-					if (m.IsGeneratedCode ())
+					if (m.IsGeneratedCode (LinkContext))
 						generated_code.Add (m);
 				}
 			}
@@ -65,7 +59,7 @@ namespace MonoTouch.Tuner {
 				return;
 			
 			// if not, it's a user type, the IsDirectBinding check is required by all ancestors
-			if (!IsGeneratedBindings (type))
+			if (!IsGeneratedBindings (type, LinkContext))
 				NeedsIsDirectBindingCheck (type);
 #if DEBUG
 			else
@@ -75,19 +69,19 @@ namespace MonoTouch.Tuner {
 		
 		// called once for each 'type' so it's a nice place to cache the result
 		// and ensure later steps re-use the same, pre-computed, result
-		static bool IsNSObject (TypeDefinition type)
+		bool IsNSObject (TypeDefinition type)
 		{
-			if (!type.IsNSObject ())
+			if (!type.IsNSObject (LinkContext))
 				return false;
 			cached_isnsobject.Add (type);
 			return true;
 		}
 		
 		// type has a "public .ctor (IntPtr)" with a [CompilerGenerated] attribute
-		static bool IsGeneratedBindings (TypeDefinition type)
+		static bool IsGeneratedBindings (TypeDefinition type, DerivedLinkContext link_context)
 		{
 			if (type.IsNested)
-				return IsGeneratedBindings (type.DeclaringType);
+				return IsGeneratedBindings (type.DeclaringType, link_context);
 			
 			if (!type.HasMethods)
 				return false;
@@ -101,12 +95,12 @@ namespace MonoTouch.Tuner {
 					continue;
 				if (!m.Parameters [0].ParameterType.Is ("System", "IntPtr"))
 					continue;
-				return m.IsGeneratedCode ();
+				return m.IsGeneratedCode (link_context);
 			}
 			return false;
 		}
 		
-		static void NeedsIsDirectBindingCheck (TypeDefinition type)
+		void NeedsIsDirectBindingCheck (TypeDefinition type)
 		{
 			// all ancestors must be disallowed
 			// so we can short-circuit the recursion if we already have processed it

--- a/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs
@@ -62,7 +62,7 @@ namespace MonoTouch.Tuner {
 			if (!HasGeneratedCode)
 				return;
 
-			isdirectbinding_check_required = type.IsDirectBindingCheckRequired ();
+			isdirectbinding_check_required = type.IsDirectBindingCheckRequired (LinkContext);
 			base.Process (type);
 		}
 
@@ -70,7 +70,7 @@ namespace MonoTouch.Tuner {
 		{
 			// special processing on generated methods from NSObject-inherited types
 			// it would be too risky to apply on user-generated code
-			if (!method.HasBody || !method.IsGeneratedCode () || (!IsExtensionType && !IsExport (method)))
+			if (!method.HasBody || !method.IsGeneratedCode (LinkContext) || (!IsExtensionType && !IsExport (method)))
 				return;
 			
 			var instructions = method.Body.Instructions;

--- a/tools/linker/ObjCExtensions.cs
+++ b/tools/linker/ObjCExtensions.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using Mono.Cecil;
 using Mono.Tuner;
 
+using Xamarin.Tuner;
+
 namespace Xamarin.Linker {
 
 	static class Namespaces {
@@ -168,18 +170,16 @@ namespace Xamarin.Linker {
 			}
 		}
 
-		internal static HashSet<TypeDefinition> cached_isnsobject;
-
-		public static bool IsNSObject (this TypeReference type)
+		public static bool IsNSObject (this TypeReference type, DerivedLinkContext link_context)
 		{
-			return type.Resolve ().IsNSObject ();
+			return type.Resolve ().IsNSObject (link_context);
 		}
 
 		// warning: *Is* means does 'type' inherits from MonoTouch.Foundation.NSObject ?
-		public static bool IsNSObject (this TypeDefinition type)
+		public static bool IsNSObject (this TypeDefinition type, DerivedLinkContext link_context)
 		{
-			if (cached_isnsobject != null)
-				return cached_isnsobject.Contains (type);
+			if (link_context.CachedIsNSObject != null)
+				return link_context.CachedIsNSObject.Contains (type);
 
 			return type.Inherits (Namespaces.Foundation, "NSObject");
 		}

--- a/tools/linker/ObjCExtensions.cs
+++ b/tools/linker/ObjCExtensions.cs
@@ -178,7 +178,7 @@ namespace Xamarin.Linker {
 		// warning: *Is* means does 'type' inherits from MonoTouch.Foundation.NSObject ?
 		public static bool IsNSObject (this TypeDefinition type, DerivedLinkContext link_context)
 		{
-			if (link_context.CachedIsNSObject != null)
+			if (link_context?.CachedIsNSObject != null)
 				return link_context.CachedIsNSObject.Contains (type);
 
 			return type.Inherits (Namespaces.Foundation, "NSObject");

--- a/tools/linker/RemoveSelectors.cs
+++ b/tools/linker/RemoveSelectors.cs
@@ -9,6 +9,8 @@ using Mono.Cecil.Cil;
 
 using Mono.Tuner;
 
+using Xamarin.Tuner;
+
 namespace Xamarin.Linker.Steps {
 
 	public class RemoveSelectors : IStep {
@@ -26,17 +28,17 @@ namespace Xamarin.Linker.Steps {
 				return;
 
 			foreach (TypeDefinition type in assembly.MainModule.Types) {
-				ProcessType (type);
+				ProcessType (type, (DerivedLinkContext) context);
 			}
 		}
 
-		void ProcessType (TypeDefinition type)
+		void ProcessType (TypeDefinition type, DerivedLinkContext context)
 		{
-			if (type.IsNSObject ()) {
+			if (type.IsNSObject (context)) {
 				ProcessNSObject (type);
 			} else if (type.HasNestedTypes) {
 				foreach (var nested in type.NestedTypes)
-					ProcessType (nested);
+					ProcessType (nested, context);
 			}
 		}
 

--- a/tools/mmp/linker/MonoMac.Tuner/OptimizeGeneratedCodeSubStep.cs
+++ b/tools/mmp/linker/MonoMac.Tuner/OptimizeGeneratedCodeSubStep.cs
@@ -30,7 +30,7 @@ namespace MonoMac.Tuner {
 		{
 			// special processing on generated methods from NSObject-inherited types
 			// it would be too risky to apply on user-generated code
-			if (!method.HasBody || !method.IsGeneratedCode () || (!IsExtensionType && !IsExport (method)))
+			if (!method.HasBody || !method.IsGeneratedCode (LinkContext) || (!IsExtensionType && !IsExport (method)))
 				return;
 			
 			var instructions = method.Body.Instructions;

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1658,7 +1658,7 @@ namespace Xamarin.Bundler
 
 			foreach (ModuleDefinition md in ad.Modules)
 				foreach (TypeDefinition td in md.Types)
-					if (td.IsNSObject ())
+					if (td.IsNSObject (s.Target.LinkContext))
 						return true;
 
 			return false;


### PR DESCRIPTION
Remove the usage of static variables in the linker so that one day we can run
the linker in parallel over multiple assembly sets.