### PR TITLE
[uikit] Add all UISpringLoadedInteractionSupporting

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -2333,8 +2333,11 @@ namespace XamCore.UIKit {
 	
 	[iOS (8,0)]
 	[BaseType (typeof (UIViewController))]
-	// Should conform to UISpringLoadedInteractionSupporting according to headers but doesn't. Filed //radar: https://trello.com/b/ZXs89x7A
-	partial interface UIAlertController {
+	partial interface UIAlertController
+#if IOS
+		: UISpringLoadedInteractionSupporting
+#endif
+	{
 		[Export ("initWithNibName:bundle:")]
 		[PostGet ("NibBundle")]
 		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
@@ -4032,7 +4035,11 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (UIScrollView))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: UICollectionView must be initialized with a non-nil layout parameter
 	[DisableDefaultCtor]
-	interface UICollectionView : NSCoding, UIDataSourceTranslating {
+	interface UICollectionView : NSCoding, UIDataSourceTranslating
+#if IOS
+		, UISpringLoadedInteractionSupporting
+#endif
+	{
 		[DesignatedInitializer]
 		[Export ("initWithFrame:collectionViewLayout:"), PostGet ("CollectionViewLayout")]
 		IntPtr Constructor (CGRect frame, UICollectionViewLayout layout);
@@ -7792,8 +7799,11 @@ namespace XamCore.UIKit {
 	
 #if !WATCH
 	[BaseType (typeof (UIControl))]
-	// Should conform to UISpringLoadedInteractionSupporting according to headers but doesn't. Filed //radar: https://trello.com/b/ZXs89x7A
-	interface UIButton : UIAccessibilityContentSizeCategoryImageAdjusting {
+	interface UIButton : UIAccessibilityContentSizeCategoryImageAdjusting
+#if IOS
+		, UISpringLoadedInteractionSupporting
+#endif
+	{
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -10771,7 +10781,11 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof(UIControl))]
-	interface UISegmentedControl {
+	interface UISegmentedControl
+#if IOS
+		: UISpringLoadedInteractionSupporting
+#endif
+	{
 		[Export ("initWithItems:")]
 		IntPtr Constructor (NSArray items);
 
@@ -11172,8 +11186,11 @@ namespace XamCore.UIKit {
 	}
 
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UITabBarDelegate)})]
-	// Should conform to UISpringLoadedInteractionSupporting according to headers but doesn't. Filed //radar: https://trello.com/b/ZXs89x7A
-	interface UITabBar {
+	interface UITabBar
+#if IOS
+		: UISpringLoadedInteractionSupporting
+#endif
+	{
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
@@ -11389,7 +11406,11 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof (UIBarItem))]
-	interface UITabBarItem : NSCoding {
+	interface UITabBarItem : NSCoding
+#if IOS
+		, UISpringLoadedInteractionSupporting
+#endif
+	{
 		[Export ("enabled")][Override]
 		bool Enabled { [Bind ("isEnabled")] get; set; }
 
@@ -11473,7 +11494,11 @@ namespace XamCore.UIKit {
 	}
 	
 	[BaseType (typeof(UIScrollView))]
-	interface UITableView : NSCoding, UIDataSourceTranslating {
+	interface UITableView : NSCoding, UIDataSourceTranslating
+#if IOS
+		, UISpringLoadedInteractionSupporting
+#endif
+	{
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 

--- a/tests/introspection/iOS/iOSApiProtocolTest.cs
+++ b/tests/introspection/iOS/iOSApiProtocolTest.cs
@@ -640,6 +640,20 @@ namespace Introspection {
 					return !TestRuntime.CheckXcodeVersion (8, 0);
 				}
 				break;
+
+			case "UISpringLoadedInteractionSupporting": // types do not conform to protocol but protocol methods work on those types (see monotouch-test)
+				switch (type.Name) {
+				case "UIButton":
+				case "UICollectionView":
+				case "UISegmentedControl":
+				case "UITableView":
+				case "UITabBar":
+				case "UIAlertController":
+				case "PKPaymentButton":
+				case "PKAddPassButton":
+					return true;
+				}
+				break;
 			}
 			return base.Skip (type, protocolName);
 		}

--- a/tests/monotouch-test/UIKit/UISpringLoadedInteractionSupportingTest.cs
+++ b/tests/monotouch-test/UIKit/UISpringLoadedInteractionSupportingTest.cs
@@ -1,0 +1,104 @@
+﻿//
+// Unit tests for UISpringLoadedInteractionSupportingTest
+//
+// Authors:
+//	Vincent Dondain <vidondai@microsoft.com>
+//
+//
+// Copyright 2017 Microsoft.
+//
+
+#if !__TVOS__ && !__WATCHOS__
+
+using System;
+#if XAMCORE_2_0
+using CoreGraphics;
+using Foundation;
+using ObjCRuntime;
+using UIKit;
+#else
+using MonoTouch.CoreGraphics;
+using MonoTouch.Foundation;
+using MonoTouch.ObjCRuntime;
+using MonoTouch.UIKit;
+#endif
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.UIKit {
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class UISpringLoadedInteractionSupportingTest {
+
+		[SetUp]
+		public void Setup ()
+		{
+			TestRuntime.AssertXcodeVersion (9, 0);
+		}
+
+		[Test]
+		public void UIAlertControllerSpringLoadTest ()
+		{
+			var alertController = new UIAlertController ();
+			alertController.SpringLoaded = true;
+			Assert.IsTrue (alertController.SpringLoaded);
+		}
+
+		[Test]
+		public void UIBarButtonItemSpringLoadTest ()
+		{
+			var barButtonItem = new UIBarButtonItem ();
+			barButtonItem.SpringLoaded = true;
+			Assert.IsTrue (barButtonItem.SpringLoaded);
+		}
+
+		[Test]
+		public void UIButtonSpringLoadTest ()
+		{
+			var button = new UIButton ();
+			button.SpringLoaded = true;
+			Assert.IsTrue (button.SpringLoaded);
+		}
+
+		[Test]
+		public void UICollectionViewSpringLoadTest ()
+		{
+			var collectionView = new UICollectionView (new CGRect (0, 0, 100, 100), new UICollectionViewLayout ());
+			collectionView.SpringLoaded = true;
+			Assert.IsTrue (collectionView.SpringLoaded);
+		}
+
+		[Test]
+		public void UISegmentedControlSpringLoadTest ()
+		{
+			var segmentedControl = new UISegmentedControl ();
+			segmentedControl.SpringLoaded = true;
+			Assert.IsTrue (segmentedControl.SpringLoaded);
+		}
+
+		[Test]
+		public void UITabBarItemSpringLoadTest ()
+		{
+			var tabBarItem = new UITabBarItem ();
+			tabBarItem.SpringLoaded = true;
+			Assert.IsTrue (tabBarItem.SpringLoaded);
+		}
+
+		[Test]
+		public void UITabBarSpringLoadTest ()
+		{
+			var tabBar = new UITabBar ();
+			tabBar.SpringLoaded = true;
+			Assert.IsTrue (tabBar.SpringLoaded);
+		}
+
+		[Test]
+		public void UITableViewSpringLoadTest ()
+		{
+			var tableView = new UITableView ();
+			tableView.SpringLoaded = true;
+			Assert.IsTrue (tableView.SpringLoaded);
+		}
+	}
+}
+
+#endif // !__TVOS__ && !__WATCHOS__

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -677,6 +677,7 @@
     <Compile Include="ModelIO\MDLTransformComponentTest.cs" />
     <Compile Include="ModelIO\MDLCameraTest.cs" />
     <Compile Include="ModelIO\MDLStereoscopicCameraTest.cs" />
+    <Compile Include="UIKit\UISpringLoadedInteractionSupportingTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
Types do not conform to the protocol but protocol methods work on those types (see monotouch-test).
Fixed introspection tests accordingly and tested the selectors in monotouch-test.