### PR TITLE
[generator] Add a way to add Availability info to generated default ctor

### DIFF
--- a/src/ObjCRuntime/PlatformAvailability2.cs
+++ b/src/ObjCRuntime/PlatformAvailability2.cs
@@ -205,4 +205,34 @@ namespace XamCore.ObjCRuntime
 		{
 		}
 	}
+
+	// Allows generator to include AvailabilityAttribute into generated default ctor
+	[AttributeUsage (AttributeTargets.Interface, AllowMultiple = true)]
+	public class DefaultCtorAvailabilityAttribute : AvailabilityBaseAttribute {
+
+		public DefaultCtorAvailabilityAttribute (AvailabilityKind availability, PlatformName platform,
+				PlatformArchitecture architecture = PlatformArchitecture.None,
+				string message = null)
+				: base (availability, platform, null, architecture, message)
+		{
+		}
+
+		public DefaultCtorAvailabilityAttribute (AvailabilityKind availability, PlatformName platform, int majorVersion, int minorVersion,
+			PlatformArchitecture architecture = PlatformArchitecture.None,
+			string message = null)
+				: base (availability,
+					platform, new Version (majorVersion, minorVersion),
+					architecture, message)
+		{
+		}
+
+		public DefaultCtorAvailabilityAttribute (AvailabilityKind availability, PlatformName platform, int majorVersion, int minorVersion, int subminorVersion,
+			PlatformArchitecture architecture = PlatformArchitecture.None,
+			string message = null)
+				: base (availability,
+					platform, new Version (majorVersion, minorVersion, subminorVersion),
+					architecture, message)
+		{
+		}
+	}
 }

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3009,7 +3009,19 @@ public partial class Generator : IMemberGatherer {
 		if (mi == null)
 			return;
 
-		foreach (var availability in AttributeManager.GetCustomAttributes<AvailabilityBaseAttribute> (mi))
+		foreach (var availability in AttributeManager.GetCustomAttributes<AvailabilityBaseAttribute> (mi)) {
+			if (availability is DefaultCtorAvailabilityAttribute)
+				continue;
+			print (availability.ToString ());
+		}
+	}
+
+	public void PrintDefaultCtorAvailabilityAttributes (MemberInfo mi)
+	{
+		if (mi == null)
+			return;
+
+		foreach (var availability in AttributeManager.GetCustomAttributes<DefaultCtorAvailabilityAttribute> (mi))
 			print (availability.ToString ());
 	}
 
@@ -5749,6 +5761,7 @@ public partial class Generator : IMemberGatherer {
 						if (!disable_default_ctor) {
 							GeneratedCode (sw, 2);
 							sw.WriteLine ("\t\t[EditorBrowsable (EditorBrowsableState.Advanced)]");
+							PrintDefaultCtorAvailabilityAttributes (type);
 							sw.WriteLine ("\t\t[Export (\"init\")]");
 							sw.WriteLine ("\t\t{0} {1} () : base (NSObjectFlag.Empty)", v, TypeName);
 							sw.WriteLine ("\t\t{");
@@ -5762,6 +5775,7 @@ public partial class Generator : IMemberGatherer {
 						if (!disable_default_ctor) {
 							GeneratedCode (sw, 2);
 							sw.WriteLine ("\t\t[EditorBrowsable (EditorBrowsableState.Advanced)]");
+							PrintDefaultCtorAvailabilityAttributes (type);
 							sw.WriteLine ("\t\t[Export (\"init\")]");
 							sw.WriteLine ("\t\t{0} {1} () : base (NSObjectFlag.Empty)", v, TypeName);
 							sw.WriteLine ("\t\t{");

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -21,7 +21,7 @@ else
 IOS_GENERATOR = $(IOS_CURRENT_DIR)/bin/btouch-native /baselib:$(IOS_CURRENT_DIR)/lib/mono/Xamarin.iOS/Xamarin.iOS.dll /unsafe
 endif
 IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts bug43579 bindastests
-IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers bug42742 warnaserror nowarn noasyncinternalwrapper noasyncwarningcs0219 bug53076 bug53076withmodel bug57070
+IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers bug42742 warnaserror nowarn noasyncinternalwrapper noasyncwarningcs0219 bug53076 bug53076withmodel bug57070 defaultctoravailabilityattributetest
 
 MAC_CURRENT_DIR=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
 ifdef IKVM
@@ -259,6 +259,14 @@ bug53076withmodel:
 	$(if $(V),,@echo "$@";) $(IOS_GENERATOR) --sourceonly:$@.source -tmpdir=$@.tmpdir $@.cs
 	@if [ `grep -r "Async (this IMyFooProtocol" $@.tmpdir/Bug53076WithModelTest | wc -l` -ne 10 ]; then \
 		echo "Error: Expected 10 'Async (this IMyFooProtocol' matches in generated code. If you modified code that generates extension FooRequiredMethodAsync (AsyncAttribute) please update the 'Async (this IMyFooProtocol' count."; exit 1; \
+	fi
+
+defaultctoravailabilityattributetest:
+	@rm -Rf $@.tmpdir
+	@mkdir -p $@.tmpdir
+	$(if $(V),,@echo "$@";) $(IOS_GENERATOR) --sourceonly:$@.source -tmpdir=$@.tmpdir $@.cs
+	@if [ `grep -r "Obsoleted" $@.tmpdir/Tests | wc -l` -ne 1 ]; then \
+		echo "Error: Expected 1 matches in generated code."; exit 1; \
 	fi
 
 clean-local::

--- a/tests/generator/defaultctoravailabilityattributetest.cs
+++ b/tests/generator/defaultctoravailabilityattributetest.cs
@@ -1,0 +1,13 @@
+using Foundation;
+using ObjCRuntime;
+
+namespace Tests {
+
+	[Introduced (PlatformName.iOS, 11, 0)]
+	[DefaultCtorAvailability (AvailabilityKind.Obsoleted, PlatformName.iOS, 11, 0, message: "Do not use")]
+	[BaseType (typeof(NSObject))]
+	interface FooClass {
+		[Export ("doSomething")]
+		void DoSomething ();
+	}
+}


### PR DESCRIPTION
This allows to add generated defautl ctor availability information 

```
[Introduced (PlatformName.iOS, 11, 0)]
[DefaultCtorAvailability (AvailabilityKind.Obsoleted, PlatformName.iOS, 11, 0, message: "Do not use")]
[BaseType (typeof(NSObject))]
interface FooClass {
	[Export ("doSomething")]
	void DoSomething ();
}
```

generates

```
[Register("FooClass", true)]
[Introduced (PlatformName.iOS, 11,0)]
public unsafe partial class FooClass : NSObject {
		
	[CompilerGenerated]
	[EditorBrowsable (EditorBrowsableState.Advanced)]
	[Obsoleted (PlatformName.iOS, 11,0, message: "Do not use")]
	[Export ("init")]
	public FooClass () : base (NSObjectFlag.Empty)
	{
		...
	}
}
```


Build diff https://gist.github.com/dalexsoto/11cdd2f95801935044363e9ae0bb47af

**I will document this later, our third party docs are out on sync in all availability stuff** fille bug https://bugzilla.xamarin.com/show_bug.cgi?id=57335 so we do not forget.