### PR TITLE
[security] Add more SecCertificate* API from beta1. Fixes #52505

### DIFF
--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -259,50 +259,97 @@ namespace XamCore.Security {
 				return new NSData (dataPtr);
 			}
 		}
-#elif XAMARIN_APPLETLS && (__IOS__ || __WATCHOS__ || __TVOS__)
-		//
-		// EXPERIMENTAL
-		// Needs some more testing before we can make this public.
-		// AppleTls does not actually use this API, so it may be removed again.
-		//
-		internal NSData GetPublicKey ()
+#else
+		[iOS (10,3)]
+		[DllImport (Constants.SecurityLibrary)]
+		static extern /* __nullable SecKeyRef */ IntPtr SecCertificateCopyPublicKey (IntPtr /* SecCertificateRef */ certificate);
+
+		[iOS (10,3)]
+		public SecKey GetPublicKey ()
 		{
-			if (handle == IntPtr.Zero)
-				throw new ObjectDisposedException ("SecCertificate");
-
-			var policy = SecPolicy.CreateBasicX509Policy ();
-			var trust = new SecTrust (this, policy);
-			trust.Evaluate ();
-
-			SecStatusCode status;
-
-			using (var key = trust.GetPublicKey ())
-			using (var query = new SecRecord (SecKind.Key)) {
-				query.SetValueRef (key);
-
-				status = SecKeyChain.Add (query);
-				if (status != SecStatusCode.Success && status != SecStatusCode.DuplicateItem)
-					throw new InvalidOperationException (status.ToString ());
-
-				bool added = status == SecStatusCode.Success;
-
-				try {
-					var data = SecKeyChain.QueryAsData (query, false, out status);
-					if (status != SecStatusCode.Success)
-						throw new InvalidOperationException (status.ToString ());
-
-					return data;
-				} finally {
-					if (added) {
-						status = SecKeyChain.Remove (query);
-						if (status != SecStatusCode.Success)
-							throw new InvalidOperationException (status.ToString ());
-					}
-				}
-			}
+			IntPtr data = SecCertificateCopyPublicKey (handle);
+			return (data == IntPtr.Zero) ? null : new SecKey (data, true);
 		}
 #endif
-#endif	
+		[iOS (10,3)] // [Mac (10,5)]
+		[DllImport (Constants.SecurityLibrary)]
+		static extern /* OSStatus */ int SecCertificateCopyCommonName (IntPtr /* SecCertificateRef */ certificate, out IntPtr /* CFStringRef * __nonnull CF_RETURNS_RETAINED */ commonName);
+
+		[iOS (10,3)]
+		public string GetCommonName ()
+		{
+			IntPtr cn;
+			if (SecCertificateCopyCommonName (handle, out cn) == 0)
+				return CFString.FetchString (cn, releaseHandle: true);
+			return null;
+		}
+
+		[iOS (10,3)] // [Mac (10,5)]
+		[DllImport (Constants.SecurityLibrary)]
+		static extern /* OSStatus */ int SecCertificateCopyEmailAddresses (IntPtr /* SecCertificateRef */ certificate, out IntPtr /* CFArrayRef * __nonnull CF_RETURNS_RETAINED */ emailAddresses);
+
+		[iOS (10,3)]
+		public string[] GetEmailAddresses ()
+		{
+			string[] results = null;
+			IntPtr emails;
+			if (SecCertificateCopyEmailAddresses (handle, out emails) == 0) {
+				results = NSArray.StringArrayFromHandle (emails);
+				if (emails != IntPtr.Zero)
+					CFObject.CFRelease (emails);
+			}
+			return results;
+		}
+
+		[iOS (10,3)]
+		[Mac (10,12,4)]
+		[DllImport (Constants.SecurityLibrary)]
+		static extern /* __nullable CFDataRef */ IntPtr SecCertificateCopyNormalizedIssuerSequence (IntPtr /* SecCertificateRef */ certificate);
+
+		[iOS (10,3)]
+		[Mac (10,12,4)]
+		public NSData GetNormalizedIssuerSequence ()
+		{
+			IntPtr data = SecCertificateCopyNormalizedIssuerSequence (handle);
+			return (data == IntPtr.Zero) ? null : new NSData (data, true);
+		}
+
+		[iOS (10,3)]
+		[Mac (10,12,4)]
+		[DllImport (Constants.SecurityLibrary)]
+		static extern /* __nullable CFDataRef */ IntPtr SecCertificateCopyNormalizedSubjectSequence (IntPtr /* SecCertificateRef */ certificate);
+
+		[iOS (10,3)]
+		[Mac (10,12,4)]
+		public NSData GetNormalizedSubjectSequence ()
+		{
+			IntPtr data = SecCertificateCopyNormalizedSubjectSequence (handle);
+			return (data == IntPtr.Zero) ? null : new NSData (data, true);
+		}
+
+#if MONOMAC
+		[Mac (10,7)]
+		[DllImport (Constants.SecurityLibrary)]
+		static extern /* __nullable CFDataRef */ IntPtr SecCertificateCopySerialNumber (IntPtr /* SecCertificateRef */ certificate, IntPtr /* CFErrorRef * */ error);
+#else
+		[iOS (10,3)]
+		[DllImport (Constants.SecurityLibrary)]
+		static extern /* __nullable CFDataRef */ IntPtr SecCertificateCopySerialNumber (IntPtr /* SecCertificateRef */ certificate);
+#endif
+		[iOS (10,3)]
+		[Mac (10,7)]
+		public NSData GetSerialNumber ()
+		{
+#if MONOMAC
+			IntPtr data = SecCertificateCopySerialNumber (handle, IntPtr.Zero);
+#else
+			IntPtr data = SecCertificateCopySerialNumber (handle);
+#endif
+			return (data == IntPtr.Zero) ? null : new NSData (data, true);
+		}
+
+#endif // COREBUILD
+		 
 		~SecCertificate ()
 		{
 			Dispose (false);

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -127,6 +127,18 @@ partial class TestRuntime
 #else
 				throw new NotImplementedException ();
 #endif
+			case 3:
+#if __WATCHOS__
+				return CheckWatchOSSystemVersion (3, 2);
+#elif __TVOS__
+				return ChecktvOSSystemVersion (10, 2);
+#elif __IOS__
+				return CheckiOSSystemVersion (10, 3);
+#elif MONOMAC
+				return CheckMacSystemVersion (10, 12, 4);
+#else
+				throw new NotImplementedException ();
+#endif
 			default:
 				throw new NotImplementedException ();
 			}

