### PR TITLE
[mmptest] Delay test directory cleanup until next test run.

### DIFF
--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -72,6 +72,9 @@
     <Compile Include="src\FrameworkLinksTests.cs" />
     <Compile Include="src\LinkerTests.cs" />
     <Compile Include="src\Extensions.cs" />
+    <Compile Include="..\mtouch\Cache.cs">
+      <Link>Cache.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -14,18 +14,7 @@ namespace Xamarin.MMP.Tests
 	{
 		void RunMMPTest (Action <string> test)
 		{
-			string tmpDir = Path.Combine (Path.GetTempPath (), "mmp-test-dir");
-			try {
-				// Clean out any existing build there first to prevent strange behavior
-				if (Directory.Exists (tmpDir))
-					Directory.Delete (tmpDir, true);
-
-				Directory.CreateDirectory (tmpDir);
-				test (tmpDir);
-			}
-			finally {
-				Directory.Delete (tmpDir, true);
-			}
+			test (Cache.CreateTemporaryDirectory ());
 		}
 
 		// TODO - We have multiple tests using this. It doesn't take that long, but is it worth caching?


### PR DESCRIPTION
Use our Cache.CreateTemporaryDirectory method which will clean up the test
directories on the next test run (instead of when a test is done).

This makes it easier to inspect temporary test files after a test has
completed.