### PR TITLE
[corebluetooth] Update up to beta 6 and enable it on watchOS

### DIFF
--- a/src/Constants.watch.cs.in
+++ b/src/Constants.watch.cs.in
@@ -44,6 +44,7 @@ namespace ObjCRuntime {
 		public const string IntentsLibrary = "/System/Library/Frameworks/Intents.framework/Intents";
 
 		// WatchOS 4.0
+		public const string CoreBluetoothLibrary = "/System/Library/Frameworks/CoreBluetooth.framework/CoreBluetooth";
 		public const string CoreMLLibrary = "/System/Library/Frameworks/CoreML.framework/CoreML";	
 	}
 }

--- a/src/CoreBluetooth/AdvertisementDataOptions.cs
+++ b/src/CoreBluetooth/AdvertisementDataOptions.cs
@@ -37,6 +37,7 @@ namespace XamCore.CoreBluetooth {
 	// It's intentionally not called AdvertisementDataOptions because different options
 	// are valid in different contexts
 	//
+	[Watch (4,0)]
 	[iOS (6,0)]
 	public class StartAdvertisingOptions : DictionaryContainer
 	{

--- a/src/CoreBluetooth/CBUUID.cs
+++ b/src/CoreBluetooth/CBUUID.cs
@@ -205,5 +205,15 @@ namespace XamCore.CoreBluetooth {
 
 			return sb.ToString ();
 		}
+
+#if MONOMAC
+		// workaround for 27160443 – Trello: https://trello.com/c/oqB27JA6
+		// try new constant (10.13+) and fallback to the old/misnamed one
+		public static NSString CharacteristicValidRangeString {
+			get {
+				return CBUUIDCharacteristicValidRangeString ?? CBUUIDValidRangeString;
+			}
+		}
+#endif
 	}
 }

--- a/src/CoreBluetooth/CoreBluetooth.cs
+++ b/src/CoreBluetooth/CoreBluetooth.cs
@@ -113,7 +113,7 @@ namespace XamCore.CoreBluetooth {
 		}
 	}
 #endif
