### PR TITLE
[mono] mono 5.4.99 is the maximum, compatible version to build everything. Fixes #60394

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -58,7 +58,7 @@ XCODE_DEVELOPER_ROOT=/Applications/Xcode9-GM.app/Contents/Developer
 
 # Minimum Mono version
 MIN_MONO_VERSION=5.4.0.201
-MAX_MONO_VERSION=5.8.99
+MAX_MONO_VERSION=5.4.99
 MIN_MONO_URL=https://bosstoragemirror.azureedge.net/wrench/mono-2017-06/71/71277e78f6ed32889e8c739f4ee4a3ebc946f84a/MonoFramework-MDK-5.4.0.201.macos10.xamarin.universal.pkg
 
 # Minimum Visual Studio version


### PR DESCRIPTION
Newer mono includes a Mono.Cecil with a breaking change that break xtro [1].
The fix cannot be compatible with stable and newer mono so it must wait that
we bump/require 2017-10.

This reverts PR2928 manually (the github generated revert [3] showed other
commits)

[1] https://bugzilla.xamarin.com/show_bug.cgi?id=60394
[2] https://github.com/xamarin/xamarin-macios/pull/2928
[3] https://github.com/xamarin/xamarin-macios/pull/2933