### PR TITLE
[macos] Reenable static registrar since Xcode9b6 un-broke SDK headers

### DIFF
--- a/tests/mmptest/src/FrameworkLinksTests.cs
+++ b/tests/mmptest/src/FrameworkLinksTests.cs
@@ -1,4 +1,4 @@
-﻿// #define ENABLE_STATIC_REGISTRAR_TESTS https://bugzilla.xamarin.com/show_bug.cgi?id=58629
+﻿#define ENABLE_STATIC_REGISTRAR_TESTS
 
 using System;
 using System.Collections.Generic;

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -1,4 +1,4 @@
-// #define ENABLE_STATIC_REGISTRAR_TESTS https://bugzilla.xamarin.com/show_bug.cgi?id=58629
+#define ENABLE_STATIC_REGISTRAR_TESTS
 
 using System;
 using System.Collections.Generic;

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -151,8 +151,6 @@ MMP_TARGETS = \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/mmp.exe \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/Mono.Cecil.dll \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/Mono.Cecil.Mdb.dll \
-
-MMP_TARGETS_disabled_bug_58629 = \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/Xamarin.Mac.registrar.mobile.a \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mmp/Xamarin.Mac.registrar.full.a \
 

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -694,12 +694,12 @@ namespace Xamarin.Bundler {
 			if (registrar == RegistrarMode.Default)
 			{
 				if (!App.EnableDebug)
-					// registrar = RegistrarMode.Static;
-					registrar = RegistrarMode.Dynamic; // Apple's macOS SDK is broken, so default to the dynamic registrar. See #58629.
+					registrar = RegistrarMode.Static;
 				else if (IsUnified && App.LinkMode == LinkMode.None && embed_mono && App.IsDefaultMarshalManagedExceptionMode && File.Exists (PartialStaticLibrary))
 					registrar = RegistrarMode.PartialStatic;
 				else
 					registrar = RegistrarMode.Dynamic;
+				Log (1, $"Defaulting registrar to '{registrar}'");
 			}
 			
 			if (no_executable) {
@@ -1081,7 +1081,7 @@ namespace Xamarin.Bundler {
 
 		static string PartialStaticLibrary {
 			get {
-				return Path.Combine (GetXamMacPrefix (), "lib", string.Format ("mmp/Xamarin.Mac.registrar.{0}.a ", IsUnifiedMobile ? "mobile" : "full"));
+				return Path.Combine (GetXamMacPrefix (), "lib", string.Format ("mmp/Xamarin.Mac.registrar.{0}.a", IsUnifiedMobile ? "mobile" : "full"));
 			}
 		}
 
@@ -1364,7 +1364,7 @@ namespace Xamarin.Bundler {
 
 				if (registrar == RegistrarMode.PartialStatic) {
 					args.Append (PartialStaticLibrary);
-					args.Append ("-framework Quartz ");
+					args.Append (" -framework Quartz ");
 				}
 
 				args.Append ("-liconv -x objective-c++ ");


### PR DESCRIPTION
- Fix a subtle spacing issues in PartialStaticLibrary property