### PR TITLE
[Foundation/UIKit] Provide LoadObject[s] methods that return the expected type in the callback. Fixes #59049.

### DIFF
--- a/src/Foundation/NSItemProvider.cs
+++ b/src/Foundation/NSItemProvider.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Threading.Tasks;
 using XamCore.CloudKit;
+using XamCore.ObjCRuntime;
 
 namespace XamCore.Foundation 
 {
-#if MONOMAC && XAMCORE_2_0 // Only 64-bit on mac
+#if (MONOMAC || IOS) && XAMCORE_2_0 // Only 64-bit on mac
 	public partial class NSItemProvider
 	{
-#if !XAMCORE_4_0
+#if !XAMCORE_4_0 && MONOMAC
 		[Obsolete ("Use RegisterCloudKitShare (CloudKitRegistrationPreparationAction) instead.")]
 		public virtual void RegisterCloudKitShare (Action<CloudKitRegistrationPreparationHandler> preparationHandler)
 		{
@@ -16,6 +17,7 @@ namespace XamCore.Foundation
 		}
 #endif
 		
+#if MONOMAC
 		public virtual Task<CloudKitRegistrationPreparationHandler> RegisterCloudKitShareAsync ()
 		{
 			var tcs = new TaskCompletionSource<CloudKitRegistrationPreparationHandler> ();
@@ -25,6 +27,45 @@ namespace XamCore.Foundation
 			RegisterCloudKitShare (action);
 			return tcs.Task;
 		}
-	}
 #endif
+
+		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
+		public NSProgress LoadObject<T> (Action<T, NSError> completionHandler) where T: NSObject, INSItemProviderReading
+		{
+			return LoadObject (new Class (typeof (T)), (rv, err) =>
+			{
+				var obj = rv as T;
+				if (obj == null && rv != null)
+					obj = Runtime.ConstructNSObject<T> (rv.Handle);
+				completionHandler (obj, err);
+			});
+		}
+
+		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
+		public Task<T> LoadObjectAsync<T> () where T: NSObject, INSItemProviderReading
+		{
+			var rv = LoadObjectAsync (new Class (typeof (T)));
+			return rv.ContinueWith ((v) =>
+			{
+				var obj = v.Result as T;
+				if (obj == null && v.Result != null)
+					obj = Runtime.ConstructNSObject<T> (v.Result.Handle);
+				return obj;
+			});
+		}
+
+		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
+		public Task<T> LoadObjectAsync<T> (out NSProgress result) where T: NSObject, INSItemProviderReading
+		{
+			var rv = LoadObjectAsync (new Class (typeof (T)), out result);
+			return rv.ContinueWith ((v) =>
+			{
+				var obj = v.Result as T;
+				if (obj == null && v.Result != null)
+					obj = Runtime.ConstructNSObject<T> (v.Result.Handle);
+				return obj;
+			});
+		}
+	}
+#endif // (MONOMAC || IOS) && XAMCORE_2_0
 }

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -954,6 +954,11 @@ namespace XamCore.ObjCRuntime {
 			}
 		}
 
+		internal static T ConstructNSObject<T> (IntPtr ptr) where T: NSObject
+		{
+			return ConstructNSObject<T> (ptr, typeof (T), MissingCtorResolution.ThrowConstructor1NotFound);
+		}
+
 		// The generic argument T is only used to cast the return value.
 		static T ConstructNSObject<T> (IntPtr ptr, Type type, MissingCtorResolution missingCtorResolution) where T: class, INativeObject
 		{

--- a/src/UIKit/UIDragDropSessionExtensions.cs
+++ b/src/UIKit/UIDragDropSessionExtensions.cs
@@ -17,9 +17,21 @@ namespace XamCore.UIKit {
 
 	public static class UIDragDropSessionExtensions {
 
-		public static NSProgress LoadObjects (this IUIDropSession session, Type type, Action<INSItemProviderReading []> completion)
+		public static NSProgress LoadObjects<T> (this IUIDropSession session, Action<T []> completion) where T: NSObject, INSItemProviderReading
 		{
-			return session.LoadObjects (new Class (type), completion);
+			return session.LoadObjects (new Class (typeof (T)), (v) =>
+			{
+				var arr = v as T[];
+				if (arr == null && v != null) {
+					arr = new T [v.Length];
+					for (int i = 0; i < arr.Length; i++) {
+						if (v [i] != null)
+							arr [i] = Runtime.ConstructNSObject<T> (v [i].Handle);
+					}
+				}
+
+				completion (arr);
+			});
 		}
 
 		public static bool CanLoadObjects (this IUIDragDropSession session, Type type)

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -9712,11 +9712,6 @@ namespace XamCore.Foundation
 		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
 		[Async, Export ("loadObjectOfClass:completionHandler:")]
 		NSProgress LoadObject (Class aClass, Action<INSItemProviderReading, NSError> completionHandler);
-
-		[Watch (4,0), TV (11,0), Mac (10,13), iOS (11,0)]
-		[Async, Wrap ("LoadObject (new Class (type), completionHandler)")]
-		NSProgress LoadObject (Type type, Action<INSItemProviderReading, NSError> completionHandler);
-
 #if !MONOMAC
 		// NSItemProvider_UIKitAdditions category
 

--- a/tests/monotouch-test/UIKit/UIDragDropSessionExtensionsTest.cs
+++ b/tests/monotouch-test/UIKit/UIDragDropSessionExtensionsTest.cs
@@ -37,7 +37,7 @@ namespace MonoTouchFixtures.UIKit {
 
 			var test = new DropSession ();
 			test.CanLoadObjects (typeof (UIImage));
-			test.LoadObjects (typeof (UIImage), null);
+			test.LoadObjects<UIImage> (null);
 		}
 	}
 


### PR DESCRIPTION
The callback for these LoadObject[s] methods take an INSItemProviderReading parameter. This tells our runtime that we must provide an instance of a managed object that implements this interface (but nothing else), so we create a `NSItemProviderReadingWrapper` instance, which complies with the API (since the wrapper type implements the corresponding interface).

Unfortunately these methods are supposed to return an instance of the passed-in type, so in order to comply with this soft (documentation-only) requirement, provide a wrapper method that creates instances of the right types.

https://bugzilla.xamarin.com/show_bug.cgi?id=59049