### PR TITLE
Fixes for XM 4.5 and netstandard13 and updated comments

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -54,10 +54,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<UsingTask TaskName="Microsoft.Build.Tasks.RemoveDir" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
 	<UsingTask TaskName="Microsoft.Build.Tasks.Touch" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
 
-	<PropertyGroup>
-		<IsXBuild Condition="'$(MSBuildRuntimeVersion)' == ''">true</IsXBuild>
-	</PropertyGroup>
-
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.Common.props"
 			Condition="'$(_XamarinCommonPropsHasBeenImported)' != 'true'" />
 
@@ -726,6 +722,8 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_ResolveAppExtensionReferences" DependsOnTargets="_SplitAppExtensionReferencesByExistent">
 		<PropertyGroup>
+			<IsXBuild Condition="'$(MSBuildRuntimeVersion)' == ''">true</IsXBuild>
+
 			<!-- When building a .sln with xbuild or building from IDE, the referenced projects are already built.  -->
 			<_BuildReferencedExtensionProjects Condition="'$(IsXBuild)' == 'true' and '$(BuildingSolutionFile)' != 'true' and '$(BuildingInsideVisualStudio)' != 'true'">true</_BuildReferencedExtensionProjects>
 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -54,6 +54,10 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<UsingTask TaskName="Microsoft.Build.Tasks.RemoveDir" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
 	<UsingTask TaskName="Microsoft.Build.Tasks.Touch" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
 
+	<PropertyGroup>
+		<IsXBuild Condition="'$(MSBuildRuntimeVersion)' == ''">true</IsXBuild>
+	</PropertyGroup>
+
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.Common.props"
 			Condition="'$(_XamarinCommonPropsHasBeenImported)' != 'true'" />
 
@@ -726,8 +730,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_ResolveAppExtensionReferences" DependsOnTargets="_SplitAppExtensionReferencesByExistent">
 		<PropertyGroup>
-			<IsXBuild Condition="'$(MSBuildRuntimeVersion)' == ''">true</IsXBuild>
-
 			<!-- When building a .sln with xbuild or building from IDE, the referenced projects are already built.  -->
 			<_BuildReferencedExtensionProjects Condition="'$(IsXBuild)' == 'true' and '$(BuildingSolutionFile)' != 'true' and '$(BuildingInsideVisualStudio)' != 'true'">true</_BuildReferencedExtensionProjects>
 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -72,10 +72,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<AssemblySearchPaths>$(XamarinMacFrameworkRoot)/lib/reference/full;$(XamarinMacFrameworkRoot)/lib/mono;$(AssemblySearchPaths)</AssemblySearchPaths>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(UseXamMacFullFramework)' == 'true'">
-		<AssemblySearchPaths>$(XamarinMacFrameworkRoot)/lib/mono/4.5;$(AssemblySearchPaths)</AssemblySearchPaths>
-	</PropertyGroup>
-
 	<!-- Do not resolve from the GAC under any circumstances in Mobile or XM45 -->
 	<PropertyGroup Condition="(('$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(UseXamMacFullFramework)' == 'true') Or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac') And !$(MonoBundlingExtraArgs.Contains('--allow-unsafe-gac-resolution'))" >
 		<AssemblySearchPaths>$([System.String]::Copy('$(AssemblySearchPaths)').Replace('{GAC}',''))</AssemblySearchPaths>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.XM45.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.XM45.targets
@@ -18,7 +18,7 @@ Copyright (C) 2015 Xamarin Inc. All rights reserved.
 
 	<!-- The XM 4.5 target framework (will hopefully be renamed at some point) is a bit of a strange case -->
 	<!-- It does not declare a TargetFrameworkIdentifier so it can be compatible with "Desktop" nugets -->
-	<!-- These days it could have been done with some paches to nuget and such, but now can not be changed -->
+	<!-- These days it could have been done with some patches to nuget and such, but now can not be changed -->
 	<!-- without breaking some number of user projects (forward only mutation is rather unacceptable here) -->
 	<!-- So this file uses some hacks to force xbuild/msbuild to resolve to the BCL/mscorlib/Facades -->
 	<!-- we keep inside Xamarin.Mac's framework and not the system mono ones. System mono is not -->

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.XM45.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.XM45.targets
@@ -27,7 +27,7 @@ Copyright (C) 2015 Xamarin Inc. All rights reserved.
 	<!-- XBuild specific hacks -->
 	<!-- TargetFrameworkDirectory needs to point to ours, and FrameworkPathOverride does not work in xbuild, so we must override. -->
 	<Target Name="GetFrameworkPaths"
-                Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND $(IsXBuild) == 'true'"
+                Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"
                 DependsOnTargets="$(GetFrameworkPathsDependsOn)">
                 <CreateProperty Value="$(XamarinMacFrameworkRoot)/lib/mono/4.5/">
                         <Output TaskParameter="Value" PropertyName="TargetFrameworkDirectory"/>
@@ -37,7 +37,7 @@ Copyright (C) 2015 Xamarin Inc. All rights reserved.
 	<!-- We only need to extend GetReferenceAssemblyPaths slightly, so we can force facades to only comes from our copy -->
 	<!-- but there is no invoking of a base target in msbuild. Copied from Microsoft.Common.targets with small changes -->
 	<Target Name="GetReferenceAssemblyPaths" 
