### PR TITLE
[mtouch] Fix collecting required internal symbols which aren't in the objc_msgSend family.

### DIFF
--- a/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
+++ b/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
@@ -108,7 +108,7 @@ namespace MonoTouch.Tuner
 						state.ProcessMethod (method);
 						break;
 					default:
-						return;
+						break;
 					}
 				}
 


### PR DESCRIPTION
Fix collecting required internal symbols which aren't in the objc_msgSend
family by not bailing out early for a function which isn't in the objc_msgSend
family.

Also add a test.