### PR TITLE
[tvos][uikit] Fix two UITableViewDataSource that are not prohibited anymore

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -11487,11 +11487,11 @@ namespace XamCore.UIKit {
 		[Export ("tableView:canMoveRowAtIndexPath:")]
 		bool CanMoveRow (UITableView tableView, NSIndexPath indexPath);
 
-		[NoTV]
+		[TV (10,2)]
 		[Export ("sectionIndexTitlesForTableView:")]
 		string [] SectionIndexTitles (UITableView tableView);
 
-		[NoTV]
+		[TV (10,2)]
 		[Export ("tableView:sectionForSectionIndexTitle:atIndex:")]
 		nint SectionFor (UITableView tableView, string title, nint atIndex);
 


### PR DESCRIPTION
Spotted by xtro

!missing-protocol-member! UITableViewDataSource::sectionIndexTitlesForTableView: not found
!missing-protocol-member! UITableViewDataSource::tableView:sectionForSectionIndexTitle:atIndex: not found

and it was in the header diff too

```diff
-- (nullable NSArray<NSString *> *)sectionIndexTitlesForTableView:(UITableView *)tableView __TVOS_PROHIBITED;                                                    // return list of section titles to display in section index view (e.g. "ABCD...Z#")
-- (NSInteger)tableView:(UITableView *)tableView sectionForSectionIndexTitle:(NSString *)title atIndex:(NSInteger)index __TVOS_PROHIBITED;  // tell table which section corresponds to section title/index (e.g. "B",1))
+- (nullable NSArray<NSString *> *)sectionIndexTitlesForTableView:(UITableView *)tableView;                               // return list of section titles to display in section index view (e.g. "ABCD...Z#")
+- (NSInteger)tableView:(UITableView *)tableView sectionForSectionIndexTitle:(NSString *)title atIndex:(NSInteger)index;  // tell table which section corresponds to section title/index (e.g. "B",1))
```