### PR TITLE
[generator] Fix native enum in native delegates return types. Fixes #53058

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1468,6 +1468,9 @@ public partial class Generator : IMemberGatherer {
 		} else if (mi.ReturnType == TypeManager.System_String) {
 			returntype = "IntPtr";
 			returnformat = "return NSString.CreateNative ({0}, true);";
+		} else if (IsNativeEnum (mi.ReturnType)) {
+			returntype = "IntPtr";
+			returnformat = "return (IntPtr) {0};";
 		} else {
 			returntype = FormatType (mi.DeclaringType, mi.ReturnType);
 		}
@@ -1601,6 +1604,8 @@ public partial class Generator : IMemberGatherer {
 			throw new BindingException (1001, true, "Do not know how to make a trampoline for {0}", pi);
 		}
 
+		var rt = mi.ReturnType;
+		var rts = IsNativeEnum (rt) ? "var" : rt.ToString ();
 		var trampoline_name = MakeTrampolineName (t);
 		var ti = new TrampolineInfo (userDelegate: FormatType (null, t),
 					     delegateName: "D" + trampoline_name,
@@ -1609,7 +1614,7 @@ public partial class Generator : IMemberGatherer {
 		                             convert: convert.ToString (),
 					     invoke: invoke.ToString (),
 					     returnType: returntype,
-					     delegateReturnType: mi.ReturnType.ToString (),
+		                             delegateReturnType: rts,
 					     returnFormat: returnformat,
 					     clear: clear.ToString (),
 					     type: t);

--- a/tests/introspection/iOS/iOSApiPInvokeTest.cs
+++ b/tests/introspection/iOS/iOSApiPInvokeTest.cs
@@ -107,19 +107,6 @@ namespace Introspection {
 			Assert.AreEqual (0, Errors, "{0} errors found in {1} native delegate validated: {2}", Errors, n, string.Join (", ", failed_api));
 		}
 
-		protected override bool Skip (MethodInfo methodInfo)
-		{
-			// ignore until https://bugzilla.xamarin.com/show_bug.cgi?id=53058 is fixed
-			if (methodInfo.DeclaringType.DeclaringType?.Name == "Trampolines") {
-				switch (methodInfo.ReturnType.Name) {
-				case "MPRemoteCommandHandlerStatus":
-				case "NSComparisonResult":
-					return true;
-				}
-			}
-			return base.Skip (methodInfo);
-		}
-
 		[Test]
 		public void MonoPInvokeCallback ()
 		{


### PR DESCRIPTION
A `[Native]` enum is either 32 bits or 64 bits depending on the CPU,
i.e. it's a `NS[U]Integer`. However the managed representation is
*always* 64 bits, a `long` enum, which means it cannot be used
directly (without a cast) when declaring code that match native.

This also enable us to remove the hack from PR #1751 to ignore some
generated trampoline code.

reference:
* https://bugzilla.xamarin.com/show_bug.cgi?id=53058
* generated code diff: https://gist.github.com/spouliot/f6196aa892a7a33257fe2cf421fffc2e