### PR TITLE
[mmp/mtouch/ObjCRuntime] Calculate the path to the runtime-options.plist using NSBundle's ResourcePath.

### DIFF
--- a/src/ObjCRuntime/RuntimeOptions.cs
+++ b/src/ObjCRuntime/RuntimeOptions.cs
@@ -192,8 +192,11 @@ namespace XamCore.ObjCRuntime {
 #else
 		internal static RuntimeOptions Read ()
 		{
-			var top_level = NSBundle.MainBundle.BundlePath;
-			var plist_path = GetFileName (top_level);
+			// for iOS NSBundle.ResourcePath returns the path to the root of the app bundle
+			// for macOS apps NSBundle.ResourcePath returns foo.app/Contents/Resources
+			// for macoS frameworks NSBundle.ResourcePath returns foo.app/Versions/Current/Resources
+			var resource_dir = NSBundle.FromClass (new Class (typeof (XamCore.Foundation.NSObject.NSObject_Disposer))).ResourcePath;
+			var plist_path = GetFileName (resource_dir);
 
 			if (!File.Exists (plist_path))
 				return null;
@@ -245,13 +248,9 @@ namespace XamCore.ObjCRuntime {
 		{
 		}
 
-		static string GetFileName (string app_dir)
+		static string GetFileName (string resource_dir)
 		{
-#if MONOMAC
-			return Path.Combine (app_dir, "Contents", "Resources", "runtime-options.plist");
-#else
-			return Path.Combine (app_dir, "runtime-options.plist");
-#endif
+			return Path.Combine (resource_dir, "runtime-options.plist");
 		}
 	}
 }

--- a/src/ObjCRuntime/RuntimeOptions.cs
+++ b/src/ObjCRuntime/RuntimeOptions.cs
@@ -11,10 +11,13 @@ using System.Net.Http;
 
 #if XAMCORE_2_0
 using Foundation;
+using ObjCRuntime;
 #elif MONOMAC && !MMP
 using MonoMac.Foundation;
+using MonoMac.ObjCRuntime;
 #elif !MTOUCH && !MMP && !MMP_TEST
 using MonoTouch.Foundation;
+using MonoTouch.ObjCRuntime;
 #endif
 
 #if !COREBUILD && (XAMARIN_APPLETLS || XAMARIN_NO_TLS)
@@ -190,12 +193,20 @@ namespace XamCore.ObjCRuntime {
 			return type;
 		}
 #else
+		[Register ("__internal__xamarin_runtimeoptions_bundlefinder")]
+		class BundleFinder : NSObject {
+			public BundleFinder ()
+			{
+				IsDirectBinding = false;
+			}
+		}
+
 		internal static RuntimeOptions Read ()
 		{
 			// for iOS NSBundle.ResourcePath returns the path to the root of the app bundle
 			// for macOS apps NSBundle.ResourcePath returns foo.app/Contents/Resources
-			// for macoS frameworks NSBundle.ResourcePath returns foo.app/Versions/Current/Resources
-			var resource_dir = NSBundle.FromClass (new Class (typeof (XamCore.Foundation.NSObject.NSObject_Disposer))).ResourcePath;
+			// for macOS frameworks NSBundle.ResourcePath returns foo.app/Versions/Current/Resources
+			var resource_dir = NSBundle.FromClass (new Class (typeof (BundleFinder))).ResourcePath;
 			var plist_path = GetFileName (resource_dir);
 
 			if (!File.Exists (plist_path))

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -645,5 +645,35 @@ namespace Xamarin.MMP.Tests
 				Assert.AreEqual (1, objcCount, "Found more than one -OjbC");
 			});
 		}
+
+		[Test]
+		[TestCase ("CFNetworkHandler", "CFNetworkHandler")]
+		[TestCase ("NSUrlSessionHandler", "NSUrlSessionHandler")]
+		[TestCase ("HttpClientHandler", "HttpClientHandler")]
+		[TestCase (null, "HttpClientHandler")]
+		[TestCase ("", "HttpClientHandler")]
+		public void HttpClientHandler (string mmpHandler, string expectedHandler)
+		{
+			RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					References = " <Reference Include=\"System.Net.Http\" />",
+					TestCode = $@"
+			var client = new System.Net.Http.HttpClient ();
+			var field = client.GetType ().BaseType.GetField (""handler"", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+			if (field == null)
+				throw new System.Exception (""Could not find the field 'handler' in HttpClient's base type (which should be 'HttpMessageInvoker')."");
+			var fieldValue = field.GetValue (client);
+			if (fieldValue == null)
+				throw new System.Exception (""Unexpected null value found in 'HttpMessageInvoker.handler' field."");
+			var fieldValueType = fieldValue.GetType ().Name;
+			if (fieldValueType != ""{expectedHandler}"")
+				throw new System.Exception ($""Unexpected field type, found '{{fieldValueType}}', expected '{expectedHandler}'"");
+",
+				};
+				if (mmpHandler != null)
+					test.CSProjConfig = "<HttpClientHandler>" + mmpHandler + "</HttpClientHandler>";
+				TI.TestUnifiedExecutable (test);
+			});
+		}
 	}
 }

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -465,7 +465,7 @@ namespace Xamarin
 			}
 		}
 
-		string CreatePlist (Profile profile, string appName)
+		public static string CreatePlist (Profile profile, string appName)
 		{
 			string plist = null;
 
@@ -497,7 +497,7 @@ namespace Xamarin
 	</array>
 </dict>
 </plist>
-", appName, MTouch.GetSdkVersion (Profile));
+", appName, MTouch.GetSdkVersion (profile));
 				break;
 			case Profile.tvOS:
 				plist = string.Format (@"<?xml version=""1.0"" encoding=""UTF-8""?>
@@ -518,7 +518,7 @@ namespace Xamarin
 	</array>
 </dict>
 </plist>
-", appName, MTouch.GetSdkVersion (Profile));
+", appName, MTouch.GetSdkVersion (profile));
 				break;
 			default:
 				throw new Exception ("Profile not specified.");

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -825,7 +825,7 @@ namespace Xamarin.Bundler {
 				GeneratePList ();
 
 			if (App.LinkMode != LinkMode.All && App.RuntimeOptions != null)
-				App.RuntimeOptions.Write (App.AppDirectory);
+				App.RuntimeOptions.Write (resources_dir);
 
 			if (aotOptions != null && aotOptions.IsAOT) {
 				if (!IsUnified)


### PR DESCRIPTION
The anatomy of apps and frameworks differ between iOS and macOS:

* iOS: we put runtime-options.plist in the root directory of the app.
* macOS:
 * for apps we put runtime-options in foo.app/Contents/Resources
 * for frameworks we put runtime-options in
   foo.framework/Versions/Current/A/Resources

Luckily NSBundle's ResourcePath property returns exactly this path, so
change our logic to use this property.

Also calculate the NSBundle using an exported type we know we have (using
the main bundle won't work when we're a framework).

And finally ad mmp/mtouch tests to verify the default HttpClientHandler according to
build arguments.