### PR TITLE
[AVFoundation] Adds missing Xcode9 API, fixes AVCaptureSynchronizedDataCollection, improves existing API, and fixes bug 59571

### DIFF
--- a/src/AVFoundation/AVCaptureSynchronizedDataCollection.cs
+++ b/src/AVFoundation/AVCaptureSynchronizedDataCollection.cs
@@ -1,0 +1,35 @@
+//
+// AVCaptureSynchronizedDataCollection.cs
+//
+// Authors:
+//	Alex Soto  <alexsoto@microsoft.com>
+//
+// Copyright 2017 Xamarin Inc. All rights reserved.
+//
+
+#if IOS || MONOMAC
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using XamCore.Foundation;
+
+namespace XamCore.AVFoundation {
+	public partial class AVCaptureSynchronizedDataCollection : IEnumerable<AVCaptureOutput> {
+		public AVCaptureSynchronizedData this [AVCaptureOutput captureOutput] {
+			get {
+				return GetSynchronizedData (captureOutput);
+			}
+		}
+
+		public IEnumerator<AVCaptureOutput> GetEnumerator ()
+		{
+			return new NSFastEnumerator<AVCaptureOutput> (this);
+		}
+
+		IEnumerator IEnumerable.GetEnumerator ()
+		{
+			return GetEnumerator ();;
+		}
+	}
+}
+#endif // IOS || MONOMAC

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -3074,6 +3074,9 @@ namespace XamCore.AVFoundation {
 
 #endif // MONOMAC
 
+#if XAMCORE_4_0
+	[Abstract] // Abstract superclass.
+#endif
 	[NoWatch, NoTV, iOS (11,0)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
@@ -3086,15 +3089,27 @@ namespace XamCore.AVFoundation {
 	[NoWatch, NoTV, iOS (11,0)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
-	interface AVCaptureSynchronizedDataCollection : INSFastEnumeration
+	interface AVCaptureSynchronizedDataCollection // NSFastEnumeration
 	{
-		[Export ("synchronizedDataForCaptureOutput:")]
-		[return: NullAllowed]
+#if !XAMCORE_4_0
+		[Obsolete ("Use 'GetSynchronizedData' Instead.")]
+		[Wrap ("GetSynchronizedData (captureOutput)", isVirtual: true)]
 		AVCaptureSynchronizedData From (AVCaptureOutput captureOutput);
 
+		// This is not reexposed because it is not needed you can use 'GetSynchronizedData' instead, also from docs:
+		// https://developer.apple.com/documentation/avfoundation/avcapturesynchronizeddatacollection/2873892-objectforkeyedsubscript?language=objc
+		// > This call is equivalent to the synchronizedDataForCaptureOutput: method, but allows subscript syntax.
+		[Obsolete ("Use 'GetSynchronizedData' Instead.")]
 		[Export ("objectForKeyedSubscript:")]
 		[return: NullAllowed]
 		AVCaptureSynchronizedData ObjectForKeyedSubscript (AVCaptureOutput key);
+#endif
+		// This method returns AVCaptureSynchronizedData but usually you will want to downcast
+		// to one of its children classes, downcasting is cumbersome so providing a generic method instead.
+		//[Protected]
+		[Export ("synchronizedDataForCaptureOutput:")]
+		[return: NullAllowed]
+		AVCaptureSynchronizedData GetSynchronizedData (AVCaptureOutput captureOutput);
 
 		[Export ("count")]
 		nuint Count { get; }
@@ -8263,7 +8278,7 @@ namespace XamCore.AVFoundation {
 
 	interface IAVCaptureDepthDataOutputDelegate {}
 	
-	[NoWatch, NoTV, iOS (11,0)]
+	[NoWatch, NoTV, iOS (11,0), Mac (10,13)]
 	[Protocol, Model]
 	[BaseType (typeof(NSObject))]
 	interface AVCaptureDepthDataOutputDelegate
@@ -8275,9 +8290,8 @@ namespace XamCore.AVFoundation {
 		void DidDropDepthData (AVCaptureDepthDataOutput output, AVDepthData depthData, CMTime timestamp, AVCaptureConnection connection, AVCaptureOutputDataDroppedReason reason);
 	}
 
-	[NoWatch, NoTV, iOS (11,0)]
+	[NoWatch, NoTV, iOS (11,0), Mac (10,13)]
 	[BaseType (typeof(AVCaptureOutput))]
-	[DisableDefaultCtor]
 	interface AVCaptureDepthDataOutput
 	{
 		[Export ("setDelegate:callbackQueue:")]
@@ -9086,6 +9100,15 @@ namespace XamCore.AVFoundation {
 		[Export ("dualCameraFusionSupported")]
 		bool DualCameraFusionSupported { [Bind ("isDualCameraFusionSupported")] get; }
 
+		// From AVCapturePhotoOutput (AVCapturePhotoOutputDepthDataDeliverySupport) Category
+
+		[iOS (11,0)]
+		[Export ("depthDataDeliverySupported")]
+		bool DepthDataDeliverySupported { [Bind ("isDepthDataDeliverySupported")] get; }
+
+		[iOS (11,0)]
+		[Export ("depthDataDeliveryEnabled")]
+		bool DepthDataDeliveryEnabled { [Bind ("isDepthDataDeliveryEnabled")] get; set; }
 	}
 #endif
 	
@@ -9229,6 +9252,12 @@ namespace XamCore.AVFoundation {
 		[iOS (10, 2)]
 		[Field ("AVCaptureDeviceTypeBuiltInDualCamera")]
 		BuiltInDualCamera,
+	}
+
+	[NoTV, iOS (7,0), NoMac, NoWatch] // matches API that uses it.
+	enum AVAuthorizationMediaType {
+		Video,
+		Audio,
 	}
 
 	[NoWatch]
@@ -9444,10 +9473,23 @@ namespace XamCore.AVFoundation {
 		[Static, Export ("authorizationStatusForMediaType:")]
 		AVAuthorizationStatus GetAuthorizationStatus (NSString avMediaTypeToken);
 
+		// Calling this method with any media type other than AVMediaTypeVideo or AVMediaTypeAudio raises an exception.
+		[iOS (7,0)]
+		[Static]
+		[Wrap ("GetAuthorizationStatus (mediaType == AVAuthorizationMediaType.Video ? AVMediaTypes.Video.GetConstant () : AVMediaTypes.Audio.GetConstant ())")]
+		AVAuthorizationStatus GetAuthorizationStatus (AVAuthorizationMediaType mediaType);
+
 		[Since (7,0)]
 		[Static, Export ("requestAccessForMediaType:completionHandler:")]
 		[Async]
 		void RequestAccessForMediaType (NSString avMediaTypeToken, AVRequestAccessStatus completion);
+
+		// Either AVMediaTypeVideo or AVMediaTypeAudio.
+		[iOS (7,0)]
+		[Static]
+		[Wrap ("RequestAccessForMediaType (mediaType == AVAuthorizationMediaType.Video ? AVMediaTypes.Video.GetConstant () : AVMediaTypes.Audio.GetConstant (), completion)")]
+		[Async]
+		void RequestAccessForMediaType (AVAuthorizationMediaType mediaType, AVRequestAccessStatus completion);
 #endif
 
 		[Since (7,0)][Mac (10,7)]
@@ -9672,6 +9714,19 @@ namespace XamCore.AVFoundation {
 		[Export ("activeColorSpace", ArgumentSemantic.Assign)]
 		AVCaptureColorSpace ActiveColorSpace { get; set; }
 
+		// From AVCaptureDevice (AVCaptureDeviceDepthSupport) Category
+
+		[iOS (11,0)]
+		[Export ("activeDepthDataFormat", ArgumentSemantic.Retain), NullAllowed]
+		AVCaptureDeviceFormat ActiveDepthDataFormat { get; set; }
+
+		[iOS (11,0)]
+		[Export ("minAvailableVideoZoomFactor")]
+		nfloat MinAvailableVideoZoomFactor { get; }
+
+		[iOS (11,0)]
+		[Export ("maxAvailableVideoZoomFactor")]
+		nfloat MaxAvailableVideoZoomFactor { get; }
 #endif
 	}
 

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -245,6 +245,7 @@ AVFOUNDATION_SOURCES = \
 	AVFoundation/AVCaptureDeviceInput.cs \
 	AVFoundation/AVCaptureFileOutput.cs \
 	AVFoundation/AVCaptureMetadataOutput.cs \
+	AVFoundation/AVCaptureSynchronizedDataCollection.cs \
 	AVFoundation/AVCaptureVideoDataOutput.cs \
 	AVFoundation/AVCaptureVideoPreviewLayer.cs \
 	AVFoundation/AVCompat.cs \


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=59571

Changes in AVFoundation
=======================

AVCaptureSynchronizedDataCollection:

* Adds `NSFastEnumerator` and `IEnumerable<AVCaptureOutput>` support.
* Obsoletes `From` method because the name does not makes sense in the current context.
* Obsoletes `ObjectForKeyedSubscript` in favor of a C# indexer.
* Adds `GetSynchronizedData` to replace obsoleted `From` method`.

AVCaptureSynchronizedData:

* Adds `[Abstract]` in XAMCORE_4_0 because it is an abstract superclass.

AVCapturePhotoOutput:

* Adds missing members `DepthDataDeliverySupported` and `DepthDataDeliveryEnabled`
  from `AVCapturePhotoOutputDepthDataDeliverySupport` category.

AVCaptureDevice:

* Adds strong typed API to `GetAuthorizationStatus` and `RequestAccessForMediaType`
  using `AVAuthorizationMediaType` enum holding the only possible values.
* Adds missing members `ActiveDepthDataFormat`, `MinAvailableVideoZoomFactor` and
  `MaxAvailableVideoZoomFactor` from `AVCaptureDeviceDepthSupport` category.

Changes in Foundation
=====================

NSFastEnumerator:

When implementing `NSFastEnumerator` suppor in `AVCaptureSynchronizedDataCollection`
I ran into a NRE whenever we tried to set the `mutationValue` from the returned state
struct, this is because `Marshal.ReadIntPtr` failed to read `state.mutationsPtr` due to
how `AVCaptureSynchronizedDataCollection` implements `NSFastEnumerator` protocol.

The `AVCaptureSynchronizedDataCollection` implementation stores the value of the number
of items it is holding instead of a pointer to it, this was the reason why `ReadIntPtr` throws.

Now, whenever `Marshal.ReadIntPtr` throws we directly use the value of `state.mutationsPtr` as a fallback.

Test
====

A test exercising the new API lives here:

https://github.com/dalexsoto/XamarinTests/blob/4715069b2bd777009c94c32fd9eed56b81103264/AVCaptureDataOutputSynchronizerTest/AVCaptureDataOutputSynchronizerTest/ViewController.cs#L174-L189

Unfortunately, the API needs an iPhone 7+, 8+ or X in order to run.