### PR TITLE
[generator] Fix smart enum FieldAttribute LibraryName generation

### DIFF
--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -142,15 +142,21 @@ public partial class Generator {
 				var fa = kvp.Value;
 				// the attributes (availability and field) are important for our tests
 				PrintPlatformAttributes (f);
-				var libname = fa.LibraryName ?? library_name;
-				print ("[Field (\"{0}\", \"{1}\")]", fa.SymbolName, libname);
+				libraries.TryGetValue (library_name, out var libPath);
+				var libname = fa.LibraryName?.Replace ("+", string.Empty);
+				// We need to check for special cases inside FieldAttributes
+				// fa.LibraryName could contain a different framework i.e UITrackingRunLoopMode (UIKit) inside NSRunLoopMode enum (Foundation).
+				// libPath could have a custom path i.e. CoreImage which in macOS is inside Quartz
+				// library_name contains the Framework constant name the Field is inside of, used as fallback.
+				bool useFieldAttrLibName = libname != null && !string.Equals (libname, library_name, StringComparison.OrdinalIgnoreCase);
+				print ("[Field (\"{0}\", \"{1}\")]", fa.SymbolName, useFieldAttrLibName ? libname : libPath ?? library_name);
 				print ("internal unsafe static IntPtr {0} {{", fa.SymbolName);
 				indent++;
 				print ("get {");
 				indent++;
 				print ("fixed (IntPtr *storage = &values [{0}])", n++);
 				indent++;
-				print ("return Dlfcn.CachePointer (Libraries.{0}.Handle, \"{1}\", storage);", libname, fa.SymbolName);
+				print ("return Dlfcn.CachePointer (Libraries.{0}.Handle, \"{1}\", storage);", useFieldAttrLibName ? libname : library_name, fa.SymbolName);
 				indent--;
 				indent--;
 				print ("}");

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -21,7 +21,7 @@ else
 IOS_GENERATOR = $(IOS_CURRENT_DIR)/bin/btouch-native /baselib:$(IOS_CURRENT_DIR)/lib/mono/Xamarin.iOS/Xamarin.iOS.dll /unsafe
 endif
 IOS_TESTS = bug15283 bug15307 bug15799 bug16036 sof20696157 bug23041 bug27430 bug27428 bug34042 btouch-with-hyphen-in-name property-redefination-ios arrayfromhandlebug bug36457 bug39614 bug40282 bug17232 bug24078-ignore-methods-events strong-dict-support-templated-dicts bug43579 bindastests
-IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers bug42742 warnaserror nowarn noasyncinternalwrapper noasyncwarningcs0219 bug53076 bug53076withmodel bug57070 fieldenumtests
+IOS_CUSTOM_TESTS = forum54078 desk63279 desk79124 multiple-api-definitions1 multiple-api-definitions2 bug29493 classNameCollision bi1036 bug37527 bug27986 bug35176 bi1046 bindas1048error bindas1049error bindas1050modelerror bindas1050protocolerror virtualwrap bug42855 bug52570classinternal bug52570methodinternal bug52570allowstaticmembers bug42742 warnaserror nowarn noasyncinternalwrapper noasyncwarningcs0219 bug53076 bug53076withmodel bug57070 fieldenumtests smartenumwithframework
 
 MAC_CURRENT_DIR=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
 ifdef IKVM
@@ -277,6 +277,14 @@ fieldenumtests:
 	@rm -Rf $@.tmpdir
 	@mkdir -p $@.tmpdir
 	$(if $(V),,@echo "$@";) $(IOS_GENERATOR) --sourceonly:$@.source -tmpdir=$@.tmpdir $@.cs --process-enums
+
+smartenumwithframework:
+	@rm -Rf $@.tmpdir
+	@mkdir -p $@.tmpdir
+	$(if $(V),,@echo "$@";) $(IOS_GENERATOR) --sourceonly:$@.source -tmpdir=$@.tmpdir $@.cs --process-enums
+	@if [ `grep -r "Libraries.CoreImage.Handle" $@.tmpdir/SmartEnumWithFramework | wc -l` -ne 2 ]; then \
+		echo "Error: Expected 2 'Libraries.CoreImage.Handle'."; exit 1; \
+	fi
 
 clean-local::
 	rm -f *.dll *.source

--- a/tests/generator/smartenumwithframework.cs
+++ b/tests/generator/smartenumwithframework.cs
@@ -1,0 +1,14 @@
+using System;
+using ObjCRuntime;
+using Foundation;
+
+namespace SmartEnumWithFramework {
+
+	enum FooEnumTest {
+		[Field ("First", "+CoreImage")]
+		First,
+		
+		[Field ("Second", "+CoreImage")]
+		Second,
+	}
+}


### PR DESCRIPTION
This fix is needed by PDFKit because it is a [remapped framework](https://github.com/xamarin/xamarin-macios/blob/f5956d6cc1eb5dfa7bab16628cf282d40237f64e/src/generator.cs#L5985),
the current code generates incorrect FieldAttribute on smart enums
because it uses `fa.LibraryName` as first option and this causes
remmaped frameworks have incorrect LibraryName generated for example
if a Field uses `+CoreImage` as `LibraryName` the following incorrect
code is generated:

```
[Field ("First", "+CoreImage")]
internal unsafe static IntPtr First {
	get {
		fixed (IntPtr *storage = &values [0])
			return Dlfcn.CachePointer (Libraries.+CoreImage.Handle, "First", storage);
	}
}
```

Build diff: https://gist.github.com/dalexsoto/dc962b317bef508f79ba0d66f414446e