### PR TITLE
[registrar] Store the attribute type separately for availability attributes saved for the registrar. (#2807)

### DIFF
--- a/tests/linker-ios/link all/LinkAllTest.cs
+++ b/tests/linker-ios/link all/LinkAllTest.cs
@@ -574,4 +574,17 @@ namespace LinkAll {
 #endif
 		}
 	}
+
+	[Introduced (PlatformName.MacOSX, 1, 0, PlatformArchitecture.Arch64)]
+	[Introduced (PlatformName.iOS, 1, 0)]
+	[Introduced (PlatformName.TvOS, 1, 0)]
+	[Introduced (PlatformName.WatchOS, 1, 0)]
+	[Preserve]
+	public class ClassFromThePast : NSObject
+	{
+		[Export ("foo:")]
+		public void Foo (ClassFromThePast obj)
+		{
+		}
+	}
 }

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -1356,6 +1356,11 @@ namespace XamCore.Registrar {
 
 		void CollectAvailabilityAttributes (IEnumerable<CustomAttribute> attributes, ref List<AvailabilityBaseAttribute> list)
 		{
+			CollectAvailabilityAttributes (attributes.Select ((v) => new Tuple<CustomAttribute, TypeReference> (v, v.Constructor.DeclaringType)), ref list);
+		}
+
+		void CollectAvailabilityAttributes (IEnumerable<Tuple<CustomAttribute, TypeReference>> attributes, ref List<AvailabilityBaseAttribute> list)
+		{
 			PlatformName currentPlatform;
 #if MTOUCH
 			switch (App.Platform) {
@@ -1375,8 +1380,9 @@ namespace XamCore.Registrar {
 			currentPlatform = global::XamCore.ObjCRuntime.PlatformName.MacOSX;
 #endif
 
-			foreach (var ca in attributes) {
-				var caType = ca.Constructor.DeclaringType.Resolve ();
+			foreach (var tuple in attributes) {
+				var ca = tuple.Item1;
+				var caType = tuple.Item2;
 				if (caType.Namespace != ObjCRuntime)
 					continue;
 				
@@ -1505,7 +1511,7 @@ namespace XamCore.Registrar {
 			if (AvailabilityAnnotations != null) {
 				object attribObjects;
 				if (AvailabilityAnnotations.TryGetValue (td, out attribObjects))
-					CollectAvailabilityAttributes ((List<CustomAttribute>) attribObjects, ref rv);
+					CollectAvailabilityAttributes ((List<Tuple<CustomAttribute, TypeReference>>) attribObjects, ref rv);
 			}
 
 			return rv;

--- a/tools/linker/CoreRemoveAttributes.cs
+++ b/tools/linker/CoreRemoveAttributes.cs
@@ -50,19 +50,21 @@ namespace Xamarin.Linker {
 				case "DeprecatedAttribute":
 				case "IntroducedAttribute":
 					var dict = context.Annotations.GetCustomAnnotations ("Availability");
-					List<CustomAttribute> attribs;
+					List<Tuple<CustomAttribute,TypeReference>> attribs;
 					object attribObjects;
 					if (!dict.TryGetValue (provider, out attribObjects)) {
-						attribs = new List<CustomAttribute> ();
+						attribs = new List<Tuple<CustomAttribute, TypeReference>> ();
 						dict [provider] = attribs;
 					} else {
-						attribs = (List<CustomAttribute>) attribObjects;
+						attribs = (List<Tuple<CustomAttribute, TypeReference>>) attribObjects;
 					}
 					// Make sure the attribute is resolved, since after removing the attribute
 					// it won't be able to do it. The 'CustomAttribute.Resolve' method is private, but fetching
 					// any property will cause it to be called.
+					// We also need to store the constructor's DeclaringType separately, because it may
+					// be nulled out from the constructor by the linker if the attribute type itself is linked away.
 					var dummy = attribute.HasConstructorArguments;
-					attribs.Add (attribute);
+					attribs.Add (new Tuple<CustomAttribute, TypeReference> (attribute, attribute.Constructor.DeclaringType));
 					break;
 				}
 			}


### PR DESCRIPTION
The registrar requires the availability attributes to work properly, which is
non-trivial when the linker is being used, because the linker runs before the
registrar, and will remove availability attributes.

For this reason we store the availability attributes separately when the
linker removes them so that the registrar can still find them, but
unfortunately it's not enough to store the CustomAttribute instance, because
it may end up crippled: if the attribute type itself is removed by the linker,
then it's not possible to get the attribute type from the CustomAttribute
instance, because 'attribute.Constructor.DeclaringType' returns null (the
linker sets the declaring type of the constructor to null).

Solution: store the attribute type separately; now we use a Tuple of
CustomAttribute and TypeReference.

Fixes this ugly exception:

    System.NullReferenceException: Object reference not set to an instance of an object
      at XamCore.Registrar.Registrar.RegisterAssembly (Mono.Cecil.AssemblyDefinition assembly) [0x00146] in /work/maccore/master/xamarin-macios/src/ObjCRuntime/Registrar.cs:2316
      at XamCore.Registrar.StaticRegistrar.Generate (System.Collections.Generic.IEnumerable`1[T] assemblies, System.String header_path, System.String source_path) [0x00035] in /work/maccore/master/xamarin-macios/tools/common/StaticRegistrar.cs:4197
      at Xamarin.Bundler.RunRegistrarTask.Execute () [0x00001] in /work/maccore/master/xamarin-macios/tools/mtouch/BuildTasks.mtouch.cs:154