### PR TITLE
[coreanimation] Update to beta 4

### DIFF
--- a/src/CoreAnimation/CAEnums.cs
+++ b/src/CoreAnimation/CAEnums.cs
@@ -31,6 +31,7 @@ using System;
 using XamCore.Foundation;
 using System.Runtime.InteropServices;
 using XamCore.CoreGraphics;
+using XamCore.ObjCRuntime;
 
 namespace XamCore.CoreAnimation {
 
@@ -45,6 +46,16 @@ namespace XamCore.CoreAnimation {
 		All = LeftEdge | RightEdge | BottomEdge | TopEdge,
 		LeftRightEdges = LeftEdge | RightEdge,
 		TopBottomEdges = TopEdge | BottomEdge
+	}
+
+	[NoWatch] // headers not updated
+	[iOS (11,0)][TV (11,0)][Mac (10,13)]
+	[Native][Flags]
+	public enum CACornerMask : nuint {
+		MinXMinYCorner = 1 << 0,
+		MaxXMinYCorner = 1 << 1,
+		MinXMaxYCorner = 1 << 2,
+		MaxXMaxYCorner = 1 << 3,
 	}
 
 #if MONOMAC

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -585,6 +585,11 @@ namespace XamCore.CoreAnimation {
 		[NullAllowed] // by default this property is null
 		[Export ("compositingFilter", ArgumentSemantic.Strong)]
 		NSObject CompositingFilter { get; set; }
+
+		[NoWatch] // headers not updated
+		[TV (11,0)][Mac (10,13)][iOS (11,0)]
+		[Export ("maskedCorners", ArgumentSemantic.Assign)]
+		CACornerMask MaskedCorners { get; set; }
 	}
 
 #if XAMCORE_2_0 || !MONOMAC
@@ -626,6 +631,16 @@ namespace XamCore.CoreAnimation {
 		
 		[Export ("presentsWithTransaction")]
 		bool PresentsWithTransaction { [Bind ("presentsWithTransaction")] get; set; }
+
+		[NoWatch][NoTV][NoiOS]
+		[Mac (10,13)]
+		[Export ("displaySyncEnabled")]
+		bool DisplaySyncEnabled { get; set; }
+
+		[NoWatch] // headers not updated
+		[TV (11,0)][Mac (10,13)][iOS (11,0)]
+		[Export ("allowsNextDrawableTimeout")]
+		bool AllowsNextDrawableTimeout { get; set; }
 	}
 #endif
 


### PR DESCRIPTION
Apple removed (mistake?) some API in beta 1. Filed as rdar 33590997

Internal tracking in
https://trello.com/c/J8BDDUV9/86-33590997-coreanimation-quartzcore-api-removals