### PR TITLE
[mmp] Track all sub-frameworks of ApplicationServices and CoreServices. Fixes #58415

### DIFF
--- a/tests/mmptest/src/FrameworkLinksTests.cs
+++ b/tests/mmptest/src/FrameworkLinksTests.cs
@@ -130,5 +130,19 @@ namespace Xamarin.MMP.Tests
 				TI.TestUnifiedExecutable (test);
 			});
 		}
+
+		[Test]
+		public void ProjectWithSubFramework_ShouldBuild ()
+		{
+			RunMMPTest (tmpDir => {
+
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { TestDecl = @"
+	[System.Runtime.InteropServices.DllImport (""/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/LaunchServices"")]
+	static extern int GetIconRef (short vRefNum, int creator, int iconType, out System.IntPtr iconRef);
+				" };
+
+				TI.TestUnifiedExecutable (test);
+			});
+		}
 	}
 }

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -390,25 +390,24 @@ namespace Xamarin.Bundler {
 						if (Frameworks.Add ("OpenAL"))
 							Driver.Log (3, "Linking with the framework OpenAL because {0} is referenced by a module reference in {1}", file, FileName);
 						break;
-#if MONOMAC
-					case "PrintCore":
-						if (Frameworks.Add ("ApplicationServices"))
-							Driver.Log (3, "Linking with the framework ApplicationServices because {0} is referenced by a module reference in {1}", file, FileName);
-						break;
-					case "SearchKit":
-						if (Frameworks.Add ("CoreServices"))
-							Driver.Log (3, "Linking with the framework CoreServices because {0} is referenced by a module reference in {1}", file, FileName);
-						break;
-					case "CFNetwork":
-						if (Frameworks.Add ("CoreServices"))
-							Driver.Log (3, "Linking with the framework CoreServices because {0} is referenced by a module reference in {1}", file, FileName);
-						break;
-#endif
 					default:
 #if MONOMAC
 						string path = Path.GetDirectoryName (name);
 						if (!path.StartsWith ("/System/Library/Frameworks", StringComparison.Ordinal))
 							continue;
+
+						// CoreServices has multiple sub-frameworks that can be used by customer code
+						if (path.StartsWith ("/System/Library/Frameworks/CoreServices.framework/", StringComparison.Ordinal)) {
+							if (Frameworks.Add ("CoreServices"))
+								Driver.Log (3, "Linking with the framework CoreServices because {0} is referenced by a module reference in {1}", file, FileName);
+							break;
+						}
+						// ApplicationServices has multiple sub-frameworks that can be used by customer code
+						if (path.StartsWith ("/System/Library/Frameworks/ApplicationServices.framework/", StringComparison.Ordinal)) {
+							if (Frameworks.Add ("ApplicationServices"))
+								Driver.Log (3, "Linking with the framework ApplicationServices because {0} is referenced by a module reference in {1}", file, FileName);
+							break;
+						}
 #endif
 
 						// detect frameworks


### PR DESCRIPTION
The existing custom list does not cover the needs of user code,
e.g. a reference to LaunchServices did not bring CoreServices

https://bugzilla.xamarin.com/show_bug.cgi?id=58415