### PR TITLE
[xtro] Fix checking availability on categories.

### DIFF
--- a/tests/xtro-sharpie/Helpers.cs
+++ b/tests/xtro-sharpie/Helpers.cs
@@ -104,9 +104,17 @@ namespace Extrospection {
 
 			// some categories are not decorated (as not available) but they extend types that are
 			if (!result.HasValue) {
-				var category = (decl.DeclContext as ObjCCategoryDecl);
+				// first check if we're checking the category itself
+				var category = decl as ObjCCategoryDecl;
 				if (category != null)
 					result = category.ClassInterface.IsAvailable (Platform);
+
+				if (!result.HasValue) {
+					// then check if we're a method inside a category
+					category = (decl.DeclContext as ObjCCategoryDecl);
+					if (category != null)
+						result = category.ClassInterface.IsAvailable (Platform);
+				}
 			}
 				
 			// but right now most frameworks consider tvOS and watchOS like iOS unless 


### PR DESCRIPTION
When checking for category availability, check if both the current declaration
is a category, and if the current's declaration container is a category.

Otherwise this scenario fails:

* Category method is available.
* Category does not have availability attributes.
* Main class is unavailable.

with this typical code sequence:

```csharp
// don't process methods (or types) that are unavailable for the current platform
if (!decl.IsAvailable () || !(decl.DeclContext as Decl).IsAvailable ())
	return;
```

In which case we'd:

* First check the method (`decl`):
	* It's available, so no further checks is done on the method.

* Then we'd check the method's container (`decl.DeclContext`):
	* The container (the category) does not have availability attributes.
	* Then we'd check if the container's container is a category (it isn't, it's the namespace).

and as such determine that the method is available.

With this change, the second step will become:

* Then we'd check the method's container (`decl.DeclContext`):
	* The container (the category) does not have availability attributes.
	* Then we'd check if the container is a category (it is), and if its main class is available (it isn't).

and as such determine that the method is unavailable.

* Check for attributes on the method's container (no attributes, so we continue).
* Check if the method's

Unclassified diff: https://gist.github.com/rolfbjarne/8fa80962596978a426eadf9b7ba39dc1