### PR TITLE
[homekit] Expose weakly-typed API since the constants are extensible. Fixed #60303

### DIFF
--- a/src/HomeKit/HMEnums.cs
+++ b/src/HomeKit/HMEnums.cs
@@ -148,8 +148,10 @@ namespace XamCore.HomeKit {
 		[Field ("HMCharacteristicTypeHeatingThreshold")]
 		HeatingThreshold,
 
+#if !XAMCORE_4_0
 		[Obsolete ("This value does not exist anymore and will always return null.")]
 		HeatingCoolingStatus,
+#endif
 
 		[Field ("HMCharacteristicTypeCurrentRelativeHumidity")]
 		CurrentRelativeHumidity,

--- a/src/HomeKit/HMHome.cs
+++ b/src/HomeKit/HMHome.cs
@@ -78,7 +78,7 @@ namespace XamCore.HomeKit {
 			if ((serviceTypes & HMServiceType.Slats) == HMServiceType.Slats)
 				arr.Add (HMServiceType.Slats.GetConstant ());
 
-			return _ServicesWithTypes (arr.ToArray ());
+			return GetServices (arr.ToArray ());
 		}
 	}
 }

--- a/src/HomeKit/HMMutableSignificantTimeEvent.cs
+++ b/src/HomeKit/HMMutableSignificantTimeEvent.cs
@@ -7,10 +7,10 @@ namespace XamCore.HomeKit {
 
 		public virtual HMSignificantEvent SignificantEvent {
 			get {
-				return (HMSignificantEvent) (HMSignificantEventExtensions.GetValue (_SignificantEvent));
+				return (HMSignificantEvent) (HMSignificantEventExtensions.GetValue (WeakSignificantEvent));
 			}
 			set {
-				_SignificantEvent = HMSignificantEventExtensions.GetConstant (value);
+				WeakSignificantEvent = HMSignificantEventExtensions.GetConstant (value);
 			}
 		}
 	}

--- a/src/HomeKit/HMSignificantTimeEvent.cs
+++ b/src/HomeKit/HMSignificantTimeEvent.cs
@@ -7,10 +7,10 @@ namespace XamCore.HomeKit {
 
 		public virtual HMSignificantEvent SignificantEvent {
 			get {
-				return (HMSignificantEvent) (HMSignificantEventExtensions.GetValue (_SignificantEvent));
+				return (HMSignificantEvent) (HMSignificantEventExtensions.GetValue (WeakSignificantEvent));
 			}
 			set {
-				_SignificantEvent = HMSignificantEventExtensions.GetConstant (value);
+				WeakSignificantEvent = HMSignificantEventExtensions.GetConstant (value);
 			}
 		}
 	}

