### PR TITLE
[Foundation] Ensure that if a request is canceled we cancel the NSUrlSessionTask

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -365,7 +365,7 @@ namespace Foundation {
 				// header, it means that we do not have the correct credentials, in any other case just do what it is expected.
 				
 				if (challenge.PreviousFailureCount == 0) {
-					var authHeader = inflight?.Request?.Headers?.Authorization;
+					var authHeader = inflight.Request?.Headers?.Authorization;
 					if (!(string.IsNullOrEmpty (authHeader?.Scheme) && string.IsNullOrEmpty (authHeader?.Parameter))) {
 						completionHandler (NSUrlSessionAuthChallengeDisposition.RejectProtectionSpace, null);
 						return;

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -216,7 +216,7 @@ namespace Foundation {
 						return inflight;
 
 				// if we did not manage to get the inflight data, we either got an error or have been canceled, lets cancel the task, that will execute DidCompleteWithError
-				task.Cancel ();
+				task?.Cancel ();
 				return null;
 			}
 


### PR DESCRIPTION
This change fixes bug #53794 

If the request is canceled, the inflight data is cleaned up. That allows
us to know that the NSUrlSessionTask should be canceled, which will
execute the DidCompleteWithError that will take care of the cleanup of
resources and will ensure that everything is back to a known situation.

Bug description: - https://bugzilla.xamarin.com/show_bug.cgi?id=53794
