### PR TITLE
[monotouch-test] Update permission checks.

### DIFF
--- a/tests/monotouch-test/AddressBook/AddressBookTest.cs
+++ b/tests/monotouch-test/AddressBook/AddressBookTest.cs
@@ -34,6 +34,7 @@ namespace MonoTouchFixtures.AddressBook {
 		[Test]
 		public void GetAllSources ()
 		{
+			TestRuntime.CheckAddressBookPermission ();
 			ABAddressBook ab = new ABAddressBook ();
 			var sources = ab.GetAllSources ();
 			int value = Runtime.Arch == Arch.DEVICE || TestRuntime.CheckSystemAndSDKVersion (7,0) ? 0 : 1;
@@ -43,6 +44,7 @@ namespace MonoTouchFixtures.AddressBook {
 		[Test]
 		public void GetDefaultSource ()
 		{
+			TestRuntime.CheckAddressBookPermission ();
 			ABAddressBook ab = new ABAddressBook ();
 			Assert.NotNull (ab.GetDefaultSource (), "GetDefaultSource");
 		}
@@ -50,6 +52,7 @@ namespace MonoTouchFixtures.AddressBook {
 		[Test]
 		public void GetSource ()
 		{
+			TestRuntime.CheckAddressBookPermission ();
 			ABAddressBook ab = new ABAddressBook ();
 			Assert.Null (ab.GetSource (-1), "-1");
 			// GetSource(0) is not reliable across device/simulator and iOS versions

--- a/tests/monotouch-test/AddressBook/PersonTest.cs
+++ b/tests/monotouch-test/AddressBook/PersonTest.cs
@@ -32,6 +32,7 @@ namespace MonoTouchFixtures.AddressBook {
 		[Test]
 		public void UpdateAddressLine ()
 		{
+			TestRuntime.CheckAddressBookPermission ();
 			if (!TestRuntime.CheckSystemAndSDKVersion (6,0))
 				Assert.Inconclusive ("System.EntryPointNotFoundException : ABAddressBookCreateWithOptions before 6.0");
 

--- a/tests/monotouch-test/AudioToolbox/AudioQueueTest.cs
+++ b/tests/monotouch-test/AudioToolbox/AudioQueueTest.cs
@@ -85,6 +85,7 @@ namespace MonoTouchFixtures.AudioToolbox {
 		[Test]
 		public void InvalidAudioBasicDescription ()
 		{
+			TestRuntime.RequestMicrophonePermission ();
 			Assert.Throws<AudioQueueException> (() => new InputAudioQueue (new AudioStreamBasicDescription ()), "A");
 		}
 	}


### PR DESCRIPTION
Apparently iOS 11 shows system dialogs for more API, so sprinkle permission
checks in more places.