### PR TITLE
Fix how we build frameworks. Fixes #53813.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -890,6 +890,7 @@ iphonesimulator:: setup-iphonesimulator build-iphonesimulator install-iphonesimu
 # this needs to be here because the normal usage of this makefile is "make all install", but nothing actually lists the -iphonesimulator targets as dependencies.
 ifdef INCLUDE_IOS
 install-local:: install-iphonesimulator
+all-local:: install-iphonesimulator
 endif
 
 IPHONESIMULATOR_TARGETS = \
@@ -1004,6 +1005,7 @@ setup:: setup-watchsimulator
 build:: build-watchsimulator
 clean-local:: clean-watchsimulator
 install-local:: install-watchsimulator
+all-local:: install-watchsimulator
 
 watchsimulator: build-watchsimulator install-watchsimulator
 
@@ -1150,6 +1152,7 @@ setup:: setup-tvsimulator
 build:: build-tvsimulator
 clean-local:: clean-tvsimulator
 install-local:: install-tvsimulator
+all-local:: install-tvsimulator
 
 tvsimulator: build-tvsimulator install-tvsimulator
 
@@ -1356,25 +1359,13 @@ $(BUILD_DESTDIR)/$(2)/tmp-lib:
 # them the required times according to how many versions we need.
 #
 $(BUILD_DESTDIR)/$(2)/tmp-lib/Mono: $(BUILD_DESTDIR)/$(2)/lib/libmonosgen-2.0.a | $(BUILD_DESTDIR)/$(2)/tmp-lib
