### PR TITLE
[build] Bump XI version to 10.7.x

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -40,7 +40,7 @@ IOS_PRODUCT=Xamarin.iOS
 IOS_PACKAGE_NAME=Xamarin.iOS
 IOS_PACKAGE_NAME_LOWER=$(shell echo $(IOS_PACKAGE_NAME) | tr "[:upper:]" "[:lower:]")
 # NEVER customize IOS_PACKAGE_VERSION itself, other parts (mtouch, web updater) are using the IOS_PACKAGE_VERSION_* variables
-IOS_PACKAGE_VERSION=10.5.0.$(IOS_COMMIT_DISTANCE)
+IOS_PACKAGE_VERSION=10.7.0.$(IOS_COMMIT_DISTANCE)
 IOS_PACKAGE_VERSION_MAJOR=$(word 1, $(subst ., ,$(IOS_PACKAGE_VERSION)))
 IOS_PACKAGE_VERSION_MINOR=$(word 2, $(subst ., ,$(IOS_PACKAGE_VERSION)))
 IOS_PACKAGE_VERSION_REV=$(word 3, $(subst ., ,$(IOS_PACKAGE_VERSION)))


### PR DESCRIPTION
Cycle 9 (10.4) is now out and I'm fairly certain we'll see Xcode8.3 out
in March, so that will become 10.6 (once stable), making our `15.1`
target to be 10.8, again when stable.

XM is not affected as it gets the API updates on the next cycle/train.