### PR TITLE
[generator] Properly set the IsDirectBinding value.

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -53,6 +53,16 @@ using System.ComponentModel;
 using XamCore.ObjCRuntime;
 using XamCore.Foundation;
 
+public static class GeneratorExtensions
+{
+	public static StreamWriter Write (this StreamWriter sw, char c, int count)
+	{
+		for (int i = 0; i < count; i++)
+			sw.Write (c);
+		return sw;
+	}
+}
+
 public static class ReflectionExtensions {
 	public static BaseTypeAttribute GetBaseTypeAttribute (Type type)
 	{
@@ -910,7 +920,8 @@ public partial class Generator : IMemberGatherer {
 	//
 	// Properties and definitions to support binding third-party Objective-C libraries
 	//
-	string init_binding_type;
+	string is_direct_binding_value; // An expression that calculates the IsDirectBinding value. Might not be a constant expression. This will be added to every constructor for a type.
+	bool? is_direct_binding; // If a constant value for IsDirectBinding is known, it's stored here. Will be null if no constant value is known.
 
 	// Whether to use ZeroCopy for strings, defaults to false
 	public bool ZeroCopyStrings;
@@ -2199,8 +2210,6 @@ public partial class Generator : IMemberGatherer {
 			marshal_types.Add (TypeManager.AURenderEventEnumerator);
 		}
 
-		init_binding_type = String.Format ("IsDirectBinding = GetType ().Assembly == global::{0}.this_assembly;", ns.Messaging);
-
 		m = GetOutputStream ("ObjCRuntime", "Messaging");
 		Header (m);
 		print (m, "namespace {0} {{", ns.ObjCRuntime);
@@ -3029,6 +3038,40 @@ public partial class Generator : IMemberGatherer {
 		for (int i=0; i < tabs; i++)
 			sw.Write ('\t');
 		sw.WriteLine ("[CompilerGenerated]");
+	}
+
+	static void WriteIsDirectBindingCondition (StreamWriter sw, ref int tabs, bool? is_direct_binding, string is_direct_binding_value, Func<string> trueCode, Func<string> falseCode)
+	{
+		if (is_direct_binding_value != null)
+			sw.Write ('\t', tabs).WriteLine ("IsDirectBinding = {0};", is_direct_binding_value);
+		
+		// If we don't know the IsDirectBinding value, we need the condition
+		if (!is_direct_binding.HasValue) {
+			sw.Write ('\t', tabs).WriteLine ("if (IsDirectBinding) {");
+			tabs++;
+		}
+
+		// We need the true part if we don't know, or if we know it's true
+		if (is_direct_binding != false) {
+			var code = trueCode ();
+			if (!string.IsNullOrEmpty (code))
+				sw.Write ('\t', tabs).WriteLine (code);
+		}
+		
+		if (!is_direct_binding.HasValue)
+			sw.Write ('\t', tabs - 1).WriteLine ("} else {");
+
+		// We need the false part if we don't know, or if we know it's false
+		if (is_direct_binding != true) {
+			var code = falseCode ();
+			if (!string.IsNullOrEmpty (code))
+				sw.Write ('\t', tabs).WriteLine (code);
+		}
+		
+		if (!is_direct_binding.HasValue) {
+			tabs--;
+			sw.Write ('\t', tabs).WriteLine ("}");
+		}
 	}
 	
 	public void print_generated_code ()
@@ -4196,26 +4239,18 @@ public partial class Generator : IMemberGatherer {
 					GenerateInvoke (false, mi, minfo, sel, argsArray, needs_temp, category_type);
 				}
 			} else {
-				if (BindThirdPartyLibrary && mi.Name == "Constructor"){
-					print (init_binding_type);
-				}
-				
 				var may_throw = ShouldMarshalNativeExceptions (mi);
 				var null_handle = may_throw && mi.Name == "Constructor";
 				if (null_handle) {
 					print ("try {");
 					indent++;
 				}
-				
-				print ("if (IsDirectBinding) {{", type.Name);
-				indent++;
-				GenerateInvoke (false, mi, minfo, sel, argsArray, needs_temp, category_type);
-				indent--;
-				print ("} else {");
-				indent++;
-				GenerateInvoke (true, mi, minfo, sel, argsArray, needs_temp, category_type);
-				indent--;
-				print ("}");
+
+				WriteIsDirectBindingCondition (sw, ref indent, is_direct_binding,
+							       mi.Name == "Constructor" ? is_direct_binding_value : null, // We only need to print the is_direct_binding value in constructors
+				                               () => { GenerateInvoke (false, mi, minfo, sel, argsArray, needs_temp, category_type); return null; },
+				                               () => { GenerateInvoke (true, mi, minfo, sel, argsArray, needs_temp, category_type); return null; }
+							      );
 				
 				if (null_handle) {
 					indent--;
@@ -5762,6 +5797,11 @@ public partial class Generator : IMemberGatherer {
 
 			bool core_image_filter = false;
 			string class_mod = null;
+
+			is_direct_binding_value = null;
+			is_direct_binding = null;
+			if (BindThirdPartyLibrary)
+				is_direct_binding_value = string.Format ("GetType ().Assembly == global::{0}.this_assembly", ns.Messaging);
 			if (is_static_class || is_category_class || is_partial) {
 				base_type = TypeManager.System_Object;
 				if (!is_partial)
@@ -5770,14 +5810,24 @@ public partial class Generator : IMemberGatherer {
 				if (is_protocol)
 					print ("[Protocol]");
 				core_image_filter = AttributeManager.HasAttribute<CoreImageFilterAttribute> (type);
-				if (!type.IsEnum && !core_image_filter)
-					print ("[Register(\"{0}\", {1})]", objc_type_name, AttributeManager.HasAttribute<SyntheticAttribute> (type) || is_model ? "false" : "true");
+				if (!type.IsEnum && !core_image_filter) {
+					if (is_model || AttributeManager.HasAttribute<SyntheticAttribute> (type)) {
+						is_direct_binding = false;
+						is_direct_binding_value = "false";
+					}
+					print ("[Register(\"{0}\", {1})]", objc_type_name, is_direct_binding == false ? "false" : "true");
+				}
 				if (is_abstract || need_abstract.ContainsKey (type))
 					class_mod = "abstract ";
 				else if (is_sealed)
 					class_mod = "sealed ";
 			} 
 			
+			if (is_sealed && is_direct_binding == null) {
+				is_direct_binding = true;
+				is_direct_binding_value = "true";
+			}
+				
 			if (is_model){
 				if (is_category_class)
 					ErrorHelper.Show (new BindingException (1022, true, "Category classes can not use the [Model] attribute"));
@@ -5942,6 +5992,8 @@ public partial class Generator : IMemberGatherer {
 							sw.WriteLine ("\t\t[Export (\"init\")]");
 							sw.WriteLine ("\t\t{0} {1} () : base (NSObjectFlag.Empty)", v, TypeName);
 							sw.WriteLine ("\t\t{");
+							if (is_direct_binding_value != null)
+								sw.WriteLine ("\t\t\tIsDirectBinding = {0};", is_direct_binding_value);
 							if (debug)
 								sw.WriteLine ("\t\t\tConsole.WriteLine (\"{0}.ctor ()\");", TypeName);
 							sw.WriteLine ("\t\t\tInitializeHandle (global::{1}.IntPtr_objc_msgSend (this.Handle, global::{2}.{0}), \"init\");", initSelector, ns.Messaging, ns.CoreObjCRuntime);
@@ -5955,15 +6007,11 @@ public partial class Generator : IMemberGatherer {
 							sw.WriteLine ("\t\t[Export (\"init\")]");
 							sw.WriteLine ("\t\t{0} {1} () : base (NSObjectFlag.Empty)", v, TypeName);
 							sw.WriteLine ("\t\t{");
-							if (BindThirdPartyLibrary)
-								sw.WriteLine ("\t\t\t{0}", init_binding_type);
-							if (debug)
-								sw.WriteLine ("\t\t\tConsole.WriteLine (\"{0}.ctor ()\");", TypeName);
-							sw.WriteLine ("\t\t\tif (IsDirectBinding) {");
-							sw.WriteLine ("\t\t\t\tInitializeHandle (global::{1}.IntPtr_objc_msgSend (this.Handle, global::{2}.{0}), \"init\");", initSelector, ns.Messaging, ns.CoreObjCRuntime);
-							sw.WriteLine ("\t\t\t} else {");
-							sw.WriteLine ("\t\t\t\tInitializeHandle (global::{1}.IntPtr_objc_msgSendSuper (this.SuperHandle, global::{2}.{0}), \"init\");", initSelector, ns.Messaging, ns.CoreObjCRuntime);
-							sw.WriteLine ("\t\t\t}");
+							var indentation = 3;
+							WriteIsDirectBindingCondition (sw, ref indentation, is_direct_binding, is_direct_binding_value,
+							                               () => string.Format ("InitializeHandle (global::{1}.IntPtr_objc_msgSend (this.Handle, global::{2}.{0}), \"init\");", initSelector, ns.Messaging, ns.CoreObjCRuntime),
+							                               () => string.Format ("InitializeHandle (global::{1}.IntPtr_objc_msgSendSuper (this.SuperHandle, global::{2}.{0}), \"init\");", initSelector, ns.Messaging, ns.CoreObjCRuntime));
+
 							WriteMarkDirtyIfDerived (sw, type);
 							sw.WriteLine ("\t\t}");
 							sw.WriteLine ();
@@ -5982,16 +6030,13 @@ public partial class Generator : IMemberGatherer {
 							sw.WriteLine ("\t\t{0} {1} (NSCoder coder) : base (NSObjectFlag.Empty)", UnifiedAPI ? v : "public", TypeName);
 							sw.WriteLine ("\t\t{");
 							if (nscoding) {
-								if (BindThirdPartyLibrary)
-									sw.WriteLine ("\t\t\t{0}", init_binding_type);
 								if (debug)
 									sw.WriteLine ("\t\t\tConsole.WriteLine (\"{0}.ctor (NSCoder)\");", TypeName);
 								sw.WriteLine ();
-								sw.WriteLine ("\t\t\tif (IsDirectBinding) {");
-								sw.WriteLine ("\t\t\t\tInitializeHandle (global::{1}.IntPtr_objc_msgSend_IntPtr (this.Handle, {0}, coder.Handle), \"initWithCoder:\");", initWithCoderSelector, ns.Messaging);
-								sw.WriteLine ("\t\t\t} else {");
-								sw.WriteLine ("\t\t\t\tInitializeHandle (global::{1}.IntPtr_objc_msgSendSuper_IntPtr (this.SuperHandle, {0}, coder.Handle), \"initWithCoder:\");", initWithCoderSelector, ns.Messaging);
-								sw.WriteLine ("\t\t\t}");
+								var indentation = 3;
+								WriteIsDirectBindingCondition (sw, ref indentation, is_direct_binding, is_direct_binding_value,
+								                               () => string.Format ("InitializeHandle (global::{1}.IntPtr_objc_msgSend_IntPtr (this.Handle, {0}, coder.Handle), \"initWithCoder:\");", initWithCoderSelector, ns.Messaging),
+								                               () => string.Format ("InitializeHandle (global::{1}.IntPtr_objc_msgSendSuper_IntPtr (this.SuperHandle, {0}, coder.Handle), \"initWithCoder:\");", initWithCoderSelector, ns.Messaging));
 								WriteMarkDirtyIfDerived (sw, type);
 							} else {
 								sw.WriteLine ("\t\t\tthrow new InvalidOperationException (\"Type does not conform to NSCoding\");");
@@ -6005,8 +6050,8 @@ public partial class Generator : IMemberGatherer {
 						sw.WriteLine ("\t\t[EditorBrowsable (EditorBrowsableState.Advanced)]");
 						sw.WriteLine ("\t\t{0} {1} (NSObjectFlag t) : base (t)", UnifiedAPI ? "protected" : "public", TypeName);
 						sw.WriteLine ("\t\t{");
-						if (BindThirdPartyLibrary)
-							sw.WriteLine ("\t\t\t{0}", init_binding_type);
+						if (is_direct_binding_value != null)
+							sw.WriteLine ("\t\t\tIsDirectBinding = {0};", is_direct_binding_value);
 						WriteMarkDirtyIfDerived (sw, type);
 						sw.WriteLine ("\t\t}");
 						sw.WriteLine ();
@@ -6015,8 +6060,8 @@ public partial class Generator : IMemberGatherer {
 					sw.WriteLine ("\t\t[EditorBrowsable (EditorBrowsableState.Advanced)]");
 					sw.WriteLine ("\t\t{0} {1} (IntPtr handle) : base (handle)", UnifiedAPI ? "protected internal" : "public", TypeName);
 					sw.WriteLine ("\t\t{");
-					if (BindThirdPartyLibrary)
-						sw.WriteLine ("\t\t\t{0}", init_binding_type);
+					if (is_direct_binding_value != null)
+						sw.WriteLine ("\t\t\tIsDirectBinding = {0};", is_direct_binding_value);
 					WriteMarkDirtyIfDerived (sw, type);
 					sw.WriteLine ("\t\t}");
 					sw.WriteLine ();

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -5766,7 +5766,8 @@ public partial class Generator : IMemberGatherer {
 			bool is_static_class = AttributeManager.HasAttribute<StaticAttribute> (type) || is_category_class;
 			bool is_partial = AttributeManager.HasAttribute<PartialAttribute> (type);
 			bool is_model = AttributeManager.HasAttribute<ModelAttribute> (type);
-			bool is_protocol = AttributeManager.HasAttribute<ProtocolAttribute> (type);
+			var protocol = AttributeManager.GetCustomAttribute<ProtocolAttribute> (type);
+			bool is_protocol = protocol != null;
 			bool is_abstract = AttributeManager.HasAttribute<AbstractAttribute> (type);
 			bool is_sealed = AttributeManager.HasAttribute<SealedAttribute> (type);
 			string class_visibility = type.IsInternal () ? "internal" : "public";
@@ -5783,7 +5784,6 @@ public partial class Generator : IMemberGatherer {
 				if (is_model && base_type == TypeManager.System_Object)
 					ErrorHelper.Show (new BindingException (1060, "The {0} protocol is decorated with [Model], but not [BaseType]. Please verify that [Model] is relevant for this protocol; if so, add [BaseType] as well, otherwise remove [Model].", type.FullName));
 
-				var protocol = AttributeManager.GetCustomAttribute<ProtocolAttribute> (type);
 				GenerateProtocolTypes (type, class_visibility, TypeName, protocol.Name ?? objc_type_name, protocol);
 			}
 
@@ -5808,7 +5808,7 @@ public partial class Generator : IMemberGatherer {
 					class_mod = "static ";
 			} else {
 				if (is_protocol)
-					print ("[Protocol]");
+					print ("[Protocol({0})]", !string.IsNullOrEmpty (protocol.Name) ? $"Name = \"{protocol.Name}\"" : string.Empty);
 				core_image_filter = AttributeManager.HasAttribute<CoreImageFilterAttribute> (type);
 				if (!type.IsEnum && !core_image_filter) {
 					if (is_model || AttributeManager.HasAttribute<SyntheticAttribute> (type)) {

--- a/tests/generator/BGenTool.cs
+++ b/tests/generator/BGenTool.cs
@@ -259,7 +259,7 @@ namespace Xamarin.Tests
 		void LoadAssembly ()
 		{
 			if (assembly == null)
-				assembly = AssemblyDefinition.ReadAssembly (Path.Combine (TmpDirectory, Path.GetFileNameWithoutExtension (ApiDefinitions [0]) + ".dll"));
+				assembly = AssemblyDefinition.ReadAssembly (Path.Combine (TmpDirectory, Path.GetFileNameWithoutExtension (ApiDefinitions [0]).Replace ('-', '_') + ".dll"));
 		}
 
 		void EnsureTempDir ()

--- a/tests/generator/generator-tests.csproj
+++ b/tests/generator/generator-tests.csproj
@@ -64,6 +64,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="tests\is-direct-binding.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="tests\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tests/generator/tests/is-direct-binding.cs
+++ b/tests/generator/tests/is-direct-binding.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Foundation;
+
+namespace NS {
+	[BaseType (typeof (NSObject))]
+	interface C {
+	}
+
+	[Sealed]
+	[BaseType (typeof (NSObject))]
+	interface S {
+	}
+
+	[Model][Protocol]
+	[BaseType (typeof (NSObject))]
+	interface P {
+	}
+}

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -57,6 +57,16 @@ namespace Introspection {
 			if (type.ContainsGenericParameters)
 				return true;
 
+#if !XAMCORE_2_0
+			// skip delegate (and other protocol references)
+			foreach (object ca in type.GetCustomAttributes (false)) {
+				if (ca is ProtocolAttribute)
+					return true;
+				if (ca is ModelAttribute)
+					return true;
+			}
+#endif
+
 			switch (type.Name) {
 			case "JSExport":
 				// This is interesting: Apple defines a private JSExport class - if you try to define your own in an Objective-C project you get this warning at startup:

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -56,16 +56,15 @@ namespace Introspection {
 		{
 			if (type.ContainsGenericParameters)
 				return true;
-			
-			// skip delegate (and other protocol references)
-			foreach (object ca in type.GetCustomAttributes (false)) {
-				if (ca is ProtocolAttribute)
-					return true;
-				if (ca is ModelAttribute)
-					return true;
-			}
 
 			switch (type.Name) {
+			case "JSExport":
+				// This is interesting: Apple defines a private JSExport class - if you try to define your own in an Objective-C project you get this warning at startup:
+				//     objc[334]: Class JSExport is implemented in both /Applications/Xcode91.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore (0x112c1e430) and /Users/rolf/Library/Developer/CoreSimulator/Devices/AC5323CF-225F-44D9-AA18-A37B7C28CA68/data/Containers/Bundle/Application/DEF9EAFC-CB5C-454F-97F5-669BBD00A609/jsexporttest.app/jsexporttest (0x105b49df0). One of the two will be used. Which one is undefined.
+				// Due to how we treat models, we'll always look the Objective-C type up at runtime (even with the static registrar),
+				// see that there's an existing JSExport type, and use that one instead of creating a new type.
+				// This is problematic, because Apple's JSExport is completely unusable, and will crash if you try to do anything.
+				return true;
 #if !XAMCORE_2_0
 			case "AVAssetResourceLoader": // We have DisableDefaultCtor in XAMCORE_2_0 but can't change in compat because of backwards compat
 			case "AVAssetResourceLoadingRequest":

--- a/tests/introspection/Mac/MacApiCtorInitTest.cs
+++ b/tests/introspection/Mac/MacApiCtorInitTest.cs
@@ -38,6 +38,11 @@ namespace Introspection {
 		protected override bool Skip (Type type)
 		{
 			switch (type.FullName) {
+#if !XAMCORE_4_0
+			case "AppKit.NSDraggingInfo":
+			case "MonoMac.AppKit.NSDraggingInfo": // binding mistakes.
+				return true;
+#endif
 			// Random failures on build machine
 			case "QuickLookUI.QLPreviewPanel":
 			case "MonoMac.QuickLookUI.QLPreviewPanel":

--- a/tests/xtro-sharpie/ObjCProtocolCheck.cs
+++ b/tests/xtro-sharpie/ObjCProtocolCheck.cs
@@ -41,6 +41,11 @@ namespace Extrospection {
 			if (!type.HasCustomAttributes)
 				return;
 
+			if (!type.IsInterface) {
+				// Only interfaces map to protocols, but unfortunately we add [Protocol] to generated model classes too, so we need to skip those.
+				return;
+			}
+
 			string pname = null;
 			bool informal = false;
 


### PR DESCRIPTION
Properly set the IsDirectBinding value to false for models and synthetic types.

This also means we can now stop excluding models when testing if the
IsDirectBinding value is correct.

Also set IsDirectBinding value to true for sealed wrapper types, since those
will always be direct bindings since they can't be subclassed.

https://gist.github.com/rolfbjarne/24028bf944db848fed4083c460d0ec71