### PR TITLE
[XM] Add the option to ignore missing files during registration

### DIFF
--- a/src/AppKit/NSApplication.cs
+++ b/src/AppKit/NSApplication.cs
@@ -33,6 +33,7 @@ namespace XamCore.AppKit {
 	public partial class NSApplication : NSResponder {
 		public static bool CheckForIllegalCrossThreadCalls = true;
 		public static bool CheckForEventAndDelegateMismatches = true;
+		public static bool IgnoreMissingAssembliesDuringRegistration = false;
 
 		private static Thread mainThread;
 

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -408,14 +408,13 @@ namespace XamCore.ObjCRuntime {
 					if (!assemblies.Contains (a))
 						CollectReferencedAssemblies (assemblies, a);
 				}
-#if MONOMAC
-				catch {
+				catch (FileNotFoundException fefe) {
 					// that's more important for XI because device builds don't go thru this step
 					// and we can end up with simulator-only failures - bug #29211
-					throw;
-#else
-				catch (FileNotFoundException fefe) {
 					NSLog ("Could not find `{0}` referenced by assembly `{1}`.", fefe.FileName, assembly.FullName);
+#if MONOMAC
+					if (!NSApplication.IgnoreMissingAssembliesDuringRegistration)
+						throw;
 #endif
 				}
 			}

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -17,6 +17,10 @@ using System.Runtime.InteropServices;
 using XamCore.Foundation;
 using XamCore.Registrar;
 
+#if MONOMAC
+using XamCore.AppKit;
+#endif
+
 #if !COREBUILD && (XAMARIN_APPLETLS || XAMARIN_NO_TLS)
 #if !MMP && !MTOUCH && !MTOUCH_TEST
 using Mono.Security.Interface;


### PR DESCRIPTION
Not all assemblies referenced at compile time are necessary
at runtime. Allow XamMac to ignore missing assemblies just
like iOS does.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=51746