### PR TITLE
[mtouch] Check for __Internal P/Invokes after processing P/Invokes for exception marshaling. Fixes #57833.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -34,6 +34,26 @@ namespace Xamarin
 	public class MTouch
 	{
 		[Test]
+		public void ExceptionMarshaling ()
+		{
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp ();
+				mtouch.CustomArguments = new string [] { "--marshal-objectivec-exceptions=throwmanagedexception", "--dlsym:+Xamarin.iOS.dll" };
+				mtouch.Debug = false; // make sure the output is stripped
+				mtouch.AssertExecute (MTouchAction.BuildDev, "build");
+
+				Assert.That (mtouch.NativeSymbolsInExecutable, Does.Contain ("_xamarin_pinvoke_wrapper_objc_msgSend"), "symbols");
+
+				// build again with llvm enabled
+				mtouch.Abi = "arm64+llvm";
+				mtouch.AssertExecute (MTouchAction.BuildDev, "build llvm");
+
+				Assert.That (mtouch.NativeSymbolsInExecutable, Does.Contain ("_xamarin_pinvoke_wrapper_objc_msgSend"), "symbols llvm");
+			}
+		}
+
+		[Test]
 		[TestCase (NormalizationForm.FormC)]
 		[TestCase (NormalizationForm.FormD)]
 		[TestCase (NormalizationForm.FormKC)]

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -882,5 +882,11 @@ public partial class NotificationController : WKUserNotificationInterfaceControl
 		void IDisposable.Dispose ()
 		{
 		}
+
+		public IEnumerable<string> NativeSymbolsInExecutable {
+			get { 
+				return ExecutionHelper.Execute ("nm", $"-gUj {StringUtils.Quote (NativeExecutablePath)}", hide_output: true).Split ('\n');
+			}
+		}
 	}
 }

--- a/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
+++ b/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
@@ -97,8 +97,6 @@ namespace MonoTouch.Tuner
 		{
 			if (method.IsPInvokeImpl && method.HasPInvokeInfo && method.PInvokeInfo != null) {
 				var pinfo = method.PInvokeInfo;
-				if (pinfo.Module.Name == "__Internal")
-					DerivedLinkContext.RequiredSymbols.AddFunction (pinfo.EntryPoint).AddMember (method);
 
 				if (state != null) {
 					switch (pinfo.EntryPoint) {
@@ -113,6 +111,9 @@ namespace MonoTouch.Tuner
 						return;
 					}
 				}
+
+				if (pinfo.Module.Name == "__Internal")
+					DerivedLinkContext.RequiredSymbols.AddFunction (pinfo.EntryPoint).AddMember (method);
 			}
 
 			if (MarkStep.IsPropertyMethod (method)) {


### PR DESCRIPTION
When we process P/Invokes to add support for exception marshaling, we may
change P/Invokes to be __Internal. This means that we need to move the check
for __Internal P/Invokes to after processing P/Invokes for exception
marshaling.

https://bugzilla.xamarin.com/show_bug.cgi?id=57833