-	$$(Q) rm -Rf $$@.tmpdir
-	$$(Q) mkdir -p $$@.tmpdir
-	$$(Q) cd $$@.tmpdir && ar -x $$<
-	$$(Q) $$(IOS_CC) -arch $(1) -dynamiclib -o $$@ $$@.tmpdir/*.o -liconv -O2 -Wl,-application_extension -miphoneos-version-min=8.0 -isysroot $(PLATFORM_SDK) -install_name @rpath/Mono.framework/Mono -compatibility_version 2 -current_version 2.0 -framework CoreFoundation -lobjc $(IOS_BITCODE_LDFLAGS) -Wl,-single_module
-	$$(Q) rm -Rf $$@.tmpdir
+	$$(Q_GEN) CC="$(IOS_CC)" ./create-shared-library.sh $$< $$@ -arch $(1) -install_name @rpath/Mono.framework/Mono -miphoneos-version-min=8.0 -isysroot $(PLATFORM_SDK) $(IOS_BITCODE_LDFLAGS)
 
 $(BUILD_DESTDIR)/$(2)/tmp-lib/libmonosgen-2.0.dylib: $(BUILD_DESTDIR)/$(2)/lib/libmonosgen-2.0.a | $(BUILD_DESTDIR)/$(2)/tmp-lib
-	$$(Q) rm -Rf $$@.tmpdir
-	$$(Q) mkdir -p $$@.tmpdir
-	$$(Q) cd $$@.tmpdir && ar -x $$<
-	$$(Q) $$(IOS_CC) -arch $(1) -dynamiclib -o $$@ $$@.tmpdir/*.o -liconv -O2 -Wl,-application_extension -miphoneos-version-min=7.0 -isysroot $(PLATFORM_SDK) -install_name @rpath/libmonosgen-2.0.dylib -compatibility_version 2 -current_version 2.0 -framework CoreFoundation -lobjc $(IOS_BITCODE_LDFLAGS) -Wl,-single_module
-	$$(Q) rm -Rf $$@.tmpdir
+	$$(Q_GEN) CC="$(IOS_CC)" ./create-shared-library.sh $$< $$@ -arch $(1) -install_name @rpath/libmonosgen-2.0.dylib -miphoneos-version-min=7.0 -isysroot $(PLATFORM_SDK) $(IOS_BITCODE_LDFLAGS)
 
 $(BUILD_DESTDIR)/$(2)/tmp-lib/libmono-profiler-log.0.dylib: $(BUILD_DESTDIR)/$(2)/lib/libmono-profiler-log.a $(BUILD_DESTDIR)/$(2)/tmp-lib/libmonosgen-2.0.dylib | $(BUILD_DESTDIR)/$(2)/tmp-lib
-	$$(Q) rm -Rf $$@.tmpdir
-	$$(Q) mkdir -p $$@.tmpdir
-	$$(Q) cd $$@.tmpdir && ar -x $$<
-	$$(Q) $$(IOS_CC) -arch $(1) -dynamiclib -o $$@ $$@.tmpdir/*.o -liconv -O2 -Wl,-application_extension -miphoneos-version-min=7.0 -isysroot $(PLATFORM_SDK) -install_name @rpath/libmono-profiler-log.dylib -compatibility_version 2 -current_version 2.0 -framework CoreFoundation -lobjc -Wl,-single_module -L$(BUILD_DESTDIR)/$(2)/tmp-lib -lmonosgen-2.0 -lz
-	$$(Q) rm -Rf $$@.tmpdir
+	$$(Q_GEN) CC="$(IOS_CC)" ./create-shared-library.sh $$< $$@ -arch $(1) -install_name @rpath/libmono-profiler-log.dylib -miphoneos-version-min=7.0 -isysroot $(PLATFORM_SDK) $(IOS_BITCODE_LDFLAGS) -L$(BUILD_DESTDIR)/$(2)/tmp-lib -lmonosgen-2.0 -lz
 
 endef
 
@@ -1411,6 +1402,7 @@ install-device: install-iphoneos
 # this needs to be here because the normal usage of this makefile is "make all install", but nothing actually lists the -iphoneos targets as dependencies.
 ifdef INCLUDE_IOS
 install-local:: install-iphoneos
+all-local:: install-iphoneos
 endif
 endif
 
@@ -1545,6 +1537,7 @@ setup:: setup-targetwatch
 build:: build-targetwatch
 clean-local:: clean-targetwatch
 install-local:: install-watchos
+all-local:: install-watchos
 
 targetwatch: build-targetwatch install-watchos
 watchos:: targetwatch
@@ -1617,12 +1610,14 @@ $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmono-profiler-log.dylib: $(WATCH
 $(WATCHOS_DIRECTORIES):
 	$(Q) mkdir -p $@
 
-$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks/Mono.framework/Mono: $(WATCHOS_TARGET_SHAREDLIBLOGPROFILER) | $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks/Mono.framework
+$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks/Mono.framework/Mono: $(BUILD_DESTDIR)/targetwatch/tmp-lib/Mono | $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks/Mono.framework
 	$(Q) cp $< $@
-	$(Q) $(WATCHOS_BIN_PATH)/install_name_tool -id @rpath/Mono.framework/Mono -change $(BUILD_DESTDIR)/targetwatch/lib/libmonosgen-2.0.1.dylib @rpath/libmonosgen-2.0.dylib $@
 
 $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks/Mono.framework/Info.plist: Mono.framework-watchos.Info.plist | $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks/Mono.framework
 	$(Q) cp $< $@
+
+$(BUILD_DESTDIR)/targetwatch/tmp-lib/Mono: $(BUILD_DESTDIR)/targetwatch/lib/libmonosgen-2.0.a
+	$(Q_GEN) CC="$(IOS_CC)" ./create-shared-library.sh $< $@ -arch armv7k -install_name @rpath/Mono.framework/Mono -mwatchos-version-min=$(MIN_WATCHOS_SDK_VERSION) -isysroot $(DEVICEWATCH_SDK) -lc++ -fembed-bitcode
 
 install-watchos: $(WATCHOS_TARGETS)
 
@@ -1723,6 +1718,7 @@ setup:: setup-targettv
 build:: build-targettv
 clean-local:: clean-targettv
 install-local:: install-tvos
+all-local:: install-tvos
 
 targettv: build-targettv install-tvos
 tvos:: targettv
@@ -1795,12 +1791,14 @@ $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib/libmono-profiler-log.dylib: $(TVOS_TAR
 $(TVOS_DIRECTORIES):
 	$(Q) mkdir -p $@
 
-$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks/Mono.framework/Mono: $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib/libmonosgen-2.0.dylib | $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks/Mono.framework
+$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks/Mono.framework/Mono: $(BUILD_DESTDIR)/targettv/tmp-lib/Mono | $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks/Mono.framework
 	$(Q) cp $< $@
-	$(Q) $(TVOS_BIN_PATH)/install_name_tool -id @rpath/Mono.framework/Mono $@
 
 $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks/Mono.framework/Info.plist: Mono.framework-tvos.Info.plist | $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks/Mono.framework
 	$(Q) cp $< $@
+
+$(BUILD_DESTDIR)/targettv/tmp-lib/Mono: $(BUILD_DESTDIR)/targettv/lib/libmonosgen-2.0.a
+	$(Q_GEN) CC="$(IOS_CC)" ./create-shared-library.sh $< $@ -arch arm64 -install_name @rpath/Mono.framework/Mono -mtvos-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(DEVICETV_SDK) -lc++ -fembed-bitcode
 
 install-tvos: $(TVOS_TARGETS)
 

--- a/builds/create-shared-library.sh
+++ b/builds/create-shared-library.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+
+# This script takes a static library (.a) as input and creates a dylib or framework from it:
+# 1) First all the object files are extracted from the static library.
+# 2) Then all the object files are relinked into a dynamic library / framework).
+#
+# Arguments
+# 1: the input static library
+# 2: the output framework library
+# 3+: any custom linker arguments.
+
+STATIC_LIBRARY=$1
+FRAMEWORK=$2
+
+if test -z $STATIC_LIBRARY; then
+	echo "The first argument must be the input (static) library."
+	exit 1
+elif ! test -f $STATIC_LIBRARY; then
+	echo "Could not find the input library: $STATIC_LIBRARY"
+	exit 1
+fi
+
+if test -z $FRAMEWORK; then
+	echo "The second argument must be the output (shared) library."
+	exit 1
+fi
+
+shift 2
+LINKER_FLAGS="$@"
+
+mkdir -p $(dirname $FRAMEWORK)
+TMPDIR=$FRAMEWORK.tmpdir
+rm -Rf $TMPDIR
+mkdir -p $TMPDIR
+cd $TMPDIR
+ar -x $STATIC_LIBRARY
+cd ..
+
+$CC $LINKER_FLAGS -dynamiclib -O2 -Wl,-application_extension -compatibility_version 2 -current_version 2.0 -framework CoreFoundation -lobjc -liconv -o $FRAMEWORK $TMPDIR/*.o
+
+rm -Rf $TMPDIR

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -32,6 +32,9 @@ define NativeCompilationTemplate
 	$$(call Q_2,LD,    [ios]) $(SIMULATOR_CC) $(SIMULATOR86_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/simulator86/lib -fapplication-extension
 	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/simulator86/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
 
+.libs/ios/%$(1).x86.framework: | .libs/ios
+	$$(call Q_2,LD,    [ios]) $(SIMULATOR_CC) $(SIMULATOR86_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -F$(IOS_DESTDIR)$(XAMARIN_IOSSIMULATOR_SDK)/Frameworks -fapplication-extension
+
 .libs/ios/%$(1).x86_64.o: %.m $(EXTRA_DEPENDENCIES) | .libs/ios
 	$$(call Q_2,OBJC,  [ios]) $(SIMULATOR_CC) $(SIMULATOR64_OBJC_CFLAGS) $$(EXTRA_DEFINES) $(SIM64_I) -g $(2) -c $$< -o $$@
 
@@ -45,6 +48,9 @@ define NativeCompilationTemplate
 	$$(call Q_2,LD,    [ios]) $(SIMULATOR_CC) $(SIMULATOR64_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/simulator64/lib -fapplication-extension
 	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/simulator64/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
 
+.libs/ios/%$(1).x86_64.framework: | .libs/ios
+	$$(call Q_2,LD,    [ios]) $(SIMULATOR_CC) $(SIMULATOR64_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -F$(IOS_DESTDIR)$(XAMARIN_IOSSIMULATOR_SDK)/Frameworks -fapplication-extension
+
 ## ios device
 
 .libs/ios/%$(1).armv7.o: %.m $(EXTRA_DEPENDENCIES) | .libs/ios
@@ -57,6 +63,9 @@ define NativeCompilationTemplate
 	$$(call Q_2,LD,    [ios]) $(DEVICE_CC) $(DEVICE7_CFLAGS)       $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/target7/lib   -fapplication-extension
 	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/target7/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
 
+.libs/ios/%$(1).armv7.framework: | .libs/ios
+	$$(call Q_2,LD,    [ios]) $(DEVICE_CC) $(DEVICE7_CFLAGS)       $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -F$(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/Frameworks -fapplication-extension
+
 .libs/ios/%$(1).armv7s.o: %.m $(EXTRA_DEPENDENCIES) | .libs/ios
 	$$(call Q_2,OBJC,  [ios]) $(DEVICE_CC) $(DEVICE7S_OBJC_CFLAGS) $$(EXTRA_DEFINES) $(DEV7s_I) -g $(2) -c $$< -o $$@ 
 
@@ -67,6 +76,9 @@ define NativeCompilationTemplate
 	$$(call Q_2,LD,    [ios]) $(DEVICE_CC) $(DEVICE7S_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/target7s/lib -fapplication-extension
 	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/target7s/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
 
+.libs/ios/%$(1).armv7s.framework: | .libs/ios
+	$$(call Q_2,LD,    [ios]) $(DEVICE_CC) $(DEVICE7S_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -F$(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/Frameworks -fapplication-extension
+
 .libs/ios/%$(1).arm64.o: %.m $(EXTRA_DEPENDENCIES) | .libs/ios
 	$$(call Q_2,OBJC,  [ios]) $(DEVICE_CC) $(DEVICE64_OBJC_CFLAGS) $$(EXTRA_DEFINES) $(DEV64_I) -g $(2) -c $$< -o $$@ 
 
@@ -76,6 +88,9 @@ define NativeCompilationTemplate
 .libs/ios/%$(1).arm64.dylib: | .libs/ios
 	$$(call Q_2,LD,    [ios]) $(DEVICE_CC) $(DEVICE64_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/target64/lib -fapplication-extension
 	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/target64/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
+
+.libs/ios/%$(1).arm64.framework: | .libs/ios
+	$$(call Q_2,LD,    [ios]) $(DEVICE_CC) $(DEVICE64_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -F$(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/Frameworks -fapplication-extension  -miphoneos-version-min=8.0
 
 ## watch simulator
 
@@ -92,6 +107,8 @@ define NativeCompilationTemplate
 	$$(call Q_2,LD,    [watchos]) $(SIMULATOR_CC) $(SIMULATORWATCH_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/watchsimulator/lib -fapplication-extension
 	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/watchsimulator/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
 
+.libs/watchos/%$(1).x86.framework: | .libs/watchos
+	$$(call Q_2,LD,    [watchos]) $(SIMULATOR_CC) $(SIMULATORWATCH_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -F$(IOS_DESTDIR)$(XAMARIN_WATCHSIMULATOR_SDK)/Frameworks -fapplication-extension
 ## watch device
 
 .libs/watchos/%$(1).armv7k.o: %.m $(EXTRA_DEPENDENCIES) | .libs/watchos
@@ -103,6 +120,9 @@ define NativeCompilationTemplate
 .libs/watchos/%$(1).armv7k.dylib: | .libs/watchos
 	$$(call Q_2,LD,    [watchos]) $(DEVICE_CC) $(DEVICEWATCH_CFLAGS)          $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/targetwatch/lib -fapplication-extension
 	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/targetwatch/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
+
+.libs/watchos/%$(1).armv7k.framework: | .libs/watchos
+	$$(call Q_2,LD,    [watchos]) $(DEVICE_CC) $(DEVICEWATCH_CFLAGS)          $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -F$(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/Frameworks -fapplication-extension
 
 ## tv simulator
 
@@ -119,6 +139,9 @@ define NativeCompilationTemplate
 	$$(call Q_2,LD,    [tvos]) $(SIMULATOR_CC) $(SIMULATORTV_CFLAGS)         $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/tvsimulator/lib -fapplication-extension
 	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/tvsimulator/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
 
+.libs/tvos/%$(1).x86_64.framework: | .libs/tvos
+	$$(call Q_2,LD,    [tvos]) $(SIMULATOR_CC) $(SIMULATORTV_CFLAGS)         $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -F$(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/Frameworks -fapplication-extension
+
 ## tv device
 
 .libs/tvos/%$(1).arm64.o: %.m $(EXTRA_DEPENDENCIES) | .libs/tvos
@@ -131,6 +154,8 @@ define NativeCompilationTemplate
 	$$(call Q_2,LD,    [tvos]) $(DEVICE_CC)    $(DEVICETV_CFLAGS)            $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(BUILD_DESTDIR)/targettv/lib -fapplication-extension
 	$(Q) install_name_tool -change $(realpath $(BUILD_DESTDIR)/targettv/lib/libmonosgen-2.0.dylib) @rpath/libmonosgen-2.0.dylib $$@
 
+.libs/tvos/%$(1).arm64.framework: | .libs/tvos
+	$$(call Q_2,LD,    [tvos]) $(DEVICE_CC)    $(DEVICETV_CFLAGS)            $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -F$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks -fapplication-extension
 endef
 
 $(eval $(call NativeCompilationTemplate,,-O2))

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -130,17 +130,11 @@ endif
 $(IOS_DESTDIR)$$(XAMARIN_$(5)SIMULATOR_SDK)/usr/lib/%.a: .libs/$(1)/%.a | $(IOS_DESTDIR)$$(XAMARIN_$(5)SIMULATOR_SDK)/usr/lib
 	$(Q) install -m 0644 $$< $$@
 
-$(IOS_DESTDIR)$$(XAMARIN_$(5)SIMULATOR_SDK)/Frameworks/Xamarin.framework/Xamarin: .libs/$(1)/libxamarin-sim.dylib | $(IOS_DESTDIR)$$(XAMARIN_$(5)SIMULATOR_SDK)/Frameworks/Xamarin.framework
-	$(Q) cp $$< $$@.tmp
-	$(Q) install_name_tool -id @rpath/$$(notdir $$@).framework/$$(notdir $$@) $$@.tmp
-	$(Q) install_name_tool -change @rpath/libmonosgen-2.0.dylib @rpath/Mono.framework/Mono $$@.tmp
-	$(Q) mv $$@.tmp $$@
+$(IOS_DESTDIR)$$(XAMARIN_$(5)SIMULATOR_SDK)/Frameworks/Xamarin.framework/Xamarin: .libs/$(1)/Xamarin-sim.framework | $(IOS_DESTDIR)$$(XAMARIN_$(5)SIMULATOR_SDK)/Frameworks/Xamarin.framework
+	$(Q) cp $$< $$@
 
-$(IOS_DESTDIR)$$(XAMARIN_$(5)SIMULATOR_SDK)/Frameworks/Xamarin-debug.framework/Xamarin-debug: .libs/$(1)/libxamarin-debug-sim.dylib | $(IOS_DESTDIR)$$(XAMARIN_$(5)SIMULATOR_SDK)/Frameworks/Xamarin-debug.framework
-	$(Q) cp $$< $$@.tmp
-	$(Q) install_name_tool -id @rpath/$$(notdir $$@).framework/$$(notdir $$@) $$@.tmp
-	$(Q) install_name_tool -change @rpath/libmonosgen-2.0.dylib @rpath/Mono.framework/Mono $$@.tmp
-	$(Q) mv $$@.tmp $$@
+$(IOS_DESTDIR)$$(XAMARIN_$(5)SIMULATOR_SDK)/Frameworks/Xamarin-debug.framework/Xamarin-debug: .libs/$(1)/Xamarin-debug-sim.framework | $(IOS_DESTDIR)$$(XAMARIN_$(5)SIMULATOR_SDK)/Frameworks/Xamarin-debug.framework
+	$(Q) cp $$< $$@
 
 $(IOS_DESTDIR)$$(XAMARIN_$(5)SIMULATOR_SDK)/Frameworks/%.framework/Info.plist: Xamarin.framework-$(1).Info.plist | $(IOS_DESTDIR)$$(XAMARIN_$(5)SIMULATOR_SDK)/Frameworks/Xamarin.framework
 	$(Q) sed 's/@BUNDLE_EXECUTABLE@/$$*/' $$< > $$@
