### PR TITLE
[Generator] BindAs attribute for smart enums of an array of nullable values generates code that doesn't compile, Fixes bug 57797

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1309,7 +1309,7 @@ public partial class Generator : IMemberGatherer {
 
 			if (arrType == TypeManager.NSString) {
 				valueConverter = isNullable ? "o == null ? null : " : string.Empty;
-				valueConverter += $"{FormatType (retType.DeclaringType, arrRetType)}Extensions.GetConstant (o), {parameterName});";
+				valueConverter += $"{FormatType (retType.DeclaringType, arrRetType)}Extensions.GetConstant ({(isNullable ? "o.Value" : "o")}), {parameterName});";
 			} else if (arrType == TypeManager.NSNumber) {
 				var cast = arrRetType.IsEnum ? "(int)" : string.Empty;
 				valueConverter = $"new NSNumber ({cast}o{denullify}), {parameterName});";

--- a/tests/generator/BGenTool.cs
+++ b/tests/generator/BGenTool.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Tests
 	class BGenTool : Tool
 	{
 		public Profile Profile;
+		public bool ProcessEnums;
 
 		public List<string> ApiDefinitions = new List<string> ();
 		public string TmpDirectory;
@@ -72,6 +73,9 @@ namespace Xamarin.Tests
 			
 			if (!string.IsNullOrEmpty (TmpDirectory))
 				sb.Append (" --tmpdir=").Append (StringUtils.Quote (TmpDirectory));
+
+			if (ProcessEnums)
+				sb.Append (" --process-enums");
 
 			return sb.ToString ();
 		}

--- a/tests/generator/ErrorTests.cs
+++ b/tests/generator/ErrorTests.cs
@@ -73,7 +73,65 @@ namespace Bug57795Tests {
 		}
 
 		[Test]
-		public void BindAsNullableArraysNoErrors ()
+		public void BindAsNullableNSStringArrayError ()
+		{
+			// https://bugzilla.xamarin.com/show_bug.cgi?id=57797
+
+			var bgen = new BGenTool {
+				Profile = Profile.iOS
+			};
+			bgen.CreateTemporaryBinding (@"
+using System;
+using Foundation;
+using ObjCRuntime;
+using AVFoundation;
+using CoreAnimation;
+
+namespace Bug57797Tests {
+
+	[BaseType (typeof (NSObject))]
+	interface FooObject {
+
+		[BindAs (typeof (AVMediaTypes? []))]
+		[Export (""strongNullableAVMediaTypesProperties"")]
+		NSString [] StrongNullableAVMediaTypesProperties { get; set; }
+	}
+}");
+			bgen.AssertExecuteError ("build");
+			bgen.AssertError (1048, "Unsupported type AVMediaTypes?[] decorated with [BindAs]");
+		}
+
+		[Test]
+		public void BindAsNullableNSValueArrayError ()
+		{
+			// https://bugzilla.xamarin.com/show_bug.cgi?id=57797
+
+			var bgen = new BGenTool {
+				Profile = Profile.iOS
+			};
+			bgen.CreateTemporaryBinding (@"
+using System;
+using Foundation;
+using ObjCRuntime;
+using AVFoundation;
+using CoreAnimation;
+
+namespace Bug57797Tests {
+
+	[BaseType (typeof (NSObject))]
+	interface FooObject {
+
+		[BindAs (typeof (CATransform3D? []))]
+		[Export (""PCATransform3DNullableArray"")]
+		NSValue [] PCATransform3DNullableArrayValue { get; set; }
+	}
+}");
+			bgen.AssertExecuteError ("build");
+			bgen.AssertError (1048, "Unsupported type CATransform3D?[] decorated with [BindAs]");
+		}
+
+		[Test]
+		public void BindAsNullableNSNumberArrayError ()
 		{
 			// https://bugzilla.xamarin.com/show_bug.cgi?id=57797
 
@@ -99,21 +157,13 @@ namespace Bug57797Tests {
 	[BaseType (typeof (NSObject))]
 	interface FooObject {
 
-		[BindAs (typeof (AVMediaTypes? []))]
-		[Export (""strongNullableAVMediaTypesProperties"")]
-		NSString [] StrongNullableAVMediaTypesProperties { get; set; }
-
-		[BindAs (typeof (CATransform3D? []))]
-		[Export (""PCATransform3DNullableArray"")]
-		NSValue [] PCATransform3DNullableArrayValue { get; set; }
-
 		[BindAs (typeof (Foo? []))]
 		[Export (""strongNullableAVMediaTypesProperties"")]
 		NSNumber[] StrongNullableFoo { get; set; }
 	}
 }");
-			bgen.AssertExecute ("build");
-			bgen.AssertNoWarnings ();
+			bgen.AssertExecuteError ("build");
+			bgen.AssertError (1048, "Unsupported type Foo?[] decorated with [BindAs]");
 		}
 	}
 }

--- a/tests/generator/ErrorTests.cs
+++ b/tests/generator/ErrorTests.cs
@@ -71,5 +71,49 @@ namespace Bug57795Tests {
 			bgen.AssertExecuteError ("build");
 			bgen.AssertError (1048, "Unsupported type AVMediaTypes[,] decorated with [BindAs]");
 		}
+
+		[Test]
+		public void BindAsNullableArraysNoErrors ()
+		{
+			// https://bugzilla.xamarin.com/show_bug.cgi?id=57797
+
+			var bgen = new BGenTool {
+				Profile = Profile.iOS,
+				ProcessEnums = true
+			};
+			bgen.CreateTemporaryBinding (@"
+using System;
+using Foundation;
+using ObjCRuntime;
+using AVFoundation;
+using CoreAnimation;
+
+namespace Bug57797Tests {
+
+	[Native]
+	enum Foo : long {
+		One,
+		Two
+	}
+
+	[BaseType (typeof (NSObject))]
+	interface FooObject {
+
+		[BindAs (typeof (AVMediaTypes? []))]
+		[Export (""strongNullableAVMediaTypesProperties"")]
+		NSString [] StrongNullableAVMediaTypesProperties { get; set; }
+
+		[BindAs (typeof (CATransform3D? []))]
+		[Export (""PCATransform3DNullableArray"")]
+		NSValue [] PCATransform3DNullableArrayValue { get; set; }
+
+		[BindAs (typeof (Foo? []))]
+		[Export (""strongNullableAVMediaTypesProperties"")]
+		NSNumber[] StrongNullableFoo { get; set; }
+	}
+}");
+			bgen.AssertExecute ("build");
+			bgen.AssertNoWarnings ();
+		}
 	}
 }


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=57797

We now correctly compile array of nullable types

Build diff: https://gist.github.com/dalexsoto/65f791ca3c0519dd7440596e3cd29490