### PR TITLE
[foundation] Fix DateTime from NSDate seconds (decimal) precision loss when converting. Fix #32022

### DIFF
--- a/src/Foundation/NSDate.cs
+++ b/src/Foundation/NSDate.cs
@@ -54,7 +54,7 @@ namespace XamCore.Foundation {
 			if (dt.Kind == DateTimeKind.Unspecified)
 				throw new ArgumentException ("DateTimeKind.Unspecified cannot be safely converted");
 
-			return FromTimeIntervalSinceReferenceDate ((dt.ToUniversalTime ().Ticks - NSDATE_TICKS) / TimeSpan.TicksPerSecond);
+			return FromTimeIntervalSinceReferenceDate ((dt.ToUniversalTime ().Ticks - NSDATE_TICKS) / (double) TimeSpan.TicksPerSecond);
 		}
 #else
 		public static implicit operator DateTime (NSDate d)
@@ -72,7 +72,7 @@ namespace XamCore.Foundation {
 
 		public static implicit operator NSDate (DateTime dt)
 		{
-			return FromTimeIntervalSinceReferenceDate ((dt.ToUniversalTime ().Ticks - NSDATE_TICKS) / TimeSpan.TicksPerSecond);
+			return FromTimeIntervalSinceReferenceDate ((dt.ToUniversalTime ().Ticks - NSDATE_TICKS) / (double) TimeSpan.TicksPerSecond);
 		}
 
 		public override string ToString ()

--- a/tests/monotouch-test/Foundation/DateTest.cs
+++ b/tests/monotouch-test/Foundation/DateTest.cs
@@ -66,5 +66,14 @@ namespace MonoTouchFixtures.Foundation {
 		{
 			Assert.IsNotNull (NSDate.Now.DescriptionWithLocale (NSLocale.CurrentLocale), "1");
 		}
+
+		[Test]
+		public void Precision32022 ()
+		{
+			var a = NSDate.Now;
+			var b = a.SecondsSinceReferenceDate - ((NSDate) (DateTime) a).SecondsSinceReferenceDate;
+			// ensure decimals are not truncated - but there's an unavoidable loss of precision
+			Assert.AreEqual (b, 0, 0.00001, "1");
+		}
 	}
 }


### PR DESCRIPTION
The explicit operator did all it's math using `long` (the internal
representation for DateTime) so the fractional part of the NSDate was
lost. E.g.

> original:  530499149.239266
> roundtrip: 530499149.0

However even when using `double` computations we're still losing some
precision - parts just can be held in the `long` (Ticks) representation
of DateTime.

> original:  530499149.239266
> roundtrip: 530499149.23927

Reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=32022