### PR TITLE
[msbuild] Fixed PathUtils.AbsoluteToRelative() logic

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/PathUtils.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/PathUtils.cs
@@ -42,7 +42,7 @@ namespace Xamarin.MacDev
 
 		public static string AbsoluteToRelative (string baseDirectory, string absolute)
 		{
-			if (!Path.IsPathRooted (absolute) || string.IsNullOrEmpty (baseDirectory))
+			if (string.IsNullOrEmpty (baseDirectory))
 				return absolute;
 
 			// canonicalize the paths

--- a/msbuild/Xamarin.MacDev.Tasks.Core/PathUtils.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/PathUtils.cs
@@ -33,7 +33,7 @@ namespace Xamarin.MacDev
 			try {
 				buffer = Marshal.AllocHGlobal (PATHMAX);
 				var result = realpath (path, buffer);
-				return result == IntPtr.Zero ? "" : Marshal.PtrToStringAuto (buffer);
+				return result == IntPtr.Zero ? path : Marshal.PtrToStringAuto (buffer);
 			} finally {
 				if (buffer != IntPtr.Zero)
 					Marshal.FreeHGlobal (buffer);


### PR DESCRIPTION
Don't require the 'absolute' path argument to be a FullPath.

The code already calls Path.GetFullPath() on the 'absolute'
path anyway.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=53176