### PR TITLE
Bump MAX_MONO_VERSION to 5.4.99

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -57,7 +57,7 @@ XCODE_DEVELOPER_ROOT=/Applications/Xcode91-beta2.app/Contents/Developer
 
 # Minimum Mono version
 MIN_MONO_VERSION=5.2.0.90
-MAX_MONO_VERSION=5.2.99
+MAX_MONO_VERSION=5.4.99
 MIN_MONO_URL=https://bosstoragemirror.blob.core.windows.net/wrench/mono-2017-04/be/bed9e6bce54e8d7bb350e21cbf4c6eee98e8f020/MonoFramework-MDK-5.2.0.90.macos10.xamarin.universal.pkg
 
 # Minimum Visual Studio version


### PR DESCRIPTION
Current stable mono is Mono 5.4.0.201 (2017-06/71277e78f6e) (64-bit)