### PR TITLE
[tests][mtouch] Fix MT0091 test after error text change. (#1956)

### DIFF
--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -35,6 +35,39 @@ namespace Xamarin.Tests
 		public static bool include_watchos;
 		public static bool include_device;
 
+		// This is the location of an Xcode which is older than the recommended one.
+		public static string GetOldXcodeRoot (Version min_version = null)
+		{
+			var xcodes = Directory.GetDirectories ("/Applications", "Xcode*.app", SearchOption.TopDirectoryOnly);
+			var with_versions = new List<Tuple<Version, string>> ();
+
+			var max_version = Version.Parse (XcodeVersion);
+			foreach (var xcode in xcodes) {
+				var path = Path.Combine (xcode, "Contents", "Developer");
+				var version = Version.Parse (GetXcodeVersion (path));
+				if (version >= max_version)
+					continue;
+				if (min_version != null && version < min_version)
+					continue;
+				with_versions.Add (new Tuple<Version, string> (version, path));
+			}
+
+			if (with_versions.Count == 0)
+				return null;
+
+			with_versions.Sort ((x, y) =>
+			{
+				if (x.Item1 > y.Item1)
+					return -1;
+				else if (x.Item1 < y.Item1)
+					return 1;
+				else
+					return 0;
+			});
+
+			return with_versions [0].Item2; // return the most recent Xcode older than the recommended one.
+		}
+
 		// This is /Library/Frameworks/Xamarin.iOS.framework/Versions/Current if running
 		// against a system XI, otherwise it's the <git checkout>/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current directory.
 		public static string MonoTouchRootDirectory {
@@ -95,6 +128,28 @@ namespace Xamarin.Tests
 			return result;
 		}
 
+		static string GetXcodeVersion (string xcode_path)
+		{
+			var version_plist = Path.Combine (xcode_path, "..", "version.plist");
+			if (!File.Exists (version_plist))
+				return null;
+
+			return GetPListStringValue (version_plist, "CFBundleShortVersionString");
+		}
+
+		public static string GetPListStringValue (string plist, string key)
+		{
+			var settings = new System.Xml.XmlReaderSettings ();
+			settings.DtdProcessing = System.Xml.DtdProcessing.Ignore;
+			var doc = new System.Xml.XmlDocument ();
+			using (var fs = new FileStream (plist, FileMode.Open, FileAccess.Read)) {
+				using (var reader = System.Xml.XmlReader.Create (fs, settings)) {
+					doc.Load (reader);
+					return doc.DocumentElement.SelectSingleNode ($"//dict/key[text()='{key}']/following-sibling::string[1]/text()").Value;
+				}
+			}
+		}
+
 		static Configuration ()
 		{
 			ParseConfigFiles ();
@@ -114,18 +169,7 @@ namespace Xamarin.Tests
 			include_watchos = !string.IsNullOrEmpty (GetVariable ("INCLUDE_WATCH", ""));
 			include_device = !string.IsNullOrEmpty (GetVariable ("INCLUDE_DEVICE", ""));
 
-			var version_plist = Path.Combine (xcode_root, "..", "version.plist");
-			if (File.Exists (version_plist)) {
-				var settings = new System.Xml.XmlReaderSettings ();
-				settings.DtdProcessing = System.Xml.DtdProcessing.Ignore;
-				var doc = new System.Xml.XmlDocument ();
-				using (var fs = new FileStream (version_plist, FileMode.Open, FileAccess.Read)) {
-					using (var reader = System.Xml.XmlReader.Create (fs, settings)) {
-						doc.Load (reader);
-						XcodeVersion = doc.DocumentElement.SelectSingleNode ("//dict/key[text()='CFBundleShortVersionString']/following-sibling::string[1]/text()").Value;
-					}
-				}
-			}
+			XcodeVersion = GetXcodeVersion (xcode_root);
 #if MONOMAC
 			mac_xcode_root = xcode_root;
 #endif

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -851,18 +851,37 @@ namespace Xamarin
 		[TestCase (Profile.iOS, "iOS")]
 		public void MT0091 (Profile profile, string name)
 		{
-			// Any old Xcode would do.
-			if (!Directory.Exists (Configuration.xcode72_root))
-				Assert.Ignore ("This test needs Xcode 7.0");
-			
+			// Any old Xcode will do.
+			var old_xcode = Configuration.GetOldXcodeRoot ();
+			if (!Directory.Exists (old_xcode))
+				Assert.Ignore ($"This test needs an Xcode older than {Configuration.XcodeVersion}");
+
+			// Get the SDK version for this Xcode version
+			string sdk_platform;
+			switch (profile) {
+			case Profile.iOS:
+				sdk_platform = "iPhoneSimulator";
+				break;
+			case Profile.tvOS:
+				sdk_platform = "AppleTVSimulator";
+				break;
+			case Profile.watchOS:
+				sdk_platform = "WatchSimulator";
+				break;
+			default:
+				throw new NotImplementedException ();
+			}
+			var sdk_settings = Path.Combine (old_xcode, "Platforms", $"{sdk_platform}.platform", "Developer", "SDKs", $"{sdk_platform}.sdk", "SDKSettings.plist");
+			var sdk_version = Configuration.GetPListStringValue (sdk_settings, "DefaultDeploymentTarget");
+
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.Profile = profile;
 				mtouch.CreateTemporaryApp ();
-				mtouch.SdkRoot = Configuration.xcode72_root;
+				mtouch.SdkRoot = old_xcode;
 				mtouch.Linker = MTouchLinker.DontLink;
-				mtouch.Sdk = "9.0";
+				mtouch.Sdk = sdk_version;
 				Assert.AreEqual (1, mtouch.Execute (MTouchAction.BuildSim));
-				mtouch.AssertError (91, String.Format ("This version of Xamarin.iOS requires the {0} {1} SDK (shipped with Xcode {2}) when the managed linker is disabled. Either upgrade Xcode, or enable the managed linker by changing the Linker behaviour to Link Framework SDKs Only.", name, GetSdkVersion (profile), Configuration.XcodeVersion));
+				mtouch.AssertError (91, String.Format ("This version of Xamarin.iOS requires the {0} {1} SDK (shipped with Xcode {2}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only (to try to avoid the new APIs).", name, GetSdkVersion (profile), Configuration.XcodeVersion));
 			}
 		}
 


### PR DESCRIPTION
Also fix the test to not depend on having a specific version of an older Xcode
installed, but instead use any old Xcode.