### PR TITLE
[link sdk] Modify the test for bug #56876 so that it doesn't trigger MT4169.

### DIFF
--- a/tests/linker-ios/link sdk/AotBugs.cs
+++ b/tests/linker-ios/link sdk/AotBugs.cs
@@ -618,11 +618,11 @@ namespace LinkSdk.Aot {
 		}
 
 		// The first character of this class is a cyrillic c, not a latin c.
-		[Preserve]
+		[Preserve (AllMembers = true)]
 		public class сolor_bug_56876
 		{
 			[System.Runtime.InteropServices.DllImport ("/usr/lib/libobjc.dylib")]
-			static extern void objc_msgSend (сolor_bug_56876 сolor);
+			static extern void sel_registerName (сolor_bug_56876 сolor);
 		}
 	}
 }


### PR DESCRIPTION
This test looks strange, but it was how I could trigger the invalid AOT-
compilation output found in bug #56876. The important part is the parameter to
the P/Invoke, but unfortunately we run into problems with such a parameter in
P/Invokes to objc_msgSend when generating P/Invoke wrappers for objc_msgSend
(i.e. when building the linksdk tests for watchOS/release):

> MT4168: Failed to generate a P/Invoke wrapper for objc_msgSend(LinkSdk.Aot.AotBugsTest.сolor_bug_56876): The registrar cannot get the ObjectiveC type for managed type `LinkSdk.Aot.AotBugsTest.сolor_bug_56876`

Fortunately the fix is trivial: use a different native function (I picked
sel_registerName, but it doesn't really matter as long as it's not in the
objc_msgSend family of functions) to avoid the P/Invoke wrapper generation
(which only occurs for the objc_msgSend family of functions).

I verified that the test still fails if the fix for bug #56876 is reverted.