### PR TITLE
[mtouch] Enable the partial static registrar for tvOS again. Fixes #57191.

### DIFF
--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -384,8 +384,8 @@ TARGETS += $(IOS_DESTDIR)$(XAMARIN_WATCHSIMULATOR_SDK)/usr/lib/Xamarin.WatchOS.r
 endif
 
 ifdef INCLUDE_TVOS
-#TARGETS +=	\
-#	$(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/usr/lib/Xamarin.TVOS.registrar.a       \
+TARGETS +=	\
+	$(IOS_DESTDIR)$(XAMARIN_TVSIMULATOR_SDK)/usr/lib/Xamarin.TVOS.registrar.a       \
 
 endif
 


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=57191