### PR TITLE
[xharness] Don't wait forever for output streams to end.

### DIFF
--- a/tests/xharness/Process_Extensions.cs
+++ b/tests/xharness/Process_Extensions.cs
@@ -91,7 +91,7 @@ namespace xharness
 						StdoutStream.Flush ();
 					}
 				} else {
-					stdout_completion.SetResult (true);
+					stdout_completion.TrySetResult (true);
 				}
 			};
 
@@ -103,7 +103,7 @@ namespace xharness
 						StderrStream.Flush ();
 					}
 				} else {
-					stderr_completion.SetResult (true);
+					stderr_completion.TrySetResult (true);
 				}
 			};
 
@@ -134,6 +134,9 @@ namespace xharness
 					process.WaitForExit ();
 				}
 				exit_completion.TrySetResult (true);
+				Task.WaitAll (new Task [] { stderr_completion.Task, stdout_completion.Task }, TimeSpan.FromSeconds (1));
+				stderr_completion.TrySetResult (false);
+				stdout_completion.TrySetResult (false);
 			}) {
 				IsBackground = true,
 			}.Start ();


### PR DESCRIPTION
Sometimes streams won't write null when done, which means that if we wait
indefinitely for this to happen, we'll effectively deadlock.

Instead have a 1s timeout, after which we consider that we've captured
everything we need.

Example: https://jenkins.mono-project.com/job/xamarin-macios-pr-builder/3771/Test_Report/
(the test run hangs waiting for the mtouch tests, which finished pretty much instantly).