### PR TITLE
[runtime] Don't look in shared memory for debug data in normal apps.

### DIFF
--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -368,6 +368,8 @@ app_initialize (xamarin_initialize_data *data, bool is_extension)
 	// The launch code here is publicly documented in xamarin/launch.h
 	// The numbers in the comments refer to numbers in xamarin/launch.h.
 
+	xamarin_is_extension = is_extension;
+
 #ifndef SYSTEM_LAUNCHER
 	if (xammac_setup ()) {
 		data->exit_code = -1;

--- a/runtime/monotouch-debug.m
+++ b/runtime/monotouch-debug.m
@@ -561,8 +561,11 @@ void monotouch_configure_debugging ()
 
 #if MONOTOUCH && (defined(__i386__) || defined (__x86_64__))
 	// Try to read shared memory as well
-	key_t shmkey = ftok ("/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mtouch", 0);
-	if (shmkey == -1) {
+	key_t shmkey;
+	if (!xamarin_is_extension) {
+		// Don't read shared memory in normal apps, because we're always able to pass
+		// the debug data (host/port) using either command-line arguments or environment variables
+	} else if ((shmkey = ftok ("/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mtouch", 0)) == -1) {
 		LOG (PRODUCT ": Could not create shared memory key: %s\n", strerror (errno));
 	} else {
 		int shmsize = 1024;

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -239,6 +239,8 @@ xamarin_main (int argc, char *argv[], bool is_extension)
 	patch_sigaction ();
 #endif
 
+	xamarin_is_extension = is_extension;
+
 	memset (managed_argv, 0, sizeof (char*) * (argc + 2));
 	managed_argv [0] = "monotouch";
 

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -76,6 +76,7 @@ bool xamarin_is_gc_coop = false;
 #endif
 enum MarshalObjectiveCExceptionMode xamarin_marshal_objectivec_exception_mode = MarshalObjectiveCExceptionModeDefault;
 enum MarshalManagedExceptionMode xamarin_marshal_managed_exception_mode = MarshalManagedExceptionModeDefault;
+bool xamarin_is_extension = false;
 
 /* Callbacks */
 

--- a/runtime/xamarin/main.h
+++ b/runtime/xamarin/main.h
@@ -57,6 +57,7 @@ extern const char *xamarin_arch_name;
 extern bool xamarin_is_gc_coop;
 extern enum MarshalObjectiveCExceptionMode xamarin_marshal_objectivec_exception_mode;
 extern enum MarshalManagedExceptionMode xamarin_marshal_managed_exception_mode;
+extern bool xamarin_is_extension;
 
 #ifdef MONOTOUCH
 extern NSString* xamarin_crashlytics_api_key;


### PR DESCRIPTION
Don't look in shared memory for debug data in normal apps, because it
interferes when debugging extensions from the same solution as a container
app:

Example, for a keyboard extension:

1. Run extension in XS.
2. Manually launch the extension's container app (which contains a textbox
   that can be used to launch the keyboard).
3. The container app reads the debug data in shared memory which was intented
   for the extension, and takes over the debugger.
4. Launch keyboard, which will not be able to connect to the IDE because the
   container app already connected to the IDE.