### PR TITLE
[mtouch] Update code that only considered .mdb (not .pdb) (#2003)

### DIFF
--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -98,7 +98,7 @@ namespace Xamarin.Bundler {
 		}
 
 		// returns false if the assembly was not copied (because it was already up-to-date).
-		public bool CopyAssembly (string source, string target, bool copy_mdb = true, bool strip = false)
+		public bool CopyAssembly (string source, string target, bool copy_debug_symbols = true, bool strip = false)
 		{
 			var copied = false;
 
@@ -117,7 +117,7 @@ namespace Xamarin.Bundler {
 				}
 
 				// Update the debug symbols file even if the assembly didn't change.
-				if (copy_mdb) {
+				if (copy_debug_symbols) {
 					if (File.Exists (source + ".mdb"))
 						Application.UpdateFile (source + ".mdb", target + ".mdb", true);
 
@@ -134,7 +134,7 @@ namespace Xamarin.Bundler {
 			return copied;
 		}
 
-		public void CopyMdbToDirectory (string directory)
+		public void CopyDebugSymbolsToDirectory (string directory)
 		{
 			string mdb_src = FullPath + ".mdb";
 			if (File.Exists (mdb_src)) {
@@ -184,7 +184,7 @@ namespace Xamarin.Bundler {
 		// Aot data is copied separately, because we might want to copy aot data 
 		// even if we don't want to copy the assembly (if 32/64-bit assemblies are identical, 
 		// only one is copied, but we still want the aotdata for both).
-		public void CopyToDirectory (string directory, bool reload = true, bool check_case = false, bool only_copy = false, bool copy_mdb = true, bool strip = false)
+		public void CopyToDirectory (string directory, bool reload = true, bool check_case = false, bool only_copy = false, bool copy_debug_symbols = true, bool strip = false)
 		{
 			var target = Path.Combine (directory, FileName);
 
@@ -197,7 +197,7 @@ namespace Xamarin.Bundler {
 
 			// our Copy code deletes the target (so copy'ing over itself is a bad idea)
 			if (directory != Path.GetDirectoryName (FullPath))
-				CopyAssembly (FullPath, target, copy_mdb: copy_mdb, strip: strip);
+				CopyAssembly (FullPath, target, copy_debug_symbols: copy_debug_symbols, strip: strip);
 
 			CopySatellitesToDirectory (directory);
 

--- a/tools/mtouch/BuildTasks.mtouch.cs
+++ b/tools/mtouch/BuildTasks.mtouch.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -208,6 +208,9 @@ namespace Xamarin.Bundler
 					var mdb = Assembly.FullPath + ".mdb";
 					if (File.Exists (mdb))
 						inputs.Add (mdb);
+					var pdb = Path.ChangeExtension (Assembly.FullPath, ".pdb");
+					if (File.Exists (pdb))
+						inputs.Add (pdb);
 					var config = Assembly.FullPath + ".config";
 					if (File.Exists (config))
 						inputs.Add (config);

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // mtouch.cs: A tool to generate the necessary code to boot a Mono
 // application on the iPhone
 //
@@ -58,7 +58,7 @@ using System.Threading;
 
 using Mono.Options;
 using Mono.Cecil;
-using Mono.Cecil.Mdb;
+using Mono.Cecil.Cil;
 using Mono.Tuner;
 
 using MonoTouch.Tuner;
@@ -129,13 +129,6 @@ namespace Xamarin.Bundler
 				return dot;
 			}
 		}
-
-		//
-		// We need to put a hard dep on Mono.Cecil.Mdb.dll so that it get's mkbundled
-		//
-#pragma warning disable 169
-		static MdbReader mdb_reader;
-#pragma warning restore 169
 
 		static int GetDefaultVerbosity ()
 		{
@@ -460,7 +453,7 @@ namespace Xamarin.Bundler
 			bool enable_llvm = (abi & Abi.LLVM) != 0;
 			bool enable_thumb = (abi & Abi.Thumb) != 0;
 			bool enable_debug = app.EnableDebug;
-			bool enable_mdb = app.PackageMdb;
+			bool enable_debug_symbols = app.PackageManagedDebugSymbols;
 			bool llvm_only = app.EnableLLVMOnlyBitCode;
 			string arch = abi.AsArchString ();
 
@@ -487,7 +480,7 @@ namespace Xamarin.Bundler
 
 			if (enable_llvm)
 				args.Append ("nodebug,");
-			else if (!(enable_debug || enable_mdb))
+			else if (!(enable_debug || enable_debug_symbols))
 				args.Append ("nodebug,");
 			else if (app.DebugAll || app.DebugAssemblies.Contains (fname) || !sdk_or_product)
 				args.Append ("soft-debug,");
@@ -662,7 +655,7 @@ namespace Xamarin.Bundler
 
 					if (app.EnableDebug)
 						sw.WriteLine ("\txamarin_gc_pump = {0};", app.DebugTrack.Value ? "TRUE" : "FALSE");
-					sw.WriteLine ("\txamarin_init_mono_debug = {0};", app.PackageMdb ? "TRUE" : "FALSE");
+					sw.WriteLine ("\txamarin_init_mono_debug = {0};", app.PackageManagedDebugSymbols ? "TRUE" : "FALSE");
 					sw.WriteLine ("\txamarin_executable_name = \"{0}\";", assembly_name);
 					sw.WriteLine ("\tmono_use_llvm = {0};", enable_llvm ? "TRUE" : "FALSE");
 					sw.WriteLine ("\txamarin_log_level = {0};", verbose);
@@ -1224,7 +1217,8 @@ namespace Xamarin.Bundler
 					}
 				}
 			},
-			{ "package-mdb:", "Specify whether debug info files (*.mdb) should be packaged in the app. Default is 'true' for debug builds and 'false' for release builds.", v => app.PackageMdb = ParseBool (v, "package-mdb") },
+			{ "package-mdb:", "Specify whether debug info files (*.mdb) should be packaged in the app. Default is 'true' for debug builds and 'false' for release builds.", v => app.PackageManagedDebugSymbols = ParseBool (v, "package-mdb"), true },
+			{ "package-debug-symbols:", "Specify whether debug info files (*.mdb / *.pdb) should be packaged in the app. Default is 'true' for debug builds and 'false' for release builds.", v => app.PackageManagedDebugSymbols = ParseBool (v, "package-debug-symbols") },
 			{ "msym:", "Specify whether managed symbolication files (*.msym) should be created. Default is 'false' for debug builds and 'true' for release builds.", v => app.EnableMSym = ParseBool (v, "msym") },
 			{ "extension", v => app.IsExtension = true },
 			{ "app-extension=", "The path of app extensions that are included in the app. This must be specified once for each app extension.", v => app.Extensions.Add (v), true /* MSBuild-internal for now */ },


### PR DESCRIPTION
Also stop using `mdb` as the name for debug symbols and remove

> static MdbReader mdb_reader;

since we're not mkbundl'ing mtouch anymore.

Related to https://github.com/xamarin/xamarin-macios/pull/2002 for mmp