### PR TITLE
[mtouch] Link with AVFoundation in watchOS apps when needed. Fixes #56862.

### DIFF
--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -247,43 +247,43 @@ public class Frameworks : Dictionary <string, Framework>
 	}
 
 	static Frameworks watch_frameworks;
-	public static Frameworks WatchFrameworks {
-		get {
-			if (watch_frameworks == null) {
-				watch_frameworks = new Frameworks {
-					// The CFNetwork framework is in the SDK, but there are no headers inside the framework, so don't enable yet.
-					// { "CFNetwork", "CFNetwork", 2 },
-					{ "ClockKit", "ClockKit", 2 },
-					{ "Contacts", "Contacts", 2 },
-					{ "CoreData", "CoreData", 2 },
-					{ "CoreFoundation", "CoreFoundation", 2 },
-					{ "CoreGraphics", "CoreGraphics", 2 },
-					{ "CoreLocation", "CoreLocation", 2 },
-					{ "CoreMotion", "CoreMotion", 2 },
-					{ "EventKit", "EventKit", 2 },
-					{ "Foundation", "Foundation", 2 },
-					{ "HealthKit", "HealthKit", 2 },
-					{ "HomeKit", "HomeKit", 2 },
-					{ "ImageIO", "ImageIO", 2 },
-					{ "MapKit", "MapKit", 2 },
-					{ "MobileCoreServices", "MobileCoreServices", 2 },
-					{ "PassKit", "PassKit", 2 },
-					{ "Security", "Security", 2 },
-					{ "UIKit", "UIKit", 2 },
-					{ "WatchConnectivity", "WatchConnectivity", 2 },
-					{ "WatchKit", "WatchKit", 2 },
+	public static Frameworks GetwatchOSFrameworks (Application app)
+	{
+		if (watch_frameworks == null) {
+			watch_frameworks = new Frameworks {
+				// The CFNetwork framework is in the SDK, but there are no headers inside the framework, so don't enable yet.
+				// { "CFNetwork", "CFNetwork", 2 },
+				{ "ClockKit", "ClockKit", 2 },
+				{ "Contacts", "Contacts", 2 },
+				{ "CoreData", "CoreData", 2 },
+				{ "CoreFoundation", "CoreFoundation", 2 },
+				{ "CoreGraphics", "CoreGraphics", 2 },
+				{ "CoreLocation", "CoreLocation", 2 },
+				{ "CoreMotion", "CoreMotion", 2 },
+				{ "EventKit", "EventKit", 2 },
+				{ "Foundation", "Foundation", 2 },
+				{ "HealthKit", "HealthKit", 2 },
+				{ "HomeKit", "HomeKit", 2 },
+				{ "ImageIO", "ImageIO", 2 },
+				{ "MapKit", "MapKit", 2 },
+				{ "MobileCoreServices", "MobileCoreServices", 2 },
+				{ "PassKit", "PassKit", 2 },
+				{ "Security", "Security", 2 },
+				{ "UIKit", "UIKit", 2 },
+				{ "WatchConnectivity", "WatchConnectivity", 2 },
+				{ "WatchKit", "WatchKit", 2 },
 
-					//{ "AVFoundation", "AVFoundation", 3 },
-					{ "CloudKit", "CloudKit", 3 },
-					{ "GameKit", "GameKit", 3 },
-					{ "SceneKit", "SceneKit", 3 },
-					{ "SpriteKit", "SpriteKit", 3 },
-					{ "UserNotifications", "UserNotifications", 3 },
-					{ "Intents", "Intents", 3,2 },
-				};
-			}
-			return watch_frameworks;
+				// AVFoundation was introduced in 3.0, but the simulator SDK was broken until 3.2.
+				{ "AVFoundation", "AVFoundation", 3, app.IsSimulatorBuild ? 2 : 0 },
+				{ "CloudKit", "CloudKit", 3 },
+				{ "GameKit", "GameKit", 3 },
+				{ "SceneKit", "SceneKit", 3 },
+				{ "SpriteKit", "SpriteKit", 3 },
+				{ "UserNotifications", "UserNotifications", 3 },
+				{ "Intents", "Intents", 3,2 },
+			};
 		}
+		return watch_frameworks;
 	}
 
 	static Frameworks tvos_frameworks;

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1688,7 +1688,7 @@ namespace Xamarin.Bundler
 			case ApplePlatform.iOS:
 				return Frameworks.GetiOSFrameworks (app);
 			case ApplePlatform.WatchOS:
-				return Frameworks.WatchFrameworks;
+				return Frameworks.GetwatchOSFrameworks (app);
 			case ApplePlatform.TVOS:
 				return Frameworks.TVOSFrameworks;
 			default:


### PR DESCRIPTION
The AVFoundation framework's headers used to be broken in the simulator SDK
([1], [2]) until watchOS 3.2 (Xcode 8.3) fixed it. This means it's now safe to
use AVFoundation.

Additionally set the initial SDK version where this framework was introduced
to 3.2 for simulator builds, which means that if customers try to use it (with
an old Xcode), they will get a nice-ish error:

> MTOUCH : error MT4134: Your application is using the 'AVFoundation' framework, which isn't included in the watchOS SDK you're using to build your app (this framework was introduced in watchOS 3.2, while you're building with the watchOS 3.1 SDK.) Please select a newer SDK in your app's watchOS Build options.

instead of an ugly:

> MTOUCH : error MT4109: Failed to compile the generated registrar code. Please file a bug report at http://bugzilla.xamarin.com

the error message is slightly incorrect (the problem is only with the
simulator SDK, not the device SDK), but this should happen very rarely (it
only occurs if all of the following are true: using AVFoundation + in a
simulator build * the static registrar manually selected), so IMHO a more
accurate error description isn't worth it.

https://bugzilla.xamarin.com/show_bug.cgi?id=56862

[1] https://github.com/xamarin/xamarin-macios/commit/71496612517eb0c6bd560aa57af391dca5d16550
[2] https://openradar.appspot.com/29131674