### PR TITLE
Add ISNMenuValidation to ActionDispatcher

### DIFF
--- a/src/AppKit/ActionDispatcher.cs
+++ b/src/AppKit/ActionDispatcher.cs
@@ -32,7 +32,7 @@ using XamCore.Foundation;
 namespace XamCore.AppKit
 {
 	[Register ("__monomac_internal_ActionDispatcher")]
-	internal class ActionDispatcher : NSObject
+	internal class ActionDispatcher : NSObject, INSMenuValidation // INSMenuValidation needed for using the Activated method of NSMenuItems if you want to be able to validate
 	{
 		const string skey = "__monomac_internal_ActionDispatcher_activated:";
 		const string dkey = "__monomac_internal_ActionDispatcher_doubleActivated:";
@@ -40,6 +40,7 @@ namespace XamCore.AppKit
 		public static Selector DoubleAction = new Selector (dkey);
 		public EventHandler Activated;
 		public EventHandler DoubleActivated;
+		public Func<NSMenuItem, bool> ValidateMenuItemFunc;
 
 		[Preserve, Export (skey)]
 		public void OnActivated (NSObject sender)
@@ -103,5 +104,14 @@ namespace XamCore.AppKit
 				return;
 			ctarget.DoubleActivated -= doubleHandler;
 		}
+
+		public bool ValidateMenuItem (NSMenuItem menuItem)
+		{
+			if (ValidateMenuItemFunc != null)
+				return ValidateMenuItemFunc (menuItem);
+
+			return true;
+		}
+
 	}
 }

--- a/src/AppKit/NSMenuItem.cs
+++ b/src/AppKit/NSMenuItem.cs
@@ -76,14 +76,14 @@ namespace XamCore.AppKit {
 			}
 		}
 
-		[Advice ("The Activated event must be set before setting ValidateMenuItem.")]
+		[Advice ("The 'Activated' event must be set before setting 'ValidateMenuItem'.")]
 		public Func <NSMenuItem, bool> ValidateMenuItem {
 			get {
 				return (target as ActionDispatcher)?.ValidateMenuItemFunc;
 			}
 			set {
 				if (!(target is ActionDispatcher))
-					throw new InvalidOperationException ("Target is not an ActionDispatcher.  ValidateMenuItem may only be set after setting the Activated event.");
+					throw new InvalidOperationException ("Target is not an 'ActionDispatcher'. 'ValidateMenuItem' may only be set after setting the 'Activated' event.");
 
 				(target as ActionDispatcher).ValidateMenuItemFunc = value;
 			}

--- a/src/AppKit/NSMenuItem.cs
+++ b/src/AppKit/NSMenuItem.cs
@@ -45,6 +45,12 @@ namespace XamCore.AppKit {
 			Activated += handler;
 		}
 
+		public NSMenuItem (string title, string charCode, EventHandler handler, Func <NSMenuItem, bool> validator) : this (title, null, charCode)
+		{
+			Activated += handler;
+			ValidateMenuItem = validator;
+		}
+
 		public NSMenuItem (string title, string charCode) : this (title, null, charCode)
 		{
 		}
@@ -70,11 +76,15 @@ namespace XamCore.AppKit {
 			}
 		}
 
+		[Advice ("The Activated event must be set before setting ValidateMenuItem.")]
 		public Func <NSMenuItem, bool> ValidateMenuItem {
 			get {
 				return (target as ActionDispatcher)?.ValidateMenuItemFunc;
 			}
 			set {
+				if (!(target is ActionDispatcher))
+					throw new InvalidOperationException ("Target is not an ActionDispatcher.  ValidateMenuItem may only be set after setting the Activated event.");
+
 				(target as ActionDispatcher).ValidateMenuItemFunc = value;
 			}
 		}

--- a/src/AppKit/NSMenuItem.cs
+++ b/src/AppKit/NSMenuItem.cs
@@ -70,5 +70,14 @@ namespace XamCore.AppKit {
 			}
 		}
 
+		public Func <NSMenuItem, bool> ValidateMenuItem {
+			get {
+				return (target as ActionDispatcher)?.ValidateMenuItemFunc;
+			}
+			set {
+				(target as ActionDispatcher).ValidateMenuItemFunc = value;
+			}
+		}
+
 	}
 }


### PR DESCRIPTION
- When a user event occurs, it looks at all of the menu items and determines if they have targets set.
- Any menu item with a target set checks to see if the target has the action method in question
- If the target has the action, it then looks for the validateMenuItem on the target
- The way we handle the event handler version is to create an ActionDispatcher, with the action method set on that object and the dispatcher set as the target.  As a result, any ValidateMenuItem method set in another class while trying to use the ActionDispatcher is never seen.  The method needs to be on the ActionDispatcher itself.
- I fixed it by adding a new ValidateMenuItem func to NSMenuItem.  I added the INSMenuValidation interface to the ActionDispatcher with the correct export, then a Func that can be set.  If the function isn't null, it calls it then returns the value.  Otherwise it just returns true.  Then added a ValidateMenuItem Func to NSMenuItem that sets/gets the one from the ActionDispatcher.
- Using this build, I was able to set the Activated method and ValidateMenuItem func on a menu item and successfully validate it.