### PR TITLE
[corebluetooth] Update up to Xcode 9.2 beta 2

### DIFF
--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -116,6 +116,11 @@ namespace XamCore.CoreBluetooth {
 		[Field ("CBConnectPeripheralOptionNotifyOnNotificationKey")]
 		NSString OptionNotifyOnNotificationKey { get; }
 
+		[NoMac] // xcode 9.2 beta 2 does not include this inside its macOS header files
+		[iOS (6,0)]
+		[Field ("CBConnectPeripheralOptionStartDelayKey")]
+		NSString OptionStartDelayKey { get; }
+
 		[Field ("CBCentralManagerOptionRestoreIdentifierKey")]
 		[Since (7,0)]
 		[Mac (10,13)]

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -117,7 +117,7 @@ namespace XamCore.CoreBluetooth {
 		NSString OptionNotifyOnNotificationKey { get; }
 
 		[NoMac] // xcode 9.2 beta 2 does not include this inside its macOS header files
-		[iOS (6,0)]
+		[iOS (11,2)][TV (11,2)][Watch (4,2)]
 		[Field ("CBConnectPeripheralOptionStartDelayKey")]
 		NSString OptionStartDelayKey { get; }
 


### PR DESCRIPTION
Add a new constant.

This was added in Xcode 9.2 SDK for iOS and tvOS - even if the constant
is marked as existing for a while (iOS 6).

This was added for watchOS in the *final* Xcode 9.1 SDK.

This has not _yet_ been exposed in the macOS SDK.