### PR TITLE
[xharness] Improve logging.

### DIFF
--- a/tests/xharness/SimpleListener.cs
+++ b/tests/xharness/SimpleListener.cs
@@ -9,7 +9,7 @@ namespace xharness
 {
 	public abstract class SimpleListener : IDisposable
 	{
-		StreamWriter output_writer;
+		Log output_writer;
 		string xml_data;
 
 		TaskCompletionSource<bool> stopped = new TaskCompletionSource<bool> ();
@@ -18,7 +18,7 @@ namespace xharness
 		public IPAddress Address { get; set; }
 		public int Port { get; set; }
 		public Log Log { get; set; }
-		public LogStream TestLog { get; set; }
+		public Log TestLog { get; set; }
 		public bool AutoExit { get; set; }
 		public bool XmlOutput { get; set; }
 
@@ -26,7 +26,7 @@ namespace xharness
 		protected abstract void Start ();
 		protected abstract void Stop ();
 
-		public StreamWriter OutputWriter {
+		public Log OutputWriter {
 			get {
 				return output_writer;
 			}
@@ -38,7 +38,7 @@ namespace xharness
 			connected.Set ();
 
 			if (output_writer == null) {
-				output_writer = TestLog.GetWriter ();
+				output_writer = TestLog;
 				// a few extra bits of data only available from this side
 				var local_data =
 $@"[Local Date/Time:	{DateTime.Now}]

--- a/tests/xharness/SimpleTcpListener.cs
+++ b/tests/xharness/SimpleTcpListener.cs
@@ -57,7 +57,7 @@ namespace xharness
 			int i;
 			int total = 0;
 			NetworkStream stream = client.GetStream ();
-			var fs = OutputWriter.BaseStream;
+			var fs = OutputWriter;
 			while ((i = stream.Read (buffer, 0, buffer.Length)) != 0) {
 				fs.Write (buffer, 0, i);
 				fs.Flush ();


### PR DESCRIPTION
Make the collection of logs (the `Logs` class) more capable by making it
disposable (which will dispose all contained logs) and give it a Directory
property to state where the logs should be stored. This makes it possible to
simplify a few repeated path calculations. It also allows us to easily dispose
the entire collection of logs when done with a test, as opposed to dispoing
the logs one by one.

Make LogFile more capable:

* Add support for writing byte arrays.
* Add support for logging after disposal: this will still write to the file,
  and not keep any files open after finished writing. This fixes a problem
  where writing to a log after it was disposed would crash xharness (which is
  not all that uncommon, given the async nature of how xharness runs tests).

This makes it possible to get rid of LogStream, and use LogFile instead.