### PR TITLE
[tests][mtouch] Adjust tests to cope with Xcode 9. Fixes #57601.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -860,7 +860,10 @@ namespace Xamarin
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Sdk = sdk_version;
 				Assert.AreEqual (1, mtouch.Execute (MTouchAction.BuildSim));
-				mtouch.AssertError (91, String.Format ("This version of Xamarin.iOS requires the {0} {1} SDK (shipped with Xcode {2}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only (to try to avoid the new APIs).", name, GetSdkVersion (profile), Configuration.XcodeVersion));
+				var xcodeVersionString = Configuration.XcodeVersion;
+				if (xcodeVersionString.EndsWith (".0", StringComparison.Ordinal))
+					xcodeVersionString = xcodeVersionString.Substring (0, xcodeVersionString.Length - 2);
+				mtouch.AssertError (91, String.Format ("This version of Xamarin.iOS requires the {0} {1} SDK (shipped with Xcode {2}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only (to try to avoid the new APIs).", name, GetSdkVersion (profile), xcodeVersionString));
 			}
 		}
 

--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -709,8 +709,11 @@ class X : ReplayKit.RPBroadcastControllerDelegate
 				mtouch.Verbosity = 9; // Increase verbosity, otherwise linker warnings aren't shown
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build");
 				mtouch.AssertNoWarnings ();
-				foreach (var line in mtouch.OutputLines)
+				foreach (var line in mtouch.OutputLines) {
+					if (line.Contains ("warning: method 'paymentAuthorizationViewController:didAuthorizePayment:handler:' in protocol 'PKPaymentAuthorizationViewControllerDelegate' not implemented [-Wprotocol]"))
+						continue; // Xcode 9 beta 1: this method changed from optional to required.
 					Assert.That (line, Does.Not.Match ("warning:"), "no warnings");
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes:

1. Failed : Xamarin.MTouch.MT0091(tvOS,"tvOS")

```
    The error 'MT0091: This version of Xamarin.iOS requires the tvOS 11.0 SDK (shipped with Xcode 9.0). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only (to try to avoid the new APIs).' was not found in the output:
    Message #1 did not match:
        actual:   'This version of Xamarin.iOS requires the tvOS 11.0 SDK (shipped with Xcode 9). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only (to try to avoid the new APIs).'
        expected: 'This version of Xamarin.iOS requires the tvOS 11.0 SDK (shipped with Xcode 9.0). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only (to try to avoid the new APIs).'
```

2. Failed : Xamarin.MTouch.MT0091(iOS,"iOS")

```
    The error 'MT0091: This version of Xamarin.iOS requires the iOS 11.0 SDK (shipped with Xcode 9.0). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only (to try to avoid the new APIs).' was not found in the output:
    Message #1 did not match:
        actual:   'This version of Xamarin.iOS requires the iOS 11.0 SDK (shipped with Xcode 9). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only (to try to avoid the new APIs).'
        expected: 'This version of Xamarin.iOS requires the iOS 11.0 SDK (shipped with Xcode 9.0). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only (to try to avoid the new APIs).'
```

3. Failed : Xamarin.Registrar.NoWarnings

```
    no warnings
    Expected: not String matching "warning:"
    But was:  "/Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.MTouchTool.CreateTemporaryDirectory298/mtouch-test-cache/registrar.m:32468:17: warning: method 'paymentAuthorizationViewController:didAuthorizePayment:handler:' in protocol 'PKPaymentAuthorizationViewControllerDelegate' not implemented [-Wprotocol]"
```

https://bugzilla.xamarin.com/show_bug.cgi?id=57601