### PR TITLE
[generator] Explicitly load NSNumber from the api assembly for core builds.

### DIFF
--- a/src/error.cs
+++ b/src/error.cs
@@ -72,6 +72,7 @@ using ProductException=BindingException;
 //		BI1049 Could not unbox type {0} from {1} container used on {2} member decorated with [BindAs].
 //		BI1050 [BindAs] cannot be used inside Protocol or Model types. Type: {0}
 //		BI1051 Internal error: Don't know how to get attributes for {0}. Please file a bug report (http://bugzilla.xamarin.com) with a test case.
+//		BI1052 Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (http://bugzilla.xamarin.com) with a test case.
 //	BI11xx	warnings
 //		BI1101 Trying to use a string as a [Target]
 //		BI1102 Using the deprecated EventArgs for a delegate signature in {0}.{1}, please use DelegateName instead

--- a/src/generator-typemanager.cs
+++ b/src/generator-typemanager.cs
@@ -503,7 +503,7 @@ public static class TypeManager {
 		NSNumber = Lookup (BindingTouch.BindingThirdParty ? platform_assembly : api_assembly, "Foundation", "NSNumber");
 		NSRange = typeof (NSRange);
 		NSString = typeof (NSString);
-		NSValue = typeof (NSValue);
+		NSValue = Lookup (BindingTouch.BindingThirdParty ? platform_assembly : api_assembly, "Foundation", "NSValue");
 		NSZone = typeof (NSZone);
 		SCNMatrix4 = typeof (SCNMatrix4);
 		SCNVector3 = typeof (SCNVector3);


### PR DESCRIPTION
This fixes an issue where we'd run into a type comparison failure otherwise,
when using the `BindAs` attribute in the api definition for our platform
assemblies, because we end up with NSNumber loaded from two different
assemblies:

Foundation.NSNumber, **temp**, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null

Foundation.NSNumber, **core**, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null