### PR TITLE
[runtime] Don't hold the framework lock when running managed code. Fixes #59994.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1887,10 +1887,10 @@ xamarin_release_managed_ref (id self, MonoObject *managed_obj)
 		[self release];
 		MONO_EXIT_GC_SAFE;
 	} else {
-		// This lock is needed so that we can safely call retainCount in the toggleref callback.
-		xamarin_framework_peer_lock ();
 		/* If we're a wrapper type, we need to unregister here, since we won't enter the release trampoline */
 		xamarin_unregister_nsobject (self, managed_obj, &exception_gchandle);
+		// This lock is needed so that we can safely call retainCount in the toggleref callback.
+		xamarin_framework_peer_lock ();
 		MONO_ENTER_GC_SAFE;
 		[self release];
 		MONO_EXIT_GC_SAFE;


### PR DESCRIPTION
There is a deadlock between the framework lock and the GC lock; resolve this by making sure we don't execute managed code while holding the framework lock.

The framework lock was introduced in xamarin/maccore@4a0748b1d8c7cbcc501306a3797eab76c613b9fb, and from analyzing that commit message, it seems we're safe as long as nobody retains/releases NSObjects (in way that makes the retainCount jump to or from 1) while the GC runs.

Calling `xamarin_unregister_nsobject` does not affect the retain count of the object; thus it's not necessary to keep the lock during the call to `xamarin_unregister_nsobject`.

https://bugzilla.xamarin.com/show_bug.cgi?id=59994
https://github.com/xamarin/maccore/commit/4a0748b1d8c7cbcc501306a3797eab76c613b9fb