### PR TITLE
[WKWebkit] Use the right native name in WKHttpCookieStore

### DIFF
--- a/src/wkwebkit.cs
+++ b/src/wkwebkit.cs
@@ -99,7 +99,7 @@ namespace XamCore.WebKit
 	}
 	
 	[Mac (10,13), iOS (11,0)]
-	[BaseType (typeof(NSObject))]
+	[BaseType (typeof(NSObject), Name = "WKHTTPCookieStore")]
 	[DisableDefaultCtor]
 	interface WKHttpCookieStore
 	{


### PR DESCRIPTION
The unmanaged name is `WKHTTPCookieStore`.

ref: https://developer.apple.com/documentation/webkit/wkhttpcookiestore?language=objc