### PR TITLE
[generator] CoreImage filters are never direct bindings.

### DIFF
--- a/src/generator-filters.cs
+++ b/src/generator-filters.cs
@@ -78,16 +78,9 @@ public partial class Generator {
 		print ("public {0} (NSCoder coder) : base (NSObjectFlag.Empty)", type_name);
 		print ("{");
 		indent++;
+		print ("IsDirectBinding = false;");
 		print ("IntPtr h;");
-		print ("if (IsDirectBinding) {");
-		indent++;
-		print ("h = global::{0}.Messaging.IntPtr_objc_msgSend_IntPtr (this.Handle, Selector.GetHandle (\"initWithCoder:\"), coder.Handle);", ns.CoreObjCRuntime);
-		indent--;
-		print ("} else {");
-		indent++;
 		print ("h = global::{0}.Messaging.IntPtr_objc_msgSendSuper_IntPtr (this.SuperHandle, Selector.GetHandle (\"initWithCoder:\"), coder.Handle);", ns.CoreObjCRuntime);
-		indent--;
-		print ("}");
 		print ("InitializeHandle (h, \"initWithCoder:\");");
 		indent--;
 		print ("}");
@@ -247,6 +240,7 @@ public partial class Generator {
 	void PrintEmptyBody ()
 	{
 		print ("{");
+		print ("\tIsDirectBinding = false;");
 		print ("}");
 		print ("");
 	}

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -141,9 +141,6 @@ namespace Introspection {
 		protected virtual void CheckIsDirectBinding (NSObject obj)
 		{
 			var attrib = obj.GetType ().GetCustomAttribute<RegisterAttribute> (false);
-			// only check types that we register - that way we avoid the 118 MonoTouch.CoreImagge.CI* "special" types
-			if (attrib == null)
-				return;
 			var is_wrapper = attrib != null && attrib.IsWrapper;
 			var is_direct_binding = GetIsDirectBinding (obj);
 			if (is_direct_binding != is_wrapper)


### PR DESCRIPTION
CoreImage filter types are our own creation, and as such will never be direct bindings.

This means we must set the IsDirectBinding value to false manually, and we can
also remove the IsDirectBinding condition in the constructor, since it's
redundant.

Additionally we can remove a condition in the introspection tests that
excluded the CoreImage filters from tests.

Generated diff: https://gist.github.com/rolfbjarne/88968a034b0cbfefb78651e831da6b5c