### PR TITLE
[CoreMedia] Fix leak in CMAttachmentBearer.GetAttachments.

### DIFF
--- a/src/CoreMedia/CMAttachmentBearer.cs
+++ b/src/CoreMedia/CMAttachmentBearer.cs
@@ -41,7 +41,7 @@ namespace XamCore.CoreMedia {
 			if (attachments == IntPtr.Zero)
 				return null;
 
-			return Runtime.GetNSObject<NSDictionary<TKey, TValue>> (attachments);
+			return Runtime.GetNSObject<NSDictionary<TKey, TValue>> (attachments, true);
 		}
 #endif
 


### PR DESCRIPTION
The caller owns the return value from CMCopyDictionaryOfAttachments, so tell
Runtime.GetNSObject that.