### PR TITLE
Revert "[modelio] All properties for MDLVertexAttributeData were turned read-only in iOS10 (#222)"

### DIFF
--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -1733,40 +1733,16 @@ namespace XamCore.ModelIO {
 	interface MDLVertexAttributeData
 	{
 		[Export ("map", ArgumentSemantic.Retain), NullAllowed]
-		MDLMeshBufferMap Map {
-			get;
-#if !XAMCORE_4_0
-			[NotImplemented]
-			set;
-#endif
-		}
+		MDLMeshBufferMap Map { get; set; }
 
 		[Export ("dataStart", ArgumentSemantic.Assign)]
-		IntPtr DataStart {
-			get;
-#if !XAMCORE_4_0
-			[NotImplemented]
-			set;
-#endif
-		}
+		IntPtr DataStart { get; set; }
 
 		[Export ("stride", ArgumentSemantic.Assign)]
-		nuint Stride {
-			get;
-#if !XAMCORE_4_0
-			[NotImplemented]
-			set;
-#endif
-		}
+		nuint Stride { get; set; }
 
 		[Export ("format", ArgumentSemantic.Assign)]
-		MDLVertexFormat Format {
-			get;
-#if !XAMCORE_4_0
-			[NotImplemented]
-			set;
-#endif
-		}
+		MDLVertexFormat Format { get; set; }
 	}
 
 	[iOS (9,0)][Mac (10,11, onlyOn64 : true)]


### PR DESCRIPTION
This reverts commit 0b6ac445ce9f9a59d5bda669c74b23c08e0d1679.

Apple reverted this change later (beta?)

references (xtro):
common.unclassified:!missing-selector! MDLVertexAttributeData::setDataStart: not bound
common.unclassified:!missing-selector! MDLVertexAttributeData::setFormat: not bound
common.unclassified:!missing-selector! MDLVertexAttributeData::setMap: not bound
common.unclassified:!missing-selector! MDLVertexAttributeData::setStride: not bound