### PR TITLE
[macos] Teach mmp to correctly swap arch specific assemblies

### DIFF
--- a/tests/common/mac/Component1.fs
+++ b/tests/common/mac/Component1.fs
@@ -1,3 +1,5 @@
 ﻿namespace FSharpXM45Library
 type Class1() = 
     member this.X = "F#"
+
+%CODE%

--- a/tests/common/mac/MyClass.cs
+++ b/tests/common/mac/MyClass.cs
@@ -10,3 +10,4 @@ namespace Library
 	}
 }
 
+%CODE%

--- a/tests/common/mac/UnifiedExample.csproj
+++ b/tests/common/mac/UnifiedExample.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+%REFERENCES_BEFORE_PLATFORM%
     <Reference Include="Xamarin.Mac" />
 %REFERENCES%
   </ItemGroup>

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -728,5 +728,28 @@ namespace Xamarin.MMP.Tests
 				TI.TestUnifiedExecutable (test);
 			});
 		}
+
+		public void Unified32BitWithXMRequiringLibrary_ShouldReferenceCorrectXM_AndNotCrash ()
+		{
+			RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig libConfig = new TI.UnifiedTestConfig (tmpDir) {
+					ProjectName = "UnifiedLibrary",
+					TestCode = "namespace Library { public static class Foo { public static void Bar () { var v = new Foundation.NSObject (); } } }"
+				};
+
+				string csprojTarget = TI.GenerateUnifiedLibraryProject (libConfig);
+				TI.BuildProject (csprojTarget, isUnified: true);
+
+				string referenceCode = string.Format (@"<Reference Include=""UnifiedLibrary""><HintPath>{0}</HintPath></Reference>", Path.Combine (tmpDir, "bin/Debug/UnifiedLibrary.dll"));
+
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					CSProjConfig = @"<PlatformTarget>x86</PlatformTarget><XamMacArch>i386</XamMacArch>",
+					ReferencesBeforePlatform = referenceCode,
+					TestCode = "Library.Foo.Bar ();"
+				};
+
+				TI.TestUnifiedExecutable (test);
+			});
+		}
 	}
 }

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -729,6 +729,7 @@ namespace Xamarin.MMP.Tests
 			});
 		}
 
+		[Test]
 		public void Unified32BitWithXMRequiringLibrary_ShouldReferenceCorrectXM_AndNotCrash ()
 		{
 			RunMMPTest (tmpDir => {


### PR DESCRIPTION
- https://bugzilla.xamarin.com/show_bug.cgi?id=58826
- If the first instance of Xamarin.Mac.dll or another arch specific assembly
is found as a library reference, it would not be handled correctly. This caused
the "reference" assembly to be copied in, which is 64-bit.
- This causes startup crashes in 32-bit applications
- Also fix csproj issue that was preventing mmp.csproj from debugging