### PR TITLE
[generator] Fixes bug 42855 generator should report an error for [Protocol] without a [Model] that specify a [BaseType]

### DIFF
--- a/src/error.cs
+++ b/src/error.cs
@@ -74,6 +74,7 @@ using ProductException=BindingException;
 //		BI1051 Internal error: Don't know how to get attributes for {0}. Please file a bug report (http://bugzilla.xamarin.com) with a test case.
 //		BI1052 Internal error: Could not find the type {0} in the assembly {1}. Please file a bug report (http://bugzilla.xamarin.com) with a test case.
 //		BI1053 Internal error: unknown target framework '{0}'.
+//		BI1060 The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].
 //	BI11xx	warnings
 //		BI1101 Trying to use a string as a [Target]
 //		BI1102 Using the deprecated EventArgs for a delegate signature in {0}.{1}, please use DelegateName instead

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1098,7 +1098,6 @@ public partial class Generator : IMemberGatherer {
 		throw new BindingException (1017, true, "Do not know how to make a signature for {0}", mai.Type);
 	}
 
-	static HashSet<Type> missing_base_type_warning_shown = new HashSet<Type> ();
 	static bool IsProtocolInterface (Type type, bool checkPrefix = true)
 	{
 		// for subclassing the type (from the binding files) is not yet prefixed by an `I`
@@ -5451,12 +5450,9 @@ public partial class Generator : IMemberGatherer {
 			if (is_protocol) {
 				if (is_static_class)
 					throw new BindingException (1025, true, "[Static] and [Protocol] are mutually exclusive ({0})", type.FullName);
-				if (is_model && base_type == TypeManager.System_Object){
-					if (!missing_base_type_warning_shown.Contains (type)){
-						missing_base_type_warning_shown.Add (type);
-						Console.WriteLine ("Warning, protocol {0} does not have a BaseType, wont generate the class, only the interface and extensions class", type.FullName);
-					}
-				}
+				if (is_model && base_type == TypeManager.System_Object)
+					throw new BindingException (1060, true, "The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].", type.FullName);
+
 				var protocol = AttributeManager.GetCustomAttribute<ProtocolAttribute> (type);
 				GenerateProtocolTypes (type, class_visibility, TypeName, protocol.Name ?? objc_type_name, protocol);
 			}

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -14,7 +14,7 @@ include $(TOP)/Make.config
 IOS_CURRENT_DIR=$(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current
 IOS_GENERATOR = $(IOS_CURRENT_DIR)/bin/btouch-native /baselib:$(IOS_CURRENT_DIR)/lib/mono/Xamarin.iOS/Xamarin.iOS.dll /unsafe
 IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts bug43579 bindastests
-IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap
+IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855
 
 MAC_CURRENT_DIR=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
 MAC_GENERATOR = $(MAC_CURRENT_DIR)/bin/bmac
@@ -61,6 +61,7 @@ $(eval $(call iOSErrorCodeTestTemplate,bindas1048error,1048))
 $(eval $(call iOSErrorCodeTestTemplate,bindas1049error,1049))
 $(eval $(call iOSErrorCodeTestTemplate,bindas1050modelerror,1050))
 $(eval $(call iOSErrorCodeTestTemplate,bindas1050protocolerror,1050))
+$(eval $(call iOSErrorCodeTestTemplate,bug42855,1060))
 
 classNameCollision:
 	@rm -Rf $@.tmpdir

--- a/tests/generator/bug42855.cs
+++ b/tests/generator/bug42855.cs
@@ -1,0 +1,16 @@
+using System;
+using Foundation;
+
+namespace Bug42855Tests {
+
+	[Protocol][Model]
+	interface MyFooClass {
+
+		[Abstract]
+		[Export ("stringMethod:")]
+		NSString StringMethod (int arg1);
+
+		[Export ("stringMethod2:")]
+		NSString StringMethod2 (int arg1);
+	}
+}


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=42855

We had some logic to catch this but we did not do anything with it.
We now error out with BI1060 whenever we find [Model] but no [BaseType]
added test case.

I am using BI1060 because Rolf reserved today the missing ones in PR https://github.com/xamarin/xamarin-macios/pull/1849