### PR TITLE
[tests] Fix copying test files in System.IO.Compression[.FileSystem] tests.

### DIFF
--- a/tests/bcl-test/System.IO.Compression.FileSystem/System.IO.Compression.FileSystem-mac.csproj.template
+++ b/tests/bcl-test/System.IO.Compression.FileSystem/System.IO.Compression.FileSystem-mac.csproj.template
@@ -80,7 +80,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
   <Target Name="AfterBuild">
-    <Copy SourceFiles="@(FilesToCopyFoo)" DestinationFolder="$(OutputPath)\System.IO.Compression.FileSystemTests.app\Contents\MonoBundle\foo" />
-    <Copy SourceFiles="@(FilesToCopyFooBar)" DestinationFolder="$(OutputPath)\System.IO.Compression.FileSystemTests.app\Contents\MonoBundle\foo\foobar" />
+    <Copy SourceFiles="@(FilesToCopyFoo)" DestinationFolder="$(OutputPath)\$(AssemblyName).app\Contents\MonoBundle\foo" />
+    <Copy SourceFiles="@(FilesToCopyFooBar)" DestinationFolder="$(OutputPath)\$(AssemblyName).app\Contents\MonoBundle\foo\foobar" />
   </Target>
 </Project>

--- a/tests/bcl-test/System.IO.Compression/System.IO.Compression-mac.csproj.template
+++ b/tests/bcl-test/System.IO.Compression/System.IO.Compression-mac.csproj.template
@@ -79,6 +79,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
   <Target Name="AfterBuild">
-    <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(OutputPath)\System.IO.CompressionTests.app\Contents\MonoBundle" />
+    <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(OutputPath)\$(AssemblyName).app\Contents\MonoBundle" />
   </Target>
 </Project>


### PR DESCRIPTION
The app path depends on the assembly name, which mean we must take the
assembly name into account when calculating the app path where to copy
resource files for these two tests.

Fixes the following tests:

* System.IO.Compression

    * ZipDeleteEntryCheckEntries (MonoTests.System.IO.Compression.ZipArchiveTests.ZipDeleteEntryCheckEntries)
    * ZipEnumerateEntriesCreateMode (MonoTests.System.IO.Compression.ZipArchiveTests.ZipEnumerateEntriesCreateMode)
    * ZipEnumerateEntriesModifiedTime (MonoTests.System.IO.Compression.ZipArchiveTests.ZipEnumerateEntriesModifiedTime)
    * ZipEnumerateEntriesReadMode (MonoTests.System.IO.Compression.ZipArchiveTests.ZipEnumerateEntriesReadMode)
    * ZipEnumerateEntriesUpdateMode (MonoTests.System.IO.Compression.ZipArchiveTests.ZipEnumerateEntriesUpdateMode)
    * ZipGetArchiveEntryStreamLengthPositionReadMode (MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetArchiveEntryStreamLengthPositionReadMode)
    * ZipGetArchiveEntryStreamLengthPositionUpdateMode (MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetArchiveEntryStreamLengthPositionUpdateMode)
    * ZipGetEntryCreateMode (MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryCreateMode)
    * ZipGetEntryDeleteReadMode (MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryDeleteReadMode)
    * ZipGetEntryDeleteUpdateMode (MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryDeleteUpdateMode)
    * ZipGetEntryOpen (MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryOpen)
    * ZipGetEntryReadMode (MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryReadMode)
    * ZipGetEntryUpdateMode (MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryUpdateMode)
    * ZipOpenAndReopenEntry (MonoTests.System.IO.Compression.ZipArchiveTests.ZipOpenAndReopenEntry)
    * ZipOpenCloseAndReopenEntry (MonoTests.System.IO.Compression.ZipArchiveTests.ZipOpenCloseAndReopenEntry)
    * ZipReadNonSeekableStream (MonoTests.System.IO.Compression.ZipArchiveTests.ZipReadNonSeekableStream)
    * ZipWriteEntriesUpdateMode (MonoTests.System.IO.Compression.ZipArchiveTests.ZipWriteEntriesUpdateMode)
    * ZipWriteEntriesUpdateModeNonZeroPosition (MonoTests.System.IO.Compression.ZipArchiveTests.ZipWriteEntriesUpdateModeNonZeroPosition)
    * ZipWriteNonSeekableStream (MonoTests.System.IO.Compression.ZipArchiveTests.ZipWriteNonSeekableStream)

* System.IO.Compression.FileSystem

    * ZipCreateFromDirectory (MonoTests.System.IO.Compression.FileSystem.ZipArchiveTests.ZipCreateFromDirectory)
    * ZipCreateFromDirectoryIncludeBase (MonoTests.System.IO.Compression.FileSystem.ZipArchiveTests.ZipCreateFromDirectoryIncludeBase)
    * ZipCreateFromEntryChangeTimestamp (MonoTests.System.IO.Compression.FileSystem.ZipArchiveTests.ZipCreateFromEntryChangeTimestamp)
    * ZipExtractToDirectory (MonoTests.System.IO.Compression.FileSystem.ZipArchiveTests.ZipExtractToDirectory)