### PR TITLE
[msbuild] Fix error when building Xamarin.Mac binding projects.

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Tasks/BTouch.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/BTouch.cs
@@ -40,14 +40,28 @@ namespace Xamarin.Mac.Tasks
 			var sb = new StringBuilder ();
 			if (isMobile) {
 				sb.Append (Path.Combine (FrameworkRoot, "lib", "bmac", "bmac-mobile.exe"));
-				sb.Append (" --target-framework=Xamarin.Mac,Version=v2.0,Profile=Mobile ");
 			} else {
 				sb.Append (Path.Combine (FrameworkRoot, "lib", "bmac", "bmac-full.exe"));
-				sb.Append (" --target-framework=Xamarin.Mac,Version=v4.5,Profile=Full ");
 			}
-			sb.Append ("-nostdlib ");
+			sb.Append (" -nostdlib ");
 			sb.Append (base.GenerateCommandLineCommands ());
 			return sb.ToString ();
 		}
+
+		protected override string GetTargetFrameworkArgument ()
+		{
+			switch (TargetFrameworkIdentifier) {
+				case null:
+				case "":
+				case "Xamarin.Mac":
+					return "/target-framework=Xamarin.Mac,Version=v2.0,Profile=Mobile";
+				case ".NETFramework":
+					return "/target-framework=Xamarin.Mac,Version=v4.5,Profile=Full";
+				default:
+					Log.LogError ($"Unknown target framework identifier: {TargetFrameworkIdentifier}.");
+					return string.Empty;
+			}
+		}
+
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
@@ -183,19 +183,23 @@ namespace Xamarin.MacDev.Tasks {
 			if (GeneratedSourcesFileList != null)
 				cmd.AppendSwitchIfNotNull ("/sourceonly:", Path.GetFullPath (GeneratedSourcesFileList));
 
+			cmd.AppendSwitch (GetTargetFrameworkArgument ());
+
+			return cmd.ToString ();
+		}
+
+		protected virtual string GetTargetFrameworkArgument ()
+		{
 			switch (TargetFrameworkIdentifier) {
 				case "MonoTouch":
 				case "Xamarin.iOS":
 				case "Xamarin.TVOS":
 				case "Xamarin.WatchOS":
-					cmd.AppendSwitch ($"/target-framework={TargetFrameworkIdentifier},v1.0");
-					break;
+					return $"/target-framework={TargetFrameworkIdentifier},v1.0";
 				default:
 					Log.LogError ($"Unknown target framework identifier: {TargetFrameworkIdentifier}.");
-					break;
+					return string.Empty;
 			}
-
-			return cmd.ToString ();
 		}
 
 		public override bool Execute ()


### PR DESCRIPTION
Xamarin.Mac binding projects would show this error:

> /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/Xamarin.Mac.ObjcBinding.CSharp.targets: error : Unknown target framework identifier: Xamarin.Mac.

while at the same time not actually failing the build (so nothing broke,
making it harder to notice).

The error is printed in BTouchTaskBase, which was previously only used for
Xamarin.iOS. Now we're using it for both Xamarin.iOS and Xamarin.Mac (in which
case it's subclassed), so make sure to not validate the
TargetFrameworkIdentifier according to only valid TargetFrameworkIdentifiers
for Xamarin.iOS.

This is accomplished by adding a new virtual overload to validate (and get the
right /target-framework argument for the generator), and override that method
in Xamarin.Mac's BTouch subclass.