### PR TITLE
[xharness] Fix generated makefile to avoid generating duplicated targets. Fixes #56492.

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -283,18 +283,16 @@ namespace xharness
 			MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "introspection", "Mac", "introspection-mac.csproj")), skipXMVariations: true) { Name = "introspection" });
 
 			var hard_coded_test_suites = new [] {
-				new { ProjectFile = "mmptest", Name = "mmptest", IsNUnit = true, Configuration = "", Variation = "" },
-				new { ProjectFile = "msbuild-mac", Name = "MSBuild tests", IsNUnit = false, Configuration = "", Variation = "" },
-				new { ProjectFile = "xammac_tests", Name = "xammac tests", IsNUnit = false, Configuration = "Debug", Variation = "Debug" },
-				new { ProjectFile = "xammac_tests", Name = "xammac tests", IsNUnit = false, Configuration = "Release", Variation = "Release" },
+				new { ProjectFile = "mmptest", Name = "mmptest", IsNUnit = true, Configurations = (string[]) null },
+				new { ProjectFile = "msbuild-mac", Name = "MSBuild tests", IsNUnit = false, Configurations = (string[]) null },
+				new { ProjectFile = "xammac_tests", Name = "xammac tests", IsNUnit = false, Configurations = new string [] { "Debug", "Release" }},
 			};
 			foreach (var p in hard_coded_test_suites) {
 				MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p.ProjectFile + "/" + p.ProjectFile + ".csproj")), generateVariations: false) {
 					Name = p.Name,
 					IsNUnitProject = p.IsNUnit,
 					SolutionPath = Path.GetFullPath (Path.Combine (RootDirectory, "tests-mac.sln")),
-					Configuration = p.Configuration,
-					Variation = p.Variation,
+					Configurations = p.Configurations,
 				});
 			}
 

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -14,7 +14,6 @@ namespace xharness
 		public string Path;
 		public string SolutionPath;
 		public string Name;
-		public string Variation;
 		public bool IsExecutableProject;
 		public bool IsNUnitProject;
 		public bool GenerateVariations = true;
@@ -126,7 +125,7 @@ namespace xharness
 	public class MacTestProject : TestProject
 	{
 		public bool SkipXMVariations;
-		public string Configuration;
+		public string [] Configurations;
 
 		public MacTestProject () : base ()
 		{


### PR DESCRIPTION
Rework how the two different xammac configurations are done, so that we don't
generate identical makefile targets for both variations (we'll generate a
single makefile target, and the configuration is selected using an environment
variable).

Fixes these makefile warnings:

```
Makefile-mac.inc:303: warning: overriding commands for target `build-mac-unified-xammac_tests'
Makefile-mac.inc:287: warning: ignoring old commands for target `build-mac-unified-xammac_tests'
Makefile-mac.inc:307: warning: overriding commands for target `clean-mac-unified-xammac_tests'
Makefile-mac.inc:291: warning: ignoring old commands for target `clean-mac-unified-xammac_tests'
Makefile-mac.inc:310: warning: overriding commands for target `exec-mac-unified-xammac_tests'
Makefile-mac.inc:294: warning: ignoring old commands for target `exec-mac-unified-xammac_tests'
Makefile-mac.inc:313: warning: overriding commands for target `run-mac-unified-xammac_tests'
Makefile-mac.inc:297: warning: ignoring old commands for target `run-mac-unified-xammac_tests'
```

https://bugzilla.xamarin.com/show_bug.cgi?id=56492