### PR TITLE
[uikit] Add == and != operators on UIEdgeInsets. Fixes #33504

### DIFF
--- a/src/UIKit/UITypes.cs
+++ b/src/UIKit/UITypes.cs
@@ -63,6 +63,16 @@ namespace XamCore.UIKit {
 			return false;
 		}
 
+		public static bool operator == (UIEdgeInsets insets1, UIEdgeInsets insets2)
+		{
+			return insets1.Equals (insets2);
+		}
+
+		public static bool operator != (UIEdgeInsets insets1, UIEdgeInsets insets2)
+		{
+			return !insets1.Equals (insets2);
+		}
+
 		public override int GetHashCode ()
 		{
 			return Top.GetHashCode () ^ Left.GetHashCode () ^ Right.GetHashCode () ^ Bottom.GetHashCode ();

--- a/tests/monotouch-test/UIKit/EdgeInsetsTest.cs
+++ b/tests/monotouch-test/UIKit/EdgeInsetsTest.cs
@@ -70,5 +70,17 @@ namespace MonoTouchFixtures.UIKit {
 			Assert.False (i.Equals (UIEdgeInsets.Zero), "Equals(UIEdgeInsets)");
 			Assert.False (UIEdgeInsets.Zero.Equals ((object) i), "Equals(object)");
 		}
+
+		[Test]
+		public void Operators ()
+		{
+			var i1 = new UIEdgeInsets (10, 20, 30, 40);
+			var i2 = new UIEdgeInsets (10, 10, 10, 10);
+
+			Assert.True (i1 == i1, "i1 == i1");
+			Assert.True (i2 == i2, "i1 == i1");
+			Assert.True (i1 != i2, "i1 != i2");
+			Assert.True (i2 != i1, "i2 != i1");
+		}
 	}
 }


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=33504