### PR TITLE
[mtouch] Protect against touchy files that don't like to be touched. Fixes #60149.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -623,6 +623,12 @@ No action is required, this message is purely informational.
 
 For further information see bug #[52727](https://bugzilla.xamarin.com/show_bug.cgi?id=52727).
 
+### <a name="MT0128"/>MT0128: Could not touch the file '*': *
+
+A failure occurred when touching a file (which is done to ensure partial builds are done correctly).
+
+This warning can most likely be ignored; in case of any problems file a bug (https://bugzilla.xamarin.com](https://bugzilla.xamarin.com/enter_bug.cgi?product=iOS)) and it will be investigated.
+
 # MT1xxx: Project related error messages
 
 ### MT10xx: Installer / mtouch

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -802,8 +802,13 @@ namespace Xamarin.Bundler
 		{
 			if (timestamp == null)
 				timestamp = DateTime.Now;
-			foreach (var filename in filenames)
-				new FileInfo (filename).LastWriteTime = timestamp.Value;
+			foreach (var filename in filenames) {
+				try {
+					new FileInfo (filename).LastWriteTime = timestamp.Value;
+				} catch (Exception e) {
+					ErrorHelper.Warning (128, "Could not touch the file '{0}': {1}", filename, e.Message);
+				}
+			}
 		}
 
 		public static void Touch (params string [] filenames)


### PR DESCRIPTION
Catch any exceptions that occur when touching files, and show a warning
instead of failing the build.

https://bugzilla.xamarin.com/show_bug.cgi?id=60149