### PR TITLE
[audiounit] Audit (xtro) fixes for tvOS

### DIFF
--- a/src/AudioUnit/AudioComponent.cs
+++ b/src/AudioUnit/AudioComponent.cs
@@ -395,6 +395,8 @@ namespace XamCore.AudioUnit
 			return new XamCore.AppKit.NSImage (AudioComponentGetIcon (handle));
 		}
 #endif
+
+#if IOS || MONOMAC
 		[NoWatch, NoTV, Mac (10,13), iOS (11,0)]
 		[DllImport (Constants.AudioUnitLibrary)]
 		static extern int /* OSStatus */ AudioUnitExtensionSetComponentList (IntPtr /* CFString */ extensionIdentifier, /* CFArrayRef */ IntPtr audioComponentInfo);
@@ -444,6 +446,7 @@ namespace XamCore.AudioUnit
 				}
 			}
 		}
+#endif
 
 #endif // !COREBUILD
     }

--- a/tests/monotouch-test/AudioToolbox/AudioComponentTest.cs
+++ b/tests/monotouch-test/AudioToolbox/AudioComponentTest.cs
@@ -1,6 +1,6 @@
 // Copyright 2011 Xamarin Inc. All rights reserved
 
-#if !__WATCHOS__
+#if IOS || MONOMAC
 using System;
 using System.Drawing;
 using System.IO;
@@ -119,4 +119,4 @@ namespace MonoTouchFixtures.AudioToolbox {
 	}
 }
 
-#endif // !__WATCHOS__
+#endif


### PR DESCRIPTION
Availability attributes in non-generated files don't hide symbols/code.

reference:
!unknown-pinvoke! AudioUnitExtensionCopyComponentList bound
!unknown-pinvoke! AudioUnitExtensionSetComponentList bound