### PR TITLE
[monotouch-test] The media library permission API is only available in iOS 9.3+. Fixes #59995.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -600,6 +600,12 @@ partial class TestRuntime
 #if !MONOMAC && !__TVOS__ && !__WATCHOS__
 	public static void RequestMediaLibraryPermission (bool assert_granted = false)
 	{
+		if (!CheckXcodeVersion (7, 3)) {
+			if (IgnoreTestThatRequiresSystemPermissions ())
+				NUnit.Framework.Assert.Ignore ("This test might show a dialog to ask for permission to access the media library, but the API to check if a dialog is required (or to request permission) is not available in this OS version.");
+			return;
+		}
+
 		if (MPMediaLibrary.AuthorizationStatus == MPMediaLibraryAuthorizationStatus.NotDetermined) {
 			if (IgnoreTestThatRequiresSystemPermissions ())
 				NUnit.Framework.Assert.Ignore ("This test would show a dialog to ask for permission to access the media library.");


### PR DESCRIPTION
The media library permission API (to either query the permission status or ask
for permission) was introduced in iOS 9.3, so we need to make sure to not call
it on earlier iOS versions.

If running on older iOS versions, then just don't do anything (unless we're
asked to ignore tests that put up permission dialogs, in which case ignore the
test, since that's the safe approach).

https://bugzilla.xamarin.com/show_bug.cgi?id=59995