### PR TITLE
[mtouch][mmp] Allow the use of major-only version numbers in arguments. Fixes #60280

### DIFF
--- a/tests/mtouch/StringUtilsTest.cs
+++ b/tests/mtouch/StringUtilsTest.cs
@@ -16,6 +16,15 @@ namespace Xamarin.Tests.Utils {
 			// unless only the major part is provided
 			v = StringUtils.ParseVersion ("6");
 			Assert.That (v.ToString (), Is.EqualTo ("6.0"), "6.0");
+			// with major and minor
+			v = StringUtils.ParseVersion ("7.1");
+			Assert.That (v.ToString (), Is.EqualTo ("7.1"), "7.1");
+			// with major and minor
+			v = StringUtils.ParseVersion ("7.1");
+			Assert.That (v.ToString (), Is.EqualTo ("7.1"), "7.1");
+			// with major, minor and build
+			v = StringUtils.ParseVersion ("10.13.2");
+			Assert.That (v.ToString (), Is.EqualTo ("10.13.2"), "10.13.2");
 		}
 	}
 }

--- a/tests/mtouch/StringUtilsTest.cs
+++ b/tests/mtouch/StringUtilsTest.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Utils;
+
+namespace Xamarin.Tests.Utils {
+
+	[TestFixture]
+	public class StringUtilsTest {
+
+		[Test]
+		public void ParseVersion ()
+		{
+			// just like Version.Parse
+			var v = StringUtils.ParseVersion ("11.0");
+			Assert.That (v.ToString (), Is.EqualTo ("11.0"), "11.0");
+			// unless only the major part is provided
+			v = StringUtils.ParseVersion ("6");
+			Assert.That (v.ToString (), Is.EqualTo ("6.0"), "6.0");
+		}
+	}
+}

--- a/tests/mtouch/mtouch.csproj
+++ b/tests/mtouch/mtouch.csproj
@@ -56,6 +56,7 @@
     <Compile Include="..\common\ProductTests.cs">
       <Link>ProductTests.cs</Link>
     </Compile>
+    <Compile Include="StringUtilsTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tools/common/StringUtils.cs
+++ b/tools/common/StringUtils.cs
@@ -55,5 +55,21 @@ namespace Xamarin.Utils {
 			return builder.ToString ();
 		}
 
+		// Version.Parse requires, minimally, both major and minor parts.
+		// However we want to accept `11` as `11.0`
+		public static Version ParseVersion (string v)
+		{
+			try {
+				// assume the normal case
+				return Version.Parse (v);
+			}
+			catch (Exception) {
+				// so maybe it's only a major version
+				int major;
+				if (Int32.TryParse (v, out major))
+					return Version.Parse (v + ".0");
+				throw;
+			}
+		}
 	}
 }

--- a/tools/common/StringUtils.cs
+++ b/tools/common/StringUtils.cs
@@ -59,17 +59,10 @@ namespace Xamarin.Utils {
 		// However we want to accept `11` as `11.0`
 		public static Version ParseVersion (string v)
 		{
-			try {
-				// assume the normal case
-				return Version.Parse (v);
-			}
-			catch (Exception) {
-				// so maybe it's only a major version
-				int major;
-				if (Int32.TryParse (v, out major))
-					return Version.Parse (v + ".0");
-				throw;
-			}
+			int major;
+			if (int.TryParse (v, out major))
+				return new Version (major, 0);
+			return Version.Parse (v);
 		}
 	}
 }

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -265,9 +265,9 @@ namespace Xamarin.Bundler {
 				{ "minos=", "Minimum supported version of Mac OS X", 
 					v => {
 						try {
-							App.DeploymentTarget = Version.Parse (v);
+							App.DeploymentTarget = StringUtils.ParseVersion (v);
 						} catch (Exception ex) {
-							ErrorHelper.Error (26, ex, "Could not parse the command line argument '{0}': {1}", "-minos", ex.Message);
+							ErrorHelper.Error (26, ex, $"Could not parse the command line argument '-minos:{v}': {ex.Message}");
 						}
 					}
 				},
@@ -314,9 +314,9 @@ namespace Xamarin.Bundler {
 				{ "sdk=", "Specifies the SDK version to compile against (version, for example \"10.9\")",
 					v => {
 						try {
-							App.SdkVersion = Version.Parse (v);
+							App.SdkVersion = StringUtils.ParseVersion (v);
 						} catch (Exception ex) {
-							ErrorHelper.Error (26, ex, "Could not parse the command line argument '{0}': {1}", "-sdk", ex.Message);
+							ErrorHelper.Error (26, ex, $"Could not parse the command line argument '-sdk:{v}': {ex.Message}");
 						}
 					}
 				},

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1046,18 +1046,18 @@ namespace Xamarin.Bundler
 			{ "sdk=", "Specifies the name of the SDK to compile against (version, for example \"3.2\")",
 				v => {
 					try {
-						app.SdkVersion = Version.Parse (v);
+						app.SdkVersion = StringUtils.ParseVersion (v);
 					} catch (Exception ex) {
-						ErrorHelper.Error (26, ex, "Could not parse the command line argument '{0}': {1}", "-sdk", ex.Message);
+						ErrorHelper.Error (26, ex, $"Could not parse the command line argument '-sdk:{v}': {ex.Message}");
 					}
 				}
 			},
 			{ "targetver=", "Specifies the name of the minimum deployment target (version, for example \"" + Xamarin.SdkVersions.iOS.ToString () + "\")",
 				v => {
 					try {
-						app.DeploymentTarget = Version.Parse (v);
+						app.DeploymentTarget = StringUtils.ParseVersion (v);
 					} catch (Exception ex) {
-						throw new MonoTouchException (26, true, ex, "Could not parse the command line argument '{0}': {1}", "-targetver", ex.Message);
+						throw new MonoTouchException (26, true, ex,  $"Could not parse the command line argument '-targetver:{v}': {ex.Message}");
 					}
 				}
 			},


### PR DESCRIPTION
The parsing done by `System.Version` does not accept a major-only string,
e.g. providing "11" would throw an exception.

Since people generally refer version as iOS 11 (and not iOS 11.0) this
is, at best, a nuisance. Xcode toolchain accept "11" as a valid string.

The first part of message was updated to show both the option name and
the (user provided) value.

The 2nd part remain the text of the .net exception message, i.e. what
`Version.Parse` tells you when it validates the string. Seeing the input
value should make it more obvious for other, incorrect version strings.

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=60280