### PR TITLE
[macos] Add hybrid-aot feature string

### DIFF
--- a/Versions-mac.plist.in
+++ b/Versions-mac.plist.in
@@ -35,6 +35,7 @@
 		<string>http-client-handlers</string>
 		<string>mono-symbol-archive</string>
 		<string>sgen-concurrent-gc</string>
+		<string>hybrid-aot</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Adds feature so md-addins can check against it to determine whether to show the AOT build options