### PR TITLE
[xtro] The right platform for macOS is 'macos', not 'osx'.

### DIFF
--- a/tests/xtro-sharpie/Helpers.cs
+++ b/tests/xtro-sharpie/Helpers.cs
@@ -87,7 +87,15 @@ namespace Extrospection {
 			return index < 0 ? source : source.Substring (0, index) + replace + source.Substring (index + find.Length);
 		}
 
-		public static string Platform { get; set; }
+		public enum Platforms
+		{
+			macOS,
+			iOS,
+			watchOS,
+			tvOS,
+		}
+
+		public static Platforms Platform { get; set; }
 
 		public static bool IsAvailable (this Decl decl)
 		{
@@ -103,13 +111,14 @@ namespace Extrospection {
 				
 			// but right now most frameworks consider tvOS and watchOS like iOS unless 
 			// decorated otherwise so we must check again if we do not get a definitve answer
-			if ((result == null) && ((Platform == "tvos") || (Platform == "watchos")))
-				result = decl.IsAvailable ("ios");
+			if ((result == null) && ((Platform == Platforms.tvOS) || (Platform == Platforms.watchOS)))
+				result = decl.IsAvailable (Platforms.iOS);
 			return !result.HasValue ? true : result.Value;
 		}
 
-		static bool? IsAvailable (this Decl decl, string platform)
+		static bool? IsAvailable (this Decl decl, Platforms platform_value)
 		{
+			var platform = platform_value.ToString ().ToLowerInvariant ();
 			bool? result = null;
 			foreach (var attr in decl.Attrs) {
 				// NS_UNAVAILABLE

--- a/tests/xtro-sharpie/Runner.cs
+++ b/tests/xtro-sharpie/Runner.cs
@@ -31,13 +31,13 @@ namespace Extrospection {
 			foreach (var assemblyName in assemblyNames) {
 				var name = Path.GetFileNameWithoutExtension (assemblyName);
 				if (name.EndsWith (".iOS", StringComparison.Ordinal))
-					Helpers.Platform = "ios";
+					Helpers.Platform = Helpers.Platforms.iOS;
 				else if (name.EndsWith (".Mac", StringComparison.Ordinal))
-					Helpers.Platform = "osx";
+					Helpers.Platform = Helpers.Platforms.macOS;
 				else if (name.EndsWith (".WatchOS", StringComparison.Ordinal))
-					Helpers.Platform = "watchos";
+					Helpers.Platform = Helpers.Platforms.watchOS;
 				else if (name.EndsWith (".TVOS", StringComparison.Ordinal))
-					Helpers.Platform = "tvos";
+					Helpers.Platform = Helpers.Platforms.tvOS;
 				managed_reader.Load (assemblyName);
 			}
 
@@ -75,7 +75,7 @@ namespace Extrospection {
 			get {
 				if (_exclusionList == null) {
 					switch (Helpers.Platform) {
-					case "osx":
+					case Helpers.Platforms.macOS:
 						_exclusionList = macOSXExclusionList;
 						break;
 					default:


### PR DESCRIPTION
The platform name is used to filter availability attributes, and if we use the
wrong platform, we'll incorrectly skip all availability attributes.

The net result in unclassified entries: https://gist.github.com/rolfbjarne/a4474bc2a40c49a85cad495b51bb514f