### PR TITLE
[arkit] Update for iOS 11 beta 1 (new framework)

### DIFF
--- a/runtime/bindings-generator.cs
+++ b/runtime/bindings-generator.cs
@@ -1867,6 +1867,21 @@ namespace Xamarin.BindingMethods.Generator
 
 			data.Add (
 				new FunctionData {
+					Comment = " // Matrix4 func (CGSize, int, nfloat, nfloat)",
+					Prefix = "simd__",
+					Variants = Variants.All,
+					ReturnType = Types.Matrix4f,
+					Parameters = new ParameterData[] {
+						new ParameterData { TypeData = Types.CGSize },
+						new ParameterData { TypeData = Types.Int32 },
+						new ParameterData { TypeData = Types.NFloat },
+						new ParameterData { TypeData = Types.NFloat },
+					},
+				}
+			);
+
+			data.Add (
+				new FunctionData {
 					Comment = " // Matrix4 func (CGSize, Int64, nfloat, nfloat)",
 					Prefix = "simd__",
 					Variants = Variants.All,

--- a/runtime/bindings-generator.cs
+++ b/runtime/bindings-generator.cs
@@ -35,6 +35,7 @@ namespace Xamarin.BindingMethods.Generator
 				writer.WriteLine ("/* This file is generated */");
 				writer.WriteLine ();
 				writer.WriteLine ("#include \"bindings.h\"");
+				writer.WriteLine ("#include <CoreGraphics/CoreGraphics.h>");
 				writer.WriteLine ();
 				writer.WriteLine ("#ifdef __cplusplus");
 				writer.WriteLine ("extern \"C\" {");
@@ -1862,6 +1863,23 @@ namespace Xamarin.BindingMethods.Generator
 				}
 			);
 
+			// Required for ARKit
+
+			data.Add (
+				new FunctionData {
+					Comment = " // Matrix4 func (CGSize, Int64, nfloat, nfloat)",
+					Prefix = "simd__",
+					Variants = Variants.All,
+					ReturnType = Types.Matrix4f,
+					Parameters = new ParameterData[] {
+						new ParameterData { TypeData = Types.CGSize },
+						new ParameterData { TypeData = Types.Int64 },
+						new ParameterData { TypeData = Types.NFloat },
+						new ParameterData { TypeData = Types.NFloat },
+					},
+				}
+			);
+
 			// We must expand functions with native types to their actual type as well.
 			for (int i = data.Count - 1; i >= 0; i--) {
 				if (!data [i].HasNativeType)
@@ -2617,6 +2635,13 @@ namespace Xamarin.BindingMethods.Generator
 				IsARMStret = true,
 				IsX86Stret = true,
 				IsX64Stret = true,
+			};
+
+			public static TypeData CGSize = new TypeData {
+				ManagedType = "CGSize",
+				NativeType = "CGSize",
+				NativeWrapperType = "CGSize",
+				RequireMarshal = false,
 			};
 		}
 	}

--- a/src/ARKit/ARPointCloud.cs
+++ b/src/ARKit/ARPointCloud.cs
@@ -1,0 +1,28 @@
+//
+// ARPointCloud.cs: Nicer code for ARPointCloud
+//
+// Authors:
+//	Vincent Dondain  <vidondai@microsoft.com>
+//
+// Copyright 2017 Microsoft Inc. All rights reserved.
+//
+
+using System;
+using System.Runtime.InteropServices;
+using Vector3 = global::OpenTK.Vector3;
+
+namespace XamCore.ARKit {
+	public partial class ARPointCloud {
+
+		public Vector3 [] Points {
+			get {
+				var count = (int)Count;
+				var rv = new Vector3 [count];
+				var ptr = (Vector3*)_GetPoints ();
+				for (int i = 0; i < count; i++)
+					rv [i] = *ptr++;
+				return rv;
+			}
+		}
+	}
+}

--- a/src/ARKit/ARPointCloud.cs
+++ b/src/ARKit/ARPointCloud.cs
@@ -7,6 +7,8 @@
 // Copyright 2017 Microsoft Inc. All rights reserved.
 //
 
+#if XAMCORE_2_0
+
 using System;
 using System.Runtime.InteropServices;
 using Vector3 = global::OpenTK.Vector3;
@@ -26,3 +28,5 @@ namespace XamCore.ARKit {
 		}
 	}
 }
+
+#endif

--- a/src/Constants.iOS.cs.in
+++ b/src/Constants.iOS.cs.in
@@ -106,6 +106,7 @@ namespace MonoTouch {
 		public const string IntentsLibrary = "/System/Library/Frameworks/Intents.framework/Intents";
 		public const string IntentsUILibrary = "/System/Library/Frameworks/IntentsUI.framework/IntentsUI";
 		// iOS 11.0
+		public const string ARKitLibrary = "/System/Library/Frameworks/ARKit.framework/ARKit";
 		public const string CoreNFCLibrary = "/System/Library/Frameworks/CoreNFC.framework/CoreNFC";
 	}
 }

