### PR TITLE
[MetalPerformaceShaders] Several MPSCnnKernel properties should be readonly

### DIFF
--- a/src/metalperformanceshaders.cs
+++ b/src/metalperformanceshaders.cs
@@ -955,11 +955,27 @@ namespace XamCore.MetalPerformanceShaders {
 	[DisableDefaultCtor]
 	interface MPSCnnConvolution {
 
+		[Override]
+		[Export ("kernelWidth")]
+		nuint KernelWidth { get; }
+
+		[Override]
+		[Export ("kernelHeight")]
+		nuint KernelHeight { get; }
+
 		[Export ("inputFeatureChannels")]
 		nuint InputFeatureChannels { get; }
 
 		[Export ("outputFeatureChannels")]
 		nuint OutputFeatureChannels { get; }
+
+		[Override]
+		[Export ("strideInPixelsX")]
+		nuint StrideInPixelsX { get; }
+
+		[Override]
+		[Export ("strideInPixelsY")]
+		nuint StrideInPixelsY { get; }
 
 		[Export ("groups")]
 		nuint Groups { get; }
@@ -1046,6 +1062,22 @@ namespace XamCore.MetalPerformanceShaders {
 	[DisableDefaultCtor]
 	interface MPSCnnPooling {
 
+		[Override]
+		[Export ("kernelWidth")]
+		nuint KernelWidth { get; }
+
+		[Override]
+		[Export ("kernelHeight")]
+		nuint KernelHeight { get; }
+
+		[Override]
+		[Export ("strideInPixelsX")]
+		nuint StrideInPixelsX { get; }
+
+		[Override]
+		[Export ("strideInPixelsY")]
+		nuint StrideInPixelsY { get; }
+
 		[Export ("initWithDevice:kernelWidth:kernelHeight:")]
 		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
 
@@ -1117,6 +1149,14 @@ namespace XamCore.MetalPerformanceShaders {
 		[Export ("delta")]
 		float Delta { get; set; }
 
+		[Override]
+		[Export ("kernelWidth")]
+		nuint KernelWidth { get; }
+
+		[Override]
+		[Export ("kernelHeight")]
+		nuint KernelHeight { get; }
+
 		[Export ("initWithDevice:kernelWidth:kernelHeight:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
@@ -1151,6 +1191,14 @@ namespace XamCore.MetalPerformanceShaders {
 
 		[Export ("ps")]
 		float Ps { get; set; }
+
+		[Override]
+		[Export ("kernelWidth")]
+		nuint KernelWidth { get; }
+
+		[Override]
+		[Export ("kernelHeight")]
+		nuint KernelHeight { get; }
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:")]
 		[DesignatedInitializer]

--- a/src/metalperformanceshaders.cs
+++ b/src/metalperformanceshaders.cs
@@ -765,19 +765,19 @@ namespace XamCore.MetalPerformanceShaders {
 
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("kernelWidth")]
-		nuint KernelWidth { get; set; }
+		nuint KernelWidth { get; }
 
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("kernelHeight")]
-		nuint KernelHeight { get; set; }
+		nuint KernelHeight { get; }
 
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("strideInPixelsX")]
-		nuint StrideInPixelsX { get; set; }
+		nuint StrideInPixelsX { get; }
 
 		[TV (11, 0), iOS (11, 0)]
 		[Export ("strideInPixelsY")]
-		nuint StrideInPixelsY { get; set; }
+		nuint StrideInPixelsY { get; }
 	}
 
 	[iOS (10,0)][TV (10,0)][Mac (10, 13, onlyOn64: true)]
@@ -955,23 +955,11 @@ namespace XamCore.MetalPerformanceShaders {
 	[DisableDefaultCtor]
 	interface MPSCnnConvolution {
 
-		[Export ("kernelWidth")]
-		nuint KernelWidth { get; }
-
-		[Export ("kernelHeight")]
-		nuint KernelHeight { get; }
-
 		[Export ("inputFeatureChannels")]
 		nuint InputFeatureChannels { get; }
 
 		[Export ("outputFeatureChannels")]
 		nuint OutputFeatureChannels { get; }
-
-		[Export ("strideInPixelsX")]
-		nuint StrideInPixelsX { get; }
-
-		[Export ("strideInPixelsY")]
-		nuint StrideInPixelsY { get; }
 
 		[Export ("groups")]
 		nuint Groups { get; }
@@ -1058,18 +1046,6 @@ namespace XamCore.MetalPerformanceShaders {
 	[DisableDefaultCtor]
 	interface MPSCnnPooling {
 
-		[Export ("kernelWidth")]
-		nuint KernelWidth { get; }
-
-		[Export ("kernelHeight")]
-		nuint KernelHeight { get; }
-
-		[Export ("strideInPixelsX")]
-		nuint StrideInPixelsX { get; }
-
-		[Export ("strideInPixelsY")]
-		nuint StrideInPixelsY { get; }
-
 		[Export ("initWithDevice:kernelWidth:kernelHeight:")]
 		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
 
@@ -1141,12 +1117,6 @@ namespace XamCore.MetalPerformanceShaders {
 		[Export ("delta")]
 		float Delta { get; set; }
 
-		[Export ("kernelWidth")]
-		nuint KernelWidth { get; }
-
-		[Export ("kernelHeight")]
-		nuint KernelHeight { get; }
-
 		[Export ("initWithDevice:kernelWidth:kernelHeight:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device, nuint kernelWidth, nuint kernelHeight);
@@ -1181,12 +1151,6 @@ namespace XamCore.MetalPerformanceShaders {
 
 		[Export ("ps")]
 		float Ps { get; set; }
-
-		[Export ("kernelWidth")]
-		nuint KernelWidth { get; }
-
-		[Export ("kernelHeight")]
-		nuint KernelHeight { get; }
 
 		[Export ("initWithDevice:kernelWidth:kernelHeight:")]
 		[DesignatedInitializer]


### PR DESCRIPTION
KernelWidth, KernelHeight, StrideInPixelsX, and StrideInPixelsY were moved to the base class, so the properties aren't needed in this subclasses anymore.  