### PR TITLE
[generator] Don't use Type.GetType to look in all loaded assemblies, look directly in the right assembly.

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1155,7 +1155,7 @@ public partial class Generator : IMemberGatherer {
 		if (type.GetFields ().Any (f => AttributeManager.GetCustomAttribute<FieldAttribute> (f) != null))
 			return true;
 		// If the above fails it's possible that it comes from another dll (like X.I.dll) so we look for the [Enum]Extensions class existence
-		return Type.GetType (type.AssemblyQualifiedName.Replace (type.Name, $"{type.Name}Extensions")) != null;
+		return type.Assembly.GetType (type.FullName + "Extensions") != null;
 	}
 
 	static Dictionary<Type,string> nsvalue_create_map;


### PR DESCRIPTION
'Type.GetType' doesn't work the same with IKVM as with Reflection, so refactor
to code that works the same (and just as correctly) for both IKVM and
Reflection.

In particular there's no need to use 'Type.GetType' with an assembly qualified
typename when we already have the assembly we need to look in: just use the
type's FullName to look up the type in the assembly instead.

Generator diff: https://gist.github.com/rolfbjarne/a3da6c9df53383c4225483f89e16d156