### PR TITLE
[Foundation] Add NSProxy stub in order to workaround bug 59247

### DIFF
--- a/src/Foundation/NSProxy.cs
+++ b/src/Foundation/NSProxy.cs
@@ -25,3 +25,13 @@ namespace XamCore.Foundation {
 	internal abstract class NSProxy : NSObject {
 	}
 }
+
+namespace XamCore.WebKit {
+	// We need to keep NSProxy (avoid linking it) if WKNavigationDelegate or IWKNavigationDelegate
+	// is used. Unfortunately [Preserve] can't help us here because we do not generate partial
+	// interfaces rigth now, so we know WKWebView will be there and can hold a reference to it.
+	public partial class WKWebView {
+		[Preserve (Conditional = true)]
+		static Type hack = typeof (NSProxy);
+	}
+}

--- a/src/Foundation/NSProxy.cs
+++ b/src/Foundation/NSProxy.cs
@@ -1,0 +1,27 @@
+﻿//
+// NSProxy.cs
+//
+// Authors:
+//	Alex Soto  <alexsoto@microsoft.com>
+//
+// Copyright 2017 Xamarin Inc. All rights reserved.
+//
+
+// HACK:
+// Yep this is just a hack to workaround https://bugzilla.xamarin.com/show_bug.cgi?id=59247
+// we need to have a better solution that removes all what NSProxy does not responds to.
+// Right now this works because NSObject implements NSObject protocol just like NSProxy, but
+// NSProxy responds to far less selectors hence doing it internal so it is not a breaking change
+// when we provide the correct fix.
+
+using System;
+using System.ComponentModel;
+using XamCore.Foundation;
+using XamCore.ObjCRuntime;
+
+namespace XamCore.Foundation {
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	[Register ("NSProxy", true)]
+	internal abstract class NSProxy : NSObject {
+	}
+}

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -712,6 +712,7 @@ FOUNDATION_SOURCES = \
 	Foundation/NSPortMessage.cs \
 	Foundation/NSPredicate.cs \
 	Foundation/NSPropertyListSerialization.cs \
+	Foundation/NSProxy.cs \
 	Foundation/NSRunLoop.cs \
 	Foundation/NSScriptCommandDescription.cs \
 	Foundation/NSScriptCommandArgumentDescription.cs \


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=59247

We need to have a better solution that removes all what NSProxy does not responds to.
Right now this works because NSObject implements NSObject protocol just like NSProxy, but
NSProxy responds to far less selectors hence doing it internal so it is not a breaking change
when we provide the correct fix.