### PR TITLE
[Foundation] Expose initWithDictionary:copyItems: in NS[Mutable]Dictionary, Fixes bug 60541

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -3594,6 +3594,9 @@ namespace XamCore.Foundation
 		[Export ("initWithDictionary:")]
 		IntPtr Constructor (NSDictionary other);
 
+		[Export ("initWithDictionary:copyItems:")]
+		IntPtr Constructor (NSDictionary other, bool copyItems);
+
 		[Export ("initWithContentsOfFile:")]
 		IntPtr Constructor (string fileName);
 
@@ -7490,6 +7493,9 @@ namespace XamCore.Foundation
 		
 		[Export ("initWithDictionary:")]
 		IntPtr Constructor (NSDictionary other);
+
+		[Export ("initWithDictionary:copyItems:")]
+		IntPtr Constructor (NSDictionary other, bool copyItems);
 
 		[Export ("initWithContentsOfFile:")]
 		IntPtr Constructor (string fileName);


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=60541