### PR TITLE
[tests] Allow monotouch-tests and introspection to run with Xcode 9 Beta 1

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -89,6 +89,23 @@ partial class TestRuntime
 	public static bool CheckXcodeVersion (int major, int minor, int build = 0)
 	{
 		switch (major) {
+		case 9:
+			switch (minor) {
+			case 0:
+#if __WATCHOS__
+				return CheckWatchOSSystemVersion (4, 0);
+#elif __TVOS__
+				return ChecktvOSSystemVersion (11, 0);
+#elif __IOS__
+				return CheckiOSSystemVersion (11, 0);
+#elif MONOMAC
+				return CheckMacSystemVersion (10, 13, 0);
+#else
+				throw new NotImplementedException ();
+#endif
+			default:
+				throw new NotImplementedException ();
+			}
 		case 8:
 			switch (minor) {
 			case 0:

--- a/tests/introspection/iOS/iOSApiCtorInitTest.cs
+++ b/tests/introspection/iOS/iOSApiCtorInitTest.cs
@@ -322,6 +322,12 @@ namespace Introspection {
 				if (TestRuntime.CheckXcodeVersion (8, 0))
 					return;
 				break;
+			// Xcode 9 Beta 1 to avoid crashes
+			case "AVCaptureInputPort":
+			case "CIImageAccumulator":
+				if (TestRuntime.CheckXcodeVersion (9, 0))
+					return;
+				break;
 			default:
 				base.CheckToString (obj);
 				break;

--- a/tests/monotouch-test/Foundation/BundleTest.cs
+++ b/tests/monotouch-test/Foundation/BundleTest.cs
@@ -82,6 +82,7 @@ namespace MonoTouchFixtures.Foundation {
 		
 		// http://developer.apple.com/library/ios/#documentation/uikit/reference/NSBundle_UIKitAdditions/Introduction/Introduction.html
 		
+#if false // Disabling for now due to Xcode 9 does not support nibs if deployment target == 6.0
 #if !__WATCHOS__
 		[Test]
 		public void LoadNibWithOptions ()
@@ -94,6 +95,7 @@ namespace MonoTouchFixtures.Foundation {
 #endif
 		}
 #endif // !__WATCHOS__
+#endif
 
 #if false
 		// some selectors are only in AppKit but we included them in MonoTouch (and this match Apple documentation)

--- a/tests/monotouch-test/Foundation/CalendarTest.cs
+++ b/tests/monotouch-test/Foundation/CalendarTest.cs
@@ -338,9 +338,10 @@ namespace MonoTouchFixtures.Foundation {
 			NSDateComponents nextYearComponent = NSCalendar.CurrentCalendar.Components (NSCalendarUnit.Day | NSCalendarUnit.Month | NSCalendarUnit.Year, NSDate.Now);
 			nextYearComponent.Year++;
 			bool delegateHit = false;
-			NSCalendar.CurrentCalendar.EnumerateDatesStartingAfterDate(NSDate.Now, nextYearComponent, NSCalendarOptions.MatchNextTime, (NSDate d, bool exactMatch, ref bool s) => 
+			NSCalendar.CurrentCalendar.EnumerateDatesStartingAfterDate(NSDate.Now, nextYearComponent, NSCalendarOptions.MatchNextTime, (NSDate d, bool exactMatch, ref bool stop) => 
 				{
 					delegateHit = true;
+					stop = true;
 				});
 			Assert.IsTrue (delegateHit, "EnumerateDatesStartingAfterDate delegate called");
 		}

--- a/tests/monotouch-test/UIKit/NibTest.cs
+++ b/tests/monotouch-test/UIKit/NibTest.cs
@@ -39,6 +39,7 @@ namespace MonoTouchFixtures.UIKit {
 			}
 		}
 
+#if false // Disabling for now due to Xcode 9 does not support nibs if deployment target == 6.0
 		[Test]
 		public void FromName ()
 		{
@@ -71,6 +72,7 @@ namespace MonoTouchFixtures.UIKit {
 				Assert.That (result2.Length, Is.EqualTo (0), "Instantiate");
 			}
 		}
+#endif
 	}
 }
 

--- a/tests/monotouch-test/UIKit/TabBarControllerTest.cs
+++ b/tests/monotouch-test/UIKit/TabBarControllerTest.cs
@@ -57,6 +57,7 @@ namespace MonoTouchFixtures.UIKit {
 			}
 		}
 
+#if false // Disabling for now due to Xcode 9 does not support nibs if deployment target == 6.0
 		[Test]
 		public void Ctor_Nib ()
 		{
@@ -66,6 +67,7 @@ namespace MonoTouchFixtures.UIKit {
 				CheckDefault (c);
 			}
 		}
+#endif
 	}
 }
 

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -156,6 +156,7 @@
     </None>
     <None Include="Entitlements.plist" />
     <None Include="app.config" />
+    <None Include="EmptyNib.xib" Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />
@@ -727,7 +728,6 @@
     <Content Include="drum01.mp3" />
   </ItemGroup>
   <ItemGroup>
-    <InterfaceDefinition Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" Include="EmptyNib.xib" />
     <InterfaceDefinition Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" Include="LaunchScreen.storyboard" />
   </ItemGroup>
   <ItemGroup>
@@ -753,7 +753,6 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Security\openssl_crt.der">
-        <LogicalName>monotouchtest.Security.openssl_crt.der</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -753,6 +753,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Security\openssl_crt.der">
+        <LogicalName>monotouchtest.Security.openssl_crt.der</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Remove EmptyNib.xib : ibtool error : Compiling IB documents for earlier than iOS 7 is no longer supported.
- It seems that NSCalendar.CurrentCalendar.EnumerateDatesStartingAfterDate won't stop enumerating unless `stop` is set to `true`.
- Add CheckXcodeVersion support for Xcode 9
- Avoid introspection to crash with Xcode 9 Beta 1