### PR TITLE
[mtouch] Load assemblies correctly when loading cached list of assemblies.

### DIFF
--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -387,8 +387,12 @@ namespace Xamarin.Bundler
 				// Check if any of the referenced assemblies changed after we cached the complete set of references
 				if (Application.IsUptodate (assemblies, new string [] { cache_file })) {
 					// Load all the assemblies in the cached list of assemblies
-					foreach (var assembly in assemblies)
-						ManifestResolver.Load (assembly);
+					foreach (var assembly in assemblies) {
+						var ad = ManifestResolver.Load (assembly);
+						var asm = new Assembly (this, ad);
+						asm.ComputeSatellites ();
+						this.Assemblies.Add (asm);
+					}
 					return;
 				}
 


### PR DESCRIPTION
Make sure to instantiate an Assembly instance for every assembly loaded using
the cached list of assemblies.

Fixes the following test failures:

1. Xamarin.MTouch.RebuildTest_WithExtensions("single","",False,System.String[]) :   second build
  Expected: 0
  But was:  1

2. Xamarin.MTouch.RebuildTest_WithExtensions("dual","armv7,arm64",False,System.String[]) :   second build
  Expected: 0
  But was:  1

3. Xamarin.MTouch.RebuildTest_WithExtensions("llvm","armv7+llvm",False,System.String[]) :   second build
  Expected: 0
  But was:  1

4. Xamarin.MTouch.RebuildTest_WithExtensions("debug","",True,System.String[]) :   second build
  Expected: 0
  But was:  1

5. Xamarin.MTouch.RebuildTest_WithExtensions("single-framework","",False,System.String[]) :   second build
  Expected: 0
  But was:  1