### PR TITLE
[mtouch] Improve how we make sure native symbols aren't stripped away. Fixes #51710 and #54417.

### DIFF
--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -199,6 +199,10 @@ The easiest way to get exact version information is to use the **Xamarin Studio*
 
 <h3><a name="MM5205">MM5205: Invalid architecture '{0}'. Valid architectures are i386 and x86_64 (when --profile=mobile).</h3>
 
+<h3><a name="MM5218"/>MM5218: Can't ignore the dynamic symbol {symbol} (--ignore-dynamic-symbol={symbol}) because it was not detected as a dynamic symbol.</h3>
+
+See the [equivalent mtouch warning](mtouch-errors.md#MT5218).
+
 <!-- 5206 used by mtouch -->
 <!-- 5207 used by mtouch -->
 <!-- 5208 used by mtouch -->
@@ -209,6 +213,8 @@ The easiest way to get exact version information is to use the **Xamarin Studio*
 <!-- 5213 used by mtouch -->
 <!-- 5214 used by mtouch -->
 <!-- 5215 used by mtouch -->
+<!-- 5216 used by mtouch -->
+<!-- 5217 used by mtouch -->
 
 ## MM53xx: other tools
 

--- a/tests/mmptest/src/LinkerTests.cs
+++ b/tests/mmptest/src/LinkerTests.cs
@@ -72,5 +72,37 @@ namespace Xamarin.MMP.Tests
 				TI.TestClassicExecutable (tmpDir, csprojConfig: "<MonoBundlingExtraArgs>--linkplatform</MonoBundlingExtraArgs>\n", includeMonoRuntime:true, shouldFail: true);
 			});
 		}
+
+		[Test]
+		[TestCase ("linker")]
+		[TestCase ("code")]
+		[TestCase ("ignore")]
+		[TestCase ("default")]
+		public void DynamicSymbolMode (string mode)
+		{
+			RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig config = new TI.UnifiedTestConfig (tmpDir) {
+					CSProjConfig = $"<MonoBundlingExtraArgs>--dynamic-symbol-mode={mode}</MonoBundlingExtraArgs>\n", 
+				};
+				var output = TI.TestUnifiedExecutable (config);
+				switch (mode) {
+				case "linker":
+				case "default":
+					Assert.That (output.BuildOutput, Does.Contain ("-u "), "reference.m");
+					Assert.That (output.BuildOutput, Does.Not.Contain ("reference.m"), "reference.m");
+					break;
+				case "code":
+					Assert.That (output.BuildOutput, Does.Not.Contain ("-u "), "reference.m");
+					Assert.That (output.BuildOutput, Does.Contain ("reference.m"), "reference.m");
+					break;
+				case "ignore":
+					Assert.That (output.BuildOutput, Does.Not.Contain ("-u "), "reference.m");
+					Assert.That (output.BuildOutput, Does.Not.Contain ("reference.m"), "reference.m");
+					break;
+				default:
+					throw new NotImplementedException ();
+				}
+			});
+		}
 	}
 }

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -27,6 +27,15 @@ namespace Xamarin
 		DontLink,
 	}
 
