### PR TITLE
[foundation] API fixes (apidiff)

### DIFF
--- a/src/Foundation/NSUnit.cs
+++ b/src/Foundation/NSUnit.cs
@@ -20,107 +20,102 @@ namespace XamCore.Foundation {
 
 	public partial class NSUnitAcceleration {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitAcceleration () { }
+		public NSUnitAcceleration () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitAngle {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitAngle () { }
+		public NSUnitAngle () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitArea {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitArea () { }
+		public NSUnitArea () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitConcentrationMass {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitConcentrationMass () { }
+		public NSUnitConcentrationMass () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitDispersion {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitDispersion () { }
+		public NSUnitDispersion () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitDuration {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitDuration () { }
+		public NSUnitDuration () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitElectricCharge {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitElectricCharge () { }
+		public NSUnitElectricCharge () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitElectricCurrent {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitElectricCurrent () { }
+		public NSUnitElectricCurrent () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitElectricPotentialDifference {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitElectricPotentialDifference () { }
+		public NSUnitElectricPotentialDifference () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitElectricResistance {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitElectricResistance () { }
+		public NSUnitElectricResistance () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitEnergy {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitEnergy () { }
+		public NSUnitEnergy () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitFrequency {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitFrequency () { }
+		public NSUnitFrequency () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitFuelEfficiency {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitFuelEfficiency () { }
+		public NSUnitFuelEfficiency () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitLength {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitLength () { }
+		public NSUnitLength () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitIlluminance {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitIlluminance () { }
+		public NSUnitIlluminance () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitMass {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitMass () { }
+		public NSUnitMass () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitPower {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitPower () { }
+		public NSUnitPower () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitPressure {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitPressure () { }
+		public NSUnitPressure () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitSpeed {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitSpeed () { }
+		public NSUnitSpeed () : base (NSObjectFlag.Empty) { }
 	}
 
 	public partial class NSUnitVolume {
 		[Obsolete ("Use .ctor(string, NSUnitConverter) or any of the static properties.")]
-		public NSUnitVolume () { }
-	}
-
-	public partial class NSDimension {
-		[Obsolete ("Not intended to be directly instantiated, this is an abstract class.")]
-		public NSDimension () { }
+		public NSUnitVolume () : base (NSObjectFlag.Empty) { }
 	}
 #endif
 }

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -254,7 +254,7 @@ namespace XamCore.Foundation
 		[Static]
 		[Export ("readableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
 		[iOS (11,0), NoWatch, NoTV, Mac(10,13)]
-		string[] ReadableTypeIdentifiersForItemProvider { get; }
+		string[] ReadableTypeIdentifiers { get; }
 
 #if !TVOS && !WATCHOS
 		[NoWatch, NoTV, Mac (10,13), iOS (11,0)]
@@ -9775,7 +9775,7 @@ namespace XamCore.Foundation
 		//
 		//[Static, Abstract]
 		//[Export ("readableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
-		//string[] ReadableTypeIdentifiersForItemProvider { get; }
+		//string[] ReadableTypeIdentifiers { get; }
 
 		//[Static]
 		//[Export ("objectWithItemProviderData:typeIdentifier:error:")]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -4702,7 +4702,7 @@ namespace XamCore.UIKit {
 		[Static]
 		[iOS (11,0), NoWatch, NoTV]
 		[Export ("readableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
-		string[] ReadableTypeIdentifiersForItemProvider { get; }
+		string[] ReadableTypeIdentifiers { get; }
 #if !WATCH
 		[iOS (11,0)]
 		[Static]
@@ -7036,7 +7036,7 @@ namespace XamCore.UIKit {
 		[Static]
 		[iOS (11,0), NoWatch, NoTV]
 		[Export ("readableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
-		string[] ReadableTypeIdentifiersForItemProvider { get; }
+		string[] ReadableTypeIdentifiers { get; }
 	
 		[Export ("renderingMode")]
 		[ThreadSafe]


### PR DESCRIPTION
1. Let's not add new, already [Obsolete] API

Type Changed: Foundation.NSDimension

Added constructors:

	[Obsolete ("Not intended to be directly instantiated, this is an abstract class.")]
	public NSDimension ();

2. Fix inconsistently named API, e.g.

Type Changed: Foundation.NSAttributedString

Added properties:

	public static string[] ReadableTypeIdentifiersForItemProvider { get; }
	public static string[] WritableTypeIdentifiers { get; }