### PR TITLE
Add Objective Sharpie 3.4 as an optional dependency, and add support for running xtro tests on wrench+jenkins.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -70,6 +70,11 @@ MAX_VISUAL_STUDIO_VERSION=7.3.99
 MIN_CMAKE_URL=https://cmake.org/files/v3.6/cmake-3.6.2-Darwin-x86_64.dmg
 MIN_CMAKE_VERSION=2.8.8
 
+# ObjectiveSharpie min/max versions
+MIN_SHARPIE_VERSION=3.4.0
+MAX_SHARPIE_VERSION=3.4.99
+MIN_SHARPIE_URL=https://download.visualstudio.microsoft.com/download/pr/100173119/c367c913219cdfa307b98fe912d07691/ObjectiveSharpie-3.4.0.pkg
+
 # Minimum OSX versions
 MIN_OSX_BUILD_VERSION=10.12
 MIN_OSX_VERSION_FOR_IOS=10.11

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -353,6 +353,10 @@ else
 	@echo "iOS tests have been disabled [$@]"
 endif
 
+wrench-xtro:
+	git clean -xfdq
+	make -C xtro-sharpie wrench
+
 jenkins: xharness/xharness.exe
 	$(Q) $(SYSTEM_MONO) --debug $< $(XHARNESS_VERBOSITY) --jenkins --autoconf --rootdir $(CURDIR) --sdkroot $(XCODE_DEVELOPER_ROOT)
 

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -31,6 +31,7 @@ namespace xharness
 		public bool IncludeSimulator = true;
 		public bool IncludeDevice;
 		public bool IncludeSystemPermissionTests = true; // tests that require access to system resources (system contacts, photo library, etc) in order to work
+		public bool IncludeXtro;
 
 		public Logs Logs = new Logs ();
 		public Log MainLog;
@@ -362,12 +363,17 @@ namespace xharness
 				"msbuild",
 				"tests/mac-binding-project",
 			}.Intersect (btouch_prefixes).ToArray ();
+			var xtro_prefixes = new string [] {
+				"tests/xtro-sharpie",
+				"src",
+			};
 
 			SetEnabled (files, mtouch_prefixes, "mtouch", ref IncludeMtouch);
 			SetEnabled (files, mmp_prefixes, "mmp", ref IncludeMmpTest);
 			SetEnabled (files, bcl_prefixes, "bcl", ref IncludeBcl);
 			SetEnabled (files, btouch_prefixes, "btouch", ref IncludeBtouch);
 			SetEnabled (files, mac_binding_project, "mac-binding-project", ref IncludeMacBindingProject);
+			SetEnabled (files, xtro_prefixes, "xtro", ref IncludeXtro);
 		}
 
 		void SetEnabled (IEnumerable<string> files, string [] prefixes, string testname, ref bool value)
@@ -400,6 +406,7 @@ namespace xharness
 			SetEnabled (labels, "mac-binding-project", ref IncludeMacBindingProject);
 			SetEnabled (labels, "ios-extensions", ref IncludeiOSExtensions);
 			SetEnabled (labels, "ios-device", ref IncludeDevice);
+			SetEnabled (labels, "xtro", ref IncludeXtro);
 
 			// enabled by default
 			SetEnabled (labels, "ios", ref IncludeiOS);
@@ -633,7 +640,17 @@ namespace xharness
 				Ignored = !IncludeMacBindingProject || !IncludeMac,
 			};
 			Tasks.Add (runMacBindingProject);
-			
+
+			var runXtroTests = new MakeTask {
+				Jenkins = this,
+				Platform = TestPlatform.All,
+				TestName = "Xtro",
+				Target = "wrench",
+				WorkingDirectory = Path.Combine (Harness.RootDirectory, "xtro-sharpie"),
+				Ignored = !IncludeXtro,
+			};
+			Tasks.Add (runXtroTests);
+
 			Tasks.AddRange (CreateRunDeviceTasks ());
 		}
 
