### PR TITLE
Enforce mono 4.8 until we've merged support for the newer mono.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -54,7 +54,7 @@ XCODE_DEVELOPER_ROOT=/Applications/Xcode82.app/Contents/Developer
 
 # Minimum Mono version
 MIN_MONO_VERSION=4.8.0.269
-MAX_MONO_VERSION=5.0.99
+MAX_MONO_VERSION=4.8.99
 MIN_MONO_URL=http://bosstoragemirror.blob.core.windows.net/wrench/mono-4.8.0/e5/e51aa0a7043a8185e264d6332ac7bc1f8f87cd39/MonoFramework-MDK-4.8.0.269.macos10.xamarin.universal.pkg
 
 # Minimum Xamarin Studio version


### PR DESCRIPTION
Otherwise things break left and right.