### PR TITLE
[xtro] Fix typo and unknown/wrong counting.

### DIFF
--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -112,7 +112,7 @@ gen-all: gen-ios gen-tvos gen-watchos gen-macos
 wrench:
 	$(MAKE) classify -j8
 	for i in *.unclassified; do echo $$i; sed 's/^/    /' $$i; done
-	@echo "@MonkyWrench: SetSummary: $(shell grep -e "^!wrong" -e "^!unknown" *.unclassified | wc -l | sed 's/ //g') unknown/wrong API found."
+	@echo "@MonkeyWrench: SetSummary: `grep -e "^!wrong" -e "^!unknown" *.unclassified | wc -l | sed 's/ //g'` unknown/wrong API found."
 	@grep -e "^!wrong" -e "^!unknown" *.unclassified
 
 .stamp-check-sharpie:


### PR DESCRIPTION
Fix typo and change how to count unknown/wrong API to not count when the
Makefile is read ($(shell ...) - before executing the tests, and as such not
finding anything wrong), but instead when printing the count (using
backticks).