### PR TITLE
[macos] Add explicit 57 error instead of NullReferenceException when …

### DIFF
--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -61,6 +61,10 @@ The path passed using `--sdkroot` does not specify a valid Xcode app. Please spe
 
 <h3><a name="MM0060">MM0060: Could not find the currently selected Xcode on the system. 'xcode-select --print-path' returned '{0}', but that directory does not exist.</h3>
 
+<h3><a name="MM0062">MM0062: No Xcode.app specified (using --sdkroot or 'xcode-select --print-path'), using the default Xcode instead: *</h3>
+
+This is a informational warning, explaining which Xcode will be used, since none was specified.
+
 <h3><a name="MM0068">MM0068: Invalid value for target framework: {0}.</h3>
 
 <h3><a name="MM0079">MM0079: Internal Error - No executable was copied into the app bundle. Please contact 'support@xamarin.com'</h3>

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -53,6 +53,10 @@ The easiest way to get exact version information is to use the **Xamarin Studio*
 
 <h3><a name="MM0056">MM0056: Cannot find Xcode in any of our default locations. Please install Xcode, or pass a custom path using --sdkroot=<path></h3>
 
+<h3><a name="MM0057">MM0057: Cannot determine the path to Xcode.app from the sdk root '*'. Please specify the full path to the Xcode.app bundle.</h3>
+
+The path passed using `--sdkroot` does not specify a valid Xcode app. Please specify a path to an Xcode app.
+
 <h3><a name="MM0059">MM0059: Could not find the currently selected Xcode on the system: {0};</h3>
 
 <h3><a name="MM0060">MM0060: Could not find the currently selected Xcode on the system. 'xcode-select --print-path' returned '{0}', but that directory does not exist.</h3>

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -554,6 +554,9 @@ namespace Xamarin.Bundler {
 		static void ValidateXcode ()
 		{
 			if (xcode_version == null) {
+				if (sdk_root == null)
+					throw ErrorHelper.CreateError (57, "Cannot determine the path to Xcode.app from the sdk root ''. Please specify the full path to the Xcode.app bundle.");
+
 				// Check what kind of path we got
 				if (File.Exists (Path.Combine (sdk_root, "Contents", "MacOS", "Xcode"))) {
 					// path to the Xcode.app

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -551,12 +551,19 @@ namespace Xamarin.Bundler {
 		}
 
 
+		const string XcodeDefault = "/Applications/Xcode.app";
 		static void ValidateXcode ()
 		{
 			if (xcode_version == null) {
-				if (sdk_root == null)
-					throw ErrorHelper.CreateError (57, "Cannot determine the path to Xcode.app from the sdk root ''. Please specify the full path to the Xcode.app bundle.");
-
+				if (sdk_root == null) {
+					if (File.Exists (Path.Combine (XcodeDefault, "Contents/MacOS/Xcode"))) {
+						sdk_root = XcodeDefault;
+						ErrorHelper.Warning (62, "No Xcode.app specified (using --sdkroot or 'xcode-select --print-path'), using the default Xcode instead: {0}", sdk_root);
+					}
+					else {
+						throw ErrorHelper.CreateError (57, "Cannot determine the path to Xcode.app from the sdk root ''. Please specify the full path to the Xcode.app bundle.");
+					}
+				}
 				// Check what kind of path we got
 				if (File.Exists (Path.Combine (sdk_root, "Contents", "MacOS", "Xcode"))) {
 					// path to the Xcode.app


### PR DESCRIPTION
…building without --sdkroot set