### PR TITLE
[msbuild] Force-Init AppleSdkSettings in DetectSdkLocationsTaskBase

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
@@ -88,7 +88,7 @@ namespace Xamarin.iOS.Tasks
 
 		public override bool Execute ()
 		{
-			AppleSdkSettings.CheckChanged ();
+			AppleSdkSettings.Init ();
 			IPhoneSdks.Reload ();
 
 			TargetArchitecture architectures;


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=59756