### PR TITLE
[storekit] Fix CampaignToken typo

### DIFF
--- a/src/StoreKit/StoreProductParameters.cs
+++ b/src/StoreKit/StoreProductParameters.cs
@@ -76,10 +76,10 @@ namespace XamCore.StoreKit {
 
 		public string CampaignToken {
 			get {
-				return GetStringValue (SKStoreProductParameterKey.AffiliateToken);
+				return GetStringValue (SKStoreProductParameterKey.CampaignToken);
 			}
 			set {
-				SetStringValue (SKStoreProductParameterKey.AffiliateToken, value);
+				SetStringValue (SKStoreProductParameterKey.CampaignToken, value);
 			}
 		}
 #endif


### PR DESCRIPTION
- Fixes bug #59078: StoreProductParameters and invalid property for CampaignToken
(https://bugzilla.xamarin.com/show_bug.cgi?id=59078)