### PR TITLE
[generator] Keep [NotImplemented] info so it is usable in 3rd party bindings. Fixes bug 52664

### DIFF
--- a/src/Foundation/NotImplementedAttribute.cs
+++ b/src/Foundation/NotImplementedAttribute.cs
@@ -1,0 +1,26 @@
+//
+// NotImplementedAttribute.cs
+//
+// Authors:
+//   Alex Soto (alexsoto@microsoft.com)
+//
+// Copyright 2017 Xamarin Inc.
+//
+
+using System;
+
+namespace XamCore.Foundation {
+	//
+	// This is designed to be applied to setter methods in
+	// a base class `Foo' when a `MutableFoo' exists.
+	//
+	// This allows the Foo.set_XXX to exists but throw an exception
+	// but derived classes would then override the property
+	//
+	[AttributeUsage (AttributeTargets.Method, AllowMultiple = false)]
+	public class NotImplementedAttribute : Attribute {
+		public NotImplementedAttribute () { }
+		public NotImplementedAttribute (string message) { Message = message; }
+		public string Message { get; set; }
+	}
+}

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -34,6 +34,7 @@ GENERATOR_ATTRIBUTE_SOURCES = \
 	$(TOP)/src/Foundation/ExportAttribute.cs \
 	$(TOP)/src/Foundation/FieldAttribute.cs \
 	$(TOP)/src/Foundation/ModelAttribute.cs \
+	$(TOP)/src/Foundation/NotImplementedAttribute.cs \
 	$(TOP)/src/Foundation/PreserveAttribute.cs \
 	$(TOP)/src/Foundation/ProtocolAttribute.cs \
 	$(TOP)/src/Foundation/RegisterAttribute.cs \

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -611,6 +611,7 @@ FOUNDATION_CORE_SOURCES = \
 	Foundation/LinkerSafeAttribute.cs \
 	Foundation/ModelAttribute.cs \
 	Foundation/ModelNotImplementedException.cs \
+	Foundation/NotImplementedAttribute.cs \
 	Foundation/NSAction.cs \
 	Foundation/NSAutoreleasePool.cs \
 	Foundation/NSDecimal.cs \

--- a/src/generator-attributes.cs
+++ b/src/generator-attributes.cs
@@ -697,20 +697,6 @@ public class AppearanceAttribute : Attribute {
 }
 
 //
-// This is designed to be applied to setter methods in
-// a base class `Foo' when a `MutableFoo' exists.
-//
-// This allows the Foo.set_XXX to exists but throw an exception 
-// but derived classes would then override the property
-//
-[AttributeUsage (AttributeTargets.Method, AllowMultiple=false)]
-public class NotImplementedAttribute : Attribute {
-	public NotImplementedAttribute () {}
-	public NotImplementedAttribute (string message) {Message=message;}
-	public string Message { get; set; }
-}
-
-//
 // Apply this attribute to a class to add methods that in Objective-c
 // are added as categories
 //

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -2028,7 +2028,7 @@ public partial class Generator : IMemberGatherer {
 		var ea = AttributeManager.GetCustomAttribute<ExportAttribute> (pinfo.GetSetMethod ());
 		if (ea != null && ea.Selector != null)
 			return ea;
-		return AttributeManager.GetCustomAttribute<ExportAttribute> (pinfo).ToSetter (pinfo);
+		return AttributeManager.GetCustomAttribute<ExportAttribute> (pinfo)?.ToSetter (pinfo);
 	}
 
 	public static ExportAttribute GetGetterExportAttribute (PropertyInfo pinfo)
