### PR TITLE
[metal] Add new MTL* API from Xcode 8.3 beta1

### DIFF
--- a/src/metal.cs
+++ b/src/metal.cs
@@ -253,11 +253,46 @@ namespace XamCore.Metal {
 		[Export ("presentDrawable:atTime:")]
 		void PresentDrawable (IMTLDrawable drawable, double presentationTime);
 
+#if XAMCORE_4_0
+		[Abstract] // @required but we can't add abstract members in C# and keep binary compatibility
+#endif
+		[iOS (10,3)][TV (10,2)][NoMac]
+		[Export ("presentDrawable:afterMinimumDuration:")]
+		void PresentDrawableAfter (IMTLDrawable drawable, double duration);
+
 #if XAMCORE_2_0
 		[Abstract]
 #endif
 		[Export ("renderCommandEncoderWithDescriptor:")]
 		IMTLRenderCommandEncoder CreateRenderCommandEncoder (MTLRenderPassDescriptor renderPassDescriptor);
+
+#if XAMCORE_4_0
+		[Abstract] // @required but we can't add abstract members in C# and keep binary compatibility
+#endif
+		[iOS (10,3)][TV (10,2)][Mac (10,12,4, onlyOn64 : true)]
+		[Export ("kernelStartTime")]
+		double /* CFTimeInterval */ KernelStartTime { get; }
+
+#if XAMCORE_4_0
+		[Abstract] // @required but we can't add abstract members in C# and keep binary compatibility
+#endif
+		[iOS (10,3)][TV (10,2)][Mac (10,12,4, onlyOn64 : true)]
+		[Export ("kernelEndTime")]
+		double /* CFTimeInterval */ KernelEndTime { get; }
+
+#if XAMCORE_4_0
+		[Abstract] // @required but we can't add abstract members in C# and keep binary compatibility
+#endif
+		[iOS (10,3)][TV (10,2)][Mac (10,12,4, onlyOn64 : true)]
+		[Export ("GPUStartTime")]
+		double /* CFTimeInterval */ GpuStartTime { get; }
+
+#if XAMCORE_4_0
+		[Abstract] // @required but we can't add abstract members in C# and keep binary compatibility
+#endif
+		[iOS (10,3)][TV (10,2)][Mac (10,12,4, onlyOn64 : true)]
+		[Export ("GPUEndTime")]
+		double /* CFTimeInterval */ GpuEndTime { get; }
 	}
 
 	interface IMTLCommandQueue {}
@@ -667,6 +702,34 @@ namespace XamCore.Metal {
 		
 		[Abstract, Export ("presentAtTime:")]
 		void Present (double presentationTime);
+
+#if XAMCORE_4_0
+		[Abstract] // @required but we can't add abstract members in C# and keep binary compatibility
+#endif
+		[iOS (10,3)][TV (10,2)][NoMac]
+		[Export ("presentAfterMinimumDuration:")]
+		void PresentAfter (double duration);
+
+#if XAMCORE_4_0
+		[Abstract] // @required but we can't add abstract members in C# and keep binary compatibility
+#endif
+		[iOS (10,3)][TV (10,2)][NoMac]
+		[Export ("addPresentedHandler:")]
+		void AddPresentedHandler (Action<IMTLDrawable> block);
+
+#if XAMCORE_4_0
+		[Abstract] // @required but we can't add abstract members in C# and keep binary compatibility
+#endif
+		[iOS (10,3)][TV (10,2)][NoMac]
+		[Export ("presentedTime")]
+		double /* CFTimeInterval */ PresentedTime { get; }
+
+#if XAMCORE_4_0
+		[Abstract] // @required but we can't add abstract members in C# and keep binary compatibility
+#endif
+		[iOS (10,3)][TV (10,2)][NoMac]
+		[Export ("drawableID")]
+		nuint DrawableID { get; }
 	}
 
 	interface IMTLTexture {}

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -176,6 +176,7 @@ namespace Introspection
 			"Geocoder",
 			"Gigapascals",
 			"Gpp",
