### PR TITLE
[DONT_MERGE_YET][msbuild][mac][ios] bxc#58504: Fix referencing netstandard projects

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.msbuild.targets
@@ -33,13 +33,35 @@ Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 	</PropertyGroup>
 
 	<!-- Implicitly references all portable design-time facades if the user is referencing a System.Runtime-based portable library -->
+
+	<UsingTask
+		TaskName="GetDependsOnNETStandard"
+		Condition="'$(IsXBuild)' != 'true'"
+		AssemblyFile="$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll" />
+
 	<Target Name="ImplicitlyExpandDesignTimeFacades" DependsOnTargets="$(ImplicitlyExpandDesignTimeFacadesDependsOn)">
+		<ItemGroup>
+			<XM_CandidateNETStandardReferences Include="@(Reference);@(_ResolvedProjectReferencePaths)" />
+			<XM_InboxNETStandardFolders Include="$(TargetFrameworkDirectory)" />
+		</ItemGroup>
+
+		<!-- This file is imported for Modern projects, which have have `$(TargetFrameworkIdentifier) != .NETFramework`, so Microsoft.NET.Build.Extensions
+		     (which provides support for ns 2.0 projects) doesn't get imported. So, we need to check if any references depend on `netstandard`. And if so,
+		     add an explicit reference to `netstandard.dll` -->
+		<GetDependsOnNETStandard
+			Condition="'$(IsXBuild)' != 'true' and '$(DependsOnNETStandard)' == '' and '@(XM_CandidateNETStandardReferences)' != ''"
+			References="@(XM_CandidateNETStandardReferences)">
+			<Output TaskParameter="DependsOnNETStandard" PropertyName="XM_DependsOnNETStandard" />
+		</GetDependsOnNETStandard>
+
 		<PropertyGroup>
 			<!-- Does one of our dependencies reference a System.Runtime-based portable library? -->
 			<_HasReferenceToSystemRuntime Condition="'$(DependsOnSystemRuntime)' == 'true' or '%(_ResolvedProjectReferencePaths.TargetPlatformIdentifier)' == 'Portable'">true</_HasReferenceToSystemRuntime>
+
+			<XM_NETStandardInbox Condition="'$(XM_NETStandardInbox)' == '' and Exists('%(XM_InboxNETStandardFolders.Identity)\netstandard.dll')">true</XM_NETStandardInbox>
 		</PropertyGroup>
 
-		<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true'">
+		<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true' or ('$(XM_NETStandardInbox)' == 'true' and '$(XM_DependsOnNETStandard)' == 'true')">
 			<_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)*.dll"/>
 
 			<_DesignTimeFacadeAssemblies_Names Include="@(_DesignTimeFacadeAssemblies->'%(FileName)')">

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -155,14 +155,34 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<Optimize />
 		</_BundleResourceWithLogicalName>
 	</ItemDefinitionGroup>
-	
+
+	<UsingTask
+		TaskName="GetDependsOnNETStandard"
+		Condition="'$(IsXBuild)' != 'true'"
+		AssemblyFile="$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll" />
+
 	<Target Name="ImplicitlyExpandDesignTimeFacades" Condition="'$(ImplicitlyExpandDesignTimeFacades)' == 'true'" DependsOnTargets="$(ImplicitlyExpandDesignTimeFacadesDependsOn)">
+		<ItemGroup>
+			<XI_CandidateNETStandardReferences Include="@(Reference);@(_ResolvedProjectReferencePaths)" />
+			<XI_InboxNETStandardFolders Include="$(TargetFrameworkDirectory)" />
+		</ItemGroup>
+
+		<!-- XI projects have `$(TargetFrameworkIdentifier) != .NETFramework`, so Microsoft.NET.Build.Extensions (which provides support for ns 2.0 projects) doesn't get
+		     imported. So, we need to check if any references depend on `netstandard`. And if so, add an explicit reference to `netstandard.dll` -->
+		<GetDependsOnNETStandard
+			Condition="'$(IsXBuild)' != 'true' and '$(DependsOnNETStandard)' == '' and '@(XI_CandidateNETStandardReferences)' != ''"
+			References="@(XI_CandidateNETStandardReferences)">
+			<Output TaskParameter="DependsOnNETStandard" PropertyName="XI_DependsOnNETStandard" />
+		</GetDependsOnNETStandard>
+
 		<PropertyGroup>
 			<_HasReferenceToSystemRuntime Condition="'$(DependsOnSystemRuntime)' == 'true' or '%(_ResolvedProjectReferencePaths.TargetPlatformIdentifier)' == 'Portable' 
 								or '%(ReferenceDependencyPaths.Filename)' == 'System.Runtime'">true</_HasReferenceToSystemRuntime>
+
+			<XI_NETStandardInbox Condition="'$(XI_NETStandardInbox)' == '' and Exists('%(XI_InboxNETStandardFolders.Identity)\netstandard.dll')">true</XI_NETStandardInbox>
 		</PropertyGroup>
 
-		<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true'">
+		<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true' or ('$(XI_NETStandardInbox)' == 'true' and '$(XI_DependsOnNETStandard)' == 'true')">
 			<_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)*.dll"/>
 			<ReferencePath Remove="@(_DesignTimeFacadeAssemblies)"/>
 			<ReferencePath Include="%(_DesignTimeFacadeAssemblies.Identity)">


### PR DESCRIPTION
Building a XI or XM (Modern) project that references a netstandard 2.0
project with msbuild fails because of a missing reference to
`netstandard.dll`.

AppDelegate.cs(21,52): error CS0012: The type 'Object' is defined in an assembly that is not referenced. You must add a reference to assembly 'netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'.

The reason is that XI and XM (Modern) projects have
`$(TargetFrameworkIdentifier) != .NETFramework`, so targets from
`Microsoft.NET.Build.Extensions` which provide ns2.0 support don't get
imported. `ImplicitlyExpandNETStandardFacades` in particular, which
would have added a reference to `netstandard.dll`.

So, instead we duplicate that in XI/XM targets. Essentially, we need to
scan all the references for a `netstandard` dependency (using
`GetDependsOnNETStandard` task) and if found, add the `netstandard.dll`
reference.

Partially fixes bxc [58504](https://bugzilla.xamarin.com/show_bug.cgi?id=58504).