### PR TITLE
[builds] Tell LLVM to stay away from newer macOS functions.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -1857,6 +1857,7 @@ endif
 
 LLVM_BASE_CONFIGURE_FLAGS=--enable-libcpp --enable-optimized --enable-assertions=no --disable-jit --disable-docs --disable-doxygen
 LLVM_CXXFLAGS=$(CCACHE_CXXFLAGS)
+LLVM_BASE_CONFIGURE_ENVIRONMENT=$(COMMON_ACVARS)
 
 # This is used just for linking with the 32 bit cross compiler
 # FIXME: Avoid building the libs not needed by mono
@@ -1864,6 +1865,7 @@ LLVM_CXXFLAGS=$(CCACHE_CXXFLAGS)
 	@mkdir -p llvm/
 	@echo "Configuring llvm"
 	@cd llvm && \
+	$(LLVM_BASE_CONFIGURE_ENVIRONMENT) \
 	$(abspath $(LLVM_PATH)/configure) --prefix=$$PWD/usr --build=i386-apple-darwin10.7  --enable-targets="arm" $(LLVM_BASE_CONFIGURE_FLAGS) --cache-file=../llvm.config.cache CC="$(CCACHE)clang" CXX="$(CCACHE)clang++" CXXFLAGS="$(LLVM_CXXFLAGS)" > $@.log 2>&1 || (echo "Configuring llvm failed:" && cat $@.log | sed "s/^/    /" && exit 1)
 	$(Q) @touch $@
 	@echo Configured llvm
@@ -1872,6 +1874,7 @@ LLVM_CXXFLAGS=$(CCACHE_CXXFLAGS)
 	@mkdir -p llvm64/
 	@echo "Configuring llvm64"
 	@cd llvm64 && \
+	$(LLVM_BASE_CONFIGURE_ENVIRONMENT) \
 	$(abspath $(LLVM_PATH)/configure) --prefix=$$PWD/usr --enable-targets="arm arm64" $(LLVM_BASE_CONFIGURE_FLAGS) --cache-file=../llvm64.config.cache CC="$(CCACHE)clang" CXX="$(CCACHE)clang++" CXXFLAGS="-Qunused-arguments" > $@.log 2>&1 || (echo "Configuring llvm64 failed:" && cat $@.log | sed "s/^/    /" && exit 1)
 	$(Q) @touch $@
 	@echo "Configured llvm64"


### PR DESCRIPTION
Fixes this build problem on Sierra:

> ld: weak import of symbol '_futimens' not supported because of option: -no_weak_imports for architecture x86_64

This is a symbol that was (will be?) introduced in High Sierra.

Interestingly this only occurs if the Xcode 8.X Command Line Tools haven't
been manually installed.

Because if the Xcode 8.X Command Line Tools are installed, this happens:

1. llvm's configure script detects that 'futimens' is not usable.

2. llvm's configure script detects that 'futimens' is not usable, because
   xcrun sets SDKROOT=/ when calling clang.

    a. When the SDKROOT variable is set, clang passes '-syslibroot /usr/lib'
       to ld.
    b. When ld gets '-syslibroot /usr/lib', ld looks in '/usr/lib' for a
       library that contains 'futimens' in the OS itself, and since we're on
       Sierra, that fails to link.
    c. So when llvm's configure script creates a test program that checks if
       'futimens' is present, the program fails. This is correct, and makes
       llvm *not* use futimens.

3. xcrun sets SDKROOT=/ because /usr/share/current-os.sdk/Info.plist exists.
   If that file does not exist, then xcrun sets SDKROOT to Xcode9's macOS SDK
   (because that's what xcode-select reports).

    a. When SDKROOT is set to Xcode9's macOS SDK, the configure check for
       'futimens' succeeds, because the macOS 10.13 SDK contains that
       function.
    b. llvm happily uses 'futimens', and then the final link fails because
       we're using a symbol not available on all target platforms.