### PR TITLE
Add support for the embeddinator in the static registrar.

### DIFF
--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -764,6 +764,8 @@ namespace XamCore.Registrar {
 #if !MTOUCH && !MMP
 			public int Size;
 			public byte Alignment;
+#else
+			public bool IsPrivate;
 #endif
 			public string FieldType;
 			public bool IsProperty;
@@ -1431,6 +1433,18 @@ namespace XamCore.Registrar {
 			return objcType;
 		}
 			
+		protected bool SupportsModernObjectiveC {
+			get {
+#if MTOUCH || MONOTOUCH
+				return true;
+#elif MMP
+				return App.Is64Build;
+#elif MONOMAC
+				return IntPtr.Size == 8;
+#endif
+			}
+		}
+
 		// This method is not thread-safe wrt 'types', and must be called with
 		// a lock held on 'types'.
 		ObjCType RegisterTypeUnsafe (TType type, ref List<Exception> exceptions)
@@ -1593,6 +1607,7 @@ namespace XamCore.Registrar {
 							DeclaringType = objcType,
 							FieldType = "XamarinObject",// "^v", // void*
 							Name = "__monoObjectGCHandle",
+							IsPrivate = SupportsModernObjectiveC,
 						}, ref exceptions);
 					}
 #endif

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -208,9 +208,9 @@ namespace Xamarin.MMP.Tests
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir);
 
 				// Due to https://bugzilla.xamarin.com/show_bug.cgi?id=48311 we can get warnings related to the registrar
-				// So ignore anything with registrar.m or gl3.h in the line
+				// So ignore anything with registrar.m or registrar.h or gl3.h in the line
 				Func<string, bool> hasLegitWarning = results =>
