### PR TITLE
[uikit] UIAccessibility.RequestGuidedAccessSession completion handler is an ObjC block. Fix #59196

### DIFF
--- a/tests/monotouch-test/UIKit/AccessibilityTest.cs
+++ b/tests/monotouch-test/UIKit/AccessibilityTest.cs
@@ -34,9 +34,9 @@ namespace MonoTouchFixtures.UIKit {
 				Assert.Inconclusive ("Requires iOS7 or later");
 
 			// should not affect execution since it needs to be a "supervised" device (and allowed in MDM)
-			//			UIAccessibility.RequestGuidedAccessSession (true, delegate (bool didSuccess) { 
-			//				Assert.Fail ("should not be reached");
-			//});
+			UIAccessibility.RequestGuidedAccessSession (true, delegate (bool didSuccess) {
+				Assert.False (didSuccess, "devices are not supervised by default");
+			});
 			UIAccessibility.RequestGuidedAccessSession (false, null);
 		}
 	}


### PR DESCRIPTION
Reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=59196