@@ -2075,6 +2092,17 @@ function oninitialload ()
 				process.StartInfo.EnvironmentVariables ["XamarinMacFrameworkRoot"] = Path.Combine (Harness.MAC_DESTDIR, "Library", "Frameworks", "Xamarin.Mac.framework", "Versions", "Current");
 				process.StartInfo.EnvironmentVariables ["XAMMAC_FRAMEWORK_PATH"] = Path.Combine (Harness.MAC_DESTDIR, "Library", "Frameworks", "Xamarin.Mac.framework", "Versions", "Current");
 				break;
+			case TestPlatform.All:
+				// Don't set:
+				//     MSBuildExtensionsPath 
+				//     XBUILD_FRAMEWORK_FOLDERS_PATH
+				// because these values used by both XM and XI and we can't set it to two different values at the same time.
+				// Any test that depends on these values should not be using 'TestPlatform.All'
+				process.StartInfo.EnvironmentVariables ["MD_APPLE_SDK_ROOT"] = Harness.XcodeRoot;
+				process.StartInfo.EnvironmentVariables ["MD_MTOUCH_SDK_ROOT"] = Path.Combine (Harness.IOS_DESTDIR, "Library", "Frameworks", "Xamarin.iOS.framework", "Versions", "Current");
+				process.StartInfo.EnvironmentVariables ["XamarinMacFrameworkRoot"] = Path.Combine (Harness.MAC_DESTDIR, "Library", "Frameworks", "Xamarin.Mac.framework", "Versions", "Current");
+				process.StartInfo.EnvironmentVariables ["XAMMAC_FRAMEWORK_PATH"] = Path.Combine (Harness.MAC_DESTDIR, "Library", "Frameworks", "Xamarin.Mac.framework", "Versions", "Current");
+				break;
 			default:
 				throw new NotImplementedException ();
 			}
