### PR TITLE
[tests][mtouch] Fix MT0091 test after error text change.

### DIFF
--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -35,6 +35,39 @@ namespace Xamarin.Tests
 		public static bool include_watchos;
 		public static bool include_device;
 
+		// This is the location of an Xcode which is older than the recommended one.
+		public static string GetOldXcodeRoot (Version min_version = null)
+		{
+			var xcodes = Directory.GetDirectories ("/Applications", "Xcode*.app", SearchOption.TopDirectoryOnly);
+			var with_versions = new List<Tuple<Version, string>> ();
+
+			var max_version = Version.Parse (XcodeVersion);
+			foreach (var xcode in xcodes) {
+				var path = Path.Combine (xcode, "Contents", "Developer");
+				var version = Version.Parse (GetXcodeVersion (path));
+				if (version >= max_version)
+					continue;
+				if (min_version != null && version < min_version)
+					continue;
+				with_versions.Add (new Tuple<Version, string> (version, path));
+			}
+
+			if (with_versions.Count == 0)
+				return null;
+
+			with_versions.Sort ((x, y) =>
+			{
+				if (x.Item1 > y.Item1)
+					return -1;
+				else if (x.Item1 < y.Item1)
+					return 1;
+				else
+					return 0;
+			});
+
+			return with_versions [0].Item2; // return the most recent Xcode older than the recommended one.
+		}
+
 		// This is /Library/Frameworks/Xamarin.iOS.framework/Versions/Current if running
 		// against a system XI, otherwise it's the <git checkout>/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current directory.
 		public static string MonoTouchRootDirectory {
@@ -95,6 +128,28 @@ namespace Xamarin.Tests
 			return result;
 		}
 
+		static string GetXcodeVersion (string xcode_path)
+		{
+			var version_plist = Path.Combine (xcode_path, "..", "version.plist");
+			if (!File.Exists (version_plist))
+				return null;
+
+			return GetPListStringValue (version_plist, "CFBundleShortVersionString");
+		}
+
+		public static string GetPListStringValue (string plist, string key)
+		{
+			var settings = new System.Xml.XmlReaderSettings ();
+			settings.DtdProcessing = System.Xml.DtdProcessing.Ignore;
+			var doc = new System.Xml.XmlDocument ();
+			using (var fs = new FileStream (plist, FileMode.Open, FileAccess.Read)) {
+				using (var reader = System.Xml.XmlReader.Create (fs, settings)) {
+					doc.Load (reader);
+					return doc.DocumentElement.SelectSingleNode ($"//dict/key[text()='{key}']/following-sibling::string[1]/text()").Value;
+				}
+			}
+		}
+
 		static Configuration ()
 		{
 			ParseConfigFiles ();
@@ -114,18 +169,7 @@ namespace Xamarin.Tests
 			include_watchos = !string.IsNullOrEmpty (GetVariable ("INCLUDE_WATCH", ""));
 			include_device = !string.IsNullOrEmpty (GetVariable ("INCLUDE_DEVICE", ""));
 
-			var version_plist = Path.Combine (xcode_root, "..", "version.plist");
-			if (File.Exists (version_plist)) {
-				var settings = new System.Xml.XmlReaderSettings ();
-				settings.DtdProcessing = System.Xml.DtdProcessing.Ignore;
-				var doc = new System.Xml.XmlDocument ();
-				using (var fs = new FileStream (version_plist, FileMode.Open, FileAccess.Read)) {
-					using (var reader = System.Xml.XmlReader.Create (fs, settings)) {
-						doc.Load (reader);
-						XcodeVersion = doc.DocumentElement.SelectSingleNode ("//dict/key[text()='CFBundleShortVersionString']/following-sibling::string[1]/text()").Value;
-					}
-				}
-			}
+			XcodeVersion = GetXcodeVersion (xcode_root);
 #if MONOMAC
 			mac_xcode_root = xcode_root;
 #endif


### PR DESCRIPTION
Also fix the test to not depend on having a specific version of an older Xcode
installed, but instead use any old Xcode.