### PR TITLE
[AVFoundation] Readd AVAssetDownloadDelegate.DidLoadTimeRange 

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -11548,6 +11548,10 @@ namespace XamCore.AVFoundation {
 		[NoWatch, NoMac, NoTV, iOS (11,0)]
 		[Export ("URLSession:aggregateAssetDownloadTask:didCompleteForMediaSelection:")]
 		void DidCompleteForMediaSelection (NSUrlSession session, AVAggregateAssetDownloadTask aggregateAssetDownloadTask, AVMediaSelection mediaSelection);
+
+		[NoWatch, NoMac, NoTV, iOS (11,0)]
+		[Export ("URLSession:aggregateAssetDownloadTask:didLoadTimeRange:totalTimeRangesLoaded:timeRangeExpectedToLoad:forMediaSelection:")]
+		void DidLoadTimeRange (NSUrlSession session, AVAggregateAssetDownloadTask aggregateAssetDownloadTask, CMTimeRange timeRange, NSValue[] loadedTimeRanges, CMTimeRange timeRangeExpectedToLoad, AVMediaSelection mediaSelection);
 	}
 
 #endif


### PR DESCRIPTION
The method was not removed BUT renamed yet it was remove on https://github.com/xamarin/xamarin-macios/pull/2687