### PR TITLE
[tests] Don't cap return value to 32-bit on 64-bit platforms in NSArrayTest.Sort. Fixes #53298.

### DIFF
--- a/tests/monotouch-test/Foundation/ArrayTest.cs
+++ b/tests/monotouch-test/Foundation/ArrayTest.cs
@@ -58,9 +58,11 @@ namespace MonoTouchFixtures.Foundation {
 			comparator_count++;
 			return 
 #if XAMCORE_2_0
-			(NSComparisonResult)
+				(NSComparisonResult) (long)
+#else
+				(int)
 #endif
-				(int) ((nint) obj2.Handle - (nint) obj1.Handle);
+				((nint) obj2.Handle - (nint) obj1.Handle);
 		}
 		
 		[Test]


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=53298