### PR TITLE
Backport fixes for #51423: NSUrlSessionHandler cancellation issues

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -212,9 +212,15 @@ namespace Foundation {
 				var inflight = default (InflightData);
 
 				lock (sessionHandler.inflightRequestsLock)
-					if (sessionHandler.inflightRequests.TryGetValue (task, out inflight))
+					if (sessionHandler.inflightRequests.TryGetValue (task, out inflight)) {
+						// ensure that we did not cancel the request, if we did, do cancel the task
+						if (inflight.CancellationToken.IsCancellationRequested)
+							task?.Cancel ();
 						return inflight;
+					}
 
+				// if we did not manage to get the inflight data, we either got an error or have been canceled, lets cancel the task, that will execute DidCompleteWithError
+				task?.Cancel ();
 				return null;
 			}
 
@@ -222,12 +228,10 @@ namespace Foundation {
 			{
 				var inflight = GetInflightData (dataTask);
 
-				try {
-					// ensure that we did not cancel the request, if we did, do cancel the task
-					if (inflight.CancellationToken.IsCancellationRequested) {
-						dataTask.Cancel ();
-					}
+				if (inflight == null)
+					return;
 
+				try {
 					var urlResponse = (NSHttpUrlResponse)response;
 					var status = (int)urlResponse.StatusCode;
 
@@ -278,6 +282,9 @@ namespace Foundation {
 			public override void DidReceiveData (NSUrlSession session, NSUrlSessionDataTask dataTask, NSData data)
 			{
 				var inflight = GetInflightData (dataTask);
+
+				if (inflight == null)
+					return;
 
 				inflight.Stream.Add (data);
 				SetResponse (inflight);
@@ -338,6 +345,11 @@ namespace Foundation {
 
 			public override void DidReceiveChallenge (NSUrlSession session, NSUrlSessionTask task, NSUrlAuthenticationChallenge challenge, Action<NSUrlSessionAuthChallengeDisposition, NSUrlCredential> completionHandler)
 			{
+				var inflight = GetInflightData (task);
+
+				if (inflight == null)
+					return;
+
 				// case for the basic auth failing up front. As per apple documentation:
 				// The URL Loading System is designed to handle various aspects of the HTTP protocol for you. As a result, you should not modify the following headers using
 				// the addValue(_:forHTTPHeaderField:) or setValue(_:forHTTPHeaderField:) methods:
@@ -352,7 +364,7 @@ namespace Foundation {
 				// header, it means that we do not have the correct credentials, in any other case just do what it is expected.
 				
 				if (challenge.PreviousFailureCount == 0) {
-					var authHeader = GetInflightData (task)?.Request?.Headers?.Authorization;
+					var authHeader = inflight.Request?.Headers?.Authorization;
 					if (!(string.IsNullOrEmpty (authHeader?.Scheme) && string.IsNullOrEmpty (authHeader?.Parameter))) {
 						completionHandler (NSUrlSessionAuthChallengeDisposition.RejectProtectionSpace, null);
 						return;
@@ -363,7 +375,7 @@ namespace Foundation {
 					if (sessionHandler.Credentials != null) {
 						var credentialsToUse = sessionHandler.Credentials as NetworkCredential;
 						if (credentialsToUse == null) {
-							var uri = GetInflightData (task).Request.RequestUri;
+							var uri = inflight.Request.RequestUri;
 							credentialsToUse = sessionHandler.Credentials.GetCredential (uri, "NTLM");
 						}
 						var credential = new NSUrlCredential (credentialsToUse.UserName, credentialsToUse.Password, NSUrlCredentialPersistence.ForSession);

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -223,15 +223,24 @@ namespace Foundation {
 				var inflight = GetInflightData (dataTask);
 
 				try {
+					// ensure that we did not cancel the request, if we did, do cancel the task
+					if (inflight.CancellationToken.IsCancellationRequested) {
+						dataTask.Cancel ();
+					}
+
 					var urlResponse = (NSHttpUrlResponse)response;
 					var status = (int)urlResponse.StatusCode;
 
 					var content = new NSUrlSessionDataTaskStreamContent (inflight.Stream, () => {
+						if (!inflight.Completed) {
+							dataTask.Cancel ();
+						}
+
 						inflight.Disposed = true;
 						inflight.Stream.TrySetException (new ObjectDisposedException ("The content stream was disposed."));
 
 						sessionHandler.RemoveInflightData (dataTask);
-					});
+					}, inflight.CancellationToken);
 
 					// NB: The double cast is because of a Xamarin compiler bug
 					var httpResponse = new HttpResponseMessage ((HttpStatusCode)status) {
@@ -278,7 +287,7 @@ namespace Foundation {
 			{
 				var inflight = GetInflightData (task);
 
-				// this can happen if the HTTP request times out and it is removed as part of the cancelation process
+				// this can happen if the HTTP request times out and it is removed as part of the cancellation process
 				if (inflight != null) {
 					// set the stream as finished
 					inflight.Stream.TrySetReceivedAllData ();
@@ -396,7 +405,7 @@ namespace Foundation {
 		{
 			Action disposed;
 
-			public NSUrlSessionDataTaskStreamContent (NSUrlSessionDataTaskStream source, Action onDisposed) : base (source)
+			public NSUrlSessionDataTaskStreamContent (NSUrlSessionDataTaskStream source, Action onDisposed, CancellationToken token) : base (source, token)
 			{
 				disposed = onDisposed;
 			}


### PR DESCRIPTION
cf01a2a (Manuel de la Pena, 12 minutes ago)
   [Foundation] Ensure that if a request is canceled we cancel the
   NSUrlSessionTask (#1900)

   If the request is canceled, the inflight data is cleaned up. That allows us
   to know that the NSUrlSessionTask should be canceled, which will execute
   the DidCompleteWithError that will take care of the cleanup of resources
   and will ensure that everything is back to a known situation.

   * Do check for managed cancelations in the GetInflightData so that it is
   check in all handlers.

c0f7c02 (Manuel de la Pena, 33 hours ago)
   [foundation] Honor the cancellation token win the async requests in
   NSUrlSessionHandler. Fixes #51423 (#1888)

   Do pass the cancelation token in the NSUrlSessionHandler to ensure that if
   the request is cancelled we do not hang for ever.

   https://bugzilla.xamarin.com/show_bug.cgi?id=51423