### PR TITLE
[runtime] Make sure to always dispose objects that should be disposed, even if things go wrong.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -998,6 +998,12 @@ print_all_exceptions (MonoObject *exc)
 	return str;
 }
 
+NSString *
+xamarin_print_all_exceptions (MonoObject *exc)
+{
+	return print_all_exceptions (exc);
+}
+
 void
 xamarin_ftnptr_exception_handler (guint32 gchandle)
 {

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -168,6 +168,7 @@ void			xamarin_process_nsexception_using_mode (NSException *ns_exception, bool t
 void			xamarin_process_managed_exception (MonoObject *exc);
 void			xamarin_process_managed_exception_gchandle (guint32 gchandle);
 void			xamarin_throw_product_exception (int code, const char *message);
+NSString *		xamarin_print_all_exceptions (MonoObject *exc);
 
 id				xamarin_invoke_objc_method_implementation (id self, SEL sel, IMP xamarin_impl);
 


### PR DESCRIPTION
This fixes an issue clang's static analyzer found: if an exception occured in
a call to managed code, we wouldn't process the list of objects to dispose:

    trampolines-invoke.m:549:2: warning: Potential leak of memory pointed to by 'dispose_list'
            MONO_THREAD_DETACH; // COOP: This will switch to GC_SAFE
            ^~~~~~~~~~~~~~~~~~
    ./xamarin/runtime.h:306:11: note: expanded from macro 'MONO_THREAD_DETACH'
            } while (0)
                     ^

Fix this by always processing the list of objects to dispose, even if
exceptions occur.