@@ -149,17 +143,11 @@ ifdef INCLUDE_DEVICE
 $(IOS_DESTDIR)$$(XAMARIN_$(6)OS_SDK)/usr/lib/%.a: .libs/$(1)/%.a | $(IOS_DESTDIR)$$(XAMARIN_$(6)OS_SDK)/usr/lib
 	$(Q) install -m 0644 $$< $$@
 
-$(IOS_DESTDIR)$$(XAMARIN_$(6)OS_SDK)/Frameworks/Xamarin.framework/Xamarin: .libs/$(1)/libxamarin-dev.dylib | $(IOS_DESTDIR)$$(XAMARIN_$(6)OS_SDK)/Frameworks/Xamarin.framework
-	$(Q) cp $$< $$@.tmp
-	$(Q) install_name_tool -id @rpath/$$(notdir $$@).framework/$$(notdir $$@) $$@.tmp
-	$(Q) install_name_tool -change @rpath/libmonosgen-2.0.dylib @rpath/Mono.framework/Mono $$@.tmp
-	$(Q) mv $$@.tmp $$@
+$(IOS_DESTDIR)$$(XAMARIN_$(6)OS_SDK)/Frameworks/Xamarin.framework/Xamarin: .libs/$(1)/Xamarin-dev.framework | $(IOS_DESTDIR)$$(XAMARIN_$(6)OS_SDK)/Frameworks/Xamarin.framework
+	$(Q) cp $$< $$@
 
