### PR TITLE
[runtime] Make the clang's static analyzer happy.

### DIFF
--- a/runtime/trampolines-i386.m
+++ b/runtime/trampolines-i386.m
@@ -121,6 +121,8 @@ marshal_return_value (void *context, const char *type, size_t size, void *vvalue
 				v[1] = *(uint16_t *) unboxed;
 			} else if (size == 5) {
 				v[1] = *(uint8_t *) unboxed;
+			} else {
+				v[1] = 0; // theoretically impossible, but it silences static analysis, and if the real world proves the theory wrong, then we still get consistent behavior.
 			}
 			it->state->eax = v[0];
 			it->state->edx = v[1];

--- a/runtime/trampolines-x86_64.m
+++ b/runtime/trampolines-x86_64.m
@@ -395,6 +395,8 @@ marshal_return_value (void *context, const char *type, size_t size, void *vvalue
 				v[1] = *(uint16_t *) unboxed;
 			} else if (size == 9) {
 				v[1] = *(uint8_t *) unboxed;
+			} else {
+				v[1] = 0; // theoretically impossible, but it silences static analysis, and if the real world proves the theory wrong, then we still get consistent behavior.
 			}
 			// figure out where to put the values.
 			const char *t = skip_type_name (type);


### PR DESCRIPTION
    trampolines-i386.m:126:19: warning: Assigned value is garbage or undefined
                            it->state->edx = v[1];
                                           ^ ~~~~
    trampolines-x86_64.m:410:16: warning: Assigned value is garbage or undefined
                                                    *reg_ptr = v [stores];
                                                             ^ ~~~~~~~~~~
    trampolines-x86_64.m:447:14: warning: Assigned value is garbage or undefined
                                    *reg_ptr = v [stores++];
                                             ^ ~~~~~~~~~~~~