### PR TITLE
[audiotoolbox] Allow SourceAudioUnit to be set to null (beta 2)

### DIFF
--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -621,7 +621,7 @@ namespace XamCore.AudioUnit
 				throw new ArgumentNullException ("sourceAudioUnit");
 
 			var auc = new AudioUnitConnection {
-				SourceAudioUnit = sourceAudioUnit.handle,
+				SourceAudioUnit = sourceAudioUnit == null ? IntPtr.Zero : sourceAudioUnit.handle,
 				SourceOutputNumber = sourceOutputNumber,
 				DestInputNumber = destInputNumber
 			};


### PR DESCRIPTION
Latest header files marks this file as nullable so we should let
our managed API accept null values.

> AudioUnit __nullable	sourceAudioUnit;