### PR TITLE
[registrar] Add support for specifying that a protocol changed informal status in a certain SDK. Fixes #43780 and #48311.

### DIFF
--- a/src/Foundation/ProtocolAttribute.cs
+++ b/src/Foundation/ProtocolAttribute.cs
@@ -34,6 +34,21 @@ namespace XamCore.Foundation {
 		public Type WrapperType { get; set; }
 		public string Name { get; set; }
 		public bool IsInformal { get; set; }
+		// In which SDK version this protocol switched from (or to, depending on the current IsInformal value) being informal.
+		// If IsInformal = true, then this protocol switched to being informal in the specified SDK version
+		// If IsInformal = false, then this protocol switched to a real protocol in the specified SDK version
+		// Version is not a valid type for attributes, so we're using an array of ints.
+		int[] informal_switch;
+		public int [] InformalSwitch {
+			get {
+				return informal_switch;
+			}
+			set {
+				if (value != null && (value.Length < 2 || value.Length > 4))
+					throw new ArgumentOutOfRangeException ("value", "array must either be null, or have between 2 and 4 elements");
+				informal_switch = value;
+			}
+		}
 	}
 
 	[AttributeUsage (AttributeTargets.Interface, AllowMultiple = true)]

--- a/src/Foundation/ProtocolAttribute.cs
+++ b/src/Foundation/ProtocolAttribute.cs
@@ -37,7 +37,7 @@ namespace XamCore.Foundation {
 		// In which SDK version this protocol switched from being informal (i.e. a category) to a formal protocol.
 		// System.Version is not a valid type for attributes, so we're using a string instead.
 		string informal_until;
-		public string InformalUntil {
+		public string FormalSince {
 			get {
 				return informal_until;
 			}

--- a/src/Foundation/ProtocolAttribute.cs
+++ b/src/Foundation/ProtocolAttribute.cs
@@ -34,19 +34,17 @@ namespace XamCore.Foundation {
 		public Type WrapperType { get; set; }
 		public string Name { get; set; }
 		public bool IsInformal { get; set; }
-		// In which SDK version this protocol switched from (or to, depending on the current IsInformal value) being informal.
-		// If IsInformal = true, then this protocol switched to being informal in the specified SDK version
-		// If IsInformal = false, then this protocol switched to a real protocol in the specified SDK version
-		// Version is not a valid type for attributes, so we're using an array of ints.
-		int[] informal_switch;
-		public int [] InformalSwitch {
+		// In which SDK version this protocol switched from being informal (i.e. a category) to a formal protocol.
+		// System.Version is not a valid type for attributes, so we're using a string instead.
+		string informal_until;
+		public string InformalUntil {
 			get {
-				return informal_switch;
+				return informal_until;
 			}
 			set {
-				if (value != null && (value.Length < 2 || value.Length > 4))
-					throw new ArgumentOutOfRangeException ("value", "array must either be null, or have between 2 and 4 elements");
-				informal_switch = value;
+				if (value != null)
+					Version.Parse (value); // This will throw an exception with invalid input, which is what we want.
+				informal_until = value;
 			}
 		}
 	}

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -1485,6 +1485,11 @@ namespace XamCore.Registrar {
 				var pAttr = GetProtocolAttribute (type);
 				isInformalProtocol = pAttr.IsInformal;
 				isProtocol = true;
+
+#if MMP || MTOUCH
+				if (pAttr.InformalSwitchVersion != null && pAttr.InformalSwitchVersion > App.SdkVersion)
+					isInformalProtocol = !isInformalProtocol;
+#endif
 			}
 
 			// make sure the base type is already registered

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -1487,7 +1487,7 @@ namespace XamCore.Registrar {
 				isProtocol = true;
 
 #if MMP || MTOUCH
-				if (pAttr.InformalSwitchVersion != null && pAttr.InformalSwitchVersion > App.SdkVersion)
+				if (pAttr.InformalUntilVersion != null && pAttr.InformalUntilVersion > App.SdkVersion)
 					isInformalProtocol = !isInformalProtocol;
 #endif
 			}

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -1487,7 +1487,7 @@ namespace XamCore.Registrar {
 				isProtocol = true;
 
 #if MMP || MTOUCH
-				if (pAttr.InformalUntilVersion != null && pAttr.InformalUntilVersion > App.SdkVersion)
+				if (pAttr.FormalSinceVersion != null && pAttr.FormalSinceVersion > App.SdkVersion)
 					isInformalProtocol = !isInformalProtocol;
 #endif
 			}

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -858,7 +858,15 @@ namespace XamCore.CoreAnimation {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Protocol (IsInformal = true)] // not informal as of iOS 10+, but removing the IsInformal value breaks when building with older SDKs (see bug #43585).
+#if IOS || TVOS
+	[Protocol (InformalSwitch = new int [] { 10, 0 })]
+#elif MONOMAC
+	[Protocol (InformalSwitch = new int [] { 10, 12 })]
+#elif WATCH
+	[Protocol (InformalSwitch = new int [] { 3, 0 })]
+#else
+	[Protocol]
+#endif
 	interface CALayerDelegate {
 		[Export ("displayLayer:")]
 		void DisplayLayer (CALayer layer);

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -859,11 +859,11 @@ namespace XamCore.CoreAnimation {
 	[BaseType (typeof (NSObject))]
 	[Model]
 #if IOS || TVOS
-	[Protocol (InformalSwitch = new int [] { 10, 0 })]
+	[Protocol (InformalUntil = "10.0")]
 #elif MONOMAC
-	[Protocol (InformalSwitch = new int [] { 10, 12 })]
+	[Protocol (InformalUntil = "10.12")]
 #elif WATCH
-	[Protocol (InformalSwitch = new int [] { 3, 0 })]
+	[Protocol (InformalUntil = "3.0"]
 #else
 	[Protocol]
 #endif

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -859,11 +859,11 @@ namespace XamCore.CoreAnimation {
 	[BaseType (typeof (NSObject))]
 	[Model]
 #if IOS || TVOS
-	[Protocol (InformalUntil = "10.0")]
+	[Protocol (FormalSince = "10.0")]
 #elif MONOMAC
-	[Protocol (InformalUntil = "10.12")]
+	[Protocol (FormalSince = "10.12")]
 #elif WATCH
-	[Protocol (InformalUntil = "3.0"]
+	[Protocol (FormalSince = "3.0"]
 #else
 	[Protocol]
 #endif

--- a/src/generator-attribute-manager.cs
+++ b/src/generator-attribute-manager.cs
@@ -141,6 +141,12 @@ public static class AttributeManager
 				for (int a = 0; a < arr.Length; a++)
 					arr [a] = (Type) typed_values [a].Value;
 				value = arr;
+			} else if (arg.TypedValue.ArgumentType.FullName == "System.Int32[]") {
+				var typed_values = (CustomAttributeTypedArgument []) arg.TypedValue.Value;
+				var arr = new int [typed_values.Length];
+				for (int a = 0; a < arr.Length; a++)
+					arr [a] = (int) typed_values [a].Value;
+				value = arr;
 			} else if (arg.TypedValue.ArgumentType.IsArray) {
 				throw ErrorHelper.CreateError (1059, "Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://bugzilla.xamarin.com) with a test case.", attribType.FullName, i + 1, arg.MemberName);
 			}

--- a/src/generator-attribute-manager.cs
+++ b/src/generator-attribute-manager.cs
@@ -141,12 +141,6 @@ public static class AttributeManager
 				for (int a = 0; a < arr.Length; a++)
 					arr [a] = (Type) typed_values [a].Value;
 				value = arr;
-			} else if (arg.TypedValue.ArgumentType.FullName == "System.Int32[]") {
-				var typed_values = (CustomAttributeTypedArgument []) arg.TypedValue.Value;
-				var arr = new int [typed_values.Length];
-				for (int a = 0; a < arr.Length; a++)
-					arr [a] = (int) typed_values [a].Value;
-				value = arr;
 			} else if (arg.TypedValue.ArgumentType.IsArray) {
 				throw ErrorHelper.CreateError (1059, "Internal error: failed to instantiate mock attribute '{0}' (unknown type for the named argument #{1} ({2}). Please file a bug report (https://bugzilla.xamarin.com) with a test case.", attribType.FullName, i + 1, arg.MemberName);
 			}

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -5135,7 +5135,11 @@ public partial class Generator : IMemberGatherer {
 		var requiredInstanceAsyncMethods = requiredInstanceMethods.Where (m => AttributeManager.HasAttribute<AsyncAttribute> (m)).ToList ();
 
 		PrintAttributes (type, platform:true, preserve:true, advice:true);
-		print ("[Protocol (Name = \"{1}\", WrapperType = typeof ({0}Wrapper){2})]", TypeName, protocol_name, protocolAttribute.IsInformal ? ", IsInformal = true" : string.Empty);
+		print ("[Protocol (Name = \"{1}\", WrapperType = typeof ({0}Wrapper){2}{3})]", 
+		       TypeName, 
+		       protocol_name, 
+		       protocolAttribute.IsInformal ? ", IsInformal = true" : string.Empty, 
+		       protocolAttribute.InformalSwitch != null ? (", InformalSwitch = new int [] { " + string.Join (", ", protocolAttribute.InformalSwitch.Select ((v) => v.ToString ())) + " }") : string.Empty);
 
 		var sb = new StringBuilder ();
 

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -5139,7 +5139,7 @@ public partial class Generator : IMemberGatherer {
 		       TypeName, 
 		       protocol_name, 
 		       protocolAttribute.IsInformal ? ", IsInformal = true" : string.Empty, 
-		       protocolAttribute.InformalUntil != null ? $", InformalUntil = \"{protocolAttribute.InformalUntil}\"" : string.Empty);
+		       protocolAttribute.FormalSince != null ? $", FormalSince = \"{protocolAttribute.FormalSince}\"" : string.Empty);
 
 		var sb = new StringBuilder ();
 

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -5139,7 +5139,7 @@ public partial class Generator : IMemberGatherer {
 		       TypeName, 
 		       protocol_name, 
 		       protocolAttribute.IsInformal ? ", IsInformal = true" : string.Empty, 
-		       protocolAttribute.InformalSwitch != null ? (", InformalSwitch = new int [] { " + string.Join (", ", protocolAttribute.InformalSwitch.Select ((v) => v.ToString ())) + " }") : string.Empty);
+		       protocolAttribute.InformalUntil != null ? $", InformalUntil = \"{protocolAttribute.InformalUntil}\"" : string.Empty);
 
 		var sb = new StringBuilder ();
 

--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -1817,7 +1817,7 @@ namespace XamCore.WebKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Protocol (IsInformal = true)]
+	[Protocol (InformalSwitch = new int [] { 10, 11 })]
 	partial interface WebDownloadDelegate {
 		[Export ("downloadWindowForAuthenticationSheet:"), DelegateName ("WebDownloadRequest"), DefaultValue (null)]
 		NSWindow OnDownloadWindowForSheet (WebDownload download);
@@ -1897,7 +1897,7 @@ namespace XamCore.WebKit {
 	}
 
 	[Model]
-	[Protocol (IsInformal = true)]
+	[Protocol (InformalSwitch = new int [] { 10, 11 })]
 	[BaseType (typeof (NSObject))]
 	partial interface WebFrameLoadDelegate {
 		[Export ("webView:didStartProvisionalLoadForFrame:"), EventArgs ("WebFrame")]
@@ -2060,7 +2060,7 @@ namespace XamCore.WebKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Protocol (IsInformal = true)]
+	[Protocol (InformalSwitch = new int [] { 10, 11 })]
 	partial interface WebPolicyDelegate  {
 		[Export ("webView:decidePolicyForNavigationAction:request:frame:decisionListener:"), EventArgs ("WebNavigationPolicy")]
 		void DecidePolicyForNavigation (WebView webView, NSDictionary actionInformation, NSUrlRequest request, WebFrame frame, NSObject decisionToken);
@@ -2204,7 +2204,7 @@ namespace XamCore.WebKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Protocol (IsInformal = true)]
+	[Protocol (InformalSwitch = new int [] { 10, 11 })]
 	partial interface WebResourceLoadDelegate {
 		[Export ("webView:identifierForInitialRequest:fromDataSource:"), DelegateName ("WebResourceIdentifierRequest"), DefaultValue (null)]
 		NSObject OnIdentifierForInitialRequest (WebView sender, NSUrlRequest request, WebDataSource dataSource);
@@ -2236,7 +2236,7 @@ namespace XamCore.WebKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Protocol (IsInformal = true)]
+	[Protocol (InformalSwitch = new int [] { 10, 11 })]
 	partial interface WebUIDelegate {
 		[Export ("webView:createWebViewWithRequest:"), DelegateName("CreateWebViewFromRequest"), DefaultValue (null)]
 		WebView UICreateWebView (WebView sender, NSUrlRequest request);

--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -1817,7 +1817,7 @@ namespace XamCore.WebKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Protocol (InformalUntil = "10.11")]
+	[Protocol (FormalSince = "10.11")]
 	partial interface WebDownloadDelegate {
 		[Export ("downloadWindowForAuthenticationSheet:"), DelegateName ("WebDownloadRequest"), DefaultValue (null)]
 		NSWindow OnDownloadWindowForSheet (WebDownload download);
@@ -1897,7 +1897,7 @@ namespace XamCore.WebKit {
 	}
 
 	[Model]
-	[Protocol (InformalUntil = "10.11")]
+	[Protocol (FormalSince = "10.11")]
 	[BaseType (typeof (NSObject))]
 	partial interface WebFrameLoadDelegate {
 		[Export ("webView:didStartProvisionalLoadForFrame:"), EventArgs ("WebFrame")]
@@ -2060,7 +2060,7 @@ namespace XamCore.WebKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Protocol (InformalUntil = "10.11")]
+	[Protocol (FormalSince = "10.11")]
 	partial interface WebPolicyDelegate  {
 		[Export ("webView:decidePolicyForNavigationAction:request:frame:decisionListener:"), EventArgs ("WebNavigationPolicy")]
 		void DecidePolicyForNavigation (WebView webView, NSDictionary actionInformation, NSUrlRequest request, WebFrame frame, NSObject decisionToken);
@@ -2204,7 +2204,7 @@ namespace XamCore.WebKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Protocol (InformalUntil = "10.11")]
+	[Protocol (FormalSince = "10.11")]
 	partial interface WebResourceLoadDelegate {
 		[Export ("webView:identifierForInitialRequest:fromDataSource:"), DelegateName ("WebResourceIdentifierRequest"), DefaultValue (null)]
 		NSObject OnIdentifierForInitialRequest (WebView sender, NSUrlRequest request, WebDataSource dataSource);
@@ -2236,7 +2236,7 @@ namespace XamCore.WebKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Protocol (InformalUntil = "10.11")]
+	[Protocol (FormalSince = "10.11")]
 	partial interface WebUIDelegate {
 		[Export ("webView:createWebViewWithRequest:"), DelegateName("CreateWebViewFromRequest"), DefaultValue (null)]
 		WebView UICreateWebView (WebView sender, NSUrlRequest request);

--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -1817,7 +1817,7 @@ namespace XamCore.WebKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Protocol (InformalSwitch = new int [] { 10, 11 })]
+	[Protocol (InformalUntil = "10.11")]
 	partial interface WebDownloadDelegate {
 		[Export ("downloadWindowForAuthenticationSheet:"), DelegateName ("WebDownloadRequest"), DefaultValue (null)]
 		NSWindow OnDownloadWindowForSheet (WebDownload download);
@@ -1897,7 +1897,7 @@ namespace XamCore.WebKit {
 	}
 
 	[Model]
-	[Protocol (InformalSwitch = new int [] { 10, 11 })]
+	[Protocol (InformalUntil = "10.11")]
 	[BaseType (typeof (NSObject))]
 	partial interface WebFrameLoadDelegate {
 		[Export ("webView:didStartProvisionalLoadForFrame:"), EventArgs ("WebFrame")]
@@ -2060,7 +2060,7 @@ namespace XamCore.WebKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Protocol (InformalSwitch = new int [] { 10, 11 })]
+	[Protocol (InformalUntil = "10.11")]
 	partial interface WebPolicyDelegate  {
 		[Export ("webView:decidePolicyForNavigationAction:request:frame:decisionListener:"), EventArgs ("WebNavigationPolicy")]
 		void DecidePolicyForNavigation (WebView webView, NSDictionary actionInformation, NSUrlRequest request, WebFrame frame, NSObject decisionToken);
@@ -2204,7 +2204,7 @@ namespace XamCore.WebKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Protocol (InformalSwitch = new int [] { 10, 11 })]
+	[Protocol (InformalUntil = "10.11")]
 	partial interface WebResourceLoadDelegate {
 		[Export ("webView:identifierForInitialRequest:fromDataSource:"), DelegateName ("WebResourceIdentifierRequest"), DefaultValue (null)]
 		NSObject OnIdentifierForInitialRequest (WebView sender, NSUrlRequest request, WebDataSource dataSource);
@@ -2236,7 +2236,7 @@ namespace XamCore.WebKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Protocol (InformalSwitch = new int [] { 10, 11 })]
+	[Protocol (InformalUntil = "10.11")]
 	partial interface WebUIDelegate {
 		[Export ("webView:createWebViewWithRequest:"), DelegateName("CreateWebViewFromRequest"), DefaultValue (null)]
 		WebView UICreateWebView (WebView sender, NSUrlRequest request);

--- a/tests/common/ExecutionHelper.cs
+++ b/tests/common/ExecutionHelper.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Tests
 		public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds (60);
 
 		public IEnumerable<ToolMessage> Messages { get { return messages; } }
-		List<string> OutputLines {
+		public List<string> OutputLines {
 			get {
 				if (output_lines == null) {
 					output_lines = new List<string> ();

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -208,9 +208,8 @@ namespace Xamarin.MMP.Tests
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir);
 
 				// Due to https://bugzilla.xamarin.com/show_bug.cgi?id=48311 we can get warnings related to the registrar
-				// So ignore anything with registrar.m or registrar.h or gl3.h in the line
 				Func<string, bool> hasLegitWarning = results =>
-					results.Split (Environment.NewLine.ToCharArray ()).Any (x => x.Contains ("warning") && !x.Contains ("registrar.m") && !x.Contains ("registrar.h") && !x.Contains ("gl3.h"));
+					results.Split (Environment.NewLine.ToCharArray ()).Any (x => x.Contains ("warning") && !x.Contains ("deviceBrowserView:selectionDidChange:"));
 
 				// Mobile
 				string buildResults = TI.TestUnifiedExecutable (test).BuildOutput;

--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -712,6 +712,22 @@ class X : ReplayKit.RPBroadcastControllerDelegate
 		}
 
 		[Test]
+		public void NoWarnings ()
+		{
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryApp ();
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.Linker = MTouchLinker.DontLink; // so that as much as possible is registered
+				mtouch.Verbosity = 9; // Increase verbosity, otherwise linker warnings aren't shown
+				mtouch.AssertExecute (MTouchAction.BuildSim, "build");
+				mtouch.AssertNoWarnings ();
+				foreach (var line in mtouch.OutputLines)
+					Assert.That (line, Does.Not.Match ("warning:"), "no warnings");
+			}
+		}
+
+		[Test]
 		public void MultiplePropertiesInHierarchy ()
 		{
 			// https://bugzilla.xamarin.com/show_bug.cgi?id=18337

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -1206,25 +1206,11 @@ namespace XamCore.Registrar {
 				case "IsInformal":
 					rv.IsInformal = (bool) prop.Argument.Value;
 					break;
-				case "InformalSwitch":
-					var attrArray = (CustomAttributeArgument []) prop.Argument.Value;
-					var arr = new int [attrArray.Length];
-					for (int i = 0; i < attrArray.Length; i++)
-						arr [i] = (int) attrArray [i].Value;
-
-					switch (arr.Length) {
-					case 2:
-						rv.InformalSwitchVersion = new Version (arr [0], arr [1]);
-						break;
-					case 3:
-						rv.InformalSwitchVersion = new Version (arr [0], arr [1], arr [2]);
-						break;
-					case 4:
-						rv.InformalSwitchVersion = new Version (arr [0], arr [1], arr [2], arr [3]);
-						break;
-					default:
+				case "InformalUntil":
+					Version version;
+					if (!Version.TryParse ((string)prop.Argument.Value, out version))
 						throw ErrorHelper.CreateError (4147, "Invalid {0} found on '{1}'. Please file a bug report at http://bugzilla.xamarin.com", "ProtocolAttribute", type.FullName);
-					}
+					rv.InformalUntilVersion = version;
 					break;
 				default:
 					throw ErrorHelper.CreateError (4147, "Invalid {0} found on '{1}'. Please file a bug report at http://bugzilla.xamarin.com", "ProtocolAttribute", type.FullName);
@@ -3857,7 +3843,7 @@ namespace XamCore.Registrar {
 		public TypeDefinition WrapperType { get; set; }
 		public string Name { get; set; }
 		public bool IsInformal { get; set; }
-		public Version InformalSwitchVersion { get; set; }
+		public Version InformalUntilVersion { get; set; }
 	}
 
 	public sealed class ProtocolMemberAttribute : Attribute {

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -1206,6 +1206,26 @@ namespace XamCore.Registrar {
 				case "IsInformal":
 					rv.IsInformal = (bool) prop.Argument.Value;
 					break;
+				case "InformalSwitch":
+					var attrArray = (CustomAttributeArgument []) prop.Argument.Value;
+					var arr = new int [attrArray.Length];
+					for (int i = 0; i < attrArray.Length; i++)
+						arr [i] = (int) attrArray [i].Value;
+
+					switch (arr.Length) {
+					case 2:
+						rv.InformalSwitchVersion = new Version (arr [0], arr [1]);
+						break;
+					case 3:
+						rv.InformalSwitchVersion = new Version (arr [0], arr [1], arr [2]);
+						break;
+					case 4:
+						rv.InformalSwitchVersion = new Version (arr [0], arr [1], arr [2], arr [3]);
+						break;
+					default:
+						throw ErrorHelper.CreateError (4147, "Invalid {0} found on '{1}'. Please file a bug report at http://bugzilla.xamarin.com", "ProtocolAttribute", type.FullName);
+					}
+					break;
 				default:
 					throw ErrorHelper.CreateError (4147, "Invalid {0} found on '{1}'. Please file a bug report at http://bugzilla.xamarin.com", "ProtocolAttribute", type.FullName);
 				}
@@ -3837,6 +3857,7 @@ namespace XamCore.Registrar {
 		public TypeDefinition WrapperType { get; set; }
 		public string Name { get; set; }
 		public bool IsInformal { get; set; }
+		public Version InformalSwitchVersion { get; set; }
 	}
 
 	public sealed class ProtocolMemberAttribute : Attribute {

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -1206,11 +1206,11 @@ namespace XamCore.Registrar {
 				case "IsInformal":
 					rv.IsInformal = (bool) prop.Argument.Value;
 					break;
-				case "InformalUntil":
+				case "FormalSince":
 					Version version;
 					if (!Version.TryParse ((string)prop.Argument.Value, out version))
 						throw ErrorHelper.CreateError (4147, "Invalid {0} found on '{1}'. Please file a bug report at http://bugzilla.xamarin.com", "ProtocolAttribute", type.FullName);
-					rv.InformalUntilVersion = version;
+					rv.FormalSinceVersion = version;
 					break;
 				default:
 					throw ErrorHelper.CreateError (4147, "Invalid {0} found on '{1}'. Please file a bug report at http://bugzilla.xamarin.com", "ProtocolAttribute", type.FullName);
@@ -3843,7 +3843,7 @@ namespace XamCore.Registrar {
 		public TypeDefinition WrapperType { get; set; }
 		public string Name { get; set; }
 		public bool IsInformal { get; set; }
-		public Version InformalUntilVersion { get; set; }
+		public Version FormalSinceVersion { get; set; }
 	}
 
 	public sealed class ProtocolMemberAttribute : Attribute {


### PR DESCRIPTION
Add support for specifying that an informal protocol became a formal protocol
(or the reverse) in a certain SDK version, so that the static registrar can
generate the correct code based on the SDK being built with.

This also fixes a series of compiler warnings when using the static registrar:

    In file included from Xamarin.Mac.registrar.full.i386.m:1:
    ./Xamarin.Mac.registrar.full.i386.h:374:11: warning: duplicate protocol definition of 'CALayerDelegate' is ignored
    @protocol CALayerDelegate
              ^
    /Applications/Xcode83.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/QuartzCore.framework/Headers/CALayer.h:798:11: note: previous definition is here
    @protocol CALayerDelegate <NSObject>
              ^
    In file included from Xamarin.Mac.registrar.full.i386.m:1:
    ./Xamarin.Mac.registrar.full.i386.h:824:11: warning: duplicate protocol definition of 'WebDownloadDelegate' is ignored
    @protocol WebDownloadDelegate
              ^
    /Applications/Xcode83.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/WebKit.framework/Headers/WebDownload.h:60:11: note: previous definition is here
    @protocol WebDownloadDelegate <NSURLDownloadDelegate>
              ^
    In file included from Xamarin.Mac.registrar.full.i386.m:1:
    ./Xamarin.Mac.registrar.full.i386.h:851:11: warning: duplicate protocol definition of 'WebFrameLoadDelegate' is ignored
    @protocol WebFrameLoadDelegate
              ^
    /Applications/Xcode83.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/WebKit.framework/Headers/WebFrameLoadDelegate.h:51:11: note: previous definition is here
    @protocol WebFrameLoadDelegate <NSObject>
              ^
    In file included from Xamarin.Mac.registrar.full.i386.m:1:
    ./Xamarin.Mac.registrar.full.i386.h:866:11: warning: duplicate protocol definition of 'WebPolicyDelegate' is ignored
    @protocol WebPolicyDelegate
              ^
    /Applications/Xcode83.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/WebKit.framework/Headers/WebPolicyDelegate.h:138:11: note: previous definition is here
    @protocol WebPolicyDelegate <NSObject>
              ^
    In file included from Xamarin.Mac.registrar.full.i386.m:1:
    ./Xamarin.Mac.registrar.full.i386.h:869:11: warning: duplicate protocol definition of 'WebResourceLoadDelegate' is ignored
    @protocol WebResourceLoadDelegate
              ^
    /Applications/Xcode83.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/WebKit.framework/Headers/WebResourceLoadDelegate.h:46:11: note: previous definition is here
    @protocol WebResourceLoadDelegate <NSObject>
              ^
    In file included from Xamarin.Mac.registrar.full.i386.m:1:
    ./Xamarin.Mac.registrar.full.i386.h:872:11: warning: duplicate protocol definition of 'WebUIDelegate' is ignored
    @protocol WebUIDelegate
              ^
    /Applications/Xcode83.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/WebKit.framework/Headers/WebUIDelegate.h:153:11: note: previous definition is here
    @protocol WebUIDelegate <NSObject>
              ^

https://bugzilla.xamarin.com/show_bug.cgi?id=43780
https://bugzilla.xamarin.com/show_bug.cgi?id=48311