### PR TITLE
[xharness] Add support for generating only specific variations for iOS projects. Fixes #57529 (#2751)

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -90,7 +90,7 @@ namespace xharness
 			}
 		}
 
-		public List<TestProject> IOSTestProjects { get; set; } = new List<TestProject> ();
+		public List<iOSTestProject> IOSTestProjects { get; set; } = new List<iOSTestProject> ();
 		public List<MacTestProject> MacTestProjects { get; set; } = new List<MacTestProject> ();
 
 		public List<BCLTest> IOSBclTests { get; set; } = new List<BCLTest> ();
@@ -308,26 +308,31 @@ namespace xharness
 			var fsharp_test_suites = new string [] { "fsharp" };
 			var fsharp_library_projects = new string [] { "fsharplibrary" };
 			var bcl_suites = new string [] { "mscorlib", "System", "System.Core", "System.Data", "System.Net.Http", "System.Numerics", "System.Runtime.Serialization", "System.Transactions", "System.Web.Services", "System.Xml", "System.Xml.Linq", "Mono.Security", "System.ComponentModel.DataAnnotations", "System.Json", "System.ServiceModel.Web", "Mono.Data.Sqlite" };
-			IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bcl-test/mscorlib/mscorlib-0.csproj")), false));
-			IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bcl-test/mscorlib/mscorlib-1.csproj")), false));
+			var bcl_skip_watchos = new string [] {
+				"Mono.Security",
+			};
+			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bcl-test/mscorlib/mscorlib-0.csproj")), false));
+			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bcl-test/mscorlib/mscorlib-1.csproj")), false));
 			foreach (var p in test_suites)
-				IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".csproj"))));
+				IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".csproj"))));
 			foreach (var p in fsharp_test_suites)
-				IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".fsproj"))));
+				IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".fsproj"))));
 			foreach (var p in library_projects)
-				IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".csproj")), false));
+				IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".csproj")), false));
 			foreach (var p in fsharp_library_projects)
-				IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".fsproj")), false));
+				IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".fsproj")), false));
 
 			foreach (var p in bcl_suites) {
-				IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bcl-test/" + p + "/" + p + ".csproj"))));
+				IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bcl-test/" + p + "/" + p + ".csproj"))) {
+					SkipwatchOSVariation = bcl_skip_watchos.Contains (p),
+				});
 				IOSBclTests.Add (new BCLTest (p));
 			}
 			
-			IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, "introspection", "iOS", "introspection-ios.csproj"))) { Name = "introspection" });
-			IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, "linker-ios", "dont link", "dont link.csproj"))));
-			IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, "linker-ios", "link all", "link all.csproj"))));
-			IOSTestProjects.Add (new TestProject (Path.GetFullPath (Path.Combine (RootDirectory, "linker-ios", "link sdk", "link sdk.csproj"))));
+			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "introspection", "iOS", "introspection-ios.csproj"))) { Name = "introspection" });
+			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "linker-ios", "dont link", "dont link.csproj"))));
+			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "linker-ios", "link all", "link all.csproj"))));
+			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "linker-ios", "link sdk", "link sdk.csproj"))));
 
 			WatchOSContainerTemplate = Path.GetFullPath (Path.Combine (RootDirectory, "templates/WatchContainer"));
 			WatchOSAppTemplate = Path.GetFullPath (Path.Combine (RootDirectory, "templates/WatchApp"));
@@ -472,34 +477,43 @@ namespace xharness
 				if (!File.Exists (file))
 					throw new FileNotFoundException (file);
 
-				var watchos = new WatchOSTarget () {
-					TemplateProjectPath = file,
-					Harness = this,
-				};
-				watchos.Execute ();
-				watchos_targets.Add (watchos);
+				if (!proj.SkipwatchOSVariation) {
+					var watchos = new WatchOSTarget () {
+						TemplateProjectPath = file,
+						Harness = this,
+						TestProject = proj,
+					};
+					watchos.Execute ();
+					watchos_targets.Add (watchos);
+				}
 
-				var tvos = new TVOSTarget () {
-					TemplateProjectPath = file,
-					Harness = this,
-				};
-				tvos.Execute ();
-				tvos_targets.Add (tvos);
+				if (!proj.SkiptvOSVariation) {
+					var tvos = new TVOSTarget () {
+						TemplateProjectPath = file,
+						Harness = this,
+						TestProject = proj,
+					};
+					tvos.Execute ();
+					tvos_targets.Add (tvos);
+				}
 
