### PR TITLE
[avfoundation] Disable incorrect AVAudioSessionInterruptionEventArgs.WasSuspended

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -1932,9 +1932,13 @@ namespace XamCore.AVFoundation {
 		[Export ("AVAudioSessionInterruptionOptionKey")]
 		AVAudioSessionInterruptionOptions Option { get; }
 
+#if false
+		// https://bugzilla.xamarin.com/show_bug.cgi?id=52730
 		[iOS (10, 3), NoMac, TV (10, 2), Watch (3,2)]
 		[Export ("AVAudioSessionInterruptionWasSuspendedKey")]
-		bool WasSuspended { get; }
+		[return: BindAs (bool?)]
+		NSNumber WasSuspended { get; }
+#endif
 	}
 
 	interface AVAudioSessionRouteChangeEventArgs {


### PR DESCRIPTION
The return type is wrong

> Value is a boolean NSNumber,

and cannot be bound as a `bool` but as a `NSNumber`, which makes it
closer to a `bool?` since it could be absent.

We'll re-enable it when merging `xcode8.3` on `master` so we can benefit
from Alex `[BindAs]` support, giving us a `bool?` on the visible API