### PR TITLE
[link sdk] Fix Sqlite3 test according to updated simulators.

### DIFF
--- a/tests/linker-ios/link sdk/DllImportTest.cs
+++ b/tests/linker-ios/link sdk/DllImportTest.cs
@@ -53,20 +53,29 @@ namespace LinkSdk {
 				Assert.That (Dlfcn.dlsym (lib, "sqlite3_bind_int"), Is.Not.EqualTo (IntPtr.Zero), "sqlite3_bind_int");
 				// iOS does not have some symbols defined - if that change/fail in the future we'll need to update Mono.Data.Sqlite
 				// note: Apple devices (at least iOS and AppleTV) running 10.x have a more recent version of libsqlite which includes _key and _rekey
-				var version = TestRuntime.CheckXcodeVersion (8, 0);
-				if (version && (Runtime.Arch == Arch.DEVICE)) {
-					Assert.That (Dlfcn.dlsym (lib, "sqlite3_key"), Is.Not.EqualTo (IntPtr.Zero), "sqlite3_key");
-					Assert.That (Dlfcn.dlsym (lib, "sqlite3_rekey"), Is.Not.EqualTo (IntPtr.Zero), "sqlite3_rekey");
-				} else {
-					Assert.That (Dlfcn.dlsym (lib, "sqlite3_key"), Is.EqualTo (IntPtr.Zero), "sqlite3_key");
-					Assert.That (Dlfcn.dlsym (lib, "sqlite3_rekey"), Is.EqualTo (IntPtr.Zero), "sqlite3_rekey");
-				}
-				Assert.That (Dlfcn.dlsym (lib, "sqlite3_column_database_name"), Is.EqualTo (IntPtr.Zero), "sqlite3_column_database_name");
-				Assert.That (Dlfcn.dlsym (lib, "sqlite3_column_database_name16"), Is.EqualTo (IntPtr.Zero), "sqlite3_column_database_name16");
-				Assert.That (Dlfcn.dlsym (lib, "sqlite3_column_origin_name"), Is.EqualTo (IntPtr.Zero), "sqlite3_column_origin_name");
-				Assert.That (Dlfcn.dlsym (lib, "sqlite3_column_origin_name16"), Is.EqualTo (IntPtr.Zero), "sqlite3_column_origin_name16");
-				Assert.That (Dlfcn.dlsym (lib, "sqlite3_column_table_name"), Is.EqualTo (IntPtr.Zero), "sqlite3_column_table_name");
-				Assert.That (Dlfcn.dlsym (lib, "sqlite3_column_table_name16"), Is.EqualTo (IntPtr.Zero), "sqlite3_column_table_name16");
+				// note 2: simulators also got the new libsqlite version with Xcode 9, and since Xcode 9 ships an ever newer sqlite version,
+				// we get even more API as well.
+				var hasNewerSqlite = TestRuntime.CheckXcodeVersion (9, 0);
+				var hasNewSqlite = hasNewerSqlite || TestRuntime.CheckXcodeVersion (8, 0) && Runtime.Arch == Arch.DEVICE;
+				
+				var new_symbols = new string [] {
+					"sqlite3_key",
+					"sqlite3_rekey",
+				};
+				var newer_symbols = new string [] {
+					"sqlite3_column_database_name",
+					"sqlite3_column_database_name16",
+					"sqlite3_column_origin_name",
+					"sqlite3_column_origin_name16",
+					"sqlite3_column_table_name",
+					"sqlite3_column_table_name16",
+				};
+
+				foreach (var symbol in new_symbols)
+					Assert.That (Dlfcn.dlsym (lib, symbol), hasNewSqlite ? Is.Not.EqualTo (IntPtr.Zero) : Is.EqualTo (IntPtr.Zero), symbol);
+
+				foreach (var symbol in newer_symbols)
+					Assert.That (Dlfcn.dlsym (lib, symbol), hasNewerSqlite ? Is.Not.EqualTo (IntPtr.Zero) : Is.EqualTo (IntPtr.Zero), symbol);
 			}
 			finally {
 				Dlfcn.dlclose (lib);


### PR DESCRIPTION
The simulators now have an updated libsqlite3.dylib, so this test needs to be
updated accordingly.

This fixes a link sdk test failure:

    [FAIL] DllImportTest.Sqlite3 : sqlite3_key