--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -397,8 +397,7 @@ namespace XamCore.ARKit {
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
-	[Protocol, Model]
-	[BaseType (typeof (NSObject))]
+	[Protocol]
 	interface ARSessionObserver {
 
 		[Export ("session:didFailWithError:")]

--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -1,0 +1,493 @@
+//
+// ARKit bindings
+//
+// Authors:
+//	Vincent Dondain  <vidondai@microsoft.com>
+//
+// Copyright 2017 Microsoft Inc. All rights reserved.
+//
+
+// #if XAMCORE_2_0
+
+using System;
+using XamCore.CoreFoundation;
+using XamCore.CoreGraphics;
+using XamCore.CoreVideo;
+using XamCore.Foundation;
+using XamCore.ObjCRuntime;
+using XamCore.SpriteKit;
+using XamCore.SceneKit;
+using XamCore.UIKit;
+
+using Vector3 = global::OpenTK.Vector3;
+using Matrix3 = global::OpenTK.Matrix3;
+using Matrix4 = global::OpenTK.Matrix4;
+
+namespace XamCore.ARKit {
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[Native]
+	public enum ARTrackingState : nint
+	{
+		NotAvailable,
+		Limited,
+		Normal,
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[Native]
+	public enum ARTrackingStateReason : nint
+	{
+		None,
+		ExcessiveMotion,
+		InsufficientFeatures,
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[ErrorDomain ("ARErrorDomain")]
+	[Native]
+	public enum ARErrorCode : nint
+	{
+		UnsupportedConfiguration = 100,
+		SensorUnavailable = 101,
+		SensorFailed = 102,
+		WorldTrackingFailed = 200,
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[Native]
+	public enum ARHitTestResultType : nuint
+	{
+		FeaturePoint = 1 << 0,
+		EstimatedHorizontalPlane = 1 << 1,
+		ExistingPlane = 1 << 3,
+		ExistingPlaneUsingExtent = 1 << 4,
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[Native]
+	public enum ARPlaneAnchorAlignment : nint
+	{
+		Horizontal,
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[Native]
+	public enum ARSessionRunOptions : nuint
+	{
+		ResetTracking = 1 << 0,
+		RemoveExistingAnchors = 1 << 1,
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[Native]
+	public enum ARWorldAlignment : nint
+	{
+		Gravity,
+		GravityAndHeading,
+		Camera,
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[Native]
+	public enum ARPlaneDetection : nuint
+	{
+		None = 0,
+		Horizontal = 1 << 0,
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[BaseType (typeof(NSObject))]
+	[DisableDefaultCtor]
+	interface ARAnchor : NSCopying
+	{
+		[NullAllowed, Export ("identifier")]
+		NSUuid Identifier { get; }
+
+		[Export ("transform")]
+		Matrix4 Transform {
+			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+			get;
+		}
+
+		[Export ("initWithTransform:")]
+		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+		IntPtr Constructor (Matrix4 transform);
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[BaseType (typeof(NSObject))]
+	[DisableDefaultCtor]
+	interface ARCamera : NSCopying
+	{
+		[Export ("transform")]
+		Matrix4 Transform {
+			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+			get;
+		}
+
+		[Export ("eulerAngles")]
+		Vector3 EulerAngles {
+			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+			get;
+		}
+
+		[Export ("trackingState")]
+		ARTrackingState TrackingState { get; }
+
+		[Export ("trackingStateReason")]
+		ARTrackingStateReason TrackingStateReason { get; }
+
+		[Export ("intrinsics")]
+		Matrix3 Intrinsics {
+			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+			get;
+		}
+
+		[Export ("imageResolution")]
+		CGSize ImageResolution { get; }
+
+		[Export ("projectionMatrix")]
+		Matrix4 ProjectionMatrix {
+			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+			get;
+		}
+
+		[Export ("projectionMatrixWithViewportSize:orientation:zNear:zFar:")]
+		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+		Matrix4 GetProjectionMatrix (CGSize viewportSize, UIInterfaceOrientation orientation, nfloat zNear, nfloat zFar);
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[BaseType (typeof(NSObject))]
+	[DisableDefaultCtor]
+	interface ARFrame : NSCopying
+	{
+		[Export ("timestamp")]
+		double Timestamp { get; }
+
+		[Export ("capturedImage")]
+		CVPixelBuffer CapturedImage { get; }
+
+		[Export ("camera", ArgumentSemantic.Copy)]
+		ARCamera Camera { get; }
+
+		[Export ("anchors", ArgumentSemantic.Copy)]
+		ARAnchor[] Anchors { get; }
+
+		[NullAllowed, Export ("lightEstimate", ArgumentSemantic.Copy)]
+		ARLightEstimate LightEstimate { get; }
+
+		[NullAllowed, Export ("rawFeaturePoints")]
+		ARPointCloud RawFeaturePoints { get; }
+
+		[Export ("hitTest:types:")]
+		ARHitTestResult[] HitTest (CGPoint point, ARHitTestResultType types);
+
+		[Export ("displayTransformWithViewportSize:orientation:")]
+		CGAffineTransform DisplayTransform (CGSize viewportSize, UIInterfaceOrientation orientation);
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[BaseType (typeof(NSObject))]
+	[DisableDefaultCtor]
+	interface ARHitTestResult
+	{
+		[Export ("type")]
+		ARHitTestResultType Type { get; }
+
+		[Export ("distance")]
+		nfloat Distance { get; }
+
+		[Export ("localTransform")]
+		Matrix4 LocalTransform {
+			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+			get;
+		}
+
+		[Export ("worldTransform")]
+		Matrix4 WorldTransform {
+			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+			get;
+		}
+
+		[NullAllowed, Export ("anchor", ArgumentSemantic.Strong)]
+		ARAnchor Anchor { get; }
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[BaseType (typeof(NSObject))]
+	[DisableDefaultCtor]
+	interface ARLightEstimate : NSCopying
+	{
+		[Export ("ambientIntensity")]
+		nfloat AmbientIntensity { get; }
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[BaseType (typeof(ARAnchor))]
+	interface ARPlaneAnchor
+	{
+		// [Export ("initWithTransform:")] marked as NS_UNAVAILABLE
+
+		[Export ("alignment")]
+		ARPlaneAnchorAlignment Alignment { get; }
+
+		[Export ("center")]
+		Vector3 Center { get; }
+
+		[Export ("extent")]
+		Vector3 Extent { get; }
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[BaseType (typeof(NSObject))]
+	[DisableDefaultCtor]
+	interface ARPointCloud : NSCopying
+	{
+		[Export ("count")]
+		nuint Count { get; }
+
+		[Export ("points")]
+		IntPtr Points { get; }
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[BaseType (typeof(SCNView))]
+	interface ARSCNView
+	{
+		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
+		IARSCNViewDelegate Delegate { get; set; }
+
+		[Export ("session", ArgumentSemantic.Strong)]
+		ARSession Session { get; set; }
+
+		[Export ("scene", ArgumentSemantic.Strong)]
+		SCNScene Scene { get; set; }
+
+		[Export ("automaticallyUpdatesLighting")]
+		bool AutomaticallyUpdatesLighting { get; set; }
+
+		[Export ("anchorForNode:")]
+		[return: NullAllowed]
+		ARAnchor GetAnchor (SCNNode node);
+
+		[Export ("nodeForAnchor:")]
+		[return: NullAllowed]
+		SCNNode GetNode (ARAnchor anchor);
+
+		[Export ("hitTest:types:")]
+		ARHitTestResult[] HitTest (CGPoint point, ARHitTestResultType types);
+	}
+
+	interface IARSCNViewDelegate {}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[Protocol, Model]
+	[BaseType (typeof(NSObject))]
+	interface ARSCNViewDelegate : SCNSceneRendererDelegate, ARSessionObserver
+	{
+		[Export ("renderer:nodeForAnchor:")]
+		[return: NullAllowed]
+		SCNNode GetNode (ISCNSceneRenderer renderer, ARAnchor anchor);
+
+		[Export ("renderer:didAddNode:forAnchor:")]
+		void DidAddNode (ISCNSceneRenderer renderer, SCNNode node, ARAnchor anchor);
+
+		[Export ("renderer:willUpdateNode:forAnchor:")]
+		void WillUpdateNode (ISCNSceneRenderer renderer, SCNNode node, ARAnchor anchor);
+
+		[Export ("renderer:didUpdateNode:forAnchor:")]
+		void DidUpdateNode (ISCNSceneRenderer renderer, SCNNode node, ARAnchor anchor);
+
+		[Export ("renderer:didRemoveNode:forAnchor:")]
+		void DidRemoveNode (ISCNSceneRenderer renderer, SCNNode node, ARAnchor anchor);
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[BaseType (typeof(SKView))]
+	interface ARSKView
+	{
+		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
+		IARSKViewDelegate Delegate { get; set; }
+
+		[Export ("session", ArgumentSemantic.Strong)]
+		ARSession Session { get; set; }
+
+		[Export ("anchorForNode:")]
+		[return: NullAllowed]
+		ARAnchor GetAnchor (SKNode node);
+
+		[Export ("nodeForAnchor:")]
+		[return: NullAllowed]
+		SKNode GetNode (ARAnchor anchor);
+
+		[Export ("hitTest:types:")]
+		ARHitTestResult[] HitTest (CGPoint point, ARHitTestResultType types);
+	}
+
+	interface IARSKViewDelegate {}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[Protocol, Model]
+	[BaseType (typeof(NSObject))]
+	interface ARSKViewDelegate : SKViewDelegate, ARSessionObserver
+	{
+		[Export ("view:nodeForAnchor:")]
+		[return: NullAllowed]
+		SKNode GetNode (ARSKView view, ARAnchor anchor);
+
+		[Export ("view:didAddNode:forAnchor:")]
+		void DidAddNode (ARSKView view, SKNode node, ARAnchor anchor);
+
+		[Export ("view:willUpdateNode:forAnchor:")]
+		void WillUpdateNode (ARSKView view, SKNode node, ARAnchor anchor);
+
+		[Export ("view:didUpdateNode:forAnchor:")]
+		void DidUpdateNode (ARSKView view, SKNode node, ARAnchor anchor);
+
+		[Export ("view:didRemoveNode:forAnchor:")]
+		void DidRemoveNode (ARSKView view, SKNode node, ARAnchor anchor);
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[BaseType (typeof(NSObject))]
+	interface ARSession
+	{
+		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
+		IARSessionDelegate Delegate { get; set; }
+
+		[NullAllowed, Export ("delegateQueue", ArgumentSemantic.Strong)]
+		DispatchQueue DelegateQueue { get; set; }
+
+		[NullAllowed, Export ("currentFrame", ArgumentSemantic.Copy)]
+		ARFrame CurrentFrame { get; }
+
+		[NullAllowed, Export ("configuration", ArgumentSemantic.Copy)]
+		ARSessionConfiguration Configuration { get; }
+
+		[Export ("runWithConfiguration:")]
+		void Run (ARSessionConfiguration configuration);
+
+		[Export ("runWithConfiguration:options:")]
+		void Run (ARSessionConfiguration configuration, ARSessionRunOptions options);
+
+		[Export ("pause")]
+		void Pause ();
+
+		[Export ("addAnchor:")]
+		void AddAnchor (ARAnchor anchor);
+
+		[Export ("removeAnchor:")]
+		void RemoveAnchor (ARAnchor anchor);
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[Protocol]
+	[BaseType (typeof(NSObject))]
+	interface ARSessionObserver
+	{
+		[Export ("session:didFailWithError:")]
+		void DidFail (ARSession session, NSError error);
+
+		[Export ("session:cameraDidChangeTrackingState:")]
+		void CameraDidChangeTrackingState (ARSession session, ARCamera camera);
+
+		[Export ("sessionWasInterrupted:")]
+		void SessionWasInterrupted (ARSession session);
+
+		[Export ("sessionInterruptionEnded:")]
+		void SessionInterruptionEnded (ARSession session);
+	}
+
+	interface IARSessionDelegate {}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[Protocol, Model]
+	[BaseType (typeof(NSObject))]
+	interface ARSessionDelegate : ARSessionObserver
+	{
+		[Export ("session:didUpdateFrame:")]
+		void DidUpdateFrame (ARSession session, ARFrame frame);
+
+		[Export ("session:didAddAnchors:")]
+		void DidAddAnchors (ARSession session, ARAnchor[] anchors);
+
+		[Export ("session:didUpdateAnchors:")]
+		void DidUpdateAnchors (ARSession session, ARAnchor[] anchors);
+
+		[Export ("session:didRemoveAnchors:")]
+		void DidRemoveAnchors (ARSession session, ARAnchor[] anchors);
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[BaseType (typeof(NSObject))]
+	interface ARSessionConfiguration : NSCopying
+	{
+		[Static]
+		[Export ("isSupported")]
+		bool IsSupported { get; }
+
+		[Export ("worldAlignment", ArgumentSemantic.Assign)]
+		ARWorldAlignment WorldAlignment { get; set; }
+
+		[Export ("lightEstimationEnabled")]
+		bool LightEstimationEnabled { [Bind ("isLightEstimationEnabled")] get; set; }
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[BaseType (typeof(ARSessionConfiguration))]
+	interface ARWorldTrackingSessionConfiguration
+	{
+		[Export ("planeDetection", ArgumentSemantic.Assign)]
+		ARPlaneDetection PlaneDetection { get; set; }
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[Static]
+	interface ARSCNDebugOptions
+	{
+		[Internal]
+		[Field ("ARSCNDebugOptionShowWorldOrigin")]
+		int _ARSCNDebugOptionShowWorldOrigin { get; }
+
+		[Static]
+		[Wrap ("(SCNDebugOptions)_ARSCNDebugOptionShowWorldOrigin")]
+		SCNDebugOptions ShowWorldOrigin { get; }
+
+		[Internal]
+		[Field ("ARSCNDebugOptionShowFeaturePoints")]
+		int _ARSCNDebugOptionShowFeaturePoints { get; }
+
+		[Static]
+		[Wrap ("(SCNDebugOptions)_ARSCNDebugOptionShowFeaturePoints")]
+		SCNDebugOptions ShowFeaturePoints { get; }
+	}
+}
+
+// #endif // XAMCORE_2_0

--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -7,7 +7,7 @@
 // Copyright 2017 Microsoft Inc. All rights reserved.
 //
 
-// #if XAMCORE_2_0
+#if XAMCORE_2_0
 
 using System;
 using XamCore.CoreFoundation;
@@ -464,26 +464,12 @@ namespace XamCore.ARKit {
 	[Static]
 	interface ARSCNDebugOptions {
 
-		[Internal]
 		[Field ("ARSCNDebugOptionShowWorldOrigin")]
-		// FIXME: Could be using [BindAs (typeof (SCNDebugOptions))]: https://bugzilla.xamarin.com/show_bug.cgi?id=57537
-		// FIXME: Should be nuint: https://bugzilla.xamarin.com/show_bug.cgi?id=57535
-		int _ARSCNDebugOptionShowWorldOrigin { get; }
-
-		[Static]
-		[Wrap ("(SCNDebugOptions)_ARSCNDebugOptionShowWorldOrigin")]
 		SCNDebugOptions ShowWorldOrigin { get; }
 
-		[Internal]
-		[Field ("ARSCNDebugOptionShowFeaturePoints")]
-		// FIXME: Could be using [BindAs (typeof (SCNDebugOptions))]: https://bugzilla.xamarin.com/show_bug.cgi?id=57537
-		// FIXME: Should be nuint: https://bugzilla.xamarin.com/show_bug.cgi?id=57535
-		int _ARSCNDebugOptionShowFeaturePoints { get; }
-
-		[Static]
-		[Wrap ("(SCNDebugOptions)_ARSCNDebugOptionShowFeaturePoints")]
+		[Field ("ARSCNDebugOptionShowWorldOrigin")]
 		SCNDebugOptions ShowFeaturePoints { get; }
 	}
 }
 
-// #endif // XAMCORE_2_0
+#endif // XAMCORE_2_0

--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -28,8 +28,7 @@ namespace XamCore.ARKit {
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
 	[Native]
-	public enum ARTrackingState : nint
-	{
+	public enum ARTrackingState : nint {
 		NotAvailable,
 		Limited,
 		Normal,
@@ -38,8 +37,7 @@ namespace XamCore.ARKit {
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
 	[Native]
-	public enum ARTrackingStateReason : nint
-	{
+	public enum ARTrackingStateReason : nint {
 		None,
 		ExcessiveMotion,
 		InsufficientFeatures,
@@ -49,8 +47,7 @@ namespace XamCore.ARKit {
 	[NoWatch, NoTV, NoMac]
 	[ErrorDomain ("ARErrorDomain")]
 	[Native]
-	public enum ARErrorCode : nint
-	{
+	public enum ARErrorCode : nint {
 		UnsupportedConfiguration = 100,
 		SensorUnavailable = 101,
 		SensorFailed = 102,
@@ -60,8 +57,7 @@ namespace XamCore.ARKit {
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
 	[Native]
-	public enum ARHitTestResultType : nuint
-	{
+	public enum ARHitTestResultType : nuint {
 		FeaturePoint = 1 << 0,
 		EstimatedHorizontalPlane = 1 << 1,
 		ExistingPlane = 1 << 3,
@@ -71,16 +67,14 @@ namespace XamCore.ARKit {
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
 	[Native]
-	public enum ARPlaneAnchorAlignment : nint
-	{
+	public enum ARPlaneAnchorAlignment : nint {
 		Horizontal,
 	}
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
 	[Native]
-	public enum ARSessionRunOptions : nuint
-	{
+	public enum ARSessionRunOptions : nuint {
 		ResetTracking = 1 << 0,
 		RemoveExistingAnchors = 1 << 1,
 	}
@@ -88,8 +82,7 @@ namespace XamCore.ARKit {
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
 	[Native]
-	public enum ARWorldAlignment : nint
-	{
+	public enum ARWorldAlignment : nint {
 		Gravity,
 		GravityAndHeading,
 		Camera,
@@ -98,18 +91,17 @@ namespace XamCore.ARKit {
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
 	[Native]
-	public enum ARPlaneDetection : nuint
-	{
+	public enum ARPlaneDetection : nuint {
 		None = 0,
 		Horizontal = 1 << 0,
 	}
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
-	[BaseType (typeof(NSObject))]
+	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	interface ARAnchor : NSCopying
-	{
+	interface ARAnchor : NSCopying {
+
 		[NullAllowed, Export ("identifier")]
 		NSUuid Identifier { get; }
 
@@ -126,10 +118,10 @@ namespace XamCore.ARKit {
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
-	[BaseType (typeof(NSObject))]
+	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	interface ARCamera : NSCopying
-	{
+	interface ARCamera : NSCopying {
+
 		[Export ("transform")]
 		Matrix4 Transform {
 			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
@@ -170,10 +162,10 @@ namespace XamCore.ARKit {
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
-	[BaseType (typeof(NSObject))]
+	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	interface ARFrame : NSCopying
-	{
+	interface ARFrame : NSCopying {
+
 		[Export ("timestamp")]
 		double Timestamp { get; }
 
@@ -201,10 +193,10 @@ namespace XamCore.ARKit {
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
-	[BaseType (typeof(NSObject))]
+	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	interface ARHitTestResult
-	{
+	interface ARHitTestResult {
+
 		[Export ("type")]
 		ARHitTestResultType Type { get; }
 
@@ -229,19 +221,20 @@ namespace XamCore.ARKit {
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
-	[BaseType (typeof(NSObject))]
+	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	interface ARLightEstimate : NSCopying
-	{
+	interface ARLightEstimate : NSCopying {
+
 		[Export ("ambientIntensity")]
 		nfloat AmbientIntensity { get; }
 	}
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
-	[BaseType (typeof(ARAnchor))]
-	interface ARPlaneAnchor
-	{
+	[BaseType (typeof (ARAnchor))]
+	[DisableDefaultCtor]
+	interface ARPlaneAnchor {
+
 		// [Export ("initWithTransform:")] marked as NS_UNAVAILABLE
 
 		[Export ("alignment")]
@@ -256,22 +249,22 @@ namespace XamCore.ARKit {
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
-	[BaseType (typeof(NSObject))]
+	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	interface ARPointCloud : NSCopying
-	{
+	interface ARPointCloud : NSCopying {
+
 		[Export ("count")]
 		nuint Count { get; }
 
-		[Export ("points")]
-		IntPtr Points { get; }
+		[Internal, Export ("points")]
+		IntPtr _GetPoints ();
 	}
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
-	[BaseType (typeof(SCNView))]
-	interface ARSCNView
-	{
+	[BaseType (typeof (SCNView))]
+	interface ARSCNView {
+
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		IARSCNViewDelegate Delegate { get; set; }
 
@@ -301,9 +294,9 @@ namespace XamCore.ARKit {
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
 	[Protocol, Model]
-	[BaseType (typeof(NSObject))]
-	interface ARSCNViewDelegate : SCNSceneRendererDelegate, ARSessionObserver
-	{
+	[BaseType (typeof (NSObject))]
+	interface ARSCNViewDelegate : SCNSceneRendererDelegate, ARSessionObserver {
+
 		[Export ("renderer:nodeForAnchor:")]
 		[return: NullAllowed]
 		SCNNode GetNode (ISCNSceneRenderer renderer, ARAnchor anchor);
@@ -323,9 +316,9 @@ namespace XamCore.ARKit {
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
-	[BaseType (typeof(SKView))]
-	interface ARSKView
-	{
+	[BaseType (typeof (SKView))]
+	interface ARSKView {
+
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		IARSKViewDelegate Delegate { get; set; }
 
@@ -349,9 +342,9 @@ namespace XamCore.ARKit {
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
 	[Protocol, Model]
-	[BaseType (typeof(NSObject))]
-	interface ARSKViewDelegate : SKViewDelegate, ARSessionObserver
-	{
+	[BaseType (typeof (NSObject))]
+	interface ARSKViewDelegate : SKViewDelegate, ARSessionObserver {
+
 		[Export ("view:nodeForAnchor:")]
 		[return: NullAllowed]
 		SKNode GetNode (ARSKView view, ARAnchor anchor);
@@ -371,9 +364,9 @@ namespace XamCore.ARKit {
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
-	[BaseType (typeof(NSObject))]
-	interface ARSession
-	{
+	[BaseType (typeof (NSObject))]
+	interface ARSession {
+
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
 		IARSessionDelegate Delegate { get; set; }
 
@@ -404,10 +397,10 @@ namespace XamCore.ARKit {
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
-	[Protocol]
-	[BaseType (typeof(NSObject))]
-	interface ARSessionObserver
-	{
+	[Protocol, Model]
+	[BaseType (typeof (NSObject))]
+	interface ARSessionObserver {
+
 		[Export ("session:didFailWithError:")]
 		void DidFail (ARSession session, NSError error);
 
@@ -426,9 +419,9 @@ namespace XamCore.ARKit {
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
 	[Protocol, Model]
-	[BaseType (typeof(NSObject))]
-	interface ARSessionDelegate : ARSessionObserver
-	{
+	[BaseType (typeof (NSObject))]
+	interface ARSessionDelegate : ARSessionObserver {
+
 		[Export ("session:didUpdateFrame:")]
 		void DidUpdateFrame (ARSession session, ARFrame frame);
 
@@ -444,9 +437,9 @@ namespace XamCore.ARKit {
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
-	[BaseType (typeof(NSObject))]
-	interface ARSessionConfiguration : NSCopying
-	{
+	[BaseType (typeof (NSObject))]
+	interface ARSessionConfiguration : NSCopying {
+
 		[Static]
 		[Export ("isSupported")]
 		bool IsSupported { get; }
@@ -460,9 +453,9 @@ namespace XamCore.ARKit {
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
-	[BaseType (typeof(ARSessionConfiguration))]
-	interface ARWorldTrackingSessionConfiguration
-	{
+	[BaseType (typeof (ARSessionConfiguration))]
+	interface ARWorldTrackingSessionConfiguration {
+
 		[Export ("planeDetection", ArgumentSemantic.Assign)]
 		ARPlaneDetection PlaneDetection { get; set; }
 	}
@@ -470,10 +463,12 @@ namespace XamCore.ARKit {
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
 	[Static]
-	interface ARSCNDebugOptions
-	{
+	interface ARSCNDebugOptions {
+
 		[Internal]
 		[Field ("ARSCNDebugOptionShowWorldOrigin")]
+		// FIXME: Could be using [BindAs (typeof (SCNDebugOptions))]: https://bugzilla.xamarin.com/show_bug.cgi?id=57537
+		// FIXME: Should be nuint: https://bugzilla.xamarin.com/show_bug.cgi?id=57535
 		int _ARSCNDebugOptionShowWorldOrigin { get; }
 
 		[Static]
@@ -482,6 +477,8 @@ namespace XamCore.ARKit {
 
 		[Internal]
 		[Field ("ARSCNDebugOptionShowFeaturePoints")]
+		// FIXME: Could be using [BindAs (typeof (SCNDebugOptions))]: https://bugzilla.xamarin.com/show_bug.cgi?id=57537
+		// FIXME: Should be nuint: https://bugzilla.xamarin.com/show_bug.cgi?id=57535
 		int _ARSCNDebugOptionShowFeaturePoints { get; }
 
 		[Static]

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1599,6 +1599,7 @@ IOS_FRAMEWORKS =         \
 	AdSupport \
 	AddressBook \
 	AddressBookUI \
+	ARKit \
 	AssetsLibrary \
 	AudioToolbox \
 	AudioUnit \

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -150,6 +150,11 @@ APPKIT_SOURCES = \
 	AppKit/NSColorPickerTouchBarItem.cs \
 	AppKit/NSSliderTouchBarItem.cs
 
+# ARKit
+
+ARKIT_SOURCES = \
+	ARKit/ARPointCloud.cs \
+
 # AssetsLibrary
 
 ASSETSLIBRARY_API_SOURCES = \

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3121,7 +3121,12 @@ public partial class Generator : IMemberGatherer {
 		return FormatTypeUsedIn (usedIn == null ? null : usedIn.Namespace, type);
 	}
 
-	public string FormatTypeUsedIn (string usedInNamespace, Type type)
+	public string FormatType (Type usedIn, Type type, bool protocolized)
+	{
+		return FormatTypeUsedIn (usedIn?.Namespace, type, protocolized);
+	}
+
+	public string FormatTypeUsedIn (string usedInNamespace, Type type, bool protocolized = false)
 	{
 		type = GetCorrectGenericType (type);
 
@@ -3143,11 +3148,12 @@ public partial class Generator : IMemberGatherer {
 		if (type.IsArray)
 			return FormatTypeUsedIn (usedInNamespace, type.GetElementType ()) + "[" + new string (',', type.GetArrayRank () - 1) + "]";
 
+		var interfaceTag = protocolized == true ? "I" : "";
 		string tname;
 		if ((usedInNamespace != null && type.Namespace == usedInNamespace) || ns.StandardNamespaces.Contains (type.Namespace) || string.IsNullOrEmpty (type.FullName))
-			tname = type.Name;
+			tname = interfaceTag + type.Name;
 		else
-			tname = "global::" + type.FullName;
+			tname = $"global::{type.Namespace}.{interfaceTag}{type.Name}";
 
 		var targs = type.GetGenericArguments ();
 		if (targs.Length > 0) {
@@ -3315,18 +3321,19 @@ public partial class Generator : IMemberGatherer {
 			if (pari == parCount - 1 && parType.IsArray && (AttributeManager.HasAttribute<ParamsAttribute> (pi) || AttributeManager.HasAttribute<ParamArrayAttribute> (pi))) {
 				sb.Append ("params ");
 			}
+			var protocolized = false;
 			if (!BindThirdPartyLibrary && Protocolize (pi)) {
 				if (!AttributeManager.HasAttribute<ProtocolAttribute> (parType)) {
 					Console.WriteLine ("Protocolized attribute for type that does not have a [Protocol] for {0}'s parameter {1}", mi, pi);
 				}
-				sb.Append ("I");
+				protocolized = true;
 			}
 
 			var bindAsAtt = GetBindAsAttribute (pi);
 			if (bindAsAtt != null)
-				sb.Append (FormatType (bindAsAtt.Type.DeclaringType, bindAsAtt.Type));
+				sb.Append (FormatType (bindAsAtt.Type.DeclaringType, bindAsAtt.Type, protocolized));
 			else
-				sb.Append (FormatType (declaringType, parType));
+				sb.Append (FormatType (declaringType, parType, protocolized));
 
 			sb.Append (" ");
 			sb.Append (pi.Name.GetSafeParamName ());

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -2084,6 +2084,8 @@ namespace XamCore.SceneKit {
 		NSString AssetUnitMeterKey { get; }
 	}
 
+	interface ISCNSceneRenderer {}
+
 	[Watch (3,0)]
 	[Mac (10,8), iOS (8,0)]
 	[Protocol, Model]
@@ -2329,22 +2331,22 @@ namespace XamCore.SceneKit {
 	interface SCNSceneRendererDelegate {
 
 		[Export ("renderer:willRenderScene:atTime:")]
-		void WillRenderScene ([Protocolize]SCNSceneRenderer renderer, SCNScene scene, double timeInSeconds);
+		void WillRenderScene (ISCNSceneRenderer renderer, SCNScene scene, double timeInSeconds);
 
 		[Export ("renderer:didRenderScene:atTime:")]
-		void DidRenderScene ([Protocolize]SCNSceneRenderer renderer, SCNScene scene, double timeInSeconds);
+		void DidRenderScene (ISCNSceneRenderer renderer, SCNScene scene, double timeInSeconds);
 
 		[Mac (10,10)]
 		[Export ("renderer:updateAtTime:")]
-		void Update ([Protocolize]SCNSceneRenderer renderer, double timeInSeconds);
+		void Update (ISCNSceneRenderer renderer, double timeInSeconds);
 
 		[Mac (10,10)]
 		[Export ("renderer:didApplyAnimationsAtTime:")]
-		void DidApplyAnimations ([Protocolize]SCNSceneRenderer renderer, double timeInSeconds);
+		void DidApplyAnimations (ISCNSceneRenderer renderer, double timeInSeconds);
 
 		[Mac (10,10)]
 		[Export ("renderer:didSimulatePhysicsAtTime:")]
-		void DidSimulatePhysics ([Protocolize]SCNSceneRenderer renderer, double timeInSeconds);
+		void DidSimulatePhysics (ISCNSceneRenderer renderer, double timeInSeconds);
 	}	
 
 	[Watch (3,0)]

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -2331,22 +2331,22 @@ namespace XamCore.SceneKit {
 	interface SCNSceneRendererDelegate {
 
 		[Export ("renderer:willRenderScene:atTime:")]
-		void WillRenderScene (ISCNSceneRenderer renderer, SCNScene scene, double timeInSeconds);
+		void WillRenderScene ([Protocolize]SCNSceneRenderer renderer, SCNScene scene, double timeInSeconds);
 
 		[Export ("renderer:didRenderScene:atTime:")]
-		void DidRenderScene (ISCNSceneRenderer renderer, SCNScene scene, double timeInSeconds);
+		void DidRenderScene ([Protocolize]SCNSceneRenderer renderer, SCNScene scene, double timeInSeconds);
 
 		[Mac (10,10)]
 		[Export ("renderer:updateAtTime:")]
-		void Update (ISCNSceneRenderer renderer, double timeInSeconds);
+		void Update ([Protocolize]SCNSceneRenderer renderer, double timeInSeconds);
 
 		[Mac (10,10)]
 		[Export ("renderer:didApplyAnimationsAtTime:")]
-		void DidApplyAnimations (ISCNSceneRenderer renderer, double timeInSeconds);
+		void DidApplyAnimations ([Protocolize]SCNSceneRenderer renderer, double timeInSeconds);
 
 		[Mac (10,10)]
 		[Export ("renderer:didSimulatePhysicsAtTime:")]
-		void DidSimulatePhysics (ISCNSceneRenderer renderer, double timeInSeconds);
+		void DidSimulatePhysics ([Protocolize]SCNSceneRenderer renderer, double timeInSeconds);
 	}	
 
 	[Watch (3,0)]

--- a/tests/introspection/iOS/iOSApiProtocolTest.cs
+++ b/tests/introspection/iOS/iOSApiProtocolTest.cs
@@ -188,6 +188,7 @@ namespace Introspection {
 				case "MKMapItem": // Conformance not in headers
 				case "NSConstraintConflict": // Conformance not in headers
 				case "NSQueryGenerationToken": // Conformance not in headers
+				case "ARCamera":
 					return true;
 #if __WATCHOS__
 				case "CLKComplicationTemplate":
@@ -294,6 +295,7 @@ namespace Introspection {
 				// iOS 11.0
 				case "MKMapItem": // Conformance not in headers
 				case "NSQueryGenerationToken": // Conformance not in headers
+				case "ARCamera":
 					return true;
 #if __WATCHOS__
 				case "CLKComplicationTemplate":

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -242,6 +242,7 @@ public class Frameworks : Dictionary <string, Framework>
 				{ "Intents", "Intents", 10 },
 				{ "IntentsUI", "IntentsUI", 10 },
 
+				{ "ARKit", "ARKit", 11 },
 				{ "CoreNFC", "CoreNFC", 11 },
 			};
 		}

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -269,7 +269,9 @@ SIMLAUNCHER_FRAMEWORKS =  \
 	-weak_framework UserNotifications		\
 	-weak_framework UserNotificationsUI		\
 	-weak_framework Intents					\
-	-weak_framework IntentsUI
+	-weak_framework IntentsUI					\
+						\
+	-weak_framework ARKit
 
 # note: there _was_ no CoreAudioKit.framework or Metal.framework for the simulator (before recent iOS9 betas)
 # note 2: there's no GameKit, in iOS 9 (beta 3 at least), you're supposed to reference GameCenter instead (looks fixed in beta 4)


### PR DESCRIPTION
Updated scenekit.cs `SCNSceneRendererDelegate` to avoid:
`ARKit/ARSCNViewDelegate.g.cs(189,43): error CS0432: Alias 'Iglobal' not found`

-----

**Part 2**

- Fixed the generator to avoid `ARKit/ARSCNViewDelegate.g.cs(189,43): error CS0432: Alias 'Iglobal' not found`
- ARPointCloud can be tested with this sample: https://www.dropbox.com/s/0xlz0sdzjj4507s/ARPointCloudTest.zip?dl=0
  It requires deploying on devices and moving the camera around so ARKit can return some points. After 5 seconds it should print the points.
- Added code comments about generator bugs.
- Fixed styling.
- Added missing simd.
- Fixed intro tests.