### PR TITLE
[mtouch] Don't look for assembly references in attributes in assemblies we ship. Partially fixes #49087.

### DIFF
--- a/tests/mtouch/SdkTest.cs
+++ b/tests/mtouch/SdkTest.cs
@@ -136,30 +136,18 @@ namespace Xamarin.Linker {
 			Facades (watchOSPath);
 		}
 
-		static string [] FindAllAssemblies ()
-		{
-			var rv = new List<string> ();
-			var dir = Path.Combine (Configuration.MonoTouchRootDirectory, "lib/mono");
-			var assemblies = Directory.GetFiles (dir, "*.dll", SearchOption.AllDirectories);
-			rv.AddRange (assemblies.Select ((v) => {
-				// Return the significant part at the end of the path,
-				// which makes the various test cases show up nicer
-				// in VSfM's test pad.
-				return v.Substring (dir.Length + 1);
-			}));
-			return rv.ToArray ();
-		}
-
 		[Test]
-		[TestCaseSource ("FindAllAssemblies")]
-		public void NoAssemblyReferenceInAttributes (string filename)
+		public void NoAssemblyReferenceInAttributes ()
 		{
-			// This tests verifies that there aren't any attributes in any assembly we ship
-			// that references an assembly that's not in the normal assembly references.
-			// It takes a significant amount of time to look in all the attributes for assembly references,
-			// and knowing that no such attributes exist in any assembly we ship, allows us
-			// to complete skip this step in mtouch
-			VerifyNoAdditionalAssemblyReferenceInAttributes (Path.Combine (Configuration.MonoTouchRootDirectory, "lib", "mono", filename));
+			var dir = Path.Combine (Configuration.MonoTouchRootDirectory, "lib/mono");
+			foreach (var filename in Directory.GetFiles (dir, "*.dll", SearchOption.AllDirectories)) {
+				// This tests verifies that there aren't any attributes in any assembly we ship
+				// that references an assembly that's not in the normal assembly references.
+				// It takes a significant amount of time to look in all the attributes for assembly references,
+				// and knowing that no such attributes exist in any assembly we ship, allows us
+				// to complete skip this step in mtouch
+				VerifyNoAdditionalAssemblyReferenceInAttributes (filename);
+			}
 		}
 
 		void VerifyNoAdditionalAssemblyReferenceInAttributes (string filename)

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -431,6 +431,9 @@ namespace Xamarin.Bundler
 				ComputeListOfAssemblies (assemblies, reference_assembly, exceptions);
 			}
 
+			if (Profile.IsSdkAssembly (assembly) || Profile.IsProductAssembly (assembly))
+				return; // We know there are no new assembly references from attributes in assemblies we ship
+
 			// Custom Attribute metadata can include references to other assemblies, e.g. [X (typeof (Y)], 
 			// but it is not reflected in AssemblyReferences :-( ref: #37611
 			// so we must scan every custom attribute to look for System.Type


### PR DESCRIPTION
Don't look for assembly references in attributes in assemblies we ship,
because it takes a significant amount of time to do this, and we can
precompute the fact that there aren't any such assembly references.

Additionally add a test to ensure we catch any changes to this assumption.

For a simple test app this makes rebuilding (without any changes) go from
~1.1s to ~0.4s.

https://bugzilla.xamarin.com/show_bug.cgi?id=49087