### PR TITLE
[macos] NSApplication.Terminate should allow null (#2471)

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -497,7 +497,7 @@ namespace XamCore.AppKit {
 		void EndModalSession (IntPtr session);
 	
 		[Export ("terminate:")]
-		void Terminate (NSObject sender);
+		void Terminate ([NullAllowed] NSObject sender);
 	
 		[Export ("requestUserAttention:")]
 		nint RequestUserAttention (NSRequestUserAttentionType requestType);


### PR DESCRIPTION
- https://bugzilla.xamarin.com/show_bug.cgi?id=58653