### PR TITLE
Disable link-keep-resources-2 test

### DIFF
--- a/tests/mmptest/regression/Makefile
+++ b/tests/mmptest/regression/Makefile
@@ -17,7 +17,6 @@ TESTS_4_0 = \
 	link-posix-2 \
 	link-system.web-icalls \
 	link-keep-resources-1 \
-	link-keep-resources-2 \
 	link-preserve-assembly \
 	link-uithread-1 \
 	link-uithread-2 \


### PR DESCRIPTION
- A change in mono added a small xml file to the resources, causing the test to fail
- Fix exists in mono/linker but 20 commits behind head, too risky to bump just for a test fix
- Will be fixed in mono's 2017-08 branch
- https://bugzilla.xamarin.com/show_bug.cgi?id=59277