### PR TITLE
[CoreAnimation] CATextLayer.Alignment* strings should be CATextLayerAlignment enum / type. Fixes bug 59537

### DIFF
--- a/src/CoreAnimation/CATextLayer.cs
+++ b/src/CoreAnimation/CATextLayer.cs
@@ -136,25 +136,25 @@ namespace XamCore.CoreAnimation {
 		}
 #if !XAMCORE_4_0
 		[Advice ("Use 'TextTruncationMode' instead.")]
-		public string TruncationMode {
-			get { return (string) _TruncationMode; }
-			set { _TruncationMode = (NSString) value; }
+		public virtual string TruncationMode {
+			get { return (string) WeakTruncationMode; }
+			set { WeakTruncationMode = (NSString) value; }
 		}
 
 		[Advice ("Use 'TextAlignmentMode' instead.")]
-		public string AlignmentMode {
-			get { return (string) _AlignmentMode; }
-			set { _AlignmentMode = (NSString) value; }
+		public virtual string AlignmentMode {
+			get { return (string) WeakAlignmentMode; }
+			set { WeakAlignmentMode = (NSString) value; }
 		}
 #endif // !XAMCORE_4_0
 		public CATextLayerTruncationMode TextTruncationMode {
-			get { return CATextLayerTruncationModeExtensions.GetValue (_TruncationMode); }
-			set { _TruncationMode = value.GetConstant (); }
+			get { return CATextLayerTruncationModeExtensions.GetValue (WeakTruncationMode); }
+			set { WeakTruncationMode = value.GetConstant (); }
 		}
 
 		public CATextLayerAlignmentMode TextAlignmentMode {
-			get { return CATextLayerAlignmentModeExtensions.GetValue (_AlignmentMode); }
-			set { _AlignmentMode = value.GetConstant (); }
+			get { return CATextLayerAlignmentModeExtensions.GetValue (WeakAlignmentMode); }
+			set { WeakAlignmentMode = value.GetConstant (); }
 		}
 	}
 }

--- a/src/CoreAnimation/CATextLayer.cs
+++ b/src/CoreAnimation/CATextLayer.cs
@@ -134,6 +134,52 @@ namespace XamCore.CoreAnimation {
 				}
 			}
 		}
+#if !XAMCORE_4_0
+		[Advice ("Use 'TextTruncationMode' instead.")]
+		public string TruncationMode {
+			get {
+				return NSString.FromHandle (_TruncationMode);
+			}
+			set {
+				if (value == null)
+					throw new ArgumentNullException (nameof (value));
+				var nsvalue = NSString.CreateNative (value);
+				_TruncationMode = nsvalue;
+				NSString.ReleaseNative (nsvalue);
+			}
+		}
+
+		[Advice ("Use 'TextAlignmentMode' instead.")]
+		public string AlignmentMode {
+			get {
+				return NSString.FromHandle (_AlignmentMode);
+			}
+			set {
+				if (value == null)
+					throw new ArgumentNullException (nameof (value));
+				var nsvalue = NSString.CreateNative (value);
+				_AlignmentMode = nsvalue;
+				NSString.ReleaseNative (nsvalue);
+			}
+		}
+#endif // !XAMCORE_4_0
+		public CATextLayerTruncationMode TextTruncationMode {
+			get {
+				return CATextLayerTruncationModeExtensions.GetValue (Runtime.GetNSObject<NSString> (_TruncationMode));
+			}
+			set {
+				_TruncationMode = value.GetConstant ().Handle;
+			}
+		}
+
+		public CATextLayerAlignmentMode TextAlignmentMode {
+			get {
+				return CATextLayerAlignmentModeExtensions.GetValue (Runtime.GetNSObject<NSString> (_AlignmentMode));
+			}
+			set {
+				_AlignmentMode = value.GetConstant ().Handle;
+			}
+		}
 	}
 }
 

--- a/src/CoreAnimation/CATextLayer.cs
+++ b/src/CoreAnimation/CATextLayer.cs
@@ -135,13 +135,13 @@ namespace XamCore.CoreAnimation {
 			}
 		}
 #if !XAMCORE_4_0
