### PR TITLE
[msbuild] Always codesign app bundles if the codesign key is non-null

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1856,7 +1856,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</ItemGroup>
 	</Target>
 
-	<Target Name="_CodesignAppBundle" Condition="'$(_RequireCodeSigning)' == 'true' And ('$(IsAppExtension)' == 'false' Or '@(_ResolvedAppExtensionReferences)' != '')" DependsOnTargets="$(_CodesignAppBundleDependsOn)"
+	<Target Name="_CodesignAppBundle" Condition="('$(_CanOutputAppBundle)' == 'true' And '$(_CodeSigningKey)' != '') And ('$(IsAppExtension)' == 'false' Or '@(_ResolvedAppExtensionReferences)' != '')" DependsOnTargets="$(_CodesignAppBundleDependsOn)"
 		Inputs="@(_CodesignAppBundleInputs)" Outputs="$(_AppBundlePath)_CodeSignature\CodeResources">
 
 		<PropertyGroup>


### PR DESCRIPTION
...even if it is a simulator build.

Turns out that starting with Xcode9, sim builds need to be codesigned
for App Groups entitlements to work properly. Interestingly, the
DetectSigningIdentity logic had a comment about needing to codesign
simulator builds for some entitlements to work already starting with
Xcode 8 but apparently the iOS targets did not respect this.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=59379