-#if !MONOMAC && !XAMCORE_4_0
+#if (IOS || TVOS) && !XAMCORE_4_0
 	public partial class CBCentralManager {
 
 		public virtual CBCentralManagerState State {

--- a/src/CoreBluetooth/CoreBluetooth.cs
+++ b/src/CoreBluetooth/CoreBluetooth.cs
@@ -113,10 +113,10 @@ namespace XamCore.CoreBluetooth {
 		}
 	}
 #endif
-#if (IOS || TVOS) && !XAMCORE_4_0
+#if !WATCH && !XAMCORE_4_0
 	public partial class CBCentralManager {
 
-		public virtual CBCentralManagerState State {
+		public new virtual CBCentralManagerState State {
 			get {
 				return (CBCentralManagerState)base.State;
 			}

--- a/src/CoreBluetooth/Enums.cs
+++ b/src/CoreBluetooth/Enums.cs
@@ -13,13 +13,11 @@ using XamCore.ObjCRuntime;
 
 namespace XamCore.CoreBluetooth {
 
-#if !MONOMAC
+	[Mac (10,13)]
+	[Watch (4,0)]
 	[iOS (10,0)]
 	[Native]
 	public enum CBManagerState : nint {
-#else
-	internal enum CBManagerState {
-#endif
 		Unknown = 0,
 		Resetting,
 		Unsupported,
@@ -31,6 +29,7 @@ namespace XamCore.CoreBluetooth {
 	// NSInteger -> CBCentralManager.h
 	[Introduced (PlatformName.iOS, 5, 0)]
 	[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'CBManagerState' instead.")]
+	[NoWatch]
 	[Native]
 	public enum CBCentralManagerState : nint {
 		Unknown = CBManagerState.Unknown,
@@ -44,6 +43,7 @@ namespace XamCore.CoreBluetooth {
 	// NSInteger -> CBPeripheralManager.h
 	[Introduced (PlatformName.iOS, 6, 0)]
 	[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'CBManagerState' instead.")]
+	[NoWatch]
 	[Native]
 	public enum CBPeripheralManagerState : nint {
 		Unknown = CBManagerState.Unknown,
@@ -55,16 +55,19 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	// NSInteger -> CBPeripheralManager.h
+	[Watch (4,0)]
 	[Native]
 	public enum CBPeripheralState : nint {
 		Disconnected,
 		Connecting,
 		Connected,
-		Disconnecting
+		[iOS (9,0)][Mac (10,13)]
+		Disconnecting,
 	}
 
 #if !XAMCORE_4_0
 	// NSInteger -> CBPeripheralManager.h
+	[Watch (4,0)]
 	[Native]
 	public enum CBPeripheralManagerAuthorizationStatus : nint {
 		NotDetermined,
@@ -75,6 +78,7 @@ namespace XamCore.CoreBluetooth {
 #endif
 
 	// NSUInteger -> CBCharacteristic.h
+	[Watch (4,0)]
 	[Flags]
 	[Native]
 	public enum CBCharacteristicProperties : nuint_compat_int {
@@ -86,10 +90,13 @@ namespace XamCore.CoreBluetooth {
 		Indicate = 32,
 		AuthenticatedSignedWrites = 64,
 		ExtendedProperties = 128,
+		[Mac (10,9)]
 		NotifyEncryptionRequired = 0x100,
+		[Mac (10,9)]
 		IndicateEncryptionRequired = 0x200
 	}
 
+	[Watch (4,0)]
 	[ErrorDomain ("CBErrorDomain")]
 	[Native] // NSInteger -> CBError.h
 	public enum CBError : nint {
@@ -104,12 +111,15 @@ namespace XamCore.CoreBluetooth {
 		PeripheralDisconnected,
 		UUIDNotAllowed,
 		AlreadyAdvertising,
-		// iOS7.1
+		[iOS (7,1)][Mac (10,13)]
 		ConnectionFailed,
-		// iOS 9
-		ConnectionLimitReached
+		[iOS (9,0)][Mac (10,13)]
+		ConnectionLimitReached,
+		[iOS (11,0)][TV (11,0)][Mac (10,13)]
+		UnknownDevice,
 	}
 
+	[Watch (4,0)]
 	[ErrorDomain ("CBATTErrorDomain")]
 	[Native] // NSInteger -> CBError.h
 	public enum CBATTError : nint {
@@ -134,6 +144,7 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	// NSInteger -> CBPeripheral.h
+	[Watch (4,0)]
 	[Native]
 	public enum CBCharacteristicWriteType : nint {
 		WithResponse,
@@ -141,6 +152,8 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	// NSUInteger -> CBCharacteristic.h
+	[Mac (10,9)]
+	[Watch (4,0)]
 	[Flags]
 	[Native]
 	public enum CBAttributePermissions : nuint_compat_int {
@@ -151,6 +164,7 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	// NSInteger -> CBPeripheralManager.h
+	[Watch (4,0)]
 	[Native]
 	public enum CBPeripheralManagerConnectionLatency : nint {
 		Low = 0,

--- a/src/CoreBluetooth/GuidWrapper.cs
+++ b/src/CoreBluetooth/GuidWrapper.cs
@@ -58,7 +58,7 @@ namespace XamCore.CoreBluetooth {
 			ConnectPeripheral (peripheral, options == null ? null : options.Dictionary);
 		}
 
-#if !TVOS
+#if !TVOS && !WATCH
 		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_9_0, Message = "Use 'RetrievePeripheralsWithIdentifiers' instead.")]
 		public void RetrievePeripherals (CBUUID [] peripheralUuids)
 		{

--- a/src/CoreBluetooth/PeripheralConnectionOptions.cs
+++ b/src/CoreBluetooth/PeripheralConnectionOptions.cs
@@ -33,6 +33,7 @@ using XamCore.ObjCRuntime;
 
 namespace XamCore.CoreBluetooth {
 
+	[Watch (4,0)]
 	public class PeripheralConnectionOptions : DictionaryContainer
 	{
 #if !COREBUILD

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -74,12 +74,14 @@ namespace XamCore.CoreBluetooth {
 		IntPtr Constructor ([NullAllowed, Protocolize] CBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue, CBCentralInitOptions options);
 
 		[NoTV]
+		[NoWatch]
 		[Availability (Obsoleted = Platform.iOS_9_0)]
 		[Mac (10, 7, onlyOn64: true)] // Was removed from 32-bit in 10.13 unannounced
 		[Export ("retrievePeripherals:"), Internal]
 		void RetrievePeripherals (NSArray peripheralUUIDs);
 
 		[NoTV]
+		[NoWatch]
 		[Mac (10, 7, onlyOn64: true)] // Was removed from 32-bit in 10.13 unannounced
 		[Export ("retrieveConnectedPeripherals")]
 		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_9_0, Message = "Use 'RetrievePeripheralsWithIdentifiers' instead.")]
@@ -351,6 +353,7 @@ namespace XamCore.CoreBluetooth {
 		CBAttributePermissions Permissions { get; set; }
 
 		[NoTV]
+		[NoWatch]
 		[NullAllowed]
 		[Export ("UUID", ArgumentSemantic.Retain)]
 		[Override]

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -14,15 +14,16 @@ using XamCore.CoreFoundation;
 
 namespace XamCore.CoreBluetooth {
 
-#if !MONOMAC
+	[Watch (4,0)]
 	[iOS (8,0)]
+	[Mac (10,13)]
 	[BaseType (typeof (NSObject))]
 	interface CBAttribute {
 		[Export ("UUID")]
 		CBUUID UUID { get; [NotImplemented] set;  }
 	}
-#endif
 
+	[Watch (4,0)]
 	[StrongDictionary ("CBCentralManager")]
 	interface CBCentralInitOptions {
 		[Export ("OptionShowPowerAlertKey")]
@@ -34,7 +35,9 @@ namespace XamCore.CoreBluetooth {
 #endif
 	}
 
-	[iOS (10,0)][NoMac]
+	[Watch (4,0)]
+	[iOS (10,0)]
+	[Mac (10,13)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
 	interface CBManager {
@@ -42,23 +45,12 @@ namespace XamCore.CoreBluetooth {
 		CBManagerState State { get; }
 	}
 
+	[Watch (4,0)]
 	[Since (5,0)]
 	[Lion]
-	[BaseType (
-#if MONOMAC
-	typeof (NSObject)
-#else
-	typeof (CBManager)
-#endif
-	, Delegates=new[] {"WeakDelegate"}, Events = new[] { typeof (CBCentralManagerDelegate)})]
+	[BaseType (typeof (CBManager), Delegates=new[] {"WeakDelegate"}, Events = new[] { typeof (CBCentralManagerDelegate)})]
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
 	interface CBCentralManager {
-#if MONOMAC
-		// Removed in iOS 10 – The selector now exists in the base type.
-		// Note: macOS doesn't inherit from CBManager.
-		[Export ("state")]
-		CBCentralManagerState State { get;  }
-#endif
 
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -71,9 +63,7 @@ namespace XamCore.CoreBluetooth {
 		[PostGet ("WeakDelegate")]
 		IntPtr Constructor ([NullAllowed, Protocolize] CBCentralManagerDelegate centralDelegate, [NullAllowed] DispatchQueue queue);
 
-#if !MONOMAC
 		[DesignatedInitializer]
-#endif
 		[iOS (7,0), Mac (10,9)]
 		[Export ("initWithDelegate:queue:options:")]
 		[PostGet ("WeakDelegate")]
@@ -113,37 +103,35 @@ namespace XamCore.CoreBluetooth {
 		[Field ("CBConnectPeripheralOptionNotifyOnDisconnectionKey")]
 		NSString OptionNotifyOnDisconnectionKey { get; }
 
-#if !MONOMAC
-		[Availability (Unavailable = Platform.Mac_Version)]
+		[Mac (10,13)]
 		[Since (6,0)]
 		[Field ("CBConnectPeripheralOptionNotifyOnConnectionKey")]
 		NSString OptionNotifyOnConnectionKey { get; }
 
-		[Availability (Unavailable = Platform.Mac_Version)]
+		[Mac (10,13)]
 		[Since (6,0)]
 		[Field ("CBConnectPeripheralOptionNotifyOnNotificationKey")]
 		NSString OptionNotifyOnNotificationKey { get; }
 
-		[Availability (Unavailable = Platform.Mac_Version)]
 		[Field ("CBCentralManagerOptionRestoreIdentifierKey")]
 		[Since (7,0)]
+		[Mac (10,13)]
 		NSString OptionRestoreIdentifierKey { get; }
 
 		[Field ("CBCentralManagerRestoredStatePeripheralsKey")]
 		[Since (7,0)]
-		[Availability (Unavailable = Platform.Mac_Version)]
+		[Mac (10,13)]
 		NSString RestoredStatePeripheralsKey { get; }
 
 		[Field ("CBCentralManagerRestoredStateScanServicesKey")]
 		[Since (7,0)]
-		[Availability (Unavailable = Platform.Mac_Version)]
+		[Mac (10,13)]
 		NSString RestoredStateScanServicesKey { get; }
 
 		[Field ("CBCentralManagerRestoredStateScanOptionsKey")]
 		[Since (7,0)]
-		[Availability (Unavailable = Platform.Mac_Version)]
+		[Mac (10,13)]
 		NSString RestoredStateScanOptionsKey { get; }
-#endif
 
 		[Since (7,0), Mac (10,9)]
 		[Export ("retrievePeripheralsWithIdentifiers:")]
@@ -161,13 +149,13 @@ namespace XamCore.CoreBluetooth {
 		[Since (7,0), Mac (10,9)]
 		NSString ScanOptionSolicitedServiceUUIDsKey { get; }
 
-#if !MONOMAC
 		[iOS (9,0)]
+		[Mac (10,13)]
 		[Export ("isScanning")]
 		bool IsScanning { get; }
-#endif
 	}
 
+	[Watch (4,0)]
 	[StrongDictionary ("AdvertisementDataKeys")]
 	interface AdvertisementData {
 		string LocalName { get; set; }
@@ -185,6 +173,7 @@ namespace XamCore.CoreBluetooth {
 		CBUUID [] SolicitedServiceUuids { get; set; }
 	}
 
+	[Watch (4,0)]
 	[Static, Internal]
 	interface AdvertisementDataKeys {
 		[Field ("CBAdvertisementDataLocalNameKey")]
@@ -214,10 +203,11 @@ namespace XamCore.CoreBluetooth {
 		NSString SolicitedServiceUuidsKey { get; }
 	}
 
+	[Watch (4,0)]
 	[StrongDictionary ("PeripheralScanningOptionsKeys")]
 	interface PeripheralScanningOptions { }
 
-
+	[Watch (4,0)]
 	[StrongDictionary ("RestoredStateKeys")]
 	interface RestoredState {
 		CBPeripheral [] Peripherals { get; set; }
@@ -225,6 +215,7 @@ namespace XamCore.CoreBluetooth {
 		PeripheralScanningOptions ScanOptions { get; set; }
 	}
 
+	[Watch (4,0)]
 	[Static, Internal]
 	interface RestoredStateKeys {
 		[Since (7,0)]
@@ -240,6 +231,7 @@ namespace XamCore.CoreBluetooth {
 		NSString ScanOptionsKey { get; }
 	}
 
+	[Watch (4,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -249,11 +241,13 @@ namespace XamCore.CoreBluetooth {
 		void UpdatedState (CBCentralManager central);
 
 		[NoTV]
+		[NoWatch]
 		[Availability (Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_8_4)] // Available in iOS 5.0 through iOS 8.4. Deprecated in iOS 7.0.
 		[Export ("centralManager:didRetrievePeripherals:"), EventArgs ("CBPeripherals")]
 		void RetrievedPeripherals (CBCentralManager central, CBPeripheral [] peripherals);
 
 		[NoTV]
+		[NoWatch]
 		[Availability (Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_8_4)] // Available in iOS 5.0 through iOS 8.4. Deprecated in iOS 7.0.
 		[Export ("centralManager:didRetrieveConnectedPeripherals:"), EventArgs ("CBPeripherals")]
 		void RetrievedConnectedPeripherals (CBCentralManager central, CBPeripheral [] peripherals);
@@ -274,6 +268,7 @@ namespace XamCore.CoreBluetooth {
 		void WillRestoreState (CBCentralManager central, NSDictionary dict);
 	}
 
+	[Watch (4,0)]
 	[Since (5,0)]
 	[Static]
 	interface CBAdvertisement {
@@ -306,18 +301,11 @@ namespace XamCore.CoreBluetooth {
 
 	}
 
+	[Watch (4,0)]
 	[Since (5,0)]
-#if MONOMAC
-	[BaseType (typeof (NSObject))]
-#else
 	[BaseType (typeof (CBAttribute))]
-#endif
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
 	interface CBCharacteristic {
-#if MONOMAC
-		[Export ("UUID")]
-		CBUUID UUID { get; [NotImplemented] set;  }
-#endif
 		
 		[Export ("properties")]
 		CBCharacteristicProperties Properties { get; [NotImplemented ("Not available on CBCharacteristic, only available on CBMutableCharacteristic")] set; }
@@ -328,7 +316,8 @@ namespace XamCore.CoreBluetooth {
 		[Export ("descriptors", ArgumentSemantic.Retain)]
 		CBDescriptor [] Descriptors { get; [NotImplemented ("Not available on CBCharacteristic, only available on CBMutableCharacteristic")] set; }
 
-		[Availability (Deprecated=Platform.iOS_8_0)]
+		[Deprecated (PlatformName.iOS, 8,0)]
+		[Deprecated (PlatformName.MacOSX, 10,13)]
 		[Export ("isBroadcasted")]
 		bool IsBroadcasted { get;  }
 
@@ -344,15 +333,15 @@ namespace XamCore.CoreBluetooth {
 #endif
 	}
 
+	[Watch (4,0)]
 	[Since (6, 0), Mac (10,9)]
 	[BaseType (typeof (CBCharacteristic))]
 	[DisableDefaultCtor]
 	interface CBMutableCharacteristic {
 
 		[NoTV]
-#if !MONOMAC
+		[NoWatch]
 		[DesignatedInitializer]
-#endif
 		[Export ("initWithType:properties:value:permissions:")]
 		[PostGet ("UUID")]
 		[PostGet ("Value")]
@@ -387,18 +376,11 @@ namespace XamCore.CoreBluetooth {
 #endif
 	}
 
+	[Watch (4,0)]
 	[Since (5,0)]
-#if MONOMAC
-	[BaseType (typeof (NSObject))]
-#else
 	[BaseType (typeof (CBAttribute))]
-#endif
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
 	interface CBDescriptor {
-#if MONOMAC
-		[Export ("UUID")]
-		CBUUID UUID { get;  }
-#endif
 		
 		[Export ("value", ArgumentSemantic.Retain)]
 		NSObject Value { get;  }
@@ -407,39 +389,37 @@ namespace XamCore.CoreBluetooth {
 		CBCharacteristic Characteristic { get; }
 	}
 
+	[Watch (4,0)]
 	[Since (6, 0), Mac (10,9)]
 	[BaseType (typeof (CBDescriptor))]
 	[DisableDefaultCtor]
 	interface CBMutableDescriptor {
 		[NoTV]
-#if !MONOMAC
+		[NoWatch]
 		[DesignatedInitializer]
-#endif
 		[Export ("initWithType:value:")]
 		[PostGet ("UUID")]
 		[PostGet ("Value")]
 		IntPtr Constructor (CBUUID uuid, NSObject descriptorValue);
 	}
 
+	[Watch (4,0)]
 	[Since (5,0)]
-	[BaseType (
-#if MONOMAC
-	typeof (NSObject)
-#else
-	typeof (CBPeer)
-#endif
-	, Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof (CBPeripheralDelegate)})]
+	[BaseType (typeof (CBPeer), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof (CBPeripheralDelegate)})]
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
 	interface CBPeripheral : NSCopying {
 		[Export ("name", ArgumentSemantic.Retain)]
 		[DisableZeroCopy]
 		string Name { get;  }
 
-		[Availability (Deprecated=Platform.iOS_8_0)]
+		[Deprecated (PlatformName.iOS, 8,0)]
+		[Deprecated (PlatformName.MacOSX, 10,13)]
+		[NoWatch]
 		[Export ("RSSI", ArgumentSemantic.Retain)]
 		NSNumber RSSI { get;  }
 
 		[NoTV]
+		[NoWatch]
 		[Availability (Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_9_0)]
 		[Export ("isConnected")]
 		[Mac (10, 7, onlyOn64: true)] // Was removed from 32-bit in 10.13 unannounced
@@ -485,14 +465,6 @@ namespace XamCore.CoreBluetooth {
 		[Export ("writeValue:forDescriptor:")]
 		void WriteValue (NSData data, CBDescriptor descriptor);
 
-#if MONOMAC
-		// Provided with the iOS7 SDK, but does not contain an NS_AVAILABLE macro.
-		// Moved to a new base class, CBPeer, in iOS 8.
-		[Since (7,0), Mavericks]
-		[Export ("identifier")]
-		NSUuid Identifier { get; }
-#endif
-
 		[iOS (9,0)][Mac (10,12)]
 		[Export ("maximumWriteValueLengthForType:")]
 		nuint GetMaximumWriteValueLength (CBCharacteristicWriteType type);
@@ -506,8 +478,17 @@ namespace XamCore.CoreBluetooth {
 		[Since (7,0), Mac (10,9)]
 		[Export ("state")]
 		CBPeripheralState State { get; }
+
+		[iOS (11,0)][TV (11,0)][Mac (10,13)]
+		[Export ("canSendWriteWithoutResponse")]
+		bool CanSendWriteWithoutResponse { get; }
+
+		[iOS (11,0)][TV (11,0)][Mac (10,13)]
+		[Export ("openL2CAPChannel:")]
+		void OpenL2CapChannel (ushort psm);
 	}
 
+	[Watch (4,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -516,19 +497,10 @@ namespace XamCore.CoreBluetooth {
 		[Export ("peripheralDidUpdateRSSI:error:"), EventArgs ("NSError", true)]
 		void RssiUpdated (CBPeripheral peripheral, NSError error);
 
-#if MONOMAC
-#if !XAMCORE_4_0
-		// This API was removed or never existed. Can't cleanly remove due to EventsArgs/Delegate
-		[Availability (Introduced=Platform.iOS_8_0)]
-		[Export ("xamarin:selector:removed:"), EventArgs ("CBRssi")]
-		[Obsolete ("It will never be called.")]
-		void RssiRead (CBPeripheral peripheral, NSNumber rssi, NSError error);
-#endif
-#else
-		[Availability (Introduced=Platform.iOS_8_0)]
+		[iOS (8,0)]
+		[Mac (10,13)]
 		[Export ("peripheral:didReadRSSI:error:"), EventArgs ("CBRssi")]
 		void RssiRead (CBPeripheral peripheral, NSNumber rssi, NSError error);
-#endif
 
 		// FIXME: TYPO: missing 's' (plural)
 		[Export ("peripheral:didDiscoverServices:"), EventArgs ("NSError", true)]
@@ -564,6 +536,7 @@ namespace XamCore.CoreBluetooth {
 		void WroteDescriptorValue (CBPeripheral peripheral, CBDescriptor descriptor, NSError error);
 
 		[NoTV]
+		[NoWatch]
 		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_8_4)]
 		[Export ("peripheralDidInvalidateServices:")]
 		void InvalidatedService (CBPeripheral peripheral);	
@@ -575,20 +548,22 @@ namespace XamCore.CoreBluetooth {
 		[Since (7,0)]
 		[Export ("peripheral:didModifyServices:"), EventArgs ("CBPeripheralServices")]
 		void ModifiedServices (CBPeripheral peripheral, CBService [] services);
+
+		[iOS (11,0)][TV (11,0)][Mac (10,13)]
+		[EventArgs ("CBPeripheralOpenL2CapChannel")]
+		[Export ("peripheral:didOpenL2CAPChannel:error:")]
+		void DidOpenL2CapChannel (CBPeripheral peripheral, [NullAllowed] CBL2CapChannel channel, [NullAllowed] NSError error);
+
+		[iOS (11,0)][TV (11,0)][Mac (10,13)]
+		[Export ("peripheralIsReadyToSendWriteWithoutResponse:")]
+		void IsReadyToSendWriteWithoutResponse (CBPeripheral peripheral);
 	}
 
+	[Watch (4,0)]
 	[Since (5,0)]
-#if MONOMAC
-	[BaseType (typeof (NSObject))]
-#else
 	[BaseType (typeof (CBAttribute))]
-#endif
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
 	interface CBService {
-#if MONOMAC
-		[Export ("UUID", ArgumentSemantic.Retain)]
-		CBUUID UUID { get; }
-#endif
 		[iOS (6,0), Mac (10,9)]
 		[Export ("isPrimary")]
 		bool Primary { get; [NotImplemented ("Not available on CBCharacteristic, only available on CBMutableService")] set; }
@@ -604,26 +579,26 @@ namespace XamCore.CoreBluetooth {
 
 	}
 		
+	[Watch (4,0)]
 	[Since (6, 0), Mac(10,9)]
 	[BaseType (typeof (CBService))]
 	[DisableDefaultCtor]
 	interface CBMutableService {
 		[NoTV]
-#if !MONOMAC
+		[NoWatch]
 		[DesignatedInitializer]
-#endif
 		[Export ("initWithType:primary:")]
 		[PostGet ("UUID")]
 		IntPtr Constructor (CBUUID uuid, bool primary);
 
 		[NoTV]
+		[NoWatch]
 		[Export ("UUID", ArgumentSemantic.Retain)]
-#if !MONOMAC
 		[Override]
-#endif
 		CBUUID UUID { get; [Availability (Obsoleted = Platform.Mac_10_13)] set; }
 
 		[NoTV]
+		[NoWatch]
 		[Export ("isPrimary")]
 		[Override]
 		bool Primary { get; set; }
@@ -637,6 +612,7 @@ namespace XamCore.CoreBluetooth {
 		CBCharacteristic[] Characteristics { get; set; }	// TODO: check array type
 	}
 
+	[Watch (4,0)]
 	[Since (5,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
@@ -654,6 +630,7 @@ namespace XamCore.CoreBluetooth {
 		CBUUID FromData (NSData theData);
 
 		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_9_0)]
+		[NoWatch]
 		[Static]
 		[Export ("UUIDWithCFUUID:")]
 		CBUUID FromCFUUID (IntPtr theUUID);
@@ -693,14 +670,27 @@ namespace XamCore.CoreBluetooth {
 		[Field ("CBUUIDCharacteristicAggregateFormatString")]
 		NSString CharacteristicAggregateFormatString { get; }
 
-#if !MONOMAC // Filled radar://27160443 – Trello: https://trello.com/c/oqB27JA6
+#if MONOMAC
+		[Internal]
+		[Field ("CBUUIDValidRangeString")]
+		NSString CBUUIDValidRangeString { get; }
+
+		[Internal]
+		[Mac (10,13)]
+		[Field ("CBUUIDCharacteristicValidRangeString")]
+		NSString CBUUIDCharacteristicValidRangeString { get; }
+#else
 		[iOS (10,0)]
 		[TV (10,0)]
 		[Field ("CBUUIDCharacteristicValidRangeString")]
-#else
-		[Field ("CBUUIDValidRangeString")]
-#endif
 		NSString CharacteristicValidRangeString { get; }
+#endif
+
+		[iOS (11,0)]
+		[TV (11,0)]
+		[Mac (10,13)]
+		[Field ("CBUUIDL2CAPPSMCharacteristicString")]
+		NSString L2CapPsmCharacteristicString { get; }
 
 #if !XAMCORE_3_0
 		[Deprecated (PlatformName.iOS, 7, 0)]
@@ -739,6 +729,7 @@ namespace XamCore.CoreBluetooth {
 		string Uuid { get; }
 	}
 		
+	[Watch (4,0)]
 	[Since (6,0), Mac(10,9)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -756,13 +747,10 @@ namespace XamCore.CoreBluetooth {
 		NSData Value { get; set; }		
 	}
 
-#if MONOMAC
 	[Mac (10,9)]
-	[BaseType (typeof (NSObject))]
-#else
+	[Watch (4,0)]
 	[iOS (6,0)]
 	[BaseType (typeof (CBPeer))]
-#endif
 	// `delloc` a default instance crash applications and a default instance, without the ability to change the UUID, does not make sense
 	[DisableDefaultCtor]
 	interface CBCentral : NSCopying {
@@ -786,24 +774,19 @@ namespace XamCore.CoreBluetooth {
 		nuint MaximumUpdateValueLength { get; }
 	}
 
+	[Watch (4,0)]
 	[Since (6, 0), Mac(10,9)]
-	[BaseType (
-#if MONOMAC
-	typeof (NSObject)
-#else
-	typeof (CBManager)
-#endif
-	, Delegates=new[] { "WeakDelegate" }, Events=new[] { typeof (CBPeripheralManagerDelegate) })]
+	[BaseType (typeof (CBManager), Delegates=new[] { "WeakDelegate" }, Events=new[] { typeof (CBPeripheralManagerDelegate) })]
 	interface CBPeripheralManager {
 		[NoTV]
+		[NoWatch]
 		[Export ("initWithDelegate:queue:")]
 		[PostGet ("WeakDelegate")]
 		IntPtr Constructor ([Protocolize] CBPeripheralManagerDelegate peripheralDelegate, [NullAllowed] DispatchQueue queue);
 
 		[NoTV]
-#if !MONOMAC
+		[NoWatch]
 		[DesignatedInitializer]
-#endif
 		[Since (7,0),Mac (10,9)]
 		[Export ("initWithDelegate:queue:options:")]
 		[PostGet ("WeakDelegate")]
@@ -820,13 +803,6 @@ namespace XamCore.CoreBluetooth {
 
 		[Export ("isAdvertising")]
 		bool Advertising { get; }
-
-#if MONOMAC
-		// Removed in iOS 10 – The selector now exists in the base type.
-		// Note: macOS doesn't inherit from CBManager.
-		[Export ("state")]
-		CBPeripheralManagerState State { get; }
-#endif
 
 		[Export ("addService:")]
 		void AddService (CBMutableService service);
@@ -855,6 +831,14 @@ namespace XamCore.CoreBluetooth {
 		[Export ("updateValue:forCharacteristic:onSubscribedCentrals:")]
 		bool UpdateValue (NSData value, CBMutableCharacteristic characteristic, [NullAllowed] CBCentral[] subscribedCentrals);
 
+		[iOS (11,0)][TV (11,0)][Mac (10,13)]
+		[Export ("publishL2CAPChannelWithEncryption:")]
+		void PublishL2CapChannel (bool encryptionRequired);
+
+		[iOS (11,0)][TV (11,0)][Mac (10,13)]
+		[Export ("unpublishL2CAPChannel:")]
+		void UnpublishL2CapChannel (ushort psm);
+
 		[Field ("CBPeripheralManagerOptionShowPowerAlertKey")]
 		[Since (7,0)]
 		NSString OptionShowPowerAlertKey { get; }
@@ -879,6 +863,7 @@ namespace XamCore.CoreBluetooth {
 #endif
 	}
 
+	[Watch (4,0)]
 	[Since (6, 0), Mac(10,9)]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -911,15 +896,33 @@ namespace XamCore.CoreBluetooth {
 
 		[Export ("peripheralManagerIsReadyToUpdateSubscribers:")]
 		void ReadyToUpdateSubscribers (CBPeripheralManager peripheral);
+
+		[iOS (11,0)][TV (11,0)][Mac (10,13)]
+		[EventArgs ("CBPeripheralManagerOpenL2CapChannel")]
+		[Export ("peripheralManager:didOpenL2CAPChannel:error:")]
+		void DidOpenL2CapChannel (CBPeripheralManager peripheral, [NullAllowed] CBL2CapChannel channel, [NullAllowed] NSError error);
+
+		[iOS (11,0)][TV (11,0)][Mac (10,13)]
+		[EventArgs ("CBPeripheralManagerL2CapChannelOperation")]
+		[Export ("peripheralManager:didUnpublishL2CAPChannel:error:")]
+		void DidUnpublishL2CapChannel (CBPeripheralManager peripheral, ushort psm, [NullAllowed] NSError error);
+
+		[iOS (11,0)][TV (11,0)][Mac (10,13)]
+		[EventArgs ("CBPeripheralManagerL2CapChannelOperation")]
+		[Export ("peripheralManager:didPublishL2CAPChannel:error:")]
+		void DidPublishL2CapChannel (CBPeripheralManager peripheral, ushort psm, [NullAllowed] NSError error);
 	}
 
-#if !MONOMAC
 	[Since (8, 0)]
+	[Mac (10,13)]
+	[Watch (4,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // CBPeer.h: - (instancetype)init NS_UNAVAILABLE;
 	interface CBPeer : NSCopying {
 		[Internal]
 		[NoTV]
+		[NoWatch]
+		[NoMac]
 		[Availability (Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_9_0)]
 		[Export ("UUID")]
 		IntPtr _UUID { get;  }
@@ -928,5 +931,21 @@ namespace XamCore.CoreBluetooth {
 		[Export ("identifier")]
 		NSUuid Identifier { get; }
 	}
-#endif
+
+	[Watch (4,0)][iOS (11,0)][TV (11,0)][Mac (10,13)]
+	[BaseType (typeof (NSObject), Name = "CBL2CAPChannel")]
+	interface CBL2CapChannel {
+
+		[Export ("peer")]
+		CBPeer Peer { get; }
+
+		[Export ("inputStream")]
+		NSInputStream InputStream { get; }
+
+		[Export ("outputStream")]
+		NSOutputStream OutputStream { get; }
+
+		[Export ("PSM")]
+		/* uint16_t */ ushort Psm { get; }
+	}
 }

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1570,6 +1570,7 @@ SHARED_SOURCES = \
 
 COMMON_FRAMEWORKS =         \
 	AVFoundation            \
+	CoreBluetooth           \
 	CoreFoundation          \
 	CoreML                  \
 	Foundation              \
@@ -1591,7 +1592,6 @@ MAC_FRAMEWORKS =            \
 	ContactsUI              \
 	CoreAnimation           \
 	CoreAudioKit            \
-	CoreBluetooth           \
 	CoreData                \
 	CoreGraphics            \
 	CoreImage               \
@@ -1665,7 +1665,6 @@ IOS_FRAMEWORKS =         \
 	ContactsUI \
 	CoreAnimation \
 	CoreAudioKit \
-	CoreBluetooth \
 	CoreData \
 	CoreGraphics \
 	CoreImage \
@@ -1771,7 +1770,6 @@ TVOS_FRAMEWORKS =           \
 	CFNetwork               \
 	CloudKit                \
 	CoreAnimation           \
-	CoreBluetooth           \
 	CoreData                \
 	CoreGraphics            \
 	CoreImage               \

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -323,6 +323,7 @@ namespace Introspection
 			"Preseti",
 			"Propogate",
 			"Psec",
+			"Psm", // Protocol/Service Multiplexer
 			"Pvrtc", // MTLBlitOption - PowerVR Texture Compression
 			"Quaterniond",
 			"Quadding",
@@ -412,6 +413,7 @@ namespace Introspection
 			"Unpremultiplying",
 			"Unprepare",
 			"Unproject",
+			"Unpublish",
 			"Uterance",
 			"Unentitled",
 			"Untrash",

--- a/tests/xtro-sharpie/osx.ignore
+++ b/tests/xtro-sharpie/osx.ignore
@@ -1,5 +1,11 @@
 # A large number of assemblies are black listed in xtro-sharpie/Runner.cs 
 
+# CoreBluetooth
+
+## old and different name for CBUUIDCharacteristicValidRangeString, removed in Xcode9 headers (27160443)
+!unknown-field! CBUUIDValidRangeString bound
+
+
 # GameController
 
 ## other CGMicroGamepad API are not available on OSX (looks like a mistake)

--- a/tests/xtro-sharpie/watchos.ignore
+++ b/tests/xtro-sharpie/watchos.ignore
@@ -9,6 +9,15 @@
 AVAudioPlayerDelegate::audioPlayerEndInterruption:withOptions:
 
 
+# CoreBluetooth
+
+## present in headers but already deprecated (we're not exposing them)
+!missing-enum! CBCentralManagerState not bound
+!missing-enum! CBPeripheralManagerState not bound
+!missing-selector! CBPeripheral::RSSI not bound
+!missing-selector! +CBUUID::UUIDWithCFUUID: not bound
+
+
 # Foundation
 
 ## does not exists in iOS (or watchOS) as a type - but some API refers to it (messy)


### PR DESCRIPTION
macOS 10.13 has finally catch up with iOS and this simplifies the
bindings a bit.