### PR TITLE
[mtouch] Don't remove information when collecting all architectures. Fixes #55555.

### DIFF
--- a/tests/common/ExecutionHelper.cs
+++ b/tests/common/ExecutionHelper.cs
@@ -211,6 +211,12 @@ namespace Xamarin.Tests
 			if (!HasOutputPattern (linePattern))
 				Assert.Fail (string.Format ("The output does not contain the line '{0}'", linePattern));
 		}
+
+		public void ForAllOutputLines (Action<string> action)
+		{
+			foreach (var line in OutputLines)
+				action (line);
+		}
 	}
 
 	class XBuild

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -89,6 +89,7 @@ namespace Xamarin
 		public bool? MSym;
 		public bool? DSym;
 		public bool? NoStrip;
+		public string NoSymbolStrip;
 		public string Mono;
 		public string GccFlags;
 
@@ -221,6 +222,14 @@ namespace Xamarin
 
 			if (NoStrip.HasValue && NoStrip.Value)
 				sb.Append (" --nostrip");
+
+			if (NoSymbolStrip != null) {
+				if (NoSymbolStrip.Length == 0) {
+					sb.Append (" --nosymbolstrip");
+				} else {
+					sb.Append (" --nosymbolstrip:").Append (NoSymbolStrip);
+				}
+			}
 
 			if (MSym.HasValue)
 				sb.Append (" --msym:").Append (MSym.Value ? "true" : "false");

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -502,10 +502,10 @@ namespace Xamarin.Bundler {
 				if (all_architectures == null) {
 					all_architectures = new HashSet<Abi> ();
 					foreach (var abi in abis)
-						all_architectures.Add (abi & Abi.ArchMask);
+						all_architectures.Add (abi);
 					foreach (var ext in AppExtensions) {
 						foreach (var abi in ext.Abis)
-							all_architectures.Add (abi & Abi.ArchMask);
+							all_architectures.Add (abi);
 					}
 				}
 				return all_architectures;

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -85,7 +85,7 @@ namespace Xamarin.Bundler
 					foreach (var abi in App.AllArchitectures) {
 						var a = abi & mask;
 						if (a != 0)
-							all_architectures.Add (a);
+							all_architectures.Add (abi);
 					}
 				}
 				return all_architectures;

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -1453,6 +1453,12 @@ namespace Xamarin.Bundler
 				linker_flags.AddOtherFlag ("-fapplication-extension");
 			}
 
+			if (App.HasFrameworks && Is64Build) {
+				// Work around https://bugzilla.xamarin.com/show_bug.cgi?id=55553
+				// This option was introduced in Xcode 5.1, so no need for Xcode version checks.
+				linker_flags.AddOtherFlag ("-Wl,-ignore_optimization_hints");
+			}
+
 			link_task = new NativeLinkTask
 			{
 				Target = this,


### PR DESCRIPTION
Of particular importance is if we're building for LLVM or not: this fixes a
bug where we wouldn't pass --llvm to the AOT compiler when compiling
assemblies to frameworks (which we do when sharing code).

https://bugzilla.xamarin.com/show_bug.cgi?id=55555