### PR TITLE
[watchos][cloudkit] Update for beta 1

### DIFF
--- a/src/CloudKit/CKCompat.cs
+++ b/src/CloudKit/CKCompat.cs
@@ -29,14 +29,6 @@ namespace XamCore.CloudKit {
 #endif
 
 #if XAMCORE_2_0 || !MONOMAC
-	public partial class CKFetchNotificationChangesOperation {
-
-		// `init` does not work on watchOS but we can keep compatibility with a different init
-		public CKFetchNotificationChangesOperation () : this ((CKServerChangeToken) null)
-		{
-		}
-	}
-
 	public partial class CKModifyBadgeOperation {
 
 		// `init` does not work on watchOS but we can keep compatibility with a different init

--- a/src/cloudkit.cs
+++ b/src/cloudkit.cs
@@ -230,7 +230,7 @@ namespace XamCore.CloudKit {
 		[Async]
 		void FetchUserRecordId (Action<CKRecordID, NSError> completionHandler);
 
-		[iOS (10,0), TV (10,0), Mac (10,12)]
+		[iOS (10,0)][Mac (10,12)]
 		[NoTV]
 		[Export ("discoverAllIdentitiesWithCompletionHandler:")]
 		[Async]
@@ -488,7 +488,6 @@ namespace XamCore.CloudKit {
 	}
 
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
-	[DisableDefaultCtor] // does not work on watchOS, working stub provided to ease source compatibility
 	[BaseType (typeof (CKOperation))]
 	interface CKFetchNotificationChangesOperation {
 		[Export ("initWithPreviousServerChangeToken:")]
@@ -1519,16 +1518,9 @@ namespace XamCore.CloudKit {
 	[iOS (9,2), Mac (10,11,2, onlyOn64 : true)]
 	[TV (9,1)]
 	[Watch (3,0)]
-#if WATCH // does not work on watchOS - existiong init* does not allow null to be used to fake it
-	[DisableDefaultCtor]
-#endif
 	[BaseType (typeof (CKDatabaseOperation))]
 	interface CKFetchWebAuthTokenOperation {
 
-#if WATCH
-		// it might be because Xcode 8.2 headers were not updated for watchOS *or* because `init` does not work
-		[DesignatedInitializer]
-#endif
 		[Export ("initWithAPIToken:")]
 		IntPtr Constructor (string token);
 


### PR DESCRIPTION
The CloudKit headers for watchOS were updated to match the ones from
iOS and tvOS (from previous Xcode) so this mostly remove some watch
specific code.

Apple also made some previously broken `init` to be
NS_DESIGNATED_INITIALIZER so those are now enabled for watchOS.