### PR TITLE
[XM] Improve XM msbuild support and add roslyn netstandard test case

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.msbuild.targets
@@ -1,0 +1,63 @@
+﻿<!--
+***********************************************************************************************
+Xamarin.Mac.Common.ImplicitFacade.msbuild.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+This file imports the version- and platform-specific targets for the project importing
+this file. This file also defines targets to produce an error if the specified targets
+file does not exist, but the project is built anyway (command-line or IDE build).
+
+Copyright (C) 2015 Xamarin Inc. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<!-- Unfortuntly Microsoft.NETFramework.CurrentVersion.targets defines this and is not included in Mobile/Modern builds so we'll add it here -->
+	<PropertyGroup>
+		<ResolveReferencesDependsOn>
+			$(ResolveReferencesDependsOn);
+			ImplicitlyExpandDesignTimeFacades
+		</ResolveReferencesDependsOn>
+
+		<ImplicitlyExpandDesignTimeFacadesDependsOn>
+			$(ImplicitlyExpandDesignTimeFacadesDependsOn);
+			GetReferenceAssemblyPaths
+		</ImplicitlyExpandDesignTimeFacadesDependsOn>
+	</PropertyGroup>
+
+	<!-- Implicitly references all portable design-time facades if the user is referencing a System.Runtime-based portable library -->
+	<Target Name="ImplicitlyExpandDesignTimeFacades" DependsOnTargets="$(ImplicitlyExpandDesignTimeFacadesDependsOn)">
+
+	<PropertyGroup>
+		<!-- Does one of our dependencies reference a System.Runtime-based portable library? -->
+		<_HasReferenceToSystemRuntime Condition="'$(DependsOnSystemRuntime)' == 'true' or '%(_ResolvedProjectReferencePaths.TargetPlatformIdentifier)' == 'Portable'">true</_HasReferenceToSystemRuntime>
+	</PropertyGroup>
+
+	<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true'">
+		<_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)*.dll"/>
+
+		<_DesignTimeFacadeAssemblies_Names Include="@(_DesignTimeFacadeAssemblies->'%(FileName)')">
+			<OriginalIdentity>%(_DesignTimeFacadeAssemblies.Identity)</OriginalIdentity>
+		</_DesignTimeFacadeAssemblies_Names>
+
+		<_ReferencePath_Names Include="@(ReferencePath->'%(FileName)')">
+			<OriginalIdentity>%(ReferencePath.Identity)</OriginalIdentity>
+		</_ReferencePath_Names>
+
+		<_DesignTimeFacadeAssemblies_Names Remove="@(_ReferencePath_Names)"/>
+
+		<ReferencePath Include="@(_DesignTimeFacadeAssemblies_Names->'%(OriginalIdentity)')">
+			<WinMDFile>false</WinMDFile>
+			<CopyLocal>false</CopyLocal>
+			<ResolvedFrom>ImplicitlyExpandDesignTimeFacades</ResolvedFrom>
+		</ReferencePath>
+		<_ResolveAssemblyReferenceResolvedFiles Include="@(ReferencePath)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandDesignTimeFacades'" />
+	</ItemGroup>
+
+	<Message Importance="Low" Text="Including @(ReferencePath)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandDesignTimeFacades'" />
+
+	</Target>
+</Project>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.msbuild.targets
@@ -15,7 +15,7 @@ Copyright (C) 2015 Xamarin Inc. All rights reserved.
 -->
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<!-- Unfortuntly Microsoft.NETFramework.CurrentVersion.targets defines this and is not included in Mobile/Modern builds so we'll add it here -->
+	<!-- Microsoft.NETFramework.CurrentVersion.targets defines this and that target file is not pulled in to Mobile/Modern builds -->
 	<PropertyGroup>
 		<ResolveReferencesDependsOn>
 			$(ResolveReferencesDependsOn);

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.msbuild.targets
@@ -10,12 +10,16 @@ This file imports the version- and platform-specific targets for the project imp
 this file. This file also defines targets to produce an error if the specified targets
 file does not exist, but the project is built anyway (command-line or IDE build).
 
-Copyright (C) 2015 Xamarin Inc. All rights reserved.
+Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 ***********************************************************************************************
 -->
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<!-- Microsoft.NETFramework.CurrentVersion.targets defines this and that target file is not pulled in to Mobile/Modern builds -->
+
+	<!-- All of this logic copied directly from Microsoft.NETFramework.CurrentVersion.targets -->
+	<!-- XM Mobile/Modern builds do not import it since their TVI is not NETFramework -->
+	<!-- However it is needed to successfully consume netstandard nuget packages -->
+	
 	<PropertyGroup>
 		<ResolveReferencesDependsOn>
 			$(ResolveReferencesDependsOn);
