### PR TITLE
Colorize dependency checks to make them nicer (and easier to see if something is ignored).

### DIFF
--- a/mk/versions.mk
+++ b/mk/versions.mk
@@ -1,10 +1,10 @@
 # usage $(call CheckSubmoduleTemplate (name,MAKEFILE VAR,repo name))
 # usage $(call CheckSubmoduleTemplate (mono,MONO,mono))
 
-COLOR_GRAY:=$(shell tput setaf 250)
-COLOR_GREEN:=$(shell tput setaf 120)
-COLOR_RED:=$(shell tput setaf 1)
-COLOR_CLEAR:=$(shell tput sgr0)
+COLOR_GRAY:=$(shell tput setaf 250 2>/dev/null)
+COLOR_GREEN:=$(shell tput setaf 120 2>/dev/null)
+COLOR_RED:=$(shell tput setaf 1 2>/dev/null)
+COLOR_CLEAR:=$(shell tput sgr0 2>/dev/null)
 
 define CheckSubmoduleTemplate
 #$(eval NEEDED_$(2)_VERSION:=$(shell git --git-dir $(abspath $($(2)_PATH)/../..)/.git --work-tree $(abspath $($(2)_PATH)/../..) ls-tree HEAD --full-tree -- external/$(1) | awk -F' ' '{printf "%s",$$3}'))

--- a/mk/versions.mk
+++ b/mk/versions.mk
@@ -1,6 +1,11 @@
 # usage $(call CheckSubmoduleTemplate (name,MAKEFILE VAR,repo name))
 # usage $(call CheckSubmoduleTemplate (mono,MONO,mono))
 
+COLOR_GRAY:=$(shell tput setaf 250)
+COLOR_GREEN:=$(shell tput setaf 120)
+COLOR_RED:=$(shell tput setaf 1)
+COLOR_CLEAR:=$(shell tput sgr0)
+
 define CheckSubmoduleTemplate
 #$(eval NEEDED_$(2)_VERSION:=$(shell git --git-dir $(abspath $($(2)_PATH)/../..)/.git --work-tree $(abspath $($(2)_PATH)/../..) ls-tree HEAD --full-tree -- external/$(1) | awk -F' ' '{printf "%s",$$3}'))
 #$(eval $(2)_VERSION:=$$$$(shell cd $($(2)_PATH) 2>/dev/null && git rev-parse HEAD 2>/dev/null))
@@ -11,7 +16,7 @@ ifeq ($$(IGNORE_$(2)_VERSION),)
 		if test x$$(RESET_VERSIONS) != "x"; then \
 			make reset-$(1) || exit 1; \
 		else \
-			echo "Your $(1) checkout is missing, please run 'git submodule update --init --recursive -- external/$(1)'"; \
+			echo "Your $(1) checkout is $(COLOR_RED)missing$(COLOR_CLEAR), please run 'git submodule update --init --recursive -- external/$(1)'"; \
 			touch .check-versions-failure; \
 		fi; \
 	else \
@@ -19,16 +24,16 @@ ifeq ($$(IGNORE_$(2)_VERSION),)
 			if test x$$(RESET_VERSIONS) != "x"; then \
 				make reset-$(1) || exit 1; \
 			else \
-				echo "Your $(1) version is out of date, please run 'make reset-$(1)' (found $($(2)_VERSION), expected $(NEEDED_$(2)_VERSION)). Alternatively export IGNORE_$(2)_VERSION=1 to skip this check."; \
+				echo "Your $(1) version is $(COLOR_RED)out of date$(COLOR_CLEAR), please run 'make reset-$(1)' (found $($(2)_VERSION), expected $(NEEDED_$(2)_VERSION)). Alternatively export IGNORE_$(2)_VERSION=1 to skip this check."; \
 				test -z "$(BUILD_REVISION)" || $(MAKE) test-$(1); \
 				touch .check-versions-failure; \
 			fi; \
 		else \
-			echo "$(1) is up-to-date."; \
+			echo "$(1) is $(COLOR_GREEN)up-to-date$(COLOR_CLEAR)."; \
 		fi; \
 	fi
 else
-	@echo "$(1) is ignored."
+	@echo "$(1) is $(COLOR_GRAY)ignored$(COLOR_CLEAR)."
 endif
 
 test-$(1)::
@@ -83,7 +88,7 @@ reset-fsharp::
 check-versions::
 	@if test -e .check-versions-failure; then  \
 		rm .check-versions-failure; \
-		echo One or more modules needs update;  \
+		echo "$(COLOR_RED)One or more modules needs update$(COLOR_CLEAR)";  \
 		exit 1; \
 	else \
 		echo All dependent modules up to date;  \

--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -17,7 +17,7 @@ check-$(1)::
 			if test x$$(RESET_VERSIONS) != "x"; then \
 				make reset-$(1) || exit 1; \
 			else \
-				echo "Your $(1) checkout is missing, please run 'make reset-$(1)'"; \
+				echo "Your $(1) checkout is $(COLOR_RED)missing$(COLOR_CLEAR), please run 'make reset-$(1)'"; \
 				touch .check-versions-failure; \
 			fi; \
 		else \
@@ -25,7 +25,7 @@ check-$(1)::
 				if test x$$(RESET_VERSIONS) != "x"; then \
 					make reset-$(1) || exit 1; \
 				else \
-					echo "Your $(1) version is out of date, please run 'make reset-$(1)' (found $($(2)_VERSION), expected $(NEEDED_$(2)_VERSION)). Alternatively export IGNORE_$(2)_VERSION=1 to skip this check."; \
+					echo "Your $(1) version is $(COLOR_RED)out of date$(COLOR_CLEAR), please run 'make reset-$(1)' (found $($(2)_VERSION), expected $(NEEDED_$(2)_VERSION)). Alternatively export IGNORE_$(2)_VERSION=1 to skip this check."; \
 					test -z "$(BUILD_REVISION)" || $(MAKE) test-$(1); \
 					touch .check-versions-failure; \
 				fi; \
@@ -34,13 +34,15 @@ check-$(1)::
 					test -z "$(BUILD_REVISION)" || $(MAKE) test-$(1); \
 					make reset-$(1) || exit 1; \
 				else \
-					echo "Your $(1) branch is out of date, please run 'make reset-$(1)' (found $($(2)_BRANCH), expected $(NEEDED_$(2)_BRANCH)). Alternatively export IGNORE_$(2)_VERSION=1 to skip this check."; \
+					echo "Your $(1) branch is $(COLOR_RED)out of date$(COLOR_CLEAR), please run 'make reset-$(1)' (found $($(2)_BRANCH), expected $(NEEDED_$(2)_BRANCH)). Alternatively export IGNORE_$(2)_VERSION=1 to skip this check."; \
 					touch .check-versions-failure; \
 				fi; \
 			else \
-				echo "$(1) is up-to-date."; \
+				echo "$(1) is $(COLOR_GREEN)up-to-date$(COLOR_CLEAR)."; \
 			fi; \
 		fi; \
+	else \
+		echo "$(1) is $(COLOR_GRAY)ignored$(COLOR_CLEAR)."; \
 	fi
 
 test-$(1)::


### PR DESCRIPTION
Also print any ignored readme-style dependencies (previously we only printed
ignored submodule-style dependencies).