### PR TITLE
[xtro-sharpie] Many methods don't have selectors in Clang's API, so default to the name if no selector.

### DIFF
--- a/tests/xtro-sharpie/Helpers.cs
+++ b/tests/xtro-sharpie/Helpers.cs
@@ -165,7 +165,8 @@ namespace Extrospection {
 				sb.Append ('+');
 			sb.Append ((self.DeclContext as NamedDecl).Name);
 			sb.Append ("::");
-			sb.Append (self.Selector);
+			var sel = self.Selector.ToString ();
+			sb.Append (string.IsNullOrEmpty (sel) ? self.Name : sel);
 			return sb.ToString ();
 		}
 


### PR DESCRIPTION
This makes a few more unclassified entries show up (mostly missing designated initializers): https://gist.github.com/rolfbjarne/07aa20f9b50b75bf3e69ac6a825e873a