### PR TITLE
[xharness] It watchOS tests don't need to be clean anymore. Fixes #58348.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -2835,7 +2835,7 @@ function oninitialload ()
 			if (Platform == TestPlatform.watchOS)
 				CompanionDevice = Jenkins.Simulators.FindCompanionDevice (Jenkins.SimulatorLoadLog, Device);
 
-			var clean_state = Platform == TestPlatform.watchOS;
+			var clean_state = false;//Platform == TestPlatform.watchOS;
 			runner = new AppRunner ()
 			{
 				Harness = Harness,


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=58348