### PR TITLE
[linker] Handle ParameterInfos preserved from XML definitions. Fixes #60176.

### DIFF
--- a/tests/mtouch/LinkerTests.cs
+++ b/tests/mtouch/LinkerTests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.IO;
+
+using NUnit.Framework;
+
+namespace Xamarin.Linker
+{
+	[TestFixture]
+	public partial class Preservation
+	{
+		[Test]
+		public void PreserveParameterInfoInXml ()
+		{
+			using (var mtouch = new MTouchTool ()) {
+				var xml = Path.Combine (mtouch.CreateTemporaryDirectory (), "extra.xml");
+				File.WriteAllText (xml, @"
+<linker>
+  <assembly fullname=""mscorlib"">
+    <type fullname=""System.Reflection.ParameterInfo"" />
+  </assembly>
+</linker>");
+				mtouch.Linker = MTouchLinker.LinkAll;
+				mtouch.XmlDefinitions = new string [] { xml };
+				mtouch.CreateTemporaryApp ();
+				mtouch.AssertExecute (MTouchAction.BuildSim, "build");
+			}
+		}
+	}
+}

--- a/tests/mtouch/mtouch.csproj
+++ b/tests/mtouch/mtouch.csproj
@@ -52,6 +52,7 @@
     <Compile Include="..\..\tools\common\StringUtils.cs">
       <Link>StringUtils.cs</Link>
     </Compile>
+    <Compile Include="LinkerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tools/linker/MonoTouch.Tuner/MonoTouchMarkStep.cs
+++ b/tools/linker/MonoTouch.Tuner/MonoTouchMarkStep.cs
@@ -102,11 +102,16 @@ namespace MonoTouch.Tuner {
 			// we need to track who's calling ParameterInfo.Name property getter, if it comes from
 			// user code then it's not possible to remove the parameters from the assemblies metadata
 			if (!parameter_info && (method.Name == "get_Name") && method.DeclaringType.Is ("System.Reflection", "ParameterInfo")) {
-				var a = current_method.DeclaringType.Module.Assembly;
-				if (!Profile.IsSdkAssembly (a) && !Profile.IsProductAssembly (a)) {
-					// see MetadataReducerSubStep for the consumer part of the data
-					Annotations.GetCustomAnnotations ("ParameterInfo").Add (method, current_method);
-					parameter_info = true;
+				if (current_method == null) {
+					// This can happen if ParameterInfo.get_Name is preserved in an xml file
+					Annotations.GetCustomAnnotations ("ParameterInfo").Add (method, null);
+				} else {
+					var a = current_method.DeclaringType.Module.Assembly;
+					if (!Profile.IsSdkAssembly (a) && !Profile.IsProductAssembly (a)) {
+						// see MetadataReducerSubStep for the consumer part of the data
+						Annotations.GetCustomAnnotations ("ParameterInfo").Add (method, current_method);
+						parameter_info = true;
+					}
 				}
 			}
 


### PR DESCRIPTION
Don't assume that a marked method has a caller, since a method can be marked
from XML as well.

This fixes a NullReferenceException:

```
error : Could not link assemblies.
 	Type: `System.Reflection.RuntimeParameterInfo`
 	Assembly: `mscorlib, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e`
 Reason: Object reference not set to an instance of an object
 --- inner exception
 System.NullReferenceException: Object reference not set to an instance of an object (Aufgaben-ID: 165)
   at MonoTouch.Tuner.MonoTouchMarkStep.MarkMethod (Mono.Cecil.MethodReference reference) [0x0004f] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/tools/linker/MonoTouch.Tuner/MonoTouchMarkStep.cs:105
   at Mono.Linker.Steps.MarkStep.MarkMethodCollection (System.Collections.IEnumerable methods) [0x00017] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/external/linker/linker/Mono.Linker.Steps/MarkStep.cs:1163
   at Mono.Linker.Steps.MarkStep.MarkMethods (Mono.Cecil.TypeDefinition type) [0x0000b] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/external/linker/linker/Mono.Linker.Steps/MarkStep.cs:1157
   at Xamarin.Linker.Steps.MobileMarkStep.MarkMethods (Mono.Cecil.TypeDefinition type) [0x0000b] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/tools/linker/MobileMarkStep.cs:123
   at Mono.Linker.Steps.MarkStep.ApplyPreserveInfo (Mono.Cecil.TypeDefinition type) [0x0004a] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/external/linker/linker/Mono.Linker.Steps/MarkStep.cs:1102
   at Mono.Linker.Steps.MarkStep.MarkType (Mono.Cecil.TypeReference reference) [0x001ee] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/external/linker/linker/Mono.Linker.Steps/MarkStep.cs:607
   at Xamarin.Linker.Steps.MobileMarkStep.MarkType (Mono.Cecil.TypeReference reference) [0x00001] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/tools/linker/MobileMarkStep.cs:71
   at Xamarin.Linker.Steps.CoreMarkStep.MarkType (Mono.Cecil.TypeReference reference) [0x00046] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/tools/linker/CoreMarkStep.cs:156
   at MonoTouch.Tuner.MonoTouchMarkStep.MarkType (Mono.Cecil.TypeReference reference) [0x00001] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/tools/linker/MonoTouch.Tuner/MonoTouchMarkStep.cs:84
   at Mono.Linker.Steps.MarkStep.MarkType (Mono.Cecil.TypeReference reference) [0x0007d] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/external/linker/linker/Mono.Linker.Steps/MarkStep.cs:566
   at Xamarin.Linker.Steps.MobileMarkStep.MarkType (Mono.Cecil.TypeReference reference) [0x00001] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/tools/linker/MobileMarkStep.cs:71
   at Xamarin.Linker.Steps.CoreMarkStep.MarkType (Mono.Cecil.TypeReference reference) [0x00046] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/tools/linker/CoreMarkStep.cs:156
   at MonoTouch.Tuner.MonoTouchMarkStep.MarkType (Mono.Cecil.TypeReference reference) [0x00001] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/tools/linker/MonoTouch.Tuner/MonoTouchMarkStep.cs:84
   at Mono.Linker.Steps.MarkStep.InitializeType (Mono.Cecil.TypeDefinition type) [0x0005b] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/external/linker/linker/Mono.Linker.Steps/MarkStep.cs:94
   at Mono.Linker.Steps.MarkStep.InitializeAssembly (Mono.Cecil.AssemblyDefinition assembly) [0x00025] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/external/linker/linker/Mono.Linker.Steps/MarkStep.cs:81
   at Mono.Linker.Steps.MarkStep.Initialize () [0x00016] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/external/linker/linker/Mono.Linker.Steps/MarkStep.cs:73
   at Mono.Linker.Steps.MarkStep.Process (Mono.Linker.LinkContext context) [0x00008] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/external/linker/linker/Mono.Linker.Steps/MarkStep.cs:66
   at Xamarin.Linker.Steps.MobileMarkStep.Process (Mono.Linker.LinkContext context) [0x00001] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/tools/linker/MobileMarkStep.cs:33
   at Xamarin.Linker.Steps.CoreMarkStep.Process (Mono.Linker.LinkContext context) [0x00017] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/tools/linker/CoreMarkStep.cs:26
   at MonoTouch.Tuner.MonoTouchMarkStep.Process (Mono.Linker.LinkContext context) [0x0001d] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/tools/linker/MonoTouch.Tuner/MonoTouchMarkStep.cs:36
   at Mono.Linker.Pipeline.Process (Mono.Linker.LinkContext context) [0x00023] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/external/linker/linker/Mono.Linker/Pipeline.cs:128
   at MonoTouch.Tuner.Linker.Process (MonoTouch.Tuner.LinkerOptions options, MonoTouch.Tuner.MonoTouchLinkContext& context, System.Collections.Generic.List`1[Mono.Cecil.AssemblyDefinition]& assemblies) [0x000e0] in /Users/builder/data/lanes/5481/2f8bbec0/source/xamarin-macios/tools/mtouch/Tuning.cs:82
```

https://bugzilla.xamarin.com/show_bug.cgi?id=60176