### PR TITLE
[tests] Use the iPhone 6 simulator instead of the iPhone 5s simulator for 64-bit testing.

### DIFF
--- a/tests/xharness/Simulators.cs
+++ b/tests/xharness/Simulators.cs
@@ -117,7 +117,7 @@ namespace xharness
 				simulator_runtime = "com.apple.CoreSimulator.SimRuntime.iOS-" + Xamarin.SdkVersions.iOS.Replace ('.', '-');
 				break;
 			case AppRunnerTarget.Simulator_iOS64:
-				simulator_devicetypes = new string [] { "com.apple.CoreSimulator.SimDeviceType.iPhone-5s" };
+				simulator_devicetypes = new string [] { "com.apple.CoreSimulator.SimDeviceType.iPhone-6" };
 				simulator_runtime = "com.apple.CoreSimulator.SimRuntime.iOS-" + Xamarin.SdkVersions.iOS.Replace ('.', '-');
 				break;
 			case AppRunnerTarget.Simulator_iOS:


### PR DESCRIPTION
Apparently Xcode 8.3 does not like the iPhone 5s simulator, and deletes it.

Every time Xcode is updated.

Which is slightly annoying when it affects the bots, since then iPhone 5s have
to be re-created on every bot.

So succumb to the pressure, and switch to using the iPhone 6 simulator instead.