### PR TITLE
[security] Add bindings for Xcode 9

### DIFF
--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -357,7 +357,7 @@ namespace XamCore.Security {
 			return (data == IntPtr.Zero) ? null : new NSData (data, true);
 		}
 
-		[iOS (10,3)]
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
 		[DllImport (Constants.SecurityLibrary)]
 		static extern /* __nullable CFDataRef */ IntPtr SecCertificateCopySerialNumberData (IntPtr /* SecCertificateRef */ certificate, ref IntPtr /* CFErrorRef * */ error);
 

--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -343,6 +343,10 @@ namespace XamCore.Security {
 #endif
 		[iOS (10,3)]
 		[Mac (10,7)]
+		[Deprecated (PlatformName.iOS, 11,0, message: "Use 'GetSerialNumber(out NSError)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10,13, message: "Use 'GetSerialNumber(out NSError)' instead.")]
+		[Deprecated (PlatformName.WatchOS, 4,0, message: "Use 'GetSerialNumber(out NSError)' instead.")]
+		[Deprecated (PlatformName.TvOS, 11,0, message: "Use 'GetSerialNumber(out NSError)' instead.")]
 		public NSData GetSerialNumber ()
 		{
 #if MONOMAC
@@ -350,6 +354,19 @@ namespace XamCore.Security {
 #else
 			IntPtr data = SecCertificateCopySerialNumber (handle);
 #endif
+			return (data == IntPtr.Zero) ? null : new NSData (data, true);
+		}
+
+		[iOS (10,3)]
+		[DllImport (Constants.SecurityLibrary)]
+		static extern /* __nullable CFDataRef */ IntPtr SecCertificateCopySerialNumberData (IntPtr /* SecCertificateRef */ certificate, ref IntPtr /* CFErrorRef * */ error);
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		public NSData GetSerialNumber (out NSError error)
+		{
+			IntPtr err = IntPtr.Zero;
+			IntPtr data = SecCertificateCopySerialNumberData (handle, ref err);
+			error = Runtime.GetNSObject<NSError> (err);
 			return (data == IntPtr.Zero) ? null : new NSData (data, true);
 		}
 

--- a/src/Security/Enums.cs
+++ b/src/Security/Enums.cs
@@ -68,6 +68,7 @@ namespace XamCore.Security {
 		NoTrustSettings 					= -25263,
 		Pkcs12VerifyFailure 				= -25264,
 		NotSigner 							= -26267,
+		MissingEntitlement				= -34018,
 		ServiceNotAvailable 				= -67585,
 		InsufficientClientID 				= -67586,
 		DeviceReset 						= -67587,

--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -1306,6 +1306,16 @@ namespace XamCore.Security {
 			}
 		}
 
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		public bool PersistentReference {
+			get {
+				return Fetch (SecAttributeKey.PersistentReference) == CFBoolean.True.Handle;
+			}
+			set {
+				SetValue (CFBoolean.FromBoolean (value).Handle, SecAttributeKey.PersistentReference);
+			}
+		}
+
 		//
 		// Matches
 		//

--- a/src/Security/SecureTransport.cs
+++ b/src/Security/SecureTransport.cs
@@ -18,6 +18,8 @@ namespace XamCore.Security {
 		Tls_1_1 = 7, 
 		Tls_1_2 = 8, 
 		Dtls_1_0 = 9,
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		Tls_1_3 = 10,
 		
 		/* Obsolete on iOS */
 		Ssl_2_0 = 1,          
@@ -107,6 +109,9 @@ namespace XamCore.Security {
 
 		[iOS (10,0)][Mac (10,12)]
 		AllowRenegotiation = 8,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		EnableSessionTickets = 9,
 	}
 
 	// Security.framework/Headers/SecureTransport.h
@@ -266,6 +271,10 @@ namespace XamCore.Security {
 		TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384		= 0xC030,	// iOS 9+
 		TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256		= 0xC031,	// iOS 9+
 		TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384		= 0xC032,	// iOS 9+
+
+		// https://tools.ietf.org/html/rfc7905
+		TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256	= 0xCCA8,	// Xcode 9+
+		TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256	= 0xCCA9,	// Xcode 9+
 
 		TLS_AES_128_GCM_SHA256						= 0x1301,	// iOS 11+
 		TLS_AES_256_GCM_SHA384						= 0x1302,	// iOS 11+

--- a/src/Security/SslContext.cs
+++ b/src/Security/SslContext.cs
@@ -608,5 +608,71 @@ namespace XamCore.Security {
 			}
 			return result;
 		}
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[DllImport (Constants.SecurityLibrary)]
+		static extern /* OSStatus */ int SSLSetSessionTicketsEnabled (IntPtr /* SSLContextRef */ context, [MarshalAs (UnmanagedType.I1)] bool /* Boolean */ enabled);
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		public int SetSessionTickets (bool enabled)
+		{
+			return SSLSetSessionTicketsEnabled (Handle, enabled);
+		}
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[DllImport (Constants.SecurityLibrary)]
+		static extern /* OSStatus */ int SSLSetError (IntPtr /* SSLContextRef */ context, SecStatusCode /* OSStatus */ status);
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		public int SetError (SecStatusCode status)
+		{
+			return SSLSetError (Handle, status);
+		}
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[DllImport (Constants.SecurityLibrary)]
+		static extern /* OSStatus */ int SSLSetOCSPResponse (IntPtr /* SSLContextRef */ context, IntPtr /* CFDataRef __nonnull */ response);
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		public int SetOcspResponse (NSData response)
+		{
+			if (response == null)
+				throw new ArgumentNullException (nameof (response));
+			return SSLSetOCSPResponse (Handle, response.Handle);
+		}
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[DllImport (Constants.SecurityLibrary)]
+		static extern /* OSStatus */ int SSLSetALPNProtocols (IntPtr /* SSLContextRef */ context, IntPtr /* CFArrayRef */ protocols);
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		public int SetAlpnProtocols (string[] protocols)
+		{
+			using (var array = NSArray.FromStrings (protocols))
+				return SSLSetALPNProtocols (Handle, array.Handle);
+		}
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[DllImport (Constants.SecurityLibrary)]
+		static extern /* OSStatus */ int SSLCopyALPNProtocols (IntPtr /* SSLContextRef */ context, ref IntPtr /* CFArrayRef* */ protocols);
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		public string[] GetAlpnProtocols (out int error)
+		{
+			IntPtr protocols = IntPtr.Zero; // must be null, CFArray allocated by SSLCopyALPNProtocols
+			error = SSLCopyALPNProtocols (Handle, ref protocols);
+			if (protocols == IntPtr.Zero)
+				return Array.Empty<string> ();
+			var result = NSArray.StringArrayFromHandle (protocols);
+			CFObject.CFRelease (protocols);
+			return result;
+		}
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		public string[] GetAlpnProtocols ()
+		{
+			int error;
+			return GetAlpnProtocols (out error);
+		}
 	}
 }

--- a/src/security.cs
+++ b/src/security.cs
@@ -134,9 +134,10 @@ namespace XamCore.Security {
 		[Field ("kSecTrustCertificateTransparency")]
 		NSString CertificateTransparency { get; }
 
-		[iOS (10,0)][Mac (10,12)]
-		[Watch (3,0)]
-		[TV (10,0)]
+		[iOS (10,0)][Deprecated (PlatformName.iOS, 11,0)]
+		[Mac (10,12)][Deprecated (PlatformName.MacOSX, 10,13)]
+		[Watch (3,0)][Deprecated (PlatformName.WatchOS, 4,0)]
+		[TV (10,0)][Deprecated (PlatformName.TvOS, 11,0)]
 		[Field ("kSecTrustCertificateTransparencyWhiteList")]
 		NSString CertificateTransparencyWhiteList { get; }
 	}
@@ -503,6 +504,11 @@ namespace XamCore.Security {
 		[TV (10,0)]
 		[Field ("kSecAttrAccessGroupToken")]
 		IntPtr AccessGroupToken { get; }
+
+		// note: kSecAttrPersistentReference (beta 1) is a typo that was not removed
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecAttrPersistentReference")]
+		IntPtr PersistentReference { get; }
 	}
 
 	[Static][Internal]
@@ -828,10 +834,86 @@ namespace XamCore.Security {
 
 		[Field ("kSecKeyAlgorithmECDHKeyExchangeCofactorX963SHA512")]
 		EcdhKeyExchangeCofactorX963Sha512,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmRSASignatureDigestPSSSHA1")]
+		RsaSignatureDigestPssSha1,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmRSASignatureDigestPSSSHA224")]
+		RsaSignatureDigestPssSha224,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmRSASignatureDigestPSSSHA256")]
+		RsaSignatureDigestPssSha256,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmRSASignatureDigestPSSSHA384")]
+		RsaSignatureDigestPssSha384,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmRSASignatureDigestPSSSHA512")]
+		RsaSignatureDigestPssSha512,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmRSASignatureMessagePSSSHA1")]
+		RsaSignatureMessagePssSha1,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmRSASignatureMessagePSSSHA224")]
+		RsaSignatureMessagePssSha224,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmRSASignatureMessagePSSSHA256")]
+		RsaSignatureMessagePssSha256,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmRSASignatureMessagePSSSHA384")]
+		RsaSignatureMessagePssSha384,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmRSASignatureMessagePSSSHA512")]
+		RsaSignatureMessagePssSha512,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmECIESEncryptionStandardVariableIVX963SHA224AESGCM")]
+		EciesEncryptionStandardVariableIvx963Sha224AesGcm,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmECIESEncryptionStandardVariableIVX963SHA256AESGCM")]
+		EciesEncryptionStandardVariableIvx963Sha256AesGcm,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmECIESEncryptionStandardVariableIVX963SHA384AESGCM")]
+		EciesEncryptionStandardVariableIvx963Sha384AesGcm,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmECIESEncryptionStandardVariableIVX963SHA512AESGCM")]
+		EciesEncryptionStandardVariableIvx963Sha512AesGcm,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmECIESEncryptionCofactorVariableIVX963SHA224AESGCM")]
+		EciesEncryptionCofactorVariableIvx963Sha224AesGcm,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmECIESEncryptionCofactorVariableIVX963SHA256AESGCM")]
+		EciesEncryptionCofactorVariableIvx963Sha256AesGcm,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmECIESEncryptionCofactorVariableIVX963SHA384AESGCM")]
+		EciesEncryptionCofactorVariableIvx963Sha384AesGcm,
+
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[Field ("kSecKeyAlgorithmECIESEncryptionCofactorVariableIVX963SHA512AESGCM")]
+		EciesEncryptionCofactorVariableIvx963Sha512AesGcm,
 	}
 
 	[iOS (10,0)][TV (10,0)][Watch (3,0)][Mac (10,12)]
 	enum SslSessionConfig {
+		[Deprecated (PlatformName.iOS, 11,0)]
+		[Deprecated (PlatformName.MacOSX, 10,13)]
+		[Deprecated (PlatformName.WatchOS, 4,0)]
+		[Deprecated (PlatformName.TvOS, 11,0)]
 		[Field ("kSSLSessionConfig_default")]
 		Default,
 
@@ -844,12 +926,20 @@ namespace XamCore.Security {
 		[Field ("kSSLSessionConfig_standard")]
 		Standard,
 
+		[Deprecated (PlatformName.iOS, 11,0)]
+		[Deprecated (PlatformName.MacOSX, 10,13)]
+		[Deprecated (PlatformName.WatchOS, 4,0)]
+		[Deprecated (PlatformName.TvOS, 11,0)]
 		[Field ("kSSLSessionConfig_RC4_fallback")]
 		RC4Fallback,
 
 		[Field ("kSSLSessionConfig_TLSv1_fallback")]
 		Tls1Fallback,
 
+		[Deprecated (PlatformName.iOS, 11,0)]
+		[Deprecated (PlatformName.MacOSX, 10,13)]
+		[Deprecated (PlatformName.WatchOS, 4,0)]
+		[Deprecated (PlatformName.TvOS, 11,0)]
 		[Field ("kSSLSessionConfig_TLSv1_RC4_fallback")]
 		Tls1RC4Fallback,
 
@@ -864,11 +954,19 @@ namespace XamCore.Security {
 
 		[iOS (10,2)][TV (10,1)][Mac (10,12,2)]
 		[Watch (3,2)]
+		[Deprecated (PlatformName.iOS, 11,0)]
+		[Deprecated (PlatformName.MacOSX, 10,13)]
+		[Deprecated (PlatformName.WatchOS, 4,0)]
+		[Deprecated (PlatformName.TvOS, 11,0)]
 		[Field ("kSSLSessionConfig_3DES_fallback")]
 		ThreeDesFallback,
 
 		[iOS (10,2)][TV (10,1)][Mac (10,12,2)]
 		[Watch (3,2)]
+		[Deprecated (PlatformName.iOS, 11,0)]
+		[Deprecated (PlatformName.MacOSX, 10,13)]
+		[Deprecated (PlatformName.WatchOS, 4,0)]
+		[Deprecated (PlatformName.TvOS, 11,0)]
 		[Field ("kSSLSessionConfig_TLSv1_3DES_fallback")]
 		Tls1ThreeDesFallback,
 	}

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -85,6 +85,7 @@ namespace Introspection
 			"Aiff",
 			"Aio",
 			"Alg", // short for Algorithm
+			"Alpn", // Application-Layer Protocol Negotiation RFC7301
 			"Amete",
 			"Amr",
 			"Anglet",
@@ -322,6 +323,7 @@ namespace Introspection
 			"Objectfor",
 			"Occlussion",
 			"Ocurrences",
+			"Ocsp", // Online Certificate Status Protocol
 			"Octree",
 			"Oid",
 			"Olus",

--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -525,6 +525,11 @@ namespace MonoTouchFixtures.Security {
 				Assert.NotNull (cert.GetNormalizedSubjectSequence (), "GetNormalizedSubjectSequence");
 				Assert.NotNull (cert.GetPublicKey (), "GetPublicKey");
 			}
+			if (TestRuntime.CheckXcodeVersion (9,0)) {
+				NSError err;
+				Assert.That (cert.GetSerialNumber (out err).Description, Is.EqualTo ("<2b9f7ee5 ca25a625 14204782 753a9bb9>"), "GetSerialNumber/NSError");
+				Assert.Null (err, "err") ;
+			}
 		}
 
 		[Test]

--- a/tests/monotouch-test/Security/SecureTransportTest.cs
+++ b/tests/monotouch-test/Security/SecureTransportTest.cs
@@ -90,6 +90,22 @@ namespace MonoTouchFixtures.Security {
 				Assert.That ((int)ssl.SetDatagramHelloCookie (new byte [32]), Is.EqualTo (-50), "no cookie in stream");
 
 				// Assert.Null (ssl.GetDistinguishedNames<string> (), "GetDistinguishedNames");
+
+				if (TestRuntime.CheckXcodeVersion (9,0)) {
+					Assert.That (ssl.SetSessionTickets (false), Is.EqualTo (0), "SetSessionTickets");
+					Assert.That (ssl.SetError (SecStatusCode.Success), Is.EqualTo (0), "SetError");
+
+					Assert.Throws<ArgumentNullException> (() => ssl.SetOcspResponse (null), "SetOcspResponse/null");
+					using (var data = new NSData ())
+						Assert.That (ssl.SetOcspResponse (data), Is.EqualTo (0), "SetOcspResponse/empty");
+
+					int error;
+					var alpn = ssl.GetAlpnProtocols (out error);
+					Assert.That (alpn, Is.Empty, "alpn");
+					Assert.That (error, Is.EqualTo ((int) SecStatusCode.Param), "GetAlpnProtocols");
+					var protocols = new [] { "HTTP/1.1", "SPDY/1" };
+					Assert.That (ssl.SetAlpnProtocols (protocols), Is.EqualTo (0), "SetAlpnProtocols");
+				}
 			}
 		}
 


### PR DESCRIPTION
Also covers the missing enum value (added in xcode9) from
https://bugzilla.xamarin.com/show_bug.cgi?id=59278