### PR TITLE
[foundation] Remove [Preserve(Conditional=true)] on the NSProxy hack

### DIFF
--- a/src/Foundation/NSProxy.cs
+++ b/src/Foundation/NSProxy.cs
@@ -27,11 +27,10 @@ namespace XamCore.Foundation {
 }
 
 namespace XamCore.WebKit {
-	// We need to keep NSProxy (avoid linking it) if WKNavigationDelegate or IWKNavigationDelegate
-	// is used. Unfortunately [Preserve] can't help us here because we do not generate partial
-	// interfaces rigth now, so we know WKWebView will be there and can hold a reference to it.
+	// We need to keep NSProxy if WKNavigationDelegate or IWKNavigationDelegate are used
+	// This cannot be done on an interface but the protocol won't be used without a WKWebView
+	// so a reference (from the static constructor) ensure NSProxy will be available
 	public partial class WKWebView {
-		[Preserve (Conditional = true)]
 		static Type hack = typeof (NSProxy);
 	}
 }

--- a/tests/linker-ios/link all/LinkAllTest.cs
+++ b/tests/linker-ios/link all/LinkAllTest.cs
@@ -533,5 +533,14 @@ namespace LinkAll {
 			var fqn = typeof (NSObject).AssemblyQualifiedName.Replace ("Foundation.NSObject", "Security.Tls.AppleTlsProvider");
 			Assert.Null (Type.GetType (fqn), "Should NOT be included (no SslStream or Socket support)");
 		}
+
+		[Test]
+		// https://bugzilla.xamarin.com/show_bug.cgi?id=59247
+		public void WebKit_NSProxy ()
+		{
+			// this test works only because "Link all" does not use WebKit
+			var fqn = typeof (NSObject).AssemblyQualifiedName.Replace ("Foundation.NSObject", "Foundation.NSProxy");
+			Assert.Null (Type.GetType (fqn), fqn);
+		}
 	}
 }

--- a/tests/linker-ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker-ios/link sdk/LinkSdkRegressionTest.cs
@@ -38,6 +38,7 @@ using UIKit;
 #if !__WATCHOS__
 using OpenGLES;
 #endif
+using WebKit;
 #else
 using MonoTouch;
 using MonoTouch.AddressBook;
@@ -50,6 +51,7 @@ using MonoTouch.ObjCRuntime;
 using MonoTouch.MapKit;
 using MonoTouch.UIKit;
 using MonoTouch.OpenGLES;
+using MonoTouch.WebKit;
 #endif
 using NUnit.Framework;
 
@@ -1047,6 +1049,16 @@ namespace LinkSdk {
 			// make test work for classic (monotouch) and unified (iOS, tvOS and watchOS)
 			var fqn = typeof (NSObject).AssemblyQualifiedName.Replace ("Foundation.NSObject", "Security.Tls.AppleTlsProvider");
 			Assert.Null (Type.GetType (fqn), "Should be included");
+		}
+
+		[Test]
+		// https://bugzilla.xamarin.com/show_bug.cgi?id=59247
+		public void WebKit_NSProxy ()
+		{
+			// a reference to WKWebView will bring the internal NSProxy type
+			var t = typeof (WKWebView);
+			var fqn = typeof (NSObject).AssemblyQualifiedName.Replace ("Foundation.NSObject", "Foundation.NSProxy");
+			Assert.NotNull (Type.GetType (fqn), fqn);
 		}
 	}
 }

--- a/tests/linker-ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker-ios/link sdk/LinkSdkRegressionTest.cs
@@ -1057,6 +1057,7 @@ namespace LinkSdk {
 		{
 			// a reference to WKWebView will bring the internal NSProxy type
 			var t = typeof (WKWebView);
+			Assert.NotNull (t, "avoid compiler optimization of unused variable"); 
 			var fqn = typeof (NSObject).AssemblyQualifiedName.Replace ("Foundation.NSObject", "Foundation.NSProxy");
 			Assert.NotNull (Type.GetType (fqn), fqn);
 		}


### PR DESCRIPTION
[foundation] Remove [Preserve(Conditional=true)] on the NSProxy hack (#2732) (#2734)

The attribute is not needed and makes everything link against WebKit
even when not needed. Also update comment to be more accurate.

Update fix for
https://bugzilla.xamarin.com/show_bug.cgi?id=59247

Adds test to verify presence/absence of NSProxy depending on WKWebView usage