### PR TITLE
Complete support for [BindAs]

### DIFF
--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -2130,7 +2130,9 @@ namespace XamCore.Registrar {
 		{
 			bool isNativeEnum;
 
-			switch (GetTypeFullName (type)) {
+			var typeFullName = GetTypeFullName (type);
+
+			switch (typeFullName) {
 			case "System.IntPtr": return "^v";
 			case "System.SByte": return "c";
 			case "System.Byte": return "C";
@@ -2162,6 +2164,10 @@ namespace XamCore.Registrar {
 			case "System.DateTime":
 				throw CreateException (4102, member, "The registrar found an invalid type `{0}` in signature for method `{2}`. Use `{1}` instead.", "System.DateTime", IsDualBuild ? "Foundation.NSDate" : CompatNamespace + ".Foundation.NSDate", member.FullName);
 			}
+
+			// We use BindAsAttribute to wrap NSNumber/NSValue into more accurate Nullable<T> types
+			if (typeFullName != null && typeFullName.Contains ("Nullable"))
+				return "@";
 
 			if (Is (type, ObjCRuntime, "Selector"))
 				return ":";

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -2130,9 +2130,7 @@ namespace XamCore.Registrar {
 		{
 			bool isNativeEnum;
 
-			var typeFullName = GetTypeFullName (type);
-
-			switch (typeFullName) {
+			switch (GetTypeFullName (type)) {
 			case "System.IntPtr": return "^v";
 			case "System.SByte": return "c";
 			case "System.Byte": return "C";
@@ -2164,10 +2162,6 @@ namespace XamCore.Registrar {
 			case "System.DateTime":
 				throw CreateException (4102, member, "The registrar found an invalid type `{0}` in signature for method `{2}`. Use `{1}` instead.", "System.DateTime", IsDualBuild ? "Foundation.NSDate" : CompatNamespace + ".Foundation.NSDate", member.FullName);
 			}
-
-			// We use BindAsAttribute to wrap NSNumber/NSValue into more accurate Nullable<T> types
-			if (typeFullName != null && typeFullName.Contains ("Nullable"))
-				return "@";
 
 			if (Is (type, ObjCRuntime, "Selector"))
 				return ":";

--- a/tests/introspection/ApiSignatureTest.cs
+++ b/tests/introspection/ApiSignatureTest.cs
@@ -181,7 +181,18 @@ namespace Introspection {
 
 		protected virtual bool Skip (Type type, MethodBase method, string selector)
 		{
+			if (method is MethodInfo mf) {
+				if (IsNullableType (mf.ReturnType))
+					return true;
+
+				foreach (var param in mf.GetParameters ()) {
+					if (IsNullableType (param.ParameterType))
+						return true;
+				}
+			}
 			return SkipDueToAttribute (method);
+
+			bool IsNullableType (Type t) => Nullable.GetUnderlyingType (t) != null;
 		}
 
 		public int CurrentParameter { get; private set; }

--- a/tests/introspection/ApiSignatureTest.cs
+++ b/tests/introspection/ApiSignatureTest.cs
@@ -985,6 +985,7 @@ namespace Introspection {
 			return false;
 		}
 
+		// This must be kept in sync with generator.cs NSValueCreateMap and NSValueReturnMap
 		protected HashSet<string> BindAsSupportedTypes = new HashSet<string> {
 			"CGAffineTransform", "Range", "CGVector", "SCNMatrix4", "CLLocationCoordinate2D",
 			"SCNVector3", "Vector", "CGPoint", "CGRect", "CGSize", "UIEdgeInsets",


### PR DESCRIPTION
Introspection tests have an issue when verifying native signatures, since we are using `Nullable<T>` and not `NSValue` or `NSNumber` it reports a false positive.

Once we land this fix we can use it for Xcode 9 bindings and actually add to `monotouch-tests` some API using this attribute. like in PR https://github.com/xamarin/xamarin-macios/pull/2193