### PR TITLE
[xtro-sharpie] Teach xtro-sharpie about how to get protocol name from the ProtocolAttribute.

### DIFF
--- a/tests/xtro-sharpie/Helpers.cs
+++ b/tests/xtro-sharpie/Helpers.cs
@@ -189,6 +189,10 @@ namespace Extrospection {
 						if (ca.HasConstructorArguments)
 							return (ca.ConstructorArguments [0].Value as string);
 						return self.Name;
+					} else if (ca.Constructor.DeclaringType.Name == "ProtocolAttribute") {
+						if (ca.HasConstructorArguments)
+							return (ca.ConstructorArguments [0].Value as string);
+						return self.Name;
 					}
 				}
 			}


### PR DESCRIPTION
Teach xtro-sharpie about how to get protocol name from the ProtocolAttribute
to calculate the native name for a TypeDefinition.

Unclassified changes: https://gist.github.com/rolfbjarne/828f8ee41eebb0a3b60a38d71822fe59