### PR TITLE
[Test][Intro] Fix introspection test on API changes for Xcode 9 Beta 1

### DIFF
--- a/src/Foundation/NSUnit.cs
+++ b/src/Foundation/NSUnit.cs
@@ -1,4 +1,4 @@
-﻿// 
+﻿﻿// 
 // NSUnit.cs
 //
 // Authors:
@@ -14,112 +14,112 @@ using XamCore.ObjCRuntime;
 namespace XamCore.Foundation {
 #if !XAMCORE_4_0
 	public partial class NSUnit {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string)")]
 		public NSUnit () { }
 	}
 
 	public partial class NSUnitAcceleration {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitAcceleration () { }
 	}
 
 	public partial class NSUnitAngle {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitAngle () { }
 	}
 
 	public partial class NSUnitArea {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitArea () { }
 	}
 
 	public partial class NSUnitConcentrationMass {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitConcentrationMass () { }
 	}
 
 	public partial class NSUnitDispersion {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitDispersion () { }
 	}
 
 	public partial class NSUnitDuration {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitDuration () { }
 	}
 
 	public partial class NSUnitElectricCharge {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitElectricCharge () { }
 	}
 
 	public partial class NSUnitElectricCurrent {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitElectricCurrent () { }
 	}
 
 	public partial class NSUnitElectricPotentialDifference {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitElectricPotentialDifference () { }
 	}
 
 	public partial class NSUnitElectricResistance {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitElectricResistance () { }
 	}
 
 	public partial class NSUnitEnergy {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitEnergy () { }
 	}
 
 	public partial class NSUnitFrequency {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitFrequency () { }
 	}
 
 	public partial class NSUnitFuelEfficiency {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitFuelEfficiency () { }
 	}
 
 	public partial class NSUnitLength {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitLength () { }
 	}
 
 	public partial class NSUnitIlluminance {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitIlluminance () { }
 	}
 
 	public partial class NSUnitMass {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitMass () { }
 	}
 
 	public partial class NSUnitPower {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitPower () { }
 	}
 
 	public partial class NSUnitPressure {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitPressure () { }
 	}
 
 	public partial class NSUnitSpeed {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitSpeed () { }
 	}
 
 	public partial class NSUnitVolume {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
 		public NSUnitVolume () { }
 	}
 
 	public partial class NSDimension {
-		[Obsolete ("Use the overload instead")]
+		[Obsolete ("Not intended to be directly instantiated, this is an abstract class.")]
 		public NSDimension () { }
 	}
 #endif

--- a/src/Foundation/NSUnit.cs
+++ b/src/Foundation/NSUnit.cs
@@ -1,0 +1,126 @@
+﻿// 
+// NSUnit.cs
+//
+// Authors:
+//	Alex Soto (alexsoto@microsoft.com)
+//     
+// Copyright 2017 Xamarin Inc.
+//
+
+using System;
+using XamCore.Foundation;
+using XamCore.ObjCRuntime;
+
+namespace XamCore.Foundation {
+#if !XAMCORE_4_0
+	public partial class NSUnit {
+		[Obsolete ("Use the overload instead")]
+		public NSUnit () { }
+	}
+
+	public partial class NSUnitAcceleration {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitAcceleration () { }
+	}
+
+	public partial class NSUnitAngle {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitAngle () { }
+	}
+
+	public partial class NSUnitArea {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitArea () { }
+	}
+
+	public partial class NSUnitConcentrationMass {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitConcentrationMass () { }
+	}
+
+	public partial class NSUnitDispersion {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitDispersion () { }
+	}
+
+	public partial class NSUnitDuration {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitDuration () { }
+	}
+
+	public partial class NSUnitElectricCharge {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitElectricCharge () { }
+	}
+
+	public partial class NSUnitElectricCurrent {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitElectricCurrent () { }
+	}
+
+	public partial class NSUnitElectricPotentialDifference {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitElectricPotentialDifference () { }
+	}
+
+	public partial class NSUnitElectricResistance {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitElectricResistance () { }
+	}
+
+	public partial class NSUnitEnergy {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitEnergy () { }
+	}
+
+	public partial class NSUnitFrequency {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitFrequency () { }
+	}
+
+	public partial class NSUnitFuelEfficiency {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitFuelEfficiency () { }
+	}
+
+	public partial class NSUnitLength {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitLength () { }
+	}
+
+	public partial class NSUnitIlluminance {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitIlluminance () { }
+	}
+
+	public partial class NSUnitMass {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitMass () { }
+	}
+
+	public partial class NSUnitPower {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitPower () { }
+	}
+
+	public partial class NSUnitPressure {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitPressure () { }
+	}
+
+	public partial class NSUnitSpeed {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitSpeed () { }
+	}
+
+	public partial class NSUnitVolume {
+		[Obsolete ("Use the overload instead")]
+		public NSUnitVolume () { }
+	}
+
+	public partial class NSDimension {
+		[Obsolete ("Use the overload instead")]
+		public NSDimension () { }
+	}
+#endif
+}

