### PR TITLE
[coregraphics] Add CGRect.Null and Infinite properties. Fixes #43628

### DIFF
--- a/src/NativeTypes/Drawing.tt
+++ b/src/NativeTypes/Drawing.tt
@@ -257,7 +257,20 @@ namespace XamCore.CoreGraphics
 	[Serializable]
 	public struct CGRect : IEquatable<CGRect>
 	{
+		[Field ("CGRectZero")] // unused but helps xtro
 		public static readonly CGRect Empty;
+
+#if !COREBUILD
+		[Field ("CGRectNull")] // unused but helps xtro
+		public static CGRect Null {
+			get { return Dlfcn.GetCGRect (Libraries.CoreGraphics.Handle, "CGRectNull"); }
+		}
+
+		[Field ("CGRectInfinite")] // unused but helps xtro
+		public static CGRect Infinite {
+			get { return Dlfcn.GetCGRect (Libraries.CoreGraphics.Handle, "CGRectInfinite"); }
+		}
+#endif
 
 		public static bool operator == (CGRect left, CGRect right)
 		{

--- a/src/NativeTypes/Drawing.tt
+++ b/src/NativeTypes/Drawing.tt
@@ -257,16 +257,16 @@ namespace XamCore.CoreGraphics
 	[Serializable]
 	public struct CGRect : IEquatable<CGRect>
 	{
-		[Field ("CGRectZero")] // unused but helps xtro
+		[Field ("CGRectZero", "CoreGraphics")] // unused but helps xtro
 		public static readonly CGRect Empty;
 
 #if !COREBUILD
-		[Field ("CGRectNull")] // unused but helps xtro
+		[Field ("CGRectNull", "CoreGraphics")] // unused but helps xtro
 		public static CGRect Null {
 			get { return Dlfcn.GetCGRect (Libraries.CoreGraphics.Handle, "CGRectNull"); }
 		}
 
-		[Field ("CGRectInfinite")] // unused but helps xtro
+		[Field ("CGRectInfinite", "CoreGraphics")] // unused but helps xtro
 		public static CGRect Infinite {
 			get { return Dlfcn.GetCGRect (Libraries.CoreGraphics.Handle, "CGRectInfinite"); }
 		}

--- a/src/ObjCRuntime/Dlfcn.cs
+++ b/src/ObjCRuntime/Dlfcn.cs
@@ -283,6 +283,17 @@ namespace XamCore.ObjCRuntime {
 		}
 #endif
 
+		public static CGRect GetCGRect (IntPtr handle, string symbol)
+		{
+			var indirect = dlsym (handle, symbol);
+			if (indirect == IntPtr.Zero)
+				return CGRect.Empty;
+			unsafe {
+				nfloat *ptr = (nfloat *) indirect;
+				return new CGRect (ptr [0], ptr [1], ptr [2], ptr [3]);
+			}
+		}
+
 		public static CGSize GetCGSize (IntPtr handle, string symbol)
 		{
 			var indirect = dlsym (handle, symbol);

--- a/tests/monotouch-test/CoreGraphics/RectTest.cs
+++ b/tests/monotouch-test/CoreGraphics/RectTest.cs
@@ -11,9 +11,11 @@ using System;
 #if XAMCORE_2_0
 using Foundation;
 using CoreGraphics;
+using ObjCRuntime;
 #else
 using MonoTouch.CoreGraphics;
 using MonoTouch.Foundation;
+using MonoTouch.ObjCRuntime;
 using System.Drawing;
 #endif
 using NUnit.Framework;
@@ -55,6 +57,39 @@ namespace MonoTouchFixtures.CoreGraphics
 			Assert.AreEqual (-28, (int)rect.Y, "y 3");
 			Assert.AreEqual (43, (int)rect.Width, "w 3");
 			Assert.AreEqual (64, (int)rect.Height, "h 3");
+		}
+
+		[Test]
+		public void Null ()
+		{
+			Assert.True (CGRect.Null.IsNull (), "Null.IsNull");
+			Assert.True (CGRect.Null.IsEmpty, "Null.IsEmpty");
+			Assert.False (CGRect.Null.IsInfinite (), "Null.IsInfinite");
+		}
+
+		[Test]
+		public void Infinite ()
+		{
+			Assert.True (CGRect.Infinite.IsInfinite (), "Infinite.IsInfinite");
+			Assert.False (CGRect.Infinite.IsEmpty, "Infinite.IsEmpty");
+			Assert.False (CGRect.Infinite.IsNull (), "Infinite.IsNull");
+		}
+
+		[Test]
+		public void Empty ()
+		{
+			Assert.True (CGRect.Empty.IsEmpty, "Empty.IsEmpty");
+			Assert.False (CGRect.Empty.IsNull (), "Empty.IsNull");
+			Assert.False (CGRect.Empty.IsInfinite (), "Empty.IsInfinite");
+
+			// for System.Drawing compatibility this was named Empty - test confirms it's identical to CGRectZero
+			var handle = Dlfcn.dlopen (Constants.CoreGraphicsLibrary, 0);
+			try {
+				var zero = Dlfcn.GetCGRect (handle, "CGRectZero");
+				Assert.AreEqual (CGRect.Empty, zero, "CGRectZero");
+			} finally {
+				Dlfcn.dlclose (handle);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Apple has both an Empty and Null constants. Our implementation is largely
done in managed code and, for historical reasons [1], match System.Drawing
behaviour. Still the constant is useful for other (e.g. 3rd party) APIs.

Also add CFRect.Infinite for the missing CGRectInfinite symbol.

[1] In the original classic we only provided RectangleF not CGRect

references:
* https://bugzilla.xamarin.com/show_bug.cgi?id=43628
* xtro
	common.unclassified:!missing-field! CGRectNull not bound
	common.unclassified:!missing-field! CGRectInfinite not bound