### PR TITLE
[ObjCRuntime] Remove XM limitation. Fixes #55857.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -575,9 +575,6 @@ namespace XamCore.ObjCRuntime {
 
 		static unsafe IntPtr GetGenericMethodFromToken (IntPtr obj, uint token_ref)
 		{
-#if MONOMAC
-			throw new NotSupportedException ();
-#else
 			var method = Class.ResolveTokenReference (token_ref, 0x06000000);
 			if (method == null)
 				return IntPtr.Zero;
@@ -591,7 +588,6 @@ namespace XamCore.ObjCRuntime {
 				throw ErrorHelper.CreateError (8023, $"An instance object is required to construct a closed generic method for the open generic method: {mb.DeclaringType.FullName}.{mb.Name} (token reference: 0x{token_ref:X}). Please file a bug report at http://bugzilla.xamarin.com.");
 
 			return ObjectWrapper.Convert (DynamicRegistrar.FindClosedMethod (nsobj.GetType (), mb));
-#endif
 		}
 
 		static IntPtr TryGetOrConstructNSObjectWrapped (IntPtr ptr)

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -38,7 +38,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\x86\Release</OutputPath>
-    <DefineConstants></DefineConstants>
+    <DefineConstants>__UNIFIED__;MONOMAC;XAMCORE_2_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <EnableCodeSigning>false</EnableCodeSigning>
@@ -49,7 +49,7 @@
     <HttpClientHandler>HttpClientHandler</HttpClientHandler>
     <TlsProvider>Default</TlsProvider>
     <LinkMode>None</LinkMode>
-    <XamMacArch></XamMacArch>
+    <XamMacArch>x86_64</XamMacArch>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -283,15 +283,18 @@ namespace xharness
 			MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "introspection", "Mac", "introspection-mac.csproj")), skipXMVariations : true));
 
 			var hard_coded_test_suites = new [] {
-				new { ProjectFile = "mmptest", Name = "mmptest", IsNUnit = true },
-				new { ProjectFile = "msbuild-mac", Name = "MSBuild tests", IsNUnit = false },
-				new { ProjectFile = "xammac_tests", Name = "xammac tests", IsNUnit = false }
+				new { ProjectFile = "mmptest", Name = "mmptest", IsNUnit = true, Configuration = "", Variation = "" },
+				new { ProjectFile = "msbuild-mac", Name = "MSBuild tests", IsNUnit = false, Configuration = "", Variation = "" },
+				new { ProjectFile = "xammac_tests", Name = "xammac tests", IsNUnit = false, Configuration = "Debug", Variation = "Debug" },
+				new { ProjectFile = "xammac_tests", Name = "xammac tests", IsNUnit = false, Configuration = "Release", Variation = "Release" },
 			};
 			foreach (var p in hard_coded_test_suites) {
 				MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p.ProjectFile + "/" + p.ProjectFile + ".csproj")), generateVariations: false) {
 					Name = p.Name,
 					IsNUnitProject = p.IsNUnit,
 					SolutionPath = Path.GetFullPath (Path.Combine (RootDirectory, "tests-mac.sln")),
+					Configuration = p.Configuration,
+					Variation = p.Variation,
 				});
 			}
 

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -484,10 +484,10 @@ namespace xharness
 				build.Jenkins = this;
 				build.TestProject = project;
 				build.SolutionPath = project.SolutionPath;
-				build.ProjectConfiguration = "Debug";
+				build.ProjectConfiguration = string.IsNullOrEmpty (project.Configuration) ? "Debug" : project.Configuration;
 				build.ProjectPlatform = "x86";
 				build.SpecifyPlatform = false;
-				build.SpecifyConfiguration = false;
+				build.SpecifyConfiguration = build.ProjectConfiguration != "Debug";
 				RunTestTask exec;
 				if (project.IsNUnitProject) {
 					var dll = Path.Combine (Path.GetDirectoryName (project.Path), project.Xml.GetOutputAssemblyPath (build.ProjectPlatform, build.ProjectConfiguration).Replace ('\\', '/'));
@@ -507,6 +507,7 @@ namespace xharness
 						TestName = project.Name,
 					};
 				}
+				exec.Variation = string.IsNullOrEmpty (project.Variation) ? null : project.Variation;
 				Tasks.Add (exec);
 
 				if (project.GenerateVariations) {

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -14,6 +14,7 @@ namespace xharness
 		public string Path;
 		public string SolutionPath;
 		public string Name;
+		public string Variation;
 		public bool IsExecutableProject;
 		public bool IsNUnitProject;
 		public bool GenerateVariations = true;
@@ -124,6 +125,7 @@ namespace xharness
 	public class MacTestProject : TestProject
 	{
 		public bool SkipXMVariations;
+		public string Configuration;
 
 		public MacTestProject () : base ()
 		{


### PR DESCRIPTION
I can't remember why I added this limitation, git history provides no clues,
and it compiles fine.

Also run the xammac tests both in Debug and Release configurations (previously
only Debug; the Release configuration triggers this bug).

https://bugzilla.xamarin.com/show_bug.cgi?id=55857