### PR TITLE
[tests] Enable xammac-tests on wrench.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -300,6 +300,11 @@ wrench-mac-introspection:
 	$(Q) $(MAKE) clean-mac-introspection
 	git clean -xfdq
 
+wrench-mac-xammac_tests:
+	@# This entire target can be removed when merging to master.
+	$(Q) $(MAKE) run-mac-xammac_tests
+	$(Q) $(MAKE) clean-mac-xammac_tests
+	git clean -xfdq
 else
 wrench-mac-%:
 	@echo "Mac tests have been disabled [$@]"


### PR DESCRIPTION
Wrench runs `wrench-mac-xammac_tests`, but since there were no such target,
make would execute the `wrench-%` target, which is disabled when iOS is
disabled.

Thus this strange behavior would be seen on wrench for xammac tests when iOS
is disabled:

    /Applications/Xcode92-beta2.app/Contents/Developer/usr/bin/make -C /Users/builder/data/lanes/5665/d2b1b757/source/xamarin-macios/tests wrench-mac-xammac_tests
    git clean -xfdq
    iOS tests have been disabled [wrench-mac-xammac_tests]

By creating the `wrench-mac-xammac_tests` target, we'll end up doing the right
thing instead.