### PR TITLE
[tests] Fix introspection tests for macOS

### DIFF
--- a/src/Security/SslContext.cs
+++ b/src/Security/SslContext.cs
@@ -641,22 +641,22 @@ namespace XamCore.Security {
 			return SSLSetOCSPResponse (Handle, response.Handle);
 		}
 
-		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][NoMac] //[Mac (10,13)] Apple forgot to export SSLSetALPNProtocols. https://bugs.swift.org/browse/SR-6131
 		[DllImport (Constants.SecurityLibrary)]
 		static extern /* OSStatus */ int SSLSetALPNProtocols (IntPtr /* SSLContextRef */ context, IntPtr /* CFArrayRef */ protocols);
 
-		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][NoMac] //[Mac (10,13)]  Apple forgot to export SSLSetALPNProtocols. https://bugs.swift.org/browse/SR-6131
 		public int SetAlpnProtocols (string[] protocols)
 		{
 			using (var array = NSArray.FromStrings (protocols))
 				return SSLSetALPNProtocols (Handle, array.Handle);
 		}
 
-		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][NoMac] //[Mac (10,13)] Apple forgot to export SSLCopyALPNProtocols.
 		[DllImport (Constants.SecurityLibrary)]
 		static extern /* OSStatus */ int SSLCopyALPNProtocols (IntPtr /* SSLContextRef */ context, ref IntPtr /* CFArrayRef* */ protocols);
 
-		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[iOS (11,0)][TV (11,0)][Watch (4,0)][NoMac] //[Mac (10,13)] Apple forgot to export the SSLCopyALPNProtocols.
 		public string[] GetAlpnProtocols (out int error)
 		{
 			IntPtr protocols = IntPtr.Zero; // must be null, CFArray allocated by SSLCopyALPNProtocols

--- a/src/Security/SslContext.cs
+++ b/src/Security/SslContext.cs
@@ -641,22 +641,23 @@ namespace XamCore.Security {
 			return SSLSetOCSPResponse (Handle, response.Handle);
 		}
 
-		[iOS (11,0)][TV (11,0)][Watch (4,0)][NoMac] //[Mac (10,13)] Apple forgot to export SSLSetALPNProtocols. https://bugs.swift.org/browse/SR-6131
+#if !MONOMAC
+		[iOS (11,0)][TV (11,0)][Watch (4,0)] //[Mac (10,13)] Apple forgot to export SSLSetALPNProtocols. https://bugs.swift.org/browse/SR-6131
 		[DllImport (Constants.SecurityLibrary)]
 		static extern /* OSStatus */ int SSLSetALPNProtocols (IntPtr /* SSLContextRef */ context, IntPtr /* CFArrayRef */ protocols);
 
-		[iOS (11,0)][TV (11,0)][Watch (4,0)][NoMac] //[Mac (10,13)]  Apple forgot to export SSLSetALPNProtocols. https://bugs.swift.org/browse/SR-6131
+		[iOS (11,0)][TV (11,0)][Watch (4,0)] //[Mac (10,13)]  Apple forgot to export SSLSetALPNProtocols. https://bugs.swift.org/browse/SR-6131
 		public int SetAlpnProtocols (string[] protocols)
 		{
 			using (var array = NSArray.FromStrings (protocols))
 				return SSLSetALPNProtocols (Handle, array.Handle);
 		}
 
-		[iOS (11,0)][TV (11,0)][Watch (4,0)][NoMac] //[Mac (10,13)] Apple forgot to export SSLCopyALPNProtocols.
+		[iOS (11,0)][TV (11,0)][Watch (4,0)] //[Mac (10,13)] Apple forgot to export SSLCopyALPNProtocols.
 		[DllImport (Constants.SecurityLibrary)]
 		static extern /* OSStatus */ int SSLCopyALPNProtocols (IntPtr /* SSLContextRef */ context, ref IntPtr /* CFArrayRef* */ protocols);
 
-		[iOS (11,0)][TV (11,0)][Watch (4,0)][NoMac] //[Mac (10,13)] Apple forgot to export the SSLCopyALPNProtocols.
+		[iOS (11,0)][TV (11,0)][Watch (4,0)] //[Mac (10,13)] Apple forgot to export the SSLCopyALPNProtocols.
 		public string[] GetAlpnProtocols (out int error)
 		{
 			IntPtr protocols = IntPtr.Zero; // must be null, CFArray allocated by SSLCopyALPNProtocols
@@ -668,11 +669,12 @@ namespace XamCore.Security {
 			return result;
 		}
 
-		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
+		[iOS (11,0)][TV (11,0)][Watch (4,0)] //[Mac (10,13)] Apple forgot to export the SSLCopyALPNProtocols.
 		public string[] GetAlpnProtocols ()
 		{
 			int error;
 			return GetAlpnProtocols (out error);
 		}
+#endif
 	}
 }

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -280,6 +280,7 @@ namespace Introspection
 			"Lopass",
 			"Lowlevel",
 			"Lun",
