### PR TITLE
Change BlockLiteral.SetupBlock to keep a reference to the delegate passed as the trampoline.

### DIFF
--- a/src/AddressBook/ABAddressBook.cs
+++ b/src/AddressBook/ABAddressBook.cs
@@ -216,7 +216,7 @@ namespace XamCore.AddressBook {
 				BlockLiteral block_handler;
 				block_handler = new BlockLiteral ();
 				block_ptr_handler = &block_handler;
-				block_handler.SetupBlock (static_completionHandler, onCompleted);
+				block_handler.SetupBlockUnsafe (static_completionHandler, onCompleted);
 
 				ABAddressBookRequestAccessWithCompletion (Handle, (void*) block_ptr_handler);
 				block_ptr_handler->CleanupBlock ();

--- a/src/AudioToolbox/SystemSound.cs
+++ b/src/AudioToolbox/SystemSound.cs
@@ -204,7 +204,7 @@ namespace XamCore.AudioToolbox {
 				BlockLiteral block_handler;
 				block_handler = new BlockLiteral ();
 				block_ptr_handler = &block_handler;
-				block_handler.SetupBlock (static_action, onCompletion);
+				block_handler.SetupBlockUnsafe (static_action, onCompletion);
 
 				AudioServicesPlayAlertSoundWithCompletion (soundId, block_ptr_handler);
 
@@ -235,7 +235,7 @@ namespace XamCore.AudioToolbox {
 				BlockLiteral block_handler;
 				block_handler = new BlockLiteral ();
 				block_ptr_handler = &block_handler;
-				block_handler.SetupBlock (static_action, onCompletion);
+				block_handler.SetupBlockUnsafe (static_action, onCompletion);
 
 				AudioServicesPlaySystemSoundWithCompletion (soundId, block_ptr_handler);
 

--- a/src/CoreFoundation/DispatchBlock.cs
+++ b/src/CoreFoundation/DispatchBlock.cs
@@ -28,7 +28,7 @@ namespace XamCore.CoreFoundation {
 			block = new BlockLiteral ();
 			block_ptr = &block;
 
-			block.SetupBlock (Trampolines.SDAction.Handler, codeToRun);
+			block.SetupBlockUnsafe (Trampolines.SDAction.Handler, codeToRun);
 			invoker ((IntPtr) block_ptr);
 			block_ptr->CleanupBlock ();
 		}

--- a/src/CoreText/CTLine.cs
+++ b/src/CoreText/CTLine.cs
@@ -260,7 +260,7 @@ namespace XamCore.CoreText {
                                 BlockLiteral block_handler;
                                 block_handler = new BlockLiteral ();
                                 block_ptr_handler = &block_handler;
-                                block_handler.SetupBlock (static_enumerate, enumerator);
+                                block_handler.SetupBlockUnsafe (static_enumerate, enumerator);
 
                                 CTLineEnumerateCaretOffsets (handle, block_ptr_handler);
                                 block_ptr_handler->CleanupBlock ();

--- a/src/Metal/MTLDevice.cs
+++ b/src/Metal/MTLDevice.cs
@@ -77,7 +77,7 @@ namespace XamCore.Metal {
 				BlockLiteral block_handler;
 				block_handler = new BlockLiteral ();
 				block_ptr_handler = &block_handler;
-				block_handler.SetupBlock (static_notificationHandler, handler);
+				block_handler.SetupBlockUnsafe (static_notificationHandler, handler);
 
 				var rv = MTLCopyAllDevicesWithObserver (ref handle, (void*) block_ptr_handler);
 				var obj = NSArray.ArrayFromHandle<IMTLDevice> (rv);

--- a/src/Security/SecSharedCredential.cs
+++ b/src/Security/SecSharedCredential.cs
@@ -47,7 +47,7 @@ namespace XamCore.Security {
 				BlockLiteral block_onComplete;
 				block_onComplete = new BlockLiteral ();
 				block_ptr_onComplete = &block_onComplete;
-				block_onComplete.SetupBlock (ActionTrampoline.Handler, handler);
+				block_onComplete.SetupBlockUnsafe (ActionTrampoline.Handler, handler);
 
 				using (var nsDomain = new NSString (domainName))
 				using (var nsAccount = new NSString (account)) {
@@ -101,7 +101,7 @@ namespace XamCore.Security {
 				BlockLiteral block_onComplete;
 				block_onComplete = new BlockLiteral ();
 				block_ptr_onComplete = &block_onComplete;
-				block_onComplete.SetupBlock (ArrayErrorActionTrampoline.Handler, onComplete);
+				block_onComplete.SetupBlockUnsafe (ArrayErrorActionTrampoline.Handler, onComplete);
 
 				NSString nsDomain = null;
 				if (domainName != null)

--- a/src/VideoToolbox/VTCompressionSession.cs
+++ b/src/VideoToolbox/VTCompressionSession.cs
@@ -277,7 +277,7 @@ namespace XamCore.VideoToolbox {
 			unsafe {
 				var block = new BlockLiteral ();
 				var blockPtr = &block;
-				block.SetupBlock (compressionOutputHandlerTrampoline, outputHandler);
+				block.SetupBlockUnsafe (compressionOutputHandlerTrampoline, outputHandler);
 
 				try {
 					return VTCompressionSessionEncodeFrameWithOutputHandler (Handle,

--- a/src/VideoToolbox/VTDecompressionSession.cs
+++ b/src/VideoToolbox/VTDecompressionSession.cs
@@ -269,7 +269,7 @@ namespace XamCore.VideoToolbox {
 			unsafe {
 				var block = new BlockLiteral ();
 				var blockPtr = &block;
-				block.SetupBlock (decompressionOutputHandlerTrampoline, outputHandler);
+				block.SetupBlockUnsafe (decompressionOutputHandlerTrampoline, outputHandler);
 
 				try {
 					return VTDecompressionSessionDecodeFrameWithOutputHandler (Handle,

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3924,7 +3924,7 @@ public partial class Generator : IMemberGatherer {
 				}
 				convs.AppendFormat (extra + "block_{0} = new BlockLiteral ();\n", pi.Name);
 				convs.AppendFormat (extra + "block_ptr_{0} = &block_{0};\n", pi.Name);
-				convs.AppendFormat (extra + "block_{0}.SetupBlock (Trampolines.{1}.Handler, {2});\n", pi.Name, trampoline_name, pi.Name.GetSafeParamName ());
+				convs.AppendFormat (extra + "block_{0}.SetupBlockUnsafe (Trampolines.{1}.Handler, {2});\n", pi.Name, trampoline_name, pi.Name.GetSafeParamName ());
 				if (null_allowed)
 					convs.AppendFormat ("}}\n");
 

--- a/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
@@ -71,5 +71,43 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				class_addMethod (cls, Selector.GetHandle ("testBlocks:"), imp, "v@:^v");
 			}
 		}
+
+		// No MonoPInvokeCallback
+		static void InvalidTrampoline1 () { }
+
+		// Wrong delegate signature in MonoPInvokeCallback
+		[MonoPInvokeCallback (typeof (Action<IntPtr>))]
+		static void InvalidTrampoline2 () { }
+
+		// Wrong delegate signature in MonoPInvokeCallback
+		[MonoPInvokeCallback (typeof (Func<IntPtr>))]
+		static void InvalidTrampoline3 () { }
+
+		// Wrong delegate signature in MonoPInvokeCallback
+		[MonoPInvokeCallback (typeof (Action<IntPtr>))]
+		static void InvalidTrampoline4 (int x) { }
+
+		// Wrong delegate signature in MonoPInvokeCallback
+		[MonoPInvokeCallback (typeof (Func<IntPtr>))]
+		static int InvalidTrampoline5 () { return 0;  }
+
+		[Test]
+		public void InvalidBlockTrampolines ()
+		{
+			BlockLiteral block = new BlockLiteral ();
+			Action userDelegate = new Action (() => Console.WriteLine ("Hello world!"));
+
+			Assert.Throws<ArgumentNullException> (() => block.SetupBlock (null, userDelegate), "null trampoline");
+
+			if (Runtime.Arch == Arch.SIMULATOR) {
+				// These checks only occur in the simulator
+				Assert.Throws<ArgumentException> (() => block.SetupBlock ((Action) InvalidBlockTrampolines, userDelegate), "instance trampoline");
+				Assert.Throws<ArgumentException> (() => block.SetupBlock ((Action) InvalidTrampoline1, userDelegate), "invalid trampoline 1");
+				Assert.Throws<ArgumentException> (() => block.SetupBlock ((Action) InvalidTrampoline2, userDelegate), "invalid trampoline 2");
+				Assert.Throws<ArgumentException> (() => block.SetupBlock ((Action) InvalidTrampoline3, userDelegate), "invalid trampoline 3");
+				Assert.Throws<ArgumentException> (() => block.SetupBlock ((Action<int>) InvalidTrampoline4, userDelegate), "invalid trampoline 4");
+				Assert.Throws<ArgumentException> (() => block.SetupBlock ((Func<int>) InvalidTrampoline5, userDelegate), "invalid trampoline 5");
+			}
+		}
 	}
 }

--- a/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
@@ -99,6 +99,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 			Assert.Throws<ArgumentNullException> (() => block.SetupBlock (null, userDelegate), "null trampoline");
 
+#if !MONOMAC
 			if (Runtime.Arch == Arch.SIMULATOR) {
 				// These checks only occur in the simulator
 				Assert.Throws<ArgumentException> (() => block.SetupBlock ((Action) InvalidBlockTrampolines, userDelegate), "instance trampoline");
@@ -108,6 +109,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				Assert.Throws<ArgumentException> (() => block.SetupBlock ((Action<int>) InvalidTrampoline4, userDelegate), "invalid trampoline 4");
 				Assert.Throws<ArgumentException> (() => block.SetupBlock ((Func<int>) InvalidTrampoline5, userDelegate), "invalid trampoline 5");
 			}
+#endif
 		}
 	}
 }


### PR DESCRIPTION
* Change BlockLiteral.SetupBlock to keep a reference to the delegate passed as
  the trampoline.

  Change BlockLiteral.SetupBlock to keep a reference to the delegate passed as
  the trampoline, so that it's safer for normal users (crashes due to
  incorrect usage are rare and random, and as such they're also hard to track
  down).

  Additionally introduce a BlockLiteral.SetupBlockUnsafe method, that still
  has the old behavior, so that we can use it in our own (reviewed) code.

* [ObjCRuntime] Add some validation to BlockLiteral.SetupBlock.

* Use BlockLiteral.SetupBlockUnsafe instead of .SetupBlock

  Use SetupBlockUnsafe in our own code, because we know our own code is using
  it correctly (by passing a trampoline stored in a static field, so that the
  GC doesn't free it).