-$(IOS_DESTDIR)$$(XAMARIN_$(6)OS_SDK)/Frameworks/Xamarin-debug.framework/Xamarin-debug: .libs/$(1)/libxamarin-debug-dev.dylib | $(IOS_DESTDIR)$$(XAMARIN_$(6)OS_SDK)/Frameworks/Xamarin-debug.framework
-	$(Q) cp $$< $$@.tmp
-	$(Q) install_name_tool -id @rpath/$$(notdir $$@).framework/$$(notdir $$@) $$@.tmp
-	$(Q) install_name_tool -change @rpath/libmonosgen-2.0.dylib @rpath/Mono.framework/Mono $$@.tmp
-	$(Q) mv $$@.tmp $$@
+$(IOS_DESTDIR)$$(XAMARIN_$(6)OS_SDK)/Frameworks/Xamarin-debug.framework/Xamarin-debug: .libs/$(1)/Xamarin-debug-dev.framework | $(IOS_DESTDIR)$$(XAMARIN_$(6)OS_SDK)/Frameworks/Xamarin-debug.framework
+	$(Q) cp $$< $$@
 
 $(IOS_DESTDIR)$$(XAMARIN_$(6)OS_SDK)/Frameworks/%.framework/Info.plist: Xamarin.framework-$(1).Info.plist | $(IOS_DESTDIR)$$(XAMARIN_$(6)OS_SDK)/Frameworks/Xamarin.framework
 	$(Q) sed 's/@BUNDLE_EXECUTABLE@/$$*/' $$< > $$@