+			"Luma",
 			"Mapbuffer",
 			"Matchingcoalesce",
 			"Megaampere",

--- a/tests/monotouch-test/Security/SecureTransportTest.cs
+++ b/tests/monotouch-test/Security/SecureTransportTest.cs
@@ -99,15 +99,35 @@ namespace MonoTouchFixtures.Security {
 					using (var data = new NSData ())
 						Assert.That (ssl.SetOcspResponse (data), Is.EqualTo (0), "SetOcspResponse/empty");
 
+// Test disabled for macOS due to Apple is not shipping SSLSetALPNProtocols and SSLCopyALPNProtocols on macOS
+#if !MONOMAC
 					int error;
 					var alpn = ssl.GetAlpnProtocols (out error);
 					Assert.That (alpn, Is.Empty, "alpn");
 					Assert.That (error, Is.EqualTo ((int) SecStatusCode.Param), "GetAlpnProtocols");
 					var protocols = new [] { "HTTP/1.1", "SPDY/1" };
 					Assert.That (ssl.SetAlpnProtocols (protocols), Is.EqualTo (0), "SetAlpnProtocols");
+#endif
 				}
 			}
 		}
+
+#if MONOMAC
+		[Test]
+		public void ReenableSSLGetSetAlpnProtocols ()
+		{
+			TestRuntime.AssertXcodeVersion (9,0);
+
+			// It seems that apple forgot to ship SSLSetALPNProtocols and SSLCopyALPNProtocols in macOS
+			// there are already radars filled about this https://bugs.swift.org/browse/SR-6131
+			// So this test will fail once Apple fixes this issue. when this happens we need to do two things, reenable
+			// the API and reenable the [Get|Set]AlpnProtocols test above, the one inside 'StreamDefaults' for the mac.
+
+			IntPtr seclib = Dlfcn.dlopen (Constants.SecurityLibrary, 0);
+			Assert.IsTrue (Dlfcn.GetIndirect (seclib, "SSLSetALPNProtocols") == IntPtr.Zero, "Reenable 'SetAlpnProtocols' inside src/Security/SslContext.cs and remove this test.");
+			Assert.IsTrue (Dlfcn.GetIndirect (seclib, "SSLCopyALPNProtocols") == IntPtr.Zero, "Reenable 'GetAlpnProtocols' inside src/Security/SslContext.cs and remove this test.");
+		}
+#endif
 
 		[Test]
 		public void DatagramDefaults ()


### PR DESCRIPTION
It seems that apple forgot to ship SSLSetALPNProtocols and SSLCopyALPNProtocols in macOS
there are already radars filled about this https://bugs.swift.org/browse/SR-6131
So this test will fail once Apple fixes this issue. when this happens we need to do two things, reenable
the API and reenable the [Get|Set]AlpnProtocols tests, the one insides 'StreamDefaults' for the mac.