### PR TITLE
[runtime] Fix an extraneous timezone release.

### DIFF
--- a/runtime/xamarin-support.m
+++ b/runtime/xamarin-support.m
@@ -46,7 +46,7 @@ xamarin_timezone_get_data (const char *name, int *size)
 	NSTimeZone *tz = nil;
 	if (name) {
 		NSString *n = [[NSString alloc] initWithUTF8String: name];
-		tz = [[NSTimeZone alloc] initWithName:n];
+		tz = [[[NSTimeZone alloc] initWithName:n] autorelease];
 		[n release];
 	} else {
 		tz = [NSTimeZone localTimeZone];
@@ -55,7 +55,6 @@ xamarin_timezone_get_data (const char *name, int *size)
 	*size = [data length];
 	void* result = malloc (*size);
 	memcpy (result, data.bytes, *size);
-	[tz release];
 	return result;
 }
 


### PR DESCRIPTION
Getting a time zone instance in two different code paths, one allocating the
time zone instance, and the other not allocating, is problematic when we
unconditionally freeing the time zone at the end.

    xamarin-support.m:58:2: warning: Incorrect decrement of the reference count of an object that is not owned at this point by the caller
            [tz release];
            ^~~~~~~~~~~~

So fix this by autoreleasing the allocated timezone.