-				var unified = new UnifiedTarget () {
-					TemplateProjectPath = file,
-					Harness = this,
-				};
-				unified.Execute ();
-				unified_targets.Add (unified);
+				if (!proj.SkipiOSVariation) {
+					var unified = new UnifiedTarget () {
+						TemplateProjectPath = file,
+						Harness = this,
+						TestProject = proj,
+					};
+					unified.Execute ();
+					unified_targets.Add (unified);
 
-				var today = new TodayExtensionTarget
-				{
-					TemplateProjectPath = file,
-					Harness = this,
-				};
-				today.Execute ();
-				today_targets.Add (today);
+					var today = new TodayExtensionTarget {
+						TemplateProjectPath = file,
+						Harness = this,
+						TestProject = proj,
+					};
+					today.Execute ();
+					today_targets.Add (today);
+				}
 			}
 
 			SolutionGenerator.CreateSolution (this, watchos_targets, "watchos");

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -148,64 +148,65 @@ namespace xharness
 				bool ignored = !IncludeDevice;
 				if (!IsIncluded (project))
 					ignored = true;
-				
-				var build64 = new XBuildTask
-				{
-					Jenkins = this,
-					TestProject = project,
-					ProjectConfiguration = "Debug64",
-					ProjectPlatform = "iPhone",
-					Platform = TestPlatform.iOS_Unified64,
-					TestName = project.Name,
-				};
-				rv.Add (new RunDeviceTask (build64, Devices.ConnectedDevices.Where ((dev) => dev.DevicePlatform == DevicePlatform.iOS && dev.Supports64Bit)) { Ignored = ignored || !IncludeiOS });
 
-				var build32 = new XBuildTask
-				{
-					Jenkins = this,
-					TestProject = project,
-					ProjectConfiguration = "Debug32",
-					ProjectPlatform = "iPhone",
-					Platform = TestPlatform.iOS_Unified32,
-					TestName = project.Name,
-				};
-				rv.Add (new RunDeviceTask (build32, Devices.ConnectedDevices.Where ((dev) => dev.DevicePlatform == DevicePlatform.iOS)) { Ignored = ignored || !IncludeiOS });
+				if (!project.SkipiOSVariation) {
+					var build64 = new XBuildTask {
+						Jenkins = this,
+						TestProject = project,
+						ProjectConfiguration = "Debug64",
+						ProjectPlatform = "iPhone",
+						Platform = TestPlatform.iOS_Unified64,
+						TestName = project.Name,
+					};
+					rv.Add (new RunDeviceTask (build64, Devices.ConnectedDevices.Where ((dev) => dev.DevicePlatform == DevicePlatform.iOS && dev.Supports64Bit)) { Ignored = ignored || !IncludeiOS });
 
-				var todayProject = project.AsTodayExtensionProject ();
-				var buildToday = new XBuildTask
-				{
-					Jenkins = this,
-					TestProject = todayProject,
-					ProjectConfiguration = "Debug64",
-					ProjectPlatform = "iPhone",
-					Platform = TestPlatform.iOS_TodayExtension64,
-					TestName = project.Name,
-				};
-				rv.Add (new RunDeviceTask (buildToday, Devices.ConnectedDevices.Where ((dev) => dev.DevicePlatform == DevicePlatform.iOS && dev.Supports64Bit)) { Ignored = ignored || !IncludeiOSExtensions });
+					var build32 = new XBuildTask {
+						Jenkins = this,
+						TestProject = project,
+						ProjectConfiguration = "Debug32",
+						ProjectPlatform = "iPhone",
+						Platform = TestPlatform.iOS_Unified32,
+						TestName = project.Name,
+					};
+					rv.Add (new RunDeviceTask (build32, Devices.ConnectedDevices.Where ((dev) => dev.DevicePlatform == DevicePlatform.iOS)) { Ignored = ignored || !IncludeiOS });
 
-				var tvOSProject = project.AsTvOSProject ();
-				var buildTV = new XBuildTask
-				{
-					Jenkins = this,
-					TestProject = tvOSProject,
-					ProjectConfiguration = "Debug",
-					ProjectPlatform = "iPhone",
-					Platform = TestPlatform.tvOS,
-					TestName = project.Name,
-				};
-				rv.Add (new RunDeviceTask (buildTV, Devices.ConnectedDevices.Where ((dev) => dev.DevicePlatform == DevicePlatform.tvOS)) { Ignored = ignored || !IncludetvOS });
+					var todayProject = project.AsTodayExtensionProject ();
+					var buildToday = new XBuildTask {
+						Jenkins = this,
+						TestProject = todayProject,
+						ProjectConfiguration = "Debug64",
+						ProjectPlatform = "iPhone",
+						Platform = TestPlatform.iOS_TodayExtension64,
+						TestName = project.Name,
+					};
+					rv.Add (new RunDeviceTask (buildToday, Devices.ConnectedDevices.Where ((dev) => dev.DevicePlatform == DevicePlatform.iOS && dev.Supports64Bit)) { Ignored = ignored || !IncludeiOSExtensions });
+				}
 
