### PR TITLE
Fix complication against newer mono with patch from mono-2017-06

### DIFF
--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -1714,15 +1714,20 @@ namespace XamCore.AudioUnit
 			get { return Current; }
 		}
 
+		bool IsAt (nint now)
+		{
+			return current != null && (current->Head.EventSampleTime == now);
+		}
+
 		public IEnumerable <AURenderEvent> EnumeratorCurrentEvents (nint now)
 		{
 			if (IsAtEnd)
 				throw new InvalidOperationException ("Can not enumerate events on AURenderEventEnumerator when at end");
 
 			do {
-				yield return *current;
+				yield return Current;
 				MoveNext ();
-			} while (current != null && (current->Head.EventSampleTime == now));
+			} while (IsAt (now));
 		}
 
 		public bool /*IEnumerator<AURenderEvent>.*/MoveNext ()


### PR DESCRIPTION
Cherry pick of https://github.com/xamarin/xamarin-macios/commit/cbb45f65b5ae226ac2ddf8dba102f3e12b6c496e

[AudioUnit] Fix csc compiler error not allowing unsafe code in iterators.

csc does not allow unsafe code in iterators:

AudioUnit/AudioUnit.cs(1725,13): error CS1629: Unsafe code may not appear in iterators
AudioUnit/AudioUnit.cs(1725,33): error CS1629: Unsafe code may not appear in iterators
AudioUnit/AudioUnit.cs(1723,19): error CS1629: Unsafe code may not appear in iterators

It looks like mcs incorrectly allows this (https://bugzilla.xamarin.com/show_bug.cgi?id=56616).

So change the code to remove unsafe usage in iterators.