### PR TITLE
[monotouch-test] Don't blindly ignore a test since it's not only run on watchOS.

### DIFF
--- a/tests/monotouch-test/Foundation/UbiquitousKeyValueStoreTest.cs
+++ b/tests/monotouch-test/Foundation/UbiquitousKeyValueStoreTest.cs
@@ -32,7 +32,6 @@ namespace MonoTouchFixtures.Foundation {
 		[Test]
 		public void Indexer ()
 		{
-			Assert.Ignore ("Doesn't work on watchOS");
 			using (var store = new NSUbiquitousKeyValueStore ()) {
 				using (var key = new NSString ("key")) {
 					using (var value = new NSString ("value")) {


### PR DESCRIPTION
Also this line is redundant, since the test is `#if !__WATCHOS__`