### PR TITLE
[runtime] Allocate memory correctly to make clang's static analyzer happy.

### DIFF
--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -72,7 +72,7 @@ xamarin_marshal_return_value (MonoType *mtype, const char *type, MonoObject *ret
 				bool is_string = e_klass == mono_get_string_class ();
 				MonoArray *m_arr = (MonoArray *) retval;
 				int length = mono_array_length (m_arr);
-				id *buf = (id *) malloc (sizeof (void *) * length);
+				id *buf = (id *) malloc (sizeof (id) * length);
 				NSArray *arr;
 				int i;
 				id v;


### PR DESCRIPTION
    trampolines.m:75:22: warning: Result of 'malloc' is converted to a pointer of type 'id', which is incompatible with sizeof operand type 'void *'
                                    id *buf = (id *) malloc (sizeof (void *) * length);
                                    ~~~~             ^~~~~~  ~~~~~~~~~~~~~~~