@@ -30,34 +34,32 @@ Copyright (C) 2015 Xamarin Inc. All rights reserved.
 
 	<!-- Implicitly references all portable design-time facades if the user is referencing a System.Runtime-based portable library -->
 	<Target Name="ImplicitlyExpandDesignTimeFacades" DependsOnTargets="$(ImplicitlyExpandDesignTimeFacadesDependsOn)">
+		<PropertyGroup>
+			<!-- Does one of our dependencies reference a System.Runtime-based portable library? -->
+			<_HasReferenceToSystemRuntime Condition="'$(DependsOnSystemRuntime)' == 'true' or '%(_ResolvedProjectReferencePaths.TargetPlatformIdentifier)' == 'Portable'">true</_HasReferenceToSystemRuntime>
+		</PropertyGroup>
 
-	<PropertyGroup>
-		<!-- Does one of our dependencies reference a System.Runtime-based portable library? -->
-		<_HasReferenceToSystemRuntime Condition="'$(DependsOnSystemRuntime)' == 'true' or '%(_ResolvedProjectReferencePaths.TargetPlatformIdentifier)' == 'Portable'">true</_HasReferenceToSystemRuntime>
-	</PropertyGroup>
+		<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true'">
+			<_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)*.dll"/>
 
-	<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true'">
-		<_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)*.dll"/>
+			<_DesignTimeFacadeAssemblies_Names Include="@(_DesignTimeFacadeAssemblies->'%(FileName)')">
+				<OriginalIdentity>%(_DesignTimeFacadeAssemblies.Identity)</OriginalIdentity>
+			</_DesignTimeFacadeAssemblies_Names>
 
-		<_DesignTimeFacadeAssemblies_Names Include="@(_DesignTimeFacadeAssemblies->'%(FileName)')">
-			<OriginalIdentity>%(_DesignTimeFacadeAssemblies.Identity)</OriginalIdentity>
-		</_DesignTimeFacadeAssemblies_Names>
+			<_ReferencePath_Names Include="@(ReferencePath->'%(FileName)')">
+				<OriginalIdentity>%(ReferencePath.Identity)</OriginalIdentity>
+			</_ReferencePath_Names>
 
-		<_ReferencePath_Names Include="@(ReferencePath->'%(FileName)')">
-			<OriginalIdentity>%(ReferencePath.Identity)</OriginalIdentity>
-		</_ReferencePath_Names>
+			<_DesignTimeFacadeAssemblies_Names Remove="@(_ReferencePath_Names)"/>
 
-		<_DesignTimeFacadeAssemblies_Names Remove="@(_ReferencePath_Names)"/>
+			<ReferencePath Include="@(_DesignTimeFacadeAssemblies_Names->'%(OriginalIdentity)')">
+				<WinMDFile>false</WinMDFile>
+				<CopyLocal>false</CopyLocal>
+				<ResolvedFrom>ImplicitlyExpandDesignTimeFacades</ResolvedFrom>
+			</ReferencePath>
+			<_ResolveAssemblyReferenceResolvedFiles Include="@(ReferencePath)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandDesignTimeFacades'" />
+		</ItemGroup>
 
-		<ReferencePath Include="@(_DesignTimeFacadeAssemblies_Names->'%(OriginalIdentity)')">
-			<WinMDFile>false</WinMDFile>
-			<CopyLocal>false</CopyLocal>
-			<ResolvedFrom>ImplicitlyExpandDesignTimeFacades</ResolvedFrom>
-		</ReferencePath>
-		<_ResolveAssemblyReferenceResolvedFiles Include="@(ReferencePath)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandDesignTimeFacades'" />
-	</ItemGroup>
-
-	<Message Importance="Low" Text="Including @(ReferencePath)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandDesignTimeFacades'" />
-
+		<Message Importance="Low" Text="Including @(ReferencePath)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandDesignTimeFacades'" />
 	</Target>
 </Project>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.xbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.xbuild.targets
@@ -10,7 +10,7 @@ This file imports the version- and platform-specific targets for the project imp
 this file. This file also defines targets to produce an error if the specified targets
 file does not exist, but the project is built anyway (command-line or IDE build).
 
-Copyright (C) 2015 Xamarin Inc. All rights reserved.
+Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 ***********************************************************************************************
 -->
 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.xbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.xbuild.targets
