### PR TITLE
[linker] Reuse the linker submodule from our mono checkout

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,9 +5,6 @@
 [submodule "external/guiunit"]
     path = external/guiunit
     url = ../../mono/guiunit.git
-[submodule "external/linker"]
-    path = external/linker
-    url = ../../mono/linker.git
 [submodule "external/llvm"]
     path = external/llvm
     url = ../../mono/llvm.git

--- a/Make.config
+++ b/Make.config
@@ -235,7 +235,7 @@ OPENTK_PATH=$(TOP)/external/opentk
 XAMARIN_MACDEV_PATH=$(TOP)/external/Xamarin.MacDev
 GUI_UNIT_PATH=$(TOP)/external/guiunit
 MACCORE_PATH=$(TOP)/../maccore
-LINKER_TOOLS_PATH=$(TOP)/external/linker
+LINKER_TOOLS_PATH=$(MONO_PATH)/external/linker
 
 MONO_PREFIX ?= /Library/Frameworks/Mono.framework/Versions/Current
 SYSTEM_MCS=$(MONO_PREFIX)/bin/mcs

--- a/mk/versions.mk
+++ b/mk/versions.mk
@@ -70,7 +70,6 @@ $(eval $(call CheckSubmoduleTemplate,Touch.Unit,TOUCH_UNIT))
 $(eval $(call CheckSubmoduleTemplate,opentk,OPENTK))
 $(eval $(call CheckSubmoduleTemplate,Xamarin.MacDev,XAMARIN_MACDEV))
 $(eval $(call CheckSubmoduleTemplate,guiunit,GUI_UNIT))
-$(eval $(call CheckSubmoduleTemplate,linker,LINKER_TOOLS))
 
 include $(TOP)/mk/xamarin.mk
 


### PR DESCRIPTION
and avoid potential out-of-sync issues with mono (i.e. single bump)
and any other product doing the same.