### PR TITLE
[macos] Fix msbuild issues with shprojj/projitem library

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
@@ -16,12 +16,12 @@ Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<!-- MSBuild specific hacks - Teach msbuild where to find our BCL and facades -->
-	<PropertyGroup Condition="'$(OS)' != 'Win_NT'">
+	<PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
 		<MacBclPath Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.Mac'">$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
 		<MacBclPath Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">$(XamarinMacFrameworkRoot)/lib/mono/Xamarin.Mac</MacBclPath>
 		<FrameworkPathOverride>$(MacBclPath)</FrameworkPathOverride>
 	</PropertyGroup>
-	<Target Name="FixTargetFrameworkDirectory" AfterTargets="GetReferenceAssemblyPaths" Condition="'$(OS)' != 'Win_NT'">
+	<Target Name="FixTargetFrameworkDirectory" AfterTargets="GetReferenceAssemblyPaths" Condition="'$(OS)' != 'Windows_NT'">
     		<ItemGroup>
 			<DesignTimeFacadeDirectories Remove="@(DesignTimeFacadeDirectories)" />
 			<DesignTimeFacadeDirectories Include="$(MacBclPath)/Facades/" />

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
@@ -16,12 +16,12 @@ Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<!-- MSBuild specific hacks - Teach msbuild where to find our BCL and facades -->
-	<PropertyGroup>
+	<PropertyGroup Condition="'$(OS)' != 'Win_NT'">
 		<MacBclPath Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.Mac'">$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
 		<MacBclPath Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">$(XamarinMacFrameworkRoot)/lib/mono/Xamarin.Mac</MacBclPath>
 		<FrameworkPathOverride>$(MacBclPath)</FrameworkPathOverride>
 	</PropertyGroup>
-	<Target Name="FixTargetFrameworkDirectory" AfterTargets="GetReferenceAssemblyPaths">
+	<Target Name="FixTargetFrameworkDirectory" AfterTargets="GetReferenceAssemblyPaths" Condition="'$(OS)' != 'Win_NT'">
     		<ItemGroup>
 			<DesignTimeFacadeDirectories Remove="@(DesignTimeFacadeDirectories)" />
 			<DesignTimeFacadeDirectories Include="$(MacBclPath)/Facades/" />

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
@@ -16,11 +16,12 @@ Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<!-- MSBuild specific hacks - Teach msbuild where to find our BCL and facades -->
+	<PropertyGroup>
+		<MacBclPath Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.Mac'">$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
+		<MacBclPath Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">$(XamarinMacFrameworkRoot)/lib/mono/Xamarin.Mac</MacBclPath>
+		<FrameworkPathOverride>$(MacBclPath)</FrameworkPathOverride>
+	</PropertyGroup>
 	<Target Name="FixTargetFrameworkDirectory" AfterTargets="GetReferenceAssemblyPaths">
-		<PropertyGroup>
-			<MacBclPath Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.Mac'">$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
-			<MacBclPath Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">$(XamarinMacFrameworkRoot)/lib/mono/Xamarin.Mac</MacBclPath>
-		</PropertyGroup>	
     		<ItemGroup>
 			<DesignTimeFacadeDirectories Remove="@(DesignTimeFacadeDirectories)" />
 			<DesignTimeFacadeDirectories Include="$(MacBclPath)/Facades/" />

--- a/tests/common/mac/TestProjects/RoslynTestApp/Full/RoslynTestApp.csproj
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Full/RoslynTestApp.csproj
@@ -127,5 +127,11 @@
   <ItemGroup>
     <Compile Include="Main.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Lib\ReadOnlyTestMacLib\ReadOnlyTestMacLib.csproj">
+      <Project>{3A745526-7709-46D2-8978-C882D9F08656}</Project>
+      <Name>ReadOnlyTestMacLib</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/tests/common/mac/TestProjects/RoslynTestApp/Full/RoslynTestApp.sln
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Full/RoslynTestApp.sln
@@ -1,0 +1,25 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoslynTestApp", "RoslynTestApp.csproj", "{FCA4311B-96A6-4AAC-8235-3E7F75111E73}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ReadOnlyTestLib", "..\Lib\ReadOnlyTestLib\ReadOnlyTestLib.shproj", "{0F90A525-90FF-4351-B5AE-F5B3AF320360}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReadOnlyTestMacLib", "..\Lib\Full\ReadOnlyTestMacLib\ReadOnlyTestMacLib.csproj", "{3A745526-7709-46D2-8978-C882D9F08656}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FCA4311B-96A6-4AAC-8235-3E7F75111E73}.Debug|x86.ActiveCfg = Debug|x86
+		{FCA4311B-96A6-4AAC-8235-3E7F75111E73}.Debug|x86.Build.0 = Debug|x86
+		{FCA4311B-96A6-4AAC-8235-3E7F75111E73}.Release|x86.ActiveCfg = Release|x86
+		{FCA4311B-96A6-4AAC-8235-3E7F75111E73}.Release|x86.Build.0 = Release|x86
+		{3A745526-7709-46D2-8978-C882D9F08656}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3A745526-7709-46D2-8978-C882D9F08656}.Debug|x86.Build.0 = Debug|Any CPU
+		{3A745526-7709-46D2-8978-C882D9F08656}.Release|x86.ActiveCfg = Release|Any CPU
+		{3A745526-7709-46D2-8978-C882D9F08656}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tests/common/mac/TestProjects/RoslynTestApp/Lib/Full/ReadOnlyTestMacLib/MyClass.cs
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Lib/Full/ReadOnlyTestMacLib/MyClass.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace ReadOnlyTestMacLib
+{
+	public class MyClass
+	{
+		public MyClass ()
+		{
+		}
+	}
+}