-					results.Split (Environment.NewLine.ToCharArray ()).Any (x => x.Contains ("warning") && !x.Contains ("registrar.m") && !x.Contains ("gl3.h"));
+					results.Split (Environment.NewLine.ToCharArray ()).Any (x => x.Contains ("warning") && !x.Contains ("registrar.m") && !x.Contains ("registrar.h") && !x.Contains ("gl3.h"));
 
 				// Mobile
 				string buildResults = TI.TestUnifiedExecutable (test).BuildOutput;

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -66,6 +66,8 @@ namespace Xamarin.Bundler {
 		public static int Concurrency => Driver.Concurrency;
 		public Version DeploymentTarget;
 		public Version SdkVersion;
+	
+		public bool Embeddinator { get; set; }
 
 		public Application (string[] arguments)
 		{

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -98,6 +98,9 @@ namespace Xamarin.Bundler {
 			options.Add ("j|jobs=", "The level of concurrency. Default is the number of processors.", v => {
 				Jobs = int.Parse (v);
 			});
+			options.Add ("embeddinator", "Enables Embeddinator targetting mode.", v => {
+				app.Embeddinator = true;
+			}, true);
 		}
 
 		static int Jobs;

--- a/tools/common/PInvokeWrapperGenerator.cs
+++ b/tools/common/PInvokeWrapperGenerator.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Bundler
 		AutoIndentStringBuilder hdr = new AutoIndentStringBuilder ();
 		AutoIndentStringBuilder decls = new AutoIndentStringBuilder ();
 		AutoIndentStringBuilder mthds = new AutoIndentStringBuilder ();
+		AutoIndentStringBuilder ifaces = new AutoIndentStringBuilder ();
 						
 		public StaticRegistrar Registrar;
 		public string HeaderPath;
@@ -46,7 +47,7 @@ namespace Xamarin.Bundler
 			hdr.WriteLine ("#include <objc/runtime.h>");
 			hdr.WriteLine ("#include <objc/message.h>");
 
-			Registrar.GeneratePInvokeWrappersStart (hdr, decls, mthds);
+			Registrar.GeneratePInvokeWrappersStart (hdr, decls, mthds, ifaces) ;
 
 			mthds.WriteLine ($"#include \"{Path.GetFileName (HeaderPath)}\"");
 
@@ -62,7 +63,7 @@ namespace Xamarin.Bundler
 
 			Registrar.GeneratePInvokeWrappersEnd ();
 
-			Driver.WriteIfDifferent (HeaderPath, hdr.ToString () + "\n" + decls.ToString () + "\n");
+			Driver.WriteIfDifferent (HeaderPath, hdr.ToString () + "\n" + decls.ToString () + "\n" + ifaces.ToString () + "\n") ;
 			Driver.WriteIfDifferent (SourcePath, mthds.ToString () + "\n" + sb.ToString () + "\n");
 		}
 

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3766,8 +3766,10 @@ namespace XamCore.Registrar {
 			header.WriteLine ("#pragma clang diagnostic ignored \"-Wtypedef-redefinition\""); // temporary hack until we can stop including glib.h
 			header.WriteLine ("#pragma clang diagnostic ignored \"-Wobjc-designated-initializers\"");
 
-			if (App.EnableDebug)
+			if (App.EnableDebug) {
 				header.WriteLine ("#define DEBUG 1");
+				methods.WriteLine ("#define DEBUG 1");
+			}
 
 			header.WriteLine ("#include <stdarg.h>");
 			if (SupportsModernObjectiveC) {

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3356,6 +3356,9 @@ namespace XamCore.Registrar {
 				}
 			}
 
+			if (App.Embeddinator)
+				body.WriteLine ("xamarin_embeddinator_initialize ();");
+
 			body.WriteLine ("MONO_ASSERT_GC_SAFE;");
 			body.WriteLine ("MONO_THREAD_ATTACH;"); // COOP: this will switch to GC_UNSAFE
 			body.WriteLine ();
@@ -3779,6 +3782,9 @@ namespace XamCore.Registrar {
 			methods.WriteLine ($"#include \"{Path.GetFileName (header_path)}\"");
 			methods.StringBuilder.AppendLine ("extern \"C\" {");
 
+			if (App.Embeddinator)
+				methods.WriteLine ("void xamarin_embeddinator_initialize ();");
+			
 			Specialize (sb);
 
 			methods.StringBuilder.AppendLine ("} /* extern \"C\" */");

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -490,8 +490,6 @@ namespace Xamarin.Bundler {
 
 		public BitCodeMode BitCodeMode { get; set; }
 
-		public bool Embeddinator { get; set; }
-
 		public bool EnableAsmOnlyBitCode { get { return BitCodeMode == BitCodeMode.ASMOnly; } }
 		public bool EnableLLVMOnlyBitCode { get { return BitCodeMode == BitCodeMode.LLVMOnly; } }
 		public bool EnableMarkerOnlyBitCode { get { return BitCodeMode == BitCodeMode.MarkerOnly; } }

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1016,11 +1016,6 @@ namespace Xamarin.Bundler
 			{ "v", "Verbose", v => verbose++ },
 			{ "q", "Quiet", v => verbose-- },
 			{ "time", v => watch_level++ },
-			{ "embeddinator", "Enables Embeddinator targetting mode.", v =>
-				{
-					app.Embeddinator = true;
-				}, true
-			},
 			{ "executable=", "Specifies the native executable name to output", v => app.ExecutableName = v },
 			{ "nofastsim", "Do not run the simulator fast-path build", v => app.NoFastSim = true },
 			{ "nodevcodeshare", "Do not share native code between extensions and main app.", v => app.NoDevCodeShare = true },


### PR DESCRIPTION
9cd3ab1 (Rolf Bjarne Kvinge, 6 days ago)
   [mtouch/mmp] Move --embeddinator to shared code so mmp gets it as well.

34edff8 (Rolf Bjarne Kvinge, 6 days ago)
   [static registrar] Initialize the embeddinator in every function entry.

ea12420 (Rolf Bjarne Kvinge, 6 days ago)
   [static registrar] Put the generated @interface declaration for public
   types in the header.

ab4765f (Rolf Bjarne Kvinge, 6 days ago)
   [static registrar] Add support for putting private properties in the
   implementation section.

   This makes registrar.h compilable as Objective-C (as opposed to
   Objective-C++), because the __monoObjectGCHandle field (whose type is an
   C++ type) isn't there anymore.

413b65a (Rolf Bjarne Kvinge, 6 days ago)
   [static registrar] Refactor code a little bit to avoid excessive
   indentation.