### PR TITLE
[coregraphics] Add missing [Flags] on CGGradientDrawingOptions. Fixes #33997

### DIFF
--- a/src/CoreGraphics/CGGradient.cs
+++ b/src/CoreGraphics/CGGradient.cs
@@ -35,6 +35,7 @@ using XamCore.Foundation;
 namespace XamCore.CoreGraphics {
 
 	// uint32_t -> CGGradient.h
+	[Flags]
 	public enum CGGradientDrawingOptions : uint_compat_int {
 		None = 0,
 		DrawsBeforeStartLocation = (1 << 0),

--- a/tests/monotouch-test/CoreGraphics/GradientTest.cs
+++ b/tests/monotouch-test/CoreGraphics/GradientTest.cs
@@ -100,5 +100,13 @@ namespace MonoTouchFixtures.CoreGraphics {
 			using (var a = NSArray.FromNSObjects (array))
 				Assert.That (CGGradientCreateWithColors (IntPtr.Zero, a.Handle, null), Is.Not.EqualTo (IntPtr.Zero), "CGGradientCreateWithColors-2");
 		}
+
+		[Test]
+		public void GradientDrawingOptions ()
+		{
+			var gdo = CGGradientDrawingOptions.DrawsAfterEndLocation | CGGradientDrawingOptions.DrawsBeforeStartLocation;
+			// this would be "3" without a [Flags] attribute
+			Assert.That (gdo.ToString (), Is.EqualTo ("DrawsBeforeStartLocation, DrawsAfterEndLocation"), "ToString/Flags");
+		}
 	}
 }


### PR DESCRIPTION
reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=33997