### PR TITLE
[mtouch] Fix compiling assemblies to frameworks on watchOS. (#2038)

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -322,7 +322,7 @@ endef
 define LibXamarinTemplate
 
 $(1)$(3)_COMMON_DYLIB_FLAGS = -lmonosgen-2.0 -Wl,-install_name,libxamarin$(4).dylib -framework Foundation -framework CFNetwork -framework UIKit -lz
-$(1)$(3)_COMMON_FRAMEWORK_FLAGS = -framework Mono -Wl,-install_name,@rpath/Xamarin.framework/Xamarin -framework Foundation -framework CFNetwork -framework UIKit -lz
+$(1)$(3)_COMMON_FRAMEWORK_FLAGS = -framework Mono -Wl,-install_name,@rpath/Xamarin$(4).framework/Xamarin$(4) -framework Foundation -framework CFNetwork -framework UIKit -lz
 
 x86_$(1)$(3)_OBJECTS    = $$(patsubst %,.libs/$(1)/%$(4).x86.o,$$($(2)_SOURCE_STEMS))    $$(patsubst %,.libs/$(1)/%$(4).x86.o,$$($(2)_I386_SOURCE_STEMS))
 x86_64_$(1)$(3)_OBJECTS = $$(patsubst %,.libs/$(1)/%$(4).x86_64.o,$$($(2)_SOURCE_STEMS)) $$(patsubst %,.libs/$(1)/%$(4).x86_64.o,$$($(2)_X86_64_SOURCE_STEMS))

--- a/tools/mtouch/BuildTasks.mtouch.cs
+++ b/tools/mtouch/BuildTasks.mtouch.cs
@@ -457,8 +457,10 @@ namespace Xamarin.Bundler
 				throw new ArgumentNullException (nameof (install_name));
 
 			flags.AddOtherFlag ("-shared");
-			if (!App.EnableMarkerOnlyBitCode && !App.EnableAsmOnlyBitCode)
+			if (!App.EnableBitCode)
 				flags.AddOtherFlag ("-read_only_relocs suppress");
+			if (App.EnableBitCode)
+				flags.AddOtherFlag ("-lc++");
 			flags.LinkWithMono ();
 			flags.AddOtherFlag ("-install_name " + Driver.Quote (install_name));
 			flags.AddOtherFlag ("-fapplication-extension"); // fixes this: warning MT5203: Native linking warning: warning: linking against dylib not safe for use in application extensions: [..]/actionextension.dll.arm64.dylib

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -133,12 +133,12 @@ namespace Xamarin.Bundler
 				LinkWithTaskOutput (link_task);
 				break;
 			case AssemblyBuildTarget.DynamicLibrary:
-				if (!(App.IsExtension && assemblies.Any ((asm) => asm.IsCodeShared)))
+				if (!(!App.HasFrameworksDirectory && assemblies.Any ((asm) => asm.IsCodeShared)))
 					AddToBundle (link_task.OutputFile);
 				LinkWithTaskOutput (link_task);
 				break;
 			case AssemblyBuildTarget.Framework:
-				if (!(App.IsExtension && assemblies.Any ((asm) => asm.IsCodeShared)))
+				if (!(!App.HasFrameworksDirectory && assemblies.Any ((asm) => asm.IsCodeShared)))
 					AddToBundle (link_task.OutputFile, $"Frameworks/{name}.framework/{name}", dylib_to_framework_conversion: true);
 				LinkWithTaskOutput (link_task);
 				break;

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -575,7 +575,7 @@ namespace Xamarin.Bundler
 					var asm_name = asm_fw.Identity;
 					if (asm_fw.BuildTargetName == asm_name)
 						continue; // this is deduceable
-					if (app.IsExtension && asm_fw.IsCodeShared) {
+					if (!app.HasFrameworksDirectory && asm_fw.IsCodeShared) {
 						assembly_location.AppendFormat ("\t{{ \"{0}\", \"../../Frameworks/{1}.framework/MonoBundle\" }},\n", asm_name, asm_fw.BuildTargetName);
 					} else {
 						assembly_location.AppendFormat ("\t{{ \"{0}\", \"Frameworks/{1}.framework/MonoBundle\" }},\n", asm_name, asm_fw.BuildTargetName);


### PR DESCRIPTION
* [runtime] Fix Xamarin-debug.framework's install name.

This makes building to frameworks work in debug mode.

* [mtouch] Fix check to add frameworks to watchKit extensions.

* [mtouch] Never pass -read_only_relocs to the native linker when bitcode is enabled.

* [mtouch] Bitcode requires linking with c++.

This particular case applies to shared libraries/frameworks (we already link
with c++ when building statically).