### PR TITLE
[foundation] Honor the cancellation token win the async requests in NSUrlSessionHandler

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -225,15 +225,15 @@ namespace Foundation {
 				try {
 					// ensure that we did not cancel the request, if we did, do cancel the task
 					if (inflight.CancellationToken.IsCancellationRequested) {
-                            dataTask.Cancel();
-                    }
+						dataTask.Cancel ();
+					}
 
 					var urlResponse = (NSHttpUrlResponse)response;
 					var status = (int)urlResponse.StatusCode;
 
 					var content = new NSUrlSessionDataTaskStreamContent (inflight.Stream, () => {
 						if (!inflight.Completed) {
-							dataTask.Cancel();
+							dataTask.Cancel ();
 						}
 
 						inflight.Disposed = true;


### PR DESCRIPTION
Do pass the cancelation token in the NSUrlSessionHandler to ensure that
if the request is cancelled we do not hang for ever.

This is a partial fix (just addresses the NSUrlSessionhandler) for bug #51423