@@ -1,0 +1,55 @@
+﻿<!--
+***********************************************************************************************
+Xamarin.Mac.Common.ImplicitFacade.xbuild.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+This file imports the version- and platform-specific targets for the project importing
+this file. This file also defines targets to produce an error if the specified targets
+file does not exist, but the project is built anyway (command-line or IDE build).
+
+Copyright (C) 2015 Xamarin Inc. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<!-- This logic had previously been XM's implementation in all cases, but in msbuild -->
+	<!-- it is no longer needed. Moved to a conditionally included files, as you can not -->
+	<!-- conditionally redefine a target. -->
+	<PropertyGroup>
+		<ImplicitlyExpandDesignTimeFacades>true</ImplicitlyExpandDesignTimeFacades>
+
+		<ResolveReferencesDependsOn>
+			_SeparateAppExtensionReferences;
+			$(ResolveReferencesDependsOn);
+			ImplicitlyExpandDesignTimeFacades
+		</ResolveReferencesDependsOn>
+
+		<ImplicitlyExpandDesignTimeFacadesDependsOn>
+			$(ImplicitlyExpandDesignTimeFacadesDependsOn);
+			GetReferenceAssemblyPaths
+		</ImplicitlyExpandDesignTimeFacadesDependsOn>
+	</PropertyGroup>
+
+	<Target Name="ImplicitlyExpandDesignTimeFacades" Condition="'$(ImplicitlyExpandDesignTimeFacades)' == 'true'" DependsOnTargets="$(ImplicitlyExpandDesignTimeFacadesDependsOn)">
+		<PropertyGroup>
+			<_HasReferenceToSystemRuntime Condition="'%(ReferenceDependencyPaths.Filename)' == 'System.Runtime'">true</_HasReferenceToSystemRuntime>
+		</PropertyGroup>
+
+		<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true'">
+			<_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)*.dll"/>
+			<ReferencePath Remove="@(_DesignTimeFacadeAssemblies)"/>
+			<ReferencePath Include="%(_DesignTimeFacadeAssemblies.Identity)">
+				<WinMDFile>false</WinMDFile>
+				<CopyLocal>false</CopyLocal>
+				<ResolvedFrom>ImplicitlyExpandDesignTimeFacades</ResolvedFrom>
+			</ReferencePath>
+			<ReferenceDependencyPath Include="@(ReferencePath)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandDesignTimeFacades'" />
+		</ItemGroup>
+
+		<Message Importance="Low" Text="Including @(ReferencePath)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandDesignTimeFacades'" />
+	</Target>
+
+</Project>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -24,6 +24,11 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 		<_XamarinCommonPropsHasBeenImported>true</_XamarinCommonPropsHasBeenImported>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<IsXBuild Condition="'$(MSBuildRuntimeVersion)' == ''">true</IsXBuild>
+		<IsXBuild Condition="'$(MSBuildRuntimeVersion)' != ''">false</IsXBuild>
+	</PropertyGroup>
+
 	<!-- When looking for related files to copy, look for Mono debugging files as well -->
 	<PropertyGroup>
 		<AllowedReferenceRelatedFileExtensions>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -654,7 +654,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		Condition="'$(UseXamMacFullFramework)' == 'true' And '$(IsXBuild)' == 'true' "/>
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.msbuild.targets"
-		Condition="'$(IsXBuild)' == 'false' "/>
+		Condition="'$(IsXBuild)' != 'true' "/>
 
 	<Target Name="_SeparateAppExtensionReferences" BeforeTargets="AssignProjectConfiguration" Condition="'$(IsAppExtension)' != 'true'">
 		<CreateItem Include="@(ProjectReference)" PreserveExistingMetadata="true" Condition="'%(Identity)' != '' And '%(ProjectReference.IsAppExtension)' == 'true'">

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -85,39 +85,8 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<_AppBundleName>$(AssemblyName)</_AppBundleName>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<ImplicitlyExpandDesignTimeFacades>true</ImplicitlyExpandDesignTimeFacades>
-
-		<ResolveReferencesDependsOn>
-			_SeparateAppExtensionReferences;
-			$(ResolveReferencesDependsOn);
-			ImplicitlyExpandDesignTimeFacades
-		</ResolveReferencesDependsOn>
-
-		<ImplicitlyExpandDesignTimeFacadesDependsOn>
-			$(ImplicitlyExpandDesignTimeFacadesDependsOn);
-			GetReferenceAssemblyPaths
-		</ImplicitlyExpandDesignTimeFacadesDependsOn>
-	</PropertyGroup>
-
-	<Target Name="ImplicitlyExpandDesignTimeFacades" Condition="'$(ImplicitlyExpandDesignTimeFacades)' == 'true'" DependsOnTargets="$(ImplicitlyExpandDesignTimeFacadesDependsOn)">
-		<PropertyGroup>
-			<_HasReferenceToSystemRuntime Condition="'%(ReferenceDependencyPaths.Filename)' == 'System.Runtime'">true</_HasReferenceToSystemRuntime>
-		</PropertyGroup>
-
-		<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true'">
-			<_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)*.dll"/>
-			<ReferencePath Remove="@(_DesignTimeFacadeAssemblies)"/>
-			<ReferencePath Include="%(_DesignTimeFacadeAssemblies.Identity)">
-				<WinMDFile>false</WinMDFile>
-				<CopyLocal>false</CopyLocal>
-				<ResolvedFrom>ImplicitlyExpandDesignTimeFacades</ResolvedFrom>
-			</ReferencePath>
-			<ReferenceDependencyPath Include="@(ReferencePath)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandDesignTimeFacades'" />
-		</ItemGroup>
-
-		<Message Importance="Low" Text="Including @(ReferencePath)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandDesignTimeFacades'" />
-	</Target>
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.Common.ImplicitFacade.xbuild.targets"
+		Condition="'$(IsXBuild)' == 'true' "/>
 
 	<PropertyGroup>
 		<BuildDependsOn>
