### PR TITLE
[monotouch-test] Make TrustTest sleep less. Makes monotouch-test run ~3x faster.

### DIFF
--- a/tests/monotouch-test/Security/TrustTest.cs
+++ b/tests/monotouch-test/Security/TrustTest.cs
@@ -61,7 +61,7 @@ namespace MonoTouchFixtures.Security {
 				result = trust.Evaluate ();
 				if (result != SecTrustResult.RecoverableTrustFailure || expect_recoverable)
 					return result;
-				NSRunLoop.Main.RunUntil (NSDate.Now.AddSeconds (i));
+				NSRunLoop.Main.RunUntil (NSDate.Now.AddSeconds (0.1 * i));
 			}
 			// we have done our best (it has not failed, but did not confirm either)
 			// still it can't recover (we and expected it could) most likely due to external factors (e.g. network)


### PR DESCRIPTION
Before: monotouchtest.exe : 37597 ms
After: monotouchtest.exe : 109570 ms

The speedup is only when TrustTest runs into RecoverableTrustFailures, and tries
multiple times before eventually giving up, otherwise the tests run even
faster.

Unfortunately it seems TrustTest always runs RecoverableTrustFailures on my
machine, which makes monotouch-test much slower than it needs to be.

OTOH it doesn't seem like TrustTest has this problem on the bots, all the
TrustTests [PASS], and monotouch-test finishes quickly:

> monotouchtest.exe : 32052 ms