### PR TITLE
[ModelIO] Fix MDLVoxelIndexExtent struct.

### DIFF
--- a/runtime/bindings-generator.cs
+++ b/runtime/bindings-generator.cs
@@ -2004,6 +2004,38 @@ namespace Xamarin.BindingMethods.Generator
 				}
 			);
 
+			data.Add (
+				new FunctionData {
+					Comment = " // MDLVoxelIndexExtent2 func ()",
+					Prefix = "simd__",
+					Variants = Variants.All,
+					ReturnType = Types.MDLVoxelIndexExtent2,
+				}
+			);
+
+			data.Add (
+				new FunctionData {
+					Comment = " // void func (MDLVoxelIndexExtent2)",
+					Prefix = "simd__",
+					Variants = Variants.NonStret,
+					Parameters = new ParameterData [] {
+						new ParameterData { TypeData = Types.MDLVoxelIndexExtent2 },
+					},
+				}
+			);
+
+			data.Add (
+				new FunctionData {
+					Comment = " // IntPtr func (MDLVoxelIndexExtent2)",
+					Prefix = "simd__",
+					Variants = Variants.NonStret,
+					ReturnType = Types.IntPtr,
+					Parameters = new ParameterData [] {
+						new ParameterData { TypeData = Types.MDLVoxelIndexExtent2 },
+					},
+				}
+			);
+
 			// We must expand functions with native types to their actual type as well.
 			for (int i = data.Count - 1; i >= 0; i--) {
 				if (!data [i].HasNativeType)
@@ -2122,6 +2154,16 @@ namespace Xamarin.BindingMethods.Generator
 				writer.WriteLine ("\t{0}{2}maxPixelValue.c = {1}.maxPixelValue [2];", managedVariable, nativeVariable, accessor);
 				writer.WriteLine ("\t{0}{2}maxPixelValue.d = {1}.maxPixelValue [3];", managedVariable, nativeVariable, accessor);
 				break;
+			case "MDLVoxelIndexExtent2":
+				writer.WriteLine ("\t{0}{2}minimumExtent.a = {1}.minimumExtent [0];", managedVariable, nativeVariable, accessor);
+				writer.WriteLine ("\t{0}{2}minimumExtent.b = {1}.minimumExtent [1];", managedVariable, nativeVariable, accessor);
+				writer.WriteLine ("\t{0}{2}minimumExtent.c = {1}.minimumExtent [2];", managedVariable, nativeVariable, accessor);
+				writer.WriteLine ("\t{0}{2}minimumExtent.d = {1}.minimumExtent [3];", managedVariable, nativeVariable, accessor);
+				writer.WriteLine ("\t{0}{2}maximumExtent.a = {1}.maximumExtent [0];", managedVariable, nativeVariable, accessor);
+				writer.WriteLine ("\t{0}{2}maximumExtent.b = {1}.maximumExtent [1];", managedVariable, nativeVariable, accessor);
+				writer.WriteLine ("\t{0}{2}maximumExtent.c = {1}.maximumExtent [2];", managedVariable, nativeVariable, accessor);
+				writer.WriteLine ("\t{0}{2}maximumExtent.d = {1}.maximumExtent [3];", managedVariable, nativeVariable, accessor);
+				break;
 			default:
 				throw new NotImplementedException (string.Format ("MarshalToManaged for: NativeType: {0} ManagedType: {1}", type.NativeType, type.ManagedType));
 			}
@@ -2227,6 +2269,16 @@ namespace Xamarin.BindingMethods.Generator
 				writer.WriteLine ("\t{0}.maxPixelValue [1] = {1}{2}maxPixelValue.b;", nativeVariable, managedVariable, accessor);
 				writer.WriteLine ("\t{0}.maxPixelValue [2] = {1}{2}maxPixelValue.c;", nativeVariable, managedVariable, accessor);
 				writer.WriteLine ("\t{0}.maxPixelValue [3] = {1}{2}maxPixelValue.d;", nativeVariable, managedVariable, accessor);
