### PR TITLE
[mtouch] Don't put frameworks in WatchKit 1 extensions. Fixes #53232.

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/ExtensionTestBase.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/ExtensionTestBase.cs
@@ -21,12 +21,12 @@ namespace Xamarin.iOS.Tasks
 			Platform = platform;
 		}
 
-		public void BuildExtension (string hostAppName, string extensionName, string platform, string config, int expectedErrorCount = 0)
+		public void BuildExtension (string hostAppName, string extensionName, string platform, string config, int expectedErrorCount = 0, System.Action<ProjectPaths> additionalAsserts = null)
 		{
-			BuildExtension (hostAppName, extensionName, platform, platform, config, expectedErrorCount);
+			BuildExtension (hostAppName, extensionName, platform, platform, config, expectedErrorCount, additionalAsserts);
 		}
 
-		public void BuildExtension (string hostAppName, string extensionName, string bundlePath, string platform, string config, int expectedErrorCount = 0)
+		public void BuildExtension (string hostAppName, string extensionName, string bundlePath, string platform, string config, int expectedErrorCount = 0, System.Action<ProjectPaths> additionalAsserts = null)
 		{
 			var mtouchPaths = SetupProjectPaths (hostAppName, "../", true, bundlePath, config);
 
@@ -66,6 +66,9 @@ namespace Xamarin.iOS.Tasks
 			} else {
 				TestFilesExists (platform == "iPhone" ? Path.Combine (AppBundlePath, ".monotouch-32") : AppBundlePath, coreFiles);
 			}
+
+			if (additionalAsserts != null)
+				additionalAsserts (mtouchPaths);
 		}
 
 		public void SetupPaths (string appName, string platform) 

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/WatchKit.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/WatchKit.cs
@@ -17,7 +17,11 @@ namespace Xamarin.iOS.Tasks {
 		[Test]
 		public void BasicTest () 
 		{
-			this.BuildExtension ("MyWatchApp", "MyWatchKitExtension", Platform, "Debug");
+			this.BuildExtension ("MyWatchApp", "MyWatchKitExtension", Platform, "Debug", additionalAsserts: (ProjectPaths mtouchPaths) =>
+			{
+				Assert.IsTrue (Directory.Exists (Path.Combine (mtouchPaths.AppBundlePath, "PlugIns", "MyWatchKitExtension.appex")), "appex");
+				Assert.IsFalse (Directory.Exists (Path.Combine (mtouchPaths.AppBundlePath, "PlugIns", "MyWatchKitExtension.appex", "Frameworks")), "frameworks");
+			});
 		}
 
 		[Test]

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -309,6 +309,18 @@ namespace Xamarin.Bundler {
 			}
 		}
 
+		public bool HasFrameworksDirectory {
+			get {
+				if (!IsExtension)
+					return true;
+
+				if (IsWatchExtension && Platform == ApplePlatform.WatchOS)
+					return true;
+				
+				return false;
+			}
+		}
+
 		public string ExtensionIdentifier {
 			get {
 				if (!IsExtension)
@@ -1076,7 +1088,7 @@ namespace Xamarin.Bundler {
 			}
 
 			// Copy frameworks to the app bundle.
-			if (!IsExtension || IsWatchExtension) {
+			if (HasFrameworksDirectory) {
 				var all_frameworks = new HashSet<string> ();
 				all_frameworks.UnionWith (Frameworks);
 				all_frameworks.UnionWith (WeakFrameworks);
@@ -1126,24 +1138,22 @@ namespace Xamarin.Bundler {
 					}
 				}
 			} else {
-				if (!IsWatchExtension) {
-					// In extensions we need to save a list of the frameworks we need so that the main app can get them.
-					var all_frameworks = new HashSet<string> (Frameworks);
-					all_frameworks.UnionWith (WeakFrameworks);
-					foreach (var t in Targets) {
-						all_frameworks.UnionWith (t.Frameworks);
-						all_frameworks.UnionWith (t.WeakFrameworks);
-						foreach (var a in t.Assemblies) {
-							if (a.Frameworks != null)
-								all_frameworks.UnionWith (a.Frameworks);
-							if (a.WeakFrameworks != null)
-								all_frameworks.UnionWith (a.WeakFrameworks);
-						}
+				// In extensions we need to save a list of the frameworks we need so that the main app can get them.
+				var all_frameworks = new HashSet<string> (Frameworks);
+				all_frameworks.UnionWith (WeakFrameworks);
+				foreach (var t in Targets) {
+					all_frameworks.UnionWith (t.Frameworks);
+					all_frameworks.UnionWith (t.WeakFrameworks);
+					foreach (var a in t.Assemblies) {
+						if (a.Frameworks != null)
+							all_frameworks.UnionWith (a.Frameworks);
+						if (a.WeakFrameworks != null)
+							all_frameworks.UnionWith (a.WeakFrameworks);
 					}
-					all_frameworks.RemoveWhere ((v) => !v.EndsWith (".framework", StringComparison.Ordinal));
-					if (all_frameworks.Count () > 0)
-						Driver.WriteIfDifferent (Path.Combine (Path.GetDirectoryName (AppDirectory), "frameworks.txt"), string.Join ("\n", all_frameworks.ToArray ()));
 				}
+				all_frameworks.RemoveWhere ((v) => !v.EndsWith (".framework", StringComparison.Ordinal));
+				if (all_frameworks.Count () > 0)
+					Driver.WriteIfDifferent (Path.Combine (Path.GetDirectoryName (AppDirectory), "frameworks.txt"), string.Join ("\n", all_frameworks.ToArray ()));
 			}
 
 			if (IsSimulatorBuild || !IsDualBuild) {


### PR DESCRIPTION
The frameworks go into the container app's Frameworks directory.

https://bugzilla.xamarin.com/show_bug.cgi?id=53232