### PR TITLE
[xtro] Add missing pinvoke to pending

### DIFF
--- a/tests/xtro-sharpie/ios.pending
+++ b/tests/xtro-sharpie/ios.pending
@@ -336,6 +336,10 @@
 ## fixed for XAMCORE_4_0
 !incorrect-protocol-member! UIDocumentPickerDelegate::documentPicker:didPickDocumentAtURL: is OPTIONAL and should NOT be abstract
 
+## https://bugzilla.xamarin.com/show_bug.cgi?id=59422
+!missing-pinvoke! UIContentSizeCategoryCompareToCategory is not bound
+!missing-pinvoke! UIContentSizeCategoryIsAccessibilityCategory is not bound
+
 # WatchKit
 
 ## unfortunate duplicated name


### PR DESCRIPTION
- Bug 59422: [uikit] Missing UIContentSizeCategoryCompareToCategory & UIContentSizeCategoryIsAccessibilityCategory
(https://bugzilla.xamarin.com/show_bug.cgi?id=59422)