--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -514,6 +514,14 @@ namespace MonoTouchFixtures.Security {
 			Assert.That (CFGetRetainCount (cert.Handle), Is.EqualTo (expectedRetainCount), "RetainCount");
 			Assert.That (cert.SubjectSummary, Is.EqualTo ("mail.google.com"), "SubjectSummary");
 			Assert.That ((nuint) (uint) mail_google_com.Length, Is.EqualTo (cert.DerData.Length), "DerData");
+			if (TestRuntime.CheckXcodeVersion (8, 3)) {
+				Assert.That (cert.GetCommonName (), Is.EqualTo ("mail.google.com"), "GetCommonName");
+				Assert.That (cert.GetSerialNumber ().Description, Is.EqualTo ("<2b9f7ee5 ca25a625 14204782 753a9bb9>"), "GetSerialNumber");
+				Assert.Null (cert.GetEmailAddresses (), "GetEmailAddresses");
+				Assert.NotNull (cert.GetNormalizedIssuerSequence (), "GetNormalizedIssuerSequence");
+				Assert.NotNull (cert.GetNormalizedSubjectSequence (), "GetNormalizedSubjectSequence");
+				Assert.NotNull (cert.GetPublicKey (), "GetPublicKey");
+			}
 		}
 
 		[Test]

--- a/tests/xtro-sharpie/Helpers.cs
+++ b/tests/xtro-sharpie/Helpers.cs
@@ -55,6 +55,7 @@ namespace Extrospection {
 			{ "NWTCPConnectionState", "NWTcpConnectionState" },
 			{ "NWUDPSessionState", "NWUdpSessionState" },
 			{ "RPRecordingErrorCode", "RPRecordingError" },
+			{ "SecTrustResultType", "SecTrustResult" },
 			{ "SKErrorCode", "SKError" },
 			{ "SSReadingListErrorCode", "SSReadingListError" },
 			{ "SCNRenderingAPI", "SCNRenderingApi" },

--- a/tests/xtro-sharpie/common.ignore
+++ b/tests/xtro-sharpie/common.ignore
@@ -152,6 +152,13 @@
 !incorrect-protocol-member! MDLObjectContainerComponent::count is REQUIRED and should be abstract
 !incorrect-protocol-member! MDLObjectContainerComponent::objectAtIndexedSubscript: is REQUIRED and should be abstract
 
+
+# Security
+
+## part of mscorlib.dll -> mcs/class/corlib/CommonCrypto/CommonCrypto.cs to implement RNGCryptoServiceProvider
+!missing-pinvoke! SecRandomCopyBytes is not bound
+
+
 # SpriteKit
 
 ## both introduced and deprecated in Xcode8


### PR DESCRIPTION
They were thought to be macOS only but xtro corrected me, they are
new in iOS 10.3 even if some existed previously.

references (xtro):
!missing-pinvoke! SecCertificateCopyCommonName is not bound
!missing-pinvoke! SecCertificateCopyEmailAddresses is not bound
!missing-pinvoke! SecCertificateCopyNormalizedIssuerSequence is not bound
!missing-pinvoke! SecCertificateCopyNormalizedSubjectSequence is not bound
!missing-pinvoke! SecCertificateCopyPublicKey is not bound
!missing-pinvoke! SecCertificateCopySerialNumber is not bound

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=52505