### PR TITLE
[runtime] Fix bug 52308 Console.WriteLine text is not showing in Device Log.

### DIFF
--- a/runtime/xamarin-support.m
+++ b/runtime/xamarin-support.m
@@ -21,22 +21,23 @@ void
 xamarin_log (const unsigned short *unicodeMessage)
 {
 	// COOP: no managed memory access: any mode.
-#if TARGET_OS_WATCH && defined (__arm__) // maybe make this configurable somehow?
 	int length = 0;
 	const unsigned short *ptr = unicodeMessage;
 	while (*ptr++)
 		length += sizeof (unsigned short);
 	NSString *msg = [[NSString alloc] initWithBytes: unicodeMessage length: length encoding: NSUTF16LittleEndianStringEncoding];
+
+#if TARGET_OS_WATCH && defined (__arm__) // maybe make this configurable somehow?
 	const char *utf8 = [msg UTF8String];
 	int len = strlen (utf8);
 	fwrite (utf8, 1, len, stdout);
 	if (len == 0 || utf8 [len - 1] != '\n')
 		fwrite ("\n", 1, 1, stdout);
 	fflush (stdout);
-	[msg release];
 #else
-	NSLog (@"%S", unicodeMessage);
+	NSLog (@"%@", msg);
 #endif
+	[msg release];
 }
 
 void*


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=52308

Apple moved to os_log[1] in iOS 10 / macOS 10.12 / tvOS 10 / watchOS 3.0
whenever you call NSLog we used to rely on NSLog parsing "%S" but
it seems broken. We now just create a NSString from the unicode str
and give that to NSLog when not in watch (NSLog in watch is broken yay).

[1]: https://developer.apple.com/reference/os/logging?language=objc