+			"Gpu",	// acronym for Graphics Processing Unit
 			"Grbg", // acronym for Green-Red-Blue-Green
 			"Hdmi",
 			"Hdr",

--- a/tests/xtro-sharpie/common.ignore
+++ b/tests/xtro-sharpie/common.ignore
@@ -89,6 +89,51 @@
 !incorrect-protocol-member! MTLResource::heap is REQUIRED and should be abstract
 !incorrect-protocol-member! MTLResource::isAliasable is REQUIRED and should be abstract
 !incorrect-protocol-member! MTLResource::makeAliasable is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLCommandBuffer::presentDrawable:afterMinimumDuration: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLDrawable::addPresentedHandler: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLDrawable::drawableID is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLDrawable::presentAfterMinimumDuration: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLDrawable::presentedTime is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLBuffer::addDebugMarker:range: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLBuffer::removeAllDebugMarkers is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLCommandBuffer::GPUEndTime is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLCommandBuffer::GPUStartTime is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLCommandBuffer::kernelEndTime is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLCommandBuffer::kernelStartTime is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLComputeCommandEncoder::dispatchThreadgroupsWithIndirectBuffer:indirectBufferOffset:threadsPerThreadgroup: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLComputeCommandEncoder::setStageInRegion: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLDevice::maxThreadsPerThreadgroup is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLDevice::newDefaultLibraryWithBundle:error: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLFunction::functionConstantsDictionary is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLFunction::label is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLFunction::patchControlPointCount is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLFunction::patchType is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLFunction::setLabel: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLFunction::stageInputAttributes is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLLibrary::newFunctionWithName:constantValues:completionHandler: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLLibrary::newFunctionWithName:constantValues:error: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLParallelRenderCommandEncoder::setColorStoreAction:atIndex: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLParallelRenderCommandEncoder::setDepthStoreAction: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLParallelRenderCommandEncoder::setStencilStoreAction: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLRenderCommandEncoder::drawIndexedPatches:patchStart:patchCount:patchIndexBuffer:patchIndexBufferOffset:controlPointIndexBuffer:controlPointIndexBufferOffset:instanceCount:baseInstance: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLRenderCommandEncoder::drawIndexedPrimitives:indexCount:indexType:indexBuffer:indexBufferOffset:instanceCount:baseVertex:baseInstance: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLRenderCommandEncoder::drawIndexedPrimitives:indexType:indexBuffer:indexBufferOffset:indirectBuffer:indirectBufferOffset: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLRenderCommandEncoder::drawPatches:patchStart:patchCount:patchIndexBuffer:patchIndexBufferOffset:instanceCount:baseInstance: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLRenderCommandEncoder::drawPrimitives:indirectBuffer:indirectBufferOffset: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLRenderCommandEncoder::drawPrimitives:vertexStart:vertexCount:instanceCount:baseInstance: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLRenderCommandEncoder::setColorStoreAction:atIndex: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLRenderCommandEncoder::setDepthStoreAction: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLRenderCommandEncoder::setStencilStoreAction: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLRenderCommandEncoder::setTessellationFactorBuffer:offset:instanceStride: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLRenderCommandEncoder::setTessellationFactorScale: is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLResource::storageMode is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLTexture::buffer is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLTexture::bufferBytesPerRow is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLTexture::bufferOffset is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLTexture::parentRelativeLevel is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLTexture::parentRelativeSlice is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLTexture::parentTexture is REQUIRED and should be abstract
+!incorrect-protocol-member! MTLTexture::usage is REQUIRED and should be abstract
 
 
 # ModelIO
@@ -124,3 +169,7 @@
 
 ## objc runtime
 !unknown-pinvoke! class_addProperty bound
+
+## CoreLocation
+# We have our own managed ctor
+!missing-pinvoke! CLLocationCoordinate2DMake is not bound


### PR DESCRIPTION
Covers iOS, tvOS and macOS (no Metal on watch yet)

Most new members are _marked_ as @required (but are not really) by
Apple. We cannot make them `abstract` as it would be a breaking change.