--- a/src/UIKit/Compat.cs
+++ b/src/UIKit/Compat.cs
@@ -90,4 +90,16 @@ namespace XamCore.UIKit {
 #endif
 
 #endif
+
+#if !XAMCORE_4_0 && !WATCH
+	public partial class UICollectionViewFocusUpdateContext {
+		[Obsolete ("This cannot be directly created")]
+		public UICollectionViewFocusUpdateContext () { }
+	}
+
+	public partial class UIFocusUpdateContext {
+		[Obsolete ("This cannot be directly created")]
+		public UIFocusUpdateContext () { }
+	}
+#endif
 }

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -10370,9 +10370,10 @@ namespace XamCore.AVFoundation {
 		[Export ("disableLooping")]
 		void DisableLooping ();
 
+#if !XAMCORE_4_0 // This API got introduced in Xcode 8.0 binding but is not currently present nor in Xcode 8.3 or Xcode 9.0 needs research
 		[Export ("loopingEnabled")]
 		bool LoopingEnabled { [Bind ("isLoopingEnabled")] get; }
-
+#endif
 		[Export ("loopCount")]
 		nint LoopCount { get; }
 

--- a/src/cloudkit.cs
+++ b/src/cloudkit.cs
@@ -622,7 +622,7 @@ namespace XamCore.CloudKit {
 	
 	[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(NSObject))]
-	interface CKFetchRecordZoneChangesOptions : NSSecureCoding
+	interface CKFetchRecordZoneChangesOptions : NSSecureCoding, NSCopying
 	{
 		[NullAllowed, Export ("previousServerChangeToken", ArgumentSemantic.Copy)]
 		CKServerChangeToken PreviousServerChangeToken { get; set; }

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -200,7 +200,7 @@ namespace XamCore.CoreAnimation {
 
 	[BaseType (typeof (NSObject))]
 	[Dispose ("OnDispose ();")]
-	interface CALayer : CAMediaTiming, NSCoding {
+	interface CALayer : CAMediaTiming, NSSecureCoding {
 		[Export ("layer")][Static]
 		CALayer Create ();
 
@@ -910,7 +910,7 @@ namespace XamCore.CoreAnimation {
 	}
 	
 	[BaseType (typeof (NSObject), Delegates=new string [] {"WeakDelegate"}, Events=new Type [] { typeof (CAAnimationDelegate)})]
-	interface CAAnimation : CAAction, CAMediaTiming, NSCoding, NSMutableCopying {
+	interface CAAnimation : CAAction, CAMediaTiming, NSSecureCoding, NSMutableCopying {
 		[Export ("animation"), Static]
 		CAAnimation CreateAnimation ();
 	
@@ -1307,7 +1307,7 @@ namespace XamCore.CoreAnimation {
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	interface CAMediaTimingFunction : NSCoding {
+	interface CAMediaTimingFunction : NSSecureCoding {
 		[Export ("functionWithName:")][Static]
 		CAMediaTimingFunction FromName (NSString  name);
 
@@ -1338,7 +1338,7 @@ namespace XamCore.CoreAnimation {
 	}
 
 	[BaseType (typeof (NSObject))]
-	interface CAValueFunction : NSCoding {
+	interface CAValueFunction : NSSecureCoding {
 		[Export ("functionWithName:"), Static]
 		CAValueFunction FromName (string name);
 
@@ -1412,7 +1412,7 @@ namespace XamCore.CoreAnimation {
 
 	[Since (5,0)]
 	[BaseType (typeof (NSObject))]
-	interface CAEmitterCell : CAMediaTiming, NSCoding {
+	interface CAEmitterCell : CAMediaTiming, NSSecureCoding {
 		[NullAllowed] // by default this property is null
 		[Export ("name", ArgumentSemantic.Copy)]
 		string Name { get; set;  }
@@ -1643,7 +1643,7 @@ namespace XamCore.CoreAnimation {
 
 	[Since(7,0), Mavericks]
 	[BaseType (typeof (NSObject))]
-	interface CAEmitterBehavior : NSCoding {
+	interface CAEmitterBehavior : NSSecureCoding {
 
 		[Export ("initWithType:")]
 		IntPtr Constructor (NSString type);

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -2230,7 +2230,7 @@ namespace XamCore.CoreImage {
 	[iOS (8,0)]
 	[Mac (10,12)]
 	[BaseType (typeof (CIFeature))]
-	partial interface CIQRCodeFeature {
+	partial interface CIQRCodeFeature : NSSecureCoding, NSCopying {
 
 		[Export ("bounds", ArgumentSemantic.Assign)]
 		CGRect Bounds { get; }

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -4637,8 +4637,8 @@ namespace XamCore.CoreImage {
 	}
 
 	[CoreImageFilter]
-	[iOS (10,0)]
-	[Mac (10,12)]
+	[iOS (11,0)]
+	[NoMac]
 	[TV (11,0)]
 	[BaseType (typeof (CIFilter))]
 	interface CIEdgePreserveUpsampleFilter {

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -4471,4 +4471,215 @@ namespace XamCore.CoreImage {
 	[BaseType (typeof (CIFilter))]
 	interface CIXRay {
 	}
+
+	[CoreImageFilter]
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CIAreaMinMaxRed {
+		// TODO: Needs review
+		//[CoreImageProperty ("inputExtent")]
+		//CIVector Extent { get; set; }
+	}
+
+	[CoreImageFilter]
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CIAttributedTextImageGenerator {
+		// TODO: Needs review
+		//[CoreImageProperty ("inputText")]
+		//NSAttributedString Text { get; set; }
+
+		//[CoreImageProperty ("inputScaleFactor")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float ScaleFactor { get; set; }
+	}
+	[CoreImageFilter]
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CIBarcodeGenerator {
+		// TODO: Needs review
+		//[CoreImageProperty ("inputBarcodeDescriptor")]
+		//CIBarcodeDescriptor BarcodeDescriptor { get; set; }
+	}
+
+	[CoreImageFilter]
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CIBicubicScaleTransform {
+		// TODO: Needs review
+		//[CoreImageProperty ("inputB")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float B { get; set; }
+		//[CoreImageProperty ("inputScale")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float Scale { get; set; }
+		//[CoreImageProperty ("inputC")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float C { get; set; }
+		//[CoreImageProperty ("inputAspectRatio")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float AspectRatio { get; set; }
+	}
+
+	[CoreImageFilter]
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CIBokehBlur {
+		// TODO: Needs review
+		//[CoreImageProperty ("inputSoftness")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float Softness { get; set; }
+		//[CoreImageProperty ("inputRadius")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float Radius { get; set; }
+		//[CoreImageProperty ("inputRingSize")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float RingSize { get; set; }
+		//[CoreImageProperty ("inputRingAmount")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float RingAmount { get; set; }
+	}
+	[CoreImageFilter]
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CIColorCubesMixedWithMask {
+		// TODO: Needs review
+		//[CoreImageProperty ("inputCubeDimension")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float CubeDimension { get; set; }
+		//[CoreImageProperty ("inputMaskImage")]
+		//CIImage MaskImage { get; set; }
+		//[CoreImageProperty ("inputCube0Data")]
+		//NSData Cube0Data { get; set; }
+		//[CoreImageProperty ("inputCube1Data")]
+		//NSData Cube1Data { get; set; }
+		//[CoreImageProperty ("inputColorSpace")]
+		//NSObject ColorSpace { get; set; }
+	}
+
+	[CoreImageFilter]
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CIColorCurves {
+		// TODO: Needs review
+		//[CoreImageProperty ("inputColorSpace")]
+		//NSObject ColorSpace { get; set; }
+		//[CoreImageProperty ("inputCurvesDomain")]
+		//CIVector CurvesDomain { get; set; }
+		//[CoreImageProperty ("inputCurvesData")]
+		//NSData CurvesData { get; set; }
+	}
+
+	[CoreImageFilter]
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CIDepthBlurEffect {
+		// TODO: Needs review
+		//[CoreImageProperty ("inputAperture")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float Aperture { get; set; }
+		//[CoreImageProperty ("inputCalibrationData")]
+		//AVCameraCalibrationData CalibrationData { get; set; }
+		//[CoreImageProperty ("inputTuningParameters")]
+		//NSDictionary TuningParameters { get; set; }
+		//[CoreImageProperty ("inputNosePositions")]
+		//CIVector NosePositions { get; set; }
+		//[CoreImageProperty ("inputLumaNoiseScale")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float LumaNoiseScale { get; set; }
+		//[CoreImageProperty ("inputChinPositions")]
+		//CIVector ChinPositions { get; set; }
+		//[CoreImageProperty ("inputDisparityImage")]
+		//CIImage DisparityImage { get; set; }
+		//[CoreImageProperty ("inputScaleFactor")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float ScaleFactor { get; set; }
+		//[CoreImageProperty ("inputRightEyePositions")]
+		//CIVector RightEyePositions { get; set; }
+		//[CoreImageProperty ("inputLeftEyePositions")]
+		//CIVector LeftEyePositions { get; set; }
+		//[CoreImageProperty ("inputFocusRect")]
+		//CIVector FocusRect { get; set; }
+	}
+
+	[CoreImageFilter]
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CIDepthToDisparity {
+		// TODO: Needs review
+	}
+
+	[CoreImageFilter]
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CIDisparityToDepth {
+		// TODO: Needs review
+	}
+
+	[CoreImageFilter]
+	[iOS (10,0)]
+	[Mac (10,12)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CIEdgePreserveUpsampleFilter {
+		// TODO: Needs review
+		//[CoreImageProperty ("inputLumaSigma")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float LumaSigma { get; set; }
+		//[CoreImageProperty ("inputSmallImage")]
+		//CIImage SmallImage { get; set; }
+		//[CoreImageProperty ("inputSpatialSigma")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float SpatialSigma { get; set; }
+	}
+
+	[CoreImageFilter]
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CILabDeltaE {
+		// TODO: Needs review
+		//[CoreImageProperty ("inputImage2")]
+		//CIImage Image2 { get; set; }
+	}
+
+	[CoreImageFilter]
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CITextImageGenerator {
+		// TODO: Needs review
+		//[CoreImageProperty ("inputText")]
+		//NSString Text { get; set; }
+		//[CoreImageProperty ("inputFontName")]
+		//NSString FontName { get; set; }
+		//[CoreImageProperty ("inputScaleFactor")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float ScaleFactor { get; set; }
+		//[CoreImageProperty ("inputFontSize")]
+		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
+		//float FontSize { get; set; }
+	}
 }

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -12140,9 +12140,7 @@ namespace XamCore.Foundation
 		bool ContainsDate (NSDate date);
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSUnit : NSCopying, NSSecureCoding {
@@ -13226,9 +13224,7 @@ namespace XamCore.Foundation
 		nuint RedirectCount { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitAcceleration : NSSecureCoding {
@@ -13251,9 +13247,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitAngle : NSSecureCoding {
@@ -13292,9 +13286,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitArea : NSSecureCoding {
@@ -13365,9 +13357,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif	
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitConcentrationMass : NSSecureCoding {
@@ -13394,9 +13384,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitDispersion : NSSecureCoding {
@@ -13415,9 +13403,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitDuration : NSSecureCoding {
@@ -13444,9 +13430,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitElectricCharge : NSSecureCoding {
@@ -13485,9 +13469,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitElectricCurrent : NSSecureCoding {
@@ -13522,9 +13504,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitElectricPotentialDifference : NSSecureCoding {
@@ -13559,9 +13539,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitElectricResistance : NSSecureCoding {
@@ -13596,9 +13574,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitEnergy : NSSecureCoding {
@@ -13633,9 +13609,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitFrequency : NSSecureCoding {
@@ -13682,9 +13656,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitFuelEfficiency : NSSecureCoding {
@@ -13711,9 +13683,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitLength : NSSecureCoding {
@@ -13816,9 +13786,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif	
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitIlluminance : NSSecureCoding {
@@ -13837,9 +13805,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitMass : NSSecureCoding {
@@ -13918,9 +13884,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitPower : NSSecureCoding {
@@ -13979,9 +13943,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitPressure : NSSecureCoding {
@@ -14036,9 +13998,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitSpeed : NSSecureCoding {
@@ -14069,9 +14029,7 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // -init should never be called on NSUnit!
-#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitVolume : NSSecureCoding {

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -12140,6 +12140,9 @@ namespace XamCore.Foundation
 		bool ContainsDate (NSDate date);
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSUnit : NSCopying, NSSecureCoding {
@@ -13223,6 +13226,9 @@ namespace XamCore.Foundation
 		nuint RedirectCount { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitAcceleration : NSSecureCoding {
@@ -13245,6 +13251,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitAngle : NSSecureCoding {
@@ -13283,6 +13292,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitArea : NSSecureCoding {
@@ -13353,6 +13365,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif	
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitConcentrationMass : NSSecureCoding {
@@ -13379,6 +13394,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitDispersion : NSSecureCoding {
@@ -13397,6 +13415,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitDuration : NSSecureCoding {
@@ -13423,6 +13444,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitElectricCharge : NSSecureCoding {
@@ -13461,6 +13485,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitElectricCurrent : NSSecureCoding {
@@ -13495,6 +13522,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitElectricPotentialDifference : NSSecureCoding {
@@ -13529,6 +13559,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitElectricResistance : NSSecureCoding {
@@ -13563,6 +13596,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitEnergy : NSSecureCoding {
@@ -13597,6 +13633,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitFrequency : NSSecureCoding {
@@ -13643,6 +13682,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitFuelEfficiency : NSSecureCoding {
@@ -13669,6 +13711,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitLength : NSSecureCoding {
@@ -13771,6 +13816,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif	
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitIlluminance : NSSecureCoding {
@@ -13789,6 +13837,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitMass : NSSecureCoding {
@@ -13867,6 +13918,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitPower : NSSecureCoding {
@@ -13925,6 +13979,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitPressure : NSSecureCoding {
@@ -13979,6 +14036,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitSpeed : NSSecureCoding {
@@ -14009,6 +14069,9 @@ namespace XamCore.Foundation
 		NSDimension BaseUnit { get; }
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // -init should never be called on NSUnit!
+#endif
 	[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 	[BaseType (typeof (NSDimension))]
 	interface NSUnitVolume : NSSecureCoding {

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -710,6 +710,7 @@ FOUNDATION_SOURCES = \
 	Foundation/NSTimeZone.cs \
 	Foundation/NSUbiquitousKeyValueStore.cs \
 	Foundation/NSUndoManager.cs \
+	Foundation/NSUnit.cs \
 	Foundation/NSUrl.cs \
 	Foundation/NSUrlComponents.cs \
 	Foundation/NSUrlConnection.cs \

--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -1227,7 +1227,7 @@ namespace XamCore.HomeKit {
 	[TV (10,0)]
 	[BaseType (typeof (HMEvent))]
 	[DisableDefaultCtor]
-	interface HMLocationEvent {
+	interface HMLocationEvent : NSMutableCopying {
 		[NoTV]
 		[NoWatch]
 		[Export ("initWithRegion:")]

--- a/src/metalperformanceshaders.cs
+++ b/src/metalperformanceshaders.cs
@@ -510,7 +510,7 @@ namespace XamCore.MetalPerformanceShaders {
 	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	interface MPSKernel : NSCopying {
+	interface MPSKernel : NSCopying, NSSecureCoding {
 		[Export ("options", ArgumentSemantic.Assign)]
 		MPSKernelOptions Options { get; set; }
 
@@ -657,7 +657,7 @@ namespace XamCore.MetalPerformanceShaders {
 	[iOS (10,0)][TV (10,0)]
 	[BaseType (typeof (NSObject), Name = "MPSCNNConvolutionDescriptor")]
 	[DisableDefaultCtor]
-	interface MPSCnnConvolutionDescriptor : NSCopying {
+	interface MPSCnnConvolutionDescriptor : NSCopying, NSSecureCoding {
 
 		[Export ("kernelWidth")]
 		nuint KernelWidth { get; set; }

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -15839,9 +15839,7 @@ namespace XamCore.UIKit {
 		string GetDetailTextForGuidedAccessRestriction (string restrictionIdentifier);
 	}
 
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // [Assert] -init is not a useful initializer for this class. Use one of the designated initializers instead
-#endif
 	[NoWatch]
 	[iOS (9,0)] // added in Xcode 7.1 / iOS 9.1 SDK
 	[BaseType (typeof (UIFocusUpdateContext))]
@@ -15911,9 +15909,7 @@ namespace XamCore.UIKit {
 		bool CanBecomeFocused { get; }
 	}
 		
-#if XAMCORE_4_0
 	[DisableDefaultCtor] // [Assert] -init is not a useful initializer for this class. Use one of the designated initializers instead
-#endif
 	[NoWatch]
 	[iOS (9,0)]
 	[BaseType (typeof(NSObject))]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -7179,7 +7179,7 @@ namespace XamCore.UIKit {
 	[Since (3,2)]
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
-	interface UIBezierPath : NSCoding, NSCopying {
+	interface UIBezierPath : NSSecureCoding, NSCopying {
 		// initWithFrame: --> unrecognized selector
 
 		[Export ("bezierPath"), Static]
@@ -15839,6 +15839,9 @@ namespace XamCore.UIKit {
 		string GetDetailTextForGuidedAccessRestriction (string restrictionIdentifier);
 	}
 
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // [Assert] -init is not a useful initializer for this class. Use one of the designated initializers instead
+#endif
 	[NoWatch]
 	[iOS (9,0)] // added in Xcode 7.1 / iOS 9.1 SDK
 	[BaseType (typeof (UIFocusUpdateContext))]
@@ -15908,6 +15911,9 @@ namespace XamCore.UIKit {
 		bool CanBecomeFocused { get; }
 	}
 		
+#if XAMCORE_4_0
+	[DisableDefaultCtor] // [Assert] -init is not a useful initializer for this class. Use one of the designated initializers instead
+#endif
 	[NoWatch]
 	[iOS (9,0)]
 	[BaseType (typeof(NSObject))]

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -77,6 +77,28 @@ namespace Introspection {
 				return true;
 			case "NEPacketTunnelProvider":
 				return true;
+			case "NSUnitDispersion": // -init should never be called on NSUnit!
+			case "NSUnitVolume": // -init should never be called on NSUnit!
+			case "NSUnitDuration": // -init should never be called on NSUnit!
+			case "NSUnitElectricCharge": // -init should never be called on NSUnit!
+			case "NSUnitElectricCurrent": // -init should never be called on NSUnit!
+			case "NSUnitElectricPotentialDifference": // -init should never be called on NSUnit!
+			case "NSUnitElectricResistance": // -init should never be called on NSUnit!
+			case "NSUnit": // -init should never be called on NSUnit!
+			case "NSUnitEnergy": // -init should never be called on NSUnit!
+			case "NSUnitAcceleration": // -init should never be called on NSUnit!
+			case "NSUnitFrequency": // -init should never be called on NSUnit!
+			case "NSUnitAngle": // -init should never be called on NSUnit!
+			case "NSUnitFuelEfficiency": // -init should never be called on NSUnit!
+			case "NSUnitArea": // -init should never be called on NSUnit!
+			case "NSUnitIlluminance": // -init should never be called on NSUnit!
+			case "NSUnitConcentrationMass": // -init should never be called on NSUnit!
+			case "NSUnitLength": // -init should never be called on NSUnit!
+			case "NSUnitMass": // -init should never be called on NSUnit!
+			case "NSUnitPower": // -init should never be called on NSUnit!
+			case "NSUnitPressure": // -init should never be called on NSUnit!
+			case "NSUnitSpeed": // -init should never be called on NSUnit!
+				return true;
 			}
 
 			return SkipDueToAttribute (type);

--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -140,6 +140,9 @@ namespace Introspection {
 				// iOS 10 : test throw because of generic usage
 				case "NSMeasurement`1":
 					return true; // skip
+				// xcode 9
+				case "NSConstraintConflict": // Conformance not in headers
+					return true;
 				}
 				break;
 			// conformance added in Xcode 8 (iOS 10 / macOS 10.12)

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -329,6 +329,12 @@ namespace Introspection {
 					return true;
 				}
 				break;
+			case "AVPlayerLooper": // This API got introduced in Xcode 8.0 binding but is not currently present nor in Xcode 8.3 or Xcode 9.0 needs research
+				switch (selectorName) {
+				case "isLoopingEnabled":
+					return true;
+				}
+				break;
 			}
 
 			// old binding mistake

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -149,6 +149,20 @@ namespace Introspection {
 					return true;
 				}
 				break;
+			// Xcode 9
+			case "CIQRCodeFeature":
+				switch (selectorName) {
+				case "copyWithZone:":
+				case "encodeWithCoder:":
+					return !TestRuntime.CheckXcodeVersion (9, 0);
+				}
+				break;
+			case "CKFetchRecordZoneChangesOptions":
+				switch (selectorName) {
+				case "copyWithZone:":
+					return !TestRuntime.CheckXcodeVersion (9, 0);
+				}
+				break;
 			}
 #endif
 			// This ctors needs to be manually bound

--- a/tests/introspection/iOS/iOSApiCtorInitTest.cs
+++ b/tests/introspection/iOS/iOSApiCtorInitTest.cs
@@ -196,6 +196,13 @@ namespace Introspection {
 			case "INStartWorkoutIntent":
 				return true;
 #endif
+			// iOS 11 Beta 1
+			case "UICollectionViewFocusUpdateContext": // [Assert] -init is not a useful initializer for this class. Use one of the designated initializers instead
+			case "UIFocusUpdateContext": // [Assert] -init is not a useful initializer for this class. Use one of the designated initializers instead
+			case "EKCalendarItem": // Fails with NSInvalidArgumentException +[EKCalendarItem frozenClass]: unrecognized selector sent to class, will fill a radar
+			case "EKParticipant": // ctor disabled in XAMCORE_3_0
+			case "UITableViewFocusUpdateContext": // Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: Invalid parameter not satisfying: focusSystem, will fill a radar
+				return true;
 			default:
 				return base.Skip (type);
 			}

--- a/tests/introspection/iOS/iOSApiProtocolTest.cs
+++ b/tests/introspection/iOS/iOSApiProtocolTest.cs
@@ -183,6 +183,12 @@ namespace Introspection {
 				case "MPMusicPlayerControllerMutableQueue":
 				case "MPMusicPlayerControllerQueue":
 					return true;
+				// iOS 11.0
+				case "UICollectionViewUpdateItem": // Conformance not in headers
+				case "MKMapItem": // Conformance not in headers
+				case "NSConstraintConflict": // Conformance not in headers
+				case "NSQueryGenerationToken": // Conformance not in headers
+					return true;
 #if __WATCHOS__
 				case "CLKComplicationTemplate":
 				case "CLKComplicationTemplateCircularSmallRingImage":
@@ -285,6 +291,10 @@ namespace Introspection {
 				case "MPMusicPlayerControllerMutableQueue":
 				case "MPMusicPlayerControllerQueue":
 					return true;
+				// iOS 11.0
+				case "MKMapItem": // Conformance not in headers
+				case "NSQueryGenerationToken": // Conformance not in headers
+					return true;
 #if __WATCHOS__
 				case "CLKComplicationTemplate":
 				case "CLKComplicationTemplateCircularSmallRingImage":
@@ -363,6 +373,10 @@ namespace Introspection {
 				// iOS 10.2
 				case "VSAccountProviderResponse":
 					return true;
+				// iOS 11.0
+				case "UICollectionViewUpdateItem": // Conformance not in headers
+					return true;
+
 #if __WATCHOS__
 				case "CLKComplicationTimelineEntry":
 					return true;

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -578,8 +578,6 @@ namespace Introspection {
 					return !TestRuntime.CheckXcodeVersion (7, 0);
 				case "HKWorkoutEvent":
 					return !TestRuntime.CheckXcodeVersion (8, 0);
-				case "CIQRCodeFeature":
-				case "CKFetchRecordZoneChangesOptions":
 				case "HMLocationEvent":
 					return !TestRuntime.CheckXcodeVersion (9, 0);
 				}
@@ -637,7 +635,6 @@ namespace Introspection {
 				case "HKBiologicalSexObject":
 				case "HKBloodTypeObject":
 					return !TestRuntime.CheckXcodeVersion (7, 0);
-				case "CIQRCodeFeature":
 				case "MPSKernel":
 				case "MPSCnnConvolutionDescriptor":
 					return !TestRuntime.CheckXcodeVersion (9, 0);

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -578,6 +578,10 @@ namespace Introspection {
 					return !TestRuntime.CheckXcodeVersion (7, 0);
 				case "HKWorkoutEvent":
 					return !TestRuntime.CheckXcodeVersion (8, 0);
+				case "CIQRCodeFeature":
+				case "CKFetchRecordZoneChangesOptions":
+				case "HMLocationEvent":
+					return !TestRuntime.CheckXcodeVersion (9, 0);
 				}
 				break;
 
@@ -633,6 +637,10 @@ namespace Introspection {
 				case "HKBiologicalSexObject":
 				case "HKBloodTypeObject":
 					return !TestRuntime.CheckXcodeVersion (7, 0);
+				case "CIQRCodeFeature":
+				case "MPSKernel":
+				case "MPSCnnConvolutionDescriptor":
+					return !TestRuntime.CheckXcodeVersion (9, 0);
 #if __TVOS__
 				case "SKAttribute":
 				case "SKAttributeValue":
@@ -649,6 +657,12 @@ namespace Introspection {
 					return true;
 				break;
 #endif
+			case "mutableCopyWithZone:":
+				switch (declaredType.Name) {
+				case "HMLocationEvent":
+					return !TestRuntime.CheckXcodeVersion (9, 0);
+				}
+				break;
 			}
 
 			return base.CheckResponse (value, actualType, method, ref name);

--- a/tests/introspection/iOS/introspection-ios.csproj
+++ b/tests/introspection/iOS/introspection-ios.csproj
@@ -52,6 +52,7 @@
     <MtouchLink>None</MtouchLink>
     <MtouchExtraArgs></MtouchExtraArgs>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug32|iPhone' ">
     <DebugSymbols>True</DebugSymbols>
@@ -66,6 +67,7 @@
     <MtouchLink>None</MtouchLink>
     <MtouchExtraArgs></MtouchExtraArgs>
     <MtouchArch>ARMv7</MtouchArch>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug64|iPhone' ">
     <DebugSymbols>True</DebugSymbols>
@@ -80,6 +82,7 @@
     <MtouchLink>None</MtouchLink>
     <MtouchExtraArgs></MtouchExtraArgs>
     <MtouchArch>ARM64</MtouchArch>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
@@ -93,6 +96,7 @@
     <MtouchLink>None</MtouchLink>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <DefineConstants>MONOTOUCH;$(DefineConstants)</DefineConstants>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release32|iPhone' ">
     <DebugType>none</DebugType>
@@ -106,6 +110,7 @@
     <MtouchLink>None</MtouchLink>
     <MtouchArch>ARMv7</MtouchArch>
     <DefineConstants>MONOTOUCH;$(DefineConstants)</DefineConstants>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release64|iPhone' ">
     <DebugType>none</DebugType>
@@ -119,6 +124,7 @@
     <MtouchLink>None</MtouchLink>
     <MtouchArch>ARM64</MtouchArch>
     <DefineConstants>MONOTOUCH;$(DefineConstants)</DefineConstants>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-bitcode|iPhone' ">
     <DebugType>none</DebugType>


### PR DESCRIPTION
Bug filled for AVPlayerLooper. LoopingEnabled -> https://bugzilla.xamarin.com/show_bug.cgi?id=57302

Bug filled for CoreImage filters -> https://bugzilla.xamarin.com/show_bug.cgi?id=57350

Need to radar

- case "EKCalendarItem": // Fails with NSInvalidArgumentException +[EKCalendarItem frozenClass]: unrecognized selector sent to class, will fill a radar
- case "UITableViewFocusUpdateContext": // Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: Invalid parameter not satisfying: focusSystem, will fill a radar
