### PR TITLE
[mtouch] Handle non-ascii characters when converting assembly to bitcode assembly. Fixes #56876.

### DIFF
--- a/tests/linker-ios/link sdk/AotBugs.cs
+++ b/tests/linker-ios/link sdk/AotBugs.cs
@@ -616,5 +616,13 @@ namespace LinkSdk.Aot {
 				Assert.That (double.Epsilon.ToString (), Is.EqualTo (nfe), "Epsilon");
 			}
 		}
+
+		// The first character of this class is a cyrillic c, not a latin c.
+		[Preserve]
+		public class сolor_bug_56876
+		{
+			[System.Runtime.InteropServices.DllImport ("/usr/lib/libobjc.dylib")]
+			static extern void objc_msgSend (сolor_bug_56876 сolor);
+		}
 	}
 }


### PR DESCRIPTION
When converting strings to a sequence of bytes, we can't just cast chars to
ints, and write that, because non-ascii characters will resulting values
outside the byte range.

Instead explicitly convert the string to a UTF8 byte array, and process that.

https://bugzilla.xamarin.com/show_bug.cgi?id=56876