### PR TITLE
[registrar] Don't verify the SDK for protocol members, and fix the SDK check for other cases. Fixes #59617.

### DIFF
--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -261,7 +261,9 @@ namespace XamCore.Registrar {
 
 				VerifySelector (method, ref exceptions);
 				method.ValidateSignature (ref exceptions);
-				if (!method.IsPropertyAccessor)
+				// Protocol members don't show up in the generated output, so it doesn't matter if we run into those.
+				// If a class implements a protocol, it will still hit this check on the implemented members.
+				if (!method.IsPropertyAccessor && !method.DeclaringType.IsProtocol)
 					Registrar.VerifyInSdk (ref exceptions, method);
 
 				rv = AddToMap (method, ref exceptions);
@@ -275,7 +277,10 @@ namespace XamCore.Registrar {
 					Properties = new List<ObjCProperty> ();
 				// Do properties and methods live in the same objc namespace? // AddToMap (property, errorIfExists);
 				Properties.Add (property);
-				Registrar.VerifyInSdk (ref exceptions, property);
+				// Protocol members don't show up in the generated output, so it doesn't matter if we run into those.
+				// If a class implements a protocol, it will still hit this check on the implemented members.
+				if (!property.DeclaringType.IsProtocol)
+					Registrar.VerifyInSdk (ref exceptions, property);
 				VerifyIsNotKeyword (ref exceptions, property);
 			}
 

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2602,4 +2602,22 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Export ("method")]
 		public static void StaticMethod () { }
 	}
+
+	// It should be possible to use a protocol with a member we can't use yet (because its signature uses a type not in the current SDK)
+	[Protocol]
+	[ProtocolMember (IsRequired = false, IsProperty = false, IsStatic = false, Name = "DetectPremonition", Selector = "detectPremonition:", ParameterType = new Type [] { typeof (FutureClass) }, ParameterByRef = new bool [] { false })]
+	public interface ISomeDelegate : INativeObject, IDisposable
+	{
+	}
+	[Introduced (PlatformName.MacOSX, 100, 0)]
+	[Introduced (PlatformName.iOS, 100, 0)]
+	[Introduced (PlatformName.TvOS, 100, 0)]
+	[Introduced (PlatformName.WatchOS, 100, 0)]
+	public class FutureClass : NSObject
+	{
+	}
+	[Preserve]
+	public class SomeConsumer : NSObject, ISomeDelegate
+	{
+	}
 }

--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -629,11 +629,7 @@ public struct FooF { public NSObject Obj; }
 			        $".*/Test.cs(.*): error MT4162: The type 'FutureType' (used as a parameter in CurrentType.Foo) is not available in {name} .* (it was introduced in {name} 99.0.0): 'use Z instead'. Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).",
 			        $".*/Test.cs(.*): error MT4162: The type 'FutureType' (used as a parameter in CurrentType.Foo) is not available in {name} .* (it was introduced in {name} 89.0.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).",
 			        $".*/Test.cs(.*): error MT4162: The type 'FutureType' (used as a return type in CurrentType.Bar) is not available in {name} .* (it was introduced in {name} 99.0.0): 'use Z instead'. Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).",
