### PR TITLE
[generator] Use target framework to determine the platform.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Tasks/BTouch.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/BTouch.cs
@@ -12,8 +12,6 @@ namespace Xamarin.Mac.Tasks
 {
 	public class BTouch : BTouchTaskBase
 	{
-		public string TargetFrameworkIdentifier { get; set; }
-
 		public string FrameworkRoot { get; set; }
 
 		protected override string GenerateCommandLineCommands ()

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
@@ -60,6 +60,9 @@ namespace Xamarin.MacDev.Tasks {
 
 		public ITaskItem[] Sources { get; set; }
 
+		[Required]
+		public string TargetFrameworkIdentifier { get; set; }
+
 		protected override string ToolName {
 			get { return Path.GetFileNameWithoutExtension (ToolExe); }
 		}
@@ -179,6 +182,18 @@ namespace Xamarin.MacDev.Tasks {
 
 			if (GeneratedSourcesFileList != null)
 				cmd.AppendSwitchIfNotNull ("/sourceonly:", Path.GetFullPath (GeneratedSourcesFileList));
+
+			switch (TargetFrameworkIdentifier) {
+				case "MonoTouch":
+				case "Xamarin.iOS":
+				case "Xamarin.TVOS":
+				case "Xamarin.WatchOS":
+					cmd.AppendSwitch ($"/target-framework={TargetFrameworkIdentifier},v1.0");
+					break;
+				default:
+					Log.LogError ($"Unknown target framework identifier: {TargetFrameworkIdentifier}.");
+					break;
+			}
 
 			return cmd.ToString ();
 		}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
@@ -76,6 +76,7 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 			OutputAssembly="$(OutputAssembly)"
 			ProcessEnums="$(ProcessEnums)"
 			References="@(ReferencePath);@(BTouchReferencePath)"
+			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			BTouchToolPath="$(BTouchToolPath)"
 			BTouchToolExe="$(BTouchToolExe)">
 		</BTouch>

--- a/src/Makefile
+++ b/src/Makefile
@@ -113,6 +113,11 @@ $(IOS_BUILD_DIR)/$(1)/generator.exe: $$(GENERATOR_SOURCES) $(IOS_BUILD_DIR)/$(1)
 # generated_sources
 # Unfortunatelly, generator uses reflection to load api which means we need to build another
 # mono (tools64) to be able to load 2.1 mscorlib (mscorlib internal version must match runtime version)
+
+# We can't pass the --target-framework values as parameters to the templates, because the commas interfere with Make's parameter parsing.
+xi_compat_profile=--target-framework=MonoTouch,v1.0
+xi_native_profile=--target-framework=Xamarin.iOS,v1.0
+
 $(IOS_BUILD_DIR)/$(1)/generated_sources: $(IOS_BUILD_DIR)/$(1)/generator.exe $$(IOS_APIS)
 	$$(call Q_PROF_GEN,ios/$(1)) PMCS_PROFILE=$(3) $$(IOS_BMONO) --debug $(IOS_BUILD_DIR)/$(1)/generator.exe \
 		$$(IOS_GENERATOR_FLAGS) \
@@ -127,6 +132,7 @@ $(IOS_BUILD_DIR)/$(1)/generated_sources: $(IOS_BUILD_DIR)/$(1)/generator.exe $$(
 		-ns=MonoTouch.ObjCRuntime \
 		-native-exception-marshalling \
 		$(2) \
+		$$(xi_$(1)_profile) \
 		$$(IOS_APIS)
 endef
 $(eval $(call IOS_GENERATOR_template,compat,--ns=MonoTouch.ObjCRuntime -p,compat-ios))
@@ -459,6 +465,7 @@ $(MAC_BUILD_DIR)/AssemblyInfo.cs: $(TOP)/src/AssemblyInfo.cs.in
 # We can't pass the --target-framework values as parameters to the templates, because the commas interfere with Make's parameter parsing.
 xm_full_profile=--target-framework=Xamarin.Mac,Version=v4.5,Profile=Full
 xm_mobile_profile=--target-framework=Xamarin.Mac,Version=v2.0,Profile=Mobile
+xm_compat_profile=--target-framework=XamMac,v1.0
 
 define MAC_GENERATOR_template
 $(MAC_BUILD_DIR)/$(1)/pmcs: pmcs.in $(PMCS_EXE) Makefile | $(MAC_BUILD_DIR)/$(1)
@@ -752,6 +759,7 @@ $(WATCH_BUILD_DIR)/watch/generated_sources: $(WATCH_BUILD_DIR)/watch/generator.e
 		-d:WATCH                                                 \
 		--ns:ObjCRuntime                                         \
 		$(WATCHOS_APIS)                                            \
+		--target-framework=Xamarin.WatchOS,v1.0                     \
 
 $(WATCH_BUILD_DIR)/watch-32/Xamarin.WatchOS.dll: $(WATCHOS_SOURCES) $(WATCH_BUILD_DIR)/watch/generated_sources $(PRODUCT_KEY_PATH) | $(WATCH_BUILD_DIR)/watch-32
 	$(call Q_PROF_PMCS,watch) PMCS_PROFILE=watch-32 $(WATCH_PMCS) -out:$@ -target:library -debug -unsafe -optimize \
@@ -950,6 +958,7 @@ $(TVOS_BUILD_DIR)/tvos/generated_sources: $(TVOS_BUILD_DIR)/tvos/generator.exe $
 		-d:TVOS                                                  \
 		--ns:ObjCRuntime                                         \
 		$(TVOS_APIS)                                            \
+		--target-framework=Xamarin.TvOS,v1.0                     \
 
 $(TVOS_BUILD_DIR)/tvos-64/Xamarin.TVOS.dll: $(TVOS_SOURCES) $(TVOS_BUILD_DIR)/tvos/generated_sources $(PRODUCT_KEY_PATH) | $(TVOS_BUILD_DIR)/tvos-64
 	$(call Q_PROF_PMCS,tvos) PMCS_PROFILE=tvos-64 $(TVOS_PMCS) -out:$@ -target:library -debug -unsafe -optimize \

--- a/src/Makefile
+++ b/src/Makefile
@@ -958,7 +958,7 @@ $(TVOS_BUILD_DIR)/tvos/generated_sources: $(TVOS_BUILD_DIR)/tvos/generator.exe $
 		-d:TVOS                                                  \
 		--ns:ObjCRuntime                                         \
 		$(TVOS_APIS)                                            \
-		--target-framework=Xamarin.TvOS,v1.0                     \
+		--target-framework=Xamarin.TVOS,v1.0                     \
 
 $(TVOS_BUILD_DIR)/tvos-64/Xamarin.TVOS.dll: $(TVOS_SOURCES) $(TVOS_BUILD_DIR)/tvos/generated_sources $(PRODUCT_KEY_PATH) | $(TVOS_BUILD_DIR)/tvos-64
 	$(call Q_PROF_PMCS,tvos) PMCS_PROFILE=tvos-64 $(TVOS_PMCS) -out:$@ -target:library -debug -unsafe -optimize \

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -61,7 +61,7 @@ WATCH_TARGETS +=                                                        \
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/bwatch                        \
 
 $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/bwatch: Makefile.generator
-	$(Q_GEN) printf '#!/bin/sh\nMONO_PATH=$(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.WatchOS/repl:$(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.WatchOS $(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/bin/bwatch-mono --debug $(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/lib/bwatch/bwatch.exe "$$@"' > $@
+	$(Q_GEN) printf '#!/bin/sh\nMONO_PATH=$(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.WatchOS/repl:$(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.WatchOS $(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/bin/bwatch-mono --debug $(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/lib/bwatch/bwatch.exe --target-framework=Xamarin.WatchOS,v1.0 "$$@"' > $@
 	$(Q) chmod +x $@
 
 $(WATCH_BUILD_DIR)/bwatch.exe: $(WATCH_BUILD_DIR)/watch-32/Xamarin.WatchOS.dll $(GENERATOR_SOURCES) Makefile.generator
@@ -83,7 +83,7 @@ TVOS_TARGETS +=                                                  \
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/btv                    \
 
 $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/btv: Makefile.generator
-	$(Q_GEN) printf '#!/bin/sh\nMONO_PATH=$(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.TVOS/repl:$(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.TVOS $(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/bin/btv-mono --debug $(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/lib/btv/btv.exe "$$@"' > $@
+	$(Q_GEN) printf '#!/bin/sh\nMONO_PATH=$(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.TVOS/repl:$(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.TVOS $(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/bin/btv-mono --debug $(IOS_TARGETDIR)$(MONOTOUCH_PREFIX)/lib/btv/btv.exe --target-framework=Xamarin.TVOS,v1.0 "$$@"' > $@
 	$(Q) chmod +x $@
 
 $(TVOS_BUILD_DIR)/btv.exe: $(TVOS_BUILD_DIR)/tvos-64/Xamarin.TVOS.dll $(GENERATOR_SOURCES) Makefile.generator

--- a/src/bmac
+++ b/src/bmac
@@ -49,7 +49,7 @@ mobile|xamarin.mac|xammac)
 *)
 	if [[ -z "$new_style" ]]; then
 		bmac=bmac-compat.exe
-		refs="-r:/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5/System.Drawing.dll -baselib:$ROOT_DIR/lib/mono/XamMac.dll"
+		refs="-r:/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5/System.Drawing.dll -baselib:$ROOT_DIR/lib/mono/XamMac.dll --target-framework=XamMac,v1.0"
 		export MONO_PATH=$ROOT_DIR/lib/mono
 	else
 		if [[ "$full_profile" -eq 1 ]]; then

--- a/src/btouch-native.in
+++ b/src/btouch-native.in
@@ -1,2 +1,2 @@
 #!/bin/sh
-MONO_PATH=@MONOTOUCH_PREFIX@/lib/mono/Xamarin.iOS @MONOTOUCH_PREFIX@/bin/btouch-mono --debug @MONOTOUCH_PREFIX@/lib/btouch/btouch-native.exe "$@"
+MONO_PATH=@MONOTOUCH_PREFIX@/lib/mono/Xamarin.iOS @MONOTOUCH_PREFIX@/bin/btouch-mono --debug @MONOTOUCH_PREFIX@/lib/btouch/btouch-native.exe  --target-framework=Xamarin.iOS,v1.0 "$@"

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -211,7 +211,7 @@ class BindingTouch {
 			},
 			{ "unified-full-profile", "Launches compiler pointing to XM Full Profile", l => { /* no-op*/ }, true },
 			{ "unified-mobile-profile", "Launches compiler pointing to XM Mobile Profile", l => { /* no-op*/ }, true },
-			{ "target-framework=", "Specify target framework to use. Always required, and the currently supported values are: 'MonoTouch,v1.0', 'Xamarin.iOS,v1.0', 'Xamarin.TvOS,v1.0', 'Xamarin.WatchOS,v1.0', 'XamMac,v1.0' 'Xamarin.Mac,Version=v2.0,Profile=Mobile', 'Xamarin.Mac,Version=v4.5,Profile=Full' and 'Xamarin.Mac,Version=v4.5,Profile=System')", v => SetTargetFramework (v) },
+			{ "target-framework=", "Specify target framework to use. Always required, and the currently supported values are: 'MonoTouch,v1.0', 'Xamarin.iOS,v1.0', 'Xamarin.TVOS,v1.0', 'Xamarin.WatchOS,v1.0', 'XamMac,v1.0', 'Xamarin.Mac,Version=v2.0,Profile=Mobile', 'Xamarin.Mac,Version=v4.5,Profile=Full' and 'Xamarin.Mac,Version=v4.5,Profile=System')", v => SetTargetFramework (v) },
 		};
 
 		try {

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -230,40 +230,40 @@ class BindingTouch {
 		if (!target_framework.HasValue)
 			throw ErrorHelper.CreateError (86, "A target framework (--target-framework) must be specified.");
 
-		switch (target_framework.Value.Identifier) {
-		case "MonoTouch":
+		switch (target_framework.Value.Identifier.ToLowerInvariant ()) {
+		case "monotouch":
 			CurrentPlatform = PlatformName.iOS;
 			Unified = false;
 			if (string.IsNullOrEmpty (baselibdll))
 				baselibdll = Path.Combine (GetSDKRoot (), "lib/mono/2.1/monotouch.dll");
 			Path.Combine (GetSDKRoot (), "bin/smcs");
 			break;
-		case "Xamarin.iOS":
+		case "xamarin.ios":
 			CurrentPlatform = PlatformName.iOS;
 			Unified = true;
 			if (string.IsNullOrEmpty (baselibdll))
 				baselibdll = Path.Combine (GetSDKRoot (), "lib/mono/Xamarin.iOS/Xamarin.iOS.dll");
 			break;
-		case "Xamarin.TvOS":
+		case "xamarin.tvos":
 			CurrentPlatform = PlatformName.TvOS;
 			Unified = true;
 			if (string.IsNullOrEmpty (baselibdll))
 				baselibdll = Path.Combine (GetSDKRoot (), "lib/mono/Xamarin.TVOS/Xamarin.TVOS.dll");
 			break;
-		case "Xamarin.WatchOS":
+		case "xamarin.watchos":
 			CurrentPlatform = PlatformName.WatchOS;
 			Unified = true;
 			if (string.IsNullOrEmpty (baselibdll))
 				baselibdll = Path.Combine (GetSDKRoot (), "lib/mono/Xamarin.WatchOS/Xamarin.WatchOS.dll");
 			break;
-		case "XamMac":
+		case "xammac":
 			CurrentPlatform = PlatformName.MacOSX;
 			Unified = false;
 			if (string.IsNullOrEmpty (baselibdll))
 				baselibdll = "MonoMac.dll";
 			net_sdk = "4";
 			break;
-		case "Xamarin.Mac":
+		case "xamarin.mac":
 			CurrentPlatform = PlatformName.MacOSX;
 			Unified = true;
 			skipSystemDrawing = target_framework == TargetFramework.Xamarin_Mac_4_5_Full;

--- a/src/btouch.in
+++ b/src/btouch.in
@@ -1,3 +1,3 @@
 #!/bin/sh
-MONO_PATH=@MONOTOUCH_PREFIX@/lib/mono/2.1 @MONOTOUCH_PREFIX@/bin/btouch-mono --debug @MONOTOUCH_PREFIX@/lib/btouch/btouch.exe "$@"
+MONO_PATH=@MONOTOUCH_PREFIX@/lib/mono/2.1 @MONOTOUCH_PREFIX@/bin/btouch-mono --debug @MONOTOUCH_PREFIX@/lib/btouch/btouch.exe --target-framework=MonoTouch,v1.0 "$@"
 

--- a/src/error.cs
+++ b/src/error.cs
@@ -73,6 +73,7 @@ using ProductException=BindingException;
 //		BI1050 [BindAs] cannot be used inside Protocol or Model types. Type: {0}
 //		BI1051 Internal error: Don't know how to get attributes for {0}. Please file a bug report (http://bugzilla.xamarin.com) with a test case.
 //		BI1052 Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (http://bugzilla.xamarin.com) with a test case.
+//		BI1053 Internal error: unknown target framework '{0}'.
 //	BI11xx	warnings
 //		BI1101 Trying to use a string as a [Target]
 //		BI1102 Using the deprecated EventArgs for a delegate signature in {0}.{1}, please use DelegateName instead

--- a/tools/common/TargetFramework.cs
+++ b/tools/common/TargetFramework.cs
@@ -34,17 +34,23 @@ namespace Xamarin.Utils
 		public static readonly TargetFramework Net_4_5 = Parse ("4.5");
 		public static readonly TargetFramework Xamarin_Mac_2_0 = Parse ("Xamarin.Mac,v2.0");
 
+		public static readonly TargetFramework MonoTouch_1_0 = Parse ("MonoTouch,v1.0");
 		public static readonly TargetFramework Xamarin_iOS_1_0 = Parse ("Xamarin.iOS,v1.0");
 		public static readonly TargetFramework Xamarin_WatchOS_1_0 = Parse ("Xamarin.WatchOS,v1.0");
 		public static readonly TargetFramework Xamarin_TVOS_1_0 = Parse ("Xamarin.TVOS,v1.0");
 
+		public static readonly TargetFramework XamMac_1_0 = Parse ("XamMac,v1.0");
 		public static readonly TargetFramework Xamarin_Mac_2_0_Mobile = Parse ("Xamarin.Mac,Version=v2.0,Profile=Mobile");
 		public static readonly TargetFramework Xamarin_Mac_4_5_Full = Parse ("Xamarin.Mac,Version=v4.5,Profile=Full");
 		public static readonly TargetFramework Xamarin_Mac_4_5_System = Parse ("Xamarin.Mac,Version=v4.5,Profile=System");
 #if MTOUCH
 		public static readonly TargetFramework [] ValidFrameworks = new TargetFramework[] { Xamarin_iOS_1_0, Xamarin_WatchOS_1_0, Xamarin_TVOS_1_0 };
 #elif GENERATOR
-		public static readonly TargetFramework [] ValidFrameworks = new TargetFramework[] { Xamarin_Mac_2_0_Mobile, Xamarin_Mac_4_5_Full, Xamarin_Mac_4_5_System };
+		public static readonly TargetFramework [] ValidFrameworks = new TargetFramework[]
+		{
+			MonoTouch_1_0, Xamarin_iOS_1_0, Xamarin_TVOS_1_0, Xamarin_WatchOS_1_0,
+			XamMac_1_0, Xamarin_Mac_2_0_Mobile, Xamarin_Mac_4_5_Full, Xamarin_Mac_4_5_System
+		};
 #endif
 
 		public static TargetFramework Parse (string targetFrameworkString)


### PR DESCRIPTION
This cuts down another group of conditional compilation sections, paving the
way for an IKVM-based generator.

This makes it required to pass --target-framework for to generator executables
(previously only required for Xamarin.Mac/Unified to distinguish between the
different Xamarin.Mac/Unified variants), but it should be invisible to users
since we'll automatically pass the correct --target-framework argument from
the corresponding scripts (btouch/btv/bwatch/bmac) and the MSBuild targets.
This will only break somebody who is executing the managed executables
directly, but nobody should do that in the first place (it's not a supported
scenario).

Generated diff: https://gist.github.com/rolfbjarne/1674be6625632446dba774a305951981