### PR TITLE
[system-dependencies] Clear xcrun cache after switching system Xcode.

### DIFF
--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -269,6 +269,8 @@ function install_specific_xcode () {
 
 	log "Executing 'sudo xcode-select -s $XCODE_DEVELOPER_ROOT'"
 	sudo xcode-select -s $XCODE_DEVELOPER_ROOT
+	log "Clearing xcrun cache..."
+	xcrun -k
 
 	ok "Xcode $XCODE_VERSION provisioned"
 }
@@ -316,6 +318,8 @@ function check_specific_xcode () {
 		if ! test -z $PROVISION_XCODE; then
 			log "Executing 'sudo xcode-select -s $XCODE_DEVELOPER_ROOT'"
 			sudo xcode-select -s $XCODE_DEVELOPER_ROOT
+			log "Clearing xcrun cache..."
+			xcrun -k
 		else
 			fail "'xcode-select -p' does not point to $XCODE_DEVELOPER_ROOT, it points to $XCODE_SELECT. Execute 'sudo xcode-select -s $XCODE_DEVELOPER_ROOT' to fix."
 		fi


### PR DESCRIPTION
It seems the xcrun cache can become corrupted when switching between betas, so
make sure to clear it when we change the system Xcode.