### PR TITLE
Remove Xcode9 radar test exclusions that have been closed by Apple

### DIFF
--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -85,10 +85,12 @@ namespace XamCore.CoreBluetooth {
 
 		[NoTV]
 		[Availability (Obsoleted = Platform.iOS_9_0)]
+		[Mac (10, 7, onlyOn64: true)] // Was removed from 32-bit in 10.13 unannounced
 		[Export ("retrievePeripherals:"), Internal]
 		void RetrievePeripherals (NSArray peripheralUUIDs);
 
 		[NoTV]
+		[Mac (10, 7, onlyOn64: true)] // Was removed from 32-bit in 10.13 unannounced
 		[Export ("retrieveConnectedPeripherals")]
 		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_9_0, Message = "Use 'RetrievePeripheralsWithIdentifiers' instead.")]
 		void RetrieveConnectedPeripherals ();
@@ -440,6 +442,7 @@ namespace XamCore.CoreBluetooth {
 		[NoTV]
 		[Availability (Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_9_0)]
 		[Export ("isConnected")]
+		[Mac (10, 7, onlyOn64: true)] // Was removed from 32-bit in 10.13 unannounced
 		bool IsConnected { get;  }
 
 		[Export ("services", ArgumentSemantic.Retain)]

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -365,7 +365,7 @@ namespace XamCore.CoreBluetooth {
 		[NullAllowed]
 		[Export ("UUID", ArgumentSemantic.Retain)]
 		[Override]
-		CBUUID UUID { get; set; }
+		CBUUID UUID { get; [Availability (Obsoleted = Platform.Mac_10_13)] set; }
 
 		[Export ("properties", ArgumentSemantic.Assign)]
 		[Override]
@@ -621,7 +621,7 @@ namespace XamCore.CoreBluetooth {
 #if !MONOMAC
 		[Override]
 #endif
-		CBUUID UUID { get; set; }
+		CBUUID UUID { get; [Availability (Obsoleted = Platform.Mac_10_13)] set; }
 
 		[NoTV]
 		[Export ("isPrimary")]

--- a/tests/introspection/Mac/MacApiCtorInitTest.cs
+++ b/tests/introspection/Mac/MacApiCtorInitTest.cs
@@ -38,13 +38,6 @@ namespace Introspection {
 		protected override bool Skip (Type type)
 		{
 			switch (type.FullName) {
-			case "CoreBluetooth.CBCentralManager":
-			case "MonoMac.CoreBluetooth.CBCentralManager":
-			case "CoreBluetooth.CBPeripheralManager":
-			case "MonoMac.CoreBluetooth.CBPeripheralManager":
-				if (Mac.CheckSystemVersion (10, 13)) // radar 32899618
-					return true;
-				break;
 			// Random failures on build machine
 			case "QuickLookUI.QLPreviewPanel":
 			case "MonoMac.QuickLookUI.QLPreviewPanel":

--- a/tests/introspection/Mac/MacApiSelectorTest.cs
+++ b/tests/introspection/Mac/MacApiSelectorTest.cs
@@ -593,20 +593,9 @@ namespace Introspection {
 			case "MonoMac.CoreBluetooth":
 			case "CoreBluetooth":
 				switch (type.Name) {
-				case "CBCentralManager":
-					switch (selectorName) {
-					case "retrieveConnectedPeripherals": // radar 32899618
-					case "retrievePeripherals:": // radar 32899618
-						if (Mac.CheckSystemVersion (10, 13))
-							return true;
-						break;
-					}
-					break;
-
 				case "CBPeripheral":
 					switch (selectorName) {
 					case "UUID": // radar 32873784
-					case "isConnected": // radar 32899618
 						if (Mac.CheckSystemVersion (10, 13))
 							return true;
 						break;

--- a/tests/introspection/Mac/MacApiSelectorTest.cs
+++ b/tests/introspection/Mac/MacApiSelectorTest.cs
@@ -590,36 +590,6 @@ namespace Introspection {
 					break;
 				}
 				break;
-			case "MonoMac.CoreBluetooth":
-			case "CoreBluetooth":
-				switch (type.Name) {
-				case "CBPeripheral":
-					switch (selectorName) {
-					case "UUID": // radar 32873784
-						if (Mac.CheckSystemVersion (10, 13))
-							return true;
-						break;
-					}
-					break;
-				case "CBCentral":
-					switch (selectorName) {
-					case "UUID": // radar 32873784
-						if (Mac.CheckSystemVersion (10, 13))
-							return true;
-						break;
-					}
-					break;
-				case "CBMutableService":
-				case "CBMutableCharacteristic":
-					switch (selectorName) {
-					case "setUUID:": // radar 32873784
-						if (Mac.CheckSystemVersion (10, 13))
-							return true;
-						break;
-					}
-					break;
-				}
-				break;
 			}
 			return base.Skip (type, selectorName);
 		}


### PR DESCRIPTION
- Radar 32899618 and 32873784 were closed as WONT_FIX so let's work around it the best we can with attributes.