### PR TITLE
[generator] Turn BI1060 into a warning instead of an error

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -5486,7 +5486,7 @@ public partial class Generator : IMemberGatherer {
 				if (is_static_class)
 					throw new BindingException (1025, true, "[Static] and [Protocol] are mutually exclusive ({0})", type.FullName);
 				if (is_model && base_type == TypeManager.System_Object)
-					throw new BindingException (1060, true, "The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].", type.FullName);
+					ErrorHelper.Show (new BindingException (1060, "The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].", type.FullName));
 
 				var protocol = AttributeManager.GetCustomAttribute<ProtocolAttribute> (type);
 				GenerateProtocolTypes (type, class_visibility, TypeName, protocol.Name ?? objc_type_name, protocol);


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-macios/commit/0ada7dedce79a795dd9c9bbf3ffa102f01e3d614#commitcomment-21338196

We wanted this to be an error [first][0] but this could lead
to break our user's code just by updating so making it a warning

[0]: https://bugzilla.xamarin.com/show_bug.cgi?id=42855