### PR TITLE
[foundation] xtro fixes for watchOS

### DIFF
--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -1113,12 +1113,14 @@ namespace XamCore.Foundation  {
 		}
 	}
 
-#if MONOMAC
+	[Mac (10,10,3)]
+	[Watch (4,0)]
+	[TV (11,0)]
+	[iOS (11,0)]
 	[Native]
 	public enum NSProcessInfoThermalState : nint {
 		Nominal, Fair, Serious, Critical
 	}
-#endif
 
 	[Native]
 #if XAMCORE_2_0

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -4920,6 +4920,7 @@ namespace XamCore.Foundation
 	[Since (5,0)]
 	[BaseType (typeof (NSObject))]
 #if WATCH
+	[Advice ("Not available on watchOS")]
 	[DisableDefaultCtor] // "NSUbiquitousKeyValueStore is unavailable" is printed to the log.
 #endif
 	interface NSUbiquitousKeyValueStore {
@@ -9756,7 +9757,8 @@ namespace XamCore.Foundation
 		[Export ("preferredPresentationSize", ArgumentSemantic.Assign)]
 		CGSize PreferredPresentationSize { get; set; }
 
-		[NoWatch, NoTV]
+		[Watch (4,0)]
+		[TV (11,0)]
 		[iOS (11,0)]
 		[Export ("preferredPresentationStyle", ArgumentSemantic.Assign)]
 		UIPreferredPresentationStyle PreferredPresentationStyle { get; set; }
@@ -11397,16 +11399,20 @@ namespace XamCore.Foundation
 		NSString PowerStateDidChangeNotification { get; }
 #endif
 
-#if MONOMAC
 		[Mac (10,10,3)]
+		[Watch (4,0)]
+		[TV (11, 0)]
+		[iOS (11,0)]
 		[Export ("thermalState")]
 		NSProcessInfoThermalState ThermalState { get; }
 
 		[Mac (10,10,3)]
 		[Field ("NSProcessInfoThermalStateDidChangeNotification")]
+		[Watch (4,0)]
+		[TV (11, 0)]
+		[iOS (11,0)]
 		[Notification]
 		NSString ThermalStateDidChangeNotification { get; }
-#endif
 	}
 
 	[NoWatch][NoTV][NoiOS]

--- a/tests/xtro-sharpie/watchos.pending
+++ b/tests/xtro-sharpie/watchos.pending
@@ -69,6 +69,12 @@
 !missing-protocol-conformance! CMSensorDataList should conform to NSFastEnumeration
 
 
+# Foundation
+
+## type was not marked as unavailable before Xcode9
+!unknown-type! NSUbiquitousKeyValueStore bound
+
+
 # HealthKit
 
 ## deprecated API (removed in same version it was added)


### PR DESCRIPTION
!missing-enum! NSProcessInfoThermalState not bound
!missing-field! NSProcessInfoThermalStateDidChangeNotification not bound
!missing-selector! NSProcessInfo::thermalState not bound

!missing-selector! NSItemProvider::preferredPresentationStyle not bound
!missing-selector! NSItemProvider::setPreferredPresentationStyle: not bound