### PR TITLE
[linker] Remove method the base class now has.

### DIFF
--- a/tools/linker/MobileSweepStep.cs
+++ b/tools/linker/MobileSweepStep.cs
@@ -54,12 +54,5 @@ namespace Xamarin.Linker {
 			if (main.HasModuleReferences && (CurrentAction == AssemblyAction.Link))
 				SweepCollection (main.ModuleReferences);
 		}
-
-		protected void SweepCollection (IList list)
-		{
-			for (int i = 0; i < list.Count; i++)
-				if (!Annotations.IsMarked ((IMetadataTokenProvider) list [i]))
-					list.RemoveAt (i--);
-		}
 	}
 }


### PR DESCRIPTION
The base class now has this method, with the exact same implementation: [SweepStep.cs#L294-L301](
https://github.com/mono/linker/blob/0a4e328e3f7dab84b35f92da1c15d2699675fd0d/linker/Mono.Linker.Steps/SweepStep.cs#L294-L301),
so there's no need to duplicate it.

It also fixes this compiler warning:

> tools/linker/MobileSweepStep.cs(58,18): warning CS0108: 'MobileSweepStep.SweepCollection(IList)' hides inherited member 'SweepStep.SweepCollection(IList)'. Use the new keyword if hiding was intended.