### PR TITLE
[xtro] Fix broken build with Mono.Cecil 0.9.6.4.

### DIFF
--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -12,6 +12,7 @@ clean-local::
 	rm -rf *os*.pch*
 
 bin/Debug/xtro-sharpie.exe build:
+	$(Q) nuget restore xtro-sharpie.sln
 	$(Q_BUILD) $(SYSTEM_MSBUILD) $(XBUILD_VERBOSITY) xtro-sharpie.sln
 
 XIOS ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/64bits/Xamarin.iOS.dll

--- a/tests/xtro-sharpie/ObjCInterfaceCheck.cs
+++ b/tests/xtro-sharpie/ObjCInterfaceCheck.cs
@@ -114,7 +114,13 @@ namespace Extrospection {
 				return false;
 			if (td.HasInterfaces) {
 				foreach (var intf in td.Interfaces) {
-					if (protocol == GetProtocolName (intf?.InterfaceType.Resolve ()))
+					TypeReference ifaceType;
+#if CECIL_0_10
+					ifaceType = intf?.InterfaceType;
+#else
+					ifaceType = intf;
+#endif
+					if (protocol == GetProtocolName (ifaceType?.Resolve ()))
 						return true;
 				}
 			}

--- a/tests/xtro-sharpie/packages.config
+++ b/tests/xtro-sharpie/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net45" />
+  <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net45" />
 </packages>

--- a/tests/xtro-sharpie/xtro-sharpie.csproj
+++ b/tests/xtro-sharpie/xtro-sharpie.csproj
@@ -57,7 +57,16 @@
       <HintPath>\Library\Frameworks\ObjectiveSharpie.framework\Versions\Current\Clang.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb">
+      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb">
+      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks">
+      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -72,6 +81,9 @@
     <Compile Include="SelectorCheck.cs" />
     <Compile Include="DesignatedInitializerCheck.cs" />
     <Compile Include="SimdCheck.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">


### PR DESCRIPTION
Facts:

* xtro-sharpie references Mono.Cecil 0.9.6 from a nuget.
* If a local Mono.Cecil.dll can't be found (according to the HintPath in the
  csproj, which points to the nuget), then msbuild will look in the system
  Mono.
* Mono 5.8 ships Mono.Cecil 0.10.
* Mono.Cecil 0.10 is not source compatible with 0.9.6 (there's a small issue
  with interfaces).
* xtro-sharpie's source code works with v0.10.

This all means that xtro-sharpie will build fine as long as the 0.9.6 nuget
has *not* been restored. This can manifest itself confusingly ("msbuild xtro-
sharpie.sln" works fine from the command line, open the solution in VSfM and
it doesn't build anymore, not even from the command line, because VSfM
automatically restored nugets in the background).

Update the source code to work with Mono.Cecil 0.9.6 because there's no 0.10
nuget yet (yet keeping the code for v0.10 clearly marked as such for future
updates to v0.10).

Also bump from 0.9.6.1 to 0.9.6.4 since that's the latest available.