### PR TITLE
[Vision] Strongify VNBarcodeSymbology API, Fixes Bug 58512

### DIFF
--- a/src/Vision/VNBarcodeSymbologyExtensions.cs
+++ b/src/Vision/VNBarcodeSymbologyExtensions.cs
@@ -1,0 +1,39 @@
+﻿//
+// VNBarcodeSymbologyExtensions.cs
+//
+// Authors:
+//	Alex Soto  <alexsoto@microsoft.com>
+//
+// Copyright 2017 Xamarin Inc. All rights reserved.
+//
+
+#if XAMCORE_2_0
+using System;
+using XamCore.Foundation;
+
+namespace XamCore.Vision {
+	public static partial class VNBarcodeSymbologyExtensions {
+		public static NSString [] GetConstants (this VNBarcodeSymbology [] self)
+		{
+			if (self == null)
+				throw new ArgumentNullException (nameof (self));
+
+			var array = new NSString [self.Length];
+			for (int n = 0; n < self.Length; n++)
+				array [n] = self [n].GetConstant ();
+			return array;
+		}
+
+		public static VNBarcodeSymbology [] GetValues (NSString [] constants)
+		{
+			if (constants == null)
+				throw new ArgumentNullException (nameof (constants));
+
+			var array = new VNBarcodeSymbology [constants.Length];
+			for (int n = 0; n < constants.Length; n++)
+				array [n] = GetValue (constants [n]);
+			return array;
+		}
+	}
+}
+#endif

--- a/src/Vision/VNDetectBarcodesRequest.cs
+++ b/src/Vision/VNDetectBarcodesRequest.cs
@@ -14,8 +14,8 @@ namespace XamCore.Vision {
 	public partial class VNDetectBarcodesRequest {
 
 		public VNBarcodeSymbology [] Symbologies {
-			get => VNBarcodeSymbologyExtensions.GetValues (WeakSymbologies);
-			set => WeakSymbologies = value.GetConstants ();
+			get { return VNBarcodeSymbologyExtensions.GetValues (WeakSymbologies); }
+			set { WeakSymbologies = value.GetConstants (); }
 		}
 	}
 }

--- a/src/Vision/VNDetectBarcodesRequest.cs
+++ b/src/Vision/VNDetectBarcodesRequest.cs
@@ -1,0 +1,22 @@
+﻿//
+// VNDetectBarcodesRequest.cs
+//
+// Authors:
+//	Alex Soto  <alexsoto@microsoft.com>
+//
+// Copyright 2017 Xamarin Inc. All rights reserved.
+//
+
+#if XAMCORE_2_0
+using System;
+
+namespace XamCore.Vision {
+	public partial class VNDetectBarcodesRequest {
+
+		public VNBarcodeSymbology [] Symbologies {
+			get => VNBarcodeSymbologyExtensions.GetValues (WeakSymbologies);
+			set => WeakSymbologies = value.GetConstants ();
+		}
+	}
+}
+#endif

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1407,6 +1407,8 @@ VIDEOTOOLBOX_SOURCES = \
 # Vision
 
 VISION_SOURCES = \
+	Vision/VNBarcodeSymbologyExtensions.cs \
+	Vision/VNDetectBarcodesRequest.cs \
 	Vision/VNFaceLandmarkRegion2D.cs \
 	Vision/VNRequest.cs \
 	Vision/VNUtils.cs \

--- a/src/vision.cs
+++ b/src/vision.cs
@@ -164,11 +164,17 @@ namespace XamCore.Vision {
 		IntPtr Constructor ([NullAllowed] VNRequestCompletionHandler completionHandler);
 
 		[Static]
+		[Protected]
 		[Export ("supportedSymbologies", ArgumentSemantic.Copy)]
-		string [] SupportedSymbologies { get; }
+		NSString [] WeakSupportedSymbologies { get; }
 
+		[Static]
+		[Wrap ("VNBarcodeSymbologyExtensions.GetValues (WeakSupportedSymbologies)")]
+		VNBarcodeSymbology [] SupportedSymbologies { get; }
+
+		[Protected]
 		[Export ("symbologies", ArgumentSemantic.Copy)]
-		string [] Symbologies { get; set; }
+		NSString [] WeakSymbologies { get; set; }
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
@@ -566,8 +572,12 @@ namespace XamCore.Vision {
 	[BaseType (typeof (VNRectangleObservation))]
 	interface VNBarcodeObservation {
 
+		[Protected]
 		[Export ("symbology")]
-		string Symbology { get; }
+		NSString WeakSymbology { get; }
+
+		[Wrap ("VNBarcodeSymbologyExtensions.GetValue (WeakSymbology)")]
+		VNBarcodeSymbology Symbology { get; }
 
 		// TODO: Enable once CoreImage Xcode 9 is bound -> https://bugzilla.xamarin.com/show_bug.cgi?id=58197
 		//[NullAllowed, Export ("barcodeDescriptor", ArgumentSemantic.Strong)]


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=58512

Created strong API (VNBarcodeSymbology) on the following properties

* VNDetectBarcodesRequest.SupportedSymbologies
* VNDetectBarcodesRequest.Symbologies
* VNBarcodeObservation.Symbology