### PR TITLE
[generator] Create CVPixelBuffer using GetINativeObject so its usable from 3rd party bindings

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -2104,7 +2104,7 @@ public partial class Generator : IMemberGatherer {
 			marshal_types.Add (new MarshalType (TypeManager.ABRecord, create: "ABRecord.FromHandle("));
 		}
 		if (Frameworks.HaveCoreVideo)
-			marshal_types.Add (new MarshalType (TypeManager.CVPixelBuffer, create: "Runtime.GetINativeObject<CVPixelBuffer> (", closingCreate: ", false)")); // owns `false` like ptr ctor https://git.io/vHvLj
+			marshal_types.Add (new MarshalType (TypeManager.CVPixelBuffer, create: "Runtime.GetINativeObject<CVPixelBuffer> (", closingCreate: ", false)")); // owns `false` like ptr ctor https://github.com/xamarin/xamarin-macios/blob/6f68ab6f79c5f1d96d2cbb1e697330623164e46d/src/CoreVideo/CVBuffer.cs#L74-L90
 		marshal_types.Add (TypeManager.CGLayer);
 		if (Frameworks.HaveCoreMedia)
 			marshal_types.Add (TypeManager.CMSampleBuffer);

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -2103,8 +2103,10 @@ public partial class Generator : IMemberGatherer {
 			marshal_types.Add (new MarshalType (TypeManager.ABPerson, create: "(ABPerson) ABRecord.FromHandle("));
 			marshal_types.Add (new MarshalType (TypeManager.ABRecord, create: "ABRecord.FromHandle("));
 		}
-		if (Frameworks.HaveCoreVideo)
-			marshal_types.Add (new MarshalType (TypeManager.CVPixelBuffer, create: "Runtime.GetINativeObject<CVPixelBuffer> (", closingCreate: ", false)")); // owns `false` like ptr ctor https://github.com/xamarin/xamarin-macios/blob/6f68ab6f79c5f1d96d2cbb1e697330623164e46d/src/CoreVideo/CVBuffer.cs#L74-L90
+		if (Frameworks.HaveCoreVideo) {
+			// owns `false` like ptr ctor https://github.com/xamarin/xamarin-macios/blob/6f68ab6f79c5f1d96d2cbb1e697330623164e46d/src/CoreVideo/CVBuffer.cs#L74-L90
+			marshal_types.Add (new MarshalType (TypeManager.CVPixelBuffer, create: "Runtime.GetINativeObject<CVPixelBuffer> (", closingCreate: ", false)"));
+		}
 		marshal_types.Add (TypeManager.CGLayer);
 		if (Frameworks.HaveCoreMedia)
 			marshal_types.Add (TypeManager.CMSampleBuffer);

--- a/tests/generator/sof20696157.cs
+++ b/tests/generator/sof20696157.cs
@@ -230,10 +230,8 @@ namespace Test {
 	[Protocol] interface C137 : IAUAudioUnitFactory {}
 	[Protocol] interface C138 : INSKeyedUnarchiverDelegate {}
 	[Protocol] interface C139 : IINStartAudioCallIntentHandling {}
-	// sof20696157.tmpdir/Test/C140.g.cs(92,10): error CS0246: The type or namespace name `CIFormat' could not be found. Are you missing `CoreImage' using directive?
-	// [Protocol] interface C140 : ICIImageProcessorInput {}
-	// sof20696157.tmpdir/Test/C141.g.cs(92,10): error CS0246: The type or namespace name `CIFormat' could not be found. Are you missing `CoreImage' using directive?
-	// [Protocol] interface C141 : ICIImageProcessorOutput {}
+	[Protocol] interface C140 : ICIImageProcessorInput {}
+	[Protocol] interface C141 : ICIImageProcessorOutput {}
 	[Protocol] interface C142 : IPHLivePhotoFrame {}
 	[Protocol] interface C143 : ICIImageProvider {}
 	[Protocol] interface C144 : IUIApplicationDelegate {}
@@ -594,10 +592,8 @@ namespace Test {
 	[Protocol] [BaseType (typeof (NSObject))] interface M137 : IAUAudioUnitFactory {}
 	[Protocol] [BaseType (typeof (NSObject))] interface M138 : INSKeyedUnarchiverDelegate {}
 	[Protocol] [BaseType (typeof (NSObject))] interface M139 : IINStartAudioCallIntentHandling {}
-	// sof20696157.tmpdir/Test/M140.g.cs(92,10): error CS0246: The type or namespace name `CIFormat' could not be found. Are you missing `CoreImage' using directive?
-	// [Protocol] [BaseType (typeof (NSObject))] interface M140 : ICIImageProcessorInput {}
-	// sof20696157.tmpdir/Test/M141.g.cs(92,10): error CS0246: The type or namespace name `CIFormat' could not be found. Are you missing `CoreImage' using directive?
-	// [Protocol] [BaseType (typeof (NSObject))] interface M141 : ICIImageProcessorOutput {}
+	[Protocol] [BaseType (typeof (NSObject))] interface M140 : ICIImageProcessorInput {}
+	[Protocol] [BaseType (typeof (NSObject))] interface M141 : ICIImageProcessorOutput {}
 	[Protocol] [BaseType (typeof (NSObject))] interface M142 : IPHLivePhotoFrame {}
 	[Protocol] [BaseType (typeof (NSObject))] interface M143 : ICIImageProvider {}
 	[Protocol] [BaseType (typeof (NSObject))] interface M144 : IUIApplicationDelegate {}

--- a/tests/monotouch-test/CoreVideo/PixelBufferTest.cs
+++ b/tests/monotouch-test/CoreVideo/PixelBufferTest.cs
@@ -102,6 +102,13 @@ namespace MonoTouchFixtures.CoreVideo {
 			Assert.Throws<ArgumentOutOfRangeException> (() => CVPixelBuffer.Create (width, height, CVPixelFormatType.CV420YpCbCr8BiPlanarVideoRange, data, planeWidths, planeHeights, new nint [] { width }, null), "invalid bytesPerRow");
 			Assert.Throws<ArgumentOutOfRangeException> (() => CVPixelBuffer.Create (width, height, CVPixelFormatType.CV420YpCbCr8BiPlanarVideoRange, data, planeWidths, planeHeights, new nint [] { width, width, width }, null), "invalid bytesPerRow");
 		}
+
+		[Test]
+		public void CheckInvalidPtr ()
+		{
+			var invalid = Runtime.GetINativeObject<CVPixelBuffer> (IntPtr.Zero, false);
+			Assert.Null (invalid, "CheckInvalidPtr");
+		}
 	}
 }
 


### PR DESCRIPTION
Complements https://bugzilla.xamarin.com/show_bug.cgi?id=52665
and PR #2102

`CVPixelBuffer` was created using the internal handle ctor, this
did not allow 3rd party bindings to bind it correctly since it
generated not compilable code.

We now use `Runtime.GetINativeObject<CVPixelBuffer> (ptr, false);` just
like the base ctor https://git.io/vHvLj.

Build diff: https://gist.github.com/dalexsoto/a58ba69228aaed713425e97398fb1c6b