### PR TITLE
Revert "[msbuild] Fixed Condition for CalculateCodesignAppBundleInputs (#2843)"

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
@@ -29,7 +29,6 @@ namespace Xamarin.MacDev.Tasks
 		[Required]
 		public string BundleIdentifier { get; set; }
 
-		[Output]
 		[Required]
 		public string CompiledEntitlements { get; set; }
 
@@ -316,6 +315,9 @@ namespace Xamarin.MacDev.Tasks
 					Log.LogError ("Could not locate the provisioning profile with a Name or UUID of {0}.", ProvisioningProfile);
 					return false;
 				}
+			} else if (Platform == MobileProvisionPlatform.iOS) {
+				Log.LogError ("Provisioning Profiles are REQUIRED for iOS.");
+				return false;
 			} else {
 				profile = null;
 			}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
@@ -353,7 +353,7 @@ namespace Xamarin.MacDev.Tasks
 				return !Log.HasLoggedErrors;
 			}
 
-			if (!RequireProvisioningProfile) {
+			if (!RequireProvisioningProfile && string.IsNullOrEmpty (ProvisioningProfile)) {
 				if (SdkIsSimulator && AppleSdkSettings.XcodeVersion.Major >= 8) {
 					// Note: Starting with Xcode 8.0, we need to codesign iOS Simulator builds in order for them to run.
 					// The "-" key is a special value allowed by the codesign utility that allows us to get away with

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -70,6 +70,7 @@ namespace Xamarin.iOS.Tasks
 
 		public string ArchiveSymbols { get; set; }
 
+		[Required]
 		public string CompiledEntitlements { get; set; }
 
 		[Required]
@@ -80,6 +81,8 @@ namespace Xamarin.iOS.Tasks
 
 		[Required]
 		public bool EnableGenericValueTypeSharing { get; set; }
+
+		public string Entitlements { get; set; }
 
 		public string License { get; set; }
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -120,7 +120,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<_RequireCodeSigning Condition="'$(ComputedPlatform)' == 'iPhone'">True</_RequireCodeSigning>
 
 		<_RequireProvisioningProfile>False</_RequireProvisioningProfile>
-		<_RequireProvisioningProfile Condition="'$(ComputedPlatform)' == 'iPhone'">True</_RequireProvisioningProfile>
+		<_RequireProvisioningProfile Condition="'$(ComputedPlatform)' == 'iPhone' Or '$(CodesignEntitlements)' != ''">True</_RequireProvisioningProfile>
 
 		<_PreparedResourceRules></_PreparedResourceRules>
 		<_AppBundleName>$(AssemblyName)</_AppBundleName>
@@ -781,9 +781,10 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			AppBundleDir="$(AppBundleDir)"
 			AppManifest="$(_AppBundlePath)Info.plist"
 			Architectures="$(TargetArchitectures)"
+			Entitlements="$(CodesignEntitlements)"
 			ExecutableName="$(_ExecutableName)"
 			NativeExecutable="$(_NativeExecutable)"
-			CompiledEntitlements="$(_CompiledEntitlements)"
+			CompiledEntitlements="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent"
 			Debug="$(MtouchDebug)"
 			EnableGenericValueTypeSharing="$(MtouchEnableGenericValueTypeSharing)"
 			ExtraArgs="$(MtouchExtraArgs)"
@@ -1394,7 +1395,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<CreatePkgInfo SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" OutputPath="$(_AppBundlePath)PkgInfo" />
 	</Target>
 
-	<Target Name="_EmbedMobileProvision" Condition="'$(_RequireProvisioningProfile)' == 'true'" DependsOnTargets="_GenerateBundleName;_DetectSigningIdentity"
+	<Target Name="_EmbedMobileProvision" Condition="'$(_RequireCodeSigning)' == 'true'" DependsOnTargets="_GenerateBundleName;_DetectSigningIdentity"
 		Outputs="$(_AppBundlePath)embedded.mobileprovision">
 		<EmbedMobileProvision
 			SessionId="$(BuildSessionId)"
@@ -1405,7 +1406,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</EmbedMobileProvision>
 	</Target>
 
-	<Target Name="_CompileEntitlements" Condition="'$(_RequireCodeSigning)' == 'true'" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectSigningIdentity"
+	<Target Name="_CompileEntitlements" Condition="'$(_RequireCodeSigning)' == 'true' Or '$(CodesignEntitlements)' != ''" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectSigningIdentity"
 		Outputs="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent">
 		<CompileEntitlements
 			SessionId="$(BuildSessionId)"
@@ -1421,7 +1422,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			SdkVersion="$(MtouchSdkVersion)"
 			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			>
-			<Output TaskParameter="CompiledEntitlements" PropertyName="_CompiledEntitlements" />
 		</CompileEntitlements>
 	</Target>
 
@@ -1676,7 +1676,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<PropertyGroup>
 			<_CodesignDisableTimestamp>False</_CodesignDisableTimestamp>
-			<_CodesignDisableTimestamp Condition="'$(_CodeSigningKey)' == '-' Or '$(MtouchDebug)' == 'true'">True</_CodesignDisableTimestamp>
+			<_CodesignDisableTimestamp Condition="'$(_SdkIsSimulator)' == 'true' Or '$(MtouchDebug)' == 'true'">True</_CodesignDisableTimestamp>
 		</PropertyGroup>
 
 		<CodesignNativeLibraries
@@ -1700,7 +1700,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<PropertyGroup>
 			<_CodesignDisableTimestamp>False</_CodesignDisableTimestamp>
-			<_CodesignDisableTimestamp Condition="'$(_CodeSigningKey)' == '-' Or '$(MtouchDebug)' == 'true'">True</_CodesignDisableTimestamp>
+			<_CodesignDisableTimestamp Condition="'$(_SdkIsSimulator)' == 'true' Or '$(MtouchDebug)' == 'true'">True</_CodesignDisableTimestamp>
 		</PropertyGroup>
 
 		<Codesign
@@ -1735,7 +1735,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</ReadItemsFromFile>
 	</Target>
 
-	<Target Name="_CodesignAppExtensions" Condition="('$(_CanOutputAppBundle)' == 'true' And '$(_CodeSigningKey)' != '') And '@(_AppExtensionCodesignProperties)' != ''"
+	<Target Name="_CodesignAppExtensions" Condition="'$(_RequireCodeSigning)' == 'true' And '@(_AppExtensionCodesignProperties)' != ''"
 		DependsOnTargets="_DetectSigningIdentity;_ReadAppExtensionCodesignProperties"
 		Inputs="$(_AppBundlePath)PlugIns\%(_AppExtensionCodesignProperties.Identity)\%(_AppExtensionCodesignProperties.NativeExecutable);%(_AppExtensionCodesignProperties.CodesignAppExtensionInputs)"
 		Outputs="$(_AppBundlePath)PlugIns\%(_AppExtensionCodesignProperties.Identity)\_CodeSignature\CodeResources">
@@ -1773,15 +1773,14 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<Touch
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true' And ('$(_CanOutputAppBundle)' == 'true' And '$(_CodeSigningKey)' != '') And Exists ('$(AppBundleDir)\..\%(_AppExtensionCodesignProperties.Identity).dSYM\Contents\Info.plist')"
+			Condition="'$(IsMacEnabled)' == 'true' And '$(_RequireCodeSigning)' == 'true' And Exists ('$(AppBundleDir)\..\%(_AppExtensionCodesignProperties.Identity).dSYM\Contents\Info.plist')"
 			Files="$(AppBundleDir)\..\%(_AppExtensionCodesignProperties.Identity).dSYM\Contents\Info.plist"
 		/>
 	</Target>
 
-	<Target Name="_PrepareCodesignAppExtension" Condition="('$(_CanOutputAppBundle)' == 'true' And '$(_CodeSigningKey)' != '') And '$(IsAppExtension)' == 'true' And '@(_ResolvedAppBundleExtensions)' == ''">
+	<Target Name="_PrepareCodesignAppExtension" Condition="'$(_RequireCodeSigning)' == 'true' And '$(IsAppExtension)' == 'true' And '@(_ResolvedAppBundleExtensions)' == ''">
 		<!-- For App Extensions, we delay running codesign until it has been copied into the main app bundle... -->
 		<PropertyGroup>
-			<_CompiledEntitlementsFullPath></_CompiledEntitlementsFullPath>
 			<_ResourceRulesFullPath></_ResourceRulesFullPath>
 		</PropertyGroup>
 
@@ -1789,8 +1788,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<Output TaskParameter="FullPath" PropertyName="_AppBundleFullPath" />
 		</GetFullPath>
 
-		<GetFullPath SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '$(_CompiledEntitlements)' != ''" RelativePath="$(_CompiledEntitlements)">
-			<Output TaskParameter="FullPath" PropertyName="_CompiledEntitlementsFullPath" />
+		<GetFullPath SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" RelativePath="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent">
+			<Output TaskParameter="FullPath" PropertyName="_EntitlementsFullPath" />
 		</GetFullPath>
 
 		<GetFullPath SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '$(_PreparedResourceRules)' != ''" RelativePath="$(_PreparedResourceRules)">
@@ -1807,7 +1806,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<_NativeExecutableFileName>$([System.IO.Path]::GetFileName('$(_NativeExecutable)'))</_NativeExecutableFileName>
 
 			<_CodesignDisableTimestamp>False</_CodesignDisableTimestamp>
-			<_CodesignDisableTimestamp Condition="'$(_CodeSigningKey)' == '-' Or '$(MtouchDebug)' == 'true'">True</_CodesignDisableTimestamp>
+			<_CodesignDisableTimestamp Condition="'$(_SdkIsSimulator)' == 'true' Or '$(MtouchDebug)' == 'true'">True</_CodesignDisableTimestamp>
 
 			<_CodesignAppExtensionInputs>@(_AppExtensionBundleFiles);$(_EntitlementsFullPath)</_CodesignAppExtensionInputs>
 		</PropertyGroup>
@@ -1820,7 +1819,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 				<NativeExecutable>$(_NativeExecutableFileName)</NativeExecutable>
 				<CodesignAllocate>$(_CodesignAllocate)</CodesignAllocate>
 				<DisableTimestamp>$(_CodesignDisableTimestamp)</DisableTimestamp>
-				<Entitlements>$(_CompiledEntitlementsFullPath)</Entitlements>
+				<Entitlements>$(_EntitlementsFullPath)</Entitlements>
 				<ResourceRules>$(_ResourceRulesFullPath)</ResourceRules>
 				<Keychain>$(CodesignKeychain)</Keychain>
 				<SigningKey>$(_CodeSigningKey)</SigningKey>
@@ -1838,7 +1837,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		/>
 	</Target>
 
-	<Target Name="_CalculateCodesignAppBundleInputs" Condition="('$(_CanOutputAppBundle)' == 'true' And '$(_CodeSigningKey)' != '') And ('$(IsAppExtension)' == 'false' Or '@(_ResolvedAppExtensionReferences)' != '')">
+	<Target Name="_CalculateCodesignAppBundleInputs" Condition="'$(_RequireCodeSigning)' == 'true' And ('$(IsAppExtension)' == 'false' Or '@(_ResolvedAppExtensionReferences)' != '')">
 		<ItemGroup>
 			<_CodesignAppBundleInputs Include="$(_AppBundlePath)**\*.*" Exclude="$(_AppBundlePath)_CodeSignature\CodeResources" />
 		</ItemGroup>
@@ -1849,7 +1848,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<PropertyGroup>
 			<_CodesignDisableTimestamp>False</_CodesignDisableTimestamp>
-			<_CodesignDisableTimestamp Condition="'$(_CodeSigningKey)' == '-' Or '$(MtouchDebug)' == 'true'">True</_CodesignDisableTimestamp>
+			<_CodesignDisableTimestamp Condition="'$(_SdkIsSimulator)' == 'true' Or '$(MtouchDebug)' == 'true'">True</_CodesignDisableTimestamp>
 		</PropertyGroup>
 
 		<Codesign
@@ -1860,7 +1859,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			CodesignAllocate="$(_CodesignAllocate)"
 			DisableTimestamp="$(_CodesignDisableTimestamp)"
 			Keychain="$(CodesignKeychain)"
-			Entitlements="$(_CompiledEntitlements)"
+			Entitlements="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent"
 			ResourceRules="$(_PreparedResourceRules)"
 			Resources="$(AppBundleDir)"
 			SigningKey="$(_CodeSigningKey)"
@@ -2005,7 +2004,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<IsStreamable Condition="'$(EmbedOnDemandResources)' == 'false'">true</IsStreamable>
 
 			<_CodesignDisableTimestamp>False</_CodesignDisableTimestamp>
-			<_CodesignDisableTimestamp Condition="'$(_CodeSigningKey)' == '-' Or '$(MtouchDebug)' == 'true'">True</_CodesignDisableTimestamp>
+			<_CodesignDisableTimestamp Condition="'$(_SdkIsSimulator)' == 'true' Or '$(MtouchDebug)' == 'true'">True</_CodesignDisableTimestamp>
 		</PropertyGroup>
 		
 		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(_IntermediateODRDir)" />
@@ -2049,7 +2048,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			CodesignAllocate="$(_CodesignAllocate)"
 			DisableTimestamp="$(_CodesignDisableTimestamp)"
 			Keychain="$(CodesignKeychain)"
-			Entitlements="$(_CompiledEntitlements)"
+			Entitlements="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent"
 			Resources="@(_AssetPack)"
 			SigningKey="$(_CodeSigningKey)"
 			ExtraArgs="$(CodesignExtraArgs)"
@@ -2076,7 +2075,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			CodesignAllocate="$(_CodesignAllocate)"
 			DisableTimestamp="$(_CodesignDisableTimestamp)"
 			Keychain="$(CodesignKeychain)"
-			Entitlements="$(_CompiledEntitlements)"
+			Entitlements="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent"
 			ResourceRules="$(_PreparedResourceRules)"
 			Resources="$(_IpaAppBundleDir)"
 			SigningKey="$(_CodeSigningKey)"

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/CodesignAppBundle.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/CodesignAppBundle.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Diagnostics;
-using System.Collections.Generic;
 
 using NUnit.Framework;
 
@@ -11,15 +9,13 @@ using Xamarin.MacDev;
 
 namespace Xamarin.iOS.Tasks
 {
-	[TestFixture ("iPhone", "Debug")]
-	[TestFixture ("iPhone", "Release")]
-	[TestFixture ("iPhoneSimulator", "Debug")]
-	[TestFixture ("iPhoneSimulator", "Release")]
+	[TestFixture ("Debug")]
+	[TestFixture ("Release")]
 	public class CodesignAppBundle : ProjectTest
 	{
 		readonly string config;
 
-		public CodesignAppBundle (string platform, string configuration) : base (platform)
+		public CodesignAppBundle (string configuration) : base ("iPhone")
 		{
 			config = configuration;
 		}
@@ -66,12 +62,8 @@ namespace Xamarin.iOS.Tasks
 			var appexDsymDir = Path.GetFullPath (Path.Combine (AppBundlePath, "..", "MyActionExtension.appex.dSYM"));
 
 			var timestamps = Directory.EnumerateFiles (AppBundlePath, "*.*", SearchOption.TopDirectoryOnly).ToDictionary (file => file, file => GetLastModified (file));
-			Dictionary<string, DateTime> dsymTimestamps = null, appexDsymTimestamps = null;
-
-			if (Platform != "iPhoneSimulator") {
-				dsymTimestamps = Directory.EnumerateFiles (dsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
-				appexDsymTimestamps = Directory.EnumerateFiles (appexDsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
-			}
+			var dsymTimestamps = Directory.EnumerateFiles (dsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
+			var appexDsymTimestamps = Directory.EnumerateFiles (appexDsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
 
 			Thread.Sleep (1000);
 
@@ -81,6 +73,8 @@ namespace Xamarin.iOS.Tasks
 			AssertProperlyCodesigned ();
 
 			var newTimestamps = Directory.EnumerateFiles (AppBundlePath, "*.*", SearchOption.TopDirectoryOnly).ToDictionary (file => file, file => GetLastModified (file));
+			var newDsymTimestamps = Directory.EnumerateFiles (dsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
+			var newAppexDsymTimestamps = Directory.EnumerateFiles (appexDsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
 
 			foreach (var file in timestamps.Keys) {
 				// The executable files will all be newer because they get touched during each Build, all other files should not change
@@ -90,27 +84,22 @@ namespace Xamarin.iOS.Tasks
 				Assert.AreEqual (timestamps[file], newTimestamps[file], "App Bundle timestamp changed: " + file);
 			}
 
-			if (Platform != "iPhoneSimulator") {
-				var newDsymTimestamps = Directory.EnumerateFiles (dsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
-				var newAppexDsymTimestamps = Directory.EnumerateFiles (appexDsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
-
-				foreach (var file in dsymTimestamps.Keys) {
-					// The Info.plist should be newer because it gets touched
-					if (Path.GetFileName (file) == "Info.plist") {
-						Assert.IsTrue (dsymTimestamps[file] < newDsymTimestamps[file], "App Bundle dSYMs Info.plist not touched: " + file);
-					} else {
-						Assert.AreEqual (dsymTimestamps[file], newDsymTimestamps[file], "App Bundle dSYMs changed: " + file);
-					}
+			foreach (var file in dsymTimestamps.Keys) {
+				// The Info.plist should be newer because it gets touched
+				if (Path.GetFileName (file) == "Info.plist") {
+					Assert.IsTrue (dsymTimestamps[file] < newDsymTimestamps[file], "App Bundle dSYMs Info.plist not touched: " + file);
+				} else {
+					Assert.AreEqual (dsymTimestamps[file], newDsymTimestamps[file], "App Bundle dSYMs changed: " + file);
 				}
-
-				// The appex dSYMs will all be newer because they currently get regenerated after each Build due to the fact that the entire
-				// *.appex gets cloned into the app bundle each time.
-				//
-				// Note: we could fix this by not using `ditto` and instead implementing this ourselves to only overwrite files if they've changed
-				// and then setting some [Output] params that specify whether or not we need to re-codesign and/or strip debug symbols.
-				foreach (var file in appexDsymTimestamps.Keys)
-					Assert.IsTrue (appexDsymTimestamps[file] < newAppexDsymTimestamps[file], "App Extension dSYMs should be newer: " + file);
 			}
+
+			// The appex dSYMs will all be newer because they currently get regenerated after each Build due to the fact that the entire
+			// *.appex gets cloned into the app bundle each time.
+			//
+			// Note: we could fix this by not using `ditto` and instead implementing this ourselves to only overwrite files if they've changed
+			// and then setting some [Output] params that specify whether or not we need to re-codesign and/or strip debug symbols.
+			foreach (var file in appexDsymTimestamps.Keys)
+				Assert.IsTrue (appexDsymTimestamps[file] < newAppexDsymTimestamps[file], "App Extension dSYMs should be newer: " + file);
 		}
 
 		[Test]


### PR DESCRIPTION
This reverts commit cb216083f1cf1c9e19d94107951eed8bc7fafbf7, because it breaks several monotouch-tests:

    [FAIL] KeyChainTest.Add_Certificate :   Add_Certificate
    [FAIL] KeyChainTest.AddQueryRemove_Identity :   Expected: True
    [FAIL] KeyChainTest.CheckId :   same guid
    [FAIL] KeyChainTest.SecItemAdd_Identity :   Expected: True
    [FAIL] RecordTest.Accessible_17579 :   Add
    [FAIL] RecordTest.AuthenticationType_17579 :   Add
    [FAIL] RecordTest.DeskCase_83099_InmutableDictionary :   Password could not be saved to keychain
    [FAIL] RecordTest.IdentityRecordTest :   Identity added
    [FAIL] RecordTest.Protocol_17579 :   Add