@@ -2209,8 +2209,9 @@ public partial class Generator : IMemberGatherer {
 				if (pi.CanWrite){
 					MethodInfo setter = pi.GetSetMethod ();
 					BindAttribute ba = GetBindAttribute (setter);
+					var notImpl = AttributeManager.HasAttribute<NotImplementedAttribute> (setter);
 					
-					if (!is_abstract)
+					if (!is_abstract && !notImpl)
 						tselectors.Add (ba != null ? ba.Selector : GetSetterExportAttribute (pi).Selector);
 					DeclareInvoker (setter);
 				}
@@ -4505,7 +4506,7 @@ public partial class Generator : IMemberGatherer {
 				PrintExport (minfo, sel, export.ArgumentSemantic);
 			}
 
-			PrintAttributes (pi.GetGetMethod(), platform:true, preserve:true, advice:true);
+			PrintAttributes (pi.GetGetMethod(), platform:true, preserve:true, advice:true, notImplemented:true);
 			if (minfo.is_abstract){
 				print ("get; ");
 			} else {
@@ -4545,7 +4546,7 @@ public partial class Generator : IMemberGatherer {
 			string sel;
 
 			if (ba == null) {
-				sel = GetSetterExportAttribute (pi).Selector;
+				sel = GetSetterExportAttribute (pi)?.Selector;
 			} else {
 				sel = ba.Selector;
 			}
@@ -4555,7 +4556,7 @@ public partial class Generator : IMemberGatherer {
 			if (not_implemented_attr == null && (!minfo.is_sealed || !minfo.is_wrapper))
 				PrintExport (minfo, sel, export.ArgumentSemantic);
 
-			PrintAttributes (pi.GetSetMethod (), platform:true, preserve:true, advice:true);
+			PrintAttributes (pi.GetSetMethod (), platform:true, preserve:true, advice:true, notImplemented:true);
 			if (minfo.is_abstract){
 				print ("set; ");
 			} else {
@@ -5095,10 +5096,16 @@ public partial class Generator : IMemberGatherer {
 				continue;
 			
 			if (!hasExportAttribute) {
-				if (p.CanRead && !AttributeManager.HasAttribute<ExportAttribute> (p.GetGetMethod ()))
-					continue;
-				if (p.CanWrite && !AttributeManager.HasAttribute<ExportAttribute> (p.GetSetMethod ()))
-					continue;
+				var getter = p.GetGetMethod ();
+				if (p.CanRead && !AttributeManager.HasAttribute<ExportAttribute> (getter)) {
+					if (!AttributeManager.HasAttribute<NotImplementedAttribute> (getter))
+						continue;
+				}
+				var setter = p.GetSetMethod ();
+				if (p.CanWrite && !AttributeManager.HasAttribute<ExportAttribute> (setter)) {
+					if (!AttributeManager.HasAttribute<NotImplementedAttribute> (setter))
+						continue;
+				}
 			}
 
 			if (@static.HasValue && @static.Value != hasStaticAttribute)
@@ -5275,20 +5282,24 @@ public partial class Generator : IMemberGatherer {
 			indent++;
 			if (pi.CanRead) {
 				var ea = GetGetterExportAttribute (pi);
+				var getMethod = pi.GetGetMethod ();
 				// there can be a [Bind] there that override the selector name to be used
 				// e.g. IMTLTexture.FramebufferOnly
-				var ba = GetBindAttribute (pi.GetGetMethod ());
-				PrintDelegateProxy (pi.GetGetMethod ());
-				if (!AttributeManager.HasAttribute<NotImplementedAttribute> (pi.GetGetMethod ())) {
+				var ba = GetBindAttribute (getMethod);
+				PrintDelegateProxy (getMethod);
+				if (!AttributeManager.HasAttribute<NotImplementedAttribute> (getMethod)) {
 					if (ba != null)
 						PrintExport (minfo, ba.Selector, ea.ArgumentSemantic);
 					else
 						PrintExport (minfo, ea);
 				}
+				PrintAttributes (getMethod, notImplemented: true);
 				print ("get;");
 			}
 			if (pi.CanWrite) {
-				if (!AttributeManager.HasAttribute<NotImplementedAttribute> (pi.GetSetMethod ()))
+				var setMethod = pi.GetSetMethod ();
+				PrintAttributes (setMethod, notImplemented:true);
+				if (!AttributeManager.HasAttribute<NotImplementedAttribute> (setMethod))
 					PrintExport (minfo, GetSetterExportAttribute (pi));
 				print ("set;");
 			}
@@ -5455,7 +5466,19 @@ public partial class Generator : IMemberGatherer {
 		print ($"[Advice (@\"{p.Message.Replace ("\"", "\"\"")}\")]");
 	}
 
-	public void PrintAttributes (MemberInfo mi, bool platform = false, bool preserve = false, bool advice = false)
+	public void PrintNotImplementedAttribute (ICustomAttributeProvider mi)
+	{
+		var p = AttributeManager.GetCustomAttribute<NotImplementedAttribute> (mi);
+		if (p == null)
+			return;
+
+		if (p.Message != null)
+			print ($"[NotImplemented (@\"{p.Message.Replace ("\"", "\"\"")}\")]");
+		else
+			print ($"[NotImplemented]");
+	}
+
+	public void PrintAttributes (MemberInfo mi, bool platform = false, bool preserve = false, bool advice = false, bool notImplemented = false)
 	{
 		if (platform)
 			PrintPlatformAttributes (mi);
@@ -5463,6 +5486,8 @@ public partial class Generator : IMemberGatherer {
 			PrintPreserveAttribute (mi);
 		if (advice)
 			PrintAdviceAttribute (mi);
+		if (notImplemented)
+			PrintNotImplementedAttribute (mi);
 	}
 
 	public static string GetSelector (MemberInfo mi)

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -7106,7 +7106,9 @@ public partial class Generator : IMemberGatherer {
 
 	public static string Quote (string s)
 	{
-		if (String.IsNullOrEmpty (s))
+		if (s == null)
+			return String.Empty;
+		if (s == string.Empty)
 			return @"""""";
 
 		return $"@\"{s.Replace ("\"", "\"\"")}\"";

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -7107,7 +7107,7 @@ public partial class Generator : IMemberGatherer {
 	public static string Quote (string s)
 	{
 		if (String.IsNullOrEmpty (s))
-			return s ?? String.Empty;
+			return @"""""";
 
 		return $"@\"{s.Replace ("\"", "\"\"")}\"";
 	}

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -5463,7 +5463,7 @@ public partial class Generator : IMemberGatherer {
 		if (p == null)
 			return;
 
-		print ($"[Advice (@\"{p.Message.Replace ("\"", "\"\"")}\")]");
+		print ($"[Advice ({Quote (p.Message)})]");
 	}
 
 	public void PrintNotImplementedAttribute (ICustomAttributeProvider mi)
@@ -5472,10 +5472,7 @@ public partial class Generator : IMemberGatherer {
 		if (p == null)
 			return;
 
-		if (p.Message != null)
-			print ($"[NotImplemented (@\"{p.Message.Replace ("\"", "\"\"")}\")]");
-		else
-			print ($"[NotImplemented]");
+		print ($"[NotImplemented ({Quote (p.Message)})]");
 	}
 
 	public void PrintAttributes (MemberInfo mi, bool platform = false, bool preserve = false, bool advice = false, bool notImplemented = false)
