### PR TITLE
[CoreGraphics] Implement CoreGraphics bindings for Xcode 9.

### DIFF
--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -156,10 +156,12 @@ namespace XamCore.CoreGraphics {
 
 		public static CGColorSpace CreateCalibratedGray (nfloat [] whitepoint, nfloat [] blackpoint, nfloat gamma)
 		{
+			if (whitepoint == null)
+				throw new ArgumentNullException (nameof (whitepoint));
 			if (whitepoint.Length != 3)
-				throw new ArgumentException ("Must have 3 values", "whitepoint");
-			if (blackpoint.Length != 3)
-				throw new ArgumentException ("Must have 3 values", "blackpoint");
+				throw new ArgumentException ("Must be null or have 3 values", nameof (whitepoint));
+			if (blackpoint != null && blackpoint.Length != 3)
+				throw new ArgumentException ("Must be null or have 3 values", nameof (blackpoint));
 			
 			var ptr = CGColorSpaceCreateCalibratedGray (whitepoint, blackpoint, gamma);
 			return ptr == IntPtr.Zero ? null : new CGColorSpace (ptr, true);
@@ -171,14 +173,16 @@ namespace XamCore.CoreGraphics {
 
 		public static CGColorSpace CreateCalibratedRGB (nfloat [] whitepoint, nfloat [] blackpoint, nfloat [] gamma, nfloat [] matrix)
 		{
+			if (whitepoint == null)
+				throw new ArgumentNullException (nameof (whitepoint));
 			if (whitepoint.Length != 3)
-				throw new ArgumentException ("Must have 3 values", "whitepoint");
-			if (blackpoint.Length != 3)
-				throw new ArgumentException ("Must have 3 values", "blackpoint");
-			if (gamma.Length != 3)
-				throw new ArgumentException ("Must have 3 values", "gamma");
-			if (matrix.Length != 9)
-				throw new ArgumentException ("Must have 9 values", "matrix");
+				throw new ArgumentException ("Must have 3 values", nameof (whitepoint));
+			if (blackpoint != null && blackpoint.Length != 3)
+				throw new ArgumentException ("Must be null or have 3 values", nameof (blackpoint));
+			if (gamma != null && gamma.Length != 3)
+				throw new ArgumentException ("Must be null or have 3 values", nameof (gamma));
+			if (matrix != null && matrix.Length != 9)
+				throw new ArgumentException ("Must be null or have 9 values", nameof (matrix));
 			
 			var ptr = CGColorSpaceCreateCalibratedRGB (whitepoint, blackpoint, gamma, matrix);
 			return ptr == IntPtr.Zero ? null : new CGColorSpace (ptr, true);

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -189,6 +189,25 @@ namespace XamCore.CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		extern static /* CGColorSpaceRef __nullable */ IntPtr CGColorSpaceCreateLab (nfloat [] whitepoint, nfloat [] blackpoint, nfloat [] range);
+
+		// Available since the beginning of time
+		public static CGColorSpace CreateLab (nfloat [] whitepoint, nfloat [] blackpoint, nfloat [] range)
+		{
+			if (whitepoint == null)
+				throw new ArgumentNullException (nameof (whitepoint));
+			if (whitepoint.Length != 3)
+				throw new ArgumentException ("Must have 3 values", nameof (whitepoint));
+			if (blackpoint != null && blackpoint.Length != 3)
+				throw new ArgumentException ("Must be null or have 3 values", nameof (blackpoint));
+			if (range != null && range.Length != 4)
+				throw new ArgumentException ("Must be null or have 4 values", nameof (range));
+
+			var ptr = CGColorSpaceCreateLab (whitepoint, blackpoint, range);
+			return ptr == IntPtr.Zero ? null : new CGColorSpace (ptr, true);
+		}
+
+		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGColorSpaceRef */ IntPtr CGColorSpaceCreateIndexed (/* CGColorSpaceRef */ IntPtr baseSpace,
 			/* size_t */ nint lastIndex, /* const unsigned char* */ byte[] colorTable);
 

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -366,43 +366,43 @@ namespace XamCore.CoreGraphics {
 			return table;
 		}
 
-		// Old API, removed in iOS 11.0, macro maps CGColorSpaceCreateWithICCData to this name
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'CreateIDCCData' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'CreateIDCCData' instead.")]
+		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'CreateIDCCData' instead.")]
+		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'CreateIDCCData' instead.")]
 		extern static /* CGColorSpaceRef */ IntPtr CGColorSpaceCreateWithICCProfile (/* CFDataRef */ IntPtr data);
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		extern static /* CGColorSpaceRef */ IntPtr CGColorSpaceCreateWithICCData (/* CFDataRef */ IntPtr data);
+		[iOS (10,0)][Mac (10,12)][Watch (3,0)][TV (10,0)]
+		extern static /* CGColorSpaceRef */ IntPtr CGColorSpaceCreateWithICCData (/* CFTypeRef cg_nullable */ IntPtr data);
 
-#if MONOMAC || IOS
-		static bool versionChecked, use11APIs;
-#else
-		const bool versionChecked = true;
-		const bool use11APIs = false;
-#endif
-	
-		static void Check11 ()
-		{
-#if MONOMAC || IOS
-			if (PlatformHelper.CheckSystemVersion (11, 0))
-				use11APIs = true;
-			versionChecked = true;
-#endif
-		}
-		
+		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'CreateIDCCData' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'CreateIDCCData' instead.")]
+		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'CreateIDCCData' instead.")]
+		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'CreateIDCCData' instead.")]
 		public static CGColorSpace CreateICCProfile (NSData data)
 		{
-			// older versions did not throw - so we'll return null
-			if (data == null)
-				return null;
-			if (!versionChecked)
-				Check11();
+			IntPtr ptr = CGColorSpaceCreateWithICCProfile (data.GetHandle ());
+			return ptr == IntPtr.Zero ? null : new CGColorSpace (ptr, true);
+		}
 
-			IntPtr ptr;
+		[Introduced (PlatformName.iOS, 10, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 12)]
+		public static CGColorSpace CreateICCData (NSData data)
+		{
+			return CreateICCData (data.GetHandle ());
+		}
 
-			if (use11APIs)
-				ptr = CGColorSpaceCreateWithICCData (data.Handle);
-			else 
-				ptr = CGColorSpaceCreateWithICCProfile (data.Handle);
+		[iOS (10,0)][Mac (10,12)][Watch (3,0)][TV (10,0)]
+		public static CGColorSpace CreateICCData (CGDataProvider provider)
+		{
+			return CreateICCData (provider.GetHandle ());
+		}
+
+		static CGColorSpace CreateICCData (IntPtr handle)
+		{
+			var ptr = CGColorSpaceCreateWithICCData (handle);
 			return ptr == IntPtr.Zero ? null : new CGColorSpace (ptr, true);
 		}
 
@@ -422,17 +422,19 @@ namespace XamCore.CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'GetICCData' instead." )]
+		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'GetICCData' instead." )]
+		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'GetICCData' instead." )]
+		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'GetICCData' instead." )]
 		extern static /* CFDataRef */ IntPtr CGColorSpaceCopyICCProfile (/* CGColorSpaceRef */ IntPtr space);
 
 		[iOS (7,0)] // note: pre-release docs/headers says iOS6 and later, available on OSX since 10.5
+		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'GetICCData' instead." )]
+		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'GetICCData' instead." )]
+		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'GetICCData' instead." )]
+		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'GetICCData' instead." )]
 		public NSData GetICCProfile ()
 		{
-			if (!versionChecked)
-				Check11 ();
-
-			if (use11APIs)
-				return GetIccData ();
-			
 			IntPtr ptr = CGColorSpaceCopyICCProfile (handle);
 			return (ptr == IntPtr.Zero) ? null : new NSData (ptr, true);
 		}

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -350,14 +350,20 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGColorSpaceRef */ IntPtr CGColorSpaceCreateWithICCData (/* CFDataRef */ IntPtr data);
 
+#if MONOMAC || IOS
 		static bool versionChecked, use11APIs;
+#else
+		const bool versionChecked = true;
+		const bool use11APIs = false;
+#endif
+	
 		static void Check11 ()
 		{
 #if MONOMAC || IOS
 			if (PlatformHelper.CheckSystemVersion (11, 0))
 				use11APIs = true;
-#endif
 			versionChecked = true;
+#endif
 		}
 		
 		public static CGColorSpace CreateICCProfile (NSData data)

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -159,9 +159,9 @@ namespace XamCore.CoreGraphics {
 			if (whitepoint == null)
 				throw new ArgumentNullException (nameof (whitepoint));
 			if (whitepoint.Length != 3)
-				throw new ArgumentException ("Must be null or have 3 values", nameof (whitepoint));
+				throw new ArgumentException ("Must have exactly 3 values", nameof (whitepoint));
 			if (blackpoint != null && blackpoint.Length != 3)
-				throw new ArgumentException ("Must be null or have 3 values", nameof (blackpoint));
+				throw new ArgumentException ("Must be null or have exactly 3 values", nameof (blackpoint));
 			
 			var ptr = CGColorSpaceCreateCalibratedGray (whitepoint, blackpoint, gamma);
 			return ptr == IntPtr.Zero ? null : new CGColorSpace (ptr, true);
@@ -176,13 +176,13 @@ namespace XamCore.CoreGraphics {
 			if (whitepoint == null)
 				throw new ArgumentNullException (nameof (whitepoint));
 			if (whitepoint.Length != 3)
-				throw new ArgumentException ("Must have 3 values", nameof (whitepoint));
+				throw new ArgumentException ("Must have exactly 3 values", nameof (whitepoint));
 			if (blackpoint != null && blackpoint.Length != 3)
-				throw new ArgumentException ("Must be null or have 3 values", nameof (blackpoint));
+				throw new ArgumentException ("Must be null or have exactly 3 values", nameof (blackpoint));
 			if (gamma != null && gamma.Length != 3)
-				throw new ArgumentException ("Must be null or have 3 values", nameof (gamma));
+				throw new ArgumentException ("Must be null or have exactly 3 values", nameof (gamma));
 			if (matrix != null && matrix.Length != 9)
-				throw new ArgumentException ("Must be null or have 9 values", nameof (matrix));
+				throw new ArgumentException ("Must be null or have exactly 9 values", nameof (matrix));
 			
 			var ptr = CGColorSpaceCreateCalibratedRGB (whitepoint, blackpoint, gamma, matrix);
 			return ptr == IntPtr.Zero ? null : new CGColorSpace (ptr, true);
@@ -197,11 +197,11 @@ namespace XamCore.CoreGraphics {
 			if (whitepoint == null)
 				throw new ArgumentNullException (nameof (whitepoint));
 			if (whitepoint.Length != 3)
-				throw new ArgumentException ("Must have 3 values", nameof (whitepoint));
+				throw new ArgumentException ("Must have exactly 3 values", nameof (whitepoint));
 			if (blackpoint != null && blackpoint.Length != 3)
-				throw new ArgumentException ("Must be null or have 3 values", nameof (blackpoint));
+				throw new ArgumentException ("Must be null or have exactly 3 values", nameof (blackpoint));
 			if (range != null && range.Length != 4)
-				throw new ArgumentException ("Must be null or have 4 values", nameof (range));
+				throw new ArgumentException ("Must be null or have exactly 4 values", nameof (range));
 
 			var ptr = CGColorSpaceCreateLab (whitepoint, blackpoint, range);
 			return ptr == IntPtr.Zero ? null : new CGColorSpace (ptr, true);

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -381,7 +381,11 @@ namespace XamCore.CoreGraphics {
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'CreateIDCCData' instead.")]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'CreateIDCCData' instead.")]
 		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'CreateIDCCData' instead.")]
+#if XAMCORE_4_0
+		public static CGColorSpace CreateIccProfile (NSData data)
+#else
 		public static CGColorSpace CreateICCProfile (NSData data)
+#endif
 		{
 			IntPtr ptr = CGColorSpaceCreateWithICCProfile (data.GetHandle ());
 			return ptr == IntPtr.Zero ? null : new CGColorSpace (ptr, true);
@@ -389,18 +393,18 @@ namespace XamCore.CoreGraphics {
 
 		[Introduced (PlatformName.iOS, 10, 0)]
 		[Introduced (PlatformName.MacOSX, 10, 12)]
-		public static CGColorSpace CreateICCData (NSData data)
+		public static CGColorSpace CreateIccData (NSData data)
 		{
-			return CreateICCData (data.GetHandle ());
+			return CreateIccData (data.GetHandle ());
 		}
 
 		[iOS (10,0)][Mac (10,12)][Watch (3,0)][TV (10,0)]
-		public static CGColorSpace CreateICCData (CGDataProvider provider)
+		public static CGColorSpace CreateIccData (CGDataProvider provider)
 		{
-			return CreateICCData (provider.GetHandle ());
+			return CreateIccData (provider.GetHandle ());
 		}
 
-		static CGColorSpace CreateICCData (IntPtr handle)
+		static CGColorSpace CreateIccData (IntPtr handle)
 		{
 			var ptr = CGColorSpaceCreateWithICCData (handle);
 			return ptr == IntPtr.Zero ? null : new CGColorSpace (ptr, true);
@@ -412,7 +416,11 @@ namespace XamCore.CoreGraphics {
 			/* CGDataProviderRef __nullable */ IntPtr profile,
 			/* CGColorSpaceRef __nullable */ IntPtr alternate);
 
+#if XAMCORE_4_0
+		public static CGColorSpace CreateIccProfile (nfloat[] range, CGDataProvider profile, CGColorSpace alternate)
+#else
 		public static CGColorSpace CreateICCProfile (nfloat[] range, CGDataProvider profile, CGColorSpace alternate)
+#endif
 		{
 			nint nComponents = range == null ? 0 : range.Length / 2;
 			IntPtr p = profile == null ? IntPtr.Zero : profile.Handle;
@@ -433,7 +441,11 @@ namespace XamCore.CoreGraphics {
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'GetICCData' instead." )]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'GetICCData' instead." )]
 		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'GetICCData' instead." )]
+#if XAMCORE_4_0
+		public NSData GetIccProfile ()
+#else
 		public NSData GetICCProfile ()
+#endif
 		{
 			IntPtr ptr = CGColorSpaceCopyICCProfile (handle);
 			return (ptr == IntPtr.Zero) ? null : new NSData (ptr, true);

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -365,7 +365,7 @@ namespace XamCore.CoreGraphics {
 			CGColorSpaceGetColorTable (handle, table);
 			return table;
 		}
-
+			
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'CreateIDCCData' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'CreateIDCCData' instead.")]

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -1387,6 +1387,6 @@ namespace XamCore.CoreGraphics {
 		AllowsContentCopying        = (1 << 4),
 		AllowsContentAccessibility  = (1 << 5),
 		AllowsCommenting            = (1 << 6),
-		AllowsFormFieldEntry        = (1 << 7) 
+		AllowsFormFieldEntry        = (1 << 7),
 	}
 }

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -579,6 +579,7 @@ namespace XamCore.CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
 		extern static void CGContextResetClip (/* CGContextRef */ IntPtr c);
 
 		[iOS (11,0)]

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -579,6 +579,15 @@ namespace XamCore.CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		extern static void CGContextResetClip (/* CGContextRef */ IntPtr c);
+
+		[iOS (11,0)]
+		public void ResetClip ()
+		{
+			CGContextResetClip (handle);
+		}
+		
+		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextClipToMask (/* CGContextRef */ IntPtr c, CGRect rect, 
 			/* CGImageRef __nullable */ IntPtr mask);
 
@@ -1366,5 +1375,17 @@ namespace XamCore.CoreGraphics {
 			return new CGBitmapContext (Handle, false);
 		}
 #endif // !COREBUILD
+	}
+
+	[iOS(11,0), Mac(10,13)]
+	public enum CGPDFAccessPermissions : uint {
+		AllowsLowQualityPrinting    = (1 << 0),
+		AllowsHighQualityPrinting   = (1 << 1),
+		AllowsDocumentChanges       = (1 << 2),
+		AllowsDocumentAssembly      = (1 << 3),
+		AllowsContentCopying        = (1 << 4),
+		AllowsContentAccessibility  = (1 << 5),
+		AllowsCommenting            = (1 << 6),
+		AllowsFormFieldEntry        = (1 << 7) 
 	}
 }

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -582,7 +582,7 @@ namespace XamCore.CoreGraphics {
 		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
 		extern static void CGContextResetClip (/* CGContextRef */ IntPtr c);
 
-		[iOS (11,0)]
+		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
 		public void ResetClip ()
 		{
 			CGContextResetClip (handle);

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -579,10 +579,10 @@ namespace XamCore.CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
+		[iOS (11,0), Mac(10,13), TV(11,0), Watch(4,0)]
 		extern static void CGContextResetClip (/* CGContextRef */ IntPtr c);
 
-		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
+		[iOS (11,0), Mac(10,13), TV(11,0), Watch(4,0)]
 		public void ResetClip ()
 		{
 			CGContextResetClip (handle);

--- a/src/CoreGraphics/CGContextPDF.cs
+++ b/src/CoreGraphics/CGContextPDF.cs
@@ -126,22 +126,36 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		unsafe extern static /* CGContextRef */ IntPtr CGPDFContextCreate (/* CGDataConsumerRef */ IntPtr consumer, CGRect *mediaBox, /* CFDictionaryRef */ IntPtr auxiliaryInfo);
 
-		public unsafe CGContextPDF (CGDataConsumer dataConsumer, CGRect mediaBox, CGPDFInfo info)
+		unsafe CGContextPDF (CGDataConsumer dataConsumer, CGRect *mediaBox, CGPDFInfo info)
 		{
-			if (dataConsumer == null)
-				throw new ArgumentNullException ("dataConsumer");
-
 			using (var dict = info == null ? null : info.ToDictionary ())
-				Handle = CGPDFContextCreate (dataConsumer.Handle, &mediaBox, dict == null ? IntPtr.Zero : dict.Handle);
+				Handle = CGPDFContextCreate (dataConsumer.GetHandle (), mediaBox, dict.GetHandle ());
+		}
+
+		public unsafe CGContextPDF (CGDataConsumer dataConsumer, CGRect mediaBox, CGPDFInfo info) :
+			this (dataConsumer, &mediaBox, info)
+		{
+		}
+
+		public unsafe CGContextPDF (CGDataConsumer dataConsumer, CGRect mediaBox) :
+			this (dataConsumer, &mediaBox, null)
+		{
+		}
+
+		public unsafe CGContextPDF (CGDataConsumer dataConsumer, CGPDFInfo info) :
+			this (dataConsumer, null, info)
+		{
+		}
+
+		public unsafe CGContextPDF (CGDataConsumer dataConsumer) :
+			this (dataConsumer, null, null)
+		{
 		}
 
 		unsafe CGContextPDF (NSUrl url, CGRect *mediaBox, CGPDFInfo info)
 		{
-			if (url == null)
-				throw new ArgumentNullException ("url");
-
 			using (var dict = info == null ? null : info.ToDictionary ())
-				Handle = CGPDFContextCreateWithURL (url.Handle, mediaBox, dict == null ? IntPtr.Zero : dict.Handle);
+				Handle = CGPDFContextCreateWithURL (url.GetHandle (), mediaBox, dict.GetHandle ());
 		}
 
 		public unsafe CGContextPDF (NSUrl url, CGRect mediaBox, CGPDFInfo info) :

--- a/src/CoreGraphics/CGContextPDF.cs
+++ b/src/CoreGraphics/CGContextPDF.cs
@@ -80,6 +80,7 @@ namespace XamCore.CoreGraphics {
 		public int? EncryptionKeyLength { get; set; }
 		public bool? AllowsPrinting { get; set; }
 		public bool? AllowsCopying { get; set; }
+		public CGPDFAccessPermissions? AccessPermissions { get; set; }
 		//public NSDictionary OutputIntent { get; set; }
 
 		internal override NSMutableDictionary ToDictionary ()
@@ -110,6 +111,8 @@ namespace XamCore.CoreGraphics {
 				ret.LowlevelSetObject (CFBoolean.False.Handle, kCGPDFContextAllowsPrinting);
 			if (AllowsCopying.HasValue && AllowsCopying.Value == false)
 				ret.LowlevelSetObject (CFBoolean.False.Handle, kCGPDFContextAllowsCopying);
+			if (AccessPermissions.HasValue)
+				ret.LowlevelSetObject (NSNumber.FromInt32 ((int) AccessPermissions.Value), kCGPDFContextAccessPermissions);
 			return ret;
 		}
 	}

--- a/src/CoreGraphics/CGPDFDocument.cs
+++ b/src/CoreGraphics/CGPDFDocument.cs
@@ -272,13 +272,14 @@ namespace XamCore.CoreGraphics {
 		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
 		extern static /* CFDictionaryPtry */ IntPtr CGPDFDocumentGetOutline (/* CGPDFDocumentRef */ IntPtr document);
 
-		[iOS (11,0), Mac(10,3)]
+		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
 		public CGPDFOutlineOptions GetOutline ()
 		{
 			var ptr = CGPDFDocumentGetOutline (handle);
 			return new CGPDFOutlineOptions (new NSDictionary (ptr));
 		}
 
+		[iOS(11,0), Mac(10,3)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static CGPDFAccessPermissions CGPDFDocumentGetAccessPermissions (IntPtr document);
 

--- a/src/CoreGraphics/CGPDFDocument.cs
+++ b/src/CoreGraphics/CGPDFDocument.cs
@@ -280,11 +280,11 @@ namespace XamCore.CoreGraphics {
 			return new CGPDFOutlineOptions (Runtime.GetNSObject<NSDictionary> (ptr));
 		}
 
-		[iOS(11,0), Mac(10,3)]
+		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static CGPDFAccessPermissions CGPDFDocumentGetAccessPermissions (IntPtr document);
 
-		[iOS(11,0), Mac(10,3)]
+		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
 		public CGPDFAccessPermissions GetAccessPermissions ()
 		{
 			return CGPDFDocumentGetAccessPermissions (handle);

--- a/src/CoreGraphics/CGPDFDocument.cs
+++ b/src/CoreGraphics/CGPDFDocument.cs
@@ -259,7 +259,7 @@ namespace XamCore.CoreGraphics {
 			return new CGPDFDictionary (CGPDFDocumentGetInfo (handle));
 		}
 
-		[DllImport (Constants.CoreGraphicsLibrary
+		[DllImport (Constants.CoreGraphicsLibrary)]
 		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
 		extern static void CGPDFContextSetOutline (/* CGPDFDocumentRef */ IntPtr document, IntPtr /* dictionary */ outline);
 

--- a/src/CoreGraphics/CGPDFDocument.cs
+++ b/src/CoreGraphics/CGPDFDocument.cs
@@ -263,6 +263,7 @@ namespace XamCore.CoreGraphics {
 		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
 		extern static void CGPDFContextSetOutline (/* CGPDFDocumentRef */ IntPtr document, IntPtr /* dictionary */ outline);
 
+		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
 		public void SetOutline (CGPDFOutlineOptions options)
 		{
 			CGPDFContextSetOutline (handle, options == null ? IntPtr.Zero : options.Dictionary.Handle);
@@ -276,7 +277,7 @@ namespace XamCore.CoreGraphics {
 		public CGPDFOutlineOptions GetOutline ()
 		{
 			var ptr = CGPDFDocumentGetOutline (handle);
-			return new CGPDFOutlineOptions (new NSDictionary (ptr));
+			return new CGPDFOutlineOptions (Runtime.GetNSObject<NSDictionary> (ptr));
 		}
 
 		[iOS(11,0), Mac(10,3)]

--- a/src/CoreGraphics/CGPDFDocument.cs
+++ b/src/CoreGraphics/CGPDFDocument.cs
@@ -259,7 +259,8 @@ namespace XamCore.CoreGraphics {
 			return new CGPDFDictionary (CGPDFDocumentGetInfo (handle));
 		}
 
-		[DllImport (Constants.CoreGraphicsLibrary)]
+		[DllImport (Constants.CoreGraphicsLibrary
+		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
 		extern static void CGPDFContextSetOutline (/* CGPDFDocumentRef */ IntPtr document, IntPtr /* dictionary */ outline);
 
 		public void SetOutline (CGPDFOutlineOptions options)
@@ -268,6 +269,7 @@ namespace XamCore.CoreGraphics {
 		}
 					
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
 		extern static /* CFDictionaryPtry */ IntPtr CGPDFDocumentGetOutline (/* CGPDFDocumentRef */ IntPtr document);
 
 		[iOS (11,0), Mac(10,3)]

--- a/src/CoreGraphics/CGPDFDocument.cs
+++ b/src/CoreGraphics/CGPDFDocument.cs
@@ -258,6 +258,34 @@ namespace XamCore.CoreGraphics {
 		{
 			return new CGPDFDictionary (CGPDFDocumentGetInfo (handle));
 		}
+
+		[DllImport (Constants.CoreGraphicsLibrary)]
+		extern static void CGPDFContextSetOutline (/* CGPDFDocumentRef */ IntPtr document, IntPtr /* dictionary */ outline);
+
+		public void SetOutline (CGPDFOutlineOptions options)
+		{
+			CGPDFContextSetOutline (handle, options == null ? IntPtr.Zero : options.Dictionary.Handle);
+		}
+					
+		[DllImport (Constants.CoreGraphicsLibrary)]
+		extern static /* CFDictionaryPtry */ IntPtr CGPDFDocumentGetOutline (/* CGPDFDocumentRef */ IntPtr document);
+
+		[iOS (11,0), Mac(10,3)]
+		public CGPDFOutlineOptions GetOutline ()
+		{
+			var ptr = CGPDFDocumentGetOutline (handle);
+			return new CGPDFOutlineOptions (new NSDictionary (ptr));
+		}
+
+		[DllImport (Constants.CoreGraphicsLibrary)]
+		extern static CGPDFAccessPermissions CGPDFDocumentGetAccessPermissions (IntPtr document);
+
+		[iOS(11,0), Mac(10,3)]
+		public CGPDFAccessPermissions GetAccessPermissions ()
+		{
+			return CGPDFDocumentGetAccessPermissions (handle);
+		}
+		
 #endif // !COREBUILD
 	}
 }

--- a/src/CoreGraphics/CGPDFDocument.cs
+++ b/src/CoreGraphics/CGPDFDocument.cs
@@ -260,31 +260,31 @@ namespace XamCore.CoreGraphics {
 		}
 
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
+		[iOS (11,0), Mac(10,13), TV(11,0), Watch(4,0)]
 		extern static void CGPDFContextSetOutline (/* CGPDFDocumentRef */ IntPtr document, IntPtr /* dictionary */ outline);
 
-		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
+		[iOS (11,0), Mac(10,13), TV(11,0), Watch(4,0)]
 		public void SetOutline (CGPDFOutlineOptions options)
 		{
 			CGPDFContextSetOutline (handle, options == null ? IntPtr.Zero : options.Dictionary.Handle);
 		}
 					
 		[DllImport (Constants.CoreGraphicsLibrary)]
-		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
+		[iOS (11,0), Mac(10,13), TV(11,0), Watch(4,0)]
 		extern static /* CFDictionaryPtry */ IntPtr CGPDFDocumentGetOutline (/* CGPDFDocumentRef */ IntPtr document);
 
-		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
+		[iOS (11,0), Mac(10,13), TV(11,0), Watch(4,0)]
 		public CGPDFOutlineOptions GetOutline ()
 		{
 			var ptr = CGPDFDocumentGetOutline (handle);
 			return new CGPDFOutlineOptions (Runtime.GetNSObject<NSDictionary> (ptr));
 		}
 
-		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
+		[iOS (11,0), Mac(10,13), TV(11,0), Watch(4,0)]
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static CGPDFAccessPermissions CGPDFDocumentGetAccessPermissions (IntPtr document);
 
-		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
+		[iOS (11,0), Mac(10,13), TV(11,0), Watch(4,0)]
 		public CGPDFAccessPermissions GetAccessPermissions ()
 		{
 			return CGPDFDocumentGetAccessPermissions (handle);

--- a/src/CoreGraphics/CGPath.cs
+++ b/src/CoreGraphics/CGPath.cs
@@ -700,6 +700,7 @@ namespace XamCore.CoreGraphics {
 
 #if !COREBUILD
 		[DllImport (Constants.CoreGraphicsLibrary)]
+		[Mac(10,13)][iOS (11,0)]
 		unsafe extern static void CGPathApplyWithBlock (IntPtr handle, BlockLiteral *blockEnumerator);
 
 		static PathApplyProxy static_apply;
@@ -719,6 +720,7 @@ namespace XamCore.CoreGraphics {
 			}
 		}
 		
+		[Mac(10,13)][iOS (11,0)]
 		public void Apply (Action<CGPathElement> block)
 		{
 			if (block == null)

--- a/src/CoreGraphics/CGPath.cs
+++ b/src/CoreGraphics/CGPath.cs
@@ -697,46 +697,5 @@ namespace XamCore.CoreGraphics {
 		{
 			CGPathAddRoundedRect (handle, null, rect, cornerWidth, cornerHeight);
 		}
-
-#if !COREBUILD
-		[DllImport (Constants.CoreGraphicsLibrary)]
-		[Mac(10,13)][iOS (11,0)]
-		unsafe extern static void CGPathApplyWithBlock (IntPtr handle, BlockLiteral *blockEnumerator);
-
-		static PathApplyProxy static_apply;
-
-		delegate void PathApplyProxy (IntPtr block, IntPtr element);
-
-		[MonoPInvokeCallback (typeof (PathApplyProxy))]
-		static unsafe void TrampolineApply (IntPtr blockPtr, IntPtr _element)
-		{
-			var block = (BlockLiteral *) blockPtr;
-			var del = (Action<CGPathElement>) (block->Target);
-			if (del != null){
-				unsafe {
-					CGPathElement element = *((CGPathElement *) _element);
-					del (element);
-				}
-			}
-		}
-		
-		[Mac(10,13)][iOS (11,0)]
-		public void Apply (Action<CGPathElement> block)
-		{
-			if (block == null)
-				throw new ArgumentNullException (nameof (block));
-			unsafe {
-				BlockLiteral *block_ptr_handler;
-				BlockLiteral block_handler;
-				block_handler = new BlockLiteral ();
-				block_ptr_handler = &block_handler;
-				static_apply = TrampolineApply;
-				block_handler.SetupBlock (static_apply, block);
-
-				CGPathApplyWithBlock (handle, block_ptr_handler);
-				block_ptr_handler->CleanupBlock ();
-			}
-		}
-#endif
 	}
 }

--- a/src/CoreGraphics/CGPath.cs
+++ b/src/CoreGraphics/CGPath.cs
@@ -702,38 +702,38 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		unsafe extern static void CGPathApplyWithBlock (IntPtr handle, BlockLiteral *blockEnumerator);
 
-                static PathApplyProxy static_apply;
+		static PathApplyProxy static_apply;
 
-                delegate void PathApplyProxy (IntPtr block, IntPtr element);
+		delegate void PathApplyProxy (IntPtr block, IntPtr element);
 
-                [MonoPInvokeCallback (typeof (PathApplyProxy))]
+		[MonoPInvokeCallback (typeof (PathApplyProxy))]
 		static unsafe void TrampolineApply (IntPtr blockPtr, IntPtr _element)
-                {
-                        var block = (BlockLiteral *) blockPtr;
-                        var del = (Action<CGPathElement>) (block->Target);
-                        if (del != null){
+		{
+			var block = (BlockLiteral *) blockPtr;
+			var del = (Action<CGPathElement>) (block->Target);
+			if (del != null){
 				unsafe {
 					CGPathElement element = *((CGPathElement *) _element);
 					del (element);
 				}
 			}
-                }
+		}
 		
 		public void Apply (Action<CGPathElement> block)
 		{
 			if (block == null)
 				throw new ArgumentNullException (nameof (block));
 			unsafe {
-                                BlockLiteral *block_ptr_handler;
-                                BlockLiteral block_handler;
-                                block_handler = new BlockLiteral ();
-                                block_ptr_handler = &block_handler;
+				BlockLiteral *block_ptr_handler;
+				BlockLiteral block_handler;
+				block_handler = new BlockLiteral ();
+				block_ptr_handler = &block_handler;
 				static_apply = TrampolineApply;
-                                block_handler.SetupBlock (static_apply, block);
+				block_handler.SetupBlock (static_apply, block);
 
-                                CGPathApplyWithBlock (handle, block_ptr_handler);
-                                block_ptr_handler->CleanupBlock ();
-                        }
+				CGPathApplyWithBlock (handle, block_ptr_handler);
+				block_ptr_handler->CleanupBlock ();
+			}
 		}
 #endif
 	}

--- a/src/CoreGraphics/CGPath.cs
+++ b/src/CoreGraphics/CGPath.cs
@@ -697,5 +697,44 @@ namespace XamCore.CoreGraphics {
 		{
 			CGPathAddRoundedRect (handle, null, rect, cornerWidth, cornerHeight);
 		}
+
+#if !COREBUILD
+		[DllImport (Constants.CoreGraphicsLibrary)]
+		unsafe extern static void CGPathApplyWithBlock (IntPtr handle, BlockLiteral *blockEnumerator);
+
+                static PathApplyProxy static_apply;
+
+                delegate void PathApplyProxy (IntPtr block, IntPtr element);
+
+                [MonoPInvokeCallback (typeof (PathApplyProxy))]
+		static unsafe void TrampolineApply (IntPtr blockPtr, IntPtr _element)
+                {
+                        var block = (BlockLiteral *) blockPtr;
+                        var del = (Action<CGPathElement>) (block->Target);
+                        if (del != null){
+				unsafe {
+					CGPathElement element = *((CGPathElement *) _element);
+					del (element);
+				}
+			}
+                }
+		
+		public void Apply (Action<CGPathElement> block)
+		{
+			if (block == null)
+				throw new ArgumentNullException (nameof (block));
+			unsafe {
+                                BlockLiteral *block_ptr_handler;
+                                BlockLiteral block_handler;
+                                block_handler = new BlockLiteral ();
+                                block_ptr_handler = &block_handler;
+				static_apply = TrampolineApply;
+                                block_handler.SetupBlock (static_apply, block);
+
+                                CGPathApplyWithBlock (handle, block_ptr_handler);
+                                block_ptr_handler->CleanupBlock ();
+                        }
+		}
+#endif
 	}
 }

--- a/src/coregraphics.cs
+++ b/src/coregraphics.cs
@@ -212,6 +212,7 @@ namespace XamCore.CoreGraphics {
 #endif
 	}
 
+	[iOS(11,0), Mac(10,13)]
 	[Static]
 	[Internal]
 	public interface CGPDFOutlineKeys {

--- a/src/coregraphics.cs
+++ b/src/coregraphics.cs
@@ -199,7 +199,7 @@ namespace XamCore.CoreGraphics {
 		[Internal]
 		[Field ("kCGColorConversionTRCSize")]
 		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
-		NSString TrcSize { get; }
+		NSString TrcSizeKey { get; }
 #endif
 	}
 
@@ -207,7 +207,9 @@ namespace XamCore.CoreGraphics {
 	[StrongDictionary ("CGColorConversionInfo")]
 	interface CGColorConversionOptions {
 		bool BlackPointCompensation { get; set; }
-		//CGSize TrcSize { get; set; }
+#if XAMCORE_2_0
+		CGSize TrcSize { get; set; }
+#endif
 	}
 
 	[Static]

--- a/src/coregraphics.cs
+++ b/src/coregraphics.cs
@@ -72,6 +72,10 @@ namespace XamCore.CoreGraphics {
 		kCGPDFXDestinationOutputProfile;
 		kCGPDFContextOutputIntents;
 #endif
+
+		[Mac (10,13)][iOS (11,0)][TV (11,0)][Watch (4,0)]
+		[Internal][Field ("kCGPDFContextAccessPermissions")]
+		IntPtr kCGPDFContextAccessPermissions { get; }
 	}
 
 	[Static]
@@ -250,6 +254,5 @@ namespace XamCore.CoreGraphics {
 #if XAMCORE_2_0
 		CGRect DestinationRect { get; set; }
 #endif
-		CGPDFAccessPermissions AccessPermissions { get; set; }
 	}
 }

--- a/src/coregraphics.cs
+++ b/src/coregraphics.cs
@@ -186,6 +186,10 @@ namespace XamCore.CoreGraphics {
 		[Field ("kCGColorSpaceGenericRGBLinear")]
 		NSString GenericRGBLinear { get; }
 #endif
+
+		[iOS (11,0)][Mac (10,13)][Watch (4,0)][TV (11,0)]
+		[Field ("kCGColorSpaceGenericLab")]
+		NSString GenericLab { get; }
 	}
 
 	[Partial]

--- a/src/coregraphics.cs
+++ b/src/coregraphics.cs
@@ -194,11 +194,52 @@ namespace XamCore.CoreGraphics {
 		[Internal]
 		[Field ("kCGColorConversionBlackPointCompensation")]
 		NSString BlackPointCompensationKey { get; }
+
+		[Internal]
+		[Field ("kCGColorConversionTRCSize")]
+		NSString TrcSize { get; }
 	}
 
 	[iOS (10,0)][TV (10,0)][Watch (3,0)][Mac (10,12)]
 	[StrongDictionary ("CGColorConversionInfo")]
 	interface CGColorConversionOptions {
 		bool BlackPointCompensation { get; set; }
+		//CGSize TrcSize { get; set; }
+	}
+
+	[Static]
+	[Internal]
+	public interface CGPDFOutlineKeys {
+		[Internal]
+		[Field ("kCGPDFOutlineTitle")]
+		NSString OutlineTitleKey { get; }
+
+		[Internal]
+		[Field ("kCGPDFOutlineChildren")]
+		NSString OutlineChildrenKey { get; }
+
+		[Internal]
+		[Field ("kCGPDFOutlineDestination")]
+		NSString OutlineDestinationKey { get;}
+
+		[Internal]
+		[Field ("kCGPDFOutlineDestinationRect")]
+		NSString DestinationRectKey { get; }
+
+		[Internal]
+		[Field ("kCGPDFContextAccessPermissions")]
+		NSString AccessPermissionsKey { get; }
+	}
+	
+	[iOS(11,0), Mac(10,13)]
+	[StrongDictionary ("CGPDFOutlineKeys")]
+	interface CGPDFOutlineOptions {
+		string OutlineTitle { get; set; }
+		NSDictionary [] OutlineChildren { get; set; }
+		NSObject OutlineDestination { get; set; }
+#if XAMCORE_2_0
+		CGRect DestinationRect { get; set; }
+#endif
+		CGPDFAccessPermissions AccessPermissions { get; set; }
 	}
 }

--- a/src/coregraphics.cs
+++ b/src/coregraphics.cs
@@ -197,6 +197,7 @@ namespace XamCore.CoreGraphics {
 
 		[Internal]
 		[Field ("kCGColorConversionTRCSize")]
+		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
 		NSString TrcSize { get; }
 	}
 

--- a/src/coregraphics.cs
+++ b/src/coregraphics.cs
@@ -195,10 +195,12 @@ namespace XamCore.CoreGraphics {
 		[Field ("kCGColorConversionBlackPointCompensation")]
 		NSString BlackPointCompensationKey { get; }
 
+#if XAMCORE_2_0
 		[Internal]
 		[Field ("kCGColorConversionTRCSize")]
 		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
 		NSString TrcSize { get; }
+#endif
 	}
 
 	[iOS (10,0)][TV (10,0)][Watch (3,0)][Mac (10,12)]

--- a/src/coregraphics.cs
+++ b/src/coregraphics.cs
@@ -206,7 +206,7 @@ namespace XamCore.CoreGraphics {
 #if XAMCORE_2_0
 		[Internal]
 		[Field ("kCGColorConversionTRCSize")]
-		[iOS (11,0), Mac(10,3), TV(11,0), Watch(4,0)]
+		[iOS (11,0), Mac(10,13), TV(11,0), Watch(4,0)]
 		NSString TrcSizeKey { get; }
 #endif
 	}

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -406,6 +406,7 @@ namespace Introspection
 			"Tlv",
 			"Toi",
 			"Transceive",
+			"Trc",
 			"Truncantion",
 			"Tweening",
 			"tx",

--- a/tests/monotouch-test/CoreGraphics/ColorSpaceTest.cs
+++ b/tests/monotouch-test/CoreGraphics/ColorSpaceTest.cs
@@ -242,24 +242,24 @@ namespace MonoTouchFixtures.CoreGraphics {
 		}
 
 		[Test]
-		public void CreateICCData ()
+		public void CreateIccData ()
 		{
 			using (var icc = NSData.FromFile (Path.Combine (NSBundle.MainBundle.ResourcePath, "LL-171A-B-B797E457-16AB-C708-1E0F-32C19DBD47B5.icc"))) {
-				using (var cs = CGColorSpace.CreateICCData (icc)) {
+				using (var cs = CGColorSpace.CreateIccData (icc)) {
 					TestICC (cs);
 				}
 				using (var provider = new CGDataProvider (icc)) {
-					using (var cs = CGColorSpace.CreateICCData (provider)) {
+					using (var cs = CGColorSpace.CreateIccData (provider)) {
 						TestICC (cs);
 					}
 				}
 			}
 
-			using (var space = CGColorSpace.CreateICCData ((NSData) null)) {
+			using (var space = CGColorSpace.CreateIccData ((NSData) null)) {
 				Assert.IsNull (space, "null data");
 			}
 
-			using (var space = CGColorSpace.CreateICCData ((CGDataProvider) null)) {
+			using (var space = CGColorSpace.CreateIccData ((CGDataProvider) null)) {
 				Assert.IsNull (space, "null data provider");
 			}
 		}

--- a/tests/monotouch-test/CoreGraphics/ContextTest.cs
+++ b/tests/monotouch-test/CoreGraphics/ContextTest.cs
@@ -58,6 +58,8 @@ namespace MonoTouchFixtures.CoreGraphics {
 		[Test]
 		public void ResetClip ()
 		{
+			TestRuntime.AssertXcodeVersion (9, 0);
+
 			// Merely tests that the P/Invoke is correct
 			using (var c = Create ()) {
 				var original = c.GetClipBoundingBox ();

--- a/tests/monotouch-test/CoreGraphics/ContextTest.cs
+++ b/tests/monotouch-test/CoreGraphics/ContextTest.cs
@@ -63,9 +63,9 @@ namespace MonoTouchFixtures.CoreGraphics {
 				var original = c.GetClipBoundingBox ();
 				var rect = new CGRect (0, 0, 2, 2);
 				c.ClipToRect (rect);
-				Assert.Equals (rect, c.GetClipBoundingBox ());
+				Assert.That (rect, Is.EqualTo (c.GetClipBoundingBox ()));
 				c.ResetClip ();
-				Assert.Equals (original, c.GetClipBoundingBox ());
+				Assert.That (original, Is.EqualTo (c.GetClipBoundingBox ()));
 			}
 		}
 	}

--- a/tests/monotouch-test/CoreGraphics/ContextTest.cs
+++ b/tests/monotouch-test/CoreGraphics/ContextTest.cs
@@ -54,5 +54,19 @@ namespace MonoTouchFixtures.CoreGraphics {
 				Assert.Throws<ArgumentException> (delegate { c.SetLineDash (6.0f, lengths, Int32.MaxValue); }, "max");
 			}
 		}
+
+		[Test]
+		public void ResetClip ()
+		{
+			// Merely tests that the P/Invoke is correct
+			using (var c = Create ()) {
+				var original = c.GetClipBoundingBox ();
+				var rect = new CGRect (0, 0, 2, 2);
+				c.ClipToRect (rect);
+				Assert.Equals (rect, c.GetClipBoundingBox ());
+				c.ResetClip ();
+				Assert.Equals (original, c.GetClipBoundingBox ());
+			}
+		}
 	}
 }

--- a/tests/monotouch-test/CoreGraphics/PDFContextTest.cs
+++ b/tests/monotouch-test/CoreGraphics/PDFContextTest.cs
@@ -74,5 +74,26 @@ namespace MonoTouchFixtures.CoreGraphics {
 				ctx.Close ();
 			}
 		}
+
+		[Test]
+		public void Constructors ()
+		{
+			Assert.Throws<Exception> (() => new CGContextPDF ((CGDataConsumer) null), "null CGDataConsumer");
+
+			Assert.Throws<Exception> (() => new CGContextPDF ((CGDataConsumer) null, RectangleF.Empty), "null CGDataConsumer, Empty");
+
+			Assert.Throws<Exception> (() => new CGContextPDF ((CGDataConsumer) null, RectangleF.Empty, null), "null CGDataConsumer, Empty, null");
+
+			Assert.Throws<Exception> (() => new CGContextPDF ((CGDataConsumer) null, null), "null CGDataConsumer, null");
+
+			Assert.Throws<Exception> (() => new CGContextPDF ((NSUrl) null), "null NSUrl");
+
+			Assert.Throws<Exception> (() => new CGContextPDF ((NSUrl) null, RectangleF.Empty), "null NSUrl, Empty");
+
+			Assert.Throws<Exception> (() => new CGContextPDF ((NSUrl) null, RectangleF.Empty, null), "null NSUrl, Empty, null");
+
+			Assert.Throws<Exception> (() => new CGContextPDF ((NSUrl) null, null), "null NSUrl, null");
+
+		}
 	}
 }

--- a/tests/monotouch-test/CoreGraphics/PDFDocumentTest.cs
+++ b/tests/monotouch-test/CoreGraphics/PDFDocumentTest.cs
@@ -58,7 +58,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 				CheckTamarin (doc);
 			}
 		}
-		
+
 		void CheckTamarin (CGPDFDocument pdf)
 		{
 			Assert.True (pdf.AllowsCopying, "AllowsCopying");
@@ -68,6 +68,14 @@ namespace MonoTouchFixtures.CoreGraphics {
 			Assert.That (pdf.Pages, Is.EqualTo ((nint) 3), "Pages");
 
 			Assert.That (pdf.GetInfo ().Count, Is.EqualTo (7), "GetInfo");
+
+			// Merely check that the P/Invoke goes through.
+			var perms = pdf.GetAccessPermissions ();
+
+			// Get and set outline
+			var outline = pdf.GetOutline ();
+			pdf.SetOutline (outline);
+
 		}
 	}
 }

--- a/tests/monotouch-test/CoreGraphics/PDFDocumentTest.cs
+++ b/tests/monotouch-test/CoreGraphics/PDFDocumentTest.cs
@@ -69,12 +69,14 @@ namespace MonoTouchFixtures.CoreGraphics {
 
 			Assert.That (pdf.GetInfo ().Count, Is.EqualTo (7), "GetInfo");
 
-			// Merely check that the P/Invoke goes through.
-			var perms = pdf.GetAccessPermissions ();
+			if (TestRuntime.CheckXcodeVersion (9, 0)) {
+				// Merely check that the P/Invoke goes through.
+				var perms = pdf.GetAccessPermissions ();
 
-			// Get and set outline
-			var outline = pdf.GetOutline ();
-			pdf.SetOutline (outline);
+				// Get and set outline
+				var outline = pdf.GetOutline ();
+				pdf.SetOutline (outline);
+			}
 
 		}
 	}

--- a/tests/monotouch-test/CoreGraphics/PDFDocumentTest.cs
+++ b/tests/monotouch-test/CoreGraphics/PDFDocumentTest.cs
@@ -58,7 +58,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 				CheckTamarin (doc);
 			}
 		}
-
+		
 		void CheckTamarin (CGPDFDocument pdf)
 		{
 			Assert.True (pdf.AllowsCopying, "AllowsCopying");

--- a/tests/monotouch-test/CoreGraphics/PDFInfoTest.cs
+++ b/tests/monotouch-test/CoreGraphics/PDFInfoTest.cs
@@ -65,6 +65,28 @@ namespace MonoTouchFixtures.CoreGraphics {
 			var info = GetInfo ();
 			UIGraphics.BeginPDFContext("file", RectangleF.Empty, info); 
 		}
+
+		[Test]
+		public void ToDictionaryWithPermissions ()
+		{
+			TestRuntime.AssertXcodeVersion (9, 0);
+
+			var filename = Environment.GetFolderPath (Environment.SpecialFolder.CommonDocuments) + "/t.pdf";
+
+			var info = GetInfo ();
+			info.AccessPermissions = CGPDFAccessPermissions.AllowsContentCopying;
+
+			using (var url = new NSUrl (filename)) {
+				using (var ctx = new CGContextPDF (url, new RectangleF (0, 0, 1000, 1000), info)) {
+					Assert.IsNotNull (ctx, "1");
+				}
+				using (var consumer = new CGDataConsumer (url)) {
+					using (var ctx = new CGContextPDF (consumer, new RectangleF (0, 0, 1000, 1000), info)) {
+						Assert.IsNotNull (ctx, "2ppdf");
+					}
+				}
+			}
+		}
 #endif
 	}
 }

--- a/tests/monotouch-test/CoreGraphics/PDFInfoTest.cs
+++ b/tests/monotouch-test/CoreGraphics/PDFInfoTest.cs
@@ -82,7 +82,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 				}
 				using (var consumer = new CGDataConsumer (url)) {
 					using (var ctx = new CGContextPDF (consumer, new RectangleF (0, 0, 1000, 1000), info)) {
-						Assert.IsNotNull (ctx, "2ppdf");
+						Assert.IsNotNull (ctx, "2");
 					}
 				}
 			}

--- a/tests/xtro-sharpie/common.ignore
+++ b/tests/xtro-sharpie/common.ignore
@@ -50,6 +50,8 @@
 ## deprecated (as the name indicates) and not exposed
 !missing-enum! CGGlyphDeprecatedEnum not bound
 
+## there's another P/Invoke that returns the same result according to the documentation (CGColorSpaceCopyName), so no need to bind another one.
+!missing-pinvoke! CGColorSpaceGetName is not bound
 
 # CoreSpotlight
 


### PR DESCRIPTION
There are no CoreGraphics changes in Xcode 9.1 beta 1; with this the
CoreGraphics bindings are up-to-date.

These changes were first started in PR #2181.