### PR TITLE
[xharness] Skipping tests is bad.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -692,7 +692,7 @@ namespace xharness
 				}
 				Task.WaitAll (tasks.ToArray ());
 				GenerateReport ();
-				return Tasks.Any ((v) => v.Failed) ? 1 : 0;
+				return Tasks.Any ((v) => v.Failed || v.Skipped) ? 1 : 0;
 			} catch (Exception ex) {
 				MainLog.WriteLine ("Unexpected exception: {0}", ex);
 				Console.WriteLine ("Unexpected exception: {0}", ex);
@@ -987,6 +987,8 @@ namespace xharness
 				return "black";
 			else if (tests.Any ((v) => v.Ignored))
 				return "gray";
+			else if (tests.Any ((v) => v.Skipped))
+				return "orangered";
 			else
 				return "black";
 		}
@@ -1021,7 +1023,7 @@ namespace xharness
 				} else if (test.Waiting) {
 					return "darkgray";
 				} else if (test.Skipped) {
-					return "silver";
+					return "orangered";
 				} else {
 					return "pink";
 				}


### PR DESCRIPTION
Skipping tests happen when a device/simulator isn't found for a test, and
should not be ignored.