### PR TITLE
[coreimage] Add CIBarcodeDescriptor and enabled missing API for VNBarcodeObservation. Fix #58197

### DIFF
--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -4708,4 +4708,13 @@ namespace XamCore.CoreImage {
 	interface CIMorphologyMinimum {
 		// TODO: Needs review: https://bugzilla.xamarin.com/show_bug.cgi?id=57350
 	}
+
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[Abstract]
+	[BaseType (typeof (NSObject))]
+	interface CIBarcodeDescriptor : NSSecureCoding, NSCopying {
+		// empty
+	}
 }

--- a/src/vision.cs
+++ b/src/vision.cs
@@ -579,9 +579,8 @@ namespace XamCore.Vision {
 		[Wrap ("VNBarcodeSymbologyExtensions.GetValue (WeakSymbology)")]
 		VNBarcodeSymbology Symbology { get; }
 
-		// TODO: Enable once CoreImage Xcode 9 is bound -> https://bugzilla.xamarin.com/show_bug.cgi?id=58197
-		//[NullAllowed, Export ("barcodeDescriptor", ArgumentSemantic.Strong)]
-		//CIBarcodeDescriptor BarcodeDescriptor { get; }
+		[NullAllowed, Export ("barcodeDescriptor", ArgumentSemantic.Strong)]
+		CIBarcodeDescriptor BarcodeDescriptor { get; }
 
 		[New]
 		[Static]


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=58197