### PR TITLE
[macOS] NSCollectionView.ValidateDrop should use 'ref', not 'out'.  Fixes #60416

### DIFF
--- a/src/AppKit/NSCollectionViewDelegate.cs
+++ b/src/AppKit/NSCollectionViewDelegate.cs
@@ -1,0 +1,38 @@
+﻿#if !XAMCORE_4_0
+using System;
+using XamCore.Foundation;
+using XamCore.ObjCRuntime;
+
+namespace XamCore.AppKit
+{
+	public partial class NSCollectionViewDelegate
+	{
+		[Obsolete ("Use 'ValidateDropOperation (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation)' instead.")]
+		[Mac (10, 11)]
+		public virtual NSDragOperation ValidateDrop (NSCollectionView collectionView, NSDraggingInfo draggingInfo, out NSIndexPath proposedDropIndexPath, out NSCollectionViewDropOperation proposedDropOperation)
+		{
+			throw new InvalidOperationException ("Use 'ValidateDropOperation (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation)' instead.");
+		}
+	}
+
+	public partial class NSCollectionViewDelegateFlowLayout
+	{
+		[Obsolete ("Use 'ValidateDropOperation (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation)' instead.")]
+		[Mac (10, 11)]
+		public virtual NSDragOperation ValidateDrop (NSCollectionView collectionView, NSDraggingInfo draggingInfo, out NSIndexPath proposedDropIndexPath, out NSCollectionViewDropOperation proposedDropOperation)
+		{
+			throw new InvalidOperationException ("Use 'ValidateDropOperation (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation)' instead.");
+		}
+	}
+
+	public static partial class NSCollectionViewDelegate_Extensions
+	{
+		[Obsolete ("Use 'ValidateDropOperation (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation)' instead.")]
+		[Mac (10, 11)]
+		public static NSDragOperation ValidateDrop (this INSCollectionViewDelegate This, NSCollectionView collectionView, NSDraggingInfo draggingInfo, out NSIndexPath proposedDropIndexPath, out NSCollectionViewDropOperation proposedDropOperation)
+		{
+			throw new InvalidOperationException ("Use 'ValidateDropOperation (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation)' instead.");
+		}
+	}
+}
+#endif

--- a/src/AppKit/NSCollectionViewDelegate.cs
+++ b/src/AppKit/NSCollectionViewDelegate.cs
@@ -11,7 +11,9 @@ namespace XamCore.AppKit
 		[Mac (10, 11)]
 		public virtual NSDragOperation ValidateDrop (NSCollectionView collectionView, NSDraggingInfo draggingInfo, out NSIndexPath proposedDropIndexPath, out NSCollectionViewDropOperation proposedDropOperation)
 		{
-			throw new InvalidOperationException ("Use 'ValidateDropOperation (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation)' instead.");
+			proposedDropIndexPath = null;
+			proposedDropOperation = NSCollectionViewDropOperation.On;
+			return ValidateDropOperation (collectionView, draggingInfo, ref proposedDropIndexPath, ref proposedDropOperation);
 		}
 	}
 
@@ -21,7 +23,9 @@ namespace XamCore.AppKit
 		[Mac (10, 11)]
 		public virtual NSDragOperation ValidateDrop (NSCollectionView collectionView, NSDraggingInfo draggingInfo, out NSIndexPath proposedDropIndexPath, out NSCollectionViewDropOperation proposedDropOperation)
 		{
-			throw new InvalidOperationException ("Use 'ValidateDropOperation (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation)' instead.");
+			proposedDropIndexPath = null;
+			proposedDropOperation = NSCollectionViewDropOperation.On;
+			return ValidateDropOperation (collectionView, draggingInfo, ref proposedDropIndexPath, ref proposedDropOperation);
 		}
 	}
 
@@ -31,7 +35,9 @@ namespace XamCore.AppKit
 		[Mac (10, 11)]
 		public static NSDragOperation ValidateDrop (this INSCollectionViewDelegate This, NSCollectionView collectionView, NSDraggingInfo draggingInfo, out NSIndexPath proposedDropIndexPath, out NSCollectionViewDropOperation proposedDropOperation)
 		{
-			throw new InvalidOperationException ("Use 'ValidateDropOperation (NSCollectionView collectionView, NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation)' instead.");
+			proposedDropIndexPath = null;
+			proposedDropOperation = NSCollectionViewDropOperation.On;
+			return This.ValidateDropOperation (collectionView, draggingInfo, ref proposedDropIndexPath, ref proposedDropOperation);
 		}
 	}
 }

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -3008,9 +3008,15 @@ namespace XamCore.AppKit {
 		[Export ("collectionView:draggingImageForItemsAtIndexPaths:withEvent:offset:")]
 		NSImage GetDraggingImage (NSCollectionView collectionView, NSSet indexPaths, NSEvent theEvent, ref CGPoint dragImageOffset);
 
+#if !XAMCORE_4_0
 		[Mac (10,11)]
 		[Export ("collectionView:validateDrop:proposedIndexPath:dropOperation:")]
-		NSDragOperation ValidateDrop (NSCollectionView collectionView, [Protocolize (4)] NSDraggingInfo draggingInfo, out NSIndexPath proposedDropIndexPath, out NSCollectionViewDropOperation proposedDropOperation);
+		NSDragOperation ValidateDropOperation (NSCollectionView collectionView, [Protocolize (4)] NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation);
+#else
+		[Mac (10,11)]
+		[Export ("collectionView:validateDrop:proposedIndexPath:dropOperation:")]
+		NSDragOperation ValidateDrop (NSCollectionView collectionView, [Protocolize (4)] NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation);
+#endif
 
 		[Mac (10,11)]
 		[Export ("collectionView:acceptDrop:indexPath:dropOperation:")]

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -3015,7 +3015,7 @@ namespace XamCore.AppKit {
 #else
 		[Mac (10,11)]
 		[Export ("collectionView:validateDrop:proposedIndexPath:dropOperation:")]
-		NSDragOperation ValidateDrop (NSCollectionView collectionView, [Protocolize (4)] NSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation);
+		NSDragOperation ValidateDrop (NSCollectionView collectionView, INSDraggingInfo draggingInfo, ref NSIndexPath proposedDropIndexPath, ref NSCollectionViewDropOperation proposedDropOperation);
 #endif
 
 		[Mac (10,11)]

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -145,6 +145,7 @@ APPKIT_SOURCES = \
 	AppKit/NSSavePanel.cs \
 	AppKit/NSWorkspace.cs \
 	AppKit/NSCollectionView.cs \
+	AppKit/NSCollectionViewDelegate.cs \
 	AppKit/NSTextTableBlock.cs \
 	AppKit/NSMutableFontCollection.cs \
 	AppKit/NSCollectionViewLayout.cs \


### PR DESCRIPTION
The two pointer parameters pass in the proposed index and operation to the method, then the developer has the option to change those values if desired inside the method.  The current binding using 'out' parameters is never called when it is supposed to be in an application.  

Because it is an existing binding, we cannot simply change the parameters to 'refs' and instead have to bind a new method using 'ref' and use code-behind to keep versions of the old binding around.

The new method also has to have a new name, because you can not have 2 methods with matching signatures where the only difference is 'ref' versus 'out.