### PR TITLE
[generator] Improve error reporting for api definition that uses the deprecated availability attributes. Fixes #57070.

### DIFF
--- a/docs/website/generator-errors.md
+++ b/docs/website/generator-errors.md
@@ -167,6 +167,8 @@ This usually indicates a bug in Xamarin.iOS/Xamarin.Mac; please [file a bug repo
 
 <h3><a name='BI1060'/>BI1060: The * protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].</h3>
 
+<h3><a name='BI1061'/>BI1061: The attribute '{attribute}' found on '{member}' is not a valid binding attribute. Please remove this attribute.</h3>
+
 # BI11xx: warnings
 
 <!-- 11xx: warnings -->

--- a/src/generator-ikvm.csproj.in
+++ b/src/generator-ikvm.csproj.in
@@ -98,6 +98,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
+    <None Include="..\docs\website\generator-errors.md">
+      <Link>generator-errors.md</Link>
+    </None>
     <!--%IKVM_FILES%-->
     <!--%FILES%-->
   </ItemGroup>

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -7117,4 +7117,16 @@ public partial class Generator : IMemberGatherer {
 
 		return $"@\"{s.Replace ("\"", "\"\"")}\"";
 	}
+
+	// Format a provider for error messages
+	public static string FormatProvider (ICustomAttributeProvider provider)
+	{
+		if (provider is Type type) {
+			return type.FullName;
+		} else if (provider is MemberInfo mi) {
+			return mi.DeclaringType.FullName + "." + mi.Name;
+		} else {
+			return provider?.ToString ();
+		}
+	}
 }

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -21,7 +21,7 @@ else
 IOS_GENERATOR = $(IOS_CURRENT_DIR)/bin/btouch-native /baselib:$(IOS_CURRENT_DIR)/lib/mono/Xamarin.iOS/Xamarin.iOS.dll /unsafe
 endif
 IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts bug43579 bindastests
-IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers bug42742 warnaserror nowarn noasyncinternalwrapper noasyncwarningcs0219 bug53076 bug53076withmodel
+IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers bug42742 warnaserror nowarn noasyncinternalwrapper noasyncwarningcs0219 bug53076 bug53076withmodel bug57070
 
 MAC_CURRENT_DIR=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
 ifdef IKVM
@@ -80,6 +80,7 @@ $(eval $(call iOSErrorCodeTestTemplate,bindas1050modelerror,1050))
 $(eval $(call iOSErrorCodeTestTemplate,bindas1050protocolerror,1050))
 $(eval $(call iOSErrorCodeTestTemplate,bug42855,1060))
 $(eval $(call iOSErrorCodeTestTemplate,bug52570,1117))
+$(eval $(call iOSErrorCodeTestTemplate,bug57070,1061))
 
 define iOSNoErrorCodesTestTemplate
 $(1):

--- a/tests/generator/bug57070.cs
+++ b/tests/generator/bug57070.cs
@@ -1,0 +1,10 @@
+using Foundation;
+using ObjCRuntime;
+
+[BaseType (typeof(NSObject))]
+interface SomeClass
+{
+	[iOS (10,0)]
+	[Export ("doSomething")]
+	void DoSomething ();
+}


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=57070