### PR TITLE
[runtime] Work around static analyzer warning about incorrect refcount decrement.

### DIFF
--- a/runtime/shared.m
+++ b/runtime/shared.m
@@ -213,7 +213,7 @@ xamarin_thread_finish (void *user_data)
 	pthread_mutex_unlock (&thread_hash_lock);
 
 	if (pool)
-		[pool release];
+		[pool drain];
 		
 	MONO_EXIT_GC_SAFE;
 }


### PR DESCRIPTION
This warning:

    shared.m:216:3: warning: Incorrect decrement of the reference count of an object that is not owned at this point by the caller
                    [pool release];
                    ^~~~~~~~~~~~~~

is somewhat incorrect, because we're using NSAutoreleasePools in uncommon ways
(at the same time it's not entirely incorrect either, because we're not
following Apple's documentation about how to use NSAutoreleasePools).

Luckily calling [NSAutoreleasePool drain] is equivalent to [NSAutoreleasePool
release], so just replace the latter with the former to silence the warning,
since clang doesn't know those two are equivalent.