### PR TITLE
[generator] Using [Async] on a method that does no return `void` should be a warning. Fixes bug 53103 

### DIFF
--- a/docs/website/binding_types_reference_guide.md
+++ b/docs/website/binding_types_reference_guide.md
@@ -1276,6 +1276,12 @@ Task<string> UploadAsync (string file);
 And on error, the resulting Task will have the exception
 set to an `NSErrorException` that wraps the resulting `NSError`. 
 
+### AsyncAttribute and members with return type different to System.Void
+
+We will issue a warning (BI1118) whenever we find `[Async]` being used on a member whose return type **is not** `System.Void`. If you really want to have `[Async]` on members with different return type to `System.Void` you can silence the warning by using `[Async (allowNonVoidReturnType: true)]`, also using the provided overloads or by setting the property `AllowNonVoidReturnType` to `true` of the `[AsyncAttribute]`.
+
+If you use `[Async]` on a member whose return type **is not** `System.Void` the returned value of the member will be **ignored**.
+
 ### AsyncAttribute.ResultType
 
 

--- a/docs/website/generator-errors.md
+++ b/docs/website/generator-errors.md
@@ -203,6 +203,10 @@ This usually indicates a bug in Xamarin.iOS/Xamarin.Mac; please [file a bug repo
 
 <h3><a name='BI1116'/>BI1116: The parameter '*' in the delegate '*' does not have a [CCallback] or [BlockCallback] attribute. Defaulting to [CCallback]. Declare a custom delegate instead of using System.Action / System.Func and add the attribute on the corresponding parameter.</h3>
 
+<h3><a name='BI1118'/> BI1118: [Async] is used in {0}.{1} where its return type isn't 'System.Void'. The return value will be ignored in the 'async' member.</h3>
+
+Please review [[AsyncAttribute]](https://developer.xamarin.com/guides/cross-platform/macios/binding/binding-types-reference/#AsyncAttribute) documentation.
+
 <!-- 2xxx: reserved -->
 <!-- 3xxx: reserved -->
 <!-- 4xxx: reserved -->

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -13681,7 +13681,7 @@ namespace XamCore.AppKit {
 #if XAMCORE_4_0
 		[Async (ResultTypeName="NSSpellCheckerCandidates")]
 #else
-		[Async (ResultTypeName="NSSpellCheckerCanidates")]
+		[Async (ResultTypeName = "NSSpellCheckerCanidates", AllowNonVoidReturnType = true)]
 #endif
 		[Export ("requestCandidatesForSelectedRange:inString:types:options:inSpellDocumentWithTag:completionHandler:")]
 		nint RequestCandidates (NSRange selectedRange, string stringToCheck, ulong checkingTypes, [NullAllowed] NSDictionary<NSString, NSObject> options, nint tag, [NullAllowed] Action<nint, NSTextCheckingResult []> completionHandler);

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -9638,7 +9638,12 @@ namespace XamCore.AVFoundation {
 
 		[Since (6,0), Mavericks]
 		[Export ("seekToDate:completionHandler:")]
+
+#if XAMCORE_4_0
 		[Async]
+#else
+		[Async (allowNonVoidReturnType: true)]
+#endif
 		bool Seek (NSDate date, AVCompletion completion);
 
 		[Since (6,0), Mavericks]

--- a/src/eventkit.cs
+++ b/src/eventkit.cs
@@ -619,7 +619,11 @@ namespace XamCore.EventKit {
 
 		[Since (6,0)]
 		[Export ("fetchRemindersMatchingPredicate:completion:")]
+#if XAMCORE_4_0
 		[Async]
+#else
+		[Async (allowNonVoidReturnType: true)]
+#endif
 		IntPtr FetchReminders (NSPredicate predicate, Action<EKReminder[]> completion);
 
 		[Since (6,0)]

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -5898,37 +5898,65 @@ namespace XamCore.Foundation
 
 		[Export ("dataTaskWithRequest:completionHandler:")]
 		[return: ForcedType]
-		[Async (ResultTypeName="NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();")]
+#if XAMCORE_4_0
+		[Async (ResultTypeName = "NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();")]
+#else
+		[Async (ResultTypeName = "NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();", AllowNonVoidReturnType = true)]
+#endif
 		NSUrlSessionDataTask CreateDataTask (NSUrlRequest request, [NullAllowed] NSUrlSessionResponse completionHandler);
 	
 		[Export ("dataTaskWithURL:completionHandler:")]
 		[return: ForcedType]
-		[Async(ResultTypeName="NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();")]
+#if XAMCORE_4_0
+		[Async (ResultTypeName = "NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();")]
+#else
+		[Async (ResultTypeName = "NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();", AllowNonVoidReturnType = true)]
+#endif
 		NSUrlSessionDataTask CreateDataTask (NSUrl url, [NullAllowed] NSUrlSessionResponse completionHandler);
 	
 		[Export ("uploadTaskWithRequest:fromFile:completionHandler:")]
 		[return: ForcedType]
-		[Async(ResultTypeName="NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();")]
+#if XAMCORE_4_0
+		[Async (ResultTypeName = "NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();")]
+#else
+		[Async (ResultTypeName = "NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();", AllowNonVoidReturnType = true)]
+#endif
 		NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request, NSUrl fileURL, NSUrlSessionResponse completionHandler);
 	
 		[Export ("uploadTaskWithRequest:fromData:completionHandler:")]
 		[return: ForcedType]
-		[Async(ResultTypeName="NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();")]
+#if XAMCORE_4_0
+		[Async (ResultTypeName = "NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();")]
+#else
+		[Async (ResultTypeName = "NSUrlSessionDataTaskRequest", PostNonResultSnippet = "result.Resume ();", AllowNonVoidReturnType = true)]
+#endif
 		NSUrlSessionUploadTask CreateUploadTask (NSUrlRequest request, NSData bodyData, NSUrlSessionResponse completionHandler);
 	
 		[Export ("downloadTaskWithRequest:completionHandler:")]
 		[return: ForcedType]
-		[Async(ResultTypeName="NSUrlSessionDownloadTaskRequest", PostNonResultSnippet = "result.Resume ();")]
+#if XAMCORE_4_0
+		[Async (ResultTypeName = "NSUrlSessionDownloadTaskRequest", PostNonResultSnippet = "result.Resume ();")]
+#else
+		[Async (ResultTypeName = "NSUrlSessionDownloadTaskRequest", PostNonResultSnippet = "result.Resume ();", AllowNonVoidReturnType = true)]
+#endif
 		NSUrlSessionDownloadTask CreateDownloadTask (NSUrlRequest request, [NullAllowed] NSUrlDownloadSessionResponse completionHandler);
 	
 		[Export ("downloadTaskWithURL:completionHandler:")]
 		[return: ForcedType]
-		[Async(ResultTypeName="NSUrlSessionDownloadTaskRequest", PostNonResultSnippet = "result.Resume ();")]
+#if XAMCORE_4_0
+		[Async (ResultTypeName = "NSUrlSessionDownloadTaskRequest", PostNonResultSnippet = "result.Resume ();")]
+#else
+		[Async (ResultTypeName = "NSUrlSessionDownloadTaskRequest", PostNonResultSnippet = "result.Resume ();", AllowNonVoidReturnType = true)]
+#endif
 		NSUrlSessionDownloadTask CreateDownloadTask (NSUrl url, [NullAllowed] NSUrlDownloadSessionResponse completionHandler);
 
 		[Export ("downloadTaskWithResumeData:completionHandler:")]
 		[return: ForcedType]
-		[Async(ResultTypeName="NSUrlSessionDownloadTaskRequest", PostNonResultSnippet = "result.Resume ();")]
+#if XAMCORE_4_0
+		[Async (ResultTypeName = "NSUrlSessionDownloadTaskRequest", PostNonResultSnippet = "result.Resume ();")]
+#else
+		[Async (ResultTypeName = "NSUrlSessionDownloadTaskRequest", PostNonResultSnippet = "result.Resume ();", AllowNonVoidReturnType = true)]
+#endif
 		NSUrlSessionDownloadTask CreateDownloadTaskFromResumeData (NSData resumeData, [NullAllowed] NSUrlDownloadSessionResponse completionHandler);
 
         

--- a/src/generator-attributes.cs
+++ b/src/generator-attributes.cs
@@ -769,10 +769,20 @@ public class AsyncAttribute : Attribute {
 	//This works with 4 kinds of callbacks: (), (NSError), (result), (result, NSError)
 	public AsyncAttribute () {}
 
+	public AsyncAttribute (bool allowNonVoidReturnType)
+	{
+		AllowNonVoidReturnType = allowNonVoidReturnType;
+	}
+
 	//This works with 2 kinds of callbacks: (...) and (..., NSError).
 	//Parameters are passed in order to a constructor in resultType
 	public AsyncAttribute (Type resultType) {
 		ResultType = resultType;
+	}
+
+	public AsyncAttribute (Type resultType, bool allowNonVoidReturnType) : this (resultType)
+	{
+		AllowNonVoidReturnType = allowNonVoidReturnType;
 	}
 
 	//This works with 2 kinds of callbacks: (...) and (..., NSError).
@@ -782,10 +792,16 @@ public class AsyncAttribute : Attribute {
 		MethodName = methodName;
 	}
 
+	public AsyncAttribute (string methodName, bool allowNonVoidReturnType) : this (methodName)
+	{
+		AllowNonVoidReturnType = allowNonVoidReturnType;
+	}
+
 	public Type ResultType { get; set; }
 	public string MethodName { get; set; }
 	public string ResultTypeName { get; set; }
 	public string PostNonResultSnippet { get; set; }
+	public bool AllowNonVoidReturnType { get; set; }
 }
 
 //

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -4573,6 +4573,7 @@ public partial class Generator : IMemberGatherer {
 		public ParameterInfo[] async_initial_params, async_completion_params;
 		public bool has_nserror, is_void_async, is_single_arg_async;
 		public MethodInfo MethodInfo;
+		public bool AllowNonVoidReturnType;
 		
 		public AsyncMethodInfo (IMemberGatherer gather, Type type, MethodInfo mi, Type category_extension_type, bool is_extension_method) : base (gather, mi, type, category_extension_type, false, is_extension_method)
 		{
@@ -4594,6 +4595,8 @@ public partial class Generator : IMemberGatherer {
 				is_void_async = true;
 			if (cbParams.Length == 1)
 				is_single_arg_async = true;
+
+			AllowNonVoidReturnType = AttributeManager.GetCustomAttribute<AsyncAttribute> (mi).AllowNonVoidReturnType;
 		}
 
 		public string GetUniqueParamName (string suggestion)
@@ -4707,6 +4710,8 @@ public partial class Generator : IMemberGatherer {
 		var mi = original_minfo.method;
 		var minfo = new AsyncMethodInfo (this, original_minfo.type, mi, original_minfo.category_extension_type, original_minfo.is_extension_method);
 		var is_void = mi.ReturnType == TypeManager.System_Void;
+		if (!is_void && !minfo.AllowNonVoidReturnType)
+			ErrorHelper.Show (new BindingException (1118, "[Async] is used in {0}.{1} where its return type isn't 'System.Void'. The return value will be ignored in the 'async' member.", mi.DeclaringType.FullName, mi.Name));
 		PrintMethodAttributes (minfo);
 
 		PrintAsyncHeader (minfo, asyncKind);

--- a/src/multipeerconnectivity.cs
+++ b/src/multipeerconnectivity.cs
@@ -59,7 +59,11 @@ namespace XamCore.MultipeerConnectivity {
 		[Export ("connectedPeers")]
 		MCPeerID [] ConnectedPeers { get; }
 
+#if XAMCORE_4_0
 		[Async]
+#else
+		[Async (allowNonVoidReturnType: true)]
+#endif
 		[Export ("sendResourceAtURL:withName:toPeer:withCompletionHandler:")]
 		NSProgress SendResource (NSUrl resourceUrl, string resourceName, MCPeerID peerID, [NullAllowed] Action<NSError> completionHandler);
 

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -3808,7 +3808,11 @@ namespace XamCore.UIKit {
 		//
 		[Since (7,0)]
 		[Export ("startInteractiveTransitionToCollectionViewLayout:completion:")]
-		[Async (ResultTypeName="UICollectionViewTransitionResult")]
+#if XAMCORE_4_0
+		[Async (ResultTypeName = "UICollectionViewTransitionResult")]
+#else
+		[Async (ResultTypeName = "UICollectionViewTransitionResult", AllowNonVoidReturnType = true)]
+#endif
 		UICollectionViewTransitionLayout StartInteractiveTransition (UICollectionViewLayout newCollectionViewLayout,
 									     UICollectionViewLayoutInteractiveTransitionCompletion completion);
 
@@ -14924,7 +14928,11 @@ namespace XamCore.UIKit {
 		void Dismiss (bool animated);
 
 		[Export ("presentAnimated:completionHandler:")]
+#if XAMCORE_4_0
 		[Async (ResultTypeName = "UIPrintInteractionResult")]
+#else
+		[Async (ResultTypeName = "UIPrintInteractionResult", AllowNonVoidReturnType = true)]
+#endif
 		// documentation (and header) mistake that Apple corrected (IIRC I filled that issue)
 #if XAMCORE_2_0
 		bool
@@ -14934,7 +14942,11 @@ namespace XamCore.UIKit {
 		Present (bool animated, UIPrintInteractionCompletionHandler completion);
 
 		[Export ("presentFromBarButtonItem:animated:completionHandler:")]
+#if XAMCORE_4_0
 		[Async (ResultTypeName = "UIPrintInteractionResult")]
+#else
+		[Async (ResultTypeName = "UIPrintInteractionResult", AllowNonVoidReturnType = true)]
+#endif
 		// documentation (and header) mistake that Apple corrected (IIRC I filled that issue)
 #if XAMCORE_2_0
 		bool
@@ -14944,7 +14956,11 @@ namespace XamCore.UIKit {
 		PresentFromBarButtonItem (UIBarButtonItem item, bool animated, UIPrintInteractionCompletionHandler completion);
 
 		[Export ("presentFromRect:inView:animated:completionHandler:")]
+#if XAMCORE_4_0
 		[Async (ResultTypeName = "UIPrintInteractionResult")]
+#else
+		[Async (ResultTypeName = "UIPrintInteractionResult", AllowNonVoidReturnType = true)]
+#endif
 		// documentation (and header) mistake that Apple corrected (IIRC I filled that issue)
 #if XAMCORE_2_0
 		bool

--- a/src/videosubscriberaccount.cs
+++ b/src/videosubscriberaccount.cs
@@ -107,7 +107,11 @@ namespace XamCore.VideoSubscriberAccount {
 		[Export ("checkAccessStatusWithOptions:completionHandler:")]
 		void CheckAccessStatus (NSDictionary options, Action<VSAccountAccessStatus, NSError> completionHandler);
 
+#if XAMCORE_4_0
 		[Async]
+#else
+		[Async (allowNonVoidReturnType: true)]
+#endif
 		[Export ("enqueueAccountMetadataRequest:completionHandler:")]
 		VSAccountManagerResult Enqueue (VSAccountMetadataRequest accountMetadataRequest, Action<VSAccountMetadata, NSError> completionHandler);
 	}

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -21,7 +21,7 @@ else
 IOS_GENERATOR = $(IOS_CURRENT_DIR)/bin/btouch-native /baselib:$(IOS_CURRENT_DIR)/lib/mono/Xamarin.iOS/Xamarin.iOS.dll /unsafe
 endif
 IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts bug43579 bindastests
-IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers bug42742 warnaserror nowarn
+IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers bug42742 warnaserror nowarn bug53103 bug53103allowNonVoidReturnType
 
 MAC_CURRENT_DIR=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
 ifdef IKVM
@@ -80,6 +80,7 @@ $(eval $(call iOSErrorCodeTestTemplate,bindas1050modelerror,1050))
 $(eval $(call iOSErrorCodeTestTemplate,bindas1050protocolerror,1050))
 $(eval $(call iOSErrorCodeTestTemplate,bug42855,1060))
 $(eval $(call iOSErrorCodeTestTemplate,bug52570,1117))
+$(eval $(call iOSErrorCodeTestTemplate,bug53103,1118))
 
 define iOSNoErrorCodesTestTemplate
 $(1):
@@ -89,6 +90,7 @@ endef
 $(eval $(call iOSNoErrorCodesTestTemplate,bug52570classinternal,1117))
 $(eval $(call iOSNoErrorCodesTestTemplate,bug52570methodinternal,1117))
 $(eval $(call iOSNoErrorCodesTestTemplate,bug52570allowstaticmembers,1117))
+$(eval $(call iOSNoErrorCodesTestTemplate,bug53103allowNonVoidReturnType,1118))
 
 classNameCollision:
 	@rm -Rf $@.tmpdir

--- a/tests/generator/bug53103.cs
+++ b/tests/generator/bug53103.cs
@@ -1,0 +1,13 @@
+using System;
+using Foundation;
+
+namespace Bug53103Tests {
+
+	[BaseType (typeof (NSObject))]
+	interface FooObject {
+
+		[Export ("fooMethodWithCompletion:")]
+		[Async]
+		NSObject FooMethod (Action<NSError, NSString> completion);
+	}
+}

--- a/tests/generator/bug53103allowNonVoidReturnType.cs
+++ b/tests/generator/bug53103allowNonVoidReturnType.cs
@@ -1,0 +1,17 @@
+using System;
+using Foundation;
+
+namespace Bug53103AllowNonVoidReturnTypeTests {
+
+	[BaseType (typeof (NSObject))]
+	interface FooObject {
+
+		[Export ("fooMethodWithCompletion:")]
+		[Async (allowNonVoidReturnType: true)]
+		NSObject FooMethod (Action<NSError, NSString> completion);
+
+		[Export ("fooMethodWithCompletion2:")]
+		[Async (AllowNonVoidReturnType = true)]
+		NSObject FooMethod2 (Action<NSError, NSString> completion);
+	}
+}


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=53103

We currently allow using [Async] on members whose return type is not
`System.Void`, this leads to silently ignoring the actual returned
result of the called member.

We have some cases on our own but fixing them is a breaking change
so if XAMCORE_4_0 ever happens we will have another look to them.

We now issue a warning (BI1118) whenever we find `[Async]` being used
on a member whose return type **is not** `System.Void` and if you
really want to have `[Async]` on members with different return type
to `System.Void` you can silence the warning by using
`[Async (allowNonVoidReturnType: true)]`, also using the provided
overloads or by setting the property `AllowNonVoidReturnType` to
`true` of the `[AsyncAttribute]`.

If you use `[Async]` on a member whose return type **is not** `System.Void`
the returned value of the member will be **ignored**.

Build diff: https://gist.github.com/dalexsoto/82261d5d7212fd770363dc968c436c98