### PR TITLE
[xharness] Set the test name correctly so that macOS and iOS variations of the same tests are grouped together in the html report.

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -280,7 +280,7 @@ namespace xharness
 			foreach (var p in test_suites)
 				MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p.ProjectFile + "/" + p.ProjectFile + ".sln"))) { Name = p.Name });
 			
-			MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "introspection", "Mac", "introspection-mac.csproj")), skipXMVariations : true));
+			MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "introspection", "Mac", "introspection-mac.csproj")), skipXMVariations: true) { Name = "introspection" });
 
 			var hard_coded_test_suites = new [] {
 				new { ProjectFile = "mmptest", Name = "mmptest", IsNUnit = true, Configuration = "", Variation = "" },
@@ -328,7 +328,7 @@ namespace xharness
 				IOSBclTests.Add (new BCLTest (p));
 			}
 			
-			IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, "introspection", "iOS", "introspection-ios.csproj"))));
+			IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, "introspection", "iOS", "introspection-ios.csproj"))) { Name = "introspection" });
 			IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, "linker-ios", "dont link", "dont link.csproj"))));
 			IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, "linker-ios", "link all", "link all.csproj"))));
 			IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, "linker-ios", "link sdk", "link sdk.csproj"))));

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -133,6 +133,7 @@ namespace xharness
 					ProjectConfiguration = "Debug64",
 					ProjectPlatform = "iPhone",
 					Platform = TestPlatform.iOS_Unified64,
+					TestName = project.Name,
 				};
 				rv.Add (new RunDeviceTask (build64, Devices.ConnectedDevices.Where ((dev) => dev.DevicePlatform == DevicePlatform.iOS && dev.Supports64Bit)) { Ignored = ignored || !IncludeiOS });
 
@@ -143,6 +144,7 @@ namespace xharness
 					ProjectConfiguration = "Debug32",
 					ProjectPlatform = "iPhone",
 					Platform = TestPlatform.iOS_Unified32,
+					TestName = project.Name,
 				};
 				rv.Add (new RunDeviceTask (build32, Devices.ConnectedDevices.Where ((dev) => dev.DevicePlatform == DevicePlatform.iOS)) { Ignored = ignored || !IncludeiOS });
 
@@ -154,6 +156,7 @@ namespace xharness
 					ProjectConfiguration = "Debug64",
 					ProjectPlatform = "iPhone",
 					Platform = TestPlatform.iOS_TodayExtension64,
+					TestName = project.Name,
 				};
 				rv.Add (new RunDeviceTask (buildToday, Devices.ConnectedDevices.Where ((dev) => dev.DevicePlatform == DevicePlatform.iOS && dev.Supports64Bit)) { Ignored = ignored || !IncludeiOSExtensions });
 
@@ -165,6 +168,7 @@ namespace xharness
 					ProjectConfiguration = "Debug",
 					ProjectPlatform = "iPhone",
 					Platform = TestPlatform.tvOS,
+					TestName = project.Name,
 				};
 				rv.Add (new RunDeviceTask (buildTV, Devices.ConnectedDevices.Where ((dev) => dev.DevicePlatform == DevicePlatform.tvOS)) { Ignored = ignored || !IncludetvOS });
 
@@ -176,6 +180,7 @@ namespace xharness
 					ProjectConfiguration = "Debug",
 					ProjectPlatform = "iPhone",
 					Platform = TestPlatform.watchOS,
+					TestName = project.Name,
 				};
 				rv.Add (new RunDeviceTask (buildWatch, Devices.ConnectedDevices.Where ((dev) => dev.DevicePlatform == DevicePlatform.watchOS)){ Ignored = ignored || !IncludewatchOS });
 			}
@@ -242,6 +247,7 @@ namespace xharness
 						ProjectPlatform = task.ProjectPlatform,
 						Platform = task.Platform,
 						InitialTask = clone_task,
+						TestName = clone.Name,
 					};
 					rv.Add (new RunDeviceTask (build, task.Candidates) { Variation = variation, Ignored = task.Ignored });
 				}
@@ -430,6 +436,7 @@ namespace xharness
 						ProjectPlatform = "iPhoneSimulator",
 						Platform = pair.Item2,
 						Ignored = pair.Item3,
+						TestName = project.Name,
 					};
 					runSimulatorTasks.AddRange (await CreateRunSimulatorTaskAsync (derived));
 				}
@@ -596,7 +603,7 @@ namespace xharness
 			if (macExec != null) {
 				return new MacExecuteTask (build) {
 					Ignored = ignore,
-					TestName = build.TestName,
+					TestName = task.TestName,
 				};
 			}
 			var nunit = task as NUnitExecuteTask;
@@ -1747,6 +1754,12 @@ function oninitialload ()
 			}
 		}
 
+		public bool HasCustomTestName {
+			get {
+				return test_name != null;
+			}
+		}
+
 		string test_name;
 		public virtual string TestName {
 			get {
@@ -2415,6 +2428,8 @@ function oninitialload ()
 			Platform = build_task.Platform;
 			ProjectPlatform = build_task.ProjectPlatform;
 			ProjectConfiguration = build_task.ProjectConfiguration;
+			if (build_task.HasCustomTestName)
+				TestName = build_task.TestName;
 		}
 
 		public override IEnumerable<Log> AggregatedLogs {

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -88,6 +88,7 @@ namespace xharness
 				Path = Path,
 				IsExecutableProject = IsExecutableProject,
 				GenerateVariations = GenerateVariations,
+				Name = Name,
 			};
 		}
 


### PR DESCRIPTION
This affects introspection-ios/introspection-mac (which are now grouped in an
`introspection` test), and dontlink-mac (which now shows up in the `dont link`
tests).