### PR TITLE
Fix Bug 51514 - [generator] Missing [Wrap] from protocol/interface when parent has a [Wrap] itself

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -5687,7 +5687,7 @@ public partial class Generator : IMemberGatherer {
 				}
 			}
 			
-			var bound_methods = new List<string> (); // List of methods bound on the class itself (not via protocols)
+			var bound_methods = new HashSet<MemberInformation> (); // List of methods bound on the class itself (not via protocols)
 			var generated_methods = new List<MemberInformation> (); // All method that have been generated
 			foreach (var mi in GetTypeContractMethods (type).OrderByDescending (m => m.Name == "Constructor").ThenBy (m => m.Name, StringComparer.Ordinal)) {
 				if (mi.IsSpecialName || (mi.Name == "Constructor" && type != mi.DeclaringType))
@@ -5703,11 +5703,11 @@ public partial class Generator : IMemberGatherer {
 
 				if (type == mi.DeclaringType || type.IsSubclassOf (mi.DeclaringType)) {
 					// not an injected protocol method.
-					bound_methods.Add (minfo.selector);
+					bound_methods.Add (minfo);
 				} else {
 					// don't inject a protocol method if the class already
 					// implements the same method.
-					if (bound_methods.Contains (minfo.selector))
+					if (bound_methods.Contains (minfo))
 						continue;
 
 					var protocolsThatHaveThisMethod = GetTypeContractMethods (type).Where (x => { var sel = GetSelector (x); return sel != null && sel == minfo.selector; } );

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -2609,10 +2609,6 @@ namespace XamCore.SceneKit {
 		[iOS (8,0)][Mac (10,10)]
 		[Export ("antialiasingMode")]
 		SCNAntialiasingMode AntialiasingMode { get; set; }
-
-		// HitTest comes from SCNSceneRenderer - and that Wrap'per is not copied (but needed for backward compatibility)
-		[Wrap ("HitTest (thePoint, options == null ? null : options.Dictionary)")]
-		new SCNHitTestResult [] HitTest (CGPoint thePoint, SCNHitTestOptions options);
 	}
 
 	[Mac (10,9), iOS (8,0)]


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=51514

The generator used a list of strings (selector names) to determine
what methods are needed to be generated. Unfortunately this info
is not available (null) when looking for it on [Wrap] decorated members
so it would only generate the first [Bind] it would find. Now it uses
a HashSet of MemberInformation objects to compare.

The removal of SCNView.HitTest inside scenekit.cs was done because
this is now correctly generated from SCNSceneRenderer interface

Build diff: https://gist.github.com/dalexsoto/02c45ca364054b0f01be620083258ff8

<img width="1459" alt="diff changes" src="https://cloud.githubusercontent.com/assets/204671/23041082/35588188-f459-11e6-9286-0fba5da65b05.png">


