### PR TITLE
[xtro] Re-enable InputMethodKit in xtro tests, fixes bug 57241

### DIFF
--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -56,7 +56,7 @@ osx.results run-osx: build $(XMAC_PCH)
 	$(MONO) bin/Debug/xtro-sharpie.exe $(XMAC_PCH) $(XMAC) | sort > osx.results
 
 $(XMAC_PCH): .stamp-check-sharpie
-	sharpie sdk-db -s macosx$(OSX_SDK_VERSION) -a $(XMAC_ARCH) -x InputMethodKit
+	sharpie sdk-db -s macosx$(OSX_SDK_VERSION) -a $(XMAC_ARCH)
 
 preclassify: ios.results osx.results
 	@comm -12 ios.results osx.results > common.unclassified.tmp


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=57241

Fixed in Xcode 9.2 betas