### PR TITLE
[Intents] Add convenience ctor overload and call correct base ctor in manual ctor.

### DIFF
--- a/src/Intents/INSpeakableString.cs
+++ b/src/Intents/INSpeakableString.cs
@@ -15,6 +15,7 @@ using XamCore.ObjCRuntime;
 namespace XamCore.Intents {
 	public partial class INSpeakableString {
 		public INSpeakableString (string identifier, string spokenPhrase, string pronunciationHint)
+			: base (NSObjectFlag.Empty)
 		{
 #if IOS
 			if (XamCore.UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -2642,6 +2642,10 @@ namespace XamCore.Intents {
 		[Export ("initWithRestaurant:reservationIdentifier:maximumNumberOfResults:earliestBookingDateForResults:")]
 		IntPtr Constructor ([NullAllowed] INRestaurant restaurant, [NullAllowed] string reservationIdentifier, [NullAllowed] NSNumber maximumNumberOfResults, [NullAllowed] NSDate earliestBookingDateForResults);
 
+		[iOS (11,0)]
+		[Wrap ("this (restaurant, reservationIdentifier, NSNumber.FromNInt (maximumNumberOfResults), earliestBookingDateForResults)")]
+		IntPtr Constructor ([NullAllowed] INRestaurant restaurant, [NullAllowed] string reservationIdentifier, nint maximumNumberOfResults, [NullAllowed] NSDate earliestBookingDateForResults);
+
 		[NullAllowed, Export ("restaurant", ArgumentSemantic.Copy)]
 		INRestaurant Restaurant { get; set; }
 


### PR DESCRIPTION
Add a convenience constructor overload in
INGetUserCurrentRestaurantReservationBookingsIntent that uses nint instead of
NSNumber, since logically "number of results" will always be some sort of
integer.

Also call the correct base constructor in INSpeakableString's custom
constructor (same as any other generated constructor). Otherwise we end up
doing something like this: [[[INSpeakableString alloc] init] initWith ...],
i.e. calling two different init methods.