### PR TITLE
[Foundation] Fix NSUrlSessionHandler thread issues.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -55,6 +55,7 @@ namespace Foundation {
 #endif
 	public partial class NSUrlSessionHandler : HttpMessageHandler
 	{
+		static readonly NSUrlSessionConfiguration configuration;
 		readonly Dictionary<string, string> headerSeparators = new Dictionary<string, string> {
 			["User-Agent"] = " ",
 			["Server"] = " "
@@ -64,10 +65,9 @@ namespace Foundation {
 		readonly Dictionary<NSUrlSessionTask, InflightData> inflightRequests;
 		readonly object inflightRequestsLock = new object ();
 
-		public NSUrlSessionHandler ()
+		static NSUrlSessionHandler ()
 		{
-			AllowAutoRedirect = true;
-			var configuration = NSUrlSessionConfiguration.DefaultSessionConfiguration;
+			configuration = NSUrlSessionConfiguration.DefaultSessionConfiguration;
 
 			// we cannot do a bitmask but we can set the minimum based on ServicePointManager.SecurityProtocol minimum
 			var sp = ServicePointManager.SecurityProtocol;
@@ -79,8 +79,13 @@ namespace Foundation {
 				configuration.TLSMinimumSupportedProtocol = SslProtocol.Tls_1_1;
 			else if ((sp & SecurityProtocolType.Tls12) != 0)
 				configuration.TLSMinimumSupportedProtocol = SslProtocol.Tls_1_2;
+		}
 
-			session = NSUrlSession.FromConfiguration (NSUrlSessionConfiguration.DefaultSessionConfiguration, new NSUrlSessionHandlerDelegate (this), null);
+		public NSUrlSessionHandler ()
+		{
+			AllowAutoRedirect = true;
+
+			session = NSUrlSession.FromConfiguration (configuration, new NSUrlSessionHandlerDelegate (this), null);
 			inflightRequests = new Dictionary<NSUrlSessionTask, InflightData> ();
 		}
 


### PR DESCRIPTION
Do not deal with the configuration in the instance constructor. We do
not need to do it for every instance AND it is racy. 

This fixes bug #53461.