### PR TITLE
[macos] System mono should resolve non-XM libraries from system (#2480)

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -64,15 +64,49 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<XamarinMacFrameworkRoot>/Library/Frameworks/Xamarin.Mac.framework/Versions/Current</XamarinMacFrameworkRoot>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(UseXamMacFullFramework)' != 'true'">
+	<Choose>
+		<When Condition=" '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
+			<PropertyGroup>
+				<TargetFrameworkName>Modern</TargetFrameworkName>
+				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/Xamarin.Mac</MacBclPath>
+			</PropertyGroup>
+		</When>
+		<When Condition=" '$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(UseXamMacFullFramework)' == 'true'">
+			<PropertyGroup>
+				<TargetFrameworkName>Full</TargetFrameworkName>
+				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
+			</PropertyGroup>
+		</When>
+		<Otherwise>
+			<PropertyGroup>
+				<TargetFrameworkName>System</TargetFrameworkName>
+				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
+			</PropertyGroup>
+		</Otherwise>
+	</Choose>
+
+	<PropertyGroup Condition="'$(TargetFrameworkName)' == 'Full'">
 		<AssemblySearchPaths>$(XamarinMacFrameworkRoot)/lib/reference/full;$(XamarinMacFrameworkRoot)/lib/mono;$(AssemblySearchPaths)</AssemblySearchPaths>
 	</PropertyGroup>
 
-	<!-- Do not resolve from the GAC under any circumstances in Mobile or XM45 -->
-	<PropertyGroup Condition="(('$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(UseXamMacFullFramework)' == 'true') Or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac') And !$(MonoBundlingExtraArgs.Contains('--allow-unsafe-gac-resolution'))" >
+	<!-- Do not resolve from the GAC in Modern or Full unless allow-unsafe-gac-resolution is passed in -->
+	<PropertyGroup Condition="'$(TargetFrameworkName)' != 'System' And !$(MonoBundlingExtraArgs.Contains('--allow-unsafe-gac-resolution'))" >
 		<AssemblySearchPaths>$([System.String]::Copy('$(AssemblySearchPaths)').Replace('{GAC}',''))</AssemblySearchPaths>
 		<AssemblySearchPaths Condition="'$(MSBuildRuntimeVersion)' != ''">$(AssemblySearchPaths.Split(';'))</AssemblySearchPaths>
 	</PropertyGroup>
+
+	<!-- Location of Libraries -->
+	<Target Name="FixTargetFrameworkDirectory" AfterTargets="GetReferenceAssemblyPaths" Condition="('$(OS)' != 'Windows_NT')">
+		<PropertyGroup>
+			<!-- For Modern / Full we overwrite TargetFrameworkDirectory to resolve non XM assemblies from our location only -->
+			<TargetFrameworkDirectory Condition="'$(TargetFrameworkName)' != 'System'">$(MacBclPath);@(DesignTimeFacadeDirectories)</TargetFrameworkDirectory>
+
+			<!-- For system we extend, not overwrite TargetFrameworkDirectory. -->
+			<!-- mscorlib, System, and other BCL libs must come from Mono System to prevent corlib mistmatches. Xamarin.Mac.dll must come from XM/lib/mono/4.5/ -->
+			<!-- If we find cases of other non-XM assemblies being resolved from XM paths, we can look into using CandidateAssemblyFiles but it is msbuild only. -->
+			<TargetFrameworkDirectory Condition="'$(TargetFrameworkName)' == 'System'">$(TargetFrameworkDirectory);$(MacBclPath)</TargetFrameworkDirectory>
+		</PropertyGroup>
+	</Target>
 
 	<PropertyGroup>
 		<_CanOutputAppBundle>False</_CanOutputAppBundle>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
@@ -16,21 +16,19 @@ Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<!-- MSBuild specific hacks - Teach msbuild where to find our BCL and facades -->
+
+	<!-- Location of mscorlib -->
 	<PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
-		<MacBclPath Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.Mac'">$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
-		<MacBclPath Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">$(XamarinMacFrameworkRoot)/lib/mono/Xamarin.Mac</MacBclPath>
-		<FrameworkPathOverride>$(MacBclPath)</FrameworkPathOverride>
+		<FrameworkPathOverride Condition="'$(TargetFrameworkName)' != 'System'">$(MacBclPath)</FrameworkPathOverride>
 	</PropertyGroup>
-	<Target Name="FixTargetFrameworkDirectory" AfterTargets="GetReferenceAssemblyPaths" Condition="'$(OS)' != 'Windows_NT'">
-    		<ItemGroup>
+
+	<Target Name="FixDesignTimeFacades" AfterTargets="GetReferenceAssemblyPaths" Condition="('$(OS)' != 'Windows_NT')">
+		<ItemGroup>
 			<DesignTimeFacadeDirectories Remove="@(DesignTimeFacadeDirectories)" />
 			<DesignTimeFacadeDirectories Include="$(MacBclPath)/Facades/" />
 		</ItemGroup>
-		<PropertyGroup>	
-			<TargetFrameworkDirectory>$(MacBclPath);@(DesignTimeFacadeDirectories)</TargetFrameworkDirectory>
-		</PropertyGroup>
 	</Target>
 	
 	<!-- Modern/Mobile does not get ImplicitlyExpandDesignTimeFacades as Microsoft.NETFramework.CurrentVersion.targets isn't pulled in -->
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.Common.ImplicitFacade.msbuild.targets" Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'"/>
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.Common.ImplicitFacade.msbuild.targets" Condition="'$(TargetFrameworkName)' == 'Modern'"/>
 </Project>

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -641,8 +641,7 @@ namespace Xamarin.MMP.Tests
 			RunMMPTest (tmpDir => {
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { XM45 = true };
 				var output = TI.TestUnifiedExecutable (test);
-				Assert.That (output.BuildOutput, Contains.Substring ("TargetFrameworkIdentifier: .NETFramework"));
-				Assert.That (output.BuildOutput, Contains.Substring ("TargetFrameworkVersion: v4.5"));
+				Assert.That (output.BuildOutput, Contains.Substring ("Selected target framework: .NETFramework,Version=v4.5; API: Unified"));
 			});
 		}
 


### PR DESCRIPTION
- https://bugzilla.xamarin.com/show_bug.cgi?id=58703
- Was broken on msbuild but undetected due to https://bugzilla.xamarin.com/show_bug.cgi?id=53164
- Unified45Build_CompileToNativeOutput was broken in a recent commit bf53e6204d0950acd5f8efcce8732bd8d8
- This was not caught as the mmp tests are not run by default
- The test was bad/wrong, and checking msbuild not mmp ouput anyway, so fixing.