### PR TITLE
[introspection] Let SkipDueToAttributeInProperty skip setters too

### DIFF
--- a/tests/introspection/ApiBaseTest.cs
+++ b/tests/introspection/ApiBaseTest.cs
@@ -172,14 +172,13 @@ namespace Introspection {
 			var m = member as MethodInfo;
 
 			if (m == null || // Skip anything that is not a method
-			    !m.Attributes.HasFlag (MethodAttributes.SpecialName) ||
-			    !m.Name.Contains ("get_")) // We want getters with SpecialName Attribute
+			    !m.Attributes.HasFlag (MethodAttributes.SpecialName)) // We want properties with SpecialName Attribute
 				return false;
 
 			// FIXME: In the future we could cache this to reduce memory requirements
 			var property = m.DeclaringType
 			                .GetProperties ()
-			                .SingleOrDefault (p => p.GetGetMethod () == m);
+			                .SingleOrDefault (p => p.GetGetMethod () == m || p.GetSetMethod () == m);
 			return property != null && SkipDueToAttribute (property);
 		}
 


### PR DESCRIPTION
`SkipDueToAttributeInProperty` which is used to check the availability attribute of properties
when the Availability info only exist on the property and not on the property Getter or Setter was wrong.
This lead to `setSpringLoaded` (which was introduced in iOS 11) to not be ignored by the test (making it fail).

- Fix bug #59085: [introspection-ios] selector not found for UIKit.UIBarButtonItem : setSpringLoaded: - Broken test
(https://bugzilla.xamarin.com/show_bug.cgi?id=59085)