### PR TITLE
[coreimage] Fix the pointer used in CIVector(nfloat[]) until the native call completes

### DIFF
--- a/src/ObjCRuntime/Messaging.iOS.cs
+++ b/src/ObjCRuntime/Messaging.iOS.cs
@@ -329,6 +329,11 @@ namespace XamCore.ObjCRuntime {
 		public extern static void void_objc_msgSendSuper_IntPtr_RectangleF_IntPtr (IntPtr receiver, IntPtr selector, IntPtr arg1, System.Drawing.RectangleF arg2, IntPtr arg3);
 		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSendSuper")]
 		public extern static void void_objc_msgSend_IntPtr_RectangleF_IntPtr (IntPtr receiver, IntPtr selector, IntPtr arg1, System.Drawing.RectangleF arg2, IntPtr arg3);
+
+		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSend")]
+		public extern static IntPtr IntPtr_objc_msgSend_IntPtr_nint (IntPtr receiver, IntPtr selector, global::System.IntPtr arg1, nint arg2);
+		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSendSuper")]
+		public extern static IntPtr IntPtr_objc_msgSendSuper_IntPtr_nint (IntPtr receiver, IntPtr selector, global::System.IntPtr arg1, nint arg2);
 #endif
 	}
 }

--- a/src/ObjCRuntime/Messaging.mac.cs
+++ b/src/ObjCRuntime/Messaging.mac.cs
@@ -599,7 +599,10 @@ namespace XamCore.ObjCRuntime {
 		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSend")]
 		public extern static int int_objc_msgSend_NSRange_IntPtr_IntPtr_IntPtr_IntPtr_IntPtr (IntPtr receiver, IntPtr selector, MonoMac.Foundation.NSRange arg1, IntPtr arg2, IntPtr arg3, IntPtr arg4, IntPtr arg5, IntPtr arg6);
 
-
+		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSend")]
+		public extern static IntPtr IntPtr_objc_msgSend_IntPtr_nint (IntPtr receiver, IntPtr selector, global::System.IntPtr arg1, nint arg2);
+		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSendSuper")]
+		public extern static IntPtr IntPtr_objc_msgSendSuper_IntPtr_nint (IntPtr receiver, IntPtr selector, global::System.IntPtr arg1, nint arg2);
 #endif
 	}
 }

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -2238,10 +2238,6 @@ namespace XamCore.CoreImage {
 		[Export ("vectorWithString:")]
 		CIVector FromString (string representation);
 
-		[DesignatedInitializer]
-		[Internal, Export ("initWithValues:count:")]
-		IntPtr Constructor (IntPtr values, nint count);
-
 		[Mac (10,9)]
 		[iOS (5,0)]
 		[Export ("initWithCGPoint:")]

--- a/tests/monotouch-test/CoreImage/CoreVectorTest.cs
+++ b/tests/monotouch-test/CoreImage/CoreVectorTest.cs
@@ -37,14 +37,33 @@ namespace MonoTouchFixtures.CoreImage {
 	public class CIVectorTest {
 		
 		[Test]
-		public void Constructors ()
+		public void CtorFloatArray ()
 		{
 			// Make sure these do not crash
-			Assert.That (new CIVector (new nfloat [0]).Count, Is.EqualTo ((nint) 0));
-			Assert.That (new CIVector (new nfloat [] {1}).Count, Is.EqualTo ((nint) 1));
-			Assert.That (new CIVector (new nfloat [] {1,2}).Count, Is.EqualTo ((nint) 2));
-			Assert.That (new CIVector (new nfloat [] {1,2,3}).Count, Is.EqualTo ((nint) 3));
-			Assert.That (new CIVector (new nfloat [] {1,2,3,4}).Count, Is.EqualTo ((nint) 4));
+			Assert.That (new CIVector (new nfloat [0]).Count, Is.EqualTo ((nint) 0), "0");
+			Assert.That (new CIVector (new nfloat [] {1}).Count, Is.EqualTo ((nint) 1), "1");
+			Assert.That (new CIVector (new nfloat [] {1,2}).Count, Is.EqualTo ((nint) 2), "2'");
+			Assert.That (new CIVector (new nfloat [] {1,2,3}).Count, Is.EqualTo ((nint) 3), "3");
+			Assert.That (new CIVector (new nfloat [] {1,2,3,4}).Count, Is.EqualTo ((nint) 4), "4");
+
+			Assert.Throws<ArgumentNullException> (() => new CIVector ((nfloat[]) null), "null");
+		}
+
+		[Test]
+		public void CtorFloatArrayCount ()
+		{
+			Assert.That (new CIVector (new nfloat [0], 0).Count, Is.EqualTo ((nint) 0), "0");
+			Assert.That (new CIVector (new nfloat [] {1}, 1).Count, Is.EqualTo ((nint) 1), "1");
+			Assert.That (new CIVector (new nfloat [] {1,2}, 2).Count, Is.EqualTo ((nint) 2), "2'");
+			Assert.That (new CIVector (new nfloat [] {1,2,3,4}, 2).Count, Is.EqualTo ((nint) 2), "4/2");
+
+			Assert.Throws<ArgumentNullException> (() => new CIVector ((nfloat[]) null, 0), "null");
+			Assert.Throws<ArgumentOutOfRangeException> (() => new CIVector (new nfloat [] {1}, 2), "out-of-range");
+		}
+
+		[Test]
+		public void CtorInts ()
+		{
 			Assert.That (new CIVector (1).Count, Is.EqualTo ((nint) 1));
 			Assert.That (new CIVector (1,2).Count, Is.EqualTo ((nint) 2));
 			Assert.That (new CIVector (1,2,3).Count, Is.EqualTo ((nint) 3));


### PR DESCRIPTION
However there's a small window between the time we get a pointer
and the call to the native selector where the memory is not fixed.
During this time the GC can move the memory resulting in hard to
diagnose crashes.

Note: `initWithValues:count:` copies the provided memory so what
happens afterward is not an issue.