### PR TITLE
[src] Don't compare code generated/processed by pmcs.

### DIFF
--- a/src/generator-diff.mk
+++ b/src/generator-diff.mk
@@ -1,4 +1,4 @@
-.generated_copy = rsync -qavz --exclude=*.dll --exclude=*.exe --exclude=*.mdb build generator-reference
+.generated_copy = rsync -qavz --exclude=*.dll --exclude=*.exe --exclude=*.mdb '--exclude=*~.pmcs*' build generator-reference
 
 generator-reference:
 	@rm -rf $@


### PR DESCRIPTION
Comparing pmcs-processed/generatedo code is redundant, because we're already
comparing the original code. Also the filenames aren't stable (they change
every time pmcs is executed), which makes any diff contain unwanted noise.