### PR TITLE
[macos] Remove linking / registrar restrictions on extensions

### DIFF
--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -134,7 +134,7 @@ The easiest way to get exact version information is to use the **Xamarin Studio*
 
 <h3><a name="MM2013">MM2013: Failed to resolve the reference to "{0}", referenced in "{1}". The app will not include the referenced assembly, and may fail at runtime.</h3>
 
-<!-- 2014 is unused now (Xamarin.Mac Extensions do not support linking. Request for linking will be ignored.) -->
+<h3><a name="MM2014">MM2014: Xamarin.Mac Extensions do not support linking. Request for linking will be ignored. ** This message is obsolete in XM 3.6+ **</h3>
 
 <!-- 2015 used by mtouch -->
 

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -134,7 +134,7 @@ The easiest way to get exact version information is to use the **Xamarin Studio*
 
 <h3><a name="MM2013">MM2013: Failed to resolve the reference to "{0}", referenced in "{1}". The app will not include the referenced assembly, and may fail at runtime.</h3>
 
-<h3><a name="MM2014">MM2014: Xamarin.Mac Extensions do not support linking. Request for linking will be ignored.</h3>
+<!-- 2014 is unused now (Xamarin.Mac Extensions do not support linking. Request for linking will be ignored.) -->
 
 <!-- 2015 used by mtouch -->
 

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -472,11 +472,6 @@ namespace Xamarin.Bundler {
 				throw new MonoMacException (2007, true,
 					"Xamarin.Mac Unified API against a full .NET framework does not support linking. Pass the -nolink flag.");
 
-			if (App.LinkMode != LinkMode.None && is_extension) {
-				App.LinkMode = LinkMode.None;
-				ErrorHelper.Warning (2014, "Xamarin.Mac Extensions do not support linking. Request for linking will be ignored.");
-			}
-
 			ValidateXcode ();
 
 			App.Initialize ();
@@ -668,8 +663,6 @@ namespace Xamarin.Bundler {
 				else
 					registrar = RegistrarMode.Dynamic;
 			}
-			if (is_extension)
-				registrar = RegistrarMode.Static;
 			
 			if (no_executable) {
 				if (unprocessed.Count != 0) {


### PR DESCRIPTION
- [Preserve] on Init is all that is needed now (unsure if additional fixes happened in time since extensions were added)
- https://bugzilla.xamarin.com/show_bug.cgi?id=43197