### PR TITLE
[vision] Minor fix wrt xtro

### DIFF
--- a/src/Constants.watch.cs.in
+++ b/src/Constants.watch.cs.in
@@ -46,5 +46,6 @@ namespace ObjCRuntime {
 		// WatchOS 4.0
 		public const string CoreBluetoothLibrary = "/System/Library/Frameworks/CoreBluetooth.framework/CoreBluetooth";
 		public const string CoreMLLibrary = "/System/Library/Frameworks/CoreML.framework/CoreML";	
+		public const string VisionLibrary = "/System/Library/Frameworks/Vision.framework/Vision";
 	}
 }

--- a/src/vision.cs
+++ b/src/vision.cs
@@ -1031,7 +1031,12 @@ namespace XamCore.Vision {
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor] // it's a designated initializer
 	interface VNSequenceRequestHandler {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
 
 		[Export ("performRequests:onCVPixelBuffer:error:")]
 		bool Perform (VNRequest [] requests, CVPixelBuffer pixelBuffer, out NSError error);

--- a/tests/xtro-sharpie/common.ignore
+++ b/tests/xtro-sharpie/common.ignore
@@ -205,6 +205,16 @@
 !missing-selector! +UIView::layerClass not bound
 
 
+# Vision
+
+## we do not expose internal framework versions
+!missing-field! VNVisionVersionNumber not bound
+
+## called indirectly (there's a required native layer for them)
+!missing-pinvoke! VNImagePointForFaceLandmarkPoint is not bound
+!missing-pinvoke! VNNormalizedFaceBoundingBoxPointForLandmarkPoint is not bound
+
+
 # non-imported headers
 
 ## objc runtime


### PR DESCRIPTION
including some things we need to ignore manually

!missing-field! VNVisionVersionNumber not bound
!missing-pinvoke! VNImagePointForFaceLandmarkPoint is not bound
!missing-pinvoke! VNNormalizedFaceBoundingBoxPointForLandmarkPoint is not bound