### PR TITLE
[mtouch/mmp] Print assembly references in verbose mode.

### DIFF
--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -110,6 +110,10 @@ namespace Xamarin.Bundler {
 			}
 		}
 
+		public static int Verbosity {
+			get { return verbose; }
+		}
+
 #if MONOMAC
 #pragma warning disable 0414
 		static string userTargetFramework = TargetFramework.Default.ToString ();

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -180,5 +180,16 @@ namespace Xamarin.Bundler {
 			// Keep the weak ones.
 			asm.Frameworks.ExceptWith (asm.WeakFrameworks);
 		}
+
+		internal static void PrintAssemblyReferences (AssemblyDefinition assembly)
+		{
+			if (Driver.Verbosity < 2)
+				return;
+
+			var main = assembly.MainModule;
+			Driver.Log ($"Loaded assembly '{assembly.FullName}' from {Driver.Quote (assembly.MainModule.FileName)}");
+			foreach (var ar in main.AssemblyReferences)
+				Driver.Log ($"    References: '{ar.FullName}'");
+		}
 	}
 }

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1862,12 +1862,7 @@ namespace Xamarin.Bundler {
 			if (resolved_assemblies.Contains (fqname))
 				return;
 			
-			var main = assembly.MainModule;
-			if (Driver.verbose > 1) {
-				Driver.Log ($"Loaded assembly '{assembly.FullName}' from {Driver.Quote (assembly.MainModule.FileName)}");
-				foreach (var ar in main.AssemblyReferences)
-					Driver.Log ($"    References: {ar.FullName}");
-			}
+			Target.PrintAssemblyReferences (assembly);
 
 			var asm = new Assembly (BuildTarget, assembly);
 			asm.ComputeSatellites ();

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1861,6 +1861,13 @@ namespace Xamarin.Bundler {
 
 			if (resolved_assemblies.Contains (fqname))
 				return;
+			
+			var main = assembly.MainModule;
+			if (Driver.verbose > 1) {
+				Driver.Log ($"Loaded assembly '{assembly.FullName}' from {Driver.Quote (assembly.MainModule.FileName)}");
+				foreach (var ar in main.AssemblyReferences)
+					Driver.Log ($"    References: {ar.FullName}");
+			}
 
 			var asm = new Assembly (BuildTarget, assembly);
 			asm.ComputeSatellites ();
@@ -1870,8 +1877,6 @@ namespace Xamarin.Bundler {
 
 			foreach (AssemblyNameReference reference in assembly.MainModule.AssemblyReferences) {
 				var reference_assembly = BuildTarget.Resolver.Resolve (SwapOutReferenceAssembly (reference.FullName));
-				if (verbose > 1)
-					Console.WriteLine ("Adding dependency {0} required by {1}", reference.Name, assembly.MainModule.Name);
 				ProcessAssemblyReferences (reference_assembly);
 			}
 		}

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -431,18 +431,14 @@ namespace Xamarin.Bundler
 			if (assemblies.Contains (fqname))
 				return;
 
-			var main = assembly.MainModule;
-			if (Driver.Verbosity > 1) {
-				Driver.Log ($"Loaded assembly '{assembly.FullName}' from {Driver.Quote (assembly.MainModule.FileName)}");
-				foreach (var ar in main.AssemblyReferences)
-					Driver.Log ($"    References: {ar.FullName}");
-			}
+			PrintAssemblyReferences (assembly);
 			assemblies.Add (fqname);
 
 			var asm = new Assembly (this, assembly);
 			asm.ComputeSatellites ();
 			this.Assemblies.Add (asm);
 
+			var main = assembly.MainModule;
 			foreach (AssemblyNameReference reference in main.AssemblyReferences) {
 				// Verify that none of the references references an incorrect platform assembly.
 				switch (reference.Name) {

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -431,13 +431,18 @@ namespace Xamarin.Bundler
 			if (assemblies.Contains (fqname))
 				return;
 
+			var main = assembly.MainModule;
+			if (Driver.Verbosity > 1) {
+				Driver.Log ($"Loaded assembly '{assembly.FullName}' from {Driver.Quote (assembly.MainModule.FileName)}");
+				foreach (var ar in main.AssemblyReferences)
+					Driver.Log ($"    References: {ar.FullName}");
+			}
 			assemblies.Add (fqname);
 
 			var asm = new Assembly (this, assembly);
 			asm.ComputeSatellites ();
 			this.Assemblies.Add (asm);
 
-			var main = assembly.MainModule;
 			foreach (AssemblyNameReference reference in main.AssemblyReferences) {
 				// Verify that none of the references references an incorrect platform assembly.
 				switch (reference.Name) {

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -162,10 +162,6 @@ namespace Xamarin.Bundler
 			get { return true; }
 		}
 
-		public static int Verbosity {
-			get { return verbose; }
-		}
-
 		public static bool Force {
 			get { return force; }
 			set { force = value; }


### PR DESCRIPTION
Sample output:

    Loaded assembly 'unifiedtestapp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' from /Users/rolf/Projects/TestApp/bin/iPhoneSimulator/Debug/unifiedtestapp.exe
        References: mscorlib, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
        References: Xamarin.iOS, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065
    Loaded assembly 'mscorlib, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e' from /work/maccore/master/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.iOS/mscorlib.dll
    Loaded assembly 'Xamarin.iOS, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065' from /work/maccore/master/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.iOS/../../64bits/Xamarin.iOS.dll
        References: mscorlib, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
        References: System, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
        References: System.Core, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
        References: Mono.Security, Version=2.0.5.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756
        References: System.Xml, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
    Loaded assembly 'System, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e' from /work/maccore/master/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.iOS/System.dll
        References: mscorlib, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
        References: Mono.Security, Version=2.0.5.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756
        References: System.Xml, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
    Loaded assembly 'Mono.Security, Version=2.0.5.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756' from /work/maccore/master/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.iOS/Mono.Security.dll
        References: mscorlib, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
        References: System, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
    Loaded assembly 'System.Xml, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e' from /work/maccore/master/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.iOS/System.Xml.dll
        References: mscorlib, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
        References: System, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
    Loaded assembly 'System.Core, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e' from /work/maccore/master/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.iOS/System.Core.dll
        References: mscorlib, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
        References: System, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e

I believe this will make it easier to diagnose cases where something
references a desktop assembly (for iOS) or some otherwise unexpected assembly
(for macOS).