### PR TITLE
[tests] Update xtro to reduce list sizes

### DIFF
--- a/tests/xtro-sharpie/EnumCheck.cs
+++ b/tests/xtro-sharpie/EnumCheck.cs
@@ -22,7 +22,9 @@ namespace Extrospection {
 			// e.g. WatchKit.WKErrorCode and WebKit.WKErrorCode :-(
 			if (!enums.TryGetValue (name, out td))
 				enums.Add (name, type);
-			else {
+			else if (td.Namespace.StartsWith ("OpenTK.", StringComparison.Ordinal)) {
+				// OpenTK duplicate a lots of enums between it's versions
+			} else {
 				Console.WriteLine ("!duplicate-type-name! {0} enum exists as both {1} and {2}", name, type.FullName, td.FullName);
 			}
 		}

--- a/tests/xtro-sharpie/common.ignore
+++ b/tests/xtro-sharpie/common.ignore
@@ -1,7 +1,7 @@
 # ARKit
 
 ## This method is manually bound.
-!simd-missing-marshaldirective! System.IntPtr ARKit.ARPointCloud::GetRawPoints(): simd type: vector_float3
+!wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARPointCloud::GetRawPoints(): simd type: vector_float3
 
 # AVFoundation
 

--- a/tests/xtro-sharpie/common.pending
+++ b/tests/xtro-sharpie/common.pending
@@ -702,3 +702,31 @@
 ## 34185961 The header WKSnapshotConfiguration.h is not included inside the umbrella WebKit.h
 !unknown-type! WKSnapshotConfiguration bound
 
+
+# recent xtro changes
+
+## init
+!missing-designated-initializer! CXAction::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! MPSBinaryImageKernel::initWithDevice: is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! MPSCNNKernel::initWithDevice: is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! MPSImageLanczosScale::initWithDevice: is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! MPSUnaryImageKernel::initWithDevice: is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! MSMessage::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! PKAddPaymentPassRequest::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! SLComposeSheetConfigurationItem::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! UIBarButtonItem::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! UIBarItem::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! UIBezierPath::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! UICollectionViewLayout::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! UICubicTimingParameters::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! UIDragPreviewParameters::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! UIImageAsset::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! UIKeyCommand::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! UILocalNotification::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! UIMotionEffect::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! UIPasteConfiguration::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! UISpringTimingParameters::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! UITabBarItem::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! UITraitCollection::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! UIUserNotificationAction::init is missing an [DesignatedInitializer] attribute
+!missing-designated-initializer! UIUserNotificationCategory::init is missing an [DesignatedInitializer] attribute

--- a/tests/xtro-sharpie/tvos.pending
+++ b/tests/xtro-sharpie/tvos.pending
@@ -14,6 +14,10 @@
 !missing-selector! AVPlayerItem::setExternalSubtitleOptionLanguages: not bound
 !missing-selector! AVPlayerItem::setSelectedExternalSubtitleOptionLanguage: not bound
 
+## this was tvos 10.2 in Xcode 8.3 and changed to iOS-only in Xcode9 betas
+## it's still exposed by AVContentKeySessionDelegate which is available in tvos 10.2
+!unknown-type! AVPersistableContentKeyRequest bound
+
 
 # CloudKit
 


### PR DESCRIPTION
* Skip OpenTK duplicate declaration (we can't change them);
* Fix rule name change for ARKit / simd;
* Add missing default initializer on `init` to pending actions;
* Add note for AVPersistableContentKeyRequest changes wrt tvOS;