### PR TITLE
[metal] Audit (xtro) based fixes

### DIFF
--- a/src/Metal/MTLDevice.cs
+++ b/src/Metal/MTLDevice.cs
@@ -48,6 +48,17 @@ namespace XamCore.Metal {
 		}
 
 #if MONOMAC
+		[Mac (10,11, onlyOn64: true), NoiOS, NoWatch, NoTV]
+		[DllImport (Constants.MetalLibrary)]
+		unsafe static extern IntPtr MTLCopyAllDevices ();
+
+		[Mac (10,11, onlyOn64: true), NoiOS, NoWatch, NoTV]
+		public static IMTLDevice [] GetAllDevices ()
+		{
+			var rv = MTLCopyAllDevices ();
+			return NSArray.ArrayFromHandle<IMTLDevice> (rv);
+		}
+
 		[Mac (10, 13, onlyOn64: true), NoiOS, NoWatch, NoTV]
 		[DllImport (Constants.MetalLibrary)]
 		unsafe static extern IntPtr MTLCopyAllDevicesWithObserver (ref IntPtr observer, void* handler);

--- a/src/Metal/MTLEnums.cs
+++ b/src/Metal/MTLEnums.cs
@@ -713,6 +713,9 @@ namespace XamCore.Metal {
 		Sample0, Min, Max
 	}
 
+#if XAMCORE_4_0
+	[NoiOS][NoTV]
+#endif
 	[Mac (10,12)]
 	[Native]
 	public enum MTLSamplerBorderColor : nuint {

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -448,6 +448,7 @@ namespace XamCore.Metal {
 		void Wait (IMTLFence fence);
 
 		[Mac (10,13, onlyOn64: true)]
+		[NoTV][NoiOS]
 #if XAMCORE_4_0
 		[Abstract]
 #endif
@@ -809,7 +810,7 @@ namespace XamCore.Metal {
 		[Export ("removable")]
 		bool Removable { [Bind ("isRemovable")] get; }
 
-		[Mac (10, 13), NoiOS, NoWatch, NoTV]
+		[Mac (10,13), iOS (11,0), TV (11,0), NoWatch]
 #if XAMCORE_4_0
 		[Abstract]
 #endif
@@ -887,6 +888,23 @@ namespace XamCore.Metal {
 #endif
 		[Export ("currentAllocatedSize")]
 		nuint CurrentAllocatedSize { get; }
+
+#if false // https://bugzilla.xamarin.com/show_bug.cgi?id=59342
+		[Mac (10,13, onlyOn64: true), NoiOS, NoTV, NoWatch]
+		[Notification]
+		[Field ("MTLDeviceWasAddedNotification")]
+		NSString DeviceWasAdded { get; }
+
+		[Mac (10,13, onlyOn64: true), NoiOS, NoTV, NoWatch]
+		[Notification]
+		[Field ("MTLDeviceRemovalRequestedNotification")]
+		NSString DeviceRemovalRequested { get; }
+
+		[Mac (10,13, onlyOn64: true), NoiOS, NoTV, NoWatch]
+		[Notification]
+		[Field ("MTLDeviceWasRemovedNotification")]
+		NSString DeviceWasRemoved { get; }
+#endif
 	}
 
 	interface IMTLDrawable {}
@@ -2419,7 +2437,7 @@ namespace XamCore.Metal {
 	}
 
 	[Mac (10,13, onlyOn64: true), iOS (11,0), TV (11,0), NoWatch]
-	[BaseType (typeof(NSObject))]
+	[BaseType (typeof(MTLType))]
 	interface MTLPointerType
 	{
 		[Export ("elementType")]
@@ -2523,18 +2541,6 @@ namespace XamCore.Metal {
 
 		[Export ("isCapturing")]
 		bool IsCapturing { get; }
-	}
-
-	[Mac (10, 13, onlyOn64: true), NoiOS, NoTV, NoWatch]
-	interface MTLDeviceNotificationName {
-		[Field ("MTLDeviceWasAddedNotification")]
-		NSString DeviceWasAdded { get; set; }
-
-		[Field ("MTLDeviceRemovalRequestedNotification")]
-		NSString DeviceRemovalRequested { get; set; }
-
-		[Field ("MTLDeviceWasRemovedNotification")]
-		NSString MTLDeviceWasRemoved { get; set; }
 	}
 
 	[Mac (10,13, onlyOn64: true), iOS (11,0), TV (11,0), NoWatch]
@@ -2643,6 +2649,7 @@ namespace XamCore.Metal {
 		[Export ("constantDataAtIndex:")]
 		IntPtr GetConstantData (nuint index);
 
+		[NoTV][NoiOS]
 		[Abstract]
 		[Export ("newArgumentEncoderForBufferAtIndex:")]
 		[return: NullAllowed]

--- a/tests/xtro-sharpie/osx.pending
+++ b/tests/xtro-sharpie/osx.pending
@@ -428,6 +428,14 @@
 !missing-selector! MPMediaItemArtwork::imageCropRect not bound
 
 
+# Metal
+
+## [Notification] in protocol - https://bugzilla.xamarin.com/show_bug.cgi?id=59342
+!missing-field! MTLDeviceRemovalRequestedNotification not bound
+!missing-field! MTLDeviceWasAddedNotification not bound
+!missing-field! MTLDeviceWasRemovedNotification not bound
+
+
 # Not available in OS X
 !missing-selector! ACAccount::userFullName not bound
 


### PR DESCRIPTION
!extra-protocol-member! unexpected selector MTLArgumentEncoder::newArgumentEncoderForBufferAtIndex: found
!extra-protocol-member! unexpected selector MTLComputeCommandEncoder::dispatchThreads:threadsPerThreadgroup: found

macos-only

!missing-field! MTLDeviceRemovalRequestedNotification not bound
!missing-field! MTLDeviceWasAddedNotification not bound
!missing-field! MTLDeviceWasRemovedNotification not bound

!missing-pinvoke! MTLCopyAllDevices is not bound