### PR TITLE
[AVFoundation] Re-enable AVAudioSessionInterruptionEventArgs.WasSuspended. Fixes bug 52730.

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -1943,13 +1943,10 @@ namespace XamCore.AVFoundation {
 		[Export ("AVAudioSessionInterruptionOptionKey")]
 		AVAudioSessionInterruptionOptions Option { get; }
 
-#if false
-		// https://bugzilla.xamarin.com/show_bug.cgi?id=52730
 		[iOS (10, 3), NoMac, TV (10, 2), Watch (3,2)]
+		[NullAllowed]
 		[Export ("AVAudioSessionInterruptionWasSuspendedKey")]
-		[return: BindAs (bool?)]
-		NSNumber WasSuspended { get; }
-#endif
+		bool WasSuspended { get; }
 	}
 
 	interface AVAudioSessionRouteChangeEventArgs {


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=52730

There is no need for bindas support here, by just using bool and
[NullAllowed] the generator does the right thing

```csharp
[CompilerGenerated]
public System.Boolean? WasSuspended {
	get {
		IntPtr value;
		if (k2 == IntPtr.Zero)
			k2 = ObjCRuntime.Dlfcn.GetIntPtr (Libraries.AVFoundation.Handle, "AVAudioSessionInterruptionWasSuspendedKey");
		if (Notification.UserInfo == null)
			return null;
		value = Notification.UserInfo.LowlevelObjectForKey (k2);

		if (value == IntPtr.Zero)
			return null;
		using (var nsn = Runtime.GetNSObject<NSNumber> (value))
			return nsn.BoolValue;
	}
}
```