### PR TITLE
[Vision] Add bindings for Xcode 9 Beta 1, 2 & 3

### DIFF
--- a/runtime/bindings.h
+++ b/runtime/bindings.h
@@ -2,6 +2,7 @@
 #define __BINDINGS_H__
 
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 #include <objc/objc.h>
 #include <objc/runtime.h>
 #include <objc/message.h>
@@ -185,6 +186,8 @@ void             xamarin_vector_float3__Vector3_objc_msgSendSuper_stret (struct 
 void             xamarin_vector_float3__void_objc_msgSendSuper_Vector3 (struct objc_super *super, SEL sel, struct Vector3f p0);
 void             xamarin_vector_float3__Vector3_objc_msgSendSuper_stret_Vector3 (struct Vector3f *v3, struct objc_super *super, SEL sel, struct Vector3f p0);
 struct Vector3f  xamarin_vector_float3__Vector3_objc_msgSendSuper_Vector3 (struct objc_super *super, SEL sel, struct Vector3f p0);
+CGPoint          xamarin_CGPoint__VNNormalizedFaceBoundingBoxPointForLandmarkPoint_Vector2_CGRect_nuint_nuint (struct Vector2f faceLandmarkPoint, CGRect faceBoundingBox, xm_nuint_t imageWidth, xm_nuint_t imageHeight);
+CGPoint          xamarin_CGPoint__VNImagePointForFaceLandmarkPoint_Vector2_CGRect_nuint_nuint (struct Vector2f faceLandmarkPoint, CGRect faceBoundingBox, xm_nuint_t imageWidth, xm_nuint_t imageHeight);
 
 #ifndef XAMCORE_2_0
 #ifdef MONOMAC

--- a/runtime/bindings.h
+++ b/runtime/bindings.h
@@ -186,8 +186,8 @@ void             xamarin_vector_float3__Vector3_objc_msgSendSuper_stret (struct 
 void             xamarin_vector_float3__void_objc_msgSendSuper_Vector3 (struct objc_super *super, SEL sel, struct Vector3f p0);
 void             xamarin_vector_float3__Vector3_objc_msgSendSuper_stret_Vector3 (struct Vector3f *v3, struct objc_super *super, SEL sel, struct Vector3f p0);
 struct Vector3f  xamarin_vector_float3__Vector3_objc_msgSendSuper_Vector3 (struct objc_super *super, SEL sel, struct Vector3f p0);
-CGPoint          xamarin_CGPoint__VNNormalizedFaceBoundingBoxPointForLandmarkPoint_Vector2_CGRect_nuint_nuint (struct Vector2f faceLandmarkPoint, CGRect faceBoundingBox, xm_nuint_t imageWidth, xm_nuint_t imageHeight);
-CGPoint          xamarin_CGPoint__VNImagePointForFaceLandmarkPoint_Vector2_CGRect_nuint_nuint (struct Vector2f faceLandmarkPoint, CGRect faceBoundingBox, xm_nuint_t imageWidth, xm_nuint_t imageHeight);
+CGPoint          xamarin_CGPoint__VNNormalizedFaceBoundingBoxPointForLandmarkPoint_Vector2_CGRect_nuint_nuint_string (struct Vector2f faceLandmarkPoint, CGRect faceBoundingBox, xm_nuint_t imageWidth, xm_nuint_t imageHeight, const char **error_msg);
+CGPoint          xamarin_CGPoint__VNImagePointForFaceLandmarkPoint_Vector2_CGRect_nuint_nuint_string (struct Vector2f faceLandmarkPoint, CGRect faceBoundingBox, xm_nuint_t imageWidth, xm_nuint_t imageHeight, const char **error_msg);
 
 #ifndef XAMCORE_2_0
 #ifdef MONOMAC

--- a/runtime/bindings.m
+++ b/runtime/bindings.m
@@ -91,24 +91,32 @@ void * monotouch_IntPtr_objc_msgSendSuper_IntPtr (struct objc_super *super, SEL 
 
 /*
  * Vector c bindings
+ *
+ * The following code uses dlsym to not have a linking dependency on Xcode 9,
+ * the code can be simplified once we require to remove dlsym or xcode 9 becomes the minimum supported version
  */
 
 typedef CGPoint (*vision_func) (vector_float2 faceLandmarkPoint, CGRect faceBoundingBox, size_t imageWidth, size_t imageHeight);
 
 CGPoint
-xamarin_CGPoint__VNNormalizedFaceBoundingBoxPointForLandmarkPoint_Vector2_CGRect_nuint_nuint (struct Vector2f faceLandmarkPoint, CGRect faceBoundingBox, xm_nuint_t imageWidth, xm_nuint_t imageHeight) {
+xamarin_CGPoint__VNNormalizedFaceBoundingBoxPointForLandmarkPoint_Vector2_CGRect_nuint_nuint_string (struct Vector2f faceLandmarkPoint, CGRect faceBoundingBox, xm_nuint_t imageWidth, xm_nuint_t imageHeight, const char **error_msg) {
 
 	static vision_func func = NULL;
+	*error_msg = NULL;
 
 	if (func == NULL) {
 		void *vision_handle = dlopen ("/System/Library/Frameworks/Vision.framework/Vision", RTLD_LAZY);
-		if (vision_handle == NULL)
-			xamarin_assertion_message ("Could not open Vision Framework");
+		if (vision_handle == NULL) {
+			*error_msg = "Could not open Vision Framework";
+			return CGPointMake (0, 0);
+		}
 
 		func = (vision_func) dlsym (vision_handle, "VNNormalizedFaceBoundingBoxPointForLandmarkPoint");
 
-		if (func == NULL)
-			xamarin_assertion_message ("Could not obtain the address for VNNormalizedFaceBoundingBoxPointForLandmarkPoint");
+		if (func == NULL) {
+			*error_msg = "Could not obtain the address for VNNormalizedFaceBoundingBoxPointForLandmarkPoint";
+			return CGPointMake (0, 0);
+		}
 	}
 
 	vector_float2 flp;
@@ -119,19 +127,24 @@ xamarin_CGPoint__VNNormalizedFaceBoundingBoxPointForLandmarkPoint_Vector2_CGRect
 }
 
 CGPoint
-xamarin_CGPoint__VNImagePointForFaceLandmarkPoint_Vector2_CGRect_nuint_nuint (struct Vector2f faceLandmarkPoint, CGRect faceBoundingBox, xm_nuint_t imageWidth, xm_nuint_t imageHeight) {
+xamarin_CGPoint__VNImagePointForFaceLandmarkPoint_Vector2_CGRect_nuint_nuint_string (struct Vector2f faceLandmarkPoint, CGRect faceBoundingBox, xm_nuint_t imageWidth, xm_nuint_t imageHeight, const char **error_msg) {
 
 	static vision_func func = NULL;
+	*error_msg = NULL;
 
 	if (func == NULL) {
 		void *vision_handle = dlopen ("/System/Library/Frameworks/Vision.framework/Vision", RTLD_LAZY);
-		if (vision_handle == NULL)
-			xamarin_assertion_message ("Could not open Vision Framework");
+		if (vision_handle == NULL) {
+			*error_msg = "Could not open Vision Framework";
+			return CGPointMake (0, 0);
+		}
 
 		func = (vision_func) dlsym (vision_handle, "VNImagePointForFaceLandmarkPoint");
 
-		if (func == NULL)
-			xamarin_assertion_message ("Could not obtain the address for VNImagePointForFaceLandmarkPoint");
+		if (func == NULL) {
+			*error_msg = "Could not obtain the address for VNImagePointForFaceLandmarkPoint";
+			return CGPointMake (0, 0);
+		}
 	}
 
 	vector_float2 flp;

--- a/runtime/bindings.m
+++ b/runtime/bindings.m
@@ -11,6 +11,7 @@
  */
 
 #include "bindings.h"
+#include <dlfcn.h>
 
 /*
  * Hand-written bindings to support ObjectiveC exceptions.
@@ -88,3 +89,54 @@ void * monotouch_IntPtr_objc_msgSendSuper_IntPtr (struct objc_super *super, SEL 
 #endif
 #endif
 
+/*
+ * Vector c bindings
+ */
+
+typedef CGPoint (*vision_func) (vector_float2 faceLandmarkPoint, CGRect faceBoundingBox, size_t imageWidth, size_t imageHeight);
+
+CGPoint
+xamarin_CGPoint__VNNormalizedFaceBoundingBoxPointForLandmarkPoint_Vector2_CGRect_nuint_nuint (struct Vector2f faceLandmarkPoint, CGRect faceBoundingBox, xm_nuint_t imageWidth, xm_nuint_t imageHeight) {
+
+	static vision_func func = NULL;
+
+	if (func == NULL) {
+		void *vision_handle = dlopen ("/System/Library/Frameworks/Vision.framework/Vision", RTLD_LAZY);
+		if (vision_handle == NULL)
+			xamarin_assertion_message ("Could not open Vision Framework");
+
+		func = (vision_func) dlsym (vision_handle, "VNNormalizedFaceBoundingBoxPointForLandmarkPoint");
+
+		if (func == NULL)
+			xamarin_assertion_message ("Could not obtain the address for VNNormalizedFaceBoundingBoxPointForLandmarkPoint");
+	}
+
+	vector_float2 flp;
+	flp [0] = faceLandmarkPoint.a;
+	flp [1] = faceLandmarkPoint.b;
+
+	return func (flp, faceBoundingBox, imageWidth, imageHeight);
+}
+
+CGPoint
+xamarin_CGPoint__VNImagePointForFaceLandmarkPoint_Vector2_CGRect_nuint_nuint (struct Vector2f faceLandmarkPoint, CGRect faceBoundingBox, xm_nuint_t imageWidth, xm_nuint_t imageHeight) {
+
+	static vision_func func = NULL;
+
+	if (func == NULL) {
+		void *vision_handle = dlopen ("/System/Library/Frameworks/Vision.framework/Vision", RTLD_LAZY);
+		if (vision_handle == NULL)
+			xamarin_assertion_message ("Could not open Vision Framework");
+
+		func = (vision_func) dlsym (vision_handle, "VNImagePointForFaceLandmarkPoint");
+
+		if (func == NULL)
+			xamarin_assertion_message ("Could not obtain the address for VNImagePointForFaceLandmarkPoint");
+	}
+
+	vector_float2 flp;
+	flp [0] = faceLandmarkPoint.a;
+	flp [1] = faceLandmarkPoint.b;
+
+	return func (flp, faceBoundingBox, imageWidth, imageHeight);
+}

--- a/src/Constants.iOS.cs.in
+++ b/src/Constants.iOS.cs.in
@@ -112,5 +112,6 @@ namespace MonoTouch {
 		public const string DeviceCheckLibrary = "/System/Library/Frameworks/DeviceCheck.framework/DeviceCheck";
 		public const string IdentityLookupLibrary = "/System/Library/Frameworks/IdentityLookup.framework/IdentityLookup";
 		public const string CoreMLLibrary = "/System/Library/Frameworks/CoreML.framework/CoreML";
+		public const string VisionLibrary = "/System/Library/Frameworks/Vision.framework/Vision";
 	}
 }

--- a/src/Constants.mac.cs.in
+++ b/src/Constants.mac.cs.in
@@ -128,5 +128,6 @@ namespace MonoMac {
 
 		// macOS 10.13
 		public const string CoreMLLibrary = "/System/Library/Frameworks/CoreML.framework/CoreML";
+		public const string VisionLibrary = "/System/Library/Frameworks/Vision.framework/Vision";
 	}
 }

--- a/src/Constants.tvos.cs.in
+++ b/src/Constants.tvos.cs.in
@@ -72,5 +72,6 @@ namespace ObjCRuntime {
 		// tvOS 11.0
 		public const string DeviceCheckLibrary = "/System/Library/Frameworks/DeviceCheck.framework/DeviceCheck";
 		public const string CoreMLLibrary = "/System/Library/Frameworks/CoreML.framework/CoreML";
+		public const string VisionLibrary = "/System/Library/Frameworks/Vision.framework/Vision";
 	}
 }

--- a/src/CoreMedia/CMAttachmentBearer.cs
+++ b/src/CoreMedia/CMAttachmentBearer.cs
@@ -28,6 +28,23 @@ namespace XamCore.CoreMedia {
 			return Runtime.GetNSObject<NSDictionary> (attachments, true);
 		}
 
+#if XAMCORE_2_0
+		// There is some API that needs a more strongly typed version of a NSDictionary
+		// and there is no easy way to downcast from NSDictionary to NSDictionary<TKey, TValue>
+		public static NSDictionary<TKey, TValue> GetAttachments<TKey, TValue> (this ICMAttachmentBearer target, CMAttachmentMode attachmentMode)
+			where TKey : class, INativeObject
+			where TValue : class, INativeObject
+		{
+			if (target == null)
+				throw new ArgumentNullException (nameof (target));
+			var attachments = CMCopyDictionaryOfAttachments (IntPtr.Zero, target.Handle, attachmentMode);
+			if (attachments == IntPtr.Zero)
+				return null;
+
+			return Runtime.GetNSObject<NSDictionary<TKey, TValue>> (attachments);
+		}
+#endif
+
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CFTypeRef */ IntPtr CMGetAttachment (/* CMAttachmentBearerRef */ IntPtr target, /* CFStringRef */ IntPtr key,
 			/* CMAttachmentMode */ out CMAttachmentMode attachmentModeOut);

--- a/src/CoreVideo/CVBuffer.cs
+++ b/src/CoreVideo/CVBuffer.cs
@@ -166,6 +166,17 @@ namespace XamCore.CoreVideo {
 			return (NSDictionary) Runtime.GetNSObject (CVBufferGetAttachments (handle, attachmentMode));
 		}
 
+#if XAMCORE_2_0
+		// There is some API that needs a more strongly typed version of a NSDictionary
+		// and there is no easy way to downcast from NSDictionary to NSDictionary<TKey, TValue>
+		public NSDictionary<TKey, TValue> GetAttachments<TKey, TValue> (CVAttachmentMode attachmentMode)
+			where TKey : class, INativeObject
+			where TValue : class, INativeObject
+		{
+			return Runtime.GetNSObject<NSDictionary<TKey, TValue>> (CVBufferGetAttachments (handle, attachmentMode));
+		}
+#endif
+
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static void CVBufferPropagateAttachments (/* CVBufferRef */ IntPtr sourceBuffer, /* CVBufferRef */ IntPtr destinationBuffer);
 

--- a/src/Foundation/NSObject.mac.cs
+++ b/src/Foundation/NSObject.mac.cs
@@ -98,6 +98,7 @@ namespace XamCore.Foundation {
 		static IntPtr mp = Dlfcn.dlopen (Constants.MediaPlayerLibrary, 1);
 		static IntPtr pc = Dlfcn.dlopen (Constants.PrintCoreLibrary, 1);
 		static IntPtr cml = Dlfcn.dlopen (Constants.CoreMLLibrary, 1);
+		static IntPtr vn = Dlfcn.dlopen (Constants.VisionLibrary, 1);
 #endif
 		// ** IF YOU ADD ITEMS HERE PLEASE UPDATE linker/ObjCExtensions.cs and mmp/linker/MonoMac.Tuner/MonoMacNamespaces.cs
 

--- a/src/Vision/VNFaceLandmarkRegion2D.cs
+++ b/src/Vision/VNFaceLandmarkRegion2D.cs
@@ -19,7 +19,7 @@ namespace XamCore.Vision {
 			get { return GetPoint (index); }
 		}
 
-		public Vector2 [] Points {
+		public virtual Vector2 [] Points {
 			get {
 				var ret = _GetPoints ();
 				if (ret == IntPtr.Zero)

--- a/src/Vision/VNFaceLandmarkRegion2D.cs
+++ b/src/Vision/VNFaceLandmarkRegion2D.cs
@@ -1,0 +1,40 @@
+﻿//
+// VNFaceLandmarkRegion2D.cs
+//
+// Authors:
+//	Alex Soto  <alexsoto@microsoft.com>
+//
+// Copyright 2017 Xamarin Inc. All rights reserved.
+//
+
+#if XAMCORE_2_0
+
+using System;
+using Vector2 = global::OpenTK.Vector2;
+
+namespace XamCore.Vision {
+	public partial class VNFaceLandmarkRegion2D {
+
+		public Vector2 this [nuint index] {
+			get { return GetPoint (index); }
+		}
+
+		public Vector2 [] Points {
+			get {
+				var ret = _GetPoints ();
+				if (ret == IntPtr.Zero)
+					return null;
+
+				unsafe {
+					var count = (int) PointCount;
+					var rv = new Vector2 [count];
+					var ptr = (Vector2*) ret;
+					for (int i = 0; i < count; i++)
+						rv [i] = *ptr++;
+					return rv;
+				}
+			}
+		}
+	}
+}
+#endif

--- a/src/Vision/VNRequest.cs
+++ b/src/Vision/VNRequest.cs
@@ -1,0 +1,29 @@
+﻿//
+// VNRequest.cs
+//
+// Authors:
+//	Alex Soto  <alexsoto@microsoft.com>
+//
+// Copyright 2017 Xamarin Inc. All rights reserved.
+//
+
+#if XAMCORE_2_0
+
+using System;
+using XamCore.Foundation;
+using XamCore.ObjCRuntime;
+
+namespace XamCore.Vision {
+	public partial class VNRequest {
+
+		public virtual T [] GetResults<T> () where T : VNObservation
+		{
+			// From docs: If the request failed, this property will be nil;
+			// otherwise, it will be an array of zero or more VNObservation
+			// subclasses specific to the VNRequest subclass.
+			// ArrayFromHandle<T> does the null checking for us.
+			return NSArray.ArrayFromHandle<T> (_Results);
+		}
+	}
+}
+#endif

--- a/src/Vision/VNUtils.cs
+++ b/src/Vision/VNUtils.cs
@@ -24,25 +24,17 @@ namespace XamCore.Vision {
 		[Field ("VNNormalizedIdentityRect", Constants.VisionLibrary)]
 		public static CGRect NormalizedIdentityRect { get; } = Dlfcn.GetCGRect (Libraries.Vision.Handle, "VNNormalizedIdentityRect");
 
-		[DllImport (Constants.VisionLibrary)]
-		static extern bool VNNormalizedRectIsIdentityRect (CGRect rect);
+		[DllImport (Constants.VisionLibrary, EntryPoint = "VNNormalizedRectIsIdentityRect")]
+		public static extern bool IsIdentityRect (CGRect rect);
 
-		public static bool IsIdentityRect (CGRect normalizedRect) => VNNormalizedRectIsIdentityRect (normalizedRect);
+		[DllImport (Constants.VisionLibrary, EntryPoint = "VNImagePointForNormalizedPoint")]
+		public static extern CGPoint GetImagePoint (CGPoint normalizedPoint, nuint imageWidth, nuint imageHeight);
 
-		[DllImport (Constants.VisionLibrary)]
-		static extern CGPoint VNImagePointForNormalizedPoint (CGPoint normalizedPoint, nuint imageWidth, nuint imageHeight);
+		[DllImport (Constants.VisionLibrary, EntryPoint = "VNImageRectForNormalizedRect")]
+		public static extern CGRect GetImageRect (CGRect normalizedRect, nuint imageWidth, nuint imageHeight);
 
-		public static CGPoint GetImagePoint (CGPoint normalizedPoint, nuint imageWidth, nuint imageHeight) => VNImagePointForNormalizedPoint (normalizedPoint, imageWidth, imageHeight);
-
-		[DllImport (Constants.VisionLibrary)]
-		static extern CGRect VNImageRectForNormalizedRect (CGRect normalizedRect, nuint imageWidth, nuint imageHeight);
-
-		public static CGRect GetImageRect (CGRect normalizedRect, nuint imageWidth, nuint imageHeight) => VNImageRectForNormalizedRect (normalizedRect, imageWidth, imageHeight);
-
-		[DllImport (Constants.VisionLibrary)]
-		static extern CGRect VNNormalizedRectForImageRect (CGRect imageRect, nuint imageWidth, nuint imageHeight);
-
-		public static CGRect GetNormalizedRect (CGRect imageRect, nuint imageWidth, nuint imageHeight) => VNNormalizedRectForImageRect (imageRect, imageWidth, imageHeight);
+		[DllImport (Constants.VisionLibrary, EntryPoint = "VNNormalizedRectForImageRect")]
+		static extern CGRect GetNormalizedRect (CGRect imageRect, nuint imageWidth, nuint imageHeight);
 
 		[DllImport ("__Internal", EntryPoint = "xamarin_CGPoint__VNNormalizedFaceBoundingBoxPointForLandmarkPoint_Vector2_CGRect_nuint_nuint_string")]
 		static extern CGPoint VNNormalizedFaceBoundingBoxPointForLandmarkPoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight, out IntPtr error);

--- a/src/Vision/VNUtils.cs
+++ b/src/Vision/VNUtils.cs
@@ -1,0 +1,70 @@
+﻿//
+// VNUtils.cs
+//
+// Authors:
+//	Alex Soto  <alexsoto@microsoft.com>
+//
+// Copyright 2017 Xamarin Inc. All rights reserved.
+//
+
+#if XAMCORE_2_0
+
+using System;
+using System.Runtime.InteropServices;
+using XamCore.CoreGraphics;
+using XamCore.ObjCRuntime;
+using XamCore.Foundation;
+
+using Vector2 = global::OpenTK.Vector2;
+
+namespace XamCore.Vision {
+	public static partial class VNUtils {
+
+		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+		[Field ("VNNormalizedIdentityRect", Constants.VisionLibrary)]
+		public static CGRect NormalizedIdentityRect { get; } = Dlfcn.GetCGRect (Libraries.Vision.Handle, "VNNormalizedIdentityRect");
+
+		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+		[DllImport (Constants.VisionLibrary)]
+		static extern bool VNNormalizedRectIsIdentityRect (CGRect rect);
+
+		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+		public static bool IsIdentityRect (CGRect normalizedRect) => VNNormalizedRectIsIdentityRect (normalizedRect);
+
+		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+		[DllImport (Constants.VisionLibrary)]
+		static extern CGPoint VNImagePointForNormalizedPoint (CGPoint normalizedPoint, nuint imageWidth, nuint imageHeight);
+
+		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+		public static CGPoint GetImagePoint (CGPoint normalizedPoint, nuint imageWidth, nuint imageHeight) => VNImagePointForNormalizedPoint (normalizedPoint, imageWidth, imageHeight);
+
+		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+		[DllImport (Constants.VisionLibrary)]
+		static extern CGRect VNImageRectForNormalizedRect (CGRect normalizedRect, nuint imageWidth, nuint imageHeight);
+
+		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+		public static CGRect GetImageRect (CGRect normalizedRect, nuint imageWidth, nuint imageHeight) => VNImageRectForNormalizedRect (normalizedRect, imageWidth, imageHeight);
+
+		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+		[DllImport (Constants.VisionLibrary)]
+		static extern CGRect VNNormalizedRectForImageRect (CGRect imageRect, nuint imageWidth, nuint imageHeight);
+
+		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+		public static CGRect GetNormalizedRect (CGRect imageRect, nuint imageWidth, nuint imageHeight) => VNNormalizedRectForImageRect (imageRect, imageWidth, imageHeight);
+
+		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+		[DllImport ("__Internal", EntryPoint = "xamarin_CGPoint__VNNormalizedFaceBoundingBoxPointForLandmarkPoint_Vector2_CGRect_nuint_nuint")]
+		static extern CGPoint VNNormalizedFaceBoundingBoxPointForLandmarkPoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight);
+
+		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+		public static CGPoint GetNormalizedFaceBoundingBoxPoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight) => VNNormalizedFaceBoundingBoxPointForLandmarkPoint (faceLandmarkPoint, faceBoundingBox, imageWidth, imageHeight);
+
+		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+		[DllImport ("__Internal", EntryPoint = "xamarin_CGPoint__VNImagePointForFaceLandmarkPoint_Vector2_CGRect_nuint_nuint")]
+		static extern CGPoint VNImagePointForFaceLandmarkPoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight);
+
+		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+		public static CGPoint GetImagePoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight) => VNImagePointForFaceLandmarkPoint (faceLandmarkPoint, faceBoundingBox, imageWidth, imageHeight);
+	}
+}
+#endif

--- a/src/Vision/VNUtils.cs
+++ b/src/Vision/VNUtils.cs
@@ -53,18 +53,34 @@ namespace XamCore.Vision {
 		public static CGRect GetNormalizedRect (CGRect imageRect, nuint imageWidth, nuint imageHeight) => VNNormalizedRectForImageRect (imageRect, imageWidth, imageHeight);
 
 		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
-		[DllImport ("__Internal", EntryPoint = "xamarin_CGPoint__VNNormalizedFaceBoundingBoxPointForLandmarkPoint_Vector2_CGRect_nuint_nuint")]
-		static extern CGPoint VNNormalizedFaceBoundingBoxPointForLandmarkPoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight);
+		[DllImport ("__Internal", EntryPoint = "xamarin_CGPoint__VNNormalizedFaceBoundingBoxPointForLandmarkPoint_Vector2_CGRect_nuint_nuint_string")]
+		static extern CGPoint VNNormalizedFaceBoundingBoxPointForLandmarkPoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight, out IntPtr error);
 
 		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
-		public static CGPoint GetNormalizedFaceBoundingBoxPoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight) => VNNormalizedFaceBoundingBoxPointForLandmarkPoint (faceLandmarkPoint, faceBoundingBox, imageWidth, imageHeight);
+		public static CGPoint GetNormalizedFaceBoundingBoxPoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight)
+		{
+			IntPtr error;
+			var result = VNNormalizedFaceBoundingBoxPointForLandmarkPoint (faceLandmarkPoint, faceBoundingBox, imageWidth, imageHeight, out error);
+			if (error != IntPtr.Zero)
+				throw new InvalidOperationException (Marshal.PtrToStringAuto (error));
+
+			return result;
+		}
 
 		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
