### PR TITLE
[mtouch] Strip less when running in embeddinator mode.

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -2044,7 +2044,7 @@ namespace Xamarin.Bundler {
 					args.Append ("-s ").Append (Driver.Quote (symbol_file)).Append (" ");
 				}
 				if (Embeddinator)
-					args.Append ("-u ");
+					args.Append ("-ux ");
 				args.Append (Driver.Quote (Executable));
 				Driver.RunStrip (args.ToString ());
 				Driver.Watch ("Native Strip", 1);


### PR DESCRIPTION
Passing -x (not remove global symbols) to strip seems to work fine.