### PR TITLE
[MTouch] If we are building a shared code extension, do not build the msym dir. #60415

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1015,6 +1015,69 @@ public class B : A {}
 		}
 
 		[Test]
+		public void MT0095_SharedCode ()
+		{
+			using (var exttool = new MTouchTool ()) {
+				exttool.Profile = Profile.iOS;
+				exttool.CreateTemporaryCacheDirectory ();
+				exttool.Linker = MTouchLinker.LinkAll;
+
+				exttool.CreateTemporaryServiceExtension ();
+				exttool.MSym = true;
+				exttool.Debug = false;
+				exttool.AssertExecute (MTouchAction.BuildDev, "build extension");
+
+				using (var apptool = new MTouchTool ()) {
+					apptool.Profile = Profile.iOS;
+					apptool.MSym = true;
+					apptool.Debug = false;
+					apptool.CreateTemporaryCacheDirectory ();
+					apptool.CreateTemporaryApp ();
+					apptool.AppExtensions.Add (exttool);
+					apptool.Linker = MTouchLinker.LinkAll;
+					apptool.AssertExecute (MTouchAction.BuildDev, "build app");
+					
+					Assert.IsTrue(Directory.Exists(Path.Combine(apptool.Cache, "Build", "Msym")), "App Msym dir");
+					Assert.IsFalse(Directory.Exists(Path.Combine(exttool.Cache, "Build", "Msym")), "Extenson Msym dir");
+					exttool.AssertNoWarnings();
+					apptool.AssertNoWarnings();
+				}
+			}
+		}
+		
+		[Test]
+		public void MT0095_NotSharedCode ()
+		{
+			using (var exttool = new MTouchTool ()) {
+				exttool.Profile = Profile.iOS;
+				exttool.CreateTemporaryCacheDirectory ();
+				exttool.Linker = MTouchLinker.LinkAll;
+				exttool.CustomArguments = new string [] { "--nodevcodeshare" };
+				exttool.CreateTemporaryServiceExtension ();
+				exttool.MSym = true;
+				exttool.Debug = false;
+				exttool.AssertExecute (MTouchAction.BuildDev, "build extension");
+
+				using (var apptool = new MTouchTool ()) {
+					apptool.Profile = Profile.iOS;
+					apptool.MSym = true;
+					apptool.Debug = false;
+					apptool.CreateTemporaryCacheDirectory ();
+					apptool.CreateTemporaryApp ();
+					apptool.AppExtensions.Add (exttool);
+					apptool.Linker = MTouchLinker.LinkAll;
+					apptool.CustomArguments = new string [] { "--nodevcodeshare" };
+					apptool.AssertExecute (MTouchAction.BuildDev, "build app");
+					
+					Assert.IsTrue(Directory.Exists(Path.Combine(apptool.Cache, "Build", "Msym")), "App Msym dir");
+					Assert.IsTrue(Directory.Exists(Path.Combine(exttool.Cache, "Build", "Msym")), "Extenson Msym dir");
+					exttool.AssertNoWarnings();
+					apptool.AssertNoWarnings();
+				}
+			}
+		}
+		
+		[Test]
 		public void MT0096 ()
 		{
 			using (var mtouch = new MTouchTool ()) {

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -2001,6 +2001,9 @@ namespace Xamarin.Bundler {
 			if (!EnableMSym)
 				return;
 
+			if (IsExtension && IsCodeShared) // we already have the data from the app
+				return;
+
 			var target_directory = string.Format ("{0}.mSYM", AppDirectory);
 			if (!Directory.Exists (target_directory))
 				Directory.CreateDirectory (target_directory);


### PR DESCRIPTION
We used to try and build the msym dir for shared code extensions, this meant that a warning was given because in that case, the msym is shared, therefore we already have it in the app path as per comments in the bug https://bugzilla.xamarin.com/show_bug.cgi?id=60415

Since the action is done at the very end, we know what we are building and we can scape the method if we are an extension and shared.