### PR TITLE
[monotouch-test] Move generated files out of the "all test files" wildcard.

### DIFF
--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -169,8 +169,8 @@
     <Compile Include="**\*.cs" Exclude="obj\**">
       <Link>%(RecursiveDir)%(Filename).cs</Link>
     </Compile>
-    <Compile Include="ObjCRuntime\TrampolineTest.generated.cs" />
-    <Compile Include="ObjCRuntime\RegistrarTest.generated.cs" />
+    <Compile Include="..\..\tests\test-libraries\TrampolineTest.generated.cs" />
+    <Compile Include="..\..\tests\test-libraries\RegistrarTest.generated.cs" />
     <Compile Include="..\..\external\mono\mcs\class\System.Drawing\Test\System.Drawing\TestPoint.cs" Condition="$(TargetFrameworkIdentifier) != 'Xamarin.WatchOS'">
       <Link>System.Drawing\TestPoint.cs</Link>
     </Compile>
@@ -334,8 +334,8 @@
     <GeneratedTestInput Include="..\..\tests\test-libraries\*.h" />
     <GeneratedTestInput Include="..\..\tests\test-libraries\*.cs" />
     <GeneratedTestInput Include="..\..\tests\test-libraries\Makefile" />
-    <GeneratedTestOutput Include="ObjCRuntime\TrampolineTest.generated.cs" />
-    <GeneratedTestOutput Include="ObjCRuntime\RegistrarTest.generated.cs" />
+    <GeneratedTestOutput Include="..\..\tests\test-libraries\TrampolineTest.generated.cs" />
+    <GeneratedTestOutput Include="..\..\tests\test-libraries\RegistrarTest.generated.cs" />
   </ItemGroup>
   <Target Name="BeforeBuild" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)">
     <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />

--- a/tests/test-libraries/.gitignore
+++ b/tests/test-libraries/.gitignore
@@ -8,4 +8,5 @@ libtest.properties.h
 libtest.decompile.m
 libtest.methods.h
 libtest.methods.m
+*.generated.cs
 

--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -11,8 +11,8 @@ GENERATED_FILES = \
 	libtest.properties.h \
 	../bindings-test/ApiDefinition.generated.cs \
 	../bindings-test/StructsAndEnums.generated.cs \
-	../monotouch-test/ObjCRuntime/RegistrarTest.generated.cs \
-	../monotouch-test/ObjCRuntime/TrampolineTest.generated.cs \
+	RegistrarTest.generated.cs \
+	TrampolineTest.generated.cs \
 
 GENERATED_FILES_PATTERN = \
 	libtest.structs%h \
@@ -20,8 +20,8 @@ GENERATED_FILES_PATTERN = \
 	libtest.properties%h \
 	../bindings-test/ApiDefinition.generated%cs \
 	../bindings-test/StructsAndEnums.generated%cs \
-	../monotouch-test/ObjCRuntime/RegistrarTest.generated%cs \
-	../monotouch-test/ObjCRuntime/TrampolineTest.generated%cs \
+	RegistrarTest.generated%cs \
+	TrampolineTest.generated%cs \
 
 testgenerator.exe: testgenerator.cs Makefile
 	$(Q) mcs -out:$@ $<

--- a/tests/test-libraries/testgenerator.cs
+++ b/tests/test-libraries/testgenerator.cs
@@ -1448,7 +1448,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		w.AppendLine (@"	}
 }");
 
-		File.WriteAllText ("../monotouch-test/ObjCRuntime/RegistrarTest.generated.cs", w.ToString ());
+		File.WriteAllText ("RegistrarTest.generated.cs", w.ToString ());
 	}
 
 	static void WriteTrampolineTests ()
@@ -1655,7 +1655,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		w.AppendLine (@"	}
 }");
 
-		File.WriteAllText ("../monotouch-test/ObjCRuntime/TrampolineTest.generated.cs", w.ToString ());
+		File.WriteAllText ("TrampolineTest.generated.cs", w.ToString ());
 	}
 
 	static void WriteStretConditions (StringBuilder w, string s, out bool never)


### PR DESCRIPTION
monotouch-test has a wildcard to automatically include new test files, but
this should not include generated files, because:

* The generated files are generated when needed, which means we can't rely on
  the wildcard to trigger their generation, because the wildcard won't find
  them before they exist, and as such msbuild won't detect that they're
  needed.
* This means the generated files must be listed separately, but in that case
  they shouldn't be found by the wildcard too, because that leads to:

        /Library/Frameworks/Mono.framework/Versions/5.4.0/lib/mono/msbuild/15.0/bin/Roslyn/Microsoft.CSharp.Core.targets(84,5): error MSB3105: The item "ObjCRuntime/TrampolineTest.generated.cs" was specified more than once in the "Sources" parameter.  Duplicate items are not supported by the "Sources" parameter.

So move the generated files to a different directory, so that the wildcard
doesn't find them.