### PR TITLE
[Mac] Fix DefaultCtorAllowed test for NSKeyedArchiver

### DIFF
--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -41,8 +41,6 @@ namespace Introspection {
 
 		string instance_type_name;
 
-		Selector finishEncoding = new Selector ("finishEncoding");
-
 		/// <summary>
 		/// Gets or sets a value indicating whether this test fixture will log untested types.
 		/// </summary>
@@ -149,8 +147,7 @@ namespace Introspection {
 		{
 			//***** ApiCtorInitTest.DefaultCtorAllowed
 			//2017-01-23 15:52:09.762 introspection[4084:16658258] *** -[NSKeyedArchiver dealloc]: warning: NSKeyedArchiver deallocated without having had -finishEncoding called on it.
-			if (obj.RespondsToSelector (finishEncoding))
-				obj.PerformSelector (finishEncoding);
+			(obj as NSKeyedArchiver)?.FinishEncoding ();
 
 			obj.Dispose ();
 		}

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -41,6 +41,8 @@ namespace Introspection {
 
 		string instance_type_name;
 
+		Selector finishEncoding = new Selector ("finishEncoding");
+
 		/// <summary>
 		/// Gets or sets a value indicating whether this test fixture will log untested types.
 		/// </summary>
@@ -145,6 +147,11 @@ namespace Introspection {
 		/// <param name="type">Type of the object, to be used if special logic is required.</param>
 		protected virtual void Dispose (NSObject obj, Type type)
 		{
+			//***** ApiCtorInitTest.DefaultCtorAllowed
+			//2017-01-23 15:52:09.762 introspection[4084:16658258] *** -[NSKeyedArchiver dealloc]: warning: NSKeyedArchiver deallocated without having had -finishEncoding called on it.
+			if (obj.RespondsToSelector (finishEncoding))
+				obj.PerformSelector (finishEncoding);
+
 			obj.Dispose ();
 		}
 


### PR DESCRIPTION
NSKeyedArchiver needs have finishEconding called before disposing.  This fix allows the same to be done for any future types that might have the same issue.