### PR TITLE
Fix shutdown hang

### DIFF
--- a/tests/common/mac/MacTestMain.cs
+++ b/tests/common/mac/MacTestMain.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Mac.Tests
 
 			public void Shutdown ()
 			{
-				Environment.Exit (TestRunner.ExitCode);
+				NSApplication.SharedApplication.Terminate (this);
 			}
 		}
 #else


### PR DESCRIPTION
Environment.Exit might hang in the following case:
 - thread T1 calls `InvokeOnMainLoop` and wait for main thread T2 to execute it
 - thread T2 calls Environment.Exit and tries to suspend T1
   - mono expect T1 to acknowledge T2 that it's been suspended <- livelock

This used to work with mono/4.8, because as T1 is a threadpool thread, the threadpool would try to kill it via `mono_thread_internal_stop(thread)` which would set `thread->state |= ThreadState_StopRequested`, then when suspending all threads (in `Environment.Exit`), we would ignore threads with `thread->state & ThreadState_StopRequested`.

mono/2017-02 doesn't treat threadpool threads any differently than normal threads anymore (it's not trying to stop them, but it's just going to suspend them), and that's what triggering the hang. Having a normal thread calls `InvokeOnMainLoop` triggers this hang with mono/4.8.

This fixes https://bugzilla.xamarin.com/show_bug.cgi?id=52604