### PR TITLE
[tests] Don't create test packages by default.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -57,7 +57,8 @@ endif
 # to run specific test suites. For more information read the README.md.
 #
 
-all-local:: qa-test-dependencies.zip mac-test-package.zip
+package-tests:
+	$(MAKE) qa-test-dependencies.zip mac-test-package.zip
 
 test.config: Makefile $(TOP)/Make.config
 	@rm -f $@

--- a/tests/apitest/apitest.csproj
+++ b/tests/apitest/apitest.csproj
@@ -51,9 +51,6 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Drawing" />
     <Reference Include="XamMac" />
-    <Reference Include="GuiUnit">
-      <HintPath>..\..\external\guiunit\bin\net_4_5\GuiUnit.exe</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
@@ -155,6 +152,12 @@
     <Compile Include="..\common\TestRuntime.cs">
       <Link>shared\TestRuntime.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">
+      <Project>{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}</Project>
+      <Name>GuiUnit_NET_4_5</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/apitest/apitest.sln
+++ b/tests/apitest/apitest.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "apitest", "apitest.csproj", "{7A0EDA95-30A6-43E1-AD43-368AD95AC48B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GuiUnit_NET_4_5", "..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj", "{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7A0EDA95-30A6-43E1-AD43-368AD95AC48B}.Debug|x86.ActiveCfg = Debug|x86
+		{7A0EDA95-30A6-43E1-AD43-368AD95AC48B}.Debug|x86.Build.0 = Debug|x86
+		{7A0EDA95-30A6-43E1-AD43-368AD95AC48B}.Release|x86.ActiveCfg = Release|x86
+		{7A0EDA95-30A6-43E1-AD43-368AD95AC48B}.Release|x86.Build.0 = Release|x86
+		{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}.Debug|x86.Build.0 = Debug|Any CPU
+		{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}.Release|x86.ActiveCfg = Release|Any CPU
+		{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tests/dontlink-mac/dontlink-mac.csproj
+++ b/tests/dontlink-mac/dontlink-mac.csproj
@@ -51,9 +51,6 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Drawing" />
     <Reference Include="XamMac" />
-    <Reference Include="GuiUnit">
-      <HintPath>..\..\external\guiunit\bin\net_4_5\GuiUnit.exe</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
@@ -63,6 +60,12 @@
     <Compile Include="..\common\mac\MacTestMain.cs">
       <Link>MacTestMain.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">
+      <Project>{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}</Project>
+      <Name>GuiUnit_NET_4_5</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/dontlink-mac/dontlink-mac.sln
+++ b/tests/dontlink-mac/dontlink-mac.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dontlink-mac", "dontlink-mac.csproj", "{FD385098-B3FD-4331-92BF-CC1F918E3334}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GuiUnit_NET_4_5", "..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj", "{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FD385098-B3FD-4331-92BF-CC1F918E3334}.Debug|x86.ActiveCfg = Debug|x86
+		{FD385098-B3FD-4331-92BF-CC1F918E3334}.Debug|x86.Build.0 = Debug|x86
+		{FD385098-B3FD-4331-92BF-CC1F918E3334}.Release|x86.ActiveCfg = Release|x86
+		{FD385098-B3FD-4331-92BF-CC1F918E3334}.Release|x86.Build.0 = Release|x86
+		{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}.Debug|x86.Build.0 = Debug|Any CPU
+		{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}.Release|x86.ActiveCfg = Release|Any CPU
+		{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -278,7 +278,7 @@ namespace xharness
 		{
 			var test_suites = new [] { new { ProjectFile = "apitest", Name = "apitest" }, new { ProjectFile = "dontlink-mac", Name = "dont link" } };
 			foreach (var p in test_suites)
-				MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p.ProjectFile + "/" + p.ProjectFile + ".csproj"))) { Name = p.Name });
+				MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p.ProjectFile + "/" + p.ProjectFile + ".sln"))) { Name = p.Name });
 			
 			MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "introspection", "Mac", "introspection-mac.csproj")), skipXMVariations : true));
 
@@ -394,7 +394,7 @@ namespace xharness
 			}
  
 			foreach (var proj in MacTestProjects.Where ((v) => v.GenerateVariations)) {
-				var file = proj.Path;
+				var file = Path.ChangeExtension (proj.Path, "csproj");
  				if (!File.Exists (file))
  					throw new FileNotFoundException (file);
 

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -570,7 +570,7 @@ namespace xharness
 			{
 				Platform = platform,
 				Jenkins = task.Jenkins,
-				TestProject = new TestProject (AddSuffixToPath (task.ProjectFile, suffix)),
+				TestProject = new TestProject (Path.ChangeExtension (AddSuffixToPath (task.ProjectFile, suffix), "csproj")),
 				ProjectConfiguration = task.ProjectConfiguration,
 				ProjectPlatform = task.ProjectPlatform,
 				SpecifyPlatform = task.BuildTask.SpecifyPlatform,


### PR DESCRIPTION
Don't create test packages by default, instead add a new target to create test
packages. This new target is called on wrench, which means the packages will
still be created when needed, but they won't be built locally in every build
(and if a packaged test fails to build, it won't fail the entire build).