### PR TITLE
[tests] Get StringUtils.cs from master to fix generator test build.

### DIFF
--- a/tools/common/StringUtils.cs
+++ b/tools/common/StringUtils.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Text;
+
+namespace Xamarin.Utils {
+	public class StringUtils {
+		static StringUtils ()
+		{
+			PlatformID pid = Environment.OSVersion.Platform;
+			if (((int)pid != 128 && pid != PlatformID.Unix && pid != PlatformID.MacOSX))
+				shellQuoteChar = '"'; // Windows
+			else
+				shellQuoteChar = '\''; // !Windows
+		}
+
+		static char shellQuoteChar;
+		static char[] mustQuoteCharacters = new char [] { ' ', '\'', ',', '$', '\\' };
+
+		public static string Quote (string f)
+		{
+			if (String.IsNullOrEmpty (f))
+				return f ?? String.Empty;
+
+			if (f.IndexOfAny (mustQuoteCharacters) == -1)
+				return f;
+
+			var s = new StringBuilder ();
+
+			s.Append (shellQuoteChar);
+			foreach (var c in f) {
+				if (c == '\'' || c == '"' || c == '\\')
+					s.Append ('\\');
+
+				s.Append (c);
+			}
+			s.Append (shellQuoteChar);
+
+			return s.ToString ();
+		}
+
+		public static string Unquote (string input)
+		{
+			if (input == null || input.Length == 0 || input [0] != shellQuoteChar)
+				return input;
+
+			var builder = new StringBuilder ();
+			for (int i = 1; i < input.Length - 1; i++) {
+				char c = input [i];
+				if (c == '\\') {
+					builder.Append (input [i + 1]);
+					i++;
+					continue;
+				}
+				builder.Append (input [i]);
+			}
+			return builder.ToString ();
+		}
+
+	}
+}


### PR DESCRIPTION
The generator unit tests depends on StringUtils.cs in master, but that file
was introduced after the xcode9 branch was created.

So copy StringUtils.cs from master to fix the generator unit test build, but
not the related changes, to avoid the potential for regressions.