### PR TITLE
[test][introspection] Remove check for void return type on Async Candidates test

### DIFF
--- a/docs/website/binding_types_reference_guide.md
+++ b/docs/website/binding_types_reference_guide.md
@@ -1215,8 +1215,8 @@ Only available on Xamarin.iOS 6.3 and newer.
 This attribute can be applied to methods that take a
 completion handler as their last argument.
 
-You can use the `[Async]` attribute on methods that return
-void and whose last argument is a callback.  When you apply
+You can use the `[Async]` attribute on methods whose
+last argument is a callback.  When you apply
 this to a method, the binding generator will generate a
 version of that method with the suffix `Async`.  If the callback
 takes no parameters, the return value will be a `Task`, if the

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -615,10 +615,12 @@ namespace XamCore.GameKit {
 #endif
 
 #if MONOMAC
+		[Async (ResultTypeName = "GKChallengeComposeResult")]
 		[Mac (10,10)]
 		[Export ("challengeComposeControllerWithMessage:players:completionHandler:")]
 		NSViewController ChallengeComposeController ([NullAllowed] string message, [NullAllowed] GKPlayer [] players, [NullAllowed] GKChallengeComposeHandler completionHandler);
 #else
+		[Async (ResultTypeName = "GKChallengeComposeResult")]
 		[NoWatch]
 		[iOS (8,0)]
 		[Export ("challengeComposeControllerWithMessage:players:completionHandler:")]
@@ -1404,9 +1406,11 @@ namespace XamCore.GameKit {
 
 #if MONOMAC
 		[Mac (10,10)]
+		[Async (ResultTypeName = "GKChallengeComposeResult")]
 		[Export ("challengeComposeControllerWithMessage:players:completionHandler:")]
 		NSViewController ChallengeComposeController ([NullAllowed] string message, GKPlayer [] players, [NullAllowed] GKChallengeComposeHandler completionHandler);
 #else
+		[Async (ResultTypeName = "GKChallengeComposeResult")]
 		[NoWatch]
 		[iOS (8,0)]
 		[Export ("challengeComposeControllerWithMessage:players:completionHandler:")]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -14725,12 +14725,15 @@ namespace XamCore.UIKit {
 		[Static, Export ("printerPickerControllerWithInitiallySelectedPrinter:")]
 		UIPrinterPickerController FromPrinter ([NullAllowed] UIPrinter printer);
 	
+		[Async (ResultTypeName = "UIPrinterPickerCompletionResult")]
 		[Export ("presentAnimated:completionHandler:")]
 		bool Present (bool animated, UIPrinterPickerCompletionHandler completion);
 	
+		[Async (ResultTypeName = "UIPrinterPickerCompletionResult")]
 		[Export ("presentFromRect:inView:animated:completionHandler:")]
 		bool PresentFromRect (CGRect rect, UIView view, bool animated, UIPrinterPickerCompletionHandler completion);
 	
+		[Async (ResultTypeName = "UIPrinterPickerCompletionResult")]
 		[Export ("presentFromBarButtonItem:animated:completionHandler:")]
 		bool PresentFromBarButtonItem (UIBarButtonItem item, bool animated, UIPrinterPickerCompletionHandler completion);
 	
@@ -14962,6 +14965,7 @@ namespace XamCore.UIKit {
 		bool ShowsPaperSelectionForLoadedPapers { get; set; }
 
 		[iOS (8,0)]
+		[Async (ResultTypeName = "UIPrintInteractionCompletionResult")]
 		[Export ("printToPrinter:completionHandler:")]
 		bool PrintToPrinter (UIPrinter printer, UIPrintInteractionCompletionHandler completion);
 	}

--- a/tests/introspection/ApiSignatureTest.cs
+++ b/tests/introspection/ApiSignatureTest.cs
@@ -921,9 +921,6 @@ namespace Introspection {
 					if (IgnoreAsync (m))
 						continue;
 
-					if (m.ReturnType.Name != "Void")
-						continue;
-
 					// some calls are "natively" async
 					if (m.Name.IndexOf ("Async", StringComparison.Ordinal) != -1)
 						continue;
@@ -972,6 +969,12 @@ namespace Introspection {
 			// it sets the callback, it will never call it
 			case "SetCompletionBlock":
 				return m.DeclaringType.Name == "SCNTransaction";
+			// It does not make sense for this API
+			case "CreateRunningPropertyAnimator":
+				return m.DeclaringType.Name == "UIViewPropertyAnimator";
+			// It does not make sense for this API
+			case "RequestData":
+				return m.DeclaringType.Name == "PHAssetResourceManager";
 			}
 			return false;
 		}


### PR DESCRIPTION
We do support the use of [Async] on methods that do not return void,
we generate an overload with an out parameter to retrieve the returned value

```csharp
[CompilerGenerated]
public unsafe virtual Task BarStringAsync (int arg1)
{
	var tcs = new TaskCompletionSource<bool> ();
	var result = BarString(arg1, (obj_) => {
		if (obj_ != null)
			tcs.SetException (new NSErrorException(obj_));
		else
			tcs.SetResult (true);
	});
	return tcs.Task;
}

[CompilerGenerated]
public unsafe virtual Task BarStringAsync (int arg1, out string result)
{
	var tcs = new TaskCompletionSource<bool> ();
	result = BarString(arg1, (obj_) => {
		if (obj_ != null)
			tcs.SetException (new NSErrorException(obj_));
		else
			tcs.SetResult (true);
	});
	return tcs.Task;
}
```

Modified the introspection test to report this, updated documentation
and update API definitions reported by introspection.