### PR TITLE
[generator] Fix and enhance [Async] attribute on [Protocol] definitions. Fixes bug 53076 

### DIFF
--- a/src/MediaPlayer/MPPlayableContentDelegate.cs
+++ b/src/MediaPlayer/MPPlayableContentDelegate.cs
@@ -1,7 +1,9 @@
 ﻿#if !XAMCORE_3_0 && !MONOMAC
-	
+
 using System;
+using System.Threading.Tasks;
 using XamCore.Foundation;
+using XamCore.ObjCRuntime;
 
 namespace XamCore.MediaPlayer {
 	public partial class MPPlayableContentDelegate {
@@ -21,6 +23,18 @@ namespace XamCore.MediaPlayer {
 		}
 
 	}
+
+#if !XAMCORE_4_0
+	public partial class MPPlayableContentDataSource : NSObject {
+		[Unavailable (PlatformName.MacOSX, PlatformArchitecture.All)]
+		[Introduced (PlatformName.iOS, 10, 0)]
+		[Obsolete ("Use 'MPPlayableContentDataSource_Extensions.GetContentItemAsync' instead")]
+		public unsafe virtual Task<MPContentItem> GetContentItemAsync (string identifier)
+		{
+			return MPPlayableContentDataSource_Extensions.GetContentItemAsync (this, identifier);
+		}
+	}
+#endif
 }
 
 #endif

--- a/src/NetworkExtension/NECompat.cs
+++ b/src/NetworkExtension/NECompat.cs
@@ -1,6 +1,7 @@
 #if XAMCORE_2_0 || !MONOMAC
 
 using System;
+using System.Threading.Tasks;
 using XamCore.Foundation;
 
 namespace XamCore.NetworkExtension {
@@ -20,6 +21,15 @@ namespace XamCore.NetworkExtension {
 		public virtual NWTcpConnection CreateTcpConnection (NWEndpoint remoteEndpoint, bool enableTls, NWTlsParameters tlsParameters, NWTcpConnectionAuthenticationDelegate @delegate)
 		{
 			return CreateTcpConnection (remoteEndpoint, enableTls, tlsParameters, (INWTcpConnectionAuthenticationDelegate) @delegate);
+		}
+	}
+
+	public partial class NWTcpConnectionAuthenticationDelegate : NSObject {
+
+		[Obsolete ("Use 'NWTcpConnectionAuthenticationDelegate_Extensions.EvaluateTrustAsync' instead")]
+		public unsafe virtual Task<global::XamCore.Security.SecTrust> EvaluateTrustAsync (NWTcpConnection connection, NSArray peerCertificateChain)
+		{
+			return NWTcpConnectionAuthenticationDelegate_Extensions.EvaluateTrustAsync (this, connection, peerCertificateChain);
 		}
 	}
 #endif

--- a/src/SceneKit/SCNCompat.cs
+++ b/src/SceneKit/SCNCompat.cs
@@ -1,6 +1,7 @@
 // Copyright 2016 Xamarin Inc. All rights reserved.
 
 using System;
+using System.Threading.Tasks;
 using XamCore.Foundation;
 using XamCore.ObjCRuntime;
 
@@ -49,5 +50,26 @@ namespace XamCore.SceneKit {
 			return WriteToUrl (url: url, options: options, aDelegate: handler, exportProgressHandler: exportProgressHandler);
 		}
 	}
