### PR TITLE
[appletls] Trust SecTrustResult.Proceed as well. Fixes #58411.

### DIFF
--- a/src/Security/Tls/AppleCertificateHelper.cs
+++ b/src/Security/Tls/AppleCertificateHelper.cs
@@ -92,7 +92,7 @@ namespace XamCore.Security.Tls
 			}
 
 			var result = trust.Evaluate ();
-			if (result == SecTrustResult.Unspecified)
+			if (result == SecTrustResult.Unspecified || result == SecTrustResult.Proceed)
 				return true;
 
 			errors |= MonoSslPolicyErrors.RemoteCertificateChainErrors;


### PR DESCRIPTION
Apple states clearly in their documentation about SecTrustResult.Proceed [1]:

    The user explicitly chose to trust a certificate in the chain (usually by
    clicking a button in a certificate trust panel).

    Your app should trust the chain.

This fixes bug #[58411][2], where SecTrustEvaluate returns
SecTrustResult.Proceed starting with iOS 11.

There's an equivalent mono fix: https://github.com/mono/mono/pull/5703

[1]: https://developer.apple.com/documentation/security/1394363-sectrustevaluate
[2]: https://bugzilla.xamarin.com/show_bug.cgi?id=58411