### PR TITLE
[mtouch] Disable incremental builds for the simulator. Fixes #55712.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -517,6 +517,14 @@ For instance: this condition occurs when an extension builds for ARMv7+llvm+thum
 
 Native code sharing requires that all the projects that share code use the same versions for all assemblies.
 
+<h3><a name="MT0125"/>MT0125: The --assembly-build-target command-line argument is ignored in the simulator.</h3>
+
+No action is required, this message is purely informational.
+
+<h3><a name="MT0126"/>MT0126: Incremental builds have been disabled because incremental builds are not supported in the simulator.</h3>
+
+No action is required, this message is purely informational.
+
 <h3><a name="MT0127"/>MT0127: Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include more than one third-party binding libraries.</h3>
 
 Incremental builds have been disabled automatically because this version of Xamarin.iOS does not always build projects with multiple third-party binding libraries correctly.

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -388,7 +388,7 @@ namespace Xamarin.iOS.Tasks
 				args.Add ("--extension");
 
 			if (Debug) {
-				if (FastDev)
+				if (FastDev && !SdkIsSimulator)
 					args.Add ("--fastdev");
 
 				args.Add ("--debug");

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1316,6 +1316,33 @@ namespace Xamarin
 			}
 		}
 
+		[Test]
+		public void MT0125 ()
+		{
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryApp ();
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.AssemblyBuildTargets.Add ("@all=framework");
+				mtouch.Linker = MTouchLinker.DontLink; // faster test.
+				mtouch.Debug = true; // faster test, because it enables fastsim
+				mtouch.AssertExecute (MTouchAction.BuildSim, "build");
+				mtouch.AssertWarning (125, "The --assembly-build-target command-line argument is ignored in the simulator.");
+			}
+		}
+
+		[Test]
+		public void MT0126 ()
+		{
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryApp ();
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.FastDev = true;
+				mtouch.Linker = MTouchLinker.DontLink; // faster test.
+				mtouch.Debug = true; // faster test, because it enables fastsim
+				mtouch.AssertExecute (MTouchAction.BuildSim, "build");
+				mtouch.AssertWarning (126, "Incremental builds have been disabled because incremental builds are not supported in the simulator.");
+			}
+		}
 
 		[Test]
 		public void MT0127 ()

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -298,8 +298,18 @@ namespace Xamarin.Bundler {
 			Tuple<AssemblyBuildTarget, string> sdk = null;
 			List<Exception> exceptions = null;
 
-			if (IsSimulatorBuild && !Embeddinator)
+			if (IsSimulatorBuild && !Embeddinator) {
+				if (assembly_build_targets.Count > 0) {
+					var first = assembly_build_targets.First ();
+					if (assembly_build_targets.Count == 1 && first.Key == "@all" && first.Value.Item1 == AssemblyBuildTarget.DynamicLibrary && first.Value.Item2 == string.Empty) {
+						ErrorHelper.Warning (126, "Incremental builds have been disabled because incremental builds are not supported in the simulator.");
+					} else {
+						ErrorHelper.Warning (125, "The --assembly-build-target command-line argument is ignored in the simulator.");
+					}
+					assembly_build_targets.Clear ();
+				}
 				return;
+			}
 			
 			if (assembly_build_targets.Count == 0) {
 				// The logic here must match the logic in 'ContainsGroupedSdkAssemblyBuildTarget' (because we will execute 'ContainsGroupedSdkAssemblyBuildTargets' before this is executed)

--- a/tools/mtouch/error.cs
+++ b/tools/mtouch/error.cs
@@ -134,6 +134,8 @@ namespace Xamarin.Bundler {
 	//																			the container app does not build for the ABI {1} (while the extension is building for this ABI).
 	//																			the container app is building for the ABI {1}, which is not compatible with the extension's ABI ({2}).
 	//																			the container app is referencing the assembly '{1}' from '{2}', while the extension references it from '{3}'.
+	//		Warning		MT0125	The --assembly-build-target command-line argument is ignored in the simulator.
+	//		Warning		MT0126	Incremental builds have been disabled because incremental builds are not supported in the simulator.
 	//		Warning		MT0127	Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include more than one third-party binding libraries.
 	// MT1xxx	file copy / symlinks (project related)
 	//			MT10xx	installer.cs / mtouch.cs


### PR DESCRIPTION
It does not make sense to support incremental builds for the simulator (since
no AOT compilation is done), it just makes the test matrix more complicated.

So simplify things by removing support for incremental builds.

We also ignore any (other) --assembly-build-target arguments, because building
to frameworks doesn't make sense either in the simulator.

https://bugzilla.xamarin.com/show_bug.cgi?id=55712