### PR TITLE
[linker] Fix OptimizeGeneratedCodeSubStep when used with csc without /optimize. Fix #53872

### DIFF
--- a/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs
@@ -260,9 +260,11 @@ namespace MonoTouch.Tuner {
 			Nop (ins);						// ldfld MonoTouch.Foundation.IsDirectBinding
 			Instruction next = ins.Next;				// brfalse IL_x (SuperHandle processing)
 			Instruction end = null;
-			// unoptimized compiled code can produce a (unneeeded) store/load combo, leave it there
-			while (next.OpCode.FlowControl != FlowControl.Cond_Branch)
-				next = next.Next; // leave the code there (the JIT/AOT will deal with it)
+			// unoptimized compiled code can produce a (unneeded) store/load combo
+			while (next.OpCode.FlowControl != FlowControl.Cond_Branch) {
+				Nop (next);
+				next = next.Next;
+			}
 			ins = (next.Operand as Instruction).Previous;		// br end (ret)
 			if (ins.OpCode.Code == Code.Ret) {			// if there's not branch but it returns immediately then do not remove the 'ret' instruction
 				ins = ins.Next;


### PR DESCRIPTION
`csc` without `/optimize` generates different IL, including additional
and not required load and store instructions. We previously ignored them
but that could leave the stack unbalanced leading to runtime exceptions.
We are now nop'ing the extraneous instructions (same as the rest of the
unneeded branch code)

This fixes #53872 [1] and also the known parts of #56209 (the other parts
are still NEEDINFO and could, possibly, be unrelated).

[1] https://bugzilla.xamarin.com/show_bug.cgi?id=53872
[2] https://bugzilla.xamarin.com/show_bug.cgi?id=56209#c2