### PR TITLE
[mmp] Add Intents and Photos mappings for namespaces

### DIFF
--- a/tools/linker/ObjCExtensions.cs
+++ b/tools/linker/ObjCExtensions.cs
@@ -55,6 +55,8 @@ namespace Xamarin.Linker {
 			MultipeerConnectivity = profile.GetNamespace ("MultipeerConnectivity");
 			MetalKit = profile.GetNamespace ("MetalKit");
 			ModelIO = profile.GetNamespace ("ModelIO");
+			Intents = profile.GetNamespace ("Intents");
+			Photos = profile.GetNamespace ("Photos");
 #if MONOMAC
 			IOBluetooth = profile.GetNamespace ("IOBluetooth");
 			IOBluetoothUI = profile.GetNamespace ("IOBluetoothUI");
@@ -127,6 +129,10 @@ namespace Xamarin.Linker {
 		public static string Security { get; private set; }
 
 		public static string StoreKit { get; private set; }
+
+		public static string Intents { get; private set; }
+
+		public static string Photos { get; private set; }
 
 #if MONOMAC
 		public static string IOBluetooth { get; private set; }

--- a/tools/mmp/linker/MonoMac.Tuner/MonoMacNamespaces.cs
+++ b/tools/mmp/linker/MonoMac.Tuner/MonoMacNamespaces.cs
@@ -66,6 +66,8 @@ namespace MonoMac.Tuner {
 		{ Constants.SceneKitLibrary, Namespaces.SceneKit },
 		{ Constants.StoreKitLibrary, Namespaces.StoreKit },
 		{ Constants.MediaPlayerLibrary, Namespaces.MediaPlayer },
+		{ Constants.IntentsLibrary, Namespaces.Intents },
+		{ Constants.PhotosLibrary, Namespaces.Photos },
 		{ Constants.PrintCoreLibrary, Namespaces.PrintCore} };
 
 		public void Process (LinkContext context)


### PR DESCRIPTION
MonoMacNamespaces needs them to properly remove the entries from
NSObject.mac.cs.

Fix debug logs:

Unprocessed library / namespace /System/Library/Frameworks/Intents.framework/Intents
Unprocessed library / namespace /System/Library/Frameworks/Photos.framework/Photos