@@ -3254,6 +3282,8 @@ function oninitialload ()
 	public enum TestPlatform
 	{
 		None,
+		All,
+
 		iOS,
 		iOS_Unified,
 		iOS_Unified32,

--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -12,7 +12,7 @@ clean-local::
 	rm -rf *os*.pch*
 
 bin/Debug/xtro-sharpie.exe build:
-	$(Q_BUILD) msbuild $(XBUILD_VERBOSITY) xtro-sharpie.sln
+	$(Q_BUILD) $(SYSTEM_MSBUILD) $(XBUILD_VERBOSITY) xtro-sharpie.sln
 
 XIOS ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/64bits/Xamarin.iOS.dll
 XIOS_GL ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/OpenTK-1.0.dll
@@ -22,7 +22,7 @@ XIOS_PCH = iphoneos$(IOS_SDK_VERSION)-$(XIOS_ARCH).pch
 ios.results run-ios: build $(XIOS_PCH)
 	$(MONO) bin/Debug/xtro-sharpie.exe $(XIOS_PCH) $(XIOS) $(XIOS_GL) | sort > ios.results
 
-$(XIOS_PCH):
+$(XIOS_PCH): .stamp-check-sharpie
 	sharpie sdk-db -s iphoneos$(IOS_SDK_VERSION) -a $(XIOS_ARCH)
 
 
@@ -33,9 +33,8 @@ XWATCHOS_PCH = watchos$(WATCH_SDK_VERSION)-$(XWATCHOS_ARCH).pch
 watchos.results run-watchos: build $(XWATCHOS_PCH)
 	$(MONO) bin/Debug/xtro-sharpie.exe $(XWATCHOS_PCH) $(XWATCHOS) | sort > watchos.results
 
-$(XWATCHOS_PCH):
+$(XWATCHOS_PCH): .stamp-check-sharpie
 	sharpie sdk-db -s watchos$(WATCH_SDK_VERSION) -a $(XWATCHOS_ARCH)
-
 
 XTVOS ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/Xamarin.TVOS.dll
 XTVOS_GL ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/OpenTK-1.0.dll
@@ -45,7 +44,7 @@ XTVOS_PCH = appletvos$(TVOS_SDK_VERSION)-$(XTVOS_ARCH).pch
 tvos.results run-tvos: build $(XTVOS_PCH)
 	$(MONO) bin/Debug/xtro-sharpie.exe $(XTVOS_PCH) $(XTVOS) $(XTVOS_GL) | sort > tvos.results
 
-$(XTVOS_PCH):
+$(XTVOS_PCH): .stamp-check-sharpie
 	sharpie sdk-db -s appletvos$(TVOS_SDK_VERSION) -a $(XTVOS_ARCH)
 
 
@@ -56,7 +55,7 @@ XMAC_PCH = macosx$(OSX_SDK_VERSION)-$(XMAC_ARCH).pch
 osx.results run-osx: build $(XMAC_PCH)
 	$(MONO) bin/Debug/xtro-sharpie.exe $(XMAC_PCH) $(XMAC) | sort > osx.results
 
-$(XMAC_PCH):
+$(XMAC_PCH): .stamp-check-sharpie
 	sharpie sdk-db -s macosx$(OSX_SDK_VERSION) -a $(XMAC_ARCH) -x InputMethodKit
 
 preclassify: ios.results osx.results
@@ -90,22 +89,32 @@ classify: classify-ios classify-osx classify-watchos classify-tvos
 
 ios-$(IOS_SDK_VERSION).g.cs: $(XIOS_PCH)
 
-gen-ios: ios-$(IOS_SDK_VERSION).g.cs
+gen-ios: ios-$(IOS_SDK_VERSION).g.cs .stamp-check-sharpie
 	sharpie query -bind $(XIOS_PCH) > ios-$(IOS_SDK_VERSION).g.cs
 
 tvos-$(TVOS_SDK_VERSION).g.cs: $(XTVOS_PCH)
 
-gen-tvos: tvos-$(TVOS_SDK_VERSION).g.cs
+gen-tvos: tvos-$(TVOS_SDK_VERSION).g.cs .stamp-check-sharpie
 	sharpie query -bind $(XTVOS_PCH) > tvos-$(TVOS_SDK_VERSION).g.cs
 
 watchos-$(WATCH_SDK_VERSION).g.cs: $(XWATCHOS_PCH)
 
-gen-watchos: watchos-$(WATCH_SDK_VERSION).g.cs
+gen-watchos: watchos-$(WATCH_SDK_VERSION).g.cs .stamp-check-sharpie
 	sharpie query -bind $(XWATCHOS_PCH) > watchos-$(WATCH_SDK_VERSION).g.cs
 
 macos-$(OSX_SDK_VERSION).g.cs: $(XMAC_PCH)
 
-gen-macos: macos-$(OSX_SDK_VERSION).g.cs
+gen-macos: macos-$(OSX_SDK_VERSION).g.cs .stamp-check-sharpie
 	sharpie query -bind $(XMAC_PCH) > macos-$(OSX_SDK_VERSION).g.cs
 
 gen-all: gen-ios gen-tvos gen-watchos gen-macos
+
+wrench:
+	$(MAKE) classify -j8
+	for i in *.unclassified; do echo $$i; sed 's/^/    /' $$i; done
+	@echo "@MonkyWrench: SetSummary: $(shell grep -e "^!wrong" -e "^!unknown" *.unclassified | wc -l | sed 's/ //g') unknown/wrong API found."
+	@grep -e "^!wrong" -e "^!unknown" *.unclassified
+
+.stamp-check-sharpie:
+	@$(TOP)/system-dependencies.sh --ignore-all --enforce-sharpie
+	@touch $@


### PR DESCRIPTION
This will add Objective Sharpie as an optional dependency, only enforced if
actually trying to run the xtro tests.

The wrench/jenkins tests will show up as green for now (since there are known
failures in the xtro tests that have to be addressed first).

See also: https://trello.com/c/p4mya431/674-run-xtro-on-wrench