### PR TITLE
[modelio] Add missing MDLMesh constructors and fix xtro

### DIFF
--- a/runtime/bindings-generator.cs
+++ b/runtime/bindings-generator.cs
@@ -466,6 +466,22 @@ namespace Xamarin.BindingMethods.Generator
 
 			data.Add (
 				new FunctionData {
+					Comment = " // IntPtr func (Vector3, Vector3i, bool, nint, IntPtr)",
+					Prefix = "simd__",
+					Variants = Variants.NonStret,
+					ReturnType = Types.IntPtr,
+					Parameters = new ParameterData[] {
+						new ParameterData { TypeData = Types.Vector3 },
+						new ParameterData { TypeData = Types.Vector3i },
+						new ParameterData { TypeData = Types.Bool },
+						new ParameterData { TypeData = Types.NInt },
+						new ParameterData { TypeData = Types.IntPtr },
+					},
+				}
+			);
+
+			data.Add (
+				new FunctionData {
 					Comment = " // void func (Vector3, Vector3)",
 					Prefix = "simd__",
 					Variants = Variants.NonStret,
@@ -1430,6 +1446,21 @@ namespace Xamarin.BindingMethods.Generator
 			// Required for ModelIO
 			data.Add (
 				new FunctionData {
+					Comment = " // IntPtr func (Vector3, bool, nint, IntPtr)",
+					Prefix = "simd__",
+					Variants = Variants.NonStret,
+					ReturnType = Types.IntPtr,
+					Parameters = new ParameterData[] {
+						new ParameterData { TypeData = Types.Vector3 },
+						new ParameterData { TypeData = Types.Bool },
+						new ParameterData { TypeData = Types.NInt },
+						new ParameterData { TypeData = Types.IntPtr },
+					},
+				}
+			);
+
+			data.Add (
+				new FunctionData {
 					Comment = " // IntPtr func (Vector3, Vector2i, bool, IntPtr, IntPtr)",
 					Prefix = "simd__",
 					Variants = Variants.NonStret,
@@ -1507,6 +1538,24 @@ namespace Xamarin.BindingMethods.Generator
 
 			data.Add (
 				new FunctionData {
+					Comment = " // IntPtr func (Vector3, Vector2i, bool, bool, bool, nint, IntPtr)",
+					Prefix = "simd__",
+					Variants = Variants.NonStret,
+					ReturnType = Types.IntPtr,
+					Parameters = new ParameterData[] {
+						new ParameterData { TypeData = Types.Vector3 },
+						new ParameterData { TypeData = Types.Vector2i },
+						new ParameterData { TypeData = Types.Bool },
+						new ParameterData { TypeData = Types.Bool },
+						new ParameterData { TypeData = Types.Bool },
+						new ParameterData { TypeData = Types.NInt },
+						new ParameterData { TypeData = Types.IntPtr },
+					},
+				}
+			);
+
+			data.Add (
+				new FunctionData {
 					Comment = " // IntPtr func (Vector3, Vector2i, int, bool, nint, IntPtr)",
 					Prefix = "simd__",
 					Variants = Variants.NonStret,
@@ -1516,6 +1565,21 @@ namespace Xamarin.BindingMethods.Generator
 						new ParameterData { TypeData = Types.Vector2i },
 						new ParameterData { TypeData = Types.Int32 },
 						new ParameterData { TypeData = Types.Bool },
+						new ParameterData { TypeData = Types.NInt },
+						new ParameterData { TypeData = Types.IntPtr },
+					},
+				}
+			);
+
+			data.Add (
+				new FunctionData {
+					Comment = " // IntPtr func (Vector3, Vector2i, nint, IntPtr)",
+					Prefix = "simd__",
+					Variants = Variants.NonStret,
+					ReturnType = Types.IntPtr,
+					Parameters = new ParameterData[] {
+						new ParameterData { TypeData = Types.Vector3 },
+						new ParameterData { TypeData = Types.Vector2i },
 						new ParameterData { TypeData = Types.NInt },
 						new ParameterData { TypeData = Types.IntPtr },
 					},

--- a/src/ModelIO/MDLMesh.cs
+++ b/src/ModelIO/MDLMesh.cs
@@ -17,6 +17,7 @@ using XamCore.ObjCRuntime;
 using Vector2i = global::OpenTK.Vector2i;
 using Vector2 = global::OpenTK.Vector2;
 using Vector3 = global::OpenTK.Vector3;
+using Vector3i = global::OpenTK.Vector3i;
 using Vector4 = global::OpenTK.Vector4;
 using Matrix2 = global::OpenTK.Matrix2;
 using Matrix3 = global::OpenTK.Matrix3;
@@ -27,6 +28,12 @@ using MathHelper = global::OpenTK.MathHelper;
 namespace XamCore.ModelIO {
 
 	partial class MDLMesh {
+
+		public enum  MDLMeshVectorType {
+			Dimensions,
+			Extent,
+		}
+
 		internal MDLMesh (Vector3 extent, Vector2i segments, bool inwardNormals, MDLGeometryType geometryType, IMDLMeshBufferAllocator allocator, int? hemisphereSegments, bool? cap, bool? isCone)
 		{
 			if (hemisphereSegments.HasValue) {
@@ -44,9 +51,44 @@ namespace XamCore.ModelIO {
 			}
 		}
 
+		internal MDLMesh (Vector3 extent, Vector3i segments, bool inwardNormals, MDLGeometryType geometryType, IMDLMeshBufferAllocator allocator)
+		{
+			InitializeHandle (InitBox (extent, segments, inwardNormals, geometryType, allocator), "initBoxWithExtent:segments:inwardNormals:geometryType:allocator:");
+		}
+
+		internal MDLMesh (Vector3 extent, Vector2i segments, bool inwardNormals, bool topCap, bool bottomCap, MDLGeometryType geometryType, IMDLMeshBufferAllocator allocator)
+		{
+			InitializeHandle (InitCylinder (extent, segments, inwardNormals, topCap, bottomCap, geometryType, allocator), "initCylinderWithExtent:segments:inwardNormals:topCap:bottomCap:geometryType:allocator:");
+		}
+
+		internal MDLMesh (Vector3 extent, Vector2i segments, MDLGeometryType geometryType, IMDLMeshBufferAllocator allocator)
+		{
+			InitializeHandle (InitPlane (extent, segments, geometryType, allocator), "initPlaneWithExtent:segments:geometryType:allocator:");
+		}
+
+		internal MDLMesh (Vector3 extent, bool inwardNormals, MDLGeometryType geometryType, IMDLMeshBufferAllocator allocator)
+		{
+			InitializeHandle (InitIcosahedron (extent, inwardNormals, geometryType, allocator), "initIcosahedronWithExtent:inwardNormals:geometryType:allocator:");
+		}
+
 		internal MDLMesh (MDLMesh mesh, int submeshIndex, uint subdivisionLevels, IMDLMeshBufferAllocator allocator)
 		{
 			InitializeHandle (InitMesh (mesh, submeshIndex, subdivisionLevels, allocator), "initMeshBySubdividingMesh:submeshIndex:subdivisionLevels:allocator:");
+		}
+
+		// Note: we turn these constructors into static constructors because we don't want to lose the shape name. Also, the signatures of these constructors differ so it would not be possible to use an enum to differentiate the shapes.
+
+		[iOS (10,0)][TV (10,0)][Mac (10,12)]
+		public static MDLMesh CreateBox (Vector3 vector, Vector3i segments, MDLGeometryType geometryType, bool inwardNormals, IMDLMeshBufferAllocator allocator, MDLMeshVectorType type = MDLMeshVectorType.Dimensions)
+		{
+			switch (type) {
+			case MDLMeshVectorType.Dimensions:
+				return NewBoxWithDimensions (vector, segments, geometryType, inwardNormals, allocator);
+			case MDLMeshVectorType.Extent:
+				return new MDLMesh (vector, segments, inwardNormals, geometryType, allocator);
+			default:
+				throw new ArgumentException ("The 'MDLMeshVectorType type' argument needs a value.");
+			}
 		}
 
 		[iOS (10,0)][TV (10,0)][Mac (10,12)]
@@ -62,6 +104,12 @@ namespace XamCore.ModelIO {
 		}
 
 		[iOS (10,0)][TV (10,0)][Mac (10,12)]
+		public static MDLMesh CreateCylinder (Vector3 extent, Vector2i segments, bool inwardNormals, bool topCap, bool bottomCap, MDLGeometryType geometryType, IMDLMeshBufferAllocator allocator)
+		{
+			return new MDLMesh (extent, segments, inwardNormals, topCap, bottomCap, geometryType, allocator);
+		}
+
+		[iOS (10,0)][TV (10,0)][Mac (10,12)]
 		public static MDLMesh CreateCapsule (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, int hemisphereSegments, IMDLMeshBufferAllocator allocator)
 		{
 			return new MDLMesh (dimensions, segments, inwardNormals, geometryType, allocator, hemisphereSegments, null, null);
@@ -71,6 +119,18 @@ namespace XamCore.ModelIO {
 		public static MDLMesh CreateCone (Vector3 dimensions, Vector2i segments, MDLGeometryType geometryType, bool inwardNormals, bool cap, IMDLMeshBufferAllocator allocator)
 		{
 			return new MDLMesh (dimensions, segments, inwardNormals, geometryType, allocator, null, cap, true);
+		}
+
+		[iOS (10,0)][TV (10,0)][Mac (10,12)]
+		public static MDLMesh CreatePlane (Vector3 extent, Vector2i segments, MDLGeometryType geometryType, IMDLMeshBufferAllocator allocator)
+		{
+			return new MDLMesh (extent, segments, geometryType, allocator);
+		}
+
+		[iOS (10,0)][TV (10,0)][Mac (10,12)]
+		public static MDLMesh CreateIcosahedron (Vector3 extent, bool inwardNormals, MDLGeometryType geometryType, IMDLMeshBufferAllocator allocator)
+		{
+			return new MDLMesh (extent, inwardNormals, geometryType, allocator);
 		}
 
 		public static MDLMesh CreateSubdividedMesh (MDLMesh mesh, int submeshIndex, uint subdivisionLevels, IMDLMeshBufferAllocator allocator)

--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -176,6 +176,12 @@ namespace XamCore.ModelIO {
 		[Static]
 		[Export ("assetWithSCNScene:bufferAllocator:")]
 		MDLAsset FromScene (SCNScene scene, [NullAllowed] IMDLMeshBufferAllocator bufferAllocator);
+
+		// MDLAsset_MDLLightBaking (category)
+
+		[Static]
+		[Export ("placeLightProbesWithDensity:heuristic:usingIrradianceDataSource:")]
+		MDLLightProbe[] PlaceLightProbes (float density, MDLProbePlacement type, MDLLightProbeIrradianceDataSource dataSource);
 	}
 
 	// Added in iOS 10 SDK but it is supposed to be present in iOS 9.
@@ -751,6 +757,13 @@ namespace XamCore.ModelIO {
 
 		// MDLMesh_Generators (category)
 
+		// Note: we turn these constructors into static constructors because we don't want to lose the shape name. Also, the signatures of these constructors differ so it would not be possible to use an enum to differentiate the shapes.
+
+		[Internal]
+		[Export ("initBoxWithExtent:segments:inwardNormals:geometryType:allocator:")]
+		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+		IntPtr InitBox (Vector3 extent, Vector3i segments, bool inwardNormals, MDLGeometryType geometryType, [NullAllowed] IMDLMeshBufferAllocator allocator);
+
 		[Internal]
 		[Export ("initSphereWithExtent:segments:inwardNormals:geometryType:allocator:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
@@ -760,6 +773,11 @@ namespace XamCore.ModelIO {
 		[Export ("initHemisphereWithExtent:segments:inwardNormals:cap:geometryType:allocator:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		IntPtr InitHemisphere (Vector3 extent, Vector2i segments, bool inwardNormals, bool cap, MDLGeometryType geometryType, [NullAllowed] IMDLMeshBufferAllocator allocator);
+
+		[Internal]
+		[Export ("initCylinderWithExtent:segments:inwardNormals:topCap:bottomCap:geometryType:allocator:")]
+		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+		IntPtr InitCylinder (Vector3 extent, Vector2i segments, bool inwardNormals, bool topCap, bool bottomCap, MDLGeometryType geometryType, [NullAllowed] IMDLMeshBufferAllocator allocator);
 
 		[Internal]
 		[Export ("initCapsuleWithExtent:cylinderSegments:hemisphereSegments:inwardNormals:geometryType:allocator:")]
@@ -772,14 +790,25 @@ namespace XamCore.ModelIO {
 		IntPtr InitCone (Vector3 extent, Vector2i segments, bool inwardNormals, bool cap, MDLGeometryType geometryType, [NullAllowed] IMDLMeshBufferAllocator allocator);
 
 		[Internal]
+		[Export ("initPlaneWithExtent:segments:geometryType:allocator:")]
+		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+		IntPtr InitPlane (Vector3 extent, Vector2i segments, MDLGeometryType geometryType, [NullAllowed] IMDLMeshBufferAllocator allocator);
+
+		[Internal]
+		[Export ("initIcosahedronWithExtent:inwardNormals:geometryType:allocator:")]
+		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+		IntPtr InitIcosahedron (Vector3 extent, bool inwardNormals, MDLGeometryType geometryType, [NullAllowed] IMDLMeshBufferAllocator allocator);
+
+		[Internal]
 		[Export ("initMeshBySubdividingMesh:submeshIndex:subdivisionLevels:allocator:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		IntPtr InitMesh (MDLMesh mesh, int submeshIndex, uint subdivisionLevels, [NullAllowed] IMDLMeshBufferAllocator allocator);
 
+		[Internal]
 		[Static]
 		[Export ("newBoxWithDimensions:segments:geometryType:inwardNormals:allocator:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		MDLMesh CreateBox (Vector3 dimensions, Vector3i segments, MDLGeometryType geometryType, bool inwardNormals, [NullAllowed] IMDLMeshBufferAllocator allocator);
+		MDLMesh NewBoxWithDimensions (Vector3 dimensions, Vector3i segments, MDLGeometryType geometryType, bool inwardNormals, [NullAllowed] IMDLMeshBufferAllocator allocator);
 
 		[Static]
 		[Export ("newPlaneWithDimensions:segments:geometryType:allocator:")]
@@ -1109,10 +1138,16 @@ namespace XamCore.ModelIO {
 		[Export ("removeObject:")]
 		void RemoveObject (MDLObject @object);
 
+#if XAMCORE_4_0
+		[Abstract]
+#endif
 		[iOS (10,3), TV (10,2), Mac (10,12,4)]
 		[Export ("objectAtIndexedSubscript:")]
 		MDLObject GetObject (nuint index);
 
+#if XAMCORE_4_0
+		[Abstract]
+#endif
 		[iOS (10,3), TV (10,2), Mac (10,12,4)]
 		[Export ("count")]
 		nuint Count { get; }

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -180,6 +180,10 @@ namespace Introspection {
 				case "initHemisphereWithExtent:segments:inwardNormals:cap:geometryType:allocator:":
 				case "initMeshBySubdividingMesh:submeshIndex:subdivisionLevels:allocator:":
 				case "initSphereWithExtent:segments:inwardNormals:geometryType:allocator:":
+				case "initBoxWithExtent:segments:inwardNormals:geometryType:allocator:":
+				case "initCylinderWithExtent:segments:inwardNormals:topCap:bottomCap:geometryType:allocator:":
+				case "initIcosahedronWithExtent:inwardNormals:geometryType:allocator:":
+				case "initPlaneWithExtent:segments:geometryType:allocator:":
 					return true;
 				}
 				break;

--- a/tests/monotouch-test/ModelIO/MDLMesh.cs
+++ b/tests/monotouch-test/ModelIO/MDLMesh.cs
@@ -89,12 +89,29 @@ namespace MonoTouchFixtures.ModelIO {
 		}
 
 		[Test]
-		public void CreateBoxTest ()
+		public void CreateBoxWithDimensonTest ()
 		{
 			Vector3 V3 = new Vector3 (1, 2, 3);
 			Vector3i V3i = new Vector3i (4, 5, 6);
 
 			using (var obj = MDLMesh.CreateBox (V3, V3i, MDLGeometryType.Triangles, true, null)) {
+				Assert.IsNotNull (obj, "obj");
+				Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (0.5f, 1, 1.5f), MinBounds = new Vector3 (-0.5f, -1, -1.5f) }, obj.BoundingBox, "BoundingBox");
+				Assert.AreEqual (1, obj.Submeshes.Count, "Submeshes Count");
+				Assert.AreEqual (1, obj.VertexBuffers.Length, "VertexBuffers Count");
+				Assert.AreEqual (TestRuntime.CheckXcodeVersion (7, 3) ? 214 : 24, obj.VertexCount, "VertexCount");
+				Assert.AreEqual (31, obj.VertexDescriptor.Attributes.Count, "VertexDescriptor Attributes Count");
+				Assert.AreEqual (31, obj.VertexDescriptor.Layouts.Count, "VertexDescriptor Layouts Count");
+			}
+		}
+
+		[Test]
+		public void CreateBoxWithExtentTest ()
+		{
+			Vector3 V3 = new Vector3 (1, 2, 3);
+			Vector3i V3i = new Vector3i (4, 5, 6);
+
+			using (var obj = MDLMesh.CreateBox (V3, V3i, MDLGeometryType.Triangles, true, null, MDLMesh.MDLMeshVectorType.Extent)) {
 				Assert.IsNotNull (obj, "obj");
 				Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (0.5f, 1, 1.5f), MinBounds = new Vector3 (-0.5f, -1, -1.5f) }, obj.BoundingBox, "BoundingBox");
 				Assert.AreEqual (1, obj.Submeshes.Count, "Submeshes Count");
@@ -162,6 +179,31 @@ namespace MonoTouchFixtures.ModelIO {
 				}
 				Assert.AreEqual (1, obj.Submeshes.Count, "Submeshes Count");
 				Assert.AreEqual (18, obj.VertexCount, "VertexCount");
+				Assert.AreEqual (31, obj.VertexDescriptor.Attributes.Count, "VertexDescriptor Attributes Count");
+				Assert.AreEqual (31, obj.VertexDescriptor.Layouts.Count, "VertexDescriptor Layouts Count");
+			}
+		}
+
+		[Test]
+		public void CreateCylinderTest ()
+		{
+			var V3 = new Vector3 (1, 1, 1);
+			var V2i = new Vector2i (3, 3);
+
+			using (var obj = MDLMesh.CreateCylinder (V3, V2i, true, true, true, MDLGeometryType.Triangles, null)) {
+				Assert.IsNotNull (obj, "obj");
+				if (TestRuntime.CheckXcodeVersion (8, 2)) {
+					Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (0.866025448f, 0.5f, 1f), MinBounds = new Vector3 (-0.866025388f, -0.5f, -0.5f) }, obj.BoundingBox, "BoundingBox");
+					Assert.AreEqual (31, obj.VertexBuffers.Length, "VertexBuffers Count");
+				} else if (TestRuntime.CheckXcodeVersion (8, 0)) {
+					Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (0.866025448f, 1.0f, 1f), MinBounds = new Vector3 (-0.866025388f, -1.0f, -0.5f) }, obj.BoundingBox, "BoundingBox");
+					Assert.AreEqual (3, obj.VertexBuffers.Length, "VertexBuffers Count");
+				} else {
+					Asserts.AreEqual (new MDLAxisAlignedBoundingBox { MaxBounds = new Vector3 (1f, 0.5f, 1f), MinBounds = new Vector3 (-0.866025388f, -0.5f, -0.866025388f) }, obj.BoundingBox, "BoundingBox");
+					Assert.AreEqual (1, obj.VertexBuffers.Length, "VertexBuffers Count");
+				}
+				Assert.AreEqual (1, obj.Submeshes.Count, "Submeshes Count");
+				Assert.AreEqual (26, obj.VertexCount, "VertexCount");
 				Assert.AreEqual (31, obj.VertexDescriptor.Attributes.Count, "VertexDescriptor Attributes Count");
 				Assert.AreEqual (31, obj.VertexDescriptor.Layouts.Count, "VertexDescriptor Layouts Count");
 			}
@@ -251,6 +293,41 @@ namespace MonoTouchFixtures.ModelIO {
 				Assert.AreEqual (1, obj.Submeshes.Count, "Submeshes Count");
 				Assert.That (obj.VertexBuffers.Length, Is.GreaterThanOrEqualTo (3), "VertexBuffers Count");
 				Assert.AreEqual (36, obj.VertexCount, "VertexCount");
+				Assert.AreEqual (31, obj.VertexDescriptor.Attributes.Count, "VertexDescriptor Attributes Count");
+				Assert.AreEqual (31, obj.VertexDescriptor.Layouts.Count, "VertexDescriptor Layouts Count");
+			}
+		}
+
+		[Test]
+		public void CreatePaneTest ()
+		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+
+			Vector3 V3 = new Vector3 (1, 2, 3);
+			Vector2i V2i = new Vector2i (4, 5);
+
+			using (var obj = MDLMesh.CreatePlane (V3, V2i, MDLGeometryType.Triangles, null)) {
+				Assert.IsNotNull (obj, "obj");
+				Assert.AreEqual (1, obj.Submeshes.Count, "Submeshes Count");
+				Assert.That (obj.VertexBuffers.Length, Is.GreaterThanOrEqualTo (3), "VertexBuffers Count");
+				Assert.AreEqual (30, obj.VertexCount, "VertexCount");
+				Assert.AreEqual (31, obj.VertexDescriptor.Attributes.Count, "VertexDescriptor Attributes Count");
+				Assert.AreEqual (31, obj.VertexDescriptor.Layouts.Count, "VertexDescriptor Layouts Count");
+			}
+		}
+
+		[Test]
+		public void CreateIcosahedronTest ()
+		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+
+			Vector3 V3 = new Vector3 (1, 2, 3);
+
+			using (var obj = MDLMesh.CreateIcosahedron (V3, true, MDLGeometryType.Triangles, null)) {
+				Assert.IsNotNull (obj, "obj");
+				Assert.AreEqual (1, obj.Submeshes.Count, "Submeshes Count");
+				Assert.That (obj.VertexBuffers.Length, Is.GreaterThanOrEqualTo (1), "VertexBuffers Count");
+				Assert.AreEqual (12, obj.VertexCount, "VertexCount");
 				Assert.AreEqual (31, obj.VertexDescriptor.Attributes.Count, "VertexDescriptor Attributes Count");
 				Assert.AreEqual (31, obj.VertexDescriptor.Layouts.Count, "VertexDescriptor Layouts Count");
 			}

--- a/tests/xtro-sharpie/common.ignore
+++ b/tests/xtro-sharpie/common.ignore
@@ -160,9 +160,13 @@
 !missing-selector! MDLObject::objectForKeyedSubscript: not bound
 !missing-selector! MDLObject::setObject:forKeyedSubscript: not bound
 
-## New @required (abstract) methods in existing types (breaking changes)
-!incorrect-protocol-member! MDLObjectContainerComponent::count is REQUIRED and should be abstract
-!incorrect-protocol-member! MDLObjectContainerComponent::objectAtIndexedSubscript: is REQUIRED and should be abstract
+## old @optional methods that became @required (abstract) in existing types (breaking changes)
+!incorrect-protocol-member! MDLMeshBuffer::allocator is REQUIRED and should be abstract
+!incorrect-protocol-member! MDLMeshBuffer::length is REQUIRED and should be abstract
+!incorrect-protocol-member! MDLMeshBuffer::type is REQUIRED and should be abstract
+!incorrect-protocol-member! MDLMeshBuffer::zone is REQUIRED and should be abstract
+!incorrect-protocol-member! MDLMeshBufferZone::allocator is REQUIRED and should be abstract
+!incorrect-protocol-member! MDLMeshBufferZone::capacity is REQUIRED and should be abstract
 
 
 # Security

--- a/tests/xtro-sharpie/common.pending
+++ b/tests/xtro-sharpie/common.pending
@@ -640,3 +640,12 @@
 
 ## Fixed in XAMCORE_4_0
 !incorrect-protocol-member! GKGameModelPlayer::playerId is REQUIRED and should be abstract
+
+# ModelIO
+
+# fixed in XAMCORE_4_0 - API break
+!incorrect-protocol-member! MDLObjectContainerComponent::count is REQUIRED and should be abstract
+!incorrect-protocol-member! MDLObjectContainerComponent::objectAtIndexedSubscript: is REQUIRED and should be abstract
+!incorrect-protocol-member! MDLTransformComponent::keyTimes is REQUIRED and should be abstract
+!incorrect-protocol-member! MDLTransformComponent::resetsTransform is REQUIRED and should be abstract
+!incorrect-protocol-member! MDLTransformComponent::setResetsTransform: is REQUIRED and should be abstract


### PR DESCRIPTION
Fixes bug #52575: Missing ModelIO API
(https://bugzilla.xamarin.com/show_bug.cgi?id=52575)

We turn the MDLMesh constructors into static ones because we don't want to lose the shape name.
Also, the signatures of these constructors differ so it would not be possible to use an enum to differentiate the shapes.