### PR TITLE
[monotouch-test] Update according to changes in Xcode 9 beta 1

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -86,6 +86,41 @@ partial class TestRuntime
 		NUnit.Framework.Assert.Ignore ("Requires the platform version shipped with Xcode {0}.{1}", major, minor);
 	}
 
+	public static bool CheckExactXcodeVersion (int major, int minor, int beta = 0)
+	{
+		var nineb1 = new {
+			Xcode = new { Major = 9, Minor = 0, Beta = 1 },
+			iOS = new { Major = 11, Minor = 0, Build = "15A5278f" },
+			tvOS = new { Major = 11, Minor = 0, Build = "?" },
+			macOS = new { Major = 10, Minor = 13, Build = "?" },
+			watchOS = new { Major = 4, Minor = 0, Build = "?" },
+		};
+		var versions = new [] { nineb1 };
+
+		foreach (var v in versions) {
+			if (v.Xcode.Major != major)
+				continue;
+			if (v.Xcode.Minor != minor)
+				continue;
+			if (v.Xcode.Beta != beta)
+				continue;
+
+#if __IOS__
+			if (!CheckExactiOSSystemVersion (v.iOS.Major, v.iOS.Minor))
+				return false;
+			if (v.iOS.Build == "?")
+				throw new NotImplementedException ($"Build number for iOS {v.iOS.Major}.{v.iOS.Minor} beta {beta}");
+			var actual = GetiOSBuildVersion ();
+			Console.WriteLine (actual);
+			return actual == v.iOS.Build;
+#else
+			throw new NotImplementedException ();
+#endif
+		}
+
+		throw new NotImplementedException ($"Xcode version {major}.{minor} beta {beta} not found");
+	}
+
 	public static bool CheckXcodeVersion (int major, int minor, int build = 0)
 	{
 		switch (major) {
@@ -309,6 +344,16 @@ partial class TestRuntime
 		if (throwIfOtherPlatform)
 			throw new Exception ("Can't get iOS System version on other platforms.");
 		return true;
+#endif
+	}
+
+	public static bool CheckExactiOSSystemVersion (int major, int minor)
+	{
+#if __IOS__
+		var version = Version.Parse (UIDevice.CurrentDevice.SystemVersion);
+		return version.Major == major && version.Minor == minor;
+#else
+		throw new Exception ("Can't get iOS System version on other platforms.");
 #endif
 	}
 

--- a/tests/monotouch-test/AddressBook/PersonTest.cs
+++ b/tests/monotouch-test/AddressBook/PersonTest.cs
@@ -54,6 +54,14 @@ namespace MonoTouchFixtures.AddressBook {
 				return;
 			}
 
+			if (TestRuntime.CheckExactXcodeVersion (9, 0, beta: 1)) {
+				// iOS 11 beta 1:
+				// radar://32681458 - ABMultiValueCreateMutableCopy doesn't create a mutable copy
+				// https://trello.com/c/casyTjRR/67-32681458-abmultivaluecreatemutablecopy-doesnt-create-a-mutable-copy
+				// Assigning the Zip property below fails.
+				return;
+			}
+
 			var multi = mutable [0];
 			var addr = multi.Value;
 			addr.Zip = "78972";

--- a/tests/monotouch-test/AddressBook/SourceTest.cs
+++ b/tests/monotouch-test/AddressBook/SourceTest.cs
@@ -43,7 +43,11 @@ namespace MonoTouchFixtures.AddressBook {
 			// ABRecord
 			// some bots returns -1 (invalid) and I get 0 after a reset (maybe permission related?)
 			Assert.That (source.Id, Is.LessThanOrEqualTo (0), "Id");
-			Assert.That (source.Type, Is.EqualTo (ABRecordType.Source), "Type");
+			if (TestRuntime.CheckXcodeVersion (9, 0)) {
+				Assert.That (source.Type, Is.EqualTo (ABRecordType.Person), "Type");
+			} else {
+				Assert.That (source.Type, Is.EqualTo (ABRecordType.Source), "Type");
+			}
 		}
 	}
 }

