### PR TITLE
[Foundation] Remove 'Key' suffix from some fields.

### DIFF
--- a/src/Foundation/NSMetadataItem.cs
+++ b/src/Foundation/NSMetadataItem.cs
@@ -477,7 +477,7 @@ namespace XamCore.Foundation {
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
-		public nint? FocalLength35mmKey {
+		public nint? FocalLength35mm {
 			get {
 				return GetNInt (NSMetadataQuery.FocalLength35mmKey);
 			}
@@ -498,7 +498,7 @@ namespace XamCore.Foundation {
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
-		public double? AltitudeKey {
+		public double? Altitude {
 			get {
 				return GetNullableDouble (NSMetadataQuery.AltitudeKey);
 			}
@@ -715,7 +715,7 @@ namespace XamCore.Foundation {
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
-		public double? MaxApertureKey {
+		public double? MaxAperture {
 			get {
 				return GetNullableDouble (NSMetadataQuery.MaxApertureKey);
 			}
@@ -799,7 +799,7 @@ namespace XamCore.Foundation {
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
-		public double? TempoKey {
+		public double? Tempo {
 			get {
 				return GetNullableDouble (NSMetadataQuery.TempoKey);
 			}
@@ -1001,7 +1001,7 @@ namespace XamCore.Foundation {
 		}
 
 		[NoWatch, NoTV, NoiOS, Mac (10, 9)]
-		public double? StarRatingKey {
+		public double? StarRating {
 			get {
 				return GetNullableDouble (NSMetadataQuery.StarRatingKey);
 			}


### PR DESCRIPTION
Of the 168 fields in NSMetadataItem, only these 5 hadn't removed the 'Key'
suffix.

So make them all equivalent by removing the 'Key' suffix from these 5 fields.