### PR TITLE
[FileProvider] Adds missing NSFileProviderPage constants, fixes bug 59297.

### DIFF
--- a/src/fileprovider.cs
+++ b/src/fileprovider.cs
@@ -56,6 +56,27 @@ namespace XamCore.FileProvider {
 	}
 
 	[iOS (11,0)]
+	[Static]
+	interface NSFileProviderPage {
+
+		[Internal]
+		[Field ("NSFileProviderInitialPageSortedByName")]
+		IntPtr _InitialPageSortedByName { get; }
+
+		[Static]
+		[Wrap ("Runtime.GetNSObject<NSData> (_InitialPageSortedByName)")]
+		NSData InitialPageSortedByName { get; }
+
+		[Internal]
+		[Field ("NSFileProviderInitialPageSortedByDate")]
+		IntPtr _InitialPageSortedByDate { get; }
+
+		[Static]
+		[Wrap ("Runtime.GetNSObject<NSData> (_InitialPageSortedByDate)")]
+		NSData InitialPageSortedByDate { get; }
+	}
+
+	[iOS (11,0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
 	interface NSFileProviderDomain {

--- a/tests/monotouch-test/FileProvider/NSFileProviderPageTest.cs
+++ b/tests/monotouch-test/FileProvider/NSFileProviderPageTest.cs
@@ -1,0 +1,36 @@
+﻿//
+// Unit tests for NSFileProviderPage
+//
+// Authors:
+//	Alex Soto <alexsoto@microsoft.com>
+//
+//
+// Copyright 2017 Xamarin Inc. All rights reserved.
+//
+
+#if XAMCORE_2_0 && __IOS__
+
+using System;
+using FileProvider;
+using Foundation;
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.FileProvider {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class NSFileProviderPageTests {
+
+		[Test]
+		public void CompressionSessionCreateTest ()
+		{
+			// The FileProvider's NSData constants are only available running on device.
+			TestRuntime.AssertDevice ();
+			TestRuntime.AssertXcodeVersion (9,0);
+
+			Assert.IsNotNull (NSFileProviderPage.InitialPageSortedByDate, "InitialPageSortedByDate should not be null");
+			Assert.IsNotNull (NSFileProviderPage.InitialPageSortedByName, "InitialPageSortedByName should not be null");
+		}
+	}
+}
+#endif

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -683,6 +683,7 @@
     <Compile Include="ModelIO\MDLStereoscopicCameraTest.cs" />
     <Compile Include="UIKit\UISpringLoadedInteractionSupportingTest.cs" />
     <Compile Include="PdfKit\PdfAnnotationTest.cs" />
+    <Compile Include="FileProvider\NSFileProviderPageTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
@@ -753,6 +754,7 @@
     <Folder Include="ARKit\" />
     <Folder Include="CoreML\" />
     <Folder Include="PdfKit\" />
+    <Folder Include="FileProvider\" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="AudioToolbox\1.caf" />


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=59297

Adds `NSFileProviderInitialPageSortedByName` and `NSFileProviderInitialPageSortedByDate`
NSData constants.