-		[DllImport ("__Internal", EntryPoint = "xamarin_CGPoint__VNImagePointForFaceLandmarkPoint_Vector2_CGRect_nuint_nuint")]
-		static extern CGPoint VNImagePointForFaceLandmarkPoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight);
+		[DllImport ("__Internal", EntryPoint = "xamarin_CGPoint__VNImagePointForFaceLandmarkPoint_Vector2_CGRect_nuint_nuint_string")]
+		static extern CGPoint VNImagePointForFaceLandmarkPoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight, out IntPtr error);
 
 		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
-		public static CGPoint GetImagePoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight) => VNImagePointForFaceLandmarkPoint (faceLandmarkPoint, faceBoundingBox, imageWidth, imageHeight);
+		public static CGPoint GetImagePoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight)
+		{
+			IntPtr error;
+			var result = VNImagePointForFaceLandmarkPoint (faceLandmarkPoint, faceBoundingBox, imageWidth, imageHeight, out error);
+			if (error != IntPtr.Zero)
+				throw new InvalidOperationException (Marshal.PtrToStringAuto (error));
+
+			return result;
+		}
 	}
 }
 #endif

--- a/src/Vision/VNUtils.cs
+++ b/src/Vision/VNUtils.cs
@@ -18,45 +18,35 @@ using XamCore.Foundation;
 using Vector2 = global::OpenTK.Vector2;
 
 namespace XamCore.Vision {
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 	public static partial class VNUtils {
-
-		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	
 		[Field ("VNNormalizedIdentityRect", Constants.VisionLibrary)]
 		public static CGRect NormalizedIdentityRect { get; } = Dlfcn.GetCGRect (Libraries.Vision.Handle, "VNNormalizedIdentityRect");
 
-		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		[DllImport (Constants.VisionLibrary)]
 		static extern bool VNNormalizedRectIsIdentityRect (CGRect rect);
 
-		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		public static bool IsIdentityRect (CGRect normalizedRect) => VNNormalizedRectIsIdentityRect (normalizedRect);
 
-		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		[DllImport (Constants.VisionLibrary)]
 		static extern CGPoint VNImagePointForNormalizedPoint (CGPoint normalizedPoint, nuint imageWidth, nuint imageHeight);
 
-		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		public static CGPoint GetImagePoint (CGPoint normalizedPoint, nuint imageWidth, nuint imageHeight) => VNImagePointForNormalizedPoint (normalizedPoint, imageWidth, imageHeight);
 
-		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		[DllImport (Constants.VisionLibrary)]
 		static extern CGRect VNImageRectForNormalizedRect (CGRect normalizedRect, nuint imageWidth, nuint imageHeight);
 
-		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		public static CGRect GetImageRect (CGRect normalizedRect, nuint imageWidth, nuint imageHeight) => VNImageRectForNormalizedRect (normalizedRect, imageWidth, imageHeight);
 
-		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		[DllImport (Constants.VisionLibrary)]
 		static extern CGRect VNNormalizedRectForImageRect (CGRect imageRect, nuint imageWidth, nuint imageHeight);
 
-		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		public static CGRect GetNormalizedRect (CGRect imageRect, nuint imageWidth, nuint imageHeight) => VNNormalizedRectForImageRect (imageRect, imageWidth, imageHeight);
 
-		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		[DllImport ("__Internal", EntryPoint = "xamarin_CGPoint__VNNormalizedFaceBoundingBoxPointForLandmarkPoint_Vector2_CGRect_nuint_nuint_string")]
 		static extern CGPoint VNNormalizedFaceBoundingBoxPointForLandmarkPoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight, out IntPtr error);
 
-		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		public static CGPoint GetNormalizedFaceBoundingBoxPoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight)
 		{
 			IntPtr error;
@@ -67,11 +57,9 @@ namespace XamCore.Vision {
 			return result;
 		}
 
-		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		[DllImport ("__Internal", EntryPoint = "xamarin_CGPoint__VNImagePointForFaceLandmarkPoint_Vector2_CGRect_nuint_nuint_string")]
 		static extern CGPoint VNImagePointForFaceLandmarkPoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight, out IntPtr error);
 