-			        $".*/Test.cs(.*): error MT4162: The type 'FutureType' (used as a return type in CurrentType.Bar) is not available in {name} .* (it was introduced in {name} 89.0.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).",
-					$"error MT4162: The type 'FutureEnum' (used as the property type of IFutureProtocol.FutureProperty) is not available in {name} .* (it was introduced in {name} 99.0.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).",
-					$"error MT4162: The type 'FutureEnum' (used as a return type in IFutureProtocol.FutureMethod) is not available in {name} .* (it was introduced in {name} 99.0.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode).",
-					$"error MT4162: The type 'FutureEnum' (used as a parameter in IFutureProtocol.FutureMethod) is not available in {name} .* (it was introduced in {name} 99.0.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode)."
-
+			        $".*/Test.cs(.*): error MT4162: The type 'FutureType' (used as a return type in CurrentType.Bar) is not available in {name} .* (it was introduced in {name} 89.0.0). Please build with a newer {name} SDK (usually done by using the most recent version of Xcode)."
 			);
 		}
 

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -522,7 +522,6 @@ namespace XamCore.Registrar {
 
 		string single_assembly;
 		IEnumerable<AssemblyDefinition> input_assemblies;
-		Mono.Linker.LinkContext link_context;
 		Dictionary<IMetadataTokenProvider, object> availability_annotations;
 
 #if MONOMAC
@@ -531,11 +530,15 @@ namespace XamCore.Registrar {
 
 		public Mono.Linker.LinkContext LinkContext {
 			get {
-				return link_context;
+				return Target?.LinkContext;
 			}
-			set {
-				link_context = value;
-				availability_annotations = link_context?.Annotations.GetCustomAnnotations ("Availability");
+		}
+
+		Dictionary<IMetadataTokenProvider, object> AvailabilityAnnotations {
+			get {
+				if (availability_annotations == null)
+					availability_annotations = LinkContext?.Annotations?.GetCustomAnnotations ("Availability");
+				return availability_annotations;
 			}
 		}
 
@@ -1499,9 +1502,9 @@ namespace XamCore.Registrar {
 			if (td.HasCustomAttributes)
 				CollectAvailabilityAttributes (td.CustomAttributes, ref rv);
 			
-			if (availability_annotations != null) {
+			if (AvailabilityAnnotations != null) {
 				object attribObjects;
-				if (availability_annotations.TryGetValue (td, out attribObjects))
+				if (AvailabilityAnnotations.TryGetValue (td, out attribObjects))
 					CollectAvailabilityAttributes ((List<CustomAttribute>) attribObjects, ref rv);
 			}
 

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -516,14 +516,7 @@ namespace XamCore.Registrar {
 		}
 	}
 
-	public interface IStaticRegistrar
-	{
-		void Generate (IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path);
-		void GenerateSingleAssembly (IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path, string assembly);
-		Mono.Linker.LinkContext LinkContext { get; set; }
-	}
-
-	class StaticRegistrar : Registrar, IStaticRegistrar {
+	class StaticRegistrar : Registrar{
 		public Target Target { get; private set; }
 		public bool IsSingleAssembly { get { return !string.IsNullOrEmpty (single_assembly); } }
 

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1178,7 +1178,6 @@ namespace Xamarin.Bundler {
 			if (registrar == RegistrarMode.Static) {
 				registrarPath = Path.Combine (App.Cache.Location, "registrar.m");
 				var registrarH = Path.Combine (App.Cache.Location, "registrar.h");
-				BuildTarget.StaticRegistrar.LinkContext = BuildTarget.LinkContext;
 				BuildTarget.StaticRegistrar.Generate (BuildTarget.Resolver.ResolverCache.Values, registrarH, registrarPath);
 
 				var platform_assembly = BuildTarget.Resolver.ResolverCache.First ((v) => v.Value.Name.Name == BuildTarget.StaticRegistrar.PlatformAssembly).Value;

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -875,10 +875,7 @@ namespace Xamarin.Bundler
 			case RegistrarMode.Static:
 			case RegistrarMode.Dynamic:
 			case RegistrarMode.Default:
-				StaticRegistrar = new StaticRegistrar (this)
-				{
-					LinkContext = LinkContext,
-				};
+				StaticRegistrar = new StaticRegistrar (this);
 				break;
 			}
 		}


### PR DESCRIPTION
This is a backport of PR #2790.

This fixes both #[59177](https://bugzilla.xamarin.com/show_bug.cgi?id=59177) and #[59617](https://bugzilla.xamarin.com/show_bug.cgi?id=59617)

https://bugzilla.xamarin.com/show_bug.cgi?id=59617
https://bugzilla.xamarin.com/show_bug.cgi?id=59177