### PR TITLE
[RFC] [linker] Refactor and simplify code optimizations.

### DIFF
--- a/tools/linker/CoreOptimizeGeneratedCode.cs
+++ b/tools/linker/CoreOptimizeGeneratedCode.cs
@@ -5,6 +5,7 @@ using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Linker;
 using Mono.Tuner;
+using Xamarin.Bundler;
 
 namespace Xamarin.Linker {
 
@@ -79,6 +80,180 @@ namespace Xamarin.Linker {
 		{
 			ins.OpCode = OpCodes.Nop;
 			ins.Operand = null;
+		}
+
+		protected static bool ValidateInstruction (MethodDefinition caller, Instruction ins, string operation, Code expected)
+		{
+			if (ins.OpCode.Code != expected) {
+				Driver.Log (1, "Could not {0} in {1} at offset {2}, expected {3} got {4}", operation, caller, ins.Offset, expected, ins);
+				return false;
+			}
+
+			return true;
+		}
+
+		protected static bool ValidateInstruction (MethodDefinition caller, Instruction ins, string operation, params Code [] expected)
+		{
+			foreach (var code in expected) {
+				if (ins.OpCode.Code == code)
+					return true;
+			}
+
+			Driver.Log (1, "Could not {0} in {1} at offset {2}, expected any of [{3}] got {4}", operation, caller, ins.Offset, string.Join (", ", expected), ins);
+			return false;
+		}
+
+		// Calculate the code blocks for both the true and false portion of a branch instruction.
+		// Example:
+		//   IL_0  brfalse IL_4
+		//   IL_1  <true code block>
+		//   IL_2  <true code block>
+		//   IL_3  br IL_6
+		//   IL_4  <false code block>
+		//   IL_5  <false code block>
+		//   IL_6  ret
+		// equivalent to the following
+		//   if (condition) {
+		//     <true code block>
+		//   } else {
+		//     <false code block>
+		//   }
+		// return the ranges
+		//    insTrueFirst: IL_1
+		//    insTrueLast: IL_2
+		//    insFalseFirst: IL_4
+		//    insFalseLast: IL_5
+		// 
+		// The ins*Last instructions will be null if this is a condition without an 'else' block.
+		protected static bool GetBranchRange (MethodDefinition caller, Instruction insBranch, string operation, out Instruction insTrueFirst, out Instruction insTrueLast, out Instruction insFalseFirst, out Instruction insFalseLast)
+		{
+			insTrueFirst = null;
+			insTrueLast = null;
+			insFalseFirst = null;
+			insFalseLast = null;
+
+			if (!ValidateInstruction (caller, insBranch, operation, Code.Brfalse, Code.Brfalse_S, Code.Brtrue, Code.Brtrue_S, Code.Bne_Un, Code.Bne_Un_S))
+				return false;
+
+			var branchTarget = (Instruction) insBranch.Operand;
+			Instruction endTarget;
+
+			switch (branchTarget.Previous.OpCode.Code) {
+			case Code.Br:
+			case Code.Br_S:
+				endTarget = (Instruction) branchTarget.Previous.Operand;
+				endTarget = endTarget.Previous;
+				break;
+			case Code.Ret:
+			case Code.Throw:
+			case Code.Rethrow:
+				endTarget = branchTarget;
+				while (endTarget.OpCode.FlowControl != FlowControl.Return && endTarget.OpCode.FlowControl != FlowControl.Throw)
+					endTarget = endTarget.Next;
+				break;
+			case Code.Leave:
+				if (caller.Body.ExceptionHandlers.Count != 1) {
+					Driver.Log (1, "Could not {0} in {1} at offset {2} because there are not exactly 1 exception handlers (found {3})", operation, caller, insBranch.Offset, caller.Body.ExceptionHandlers.Count);
+					return false;
+				}
+				endTarget = caller.Body.ExceptionHandlers [0].TryEnd.Previous;
+				break;
+			case Code.Call:
+			case Code.Stsfld:
+				// condition without 'else' clause
+				// there are a lot more instructions that can go into this case statement, but keep a whitelist for now.
+				endTarget = null;
+				break;
+			default:
+				Driver.Log (1, "Could not {0} in {1} at offset {2} because the instruction before the branch target was unexpected ({3})", operation, caller, insBranch.Offset, branchTarget.Previous);
+				return false;
+			}
+			switch (insBranch.OpCode.Code) {
+			case Code.Brfalse:
+			case Code.Brfalse_S:
+			case Code.Bne_Un:
+			case Code.Bne_Un_S:
+				insTrueFirst = insBranch.Next;
+				insTrueLast = branchTarget.Previous;
+				insFalseFirst = branchTarget;
+				insFalseLast = endTarget;
+				break;
+			case Code.Brtrue:
+			case Code.Brtrue_S:
+				insFalseFirst = insBranch.Next;
+				insFalseLast = branchTarget.Previous;
+				insTrueFirst = branchTarget;
+				insTrueLast = endTarget;
+				break;
+			default:
+				Driver.Log (1, "Could not {0} in {1} at offset {2} because the branch instruction was unexpected ({3})", operation, caller, insBranch.Offset, insBranch);
+				return false;
+			}
+
+			return true;
+		}
+
+		// This method will clear out (Nop) the non-taken conditional code block, depending on the constant value 'constantValue'.
+		// insBranch must be a conditional branch instruction (brtrue/brfalse/bne).
+		// The caller must clear out the instructions that calculates the value loaded on the stack for the branch instruction.
+		protected static bool InlineBranchCondition (MethodDefinition caller, string operation, Instruction insBranch, bool constantValue)
+		{
+			Instruction insTrueFirst;
+			Instruction insTrueLast;
+			Instruction insFalseFirst;
+			Instruction insFalseLast;
+			if (!GetBranchRange (caller, insBranch, operation, out insTrueFirst, out insTrueLast, out insFalseFirst, out insFalseLast))
+				return false;
+
+			Instruction first = !constantValue ? insTrueFirst : insFalseFirst;
+			Instruction last = !constantValue ? insTrueLast : insFalseLast;
+
+			if (last == null) {
+				// This is a condition without an 'else' block, and the 'else' block is the one we'd remove,
+				// which means we just have to clear the branch instruction itself
+				Nop (insBranch);
+				return true;
+			}
+
+			// Check if there are other branch instructions into the instructions that will be removed
+			var instructions = caller.Body.Instructions;
+			for (int i = 0; i < instructions.Count; i++) {
+				var ins = instructions [i];
+				if (ins == insBranch)
+					continue;
+				if (ins.Offset >= first.Offset && ins.Offset <= last.Offset)
+					continue;
+
+				switch (ins.OpCode.FlowControl) {
+				case FlowControl.Branch:
+				case FlowControl.Cond_Branch:
+					var target = (Instruction) ins.Operand;
+					if (target.Offset >= first.Offset && target.Offset <= last.Offset) {
+						Driver.Log (1, "Could not {0} in {1} because there's a branch instruction elsewhere in the method that branches into the section of code to be removed.\n" + 
+						            "\tFirst instruction to be removed: {2}\n" + 
+						            "\tLast instruction to be removed: {3}\n" +
+						            "\tOffending branch instruction: {4}\n" +
+						            "\tBranching to: {5}", 
+						            operation, caller, first, last, ins, target);
+						return false;
+					}
+					break;
+				default:
+					continue;
+				}
+			}
+
+			// We have the information we need, now we can start clearing instructions
+			Nop (insBranch);
+			Instruction current = first;
+			do {
+				Nop (current);
+				if (current == last)
+					break;
+				current = current.Next;
+			} while (true);
+
+			return true;
 		}
 	}
 }