--- a/tests/common/mac/TestProjects/RoslynTestApp/Lib/Full/ReadOnlyTestMacLib/ReadOnlyTestMacLib.csproj
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Lib/Full/ReadOnlyTestMacLib/ReadOnlyTestMacLib.csproj
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3A745526-7709-46D2-8978-C882D9F08656}</ProjectGuid>
+    <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ReadOnlyTestMacLib</RootNamespace>
+    <AssemblyName>ReadOnlyTestMacLib</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
+    <UseXamMacFullFramework>true</UseXamMacFullFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <EnableCodeSigning>false</EnableCodeSigning>
+    <CreatePackage>false</CreatePackage>
+    <EnablePackageSigning>false</EnablePackageSigning>
+    <IncludeMonoRuntime>false</IncludeMonoRuntime>
+    <UseSGen>false</UseSGen>
+    <HttpClientHandler>HttpClientHandler</HttpClientHandler>
+    <LinkMode>None</LinkMode>
+    <XamMacArch></XamMacArch>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <DefineConstants></DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <EnableCodeSigning>false</EnableCodeSigning>
+    <CreatePackage>false</CreatePackage>
+    <EnablePackageSigning>false</EnablePackageSigning>
+    <IncludeMonoRuntime>false</IncludeMonoRuntime>
+    <UseSGen>false</UseSGen>
+    <HttpClientHandler>HttpClientHandler</HttpClientHandler>
+    <LinkMode>None</LinkMode>
+    <XamMacArch></XamMacArch>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.Mac" />
+  </ItemGroup>
+  <Import Project="..\..\ReadOnlyTestLib\ReadOnlyTestLib.projitems" Label="Shared" Condition="Exists('..\..\ReadOnlyTestLib\ReadOnlyTestLib.projitems')" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
+</Project>

--- a/tests/common/mac/TestProjects/RoslynTestApp/Lib/Modern/ReadOnlyTestMacLib/MyClass.cs
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Lib/Modern/ReadOnlyTestMacLib/MyClass.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace ReadOnlyTestMacLib
+{
+	public class MyClass
+	{
+		public MyClass ()
+		{
+		}
+	}
+}

--- a/tests/common/mac/TestProjects/RoslynTestApp/Lib/Modern/ReadOnlyTestMacLib/ReadOnlyTestMacLib.csproj
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Lib/Modern/ReadOnlyTestMacLib/ReadOnlyTestMacLib.csproj
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3A745526-7709-46D2-8978-C882D9F08656}</ProjectGuid>
+    <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ReadOnlyTestMacLib</RootNamespace>
+    <AssemblyName>ReadOnlyTestMacLib</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
+    <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <EnableCodeSigning>false</EnableCodeSigning>
+    <CreatePackage>false</CreatePackage>
+    <EnablePackageSigning>false</EnablePackageSigning>
+    <IncludeMonoRuntime>false</IncludeMonoRuntime>
+    <UseSGen>false</UseSGen>
+    <HttpClientHandler>HttpClientHandler</HttpClientHandler>
+    <LinkMode>None</LinkMode>
+    <XamMacArch></XamMacArch>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <DefineConstants></DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <EnableCodeSigning>false</EnableCodeSigning>
+    <CreatePackage>false</CreatePackage>
+    <EnablePackageSigning>false</EnablePackageSigning>
+    <IncludeMonoRuntime>false</IncludeMonoRuntime>
+    <UseSGen>false</UseSGen>
+    <HttpClientHandler>HttpClientHandler</HttpClientHandler>
+    <LinkMode>None</LinkMode>
+    <XamMacArch></XamMacArch>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.Mac" />
+  </ItemGroup>
+  <Import Project="..\..\ReadOnlyTestLib\ReadOnlyTestLib.projitems" Label="Shared" Condition="Exists('..\..\ReadOnlyTestLib\ReadOnlyTestLib.projitems')" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
+</Project>

--- a/tests/common/mac/TestProjects/RoslynTestApp/Lib/ReadOnlyTestLib/MyClass.cs
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Lib/ReadOnlyTestLib/MyClass.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ReadOnlyTestLib
+{
+	public class MyClass
+	{
+		static IReadOnlyCollection<string> Test ()
+		{
+			var dict = new Dictionary<string, string> {
+				["foo"] = "bar"
+			};
+
+			return (IReadOnlyCollection<string>)dict.Values;
+		}
+	}
+}

