### PR TITLE
[mtouch] Copy aot data to the app even for assemblies that aren't copied. Fixes #54499. (#1964)

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -34,6 +34,49 @@ namespace Xamarin
 	public class MTouch
 	{
 		[Test]
+		[TestCase ("armv7,arm64")]
+		public void AotDataTest (string abi)
+		{
+			AssertDeviceAvailable ();
+
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryApp ();
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.Abi = abi;
+				mtouch.DSym = false; // speeds up the test
+				mtouch.MSym = false; // speeds up the test
+				mtouch.AssertExecute (MTouchAction.BuildDev, "build");
+
+				var expectedFiles = new string []
+				{
+					"NOTICE",
+					"testApp",
+					"testApp.aotdata.armv7",
+					"testApp.aotdata.arm64",
+					"testApp.exe",
+					"mscorlib.dll",
+					"mscorlib.aotdata.armv7",
+					"mscorlib.aotdata.arm64",
+					"System.dll",
+					"System.aotdata.armv7",
+					"System.aotdata.arm64",
+					"Xamarin.iOS.dll",
+					"Xamarin.iOS.aotdata.armv7",
+					"Xamarin.iOS.aotdata.arm64",
+
+				};
+				var allFiles = Directory.GetFiles (mtouch.AppPath, "*", SearchOption.AllDirectories);
+				var failed = new List<string> ();
+				foreach (var expected in expectedFiles) {
+					if (allFiles.Any ((v) => v.EndsWith (expected, StringComparison.Ordinal)))
+						continue;
+					failed.Add (expected);
+				}
+				Assert.IsEmpty (failed, "expected files");
+			}
+		}
+
+		[Test]
 		[TestCase ("single", "",                   false)]
 		[TestCase ("dual",   "armv7,arm64", false)]
 		[TestCase ("llvm",   "armv7+llvm",  false)]

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1883,6 +1883,7 @@ namespace Xamarin.Bundler {
 					
 				foreach (var asm in target.Assemblies) {
 					asm.CopyToDirectory (tmpdir, reload: false, only_copy: true);
+					asm.CopyAotDataFilesToDirectory (tmpdir);
 				}
 				// mono-symbolicate knows best
 				CopyMSymData (target_directory, tmpdir);
@@ -1998,6 +1999,8 @@ namespace Xamarin.Bundler {
 					} else {
 						assemblies [0].CopyToDirectory (AppDirectory, copy_mdb: PackageMdb, strip: strip, only_copy: true);
 					}
+					foreach (var asm in assemblies)
+						asm.CopyAotDataFilesToDirectory (size_specific ? asm.Target.AppTargetDirectory : AppDirectory);
 					break;
 				case AssemblyBuildTarget.Framework:
 					// Put our resources in a subdirectory in the framework
@@ -2011,6 +2014,8 @@ namespace Xamarin.Bundler {
 					} else {
 						assemblies [0].CopyToDirectory (resource_directory, copy_mdb: PackageMdb, strip: strip, only_copy: true);
 					}
+					foreach (var asm in assemblies)
+						asm.CopyAotDataFilesToDirectory (size_specific ? Path.Combine (resource_directory, Path.GetFileName (asm.Target.AppTargetDirectory)) : resource_directory);
 					break;
 				default:
 					throw ErrorHelper.CreateError (100, "Invalid assembly build target: '{0}'. Please file a bug report with a test case (http://bugzilla.xamarin.com).", build_target);

--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -176,11 +176,14 @@ namespace Xamarin.Bundler {
 			}
 		}
 
-		// this will copy (and optionally strip) the assembly and all the related files:
+		// this will copy (and optionally strip) the assembly and almost all the related files:
 		// * debug file (.mdb)
 		// * config file (.config)
 		// * satellite assemblies (<language id>/.dll)
-		// * aot data
+		//
+		// Aot data is copied separately, because we might want to copy aot data 
+		// even if we don't want to copy the assembly (if 32/64-bit assemblies are identical, 
+		// only one is copied, but we still want the aotdata for both).
 		public void CopyToDirectory (string directory, bool reload = true, bool check_case = false, bool only_copy = false, bool copy_mdb = true, bool strip = false)
 		{
 			var target = Path.Combine (directory, FileName);
@@ -205,7 +208,10 @@ namespace Xamarin.Bundler {
 					FullPath = target;
 				}
 			}
+		}
 
+		public void CopyAotDataFilesToDirectory (string directory)
+		{
 			foreach (var aotdata in AotInfos.Values.SelectMany ((info) => info.AotDataFiles))
 				Application.UpdateFile (aotdata, Path.Combine (directory, Path.GetFileName (aotdata)));
 		}


### PR DESCRIPTION
We want to copy the aot data for both the 32-bit and the 64-bit versions of an
assembly even if the 32-bit and 64-bit versions of the assembly are identical.

https://bugzilla.xamarin.com/show_bug.cgi?id=54499