### PR TITLE
More details for the cryptic "can't lipo directories" error

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1583,7 +1583,7 @@ namespace Xamarin.Bundler {
 				if (isFramework) {
 					// This is a framework
 					if (files.Count != 1)
-						throw ErrorHelper.CreateError (99, "Internal error: 'can't lipo directories'. Please file a bug report with a test case (http://bugzilla.xamarin.com).");
+                        throw ErrorHelper.CreateError (99, $"Internal error: 'can't lipo directories'. {name}:{info}:{targetPath}:{files.Count} Please file a bug report with a test case (http://bugzilla.xamarin.com).");
 					if (info.DylibToFramework)
 						throw ErrorHelper.CreateError (99, "Internal error: 'can't convert frameworks to frameworks'. Please file a bug report with a test case (http://bugzilla.xamarin.com).");
 					var framework_src = files.First ();


### PR DESCRIPTION
In order to write a good bug request, we need to know what part of our code is triggering the error. Pardon my formatting, I read the mono guide, but I'm not sure how to make visual studio follow the suggested tab to spaces ratio. I was happy to get it to compile. I'm also filing a separate bugzilla report for the Crashlytics nuget which makes this happen.