### PR TITLE
[xharness] Don't freak out if we find a device we can't categorize.

### DIFF
--- a/tests/xharness/Simulators.cs
+++ b/tests/xharness/Simulators.cs
@@ -580,6 +580,7 @@ namespace xharness
 
 	public enum DevicePlatform
 	{
+		Unknown,
 		iOS,
 		tvOS,
 		watchOS,
@@ -610,7 +611,7 @@ namespace xharness
 				case "Watch":
 					return DevicePlatform.watchOS;
 				default:
-					throw new NotImplementedException ();
+					return DevicePlatform.Unknown;
 				}
 			}
 		}


### PR DESCRIPTION
It's most likely just an untrusted device (in which case DeviceClass will be
an empty string).