### PR TITLE
[AppKit] Add [NullAllowed] to NSWorkspace.SharedWorkspace.OpenFile, fixes bug 60821.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -20700,10 +20700,10 @@ namespace XamCore.AppKit {
 		bool OpenFile (string fullPath);
 		
 		[Export ("openFile:withApplication:"), ThreadSafe]
-		bool OpenFile (string fullPath, string appName);
+		bool OpenFile (string fullPath, [NullAllowed] string appName);
 		
 		[Export ("openFile:withApplication:andDeactivate:"), ThreadSafe]
-		bool OpenFile (string fullPath, string appName, bool deactivate);
+		bool OpenFile (string fullPath, [NullAllowed] string appName, bool deactivate);
 		
 		[Export ("openFile:fromImage:at:inView:"), ThreadSafe]
 		bool OpenFile (string fullPath, NSImage anImage, CGPoint point, NSView aView);


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=60821

According to header definitions, `appName` is allowed to be null.

```objc
- (BOOL)openFile:(NSString *)fullPath withApplication:(nullable NSString *)appName;
- (BOOL)openFile:(NSString *)fullPath withApplication:(nullable NSString *)appName andDeactivate:(BOOL)flag;
```