### PR TITLE
[msbuild] Fix MSBuild tests to build using Xcode 9.

### DIFF
--- a/msbuild/tests/MySingleView/Info.plist
+++ b/msbuild/tests/MySingleView/Info.plist
@@ -15,7 +15,7 @@
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard</string>
 	<key>MinimumOSVersion</key>
-	<string>6.1</string>
+	<string>7.0</string>
 	<key>CFBundleDisplayName</key>
 	<string>ApplicationName</string>
 	<key>CFBundleIdentifier</key>

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
@@ -36,6 +36,7 @@ namespace Xamarin.iOS.Tasks
 					"LaunchImage-568h@2x.png",
 					"LaunchImage.png",
 					"LaunchImage@2x.png",
+					"Assets.car",
 				};
 				return files.Select (s => Path.Combine (AppBundlePath, s)).ToArray ();
 			}
@@ -435,7 +436,7 @@ namespace Xamarin.iOS.Tasks
 			var path = Path.Combine (MonoTouchProjectPath, "Info.plist");
 			var plist = PDictionary.FromFile (path);
 
-			plist.SetMinimumOSVersion ("6.1");
+			plist.SetMinimumOSVersion ("7.0");
 			plist.Save (path, true);
 
 			RunTarget (MonoTouchProject, TargetName.CollectBundleResources);
@@ -480,7 +481,7 @@ namespace Xamarin.iOS.Tasks
 
 			// Start without app icon.
 			plist.Remove("XSAppIconAssets");
-			plist.SetMinimumOSVersion ("6.1");
+			plist.SetMinimumOSVersion ("7.0");
 			plist.Save (path, true);
 
 			RunTarget (project, TargetName.CompileImageAssets);


### PR DESCRIPTION
Set the min deployment target to 7.0 for a test to make sure ibtool doesn't
complain, and fix the list of expected bundle resources by adding Assets.car
to the list.

Fixes the following failures:

1. Xamarin.iOS.Tasks.TargetTests.BuildExecutable :   #RunTarget-ErrorCount

    	ibtool exited with code 1
    	Compiling IB documents for earlier than iOS 7 is no longer supported.
      Expected: 0
      But was:  2

2. Xamarin.iOS.Tasks.TargetTests.BundleResources :   #RunTarget-ErrorCount

    	ibtool exited with code 1
    	Compiling IB documents for earlier than iOS 7 is no longer supported.
      Expected: 0
      But was:  2

3. Xamarin.iOS.Tasks.TargetTests.CleanExecutable :   #RunTarget-ErrorCount

    	ibtool exited with code 1
    	Compiling IB documents for earlier than iOS 7 is no longer supported.
      Expected: 0
      But was:  2

4. Xamarin.iOS.Tasks.TargetTests.CopyContentToBundle :   #RunTarget-ErrorCount

    	ibtool exited with code 1
    	Compiling IB documents for earlier than iOS 7 is no longer supported.
      Expected: 0
      But was:  2

5. Xamarin.iOS.Tasks.TargetTests.Disappearing_Bundle_Resource :   #2

      Expected: True
      But was:  False

6. Xamarin.iOS.Tasks.TargetTests.Disappearing_Content :   #2

      Expected: True
      But was:  False

7. Xamarin.iOS.Tasks.TargetTests.OptimizePngs_DefaultValue :   #RunTarget-ErrorCount

    	ibtool exited with code 1
    	Compiling IB documents for earlier than iOS 7 is no longer supported.
      Expected: 0
      But was:  2

8. Xamarin.iOS.Tasks.TargetTests.OptimizePngs_False :   #RunTarget-ErrorCount

    	ibtool exited with code 1
    	Compiling IB documents for earlier than iOS 7 is no longer supported.
      Expected: 0
      But was:  2

9. Xamarin.iOS.Tasks.TargetTests.OptimizePngs_True :   #RunTarget-ErrorCount

    	ibtool exited with code 1
    	Compiling IB documents for earlier than iOS 7 is no longer supported.
      Expected: 0
      But was:  2

10. Xamarin.iOS.Tasks.TargetTests.RebuildExecutable_NoModifications :   #RunTarget-ErrorCount

    	ibtool exited with code 1
    	Compiling IB documents for earlier than iOS 7 is no longer supported.
      Expected: 0
      But was:  2

11. Xamarin.iOS.Tasks.TargetTests.RebuildExecutable_TouchLibraryDll :   #RunTarget-ErrorCount

    	ibtool exited with code 1
    	Compiling IB documents for earlier than iOS 7 is no longer supported.
      Expected: 0
      But was:  2

12. Xamarin.iOS.Tasks.TargetTests.UnpackLibraryResources_ExecutableProject :   #RunTarget-ErrorCount

    	ibtool exited with code 1
    	Compiling IB documents for earlier than iOS 7 is no longer supported.
      Expected: 0
      But was:  2