### PR TITLE
[ARKit] Rename a few method to make them nicer.

### DIFF
--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -203,7 +203,7 @@ namespace XamCore.ARKit {
 		ARHitTestResult[] HitTest (CGPoint point, ARHitTestResultType types);
 
 		[Export ("displayTransformForOrientation:viewportSize:")]
-		CGAffineTransform DisplayTransform (UIInterfaceOrientation orientation, CGSize viewportSize);
+		CGAffineTransform GetDisplayTransform (UIInterfaceOrientation orientation, CGSize viewportSize);
 	}
 
 	[iOS (11,0)]
@@ -434,10 +434,10 @@ namespace XamCore.ARKit {
 		void CameraDidChangeTrackingState (ARSession session, ARCamera camera);
 
 		[Export ("sessionWasInterrupted:")]
-		void SessionWasInterrupted (ARSession session);
+		void WasInterrupted (ARSession session);
 
 		[Export ("sessionInterruptionEnded:")]
-		void SessionInterruptionEnded (ARSession session);
+		void InterruptionEnded (ARSession session);
 
 		[Export ("session:didOutputAudioSampleBuffer:")]
 		void DidOutputAudioSampleBuffer (ARSession session, CMSampleBuffer audioSampleBuffer);


### PR DESCRIPTION
* DisplayTransform -> GetDisplayTransform since methods should have verbs.

* SessionWasInterrupted -> WasInterrupted and SessionInterruptionEnded ->
  InterruptionEnded since these names match better with the other names
  (CameraDidChangeTrackingState / DidFail / DidOutputAudioSampleBuffer: none
  are prefixed with 'Session'). Additionally, the type is a Model (for the
  delegate pattern), which means all methods are more-or-less event-like, and
  the first argument is always the same (the protocol itself), which is
  another indicator the methods should be named similarly.