### PR TITLE
[introspection] Make sure '[FAIL]' is printed before every failure.

### DIFF
--- a/tests/introspection/ApiBaseTest.cs
+++ b/tests/introspection/ApiBaseTest.cs
@@ -66,6 +66,8 @@ namespace Introspection {
 		protected void AddErrorLine (string line)
 		{
 			error_output.AppendLine (line);
+			if (!line.StartsWith ("[FAIL] ", StringComparison.Ordinal))
+				Console.Error.Write ("[FAIL] ");
 			Console.Error.WriteLine (line);
 			Errors++;
 		}


### PR DESCRIPTION
This makes xharness able to list the failures in the inline summary.