### PR TITLE
[corefoundation] Fix CallbackDelegate signature to be 32bits safe (enum). Fixes #52279

### DIFF
--- a/src/CoreFoundation/CFStream.cs
+++ b/src/CoreFoundation/CFStream.cs
@@ -131,11 +131,11 @@ namespace XamCore.CoreFoundation {
 		}
 		
 		[MonoNativeFunctionWrapper]
-		delegate void CallbackDelegate (IntPtr stream, CFStreamEventType eventType, IntPtr info);
+		delegate void CallbackDelegate (IntPtr stream, IntPtr /* CFStreamEventType */ eventType, IntPtr info);
 
 		static void CFReadStreamRef_InvokeCallback (IntPtr callback, IntPtr stream, CFStreamEventType eventType, IntPtr info)
 		{
-			((CallbackDelegate)Marshal.GetDelegateForFunctionPointer (callback, typeof (CallbackDelegate))) (stream, eventType, info);
+			((CallbackDelegate)Marshal.GetDelegateForFunctionPointer (callback, typeof (CallbackDelegate))) (stream, (IntPtr) eventType, info);
 		}
 	}
 


### PR DESCRIPTION
The `CFStreamEventType` enum is based on `NSUInteger`. The native delegate
CallbackDelegate was using it directly and that made it incorrect on 32
bits platforms.

We have introspection tests to check enums on p/invoke, but it seems they
don't cover native delegates - decorated with [MonoNativeFunctionWrapper]
That's to be added in a different PR.

references:
https://bugzilla.xamarin.com/show_bug.cgi?id=52279