### PR TITLE
[generator] Properly determine if selectors are inlined. Fixes #52646.

### DIFF
--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -140,7 +140,7 @@ class BindingTouch {
 		bool external = false;
 		bool public_mode = true;
 		bool nostdlib = false;
-		bool inline_selectors = Unified && CurrentPlatform != PlatformName.MacOSX;
+		bool? inline_selectors = null;
 		List<string> sources;
 		var resources = new List<string> ();
 		var linkwith = new List<string> ();
@@ -422,7 +422,7 @@ class BindingTouch {
 				BindThirdPartyLibrary = BindingThirdParty,
 				BaseDir = basedir != null ? basedir : tmpdir,
 				ZeroCopyStrings = zero_copy,
-				InlineSelectors = inline_selectors,
+				InlineSelectors = inline_selectors ?? (Unified && CurrentPlatform != PlatformName.MacOSX),
 			};
 
 			if (!Unified && !BindingThirdParty) {


### PR DESCRIPTION
Properly determine if selectors are inlined by not deciding anything until we
have the information required to make a correct decision. Since we're now
determining the target platform using the command-line argument, we can't use
the corresponding variables until after the command-line arguments have been
parsed.

This fixes several generator tests when those tests are built using XI/Unified
(so new new tests are needed for this).

https://bugzilla.xamarin.com/show_bug.cgi?id=52646