### PR TITLE
[xharness] Make sure different flavors of XM tests don't build/run from the same path.

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -243,9 +243,9 @@ namespace xharness
 			MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "introspection", "Mac", "introspection-mac.csproj")), targetFrameworkFlavor: MacFlavors.Modern) { Name = "introspection" });
 
 			var hard_coded_test_suites = new [] {
-				new { ProjectFile = "mmptest", Name = "mmptest", IsNUnit = true, Configurations = (string[]) null },
-				new { ProjectFile = "msbuild-mac", Name = "MSBuild tests", IsNUnit = false, Configurations = (string[]) null },
-				new { ProjectFile = "xammac_tests", Name = "xammac tests", IsNUnit = false, Configurations = new string [] { "Debug", "Release" }},
+				new { ProjectFile = "mmptest", Name = "mmptest", IsNUnit = true, Configurations = (string[]) null, Platform = "x86", },
+				new { ProjectFile = "msbuild-mac", Name = "MSBuild tests", IsNUnit = false, Configurations = (string[]) null, Platform = "x86" },
+				new { ProjectFile = "xammac_tests", Name = "xammac tests", IsNUnit = false, Configurations = new string [] { "Debug", "Release" }, Platform = "AnyCPU" },
 			};
 			foreach (var p in hard_coded_test_suites) {
 				MacTestProjects.Add (new MacTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p.ProjectFile + "/" + p.ProjectFile + ".csproj")), generateVariations: false) {
@@ -253,6 +253,7 @@ namespace xharness
 					IsNUnitProject = p.IsNUnit,
 					SolutionPath = Path.GetFullPath (Path.Combine (RootDirectory, "tests-mac.sln")),
 					Configurations = p.Configurations,
+					Platform = p.Platform,
 				});
 			}
 
@@ -282,7 +283,8 @@ namespace xharness
 					var bclTestInfo = new MacBCLTestInfo (this, p, flavor);
 					var bclTestProject = new MacTestProject (bclTestInfo.ProjectPath, targetFrameworkFlavor: flavor, generateVariations: false) {
 						Name = p,
-						BCLInfo = bclTestInfo
+						BCLInfo = bclTestInfo,
+						Platform = "AnyCPU",
 					};
 
 					MacTestProjects.Add (bclTestProject);

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -529,7 +529,7 @@ namespace xharness
 					build.TestProject = project;
 					build.SolutionPath = project.SolutionPath;
 					build.ProjectConfiguration = config;
-					build.ProjectPlatform = "x86";
+					build.ProjectPlatform = project.Platform;
 					build.SpecifyPlatform = false;
 					build.SpecifyConfiguration = build.ProjectConfiguration != "Debug";
 					RunTestTask exec;
@@ -2606,10 +2606,15 @@ function oninitialload ()
 				suffix = "-unifiedXM45-32";
 				break;
 			}
-			if (BCLTest)
-				Path = System.IO.Path.Combine (System.IO.Path.GetDirectoryName (ProjectFile), "bin", BuildTask.ProjectConfiguration + suffix, name + "Tests.app", "Contents", "MacOS", name + "Tests");
-			else
+			if (ProjectFile.EndsWith (".sln")) {
 				Path = System.IO.Path.Combine (System.IO.Path.GetDirectoryName (ProjectFile), "bin", BuildTask.ProjectPlatform, BuildTask.ProjectConfiguration + suffix, name + ".app", "Contents", "MacOS", name);
+			} else {
+				var project = new System.Xml.XmlDocument ();
+				project.LoadWithoutNetworkAccess (ProjectFile);
+				var outputPath = project.GetOutputPath (BuildTask.ProjectPlatform, BuildTask.ProjectConfiguration).Replace ('\\', '/');
+				var assemblyName = project.GetAssemblyName ();
+				Path = System.IO.Path.Combine (System.IO.Path.GetDirectoryName (ProjectFile), outputPath, assemblyName + ".app", "Contents", "MacOS", assemblyName);
+			}
 
 			using (var resource = await NotifyAndAcquireDesktopResourceAsync ()) {
 				using (var proc = new Process ()) {

--- a/tests/xharness/PListExtensions.cs
+++ b/tests/xharness/PListExtensions.cs
@@ -20,6 +20,19 @@ namespace xharness
 			}
 		}
 
+		public static void LoadXmlWithoutNetworkAccess (this XmlDocument doc, string xml)
+		{
+			using (var fs = new StringReader (xml)) {
+				var settings = new XmlReaderSettings () {
+					XmlResolver = null,
+					DtdProcessing = DtdProcessing.Parse,
+				};
+				using (var reader = XmlReader.Create (fs, settings)) {
+					doc.Load (reader);
+				}
+			}
+		}
+
 		public static void SetMinimumOSVersion (this XmlDocument plist, string value)
 		{
 			SetPListStringValue (plist, "MinimumOSVersion", value);

--- a/tests/xharness/ProjectFileExtensions.cs
+++ b/tests/xharness/ProjectFileExtensions.cs
@@ -177,6 +177,20 @@ namespace xharness
 
 		public static void SetIntermediateOutputPath (this XmlDocument csproj, string value)
 		{
+			// Set any existing IntermediateOutputPath
+			var nodes = csproj.SelectNodes ("/*/*/*[local-name() = 'IntermediateOutputPath']");
+			var hasToplevel = false;
+			if (nodes.Count != 0) {
+				foreach (XmlNode n in nodes) {
+					n.InnerText = value;
+					hasToplevel |= n.Attributes ["Condition"] == null;
+				}
+			}
+
+			if (hasToplevel)
+				return;
+			
+			// Make sure there's a top-level version too.
 			var project = csproj.ChildNodes [1];
 			var property_group = project.ChildNodes [0];
 
@@ -188,6 +202,11 @@ namespace xharness
 		public static void SetTargetFrameworkIdentifier (this XmlDocument csproj, string value)
 		{
 			SetTopLevelPropertyGroupValue (csproj, "TargetFrameworkIdentifier", value);
+		}
+
+		public static void SetTargetFrameworkVersion (this XmlDocument csproj, string value)
+		{
+			SetTopLevelPropertyGroupValue (csproj, "TargetFrameworkVersion", value);
 		}
 
 		public static void SetTopLevelPropertyGroupValue (this XmlDocument csproj, string key, string value)

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -158,6 +158,7 @@ namespace xharness
 		public bool GenerateModern => TargetFrameworkFlavor == MacFlavors.All || TargetFrameworkFlavor == MacFlavors.Modern;
 		public bool GenerateFull => TargetFrameworkFlavor == MacFlavors.All || TargetFrameworkFlavor == MacFlavors.Full;
 
+		public string Platform = "x86";
 		public string [] Configurations;
 
 		public MacTestProject () : base ()


### PR DESCRIPTION
Change [Intermediate]OutputPath of Xamarin.Mac test projects to include the
project flavor, so that they don't build into (and run from) the same location
(which leads to random and incorrect behavior for at least one of the
flavors).

Fixes https://github.com/xamarin/maccore/issues/584