@@ -681,8 +650,11 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		/>
 	</Target>
 
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.XM45.targets"
-		Condition="'$(UseXamMacFullFramework)' == 'true'"/>
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.XM45.xbuild.targets"
+		Condition="'$(UseXamMacFullFramework)' == 'true' And '$(IsXBuild)' == 'true' "/>
+
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.msbuild.targets"
+		Condition="'$(IsXBuild)' == 'false' "/>
 
 	<Target Name="_SeparateAppExtensionReferences" BeforeTargets="AssignProjectConfiguration" Condition="'$(IsAppExtension)' != 'true'">
 		<CreateItem Include="@(ProjectReference)" PreserveExistingMetadata="true" Condition="'%(Identity)' != '' And '%(ProjectReference.IsAppExtension)' == 'true'">
@@ -731,8 +703,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_ResolveAppExtensionReferences" DependsOnTargets="_SplitAppExtensionReferencesByExistent">
 		<PropertyGroup>
-			<IsXBuild Condition="'$(MSBuildRuntimeVersion)' == ''">true</IsXBuild>
-
 			<!-- When building a .sln with xbuild or building from IDE, the referenced projects are already built.  -->
 			<_BuildReferencedExtensionProjects Condition="'$(IsXBuild)' == 'true' and '$(BuildingSolutionFile)' != 'true' and '$(BuildingInsideVisualStudio)' != 'true'">true</_BuildReferencedExtensionProjects>
 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -28,6 +28,11 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 	<Import Project="Xamarin.Mac.ObjCBinding.Common.targets" />
 
 	<PropertyGroup>
+		<IsXBuild Condition="'$(MSBuildRuntimeVersion)' == ''">true</IsXBuild>
+		<IsXBuild Condition="'$(MSBuildRuntimeVersion)' != ''">false</IsXBuild>
+	</PropertyGroup>
+
+	<PropertyGroup>
 		<_GeneratedSourcesFileList>$(GeneratedSourcesDir)\sources.list</_GeneratedSourcesFileList>
 
 		<!-- Add our own pre-build steps -->
@@ -39,8 +44,10 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 		</CompileDependsOn>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.XM45.targets"
-		Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"/>
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.XM45.xbuild.targets"
+		Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And '$(IsXBuild)' == 'true' "/>
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.msbuild.targets"
+		Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And '$(IsXBuild)' == 'false' "/>
 
 	<!-- Override the CoreCompile Target to use btouch -->
 	<Target Name="_GenerateBindings"

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
@@ -69,7 +69,16 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Xamarin.Mac.XM45.targets">
+    <None Include="Xamarin.Mac.Common.ImplicitFacade.msbuild.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Xamarin.Mac.Common.ImplicitFacade.xbuild.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Xamarin.Mac.XM45.xbuild.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Xamarin.Mac.msbuild.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Xamarin.Mac.Common.targets">

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.XM45.xbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.XM45.xbuild.targets
@@ -1,6 +1,6 @@
 ﻿<!--
 ***********************************************************************************************
-Xamarin.Mac.XM45.targets
+Xamarin.Mac.XM45.xbuild.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
   created a backup copy.  Incorrect changes to this file will make it
