### PR TITLE
[xharness] Don't run the mmp regression tests in parallel with other tests.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -617,6 +617,7 @@ namespace xharness
 				WorkingDirectory = Path.Combine (Harness.RootDirectory, "mmptest", "regression"),
 				Ignored = !IncludeMmpTest || !IncludeMac,
 				Timeout = TimeSpan.FromMinutes (30),
+				SupportsParallelExecution = false, // Already doing parallel execution by running "make -jX"
 			};
 			run_mmp.Environment.Add ("BUILD_REVISION", "jenkins"); // This will print "@MonkeyWrench: AddFile: <log path>" lines, which we can use to get the log filenames.
 			Tasks.Add (run_mmp);
@@ -1906,6 +1907,8 @@ function oninitialload ()
 		static int counter;
 		public readonly int ID = counter++;
 
+		bool? supports_parallel_execution;
+
 		public Jenkins Jenkins;
 		public Harness Harness { get { return Jenkins.Harness; } }
 		public TestProject TestProject;
@@ -2229,7 +2232,10 @@ function oninitialload ()
 
 		public virtual bool SupportsParallelExecution {
 			get {
-				return true;
+				return supports_parallel_execution ?? true;
+			}
+			set {
+				supports_parallel_execution = value;
 			}
 		}
 


### PR DESCRIPTION
The mmp regression tests are already executed in parallel (using `make -j8` in
the Makefile), and they're quite CPU intensitive, which means that if xharness
runs other tests in addition to the these tests, then those other tests may
fail randomly.