### PR TITLE
[runtime] Print any dialogs messages to the console as well.

### DIFF
--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -228,6 +228,8 @@ exit_with_message (const char *reason, const char *argv0, bool request_mono)
 	NSString *fmt = request_mono ? @"%s\n\nPlease download and install the latest version of Mono." : @"%s\n";
 	NSString *msg = [NSString stringWithFormat:fmt, reason]; 
 	[alert setInformativeText:msg];
+	NSLog (@"%@", msg);
+	
 	if (request_mono) {
 		[alert addButtonWithTitle:@"Download Mono Framework"];
 		[alert addButtonWithTitle:@"Cancel"];


### PR DESCRIPTION
I've spent way too much time looking at the console waiting for things to
appear, all the while a dialog has hid away beneath other windows on my
system, waiting indefinitely for my attention.