### PR TITLE
Add embeddinator support.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1100,6 +1100,18 @@ print_callback (const char *string, mono_bool is_stdout)
 }
 
 void
+xamarin_initialize_embedded ()
+{
+	static bool initialized = false;
+	if (initialized)
+		return;
+	initialized = true;
+
+	char *argv[] = { (char *) "embedded" };
+	xamarin_main (1, argv, XamarinLaunchModeEmbedded);
+}
+
+void
 xamarin_initialize ()
 {
 	// COOP: accessing managed memory: UNSAFE mode

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2326,6 +2326,18 @@ xamarin_locate_assembly_resource (const char *assembly_name, const char *culture
 		return true;
 	}
 
+#if !MONOMAC && (defined(__i386__) || defined (__x86_64__))
+	// In the simulator we also check in a 'simulator' subdirectory. This is
+	// so that we can create a framework that works for both simulator and
+	// device, without affecting device builds in any way (device-specific
+	// files just go in the MonoBundle directory)
+	snprintf (root, sizeof (root), "%s/Frameworks/%s.framework/MonoBundle/simulator", app_path, aname);
+	if (xamarin_locate_assembly_resource_for_root (root, culture, resource, path, pathlen)) {
+		LOG_RESOURCELOOKUP (PRODUCT ": Located resource '%s' from framework '%s': %s\n", resource, aname, path);
+		return true;
+	}
+#endif // !MONOMAC
+
 	// Then in a framework named as the assembly
 	snprintf (root, sizeof (root), "%s/Frameworks/%s.framework/MonoBundle", app_path, aname);
 	if (xamarin_locate_assembly_resource_for_root (root, culture, resource, path, pathlen)) {

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -98,6 +98,12 @@ enum NSObjectFlags {
 	NSObjectFlagsHasManagedRef = 32,
 };
 
+enum XamarinLaunchMode {
+	XamarinLaunchModeApp = 0,
+	XamarinLaunchModeExtension = 1,
+	XamarinLaunchModeEmbedded = 2,
+};
+
 struct AssemblyLocation {
 	const char *assembly_name; // base name (without extension) of the assembly
 	const char *location; // the directory where the assembly is
@@ -109,6 +115,7 @@ struct AssemblyLocations {
 };
 
 void xamarin_initialize ();
+void xamarin_initialize_embedded (); /* STABLE */
 
 void			xamarin_assertion_message (const char *msg, ...) __attribute__((__noreturn__));
 const char *	xamarin_get_bundle_path (); /* Public API */
@@ -159,7 +166,7 @@ void			xamarin_create_managed_ref (id self, void * managed_object, bool retain);
 void            xamarin_release_managed_ref (id self, MonoObject *managed_obj);
 void			xamarin_notify_dealloc (id self, int gchandle);
 
-int				xamarin_main (int argc, char *argv[], bool is_extension);
+int				xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode);
 
 char *			xamarin_type_get_full_name (MonoType *type, guint32 *exception_gchandle); // return value must be freed with 'mono_free'
 char *			xamarin_class_get_full_name (MonoClass *klass, guint32 *exception_gchandle); // return value must be freed with 'mono_free'

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -115,7 +115,7 @@ struct AssemblyLocations {
 };
 
 void xamarin_initialize ();
-void xamarin_initialize_embedded (); /* STABLE */
+void xamarin_initialize_embedded (); /* Public API, must not change - this is used by the embeddinator */
 
 void			xamarin_assertion_message (const char *msg, ...) __attribute__((__noreturn__));
 const char *	xamarin_get_bundle_path (); /* Public API */

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -449,17 +449,6 @@ namespace Xamarin
 		}
 
 		[Test]
-		public void MT0008 ()
-		{
-			using (var mtouch = new MTouchTool ()) {
-				mtouch.CreateTemporaryAppDirectory ();
-				mtouch.CustomArguments = new string [] { "foo.exe", "bar.exe" };
-				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
-				mtouch.AssertError (8, "You should provide one root assembly only, found 2 assemblies: 'foo.exe', 'bar.exe'");
-			}
-		}
-
-		[Test]
 		public void MT0015 ()
 		{
 			using (var mtouch = new MTouchTool ()) {

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Bundler {
 		public MarshalObjectiveCExceptionMode MarshalObjectiveCExceptions;
 		public MarshalManagedExceptionMode MarshalManagedExceptions;
 		public bool IsDefaultMarshalManagedExceptionMode;
-		public string RootAssembly;
+		public List<string> RootAssemblies = new List<string> ();
 		public List<Application> SharedCodeApps = new List<Application> (); // List of appexes we're sharing code with.
 		public string RegistrarOutputLibrary;
 
@@ -438,8 +438,11 @@ namespace Xamarin.Bundler {
 			if (Registrar != RegistrarMode.Static)
 				throw new PlatformException (67, "Invalid registrar: {0}", Registrar); // this is only called during our own build
 
-			var registrar_m = RegistrarOutputLibrary;
+			if (RootAssemblies.Count != 1)
+				throw ErrorHelper.CreateError (8, "You should provide one root assembly only, found {0} assemblies: '{1}'", RootAssemblies.Count, string.Join ("', '", RootAssemblies.ToArray ()));
 
+			var registrar_m = RegistrarOutputLibrary;
+			var RootAssembly = RootAssemblies [0];
 			var resolvedAssemblies = new List<AssemblyDefinition> ();
 			var resolver = new PlatformResolver () {
 				FrameworkDirectory = Driver.GetPlatformFrameworkDirectory (this),

--- a/tools/common/CompilerFlags.cs
+++ b/tools/common/CompilerFlags.cs
@@ -130,6 +130,8 @@ namespace Xamarin.Utils
 			default:
 				throw ErrorHelper.CreateError (100, "Invalid assembly build target: '{0}'. Please file a bug report with a test case (http://bugzilla.xamarin.com).", mode);
 			}
+			AddOtherFlag ("-lz");
+			AddOtherFlag ("-liconv");
 		}
 
 		public void LinkWithXamarin ()

--- a/tools/common/CompilerFlags.cs
+++ b/tools/common/CompilerFlags.cs
@@ -150,6 +150,8 @@ namespace Xamarin.Utils
 			}
 			AddFramework ("Foundation");
 			AddOtherFlag ("-lz");
+			if (Application.Platform != ApplePlatform.WatchOS && Application.Platform != ApplePlatform.TVOS)
+				Frameworks.Add ("CFNetwork"); // required by xamarin_start_wwan
 		}
 
 		public void AddFramework (string framework)

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -106,10 +106,6 @@ namespace Xamarin.Bundler {
 		{
 			foreach (var a in Assemblies)
 				a.ComputeLinkerFlags ();
-#if MTOUCH
-			if (App.Platform != ApplePlatform.WatchOS && App.Platform != ApplePlatform.TVOS)
-				Frameworks.Add ("CFNetwork"); // required by xamarin_start_wwan
-#endif
 		}
 
 		public void GatherFrameworks ()

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -114,14 +114,17 @@ namespace Xamarin.Bundler {
 
 		public void GatherFrameworks ()
 		{
+			Assembly asm = null;
 			AssemblyDefinition productAssembly = null;
 
 			foreach (var assembly in Assemblies) {
 				if (assembly.AssemblyDefinition.Name.Name == Driver.GetProductAssembly (App)) {
-					productAssembly = assembly.AssemblyDefinition;
+					asm = assembly;
 					break;
 				}
 			}
+
+			productAssembly = asm.AssemblyDefinition;
 
 			// *** make sure any change in the above lists (or new list) are also reflected in 
 			// *** Makefile so simlauncher-sgen does not miss any framework
@@ -169,7 +172,7 @@ namespace Xamarin.Bundler {
 						}
 
 						if (App.SdkVersion >= framework.Version) {
-							var add_to = App.DeploymentTarget >= framework.Version ? Frameworks : WeakFrameworks;
+							var add_to = App.DeploymentTarget >= framework.Version ? asm.Frameworks : asm.WeakFrameworks;
 							add_to.Add (framework.Name);
 							continue;
 						}
@@ -179,7 +182,7 @@ namespace Xamarin.Bundler {
 
 			// Make sure there are no duplicates between frameworks and weak frameworks.
 			// Keep the weak ones.
-			Frameworks.ExceptWith (WeakFrameworks);
+			asm.Frameworks.ExceptWith (asm.WeakFrameworks);
 		}
 	}
 }

--- a/tools/linker/MobileResolveMainAssemblyStep.cs
+++ b/tools/linker/MobileResolveMainAssemblyStep.cs
@@ -34,12 +34,15 @@ namespace Xamarin.Linker.Steps {
 
 			Annotations.Push (assembly);
 
+			var is_product_assembly = Mono.Tuner.Profile.IsProductAssembly (assembly);
 			foreach (var t in assembly.MainModule.Types) {
-				if (t.IsPublic && embeddinator) {
-					// Mark all public types when in embeddinator mode.
-					// There may be no types with the Register attribute,
-					// which means that without this the assembly might be completely ignored even if it's not linked.
-					Annotations.Mark (t);
+				if (embeddinator) {
+					if (t.IsPublic && !is_product_assembly) {
+						// Mark all public types when in embeddinator mode.
+						// There may be no types with the Register attribute,
+						// which means that without this the assembly might be completely ignored even if it's not linked.
+						Annotations.Mark (t);
+					}
 					continue;
 				}
 

--- a/tools/linker/MobileResolveMainAssemblyStep.cs
+++ b/tools/linker/MobileResolveMainAssemblyStep.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Linker.Steps {
 				}
 
 				if (!t.HasCustomAttribute (Namespaces.Foundation, "RegisterAttribute"))
-						continue;
+					continue;
 				Annotations.Mark (t);
 				// the existing logic (both the general one and applying to NSObject) 
 				// should bring everything else that's required

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -490,7 +490,7 @@ namespace Xamarin.Bundler {
 			ValidateSDKVersion ();
 
 			if (action == Action.RunRegistrar) {
-				App.RootAssembly = unprocessed [0];
+				App.RootAssemblies.AddRange (unprocessed);
 				App.Registrar = RegistrarMode.Static;
 				App.RunRegistrar ();
 				return;

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1414,7 +1414,13 @@ namespace Xamarin.Bundler {
 			if (!IsDeviceBuild || IsExtension)
 				return;
 
-			if (Directory.Exists (Path.Combine (AppDirectory, "NOTICE")))
+			WriteNotice (AppDirectory);
+		}
+
+		void WriteNotice (string directory)
+		{
+			var path = Path.Combine (directory, "NOTICE");
+			if (Directory.Exists (path))
 				throw new MonoTouchException (1016, true, "Failed to create the NOTICE file because a directory already exists with the same name.");
 
 			try {
@@ -1423,7 +1429,7 @@ namespace Xamarin.Bundler {
 				sb.Append ("Xamarin built applications contain open source software.  ");
 				sb.Append ("For detailed attribution and licensing notices, please visit...");
 				sb.AppendLine ().AppendLine ().Append ("http://xamarin.com/mobile-licensing").AppendLine ();
-				Driver.WriteIfDifferent (Path.Combine (AppDirectory, "NOTICE"), sb.ToString ());
+				Driver.WriteIfDifferent (path, sb.ToString ());
 			} catch (Exception ex) {
 				throw new MonoTouchException (1017, true, ex, "Failed to create the NOTICE file: {0}", ex.Message);
 			}

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -486,6 +486,8 @@ namespace Xamarin.Bundler {
 
 		public BitCodeMode BitCodeMode { get; set; }
 
+		public bool Embeddinator { get; set; }
+
 		public bool EnableAsmOnlyBitCode { get { return BitCodeMode == BitCodeMode.ASMOnly; } }
 		public bool EnableLLVMOnlyBitCode { get { return BitCodeMode == BitCodeMode.LLVMOnly; } }
 		public bool EnableMarkerOnlyBitCode { get { return BitCodeMode == BitCodeMode.MarkerOnly; } }

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -165,7 +165,9 @@ namespace Xamarin.Bundler {
 
 		public AssemblyBuildTarget LibMonoLinkMode {
 			get {
-				if (HasFrameworks || UseMonoFramework.Value) {
+				if (Embeddinator) {
+					return AssemblyBuildTarget.StaticObject;
+				} else if (HasFrameworks || UseMonoFramework.Value) {
 					return AssemblyBuildTarget.Framework;
 				} else if (HasDynamicLibraries) {
 					return AssemblyBuildTarget.DynamicLibrary;
@@ -176,7 +178,9 @@ namespace Xamarin.Bundler {
 		}
 		public AssemblyBuildTarget LibXamarinLinkMode {
 			get {
-				if (HasFrameworks) {
+				if (Embeddinator) {
+					return AssemblyBuildTarget.StaticObject;
+				} else if (HasFrameworks) {
 					return AssemblyBuildTarget.Framework;
 				} else if (HasDynamicLibraries) {
 					return AssemblyBuildTarget.DynamicLibrary;

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1420,6 +1420,9 @@ namespace Xamarin.Bundler {
 			if (!IsDeviceBuild || IsExtension)
 				return;
 
+			if (Embeddinator)
+				return;
+
 			WriteNotice (AppDirectory);
 		}
 
@@ -1591,6 +1594,7 @@ namespace Xamarin.Bundler {
 					if (info.DylibToFramework) {
 						var bundleName = Path.GetFileName (name);
 						CreateFrameworkInfoPList (Path.Combine (targetDirectory, "Info.plist"), bundleName, BundleId + Path.GetFileNameWithoutExtension (bundleName), bundleName);
+						CreateFrameworkNotice (targetDirectory);
 					}
 				}
 			}
@@ -2044,6 +2048,14 @@ namespace Xamarin.Bundler {
 				return;
 
 			RuntimeOptions.Write (AppDirectory);
+		}
+
+		public void CreateFrameworkNotice (string output_path)
+		{
+			if (!Embeddinator)
+				return;
+
+			WriteNotice (output_path);
 		}
 
 		public void CreateFrameworkInfoPList (string output_path, string framework_name, string bundle_identifier, string bundle_name)

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1600,7 +1600,7 @@ namespace Xamarin.Bundler {
 			}
 
 			// If building a fat app, we need to lipo the two different executables we have together
-			if (IsDeviceBuild) {
+			if (IsDeviceBuild && !Embeddinator) {
 				if (IsDualBuild) {
 					if (IsUptodate (new string [] { Targets [0].Executable, Targets [1].Executable }, new string [] { Executable })) {
 						cached_executable = true;

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1310,6 +1310,11 @@ namespace Xamarin.Bundler {
 
 			Namespaces.Initialize ();
 
+			if (Embeddinator) {
+				// The assembly we're embedding doesn't necessarily reference our platform assembly, but we still need it.
+				RootAssemblies.Add (Path.Combine (Driver.GetPlatformFrameworkDirectory (this), Driver.GetProductAssembly (this) + ".dll"));
+			}
+
 			InitializeCommon ();
 
 			Driver.Watch ("Resolve References", 1);

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1607,25 +1607,33 @@ namespace Xamarin.Bundler {
 			// If building a fat app, we need to lipo the two different executables we have together
 			if (IsDeviceBuild && !Embeddinator) {
 				if (IsDualBuild) {
-					if (IsUptodate (new string [] { Targets [0].Executable, Targets [1].Executable }, new string [] { Executable })) {
+					if (Lipo (Executable, Targets [0].Executable, Targets [1].Executable))
 						cached_executable = true;
-						Driver.Log (3, "Target '{0}' is up-to-date.", Executable);
-					} else {
-						var cmd = new StringBuilder ();
-						foreach (var target in Targets) {
-							cmd.Append (Driver.Quote (target.Executable));
-							cmd.Append (' ');
-						}
-						cmd.Append ("-create -output ");
-						cmd.Append (Driver.Quote (Executable));
-						Driver.RunLipo (cmd.ToString ());
-					}
 				} else {
 					cached_executable = Targets [0].CachedExecutable;
 				}
 			}
 		}
-			
+
+		// Returns true if is up-to-date
+		static bool Lipo (string output, params string [] inputs)
+		{
+			if (IsUptodate (inputs, new string [] { output })) {
+				Driver.Log (3, "Target '{0}' is up-to-date.", output);
+				return true;
+			} else {
+				var cmd = new StringBuilder ();
+				foreach (var input in inputs) {
+					cmd.Append (Driver.Quote (input));
+					cmd.Append (' ');
+				}
+				cmd.Append ("-create -output ");
+				cmd.Append (Driver.Quote (output));
+				Driver.RunLipo (cmd.ToString ());
+				return false;
+			}
+		}
+
 		public void ExtractNativeLinkInfo ()
 		{
 			var exceptions = new List<Exception> ();

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1102,11 +1102,24 @@ namespace Xamarin.Bundler {
 			if (EnableAsmOnlyBitCode)
 				LLVMAsmWriter = true;
 
+			List<Exception> exceptions = null;
 			foreach (var root in RootAssemblies) {
-				if (!File.Exists (root))
-					throw new MonoTouchException (7, true, "The root assembly '{0}' does not exist", root);
+				if (File.Exists (root))
+					continue;
+
+				if (exceptions == null)
+					exceptions = new List<Exception> ();
+
+				if (root [0] == '-' || root [0] == '/') {
+					exceptions.Add (ErrorHelper.CreateError (18, "Unknown command line argument: '{0}'", root));
+				} else {
+					exceptions.Add (ErrorHelper.CreateError (7, "The root assembly '{0}' does not exist", root));
+				}
 			}
-			
+			if (exceptions?.Count > 0)
+				throw new AggregateException (exceptions);
+
+
 			if (no_framework)
 				throw ErrorHelper.CreateError (96, "No reference to Xamarin.iOS.dll was found.");
 

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -2053,6 +2053,8 @@ namespace Xamarin.Bundler {
 					// "PackageInspectionFailed: Failed to load Info.plist from bundle at path /private/var/installd/Library/Caches/com.apple.mobile.installd.staging/temp.CR0vmK/extracted/testapp.app/Frameworks/TestApp.framework"
 					var target_name = assemblies [0].BuildTargetName;
 					var resource_directory = Path.Combine (AppDirectory, "Frameworks", $"{target_name}.framework", "MonoBundle");
+					if (IsSimulatorBuild)
+						resource_directory = Path.Combine (resource_directory, "simulator");
 					if (size_specific) {
 						assemblies [0].CopyToDirectory (Path.Combine (resource_directory, Path.GetFileName (assemblies [0].Target.AppTargetDirectory)), copy_debug_symbols: PackageManagedDebugSymbols, strip: strip, only_copy: true);
 						assemblies [1].CopyToDirectory (Path.Combine (resource_directory, Path.GetFileName (assemblies [1].Target.AppTargetDirectory)), copy_debug_symbols: PackageManagedDebugSymbols, strip: strip, only_copy: true);

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -1059,6 +1059,10 @@ namespace Xamarin.Bundler
 						if (a.HasLinkWithAttributes && !App.EnableBitCode)
 							compiler_flags.ReferenceSymbols (GetRequiredSymbols (a, true));
 					}
+					if (App.Embeddinator) {
+						if (!string.IsNullOrEmpty (App.UserGccFlags))
+							compiler_flags.AddOtherFlag (App.UserGccFlags);
+					}
 					compiler_flags.LinkWithMono ();
 					compiler_flags.LinkWithXamarin ();
 					if (GetEntryPoints ().ContainsKey ("UIApplicationMain"))

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -1365,9 +1365,6 @@ namespace Xamarin.Bundler
 
 			linker_flags.AddOtherFlag ($"-o {Driver.Quote (Executable)}");
 
-			linker_flags.AddOtherFlag ("-lz");
-			linker_flags.AddOtherFlag ("-liconv");
-
 			bool need_libcpp = false;
 			if (App.EnableBitCode)
 				need_libcpp = true;

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -1315,7 +1315,7 @@ namespace Xamarin.Bundler
 
 		public void NativeLink (BuildTasks build_tasks)
 		{
-			if (App.Embeddinator) {
+			if (App.Embeddinator && App.IsDeviceBuild) {
 				build_tasks.AddRange (embeddinator_tasks);
 				return;
 			}

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -1397,20 +1397,25 @@ namespace Xamarin.Bundler
 				linker_flags.ReferenceSymbols (GetRequiredSymbols ());
 			}
 
-			string mainlib;
-			if (App.IsWatchExtension) {
-				mainlib = "libwatchextension.a";
-				linker_flags.AddOtherFlag (" -e _xamarin_watchextension_main");
-			} else if (App.IsTVExtension) {
-				mainlib = "libtvextension.a";
-			} else if (App.IsExtension) {
-				mainlib = "libextension.a";
-			} else {
-				mainlib = "libapp.a";
-			}
 			var libdir = Path.Combine (Driver.GetProductSdkDirectory (App), "usr", "lib");
-			var libmain = Path.Combine (libdir, mainlib);
-			linker_flags.AddLinkWith (libmain, true);
+			if (App.Embeddinator) {
+				linker_flags.AddOtherFlag ("-shared");
+				linker_flags.AddOtherFlag ($"-install_name {Driver.Quote ($"@rpath/{App.ExecutableName}.framework/{App.ExecutableName}")}");
+			} else {
+				string mainlib;
+				if (App.IsWatchExtension) {
+					mainlib = "libwatchextension.a";
+					linker_flags.AddOtherFlag (" -e _xamarin_watchextension_main");
+				} else if (App.IsTVExtension) {
+					mainlib = "libtvextension.a";
+				} else if (App.IsExtension) {
+					mainlib = "libextension.a";
+				} else {
+					mainlib = "libapp.a";
+				}
+				var libmain = Path.Combine (libdir, mainlib);
+				linker_flags.AddLinkWith (libmain, true);
+			}
 
 			if (App.EnableProfiling) {
 				string libprofiler;

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -48,6 +48,7 @@ namespace Xamarin.Bundler
 		Dictionary<Abi, CompileTask> pinvoke_tasks = new Dictionary<Abi, CompileTask> ();
 		List<CompileTask> link_with_task_output = new List<CompileTask> ();
 		List<AOTTask> aot_dependencies = new List<AOTTask> ();
+		List<LinkTask> embeddinator_tasks = new List<LinkTask> ();
 		CompilerFlags linker_flags;
 		NativeLinkTask link_task;
 
@@ -1094,6 +1095,12 @@ namespace Xamarin.Bundler
 					link_task.AddDependency (link_dependencies);
 					link_task.AddDependency (aottasks);
 
+					if (App.Embeddinator) {
+						link_task.AddDependency (link_with_task_output);
+						link_task.CompilerFlags.AddLinkWith (link_with_task_output.Select ((v) => v.OutputFile));
+						embeddinator_tasks.Add (link_task);
+					}
+
 					LinkWithBuildTarget (build_target, name, link_task, assemblies);
 
 					foreach (var info in infos)
@@ -1209,9 +1216,6 @@ namespace Xamarin.Bundler
 				ErrorHelper.Warning (3006, "Could not compute a complete dependency map for the project. This will result in slower build times because Xamarin.iOS can't properly detect what needs to be rebuilt (and what does not need to be rebuilt). Please review previous warnings for more details.");
 			}
 
-			// Compile the managed assemblies into object files, frameworks or shared libraries
-			AOTCompile ();
-
 			List<string> registration_methods = new List<string> ();
 
 			// The static registrar.
@@ -1303,11 +1307,19 @@ namespace Xamarin.Bundler
 				LinkWithTaskOutput (main_task);
 			}
 
+			// Compile the managed assemblies into object files, frameworks or shared libraries
+			AOTCompile ();
+
 			Driver.Watch ("Compile", 1);
 		}
 
 		public void NativeLink (BuildTasks build_tasks)
 		{
+			if (App.Embeddinator) {
+				build_tasks.AddRange (embeddinator_tasks);
+				return;
+			}
+
 			if (!string.IsNullOrEmpty (App.UserGccFlags))
 				App.DeadStrip = false;
 			if (App.EnableLLVMOnlyBitCode)

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -228,6 +228,7 @@ namespace Xamarin.Bundler
 					// We check elsewhere that the path exists, so I'm not sure how we can get into this.
 					throw ErrorHelper.CreateError (2019, "Can not load the root assembly '{0}'.", root_assembly);
 				}
+				roots.Add (root);
 			}
 
 			foreach (var reference in App.References) {

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -67,7 +67,7 @@ namespace MonoTouch.Tuner {
 			var pipeline = CreatePipeline (options);
 
 			foreach (var ad in options.MainAssemblies)
-				pipeline.PrependStep (new MobileResolveMainAssemblyStep (ad));
+				pipeline.PrependStep (new MobileResolveMainAssemblyStep (ad, options.Application.Embeddinator));
 
 			context = CreateLinkContext (options, pipeline);
 			context.Resolver.AddSearchDirectory (options.OutputDirectory);

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Bundler {
 	//					MT0005	<unused>
 	//					MT0006	There is no devel platform at '{0}', use --platform=PLAT to specify the SDK
 	//					MT0007	The root assembly '{0}' does not exist
-	//					MT0008	You should provide one root assembly only, found {0} assemblies: '{1}'
+	//					MT0008	<unused>
 	//					MT0009	Error while loading assemblies: {0}
 	//					MT0010	Could not parse the command line arguments: {0}
 	//					MT0011	{0} was built against a more recent runtime ({1}) than Xamarin.iOS supports

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -111,6 +111,7 @@ namespace Xamarin.Bundler
 			DownloadCrashReport,
 			KillWatchApp,
 			LaunchWatchApp,
+			Embeddinator,
 		}
 
 		static bool xcode_version_check = true;
@@ -1010,6 +1011,11 @@ namespace Xamarin.Bundler
 			{ "v", "Verbose", v => verbose++ },
 			{ "q", "Quiet", v => verbose-- },
 			{ "time", v => watch_level++ },
+			{ "embeddinator", "Enables Embeddinator targetting mode.", v =>
+				{
+					app.Embeddinator = true;
+				}, true
+			},
 			{ "executable=", "Specifies the native executable name to output", v => app.ExecutableName = v },
 			{ "nofastsim", "Do not run the simulator fast-path build", v => app.NoFastSim = true },
 			{ "nodevcodeshare", "Do not share native code between extensions and main app.", v => app.NoDevCodeShare = true },

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -680,9 +680,9 @@ namespace Xamarin.Bundler
 						// the name of the executable must be the bundle id (reverse dns notation)
 						// but we do not want to impose that (ugly) restriction to the managed .exe / project name / ...
 						sw.WriteLine ("\targv [0] = (char *) \"{0}\";", Path.GetFileNameWithoutExtension (app.RootAssemblies [0]));
-						sw.WriteLine ("\tint rv = xamarin_main (argc, argv, true);");
+						sw.WriteLine ("\tint rv = xamarin_main (argc, argv, XamarinLaunchModeApp);");
 					} else {
-						sw.WriteLine ("\tint rv = xamarin_main (argc, argv, false);");
+						sw.WriteLine ("\tint rv = xamarin_main (argc, argv, XamarinLaunchModeExtension);");
 					}
 					sw.WriteLine ("\t[pool drain];");
 					sw.WriteLine ("\treturn rv;");

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -683,9 +683,9 @@ namespace Xamarin.Bundler
 						// the name of the executable must be the bundle id (reverse dns notation)
 						// but we do not want to impose that (ugly) restriction to the managed .exe / project name / ...
 						sw.WriteLine ("\targv [0] = (char *) \"{0}\";", Path.GetFileNameWithoutExtension (app.RootAssemblies [0]));
-						sw.WriteLine ("\tint rv = xamarin_main (argc, argv, XamarinLaunchModeApp);");
-					} else {
 						sw.WriteLine ("\tint rv = xamarin_main (argc, argv, XamarinLaunchModeExtension);");
+					} else {
+						sw.WriteLine ("\tint rv = xamarin_main (argc, argv, XamarinLaunchModeApp);");
 					}
 					sw.WriteLine ("\t[pool drain];");
 					sw.WriteLine ("\treturn rv;");

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -569,7 +569,7 @@ namespace Xamarin.Bundler
 				}
 			}
 
-			if ((abi & Abi.SimulatorArchMask) == 0) {
+			if ((abi & Abi.SimulatorArchMask) == 0 || app.Embeddinator) {
 				var frameworks = assemblies.Where ((a) => a.BuildTarget == AssemblyBuildTarget.Framework)
 				                           .OrderBy ((a) => a.Identity, StringComparer.Ordinal);
 				foreach (var asm_fw in frameworks) {

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -576,11 +576,13 @@ namespace Xamarin.Bundler
 					var asm_name = asm_fw.Identity;
 					if (asm_fw.BuildTargetName == asm_name)
 						continue; // this is deduceable
-					if (app.IsExtension && asm_fw.IsCodeShared) {
-						assembly_location.AppendFormat ("\t{{ \"{0}\", \"../../Frameworks/{1}.framework/MonoBundle\" }},\n", asm_name, asm_fw.BuildTargetName);
-					} else {
-						assembly_location.AppendFormat ("\t{{ \"{0}\", \"Frameworks/{1}.framework/MonoBundle\" }},\n", asm_name, asm_fw.BuildTargetName);
-					}
+					var prefix = string.Empty;
+					if (app.IsExtension && asm_fw.IsCodeShared)
+						prefix = "../../";
+					var suffix = string.Empty;
+					if (app.IsSimulatorBuild)
+						suffix = "/simulator";
+					assembly_location.AppendFormat ("\t{{ \"{0}\", \"{2}Frameworks/{1}.framework/MonoBundle{3}\" }},\n", asm_name, asm_fw.BuildTargetName, prefix, suffix);
 					assembly_location_count++;
 				}
 			}

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -885,6 +885,9 @@ namespace Xamarin.Bundler
 			if (app.MarshalObjectiveCExceptions != MarshalObjectiveCExceptionMode.UnwindManagedCode)
 				return false; // UnwindManagedCode is the default for debug builds.
 
+			if (app.Embeddinator)
+				return false;
+
 			return true;
 		}
 

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -679,7 +679,7 @@ namespace Xamarin.Bundler
 					if (app.IsExtension) {
 						// the name of the executable must be the bundle id (reverse dns notation)
 						// but we do not want to impose that (ugly) restriction to the managed .exe / project name / ...
-						sw.WriteLine ("\targv [0] = (char *) \"{0}\";", Path.GetFileNameWithoutExtension (app.RootAssembly));
+						sw.WriteLine ("\targv [0] = (char *) \"{0}\";", Path.GetFileNameWithoutExtension (app.RootAssemblies [0]));
 						sw.WriteLine ("\tint rv = xamarin_main (argc, argv, true);");
 					} else {
 						sw.WriteLine ("\tint rv = xamarin_main (argc, argv, false);");
@@ -1301,23 +1301,9 @@ namespace Xamarin.Bundler
 			app.RuntimeOptions = RuntimeOptions.Create (app, http_message_handler, tls_provider);
 
 			if (action == Action.Build || action == Action.RunRegistrar) {
-				if (assemblies.Count != 1) {
-					var exceptions = new List<Exception> ();
-					for (int i = assemblies.Count - 1; i >= 0; i--) {
-						if (assemblies [i].StartsWith ("-", StringComparison.Ordinal)) {
-							exceptions.Add (new MonoTouchException (18, true, "Unknown command line argument: '{0}'", assemblies [i]));
-							assemblies.RemoveAt (i);
-						}
-					}
-					if (assemblies.Count > 1) {
-						exceptions.Add (new MonoTouchException (8, true, "You should provide one root assembly only, found {0} assemblies: '{1}'", assemblies.Count, string.Join ("', '", assemblies.ToArray ())));
-					} else if (assemblies.Count == 0) {
-						exceptions.Add (new MonoTouchException (17, true, "You should provide a root assembly."));
-					}
-
-					throw new AggregateException (exceptions);
-				}
-				app.RootAssembly = assemblies [0];
+				if (assemblies.Count == 0)
+					throw new MonoTouchException (17, true, "You should provide a root assembly.");
+				app.RootAssemblies = assemblies;
 			}
 
 			return app;

--- a/tools/mtouch/simlauncher.m
+++ b/tools/mtouch/simlauncher.m
@@ -28,7 +28,7 @@ void xamarin_setup_impl ()
 int
 main (int argc, char** argv)
 {
-	@autoreleasepool { return xamarin_main (argc, argv, false); }
+	@autoreleasepool { return xamarin_main (argc, argv, XamarinLaunchModeApp); }
 }
 
 


### PR DESCRIPTION
This is a series of commits that adds an embeddinator mode to mtouch and our
runtime.

The commits are quite small and self-contained, but they don't really make
much sense by themselves (separate from embeddinator support), so I put them
all in one pull request.

It's probably easiest to review commit-by-commit, since the commit message explains each change.