@@ -16,7 +16,7 @@ Copyright (C) 2015 Xamarin Inc. All rights reserved.
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-	<!-- The XM 4.5 target framework (will hopefully be renamed at some point) is a bit of a strange case -->
+	<!-- The XM 4.5 target framework (also called Full) is a bit of a strange case -->
 	<!-- It does not declare a TargetFrameworkIdentifier so it can be compatible with "Desktop" nugets -->
 	<!-- These days it could have been done with some patches to nuget and such, but now can not be changed -->
 	<!-- without breaking some number of user projects (forward only mutation is rather unacceptable here) -->
@@ -24,7 +24,8 @@ Copyright (C) 2015 Xamarin Inc. All rights reserved.
 	<!-- we keep inside Xamarin.Mac's framework and not the system mono ones. System mono is not -->
 	<!-- necessarily in sync with ours and is not safe to depend upon -->
 	
-	<!-- XBuild specific hacks -->
+	<!-- XBuild specific hacks - Msbuild are in Xamarin.Mac.msbuild.targets and not XM 4.5 (Full) specific -->
+
 	<!-- TargetFrameworkDirectory needs to point to ours, and FrameworkPathOverride does not work in xbuild, so we must override. -->
 	<Target Name="GetFrameworkPaths"
                 Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"
@@ -61,6 +62,4 @@ Copyright (C) 2015 Xamarin Inc. All rights reserved.
                         </_ExplicitReference>
                 </ItemGroup>
 	</Target>
-	<!-- End the xbuild hacks  -->
-	<!-- TODO - msbuild hacks  -->
 </Project>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
@@ -13,7 +13,6 @@ file does not exist, but the project is built anyway (command-line or IDE build)
 Copyright (C) 2015 Xamarin Inc. All rights reserved.
 ***********************************************************************************************
 -->
-<!-- Rename file -->
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<!-- MSBuild specific hacks - Teach msbuild where to find our BCL and facades -->

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
@@ -10,7 +10,7 @@ This file imports the version- and platform-specific targets for the project imp
 this file. This file also defines targets to produce an error if the specified targets
 file does not exist, but the project is built anyway (command-line or IDE build).
 
-Copyright (C) 2015 Xamarin Inc. All rights reserved.
+Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 ***********************************************************************************************
 -->
 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
@@ -1,0 +1,36 @@
+﻿<!--
+***********************************************************************************************
+Xamarin.Mac.msbuild.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+This file imports the version- and platform-specific targets for the project importing
+this file. This file also defines targets to produce an error if the specified targets
+file does not exist, but the project is built anyway (command-line or IDE build).
+
+Copyright (C) 2015 Xamarin Inc. All rights reserved.
+***********************************************************************************************
+-->
+<!-- Rename file -->
+
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<!-- MSBuild specific hacks - Teach msbuild where to find our BCL and facades -->
+	<Target Name="FixTargetFrameworkDirectory" AfterTargets="GetReferenceAssemblyPaths">
+		<PropertyGroup>
+			<MacBclPath Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.Mac'">$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
+			<MacBclPath Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">$(XamarinMacFrameworkRoot)/lib/mono/Xamarin.Mac</MacBclPath>
+		</PropertyGroup>	
+    		<ItemGroup>
+			<DesignTimeFacadeDirectories Remove="@(DesignTimeFacadeDirectories)" />
+			<DesignTimeFacadeDirectories Include="$(MacBclPath)/Facades/" />
+		</ItemGroup>
+		<PropertyGroup>	
+			<TargetFrameworkDirectory>$(MacBclPath);@(DesignTimeFacadeDirectories)</TargetFrameworkDirectory>
+		</PropertyGroup>
+	</Target>
+	
+	<!-- Modern/Mobile does not get ImplicitlyExpandDesignTimeFacades as Microsoft.NETFramework.CurrentVersion.targets isn't pulled in -->
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.Common.ImplicitFacade.msbuild.targets" Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'"/>
+</Project>

--- a/tests/common/mac/TestProjects/RoslynTestApp/Full/Entitlements.plist
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Full/Entitlements.plist
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/tests/common/mac/TestProjects/RoslynTestApp/Full/Info.plist
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Full/Info.plist
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>RoslynTestApp</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.companyname.roslyntestapp</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.12</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>(c) Chris Hamons</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSMainStoryboardFile</key>
+	<string>Main</string>
+	<key>XSAppIconAssets</key>
+	<string>Assets.xcassets/AppIcon.appiconset</string>
+	
+</dict>
+</plist>

