### PR TITLE
[modelio] Re-add original MDLMesh.CreateBox signature

### DIFF
--- a/src/ModelIO/MDLMesh.cs
+++ b/src/ModelIO/MDLMesh.cs
@@ -79,7 +79,13 @@ namespace XamCore.ModelIO {
 		// Note: we turn these constructors into static constructors because we don't want to lose the shape name. Also, the signatures of these constructors differ so it would not be possible to use an enum to differentiate the shapes.
 
 		[iOS (10,0)][TV (10,0)][Mac (10,12)]
-		public static MDLMesh CreateBox (Vector3 vector, Vector3i segments, MDLGeometryType geometryType, bool inwardNormals, IMDLMeshBufferAllocator allocator, MDLMeshVectorType type = MDLMeshVectorType.Dimensions)
+		public static MDLMesh CreateBox (Vector3 dimensions, Vector3i segments, MDLGeometryType geometryType, bool inwardNormals, IMDLMeshBufferAllocator allocator)
+		{
+			return CreateBox (dimensions, segments, geometryType, inwardNormals, allocator, MDLMeshVectorType.Dimensions);
+		}
+
+		[iOS (10,0)][TV (10,0)][Mac (10,12)]
+		public static MDLMesh CreateBox (Vector3 vector, Vector3i segments, MDLGeometryType geometryType, bool inwardNormals, IMDLMeshBufferAllocator allocator, MDLMeshVectorType type)
 		{
 			switch (type) {
 			case MDLMeshVectorType.Dimensions:

--- a/src/ModelIO/MDLMesh.cs
+++ b/src/ModelIO/MDLMesh.cs
@@ -85,7 +85,7 @@ namespace XamCore.ModelIO {
 		}
 
 		[iOS (10,0)][TV (10,0)][Mac (10,12)]
-		public static MDLMesh CreateBox (Vector3 vector, Vector3i segments, MDLGeometryType geometryType, bool inwardNormals, IMDLMeshBufferAllocator allocator, MDLMeshVectorType type)
+		public static MDLMesh CreateBox (Vector3 vector, Vector3i segments, MDLGeometryType geometryType, bool inwardNormals, IMDLMeshBufferAllocator allocator, MDLMeshVectorType type = MDLMeshVectorType.Dimensions)
 		{
 			switch (type) {
 			case MDLMeshVectorType.Dimensions:


### PR DESCRIPTION
Type Changed: ModelIO.MDLMesh

Removed method:

    public static MDLMesh CreateBox (OpenTK.Vector3 dimensions, OpenTK.Vector3i segments, MDLGeometryType geometryType, bool inwardNormals, IMDLMeshBufferAllocator allocator);

---

Adding an optional argument (so not having the original signature anymore) would break binary compatibility.