### PR TITLE
[mtouch] Compare contents of config files before copying them.

### DIFF
--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -172,7 +172,7 @@ namespace Xamarin.Bundler {
 			string config_src = FullPath + ".config";
 			if (File.Exists (config_src)) {
 				string config_target = Path.Combine (directory, FileName + ".config");
-				Application.UpdateFile (config_src, config_target);
+				Application.UpdateFile (config_src, config_target, true);
 			}
 		}
 


### PR DESCRIPTION
Since ee4c07b9cea4b4a7ba547e07f9ac4d77ddcf3700 we treat config files like
debug files and assemblies (they're all touched after the linker is done).
This means we also need to apply the same logic when copying config files as
we do when copying debug files and assemblies (only copy if the contents are
different), otherwise we end up rebuilding too much.

This fixes a few test failures:

1. Failed : Xamarin.MTouch.RebuildTest_WithExtensions("single","",False,System.String[])
    single
    Expected: <empty>
    But was:  < "/Users/builder/data/lanes/1381/a6cf8c5e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.MTouchTool.CreateTemporaryDirectory294/testServiceExtension.appex/testServiceExtension is modified, timestamp: 5/29/2017 6:21:25 PM", "/Users/builder/data/lanes/1381/a6cf8c5e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.MTouchTool.CreateTemporaryDirectory294/testServiceExtension.appex/testServiceExtension.aotdata.armv7 is modified, timestamp: 5/29/2017 6:21:24 PM", "/Users/builder/data/lanes/1381/a6cf8c5e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.MTouchTool.CreateTemporaryDirectory294/testServiceExtension.appex/testServiceExtension.dll.config is modified, timestamp: 5/29/2017 6:21:24 PM" >

2. Failed : Xamarin.MTouch.RebuildTest_WithExtensions("dual","armv7,arm64",False,System.String[])
    dual
    Expected: <empty>
    But was:  < "/Users/builder/data/lanes/1381/a6cf8c5e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.MTouchTool.CreateTemporaryDirectory298/testServiceExtension.appex/testServiceExtension is modified, timestamp: 5/29/2017 6:22:44 PM", "/Users/builder/data/lanes/1381/a6cf8c5e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.MTouchTool.CreateTemporaryDirectory298/testServiceExtension.appex/testServiceExtension.aotdata.arm64 is modified, timestamp: 5/29/2017 6:22:43 PM", "/Users/builder/data/lanes/1381/a6cf8c5e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.MTouchTool.CreateTemporaryDirectory298/testServiceExtension.appex/testServiceExtension.aotdata.armv7 is modified, timestamp: 5/29/2017 6:22:43 PM", "/Users/builder/data/lanes/1381/a6cf8c5e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.MTouchTool.CreateTemporaryDirectory298/testServiceExtension.appex/testServiceExtension.dll.config is modified, timestamp: 5/29/2017 6:22:37 PM" >

3. Failed : Xamarin.MTouch.RebuildTest_WithExtensions("llvm","armv7+llvm",False,System.String[])
    llvm
    Expected: <empty>
    But was:  < "/Users/builder/data/lanes/1381/a6cf8c5e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.MTouchTool.CreateTemporaryDirectory302/testServiceExtension.appex/testServiceExtension is modified, timestamp: 5/29/2017 6:23:38 PM", "/Users/builder/data/lanes/1381/a6cf8c5e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.MTouchTool.CreateTemporaryDirectory302/testServiceExtension.appex/testServiceExtension.aotdata.armv7 is modified, timestamp: 5/29/2017 6:23:37 PM", "/Users/builder/data/lanes/1381/a6cf8c5e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.MTouchTool.CreateTemporaryDirectory302/testServiceExtension.appex/testServiceExtension.dll.config is modified, timestamp: 5/29/2017 6:23:37 PM" >

4. Failed : Xamarin.MTouch.RebuildTest_WithExtensions("debug","",True,System.String[])
    debug
    Expected: <empty>
    But was:  < "/Users/builder/data/lanes/1381/a6cf8c5e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.MTouchTool.CreateTemporaryDirectory306/testServiceExtension.appex/testServiceExtension is modified, timestamp: 5/29/2017 6:24:22 PM", "/Users/builder/data/lanes/1381/a6cf8c5e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.MTouchTool.CreateTemporaryDirectory306/testServiceExtension.appex/testServiceExtension.aotdata.armv7 is modified, timestamp: 5/29/2017 6:24:22 PM", "/Users/builder/data/lanes/1381/a6cf8c5e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.MTouchTool.CreateTemporaryDirectory306/testServiceExtension.appex/testServiceExtension.dll.config is modified, timestamp: 5/29/2017 6:24:21 PM" >

5. Failed : Xamarin.MTouch.RebuildTest_WithExtensions("single-framework","",False,System.String[])
    single-framework
    Expected: <empty>
    But was:  < "/Users/builder/data/lanes/1381/a6cf8c5e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.MTouchTool.CreateTemporaryDirectory310/testServiceExtension.appex/testServiceExtension is modified, timestamp: 5/29/2017 6:25:07 PM", "/Users/builder/data/lanes/1381/a6cf8c5e/source/xamarin-