--- a/tests/common/mac/TestProjects/RoslynTestApp/Full/Main.cs
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Full/Main.cs
@@ -1,0 +1,36 @@
+﻿using AppKit;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RoslynTestApp
+{
+	static class MainClass
+	{
+		static void Main (string[] args)
+		{
+			NSApplication.IgnoreMissingAssembliesDuringRegistration = true;
+			NSApplication.Init ();
+
+			SyntaxTree tree = CSharpSyntaxTree.ParseText (
+@"using System;
+using System.Collections;
+using System.Linq;
+using System.Text;
+
+namespace HelloWorld
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine(""Hello, World!"");
+        }
+    }
+}");
+
+			var root = (CompilationUnitSyntax)tree.GetRoot ();
+			System.Console.WriteLine (root);
+		}
+	}
+}

--- a/tests/common/mac/TestProjects/RoslynTestApp/Full/RoslynTestApp.csproj
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Full/RoslynTestApp.csproj
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{FCA4311B-96A6-4AAC-8235-3E7F75111E73}</ProjectGuid>
+    <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>RoslynTestApp</RootNamespace>
+    <AssemblyName>RoslynTestApp</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
+    <UseXamMacFullFramework>true</UseXamMacFullFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <EnableCodeSigning>false</EnableCodeSigning>
+    <CodeSigningKey>Mac Developer</CodeSigningKey>
+    <CreatePackage>false</CreatePackage>
+    <EnablePackageSigning>false</EnablePackageSigning>
+    <IncludeMonoRuntime>false</IncludeMonoRuntime>
+    <UseSGen>true</UseSGen>
+    <UseRefCounting>true</UseRefCounting>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <EnableCodeSigning>false</EnableCodeSigning>
+    <CreatePackage>true</CreatePackage>
+    <EnablePackageSigning>false</EnablePackageSigning>
+    <IncludeMonoRuntime>true</IncludeMonoRuntime>
+    <UseSGen>true</UseSGen>
+    <UseRefCounting>true</UseRefCounting>
+    <LinkMode>None</LinkMode>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="Xamarin.Mac" />
+    <Reference Include="mscorlib" />
+    <Reference Include="System.AppContext">
+      <HintPath>..\..\..\..\..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\..\..\..\..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Console">
+      <HintPath>..\..\..\..\..\..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.FileVersionInfo">
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.FileVersionInfo.4.3.0\lib\net46\System.Diagnostics.FileVersionInfo.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.StackTrace">
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.StackTrace.4.3.0\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression">
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives">
+      <HintPath>..\..\..\..\..\..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem">
+      <HintPath>..\..\..\..\..\..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata">
+      <HintPath>..\..\..\..\..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Security.Cryptography.Encoding">
+      <HintPath>..\..\..\..\..\..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives">
+      <HintPath>..\..\..\..\..\..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms">
+      <HintPath>..\..\..\..\..\..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates">
+      <HintPath>..\..\..\..\..\..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encoding.CodePages">
+      <HintPath>..\..\..\..\..\..\packages\System.Text.Encoding.CodePages.4.3.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Thread">
+      <HintPath>..\..\..\..\..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple">
+      <HintPath>..\..\..\..\..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.ReaderWriter">
+      <HintPath>..\..\..\..\..\..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml.XmlDocument">
+      <HintPath>..\..\..\..\..\..\packages\System.Xml.XmlDocument.4.3.0\lib\net46\System.Xml.XmlDocument.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XPath">
+      <HintPath>..\..\..\..\..\..\packages\System.Xml.XPath.4.3.0\lib\net46\System.Xml.XPath.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XPath.XDocument">
+      <HintPath>..\..\..\..\..\..\packages\System.Xml.XPath.XDocument.4.3.0\lib\net46\System.Xml.XPath.XDocument.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis">
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.CodeAnalysis.Common.2.0.0-rc4\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp">
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.2.0.0-rc4\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+    <None Include="Entitlements.plist" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
+</Project>

--- a/tests/common/mac/TestProjects/RoslynTestApp/Full/packages.config
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Full/packages.config
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.0.0-rc4" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.0.0-rc4" targetFramework="net46" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net46" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
+  <package id="System.Console" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.StackTrace" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net46" />
+  <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net46" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net46" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net46" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XPath" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XPath.XDocument" version="4.3.0" targetFramework="net46" />
+</packages>

--- a/tests/common/mac/TestProjects/RoslynTestApp/Modern/Entitlements.plist
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Modern/Entitlements.plist
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/tests/common/mac/TestProjects/RoslynTestApp/Modern/Info.plist
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Modern/Info.plist
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>RoslynTestApp</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.companyname.roslyntestapp</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.12</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>(c) Chris Hamons</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSMainStoryboardFile</key>
+	<string>Main</string>
+	<key>XSAppIconAssets</key>
+	<string>Assets.xcassets/AppIcon.appiconset</string>
+	
+</dict>
+</plist>

