### PR TITLE
[linker] Use correct namespace for async debugging helpers. Fixes #59015

### DIFF
--- a/tools/linker/MobileMarkStep.cs
+++ b/tools/linker/MobileMarkStep.cs
@@ -259,19 +259,25 @@ namespace Xamarin.Linker.Steps {
 		void ProcessCorlib (TypeDefinition type)
 		{
 			switch (type.Namespace) {
-			case "System.Runtime.CompilerServices.AsyncTaskMethodBuilder":
-				if (DebugBuild)
-					MarkNamedMethod (type, "SetNotificationForWaitCompletion");
+			case "System.Runtime.CompilerServices":
+				switch (type.Name) {
+					case "AsyncTaskMethodBuilder":
+					case "AsyncTaskMethodBuilder`1":
+					if (DebugBuild) {
+						MarkNamedMethod (type, "SetNotificationForWaitCompletion");
+						MarkNamedMethod (type, "get_ObjectIdForDebugger");
+					}
+					break;
+				}
 				break;
-			case "System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1":
-				if (DebugBuild)
-					MarkNamedMethod (type, "SetNotificationForWaitCompletion");
+			case "System.Threading.Tasks":
+				switch (type.Name) {
+					case "Task":
+					if (DebugBuild)
+						MarkNamedMethod (type, "NotifyDebuggerOfWaitCompletion");
+					break;
+				}
 				break;
-			case "System.Threading.Tasks.Task":
-				if (DebugBuild)
-					MarkNamedMethod (type, "NotifyDebuggerOfWaitCompletion");
-				break;
-
 			case "System.Security.Cryptography":
 				switch (type.Name) {
 				case "Aes":


### PR DESCRIPTION
Replace https://github.com/xamarin/xamarin-macios/pull/2704
It's almost identical but it adds unit tests so this does not regress.

The issue was already reported in [1] but the fix [2] was incorrect
and that was also missed when the bug was verified by QA [3].

[1] https://bugzilla.xamarin.com/show_bug.cgi?id=55037
[2] https://github.com/xamarin/xamarin-macios/pull/2004
[3] https://bugzilla.xamarin.com/show_bug.cgi?id=55037#c10