### PR TITLE
[mediaplayer] macOS update for Xcode 8.3

### DIFF
--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -1407,6 +1407,7 @@ namespace XamCore.MediaPlayer {
 		NSString PropertyIsLiveStream { get; }
 
 		[iOS (10,3)]
+		[Mac (10,12,3)]
 		[Field ("MPNowPlayingInfoPropertyAssetURL")]
 		NSString PropertyAssetUrl { get; }
 	}


### PR DESCRIPTION
Headers say 10.12.3 and not 10.12.4, ran introspection-mac and the selector is indeed available on 10.12.3.