### PR TITLE
[mmp/mtouch] Don't link with frameworks not available in the current SDK. Fixes #59636. (#2777)

### DIFF
--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -758,5 +758,21 @@ namespace Xamarin.MMP.Tests
 				TI.TestUnifiedExecutable (test);
 			});
 		}
+
+		[Test]
+		public void OldXcodeTest ()
+		{
+			var oldXcode = Xamarin.Tests.Configuration.GetOldXcodeRoot ();
+
+			if (string.IsNullOrEmpty (oldXcode))
+				Assert.Ignore ("This test needs an old Xcode.");
+
+			RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					CSProjConfig = "<DebugSymbols>True</DebugSymbols>", // This makes the msbuild tasks pass /debug to mmp
+				};
+				TI.TestUnifiedExecutable (test, shouldFail: false, configuration: "Debug", environment: new string [] { "MD_APPLE_SDK_ROOT", Path.GetDirectoryName (Path.GetDirectoryName (oldXcode)) });
+			});
+		}
 	}
 }

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -415,7 +415,10 @@ namespace Xamarin.Bundler {
 						// detect frameworks
 						int f = name.IndexOf (".framework/", StringComparison.Ordinal);
 						if (f > 0) {
-							if (Frameworks.Add (file))
+							Framework framework;
+							if (Driver.GetFrameworks (App).TryGetValue (file, out framework) && framework.Version > App.SdkVersion)
+								Driver.Log (3, "Not linking with the framework {0} (referenced by a module reference in {1}) because it was introduced in {2} {3}, and we're using the {2} {4} SDK.", file, FileName, App.PlatformName, framework.Version, App.SdkVersion);
+							else if (Frameworks.Add (file))
 								Driver.Log (3, "Linking with the framework {0} because it's referenced by a module reference in {1}", file, FileName);
 						} else {
 							if (UnresolvedModuleReferences == null)

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -172,6 +172,8 @@ namespace Xamarin.Bundler {
 							var add_to = App.DeploymentTarget >= framework.Version ? asm.Frameworks : asm.WeakFrameworks;
 							add_to.Add (framework.Name);
 							continue;
+						} else {
+							Driver.Log (3, "Not linking with the framework {0} (used by the type {1}) because it was introduced in {2} {3}, and we're using the {2} {4} SDK.", framework.Name, td.FullName, App.PlatformName, framework.Version, App.SdkVersion);
 						}
 					}
 				}


### PR DESCRIPTION
We already have this logic for frameworks we detect according to the namespace
of the used types, but not for frameworks we detect from P/Invokes.

Fix this by using the same framework exclusion logic for frameworks detected
from P/Invokes: don't link with frameworks not available in the current SDK.

https://bugzilla.xamarin.com/show_bug.cgi?id=59636