### PR TITLE
[Mac,iOS] Generate create_classes as C methods so they can be used from objc.

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3803,19 +3803,20 @@ namespace XamCore.Registrar {
 			
 			Specialize (sb);
 
+			methods.WriteLine ();
+			methods.AppendLine ();
+			methods.AppendLine (sb);
+
 			methods.StringBuilder.AppendLine ("} /* extern \"C\" */");
 
 			FlushTrace ();
+
+			Driver.WriteIfDifferent (source_path, methods.ToString ());
 
 			header.AppendLine ();
 			header.AppendLine (declarations);
 			header.AppendLine (interfaces);
 			Driver.WriteIfDifferent (header_path, header.ToString ());
-
-			methods.WriteLine ();
-			methods.AppendLine ();
-			methods.AppendLine (sb);
-			Driver.WriteIfDifferent (source_path, methods.ToString ());
 
 			header.Dispose ();
 			header = null;

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1113,7 +1113,7 @@ namespace Xamarin.Bundler {
 				sw.WriteLine ("#import <AppKit/NSAlert.h>");
 				sw.WriteLine ("#import <Foundation/NSDate.h>"); // 10.7 wants this even if not needed on 10.9
 				if (Driver.registrar == RegistrarMode.PartialStatic)
-					sw.WriteLine ("extern int xamarin_create_classes_Xamarin_Mac ();");
+					sw.WriteLine ("extern \"C\" void xamarin_create_classes_Xamarin_Mac ();");
 				sw.WriteLine ();
 				sw.WriteLine ();
 				sw.WriteLine ();

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -615,7 +615,7 @@ namespace Xamarin.Bundler
 
 					if (registration_methods != null) {
 						foreach (var method in registration_methods) {
-							sw.Write ("void ");
+							sw.Write ("extern \"C\" void ");
 							sw.Write (method);
 							sw.WriteLine ("();");
 						}

--- a/tools/mtouch/simlauncher.m
+++ b/tools/mtouch/simlauncher.m
@@ -9,7 +9,15 @@
 
 #include "xamarin/xamarin.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void xamarin_create_classes_Xamarin_iOS ();
+
+#ifdef __cplusplus
+}
+#endif
 
 void xamarin_setup_impl ()
 {


### PR DESCRIPTION
This change introduces the export of create_classes methods as objc compatible, without enforcing Objective-C++ as the development language for custom registrar embedders by moving the stringbuilder flushing inside the extern "C" block.
Mark the generated linking code as extern "C" too and also change the return type of xamarin_create_classes_Xamarin_Mac to void in mmp generation, as it was mistakenly set to int.

Marking as dont-merge and macios is still building locally for me so I can't test it yet.