### PR TITLE
[arkit] Add ARBlendShapeLocationOptions strong dictionary

### DIFF
--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -645,6 +645,7 @@ namespace XamCore.ARKit {
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
 	[Static]
+	[Internal]
 	interface ARBlendShapeLocationKeys {
 
 		[Field ("ARBlendShapeLocationBrowDownLeft")]

--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -536,16 +536,284 @@ namespace XamCore.ARKit {
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
+	[StrongDictionary ("ARBlendShapeLocationKeys")]
+	interface ARBlendShapeLocationOptions {
+
+		float BrowDownLeft { get; set; }
+
+		float BrowDownRight { get; set; }
+
+		float BrowInnerUp { get; set; }
+
+		float BrowOuterUpLeft { get; set; }
+
+		float BrowOuterUpRight { get; set; }
+
+		float CheekPuff { get; set; }
+
+		float CheekSquintLeft { get; set; }
+
+		float CheekSquintRight { get; set; }
+
+		float EyeBlinkLeft { get; set; }
+
+		float EyeBlinkRight { get; set; }
+
+		float EyeLookDownLeft { get; set; }
+
+		float EyeLookDownRight { get; set; }
+
+		float EyeLookInLeft { get; set; }
+
+		float EyeLookInRight { get; set; }
+
+		float EyeLookOutLeft { get; set; }
+
+		float EyeLookOutRight { get; set; }
+
+		float EyeLookUpLeft { get; set; }
+
+		float EyeLookUpRight { get; set; }
+
+		float EyeSquintLeft { get; set; }
+
+		float EyeSquintRight { get; set; }
+
+		float EyeWideLeft { get; set; }
+
+		float EyeWideRight { get; set; }
+
+		float JawForward { get; set; }
+
+		float JawLeft { get; set; }
+
+		float JawOpen { get; set; }
+
+		float JawRight { get; set; }
+
+		float MouthClose { get; set; }
+
+		float MouthDimpleLeft { get; set; }
+
+		float MouthDimpleRight { get; set; }
+
+		float MouthFrownLeft { get; set; }
+
+		float MouthFrownRight { get; set; }
+
+		float MouthFunnel { get; set; }
+
+		float MouthLeft { get; set; }
+
+		float MouthLowerDownLeft { get; set; }
+
+		float MouthLowerDownRight { get; set; }
+
+		float MouthPressLeft { get; set; }
+
+		float MouthPressRight { get; set; }
+
+		float MouthPucker { get; set; }
+
+		float MouthRight { get; set; }
+
+		float MouthRollLower { get; set; }
+
+		float MouthRollUpper { get; set; }
+
+		float MouthShrugLower { get; set; }
+
+		float MouthShrugUpper { get; set; }
+
+		float MouthSmileLeft { get; set; }
+
+		float MouthSmileRight { get; set; }
+
+		float MouthStretchLeft { get; set; }
+
+		float MouthStretchRight { get; set; }
+
+		float MouthUpperUpLeft { get; set; }
+
+		float MouthUpperUpRight { get; set; }
+
+		float NoseSneerLeft { get; set; }
+
+		float NoseSneerRight { get; set; }
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
+	[Static]
+	interface ARBlendShapeLocationKeys {
+
+		[Field ("ARBlendShapeLocationBrowDownLeft")]
+		NSString BrowDownLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationBrowDownRight")]
+		NSString BrowDownRightKey { get; }
+
+		[Field ("ARBlendShapeLocationBrowInnerUp")]
+		NSString BrowInnerUpKey { get; }
+
+		[Field ("ARBlendShapeLocationBrowOuterUpLeft")]
+		NSString BrowOuterUpLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationBrowOuterUpRight")]
+		NSString BrowOuterUpRightKey { get; }
+
+		[Field ("ARBlendShapeLocationCheekPuff")]
+		NSString CheekPuffKey { get; }
+
+		[Field ("ARBlendShapeLocationCheekSquintLeft")]
+		NSString CheekSquintLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationCheekSquintRight")]
+		NSString CheekSquintRightKey { get; }
+
+		[Field ("ARBlendShapeLocationEyeBlinkLeft")]
+		NSString EyeBlinkLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationEyeBlinkRight")]
+		NSString EyeBlinkRightKey { get; }
+
+		[Field ("ARBlendShapeLocationEyeLookDownLeft")]
+		NSString EyeLookDownLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationEyeLookDownRight")]
+		NSString EyeLookDownRightKey { get; }
+
+		[Field ("ARBlendShapeLocationEyeLookInLeft")]
+		NSString EyeLookInLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationEyeLookInRight")]
+		NSString EyeLookInRightKey { get; }
+
+		[Field ("ARBlendShapeLocationEyeLookOutLeft")]
+		NSString EyeLookOutLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationEyeLookOutRight")]
+		NSString EyeLookOutRightKey { get; }
+
+		[Field ("ARBlendShapeLocationEyeLookUpLeft")]
+		NSString EyeLookUpLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationEyeLookUpRight")]
+		NSString EyeLookUpRightKey { get; }
+
+		[Field ("ARBlendShapeLocationEyeSquintLeft")]
+		NSString EyeSquintLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationEyeSquintRight")]
+		NSString EyeSquintRightKey { get; }
+
+		[Field ("ARBlendShapeLocationEyeWideLeft")]
+		NSString EyeWideLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationEyeWideRight")]
+		NSString EyeWideRightKey { get; }
+
+		[Field ("ARBlendShapeLocationJawForward")]
+		NSString JawForwardKey { get; }
+
+		[Field ("ARBlendShapeLocationJawLeft")]
+		NSString JawLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationJawOpen")]
+		NSString JawOpenKey { get; }
+
+		[Field ("ARBlendShapeLocationJawRight")]
+		NSString JawRightKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthClose")]
+		NSString MouthCloseKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthDimpleLeft")]
+		NSString MouthDimpleLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthDimpleRight")]
+		NSString MouthDimpleRightKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthFrownLeft")]
+		NSString MouthFrownLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthFrownRight")]
+		NSString MouthFrownRightKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthFunnel")]
+		NSString MouthFunnelKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthLeft")]
+		NSString MouthLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthLowerDownLeft")]
+		NSString MouthLowerDownLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthLowerDownRight")]
+		NSString MouthLowerDownRightKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthPressLeft")]
+		NSString MouthPressLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthPressRight")]
+		NSString MouthPressRightKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthPucker")]
+		NSString MouthPuckerKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthRight")]
+		NSString MouthRightKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthRollLower")]
+		NSString MouthRollLowerKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthRollUpper")]
+		NSString MouthRollUpperKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthShrugLower")]
+		NSString MouthShrugLowerKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthShrugUpper")]
+		NSString MouthShrugUpperKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthSmileLeft")]
+		NSString MouthSmileLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthSmileRight")]
+		NSString MouthSmileRightKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthStretchLeft")]
+		NSString MouthStretchLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthStretchRight")]
+		NSString MouthStretchRightKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthUpperUpLeft")]
+		NSString MouthUpperUpLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationMouthUpperUpRight")]
+		NSString MouthUpperUpRightKey { get; }
+
+		[Field ("ARBlendShapeLocationNoseSneerLeft")]
+		NSString NoseSneerLeftKey { get; }
+
+		[Field ("ARBlendShapeLocationNoseSneerRight")]
+		NSString NoseSneerRightKey { get; }
+	}
+
+	[iOS (11,0)]
+	[NoWatch, NoTV, NoMac]
 	[BaseType (typeof(ARAnchor))]
 	interface ARFaceAnchor : ARTrackable {
 		[Export ("geometry")]
 		ARFaceGeometry Geometry { get; }
 
-		/* Will come in next PR
-		// @property (readonly, nonatomic) NSDictionary<ARBlendShapeLocation,NSNumber *> * _Nonnull blendShapes;
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("blendShapes")]
-		NSDictionary<NSString, NSNumber> BlendShapes { get; }
-		*/
+		NSDictionary WeakBlendShapes { get; }
+
+		[Wrap ("WeakBlendShapes")]
+		ARBlendShapeLocationOptions BlendShapes { get; }
 	}
 
 	[iOS (11,0)]
@@ -553,10 +821,12 @@ namespace XamCore.ARKit {
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
 	interface ARFaceGeometry : NSCopying {
-		/* Will come in next PR
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("initWithBlendShapes:")]
-		IntPtr Constructor (NSDictionary<NSString, NSNumber> blendShapes);
-		*/
+		IntPtr Constructor (NSDictionary blendShapes);
+
+		[Wrap ("this ((NSDictionary)blendShapes?.Dictionary)")]
+		IntPtr Constructor (ARBlendShapeLocationOptions blendShapes);
 
 		[Export ("vertexCount")]
 		nuint VertexCount { get; }


### PR DESCRIPTION
I chose to not transform those `ARBlendShapeLocation` constants (`[Field]`) into a smart enum because a strong dictionary is what the APIs need most.