### PR TITLE
[runtime] set mono_set_crash_chaining

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -519,6 +519,10 @@
 			"mono_bool", "chain_signals"
 		),
 
+		new Export ("void", "mono_set_crash_chaining",
+			"mono_bool", "chain_signals"
+		),
+
 		new Export ("void", "mono_jit_set_trace_options",
 			"const char *", "option"
 		),

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -414,6 +414,7 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 #endif
 
 	mono_set_signal_chaining (TRUE);
+	mono_set_crash_chaining (TRUE);
 	mono_install_unhandled_exception_hook (xamarin_unhandled_exception_handler, NULL);
 	mono_install_ftnptr_eh_callback (xamarin_ftnptr_exception_handler);
 


### PR DESCRIPTION
it was introduced a while ago for Xamarin-Android:

https://github.com/mono/mono/commit/8ffc4070a94c5c3ef73b99e836e1b1e5652dffba

https://github.com/xamarin/xamarin-android/blob/8d7cc2b8000f8d1b0329561d368c4611fa2f9279/src/monodroid/jni/monodroid-glue.c#L2840

it potentially helps to get even better crash reports.