### PR TITLE
[runtime] Fix potential memory leak in error conditions.

### DIFF
--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -90,8 +90,10 @@ xamarin_marshal_return_value (MonoType *mtype, const char *type, MonoObject *ret
 						v = sv;
 					} else {
 						v = xamarin_get_handle (value, exception_gchandle);
-						if (*exception_gchandle != 0)
+						if (*exception_gchandle != 0) {
+							free (buf);
 							 return NULL;
+						}
 					}
 					buf[i] = v;
 				}


### PR DESCRIPTION
This was found by clang's static analyzer:

    trampolines.m:94:16: warning: Potential leak of memory pointed to by 'buf'
                                                             return NULL;
                                                                    ^~~~