### PR TITLE
[storekit] Fix SKCloudServiceSetupOptions strong dictionary's 'Action'

### DIFF
--- a/src/StoreKit/SKCloudServiceSetupOptions.cs
+++ b/src/StoreKit/SKCloudServiceSetupOptions.cs
@@ -14,10 +14,7 @@ namespace XamCore.StoreKit {
 				return (SKCloudServiceSetupAction?) (SKCloudServiceSetupActionExtensions.GetValue (_Action));
 			}
 			set {
-				if (value != null)
-					_Action = SKCloudServiceSetupActionExtensions.GetConstant (value.Value);
-				else
-					throw new ArgumentNullException ("value");
+				_Action = value != null ? SKCloudServiceSetupActionExtensions.GetConstant (value.Value) : null;
 			}
 		}
 	}

--- a/src/StoreKit/SKCloudServiceSetupOptions.cs
+++ b/src/StoreKit/SKCloudServiceSetupOptions.cs
@@ -1,4 +1,4 @@
-#if !MONOMAC && !TVOS
+#if __IOS__
 
 using System;
 using XamCore.ObjCRuntime;
@@ -9,15 +9,18 @@ namespace XamCore.StoreKit {
 	partial class SKCloudServiceSetupOptions {
 
 		[iOS (10,1)]
-		public virtual SKCloudServiceSetupAction Action {
+		public virtual SKCloudServiceSetupAction? Action {
 			get {
-				return (SKCloudServiceSetupAction) (SKCloudServiceSetupActionExtensions.GetValue (_Action));
+				return (SKCloudServiceSetupAction?) (SKCloudServiceSetupActionExtensions.GetValue (_Action));
 			}
 			set {
-				_Action = SKCloudServiceSetupActionExtensions.GetConstant (value);
+				if (value != null)
+					_Action = SKCloudServiceSetupActionExtensions.GetConstant (value.Value);
+				else
+					throw new ArgumentNullException ("value");
 			}
 		}
 	}
 }
 
-#endif // !MONOMAC && !TVOS
+#endif // __IOS__

--- a/src/StoreKit/SKCloudServiceSetupOptions.cs
+++ b/src/StoreKit/SKCloudServiceSetupOptions.cs
@@ -1,0 +1,23 @@
+#if !MONOMAC && !TVOS
+
+using System;
+using XamCore.ObjCRuntime;
+using XamCore.Foundation;
+
+namespace XamCore.StoreKit {
+
+	partial class SKCloudServiceSetupOptions {
+
+		[iOS (10,1)]
+		public virtual SKCloudServiceSetupAction Action {
+			get {
+				return (SKCloudServiceSetupAction) (SKCloudServiceSetupActionExtensions.GetValue (_Action));
+			}
+			set {
+				_Action = SKCloudServiceSetupActionExtensions.GetConstant (value);
+			}
+		}
+	}
+}
+
+#endif // !MONOMAC && !TVOS

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1300,6 +1300,7 @@ STOREKIT_CORE_SOURCES = \
 
 STOREKIT_SOURCES = \
 	StoreKit/NativeMethods.cs \
+	StoreKit/SKCloudServiceSetupOptions.cs \
 	StoreKit/SKPayment.cs \
 	StoreKit/SKPaymentTransactionObserver.cs \
 

--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -546,7 +546,11 @@ namespace XamCore.StoreKit {
 	interface SKCloudServiceSetupOptions
 	{
 		// Headers comment: Action for setup entry point (of type SKCloudServiceSetupAction).
-		SKCloudServiceSetupAction Action { get; set; }
+		// FIXME: Once https://bugzilla.xamarin.com/show_bug.cgi?id=57870 is fixed we should have a wrapper on a new property
+		// `SKCloudServiceSetupAction Action { get; set; }` and avoid manual code.
+		[Internal]
+		[Export ("ActionKey")]
+		NSString _Action { get; set; }
 
 		// Headers comment: Identifier of the iTunes Store item the user is trying to access which requires cloud service setup (NSNumber).
 		nint ITunesItemIdentifier { get; set; }

--- a/tests/monotouch-test/StoreKit/SKCloudServiceSetupOptionsTest.cs
+++ b/tests/monotouch-test/StoreKit/SKCloudServiceSetupOptionsTest.cs
@@ -1,0 +1,34 @@
+//
+// Unit tests for SKCloudServiceSetupOptionsTest
+//
+// Authors:
+//	Vincent Dondain <vidondai@microsoft.com>
+//
+// Copyright 2017 Microsoft. All rights reserved.
+//
+
+
+using System;
+using Foundation;
+using NUnit.Framework;
+using StoreKit;
+
+namespace MonoTouchFixtures.StoreKit {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class SKCloudServiceSetupOptionsTest {
+
+		[Test]
+		public void ActionTest ()
+		{
+			TestRuntime.AssertXcodeVersion (8, 1);
+
+			var optionsObject = new SKCloudServiceSetupOptions {
+				Action = SKCloudServiceSetupAction.Subscribe
+			};
+			Assert.AreEqual ("sdkSubscribe", optionsObject.Dictionary ["SKCloudServiceSetupOptionsActionKey"].ToString (), "SKCloudServiceSetupOptionsActionKey");
+			Assert.AreEqual (SKCloudServiceSetupAction.Subscribe, optionsObject.Action, "SKCloudServiceSetupOptions.Action");
+		}
+	}
+}

--- a/tests/monotouch-test/StoreKit/SKCloudServiceSetupOptionsTest.cs
+++ b/tests/monotouch-test/StoreKit/SKCloudServiceSetupOptionsTest.cs
@@ -7,6 +7,7 @@
 // Copyright 2017 Microsoft. All rights reserved.
 //
 
+#if __IOS__
 
 using System;
 using Foundation;
@@ -32,3 +33,5 @@ namespace MonoTouchFixtures.StoreKit {
 		}
 	}
 }
+
+#endif // __IOS__

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -704,6 +704,7 @@
     <Compile Include="ModelIO\MDLAnimatedValueTypesTests.cs" />
     <Compile Include="CoreVideo\CVImageBufferTests.cs" />
     <Compile Include="CoreVideo\CVMetalTextureCacheTests.cs" />
+    <Compile Include="StoreKit\SKCloudServiceSetupOptionsTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
- Fixes bug [#59928](https://bugzilla.xamarin.com/show_bug.cgi?id=59928): SKCloudServiceSetupViewController.LoadAsync() does not work correctly when passed an SKCloudServiceSetupOptions object instead of a manually-created NSDictionary