### PR TITLE
[tests] Adjust monotouch-test not to crash on an Apple bug. Fixes #52162

### DIFF
--- a/tests/monotouch-test/CoreText/CTLineTest.cs
+++ b/tests/monotouch-test/CoreText/CTLineTest.cs
@@ -12,12 +12,14 @@
 using System;
 #if XAMCORE_2_0
 using Foundation;
+using ObjCRuntime;
 using UIKit;
 using CoreGraphics;
 using CoreText;
 #else
 using MonoTouch.CoreGraphics;
 using MonoTouch.CoreText;
+using MonoTouch.ObjCRuntime;
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
 #endif
@@ -55,6 +57,11 @@ namespace MonoTouchFixtures.CoreText
 
 			var attributedString = new NSAttributedString ("Hello world.\nWoohooo!\nThere", sa);
 
+			// there's a bug in iOS 10.3 (beta1 and 2 at least) where a crash happens, only on i386, if execution continue
+			// this works fine with earlier simulator (on Xcode 8.3) or on devices (with 10.3) with 32bits builds
+			if (TestRuntime.CheckSDKVersion (8, 3) && (Runtime.Arch == Arch.SIMULATOR) && (IntPtr.Size == 4))
+				return;
+			
 			var line = new CTLine (attributedString);
 			bool executed = false;
 #if XAMCORE_2_0


### PR DESCRIPTION
iOS 10.3 simulator (i386 only) will crash executing CTLineTests.
EnumerateCaretOffsets test case.

This does not happen on 64 bits (simulator) or on device builds,
including 32 bits builds. Running iOS 10.1 simulator (with Xcode 8.3)
also runs without problems.

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=52162