### PR TITLE
[xharness] Create device tasks even if we can't load devices.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -134,7 +134,6 @@ namespace xharness
 				await Devices.LoadAsync (DeviceLoadLog, removed_locked: true);
 			} catch (Exception e) {
 				DeviceLoadLog.WriteLine ("Failed to load devices: {0}", e);
-				return rv;
 			}
 
 			foreach (var project in Harness.IOSTestProjects) {


### PR DESCRIPTION
The tests will eventually end up skipped because there are no applicable
devices, and matches the behavior when no devices are connected.

The log file for the device list will show what actually happened.