### PR TITLE
[tests] Fix linksdk WebKit_NSProxy test. Fixes #59671 (#2746)

### DIFF
--- a/tests/linker-ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker-ios/link sdk/LinkSdkRegressionTest.cs
@@ -1057,6 +1057,7 @@ namespace LinkSdk {
 		{
 			// a reference to WKWebView will bring the internal NSProxy type
 			var t = typeof (WKWebView);
+			Assert.NotNull (t, "avoid compiler optimization of unused variable"); 
 			var fqn = typeof (NSObject).AssemblyQualifiedName.Replace ("Foundation.NSObject", "Foundation.NSProxy");
 			Assert.NotNull (Type.GetType (fqn), fqn);
 		}


### PR DESCRIPTION
In release (optimize) mode the compiler would eliminate the unused

> var t = typeof (WKWebView);

which means the linker would never see `WKWebView`, which in turns
removed `NSProxy`.

Original bug: https://bugzilla.xamarin.com/show_bug.cgi?id=59247
Original PR: https://github.com/xamarin/xamarin-macios/pull/2732

https://bugzilla.xamarin.com/show_bug.cgi?id=59671