### PR TITLE
[generator] Fixes bug 52570 - [generator] warn when [Static] is used in a [Category]

### DIFF
--- a/docs/website/binding_types_reference_guide.md
+++ b/docs/website/binding_types_reference_guide.md
@@ -380,6 +380,50 @@ that contains the `MakeBackgroundRed` extension method.   This means
 that you can now call "MakeBackgroundRed" on any `UIView` subclass,
 giving you the same functionality you would get on Objective-C.
 
+In some cases you will find **static** members inside categories like in the following example:
+
+```objc
+@interface FooObject (MyFooObjectExtension)
++ (BOOL)boolMethod:(NSRange *)range;
+@end
+```
+
+This will lead to an **incorrect** Category C# interface definition:
+
+```csharp
+[Category]
+[BaseType (typeof (FooObject))]
+interface FooObject_Extensions {
+
+	// Incorrect Interface definition
+	[Static]
+	[Export ("boolMethod:")]
+	bool BoolMethod (NSRange range);
+}
+```
+
+This is incorrect because in order to use the `BoolMethod` extension you need an instance of `FooObject` but you are binding an ObjC **static** extension, this is a side effect due to the fact of how C# extension methods are implemented. 
+
+The only way to use the above definitions is by the following ugly code:
+
+```csharp
+(null as FooObject).BoolMethod (range);
+```
+
+The recommendation to avoid this is to inline the `BoolMethod` definition inside the `FooObject` interface definition itself, this will allow you to call this extension like it is intended `FooObject.BoolMethod (range)`.
+
+```csharp
+[BaseType (typeof (NSObject))]
+interface FooObject {
+
+	[Static]
+	[Export ("boolMethod:")]
+	bool BoolMethod (NSRange range);
+}
+```
+
+We will issue a warning (BI1117) whenever we find a `[Static]` member inside a `[Category]` definition. If you really want to have `[Static]` members inside your `[Category]` definitions you can silence the warning by using `[Category (allowStaticMembers: true)]` or by decorating either your member or `[Category]` interface definition with `[Internal]`.
+
  <a name="StaticAttribute" class="injected"></a>
 
 

