### PR TITLE
[monotouch-test] Fix regression in CalendarTest to not compare UTC and local time directly.

### DIFF
--- a/tests/monotouch-test/Foundation/CalendarTest.cs
+++ b/tests/monotouch-test/Foundation/CalendarTest.cs
@@ -37,7 +37,7 @@ namespace MonoTouchFixtures.Foundation {
 			var now = DateTime.Now.ToUniversalTime ();
 			NSDateComponents comps;
 
-			comps = cal.Components (NSCalendarUnit.Year | NSCalendarUnit.Month | NSCalendarUnit.Day, NSDate.Now);
+			comps = cal.Components (NSCalendarUnit.Year | NSCalendarUnit.Month | NSCalendarUnit.Day, (NSDate) now);
 			Assert.AreEqual (now.Year, comps.Year, "a year");
 			Assert.AreEqual (now.Month, comps.Month, "a month");
 			Assert.AreEqual (now.Day, comps.Day, "a day");


### PR DESCRIPTION
In 0442cdf9c0c4cbb3ae2a0f21125dcc98ae85b648 the `now` variable was changed to be a UTC date, but unfortunately the code that compares it to a local date (NSDate.Now) wasn't updated.

Only year/month/day values were compared, which meant the test would fail if run when UTC and local time didn't represent the same date (and conversely would pass if the UTC and local date was the same date, which is why the changed did not fail the PR test run: the PR was tested during the 19 hours of the day when EST and UTC represent the sam date).

Fix this by converting the UTC `now` to NSDate instead of using NSDate.Now.

This has the additional benefit of also fixing a (much smaller) race condition: if midnight occurred just between calculating `now` and NSDate.Now, the test would also fail.