### PR TITLE
[mtouch] Cache the list of assemblies we computed. Partially fixes #49087.

### DIFF
--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -414,6 +414,7 @@ namespace Xamarin.Bundler
 				throw new AggregateException (exceptions);
 
 			// Cache all the assemblies we found.
+			Directory.CreateDirectory (Path.GetDirectoryName (cache_file));
 			File.WriteAllLines (cache_file, assemblies);
 		}
 


### PR DESCRIPTION
Computing the list of assemblies can be expensive, so cache it and re-use the
cached list if we can.

https://bugzilla.xamarin.com/show_bug.cgi?id=49087