### PR TITLE
[xharness] Define XAMMAC for XM/Modern and XAMMAC_4_5 for XM/Full, just like we do when building the BCL.

### DIFF
--- a/tests/xharness/BCLTestInfo.cs
+++ b/tests/xharness/BCLTestInfo.cs
@@ -198,7 +198,10 @@ namespace xharness
 				inputProject.SetTargetFrameworkIdentifier ("Xamarin.Mac");
 				inputProject.SetTargetFrameworkVersion ("v2.0");
 				inputProject.RemoveNode ("UseXamMacFullFramework");
-				inputProject.AddAdditionalDefines ("MOBILE");
+				inputProject.AddAdditionalDefines ("MOBILE;XAMMAC");
+				break;
+			case MacFlavors.Full:
+				inputProject.AddAdditionalDefines ("XAMMAC_4_5");
 				break;
 			}
 			inputProject.SetOutputPath ("bin\\$(Platform)\\$(Configuration)" + FlavorSuffix);


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/587, because the failing test ignores an assert when XAMMAC is defined: https://github.com/mono/mono/blob/1c4d741a020da74f250f5c4764b5a87a0a139a76/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs#L127-L130