### PR TITLE
[tests][intro] Add validation for methods decorated with [MonoPInvokeCallback]

### DIFF
--- a/src/MonoPInvokeCallbackAttribute.cs
+++ b/src/MonoPInvokeCallbackAttribute.cs
@@ -30,7 +30,12 @@ namespace XamCore {
 
 	[AttributeUsage (AttributeTargets.Method)]
 	public sealed class MonoPInvokeCallbackAttribute : Attribute {
-			public MonoPInvokeCallbackAttribute (Type t) {}
+		public MonoPInvokeCallbackAttribute (Type t)
+		{
+			DelegateType = t;
+		}
+
+		public Type DelegateType { get; set; }
 	}
 }
 

--- a/tests/introspection/iOS/iOSApiPInvokeTest.cs
+++ b/tests/introspection/iOS/iOSApiPInvokeTest.cs
@@ -107,6 +107,19 @@ namespace Introspection {
 			Assert.AreEqual (0, Errors, "{0} errors found in {1} native delegate validated: {2}", Errors, n, string.Join (", ", failed_api));
 		}
 
+		protected override bool Skip (MethodInfo methodInfo)
+		{
+			// ignore until https://bugzilla.xamarin.com/show_bug.cgi?id=53058 is fixed
+			if (methodInfo.DeclaringType.DeclaringType?.Name == "Trampolines") {
+				switch (methodInfo.ReturnType.Name) {
+				case "MPRemoteCommandHandlerStatus":
+				case "NSComparisonResult":
+					return true;
+				}
+			}
+			return base.Skip (methodInfo);
+		}
+
 		[Test]
 		public void MonoPInvokeCallback ()
 		{

--- a/tests/introspection/iOS/iOSApiPInvokeTest.cs
+++ b/tests/introspection/iOS/iOSApiPInvokeTest.cs
@@ -108,6 +108,30 @@ namespace Introspection {
 		}
 
 		[Test]
+		public void MonoPInvokeCallback ()
+		{
+			var pinvokeCallbacks = from type in Assembly.GetTypes () where !Skip (type)
+				from mi in type.GetMethods (BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
+				let attr = mi.GetCustomAttribute<MonoPInvokeCallbackAttribute> ()
+				where attr != null && !Skip (mi)
+				select mi;
+
+			var failed_api = new List<string> ();
+			Errors = 0;
+			int c = 0, n = 0;
+			foreach (var mi in pinvokeCallbacks) {
+				if (LogProgress)
+					Console.WriteLine ("{0}. {1}", c++, mi);
+
+				var attr = mi.GetCustomAttribute<MonoPInvokeCallbackAttribute> ();
+				foreach (var m in attr.DelegateType.GetMethods ())
+					CheckSignature (m);
+				n++;
+			}
+			Assert.AreEqual (0, Errors, "{0} errors found in {1} native delegate validated: {2}", Errors, n, string.Join (", ", failed_api));
+		}
+
+		[Test]
 		public void NUnitLite ()
 		{
 			var a = typeof (TestAttribute).Assembly;


### PR DESCRIPTION
Presently we're looking if enums decorated with [Native] are used, just
like we do for p/invokes and delegate types decorated with a
[MonoNativeFunctionWrapper] attribute.

Testing properly required to add a property to MonoPInvokeCallbackAttribute
so we can get back the type given as it's argument.