### PR TITLE
[CoreImage] Update filters for Xcode 9

### DIFF
--- a/src/CoreImage/CIFilter.cs
+++ b/src/CoreImage/CIFilter.cs
@@ -31,7 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 // Adding new Filters:
-//    * Create new class with the two constructors
+//    * Create a new class/interface in coreimage.cs
 //    * Add it to CIFilter.FromName switch
 //    * Implement properties for each parameter
 //    * Use the documented string in "Parameter" in each section as the key for the get/set methods
@@ -85,6 +85,26 @@
 // Totally* new filters on iOS 9.0
 //    CIPDF417BarcodeGenerator
 //    * most of OSX specicic filters are now available on iOS9
+//
+// New filters on Xcode 9
+//    CIAreaMinMaxRed
+//    CIAttributedTextImageGenerator
+//    CIBarcodeGenerator
+//    CIBicubicScaleTransform
+//    CIBokehBlur
+//    CIColorCubesMixedWithMask
+//    CIColorCurves
+//    CIDepthBlurEffect
+//    CIDepthToDisparity
+//    CIDisparityToDepth
+//    CIEdgePreserveUpsampleFilter
+//    CILabDeltaE
+//    CITextImageGenerator
+//    CIMorphologyGradient
+//    CIMorphologyMaximum
+//    CIMorphologyMinimum
+//    CIBlendWithBlueMask
+//    CIBlendWithRedMask
 //
 using System;
 using System.Diagnostics;
