### PR TITLE
[msbuild] Pass -float32 to aot-options if UseFloat32 = false

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -426,6 +426,8 @@ namespace Xamarin.iOS.Tasks
 
 			if (UseFloat32 /* We want to compile 32-bit floating point code to use 32-bit floating point operations */)
 				args.Add ("--aot-options=-O=float32");
+			else
+				args.Add ("--aot-options=-O=-float32");
 
 			if (!EnableGenericValueTypeSharing)
 				args.Add ("--gsharedvt=false");

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/MTouchTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/MTouchTaskTests.cs
@@ -154,6 +154,15 @@ namespace Xamarin.iOS.Tasks
 		}
 
 		[Test]
+		public void StandardCommandline_WithoutFloat32 ()
+		{
+			Task.UseFloat32 = false;
+
+			var args = Task.GenerateCommandLineCommands ();
+			Assert.IsTrue (args.Contains ("--aot-options=-O=-float32"));
+		}
+
+		[Test]
 		public void ParsedExtraArgs ()
 		{
 			try {


### PR DESCRIPTION
The runtime team is going to change the default for the float 32 option.
Therefore, to avoid breaking users who are currently **not** using this option,
we need to force the use of `-float32`.