### PR TITLE
[OpenTK] Rework makefiles to avoid zero-length pdbs.

### DIFF
--- a/src/OpenGLES/Makefile-1.0.include
+++ b/src/OpenGLES/Makefile-1.0.include
@@ -28,33 +28,26 @@ IOS_OPENTK_1_0_CORE_SOURCES = \
 
 OPENTK_1_0_SOURCES:=$(shell grep "Compile Include" OpenTK.csproj | sed 's/.*Include="//' | sed 's/".*//' | sed 's_\\_/_g' )
 
-OPENTK_1_0_DEPENDENCIES = Makefile OpenGLES/Makefile-1.0.include $(OPENTK_1_0_SOURCES) OpenTK.csproj
+OPENTK_1_0_DEPENDENCIES = Makefile OpenGLES/Makefile-1.0.include $(OPENTK_1_0_SOURCES) opentk.csproj
 OPENTK_1_0_MCS_FLAGS = -warn:0 -unsafe -target:library -noconfig -publicsign -debug:portable -optimize -define:MONOTOUCH -define:IPHONE -define:MOBILE -d:MINIMAL $(OPENTK_1_0_SOURCES) -keyfile:$(PRODUCT_KEY_PATH) -define:OPENTK_1_0
 
 # Xamarin.iOS
 
-$(IOS_BUILD_DIR)/compat/OpenTK-1.0.dll:    $(IOS_BUILD_DIR)/compat/monotouch.dll $(OPENTK_1_0_DEPENDENCIES) $(IOS_BUILD_DIR)/compat/OpenTK-1.0.dll.config 
-	$(call Q_PROF_CSC,ios/compat) $(IOS_CSC) -r:$(MONOTOUCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_MONO_PATH)/System.Xml.dll $(OPENTK_1_0_MCS_FLAGS) -out:$@ -r:$<
+$(IOS_BUILD_DIR)/compat/OpenTK-1.0%dll $(IOS_BUILD_DIR)/compat/OpenTK-1.0%pdb:    $(IOS_BUILD_DIR)/compat/monotouch.dll $(OPENTK_1_0_DEPENDENCIES) $(IOS_BUILD_DIR)/compat/OpenTK-1.0.dll.config
+	$(call Q_PROF_CSC,ios/compat) $(IOS_CSC) -r:$(MONOTOUCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_MONO_PATH)/System.Xml.dll $(OPENTK_1_0_MCS_FLAGS) -out:$(basename $@).dll -r:$<
 
-$(IOS_BUILD_DIR)/reference/OpenTK-1.0.dll: $(IOS_BUILD_DIR)/reference/Xamarin.iOS.dll $(OPENTK_1_0_DEPENDENCIES) $(IOS_BUILD_DIR)/reference/OpenTK-1.0.dll.config 
-	$(call Q_PROF_CSC,ios/unified) $(IOS_CSC) -r:$(MONOTOUCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_MONO_PATH)/System.Xml.dll $(OPENTK_1_0_MCS_FLAGS) -out:$@ -r:$< -D:XAMCORE_2_0
+$(IOS_BUILD_DIR)/reference/OpenTK-1.0%dll $(IOS_BUILD_DIR)/reference/OpenTK-1.0%pdb: $(IOS_BUILD_DIR)/reference/Xamarin.iOS.dll $(OPENTK_1_0_DEPENDENCIES) $(IOS_BUILD_DIR)/reference/OpenTK-1.0.dll.config
+	$(call Q_PROF_CSC,ios/unified) $(IOS_CSC) -r:$(MONOTOUCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_MONO_PATH)/System.Xml.dll $(OPENTK_1_0_MCS_FLAGS) -out:$(basename $@).dll -r:$< -D:XAMCORE_2_0
 
 # Xamarin.TVOS
 
-$(TVOS_BUILD_DIR)/reference/OpenTK-1.0.dll: $(TVOS_BUILD_DIR)/reference/Xamarin.TVOS.dll $(OPENTK_1_0_DEPENDENCIES) $(TVOS_BUILD_DIR)/reference/OpenTK-1.0.dll.config
-	$(call Q_PROF_CSC,tvos) $(SYSTEM_CSC)     $(OPENTK_1_0_MCS_FLAGS) -r:$(TVOS_LIBDIR)/System.dll -r:$(TVOS_LIBDIR)/System.Xml.dll -out:$@ -r:$< -D:XAMCORE_2_0 -D:XAMCORE_3_0 -D:TVOS
-
-$(TVOS_BUILD_DIR)/reference/OpenTK-1.0.pdb: $(IOS_BUILD_DIR)/reference/OpenTK-1.0.dll
-	@touch $@
+$(TVOS_BUILD_DIR)/reference/OpenTK-1.0%dll $(TVOS_BUILD_DIR)/reference/OpenTK-1.0%pdb: $(TVOS_BUILD_DIR)/reference/Xamarin.TVOS.dll $(OPENTK_1_0_DEPENDENCIES) $(TVOS_BUILD_DIR)/reference/OpenTK-1.0.dll.config
+	$(call Q_PROF_CSC,tvos) $(SYSTEM_CSC)     $(OPENTK_1_0_MCS_FLAGS) -r:$(TVOS_LIBDIR)/System.dll -r:$(TVOS_LIBDIR)/System.Xml.dll -out:$(basename $@).dll -r:$< -D:XAMCORE_2_0 -D:XAMCORE_3_0 -D:TVOS
 
 # common targets
 
 %/OpenTK-1.0.dll.config: $(OPENTK_PATH)/Source/OpenTK/OpenTK.dll.config | $(IOS_BUILD_DIR)/reference $(IOS_BUILD_DIR)/compat $(TVOS_BUILD_DIR)/tvos
 	$(Q) cp $< $@
-
-%/OpenTK-1.0.pdb: %/OpenTK-1.0.dll
-	@touch $@
-
 
 # other stuff
 


### PR DESCRIPTION
For some reason I don't quite understand, I ended up with zero-length pdbs for
OpenTK-1.0.dll locally. Looking at the makefile this might be happening in
custom rules that touch the pdbs (which would cause zero-length files if the
pdb didn't exist before that rule executed), so rewrite the OpenTK targets to
use pattern rules with multiple targets, which tells Make that the same recipe
builds all targets, instead of relying on custom rules that does unrelated
things (i.e. `touch foo.pdb`) to provide a rule for the pdbs.