### PR TITLE
[Contacts] Better API for CNContainer_PredicatesExtension and CNGroup_PredicatesExtension categories. Fixes #52571 

### DIFF
--- a/src/contacts.cs
+++ b/src/contacts.cs
@@ -560,7 +560,6 @@ namespace XamCore.Contacts {
 #endif
 		NSPredicate CreatePredicateForContainers (string [] identifiers);
 
-		[NoiOS][NoWatch]
 		[Static]
 #if XAMCORE_4_0
 		[Export ("predicateForContainerOfContactWithIdentifier:")]

--- a/src/contacts.cs
+++ b/src/contacts.cs
@@ -521,14 +521,17 @@ namespace XamCore.Contacts {
 	[BaseType (typeof (CNContainer))]
 	interface CNContainer_PredicatesExtension {
 
+		[Obsolete ("Use CNContainer.CreatePredicateForContainers instead")]
 		[Static]
 		[Export ("predicateForContainersWithIdentifiers:")]
 		NSPredicate GetPredicateForContainers (string [] identifiers);
 
+		[Obsolete ("Use CNContainer.CreatePredicateForContainerOfContact instead")]
 		[Static]
 		[Export ("predicateForContainerOfContactWithIdentifier:")]
 		NSPredicate GetPredicateForContainerOfContact (string contactIdentifier);
 
+		[Obsolete ("Use CNContainer.CreatePredicateForContainerOfGroup instead")]
 		[Static]
 		[Export ("predicateForContainerOfGroupWithIdentifier:")]
 		NSPredicate GetPredicateForContainerOfGroup (string groupIdentifier);
@@ -548,6 +551,7 @@ namespace XamCore.Contacts {
 		[Export ("type", ArgumentSemantic.Assign)]
 		CNContainerType ContainerType { get; }
 
+#region comes from CNContainer (Predicates) Category
 		[Static]
 #if XAMCORE_4_0
 		[Export ("predicateForContainersWithIdentifiers:")]
@@ -572,6 +576,7 @@ namespace XamCore.Contacts {
 		[Wrap ("(null as CNContainer).GetPredicateForContainerOfGroup (groupIdentifier)")]
 #endif
 		NSPredicate CreatePredicateForContainerOfGroup (string groupIdentifier);
+#endregion
 	}
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
@@ -613,15 +618,18 @@ namespace XamCore.Contacts {
 	[BaseType (typeof (CNGroup))]
 	interface CNGroup_PredicatesExtension {
 
+		[Obsolete ("Use CNGroup.CreatePredicateForGroups instead")]
 		[Static]
 		[Export ("predicateForGroupsWithIdentifiers:")]
 		NSPredicate GetPredicateForGroups (string [] identifiers);
 
+		[Obsolete ("Use CNGroup.CreatePredicateForSubgroupsInGroup instead")]
 		[NoiOS][NoWatch]
 		[Static]
 		[Export ("predicateForSubgroupsInGroupWithIdentifier:")]
 		NSPredicate GetPredicateForSubgroupsInGroup (string parentGroupIdentifier);
 
+		[Obsolete ("Use CNGroup.CreatePredicateForGroupsInContainer instead")]
 		[Static]
 		[Export ("predicateForGroupsInContainerWithIdentifier:")]
 		NSPredicate GetPredicateForGroupsInContainer (string containerIdentifier);
@@ -638,6 +646,7 @@ namespace XamCore.Contacts {
 		[Export ("name")]
 		string Name { get; }
 
+#region comes from CNGroup (Predicates) Category
 		[Static]
 #if XAMCORE_4_0
 		[Export ("predicateForGroupsWithIdentifiers:")]
@@ -662,6 +671,7 @@ namespace XamCore.Contacts {
 		[Wrap ("(null as CNGroup).GetPredicateForGroupsInContainer (containerIdentifier)")]
 #endif
 		NSPredicate CreatePredicateForGroupsInContainer (string containerIdentifier);
+#endregion
 	}
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]

--- a/src/contacts.cs
+++ b/src/contacts.cs
@@ -515,6 +515,7 @@ namespace XamCore.Contacts {
 		CNContact [] GetContactsFromData (NSData data, out NSError error);
 	}
 
+#if !XAMCORE_4_0
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Category (allowStaticMembers: true)]
 	[BaseType (typeof (CNContainer))]
@@ -532,6 +533,7 @@ namespace XamCore.Contacts {
 		[Export ("predicateForContainerOfGroupWithIdentifier:")]
 		NSPredicate GetPredicateForContainerOfGroup (string groupIdentifier);
 	}
+#endif
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
@@ -545,6 +547,31 @@ namespace XamCore.Contacts {
 
 		[Export ("type", ArgumentSemantic.Assign)]
 		CNContainerType ContainerType { get; }
+
+		[Static]
+#if XAMCORE_4_0
+		[Export ("predicateForContainersWithIdentifiers:")]
+#else
+		[Wrap ("(null as CNContainer).GetPredicateForContainers (identifiers)")]
+#endif
+		NSPredicate CreatePredicateForContainers (string [] identifiers);
+
+		[NoiOS][NoWatch]
+		[Static]
+#if XAMCORE_4_0
+		[Export ("predicateForContainerOfContactWithIdentifier:")]
+#else
+		[Wrap ("(null as CNContainer).GetPredicateForContainerOfContact (contactIdentifier)")]
+#endif
+		NSPredicate CreatePredicateForContainerOfContact (string contactIdentifier);
+
+		[Static]
+#if XAMCORE_4_0
+		[Export ("predicateForContainerOfGroupWithIdentifier:")]
+#else
+		[Wrap ("(null as CNContainer).GetPredicateForContainerOfGroup (groupIdentifier)")]
+#endif
+		NSPredicate CreatePredicateForContainerOfGroup (string groupIdentifier);
 	}
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
@@ -580,6 +607,7 @@ namespace XamCore.Contacts {
 		NSString KeyPaths { get; }
 	}
 
+#if !XAMCORE_4_0
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[Category (allowStaticMembers: true)]
 	[BaseType (typeof (CNGroup))]
@@ -598,6 +626,7 @@ namespace XamCore.Contacts {
 		[Export ("predicateForGroupsInContainerWithIdentifier:")]
 		NSPredicate GetPredicateForGroupsInContainer (string containerIdentifier);
 	}
+#endif
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
@@ -608,6 +637,31 @@ namespace XamCore.Contacts {
 
 		[Export ("name")]
 		string Name { get; }
+
+		[Static]
+#if XAMCORE_4_0
+		[Export ("predicateForGroupsWithIdentifiers:")]
+#else
+		[Wrap ("(null as CNGroup).GetPredicateForGroups (identifiers)")]
+#endif
+		NSPredicate CreatePredicateForGroups (string [] identifiers);
+
+		[NoiOS][NoWatch]
+		[Static]
+#if XAMCORE_4_0
+		[Export ("predicateForSubgroupsInGroupWithIdentifier:")]
+#else
+		[Wrap ("(null as CNGroup).GetPredicateForSubgroupsInGroup (parentGroupIdentifier)")]
+#endif
+		NSPredicate CreatePredicateForSubgroupsInGroup (string parentGroupIdentifier);
+
+		[Static]
+#if XAMCORE_4_0
+		[Export ("predicateForGroupsInContainerWithIdentifier:")]
+#else
+		[Wrap ("(null as CNGroup).GetPredicateForGroupsInContainer (containerIdentifier)")]
+#endif
+		NSPredicate CreatePredicateForGroupsInContainer (string containerIdentifier);
 	}
 
 	[iOS (9,0), Mac (10,11, onlyOn64: true)]


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=52571

Unfortunately [Static] methods inside [Category] lead to bad code
I have exposed alternative methods that call the static extensions
and when XAMCORE_4_0 is a thing they will get inlined in their
respective class