-				var watchOSProject = project.AsWatchOSProject ();
-				var buildWatch = new XBuildTask
-				{
-					Jenkins = this,
-					TestProject = watchOSProject,
-					ProjectConfiguration = "Debug",
-					ProjectPlatform = "iPhone",
-					Platform = TestPlatform.watchOS,
-					TestName = project.Name,
-				};
-				rv.Add (new RunDeviceTask (buildWatch, Devices.ConnectedDevices.Where ((dev) => dev.DevicePlatform == DevicePlatform.watchOS)){ Ignored = ignored || !IncludewatchOS });
+				if (!project.SkiptvOSVariation) {
+					var tvOSProject = project.AsTvOSProject ();
+					var buildTV = new XBuildTask {
+						Jenkins = this,
+						TestProject = tvOSProject,
+						ProjectConfiguration = "Debug",
+						ProjectPlatform = "iPhone",
+						Platform = TestPlatform.tvOS,
+						TestName = project.Name,
+					};
+					rv.Add (new RunDeviceTask (buildTV, Devices.ConnectedDevices.Where ((dev) => dev.DevicePlatform == DevicePlatform.tvOS)) { Ignored = ignored || !IncludetvOS });
+				}
+
+				if (!project.SkipwatchOSVariation) {
+					var watchOSProject = project.AsWatchOSProject ();
+					var buildWatch = new XBuildTask {
+						Jenkins = this,
+						TestProject = watchOSProject,
+						ProjectConfiguration = "Debug",
+						ProjectPlatform = "iPhone",
+						Platform = TestPlatform.watchOS,
+						TestName = project.Name,
+					};
+					rv.Add (new RunDeviceTask (buildWatch, Devices.ConnectedDevices.Where ((dev) => dev.DevicePlatform == DevicePlatform.watchOS)) { Ignored = ignored || !IncludewatchOS });
+				}
 			}
 
 			var assembly_build_targets = new []
@@ -449,9 +450,12 @@ namespace xharness
 					ignored = true;
 
 				var ps = new List<Tuple<TestProject, TestPlatform, bool>> ();
