### PR TITLE
[msbuild] Avoid running ObjCBinding tasks on VS design-time builds

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -52,7 +52,8 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 	<!-- Override the CoreCompile Target to use btouch -->
 	<Target Name="_GenerateBindings"
 		Inputs="$(MSBuildAllProjects);@(ObjcBindingApiDefinition);@(ObjcBindingCoreSource);@(ReferencePath);@(ObjcBindingNativeLibrary)"
-		Outputs="$(_GeneratedSourcesFileList)">
+		Outputs="$(_GeneratedSourcesFileList)"
+		Condition="'$(DesignTimeBuild)' != 'true'">
 
 		<ItemGroup>
 			<BTouchReferencePath Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll'" />
@@ -90,7 +91,7 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 		</BTouch>
 	</Target>
 
-	<Target Name="_PrepareNativeReferences">
+	<Target Name="_PrepareNativeReferences" Condition="'$(DesignTimeBuild)' != 'true'">
 		<PrepareNativeReferences
 			SessionId="$(BuildSessionId)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
@@ -125,7 +126,9 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 		</CreateItem>
 	</Target>
 
-	<Target Name="_CollectGeneratedSources" DependsOnTargets="_CompressFrameworks;_GenerateBindings">
+	<Target Name="_CollectGeneratedSources" DependsOnTargets="_CompressFrameworks;_GenerateBindings"
+		Condition="'$(DesignTimeBuild)' != 'true'">
+		
 		<ReadLinesFromFile File="$(_GeneratedSourcesFileList)" >
 			<Output TaskParameter="Lines" ItemName="GeneratedSources" />
 		</ReadLinesFromFile>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
@@ -45,7 +45,8 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 	<!-- Override the CoreCompile Target to use btouch -->
 	<Target Name="_GenerateBindings"
 		Inputs="$(MSBuildAllProjects);@(ObjcBindingApiDefinition);@(ObjcBindingCoreSource);@(ReferencePath);@(ObjcBindingNativeLibrary)"
-		Outputs="$(_GeneratedSourcesFileList)">
+		Outputs="$(_GeneratedSourcesFileList)"
+		Condition="'$(DesignTimeBuild)' != 'true'">
 
 		<PropertyGroup>
 			<BTouchEmitDebugInformation>false</BTouchEmitDebugInformation>
@@ -81,7 +82,7 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 		</BTouch>
 	</Target>
 
-	<Target Name="_PrepareNativeReferences">
+	<Target Name="_PrepareNativeReferences" Condition="'$(DesignTimeBuild)' != 'true'">
 		<PrepareNativeReferences
 			SessionId="$(BuildSessionId)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
@@ -142,7 +143,9 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 	</Target>
 	<!-- /OBSOLETE -->
 
-	<Target Name="_CollectGeneratedSources" DependsOnTargets="_GenerateBindings;_CompressNativeFrameworkResources;_CompressObjCBindingNativeFrameworkResources">
+	<Target Name="_CollectGeneratedSources" DependsOnTargets="_GenerateBindings;_CompressNativeFrameworkResources;_CompressObjCBindingNativeFrameworkResources"
+		Condition="'$(DesignTimeBuild)' != 'true'">
+		
 		<ReadLinesFromFile File="$(_GeneratedSourcesFileList)" >
 			<Output TaskParameter="Lines" ItemName="GeneratedSources" />
 		</ReadLinesFromFile>


### PR DESCRIPTION
These targets were failing to build on design-time builds for mostly 2 reasons:
- When loading the project VS is not connected to the Mac, which is required for binding projects.
- Since a reduce amount of targets are ran, the ReferencePath list is empty and makes _GeneratedSourcesFileList fail

Anyway, we shouldn't run targets that we don't need on a design-time build to avoid impacting on its performance

Why these targets were being executed on design-time builds? It's a side effect of adding them to CompileDependsOn.

Reference to design-time builds: https://github.com/dotnet/project-system/blob/master/docs/design-time-builds.md#what-is-a-design-time-build

Fixes bug 387900 - Referenced component could not be found for Binding Library projects
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/387900