### PR TITLE
[tests][introspection] Teach intro about BindAs and Nullable types. Backport fix from master to xcode9.

### DIFF
--- a/tests/introspection/ApiSignatureTest.cs
+++ b/tests/introspection/ApiSignatureTest.cs
@@ -645,6 +645,12 @@ namespace Introspection {
 		{
 			switch (encodedType) {
 			case '@':
+				// We use BindAsAttribute to wrap NSNumber/NSValue into more accurate Nullable<T> types
+				// So we check if T of nullable is supported by bindAs
+				var nullableType = Nullable.GetUnderlyingType (type);
+				if (nullableType != null)
+					return BindAsSupportedTypes.Contains (nullableType.Name);
+
 				return (type.IsInterface ||								// protocol
 					type.IsArray || 									// NSArray
 					(type.Name == "NSArray") || 						// NSArray
@@ -980,5 +986,14 @@ namespace Introspection {
 			}
 			return false;
 		}
+
+		// This must be kept in sync with generator.cs NSValueCreateMap and NSValueReturnMap
+		protected HashSet<string> BindAsSupportedTypes = new HashSet<string> {
+			"CGAffineTransform", "Range", "CGVector", "SCNMatrix4", "CLLocationCoordinate2D",
+			"SCNVector3", "Vector", "CGPoint", "CGRect", "CGSize", "UIEdgeInsets",
+			"UIOffset", "MKCoordinateSpan", "CMTimeRange", "CMTime", "CMTimeMapping",
+			"CATransform3D", "Boolean", "Byte", "Double", "Float", "Int16", "Int32",
+			"Int64", "SByte", "UInt16", "UInt32", "UInt64", "nfloat", "nint", "nuint",
+		};
 	}
 }


### PR DESCRIPTION
Backport fix from master to xcode9

* [introspection] Add better type checking instead of totally skipping the type when Nullable type is encountered

Introspection will currently fail if BindAs is used. Introspection
will report that the incorrect type is registered so we need verify
if a Nullable type is found in the signature and check against of
a withelist of BindAs supported types