### PR TITLE
[macos] Fix test failure in CertificateTest (#2036)

### DIFF
--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -517,7 +517,10 @@ namespace MonoTouchFixtures.Security {
 			if (TestRuntime.CheckXcodeVersion (8, 3)) {
 				Assert.That (cert.GetCommonName (), Is.EqualTo ("mail.google.com"), "GetCommonName");
 				Assert.That (cert.GetSerialNumber ().Description, Is.EqualTo ("<2b9f7ee5 ca25a625 14204782 753a9bb9>"), "GetSerialNumber");
-				Assert.Null (cert.GetEmailAddresses (), "GetEmailAddresses");
+
+				var emailAddresses = cert.GetEmailAddresses ();
+				Assert.IsTrue (emailAddresses == null || emailAddresses.Length == 0, "GetEmailAddresses");
+
 				Assert.NotNull (cert.GetNormalizedIssuerSequence (), "GetNormalizedIssuerSequence");
 				Assert.NotNull (cert.GetNormalizedSubjectSequence (), "GetNormalizedSubjectSequence");
 				Assert.NotNull (cert.GetPublicKey (), "GetPublicKey");


### PR DESCRIPTION
- SecCertificateCopyEmailAddresses behaves differently on macOS than iOS with
 macOS getting the "documented" behavior of returning an empty array and iOS
 returning null.
- Fix the test to just accept null or 0 elements