@@ -289,6 +277,30 @@ endif
 	$(Q) install_name_tool -id @rpath/libxamarin-debug.dylib $$@
 	$(Q) install_name_tool -change @rpath/ @rpath/libmonosgen-2.0.dylib $$@
 
+.libs/$(1)/Xamarin-dev.framework:  $$(foreach arch,$$($(2)_DEVICE_ARCHITECTURES),.libs/$(1)/Xamarin.$$(arch).framework)
+	$(Q) rm -f $$@
+ifeq (1,$$(words $$($(2)_DEVICE_ARCHITECTURES)))
+	$(Q) cp $$^ $$@
+else
+	$$(call Q_2,LIPO,  [$1]) $(DEVICE_BIN_PATH)/lipo $$^ -create -output $$@
+endif
+
+.libs/$(1)/Xamarin-debug-dev.framework:  $$(foreach arch,$$($(2)_DEVICE_ARCHITECTURES),.libs/$(1)/Xamarin-debug.$$(arch).framework)
+	$(Q) rm -f $$@
+ifeq (1,$$(words $$($(2)_DEVICE_ARCHITECTURES)))
+	$(Q) cp $$^ $$@
+else
+	$$(call Q_2,LIPO,  [$1]) $(DEVICE_BIN_PATH)/lipo $$^ -create -output $$@
+endif
+
+.libs/$(1)/Xamarin-sim.framework:  $$(foreach arch,$$($(2)_SIM_ARCHITECTURES),.libs/$(1)/Xamarin.$$(arch).framework)
+	$(Q) rm -f $$@
+	$$(call Q_2,LIPO,  [$1]) $(DEVICE_BIN_PATH)/lipo $$^ -create -output $$@
+
+.libs/$(1)/Xamarin-debug-sim.framework:  $$(foreach arch,$$($(2)_SIM_ARCHITECTURES),.libs/$(1)/Xamarin-debug.$$(arch).framework)
+	$(Q) rm -f $$@
+	$$(call Q_2,LIPO,  [$1]) $(DEVICE_BIN_PATH)/lipo $$^ -create -output $$@
+
 .SECONDARY: $$(foreach arch,$$($(2)_ARCHITECTURES),.libs/$(1)/app-main.$$(arch).o)
 endef
 
