### PR TITLE
[monotouch-test] Tweak CalendarTest yet again.

### DIFF
--- a/tests/monotouch-test/Foundation/CalendarTest.cs
+++ b/tests/monotouch-test/Foundation/CalendarTest.cs
@@ -34,7 +34,7 @@ namespace MonoTouchFixtures.Foundation {
 		public void DateComponentsTest ()
 		{
 			var cal = new NSCalendar (NSCalendarType.Gregorian);
-			var now = DateTime.Now.ToUniversalTime ();
+			var now = DateTime.Now;
 			NSDateComponents comps;
 
 			comps = cal.Components (NSCalendarUnit.Year | NSCalendarUnit.Month | NSCalendarUnit.Day, (NSDate) now);
@@ -42,7 +42,8 @@ namespace MonoTouchFixtures.Foundation {
 			Assert.AreEqual (now.Month, comps.Month, "a month");
 			Assert.AreEqual (now.Day, comps.Day, "a day");
 
-			comps = cal.Components (NSCalendarUnit.Hour, (NSDate) now.AddHours (-1), (NSDate) now, NSDateComponentsWrappingBehavior.None);
+			var dayCompare = now.ToUniversalTime ();
+			comps = cal.Components (NSCalendarUnit.Hour, (NSDate) dayCompare.AddHours (-1), (NSDate) dayCompare, NSDateComponentsWrappingBehavior.None);
 			Assert.AreEqual (1, comps.Hour, "b hour");
 		}
 


### PR DESCRIPTION
Hopefully third time's the charm...

Don't do date math (adding hours) to a local datetime, since DST *will* muddy
the waters and prove that 1=2.

Instead convert the date we want to calculate on to UTC, which should be DST-agnostic.

I've tested this by running the test for every hour during the next 10 years,
so that should cover mostly everything (although I'm still waiting for the
Delorean I ordered to be able to test both in the future and the past).

Previous attempts:

https://github.com/rolfbjarne/xamarin-macios/commit/0442cdf9c0c4cbb3ae2a0f21125dcc98ae85b648
https://github.com/rolfbjarne/xamarin-macios/commit/5caddb35710482574eafd7b9a0cbb8c4aa97d4db

Should fix https://github.com/xamarin/maccore/issues/573.