### PR TITLE
[macos] Fix pdb mismatch when saving assemblies processed by mmp

### DIFF
--- a/tools/mmp/resolver.cs
+++ b/tools/mmp/resolver.cs
@@ -28,6 +28,7 @@ using System.Linq;
 using System.Security.Cryptography;
 
 using Mono.Cecil;
+using Mono.Cecil.Cil;
 
 namespace Xamarin.Bundler {
 	public partial class MonoMacResolver : IAssemblyResolver {
@@ -72,7 +73,9 @@ namespace Xamarin.Bundler {
 			assembly = AssemblyDefinition.ReadAssembly (fileName, new ReaderParameters 
 				{
 					AssemblyResolver = this,
-					InMemory = new FileInfo (fileName).Length < 1024 * 1024 * 100 // 100 MB
+					InMemory = new FileInfo (fileName).Length < 1024 * 1024 * 100, // 100 MB
+					ReadSymbols = true,
+					SymbolReaderProvider = new DefaultSymbolReaderProvider (throwIfNoSymbol: false) 
 				});
 			cache.Add (name, assembly);
 			return assembly;

--- a/tools/mmp/resolver.cs
+++ b/tools/mmp/resolver.cs
@@ -70,17 +70,13 @@ namespace Xamarin.Bundler {
 			if (cache.TryGetValue (name, out assembly))
 				return assembly;
 
-			var readParams = new ReaderParameters {
-				AssemblyResolver = this,
-				InMemory = new FileInfo (fileName).Length < 1024 * 1024 * 100, // 100 MB
-			};
-
-			if (Driver.EnableDebug) {
-				readParams.ReadSymbols = true;
-				readParams.SymbolReaderProvider = new DefaultSymbolReaderProvider (throwIfNoSymbol: false);
-			}
-
-			assembly = AssemblyDefinition.ReadAssembly (fileName, readParams);
+			assembly = AssemblyDefinition.ReadAssembly (fileName, new ReaderParameters 
+				{
+					AssemblyResolver = this,
+					InMemory = new FileInfo (fileName).Length < 1024 * 1024 * 100, // 100 MB
+					ReadSymbols = true,
+					SymbolReaderProvider = new DefaultSymbolReaderProvider (throwIfNoSymbol: false) 
+				});
 			cache.Add (name, assembly);
 			return assembly;
 		}

--- a/tools/mmp/resolver.cs
+++ b/tools/mmp/resolver.cs
@@ -70,13 +70,17 @@ namespace Xamarin.Bundler {
 			if (cache.TryGetValue (name, out assembly))
 				return assembly;
 
-			assembly = AssemblyDefinition.ReadAssembly (fileName, new ReaderParameters 
-				{
-					AssemblyResolver = this,
-					InMemory = new FileInfo (fileName).Length < 1024 * 1024 * 100, // 100 MB
-					ReadSymbols = true,
-					SymbolReaderProvider = new DefaultSymbolReaderProvider (throwIfNoSymbol: false) 
-				});
+			var readParams = new ReaderParameters {
+				AssemblyResolver = this,
+				InMemory = new FileInfo (fileName).Length < 1024 * 1024 * 100, // 100 MB
+			};
+
+			if (Driver.EnableDebug) {
+				readParams.ReadSymbols = true;
+				readParams.SymbolReaderProvider = new DefaultSymbolReaderProvider (throwIfNoSymbol: false);
+			}
+
+			assembly = AssemblyDefinition.ReadAssembly (fileName, readParams);
 			cache.Add (name, assembly);
 			return assembly;
 		}

--- a/tools/mtouch/AssemblyResolver.cs
+++ b/tools/mtouch/AssemblyResolver.cs
@@ -16,6 +16,7 @@ using System.IO;
 using System.Linq;
 
 using Mono.Cecil;
+using Mono.Cecil.Cil;
 using Mono.Tuner;
 
 using Xamarin.Bundler;
@@ -70,6 +71,8 @@ namespace MonoTouch.Tuner {
 			var parameters = new ReaderParameters ();
 			parameters.AssemblyResolver = this;
 			parameters.InMemory = new FileInfo (path).Length < 1024 * 1024 * 100; // 100 MB.
+			parameters.ReadSymbols = true;
+			parameters.SymbolReaderProvider = new DefaultSymbolReaderProvider (throwIfNoSymbol: false);
 			return parameters;
 		}
 


### PR DESCRIPTION
- Teach mmp's resolver to ask for symbol reading from Cecil
- Customer reports XM > 3.0 had broken library behavior but not before, possibly new cecil version?