### PR TITLE
[UIKit] Don't construct new objects in UIDragDropSessionExtensions.LoadObjects if what we have is usable. Fixes #59944.

### DIFF
--- a/src/UIKit/UIDragDropSessionExtensions.cs
+++ b/src/UIKit/UIDragDropSessionExtensions.cs
@@ -25,8 +25,14 @@ namespace XamCore.UIKit {
 				if (arr == null && v != null) {
 					arr = new T [v.Length];
 					for (int i = 0; i < arr.Length; i++) {
-						if (v [i] != null)
-							arr [i] = Runtime.ConstructNSObject<T> (v [i].Handle);
+						if (v [i] == null)
+							continue;
+
+						arr [i] = v [i] as T;
+						if (arr [i] != null)
+							continue;
+
+						arr [i] = Runtime.ConstructNSObject<T> (v [i].Handle);
 					}
 				}
 


### PR DESCRIPTION
We might get an array of instances that are of the right type; in that case
use those instances instead of creating new ones.

https://bugzilla.xamarin.com/show_bug.cgi?id=59944