### PR TITLE
[photos] Add helpers when PHLivePhotoEditingOption/NSDictionary is null (to avoid ambiguous API)

### DIFF
--- a/src/photos.cs
+++ b/src/photos.cs
@@ -1151,6 +1151,10 @@ namespace XamCore.Photos
 		void _PrepareLivePhotoForPlayback (CGSize targetSize, [NullAllowed] NSDictionary options, Action<PHLivePhoto, NSError> handler);
 
 		[Async]
+		[Wrap ("_PrepareLivePhotoForPlayback (targetSize, null, handler)")]
+		void PrepareLivePhotoForPlayback (CGSize targetSize, Action<PHLivePhoto, NSError> handler);
+
+		[Async]
 		[Wrap ("_PrepareLivePhotoForPlayback (targetSize, (NSDictionary)options, handler)", IsVirtual = true)]
 		void PrepareLivePhotoForPlayback (CGSize targetSize, [NullAllowed] NSDictionary<NSString, NSObject> options, Action<PHLivePhoto, NSError> handler);
 
@@ -1165,6 +1169,10 @@ namespace XamCore.Photos
 		[Internal]
 		[Export ("saveLivePhotoToOutput:options:completionHandler:")]
 		void _SaveLivePhoto (PHContentEditingOutput output, [NullAllowed] NSDictionary options, Action<bool, NSError> handler);
+
+		[Async]
+		[Wrap ("_SaveLivePhoto (output, null, handler)")]
+		void SaveLivePhoto (PHContentEditingOutput output, Action<bool, NSError> handler);
 
 		[Async]
 		[Wrap ("_SaveLivePhoto (output, options, handler)", IsVirtual = true)]


### PR DESCRIPTION
Adding a strongly typed `PHLivePhotoEditingOption` (a strongly typed
version of an `NSDictionary`) can cause a `CS0121` (call is ambiguous)
since using a `null` argument is common (only one option exist so far).

This PR adds overloads that makes the code nicer in such case, e.g.

before Xcode9:

> // null is used when no options are given
> _foo.SaveLivePhoto (output, null, completion);

current (Xcode 9)

> // casting required to remove ambiguity with PHLivePhotoEditingOption
> _foo.SaveLivePhoto (output, (NSDictionary)null, completion);

with this PR

> // no option, no argument
> _foo.SaveLivePhoto (output, completion);

The same applies to `PrepareLivePhotoForPlayback`.