### PR TITLE
[msbuild] Ignore .DS_Store files when cloning asset catalogs

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
@@ -297,6 +297,10 @@ namespace Xamarin.MacDev.Tasks
 			for (int i = 0; i < ImageAssets.Length; i++) {
 				var vpath = BundleResource.GetVirtualProjectPath (ProjectDir, ImageAssets[i], !string.IsNullOrEmpty (SessionId));
 
+				// Ignore MacOS .DS_Store files...
+				if (Path.GetFileName (vpath).Equals (".DS_Store", StringComparison.OrdinalIgnoreCase))
+					continue;
+
 				// get the parent (which will typically be .appiconset, .launchimage, .imageset, .iconset, etc)
 				var catalog = Path.GetDirectoryName (vpath);
 
@@ -336,6 +340,10 @@ namespace Xamarin.MacDev.Tasks
 					var clone = false;
 					ITaskItem item;
 
+					// Ignore MacOS .DS_Store files...
+					if (Path.GetFileName (vpath).Equals (".DS_Store", StringComparison.OrdinalIgnoreCase))
+						continue;
+
 					foreach (var catalog in clones) {
 						if (vpath.Length > catalog.Length && vpath[catalog.Length] == '/' && vpath.StartsWith (catalog, StringComparison.Ordinal)) {
 							clone = true;
@@ -344,17 +352,24 @@ namespace Xamarin.MacDev.Tasks
 					}
 
 					if (clone) {
-						var path = Path.Combine (intermediateCloneDir, vpath);
-						var dir = Path.GetDirectoryName (path);
+						var dest = Path.Combine (intermediateCloneDir, vpath);
+						var src = ImageAssets[i].GetMetadata ("FullPath");
+						var dir = Path.GetDirectoryName (dest);
 
 						Directory.CreateDirectory (dir);
-						File.Copy (ImageAssets[i].GetMetadata ("FullPath"), path, true);
+
+						if (!File.Exists (src)) {
+							Log.LogError (null, null, null, src, 0, 0, 0, 0, "File not found: {0}", src);
+							return false;
+						}
+
+						File.Copy (src, dest, true);
 
 						// filter out everything except paths containing a Contents.json file since our main processing loop only cares about these
 						if (Path.GetFileName (vpath) != "Contents.json")
 							continue;
 
-						item = new TaskItem (path);
+						item = new TaskItem (dest);
 						ImageAssets[i].CopyMetadataTo (item);
 						item.SetMetadata ("Link", vpath);
 					} else {

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
@@ -352,16 +352,17 @@ namespace Xamarin.MacDev.Tasks
 					}
 
 					if (clone) {
-						var dest = Path.Combine (intermediateCloneDir, vpath);
 						var src = ImageAssets[i].GetMetadata ("FullPath");
-						var dir = Path.GetDirectoryName (dest);
-
-						Directory.CreateDirectory (dir);
 
 						if (!File.Exists (src)) {
 							Log.LogError (null, null, null, src, 0, 0, 0, 0, "File not found: {0}", src);
 							return false;
 						}
+
+						var dest = Path.Combine (intermediateCloneDir, vpath);
+						var dir = Path.GetDirectoryName (dest);
+
+						Directory.CreateDirectory (dir);
 
 						File.Copy (src, dest, true);
 


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=52851

The problem here is that the .DS_Store file was included in
the .csproj file but did not exist on disk, so when we went
to clone that file into the obj/ dir before running actool
on it, File.Copy() would fail because the file did not
actually exist.

Since these files are worthless anyway, we can safely ignore
them.

Also added logic to verify that files exist before copying
them in order to report a better error than an exception
stack trace.