--- a/tests/common/mac/TestProjects/RoslynTestApp/Modern/Main.cs
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Modern/Main.cs
@@ -1,0 +1,36 @@
+﻿using AppKit;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RoslynTestApp
+{
+	static class MainClass
+	{
+		static void Main (string[] args)
+		{
+			NSApplication.IgnoreMissingAssembliesDuringRegistration = true;
+			NSApplication.Init ();
+
+			SyntaxTree tree = CSharpSyntaxTree.ParseText (
+@"using System;
+using System.Collections;
+using System.Linq;
+using System.Text;
+
+namespace HelloWorld
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine(""Hello, World!"");
+        }
+    }
+}");
+
+			var root = (CompilationUnitSyntax)tree.GetRoot ();
+			System.Console.WriteLine (root);
+		}
+	}
+}

--- a/tests/common/mac/TestProjects/RoslynTestApp/Modern/RoslynTestApp.csproj
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Modern/RoslynTestApp.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProjectGuid>{F8500DCE-2119-4DF9-8360-0F46DDB6930C}</ProjectGuid>
+    <ProjectGuid>{0D155A7F-561C-4187-967D-3879FA760217}</ProjectGuid>
     <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
-    <RootNamespace>msbuildMac</RootNamespace>
-    <AssemblyName>msbuild-mac</AssemblyName>
+    <RootNamespace>RoslynTestApp</RootNamespace>
+    <AssemblyName>RoslynTestApp</AssemblyName>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
@@ -16,11 +16,10 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\x86\Debug</OutputPath>
-    <DefineConstants>__UNIFIED__;DEBUG;XAMCORE_2_0;MONOMAC</DefineConstants>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
     <EnableCodeSigning>false</EnableCodeSigning>
     <CodeSigningKey>Mac Developer</CodeSigningKey>
     <CreatePackage>false</CreatePackage>
@@ -28,18 +27,15 @@
     <IncludeMonoRuntime>false</IncludeMonoRuntime>
     <UseSGen>true</UseSGen>
     <UseRefCounting>true</UseRefCounting>
-    <Profiling>true</Profiling>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\x86\Release</OutputPath>
-    <DefineConstants>__UNIFIED__;XAMCORE_2_0;MONOMAC;MMP_TEST</DefineConstants>
+    <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <EnableCodeSigning>true</EnableCodeSigning>
-    <CodeSigningKey>Developer ID Application</CodeSigningKey>
+    <EnableCodeSigning>false</EnableCodeSigning>
     <CreatePackage>true</CreatePackage>
     <EnablePackageSigning>false</EnablePackageSigning>
     <IncludeMonoRuntime>true</IncludeMonoRuntime>
@@ -52,36 +48,30 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.Mac" />
-    <Reference Include="System.Xml" />
-    <Reference Include="GuiUnit">
-      <HintPath>..\..\external\guiunit\bin\net_4_5\GuiUnit.exe</HintPath>
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\..\..\..\..\..\packages\System.Collections.Immutable.1.3.1\lib\netstandard1.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Reflection.Metadata">
+      <HintPath>..\..\..\..\..\..\packages\System.Reflection.Metadata.1.4.2\lib\netstandard1.1\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple">
+      <HintPath>..\..\..\..\..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis">
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.CodeAnalysis.Common.2.0.0-rc4\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp">
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.CodeAnalysis.CSharp.2.0.0-rc4\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Resources\" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="Info.plist" />
+    <None Include="Entitlements.plist" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="src\MSBuild-Smoke.cs" />
-    <Compile Include="..\common\mac\MacTestMain.cs">
-      <Link>MacTestMain.cs</Link>
-    </Compile>
-    <Compile Include="..\common\mac\ProjectTestHelpers.cs">
-      <Link>ProjectTestHelpers.cs</Link>
-    </Compile>
-    <Compile Include="..\..\tests\common\Configuration.cs">
-      <Link>Configuration.cs</Link>
-    </Compile>
-    <Compile Include="..\..\src\ObjCRuntime\ErrorHelper.cs">
-      <Link>ErrorHelper.cs</Link>
-    </Compile>
-    <Compile Include="..\..\src\ObjCRuntime\RuntimeException.cs">
-      <Link>RuntimeException.cs</Link>
-    </Compile>
-    <Compile Include="src\RoslynSmokeTests.cs" />
+    <Compile Include="Main.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
-  <Import Project="CustomBuildActions.targets" />
 </Project>