-		Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND $(IsXBuild) == 'true'"
+		Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"
 		DependsOnTargets="$(GetReferenceAssemblyPathsDependsOn)">
 
 		<ItemGroup Condition="'$(ImplicitlyExpandDesignTimeFacades)' == 'true'">
@@ -53,7 +53,7 @@ Copyright (C) 2015 Xamarin Inc. All rights reserved.
 
 	<!-- This lets us bypass the standard MSBuild resolution of mscorlib, which always picks an incompatible system copy. -->
         <Target Name="_AddCorlibReference" 
-		Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND $(IsXBuild) == 'true'"
+		Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"
 		DependsOnTargets="GetReferenceAssemblyPaths">
   		<ItemGroup>
                         <_ExplicitReference Include="$(XamarinMacFrameworkRoot)/lib/mono/4.5/mscorlib.dll">

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.XM45.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.XM45.targets
@@ -15,20 +15,29 @@ Copyright (C) 2015 Xamarin Inc. All rights reserved.
 -->
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<!-- These hacks will need to be rewritten if/when we move from xbuild to msbuild. Most likely to use FrameworkPathOverride, which should hopefully work.-->
-	<!-- This lets us bypass the standard MSBuild framework resolution and point to our copy. -->
-	<!-- Without this, we'll resolve System.dll and such from the system mono  -->
+
+	<!-- The XM 4.5 target framework (will hopefully be renamed at some point) is a bit of a strange case -->
+	<!-- It does not declare a TargetFrameworkIdentifier so it can be compatible with "Desktop" nugets -->
+	<!-- These days it could have been done with some paches to nuget and such, but now can not be changed -->
+	<!-- without breaking some number of user projects (forward only mutation is rather unacceptable here) -->
+	<!-- So this file uses some hacks to force xbuild/msbuild to resolve to the BCL/mscorlib/Facades -->
+	<!-- we keep inside Xamarin.Mac's framework and not the system mono ones. System mono is not -->
+	<!-- necessarily in sync with ours and is not safe to depend upon -->
+	
+	<!-- XBuild specific hacks -->
+	<!-- TargetFrameworkDirectory needs to point to ours, and FrameworkPathOverride does not work in xbuild, so we must override. -->
 	<Target Name="GetFrameworkPaths"
-                Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"
+                Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND $(IsXBuild) == 'true'"
                 DependsOnTargets="$(GetFrameworkPathsDependsOn)">
                 <CreateProperty Value="$(XamarinMacFrameworkRoot)/lib/mono/4.5/">
                         <Output TaskParameter="Value" PropertyName="TargetFrameworkDirectory"/>
                 </CreateProperty>
        </Target>
 
-	<!-- Also part of the GetFrameworkPaths hack. -->
+	<!-- We only need to extend GetReferenceAssemblyPaths slightly, so we can force facades to only comes from our copy -->
+	<!-- but there is no invoking of a base target in msbuild. Copied from Microsoft.Common.targets with small changes -->
 	<Target Name="GetReferenceAssemblyPaths" 
-		Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"
+		Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND $(IsXBuild) == 'true'"
 		DependsOnTargets="$(GetReferenceAssemblyPathsDependsOn)">
 
 		<ItemGroup Condition="'$(ImplicitlyExpandDesignTimeFacades)' == 'true'">
@@ -40,16 +49,18 @@ Copyright (C) 2015 Xamarin Inc. All rights reserved.
 		<PropertyGroup Condition="'@(DesignTimeFacadeDirectories)' != ''">
 			<TargetFrameworkDirectory>$(TargetFrameworkDirectory);@(DesignTimeFacadeDirectories)</TargetFrameworkDirectory>
 		</PropertyGroup>
-       	</Target>
+	</Target>
 
 	<!-- This lets us bypass the standard MSBuild resolution of mscorlib, which always picks an incompatible system copy. -->
         <Target Name="_AddCorlibReference" 
-		Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"
+		Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND $(IsXBuild) == 'true'"
 		DependsOnTargets="GetReferenceAssemblyPaths">
-                <ItemGroup>
+  		<ItemGroup>
                         <_ExplicitReference Include="$(XamarinMacFrameworkRoot)/lib/mono/4.5/mscorlib.dll">
                                 <Private>false</Private>
                         </_ExplicitReference>
                 </ItemGroup>
-	</Target>	
+	</Target>
+	<!-- End the xbuild hacks  -->
+	<!-- TODO - msbuild hacks  -->
 </Project>

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -705,7 +705,7 @@ namespace Xamarin.Bundler {
 					throw new MonoMacException (23, true, "Application name '{0}.exe' conflicts with another user assembly.", root_wo_ext);
 
 				string monoFrameworkDirectory = TargetFramework.MonoFrameworkDirectory;
-				if (IsUnifiedFullSystemFramework || IsClassic)
+				if (IsUnifiedFullXamMacFramework || IsUnifiedFullSystemFramework || IsClassic)
 					monoFrameworkDirectory = "4.5";
 
 				fx_dir = Path.Combine (MonoDirectory, "lib", "mono", monoFrameworkDirectory);


### PR DESCRIPTION
- It turns out that a majority of the pain was due to HintPaths pointing to netstandard13 facades directly in the project in question
- There was one bug in mmp that was fixed
- I expanded the comments in XM45.targets files to prevent myself/others from being confused more than necessary
- MSBuild + netstandard13 is busted and will be fixed in another PR