### PR TITLE
[ObjCRuntime] Add assembly registration event.

### DIFF
--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -67,6 +67,19 @@ using ProductException=MonoMac.RuntimeException;
 // This file cannot use any cecil code, since it's also compiled into monotouch.dll
 //
 
+#if MONOMAC
+namespace XamCore.ObjCRuntime
+{
+	public delegate void AssemblyRegistrationHandler (object sender, AssemblyRegistrationEventArgs args);
+
+	public class AssemblyRegistrationEventArgs : EventArgs
+	{
+		public bool Register { get; set; }
+		public System.Reflection.AssemblyName AssemblyName { get; internal set; }
+	}
+}
+#endif
+
 namespace XamCore.Registrar {
 	static class Shared {
 		

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -236,6 +236,23 @@ namespace XamCore.ObjCRuntime {
 		}
 #endif
 
+#if MONOMAC
+		public static event AssemblyRegistrationHandler AssemblyRegistration;
+
+		static bool OnAssemblyRegistration (AssemblyName assembly_name)
+		{
+			if (AssemblyRegistration != null) {
+				var args = new AssemblyRegistrationEventArgs
+				{
+					Register = true,
+					AssemblyName = assembly_name
+				};
+				AssemblyRegistration (null, args);
+				return args.Register;
+			}
+			return true;
+		}
+#endif
 		static MarshalObjectiveCExceptionMode objc_exception_mode;
 		static MarshalManagedExceptionMode managed_exception_mode;
 
@@ -388,7 +405,12 @@ namespace XamCore.ObjCRuntime {
 			assemblies.Add (NSObject.PlatformAssembly); // make sure our platform assembly comes first
 			// Recursively get all assemblies referenced by the entry assembly.
 			if (entry_assembly != null) {
-				CollectReferencedAssemblies (assemblies, entry_assembly);
+				var register_entry_assembly = true;
+#if MONOMAC
+				register_entry_assembly = OnAssemblyRegistration (entry_assembly.GetName ());
+#endif
+				if (register_entry_assembly)
+					CollectReferencedAssemblies (assemblies, entry_assembly);
 			} else {
 				Console.WriteLine ("Could not find the entry assembly.");
 			}
@@ -396,6 +418,9 @@ namespace XamCore.ObjCRuntime {
 #if MONOMAC
 			// Add all assemblies already loaded
 			foreach (var a in AppDomain.CurrentDomain.GetAssemblies ()) {
+				if (!OnAssemblyRegistration (a.GetName ()))
+					continue;
+
 				if (!assemblies.Contains (a))
 					assemblies.Add (a);
 			}
@@ -409,6 +434,10 @@ namespace XamCore.ObjCRuntime {
 		{
 			assemblies.Add (assembly);
 			foreach (var rf in assembly.GetReferencedAssemblies ()) {
+#if MONOMAc
+				if (!OnAssemblyRegistration (rf))
+					continue;
+#endif
 				try {
 					var a = Assembly.Load (rf);
 					if (!assemblies.Contains (a))

--- a/tests/common/mac/TestProjects/AssemblyRegistration/AssemblyRegistration.csproj
+++ b/tests/common/mac/TestProjects/AssemblyRegistration/AssemblyRegistration.csproj
@@ -3,24 +3,23 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProjectGuid>{F8500DCE-2119-4DF9-8360-0F46DDB6930C}</ProjectGuid>
+    <ProjectGuid>{DA730957-774A-41A0-93A6-B4F0B91A035F}</ProjectGuid>
     <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
-    <RootNamespace>msbuildMac</RootNamespace>
-    <AssemblyName>msbuild-mac</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
-    <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
+    <RootNamespace>AssemblyRegistration</RootNamespace>
+    <AssemblyName>AssemblyRegistration</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
+    <UseXamMacFullFramework>true</UseXamMacFullFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\x86\Debug</OutputPath>
-    <DefineConstants>__UNIFIED__;DEBUG;XAMCORE_2_0;MONOMAC</DefineConstants>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
     <EnableCodeSigning>false</EnableCodeSigning>
     <CodeSigningKey>Mac Developer</CodeSigningKey>
     <CreatePackage>false</CreatePackage>
@@ -32,57 +31,29 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\x86\Release</OutputPath>
-    <DefineConstants>__UNIFIED__;XAMCORE_2_0;MONOMAC;MMP_TEST</DefineConstants>
+    <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <EnableCodeSigning>true</EnableCodeSigning>
-    <CodeSigningKey>Developer ID Application</CodeSigningKey>
+    <EnableCodeSigning>false</EnableCodeSigning>
     <CreatePackage>true</CreatePackage>
     <EnablePackageSigning>false</EnablePackageSigning>
     <IncludeMonoRuntime>true</IncludeMonoRuntime>
     <UseSGen>true</UseSGen>
     <UseRefCounting>true</UseRefCounting>
-    <LinkMode>SdkOnly</LinkMode>
+    <LinkMode>None</LinkMode>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="Xamarin.Mac" />
-    <Reference Include="System.Xml" />
-    <Reference Include="GuiUnit">
-      <HintPath>..\..\external\guiunit\bin\net_4_5\GuiUnit.exe</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="src\MSBuild-Smoke.cs" />
-    <Compile Include="..\common\mac\MacTestMain.cs">
-      <Link>MacTestMain.cs</Link>
-    </Compile>
-    <Compile Include="..\common\mac\ProjectTestHelpers.cs">
-      <Link>ProjectTestHelpers.cs</Link>
-    </Compile>
-    <Compile Include="..\..\tests\common\Configuration.cs">
-      <Link>Configuration.cs</Link>
-    </Compile>
-    <Compile Include="..\..\src\ObjCRuntime\ErrorHelper.cs">
-      <Link>ErrorHelper.cs</Link>
-    </Compile>
-    <Compile Include="..\..\src\ObjCRuntime\RuntimeException.cs">
-      <Link>RuntimeException.cs</Link>
-    </Compile>
-    <Compile Include="src\RoslynSmokeTests.cs" />
-    <Compile Include="src\RuntimeTests.cs" />
+    <Compile Include="Main.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
-  <Import Project="CustomBuildActions.targets" />
 </Project>

--- a/tests/common/mac/TestProjects/AssemblyRegistration/Info.plist
+++ b/tests/common/mac/TestProjects/AssemblyRegistration/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>AssemblyRegistration</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.xamarin.assemblyregistration</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.12</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/tests/common/mac/TestProjects/AssemblyRegistration/Main.cs
+++ b/tests/common/mac/TestProjects/AssemblyRegistration/Main.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+using AppKit;
+using Foundation;
+using ObjCRuntime;
+
+static class MainClass {
+	static int Main (string [] args)
+	{
+		Runtime.AssemblyRegistration += (object sender, AssemblyRegistrationEventArgs ea) =>
+		{
+			Console.WriteLine (ea.AssemblyName);
+			switch (ea.AssemblyName.Name) {
+			case "AssemblyRegistration":
+				ea.Register = false;
+				break;
+			default:
+				break;
+			}
+		};
+		NSApplication.Init ();
+		return 0;
+	}
+}
+
+// We deliberately declare two functions with the same selector
+// Then we skip registration for this assembly, so that no exception is thrown.
+[Register ("TestClass")]
+public class TestClass : NSObject {
+	[Export ("xap")]
+	public void Foo ()
+	{
+	}
+
+	[Export ("xap")]
+	public void Bar ()
+	{
+	}
+}

--- a/tests/msbuild-mac/src/RuntimeTests.cs
+++ b/tests/msbuild-mac/src/RuntimeTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+using NUnit.Framework;
+
+namespace Xamarin.MMP.Tests
+{
+	[TestFixture]
+	public class RuntimeTests
+	{
+		public string TestProjectRoot => Path.Combine (TI.FindSourceDirectory (), "TestProjects");
+
+		[Test]
+		public void AssemblyRegistration ()
+		{
+			var projectName = "AssemblyRegistration";
+			var projectPath = Path.Combine (TestProjectRoot, projectName, $"{projectName}.csproj");
+
+			TI.CleanUnifiedProject (projectPath);
+			TI.BuildProject (projectPath, true, useMSBuild: false);
+			TI.RunAndAssert (Path.Combine (Path.GetDirectoryName (projectPath), $"bin/Debug/{projectName}.app/Contents/MacOS/{projectName}"), new StringBuilder (), "Run");
+		}
+	}
+}


### PR DESCRIPTION
Add an assembly registration event, that allows apps to opt out of
Xamarin.Mac's default behavior to recursively load every assembly referenced
by the entry assembly.

This is only for Xamarin.Mac, since it does not make sense to have this API in
Xamarin.iOS because assemblies are statically registered at build time.