### PR TITLE
Make sure we pass gc options if using concurrent sgen (#1867)

### DIFF
--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -878,6 +878,10 @@ namespace Xamarin.Bundler
 			if (app.EnvironmentVariables.Count > 0)
 				return false;
 
+			// If we are asked to run with concurrent sgen we also need to pass environment variables
+			if (app.EnableSGenConc)
+				return false;
+
 			if (app.Registrar == RegistrarMode.Static)
 				return false;
 


### PR DESCRIPTION
When using debug simulator we don't generate main.m so we were not passing the gc options.

The MONO_GC_PARAMS variable is not in app.EnvironmentVariables (which only contains environment variables passed to mtouch using --setenv), which is why the above condition does not trigger.