### PR TITLE
[msbuild] Make sure to codesign appex dylibs

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CodesignNativeLibrariesTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CodesignNativeLibrariesTaskBase.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+using Parallel = System.Threading.Tasks.Parallel;
+using ParallelOptions = System.Threading.Tasks.ParallelOptions;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Xamarin.MacDev;
+using Xamarin.MacDev.Tasks;
+
+namespace Xamarin.iOS.Tasks
+{
+	public abstract class CodesignNativeLibrariesTaskBase : Task
+	{
+		const string ToolName = "codesign";
+		string toolExe;
+
+		#region Inputs
+
+		public string SessionId { get; set; }
+
+		[Required]
+		public string AppBundleDir { get; set; }
+
+		[Required]
+		public string IntermediateOutputPath { get; set; }
+
+		[Required]
+		public string CodesignAllocate { get; set; }
+
+		public bool DisableTimestamp { get; set; }
+
+		public string Keychain { get; set; }
+
+		[Required]
+		public string SigningKey { get; set; }
+
+		public string ExtraArgs { get; set; }
+
+		public string ToolExe {
+			get { return toolExe ?? ToolName; }
+			set { toolExe = value; }
+		}
+
+		public string ToolPath { get; set; }
+
+		#endregion
+
+		string GetFullPathToTool ()
+		{
+			if (!string.IsNullOrEmpty (ToolPath))
+				return Path.Combine (ToolPath, ToolExe);
+
+			var path = Path.Combine ("/usr/bin", ToolExe);
+
+			return File.Exists (path) ? path : ToolExe;
+		}
+
+		ProcessStartInfo GetProcessStartInfo (string tool, string args)
+		{
+			var startInfo = new ProcessStartInfo (tool, args);
+
+			startInfo.WorkingDirectory = Environment.CurrentDirectory;
+			startInfo.EnvironmentVariables["CODESIGN_ALLOCATE"] = CodesignAllocate;
+
+			startInfo.CreateNoWindow = true;
+
+			return startInfo;
+		}
+
+		string GenerateCommandLineArguments (string dylib)
+		{
+			var args = new ProcessArgumentBuilder ();
+
+			args.Add ("-v");
+			args.Add ("--force");
+
+			args.Add ("--sign");
+			args.AddQuoted (SigningKey);
+
+			if (!string.IsNullOrEmpty (Keychain)) {
+				args.Add ("--keychain");
+				args.AddQuoted (Path.GetFullPath (Keychain));
+			}
+
+			if (DisableTimestamp)
+				args.Add ("--timestamp=none");
+
+			if (!string.IsNullOrEmpty (ExtraArgs))
+				args.Add (ExtraArgs);
+
+			args.AddQuoted (dylib);
+
+			return args.ToString ();
+		}
+
+		void Codesign (string dylib)
+		{
+			var startInfo = GetProcessStartInfo (GetFullPathToTool (), GenerateCommandLineArguments (dylib));
+			var messages = new StringBuilder ();
+			var errors = new StringBuilder ();
+			int exitCode;
+
+			try {
+				Log.LogMessage (MessageImportance.Normal, "Tool {0} execution started with arguments: {1}", startInfo.FileName, startInfo.Arguments);
+
+				using (var stdout = new StringWriter (messages)) {
+					using (var stderr = new StringWriter (errors)) {
+						var process = ProcessUtils.StartProcess (startInfo, stdout, stderr);
+
+						process.Wait ();
+
+						exitCode = process.Result;
+					}
+
+					Log.LogMessage (MessageImportance.Low, "Tool {0} execution finished (exit code = {1}).", startInfo.FileName, exitCode);
+				}
+			} catch (Exception ex) {
+				Log.LogError ("Error executing tool '{0}': {1}", startInfo.FileName, ex.Message);
+				return;
+			}
+
+			if (messages.Length > 0)
+				Log.LogMessage (MessageImportance.Normal, "{0}", messages.ToString ());
+
+			if (exitCode != 0) {
+				if (errors.Length > 0)
+					Log.LogError ("Failed to codesign '{0}': {1}", dylib, errors);
+				else
+					Log.LogError ("Failed to codesign '{0}'", dylib);
+			} else {
+				var output = GetOutputPath (dylib);
+				var dir = Path.GetDirectoryName (output);
+
+				Directory.CreateDirectory (dir);
+
+				File.WriteAllText (output, string.Empty);
+			}
+		}
+
+		string GetOutputPath (string path)
+		{
+			var rpath = PathUtils.AbsoluteToRelative (AppBundleDir, path);
+
+			return Path.Combine (IntermediateOutputPath, rpath);
+		}
+
+		bool NeedsCodesign (string path)
+		{
+			var output = GetOutputPath (path);
+
+			return !File.Exists (output) || File.GetLastWriteTimeUtc (path) >= File.GetLastWriteTimeUtc (output);
+		}
+
+		public override bool Execute ()
+		{
+			Log.LogTaskName ("CodesignNativeLibraries");
+			Log.LogTaskProperty ("AppBundleDir", AppBundleDir);
+			Log.LogTaskProperty ("CodesignAllocate", CodesignAllocate);
+			Log.LogTaskProperty ("DisableTimestamp", DisableTimestamp);
+			Log.LogTaskProperty ("IntermediateOutputPath", IntermediateOutputPath);
+			Log.LogTaskProperty ("Keychain", Keychain);
+			Log.LogTaskProperty ("SigningKey", SigningKey);
+			Log.LogTaskProperty ("ExtraArgs", ExtraArgs);
+
+			if (!Directory.Exists (AppBundleDir))
+				return true;
+
+			var subdirs = new List<string> ();
+			var dylibs = new List<string> ();
+
+			foreach (var path in Directory.EnumerateFileSystemEntries (AppBundleDir)) {
+				if (Directory.Exists (path)) {
+					var name = Path.GetFileName (path);
+
+					if (name != "PlugIns" && name != "Watch")
+						subdirs.Add (path);
+				} else {
+					if (path.EndsWith (".metallib", StringComparison.Ordinal) || path.EndsWith (".dylib", StringComparison.Ordinal)) {
+						if (NeedsCodesign (path))
+							dylibs.Add (path);
+					}
+				}
+			}
+
+			foreach (var subdir in subdirs) {
+				foreach (var dylib in Directory.EnumerateFiles (subdir, "*.*", SearchOption.AllDirectories)) {
+					if (dylib.EndsWith (".metallib", StringComparison.Ordinal) || dylib.EndsWith (".dylib", StringComparison.Ordinal)) {
+						if (NeedsCodesign (dylib))
+							dylibs.Add (dylib);
+					}
+				}
+			}
+
+			if (dylibs.Count == 0)
+				return true;
+
+			Parallel.ForEach (dylibs, new ParallelOptions { MaxDegreeOfParallelism = Math.Max (Environment.ProcessorCount / 2, 1) }, (dylib) => {
+				Codesign (dylib);
+			});
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -177,9 +177,6 @@ namespace Xamarin.iOS.Tasks
 		[Required]
 		[Output]
 		public ITaskItem NativeExecutable { get; set; }
-		
-		[Output]
-		public ITaskItem[] NativeLibraries { get; set; }
 
 		#endregion
 
@@ -707,23 +704,7 @@ namespace Xamarin.iOS.Tasks
 
 			Directory.CreateDirectory (AppBundleDir);
 
-			var mtouchExecution = base.Execute ();
-
-			try {
-				var nativeLibrariesPath = Directory.EnumerateFiles (AppBundleDir, "*.dylib", SearchOption.AllDirectories);
-				var nativeLibraryItems = new List<ITaskItem> ();
-
-				foreach (var nativeLibrary in nativeLibrariesPath) {
-					nativeLibraryItems.Add (new TaskItem (nativeLibrary));
-				}
-
-				NativeLibraries = nativeLibraryItems.ToArray ();
-			} catch (Exception ex) {
-				Log.LogError (null, null, null, AppManifest.ItemSpec, 0, 0, 0, 0, "Could not get native libraries: {0}", ex.Message);
-				return false;
-			}
-
-			return mtouchExecution;
+			return base.Execute ();
 		}
 
 		string ResolveFrameworkFile (string fullName)

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -39,6 +39,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<UsingTask TaskName="Xamarin.iOS.Tasks.ACTool" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.iOS.Tasks.Archive" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.iOS.Tasks.CodesignNativeLibraries" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.iOS.Tasks.CodesignVerify" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.iOS.Tasks.CollectAssetPacks" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.iOS.Tasks.CollectFrameworks" AssemblyFile="Xamarin.iOS.Tasks.dll" />
@@ -525,10 +526,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			SdkDevPath="$(_SdkDevPath)"
 			OutputLibrary="$(_AppBundlePath)default.metallib">
 		</MetalLib>
-
-		<CreateItem Include="$(_AppBundlePath)default.metallib">
-			<Output TaskParameter="Include" ItemName="_NativeLibrary" />
-		</CreateItem>
 	</Target>
 
 	<Target Name="_PackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'false'" DependsOnTargets="_CollectBundleResources">
@@ -753,7 +750,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			Verbosity="$(MtouchVerbosity)"
 			>
 			<Output TaskParameter="CompiledArchitectures" PropertyName="_CompiledArchitectures" />
-			<Output TaskParameter="NativeLibraries" ItemName="_NativeLibrary" />
 		</MTouch>
 	</Target>
 
@@ -1618,38 +1614,27 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<!-- Note: Always codesign *.dylibs even for Simulator builds. We use $(_CanOutputAppBundle) because dylibs can exist in app extensions as well. -->
-	<Target Name="_CodesignNativeLibraries" Condition="'$(_CanOutputAppBundle)' == 'true' And '$(_CodeSigningKey)' != '' And '@(_NativeLibrary)' != ''" DependsOnTargets="_DetectSigningIdentity;_CompileToNative"
-		Inputs="%(_NativeLibrary.Identity)" Outputs="$(DeviceSpecificIntermediateOutputPath)codesign\%(_NativeLibrary.Filename)%(_NativeLibrary.Extension)">
+	<Target Name="_CodesignNativeLibraries" Condition="'$(_CanOutputAppBundle)' == 'true' And '$(_CodeSigningKey)' != ''" DependsOnTargets="_DetectSigningIdentity;_CompileToNative">
 
 		<PropertyGroup>
 			<_CodesignDisableTimestamp>False</_CodesignDisableTimestamp>
 			<_CodesignDisableTimestamp Condition="'$(_SdkIsSimulator)' == 'true' Or '$(MtouchDebug)' == 'true'">True</_CodesignDisableTimestamp>
 		</PropertyGroup>
 
-		<Codesign
+		<CodesignNativeLibraries
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(CodesignExe)"
 			ToolPath="$(CodesignPath)"
+			AppBundleDir="$(AppBundleDir)"
+			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)codesign"
 			CodesignAllocate="$(_CodesignAllocate)"
 			DisableTimestamp="$(_CodesignDisableTimestamp)"
 			Keychain="$(CodesignKeychain)"
-			Resources="@(_NativeLibrary)"
 			SigningKey="$(_CodeSigningKey)"
 			ExtraArgs="$(CodesignExtraArgs)"
 			>
-		</Codesign>
-
-		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(DeviceSpecificIntermediateOutputPath)codesign" />
-
-		<Touch
-			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true'"
-			AlwaysCreate="true"
-			Files="$(DeviceSpecificIntermediateOutputPath)codesign\%(_NativeLibrary.Filename)%(_NativeLibrary.Extension)"
-			>
-			<Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
-		</Touch>
+		</CodesignNativeLibraries>
 	</Target>
 
 	<Target Name="_CodesignFrameworks" Condition="'$(_CanOutputAppBundle)' == 'true' And '$(_CodeSigningKey)' != '' And '@(_Frameworks)' != ''" DependsOnTargets="_DetectSigningIdentity;_CollectFrameworks"
@@ -1696,6 +1681,22 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		DependsOnTargets="_DetectSigningIdentity;_ReadAppExtensionCodesignProperties"
 		Inputs="$(_AppBundlePath)PlugIns\%(_AppExtensionCodesignProperties.Identity)\%(_AppExtensionCodesignProperties.NativeExecutable);%(_AppExtensionCodesignProperties.CodesignAppExtensionInputs)"
 		Outputs="$(_AppBundlePath)PlugIns\%(_AppExtensionCodesignProperties.Identity)\_CodeSignature\CodeResources">
+
+		<CodesignNativeLibraries
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			ToolExe="$(CodesignExe)"
+			ToolPath="$(CodesignPath)"
+			AppBundleDir="$(_AppBundlePath)PlugIns\%(_AppExtensionCodesignProperties.Identity)"
+			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)codesign\PlugIns\%(_AppExtensionCodesignProperties.Identity)"
+			CodesignAllocate="%(_AppExtensionCodesignProperties.CodesignAllocate)"
+			DisableTimestamp="%(_AppExtensionCodesignProperties.DisableTimestamp)"
+			Keychain="%(_AppExtensionCodesignProperties.Keychain)"
+			SigningKey="%(_AppExtensionCodesignProperties.SigningKey)"
+			ExtraArgs="%(_AppExtensionCodesignProperties.ExtraArgs)"
+			>
+		</CodesignNativeLibraries>
+
 		<Codesign
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Tasks\WriteAssetPackManifestTaskBase.cs" />
     <Compile Include="Tasks\FindWatchOS2AppBundleTaskBase.cs" />
     <Compile Include="Tasks\DetectDebugNetworkConfigurationTaskBase.cs" />
