### PR TITLE
[Proposal] Add playground to IKVM generator template

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -11,3 +11,4 @@ xammac.csproj
 xamtvos.csproj
 xamwatch.csproj
 generator-ikvm.csproj
+generator-playground.cs

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -70,6 +70,7 @@ generator-ikvm.csproj: generator-ikvm.csproj.in Makefile.generator
 		-e 's^%MAC_FULL_PMCS_PROFILE%^full^' \
 		-e 's^%MAC_MOBILE_ARGS%^-d:MONOMAC -d:XAMARIN_MAC -compiler:$(MAC_BUILD_DIR)/mobile/pmcs -process-enums -native-exception-marshalling -core -sourceonly:$(MAC_BUILD_DIR)/mobile/generated-sources -tmpdir:$(MAC_BUILD_DIR)/mobile -baselib:$(MAC_BUILD_DIR)/mobile/core.dll -d:NO_SYSTEM_DRAWING --ns=ObjCRuntime $(SHARED_SYSTEM_DRAWING_SOURCES) $(xm_mobile_profile) $(MAC_APIS)^' \
 		-e 's^%MAC_MOBILE_PMCS_PROFILE%^mobile^' \
+		-e 's^%IOS_UNIFIED_PLAYGROUND_ARGS%^$(IOS_GENERATOR_FLAGS) -core -sourceonly=$(IOS_BUILD_DIR)/playground/generated_sources -compiler=$(IOS_PMCS) -nostdlib -noconfig -no-mono-path -tmpdir=$(IOS_BUILD_DIR)/playground -baselib=$(IOS_BUILD_DIR)/native/core.dll -r=$(MONO_PATH)/mcs/class/lib/monotouch/System.dll -ns=MonoTouch.ObjCRuntime -native-exception-marshalling --ns=ObjCRuntime $(xi_native_profile) $(IOS_APIS) generator-playground.cs^' \
 		-e 's^%MD_MTOUCH_SDK_ROOT%^$(MD_MTOUCH_SDK_ROOT)^' \
 		-e 's^%XamarinMacFrameworkRoot%^$(XamarinMacFrameworkRoot)^' \
 		$< | xmllint --format - > $@

--- a/src/generator-ikvm.csproj.in
+++ b/src/generator-ikvm.csproj.in
@@ -92,6 +92,15 @@
       <Variable name="XamarinMacFrameworkRoot" value="%XamarinMacFrameworkRoot%" />
     </EnvironmentVariables>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'ios-unified-playground' ">
+    <StartAction>Project</StartAction>
+    <StartArguments>%IOS_UNIFIED_PLAYGROUND_ARGS%</StartArguments>
+    <StartWorkingDirectory>%WORKING_DIR%</StartWorkingDirectory>
+    <EnvironmentVariables>
+      <Variable name="PMCS_PROFILE" value="%IOS_UNIFIED_PMCS_PROFILE%" />
+      <Variable name="MD_MTOUCH_SDK_ROOT" value="%MD_MTOUCH_SDK_ROOT%" />
+    </EnvironmentVariables>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/generator-playground.cs
+++ b/src/generator-playground.cs
@@ -1,0 +1,16 @@
+// 
+// generator-playground.cs: Used to debug generator, this is an ApiDefinition.cs file
+//							that you can use to create your own interfaces definitions
+//
+// Authors:
+//    Alex Soto (alexsoto@microsoft.com
+// 
+// Copyright 2017 Xamarin Inc.
+//
+
+using System;
+using XamCore.Foundation;
+
+namespace Playground {
+
+}


### PR DESCRIPTION
When adding new features to the generator we find ourselves
creating new test cases in `test/generator` or with binding projects
and not actually modifying the actual SDK api definition source files
because you get a lot of noise on the generated code.

By doing the above it would not allow us to leverage the new debugging
capabilities (thanks @rolfbjarne !!) that the new IKVM based generator grant us.

So my proposal is to have this Playground (generator-playground.cs)
where you can add arbitrary interface definitions to test and debug the
generator that sould end up as your test case in tests/generator.