+#endif
+
+#if !XAMCORE_4_0
+#if XAMCORE_2_0 || !MONOMAC
+	public abstract partial class SCNSceneRenderer : NSObject {
+		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[Obsolete ("Use 'SCNSceneRenderer_Extensions.PrepareAsync' instead")]
+		public unsafe virtual Task<bool> PrepareAsync (NSObject[] objects)
+		{
+			return SCNSceneRenderer_Extensions.PrepareAsync (this, objects);
+		}
+
+		[Introduced (PlatformName.iOS, 9, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 11, PlatformArchitecture.Arch64)]
+		[Obsolete ("Use 'SCNSceneRenderer_Extensions.PresentSceneAsync' instead")]
+		public unsafe virtual Task PresentSceneAsync (SCNScene scene, global::XamCore.SpriteKit.SKTransition transition, SCNNode pointOfView)
+		{
+			return SCNSceneRenderer_Extensions.PresentSceneAsync (this, scene, transition, pointOfView);
+		}
+	}
+#endif
 #endif
 }

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -4958,7 +4958,8 @@ public partial class Generator : IMemberGatherer {
 		if (AttributeManager.HasAttribute<AsyncAttribute> (mi)) {
 			// We do not want Async methods inside internal wrapper classes, they are useless
 			// internal sealed class FooWrapper : BaseWrapper, IMyFooDelegate
-			if (minfo.is_basewrapper_protocol_method)
+			// Also we do not want Async members inside [Model] classes
+			if (minfo.is_basewrapper_protocol_method || minfo.is_model)
 				return;
 
 			GenerateAsyncMethod (minfo, AsyncMethodKind.Plain);

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -4724,6 +4724,15 @@ public partial class Generator : IMemberGatherer {
 				ttype = "Tuple<bool,NSError>";
 		}
 		print ("var tcs = new TaskCompletionSource<{0}> ();", ttype);
+
+		// Intentionaly disable warning 0219 when method's return type is != void and AsyncMethodKind == Plain we ignore the returned value
+		bool shouldDisable219 = !is_void && asyncKind == AsyncMethodKind.Plain;
+		if (shouldDisable219) {
+			indent-=3;
+			print ("#pragma warning disable 0219 // Intentionaly ignoring result");
+			indent+=3;
+		}
+
 		print ("{6}{5}{4}{0}({1}{2}({3}) => {{",
 		       mi.Name,
 		       GetInvokeParamList (minfo.async_initial_params, false),
@@ -4733,6 +4742,14 @@ public partial class Generator : IMemberGatherer {
 			   is_void ? string.Empty : minfo.GetUniqueParamName ("result") + " = ",
 			   is_void ? string.Empty : (asyncKind == AsyncMethodKind.WithResultOutParameter ? string.Empty : "var ")
 		);
+
+		// Re-enable warning 0219 if needed
+		if (shouldDisable219) {
+			indent-=3;
+			print ("#pragma warning restore 0219");
+			indent+=3;
+		}
+
 		indent++;
 
 		int nesting_level = 1;

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -21,7 +21,7 @@ else
 IOS_GENERATOR = $(IOS_CURRENT_DIR)/bin/btouch-native /baselib:$(IOS_CURRENT_DIR)/lib/mono/Xamarin.iOS/Xamarin.iOS.dll /unsafe
 endif
 IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts bug43579 bindastests
-IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers bug42742 warnaserror nowarn noasyncinternalwrapper noasyncwarningcs0219 bug53076
+IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers bug42742 warnaserror nowarn noasyncinternalwrapper noasyncwarningcs0219 bug53076 bug53076withmodel
 
 MAC_CURRENT_DIR=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
 ifdef IKVM
@@ -249,6 +249,14 @@ bug53076:
 	@mkdir -p $@.tmpdir
 	$(if $(V),,@echo "$@";) $(IOS_GENERATOR) --sourceonly:$@.source -tmpdir=$@.tmpdir $@.cs
 	@if [ `grep -r "Async (this IMyFooProtocol" $@.tmpdir/Bug53076Test | wc -l` -ne 10 ]; then \
+		echo "Error: Expected 10 'Async (this IMyFooProtocol' matches in generated code. If you modified code that generates extension FooRequiredMethodAsync (AsyncAttribute) please update the 'Async (this IMyFooProtocol' count."; exit 1; \
+	fi
+
+bug53076withmodel:
+	@rm -Rf $@.tmpdir
+	@mkdir -p $@.tmpdir
+	$(if $(V),,@echo "$@";) $(IOS_GENERATOR) --sourceonly:$@.source -tmpdir=$@.tmpdir $@.cs
+	@if [ `grep -r "Async (this IMyFooProtocol" $@.tmpdir/Bug53076WithModelTest | wc -l` -ne 10 ]; then \
 		echo "Error: Expected 10 'Async (this IMyFooProtocol' matches in generated code. If you modified code that generates extension FooRequiredMethodAsync (AsyncAttribute) please update the 'Async (this IMyFooProtocol' count."; exit 1; \
 	fi
 

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -21,7 +21,7 @@ else
 IOS_GENERATOR = $(IOS_CURRENT_DIR)/bin/btouch-native /baselib:$(IOS_CURRENT_DIR)/lib/mono/Xamarin.iOS/Xamarin.iOS.dll /unsafe
 endif
 IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts bug43579 bindastests
-IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers bug42742 warnaserror nowarn
+IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers bug42742 warnaserror nowarn noasyncinternalwrapper
 
 MAC_CURRENT_DIR=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
 ifdef IKVM
@@ -232,6 +232,14 @@ nowarn:
 	$(if $(V),,@echo "macOS $@ Disabled Warning Found";) $(MAC_CLASSIC_GENERATOR) $@.cs | grep "warning BI1117" > /dev/null 2>&1
 	$(if $(V),,@echo "macOS $@ Only 1116";) $(MAC_CLASSIC_GENERATOR) -nowarn:1116 $@.cs | grep "warning BI1117" > /dev/null 2>&1
 	$(if $(V),,@echo "macOS $@ Only 1117";) !($(MAC_CLASSIC_GENERATOR) -nowarn:1117 $@.cs | grep "warning BI1117" > /dev/null 2>&1)
+
+noasyncinternalwrapper:
+	@rm -Rf $@.tmpdir
+	@mkdir -p $@.tmpdir
+	$(if $(V),,@echo "$@";) $(IOS_GENERATOR) --sourceonly:$@.source -tmpdir=$@.tmpdir $@.cs
+	@if [ `grep -r RequiredMethodAsync $@.tmpdir/NoAsyncInternalWrapperTests | wc -l` -ne 0 ]; then \
+		echo "Error: Expected 0 RequiredMethodAsync members in generated code. If you modified code that generates RequiredMethodAsync (AsyncAttribute) please update the RequiredMethodAsync count."; exit 1; \
+	fi
 
 clean-local::
 	rm -f *.dll *.source

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -21,7 +21,7 @@ else
 IOS_GENERATOR = $(IOS_CURRENT_DIR)/bin/btouch-native /baselib:$(IOS_CURRENT_DIR)/lib/mono/Xamarin.iOS/Xamarin.iOS.dll /unsafe
 endif
 IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts bug43579 bindastests
-IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers bug42742 warnaserror nowarn noasyncinternalwrapper noasyncwarningcs0219
+IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers bug42742 warnaserror nowarn noasyncinternalwrapper noasyncwarningcs0219 bug53076
 
 MAC_CURRENT_DIR=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
 ifdef IKVM
@@ -243,6 +243,14 @@ noasyncinternalwrapper:
 
 noasyncwarningcs0219:
 	$(if $(V),,@echo "$@";) !($(IOS_GENERATOR) $@.cs 2>&1 | grep "warning CS0219" > /dev/null 2>&1)
+
+bug53076:
+	@rm -Rf $@.tmpdir
+	@mkdir -p $@.tmpdir
+	$(if $(V),,@echo "$@";) $(IOS_GENERATOR) --sourceonly:$@.source -tmpdir=$@.tmpdir $@.cs
+	@if [ `grep -r "Async (this IMyFooProtocol" $@.tmpdir/Bug53076Test | wc -l` -ne 10 ]; then \
+		echo "Error: Expected 10 'Async (this IMyFooProtocol' matches in generated code. If you modified code that generates extension FooRequiredMethodAsync (AsyncAttribute) please update the 'Async (this IMyFooProtocol' count."; exit 1; \
+	fi
 
 clean-local::
 	rm -f *.dll *.source

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -21,7 +21,7 @@ else
 IOS_GENERATOR = $(IOS_CURRENT_DIR)/bin/btouch-native /baselib:$(IOS_CURRENT_DIR)/lib/mono/Xamarin.iOS/Xamarin.iOS.dll /unsafe
 endif
 IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts bug43579 bindastests
-IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers bug42742 warnaserror nowarn noasyncinternalwrapper
+IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers bug42742 warnaserror nowarn noasyncinternalwrapper noasyncwarningcs0219
 
 MAC_CURRENT_DIR=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
 ifdef IKVM
@@ -240,6 +240,9 @@ noasyncinternalwrapper:
 	@if [ `grep -r RequiredMethodAsync $@.tmpdir/NoAsyncInternalWrapperTests | wc -l` -ne 0 ]; then \
 		echo "Error: Expected 0 RequiredMethodAsync members in generated code. If you modified code that generates RequiredMethodAsync (AsyncAttribute) please update the RequiredMethodAsync count."; exit 1; \
 	fi
+
+noasyncwarningcs0219:
+	$(if $(V),,@echo "$@";) !($(IOS_GENERATOR) $@.cs 2>&1 | grep "warning CS0219" > /dev/null 2>&1)
 
 clean-local::
 	rm -f *.dll *.source

--- a/tests/generator/bug53076.cs
+++ b/tests/generator/bug53076.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+using Foundation;
+using ObjCRuntime;
+
+namespace Bug53076Test {
+	[Protocol]
+	interface MyFooProtocol {
+
+		[Abstract]
+		[Async]
+		[Export ("requiredMethod:completion:")]
+		void RequiredMethod (int arg1, Action<NSError> err);
+
+		[Async]
+		[Export ("optional:completion:")]
+		void OptionalMethod (int arg1, Action<NSError> err);
+
+		[Abstract]
+		[Async]
+		[Export ("requiredReturnMethod:completion:")]
+		bool RequiredReturnMethod (int arg1, Action<NSError> err);
+
+		[Async]
+		[Export ("optionalReturn:completion:")]
+		bool OptionalReturnMethod (int arg1, Action<NSError> err);
+
+		[Abstract]
+		[Async (ResultTypeName = "RequiredReturnMethodObjResult")]
+		[Export ("requiredReturnMethodObj:completion:")]
+		bool RequiredReturnMethodObj (int arg1, Action<NSError,NSObject> err);
+
+		[Async (ResultTypeName = "RequiredReturnMethodObjResult")]
+		[Export ("optionalReturnObj:completion:")]
+		bool OptionalReturnMethodObj (int arg1, Action<NSError,NSObject> err);
+	}
+}
+

--- a/tests/generator/bug53076withmodel.cs
+++ b/tests/generator/bug53076withmodel.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+using Foundation;
+using ObjCRuntime;
+
+namespace Bug53076WithModelTest {
+	[Protocol][Model]
+	[BaseType (typeof (NSObject))]
+	interface MyFooProtocol {
+
+		[Abstract]
+		[Async]
+		[Export ("requiredMethod:completion:")]
+		void RequiredMethod (int arg1, Action<NSError> err);
+
+		[Async]
+		[Export ("optional:completion:")]
+		void OptionalMethod (int arg1, Action<NSError> err);
+
+		[Abstract]
+		[Async]
+		[Export ("requiredReturnMethod:completion:")]
+		bool RequiredReturnMethod (int arg1, Action<NSError> err);
+
+		[Async]
+		[Export ("optionalReturn:completion:")]
+		bool OptionalReturnMethod (int arg1, Action<NSError> err);
+
+		[Abstract]
+		[Async (ResultTypeName = "RequiredReturnMethodObjResult")]
+		[Export ("requiredReturnMethodObj:completion:")]
+		bool RequiredReturnMethodObj (int arg1, Action<NSError,NSObject> err);
+
+		[Async (ResultTypeName = "RequiredReturnMethodObjResult")]
+		[Export ("optionalReturnObj:completion:")]
+		bool OptionalReturnMethodObj (int arg1, Action<NSError,NSObject> err);
+	}
+}
+

--- a/tests/generator/noasyncinternalwrapper.cs
+++ b/tests/generator/noasyncinternalwrapper.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+using Foundation;
+using ObjCRuntime;
+
+namespace NoAsyncInternalWrapperTests {
+	[Protocol]
+	interface MyFooDelegate {
+
+		[Abstract]
+		[Async]
+		[Export ("requiredMethod:completion:")]
+		void RequiredMethod (int arg1, Action<NSError> err);
+
+		[Async]
+		[Export ("optional:completion:")]
+		void OptionalMethod (int arg1, Action<NSError> err);	
+	}
+}
+

--- a/tests/generator/noasyncwarningcs0219.cs
+++ b/tests/generator/noasyncwarningcs0219.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+using Foundation;
+using ObjCRuntime;
+
+namespace NoAsyncWarningCS0219Test {
+	[BaseType (typeof (NSObject))]
+	interface MyBarClass {
+
+		[Async]
+		[Export ("barString:completion:")]
+		void Bar (int arg1, Action<NSError> err);
+
+		[Async]
+		[Export ("barString:completion:")]
+		string BarString (int arg1, Action<NSError> err);
+
+		[Async (ResultTypeName = "BarString2Result")]
+		[Export ("barString2:completion:")]
+		string BarString2 (int arg1, Action<NSError, NSObject> err);
+	}
+}
+


### PR DESCRIPTION
The fix for [bug 53076](https://bugzilla.xamarin.com/show_bug.cgi?id=53076) is made of the following 4 commits, each commit has a build diff that represents the difference from the current commit vs the one before. 

Here is a global build diff: https://gist.github.com/dalexsoto/4dac3e1e58d89c14c564fcea04531558

## [generator] Remove Async members from internal BaseWrapper derived types

Currently we generate FooAsync members inside internal BaseWrapper
derived types used by protocol support. This generated Async members
are useles so we remove them to avoid extra metadata.

Old generated code

```csharp
internal sealed class MyFooDelegateWrapper : BaseWrapper, IMyFooDelegate {
	[Preserve (Conditional = true)]
	public MyFooDelegateWrapper (IntPtr handle, bool owns)
		: base (handle, owns)
	{
	}

	[Export ("stringMethod:completion:")]
	[CompilerGenerated]
	public unsafe void StringMethod (int arg1, [BlockProxy (typeof (ObjCRuntime.Trampolines.NIDActionArity1V0))]global::System.Action<NSError> err)
	{
		if (err == null)
			throw new ArgumentNullException ("err");
		BlockLiteral *block_ptr_err;
		BlockLiteral block_err;
		block_err = new BlockLiteral ();
		block_ptr_err = &block_err;
		block_err.SetupBlock (Trampolines.SDActionArity1V0.Handler, err);

		global::ApiDefinition.Messaging.void_objc_msgSend_int_IntPtr (this.Handle, Selector.GetHandle ("stringMethod:completion:"), arg1, (IntPtr) block_ptr_err);
		block_ptr_err->CleanupBlock ();

	}

	[CompilerGenerated]
	public unsafe Task StringMethodAsync (int arg1)
	{
		var tcs = new TaskCompletionSource<bool> ();
		StringMethod(arg1, (obj_) => {
			if (obj_ != null)
				tcs.SetException (new NSErrorException(obj_));
			else
				tcs.SetResult (true);
		});
		return tcs.Task;
	}

}
```

new generated code:

```csharp
internal sealed class MyFooDelegateWrapper : BaseWrapper, IMyFooDelegate {
	[Preserve (Conditional = true)]
	public MyFooDelegateWrapper (IntPtr handle, bool owns)
		: base (handle, owns)
	{
	}

	[Export ("stringMethod:completion:")]
	[CompilerGenerated]
	public unsafe void StringMethod (int arg1, [BlockProxy (typeof (ObjCRuntime.Trampolines.NIDActionArity1V0))]global::System.Action<NSError> err)
	{
		if (err == null)
			throw new ArgumentNullException ("err");
		BlockLiteral *block_ptr_err;
		BlockLiteral block_err;
		block_err = new BlockLiteral ();
		block_ptr_err = &block_err;
		block_err.SetupBlock (Trampolines.SDActionArity1V0.Handler, err);

		global::ApiDefinition.Messaging.void_objc_msgSend_int_IntPtr (this.Handle, Selector.GetHandle ("stringMethod:completion:"), arg1, (IntPtr) block_ptr_err);
		block_ptr_err->CleanupBlock ();

	}
}
```

Added unit test.

build diff for this change:

https://gist.github.com/dalexsoto/eeaefc9d86e37b0c5ce5fe6d5d091383

## [generator] Disable CS0219 when using AsyncAttribute to avoid warning 
Currently we get a CS2019 warning whenever we use AsyncAttribute
because we ignore the `result` variable on methods whose return
type is != `void` which is the expected behaviour.

This is specially more annoying on third party bindings,
the generated code did not disable this warning so you get
an "unfixable" warning on the generated code and the user
has no way to fix this on their own.

We now disable and restore CS2019 in the generated code as needed.
Nobody likes warnings that are not their fault.

Added unit test.

Build diff:

https://gist.github.com/dalexsoto/6f57d3f84b039b9fda863e2f8cfcf365

## [generator] Turn [Async] methods inside [Protocol] into extension methods

Partial fix for:
https://bugzilla.xamarin.com/show_bug.cgi?id=53076

We currently generate extension methods for optional members decorated
with [Async] inside a [Protocol] but we ignore the required methods
decorated with [Async]. This commit fixes this issue and we now
generate extension methods for required members.

Lets take the following API definition

```csharp
[Protocol]
interface MyFooProtocol {

	[Abstract]
	[Async]
	[Export ("requiredMethod:completion:")]
	void RequiredMethod (int arg1, Action<NSError> err);

	[Async]
	[Export ("optional:completion:")]
	void OptionalMethod (int arg1, Action<NSError> err);
}
```

This generates:

```csharp
public static partial class MyFooProtocol_Extensions {
	[CompilerGenerated]
	public unsafe static void OptionalMethod (this IMyFooProtocol This, int arg1, [BlockProxy (typeof (ObjCRuntime.Trampolines.NIDActionArity1V0))]global::System.Action<NSError> err)
	{
		if (err == null)
			throw new ArgumentNullException ("err");
		BlockLiteral *block_ptr_err;
		BlockLiteral block_err;
		block_err = new BlockLiteral ();
		block_ptr_err = &block_err;
		block_err.SetupBlock (Trampolines.SDActionArity1V0.Handler, err);

		global::ApiDefinition.Messaging.void_objc_msgSend_int_IntPtr (This.Handle, Selector.GetHandle ("optional:completion:"), arg1, (IntPtr) block_ptr_err);
		block_ptr_err->CleanupBlock ();

	}

	[CompilerGenerated]
	public unsafe static Task OptionalMethodAsync (this IMyFooProtocol This, int arg1)
	{
		var tcs = new TaskCompletionSource<bool> ();
		This.OptionalMethod(arg1, (obj_) => {
			if (obj_ != null)
				tcs.SetException (new NSErrorException(obj_));
			else
				tcs.SetResult (true);
		});
		return tcs.Task;
	}

	[CompilerGenerated]
	public unsafe static Task RequiredMethodAsync (this IMyFooProtocol This, int arg1)
	{
		var tcs = new TaskCompletionSource<bool> ();
		This.RequiredMethod(arg1, (obj_) => {
			if (obj_ != null)
				tcs.SetException (new NSErrorException(obj_));
			else
				tcs.SetResult (true);
		});
		return tcs.Task;
	}

}
```

Adds unit test

Build diff:
https://gist.github.com/dalexsoto/75290d1ffa1fdfb529cc30b9e66de5f2

## [generator] Remove [Async] members from [Model] classes, fixes bug 53076.

https://bugzilla.xamarin.com/show_bug.cgi?id=53076

When [Async] was used on a member of a [Model][Protocol][Basetype]
interface the ModelClass ended up with additional FooAsync methods that
are not really part of the Model.

This commit removed any instances of FooAsync members from model classes
and also fixes any breaking changes in the currently bound classes.

Added test case using Model.

build diff:
https://gist.github.com/dalexsoto/75cb8424f2462bd6b513049f00bba6a8