### PR TITLE
Fixes for XM 4.5 and netstandard13 and updated comments (#1758)

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -68,10 +68,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<AssemblySearchPaths>$(XamarinMacFrameworkRoot)/lib/reference/full;$(XamarinMacFrameworkRoot)/lib/mono;$(AssemblySearchPaths)</AssemblySearchPaths>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(UseXamMacFullFramework)' == 'true'">
-		<AssemblySearchPaths>$(XamarinMacFrameworkRoot)/lib/mono/4.5;$(AssemblySearchPaths)</AssemblySearchPaths>
-	</PropertyGroup>
-
 	<!-- Do not resolve from the GAC under any circumstances in Mobile or XM45 -->
 	<PropertyGroup Condition="(('$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(UseXamMacFullFramework)' == 'true') Or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac') And !$(MonoBundlingExtraArgs.Contains('--allow-unsafe-gac-resolution'))" >
 		<AssemblySearchPaths>$([System.String]::Copy('$(AssemblySearchPaths)').Replace('{GAC}',''))</AssemblySearchPaths>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.XM45.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.XM45.targets
@@ -15,9 +15,17 @@ Copyright (C) 2015 Xamarin Inc. All rights reserved.
 -->
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<!-- These hacks will need to be rewritten if/when we move from xbuild to msbuild. Most likely to use FrameworkPathOverride, which should hopefully work.-->
-	<!-- This lets us bypass the standard MSBuild framework resolution and point to our copy. -->
-	<!-- Without this, we'll resolve System.dll and such from the system mono  -->
+
+	<!-- The XM 4.5 target framework (will hopefully be renamed at some point) is a bit of a strange case -->
+	<!-- It does not declare a TargetFrameworkIdentifier so it can be compatible with "Desktop" nugets -->
+	<!-- These days it could have been done with some patches to nuget and such, but now can not be changed -->
+	<!-- without breaking some number of user projects (forward only mutation is rather unacceptable here) -->
+	<!-- So this file uses some hacks to force xbuild/msbuild to resolve to the BCL/mscorlib/Facades -->
+	<!-- we keep inside Xamarin.Mac's framework and not the system mono ones. System mono is not -->
+	<!-- necessarily in sync with ours and is not safe to depend upon -->
+	
+	<!-- XBuild specific hacks -->
+	<!-- TargetFrameworkDirectory needs to point to ours, and FrameworkPathOverride does not work in xbuild, so we must override. -->
 	<Target Name="GetFrameworkPaths"
                 Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"
                 DependsOnTargets="$(GetFrameworkPathsDependsOn)">
@@ -26,7 +34,8 @@ Copyright (C) 2015 Xamarin Inc. All rights reserved.
                 </CreateProperty>
        </Target>
 
-	<!-- Also part of the GetFrameworkPaths hack. -->
+	<!-- We only need to extend GetReferenceAssemblyPaths slightly, so we can force facades to only comes from our copy -->
+	<!-- but there is no invoking of a base target in msbuild. Copied from Microsoft.Common.targets with small changes -->
 	<Target Name="GetReferenceAssemblyPaths" 
 		Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"
 		DependsOnTargets="$(GetReferenceAssemblyPathsDependsOn)">
@@ -40,16 +49,18 @@ Copyright (C) 2015 Xamarin Inc. All rights reserved.
 		<PropertyGroup Condition="'@(DesignTimeFacadeDirectories)' != ''">
 			<TargetFrameworkDirectory>$(TargetFrameworkDirectory);@(DesignTimeFacadeDirectories)</TargetFrameworkDirectory>
 		</PropertyGroup>
-       	</Target>
+	</Target>
 
 	<!-- This lets us bypass the standard MSBuild resolution of mscorlib, which always picks an incompatible system copy. -->
         <Target Name="_AddCorlibReference" 
 		Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"
 		DependsOnTargets="GetReferenceAssemblyPaths">
-                <ItemGroup>
+  		<ItemGroup>
                         <_ExplicitReference Include="$(XamarinMacFrameworkRoot)/lib/mono/4.5/mscorlib.dll">
                                 <Private>false</Private>
                         </_ExplicitReference>
                 </ItemGroup>
-	</Target>	
+	</Target>
+	<!-- End the xbuild hacks  -->
+	<!-- TODO - msbuild hacks  -->
 </Project>

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -705,7 +705,7 @@ namespace Xamarin.Bundler {
 					throw new MonoMacException (23, true, "Application name '{0}.exe' conflicts with another user assembly.", root_wo_ext);
 
 				string monoFrameworkDirectory = TargetFramework.MonoFrameworkDirectory;
-				if (IsUnifiedFullSystemFramework || IsClassic)
+				if (IsUnifiedFullXamMacFramework || IsUnifiedFullSystemFramework || IsClassic)
 					monoFrameworkDirectory = "4.5";
 
 				fx_dir = Path.Combine (MonoDirectory, "lib", "mono", monoFrameworkDirectory);


### PR DESCRIPTION
- Update comments on XM45.targets file
- Remove unnecessary AssemblySearchPaths hack causing issues using nugets with same name as Facades
- Note: MSBuild with XM 4.5 is still broken for now