### PR TITLE
[coretext] Use [MarshalAs (UnmanagedType.I1)] on `bool` parameters used with native code. Fixes #52162

### DIFF
--- a/src/CoreText/CTLine.cs
+++ b/src/CoreText/CTLine.cs
@@ -233,7 +233,7 @@ namespace XamCore.CoreText {
 		}
 
 		public delegate void CaretEdgeEnumerator (double offset, nint charIndex, bool leadingEdge, ref bool stop);
-		unsafe delegate void CaretEdgeEnumeratorProxy (IntPtr block, double offset, nint charIndex, bool leadingEdge, ref bool stop);
+		unsafe delegate void CaretEdgeEnumeratorProxy (IntPtr block, double offset, nint charIndex, [MarshalAs (UnmanagedType.I1)] bool leadingEdge, [MarshalAs (UnmanagedType.I1)] ref bool stop);
 		
 		[iOS (9,0)][Mac (10,11)]
 		[DllImport (Constants.CoreTextLibrary)]

--- a/tests/monotouch-test/CoreText/CTLineTest.cs
+++ b/tests/monotouch-test/CoreText/CTLineTest.cs
@@ -12,14 +12,12 @@
 using System;
 #if XAMCORE_2_0
 using Foundation;
-using ObjCRuntime;
 using UIKit;
 using CoreGraphics;
 using CoreText;
 #else
 using MonoTouch.CoreGraphics;
 using MonoTouch.CoreText;
-using MonoTouch.ObjCRuntime;
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
 #endif
@@ -57,11 +55,6 @@ namespace MonoTouchFixtures.CoreText
 
 			var attributedString = new NSAttributedString ("Hello world.\nWoohooo!\nThere", sa);
 
-			// there's a bug in iOS 10.3 (beta1 and 2 at least) where a crash happens, only on i386, if execution continue
-			// this works fine with earlier simulator (on Xcode 8.3) or on devices (with 10.3) with 32bits builds
-			if (TestRuntime.CheckSDKVersion (8, 3) && (Runtime.Arch == Arch.SIMULATOR) && (IntPtr.Size == 4))
-				return;
-			
 			var line = new CTLine (attributedString);
 			bool executed = false;
 #if XAMCORE_2_0


### PR DESCRIPTION
iOS 10.3 simulator (i386 only) will crash executing CTLineTests.
EnumerateCaretOffsets test case. This was not a problem with older SDK so
the code likely changed (but the issue was in our code)