-		[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		public static CGPoint GetImagePoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight)
 		{
 			IntPtr error;

--- a/src/Vision/VNUtils.cs
+++ b/src/Vision/VNUtils.cs
@@ -34,7 +34,7 @@ namespace XamCore.Vision {
 		public static extern CGRect GetImageRect (CGRect normalizedRect, nuint imageWidth, nuint imageHeight);
 
 		[DllImport (Constants.VisionLibrary, EntryPoint = "VNNormalizedRectForImageRect")]
-		static extern CGRect GetNormalizedRect (CGRect imageRect, nuint imageWidth, nuint imageHeight);
+		public static extern CGRect GetNormalizedRect (CGRect imageRect, nuint imageWidth, nuint imageHeight);
 
 		[DllImport ("__Internal", EntryPoint = "xamarin_CGPoint__VNNormalizedFaceBoundingBoxPointForLandmarkPoint_Vector2_CGRect_nuint_nuint_string")]
 		static extern CGPoint VNNormalizedFaceBoundingBoxPointForLandmarkPoint (Vector2 faceLandmarkPoint, CGRect faceBoundingBox, nuint imageWidth, nuint imageHeight, out IntPtr error);

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1397,6 +1397,12 @@ VIDEOTOOLBOX_SOURCES = \
 	VideoToolbox/VTUtilities.cs \
 	VideoToolbox/VTPixelTransferProperties.cs \
 
+# Vision
+
+VISION_SOURCES = \
+	Vision/VNFaceLandmarkRegion2D.cs \
+	Vision/VNUtils.cs \
+
 # WatchConnectivity
 
 WATCHCONNECTIVITY_CORE_SOURCES = \
@@ -1604,6 +1610,7 @@ MAC_FRAMEWORKS =            \
 	StoreKit                \
 	SystemConfiguration     \
 	VideoToolbox            \
+	Vision                  \
 	WebKit                  \
 	WKWebKit                \
 
@@ -1689,6 +1696,7 @@ IOS_FRAMEWORKS =         \
 	UserNotificationsUI \
 	VideoToolbox \
 	VideoSubscriberAccount \
+	Vision \
 	WatchConnectivity \
 	WatchKit \
 	WKWebKit \
@@ -1768,6 +1776,7 @@ TVOS_FRAMEWORKS =           \
 	UserNotifications       \
 	VideoSubscriberAccount  \
 	VideoToolbox            \
+	Vision            \
 
 #
 # Compute the SOURCES variables.

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1401,6 +1401,7 @@ VIDEOTOOLBOX_SOURCES = \
 
 VISION_SOURCES = \
 	Vision/VNFaceLandmarkRegion2D.cs \
+	Vision/VNRequest.cs \
 	Vision/VNUtils.cs \
 
 # WatchConnectivity

--- a/src/vision.cs
+++ b/src/vision.cs
@@ -131,8 +131,8 @@ namespace XamCore.Vision {
 	delegate void VNRequestCompletionHandler (VNRequest request, NSError error);
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
-	[BaseType (typeof (VNImageBasedRequest))]
 	[DisableDefaultCtor]
+	[BaseType (typeof (VNImageBasedRequest))]
 	interface VNCoreMLRequest {
 
 		[Export ("model")]
@@ -155,6 +155,7 @@ namespace XamCore.Vision {
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 	[Abstract]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNImageBasedRequest))]
 	interface VNDetectBarcodesRequest {
 
@@ -171,6 +172,7 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNImageBasedRequest))]
 	interface VNDetectFaceLandmarksRequest : VNFaceObservationAccepting {
 
@@ -180,6 +182,7 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNImageBasedRequest))]
 	interface VNDetectFaceRectanglesRequest {
 
@@ -189,6 +192,7 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNImageBasedRequest))]
 	interface VNDetectHorizonRequest {
 
@@ -198,6 +202,7 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNImageBasedRequest))]
 	interface VNDetectRectanglesRequest {
 
@@ -225,6 +230,7 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNImageBasedRequest))]
 	interface VNDetectTextRectanglesRequest {
 
@@ -238,6 +244,7 @@ namespace XamCore.Vision {
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 	[Abstract]
+	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
 	interface VNFaceLandmarkRegion {
 
@@ -246,6 +253,7 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNFaceLandmarkRegion))]
 	interface VNFaceLandmarkRegion2D {
 
@@ -260,6 +268,7 @@ namespace XamCore.Vision {
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 	[Abstract]
+	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
 	interface VNFaceLandmarks {
 
@@ -268,6 +277,7 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNFaceLandmarks))]
 	interface VNFaceLandmarks2D {
 
@@ -324,6 +334,7 @@ namespace XamCore.Vision {
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 	[Abstract]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNTargetedImageRequest))]
 	interface VNImageRegistrationRequest {
 
@@ -364,6 +375,7 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNImageRegistrationRequest))]
 	interface VNTranslationalImageRegistrationRequest {
 
@@ -405,6 +417,7 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNImageRegistrationRequest))]
 	interface VNHomographicImageRegistrationRequest {
 
@@ -447,6 +460,7 @@ namespace XamCore.Vision {
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 	[Abstract]
+	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
 	interface VNObservation : NSCopying, NSSecureCoding {
 
@@ -458,6 +472,7 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNObservation))]
 	interface VNDetectedObjectObservation {
 
@@ -470,14 +485,21 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNDetectedObjectObservation))]
 	interface VNFaceObservation {
 
 		[NullAllowed, Export ("landmarks", ArgumentSemantic.Strong)]
 		VNFaceLandmarks2D Landmarks { get; }
+
+		[New]
+		[Static]
+		[Export ("observationWithBoundingBox:")]
+		VNFaceObservation FromBoundingBox (CGRect boundingBox);
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNObservation))]
 	interface VNClassificationObservation {
 
@@ -486,6 +508,7 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNObservation))]
 	interface VNCoreMLFeatureValueObservation {
 
@@ -494,6 +517,7 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNObservation))]
 	interface VNPixelBufferObservation {
 
@@ -502,6 +526,7 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNDetectedObjectObservation))]
 	interface VNRectangleObservation {
 
@@ -516,14 +541,25 @@ namespace XamCore.Vision {
 
 		[Export ("bottomRight", ArgumentSemantic.Assign)]
 		CGPoint BottomRight { get; }
+
+		[New]
+		[Static]
+		[Export ("observationWithBoundingBox:")]
+		VNRectangleObservation FromBoundingBox (CGRect boundingBox);
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNDetectedObjectObservation))]
 	interface VNTextObservation {
 
 		[NullAllowed, Export ("characterBoxes", ArgumentSemantic.Copy)]
 		VNRectangleObservation [] CharacterBoxes { get; }
+
+		[New]
+		[Static]
+		[Export ("observationWithBoundingBox:")]
+		VNTextObservation FromBoundingBox (CGRect boundingBox);
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
@@ -533,12 +569,18 @@ namespace XamCore.Vision {
 		[Export ("symbology")]
 		string Symbology { get; }
 
-		// TODO: Enable once CoreImage Xcode 9 is bound
+		// TODO: Enable once CoreImage Xcode 9 is bound -> https://bugzilla.xamarin.com/show_bug.cgi?id=58197
 		//[NullAllowed, Export ("barcodeDescriptor", ArgumentSemantic.Strong)]
 		//CIBarcodeDescriptor BarcodeDescriptor { get; }
+
+		[New]
+		[Static]
+		[Export ("observationWithBoundingBox:")]
+		VNBarcodeObservation FromBoundingBox (CGRect boundingBox);
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNObservation))]
 	interface VNHorizonObservation {
 
@@ -551,11 +593,13 @@ namespace XamCore.Vision {
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 	[Abstract]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNObservation))]
 	interface VNImageAlignmentObservation {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNImageAlignmentObservation))]
 	interface VNImageTranslationAlignmentObservation {
 
@@ -564,6 +608,7 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNImageAlignmentObservation))]
 	interface VNImageHomographicAlignmentObservation {
 
@@ -578,6 +623,7 @@ namespace XamCore.Vision {
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 	[Abstract]
+	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
 	interface VNRequest : NSCopying {
 
@@ -591,8 +637,12 @@ namespace XamCore.Vision {
 		[NullAllowed, Export ("preferredMetalContext", ArgumentSemantic.Retain)]
 		IMTLDevice PreferredMetalContext { get; set; }
 
+		// From docs: VNObservation subclasses specific to the VNRequest subclass
+		// Since downcasting is not easy we are exposing
+		// this property as a generic method 'GetResults'.
+		[Internal]
 		[NullAllowed, Export ("results", ArgumentSemantic.Copy)]
-		VNObservation [] Results { get; }
+		IntPtr _Results { get; }
 
 		[NullAllowed, Export ("completionHandler", ArgumentSemantic.Copy)]
 		VNRequestCompletionHandler CompletionHandler { get; }
@@ -600,6 +650,7 @@ namespace XamCore.Vision {
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 	[Abstract]
+	[DisableDefaultCtor]
 	[BaseType (typeof (VNRequest))]
 	interface VNImageBasedRequest {
 
@@ -612,12 +663,26 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
-	enum VNImageOption {
+	[Internal]
+	[Static]
+	interface VNImageOptionKeys {
 		[Field ("VNImageOptionProperties")]
-		Properties,
+		NSString PropertiesKey { get; }
 
 		[Field ("VNImageOptionCameraIntrinsics")]
-		CameraIntrinsics,
+		NSString CameraIntrinsicsKey { get; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[StrongDictionary ("VNImageOptionKeys")]
+	interface VNImageOptions {
+		[Export ("PropertiesKey")] // Have the option to set your own dict
+		NSDictionary WeakProperties { get; set; }
+
+		[StrongDictionary] // Yep we need CoreGraphics to disambiguate
+		CoreGraphics.CGImageProperties Properties { get; set; }
+
+		NSData CameraIntrinsics { get; set; }
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
@@ -626,34 +691,64 @@ namespace XamCore.Vision {
 	interface VNImageRequestHandler {
 
 		[Export ("initWithCVPixelBuffer:options:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary<NSString, NSObject> options);
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary options);
+
+		[Wrap ("this (pixelBuffer, imageOptions?.Dictionary)")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions imageOptions);
 
 		[Export ("initWithCVPixelBuffer:orientation:options:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary<NSString, NSObject> options);
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary options);
+
+		[Wrap ("this (pixelBuffer, orientation, imageOptions?.Dictionary)")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
 
 		[Export ("initWithCGImage:options:")]
-		IntPtr Constructor (CGImage image, NSDictionary<NSString, NSObject> options);
+		IntPtr Constructor (CGImage image, NSDictionary options);
+
+		[Wrap ("this (image, imageOptions?.Dictionary)")]
+		IntPtr Constructor (CGImage image, VNImageOptions imageOptions);
 
 		[Export ("initWithCGImage:orientation:options:")]
-		IntPtr Constructor (CGImage image, CGImagePropertyOrientation orientation, NSDictionary<NSString, NSObject> options);
+		IntPtr Constructor (CGImage image, CGImagePropertyOrientation orientation, NSDictionary options);
+
+		[Wrap ("this (image, orientation, imageOptions?.Dictionary)")]
+		IntPtr Constructor (CGImage image, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
 
 		[Export ("initWithCIImage:options:")]
-		IntPtr Constructor (CIImage image, NSDictionary<NSString, NSObject> options);
+		IntPtr Constructor (CIImage image, NSDictionary options);
+
+		[Wrap ("this (image, imageOptions?.Dictionary)")]
+		IntPtr Constructor (CIImage image, VNImageOptions imageOptions);
 
 		[Export ("initWithCIImage:orientation:options:")]
-		IntPtr Constructor (CIImage image, CGImagePropertyOrientation orientation, NSDictionary<NSString, NSObject> options);
+		IntPtr Constructor (CIImage image, CGImagePropertyOrientation orientation, NSDictionary options);
+
+		[Wrap ("this (image, orientation, imageOptions?.Dictionary)")]
+		IntPtr Constructor (CIImage image, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
 
 		[Export ("initWithURL:options:")]
-		IntPtr Constructor (NSUrl imageUrl, NSDictionary<NSString, NSObject> options);
+		IntPtr Constructor (NSUrl imageUrl, NSDictionary options);
+
+		[Wrap ("this (imageUrl, imageOptions?.Dictionary)")]
+		IntPtr Constructor (NSUrl imageUrl, VNImageOptions imageOptions);
 
 		[Export ("initWithURL:orientation:options:")]
-		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary<NSString, NSObject> options);
+		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary options);
+
+		[Wrap ("this (imageUrl, orientation, imageOptions?.Dictionary)")]
+		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
 
 		[Export ("initWithData:options:")]
-		IntPtr Constructor (NSData imageData, NSDictionary<NSString, NSObject> options);
+		IntPtr Constructor (NSData imageData, NSDictionary options);
+
+		[Wrap ("this (imageData, imageOptions?.Dictionary)")]
+		IntPtr Constructor (NSData imageData, VNImageOptions imageOptions);
 
 		[Export ("initWithData:orientation:options:")]
-		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary<NSString, NSObject> options);
+		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary options);
+
+		[Wrap ("this (imageData, orientation, imageOptions?.Dictionary)")]
+		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions imageOptions);
 
 		[Export ("performRequests:error:")]
 		bool Perform (VNRequest [] requests, out NSError error);

--- a/src/vision.cs
+++ b/src/vision.cs
@@ -59,7 +59,7 @@ namespace XamCore.Vision {
 	enum VNImageCropAndScaleOption : nuint {
 		CenterCrop = 0,
 		ScaleFit = 1,
-		ScaleFill
+		ScaleFill,
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]

--- a/src/vision.cs
+++ b/src/vision.cs
@@ -28,7 +28,7 @@ namespace XamCore.Vision {
 	[ErrorDomain ("VNErrorDomain")]
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 	[Native]
-	public enum VNErrorCode : nint {
+	enum VNErrorCode : nint {
 		Ok = 0,
 		RequestCancelled,
 		InvalidFormat,
@@ -49,20 +49,21 @@ namespace XamCore.Vision {
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 	[Native]
-	public enum VNRequestTrackingLevel : nuint {
+	enum VNRequestTrackingLevel : nuint {
 		Accurate = 0,
 		Fast,
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
-	public enum VNImageCropAndScaleOption : uint {
+	[Native]
+	enum VNImageCropAndScaleOption : nuint {
 		CenterCrop = 0,
 		ScaleFit = 1,
-		ScaleFill,
+		ScaleFill
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
-	public enum VNBarcodeSymbology {
+	enum VNBarcodeSymbology {
 		[Field ("VNBarcodeSymbologyAztec")]
 		Aztec,
 

--- a/src/vision.cs
+++ b/src/vision.cs
@@ -1,0 +1,790 @@
+﻿//
+// Vision C# bindings
+//
+// Authors:
+//	Alex Soto  <alexsoto@microsoft.com>
+//
+// Copyright 2017 Xamarin Inc. All rights reserved.
+//
+
+#if XAMCORE_2_0
+
+using System;
+using XamCore.CoreFoundation;
+using XamCore.CoreGraphics;
+using XamCore.CoreImage;
+using XamCore.CoreML;
+using XamCore.CoreVideo;
+using XamCore.Foundation;
+using XamCore.Metal;
+using XamCore.ObjCRuntime;
+
+using Vector2 = global::OpenTK.Vector2;
+using Matrix3 = global::OpenTK.Matrix3;
+
+namespace XamCore.Vision {
+
+	[ErrorDomain ("VNErrorDomain")]
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[Native]
+	public enum VNErrorCode : nint {
+		Ok = 0,
+		RequestCancelled,
+		InvalidFormat,
+		OperationFailed,
+		OutOfBoundsError,
+		InvalidOption,
+		IOError,
+		MissingOption,
+		NotImplemented,
+		InternalError,
+		OutOfMemory,
+		UnknownError,
+		InvalidOperation,
+		InvalidImage,
+		InvalidArgument,
+		InvalidModel
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[Native]
+	public enum VNRequestTrackingLevel : nuint {
+		Accurate = 0,
+		Fast
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	public enum VNImageCropAndScaleOption : uint {
+		CenterCrop = 0,
+		ScaleFit = 1,
+		ScaleFill
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	public enum VNBarcodeSymbology {
+		[Field ("VNBarcodeSymbologyAztec")]
+		Aztec,
+
+		[Field ("VNBarcodeSymbologyCODE39")]
+		Code39,
+
+		[Field ("VNBarcodeSymbologyCODE39Checksum")]
+		Code39Checksum,
+
+		[Field ("VNBarcodeSymbologyCODE39FullASCII")]
+		Code39FullAscii,
+
+		[Field ("VNBarcodeSymbologyCODE39FullASCIIChecksum")]
+		Code39FullAsciiChecksum,
+
+		[Field ("VNBarcodeSymbologyCODE93")]
+		Code93,
+
+		[Field ("VNBarcodeSymbologyCODE93i")]
+		Code93i,
+
+		[Field ("VNBarcodeSymbologyCODE128")]
+		Code128,
+
+		[Field ("VNBarcodeSymbologyDataMatrix")]
+		DataMatrix,
+
+		[Field ("VNBarcodeSymbologyEAN8")]
+		Ean8,
+
+		[Field ("VNBarcodeSymbologyEAN13")]
+		Ean13,
+
+		[Field ("VNBarcodeSymbologyI2OF5")]
+		I2OF5,
+
+		[Field ("VNBarcodeSymbologyI2OF5Checksum")]
+		I2OF5Checksum,
+
+		[Field ("VNBarcodeSymbologyITF14")]
+		Itf14,
+
+		[Field ("VNBarcodeSymbologyPDF417")]
+		Pdf417,
+
+		[Field ("VNBarcodeSymbologyQR")]
+		QR,
+
+		[Field ("VNBarcodeSymbologyUPCE")]
+		Upce,
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor]
+	interface VNCoreMLModel {
+
+		[Static]
+		[Export ("modelForMLModel:error:")]
+		[return: NullAllowed]
+		VNCoreMLModel FromMLModel (MLModel model, out NSError error);
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	delegate void VNRequestCompletionHandler (VNRequest request, NSError error);
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNImageBasedRequest))]
+	[DisableDefaultCtor]
+	interface VNCoreMLRequest {
+
+		[Export ("model")]
+		VNCoreMLModel Model { get; }
+
+		[Export ("imageCropAndScaleOption", ArgumentSemantic.Assign)]
+		VNImageCropAndScaleOption ImageCropAndScaleOption { get; set; }
+
+		[Export ("initWithModel:")]
+		IntPtr Constructor (VNCoreMLModel model);
+
+		[Export ("initWithModel:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (VNCoreMLModel model, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithCompletionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[Abstract]
+	[BaseType (typeof (VNImageBasedRequest))]
+	interface VNDetectBarcodesRequest {
+
+		[Export ("initWithCompletionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Static]
+		[Export ("supportedSymbologies", ArgumentSemantic.Copy)]
+		string [] SupportedSymbologies { get; }
+
+		[Export ("symbologies", ArgumentSemantic.Copy)]
+		string [] Symbologies { get; set; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNImageBasedRequest))]
+	interface VNDetectFaceLandmarksRequest : VNFaceObservationAccepting {
+
+		[Export ("initWithCompletionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNImageBasedRequest))]
+	interface VNDetectFaceRectanglesRequest {
+
+		[Export ("initWithCompletionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNImageBasedRequest))]
+	interface VNDetectHorizonRequest {
+
+		[Export ("initWithCompletionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNImageBasedRequest))]
+	interface VNDetectRectanglesRequest {
+
+		[Export ("initWithCompletionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("minimumAspectRatio")]
+		float MinimumAspectRatio { get; set; }
+
+		[Export ("maximumAspectRatio")]
+		float MaximumAspectRatio { get; set; }
+
+		[Export ("quadratureTolerance")]
+		float QuadratureTolerance { get; set; }
+
+		[Export ("minimumSize")]
+		float MinimumSize { get; set; }
+
+		[Export ("minimumConfidence")]
+		float MinimumConfidence { get; set; }
+
+		[Export ("maximumObservations")]
+		nuint MaximumObservations { get; set; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNImageBasedRequest))]
+	interface VNDetectTextRectanglesRequest {
+
+		[Export ("initWithCompletionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("reportCharacterBoxes")]
+		bool ReportCharacterBoxes { get; set; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[Abstract]
+	[BaseType (typeof (NSObject))]
+	interface VNFaceLandmarkRegion {
+
+		[Export ("pointCount")]
+		nuint PointCount { get; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNFaceLandmarkRegion))]
+	interface VNFaceLandmarkRegion2D {
+
+		[Internal]
+		[Export ("points")]
+		IntPtr _GetPoints ();
+
+		[Export ("pointAtIndex:")]
+		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+		Vector2 GetPoint (nuint index);
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[Abstract]
+	[BaseType (typeof (NSObject))]
+	interface VNFaceLandmarks {
+
+		[Export ("confidence")]
+		float Confidence { get; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNFaceLandmarks))]
+	interface VNFaceLandmarks2D {
+
+		[NullAllowed, Export ("allPoints")]
+		VNFaceLandmarkRegion2D AllPoints { get; }
+
+		[NullAllowed, Export ("faceContour")]
+		VNFaceLandmarkRegion2D FaceContour { get; }
+
+		[NullAllowed, Export ("leftEye")]
+		VNFaceLandmarkRegion2D LeftEye { get; }
+
+		[NullAllowed, Export ("rightEye")]
+		VNFaceLandmarkRegion2D RightEye { get; }
+
+		[NullAllowed, Export ("leftEyebrow")]
+		VNFaceLandmarkRegion2D LeftEyebrow { get; }
+
+		[NullAllowed, Export ("rightEyebrow")]
+		VNFaceLandmarkRegion2D RightEyebrow { get; }
+
+		[NullAllowed, Export ("nose")]
+		VNFaceLandmarkRegion2D Nose { get; }
+
+		[NullAllowed, Export ("noseCrest")]
+		VNFaceLandmarkRegion2D NoseCrest { get; }
+
+		[NullAllowed, Export ("medianLine")]
+		VNFaceLandmarkRegion2D MedianLine { get; }
+
+		[NullAllowed, Export ("outerLips")]
+		VNFaceLandmarkRegion2D OuterLips { get; }
+
+		[NullAllowed, Export ("innerLips")]
+		VNFaceLandmarkRegion2D InnerLips { get; }
+
+		[NullAllowed, Export ("leftPupil")]
+		VNFaceLandmarkRegion2D LeftPupil { get; }
+
+		[NullAllowed, Export ("rightPupil")]
+		VNFaceLandmarkRegion2D RightPupil { get; }
+	}
+
+	interface IVNFaceObservationAccepting { }
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[Protocol]
+	interface VNFaceObservationAccepting {
+
+		[Abstract]
+		[NullAllowed, Export ("inputFaceObservations", ArgumentSemantic.Copy)]
+		VNFaceObservation [] InputFaceObservations { get; set; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[Abstract]
+	[BaseType (typeof (VNTargetedImageRequest))]
+	interface VNImageRegistrationRequest {
+
+		[Export ("initWithTargetedCVPixelBuffer:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer);
+
+		[Export ("initWithTargetedCVPixelBuffer:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCGImage:")]
+		IntPtr Constructor (CGImage image);
+
+		[Export ("initWithTargetedCGImage:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (CGImage image, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCIImage:")]
+		IntPtr Constructor (CIImage image);
+
+		[Export ("initWithTargetedCIImage:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (CIImage image, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageURL:")]
+		IntPtr Constructor (NSUrl imageUrl);
+
+		[Export ("initWithTargetedImageURL:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (NSUrl imageUrl, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageData:")]
+		IntPtr Constructor (NSData imageData);
+
+		[Export ("initWithTargetedImageData:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (NSData imageData, [NullAllowed] VNRequestCompletionHandler completionHandler);
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNImageRegistrationRequest))]
+	interface VNTranslationalImageRegistrationRequest {
+
+		// Inlined from parent class
+		[Export ("initWithTargetedCVPixelBuffer:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer);
+
+		[Export ("initWithTargetedCVPixelBuffer:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCGImage:")]
+		IntPtr Constructor (CGImage image);
+
+		[Export ("initWithTargetedCGImage:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (CGImage image, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCIImage:")]
+		IntPtr Constructor (CIImage image);
+
+		[Export ("initWithTargetedCIImage:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (CIImage image, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageURL:")]
+		IntPtr Constructor (NSUrl imageUrl);
+
+		[Export ("initWithTargetedImageURL:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (NSUrl imageUrl, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageData:")]
+		IntPtr Constructor (NSData imageData);
+
+		[Export ("initWithTargetedImageData:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (NSData imageData, [NullAllowed] VNRequestCompletionHandler completionHandler);
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNImageRegistrationRequest))]
+	interface VNHomographicImageRegistrationRequest {
+
+		// Inlined from parent class
+		[Export ("initWithTargetedCVPixelBuffer:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer);
+
+		[Export ("initWithTargetedCVPixelBuffer:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCGImage:")]
+		IntPtr Constructor (CGImage image);
+
+		[Export ("initWithTargetedCGImage:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (CGImage image, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCIImage:")]
+		IntPtr Constructor (CIImage image);
+
+		[Export ("initWithTargetedCIImage:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (CIImage image, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageURL:")]
+		IntPtr Constructor (NSUrl imageUrl);
+
+		[Export ("initWithTargetedImageURL:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (NSUrl imageUrl, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageData:")]
+		IntPtr Constructor (NSData imageData);
+
+		[Export ("initWithTargetedImageData:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (NSData imageData, [NullAllowed] VNRequestCompletionHandler completionHandler);
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[Abstract]
+	[BaseType (typeof (NSObject))]
+	interface VNObservation : NSCopying, NSSecureCoding {
+
+		[Export ("uuid", ArgumentSemantic.Strong)]
+		NSUuid Uuid { get; }
+
+		[Export ("confidence")]
+		float Confidence { get; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNObservation))]
+	interface VNDetectedObjectObservation {
+
+		[Static]
+		[Export ("observationWithBoundingBox:")]
+		VNDetectedObjectObservation FromBoundingBox (CGRect boundingBox);
+
+		[Export ("boundingBox", ArgumentSemantic.Assign)]
+		CGRect BoundingBox { get; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNDetectedObjectObservation))]
+	interface VNFaceObservation {
+
+		[NullAllowed, Export ("landmarks", ArgumentSemantic.Strong)]
+		VNFaceLandmarks2D Landmarks { get; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNObservation))]
+	interface VNClassificationObservation {
+
+		[Export ("identifier")]
+		string Identifier { get; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNObservation))]
+	interface VNCoreMLFeatureValueObservation {
+
+		[Export ("featureValue", ArgumentSemantic.Copy)]
+		MLFeatureValue FeatureValue { get; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNObservation))]
+	interface VNPixelBufferObservation {
+
+		[Export ("pixelBuffer")]
+		CVPixelBuffer PixelBuffer { get; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNDetectedObjectObservation))]
+	interface VNRectangleObservation {
+
+		[Export ("topLeft", ArgumentSemantic.Assign)]
+		CGPoint TopLeft { get; }
+
+		[Export ("topRight", ArgumentSemantic.Assign)]
+		CGPoint TopRight { get; }
+
+		[Export ("bottomLeft", ArgumentSemantic.Assign)]
+		CGPoint BottomLeft { get; }
+
+		[Export ("bottomRight", ArgumentSemantic.Assign)]
+		CGPoint BottomRight { get; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNDetectedObjectObservation))]
+	interface VNTextObservation {
+
+		[NullAllowed, Export ("characterBoxes", ArgumentSemantic.Copy)]
+		VNRectangleObservation [] CharacterBoxes { get; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNRectangleObservation))]
+	interface VNBarcodeObservation {
+
+		[Export ("symbology")]
+		string Symbology { get; }
+
+		// TODO: Enable once CoreImage Xcode 9 is bound
+		//[NullAllowed, Export ("barcodeDescriptor", ArgumentSemantic.Strong)]
+		//CIBarcodeDescriptor BarcodeDescriptor { get; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNObservation))]
+	interface VNHorizonObservation {
+
+		[Export ("transform", ArgumentSemantic.Assign)]
+		CGAffineTransform Transform { get; }
+
+		[Export ("angle")]
+		nfloat Angle { get; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[Abstract]
+	[BaseType (typeof (VNObservation))]
+	interface VNImageAlignmentObservation {
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNImageAlignmentObservation))]
+	interface VNImageTranslationAlignmentObservation {
+
+		[Export ("alignmentTransform", ArgumentSemantic.Assign)]
+		CGAffineTransform AlignmentTransform { get; set; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNImageAlignmentObservation))]
+	interface VNImageHomographicAlignmentObservation {
+
+		[Export ("warpTransform", ArgumentSemantic.Assign)]
+		Matrix3 WarpTransform {
+			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+			get;
+			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+			set;
+		}
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[Abstract]
+	[BaseType (typeof (NSObject))]
+	interface VNRequest : NSCopying {
+
+		[Export ("initWithCompletionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("preferBackgroundProcessing")]
+		bool PreferBackgroundProcessing { get; set; }
+
+		[NullAllowed, Export ("preferredMetalContext", ArgumentSemantic.Retain)]
+		IMTLDevice PreferredMetalContext { get; set; }
+
+		[NullAllowed, Export ("results", ArgumentSemantic.Copy)]
+		VNObservation [] Results { get; }
+
+		[NullAllowed, Export ("completionHandler", ArgumentSemantic.Copy)]
+		VNRequestCompletionHandler CompletionHandler { get; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[Abstract]
+	[BaseType (typeof (VNRequest))]
+	interface VNImageBasedRequest {
+
+		[Export ("initWithCompletionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("regionOfInterest", ArgumentSemantic.Assign)]
+		CGRect RegionOfInterest { get; set; }
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	enum VNImageOption {
+		[Field ("VNImageOptionProperties")]
+		Properties,
+
+		[Field ("VNImageOptionCameraIntrinsics")]
+		CameraIntrinsics,
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor]
+	interface VNImageRequestHandler {
+
+		[Export ("initWithCVPixelBuffer:options:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary<NSString, NSObject> options);
+
+		[Export ("initWithCVPixelBuffer:orientation:options:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, int orientation, NSDictionary<NSString, NSObject> options);
+
+		[Export ("initWithCGImage:options:")]
+		IntPtr Constructor (CGImage image, NSDictionary<NSString, NSObject> options);
+
+		[Export ("initWithCGImage:orientation:options:")]
+		IntPtr Constructor (CGImage image, int orientation, NSDictionary<NSString, NSObject> options);
+
+		[Export ("initWithCIImage:options:")]
+		IntPtr Constructor (CIImage image, NSDictionary<NSString, NSObject> options);
+
+		[Export ("initWithCIImage:orientation:options:")]
+		IntPtr Constructor (CIImage image, int orientation, NSDictionary<NSString, NSObject> options);
+
+		[Export ("initWithURL:options:")]
+		IntPtr Constructor (NSUrl imageUrl, NSDictionary<NSString, NSObject> options);
+
+		[Export ("initWithURL:orientation:options:")]
+		IntPtr Constructor (NSUrl imageUrl, int orientation, NSDictionary<NSString, NSObject> options);
+
+		[Export ("initWithData:options:")]
+		IntPtr Constructor (NSData imageData, NSDictionary<NSString, NSObject> options);
+
+		[Export ("initWithData:orientation:options:")]
+		IntPtr Constructor (NSData imageData, int orientation, NSDictionary<NSString, NSObject> options);
+
+		[Export ("performRequests:error:")]
+		bool Perform (VNRequest [] requests, out NSError error);
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (NSObject))]
+	interface VNSequenceRequestHandler {
+
+		[Export ("performRequests:onCVPixelBuffer:error:")]
+		bool Perform (VNRequest [] requests, CVPixelBuffer pixelBuffer, out NSError error);
+
+		[Export ("performRequests:onCVPixelBuffer:orientation:error:")]
+		bool Perform (VNRequest [] requests, CVPixelBuffer pixelBuffer, int orientation, out NSError error);
+
+		[Export ("performRequests:onCGImage:error:")]
+		bool Perform (VNRequest [] requests, CGImage image, out NSError error);
+
+		[Export ("performRequests:onCGImage:orientation:error:")]
+		bool Perform (VNRequest [] requests, CGImage image, int orientation, out NSError error);
+
+		[Export ("performRequests:onCIImage:error:")]
+		bool Perform (VNRequest [] requests, CIImage image, out NSError error);
+
+		[Export ("performRequests:onCIImage:orientation:error:")]
+		bool Perform (VNRequest [] requests, CIImage image, int orientation, out NSError error);
+
+		[Export ("performRequests:onImageURL:error:")]
+		bool Perform (VNRequest [] requests, NSUrl imageUrl, out NSError error);
+
+		[Export ("performRequests:onImageURL:orientation:error:")]
+		bool Perform (VNRequest [] requests, NSUrl imageUrl, int orientation, out NSError error);
+
+		[Export ("performRequests:onImageData:error:")]
+		bool Perform (VNRequest [] requests, NSData imageData, out NSError error);
+
+		[Export ("performRequests:onImageData:orientation:error:")]
+		bool Perform (VNRequest [] requests, NSData imageData, int orientation, out NSError error);
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[Abstract]
+	[BaseType (typeof (VNImageBasedRequest))]
+	[DisableDefaultCtor]
+	interface VNTargetedImageRequest {
+
+		[Export ("initWithTargetedCVPixelBuffer:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer);
+
+		[Export ("initWithTargetedCVPixelBuffer:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCGImage:")]
+		IntPtr Constructor (CGImage image);
+
+		[Export ("initWithTargetedCGImage:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (CGImage image, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCIImage:")]
+		IntPtr Constructor (CIImage image);
+
+		[Export ("initWithTargetedCIImage:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (CIImage image, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageURL:")]
+		IntPtr Constructor (NSUrl imageUrl);
+
+		[Export ("initWithTargetedImageURL:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (NSUrl imageUrl, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageData:")]
+		IntPtr Constructor (NSData imageData);
+
+		[Export ("initWithTargetedImageData:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (NSData imageData, [NullAllowed] VNRequestCompletionHandler completionHandler);
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNTrackingRequest))]
+	[DisableDefaultCtor]
+	interface VNTrackObjectRequest {
+
+		[Export ("initWithCompletionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithDetectedObjectObservation:")]
+		IntPtr Constructor (VNDetectedObjectObservation observation);
+
+		[Export ("initWithDetectedObjectObservation:completionHandler:")]
+		IntPtr Constructor (VNDetectedObjectObservation observation, [NullAllowed] VNRequestCompletionHandler completionHandler);
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[BaseType (typeof (VNTrackingRequest))]
+	[DisableDefaultCtor]
+	interface VNTrackRectangleRequest {
+
+		[Export ("initWithCompletionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithRectangleObservation:")]
+		IntPtr Constructor (VNRectangleObservation observation);
+
+		[Export ("initWithRectangleObservation:completionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (VNRectangleObservation observation, [NullAllowed] VNRequestCompletionHandler completionHandler);
+	}
+
+	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+	[Abstract]
+	[BaseType (typeof (VNImageBasedRequest))]
+	[DisableDefaultCtor]
+	interface VNTrackingRequest {
+
+		[Export ("initWithCompletionHandler:")]
+		[DesignatedInitializer]
+		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Export ("inputObservation", ArgumentSemantic.Strong)]
+		VNDetectedObjectObservation InputObservation { get; set; }
+
+		[Export ("trackingLevel", ArgumentSemantic.Assign)]
+		VNRequestTrackingLevel TrackingLevel { get; set; }
+
+		[Export ("lastFrame")]
+		bool LastFrame { [Bind ("isLastFrame")] get; set; }
+	}
+}
+#endif

--- a/src/vision.cs
+++ b/src/vision.cs
@@ -18,6 +18,7 @@ using XamCore.CoreVideo;
 using XamCore.Foundation;
 using XamCore.Metal;
 using XamCore.ObjCRuntime;
+using XamCore.ImageIO;
 
 using Vector2 = global::OpenTK.Vector2;
 using Matrix3 = global::OpenTK.Matrix3;
@@ -627,31 +628,31 @@ namespace XamCore.Vision {
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary<NSString, NSObject> options);
 
 		[Export ("initWithCVPixelBuffer:orientation:options:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, int orientation, NSDictionary<NSString, NSObject> options);
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary<NSString, NSObject> options);
 
 		[Export ("initWithCGImage:options:")]
 		IntPtr Constructor (CGImage image, NSDictionary<NSString, NSObject> options);
 
 		[Export ("initWithCGImage:orientation:options:")]
-		IntPtr Constructor (CGImage image, int orientation, NSDictionary<NSString, NSObject> options);
+		IntPtr Constructor (CGImage image, CGImagePropertyOrientation orientation, NSDictionary<NSString, NSObject> options);
 
 		[Export ("initWithCIImage:options:")]
 		IntPtr Constructor (CIImage image, NSDictionary<NSString, NSObject> options);
 
 		[Export ("initWithCIImage:orientation:options:")]
-		IntPtr Constructor (CIImage image, int orientation, NSDictionary<NSString, NSObject> options);
+		IntPtr Constructor (CIImage image, CGImagePropertyOrientation orientation, NSDictionary<NSString, NSObject> options);
 
 		[Export ("initWithURL:options:")]
 		IntPtr Constructor (NSUrl imageUrl, NSDictionary<NSString, NSObject> options);
 
 		[Export ("initWithURL:orientation:options:")]
-		IntPtr Constructor (NSUrl imageUrl, int orientation, NSDictionary<NSString, NSObject> options);
+		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary<NSString, NSObject> options);
 
 		[Export ("initWithData:options:")]
 		IntPtr Constructor (NSData imageData, NSDictionary<NSString, NSObject> options);
 
 		[Export ("initWithData:orientation:options:")]
-		IntPtr Constructor (NSData imageData, int orientation, NSDictionary<NSString, NSObject> options);
+		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary<NSString, NSObject> options);
 
 		[Export ("performRequests:error:")]
 		bool Perform (VNRequest [] requests, out NSError error);
@@ -665,31 +666,31 @@ namespace XamCore.Vision {
 		bool Perform (VNRequest [] requests, CVPixelBuffer pixelBuffer, out NSError error);
 
 		[Export ("performRequests:onCVPixelBuffer:orientation:error:")]
-		bool Perform (VNRequest [] requests, CVPixelBuffer pixelBuffer, int orientation, out NSError error);
+		bool Perform (VNRequest [] requests, CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, out NSError error);
 
 		[Export ("performRequests:onCGImage:error:")]
 		bool Perform (VNRequest [] requests, CGImage image, out NSError error);
 
 		[Export ("performRequests:onCGImage:orientation:error:")]
-		bool Perform (VNRequest [] requests, CGImage image, int orientation, out NSError error);
+		bool Perform (VNRequest [] requests, CGImage image, CGImagePropertyOrientation orientation, out NSError error);
 
 		[Export ("performRequests:onCIImage:error:")]
 		bool Perform (VNRequest [] requests, CIImage image, out NSError error);
 
 		[Export ("performRequests:onCIImage:orientation:error:")]
-		bool Perform (VNRequest [] requests, CIImage image, int orientation, out NSError error);
+		bool Perform (VNRequest [] requests, CIImage image, CGImagePropertyOrientation orientation, out NSError error);
 
 		[Export ("performRequests:onImageURL:error:")]
 		bool Perform (VNRequest [] requests, NSUrl imageUrl, out NSError error);
 
 		[Export ("performRequests:onImageURL:orientation:error:")]
-		bool Perform (VNRequest [] requests, NSUrl imageUrl, int orientation, out NSError error);
+		bool Perform (VNRequest [] requests, NSUrl imageUrl, CGImagePropertyOrientation orientation, out NSError error);
 
 		[Export ("performRequests:onImageData:error:")]
 		bool Perform (VNRequest [] requests, NSData imageData, out NSError error);
 
 		[Export ("performRequests:onImageData:orientation:error:")]
-		bool Perform (VNRequest [] requests, NSData imageData, int orientation, out NSError error);
+		bool Perform (VNRequest [] requests, NSData imageData, CGImagePropertyOrientation orientation, out NSError error);
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]

--- a/src/vision.cs
+++ b/src/vision.cs
@@ -43,21 +43,21 @@ namespace XamCore.Vision {
 		InvalidOperation,
 		InvalidImage,
 		InvalidArgument,
-		InvalidModel
+		InvalidModel,
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 	[Native]
 	public enum VNRequestTrackingLevel : nuint {
 		Accurate = 0,
-		Fast
+		Fast,
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 	public enum VNImageCropAndScaleOption : uint {
 		CenterCrop = 0,
 		ScaleFit = 1,
-		ScaleFill
+		ScaleFill,
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -224,6 +224,7 @@ namespace Introspection
 			"Ipp",
 			"Iptc",
 			"Ircs",
+			"Itf",
 			"Itu",
 			"Jcb", // Japanese credit card company
 			"Jfif",
@@ -374,6 +375,7 @@ namespace Introspection
 			"Superentity",
 			"Sym",
 			"Synchronizable",
+			"Symbologies",
 			"Tanh",
 			"Texcoord",
 			"Texel",
@@ -404,6 +406,7 @@ namespace Introspection
 			"Uterance",
 			"Unentitled",
 			"Utf",
+			"Upce",
 			"Uti",
 			"Varispeed",
 			"Vergence",

--- a/tests/introspection/iOS/iOSApiWeakPropertyTest.cs
+++ b/tests/introspection/iOS/iOSApiWeakPropertyTest.cs
@@ -39,6 +39,9 @@ namespace Introspection {
 			// UIStringAttributes is a DictionaryContainer that expose a Weak* NSString
 			case "UIStringAttributes":
 				return property.Name == "WeakTextEffect";
+			// VNImageOptions is a DictionaryContainer that exposes a Weak* NSDictionary
+			case "VNImageOptions":
+				return property.Name == "WeakProperties";
 #if !XAMCORE_3_0
 			// #37451 - setter does not exists but we have to keep it for binary compatibility
 			// OTOH we can't give it a selector (private API) even if we suspect Apple is mostly running `strings` on executable

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -140,6 +140,7 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "MediaPlayer", "MediaPlayer", 10, 12, 1 },
 
 					{ "CoreML", "CoreML", 10, 13 },
+					{ "Vision", "Vision", 10, 13 },
 				};
 			}
 			return mac_frameworks;
@@ -249,6 +250,7 @@ public class Frameworks : Dictionary <string, Framework>
 				{ "DeviceCheck", "DeviceCheck", 11 },
 				{ "IdentityLookup", "IdentityLookup", 11 },
 				{ "CoreML", "CoreML", 11 },
+				{ "Vision", "Vision", 11 },
 			};
 		}
 		return ios_frameworks;
@@ -357,6 +359,7 @@ public class Frameworks : Dictionary <string, Framework>
 
 					{ "DeviceCheck", "DeviceCheck", 11 },
 					{ "CoreML", "CoreML", 11 },
+					{ "Vision", "Vision", 11 },
 				};
 			}
 			return tvos_frameworks;

--- a/tools/linker/ObjCExtensions.cs
+++ b/tools/linker/ObjCExtensions.cs
@@ -58,6 +58,7 @@ namespace Xamarin.Linker {
 			Intents = profile.GetNamespace ("Intents");
 			Photos = profile.GetNamespace ("Photos");
 			CoreML = profile.GetNamespace ("CoreML");
+			Vision = profile.GetNamespace ("Vision");
 #if MONOMAC
 			IOBluetooth = profile.GetNamespace ("IOBluetooth");
 			IOBluetoothUI = profile.GetNamespace ("IOBluetoothUI");
@@ -136,6 +137,8 @@ namespace Xamarin.Linker {
 		public static string Photos { get; private set; }
 
 		public static string CoreML { get; private set; }
+
+		public static string Vision { get; private set; }
 
 #if MONOMAC
 		public static string IOBluetooth { get; private set; }

--- a/tools/mmp/linker/MonoMac.Tuner/MonoMacNamespaces.cs
+++ b/tools/mmp/linker/MonoMac.Tuner/MonoMacNamespaces.cs
@@ -70,6 +70,7 @@ namespace MonoMac.Tuner {
 		{ Constants.PhotosLibrary, Namespaces.Photos },
 		{ Constants.PrintCoreLibrary, Namespaces.PrintCore },
 		{ Constants.CoreMLLibrary, Namespaces.CoreML },
+		{ Constants.VisionLibrary, Namespaces.Vision },
 	};
 
 		public void Process (LinkContext context)


### PR DESCRIPTION
This commit also adds two convenience overloads to GetAttachments
that allows you to get a more strongly typed version of the
returned dictionary, this is needed because there is no easy way
to downcast from NSDictionary to NSDictionary<TKey, TValue>
and it is used in the sample that excecises the Vision API found here

https://github.com/dalexsoto/FaceDetector

As a side note, the manual vector code is exercised in the above sample.