### PR TITLE
[monotouch-test] Fix tests causing trouble for the AOT compiler.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
@@ -72,6 +72,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 		}
 
+#if !DEVICE && !MONOMAC // some of these tests cause the AOT compiler to assert
 		// No MonoPInvokeCallback
 		static void InvalidTrampoline1 () { }
 
@@ -90,6 +91,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		// Wrong delegate signature in MonoPInvokeCallback
 		[MonoPInvokeCallback (typeof (Func<IntPtr>))]
 		static int InvalidTrampoline5 () { return 0;  }
+#endif // !DEVICE
 
 		[Test]
 		public void InvalidBlockTrampolines ()
@@ -99,7 +101,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 			Assert.Throws<ArgumentNullException> (() => block.SetupBlock (null, userDelegate), "null trampoline");
 
-#if !MONOMAC
+#if !DEVICE && !MONOMAC
 			if (Runtime.Arch == Arch.SIMULATOR) {
 				// These checks only occur in the simulator
 				Assert.Throws<ArgumentException> (() => block.SetupBlock ((Action) InvalidBlockTrampolines, userDelegate), "instance trampoline");
@@ -109,7 +111,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				Assert.Throws<ArgumentException> (() => block.SetupBlock ((Action<int>) InvalidTrampoline4, userDelegate), "invalid trampoline 4");
 				Assert.Throws<ArgumentException> (() => block.SetupBlock ((Func<int>) InvalidTrampoline5, userDelegate), "invalid trampoline 5");
 			}
-#endif
+#endif // !DEVICE
 		}
 	}
 }

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -50,7 +50,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhone\$(Configuration)-unified</OutputPath>
-    <DefineConstants>DEBUG;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DEBUG;DEVICE;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>0</WarningLevel>
     <MtouchDebug>True</MtouchDebug>
@@ -67,7 +67,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhone\$(Configuration)-unified</OutputPath>
-    <DefineConstants>DEBUG;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DEBUG;DEVICE;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>0</WarningLevel>
     <MtouchDebug>True</MtouchDebug>
@@ -82,7 +82,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhone\$(Configuration)-unified</OutputPath>
-    <DefineConstants>DEBUG;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DEBUG;DEVICE;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>0</WarningLevel>
     <MtouchDebug>True</MtouchDebug>
@@ -96,7 +96,7 @@
     <DebugType>none</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhone\$(Configuration)-unified</OutputPath>
-    <DefineConstants>MONOTOUCH;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>MONOTOUCH;DEVICE;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
@@ -110,7 +110,7 @@
     <DebugType>none</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhone\$(Configuration)-unified</OutputPath>
-    <DefineConstants>MONOTOUCH;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>MONOTOUCH;DEVICE;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
@@ -124,7 +124,7 @@
     <DebugType>none</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhone\$(Configuration)-unified</OutputPath>
-    <DefineConstants>MONOTOUCH;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>MONOTOUCH;DEVICE;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
@@ -138,7 +138,7 @@
     <DebugType>none</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhone\$(Configuration)-unified</OutputPath>
-    <DefineConstants>MONOTOUCH;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>MONOTOUCH;DEVICE;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>


### PR DESCRIPTION
Fix tests causing trouble for the AOT compiler by not building those tests on
device (they're testing error conditions in the simulator, which means it's
acceptable to exclude these tests for device builds).

This fixes an AOT-compiler assert:

> * Assertion at /Users/builder/data/lanes/1381/d264709b/source/xamarin-macios/external/mono/mono/metadata/marshal.c:8497, condition `sig->param_count == invoke_sig->param_count + 1' not met

due to invalid [MonoPInvokeCallback] attributes.