### PR TITLE
[common] Fix StringUtils.Quote to quote backslashes too. Fixes #57768.

### DIFF
--- a/tools/common/StringUtils.cs
+++ b/tools/common/StringUtils.cs
@@ -13,13 +13,14 @@ namespace Xamarin.Utils {
 		}
 
 		static char shellQuoteChar;
+		static char[] mustQuoteCharacters = new char [] { ' ', '\'', ',', '$', '\\' };
 
 		public static string Quote (string f)
 		{
 			if (String.IsNullOrEmpty (f))
 				return f ?? String.Empty;
 
-			if (f.IndexOf (' ') == -1 && f.IndexOf ('\'') == -1 && f.IndexOf (',') == -1 && f.IndexOf ('$') == -1 && f.IndexOf ('\\') == -1)
+			if (f.IndexOfAny (mustQuoteCharacters) == -1)
 				return f;
 
 			var s = new StringBuilder ();

--- a/tools/common/StringUtils.cs
+++ b/tools/common/StringUtils.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Utils {
 			if (String.IsNullOrEmpty (f))
 				return f ?? String.Empty;
 
-			if (f.IndexOf (' ') == -1 && f.IndexOf ('\'') == -1 && f.IndexOf (',') == -1 && f.IndexOf ('$') == -1)
+			if (f.IndexOf (' ') == -1 && f.IndexOf ('\'') == -1 && f.IndexOf (',') == -1 && f.IndexOf ('$') == -1 && f.IndexOf ('\\') == -1)
 				return f;
 
 			var s = new StringBuilder ();


### PR DESCRIPTION
Some Quote implementations quoted backslashes, some didn't. When selecting a
common implementation, one of the implementations that didn't quote
backslashes won, and the rest were forgotten. Almost. Except for the MT0106
test, which started failing, thus exposing the winner's deficiencies.

So dethrone the implementation that won and reinstante the importance of the
backslash.

https://bugzilla.xamarin.com/show_bug.cgi?id=57768