### PR TITLE
[src] Fix infinite recursion in make.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -342,7 +342,6 @@ IOS_TARGETS += \
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/2.1/monotouch.dll.mdb               \
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/2.1/OpenTK.dll                      \
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/2.1/OpenTK.pdb                      \
-	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/2.1/OpenTK.dll.config               \
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/2.1/OpenTK-1.0.dll                  \
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/2.1/OpenTK-1.0.pdb                  \
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/2.1/OpenTK-1.0.dll.config           \

--- a/src/OpenGLES/Makefile.include
+++ b/src/OpenGLES/Makefile.include
@@ -1,6 +1,3 @@
-$(IOS_BUILD_DIR)/compat/OpenTK.dll.config: ./OpenGLES/OpenTK/OpenTK.dll.config | $(IOS_BUILD_DIR)/compat
-	$(Q) cp $< $@
-
 $(IOS_BUILD_DIR)/compat/OpenTK.dll: Makefile OpenGLES/Makefile.include $(shell cat OpenTK.dll.sources) $(IOS_BUILD_DIR)/compat/monotouch.dll | $(IOS_BUILD_DIR)/compat
 	$(Q_CSC) $(IOS_CSC) -warn:0 -unsafe -target:library -debug:portable -optimize -publicsign -define:MONOTOUCH -define:IPHONE -d:MINIMAL -out:$@ @./$(@F).sources -r:$(IOS_BUILD_DIR)/compat/monotouch.dll -r:$(MONOTOUCH_MONO_PATH)/System.dll -keyfile:$(PRODUCT_KEY_PATH)
 	$(Q) touch $@


### PR DESCRIPTION
For some reason the target to build OpenTK.dll.config may cause an infinite
recursion in make.

I don't understand what's happening, but we don't need OpenTK.dll.config
anymore, so just not produce/ship it anymore.