### PR TITLE
[iosurface] IOSurface is not usable before iOS/tvOS 11. Fixes #59201

### DIFF
--- a/src/Constants.iOS.cs.in
+++ b/src/Constants.iOS.cs.in
@@ -115,17 +115,7 @@ namespace MonoTouch {
 		public const string VisionLibrary = "/System/Library/Frameworks/Vision.framework/Vision";
 		public const string FileProviderLibrary = "/System/Library/Frameworks/FileProvider.framework/FileProvider";
 		public const string FileProviderUILibrary = "/System/Library/Frameworks/FileProviderUI.framework/FileProviderUI";
-		public static string IOSurfaceLibrary {
-			get {
-// Disabled because of bug #59201
-// #if !COREBUILD && !MTOUCH
-// // Sidenote: this is in /System/Library/Frameworks/IOSurface.framework/IOSurface in macOS 10.12.
-// 				if (!XamCore.UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
-// 					return "/System/Library/PrivateFrameworks/IOSurface.framework/IOSurface";
-// #endif
-				return "/System/Library/Frameworks/IOSurface.framework/IOSurface";
-			}
-		}
+		public const string IOSurfaceLibrary = "/System/Library/Frameworks/IOSurface.framework/IOSurface";
 		public const string PdfKitLibrary = "/System/Library/Frameworks/PDFKit.framework/PDFKit";
 	}
 }

--- a/src/Constants.tvos.cs.in
+++ b/src/Constants.tvos.cs.in
@@ -73,16 +73,6 @@ namespace ObjCRuntime {
 		public const string DeviceCheckLibrary = "/System/Library/Frameworks/DeviceCheck.framework/DeviceCheck";
 		public const string CoreMLLibrary = "/System/Library/Frameworks/CoreML.framework/CoreML";
 		public const string VisionLibrary = "/System/Library/Frameworks/Vision.framework/Vision";
-		public static string IOSurfaceLibrary {
-			get {
-// Disabled because of bug #59201
-// #if !COREBUILD && !MTOUCH
-// // Sidenote: this is in /System/Library/Frameworks/IOSurface.framework/IOSurface in macOS 10.12.
-// 				if (!XamCore.UIKit.UIDevice.CurrentDevice.CheckSystemVersion (11, 0))
-// 					return "/System/Library/PrivateFrameworks/IOSurface.framework/IOSurface";
-// #endif
-				return "/System/Library/Frameworks/IOSurface.framework/IOSurface";
-			}
-		}
+		public const string IOSurfaceLibrary = "/System/Library/Frameworks/IOSurface.framework/IOSurface";
 	}
 }

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -245,12 +245,12 @@ public class Frameworks : Dictionary <string, Framework>
 				{ "UserNotificationsUI", "UserNotificationsUI", 10 },
 				{ "Intents", "Intents", 10 },
 				{ "IntentsUI", "IntentsUI", 10 },
-				{ "IOSurface", "IOSurface", 10 },
 
 				{ "ARKit", "ARKit", 11 },
 				{ "CoreNFC", "CoreNFC", 11 },
 				{ "DeviceCheck", "DeviceCheck", 11 },
 				{ "IdentityLookup", "IdentityLookup", 11 },
+				{ "IOSurface", "IOSurface", 11 },
 				{ "CoreML", "CoreML", 11 },
 				{ "Vision", "Vision", 11 },
 				{ "FileProvider", "FileProvider", 11 },
@@ -361,10 +361,10 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "UserNotifications", "UserNotifications", 10 },
 					{ "VideoSubscriberAccount", "VideoSubscriberAccount", 10 },
 					{ "VideoToolbox", "VideoToolbox", 10,2 },
-					{ "IOSurface", "IOSurface", 10 },
 
 					{ "DeviceCheck", "DeviceCheck", 11 },
 					{ "CoreML", "CoreML", 11 },
+					{ "IOSurface", "IOSurface", 11 },
 					{ "Vision", "Vision", 11 },
 				};
 			}

--- a/tools/mtouch/BuildTasks.mtouch.cs
+++ b/tools/mtouch/BuildTasks.mtouch.cs
@@ -336,7 +336,7 @@ namespace Xamarin.Bundler
 			// /System/Library/PrivateFrameworks/JavaScriptCore.framework/JavaScriptCore instead of
 			// /System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore
 			// more details in https://bugzilla.xamarin.com/show_bug.cgi?id=31036
-			if (Target.WeakFrameworks.Count > 0)
+			if (CompilerFlags.WeakFrameworks.Count > 0)
 				Target.AdjustDylibs ();
 			Driver.Watch ("Native Link", 1);
 		}


### PR DESCRIPTION
Apple rejects apps that links with the previously private IOSurface.framework.
We were not sure about this [1] and had it disabled (this is removed).

However another bug stopped our adjustment logic [2] from being executed. This
is needed since `clang` picks up the private framework if it does not find the
public one (even when asking for a weak framework),

[1] https://bugzilla.xamarin.com/show_bug.cgi?id=59201
[2] Added a while ago for JavascriptCore