### PR TITLE
[generator] Bump .NET version for the generator's project file.

### DIFF
--- a/src/generator-ikvm.csproj.in
+++ b/src/generator-ikvm.csproj.in
@@ -9,6 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>src</RootNamespace>
     <AssemblyName>bgen</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>


### PR DESCRIPTION
Array.Empty<T> did not exist in earlier versions of .NET, so this would build
fine on the command-line (which builds using the system's latest .NET
version), but not with the project file (which apparently defaults to .NET 4.5
unless otherwise specified).

So bump the .NET version in the project file so that compilation works the
same in both cases.