### PR TITLE
[Debugger] Do state why we did not copy the aot files.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -377,8 +377,6 @@ A last-straw solution would be to use an older version of Xamarin.iOS, one that 
 
 ### <a name="MT0096"/>MT0096: No reference to Xamarin.iOS.dll was found.
 
-### <a name="MT0097"/>MT0097: Aot files could not be found at the expected directory '{msymdir}'.
-
 <!-- MT0097: used by mmp -->
 <!-- MT0098: used by mmp -->
 
@@ -562,7 +560,9 @@ linker. This will most likely result in native linker errors.
 
 The solution is to remove the `--dynamic-symbol-mode=linker` argument from the additional mtouch arguments in the project's Build options.
 
-<!-- 0116 - 0122: free to use -->
+### <a name="MT0116"/>MT0116: Aot files could not be found at the expected directory '{msymdir}'.
+
+<!-- 0117 - 0122: free to use -->
 
 ### <a name="MT0123"/>MT0123: The current language was set to '{language}' according to the LANG environment variable (LANG={LANG}).
 

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -377,6 +377,8 @@ A last-straw solution would be to use an older version of Xamarin.iOS, one that 
 
 ### <a name="MT0096"/>MT0096: No reference to Xamarin.iOS.dll was found.
 
+### <a name="MT0097"/>MT0097: Aot files could not be found at the expected directory '{msymdir}'.
+
 <!-- MT0097: used by mmp -->
 <!-- MT0098: used by mmp -->
 

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1996,7 +1996,7 @@ namespace Xamarin.Bundler {
 				GenerateMSymManifest (target, target_directory);
 				var msymdir = Path.Combine (target.BuildDirectory, "Msym");
 				if (!Directory.Exists (msymdir)) {
-					ErrorHelper.Warning (95, $"Aot files could not be copied to msym directory is missing: '{msymdir}'");
+					ErrorHelper.Warning (97, $"Aot files could not be found at the expected directory '{msymdir}'.");
 					continue;
 				}
 				// copy aot data must be done BEFORE we do copy the msym one

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1996,7 +1996,7 @@ namespace Xamarin.Bundler {
 				GenerateMSymManifest (target, target_directory);
 				var msymdir = Path.Combine (target.BuildDirectory, "Msym");
 				if (!Directory.Exists (msymdir)) {
-					ErrorHelper.Warning (97, $"Aot files could not be found at the expected directory '{msymdir}'.");
+					ErrorHelper.Warning (116, $"The directory {msymdir} containing the mono symbols could not be found.");
 					continue;
 				}
 				// copy aot data must be done BEFORE we do copy the msym one

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1995,6 +1995,10 @@ namespace Xamarin.Bundler {
 			foreach (var target in Targets) {
 				GenerateMSymManifest (target, target_directory);
 				var msymdir = Path.Combine (target.BuildDirectory, "Msym");
+				if (!Directory.Exists (msymdir)) {
+					ErrorHelper.Warning (95, $"Aot files could not be copied to msym directory is missing: '{msymdir}'");
+					continue;
+				}
 				// copy aot data must be done BEFORE we do copy the msym one
 				CopyAotData (msymdir, target_directory);
 				


### PR DESCRIPTION
The issue seems to be that the AOT files are not generated for the extension project. Has nothing to do with the msym files.