### PR TITLE
[Foundation] Improve NSItemProviderReading & NSItemProviderWriting protocols/compliance.

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -9785,9 +9785,15 @@ namespace XamCore.Foundation
 		[Export ("writableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
 		string[] WritableTypeIdentifiers { get; }
 
-		[Static]
-		[Export ("itemProviderVisibilityForRepresentationWithTypeIdentifier:")]
-		NSItemProviderRepresentationVisibility GetItemProviderVisibility (string typeIdentifier);
+		// This is an optional method, which means the generator will inline it in any classes
+		// that implements this interface. Unfortunately none of the native classes that implements
+		// the protocol actually implements this method, which means that inlining the method will cause
+		// introspection to complain (rightly). So comment out this method to avoid generator a lot of unusable API.
+		// See also https://bugzilla.xamarin.com/show_bug.cgi?id=59308.
+		//
+		// [Static]
+		// [Export ("itemProviderVisibilityForRepresentationWithTypeIdentifier:")]
+		// NSItemProviderRepresentationVisibility GetItemProviderVisibility (string typeIdentifier);
 
 		[Export ("writableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
 		// 'WritableTypeIdentifiers' is a nicer name, but there's a static property with that name.

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -250,32 +250,6 @@ namespace XamCore.Foundation
 		[Wrap ("this (data, options == null ? null : options.Dictionary, out resultDocumentAttributes, ref error)")]
 		IntPtr Constructor (NSData data, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, ref NSError error);
 
-		// From the NSItemProviderReading protocol, a static method.
-		[Static]
-		[Export ("readableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
-		[iOS (11,0), NoWatch, NoTV, Mac(10,13)]
-		string[] ReadableTypeIdentifiers { get; }
-
-#if !TVOS && !WATCHOS
-		[NoWatch, NoTV, Mac (10,13), iOS (11,0)]
-		[Static]
-		[Export ("objectWithItemProviderData:typeIdentifier:error:")]
-		[return: NullAllowed]
-		NSAttributedString FromItemProviderData (NSData itemProviderData, string typeIdentifier, [NullAllowed] out NSError outError);
-#endif
-
-		// From the NSItemProviderWriting protocol, a static method.
-		[NoWatch, NoTV, Mac (10,13), iOS (11,0)]
-		[Static]
-		[Export ("writableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
-		string[] WritableTypeIdentifiers { get; }
-
-		// From the NSItemProviderWriting protocol, a static method.
-		[NoWatch, NoTV, Mac (10,13), NoiOS]
-		[Static]
-		[Export ("itemProviderVisibilityForRepresentationWithTypeIdentifier:")]
-		NSItemProviderRepresentationVisibility GetItemProviderVisibility (string typeIdentifier);
-		
 		[Since (7,0)]
 		[Export ("dataFromRange:documentAttributes:error:")]
 		NSData GetDataFromRange (NSRange range, NSDictionary attributes, ref NSError error);
@@ -5302,9 +5276,7 @@ namespace XamCore.Foundation
 #if MONOMAC
 	, NSPasteboardReading, NSPasteboardWriting
 #endif
-#if !WATCH && !TVOS
-	, NSItemProviderWriting
-#endif
+	, NSItemProviderWriting, NSItemProviderReading
 	{
 		[Export ("initWithScheme:host:path:")]
 		IntPtr Constructor (string scheme, string host, string path);
@@ -5995,21 +5967,24 @@ namespace XamCore.Foundation
 		NSString FileProtectionCompleteUntilFirstUserAuthentication { get; }
 #endif
 
+		// From the NSItemProviderReading protocol
 		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		[Static]
 		[Export ("readableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
-		string[] ReadableTypeIdentifiers { get; }
+		new string[] ReadableTypeIdentifiers { get; }
 
+		// From the NSItemProviderReading protocol
 		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		[Static]
 		[Export ("objectWithItemProviderData:typeIdentifier:error:")]
 		[return: NullAllowed]
-		NSUrl FromItemProviderData (NSData itemProviderData, string typeIdentifier, [NullAllowed] out NSError outError);
+		new NSUrl GetObject (NSData data, string typeIdentifier, [NullAllowed] out NSError outError);
 
-		[NoWatch, NoTV, Mac (10,13), iOS (11,0)]
+		// From the NSItemProviderWriting protocol
+		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		[Static]
 		[Export ("writableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
-		string[] WritableTypeIdentifiers { get; }
+		new string[] WritableTypeIdentifiers { get; }
 	}
 
 	
@@ -7809,9 +7784,7 @@ namespace XamCore.Foundation
 	#if MONOMAC
 		, NSPasteboardReading, NSPasteboardWriting // Documented that it implements NSPasteboard protocols even if header doesn't show it
 	#endif
-#if !WATCH && !TVOS
-		, NSItemProviderWriting
-#endif
+		, NSItemProviderReading, NSItemProviderWriting
 	{
 		[Export ("initWithData:encoding:")]
 		IntPtr Constructor (NSData data, NSStringEncoding encoding);
@@ -8071,21 +8044,24 @@ namespace XamCore.Foundation
 		[Export ("paragraphRangeForRange:")]
 		NSRange GetParagraphRange (NSRange range);
 
+		// From the NSItemProviderReading protocol
+
 		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		[Static]
 		[Export ("readableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
-		string[] ReadableTypeIdentifiers { get; }
+		new string[] ReadableTypeIdentifiers { get; }
 
 		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		[Static]
 		[Export ("objectWithItemProviderData:typeIdentifier:error:")]
 		[return: NullAllowed]
-		NSString FromItemProviderData (NSData itemProviderData, string typeIdentifier, [NullAllowed] out NSError outError);
+		new NSString GetObject (NSData data, string typeIdentifier, [NullAllowed] out NSError outError);
 
-		[NoWatch, NoTV, Mac (10,13), iOS (11,0)]
+		// From the NSItemProviderWriting protocol
+		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		[Static]
 		[Export ("writableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
-		string[] WritableTypeIdentifiers { get; }
+		new string[] WritableTypeIdentifiers { get; }
 	}
 
 	[StrongDictionary ("NSString")]
@@ -8134,12 +8110,6 @@ namespace XamCore.Foundation
 
 		[Export ("replaceCharactersInRange:withString:")]
 		void ReplaceCharactersInRange (NSRange range, NSString aString);
-
-		// From the NSItemProviderWriting protocol, a static method.
-		[NoWatch, NoTV, Mac (10,13), iOS (11,0)]
-		[Static]
-		[Export ("writableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
-		string[] WritableTypeIdentifiers { get; }
 	}
 	
 	[Category, BaseType (typeof (NSString))]
@@ -9777,7 +9747,6 @@ namespace XamCore.Foundation
 	[Protocol]
 	interface NSItemProviderReading
 	{
-		//
 		// This static method has to be implemented on each class that implements
 		// this, this is not a capability that exists in C#.
 		// We are inlining these on each class that implements NSItemProviderReading
@@ -9785,14 +9754,14 @@ namespace XamCore.Foundation
 		// user needs to manually [Export] the selector on a static method, like
 		// they do for the "layer" property on CALayer subclasses.
 		//
-		//[Static, Abstract]
-		//[Export ("readableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
-		//string[] ReadableTypeIdentifiers { get; }
+		[Static, Abstract]
+		[Export ("readableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
+		string[] ReadableTypeIdentifiers { get; }
 
-		//[Static]
-		//[Export ("objectWithItemProviderData:typeIdentifier:error:")]
-		//[return: NullAllowed]
-		//INSItemProviderReading GetObject (NSData data, string typeIdentifier, [NullAllowed] out NSError outError);
+		[Static, Abstract]
+		[Export ("objectWithItemProviderData:typeIdentifier:error:")]
+		[return: NullAllowed]
+		INSItemProviderReading GetObject (NSData data, string typeIdentifier, [NullAllowed] out NSError outError);
 	}
 
 	interface INSItemProviderWriting {}
@@ -9809,20 +9778,23 @@ namespace XamCore.Foundation
 		// user needs to manually [Export] the selector on a static method, like
 		// they do for the "layer" property on CALayer subclasses.
 		//
-		//[Static, Abstract]
-		//[Export ("writableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
-		//string[] WritableTypeIdentifiersForItemProvider { get; }
-
-		//[Static]
-		//[Export ("itemProviderVisibilityForRepresentationWithTypeIdentifier:")]
-		//NSItemProviderRepresentationVisibility GetItemProviderVisibility (string typeIdentifier);
-
+		[Static, Abstract]
 		[Export ("writableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
-		string[] WritableTypeIdentifiersForItemProvider { get; }
+		string[] WritableTypeIdentifiers { get; }
 
+		[Static]
 		[Export ("itemProviderVisibilityForRepresentationWithTypeIdentifier:")]
 		NSItemProviderRepresentationVisibility GetItemProviderVisibility (string typeIdentifier);
 
+		[Export ("writableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
+		// 'WritableTypeIdentifiers' is a nicer name, but there's a static property with that name.
+		string[] WritableTypeIdentifiersForItemProvider { get; }
+
+		[Export ("itemProviderVisibilityForRepresentationWithTypeIdentifier:")]
+		// 'GetItemProviderVisibility' is a nicer name, but there's a static method with that name.
+		NSItemProviderRepresentationVisibility GetItemProviderVisibilityForTypeIdentifier (string typeIdentifier);
+
+		[Abstract]
 		[Async, Export ("loadDataWithTypeIdentifier:forItemProviderCompletionHandler:")]
 		[return: NullAllowed]
 		NSProgress LoadData (string typeIdentifier, Action<NSData, NSError> completionHandler);

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -4709,16 +4709,6 @@ namespace XamCore.UIKit {
 		[return: NullAllowed]
 		UIColor FromName (string name);
 
-		// From the NSItemProviderReading protocol, a special constructor.
-		[iOS (11,0), NoWatch, NoTV]
-		[Export ("initWithItemProviderData:typeIdentifier:error:")]
-		IntPtr Constructor (NSData providerData, string typeIdentifier, out NSError outError);
-
-		// From the NSItemProviderReading protocol, a static method.
-		[Static]
-		[iOS (11,0), NoWatch, NoTV]
-		[Export ("readableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
-		string[] ReadableTypeIdentifiers { get; }
 #if !WATCH
 		[iOS (11,0), TV (11,0)]
 		[Static]
@@ -4872,10 +4862,33 @@ namespace XamCore.UIKit {
 		bool GetRGBA2 (out nfloat red, out nfloat green, out nfloat blue, out nfloat alpha);
 #endif
 
+		// From the NSItemProviderReading protocol, a static method.
+		[Static]
+		[iOS (11,0), NoWatch, NoTV]
+		[Export ("readableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
+#if !WATCH && !TVOS
+		new
+#endif
+		string[] ReadableTypeIdentifiers { get; }
+
+		// From the NSItemProviderReading protocol, a static method.
+		[iOS (11,0), NoWatch, NoTV]
+		[Static]
+		[Export ("objectWithItemProviderData:typeIdentifier:error:")]
+		[return: NullAllowed]
+#if !WATCH && !TVOS
+		new
+#endif
+		UIColor GetObject (NSData data, string typeIdentifier, [NullAllowed] out NSError outError);
+
 		// From the NSItemProviderWriting protocol, a static method.
-		[NoWatch, NoTV, Mac (10,13), iOS (11,0)]
+		// NSItemProviderWriting doesn't seem to be implemented for tvOS/watchOS, even though the headers say otherwise.
+		[NoWatch, NoTV, iOS (11,0)]
 		[Static]
 		[Export ("writableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
+#if !WATCH && !TVOS
+		new
+#endif
 		string[] WritableTypeIdentifiers { get; }
 	}
 
@@ -7025,17 +7038,25 @@ namespace XamCore.UIKit {
 		UIImage FromImage (CIImage image);
 #endif // !WATCH
 
-		// From the NSItemProviderReading protocol, a special constructor.
-		[Export ("initWithItemProviderData:typeIdentifier:error:")]
-		[iOS (11,0), NoWatch, NoTV]
-		IntPtr Constructor (NSData providerData, string typeIdentifier, out NSError outError);
-
 		// From the NSItemProviderReading protocol, a static method.
 		[Static]
 		[iOS (11,0), NoWatch, NoTV]
 		[Export ("readableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
+#if !WATCH && !TVOS
+		new
+#endif
 		string[] ReadableTypeIdentifiers { get; }
 	
+		// From the NSItemProviderReading protocol, a static method.
+		[Static]
+		[Export ("objectWithItemProviderData:typeIdentifier:error:")]
+		[iOS (11,0), NoWatch, NoTV]
+		[return: NullAllowed]
+#if !WATCH && !TVOS
+		new
+#endif
+		UIImage GetObject (NSData data, string typeIdentifier, [NullAllowed] out NSError outError);
+
 		[Export ("renderingMode")]
 		[ThreadSafe]
 		[Since (7,0)]
@@ -7237,9 +7258,13 @@ namespace XamCore.UIKit {
 #endif
 
 		// From the NSItemProviderWriting protocol, a static method.
-		[NoWatch, NoTV, Mac (10,13), iOS (11,0)]
+		// NSItemProviderWriting doesn't seem to be implemented for tvOS/watchOS, even though the headers say otherwise.
+		[NoWatch, NoTV, iOS (11,0)]
 		[Static]
 		[Export ("writableTypeIdentifiersForItemProvider", ArgumentSemantic.Copy)]
+#if !WATCH && !TVOS
+		new
+#endif
 		string[] WritableTypeIdentifiers { get; }
 	}
 


### PR DESCRIPTION
* NSItemProviderWriting/NSItemProviderReading: Implement correctly and completely by uncommenting commented out code.

* NSMutableString/NSAttributedString: remove inlined members, since these classes don't implement NSItemProviderReading / NSItemProviderWriting (according to the headers at least).

* NSUrl: all platforms now seem to implement NSItemProviderReading / NSItemProviderWriting.

* NSString: all platforms now seem to implement both NSItemProviderReading and NSItemProviderWriting

* UIColor/UIImage: Update inlined protocol members according to the latest beta.

Additionally, due to the following conditions:

* The protocols all have the correct members now.
* In the API definition we tell the generator to inline members from a protocol by inheriting from the corresponding interface.
* The generator doesn't inline static members from protocols.

several 'new' keywords had to be added to silence a compiler warning that occurrs when we manually inline a static member, since the member would be included in the type both from the inherited interface and the manual implementation.