@@ -612,6 +632,42 @@ namespace XamCore.CoreImage {
 			case "CIPDF417BarcodeGenerator":
 			case "CIPdf417BarcodeGenerator":
 				return new CIPdf417BarcodeGenerator (handle);
+			case "CIAreaMinMaxRed":
+				return new CIAreaMinMaxRed (handle);
+			case "CIAttributedTextImageGenerator":
+				return new CIAttributedTextImageGenerator (handle);
+			case "CIBarcodeGenerator":
+				return new CIBarcodeGenerator (handle);
+			case "CIBicubicScaleTransform":
+				return new CIBicubicScaleTransform (handle);
+			case "CIBokehBlur":
+				return new CIBokehBlur (handle);
+			case "CIColorCubesMixedWithMask":
+				return new CIColorCubesMixedWithMask (handle);
+			case "CIColorCurves":
+				return new CIColorCurves (handle);
+			case "CIDepthBlurEffect":
+				return new CIDepthBlurEffect (handle);
+			case "CIDepthToDisparity":
+				return new CIDepthToDisparity (handle);
+			case "CIDisparityToDepth":
+				return new CIDisparityToDepth (handle);
+			case "CIEdgePreserveUpsampleFilter":
+				return new CIEdgePreserveUpsampleFilter (handle);
+			case "CILabDeltaE":
+				return new CILabDeltaE (handle);
+			case "CITextImageGenerator":
+				return new CITextImageGenerator (handle);
+			case "CIMorphologyGradient":
+				return new CIMorphologyGradient (handle);
+			case "CIMorphologyMaximum":
+				return new CIMorphologyMaximum (handle);
+			case "CIMorphologyMinimum":
+				return new CIMorphologyMinimum (handle);
+			case "CIBlendWithBlueMask":
+				return new CIBlendWithBlueMask (handle);
+			case "CIBlendWithRedMask":
+				return new CIBlendWithRedMask (handle);
 			default:
 				throw new NotImplementedException (String.Format ("Unknown filter type returned: `{0}', returning a default CIFilter", filterName));
 			}

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -3723,11 +3723,8 @@ namespace XamCore.CoreImage {
 
 	[CoreImageFilter]
 	[iOS (8,3)]
-	[BaseType (typeof (CIFilter))]
+	[BaseType (typeof (CILinearBlur))]
 	interface CIMotionBlur {
-
-		[CoreImageFilterProperty ("inputRadius")]
-		float Radius { get; set; }
 
 		[CoreImageFilterProperty ("inputAngle")]
 		float Angle { get; set; }
@@ -4741,7 +4738,9 @@ namespace XamCore.CoreImage {
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-	[BaseType (typeof (CIFilter))] // Maybe 'CIScaleTransform' (shared 'Scale' and 'AspectRatio' property)?
+	// Maybe 'typeof (CIFilter)' (shared 'Scale' and 'AspectRatio' property).
+	// It's possible to add ours but it can bite us back in the future if Apple introduce the same with different properties.
+	[BaseType (typeof (CIFilter))]
 	interface CIBicubicScaleTransform {
 		[CoreImageFilterProperty ("inputB")]
 		float B { get; set; }
@@ -4758,11 +4757,8 @@ namespace XamCore.CoreImage {
 
 	[CoreImageFilter]
 	[Abstract]
-	[iOS (11,0)]
-	[Mac (10,13)]
-	[TV (11,0)]
 	[BaseType (typeof (CIFilter))]
-	interface CIBlur { // `CIMotionBlur.SuperClass == CILinearBlur` but it's marked as `[NoiOS]` and `[NoMac]` so we have ours
+	interface CILinearBlur {
 		[CoreImageFilterProperty ("inputRadius")]
 		float Radius { get; set; }
 	}
@@ -4771,7 +4767,7 @@ namespace XamCore.CoreImage {
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-	[BaseType (typeof (CIBlur))] // `CIBokehBlur` doesn't explicitly have `SuperClass` but it should be `CIBlur` to inherit the `inputRadius` property
+	[BaseType (typeof (CILinearBlur))]
 	interface CIBokehBlur {
 		[CoreImageFilterProperty ("inputSoftness")]
 		float Softness { get; set; }
@@ -4833,9 +4829,10 @@ namespace XamCore.CoreImage {
 		[CoreImageFilterProperty ("inputCalibrationData")]
 		AVCameraCalibrationData CalibrationData { get; set; }
 
-		// FIXME: How to bind this? Strongly typed?
+		// Radar: https://trello.com/c/9eA2BA2o
+		// Don't know how to test this as I don't know which keys are valid.
 		// [CoreImageFilterProperty ("inputTuningParameters")]
-		// NSDictionary TuningParameters { get; set; }
+		// NSDictionary WeakTuningParameters { get; set; }
 
 		[CoreImageFilterProperty ("inputNosePositions")]
 		CIVector NosePositions { get; set; }

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -2615,7 +2615,7 @@ namespace XamCore.CoreImage {
 		CIVector Extent { get; set; }
 	}
 
-	[CoreImageFilter]
+	[CoreImageFilter (StringCtorVisibility = MethodAttributes.Public)]
 	[iOS (9,0)]
 	[BaseType (typeof (CIFilter))]
 	interface CIAreaMaximum {
@@ -4696,31 +4696,35 @@ namespace XamCore.CoreImage {
 	interface CIXRay {
 	}
 
-#if false // Needs review: https://bugzilla.xamarin.com/show_bug.cgi?id=57350
 	[CoreImageFilter]
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-	[BaseType (typeof (CIFilter))]
+	[BaseType (typeof (CIAreaMaximum))]
 	interface CIAreaMinMaxRed {
-		// TODO: Needs review
-		//[CoreImageProperty ("inputExtent")]
-		//CIVector Extent { get; set; }
+		[CoreImageFilterProperty ("inputExtent")]
+		CIVector Extent { get; set; }
+	}
+
+	[CoreImageFilter]
+	[Abstract]
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CIImageGenerator {
+		[CoreImageFilterProperty ("inputScaleFactor")]
+		float ScaleFactor { get; set; }
 	}
 
 	[CoreImageFilter]
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-	[BaseType (typeof (CIFilter))]
+	[BaseType (typeof (CIImageGenerator))]
 	interface CIAttributedTextImageGenerator {
-		// TODO: Needs review
-		//[CoreImageProperty ("inputText")]
-		//NSAttributedString Text { get; set; }
-
-		//[CoreImageProperty ("inputScaleFactor")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float ScaleFactor { get; set; }
+		[CoreImageFilterProperty ("inputText")]
+		NSAttributedString Text { get; set; }
 	}
 
 	[CoreImageFilter]
@@ -4729,70 +4733,76 @@ namespace XamCore.CoreImage {
 	[TV (11,0)]
 	[BaseType (typeof (CIFilter))]
 	interface CIBarcodeGenerator {
-		// TODO: Needs review
-		//[CoreImageProperty ("inputBarcodeDescriptor")]
-		//CIBarcodeDescriptor BarcodeDescriptor { get; set; }
+		[CoreImageFilterProperty ("inputBarcodeDescriptor")]
+		CIBarcodeDescriptor BarcodeDescriptor { get; set; }
 	}
 
 	[CoreImageFilter]
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-	[BaseType (typeof (CIFilter))]
+	[BaseType (typeof (CIFilter))] // Maybe 'CIScaleTransform' (shared 'Scale' and 'AspectRatio' property)?
 	interface CIBicubicScaleTransform {
-		// TODO: Needs review
-		//[CoreImageProperty ("inputB")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float B { get; set; }
-		//[CoreImageProperty ("inputScale")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float Scale { get; set; }
-		//[CoreImageProperty ("inputC")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float C { get; set; }
-		//[CoreImageProperty ("inputAspectRatio")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float AspectRatio { get; set; }
+		[CoreImageFilterProperty ("inputB")]
+		float B { get; set; }
+
+		[CoreImageFilterProperty ("inputC")]
+		float C { get; set; }
+
+		[CoreImageFilterProperty ("inputScale")]
+		float Scale { get; set; }
+
+		[CoreImageFilterProperty ("inputAspectRatio")]
+		float AspectRatio { get; set; }
+	}
+
+	[CoreImageFilter]
+	[Abstract]
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CIBlur { // `CIMotionBlur.SuperClass == CILinearBlur` but it's marked as `[NoiOS]` and `[NoMac]` so we have ours
+		[CoreImageFilterProperty ("inputRadius")]
+		float Radius { get; set; }
 	}
 
 	[CoreImageFilter]
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-	[BaseType (typeof (CIFilter))]
+	[BaseType (typeof (CIBlur))] // `CIBokehBlur` doesn't explicitly have `SuperClass` but it should be `CIBlur` to inherit the `inputRadius` property
 	interface CIBokehBlur {
-		// TODO: Needs review
-		//[CoreImageProperty ("inputSoftness")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float Softness { get; set; }
-		//[CoreImageProperty ("inputRadius")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float Radius { get; set; }
-		//[CoreImageProperty ("inputRingSize")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float RingSize { get; set; }
-		//[CoreImageProperty ("inputRingAmount")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float RingAmount { get; set; }
+		[CoreImageFilterProperty ("inputSoftness")]
+		float Softness { get; set; }
+
+		[CoreImageFilterProperty ("inputRingSize")]
+		float RingSize { get; set; }
+
+		[CoreImageFilterProperty ("inputRingAmount")]
+		float RingAmount { get; set; }
 	}
+
 	[CoreImageFilter]
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-	[BaseType (typeof (CIFilter))]
+	[BaseType (typeof (CIFilter))] // Could almost be typeof 'CIColorCube' but property is 'inputCube0Data' not 'inputCubeData'
 	interface CIColorCubesMixedWithMask {
-		// TODO: Needs review
-		//[CoreImageProperty ("inputCubeDimension")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float CubeDimension { get; set; }
-		//[CoreImageProperty ("inputMaskImage")]
-		//CIImage MaskImage { get; set; }
-		//[CoreImageProperty ("inputCube0Data")]
-		//NSData Cube0Data { get; set; }
-		//[CoreImageProperty ("inputCube1Data")]
-		//NSData Cube1Data { get; set; }
-		//[CoreImageProperty ("inputColorSpace")]
-		//NSObject ColorSpace { get; set; }
+		[CoreImageFilterProperty ("inputCubeDimension")]
+		float CubeDimension { get; set; }
+
+		[CoreImageFilterProperty ("inputMaskImage")]
+		CIImage MaskImage { get; set; }
+
+		[CoreImageFilterProperty ("inputCube0Data")]
+		NSData Cube0Data { get; set; }
+
+		[CoreImageFilterProperty ("inputCube1Data")]
+		NSData Cube1Data { get; set; }
+
+		[CoreImageFilterProperty ("inputColorSpace")]
+		CGColorSpace ColorSpace { get; set; }
 	}
 
 	[CoreImageFilter]
@@ -4801,13 +4811,14 @@ namespace XamCore.CoreImage {
 	[TV (11,0)]
 	[BaseType (typeof (CIFilter))]
 	interface CIColorCurves {
-		// TODO: Needs review
-		//[CoreImageProperty ("inputColorSpace")]
-		//NSObject ColorSpace { get; set; }
-		//[CoreImageProperty ("inputCurvesDomain")]
-		//CIVector CurvesDomain { get; set; }
-		//[CoreImageProperty ("inputCurvesData")]
-		//NSData CurvesData { get; set; }
+		[CoreImageFilterProperty ("inputColorSpace")]
+		CGColorSpace ColorSpace { get; set; }
+
+		[CoreImageFilterProperty ("inputCurvesDomain")]
+		CIVector CurvesDomain { get; set; }
+
+		[CoreImageFilterProperty ("inputCurvesData")]
+		NSData CurvesData { get; set; }
 	}
 
 	[CoreImageFilter]
@@ -4816,67 +4827,77 @@ namespace XamCore.CoreImage {
 	[TV (11,0)]
 	[BaseType (typeof (CIFilter))]
 	interface CIDepthBlurEffect {
-		// TODO: Needs review
-		//[CoreImageProperty ("inputAperture")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float Aperture { get; set; }
-		//[CoreImageProperty ("inputCalibrationData")]
-		//AVCameraCalibrationData CalibrationData { get; set; }
-		//[CoreImageProperty ("inputTuningParameters")]
-		//NSDictionary TuningParameters { get; set; }
-		//[CoreImageProperty ("inputNosePositions")]
-		//CIVector NosePositions { get; set; }
-		//[CoreImageProperty ("inputLumaNoiseScale")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float LumaNoiseScale { get; set; }
-		//[CoreImageProperty ("inputChinPositions")]
-		//CIVector ChinPositions { get; set; }
-		//[CoreImageProperty ("inputDisparityImage")]
-		//CIImage DisparityImage { get; set; }
-		//[CoreImageProperty ("inputScaleFactor")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float ScaleFactor { get; set; }
-		//[CoreImageProperty ("inputRightEyePositions")]
-		//CIVector RightEyePositions { get; set; }
-		//[CoreImageProperty ("inputLeftEyePositions")]
-		//CIVector LeftEyePositions { get; set; }
-		//[CoreImageProperty ("inputFocusRect")]
-		//CIVector FocusRect { get; set; }
+		[CoreImageFilterProperty ("inputAperture")]
+		float Aperture { get; set; }
+
+		[CoreImageFilterProperty ("inputCalibrationData")]
+		AVCameraCalibrationData CalibrationData { get; set; }
+
+		// FIXME: How to bind this? Strongly typed?
+		// [CoreImageFilterProperty ("inputTuningParameters")]
+		// NSDictionary TuningParameters { get; set; }
+
+		[CoreImageFilterProperty ("inputNosePositions")]
+		CIVector NosePositions { get; set; }
+
+		[CoreImageFilterProperty ("inputLumaNoiseScale")]
+		float LumaNoiseScale { get; set; }
+
+		[CoreImageFilterProperty ("inputChinPositions")]
+		CIVector ChinPositions { get; set; }
+
+		[CoreImageFilterProperty ("inputDisparityImage")]
+		CIImage DisparityImage { get; set; }
+
+		[CoreImageFilterProperty ("inputScaleFactor")]
+		float ScaleFactor { get; set; }
+
+		[CoreImageFilterProperty ("inputRightEyePositions")]
+		CIVector RightEyePositions { get; set; }
+
+		[CoreImageFilterProperty ("inputLeftEyePositions")]
+		CIVector LeftEyePositions { get; set; }
+
+		[CoreImageFilterProperty ("inputFocusRect")]
+		CIVector FocusRect { get; set; }
 	}
+
+	[CoreImageFilter]
+	[Abstract]
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CIDepthDisparityConverter {}
 
 	[CoreImageFilter]
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-	[BaseType (typeof (CIFilter))]
-	interface CIDepthToDisparity {
-		// TODO: Needs review
-	}
+	[BaseType (typeof (CIDepthDisparityConverter))]
+	interface CIDepthToDisparity {}
 
 	[CoreImageFilter]
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-	[BaseType (typeof (CIFilter))]
-	interface CIDisparityToDepth {
-		// TODO: Needs review
-	}
+	[BaseType (typeof (CIDepthDisparityConverter))]
+	interface CIDisparityToDepth {}
 
 	[CoreImageFilter]
 	[iOS (11,0)]
-	[NoMac]
+	[Mac (10,13)]
 	[TV (11,0)]
 	[BaseType (typeof (CIFilter))]
 	interface CIEdgePreserveUpsampleFilter {
-		// TODO: Needs review
-		//[CoreImageProperty ("inputLumaSigma")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float LumaSigma { get; set; }
-		//[CoreImageProperty ("inputSmallImage")]
-		//CIImage SmallImage { get; set; }
-		//[CoreImageProperty ("inputSpatialSigma")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float SpatialSigma { get; set; }
+		[CoreImageFilterProperty ("inputLumaSigma")]
+		float LumaSigma { get; set; }
+
+		[CoreImageFilterProperty ("inputSmallImage")]
+		CIImage SmallImage { get; set; }
+
+		[CoreImageFilterProperty ("inputSpatialSigma")]
+		float SpatialSigma { get; set; }
 	}
 
 	[CoreImageFilter]
@@ -4885,75 +4906,71 @@ namespace XamCore.CoreImage {
 	[TV (11,0)]
 	[BaseType (typeof (CIFilter))]
 	interface CILabDeltaE {
-		// TODO: Needs review
-		//[CoreImageProperty ("inputImage2")]
-		//CIImage Image2 { get; set; }
+		[CoreImageFilterProperty ("inputImage2")]
+		CIImage Image2 { get; set; }
 	}
 
 	[CoreImageFilter]
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-	[BaseType (typeof (CIFilter))]
+	[BaseType (typeof (CIImageGenerator))]
 	interface CITextImageGenerator {
-		// TODO: Needs review
-		//[CoreImageProperty ("inputText")]
-		//NSString Text { get; set; }
-		//[CoreImageProperty ("inputFontName")]
-		//NSString FontName { get; set; }
-		//[CoreImageProperty ("inputScaleFactor")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float ScaleFactor { get; set; }
-		//[CoreImageProperty ("inputFontSize")]
-		//// TODO: this was an NSNumber transformed to float, but maybe an int or bool is more appropriate
-		//float FontSize { get; set; }
+		[CoreImageFilterProperty ("inputText")]
+		string Text { get; set; }
+
+		[CoreImageFilterProperty ("inputFontName")]
+		string FontName { get; set; }
+
+		[CoreImageFilterProperty ("inputFontSize")]
+		float FontSize { get; set; }
+	}
+
+	[CoreImageFilter]
+	[Abstract]
+	[iOS (11,0)]
+	[Mac (10,13)]
+	[TV (11,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CIMorphology {
+		[CoreImageFilterProperty ("inputRadius")]
+		float Radius { get; set; }
 	}
 
 	[CoreImageFilter]
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-	[BaseType (typeof (CIFilter))]
-	interface CIMorphologyGradient {
-		// TODO: Needs review: https://bugzilla.xamarin.com/show_bug.cgi?id=57350
-	}
+	[BaseType (typeof (CIMorphology))]
+	interface CIMorphologyGradient {}
 
 	[CoreImageFilter]
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-	[BaseType (typeof (CIFilter))]
-	interface CIMorphologyMaximum {
-		// TODO: Needs review: https://bugzilla.xamarin.com/show_bug.cgi?id=57350
-	}
+	[BaseType (typeof (CIMorphology))]
+	interface CIMorphologyMaximum {}
 
 	[CoreImageFilter]
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-	[BaseType (typeof (CIFilter))]
-	interface CIMorphologyMinimum {
-		// TODO: Needs review: https://bugzilla.xamarin.com/show_bug.cgi?id=57350
-	}
+	[BaseType (typeof (CIMorphology))]
+	interface CIMorphologyMinimum {}
 
 	[CoreImageFilter]
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-	[BaseType (typeof (CIFilter))]
-	interface CIBlendWithBlueMask {
-		// TODO: Needs review: https://bugzilla.xamarin.com/show_bug.cgi?id=57350
-	}
+	[BaseType (typeof (CIBlendWithMask))]
+	interface CIBlendWithBlueMask {}
 
 	[CoreImageFilter]
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-	[BaseType (typeof (CIFilter))]
-	interface CIBlendWithRedMask {
-		// TODO: Needs review: https://bugzilla.xamarin.com/show_bug.cgi?id=57350
-	}
-#endif // false
+	[BaseType (typeof (CIBlendWithMask))]
+	interface CIBlendWithRedMask {}
 
 	[iOS (11,0)]
 	[Mac (10,13)]

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -4738,7 +4738,7 @@ namespace XamCore.CoreImage {
 	[iOS (11,0)]
 	[Mac (10,13)]
 	[TV (11,0)]
-	// Maybe 'typeof (CIFilter)' (shared 'Scale' and 'AspectRatio' property).
+	// Maybe 'typeof (CIScaleTransform)' (shared 'Scale' and 'AspectRatio' property).
 	// It's possible to add ours but it can bite us back in the future if Apple introduce the same with different properties.
 	[BaseType (typeof (CIFilter))]
 	interface CIBicubicScaleTransform {

--- a/src/generator-filters.cs
+++ b/src/generator-filters.cs
@@ -172,8 +172,10 @@ public partial class Generator {
 			indent--;
 			print ("return new CGAffineTransform (1, 0, 0, 1, 0, 0);");
 			break;
-		// NSObject should not be added - the only case it's found (right now) is for CGColorSpace
+		// NSObject should not be added
+		case "AVCameraCalibrationData":
 		case "CGColorSpace":
+		case "CIBarcodeDescriptor":
 			print ("return Runtime.GetINativeObject <{0}> (GetHandle (\"{1}\"), true);", propertyType, propertyName);
 			break;
 		case "CIColor":
@@ -191,11 +193,13 @@ public partial class Generator {
 		case "int":
 			print ("return GetInt (\"{0}\");", propertyName);
 			break;
+		case "NSAttributedString":
 		case "NSData":
 			// NSNumber should not be added - it should be bound as a float (common), int32 or bool
 			print ("return ValueForKey (\"{0}\") as {1};", propertyName, propertyType);
 			break;
 		case "string":
+			// NSString should not be added - it should be bound as a string
 			print ("return (string) (ValueForKey (\"{0}\") as NSString);", propertyName);
 			break;
 		default:
@@ -224,18 +228,22 @@ public partial class Generator {
 		case "int":
 			print ("SetInt (\"{0}\", value);", propertyName);
 			break;
-		// NSObject should not be added - the only case it's found (right now) is for CGColorSpace
+		// NSObject should not be added
+		case "AVCameraCalibrationData":
 		case "CGColorSpace":
+		case "CIBarcodeDescriptor":
 			print ("SetHandle (\"{0}\", value == null ? IntPtr.Zero : value.Handle);", propertyName);
 			break;
 		case "CIColor":
 		case "CIImage":
 		case "CIVector":
+		case "NSAttributedString":
 		case "NSData":
 		// NSNumber should not be added - it should be bound as a int or a float
 			print ("SetValue (\"{0}\", value);", propertyName);
 			break;
 		case "string":
+			// NSString should not be added - it should be bound as a string
 			print ("using (var ns = new NSString (value))");
 			indent++;
 			print ("SetValue (\"{0}\", ns);", propertyName);

--- a/tests/monotouch-test/CoreImage/FilterTest.cs
+++ b/tests/monotouch-test/CoreImage/FilterTest.cs
@@ -103,10 +103,6 @@ namespace MonoTouchFixtures.CoreImage {
 			using (var f = new CIColorCubeWithColorSpace ()) {
 				Assert.Null (f.ColorSpace, "ColorSpace/default");
 				using (var cs = CGColorSpace.CreateDeviceGray ()) {
-					var nsname = NSString.CreateNative ("inputColorSpace");
-					// TODO: remove when `CIBarcodeDescriptorTest` passes
-					// This works `inputColorSpace` is set
-					Messaging.void_objc_msgSend_IntPtr_IntPtr (f.Handle, Selector.GetHandle ("setValue:forKey:"), cs.Handle, nsname);
 					f.ColorSpace = cs;
 					var rc = CFGetRetainCount (cs.Handle);
 					for (int i = 0; i < 5; i++)
@@ -125,11 +121,7 @@ namespace MonoTouchFixtures.CoreImage {
 
 			using (var f = new CIBarcodeGenerator ()) {
 				Assert.Null (f.BarcodeDescriptor, "CIBarcodeDescriptor/default");
-				using (var b = new CIQRCodeDescriptor ()) {
-					var nsname = NSString.CreateNative ("inputBarcodeDescriptor");
-					// TODO: remove when `CIBarcodeDescriptorTest` passes
-					// This doesn't work, `inputBarcodeDescriptor` is not set.
-					Messaging.void_objc_msgSend_IntPtr_IntPtr (f.Handle, Selector.GetHandle ("setValue:forKey:"), b.Handle, nsname);
+				using (var b = new CIQRCodeDescriptor (new NSData (), 1, 0, CIQRCodeErrorCorrectionLevel.Q)) {
 					f.BarcodeDescriptor = b;
 					var rc = CFGetRetainCount (b.Handle);
 					for (int i = 0; i < 5; i++)


### PR DESCRIPTION
- Fixes bug #57350: Review new CoreImage filters added in Xcode 9
(https://bugzilla.xamarin.com/show_bug.cgi?id=57350).
- Adds `AVCameraCalibrationData` and `CIBarcodeDescriptor` to `generator-filters`.
- Fixes `ApiCoreImageFiltersTest`'s `GenerateBinding` to use valid `[CoreImageFilterProperty]`.
- In `CheckManagedFilters` generate code of SuperClass when detected so it's easier to bind.