--- a/tests/monotouch-test/AddressBookUI/AddressFormattingTest.cs
+++ b/tests/monotouch-test/AddressBookUI/AddressFormattingTest.cs
@@ -45,12 +45,19 @@ namespace MonoTouchFixtures.AddressBookUI {
 				{ new NSString ("SubThoroughfare"), new NSString ("1-3") }, 
 				{ new NSString ("CountryCode"), new NSString ("CA") }, 
 			}) {
-				string expected = "1–3 Rue Des Carrières\nQuebec City‎ Quebec‎ G1R 5J5";
+				string expected1 = "1–3 Rue Des Carrières\nQuebec City‎ Quebec‎ G1R 5J5";
+				string expected2 = "1–3 Rue Des Carrières\nQuebec City Quebec G1R 5J5"; // there's a "(char) 8206" character just after 'Quebec'
+				string expected;
 				string s = ABAddressFormatting.ToString (dict, false);
+				if (TestRuntime.CheckXcodeVersion (9, 0)) {
+					expected = expected2;
+				} else {
+					expected = expected1;
+				}
 				Assert.That (s, Is.EqualTo (expected), "false");
 				// country names can be translated, e.g. chinese, so we can't compare it
 				s = ABAddressFormatting.ToString (dict, true);
-				Assert.True (s.StartsWith (expected, StringComparison.Ordinal), "prefix");
+				Assert.That (s, Is.StringStarting (expected), "prefix");
 
 				// Apple broke this again (8.0.x are hard to predict) - test will fail once it's corrected
 				// iOS 8.1.2 device: working
@@ -60,6 +67,10 @@ namespace MonoTouchFixtures.AddressBookUI {
 
 				// we don't check before 8.2 - where both device and simulators works again properly
 				if (!UIDevice.CurrentDevice.CheckSystemVersion (8,2))
+					return;
+
+				// iOS 11.0 beta 1: broken
+				if (TestRuntime.CheckExactXcodeVersion (9, 0, beta: 1))
 					return;
 
 				Assert.That (s [expected.Length], Is.EqualTo ('\n'), "newline");

--- a/tests/monotouch-test/MediaToolbox/FormatNamesTest.cs
+++ b/tests/monotouch-test/MediaToolbox/FormatNamesTest.cs
@@ -32,7 +32,11 @@ namespace MonoTouchFixtures.MediaToolbox {
 
 			Assert.That (CMMediaType.Audio.GetLocalizedName (), Is.EqualTo ("Sound"), "Audio");
 			Assert.That (CMMediaType.ClosedCaption.GetLocalizedName (), Is.EqualTo ("Closed Caption"), "ClosedCaption");
-			Assert.That (CMMediaType.Metadata.GetLocalizedName (), Is.EqualTo ("meta"), "Metadata");
+			if (TestRuntime.CheckXcodeVersion (9, 0)) {
+				Assert.That (CMMediaType.Metadata.GetLocalizedName (), Is.EqualTo ("Metadata"), "Metadata");
+			} else {
+				Assert.That (CMMediaType.Metadata.GetLocalizedName (), Is.EqualTo ("meta"), "Metadata");
+			}
 			Assert.That (CMMediaType.Muxed.GetLocalizedName (), Is.EqualTo ("Muxed"), "Muxed");
 			Assert.That (CMMediaType.Subtitle.GetLocalizedName (), Is.EqualTo ("Subtitle"), "Subtitle");
 			Assert.That (CMMediaType.Text.GetLocalizedName (), Is.EqualTo ("Text"), "Text");

--- a/tests/monotouch-test/ModelIO/MDLMaterialProperty.cs
+++ b/tests/monotouch-test/ModelIO/MDLMaterialProperty.cs
@@ -161,7 +161,11 @@ namespace MonoTouchFixtures.ModelIO {
 
 				// Looks like the URLValue can't change after construction
 				obj.UrlValue = url;
-				Assert.IsNull (obj.UrlValue, "2 UrlValue");
+				if (TestRuntime.CheckXcodeVersion (9, 0)) {
+					Assert.AreSame (url, obj.UrlValue, "2 UrlValue");
+				} else {
+					Assert.IsNull (obj.UrlValue, "2 UrlValue");
+				}
 			}
 
 

--- a/tests/monotouch-test/SceneKit/NodeTest.cs
+++ b/tests/monotouch-test/SceneKit/NodeTest.cs
@@ -49,6 +49,9 @@ namespace MonoTouchFixtures.SceneKit {
 			if (!TestRuntime.CheckSystemAndSDKVersion (8,0))
 				Assert.Ignore ("Requires iOS8");
 
+			if (TestRuntime.CheckXcodeVersion (9, 0))
+				Assert.Ignore ("Crashes: https://trello.com/c/IjrMT5K5/68-32688391-crash-after-adding-caanimation-to-scnnode");
+			
 			using (var a = CAAnimation.CreateAnimation ())
 			using (var n = SCNNode.Create ()) {
 				n.AddAnimation (a, (NSString) null);

--- a/tests/monotouch-test/UIKit/TextFieldTest.cs
+++ b/tests/monotouch-test/UIKit/TextFieldTest.cs
@@ -7,9 +7,11 @@ using System.Drawing;
 #if XAMCORE_2_0
 using Foundation;
 using UIKit;
+using CoreGraphics;
 #else
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
+using MonoTouch.CoreGraphics;
 #endif
 using NUnit.Framework;
 
@@ -54,7 +56,11 @@ namespace MonoTouchFixtures.UIKit {
 		public void EmptySelection ()
 		{
 			using (var tf = new UITextField ()) {
-				Assert.IsNull (tf.SelectedTextRange, "SelectedTextRange");
+				if (TestRuntime.CheckXcodeVersion (9, 0)) {
+					Assert.IsNotNull (tf.SelectedTextRange, "SelectedTextRange 1");
+				} else {
+					Assert.IsNull (tf.SelectedTextRange, "SelectedTextRange");
+				}
 				if (TestRuntime.CheckSystemAndSDKVersion (6,0)) {
 					Assert.IsNull (tf.TypingAttributes, "default");
 					// ^ calling TypingAttributes does not crash like UITextView does, it simply returns null
@@ -83,7 +89,11 @@ namespace MonoTouchFixtures.UIKit {
 			// https://bugzilla.xamarin.com/show_bug.cgi?id=20572
 			using (UITextField tf = new UITextField ()) {
 				var rect = tf.GetCaretRectForPosition (null);
-				Assert.True (rect.IsEmpty, "IsEmpty");
+				if (TestRuntime.CheckXcodeVersion (9, 0)) {
+					Assert.AreEqual (new CGRect (0, -12, 2, 18.5), rect, "IsEmpty");
+				} else {
+					Assert.AreEqual (CGRect.Empty, rect, "IsEmpty");
+				}
 			}
 		}
 


### PR DESCRIPTION
* Update AddressBookUI.AddressFormattingTest according to iOS 11 behavior.

* Update MediaToolbox.FormatNamesTest according to iOS 11 behavior.

* Update UIKit.TextFieldTest according to iOS 11 behavior.

* Ignore SceneKit.NodeTest, it crashes due to an Apple bug.

* Update MDLMaterialProperty test according to new behavior in iOS 11.

* Update AddressBook.SourceTest according to new behavior.

* Ignore parts of AddressBookTest.PersonTest due to an Apple bug.

    ABMultiValueCreateMutableCopy stopped creating a mutable copy, so our
    tests fails. Ignore the corresponding test in beta 1.