### PR TITLE
[mtouch][mmp] Add better diagnose for bugs #59570 and #58063

### DIFF
--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -153,6 +153,13 @@ The easiest way to get exact version information is to use the **Xamarin Studio*
 
 ### <a name="MM2100"/>MM2100: Xamarin.Mac Classic API does not support Platform Linking.
 
+### <a name="MM2103"/>MM2103: Error processing assembly '\*': *
+
+An unexpected error occured when processing an assembly.
+
+The assembly causing the issue is named in the error message. In order to fix this issue the assembly will need to be provided in a [bug report](https://bugzilla.xamarin.com) along with a complete build log with verbosity enabled (i.e. `-v -v -v -v` in the **Additional mtouch arguments**).
+
+
 # MM3xxx: AOT
 
 ## MM30xx: AOT (general) errors

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -1217,6 +1217,14 @@ Something unexpected occured when trying to mark the method mentioned in the err
 
 The assembly causing the issue is named in the error message. In order to fix this issue the assembly will need to be provided in a [bug report](https://bugzilla.xamarin.com) along with a complete build log with verbosity enabled (i.e. `-v -v -v -v` in the **Additional mtouch arguments**).
 
+
+### <a name="MT2103"/>MT2103: Error processing assembly '\*': *
+
+An unexpected error occured when processing an assembly.
+
+The assembly causing the issue is named in the error message. In order to fix this issue the assembly will need to be provided in a [bug report](https://bugzilla.xamarin.com) along with a complete build log with verbosity enabled (i.e. `-v -v -v -v` in the **Additional mtouch arguments**).
+
+
 # MT3xxx: AOT error messages
 
 <!--

--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -269,7 +269,12 @@ namespace MonoMac.Tuner {
 				return;
 			}
 
-			base.ProcessAssembly (assembly);
+			try {
+				base.ProcessAssembly (assembly);
+			}
+			catch (Exception e) {
+				throw new MonoMacException (2103, true, e, $"Error processing assembly '{assembly.FullName}': {e}");
+			}
 		}
 	}
 

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -284,7 +284,12 @@ namespace MonoTouch.Tuner {
 				return;
 			}
 
-			base.ProcessAssembly (assembly);
+			try {
+				base.ProcessAssembly (assembly);
+			}
+			catch (Exception e) {
+				throw new MonoTouchException (2103, true, e, $"Error processing assembly '{assembly.FullName}': {e}");
+			}
 		}
 	}
 }


### PR DESCRIPTION
Bug #59570 was a dupe of #58063 but was harder (than it should be) to
diagnose because the error did not point out which assembly had the
issue (requiring a whole, large, customer solution to confirm).

This adds a new MT2103 error which points to the assembly that could
not be read.

E.g. VSfM will now show

> Error MT2103: Error processing assembly 'Shim, Version=2.0.1.0, Culture=neutral, PublicKeyToken=c55ec16d10c4b366': System.NullReferenceException: Object reference not set to an instance of an object (MT2103) (...)

[1] https://bugzilla.xamarin.com/show_bug.cgi?id=59570
[2] https://bugzilla.xamarin.com/show_bug.cgi?id=58063