### PR TITLE
[security] Add RequestSharedWebCredential overload. Fixes #60423

### DIFF
--- a/src/Security/SecSharedCredential.cs
+++ b/src/Security/SecSharedCredential.cs
@@ -8,26 +8,7 @@ using XamCore.ObjCRuntime;
 using XamCore.CoreFoundation;
 using XamCore.Foundation;
 
-#if XAMCORE_2_0
-using xint = System.nuint;
-#else
-using xint = System.Int32;
-#endif
-
 namespace XamCore.Security {
-
-	public partial class SecSharedCredentialInfo {
-
-		public int? Port {
-			get { return _Port?.Int32Value; }
-			set {
-				if (value == null)
-					_Port = null;
-				else
-					_Port = new NSNumber (value.Value);
-			}
-		}
-	}
 
 	public static partial class SecSharedCredential {
 
@@ -120,9 +101,9 @@ namespace XamCore.Security {
 		{
 			Action<NSArray, NSError> onComplete = (NSArray a, NSError e) => {
 				var creds = new SecSharedCredentialInfo [a.Count];
-				for (xint i = 0; i < a.Count; i++) {
-					var dict = a.GetItem<NSDictionary> (i);
-					creds [i] = new SecSharedCredentialInfo (dict);
+				int i = 0;
+				foreach (var dict in NSArray.FromArrayNative<NSDictionary> (a)) {
+					creds [i++] = new SecSharedCredentialInfo (dict);
 				}
 				handler (creds, e);
 			};

--- a/src/security.cs
+++ b/src/security.cs
@@ -891,4 +891,36 @@ namespace XamCore.Security {
 
 		NSData SharedInfo { get; set; }
 	}
+
+#if IOS
+	[iOS (8,0)][NoTV][NoWatch][NoMac]
+	[Internal][Static]
+	interface SecSharedCredentialKeys {
+		[Field ("kSecAttrServer")]
+		NSString ServerKey { get; }
+
+		[Field ("kSecAttrAccount")]
+		NSString AccountKey { get; }
+
+		[Field ("kSecSharedPassword")]
+		NSString PasswordKey { get; }
+
+		[Field ("kSecAttrPort")]
+		NSString _PortKey { get; }
+	}
+
+	[iOS (8,0)][NoTV][NoWatch][NoMac]
+	[StrongDictionary ("SecSharedCredentialKeys")]
+	interface SecSharedCredentialInfo {
+
+		string Server { get; set; }
+
+		string Account { get; set; }
+
+		string Password { get; set; }
+
+		[Internal]
+		NSNumber _Port { get; set; }
+	}
+#endif
 }

--- a/src/security.cs
+++ b/src/security.cs
@@ -906,7 +906,7 @@ namespace XamCore.Security {
 		NSString PasswordKey { get; }
 
 		[Field ("kSecAttrPort")]
-		NSString _PortKey { get; }
+		NSString PortKey { get; }
 	}
 
 	[iOS (8,0)][NoTV][NoWatch][NoMac]
@@ -919,8 +919,7 @@ namespace XamCore.Security {
 
 		string Password { get; set; }
 
-		[Internal]
-		NSNumber _Port { get; set; }
+		int Port { get; set; }
 	}
 #endif
 }

--- a/tests/monotouch-test/Security/SecSharedCredentialTest.cs
+++ b/tests/monotouch-test/Security/SecSharedCredentialTest.cs
@@ -94,40 +94,6 @@ namespace MonoTouchFixtures.Security {
 		}
 
 		[Test]
-		// We do not want to block for a long period of time if the event is not set.
-		// We are testing the fact that the trampoline works.
-		[Timeout (5000)]
-		public void RequestSharedWebCredentialNullDomain ()
-		{
-			if (!TestRuntime.CheckSystemAndSDKVersion (8, 0))
-				Assert.Ignore ("Ignoring RequestSharedWebCredentialNullDomain test: Requires iOS8+");
-
-			Action <string[], NSError> getHandler = (string [] pwds, NSError e) => {
-				waitEvent.Set ();
-			};
-			SecSharedCredential.RequestSharedWebCredential (null, account, getHandler);
-			waitEvent.WaitOne ();
-			Assert.Pass ("Block was correctly executed.");
-		}
-
-		[Test]
-		// We do not want to block for a long period of time if the event is not set.
-		// We are testing the fact that the trampoline works.
-		[Timeout (5000)]
-		public void RequestSharedWebCredentialNullAccount ()
-		{
-			if (!TestRuntime.CheckSystemAndSDKVersion (8, 0))
-				Assert.Ignore ("Ignoring RequestSharedWebCredentialNullAccount test: Requires iOS8+");
-
-			Action <string[], NSError> getHandler = (string [] pwds, NSError e) => {
-				waitEvent.Set ();
-			};
-			SecSharedCredential.RequestSharedWebCredential (null, null, getHandler);
-			waitEvent.WaitOne ();
-			Assert.Pass ("Block was correctly executed.");
-		}
-
-		[Test]
 		public void CreateSharedWebCredentialPassword ()
 		{
 			if (!TestRuntime.CheckSystemAndSDKVersion (8, 0))


### PR DESCRIPTION
* The original API was incorrect. Lack of documentation at binding time?
* Use a strong dictionary to expose the credentials

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=60423