-				ps.Add (new Tuple<TestProject, TestPlatform, bool> (project, TestPlatform.iOS_Unified, ignored || !IncludeiOS));
-				ps.Add (new Tuple<TestProject, TestPlatform, bool> (project.AsTvOSProject (), TestPlatform.tvOS, ignored || !IncludetvOS));
-				ps.Add (new Tuple<TestProject, TestPlatform, bool> (project.AsWatchOSProject (), TestPlatform.watchOS, ignored || !IncludewatchOS));
+				if (!project.SkipiOSVariation)
+					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project, TestPlatform.iOS_Unified, ignored || !IncludeiOS));
+				if (!project.SkiptvOSVariation)
+					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project.AsTvOSProject (), TestPlatform.tvOS, ignored || !IncludetvOS));
+				if (!project.SkipwatchOSVariation)
+					ps.Add (new Tuple<TestProject, TestPlatform, bool> (project.AsWatchOSProject (), TestPlatform.watchOS, ignored || !IncludewatchOS));
 				foreach (var pair in ps) {
 					var derived = new XBuildTask () {
 						Jenkins = this,

--- a/tests/xharness/MakefileGenerator.cs
+++ b/tests/xharness/MakefileGenerator.cs
@@ -275,7 +275,7 @@ namespace xharness
 				writer.WriteLine ("\t$(Q) touch $@");
 				writer.WriteLine ();
 
-				var allTargets = new List<Target> ();
+				var allTargets = new List<iOSTarget> ();
 				allTargets.AddRange (unified_targets);
 				allTargets.AddRange (tvos_targets);
 				allTargets.AddRange (watchos_targets);
@@ -608,9 +608,9 @@ namespace xharness
 				writer.WriteLine ("\t$(Q) if test -e \".$@-failure.stamp\"; then cat \".$@-failure.stamp\"; rm \".$@-failure.stamp\"; exit 1; fi");
 
 				foreach (var mode in new string [] { "sim", "dev" }) {
-					WriteCollectionTarget (writer, "run-ios-" + mode, unified_targets.Where ((v) => v.IsExe), mode);
-					WriteCollectionTarget (writer, "run-tvos-" + mode, tvos_targets.Where ((v) => v.IsExe), mode);
-					WriteCollectionTarget (writer, "run-watchos-" + mode, watchos_targets.Where ((v) => v.IsExe), mode);
+					WriteCollectionTarget (writer, "run-ios-" + mode, unified_targets.Where ((v) => v.IsExe && v.TestProject?.SkipiOSVariation != true), mode);
+					WriteCollectionTarget (writer, "run-tvos-" + mode, tvos_targets.Where ((v) => v.IsExe && v.TestProject?.SkiptvOSVariation != true), mode);
+					WriteCollectionTarget (writer, "run-watchos-" + mode, watchos_targets.Where ((v) => v.IsExe && v.TestProject?.SkipwatchOSVariation != true), mode);
 				}
 
 				writer.WriteLine ();
@@ -631,11 +631,24 @@ namespace xharness
 						continue;
 					var make_escaped_name = target.GetMakeName ();
 
-					writer.WriteTarget ("build-sim-{0}", "build-ios-sim-{0} build-tvos-sim-{0} build-watchos-sim-{0}", make_escaped_name);
+					var proj = target.TestProject;
+					var includeiOS = harness.INCLUDE_IOS && proj?.SkipiOSVariation != true;
+					var includetvOS = harness.INCLUDE_TVOS && proj?.SkiptvOSVariation != true;
+					var includewatchOS = harness.INCLUDE_WATCH && proj?.SkipwatchOSVariation != true;
+
+					var dependencies = new List<string> ();
+					if (includeiOS)
+						dependencies.Add ("ios");
+					if (includetvOS)
+						dependencies.Add ("tvos");
+					if (includewatchOS)
+						dependencies.Add ("watchos");
+					
+					writer.WriteTarget ("build-sim-{0}", string.Join (" ", dependencies.Select ((v) => $"build-{v}-sim-{{0}}")), make_escaped_name);
 					writer.WriteLine ("\t$(Q) echo Simulator builds succeeded"); // This is important, otherwise we'll end up executing the catch-all build-% target
 					writer.WriteLine ();
 
-					writer.WriteTarget ("build-dev-{0}", "build-ios-dev-{0} build-tvos-dev-{0} build-watchos-dev-{0}", make_escaped_name);
+					writer.WriteTarget ("build-dev-{0}", string.Join (" ", dependencies.Select ((v) => $"build-{v}-dev-{{0}}")), make_escaped_name);
 					writer.WriteLine ("\t$(Q) echo Device builds succeeded"); // This is important, otherwise we'll end up executing the catch-all build-% target
 					writer.WriteLine ();
 
@@ -644,56 +657,80 @@ namespace xharness
 					writer.WriteLine ();
 
 					writer.WriteTarget ("run-sim-{0}", "build-sim-{0}", make_escaped_name);
-					writer.WriteLine ("\t$(Q) $(MAKE) \"exec-ios-sim32-{0}\"      || echo \"exec-ios-sim32-{0} failed\"      >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"exec-ios-sim64-{0}\"      || echo \"exec-ios-sim64-{0} failed\"      >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"exec-tvos-sim-{0}\"       || echo \"exec-tvos-sim-{0} failed\"       >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"exec-watchos-sim-{0}\"    || echo \"exec-watchos-sim-{0} failed\"    >> \".$@-failure.stamp\"", target.GetMakeName (false));
+					if (includeiOS) {
+						writer.WriteLine ("\t$(Q) $(MAKE) \"exec-ios-sim32-{0}\"      || echo \"exec-ios-sim32-{0} failed\"      >> \".$@-failure.stamp\"", target.GetMakeName (false));
+						writer.WriteLine ("\t$(Q) $(MAKE) \"exec-ios-sim64-{0}\"      || echo \"exec-ios-sim64-{0} failed\"      >> \".$@-failure.stamp\"", target.GetMakeName (false));
+					}
+					if (includetvOS)
+						writer.WriteLine ("\t$(Q) $(MAKE) \"exec-tvos-sim-{0}\"       || echo \"exec-tvos-sim-{0} failed\"       >> \".$@-failure.stamp\"", target.GetMakeName (false));
+					if (includewatchOS)
+						writer.WriteLine ("\t$(Q) $(MAKE) \"exec-watchos-sim-{0}\"    || echo \"exec-watchos-sim-{0} failed\"    >> \".$@-failure.stamp\"", target.GetMakeName (false));
 					writer.WriteLine ("\t$(Q) if test -e \".$@-failure.stamp\"; then cat \".$@-failure.stamp\"; rm \".$@-failure.stamp\"; exit 1; fi");
 					writer.WriteLine ();
 
 					writer.WriteTarget ("run-dev-{0}", "build-dev-{0}", make_escaped_name);
-					writer.WriteLine ("\t$(Q) $(MAKE) \"install-ios-dev-{0}\"        || echo \"install-ios-dev-{0} failed\"        >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"exec-ios-dev-{0}\"           || echo \"exec-ios-dev-{0} failed\"           >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"install-tvos-dev-{0}\"       || echo \"install-tvos-dev-{0} failed\"       >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"exec-tvos-dev-{0}\"          || echo \"exec-tvos-dev-{0} failed\"          >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"install-watchos-dev-{0}\"    || echo \"install-watchos-dev-{0} failed\"    >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"exec-watchos-dev-{0}\"       || echo \"exec-watchos-dev-{0} failed\"       >> \".$@-failure.stamp\"", target.GetMakeName (false));
+					if (includeiOS) {
+						writer.WriteLine ("\t$(Q) $(MAKE) \"install-ios-dev-{0}\"        || echo \"install-ios-dev-{0} failed\"        >> \".$@-failure.stamp\"", target.GetMakeName (false));
+						writer.WriteLine ("\t$(Q) $(MAKE) \"exec-ios-dev-{0}\"           || echo \"exec-ios-dev-{0} failed\"           >> \".$@-failure.stamp\"", target.GetMakeName (false));
+					}
+					if (includetvOS) {
+						writer.WriteLine ("\t$(Q) $(MAKE) \"install-tvos-dev-{0}\"       || echo \"install-tvos-dev-{0} failed\"       >> \".$@-failure.stamp\"", target.GetMakeName (false));
+						writer.WriteLine ("\t$(Q) $(MAKE) \"exec-tvos-dev-{0}\"          || echo \"exec-tvos-dev-{0} failed\"          >> \".$@-failure.stamp\"", target.GetMakeName (false));
+					}
+					if (includewatchOS) {
+						writer.WriteLine ("\t$(Q) $(MAKE) \"install-watchos-dev-{0}\"    || echo \"install-watchos-dev-{0} failed\"    >> \".$@-failure.stamp\"", target.GetMakeName (false));
+						writer.WriteLine ("\t$(Q) $(MAKE) \"exec-watchos-dev-{0}\"       || echo \"exec-watchos-dev-{0} failed\"       >> \".$@-failure.stamp\"", target.GetMakeName (false));
+					}
 					writer.WriteLine ("\t$(Q) if test -e \".$@-failure.stamp\"; then cat \".$@-failure.stamp\"; rm \".$@-failure.stamp\"; exit 1; fi");
 					writer.WriteLine ();
 
 					writer.WriteTarget ("run-{0}", "build-{0}", make_escaped_name);
 					// sim
-					writer.WriteLine ("\t$(Q) $(MAKE) \"exec-ios-sim32-{0}\"      || echo \"exec-ios-sim32-{0} failed\"      >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"exec-ios-sim64-{0}\"      || echo \"exec-ios-sim64-{0} failed\"      >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"exec-tvos-sim-{0}\"       || echo \"exec-tvos-sim-{0} failed\"       >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"exec-watchos-sim-{0}\"    || echo \"exec-watchos-sim-{0} failed\"    >> \".$@-failure.stamp\"", target.GetMakeName (false));
+					if (includeiOS) {
+						writer.WriteLine ("\t$(Q) $(MAKE) \"exec-ios-sim32-{0}\"      || echo \"exec-ios-sim32-{0} failed\"      >> \".$@-failure.stamp\"", target.GetMakeName (false));
+						writer.WriteLine ("\t$(Q) $(MAKE) \"exec-ios-sim64-{0}\"      || echo \"exec-ios-sim64-{0} failed\"      >> \".$@-failure.stamp\"", target.GetMakeName (false));
+					}
+					if (includetvOS)
+						writer.WriteLine ("\t$(Q) $(MAKE) \"exec-tvos-sim-{0}\"       || echo \"exec-tvos-sim-{0} failed\"       >> \".$@-failure.stamp\"", target.GetMakeName (false));
+					if (includewatchOS)
+						writer.WriteLine ("\t$(Q) $(MAKE) \"exec-watchos-sim-{0}\"    || echo \"exec-watchos-sim-{0} failed\"    >> \".$@-failure.stamp\"", target.GetMakeName (false));
 					// dev
-					writer.WriteLine ("\t$(Q) $(MAKE) \"install-ios-dev-{0}\"        || echo \"install-ios-dev-{0} failed\"        >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"exec-ios-dev-{0}\"           || echo \"exec-ios-dev-{0} failed\"           >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"install-tvos-dev-{0}\"       || echo \"install-tvos-dev-{0} failed\"       >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"exec-tvos-dev-{0}\"          || echo \"exec-tvos-dev-{0} failed\"          >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"install-watchos-dev-{0}\"    || echo \"install-watchos-dev-{0} failed\"    >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"exec-watchos-dev-{0}\"       || echo \"exec-watchos-dev-{0} failed\"       >> \".$@-failure.stamp\"", target.GetMakeName (false));
+					if (includeiOS) {
+						writer.WriteLine ("\t$(Q) $(MAKE) \"install-ios-dev-{0}\"        || echo \"install-ios-dev-{0} failed\"        >> \".$@-failure.stamp\"", target.GetMakeName (false));
+						writer.WriteLine ("\t$(Q) $(MAKE) \"exec-ios-dev-{0}\"           || echo \"exec-ios-dev-{0} failed\"           >> \".$@-failure.stamp\"", target.GetMakeName (false));
+					}
+					if (includetvOS) {
+						writer.WriteLine ("\t$(Q) $(MAKE) \"install-tvos-dev-{0}\"       || echo \"install-tvos-dev-{0} failed\"       >> \".$@-failure.stamp\"", target.GetMakeName (false));
+						writer.WriteLine ("\t$(Q) $(MAKE) \"exec-tvos-dev-{0}\"          || echo \"exec-tvos-dev-{0} failed\"          >> \".$@-failure.stamp\"", target.GetMakeName (false));
+					}
+					if (includewatchOS) {
+						writer.WriteLine ("\t$(Q) $(MAKE) \"install-watchos-dev-{0}\"    || echo \"install-watchos-dev-{0} failed\"    >> \".$@-failure.stamp\"", target.GetMakeName (false));
+						writer.WriteLine ("\t$(Q) $(MAKE) \"exec-watchos-dev-{0}\"       || echo \"exec-watchos-dev-{0} failed\"       >> \".$@-failure.stamp\"", target.GetMakeName (false));
+					}
 					writer.WriteLine ("\t$(Q) if test -e \".$@-failure.stamp\"; then cat \".$@-failure.stamp\"; rm \".$@-failure.stamp\"; exit 1; fi");
 					writer.WriteLine ();
 
 					// Wrench needs a slightly different approach, because we want to run some tests, even if other tests failed to build
 					// (the default is to build all, then run all if everything built). The problem is that there's no way (that I've found)
 					// to make the build parallelizable and support the wrench mode at the same time.
-
 					writer.WriteLine ("wrenchhelper-{0}:", make_escaped_name);
 					writer.WriteLine ("\t$(Q) rm -f \".$@-failure.stamp\" \".$@-ios-sim-build-failure.stamp\" \".$@-tvos-sim-build-failure.stamp\" \".$@-watchos-sim-build-failure.stamp\"");
 					writer.WriteLine ("\t$(Q) echo \"@MonkeyWrench: SetSummary:\"");
 					// first build (serialized)
-					writer.WriteLine ("\t$(Q) $(MAKE) \"build-ios-sim-{0}\"        || echo \"@MonkeyWrench: AddSummary: <b>ios failed to build</b> <br/>\"     >> \".$@-ios-sim-build-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) $(MAKE) \"build-tvos-sim-{0}\"       || echo \"@MonkeyWrench: AddSummary: <b>tvos failed to build</b> <br/>\"    >> \".$@-tvos-sim-build-failure.stamp\"", target.GetMakeName (false));
-					if (harness.INCLUDE_WATCH)
+					if (includeiOS)
+						writer.WriteLine ("\t$(Q) $(MAKE) \"build-ios-sim-{0}\"        || echo \"@MonkeyWrench: AddSummary: <b>ios failed to build</b> <br/>\"     >> \".$@-ios-sim-build-failure.stamp\"", target.GetMakeName (false));
+					if (includetvOS)
+						writer.WriteLine ("\t$(Q) $(MAKE) \"build-tvos-sim-{0}\"       || echo \"@MonkeyWrench: AddSummary: <b>tvos failed to build</b> <br/>\"    >> \".$@-tvos-sim-build-failure.stamp\"", target.GetMakeName (false));
+					if (includewatchOS)
 						writer.WriteLine ("\t$(Q) $(MAKE) \"build-watchos-sim-{0}\"    || echo \"@MonkeyWrench: AddSummary: <b>watchos failed to build</b> <br/>\" >> \".$@-watchos-sim-build-failure.stamp\"", target.GetMakeName (false));
 					// then run
-					writer.WriteLine ("\t$(Q) (test -e \".$@-ios-sim-build-failure.stamp\" && cat \".$@-ios-sim-build-failure.stamp\" >> \".$@-failure.stamp\") || $(MAKE) \"exec-ios-sim32-{0}\"      || echo \"exec-ios-sim32-{0} failed\"      >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q)  test -e \".$@-ios-sim-build-failure.stamp\"                                                                             || $(MAKE) \"exec-ios-sim64-{0}\"      || echo \"exec-ios-sim64-{0} failed\"      >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					writer.WriteLine ("\t$(Q) (test -e \".$@-tvos-sim-build-failure.stamp\"       && cat \".$@-tvos-sim-build-failure.stamp\"       >> \".$@-failure.stamp\") || $(MAKE) \"exec-tvos-sim-{0}\"       || echo \"exec-tvos-sim-{0} failed\"       >> \".$@-failure.stamp\"", target.GetMakeName (false));
-					if (harness.INCLUDE_WATCH) {
+					if (includeiOS) {
+						writer.WriteLine ("\t$(Q) (test -e \".$@-ios-sim-build-failure.stamp\" && cat \".$@-ios-sim-build-failure.stamp\" >> \".$@-failure.stamp\") || $(MAKE) \"exec-ios-sim32-{0}\"      || echo \"exec-ios-sim32-{0} failed\"      >> \".$@-failure.stamp\"", target.GetMakeName (false));
+						writer.WriteLine ("\t$(Q)  test -e \".$@-ios-sim-build-failure.stamp\"                                                                             || $(MAKE) \"exec-ios-sim64-{0}\"      || echo \"exec-ios-sim64-{0} failed\"      >> \".$@-failure.stamp\"", target.GetMakeName (false));
+					}
+					if (includetvOS)
+						writer.WriteLine ("\t$(Q) (test -e \".$@-tvos-sim-build-failure.stamp\"       && cat \".$@-tvos-sim-build-failure.stamp\"       >> \".$@-failure.stamp\") || $(MAKE) \"exec-tvos-sim-{0}\"       || echo \"exec-tvos-sim-{0} failed\"       >> \".$@-failure.stamp\"", target.GetMakeName (false));
+					if (includewatchOS) {
 						if (harness.DisableWatchOSOnWrench) {
 							writer.WriteLine ("\t$(Q) (test -e \".$@-watchos-sim-build-failure.stamp\"    && cat \".$@-watchos-sim-build-failure.stamp\"                            ) || $(MAKE) \"exec-watchos-sim-{0}\"    || echo \"exec-watchos-sim-{0} failed\"                            ", target.GetMakeName (false));
 						} else {

--- a/tests/xharness/Program.cs
+++ b/tests/xharness/Program.cs
@@ -20,26 +20,26 @@ namespace xharness
 				{ "configure", "Creates project files and makefiles.", (v) => harness.Action = HarnessAction.Configure },
 				{ "autoconf", "Automatically decide what to configure.", (v) => harness.AutoConf = true },
 				{ "rootdir=", "The root directory for the tests.", (v) => harness.RootDirectory = v },
-				{ "project=", "Add a project file to process. This can be specified multiple times.", (v) => harness.IOSTestProjects.Add (new TestProject (v)) },
+				{ "project=", "Add a project file to process. This can be specified multiple times.", (v) => harness.IOSTestProjects.Add (new iOSTestProject (v)) },
 				{ "watchos-container-template=", "The directory to use as a template for a watchos container app.", (v) => harness.WatchOSContainerTemplate = v },
 				{ "watchos-app-template=", "The directory to use as a template for a watchos app.", (v) => harness.WatchOSAppTemplate = v },
 				// Run
 				{ "run=", "Executes a project.", (v) =>
 					{
 						harness.Action = HarnessAction.Run;
-						harness.IOSTestProjects.Add (new TestProject (v));
+						harness.IOSTestProjects.Add (new iOSTestProject (v));
 					}
 				},
 				{ "install=", "Installs a project.", (v) =>
 					{
 						harness.Action = HarnessAction.Install;
-						harness.IOSTestProjects.Add (new TestProject (v));
+						harness.IOSTestProjects.Add (new iOSTestProject (v));
 					}
 				},
 				{ "uninstall=", "Uninstalls a project.", (v) =>
 					{
 						harness.Action = HarnessAction.Uninstall;
-						harness.IOSTestProjects.Add (new TestProject (v));
+						harness.IOSTestProjects.Add (new iOSTestProject (v));
 					}
 				},
 				{ "sdkroot=", "Where Xcode is", (v) => harness.SdkRoot = v },

--- a/tests/xharness/TVOSTarget.cs
+++ b/tests/xharness/TVOSTarget.cs
@@ -5,7 +5,7 @@ using System.Xml;
 
 namespace xharness
 {
-	public class TVOSTarget : Target
+	public class TVOSTarget : iOSTarget
 	{
 		public override string Suffix {
 			get {

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -122,6 +122,22 @@ namespace xharness
 		}
 	}
 
+	public class iOSTestProject : TestProject
+	{
+		public bool SkipiOSVariation;
+		public bool SkipwatchOSVariation;
+		public bool SkiptvOSVariation;
+
+		public iOSTestProject ()
+		{
+		}
+
+		public iOSTestProject (string path, bool isExecutableProject = true, bool generateVariations = true)
+			: base (path, isExecutableProject, generateVariations)
+		{
+		}
+	}
+
 	public class MacTestProject : TestProject
 	{
 		public bool SkipXMVariations;

--- a/tests/xharness/UnifiedTarget.cs
+++ b/tests/xharness/UnifiedTarget.cs
@@ -2,7 +2,7 @@
 
 namespace xharness
 {
-	public class UnifiedTarget : Target
+	public class UnifiedTarget : iOSTarget
 	{
 		public override string Suffix {
 			get {

--- a/tests/xharness/WatchOSTarget.cs
+++ b/tests/xharness/WatchOSTarget.cs
@@ -5,7 +5,7 @@ using System.Xml;
 
 namespace xharness
 {
-	public class WatchOSTarget : Target
+	public class WatchOSTarget : iOSTarget
 	{
 		public string AppName { get; private set; }
 		public string ExtensionName { get; private set; }

--- a/tests/xharness/iOSTarget.cs
+++ b/tests/xharness/iOSTarget.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace xharness
+{
+	// iOS here means Xamarin.iOS, not iOS as opposed to tvOS/watchOS.
+	public class iOSTarget : Target
+	{
+		public iOSTestProject TestProject;
+	}
+}

--- a/tests/xharness/xharness.csproj
+++ b/tests/xharness/xharness.csproj
@@ -83,6 +83,7 @@
       <Link>StringUtils.cs</Link>
     </Compile>
     <Compile Include="SimpleFileListener.cs" />
+    <Compile Include="iOSTarget.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
And use it to skip watchOS tests for Mono.Security, since we don't ship Mono.Security.dll for watchOS.

https://bugzilla.xamarin.com/show_bug.cgi?id=57529