### PR TITLE
[ARKit] Fix marshalling for ARPointCloud.RawFeaturePoints.

### DIFF
--- a/src/ARKit/ARPointCloud.cs
+++ b/src/ARKit/ARPointCloud.cs
@@ -20,9 +20,11 @@ namespace XamCore.ARKit {
 			get {
 				var count = (int)Count;
 				var rv = new Vector3 [count];
-				var ptr = (Vector3*)GetRawPoints ();
-				for (int i = 0; i < count; i++)
-					rv [i] = *ptr++;
+				var ptr = GetRawPoints ();
+				for (int i = 0; i < count; i++) {
+					rv [i] = *(Vector3 *) ptr;
+					ptr += 16; // 3 floats + 1 padding float = 16 bytes
+				}
 				return rv;
 			}
 		}

--- a/tests/monotouch-test/ARKit/ARPointCloudTest.cs
+++ b/tests/monotouch-test/ARKit/ARPointCloudTest.cs
@@ -25,7 +25,7 @@ namespace MonoTouchFixtures.ARKit {
 
 		GCHandle vectorArrayHandle;
 		GCHandle identifiersHandle;
-		Vector3 [] vectorArray;
+		Vector4 [] vectorArray;
 		ulong [] identifiers;
 
 		public ARPointCloudPoker () : base (IntPtr.Zero)
@@ -40,7 +40,7 @@ namespace MonoTouchFixtures.ARKit {
 
 		protected unsafe override IntPtr GetRawPoints ()
 		{
-			vectorArray = new Vector3 [] { new Vector3 (1, 2, 3), new Vector3 (4, 5, 6) };
+			vectorArray = new Vector4 [] { new Vector4 (1, 2, 3, -1), new Vector4 (4, 5, 6, -1) };
 			if (!vectorArrayHandle.IsAllocated)
 				vectorArrayHandle = GCHandle.Alloc (vectorArray, GCHandleType.Pinned);
 			Vector3* addr = (Vector3*)vectorArrayHandle.AddrOfPinnedObject ();


### PR DESCRIPTION
ARPointCloud.RawFeaturePoints is an array of Vector3, but each vector is
16-byte aligned (as if it were an array of Vector4).

This means we need to account for this when creating a managed array from
pointer to the native C-style array.