### PR TITLE
[AVFoundation] Adds missing Xcode9 API.

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -9083,6 +9083,15 @@ namespace XamCore.AVFoundation {
 		[Export ("dualCameraFusionSupported")]
 		bool DualCameraFusionSupported { [Bind ("isDualCameraFusionSupported")] get; }
 
+		// From AVCapturePhotoOutput (AVCapturePhotoOutputDepthDataDeliverySupport) Category
+
+		[iOS (11,0)]
+		[Export ("depthDataDeliverySupported")]
+		bool DepthDataDeliverySupported { [Bind ("isDepthDataDeliverySupported")] get; }
+
+		[iOS (11,0)]
+		[Export ("depthDataDeliveryEnabled")]
+		bool DepthDataDeliveryEnabled { [Bind ("isDepthDataDeliveryEnabled")] get; set; }
 	}
 #endif
 	
@@ -9668,6 +9677,20 @@ namespace XamCore.AVFoundation {
 		[iOS (10, 0)]
 		[Export ("activeColorSpace", ArgumentSemantic.Assign)]
 		AVCaptureColorSpace ActiveColorSpace { get; set; }
+
+		// From AVCaptureDevice (AVCaptureDeviceDepthSupport) Category
+
+		[iOS (11,0)]
+		[Export ("activeDepthDataFormat", ArgumentSemantic.Retain), NullAllowed]
+		AVCaptureDeviceFormat ActiveDepthDataFormat { get; set; }
+
+		[iOS (11,0)]
+		[Export ("minAvailableVideoZoomFactor")]
+		nfloat MinAvailableVideoZoomFactor { get; }
+
+		[iOS (11,0)]
+		[Export ("maxAvailableVideoZoomFactor")]
+		nfloat MaxAvailableVideoZoomFactor { get; }
 
 #endif
 	}


### PR DESCRIPTION
AVCapturePhotoOutput:

* Adds missing members `DepthDataDeliverySupported` and `DepthDataDeliveryEnabled`
  from `AVCapturePhotoOutputDepthDataDeliverySupport` category.

AVCaptureDevice:

* Adds missing members `ActiveDepthDataFormat`, `MinAvailableVideoZoomFactor` and
  `MaxAvailableVideoZoomFactor` from `AVCaptureDeviceDepthSupport` category.