### PR TITLE
[mmp] Fix symbol name for 32-bit Objective-C classes. Fixes #58861.

### DIFF
--- a/tests/common/mac/ProjectTestHelpers.cs
+++ b/tests/common/mac/ProjectTestHelpers.cs
@@ -90,6 +90,11 @@ namespace Xamarin.MMP.Tests
 			StringBuilder output = new StringBuilder ();
 			Environment.SetEnvironmentVariable ("MONO_PATH", null);
 			int compileResult = Xamarin.Bundler.Driver.RunCommand (exe, args != null ? args.ToString() : string.Empty, null, output, suppressPrintOnErrors: shouldFail);
+			if (!shouldFail && compileResult != 0 && Xamarin.Bundler.Driver.Verbosity < 1) {
+				// Driver.RunCommand won't print failed output unless verbosity > 0, so let's do it ourselves.
+				Console.WriteLine ($"Execution failed; exit code: {compileResult}");
+				Console.WriteLine (output);
+			}
 			Func<string> getInfo = () => getAdditionalFailInfo != null ? getAdditionalFailInfo() : "";
 			if (!shouldFail)
 				Assert.AreEqual (0, compileResult, stepName + " failed:\n\n'" + output + "' " + exe + " " + args + getInfo ());

--- a/tests/common/mac/ProjectTestHelpers.cs
+++ b/tests/common/mac/ProjectTestHelpers.cs
@@ -424,6 +424,7 @@ namespace Xamarin.Bundler {
 	public static partial class Driver
 	{
 		public static int verbose { get { return 0; } }
+		public static int Verbosity {  get { return verbose; }}
 		public static int RunCommand (string path, string args, string[] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
 		{
 			Exception stdin_exc = null;

--- a/tests/mac-binding-project/Makefile
+++ b/tests/mac-binding-project/Makefile
@@ -16,10 +16,12 @@ bin/SimpleClassDylib.dylib:  bin
 bin/SimpleClass\ Dylib.dylib: bin/SimpleClassDylib.dylib
 	$(Q) cp bin/SimpleClassDylib.dylib bin/SimpleClass\ Dylib.dylib
 
-bin/SimpleClassStatic.a: bin
-	$(Q) clang -c ../common/mac/SimpleClass.m -o bin/SimpleClass.o -std=gnu99 -mmacosx-version-min=10.9
-	$(Q) xcrun ar -rcs bin/SimpleClassStatic.a bin/SimpleClass.o
-	$(Q) rm bin/SimpleClass.o
+bin/SimpleClass.%.a: ../common/mac/SimpleClass.m bin
+	$(Q) clang -c $< -o bin/SimpleClass.$*.o -std=gnu99 -mmacosx-version-min=10.9 -arch $*
+	$(Q) xcrun ar -rcs $@ bin/SimpleClass.$*.o
+
+bin/SimpleClassStatic.a: bin bin/SimpleClass.i386.a bin/SimpleClass.x86_64.a
+	$(Q) lipo -create bin/SimpleClass.i386.a bin/SimpleClass.x86_64.a -output $@
 
 bin/Mobile-dynamic/MobileBinding.dll: bin/SimpleClassDylib.dylib
 	$(Q) $(SYSTEM_XBUILD) $(XBUILD_VERBOSITY) MobileBinding/MobileBinding_dynamic.csproj

--- a/tests/mmptest/CustomBuildActions.targets
+++ b/tests/mmptest/CustomBuildActions.targets
@@ -5,7 +5,7 @@
 	    <BuildDependsOn>$(BuildDependsOn);CreateNativeLibs</BuildDependsOn>
 	</PropertyGroup>
 
-	<Target Name="CreateNativeLibs" Inputs="../common/mac/SimpleClass.m" Outputs="../mac-binding-project/bin/SimpleClassDylib.dylib;../mac-binding-project/bin/SimpleClassStatic.a">
-		<Exec Command="make bin/SimpleClassDylib.dylib bin/SimpleClassStatic.a" WorkingDirectory="../mac-binding-project/"/>
+	<Target Name="CreateNativeLibs" Inputs="../common/mac/SimpleClass.m" Outputs="../mac-binding-project/bin/SimpleClassDylib.dylib;../mac-binding-project/bin/SimpleClassStatic.a;../mac-binding-project/bin/Mobile-static/MobileBinding.dll">
+		<Exec Command="make bin/SimpleClassDylib.dylib bin/SimpleClassStatic.a bin/Mobile-static/MobileBinding.dll" WorkingDirectory="../mac-binding-project/"/>
 	</Target>
 </Project>

--- a/tests/mmptest/src/NativeReferencesTests.cs
+++ b/tests/mmptest/src/NativeReferencesTests.cs
@@ -31,6 +31,15 @@ namespace Xamarin.MMP.Tests
 			}
 		}
 
+		public string MobileStaticBindingPath {
+			get {
+				string rootDir = TI.FindRootDirectory ();
+				string buildLibPath = Path.Combine (rootDir, "../tests/mac-binding-project/bin/Mobile-static/MobileBinding.dll");
+				Assert.IsTrue (File.Exists (buildLibPath), string.Format ("MobileStaticBindingPath missing? {0}", buildLibPath));
+				return buildLibPath;
+			}
+		}
+
 		string CreateNativeRefInclude (string path, string kind) => string.Format (NativeReferenceTemplate, path, kind);
 		string CreateItemGroup (IEnumerable<string> elements) => string.Format (ItemGroupTemplate, string.Concat (elements));
 		string CreateSingleNativeRef (string path, string kind) => CreateItemGroup (CreateNativeRefInclude (path, kind).FromSingleItem ());
@@ -104,6 +113,19 @@ namespace Xamarin.MMP.Tests
 					string clangLine = s.Split ('\n').First (x => x.Contains ("xcrun -sdk macosx clang"));
 					return clangLine.Contains ("SimpleClassStatic.a");
 				});
