### PR TITLE
[mmp] Map macOS 10.12.4 SDK with Xcode 8.3

### DIFF
--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -494,6 +494,8 @@ namespace Xamarin.Bundler {
 		static Version MutateSDKVersionToPointRelease (Version rv)
 		{
 			if (rv.Major == 10 && (rv.Revision == 0 || rv.Revision == -1)) {
+				if (rv.Minor == 12 && XcodeVersion >= new Version (8, 3))
+					return new Version (rv.Major, rv.Minor, 4);
 				if (rv.Minor == 12 && XcodeVersion >= new Version (8, 2))
 					return new Version (rv.Major, rv.Minor, 2);
 				if (rv.Minor == 12 && XcodeVersion >= new Version (8, 1))


### PR DESCRIPTION
This should stop errors like below to happen on wrench

```
Xamarin.Bundler.MonoMacException: The type 'AVFoundation.IAVContentKeyRecipient' (used as a parameter in AVFoundation.AVContentKeySession.Add) is not available in macOS 10.12.2 (it was introduced in macOS 10.12.4). Please build with a newer macOS SDK (usually done by using the most recent version of Xcode).
```