### PR TITLE
[intents] Updated to Xcode8.3 Beta 5

### DIFF
--- a/src/intents.cs
+++ b/src/intents.cs
@@ -323,7 +323,8 @@ namespace XamCore.Intents {
 		Pending,
 		Completed,
 		Canceled,
-		Failed
+		Failed,
+		Unpaid
 	}
 
 	[Native]
@@ -2740,12 +2741,12 @@ namespace XamCore.Intents {
 	[BaseType (typeof (NSObject))]
 	interface INPreferences {
 
-		[NoWatch] // It seems this is not available on watchOS radar:30529232 https://trello.com/c/h8xBlKTt
+		[NoWatch]
 		[Static]
 		[Export ("siriAuthorizationStatus")]
 		INSiriAuthorizationStatus SiriAuthorizationStatus { get; }
 
-		[NoWatch] // It seems this is not available on watchOS radar:30529232 https://trello.com/c/h8xBlKTt
+		[NoWatch]
 		[Static]
 		[Async]
 		[Export ("requestSiriAuthorization:")]


### PR DESCRIPTION
Apple added API_UNAVAILABLE(watchos) to

+ (INSiriAuthorizationStatus)siriAuthorizationStatus
+ (void)requestSiriAuthorization:(void (^)(INSiriAuthorizationStatus status))handler

So we got the availability right :D