### PR TITLE
[mtouch] Normalize strings that refer to assemblies and their paths before comparing them. Fixes #57266.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -34,6 +34,24 @@ namespace Xamarin
 	public class MTouch
 	{
 		[Test]
+		[TestCase (NormalizationForm.FormC)]
+		[TestCase (NormalizationForm.FormD)]
+		[TestCase (NormalizationForm.FormKC)]
+		[TestCase (NormalizationForm.FormKD)]
+		public void StringNormalization (NormalizationForm form)
+		{
+			var str = "Tūhono".Normalize (form);
+
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (appName: str);
+				mtouch.Linker = MTouchLinker.LinkSdk;
+				mtouch.Verbosity = 9;
+				mtouch.AssertExecute (MTouchAction.BuildSim, "build");
+			}
+		}
+
+		[Test]
 		public void FatAppFiles ()
 		{
 			AssertDeviceAvailable ();

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -504,9 +504,37 @@ namespace Xamarin.Bundler {
 		}
 	}
 
+	public sealed class NormalizedStringComparer : IEqualityComparer<string>
+	{
+		public static readonly NormalizedStringComparer OrdinalIgnoreCase = new NormalizedStringComparer (StringComparer.OrdinalIgnoreCase);
+
+		StringComparer comparer;
+
+		public NormalizedStringComparer (StringComparer comparer)
+		{
+			this.comparer = comparer;
+		}
+
+		public bool Equals (string x, string y)
+		{
+			// From what I gather it doesn't matter which normalization form
+			// is used, but I chose Form D because HFS normalizes to Form D.
+			if (x != null)
+				x = x.Normalize (System.Text.NormalizationForm.FormD);
+			if (y != null)
+				y = y.Normalize (System.Text.NormalizationForm.FormD);
+			return comparer.Equals (x, y);
+		}
+
+		public int GetHashCode (string obj)
+		{
+			return comparer.GetHashCode (obj?.Normalize (System.Text.NormalizationForm.FormD));
+		}
+	}
+
 	public class AssemblyCollection : IEnumerable<Assembly>
 	{
-		Dictionary<string, Assembly> HashedAssemblies = new Dictionary<string, Assembly> (StringComparer.OrdinalIgnoreCase);
+		Dictionary<string, Assembly> HashedAssemblies = new Dictionary<string, Assembly> (NormalizedStringComparer.OrdinalIgnoreCase);
 
 		public void Add (Assembly assembly)
 		{

--- a/tools/mtouch/AssemblyResolver.cs
+++ b/tools/mtouch/AssemblyResolver.cs
@@ -62,7 +62,7 @@ namespace MonoTouch.Tuner {
 
 		public MonoTouchResolver ()
 		{
-			cache = new Dictionary<string, AssemblyDefinition> (StringComparer.OrdinalIgnoreCase);
+			cache = new Dictionary<string, AssemblyDefinition> (NormalizedStringComparer.OrdinalIgnoreCase);
 		}
 
 		ReaderParameters CreateParameters (string path)
@@ -75,7 +75,7 @@ namespace MonoTouch.Tuner {
 
 		public IDictionary ToResolverCache ()
 		{
-			var resolver_cache = new Hashtable (StringComparer.OrdinalIgnoreCase);
+			var resolver_cache = new Dictionary<string, AssemblyDefinition> (NormalizedStringComparer.OrdinalIgnoreCase);
 			foreach (var pair in cache)
 				resolver_cache.Add (pair.Key, pair.Value);
 


### PR DESCRIPTION
HFS normalizes filenames to Form D when files are stored. This means that an
assembly whose assembly name is stored in Form C might be stored in a file
whose filename is Form D (which you'll get if you use the Form C filename).

However, this is a problem when we've already loaded an assembly and if we
doesn't take normalization into account: we check the cache based on the
filename, but store in the cache based on the assembly name. If those two uses
different normalization schemes, bad things (bug #57266) happen.

So in these scenarios normalize strings before comparing them.

https://bugzilla.xamarin.com/show_bug.cgi?id=57266