### PR TITLE
[wkwebkit] Fix (native) protocol names

### DIFF
--- a/src/wkwebkit.cs
+++ b/src/wkwebkit.cs
@@ -316,7 +316,7 @@ namespace XamCore.WebKit
 #if XAMCORE_2_0
 	interface IWKUrlSchemeHandler {}
 	[Mac (10,13), iOS (11,0)]
-	[Protocol]
+	[Protocol (Name = "WKURLSchemeHandler")]
 	interface WKUrlSchemeHandler
 	{
 		[Abstract]
@@ -331,7 +331,7 @@ namespace XamCore.WebKit
 	interface IWKUrlSchemeTask {}
 
 	[Mac (10,13), iOS (11,0)]
-	[Protocol]
+	[Protocol (Name = "WKURLSchemeTask")]
 	interface WKUrlSchemeTask
 	{
 		[Abstract]

--- a/tests/xtro-sharpie/common.pending
+++ b/tests/xtro-sharpie/common.pending
@@ -675,3 +675,10 @@
 !missing-selector! MLFeatureDescription::setDictionaryConstraint: not bound
 !missing-selector! MLFeatureDescription::setImageConstraint: not bound
 !missing-selector! MLFeatureDescription::setMultiArrayConstraint: not bound
+
+
+# WekKit
+
+## 34185961 The header WKSnapshotConfiguration.h is not included inside the umbrella WebKit.h
+!unknown-type! WKSnapshotConfiguration bound
+


### PR DESCRIPTION
Also ignore xtro's WKSnapshotConfiguration since it's an Apple bug 34185961

reference (xtro)
!missing-protocol! WKURLSchemeHandler not bound
!missing-protocol! WKURLSchemeTask not bound
!unknown-protocol! WKUrlSchemeHandler bound
!unknown-protocol! WKUrlSchemeTask bound

!unknown-type! WKSnapshotConfiguration bound