### PR TITLE
[monotouch-test] Allow more values for MACaptionAppearanceGetDisplayType.

### DIFF
--- a/tests/monotouch-test/MediaAccessibility/CaptionAppearanceTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/CaptionAppearanceTest.cs
@@ -50,7 +50,7 @@ namespace MonoTouchFixtures.MediaAccessibility {
 			if (!TestRuntime.CheckSystemAndSDKVersion (7,0))
 				Assert.Ignore ("requires iOS7+");
 
-			Assert.That (MACaptionAppearance.GetDisplayType (MACaptionAppearanceDomain.Default), Is.EqualTo (MACaptionAppearanceDisplayType.Automatic), "Default");
+			Assert.That (MACaptionAppearance.GetDisplayType (MACaptionAppearanceDomain.Default), Is.EqualTo (MACaptionAppearanceDisplayType.Automatic).Or.EqualTo (MACaptionAppearanceDisplayType.AlwaysOn).Or.EqualTo (MACaptionAppearanceDisplayType.ForcedOnly), "Default");
 		}
 	}
 }


### PR DESCRIPTION
On at least one of my devices I get MACaptionAppearanceDisplayType.AlwaysOn,
while the locale is 'en'.

So just allow all valid enum values for the return type.