### PR TITLE
[Generator] BindAs attribute for smart enum to multidimensional array generates code that doesn't compile, Fixes Bug 57795

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1302,7 +1302,7 @@ public partial class Generator : IMemberGatherer {
 		} else if (originalType == TypeManager.NSString && IsSmartEnum (retType)) {
 			temp = isNullable ? $"{parameterName} == null ? null : " : string.Empty;
 			temp += $"{FormatType (retType.DeclaringType, retType)}Extensions.GetConstant ({parameterName}{denullify});";
-		} else if (originalType.IsArray) {
+		} else if (originalType.IsArray && originalType.GetArrayRank () == 1) {
 			var arrType = originalType.GetElementType ();
 			var arrRetType = TypeManager.GetUnderlyingNullableType (retType.GetElementType ()) ?? retType.GetElementType ();
 			var valueConverter = string.Empty;
@@ -1443,7 +1443,7 @@ public partial class Generator : IMemberGatherer {
 		} else if (originalReturnType == TypeManager.NSString && IsSmartEnum (retType)) {
 			append = $"{FormatType (retType.DeclaringType, retType)}Extensions.GetValue (";
 			suffix = ")";
-		} else if (originalReturnType.IsArray) {
+		} else if (originalReturnType.IsArray && originalReturnType.GetArrayRank () == 1) {
 			var arrType = originalReturnType.GetElementType ();
 			var nullableElementType = TypeManager.GetUnderlyingNullableType (retType.GetElementType ());
 			var arrIsNullable = nullableElementType != null;

--- a/tests/generator/ErrorTests.cs
+++ b/tests/generator/ErrorTests.cs
@@ -46,5 +46,30 @@ namespace Bug52570Tests {
 			bgen.AssertExecute ("build");
 			bgen.AssertWarning (1117, "The SomeMethod member is decorated with [Static] and its container class Bug52570Tests.FooObject_Extensions is decorated with [Category] this leads to hard to use code. Please inline SomeMethod into Bug52570Tests.FooObject class.");
 		}
+
+		[Test]
+		public void BindAsNoMultidimensionalArrays ()
+		{
+			var bgen = new BGenTool ();
+			bgen.Profile = Profile.iOS;
+			bgen.CreateTemporaryBinding (@"
+using System;
+using Foundation;
+using AVFoundation;
+using ObjCRuntime;
+
+namespace Bug57795Tests {
+
+	[BaseType (typeof (NSObject))]
+	interface FooObject {
+
+		[BindAs (typeof (AVMediaTypes [,]))]
+		[Export (""strongAVMediaTypesPropertiesMulti:"")]
+		NSString [,] StrongAVMediaTypesPropertiesMulti { get; set; }
+	}
+}");
+			bgen.AssertExecuteError ("build");
+			bgen.AssertError (1048, "Unsupported type AVMediaTypes[,] decorated with [BindAs]");
+		}
 	}
 }


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=57795

We now error out with "BI1048 Unsupported type Foo[,] decorated with [BindAs]"

Build diff: https://gist.github.com/dalexsoto/5d26240320b9e805d4cc10b9281010d4