### PR TITLE
[tests] Fix msbuild-mac project to use a project reference to GuiUnit.

### DIFF
--- a/tests/msbuild-mac/msbuild-mac.csproj
+++ b/tests/msbuild-mac/msbuild-mac.csproj
@@ -53,9 +53,6 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.Mac" />
     <Reference Include="System.Xml" />
-    <Reference Include="GuiUnit">
-      <HintPath>..\..\external\guiunit\bin\net_4_5\GuiUnit.exe</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
@@ -82,6 +79,12 @@
     </Compile>
     <Compile Include="src\RoslynSmokeTests.cs" />
     <Compile Include="src\RuntimeTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">
+      <Project>{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}</Project>
+      <Name>GuiUnit_NET_4_5</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
   <Import Project="CustomBuildActions.targets" />


### PR DESCRIPTION
xbuild will automatically find and build project references, while directly
referencing the assembly won't.