### PR TITLE
[AudioToolbox] Free the right GCHandle when failing to create an InputAudioQueue. Fixes #59911.

### DIFF
--- a/src/AudioToolbox/AudioQueue.cs
+++ b/src/AudioToolbox/AudioQueue.cs
@@ -1477,7 +1477,7 @@ namespace XamCore.AudioToolbox {
 				gch = mygch;
 				return;
 			}
-			gch.Free ();
+			mygch.Free ();
 			throw new AudioQueueException (code);
 		}
 

--- a/tests/monotouch-test/AudioToolbox/AudioQueueTest.cs
+++ b/tests/monotouch-test/AudioToolbox/AudioQueueTest.cs
@@ -81,6 +81,12 @@ namespace MonoTouchFixtures.AudioToolbox {
 
 			//Assert.That (called, Is.True, "#10");
 		}
+
+		[Test]
+		public void InvalidAudioBasicDescription ()
+		{
+			Assert.Throws<AudioQueueException> (() => new InputAudioQueue (new AudioStreamBasicDescription ()), "A");
+		}
 	}
 }
 


### PR DESCRIPTION
When we fail to create an InputAudioQueue, we need to free the local GCHandle
we previously created, not the instance GCHandle where we'd put the local
GCHandle in case of success.

This fixes bug #59911 to throw the correct (invalid parameter) exception (and
not leak the local GCHandle either).

https://bugzilla.xamarin.com/show_bug.cgi?id=59911