### PR TITLE
[xharness] Fix clearing simulator state. Fixes #60229 and #58951.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -3127,16 +3127,17 @@ function oninitialload ()
 				// We need to set the dialog permissions for all the apps
 				// before launching the simulator, because once launched
 				// the simulator caches the values in-memory.
-				foreach (var task in Tasks)
+				var executingTasks = Tasks.Where ((v) => !v.Ignored && !v.Failed);
+				foreach (var task in executingTasks)
 					await task.SelectSimulatorAsync ();
 
-				var devices = Tasks.First ().Simulators;
+				var devices = executingTasks.First ().Simulators;
 				Jenkins.MainLog.WriteLine ("Selected simulator: {0}", devices.Length > 0 ? devices [0].Name : "none");
 
 				foreach (var dev in devices)
-					await dev.PrepareSimulatorAsync (Jenkins.MainLog, Tasks.Where ((v) => !v.Ignored && !v.Failed).Select ((v) => v.BundleIdentifier).ToArray ());
+					await dev.PrepareSimulatorAsync (Jenkins.MainLog, executingTasks.Select ((v) => v.BundleIdentifier).ToArray ());
 
-				foreach (var task in Tasks) {
+				foreach (var task in executingTasks) {
 					task.AcquiredResource = desktop;
 					try {
 						await task.RunAsync ();


### PR DESCRIPTION
Fix clearing the simulator state by properly finding the correct simulators
from tasks that will actually run, and not from potentially ignored/failed
tasks (which won't have necessarily simulators).

https://bugzilla.xamarin.com/show_bug.cgi?id=58951
https://bugzilla.xamarin.com/show_bug.cgi?id=60229