### PR TITLE
Revert "bumped max Mono version to 5.8.99"

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -58,7 +58,7 @@ XCODE_DEVELOPER_ROOT=/Applications/Xcode9-GM.app/Contents/Developer
 
 # Minimum Mono version
 MIN_MONO_VERSION=5.4.0.201
-MAX_MONO_VERSION=5.8.99
+MAX_MONO_VERSION=5.4.99
 MIN_MONO_URL=https://bosstoragemirror.azureedge.net/wrench/mono-2017-06/71/71277e78f6ed32889e8c739f4ee4a3ebc946f84a/MonoFramework-MDK-5.4.0.201.macos10.xamarin.universal.pkg
 
 # Minimum Visual Studio version


### PR DESCRIPTION
Reverts xamarin/xamarin-macios#2928

Bump includes a Cecil update with a breaking change (and we can't be sure which version is installed between MIN and MAX)