### PR TITLE
[audiotoolbox] Remove null check on sourceAudioUnit

### DIFF
--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -617,9 +617,6 @@ namespace XamCore.AudioUnit
 
 		public AudioUnitStatus MakeConnection (AudioUnit sourceAudioUnit, uint sourceOutputNumber, uint destInputNumber)
 		{
-			if (sourceAudioUnit == null)
-				throw new ArgumentNullException ("sourceAudioUnit");
-
 			var auc = new AudioUnitConnection {
 				SourceAudioUnit = sourceAudioUnit == null ? IntPtr.Zero : sourceAudioUnit.handle,
 				SourceOutputNumber = sourceOutputNumber,


### PR DESCRIPTION
PR #1667 changed some code to allow null SourceAudioUnit - but it forgot
to remove the null check that throws an ArgumentNullException. Thanks
to Tim for spotting this.