### PR TITLE
[avfoundation][watchos] Enable AudioBufferList (fix #59145) + audit (xtro)

### DIFF
--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -898,6 +898,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoTV, iOS (11,0)]
+	[NoWatch]
 	[Native]
 	public enum AVCaptureLensStabilizationStatus : nint
 	{

--- a/src/AudioToolbox/AudioType.cs
+++ b/src/AudioToolbox/AudioType.cs
@@ -1140,7 +1140,6 @@ namespace XamCore.AudioToolbox {
 		}
 	}
 
-#if !WATCH
 	[StructLayout(LayoutKind.Sequential)]
 	public struct AudioBuffer {
 		public int NumberChannels;
@@ -1165,5 +1164,4 @@ namespace XamCore.AudioToolbox {
 		public /* UInt16 */ ushort Reserved;
 	}
 #endif
-#endif // !WATCH
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -768,6 +768,7 @@ WATCHOS_EXTRA_CORE_SOURCES = \
     $(WATCH_BUILD_DIR)/Constants.cs    \
     $(WATCH_BUILD_DIR)/AssemblyInfo.cs \
     $(IOS_OPENTK_1_0_CORE_SOURCES)     \
+    AudioToolbox/AudioBuffers.cs       \
     AudioToolbox/AudioType.cs          \
 	$(SHARED_SYSTEM_DRAWING_SOURCES)   \
 	$(MONO_PATH)/mcs/class/System.Drawing/System.Drawing/Color.cs \

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -454,6 +454,7 @@ namespace XamCore.AVFoundation {
 		Unknown = 5,
 	}
 
+	[NoWatch]
 	enum AVFileTypes {
 		[Field ("AVFileTypeQuickTimeMovie")]
 		QuickTimeMovie = 0,
@@ -884,12 +885,11 @@ namespace XamCore.AVFoundation {
 		nuint Bus { get; }
 	}
 
-	// AudioBufferList is binded as AudioBuffers which is in AudioToolbox, uncomment once bug #59145 is fixed
-#if !WATCH && XAMCORE_2_0
+#if XAMCORE_2_0
 	[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
-	delegate AVAudioEngineManualRenderingStatus AVAudioEngineManualRenderingBlock (/* AVAudioFrameCount = uint */ uint numberOfFrames, AudioBuffers outBuffer, [NullAllowed] /* OSStatus */ int outError);
+	delegate AVAudioEngineManualRenderingStatus AVAudioEngineManualRenderingBlock (/* AVAudioFrameCount = uint */ uint numberOfFrames, AudioBuffers outBuffer, [NullAllowed] /* OSStatus */ ref int outError);
 #endif
-	
+
 	[Watch (3,0)]
 	[iOS (8,0)][Mac (10,10)]
 	[BaseType (typeof (NSObject))]
@@ -903,7 +903,8 @@ namespace XamCore.AVFoundation {
 		[Export ("outputNode")]
 		AVAudioOutputNode OutputNode { get; }
 
-		[NoTV, NoWatch]
+		[TV (11,0)]
+		[Watch (4,0)]
 		[Export ("inputNode"), NullAllowed]
 		AVAudioInputNode InputNode { get; }
 
@@ -982,8 +983,7 @@ namespace XamCore.AVFoundation {
 		[Export ("renderOffline:toBuffer:error:")]
 		AVAudioEngineManualRenderingStatus RenderOffline (uint numberOfFrames, AVAudioPcmBuffer buffer, [NullAllowed] out NSError outError);
 
-		// uncomment once bug #59145 is fixed
-#if !WATCH && XAMCORE_2_0
+#if XAMCORE_2_0
 		[Watch (4, 0), TV (11, 0), Mac (10, 13), iOS (11, 0)]
 		[Export ("manualRenderingBlock")]
 		AVAudioEngineManualRenderingBlock ManualRenderingBlock { get; }
@@ -1358,10 +1358,8 @@ namespace XamCore.AVFoundation {
 	interface AVAudioOutputNode {
 
 	}	
-	
-	// AudioBufferList is binded as AudioBuffers which is present in AudioToolbox which is not present on the watch. bug filled: 
-	// https://bugzilla.xamarin.com/show_bug.cgi?id=59145
-#if !WATCH && XAMCORE_2_0
+
+#if XAMCORE_2_0
 	[Watch (4,0), TV (11,0), Mac (10,10), iOS (8,0)]
 	delegate AudioBuffers AVAudioIONodeInputBlock (uint frameCount);
 #endif
@@ -1373,9 +1371,8 @@ namespace XamCore.AVFoundation {
 	// note: sample source (header) suggest it comes from AVAudioEngine properties
 	interface AVAudioInputNode : AVAudioMixing {
 
-		// uncomment once bug 59145 is fixed.
-#if !WATCH && XAMCORE_2_0
-		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
+#if XAMCORE_2_0
+		[Mac (10,13), iOS (11,0)]
 		[Export ("setManualRenderingInputPCMFormat:inputBlock:")]
 		bool SetManualRenderingInputPcmFormat (AVAudioFormat format, AVAudioIONodeInputBlock block);
 #endif
@@ -1516,7 +1513,8 @@ namespace XamCore.AVFoundation {
 		[Since (7,0), Mac (10,9), Export ("initWithContentsOfURL:fileTypeHint:error:")]
 		IntPtr Constructor (NSUrl url, [NullAllowed] string fileTypeHint, out NSError outError);
 
-		[NoWatch, iOS (10, 0), TV (10,0), Mac (10,12)]
+		[iOS (10, 0), TV (10,0), Mac (10,12)]
+		[Watch (4,0)]
 		[Export ("format")]
 		AVAudioFormat Format { get; }
 	}
@@ -1623,7 +1621,8 @@ namespace XamCore.AVFoundation {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[NoTV, NoWatch]
+	[NoTV]
+	[Watch (4,0)]
 	interface AVAudioRecorder {
 		[Export ("initWithURL:settings:error:")][Internal]
 		IntPtr InitWithUrl (NSUrl url, NSDictionary settings, out NSError error);
@@ -1718,7 +1717,8 @@ namespace XamCore.AVFoundation {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	[NoTV, NoWatch]
+	[NoTV]
+	[Watch (4,0)]
 	interface AVAudioRecorderDelegate {
 		[Export ("audioRecorderDidFinishRecording:successfully:"), CheckDisposed]
 		void FinishedRecording (AVAudioRecorder recorder, bool flag);
@@ -2097,7 +2097,8 @@ namespace XamCore.AVFoundation {
 		[PostGet ("OutputDataSource")]
 		bool SetOutputDataSource ([NullAllowed] AVAudioSessionDataSourceDescription dataSource, out NSError outError);
 
-		[NoTV, NoWatch]
+		[NoTV]
+		[Watch (4,0)]
 		[Since (7,0)]
 		[Export ("requestRecordPermission:")]
 		void RequestRecordPermission (AVPermissionGranted responseCallback);

--- a/src/generator-typemanager.cs
+++ b/src/generator-typemanager.cs
@@ -253,8 +253,9 @@ public static class TypeManager {
 			ABPerson = Lookup (platform_assembly, "AddressBook", "ABPerson");
 			ABRecord = Lookup (platform_assembly, "AddressBook", "ABRecord");
 		}
+		// misplaced API, it's really in CoreAudio (now available everywhere)
+		AudioBuffers = Lookup (platform_assembly, "AudioToolbox", "AudioBuffers");
 		if (Frameworks.HaveAudioToolbox) {
-			AudioBuffers = Lookup (platform_assembly, "AudioToolbox", "AudioBuffers");
 			MusicSequence = Lookup (platform_assembly, "AudioToolbox", "MusicSequence", true /* may not be found */);
 		}
 		if (Frameworks.HaveAudioUnit) {

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1762,7 +1762,7 @@ public partial class Generator : IMemberGatherer {
 		}
 
 		// This means you need to add a new MarshalType in the method "Go"
-		throw new BindingException (1002, true, "Unknown kind {0} in method '{1}.{2}'", pi, mi.DeclaringType.FullName, mi.Name.GetSafeParamName ());
+		throw new BindingException (1002, true, "Unknown kind {0} in method '{1}.{2}'", pi.ParameterType.FullName, mi.DeclaringType.FullName, mi.Name.GetSafeParamName ());
 	}
 
 	public bool ParameterNeedsNullCheck (ParameterInfo pi, MethodInfo mi, PropertyInfo propInfo = null)
@@ -2147,8 +2147,8 @@ public partial class Generator : IMemberGatherer {
 		marshal_types.Add (TypeManager.SecIdentity);
 		marshal_types.Add (TypeManager.SecTrust);
 		marshal_types.Add (TypeManager.SecAccessControl);
+		marshal_types.Add (TypeManager.AudioBuffers);
 		if (Frameworks.HaveAudioUnit) {
-			marshal_types.Add (TypeManager.AudioBuffers);
 			marshal_types.Add (TypeManager.AURenderEventEnumerator);
 		}
 

--- a/tests/xtro-sharpie/watchos.ignore
+++ b/tests/xtro-sharpie/watchos.ignore
@@ -8,6 +8,9 @@
 ## types/members marked as deprecated in watchOS 2.0 (even if the framework was not available before 3.0)
 AVAudioPlayerDelegate::audioPlayerEndInterruption:withOptions:
 
+## it's not exposed in the API offered by watchOS
+!missing-enum! AVAudioSessionRecordPermission not bound
+
 
 # CoreBluetooth
 


### PR DESCRIPTION
1. AudioBufferList is part of CoreAudio (wrong namespace, which needs
   a few changes in the generator) and now available in watchOS 4
   https://bugzilla.xamarin.com/show_bug.cgi?id=59145

2. Also fixes xtro found issues:

!missing-type! AVAudioRecorder not bound
!missing-selector! AVAudioRecorder::averagePowerForChannel: not bound
!missing-selector! AVAudioRecorder::channelAssignments not bound
!missing-selector! AVAudioRecorder::currentTime not bound
!missing-selector! AVAudioRecorder::delegate not bound
!missing-selector! AVAudioRecorder::deviceCurrentTime not bound
!missing-selector! AVAudioRecorder::format not bound
!missing-selector! AVAudioRecorder::initWithURL:format:error: not bound
!missing-selector! AVAudioRecorder::initWithURL:settings:error: not bound
!missing-selector! AVAudioRecorder::isMeteringEnabled not bound
!missing-selector! AVAudioRecorder::isRecording not bound
!missing-selector! AVAudioRecorder::peakPowerForChannel: not bound
!missing-selector! AVAudioRecorder::recordAtTime: not bound
!missing-selector! AVAudioRecorder::recordAtTime:forDuration: not bound
!missing-selector! AVAudioRecorder::recordForDuration: not bound
!missing-selector! AVAudioRecorder::setChannelAssignments: not bound
!missing-selector! AVAudioRecorder::setDelegate: not bound
!missing-selector! AVAudioRecorder::setMeteringEnabled: not bound
!missing-selector! AVAudioRecorder::settings not bound
!missing-selector! AVAudioRecorder::url not bound

!missing-protocol! AVAudioRecorderDelegate not bound

!missing-selector! AVAudioEngine::inputNode not bound
!missing-selector! AVAudioEngine::manualRenderingBlock not bound
!missing-selector! AVAudioInputNode::setManualRenderingInputPCMFormat:inputBlock: not bound
!missing-selector! AVAudioPlayer::format not bound
!missing-selector! AVAudioSession::requestRecordPermission: not bound

!unknown-field! AVFileType3GPP bound
!unknown-field! AVFileType3GPP2 bound
!unknown-field! AVFileTypeAC3 bound
!unknown-field! AVFileTypeAIFC bound
!unknown-field! AVFileTypeAIFF bound
!unknown-field! AVFileTypeAMR bound
!unknown-field! AVFileTypeAVCI bound
!unknown-field! AVFileTypeAppleM4A bound
!unknown-field! AVFileTypeAppleM4V bound
!unknown-field! AVFileTypeCoreAudioFormat bound
!unknown-field! AVFileTypeDNG bound
!unknown-field! AVFileTypeEnhancedAC3 bound
!unknown-field! AVFileTypeHEIC bound
!unknown-field! AVFileTypeHEIF bound
!unknown-field! AVFileTypeJPEG bound
!unknown-field! AVFileTypeMPEG4 bound
!unknown-field! AVFileTypeMPEGLayer3 bound
!unknown-field! AVFileTypeQuickTimeMovie bound
!unknown-field! AVFileTypeSunAU bound
!unknown-field! AVFileTypeTIFF bound
!unknown-field! AVFileTypeWAVE bound