### PR TITLE
[tests] Exclude tests whose category is !BITCODE when running on watchOS/Release. Partially fixes #59947.

### DIFF
--- a/tests/mini/AppDelegate.cs
+++ b/tests/mini/AppDelegate.cs
@@ -17,7 +17,11 @@ namespace mini
 {
 	[TestFixture]
 	class JitTests {
+#if BITCODE
+		static string[] args = new string[] { "--exclude", "!FULLAOT", "--exclude", "!BITCODE", "--verbose" };
+#else
 		static string[] args = new string[] { "--exclude", "!FULLAOT", "--verbose" };
+#endif
 
 		[Test]
 		public static void Basic () {

--- a/tests/xharness/WatchOSTarget.cs
+++ b/tests/xharness/WatchOSTarget.cs
@@ -75,6 +75,7 @@ namespace xharness
 			csproj.FixArchitectures ("i386", "ARMv7k");
 			csproj.FixInfoPListInclude (suffix);
 			csproj.SetOutputType ("Library");
+			csproj.AddAdditionalDefines ("BITCODE", "iPhone", "Release");
 			csproj.AddAdditionalDefines ("XAMCORE_2_0;XAMCORE_3_0;FEATURE_NO_BSD_SOCKETS");
 			csproj.RemoveReferences ("OpenTK-1.0");
 			var ext = IsFSharp ? "fs" : "cs";


### PR DESCRIPTION
Exclude tests whose category is !BITCODE when running on watchOS/Release. This
also requires a minor update to xharness to add a BITCODE conditional
compilation flag to generated watchOS/Release projects configurations.

This partially fixes #59947 (the fix will be complete once we bump to mono/2017-08).

https://bugzilla.xamarin.com/show_bug.cgi?id=59947