### PR TITLE
[AVFoundation] AVFoundation API Enhancements

### DIFF
--- a/src/AVFoundation/AVCaptureSynchronizedDataCollection.cs
+++ b/src/AVFoundation/AVCaptureSynchronizedDataCollection.cs
@@ -1,0 +1,37 @@
+﻿//
+// AVCaptureSynchronizedDataCollection.cs
+//
+// Authors:
+//	Alex Soto  <alexsoto@microsoft.com>
+//
+// Copyright 2017 Xamarin Inc. All rights reserved.
+//
+
+#if IOS || MONOMAC
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using XamCore.Foundation;
+
+namespace XamCore.AVFoundation {
+	public partial class AVCaptureSynchronizedDataCollection { //: IEnumerable<AVCaptureOutput>
+		public AVCaptureSynchronizedData this [AVCaptureOutput captureOutput] {
+			get {
+				return GetSynchronizedData (captureOutput);
+			}
+		}
+
+		// TODO: Enable IEnumerable/NSFastEnumerator once radar://34641736 is fixed
+		//https://trello.com/c/iFtsFSWs
+		//public IEnumerator<AVCaptureOutput> GetEnumerator ()
+		//{
+		//	return new NSFastEnumerator<AVCaptureOutput> (this);
+		//}
+
+		//IEnumerator IEnumerable.GetEnumerator ()
+		//{
+		//	return GetEnumerator (); ;
+		//}
+	}
+}
+#endif // IOS || MONOMAC

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -3092,14 +3092,14 @@ namespace XamCore.AVFoundation {
 	interface AVCaptureSynchronizedDataCollection
 	{
 #if !XAMCORE_4_0
-		[Obsolete ("Use 'GetSynchronizedData' Instead.")]
+		[Obsolete ("Use 'GetSynchronizedData' instead.")]
 		[Wrap ("GetSynchronizedData (captureOutput)", isVirtual: true)]
 		AVCaptureSynchronizedData From (AVCaptureOutput captureOutput);
 
 		// This is not reexposed because it is not needed you can use 'GetSynchronizedData' instead, also from docs:
 		// https://developer.apple.com/documentation/avfoundation/avcapturesynchronizeddatacollection/2873892-objectforkeyedsubscript?language=objc
 		// > This call is equivalent to the synchronizedDataForCaptureOutput: method, but allows subscript syntax.
-		[Obsolete ("Use 'GetSynchronizedData' Instead.")]
+		[Obsolete ("Use 'GetSynchronizedData' instead.")]
 		[Export ("objectForKeyedSubscript:")]
 		[return: NullAllowed]
 		AVCaptureSynchronizedData ObjectForKeyedSubscript (AVCaptureOutput key);

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -3074,6 +3074,9 @@ namespace XamCore.AVFoundation {
 
 #endif // MONOMAC
 
+#if XAMCORE_4_0
+	[Abstract] // Abstract superclass.
+#endif
 	[NoWatch, NoTV, iOS (11,0)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
@@ -3086,15 +3089,25 @@ namespace XamCore.AVFoundation {
 	[NoWatch, NoTV, iOS (11,0)]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
-	interface AVCaptureSynchronizedDataCollection : INSFastEnumeration
+	interface AVCaptureSynchronizedDataCollection
 	{
-		[Export ("synchronizedDataForCaptureOutput:")]
-		[return: NullAllowed]
+#if !XAMCORE_4_0
+		[Obsolete ("Use 'GetSynchronizedData' Instead.")]
+		[Wrap ("GetSynchronizedData (captureOutput)", isVirtual: true)]
 		AVCaptureSynchronizedData From (AVCaptureOutput captureOutput);
 
+		// This is not reexposed because it is not needed you can use 'GetSynchronizedData' instead, also from docs:
+		// https://developer.apple.com/documentation/avfoundation/avcapturesynchronizeddatacollection/2873892-objectforkeyedsubscript?language=objc
+		// > This call is equivalent to the synchronizedDataForCaptureOutput: method, but allows subscript syntax.
+		[Obsolete ("Use 'GetSynchronizedData' Instead.")]
 		[Export ("objectForKeyedSubscript:")]
 		[return: NullAllowed]
 		AVCaptureSynchronizedData ObjectForKeyedSubscript (AVCaptureOutput key);
+#endif
+
+		[Export ("synchronizedDataForCaptureOutput:")]
+		[return: NullAllowed]
+		AVCaptureSynchronizedData GetSynchronizedData (AVCaptureOutput captureOutput);
 
 		[Export ("count")]
 		nuint Count { get; }
@@ -8263,7 +8276,7 @@ namespace XamCore.AVFoundation {
 
 	interface IAVCaptureDepthDataOutputDelegate {}
 	
-	[NoWatch, NoTV, iOS (11,0)]
+	[NoWatch, NoTV, iOS (11,0), Mac (10,13)]
 	[Protocol, Model]
 	[BaseType (typeof(NSObject))]
 	interface AVCaptureDepthDataOutputDelegate
@@ -8275,9 +8288,8 @@ namespace XamCore.AVFoundation {
 		void DidDropDepthData (AVCaptureDepthDataOutput output, AVDepthData depthData, CMTime timestamp, AVCaptureConnection connection, AVCaptureOutputDataDroppedReason reason);
 	}
 
-	[NoWatch, NoTV, iOS (11,0)]
+	[NoWatch, NoTV, iOS (11,0), Mac (10,13)]
 	[BaseType (typeof(AVCaptureOutput))]
-	[DisableDefaultCtor]
 	interface AVCaptureDepthDataOutput
 	{
 		[Export ("setDelegate:callbackQueue:")]
@@ -9231,6 +9243,12 @@ namespace XamCore.AVFoundation {
 		BuiltInDualCamera,
 	}
 
+	[NoTV, iOS (7,0), NoMac, NoWatch] // matches API that uses it.
+	enum AVAuthorizationMediaType {
+		Video,
+		Audio,
+	}
+
 	[NoWatch]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
@@ -9444,10 +9462,23 @@ namespace XamCore.AVFoundation {
 		[Static, Export ("authorizationStatusForMediaType:")]
 		AVAuthorizationStatus GetAuthorizationStatus (NSString avMediaTypeToken);
 
+		// Calling this method with any media type other than AVMediaTypeVideo or AVMediaTypeAudio raises an exception.
+		[iOS (7,0)]
+		[Static]
+		[Wrap ("GetAuthorizationStatus (mediaType == AVAuthorizationMediaType.Video ? AVMediaTypes.Video.GetConstant () : AVMediaTypes.Audio.GetConstant ())")]
+		AVAuthorizationStatus GetAuthorizationStatus (AVAuthorizationMediaType mediaType);
+
 		[Since (7,0)]
 		[Static, Export ("requestAccessForMediaType:completionHandler:")]
 		[Async]
 		void RequestAccessForMediaType (NSString avMediaTypeToken, AVRequestAccessStatus completion);
+
+		// Either AVMediaTypeVideo or AVMediaTypeAudio.
+		[iOS (7,0)]
+		[Static]
+		[Wrap ("RequestAccessForMediaType (mediaType == AVAuthorizationMediaType.Video ? AVMediaTypes.Video.GetConstant () : AVMediaTypes.Audio.GetConstant (), completion)")]
+		[Async]
+		void RequestAccessForMediaType (AVAuthorizationMediaType mediaType, AVRequestAccessStatus completion);
 #endif
 
 		[Since (7,0)][Mac (10,7)]

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -245,6 +245,7 @@ AVFOUNDATION_SOURCES = \
 	AVFoundation/AVCaptureDeviceInput.cs \
 	AVFoundation/AVCaptureFileOutput.cs \
 	AVFoundation/AVCaptureMetadataOutput.cs \
+	AVFoundation/AVCaptureSynchronizedDataCollection.cs \
 	AVFoundation/AVCaptureVideoDataOutput.cs \
 	AVFoundation/AVCaptureVideoPreviewLayer.cs \
 	AVFoundation/AVCompat.cs \


### PR DESCRIPTION
Changes in AVFoundation
===================

AVCaptureSynchronizedDataCollection:

* Obsoletes `From` method because the name does not makes sense in the current context.
* Obsoletes `ObjectForKeyedSubscript` in favor of a C# indexer.
* Adds `GetSynchronizedData` to replace obsoleted `From` method`.

AVCaptureSynchronizedData:

* Adds `[Abstract]` in XAMCORE_4_0 because it is an abstract superclass.

AVCaptureDevice:

* Adds strong typed API to `GetAuthorizationStatus` and `RequestAccessForMediaType`
  using `AVAuthorizationMediaType` enum holding the only possible values.

AVCaptureDepthDataOutput:

* AVCaptureDepthDataOutput needs its default .ctor, there is no other way
  to instantiate this class.

Test
====

A test exercising the new API lives here:

https://github.com/dalexsoto/XamarinTests/blob/4715069b2bd777009c94c32fd9eed56b81103264/AVCaptureDataOutputSynchronizerTest/AVCaptureDataOutputSynchronizerTest/ViewController.cs

The API needs an iPhone 7+, 8+ or X in order to run.