### PR TITLE
[coreimage] Add new Image Dictionary Keys

### DIFF
--- a/src/CoreImage/CIImage.cs
+++ b/src/CoreImage/CIImage.cs
@@ -144,7 +144,7 @@ namespace XamCore.CoreImage {
 				throw new ArgumentNullException ("colorSpace");
 			
 			using (var arr = NSArray.FromIntPtrs (new IntPtr [] { colorSpace.Handle })){
-				using (var keys = NSArray.FromIntPtrs (new IntPtr [] { CIImageColorSpaceKey.Handle } )){
+				using (var keys = NSArray.FromIntPtrs (new IntPtr [] { CIImageInitializationOptionsKeys.ColorSpaceKey.Handle } )){
 					using (var dict = NSDictionary.FromObjectsAndKeysInternal (arr, keys)){
 						return FromCGImage (image, dict);
 					}

--- a/src/CoreImage/CIImageInitializationOptions.cs
+++ b/src/CoreImage/CIImageInitializationOptions.cs
@@ -34,30 +34,21 @@ using XamCore.CoreGraphics;
 
 namespace XamCore.CoreImage {
 
-	public class CIImageInitializationOptions : DictionaryContainer
+	public partial class CIImageInitializationOptions
 	{
 #if !COREBUILD
-		public CIImageInitializationOptions ()
-			: base (new NSMutableDictionary ())
-		{
-		}
-
-		public CIImageInitializationOptions (NSDictionary dictionary)
-			: base (dictionary)
-		{
-		}
-
 		public CGColorSpace ColorSpace {
 			get {
-				return GetNativeValue<CGColorSpace> (CIImage.CIImageColorSpaceKey);
+				return GetNativeValue<CGColorSpace> (CIImageInitializationOptionsKeys.ColorSpaceKey);
 			}
 			set {
-				SetNativeValue (CIImage.CIImageColorSpaceKey, value == null ? null : value);
+				SetNativeValue (CIImageInitializationOptionsKeys.ColorSpaceKey, value == null ? null : value);
 			}
 		}
 #endif
 	}
 
+	// Keeping 'CIImageInitializationOptionsWithMetadata' to avoid breaking change
 	public class CIImageInitializationOptionsWithMetadata : CIImageInitializationOptions
 	{
 #if !COREBUILD
@@ -68,18 +59,6 @@ namespace XamCore.CoreImage {
 		public CIImageInitializationOptionsWithMetadata (NSDictionary dictionary)
 			: base (dictionary)
 		{
-		}
-
-		public CGImageProperties Properties {
-			get {
-				var dict = GetNativeValue<NSDictionary> (CIImage.CIImagePropertiesKey);
-				if (dict == null)
-					return null;
-				return new CGImageProperties (dict);
-			}
-			set {
-				SetNativeValue (CIImage.CIImagePropertiesKey, value == null ? null : value.Dictionary, false);
-			}
 		}
 #endif
 	}

--- a/src/Foundation/DictionaryContainer.cs
+++ b/src/Foundation/DictionaryContainer.cs
@@ -237,6 +237,8 @@ namespace XamCore.Foundation {
 				throw new ArgumentNullException ("key");
 
 			var dict = GetNSDictionary (key);
+			if (dict == null)
+				return null;
 			T value = (T)Activator.CreateInstance (typeof(T),
 				new object[] { dict }
 			);

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -25,6 +25,7 @@
 //
 
 using System;
+using System.ComponentModel;
 using System.Reflection;
 using XamCore.AVFoundation;
 using XamCore.Foundation;
@@ -1270,6 +1271,7 @@ namespace XamCore.CoreImage {
 		[Export ("imageWithCGImage:")]
 		CIImage FromCGImage (CGImage image);
 
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Static]
 		[Export ("imageWithCGImage:options:")]
 		CIImage FromCGImage (CGImage image, [NullAllowed] NSDictionary d);
@@ -1306,6 +1308,7 @@ namespace XamCore.CoreImage {
 		[Export ("imageWithContentsOfURL:")]
 		CIImage FromUrl (NSUrl url);
 
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Static]
 		[Export ("imageWithContentsOfURL:options:")]
 		CIImage FromUrl (NSUrl url, [NullAllowed] NSDictionary d);
@@ -1318,6 +1321,7 @@ namespace XamCore.CoreImage {
 		[Export ("imageWithData:")]
 		CIImage FromData (NSData data);
 
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Static]
 		[Export ("imageWithData:options:")]
 		CIImage FromData (NSData data, [NullAllowed] NSDictionary d);
@@ -1332,18 +1336,21 @@ namespace XamCore.CoreImage {
 		CIImage FromImageBuffer (CVImageBuffer imageBuffer);
 
 #if MONOMAC && !XAMCORE_4_0
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Static]
 		[Mac(10,4)]
 		[Export ("imageWithCVImageBuffer:options:")]
 		CIImage FromImageBuffer (CVImageBuffer imageBuffer, [NullAllowed] NSDictionary dict);
 #else
 #if XAMCORE_2_0
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Static]
 		[iOS(9,0)]
 		[Internal] // This overload is needed for our strong dictionary support (but only for Unified, since for Classic the generic version is transformed to this signature)
 		[Export ("imageWithCVImageBuffer:options:")]
 		CIImage FromImageBuffer (CVImageBuffer imageBuffer, [NullAllowed] NSDictionary dict);
 #endif
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Static]
 		[iOS(9,0)]
 		[Export ("imageWithCVImageBuffer:options:")]
@@ -1359,6 +1366,7 @@ namespace XamCore.CoreImage {
 		[Export ("imageWithCVPixelBuffer:")]
 		CIImage FromImageBuffer (CVPixelBuffer buffer);
 
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Static]
 		[Export ("imageWithCVPixelBuffer:options:")]
 		CIImage FromImageBuffer (CVPixelBuffer buffer, [NullAllowed] NSDictionary dict);
@@ -1377,6 +1385,7 @@ namespace XamCore.CoreImage {
 		[iOS (11,0)]
 		[TV (11,0)]
 		[Mac (10,13)]
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Static]
 		[Export ("imageWithIOSurface:options:")]
 		CIImage FromSurface (IOSurface.IOSurface surface, NSDictionary options);
@@ -1399,6 +1408,7 @@ namespace XamCore.CoreImage {
 		[Export ("initWithCGImage:")]
 		IntPtr Constructor (CGImage image);
 
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("initWithCGImage:options:")]
 		IntPtr Constructor (CGImage image, [NullAllowed] NSDictionary d);
 
@@ -1409,6 +1419,7 @@ namespace XamCore.CoreImage {
 		[Export ("initWithCGLayer:")]
 		IntPtr Constructor (CGLayer layer);
 
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("initWithCGLayer:options:")]
 		IntPtr Constructor (CGLayer layer, [NullAllowed] NSDictionary d);
 

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -942,6 +942,14 @@ namespace XamCore.CoreImage {
 		[Since (7,0)]
 		[Field ("kCIInputExtentKey", "+CoreImage")]
 		NSString Extent  { get; }
+
+		[iOS (11,0), TV (11,0), Mac (10,13)]
+		[Field ("kCIInputDepthImageKey", "+CoreImage")]
+		NSString DepthImage { get; }
+
+		[iOS (11,0), TV (11,0), Mac (10,13)]
+		[Field ("kCIInputDisparityImageKey", "+CoreImage")]
+		NSString DisparityImage { get; }
 	}
 		
 	[Since (5,0)]
@@ -1261,6 +1269,54 @@ namespace XamCore.CoreImage {
 
 		[Export ("extent")]
 		CGRect Extent { get; }
+	}
+
+	[StrongDictionary ("CIImageInitializationOptionsKeys")]
+	interface CIImageInitializationOptions {
+		// Bug #60726: [Generator] Support INativeObject in StrongDictionary
+		// (https://bugzilla.xamarin.com/show_bug.cgi?id=60726)
+		// CGColorSpace ColorSpace { get; set; }
+
+		CoreGraphics.CGImageProperties Properties { get; set; }
+
+		[iOS (11,0), TV (11,0), Mac (10,13)]
+		bool ApplyOrientationProperty { get; set; }
+
+		[iOS (11,0), TV (11,0), Mac (10,13)]
+		bool NearestSampling { get; set; }
+
+		[iOS (11,0), TV (11,0), Mac (10,13)]
+		bool AuxiliaryDepth { get; set; }
+
+		[iOS (11,0), TV (11,0), Mac (10,13)]
+		bool AuxiliaryDisparity { get; set; }
+	}
+
+	[Internal]
+	[Static]
+	interface CIImageInitializationOptionsKeys {
+		[Field ("kCIImageColorSpace")]
+		NSString ColorSpaceKey { get; }
+
+		[MountainLion]
+		[Field ("kCIImageProperties")]
+		NSString PropertiesKey { get; }
+
+		[iOS (11,0), TV (11,0), Mac (10,13)]
+		[Field ("kCIImageNearestSampling")]
+		NSString NearestSamplingKey { get; }
+
+		[iOS (11,0), TV (11,0), Mac (10,13)]
+		[Field ("kCIImageApplyOrientationProperty")]
+		NSString ApplyOrientationPropertyKey { get; }
+
+		[iOS (11,0), TV (11,0), Mac (10,13)]
+		[Field ("kCIImageAuxiliaryDepth")]
+		NSString AuxiliaryDepthKey { get; }
+
+		[iOS (11,0), TV (11,0), Mac (10,13)]
+		[Field ("kCIImageAuxiliaryDisparity")]
+		NSString AuxiliaryDisparityKey { get; }
 	}
 	
 	[BaseType (typeof (NSObject))]
@@ -1691,13 +1747,6 @@ namespace XamCore.CoreImage {
 
 		[Export ("autoAdjustmentFiltersWithOptions:"), Internal]
 		NSArray _GetAutoAdjustmentFilters ([NullAllowed] NSDictionary opts);
-
-		[Field ("kCIImageColorSpace"), Internal]
-		NSString CIImageColorSpaceKey { get; }
-
-		[MountainLion]
-		[Field ("kCIImageProperties"), Internal]
-		NSString CIImagePropertiesKey { get; }
 
 		[Since (6,0)] // publicly documented in 7.0 but really available since 6.0
 		[Mac (10,12)]

--- a/tests/xtro-sharpie/common.pending
+++ b/tests/xtro-sharpie/common.pending
@@ -65,14 +65,6 @@
 !missing-selector! CISampler::initWithImage:keysAndValues: not bound
 !missing-selector! +CISampler::samplerWithImage:keysAndValues: not bound
 
-## https://bugzilla.xamarin.com/show_bug.cgi?id=59296
-!missing-field! kCIImageApplyOrientationProperty not bound
-!missing-field! kCIImageAuxiliaryDepth not bound
-!missing-field! kCIImageAuxiliaryDisparity not bound
-!missing-field! kCIImageNearestSampling not bound
-!missing-field! kCIInputDepthImageKey not bound
-!missing-field! kCIInputDisparityImageKey not bound
-
 
 # Foundation
 


### PR DESCRIPTION
- Fixes bug #59296: [coreimage] Some `kCI*`keys are not bound (https://bugzilla.xamarin.com/show_bug.cgi?id=59296)
- Generate a StrongDictionary for `CIImageInitializationOptions` to avoid manual code.
- Move `CGImageProperties Properties { get; set; }` to parent type `CIImageInitializationOptions` (avoid 2 strong dictionaries).
  Reason:
  Even though the headers give us an indication of which constructors should use some CIImage keys it's hard to apply that to all constructors consistently.
  We could have 1 strong dictionary per constructor (duplicate members) with just the exact members we know it supports (based on headers) however it's better to have a single strong dictionary and document the options because A might be available only in X today and Y next too next year.
- Fix `DictionaryContainer`'s `GetStrongDictionary` to return null and not throw if target StrongDictionary is not yet set.

Basically:

```
var options = new CIImageInitializationOptionsWithMetadata ();
Assert.That (options.Dictionary.Count, Is.EqualTo (0), "Count");
```

Would throw:

``` 
System.Reflection.TargetInvocationException : Exception has been thrown by the target of an invocation.
 ----> System.ArgumentNullException : Value cannot be null.
```

- Add EditorBrowsableState.Advanced to CIImage's NSDictionary .ctor