### PR TITLE
[generator] No more typeof.

### DIFF
--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -35,7 +35,7 @@ public partial class Generator {
 
 	void CopyObsolete (ICustomAttributeProvider provider)
 	{
-		foreach (ObsoleteAttribute oa in AttributeManager.GetCustomAttributes (provider, typeof (ObsoleteAttribute), false))
+		foreach (ObsoleteAttribute oa in AttributeManager.GetCustomAttributes (provider, TypeManager.ObsoleteAttribute, false))
 			print ("[Obsolete (\"{0}\", {1})]", oa.Message, oa.IsError ? "true" : "false");
 	}
 
@@ -44,7 +44,7 @@ public partial class Generator {
 	//	- call/emit PrintPlatformAttributes on the type
 	void GenerateEnum (Type type)
 	{
-		if (AttributeManager.HasAttribute (type, typeof (FlagsAttribute)))
+		if (AttributeManager.HasAttribute (type, TypeManager.FlagsAttribute))
 			print ("[Flags]");
 
 		var native = AttributeManager.GetCustomAttribute<NativeAttribute> (type);

--- a/src/generator-filters.cs
+++ b/src/generator-filters.cs
@@ -22,7 +22,7 @@ public partial class Generator {
 
 	public void GenerateFilter (Type type)
 	{
-		var is_abstract = AttributeManager.HasAttribute (type, typeof (AbstractAttribute));
+		var is_abstract = AttributeManager.HasAttribute (type, TypeManager.AbstractAttribute);
 		var filter = AttributeManager.GetCustomAttribute<CoreImageFilterAttribute> (type);
 		var base_type = AttributeManager.GetCustomAttribute<BaseTypeAttribute> (type);
 		var type_name = type.Name;

--- a/src/generator-typemanager.cs
+++ b/src/generator-typemanager.cs
@@ -188,12 +188,28 @@ public static class TypeManager {
 	public static Type CoreGraphics_CGSize;
 
 	static Assembly api_assembly;
+	static Assembly corlib_assembly;
+	static Assembly system_assembly;
 	static Assembly platform_assembly;
+	static Assembly binding_assembly;
+
+	public static Assembly CorlibAssembly {
+		get { return corlib_assembly; }
+	}
+
+	public static Assembly PlatformAssembly {
+		get { return platform_assembly; }
+		set { platform_assembly = value; }
+	}
 
 	static Type Lookup (Assembly assembly, string @namespace, string @typename, bool inexistentOK = false)
 	{
 		string fullname;
-		string nsManagerPrefix = BindingTouch.NamespacePlatformPrefix;
+		string nsManagerPrefix = null;
+
+		if (assembly == platform_assembly || assembly == api_assembly)
+			nsManagerPrefix = BindingTouch.NamespacePlatformPrefix;
+		
 		if (!string.IsNullOrEmpty (nsManagerPrefix))
 			nsManagerPrefix += ".";
 
@@ -212,27 +228,30 @@ public static class TypeManager {
 	public static void Initialize (Assembly api)
 	{
 		api_assembly = api;
+		corlib_assembly = typeof (object).Assembly;
+		system_assembly = typeof (System.ComponentModel.BrowsableAttribute).Assembly;
 		platform_assembly = typeof (NSObject).Assembly;
+		binding_assembly = typeof (ProtocolizeAttribute).Assembly;
 
 		/* corlib */
-		System_Attribute = typeof (System.Attribute);
-		System_Boolean = typeof (bool);
-		System_Byte = typeof (byte);
-		System_Delegate = typeof (System.Delegate);
-		System_Double = typeof (double);
-		System_Float = typeof (float);
-		System_Int16 = typeof (short);
-		System_Int32 = typeof (int);
-		System_Int64 = typeof (long);
-		System_IntPtr = typeof (System.IntPtr);
-		System_Object = typeof (object);
-		System_SByte = typeof (sbyte);
-		System_String = typeof (string);
-		System_String_Array = typeof (string[]);
-		System_UInt16 = typeof (ushort);
-		System_UInt32 = typeof (uint);
-		System_UInt64 = typeof (ulong);
-		System_Void = typeof (void);
+		System_Attribute = Lookup (corlib_assembly, "System", "Attribute");
+		System_Boolean = Lookup (corlib_assembly, "System", "Boolean");
+		System_Byte = Lookup (corlib_assembly, "System", "Byte");
+		System_Delegate = Lookup (corlib_assembly, "System", "Delegate");
+		System_Double = Lookup (corlib_assembly, "System", "Double");
+		System_Float = Lookup (corlib_assembly, "System", "Single");
+		System_Int16 = Lookup (corlib_assembly, "System", "Int16");
+		System_Int32 = Lookup (corlib_assembly, "System", "Int32");
+		System_Int64 = Lookup (corlib_assembly, "System", "Int64");
+		System_IntPtr = Lookup (corlib_assembly, "System", "IntPtr");
+		System_Object = Lookup (corlib_assembly, "System", "Object");
+		System_SByte = Lookup (corlib_assembly, "System", "SByte");
+		System_String = Lookup (corlib_assembly, "System", "String");
+		System_String_Array = Lookup (corlib_assembly, "System", "String").MakeArrayType ();
+		System_UInt16 = Lookup (corlib_assembly, "System", "UInt16");
+		System_UInt32 = Lookup (corlib_assembly, "System", "UInt32");
+		System_UInt64 = Lookup (corlib_assembly, "System", "UInt64");
+		System_Void = Lookup (corlib_assembly, "System", "Void");
 
 		if (Generator.UnifiedAPI) {
 			System_nint = Lookup (platform_assembly, "System", "nint");
@@ -241,14 +260,14 @@ public static class TypeManager {
 		}
 
 		/* fundamental */
-		NSObject = typeof (NSObject);
-		INativeObject = typeof (INativeObject);
+		NSObject = Lookup (platform_assembly, "Foundation", "NSObject");
+		INativeObject = Lookup (platform_assembly, "ObjCRuntime", "INativeObject");
 
 		/* objcruntime */
-		BlockLiteral = typeof (BlockLiteral);
-		Class = typeof (Class);
-		Protocol = typeof (Protocol);
-		Selector = typeof (Selector);
+		BlockLiteral = Lookup (platform_assembly, "ObjCRuntime", "BlockLiteral");
+		Class = Lookup (platform_assembly, "ObjCRuntime", "Class");
+		Protocol = Lookup (platform_assembly, "ObjCRuntime", "Protocol");
+		Selector = Lookup (platform_assembly, "ObjCRuntime", "Selector");
 
 		if (Generator.UnifiedAPI) {
 			Constants = Lookup (platform_assembly, "ObjCRuntime", "Constants");
@@ -257,85 +276,85 @@ public static class TypeManager {
 		}
 
 		/* attributes */
-		AbstractAttribute = typeof (AbstractAttribute);
-		AdvancedAttribute = typeof (AdvancedAttribute);
-		AlignAttribute = typeof (AlignAttribute);
-		AppearanceAttribute = typeof (AppearanceAttribute);
-		AsyncAttribute = typeof (AsyncAttribute);
-		AutoreleaseAttribute = typeof (AutoreleaseAttribute);
-		AvailabilityBaseAttribute = typeof (AvailabilityBaseAttribute);
-		BaseTypeAttribute = typeof (BaseTypeAttribute);
-		BindAttribute = typeof (BindAttribute);
-		BlockCallbackAttribute = typeof (BlockCallbackAttribute);
-		CategoryAttribute = typeof (CategoryAttribute);
-		CCallbackAttribute = typeof (CCallbackAttribute);
-		CheckDisposedAttribute = typeof (CheckDisposedAttribute);
-		CoreImageFilterAttribute = typeof (CoreImageFilterAttribute);
-		CoreImageFilterPropertyAttribute = typeof (CoreImageFilterPropertyAttribute);
-		DebuggerBrowsableAttribute = typeof (DebuggerBrowsableAttribute);
-		DebuggerDisplayAttribute = typeof (DebuggerDisplayAttribute);
-		DefaultValueAttribute = typeof (DefaultValueAttribute);
-		DefaultValueFromArgumentAttribute = typeof (DefaultValueFromArgumentAttribute);
-		DelegateApiNameAttribute = typeof (DelegateApiNameAttribute);
-		DelegateNameAttribute = typeof (DelegateNameAttribute);
-		DesignatedInitializerAttribute = typeof (DesignatedInitializerAttribute);
-		DisableZeroCopyAttribute = typeof (DisableZeroCopyAttribute);
-		DisposeAttribute = typeof (DisposeAttribute);
-		EditorBrowsableAttribute = typeof (System.ComponentModel.EditorBrowsableAttribute);
-		EventArgsAttribute = typeof (EventArgsAttribute);
-		EventNameAttribute = typeof (EventNameAttribute);
-		ExportAttribute = typeof (ExportAttribute);
-		FactoryAttribute = typeof (FactoryAttribute);
-		FieldAttribute = typeof (FieldAttribute);
-		FieldOffsetAttribute = typeof (FieldOffsetAttribute);
-		FlagsAttribute = typeof (FlagsAttribute);
-		InternalAttribute = typeof (InternalAttribute);
-		IsThreadStaticAttribute = typeof (IsThreadStaticAttribute);
-		LinkWithAttribute = typeof (LinkWithAttribute);
-		ManualAttribute = typeof (ManualAttribute);
-		MarshalAsAttribute = typeof (MarshalAsAttribute);
-		MarshalNativeExceptionsAttribute = typeof (MarshalNativeExceptionsAttribute);
-		ModelAttribute = typeof (ModelAttribute);
-		NativeAttribute = typeof (NativeAttribute);
-		NewAttribute = typeof (NewAttribute);
-		NoDefaultValueAttribute = typeof (NoDefaultValueAttribute);
-		NotificationAttribute = typeof (NotificationAttribute);
-		NotImplementedAttribute = typeof (NotImplementedAttribute);
-		NullAllowedAttribute = typeof (NullAllowedAttribute);
-		ObsoleteAttribute = typeof (ObsoleteAttribute);
-		OptionalImplementationAttribute = typeof (OptionalImplementationAttribute);
-		OutAttribute = typeof (OutAttribute);
-		OverrideAttribute = typeof (OverrideAttribute);
-		ParamArrayAttribute = typeof (ParamArrayAttribute);
-		ParamsAttribute = typeof (ParamsAttribute);
-		PartialAttribute = typeof (PartialAttribute);
-		PlainStringAttribute = typeof (PlainStringAttribute);
-		PostGetAttribute = typeof (PostGetAttribute);
-		PostSnippetAttribute = typeof (PostSnippetAttribute);
-		PreSnippetAttribute = typeof (PreSnippetAttribute);
-		ProbePresenceAttribute = typeof (ProbePresenceAttribute);
-		PrologueSnippetAttribute = typeof (PrologueSnippetAttribute);
-		ProtectedAttribute = typeof (ProtectedAttribute);
-		ProtocolAttribute = typeof (ProtocolAttribute);
-		ProtocolizeAttribute = typeof (ProtocolizeAttribute);
-		ProxyAttribute = typeof (ProxyAttribute);
-		RegisterAttribute = typeof (RegisterAttribute);
-		ReleaseAttribute = typeof (ReleaseAttribute);
-		RetainAttribute = typeof (RetainAttribute);
-		SealedAttribute = typeof (SealedAttribute);
-		StaticAttribute = typeof (StaticAttribute);
-		StrongDictionaryAttribute = typeof (StrongDictionaryAttribute);
-		SyntheticAttribute = typeof (SyntheticAttribute);
-		TargetAttribute = typeof (TargetAttribute);
-		ThreadSafeAttribute = typeof (ThreadSafeAttribute);
-		TransientAttribute = typeof (TransientAttribute);
-		UnifiedInternalAttribute = typeof (UnifiedInternalAttribute);
-		WrapAttribute = typeof (WrapAttribute);
-		ZeroCopyStringsAttribute = typeof (ZeroCopyStringsAttribute);
+		AbstractAttribute = Lookup (binding_assembly, "", "AbstractAttribute");
+		AdvancedAttribute = Lookup (binding_assembly, "", "AdvancedAttribute");
+		AlignAttribute = Lookup (binding_assembly, "", "AlignAttribute");
+		AppearanceAttribute = Lookup (binding_assembly, "", "AppearanceAttribute");
+		AsyncAttribute = Lookup (binding_assembly, "", "AsyncAttribute");
+		AutoreleaseAttribute = Lookup (binding_assembly, "", "AutoreleaseAttribute");
+		AvailabilityBaseAttribute = Lookup (platform_assembly, "ObjCRuntime", "AvailabilityBaseAttribute");
+		BaseTypeAttribute = Lookup (binding_assembly, "", "BaseTypeAttribute");
+		BindAttribute = Lookup (binding_assembly, "", "BindAttribute");
+		BlockCallbackAttribute = Lookup (binding_assembly, "", "BlockCallbackAttribute");
+		CategoryAttribute = Lookup (binding_assembly, "", "CategoryAttribute");
+		CCallbackAttribute = Lookup (binding_assembly, "", "CCallbackAttribute");
+		CheckDisposedAttribute = Lookup (binding_assembly, "", "CheckDisposedAttribute");
+		CoreImageFilterAttribute = Lookup (binding_assembly, "", "CoreImageFilterAttribute");
+		CoreImageFilterPropertyAttribute = Lookup (binding_assembly, "", "CoreImageFilterPropertyAttribute");
+		DebuggerBrowsableAttribute = Lookup (corlib_assembly, "System.Diagnostics", "DebuggerBrowsableAttribute");
+		DebuggerDisplayAttribute = Lookup (corlib_assembly, "System.Diagnostics", "DebuggerDisplayAttribute");
+		DefaultValueAttribute = Lookup (binding_assembly, "", "DefaultValueAttribute");
+		DefaultValueFromArgumentAttribute = Lookup (binding_assembly, "", "DefaultValueFromArgumentAttribute");
+		DelegateApiNameAttribute = Lookup (binding_assembly, "", "DelegateApiNameAttribute");
+		DelegateNameAttribute = Lookup (binding_assembly, "", "DelegateNameAttribute");
+		DesignatedInitializerAttribute = Lookup (binding_assembly, "", "DesignatedInitializerAttribute");
+		DisableZeroCopyAttribute = Lookup (binding_assembly, "", "DisableZeroCopyAttribute");
+		DisposeAttribute = Lookup (binding_assembly, "", "DisposeAttribute");
+		EditorBrowsableAttribute = Lookup (system_assembly, "System.ComponentModel", "EditorBrowsableAttribute");
+		EventArgsAttribute = Lookup (binding_assembly, "", "EventArgsAttribute");
+		EventNameAttribute = Lookup (binding_assembly, "", "EventNameAttribute");
+		ExportAttribute = Lookup (platform_assembly, "Foundation", "ExportAttribute");
+		FactoryAttribute = Lookup (binding_assembly, "", "FactoryAttribute");
+		FieldAttribute = Lookup (platform_assembly, "Foundation", "FieldAttribute");
+		FieldOffsetAttribute = Lookup (corlib_assembly, "System.Runtime.InteropServices", "FieldOffsetAttribute");
+		FlagsAttribute = Lookup (corlib_assembly, "System", "FlagsAttribute");
+		InternalAttribute = Lookup (binding_assembly, "", "InternalAttribute");
+		IsThreadStaticAttribute = Lookup (binding_assembly, "", "IsThreadStaticAttribute");
+		LinkWithAttribute = Lookup (platform_assembly, "ObjCRuntime", "LinkWithAttribute");
+		ManualAttribute = Lookup (binding_assembly, "", "ManualAttribute");
+		MarshalAsAttribute = Lookup (corlib_assembly, "System.Runtime.InteropServices", "MarshalAsAttribute");
+		MarshalNativeExceptionsAttribute = Lookup (binding_assembly, "", "MarshalNativeExceptionsAttribute");
+		ModelAttribute = Lookup (platform_assembly, "Foundation", "ModelAttribute");
+		NativeAttribute = Lookup (platform_assembly, "ObjCRuntime", "NativeAttribute");
+		NewAttribute = Lookup (binding_assembly, "", "NewAttribute");
+		NoDefaultValueAttribute = Lookup (binding_assembly, "", "NoDefaultValueAttribute");
+		NotificationAttribute = Lookup (binding_assembly, "", "NotificationAttribute");
+		NotImplementedAttribute = Lookup (binding_assembly, "", "NotImplementedAttribute");
+		NullAllowedAttribute = Lookup (binding_assembly, "", "NullAllowedAttribute");
+		ObsoleteAttribute = Lookup (corlib_assembly, "System", "ObsoleteAttribute");
+		OptionalImplementationAttribute = Lookup (binding_assembly, "", "OptionalImplementationAttribute");
+		OutAttribute = Lookup (corlib_assembly, "System.Runtime.InteropServices", "OutAttribute");
+		OverrideAttribute = Lookup (binding_assembly, "", "OverrideAttribute");
+		ParamArrayAttribute = Lookup (corlib_assembly, "System", "ParamArrayAttribute");
+		ParamsAttribute = Lookup (binding_assembly, "", "ParamsAttribute");
+		PartialAttribute = Lookup (binding_assembly, "", "PartialAttribute");
+		PlainStringAttribute = Lookup (binding_assembly, "", "PlainStringAttribute");
+		PostGetAttribute = Lookup (binding_assembly, "", "PostGetAttribute");
+		PostSnippetAttribute = Lookup (binding_assembly, "", "PostSnippetAttribute");
+		PreSnippetAttribute = Lookup (binding_assembly, "", "PreSnippetAttribute");
+		ProbePresenceAttribute = Lookup (binding_assembly, "", "ProbePresenceAttribute");
+		PrologueSnippetAttribute = Lookup (binding_assembly, "", "PrologueSnippetAttribute");
+		ProtectedAttribute = Lookup (binding_assembly, "", "ProtectedAttribute");
+		ProtocolAttribute = Lookup (platform_assembly, "Foundation", "ProtocolAttribute");
+		ProtocolizeAttribute = Lookup (binding_assembly, "", "ProtocolizeAttribute");
+		ProxyAttribute = Lookup (binding_assembly, "", "ProxyAttribute");
+		RegisterAttribute = Lookup (platform_assembly, "Foundation", "RegisterAttribute");
+		ReleaseAttribute = Lookup (binding_assembly, "", "ReleaseAttribute");
+		RetainAttribute = Lookup (binding_assembly, "", "RetainAttribute");
+		SealedAttribute = Lookup (binding_assembly, "", "SealedAttribute");
+		StaticAttribute = Lookup (binding_assembly, "", "StaticAttribute");
+		StrongDictionaryAttribute = Lookup (binding_assembly, "", "StrongDictionaryAttribute");
+		SyntheticAttribute = Lookup (binding_assembly, "", "SyntheticAttribute");
+		TargetAttribute = Lookup (binding_assembly, "", "TargetAttribute");
+		ThreadSafeAttribute = Lookup (binding_assembly, "", "ThreadSafeAttribute");
+		TransientAttribute = Lookup (binding_assembly, "", "TransientAttribute");
+		UnifiedInternalAttribute = Lookup (binding_assembly, "", "UnifiedInternalAttribute");
+		WrapAttribute = Lookup (binding_assembly, "", "WrapAttribute");
+		ZeroCopyStringsAttribute = Lookup (binding_assembly, "", "ZeroCopyStringsAttribute");
 
 		/* Different binding types */
 
-		DictionaryContainerType = typeof (DictionaryContainerType);
+		DictionaryContainerType = Lookup (platform_assembly, "Foundation", "DictionaryContainer");
 
 		if (Frameworks.HaveAddressBook) {
 			ABAddressBook = Lookup (platform_assembly, "AddressBook", "ABAddressBook");
@@ -351,24 +370,24 @@ public static class TypeManager {
 			AudioUnit = Lookup (platform_assembly, "AudioUnit", "AudioUnit");
 			AURenderEventEnumerator = Lookup (platform_assembly, "AudioUnit", "AURenderEventEnumerator");
 		}
-		AVCaptureWhiteBalanceGains = typeof (XamCore.AVFoundation.AVCaptureWhiteBalanceGains);
+		AVCaptureWhiteBalanceGains = Lookup (platform_assembly, "AVFoundation", "AVCaptureWhiteBalanceGains");
 		if (Frameworks.HaveCoreAnimation)
 			CATransform3D = Lookup (platform_assembly, "CoreAnimation", "CATransform3D");
 
-		CFRunLoop = typeof (CFRunLoop);
-		CGAffineTransform = typeof (CGAffineTransform);
-		CGColor = typeof (CGColor);
-		CGColorSpace = typeof (CGColorSpace);
-		CGContext = typeof (CGContext);
-		CGGradient = typeof (CGGradient);
-		CGImage = typeof (CGImage);
-		CGLayer = typeof (CGLayer);
+		CFRunLoop = Lookup (platform_assembly, "CoreFoundation", "CFRunLoop");
+		CGAffineTransform = Lookup (platform_assembly, "CoreGraphics", "CGAffineTransform");
+		CGColor = Lookup (platform_assembly, "CoreGraphics", "CGColor");
+		CGColorSpace = Lookup (platform_assembly, "CoreGraphics", "CGColorSpace");
+		CGContext = Lookup (platform_assembly, "CoreGraphics", "CGContext");
+		CGGradient = Lookup (platform_assembly, "CoreGraphics", "CGGradient");
+		CGImage = Lookup (platform_assembly, "CoreGraphics", "CGImage");
+		CGLayer = Lookup (platform_assembly, "CoreGraphics", "CGLayer");
 		if (Frameworks.HaveOpenGL) {
 			CGLContext = Lookup (platform_assembly, "OpenGL", "CGLContext");
 			CGLPixelFormat = Lookup (platform_assembly, "OpenGL", "CGLPixelFormat");
 		}
-		CGPath = typeof (CGPath);
-		CGVector = typeof (CGVector);
+		CGPath = Lookup (platform_assembly, "CoreGraphics", "CGPath");
+		CGVector = Lookup (platform_assembly, "CoreGraphics", "CGVector");
 		if (Frameworks.HaveCoreLocation)
 			CLLocationCoordinate2D = Lookup (platform_assembly, "CoreLocation", "CLLocationCoordinate2D");
 		if (Frameworks.HaveCoreMedia) {
@@ -387,7 +406,7 @@ public static class TypeManager {
 			CVPixelBuffer = Lookup (platform_assembly, "CoreVideo", "CVPixelBuffer");
 			CVPixelBufferPool = Lookup (platform_assembly, "CoreVideo", "CVPixelBufferPool");
 		}
-		DispatchQueue = typeof (DispatchQueue);
+		DispatchQueue = Lookup (platform_assembly, "CoreFoundation", "DispatchQueue");
 		if (Frameworks.HaveCoreMidi)
 			MidiEndpoint = Lookup (platform_assembly, "CoreMidi", "MidiEndpoint");
 		if (Frameworks.HaveMapKit)
@@ -395,16 +414,16 @@ public static class TypeManager {
 		if (Frameworks.HaveMediaToolbox)
 			MTAudioProcessingTap = Lookup (platform_assembly, "MediaToolbox", "MTAudioProcessingTap");
 		NSNumber = Lookup (BindingTouch.BindingThirdParty ? platform_assembly : api_assembly, "Foundation", "NSNumber");
-		NSRange = typeof (NSRange);
-		NSString = typeof (NSString);
+		NSRange = Lookup (platform_assembly, "Foundation", "NSRange");
+		NSString = Lookup (platform_assembly, "Foundation", "NSString");
 		NSValue = Lookup (BindingTouch.BindingThirdParty ? platform_assembly : api_assembly, "Foundation", "NSValue");
-		NSZone = typeof (NSZone);
-		SCNVector3 = typeof (XamCore.SceneKit.SCNVector3);
-		SCNVector4 = typeof (XamCore.SceneKit.SCNVector4);
-		SCNMatrix4 = typeof (XamCore.SceneKit.SCNMatrix4);
-		SecAccessControl = typeof (SecAccessControl);
-		SecIdentity = typeof (SecIdentity);
-		SecTrust = typeof (SecTrust);
+		NSZone = Lookup (platform_assembly, "Foundation", "NSZone");
+		SCNVector3 = Lookup (platform_assembly, "SceneKit", "SCNVector3");
+		SCNVector4 = Lookup (platform_assembly, "SceneKit", "SCNVector4");
+		SCNMatrix4 = Lookup (platform_assembly, "SceneKit", "SCNMatrix4");
+		SecAccessControl = Lookup (platform_assembly, "Security", "SecAccessControl");
+		SecIdentity = Lookup (platform_assembly, "Security", "SecIdentity");
+		SecTrust = Lookup (platform_assembly, "Security", "SecTrust");
 		if (Frameworks.HaveUIKit) {
 			UIOffset = Lookup (platform_assembly, "UIKit", "UIOffset");
 			UIEdgeInsets = Lookup (platform_assembly, "UIKit", "UIEdgeInsets");


### PR DESCRIPTION
Replace all `typeof` expressions with equivalent TypeManager fields, since
`typeof` expressions won't work correctly when we switch to IKVM instead of
reflection.

Generator diff: https://gist.github.com/rolfbjarne/066dbf08eaf0ece56bc9256c5e12c5b9