### PR TITLE
[mtouch] Show MT0091 as a warning if we're using the dynamic registrar.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -569,7 +569,14 @@ earlier iOS version.
 
 <h3><a name="MT0117"/>MT0117: Can't launch a 32-bit app on a simulator that only supports 64-bit.</h3>
 
-<!-- 0116 - 0124: free to use -->
+<h3><a name="MT0118"/>MT0118: Skipped linking with the framework '{framework}' (referenced by a module reference in {module_reference}) because it was introduced in {platform} {platform_version} (and currently building with the {platform} SDK {sdk_version}).</h3>
+
+A framework reference was detected to a framework that isn't included in the
+SDK currently being used to build.
+
+This is usually fixed by using the latest available version of Xcode.
+
+<!-- 0119 - 0124: free to use -->
 
 <h3><a name="MT0125"/>MT0125: The --assembly-build-target command-line argument is ignored in the simulator.</h3>
 

--- a/tests/common/ExecutionHelper.cs
+++ b/tests/common/ExecutionHelper.cs
@@ -198,6 +198,9 @@ namespace Xamarin.Tests
 				Assert.Fail (string.Format ("The error '{0}{1:0000}: {2}' was not found in the output:\n{3}", prefix, number, message, string.Join ("\n", details.ToArray ())));
 			}
 
+			if (!matches.Where ((msg) => msg.IsError).Any ())
+				Assert.Fail (string.Format ("Found the message '{0}{1:0000}: {2}' as expected, but it's a warning, not an error.", prefix, number, message));
+
 			if (filename != null) {
 				var hasDirectory = filename.IndexOf (Path.DirectorySeparatorChar) > -1;
 				if (!matches.Any ((v) => {
@@ -246,8 +249,12 @@ namespace Xamarin.Tests
 
 		public void AssertWarning (string prefix, int number, string message)
 		{
-			if (!messages.Any ((msg) => msg.Prefix == prefix && msg.Number == number))
+			var matches = messages.Where ((msg) => msg.Prefix == prefix && msg.Number == number);
+			if (!matches.Any ())
 				Assert.Fail (string.Format ("The warning '{0}{1:0000}' was not found in the output.", prefix, number));
+
+			if (!matches.Where ((msg) => msg.IsWarning).Any ())
+				Assert.Fail (string.Format ("Found the message '{0}{1:0000}: {2}' as expected, but it's an error, not a warning.", prefix, number, message));
 
 			if (messages.Any ((msg) => msg.Message == message))
 				return;

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -864,10 +864,18 @@ namespace Xamarin
 				mtouch.SdkRoot = old_xcode;
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Sdk = sdk_version;
-				Assert.AreEqual (1, mtouch.Execute (MTouchAction.BuildSim));
+				mtouch.AssertExecute (MTouchAction.BuildSim, "build sim dynamic");
 				var xcodeVersionString = Configuration.XcodeVersion;
 				if (xcodeVersionString.EndsWith (".0", StringComparison.Ordinal))
 					xcodeVersionString = xcodeVersionString.Substring (0, xcodeVersionString.Length - 2);
+				mtouch.AssertWarning (91, String.Format ("This version of Xamarin.iOS requires the {0} {1} SDK (shipped with Xcode {2}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only (to try to avoid the new APIs).", name, GetSdkVersion (profile), xcodeVersionString));
+
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build sim static");
+				mtouch.AssertError (91, String.Format ("This version of Xamarin.iOS requires the {0} {1} SDK (shipped with Xcode {2}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only (to try to avoid the new APIs).", name, GetSdkVersion (profile), xcodeVersionString));
+
+				mtouch.Registrar = MTouchRegistrar.Unspecified;
+				mtouch.AssertExecuteFailure (MTouchAction.BuildDev, "build dev");
 				mtouch.AssertError (91, String.Format ("This version of Xamarin.iOS requires the {0} {1} SDK (shipped with Xcode {2}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only (to try to avoid the new APIs).", name, GetSdkVersion (profile), xcodeVersionString));
 			}
 		}

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -813,7 +813,7 @@ namespace Xamarin
 				mtouch.CreateTemporaryApp ();
 				mtouch.TargetFramework = GetTargetFramework (profile);
 				Assert.AreEqual (0, mtouch.Execute (MTouchAction.BuildSim));
-				mtouch.AssertError (85, string.Format ("No reference to '{0}' was found. It will be added automatically.", Path.GetFileName (GetBaseLibrary (profile))));
+				mtouch.AssertWarning (85, string.Format ("No reference to '{0}' was found. It will be added automatically.", Path.GetFileName (GetBaseLibrary (profile))));
 			}
 		}
 
@@ -3056,11 +3056,11 @@ public partial class NotificationService : UNNotificationServiceExtension
 
 				mtouch.HttpMessageHandler = "HttpClientHandler";
 				mtouch.AssertExecute (MTouchAction.BuildSim);
-				mtouch.AssertError (2015, "Invalid HttpMessageHandler `HttpClientHandler` for watchOS. The only valid value is NSUrlSessionHandler.");
+				mtouch.AssertWarning (2015, "Invalid HttpMessageHandler `HttpClientHandler` for watchOS. The only valid value is NSUrlSessionHandler.");
 
 				mtouch.HttpMessageHandler = "CFNetworkHandler";
 				mtouch.AssertExecute (MTouchAction.BuildSim);
-				mtouch.AssertError (2015, "Invalid HttpMessageHandler `CFNetworkHandler` for watchOS. The only valid value is NSUrlSessionHandler.");
+				mtouch.AssertWarning (2015, "Invalid HttpMessageHandler `CFNetworkHandler` for watchOS. The only valid value is NSUrlSessionHandler.");
 
 				mtouch.HttpMessageHandler = "Dummy";
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim);

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -415,7 +415,10 @@ namespace Xamarin.Bundler {
 						// detect frameworks
 						int f = name.IndexOf (".framework/", StringComparison.Ordinal);
 						if (f > 0) {
-							if (Frameworks.Add (file))
+							if (Driver.GetFrameworks (App).TryGetValue (file, out var fw) && fw.Version > App.SdkVersion)
+								ErrorHelper.Warning (118, "Skipped linking with the framework '{0}' (referenced by a module reference in {1}) because it was introduced in {2} {3} (and currently building with the {2} SDK {4}).",
+													 file, FileName, App.PlatformName, fw.Version, App.SdkVersion);
+							else if (Frameworks.Add (file))
 								Driver.Log (3, "Linking with the framework {0} because it's referenced by a module reference in {1}", file, FileName);
 						} else {
 							if (UnresolvedModuleReferences == null)


### PR DESCRIPTION
Even if using an Xcode older than the bindings we're shipping, everything
might just happen to work when using the dynamic registrar, so downgrade the
MT0091 error to a warning in that case (and cross fingers, because things
might still break).

Hopefully this makes it easier when using older Xcodes, because the typical
scenario of Sim+DontLink and Dev+LinkSdk/LinkAll will now just work (if the
app developer also crosses fingers piously and sacrifies the appropriate
amount of pizza to the proper deity).

Reference: https://trello.com/c/wP3Pcb1q/692-targeting-older-xcodes-without-enabling-managed-linking