### PR TITLE
[xharness] Add support for manually reloading devices/simulators from the html UI.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -928,6 +928,12 @@ namespace xharness
 								}
 							}
 							break;
+						case "/reload-devices":
+							GC.KeepAlive (Devices.LoadAsync (DeviceLoadLog, force: true));
+							break;
+						case "/reload-simulators":
+							GC.KeepAlive (Simulators.LoadAsync (SimulatorLoadLog, force: true));
+							break;
 						case "/quit":
 							using (var writer = new StreamWriter (response.OutputStream)) {
 								writer.WriteLine ("<!DOCTYPE html>");
@@ -1192,7 +1198,7 @@ namespace xharness
 
 #nav {
 	display: inline-block;
-	width: 300px;
+	width: 350px;
 }
 
 #nav > * {
@@ -1508,6 +1514,12 @@ function oninitialload ()
 	<li>Toggle visibility
 		<ul>
 			<li class=""adminitem""><a href='javascript:toggleVisibility (""toggleable-ignored"");'>Ignored tests</a></li>
+		</ul>
+	</li>
+	<li>Reload
+		<ul>
+			<li class=""adminitem""><a href='javascript:sendrequest (""reload-devices"");'>Devices</a></li>
+			<li class=""adminitem""><a href='javascript:sendrequest (""reload-simulators"");'>Simulators</a></li>
 		</ul>
 	</li>
 </ul>");

--- a/tests/xharness/Simulators.cs
+++ b/tests/xharness/Simulators.cs
@@ -26,10 +26,16 @@ namespace xharness
 		public IEnumerable<SimDevice> AvailableDevices => available_devices;
 		public IEnumerable<SimDevicePair> AvailableDevicePairs => available_device_pairs;
 
-		public async Task LoadAsync (Log log)
+		public async Task LoadAsync (Log log, bool force = false)
 		{
-			if (loaded)
-				return;
+			if (loaded) {
+				if (!force)
+					return;
+				supported_runtimes.Reset ();
+				supported_device_types.Reset ();
+				available_devices.Reset ();
+				available_device_pairs.Reset ();
+			}
 			loaded = true;
 
 			await Task.Run (async () =>
@@ -497,10 +503,14 @@ namespace xharness
 			}
 		}
 
-		public async Task LoadAsync (Log log, bool extra_data = false, bool removed_locked = false)
+		public async Task LoadAsync (Log log, bool extra_data = false, bool removed_locked = false, bool force = false)
 		{
-			if (loaded)
-				return;
+			if (loaded) {
+				if (!force)
+					return;
+				connected_devices.Reset ();
+			}
+
 			loaded = true;
 
 			await Task.Run (async () =>
@@ -724,6 +734,12 @@ namespace xharness
 		void WaitForCompletion ()
 		{
 			completed.Task.Wait ();
+		}
+
+		public void Reset ()
+		{
+			completed = new TaskCompletionSource<bool> ();
+			list.Clear ();
 		}
 
 		public IEnumerator<T> GetEnumerator ()


### PR DESCRIPTION
This is useful when forgetting to plug in a device before launching the web ui.