### PR TITLE
[introspection] Remove intro checks on watch

### DIFF
--- a/tests/introspection/iOS/iOSApiCtorInitTest.cs
+++ b/tests/introspection/iOS/iOSApiCtorInitTest.cs
@@ -180,22 +180,6 @@ namespace Introspection {
 			// iOS 10 - this works only on devices, so we skip the simulator
 			case "MTLHeapDescriptor":
 				return Runtime.Arch == Arch.SIMULATOR;
-#if __WATCHOS__
-			// The following watchOS 3.2 Beta 2 types Fails, but they can be created we verified using an ObjC app, we will revisit before stable
-			case "INRequestPaymentIntent":
-			case "INRequestRideIntent":
-			case "INResumeWorkoutIntent":
-			case "INRideVehicle":
-			case "INSearchCallHistoryIntent":
-			case "INSearchForMessagesIntent":
-			case "INSearchForPhotosIntent":
-			case "INSendMessageIntent":
-			case "INSendPaymentIntent":
-			case "INStartAudioCallIntent":
-			case "INStartPhotoPlaybackIntent":
-			case "INStartWorkoutIntent":
-				return true;
-#endif
 			default:
 				return base.Skip (type);
 			}

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -94,45 +94,6 @@ namespace Introspection {
 			//  to a MTLHeapDescriptorInternal and don't respond - so we'll add unit tests for them
 			case "MTLHeapDescriptor":
 				return Runtime.Arch == Arch.DEVICE;
-#if __WATCHOS__
-				// The following watchOS 3.2 Beta 2 types Fails, but they can be created we verified using an ObjC app, we will revisit before stable
-			case "INPersonResolutionResult":
-			case "INPlacemarkResolutionResult":
-			case "INPreferences":
-			case "INRadioTypeResolutionResult":
-			case "INRelativeReferenceResolutionResult":
-			case "INRelativeSettingResolutionResult":
-			case "INRideCompletionStatus":
-			case "INSpeakableStringResolutionResult":
-			case "INStringResolutionResult":
-			case "INTemperatureResolutionResult":
-			case "INWorkoutGoalUnitTypeResolutionResult":
-			case "INWorkoutLocationTypeResolutionResult":
-			case "INBillPayeeResolutionResult":
-			case "INBillTypeResolutionResult":
-			case "INBooleanResolutionResult":
-			case "INCallRecordTypeResolutionResult":
-			case "INCarAirCirculationModeResolutionResult":
-			case "INCarAudioSourceResolutionResult":
-			case "INCarDefrosterResolutionResult":
-			case "INCarSeatResolutionResult":
-			case "INCarSignalOptionsResolutionResult":
-			case "INCurrencyAmountResolutionResult":
-			case "INDateComponentsRangeResolutionResult":
-			case "INDateComponentsResolutionResult":
-			case "INDoubleResolutionResult":
-			case "INImage":
-			case "INIntegerResolutionResult":
-			case "INInteraction":
-			case "INMessageAttributeOptionsResolutionResult":
-			case "INPaymentAmountResolutionResult":
-			case "INMessageAttributeResolutionResult":
-			case "INPaymentMethod":
-			case "INPaymentStatusResolutionResult":
-			case "INPaymentAccountResolutionResult":
-				return true;
-#endif
-
 			default:
 				return base.Skip (type);
 			}


### PR DESCRIPTION
For some reason introspection tests failed randomly on some selectors
and classes that according to headers are available on watchOS and
are actually usable I used some types on the intents framework watch sample