### PR TITLE
[mtouch] Remove workaround for bug 43462, this fixes slow builds (bug 52545)

### DIFF
--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -1245,8 +1245,6 @@ class CTP4 : CTP3 {
 					}
 				};
 				p.WaitForExit ();
-				
-				GC.Collect (); // Workaround for: https://bugzilla.xamarin.com/show_bug.cgi?id=43462#c14
 
 				Console.WriteLine (output);
 				

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -210,8 +210,6 @@ namespace Xamarin.Bundler {
 				stderr_completed.WaitOne (TimeSpan.FromSeconds (1));
 				stdout_completed.WaitOne (TimeSpan.FromSeconds (1));
 
-				GC.Collect (); // Workaround for: https://bugzilla.xamarin.com/show_bug.cgi?id=43462#c14
-
 				if (p.ExitCode != 0) {
 					// note: this repeat the failing command line. However we can't avoid this since we're often
 					// running commands in parallel (so the last one printed might not be the one failing)

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1443,7 +1443,6 @@ namespace Xamarin.Bundler {
 				if (p.Start ()) {
 					var error = p.StandardError.ReadToEnd();
 					p.WaitForExit ();
-					GC.Collect (); // Workaround for: https://bugzilla.xamarin.com/show_bug.cgi?id=43462#c14
 					if (p.ExitCode == 0)
 						return;
 					else {

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1503,8 +1503,6 @@ namespace Xamarin.Bundler
 
 				p.WaitForExit ();
 
-				GC.Collect (); // Workaround for: https://bugzilla.xamarin.com/show_bug.cgi?id=43462#c14
-
 				return p.ExitCode;
 			}
 		}


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=52545

Some projects took a lot of time to build with the workaround for
bug 43462 but now that it is fixed we can remove it and stop the slowness.