### PR TITLE
[registrar] Define a magic symbol to avoid a compiler warning.

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -1724,6 +1724,13 @@ namespace XamCore.Registrar {
 			string h;
 			switch (ns) {
 #if MMP
+			case "GLKit":
+				// This prevents this warning:
+				//     /Applications/Xcode83.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/OpenGL.framework/Headers/gl.h:5:2: warning: gl.h and gl3.h are both
+				//     included. Compiler will not invoke errors if using removed OpenGL functionality. [-W#warnings]
+				// This warning shows up when both GLKit/GLKit.h and Quartz/Quartz.h are included.
+				header.WriteLine ("#define GL_DO_NOT_WARN_IF_MULTI_GL_VERSION_HEADERS_INCLUDED 1");
+				goto default;
 			case "CoreBluetooth":
 				header.WriteLine ("#import <IOBluetooth/IOBluetooth.h>");
 				header.WriteLine ("#import <CoreBluetooth/CoreBluetooth.h>");


### PR DESCRIPTION
This avoids the following compiler warning:

    /Applications/Xcode83.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/OpenGL.framework/Headers/gl.h:5:2: warning: gl.h and gl3.h are both included. Compiler will not invoke errors if using removed OpenGL functionality. [-W#warnings]

I found the magic symbol by looking at the headers.