+	public enum MTouchSymbolMode
+	{
+		Unspecified,
+		Default,
+		Linker,
+		Code,
+		Ignore,
+	}
+
 	public enum MTouchRegistrar
 	{
 		Unspecified,
@@ -80,6 +89,7 @@ namespace Xamarin
 		public string Cache;
 		public string Device; // --device
 		public MTouchLinker Linker;
+		public MTouchSymbolMode SymbolMode;
 		public bool? NoFastSim;
 		public MTouchRegistrar Registrar;
 		public I18N I18N;
@@ -382,6 +392,25 @@ namespace Xamarin
 				break;
 			case MTouchLinker.LinkSdk:
 				sb.Append (" --linksdkonly");
+				break;
+			default:
+				throw new NotImplementedException ();
+			}
+
+			switch (SymbolMode) {
+			case MTouchSymbolMode.Ignore:
+				sb.Append (" --dynamic-symbol-mode=ignore");
+				break;
+			case MTouchSymbolMode.Code:
+				sb.Append (" --dynamic-symbol-mode=code");
+				break;
+			case MTouchSymbolMode.Default:
+				sb.Append (" --dynamic-symbol-mode=default");
+				break;
+			case MTouchSymbolMode.Linker:
+				sb.Append (" --dynamic-symbol-mode=linker");
+				break;
+			case MTouchSymbolMode.Unspecified:
 				break;
 			default:
 				throw new NotImplementedException ();

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -536,6 +536,11 @@ namespace Xamarin.Bundler {
 			return HashedAssemblies.TryGetValue (identity, out assembly);
 		}
 
+		public bool TryGetValue (AssemblyDefinition asm, out Assembly assembly)
+		{
+			return HashedAssemblies.TryGetValue (Assembly.GetIdentity (asm), out assembly);
+		}
+
 		public bool ContainsKey (string identity)
 		{
 			return HashedAssemblies.ContainsKey (identity);

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -541,6 +541,11 @@ namespace Xamarin.Bundler {
 			return HashedAssemblies.TryGetValue (Assembly.GetIdentity (asm), out assembly);
 		}
 
+		public bool Contains (AssemblyDefinition asm)
+		{
+			return HashedAssemblies.ContainsKey (Assembly.GetIdentity (asm));
+		}
+
 		public bool ContainsKey (string identity)
 		{
 			return HashedAssemblies.ContainsKey (identity);

--- a/tools/common/CompilerFlags.cs
+++ b/tools/common/CompilerFlags.cs
@@ -53,13 +53,13 @@ namespace Xamarin.Utils
 			UnresolvedSymbols.Add (symbol);
 		}
 
-		public void ReferenceSymbols (IEnumerable<string> symbols)
+		public void ReferenceSymbols (IEnumerable<Symbol> symbols)
 		{
 			if (UnresolvedSymbols == null)
 				UnresolvedSymbols = new HashSet<string> ();
 
 			foreach (var symbol in symbols)
-				UnresolvedSymbols.Add (symbol);
+				UnresolvedSymbols.Add (symbol.Name);
 		}
 
 		public void AddDefine (string define)

--- a/tools/common/DerivedLinkContext.cs
+++ b/tools/common/DerivedLinkContext.cs
@@ -4,14 +4,15 @@ using Mono.Cecil;
 using Mono.Linker;
 
 using XamCore.Registrar;
+using Xamarin.Bundler;
 
 namespace Xamarin.Tuner
 {
 	public class DerivedLinkContext : LinkContext
 	{
 		internal StaticRegistrar StaticRegistrar;
-		Dictionary<string, List<MemberReference>> required_symbols;
-		Dictionary<string, TypeDefinition> objectivec_classes;
+		internal Target Target;
+		Symbols required_symbols;
 
 		// SDK candidates - they will be preserved only if the application (not the SDK) uses it
 		List<ICustomAttributeProvider> srs_data_contract = new List<ICustomAttributeProvider> ();
@@ -48,30 +49,14 @@ namespace Xamarin.Tuner
 			}
 		}
 
-		public List<MemberReference> GetRequiredSymbolList (string symbol)
-		{
-			List<MemberReference> rv;
-			if (!RequiredSymbols.TryGetValue (symbol, out rv))
-				required_symbols [symbol] = rv = new List<MemberReference> ();
-			return rv;
-		}
-
-		public Dictionary<string, List<MemberReference>> RequiredSymbols {
+		public Symbols RequiredSymbols {
 			get {
 				if (required_symbols == null)
-					required_symbols = new Dictionary<string, List<MemberReference>> ();
+					required_symbols = new Symbols ();
 				return required_symbols;
 			}
 		}
 
-		public Dictionary<string, TypeDefinition> ObjectiveCClasses {
-			get {
-				if (objectivec_classes == null)
-					objectivec_classes = new Dictionary<string, TypeDefinition> ();
-				return objectivec_classes;
-			}
-		}
-		
 		public DerivedLinkContext (Pipeline pipeline, AssemblyResolver resolver)
 			: base (pipeline, resolver)
 		{

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -101,6 +101,27 @@ namespace Xamarin.Bundler {
 			options.Add ("embeddinator", "Enables Embeddinator targetting mode.", v => {
 				app.Embeddinator = true;
 			}, true);
+			options.Add ("dynamic-symbol-mode:", "Specify how dynamic symbols are treated so that they're not linked away by the native linker. Valid values: linker (pass \"-u symbol\" to the native linker), code (generate native code that uses the dynamic symbol), ignore (do nothing and hope for the best). The default is 'code' when using bitcode, and 'linker' otherwise.", (v) => {
+				switch (v.ToLowerInvariant ()) {
+				case "default":
+					app.SymbolMode = SymbolMode.Default;
+					break;
+				case "linker":
+					app.SymbolMode = SymbolMode.Linker;
+					break;
+				case "code":
+					app.SymbolMode = SymbolMode.Code;
+					break;
+				case "ignore":
+					app.SymbolMode = SymbolMode.Ignore;
+					break;
+				default:
+					throw ErrorHelper.CreateError (26, "Could not parse the command line argument '{0}': {1}", "--dynamic-symbol-mode", $"Invalid value: {v}. Valid values are: default, linker, code and ignore.");
+				}
+			});
+			options.Add ("ignore-dynamic-symbol:", "Specify that Xamarin.iOS/Xamarin.Mac should not try to prevent the linker from removing the specified symbol.", (v) => {
+				app.IgnoredSymbols.Add (v);
+			});
 		}
 
 		static int Jobs;

--- a/tools/common/Symbols.cs
+++ b/tools/common/Symbols.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+
+using Mono.Cecil;
+
+namespace Xamarin.Bundler
+{
+	public enum SymbolType
+	{
+		Function,
+		ObjectiveCClass,
+		Field,
+	}
+
+	public enum SymbolMode
+	{
+		Default,
+		Linker, // pass "-u symbol" to the native linker
+		Code, // generate code
+		Ignore, // do nothing and hope for the best
+	}
+
+	public class Symbol
+	{
+		public SymbolType Type;
+		public bool Ignore;
+
+		string name;
+		public string Name {
+			get {
+				if (name != null)
+					return name;
+				if (ObjectiveCName != null)
+					return "OBJC_CLASS_$_" + ObjectiveCName;
+				throw ErrorHelper.CreateError (99, $"Internal error: symbol without a name (type: {Type}). Please file a bug report with a test case (https://bugzilla.xamarin.com).");
+			}
+			set {
+				name = value;
+			}
+		}
+		public string ObjectiveCName;
+
+		List<MemberReference> members = new List<MemberReference> ();
+		public IEnumerable<MemberReference> Members { get { return members; } }
+
+		public HashSet<AssemblyDefinition> Assemblies { get; private set; } = new HashSet<AssemblyDefinition> ();
+
+		public void AddMember (MemberReference member)
+		{
+			members.Add (member);
+			Assemblies.Add (member.Module.Assembly);
+		}
+
+		public void AddAssembly (AssemblyDefinition assembly)
+		{
+			Assemblies.Add (assembly);
+		}
+	}
+
+	public class Symbols : IEnumerable<Symbol>
+	{
+		Dictionary<string, Symbol> store = new Dictionary<string, Symbol> (StringComparer.Ordinal);
+
+		public int Count {
+			get {
+				return store.Count;
+			}
+		}
+
+		public void Add (Symbol symbol)
+		{
+			store.Add (symbol.Name, symbol);
+		}
+
+		public Symbol AddObjectiveCClass (string class_name)
+		{
+			var symbol = new Symbol {
+				Type = SymbolType.ObjectiveCClass,
+				ObjectiveCName = class_name,
+			};
+			var existing = Find (symbol.Name);
+			if (existing != null)
+				return existing;
+			Add (symbol);
+			return symbol;
+		}
+
+		public Symbol AddField (string name)
+		{
+			Symbol rv = Find (name);
+			if (rv == null) {
+				rv = new Symbol { Name = name, Type = SymbolType.Field };
+				Add (rv);
+			}
+			return rv;
+		}
+
+		public Symbol AddFunction (string name)
+		{
+			Symbol rv = Find (name);
+			if (rv == null) {
+				rv = new Symbol { Name = name, Type = SymbolType.Function };
+				Add (rv);
+			}
+			return rv;
+		}
+
+		public void Remove (Func<Symbol, bool> condition)
+		{
+			foreach (var symbol in this) {
+				if (condition (symbol))
+					store.Remove (symbol.Name);
+			}
+		}
+
+		public IEnumerator<Symbol> GetEnumerator ()
+		{
+			return store.Values.GetEnumerator ();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator ()
+		{
+			return store.Values.GetEnumerator ();
+		}
+
+		public Symbol Find (string name)
+		{
+			Symbol rv;
+			store.TryGetValue (name, out rv);
+			return rv;
+		}
+
+		public bool Contains (string name)
+		{
+			return store.ContainsKey (name);
+		}
+
+		public Symbol this [string name] {
+			get {
+				return store [name];
+			}
+		}
+
+		public void Load (string filename, Target target)
+		{
+			using (var reader = new StreamReader (filename)) {
+				string line;
+				Symbol current = null;
+				while ((line = reader.ReadLine ()) != null) {
+					if (line.Length == 0)
+						continue;
+					if (line [0] == '\t') {
+						var asm = line.Substring (1);
+						Assembly assembly;
+						if (!target.Assemblies.TryGetValue (Assembly.GetIdentity (asm), out assembly))
+							throw ErrorHelper.CreateError (99, $"Internal error: serialized assembly {asm} for symbol {current.Name}, but no such assembly loaded. Please file a bug report with a test case (https://bugzilla.xamarin.com).");
+						current.AddAssembly (assembly.AssemblyDefinition);
+					} else {
+						var eq = line.IndexOf ('=');
+						var typestr = line.Substring (0, eq);
+						var name = line.Substring (eq + 1);
+						current = new Symbol { Name = name, Type = (SymbolType) Enum.Parse (typeof (SymbolType), typestr) };
+						Add (current);
+					}
+				}
+			}
+		}
+
+		public void Save (string filename)
+		{
+			using (var writer = new StreamWriter (filename)) {
+				foreach (var symbol in store.Values) {
+					writer.WriteLine ("{0}={1}", symbol.Type, symbol.Name);
+					foreach (var asm in symbol.Assemblies)
+						writer.WriteLine ($"\t{asm.MainModule.FileName}");
+				}
+			}
+		}
+	}
+}

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -260,6 +260,7 @@ namespace Xamarin.Bundler {
 			if (single_assembly != null && !symbol.Members.Any ((v) => v.Module.Assembly == single_assembly.AssemblyDefinition))
 				return false; // nope, this symbol is not used in the assembly we're using as filter.
 
+#if MTOUCH
 			// If we're code-sharing, the managed linker might have found symbols
 			// that are not in any of the assemblies in the current app.
 			// This occurs because the managed linker processes all the
@@ -271,6 +272,7 @@ namespace Xamarin.Bundler {
 				if (!symbol.Assemblies.Any ((v) => Assemblies.Contains (v)))
 					return false;
 			}
+#endif
 
 			switch (symbol.Type) {
 			case SymbolType.Field:

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -19,6 +19,7 @@ using Xamarin.Linker;
 
 using Xamarin.Utils;
 using XamCore.Registrar;
+using XamCore.ObjCRuntime;
 
 #if MONOTOUCH
 using MonoTouch;
@@ -45,6 +46,11 @@ namespace Xamarin.Bundler {
 
 		internal StaticRegistrar StaticRegistrar { get; set; }
 
+		// If we didn't link because the existing (cached) assemblyes are up-to-date.
+		bool cached_link = false;
+
+		Symbols dynamic_symbols;
+
 #if MONOMAC
 		public bool Is32Build { get { return !Driver.Is64Bit; } }
 		public bool Is64Build { get { return Driver.Is64Bit; } }
@@ -60,13 +66,6 @@ namespace Xamarin.Bundler {
 			foreach (var a in Assemblies) {
 				try {
 					a.ExtractNativeLinkInfo ();
-
-#if MTOUCH
-					if (a.HasLinkWithAttributes && App.EnableBitCode && !App.OnlyStaticLibraries) {
-						ErrorHelper.Warning (110, "Incremental builds have been disabled because this version of Xamarin.iOS does not support incremental builds in projects that include third-party binding libraries and that compiles to bitcode.");
-						App.ClearAssemblyBuildTargets (); // the default is to compile to static libraries, so just revert to the default.
-					}
-#endif
 				} catch (Exception e) {
 					exceptions.Add (e);
 				}
@@ -190,6 +189,190 @@ namespace Xamarin.Bundler {
 			Driver.Log ($"Loaded assembly '{assembly.FullName}' from {Driver.Quote (assembly.MainModule.FileName)}");
 			foreach (var ar in main.AssemblyReferences)
 				Driver.Log ($"    References: '{ar.FullName}'");
+		}
+
+		public Symbols GetAllSymbols ()
+		{
+			CollectAllSymbols ();
+			return dynamic_symbols;
+		}
+
+		public void CollectAllSymbols ()
+		{
+			if (dynamic_symbols != null)
+				return;
+
+			var cache_location = Path.Combine (App.Cache.Location, "entry-points.txt");
+			if (cached_link) {
+				dynamic_symbols = new Symbols ();
+				dynamic_symbols.Load (cache_location, this);
+			} else {
+				if (LinkContext == null) {
+					// This happens when using the simlauncher and the msbuild tasks asked for a list
+					// of symbols (--symbollist). In that case just produce an empty list, since the
+					// binary shouldn't end up stripped anyway.
+					dynamic_symbols = new Symbols ();
+				} else {
+					dynamic_symbols = LinkContext.RequiredSymbols;
+				}
+
+				// keep the debugging helper in debugging binaries only
+				var has_mono_pmip = App.EnableDebug;
+#if MMP
+				has_mono_pmip &= !Driver.IsUnifiedFullSystemFramework;
+#endif
+				if (has_mono_pmip)
+					dynamic_symbols.AddFunction ("mono_pmip");
+
+				bool has_dyn_msgSend;
+#if MONOTOUCH
+				has_dyn_msgSend = App.IsSimulatorBuild;
+#else
+				has_dyn_msgSend = App.MarshalObjectiveCExceptions != MarshalObjectiveCExceptionMode.Disable && !App.RequiresPInvokeWrappers && Is64Build;
+#endif
+
+				if (has_dyn_msgSend) {
+					dynamic_symbols.AddFunction ("xamarin_dyn_objc_msgSend");
+					dynamic_symbols.AddFunction ("xamarin_dyn_objc_msgSendSuper");
+					dynamic_symbols.AddFunction ("xamarin_dyn_objc_msgSend_stret");
+					dynamic_symbols.AddFunction ("xamarin_dyn_objc_msgSendSuper_stret");
+				}
+
+				dynamic_symbols.Save (cache_location);
+			}
+
+			foreach (var name in App.IgnoredSymbols) {
+				var symbol = dynamic_symbols.Find (name);
+				if (symbol == null) {
+					ErrorHelper.Warning (5218, $"Can't ignore the dynamic symbol {Driver.Quote (name)} (--ignore-dynamic-symbol={Driver.Quote (name)}) because it was not detected as a dynamic symbol.");
+				} else {
+					symbol.Ignore = true;
+				}
+			}
+		}
+
+		bool IsRequiredSymbol (Symbol symbol, Assembly single_assembly = null)
+		{
+			if (symbol.Ignore)
+				return false;
+
+			// Check if this symbol is used in the assembly we're filtering to
+			if (single_assembly != null && !symbol.Members.Any ((v) => v.Module.Assembly == single_assembly.AssemblyDefinition))
+				return false; // nope, this symbol is not used in the assembly we're using as filter.
+
+			switch (symbol.Type) {
+			case SymbolType.Field:
+				return true;
+			case SymbolType.Function:
+#if MTOUCH
+				// functions are not required if they're used in an assembly which isn't using dlsym, and we're AOT-compiling.
+				if (App.IsSimulatorBuild)
+					return true;
+				if (single_assembly != null)
+					return App.UseDlsym (single_assembly.FileName);
+
+				if (symbol.Members != null) {
+					foreach (var member in symbol.Members) {
+						if (!App.UseDlsym (member.Module.FileName))
+							return false;
+					}
+				}
+#endif
+				return true;
+			case SymbolType.ObjectiveCClass:
+				// Objective-C classes are not required when we're using the static registrar and we're not compiling to shared libraries,
+				// (because the registrar code is linked into the main app, but not each shared library, 
+				// so the registrar code won't keep symbols in the shared libraries).
+				if (single_assembly != null)
+					return true;
+				return App.Registrar != RegistrarMode.Static;
+			default:
+				throw ErrorHelper.CreateError (99, $"Internal error: invalid symbol type {symbol.Type} for symbol {symbol.Name}. Please file a bug report with a test case (https://bugzilla.xamarin.com).");
+			}
+		}
+
+		public Symbols GetRequiredSymbols (Assembly assembly = null)
+		{
+			CollectAllSymbols ();
+
+			Symbols filtered = new Symbols ();
+			foreach (var ep in dynamic_symbols) {
+				if (IsRequiredSymbol (ep, assembly)) {
+					filtered.Add (ep);
+				}
+			}
+			return filtered ?? dynamic_symbols;
+		}
+
+#if MTOUCH
+		IEnumerable<CompileTask> GenerateReferencingSource (string reference_m, IEnumerable<Symbol> symbols)
+#else
+		internal string GenerateReferencingSource (string reference_m, IEnumerable<Symbol> symbols)
+#endif
+		{
+			if (!symbols.Any ()) {
+				if (File.Exists (reference_m))
+					File.Delete (reference_m);
+#if MTOUCH
+				yield break;
+#else
+				return null;
+#endif
+			}
+			var sb = new StringBuilder ();
+			sb.AppendLine ("#import <Foundation/Foundation.h>");
+			foreach (var symbol in symbols) {
+				switch (symbol.Type) {
+				case SymbolType.Function:
+				case SymbolType.Field:
+					sb.Append ("extern void * ").Append (symbol.Name).AppendLine (";");
+					break;
+				case SymbolType.ObjectiveCClass:
+					sb.AppendLine ($"@interface {symbol.ObjectiveCName} : NSObject @end");
+					break;
+				default:
+					throw ErrorHelper.CreateError (99, $"Internal error: invalid symbol type {symbol.Type} for {symbol.Name}. Please file a bug report with a test case (https://bugzilla.xamarin.com).");
+				}
+			}
+			sb.AppendLine ("static void __xamarin_symbol_referencer () __attribute__ ((used)) __attribute__ ((optnone));");
+			sb.AppendLine ("void __xamarin_symbol_referencer ()");
+			sb.AppendLine ("{");
+			sb.AppendLine ("\tvoid *value;");
+			foreach (var symbol in symbols) {
+				switch (symbol.Type) {
+				case SymbolType.Function:
+				case SymbolType.Field:
+					sb.AppendLine ($"\tvalue = {symbol.Name};");
+					break;
+				case SymbolType.ObjectiveCClass:
+					sb.AppendLine ($"\tvalue = [{symbol.ObjectiveCName} class];");
+					break;
+				default:
+					throw ErrorHelper.CreateError (99, $"Internal error: invalid symbol type {symbol.Type} for {symbol.Name}. Please file a bug report with a test case (https://bugzilla.xamarin.com).");
+				}
+			}
+			sb.AppendLine ("}");
+			sb.AppendLine ();
+
+			Driver.WriteIfDifferent (reference_m, sb.ToString ());
+
+#if MTOUCH
+			foreach (var abi in GetArchitectures (AssemblyBuildTarget.StaticObject)) {
+				var arch = abi.AsArchString ();
+				var reference_o = Path.Combine (Path.GetDirectoryName (reference_m), arch, Path.GetFileNameWithoutExtension (reference_m) + ".o");
+				var compile_task = new CompileTask {
+					Target = this,
+					Abi = abi,
+					InputFile = reference_m,
+					OutputFile = reference_o,
+					SharedLibrary = false,
+					Language = "objective-c",
+				};
+				yield return compile_task;
+			}
+#else
+			return reference_m;
+#endif
 		}
 	}
 }

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -260,6 +260,18 @@ namespace Xamarin.Bundler {
 			if (single_assembly != null && !symbol.Members.Any ((v) => v.Module.Assembly == single_assembly.AssemblyDefinition))
 				return false; // nope, this symbol is not used in the assembly we're using as filter.
 
+			// If we're code-sharing, the managed linker might have found symbols
+			// that are not in any of the assemblies in the current app.
+			// This occurs because the managed linker processes all the
+			// assemblies for all the apps together, but when linking natively
+			// we're only linking with the assemblies that actually go into the app.
+			if (App.IsCodeShared && symbol.Assemblies.Count > 0) {
+				// So if this is a symbol related to any assembly, make sure
+				// at least one of those assemblies are in the current app.
+				if (!symbol.Assemblies.Any ((v) => Assemblies.Contains (v)))
+					return false;
+			}
+
 			switch (symbol.Type) {
 			case SymbolType.Field:
 				return true;

--- a/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
+++ b/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
@@ -67,10 +67,29 @@ namespace MonoTouch.Tuner
 					ProcessMethod (method);
 			}
 
+			AddRequiredObjectiveCType (type);
+		}
+
+		void AddRequiredObjectiveCType (TypeDefinition type)
+		{
 			var registerAttribute = DerivedLinkContext.StaticRegistrar?.GetRegisterAttribute (type);
-			if (registerAttribute != null && registerAttribute.IsWrapper && !DerivedLinkContext.StaticRegistrar.HasProtocolAttribute (type)) {
+			if (registerAttribute == null)
+				return;
+
+			if (!registerAttribute.IsWrapper)
+				return;
+
+			if (DerivedLinkContext.StaticRegistrar.HasProtocolAttribute (type))
+				return;
+
+			Assembly asm;
+			bool has_linkwith_attributes = false;
+			if (DerivedLinkContext.Target.Assemblies.TryGetValue (type.Module.Assembly, out asm))
+				has_linkwith_attributes = asm.HasLinkWithAttributes;
+
+			if (has_linkwith_attributes) {
 				var exportedName = DerivedLinkContext.StaticRegistrar.GetExportedTypeName (type, registerAttribute);
-				DerivedLinkContext.ObjectiveCClasses [exportedName] = type;
+				DerivedLinkContext.RequiredSymbols.AddObjectiveCClass (exportedName).AddMember (type);
 			}
 		}
 
@@ -79,7 +98,7 @@ namespace MonoTouch.Tuner
 			if (method.IsPInvokeImpl && method.HasPInvokeInfo && method.PInvokeInfo != null) {
 				var pinfo = method.PInvokeInfo;
 				if (pinfo.Module.Name == "__Internal")
-					DerivedLinkContext.GetRequiredSymbolList (pinfo.EntryPoint).Add (method);
+					DerivedLinkContext.RequiredSymbols.AddFunction (pinfo.EntryPoint).AddMember (method);
 
 				if (state != null) {
 					switch (pinfo.EntryPoint) {
@@ -101,7 +120,7 @@ namespace MonoTouch.Tuner
 				object symbol;
 				// The Field attribute may have been linked away, but we've stored it in an annotation.
 				if (property != null && Context.Annotations.GetCustomAnnotations ("ExportedFields").TryGetValue (property, out symbol)) {
-					DerivedLinkContext.GetRequiredSymbolList ((string) symbol).Add (property);
+					DerivedLinkContext.RequiredSymbols.AddField ((string) symbol).AddMember (property);
 				}
 			}
 		}

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -112,6 +112,7 @@ mmp_sources = \
 	$(TOP)/tools/common/Driver.cs \
 	$(TOP)/tools/common/Frameworks.cs \
 	$(TOP)/tools/common/StaticRegistrar.cs \
+	$(TOP)/tools/common/Symbols.cs    \
 	$(TOP)/tools/common/MachO.cs           \
 	$(TOP)/src/ObjCRuntime/Registrar.core.cs	\
 	$(TOP)/src/ObjCRuntime/Registrar.cs \

--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -130,6 +130,7 @@ namespace MonoMac.Tuner {
 			}
 			context.OutputDirectory = options.OutputDirectory;
 			context.StaticRegistrar = options.Target.StaticRegistrar;
+			context.Target = options.Target;
 			return context;
 		}
 

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -690,7 +690,6 @@ namespace Xamarin.Bundler {
 			string fx_dir = null;
 			string root_assembly = null;
 			var native_libs = new Dictionary<string, List<MethodDefinition>> ();
-			HashSet<string> internalSymbols = new HashSet<string> ();
 
 			if (registrar == RegistrarMode.Default)
 			{
@@ -824,26 +823,19 @@ namespace Xamarin.Bundler {
 						native_libs.Add (kvp.Key, kvp.Value);
 					}
 				}
-				internalSymbols.UnionWith (BuildTarget.LinkContext.RequiredSymbols.Keys);
 				Watch (string.Format ("Linking (mode: '{0}')", App.LinkMode), 1);
 			}
-			
+
 			// These must occur _after_ Linking
+			BuildTarget.CollectAllSymbols ();
 			BuildTarget.ComputeLinkerFlags ();
 			BuildTarget.GatherFrameworks ();
-
-			if (App.MarshalObjectiveCExceptions != MarshalObjectiveCExceptionMode.Disable && !App.RequiresPInvokeWrappers && BuildTarget.Is64Build) {
-				internalSymbols.Add ("xamarin_dyn_objc_msgSend");
-				internalSymbols.Add ("xamarin_dyn_objc_msgSendSuper");
-				internalSymbols.Add ("xamarin_dyn_objc_msgSend_stret");
-				internalSymbols.Add ("xamarin_dyn_objc_msgSendSuper_stret");
-			}
 
 			CopyDependencies (native_libs);
 			Watch ("Copy Dependencies", 1);
 
 			// MDK check
-			var ret = Compile (internalSymbols);
+			var ret = Compile ();
 			Watch ("Compile", 1);
 			if (ret != 0) {
 				if (ret == 1)
@@ -1184,7 +1176,7 @@ namespace Xamarin.Bundler {
 			frameworks_copied_to_bundle_dir = true;
 		}
 
-		static int Compile (IEnumerable<string> internalSymbols)
+		static int Compile ()
 		{
 			int ret = 1;
 
@@ -1317,9 +1309,26 @@ namespace Xamarin.Bundler {
 					args.Append ("-framework ").Append (f).Append (' ');
 				foreach (var f in BuildTarget.WeakFrameworks)
 					args.Append ("-weak_framework ").Append (f).Append (' ');
-				Driver.WriteIfDifferent (Path.Combine (App.Cache.Location, "exported-symbols-list"), string.Join ("\n", internalSymbols.Select ((symbol) => "_" + symbol).ToArray ()));
-				foreach (var symbol in internalSymbols)
-					args.Append ("-u _").Append (symbol).Append (' ');
+
+				var requiredSymbols = BuildTarget.GetRequiredSymbols ();
+				Driver.WriteIfDifferent (Path.Combine (App.Cache.Location, "exported-symbols-list"), string.Join ("\n", requiredSymbols.Select ((symbol) => "_" + symbol.Name).ToArray ()));
+				switch (App.SymbolMode) {
+				case SymbolMode.Ignore:
+					break;
+				case SymbolMode.Code:
+					string reference_m = Path.Combine (App.Cache.Location, "reference.m");
+					reference_m = BuildTarget.GenerateReferencingSource (reference_m, requiredSymbols);
+					if (!string.IsNullOrEmpty (reference_m))
+						args.Append (Quote (reference_m)).Append (' ');
+					break;
+				case SymbolMode.Linker:
+				case SymbolMode.Default:
+					foreach (var symbol in requiredSymbols)
+						args.Append ("-u ").Append (Quote ("_" + symbol.Name)).Append (' ');
+					break;
+				default:
+					throw ErrorHelper.CreateError (99, $"Internal error: invalid symbol mode: {App.SymbolMode}. Please file a bug report with a test case (https://bugzilla.xamarin.com).");
+				}
 
 				bool linkWithRequiresForceLoad = BuildTarget.Assemblies.Any (x => x.ForceLoad);
 				if (no_executable || linkWithRequiresForceLoad)

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -331,6 +331,9 @@
     <Compile Include="linker\MonoMac.Tuner\MacBaseProfile.cs">
       <Link>MonoMac.Tuner\MacBaseProfile.cs</Link>
     </Compile>
+    <Compile Include="..\common\Symbols.cs">
+      <Link>external\Symbols.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1816,8 +1816,8 @@ namespace Xamarin.Bundler {
 																"Native linking failed, undefined Objective-C class: {0}. The symbol '{1}' could not be found in any of the libraries or frameworks linked with your application.",
 							                                    symbol.Replace ("_OBJC_CLASS_$_", ""), symbol));
 						} else {
-							var members = target.GetMembersForSymbol (symbol.Substring (1));
-							if (members != null && members.Count > 0) {
+							var members = target.GetAllSymbols ().Find (symbol.Substring (1))?.Members;
+							if (members != null && members.Any ()) {
 								var member = members.First (); // Just report the first one.
 								// Neither P/Invokes nor fields have IL, so we can't find the source code location.
 								errors.Add (new MonoTouchException (5214, error,
@@ -2033,7 +2033,7 @@ namespace Xamarin.Bundler {
 			Driver.Watch ("Linking DWARF symbols", 1);
 		}
 
-		IEnumerable<string> GetRequiredSymbols ()
+		IEnumerable<Symbol> GetRequiredSymbols ()
 		{
 			foreach (var target in Targets) {
 				foreach (var symbol in target.GetRequiredSymbols ())
@@ -2043,10 +2043,10 @@ namespace Xamarin.Bundler {
 
 		bool WriteSymbolList (string filename)
 		{
-			var required_symbols = GetRequiredSymbols ().ToArray ();
+			var required_symbols = GetRequiredSymbols ();
 			using (StreamWriter writer = new StreamWriter (filename)) {
-				foreach (string symbol in required_symbols)
-					writer.WriteLine ("_{0}", symbol);
+				foreach (var symbol in required_symbols)
+					writer.WriteLine ("_{0}", symbol.Name);
 				foreach (var symbol in NoSymbolStrip)
 					writer.WriteLine ("_{0}", symbol);
 				writer.Flush ();

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -110,6 +110,7 @@ MTOUCH_SOURCES = \
 	$(TOP)/tools/common/Driver.cs		\
 	$(TOP)/tools/common/Frameworks.cs	\
 	$(TOP)/tools/common/MachO.cs		\
+	$(TOP)/tools/common/Symbols.cs			\
 	mtouch.cs		\
 	$(TOP)/tools/common/PInvokeWrapperGenerator.cs	\
 	$(TOP)/tools/common/TargetFramework.cs	\

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -135,7 +135,7 @@ namespace MonoTouch.Tuner {
 			context.OutputDirectory = options.OutputDirectory;
 			context.SetParameter ("debug-build", options.DebugBuild.ToString ());
 			context.StaticRegistrar = options.Target.StaticRegistrar;
-
+			context.Target = options.Target;
 			options.LinkContext = context;
 
 			return context;

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -333,6 +333,9 @@
       <Link>common\BuildTasks.cs</Link>
     </Compile>
     <Compile Include="BuildTasks.mtouch.cs" />
+    <Compile Include="..\common\Symbols.cs">
+      <Link>external\Symbols.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Core" />


### PR DESCRIPTION
* Refactor required symbol collection to store more information about each
  symbol (field, function, Objective-C class), and in general make the code
  more straight forward.
* Implement support for generating source code that references these symbols,
  and do this whenever we can't ask the native linker to keep these symbols
  (when using bitcode). Additionally make it possible to do this manually, so
  that the source code can be generated for non-bitcode platforms too (which
  is useful if the number of symbols is enormous, in which case we might
  surpass the maximum command-line length).
* Also make it possible to completely ignore native symbols, or ignore them on
  a per-symbol basis. This provides a fallback for users if we get something
  right and we try to preserve something that shouldn't be preserved (for
  instance if it doesn't exist), and the user ends up with unfixable linker
  errors.
* Don't collect Objective-C classes unless they're in an assembly with
  LinkWith attributes. We don't need to preserve Objective-C classes in any
  other circumstances.
* Implement everything for both Xamarin.iOS and Xamarin.Mac, and share the
  code between them.
* Remove previous workaround for bug #51710, since it's no longer needed.
* Add tests.

https://bugzilla.xamarin.com/show_bug.cgi?id=54417
https://bugzilla.xamarin.com/show_bug.cgi?id=51710