### PR TITLE
[msbuild] Allow extensions bundle other extensions

### DIFF
--- a/Versions-ios.plist.in
+++ b/Versions-ios.plist.in
@@ -100,6 +100,8 @@
 		<dict>
 			<key>com.apple.watchkit</key>
 			<string>2.0</string>
+			<key>com.apple.intents-service</key>
+			<string>3.2</string>
 		</dict>
 	</dict>
 </dict>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1279,7 +1279,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</PrepareResourceRules>
 	</Target>
 
-	<Target Name="_SeparateAppExtensionReferences" BeforeTargets="AssignProjectConfiguration" Condition="'$(IsAppExtension)' == 'false'">
+	<Target Name="_SeparateAppExtensionReferences" BeforeTargets="AssignProjectConfiguration">
 		<CreateItem Include="@(ProjectReference)" PreserveExistingMetadata="true" Condition="'%(Identity)' != '' And '%(ProjectReference.IsAppExtension)' == 'true'">
 			<Output ItemName="_AppExtensionReference" TaskParameter="Include" />
 		</CreateItem>
@@ -1384,7 +1384,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</DetectDebugNetworkConfiguration>
 	</Target>
 
-	<Target Name="_CopyAppExtensionsToBundle" Condition="'$(IsAppExtension)' == 'false'" DependsOnTargets="_ResolveAppExtensionReferences">
+	<Target Name="_CopyAppExtensionsToBundle" DependsOnTargets="_ResolveAppExtensionReferences">
 		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '@(_ResolvedAppExtensionReferences)' != ''" Directories="$(_AppBundlePath)PlugIns" />
 
 		<Ditto


### PR DESCRIPTION
watchOS 3.2 introduced SiriKit extension that must be bundled
inside the Watch App Extension (yep a extension inside another extension).

So the _ResolveAppExtensionReferences and _CopyAppExtensionsToBundle should
now be run on extension projects too.