### PR TITLE
[mtouch] Disable fastdev for projects with more than one binding library. Works around bug #52727.

### DIFF
--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -71,6 +71,13 @@ namespace Xamarin.Bundler {
 					exceptions.Add (e);
 				}
 			}
+
+#if MTOUCH
+			if (App.FastDev && Assemblies.Count ((v) => v.HasLinkWithAttributes) > 1) {
+				ErrorHelper.Warning (127, "Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include more than one third-party binding libraries.");
+				App.FastDev = false;
+			}
+#endif
 		}
 
 		[DllImport (Constants.libSystemLibrary, SetLastError = true, EntryPoint = "strerror")]

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -106,6 +106,7 @@ namespace Xamarin.Bundler {
 	//					MT0097 <used by mmp>
 	//		Warning		MT0110  Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include third-party binding libraries and that compiles to bitcode.
 	//		Warning		MT0111	Bitcode has been enabled because this version of Xamarin.iOS does not support building watchOS projects using LLVM without enabling bitcode.
+	//		Warning		MT0127	Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include more than one third-party binding libraries.
 	// MT1xxx	file copy / symlinks (project related)
 	//			MT10xx	installer.cs / mtouch.cs
 	//					MT1001	Could not find an application at the specified directory: {0}


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=52727