### PR TITLE
[intents] Fix INPerson.SiriMatches as not available on macOS

### DIFF
--- a/src/intents.cs
+++ b/src/intents.cs
@@ -2614,7 +2614,7 @@ namespace XamCore.Intents {
 		// Inlined from INInteraction (INPerson) Category
 
 		[Introduced (PlatformName.iOS, 10, 3)]
-		[Introduced (PlatformName.MacOSX, 10, 12, 4, PlatformArchitecture.Arch64)]
+		[Unavailable (PlatformName.MacOSX)]
 		[Export ("siriMatches", ArgumentSemantic.Copy), NullAllowed]
 		INPerson [] SiriMatches { get; }
 	}


### PR DESCRIPTION
Mac introspection does not like it on wrench, which seems to
have a Sierra beta (or it would be ignored)

> [FAIL] Selector not found for Intents.INPerson : siriMatches

and xtro / headers can't see it being available on macOS either