### PR TITLE
[mtouch] Fix linking with the same third-party framework from both extension and container app. Fixes #56635.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -747,6 +747,18 @@ Please unlock the device and try again.
 
 <!-- 1034 used by mmp -->
 
+<h3><a name="MT1035"/>MT1035: Cannot include different versions of the framework '{name}'</h3>
+
+It is not possible to link with different versions of the same framework.
+
+This typically happens when an extension references a different version of a framework than the container app (possibly through a third-party binding assembly).
+
+Following this error there will be multiple [MT1036](#MT1036) errors listing the paths for each different framework.
+
+<h3><a name="MT1036"/>MT1036: Framework '{name}' included from: {path} (Related to previous error)</h3>
+
+This error is reported only together with [MT1036](#MT1036). Please see [MT1036](#MT1036) for more information.
+
 ### MT11xx: Debug Service
 
 <!--

--- a/tools/common/cache.cs
+++ b/tools/common/cache.cs
@@ -69,6 +69,22 @@ public class Cache {
 		Directory.CreateDirectory (Location);
 	}
 
+	public static bool CompareDirectories (string a, string b, bool ignore_cache = false)
+	{
+		if (Driver.Force && !ignore_cache) {
+			Driver.Log (6, "Directories {0} and {1} are considered different because -f was passed to " + NAME + ".", a, b);
+			return false;
+		}
+
+		var diff = new StringBuilder ();
+		if (Driver.RunCommand ("diff", $"-ur {Driver.Quote (a)} {Driver.Quote (b)}", output: diff, suppressPrintOnErrors: true) != 0) {
+			Driver.Log (1, "Directories {0} and {1} are considered different because diff said so:\n{2}", a, b, diff);
+			return false;
+		}
+
+		return true;
+	}
+
 	public static bool CompareFiles (string a, string b, bool ignore_cache = false)
 	{
 		if (Driver.Force && !ignore_cache) {

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1580,12 +1580,32 @@ namespace Xamarin.Bundler {
 				if (!HasFrameworksDirectory && (isFramework || info.DylibToFramework))
 					continue; // Don't copy frameworks to app extensions (except watch extensions), they go into the container app.
 
+				if (!files.All ((v) => Directory.Exists (v)))
+					throw ErrorHelper.CreateError (99, $"Internal error: 'can't process a mix of dylibs and frameworks: {string.Join (", ", files)}'. Please file a bug report with a test case (https://bugzilla.xamarin.com).");
+
 				if (isFramework) {
 					// This is a framework
-					if (files.Count != 1)
-						throw ErrorHelper.CreateError (99, "Internal error: 'can't lipo directories'. Please file a bug report with a test case (http://bugzilla.xamarin.com).");
+					if (files.Count > 1) {
+						// If we have multiple frameworks, check if they're identical, and remove any duplicates
+						var firstFile = files.First ();
+						foreach (var otherFile in files.Where ((v) => v != firstFile).ToArray ()) {
+							if (Cache.CompareDirectories (firstFile, otherFile, ignore_cache: true)) {
+								Driver.Log (6, $"Framework '{name}' included from both '{firstFile}' and '{otherFile}', but they are identical, so the latter will be ignored.");
+								files.Remove (otherFile);
+								continue;
+							}
+						}
+					}
+					if (files.Count != 1) {
+						var exceptions = new List<Exception> ();
+						var fname = Path.GetFileName (name);
+						exceptions.Add (ErrorHelper.CreateError (1035, $"Cannot include different versions of the framework '{fname}'"));
+						foreach (var file in files)
+							exceptions.Add (ErrorHelper.CreateError (1036, $"Framework '{fname}' included from: {file} (Related to previous error)"));
+						throw new AggregateException (exceptions);
+					}
 					if (info.DylibToFramework)
-						throw ErrorHelper.CreateError (99, "Internal error: 'can't convert frameworks to frameworks'. Please file a bug report with a test case (http://bugzilla.xamarin.com).");
+						throw ErrorHelper.CreateError (99, $"Internal error: 'can't convert frameworks to frameworks: {files.First ()}'. Please file a bug report with a test case (https://bugzilla.xamarin.com).");
 					var framework_src = files.First ();
 					var framework_filename = Path.Combine (framework_src, Path.GetFileNameWithoutExtension (framework_src));
 					if (!MachO.IsDynamicFramework (framework_filename)) {

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -338,6 +338,9 @@
     <None Include="Makefile" />
     <None Include="monotouch-fixes.c" />
     <None Include="simlauncher.m" />
+    <None Include="..\..\docs\website\mtouch-errors.md">
+      <Link>mtouch-errors.md</Link>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Mono.Linker\" />


### PR DESCRIPTION
If both an extension and the container app (or multiple extensions) reference
the same binding assembly for a framework, then we'd error out with an
internal error when trying to copy the framework from both locations to the
container app.

So instead detect when we're trying to copy multiple identical (by comparing
the on-disk contents) frameworks, and only copy one of them.

We'll still show an error if the frameworks are different, but now a nice
MT1035 error with a proper error description instead of an internal error.

https://bugzilla.xamarin.com/show_bug.cgi?id=56635