### PR TITLE
[tests][linkall] Make sure the compiler won't remove a field that triggers the inclusion of OpenTK-1.dll. Fixes #54466 (#1961)

### DIFF
--- a/tests/linker-ios/link all/LinkAllTest.cs
+++ b/tests/linker-ios/link all/LinkAllTest.cs
@@ -408,6 +408,8 @@ namespace LinkAll {
 		{
 			// that will bring OpenTK-1.0 into the .app
 			OpenTK.WindowState state = OpenTK.WindowState.Normal;
+			// Compiler optimization (roslyn release) can remove the variable, which removes OpenTK-1.dll from the app and fail the test
+			Assert.That (state, Is.EqualTo (OpenTK.WindowState.Normal), "normal");
 
 			var gl = Type.GetType ("OpenTK.Graphics.ES11.GL, OpenTK-1.0", false);
 			Assert.NotNull (gl, "ES11/GL");


### PR DESCRIPTION
Roslyn, when building in release, can remove unused fields. That broke
a test that ensure OpenTK types got preserved correctly (because the
assembly is not needed/included without that reference)

https://bugzilla.xamarin.com/show_bug.cgi?id=54466