### PR TITLE
[arkit] Add missing MarshalDirective to ARPlaneAnchor

### DIFF
--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -258,10 +258,16 @@ namespace XamCore.ARKit {
 		ARPlaneAnchorAlignment Alignment { get; }
 
 		[Export ("center")]
-		Vector3 Center { get; }
+		Vector3 Center {
+			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+			get;
+		}
 
 		[Export ("extent")]
-		Vector3 Extent { get; }
+		Vector3 Extent {
+			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+			get;
+		}
 	}
 
 	[iOS (11,0)]


### PR DESCRIPTION
- Fixes bug #58648: ARPlaneAnchor.Extent property seems incorrect but changes to correct value after Debug access
(https://bugzilla.xamarin.com/show_bug.cgi?id=58648)