### PR TITLE
Support overloading Objective-C methods based on static/instance.

### DIFF
--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -71,7 +71,8 @@
 
 		new XDelegate ("MethodDescription", "UnmanagedMethodDescription", "xamarin_get_method_for_selector",
 			"Class", "IntPtr", "cls",
-			"SEL", "IntPtr", "sel"
+			"SEL", "IntPtr", "sel",
+			"bool", "bool", "is_static"
 		) { WrappedManagedFunction = "GetMethodForSelector" },
 
 		new XDelegate ("MonoObject *", "IntPtr", "xamarin_get_nsobject",
@@ -140,6 +141,7 @@
 		new XDelegate ("MethodDescription", "UnmanagedMethodDescription", "xamarin_get_method_and_object_for_selector",
 			"Class", "IntPtr", "cls",
 			"SEL", "IntPtr", "sel",
+			"bool", "bool", "is_static",
 			"id", "IntPtr", "obj",
 			"MonoObject **", "ref IntPtr", "mthis"
 		) { WrappedManagedFunction = "GetMethodAndObjectForSelector" },

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -88,9 +88,9 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 	int mofs = 0;
 
 	if (is_ctor || is_static) {
-		desc = xamarin_get_method_for_selector ([self class], sel, &exception_gchandle);
+		desc = xamarin_get_method_for_selector ([self class], sel, is_static, &exception_gchandle);
 	} else {
-		desc = xamarin_get_method_and_object_for_selector ([self class], sel, self, &mthis, &exception_gchandle);
+		desc = xamarin_get_method_and_object_for_selector ([self class], sel, is_static, self, &mthis, &exception_gchandle);
 	}
 	if (exception_gchandle != 0)
 		goto exception_handling;

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -225,7 +225,7 @@ MonoObject*					xamarin_get_class							(Class ptr, guint32 *exception_gchandle)
 MonoObject*					xamarin_get_selector						(SEL ptr, guint32 *exception_gchandle);
 Class						xamarin_get_class_handle					(MonoObject *obj, guint32 *exception_gchandle);
 SEL							xamarin_get_selector_handle					(MonoObject *obj, guint32 *exception_gchandle);
-MethodDescription			xamarin_get_method_for_selector				(Class cls, SEL sel, guint32 *exception_gchandle);
+MethodDescription			xamarin_get_method_for_selector				(Class cls, SEL sel, bool is_static, guint32 *exception_gchandle);
 bool						xamarin_has_nsobject 						(id obj, guint32 *exception_gchandle);
 MonoObject*					xamarin_get_nsobject 						(id obj, guint32 *exception_gchandle);
 id							xamarin_get_handle_for_inativeobject		(MonoObject *obj, guint32 *exception_gchandle);
@@ -239,7 +239,7 @@ MonoObject*					xamarin_get_nsobject_with_type				(id obj, void *type, int32_t *
 void						xamarin_dispose								(MonoObject *mobj, guint32 *exception_gchandle);
 bool	 					xamarin_is_parameter_transient				(MonoReflectionMethod *method, int parameter /* 0-based */, guint32 *exception_gchandle);
 bool						xamarin_is_parameter_out                    (MonoReflectionMethod *method, int parameter /* 0-based */, guint32 *exception_gchandle);
-MethodDescription			xamarin_get_method_and_object_for_selector	(Class cls, SEL sel, id self, MonoObject **mthis, guint32 *exception_gchandle);
+MethodDescription			xamarin_get_method_and_object_for_selector	(Class cls, SEL sel, bool is_static, id self, MonoObject **mthis, guint32 *exception_gchandle);
 guint32 					xamarin_create_product_exception_for_error	(int code, const char *message, guint32 *exception_gchandle);
 
 #ifdef __cplusplus

--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -840,10 +840,10 @@ namespace XamCore.Registrar {
 				custom_type_map [type] = null;
 		}
 
-		public UnmanagedMethodDescription GetMethodDescriptionAndObject (Type type, IntPtr selector, IntPtr obj, ref IntPtr mthis)
+		public UnmanagedMethodDescription GetMethodDescriptionAndObject (Type type, IntPtr selector, bool is_static, IntPtr obj, ref IntPtr mthis)
 		{
 			var sel = new Selector (selector);
-			var res = GetMethodNoThrow (type, type, sel.Name);
+			var res = GetMethodNoThrow (type, type, sel.Name, is_static);
 			if (res == null)
 				throw ErrorHelper.CreateError (8006, "Failed to find the selector '{0}' on the type '{1}'", sel.Name, type.FullName);
 
@@ -887,10 +887,10 @@ namespace XamCore.Registrar {
 			throw ErrorHelper.CreateError (8003, "Failed to find the closed generic method '{0}' on the type '{1}'.", open_method.Name, closed_type.FullName);
 		}
 
-		public UnmanagedMethodDescription GetMethodDescription (Type type, IntPtr selector)
+		public UnmanagedMethodDescription GetMethodDescription (Type type, IntPtr selector, bool is_static)
 		{
 			var sel = new Selector (selector);
-			var res = GetMethodNoThrow (type, type, sel.Name);
+			var res = GetMethodNoThrow (type, type, sel.Name, is_static);
 			if (res == null)
 				throw ErrorHelper.CreateError (8006, "Failed to find the selector '{0}' on the type '{1}'", sel.Name, type.FullName);
 			if (type.IsGenericType && res.Method is ConstructorInfo)
@@ -899,7 +899,7 @@ namespace XamCore.Registrar {
 			return res.MethodDescription.GetUnmanagedDescription ();
 		}
 
-		ObjCMethod GetMethodNoThrow (Type original_type, Type type, string selector)
+		ObjCMethod GetMethodNoThrow (Type original_type, Type type, string selector, bool is_static)
 		{
 			var objcType = RegisterType (type);
 			
@@ -908,8 +908,8 @@ namespace XamCore.Registrar {
 
 			ObjCMember member = null;
 			
-			if (type.BaseType != typeof (object) && !objcType.Map.TryGetValue (selector, out member))
-				return GetMethodNoThrow (original_type, type.BaseType, selector);
+			if (type.BaseType != typeof (object) && !objcType.TryGetMember (selector, is_static, out member))
+				return GetMethodNoThrow (original_type, type.BaseType, selector, is_static);
 			
 			var method = member as ObjCMethod;
 			

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -556,10 +556,10 @@ namespace XamCore.ObjCRuntime {
 			return ((Selector) ObjectWrapper.Convert (sel)).Handle;
 		}
 
-		static UnmanagedMethodDescription GetMethodForSelector (IntPtr cls, IntPtr sel)
+		static UnmanagedMethodDescription GetMethodForSelector (IntPtr cls, IntPtr sel, bool is_static)
 		{
 			// This is called by the old registrar code.
-			return Registrar.GetMethodDescription (Class.Lookup (cls), sel);
+			return Registrar.GetMethodDescription (Class.Lookup (cls), sel, is_static);
 		}
 
 		static IntPtr GetNSObjectWrapped (IntPtr ptr)
@@ -675,9 +675,9 @@ namespace XamCore.ObjCRuntime {
 			return parameters [parameter].IsOut;
 		}
 
-		static UnmanagedMethodDescription GetMethodAndObjectForSelector (IntPtr klass, IntPtr sel, IntPtr obj, ref IntPtr mthis)
+		static UnmanagedMethodDescription GetMethodAndObjectForSelector (IntPtr klass, IntPtr sel, bool is_static, IntPtr obj, ref IntPtr mthis)
 		{
-			return Registrar.GetMethodDescriptionAndObject (Class.Lookup (klass), sel, obj, ref mthis);
+			return Registrar.GetMethodDescriptionAndObject (Class.Lookup (klass), sel, is_static, obj, ref mthis);
 		}
 
 		static int CreateProductException (int code, string msg)

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2529,4 +2529,15 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			block.CleanupBlock ();
 		}
 	}
+
+	[Preserve]
+	class OverloadByStaticity : NSObject
+	{
+		// Two methods/properties can 
+		[Export ("method")]
+		public void InstanceMethod () { }
+
+		[Export ("method")]
+		public static void StaticMethod () { } 
+	}
 }

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2533,11 +2533,11 @@ namespace MonoTouchFixtures.ObjCRuntime {
 	[Preserve]
 	class OverloadByStaticity : NSObject
 	{
-		// Two methods/properties can 
+		// Two Objective-C methods can have the same selector if one is static and the other instance.
 		[Export ("method")]
 		public void InstanceMethod () { }
 
 		[Export ("method")]
-		public static void StaticMethod () { } 
+		public static void StaticMethod () { }
 	}
 }


### PR DESCRIPTION
Two Objective-C methods can be named identically as long as one is static and
the other instance.

We must support this since Apple did just this (in the NSItemProviderReading /
NSItemProviderWriting protocols).

We solve it by prepending a '+' or '-' to the selector when hashing it (to
determine selector uniqueness, and to look the method up again at runtime).