### PR TITLE
Avoid duplicating define constants if they exist

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.CSharp.targets
@@ -22,7 +22,9 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants>__UNIFIED__;__MOBILE__;__TVOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__TVOS__'))">__TVOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.CSharp.targets
@@ -22,9 +22,9 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__TVOS__'))">__TVOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__TVOS__($|;)'))">__TVOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.CSharp.targets
@@ -22,9 +22,13 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__TVOS__($|;)'))">__TVOS__;$(DefineConstants)</DefineConstants>
+		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
+		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
+		<_IsTVOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__TVOS__($|;)'))</_IsTVOSDefined>
+
+		<DefineConstants Condition="!$(_IsUnifiedDefined)">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsMobileDefined)">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsTVOSDefined)">__TVOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.FSharp.targets
@@ -21,9 +21,9 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__TVOS__'))">__TVOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__TVOS__($|;)'))">__TVOS__;$(DefineConstants)</DefineConstants>
 
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.FSharp.targets
@@ -21,9 +21,13 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__TVOS__($|;)'))">__TVOS__;$(DefineConstants)</DefineConstants>
+		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
+		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
+		<_IsTVOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__TVOS__($|;)'))</_IsTVOSDefined>
+
+		<DefineConstants Condition="!$(_IsUnifiedDefined)">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsMobileDefined)">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsTVOSDefined)">__TVOS__;$(DefineConstants)</DefineConstants>
 
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.FSharp.targets
@@ -21,7 +21,9 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants>__UNIFIED__;__MOBILE__;__TVOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__TVOS__'))">__TVOS__;$(DefineConstants)</DefineConstants>
 
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.CSharp.targets
@@ -22,9 +22,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__TVOS__'))">__TVOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__TVOS__($|;)'))">__TVOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.CSharp.targets
@@ -22,9 +22,13 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__TVOS__($|;)'))">__TVOS__;$(DefineConstants)</DefineConstants>
+		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
+		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
+		<_IsTVOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__TVOS__($|;)'))</_IsTVOSDefined>
+
+		<DefineConstants Condition="!$(_IsUnifiedDefined)">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsMobileDefined)">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsTVOSDefined)">__TVOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.CSharp.targets
@@ -22,7 +22,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants>__UNIFIED__;__MOBILE__;__TVOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__TVOS__'))">__TVOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.FSharp.targets
@@ -21,9 +21,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__TVOS__'))">__TVOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__TVOS__($|;)'))">__TVOS__;$(DefineConstants)</DefineConstants>
 
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.FSharp.targets
@@ -21,9 +21,13 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__TVOS__($|;)'))">__TVOS__;$(DefineConstants)</DefineConstants>
+		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
+		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
+		<_IsTVOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__TVOS__($|;)'))</_IsTVOSDefined>
+
+		<DefineConstants Condition="!$(_IsUnifiedDefined)">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsMobileDefined)">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsTVOSDefined)">__TVOS__;$(DefineConstants)</DefineConstants>
 
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.FSharp.targets
@@ -21,7 +21,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants>__UNIFIED__;__MOBILE__;__TVOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__TVOS__'))">__TVOS__;$(DefineConstants)</DefineConstants>
 
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.CSharp.targets
@@ -22,9 +22,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__WATCHOS__'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__WATCHOS__($|;)'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.WatchOS.App.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.CSharp.targets
@@ -22,9 +22,13 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__WATCHOS__($|;)'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
+		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
+		<_IsWATCHOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__WATCHOS__($|;)'))</_IsWATCHOSDefined>
+
+		<DefineConstants Condition="!$(_IsUnifiedDefined)">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsMobileDefined)">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsWATCHOSDefined)">__WATCHOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.WatchOS.App.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.CSharp.targets
@@ -22,7 +22,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants>__UNIFIED__;__MOBILE__;__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__WATCHOS__'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.WatchOS.App.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.FSharp.targets
@@ -21,9 +21,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__WATCHOS__'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__WATCHOS__($|;)'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
 
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.FSharp.targets
@@ -21,7 +21,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants>__UNIFIED__;__MOBILE__;__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__WATCHOS__'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
 
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.App.FSharp.targets
@@ -21,9 +21,13 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__WATCHOS__($|;)'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
+		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
+		<_IsWATCHOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__WATCHOS__($|;)'))</_IsWATCHOSDefined>
+
+		<DefineConstants Condition="!$(_IsUnifiedDefined)">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsMobileDefined)">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsWATCHOSDefined)">__WATCHOS__;$(DefineConstants)</DefineConstants>
 
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.CSharp.targets
@@ -22,7 +22,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants>__UNIFIED__;__MOBILE__;__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__WATCHOS__'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.WatchOS.AppExtension.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.CSharp.targets
@@ -22,9 +22,13 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__WATCHOS__($|;)'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
+		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
+		<_IsWATCHOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__WATCHOS__($|;)'))</_IsWATCHOSDefined>
+
+		<DefineConstants Condition="!$(_IsUnifiedDefined)">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsMobileDefined)">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsWATCHOSDefined)">__WATCHOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.WatchOS.AppExtension.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.CSharp.targets
@@ -22,9 +22,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__WATCHOS__'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__WATCHOS__($|;)'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.WatchOS.AppExtension.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.FSharp.targets
@@ -21,9 +21,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__WATCHOS__'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__WATCHOS__($|;)'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
 
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.FSharp.targets
@@ -21,7 +21,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants>__UNIFIED__;__MOBILE__;__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__WATCHOS__'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
 
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.FSharp.targets
@@ -21,9 +21,13 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__WATCHOS__($|;)'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
+		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
+		<_IsWATCHOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__WATCHOS__($|;)'))</_IsWATCHOSDefined>
+
+		<DefineConstants Condition="!$(_IsUnifiedDefined)">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsMobileDefined)">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsWATCHOSDefined)">__WATCHOS__;$(DefineConstants)</DefineConstants>
 
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.CSharp.targets
@@ -22,9 +22,13 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__WATCHOS__($|;)'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
+		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
+		<_IsWATCHOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__WATCHOS__($|;)'))</_IsWATCHOSDefined>
+
+		<DefineConstants Condition="!$(_IsUnifiedDefined)">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsMobileDefined)">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsWATCHOSDefined)">__WATCHOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.WatchOS.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.CSharp.targets
@@ -22,9 +22,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__WATCHOS__'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__WATCHOS__($|;)'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.WatchOS.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.CSharp.targets
@@ -22,7 +22,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants>__UNIFIED__;__MOBILE__;__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__WATCHOS__'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.WatchOS.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.FSharp.targets
@@ -21,9 +21,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__WATCHOS__'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__WATCHOS__($|;)'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
 		
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.FSharp.targets
@@ -21,9 +21,13 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__WATCHOS__($|;)'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
+		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
+		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
+		<_IsWATCHOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__WATCHOS__($|;)'))</_IsWATCHOSDefined>
+
+		<DefineConstants Condition="!$(_IsUnifiedDefined)">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsMobileDefined)">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsWATCHOSDefined)">__WATCHOS__;$(DefineConstants)</DefineConstants>
 		
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.FSharp.targets
@@ -21,8 +21,10 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants>__UNIFIED__;__MOBILE__;__WATCHOS__;$(DefineConstants)</DefineConstants>
-
+		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__WATCHOS__'))">__WATCHOS__;$(DefineConstants)</DefineConstants>
+		
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can
 		     remove this -->

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.CSharp.targets
@@ -22,9 +22,13 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__IOS__($|;)'))">__IOS__;$(DefineConstants)</DefineConstants>
+		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
+		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
+		<_IsIOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__IOS__($|;)'))</_IsIOSDefined>
+
+		<DefineConstants Condition="!$(_IsUnifiedDefined)">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsMobileDefined)">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsIOSDefined)">__IOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.iOS.AppExtension.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.CSharp.targets
@@ -22,7 +22,9 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__IOS__'))">__IOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.iOS.AppExtension.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.CSharp.targets
@@ -22,9 +22,9 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__IOS__'))">__IOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__IOS__($|;)'))">__IOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.iOS.AppExtension.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.FSharp.targets
@@ -21,8 +21,10 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;$(DefineConstants)</DefineConstants>
-
+		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__IOS__'))">__IOS__;$(DefineConstants)</DefineConstants>
+		
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can
 		     remove this -->

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.FSharp.targets
@@ -21,9 +21,9 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__IOS__'))">__IOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__IOS__($|;)'))">__IOS__;$(DefineConstants)</DefineConstants>
 		
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.FSharp.targets
@@ -21,9 +21,14 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__IOS__($|;)'))">__IOS__;$(DefineConstants)</DefineConstants>
+
+		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
+		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
+		<_IsIOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__IOS__($|;)'))</_IsIOSDefined>
+
+		<DefineConstants Condition="!$(_IsUnifiedDefined)">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsMobileDefined)">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsIOSDefined)">__IOS__;$(DefineConstants)</DefineConstants>
 		
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.CSharp.targets
@@ -22,9 +22,9 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__IOS__'))">__IOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__IOS__($|;)'))">__IOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.iOS.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.CSharp.targets
@@ -22,9 +22,13 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__IOS__($|;)'))">__IOS__;$(DefineConstants)</DefineConstants>
+		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
+		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
+		<_IsIOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__IOS__($|;)'))</_IsIOSDefined>
+
+		<DefineConstants Condition="!$(_IsUnifiedDefined)">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsMobileDefined)">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsIOSDefined)">__IOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.iOS.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.CSharp.targets
@@ -22,7 +22,9 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__IOS__'))">__IOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.iOS.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.FSharp.targets
@@ -21,9 +21,9 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__IOS__'))">__IOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__IOS__($|;)'))">__IOS__;$(DefineConstants)</DefineConstants>
 		
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.FSharp.targets
@@ -21,10 +21,15 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__IOS__($|;)'))">__IOS__;$(DefineConstants)</DefineConstants>
-		
+
+		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
+		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
+		<_IsIOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__IOS__($|;)'))</_IsIOSDefined>
+
+		<DefineConstants Condition="!$(_IsUnifiedDefined)">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsMobileDefined)">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsIOSDefined)">__IOS__;$(DefineConstants)</DefineConstants>
+
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can
 		     remove this -->

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.FSharp.targets
@@ -21,8 +21,10 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
-		<DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;$(DefineConstants)</DefineConstants>
-
+		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__IOS__'))">__IOS__;$(DefineConstants)</DefineConstants>
+		
 		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
 		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can
 		     remove this -->

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.CSharp.targets
@@ -22,7 +22,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(DefineConstants.Contains('__IOS__'))">__IOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.iOS.WatchApp.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.CSharp.targets
@@ -22,9 +22,9 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants Condition="!$(DefineConstants.Contains('__UNIFIED__'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__MOBILE__'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$(DefineConstants.Contains('__IOS__'))">__IOS__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__IOS__($|;)'))">__IOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.iOS.WatchApp.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.WatchApp.CSharp.targets
@@ -22,9 +22,13 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__UNIFIED__($|;)'))">__UNIFIED__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__MOBILE__($|;)'))">__MOBILE__;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch($(DefineConstants.Trim()), '(^|;)__IOS__($|;)'))">__IOS__;$(DefineConstants)</DefineConstants>
+		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
+		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
+		<_IsIOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__IOS__($|;)'))</_IsIOSDefined>
+
+		<DefineConstants Condition="!$(_IsUnifiedDefined)">__UNIFIED__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsMobileDefined)">__MOBILE__;$(DefineConstants)</DefineConstants>
+		<DefineConstants Condition="!$(_IsIOSDefined)">__IOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Import Project="Xamarin.iOS.WatchApp.Common.targets" />


### PR DESCRIPTION
In VS the property page for Build will show whatever is in DefineConstants, and then save it. Without this, that means that any time the Build page is saved, it duplicates the constants.
This fixes bug#32765: Bug 32765 - Conditional compilation symbols are duplicated everytime I reload the project or restart visual studio (https://bugzilla.xamarin.com/show_bug.cgi?id=32765)