### PR TITLE
Update run-tests to use file. (#2794)

### DIFF
--- a/jenkins/run-tests.sh
+++ b/jenkins/run-tests.sh
@@ -6,7 +6,7 @@ cd $WORKSPACE
 security default-keychain -s builder.keychain
 security list-keychains -s builder.keychain
 echo "Unlock keychain"
-security unlock-keychain -p $OSX_KEYCHAIN_PASS
+security unlock-keychain -p `cat ~/.config/keychain`
 echo "Increase keychain unlock timeout"
 security set-keychain-settings -lut 7200
 


### PR DESCRIPTION
This is needed to cope with a configuration change on the Jenkins bots.

It does not change anything we ship.