### PR TITLE
Framework tests were still binding non-linked Simple class which erro…

### DIFF
--- a/tests/mac-binding-project/Makefile
+++ b/tests/mac-binding-project/Makefile
@@ -41,35 +41,35 @@ bin/Mobile-framework/MobileBinding.dll:
 	$(Q) $(SYSTEM_XBUILD) $(XBUILD_VERBOSITY) MobileBinding/MobileBinding_framework.csproj
 
 
-bin/MobileTest-static/MobileTestApp.app: bin/Mobile-static/MobileBinding.dll
+bin/MobileTest-static/MobileTestApp.app/Contents/MacOS/MobileTestApp: bin/Mobile-static/MobileBinding.dll
 	$(Q) $(SYSTEM_XBUILD) $(XBUILD_VERBOSITY) MobileTestApp/MobileTestApp_static.csproj
 
-bin/MobileTest-static-newstyle/MobileTestApp.app: bin/Mobile-static-newstyle/MobileBinding.dll
+bin/MobileTest-static-newstyle/MobileTestApp.app/Contents/MacOS/MobileTestApp: bin/Mobile-static-newstyle/MobileBinding.dll
 	$(Q) $(SYSTEM_XBUILD) $(XBUILD_VERBOSITY) MobileTestApp/MobileTestApp_static_newstyle.csproj
 
-bin/MobileTest-withLinker/MobileTestApp.app: bin/Mobile-static/MobileBinding.dll
+bin/MobileTest-withLinker/MobileTestApp.app/Contents/MacOS/MobileTestApp: bin/Mobile-static/MobileBinding.dll
 	$(Q) $(SYSTEM_XBUILD) $(XBUILD_VERBOSITY) MobileTestApp/MobileTestApp_WithLinker.csproj
 
-bin/MobileTest-dynamic/MobileTestApp.app: bin/Mobile-dynamic/MobileBinding.dll
+bin/MobileTest-dynamic/MobileTestApp.app/Contents/MacOS/MobileTestApp: bin/Mobile-dynamic/MobileBinding.dll
 	$(Q) $(SYSTEM_XBUILD) $(XBUILD_VERBOSITY) MobileTestApp/MobileTestApp_dynamic.csproj
 
-bin/MobileTest-dynamic-newstyle/MobileTestApp.app: bin/Mobile-dynamic-newstyle/MobileBinding.dll
+bin/MobileTest-dynamic-newstyle/MobileTestApp.app/Contents/MacOS/MobileTestApp: bin/Mobile-dynamic-newstyle/MobileBinding.dll
 	$(Q) $(SYSTEM_XBUILD) $(XBUILD_VERBOSITY) MobileTestApp/MobileTestApp_dynamic_newstyle.csproj
 
-bin/MobileTest-dynamic-spaces/MobileTestApp.app: bin/Mobile-dynamic-spaces/Mobile\ Binding.dll
+bin/MobileTest-dynamic-spaces/MobileTestApp.app/Contents/MacOS/MobileTestApp: bin/Mobile-dynamic-spaces/Mobile\ Binding.dll
 	$(Q) $(SYSTEM_XBUILD) $(XBUILD_VERBOSITY) MobileTestApp/MobileTestApp_dynamic_spaces.csproj
 
-bin/MobileTest-framework/MobileTestApp.app: bin/Mobile-framework/MobileBinding.dll
+bin/MobileTest-framework/MobileTestApp.app/Contents/MacOS/MobileTestApp: bin/Mobile-framework/MobileBinding.dll
 	$(Q) $(SYSTEM_XBUILD) $(XBUILD_VERBOSITY) MobileTestApp/MobileTestApp_framework.csproj
 
 
 
 
-test-static:: bin/MobileTest-static/MobileTestApp.app bin/MobileTest-static-newstyle/MobileTestApp.app
+test-static:: bin/MobileTest-static/MobileTestApp.app/Contents/MacOS/MobileTestApp bin/MobileTest-static-newstyle/MobileTestApp.app/Contents/MacOS/MobileTestApp
 	$(Q) ./bin/MobileTest-static/MobileTestApp.app/Contents/MacOS/MobileTestApp 2>&1 | grep 42 > /dev/null
 	$(Q) ./bin/MobileTest-static-newstyle/MobileTestApp.app/Contents/MacOS/MobileTestApp 2>&1 | grep 42 > /dev/null
 
