### PR TITLE
[runtime] Rework initialization for Xamarin.Mac extensions.

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -491,6 +491,10 @@
 			"const char *", "runtime_version"
 		),
 
+		new Export ("MonoDomain *", "mono_jit_init",
+			"const char *", "file"
+		),
+
 		new Export ("int", "mono_jit_exec",
 			"MonoDomain *", "domain",
 			"MonoAssembly *", "assembly",

--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -475,9 +475,9 @@ app_initialize (xamarin_initialize_data *data)
 
 			if (!xamarin_file_exists ([exePath UTF8String]))
 				exit_with_message ([[NSString stringWithFormat:@"Could not find the executable '%@'\n\nFull path: %@", exeName, exePath] UTF8String], data->basename, false);
-			}
-			exe_path = strdup ([exePath UTF8String]);
-		 } else {
+		}
+		exe_path = strdup ([exePath UTF8String]);
+	} else {
 
 		mono_jit_init_version ("EmbeddedXamarinMac", "v4.0.0.0");
 

--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -18,7 +18,6 @@
 	bool xamarin_enable_debug = 0;
 #endif
 
-static const char *exe_path = NULL;
 static char original_working_directory_path [MAXPATHLEN];
 
 extern "C" const char * const
@@ -456,6 +455,7 @@ app_initialize (xamarin_initialize_data *data)
 	mono_version = mono_get_runtime_build_info ();
 	if (!check_mono_version (mono_version, [minVersion UTF8String]))
 		exit_with_message ([[NSString stringWithFormat:@"This application requires the Mono framework version %@ or newer.", minVersion] UTF8String], data->basename, true);
+
 	// 6) Find the executable. The name is: [...]
 	if (data->launch_mode == XamarinLaunchModeApp) {
 		NSString *exeName = NULL;
@@ -476,26 +476,14 @@ app_initialize (xamarin_initialize_data *data)
 			if (!xamarin_file_exists ([exePath UTF8String]))
 				exit_with_message ([[NSString stringWithFormat:@"Could not find the executable '%@'\n\nFull path: %@", exeName, exePath] UTF8String], data->basename, false);
 		}
-		exe_path = strdup ([exePath UTF8String]);
+		xamarin_entry_assembly_path = strdup ([exePath UTF8String]);
 	} else {
+		NSString *dllName = [[NSString stringWithUTF8String: data->basename] stringByAppendingString: @".dll"];
+		NSString *dllPath = [[[NSString stringWithUTF8String: xamarin_get_bundle_path ()] stringByAppendingString: @"/"] stringByAppendingString: dllName];
+		if (!xamarin_file_exists ([dllPath UTF8String]))
+				exit_with_message ([[NSString stringWithFormat:@"Could not find the extension library '%@'\n\nFull path: %@", dllName, dllPath] UTF8String], data->basename, false);
 
-		mono_jit_init_version ("EmbeddedXamarinMac", "v4.0.0.0");
-
-		MonoAssembly *assembly = xamarin_open_assembly ("Xamarin.Mac.dll");
-		if (!assembly)
-			xamarin_assertion_message ("Failed to load %s.", "Xamarin.Mac.dll");
-
-		MonoImage *image = mono_assembly_get_image (assembly);
-
-		MonoClass *app_class = mono_class_from_name (image, "AppKit", "NSApplication");
-		if (!app_class)
-			xamarin_assertion_message ("Fatal error: failed to load the NSApplication class");
-
-		MonoMethod *initialize = mono_class_get_method_from_name (app_class, "Init", 0);
-		if (!initialize)
-			xamarin_assertion_message ("Fatal error: failed to load the NSApplication init method");
-
-		mono_runtime_invoke (initialize, NULL, NULL, NULL);
+		xamarin_entry_assembly_path = strdup ([dllPath UTF8String]);
 	}
 
 	// 7a) [If not embedding] Parse the system Mono's config file ($monodir/etc/mono/config).
@@ -544,6 +532,38 @@ app_initialize (xamarin_initialize_data *data)
 }
 
 #define __XAMARIN_MAC_RELAUNCH_APP__ "__XAMARIN_MAC_RELAUNCH_APP__"
