### PR TITLE
[msbuild] Ensure the MainAssembly path is absolute

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -605,7 +605,7 @@ namespace Xamarin.iOS.Tasks
 			args.Add ("--target-framework");
 			args.Add (TargetFrameworkIdentifier + "," + TargetFrameworkVersion);
 
-			args.AddQuoted (MainAssembly.ItemSpec);
+			args.AddQuoted (Path.GetFullPath (MainAssembly.ItemSpec));
 
 			// We give the priority to the ExtraArgs to set the mtouch verbosity.
 			if (string.IsNullOrEmpty (ExtraArgs) || (!string.IsNullOrEmpty (ExtraArgs) && !ExtraArgs.Contains ("-q") && !ExtraArgs.Contains ("-v")))


### PR DESCRIPTION
Fixes bug #52758 (https://bugzilla.xamarin.com/show_bug.cgi?id=52758)

For appex the MainAssembly path should be absolute, since mtouch will generate a build-arguments.txt file that then will be used to build the extension in the same mtouch process than the container app. Due to this, if the path stored is relative mtouch won't be able to find the assembly.