### PR TITLE
[msbuild] Fix running bgen for Xamarin.Mac. (#1977)

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Tasks/BTouch.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/BTouch.cs
@@ -33,15 +33,13 @@ namespace Xamarin.Mac.Tasks
 				isMobile = true; // Some older binding don't have either tag, assume mobile since it is the default
 			}
 
-			EnvironmentVariables = new string[] {
-				"MONO_PATH=" + string.Format ("{0}/lib/mono/{1}", FrameworkRoot, isMobile ? "Xamarin.Mac" : "4.5")
-			};
-
 			var sb = new StringBuilder ();
 			var bgen = Path.Combine (FrameworkRoot, "lib", "bgen", "bgen.exe");
-			if (File.Exists (bgen)) {
-				sb.Append (bgen);
-			} else {
+			if (!File.Exists (bgen)) {
+				EnvironmentVariables = new string[] {
+					"MONO_PATH=" + string.Format ("{0}/lib/mono/{1}", FrameworkRoot, isMobile ? "Xamarin.Mac" : "4.5")
+				};
+
 				if (isMobile) {
 					sb.Append (Path.Combine (FrameworkRoot, "lib", "bmac", "bmac-mobile.exe"));
 				} else {

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.props
@@ -36,8 +36,9 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 
 		<BaseLibDllPath Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">$(XamarinMacFrameworkRoot)/lib/mono/Xamarin.Mac/Xamarin.Mac.dll</BaseLibDllPath>
 		<BaseLibDllPath Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.Mac'">$(XamarinMacFrameworkRoot)/lib/mono/4.5/Xamarin.Mac.dll</BaseLibDllPath>
-		<BTouchToolExe>bmac-mobile-mono</BTouchToolExe>
 		<BTouchToolPath>$(XamarinMacFrameworkRoot)/bin/</BTouchToolPath>
+		<BTouchToolExe Condition="Exists('$(BTouchToolPath)/bgen')">bgen</BTouchToolExe>
+		<BTouchToolExe Condition="!Exists('$(BTouchToolPath)/bgen')">bmac-mobile-mono</BTouchToolExe>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 
 		<DefineConstants>__UNIFIED__;$(DefineConstants)</DefineConstants>


### PR DESCRIPTION
bgen must be executed with the system mono, not bmac-mobile-mono, and without
the MONO_PATH variable set.