@@ -7106,5 +7103,12 @@ public partial class Generator : IMemberGatherer {
 			return t.FullName;
 		
 	}
-	
+
+	public static string Quote (string s)
+	{
+		if (String.IsNullOrEmpty (s))
+			return s ?? String.Empty;
+
+		return $"@\"{s.Replace ("\"", "\"\"")}\"";
+	}
 }

--- a/tests/generator/sof20696157.cs
+++ b/tests/generator/sof20696157.cs
@@ -179,7 +179,7 @@ namespace Test {
 	[Protocol] interface C86 : IMTLSamplerState {}
 	[Protocol] interface C87 : IINSearchCallHistoryIntentHandling {}
 	[Protocol] interface C88 : IAVPictureInPictureControllerDelegate {}
-	// [Protocol] interface C89 : INSTextLayoutOrientationProvider {}
+	[Protocol] interface C89 : INSTextLayoutOrientationProvider {}
 	[Protocol] interface C90 : IGKStrategist {}
 	[Protocol] interface C91 : INSDiscardableContent {}
 	[Protocol] interface C92 : IAVPlayerViewControllerDelegate {}
@@ -358,7 +358,7 @@ namespace Test {
 	[Protocol] interface C265 : INSFetchedResultsControllerDelegate {}
 	[Protocol] interface C266 : IUIViewControllerInteractiveTransitioning {}
 	[Protocol] interface C267 : INSFetchedResultsSectionInfo {}
-	// [Protocol] interface C268 : IUIViewControllerPreviewing {}
+	[Protocol] interface C268 : IUIViewControllerPreviewing {}
 	[Protocol] interface C269 : IHMHomeManagerDelegate {}
 	[Protocol] interface C270 : IUIViewControllerPreviewingDelegate {}
 	[Protocol] interface C271 : IUIViewControllerRestoration {}
@@ -541,7 +541,7 @@ namespace Test {
 	[Protocol] [BaseType (typeof (NSObject))] interface M86 : IMTLSamplerState {}
 	[Protocol] [BaseType (typeof (NSObject))] interface M87 : IINSearchCallHistoryIntentHandling {}
 	[Protocol] [BaseType (typeof (NSObject))] interface M88 : IAVPictureInPictureControllerDelegate {}
-	// [Protocol] [BaseType (typeof (NSObject))] interface M89 : INSTextLayoutOrientationProvider {}
+	[Protocol] [BaseType (typeof (NSObject))] interface M89 : INSTextLayoutOrientationProvider {}
 	[Protocol] [BaseType (typeof (NSObject))] interface M90 : IGKStrategist {}
 	[Protocol] [BaseType (typeof (NSObject))] interface M91 : INSDiscardableContent {}
 	[Protocol] [BaseType (typeof (NSObject))] interface M92 : IAVPlayerViewControllerDelegate {}
@@ -720,7 +720,7 @@ namespace Test {
 	[Protocol] [BaseType (typeof (NSObject))] interface M265 : INSFetchedResultsControllerDelegate {}
 	[Protocol] [BaseType (typeof (NSObject))] interface M266 : IUIViewControllerInteractiveTransitioning {}
 	[Protocol] [BaseType (typeof (NSObject))] interface M267 : INSFetchedResultsSectionInfo {}
-	// [Protocol] [BaseType (typeof (NSObject))] interface M268 : IUIViewControllerPreviewing {}
+	[Protocol] [BaseType (typeof (NSObject))] interface M268 : IUIViewControllerPreviewing {}
 	[Protocol] [BaseType (typeof (NSObject))] interface M269 : IHMHomeManagerDelegate {}
 	[Protocol] [BaseType (typeof (NSObject))] interface M270 : IUIViewControllerPreviewingDelegate {}
 	[Protocol] [BaseType (typeof (NSObject))] interface M271 : IUIViewControllerRestoration {}

--- a/tools/linker/CoreRemoveAttributes.cs
+++ b/tools/linker/CoreRemoveAttributes.cs
@@ -27,6 +27,7 @@ namespace Xamarin.Linker {
 			case "LionAttribute":
 			case "MountainLionAttribute":
 			case "MavericksAttribute":
+			case "NotImplementedAttribute":
 			case "ObsoletedAttribute":
 			case "SinceAttribute":
 			case "ThreadSafeAttribute":


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=52664

Currently, we do not keep the [[NotImplemented]](https://developer.xamarin.com/guides/cross-platform/macios/binding/objective-c-libraries/#Objective-C_Mutable_Pattern_and_Properties) information and the
generator gets a little confused because it will not find an Export
inside the getters/setters of properties and there is no way to tell
if this was intentional or not. We now keep the [NotImplemented]
and also add some null checks in the generator where needed.

Also makes sense to keep the `[NotImplemented]` because it has a [Message property that actually tells you why it is not available](https://github.com/xamarin/xamarin-macios/blob/abaced76e3e3cf885a306ae38630c6c28baa6ef6/src/storekit.cs#L90-L91) and we really just ignored it after the generation step.

Reenabled tests disabled in https://github.com/xamarin/xamarin-macios/pull/1745/commits/9f036b218a7246822000488695f0edd0e43c4778

Build diff: https://gist.github.com/dalexsoto/f69fe989e290694a6f863ab97e82798b