### PR TITLE
[build] Fix dependencies for various files to rebuild more intelligently when needed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,16 +49,16 @@ $(IOS_DESTDIR)/Developer/MonoTouch/Version: | $(IOS_DESTDIR)/Developer/MonoTouch
 $(IOS_DESTDIR)/Developer/MonoTouch/usr/share: | $(IOS_DESTDIR)/Developer/MonoTouch/usr
 	$(Q_LN) ln -Fs $(abspath $(IOS_TARGETDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/share) $@
 
-$(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)/buildinfo: Make.config .git/index | $(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)
+$(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)/buildinfo: Make.config.inc .git/index | $(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)
 	$(Q_GEN) echo "Version: $(IOS_PACKAGE_VERSION)" > $@
 	$(Q) echo "Hash: $(shell git log --oneline -1 --pretty=%h)" >> $@
 	$(Q) echo "Branch: $(CURRENT_BRANCH)" >> $@
 	$(Q) echo "Build date: $(shell date '+%Y-%m-%d %H:%M:%S%z')" >> $@
 
-$(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)/Version: Make.config
+$(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)/Version: Make.config.inc
 	$(Q) echo $(IOS_PACKAGE_VERSION) > $@
 
-$(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)/updateinfo: Make.config
+$(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)/updateinfo: Make.config.inc
 	$(Q) echo "4569c276-1397-4adb-9485-82a7696df22e $(IOS_PACKAGE_UPDATE_ID)" > $@
 
 $(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)/Versions.plist: Versions-ios.plist.in Makefile $(TOP)/Make.config versions-check.csharp
@@ -92,16 +92,16 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_DIR)/Versions/Current: | $(MAC_DESTDIR)$(MAC_FRAME
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_DIR)/Commands:
 	$(Q_LN) ln -hfs $(MAC_TARGETDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/bin $@
 
-$(MAC_DESTDIR)/$(MAC_FRAMEWORK_CURRENT_DIR)/buildinfo: Make.config .git/index | $(MAC_DESTDIR)/$(MAC_FRAMEWORK_CURRENT_DIR)
+$(MAC_DESTDIR)/$(MAC_FRAMEWORK_CURRENT_DIR)/buildinfo: Make.config.inc .git/index | $(MAC_DESTDIR)/$(MAC_FRAMEWORK_CURRENT_DIR)
 	$(Q_GEN) echo "Version: $(MAC_PACKAGE_VERSION)" > $@
 	$(Q) echo "Hash: $(shell git log --oneline -1 --pretty=%h)" >> $@
 	$(Q) echo "Branch: $(shell git symbolic-ref --short HEAD)" >> $@
 	$(Q) echo "Build date: $(shell date '+%Y-%m-%d %H:%M:%S%z')" >> $@
 
-$(MAC_DESTDIR)/$(MAC_FRAMEWORK_CURRENT_DIR)/updateinfo: Make.config
+$(MAC_DESTDIR)/$(MAC_FRAMEWORK_CURRENT_DIR)/updateinfo: Make.config.inc
 	$(Q) echo "0ab364ff-c0e9-43a8-8747-3afb02dc7731 $(MAC_PACKAGE_UPDATE_ID)" > $@
 
-$(MAC_DESTDIR)/$(MAC_FRAMEWORK_CURRENT_DIR)/Version: Make.config
+$(MAC_DESTDIR)/$(MAC_FRAMEWORK_CURRENT_DIR)/Version: Make.config.inc
 	$(Q) echo $(MAC_PACKAGE_VERSION) > $@
 
 $(MAC_DESTDIR)/$(MAC_FRAMEWORK_CURRENT_DIR)/Versions.plist: Versions-mac.plist.in Makefile $(TOP)/Make.config versions-check.csharp

--- a/src/Makefile
+++ b/src/Makefile
@@ -629,6 +629,7 @@ INSTALL_TARGETS+=install-mac
 ALL_TARGETS+=all-mac
 
 MAC_TARGETS_DIRS += \
+	$(MAC_BUILD_DIR) \
 	$(MAC_BUILD_DIR)/mobile \
 	$(MAC_BUILD_DIR)/mobile/Facades \
 	$(MAC_BUILD_DIR)/full \

--- a/src/Makefile
+++ b/src/Makefile
@@ -82,8 +82,7 @@ IOS_compat_GENERATE=$(IOS_BMONO) --debug $(IOS_compat_GENERATOR)
 IOS_native_GENERATOR=$(IOS_BUILD_DIR)/native/generator.exe
 IOS_native_GENERATE=$(IOS_BMONO) --debug $(IOS_native_GENERATOR)
 endif
-$(IOS_BUILD_DIR)/Constants.cs: Constants.iOS.cs.in Makefile
-	$(Q) mkdir -p $(IOS_BUILD_DIR)
+$(IOS_BUILD_DIR)/Constants.cs: Constants.iOS.cs.in Makefile $(TOP)/Make.config.inc | $(IOS_BUILD_DIR)
 	$(call Q_PROF_GEN,ios) sed \
 		-e "s/@VERSION@/$(IOS_PACKAGE_VERSION_MAJOR).$(IOS_PACKAGE_VERSION_MINOR).$(IOS_PACKAGE_VERSION_REV)/g" \
 		-e "s/@REVISION@/$(IOS_COMMIT_DISTANCE) ($(CURRENT_BRANCH): $(shell git log -1 --pretty=%h))/g" \
@@ -482,7 +481,7 @@ MAC_MODERNHTTP_SOURCES = \
 	$(abspath $(MONO_PATH)/mcs/class/System.Net.Http/CFContentStream.cs)  \
 	$(abspath $(MONO_PATH)/mcs/class/System.Net.Http/CFNetworkHandler.cs) \
 
-$(MAC_BUILD_DIR)/Constants.cs: Constants.mac.cs.in Makefile
+$(MAC_BUILD_DIR)/Constants.cs: Constants.mac.cs.in Makefile $(TOP)/Make.config.inc | $(MAC_BUILD_DIR)
 	$(Q) sed \
 			-e "s/@VERSION@/$(MAC_PACKAGE_VERSION_MAJOR).$(MAC_PACKAGE_VERSION_MINOR).$(MAC_PACKAGE_VERSION_REV)/g" \
 			-e "s/@REVISION@/$(MAC_COMMIT_DISTANCE) ($(CURRENT_BRANCH): $(shell git log -1 --pretty=%h))/g" \
@@ -774,7 +773,7 @@ WATCHOS_CORE_SOURCES +=           \
 WATCHOS_SOURCES +=                \
     $(WATCHOS_EXTRA_CORE_SOURCES) \
 
-$(WATCH_BUILD_DIR)/Constants.cs: $(TOP)/src/Constants.watch.cs.in $(TOP)/Make.config $(TOP)/.git/HEAD | $(WATCH_BUILD_DIR)
+$(WATCH_BUILD_DIR)/Constants.cs: $(TOP)/src/Constants.watch.cs.in Makefile $(TOP)/Make.config.inc | $(WATCH_BUILD_DIR)
 	$(call Q_PROF_GEN,watch) sed \
 		-e "s/@VERSION@/$(IOS_PACKAGE_VERSION_MAJOR).$(IOS_PACKAGE_VERSION_MINOR).$(IOS_PACKAGE_VERSION_REV)/g" \
 		-e "s/@REVISION@/$(IOS_COMMIT_DISTANCE) ($(CURRENT_BRANCH): $(shell git log -1 --pretty=%h))/g" \
@@ -991,7 +990,7 @@ TVOS_CORE_SOURCES +=           \
 TVOS_SOURCES +=                \
 	$(TVOS_EXTRA_CORE_SOURCES) \
 
-$(TVOS_BUILD_DIR)/Constants.cs: $(TOP)/src/Constants.tvos.cs.in $(TOP)/Make.config $(TOP)/.git/HEAD | $(TVOS_BUILD_DIR)
+$(TVOS_BUILD_DIR)/Constants.cs: $(TOP)/src/Constants.tvos.cs.in Makefile $(TOP)/Make.config.inc | $(TVOS_BUILD_DIR)
 	$(call Q_PROF_GEN,tvos) sed \
 		-e "s/@VERSION@/$(IOS_PACKAGE_VERSION_MAJOR).$(IOS_PACKAGE_VERSION_MINOR).$(IOS_PACKAGE_VERSION_REV)/g" \
 		-e "s/@REVISION@/$(IOS_COMMIT_DISTANCE) ($(CURRENT_BRANCH): $(shell git log -1 --pretty=%h))/g" \


### PR DESCRIPTION
[build] Fix dependencies for various installed files.

Some auto-generated installed files with version numbers must depend on
Make.config.inc, since that's where the revision number is stored.

Make.config.inc depends on Makefile, so there's no need to depend on
Makefile as well.

[src] Rebuild Constants.cs when Make.config.inc changes.

Also unify the makefile targets/dependencies for the various Constants.cs
recipes.