### PR TITLE
[generator] Improve the BI1001 error message to include the actual parameter type

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1673,7 +1673,7 @@ public partial class Generator : IMemberGatherer {
 				continue;
 			}
 			
-			throw new BindingException (1001, true, "Do not know how to make a trampoline for {0}", pi);
+			throw new BindingException (1001, true, $"Do not know how to make a trampoline for {pi.ParameterType.FullName}");
 		}
 
 		var rt = mi.ReturnType;


### PR DESCRIPTION
E.g. from

	error BI1001: bgen: Do not know how to make a trampoline for IKVM.Reflection.Reader.ParameterInfoImpl

to

	error BI1001: bgen: Do not know how to make a trampoline for Foundation.NSError&