### PR TITLE
[foundation] Make sure NSUrlSessionConfiguration.TLSMinimumSupportedProtocol is set

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -80,7 +80,7 @@ namespace Foundation {
 			else if ((sp & SecurityProtocolType.Tls12) != 0)
 				configuration.TLSMinimumSupportedProtocol = SslProtocol.Tls_1_2;
 
-			session = NSUrlSession.FromConfiguration (NSUrlSessionConfiguration.DefaultSessionConfiguration, new NSUrlSessionHandlerDelegate (this), null);
+			session = NSUrlSession.FromConfiguration (configuration, new NSUrlSessionHandlerDelegate (this), null);
 			inflightRequests = new Dictionary<NSUrlSessionTask, InflightData> ();
 		}
 


### PR DESCRIPTION
During the investigation for a System.Configuration race in bug #53461 [1]
it was found that we did not pass the computed value for
`TLSMinimumSupportedProtocol` based on `ServicePointManager.SecurityProtocols`
to the `NSUrlSession`, in effect allowing what the OS does, by default,
and not what the application requested.

This replace an earlier attempt to fix the race in PR #1889

[1] https://bugzilla.xamarin.com/show_bug.cgi?id=53461
[2] https://github.com/xamarin/xamarin-macios/pull/1889