### PR TITLE
[53273] Allow passing null to CGLContext.CurrentContext

### DIFF
--- a/src/OpenGL/CGLContext.cs
+++ b/src/OpenGL/CGLContext.cs
@@ -117,7 +117,7 @@ namespace XamCore.OpenGL {
 
 			set {
 
-				CGLErrorCode retValue = CGLSetCurrentContext (value.Handle);
+				CGLErrorCode retValue = CGLSetCurrentContext (value?.Handle ?? IntPtr.Zero);
 				if (retValue != CGLErrorCode.NoError)
 					throw new Exception ("Error setting the Current Context");
 			}

--- a/tests/apitest/src/OpenGL/CGLContext.cs
+++ b/tests/apitest/src/OpenGL/CGLContext.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using NUnit.Framework;
+using OpenGL;
+
+namespace Xamarin.Mac.Tests {
+	[TestFixture]
+	public class CGLContextTests {
+		[Test]
+		public void CurrentContextAllowsNull ()
+		{
+			Assert.DoesNotThrow (() => {
+				CGLContext.CurrentContext = null;
+			});
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=53273