### PR TITLE
Disable link-keep-resources-2 in d15-5 branch

### DIFF
--- a/tests/mmptest/regression/Makefile
+++ b/tests/mmptest/regression/Makefile
@@ -17,7 +17,6 @@ TESTS_4_0 = \
 	link-posix-2 \
 	link-system.web-icalls \
 	link-keep-resources-1 \
-	link-keep-resources-2 \
 	link-preserve-assembly \
 	link-uithread-1 \
 	link-uithread-2 \


### PR DESCRIPTION
- Fix exists in mono/linker but 20 commits behind head, too risky to bump