### PR TITLE
Ensure we're checked out in a directory named 'xamarin-macios'.

### DIFF
--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -590,6 +590,10 @@ check_mono
 check_xamarin_studio
 check_cmake
 
+if [[ "x$(basename $(pwd))" != xxamarin-macios ]]; then
+	fail "xamarin-macios must be checked out in a directory named 'xamarin-macios'."
+fi
+
 if test -z $FAIL; then
 	echo "System check succeeded"
 else


### PR DESCRIPTION
Otherwise the build will fail, since some dependencies use "TOP=[...]/xamarin-macios".