--- a/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs
@@ -4,6 +4,7 @@ using Mono.Tuner;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Xamarin.Linker;
+using Xamarin.Bundler;
 
 namespace MonoTouch.Tuner {
 	
@@ -68,198 +69,187 @@ namespace MonoTouch.Tuner {
 
 		protected override void Process (MethodDefinition method)
 		{
-			// special processing on generated methods from NSObject-inherited types
-			// it would be too risky to apply on user-generated code
-			if (!method.HasBody || !method.IsGeneratedCode (LinkContext) || (!IsExtensionType && !IsExport (method)))
+			if (!method.HasBody)
 				return;
+
+			if (method.IsGeneratedCode (LinkContext) && (IsExtensionType || IsExport (method))) {
+				// We optimize methods that have the [GeneratedCodeAttribute] and is either an extension type or an exported method
+			} else {
+				// but it would be too risky to apply on user-generated code
+				return;
+			}
 			
 			var instructions = method.Body.Instructions;
 			for (int i = 0; i < instructions.Count; i++) {
-				switch (instructions [i].OpCode.Code) {
+				var ins = instructions [i];
+				switch (ins.OpCode.Code) {
 				case Code.Call:
-					ProcessCalls (method, i);
+					ProcessCalls (method, ins);
 					break;
 				case Code.Ldsfld:
-					ProcessLoadStaticField (method, i);
+					ProcessLoadStaticField (method, ins);
 					break;
 				}
 			}
 		}
 		
-		void ProcessCalls (MethodDefinition caller, int i)
+		void ProcessCalls (MethodDefinition caller, Instruction ins)
 		{
-			var instructions = caller.Body.Instructions;
-			Instruction ins = instructions [i];
 			var mr = ins.Operand as MethodReference;
-			// if it could not be resolved to a definition then it won't be NSObject
-			if (mr == null)
-				return;
-
-			switch (mr.Name) {
+			switch (mr?.Name) {
 			case "IsNewRefcountEnabled":
-				// note: calling IsNSObject would check inheritance (time consuming)
-				if (!mr.DeclaringType.Is (Namespaces.Foundation, "NSObject"))
-					return;
-
-				Nop (ins);							// call bool MonoTouch.Foundation.NSObject::IsNewRefcountEnabled()
-				ins = instructions [++i];			// brtrue IL_x
-				while (ins.OpCode.FlowControl != FlowControl.Cond_Branch)
-					ins = instructions [++i];		// csc debug IL is quite not optimal as can include an _unneeded_ stloc/ldloc[.x] (ref: #32282)
-				Instruction branch_to = (ins.Operand as Instruction);
-				while (ins != branch_to) {
-					//Console.WriteLine ("\t\t{0}", ins.OpCode.Code);
-					Nop (ins);						// for getters: ldarg.0 + ldloc.0 + stfld
-					ins = instructions [++i];		// for setters: ldarg.0 + ldarg.1 + stfld
-				}
+				ProcessIsNewRefcountEnabled (caller, ins);
 				break;
 			case "EnsureUIThread":
-				if (EnsureUIThread || !mr.DeclaringType.Is (Namespaces.UIKit, "UIApplication"))
-					return;
-#if DEBUG
-				Console.WriteLine ("\t{0} EnsureUIThread {1}", caller, EnsureUIThread);
-#endif						
-				Nop (ins);								// call void MonoTouch.UIKit.UIApplication::EnsureUIThread()
+				ProcessEnsureUIThread (caller, ins);
 				break;
 			case "get_Size":
-				if (!ApplyIntPtrSizeOptimization)
-					return;
-				// This will optimize code of following code:
-				// if (IntPtr.Size == 8) { ... } else { ... }
-
-				// only if we're linking bindings with architecture specific code paths
-				if (!mr.DeclaringType.Is ("System", "IntPtr"))
-					return;
-
-				if (!(ins.Next.OpCode == OpCodes.Ldc_I4_8 && (ins.Next.Next.OpCode == OpCodes.Bne_Un || ins.Next.Next.OpCode == OpCodes.Bne_Un_S)))
-					return;
-#if DEBUG
-				Console.WriteLine ("\t{0} get_Size {1} bits", caller, Arch * 8);
-#endif
-
-				// remove conditon check
-				Nop (ins);								// call int32 [mscorlib]System.IntPtr::get_Size()
-				ins = instructions [++i];
-				if (ins.OpCode.Code != Code.Ldc_I4_8) {
-#if DEBUG
-					Console.WriteLine ("Unexpected code sequence for get_Size: {0}", ins);
-#endif
-					break; // unexpected code sequence, bail out
-				}
-				Nop (ins);								// ldc.i4.8
-				ins = instructions [++i];
-				Instruction bne = (ins.Operand as Instruction);
-				if (ins.OpCode.Code != Code.Bne_Un && ins.OpCode.Code != Code.Bne_Un_S) {
-#if DEBUG
-					Console.WriteLine ("Unexpected code sequence for get_Size: {0}", ins);
-#endif
-					break; // unexpected code sequence, bail out
-				}
-				Nop (ins);								// bne.un XXXX
-				// remove unused branch
-				if (Arch == 8) {
-					ins = bne;
-					var end = bne.Previous.Operand as Instruction;
-#if DEBUG
-					if (end == null)
-						Console.WriteLine ();
-#endif
-					// keep 64 bits branch and remove 32 bits branch
-					while (ins != end && ins.OpCode.Code != Code.Ret && ins.OpCode.Code != Code.Leave && ins.OpCode.Code != Code.Leave_S) {
-						Nop (ins);
-						ins = ins.Next;
-					}
-				} else {
-					// keep 32 bits branch and remove 64 bits branch
-					ins = instructions [++i];
-					bne = bne.Previous;
-					while (ins != bne) {
-						Nop (ins);
-						ins = instructions [++i];
-					}
-					Nop (ins);
-				}
+				ProcessIntPtrSize (caller, ins);
 				break;
 			case "get_IsDirectBinding":
-				// Unified use a property (getter) to check the condition (while Classic used a field)
-				if (isdirectbinding_check_required)
-					return;
-				if (!mr.DeclaringType.Is (Namespaces.Foundation, "NSObject"))
-					return;
-#if DEBUG
-				Console.WriteLine ("NSObject.get_IsDirectBinding called inside {0}", caller);
-#endif
 				ProcessIsDirectBinding (caller, ins);
 				break;
 			}
-		}
 
-		static bool IsField (Instruction ins, string nspace, string type, string field)
-		{
-			FieldReference fr = (ins.Operand as FieldReference);
-			if (fr.Name != field)
-				return false;
-			return fr.DeclaringType.Is (nspace, type);
+			return;
 		}
 				
 		// https://app.asana.com/0/77259014252/77812690163
-		void ProcessLoadStaticField (MethodDefinition caller, int i)
+		void ProcessLoadStaticField (MethodDefinition caller, Instruction ins)
 		{
-			var instructions = caller.Body.Instructions;
-			Instruction ins = instructions [i];
-			if (!IsField (ins, Namespaces.ObjCRuntime, "Runtime", "Arch"))
-				return;
-#if DEBUG
-			Console.WriteLine ("Runtime.Arch checked inside {0}", caller);
-#endif
-			Nop (ins);									// ldsfld valuetype MonoTouch.ObjCRuntime.Arch MonoTouch.ObjCRuntime::Arch
-			ins = instructions [++i];
-			Instruction branch_to = null;
-			if (Device) {
-				// a direct brtrue IL_x (optimal) or a longer sequence to compare (likely csc without /optimize)
-				while (ins.OpCode.FlowControl != FlowControl.Cond_Branch) {
-					Nop (ins);
-					ins = instructions [++i];
-				}
-				Instruction start = (ins.Operand as Instruction);
-				Nop (ins);								// brtrue IL_x
-				ins = start;
-				branch_to = (ins.Previous.Operand as Instruction);
-			} else {
-				branch_to = (ins.Operand as Instruction);
-			}
-			// remove unused (device or simulator) block
-			while (ins != branch_to) {
-				Nop (ins);
-				ins = ins.Next;
+			FieldReference fr = ins.Operand as FieldReference;
+			switch (fr?.Name) {
+			case "Arch":
+				ProcessRuntimeArch (caller, ins);
+				break;
 			}
 		}
 
-		static void ProcessIsDirectBinding (MethodDefinition caller, Instruction ins)
+		void ProcessRuntimeArch (MethodDefinition caller, Instruction ins)
 		{
-			Nop (ins.Previous);					// ldarg.0
-			Nop (ins);						// ldfld MonoTouch.Foundation.IsDirectBinding
-			Instruction next = ins.Next;				// brfalse IL_x (SuperHandle processing)
-			Instruction end = null;
-			// unoptimized compiled code can produce a (unneeded) store/load combo
-			while (next.OpCode.FlowControl != FlowControl.Cond_Branch) {
-				Nop (next);
-				next = next.Next;
-			}
-			ins = (next.Operand as Instruction).Previous;		// br end (ret)
-			if (ins.OpCode.Code == Code.Ret) {			// if there's not branch but it returns immediately then do not remove the 'ret' instruction
-				ins = ins.Next;
-				end = (ins.Operand as Instruction);		// ret
-			} else if (ins.OpCode.Code == Code.Leave) {		// if there's a try/catch, e.g. for a using like "using (x = new NSAutoreleasePool ())"
-				ins = ins.Next;
-				end = caller.Body.ExceptionHandlers [0].TryEnd;	// leave
-			} else {
-				end = (ins.Operand as Instruction);		// ret
-			}
-			Nop (next);
-			while (ins != end) {					// remove the 'else' branch
-				Nop (ins);
-				ins = ins.Next;
-			}
+			const string operation = "inline Runtime.Arch";
+
+			// Verify we're checking the right Arch field
+			var fr = ins.Operand as FieldReference;
+			if (!fr.DeclaringType.Is (Namespaces.ObjCRuntime, "Runtime"))
+				return;
+			
+			// Verify a few assumptions before doing anything
+			if (!ValidateInstruction (caller, ins, operation, Code.Ldsfld))
+				return;
+
+			// We're fine, inline the Runtime.Arch condition
+			// The enum values are Runtime.DEVICE = 0 and Runtime.SIMULATOR = 1,
+			// which means that 'SIMULATOR' equals true (in other words negate
+			// the Device value to get the constant).
+			if (!InlineBranchCondition (caller, operation, ins.Next, !Device))
+				return;
+
+			// Clearing the branch succeeded, so clear the condition too
+			Nop (ins); // ldsfld valuetype ObjCRuntime.Arch ObjCRuntime::Arch
+		}
+
+		void ProcessEnsureUIThread (MethodDefinition caller, Instruction ins)
+		{
+			const string operation = "remove calls to UIApplication::EnsureUIThread";
+
+			if (EnsureUIThread)
+				return;
+
+			// Verify we're checking the right get_EnsureUIThread call
+			var mr = ins.Operand as MethodReference;
+			if (!mr.DeclaringType.Is (Namespaces.UIKit, "UIApplication"))
+				return;
+
+			// Verify a few assumptions before doing anything
+			if (!ValidateInstruction (caller, ins, operation, Code.Call))
+				return;
+
+			// This is simple: just remove the call
+			Nop (ins); // call void UIKit.UIApplication::EnsureUIThread()
+		}
+
+		void ProcessIsNewRefcountEnabled (MethodDefinition caller, Instruction ins)
+		{
+			const string operation = "inline NSObject.IsNewRefcountEnabled";
+
+			// Verify we're checking the right get_IsNewRefcountEnabled call
+			var mr = ins.Operand as MethodReference;
+			if (!mr.DeclaringType.Is (Namespaces.Foundation, "NSObject"))
+				return;
+
+			// Verify a few assumptions before doing anything
+			if (!ValidateInstruction (caller, ins, operation, Code.Call))
+				return;
+
+			// We're fine, inline the get_IsNewRefcountEnabled condition
+			if (!InlineBranchCondition (caller, operation, ins.Next, true))
+				return;
+
+			// Clearing the branch succeeded, so clear the condition too
+			Nop (ins); // call bool Foundation.NSObject::IsNewRefcountEnabled()
+		}
+
+		void ProcessIntPtrSize (MethodDefinition caller, Instruction ins)
+		{
+			const string operation = "inline IntPtr.Size";
+
+			if (!ApplyIntPtrSizeOptimization)
+				return;
+
+			// This will optimize the following code sequence
+			// if (IntPtr.Size == 8) { ... } else { ... }
+
+			// Verify we're checking the right get_Size call
+			var mr = ins.Operand as MethodReference;
+			if (!mr.DeclaringType.Is ("System", "IntPtr"))
+				return;
+
+			// Verify a few assumptions before doing anything
+			if (!ValidateInstruction (caller, ins.Next, operation, Code.Ldc_I4_8))
+				return;
+
+			var branchInstruction = ins.Next.Next;
+			if (!ValidateInstruction (caller, branchInstruction, operation, Code.Bne_Un, Code.Bne_Un_S))
+				return;
+
+			// We're fine, inline the get_Size condition
+			if (!InlineBranchCondition (caller, operation, branchInstruction, Arch == 8))
+				return;
+
+			// Clearing the branch succeeded, so clear the condition too
+			Nop (ins);      // call int32 [mscorlib]System.IntPtr::get_Size()
+			Nop (ins.Next); // ldc.i4.8
+		}
+
+		void ProcessIsDirectBinding (MethodDefinition caller, Instruction ins)
+		{
+			const string operation = "inline IsDirectBinding";
+
+			// We can't inline if the IsDirectBinding check is required
+			if (isdirectbinding_check_required)
+				return;
+
+			// Verify we're checking the right get_IsDirectBinding call
+			var mr = ins.Operand as MethodReference;
+			if (!mr.DeclaringType.Is (Namespaces.Foundation, "NSObject"))
+				return;
+
+			// Verify a few assumptions before doing anything
+			if (!ValidateInstruction (caller, ins.Previous, operation, Code.Ldarg_0))
+				return;
+
+			if (!ValidateInstruction (caller, ins, operation, Code.Call))
+				return;
+
+			// We're fine, inline the IsDirectBinding condition
+			var insBranch = ins.Next;
+			if (!InlineBranchCondition (caller, operation, insBranch, true))
+				return;
+
+			// Clearing the branch succeeded, so clear the condition too
+			Nop (ins.Previous);  // ldarg.0
+			Nop (ins);           // call System.Boolean Foundation.NSObject::get_IsDirectBinding()
 		}
 	}
 }


### PR DESCRIPTION
We had several types of code optimizations, where we'd determine a particular
expression is a constant, then remove the condition and the code for any
dead branches.

Unfortunately each type of expression had its own logic to determine the
sequence of code to remove, each slightly different depending on the actual
conditional expression. This has led to bugs in the past, either when
switching between compilers (mcs/csc), or compilers have changed their emitted
code.

So implement a more generic version that given a branch instruction is able to
determine the exact code sequences that correspond to the true and false
blocks of the condition. This version is also a lot more defensive than the
previous code, it will bail out without doing anything if it finds a code
sequence it doesn't understand.

This also makes it easier to implement other similar code optimizations.