### PR TITLE
NSActivityOptions.IdleDisplaySleepDisabled had wrong value

### DIFF
--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -970,13 +970,13 @@ namespace XamCore.Foundation  {
 
 	[Flags]
 	public enum NSActivityOptions : ulong {
-		IdleDisplaySleepDisabled = 1 << 40,
-		IdleSystemSleepDisabled = 1 << 20,
-		SuddenTerminationDisabled = 1 << 14,
-		AutomaticTerminationDisabled = 1 << 15,
-		UserInitiated = 0x00FFFFFF | IdleSystemSleepDisabled,
-		Background = 0x000000ff,
-		LatencyCritical = 0xFF00000000,
+		IdleDisplaySleepDisabled = 1UL << 40,
+		IdleSystemSleepDisabled = 1UL << 20,
+		SuddenTerminationDisabled = 1UL << 14,
+		AutomaticTerminationDisabled = 1UL << 15,
+		UserInitiated = 0x00FFFFFFUL | IdleSystemSleepDisabled,
+		Background = 0x000000ffUL,
+		LatencyCritical = 0xFF00000000UL,
 	}
 
 	[Native]


### PR DESCRIPTION
This was due to an integer overflow.  The original value was based on `Int32`

```csharp
1 << 40 // value 256
```

The correct value should be based on a `UInt64`.

```csharp
1UL << 40 // value 1099511627776
```

Reference documentation. 
https://developer.apple.com/documentation/foundation/nsactivityoptions/nsactivityidledisplaysleepdisabled?language=objc