+			});
+		}
+
+		[Test]
+		public void Unified_WithStaticNativeRef_32bit ()
+		{
+			RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					CSProjConfig = "<XamMacArch>i386</XamMacArch>",
+					References = $"<Reference Include=\"SimpleBinding_static\"><HintPath>{MobileStaticBindingPath}</HintPath></Reference>",
+					TestCode = "System.Console.WriteLine (new Simple.SimpleClass ().DoIt ());"
+				};
+				NativeReferenceTestCore (tmpDir, test, "Unified_WithStaticNativeRef_32bit", null, true, false);
 			});
 		}
 

--- a/tools/common/CompilerFlags.cs
+++ b/tools/common/CompilerFlags.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Utils
 				UnresolvedSymbols = new HashSet<string> ();
 
 			foreach (var symbol in symbols)
-				UnresolvedSymbols.Add (symbol.Name);
+				UnresolvedSymbols.Add (symbol.Prefix + symbol.Name);
 		}
 
 		public void AddDefine (string define)
@@ -249,7 +249,7 @@ namespace Xamarin.Utils
 
 			if (UnresolvedSymbols != null) {
 				foreach (var symbol in UnresolvedSymbols)
-					args.Append (" -u ").Append (StringUtils.Quote ("_" + symbol));
+					args.Append (" -u ").Append (StringUtils.Quote (symbol));
 			}
 
 			if (SourceFiles != null) {

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -131,6 +131,16 @@ namespace Xamarin.Bundler {
 			}
 		}
 
+		public static bool SupportsModernObjectiveC {
+			get {
+#if MONOMAC || MMP
+				return Is64Bit;
+#else
+				return true;
+#endif
+			}
+		}
+
 		public static int Verbosity {
 			get { return verbose; }
 		}

--- a/tools/common/Symbols.cs
+++ b/tools/common/Symbols.cs
@@ -32,8 +32,10 @@ namespace Xamarin.Bundler
 			get {
 				if (name != null)
 					return name;
-				if (ObjectiveCName != null)
-					return "OBJC_CLASS_$_" + ObjectiveCName;
+				if (ObjectiveCName != null) {
+					var prefix = Driver.SupportsModernObjectiveC ? "OBJC_CLASS_$_" : ".objc_class_name_";
+					return prefix + ObjectiveCName;
+				}
 				throw ErrorHelper.CreateError (99, $"Internal error: symbol without a name (type: {Type}). Please file a bug report with a test case (https://bugzilla.xamarin.com).");
 			}
 			set {
@@ -41,6 +43,14 @@ namespace Xamarin.Bundler
 			}
 		}
 		public string ObjectiveCName;
+
+		public string Prefix {
+			get {
+				if (ObjectiveCName != null && !Driver.SupportsModernObjectiveC)
+					return string.Empty;
+				return "_";
+			}
+		}
 
 		List<MemberReference> members = new List<MemberReference> ();
 		public IEnumerable<MemberReference> Members { get { return members; } }

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1294,7 +1294,7 @@ namespace Xamarin.Bundler {
 					args.Append ("-weak_framework ").Append (f).Append (' ');
 
 				var requiredSymbols = BuildTarget.GetRequiredSymbols ();
-				Driver.WriteIfDifferent (Path.Combine (App.Cache.Location, "exported-symbols-list"), string.Join ("\n", requiredSymbols.Select ((symbol) => "_" + symbol.Name).ToArray ()));
+				Driver.WriteIfDifferent (Path.Combine (App.Cache.Location, "exported-symbols-list"), string.Join ("\n", requiredSymbols.Select ((symbol) => symbol.Prefix + symbol.Name).ToArray ()));
 				switch (App.SymbolMode) {
 				case SymbolMode.Ignore:
 					break;
@@ -1307,7 +1307,7 @@ namespace Xamarin.Bundler {
 				case SymbolMode.Linker:
 				case SymbolMode.Default:
 					foreach (var symbol in requiredSymbols)
-						args.Append ("-u ").Append (StringUtils.Quote ("_" + symbol.Name)).Append (' ');
+						args.Append ("-u ").Append (StringUtils.Quote (symbol.Prefix + symbol.Name)).Append (' ');
 					break;
 				default:
 					throw ErrorHelper.CreateError (99, $"Internal error: invalid symbol mode: {App.SymbolMode}. Please file a bug report with a test case (https://bugzilla.xamarin.com).");


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=58861