### PR TITLE
[contacts] Fix breaking change (api-diff)

### DIFF
--- a/src/contacts.cs
+++ b/src/contacts.cs
@@ -1069,6 +1069,10 @@ namespace XamCore.Contacts {
 		[Static]
 		[Export ("localizedStringForKey:")]
 		string LocalizeProperty (NSString property);
+
+		[Static]
+		[Wrap ("LocalizeProperty (option.GetConstant ())")]
+		string LocalizeProperty (CNPostalAddressKeyOption option);
 	}
 
 #if !XAMCORE_4_0


### PR DESCRIPTION
Type Changed: Contacts.CNPostalAddress

Removed method:

	public static string LocalizeProperty (CNPostalAddressKeyOption option);