### PR TITLE
[mtouch tests] Add sleep to fix #47696.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1049,6 +1049,7 @@ namespace Xamarin
 				tool.CreateTemporaryApp ();
 				tool.Linker = MTouchLinker.DontLink;
 				tool.Debug = true;
+				System.Threading.Thread.Sleep (1000); // HFS does not have sub-second timestamp resolution, so make sure the timestamps actually are different...
 				tool.AssertExecute (MTouchAction.BuildSim);
 				tool.AssertOutputPattern ("was built using fast-path for simulator"); // This is just to ensure we're actually testing fastsim. If this fails, modify the mtouch options to make this test use fastsim again.
 				Assert.That (File.GetLastWriteTimeUtc (tool.RootAssembly), Is.LessThan (File.GetLastWriteTimeUtc (tool.NativeExecutablePath)), "simlauncher timestamp");


### PR DESCRIPTION
Sometimes, when the stars align, fastsim can build an app in less than a
second.

Coupled with the fact that HFS+'s filestamp resolution is 1 second, we can't
assert that filestamps change without making sure enough time passes by.

So sleep for a second.

https://bugzilla.xamarin.com/show_bug.cgi?id=47696