### PR TITLE
[ImageIO] Fix API to not duplicate the instance in instance methods.

### DIFF
--- a/src/ImageIO/CGImageDestination.cs
+++ b/src/ImageIO/CGImageDestination.cs
@@ -501,10 +501,10 @@ namespace XamCore.ImageIO {
 		static extern void CGImageDestinationAddAuxiliaryDataInfo (IntPtr /* CGImageDestinationRef* */ idst, IntPtr /* CFStringRef* */ auxiliaryImageDataType, IntPtr /* CFDictionaryRef* */ auxiliaryDataInfoDictionary);
 
 		[Watch (4, 0), TV (11, 0), Mac (10, 13), iOS (11, 0)]
-		public void AddAuxiliaryDataInfo (CGImageDestination dest, CGImageAuxiliaryDataType auxiliaryImageDataType, CGImageAuxiliaryDataInfo auxiliaryDataInfo)
+		public void AddAuxiliaryDataInfo (CGImageAuxiliaryDataType auxiliaryImageDataType, CGImageAuxiliaryDataInfo auxiliaryDataInfo)
 		{
 			using (var dict = auxiliaryDataInfo?.ToDictionary ()) {
-				CGImageDestinationAddAuxiliaryDataInfo (dest.GetHandle (), auxiliaryImageDataType.GetConstant ().GetHandle (), dict.GetHandle ());
+				CGImageDestinationAddAuxiliaryDataInfo (Handle, auxiliaryImageDataType.GetConstant ().GetHandle (), dict.GetHandle ());
 			}
 		}
 	}

--- a/src/ImageIO/CGImageSource.cs
+++ b/src/ImageIO/CGImageSource.cs
@@ -382,9 +382,9 @@ namespace XamCore.ImageIO {
 		static extern IntPtr /* CFDictionaryRef* */ CGImageSourceCopyAuxiliaryDataInfoAtIndex (IntPtr /* CGImageSourceRef* */ isrc, nuint index, IntPtr /* CFStringRef* */ auxiliaryImageDataType);
 
 		[Watch (4, 0), TV (11, 0), Mac (10, 13), iOS (11, 0)]
-		public CGImageAuxiliaryDataInfo CopyAuxiliaryDataInfo (CGImageSource imageSource, nuint index, CGImageAuxiliaryDataType auxiliaryImageDataType)
+		public CGImageAuxiliaryDataInfo CopyAuxiliaryDataInfo (nuint index, CGImageAuxiliaryDataType auxiliaryImageDataType)
 		{
-			var ptr = CGImageSourceCopyAuxiliaryDataInfoAtIndex (imageSource.GetHandle (), index, auxiliaryImageDataType.GetConstant ().GetHandle ());
+			var ptr = CGImageSourceCopyAuxiliaryDataInfoAtIndex (Handle, index, auxiliaryImageDataType.GetConstant ().GetHandle ());
 			if (ptr == IntPtr.Zero)
 				return null;
 


### PR DESCRIPTION
An instance method does not need to take the instance as a parameter, so
remove the first (instance) parameter for
CGImageDestination.AddAuxiliaryDataInfo and
CGImageSource.CopyAuxiliaryDataInfo.

An alternative solution would be to make the methods static, but I like the
instance API better.