-test-dynamic:: bin/MobileTest-dynamic/MobileTestApp.app bin/MobileTest-dynamic-newstyle/MobileTestApp.app bin/MobileTest-dynamic-spaces/MobileTestApp.app
+test-dynamic:: bin/MobileTest-dynamic/MobileTestApp.app/Contents/MacOS/MobileTestApp bin/MobileTest-dynamic-newstyle/MobileTestApp.app/Contents/MacOS/MobileTestApp bin/MobileTest-dynamic-spaces/MobileTestApp.app/Contents/MacOS/MobileTestApp
 	$(Q) ./bin/MobileTest-dynamic/MobileTestApp.app/Contents/MacOS/MobileTestApp 2>&1 | grep 42 > /dev/null
 	$(Q) test -e bin/MobileTest-dynamic/MobileTestApp.app/Contents/MonoBundle/SimpleClassDylib.dylib
 	$(Q) ./bin/MobileTest-dynamic-newstyle/MobileTestApp.app/Contents/MacOS/MobileTestApp 2>&1 | grep 42 > /dev/null
@@ -77,10 +77,10 @@ test-dynamic:: bin/MobileTest-dynamic/MobileTestApp.app bin/MobileTest-dynamic-n
 	$(Q) ./bin/MobileTest-dynamic-spaces/MobileTestApp.app/Contents/MacOS/MobileTestApp 2>&1 | grep 42 > /dev/null
 	$(Q) test -e bin/MobileTest-dynamic-spaces/MobileTestApp.app/Contents/MonoBundle/SimpleClass\ Dylib.dylib
 
-test-framework:: bin/MobileTest-framework/MobileTestApp.app
+test-framework:: bin/MobileTest-framework/MobileTestApp.app/Contents/MacOS/MobileTestApp
 	$(Q) test -e bin/MobileTest-framework/MobileTestApp.app/Contents/Frameworks/iTunesLibrary.framework
 
-test-withLinker:: bin/MobileTest-withLinker/MobileTestApp.app
+test-withLinker:: bin/MobileTest-withLinker/MobileTestApp.app/Contents/MacOS/MobileTestApp
 	$(Q) ./bin/MobileTest-withLinker/MobileTestApp.app/Contents/MacOS/MobileTestApp 2>&1 | grep 42 > /dev/null
 
 

--- a/tests/mac-binding-project/MobileBinding/ApiDefinition.cs
+++ b/tests/mac-binding-project/MobileBinding/ApiDefinition.cs
@@ -1,5 +1,6 @@
 using Foundation;
 
+#if !FRAMEWORK_TEST
 namespace Simple {
   [BaseType (typeof (NSObject))]
   interface SimpleClass {
@@ -7,3 +8,4 @@ namespace Simple {
     int DoIt ();
   }
 }
+#endif

--- a/tests/mac-binding-project/MobileBinding/MobileBinding_framework.csproj
+++ b/tests/mac-binding-project/MobileBinding/MobileBinding_framework.csproj
@@ -16,7 +16,7 @@
     <Optimize>false</Optimize>
     <OutputPath>..\bin\Mobile-framework\</OutputPath>
     <BaseIntermediateOutputPath>../obj/Mobile-framework/</BaseIntermediateOutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
+    <DefineConstants>DEBUG;FRAMEWORK_TEST</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/tests/mac-binding-project/MobileTestApp/Main.cs
+++ b/tests/mac-binding-project/MobileTestApp/Main.cs
@@ -3,7 +3,9 @@ using System.Reflection;
 using System.IO;
 
 using AppKit;
+#if !FRAMEWORK_TEST
 using Simple;
+#endif
 
 namespace MobileTestApp
 {
@@ -21,10 +23,11 @@ namespace MobileTestApp
 #pragma warning disable 0219		
 			var v = ObjCRuntime.Dlfcn.dlopen (GetCurrentExecutingDirectory () + "/SimpleClassDylib.dylib", 0);
 #pragma warning restore 0219
-
 			NSApplication.Init ();
+#if !FRAMEWORK_TEST
 			SimpleClass c = new SimpleClass ();
 			Console.WriteLine (c.DoIt());
+#endif
 		}
 	}
 }

--- a/tests/mac-binding-project/MobileTestApp/MobileTestApp_framework.csproj
+++ b/tests/mac-binding-project/MobileTestApp/MobileTestApp_framework.csproj
@@ -20,7 +20,7 @@
     <Optimize>false</Optimize>
     <OutputPath>..\bin\MobileTest-framework\</OutputPath>
     <BaseIntermediateOutputPath>../bin/MobileTest-framework/</BaseIntermediateOutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
+    <DefineConstants>DEBUG;FRAMEWORK_TEST</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>


### PR DESCRIPTION
https://github.com/xamarin/xamarin-macios/pull/2216 for d15-3 to fix test warnings.