--- a/src/contacts.cs
+++ b/src/contacts.cs
@@ -516,7 +516,7 @@ namespace XamCore.Contacts {
 	}
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
-	[Category]
+	[Category (allowStaticMembers: true)]
 	[BaseType (typeof (CNContainer))]
 	interface CNContainer_PredicatesExtension {
 
@@ -581,7 +581,7 @@ namespace XamCore.Contacts {
 	}
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
-	[Category]
+	[Category (allowStaticMembers: true)]
 	[BaseType (typeof (CNGroup))]
 	interface CNGroup_PredicatesExtension {
 

--- a/src/error.cs
+++ b/src/error.cs
@@ -92,6 +92,7 @@ using ProductException=BindingException;
 //		BI1114 Binding error: test unable to find property: {0} on {1}.
 //		BI1115 The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback].
 //		BI1116 The parameter '{0}' in the delegate '{1}' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.
+//		BI1117 The {0} member is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.
 // BI2xxx	reserved
 // BI3xxx	reserved
 // BI4xxx	reserved

--- a/src/generator-attributes.cs
+++ b/src/generator-attributes.cs
@@ -712,7 +712,15 @@ public class NotImplementedAttribute : Attribute {
 // }
 [AttributeUsage (AttributeTargets.Interface, AllowMultiple=false)]
 public class CategoryAttribute : Attribute {
-	public CategoryAttribute () {}
+	public bool AllowStaticMembers;
+	public CategoryAttribute () { }
+#if XAMCORE_4_0
+	[Obsolete ("Inline the static members in this category in the category's class (and remove this obsolete once fixed)"]
+#endif
+	public CategoryAttribute (bool allowStaticMembers)
+	{
+		AllowStaticMembers = allowStaticMembers;
+	}
 }
 
 //

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -420,7 +420,7 @@ public class MemberInformation
 	public readonly Type type;
 	public readonly Type category_extension_type;
 	public readonly bool is_abstract, is_protected, is_internal, is_unified_internal, is_override, is_new, is_sealed, is_static, is_thread_static, is_autorelease, is_wrapper, is_forced;
-	public readonly bool is_type_sealed;
+	public readonly bool is_type_sealed, ignore_category_static_warnings;
 	public readonly Generator.ThreadCheck threadCheck;
 	public bool is_unsafe, is_virtual_method, is_export, is_category_extension, is_variadic, is_interface_impl, is_extension_method, is_appearance, is_model, is_ctor;
 	public bool is_return_release;
@@ -532,8 +532,10 @@ public class MemberInformation
 		}
 
 		this.category_extension_type = category_extension_type;
-		if (category_extension_type != null)
+		if (category_extension_type != null) {
 			is_category_extension = true;
+			ignore_category_static_warnings = is_internal || type.IsInternal () || AttributeManager.GetCustomAttribute<CategoryAttribute> (type).AllowStaticMembers;
+		}
 
 		if (is_static || is_category_extension || is_interface_impl || is_extension_method || is_type_sealed)
 			is_virtual_method = false;
@@ -3907,6 +3909,13 @@ public partial class Generator : IMemberGatherer {
 		}
 
 		CurrentMethod = String.Format ("{0}.{1}", type.Name, mi.Name);
+
+		// Warn about [Static] used in a member of [Category]
+		var hasStaticAtt = AttributeManager.HasAttribute<StaticAttribute> (mi);
+		if (category_type != null && hasStaticAtt && !minfo.ignore_category_static_warnings) {
+			var baseTypeAtt = AttributeManager.GetCustomAttribute<BaseTypeAttribute> (minfo.type);
+			ErrorHelper.Show (new BindingException (1117, "The {0} member is decorated with [Static] and its container class {1} is decorated with [Category] this leads to hard to use code. Please inline {0} into {2} class.", mi.Name, type.FullName, baseTypeAtt?.BaseType.FullName));
+		}
 
 		indent++;
 		// if the namespace/type needs it and if the member is NOT marked as safe (don't check)

--- a/src/iad.cs
+++ b/src/iad.cs
@@ -172,7 +172,8 @@ namespace XamCore.iAd {
 		void WillLoad (ADInterstitialAd interstitialAd);
 	}
 
-	[Category, BaseType (typeof (MPMoviePlayerController))]
+	[Category (allowStaticMembers: true)] // Classic isn't internal so we need this
+	[BaseType (typeof (MPMoviePlayerController))]
 	partial interface IAdPreroll {
 
 #if XAMCORE_2_0
@@ -199,7 +200,8 @@ namespace XamCore.iAd {
 #endif
 
 	[Deprecated (PlatformName.iOS, 10, 0)]
-	[Category, BaseType (typeof (UIViewController))]
+	[Category (allowStaticMembers: true)] // Classic isn't internal so we need this
+	[BaseType (typeof (UIViewController))]
 	partial interface IAdAdditions {
 
 #if XAMCORE_2_0
@@ -275,7 +277,7 @@ namespace XamCore.iAd {
 
 	delegate void AttributedToiAdCompletionHandler (bool attributedToiAd);
 
-	[Category]
+	[Category (allowStaticMembers: true)] // Classic isn't internal so we need this
 	[BaseType (typeof (AVPlayerViewController))]
 	interface iAdPreroll_AVPlayerViewController {
 		[iOS (8,0)]

--- a/src/notificationcenter.cs
+++ b/src/notificationcenter.cs
@@ -60,7 +60,7 @@ namespace XamCore.NotificationCenter {
 #if !MONOMAC
 	[iOS (8,0)]
 	[BaseType (typeof (UIVibrancyEffect))]
-	[Category]
+	[Category (allowStaticMembers: true)] // Classic isn't internal so we need this
 	interface UIVibrancyEffect_NotificationCenter {
 #if XAMCORE_2_0
 		[Internal]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -131,7 +131,8 @@ namespace XamCore.UIKit {
 
 #if !XAMCORE_3_0
 	[NoWatch]
-	[Category, BaseType (typeof (NSAttributedString))]
+	[Category (allowStaticMembers: true)] // Classic isn't internal so we need this
+	[BaseType (typeof (NSAttributedString))]
 	interface NSAttributedStringAttachmentConveniences {
 #if XAMCORE_2_0
 		[Internal]

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -14,7 +14,7 @@ include $(TOP)/Make.config
 IOS_CURRENT_DIR=$(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current
 IOS_GENERATOR = $(IOS_CURRENT_DIR)/bin/btouch-native /baselib:$(IOS_CURRENT_DIR)/lib/mono/Xamarin.iOS/Xamarin.iOS.dll /unsafe
 IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts bug43579 bindastests
-IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855
+IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers
 
 MAC_CURRENT_DIR=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
 MAC_GENERATOR = $(MAC_CURRENT_DIR)/bin/bmac
@@ -62,6 +62,16 @@ $(eval $(call iOSErrorCodeTestTemplate,bindas1049error,1049))
 $(eval $(call iOSErrorCodeTestTemplate,bindas1050modelerror,1050))
 $(eval $(call iOSErrorCodeTestTemplate,bindas1050protocolerror,1050))
 $(eval $(call iOSErrorCodeTestTemplate,bug42855,1060))
+$(eval $(call iOSErrorCodeTestTemplate,bug52570,1117))
+
+define iOSNoErrorCodesTestTemplate
+$(1):
+	$(if $(V),,@echo "$@";) !($(IOS_GENERATOR) $(1).cs 2>&1 | grep BI$(2) > /dev/null)
+endef
+
+$(eval $(call iOSNoErrorCodesTestTemplate,bug52570classinternal,1117))
+$(eval $(call iOSNoErrorCodesTestTemplate,bug52570methodinternal,1117))
+$(eval $(call iOSNoErrorCodesTestTemplate,bug52570allowstaticmembers,1117))
 
 classNameCollision:
 	@rm -Rf $@.tmpdir

--- a/tests/generator/bug52570.cs
+++ b/tests/generator/bug52570.cs
@@ -1,0 +1,19 @@
+using System;
+using Foundation;
+
+namespace Bug52570Tests {
+
+	[Category]
+	[BaseType (typeof (FooObject))]
+	interface FooObject_Extensions {
+
+		[Static]
+		[Export ("someMethod:")]
+		bool SomeMethod (NSRange range);
+	}
+
+	[BaseType (typeof (NSObject))]
+	interface FooObject {
+	
+	}
+}

--- a/tests/generator/bug52570allowstaticmembers.cs
+++ b/tests/generator/bug52570allowstaticmembers.cs
@@ -1,0 +1,19 @@
+using System;
+using Foundation;
+
+namespace bug52570AllowStaticMembers {
+
+	[Category (allowStaticMembers: true)]
+	[BaseType (typeof (FooObject))]
+	interface FooObject_Extensions {
+
+		[Static]
+		[Export ("someMethod:")]
+		bool SomeMethod (NSRange range);
+	}
+
+	[BaseType (typeof (NSObject))]
+	interface FooObject {
+	
+	}
+}

--- a/tests/generator/bug52570classinternal.cs
+++ b/tests/generator/bug52570classinternal.cs
@@ -1,0 +1,20 @@
+using System;
+using Foundation;
+
+namespace Bug52570ClassInternal {
+
+	[Category]
+	[Internal]
+	[BaseType (typeof (FooObject))]
+	interface FooObject_Extensions {
+
+		[Static]
+		[Export ("someMethod:")]
+		bool SomeMethod (NSRange range);
+	}
+
+	[BaseType (typeof (NSObject))]
+	interface FooObject {
+	
+	}
+}

--- a/tests/generator/bug52570methodinternal.cs
+++ b/tests/generator/bug52570methodinternal.cs
@@ -1,0 +1,20 @@
+using System;
+using Foundation;
+
+namespace bug52570MethodInternal {
+
+	[Category]
+	[BaseType (typeof (FooObject))]
+	interface FooObject_Extensions {
+
+		[Static]
+		[Internal]
+		[Export ("someMethod:")]
+		bool SomeMethod (NSRange range);
+	}
+
+	[BaseType (typeof (NSObject))]
+	interface FooObject {
+	
+	}
+}


### PR DESCRIPTION
In some cases you will find **static** members inside categories like in the following example:

```objc
@interface FooObject (MyFooObjectExtension)
+ (BOOL)boolMethod:(NSRange *)range;
@end
```

This will lead to an **incorrect** Category C# interface definition:

```csharp
[Category]
[BaseType (typeof (FooObject))]
interface FooObject_Extensions {

	// Incorrect Interface definition
	[Static]
	[Export ("boolMethod:")]
	bool BoolMethod (NSRange range);
}
```

This is incorrect because in order to use the `BoolMethod` extension you need an instance of `FooObject` but you are binding an ObjC **static** extension, this is a side effect due to the fact of how C# extension methods are implemented.

The only way to use the above definitions is by the following ugly code:

```csharp
(null as FooObject).BoolMethod (range);
```

The recomendation to avoid this is to inline the `BoolMethod` definition inside the `FooObject` interface definition itself, this will allow you to call this extension like it is intended `FooObject.BoolMethod (range)`.

```csharp
[BaseType (typeof (NSObject))]
interface FooObject {

	[Static]
	[Export ("boolMethod:")]
	bool BoolMethod (NSRange range);
}
```

We will issue a warning (BI1117) whenever we find a `[Static]` member inside a `[Category]` definition. If you really want to have `[Static]` members inside your `[Category]` definitions you can silence the warning by using `[Category (allowStaticMembers: true)]` or by decorating either your member or `[Category]` interface definition with `[Internal]`.