### PR TITLE
[macos][mmp] Fix RemoveSelectors when generics are used, Fix #55693

### DIFF
--- a/tools/linker/RemoveSelectors.cs
+++ b/tools/linker/RemoveSelectors.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Linker.Steps {
 				switch (instruction.OpCode.OperandType) {
 				case OperandType.InlineTok:
 				case OperandType.InlineField:
-					var field = instruction.Operand as FieldDefinition;
+					var field = (instruction.Operand as FieldReference)?.Resolve ();
 					if (field == null)
 						continue;
 
@@ -110,7 +110,7 @@ namespace Xamarin.Linker.Steps {
 			if (instruction.OpCode != OpCodes.Stsfld)
 				return false;
 
-			var field = instruction.Operand as FieldDefinition;
+			var field = (instruction.Operand as FieldReference)?.Resolve ();
 			if (field == null)
 				return false;
 


### PR DESCRIPTION
This XM-only RemoveSelectors works on FieldDefinition but in some cases,
e.g. inside a generic types, it's FieldReference that are encoded. This
meant the static constructor was not re-written correctly and would throw
a TargetInvocationException (since the fields were removed correctly)

https://bugzilla.xamarin.com/show_bug.cgi?id=55693