### PR TITLE
[tests] Fix bug 57699 - [iOS]InternalsTest failure (Linkall) tests on device

### DIFF
--- a/tests/linker-ios/link all/link all.csproj
+++ b/tests/linker-ios/link all/link all.csproj
@@ -54,6 +54,7 @@
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchExtraArgs>-gcc_flags="-UhoItsB0rken"</MtouchExtraArgs>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug32|iPhone' ">
     <DebugSymbols>True</DebugSymbols>


### PR DESCRIPTION
Fixes bug https://bugzilla.xamarin.com/show_bug.cgi?id=57699

Strip native debugging symbols should not be checked for debug builds