### PR TITLE
[macos][storekit] SKDownload::transaction was added to macOS (10.11)

### DIFF
--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -63,12 +63,13 @@ namespace XamCore.StoreKit {
 		[Static]
 		void DeleteContentForProduct (string productId);
 #else
-		[Export ("transaction")]
-		SKPaymentTransaction Transaction { get;  }
-
 		[Field ("SKDownloadTimeRemainingUnknown")]
 		double TimeRemainingUnknown { get; }
 #endif
+
+		[Mac (10,11)]
+		[Export ("transaction")]
+		SKPaymentTransaction Transaction { get;  }
 	}
 
 	[BaseType (typeof (NSObject))]


### PR DESCRIPTION
reference (xtro):
osx.unclassified:!missing-selector! SKDownload::transaction not bound