### PR TITLE
[CoreGraphics] Fix memory leak in CGColorSpace.Name.

### DIFF
--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -404,7 +404,7 @@ namespace XamCore.CoreGraphics {
 		[TV (10,0)]
 		public string Name {
 			get {
-				return CFString.FetchString (CGColorSpaceCopyName (handle));
+				return CFString.FetchString (CGColorSpaceCopyName (handle), true);
 			}
 		}
 


### PR DESCRIPTION
As the native name says, 'CGColorSpaceCopyName' returns a copy, which means we own the return value.