### PR TITLE
[tests][msbuild] Fix compiler warning.

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
@@ -276,7 +276,7 @@ namespace Xamarin.iOS.Tasks
 		{
 			path = Path.Combine (TempDir, path);
 			Directory.CreateDirectory (Path.GetDirectoryName (path));
-			using (new FileStream (path, FileMode.CreateNew));
+			using (new FileStream (path, FileMode.CreateNew)) {}
 			return path;
 		}
 


### PR DESCRIPTION
Fixes:

TestHelpers/TestBase.cs(279,53): warning CS0642: Possible mistaken empty statement