-		[Advice ("Use 'TextTruncationMode' instead.")]
+		[Obsolete ("Use 'TextTruncationMode' instead.")]
 		public virtual string TruncationMode {
 			get { return (string) WeakTruncationMode; }
 			set { WeakTruncationMode = (NSString) value; }
 		}
 
-		[Advice ("Use 'TextAlignmentMode' instead.")]
+		[Obsolete ("Use 'TextAlignmentMode' instead.")]
 		public virtual string AlignmentMode {
 			get { return (string) WeakAlignmentMode; }
 			set { WeakAlignmentMode = (NSString) value; }

--- a/src/CoreAnimation/CATextLayer.cs
+++ b/src/CoreAnimation/CATextLayer.cs
@@ -137,48 +137,24 @@ namespace XamCore.CoreAnimation {
 #if !XAMCORE_4_0
 		[Advice ("Use 'TextTruncationMode' instead.")]
 		public string TruncationMode {
-			get {
-				return NSString.FromHandle (_TruncationMode);
-			}
-			set {
-				if (value == null)
-					throw new ArgumentNullException (nameof (value));
-				var nsvalue = NSString.CreateNative (value);
-				_TruncationMode = nsvalue;
-				NSString.ReleaseNative (nsvalue);
-			}
+			get { return (string) _TruncationMode; }
+			set { _TruncationMode = (NSString) value; }
 		}
 
 		[Advice ("Use 'TextAlignmentMode' instead.")]
 		public string AlignmentMode {
-			get {
-				return NSString.FromHandle (_AlignmentMode);
-			}
-			set {
-				if (value == null)
-					throw new ArgumentNullException (nameof (value));
-				var nsvalue = NSString.CreateNative (value);
-				_AlignmentMode = nsvalue;
-				NSString.ReleaseNative (nsvalue);
-			}
+			get { return (string) _AlignmentMode; }
+			set { _AlignmentMode = (NSString) value; }
 		}
 #endif // !XAMCORE_4_0
 		public CATextLayerTruncationMode TextTruncationMode {
-			get {
-				return CATextLayerTruncationModeExtensions.GetValue (Runtime.GetNSObject<NSString> (_TruncationMode));
-			}
-			set {
-				_TruncationMode = value.GetConstant ().Handle;
-			}
+			get { return CATextLayerTruncationModeExtensions.GetValue (_TruncationMode); }
+			set { _TruncationMode = value.GetConstant (); }
 		}
 
 		public CATextLayerAlignmentMode TextAlignmentMode {
-			get {
-				return CATextLayerAlignmentModeExtensions.GetValue (Runtime.GetNSObject<NSString> (_AlignmentMode));
-			}
-			set {
-				_AlignmentMode = value.GetConstant ().Handle;
-			}
+			get { return CATextLayerAlignmentModeExtensions.GetValue (_AlignmentMode); }
+			set { _AlignmentMode = value.GetConstant (); }
 		}
 	}
 }

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -868,11 +868,11 @@ namespace XamCore.CoreAnimation {
 
 		[Internal]
 		[Export ("truncationMode", ArgumentSemantic.Copy)]
-		IntPtr _TruncationMode { get; set; }
+		NSString _TruncationMode { get; set; }
 
 		[Internal]
 		[Export ("alignmentMode", ArgumentSemantic.Copy)]
-		IntPtr _AlignmentMode { get; set; }
+		NSString _AlignmentMode { get; set; }
 
 #if !XAMCORE_4_0 // Use smart enums instead, CATruncationMode and CATextLayerAlignmentMode.
 		[Advice ("Use 'CATextLayerTruncationMode.None.GetConstant ()' instead.")]

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -866,13 +866,13 @@ namespace XamCore.CoreAnimation {
 		[Export ("wrapped")]
 		bool Wrapped { [Bind ("isWrapped")] get; set; }
 
-		[Internal]
+		[Protected]
 		[Export ("truncationMode", ArgumentSemantic.Copy)]
-		NSString _TruncationMode { get; set; }
+		NSString WeakTruncationMode { get; set; }
 
-		[Internal]
+		[Protected]
 		[Export ("alignmentMode", ArgumentSemantic.Copy)]
-		NSString _AlignmentMode { get; set; }
+		NSString WeakAlignmentMode { get; set; }
 
 #if !XAMCORE_4_0 // Use smart enums instead, CATruncationMode and CATextLayerAlignmentMode.
 		[Advice ("Use 'CATextLayerTruncationMode.None.GetConstant ()' instead.")]

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -808,6 +808,37 @@ namespace XamCore.CoreAnimation {
 		CALayer HitTest (CGPoint thePoint);
 	}
 
+	enum CATextLayerTruncationMode {
+		[Field ("kCATruncationNone")]
+		None,
+
+		[Field ("kCATruncationStart")]
+		Start,
+
+		[Field ("kCATruncationMiddle")]
+		Middle,
+
+		[Field ("kCATruncationEnd")]
+		End,
+	}
+
+	enum CATextLayerAlignmentMode {
+		[Field ("kCAAlignmentLeft")]
+		Left,
+
+		[Field ("kCAAlignmentRight")]
+		Right,
+
+		[Field ("kCAAlignmentCenter")]
+		Center,
+
+		[Field ("kCAAlignmentJustified")]
+		Justified,
+
+		[Field ("kCAAlignmentNatural")]
+		Natural,
+	}
+
 	[Since (3,2)]
 	[BaseType (typeof (CALayer))]
 	interface CATextLayer {
@@ -835,38 +866,60 @@ namespace XamCore.CoreAnimation {
 		[Export ("wrapped")]
 		bool Wrapped { [Bind ("isWrapped")] get; set; }
 
+		[Internal]
 		[Export ("truncationMode", ArgumentSemantic.Copy)]
-		string TruncationMode { get; set; }
+		IntPtr _TruncationMode { get; set; }
 
+		[Internal]
 		[Export ("alignmentMode", ArgumentSemantic.Copy)]
-		string AlignmentMode { get; set; }
+		IntPtr _AlignmentMode { get; set; }
 
-		[Field ("kCATruncationNone")]
+#if !XAMCORE_4_0 // Use smart enums instead, CATruncationMode and CATextLayerAlignmentMode.
+		[Advice ("Use 'CATextLayerTruncationMode.None.GetConstant ()' instead.")]
+		[Static]
+		[Wrap ("CATextLayerTruncationMode.None.GetConstant ()")]
 		NSString TruncationNone { get; }
 		
-		[Field ("kCATruncationStart")]
+		[Advice ("Use 'CATextLayerTruncationMode.Start.GetConstant ()' instead.")]
+		[Static]
+		[Wrap ("CATextLayerTruncationMode.Start.GetConstant ()")]
 		NSString TruncantionStart { get; }
 		
-		[Field ("kCATruncationEnd")]
+		[Advice ("Use 'CATextLayerTruncationMode.End.GetConstant ()' instead.")]
+		[Static]
+		[Wrap ("CATextLayerTruncationMode.End.GetConstant ()")]
 		NSString TruncantionEnd { get; }
 		
-		[Field ("kCATruncationMiddle")]
+		[Advice ("Use 'CATextLayerTruncationMode.Middle.GetConstant ()' instead.")]
+		[Static]
+		[Wrap ("CATextLayerTruncationMode.Middle.GetConstant ()")]
 		NSString TruncantionMiddle { get; }
 		
-		[Field ("kCAAlignmentNatural")]
+		[Advice ("Use 'CATextLayerAlignmentMode.Natural.GetConstant ()' instead.")]
+		[Static]
+		[Wrap ("CATextLayerAlignmentMode.Natural.GetConstant ()")]
 		NSString AlignmentNatural { get; }
 		
-		[Field ("kCAAlignmentLeft")]
+		[Advice ("Use 'CATextLayerAlignmentMode.Left.GetConstant ()' instead.")]
+		[Static]
+		[Wrap ("CATextLayerAlignmentMode.Left.GetConstant ()")]
 		NSString AlignmentLeft { get; }
 		
-		[Field ("kCAAlignmentRight")]
+		[Advice ("Use 'CATextLayerAlignmentMode.Right.GetConstant ()' instead.")]
+		[Static]
+		[Wrap ("CATextLayerAlignmentMode.Right.GetConstant ()")]
 		NSString AlignmentRight { get; }
 		
-		[Field ("kCAAlignmentCenter")]
+		[Advice ("Use 'CATextLayerAlignmentMode.Center.GetConstant ()' instead.")]
+		[Static]
+		[Wrap ("CATextLayerAlignmentMode.Center.GetConstant ()")]
 		NSString AlignmentCenter { get; }
 		
-		[Field ("kCAAlignmentJustified")]
+		[Advice ("Use 'CATextLayerAlignmentMode.Justified.GetConstant ()' instead.")]
+		[Static]
+		[Wrap ("CATextLayerAlignmentMode.Justified.GetConstant ()")]
 		NSString AlignmentJustified { get; }
+#endif // !XAMCORE_4_0
 
 		[iOS(9,0)]
 		[Export ("allowsFontSubpixelQuantization")]

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -875,47 +875,47 @@ namespace XamCore.CoreAnimation {
 		NSString WeakAlignmentMode { get; set; }
 
 #if !XAMCORE_4_0 // Use smart enums instead, CATruncationMode and CATextLayerAlignmentMode.
-		[Advice ("Use 'CATextLayerTruncationMode.None.GetConstant ()' instead.")]
+		[Obsolete ("Use 'CATextLayerTruncationMode.None.GetConstant ()' instead.")]
 		[Static]
 		[Wrap ("CATextLayerTruncationMode.None.GetConstant ()")]
 		NSString TruncationNone { get; }
 		
-		[Advice ("Use 'CATextLayerTruncationMode.Start.GetConstant ()' instead.")]
+		[Obsolete ("Use 'CATextLayerTruncationMode.Start.GetConstant ()' instead.")]
 		[Static]
 		[Wrap ("CATextLayerTruncationMode.Start.GetConstant ()")]
 		NSString TruncantionStart { get; }
 		
-		[Advice ("Use 'CATextLayerTruncationMode.End.GetConstant ()' instead.")]
+		[Obsolete ("Use 'CATextLayerTruncationMode.End.GetConstant ()' instead.")]
 		[Static]
 		[Wrap ("CATextLayerTruncationMode.End.GetConstant ()")]
 		NSString TruncantionEnd { get; }
 		
-		[Advice ("Use 'CATextLayerTruncationMode.Middle.GetConstant ()' instead.")]
+		[Obsolete ("Use 'CATextLayerTruncationMode.Middle.GetConstant ()' instead.")]
 		[Static]
 		[Wrap ("CATextLayerTruncationMode.Middle.GetConstant ()")]
 		NSString TruncantionMiddle { get; }
 		
-		[Advice ("Use 'CATextLayerAlignmentMode.Natural.GetConstant ()' instead.")]
+		[Obsolete ("Use 'CATextLayerAlignmentMode.Natural.GetConstant ()' instead.")]
 		[Static]
 		[Wrap ("CATextLayerAlignmentMode.Natural.GetConstant ()")]
 		NSString AlignmentNatural { get; }
 		
-		[Advice ("Use 'CATextLayerAlignmentMode.Left.GetConstant ()' instead.")]
+		[Obsolete ("Use 'CATextLayerAlignmentMode.Left.GetConstant ()' instead.")]
 		[Static]
 		[Wrap ("CATextLayerAlignmentMode.Left.GetConstant ()")]
 		NSString AlignmentLeft { get; }
 		
-		[Advice ("Use 'CATextLayerAlignmentMode.Right.GetConstant ()' instead.")]
+		[Obsolete ("Use 'CATextLayerAlignmentMode.Right.GetConstant ()' instead.")]
 		[Static]
 		[Wrap ("CATextLayerAlignmentMode.Right.GetConstant ()")]
 		NSString AlignmentRight { get; }
 		
-		[Advice ("Use 'CATextLayerAlignmentMode.Center.GetConstant ()' instead.")]
+		[Obsolete ("Use 'CATextLayerAlignmentMode.Center.GetConstant ()' instead.")]
 		[Static]
 		[Wrap ("CATextLayerAlignmentMode.Center.GetConstant ()")]
 		NSString AlignmentCenter { get; }
 		
-		[Advice ("Use 'CATextLayerAlignmentMode.Justified.GetConstant ()' instead.")]
+		[Obsolete ("Use 'CATextLayerAlignmentMode.Justified.GetConstant ()' instead.")]
 		[Static]
 		[Wrap ("CATextLayerAlignmentMode.Justified.GetConstant ()")]
 		NSString AlignmentJustified { get; }

--- a/tests/monotouch-test/CoreAnimation/CATextLayerTests.cs
+++ b/tests/monotouch-test/CoreAnimation/CATextLayerTests.cs
@@ -1,0 +1,60 @@
+﻿//
+// Unit tests for CATextLayerTests
+//
+// Authors:
+//	Alex Soto <alexsoto@microsoft.com>
+//
+//
+// Copyright 2017 Xamarin Inc. All rights reserved.
+//
+
+#if !__WATCHOS__
+
+using System;
+using NUnit.Framework;
+
+#if XAMCORE_2_0
+using Foundation;
+using CoreAnimation;
+#else
+using MonoTouch.CoreAnimation;
+using MonoTouch.Foundation;
+#endif
+
+namespace MonoTouchFixtures.CoreAnimation {
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class CATextLayerTests {
+
+		[Test]
+		public void CATextLayerTruncationModeTest ()
+		{
+			var textLayer = new CATextLayer {
+				String = "Hello",
+				TextTruncationMode = CATextLayerTruncationMode.Middle
+			};
+
+			Assert.AreEqual (CATextLayerTruncationMode.Middle, textLayer.TextTruncationMode, "TextTruncationMode");
+			Assert.AreEqual (textLayer.TruncationMode, (string) textLayer.TextTruncationMode.GetConstant (), "TruncationMode");
+
+			textLayer.TruncationMode = CATextLayer.TruncantionEnd;
+			Assert.AreEqual (CATextLayerTruncationMode.End, textLayer.TextTruncationMode, "TextTruncationMode 2");
+		}
+
+		[Test]
+		public void CATextLayerAlignmentModeTest ()
+		{
+			var textLayer = new CATextLayer {
+				String = "Hello",
+				TextAlignmentMode = CATextLayerAlignmentMode.Justified
+			};
+
+			Assert.AreEqual (CATextLayerAlignmentMode.Justified, textLayer.TextAlignmentMode, "TextAlignmentMode");
+			Assert.AreEqual (textLayer.AlignmentMode, (string) textLayer.TextAlignmentMode.GetConstant (), "AlignmentMode");
+
+			textLayer.AlignmentMode = CATextLayer.AlignmentNatural;
+			Assert.AreEqual (CATextLayerAlignmentMode.Natural, textLayer.TextAlignmentMode, "TextAlignmentMode 2");
+		}
+	}
+}
+#endif // !__WATCHOS__

--- a/tests/monotouch-test/CoreAnimation/CATextLayerTests.cs
+++ b/tests/monotouch-test/CoreAnimation/CATextLayerTests.cs
@@ -39,6 +39,8 @@ namespace MonoTouchFixtures.CoreAnimation {
 
 			textLayer.TruncationMode = CATextLayer.TruncantionEnd;
 			Assert.AreEqual (CATextLayerTruncationMode.End, textLayer.TextTruncationMode, "TextTruncationMode 2");
+
+			Assert.Throws<ArgumentNullException> (() => textLayer.TruncationMode = null);
 		}
 
 		[Test]
@@ -54,6 +56,8 @@ namespace MonoTouchFixtures.CoreAnimation {
 
 			textLayer.AlignmentMode = CATextLayer.AlignmentNatural;
 			Assert.AreEqual (CATextLayerAlignmentMode.Natural, textLayer.TextAlignmentMode, "TextAlignmentMode 2");
+
+			Assert.Throws<ArgumentNullException> (() => textLayer.AlignmentMode = null);
 		}
 	}
 }

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -700,6 +700,7 @@
     <Compile Include="Metal\MTLTileRenderPipelineDescriptor.cs" />
     <Compile Include="Metal\MTLTileRenderPipelineColorAttachmentDescriptorTests.cs" />
     <Compile Include="AVFoundation\AVDepthDataTests.cs" />
+    <Compile Include="CoreAnimation\CATextLayerTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=59537

Removes constants from `CATextLayer` (only for XAMCORE_4_0) and creates
two smart enums `CATextLayerTruncationMode` and `CATextLayerAlignmentMode`.
Also this introduces two new strong properties into CATextLayer class,
`TextTruncationMode` and `TextAlignmentMode` that takes the new enums
respectively, these new properties are meant to replace their
string counterparts `TruncationMode` and `AlignmentMode`.