### PR TITLE
Auto-enable the Xamarin build if the maccore repository exists.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -8,6 +8,7 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config
 	@printf "IOS_COMMIT_DISTANCE:=$(shell LANG=C; export LANG && git log `git blame $(TOP)/Make.config HEAD | grep IOS_PACKAGE_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@
 	@printf "MAC_COMMIT_DISTANCE:=$(shell LANG=C; export LANG && git log `git blame $(TOP)/Make.config HEAD | grep MAC_PACKAGE_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@
 	@if which ccache > /dev/null 2>&1; then printf "ENABLE_CCACHE=1\nexport CCACHE_BASEDIR=$(abspath $(TOP)/..)\n" >> $@; echo "Found ccache on the system, enabling it"; fi
+	@if test -d $(TOP)/../maccore; then printf "ENABLE_XAMARIN=1\n" >> $@; echo "Detected the maccore repository, automatically enabled the Xamarin build"; fi
 
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 


### PR DESCRIPTION
This makes it a bit harder to accidentally not enable the Xamarin build.