### PR TITLE
[mmp] Propagate the static registrar to the linker like we do for mtouch.

### DIFF
--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -35,6 +35,7 @@ namespace MonoMac.Tuner {
 		internal PInvokeWrapperGenerator MarshalNativeExceptionsState { get; set; }
 		internal RuntimeOptions RuntimeOptions { get; set; }
 		public bool SkipExportedSymbolsInSdkAssemblies { get; set; }
+		public Target Target { get; set; }
 
 		public static I18nAssemblies ParseI18nAssemblies (string i18n)
 		{
@@ -135,6 +136,7 @@ namespace MonoMac.Tuner {
 				context.SymbolWriterProvider = new DefaultSymbolWriterProvider ();
 			}
 			context.OutputDirectory = options.OutputDirectory;
+			context.StaticRegistrar = options.Target.StaticRegistrar;
 			return context;
 		}
 

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1415,6 +1415,7 @@ namespace Xamarin.Bundler {
 					Registrar = (StaticRegistrar) BuildTarget.StaticRegistrar,
 				},
 				SkipExportedSymbolsInSdkAssemblies = !embed_mono,
+				Target = BuildTarget,
 			};
 
 			linker_options = options;


### PR DESCRIPTION
Fixes this compiler warning:

/work/maccore/master/xamarin-macios/tools/common/DerivedLinkContext.cs(12,28): warning CS0649: Field 'DerivedLinkContext.StaticRegistrar' is never assigned to, and will always have its default value null

and makes the mmp code closer to mtouch.