### PR TITLE
[msbuild] Index into the correct item array when printing an error me…

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
@@ -309,7 +309,7 @@ namespace Xamarin.MacDev.Tasks
 					catalog = Path.GetDirectoryName (catalog);
 
 				if (string.IsNullOrEmpty (catalog)) {
-					Log.LogWarning (null, null, null, items[i].ItemSpec, 0, 0, 0, 0, "Asset not part of an asset catalog: {0}", items[i].ItemSpec);
+					Log.LogWarning (null, null, null, ImageAssets[i].ItemSpec, 0, 0, 0, 0, "Asset not part of an asset catalog: {0}", ImageAssets[i].ItemSpec);
 					continue;
 				}
 
@@ -446,7 +446,7 @@ namespace Xamarin.MacDev.Tasks
 
 						Directory.CreateDirectory (assetDir);
 
-						for (int j = 0; j < tags.Count; j++)
+						for (int j = 0; j < tagList.Count; j++)
 							ptags.Add (new PString (tagList[j]));
 
 						assetpack.Add ("bundle-id", new PString (string.Format ("{0}.asset-pack-{1}", bundleIdentifier, hash)));


### PR DESCRIPTION
…ssage

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=52860

When the ImageAssets contain an item that doesn't live within
a *.xcassets directory, index into ImageAssets[] rather than
items[] which hasn't been populated yet.

Also fixed the tagsList for-loop to use tagsList.Count instead
for correctness (even though tags.Count and tagsList.Count
should always be identical).