### PR TITLE
Fix CFMessagePort crash when returning data from callback

### DIFF
--- a/src/CoreFoundation/CFMessagePort.cs
+++ b/src/CoreFoundation/CFMessagePort.cs
@@ -360,6 +360,8 @@ namespace XamCore.CoreFoundation {
 			
 			using (var managedData = Runtime.GetNSObject<NSData> (data)) {
 				var result = callback.Invoke (msgid, managedData);
+				// System will release returned CFData
+				result?.DangerousRetain ();
 				return result == null ? IntPtr.Zero : result.Handle;
 			}
 		}


### PR DESCRIPTION
- The system releases returned CFData, which caused over release crashes
- https://bugzilla.xamarin.com/show_bug.cgi?id=51263
- Was checked w\ instruments after fix for leaks (none found).