### PR TITLE
bump max visual studio version to latest alpha

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -60,7 +60,7 @@ MIN_MONO_URL=https://bosstoragemirror.blob.core.windows.net/wrench/mono-2017-04/
 # Minimum Visual Studio version
 MIN_VISUAL_STUDIO_URL=https://bosstoragemirror.blob.core.windows.net/wrench/monodevelop-lion-dogfood-vNext/8f/8f1c13cb983138ee63bd53e09908ea5e737988cd/VisualStudioForMac-Preview-7.0.0.2728.dmg
 MIN_VISUAL_STUDIO_VERSION=7.0.0.2728
-MAX_VISUAL_STUDIO_VERSION=7.0.99
+MAX_VISUAL_STUDIO_VERSION=7.1.0.583
 
 # Minimum CMake version
 MIN_CMAKE_URL=https://cmake.org/files/v3.6/cmake-3.6.2-Darwin-x86_64.dmg


### PR DESCRIPTION
I increased the allowed visual studio version, and I added a fix that also prevents a null exception from attempting to be read during build error generation.