### PR TITLE
[AVFoundation] Add BindAs to fix bug 44015 & 48235

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -7956,6 +7956,9 @@ namespace XamCore.AVFoundation {
 		void SetSampleBufferDelegateQueue ([NullAllowed] IAVCaptureVideoDataOutputSampleBufferDelegate sampleBufferDelegate, [NullAllowed] DispatchQueue sampleBufferCallbackQueue);
 
 		// 5.0 APIs
+#if XAMCORE_4_0
+		[BindAs (typeof (XamCore.CoreVideo.CVPixelFormatType []))]
+#endif
 		[Export ("availableVideoCVPixelFormatTypes")]
 		NSNumber [] AvailableVideoCVPixelFormatTypes { get;  }
 
@@ -8381,6 +8384,9 @@ namespace XamCore.AVFoundation {
 		[Export ("isStillImageStabilizationScene")]
 		bool IsStillImageStabilizationScene { get; }
 
+#if XAMCORE_4_0
+		[BindAs (typeof (AVCaptureFlashMode []))]
+#endif		
 		[Export ("supportedFlashModes")]
 		NSNumber[] SupportedFlashModes { get; }
 


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=48235
https://bugzilla.xamarin.com/show_bug.cgi?id=44015

* Adding BindAs to `AVCaptureVideoDataOutput.AvailableVideoCVPixelFormatTypes`
* Adding BindAs to `AVCapturePhotoOutput.SupportedFlashModes`

Both only if `XAMCORE_4_0` ever happens