--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -344,11 +344,11 @@ namespace XamCore.HomeKit {
 	[BaseType (typeof (NSObject))]
 	partial interface HMCharacteristic {
 
-		[Internal]
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("characteristicType", ArgumentSemantic.Copy)]
-		NSString _CharacteristicType { get; }
+		NSString WeakCharacteristicType { get; }
 
-		[Wrap ("HMCharacteristicTypeExtensions.GetValue (_CharacteristicType)")]
+		[Wrap ("HMCharacteristicTypeExtensions.GetValue (WeakCharacteristicType)")]
 		HMCharacteristicType CharacteristicType { get; }
 
 		[Export ("service", ArgumentSemantic.Weak)]
@@ -583,9 +583,9 @@ namespace XamCore.HomeKit {
 		[Export ("assignAccessory:toRoom:completionHandler:")]
 		void AssignAccessory (HMAccessory accessory, HMRoom room, Action<NSError> completion);
 
-		[Internal]
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("servicesWithTypes:")]
-		HMService [] _ServicesWithTypes (NSString [] serviceTypes);
+		HMService [] GetServices (NSString [] serviceTypes);
 
 		[NoTV]
 		[NoWatch]
@@ -871,11 +871,11 @@ namespace XamCore.HomeKit {
 		[Export ("accessory", ArgumentSemantic.Weak)]
 		HMAccessory Accessory { get; }
 
-		[Internal]
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("serviceType", ArgumentSemantic.Copy)]
-		NSString _ServiceType { get; }
+		NSString WeakServiceType { get; }
 
-		[Wrap ("HMServiceTypeExtensions.GetValue (_ServiceType)")]
+		[Wrap ("HMServiceTypeExtensions.GetValue (WeakServiceType)")]
 		HMServiceType ServiceType { get; }
 
 		[Export ("name")]
@@ -1140,11 +1140,11 @@ namespace XamCore.HomeKit {
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInternalInconsistencyException Reason: init is unavailable
 	interface HMAccessoryCategory {
-		[Internal]
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("categoryType")]
-		NSString _CategoryType { get; }
+		NSString WeakCategoryType { get; }
 
-		[Wrap ("HMAccessoryCategoryTypeExtensions.GetValue (_CategoryType)")]
+		[Wrap ("HMAccessoryCategoryTypeExtensions.GetValue (WeakCategoryType)")]
 		HMAccessoryCategoryType CategoryType { get; }
 
 		[Export ("localizedDescription")]
@@ -1711,12 +1711,12 @@ namespace XamCore.HomeKit {
 		[Wrap ("this (HMSignificantEventExtensions.GetConstant (significantEvent), offset)")]
 		IntPtr Constructor (HMSignificantEvent significantEvent, [NullAllowed] NSDateComponents offset);
 
-		[Internal]
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("significantEvent", ArgumentSemantic.Strong)]
-		NSString _SignificantEvent { get; [NotImplemented] set; }
+		NSString WeakSignificantEvent { get; [NotImplemented] set; }
 
 		// FIXME: Bug https://bugzilla.xamarin.com/show_bug.cgi?id=57870
-		// [Wrap ("HMSignificantEventExtensions.GetValue (_SignificantEvent)")]
+		// [Wrap ("HMSignificantEventExtensions.GetValue (WeakSignificantEvent)")]
 		// HMSignificantEvent SignificantEvent { get; [NotImplemented] set; }
 
 		[NullAllowed, Export ("offset", ArgumentSemantic.Strong)]
@@ -1734,14 +1734,14 @@ namespace XamCore.HomeKit {
 		[Wrap ("this (HMSignificantEventExtensions.GetConstant (significantEvent), offset)")]
 		IntPtr Constructor (HMSignificantEvent significantEvent, [NullAllowed] NSDateComponents offset);
 
-		[Internal]
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Override]
 		[Export ("significantEvent", ArgumentSemantic.Strong)]
-		NSString _SignificantEvent { get; set; }
+		NSString WeakSignificantEvent { get; set; }
 
 		// FIXME: Bug https://bugzilla.xamarin.com/show_bug.cgi?id=57870
 		// [Override]
-		// [Wrap ("HMSignificantEventExtensions.GetValue (_SignificantEvent)")]
+		// [Wrap ("HMSignificantEventExtensions.GetValue (WeakSignificantEvent)")]
 		// HMSignificantEvent SignificantEvent { get; set; }
 
 		[Override]

--- a/tests/introspection/ApiWeakPropertyTest.cs
+++ b/tests/introspection/ApiWeakPropertyTest.cs
@@ -43,6 +43,9 @@ namespace Introspection {
 			// the selector starts with `weak`
 			case "WeakRelatedUniqueIdentifier":
 				return property.DeclaringType.Name == "CSSearchableItemAttributeSet";
+			// this is a weakly typed API (not a weak reference) with a [NotImplemented] so there's no [Export]
+			case "WeakSignificantEvent":
+				return property.DeclaringType.Name == "HMSignificantTimeEvent";
 			}
 			return false;
 		}


### PR DESCRIPTION
This is a case of NSString enum extensibility - even if this framework does not use the usual `NS_EXTENSIBLE_STRING_ENUM` macro (which is recent and have not been applied for all framework / headers).

Minimally we need to provide alternative, weakly typed, `NSString`-based API wherever the (extensible) enums types are used. Not the best API (even if we can minimize it's use with `[EditorBrowsable (EditorBrowsableState.Advanced)]`) but C# enums can't be extended this way.

Also, even if less urgent, we need to make the enum-generated helper aware of the extensibility so they do not throw, making it easier to mix strongly and weakly typed code (instead of choosing one over the other).

Taking the first step for `xcode92` with the enum-backed constants in HomeKit, i.e.
* HMAccessoryCategoryType
* HMCharacteristicType
* HMServiceType
* HMSignificantEvent

Reference
https://bugzilla.xamarin.com/show_bug.cgi?id=60303