### PR TITLE
[Metal] Renamed MTLArgumentDescriptor.ArgumentDescriptor to Create, fixes bug 59498

### DIFF
--- a/src/metal.cs
+++ b/src/metal.cs
@@ -2570,7 +2570,7 @@ namespace XamCore.Metal {
 	{
 		[Static]
 		[Export ("argumentDescriptor")]
-		MTLArgumentDescriptor ArgumentDescriptor { get; }
+		MTLArgumentDescriptor Create ();
 
 		[Export ("dataType", ArgumentSemantic.Assign)]
 		MTLDataType DataType { get; set; }


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=59498

From [argumentDescriptor docs](https://developer.apple.com/documentation/metal/mtlargumentdescriptor/2915746-argumentdescriptor?language=objc)

> Creates an empty argument descriptor.