### PR TITLE
[monotouch-test] Disable FontDescriptorTest.WithFeature

### DIFF
--- a/tests/monotouch-test/CoreText/FontDescriptorTest.cs
+++ b/tests/monotouch-test/CoreText/FontDescriptorTest.cs
@@ -62,6 +62,7 @@ namespace MonoTouchFixtures.CoreText {
 			}
 		}
 
+#if !__TVOS__ // https://bugzilla.xamarin.com/show_bug.cgi?id=58929
 		[Test]
 		public void WithFeature ()
 		{
@@ -89,6 +90,7 @@ namespace MonoTouchFixtures.CoreText {
 				Assert.That (set_feature.FeatureWeak, Is.EqualTo ((int)CTFontFeatureLigatures.Selector.RareLigaturesOn), "#2");
 			}
 		}
+#endif // !__TVOS__
 	}
 }
 


### PR DESCRIPTION
Disabled because it looks like the tvOS font we use: "Gujarati Sangam MN"
does not have rare ligatures anymore (and the entire test is based on it).
Before getting an actual fix for that, let's disable the test so it doesn't break all current builds.
See: https://bugzilla.xamarin.com/show_bug.cgi?id=58929