### PR TITLE
[Intents] Fix watchOS INCarSeatResolutionResult breaking changes

### DIFF
--- a/src/Intents/INCarSeatResolutionResult.cs
+++ b/src/Intents/INCarSeatResolutionResult.cs
@@ -7,17 +7,20 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if XAMCORE_2_0 && IOS
+#if XAMCORE_2_0 && !MONOMAC
 using System;
 using XamCore.Foundation;
 using XamCore.ObjCRuntime;
-using XamCore.UIKit;
 
 namespace XamCore.Intents {
 	public partial class INCarSeatResolutionResult {
 		public static INCarSeatResolutionResult GetSuccess (INCarSeat resolvedValue)
 		{
-			if (UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+#if IOS
+			if (XamCore.UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+#elif WATCH
+			if (XamCore.WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+#endif
 				return SuccessWithResolvedCarSeat (resolvedValue);
 			else
 				return SuccessWithResolvedValue (resolvedValue);
@@ -25,7 +28,11 @@ namespace XamCore.Intents {
 
 		public static INCarSeatResolutionResult GetConfirmationRequired (INCarSeat valueToConfirm)
 		{
-			if (UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+#if IOS
+			if (XamCore.UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
+#elif WATCH
+			if (XamCore.WatchKit.WKInterfaceDevice.CurrentDevice.CheckSystemVersion (4, 0))
+#endif
 				return ConfirmationRequiredWithCarSeatToConfirm (valueToConfirm);
 			else
 				return ConfirmationRequiredWithValueToConfirm (valueToConfirm);

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -1957,6 +1957,11 @@ namespace XamCore.Intents {
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-type! INCarSeatResolutionResult bound
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
+#if XAMCORE_4_0
+	[NoWatch]
+#else
+	[Obsoleted (PlatformName.WatchOS, message:"'INCarSeatResolutionResult' is not available in watchOS.")]
+#endif
 	interface INCarSeatResolutionResult {
 
 		[iOS (11,0)]

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -1957,11 +1957,6 @@ namespace XamCore.Intents {
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-type! INCarSeatResolutionResult bound
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
-#if XAMCORE_4_0
-	[NoWatch]
-#else
-	[Obsoleted (PlatformName.WatchOS, message:"'INCarSeatResolutionResult' is not available in watchOS.")]
-#endif
 	interface INCarSeatResolutionResult {
 
 		[iOS (11,0)]

--- a/tests/xtro-sharpie/ios.ignore
+++ b/tests/xtro-sharpie/ios.ignore
@@ -85,6 +85,15 @@
 !unknown-native-enum! GKPeerPickerConnectionType bound
 
 
+#Intents
+
+## The following were deprecated in ios(10.0, 10.0)
+!missing-selector! INRideDriver::initWithHandle:displayName:image:rating:phoneNumber: not bound
+!missing-selector! INRideDriver::initWithHandle:nameComponents:image:rating:phoneNumber: not bound
+!missing-selector! INRideOption::identifier not bound
+!missing-selector! INRideOption::setIdentifier: not bound
+
+
 # IntentsUI
 
 ## not exposed by our API (better use the OS version)


### PR DESCRIPTION
INCarSeatResolutionResult is not available in watchOS, unfortunately
it was bound pre xcode9 so until XAMCORE_4_0 happens it won't get removed

```
Type Changed: Intents.INCarSeatResolutionResult

Removed methods:

    public static INCarSeatResolutionResult GetConfirmationRequired (INCarSeat valueToConfirm);
    public static INCarSeatResolutionResult GetSuccess (INCarSeat resolvedValue);
```