### PR TITLE
[AVFoundation] Use Simd-matrix for API that needs it.

### DIFF
--- a/runtime/bindings-generator.cs
+++ b/runtime/bindings-generator.cs
@@ -2287,6 +2287,15 @@ namespace Xamarin.BindingMethods.Generator
 				}
 			);
 
+			data.Add (
+				new FunctionData {
+					Comment = " // NMatrix4x3 func ()",
+					Prefix = "simd__",
+					Variants = Variants.All,
+					ReturnType = Types.NMatrix4x3,
+				}
+			);
+
 			// We must expand functions with native types to their actual type as well.
 			for (int i = data.Count - 1; i >= 0; i--) {
 				if (!data [i].HasNativeType)
@@ -2360,6 +2369,13 @@ namespace Xamarin.BindingMethods.Generator
 				writer.WriteLine ("\t\t{0}{2}columns [i].b = {1}.columns [i] [1];", managedVariable, nativeVariable, accessor);
 				writer.WriteLine ("\t\t{0}{2}columns [i].c = {1}.columns [i] [2];", managedVariable, nativeVariable, accessor);
 				writer.WriteLine ("\t\t{0}{2}columns [i].d = {1}.columns [i] [3];", managedVariable, nativeVariable, accessor);
+				writer.WriteLine ("\t}");
+				break;
+			case "NMatrix4x3":
+				writer.WriteLine ("\tfor (int i = 0; i < 4; i++) {");
+				writer.WriteLine ("\t\t{0}{2}columns [i].a = {1}.columns [i] [0];", managedVariable, nativeVariable, accessor);
+				writer.WriteLine ("\t\t{0}{2}columns [i].b = {1}.columns [i] [1];", managedVariable, nativeVariable, accessor);
+				writer.WriteLine ("\t\t{0}{2}columns [i].c = {1}.columns [i] [2];", managedVariable, nativeVariable, accessor);
 				writer.WriteLine ("\t}");
 				break;
 			case "MDLAxisAlignedBoundingBox":
@@ -2480,6 +2496,13 @@ namespace Xamarin.BindingMethods.Generator
 				writer.WriteLine ("\t\t{0}.columns [i][1] = {1}{2}columns [i].b;", nativeVariable, managedVariable, accessor);
 				writer.WriteLine ("\t\t{0}.columns [i][2] = {1}{2}columns [i].c;", nativeVariable, managedVariable, accessor);
 				writer.WriteLine ("\t\t{0}.columns [i][3] = {1}{2}columns [i].d;", nativeVariable, managedVariable, accessor);
+				writer.WriteLine ("\t}");
+				break;
+			case "NMatrix4x3":
+				writer.WriteLine ("\tfor (int i = 0; i < 4; i++) {");
+				writer.WriteLine ("\t\t{0}.columns [i][0] = {1}{2}columns [i].a;", nativeVariable, managedVariable, accessor);
+				writer.WriteLine ("\t\t{0}.columns [i][1] = {1}{2}columns [i].b;", nativeVariable, managedVariable, accessor);
+				writer.WriteLine ("\t\t{0}.columns [i][2] = {1}{2}columns [i].c;", nativeVariable, managedVariable, accessor);
 				writer.WriteLine ("\t}");
 				break;
 			case "MDLAxisAlignedBoundingBox":
@@ -3041,6 +3064,15 @@ namespace Xamarin.BindingMethods.Generator
 				ManagedType = "NMatrix4",
 				NativeType = "matrix_float4x4",
 				NativeWrapperType = "struct NMatrix4",
+				RequireMarshal = true,
+				IsARMStret = true,
+				IsX86Stret = true,
+				IsX64Stret = true,
+			};
+			public static TypeData NMatrix4x3 = new TypeData {
+				ManagedType = "NMatrix4x3",
+				NativeType = "matrix_float4x3",
+				NativeWrapperType = "struct NMatrix4x3",
 				RequireMarshal = true,
 				IsARMStret = true,
 				IsX86Stret = true,

--- a/runtime/bindings.h
+++ b/runtime/bindings.h
@@ -83,6 +83,7 @@ typedef __attribute__((__ext_vector_type__(4))) float vector_float4;
 typedef struct { vector_float2 columns[2]; } matrix_float2x2;
 typedef struct { vector_float3 columns[3]; } matrix_float3x3;
 typedef struct { vector_float4 columns[4]; } matrix_float4x4;
+typedef struct { vector_float3 columns[4]; } matrix_float4x3;
 
 typedef struct { vector_float4 vector; } simd_quatf;
 
@@ -175,6 +176,11 @@ struct Matrix4f {
 };
 
 struct NMatrix4 {
+	Vector4f columns [4];
+};
+
+struct NMatrix4x3 {
+	// Use Vector4f here, since the managed version has padding to match accordingly.
 	Vector4f columns [4];
 };
 

--- a/src/Simd/MatrixFloat4x3.cs
+++ b/src/Simd/MatrixFloat4x3.cs
@@ -1,0 +1,187 @@
+//
+// Authors:
+//     Rolf Bjarne Kvinge <rolf@xamarin.com>
+//
+// Copyright (c) 2017 Microsoft Inc
+//
+
+//
+// This represents the native matrix_float4x3 type (3 rows and 4 columns)
+//
+
+using System;
+using System.Runtime.InteropServices;
+
+using VectorFloat4=global::OpenTK.Vector4;
+
+namespace OpenTK
+{
+	[StructLayout (LayoutKind.Sequential)]
+	public struct NMatrix4x3 : IEquatable<NMatrix4x3>
+	{
+		public float M11;
+		public float M21;
+		public float M31;
+		float dummy1;
+
+		public float M12;
+		public float M22;
+		public float M32;
+		float dummy2;
+
+		public float M13;
+		public float M23;
+		public float M33;
+		float dummy3;
+
+		public float M14;
+		public float M24;
+		public float M34;
+		float dummy4;
+
+		public NMatrix4x3 (
+			float m11, float m12, float m13, float m14,
+			float m21, float m22, float m23, float m24,
+			float m31, float m32, float m33, float m34)
+		{
+			M11 = m11;
+			M21 = m21;
+			M31 = m31;
+			M12 = m12;
+			M22 = m22;
+			M32 = m32;
+			M13 = m13;
+			M23 = m23;
+			M33 = m33;
+			M14 = m14;
+			M24 = m24;
+			M34 = m34;
+			dummy1 = 0;
+			dummy2 = 0;
+			dummy3 = 0;
+			dummy4 = 0;
+		}
+
+		public NVector3 Column0 {
+			get {
+				return new NVector3 (M11, M21, M31);
+			}
+			set {
+				M11 = value.X;
+				M21 = value.Y;
+				M31 = value.Z;
+			}
+		}
+
+		public NVector3 Column1 {
+			get {
+				return new NVector3 (M12, M22, M32);
+			}
+			set {
+				M12 = value.X;
+				M22 = value.Y;
+				M32 = value.Z;
+			}
+		}
+
+		public NVector3 Column2 {
+			get {
+				return new NVector3 (M13, M23, M33);
+			}
+			set {
+				M13 = value.X;
+				M23 = value.Y;
+				M33 = value.Z;
+			}
+		}
+
+		public NVector3 Column3 {
+			get {
+				return new NVector3 (M14, M24, M34);
+			}
+			set {
+				M14 = value.X;
+				M24 = value.Y;
+				M34 = value.Z;
+			}
+		}
+
+		public Vector4 Row0 {
+			get {
+				return new Vector4 (M11, M12, M13, M14);
+			}
+			set {
+				M11 = value.X;
+				M12 = value.Y;
+				M13 = value.Z;
+				M14 = value.W;
+			}
+		}
+
+		public Vector4 Row1 {
+			get {
+				return new Vector4 (M21, M22, M23, M24);
+			}
+			set {
+				M21 = value.X;
+				M22 = value.Y;
+				M23 = value.Z;
+				M24 = value.W;
+			}
+		}
+
+		public Vector4 Row2 {
+			get {
+				return new Vector4 (M31, M32, M33, M34);
+			}
+			set {
+				M31 = value.X;
+				M32 = value.Y;
+				M33 = value.Z;
+				M34 = value.W;
+			}
+		}
+
+		public static bool operator == (NMatrix4x3 left, NMatrix4x3 right)
+		{
+			return left.Equals (right);
+		}
+
+		public static bool operator != (NMatrix4x3 left, NMatrix4x3 right)
+		{
+			return !left.Equals (right);
+		}
+
+		public override string ToString ()
+		{
+			return
+				$"({M11}, {M12}, {M13}, {M14})\n" +
+				$"({M21}, {M22}, {M23}, {M24})\n" +
+				$"({M31}, {M32}, {M33}, {M34})";
+		}
+
+		public override int GetHashCode ()
+		{
+			return
+				M11.GetHashCode () ^ M12.GetHashCode () ^ M13.GetHashCode () ^ M14.GetHashCode () ^
+				M21.GetHashCode () ^ M22.GetHashCode () ^ M23.GetHashCode () ^ M24.GetHashCode () ^
+				M31.GetHashCode () ^ M32.GetHashCode () ^ M33.GetHashCode () ^ M34.GetHashCode ();
+		}
+
+		public override bool Equals (object obj)
+		{
+			if (!(obj is NMatrix4x3))
+				return false;
+
+			return Equals ((NMatrix4x3) obj);
+		}
+
+		public bool Equals (NMatrix4x3 other)
+		{
+			return
+				M11 == other.M11 && M12 == other.M12 && M13 == other.M13 && M14 == other.M14 &&
+				M21 == other.M21 && M22 == other.M22 && M23 == other.M23 && M24 == other.M24 &&
+				M31 == other.M31 && M32 == other.M32 && M33 == other.M33 && M34 == other.M34;
+		}
+	}
+}

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -7874,15 +7874,13 @@ namespace XamCore.AVFoundation {
 	interface AVCameraCalibrationData
 	{
 		[Export ("intrinsicMatrix")]
-		Matrix3 GetIntrinsicMatrix { [MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")] get;}
+		NMatrix3 IntrinsicMatrix { [MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")] get; }
 
 		[Export ("intrinsicMatrixReferenceDimensions")]
 		CGSize IntrinsicMatrixReferenceDimensions { get; }
 
-		/*
 		[Export ("extrinsicMatrix")]
-		Matrix4 GetExtrinsicMatrix { [MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")] get;}; // should be a matrix 4x3
-		*/
+		NMatrix4x3 ExtrinsicMatrix { [MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")] get; }
 
 		[Export ("pixelSize")]
 		float PixelSize { get; }

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1532,6 +1532,7 @@ SHARED_CORE_SOURCES = \
 	ObjCRuntime/Selector.cs \
 	Simd/MatrixFloat2x2.cs \
 	Simd/MatrixFloat3x3.cs \
+	Simd/MatrixFloat4x3.cs \
 	Simd/MatrixFloat4x4.cs \
 	Simd/VectorFloat3.cs \
 

--- a/tests/bindings-test/StructsAndEnums.cs
+++ b/tests/bindings-test/StructsAndEnums.cs
@@ -10,6 +10,7 @@ using ObjCRuntime;
 
 using MatrixFloat2x2 = global::OpenTK.NMatrix2;
 using MatrixFloat3x3 = global::OpenTK.NMatrix3;
+using MatrixFloat4x3 = global::OpenTK.NMatrix4x3;
 using MatrixFloat4x4 = global::OpenTK.NMatrix4;
 
 namespace Bindings.Test
@@ -26,6 +27,9 @@ namespace Bindings.Test
 
 		[DllImport ("__Internal")]
 		public static extern void x_get_matrix_float4x4 (IntPtr self, string sel, out float r0c0, out float r0c1, out float r0c2, out float r0c3, out float r1c0, out float r1c1, out float r1c2, out float r1c3, out float r2c0, out float r2c1, out float r2c2, out float r2c3, out float r3c0, out float r3c1, out float r3c2, out float r3c3);
+
+		[DllImport ("__Internal")]
+		public static extern void x_get_matrix_float4x3 (IntPtr self, string sel, out float r0c0, out float r0c1, out float r0c2, out float r0c3, out float r1c0, out float r1c1, out float r1c2, out float r1c3, out float r2c0, out float r2c1, out float r2c2, out float r2c3);
 
 		public static MatrixFloat2x2 GetMatrixFloat2x2 (NSObject obj, string selector)
 		{
@@ -58,6 +62,15 @@ namespace Bindings.Test
 				r3c0, r3c1, r3c2, r3c3);
 		}
 
+		public static MatrixFloat4x3 GetMatrixFloat4x3 (NSObject obj, string selector)
+		{
+			float r0c0, r0c1, r0c2, r0c3, r1c0, r1c1, r1c2, r1c3, r2c0, r2c1, r2c2, r2c3;
+			x_get_matrix_float4x3 (obj.Handle, selector, out r0c0, out r0c1, out r0c2, out r0c3, out r1c0, out r1c1, out r1c2, out r1c3, out r2c0, out r2c1, out r2c2, out r2c3);
+			return new MatrixFloat4x3 (
+				r0c0, r0c1, r0c2, r0c3,
+				r1c0, r1c1, r1c2, r1c3,
+				r2c0, r2c1, r2c2, r2c3);
+		}
 
 #if !__WATCHOS__
 		[DllImport ("__Internal")]

--- a/tests/monotouch-test/Asserts.cs
+++ b/tests/monotouch-test/Asserts.cs
@@ -12,6 +12,7 @@ using MonoTouch.ModelIO;
 using OpenTK;
 using MatrixFloat2x2 = global::OpenTK.NMatrix2;
 using MatrixFloat3x3 = global::OpenTK.NMatrix3;
+using MatrixFloat4x3 = global::OpenTK.NMatrix4x3;
 using MatrixFloat4x4 = global::OpenTK.NMatrix4;
 using VectorFloat3 = global::OpenTK.NVector3;
 using NUnit.Framework;
@@ -369,6 +370,38 @@ public static class Asserts
 		AreEqual (expected.M24, actual.M24, message + " (M24)");
 		AreEqual (expected.M34, actual.M34, message + " (M34)");
 		AreEqual (expected.M44, actual.M44, message + " (M44)");
+	}
+
+	public static void AreEqual (MatrixFloat4x3 expected, MatrixFloat4x3 actual, float delta, string message)
+	{
+		AreEqual (expected.M11, actual.M11, delta, message + " (M11)");
+		AreEqual (expected.M21, actual.M21, delta, message + " (M21)");
+		AreEqual (expected.M31, actual.M31, delta, message + " (M31)");
+		AreEqual (expected.M12, actual.M12, delta, message + " (M12)");
+		AreEqual (expected.M22, actual.M22, delta, message + " (M22)");
+		AreEqual (expected.M32, actual.M32, delta, message + " (M32)");
+		AreEqual (expected.M13, actual.M13, delta, message + " (M13)");
+		AreEqual (expected.M23, actual.M23, delta, message + " (M23)");
+		AreEqual (expected.M33, actual.M33, delta, message + " (M33)");
+		AreEqual (expected.M14, actual.M14, delta, message + " (M14)");
+		AreEqual (expected.M24, actual.M24, delta, message + " (M24)");
+		AreEqual (expected.M34, actual.M34, delta, message + " (M34)");
+	}
+
+	public static void AreEqual (MatrixFloat4x3 expected, MatrixFloat4x3 actual, string message)
+	{
+		AreEqual (expected.M11, actual.M11, message + " (M11)");
+		AreEqual (expected.M21, actual.M21, message + " (M21)");
+		AreEqual (expected.M31, actual.M31, message + " (M31)");
+		AreEqual (expected.M12, actual.M12, message + " (M12)");
+		AreEqual (expected.M22, actual.M22, message + " (M22)");
+		AreEqual (expected.M32, actual.M32, message + " (M32)");
+		AreEqual (expected.M13, actual.M13, message + " (M13)");
+		AreEqual (expected.M23, actual.M23, message + " (M23)");
+		AreEqual (expected.M33, actual.M33, message + " (M33)");
+		AreEqual (expected.M14, actual.M14, message + " (M14)");
+		AreEqual (expected.M24, actual.M24, message + " (M24)");
+		AreEqual (expected.M34, actual.M34, message + " (M34)");
 	}
 }
 

--- a/tests/monotouch-test/Simd/MatrixFloat4x3Test.cs
+++ b/tests/monotouch-test/Simd/MatrixFloat4x3Test.cs
@@ -1,0 +1,188 @@
+﻿
+using System;
+using System.Diagnostics;
+
+using Foundation;
+using ObjCRuntime;
+
+using OpenTK;
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.Simd
+{
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class NMatrix4x3Test
+	{
+		[Test]
+		public void ElementConstructor ()
+		{
+			var expected = GetTestMatrix ();
+			var actual = new NMatrix4x3 (
+				expected.M11, expected.M12, expected.M13, expected.M14,
+				expected.M21, expected.M22, expected.M23, expected.M24,
+				expected.M31, expected.M32, expected.M33, expected.M34);
+			Asserts.AreEqual (expected, actual, "ctor 1");
+
+		}
+
+		[Test]
+		public void Elements ()
+		{
+			var expected = GetTestMatrix ();
+			var actual = (NMatrix4x3) expected;
+
+			Assert.AreEqual (expected.M11, actual.M11, "m11 getter");
+			Assert.AreEqual (expected.M12, actual.M12, "m12 getter");
+			Assert.AreEqual (expected.M13, actual.M13, "m13 getter");
+			Assert.AreEqual (expected.M14, actual.M14, "m14 getter");
+			Assert.AreEqual (expected.M21, actual.M21, "m21 getter");
+			Assert.AreEqual (expected.M22, actual.M22, "m22 getter");
+			Assert.AreEqual (expected.M23, actual.M23, "m23 getter");
+			Assert.AreEqual (expected.M24, actual.M24, "m24 getter");
+			Assert.AreEqual (expected.M31, actual.M31, "m31 getter");
+			Assert.AreEqual (expected.M32, actual.M32, "m32 getter");
+			Assert.AreEqual (expected.M33, actual.M33, "m33 getter");
+			Assert.AreEqual (expected.M34, actual.M34, "m34 getter");
+
+			var newExpected = GetTestMatrix ();
+			actual.M11 = newExpected.M11;
+			actual.M12 = newExpected.M12;
+			actual.M13 = newExpected.M13;
+			actual.M14 = newExpected.M14;
+			actual.M21 = newExpected.M21;
+			actual.M22 = newExpected.M22;
+			actual.M23 = newExpected.M23;
+			actual.M24 = newExpected.M24;
+			actual.M31 = newExpected.M31;
+			actual.M32 = newExpected.M32;
+			actual.M33 = newExpected.M33;
+			actual.M34 = newExpected.M34;
+			Assert.AreEqual (newExpected.M11, actual.M11, "m11 setter");
+			Assert.AreEqual (newExpected.M12, actual.M12, "m12 setter");
+			Assert.AreEqual (newExpected.M13, actual.M13, "m13 setter");
+			Assert.AreEqual (newExpected.M14, actual.M14, "m14 setter");
+			Assert.AreEqual (newExpected.M21, actual.M21, "m21 setter");
+			Assert.AreEqual (newExpected.M22, actual.M22, "m22 setter");
+			Assert.AreEqual (newExpected.M23, actual.M23, "m23 setter");
+			Assert.AreEqual (newExpected.M24, actual.M24, "m24 setter");
+			Assert.AreEqual (newExpected.M31, actual.M31, "m31 setter");
+			Assert.AreEqual (newExpected.M32, actual.M32, "m32 setter");
+			Assert.AreEqual (newExpected.M33, actual.M33, "m33 setter");
+			Assert.AreEqual (newExpected.M34, actual.M34, "m34 setter");
+		}
+
+		[Test]
+		public void Equality_Operator ()
+		{
+			var inputL = GetTestMatrix ();
+			var inputR = GetTestMatrix ();
+			var inputSimdL = (NMatrix4x3) inputL;
+			var inputSimdR = (NMatrix4x3) inputR;
+
+			// matrices are different
+			Assert.AreEqual (inputL == inputR, inputSimdL == inputSimdR, "inequality");
+			Assert.IsFalse (inputL == inputR, "inequality 2 expected");
+			Assert.IsFalse (inputSimdL == inputSimdR, "inequality 2 actual");
+
+			inputL = inputR;
+			inputSimdL = inputSimdR;
+			// matrices are identical
+			Assert.AreEqual (inputL == inputR, inputSimdL == inputSimdR, "equality");
+			Assert.IsTrue (inputL == inputR, "equality 2 expected");
+			Assert.IsTrue (inputSimdL == inputSimdR, "equality 2 actual");
+		}
+
+		[Test]
+		public void Inequality_Operator ()
+		{
+			var inputL = GetTestMatrix ();
+			var inputR = GetTestMatrix ();
+			var inputSimdL = (NMatrix4x3) inputL;
+			var inputSimdR = (NMatrix4x3) inputR;
+
+			// matrices are different
+			Assert.AreEqual (inputL != inputR, inputSimdL != inputSimdR, "inequality");
+			Assert.IsTrue (inputL != inputR, "inequality 2 expected");
+			Assert.IsTrue (inputSimdL != inputSimdR, "inequality 2 actual");
+
+			inputL = inputR;
+			inputSimdL = inputSimdR;
+			// matrices are identical
+			Assert.AreEqual (inputL != inputR, inputSimdL != inputSimdR, "equality");
+			Assert.IsFalse (inputL != inputR, "equality 2 expected");
+			Assert.IsFalse (inputSimdL != inputSimdR, "equality 2 actual");
+		}
+
+		[Test]
+		public void ToStringTest ()
+		{
+			var expected = GetTestMatrix ();
+			var actual = (NMatrix4x3) expected;
+
+			Assert.AreEqual (expected.ToString (), actual.ToString (), "tostring");
+		}
+
+		// GetHashCode doesn't have to be identical, so no need to test
+
+		[Test]
+		public void Equals_Object ()
+		{
+			var expectedA = GetTestMatrix ();
+			var expectedB = GetTestMatrix ();
+			var actualA = (NMatrix4x3) expectedA;
+			var actualB = (NMatrix4x3) expectedB;
+
+			Assert.IsTrue (actualA.Equals ((object) actualA), "self");
+			Assert.IsFalse (actualA.Equals ((object) actualB), "other");
+			Assert.IsFalse (actualA.Equals (null), "null");
+			Assert.IsTrue (actualA.Equals (expectedA), "other type");
+		}
+
+		[Test]
+		public void Equals_Matrix ()
+		{
+			var expectedA = GetTestMatrix ();
+			var expectedB = GetTestMatrix ();
+			var actualA = (NMatrix4x3) expectedA;
+			var actualB = (NMatrix4x3) expectedB;
+
+			Assert.IsTrue (actualA.Equals (actualA), "self");
+			Assert.IsFalse (actualA.Equals (actualB), "other");
+		}
+
+		// A collection of test matrices.
+		//
+		// I initially tried randomly generating test matrices, but it turns out
+		// there are accumulative computational differences in the different algorithms
+		// between Matrix4 and NMatrix4x3. Since the differences are accumulative,
+		// I couldn't find a minimal sensible delta values when comparing 
+		// matrices.
+		//
+		// So I just serialized a few matrices that were randomly generated, and
+		// these have been tested to not produce accumulative computational differences.
+		// 
+		static NMatrix4x3 [] test_matrices = new [] {
+			new NMatrix4x3 (0.1532144f, 0.5451511f, 0.2004739f, 0.8351463f, 0.9884372f, 0.1313103f, 0.3327205f, 0.01164342f, 0.6563147f, 0.7923161f, 0.6764754f, 0.07481737f),
+			new NMatrix4x3 (0.7717745f, 0.559364f, 0.00918373f, 0.6579159f, 0.123461f, 0.9993145f, 0.5487496f, 0.2823398f, 0.9710717f, 0.8750508f, 0.472472f, 0.2608089f),
+			new NMatrix4x3 (0.2023053f, 0.4701468f, 0.6618567f, 0.7685714f, 0.8561344f, 0.009231919f, 0.6150167f, 0.7542298f, 0.550727f, 0.3625788f, 0.6639862f, 0.5763468f),
+			new NMatrix4x3 (9.799572E+08f, 1.64794E+09f, 1.117296E+09f, 1.239858E+09f, 6.389504E+07f, 1.172175E+09f, 1.399567E+09f, 1.187143E+09f, 3.729208E+07f, 5.50313E+08f, 1.847369E+09f, 1.612405E+09f),
+			new NMatrix4x3 (1.102396E+09f, 3.082477E+08f, 1.126484E+09f, 5.022931E+08f, 1.966322E+09f, 1.1814E+09f, 8.464673E+08f, 1.940651E+09f, 1.229937E+09f, 1.367379E+09f, 1.900015E+09f, 1.516109E+09f),
+			new NMatrix4x3 (2.263112E+08f, 8.79644E+08f, 1.303282E+09f, 1.654159E+09f, 3.705524E+08f, 1.984941E+09f, 2.175935E+07f, 4.633518E+08f, 1.801243E+09f, 1.616996E+09f, 1.620852E+09f, 7291498f),
+			new NMatrix4x3 (0.4904693f, 0.841727f, 0.2294401f, 0.5736054f, 0.5406881f, 0.2172498f, 0.1261143f, 0.6736677f, 0.4570194f, 0.9091009f, 0.7669608f, 0.8468134f),
+			new NMatrix4x3 (0.1252193f, 0.08986127f, 0.3407605f, 0.9144857f, 0.340791f, 0.2192288f, 0.5144276f, 0.01813344f, 0.07687104f, 0.7971596f, 0.6393988f, 0.9002907f),
+			new NMatrix4x3 (8.176959E+08f, 1.386156E+09f, 5.956444E+08f, 4.210506E+08f, 1.212676E+09f, 4.131035E+08f, 1.032453E+09f, 2.074689E+08f, 1.536594E+09f, 3.266183E+07f, 5.222072E+08f, 7.923175E+08f),
+			new NMatrix4x3 (0.006755914f, 0.07464754f, 0.287938f, 0.3724834f, 0.1496783f, 0.6224982f, 0.7150125f, 0.5554719f, 0.4638171f, 0.4200902f, 0.4867154f, 0.773377f),
+		};
+
+		static int counter;
+		internal static NMatrix4x3 GetTestMatrix ()
+		{
+			counter++;
+			if (counter == test_matrices.Length)
+				counter = 0;
+			return test_matrices [counter];
+		}
+	}
+}

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -650,6 +650,7 @@
     <Compile Include="AVFoundation\PlayerItemVideoOutputTest.cs" />
     <Compile Include="Simd\MatrixFloat2x2Test.cs" />
     <Compile Include="Simd\MatrixFloat3x3Test.cs" />
+    <Compile Include="Simd\MatrixFloat4x3Test.cs" />
     <Compile Include="Simd\MatrixFloat4x4Test.cs" />
     <Compile Include="Simd\VectorFloat3Test.cs" />
     <Compile Include="mono\ConfigTest.cs" />

--- a/tests/test-libraries/libtest.h
+++ b/tests/test-libraries/libtest.h
@@ -17,6 +17,7 @@ void useZLib ();
 void x_get_matrix_float2x2 (id self, const char *sel, float* r0c0, float* r0c1, float* r1c0, float* r1c1);
 void x_get_matrix_float3x3 (id self, const char *sel, float* r0c0, float* r0c1, float* r0c2, float* r1c0, float* r1c1, float* r1c2, float* r2c0, float* r2c1, float* r2c2);
 void x_get_matrix_float4x4 (id self, const char *sel, float* r0c0, float* r0c1, float* r0c2, float* r0c3, float* r1c0, float* r1c1, float* r1c2, float* r1c3, float* r2c0, float* r2c1, float* r2c2, float* r2c3, float* r3c0, float* r3c1, float* r3c2, float* r3c3);
+void x_get_matrix_float4x3 (id self, const char *sel, float* r0c0, float* r0c1, float* r0c2, float* r0c3, float* r1c0, float* r1c1, float* r1c2, float* r1c3, float* r2c0, float* r2c1, float* r2c2, float* r2c3);
 
 #if !TARGET_OS_WATCH
 void x_mdltransformcomponent_get_local_transform (id<MDLTransformComponent> self, NSTimeInterval time, float* r0c0, float* r0c1, float* r0c2, float* r0c3, float* r1c0, float* r1c1, float* r1c2, float* r1c3, float* r2c0, float* r2c1, float* r2c2, float* r2c3, float* r3c0, float* r3c1, float* r3c2, float* r3c3);

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -117,6 +117,41 @@ x_get_matrix_float4x4 (id self, const char *sel,
 	*r3c3 = rv.columns[3][3];
 }
 
+typedef matrix_float4x3 (*func_x_get_matrix_float4x3_msgSend) (id self, SEL sel);
+void
+x_get_matrix_float4x3 (id self, const char *sel,
+		float* r0c0, float* r0c1, float* r0c2, float* r0c3,
+		float* r1c0, float* r1c1, float* r1c2, float* r1c3,
+		float* r2c0, float* r2c1, float* r2c2, float* r2c3)
+{
+	matrix_float4x3 rv;
+#if __i386__
+	IMP msgSend = (IMP) objc_msgSend_stret;
+#elif __x86_64__
+	IMP msgSend = (IMP) objc_msgSend_stret;
+#elif __arm64__
+	IMP msgSend = (IMP) objc_msgSend;
+#elif __arm__
+	IMP msgSend = (IMP) objc_msgSend_stret;
+#else
+#error unknown architecture
+#endif
+	rv = ((func_x_get_matrix_float4x3_msgSend) msgSend) (self, sel_registerName (sel));
+	*r0c0 = rv.columns[0][0];
+	*r0c1 = rv.columns[1][0];
+	*r0c2 = rv.columns[2][0];
+	*r0c3 = rv.columns[3][0];
+
+	*r1c0 = rv.columns[0][1];
+	*r1c1 = rv.columns[1][1];
+	*r1c2 = rv.columns[2][1];
+	*r1c3 = rv.columns[3][1];
+
+	*r2c0 = rv.columns[0][2];
+	*r2c1 = rv.columns[1][2];
+	*r2c2 = rv.columns[2][2];
+	*r2c3 = rv.columns[3][2];
+}
 #if !TARGET_OS_WATCH
 void
 x_mdltransformcomponent_get_local_transform (id<MDLTransformComponent> self, NSTimeInterval time,

--- a/tests/test-libraries/rename.h
+++ b/tests/test-libraries/rename.h
@@ -57,6 +57,7 @@
 	#define x_mdltransformcomponent_get_local_transform object_x_mdltransformcomponent_get_local_transform
 	#define x_mdltransform_create_global_transform object_x_mdltransform_create_global_transform
 	#define x_get_matrix_float4x4 object_x_get_matrix_float4x4
+	#define x_get_matrix_float4x3 object_x_get_matrix_float4x3
 	#define x_get_matrix_float3x3 object_x_get_matrix_float3x3
 	#define x_get_matrix_float2x2 object_x_get_matrix_float2x2
 #elif PREFIX == 2
@@ -117,6 +118,7 @@
 	#define x_mdltransformcomponent_get_local_transform ar_x_mdltransformcomponent_get_local_transform
 	#define x_mdltransform_create_global_transform ar_x_mdltransform_create_global_transform
 	#define x_get_matrix_float4x4 ar_x_get_matrix_float4x4
+	#define x_get_matrix_float4x3 ar_x_get_matrix_float4x3
 	#define x_get_matrix_float3x3 ar_x_get_matrix_float3x3
 	#define x_get_matrix_float2x2 ar_x_get_matrix_float2x2
 #else


### PR DESCRIPTION
This also requires implementing the corresponding matrix (NMatrix4x3).

Fixes this xtro issue:

```
!unknown-simd-type-in-signature! OpenTK.Matrix3 AVFoundation.AVCameraCalibrationData::get_GetIntrinsicMatrix(): the native signature has a simd type (matrix_float3x3), while the corresponding managed method is using an incorrect (non-simd) type.
```