### PR TITLE
[Intents] Fix breaking changes in Intents added in Xcode 9 Bindings

### DIFF
--- a/src/intents.cs
+++ b/src/intents.cs
@@ -2159,7 +2159,11 @@ namespace XamCore.Intents {
 	[Introduced (PlatformName.WatchOS, 3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol] 
-	interface INPaymentsDomainHandling : INSendPaymentIntentHandling, INRequestPaymentIntentHandling, INPayBillIntentHandling, INSearchForBillsIntentHandling, INSearchForAccountsIntentHandling, INTransferMoneyIntentHandling {
+	interface INPaymentsDomainHandling : INSendPaymentIntentHandling, INRequestPaymentIntentHandling, INPayBillIntentHandling, INSearchForBillsIntentHandling
+#if XAMCORE_4_0 // Added in iOS 11 -> #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 110000
+	, INSearchForAccountsIntentHandling, INTransferMoneyIntentHandling
+#endif
+	{
 	}
 
 	[Introduced (PlatformName.iOS, 10, 0)]
@@ -2174,7 +2178,7 @@ namespace XamCore.Intents {
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INRidesharingDomainHandling : INListRideOptionsIntentHandling, INRequestRideIntentHandling, INGetRideStatusIntentHandling 
-#if !WATCH
+#if XAMCORE_4_0 // Added in iOS 11 -> #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 110000
 	, INCancelRideIntentHandling, INSendRideFeedbackIntentHandling
 #endif
 	{


### PR DESCRIPTION
Apple added more protocol conformances to INRidesharingDomainHandling and
INPaymentsDomainHandling protocols in Xcode 9, I introduced these breaking
changes back when I did intents binding so fixing them :)