### PR TITLE
[tests] Fix mac-apitest on High-Sierra

### DIFF
--- a/tests/apitest/src/EveryFrameworkSmokeTest.cs
+++ b/tests/apitest/src/EveryFrameworkSmokeTest.cs
@@ -59,6 +59,7 @@ namespace Xamarin.Mac.Tests
 				case "MapKitLibrary":
 				case "MediaLibraryLibrary":
 				case "MetalKitLibrary":
+				case "MetalPerformanceShadersLibrary":
 				case "ModelIOLibrary":
 				case "MultipeerConnectivityLibrary":
 				case "NetworkExtensionLibrary":


### PR DESCRIPTION
MetalPerformanceShadersLibrary is new in macOS 10.13 and only available
for 64bits.

from https://wrench.internalx.com/Wrench/WebServices/Download.aspx?workfile_id=19778531

    Tests run: 248, Passed: 238, Errors: 0, Failures: 1, Inconclusive: 0
      Not run: 9, Invalid: 0, Ignored: 9, Skipped: 0
    Elapsed time: 00:00:11.3800000

    Errors and Failures:

    1) ExpectedLibrariesAreLoaded (Xamarin.Mac.Tests.EveryFrameworkSmokeTests.ExpectedLibrariesAreLoaded)
       MetalPerformanceShadersLibrary (/System/Library/Frameworks/MetalPerformanceShaders.framework/MetalPerformanceShaders) failed to load but this was not expected
      at Xamarin.Mac.Tests.EveryFrameworkSmokeTests.ExpectedLibrariesAreLoaded () [0x000c5] in /Users/builder/data/lanes/5665/74d2dcad/source/xamarin-macios/tests/apitest/src/EveryFrameworkSmokeTest.cs:99
      at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
      at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00032] in /Library/Frameworks/Xamarin.Mac.framework/Versions/4.1.1.45/src/mono/mcs/class/corlib/System.Reflection/MonoMethod.cs:305