### PR TITLE
[VSTS] --no-sudo option in system-dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,16 @@ else
 endif
 endif
 
+package:
+	mkdir -p ../package
+	$(MAKE) -C ../maccore package
+	# copy .pkg, .zip and *updateinfo to the packages directory to be uploaded to storage
+	cp ../maccore/release/*.pkg ../package
+	-cp ../maccore/release/*.zip ../package
+	-cp ../maccore/release/*updateinfo ../package
+	-cp ../maccore/tests/*.zip ../package
+	-cp ../xamarin-macios/tests/*.zip ../package
+
 install-system: install-system-ios install-system-mac
 	@# Clean up some old files
 	$(Q) rm -Rf /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/iOS

--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -4,10 +4,14 @@ set -o pipefail
 
 FAIL=
 PROVISION_DOWNLOAD_DIR=/tmp/x-provisioning
-
+SUDO=sudo
 # parse command-line arguments
 while ! test -z $1; do
 	case $1 in
+		--no-sudo)
+			SUDO=
+			shift
+			;;
 		--provision-xcode)
 			PROVISION_XCODE=1
 			shift
@@ -159,7 +163,7 @@ function install_mono () {
 	curl -L $MONO_URL > $MONO_PKG
 
 	log "Installing Mono $MIN_MONO_VERSION from $MONO_URL..."
-	sudo installer -pkg $MONO_PKG -target /
+	$SUDO installer -pkg $MONO_PKG -target /
 
 	rm -f $MONO_PKG
 }
@@ -184,9 +188,9 @@ function install_visual_studio () {
 	log "Mounting $VS_DMG into $VS_MOUNTPOINT..."
 	hdiutil attach $VS_DMG -mountpoint $VS_MOUNTPOINT -quiet -nobrowse
 	log "Removing previous Visual Studio from $VS"
-	sudo rm -Rf "$VS"
+	$SUDO rm -Rf "$VS"
 	log "Installing Visual Studio $MIN_VISUAL_STUDIO_VERSION to $VS..."
-	sudo cp -R "$VS_MOUNTPOINT/Visual Studio.app" /Applications
+	$SUDO cp -R "$VS_MOUNTPOINT/Visual Studio.app" /Applications
 	log "Unmounting $VS_DMG..."
 	hdiutil detach $VS_MOUNTPOINT -quiet
 
@@ -247,11 +251,11 @@ function install_specific_xcode () {
 	rm -f $XCODE_DMG
 
 	log "Removing any com.apple.quarantine attributes from the installed Xcode"
-	sudo xattr -d -r com.apple.quarantine $XCODE_ROOT
+	$SUDO xattr -d -r com.apple.quarantine $XCODE_ROOT
 
 	if is_at_least_version $XCODE_VERSION 5.0; then
 		log "Accepting Xcode license"
-		sudo $XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -license accept
+		$SUDO $XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -license accept
 	fi
 
 	if is_at_least_version $XCODE_VERSION 8.0; then
@@ -259,7 +263,7 @@ function install_specific_xcode () {
 		for pkg in $PKGS; do
 			if test -f "$XCODE_DEVELOPER_ROOT/../Resources/Packages/$pkg"; then
 				log "Installing $pkg"
-				sudo /usr/sbin/installer -dumplog -verbose -pkg "$XCODE_DEVELOPER_ROOT/../Resources/Packages/$pkg" -target /
+				$SUDO /usr/sbin/installer -dumplog -verbose -pkg "$XCODE_DEVELOPER_ROOT/../Resources/Packages/$pkg" -target /
 				log "Installed $pkg"
 			else
 				log "Not installing $pkg because it doesn't exist."
@@ -267,8 +271,8 @@ function install_specific_xcode () {
 		done
 	fi
 
-	log "Executing 'sudo xcode-select -s $XCODE_DEVELOPER_ROOT'"
-	sudo xcode-select -s $XCODE_DEVELOPER_ROOT
+	log "Executing '$SUDO xcode-select -s $XCODE_DEVELOPER_ROOT'"
+	$SUDO xcode-select -s $XCODE_DEVELOPER_ROOT
 
 	ok "Xcode $XCODE_VERSION provisioned"
 }
@@ -295,9 +299,9 @@ function check_specific_xcode () {
 		if is_at_least_version $XCODE_VERSION 5.0; then
 			if ! $XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -license check >/dev/null 2>&1; then
 				if ! test -z $PROVISION_XCODE; then
-					sudo $XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -license accept
+					$SUDO $XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -license accept
 				else
-					fail "The license for Xcode $XCODE_VERSION has not been accepted. Execute 'sudo $XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild' to review the license and accept it."
+					fail "The license for Xcode $XCODE_VERSION has not been accepted. Execute '$SUDO $XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild' to review the license and accept it."
 				fi
 				return
 			fi
@@ -314,10 +318,10 @@ function check_specific_xcode () {
 	local XCODE_SELECT=$(xcode-select -p)
 	if [[ "x$XCODE_SELECT" != "x$XCODE_DEVELOPER_ROOT" ]]; then
 		if ! test -z $PROVISION_XCODE; then
-			log "Executing 'sudo xcode-select -s $XCODE_DEVELOPER_ROOT'"
-			sudo xcode-select -s $XCODE_DEVELOPER_ROOT
+			log "Executing '$SUDO xcode-select -s $XCODE_DEVELOPER_ROOT'"
+			$SUDO xcode-select -s $XCODE_DEVELOPER_ROOT
 		else
-			fail "'xcode-select -p' does not point to $XCODE_DEVELOPER_ROOT, it points to $XCODE_SELECT. Execute 'sudo xcode-select -s $XCODE_DEVELOPER_ROOT' to fix."
+			fail "'xcode-select -p' does not point to $XCODE_DEVELOPER_ROOT, it points to $XCODE_SELECT. Execute '$SUDO xcode-select -s $XCODE_DEVELOPER_ROOT' to fix."
 		fi
 	fi
 
@@ -596,3 +600,4 @@ else
 	echo "System check failed"
 	exit 1
 fi
+


### PR DESCRIPTION
I removed the product signing scripts and only have changes specific to this repo (provisioning and packaging). Eventually I'll be adding Bockover's provisionator bootstrap scripts, but these preliminary changes will provide green master builds on VSTS.

https://devdiv.visualstudio.com/DevDiv/Default/_build/index?buildId=956611&_a=summary