+
+static void
+run_application_init (xamarin_initialize_data *data)
+{
+	if (!xamarin_file_exists (xamarin_entry_assembly_path))
+		exit_with_message ([[NSString stringWithFormat:@"Could not find the assembly '%s'", xamarin_entry_assembly_path] UTF8String], data->basename, false);
+
+	// Make sure any output from mono isn't lost when launching extensions,
+	// etc, by installing the log callbacks early (xamarin_initialize will
+	// also do this, but if something goes wrong before we reach
+	// xamarin_initialize when running as an extension, the output will be
+	// lost).
+	xamarin_install_log_callbacks ();
+
+	mono_jit_init (xamarin_entry_assembly_path);
+
+	MonoAssembly *assembly = xamarin_open_assembly ("Xamarin.Mac.dll");
+	if (!assembly)
+		xamarin_assertion_message ("Failed to load %s.", "Xamarin.Mac.dll");
+
+	MonoImage *image = mono_assembly_get_image (assembly);
+
+	MonoClass *app_class = mono_class_from_name (image, "AppKit", "NSApplication");
+	if (!app_class)
+		xamarin_assertion_message ("Fatal error: failed to load the NSApplication class");
+
+	MonoMethod *initialize = mono_class_get_method_from_name (app_class, "Init", 0);
+	if (!initialize)
+		xamarin_assertion_message ("Fatal error: failed to load the NSApplication.Init method");
+
+	mono_runtime_invoke (initialize, NULL, NULL, NULL);
+}
 
 int xamarin_main (int argc, char **argv, enum XamarinLaunchMode launch_mode)
 {
@@ -602,7 +622,7 @@ int xamarin_main (int argc, char **argv, enum XamarinLaunchMode launch_mode)
 		}
 
 		// executable assembly
-		*ptr++ = exe_path;
+		*ptr++ = xamarin_entry_assembly_path;
 
 		if (xamarin_mac_hybrid_aot)
 			*ptr++ = "--hybrid-aot";
