### PR TITLE
[vision] Update to beta 6

### DIFF
--- a/src/vision.cs
+++ b/src/vision.cs
@@ -344,40 +344,126 @@ namespace XamCore.Vision {
 	[BaseType (typeof (VNTargetedImageRequest))]
 	interface VNImageRegistrationRequest {
 
-		[Export ("initWithTargetedCVPixelBuffer:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer);
+		// Inlined from parent class
+		[Export ("initWithTargetedCVPixelBuffer:options:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
 
-		[Export ("initWithTargetedCVPixelBuffer:completionHandler:")]
-		[DesignatedInitializer]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		[Wrap ("this (pixelBuffer, options?.Dictionary)")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
 
-		[Export ("initWithTargetedCGImage:")]
-		IntPtr Constructor (CGImage image);
+		[Export ("initWithTargetedCVPixelBuffer:options:completionHandler:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Export ("initWithTargetedCGImage:completionHandler:")]
-		[DesignatedInitializer]
-		IntPtr Constructor (CGImage image, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		[Wrap ("this (pixelBuffer, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
-		[Export ("initWithTargetedCIImage:")]
-		IntPtr Constructor (CIImage image);
+		[Export ("initWithTargetedCVPixelBuffer:orientation:options:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Export ("initWithTargetedCIImage:completionHandler:")]
-		[DesignatedInitializer]
-		IntPtr Constructor (CIImage image, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		[Wrap ("this (pixelBuffer, orientation, options?.Dictionary)")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
 
-		[Export ("initWithTargetedImageURL:")]
-		IntPtr Constructor (NSUrl imageUrl);
+		[Export ("initWithTargetedCVPixelBuffer:orientation:options:completionHandler:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Export ("initWithTargetedImageURL:completionHandler:")]
-		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl imageUrl, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		[Wrap ("this (pixelBuffer, orientation, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
-		[Export ("initWithTargetedImageData:")]
-		IntPtr Constructor (NSData imageData);
+		[Export ("initWithTargetedCGImage:options:")]
+		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict);
 
-		[Export ("initWithTargetedImageData:completionHandler:")]
-		[DesignatedInitializer]
-		IntPtr Constructor (NSData imageData, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		[Wrap ("this (cgImage, options?.Dictionary)")]
+		IntPtr Constructor (CGImage cgImage, VNImageOptions options);
+
+		[Export ("initWithTargetedCGImage:options:completionHandler:")]
+		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (cgImage, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCGImage:orientation:options:")]
+		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+
+		[Wrap ("this (cgImage, orientation, options?.Dictionary)")]
+		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
+
+		[Export ("initWithTargetedCGImage:orientation:options:completionHandler:")]
+		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (cgImage, orientation, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCIImage:options:")]
+		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict);
+
+		[Wrap ("this (ciImage, options?.Dictionary)")]
+		IntPtr Constructor (CIImage ciImage, VNImageOptions options);
+
+		[Export ("initWithTargetedCIImage:options:completionHandler:")]
+		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (ciImage, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCIImage:orientation:options:")]
+		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+
+		[Wrap ("this (ciImage, orientation, options?.Dictionary)")]
+		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
+
+		[Export ("initWithTargetedCIImage:orientation:options:completionHandler:")]
+		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (ciImage, orientation, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageURL:options:")]
+		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict);
+
+		[Wrap ("this (imageUrl, options?.Dictionary)")]
+		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options);
+
+		[Export ("initWithTargetedImageURL:options:completionHandler:")]
+		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (imageUrl, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageURL:orientation:options:")]
+		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+
+		[Wrap ("this (imageUrl, orientation, options?.Dictionary)")]
+		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
+
+		[Export ("initWithTargetedImageURL:orientation:options:completionHandler:")]
+		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (imageUrl, orientation, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageData:options:")]
+		IntPtr Constructor (NSData imageData, NSDictionary optionsDict);
+
+		[Wrap ("this (imageData, options?.Dictionary)")]
+		IntPtr Constructor (NSData imageData, VNImageOptions options);
+
+		[Export ("initWithTargetedImageData:options:completionHandler:")]
+		IntPtr Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (imageData, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageData:orientation:options:")]
+		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+
+		[Wrap ("this (imageData, orientation, options?.Dictionary)")]
+		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
+
+		[Export ("initWithTargetedImageData:orientation:options:completionHandler:")]
+		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (imageData, orientation, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
@@ -386,40 +472,125 @@ namespace XamCore.Vision {
 	interface VNTranslationalImageRegistrationRequest {
 
 		// Inlined from parent class
-		[Export ("initWithTargetedCVPixelBuffer:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer);
+[Export ("initWithTargetedCVPixelBuffer:options:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
 
-		[Export ("initWithTargetedCVPixelBuffer:completionHandler:")]
-		[DesignatedInitializer]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		[Wrap ("this (pixelBuffer, options?.Dictionary)")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
 
-		[Export ("initWithTargetedCGImage:")]
-		IntPtr Constructor (CGImage image);
+		[Export ("initWithTargetedCVPixelBuffer:options:completionHandler:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Export ("initWithTargetedCGImage:completionHandler:")]
-		[DesignatedInitializer]
-		IntPtr Constructor (CGImage image, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		[Wrap ("this (pixelBuffer, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
-		[Export ("initWithTargetedCIImage:")]
-		IntPtr Constructor (CIImage image);
+		[Export ("initWithTargetedCVPixelBuffer:orientation:options:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Export ("initWithTargetedCIImage:completionHandler:")]
-		[DesignatedInitializer]
-		IntPtr Constructor (CIImage image, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		[Wrap ("this (pixelBuffer, orientation, options?.Dictionary)")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
 
-		[Export ("initWithTargetedImageURL:")]
-		IntPtr Constructor (NSUrl imageUrl);
+		[Export ("initWithTargetedCVPixelBuffer:orientation:options:completionHandler:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Export ("initWithTargetedImageURL:completionHandler:")]
-		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl imageUrl, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		[Wrap ("this (pixelBuffer, orientation, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
-		[Export ("initWithTargetedImageData:")]
-		IntPtr Constructor (NSData imageData);
+		[Export ("initWithTargetedCGImage:options:")]
+		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict);
 
-		[Export ("initWithTargetedImageData:completionHandler:")]
-		[DesignatedInitializer]
-		IntPtr Constructor (NSData imageData, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		[Wrap ("this (cgImage, options?.Dictionary)")]
+		IntPtr Constructor (CGImage cgImage, VNImageOptions options);
+
+		[Export ("initWithTargetedCGImage:options:completionHandler:")]
+		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (cgImage, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCGImage:orientation:options:")]
+		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+
+		[Wrap ("this (cgImage, orientation, options?.Dictionary)")]
+		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
+
+		[Export ("initWithTargetedCGImage:orientation:options:completionHandler:")]
+		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (cgImage, orientation, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCIImage:options:")]
+		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict);
+
+		[Wrap ("this (ciImage, options?.Dictionary)")]
+		IntPtr Constructor (CIImage ciImage, VNImageOptions options);
+
+		[Export ("initWithTargetedCIImage:options:completionHandler:")]
+		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (ciImage, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCIImage:orientation:options:")]
+		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+
+		[Wrap ("this (ciImage, orientation, options?.Dictionary)")]
+		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
+
+		[Export ("initWithTargetedCIImage:orientation:options:completionHandler:")]
+		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (ciImage, orientation, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageURL:options:")]
+		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict);
+
+		[Wrap ("this (imageUrl, options?.Dictionary)")]
+		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options);
+
+		[Export ("initWithTargetedImageURL:options:completionHandler:")]
+		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (imageUrl, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageURL:orientation:options:")]
+		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+
+		[Wrap ("this (imageUrl, orientation, options?.Dictionary)")]
+		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
+
+		[Export ("initWithTargetedImageURL:orientation:options:completionHandler:")]
+		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (imageUrl, orientation, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageData:options:")]
+		IntPtr Constructor (NSData imageData, NSDictionary optionsDict);
+
+		[Wrap ("this (imageData, options?.Dictionary)")]
+		IntPtr Constructor (NSData imageData, VNImageOptions options);
+
+		[Export ("initWithTargetedImageData:options:completionHandler:")]
+		IntPtr Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (imageData, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageData:orientation:options:")]
+		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+
+		[Wrap ("this (imageData, orientation, options?.Dictionary)")]
+		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
+
+		[Export ("initWithTargetedImageData:orientation:options:completionHandler:")]
+		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (imageData, orientation, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
@@ -428,40 +599,125 @@ namespace XamCore.Vision {
 	interface VNHomographicImageRegistrationRequest {
 
 		// Inlined from parent class
-		[Export ("initWithTargetedCVPixelBuffer:")]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer);
+		[Export ("initWithTargetedCVPixelBuffer:options:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
 
-		[Export ("initWithTargetedCVPixelBuffer:completionHandler:")]
-		[DesignatedInitializer]
-		IntPtr Constructor (CVPixelBuffer pixelBuffer, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		[Wrap ("this (pixelBuffer, options?.Dictionary)")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options);
 
-		[Export ("initWithTargetedCGImage:")]
-		IntPtr Constructor (CGImage image);
+		[Export ("initWithTargetedCVPixelBuffer:options:completionHandler:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Export ("initWithTargetedCGImage:completionHandler:")]
-		[DesignatedInitializer]
-		IntPtr Constructor (CGImage image, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		[Wrap ("this (pixelBuffer, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
-		[Export ("initWithTargetedCIImage:")]
-		IntPtr Constructor (CIImage image);
+		[Export ("initWithTargetedCVPixelBuffer:orientation:options:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
 
-		[Export ("initWithTargetedCIImage:completionHandler:")]
-		[DesignatedInitializer]
-		IntPtr Constructor (CIImage image, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		[Wrap ("this (pixelBuffer, orientation, options?.Dictionary)")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options);
 
-		[Export ("initWithTargetedImageURL:")]
-		IntPtr Constructor (NSUrl imageUrl);
+		[Export ("initWithTargetedCVPixelBuffer:orientation:options:completionHandler:")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
 
-		[Export ("initWithTargetedImageURL:completionHandler:")]
-		[DesignatedInitializer]
-		IntPtr Constructor (NSUrl imageUrl, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		[Wrap ("this (pixelBuffer, orientation, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CVPixelBuffer pixelBuffer, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 
-		[Export ("initWithTargetedImageData:")]
-		IntPtr Constructor (NSData imageData);
+		[Export ("initWithTargetedCGImage:options:")]
+		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict);
 
-		[Export ("initWithTargetedImageData:completionHandler:")]
-		[DesignatedInitializer]
-		IntPtr Constructor (NSData imageData, [NullAllowed] VNRequestCompletionHandler completionHandler);
+		[Wrap ("this (cgImage, options?.Dictionary)")]
+		IntPtr Constructor (CGImage cgImage, VNImageOptions options);
+
+		[Export ("initWithTargetedCGImage:options:completionHandler:")]
+		IntPtr Constructor (CGImage cgImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (cgImage, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CGImage cgImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCGImage:orientation:options:")]
+		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+
+		[Wrap ("this (cgImage, orientation, options?.Dictionary)")]
+		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options);
+
+		[Export ("initWithTargetedCGImage:orientation:options:completionHandler:")]
+		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (cgImage, orientation, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CGImage cgImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCIImage:options:")]
+		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict);
+
+		[Wrap ("this (ciImage, options?.Dictionary)")]
+		IntPtr Constructor (CIImage ciImage, VNImageOptions options);
+
+		[Export ("initWithTargetedCIImage:options:completionHandler:")]
+		IntPtr Constructor (CIImage ciImage, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (ciImage, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CIImage ciImage, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedCIImage:orientation:options:")]
+		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+
+		[Wrap ("this (ciImage, orientation, options?.Dictionary)")]
+		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options);
+
+		[Export ("initWithTargetedCIImage:orientation:options:completionHandler:")]
+		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (ciImage, orientation, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (CIImage ciImage, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageURL:options:")]
+		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict);
+
+		[Wrap ("this (imageUrl, options?.Dictionary)")]
+		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options);
+
+		[Export ("initWithTargetedImageURL:options:completionHandler:")]
+		IntPtr Constructor (NSUrl imageUrl, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (imageUrl, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (NSUrl imageUrl, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageURL:orientation:options:")]
+		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+
+		[Wrap ("this (imageUrl, orientation, options?.Dictionary)")]
+		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options);
+
+		[Export ("initWithTargetedImageURL:orientation:options:completionHandler:")]
+		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (imageUrl, orientation, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (NSUrl imageUrl, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageData:options:")]
+		IntPtr Constructor (NSData imageData, NSDictionary optionsDict);
+
+		[Wrap ("this (imageData, options?.Dictionary)")]
+		IntPtr Constructor (NSData imageData, VNImageOptions options);
+
+		[Export ("initWithTargetedImageData:options:completionHandler:")]
+		IntPtr Constructor (NSData imageData, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (imageData, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (NSData imageData, VNImageOptions options, VNRequestCompletionHandler completionHandler);
+
+		[Export ("initWithTargetedImageData:orientation:options:")]
+		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict);
+
+		[Wrap ("this (imageData, orientation, options?.Dictionary)")]
+		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options);
+
+		[Export ("initWithTargetedImageData:orientation:options:completionHandler:")]
+		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, NSDictionary optionsDict, [NullAllowed] VNRequestCompletionHandler completionHandler);
+
+		[Wrap ("this (imageData, orientation, options?.Dictionary, completionHandler)")]
+		IntPtr Constructor (NSData imageData, CGImagePropertyOrientation orientation, VNImageOptions options, VNRequestCompletionHandler completionHandler);
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]

--- a/src/vision.cs
+++ b/src/vision.cs
@@ -472,7 +472,7 @@ namespace XamCore.Vision {
 	interface VNTranslationalImageRegistrationRequest {
 
 		// Inlined from parent class
-[Export ("initWithTargetedCVPixelBuffer:options:")]
+		[Export ("initWithTargetedCVPixelBuffer:options:")]
 		IntPtr Constructor (CVPixelBuffer pixelBuffer, NSDictionary optionsDict);
 
 		[Wrap ("this (pixelBuffer, options?.Dictionary)")]


### PR DESCRIPTION
Removal of some deprecated (during beta) `init*` selectors.

Also sync the versions that were inlined in subclasses - the old
ones were not removed and the new ones were not added.