### PR TITLE
[xharness] There's no need to wait for simulators/devices to load.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -93,7 +93,7 @@ namespace xharness
 				}
 			});
 
-			return Task.WhenAll (simulatorLoadTask, deviceLoadTask);
+			return Task.CompletedTask;
 		}
 
 		IEnumerable<RunSimulatorTask> CreateRunSimulatorTaskAsync (XBuildTask buildTask)


### PR DESCRIPTION
We construct every test case independent of whether a simulator or device is
available, which means we don't have to wait for simulators/devices to load
before creating test cases. Enumerating the available simulators/devices will
still block until loading is complete, but that only happens when we want to
run a test (after building it).

This makes the initial load much faster, since listing devices is becoming
slower now.