### PR TITLE
[msbuild] Codesign iOS Simulator builds using the '-' key

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
@@ -29,6 +29,7 @@ namespace Xamarin.MacDev.Tasks
 		[Required]
 		public string BundleIdentifier { get; set; }
 
+		[Output]
 		[Required]
 		public string CompiledEntitlements { get; set; }
 
@@ -315,9 +316,6 @@ namespace Xamarin.MacDev.Tasks
 					Log.LogError ("Could not locate the provisioning profile with a Name or UUID of {0}.", ProvisioningProfile);
 					return false;
 				}
-			} else if (Platform == MobileProvisionPlatform.iOS) {
-				Log.LogError ("Provisioning Profiles are REQUIRED for iOS.");
-				return false;
 			} else {
 				profile = null;
 			}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
@@ -353,7 +353,7 @@ namespace Xamarin.MacDev.Tasks
 				return !Log.HasLoggedErrors;
 			}
 
-			if (!RequireProvisioningProfile && string.IsNullOrEmpty (ProvisioningProfile)) {
+			if (!RequireProvisioningProfile) {
 				if (SdkIsSimulator && AppleSdkSettings.XcodeVersion.Major >= 8) {
 					// Note: Starting with Xcode 8.0, we need to codesign iOS Simulator builds in order for them to run.
 					// The "-" key is a special value allowed by the codesign utility that allows us to get away with

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -70,7 +70,6 @@ namespace Xamarin.iOS.Tasks
 
 		public string ArchiveSymbols { get; set; }
 
-		[Required]
 		public string CompiledEntitlements { get; set; }
 
 		[Required]
@@ -81,8 +80,6 @@ namespace Xamarin.iOS.Tasks
 
 		[Required]
 		public bool EnableGenericValueTypeSharing { get; set; }
-
-		public string Entitlements { get; set; }
 
 		public string License { get; set; }
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -654,6 +654,11 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<Output TaskParameter="DetectedDistributionType" PropertyName="_DistributionType" />
 			<Output TaskParameter="DetectedProvisioningProfile" PropertyName="_ProvisioningProfile" />
 		</DetectSigningIdentity>
+
+		<PropertyGroup>
+			<!-- Always use '-' as the signing key for iOS Simulator builds -->
+			<_CodeSigningKey Condition="'$(_SdkIsSimulator)' == 'true'">-</_CodeSigningKey>
+		</PropertyGroup>
 	</Target>
 	
 	<Target Name="_GenerateBundleName" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_ComputeTargetArchitectures">
@@ -781,10 +786,9 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			AppBundleDir="$(AppBundleDir)"
 			AppManifest="$(_AppBundlePath)Info.plist"
 			Architectures="$(TargetArchitectures)"
-			Entitlements="$(CodesignEntitlements)"
 			ExecutableName="$(_ExecutableName)"
 			NativeExecutable="$(_NativeExecutable)"
-			CompiledEntitlements="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent"
+			CompiledEntitlements="$(_CompiledEntitlements)"
 			Debug="$(MtouchDebug)"
 			EnableGenericValueTypeSharing="$(MtouchEnableGenericValueTypeSharing)"
 			ExtraArgs="$(MtouchExtraArgs)"
@@ -1422,6 +1426,15 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			SdkVersion="$(MtouchSdkVersion)"
 			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			>
+
+			<!-- We output the same task parameter to 2 different properties because they will be used differently -->
+
+			<!-- $(_CompiledEntitlements) will be passed to the MTouch task (only really needed for iOS Simulator builds,
+				 but does not cause harm when set for device builds). -->
+			<Output TaskParameter="CompiledEntitlements" PropertyName="_CompiledEntitlements" />
+
+			<!-- $(_CompiledCodesignEntitlements) will be used only with Codesign tasks when building for device. MUST NOT BE SET for iOS Simulator builds. -->
+			<Output TaskParameter="CompiledEntitlements" PropertyName="_CompiledCodesignEntitlements" Condition="'$(_SdkIsSimulator)' == 'false'" />
 		</CompileEntitlements>
 	</Target>
 
@@ -1735,7 +1748,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</ReadItemsFromFile>
 	</Target>
 
-	<Target Name="_CodesignAppExtensions" Condition="'$(_RequireCodeSigning)' == 'true' And '@(_AppExtensionCodesignProperties)' != ''"
+	<Target Name="_CodesignAppExtensions" Condition="('$(_CanOutputAppBundle)' == 'true' And '$(_CodeSigningKey)' != '') And '@(_AppExtensionCodesignProperties)' != ''"
 		DependsOnTargets="_DetectSigningIdentity;_ReadAppExtensionCodesignProperties"
 		Inputs="$(_AppBundlePath)PlugIns\%(_AppExtensionCodesignProperties.Identity)\%(_AppExtensionCodesignProperties.NativeExecutable);%(_AppExtensionCodesignProperties.CodesignAppExtensionInputs)"
 		Outputs="$(_AppBundlePath)PlugIns\%(_AppExtensionCodesignProperties.Identity)\_CodeSignature\CodeResources">
@@ -1773,14 +1786,15 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<Touch
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true' And '$(_RequireCodeSigning)' == 'true' And Exists ('$(AppBundleDir)\..\%(_AppExtensionCodesignProperties.Identity).dSYM\Contents\Info.plist')"
+			Condition="'$(IsMacEnabled)' == 'true' And ('$(_CanOutputAppBundle)' == 'true' And '$(_CodeSigningKey)' != '') And Exists ('$(AppBundleDir)\..\%(_AppExtensionCodesignProperties.Identity).dSYM\Contents\Info.plist')"
 			Files="$(AppBundleDir)\..\%(_AppExtensionCodesignProperties.Identity).dSYM\Contents\Info.plist"
 		/>
 	</Target>
 
-	<Target Name="_PrepareCodesignAppExtension" Condition="'$(_RequireCodeSigning)' == 'true' And '$(IsAppExtension)' == 'true' And '@(_ResolvedAppBundleExtensions)' == ''">
+	<Target Name="_PrepareCodesignAppExtension" Condition="('$(_CanOutputAppBundle)' == 'true' And '$(_CodeSigningKey)' != '') And '$(IsAppExtension)' == 'true' And '@(_ResolvedAppBundleExtensions)' == ''">
 		<!-- For App Extensions, we delay running codesign until it has been copied into the main app bundle... -->
 		<PropertyGroup>
+			<_CompiledEntitlementsFullPath></_CompiledEntitlementsFullPath>
 			<_ResourceRulesFullPath></_ResourceRulesFullPath>
 		</PropertyGroup>
 
@@ -1788,8 +1802,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<Output TaskParameter="FullPath" PropertyName="_AppBundleFullPath" />
 		</GetFullPath>
 
-		<GetFullPath SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" RelativePath="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent">
-			<Output TaskParameter="FullPath" PropertyName="_EntitlementsFullPath" />
+		<GetFullPath SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '$(_CompiledCodesignEntitlements)' != ''" RelativePath="$(_CompiledCodesignEntitlements)">
+			<Output TaskParameter="FullPath" PropertyName="_CompiledEntitlementsFullPath" />
 		</GetFullPath>
 
 		<GetFullPath SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '$(_PreparedResourceRules)' != ''" RelativePath="$(_PreparedResourceRules)">
@@ -1819,7 +1833,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 				<NativeExecutable>$(_NativeExecutableFileName)</NativeExecutable>
 				<CodesignAllocate>$(_CodesignAllocate)</CodesignAllocate>
 				<DisableTimestamp>$(_CodesignDisableTimestamp)</DisableTimestamp>
-				<Entitlements>$(_EntitlementsFullPath)</Entitlements>
+				<Entitlements>$(_CompiledEntitlementsFullPath)</Entitlements>
 				<ResourceRules>$(_ResourceRulesFullPath)</ResourceRules>
 				<Keychain>$(CodesignKeychain)</Keychain>
 				<SigningKey>$(_CodeSigningKey)</SigningKey>
@@ -1837,7 +1851,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		/>
 	</Target>
 
-	<Target Name="_CalculateCodesignAppBundleInputs" Condition="'$(_RequireCodeSigning)' == 'true' And ('$(IsAppExtension)' == 'false' Or '@(_ResolvedAppExtensionReferences)' != '')">
+	<Target Name="_CalculateCodesignAppBundleInputs" Condition="('$(_CanOutputAppBundle)' == 'true' And '$(_CodeSigningKey)' != '') And ('$(IsAppExtension)' == 'false' Or '@(_ResolvedAppExtensionReferences)' != '')">
 		<ItemGroup>
 			<_CodesignAppBundleInputs Include="$(_AppBundlePath)**\*.*" Exclude="$(_AppBundlePath)_CodeSignature\CodeResources" />
 		</ItemGroup>
@@ -1859,7 +1873,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			CodesignAllocate="$(_CodesignAllocate)"
 			DisableTimestamp="$(_CodesignDisableTimestamp)"
 			Keychain="$(CodesignKeychain)"
-			Entitlements="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent"
+			Entitlements="$(_CompiledCodesignEntitlements)"
 			ResourceRules="$(_PreparedResourceRules)"
 			Resources="$(AppBundleDir)"
 			SigningKey="$(_CodeSigningKey)"
@@ -2048,7 +2062,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			CodesignAllocate="$(_CodesignAllocate)"
 			DisableTimestamp="$(_CodesignDisableTimestamp)"
 			Keychain="$(CodesignKeychain)"
-			Entitlements="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent"
+			Entitlements="$(_CompiledCodesignEntitlements)"
 			Resources="@(_AssetPack)"
 			SigningKey="$(_CodeSigningKey)"
 			ExtraArgs="$(CodesignExtraArgs)"
@@ -2075,7 +2089,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			CodesignAllocate="$(_CodesignAllocate)"
 			DisableTimestamp="$(_CodesignDisableTimestamp)"
 			Keychain="$(CodesignKeychain)"
-			Entitlements="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent"
+			Entitlements="$(_CompiledCodesignEntitlements)"
 			ResourceRules="$(_PreparedResourceRules)"
 			Resources="$(_IpaAppBundleDir)"
 			SigningKey="$(_CodeSigningKey)"

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/CodesignAppBundle.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/CodesignAppBundle.cs
@@ -1,7 +1,9 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Diagnostics;
+using System.Collections.Generic;
 
 using NUnit.Framework;
 
@@ -9,13 +11,15 @@ using Xamarin.MacDev;
 
 namespace Xamarin.iOS.Tasks
 {
-	[TestFixture ("Debug")]
-	[TestFixture ("Release")]
+	[TestFixture ("iPhone", "Debug")]
+	[TestFixture ("iPhone", "Release")]
+	[TestFixture ("iPhoneSimulator", "Debug")]
+	[TestFixture ("iPhoneSimulator", "Release")]
 	public class CodesignAppBundle : ProjectTest
 	{
 		readonly string config;
 
-		public CodesignAppBundle (string configuration) : base ("iPhone")
+		public CodesignAppBundle (string platform, string configuration) : base (platform)
 		{
 			config = configuration;
 		}
@@ -62,8 +66,12 @@ namespace Xamarin.iOS.Tasks
 			var appexDsymDir = Path.GetFullPath (Path.Combine (AppBundlePath, "..", "MyActionExtension.appex.dSYM"));
 
 			var timestamps = Directory.EnumerateFiles (AppBundlePath, "*.*", SearchOption.TopDirectoryOnly).ToDictionary (file => file, file => GetLastModified (file));
-			var dsymTimestamps = Directory.EnumerateFiles (dsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
-			var appexDsymTimestamps = Directory.EnumerateFiles (appexDsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
+			Dictionary<string, DateTime> dsymTimestamps = null, appexDsymTimestamps = null;
+
+			if (Platform != "iPhoneSimulator") {
+				dsymTimestamps = Directory.EnumerateFiles (dsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
+				appexDsymTimestamps = Directory.EnumerateFiles (appexDsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
+			}
 
 			Thread.Sleep (1000);
 
@@ -73,8 +81,6 @@ namespace Xamarin.iOS.Tasks
 			AssertProperlyCodesigned ();
 
 			var newTimestamps = Directory.EnumerateFiles (AppBundlePath, "*.*", SearchOption.TopDirectoryOnly).ToDictionary (file => file, file => GetLastModified (file));
-			var newDsymTimestamps = Directory.EnumerateFiles (dsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
-			var newAppexDsymTimestamps = Directory.EnumerateFiles (appexDsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
 
 			foreach (var file in timestamps.Keys) {
 				// The executable files will all be newer because they get touched during each Build, all other files should not change
@@ -84,22 +90,27 @@ namespace Xamarin.iOS.Tasks
 				Assert.AreEqual (timestamps[file], newTimestamps[file], "App Bundle timestamp changed: " + file);
 			}
 
-			foreach (var file in dsymTimestamps.Keys) {
-				// The Info.plist should be newer because it gets touched
-				if (Path.GetFileName (file) == "Info.plist") {
-					Assert.IsTrue (dsymTimestamps[file] < newDsymTimestamps[file], "App Bundle dSYMs Info.plist not touched: " + file);
-				} else {
-					Assert.AreEqual (dsymTimestamps[file], newDsymTimestamps[file], "App Bundle dSYMs changed: " + file);
-				}
-			}
+			if (Platform != "iPhoneSimulator") {
+				var newDsymTimestamps = Directory.EnumerateFiles (dsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
+				var newAppexDsymTimestamps = Directory.EnumerateFiles (appexDsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
 
-			// The appex dSYMs will all be newer because they currently get regenerated after each Build due to the fact that the entire
-			// *.appex gets cloned into the app bundle each time.
-			//
-			// Note: we could fix this by not using `ditto` and instead implementing this ourselves to only overwrite files if they've changed
-			// and then setting some [Output] params that specify whether or not we need to re-codesign and/or strip debug symbols.
-			foreach (var file in appexDsymTimestamps.Keys)
-				Assert.IsTrue (appexDsymTimestamps[file] < newAppexDsymTimestamps[file], "App Extension dSYMs should be newer: " + file);
+				foreach (var file in dsymTimestamps.Keys) {
+					// The Info.plist should be newer because it gets touched
+					if (Path.GetFileName (file) == "Info.plist") {
+						Assert.IsTrue (dsymTimestamps[file] < newDsymTimestamps[file], "App Bundle dSYMs Info.plist not touched: " + file);
+					} else {
+						Assert.AreEqual (dsymTimestamps[file], newDsymTimestamps[file], "App Bundle dSYMs changed: " + file);
+					}
+				}
+
+				// The appex dSYMs will all be newer because they currently get regenerated after each Build due to the fact that the entire
+				// *.appex gets cloned into the app bundle each time.
+				//
+				// Note: we could fix this by not using `ditto` and instead implementing this ourselves to only overwrite files if they've changed
+				// and then setting some [Output] params that specify whether or not we need to re-codesign and/or strip debug symbols.
+				foreach (var file in appexDsymTimestamps.Keys)
+					Assert.IsTrue (appexDsymTimestamps[file] < newAppexDsymTimestamps[file], "App Extension dSYMs should be newer: " + file);
+			}
 		}
 
 		[Test]


### PR DESCRIPTION
When codesigning iOS Simulator builds, it is important to note
that the codesign command itself cannot include the entitlements,
but the mtouch command *MUST* embed the entitlements using
-Xlinker.