### PR TITLE
[msbuild] Fix DetectSdkLocationsTaskBase platform check

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
@@ -96,10 +96,12 @@ namespace Xamarin.Mac.Tasks
 		bool EnsureAppleSdkRoot ()
 		{
 			if (!MacOSXSdks.Native.IsInstalled) {
-				var ideSdkPath = "(Tools > Options > Xamarin > iOS Settings > Apple SDK)";
+				string ideSdkPath;
 				if (Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX)
 					ideSdkPath = "(Project > SDK Locations > Apple > Apple SDK)";
-				Log.LogError ("Could not find a valid Xcode app bundle at '{0}'. Please update your Apple SDK location in Visual Studio's preferences {1}.", AppleSdkSettings.InvalidDeveloperRoot, ideSdkPath);
+				else
+					ideSdkPath = "(Tools > Options > Xamarin > iOS Settings > Apple SDK)";
+				Log.LogError("Could not find a valid Xcode app bundle at '{0}'. Please update your Apple SDK location in Visual Studio's preferences {1}.", AppleSdkSettings.InvalidDeveloperRoot, ideSdkPath);
 				return false;
 			}
 			Log.LogMessage(MessageImportance.Low, "DeveloperRoot: {0}", MacOSXSdks.Native.DeveloperRoot);

--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
@@ -97,11 +97,13 @@ namespace Xamarin.Mac.Tasks
 		{
 			if (!MacOSXSdks.Native.IsInstalled) {
 				string ideSdkPath;
-				if (Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX)
-					ideSdkPath = "(Project > SDK Locations > Apple > Apple SDK)";
+				if (string.IsNullOrEmpty(SessionId))
+					// SessionId is only and always defined on windows.
+					// We can't check 'Environment.OSVersion.Platform' since the base tasks are always executed on the Mac.
+					ideSdkPath = "(Projects > SDK Locations > Apple > Apple SDK)";
 				else
 					ideSdkPath = "(Tools > Options > Xamarin > iOS Settings > Apple SDK)";
-				Log.LogError("Could not find a valid Xcode app bundle at '{0}'. Please update your Apple SDK location in Visual Studio's preferences {1}.", AppleSdkSettings.InvalidDeveloperRoot, ideSdkPath);
+				Log.LogError ("Could not find a valid Xcode app bundle at '{0}'. Please update your Apple SDK location in Visual Studio's preferences {1}.", AppleSdkSettings.InvalidDeveloperRoot, ideSdkPath);
 				return false;
 			}
 			Log.LogMessage(MessageImportance.Low, "DeveloperRoot: {0}", MacOSXSdks.Native.DeveloperRoot);

--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
@@ -96,10 +96,9 @@ namespace Xamarin.Mac.Tasks
 		bool EnsureAppleSdkRoot ()
 		{
 			if (!MacOSXSdks.Native.IsInstalled) {
-				var ideSdkPath = "(Project > SDK Locations > Apple > Apple SDK)";
-#if WINDOWS
 				var ideSdkPath = "(Tools > Options > Xamarin > iOS Settings > Apple SDK)";
-#endif
+				if (Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX)
+					ideSdkPath = "(Project > SDK Locations > Apple > Apple SDK)";
 				Log.LogError ("Could not find a valid Xcode app bundle at '{0}'. Please update your Apple SDK location in Visual Studio's preferences {1}.", AppleSdkSettings.InvalidDeveloperRoot, ideSdkPath);
 				return false;
 			}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
@@ -291,9 +291,11 @@ namespace Xamarin.iOS.Tasks
 		bool EnsureAppleSdkRoot ()
 		{
 			if (!CurrentSdk.IsInstalled) {
-				var ideSdkPath = "(Tools > Options > Xamarin > iOS Settings > Apple SDK)";
+				string ideSdkPath;
 				if (Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX)
 					ideSdkPath = "(Project > SDK Locations > Apple > Apple SDK)";
+				else
+					ideSdkPath = "(Tools > Options > Xamarin > iOS Settings > Apple SDK)";
 				Log.LogError ("Could not find a valid Xcode app bundle at '{0}'. Please update your Apple SDK location in Visual Studio's preferences {1}.", AppleSdkSettings.InvalidDeveloperRoot, ideSdkPath);
 				return false;
 			}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
@@ -292,7 +292,9 @@ namespace Xamarin.iOS.Tasks
 		{
 			if (!CurrentSdk.IsInstalled) {
 				string ideSdkPath;
-				if (Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX)
+				if (string.IsNullOrEmpty(SessionId))
+					// SessionId is only and always defined on windows.
+					// We can't check 'Environment.OSVersion.Platform' since the base tasks are always executed on the Mac.
 					ideSdkPath = "(Project > SDK Locations > Apple > Apple SDK)";
 				else
 					ideSdkPath = "(Tools > Options > Xamarin > iOS Settings > Apple SDK)";

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
@@ -291,10 +291,9 @@ namespace Xamarin.iOS.Tasks
 		bool EnsureAppleSdkRoot ()
 		{
 			if (!CurrentSdk.IsInstalled) {
-				var ideSdkPath = "(Project > SDK Locations > Apple > Apple SDK)";
-#if WINDOWS
 				var ideSdkPath = "(Tools > Options > Xamarin > iOS Settings > Apple SDK)";
-#endif
+				if (Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX)
+					ideSdkPath = "(Project > SDK Locations > Apple > Apple SDK)";
 				Log.LogError ("Could not find a valid Xcode app bundle at '{0}'. Please update your Apple SDK location in Visual Studio's preferences {1}.", AppleSdkSettings.InvalidDeveloperRoot, ideSdkPath);
 				return false;
 			}


### PR DESCRIPTION
For windows, ideSdkPath was defined twice.
Also the base tasks are being built only on the Mac, VSW get those from the bundle.zip, so the Windows check should be done at runtime.