+				break;
+			case "MDLVoxelIndexExtent2":
+				writer.WriteLine ("\t{0}.minimumExtent [0] = {1}{2}minimumExtent.a;", nativeVariable, managedVariable, accessor);
+				writer.WriteLine ("\t{0}.minimumExtent [1] = {1}{2}minimumExtent.b;", nativeVariable, managedVariable, accessor);
+				writer.WriteLine ("\t{0}.minimumExtent [2] = {1}{2}minimumExtent.c;", nativeVariable, managedVariable, accessor);
+				writer.WriteLine ("\t{0}.minimumExtent [3] = {1}{2}minimumExtent.d;", nativeVariable, managedVariable, accessor);
+				writer.WriteLine ("\t{0}.maximumExtent [0] = {1}{2}maximumExtent.a;", nativeVariable, managedVariable, accessor);
+				writer.WriteLine ("\t{0}.maximumExtent [1] = {1}{2}maximumExtent.b;", nativeVariable, managedVariable, accessor);
+				writer.WriteLine ("\t{0}.maximumExtent [2] = {1}{2}maximumExtent.c;", nativeVariable, managedVariable, accessor);
+				writer.WriteLine ("\t{0}.maximumExtent [3] = {1}{2}maximumExtent.d;", nativeVariable, managedVariable, accessor);
 				break;
 			default:
 				throw new NotImplementedException (string.Format ("MarshalToNative for: NativeType: {0} ManagedType: {1}", type.NativeType, type.ManagedType));
@@ -2840,6 +2892,15 @@ namespace Xamarin.BindingMethods.Generator
 				IsX64Stret = true,
 			};
 
+			public static TypeData MDLVoxelIndexExtent2 = new TypeData {
+				ManagedType = "MDLVoxelIndexExtent2",
+				NativeType = "MDLVoxelIndexExtent",
+				NativeWrapperType = "struct MDLVoxelIndexExtentWrapper",
+				RequireMarshal = true,
+				IsARMStret = true,
+				IsX86Stret = true,
+				IsX64Stret = true,
+			};
 		}
 	}
 

--- a/runtime/bindings.h
+++ b/runtime/bindings.h
@@ -113,6 +113,12 @@ typedef struct
     vector_float4   maxPixelValue;
 } MPSImageHistogramInfo;
 