+    <Compile Include="Tasks\CodesignNativeLibrariesTaskBase.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/msbuild/Xamarin.iOS.Tasks/Tasks/CodesignNativeLibraries.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Tasks/CodesignNativeLibraries.cs
@@ -1,0 +1,6 @@
+﻿namespace Xamarin.iOS.Tasks
+{
+	public class CodesignNativeLibraries : CodesignNativeLibrariesTaskBase
+	{
+	}
+}

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Tasks\WriteAssetPackManifest.cs" />
     <Compile Include="Tasks\FindWatchOS2AppBundle.cs" />
     <Compile Include="Tasks\DetectDebugNetworkConfiguration.cs" />
+    <Compile Include="Tasks\CodesignNativeLibraries.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.iOS.Tasks.Core\Xamarin.iOS.Tasks.Core.csproj">

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/CodesignAppBundle.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/CodesignAppBundle.cs
@@ -1,61 +1,96 @@
 ﻿using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Diagnostics;
 
 using NUnit.Framework;
 
+using Xamarin.MacDev;
+
 namespace Xamarin.iOS.Tasks
 {
-	[TestFixture ("iPhone")]
+	[TestFixture ("Debug")]
+	[TestFixture ("Release")]
 	public class CodesignAppBundle : ProjectTest
 	{
-		public CodesignAppBundle (string platform) : base (platform)
+		readonly string config;
+
+		public CodesignAppBundle (string configuration) : base ("iPhone")
 		{
+			config = configuration;
 		}
 
-		[Ignore] // requires msbuild instead of xbuild
+		static bool IsCodesigned (string path)
+		{
+			var psi = new ProcessStartInfo ("/usr/bin/codesign");
+			var args = new ProcessArgumentBuilder ();
+
+			args.Add ("--verify");
+			args.AddQuoted (path);
+
+			psi.Arguments = args.ToString ();
+
+			var process = Process.Start (psi);
+			process.WaitForExit ();
+
+			return process.ExitCode == 0;
+		}
+
+		void AssertProperlyCodesigned ()
+		{
+			foreach (var dylib in Directory.EnumerateFiles (AppBundlePath, "*.dylib", SearchOption.AllDirectories))
+				Assert.IsTrue (IsCodesigned (dylib), "{0} is not properly codesigned.", dylib);
+		}
+
 		[Test]
 		public void RebuildNoChanges ()
 		{
-			BuildProject ("MyTabbedApplication", Platform, "Release", clean: true);
+			BuildProject ("MyTabbedApplication", Platform, config, clean: true);
 
-			var dsymDir = Path.GetFullPath (Path.Combine (AppBundlePath, "..", "MyTabbedApplication.app.dSYM"));
-			var appexDsymDir = Path.GetFullPath (Path.Combine (AppBundlePath, "..", "MyActionExtension.appex.dSYM"));
+			AssertProperlyCodesigned ();
 
-			var timestamps = Directory.EnumerateFiles (AppBundlePath, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
-			var dsymTimestamps = Directory.EnumerateFiles (dsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
-			var appexDsymTimestamps = Directory.EnumerateFiles (appexDsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
+			//var dsymDir = Path.GetFullPath (Path.Combine (AppBundlePath, "..", "MyTabbedApplication.app.dSYM"));
+			//var appexDsymDir = Path.GetFullPath (Path.Combine (AppBundlePath, "..", "MyActionExtension.appex.dSYM"));
+
+			//var timestamps = Directory.EnumerateFiles (AppBundlePath, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
+			//var dsymTimestamps = Directory.EnumerateFiles (dsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
+			//var appexDsymTimestamps = Directory.EnumerateFiles (appexDsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
 
 			Thread.Sleep (1000);
 
 			// Rebuild w/ no changes
-			BuildProject ("MyTabbedApplication", Platform, "Release", clean: false);
+			BuildProject ("MyTabbedApplication", Platform, config, clean: false);
 
-			var newTimestamps = Directory.EnumerateFiles (AppBundlePath, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
-			var newDsymTimestamps = Directory.EnumerateFiles (dsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
-			var newAppexDsymTimestamps = Directory.EnumerateFiles (appexDsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
+			AssertProperlyCodesigned ();
 
-			foreach (var file in timestamps.Keys)
-				Assert.AreEqual (timestamps[file], newTimestamps[file], "App Bundle timestamp changed: " + file);
+			// Note: the following checks all require msbuild instead of xbuild to work properly
 
-			foreach (var file in dsymTimestamps.Keys)
-				Assert.AreEqual (dsymTimestamps[file], newDsymTimestamps[file], "App Bundle DSym timestamp changed: " + file);
+			//var newTimestamps = Directory.EnumerateFiles (AppBundlePath, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
+			//var newDsymTimestamps = Directory.EnumerateFiles (dsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
+			//var newAppexDsymTimestamps = Directory.EnumerateFiles (appexDsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
 
-			foreach (var file in appexDsymTimestamps.Keys)
-				Assert.AreEqual (appexDsymTimestamps[file], newAppexDsymTimestamps[file], "App Extension DSym timestamp changed: " + file);
+			//foreach (var file in timestamps.Keys)
+			//	Assert.AreEqual (timestamps[file], newTimestamps[file], "App Bundle timestamp changed: " + file);
+
+			//foreach (var file in dsymTimestamps.Keys)
+			//	Assert.AreEqual (dsymTimestamps[file], newDsymTimestamps[file], "App Bundle DSym timestamp changed: " + file);
+
+			//foreach (var file in appexDsymTimestamps.Keys)
+			//	Assert.AreEqual (appexDsymTimestamps[file], newAppexDsymTimestamps[file], "App Extension DSym timestamp changed: " + file);
 		}
 
-		[Ignore] // requires msbuild instead of xbuild
 		[Test]
 		public void CodesignAfterModifyingAppExtensionTest ()
 		{
-			var csproj = BuildProject ("MyTabbedApplication", Platform, "Release", clean: true);
+			var csproj = BuildProject ("MyTabbedApplication", Platform, config, clean: true);
 			var testsDir = Path.GetDirectoryName (Path.GetDirectoryName (csproj));
 			var appexProjectDir = Path.Combine (testsDir, "MyActionExtension");
 			var viewController = Path.Combine (appexProjectDir, "ActionViewController.cs");
 			var mainExecutable = Path.Combine (AppBundlePath, "MyTabbedApplication");
 			var timestamp = File.GetLastWriteTimeUtc (mainExecutable);
 			var text = File.ReadAllText (viewController);
+
+			AssertProperlyCodesigned ();
 
 			Thread.Sleep (1000);
 
@@ -64,11 +99,13 @@ namespace Xamarin.iOS.Tasks
 			File.WriteAllText (viewController, text);
 
 			try {
-				BuildProject ("MyTabbedApplication", Platform, "Release", clean: false);
+				BuildProject ("MyTabbedApplication", Platform, config, clean: false);
 				var newTimestamp = File.GetLastWriteTimeUtc (mainExecutable);
 
 				// make sure that the main app bundle was codesigned due to the changes in the appex
 				Assert.IsTrue (newTimestamp > timestamp, "The main app bundle does not seem to have been re-codesigned");
+
+				AssertProperlyCodesigned ();
 			} finally {
 				// restore the original ActionViewController.cs code...
 				text = text.Replace ("bool imageFound = true;", "bool imageFound = false;");
@@ -76,17 +113,18 @@ namespace Xamarin.iOS.Tasks
 			}
 		}
 
-		[Ignore] // requires msbuild instead of xbuild
 		[Test]
 		public void CodesignAfterModifyingWatchApp2Test ()
 		{
-			var csproj = BuildProject ("MyWatch2Container", Platform, "Release", clean: true);
+			var csproj = BuildProject ("MyWatch2Container", Platform, config, clean: true);
 			var testsDir = Path.GetDirectoryName (Path.GetDirectoryName (csproj));
 			var appexProjectDir = Path.Combine (testsDir, "MyWatchKit2Extension");
 			var viewController = Path.Combine (appexProjectDir, "InterfaceController.cs");
 			var mainExecutable = Path.Combine (AppBundlePath, "MyWatch2Container");
 			var timestamp = File.GetLastWriteTimeUtc (mainExecutable);
 			var text = File.ReadAllText (viewController);
+
+			AssertProperlyCodesigned ();
 
 			Thread.Sleep (1000);
 
@@ -95,11 +133,15 @@ namespace Xamarin.iOS.Tasks
 			File.WriteAllText (viewController, text);
 
 			try {
-				BuildProject ("MyWatch2Container", Platform, "Release", clean: false);
+				BuildProject ("MyWatch2Container", Platform, config, clean: false);
+
+				AssertProperlyCodesigned ();
+
 				var newTimestamp = File.GetLastWriteTimeUtc (mainExecutable);
 
 				// make sure that the main app bundle was codesigned due to the changes in the appex
-				Assert.IsTrue (newTimestamp > timestamp, "The main app bundle does not seem to have been re-codesigned");
+				// Note: this step requires msbuild instead of xbuild to work properly
+				//Assert.IsTrue (newTimestamp > timestamp, "The main app bundle does not seem to have been re-codesigned");
 			} finally {
 				// restore the original ActionViewController.cs code...
 				text = text.Replace ("{0} The Awakening...", "{0} awake with context");


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=52745

Added a new CodesignNativeLibraries task that scans for
and then codesigns each *.dylib and *.metallib in the
app bundle (minus those in the PlugIns and Watch dirs).