### PR TITLE
[msbuild] Strip frameworks better. (#2305)

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/SymbolStripTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/SymbolStripTaskBase.cs
@@ -49,6 +49,7 @@ namespace Xamarin.MacDev.Tasks
 			if (IsFramework) {
 				// Only remove debug symbols from frameworks.
 				args.AppendSwitch ("-S");
+				args.AppendSwitch ("-x");
 			}
 
 			args.AppendFileNameIfNotNull (Executable);


### PR DESCRIPTION
This can save a significant amount of space when using code-sharing: the PIX
app saved ~11mb in release mode (when stripping).

`man strip` says:

```
For dynamic shared libraries, the maximum level of stripping is usually -x (to remove all non-global symbols).

-x Remove all local symbols (saving only global symbols).
```