### PR TITLE
Add Intents and VideoToolbox to registrar and fix version check

### DIFF
--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -17,30 +17,35 @@ public class Frameworks : Dictionary <string, Framework>
 {
 	public void Add (string @namespace, int major_version)
 	{
-		Add (@namespace, @namespace, major_version, 0, 0);
+		Add (@namespace, @namespace, new Version (major_version, 0));
 	}
 
 	public void Add (string @namespace, string framework, int major_version)
 	{
-		Add (@namespace, framework, major_version, 0, 0);
+		Add (@namespace, framework, new Version (major_version, 0));
 	}
 
 	public void Add (string @namespace, int major_version, int minor_version)
 	{
-		Add (@namespace, @namespace, major_version, minor_version, 0);
+		Add (@namespace, @namespace, new Version (major_version, minor_version));
 	}
 
 	public void Add (string @namespace, string framework, int major_version, int minor_version)
 	{
-		Add(@namespace, framework, major_version, minor_version, 0);
+		Add (@namespace, framework, new Version (major_version, minor_version));
 	}
 
 	public void Add (string @namespace, string framework, int major_version, int minor_version, int build_version)
 	{
+		Add (@namespace, framework, new Version (major_version, minor_version, build_version));
+	}
+
+	public void Add (string @namespace, string framework, Version version)
+	{
 		var fr = new Framework () {
 			Namespace = Driver.IsUnified ? @namespace : XamCore.Registrar.Registrar.CompatNamespace + "." + @namespace,
 			Name = framework,
-			Version = new Version (major_version, minor_version, build_version)
+			Version = version
 		};
 		base.Add (fr.Namespace, fr);
 	}
@@ -274,6 +279,7 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "SceneKit", "SceneKit", 3 },
 					{ "SpriteKit", "SpriteKit", 3 },
 					{ "UserNotifications", "UserNotifications", 3 },
+					{ "Intents", "Intents", 3,2 },
 				};
 			}
 			return watch_frameworks;
@@ -337,6 +343,7 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "ReplayKit", "ReplayKit", 10 },
 					{ "UserNotifications", "UserNotifications", 10 },
 					{ "VideoSubscriberAccount", "VideoSubscriberAccount", 10 },
+					{ "VideoToolbox", "VideoToolbox", 10,2 },
 				};
 			}
 			return tvos_frameworks;

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -1678,15 +1678,14 @@ namespace XamCore.Registrar {
 					if (!reported_frameworks.Contains (framework.Name)) {
 						exceptions.Add (ErrorHelper.CreateError (4134, 
 #if MMP
-							"Your application is using the '{0}' framework, which isn't included in the MacOS SDK you're using to build your app (this framework was introduced in OSX {2}, while you're building with the MacOS {1} SDK.) " +
+							"Your application is using the '{0}' framework, which isn't included in the {3} SDK you're using to build your app (this framework was introduced in {3} {2}, while you're building with the {3} {1} SDK.) " +
 							"This configuration is not supported with the static registrar (pass --registrar:dynamic as an additional mmp argument in your project's Mac Build option to select). " +
 							"Alternatively select a newer SDK in your app's Mac Build options.",
 #else
-							"Your application is using the '{0}' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS {2}, while you're building with the iOS {1} SDK.) " +
-							"This configuration is only supported with the legacy registrar (pass --registrar:legacy as an additional mtouch argument in your project's iOS Build option to select). " +
-							"Alternatively select a newer SDK in your app's iOS Build options.",
+							"Your application is using the '{0}' framework, which isn't included in the {3} SDK you're using to build your app (this framework was introduced in {3} {2}, while you're building with the {3} {1} SDK.) " +
+							"Please select a newer SDK in your app's {3} Build options.",
 #endif
-							framework.Name, Driver.SDKVersion, framework.Version));
+							framework.Name, Driver.SDKVersion, framework.Version, App.PlatformName));
 						reported_frameworks.Add (framework.Name);
 					}
 					return;


### PR DESCRIPTION
A fix (thanks Rolf!) in how we do SDK version checks is needed
because for some reason `new Version (3, 2, 0)` isn't the same to
`new Version (3, 2)` and we end up with a MT4134 when building the
watchOS static registrar.