### PR TITLE
[macos] Fix guiunit error on clean builds by depending on correct copy

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -446,7 +446,7 @@ namespace xharness
 			foreach (var proj in MacTestProjects.Where ((v) => !v.GenerateVariations)) {
 				var file = proj.Path;
 
-				MacUnifiedTarget unifiedTarget = new MacUnifiedTarget (proj.GenerateModern, false, true, true) {
+				var unifiedTarget = new MacUnifiedTarget (proj.GenerateModern, false, true, true) {
 					TemplateProjectPath = file,
 					Harness = this,
 					IsNUnitProject = proj.IsNUnitProject,

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -446,24 +446,13 @@ namespace xharness
 			foreach (var proj in MacTestProjects.Where ((v) => !v.GenerateVariations)) {
 				var file = proj.Path;
 
-				MacUnifiedTarget unifiedTarget = null;
-				if (proj.GenerateModern) {
-					unifiedTarget = new MacUnifiedTarget (true, false, true, true) {
-						TemplateProjectPath = file,
-						Harness = this,
-						IsNUnitProject = proj.IsNUnitProject,
-					};
-				}
-				else if (proj.GenerateFull) {
-					unifiedTarget = new MacUnifiedTarget (false, false, true, true) {
-						TemplateProjectPath = file,
-						Harness = this,
-						IsNUnitProject = proj.IsNUnitProject,
-					};
-				}
+				MacUnifiedTarget unifiedTarget = new MacUnifiedTarget (proj.GenerateModern, false, true, true) {
+					TemplateProjectPath = file,
+					Harness = this,
+					IsNUnitProject = proj.IsNUnitProject,
+				};
 				unifiedTarget.Execute ();
 				hardcoded_unified_targets.Add (unifiedTarget);
-
  			}
  
 			MakefileGenerator.CreateMacMakefile (this, classic_targets.Union<MacTarget> (unified_targets).Union (hardcoded_unified_targets) );

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -278,7 +278,7 @@ namespace xharness
 			foreach (var p in test_suites)
 				MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p.ProjectFile + "/" + p.ProjectFile + ".sln"))) { Name = p.Name });
 			
-			MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "introspection", "Mac", "introspection-mac.csproj")), skipXMVariations: true) { Name = "introspection" });
+			MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "introspection", "Mac", "introspection-mac.csproj")), targetFrameworkFlavor: MacFlavors.Modern) { Name = "introspection" });
 
 			var hard_coded_test_suites = new [] {
 				new { ProjectFile = "mmptest", Name = "mmptest", IsNUnit = true, Configurations = (string[]) null },
@@ -296,7 +296,7 @@ namespace xharness
 
 			var bcl_suites = new string[] { "mscorlib", "System", "System.Core", "System.Data", "System.Net.Http", "System.Numerics", "System.Runtime.Serialization", "System.Transactions", "System.Web.Services", "System.Xml", "System.Xml.Linq", "Mono.Security", "System.ComponentModel.DataAnnotations", "System.Json", "System.ServiceModel.Web", "Mono.Data.Sqlite" };
 			foreach (var p in bcl_suites) {
-				MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bcl-test/" + p + "/" + p + "-Mac.csproj")), generateVariations: false) { Name = p });
+				MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bcl-test/" + p + "/" + p + "-Mac.csproj")), targetFrameworkFlavor: MacFlavors.Full, generateVariations: false) { Name = p });
 				MacBclTests.Add (new MacBCLTest (p));
 			}
 		}
