### PR TITLE
[mmp] Fix compiler warning by moving #ifs.

### DIFF
--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -141,8 +141,8 @@ namespace Xamarin.Bundler {
 					Framework framework;
 					if (Driver.GetFrameworks (App).TryGetValue (nspace, out framework)) {
 						// framework specific processing
-						switch (framework.Name) {
 #if !MONOMAC
+						switch (framework.Name) {
 						case "CoreAudioKit":
 							// CoreAudioKit seems to be functional in the iOS 9 simulator.
 							if (App.IsSimulatorBuild && App.SdkVersion.Major < 9)
@@ -164,8 +164,8 @@ namespace Xamarin.Bundler {
 								continue;
 							}
 							break;
-#endif
 						}
+#endif
 
 						if (App.SdkVersion >= framework.Version) {
 							var add_to = App.DeploymentTarget >= framework.Version ? asm.Frameworks : asm.WeakFrameworks;


### PR DESCRIPTION
Fixes this compiler warning:

/work/maccore/master/xamarin-macios/tools/common/Target.cs(144,31): warning CS1522: Empty switch block