### PR TITLE
[ObjCRuntime] Only use a 'BundleFinder' class when we don't have another internal type we can use. Fixes #56255.

### DIFF
--- a/src/AssemblyInfo.cs.in
+++ b/src/AssemblyInfo.cs.in
@@ -15,3 +15,5 @@ using System.Runtime.CompilerServices;
 // FIXME: Probably need to add Copyright 2009-2011 Novell Inc.
 // [assembly: AssemblyCopyright ("Copyright 2011-2014 Xamarin Inc.")]
 [assembly: AssemblyCompany ("Xamarin Inc.")]
+
+[assembly: InternalsVisibleTo ("System.Net.Http, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]

--- a/src/ObjCRuntime/RuntimeOptions.cs
+++ b/src/ObjCRuntime/RuntimeOptions.cs
@@ -194,26 +194,12 @@ namespace XamCore.ObjCRuntime {
 		}
 #else
 
-#if SYSTEM_NET_HTTP
-		[Register ("__internal__xamarin_runtimeoptions_bundlefinder")]
-		class BundleFinder : NSObject {
-			public BundleFinder ()
-			{
-				IsDirectBinding = false;
-			}
-		}
-#endif
-
 		internal static RuntimeOptions Read ()
 		{
 			// for iOS NSBundle.ResourcePath returns the path to the root of the app bundle
 			// for macOS apps NSBundle.ResourcePath returns foo.app/Contents/Resources
 			// for macOS frameworks NSBundle.ResourcePath returns foo.app/Versions/Current/Resources
-#if SYSTEM_NET_HTTP
-			Class bundle_finder = new Class (typeof (BundleFinder));
-#else
 			Class bundle_finder = new Class (typeof (NSObject.NSObject_Disposer));
-#endif
 			var resource_dir = NSBundle.FromClass (bundle_finder).ResourcePath;
 			var plist_path = GetFileName (resource_dir);
 

--- a/src/ObjCRuntime/RuntimeOptions.cs
+++ b/src/ObjCRuntime/RuntimeOptions.cs
@@ -193,6 +193,8 @@ namespace XamCore.ObjCRuntime {
 			return type;
 		}
 #else
+
+#if SYSTEM_NET_HTTP
 		[Register ("__internal__xamarin_runtimeoptions_bundlefinder")]
 		class BundleFinder : NSObject {
 			public BundleFinder ()
@@ -200,13 +202,19 @@ namespace XamCore.ObjCRuntime {
 				IsDirectBinding = false;
 			}
 		}
+#endif
 
 		internal static RuntimeOptions Read ()
 		{
 			// for iOS NSBundle.ResourcePath returns the path to the root of the app bundle
 			// for macOS apps NSBundle.ResourcePath returns foo.app/Contents/Resources
 			// for macOS frameworks NSBundle.ResourcePath returns foo.app/Versions/Current/Resources
-			var resource_dir = NSBundle.FromClass (new Class (typeof (BundleFinder))).ResourcePath;
+#if SYSTEM_NET_HTTP
+			Class bundle_finder = new Class (typeof (BundleFinder));
+#else
+			Class bundle_finder = new Class (typeof (NSObject.NSObject_Disposer));
+#endif
+			var resource_dir = NSBundle.FromClass (bundle_finder).ResourcePath;
 			var plist_path = GetFileName (resource_dir);
 
 			if (!File.Exists (plist_path))


### PR DESCRIPTION
Inside our platform assemblies, we can use the NSObject.NSObject_Disposer
class to find the bundle (this class is not binding an existing Objective-C
class, which would make it unusable for this purpose, and it's also needed
always, which means we're not adding unnecessary bloat to linked platform
assemblies).

However, for System.Net.Http.dll, I couldn't find any publicly visible type
that would fit those criteria, so we're still using a custom 'BundleFinder'
class.

https://bugzilla.xamarin.com/show_bug.cgi?id=56255