### PR TITLE
Keeps references to the delegate passed to Marshal.GetFunctionPointerForDelegate

### DIFF
--- a/src/CoreFoundation/CFRunLoop.cs
+++ b/src/CoreFoundation/CFRunLoop.cs
@@ -150,15 +150,19 @@ namespace XamCore.CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static /* CFRunLoopSourceRef */ IntPtr CFRunLoopSourceCreate (/* CFAllocatorRef */ IntPtr allocator, /* CFIndex */ nint order, /* CFRunLoopSourceContext* */ IntPtr context);
 
+		static ScheduleCallback ScheduleDelegate = (ScheduleCallback) Schedule;
+		static CancelCallback CancelDelegate = (CancelCallback) Cancel;
+		static PerformCallback PerformDelegate = (PerformCallback) Perform;
+		
 		protected CFRunLoopSourceCustom ()
 			: base (IntPtr.Zero, true)
 		{
 			gch = GCHandle.Alloc (this);
 			var ctx = new CFRunLoopSourceContext ();
 			ctx.Info = GCHandle.ToIntPtr (gch);
-			ctx.Schedule = Marshal.GetFunctionPointerForDelegate ((ScheduleCallback)Schedule);
-			ctx.Cancel = Marshal.GetFunctionPointerForDelegate ((CancelCallback)Cancel);
-			ctx.Perform = Marshal.GetFunctionPointerForDelegate ((PerformCallback)Perform);
+			ctx.Schedule = Marshal.GetFunctionPointerForDelegate (ScheduleDelegate);
+			ctx.Cancel = Marshal.GetFunctionPointerForDelegate (CancelDelegate);
+			ctx.Perform = Marshal.GetFunctionPointerForDelegate (PerformDelegate);
 
 			var ptr = Marshal.AllocHGlobal (Marshal.SizeOf (typeof(CFRunLoopSourceContext)));
 			try {

--- a/src/ObjCRuntime/Blocks.cs
+++ b/src/ObjCRuntime/Blocks.cs
@@ -83,6 +83,10 @@ namespace XamCore.ObjCRuntime {
 		[DllImport ("__Internal")]
 		static extern IntPtr xamarin_get_block_descriptor ();
 
+		struct DelegatePairs {
+			public Delegate Trampoline, UserDelegate;
+		}
+
 		//
 		// trampoline must be static, and someone else needs to keep a ref to it
 		//
@@ -90,7 +94,8 @@ namespace XamCore.ObjCRuntime {
 		{
 			isa = block_class;
 			invoke = Marshal.GetFunctionPointerForDelegate (trampoline);
-			local_handle = (IntPtr) GCHandle.Alloc (userDelegate);
+			var delegates = new DelegatePairs () { Trampoline = trampoline, UserDelegate = userDelegate };
+			local_handle = (IntPtr) GCHandle.Alloc (delegates);
 			global_handle = IntPtr.Zero;
 			flags = BlockFlags.BLOCK_HAS_COPY_DISPOSE | BlockFlags.BLOCK_HAS_SIGNATURE;
 


### PR DESCRIPTION
While this issue would have been rare due to the typical scenarios where Blocks are used
and the rare use of CFRunLoop, there is a chance that the delegates that are created
implicitly when passing a method name to GetFunctionPointerForDelegate would be released
and that the native code trying to call back into managed code would have executed
invalid code.

This incorrect use of the GetFunctionPointerForDelegate was discovered
by the TensorFlowSharp bindings on Windows which used a similar idiom.

In the case of CFRunLoop, we now keep the delegates that are used as
static variables in the CFRunLoop class.  On the case of Block,
instead of tracking a single delegate, we now track two delegates in
the GCHandle allcoated object.