### PR TITLE
[xharness] Don't show verbose diagnostics when killing the device log capture process.

### DIFF
--- a/tests/xharness/DeviceLogCapturer.cs
+++ b/tests/xharness/DeviceLogCapturer.cs
@@ -58,7 +58,7 @@ namespace xharness
 			if (process.HasExited)
 				return;
 			
-			process.KillTreeAsync (Harness.HarnessLog).Wait ();
+			process.KillTreeAsync (Harness.HarnessLog, diagnostics: false).Wait ();
 			process.Dispose ();
 		}
 	}

--- a/tests/xharness/Process_Extensions.cs
+++ b/tests/xharness/Process_Extensions.cs
@@ -156,8 +156,8 @@ namespace xharness
 		{
 			var pids = new List<int> ();
 			GetChildrenPS (log, pids, pid);
-			log.WriteLine ($"Pids to kill: {string.Join (", ", pids.Select ((v) => v.ToString ()).ToArray ())}");
 			if (diagnostics) {
+				log.WriteLine ($"Pids to kill: {string.Join (", ", pids.Select ((v) => v.ToString ()).ToArray ())}");
 				using (var ps = new Process ()) {
 					log.WriteLine ("Writing process list:");
 					ps.StartInfo.FileName = "ps";


### PR DESCRIPTION
Killing this process is normal, so no diagnostics is needed (it only ends up
confusing because it looks like something crashed or timed out).