### PR TITLE
Mark CALayer.Contents as unsafe for automatic expansion by debuggers

### DIFF
--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -30,6 +30,7 @@
 //
 
 using System;
+using System.Diagnostics;
 #if MONOMAC
 using XamCore.AppKit;
 using XamCore.CoreVideo;

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -312,7 +312,7 @@ namespace XamCore.CoreAnimation {
 		[Export ("containsPoint:")]
 		bool Contains (CGPoint p);
 
-		[DebuggerBrowsable(DebuggerBrowsableState.Advanced)]
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("contents", ArgumentSemantic.Strong), NullAllowed]
 		CGImage Contents { get; set; }
 

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -312,7 +312,7 @@ namespace XamCore.CoreAnimation {
 		[Export ("containsPoint:")]
 		bool Contains (CGPoint p);
 
-		[EditorBrowsable (EditorBrowsableState.Advanced)]
+		[DebuggerBrowsable (DebuggerBrowsableState.Never)]
 		[Export ("contents", ArgumentSemantic.Strong), NullAllowed]
 		CGImage Contents { get; set; }
 

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -312,6 +312,7 @@ namespace XamCore.CoreAnimation {
 		[Export ("containsPoint:")]
 		bool Contains (CGPoint p);
 
+		[DebuggerBrowsable(DebuggerBrowsableState.Advanced)]
 		[Export ("contents", ArgumentSemantic.Strong), NullAllowed]
 		CGImage Contents { get; set; }
 


### PR DESCRIPTION
- https://bugzilla.xamarin.com/show_bug.cgi?id=58116
- Existing GetContentsAs will return the conents as correct type if you know it.