### PR TITLE
[xharness] Fix iterating over no simulators.

### DIFF
--- a/tests/xharness/Simulators.cs
+++ b/tests/xharness/Simulators.cs
@@ -285,7 +285,7 @@ namespace xharness
 					if (devices == null)
 						devices = Enumerable.Simulators.FindAsync (Enumerable.Target, Enumerable.Log).Result;
 					moved = true;
-					return moved;
+					return devices != null;
 				}
 
 				public void Reset ()


### PR DESCRIPTION
Fixes an issue where xharness would try to run tests on a 32-bit simulator,
which does not exist on iOS 11.