### PR TITLE
[msbuild][mac] Fix #58479: Assign project configurations for IDE case

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -678,13 +678,13 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<AssignProjectConfiguration
 			ProjectReferences = "@(_AppExtensionReference)"
 			SolutionConfigurationContents = "$(CurrentSolutionConfigurationContents)"
-			Condition="'$(BuildingSolutionFile)' == 'true'">
+			Condition="'$(CurrentSolutionConfigurationContents)' != ''">
 
 			<Output TaskParameter="AssignedProjects" ItemName="_AppExtensionReferenceWithConfiguration"/>
 		</AssignProjectConfiguration>
 
 		<!-- Else, just -->
-		<CreateItem Include="@(_AppExtensionReference)" Condition="'$(BuildingSolutionFile)' != 'true'">
+		<CreateItem Include="@(_AppExtensionReference)" Condition="'$(CurrentSolutionConfigurationContents)' == ''">
 			<Output TaskParameter="Include" ItemName="_AppExtensionReferenceWithConfiguration"/>
 		</CreateItem>
 


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=58479

_AssignAppExtensionConfiguration assigns project configuration from
`$(CurrentSolutionConfigurationContents)`, using the
`AssignProjectConfiguration` task, which is set if
`$(BuildingSolutionFile)` or `$(BuildingVisualStudio)` is true. We check
only for the former. It would be simpler to just check for ..

	`$(CurrentSolutionConfigurationContents) != ''`

.. like the iOS targets. This mapping from this task is used when
invoking `GetBundleTargetPath` on the extension project:

	Properties="%(_AppExtensionReferenceWithConfigurationExistent.SetConfiguration); %(_AppExtensionReferenceWithConfigurationExistent.SetPlatform)"

Details:

This failed for a project that had a reference to an app extension
project, with VSMac/msbuild. The app extension project was being built
with `Configuration==Debug` and `Platform==x86` for which the project
does not define any properties (like `$(OutputPath)`).

When the main project is built, we invoke `GetBundleTargetPath` on
the extension project, which in this case, has a different
config+platform mapping than the one for the referencing project. But
since the earlier `AssignProjectConfiguration` was skipped due to the
incorrect condition, `GetBundleTargetPath` is invoked with no
config+platform, thus falling back to extension project's defaults.

Note: The referencing project was being built with Debug|x86 and the
referenced project was expected to be built with Debug|AnyCPU .

This project:

- VSMac/xbuild - Works
	- This happens to work because the default from the extension
	  project is Debug|AnyCPU, so even though
	  `AssignProjectConfiguration` didn't set those properties, it
	  builds just fine.

- command line xbuild/msbuild - works!
	- `AssignProjectConfiguration` works because this time the
	  condition `$(BuildingSolutionFile) == 'true'` is True.

- VSMac/msbuild - fails
	- In this case, the default case does not work because in VSMac,
	  we use `SetGlobalProperty` to set config+platform properties
	  when starting the build for the referencing project.

	- And when the referencing project builds the referenced project
	  (via `GetBundleTargetPath`), it is built with config+platform
	  global properties set, and thus defaults from the referenced
	  don't get picked up!

	  	`<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>`

	- With the `AssignProjectConfiguration` fix, we set the
	  properties via the `MSBuild` task, so it works.
	  But this needs to be fixed in VSMac anyway.