@@ -614,6 +634,8 @@ int xamarin_main (int argc, char **argv, enum XamarinLaunchMode launch_mode)
 
 		switch (launch_mode) {
 		case XamarinLaunchModeExtension: {
+			run_application_init (&data);
+
 			void * libExtensionHandle = dlopen ("/usr/lib/libextension.dylib", RTLD_LAZY);
 			if (libExtensionHandle == nil)
 				exit_with_message ("Unable to load libextension.dylib", data.basename, false);
@@ -633,7 +655,7 @@ int xamarin_main (int argc, char **argv, enum XamarinLaunchMode launch_mode)
 			rv = mono_main (new_argc, new_argv);
 			break;
 		case XamarinLaunchModeEmbedded:
-			// do nothing
+			run_application_init (&data);
 			break;
 		default:
 			xamarin_assertion_message ("Invalid launch mode: %i.", launch_mode);

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -60,6 +60,7 @@ const char *xamarin_executable_name = NULL;
 #if MONOMAC
 NSString * xamarin_custom_bundle_name = nil;
 bool xamarin_is_mkbundle = false;
+char *xamarin_entry_assembly_path = NULL;
 #endif
 #if defined (__i386__)
 const char *xamarin_arch_name = "i386";
@@ -139,6 +140,10 @@ struct InitializationOptions {
 	struct MTRegistrationMap* RegistrationData;
 	enum MarshalObjectiveCExceptionMode MarshalObjectiveCExceptionMode;
 	enum MarshalManagedExceptionMode MarshalManagedExceptionMode;
+#if MONOMAC
+	enum XamarinLaunchMode LaunchMode;
+	const char *EntryAssemblyPath;
+#endif
 	struct AssemblyLocations* AssemblyLocations;
 };
 
@@ -1111,6 +1116,15 @@ xamarin_initialize_embedded ()
 	xamarin_main (1, argv, XamarinLaunchModeEmbedded);
 }
 
+/* Installs g_print/g_error handlers that will redirect output to the system Console */
+void
+xamarin_install_log_callbacks ()
+{
+	mono_trace_set_log_handler (log_callback, NULL);
+	mono_trace_set_print_handler (print_callback);
+	mono_trace_set_printerr_handler (print_callback);
+}
+
 void
 xamarin_initialize ()
 {
@@ -1138,9 +1152,7 @@ xamarin_initialize ()
 
 	MONO_ENTER_GC_UNSAFE;
 
-	mono_trace_set_log_handler (log_callback, NULL);
-	mono_trace_set_print_handler (print_callback);
-	mono_trace_set_printerr_handler (print_callback);
+	xamarin_install_log_callbacks ();
 
 #if MONOMAC
 	detect_product_assembly ();
@@ -1189,6 +1201,10 @@ xamarin_initialize ()
 	options.Trampolines = &trampolines;
 	options.MarshalObjectiveCExceptionMode = xamarin_marshal_objectivec_exception_mode;
 	options.MarshalManagedExceptionMode = xamarin_marshal_managed_exception_mode;
+#if MONOMAC
+	options.LaunchMode = xamarin_launch_mode;
+	options.EntryAssemblyPath = xamarin_entry_assembly_path;
+#endif
 
 	params [0] = &options;
 

--- a/runtime/xamarin/main.h
+++ b/runtime/xamarin/main.h
@@ -37,6 +37,7 @@ enum MarshalManagedExceptionMode : int {
 	MarshalManagedExceptionModeDisable                  = 4,
 };
 
+/* This enum must always match the identical enum in src/ObjCRuntime/Runtime.cs */
 enum XamarinLaunchMode {
 	XamarinLaunchModeApp = 0,
 	XamarinLaunchModeExtension = 1,
@@ -55,6 +56,7 @@ extern bool xamarin_debug_mode;
 extern bool xamarin_disable_lldb_attach;
 #if MONOMAC
 extern bool xamarin_mac_hybrid_aot;
+extern char *xamarin_entry_assembly_path;
 #endif
 extern bool xamarin_init_mono_debug;
 extern int xamarin_log_level;
@@ -82,6 +84,8 @@ bool xamarin_get_use_sgen (); /* Public API, always returns true */
 
 void xamarin_set_is_unified (bool value);  /* Public API */
 bool xamarin_get_is_unified ();  /* Public API */
+
+int xamarin_get_launch_mode ();
 
 int xamarin_watchextension_main (int argc, char **argv);
 

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -194,7 +194,7 @@ bool			xamarin_locate_assembly_resource (const char *assembly_name, const char *
 // this functions support NSLog/NSString-style format specifiers.
 void			xamarin_printf (const char *format, ...);
 void			xamarin_vprintf (const char *format, va_list args);
-void            xamarin_install_log_callbacks ();
+void			xamarin_install_log_callbacks ();
 
 /*
  * Look for an assembly in the app and open it.

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -194,6 +194,7 @@ bool			xamarin_locate_assembly_resource (const char *assembly_name, const char *
 // this functions support NSLog/NSString-style format specifiers.
 void			xamarin_printf (const char *format, ...);
 void			xamarin_vprintf (const char *format, va_list args);
+void            xamarin_install_log_callbacks ();
 
 /*
  * Look for an assembly in the app and open it.

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -103,6 +103,15 @@ namespace XamCore.ObjCRuntime {
 			IsSimulator				= 0x10,
 		}
 
+#if MONOMAC
+		/* This enum must always match the identical enum in runtime/xamarin/main.h */
+		internal enum LaunchMode : int {
+			App = 0,
+			Extension = 1,
+			Embedded = 2,
+		}
+#endif
+
 		[StructLayout (LayoutKind.Sequential)]
 		internal unsafe struct InitializationOptions {
 			public int Size;
@@ -112,6 +121,10 @@ namespace XamCore.ObjCRuntime {
 			public MTRegistrationMap *RegistrationMap;
 			public MarshalObjectiveCExceptionMode MarshalObjectiveCExceptionMode;
 			public MarshalManagedExceptionMode MarshalManagedExceptionMode;
+#if MONOMAC
+			public LaunchMode LaunchMode;
+			public IntPtr EntryAssemblyPath; /* char * */
+#endif
 			IntPtr AssemblyLocations;
 
 			public bool IsSimulator {
@@ -367,6 +380,16 @@ namespace XamCore.ObjCRuntime {
 			return BlockLiteral.GetBlockForDelegate ((MethodInfo) ObjectWrapper.Convert (method), ObjectWrapper.Convert (@delegate));
 		}
 
+		static unsafe Assembly GetEntryAssembly ()
+		{
+			var asm = Assembly.GetEntryAssembly ();
+#if MONOMAC
+			if (asm == null)
+				asm = Assembly.LoadFile (Marshal.PtrToStringAuto (options->EntryAssemblyPath));
+#endif
+			return asm;
+		}
+
 		// This method will register all assemblies referenced by the entry assembly.
 		// For XM it will also register all assemblies loaded in the current appdomain.
 		internal static void RegisterAssemblies ()
@@ -375,7 +398,7 @@ namespace XamCore.ObjCRuntime {
 			var watch = new Stopwatch ();
 #endif
 
-			RegisterEntryAssembly (Assembly.GetEntryAssembly ());
+			RegisterEntryAssembly (GetEntryAssembly ());
 
 #if PROFILE
 			Console.WriteLine ("RegisterAssemblies completed in {0} ms", watch.ElapsedMilliseconds);


### PR DESCRIPTION
1. Delay the Application.Init execution from step 6 in the initialization
   sequence, to when we'd run the managed Main function for a normal app. This
   makes the code a bit easier to reason about, since both code paths behave
   more similar. It's also matches the initialization documentation better
   (step 6 is "find the executable", not "find the executable and run
   Application.Init").

2. Install custom callbacks for mono's logging function just before calling
   Application.Init. We already install these custom callbacks in
   xamarin_initialize, but that doesn't help much if something goes wrong
   before xamarin_initialize is called (and there's no harm in doing this
   twice).

3. Treat the extension dll as an entry assembly, make the path to the entry
   assembly available to managed code, and load this assembly if
   Assembly.GetEntryAssembly can't find it (which happens for extensions,
   since there's no entry point as Assembly.GetEntryAssembly defines an entry
   assembly).

This fixes launching of Xamarin.Mac extensions.