### PR TITLE
[AVFoundation] Implement AVCapturePhoto. Partially fixes #59388.

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -12186,4 +12186,46 @@ namespace XamCore.AVFoundation {
 		[Export ("multipleRoutesDetected")]
 		bool MultipleRoutesDetected { get; }
 	}
+
+	[NoTV, iOS (11,0), NoWatch, NoMac]
+	[BaseType (typeof(NSObject))]
+	[DisableDefaultCtor]
+	interface AVCapturePhoto
+	{
+		[Export ("timestamp")]
+		CMTime Timestamp { get; }
+
+		[Export ("rawPhoto")]
+		bool RawPhoto { [Bind ("isRawPhoto")] get; }
+
+		[NullAllowed, Export ("pixelBuffer")]
+		CVPixelBuffer PixelBuffer { get; }
+
+		[NullAllowed, Export ("previewPixelBuffer")]
+		CVPixelBuffer PreviewPixelBuffer { get; }
+
+		[NullAllowed, Export ("embeddedThumbnailPhotoFormat")]
+		NSDictionary<NSString, NSObject> EmbeddedThumbnailPhotoFormat { get; }
+
+		[NullAllowed, Export ("depthData")]
+		AVDepthData DepthData { get; }
+
+		[Export ("metadata")]
+		NSDictionary<NSString, NSObject> Metadata { get; }
+
+		[NullAllowed, Export ("cameraCalibrationData")]
+		AVCameraCalibrationData CameraCalibrationData { get; }
+
+		[Export ("resolvedSettings")]
+		AVCaptureResolvedPhotoSettings ResolvedSettings { get; }
+
+		[Export ("photoCount")]
+		nint PhotoCount { get; }
+
+		[NullAllowed, Export ("sourceDeviceType")]
+		NSString WeakSourceDeviceType { get; }
+
+		[Wrap ("AVCaptureDeviceTypeExtensions.GetValue (WeakSourceDeviceType)")]
+		AVCaptureDeviceType SourceDeviceType { get; }
+	}
 }

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -12205,13 +12205,19 @@ namespace XamCore.AVFoundation {
 		CVPixelBuffer PreviewPixelBuffer { get; }
 
 		[NullAllowed, Export ("embeddedThumbnailPhotoFormat")]
-		NSDictionary<NSString, NSObject> EmbeddedThumbnailPhotoFormat { get; }
+		NSDictionary WeakEmbeddedThumbnailPhotoFormat { get; }
+
+		[Wrap ("WeakEmbeddedThumbnailPhotoFormat")]
+		AVVideoSettingsCompressed EmbeddedThumbnailPhotoFormat { get; }
 
 		[NullAllowed, Export ("depthData")]
 		AVDepthData DepthData { get; }
 
 		[Export ("metadata")]
-		NSDictionary<NSString, NSObject> Metadata { get; }
+		NSDictionary WeakMetadata { get; }
+
+		[Wrap ("WeakMetadata")]
+		CoreGraphics.CGImageProperties Properties { get; }
 
 		[NullAllowed, Export ("cameraCalibrationData")]
 		AVCameraCalibrationData CameraCalibrationData { get; }


### PR DESCRIPTION
Fixes:

> common.unclassified:!missing-type! AVCapturePhoto not bound

https://bugzilla.xamarin.com/show_bug.cgi?id=59388