### PR TITLE
[registrar] Support 'out' parameters from NULL pointers. Fixes #54919.

### DIFF
--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -478,7 +478,10 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 				if (type [0] == _C_PTR && type [1] == _C_ID) {
 					MonoClass *p_klass = mono_class_from_mono_type (p);
 
-					if (p_klass == mono_get_string_class ()) {
+					if (arg == NULL) {
+						// Can't write back to a NULL pointer, so ignore this.
+						LOGZ (" not writing back to a null pointer\n");
+					} else if (p_klass == mono_get_string_class ()) {
 						MonoString *value = (MonoString *) arg_frame [ofs];
 						if (value == NULL) {
 							*(NSObject **) arg = NULL;

--- a/tests/bindings-test/ApiDefinition.cs
+++ b/tests/bindings-test/ApiDefinition.cs
@@ -173,6 +173,9 @@ namespace Bindings.Test {
 		[Export ("V:c:c:c:c:i:d:")]
 		void V (sbyte c1, sbyte c2, sbyte c3, sbyte c4, sbyte c5, int i1, double d1);
 
+		[Export ("V:n:")]
+		void V (out NSObject n1, out NSString n2);
+
 		[Export ("invoke_V")]
 		void Invoke_V ();
 
@@ -184,6 +187,9 @@ namespace Bindings.Test {
 
 		[Export ("Sf_invoke")]
 		Sf Sf_invoke ();
+
+		[Export ("invoke_V_null_out")]
+		void Invoke_V_null_out ();
 
 		[Export ("methodReturningBlock")]
 		RegistrarTestBlock MethodReturningBlock ();

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2413,6 +2413,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 		}
 
+#if !MONOMAC // ObjCRegistrarTest is from Bindings.Tests, which is not currently implemented on mac
 		class NullOutParameters : ObjCRegistrarTest
 		{
 			public override void V (out NSObject n1, out NSString n2)
@@ -2429,6 +2430,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				obj.Invoke_V_null_out ();
 		}
 	}
+#endif
 
 #if !__WATCHOS__
 	[Category (typeof (CALayer))]

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2412,6 +2412,22 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			using (var m = new NSMeasurement<NSUnitTemperature> (2, NSUnitTemperature.Fahrenheit)) {
 			}
 		}
+
+		class NullOutParameters : ObjCRegistrarTest
+		{
+			public override void V (out NSObject n1, out NSString n2)
+			{
+				n1 = null;
+				n2 = null;
+			}
+		}
+
+		[Test]
+		public void TestNullOutParameters ()
+		{
+			using (var obj = new NullOutParameters ())
+				obj.Invoke_V_null_out ();
+		}
 	}
 
 #if !__WATCHOS__

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2429,8 +2429,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			using (var obj = new NullOutParameters ())
 				obj.Invoke_V_null_out ();
 		}
-	}
 #endif
+	}
 
 #if !__WATCHOS__
 	[Category (typeof (CALayer))]

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -128,6 +128,10 @@ static UltimateMachine *shared;
 		_Pc1 = c1; _Pc2 = c2; _Pc3 = c3; _Pc4 = c4; _Pc5 = c5; _Pi1 = i1; _Pd1 = d1;
 	}
 
+	-(void) V:(out id  _Nullable *)n1 n:(out NSString * _Nullable *)n2
+	{
+		abort (); // this method is supposed to be overridden
+	}
 
 	/*
 	 * Invoke method
@@ -151,6 +155,11 @@ static UltimateMachine *shared;
 	-(struct Sf) Sf_invoke
 	{
 		return [self Sf];
+	}
+
+	-(void) invoke_V_null_out
+	{
+		[self V:nil n:nil];
 	}
 
 	/*

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3105,7 +3105,8 @@ namespace XamCore.Registrar {
 							body_setup.AppendLine ("void * handle{0} = NULL;", i);
 							copyback.AppendLine ("if (mobj{0} != NULL)", i);
 							copyback.AppendLine ("handle{0} = xamarin_get_nsobject_handle (mobj{0});", i);
-							copyback.AppendLine ("*p{0} = (id) handle{0};", i);
+							copyback.AppendLine ("if (p{0} != NULL)", i).Indent ();
+							copyback.AppendLine ("*p{0} = (id) handle{0};", i).Unindent ();
 						} else {
 							body_setup.AppendLine ("NSObject *nsobj{0} = NULL;", i);
 							setup_call_stack.AppendLine ("nsobj{0} = (NSObject *) p{0};", i);


### PR DESCRIPTION
Native code doesn't have the 'out' and 'ref' distinction C# has, and passes
NULL around left and right.

So make sure the generated code from the static registrar doesn't write to such NULLs.

https://bugzilla.xamarin.com/show_bug.cgi?id=54919