### PR TITLE
[runtime] Call mono_raise_exception if mono_set_pending_exception isn't available. Works around bug #59979

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -241,7 +241,10 @@
 
 		new Export (true, "void", "mono_set_pending_exception",
 			"MonoException *", "exc"
-		),
+		)
+		{
+			AlternativeEntryPoint = "mono_raise_exception",
+		},
 
 		#endregion
 
@@ -671,6 +674,7 @@
 	{
 		public string ReturnType;
 		public string EntryPoint;
+		public string AlternativeEntryPoint;
 		public List<Arg> Arguments;
 		public bool Optional;
 

--- a/runtime/mono-runtime.m.t4
+++ b/runtime/mono-runtime.m.t4
@@ -125,7 +125,11 @@ MONO_API <#= export.ReturnType #>
 {
 <# if (export.Optional) { #>
 	if (<#= export.EntryPoint #>_func == NULL)
+<# if (!string.IsNullOrEmpty (export.AlternativeEntryPoint)) { #>
+		return <#= export.AlternativeEntryPoint #> (<#= export.ArgumentNames #>);
+<# } else {#>
 		xamarin_assertion_message ("Could not load <#= export.EntryPoint #>\n");
+<# } #>
 
 <# } #>
 	return <#= export.EntryPoint #>_func (<#= export.ArgumentNames #>);


### PR DESCRIPTION
mono_set_pending_exception is a private mono symbol, which means we won't find
it when using the system mono (as a dynamic library). In that case, we'd
abort.

Instead try to call mono_raise_exception, and hope for the best. It will leak
somewhat, but that's still better than asserting.

This changes the generated wrapper function from:

```c
MONO_API void
mono_set_pending_exception (MonoException * exc)
{
	if (mono_set_pending_exception_func == NULL)
		xamarin_assertion_message ("Could not load mono_set_pending_exception\n");

	return mono_set_pending_exception_func (exc);
}
```

to

```c
MONO_API void
mono_set_pending_exception (MonoException * exc)
{
	if (mono_set_pending_exception_func == NULL)
		return mono_raise_exception (exc);

	return mono_set_pending_exception_func (exc);
}
```

Also this only applies to Xamarin.Mac apps that use the system mono (such as VSfM).

https://bugzilla.xamarin.com/show_bug.cgi?id=59979