### PR TITLE
[msbuild] Adjust verbosity, and set default verbosity level.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -701,18 +701,20 @@ namespace Xamarin.iOS.Tasks
 
 		static string GetVerbosityLevel (int v) {
 			string result = "";
+			// The values here come from: https://github.com/mono/monodevelop/blob/143f9b6617123a0841a5cc5a2a4e13b309535792/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild.Shared/RemoteBuildEngineMessages.cs#L186
+			// Assume 'Normal (2)' is the default verbosity (no change), and the other values follow from there.
 			switch (v) {
 			case 0:
-				result = "-q";
+				result = "-q -q -q -q";
 				break;
 			case 1:
-				result = "-v";
+				result = "-q -q";
 				break;
 			case 2:
-				result = "-v -v";
+				result = "";
 				break;
 			case 3:
-				result = "-v -v -v";
+				result = "-v -v";
 				break;
 			case 4:
 				result = "-v -v -v -v";

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
@@ -51,6 +51,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<MtouchUseThumb Condition="'$(MtouchUseThumb)' == ''">False</MtouchUseThumb>
 		<MtouchProjectDirectory>$(MSBuildProjectDirectory)</MtouchProjectDirectory>
 		<MtouchEnableSGenConc Condition="'$(MtouchEnableSGenConc)' == ''">False</MtouchEnableSGenConc>
+		<MtouchVerbosity Condition="$(MtouchVerbosity) == ''">2</MtouchVerbosity>
 
 		<IsMacEnabled>true</IsMacEnabled>
 		<MtouchTargetsEnabled>$(IsMacEnabled)</MtouchTargetsEnabled>


### PR DESCRIPTION
The MtouchVerbosity value is set when building from VSfM, and in that case the
logic works fine.

However, when building from the command line, or from VS, the default value
for MtouchVerbosity would be '0', which would mean 'Quiet', which is not what
we want the default verbosity to be.

So set the default MtouchVerbosity value to '2' (Normal verbosity), and at the
same time adjust the values passed to mtouch so that 'Normal' actually means
the default (neither quiet nor verbose).