### PR TITLE
[opengles] Enable the new API using IOSurface

### DIFF
--- a/src/opengles.cs
+++ b/src/opengles.cs
@@ -80,13 +80,12 @@ namespace XamCore.OpenGLES {
 		[Export ("multiThreaded")]
 		bool IsMultiThreaded { [Bind ("isMultiThreaded")] get; set; }
 
-#if false // https://bugzilla.xamarin.com/show_bug.cgi?id=58054
 		// IOSurface (EAGLContext)
 
 		[iOS (11,0)]
+		[TV (11,0)]
 		[Export ("texImageIOSurface:target:internalFormat:width:height:format:type:plane:")]
-		bool TexImage (IOSurface ioSurface, nuint target, nuint internalFormat, uint width, uint height, nuint format, nuint type, uint plane);
-#endif
+		bool TexImage (IOSurface.IOSurface ioSurface, nuint target, nuint internalFormat, uint width, uint height, nuint format, nuint type, uint plane);
 	}
 
 	[Protocol]

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -276,6 +276,17 @@ namespace Introspection {
 					break;
 				}
 				break;
+			case "EAGLContext":
+				switch (name) {
+				// symbol only exists on devices (not in simulator libraries)
+				case "texImageIOSurface:target:internalFormat:width:height:format:type:plane:":
+					if (Runtime.Arch == Arch.SIMULATOR)
+						return true;
+					if (!TestRuntime.CheckXcodeVersion (9, 0))
+						return true;
+					break;
+				}
+				break;
 			}
 
 			switch (name) {


### PR DESCRIPTION
The symbol only exists inside device libraries, not on simulator,
and the introspection tests were updated to ignore it.

Part of https://bugzilla.xamarin.com/show_bug.cgi?id=58054