### PR TITLE
[generator] Don't cast the return value from AttributeManager.GetCustomAttributes.

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3933,9 +3933,9 @@ public partial class Generator : IMemberGatherer {
 		// However we want them even if ImplementsAppearance is true (i.e. the original type needs them)
 		if (!is_appearance) {
 			if (HasAttribute (mi, TypeManager.PostGetAttribute))
-				postget = ((PostGetAttribute []) AttributeManager.GetCustomAttributes (mi,TypeManager.PostGetAttribute, true));
+				postget = AttributeManager.GetCustomAttributes<PostGetAttribute> (mi, true);
 			else if (propInfo != null)
-				postget = ((PostGetAttribute []) AttributeManager.GetCustomAttributes (propInfo,TypeManager.PostGetAttribute, true));
+				postget = AttributeManager.GetCustomAttributes<PostGetAttribute> (propInfo, true);
 
 			if (postget != null && postget.Length == 0)
 				postget = null;
@@ -4956,7 +4956,7 @@ public partial class Generator : IMemberGatherer {
 			if (m.Name == "Constructor")
 				continue;
 
-			var attrs = AttributeManager.GetCustomAttributes (m, true) as Attribute [];
+			var attrs = AttributeManager.GetCustomAttributes<Attribute> (m, true);
 			AvailabilityBaseAttribute availabilityAttribute = null;
 			bool hasExportAttribute = false;
 			bool hasStaticAttribute = false;
@@ -4990,7 +4990,7 @@ public partial class Generator : IMemberGatherer {
 		var list = type.GetProperties (BindingFlags.Public | BindingFlags.Instance);
 
 		foreach (var p in list) {
-			var attrs = AttributeManager.GetCustomAttributes (p, true) as Attribute [];
+			var attrs = AttributeManager.GetCustomAttributes<Attribute> (p, true);
 			AvailabilityBaseAttribute availabilityAttribute = null;
 			bool hasExportAttribute = false;
 			bool hasStaticAttribute = false;


### PR DESCRIPTION
The IKVM version won't return an array of the exact attribute type, so casting doesn't work.

Use the generic version instead, which returns an array of the right type
directly, and works with both IKVM and Reflection.

Generator diff: https://gist.github.com/rolfbjarne/06c3ff20dc90631d345aeebd54790018 (all changes unrelated)