### PR TITLE
[mmp] The partial static registrar can't be used with custom managed exception marshaling. Fixes #55870.

### DIFF
--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -652,7 +652,7 @@ namespace Xamarin.Bundler {
 			{
 				if (!App.EnableDebug)
 					registrar = RegistrarMode.Static;
-				else if (IsUnified && App.LinkMode == LinkMode.None && embed_mono)
+				else if (IsUnified && App.LinkMode == LinkMode.None && embed_mono && App.IsDefaultMarshalManagedExceptionMode)
 					registrar = RegistrarMode.PartialStatic;
 				else
 					registrar = RegistrarMode.Dynamic;


### PR DESCRIPTION
This is because the generated output from the static registrar depends on the
managed exception marshaling mode, and the partial static registrar executes
with the default managed exception marshaling mode.

https://bugzilla.xamarin.com/show_bug.cgi?id=55870