### PR TITLE
[xharness] Fix project cloning to understand how to build test-libraries.

### DIFF
--- a/tests/bindings-framework-test/bindings-framework-test.csproj
+++ b/tests/bindings-framework-test/bindings-framework-test.csproj
@@ -50,6 +50,9 @@
     <ObjcBindingCoreSource Include="StructsAndEnums.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.ObjCBinding.CSharp.targets" />
+  <PropertyGroup>
+    <TestLibrariesDirectory>..\..\tests\test-libraries</TestLibrariesDirectory>
+  </PropertyGroup>
   <ItemGroup>
     <ObjcBindingNativeFramework Include="..\..\tests\test-libraries\.libs\ios\XTest.framework">
       <Link>XTest.framework</Link>
@@ -80,9 +83,6 @@
     <TestLibrariesOutput Include="..\..\tests\test-libraries\.libs\ios\XSharedObjectTest.framework" />
     <TestLibrariesOutput Include="..\..\tests\test-libraries\.libs\ios\XSharedARTest.framework" />
   </ItemGroup>
-  <PropertyGroup>
-    <TestLibrariesDirectory>..\..\tests\test-libraries</TestLibrariesDirectory>
-  </PropertyGroup>
   <Target Name="BeforeBuild" Inputs="@(TestLibrariesInput)" Outputs="@(TestLibrariesOutput)">
     <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />
   </Target>

--- a/tests/bindings-test/bindings-test.csproj
+++ b/tests/bindings-test/bindings-test.csproj
@@ -55,6 +55,9 @@
     <ObjcBindingCoreSource Include="StructsAndEnums.generated.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.ObjCBinding.CSharp.targets" />
+  <PropertyGroup>
+    <TestLibrariesDirectory>..\..\tests\test-libraries</TestLibrariesDirectory>
+  </PropertyGroup>
   <ItemGroup>
     <ObjcBindingNativeLibrary Include="..\..\tests\test-libraries\.libs\ios\libtest.a">
       <Link>libtest.a</Link>
@@ -99,6 +102,6 @@
     <GeneratedTestOutput Include="StructsAndEnums.generated.cs" />
   </ItemGroup>
   <Target Name="BeforeBuild" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)">
-    <Exec Command="make -j8 -C ..\..\tests\test-libraries" />
+    <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />
   </Target>
 </Project>

--- a/tests/bindings-test2/bindings-test2.csproj
+++ b/tests/bindings-test2/bindings-test2.csproj
@@ -53,6 +53,9 @@
     <ObjcBindingCoreSource Include="StructsAndEnums.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.ObjCBinding.CSharp.targets" />
+  <PropertyGroup>
+    <TestLibrariesDirectory>..\..\tests\test-libraries</TestLibrariesDirectory>
+  </PropertyGroup>
   <ItemGroup>
     <ObjcBindingNativeLibrary Include="..\..\tests\test-libraries\.libs\ios\libtest2.a">
       <Link>libtest2.a</Link>
@@ -80,7 +83,7 @@
     <GeneratedTestOutput Include="..\..\tests\test-libraries\.libs\ios\libtest2.a" />
   </ItemGroup>
   <Target Name="BeforeBuild" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)">
-    <Exec Command="make -j8 -C ..\..\tests\test-libraries" />
+    <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />
   </Target>
   <ItemGroup>
     <ProjectReference Include="..\bindings-test\bindings-test.csproj">

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -780,6 +780,9 @@
     <ImageAsset Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" Include="Assets.xcassets\AppIcons.appiconset\icon-app-76%402x.png" />
     <ImageAsset Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" Include="Assets.xcassets\AppIcons.appiconset\icon-app-83.5%402x.png" />
   </ItemGroup>
+  <PropertyGroup>
+    <TestLibrariesDirectory>..\..\tests\test-libraries</TestLibrariesDirectory>
+  </PropertyGroup>
   <ItemGroup>
     <GeneratedTestInput Include="..\..\tests\test-libraries\*.m" />
     <GeneratedTestInput Include="..\..\tests\test-libraries\*.h" />
@@ -789,6 +792,6 @@
     <GeneratedTestOutput Include="ObjCRuntime\RegistrarTest.generated.cs" />
   </ItemGroup>
   <Target Name="BeforeBuild" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)">
-    <Exec Command="make -j8 -C ..\..\tests\test-libraries" />
+    <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />
   </Target>
 </Project>

--- a/tests/xharness/ProjectFileExtensions.cs
+++ b/tests/xharness/ProjectFileExtensions.cs
@@ -689,7 +689,6 @@ namespace xharness
 				new string [] { "GeneratedTestOutput", "Include" },
 				new string [] { "TestLibrariesInput", "Include" },
 				new string [] { "TestLibrariesOutput", "Include" },
-				new string [] { "TestLibrariesOutput", "Include" },
 				new string [] { "Content", "Include" },
 				new string [] { "ObjcBindingApiDefinition", "Include" },
 				new string [] { "ObjcBindingCoreSource", "Include" },


### PR DESCRIPTION
Use a 'TestLibrariesDirectory' property in the project files, which is
rewritten correctly when a project is cloned.