### PR TITLE
Allow NSUrlSessionHandler advanced configuration.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -64,10 +64,18 @@ namespace Foundation {
 		readonly Dictionary<NSUrlSessionTask, InflightData> inflightRequests;
 		readonly object inflightRequestsLock = new object ();
 
-		public NSUrlSessionHandler ()
+		public NSUrlSessionHandler () : this(NSUrlSessionConfiguration.DefaultSessionConfiguration)
 		{
+		}
+
+		public NSUrlSessionHandler (NSUrlSessionConfiguration configuration)
+		{
+			if (configuration == null)
+			{
+				throw new ArgumentNullException("configuration");
+			}
+
 			AllowAutoRedirect = true;
-			var configuration = NSUrlSessionConfiguration.DefaultSessionConfiguration;
 
 			// we cannot do a bitmask but we can set the minimum based on ServicePointManager.SecurityProtocol minimum
 			var sp = ServicePointManager.SecurityProtocol;

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -64,16 +64,14 @@ namespace Foundation {
 		readonly Dictionary<NSUrlSessionTask, InflightData> inflightRequests;
 		readonly object inflightRequestsLock = new object ();
 
-		public NSUrlSessionHandler () : this(NSUrlSessionConfiguration.DefaultSessionConfiguration)
+		public NSUrlSessionHandler () : this (NSUrlSessionConfiguration.DefaultSessionConfiguration)
 		{
 		}
 
 		public NSUrlSessionHandler (NSUrlSessionConfiguration configuration)
 		{
 			if (configuration == null)
-			{
-				throw new ArgumentNullException("configuration");
-			}
+				throw new ArgumentNullException (nameof (configuration));
 
 			AllowAutoRedirect = true;
 


### PR DESCRIPTION
NSUrlSessionHandler uses `NSUrlSessionConfiguration.DefaultSessionConfiguration` and there is no way to use custom configuration.
That means:
- no way to use custom cookie storage
- no way setup custom proxy settings
- ...

Here is the proposal to allow "advanced" tuning with non-default configuration.