--- a/tests/common/mac/TestProjects/RoslynTestApp/Modern/packages.config
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Modern/packages.config
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="xamarinmac20" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.0.0-rc4" targetFramework="xamarinmac20" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.0.0-rc4" targetFramework="xamarinmac20" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Collections" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="xamarinmac20" />
+  <package id="System.Console" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Diagnostics.StackTrace" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Linq" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="xamarinmac20" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Threading" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Threading.Thread" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="xamarinmac20" />
+  <package id="System.Xml.XPath.XDocument" version="4.3.0" targetFramework="xamarinmac20" />
+</packages>

--- a/tests/msbuild-mac/src/MSBuild-Smoke.cs
+++ b/tests/msbuild-mac/src/MSBuild-Smoke.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 namespace Xamarin.MMP.Tests
 {
 	[TestFixture]
-	public class MMPTests
+	public partial class MMPTests
 	{
 		void RunMSBuildTest (Action <string> test)
 		{

--- a/tests/msbuild-mac/src/RoslynSmokeTests.cs
+++ b/tests/msbuild-mac/src/RoslynSmokeTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+
+namespace Xamarin.MMP.Tests
+{
+	[TestFixture]
+	public partial class MMPTests
+	{
+		const string nugetPath = "/Library/Frameworks/Mono.framework/Versions/Current/Commands/nuget";
+
+		public string RoslynTestProjectRoot => Path.Combine (TI.FindSourceDirectory (), "TestProjects/RoslynTestApp/");
+
+		void RestoreRoslynNuget (string projectType)
+		{
+			StringBuilder nugetArgs = new StringBuilder ("restore " + Path.Combine (RoslynTestProjectRoot + projectType + "/") + "packages.config");
+
+			TI.RunAndAssert (nugetPath, nugetArgs, "Restore Nuget");
+		}
+
+		// [Test] - https://bugzilla.xamarin.com/show_bug.cgi?id=53164
+		public void XMModernRosylnProjet_ShouldBuildAndRunWithMSBuild ()
+		{
+			string projectPath = Path.Combine (RoslynTestProjectRoot, "Modern/RoslynTestApp.csproj");
+
+			TI.CleanUnifiedProject (projectPath);
+			RestoreRoslynNuget ("Modern");
+			TI.BuildProject (projectPath, true, useMSBuild: true);
+		}
+
+		// [Test] - https://bugzilla.xamarin.com/show_bug.cgi?id=53164
+		public void XMFullRosylnProjet_ShouldBuildAndRunWithMSBuild ()
+		{
+			string projectPath = Path.Combine (RoslynTestProjectRoot, "Full/RoslynTestApp.csproj");
+
+			TI.CleanUnifiedProject (projectPath);
+			RestoreRoslynNuget ("Full");
+			TI.BuildProject (projectPath, true, useMSBuild: true);
+		}
+	}
+}

--- a/tests/msbuild-mac/src/RoslynSmokeTests.cs
+++ b/tests/msbuild-mac/src/RoslynSmokeTests.cs
@@ -27,6 +27,7 @@ namespace Xamarin.MMP.Tests
 			TI.CleanUnifiedProject (projectPath);
 			RestoreRoslynNuget ("Modern");
 			TI.BuildProject (projectPath, true, useMSBuild: true);
+			TI.RunAndAssert (Path.Combine (RoslynTestProjectRoot, "Modern/bin/Debug/RoslynTestApp.app/Contents/MacOS/RoslynTestApp"), new StringBuilder (), "Run");
 		}
 
 		// [Test] - https://bugzilla.xamarin.com/show_bug.cgi?id=53164
@@ -37,6 +38,7 @@ namespace Xamarin.MMP.Tests
 			TI.CleanUnifiedProject (projectPath);
 			RestoreRoslynNuget ("Full");
 			TI.BuildProject (projectPath, true, useMSBuild: true);
+			TI.RunAndAssert (Path.Combine (RoslynTestProjectRoot, "Full/bin/Debug/RoslynTestApp.app/Contents/MacOS/RoslynTestApp"), new StringBuilder (), "Run");
 		}
 	}
 }


### PR DESCRIPTION
- Significant changes to target file under msbuild, ImplicitFacade processing in particular
- Tests are disabled due to https://bugzilla.xamarin.com/show_bug.cgi?id=53164 where we can't tests local target files only global
- Requires a mono msbuild with https://github.com/mono/msbuild/commit/95ab657a9017ea19eef8afa0d05841fdd781f363 for tests to pass
- Until then, this is a workaround:
    sudo cp /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/Roslyn/System.Reflection.Metadata.dll /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/