### PR TITLE
[xharness] Fix javascript to work in Safari 11.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1378,8 +1378,9 @@ function autorefresh()
 				if (new_obj) {
 					if (ar_obj.innerHTML != new_obj.innerHTML)
 						ar_obj.innerHTML = new_obj.innerHTML;
-					if (ar_obj.style != new_obj.style)
+					if (ar_obj.style.cssText != new_obj.style.cssText) {
 						ar_obj.style = new_obj.style;
+					}
 					
 					var evt = ar_obj.getAttribute ('data-onautorefresh');
 					if (evt != '') {


### PR DESCRIPTION
There seems to be two bugs:

1. Comparing identical styles returns false (although this may just be how javascript works).

2. Given the following:

```javascript
    ar_obj.style.display = 'hide';
    new_obj.style.display = 'hide';
    ar_obj.style = new_obj.style;
    // now ar_obj.style.display == 'block'. HUH!?!
```

I can't fathom how this is expected, but Chrome shows the same behavior. Yay javascript.

Fix this by not trying to assign identical styles, by comparing the css text
instead of the style objects.