### PR TITLE
[mtouch/mmp] Handle empty aggregated exceptions better.

### DIFF
--- a/src/ObjCRuntime/ErrorHelper.cs
+++ b/src/ObjCRuntime/ErrorHelper.cs
@@ -239,7 +239,7 @@ namespace XamCore.ObjCRuntime {
 		{
 			AggregateException ae = ex as AggregateException;
 
-			if (ae != null) {
+			if (ae != null && ae.InnerExceptions.Count > 0) {
 				foreach (var ie in ae.InnerExceptions)
 					CollectExceptions (ie, exceptions);
 			} else {


### PR DESCRIPTION
This only happens when something else is wrong, but this makes finding out
what that something else is much easier.