### PR TITLE
[VideoToolbox] Updated to Xcode 8.3 Beta 1

### DIFF
--- a/src/VideoToolbox/VTCompressionProperties.cs
+++ b/src/VideoToolbox/VTCompressionProperties.cs
@@ -17,7 +17,6 @@ using XamCore.CoreVideo;
 
 namespace XamCore.VideoToolbox {
 	public partial class VTCompressionProperties {
-		[Mac (10,8), iOS (8,0)]
 		public VTProfileLevel ProfileLevel {
 			get {
 				var key = GetNSStringValue (VTCompressionPropertyKey.ProfileLevel);
@@ -275,7 +274,7 @@ namespace XamCore.VideoToolbox {
 			}
 		}
 
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		public VTH264EntropyMode H264EntropyMode { 
 			get {
 				var key = GetNSStringValue (VTCompressionPropertyKey.H264EntropyMode);
@@ -303,7 +302,6 @@ namespace XamCore.VideoToolbox {
 			}
 		}
 
-		[Mac (10,8), iOS (8,0)]
 		public List<VTDataRateLimit> DataRateLimits { 
 			get { 
 				using (var arr = GetNativeValue <NSArray> (VTCompressionPropertyKey.DataRateLimits)) {
@@ -340,7 +338,6 @@ namespace XamCore.VideoToolbox {
 			}
 		}
 
-		[Mac (10,8), iOS (8,0)]
 		public VTFieldDetail FieldDetail { 
 			get {
 				var key = GetNSStringValue (VTCompressionPropertyKey.FieldDetail);
@@ -378,7 +375,6 @@ namespace XamCore.VideoToolbox {
 			}
 		}
 #if XAMCORE_2_0
-		[Mac (10,8), iOS (8,0)]
 		public VTColorPrimaries ColorPrimaries { 
 			get {
 				var key = GetNSStringValue (VTCompressionPropertyKey.ColorPrimaries);
@@ -417,7 +413,6 @@ namespace XamCore.VideoToolbox {
 		}
 #endif
 
-		[Mac (10,8), iOS (8,0)]
 		public VTTransferFunction TransferFunction { 
 			get {
 				var key = GetNSStringValue (VTCompressionPropertyKey.TransferFunction);
@@ -450,7 +445,6 @@ namespace XamCore.VideoToolbox {
 			}
 		}
 
-		[Mac (10,8), iOS (8,0)]
 		public VTYCbCrMatrix YCbCrMatrix { 
 			get {
 				var key = GetNSStringValue (VTCompressionPropertyKey.YCbCrMatrix);
@@ -483,7 +477,6 @@ namespace XamCore.VideoToolbox {
 			}
 		}
 
-		[Mac (10,8), iOS (8,0)]
 		public VTMultiPassStorage MultiPassStorage {
 			get	{
 				return GetNativeValue<VTMultiPassStorage> (VTCompressionPropertyKey.MultiPassStorage);

--- a/src/VideoToolbox/VTCompressionSession.cs
+++ b/src/VideoToolbox/VTCompressionSession.cs
@@ -17,7 +17,7 @@ using XamCore.CoreMedia;
 using XamCore.CoreVideo;
 
 namespace XamCore.VideoToolbox {
-	[Mac (10,8), iOS (8,0)]
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	public class VTCompressionSession : VTSession {
 		GCHandle callbackHandle;
 

--- a/src/VideoToolbox/VTDecompressionProperties.cs
+++ b/src/VideoToolbox/VTDecompressionProperties.cs
@@ -17,14 +17,12 @@ using XamCore.CoreVideo;
 
 namespace XamCore.VideoToolbox {
 	public partial class VTDecompressionProperties {
-		[Mac (10,8), iOS (8,0)]
 		public CVPixelBufferPool PixelBufferPool {
 			get {
 				return GetNativeValue<CVPixelBufferPool> (VTDecompressionPropertyKey.PixelBufferPool);
 			}
 		}
 
-		[Mac (10,8), iOS (8,0)]
 		public VTFieldMode FieldMode { 
 			get {
 				var key = GetNSStringValue (VTDecompressionPropertyKey.FieldMode);
@@ -67,7 +65,6 @@ namespace XamCore.VideoToolbox {
 			}
 		}
 
-		[Mac (10,8), iOS (8,0)]
 		public VTDeinterlaceMode DeinterlaceMode { 
 			get {
 				var key = GetNSStringValue (VTDecompressionPropertyKey.DeinterlaceMode);
@@ -95,7 +92,6 @@ namespace XamCore.VideoToolbox {
 			}
 		}
 
-		[Mac (10,8), iOS (8,0)]
 		public VTOnlyTheseFrames OnlyTheseFrames { 
 			get {
 				var key = GetNSStringValue (VTDecompressionPropertyKey.OnlyTheseFrames);

--- a/src/VideoToolbox/VTDecompressionSession.cs
+++ b/src/VideoToolbox/VTDecompressionSession.cs
@@ -17,7 +17,7 @@ using XamCore.CoreMedia;
 using XamCore.CoreVideo;
 
 namespace XamCore.VideoToolbox {
-	[Mac (10,8), iOS (8,0)]
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	public class VTDecompressionSession : VTSession {
 
 		GCHandle callbackHandle;

--- a/src/VideoToolbox/VTFrameSilo.cs
+++ b/src/VideoToolbox/VTFrameSilo.cs
@@ -16,7 +16,7 @@ using XamCore.Foundation;
 using XamCore.CoreMedia;
 
 namespace XamCore.VideoToolbox {
-	[Mac (10,10), iOS (8,0)]
+	[Mac (10,10), iOS (8,0), TV (10,2)]
 	public class VTFrameSilo : INativeObject, IDisposable {
 		IntPtr handle;
 		GCHandle callbackHandle;

--- a/src/VideoToolbox/VTMultiPassStorage.cs
+++ b/src/VideoToolbox/VTMultiPassStorage.cs
@@ -16,7 +16,7 @@ using XamCore.Foundation;
 using XamCore.CoreMedia;
 
 namespace XamCore.VideoToolbox {
-	[Mac (10,10), iOS (8,0)]
+	[Mac (10,10), iOS (8,0), TV (10,2)]
 	public class VTMultiPassStorage : INativeObject, IDisposable {
 		IntPtr handle;
 		bool closed;

--- a/src/VideoToolbox/VTPixelTransferProperties.cs
+++ b/src/VideoToolbox/VTPixelTransferProperties.cs
@@ -20,7 +20,6 @@ using XamCore.AVFoundation;
 namespace XamCore.VideoToolbox {
 	public partial class VTPixelTransferProperties : DictionaryContainer {
 
-		[Mac (10,8), iOS (9,0)]
 		public VTScalingMode ScalingMode { 
 			get {
 				var key = GetNSStringValue (VTPixelTransferPropertyKeys.ScalingMode);
@@ -58,7 +57,6 @@ namespace XamCore.VideoToolbox {
 			}
 		}
 
-		[Mac (10,8), iOS (9,0)]
 		public VTDownsamplingMode DownsamplingMode { 
 			get {
 				var key = GetNSStringValue (VTPixelTransferPropertyKeys.DownsamplingMode);
@@ -86,8 +84,8 @@ namespace XamCore.VideoToolbox {
 			}
 		}
 
-#if MONOMAC && XAMCORE_2_0
-		[Mac (10,8)]
+#if XAMCORE_2_0
+		[iOS (10,0)]
 		public VTColorPrimaries DestinationColorPrimaries { 
 			get {
 				var key = GetNSStringValue (VTPixelTransferPropertyKeys.DestinationColorPrimaries);
@@ -125,8 +123,8 @@ namespace XamCore.VideoToolbox {
 			}
 		}
 #endif
-#if MONOMAC
-		[Mac (10,8)]
+
+		[iOS (10,0)]
 		public VTTransferFunction DestinationTransferFunction { 
 			get {
 				var key = GetNSStringValue (VTPixelTransferPropertyKeys.DestinationTransferFunction);
@@ -158,8 +156,7 @@ namespace XamCore.VideoToolbox {
 				}
 			}
 		}
-#endif
-		[Mac (10,8), iOS (9,0)]
+
 		public VTYCbCrMatrix DestinationYCbCrMatrix { 
 			get {
 				var key = GetNSStringValue (VTPixelTransferPropertyKeys.DestinationYCbCrMatrix);

--- a/src/VideoToolbox/VTPropertyOptions.cs
+++ b/src/VideoToolbox/VTPropertyOptions.cs
@@ -18,7 +18,6 @@ using XamCore.CoreVideo;
 namespace XamCore.VideoToolbox {
 
 	public partial class VTPropertyOptions {
-		[Mac (10,8), iOS (8,0)]
 		public VTPropertyType Type { 
 			get {
 				var key = GetNSStringValue (VTPropertyKeys.Type);
@@ -51,7 +50,6 @@ namespace XamCore.VideoToolbox {
 			}
 		}
 
-		[Mac (10,8), iOS (8,0)]
 		public VTReadWriteStatus ReadWriteStatus { 
 			get {
 				var key = GetNSStringValue (VTPropertyKeys.ReadWriteStatus);

--- a/src/VideoToolbox/VTSession.cs
+++ b/src/VideoToolbox/VTSession.cs
@@ -16,7 +16,7 @@ using XamCore.CoreMedia;
 using XamCore.CoreVideo;
 
 namespace XamCore.VideoToolbox {		
-	[Mac (10,8), iOS (8,0)]
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	public class VTSession : INativeObject, IDisposable {
 		IntPtr handle;
 

--- a/src/VideoToolbox/VTUtilities.cs
+++ b/src/VideoToolbox/VTUtilities.cs
@@ -15,8 +15,8 @@ using XamCore.CoreGraphics;
 using XamCore.CoreVideo;
 
 namespace XamCore.VideoToolbox {
+	[Mac (10,11), iOS (9,0), TV (10,2)]
 	public static class VTUtilities {
-		[Mac (10,11), iOS (9,0)]
 		[DllImport (Constants.VideoToolboxLibrary)]
 		extern static VTStatus VTCreateCGImageFromCVPixelBuffer (
 			/* CM_NONNULL CVPixelBufferRef */ IntPtr pixelBuffer,
@@ -26,7 +26,6 @@ namespace XamCore.VideoToolbox {
 		// intentionally not exposing the (NSDictionary options) argument
 		// since header docs indicate that there are no options available
 		// as of 9.0/10.11 and to always pass NULL
-		[Mac (10,11), iOS (9,0)]
 		public static VTStatus ToCGImage (this CVPixelBuffer pixelBuffer, out CGImage image)
 		{
 			if (pixelBuffer == null)

--- a/src/VideoToolbox/VTVideoEncoder.cs
+++ b/src/VideoToolbox/VTVideoEncoder.cs
@@ -12,7 +12,7 @@ using XamCore.ObjCRuntime;
 using XamCore.Foundation;
 
 namespace XamCore.VideoToolbox {
-	[Mac (10,8), iOS (8,0)]
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	public class VTVideoEncoder {
 
 		[DllImport (Constants.VideoToolboxLibrary)]

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3096,15 +3096,19 @@ public partial class Generator : IMemberGatherer {
 
 				print ("namespace {0} {{", dictType.Namespace);
 				indent++;
+				PrintPlatformAttributes (dictType);
 				print ("public partial class {0} : DictionaryContainer {{", typeName);
 				indent++;
 				sw.WriteLine ("#if !COREBUILD");
 				print ("[Preserve (Conditional = true)]");
 				print ("public {0} () : base (new NSMutableDictionary ()) {{}}\n", typeName);
 				print ("[Preserve (Conditional = true)]");
-				print ("public {0} (NSDictionary dictionary) : base (dictionary) {{}}", typeName);
+				print ("public {0} (NSDictionary dictionary) : base (dictionary) {{}}\n", typeName);
 
 				foreach (var pi in dictType.GatherProperties ()){
+					if (pi.IsUnavailable ())
+						continue;
+					
 					string keyname;
 					object [] attrs = pi.GetCustomAttributes (typeof (ExportAttribute), true);
 					if (attrs.Length == 0)
@@ -3115,6 +3119,7 @@ public partial class Generator : IMemberGatherer {
 							keyname = keyContainerType + "." + keyname;
 					}
 
+					PrintPlatformAttributes (pi);
 					string modifier = pi.IsInternal () ? "internal" : "public";
 					
 					print (modifier + " {0}{1} {2} {{",

--- a/src/videotoolbox.cs
+++ b/src/videotoolbox.cs
@@ -14,702 +14,590 @@ using XamCore.AVFoundation;
 
 namespace XamCore.VideoToolbox {
 
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[Static]
 	interface VTCompressionPropertyKey {
 		// Buffers
 
 		[Field ("kVTCompressionPropertyKey_NumberOfPendingFrames")]
-		[Mac (10,8), iOS (8,0)]
 		NSString NumberOfPendingFrames { get; }
 
 		[Field ("kVTCompressionPropertyKey_PixelBufferPoolIsShared")]
-		[Mac (10,8), iOS (8,0)]
 		NSString PixelBufferPoolIsShared { get; }
 
 		[Field ("kVTCompressionPropertyKey_VideoEncoderPixelBufferAttributes")]
-		[Mac (10,8), iOS (8,0)]
 		NSString VideoEncoderPixelBufferAttributes { get; }
 
 		// Frame dependency
 
 		[Field ("kVTCompressionPropertyKey_MaxKeyFrameInterval")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MaxKeyFrameInterval { get; }
 
 		[Field ("kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MaxKeyFrameIntervalDuration { get; }
 
 		[Field ("kVTCompressionPropertyKey_AllowTemporalCompression")]
-		[Mac (10,8), iOS (8,0)]
 		NSString AllowTemporalCompression { get; }
 
 		[Field ("kVTCompressionPropertyKey_AllowFrameReordering")]
-		[Mac (10,8), iOS (8,0)]
 		NSString AllowFrameReordering { get; }
 
 		// Rate control
 
 		[Field ("kVTCompressionPropertyKey_AverageBitRate")]
-		[Mac (10,8), iOS (8,0)]
 		NSString AverageBitRate { get; }
 
 		[Field ("kVTCompressionPropertyKey_DataRateLimits")]
-		[Mac (10,8), iOS (8,0)]
 		NSString DataRateLimits { get; } // NSArray of an even number of CFNumbers alternating [int, double](bytes, seconds] Read/write
 
 		[Field ("kVTCompressionPropertyKey_Quality")]
-		[Mac (10,8), iOS (8,0)]
 		NSString Quality { get; }
 
 		[Field ("kVTCompressionPropertyKey_MoreFramesBeforeStart")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MoreFramesBeforeStart { get; }
 
 		[Field ("kVTCompressionPropertyKey_MoreFramesAfterEnd")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MoreFramesAfterEnd { get; }
 
 		// Bitstream configuration
 
 		[Field ("kVTCompressionPropertyKey_ProfileLevel")]
-		[Mac (10,8), iOS (8,0)]
 		NSString ProfileLevel { get; }
 
 		[Field ("kVTCompressionPropertyKey_H264EntropyMode")]
-		[Mac (10,9), iOS (8,0)]	
+		[Mac (10,9)]
 		NSString H264EntropyMode { get; }
 
 		[Field ("kVTCompressionPropertyKey_Depth")]
-		[Mac (10,8), iOS (8,0)]
 		NSString Depth { get; }
 
 		// Runtime restrictions
 
 		[Field ("kVTCompressionPropertyKey_MaxFrameDelayCount")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MaxFrameDelayCount { get; }
 
 		[Field ("kVTCompressionPropertyKey_MaxH264SliceBytes")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MaxH264SliceBytes { get; }
 
 		[Field ("kVTCompressionPropertyKey_RealTime")]
-		[Mac (10,9), iOS (8,0)] 
+		[Mac (10,9)]
 		NSString RealTime { get; }
 
 		// Hints
 
 		[Field ("kVTCompressionPropertyKey_SourceFrameCount")]
-		[Mac (10,8), iOS (8,0)]
 		NSString SourceFrameCount { get; }
 
 		[Field ("kVTCompressionPropertyKey_ExpectedFrameRate")]
-		[Mac (10,8), iOS (8,0)]
 		NSString ExpectedFrameRate { get; }
 
 		[Field ("kVTCompressionPropertyKey_ExpectedDuration")]
-		[Mac (10,8), iOS (8,0)]
 		NSString ExpectedDuration { get; }
 
 		// Hardware acceleration
 		// Hardware acceleration is default behavior on iOS. No opt-in required.
 
 		[Field ("kVTCompressionPropertyKey_UsingHardwareAcceleratedVideoEncoder")]
-		[Mac (10,8), iOS (8,0)]
 		NSString UsingHardwareAcceleratedVideoEncoder { get; } // CFBoolean Read
 
 		// Clean aperture and pixel aspect ratio
 
 		[Field ("kVTCompressionPropertyKey_CleanAperture")]
-		[Mac (10,8), iOS (8,0)]
 		NSString CleanAperture { get; }
 
 		[Field ("kVTCompressionPropertyKey_PixelAspectRatio")]
-		[Mac (10,8), iOS (8,0)]
 		NSString PixelAspectRatio { get; }
 
 		[Field ("kVTCompressionPropertyKey_FieldCount")]
-		[Mac (10,8), iOS (8,0)]
 		NSString FieldCount { get; } 
 
 		[Field ("kVTCompressionPropertyKey_FieldDetail")]
-		[Mac (10,8), iOS (8,0)]
 		NSString FieldDetail { get; } 
 
 		[Field ("kVTCompressionPropertyKey_AspectRatio16x9")]
-		[Mac (10,8), iOS (8,0)]
 		NSString AspectRatio16x9 { get; } 
 
 		[Field ("kVTCompressionPropertyKey_ProgressiveScan")]
-		[Mac (10,8), iOS (8,0)]
 		NSString ProgressiveScan { get; } 
 
 		// Color
 
 		[Field ("kVTCompressionPropertyKey_ColorPrimaries")]
-		[Mac (10,8), iOS (8,0)]
 		NSString ColorPrimaries { get; } 
 
 		[Field ("kVTCompressionPropertyKey_TransferFunction")]
-		[Mac (10,8), iOS (8,0)]
 		NSString TransferFunction { get; } 
 
 		[Field ("kVTCompressionPropertyKey_YCbCrMatrix")]
-		[Mac (10,8), iOS (8,0)]
 		NSString YCbCrMatrix { get; } 
 
 		[Field ("kVTCompressionPropertyKey_ICCProfile")]
-		[Mac (10,8), iOS (8,0)]
 		NSString ICCProfile { get; } 
 
 		// Pre-compression processing
 
 		[Field ("kVTCompressionPropertyKey_PixelTransferProperties")]
-		[Mac (10,8), iOS (8,0)]
 		NSString PixelTransferProperties { get; }
 
 		// Multi-pass
 
 		[Field ("kVTCompressionPropertyKey_MultiPassStorage")]
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		NSString MultiPassStorage { get; }
 	}
 
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[StrongDictionary ("VTCompressionPropertyKey")]
 	interface VTCompressionProperties {
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("NumberOfPendingFrames")]
 		int NumberOfPendingFrames { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("PixelBufferPoolIsShared")]
 		bool PixelBufferPoolIsShared { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("VideoEncoderPixelBufferAttributes")]
 		NSDictionary VideoEncoderPixelBufferAttributes { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("MaxKeyFrameInterval")]
 		int MaxKeyFrameInterval { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("MaxKeyFrameIntervalDuration")]
 		double MaxKeyFrameIntervalDuration { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("AllowTemporalCompression")]
 		bool AllowTemporalCompression { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("AllowFrameReordering")]
 		bool AllowFrameReordering { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("AverageBitRate")]
 		int AverageBitRate { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("Quality")]
 		float Quality { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("MoreFramesBeforeStart")]
 		bool MoreFramesBeforeStart { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("MoreFramesAfterEnd")]
 		bool MoreFramesAfterEnd { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("Depth")]
 		CMPixelFormat Depth { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("MaxFrameDelayCount")]
 		int MaxFrameDelayCount { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("MaxH264SliceBytes")]
 		int MaxH264SliceBytes { get; set; }
 
-		[Mac (10,9), iOS (8,0)] 
+		[Mac (10,9)]
 		[Export ("RealTime")]
 		bool RealTime { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("SourceFrameCount")]
 		uint SourceFrameCount { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("ExpectedFrameRate")]
 		double ExpectedFrameRate { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("ExpectedDuration")]
 		double ExpectedDuration { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("UsingHardwareAcceleratedVideoEncoder")]
 		bool UsingHardwareAcceleratedVideoEncoder { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("CleanAperture")]
 		NSDictionary CleanAperture { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("PixelAspectRatio")]
 		NSDictionary PixelAspectRatio { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("FieldCount")]
 		VTFieldCount FieldCount { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("AspectRatio16x9")]
 		bool AspectRatio16x9 { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("ProgressiveScan")]
 		bool ProgressiveScan { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("ICCProfile")]
 		NSData ICCProfile { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("PixelTransferProperties")]
 		NSDictionary PixelTransferProperties { get; set; }
 	}
 
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[Static]
 	interface VTProfileLevelKeys {
 		// H264
 
 		[Field ("kVTProfileLevel_H264_Baseline_1_3")]
-		[Mac (10,8), iOS (8,0)]
 		NSString H264_Baseline_1_3 { get; }
 
 		[Field ("kVTProfileLevel_H264_Baseline_3_0")]
-		[Mac (10,8), iOS (8,0)]
 		NSString H264_Baseline_3_0 { get; }
 
 		[Field ("kVTProfileLevel_H264_Baseline_3_1")]
-		[Mac (10,8), iOS (8,0)]
 		NSString H264_Baseline_3_1 { get; }
 
 		[Field ("kVTProfileLevel_H264_Baseline_3_2")]
-		[Mac (10,8), iOS (8,0)]
 		NSString H264_Baseline_3_2 { get; }
 
 		[Field ("kVTProfileLevel_H264_Baseline_4_0")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_Baseline_4_0 { get; }
 
 		[Field ("kVTProfileLevel_H264_Baseline_4_1")]
-		[Mac (10,8), iOS (8,0)]
 		NSString H264_Baseline_4_1 { get; }
 
 		[Field ("kVTProfileLevel_H264_Baseline_4_2")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_Baseline_4_2 { get; }
 
 		[Field ("kVTProfileLevel_H264_Baseline_5_0")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_Baseline_5_0 { get; }
 
 		[Field ("kVTProfileLevel_H264_Baseline_5_1")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_Baseline_5_1 { get; }
 
 		[Field ("kVTProfileLevel_H264_Baseline_5_2")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_Baseline_5_2 { get; }
 
 		[Field ("kVTProfileLevel_H264_Baseline_AutoLevel")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_Baseline_AutoLevel { get; }
 
 		[Field ("kVTProfileLevel_H264_Main_3_0")]
-		[Mac (10,8), iOS (8,0)]
 		NSString H264_Main_3_0 { get; }
 
 		[Field ("kVTProfileLevel_H264_Main_3_1")]
-		[Mac (10,8), iOS (8,0)]
 		NSString H264_Main_3_1 { get; }
 
 		[Field ("kVTProfileLevel_H264_Main_3_2")]
-		[Mac (10,8), iOS (8,0)]
 		NSString H264_Main_3_2 { get; }
 
 		[Field ("kVTProfileLevel_H264_Main_4_0")]
-		[Mac (10,8), iOS (8,0)]
 		NSString H264_Main_4_0 { get; }
 
 		[Field ("kVTProfileLevel_H264_Main_4_1")]
-		[Mac (10,8), iOS (8,0)]
 		NSString H264_Main_4_1 { get; }
 
 		[Field ("kVTProfileLevel_H264_Main_4_2")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_Main_4_2 { get; }
 
 		[Field ("kVTProfileLevel_H264_Main_5_0")]
-		[Mac (10,8), iOS (8,0)]
 		NSString H264_Main_5_0 { get; }
 
 		[Field ("kVTProfileLevel_H264_Main_5_1")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_Main_5_1 { get; }
 
 		[Field ("kVTProfileLevel_H264_Main_5_2")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_Main_5_2 { get; }
 
 		[Field ("kVTProfileLevel_H264_Main_AutoLevel")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_Main_AutoLevel { get; }
 
 		[Field ("kVTProfileLevel_H264_Extended_5_0")]
-		[Mac (10,8), iOS (8,0)]
 		NSString H264_Extended_5_0 { get; }
 
 		[Field ("kVTProfileLevel_H264_Extended_AutoLevel")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_Extended_AutoLevel { get; }
 
 		[Field ("kVTProfileLevel_H264_High_3_0")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_High_3_0 { get; }
 
 		[Field ("kVTProfileLevel_H264_High_3_1")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_High_3_1 { get; }
 
 		[Field ("kVTProfileLevel_H264_High_3_2")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_High_3_2 { get; }
 
 		[Field ("kVTProfileLevel_H264_High_4_0")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_High_4_0 { get; }
 
 		[Field ("kVTProfileLevel_H264_High_4_1")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_High_4_1 { get; }
 
 		[Field ("kVTProfileLevel_H264_High_4_2")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_High_4_2 { get; }
 
 		[Field ("kVTProfileLevel_H264_High_5_0")]
-		[Mac (10,8), iOS (8,0)]
 		NSString H264_High_5_0 { get; }
 
 		[Field ("kVTProfileLevel_H264_High_5_1")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_High_5_1 { get; }
 
 		[Field ("kVTProfileLevel_H264_High_5_2")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_High_5_2 { get; }
 
 		[Field ("kVTProfileLevel_H264_High_AutoLevel")]
-		[Mac (10,9), iOS (8,0)]
+		[Mac (10,9)]
 		NSString H264_High_AutoLevel { get; }
 
 		// MP4V
 
 		[Field ("kVTProfileLevel_MP4V_Simple_L0")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MP4V_Simple_L0 { get; }
 
 		[Field ("kVTProfileLevel_MP4V_Simple_L1")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MP4V_Simple_L1 { get; }
 
 		[Field ("kVTProfileLevel_MP4V_Simple_L2")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MP4V_Simple_L2 { get; }
 
 		[Field ("kVTProfileLevel_MP4V_Simple_L3")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MP4V_Simple_L3 { get; }
 
 		[Field ("kVTProfileLevel_MP4V_Main_L2")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MP4V_Main_L2 { get; }
 
 		[Field ("kVTProfileLevel_MP4V_Main_L3")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MP4V_Main_L3 { get; }
 
 		[Field ("kVTProfileLevel_MP4V_Main_L4")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MP4V_Main_L4 { get; }
 
 		[Field ("kVTProfileLevel_MP4V_AdvancedSimple_L0")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MP4V_AdvancedSimple_L0 { get; }
 
 		[Field ("kVTProfileLevel_MP4V_AdvancedSimple_L1")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MP4V_AdvancedSimple_L1 { get; }
 
 		[Field ("kVTProfileLevel_MP4V_AdvancedSimple_L2")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MP4V_AdvancedSimple_L2 { get; }
 
 		[Field ("kVTProfileLevel_MP4V_AdvancedSimple_L3")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MP4V_AdvancedSimple_L3 { get; }
 
 		[Field ("kVTProfileLevel_MP4V_AdvancedSimple_L4")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MP4V_AdvancedSimple_L4 { get; }
 
 		// H263
 
 		[Field ("kVTProfileLevel_H263_Profile0_Level10")]
-		[Mac (10,8), iOS (8,0)]
 		NSString H263_Profile0_Level10 { get; }
 
 		[Field ("kVTProfileLevel_H263_Profile0_Level45")]
-		[Mac (10,8), iOS (8,0)]
 		NSString H263_Profile0_Level45 { get; }
 
 		[Field ("kVTProfileLevel_H263_Profile3_Level45")]
-		[Mac (10,8), iOS (8,0)]
 		NSString H263_Profile3_Level45 { get; } 
 	}
 
 	[Static]
+	[Mac (10,9), iOS (8,0), TV (10,2)]
 	interface VTH264EntropyModeKeys {
 		[Field ("kVTH264EntropyMode_CAVLC")]
-		[Mac (10,9), iOS (8,0)]
 		NSString CAVLC { get; } 
 
 		[Field ("kVTH264EntropyMode_CABAC")]
-		[Mac (10,9), iOS (8,0)]
 		NSString CABAC { get; } 
 	}
 		
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[StrongDictionary ("VTVideoEncoderSpecificationKeys")]
 	interface VTVideoEncoderSpecification {
-#if MONOMAC
-		[Mac (10,9)] 
+
+		[Mac (10,9), NoiOS, NoTV]
 		[Export ("EnableHardwareAcceleratedVideoEncoder")]
 		bool EnableHardwareAcceleratedVideoEncoder { get; set; }
 
-		[Mac (10,9)] 
+		[Mac (10,9), NoiOS, NoTV]
 		[Export ("RequireHardwareAcceleratedVideoEncoder")]
 		bool RequireHardwareAcceleratedVideoEncoder { get; set; }
-#endif
-		[Mac (10,8), iOS (8,0)]
+
 		[Export ("EncoderID")]
 		string EncoderID { get; set; }
 	}
 
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[Static]
 	interface VTVideoEncoderSpecificationKeys {
-#if MONOMAC
+
 		[Field ("kVTVideoEncoderSpecification_EnableHardwareAcceleratedVideoEncoder")]
-		[Mac (10,9)] 
+		[Mac (10,9), NoiOS, NoTV]
 		NSString EnableHardwareAcceleratedVideoEncoder { get; }
 
 		[Field ("kVTVideoEncoderSpecification_RequireHardwareAcceleratedVideoEncoder")]
-		[Mac (10,9)] 
+		[Mac (10,9), NoiOS, NoTV]
 		NSString RequireHardwareAcceleratedVideoEncoder { get; }
-#endif
-		[Mac (10,8), iOS (8,0)]
+
 		[Field ("kVTVideoEncoderSpecification_EncoderID")]
 		NSString EncoderID { get; }
 	}
 
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[StrongDictionary ("VTEncodeFrameOptionKey")]
 	interface VTEncodeFrameOptions {
+
 		[Export ("ForceKeyFrame")]
 		bool ForceKeyFrame { get; set; }
 	}
 
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[Static]
 	interface VTEncodeFrameOptionKey {
 		// Per-frame configuration
 
 		[Field ("kVTEncodeFrameOptionKey_ForceKeyFrame")]
-		[Mac (10,8), iOS (8,0)]
 		NSString ForceKeyFrame { get; } 
 	}
 
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[Static]
 	interface VTDecompressionPropertyKey {
 		// Pixel buffer pools
 
 		[Field ("kVTDecompressionPropertyKey_PixelBufferPool")]
-		[Mac (10,8), iOS (8,0)]
 		NSString PixelBufferPool { get; }
 
 		[Field ("kVTDecompressionPropertyKey_PixelBufferPoolIsShared")]
-		[Mac (10,8), iOS (8,0)]
 		NSString PixelBufferPoolIsShared { get; }
 
 		[Field ("kVTDecompressionPropertyKey_OutputPoolRequestedMinimumBufferCount")]
-		[Mac (10,9), iOS (8,0)] 
+		[Mac (10,9)]
 		NSString OutputPoolRequestedMinimumBufferCount { get; }
 
 		// Asynchronous state
 
 		[Field ("kVTDecompressionPropertyKey_NumberOfFramesBeingDecoded")]
-		[Mac (10,8), iOS (8,0)]
 		NSString NumberOfFramesBeingDecoded { get; }
 
 		[Field ("kVTDecompressionPropertyKey_MinOutputPresentationTimeStampOfFramesBeingDecoded")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MinOutputPresentationTimeStampOfFramesBeingDecoded { get; }
 
 		[Field ("kVTDecompressionPropertyKey_MaxOutputPresentationTimeStampOfFramesBeingDecoded")]
-		[Mac (10,8), iOS (8,0)]
 		NSString MaxOutputPresentationTimeStampOfFramesBeingDecoded { get; } 
 
 		// Content
 
 		[Field ("kVTDecompressionPropertyKey_ContentHasInterframeDependencies")]
-		[Mac (10,8), iOS (8,0)]
 		NSString ContentHasInterframeDependencies { get; }
 
 		// Hardware acceleration
 		// hardware acceleration is default behavior on iOS.  no opt-in required.
 		 
 		[Field ("kVTDecompressionPropertyKey_UsingHardwareAcceleratedVideoDecoder")]
-		[Mac (10,9), iOS (8,0)] 
+		[Mac (10,9)]
 		NSString UsingHardwareAcceleratedVideoDecoder { get; } 
 
 		// Decoder behavior
 
 		[Field ("kVTDecompressionPropertyKey_RealTime")]
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		NSString RealTime { get; }
 
 		[Field ("kVTDecompressionPropertyKey_ThreadCount")]
-		[Mac (10,8), iOS (8,0)]
 		NSString ThreadCount { get; }
 
 		[Field ("kVTDecompressionPropertyKey_FieldMode")]
-		[Mac (10,8), iOS (8,0)]
 		NSString FieldMode { get; }
 
 		[Field ("kVTDecompressionProperty_FieldMode_BothFields")]
-		[Mac (10,8), iOS (8,0)]
 		NSString FieldMode_BothFields { get; } 
 
 		[Field ("kVTDecompressionProperty_FieldMode_TopFieldOnly")]
-		[Mac (10,8), iOS (8,0)]
 		NSString FieldMode_TopFieldOnly { get; }
 
 		[Field ("kVTDecompressionProperty_FieldMode_BottomFieldOnly")]
-		[Mac (10,8), iOS (8,0)]
 		NSString FieldMode_BottomFieldOnly { get; }
 
 		[Field ("kVTDecompressionProperty_FieldMode_SingleField")]
-		[Mac (10,8), iOS (8,0)] 
 		NSString FieldMode_SingleField { get; }
 
 		[Field ("kVTDecompressionProperty_FieldMode_DeinterlaceFields")]
-		[Mac (10,8), iOS (8,0)]
 		NSString FieldMode_DeinterlaceFields { get; }
 
 		[Field ("kVTDecompressionPropertyKey_DeinterlaceMode")]
-		[Mac (10,8), iOS (8,0)]  
 		NSString DeinterlaceMode { get; }
 
 		[Field ("kVTDecompressionProperty_DeinterlaceMode_VerticalFilter")]
-		[Mac (10,8), iOS (8,0)]  
 		NSString DeinterlaceMode_VerticalFilter { get; } 
 
 		[Field ("kVTDecompressionProperty_DeinterlaceMode_Temporal")]
-		[Mac (10,8), iOS (8,0)]	
 		NSString DeinterlaceMode_Temporal { get; } 
 
 		[Field ("kVTDecompressionPropertyKey_ReducedResolutionDecode")]
-		[Mac (10,8), iOS (8,0)]
 		NSString ReducedResolutionDecode { get; }
 
 		[Field ("kVTDecompressionPropertyKey_ReducedCoefficientDecode")]
-		[Mac (10,8), iOS (8,0)]
 		NSString ReducedCoefficientDecode { get; }
 
 		[Field ("kVTDecompressionPropertyKey_ReducedFrameDelivery")]
-		[Mac (10,8), iOS (8,0)]
 		NSString ReducedFrameDelivery { get; }
 
 		[Field ("kVTDecompressionPropertyKey_OnlyTheseFrames")]
-		[Mac (10,8), iOS (8,0)]
 		NSString OnlyTheseFrames { get; } 
 
 		[Field ("kVTDecompressionProperty_OnlyTheseFrames_AllFrames")]
-		[Mac (10,8), iOS (8,0)]
 		NSString OnlyTheseFrames_AllFrames { get; } 
 
 		[Field ("kVTDecompressionProperty_OnlyTheseFrames_NonDroppableFrames")]
-		[Mac (10,8), iOS (8,0)]
 		NSString OnlyTheseFrames_NonDroppableFrames { get; } 
 
 		[Field ("kVTDecompressionProperty_OnlyTheseFrames_IFrames")]
-		[Mac (10,8), iOS (8,0)]
 		NSString OnlyTheseFrames_IFrames { get; } 
 
 		[Field ("kVTDecompressionProperty_OnlyTheseFrames_KeyFrames")]
-		[Mac (10,8), iOS (8,0)]
 		NSString OnlyTheseFrames_KeyFrames { get; } 
 
 		[Field ("kVTDecompressionPropertyKey_SuggestedQualityOfServiceTiers")]
-		[Mac (10,8), iOS (8,0)]
 		NSString SuggestedQualityOfServiceTiers { get; }
 
 		[Field ("kVTDecompressionPropertyKey_SupportedPixelFormatsOrderedByQuality")]
-		[Mac (10,8), iOS (8,0)]
 		NSString SupportedPixelFormatsOrderedByQuality { get; }
 
 		[Field ("kVTDecompressionPropertyKey_SupportedPixelFormatsOrderedByPerformance")]
-		[Mac (10,8), iOS (8,0)]
 		NSString SupportedPixelFormatsOrderedByPerformance { get; }
 
 		[Field ("kVTDecompressionPropertyKey_PixelFormatsWithReducedResolutionSupport")]
-		[Mac (10,8), iOS (8,0)]
 		NSString PixelFormatsWithReducedResolutionSupport { get; }
 
 		//Post-decompression processing
 
 		[Field ("kVTDecompressionPropertyKey_PixelTransferProperties")]
-		[Mac (10,8), iOS (8,0)]
 		NSString PixelTransferProperties { get; }
 	}
 
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[StrongDictionary ("VTDecompressionPropertyKey")]
 	interface VTDecompressionProperties	{
-		[Mac (10,8), iOS (8,0)]
+		
 		[Export ("PixelBufferPoolIsShared")]
 		bool PixelBufferPoolIsShared { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("OutputPoolRequestedMinimumBufferCount")]
 		uint OutputPoolRequestedMinimumBufferCount { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("NumberOfFramesBeingDecoded")]
 		uint NumberOfFramesBeingDecoded { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("MinOutputPresentationTimeStampOfFramesBeingDecoded")]
 		NSDictionary MinOutputPresentationTimeStampOfFramesBeingDecoded { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("MaxOutputPresentationTimeStampOfFramesBeingDecoded")]
 		NSDictionary MaxOutputPresentationTimeStampOfFramesBeingDecoded { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("ContentHasInterframeDependencies")]
 		bool ContentHasInterframeDependencies { get; }
 
@@ -717,319 +605,274 @@ namespace XamCore.VideoToolbox {
 		// hardware acceleration is default behavior on iOS.  no opt-in required.
 
 		[Export ("UsingHardwareAcceleratedVideoDecoder")]
-		[Mac (10,9)] 
+		[Mac (10,9)]
 		bool UsingHardwareAcceleratedVideoDecoder { get; } 
 
-		[Mac (10,10), iOS (8,0)]
+		[Mac (10,10)]
 		[Export ("RealTime")]
 		bool RealTime { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("ThreadCount")]
 		uint ThreadCount { get; set; }
 
 		[StrongDictionary]
-		[Mac (10,8), iOS (8,0)]
 		[Export ("ReducedResolutionDecode")]
 		VTDecompressionResolutionOptions ReducedResolutionDecode { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("ReducedCoefficientDecode")]
 		uint ReducedCoefficientDecode { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("ReducedFrameDelivery")]
 		float ReducedFrameDelivery { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("SuggestedQualityOfServiceTiers")]
 		NSDictionary[] SuggestedQualityOfServiceTiers { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("SupportedPixelFormatsOrderedByQuality")]
 		CMPixelFormat[] SupportedPixelFormatsOrderedByQuality { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("SupportedPixelFormatsOrderedByPerformance")]
 		CMPixelFormat[] SupportedPixelFormatsOrderedByPerformance { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("PixelFormatsWithReducedResolutionSupport")]
 		CMPixelFormat[] PixelFormatsWithReducedResolutionSupport { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Advice ("Use Strongly typed version PixelTransferSettings")]
 		[Export ("PixelTransferProperties")]
 		NSDictionary PixelTransferProperties { get; set; }
 
 		// VTPixelTransferProperties are available in iOS 9 radar://22614931 https://trello.com/c/bTl6hRu9
 		[StrongDictionary]
-		[Mac (10,8), iOS (9,0)]
+		[iOS (9,0)]
 		[Export ("PixelTransferProperties")]
 		VTPixelTransferProperties PixelTransferSettings { get; set; }
 	}
 
+	[Mac (10,9), iOS (8,0), TV (10,2)]
 	[StrongDictionary ("VTVideoDecoderSpecificationKeys")]
 	interface VTVideoDecoderSpecification {
 		[Export ("EnableHardwareAcceleratedVideoDecoder")]
-		[Mac (10,9)]
 		bool EnableHardwareAcceleratedVideoDecoder { get; set; }
 
 		[Export ("RequireHardwareAcceleratedVideoDecoder")]
-		[Mac (10,9)]
 		bool RequireHardwareAcceleratedVideoDecoder { get; set; }
 	}
 
+	[Mac (10,9), iOS (8,0), TV (10,2)]
 	[Static]
 	interface VTVideoDecoderSpecificationKeys {
 		[Field ("kVTVideoDecoderSpecification_EnableHardwareAcceleratedVideoDecoder")]
-		[Mac (10,9), iOS (8,0)] 
 		NSString EnableHardwareAcceleratedVideoDecoder { get; }
 
 		[Field ("kVTVideoDecoderSpecification_RequireHardwareAcceleratedVideoDecoder")]
-		[Mac (10,9), iOS (8,0)] 
 		NSString RequireHardwareAcceleratedVideoDecoder { get; }
 	}
 
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[StrongDictionary ("VTDecompressionResolutionKeys")]
 	interface VTDecompressionResolutionOptions {
 		[Export ("Width")]
-		[Mac (10,8), iOS (8,0)]
 		float Width { get; set; }
 
 		[Export ("Height")]
-		[Mac (10,8), iOS (8,0)]
 		float Height { get; set; }
 	}
 
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[Static]
 	interface VTDecompressionResolutionKeys {
 		[Field ("kVTDecompressionResolutionKey_Width")]
-		[Mac (10,8), iOS (8,0)]
 		NSString Width { get; }
 
 		[Field ("kVTDecompressionResolutionKey_Height")]
-		[Mac (10,8), iOS (8,0)]
 		NSString Height { get; }
 	}
 
 	// VTSession.h
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[StrongDictionary ("VTPropertyKeys")]
 	interface VTPropertyOptions {
 		[Export ("ShouldBeSerialized")]
-		[Mac (10,8), iOS (8,0)]
 		bool ShouldBeSerialized { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("SupportedValueMinimumKey")]
 		NSNumber SupportedValueMinimum { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("SupportedValueMaximumKey")]
 		NSNumber SupportedValueMaximum { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("SupportedValueListKey")]
 		NSNumber[] SupportedValueList { get; set; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Export ("DocumentationKey")]
 		NSString Documentation { get; set; }
 	}
 
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[Static]
 	interface VTPropertyKeys {
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTPropertyTypeKey")]
 		NSString Type { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTPropertyReadWriteStatusKey")]
 		NSString ReadWriteStatus { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTPropertyShouldBeSerializedKey")]
 		NSString ShouldBeSerialized { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTPropertySupportedValueMinimumKey")]
 		NSString SupportedValueMinimumKey { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTPropertySupportedValueMaximumKey")]
 		NSString SupportedValueMaximumKey { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTPropertySupportedValueListKey")]
 		NSString SupportedValueListKey { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTPropertyDocumentationKey")]
 		NSString DocumentationKey { get; }
 	}
 
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[Static]
 	interface VTPropertyTypeKeys {
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTPropertyType_Boolean")]
 		NSString Boolean { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTPropertyType_Enumeration")]
 		NSString Enumeration { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTPropertyType_Number")]
 		NSString Number { get; }
 	}
 
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[Static]
 	interface VTPropertyReadWriteStatusKeys {
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTPropertyReadWriteStatus_ReadOnly")]
 		NSString ReadOnly { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTPropertyReadWriteStatus_ReadWrite")]
 		NSString ReadWrite { get; }
 	}
 
 	// VTVideoEncoderList.h
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[Static]
 	[Internal]
 	interface VTVideoEncoderList {
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTVideoEncoderList_CodecName")]
 		NSString CodecName { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTVideoEncoderList_CodecType")]
 		NSString CodecType { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTVideoEncoderList_DisplayName")]
 		NSString DisplayName { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTVideoEncoderList_EncoderID")]
 		NSString EncoderID { get; }
 
-		[Mac (10,8), iOS (8,0)]
 		[Field ("kVTVideoEncoderList_EncoderName")]
 		NSString EncoderName { get; }
 	}
 
 	// VTMultiPassStorage.h
+	[Mac (10,10), iOS (8,0), TV (10,2)] // not decorated in the header files - but all other definitions are 10.10 & 8.0
 	[Static]
 	interface VTMultiPassStorageCreationOptionKeys {
 		[Field ("kVTMultiPassStorageCreationOption_DoNotDelete")]
-		[Mac (10,10), iOS (8,0)] // not decorated in the header files - but all other definitions are 10.10 & 8.0
 		NSString DoNotDelete { get; }
 	}
 
+	[Mac (10,8), iOS (8,0), TV (10,2)]
 	[StrongDictionary ("VTMultiPassStorageCreationOptionKeys")]
 	interface VTMultiPassStorageCreationOptions {
 		[Export ("DoNotDelete")]
-		[Mac (10,8), iOS (8,0)]
 		bool DoNotDelete { get; set; }
 	}
 
 	// VTPixelTransferProperties are available in iOS 9 radar://22614931 https://trello.com/c/bTl6hRu9
+	[Mac (10,8), iOS (9,0), TV (10,2)]
 	[StrongDictionary ("VTPixelTransferPropertyKeys")]
 	interface VTPixelTransferProperties {
 		[StrongDictionary]
-		[Mac (10,8), iOS (9,0)]
 		[Export ("DestinationCleanAperture")]
 		AVVideoCleanApertureSettings DestinationCleanAperture { get; set; }
 
 		[StrongDictionary]
-		[Mac (10,8), iOS (9,0)]
 		[Export ("DestinationPixelAspectRatio")]
 		AVVideoPixelAspectRatioSettings DestinationPixelAspectRatio { get; set; }
 
 		[iOS (10,0)]
-		[Mac (10,8)]
 		[Export ("DestinationICCProfile")]
 		NSData DestinationICCProfile { get; set; }
 	}
 
 	// VTPixelTransferProperties are available in iOS 9 radar://22614931 https://trello.com/c/bTl6hRu9
+	[Mac (10,8), iOS (9,0), TV (10,2)]
 	[Static]
 	[AdvancedAttribute]
 	interface VTPixelTransferPropertyKeys {
 
 		// ScalingMode
 
-		[Mac (10,8), iOS (9,0)]
 		[Field ("kVTPixelTransferPropertyKey_ScalingMode")]
 		NSString ScalingMode { get; }
 
-		[Mac (10,8), iOS (9,0)]
 		[Field ("kVTScalingMode_Normal")]
 		NSString ScalingMode_Normal { get; }
 
-		[Mac (10,8), iOS (9,0)]
 		[Field ("kVTScalingMode_CropSourceToCleanAperture")]
 		NSString ScalingMode_CropSourceToCleanAperture { get; }
 
-		[Mac (10,8), iOS (9,0)]
 		[Field ("kVTScalingMode_Letterbox")]
 		NSString ScalingMode_Letterbox { get; }
 
-		[Mac (10,8), iOS (9,0)]
 		[Field ("kVTScalingMode_Trim")]
 		NSString ScalingMode_Trim { get; }
 
 		// DestinationCleanAperture
 
-		[Mac (10,8), iOS (9,0)]
 		[Field ("kVTPixelTransferPropertyKey_DestinationCleanAperture")]
 		NSString DestinationCleanAperture { get; }
 
 		// DestinationCleanAperture
 
-		[Mac (10,8), iOS (9,0)]
 		[Field ("kVTPixelTransferPropertyKey_DestinationPixelAspectRatio")]
 		NSString DestinationPixelAspectRatio { get; }
 
 		// DownsamplingMode
 
-		[Mac (10,8), iOS (9,0)]
 		[Field ("kVTPixelTransferPropertyKey_DownsamplingMode")]
 		NSString DownsamplingMode { get; }
 
-		[Mac (10,8), iOS (9,0)]
 		[Field ("kVTDownsamplingMode_Decimate")]
 		NSString DownsamplingMode_Decimate { get; }
 
-		[Mac (10,8), iOS (9,0)]
 		[Field ("kVTDownsamplingMode_Average")]
 		NSString DownsamplingMode_Average { get; }
 
 		// DestinationColorPrimaries
 
 		[iOS (10,0)]
-		[Mac (10,8)]
 		[Field ("kVTPixelTransferPropertyKey_DestinationColorPrimaries")]
 		NSString DestinationColorPrimaries { get; }
 
 		// DestinationColorPrimaries
 
 		[iOS (10,0)]
-		[Mac (10,8)]
 		[Field ("kVTPixelTransferPropertyKey_DestinationTransferFunction")]
 		NSString DestinationTransferFunction { get; }
 
 		// DestinationICCProfile
 
 		[iOS (10,0)]
-		[Mac (10,8)]
 		[Field ("kVTPixelTransferPropertyKey_DestinationICCProfile")]
 		NSString DestinationICCProfile { get; }
 
 		// DestinationYCbCrMatrix
 
-		[Mac (10,8), iOS (9,0)]
 		[Field ("kVTPixelTransferPropertyKey_DestinationYCbCrMatrix")]
 		NSString DestinationYCbCrMatrix { get; }
 	}

--- a/tests/monotouch-test/VideoToolbox/VTCompressionSessionTests.cs
+++ b/tests/monotouch-test/VideoToolbox/VTCompressionSessionTests.cs
@@ -8,7 +8,7 @@
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
 
-#if !__TVOS__ && !__WATCHOS__
+#if !__WATCHOS__
 
 using System;
 
@@ -147,5 +147,5 @@ namespace MonoTouchFixtures.VideoToolbox {
 	}
 }
 
-#endif // !__TVOS__ && !__WATCHOS__
+#endif // !__WATCHOS__
 

--- a/tests/monotouch-test/VideoToolbox/VTDecompressionSessionTests.cs
+++ b/tests/monotouch-test/VideoToolbox/VTDecompressionSessionTests.cs
@@ -8,7 +8,7 @@
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
 
-#if !__TVOS__ && !__WATCHOS__
+#if !__WATCHOS__
 
 using System;
 
@@ -112,4 +112,4 @@ namespace MonoTouchFixtures.VideoToolbox {
 	}
 }
 
-#endif // !__TVOS__ && !__WATCHOS__
+#endif // !__WATCHOS__

--- a/tests/monotouch-test/VideoToolbox/VTFrameSiloTests.cs
+++ b/tests/monotouch-test/VideoToolbox/VTFrameSiloTests.cs
@@ -8,7 +8,7 @@
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
 
-#if !__TVOS__ && !__WATCHOS__
+#if !__WATCHOS__
 
 using System;
 
@@ -85,4 +85,4 @@ namespace MonoTouchFixtures.VideoToolbox {
 	}
 }
 
-#endif // !__TVOS__ && !__WATCHOS__
+#endif // !__WATCHOS__

--- a/tests/monotouch-test/VideoToolbox/VTMultiPassStorageTests.cs
+++ b/tests/monotouch-test/VideoToolbox/VTMultiPassStorageTests.cs
@@ -8,7 +8,7 @@
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
 
-#if !__TVOS__ && !__WATCHOS__
+#if !__WATCHOS__
 
 using System;
 
@@ -60,4 +60,4 @@ namespace MonoTouchFixtures.VideoToolbox {
 	}
 }
 
-#endif // !__TVOS__ && !__WATCHOS__
+#endif // !__WATCHOS__

--- a/tests/monotouch-test/VideoToolbox/VTUtilitiesTests.cs
+++ b/tests/monotouch-test/VideoToolbox/VTUtilitiesTests.cs
@@ -8,7 +8,7 @@
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
 
-#if !__TVOS__ && !__WATCHOS__
+#if !__WATCHOS__
 
 using System;
 using System.Drawing;
@@ -68,14 +68,21 @@ namespace MonoTouchFixtures.VideoToolbox {
 
 			var pxbuffer = new CVPixelBuffer (originalCGImage.Width, originalCGImage.Height, CVPixelFormatType.CV32ARGB,
 				               new CVPixelBufferAttributes { CGImageCompatibility = true, CGBitmapContextCompatibility = true });
+#if !__TVOS__
 			pxbuffer.Lock (CVOptionFlags.None);
-
+#else
+			pxbuffer.Lock (CVPixelBufferLock.None);
+#endif
 			using (var colorSpace = CGColorSpace.CreateDeviceRGB ())
 			using (var ctx = new CGBitmapContext (pxbuffer.BaseAddress, originalCGImage.Width, originalCGImage.Height, 8, 
 				                 4 * originalCGImage.Width, colorSpace, CGBitmapFlags.NoneSkipLast)) {
 				ctx.RotateCTM (0);
 				ctx.DrawImage (new RectangleF (0, 0, originalCGImage.Width, originalCGImage.Height), originalCGImage);
+#if !__TVOS__
 				pxbuffer.Unlock (CVOptionFlags.None);
+#else
+				pxbuffer.Unlock (CVPixelBufferLock.None);
+#endif
 			}
 
 			Assert.NotNull (pxbuffer, "VTUtilitiesTests.ToCGImageTest pxbuffer should not be null");
@@ -94,4 +101,4 @@ namespace MonoTouchFixtures.VideoToolbox {
 	}
 }
 
-#endif // !__TVOS__ && !__WATCHOS__
+#endif // !__WATCHOS__

--- a/tests/monotouch-test/VideoToolbox/VTVideoEncoderListTests.cs
+++ b/tests/monotouch-test/VideoToolbox/VTVideoEncoderListTests.cs
@@ -8,7 +8,7 @@
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
 
-#if !__TVOS__ && !__WATCHOS__
+#if !__WATCHOS__
 
 using System;
 #if XAMCORE_2_0
@@ -40,4 +40,4 @@ namespace MonoTouchFixtures.VideoToolbox {
 	}
 }
 
-#endif // !__TVOS__ && !__WATCHOS__
+#endif // !__WATCHOS__


### PR DESCRIPTION
## [Generator] Add availability info to StrongDictionary

* We did not honor/reflect the availability information on the generated code from StrongDictionary members/classes nor we would honor unavailability attributes like NoiOS, NoTV and NoMac applied to members. This commit fixes both scenarios, and they are exercised by the VideoToolbox update.

## VideoToolbox API
* Updated API to reflect Xcode 8.3 beta 1 changes
* This commit also fixes availability metadata to avoid duplicating it by moving member availability metadata into its container class where possible.
* Enables VideoToolbox tests for tvOS.