### PR TITLE
[wkwebkit] Update for beta 4

### DIFF
--- a/src/wkwebkit.cs
+++ b/src/wkwebkit.cs
@@ -145,6 +145,10 @@ namespace XamCore.WebKit
 		[iOS (9,0)][Mac (10,11, onlyOn64 : true)]
 		[Export ("securityOrigin")]
 		WKSecurityOrigin SecurityOrigin { get; }
+
+		[iOS (11,0)][Mac (10,13, onlyOn64 : true)]
+		[NullAllowed, Export ("webView", ArgumentSemantic.Weak)]
+		WKWebView WebView { get; }
 	}
 
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)] // Not defined in 32-bit


### PR DESCRIPTION
Note: WKWindowFeatures.h is not compiled (part of the framework umbrella)
and the `@interface WKWindowFeatures (WKPrivate)` sounds like it should
not have been exposed (it's all fields starting with `_`)