### PR TITLE
[mtouch] Don't open files for writing when it's not needed.

### DIFF
--- a/tools/common/cache.cs
+++ b/tools/common/cache.cs
@@ -81,8 +81,8 @@ public class Cache {
 			return false;
 		}
 
-		using (var astream = new FileStream (a, FileMode.Open)) {
-			using (var bstream = new FileStream (b, FileMode.Open)) {
+		using (var astream = new FileStream (a, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+			using (var bstream = new FileStream (b, FileMode.Open, FileAccess.Read, FileShare.Read)) {
 				bool rv;
 				Driver.Log (6, "Comparing files {0} and {1}...", a, b);
 				rv = CompareStreams (astream, bstream, ignore_cache);


### PR DESCRIPTION
This fixes a file sharing exception:

> MTOUCH: error MT1009: Could not copy the assembly '[...]/msbuild/tests/MyActionExtension/bin/iPhone/Debug/MyActionExtension.dll' to '[...]/msbuild/tests/MyTabbedApplication/obj/iPhone/Debug/mtouch-cache/32/Link/MyActionExtension.dll': Sharing violation on path [...]/msbuild/tests/MyActionExtension/bin/iPhone/Debug/MyActionExtension.pdb