### PR TITLE
[bug] Use Identity instead of FullPath on _CompressObjCBindingNativeFrameworkResources target

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
@@ -133,7 +133,7 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 			Symlinks="true"
 			Sources="%(ObjCBindingNativeFramework.Identity)"
 			OutputFile="$(IntermediateOutputPath)%(ObjCBindingNativeFramework.Filename)%(ObjCBindingNativeFramework.Extension)"
-			WorkingDirectory="%(ObjCBindingNativeFramework.FullPath)" >
+			WorkingDirectory="%(ObjCBindingNativeFramework.Identity)" >
 		</Zip>
 
 		<CreateItem Include="$(IntermediateOutputPath)%(ObjCBindingNativeFramework.Filename)%(ObjCBindingNativeFramework.Extension)">


### PR DESCRIPTION
Using the FullPath property breaks the build from Windows, since the metadata will contain a Windows path.

Partial fix for Bug #51759 - Getting build error for iOS sample 'Simpleapp-with-framework'

https://bugzilla.xamarin.com/show_bug.cgi?id=51759