### PR TITLE
Table view naming fix p1

### DIFF
--- a/Xamarin.Mac.sln
+++ b/Xamarin.Mac.sln
@@ -324,6 +324,31 @@ Global
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = tools\mmp\mmp.csproj
+		Policies = $0
+		$0.TextStylePolicy = $1
+		$1.FileWidth = 80
+		$1.TabWidth = 8
+		$1.IndentWidth = 8
+		$1.scope = text/x-csharp
+		$0.CSharpFormattingPolicy = $2
+		$2.IndentSwitchSection = False
+		$2.NewLinesForBracesInProperties = False
+		$2.NewLinesForBracesInAccessors = False
+		$2.NewLinesForBracesInAnonymousMethods = False
+		$2.NewLinesForBracesInControlBlocks = False
+		$2.NewLinesForBracesInAnonymousTypes = False
+		$2.NewLinesForBracesInObjectCollectionArrayInitializers = False
+		$2.NewLinesForBracesInLambdaExpressionBody = False
+		$2.NewLineForElse = False
+		$2.NewLineForCatch = False
+		$2.NewLineForFinally = False
+		$2.NewLineForMembersInObjectInit = False
+		$2.NewLineForMembersInAnonymousTypes = False
+		$2.NewLineForClausesInQuery = False
+		$2.SpacingAfterMethodDeclarationName = True
+		$2.SpaceAfterMethodCallName = True
+		$2.SpaceBeforeOpenSquareBracket = True
+		$2.scope = text/x-csharp
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{D12F0F7B-8DE3-43EC-BA49-41052D065A9B} = {542D4426-F287-4126-9889-E17628DAECEA}

--- a/Xamarin.Mac.sln
+++ b/Xamarin.Mac.sln
@@ -326,7 +326,7 @@ Global
 		StartupItem = tools\mmp\mmp.csproj
 		Policies = $0
 		$0.TextStylePolicy = $1
-		$1.FileWidth = 80
+		$1.FileWidth = 180
 		$1.TabWidth = 8
 		$1.IndentWidth = 8
 		$1.scope = text/x-csharp
@@ -349,6 +349,7 @@ Global
 		$2.SpaceAfterMethodCallName = True
 		$2.SpaceBeforeOpenSquareBracket = True
 		$2.scope = text/x-csharp
+		$2.SpaceAfterCast = True
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{D12F0F7B-8DE3-43EC-BA49-41052D065A9B} = {542D4426-F287-4126-9889-E17628DAECEA}

--- a/Xamarin.iOS.sln
+++ b/Xamarin.iOS.sln
@@ -555,4 +555,31 @@ Global
 		{839212D5-C25B-4284-AA96-59C3872B8184} = {2BFA13F8-B568-48BF-9A70-9D43F718C523}
 		{9A1177F5-16E6-45DE-AA69-DC9924EC39B8} = {2BFA13F8-B568-48BF-9A70-9D43F718C523}
 	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		Policies = $0
+		$0.TextStylePolicy = $1
+		$1.FileWidth = 80
+		$1.TabWidth = 8
+		$1.IndentWidth = 8
+		$1.scope = text/x-csharp
+		$0.CSharpFormattingPolicy = $2
+		$2.IndentSwitchSection = False
+		$2.NewLinesForBracesInProperties = False
+		$2.NewLinesForBracesInAccessors = False
+		$2.NewLinesForBracesInAnonymousMethods = False
+		$2.NewLinesForBracesInControlBlocks = False
+		$2.NewLinesForBracesInAnonymousTypes = False
+		$2.NewLinesForBracesInObjectCollectionArrayInitializers = False
+		$2.NewLinesForBracesInLambdaExpressionBody = False
+		$2.NewLineForElse = False
+		$2.NewLineForCatch = False
+		$2.NewLineForFinally = False
+		$2.NewLineForMembersInObjectInit = False
+		$2.NewLineForMembersInAnonymousTypes = False
+		$2.NewLineForClausesInQuery = False
+		$2.SpacingAfterMethodDeclarationName = True
+		$2.SpaceAfterMethodCallName = True
+		$2.SpaceBeforeOpenSquareBracket = True
+		$2.scope = text/x-csharp
+	EndGlobalSection
 EndGlobal

--- a/Xamarin.iOS.sln
+++ b/Xamarin.iOS.sln
@@ -558,7 +558,7 @@ Global
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0
 		$0.TextStylePolicy = $1
-		$1.FileWidth = 80
+		$1.FileWidth = 180
 		$1.TabWidth = 8
 		$1.IndentWidth = 8
 		$1.scope = text/x-csharp
@@ -581,5 +581,6 @@ Global
 		$2.SpaceAfterMethodCallName = True
 		$2.SpaceBeforeOpenSquareBracket = True
 		$2.scope = text/x-csharp
+		$2.SpaceAfterCast = True
 	EndGlobalSection
 EndGlobal

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -8860,7 +8860,7 @@ namespace XamCore.UIKit {
 #if XAMCORE_4_0
 		nint RowsInSection (UITableView tableView, nint section);
 #else
-        nint RowsInSection (UITableView tableview, nint section);
+		nint RowsInSection (UITableView tableview, nint section);
 #endif
 
 		[Export ("tableView:cellForRowAtIndexPath:")]
@@ -11161,9 +11161,9 @@ namespace XamCore.UIKit {
 		[Export ("tableView:numberOfRowsInSection:")]
 		[Abstract]
 #if XAMCORE_4_0
-        nint RowsInSection (UITableView tableView, nint section);
+		nint RowsInSection (UITableView tableView, nint section);
 #else
-        nint RowsInSection (UITableView tableview, nint section);
+		nint RowsInSection (UITableView tableview, nint section);
 #endif
 
 		[Export ("tableView:cellForRowAtIndexPath:")]


### PR DESCRIPTION
Now the Xamarin.iOS solution follows the mono naming convention. This will prevent people from straying from the spaces vs tabs standard. @chamons 