### PR TITLE
[uikit] Mark NSFileProviderExtension as [ThreadSafe]. Fixes #53075

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -279,6 +279,7 @@ namespace XamCore.UIKit {
 	[NoWatch]
 	[NoTV]
 	[iOS (8,0)]
+	[ThreadSafe]
 	[BaseType (typeof (NSObject))]
 	partial interface NSFileProviderExtension {
 	    [Static, Export ("writePlaceholderAtURL:withMetadata:error:")]


### PR DESCRIPTION
Even if it's in UIKit, this is not a UI type and does not _suffer_ from
the UI thread restriction. In fact it's used with file coordination which
implies threading is required.

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=53075