### PR TITLE
[generator] Don't specify platform-specific conditional compilation symbols.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -105,7 +105,6 @@ $(IOS_BUILD_DIR)/$(1)/core.dll: $$(IOS_PMCS) $$(IOS_CORE_SOURCES) frameworks.sou
 # generator.exe
 $(IOS_BUILD_DIR)/$(1)/generator.exe: $$(GENERATOR_SOURCES) $(IOS_BUILD_DIR)/$(1)/core.dll
 	$$(call Q_PROF_PMCS,ios/$(1)) PMCS_PROFILE=$(3) $$(IOS_PMCS) -out:$$@ -debug -unsafe \
-		$$(IOS_DEFINES) \
 		-r:$(IOS_BUILD_DIR)/$(1)/core.dll \
 		$$(GENERATOR_DEFINES)             \
 		$$(GENERATOR_SOURCES)
@@ -408,7 +407,6 @@ MAC_WARNINGS_TO_FIX := $(MAC_WARNINGS_TO_FIX),4014
 
 MAC_COMMON_DEFINES = -define:NET_2_0,XAMARIN_MAC,MONOMAC
 MAC_BOOTSTRAP_DEFINES = $(MAC_COMMON_DEFINES),COREBUILD
-MAC_GENERATOR_DEFINES = $(MAC_COMMON_DEFINES) $(GENERATOR_DEFINES)
 
 SN_KEY = $(PRODUCT_KEY_PATH)
 
@@ -482,9 +480,8 @@ $(MAC_BUILD_DIR)/$(1)/core.dll: $(MAC_BUILD_DIR)/$(1)/pmcs $(MAC_CORE_SOURCES) f
 $(MAC_BUILD_DIR)/$(1)/_bmac.exe: $(MAC_BUILD_DIR)/$(1)/core.dll $(MAC_APIS) $(GENERATOR_SOURCES)
 	$$(call Q_PROF_PMCS,mac/$(1)) PMCS_PROFILE=$(6) $(MAC_BUILD_DIR)/$(1)/pmcs \
 		-out:$$@ -debug -unsafe \
-		$(MAC_GENERATOR_DEFINES) \
+		$(GENERATOR_DEFINES) \
 		-r:$$(@D)/core.dll \
-		$(7) \
 		$(GENERATOR_SOURCES)
 
 $(MAC_BUILD_DIR)/$(1)/generated-sources: $(MAC_BUILD_DIR)/$(1)/_bmac.exe $(MAC_APIS)
