### PR TITLE
[CoreText] Fix an extraneous free in CTFont.GetDefaultCascadeList.

### DIFF
--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -2191,7 +2191,7 @@ namespace XamCore.CoreText {
 
 					var ret = new CTFontDescriptor [n];
 					for (nint i = 0; i < n; i++)
-						ret [i] = new CTFontDescriptor (retArray.GetValue (i), true);
+						ret [i] = new CTFontDescriptor (retArray.GetValue (i), false);
 
 					return ret;
 				}


### PR DESCRIPTION
We do not own the return value from CFArrayGetValueAtIndex, so don't say we do
when creating CTFontDescriptor instances, since that leads to angry dragons:

    2017-08-28 20:15:20.293 monotouchtest[33186:2311738] A_FontTest
    2017-08-28 20:15:20.294 monotouchtest[33186:2311738] 	[PASS] A_FontTest.CTFontCreateWithFontDescriptorAndOptions
    2017-08-28 20:15:20.295 monotouchtest[33186:2311738] 	[PASS] A_FontTest.CTFontCreateWithNameAndOptions
    2017-08-28 20:15:20.296 monotouchtest[33186:2311738] critical: Stacktrace:

    at <unknown> <0xffffffff>
    at (wrapper managed-to-native) CoreText.CTFont.CTFontCopyDefaultCascadeListForLanguages (intptr,intptr) [0x0000a] in <ae65a2b1eea242d2b68fe784749543bf>:0
    at CoreText.CTFont.GetDefaultCascadeList (string[]) [0x00013] in /work/maccore/xcode9/xamarin-macios/src/CoreText/CTFont.cs:2185
    at MonoTouchFixtures.CoreText.A_FontTest.GetCascadeList () [0x0001e] in /work/maccore/xcode9/xamarin-macios/tests/monotouch-test/CoreText/FontTest.cs:78
    at (wrapper runtime-invoke) object.runtime_invoke_void__this__ (object,intptr,intptr,intptr) [0x0004f] in <7c58d77f8ca548d5b9b32e70a64ba2fd>:0
    at <unknown> <0xffffffff>
    at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&) [0x00016] in <7c58d77f8ca548d5b9b32e70a64ba2fd>:0
    at System.Reflection.MonoMethod.Invoke (object,System.Reflection.BindingFlags,System.Reflection.Binder,object[],System.Globalization.CultureInfo) [0x00032] in /work/maccore/xcode9/xamarin-macios/external/mono/mcs/class/corlib/System.Reflection/MonoMethod.cs:305
    at System.Reflection.MethodBase.Invoke (object,object[]) [0x00000] in /work/maccore/xcode9/xamarin-macios/external/mono/mcs/class/referencesource/mscorlib/system/reflection/methodbase.cs:229
    at NUnit.Framework.Internal.Reflect.InvokeMethod (System.Reflection.MethodInfo,object,object[]) [0x00009] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/Reflect.cs:215
    at NUnit.Framework.Internal.Commands.TestMethodCommand.RunNonAsyncTestMethod (NUnit.Framework.Internal.TestExecutionContext) [0x00025] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/Commands/TestMethodCommand.cs:116
    at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod (NUnit.Framework.Internal.TestExecutionContext) [0x0001a] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/Commands/TestMethodCommand.cs:90
    at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute (NUnit.Framework.Internal.TestExecutionContext) [0x00000] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/Commands/TestMethodCommand.cs:66
    at NUnit.Framework.Internal.Commands.SetUpTearDownCommand.Execute (NUnit.Framework.Internal.TestExecutionContext) [0x00007] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/Commands/SetUpTearDownCommand.cs:84
    at NUnit.Framework.Internal.WorkItems.SimpleWorkItem.PerformWork () [0x00000] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/WorkItems/SimpleWorkItem.cs:64
    at NUnit.Framework.Internal.WorkItems.WorkItem.RunTest () [0x00071] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/WorkItems/WorkItem.cs:196
    at NUnit.Framework.Internal.WorkItems.WorkItem.Execute (NUnit.Framework.Internal.TestExecutionContext) [0x00063] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/WorkItems/WorkItem.cs:136
    at NUnit.Framework.Internal.WorkItems.CompositeWorkItem.RunChildren () [0x00035] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/WorkItems/CompositeWorkItem.cs:154
    at NUnit.Framework.Internal.WorkItems.CompositeWorkItem.PerformWork () [0x000de] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/WorkItems/CompositeWorkItem.cs:93
    at NUnit.Framework.Internal.WorkItems.WorkItem.RunTest () [0x00071] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/WorkItems/WorkItem.cs:196
    at NUnit.Framework.Internal.WorkItems.WorkItem.Execute (NUnit.Framework.Internal.TestExecutionContext) [0x00063] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/WorkItems/WorkItem.cs:136
    at NUnit.Framework.Internal.WorkItems.CompositeWorkItem.RunChildren () [0x00035] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/WorkItems/CompositeWorkItem.cs:154
    at NUnit.Framework.Internal.WorkItems.CompositeWorkItem.PerformWork () [0x000de] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/WorkItems/CompositeWorkItem.cs:93
    at NUnit.Framework.Internal.WorkItems.WorkItem.RunTest () [0x00071] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/WorkItems/WorkItem.cs:196
    at NUnit.Framework.Internal.WorkItems.WorkItem.Execute (NUnit.Framework.Internal.TestExecutionContext) [0x00063] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/WorkItems/WorkItem.cs:136
    at NUnit.Framework.Internal.WorkItems.CompositeWorkItem.RunChildren () [0x00035] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/WorkItems/CompositeWorkItem.cs:154
    at NUnit.Framework.Internal.WorkItems.CompositeWorkItem.PerformWork () [0x000de] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/WorkItems/CompositeWorkItem.cs:93
    at NUnit.Framework.Internal.WorkItems.WorkItem.RunTest () [0x00071] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/WorkItems/WorkItem.cs:196
    at NUnit.Framework.Internal.WorkItems.WorkItem.Execute (NUnit.Framework.Internal.TestExecutionContext) [0x00063] in /work/maccore/xcode9/xamarin-macios/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/WorkItems/WorkItem.cs:136
    at MonoTouch.NUnit.UI.BaseTouchRunner.Run (NUnit.Framework.Internal.Test) [0x0004d] in /work/maccore/xcode9/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchRunner.cs:442
    at MonoTouch.NUnit.UI.BaseTouchRunner.Run () [0x00030] in /work/maccore/xcode9/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchRunner.cs:171
    at MonoTouch.Dialog.StringElement.Selected (MonoTouch.Dialog.DialogViewController,UIKit.UITableView,Foundation.NSIndexPath) [0x00008] in /work/maccore/xcode9/xamarin-macios/external/MonoTouch.Dialog/MonoTouch.Dialog/Elements.cs:765
    at MonoTouch.Dialog.DialogViewController.Selected (Foundation.NSIndexPath) [0x00026] in /work/maccore/xcode9/xamarin-macios/external/MonoTouch.Dialog/MonoTouch.Dialog/DialogViewController.cs:577
    at MonoTouch.Dialog.DialogViewController/Source.RowSelected (UIKit.UITableView,Foundation.NSIndexPath) [0x00016] in /work/maccore/xcode9/xamarin-macios/external/MonoTouch.Dialog/MonoTouch.Dialog/DialogViewController.cs:402
    at (wrapper runtime-invoke) <Module>.runtime_invoke_void__this___object_object (object,intptr,intptr,intptr) [0x0005d] in <32f0c196c5bc4aa18daea2ee64a7814e>:0
    at <unknown> <0xffffffff>
    at (wrapper managed-to-native) UIKit.UIApplication.UIApplicationMain (int,string[],intptr,intptr) [0x0005c] in <ae65a2b1eea242d2b68fe784749543bf>:0
    at UIKit.UIApplication.Main (string[],intptr,intptr) [0x00005] in /work/maccore/xcode9/xamarin-macios/src/UIKit/UIApplication.cs:79
    at UIKit.UIApplication.Main (string[],string,string) [0x00038] in /work/maccore/xcode9/xamarin-macios/src/UIKit/UIApplication.cs:63
    at monotouchtest.Application.Main (string[]) [0x00011] in /work/maccore/xcode9/xamarin-macios/tests/monotouch-test/Main.cs:27
    at (wrapper runtime-invoke) <Module>.runtime_invoke_void_object (object,intptr,intptr,intptr) [0x00051] in <30a7f7e09de9467b8b454221034a0e38>:0

    Native stacktrace:

    0   monotouchtest                       0x000000010fca03c4 mono_handle_native_crash + 244
    1   monotouchtest                       0x000000010fcadd30 mono_sigsegv_signal_handler + 288
    2   libsystem_platform.dylib            0x000000011feb3b3a _sigtramp + 26
    3   CoreFoundation                      0x000000011de035a2 computeSanitizedString + 146
    4   CoreText                            0x00000001168df314 _ZN15TPurgeableCache19RetainedValueForKeyEPKv + 54
    5   CoreText                            0x00000001168def85 _ZNK17TDescriptorSource22CopyDescriptorUncachedEPK7__CFURLbPK10__CFString + 55
    6   CoreText                            0x00000001168df34f _ZNK17TDescriptorSource14CopyDescriptorEPK7__CFURLbPK10__CFString + 27
    7   CoreText                            0x00000001168e20ad _ZNK17TDescriptorSource35CopyFontDescriptorPerPostScriptNameEPK10__CFStringmm + 297
    8   CoreText                            0x00000001168dfd9e _ZNK17TDescriptorSource30CopySystemFontDescriptorByNameEPK10__CFString10UIFontFlag + 54
    9   CoreText                            0x00000001168e54c4 _ZNK14TFontFallbacks17CopyFontFallbacksEPK10__CFStringS2_PK9__CFArray + 652
    10  CoreText                            0x00000001168e4a00 _ZNK14TFontFallbacks29CopyFontFallbacksForLanguagesEPK10__CFStringPK9__CFArray + 122
    11  CoreText                            0x00000001168e4971 _ZN17TDescriptorSource39CopyDefaultSubstitutionListForLanguagesEPK10__CFStringPK9__CFArray + 61
    12  CoreText                            0x00000001169397a7 _ZNK9TBaseFont28CreateSystemDefaultFallbacksEPK10__CFStringPK9__CFArray + 51
    13  CoreText                            0x000000011693999c _ZNK9TBaseFont15CreateFallbacksE10UIFontFlagPPK16__CFCharacterSetPK9__CFArray + 346
    14  CoreText                            0x00000001168c1036 _ZNK5TFont24CreateDefaultCascadeListEPK9__CFArray + 242
    15  CoreText                            0x00000001168b8ff9 CTFontCopyDefaultCascadeListForLanguages + 97
    16  ???                                 0x0000000140eaefd3 0x0 + 5384105939
    17  ???                                 0x0000000140eae761 0x0 + 5384103777
    18  ???                                 0x000000013c9c8e74 0x0 + 5311860340
    19  monotouchtest                       0x000000010fcb0c89 mono_jit_runtime_invoke + 1273
    20  monotouchtest                       0x000000010fd6e3a8 do_runtime_invoke + 88
    21  monotouchtest                       0x000000010fd71bac mono_runtime_try_invoke_array + 1292
    22  monotouchtest                       0x000000010fd15587 ves_icall_InternalInvoke + 647
    23  ???                                 0x000000013e9fcd13 0x0 + 5345627411
    24  ???                                 0x000000013e9fc738 0x0 + 5345625912
    25  ???                                 0x000000013e9fded5 0x0 + 5345631957
    26  ???                                 0x000000013e9fbb76 0x0 + 5345622902
    27  ???                                 0x000000013e9e237e 0x0 + 5345518462
    28  ???                                 0x000000013e9e237e 0x0 + 5345518462
    29  ???                                 0x000000013e9e237e 0x0 + 5345518462
    30  ???                                 0x000000013e9e237e 0x0 + 5345518462
    31  ???                                 0x000000013e873006 0x0 + 5344014342
    32  monotouchtest                       0x000000010fcb0c89 mono_jit_runtime_invoke + 1273
    33  monotouchtest                       0x000000010fd6e3a8 do_runtime_invoke + 88
    34  monotouchtest                       0x000000010fd6e320 mono_runtime_invoke + 208
    35  monotouchtest                       0x000000010fe71af1 xamarin_invoke_trampoline + 5617
    36  monotouchtest                       0x000000010fe79ddd xamarin_arch_trampoline + 189
    37  monotouchtest                       0x000000010fe7b1a1 xamarin_x86_64_common_trampoline + 110
    38  UIKit                               0x0000000111b9876b -[UITableView _selectRowAtIndexPath:animated:scrollPosition:notifyDelegate:] + 1810
    39  UIKit                               0x0000000111b98986 -[UITableView _userSelectRowAtPendingSelectionIndexPath:] + 344
    40  UIKit                               0x0000000111a6b5c9 _runAfterCACommitDeferredBlocks + 318
    41  UIKit                               0x0000000111a59dad _cleanUpAfterCAFlushAndRunDeferredBlocks + 280
    42  UIKit                               0x0000000111a89f68 _afterCACommitHandler + 137
    43  CoreFoundation                      0x000000011de3ddb7 __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 23
    44  CoreFoundation                      0x000000011de3dd0e __CFRunLoopDoObservers + 430
    45  CoreFoundation                      0x000000011de22324 __CFRunLoopRun + 1572
    46  CoreFoundation                      0x000000011de21a89 CFRunLoopRunSpecific + 409
    47  GraphicsServices                    0x0000000121b7e9c6 GSEventRunModal + 62
    48  UIKit                               0x0000000111a5f7d0 UIApplicationMain + 159
    49  ???                                 0x000000013c9c4474 0x0 + 5311841396
    50  ???                                 0x000000013c9c40ad 0x0 + 5311840429
    =================================================================
    Got a SIGSEGV while executing native code. This usually indicates
    a fatal error in the mono runtime or one of the native libraries
    used by your application.
    =================================================================