### PR TITLE
[Don't Link] Update TableViewSourceTest's assert message

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -11341,8 +11341,6 @@ namespace XamCore.UIKit {
 		[Export ("indexPathForPreferredFocusedViewInTableView:")]
 		[return: NullAllowed]
 		NSIndexPath GetIndexPathForPreferredFocusedView (UITableView tableView);
-
-		// WARNING: If you add more methods here, add them to UITableViewController as well.
 	}
 	
 	[BaseType (typeof (UIView))]

--- a/tests/linker-ios/dont link/TableViewSourceTest.cs
+++ b/tests/linker-ios/dont link/TableViewSourceTest.cs
@@ -28,7 +28,7 @@ namespace DontLink.UIKit {
 	[Preserve (AllMembers = true)]
 	public class TableViewSourceTest {
 
-		// UITableViewSource is MonoTouch specific and should include veverything from
+		// UITableViewSource is Xamarin.iOS specific and should include everything from
 		// UITableViewDelegate and UITableViewDataSource - but it's easy to forget to
 		// update its members (e.g. bug 8298 for iOS6 additions).
 
@@ -52,7 +52,7 @@ namespace DontLink.UIKit {
 			methods.RemoveAll (delegate (string name) {
 				return tvsource.Contains (name);
 			});
-			Assert.That (methods.Count, Is.EqualTo (0), "Incomplete bindings! " + String.Join (", ", methods));
+			Assert.That (methods.Count, Is.EqualTo (0), "Incomplete bindings! Please add the following members to UITableViewSource: " + String.Join (", ", methods));
 		}
 	}
 }


### PR DESCRIPTION
- Remove obsolete and confusing warning in `UITableViewSource`.
  See https://github.com/xamarin/maccore/commit/59991815d5467e43505220fc4ebfe8f573849855
  where UITableViewController started conforming to UITableViewDataSource, UITableViewDelegate
  removing the need to add all methods to UITableViewController.