### PR TITLE
[mtouch] Disable the workaround for bug #55553 when compiling for bitcode.

### DIFF
--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -1453,7 +1453,7 @@ namespace Xamarin.Bundler
 				linker_flags.AddOtherFlag ("-fapplication-extension");
 			}
 
-			if (App.HasFrameworks && Is64Build) {
+			if (App.HasFrameworks && Is64Build && !App.EnableBitCode) {
 				// Work around https://bugzilla.xamarin.com/show_bug.cgi?id=55553
 				// This option was introduced in Xcode 5.1, so no need for Xcode version checks.
 				linker_flags.AddOtherFlag ("-Wl,-ignore_optimization_hints");


### PR DESCRIPTION
The linker doesn't allow it when building for bitcode:

> 	ld: -ignore_optimization_hints and -bitcode_bundle (Xcode setting ENABLE_BITCODE=YES) cannot be used together
>	clang: error: linker command failed with exit code 1 (use -v to see invocation)

This fixes the Xamarin.MTouch.StripBitcodeFromFrameworks(tvOS,Marker) mtouch test.