### PR TITLE
[spritekit] Update for Xcode 8.3 beta 1 - part 3

### DIFF
--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -125,6 +125,11 @@ namespace XamCore.SpriteKit {
 		[Static, Export ("node")]
 		SKNode Create ();
 
+		[Static]
+		[Export ("nodeWithFileNamed:")]
+		[return: NullAllowed]
+		SKNode Create (string filename);
+
 		[Export ("frame")]
 		CGRect Frame { get; }
 
@@ -252,6 +257,9 @@ namespace XamCore.SpriteKit {
 
 		[Export ("intersectsNode:")]
 		bool IntersectsNode (SKNode node);
+
+		[Export ("isEqualToNode:")]
+		bool IsEqual (SKNode node);
 
 		[Export ("inParentHierarchy:")]
 		bool InParentHierarchy (SKNode node);
@@ -1900,10 +1908,6 @@ namespace XamCore.SpriteKit {
 			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")] set;
 		}
 
-#if false
-	// Do we really need these static factory methods, instead of the nice construcotrs we have in C#?
-	// Only reason Apple exposed these is because [[foo alloc] init] is annoying
-	//
 		[Static, Export ("uniformWithName:")]
 		SKUniform Create (string name);
 
@@ -1948,7 +1952,6 @@ namespace XamCore.SpriteKit {
 		[Export ("uniformWithName:matrixFloat4x4:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		SKUniform Create (string name, Matrix4 value);
-#endif
 	}
 
 	delegate void SKActionDurationHandler (SKNode node, nfloat elapsedTime);

--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -1105,7 +1105,6 @@ namespace XamCore.SpriteKit {
 		[Export ("attributeValues", ArgumentSemantic.Copy)]
 		NSDictionary<NSString, SKAttributeValue> AttributeValues { get; set; }
 
-#if XAMCORE_4_0
 		[iOS (9,0), Mac(10,11)]
 		[Export ("valueForAttributeNamed:")]
 		[return: NullAllowed]
@@ -1114,7 +1113,6 @@ namespace XamCore.SpriteKit {
 		[iOS (9,0), Mac(10,11)]
 		[Export ("setValue:forAttributeNamed:")]
 		void SetValue (SKAttributeValue value, string key);
-#endif
 	}
 
 	[Watch (3,0)]
@@ -3064,7 +3062,6 @@ namespace XamCore.SpriteKit {
 		[Export ("attributeValues", ArgumentSemantic.Copy)]
 		NSDictionary<NSString, SKAttributeValue> AttributeValues { get; set; }
 
-#if XAMCORE_4_0
 		[iOS (9,0), Mac(10,11)]
 		[Export ("valueForAttributeNamed:")]
 		[return: NullAllowed]
@@ -3073,7 +3070,6 @@ namespace XamCore.SpriteKit {
 		[iOS (9,0), Mac(10,11)]
 		[Export ("setValue:forAttributeNamed:")]
 		void SetValue (SKAttributeValue value, string key);
-#endif
 	}
 
 	[Watch (3,0)]

--- a/tests/xtro-sharpie/common.pending
+++ b/tests/xtro-sharpie/common.pending
@@ -57,34 +57,13 @@
 
 # SpriteKit
 
-## https://bugzilla.xamarin.com/show_bug.cgi?id=34946
-!missing-selector! +SKNode::nodeWithFileNamed: not bound
-!missing-selector! SKNode::isEqualToNode: not bound
-!missing-selector! +SKUniform::uniformWithName: not bound
-!missing-selector! +SKUniform::uniformWithName:texture: not bound
-!missing-selector! +SKUniform::uniformWithName:float: not bound
+## Deprecated in iOS 10
 !missing-selector! +SKUniform::uniformWithName:floatVector2: not bound
 !missing-selector! +SKUniform::uniformWithName:floatVector3: not bound
 !missing-selector! +SKUniform::uniformWithName:floatVector4: not bound
 !missing-selector! +SKUniform::uniformWithName:floatMatrix2: not bound
 !missing-selector! +SKUniform::uniformWithName:floatMatrix3: not bound
 !missing-selector! +SKUniform::uniformWithName:floatMatrix4: not bound
-!missing-selector! +SKActions::falloffTo:duration: not bound
-!missing-selector! +SKVideoNode::videoNodeWithFileNamed: not bound
-!missing-selector! +SKVideoNode::videoNodeWithURL: not bound
-
-## https://bugzilla.xamarin.com/show_bug.cgi?id=37727
-!missing-selector! SKVideoNode::initWithFileNamed: not bound
-!missing-selector! SKVideoNode::initWithURL: not bound
-
-## Do we really need these static factory methods, instead of the nice construcotrs we have in C#?
-## Only reason Apple exposed these is because [[foo alloc] init] is annoying
-!missing-selector! +SKUniform::uniformWithName:matrixFloat2x2: not bound
-!missing-selector! +SKUniform::uniformWithName:matrixFloat3x3: not bound
-!missing-selector! +SKUniform::uniformWithName:matrixFloat4x4: not bound
-!missing-selector! +SKUniform::uniformWithName:vectorFloat2: not bound
-!missing-selector! +SKUniform::uniformWithName:vectorFloat3: not bound
-!missing-selector! +SKUniform::uniformWithName:vectorFloat4: not bound
 
 
 # UIKit

--- a/tests/xtro-sharpie/common.pending
+++ b/tests/xtro-sharpie/common.pending
@@ -77,6 +77,15 @@
 !missing-selector! SKVideoNode::initWithFileNamed: not bound
 !missing-selector! SKVideoNode::initWithURL: not bound
 
+## Do we really need these static factory methods, instead of the nice construcotrs we have in C#?
+## Only reason Apple exposed these is because [[foo alloc] init] is annoying
+!missing-selector! +SKUniform::uniformWithName:matrixFloat2x2: not bound
+!missing-selector! +SKUniform::uniformWithName:matrixFloat3x3: not bound
+!missing-selector! +SKUniform::uniformWithName:matrixFloat4x4: not bound
+!missing-selector! +SKUniform::uniformWithName:vectorFloat2: not bound
+!missing-selector! +SKUniform::uniformWithName:vectorFloat3: not bound
+!missing-selector! +SKUniform::uniformWithName:vectorFloat4: not bound
+
 
 # UIKit
 


### PR DESCRIPTION
- Fixes bug #52568: Missing SpriteKit API
(https://bugzilla.xamarin.com/show_bug.cgi?id=52568)

xtro revealed that some selectors were still missing after the "part 2" fix.