### PR TITLE
[mmp] Remove check for null tls_provider since only appleTLS is supported

### DIFF
--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -478,10 +478,6 @@ namespace Xamarin.Bundler {
 				ErrorHelper.Warning (2014, "Xamarin.Mac Extensions do not support linking. Request for linking will be ignored.");
 			}
 
-			if (!IsUnifiedMobile && tls_provider != null)
-				throw new MonoMacException (2011, true, "Selecting a TLS Provider is only supported in the Unified Mobile profile");
-
-
 			ValidateXcode ();
 
 			App.InitializeCommon ();


### PR DESCRIPTION
Per @spouliot comment on [PR1925](https://github.com/xamarin/xamarin-macios/pull/1925#discussion_r108472518) 