### PR TITLE
Add support for indicating that a binding library does not support incremental builds.

### DIFF
--- a/src/ObjCRuntime/LinkWithAttribute.cs
+++ b/src/ObjCRuntime/LinkWithAttribute.cs
@@ -113,5 +113,11 @@ namespace XamCore.ObjCRuntime {
 		public DlsymOption Dlsym {
 			get; set;
 		}
+
+#if !MONOMAC
+		public bool SupportsIncrementalBuilds {
+			get; set;
+		} = true;
+#endif
 	}
 }

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -171,6 +171,9 @@ namespace Xamarin.Bundler {
 					EnableCxx = true;
 
 #if MONOTOUCH
+				if (!linkWith.SupportsIncrementalBuilds)
+					App.FastDev = false;
+
 				if (linkWith.Dlsym != DlsymOption.Default)
 					App.SetDlsymOption (FullPath, linkWith.Dlsym == DlsymOption.Required);
 #endif
@@ -252,6 +255,9 @@ namespace Xamarin.Bundler {
 			Driver.Log (3, "    LinkTarget: {0}", linkWith.LinkTarget);
 			Driver.Log (3, "    NeedsGccExceptionHandling: {0}", linkWith.NeedsGccExceptionHandling);
 			Driver.Log (3, "    SmartLink: {0}", linkWith.SmartLink);
+#if MONOTOUCH
+			Driver.Log (3, "    SupportsIncrementalBuilds: {0}", linkWith.SupportsIncrementalBuilds);
+#endif
 			Driver.Log (3, "    WeakFrameworks: {0}", linkWith.WeakFrameworks);
 		}
 
@@ -305,6 +311,11 @@ namespace Xamarin.Bundler {
 				case "Dlsym":
 					linkWith.Dlsym = (DlsymOption) property.Argument.Value;
 					break;
+#if MONOTOUCH
+				case "SupportsIncrementalBuilds":
+					linkWith.SupportsIncrementalBuilds = (bool) property.Argument.Value;
+					break;
+#endif
 				default: 
 					break;
 				}


### PR DESCRIPTION
It's tricky to make sure binding libraries always work with incremental builds
(which means that we frequently get it wrong), so this means there's an escape
plan for binding libraries.

https://bugzilla.xamarin.com/show_bug.cgi?id=52727