### PR TITLE
[mtouch] Show a nice error (MT4168) if the user registers a managed class with an Objective-C keyword. Fixes #51776.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -1484,6 +1484,12 @@ This usually indicates a bug in Xamarin.iOS; please file a bug at [http://bugzil
 
 This usually indicates a bug in Xamarin.iOS; please file a bug at [http://bugzilla.xamarin.com](https://bugzilla.xamarin.com/enter_bug.cgi?product=iOS).
 
+<h3><a name="MT4168"/>MT4168: Cannot register the type '{managed_name}' because its Objective-C name '{exported_name}' is an Objective-C keyword. Please use a different name.</h3>
+
+The Objective-C name for the type in question is not a valid Objective-C identifier.
+
+Please use a valid Objective-C identifier.
+
 # MT5xxx: GCC and toolchain error messages
 
 ### MT51xx: Compilation

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -276,7 +276,7 @@ namespace XamCore.Registrar {
 				VerifyIsNotKeyword (ref exceptions, property);
 			}
 
-			static bool IsObjectiveCKeyword (string name)
+			public static bool IsObjectiveCKeyword (string name)
 			{
 				switch (name) {
 				case "auto":
@@ -1519,6 +1519,9 @@ namespace XamCore.Registrar {
 
 			if (!objcType.IsWrapper && objcType.BaseType != null)
 				VerifyTypeInSDK (ref exceptions, objcType.BaseType.Type, baseTypeOf: objcType.Type);
+
+			if (ObjCType.IsObjectiveCKeyword (objcType.ExportedName))
+				AddException (ref exceptions, ErrorHelper.CreateError (4168, $"Cannot register the type '{GetTypeFullName (type)}' because its Objective-C name '{objcType.ExportedName}' is an Objective-C keyword. Please use a different name."));
 
 			// make sure all the protocols this type implements are registered
 			if (objcType.Protocols != null) {

--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -610,6 +610,26 @@ public struct FooF { public NSObject Obj; }
 			);
 		}
 
+		static string [] objective_c_keywords = new string [] {
+			"auto",
+			"break",
+			"case", "char", "const", "continue",
+			"default", "do", "double",
+			"else", "enum", "export", "extern",
+			"float", "for",
+			"goto",
+			"if", "inline", "int",
+			"long",
+			"register", "return",
+			"short", "signed", "sizeof", "static", "struct", "switch",
+			"template", "typedef", "union",
+			"unsigned",
+			"void", "volatile",
+			"while",
+			"_Bool",
+			"_Complex",
+		};
+
 		[Test]
 		public void MT4164 ()
 		{
@@ -709,6 +729,24 @@ class X : ReplayKit.RPBroadcastControllerDelegate
 }
 ";
 			Verify (R.Static, code, true);
+		}
+
+		[Test]
+		public void MT4168 ()
+		{
+			using (var mtouch = new MTouchTool ()) {
+				var sb = new StringBuilder ();
+				foreach (var kw in objective_c_keywords) {
+					sb.AppendLine ($"[Foundation.Register (\"{kw}\")]");
+					sb.AppendLine ($"class X{kw} : Foundation.NSObject {{}}");
+				}
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.CreateTemporaryApp (extraCode: sb.ToString ());
+				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
+				foreach (var kw in objective_c_keywords)
+					mtouch.AssertError (4168, $"Cannot register the type 'X{kw}' because its Objective-C name '{kw}' is an Objective-C keyword. Please use a different name.");
+			}
 		}
 
 		[Test]


### PR DESCRIPTION
Previously:

    obj/iPhone/Ad-Hoc/mtouch-cache/64/registrar.m:4402:12: error: expected identifier
    @interface register : UITableViewController {
    ^
    obj/iPhone/Ad-Hoc/mtouch-cache/64/registrar.m:4402:21: error: expected unqualified-id
    @interface register : UITableViewController {

    error : Failed to compile the generated registrar code. Please file a bug report at http://bugzilla.xamarin.com

Now:

    error MT4168: Cannot register the type 'register' because its Objective-C name 'register' is an Objective-C keyword. Please use a different name.

https://bugzilla.xamarin.com/show_bug.cgi?id=51776