### PR TITLE
[xharness] Don't keep files open when not needed anymore.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -722,6 +722,7 @@ namespace xharness
 				}
 
 				logdev.StopCapture ();
+				device_system_log.Dispose ();
 
 				// Upload the system log
 				if (File.Exists (device_system_log.FullPath)) {

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -2056,6 +2056,7 @@ function oninitialload ()
 					log.WriteLine (FailureMessage);
 				}
 			} finally {
+				MainLog.Dispose ();
 				duration.Stop ();
 			}
 
@@ -2325,6 +2326,7 @@ function oninitialload ()
 					}
 					Jenkins.MainLog.WriteLine ("Built {0} ({1})", TestName, Mode);
 				}
+				log.Dispose ();
 			}
 		}
 	}
@@ -2401,6 +2403,8 @@ function oninitialload ()
 					}
 					Jenkins.MainLog.WriteLine ("Built {0} ({1})", TestName, Mode);
 				}
+
+				log.Dispose ();
 			}
 		}
 
@@ -3006,6 +3010,9 @@ function oninitialload ()
 					// Also clean up after us locally.
 					if (Harness.InJenkins || Harness.InWrench || Succeeded)
 						await BuildTask.CleanAsync ();
+
+					uninstall_log.Dispose ();
+					install_log.Dispose ();
 				}
 			}
 		}

--- a/tests/xharness/Log.cs
+++ b/tests/xharness/Log.cs
@@ -93,6 +93,8 @@ namespace xharness
 
 	public class LogFile : Log
 	{
+		object lock_obj = new object ();
+		bool append;
 		public string Path;
 		StreamWriter writer;
 
@@ -100,14 +102,14 @@ namespace xharness
 			: base (description)
 		{
 			Path = path;
-
-			writer = new StreamWriter (new FileStream (Path, append ? FileMode.Append : FileMode.Create, FileAccess.Write, FileShare.Read));
-			writer.AutoFlush = true;
+			this.append = append;
+			if (!append)
+				File.WriteAllText (path, string.Empty);
 		}
 
 		protected override void WriteImpl (string value)
 		{
-			writer.Write (value);
+			GetWriter ().Write (value);
 		}
 
 		public override string FullPath {
@@ -123,6 +125,12 @@ namespace xharness
 
 		public override StreamWriter GetWriter ()
 		{
+			lock (lock_obj) {
+				if (writer == null) {
+					writer = new StreamWriter (new FileStream (Path, append ? FileMode.Append : FileMode.Create, FileAccess.Write, FileShare.Read));
+					writer.AutoFlush = true;
+				}
+			}
 			return writer;
 		}
 
@@ -142,12 +150,6 @@ namespace xharness
 		string path;
 		FileStream fs;
 		StreamWriter writer;
-
-		public FileStream FileStream {
-			get {
-				return fs;
-			}
-		}
 
 		public override StreamReader GetReader ()
 		{


### PR DESCRIPTION
Dispose logs (so that the corresponding files are closed) when we're done with
them, and also don't open a file log by default (usually we just want a
filename to pass to somebody else), but instead open the file if needed.

This should decrease the number of open file descriptors in xharness, which
sometimes become a problem when running many tests.