### PR TITLE
[xtro-sharpie] Fix a compiler warning.

### DIFF
--- a/tests/xtro-sharpie/Runner.cs
+++ b/tests/xtro-sharpie/Runner.cs
@@ -193,18 +193,19 @@ namespace Extrospection {
 		
 		public override void VisitDecl (Decl decl)
 		{
-			if (decl is FunctionDecl)
+			if (decl is FunctionDecl) {
 				;
-			else if (decl is VarDecl)
+			} else if (decl is VarDecl) {
 				;
-			else if (decl is ObjCProtocolDecl)
+			} else if (decl is ObjCProtocolDecl) {
 				;
-			else if (decl is ObjCInterfaceDecl)
+			} else if (decl is ObjCInterfaceDecl) {
 				;
-			else if (decl is EnumDecl)
+			} else if (decl is EnumDecl) {
 				;
-			else
+			} else {
 				Console.WriteLine ("{0}\t{1}", decl, decl.GetType ().Name);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes these warnings:

Runner.cs(197,5): warning CS0642: Possible mistaken empty statement
Runner.cs(199,5): warning CS0642: Possible mistaken empty statement
Runner.cs(201,5): warning CS0642: Possible mistaken empty statement
Runner.cs(203,5): warning CS0642: Possible mistaken empty statement
Runner.cs(205,5): warning CS0642: Possible mistaken empty statement