### PR TITLE
[generator] Don't ask for inherited attributes.

### DIFF
--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -385,7 +385,7 @@ class BindingTouch {
 				
 			TypeManager.Initialize (api);
 
-			foreach (object attr in AttributeManager.GetCustomAttributes (api, TypeManager.LinkWithAttribute, true)) {
+			foreach (object attr in AttributeManager.GetCustomAttributes (api, TypeManager.LinkWithAttribute)) {
 				LinkWithAttribute linkWith = (LinkWithAttribute) attr;
 				
 				if (!linkwith.Contains (linkWith.LibraryName)) {
@@ -408,12 +408,12 @@ class BindingTouch {
 			var  strong_dictionaries = new List<Type> ();
 			foreach (var t in api.GetTypes ()){
 				if ((process_enums && t.IsEnum) ||
-				    AttributeManager.HasAttribute (t, TypeManager.BaseTypeAttribute, true) ||
-				    AttributeManager.HasAttribute (t, TypeManager.ProtocolAttribute, true) ||
-				    AttributeManager.HasAttribute (t, TypeManager.StaticAttribute, true) ||
-				    AttributeManager.HasAttribute (t, TypeManager.PartialAttribute, true))
+				    AttributeManager.HasAttribute (t, TypeManager.BaseTypeAttribute) ||
+				    AttributeManager.HasAttribute (t, TypeManager.ProtocolAttribute) ||
+				    AttributeManager.HasAttribute (t, TypeManager.StaticAttribute) ||
+				    AttributeManager.HasAttribute (t, TypeManager.PartialAttribute))
 					types.Add (t);
-				if (AttributeManager.HasAttribute (t, TypeManager.StrongDictionaryAttribute, true))
+				if (AttributeManager.HasAttribute (t, TypeManager.StrongDictionaryAttribute))
 					strong_dictionaries.Add (t);
 			}
 

--- a/src/generator-attribute-manager.cs
+++ b/src/generator-attribute-manager.cs
@@ -3,54 +3,54 @@ using System.Reflection;
 
 public static class AttributeManager
 {
-	public static System.Attribute GetCustomAttribute (ICustomAttributeProvider provider, Type type, bool inherit = false)
+	public static System.Attribute GetCustomAttribute (ICustomAttributeProvider provider, Type type)
 	{
 		if (provider == null)
 			return null;
 
 		var pi = provider as ParameterInfo;
 		if (pi != null)
-			return Attribute.GetCustomAttribute (pi, type, inherit);
+			return Attribute.GetCustomAttribute (pi, type);
 		var mi = provider as MemberInfo;
 		if (mi != null)
-			return Attribute.GetCustomAttribute (mi, type, inherit);
+			return Attribute.GetCustomAttribute (mi, type);
 		var asm = provider as Assembly;
 		if (asm != null)
-			return Attribute.GetCustomAttribute (asm, type, inherit);
+			return Attribute.GetCustomAttribute (asm, type);
 		throw new BindingException (1051, true, "Internal error: Don't know how to get attributes for {0}. Please file a bug report (http://bugzilla.xamarin.com) with a test case.", provider.GetType ().FullName);
 	}
 
-	public static T GetCustomAttribute <T> (ICustomAttributeProvider provider, bool inherit = false) where T: System.Attribute
+	public static T GetCustomAttribute <T> (ICustomAttributeProvider provider) where T: System.Attribute
 	{
-		return (T) GetCustomAttribute (provider, typeof (T), inherit);
+		return (T) GetCustomAttribute (provider, typeof (T));
 	}
 
-	public static T [] GetCustomAttributes<T> (ICustomAttributeProvider provider, bool inherits) where T : System.Attribute
+	public static T [] GetCustomAttributes<T> (ICustomAttributeProvider provider) where T : System.Attribute
 	{
-		return (T []) provider.GetCustomAttributes (typeof (T), inherits);
+		return (T []) provider.GetCustomAttributes (typeof (T), false);
 	}
 
-	public static object [] GetCustomAttributes (ICustomAttributeProvider provider, Type type, bool inherits)
+	public static object [] GetCustomAttributes (ICustomAttributeProvider provider, Type type)
 	{
 		if (type == null)
 			throw new System.ArgumentNullException (nameof (type));
 
-		return (System.Attribute []) provider.GetCustomAttributes (type, inherits);
+		return (System.Attribute []) provider.GetCustomAttributes (type, false);
 	}
 
-	public static object [] GetCustomAttributes (ICustomAttributeProvider provider, bool inherits)
+	public static object [] GetCustomAttributes (ICustomAttributeProvider provider)
 	{
-		return provider.GetCustomAttributes (inherits);
+		return provider.GetCustomAttributes (false);
 	}
 
-	public static bool HasAttribute<T> (ICustomAttributeProvider provider, bool inherit = false) where T : Attribute
+	public static bool HasAttribute<T> (ICustomAttributeProvider provider) where T : Attribute
 	{
-		return HasAttribute (provider, typeof (T), inherit);
+		return HasAttribute (provider, typeof (T));
 	}
 
-	public static bool HasAttribute (ICustomAttributeProvider provider, string type_name, bool inherit = false)
+	public static bool HasAttribute (ICustomAttributeProvider provider, string type_name)
 	{
-		foreach (var attr in AttributeManager.GetCustomAttributes (provider, inherit)) {
+		foreach (var attr in AttributeManager.GetCustomAttributes (provider)) {
 			if (attr.GetType ().Name == type_name)
 				return true;
 		}
@@ -58,9 +58,9 @@ public static class AttributeManager
 		return false;
 	}
 
-	public static bool HasAttribute (ICustomAttributeProvider provider, Type attribute_type, bool inherits = false)
+	public static bool HasAttribute (ICustomAttributeProvider provider, Type attribute_type)
 	{
-		var attribs = GetCustomAttributes (provider, attribute_type, inherits);
+		var attribs = GetCustomAttributes (provider, attribute_type);
 		if (attribs == null || attribs.Length == 0)
 			return false;
 

--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -35,7 +35,7 @@ public partial class Generator {
 
 	void CopyObsolete (ICustomAttributeProvider provider)
 	{
-		foreach (ObsoleteAttribute oa in AttributeManager.GetCustomAttributes (provider, TypeManager.ObsoleteAttribute, false))
+		foreach (ObsoleteAttribute oa in AttributeManager.GetCustomAttributes (provider, TypeManager.ObsoleteAttribute))
 			print ("[Obsolete (\"{0}\", {1})]", oa.Message, oa.IsError ? "true" : "false");
 	}
 


### PR DESCRIPTION
IKVM doesn't have API that supports looking for inherited attributes (we'd
have to implement the logic ourselves if we needed it), so I decided to check
if we really need to fetch inherited attributes.

Turns out we don't: removing all lookup for inherited attributes does not
change the generated output, nor does it fail any of our tests.

A few more reasons I think this is fairly safe:

* For events and properties, the `inherits` flag is ignored according to MSDN,
  so removing it does not change anything at all.
* Fields can't be inherited (they're not virtual), so asking for inherited
  attributes doesn't even make sense.
* Our binding syntax generally does not use inheritance (a base type is
  expressed by putting the `[BaseType]` attribute on the binding interface,
  not making the binding interface actually inherit from its alleged base
  type).
* Even when the syntax does use inheritance (to inline protocols), the inlined
  protocols do not use inheritence themselves, so none of the members in the
  inlined protocols will override base class member (since there is no base
  class).

Generator diff: https://gist.github.com/rolfbjarne/6a767517a9db76e415827039885c6b09 (all changes are unrelated)