### PR TITLE
[Xamarin.Mac] Add support for building to a framework for the embeddinator.

### DIFF
--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -74,6 +74,8 @@ The easiest way to get exact version information is to use the **Xamarin Studio*
 
 # MM1xxx: file copy / symlinks (project related)
 
+<h3><a name="MM1034">MM1034: Could not create symlink '{file}' -> '{target}': error {number}</h3>
+
 ## MM14xx: Product assemblies
 
 <h3><a name="MM1401">MM1401: The required '{0}' assembly is missing from the references</h3>

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -743,6 +743,8 @@ Please unlock the device and try again.
 
 <h3><a name="MT1033"/>MT1033: Could not uninstall the application '*' from the device '*': *</h3>
 
+<!-- 1034 used by mmp -->
+
 ### MT11xx: Debug Service
 
 <!--

--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -363,12 +363,12 @@ update_environment (xamarin_initialize_data *data)
 }
 
 static void
-app_initialize (xamarin_initialize_data *data, bool is_extension)
+app_initialize (xamarin_initialize_data *data)
 {
 	// The launch code here is publicly documented in xamarin/launch.h
 	// The numbers in the comments refer to numbers in xamarin/launch.h.
 
-	xamarin_is_extension = is_extension;
+	xamarin_launch_mode = data->launch_mode;
 
 #ifndef SYSTEM_LAUNCHER
 	if (xammac_setup ()) {
@@ -442,7 +442,7 @@ app_initialize (xamarin_initialize_data *data, bool is_extension)
 	if (!check_mono_version (mono_version, [minVersion UTF8String]))
 		exit_with_message ([[NSString stringWithFormat:@"This application requires the Mono framework version %@ or newer.", minVersion] UTF8String], data->basename, true);
 	// 6) Find the executable. The name is: [...]
-	if (!is_extension) {
+	if (data->launch_mode == XamarinLaunchModeApp) {
 		NSString *exeName = NULL;
 		NSString *exePath;
 		if (plist != NULL)
@@ -534,8 +534,6 @@ int xamarin_main (int argc, char **argv, enum XamarinLaunchMode launch_mode)
 {
 	xamarin_initialize_data data = { 0 };
 
-	bool is_extension = launch_mode == XamarinLaunchModeExtension;
-
 	if (getcwd (original_working_directory_path, sizeof (original_working_directory_path)) == NULL)
 		original_working_directory_path [0] = '\0';
 
@@ -543,6 +541,7 @@ int xamarin_main (int argc, char **argv, enum XamarinLaunchMode launch_mode)
 		data.size = sizeof (data);
 		data.argc = argc;
 		data.argv = argv;
+		data.launch_mode = launch_mode;
 		// basename = Path.GetFileName (argv [0])
 		if (!(data.basename = strrchr (argv [0], '/'))) {
 			data.basename = argv [0];
@@ -554,7 +553,7 @@ int xamarin_main (int argc, char **argv, enum XamarinLaunchMode launch_mode)
 		if (data.is_relaunch)
 			unsetenv (__XAMARIN_MAC_RELAUNCH_APP__);
 
-		app_initialize (&data, is_extension);
+		app_initialize (&data);
 
 		if (data.exit)
 			return data.exit_code;

--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -310,8 +310,16 @@ update_environment (xamarin_initialize_data *data)
 		return;
 
 	// 3) Ensure the following environment variables are set: [...]
-	NSString *res_dir = [data->app_dir stringByAppendingPathComponent: @"Contents/Resources"];
-	NSString *monobundle_dir = [data->app_dir stringByAppendingPathComponent: @"Contents/MonoBundle"];
+	NSString *res_dir;
+	NSString *monobundle_dir;
+
+	if (data->launch_mode == XamarinLaunchModeEmbedded) {
+		monobundle_dir = [data->app_dir stringByAppendingPathComponent: @"Versions/Current/MonoBundle"];
+		res_dir = [data->app_dir stringByAppendingPathComponent: @"Versions/Current/Resources"];
+	} else {
+		monobundle_dir = [data->app_dir stringByAppendingPathComponent: @"Contents/MonoBundle"];
+		res_dir = [data->app_dir stringByAppendingPathComponent: @"Contents/Resources"];
+	}
 
 #ifdef DYNAMIC_MONO_RUNTIME
 	NSString *bin_dir = [data->app_dir stringByAppendingPathComponent: @"Contents/MacOS"];
@@ -379,7 +387,14 @@ app_initialize (xamarin_initialize_data *data)
 
 	bool mkbundle = xamarin_get_is_mkbundle ();
 
-	data->app_dir = [[NSBundle mainBundle] bundlePath]; // this is good until the autorelease pool releases the bundlePath string.
+	NSBundle *bundle;
+
+	if (data->launch_mode == XamarinLaunchModeEmbedded) {
+		bundle = [NSBundle bundleForClass: [XamarinAssociatedObject class]];
+	} else {
+		bundle = [NSBundle mainBundle];
+	}
+	data->app_dir = [bundle bundlePath]; // this is good until the autorelease pool releases the bundlePath string.
 
 	// 1) If found, call the custom initialization function (xamarin_custom_initialize)
 	xamarin_custom_initialize_func init = (xamarin_custom_initialize_func) dlsym (RTLD_MAIN_ONLY, "xamarin_app_initialize");

--- a/runtime/monotouch-debug.m
+++ b/runtime/monotouch-debug.m
@@ -562,7 +562,7 @@ void monotouch_configure_debugging ()
 #if MONOTOUCH && (defined(__i386__) || defined (__x86_64__))
 	// Try to read shared memory as well
 	key_t shmkey;
-	if (!xamarin_is_extension) {
+	if (xamarin_launch_mode == XamarinLaunchModeApp) {
 		// Don't read shared memory in normal apps, because we're always able to pass
 		// the debug data (host/port) using either command-line arguments or environment variables
 	} else if ((shmkey = ftok ("/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mtouch", 0)) == -1) {

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -234,7 +234,7 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 	patch_sigaction ();
 #endif
 
-	xamarin_is_extension = launch_mode == XamarinLaunchModeExtension;
+	xamarin_launch_mode = launch_mode;
 
 	memset (managed_argv, 0, sizeof (char*) * (argc + 2));
 	managed_argv [0] = "monotouch";

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1227,10 +1227,12 @@ xamarin_get_bundle_path ()
 	char *result;
 
 #if MONOMAC
-	if (xamarin_custom_bundle_name != nil)
-		bundle_path = [[main_bundle bundlePath] stringByAppendingPathComponent:[@"Contents/" stringByAppendingString:xamarin_custom_bundle_name]];
-	else
-		bundle_path = [[main_bundle bundlePath] stringByAppendingPathComponent:@"Contents/MonoBundle"];
+	if (xamarin_launch_mode == XamarinLaunchModeEmbedded) {
+		bundle_path = [[[NSBundle bundleForClass: [XamarinAssociatedObject class]] bundlePath] stringByAppendingPathComponent: @"Versions/Current"];
+	} else {
+		bundle_path = [[main_bundle bundlePath] stringByAppendingPathComponent:@"Contents"];
+	}
+	bundle_path = [bundle_path stringByAppendingPathComponent: xamarin_custom_bundle_name == NULL ? @"MonoBundle" : xamarin_custom_bundle_name];
 #else
 	bundle_path = [main_bundle bundlePath];
 #endif

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -76,7 +76,7 @@ bool xamarin_is_gc_coop = false;
 #endif
 enum MarshalObjectiveCExceptionMode xamarin_marshal_objectivec_exception_mode = MarshalObjectiveCExceptionModeDefault;
 enum MarshalManagedExceptionMode xamarin_marshal_managed_exception_mode = MarshalManagedExceptionModeDefault;
-bool xamarin_is_extension = false;
+enum XamarinLaunchMode xamarin_launch_mode = XamarinLaunchModeApp;
 
 /* Callbacks */
 
@@ -2346,7 +2346,7 @@ xamarin_locate_assembly_resource (const char *assembly_name, const char *culture
 	}
 
 	// Then in the container app's root directory (for extensions)
-	if (xamarin_is_extension) {
+	if (xamarin_launch_mode == XamarinLaunchModeExtension) {
 		snprintf (root, sizeof (root), "../..");
 		if (xamarin_locate_assembly_resource_for_root (root, culture, resource, path, pathlen)) {
 			LOG_RESOURCELOOKUP (PRODUCT ": Located resource '%s' from container app bundle '%s': %s\n", resource, aname, path);

--- a/runtime/xamarin/launch.h
+++ b/runtime/xamarin/launch.h
@@ -103,6 +103,7 @@ typedef struct xamarin_initialize_data {
 	bool exit; // If initialization failed and the app should exit.
 	int exit_code; // The exit code to return if initialization failed.
 	bool requires_relaunch; // if the launcher should respawn itself (setting some environment variables require this, in particular DYLD_* variables). This is ignored if 'is_relaunch' is true.
+	enum XamarinLaunchMode launch_mode;
 } xamarin_initialize_data;
 
 typedef void (*xamarin_custom_initialize_func) (xamarin_initialize_data *data);

--- a/runtime/xamarin/main.h
+++ b/runtime/xamarin/main.h
@@ -37,6 +37,12 @@ enum MarshalManagedExceptionMode : int {
 	MarshalManagedExceptionModeDisable                  = 4,
 };
 
+enum XamarinLaunchMode {
+	XamarinLaunchModeApp = 0,
+	XamarinLaunchModeExtension = 1,
+	XamarinLaunchModeEmbedded = 2,
+};
+
 extern bool mono_use_llvm; // this is defined inside mono
 
 #if MONOMAC
@@ -57,7 +63,7 @@ extern const char *xamarin_arch_name;
 extern bool xamarin_is_gc_coop;
 extern enum MarshalObjectiveCExceptionMode xamarin_marshal_objectivec_exception_mode;
 extern enum MarshalManagedExceptionMode xamarin_marshal_managed_exception_mode;
-extern bool xamarin_is_extension;
+extern enum XamarinLaunchMode xamarin_launch_mode;
 
 #ifdef MONOTOUCH
 extern NSString* xamarin_crashlytics_api_key;

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -98,12 +98,6 @@ enum NSObjectFlags {
 	NSObjectFlagsHasManagedRef = 32,
 };
 
-enum XamarinLaunchMode {
-	XamarinLaunchModeApp = 0,
-	XamarinLaunchModeExtension = 1,
-	XamarinLaunchModeEmbedded = 2,
-};
-
 struct AssemblyLocation {
 	const char *assembly_name; // base name (without extension) of the assembly
 	const char *location; // the directory where the assembly is

--- a/src/AppKit/NSApplication.cs
+++ b/src/AppKit/NSApplication.cs
@@ -46,6 +46,7 @@ namespace XamCore.AppKit {
 
 		static bool initialized;
 
+		[Preserve]
 		public static void Init ()
 		{
 			if (initialized) {

--- a/src/ObjCRuntime/Runtime.mac.cs
+++ b/src/ObjCRuntime/Runtime.mac.cs
@@ -88,7 +88,7 @@ namespace XamCore.ObjCRuntime {
 			IntPtr rv;
 
 			if (runtime_library == IntPtr.Zero) {
-				runtime_library = new IntPtr (-5 /* RTLD_MAIN_ONLY */);
+				runtime_library = new IntPtr (-2 /* RTLD_DEFAULT */);
 				rv = Dlfcn.dlsym (runtime_library, name);
 				if (rv == IntPtr.Zero) {
 					runtime_library = Dlfcn.dlopen ("libxammac.dylib", 0);

--- a/tools/mmp/Info-framework.plist.tmpl
+++ b/tools/mmp/Info-framework.plist.tmpl
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleDisplayName</key>
+	<string>@BUNDLEDISPLAYNAME@</string>
+	<key>CFBundleExecutable</key>
+	<string>@EXECUTABLE@</string>
+	<key>CFBundleIdentifier</key>
+	<string>@BUNDLEID@</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>@BUNDLENAME@</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -133,8 +133,8 @@ LOCAL_MMP = \
 	Mono.Cecil.dll \
 	Mono.Cecil.Mdb.dll \
 
-mmp.exe: Makefile $(MONO_CECIL_DLL) $(MONO_CECIL_MDB_DLL) $(mmp_sources) config config_mobile Info.plist.tmpl $(tuner_sources) $(linker_resources)
-	$(Q_CSC) $(SYSTEM_CSC) -unsafe -out:mmp.exe $(DEFINES) -r:$(MONO_CECIL_DLL) -r:$(MONO_CECIL_MDB_DLL) -r:Mono.Security.dll  -resource:config -resource:config_mobile -resource:machine.4_5.config -resource:Info.plist.tmpl $(linker_resources:%=-resource:%) $(tuner_sources) $(mmp_sources) -debug:portable
+mmp.exe: Makefile $(MONO_CECIL_DLL) $(MONO_CECIL_MDB_DLL) $(mmp_sources) config config_mobile Info.plist.tmpl Info-framework.plist.tmpl $(tuner_sources) $(linker_resources)
+	$(Q_CSC) $(SYSTEM_CSC) -unsafe -out:mmp.exe $(DEFINES) -r:$(MONO_CECIL_DLL) -r:$(MONO_CECIL_MDB_DLL) -r:Mono.Security.dll  -resource:config -resource:config_mobile -resource:machine.4_5.config -resource:Info.plist.tmpl -resource:Info-framework.plist.tmpl $(linker_resources:%=-resource:%) $(tuner_sources) $(mmp_sources) -debug:portable
 	$(Q) cp $(MONO_CECIL_DLL) $(MONO_CECIL_MDB_DLL) .
 
 Mono.Cecil.dll: $(MONO_CECIL_DLL)

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -928,11 +928,11 @@ namespace Xamarin.Bundler {
 		}
 
 		static void GeneratePList () {
-			var sr = new StreamReader (typeof (Driver).Assembly.GetManifestResourceStream ("Info.plist.tmpl"));
+			var sr = new StreamReader (typeof (Driver).Assembly.GetManifestResourceStream (App.Embeddinator ? "Info-framework.plist.tmpl" : "Info.plist.tmpl"));
 			var all = sr.ReadToEnd ();
 			var icon_str = (icon != null) ? "\t<key>CFBundleIconFile</key>\n\t<string>" + icon + "</string>\n\t" : "";
-
-			using (var sw = new StreamWriter (Path.Combine (contents_dir, "Info.plist"))){
+			var path = Path.Combine (App.Embeddinator ? resources_dir : contents_dir, "Info.plist");
+			using (var sw = new StreamWriter (path)){
 				sw.WriteLine (
 					all.Replace ("@BUNDLEDISPLAYNAME@", app_name).
 					Replace ("@EXECUTABLE@", app_name).

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -347,6 +347,12 @@
     <EmbeddedResource Include="machine.4_5.config">
       <LogicalName>machine.4_5.config</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="Info-framework.plist.tmpl">
+      <LogicalName>Info-framework.plist.tmpl</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Info.plist.tmpl">
+      <LogicalName>Info.plist.tmpl</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />


### PR DESCRIPTION
This is a series of commits that adds support to mmp and our runtime to build
macOS frameworks from managed assemblies.

The commits are self-contained and separate from eachother, so it might be
simpler to review this commit-by-commit.