@@ -506,7 +503,7 @@ $(MAC_BUILD_DIR)/$(1)/generated-sources: $(MAC_BUILD_DIR)/$(1)/_bmac.exe $(MAC_A
 endef
 
 $(eval $(call MAC_GENERATOR_template,compat,--ns=MonoMac.ObjCRuntime,-r:/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5/System.Drawing.dll,,$(SYSTEM_MONO),compat-mac))
-$(eval $(call MAC_GENERATOR_template,full,--ns=ObjCRuntime,-d:NO_SYSTEM_DRAWING,,$(SYSTEM_MONO),full,-d:NO_SYSTEM_DRAWING))
+$(eval $(call MAC_GENERATOR_template,full,--ns=ObjCRuntime,-d:NO_SYSTEM_DRAWING,,$(SYSTEM_MONO),full))
 $(eval $(call MAC_GENERATOR_template,mobile,--ns=ObjCRuntime,$(SHARED_SYSTEM_DRAWING_SOURCES),-nostdlib -r:mscorlib.dll -lib:$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/Xamarin.Mac,$(TOP)/builds/install/mono-mac64,mobile))
 
 define MAC_TARGETS_template
@@ -737,7 +734,6 @@ $(WATCH_BUILD_DIR)/watch/core.dll: $(WATCH_PMCS) $(WATCHOS_CORE_SOURCES) framewo
 $(WATCH_BUILD_DIR)/watch/generator.exe: $(GENERATOR_SOURCES) $(WATCH_BUILD_DIR)/watch/core.dll
 	$(call Q_PROF_PMCS,watch) PMCS_PROFILE=watch $(WATCH_PMCS) -out:$@ -debug -unsafe \
 		-r:$(WATCH_BUILD_DIR)/watch/core.dll \
-		$(WATCH_DEFINES)                      \
 		$(GENERATOR_SOURCES)                  \
 		$(GENERATOR_DEFINES)                  \
 
@@ -936,7 +932,6 @@ $(TVOS_BUILD_DIR)/tvos/core.dll: $(TVOS_BUILD_DIR)/pmcs $(TVOS_CORE_SOURCES) fra
 $(TVOS_BUILD_DIR)/tvos/generator.exe: $(GENERATOR_SOURCES) $(TVOS_BUILD_DIR)/tvos/core.dll
 	$(call Q_PROF_PMCS,tvos) PMCS_PROFILE=tvos $(TVOS_BUILD_DIR)/pmcs --keep -out:$@ -debug -unsafe \
 		-r:$(TVOS_BUILD_DIR)/tvos/core.dll \
-		$(TVOS_DEFINES)                      \
 		$(GENERATOR_SOURCES)                  \
 		$(GENERATOR_DEFINES)                  \
 

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -40,10 +40,10 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/%: %.in | $(IOS_DESTDIR)$(MONOTOUCH_PREFIX
 	$(Q) chmod +x $@
 
 $(IOS_BUILD_DIR)/btouch.exe: $(IOS_BUILD_DIR)/compat/monotouch.dll $(GENERATOR_SOURCES) Makefile.generator
-	$(call Q_PROF_PMCS,ios/compat) $(SYSTEM_MONO) --debug $(PMCS_EXE) -profile:"$(TOP)/src/pmcs-profiles/compat-ios" -compiler:$(IOS_CSC) -global-replace:"^XamCore=MonoTouch" -debug $(GENERATOR_DEFINES) -define:IOS,__IOS__             -out:$@ $(GENERATOR_SOURCES) -r:$<
+	$(call Q_PROF_PMCS,ios/compat) $(SYSTEM_MONO) --debug $(PMCS_EXE) -profile:"$(TOP)/src/pmcs-profiles/compat-ios" -compiler:$(IOS_CSC) -global-replace:"^XamCore=MonoTouch" -debug $(GENERATOR_DEFINES) -out:$@ $(GENERATOR_SOURCES) -r:$<
 
 $(IOS_BUILD_DIR)/btouch-native.exe: $(IOS_BUILD_DIR)/reference/Xamarin.iOS.dll $(GENERATOR_SOURCES) Makefile.generator
-	$(call Q_PROF_PMCS,ios/native) $(SYSTEM_MONO) --debug $(PMCS_EXE) -profile:"$(TOP)/src/pmcs-profiles/native"     -compiler:$(IOS_CSC) -global-replace:"^XamCore.="         -debug $(GENERATOR_DEFINES) -define:IOS,__IOS__,XAMCORE_2_0,__UNIFIED__ -out:$@ $(GENERATOR_SOURCES) -r:$<
+	$(call Q_PROF_PMCS,ios/native) $(SYSTEM_MONO) --debug $(PMCS_EXE) -profile:"$(TOP)/src/pmcs-profiles/native"     -compiler:$(IOS_CSC) -global-replace:"^XamCore.="         -debug $(GENERATOR_DEFINES) -out:$@ $(GENERATOR_SOURCES) -r:$<
 
 $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/btouch/%.exe: $(IOS_BUILD_DIR)/%.exe | $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/btouch
 	$(Q) install -m 0755 $< $@
@@ -65,7 +65,7 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/bwatch: Makefile.generator
 	$(Q) chmod +x $@
 
 $(WATCH_BUILD_DIR)/bwatch.exe: $(WATCH_BUILD_DIR)/watch-32/Xamarin.WatchOS.dll $(GENERATOR_SOURCES) Makefile.generator
-	$(call Q_PROF_PMCS,watch) $(SYSTEM_MONO) --debug $(PMCS_EXE) -profile:"$(TOP)/src/pmcs-profiles/watch" -compiler:$(SYSTEM_MCS) -nostdlib -r:mscorlib -lib:$(WATCH_LIBDIR)/repl -global-replace:"^XamCore.=" -debug $(GENERATOR_DEFINES) -define:XAMCORE_2_0,XAMCORE_3_0,__UNIFIED__ -d:WATCH -d:__WATCHOS__ -out:$@ $(GENERATOR_SOURCES) -r:$<
+	$(call Q_PROF_PMCS,watch) $(SYSTEM_MONO) --debug $(PMCS_EXE) -profile:"$(TOP)/src/pmcs-profiles/watch" -compiler:$(SYSTEM_MCS) -nostdlib -r:mscorlib -lib:$(WATCH_LIBDIR)/repl -global-replace:"^XamCore.=" -debug $(GENERATOR_DEFINES) -out:$@ $(GENERATOR_SOURCES) -r:$<
 
 $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bwatch/%.exe: $(WATCH_BUILD_DIR)/%.exe | $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bwatch
 	$(Q) install -m 0755 $< $@
@@ -87,7 +87,7 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/btv: Makefile.generator
 	$(Q) chmod +x $@
 
 $(TVOS_BUILD_DIR)/btv.exe: $(TVOS_BUILD_DIR)/tvos-64/Xamarin.TVOS.dll $(GENERATOR_SOURCES) Makefile.generator
-	$(call Q_PROF_PMCS,tvos) $(SYSTEM_MONO) --debug $(PMCS_EXE) -profile:"$(TOP)/src/pmcs-profiles/tvos" -compiler:$(SYSTEM_MCS) -nostdlib -r:mscorlib.dll -lib:$(TVOS_LIBDIR)/repl -global-replace:"^XamCore.=" -debug $(GENERATOR_DEFINES) -define:XAMCORE_2_0,XAMCORE_3_0,__UNIFIED__ -d:TVOS -d:__TVOS__ -out:$@ $(GENERATOR_SOURCES) -r:$<
+	$(call Q_PROF_PMCS,tvos) $(SYSTEM_MONO) --debug $(PMCS_EXE) -profile:"$(TOP)/src/pmcs-profiles/tvos" -compiler:$(SYSTEM_MCS) -nostdlib -r:mscorlib.dll -lib:$(TVOS_LIBDIR)/repl -global-replace:"^XamCore.=" -debug $(GENERATOR_DEFINES) -out:$@ $(GENERATOR_SOURCES) -r:$<
 
 $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/btv/%.exe: $(TVOS_BUILD_DIR)/%.exe | $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/btv
 	$(Q) install -m 0755 $< $@
@@ -107,10 +107,10 @@ MAC_TARGETS += \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bmac/bmac-compat.exe     \
 
 $(MAC_BUILD_DIR)/bmac-%.exe: $(MAC_BUILD_DIR)/%-32/Xamarin.Mac.dll $(GENERATOR_SOURCES) $(SN_KEY) Makefile.generator
-	$(call Q_PROF_PMCS,mac/full)   PMCS_PROFILE=$*         $(MAC_BUILD_DIR)/$*/pmcs     -out:$@ -debug $(GENERATOR_DEFINES) -unsafe $(MAC_GENERATOR_DEFINES) -keyfile:$(SN_KEY) -r:$< $(GENERATOR_SOURCES)
+	$(call Q_PROF_PMCS,mac/full)   PMCS_PROFILE=$*         $(MAC_BUILD_DIR)/$*/pmcs     -out:$@ -debug $(GENERATOR_DEFINES) -unsafe -keyfile:$(SN_KEY) -r:$< $(GENERATOR_SOURCES)
 
 $(MAC_BUILD_DIR)/bmac-compat.exe: $(MAC_BUILD_DIR)/compat/XamMac.dll $(GENERATOR_SOURCES) $(SN_KEY) Makefile.generator
-	$(call Q_PROF_PMCS,mac/compat) PMCS_PROFILE=compat-mac $(MAC_BUILD_DIR)/compat/pmcs -out:$@ -debug $(GENERATOR_DEFINES) -unsafe $(MAC_GENERATOR_DEFINES) -keyfile:$(SN_KEY) -r:$< $(GENERATOR_SOURCES) -r:System.Drawing
+	$(call Q_PROF_PMCS,mac/compat) PMCS_PROFILE=compat-mac $(MAC_BUILD_DIR)/compat/pmcs -out:$@ -debug $(GENERATOR_DEFINES) -unsafe -keyfile:$(SN_KEY) -r:$< $(GENERATOR_SOURCES) -r:System.Drawing
 
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/bmac: bmac | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin
 	$(Q) install -m 0755 $< $@


### PR DESCRIPTION
All the platform-specific conditional compilation symbols are unusued, so we
don't need to define them anymore.

Generator diff: https://gist.github.com/rolfbjarne/865b4ed20648614ceff04a870a3d0786