### PR TITLE
Add a nullable attribute in Intents from Xcode 8.3

### DIFF
--- a/src/intents.cs
+++ b/src/intents.cs
@@ -1859,7 +1859,7 @@ namespace XamCore.Intents {
 		[Export ("imageWithImageData:")]
 		INImage FromData (NSData imageData);
 
-		[Static]
+		[return: NullAllowed][Static]
 		[Export ("imageWithURL:")]
 		INImage FromUrl (NSUrl url);
 


### PR DESCRIPTION
Only missing mac-only change from Xcode 8.3