### PR TITLE
[build] Bump to use Xcode8.3 beta 3

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -49,8 +49,8 @@ IOS_PACKAGE_UPDATE_ID=$(shell printf "2%02d%02d%02d%03d" $(IOS_PACKAGE_VERSION_M
 
 # Xcode 8.3 beta 2
 XCODE_VERSION=8.3
-XCODE_URL=http://xamarin-storage/bot-provisioning/Xcode_8.3_beta_2.xip
-XCODE_DEVELOPER_ROOT=/Applications/Xcode83-beta2.app/Contents/Developer
+XCODE_URL=http://xamarin-storage/bot-provisioning/Xcode_8.3_beta_3.xip
+XCODE_DEVELOPER_ROOT=/Applications/Xcode83-beta3.app/Contents/Developer
 
 # Minimum Mono version
 MIN_MONO_VERSION=4.6.1.5
@@ -58,7 +58,7 @@ MAX_MONO_VERSION=4.8.0.999
 MIN_MONO_URL=http://download.xamarin.com/MonoFrameworkMDK/Macx86/MonoFramework-MDK-4.6.1.5.macos10.xamarin.universal.pkg
 
 # Minimum Xamarin Studio version
-MIN_XAMARIN_STUDIO_URL=https://files.xamarin.com/~rolf/XamarinStudio-6.1.0.4373.dmg
+MIN_XAMARIN_STUDIO_URL=https://bosstoragemirror.blob.core.windows.net/wrench/monodevelop-lion-cycle8-mlaunch-xcode83-fix-clone/77/776f2e6f2c16460204aa92f566caacf2da49259c/XamarinStudio-6.1.5.3.dmg
 MIN_XAMARIN_STUDIO_VERSION=6.1.0.4373
 MAX_XAMARIN_STUDIO_VERSION=6.2.0.9999
 


### PR DESCRIPTION
Also update XS URL to something available (not 404).

Note: there will be some test failures (e.g. introspection for Intents) until bindings are updated for beta 3.