@@ -310,6 +322,7 @@ endef
 define LibXamarinTemplate
 
 $(1)$(3)_COMMON_DYLIB_FLAGS = -lmonosgen-2.0 -Wl,-install_name,libxamarin$(4).dylib -framework Foundation -framework CFNetwork -framework UIKit -lz
+$(1)$(3)_COMMON_FRAMEWORK_FLAGS = -framework Mono -Wl,-install_name,@rpath/Xamarin.framework/Xamarin -framework Foundation -framework CFNetwork -framework UIKit -lz
 
 x86_$(1)$(3)_OBJECTS    = $$(patsubst %,.libs/$(1)/%$(4).x86.o,$$($(2)_SOURCE_STEMS))    $$(patsubst %,.libs/$(1)/%$(4).x86.o,$$($(2)_I386_SOURCE_STEMS))
 x86_64_$(1)$(3)_OBJECTS = $$(patsubst %,.libs/$(1)/%$(4).x86_64.o,$$($(2)_SOURCE_STEMS)) $$(patsubst %,.libs/$(1)/%$(4).x86_64.o,$$($(2)_X86_64_SOURCE_STEMS))
@@ -341,6 +354,24 @@ $$(foreach arch,$$($(2)_ARCHITECTURES),$$(eval $$(call LibXamarinArchTemplate,$(
 
 .libs/$(1)/libxamarin$(4).armv7k.dylib: EXTRA_FLAGS=$$($(1)$(3)_COMMON_DYLIB_FLAGS)
 .libs/$(1)/libxamarin$(4).armv7k.dylib: $$(armv7k_$(1)$(3)_OBJECTS)
+
+.libs/$(1)/Xamarin$(4).x86.framework: EXTRA_FLAGS=$$($(1)$(3)_COMMON_FRAMEWORK_FLAGS)
+.libs/$(1)/Xamarin$(4).x86.framework: $$(x86_$(1)$(3)_OBJECTS)
+
+.libs/$(1)/Xamarin$(4).x86_64.framework: EXTRA_FLAGS=$$($(1)$(3)_COMMON_FRAMEWORK_FLAGS)
+.libs/$(1)/Xamarin$(4).x86_64.framework: $$(x86_64_$(1)$(3)_OBJECTS)
+
+.libs/$(1)/Xamarin$(4).armv7.framework: EXTRA_FLAGS=$$($(1)$(3)_COMMON_FRAMEWORK_FLAGS) -miphoneos-version-min=8.0
+.libs/$(1)/Xamarin$(4).armv7.framework: $$(armv7_$(1)$(3)_OBJECTS)
+
+.libs/$(1)/Xamarin$(4).armv7s.framework: EXTRA_FLAGS=$$($(1)$(3)_COMMON_FRAMEWORK_FLAGS) -miphoneos-version-min=8.0
+.libs/$(1)/Xamarin$(4).armv7s.framework: $$(armv7s_$(1)$(3)_OBJECTS)
+
+.libs/$(1)/Xamarin$(4).arm64.framework: EXTRA_FLAGS=$$($(1)$(3)_COMMON_FRAMEWORK_FLAGS)
+.libs/$(1)/Xamarin$(4).arm64.framework: $$(arm64_$(1)$(3)_OBJECTS)
+
+.libs/$(1)/Xamarin$(4).armv7k.framework: EXTRA_FLAGS=$$($(1)$(3)_COMMON_FRAMEWORK_FLAGS)
+.libs/$(1)/Xamarin$(4).armv7k.framework: $$(armv7k_$(1)$(3)_OBJECTS)
 endef
 
 $(eval $(call LibXamarinTemplate,ios,IOS))

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -1032,7 +1032,7 @@ namespace Xamarin.Bundler
 						break;
 					case AssemblyBuildTarget.Framework:
 						install_name = $"@rpath/{name}.framework/{name}";
-						compiler_output = Path.Combine (App.Cache.Location, arch, $"lib{name}.dylib"); // frameworks are almost identical to dylibs, so this is expected.
+						compiler_output = Path.Combine (App.Cache.Location, arch, name);
 						break;
 					default:
 						throw ErrorHelper.CreateError (100, "Invalid assembly build target: '{0}'. Please file a bug report with a test case (http://bugzilla.xamarin.com).", build_target);


### PR DESCRIPTION
Previously we copied any equivalent .dylib and ran install_name_tool on the
library to change the library id to make it a framework.

Unfortunately this does not work when the library contains bitcode, because
bitcode embeds linker flags (-install_name for instance), and
install_name_tool does not change those linker flags.

This means that we need to create frameworks by linking with the proper
arguments, since it's much more difficult to fixup the embedded bitcode linker
flags as well.

So change how be build Mono.framework, Xamarin.framework, and any frameworks
built from assemblies to:

* Always link instead of fixup a dylib. For Mono.framework this means
  extracting all the object files from libmonosgen-2.0.a and linking those,
  for Xamarin.framework this means linking the object files we've already
  built.

* Make sure the library is correctly named when linked (once again: bitcode
  contains embedded linker flags, so renaming the executable later breaks
  stuff as well).

I've also extracted the logic that creates Mono.framework from
libmonosgen-2.0.a to a separate shell script, to deduplicate this logic.

This required a minor change in the mono builds: we need the Mono.framework
when building the `all` target, so make sure that happens.

https://bugzilla.xamarin.com/show_bug.cgi?id=53813