### PR TITLE
Fix netstd2 issue on XM full by expanding facades the same as Modern

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -87,21 +87,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<PropertyGroup Condition="'$(TargetFrameworkName)' == 'Full'">
 		<AssemblySearchPaths>$(XamarinMacFrameworkRoot)/lib/reference/full;$(XamarinMacFrameworkRoot)/lib/mono;$(AssemblySearchPaths)</AssemblySearchPaths>
-
-		<!--
-		     This is to handle the case of XM/Full project referencing a netstandard project.
-
-		     For XM/Full, $(TargetFrameworkDirectory) is `lib/mono/4.5` which has `netstandard.dll`.
-		     This causes ImplicitlyExpandNETStandardFacades to skip expanding assuming that when ImplicitlyExpandDesignTimeFacades
-		     expands the facades, `netstandard.dll` would get referenced too.
-
-		     But if the XM project does NOT have any System.Runtime facades, then ImplicitlyExpandDesignTimeFacades will not expand
-		     the facades and so we end up with no `netstandard.dll` reference!
-
-		     With `$(NETStandardInbox) == false`, `ImplicitlyExpandNETStandardFacades` behaves as if `netstandard.dll` was not
-		     available in the framework directories and will expand the facades if required.
-		-->
-		<NETStandardInbox Condition="'$(NETStandardInbox)' == ''">false</NETStandardInbox>
+		<ImplicitlyExpandNETStandardFacades>False</ImplicitlyExpandNETStandardFacades>
 	</PropertyGroup>
 
 	<!-- Do not resolve from the GAC in Modern or Full unless allow-unsafe-gac-resolution is passed in -->

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.msbuild.targets
@@ -29,6 +29,5 @@ Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 		</ItemGroup>
 	</Target>
 	
-	<!-- Modern/Mobile does not get ImplicitlyExpandDesignTimeFacades as Microsoft.NETFramework.CurrentVersion.targets isn't pulled in -->
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.Common.ImplicitFacade.msbuild.targets" Condition="'$(TargetFrameworkName)' == 'Modern'"/>
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.Common.ImplicitFacade.msbuild.targets" Condition="'$(TargetFrameworkName)' == 'Modern' Or '$(TargetFrameworkName)' == 'Full'"/>
 </Project>


### PR DESCRIPTION
- The idea is to force Full and Modern to expand facades the same way. That way, we get the same, working behavior.
- f79f2e44241ebfd8d55fff9596f88ba4adc43e50 was not sufficient, even though it matched XI, because of the difference between XI (and Modern) and what Full was doing.