### PR TITLE
[xharness] Timestamp install logs.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -2823,6 +2823,7 @@ function oninitialload ()
 			Jenkins.MainLog.WriteLine ("Running '{0}' on device (candidates: '{1}')", ProjectFile, string.Join ("', '", Candidates.Select ((v) => v.Name).ToArray ()));
 
 			var install_log = Logs.CreateStream (LogDirectory, $"install-{Timestamp}.log", "Install log");
+			install_log.Timestamp = true;
 			var uninstall_log = Logs.CreateStream (LogDirectory, $"uninstall-{Timestamp}.log", "Uninstall log");
 			using (var device_resource = await NotifyBlockingWaitAsync (Jenkins.GetDeviceResources (Candidates).AcquireAnyConcurrentAsync ())) {
 				try {

--- a/tests/xharness/Process_Extensions.cs
+++ b/tests/xharness/Process_Extensions.cs
@@ -58,14 +58,12 @@ namespace xharness
 	{
 		public static async Task<ProcessExecutionResult> RunAsync (this Process process, Log log, CancellationToken? cancellation_token = null)
 		{
-			var stream = log.GetWriter ();
-			return await RunAsync (process, log, stream, stream, cancellation_token: cancellation_token);
+			return await RunAsync (process, log, log, log, cancellation_token: cancellation_token);
 		}
 
 		public static Task<ProcessExecutionResult> RunAsync (this Process process, Log log, bool append = true, TimeSpan? timeout = null, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null)
 		{
-			var writer = log.GetWriter ();
-			return RunAsync (process, log, writer, writer, timeout, environment_variables, cancellation_token);
+			return RunAsync (process, log, log, log, timeout, environment_variables, cancellation_token);
 		}
 
 		public static async Task<ProcessExecutionResult> RunAsync (this Process process, Log log, TextWriter StdoutStream, TextWriter StderrStream, TimeSpan? timeout = null, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null)


### PR DESCRIPTION
So that we get exact numbers of how long it takes to install on watch (and if
the watch installation stalls, or just times out because it takes too long).