### PR TITLE
[mtouch] Set the force flag again when the cache is invalid. Fixes #54973.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -137,6 +137,7 @@ namespace Xamarin
 				mtouch.Abi = abi;
 				mtouch.Debug = debug;
 				mtouch.TargetVer = "6.0";
+				mtouch.NoStrip = true;
 				DateTime dt = DateTime.MinValue;
 
 				mtouch.DSym = false; // we don't need the dSYMs for this test, so disable them to speed up the test.
@@ -167,6 +168,15 @@ namespace Xamarin
 				mtouch.AssertExecute (MTouchAction.BuildDev, "third build");
 				Console.WriteLine ("third build done");
 				mtouch.AssertNoneModified (dt, name + " - third build", "testApp", "testApp.exe", "testApp.aotdata.armv7", "testApp.aotdata.arm64");
+
+				// Test that a complete rebuild occurs when command-line options changes
+				dt = DateTime.Now;
+				System.Threading.Thread.Sleep (1000); // make sure all new timestamps are at least a second older.
+
+				mtouch.GccFlags = "-v";
+				mtouch.AssertExecute (MTouchAction.BuildDev, "fourth build");
+				Console.WriteLine ("fourth build done");
+				mtouch.AssertAllModified (dt, name + " - fourth build", "NOTICE");
 			}
 		}
 

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -806,6 +806,10 @@ namespace Xamarin.Bundler {
 
 			// Something's not valid anymore, so clean everything.
 			Cache.Clean ();
+			// Make sure everything is rebuilt no matter what, the cache is not
+			// the only location taken into account when determing if something
+			// needs to be rebuilt.
+			Driver.Force = true;
 			AppExtensions.ForEach ((v) => v.Cache.Clean ());
 		}
 


### PR DESCRIPTION
In 11390f119ce745f9d4d2e8362c4befae98cc2a44 we stopped setting the force flag
when the cache was invalid, because we'd delete the cache anyway, and it was
determined that deleting the cache was enough.

Unfortunately it's not, because some output is not in the cache, and might not
get correctly updated.

Scenario:

* User builds app.
* User changes some build option (for instance switching off incremental
  builds).
* User does an insignificant change in a source file for the executable
  process.
* User builds app again (without cleaning). This will rebuild the exe, but
  since the change was insignificant, all the IL, except the MVID, would
  remain identical.
* mtouch would see that the command-line options changed, and invalidate the
  cache. This would delete the cache, and everything would be rebuilt,
  including AOT-compiling the assemblies again.
* When the time came for mtouch to copy assemblies to the app directory,
  mtouch would realize that the existing .exe in the app (which was not
  deleted because it's not in the cache, but the actual output directory) was
  only insignificantly different (only the MVID was different, which our cache
  logic knows to ignore when comparing assemblies), so it wouldn't copy the
  .exe to the .app.
* At runtime we'd assert, because the MVID in the aot-compiled code was
  different from the MVID in the assembly:

      error: Failed to load AOT module '(null)' while running in aot-only mode: doesn't match assembly.

* The exact assert varies depending on which build option changed. Other
  variations:

      Failed to load AOT module '(null)' while running in aot-only mode: compiled against GC (4, while the current runtime uses GC sgen)

      * Assertion at /Users/builder/data/lanes/4691/0719ced1/source/xamarin-macios/external/mono/mono/metadata/metadata.c:1118, condition `idx < t->rows' not met

Because of this I'm reverting 11390f119ce745f9d4d2e8362c4befae98cc2a44, and
once again setting the force flag when the cache is invalid. It might be
overkill, but it's the safest option (cache invalidation is after all the only
hard problem in computer science), and bugs are very annoying and
timeconsuming to track down.

https://bugzilla.xamarin.com/show_bug.cgi?id=54973