### PR TITLE
[src] Fix directory dependence for build/tvos/reference/OpenTK-1.0.dll.config. Fixes #59432.

### DIFF
--- a/src/OpenGLES/Makefile-1.0.include
+++ b/src/OpenGLES/Makefile-1.0.include
@@ -46,7 +46,7 @@ $(TVOS_BUILD_DIR)/reference/OpenTK-1.0%dll $(TVOS_BUILD_DIR)/reference/OpenTK-1.
 
 # common targets
 
-%/OpenTK-1.0.dll.config: $(OPENTK_PATH)/Source/OpenTK/OpenTK.dll.config | $(IOS_BUILD_DIR)/reference $(IOS_BUILD_DIR)/compat $(TVOS_BUILD_DIR)/tvos
+%/OpenTK-1.0.dll.config: $(OPENTK_PATH)/Source/OpenTK/OpenTK.dll.config | $(IOS_BUILD_DIR)/reference $(IOS_BUILD_DIR)/compat $(TVOS_BUILD_DIR)/reference
 	$(Q) cp $< $@
 
 # other stuff


### PR DESCRIPTION
Otherwise copying OpenTK-1.0.dll.config to its target destination would fail
because the target directory didn't exist:

> make[2]: *** [build/tvos/reference/OpenTK-1.0.dll.config] Error 1

https://bugzilla.xamarin.com/show_bug.cgi?id=59432