### PR TITLE
[tests][mtouch] Add support for reading binary plists.

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -112,6 +112,9 @@
     <Compile Include="ProjectsTests\LinkedAssets.cs" />
     <Compile Include="ProjectsTests\CodesignAppBundle.cs" />
     <Compile Include="ProjectsTests\BindingReferences.cs" />
+    <Compile Include="..\..\..\tools\common\StringUtils.cs">
+      <Link>StringUtils.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Some plists in Xcode 9 are now binary plists (instead of just plain xml files
like they were in previous versions of Xcode). This causes trouble for some of
our tests, so make sure we handle binary plists as well.

Fixes these failures:

1. Xamarin.MTouch.MT0091(tvOS,"tvOS") : System.Xml.XmlException : Data at the root level is invalid. Line 1, position 1.

2. Xamarin.MTouch.MT0091(iOS,"iOS") : System.Xml.XmlException : Data at the root level is invalid. Line 1, position 1.