--- a/tests/common/mac/TestProjects/RoslynTestApp/Lib/ReadOnlyTestLib/ReadOnlyTestLib.projitems
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Lib/ReadOnlyTestLib/ReadOnlyTestLib.projitems
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>{0F90A525-90FF-4351-B5AE-F5B3AF320360}</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>ReadOnlyTestLib</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)MyClass.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/common/mac/TestProjects/RoslynTestApp/Lib/ReadOnlyTestLib/ReadOnlyTestLib.shproj
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Lib/ReadOnlyTestLib/ReadOnlyTestLib.shproj
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectGuid>{0F90A525-90FF-4351-B5AE-F5B3AF320360}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <Import Project="ReadOnlyTestLib.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/tests/common/mac/TestProjects/RoslynTestApp/Modern/RoslynTestApp.csproj
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Modern/RoslynTestApp.csproj
@@ -73,5 +73,11 @@
   <ItemGroup>
     <Compile Include="Main.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Lib\Modern\ReadOnlyTestMacLib\ReadOnlyTestMacLib.csproj">
+      <Project>{3A745526-7709-46D2-8978-C882D9F08656}</Project>
+      <Name>ReadOnlyTestMacLib</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/tests/common/mac/TestProjects/RoslynTestApp/Modern/RoslynTestApp.sln
+++ b/tests/common/mac/TestProjects/RoslynTestApp/Modern/RoslynTestApp.sln
@@ -1,0 +1,25 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoslynTestApp", "RoslynTestApp.csproj", "{0D155A7F-561C-4187-967D-3879FA760217}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ReadOnlyTestLib", "..\Lib\ReadOnlyTestLib\ReadOnlyTestLib.shproj", "{0F90A525-90FF-4351-B5AE-F5B3AF320360}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReadOnlyTestMacLib", "..\Lib\Modern\ReadOnlyTestMacLib\ReadOnlyTestMacLib.csproj", "{3A745526-7709-46D2-8978-C882D9F08656}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0D155A7F-561C-4187-967D-3879FA760217}.Debug|x86.ActiveCfg = Debug|x86
+		{0D155A7F-561C-4187-967D-3879FA760217}.Debug|x86.Build.0 = Debug|x86
+		{0D155A7F-561C-4187-967D-3879FA760217}.Release|x86.ActiveCfg = Release|x86
+		{0D155A7F-561C-4187-967D-3879FA760217}.Release|x86.Build.0 = Release|x86
+		{3A745526-7709-46D2-8978-C882D9F08656}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3A745526-7709-46D2-8978-C882D9F08656}.Debug|x86.Build.0 = Debug|Any CPU
+		{3A745526-7709-46D2-8978-C882D9F08656}.Release|x86.ActiveCfg = Release|Any CPU
+		{3A745526-7709-46D2-8978-C882D9F08656}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tests/msbuild-mac/src/RoslynSmokeTests.cs
+++ b/tests/msbuild-mac/src/RoslynSmokeTests.cs
@@ -22,7 +22,7 @@ namespace Xamarin.MMP.Tests
 		// [Test] - https://bugzilla.xamarin.com/show_bug.cgi?id=53164
 		public void XMModernRosylnProjet_ShouldBuildAndRunWithMSBuild ()
 		{
-			string projectPath = Path.Combine (RoslynTestProjectRoot, "Modern/RoslynTestApp.csproj");
+			string projectPath = Path.Combine (RoslynTestProjectRoot, "Modern/RoslynTestApp.sln");
 
 			TI.CleanUnifiedProject (projectPath);
 			RestoreRoslynNuget ("Modern");
@@ -33,7 +33,7 @@ namespace Xamarin.MMP.Tests
 		// [Test] - https://bugzilla.xamarin.com/show_bug.cgi?id=53164
 		public void XMFullRosylnProjet_ShouldBuildAndRunWithMSBuild ()
 		{
-			string projectPath = Path.Combine (RoslynTestProjectRoot, "Full/RoslynTestApp.csproj");
+			string projectPath = Path.Combine (RoslynTestProjectRoot, "Full/RoslynTestApp.sln");
 
 			TI.CleanUnifiedProject (projectPath);
 			RestoreRoslynNuget ("Full");


### PR DESCRIPTION
- In some build cases this chunk of code:

    <ItemGroup Condition=" '$(NoCompilerStandardLib)' == 'true' and '$(NoStdLib)' != 'true' ">
          <!-- Note that unlike VB, C# does not automatically locate System.dll as a "standard library"
               instead the reference is always passed from the project. Also, for mscorlib.dll
               we need to provide the explicit location in order to maintain the correct behaviour
     -->
        <_ExplicitReference Include="$(FrameworkPathOverride)\mscorlib.dll" />
    </ItemGroup>

would trigger and force us to use mscorlib from system mono. That does not work well.
- By setting FrameworkPathOverride, we can get the right mscorlib
- However, that ItemGroup happens outside of a target, so we must move our setting to match for it to take effect