### PR TITLE
[generator] Use FieldInfo.GetRawConstantValue instead of FieldInfo.GetValue.

### DIFF
--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -164,7 +164,7 @@ public partial class Generator {
 			var default_symbol_name = default_symbol?.Item2.SymbolName;
 			// more than one enum member can share the same numeric value - ref: #46285
 			foreach (var kvp in fields) {
-				print ("case {0}: // {1}.{2}", Convert.ToInt64 (kvp.Key.GetValue (null)), type.Name, kvp.Key.Name);
+				print ("case {0}: // {1}.{2}", Convert.ToInt64 (kvp.Key.GetRawConstantValue ()), type.Name, kvp.Key.Name);
 				var sn = kvp.Value.SymbolName;
 				if (sn == default_symbol_name)
 					print ("default:");

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -2508,7 +2508,7 @@ public partial class Generator : IMemberGatherer {
 		var libSuffixedName = $"{library_name}Library";
 		var constType = TypeManager.Constants;
 		var field = constType.GetFields (BindingFlags.Public | BindingFlags.Static).FirstOrDefault (f => f.Name == libSuffixedName);
-		library_path = (string) field?.GetValue (null);
+		library_path = (string) (field?.GetRawConstantValue ());
 		return library_path == null;
 	}
 


### PR DESCRIPTION
IKVM doesn't have FieldInfo.GetValue, so switch to GetRawConstantValue instead.

Both API work the same way in the cases we use it, so there is no change in the generated code.

Generator diff: https://gist.github.com/rolfbjarne/0110ae637f24a171b1caa20d8220366a