### PR TITLE
[runtime] Make xamarin_open_assembly public and stable.

### DIFF
--- a/runtime/runtime-internal.h
+++ b/runtime/runtime-internal.h
@@ -26,7 +26,6 @@
 #endif
 
 void *xamarin_marshal_return_value (MonoType *mtype, const char *type, MonoObject *retval, bool retain, MonoMethod *method, guint32 *exception_gchandle);
-MonoAssembly * xamarin_open_assembly (const char *name);
 
 /*
  * XamarinGCHandle

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -194,6 +194,13 @@ bool			xamarin_locate_assembly_resource (const char *assembly_name, const char *
 void			xamarin_printf (const char *format, ...);
 void			xamarin_vprintf (const char *format, va_list args);
 
+/*
+ * Look for an assembly in the app and open it.
+ *
+ * Stable API.
+ */
+MonoAssembly * xamarin_open_assembly (const char *name);
+
 #if defined(__arm__) || defined(__aarch64__)
 void mono_aot_register_module (void *aot_info);
 #endif


### PR DESCRIPTION
This is needed for Embeddinator-4000.