### PR TITLE
[monotouch-test] Fix randomly crashing SystemSoundTest.FromFile to not get a callback after the sound was disposed. Fixes #52903.

### DIFF
--- a/tests/monotouch-test/AudioToolbox/SystemSoundTest.cs
+++ b/tests/monotouch-test/AudioToolbox/SystemSoundTest.cs
@@ -15,11 +15,13 @@ using System.IO;
 using Foundation;
 using AudioToolbox;
 using CoreFoundation;
+using ObjCRuntime;
 #else
 using MonoTouch.Foundation;
 using MonoTouch.MediaPlayer;
 using MonoTouch.AudioToolbox;
 using MonoTouch.CoreFoundation;
+using MonoTouch.ObjCRuntime;
 #endif
 using NUnit.Framework;
 using System.Threading;
@@ -38,6 +40,9 @@ namespace MonoTouchFixtures.AudioToolbox {
 			var path = NSBundle.MainBundle.PathForResource ("1", "caf", "AudioToolbox");
 #else
 			var path = Path.GetFullPath (Path.Combine ("AudioToolbox", "1.caf"));
+
+			if (Runtime.Arch == Arch.SIMULATOR)
+				Assert.Ignore ("PlaySystemSound doesn't work in the simulator");
 #endif
 
 			using (var ss = SystemSound.FromFile (NSUrl.FromFilename (path))) {

--- a/tests/monotouch-test/AudioToolbox/SystemSoundTest.cs
+++ b/tests/monotouch-test/AudioToolbox/SystemSoundTest.cs
@@ -30,6 +30,7 @@ namespace MonoTouchFixtures.AudioToolbox {
 	[Preserve (AllMembers = true)]
 	public class SystemSoundTest
 	{
+#if !MONOMAC // Currently no AppDelegate in xammac_test
 		[Test]
 		public void FromFile ()
 		{
@@ -40,12 +41,18 @@ namespace MonoTouchFixtures.AudioToolbox {
 #endif
 
 			using (var ss = SystemSound.FromFile (NSUrl.FromFilename (path))) {
+				var completed = false;
+				const int timeout = 10;
+
 				Assert.AreEqual (AudioServicesError.None, ss.AddSystemSoundCompletion (delegate {
+					completed = true;
 					}));
 
 				ss.PlaySystemSound ();
+				Assert.IsTrue (MonoTouchFixtures.AppDelegate.RunAsync (DateTime.Now.AddSeconds (timeout), async () => { }, () => completed), "PlaySystemSound");
 			}
 		}
+#endif
 
 		[Test]
 		public void Properties ()


### PR DESCRIPTION
SystemSoundTest.FromFile was requesting to be called back when the sound
completed playback. This causes problems when the sound is disposed after it
has started playing, because in that case disposing it won't prevent the
callback from being called, but instead random InvalidCastExceptions / crashes
would occur.

https://bugzilla.xamarin.com/show_bug.cgi?id=52903