### PR TITLE
[UIKit] De-model UIDataSourceTranslating.

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -17734,8 +17734,7 @@ namespace XamCore.UIKit {
 #endregion
 
 	[TV (11,0), iOS (11,0)]
-	[Protocol, Model]
-	[BaseType (typeof(NSObject))]
+	[Protocol]
 	interface UIDataSourceTranslating {
 		[Abstract]
 		[Export ("presentationSectionIndexForDataSourceSectionIndex:")]


### PR DESCRIPTION
It's not clear from neither the documentation nor the headers how this
protocol is supposed to be used, and since it doesn't correspond to the
delegate pattern, remove the [Model] attribute for now.

We can always add it back later.