### PR TITLE
[Intents] Adds missing API found by xtro, fixes Bug 59183

### DIFF
--- a/src/Intents/INCarSeatResolutionResult.cs
+++ b/src/Intents/INCarSeatResolutionResult.cs
@@ -1,0 +1,35 @@
+﻿//
+// INCarSeatResolutionResult.cs
+//
+// Authors:
+//	Alex Soto  <alexsoto@microsoft.com>
+//
+// Copyright 2017 Xamarin Inc. All rights reserved.
+//
+
+#if XAMCORE_2_0 && IOS
+using System;
+using XamCore.Foundation;
+using XamCore.ObjCRuntime;
+using XamCore.UIKit;
+
+namespace XamCore.Intents {
+	public partial class INCarSeatResolutionResult {
+		public static INCarSeatResolutionResult GetSuccess (INCarSeat resolvedValue)
+		{
+			if (UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+				return SuccessWithResolvedCarSeat (resolvedValue);
+			else
+				return SuccessWithResolvedValue (resolvedValue);
+		}
+
+		public static INCarSeatResolutionResult GetConfirmationRequired (INCarSeat valueToConfirm)
+		{
+			if (UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+				return ConfirmationRequiredWithCarSeatToConfirm (valueToConfirm);
+			else
+				return ConfirmationRequiredWithValueToConfirm (valueToConfirm);
+		}
+	}
+}
+#endif

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -853,6 +853,7 @@ INTENTS_SOURCES = \
 	Intents/INCarAirCirculationModeResolutionResult.cs \
 	Intents/INCarAudioSourceResolutionResult.cs \
 	Intents/INCarDefrosterResolutionResult.cs \
+	Intents/INCarSeatResolutionResult.cs \
 	Intents/INCarSignalOptionsResolutionResult.cs \
 	Intents/INCompat.cs \
 	Intents/INGetCarLockStatusIntentResponse.cs \

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -1959,13 +1959,29 @@ namespace XamCore.Intents {
 	[DisableDefaultCtor]
 	interface INCarSeatResolutionResult {
 
+		[iOS (11,0)]
+		[Internal]
+		[Static]
+		[Export ("successWithResolvedCarSeat:")]
+		INCarSeatResolutionResult SuccessWithResolvedCarSeat (INCarSeat resolvedCarSeat);
+
+		[Internal]
+		[Deprecated (PlatformName.iOS, 11, 0)]
 		[Static]
 		[Export ("successWithResolvedValue:")]
-		INCarSeatResolutionResult GetSuccess (INCarSeat resolvedValue);
+		INCarSeatResolutionResult SuccessWithResolvedValue (INCarSeat resolvedValue);
 
+		[iOS (11,0)]
+		[Internal]
+		[Static]
+		[Export ("confirmationRequiredWithCarSeatToConfirm:")]
+		INCarSeatResolutionResult ConfirmationRequiredWithCarSeatToConfirm (INCarSeat carSeatToConfirm);
+
+		[Internal]
+		[Deprecated (PlatformName.iOS, 11, 0)]
 		[Static]
 		[Export ("confirmationRequiredWithValueToConfirm:")]
-		INCarSeatResolutionResult GetConfirmationRequired (INCarSeat valueToConfirm);
+		INCarSeatResolutionResult ConfirmationRequiredWithValueToConfirm (INCarSeat valueToConfirm);
 
 		// Fixes bug 43205. We need to return the inherited type not the base type
 		// because users won't be able to downcast easily

--- a/src/intentsui.cs
+++ b/src/intentsui.cs
@@ -41,7 +41,9 @@ namespace XamCore.IntentsUI {
 	[Protocol]
 	interface INUIHostedViewControlling {
 
+#if !XAMCORE_4_0 // Apple made this member optional in iOS 11
 		[Abstract]
+#endif
 		[Export ("configureWithInteraction:context:completion:")]
 		void Configure (INInteraction interaction, INUIHostedViewContext context, Action<CGSize> completion);
 

--- a/tests/xtro-sharpie/ios.pending
+++ b/tests/xtro-sharpie/ios.pending
@@ -269,6 +269,11 @@
 
 ## Looks like this was removed by apple in Intents iOS 11.0 Beta 1 to Beta 2 - http://codeworkshop.net/objc-diff/sdkdiffs/ios/11.0b2/Intents.html
 !extra-protocol-member! unexpected selector INSetProfileInCarIntentHandling::resolveDefaultProfileForSetProfileInCar:withCompletion: found
+## Same added and removed in iOS 11
+!missing-selector! +INNotebookItemTypeResolutionResult::disambiguationWithValuesToDisambiguate: not bound
+
+## Apple made this protocol member optional in iOS 11 but it is a breaking change for us. Added to XAMCORE_4_0.
+!incorrect-protocol-member! INUIHostedViewControlling::configureWithInteraction:context:completion: is OPTIONAL and should NOT be abstract
 
 # UIKit
 

--- a/tests/xtro-sharpie/watchos.pending
+++ b/tests/xtro-sharpie/watchos.pending
@@ -123,6 +123,9 @@
 !unknown-type! INRelativeReferenceResolutionResult bound
 !unknown-type! INRelativeSettingResolutionResult bound
 
+## Added and removed in watchOS 4
+!missing-selector! +INNotebookItemTypeResolutionResult::disambiguationWithValuesToDisambiguate: not bound
+
 #PassKit
 
 ## No availability macro is provided for PKLabeledValue on watchOS / radar: https://trello.com/c/MvaHEZlc


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=59183

Fixes

```
!missing-selector! +INNotebookItemTypeResolutionResult::disambiguationWithValuesToDisambiguate: not bound
!missing-selector! +INCarSeatResolutionResult::confirmationRequiredWithCarSeatToConfirm: not bound
!missing-selector! +INCarSeatResolutionResult::successWithResolvedCarSeat: not bound
!incorrect-protocol-member! INUIHostedViewControlling::configureWithInteraction:context:completion: is OPTIONAL and should NOT be abstract
```