### PR TITLE
[mapkit] Add MKLocalSearchRequest initWithCompletion: in unified. Fixes #53083

### DIFF
--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -1246,11 +1246,9 @@ namespace XamCore.MapKit {
 #endif
 	interface MKLocalSearchRequest : NSCopying {
 
-#if !XAMCORE_2_0 && !MONOMAC
-		[TV (9,2)][NoWatch][iOS (9,3)]
+		[TV (9,2)][NoWatch][iOS (9,3)][Mac (10,11,4, onlyOn64 : true)]
 		[Export ("initWithCompletion:")]
 		IntPtr Constructor (MKLocalSearchCompletion completion);
-#endif
 
 		[Export ("naturalLanguageQuery", ArgumentSemantic.Copy)]
 		[NullAllowed]


### PR DESCRIPTION
It was left out by mistake when added (to classic only). Since then macOS
also added support for the API.

references
bugzilla: https://bugzilla.xamarin.com/show_bug.cgi?id=53083
xtro: common.unclassified:!missing-selector! MKLocalSearchRequest::initWithCompletion: not bound