### PR TITLE
[xharness] Report the exit code when thinking a test crashed.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -2635,7 +2635,7 @@ function oninitialload ()
 								ExecutionResult = TestExecutingResult.Succeeded;
 							} else {
 								ExecutionResult = TestExecutingResult.Failed;
-								FailureMessage = result.ExitCode != 1 ? "Test run crashed." : "Test run failed.";
+								FailureMessage = result.ExitCode != 1 ? $"Test run crashed (exit code: {result.ExitCode})." : "Test run failed.";
 								log.WriteLine (FailureMessage);
 							}
 						} finally {


### PR DESCRIPTION
Usually an exit code of neither 0 nor 1 means a test run crashed (in
particular if the exit code is 130+), but this may not always be true, so
report the exit code as well so that a human can evaluate properly.