### PR TITLE
[homekit] Audit (xtro) fixes

### DIFF
--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -1155,7 +1155,7 @@ namespace XamCore.HomeKit {
 	[iOS (9,0)]
 	[BaseType (typeof (HMEvent))]
 	[DisableDefaultCtor]
-	interface HMCharacteristicEvent { // NSMutableCopying conformance in header but invalud copyWithZone: and mutableCopyWithZone: selectors on iOS Unified 32-bits
+	interface HMCharacteristicEvent : NSMutableCopying {
 		[NoTV]
 		[NoWatch]
 		[Export ("initWithCharacteristic:triggerValue:")]

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -440,6 +440,14 @@ namespace Introspection {
 					return true;
 				}
 				break;
+			case "HMCharacteristicEvent":
+				switch (selectorName) {
+				case "copyWithZone:":
+				case "mutableCopyWithZone:":
+					// Added in Xcode9 (i.e. only 64 bits) so skip 32 bits
+					return IntPtr.Size == 4;
+				}
+				break;
 			}
 
 			// old binding mistake

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -445,7 +445,7 @@ namespace Introspection {
 				case "copyWithZone:":
 				case "mutableCopyWithZone:":
 					// Added in Xcode9 (i.e. only 64 bits) so skip 32 bits
-					return IntPtr.Size == 4;
+					return !TestRuntime.CheckXcodeVersion (9,0);
 				}
 				break;
 			}

--- a/tests/xtro-sharpie/common.pending
+++ b/tests/xtro-sharpie/common.pending
@@ -79,6 +79,13 @@
 !missing-selector! NSURLSession::getTasksWithCompletionHandler: not bound
 
 
+# HomeKit
+
+## unrecognized selector - rdar 33883958: https://trello.com/c/TIlzWzrL
+!missing-selector! HMMutablePresenceEvent::setPresenceEventType: not bound
+!missing-selector! HMMutablePresenceEvent::setPresenceUserType: not bound
+
+
 # Photos
 
 ## xcode 8 beta 1-6 defines it but it does not exists in the binaries - rdar #28169810 https://trello.com/c/RwXK6YRX


### PR DESCRIPTION
- HMCharacteristicEvent conforms to NSMutableCopying on iOS11
  which makes it 64 bits only (so adjust intro tests)

- Ignore extra setters on HMMutablePresenceEvent, rdar 33883958

!missing-selector! HMMutablePresenceEvent::setPresenceEventType: not bound
!missing-selector! HMMutablePresenceEvent::setPresenceUserType: not bound