### PR TITLE
[homekit] Update for xcode8.3 beta 3 (breaking change)

### DIFF
--- a/src/HomeKit/HMEnums.cs
+++ b/src/HomeKit/HMEnums.cs
@@ -908,8 +908,8 @@ namespace XamCore.HomeKit {
 	[Watch (3,0), TV (10,0), iOS (10,0)]
 	[Native]
 	public enum HMCharacteristicValueContactState : nint {
-		None = 0,
-		Detected
+		Detected = 0,
+		None,
 	}
 
 	[Watch (3,0), TV (10,0), iOS (10,0)]


### PR DESCRIPTION
Apple swapped None and Detected in HMCharacteristicValueContactState.
The Apple dev forums and stackoverflow are silent about this change.
This enum isn't used by any other HomeKit method and it's questionable how many people
are using HomeKit at all.

Given that, we decided to exceptionally do a breaking change for this enum.
The symbols remain the same only the values change.
Only the people using HomeKit and this particular enum should be affected.