### PR TITLE
[monotouch-test] Don't subclass MKMapView.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -1427,10 +1427,12 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 		}
 
-		public class NativeObjectArrayType : MKMapView
+		public class NativeObjectArrayType : NSObject
 		{
 			public IMKAnnotation[] Annotations;
-			public override void AddAnnotations(params IMKAnnotation[] annotations)
+
+			[Export ("addAnnotations:")]
+			public void AddAnnotations (params IMKAnnotation[] annotations)
 			{
 				this.Annotations = annotations;
 			}


### PR DESCRIPTION
MKMapView doesn't like being subclassed (Apple says "you should not subclass the MKMapView class itself").

Bad things like this starts happening:

    Thread 0 name:  tid_303  Dispatch queue: com.apple.main-thread
    Thread 0 Crashed:
    0   libsystem_kernel.dylib        	0x0000000186b25348 __pthread_kill + 8
    1   libsystem_pthread.dylib       	0x0000000186c39354 pthread_kill$VARIANT$mp + 396
    2   libsystem_c.dylib             	0x0000000186a94fd8 abort + 140
    3   monotouchtest                 	0x0000000101c02c14 mono_handle_native_crash + 22047764 (mini-exceptions.c:2548)
    4   monotouchtest                 	0x0000000101c0d02c mono_sigsegv_signal_handler + 22089772 (mini-runtime.c:2886)
    5   libsystem_platform.dylib      	0x0000000186c33b60 _sigtramp + 52
    6   CoreFoundation                	0x0000000186f93108 cow_cleanup + 112
    7   CoreFoundation                	0x0000000186f93108 cow_cleanup + 112
    8   CoreFoundation                	0x0000000186eda51c -[__NSArrayM dealloc] + 68
    9   CoreFoundation                	0x000000018703f5c8 __CFBasicHashDrain + 312
    10  CoreFoundation                	0x0000000186fb5b44 _CFRelease + 224
    11  CoreText                      	0x000000018a808404 TDescriptorSource::PurgeFontFallbacksCache+ 488452 () + 92
    12  CoreText                      	0x000000018a808374 TDescriptorSource::PurgeFromCaches+ 488308 (__CFURL const*) const + 176
    13  CoreText                      	0x000000018a7eec74 CTFontRemoveFromCaches + 168
    14  VectorKit                     	0x0000000196a539b0 +[VKSharedResourcesManager removeResourceUser:] + 324
    15  VectorKit                     	0x0000000196ca27a4 md::MapEngine::~MapEngine+ 2643876 () + 360
    16  VectorKit                     	0x0000000196ca2634 md::MapEngine::~MapEngine+ 2643508 () + 12
    17  libobjc.A.dylib               	0x000000018651eef4 object_cxxDestructFromClass+ 28404 (objc_object*, objc_class*) + 148
    18  libobjc.A.dylib               	0x000000018652c638 objc_destructInstance + 88
    19  libobjc.A.dylib               	0x000000018652c690 object_dispose + 16
    20  QuartzCore                    	0x000000018afca3ac -[CALayer dealloc] + 116
    21  VectorKit                     	0x0000000196a43294 -[VKMapView dealloc] + 940
    22  QuartzCore                    	0x000000018af6aafc CA::release_objects+ 744188 (X::List<void const*>*) + 32
    23  QuartzCore                    	0x000000018afd97d8 CA::Layer::~Layer+ 1198040 () + 276
    24  QuartzCore                    	0x000000018afca37c -[CALayer dealloc] + 68
    25  QuartzCore                    	0x000000018af6b16c CA::Transaction::commit+ 745836 () + 1052
    26  UIKit                         	0x0000000190393290 _afterCACommitHandler + 256
    27  CoreFoundation                	0x0000000186fb38b8 __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 32
    28  CoreFoundation                	0x0000000186fb1270 __CFRunLoopDoObservers + 412
    29  CoreFoundation                	0x0000000186fb182c __CFRunLoopRun + 1292
    30  CoreFoundation                	0x0000000186ed22d8 CFRunLoopRunSpecific + 436
    31  GraphicsServices              	0x0000000188d58f84 GSEventRunModal + 100
    32  UIKit                         	0x000000019040427c UIApplicationMain + 208
    33  monotouchtest                 	0x000000010106eb90 wrapper_managed_to_native_UIKit_UIApplication_UIApplicationMain_int_string___intptr_intptr + 9907088 (/<unknown>:1)
    34  monotouchtest                 	0x0000000100f0d6ac UIKit_UIApplication_Main_string___intptr_intptr + 8459948 (UIApplication.cs:79)
    35  monotouchtest                 	0x0000000100f0d66c UIKit_UIApplication_Main_string___string_string + 8459884 (UIApplication.cs:63)
    36  monotouchtest                 	0x0000000100b10450 monotouchtest_Application_Main_string__ + 4277328 (Main.cs:27)
    37  monotouchtest                 	0x0000000100e0c244 wrapper_runtime_invoke_object_runtime_invoke_dynamic_intptr_intptr_intptr_intptr + 244
    38  monotouchtest                 	0x0000000101c10048 mono_jit_runtime_invoke + 22102088 (mini-runtime.c:2526)
    39  monotouchtest                 	0x0000000101c75eec do_runtime_invoke + 22519532 (object.c:2829)
    40  monotouchtest                 	0x0000000101c78a3c do_exec_main_checked + 22530620 (object.c:4623)
    41  monotouchtest                 	0x0000000101bf9a1c mono_jit_exec + 22010396 (driver.g.c:1040)
    42  monotouchtest                 	0x0000000101d13d60 xamarin_main + 23166304 (monotouch-main.m:482)
    43  monotouchtest                 	0x00000001007de710 main + 927504 (main.m:67)
    44  libdyld.dylib                 	0x00000001869f656c start + 4