### PR TITLE
[opengles] Add version check to EAGLContext.PresentRenderBufferTest

### DIFF
--- a/tests/monotouch-test/OpenGLES/EAGLContext.cs
+++ b/tests/monotouch-test/OpenGLES/EAGLContext.cs
@@ -31,11 +31,15 @@ namespace MonoTouchFixtures.OpenGLES
 		[Test]
 		public void PresentRenderBufferTest ()
 		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+
 			var obj = new EAGLContext (EAGLRenderingAPI.OpenGLES2);
 
 			Asserts.AreEqual (true, obj.PresentRenderBuffer ((int)RenderbufferTarget.Renderbuffer, 0), "PresentRenderBuffer");
-			Asserts.AreEqual (true, obj.PresentRenderBuffer ((int)RenderbufferTarget.Renderbuffer, 0, EAGLContext.PresentationMode.AtTime), "PresentRenderBufferAtTime");
-			Asserts.AreEqual (true, obj.PresentRenderBuffer ((int)RenderbufferTarget.Renderbuffer, 0, EAGLContext.PresentationMode.AfterMinimumDuration), "PresentRenderBufferAfterMinimumDuration");
+			if (TestRuntime.CheckXcodeVersion (8, 3)) {
+				Asserts.AreEqual (true, obj.PresentRenderBuffer ((int)RenderbufferTarget.Renderbuffer, 0, EAGLContext.PresentationMode.AtTime), "PresentRenderBufferAtTime");
+				Asserts.AreEqual (true, obj.PresentRenderBuffer ((int)RenderbufferTarget.Renderbuffer, 0, EAGLContext.PresentationMode.AfterMinimumDuration), "PresentRenderBufferAfterMinimumDuration");
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fix bug #52456: [iOS]EAGLContextTest.PresentRenderBufferTest failed on lower versions of iOS
(https://bugzilla.xamarin.com/show_bug.cgi?id=52456)