### PR TITLE
[msbuild] Use @(ReferencePath) instead of @(ResolvedFiles)

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -415,7 +415,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			NoOverwrite="@(_BundleResourceWithLogicalName)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			TargetFrameworkDirectory="$(TargetFrameworkDirectory)"
-			ReferencedLibraries="@(ResolvedFiles)">
+			ReferencedLibraries="@(ReferencePath)">
 			<Output TaskParameter="BundleResourcesWithLogicalNames" ItemName="_BundleResourceWithLogicalName" />
 			<Output TaskParameter="BundleResourcesWithLogicalNames" ItemName="FileWrites" />
 		</UnpackLibraryResources>


### PR DESCRIPTION
This allows things to work on both xbuild and msbuild.

In xbuild, both lists are exactly the same and on msbuild,
only @(ReferencePath) exists.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=55147