+typedef vector_int4 MDLVoxelIndex;
+typedef struct {
+    MDLVoxelIndex minimumExtent;
+    MDLVoxelIndex maximumExtent;
+} MDLVoxelIndexExtent;
+
 /*
  * iOS has a vector type (vector_float3) which can't be expressed
  * in P/Invoke signatures, so we need custom wrappers.
@@ -198,6 +204,13 @@ struct MPSImageHistogramInfoWrapper {
 #endif
 	Vector4f minPixelValue;
 	Vector4f maxPixelValue;
+};
+
+typedef Vector4i MDLVoxelIndexWrapper;
+
+struct MDLVoxelIndexExtentWrapper {
+    MDLVoxelIndexWrapper minimumExtent;
+    MDLVoxelIndexWrapper maximumExtent;
 };
 
 static_assert (sizeof (MPSImageHistogramInfoWrapper) == sizeof (MPSImageHistogramInfo), "Sizes aren't equal");

--- a/src/ModelIO/MIEnums.cs
+++ b/src/ModelIO/MIEnums.cs
@@ -252,7 +252,7 @@ namespace XamCore.ModelIO {
 	}
 
 #if !XAMCORE_4_0
-	[Obsolete ("Use 'MDLVoxelIndexExtent2' instead")]
+	[Obsolete ("Use 'MDLVoxelIndexExtent2' instead.")]
 	[StructLayout(LayoutKind.Sequential)]
 	public struct MDLVoxelIndexExtent {
 		public MDLVoxelIndexExtent (Vector4 minimumExtent, Vector4 maximumExtent)

--- a/src/ModelIO/MIEnums.cs
+++ b/src/ModelIO/MIEnums.cs
@@ -18,6 +18,7 @@ using XamCore.ObjCRuntime;
 using Vector2 = global::OpenTK.Vector2;
 using Vector3 = global::OpenTK.Vector3;
 using Vector4 = global::OpenTK.Vector4;
+using Vector4i = global::OpenTK.Vector4i;
 using Matrix2 = global::OpenTK.Matrix2;
 using Matrix3 = global::OpenTK.Matrix3;
 using Matrix4 = global::OpenTK.Matrix4;
@@ -250,6 +251,8 @@ namespace XamCore.ModelIO {
 		Environment
 	}
 
+#if !XAMCORE_4_0
+	[Obsolete ("Use 'MDLVoxelIndexExtent2' instead")]
 	[StructLayout(LayoutKind.Sequential)]
 	public struct MDLVoxelIndexExtent {
 		public MDLVoxelIndexExtent (Vector4 minimumExtent, Vector4 maximumExtent)
@@ -258,6 +261,27 @@ namespace XamCore.ModelIO {
 			this.MaximumExtent = maximumExtent;
 		}
 		public Vector4 MinimumExtent, MaximumExtent;
+	}
+#endif
+
+	[StructLayout(LayoutKind.Sequential)]
+#if XAMCORE_4_0
+	public struct MDLVoxelIndexExtent {
+#else
+	public struct MDLVoxelIndexExtent2 {
+#endif
+		public Vector4i MinimumExtent { get; private set; }
+		public Vector4i MaximumExtent { get; private set; }
+
+#if XAMCORE_4_0
+		public MDLVoxelIndexExtent (Vector4i minimumExtent, Vector4i maximumExtent)
+#else
+		public MDLVoxelIndexExtent2 (Vector4i minimumExtent, Vector4i maximumExtent)
+#endif
+		{
+			this.MinimumExtent = minimumExtent;
+			this.MaximumExtent = maximumExtent;
+		}
 	}
 
 	[Native]

--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -1895,9 +1895,20 @@ namespace XamCore.ModelIO {
 		[Export ("setVoxelsForMesh:divisions:interiorNBWidth:exteriorNBWidth:patchRadius:")]
 		void SetVoxels (MDLMesh mesh, int divisions, float interiorNBWidth, float exteriorNBWidth, float patchRadius);
 
+#if !XAMCORE_4_0
+		[Obsolete ("Use 'GetVoxels (MDLVoxelIndexExtent2)' instead.")]
+#endif
 		[Export ("voxelsWithinExtent:")]
 		[return: NullAllowed]
 		NSData GetVoxels (MDLVoxelIndexExtent withinExtent);
+
+#if !XAMCORE_4_0
+		[Sealed]
+		[Export ("voxelsWithinExtent:")]
+		[return: NullAllowed]
+		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+		NSData GetVoxels (MDLVoxelIndexExtent2 withinExtent);
+#endif
 
 		[Export ("voxelIndices")]
 		[return: NullAllowed]
@@ -1927,8 +1938,20 @@ namespace XamCore.ModelIO {
 		[Export ("count")]
 		nuint Count { get; }
 
+#if !XAMCORE_4_0
+		[Obsolete ("Use 'VoxelIndexExtent2' instead.")]
+#endif
 		[Export ("voxelIndexExtent")]
 		MDLVoxelIndexExtent VoxelIndexExtent { get; }
+
+#if !XAMCORE_4_0
+		[Export ("voxelIndexExtent")]
+		[Sealed]
+		MDLVoxelIndexExtent2 VoxelIndexExtent2 {
+			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
+			get;
+		}
+#endif
 
 		[Export ("boundingBox")]
 		MDLAxisAlignedBoundingBox BoundingBox {

--- a/tests/monotouch-test/ModelIO/MDLVoxelArrayTest.cs
+++ b/tests/monotouch-test/ModelIO/MDLVoxelArrayTest.cs
@@ -1,0 +1,83 @@
+﻿//
+// MDLAssert Unit Tests
+//
+// Authors:
+//	Rolf Bjarne Kvinge <rolf@xamarin.com>
+//
+// Copyright 2017 Microsoft Inc.
+//
+
+#if !__WATCHOS__
+
+using System;
+#if XAMCORE_2_0
+using CoreGraphics;
+using Foundation;
+#if !MONOMAC
+using UIKit;
+#endif
+#if !__TVOS__
+using MultipeerConnectivity;
+#endif
+using ModelIO;
+using ObjCRuntime;
+#else
+using MonoTouch.CoreGraphics;
+using MonoTouch.Foundation;
+#if !__TVOS__
+using MonoTouch.MultipeerConnectivity;
+#endif
+using MonoTouch.UIKit;
+using MonoTouch.ModelIO;
+using MonoTouch.ObjCRuntime;
+#endif
+using OpenTK;
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.ModelIO
+{
+
+	[TestFixture]
+	// we want the test to be available if we use the linker
+	[Preserve (AllMembers = true)]
+	public class MDLVoxelArrayTest
+	{
+		[TestFixtureSetUp]
+		public void Setup ()
+		{
+			TestRuntime.AssertXcodeVersion (7, 0);
+		}
+
+		[Test]
+		public void BoundingBoxTest ()
+		{
+			MDLAxisAlignedBoundingBox box = new MDLAxisAlignedBoundingBox (
+				new Vector3 (4, 5, 6),
+				new Vector3 (1, 2, 3)
+			);
+			using (var data = new NSData ()) {
+				using (var obj = new MDLVoxelArray (data, box, 1.0f)) {
+					Asserts.AreEqual (box, obj.BoundingBox, "BoundingBox");
+
+					var extents = new MDLVoxelIndexExtent2 (
+						new Vector4i (1, 2, 3, 4),
+						new Vector4i (5, 6, 7, 8));
+					var voxels = obj.GetVoxels (extents);
+					Assert.IsNull (voxels, "GetVoxels");
+
+					extents = obj.VoxelIndexExtent2;
+					Asserts.AreEqual (-1, extents.MaximumExtent.X, "MaxX");
+					Asserts.AreEqual (-1, extents.MaximumExtent.Y, "MaxY");
+					Asserts.AreEqual (-1, extents.MaximumExtent.Z, "MaxZ");
+					Asserts.AreEqual (0, extents.MaximumExtent.W, "MaxW");
+					Asserts.AreEqual (0, extents.MinimumExtent.X, "MinX");
+					Asserts.AreEqual (0, extents.MinimumExtent.Y, "MinY");
+					Asserts.AreEqual (0, extents.MinimumExtent.Z, "MinZ");
+					Asserts.AreEqual (0, extents.MinimumExtent.W, "MinW");
+				}
+			}
+		}
+	}
+}
+
+#endif // !__WATCHOS__

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -664,6 +664,7 @@
     <Compile Include="MetalPerformanceShaders\MPSImageHistogramEqualizationTest.cs" />
     <Compile Include="MetalPerformanceShaders\MPSImageHistogramSpecificationTest.cs" />
     <Compile Include="ModelIO\MDLAssetTest.cs" />
+    <Compile Include="ModelIO\MDLVoxelArrayTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
The MDLVoxelIndexExtent is a struct containing two 4-dimensional vectors of
integers (not floats, as originally and incorrectly implemented).

Fix this my creating a new MDLVoxelIndexExtent2 struct with the right fields,
re-implement all the API that exposes this struct and obsolete the old API.

Also add missing [MarshalDirective] attributes.

And write a test to make sure it works fine now and forever.