### PR TITLE
[mtouch] Put 'mono_profiler_startup_log' in the symbol list. Fixes #58778.

### DIFF
--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -120,6 +120,8 @@ namespace Xamarin
 		public string AotOtherArguments;
 		public string [] LinkSkip;
 		public string [] XmlDefinitions;
+		public bool? Profiling;
+		public string SymbolList;
 
 #pragma warning restore 649
 
@@ -306,6 +308,12 @@ namespace Xamarin
 					sb.Append (" --nosymbolstrip:").Append (NoSymbolStrip);
 				}
 			}
+
+			if (Profiling.HasValue)
+				sb.Append (" --profiling:").Append (Profiling.Value ? "true" : "false");
+
+			if (!string.IsNullOrEmpty (SymbolList))
+				sb.Append (" --symbollist=").Append (StringUtils.Quote (SymbolList));
 
 			if (MSym.HasValue)
 				sb.Append (" --msym:").Append (MSym.Value ? "true" : "false");

--- a/tools/common/CompilerFlags.cs
+++ b/tools/common/CompilerFlags.cs
@@ -45,14 +45,6 @@ namespace Xamarin.Utils
 			}
 		}
 
-		public void ReferenceSymbol (string symbol)
-		{
-			if (UnresolvedSymbols == null)
-				UnresolvedSymbols = new HashSet<string> ();
-
-			UnresolvedSymbols.Add (symbol);
-		}
-
 		public void ReferenceSymbols (IEnumerable<Symbol> symbols)
 		{
 			if (UnresolvedSymbols == null)

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -238,6 +238,11 @@ namespace Xamarin.Bundler {
 					dynamic_symbols.AddFunction ("xamarin_dyn_objc_msgSendSuper_stret");
 				}
 
+#if MONOTOUCH
+				if (App.EnableProfiling && App.LibProfilerLinkMode == AssemblyBuildTarget.StaticObject)
+					dynamic_symbols.AddFunction ("mono_profiler_startup_log");
+#endif
+
 				dynamic_symbols.Save (cache_location);
 			}
 

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -1396,8 +1396,6 @@ namespace Xamarin.Bundler
 				case AssemblyBuildTarget.StaticObject:
 					libprofiler = Path.Combine (libdir, "libmono-profiler-log.a");
 					linker_flags.AddLinkWith (libprofiler);
-					if (!App.EnableBitCode)
-						linker_flags.ReferenceSymbol ("mono_profiler_startup_log");
 					break;
 				case AssemblyBuildTarget.Framework: // We don't ship the profiler as a framework, so this should be impossible.
 				default:


### PR DESCRIPTION
We need the 'mono_profiler_startup_log' symbol when profiling is enabled, so make
sure to add the symbol to the correct list of symbols we need.

Previously we were passing `-u _mono_profiler_startup_log` to clang directly,
which is fine, but not complete, since it does not write the symbol to the
symbollist file (--symbollist=file), which means it wouldn't be preserved when
the MSBuild tasks strip the executable.

https://bugzilla.xamarin.com/show_bug.cgi?id=58778