### PR TITLE
[monotouch-test] Tweak CalendarTest to work when 1h = 2h due to DST change.

### DIFF
--- a/tests/monotouch-test/Foundation/CalendarTest.cs
+++ b/tests/monotouch-test/Foundation/CalendarTest.cs
@@ -34,7 +34,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void DateComponentsTest ()
 		{
 			var cal = new NSCalendar (NSCalendarType.Gregorian);
-			var now = DateTime.Now;
+			var now = DateTime.Now.ToUniversalTime ();
 			NSDateComponents comps;
 
 			comps = cal.Components (NSCalendarUnit.Year | NSCalendarUnit.Month | NSCalendarUnit.Day, NSDate.Now);


### PR DESCRIPTION
At 2:00 AM on November 5h 2017, winter came to our bots in Boston.

This meant that between 2:00 and 3:00 AM, subtracting 1h from the current
time yielded a time difference of 2h.

This was caught by our observant tests:

    [FAIL] CalendarTest.DateComponentsTest :   b hour
        Expected: 1
        But was:  2

To avoid such issues next time this test happens to run during this single
hour of the entire year that causes problems, change the test to use time
calculcation using UTC instead.