@@ -413,16 +413,18 @@ namespace xharness
 
 				foreach (bool thirtyTwoBit in new bool[] { false, true })
 				{
-					var unifiedMobile = new MacUnifiedTarget (true, thirtyTwoBit)
-					{
-						TemplateProjectPath = file,
-						Harness = this,
-						IsNUnitProject = proj.IsNUnitProject,
-					};
-					unifiedMobile.Execute ();
-					unified_targets.Add (unifiedMobile);
+					if (proj.GenerateModern) {
+						var unifiedMobile = new MacUnifiedTarget (true, thirtyTwoBit)
+						{
+							TemplateProjectPath = file,
+							Harness = this,
+							IsNUnitProject = proj.IsNUnitProject,
+						};
+						unifiedMobile.Execute ();
+						unified_targets.Add (unifiedMobile);
+					}
 
-					if (!proj.SkipXMVariations) {
+					if (proj.GenerateFull) {
 						var unifiedXM45 = new MacUnifiedTarget (false, thirtyTwoBit)
 						{
 							TemplateProjectPath = file,
@@ -443,14 +445,25 @@ namespace xharness
  
 			foreach (var proj in MacTestProjects.Where ((v) => !v.GenerateVariations)) {
 				var file = proj.Path;
-				var unifiedMobile = new MacUnifiedTarget (true, false, true)
-				{
- 					TemplateProjectPath = file,
- 					Harness = this,
-					IsNUnitProject = proj.IsNUnitProject,
- 				};
-				unifiedMobile.Execute ();
-				hardcoded_unified_targets.Add (unifiedMobile);
+
+				MacUnifiedTarget unifiedTarget = null;
+				if (proj.GenerateModern) {
+					unifiedTarget = new MacUnifiedTarget (true, false, true, true) {
+						TemplateProjectPath = file,
+						Harness = this,
+						IsNUnitProject = proj.IsNUnitProject,
+					};
+				}
+				else if (proj.GenerateFull) {
+					unifiedTarget = new MacUnifiedTarget (false, false, true, true) {
+						TemplateProjectPath = file,
+						Harness = this,
+						IsNUnitProject = proj.IsNUnitProject,
+					};
+				}
+				unifiedTarget.Execute ();
+				hardcoded_unified_targets.Add (unifiedTarget);
+
  			}
  
 			MakefileGenerator.CreateMacMakefile (this, classic_targets.Union<MacTarget> (unified_targets).Union (hardcoded_unified_targets) );

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -557,7 +557,7 @@ namespace xharness
 					if (project.GenerateVariations) {
 						Tasks.Add (CloneExecuteTask (exec, TestPlatform.Mac_Unified, "-unified", ignored));
 						Tasks.Add (CloneExecuteTask (exec, TestPlatform.Mac_Unified32, "-unified-32", ignored));
-						if (!project.SkipXMVariations) {
+						if (project.GenerateFull) {
 							Tasks.Add (CloneExecuteTask (exec, TestPlatform.Mac_UnifiedXM45, "-unifiedXM45", ignored));
 							Tasks.Add (CloneExecuteTask (exec, TestPlatform.Mac_UnifiedXM45_32, "-unifiedXM45-32", ignored));
 						}

--- a/tests/xharness/MacUnifiedTarget.cs
+++ b/tests/xharness/MacUnifiedTarget.cs
@@ -9,12 +9,14 @@ namespace xharness
 
 		bool SkipProjectGeneration;
 		bool ThirtyTwoBit;
+		bool SkipSuffix;
 
-		public MacUnifiedTarget (bool mobile, bool thirtyTwoBit, bool shouldSkipProjectGeneration = false) : base ()
+		public MacUnifiedTarget (bool mobile, bool thirtyTwoBit, bool shouldSkipProjectGeneration = false, bool skipSuffix = false) : base ()
 		{
 			Mobile = mobile;
 			ThirtyTwoBit = thirtyTwoBit;
 			SkipProjectGeneration = shouldSkipProjectGeneration;
+			SkipSuffix = skipSuffix;
 		}
 
 		public override bool ShouldSkipProjectGeneration
@@ -29,7 +31,15 @@ namespace xharness
 			get {
 				if (SkipProjectGeneration)
 					return "";
-				return "-unified" + (Mobile ? "" : "XM45") + (ThirtyTwoBit ? "-32" : "");
+				string suffix = (Mobile ? "" : "XM45") + (ThirtyTwoBit ? "-32" : "");
+				return "-unified" + (SkipSuffix ? "" : suffix);
+			}
+		}
+
+		public override string MakefileWhereSuffix {
+			get {
+				string suffix = (Mobile ? "" : "XM45") + (ThirtyTwoBit ? "32" : "");
+				return "unified" + (SkipSuffix ? "" : suffix);
 			}
 		}
 			
@@ -78,12 +88,6 @@ namespace xharness
 		public override string Platform {
 			get {
 				return "mac";
-			}
-		}
-
-		public override string MakefileWhereSuffix {
-			get {
-				return "unified" + (Mobile ? "" : "XM45") + (ThirtyTwoBit ? "32" : "");
 			}
 		}
 

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -138,18 +138,24 @@ namespace xharness
 		}
 	}
 
+	public enum MacFlavors { All, Modern, Full }
+
 	public class MacTestProject : TestProject
 	{
-		public bool SkipXMVariations;
+		public MacFlavors TargetFrameworkFlavor;
+
+		public bool GenerateModern => TargetFrameworkFlavor == MacFlavors.All || TargetFrameworkFlavor == MacFlavors.Modern;
+		public bool GenerateFull => TargetFrameworkFlavor == MacFlavors.All || TargetFrameworkFlavor == MacFlavors.Full;
+
 		public string [] Configurations;
 
 		public MacTestProject () : base ()
 		{
 		}
 
-		public MacTestProject (string path, bool isExecutableProject = true, bool generateVariations = true, bool skipXMVariations = false) : base (path, isExecutableProject, generateVariations)
+		public MacTestProject (string path, bool isExecutableProject = true, bool generateVariations = true, MacFlavors targetFrameworkFlavor = MacFlavors.All) : base (path, isExecutableProject, generateVariations)
 		{
-			SkipXMVariations = skipXMVariations;
+			TargetFrameworkFlavor = targetFrameworkFlavor;
 		}
 	}
 }


### PR DESCRIPTION
- From a clean build making a BCL test would error due to the non-mobile guiunit not being built
- This was because the Makefile-mac.inc target was incorrect
- This was because xharness assumed that non variation based targets were always Modern
- However, BCL tests are Full, not Modern