### PR TITLE
[FileProvider] Adds missing protocol and keys from audit

### DIFF
--- a/src/fileprovider.cs
+++ b/src/fileprovider.cs
@@ -19,7 +19,7 @@ namespace XamCore.FileProvider {
 	[iOS (11,0)]
 	[ErrorDomain ("NSFileProviderErrorDomain")]
 	[Native]
-	public enum NSFileProviderError : nint {
+	enum NSFileProviderError : nint {
 		NotAuthenticated = -1000,
 		FilenameCollision = -1001,
 		SyncAnchorExpired = -1002,
@@ -27,6 +27,25 @@ namespace XamCore.FileProvider {
 		InsufficientQuota = -1003,
 		ServerUnreachable = -1004,
 		NoSuchItem = -1005,
+	}
+
+	[iOS (11,0)]
+	[Static]
+	interface NSFileProviderErrorKeys {
+
+		[Field ("NSFileProviderErrorCollidingItemKey")]
+		NSString CollidingItemKey { get; }
+
+		[Field ("NSFileProviderErrorNonExistentItemIdentifierKey")]
+		NSString NonExistentItemIdentifierKey { get; }
+	}
+
+	[iOS (11,0)]
+	[Static]
+	interface NSFileProviderFavoriteRank {
+
+		[Field ("NSFileProviderFavoriteRankUnranked")]
+		ulong Unranked { get; }
 	}
 
 	[iOS (11,0)]
@@ -43,7 +62,7 @@ namespace XamCore.FileProvider {
 	[iOS (11,0)]
 	[Native]
 	[Flags]
-	public enum NSFileProviderItemCapabilities : nuint {
+	enum NSFileProviderItemCapabilities : nuint {
 		Reading = 1 << 0,
 		Writing = 1 << 1,
 		Reparenting = 1 << 2,
@@ -314,6 +333,20 @@ namespace XamCore.FileProvider {
 		[Export ("managerForDomain:")]
 		[return: NullAllowed]
 		NSFileProviderManager FromDomain (NSFileProviderDomain domain);
+	}
+
+	[iOS (11,0)]
+	[Protocol]
+	interface NSFileProviderServiceSource {
+
+		[Abstract]
+		[Export ("serviceName")]
+		string ServiceName { get; }
+
+		[Abstract]
+		[Export ("makeListenerEndpointAndReturnError:")]
+		[return: NullAllowed]
+		NSXpcListenerEndpoint MakeListenerEndpoint (out NSError error);
 	}
 }
 #endif

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -15359,6 +15359,7 @@ namespace XamCore.Foundation
 
 	[iOS (6,0), Mac (10,8), Watch (2,0), TV (9,0)]
 	[BaseType (typeof (NSObject), Name = "NSXPCListenerEndpoint")]
+	[DisableDefaultCtor]
 	interface NSXpcListenerEndpoint : NSSecureCoding
 	{
 	}

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -15356,4 +15356,10 @@ namespace XamCore.Foundation
 		[Export ("stringFromUnit:")]
 		string ToString (NSUnit unit);
 	}
+
+	[iOS (6,0), Mac (10,8), Watch (2,0), TV (9,0)]
+	[BaseType (typeof (NSObject), Name = "NSXPCListenerEndpoint")]
+	interface NSXpcListenerEndpoint : NSSecureCoding
+	{
+	}
 }


### PR DESCRIPTION
```
!missing-protocol! NSFileProviderServiceSource not bound
!missing-field! NSFileProviderErrorCollidingItemKey not bound
!missing-field! NSFileProviderErrorNonExistentItemIdentifierKey not bound
!missing-field! NSFileProviderFavoriteRankUnranked not bound
```

Also adds `NSXpcListenerEndpoint` to foundation, needed by `NSFileProviderServiceSource` protocol.