### PR TITLE
[builds] Improve mono/llvm dependencies. (#1948)

### DIFF
--- a/builds/.gitignore
+++ b/builds/.gitignore
@@ -1,4 +1,5 @@
 .stamp*
+.deps.*.mk
 *.config.cache
 install
 mac32

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -26,6 +26,20 @@ ifndef ENABLE_XM_BTLS
 XAMARIN_MAC_CONFIGURE_FLAGS += --disable-btls
 endif
 
+# this is a list of all the files from mono we care about, so that we
+# can use that list as dependencies for our makefile targets
+-include .deps.mono.mk
+.deps.mono.mk: $(TOP)/.git/modules/external/mono/HEAD
+	$(Q) printf 'MONO_DEPENDENCIES += Makefile \\\n' > $@.tmp
+	$(Q) cd $(MONO_PATH) && git ls-files 'mcs/class/*.cs' '*.h' '*.c' '*.cpp' | grep -v "/Test/" | sed 's/ /\\ /g' | sed 's@^\(.*\)$$@	$(MONO_PATH)/\1 \\@' >> $(abspath $@).tmp
+	$(Q) mv $@.tmp $@
+
+-include .deps.llvm.mk
+.deps.llvm.mk: $(TOP)/.git/modules/external/llvm/HEAD
+	$(Q) printf 'LLVM_DEPENDENCIES += Makefile \\\n' > $@.tmp
+	$(Q) cd $(LLVM_PATH) && git ls-files | grep -v "^test" | sed 's/ /\\ /g' | sed 's@^\(.*\)$$@	$(LLVM_PATH)/\1 \\@' >> $(abspath $@).tmp
+	$(Q) mv $@.tmp $@
+
 # ld: weak import of symbol '_fstatat' not supported because of option: -no_weak_imports for architecture x86_64
 # according to 'man fstatat' it appeared in OS X 10.10 (iOS 8)
 # so disable 'fstatat' by setting using ac_cv_func_fstatat=no
@@ -220,42 +234,29 @@ $(BUILD_DESTDIR)/mono-$(2): mono-wrapper.in .stamp-configure-$(2) | $(BUILD_DEST
 	$$(Q_GEN) sed < $$< > $$@ 's|@ARCH@|$(1)|g; s|@MONO@|$(realpath .)/$(2)/mono/mini/mono|g; s|@FRAMEWORK_ROOT@|$(abspath $(MAC_DESTDIR)/$$(MAC_FRAMEWORK_CURRENT_DIR))|g'
 	$$(Q) chmod +x $$@
 
-build-$(2): .stamp-configure-$(2) $(BUILD_DESTDIR)/mono-$(2)
+.stamp-build-$(2): .stamp-configure-$(2) $(BUILD_DESTDIR)/mono-$(2) $(MONO_DEPENDENCIES)
 	PATH="$(MONO_PREFIX)/bin:$(PATH)" $(MAKE) -C $(2)/eglib/src
 	PATH="$(MONO_PREFIX)/bin:$(PATH)" $(MAKE) -C $(2)/mono
 	PATH="$(MONO_PREFIX)/bin:$(PATH)" $(MAKE) -C $(2)/mono install
 	PATH="$(MONO_PREFIX)/bin:$(PATH)" $(MAKE) -C $(2)/support
+	$(Q) touch $$@
+
+build-$(2): .stamp-build-$(2)
 endef
 
 $(eval $(call MacBuildTemplate,i386,mac32))
 $(eval $(call MacBuildTemplate,x86_64,mac64))
 
+$(MONO_PATH)/mcs/class/lib/%: .stamp-build-tools64; @true
+
 define MacInstallBclTemplate
 
 MAC_DIRECTORIES += \
-	$$(BUILD_DESTDIR)/mac/$(2)/bcl/Facades \
-	$$(BUILD_DESTDIR)/mac/$(2)/bcl         \
+	$$(BUILD_DESTDIR)/bcl/$(2)/Facades \
+	$$(BUILD_DESTDIR)/bcl/$(2)         \
 
-# copy to temporary directory before signing,
-# otherwise we end up re-signing if installing into a different directory.
-$$(BUILD_DESTDIR)/mac/$(2)/bcl/Facades/%.dll: $$(MONO_PATH)/mcs/class/lib/$(2)/Facades/%.dll | $$(BUILD_DESTDIR)/mac/$(2)/bcl/Facades
-	@# sign the Facade assembly
-	$$(Q) cp $$< $$@
-	$$(Q_SN) MONO_CFG_DIR=$(TOP) $(SYSTEM_SN) -q -R $$@ $$(PRODUCT_KEY_PATH)
-
-$$(BUILD_DESTDIR)/mac/$(2)/bcl/%.dll: $$(MONO_PATH)/mcs/class/lib/$(2)/%.dll | $$(BUILD_DESTDIR)/mac/$(2)/bcl
-	@# sign the BCL assembly
-	$$(Q) cp $$< $$@
-	$$(Q_SN) MONO_CFG_DIR=$(TOP) $(SYSTEM_SN) -q -R $$@ $$(PRODUCT_KEY_PATH)
-
-$$(BUILD_DESTDIR)/mac/$(2)/bcl/%.pdb: $$(MONO_PATH)/mcs/class/lib/$(2)/%.pdb .stamp-build-tools64 | $$(BUILD_DESTDIR)/mac/$(2)/bcl
-	$$(Q) cp $$< $$@
-
-$$(MAC_DESTDIR)$$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/$(1)/%.dll: $$(BUILD_DESTDIR)/mac/$(2)/bcl/%.dll | $$(MAC_DESTDIR)$$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/$(1)/Facades
+$$(MAC_DESTDIR)$$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/$(1)/%: $$(BUILD_DESTDIR)/bcl/$(2)/% | $$(MAC_DESTDIR)$$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/$(1)/Facades
 	$$(Q) install -m 0755 $$< $$@
-
-$$(MAC_DESTDIR)$$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/$(1)/%.pdb: $$(BUILD_DESTDIR)/mac/$(2)/bcl/%.pdb | $$(MAC_DESTDIR)$$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/$(1)/Facades
-	$$(Q) install -m 0644 $$< $$@
 endef
 
 $(eval $(call MacInstallBclTemplate,Xamarin.Mac,xammac))
@@ -264,7 +265,7 @@ $(eval $(call MacInstallBclTemplate,4.5,xammac_net_4_5))
 $(MAC_DIRECTORIES) $(BUILD_DESTDIR):
 	$(Q) mkdir -p $@
 
-mac-facade-check:
+mac-facade-check: $(MAC_BCL_TARGETS)
 	$(Q) rm -f .$@*
 	$(Q) echo $(MAC_4_5_FACADE_ASSEMBLIES) | tr ' ' '\n' | sort > .$@1
 	$(Q) ls -1 $(MONO_PATH)/mcs/class/lib/xammac_net_4_5/Facades | grep dll$$ | sed 's/[.]dll//' | sort > .$@2
@@ -275,6 +276,8 @@ define lipo_template_static
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/$1: mac32/$(2)/.libs/$(1) mac64/$(2)/.libs/$(1) | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib
 	$(QT_LIPO) lipo -create $$+ -output $$@
 
+mac32/$(2)/.libs/$(1): .stamp-build-mac32
+mac64/$(2)/.libs/$(1): .stamp-build-mac64
 MAC_TARGETS += $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/$1
 endef
 
@@ -283,6 +286,8 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/$1: mac32/$(2)/.libs/$(1) mac64/$
 	$(QT_LIPO) lipo -create $$+ -output $$@
 	$(Q) install_name_tool -id @rpath/$1 $$@
 
+mac32/$(2)/.libs/$(1): .stamp-build-mac32
+mac64/$(2)/.libs/$(1): .stamp-build-mac64
 MAC_TARGETS += $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/$1
 endef
 
@@ -290,6 +295,10 @@ $(eval $(call lipo_template_static,libmono-profiler-log.a,mono/profiler))
 $(eval $(call lipo_template_static,libmonosgen-2.0.a,mono/mini))
 $(eval $(call lipo_template_dynamic,libmonosgen-2.0.dylib,mono/mini))
 $(eval $(call lipo_template_dynamic,libMonoPosixHelper.dylib,support))
+
+mac32/data/mono-2.pc: .stamp-build-mac32
+install/mac64/bin/mono-sgen: .stamp-build-mac64
+install/mac32/bin/mono-sgen: .stamp-build-mac32
 
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/libmono-2.0.dylib $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/libmono-2.0.a: | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib
 	$(Q_LN) ln -sf libmonosgen-2.0$(suffix $@) $@
@@ -310,8 +319,7 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_DIR)/Versions/Current:
 	$(Q_LN) ln -hfs $(MAC_INSTALL_VERSION) $(MAC_DESTDIR)$(MAC_FRAMEWORK_DIR)/Versions/Current
 
 build:: build-mac
-build-mac: build-mac32 build-mac64
-	$(MAKE) $(MAC_TARGETS)
+build-mac: $(MAC_TARGETS)
 
 install-local:: install-mac
 install-mac: $(MAC_TARGETS)
@@ -441,23 +449,14 @@ setup-tools64: .stamp-configure-tools64
 build-tools-bcl: build-tools64
 build-tools: build-tools64
 
-.stamp-build-tools64: .stamp-configure-tools64
+.stamp-build-tools64: .stamp-configure-tools64 $(MONO_DEPENDENCIES)
 	$(MAKE) -C tools64 all EXTERNAL_MCS=$(SYSTEM_MCS) EXTERNAL_RUNTIME=$(SYSTEM_MONO) MONOTOUCH_MCS_FLAGS=$(IOS_MCS_FLAGS) XAMMAC_MCS_FLAGS=$(MAC_MCS_FLAGS)
 	# NO_INSTALL is defined in mono/mcs/build/profiles except for net_4_5. If we don't have it, then it attempts to install into a gac, and sometimes fail
 	NO_INSTALL=1 $(MAKE) -C tools64 -j 1 install EXTERNAL_MCS=$(SYSTEM_MCS) EXTERNAL_RUNTIME=$(SYSTEM_MONO)
 	@touch .stamp-build-tools64
 
-build-tools64: .stamp-build-tools64
-ifdef INCLUDE_IOS
-	$(MAKE) $(IOS_BCL_TARGETS)
-endif
-ifdef INCLUDE_TVOS
-	$(MAKE) $(TVOS_BCL_TARGETS)
-endif
-	$(MAKE) $(MAC_BCL_TARGETS)
-
 clean-tools64:
-	rm -rf tools64 .stamp-configure-tools64 tools64.config.cache
+	rm -rf tools64 .stamp-*-tools64 tools64.config.cache
 	rm -f .stamp-build-tools64
 
 ifdef INCLUDE_WATCH
@@ -515,8 +514,6 @@ WATCHBCL_CONFIGURE_ENVIRONMENT = \
 	CC="$(MAC_CC)" \
 	CXX="$(MAC_CXX)" \
 
-tools:: build-watchbcl install-tools-watch
-
 ifdef INCLUDE_WATCH
 setup:: setup-watchbcl
 build:: build-watchbcl
@@ -535,20 +532,17 @@ endif
 build-tools-bcl: build-watchbcl
 build-tools: build-watchbcl
 
-build-watchbcl: .stamp-build-watchbcl
-	$(MAKE) $(WATCH_BCL_TARGETS)
-
 ifeq ($(WATCH_MONO_PATH),$(MONO_PATH))
-.stamp-build-watchbcl: .stamp-build-tools64
+.stamp-build-watchbcl: .stamp-build-tools64 $(MONO_DEPENDENCIES)
 else
-.stamp-build-watchbcl: .stamp-configure-watchbcl .stamp-build-tools64
+.stamp-build-watchbcl: .stamp-configure-watchbcl .stamp-build-tools64 $(MONO_DEPENDENCIES)
 	$(MAKE) -C watchbcl all EXTERNAL_MCS=$(SYSTEM_MCS) EXTERNAL_RUNTIME=$(SYSTEM_MONO)
 	$(MAKE) -C watchbcl install EXTERNAL_MCS=$(SYSTEM_MCS) EXTERNAL_RUNTIME=$(SYSTEM_MONO)
 endif
 	$(Q) touch $@
 
 clean-watchbcl:
-	rm -rf watchbcl .stamp-configure-watchbcl watchbcl.config.cache
+	rm -rf watchbcl .stamp-*-watchbcl watchbcl.config.cache
 
 #
 # Xamarin.iOS/WatchOS/TVOS BCL assemblies
@@ -579,24 +573,24 @@ WATCHOS_FACADE_ASSEMBLIES = $(IOS_FACADE_ASSEMBLIES)
 TVOS_REPL_ASSEMBLIES = $(IOS_REPL_ASSEMBLIES)
 WATCHOS_REPL_ASSEMBLIES = $(IOS_REPL_ASSEMBLIES)
 
-ios-facade-check:
+ios-facade-check: $(IOS_BCL_TARGETS)
 	$(Q) rm -f .$@*
 	$(Q) echo $(IOS_FACADE_ASSEMBLIES) | tr ' ' '\n' | sort > .$@1
 	$(Q) ls -1 $(MONO_PATH)/mcs/class/lib/monotouch/Facades | grep dll$$ | sed 's/[.]dll//' | sort > .$@2
 	$(Q) if ! diff -u .$@1 .$@2; then echo "\n*** There are Facade assemblies in "$(MONO_PATH)/mcs/class/lib/monotouch/Facades" not defined in "$(FACADE_SUBDIRS_MK)"***\n"; exit 1; fi
 	$(Q) rm -f .$@*
 
-watch-facade-check:
+watch-facade-check: $(WATCH_BCL_TARGETS)
 	@true
 
-disabled-watch-facade-check:
+disabled-watch-facade-check: $(WATCH_BCL_TARGETS)
 	$(Q) rm -f .$@*
 	$(Q) echo $(WATCHOS_FACADE_ASSEMBLIES) | tr ' ' '\n' | sort > .$@1
 	$(Q) ls -1 $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/Facades | grep dll$$ | sed 's/[.]dll//' | sort > .$@2
 	$(Q) if ! diff -u .$@1 .$@2; then echo "\n*** There are Facade assemblies in "$(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/Facades" not defined in "$(FACADE_SUBDIRS_MK)" ***\n"; exit 1; fi
 	$(Q) rm -f .$@*
 
-tvos-facade-check:
+tvos-facade-check: $(TVOS_BCL_TARGETS) 
 	$(Q) rm -f .$@*
 	$(Q) echo $(TVOS_FACADE_ASSEMBLIES) | tr ' ' '\n' | sort > .$@1
 	$(Q) ls -1 $(MONO_PATH)/mcs/class/lib/monotouch_tv/Facades | grep dll$$ | sed 's/[.]dll//' | sort > .$@2
@@ -612,25 +606,25 @@ IOS_BCL_TARGETS_DIRS +=                    \
 	$(PREFIX)/lib/mono/Xamarin.iOS/Facades \
 	$(PREFIX)/lib/mono/2.1/repl            \
 	$(PREFIX)/lib/mono/Xamarin.iOS/repl    \
-	$(BUILD_DESTDIR)/ios/bcl/Facades       \
-	$(BUILD_DESTDIR)/ios/bcl               \
-	$(BUILD_DESTDIR)/ios/bcl/repl          \
+	$(BUILD_DESTDIR)/bcl/monotouch         \
+	$(BUILD_DESTDIR)/bcl/monotouch/Facades \
+	$(BUILD_DESTDIR)/bcl/monotouch_runtime \
 
 WATCH_BCL_TARGETS_DIRS +=                      \
 	$(PREFIX)/lib/mono/Xamarin.WatchOS         \
 	$(PREFIX)/lib/mono/Xamarin.WatchOS/Facades \
 	$(PREFIX)/lib/mono/Xamarin.WatchOS/repl    \
-	$(BUILD_DESTDIR)/watchos/bcl/Facades       \
-	$(BUILD_DESTDIR)/watchos/bcl               \
-	$(BUILD_DESTDIR)/watchos/bcl/repl          \
+	$(BUILD_DESTDIR)/bcl/monotouch_watch         \
+	$(BUILD_DESTDIR)/bcl/monotouch_watch/Facades \
+	$(BUILD_DESTDIR)/bcl/monotouch_watch_runtime \
 
 TVOS_BCL_TARGETS_DIRS +=                    \
 	$(PREFIX)/lib/mono/Xamarin.TVOS         \
 	$(PREFIX)/lib/mono/Xamarin.TVOS/Facades \
 	$(PREFIX)/lib/mono/Xamarin.TVOS/repl    \
-	$(BUILD_DESTDIR)/tvos/bcl/Facades       \
-	$(BUILD_DESTDIR)/tvos/bcl               \
-	$(BUILD_DESTDIR)/tvos/bcl/repl          \
+	$(BUILD_DESTDIR)/bcl/monotouch_tv         \
+	$(BUILD_DESTDIR)/bcl/monotouch_tv/Facades \
+	$(BUILD_DESTDIR)/bcl/monotouch_tv_runtime \
 
 IOS_BCL_TARGETS +=                                                                                                  \
 	$(foreach file,$(IOS_ASSEMBLIES),$(PREFIX)/lib/mono/2.1/$(file).dll)                                                \
@@ -674,49 +668,34 @@ ifndef IKVM
 TVOS_BCL_TARGETS += $(PREFIX)/bin/btv-mono
 endif
 
-$(PREFIX)/lib/mono/Xamarin.iOS/%.pdb: $(BUILD_DESTDIR)/ios/bcl/%.pdb | $(PREFIX)/lib/mono/Xamarin.iOS $(PREFIX)/lib/mono/Xamarin.iOS/repl
+$(PREFIX)/lib/mono/Xamarin.iOS/repl/%: $(BUILD_DESTDIR)/bcl/monotouch_runtime/% | $(PREFIX)/lib/mono/Xamarin.iOS/repl
+	$(Q) install -m 0755 $< $@
+
+$(PREFIX)/lib/mono/Xamarin.iOS/%: $(BUILD_DESTDIR)/bcl/monotouch/% | $(PREFIX)/lib/mono/Xamarin.iOS $(PREFIX)/lib/mono/Xamarin.iOS/Facades
 	$(Q) install -m 0644 $< $@
 
-$(PREFIX)/lib/mono/Xamarin.iOS/Facades/%.dll: $(BUILD_DESTDIR)/ios/bcl/Facades/%.dll | $(PREFIX)/lib/mono/Xamarin.iOS/Facades
+$(PREFIX)/lib/mono/2.1/repl/%: $(BUILD_DESTDIR)/bcl/monotouch_runtime/% | $(PREFIX)/lib/mono/2.1/repl
 	$(Q) install -m 0755 $< $@
 
-$(PREFIX)/lib/mono/Xamarin.iOS/%.dll: $(BUILD_DESTDIR)/ios/bcl/%.dll | $(PREFIX)/lib/mono/Xamarin.iOS $(PREFIX)/lib/mono/Xamarin.iOS/repl
+$(PREFIX)/lib/mono/2.1/%: $(BUILD_DESTDIR)/bcl/monotouch/% | $(PREFIX)/lib/mono/2.1 $(PREFIX)/lib/mono/2.1/Facades
 	$(Q) install -m 0755 $< $@
-
-$(PREFIX)/lib/mono/Xamarin.iOS/repl/%: | $(PREFIX)/lib/mono/Xamarin.iOS/repl
-	$(Q) install -m 0755 $< $@
-
-$(PREFIX)/lib/mono/2.1/Facades/%.dll: $(BUILD_DESTDIR)/ios/bcl/Facades/%.dll | $(PREFIX)/lib/mono/2.1/Facades
-	$(Q) install -m 0755 $< $@
-
-$(PREFIX)/lib/mono/2.1/%.dll: $(BUILD_DESTDIR)/ios/bcl/%.dll | $(PREFIX)/lib/mono/2.1 $(PREFIX)/lib/mono/2.1/repl
-	$(Q) install -m 0755 $< $@
-
-$(PREFIX)/lib/mono/2.1/%.pdb: $(BUILD_DESTDIR)/ios/bcl/%.pdb | $(PREFIX)/lib/mono/2.1 $(PREFIX)/lib/mono/2.1/repl
-	$(Q) install -m 0644 $< $@
 
 ifndef IKVM
 $(PREFIX)/bin/btouch-mono: $(BUILD_DESTDIR)/tools64/bin/mono | $(PREFIX)/bin
 	$(Q) install -s -m 0755 $< $@
 endif
 
-$(PREFIX)/lib/mono/Xamarin.WatchOS/Facades/%.dll: $(BUILD_DESTDIR)/watchos/bcl/Facades/%.dll | $(PREFIX)/lib/mono/Xamarin.WatchOS/Facades
+$(PREFIX)/lib/mono/Xamarin.WatchOS/repl/%: $(BUILD_DESTDIR)/bcl/monotouch_watch_runtime/% | $(PREFIX)/lib/mono/Xamarin.WatchOS/repl
 	$(Q) install -m 0755 $< $@
 
-$(PREFIX)/lib/mono/Xamarin.WatchOS/%.dll: $(BUILD_DESTDIR)/watchos/bcl/%.dll | $(PREFIX)/lib/mono/Xamarin.WatchOS $(PREFIX)/lib/mono/Xamarin.WatchOS/repl
+$(PREFIX)/lib/mono/Xamarin.WatchOS/%: $(BUILD_DESTDIR)/bcl/monotouch_watch/% | $(PREFIX)/lib/mono/Xamarin.WatchOS $(PREFIX)/lib/mono/Xamarin.WatchOS/Facades
 	$(Q) install -m 0755 $< $@
 
-$(PREFIX)/lib/mono/Xamarin.WatchOS/%.pdb: $(BUILD_DESTDIR)/watchos/bcl/%.pdb | $(PREFIX)/lib/mono/Xamarin.WatchOS $(PREFIX)/lib/mono/Xamarin.WatchOS/repl
-	$(Q) install -m 0644 $< $@
-
-$(PREFIX)/lib/mono/Xamarin.TVOS/Facades/%.dll: $(BUILD_DESTDIR)/tvos/bcl/Facades/%.dll | $(PREFIX)/lib/mono/Xamarin.TVOS/Facades
+$(PREFIX)/lib/mono/Xamarin.TVOS/repl/%: $(BUILD_DESTDIR)/bcl/monotouch_tv_runtime/% | $(PREFIX)/lib/mono/Xamarin.TVOS/repl
 	$(Q) install -m 0755 $< $@
 
-$(PREFIX)/lib/mono/Xamarin.TVOS/%.dll: $(BUILD_DESTDIR)/tvos/bcl/%.dll | $(PREFIX)/lib/mono/Xamarin.TVOS $(PREFIX)/lib/mono/Xamarin.TVOS/repl
+$(PREFIX)/lib/mono/Xamarin.TVOS/%: $(BUILD_DESTDIR)/bcl/monotouch_tv/% | $(PREFIX)/lib/mono/Xamarin.TVOS $(PREFIX)/lib/mono/Xamarin.TVOS/Facades
 	$(Q) install -m 0755 $< $@
-
-$(PREFIX)/lib/mono/Xamarin.TVOS/%.pdb: $(BUILD_DESTDIR)/tvos/bcl/%.pdb | $(PREFIX)/lib/mono/Xamarin.TVOS $(PREFIX)/lib/mono/Xamarin.TVOS/repl
-	$(Q) install -m 0644 $< $@
 
 ifndef IKVM
 $(PREFIX)/bin/btv-mono: $(BUILD_DESTDIR)/tools64/bin/mono | $(PREFIX)/bin
@@ -732,104 +711,67 @@ endif
 
 # copy to temporary directory before signing
 # otherwise we end up re-signing if installing into a different directory.
-$(BUILD_DESTDIR)/ios/bcl/Facades/%.dll: $(MONO_PATH)/mcs/class/lib/monotouch/Facades/%.dll | $(BUILD_DESTDIR)/ios/bcl/Facades
-	@# sign the Facade assembly
+
+TMP_BCL_TARGET_DIRS = \
+	$(BUILD_DESTDIR)/bcl/monotouch \
+	$(BUILD_DESTDIR)/bcl/monotouch/Facades \
+	$(BUILD_DESTDIR)/bcl/monotouch_runtime \
+	$(BUILD_DESTDIR)/bcl/monotouch_tv \
+	$(BUILD_DESTDIR)/bcl/monotouch_tv/Facades \
+	$(BUILD_DESTDIR)/bcl/monotouch_tv_runtime \
+	$(BUILD_DESTDIR)/bcl/monotouch_watch \
+	$(BUILD_DESTDIR)/bcl/monotouch_watch/Facades \
+	$(BUILD_DESTDIR)/bcl/monotouch_watch_runtime \
+	$(BUILD_DESTDIR)/bcl/xammac \
+	$(BUILD_DESTDIR)/bcl/xammac/Facades \
+	$(BUILD_DESTDIR)/bcl/xammac_net_4_5 \
+	$(BUILD_DESTDIR)/bcl/xammac_net_4_5/Facades \
+
+$(BUILD_DESTDIR)/bcl/%.dll: $(MONO_PATH)/mcs/class/lib/%.dll | $(TMP_BCL_TARGET_DIRS)
 	$(Q) cp $< $@
 	$(Q_SN) MONO_CFG_DIR=$(TOP) $(SYSTEM_SN) -q -R $@ $(PRODUCT_KEY_PATH)
 
-$(BUILD_DESTDIR)/ios/bcl/%.dll: $(MONO_PATH)/mcs/class/lib/monotouch/%.dll | $(BUILD_DESTDIR)/ios/bcl
-	@# sign the BCL assembly
-	$(Q) cp $< $@
-	$(Q_SN) MONO_CFG_DIR=$(TOP) $(SYSTEM_SN) -q -R $@ $(PRODUCT_KEY_PATH)
-
-$(BUILD_DESTDIR)/ios/bcl/repl/%.dll: $(MONO_PATH)/mcs/class/lib/monotouch_runtime/%.dll | $(BUILD_DESTDIR)/ios/bcl/repl
-	@# sign the BCL assembly
-	$(Q) cp $< $@
-	$(Q_SN) MONO_CFG_DIR=$(TOP) $(SYSTEM_SN) -q -R $@ $(PRODUCT_KEY_PATH)
-
-$(BUILD_DESTDIR)/ios/bcl/%.pdb: $(MONO_PATH)/mcs/class/lib/monotouch/%.pdb .stamp-build-tools64 | $(BUILD_DESTDIR)/ios/bcl
-	$(Q) cp $< $@
-
-$(BUILD_DESTDIR)/ios/bcl/repl/%.pdb: $(MONO_PATH)/mcs/class/lib/monotouch_runtime/%.pdb .stamp-build-tools64 | $(BUILD_DESTDIR)/ios/bcl/repl
-	$(Q) cp $< $@
-
-$(BUILD_DESTDIR)/watchos/bcl/Facades/%.dll: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/Facades/%.dll | $(BUILD_DESTDIR)/watchos/bcl/Facades
-	@# sign the Facade assembly
-	$(Q) cp $< $@
-	$(Q_SN) MONO_CFG_DIR=$(TOP) $(SYSTEM_SN) -q -R $@ $(PRODUCT_KEY_PATH)
-
-$(BUILD_DESTDIR)/watchos/bcl/%.dll: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/%.dll | $(BUILD_DESTDIR)/watchos/bcl
-	@# sign the BCL assembly
-	$(Q) cp $< $@
-	$(Q_SN) MONO_CFG_DIR=$(TOP) $(SYSTEM_SN) -q -R $@ $(PRODUCT_KEY_PATH)
-
-$(BUILD_DESTDIR)/watchos/bcl/repl/%.dll: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch_runtime/%.dll | $(BUILD_DESTDIR)/watchos/bcl/repl
-	@# sign the BCL assembly
-	$(Q) cp $< $@
-	$(Q_SN) MONO_CFG_DIR=$(TOP) $(SYSTEM_SN) -q -R $@ $(PRODUCT_KEY_PATH)
-
-$(BUILD_DESTDIR)/watchos/bcl/%.pdb: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/%.pdb .stamp-build-watchbcl .stamp-build-tools64 | $(BUILD_DESTDIR)/watchos/bcl
-	$(Q) cp $< $@
-
-$(BUILD_DESTDIR)/watchos/bcl/repl/%.pdb: $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch_runtime/%.pdb .stamp-build-watchbcl .stamp-build-tools64 | $(BUILD_DESTDIR)/watchos/bcl/repl
-	$(Q) cp $< $@
-
-$(BUILD_DESTDIR)/tvos/bcl/Facades/%.dll: $(MONO_PATH)/mcs/class/lib/monotouch_tv/Facades/%.dll | $(BUILD_DESTDIR)/tvos/bcl/Facades
-	@# sign the Facade assembly
-	$(Q) cp $< $@
-	$(Q_SN) MONO_CFG_DIR=$(TOP) $(SYSTEM_SN) -q -R $@ $(PRODUCT_KEY_PATH)
-
-$(BUILD_DESTDIR)/tvos/bcl/%.dll: $(MONO_PATH)/mcs/class/lib/monotouch_tv/%.dll | $(BUILD_DESTDIR)/tvos/bcl
-	@# sign the BCL assembly
-	$(Q) cp $< $@
-	$(Q_SN) MONO_CFG_DIR=$(TOP) $(SYSTEM_SN) -q -R $@ $(PRODUCT_KEY_PATH)
-
-$(BUILD_DESTDIR)/tvos/bcl/repl/%.dll: $(MONO_PATH)/mcs/class/lib/monotouch_tv_runtime/%.dll | $(BUILD_DESTDIR)/tvos/bcl/repl
-	@# sign the BCL assembly
-	$(Q) cp $< $@
-	$(Q_SN) MONO_CFG_DIR=$(TOP) $(SYSTEM_SN) -q -R $@ $(PRODUCT_KEY_PATH)
-
-$(BUILD_DESTDIR)/tvos/bcl/%.pdb: $(MONO_PATH)/mcs/class/lib/monotouch_tv/%.pdb .stamp-build-tools64 | $(BUILD_DESTDIR)/tvos/bcl
-	$(Q) cp $< $@
-
-$(BUILD_DESTDIR)/tvos/bcl/repl/%.pdb: $(MONO_PATH)/mcs/class/lib/monotouch_tv_runtime/%.pdb .stamp-build-tools64 | $(BUILD_DESTDIR)/tvos/bcl/repl
+$(BUILD_DESTDIR)/bcl/%.pdb: $(MONO_PATH)/mcs/class/lib/%.pdb | $(TMP_BCL_TARGET_DIRS)
 	$(Q) cp $< $@
 
 $(IOS_BCL_TARGETS_DIRS) $(WATCH_BCL_TARGETS_DIRS) $(TVOS_BCL_TARGETS_DIRS):
 	$(Q) mkdir -p $@
 
-.SECONDARY: $(foreach file,$(IOS_FACADE_ASSEMBLIES),$(BUILD_DESTDIR)/ios/bcl/Facades/$(file).dll) $(foreach file,$(IOS_ASSEMBLIES),$(BUILD_DESTDIR)/ios/bcl/$(file).pdb) $(foreach file,$(IOS_ASSEMBLIES),$(BUILD_DESTDIR)/ios/bcl/$(file).dll)
-.SECONDARY: \
-	$(foreach file,$(MAC_FACADE_ASSEMBLIES),$(BUILD_DESTDIR)/mac/xammac/bcl/Facades/$(file).dll) \
-	$(foreach file,$(MAC_ASSEMBLIES),$(BUILD_DESTDIR)/mac/xammac/bcl/$(file).pdb) \
-	$(foreach file,$(MAC_ASSEMBLIES),$(BUILD_DESTDIR)/mac/xammac/bcl/$(file).dll) \
-	$(foreach file,$(MAC_FACADE_ASSEMBLIES),$(BUILD_DESTDIR)/mac/net_4_5/bcl/Facades/$(file).dll) \
-	$(foreach file,$(MAC_4_5_ASSEMBLIES),$(BUILD_DESTDIR)/mac/net_4_5/bcl/$(file).pdb) \
-	$(foreach file,$(MAC_4_5_ASSEMBLIES),$(BUILD_DESTDIR)/mac/net_4_5/bcl/$(file).dll) \
+# Keep all intermediate files always.
+.SECONDARY:
 
-.SECONDARY: \
-	$(foreach file,$(WATCHOS_FACADE_ASSEMBLIES),$(BUILD_DESTDIR)/watchos/bcl/Facades/$(file).dll)    \
-	$(foreach file,$(WATCHOS_ASSEMBLIES),$(BUILD_DESTDIR)/watchos/bcl/$(file).pdb)               \
-	$(foreach file,$(WATCHOS_ASSEMBLIES),$(BUILD_DESTDIR)/watchos/bcl/$(file).dll)                   \
-	$(foreach file,$(WATCHOS_REPL_ASSEMBLIES),$(BUILD_DESTDIR)/watchos/bcl/repl/$(file).dll)         \
-	$(foreach file,$(WATCHOS_REPL_ASSEMBLIES),$(BUILD_DESTDIR)/watchos/bcl/repl/$(file).pdb)     \
-	$(foreach file,$(TVOS_FACADE_ASSEMBLIES),$(BUILD_DESTDIR)/tvos/bcl/Facades/$(file).dll)          \
-	$(foreach file,$(TVOS_ASSEMBLIES),$(BUILD_DESTDIR)/tvos/bcl/$(file).pdb)                     \
-	$(foreach file,$(TVOS_ASSEMBLIES),$(BUILD_DESTDIR)/tvos/bcl/$(file).dll)                         \
-	$(foreach file,$(TVOS_REPL_ASSEMBLIES),$(BUILD_DESTDIR)/tvos/bcl/repl/$(file).dll)               \
-	$(foreach file,$(TVOS_REPL_ASSEMBLIES),$(BUILD_DESTDIR)/tvos/bcl/repl/$(file).pdb)           \
+install-tools-tvos: $(TVOS_BCL_TARGETS) tvos-facade-check
+	@true
 
-install-tools-tvos: $(TVOS_BCL_TARGETS)
-	$(Q) $(MAKE) tvos-facade-check
+install-tools-watch: $(WATCH_BCL_TARGETS) watch-facade-check
+	@true
 
-install-tools-watch: $(WATCH_BCL_TARGETS)
-	$(Q) $(MAKE) watch-facade-check
+install-tools-ios: $(IOS_BCL_TARGETS) ios-facade-check
+	@true
 
-install-tools-ios: $(IOS_BCL_TARGETS)
-	$(Q) $(MAKE) ios-facade-check
+install-tools-mac: $(MAC_BCL_TARGETS) mac-facade-check
+	@true
 
-install-tools-mac: $(MAC_BCL_TARGETS)
-	$(Q) $(MAKE) mac-facade-check
+build-watchbcl: $(WATCH_BCL_TARGETS)
+	@true
+
+$(IOS_BCL_TARGETS): .stamp-build-tools64
+$(TVOS_BCL_TARGETS): .stamp-build-tools64
+$(MAC_BCL_TARGETS): .stamp-build-tools64
+$(WATCH_BCL_TARGETS): .stamp-build-tools64
+
+ifdef INCLUDE_IOS
+build-tools64: $(IOS_BCL_TARGETS)
+endif
+ifdef INCLUDE_TVOS
+build-tools64: $(TVOS_BCL_TARGETS)
+endif
+ifdef INCLUDE_WATCH
+build-tools64: $(WATCH_BCL_TARGETS)
+endif
+
+build-tools64: $(MAC_BCL_TARGETS)
+	@true
 
 verify-signature:
 	for file in $(PREFIX)/lib/mono/2.1/*.dll; do \
@@ -902,15 +844,18 @@ setup-$(2): .stamp-configure-$(2)
 .stamp-configure-$(2): $(MONO_PATH)/configure
 	$(Q) $(SIM$(2)_CONFIGURE_ENVIRONMENT) ./wrap-configure.sh $(2) $(abspath $(MONO_PATH)/configure) $(SIM$(2)_CONFIGURE_FLAGS)
 
-build-$(2): .stamp-configure-$(2)
+.stamp-build-$(2): .stamp-configure-$(2) $(MONO_DEPENDENCIES)
 	PATH="$(SIM_BIN):$(PATH)" $(MAKE) -C $(2)/eglib all
 	PATH="$(SIM_BIN):$(PATH)" $(MAKE) -C $(2)/mono all
 	PATH="$(SIM_BIN):$(PATH)" $(MAKE) -C $(2)/support all
 	PATH="$(SIM_BIN):$(PATH)" $(MAKE) -C $(2)/eglib install
 	PATH="$(SIM_BIN):$(PATH)" $(MAKE) -C $(2)/mono install
+	$(Q) touch $$@
+
+build-$(2): .stamp-build-$(2)
 
 clean-$(2):
-	-rm -rf $(2) .stamp-configure-$(2) $(2).config.cache
+	-rm -rf $(2) .stamp-*-$(2) $(2).config.cache
 
 setup-iphonesimulator:: setup-$(2)
 build-iphonesimulator:: build-$(2)
@@ -920,6 +865,11 @@ $(eval SIM_TARGET_LIBMONOSGEN:=$(SIM_TARGET_LIBMONOSGEN) $(BUILD_DESTDIR)/$(2)/l
 $(eval SIM_TARGET_SHAREDMONOSGEN:=$(SIM_TARGET_SHAREDMONOSGEN) $(BUILD_DESTDIR)/$(2)/lib/libmonosgen-2.0.dylib)
 $(eval SIM_TARGET_LIBLOGPROFILER:=$(SIM_TARGET_LIBLOGPROFILER) $(BUILD_DESTDIR)/$(2)/lib/libmono-profiler-log-static.a)
 $(eval SIM_TARGET_SHAREDLIBLOGPROFILER:=$(SIM_TARGET_SHAREDLIBLOGPROFILER) $(BUILD_DESTDIR)/$(2)/tmp-lib/libmono-profiler-log.0.dylib)
+
+$(BUILD_DESTDIR)/$(2)/lib/libmonosgen-2.0.a: .stamp-build-$(2)
+$(BUILD_DESTDIR)/$(2)/lib/libmonosgen-2.0.dylib: .stamp-build-$(2)
+$(BUILD_DESTDIR)/$(2)/lib/libmono-profiler-log-static.a: .stamp-build-$(2)
+$(BUILD_DESTDIR)/$(2)/lib/libmono-profiler-log.0.dylib: .stamp-build-$(2)
 
 $(BUILD_DESTDIR)/$(2)/tmp-lib/libmono-profiler-log.0.dylib: $(BUILD_DESTDIR)/$(2)/lib/libmono-profiler-log.0.dylib | $(BUILD_DESTDIR)/$(2)/tmp-lib
 	$(Q) cp $$< $$@
@@ -1065,22 +1015,30 @@ setup-watchsimulator: .stamp-configure-watchsimulator
 .stamp-configure-watchsimulator: $(WATCH_MONO_PATH)/configure
 	$(Q) $(WATCHSIMULATOR_ENVIRONMENT) ./wrap-configure.sh watchsimulator $(abspath $(WATCH_MONO_PATH)/configure) $(WATCHSIMULATOR_CONFIGURE_FLAGS)
 
-build-watchsimulator: export DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT)
-build-watchsimulator: export PATH:="$(WATCHSIMULATOR_BIN_PATH):$(PATH)"
-build-watchsimulator: .stamp-configure-watchsimulator
+.stamp-build-watchsimulator: export DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT)
+.stamp-build-watchsimulator: export PATH:="$(WATCHSIMULATOR_BIN_PATH):$(PATH)"
+.stamp-build-watchsimulator: .stamp-configure-watchsimulator $(MONO_DEPENDENCIES)
 	$(Q) $(MAKE) -C watchsimulator/eglib all
 	$(Q) $(MAKE) -C watchsimulator/mono all
 	$(Q) $(MAKE) -C watchsimulator/support all
 	$(Q) $(MAKE) -C watchsimulator/eglib install
 	$(Q) $(MAKE) -C watchsimulator/mono install
+	$(Q) touch $@
+
+build-watchsimulator: .stamp-build-watchsimulator
 
 clean-watchsimulator:
-	$(Q) rm -rf watchsimulator .stamp-configure-watchsimulator watchsimulator.config.cache
+	$(Q) rm -rf watchsimulator .stamp-*-watchsimulator watchsimulator.config.cache
 
 WATCHSIMULATOR_LIBMONOSGEN          = $(BUILD_DESTDIR)/watchsimulator/lib/libmonosgen-2.0.a
 WATCHSIMULATOR_SHAREDMONOSGEN       = $(BUILD_DESTDIR)/watchsimulator/lib/libmonosgen-2.0.dylib
 WATCHSIMULATOR_LIBLOGPROFILER       = $(BUILD_DESTDIR)/watchsimulator/lib/libmono-profiler-log-static.a
 WATCHSIMULATOR_SHAREDLIBLOGPROFILER = $(BUILD_DESTDIR)/watchsimulator/lib/libmono-profiler-log.0.dylib
+
+$(WATCHSIMULATOR_LIBMONOSGEN): .stamp-build-watchsimulator
+$(WATCHSIMULATOR_SHAREDMONOSGEN): .stamp-build-watchsimulator
+$(WATCHSIMULATOR_LIBLOGPROFILER): .stamp-build-watchsimulator
+$(WATCHSIMULATOR_SHAREDLIBLOGPROFILER): .stamp-build-watchsimulator
 
 WATCHSIMULATOR_TARGETS = \
 	$(IOS_DESTDIR)$(XAMARIN_WATCHSIMULATOR_SDK)/usr/lib/libmonosgen-2.0.a            \
@@ -1204,22 +1162,30 @@ setup-tvsimulator: .stamp-configure-tvsimulator
 .stamp-configure-tvsimulator: $(MONO_PATH)/configure
 	$(Q) $(TVSIMULATOR_ENVIRONMENT) ./wrap-configure.sh tvsimulator $(abspath $(MONO_PATH)/configure) $(TVSIMULATOR_CONFIGURE_FLAGS)
 
-build-tvsimulator: export DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT)
-build-tvsimulator: export PATH:="$(TVSIMULATOR_BIN_PATH):$(PATH)"
-build-tvsimulator: .stamp-configure-tvsimulator
+.stamp-build-tvsimulator: export DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT)
+.stamp-build-tvsimulator: export PATH:="$(TVSIMULATOR_BIN_PATH):$(PATH)"
+.stamp-build-tvsimulator: .stamp-configure-tvsimulator $(MONO_DEPENDENCIES)
 	$(Q) $(MAKE) -C tvsimulator/eglib all
 	$(Q) $(MAKE) -C tvsimulator/mono all
 	$(Q) $(MAKE) -C tvsimulator/support all
 	$(Q) $(MAKE) -C tvsimulator/eglib install
 	$(Q) $(MAKE) -C tvsimulator/mono install
+	$(Q) touch $@
+
+build-tvsimulator: .stamp-build-tvsimulator
 
 clean-tvsimulator:
-	$(Q) rm -rf tvsimulator .stamp-configure-tvsimulator tvsimulator.config.cache
+	$(Q) rm -rf tvsimulator .stamp-*-tvsimulator tvsimulator.config.cache
 
 TVSIMULATOR_LIBMONOSGEN          = $(BUILD_DESTDIR)/tvsimulator/lib/libmonosgen-2.0.a
 TVSIMULATOR_SHAREDMONOSGEN       = $(BUILD_DESTDIR)/tvsimulator/lib/libmonosgen-2.0.dylib
 TVSIMULATOR_LIBLOGPROFILER       = $(BUILD_DESTDIR)/tvsimulator/lib/libmono-profiler-log-static.a
 TVSIMULATOR_SHAREDLIBLOGPROFILER = $(BUILD_DESTDIR)/tvsimulator/lib/libmono-profiler-log.0.dylib
+
+$(TVSIMULATOR_LIBMONOSGEN): .stamp-build-tvsimulator
+$(TVSIMULATOR_SHAREDMONOSGEN): .stamp-build-tvsimulator
+$(TVSIMULATOR_LIBLOGPROFILER): .stamp-build-tvsimulator
+$(TVSIMULATOR_SHAREDLIBLOGPROFILER): .stamp-build-tvsimulator
 
 TVSIMULATOR_TARGETS = \
 	$(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/usr/lib/libmonosgen-2.0.a            \
@@ -1341,14 +1307,17 @@ setup-$(2): .stamp-configure-$(2)
 .stamp-configure-$(2): $(MONO_PATH)/configure
 	$(Q) $($(2)_ACVARS) $($(2)_CONFIGURE_ENVIRONMENT) ./wrap-configure.sh $(2) $(abspath $(MONO_PATH)/configure) $($(2)_CONFIGURE_FLAGS)
 
-build-$(2): .stamp-configure-$(2)
+.stamp-build-$(2): .stamp-configure-$(2) $(MONO_DEPENDENCIES)
 	PATH="$(PLATFORM_BIN):$(PATH)" $(MAKE) -C $(2)/eglib
 	PATH="$(PLATFORM_BIN):$(PATH)" $(MAKE) -C $(2)/mono
 	PATH="$(PLATFORM_BIN):$(PATH)" $(MAKE) -C $(2)/eglib install
 	PATH="$(PLATFORM_BIN):$(PATH)" $(MAKE) -C $(2)/mono install
+	$(Q) touch $$@
+
+build-$(2): .stamp-build-$(2)
 
 clean-$(2):
-	-rm -rf $(2) .stamp-configure-$(2) $(2).config.cache
+	-rm -rf $(2) .stamp-*-$(2) $(2).config.cache
 
 setup-iphoneos:: setup-$(2)
 build-iphoneos:: build-$(2)
@@ -1364,6 +1333,10 @@ $(eval TARGET_SHAREDMONOSGEN:=$(TARGET_SHAREDMONOSGEN) $(BUILD_DESTDIR)/$(2)/tmp
 $(eval TARGET_LIBLOGPROFILER:=$(TARGET_LIBLOGPROFILER) $(BUILD_DESTDIR)/$(2)/lib/libmono-profiler-log-static.a)
 $(eval TARGET_SHAREDLIBLOGPROFILER:=$(TARGET_SHAREDLIBLOGPROFILER) $(BUILD_DESTDIR)/$(2)/tmp-lib/libmono-profiler-log.0.dylib)
 $(eval TARGET_MONOFRAMEWORK:=$(TARGET_MONOFRAMEWORK) $(BUILD_DESTDIR)/$(2)/tmp-lib/Mono)
+
+$(BUILD_DESTDIR)/$(2)/lib/libmonosgen-2.0.a: .stamp-build-$(2)
+$(BUILD_DESTDIR)/$(2)/lib/libmono-profiler-log-static.a: .stamp-build-$(2)
+$(BUILD_DESTDIR)/$(2)/lib/libmono-profiler-log.a: .stamp-build-$(2)
 
 $(BUILD_DESTDIR)/$(2)/tmp-lib:
 	$$(Q) mkdir -p $$@
@@ -1585,16 +1558,19 @@ setup-targetwatch: .stamp-configure-targetwatch
 .stamp-configure-targetwatch: $(WATCH_MONO_PATH)/configure
 	$(Q) $(WATCHOS_ENVIRONMENT) ./wrap-configure.sh targetwatch $(abspath $(WATCH_MONO_PATH)/configure) $(WATCHOS_CONFIGURE_FLAGS)
 
-build-targetwatch: export DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT)
-build-targetwatch: export PATH:="$(WATCHOS_BIN_PATH):$(PATH)"
-build-targetwatch: .stamp-configure-targetwatch
+.stamp-build-targetwatch: export DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT)
+.stamp-build-targetwatch: export PATH:="$(WATCHOS_BIN_PATH):$(PATH)"
+.stamp-build-targetwatch: .stamp-configure-targetwatch $(MONO_DEPENDENCIES)
 	$(Q) $(MAKE) -C targetwatch/eglib
 	$(Q) $(MAKE) -C targetwatch/mono
 	$(Q) $(MAKE) -C targetwatch/eglib install
 	$(Q) $(MAKE) -C targetwatch/mono install
+	$(Q) touch $@
+
+build-targetwatch: .stamp-build-targetwatch
 
 clean-targetwatch:
-	$(Q) rm -rf targetwatch .stamp-configure-targetwatch targetwatch.config.cache
+	$(Q) rm -rf targetwatch .stamp-*-targetwatch targetwatch.config.cache
 
 setup-watchos: setup-targetwatch
 build-watchos: build-targetwatch
@@ -1604,6 +1580,11 @@ WATCHOS_TARGET_LIBMONOSGEN          = $(BUILD_DESTDIR)/targetwatch/lib/libmonosg
 WATCHOS_TARGET_SHAREDMONOSGEN       = $(BUILD_DESTDIR)/targetwatch/lib/libmonosgen-2.0.dylib
 WATCHOS_TARGET_LIBLOGPROFILER       = $(BUILD_DESTDIR)/targetwatch/lib/libmono-profiler-log-static.a
 WATCHOS_TARGET_SHAREDLIBLOGPROFILER = $(BUILD_DESTDIR)/targetwatch/lib/libmono-profiler-log.0.dylib
+
+$(WATCHOS_TARGET_LIBMONOSGEN): .stamp-build-targetwatch
+$(WATCHOS_TARGET_SHAREDMONOSGEN): .stamp-build-targetwatch
+$(WATCHOS_TARGET_LIBLOGPROFILER): .stamp-build-targetwatch
+$(WATCHOS_TARGET_SHAREDLIBLOGPROFILER): .stamp-build-targetwatch
 
 device:: watchos
 
@@ -1755,16 +1736,19 @@ setup-targettv: .stamp-configure-targettv
 .stamp-configure-targettv: $(MONO_PATH)/configure
 	$(Q) $(TVOS_ENVIRONMENT) ./wrap-configure.sh targettv $(abspath $(MONO_PATH)/configure) $(TVOS_CONFIGURE_FLAGS)
 
-build-targettv: export DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT)
-build-targettv: export PATH:="$(TVOS_BIN_PATH):$(PATH)"
-build-targettv: .stamp-configure-targettv
+.stamp-build-targettv: export DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT)
+.stamp-build-targettv: export PATH:="$(TVOS_BIN_PATH):$(PATH)"
+.stamp-build-targettv: .stamp-configure-targettv $(MONO_DEPENDENCIES)
 	$(Q) $(MAKE) -C targettv/eglib
 	$(Q) $(MAKE) -C targettv/mono
 	$(Q) $(MAKE) -C targettv/eglib install
 	$(Q) $(MAKE) -C targettv/mono install
+	$(Q) touch $@
+
+build-targettv: .stamp-build-targettv
 
 clean-targettv:
-	$(Q) rm -rf targettv .stamp-configure-targettv targettv.config.cache
+	$(Q) rm -rf targettv .stamp-*-targettv targettv.config.cache
 
 setup-tvos: setup-targettv
 build-tvos: build-targettv
@@ -1774,6 +1758,11 @@ TVOS_TARGET_LIBMONOSGEN          = $(BUILD_DESTDIR)/targettv/lib/libmonosgen-2.0
 TVOS_TARGET_SHAREDMONOSGEN       = $(BUILD_DESTDIR)/targettv/lib/libmonosgen-2.0.dylib
 TVOS_TARGET_LIBLOGPROFILER       = $(BUILD_DESTDIR)/targettv/lib/libmono-profiler-log-static.a
 TVOS_TARGET_SHAREDLIBLOGPROFILER = $(BUILD_DESTDIR)/targettv/lib/libmono-profiler-log.0.dylib
+
+$(TVOS_TARGET_LIBMONOSGEN): .stamp-build-targettv
+$(TVOS_TARGET_SHAREDMONOSGEN): .stamp-build-targettv
+$(TVOS_TARGET_LIBLOGPROFILER): .stamp-build-targettv
+$(TVOS_TARGET_SHAREDLIBLOGPROFILER): .stamp-build-targettv
 
 device:: tvos
 
@@ -1861,11 +1850,11 @@ LLVM_CXXFLAGS=$(CCACHE_CXXFLAGS)
 build-llvm: .stamp-build-llvm
 build-llvm64: .stamp-build-llvm64
 
-.stamp-build-llvm: .stamp-configure-llvm
+.stamp-build-llvm: .stamp-configure-llvm $(LLVM_DEPENDENCIES)
 	$(MAKE) -C llvm all install
 	$(Q) touch $@
 
-.stamp-build-llvm64: .stamp-configure-llvm64
+.stamp-build-llvm64: .stamp-configure-llvm64 $(LLVM_DEPENDENCIES)
 	$(MAKE) -C llvm64 all install
 	$(Q) touch $@
 
@@ -1905,10 +1894,10 @@ $(WATCH_MONO_PATH)/tools/offsets-tool/MonoAotOffsetsDumper.exe: $(wildcard $(WAT
 	$(Q) $(MAKE) -C $(dir $@) MonoAotOffsetsDumper.exe
 endif
 
-target7/mono/arch/arm/arm_dpimacros.h: setup-target7
+target7/mono/arch/arm/arm_dpimacros.h: .stamp-configure-target7
 	$(Q) $(MAKE) -C $(dir $@) $(notdir $@)
 
-targetwatch/mono/arch/arm/arm_dpimacros.h: setup-targetwatch
+targetwatch/mono/arch/arm/arm_dpimacros.h: .stamp-configure-targetwatch
 	$(Q) $(MAKE) -C $(dir $@) $(notdir $@)
 
 # template definition for generating AOT cross offsets for an ABI
@@ -1981,15 +1970,20 @@ setup-cross: .stamp-configure-cross
 
 $(eval $(call GenerateCrossOffsets,arm-apple-darwin10,$(TOP)/builds/cross/,cross,$(MONO_PATH)))
 
-build-cross: setup-cross cross/arm-apple-darwin10.h
+.stamp-build-cross: .stamp-configure-cross cross/arm-apple-darwin10.h $(MONO_DEPENDENCIES)
 	$(MAKE) -C cross/eglib
 	$(MAKE) -C cross/mono
 	$(MAKE) -C cross/mono install
+	$(Q) touch $@
+
+build-cross: .stamp-build-cross
 
 CROSS_TARGETS = \
 	$(PREFIX)/bin/arm-darwin-mono-sgen  \
 
-$(PREFIX)/bin/arm-darwin-mono-%: $(BUILD_DESTDIR)/cross/bin/arm-darwin-mono-% | $(PREFIX)/bin
+$(BUILD_DESTDIR)/cross/bin/arm-darwin-mono-sgen: .stamp-build-cross
+
+$(PREFIX)/bin/arm-darwin-mono-sgen: $(BUILD_DESTDIR)/cross/bin/arm-darwin-mono-sgen | $(PREFIX)/bin
 	$(call Q_2,INSTALL ,[CROSS]) install -c -m 0755 $(INSTALL_STRIP_FLAG) $< $@
 
 $(PREFIX)/bin:
@@ -2051,13 +2045,18 @@ install-directories:
 
 $(eval $(call GenerateCrossOffsets,aarch64-apple-darwin10,$(TOP)/builds/cross64/,cross64,$(MONO_PATH)))
 
-build-cross64: setup-cross64 cross64/aarch64-apple-darwin10.h
+.stamp-build-cross64: .stamp-configure-cross64 cross64/aarch64-apple-darwin10.h $(MONO_DEPENDENCIES)
 	$(MAKE) -C cross64/eglib
 	$(MAKE) -C cross64/mono
 	@$(MAKE) -C cross64/mono install
+	$(Q) touch $@
+
+build-cross64: .stamp-build-cross64
 
 CROSS64_TARGETS = \
 	$(PREFIX)/bin/arm64-darwin-mono-sgen \
+
+$(BUILD_DESTDIR)/cross64/bin/aarch64-darwin-mono-sgen: .stamp-build-cross64
 
 $(PREFIX)/bin/arm64-darwin-mono-sgen: $(BUILD_DESTDIR)/cross64/bin/aarch64-darwin-mono-sgen | $(PREFIX)/bin
 	$(call Q_2,INSTALL ,[CROSS64]) install -c -m 0755 $(INSTALL_STRIP_FLAG) $< $@
@@ -2065,7 +2064,7 @@ $(PREFIX)/bin/arm64-darwin-mono-sgen: $(BUILD_DESTDIR)/cross64/bin/aarch64-darwi
 install-cross64: install-llvm64 $(CROSS64_TARGETS)
 
 clean-cross64:
-	-rm -rf cross64 .stamp-configure-cross64 cross64.config.cache
+	-rm -rf cross64 .stamp-*-cross64 cross64.config.cache
 
 
 #
@@ -2113,15 +2112,20 @@ build-cross: setup-cross
 
 $(eval $(call GenerateCrossOffsets,armv7k-apple-darwin,$(TOP)/builds/cross-watch/,cross-watch,$(WATCH_MONO_PATH)))
 
-build-cross-watch: setup-cross-watch cross-watch/armv7k-apple-darwin.h
+.stamp-build-cross-watch: .stamp-configure-cross-watch cross-watch/armv7k-apple-darwin.h $(MONO_DEPENDENCIES)
 	$(MAKE) -C cross-watch/eglib
 	$(MAKE) -C cross-watch/mono
 	$(MAKE) -C cross-watch/mono install
+	$(Q) touch $@
+
+build-cross-watch: .stamp-build-cross-watch
 
 CROSS_WATCH_TARGETS = \
 	$(PREFIX)/bin/armv7k-unknown-darwin-mono-sgen  \
 
-$(PREFIX)/bin/armv7k-unknown-darwin-mono-%: $(BUILD_DESTDIR)/cross-watch/bin/armv7k-unknown-darwin-mono-% | $(PREFIX)/bin
+$(BUILD_DESTDIR)/cross-watch/bin/armv7k-unknown-darwin-mono-sgen: .stamp-build-cross-watch
+
+$(PREFIX)/bin/armv7k-unknown-darwin-mono-sgen: $(BUILD_DESTDIR)/cross-watch/bin/armv7k-unknown-darwin-mono-sgen | $(PREFIX)/bin
 	$(call Q_2,INSTALL ,[CROSS]) install -c -m 0755 $(INSTALL_STRIP_FLAG) $< $@
 
 install-cross-watch: install-llvm $(CROSS_WATCH_TARGETS)
@@ -2172,15 +2176,18 @@ setup-crosstv: .stamp-configure-crosstv
 
 $(eval $(call GenerateCrossOffsets,aarch64-apple-darwin10,$(TOP)/builds/crosstv/,crosstv,$(MONO_PATH)))
 
-build-crosstv: setup-crosstv crosstv/aarch64-apple-darwin10.h
+.stamp-build-crosstv: .stamp-configure-crosstv crosstv/aarch64-apple-darwin10.h $(MONO_DEPENDENCIES)
 	$(MAKE) -C crosstv/eglib
 	$(MAKE) -C crosstv/mono
 	$(MAKE) -C crosstv/mono install
+	$(Q) touch $@
 
 TV_WATCH_TARGETS = \
 	$(PREFIX)/bin/aarch64-unknown-darwin-mono-sgen  \
 
-$(PREFIX)/bin/aarch64-unknown-darwin-mono-%: $(BUILD_DESTDIR)/crosstv/bin/aarch64-unknown-darwin-mono-% | $(PREFIX)/bin
+$(BUILD_DESTDIR)/crosstv/bin/aarch64-unknown-darwin-mono-sgen: .stamp-build-crosstv
+
+$(PREFIX)/bin/aarch64-unknown-darwin-mono-sgen: $(BUILD_DESTDIR)/crosstv/bin/aarch64-unknown-darwin-mono-sgen | $(PREFIX)/bin
 	$(call Q_2,INSTALL ,[CROSSTV]) install -c -m 0755 $(INSTALL_STRIP_FLAG) $< $@
 
 install-crosstv: install-llvm $(TV_WATCH_TARGETS)

--- a/msbuild/.gitignore
+++ b/msbuild/.gitignore
@@ -1,1 +1,3 @@
 .build-stamp
+.stamp-test-xml
+

--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -314,7 +314,7 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/msbuild/%.dll: build/%.dll | $(MA
 ##
 
 # we must install locally during 'make all', because the F# build depends on the msbuild targets/assemblies.
-all-local:: $(MSBUILD_PRODUCTS) test-xml
+all-local:: $(MSBUILD_PRODUCTS) .stamp-test-xml
 
 .build-stamp: $(ALL_SOURCES)
 	$(Q) $(SYSTEM_MONO) /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore
@@ -348,9 +348,10 @@ install-symlinks: $(MSBUILD_SYMLINKS)
 
 install-local:: $(MSBUILD_PRODUCTS)
 
-test-xml:
-	$(Q) xmllint --noout $(wildcard */*.targets) $(wildcard */*.props)
+.stamp-test-xml: $(wildcard */*.targets) $(wildcard */*.props)
+	$(Q) xmllint --noout $^
 	@echo Targets files are valid XML
+	@touch $@
 
 # make will automatically consider files created in chained implicit rules as temporary files, and delete them afterwards
 # marking those files as .SECONDARY will prevent that deletion.

--- a/src/Makefile
+++ b/src/Makefile
@@ -72,7 +72,7 @@ IOS_BMONO = MONO_PATH=$(IOS_LIBDIR) $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/btouch
 ifdef IKVM
 IOS_GENERATOR=build/common/bgen.exe
 IOS_GENERATE=$(SYSTEM_MONO) --debug $(IOS_GENERATOR)
-IOS_GENERATOR_DEPENDENCIES=$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bgen/monotouch.BindingAttributes.dll $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bgen/Xamarin.iOS.BindingAttributes.dll
+IOS_GENERATOR_DEPENDENCIES=$(IOS_BUILD_DIR)/native/monotouch.BindingAttributes.dll $(IOS_BUILD_DIR)/native/Xamarin.iOS.BindingAttributes.dll
 IOS_compat_GENERATOR=$(IOS_GENERATOR)
 IOS_compat_GENERATE=$(IOS_GENERATE)
 IOS_native_GENERATOR=$(IOS_GENERATOR)
@@ -509,7 +509,7 @@ MAC_full_GENERATOR=$(MAC_GENERATOR)
 MAC_full_GENERATE=$(MAC_GENERATE)
 MAC_mobile_GENERATOR=$(MAC_GENERATOR)
 MAC_mobile_GENERATE=$(MAC_GENERATE)
-MAC_GENERATOR_DEPENDENCIES=$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/XamMac.BindingAttributes.dll $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/Xamarin.Mac-full.BindingAttributes.dll $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/Xamarin.Mac-mobile.BindingAttributes.dll
+MAC_GENERATOR_DEPENDENCIES=$(MAC_BUILD_DIR)/XamMac.BindingAttributes.dll $(MAC_BUILD_DIR)/Xamarin.Mac-full.BindingAttributes.dll $(MAC_BUILD_DIR)/Xamarin.Mac-mobile.BindingAttributes.dll
 else
 MAC_compat_GENERATOR=$(MAC_BUILD_DIR)/compat/_bmac.exe
 MAC_compat_GENERATE=$(SYSTEM_MONO) --debug $(MAC_compat_GENERATOR)
@@ -751,6 +751,7 @@ WATCH_BMONO = MONO_PATH=$(WATCH_LIBDIR)/repl $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/b
 ifdef IKVM
 WATCH_GENERATOR=build/common/bgen.exe
 WATCH_GENERATE=$(SYSTEM_MONO) --debug $(WATCH_GENERATOR)
+WATCH_GENERATOR_DEPENDENCIES=$(WATCH_BUILD_DIR)/Xamarin.WatchOS.BindingAttributes.dll
 else
 WATCH_GENERATOR=$(WATCH_BUILD_DIR)/watch/generator.exe
 WATCH_GENERATE=$(WATCH_BMONO) --debug $(WATCH_GENERATOR)
@@ -814,7 +815,7 @@ $(WATCH_BUILD_DIR)/watch/generator.exe: $(GENERATOR_SOURCES) $(WATCH_BUILD_DIR)/
 		$(GENERATOR_DEFINES)                  \
 
 # generated_sources
-$(WATCH_BUILD_DIR)/watch/generated_sources: $(WATCH_GENERATOR) $(WATCHOS_APIS) $(WATCH_BUILD_DIR)/watch/core.dll $(WATCH_PMCS)
+$(WATCH_BUILD_DIR)/watch/generated_sources: $(WATCH_GENERATOR) $(WATCHOS_APIS) $(WATCH_BUILD_DIR)/watch/core.dll $(WATCH_PMCS) $(WATCH_GENERATOR_DEPENDENCIES)
 	$(call Q_PROF_GEN,watch) PMCS_PROFILE=watch $(WATCH_GENERATE) \
 		-inline-selectors                                        \
 		-process-enums                                           \
@@ -974,6 +975,7 @@ TVOS_BMONO = MONO_PATH=$(TVOS_LIBDIR)/repl $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin
 ifdef IKVM
 TVOS_GENERATOR=build/common/bgen.exe
 TVOS_GENERATE=$(SYSTEM_MONO) --debug $(TVOS_GENERATOR)
+TVOS_GENERATOR_DEPENDENCIES=$(TVOS_BUILD_DIR)/Xamarin.TVOS.BindingAttributes.dll
 else
 TVOS_GENERATOR=$(TVOS_BUILD_DIR)/tvos/generator.exe
 TVOS_GENERATE=$(TVOS_BMONO) --debug $(TVOS_GENERATOR)
@@ -1031,7 +1033,7 @@ $(TVOS_BUILD_DIR)/tvos/generator.exe: $(GENERATOR_SOURCES) $(TVOS_BUILD_DIR)/tvo
 		$(GENERATOR_DEFINES)                  \
 
 # generated_sources
-$(TVOS_BUILD_DIR)/tvos/generated_sources: $(TVOS_GENERATOR) $(TVOS_APIS) $(TVOS_BUILD_DIR)/tvos/core.dll $(TVOS_PMCS)
+$(TVOS_BUILD_DIR)/tvos/generated_sources: $(TVOS_GENERATOR) $(TVOS_APIS) $(TVOS_BUILD_DIR)/tvos/core.dll $(TVOS_PMCS) $(TVOS_GENERATOR_DEPENDENCIES)
 	$(call Q_PROF_GEN,tvos) PMCS_PROFILE=tvos $(TVOS_GENERATE) \
 		-inline-selectors                                        \
 		-process-enums                                           \

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -174,19 +174,19 @@ $(MMP_DIRECTORIES):
 
 GENERATE_PART_REGISTRAR = $(Q_GEN) $(SYSTEM_MONO) --debug mmp.exe --xamarin-framework-directory=$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR) -q --runregistrar:$(abspath $@) --sdkroot $(XCODE_DEVELOPER_ROOT) --sdk $(OSX_SDK_VERSION)   $< --registrar:static
 
-Xamarin.Mac.registrar.mobile.i386.m:     $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/i386/mobile/Xamarin.Mac.dll $(LOCAL_MMP)
+Xamarin.Mac.registrar.mobile.i386.m:   $(TOP)/src/build/mac/mobile-32/Xamarin.Mac.dll $(LOCAL_MMP)
 	$(GENERATE_PART_REGISTRAR) --target-framework Xamarin.Mac,v1.0 --arch=i386
 	$(Q) touch Xamarin.Mac.registrar.mobile.i386.m Xamarin.Mac.registrar.mobile.i386.h
 
-Xamarin.Mac.registrar.mobile.x86_64.m:     $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/mobile/Xamarin.Mac.dll $(LOCAL_MMP)
+Xamarin.Mac.registrar.mobile.x86_64.m: $(TOP)/src/build/mac/mobile-64/Xamarin.Mac.dll $(LOCAL_MMP)
 	$(GENERATE_PART_REGISTRAR) --target-framework Xamarin.Mac,v1.0 --arch=x86_64
 	$(Q) touch Xamarin.Mac.registrar.mobile.x86_64.m Xamarin.Mac.registrar.mobile.x86_64.h
 
-Xamarin.Mac.registrar.full.i386.m:     $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/i386/full/Xamarin.Mac.dll $(LOCAL_MMP)
+Xamarin.Mac.registrar.full.i386.m:     $(TOP)/src/build/mac/full-32/Xamarin.Mac.dll $(LOCAL_MMP)
 	$(GENERATE_PART_REGISTRAR) --target-framework 4.5 --arch=i386 --xamarin-full-framework --nolink
 	$(Q) touch Xamarin.Mac.registrar.full.i386.m Xamarin.Mac.registrar.full.i386.h
 
-Xamarin.Mac.registrar.full.x86_64.m:     $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/x86_64/full/Xamarin.Mac.dll $(LOCAL_MMP)
+Xamarin.Mac.registrar.full.x86_64.m:   $(TOP)/src/build/mac/full-64/Xamarin.Mac.dll $(LOCAL_MMP)
 	$(GENERATE_PART_REGISTRAR) --target-framework 4.5 --arch=x86_64 --xamarin-full-framework --nolink
 	$(Q) touch Xamarin.Mac.registrar.full.x86_64.m Xamarin.Mac.registrar.full.x86_64.h
 


### PR DESCRIPTION
* [builds] Improve mono/llvm dependencies.

* Create a list of all the files in the mono and llvm repositories, and save
  these lists as a Make variable (in a generated Makefile - .deps.*.mk). We
  don't list _all_ the files in each repository, because there are quite a few
  (55k for mono), and Make measurably takes a while to check all of them, so
  try to limit it to a sane subset, without risking missing changes to files
  that actually matters.

* Always create stamp files when we're done with mono builds.

* Modify the mono/llvm builds to depend on all the files in their
  repositories.

* Explicitly list the corresponding .stamp-build-* files as dependencies for
  various files that are produced by the mono builds, so that make knows how
  to build these files.

* Rewrite the *-facade-check targets to depend on the corresponding
  *_BCL_TARGETS, so that we can avoid running a submake to the same Makefile
  to execute the facade checks.

  It now takes a little while (less than a second on my machine, which is
  fine) for make to list all dependencies and get their timestamps, but if
  executing multiple submakes this adds up to a multi-second timewaste.

  So avoid the timewaste by not doing submakes, but instead use dependencies
  to enforce the required target execution ordering.

* Don't depend on nicely named intermediate targets, since won't prevent
  rebuilds:

      build-cross64: setup-cross64

  Since the `setup-cross64` file doesn't exist, `build-cross64` will always
  execute. Instead depend on the stamp file:

      build-cross64: .stamp-configure-cross64

  And now `build-cross64` will only rebuild if needed.

* Don't try to list all intermediate files as .SECONDARY dependencies, instead
  list none at all, which works as if all files were listed as dependencies.

* Some targets had to move later in the file, since variables used in dependencies:

       foo: $(VARIABLE)

  must be defined before that point in the file, as opposed to variables used in recipes:

       foo:
           $(MAKE) $(VARIABLE)

  can be defined anywhere in the Makefile.

* Simplify the targets that sign assemblies significantly.

There are a few end results:

* It's now possible to do `make install`, without doing `make all` first. This
  might seem weird, but that also ensures the more common `make all install`
  works properly.

* Remakes (without any mono/llvm changes) in build/ are much faster, because
  we now won't recurse into every mono build:

      $ time make all -C builds/ -j8
      [...]
      real  0m1.873s

  This even means that we might be able to make it a habit to remake in the
  root directory, which doesn't take forever now:

      $ time make all -j8
      [...]
      real  0m4.521s

  Unfortunately adding `make install` to the mix still does some useless
  stuff, and it ends up taking ~30 seconds to complete a full build:

      $ time make all install -j8
      [...]
      real  0m32.542s

* [msbuild] Don't verify the xml syntax of targets files unless the files change.

* [build] Don't depend on installed files.

Don't depend on installed files, because that causes a rebuild when installing
to a different directory (i.e. package creation).

* Bump maccore to get build improvements.

Rebuilds are now very fast:

    $ make all install -j8
    $ time make all install -j8
    real	0m5.735s

Less than 6s to figure out that nothing needs to be done.

And strangely flushing the disk cache doesn't make it much slower:

    $ sudo purge
    $ time make all install -j8
    real	0m7.309s

Which probably means that Make mostly reads file metadata, and not actual file
contents (which is good).