### PR TITLE
[RFC] Make the dynamic registrar removable.

### DIFF
--- a/Xamarin.iOS.sln
+++ b/Xamarin.iOS.sln
@@ -23,13 +23,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mtouch", "tests\mtouch\mtou
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "libmonotouch", "runtime\libmonotouch.csproj", "{8A5B637C-E4FF-4145-B887-9347020100F4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xamios", "src\xamios.csproj", "{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bindings-generator", "runtime\bindings-generator.csproj", "{6B616492-49F0-43EF-8390-F9D1B4CCC632}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "generator", "src\generator.csproj", "{D2EE02C0-9BFD-477D-AC92-4DE2D8490790}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "generator-tests", "tests\generator\generator-tests.csproj", "{10790816-D00E-40A0-8653-2A8AB4DD33A9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xamios", "src\xamios.csproj", "{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "generator", "src\generator.csproj", "{D2EE02C0-9BFD-477D-AC92-4DE2D8490790}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -434,44 +434,6 @@ Global
 		{8A5B637C-E4FF-4145-B887-9347020100F4}.Debug|x86.Build.0 = Debug|Any CPU
 		{8A5B637C-E4FF-4145-B887-9347020100F4}.Release|x86.ActiveCfg = Release|Any CPU
 		{8A5B637C-E4FF-4145-B887-9347020100F4}.Release|x86.Build.0 = Release|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.net_2_0_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.net_2_0_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.net_2_0_Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.net_2_0_Release|Any CPU.Build.0 = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.net_3_5_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.net_3_5_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.net_3_5_Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.net_3_5_Release|Any CPU.Build.0 = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.net_4_0_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.net_4_0_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.net_4_0_Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.net_4_0_Release|Any CPU.Build.0 = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.silverlight_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.silverlight_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.silverlight_Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.silverlight_Release|Any CPU.Build.0 = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.winphone_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.winphone_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.winphone_Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.winphone_Release|Any CPU.Build.0 = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Release|iPhone.Build.0 = Release|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.DebugStaticRegistrar|iPhone.ActiveCfg = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.DebugStaticRegistrar|iPhone.Build.0 = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Debug|x86.Build.0 = Debug|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Release|x86.ActiveCfg = Release|Any CPU
-		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Release|x86.Build.0 = Release|Any CPU
 		{6B616492-49F0-43EF-8390-F9D1B4CCC632}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{6B616492-49F0-43EF-8390-F9D1B4CCC632}.Debug|Any CPU.Build.0 = Debug|x86
 		{6B616492-49F0-43EF-8390-F9D1B4CCC632}.Release|Any CPU.ActiveCfg = Release|x86
@@ -550,6 +512,8 @@ Global
 		{10790816-D00E-40A0-8653-2A8AB4DD33A9}.Debug|x86.Build.0 = Debug|Any CPU
 		{10790816-D00E-40A0-8653-2A8AB4DD33A9}.Release|x86.ActiveCfg = Release|Any CPU
 		{10790816-D00E-40A0-8653-2A8AB4DD33A9}.Release|x86.Build.0 = Release|Any CPU
+		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{208744BD-504E-47D7-9A98-1CF02454A6DA} = {2BFA13F8-B568-48BF-9A70-9D43F718C523}

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -2322,3 +2322,9 @@ This indicates a bug in Xamarin.iOS. Please file a bug at [http://bugzilla.xamar
 
 This indicates a bug in Xamarin.iOS. Please file a bug at [http://bugzilla.xamarin.com](https://bugzilla.xamarin.com/enter_bug.cgi?product=iOS).
 
+### <a name="MT8025"/>MT8025: * is not supported when the dynamic registrar has been linked away.
+
+This usually indicates a bug in Xamarin.iOS, because the dynamic registrar should not be linked away if it's needed. Please file a bug at [https://bugzilla.xamarin.com](https://bugzilla.xamarin.com/enter_bug.cgi?product=iOS).
+
+It's possible to force the linker to keep the dynamic registrar present by adding `--linker-optimize=-remove-dynamic-registrar` to the additional mtouch arguments in the project's iOS Build options.
+

--- a/runtime/Delegates.cs.t4
+++ b/runtime/Delegates.cs.t4
@@ -68,9 +68,23 @@ namespace XamCore.ObjCRuntime {
 
 <# } #>
 
+        [LinkerOptimize] // To inline the Runtime.DynamicRegistrationSupported code if possible.
 		static void RegisterDelegates (InitializationOptions* options)
 		{
-<# foreach (var d in delegates) { #>
+<# foreach (var d in delegates) {
+	if (d.OnlyDynamicUsage) continue; #>
+			options->Delegates-><#= d.SimpleEntryPoint #> = GetFunctionPointer (new <#= d.SimpleEntryPoint #>_delegate (<#= d.SimpleEntryPoint #>));
+<# } #>
+
+            // The linker will remove this condition (and the subsequent method call) if possible
+			if (DynamicRegistrationSupported)
+				RegisterDelegatesDynamic (options);
+		}
+
+		static void RegisterDelegatesDynamic (InitializationOptions* options)
+		{
+<# foreach (var d in delegates) {
+	if (!d.OnlyDynamicUsage) continue; #>
 			options->Delegates-><#= d.SimpleEntryPoint #> = GetFunctionPointer (new <#= d.SimpleEntryPoint #>_delegate (<#= d.SimpleEntryPoint #>));
 <# } #>
 		}

--- a/runtime/delegates.h.t4
+++ b/runtime/delegates.h.t4
@@ -18,7 +18,10 @@
 extern "C" {
 #endif
 
-<# foreach (var d in delegates) { #>
+<# foreach (var d in delegates) {
+		if (!d.OnlyDynamicUsage)
+			continue;
+#>
 <#= d.CReturnType #>
 <#= d.EntryPoint #> (<#= d.CArgumentSignature #>);
 

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -9,135 +9,204 @@
 		new XDelegate ("void", "void", "xamarin_register_nsobject",
 			"MonoObject *", "IntPtr", "managed_obj",
 			"id", "IntPtr", "native_obj"
-		) { WrappedManagedFunction = "RegisterNSObject" },
+		) {
+			WrappedManagedFunction = "RegisterNSObject",
+			OnlyDynamicUsage = true,
+		},
 
 		new XDelegate ("void", "void", "xamarin_register_assembly",
 			"MonoReflectionAssembly *", "IntPtr", "assembly"
-		) { WrappedManagedFunction = "RegisterAssembly" },
+		) {
+			WrappedManagedFunction = "RegisterAssembly",
+			OnlyDynamicUsage = true,
+		},
 
 		new XDelegate ("void", "void", "xamarin_throw_ns_exception",
 			"NSException *", "IntPtr", "exc"
 		) {
 			WrappedManagedFunction = "ThrowNSException",
 			ExceptionHandling = false,
+			OnlyDynamicUsage = false,
 		},
 
 		new XDelegate ("void", "void", "xamarin_rethrow_managed_exception",
 			"guint32", "uint", "original_exception_gchandle"
-		) { WrappedManagedFunction = "RethrowManagedException" },
+		) {
+			WrappedManagedFunction = "RethrowManagedException",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("int", "int", "xamarin_create_ns_exception",
 			"NSException *", "IntPtr", "exc"
-		) { WrappedManagedFunction = "CreateNSException" },
+		) {
+			WrappedManagedFunction = "CreateNSException",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("NSException *", "IntPtr", "xamarin_unwrap_ns_exception",
 			"int", "int", "exc_handle"
-		) { WrappedManagedFunction = "UnwrapNSException" },
+		) {
+			WrappedManagedFunction = "UnwrapNSException",
+			OnlyDynamicUsage = true,
+		},
 
 		new XDelegate ("MonoObject *", "IntPtr", "xamarin_get_block_wrapper_creator",
 			"MonoObject *", "IntPtr", "method",
 			"int", "int", "parameter"
-		) { WrappedManagedFunction = "GetBlockWrapperCreator" },
+		) {
+			WrappedManagedFunction = "GetBlockWrapperCreator",
+			OnlyDynamicUsage = true,
+		},
 
 		new XDelegate ("MonoObject *", "IntPtr", "xamarin_create_block_proxy",
 			"MonoObject *", "IntPtr", "method",
 			"void *", "IntPtr", "block"
-		) { WrappedManagedFunction = "CreateBlockProxy" },
+		) {
+			WrappedManagedFunction = "CreateBlockProxy",
+			OnlyDynamicUsage = true,
+		},
 
 		new XDelegate ("id", "IntPtr", "xamarin_create_delegate_proxy",
 			"MonoObject *", "IntPtr", "method",
-			"MonoObject *", "IntPtr", "block"
-		) { WrappedManagedFunction = "CreateDelegateProxy" },
+			"MonoObject *", "IntPtr", "block",
+			"const char *", "IntPtr", "signature"
+		) {
+			WrappedManagedFunction = "CreateDelegateProxy",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("void", "void", "xamarin_register_entry_assembly",
 			"MonoReflectionAssembly *", "IntPtr", "assembly"
-		) { WrappedManagedFunction = "RegisterEntryAssembly" },
+		) {
+			WrappedManagedFunction = "RegisterEntryAssembly",
+			OnlyDynamicUsage = true,
+		},
 
 		new XDelegate ("MonoObject *", "IntPtr", "xamarin_get_class",
 			"Class", "IntPtr", "ptr"
-		) { WrappedManagedFunction = "GetClass" },
+		) {
+			WrappedManagedFunction = "GetClass",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("MonoObject *", "IntPtr", "xamarin_get_selector",
 			"SEL", "IntPtr", "ptr"
-		) { WrappedManagedFunction = "GetSelector" },
-
-		new XDelegate ("Class", "IntPtr", "xamarin_get_class_handle",
-			"MonoObject *", "IntPtr", "obj"
-		) { WrappedManagedFunction = "GetClassHandle" },
-
-		new XDelegate ("SEL", "IntPtr", "xamarin_get_selector_handle",
-			"MonoObject *", "IntPtr", "obj"
-		) { WrappedManagedFunction = "GetSelectorHandle" },
+		) {
+			WrappedManagedFunction = "GetSelector",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("void", "void", "xamarin_get_method_for_selector",
 			"Class", "IntPtr", "cls",
 			"SEL", "IntPtr", "sel",
 			"bool", "bool", "is_static",
 			"MethodDescription *", "IntPtr", "desc"
-		) { WrappedManagedFunction = "GetMethodForSelector" },
+		) {
+			WrappedManagedFunction = "GetMethodForSelector",
+			OnlyDynamicUsage = true,
+		},
 
 		new XDelegate ("MonoObject *", "IntPtr", "xamarin_get_nsobject",
 			"id", "IntPtr", "obj"
-		) { WrappedManagedFunction = "GetNSObjectWrapped" },
+		) {
+			WrappedManagedFunction = "GetNSObjectWrapped",
+			OnlyDynamicUsage = true,
+		},
 
 		new XDelegate ("bool", "bool", "xamarin_has_nsobject",
 			"id", "IntPtr", "obj"
-		) { WrappedManagedFunction = "HasNSObject" },
+		) {
+			WrappedManagedFunction = "HasNSObject",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("id", "IntPtr", "xamarin_get_handle_for_inativeobject",
 			"MonoObject *", "IntPtr", "obj"
-		) { WrappedManagedFunction = "GetHandleForINativeObject" },
+		) {
+			WrappedManagedFunction = "GetHandleForINativeObject",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("void", "void", "xamarin_unregister_nsobject",
 			"id", "IntPtr", "native_obj",
 			"MonoObject *", "IntPtr", "managed_obj"
-		) { WrappedManagedFunction = "UnregisterNSObject" },
+		) {
+			WrappedManagedFunction = "UnregisterNSObject",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("MonoObject *", "IntPtr", "xamarin_try_get_or_construct_nsobject",
 			"id", "IntPtr", "obj"
-		) { WrappedManagedFunction = "TryGetOrConstructNSObjectWrapped" },
+		) {
+			WrappedManagedFunction = "TryGetOrConstructNSObjectWrapped",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("MonoObject *", "IntPtr", "xamarin_get_inative_object_dynamic",
 			"id", "IntPtr", "obj",
 			"bool", "bool", "owns",
 			"void *", "IntPtr", "type"
-		) { WrappedManagedFunction = "GetINativeObject_Dynamic" },
+		) {
+			WrappedManagedFunction = "GetINativeObject_Dynamic",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("MonoReflectionMethod *", "IntPtr", "xamarin_get_method_from_token",
 			"unsigned int", "uint", "token_ref"
-		) { WrappedManagedFunction = "GetMethodFromToken" },
+		) {
+			WrappedManagedFunction = "GetMethodFromToken",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("MonoReflectionMethod *", "IntPtr", "xamarin_get_generic_method_from_token",
 			"MonoObject *", "IntPtr", "obj",
 			"unsigned int", "uint", "token_ref"
-		) { WrappedManagedFunction = "GetGenericMethodFromToken" },
+		) {
+			WrappedManagedFunction = "GetGenericMethodFromToken",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("MonoObject *", "IntPtr", "xamarin_get_inative_object_static",
 			"id", "IntPtr", "obj",
 			"bool", "bool", "owns",
 			"const char *", "string", "type_name",
 			"const char *", "string", "iface_name"
-		) { WrappedManagedFunction = "GetINativeObject_Static" },
+		) {
+			WrappedManagedFunction = "GetINativeObject_Static",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("MonoObject *", "IntPtr", "xamarin_get_nsobject_with_type",
 			"id", "IntPtr", "obj",
 			"void *", "IntPtr", "type",
 			"int32_t *", "out bool", "created"
-		) { WrappedManagedFunction = "GetNSObjectWithType" },
+		) {
+			WrappedManagedFunction = "GetNSObjectWithType",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("void", "void", "xamarin_dispose",
 			"MonoObject *", "IntPtr", "mobj"
-		) { WrappedManagedFunction = "Dispose" },
+		) {
+			WrappedManagedFunction = "Dispose",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("bool", "bool", "xamarin_is_parameter_transient",
 			"MonoReflectionMethod *", "IntPtr", "method",
 			"int", "int", "parameter"
-		) { WrappedManagedFunction = "IsParameterTransient" },
+		) {
+			WrappedManagedFunction = "IsParameterTransient",
+			OnlyDynamicUsage = true,
+		},
 
 		new XDelegate ("bool", "bool", "xamarin_is_parameter_out",
 			"MonoReflectionMethod *", "IntPtr", "method",
 			"int", "int", "parameter"
-		) { WrappedManagedFunction = "IsParameterOut" },
+		) {
+			WrappedManagedFunction = "IsParameterOut",
+			OnlyDynamicUsage = true,
+		},
 
 		new XDelegate ("void", "void", "xamarin_get_method_and_object_for_selector",
 			"Class", "IntPtr", "cls",
@@ -146,38 +215,62 @@
 			"id", "IntPtr", "obj",
 			"MonoObject **", "ref IntPtr", "mthis",
 			"MethodDescription *", "IntPtr", "desc"
-		) { WrappedManagedFunction = "GetMethodAndObjectForSelector" },
+		) {
+			WrappedManagedFunction = "GetMethodAndObjectForSelector",
+			OnlyDynamicUsage = true,
+		},
 
 		new XDelegate ("guint32", "int", "xamarin_create_product_exception_for_error",
 			"int", "int", "code",
 			"const char *", "string", "message"
-		) { WrappedManagedFunction = "CreateProductException" },
+		) {
+			WrappedManagedFunction = "CreateProductException",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("char *", "IntPtr", "xamarin_reflection_type_get_full_name",
 			"MonoReflectionType *", "IntPtr", "type"
-		) { WrappedManagedFunction = "TypeGetFullName" },
+		) {
+			WrappedManagedFunction = "TypeGetFullName",
+			OnlyDynamicUsage = true,
+		},
 
 		new XDelegate ("char *", "IntPtr", "xamarin_lookup_managed_type_name",
 			"Class", "IntPtr", "klass"
-		) { WrappedManagedFunction = "LookupManagedTypeName" },
+		) {
+			WrappedManagedFunction = "LookupManagedTypeName",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("MarshalManagedExceptionMode", "MarshalManagedExceptionMode", "xamarin_on_marshal_managed_exception",
 			"int", "int", "exception"
-		) { WrappedManagedFunction = "OnMarshalManagedException" },
+		) {
+			WrappedManagedFunction = "OnMarshalManagedException",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("MarshalObjectiveCExceptionMode", "MarshalObjectiveCExceptionMode", "xamarin_on_marshal_objectivec_exception",
 			"id", "IntPtr", "exception",
 			"bool", "bool", "throwManagedAsDefault"
-		) { WrappedManagedFunction = "OnMarshalObjectiveCException" },
+		) {
+			WrappedManagedFunction = "OnMarshalObjectiveCException",
+			OnlyDynamicUsage = false,
+		},
 
 		new XDelegate ("NSString *", "IntPtr", "xamarin_convert_smart_enum_to_nsstring",
 			"void *", "IntPtr", "value"
-		) { WrappedManagedFunction = "ConvertSmartEnumToNSString" },
+		) {
+			WrappedManagedFunction = "ConvertSmartEnumToNSString",
+			OnlyDynamicUsage = true,
+		},
 
 		new XDelegate ("void *", "IntPtr", "xamarin_convert_nsstring_to_smart_enum",
 			"NSString *", "IntPtr", "value",
 			"MonoReflectionType *", "IntPtr", "type"
-		) { WrappedManagedFunction = "ConvertNSStringToSmartEnum" },
+		) {
+			WrappedManagedFunction = "ConvertNSStringToSmartEnum",
+			OnlyDynamicUsage = true,
+		},
 	};
 	delegates.CalculateLengths ();
 #><#+
@@ -211,6 +304,8 @@
 		public List<Arg> Arguments;
 		public string WrappedManagedFunction;
 		public bool ExceptionHandling = true;
+		// Detemines whether the function is only used by the dynamic registrar (in which case we might be able to link the function away if the static registrar is being used)
+		public bool OnlyDynamicUsage;
 
 		public XDelegates Delegates;
 

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -451,9 +451,11 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 			xamarin_process_managed_exception_gchandle (exception_gchandle);
 	}
 
-	xamarin_register_entry_assembly (mono_assembly_get_object (mono_domain_get (), assembly), &exception_gchandle);
-	if (exception_gchandle != 0)
-		xamarin_process_managed_exception_gchandle (exception_gchandle);
+	if (xamarin_supports_dynamic_registration) {
+		xamarin_register_entry_assembly (mono_assembly_get_object (mono_domain_get (), assembly), &exception_gchandle);
+		if (exception_gchandle != 0)
+			xamarin_process_managed_exception_gchandle (exception_gchandle);
+	}
 #endif
 
 	DEBUG_LAUNCH_TIME_PRINT ("\tAssembly register time");

--- a/runtime/runtime-generated.h.t4
+++ b/runtime/runtime-generated.h.t4
@@ -22,6 +22,8 @@ extern "C" {
 #endif
 
 <# foreach (var d in delegates) {
+		if (d.OnlyDynamicUsage)
+			continue;
 #>
 <#= d.CReturnType #>
 <#= d.EntryPoint #> (<#= d.CArgumentSignature #>);

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -166,7 +166,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 			if (exception_gchandle != 0)
 				goto exception_handling;
 			if (desc->bindas [i + 1].original_type != NULL) {
-				arg_ptrs [i + mofs] = xamarin_generate_conversion_to_managed ((id) arg, mono_reflection_type_get_type (desc->bindas [i + 1].original_type), p, method, &exception_gchandle, (void **) &free_list);
+				arg_ptrs [i + mofs] = xamarin_generate_conversion_to_managed ((id) arg, mono_reflection_type_get_type (desc->bindas [i + 1].original_type), p, method, &exception_gchandle, INVALID_TOKEN_REF, (void **) &free_list);
 				if (exception_gchandle != 0)
 					goto exception_handling;
 				ofs++;

--- a/runtime/xamarin/main.h
+++ b/runtime/xamarin/main.h
@@ -67,6 +67,7 @@ extern bool xamarin_is_gc_coop;
 extern enum MarshalObjectiveCExceptionMode xamarin_marshal_objectivec_exception_mode;
 extern enum MarshalManagedExceptionMode xamarin_marshal_managed_exception_mode;
 extern enum XamarinLaunchMode xamarin_launch_mode;
+extern bool xamarin_supports_dynamic_registration;
 
 typedef void (*xamarin_setup_callback) ();
 typedef int (*xamarin_extension_main_callback) (int argc, char** argv);

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -18,6 +18,7 @@
 
 #include "main.h"
 #include "mono-runtime.h"
+#include "runtime-generated.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -65,22 +66,45 @@ typedef struct __attribute__((packed)) {
 	uint8_t assembly_index:7; /* 0-based index into the '__xamarin_registration_assemblies' array. Max 127 (registered) assemblies before a full token reference has to be used */
 	uint32_t token:24; /* RID of the corresponding metadata token. The exact type of metadata token depends on the context where the token reference is used. */
 } MTTokenReference;
+static const uint32_t INVALID_TOKEN_REF = 0xFFFFFFFF;
 
 typedef struct __attribute__((packed)) {
 	void *handle;
 	uint32_t /* MTTokenReference */ type_reference;
 } MTClassMap;
 
+typedef struct __attribute__((packed)) {
+	uint32_t /* MTTokenReference */ skipped_reference;
+	uint32_t /* MTTokenReference */ actual_reference;
+} MTManagedClassMap;
+
+typedef struct __attribute__((packed)) {
+	uint32_t /* MTTokenReference */ token; // Token to a class)
+	uint32_t protocol_count; // Number of protocols
+	const char * const * protocols;
+} MTProtocolMap;
+
+typedef struct __attribute__((packed)) {
+	uint32_t protocol_token;
+	uint32_t wrapper_token;
+} MTProtocolWrapperMap;
+
 struct MTRegistrationMap;
 
 struct MTRegistrationMap {
 	const char **assembly;
 	MTClassMap *map;
-	MTFullTokenReference *full_token_references;
+	const MTProtocolMap *protocols; // array of MTProtocolMap, sorted ascending by token
+	const MTProtocolWrapperMap *protocol_wrappers; // array of MTProtocolWrapperMap, sorted ascending by protocol_token
+	const MTFullTokenReference *full_token_references;
+	const MTManagedClassMap *skipped_map;
 	int assembly_count;
 	int map_count;
 	int custom_type_count;
+	int protocol_count;
+	int protocol_wrapper_count;
 	int full_token_reference_count;
+	int skipped_map_count;
 };
 
 typedef struct {
@@ -141,7 +165,7 @@ MonoType *		xamarin_get_parameter_type (MonoMethod *managed_method, int index);
 MonoObject *	xamarin_get_nsobject_with_type_for_ptr (id self, bool owns, MonoType* type, guint32 *exception_gchandle);
 MonoObject *	xamarin_get_nsobject_with_type_for_ptr_created (id self, bool owns, MonoType *type, int32_t *created, guint32 *exception_gchandle);
 int *			xamarin_get_delegate_for_block_parameter (MonoMethod *method, int par, void *nativeBlock, guint32 *exception_gchandle);
-id              xamarin_get_block_for_delegate (MonoMethod *method, MonoObject *delegate, guint32 *exception_gchandle);
+id              xamarin_get_block_for_delegate (MonoMethod *method, MonoObject *delegate, const char *signature, guint32 *exception_gchandle);
 id				xamarin_get_nsobject_handle (MonoObject *obj);
 void			xamarin_set_nsobject_handle (MonoObject *obj, id handle);
 uint8_t         xamarin_get_nsobject_flags (MonoObject *obj);
@@ -154,6 +178,7 @@ char *			xamarin_strdup_printf (const char *msg, ...);
 void *			xamarin_calloc (size_t size);
 void			xamarin_free (void *ptr);
 MonoMethod *	xamarin_get_reflection_method_method (MonoReflectionMethod *method);
+MonoMethod *	xamarin_get_managed_method_for_token (guint32 token_ref, guint32 *exception_gchandle);
 void			xamarin_framework_peer_lock ();
 void			xamarin_framework_peer_unlock ();
 bool			xamarin_file_exists (const char *path);

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -53,12 +53,12 @@ enum ArgumentSemantic /* Xcode 4.4 doesn't like this ': int' */ {
 // will be stored in this pointer. Otherwise a memory is allocated, and the
 // return value must be freed using xamarin_free.
 // Returns: a pointer to the value type. In case of an exception, 'ptr' is returned (and no memory allocated in any circumstances).
-typedef void *	(*xamarin_id_to_managed_func) (id value, void *ptr, MonoClass *managedType, guint32 *exception_gchandle);
+typedef void *	(*xamarin_id_to_managed_func) (id value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
 // Function to convert from managed to id.
-typedef id		(*xamarin_managed_to_id_func) (MonoObject *value, guint32 *exception_gchandle);
+typedef id		(*xamarin_managed_to_id_func) (MonoObject *value, guint32 context, guint32 *exception_gchandle);
 
-id              xamarin_generate_conversion_to_native (MonoObject *value, MonoType *inputType, MonoType *outputType, MonoMethod *method, guint32 *exception_gchandle);
-void *          xamarin_generate_conversion_to_managed (id value, MonoType *inputType, MonoType *outputType, MonoMethod *method, guint32 *exception_gchandle, /*SList*/ void **free_list);
+id              xamarin_generate_conversion_to_native (MonoObject *value, MonoType *inputType, MonoType *outputType, MonoMethod *method, guint32 context, guint32 *exception_gchandle);
+void *          xamarin_generate_conversion_to_managed (id value, MonoType *inputType, MonoType *outputType, MonoMethod *method, guint32 *exception_gchandle, guint32 context, /*SList*/ void **free_list);
 NSNumber *      xamarin_convert_managed_to_nsnumber (MonoObject *value, MonoType *managedType, MonoType *nativeType, MonoMethod *method, guint32 *exception_gchandle);
 NSValue *       xamarin_convert_managed_to_nsvalue (MonoObject *value, MonoType *managedType, MonoType *nativeType, MonoMethod *method, guint32 *exception_gchandle);
 NSString *      xamarin_convert_managed_to_nsstring (MonoObject *value, MonoType *managedType, MonoType *nativeType, MonoMethod *method, guint32 *exception_gchandle);
@@ -73,82 +73,82 @@ xamarin_managed_to_id_func xamarin_get_managed_to_nsnumber_func (MonoClass *mana
 xamarin_id_to_managed_func xamarin_get_nsvalue_to_managed_func (MonoClass *managedType, MonoMethod *method, guint32 *exception_gchandle);
 xamarin_managed_to_id_func xamarin_get_managed_to_nsvalue_func (MonoClass *managedType, MonoMethod *method, guint32 *exception_gchandle);
 
-xamarin_id_to_managed_func xamarin_get_nsstring_to_smart_enum_func (MonoClass *managedType, MonoMethod *method, guint32 *exception_gchandle);
-xamarin_managed_to_id_func xamarin_get_smart_enum_to_nsstring_func (MonoClass *managedType, MonoMethod *method, guint32 *exception_gchandle);
+xamarin_id_to_managed_func xamarin_get_nsstring_to_smart_enum_func (MonoClass *managedType, MonoMethod *method, bool static_registrar, guint32 *exception_gchandle);
+xamarin_managed_to_id_func xamarin_get_smart_enum_to_nsstring_func (MonoClass *managedType, MonoMethod *method, bool static_registrar, guint32 *exception_gchandle);
 
-NSArray *   xamarin_convert_managed_to_nsarray_with_func (MonoArray *array, xamarin_managed_to_id_func convert, guint32 *exception_gchandle);
-MonoArray * xamarin_convert_nsarray_to_managed_with_func (NSArray *array, MonoClass *managedElementType, xamarin_id_to_managed_func convert, guint32 *exception_gchandle);
+NSArray *   xamarin_convert_managed_to_nsarray_with_func (MonoArray *array, xamarin_managed_to_id_func convert, guint32 context, guint32 *exception_gchandle);
+MonoArray * xamarin_convert_nsarray_to_managed_with_func (NSArray *array, MonoClass *managedElementType, xamarin_id_to_managed_func convert, guint32 context, guint32 *exception_gchandle);
 
 // Returns a pointer to the value type, which must be freed using xamarin_free.
-void *xamarin_nsnumber_to_bool   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_sbyte  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_byte   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_short  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_ushort (NSNumber *number, void *ptr, MonoClass *managedType, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_int    (NSNumber *number, void *ptr, MonoClass *managedType, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_uint   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_long   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_ulong  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_nint   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_nuint  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_float  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_double (NSNumber *number, void *ptr, MonoClass *managedType, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_nfloat (NSNumber *number, void *ptr, MonoClass *managedType, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_bool   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_sbyte  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_byte   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_short  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_ushort (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_int    (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_uint   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_long   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_ulong  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_nint   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_nuint  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_float  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_double (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_nfloat (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
 
 // Returns a pointer to the value type, which must be freed using xamarin_free
-void *xamarin_nsvalue_to_nsrange                (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cgaffinetransform      (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cgpoint                (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cgrect                 (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cgsize                 (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cgvector               (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_catransform3d          (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cllocationcoordinate2d (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cmtime                 (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cmtimemapping          (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cmtimerange            (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_mkcoordinatespan       (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_scnmatrix4             (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_scnvector3             (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_scnvector4             (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_uiedgeinsets           (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_uioffset               (NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_nsdirectionaledgeinsets(NSValue *value, void *ptr, MonoClass *managedType, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_nsrange                (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cgaffinetransform      (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cgpoint                (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cgrect                 (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cgsize                 (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cgvector               (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_catransform3d          (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cllocationcoordinate2d (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cmtime                 (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cmtimemapping          (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cmtimerange            (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_mkcoordinatespan       (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_scnmatrix4             (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_scnvector3             (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_scnvector4             (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_uiedgeinsets           (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_uioffset               (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_nsdirectionaledgeinsets(NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
 
-id xamarin_bool_to_nsnumber   (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_sbyte_to_nsnumber  (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_byte_to_nsnumber   (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_short_to_nsnumber  (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_ushort_to_nsnumber (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_int_to_nsnumber    (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_uint_to_nsnumber   (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_long_to_nsnumber   (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_ulong_to_nsnumber  (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_nint_to_nsnumber   (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_nuint_to_nsnumber  (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_float_to_nsnumber  (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_double_to_nsnumber (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_nfloat_to_nsnumber (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_nfloat_to_nsnumber (MonoObject *value, guint32 *exception_gchandle);
+id xamarin_bool_to_nsnumber   (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
+id xamarin_sbyte_to_nsnumber  (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
+id xamarin_byte_to_nsnumber   (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
+id xamarin_short_to_nsnumber  (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
+id xamarin_ushort_to_nsnumber (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
+id xamarin_int_to_nsnumber    (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
+id xamarin_uint_to_nsnumber   (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
+id xamarin_long_to_nsnumber   (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
+id xamarin_ulong_to_nsnumber  (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
+id xamarin_nint_to_nsnumber   (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
+id xamarin_nuint_to_nsnumber  (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
+id xamarin_float_to_nsnumber  (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
+id xamarin_double_to_nsnumber (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
+id xamarin_nfloat_to_nsnumber (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
+id xamarin_nfloat_to_nsnumber (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
 
-id xamarin_nsrange_to_nsvalue                (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_cgaffinetransform_to_nsvalue      (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_cgpoint_to_nsvalue                (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_cgrect_to_nsvalue                 (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_cgsize_to_nsvalue                 (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_cgvector_to_nsvalue               (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_catransform3d_to_nsvalue          (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_cllocationcoordinate2d_to_nsvalue (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_cmtime_to_nsvalue                 (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_cmtimemapping_to_nsvalue          (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_cmtimerange_to_nsvalue            (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_mkcoordinatespan_to_nsvalue       (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_scnmatrix4_to_nsvalue             (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_scnvector3_to_nsvalue             (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_scnvector4_to_nsvalue             (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_uiedgeinsets_to_nsvalue           (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_uioffset_to_nsvalue               (MonoObject *value, guint32 *exception_gchandle);
-id xamarin_nsdirectionaledgeinsets_to_nsvalue(MonoObject *value, guint32 *exception_gchandle);
+id xamarin_nsrange_to_nsvalue                (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_cgaffinetransform_to_nsvalue      (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_cgpoint_to_nsvalue                (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_cgrect_to_nsvalue                 (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_cgsize_to_nsvalue                 (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_cgvector_to_nsvalue               (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_catransform3d_to_nsvalue          (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_cllocationcoordinate2d_to_nsvalue (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_cmtime_to_nsvalue                 (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_cmtimemapping_to_nsvalue          (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_cmtimerange_to_nsvalue            (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_mkcoordinatespan_to_nsvalue       (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_scnmatrix4_to_nsvalue             (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_scnvector3_to_nsvalue             (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_scnvector4_to_nsvalue             (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_uiedgeinsets_to_nsvalue           (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_uioffset_to_nsvalue               (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_nsdirectionaledgeinsets_to_nsvalue(MonoObject *value, guint32 context, guint32 *exception_gchandle);
 
 /* Copied from SGen */
 

--- a/src/AddressBook/ABAddressBook.cs
+++ b/src/AddressBook/ABAddressBook.cs
@@ -207,6 +207,7 @@ namespace XamCore.AddressBook {
 		extern unsafe static void ABAddressBookRequestAccessWithCompletion (IntPtr addressbook, void * completion);
 
 		[iOS (6,0)]
+		[LinkerOptimize]
 		public void RequestAccess (Action<bool,NSError> onCompleted)
 		{
 			if (onCompleted == null)
@@ -223,6 +224,7 @@ namespace XamCore.AddressBook {
 			}
 		}
 
+		[UserDelegateType (typeof (Action<bool, NSError>))]
 		internal delegate void InnerCompleted (IntPtr block, bool success, IntPtr error);
 		static readonly InnerCompleted static_completionHandler = TrampolineCompletionHandler;
 		[MonoPInvokeCallback (typeof (InnerCompleted))]

--- a/src/AudioToolbox/SystemSound.cs
+++ b/src/AudioToolbox/SystemSound.cs
@@ -192,6 +192,7 @@ namespace XamCore.AudioToolbox {
 		}
 
 		[iOS (9,0)][Mac (10,11)]
+		[LinkerOptimize]
 		public void PlayAlertSound (Action onCompletion)
 		{
 			if (onCompletion == null)
@@ -224,6 +225,7 @@ namespace XamCore.AudioToolbox {
 		}
 
 		[iOS (9,0)][Mac (10,11)]
+		[LinkerOptimize]
 		public void PlaySystemSound (Action onCompletion)
 		{
 			if (onCompletion == null)

--- a/src/CoreFoundation/DispatchBlock.cs
+++ b/src/CoreFoundation/DispatchBlock.cs
@@ -21,6 +21,7 @@ namespace XamCore.CoreFoundation {
 		// You must invoke ->CleanupBlock after you have transferred ownership to
 		// the unmanaged code to release the resources allocated on the managed side
 		//
+		[LinkerOptimize]
 		public static unsafe void Invoke (Action codeToRun, Action<IntPtr> invoker)
 		{
 			BlockLiteral *block_ptr;

--- a/src/CoreText/CTLine.cs
+++ b/src/CoreText/CTLine.cs
@@ -233,6 +233,7 @@ namespace XamCore.CoreText {
 		}
 
 		public delegate void CaretEdgeEnumerator (double offset, nint charIndex, bool leadingEdge, ref bool stop);
+		[UserDelegateType (typeof (CaretEdgeEnumerator))]
 		unsafe delegate void CaretEdgeEnumeratorProxy (IntPtr block, double offset, nint charIndex, [MarshalAs (UnmanagedType.I1)] bool leadingEdge, [MarshalAs (UnmanagedType.I1)] ref bool stop);
 		
 		[iOS (9,0)][Mac (10,11)]
@@ -251,6 +252,7 @@ namespace XamCore.CoreText {
  		}
 		
 		[iOS (9,0)][Mac (10,11)]
+		[LinkerOptimize]
 		public void EnumerateCaretOffsets (CaretEdgeEnumerator enumerator)
 		{
 			if (enumerator == null)

--- a/src/Foundation/NSAutoreleasePool.cs
+++ b/src/Foundation/NSAutoreleasePool.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Reflection;
 using System.Collections;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 using XamCore.ObjCRuntime;
@@ -39,6 +40,7 @@ namespace XamCore.Foundation {
 		public override IntPtr ClassHandle { get { return Class.GetHandle ("NSAutoreleasePool"); } }
 
 		[Export ("init")]
+		[CompilerGenerated] // Makes the linker optimize this method
 		public NSAutoreleasePool () : base (NSObjectFlag.Empty)
 		{
 			IsDirectBinding = GetType () == typeof (NSAutoreleasePool);
@@ -50,9 +52,19 @@ namespace XamCore.Foundation {
 
 		}
 
-		public NSAutoreleasePool (NSObjectFlag t) : base (t) {}
+#if XAMCORE_4_0
+		protected
+#else
+		public
+#endif
+		NSAutoreleasePool (NSObjectFlag t) : base (t) {}
 
-		public NSAutoreleasePool (IntPtr handle) : base (handle) {}
+#if XAMCORE_4_0
+		protected
+#else
+		public
+#endif
+		NSAutoreleasePool (IntPtr handle) : base (handle) {}
 
 #if !XAMCORE_2_0
 		protected override void Dispose (bool disposing) {

--- a/src/Metal/MTLDevice.cs
+++ b/src/Metal/MTLDevice.cs
@@ -64,6 +64,7 @@ namespace XamCore.Metal {
 		unsafe static extern IntPtr MTLCopyAllDevicesWithObserver (ref IntPtr observer, void* handler);
 
 		[Mac (10, 13, onlyOn64: true), NoiOS, NoWatch, NoTV]
+		[LinkerOptimize]
 		public static IMTLDevice [] GetAllDevices (ref NSObject observer, MTLDeviceNotificationHandler handler)
 		{
 			if (observer == null)

--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -78,7 +78,7 @@ namespace XamCore.Registrar
 	class DynamicRegistrar : Registrar
 	{
 		Dictionary<IntPtr, ObjCType> type_map;
-		Dictionary <string, object> registered_assemblies; // Use Dictionary instead of HashSet to avoid pulling in System.Core.dll.
+		static Dictionary<string, object> registered_assemblies; // Use Dictionary instead of HashSet to avoid pulling in System.Core.dll.
 
 		// custom_type_map can be accessed from multiple threads, and at the
 		// same time mutated by the registrar, so any accesses needs to be locked
@@ -100,7 +100,7 @@ namespace XamCore.Registrar
 			return registered_assemblies != null && registered_assemblies.ContainsKey (GetAssemblyName (assembly));
 		}
 
-		public void SetAssemblyRegistered (string assembly)
+		public static void SetAssemblyRegistered (string assembly)
 		{
 			if (registered_assemblies == null)
 				registered_assemblies = new Dictionary<string, object> ();
@@ -143,24 +143,6 @@ namespace XamCore.Registrar
 		protected override bool Is64Bits {
 			get {
 				return IntPtr.Size == 8;
-			}
-		}
-
-		protected override bool IsDualBuildImpl {
-			get {
-				return NSObject.PlatformAssembly.GetName ().Name == 
-#if MONOMAC
-					"Xamarin.Mac";
-#elif TVOS
-					"Xamarin.TVOS";
-#elif WATCH
-					"Xamarin.WatchOS";
-#elif IOS
-					"Xamarin.iOS";
-#else
-	#error unknown platform
-					"unknown platform";
-#endif
 			}
 		}
 
@@ -623,7 +605,7 @@ namespace XamCore.Registrar
 		{
 			isNativeEnum = false;
 			if (type.IsEnum)
-				isNativeEnum = IsDualBuildImpl && type.IsDefined (typeof (NativeAttribute), false);
+				isNativeEnum = IsDualBuild && type.IsDefined (typeof (NativeAttribute), false);
 			return type.IsEnum;
 		}
 
@@ -988,9 +970,9 @@ namespace XamCore.Registrar
 					bool is_custom_type;
 					var tp = Class.FindType (@class, out is_custom_type);
 					if (tp != null) {
-						type = RegisterType (tp);
-						if (is_custom_type)
-							AddCustomType (tp);
+						//type = RegisterType (tp);
+						//if (is_custom_type)
+							//AddCustomType (tp);
 						return tp;
 					}
 

--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -19,17 +19,18 @@ using XamCore.ObjCRuntime;
 using XamCore.UIKit;
 #endif
 
-namespace XamCore.Registrar {
+namespace XamCore.Registrar
+{
 	// Somewhere to put shared code between the old and the new dynamic registrars.
 	// Putting code in either of those classes will increase the executable size,
 	// since unused code will be pulled in by the linker.
-	static class SharedDynamic {
+	static class SharedDynamic
+	{
 		public static Dictionary<MethodBase, List<MethodBase>> PrepareInterfaceMethodMapping (Type type)
 		{
 			Dictionary<MethodBase, List<MethodBase>> rv = null;
-			var ifaces = type.FindInterfaces ((v, o) =>
-			                                  {
-				var attribs = v.GetCustomAttributes (typeof(ProtocolAttribute), true);
+			var ifaces = type.FindInterfaces ((v, o) => {
+				var attribs = v.GetCustomAttributes (typeof (ProtocolAttribute), true);
 				return attribs != null && attribs.Length > 0;
 			}, null);
 
@@ -55,7 +56,7 @@ namespace XamCore.Registrar {
 
 			return rv;
 		}
-		
+
 		public static T GetOneAttribute<T> (ICustomAttributeProvider provider) where T : Attribute
 		{
 			var attribs = provider.GetCustomAttributes (typeof (T), false);
@@ -74,7 +75,8 @@ namespace XamCore.Registrar {
 		}
 	}
 
-	class DynamicRegistrar : Registrar {
+	class DynamicRegistrar : Registrar
+	{
 		Dictionary<IntPtr, ObjCType> type_map;
 		Dictionary <string, object> registered_assemblies; // Use Dictionary instead of HashSet to avoid pulling in System.Core.dll.
 
@@ -83,14 +85,14 @@ namespace XamCore.Registrar {
 		// so that it's not queried and mutated at the same time from multiple threads.
 		// Note that the registrar is already making sure it's not _mutated_ from
 		// multiple threads at the same time.
-		Dictionary <Type, object> custom_type_map; // Use Dictionary instead of HashSet to avoid pulling in System.Core.dll.
+		Dictionary<Type, object> custom_type_map; // Use Dictionary instead of HashSet to avoid pulling in System.Core.dll.
 
 		protected object lock_obj = new object ();
 
 		public DynamicRegistrar ()
 		{
 			type_map = new Dictionary<IntPtr, ObjCType> (Runtime.IntPtrEqualityComparer);
-			custom_type_map = new Dictionary <Type, object> (Runtime.TypeEqualityComparer);
+			custom_type_map = new Dictionary<Type, object> (Runtime.TypeEqualityComparer);
 		}
 
 		protected override bool SkipRegisterAssembly (Assembly assembly)

--- a/src/ObjCRuntime/LinkerOptimizeAttribute.cs
+++ b/src/ObjCRuntime/LinkerOptimizeAttribute.cs
@@ -1,0 +1,12 @@
+//
+// LinkerOptimize.cs: Apply this to methods to tell the linker to optimize them
+//
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace XamCore.ObjCRuntime {
+
+	[AttributeUsage (AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor | AttributeTargets.Field, AllowMultiple = false)]
+	public class LinkerOptimizeAttribute : Attribute { }
+}

--- a/src/ObjCRuntime/Protocol.cs
+++ b/src/ObjCRuntime/Protocol.cs
@@ -69,6 +69,12 @@ namespace XamCore.ObjCRuntime {
 		internal extern static IntPtr objc_getProtocol (string name);
 
 		[DllImport ("/usr/lib/libobjc.dylib")]
+		internal extern static IntPtr objc_getProtocol (IntPtr ptr);
+
+		[DllImport ("/usr/lib/libobjc.dylib")]
+		internal extern static bool protocol_conformsToProtocol (IntPtr proto, IntPtr other);
+
+		[DllImport ("/usr/lib/libobjc.dylib")]
 		internal extern static IntPtr objc_allocateProtocol (string name);
 
 		[DllImport ("/usr/lib/libobjc.dylib")]

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -31,12 +31,12 @@ using TProperty=Mono.Cecil.PropertyDefinition;
 using TField=Mono.Cecil.FieldDefinition;
 using R=XamCore.Registrar.Registrar;
 #else
-using TAssembly=System.Reflection.Assembly;
-using TType=System.Type;
-using TMethod=System.Reflection.MethodBase;
-using TProperty=System.Reflection.PropertyInfo;
-using TField=System.Reflection.FieldInfo;
-using R=XamCore.ObjCRuntime.Runtime;
+using TAssembly = System.Reflection.Assembly;
+using TType = System.Type;
+using TMethod = System.Reflection.MethodBase;
+using TProperty = System.Reflection.PropertyInfo;
+using TField = System.Reflection.FieldInfo;
+using R = XamCore.ObjCRuntime.Runtime;
 #endif
 
 #if MONOTOUCH
@@ -45,7 +45,7 @@ using Xamarin.Bundler;
 using ProductException=Xamarin.Bundler.MonoTouchException;
 #else
 #if XAMCORE_2_0
-using ProductException=ObjCRuntime.RuntimeException;
+using ProductException = ObjCRuntime.RuntimeException;
 #else
 using ProductException=MonoTouch.RuntimeException;
 #endif
@@ -80,9 +80,11 @@ namespace XamCore.ObjCRuntime
 }
 #endif
 
-namespace XamCore.Registrar {
-	static class Shared {
-		
+namespace XamCore.Registrar
+{
+	static class Shared
+	{
+
 		public static ProductException GetMT4127 (TMethod impl, List<TMethod> ifaceMethods)
 		{
 			var msg = new System.Text.StringBuilder ();
@@ -100,13 +102,14 @@ namespace XamCore.Registrar {
 		}
 	}
 
-	abstract partial class Registrar {
+	abstract partial class Registrar
+	{
 #if MTOUCH || MMP
 		public Application App { get; protected set; }
 #endif
 
 		Dictionary<TAssembly, object> assemblies = new Dictionary<TAssembly, object> (); // Use Dictionary instead of HashSet to avoid pulling in System.Core.dll.
-		// locking: all accesses must lock 'types'.
+												 // locking: all accesses must lock 'types'.
 		Dictionary<TType, ObjCType> types = new Dictionary<TType, ObjCType> ();
 		// this is used to check if multiple types are registered with the same name.
 		// locking: all accesses must lock 'type_map'.

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -123,7 +123,19 @@ namespace XamCore.Registrar
 		TMethod conforms_to_protocol;
 		TMethod invoke_conforms_to_protocol;
 
-		public static bool IsDualBuild { get; private set; }
+#if MONOMAC
+#if MMP
+		public static bool IsDualBuild { get { return Xamarin.Bundler.Driver.IsUnified; } }
+#else
+#if XAMCORE_2_0
+		public const bool IsDualBuild = true;
+#else
+		public const bool IsDualBuild = false;
+#endif // XAMCORE_2_0
+#endif // MMP
+#else
+		public const bool IsDualBuild = true;
+#endif // MONOMAC
 
 		public IEnumerable<TAssembly> GetAssemblies ()
 		{
@@ -145,6 +157,8 @@ namespace XamCore.Registrar
 			public bool IsGeneric;
 #if !MTOUCH && !MMP
 			public IntPtr Handle;
+#else
+			public TType ProtocolWrapperType;
 #endif
 
 			public Dictionary<string, ObjCField> Fields;
@@ -985,6 +999,7 @@ namespace XamCore.Registrar
 		}
 
 		protected virtual void OnRegisterType (ObjCType type) {}
+		protected virtual void OnSkipType (TType type, ObjCType registered_type) { }
 		protected virtual void OnReloadType (ObjCType type) {}
 		protected virtual void OnRegisterProtocol (ObjCType type) {}
 		protected virtual void OnRegisterCategory (ObjCType type, ref List<Exception> exceptions) {}
@@ -999,6 +1014,7 @@ namespace XamCore.Registrar
 		protected abstract bool ContainsPlatformReference (TAssembly assembly); // returns true if the assembly is monotouch.dll too.
 		protected abstract TType GetBaseType (TType type); // for generic parameters it returns the first specific class constraint.
 		protected abstract TType[] GetInterfaces (TType type); // may return interfaces from base classes as well. May return null if no interfaces found.
+		protected virtual TType [] GetLinkedAwayInterfaces (TType type) { return null; } // may NOT return interfaces from base classes as well. May return null if no interfaces found.
 		protected abstract TMethod GetBaseMethod (TMethod method);
 		protected abstract TType[] GetParameters (TMethod method);
 		protected abstract string GetParameterName (TMethod method, int parameter_index);
@@ -1050,7 +1066,6 @@ namespace XamCore.Registrar
 		protected abstract bool IsCorlibType (TType type);
 		protected abstract bool IsSimulatorOrDesktop { get; }
 		protected abstract bool Is64Bits { get; }
-		protected abstract bool IsDualBuildImpl { get; }
 		protected abstract Exception CreateException (int code, Exception innerException, TMethod method, string message, params object[] args);
 		protected abstract Exception CreateException (int code, Exception innerException, TType type, string message, params object [] args);
 		protected abstract string PlatformName { get; }
@@ -1070,11 +1085,6 @@ namespace XamCore.Registrar
 		// This is just to support the single-file/partial build registration
 		// used for Xamarin.iOS.dll.
 		protected virtual bool LaxMode { get { return false; } }
-
-		public Registrar ()
-		{
-			IsDualBuild = IsDualBuildImpl;
-		}
 
 		protected bool IsArray (TType type)
 		{
@@ -1595,6 +1605,8 @@ namespace XamCore.Registrar
 			// return interfaces from all base classes as well.
 			// We only want the interfaces declared on this type.
 
+			// Additionally it may return interface implementations that were linked away.
+
 			// This function will return arrays with null entries.
 
 			var type = objcType.Type;
@@ -1626,18 +1638,38 @@ namespace XamCore.Registrar
 		ObjCType [] GetProtocols (ObjCType type, ref List<Exception> exceptions)
 		{
 			var interfaces = GetInterfacesImpl (type);
-			if (interfaces == null || interfaces.Length == 0)
-				return null;
-
-			var protocolList = new List<ObjCType> (interfaces.Length);
-			for (int i = 0; i < interfaces.Length; i++) {
-				if (interfaces [i] == null)
-					continue;
-				var baseP = RegisterTypeUnsafe (interfaces [i], ref exceptions);
-				if (baseP != null)
-					protocolList.Add (baseP);
+			List<ObjCType> protocolList = null;
+			if (interfaces?.Length > 0) {
+				protocolList = new List<ObjCType> (interfaces.Length);
+				for (int i = 0; i < interfaces.Length; i++) {
+					if (interfaces [i] == null)
+						continue;
+					var baseP = RegisterTypeUnsafe (interfaces [i], ref exceptions);
+					if (baseP != null)
+						protocolList.Add (baseP);
+				}
 			}
-			if (protocolList.Count == 0)
+			var linkedAwayInterfaces = GetLinkedAwayInterfaces (type.Type);
+			if (linkedAwayInterfaces?.Length > 0) {
+				if (protocolList == null)
+					protocolList = new List<ObjCType> ();
+				foreach (var iface in linkedAwayInterfaces) {
+					if (!HasProtocolAttribute (iface))
+						continue;
+					var objcType = new ObjCType () {
+						Registrar = this,
+						Type = iface,
+						IsProtocol = true,
+					};
+#if MMP || MTOUCH
+					objcType.ProtocolWrapperType = GetProtocolAttributeWrapperType (objcType.Type);
+					objcType.IsWrapper = objcType.ProtocolWrapperType != null;
+#endif
+
+					protocolList.Add (objcType);
+				}
+			}
+			if (protocolList == null || protocolList.Count == 0)
 				return null;
 			return protocolList.ToArray ();
 		}
@@ -1810,8 +1842,10 @@ namespace XamCore.Registrar
 			}
 
 			var register_attribute = GetRegisterAttribute (type);
-			if (register_attribute != null && register_attribute.SkipRegistration)
+			if (register_attribute != null && register_attribute.SkipRegistration) {
+				OnSkipType (type, baseObjCType);
 				return baseObjCType;
+			}
 
 			objcType = new ObjCType () {
 				Registrar = this,
@@ -1824,6 +1858,9 @@ namespace XamCore.Registrar
 			objcType.VerifyRegisterAttribute (ref exceptions);
 			objcType.Protocols = GetProtocols (objcType, ref exceptions);
 			objcType.BaseType = isProtocol ? null : (baseObjCType ?? objcType);
+#if MMP || MTOUCH
+			objcType.ProtocolWrapperType = (isProtocol && !isInformalProtocol) ? GetProtocolAttributeWrapperType (objcType.Type) : null;
+#endif
 			objcType.IsWrapper = (isProtocol && !isInformalProtocol) ? (GetProtocolAttributeWrapperType (objcType.Type) != null) : (objcType.RegisterAttribute != null && objcType.RegisterAttribute.IsWrapper);
 
 			if (!objcType.IsWrapper && objcType.BaseType != null)
@@ -2295,10 +2332,10 @@ namespace XamCore.Registrar
 				lock (this.types) {
 					foreach (TType type in types) {
 						//Trace (" Checking {0}", GetTypeFullName (type));
-						if (HasModelAttribute (type)) {
-							Trace ("{0} is a model: not registering it", GetTypeFullName (type));
-							continue;
-						}
+						//if (HasModelAttribute (type)) {
+						//	Trace ("{0} is a model: not registering it", GetTypeFullName (type));
+						//	continue;
+						//}
 
 						RegisterTypeUnsafe (type, ref exceptions);
 					}
@@ -2322,10 +2359,9 @@ namespace XamCore.Registrar
 
 		public string ComputeSignature (TType DeclaringType, TMethod Method, ObjCMember member = null, bool isCategoryInstance = false, bool isBlockSignature = false)
 		{
-			var success = true;
-			var signature = new StringBuilder ();
 			bool is_ctor;
 			var method = member as ObjCMethod;
+			TType return_type = null;
 
 			if (Method != null) {
 				is_ctor = IsConstructor (Method);
@@ -2333,16 +2369,8 @@ namespace XamCore.Registrar
 				is_ctor = method.IsConstructor;
 			}
 
-			if (is_ctor) {
-				signature.Append ('@');
-			} else {
-				var ReturnType = Method != null ? GetReturnType (Method) : method.NativeReturnType;
-				signature.Append (ToSignature (ReturnType, member, ref success));
-				if (!success)
-					throw CreateException (4104, Method ?? method.Method, "The registrar cannot marshal the return value of type `{0}` in the method `{1}.{2}`.", GetTypeFullName (ReturnType), GetTypeFullName (DeclaringType), GetDescriptiveMethodName (Method ?? method.Method));
-			}
-
-			signature.Append (isBlockSignature ? "@?" : "@:");
+			if (!is_ctor)
+				return_type = Method != null ? GetReturnType (Method) : method.NativeReturnType;
 
 			TType[] parameters;
 			if (Method != null) {
@@ -2350,6 +2378,26 @@ namespace XamCore.Registrar
 			} else {
 				parameters = method.NativeParameters;
 			}
+
+			return ComputeSignature (DeclaringType, is_ctor, return_type, parameters, Method, member, isCategoryInstance, isBlockSignature);
+		}
+
+		public string ComputeSignature (TType declaring_type, bool is_ctor, TType return_type, TType [] parameters, TMethod mi = null, ObjCMember member = null, bool isCategoryInstance = false, bool isBlockSignature = false)
+		{
+			var success = true;
+			var signature = new StringBuilder ();
+			if (mi == null)
+				mi = (member as ObjCMethod)?.Method;
+			
+			if (is_ctor) {
+				signature.Append ('@');
+			} else {
+				signature.Append (ToSignature (return_type, member, ref success));
+				if (!success)
+					throw CreateException (4104, mi, "The registrar cannot marshal the return value of type `{0}` in the method `{1}.{2}`.", GetTypeFullName (return_type), GetTypeFullName (declaring_type), GetDescriptiveMethodName (mi));
+			}
+
+			signature.Append (isBlockSignature ? "@?" : "@:");
 
 			if (parameters != null) {
 				for (int i = 0; i < parameters.Length; i++) {
@@ -2363,15 +2411,13 @@ namespace XamCore.Registrar
 						signature.Append (ToSignature (type, member, ref success));
 					}
 					if (!success) {
-						var mi = Method ?? method.Method;
 						throw CreateException (4136, mi, "The registrar cannot marshal the parameter type '{0}' of the parameter '{1}' in the method '{2}.{3}'",
-							GetTypeFullName (GetParameters (mi) [i]), GetParameterName (mi, i), GetTypeFullName (DeclaringType), GetDescriptiveMethodName (mi));
+							GetTypeFullName (parameters [i]), GetParameterName (mi, i), GetTypeFullName (declaring_type), GetDescriptiveMethodName (mi));
 					}
 				}
 			}
 			return signature.ToString ();
 		}
-
 		protected string ToSignature (TType type, ObjCMember member, bool forProperty = false)
 		{
 			bool success = true;

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -54,17 +54,43 @@ namespace XamCore.ObjCRuntime {
 		internal unsafe struct MTRegistrationMap {
 			public IntPtr assembly;
 			public MTClassMap *map;
+			public MTProtocolMap* protocol_map;
+			public MTProtocolWrapperMap* protocol_wrapper_map;
 			public IntPtr full_token_references; /* array of MTFullTokenReference */
+			public MTManagedClassMap* skipped_map;
 			public int assembly_count;
 			public int map_count;
 			public int custom_type_count;
+			public int protocol_count;
+			public int protocol_wrapper_count;
 			public int full_token_reference_count;
+			public int skipped_map_count;
 		}
 
 		[StructLayout (LayoutKind.Sequential, Pack = 1)]
 		internal struct MTClassMap {
 			public IntPtr handle;
 			public uint type_reference;
+		}
+
+		[StructLayout (LayoutKind.Sequential, Pack = 1)]
+		internal struct MTManagedClassMap
+		{
+			public uint skipped_reference; // implied token type: TypeDef
+			public uint actual_reference; // implied token type: TypeDef
+		}
+
+		[StructLayout (LayoutKind.Sequential, Pack = 1)]
+		internal struct MTProtocolMap {
+			public uint token;
+			public uint protocol_count;
+			public IntPtr protocols; // array of char*.
+		}
+
+		[StructLayout (LayoutKind.Sequential, Pack = 1)]
+		internal struct MTProtocolWrapperMap {
+			public uint protocol_token;
+			public uint wrapper_token;
 		}
 
 		/* Keep Delegates, Trampolines and InitializationOptions in sync with monotouch-glue.m */
@@ -92,6 +118,7 @@ namespace XamCore.ObjCRuntime {
 			public IntPtr set_gchandle_tramp;
 		}
 
+		[Flags]
 		internal enum InitializationFlags : int {
 			/* unused               = 0x01 */
 			/* unused				= 0x02,*/
@@ -133,6 +160,19 @@ namespace XamCore.ObjCRuntime {
 
 		internal static unsafe InitializationOptions* options;
 
+		[LinkerOptimize]
+		public static bool DynamicRegistrationSupported {
+			get {
+				// The linker will turn calls to this property into a constant, and for if blocks remove the resulting dead code.
+				//
+				// The value is false if both these conditions are true:
+				// * The static registrar is selected
+				// * No Runtime.ConnectMethod overloads are used anywhere.
+				// * No BlockLiteral.SetupBlock calls anywhere (the linker can rewrite some BlockLiteral.SetupBlock calls so that they do not count, but not always).
+				return true;
+			}
+		}
+
 		internal static bool Initialized {
 			get { return initialized; }
 		}
@@ -143,6 +183,7 @@ namespace XamCore.ObjCRuntime {
 #endif
 
 		[Preserve] // called from native - runtime.m.
+		[LinkerOptimize] // To inline the Runtime.DynamicRegistrationSupported code if possible.
 		unsafe static void Initialize (InitializationOptions* options)
 		{
 #if PROFILE
@@ -205,7 +246,9 @@ namespace XamCore.ObjCRuntime {
 
 			NSObjectClass = NSObject.Initialize ();
 
-			Registrar = new DynamicRegistrar ();
+			// The linker will remove this condition (and the subsequent new call) if possible
+			if (DynamicRegistrationSupported)
+				Registrar = new DynamicRegistrar ();
 			RegisterDelegates (options);
 			Class.Initialize (options);
 			InitializePlatform (options);
@@ -402,9 +445,9 @@ namespace XamCore.ObjCRuntime {
 			return ObjectWrapper.Convert (CreateBlockProxy ((MethodInfo) ObjectWrapper.Convert (method), block));
 		}
 			
-		static IntPtr CreateDelegateProxy (IntPtr method, IntPtr @delegate)
+		static IntPtr CreateDelegateProxy (IntPtr method, IntPtr @delegate, IntPtr signature)
 		{
-			return BlockLiteral.GetBlockForDelegate ((MethodInfo) ObjectWrapper.Convert (method), ObjectWrapper.Convert (@delegate));
+			return BlockLiteral.GetBlockForDelegate ((MethodInfo) ObjectWrapper.Convert (method), ObjectWrapper.Convert (@delegate), Marshal.PtrToStringAuto (signature));
 		}
 
 		static unsafe Assembly GetEntryAssembly ()
@@ -571,16 +614,6 @@ namespace XamCore.ObjCRuntime {
 		static IntPtr GetSelector (IntPtr sel)
 		{
 			return ObjectWrapper.Convert (new Selector (sel));
-		}
-
-		static IntPtr GetClassHandle (IntPtr klass)
-		{
-			return ((Class) ObjectWrapper.Convert (klass)).Handle;
-		}
-
-		static IntPtr GetSelectorHandle (IntPtr sel)
-		{
-			return ((Selector) ObjectWrapper.Convert (sel)).Handle;
 		}
 
 		static void GetMethodForSelector (IntPtr cls, IntPtr sel, bool is_static, IntPtr desc)
@@ -1310,20 +1343,44 @@ namespace XamCore.ObjCRuntime {
 			return ConstructINativeObject<T> (ptr, owns, implementation, MissingCtorResolution.ThrowConstructor2NotFound);
 		}
 
+		static Type FindProtocolWrapperTypeDynamic (Type type)
+		{
+			// need to look up the type from the ProtocolAttribute.
+			var a = type.GetCustomAttributes (typeof (XamCore.Foundation.ProtocolAttribute), false);
+			var attr = (XamCore.Foundation.ProtocolAttribute) (a.Length > 0 ? a [0] : null);
+			return attr?.WrapperType;
+		}
+
+		[LinkerOptimize]
 		private static Type FindProtocolWrapperType (Type type)
 		{
 			if (type == null || !type.IsInterface)
 				return null;
 
-			// need to look up the type from the ProtocolAttribute.
-			var a = type.GetCustomAttributes (typeof (XamCore.Foundation.ProtocolAttribute), false);
+			if (DynamicRegistrationSupported) {
+				// Use a separate method for the logic in FindProtocolWrapperTypeDynamic, because it uses ProtocolAttribute,
+				// and even if the linker is able to remove this chunk of code, it's not able to remove the local
+				// variable (of type ProtocolAttribute), which means the ProtocolAttribute type won't be linked away.
+				// By using a separate method the linker will remove the entire method once the code below is optimized away.
+				var rv = FindProtocolWrapperTypeDynamic (type);
+				if (rv != null)
+					return rv;
+			}
 
-			var attr = (XamCore.Foundation.ProtocolAttribute) (a.Length > 0 ? a [0] : null);
-			if (attr == null || attr.WrapperType == null)
-				throw ErrorHelper.CreateError (4125, "The registrar found an invalid interface '{0}': " +
-					"The interface must have a Protocol attribute specifying its wrapper type.",
-					type.FullName);
-			return attr.WrapperType;
+			var token = Class.GetTokenReference (type);
+			unsafe {
+				var map = options->RegistrationMap;
+				// FIXME: binary search
+				for (int i = 0; i < map->protocol_wrapper_count; i++) {
+					var entry = map->protocol_wrapper_map [i];
+					if (entry.protocol_token == token)
+						return (Type) Class.ResolveTokenReference (entry.wrapper_token, 0x02000000 /* TypeDef */);
+				}
+			}
+
+			throw ErrorHelper.CreateError (4125, "The registrar found an invalid interface '{0}': " +
+				"The interface must have a Protocol attribute specifying its wrapper type.",
+				type.FullName);
 		}
 
 		public static IntPtr GetProtocol (string protocol)
@@ -1338,7 +1395,8 @@ namespace XamCore.ObjCRuntime {
 
 			ConnectMethod (type, method, new ExportAttribute (selector.Name));
 		}
-			
+
+		[LinkerOptimize]
 		public static void ConnectMethod (Type type, MethodInfo method, ExportAttribute export)
 		{
 			if (type == null)
@@ -1349,6 +1407,9 @@ namespace XamCore.ObjCRuntime {
 
 			if (export == null)
 				throw new ArgumentNullException ("export");
+
+			if (!DynamicRegistrationSupported)
+				throw ErrorHelper.CreateError (8025, "Runtime.ConnectMethod is not supported when the dynamic registrar has been linked away.");
 
 			Registrar.RegisterMethod (type, method, export);
 		}
@@ -1426,6 +1487,60 @@ namespace XamCore.ObjCRuntime {
 
 		[DllImport (Constants.libSystemLibrary)]
 		unsafe extern internal static void memcpy (byte * target, byte * source, nint n);
+
+		// This function will try to compare a native UTF8 string to a managed string without creating a temporary managed string for the native UTF8 string.
+		// Currently this only works if the UTF8 string only contains single-byte characters.
+		internal static bool StringEquals (IntPtr utf8, string str)
+		{
+			// The vast majority of strings we compare fall within the single-byte UTF8 range, so optimize for this
+			unsafe {
+				byte* c = (byte*) utf8;
+				for (int i = 0; i < str.Length; i++) {
+					byte b = c [i];
+					if (b > 0x7F) {
+						// This string is a multibyte UTF8 string, so go the slow route and convert it to a managed string before comparison
+						return string.Equals (Marshal.PtrToStringUTF8 (utf8), str);
+					}
+					if (b != (short) str [i])
+						return false;
+				}
+				return c [str.Length] == 0;
+			}
+		}
+
+		internal static bool ConformsToProtocol (Type type, IntPtr protocol, bool recursive = false)
+		{
+			var token = Class.GetTokenReference (type);
+			unsafe {
+				var map = options->RegistrationMap;
+				for (int i = 0; i < map->protocol_count; i++) {
+					MTProtocolMap pmap = map->protocol_map [i];
+					if (pmap.token != token)
+						continue;
+
+					for (var p = 0; p < pmap.protocol_count; p++) {
+						var pnameptr = Marshal.ReadIntPtr (pmap.protocols, p * IntPtr.Size);
+						var phandle = Protocol.objc_getProtocol (pnameptr);
+						if (phandle == IntPtr.Zero)
+							throw new NotImplementedException (); // FIXME
+						if (phandle == protocol)
+							return true;
+						if (Protocol.protocol_conformsToProtocol (phandle, protocol))
+							return true; // FIXME: add tests
+					}
+
+					break;
+				}
+			}
+
+			if (!recursive)
+				return false;
+
+			if (type == typeof (NSObject))
+				return false;
+
+			return ConformsToProtocol (type.BaseType, protocol, recursive);
+		}
 	}
 		
 	internal class IntPtrEqualityComparer : IEqualityComparer<IntPtr>

--- a/src/Security/SecSharedCredential.cs
+++ b/src/Security/SecSharedCredential.cs
@@ -18,6 +18,7 @@ namespace XamCore.Security {
 			IntPtr /* void (^completionHandler)( CFErrorRef error) ) */ completionHandler);
 			
 		[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
+		[UserDelegateType (typeof (global::System.Action<NSError>))]
 		internal delegate void DActionArity1V12 (IntPtr block, IntPtr obj);
 		
 		// This class bridges native block invocations that call into C#
@@ -35,6 +36,7 @@ namespace XamCore.Security {
 		} 
 
 		[iOS (8,0)]
+		[LinkerOptimize]
 		public static void AddSharedWebCredential (string domainName, string account, string password, Action<NSError> handler)
 		{
 			if (domainName == null)
@@ -70,6 +72,7 @@ namespace XamCore.Security {
 			IntPtr /* void (^completionHandler)( CFArrayRef credentials, CFErrorRef error) */ completionHandler);
 
 		[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
+		[UserDelegateType (typeof (global::System.Action<NSArray, NSError>))]
 		internal delegate void ArrayErrorAction (IntPtr block, IntPtr array, IntPtr err);
 
 		//
@@ -97,6 +100,7 @@ namespace XamCore.Security {
 #endif
 
 		[iOS (8,0)]
+		[LinkerOptimize]
 		public static void RequestSharedWebCredential (string domainName, string account, Action<SecSharedCredentialInfo[], NSError> handler)
 		{
 			Action<NSArray, NSError> onComplete = (NSArray a, NSError e) => {

--- a/src/UIKit/UIAccessibility.cs
+++ b/src/UIKit/UIAccessibility.cs
@@ -196,6 +196,7 @@ namespace XamCore.UIKit {
 		extern unsafe static void UIAccessibilityRequestGuidedAccessSession (/* BOOL */ bool enable, /* void(^completionHandler)(BOOL didSucceed) */ void * completionHandler);
 
 		[iOS (7,0)]
+		[LinkerOptimize]
 		public static void RequestGuidedAccessSession (bool enable, Action<bool> completionHandler)
 		{
 			unsafe {
@@ -219,7 +220,8 @@ namespace XamCore.UIKit {
 			});
 			return tcs.Task;
 		}
-		
+
+		[UserDelegateType  (typeof (Action<bool>))]
 		internal delegate void InnerRequestGuidedAccessSession (IntPtr block, bool enable);
 		static readonly InnerRequestGuidedAccessSession callback = TrampolineRequestGuidedAccessSession;
 

--- a/src/VideoToolbox/VTCompressionSession.cs
+++ b/src/VideoToolbox/VTCompressionSession.cs
@@ -263,6 +263,7 @@ namespace XamCore.VideoToolbox {
 		}
 
 		[Mac (10,11), iOS (9,0)]
+		[LinkerOptimize]
 		public VTStatus EncodeFrame (CVImageBuffer imageBuffer, CMTime presentationTimestamp, CMTime duration,
 			NSDictionary frameProperties, IntPtr sourceFrame, out VTEncodeInfoFlags infoFlags,
 			VTCompressionOutputHandler outputHandler)

--- a/src/VideoToolbox/VTDecompressionSession.cs
+++ b/src/VideoToolbox/VTDecompressionSession.cs
@@ -256,6 +256,7 @@ namespace XamCore.VideoToolbox {
 		}
 
 		[Mac (10,11), iOS (9,0)]
+		[LinkerOptimize]
 		public VTStatus DecodeFrame (CMSampleBuffer sampleBuffer, VTDecodeFrameFlags decodeFlags,
 			out VTDecodeInfoFlags infoFlags, VTDecompressionOutputHandler outputHandler)
 		{

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -3123,7 +3123,7 @@ namespace XamCore.AVFoundation {
 
 	interface IAVCaptureDataOutputSynchronizerDelegate {}
 	
-	[NoWatch, NoTV, iOS (11,0)]
+	[NoWatch, NoTV, iOS (11,0), NoMac]
 	[Protocol, Model]
 	[BaseType (typeof(NSObject))]
 	interface AVCaptureDataOutputSynchronizerDelegate
@@ -3133,7 +3133,7 @@ namespace XamCore.AVFoundation {
 		void DidOutputSynchronizedDataCollection (AVCaptureDataOutputSynchronizer synchronizer, AVCaptureSynchronizedDataCollection synchronizedDataCollection);
 	}
 
-	[NoWatch, NoTV, iOS (11,0)]
+	[NoWatch, NoTV, iOS (11,0), NoMac]
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
 	interface AVCaptureDataOutputSynchronizer

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1532,6 +1532,7 @@ SHARED_CORE_SOURCES = \
 	ObjCRuntime/Blocks.cs \
 	ObjCRuntime/Class.cs \
 	ObjCRuntime/INativeObject.cs \
+	ObjCRuntime/LinkerOptimizeAttribute.cs \
 	ObjCRuntime/LinkWithAttribute.cs \
 	ObjCRuntime/Messaging.iOS.cs \
 	ObjCRuntime/Messaging.mac.cs \

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -2914,6 +2914,7 @@ public partial class Generator : IMemberGatherer {
 					print ("");
 					// linker will remove the attributes (but it's useful for testing)
 					print ("[CompilerGenerated]");
+					print ("[LinkerOptimize]");
 					print ("{0} {1}{2} {3} {{",
 					       is_internal ? "internal" : "public",
 					       propertyType,
@@ -3040,6 +3041,9 @@ public partial class Generator : IMemberGatherer {
 		for (int i=0; i < tabs; i++)
 			sw.Write ('\t');
 		sw.WriteLine ("[CompilerGenerated]");
+		for (int i = 0; i < tabs; i++)
+			sw.Write ('\t');
+		sw.WriteLine ("[LinkerOptimize]");
 	}
 
 	static void WriteIsDirectBindingCondition (StreamWriter sw, ref int tabs, bool? is_direct_binding, string is_direct_binding_value, Func<string> trueCode, Func<string> falseCode)
@@ -4596,6 +4600,7 @@ public partial class Generator : IMemberGatherer {
 				var_name = string.Format ("__mt_{0}_var{1}", pi.Name, minfo.is_static ? "_static" : "");
 
 				print ("[CompilerGenerated]");
+				print ("[LinkerOptimize]");
 
 				if (minfo.is_thread_static)
 					print ("[ThreadStatic]");
@@ -5436,7 +5441,7 @@ public partial class Generator : IMemberGatherer {
 			print_generated_code ();
 			PrintDelegateProxy (minfo);
 			PrintExport (minfo);
-			print ("[Preserve (Conditional = true)]");
+			//print ("[Preserve (Conditional = true)]");
 			if (minfo.is_unsafe)
 				mod = "unsafe ";
 			print ("{0}{1};", mod, MakeSignature (minfo, true));
@@ -5448,7 +5453,7 @@ public partial class Generator : IMemberGatherer {
 			var mod = string.Empty;
 			minfo.is_export = true;
 
-			print ("[Preserve (Conditional = true)]");
+			//print ("[Preserve (Conditional = true)]");
 
 			if (minfo.is_unsafe)
 				mod = "unsafe ";
@@ -6754,6 +6759,7 @@ public partial class Generator : IMemberGatherer {
 				var disposeAttr = AttributeManager.GetCustomAttributes<DisposeAttribute> (type);
 				if (disposeAttr.Length > 0 || instance_fields_to_clear_on_dispose.Count > 0){
 					print ("[CompilerGenerated]");
+					print ("[LinkerOptimize]");
 					print ("protected override void Dispose (bool disposing)");
 					print ("{");
 					indent++;

--- a/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/BlocksTest.cs
@@ -39,6 +39,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void TestSetupBlock ()
 		{
+			if (!Runtime.DynamicRegistrationSupported)
+				Assert.Ignore ("This test requires the dynamic registrar to be available.");
+
 			using (var obj = new TestClass ()) {
 				TestClass.OnCallback = ((IntPtr blockArgument, IntPtr self, IntPtr argument) => 
 					{

--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -73,6 +73,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		{
 			if (connectMethodTestDone)
 				Assert.Ignore ("This test can only be executed once, it modifies global state.");
+			if (!Runtime.DynamicRegistrationSupported)
+				Assert.Ignore ("This test requires support for dynamic registration.");
 			connectMethodTestDone = true;
 			// Bug 20013. This should not throw a KeyNotFoundException.
 			Runtime.ConnectMethod (typeof (ConnectMethodClass).GetMethod ("Method"), new Selector ("method"));
@@ -356,6 +358,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void ConnectMethod ()
 		{
+			if (!Runtime.DynamicRegistrationSupported)
+				Assert.Ignore ("This test requires support for dynamic registration.");
+			
 			var minfo = typeof (RuntimeTest).GetMethod ("ConnectMethod");
 			Assert.Throws<ArgumentNullException> (() => Runtime.ConnectMethod (null, new Selector ("")), "1");
 			Assert.Throws<ArgumentNullException> (() => Runtime.ConnectMethod (minfo, null), "2");
@@ -371,6 +376,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void ConnectMethod1 ()
 		{
+			if (!Runtime.DynamicRegistrationSupported)
+				Assert.Ignore ("This test requires support for dynamic registration.");
+			
 			if (connectMethod1Done)
 				Assert.Ignore ("This is a one-shot test. Restart to run again.");
 			connectMethod1Done = true;
@@ -385,6 +393,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void ConnectMethod2 ()
 		{
+			if (!Runtime.DynamicRegistrationSupported)
+				Assert.Ignore ("This test requires support for dynamic registration.");
+			
 			if (connectMethod2Done)
 				Assert.Ignore ("This is a one-shot test. Restart to run again.");
 			connectMethod2Done = true;
@@ -407,6 +418,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void ConnectMethod3 ()
 		{
+			if (!Runtime.DynamicRegistrationSupported)
+				Assert.Ignore ("This test requires support for dynamic registration.");
+			
 			if (connectMethod3Done)
 				Assert.Ignore ("This is a one-shot test. Restart to run again.");
 			connectMethod3Done = true;

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -25,12 +25,14 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>0</WarningLevel>
     <MtouchDebug>True</MtouchDebug>
-    <MtouchExtraArgs>-v -v -v -v</MtouchExtraArgs>
+    <MtouchExtraArgs>-v -v -v -v --registrar:static --linker-optimize:remove-dynamic-registrar</MtouchExtraArgs>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <MtouchArch>i386, x86_64</MtouchArch>
+    <MtouchArch>x86_64</MtouchArch>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <MtouchLink>None</MtouchLink>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <DeviceSpecificBuild>false</DeviceSpecificBuild>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>
@@ -56,11 +58,12 @@
     <MtouchDebug>True</MtouchDebug>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchExtraArgs>-v -v -v -v</MtouchExtraArgs>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARM64</MtouchArch>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <IpaPackageName>
     </IpaPackageName>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <DeviceSpecificBuild>false</DeviceSpecificBuild>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug64|iPhone' ">
     <DebugSymbols>True</DebugSymbols>
@@ -76,6 +79,7 @@
     <MtouchArch>ARM64</MtouchArch>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <DeviceSpecificBuild>false</DeviceSpecificBuild>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug32|iPhone' ">
     <DebugSymbols>True</DebugSymbols>
@@ -166,9 +170,6 @@
     <None Include="EmptyNib.xib" Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs" Exclude="obj\**">
-      <Link>%(RecursiveDir)%(Filename).cs</Link>
-    </Compile>
     <Compile Include="..\..\tests\test-libraries\TrampolineTest.generated.cs" />
     <Compile Include="..\..\tests\test-libraries\RegistrarTest.generated.cs" />
     <Compile Include="..\..\external\mono\mcs\class\System.Drawing\Test\System.Drawing\TestPoint.cs" Condition="$(TargetFrameworkIdentifier) != 'Xamarin.WatchOS'">
@@ -200,6 +201,1536 @@
     </Compile>
     <Compile Include="..\common\ConditionalCompilation.cs">
       <Link>ConditionalCompilation.cs</Link>
+    </Compile>
+    <Compile Include="AppDelegate.cs">
+      <Link>AppDelegate.cs</Link>
+    </Compile>
+    <Compile Include="Asserts.cs">
+      <Link>Asserts.cs</Link>
+    </Compile>
+    <Compile Include="Main.cs">
+      <Link>Main.cs</Link>
+    </Compile>
+    <Compile Include="NativeTypesTest.cs">
+      <Link>NativeTypesTest.cs</Link>
+    </Compile>
+    <Compile Include="ARKit\ARPointCloudTest.cs">
+      <Link>ARKit\ARPointCloudTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\AVAssetDownloadUrlSessionTests.cs">
+      <Link>AVFoundation\AVAssetDownloadUrlSessionTests.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\AVAssetImageGeneratorTest.cs">
+      <Link>AVFoundation\AVAssetImageGeneratorTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\AVAudioConverterPrimeInfoTest.cs">
+      <Link>AVFoundation\AVAudioConverterPrimeInfoTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\AVBeatRangeTest.cs">
+      <Link>AVFoundation\AVBeatRangeTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\AVCapturePhotoBracketSettingsTest.cs">
+      <Link>AVFoundation\AVCapturePhotoBracketSettingsTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\AVCaptureWhiteBalanceGainsTest.cs">
+      <Link>AVFoundation\AVCaptureWhiteBalanceGainsTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\AVDepthDataTests.cs">
+      <Link>AVFoundation\AVDepthDataTests.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\AVPlayerLooperTest.cs">
+      <Link>AVFoundation\AVPlayerLooperTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\AudioPlayerTest.cs">
+      <Link>AVFoundation\AudioPlayerTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\AudioRecorderTest.cs">
+      <Link>AVFoundation\AudioRecorderTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\CaptureDeviceTest.cs">
+      <Link>AVFoundation\CaptureDeviceTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\CaptureMetadataOutputTest.cs">
+      <Link>AVFoundation\CaptureMetadataOutputTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\MetadataObjectTest.cs">
+      <Link>AVFoundation\MetadataObjectTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\PlayerItemTest.cs">
+      <Link>AVFoundation\PlayerItemTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\PlayerItemVideoOutputTest.cs">
+      <Link>AVFoundation\PlayerItemVideoOutputTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\QueuePlayerTest.cs">
+      <Link>AVFoundation\QueuePlayerTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\SpeechSynthesisVoiceTest.cs">
+      <Link>AVFoundation\SpeechSynthesisVoiceTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\UtilitiesTest.cs">
+      <Link>AVFoundation\UtilitiesTest.cs</Link>
+    </Compile>
+    <Compile Include="AVFoundation\VideoCompositionInstructionTest.cs">
+      <Link>AVFoundation\VideoCompositionInstructionTest.cs</Link>
+    </Compile>
+    <Compile Include="AVKit\PlayerViewControllerTest.cs">
+      <Link>AVKit\PlayerViewControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="AdSupport\IdentifierManagerTest.cs">
+      <Link>AdSupport\IdentifierManagerTest.cs</Link>
+    </Compile>
+    <Compile Include="AddressBook\AddressBookTest.cs">
+      <Link>AddressBook\AddressBookTest.cs</Link>
+    </Compile>
+    <Compile Include="AddressBook\PersonTest.cs">
+      <Link>AddressBook\PersonTest.cs</Link>
+    </Compile>
+    <Compile Include="AddressBook\SourceTest.cs">
+      <Link>AddressBook\SourceTest.cs</Link>
+    </Compile>
+    <Compile Include="AddressBookUI\AddressFormattingTest.cs">
+      <Link>AddressBookUI\AddressFormattingTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioToolbox\AudioBalanceFadeTest.cs">
+      <Link>AudioToolbox\AudioBalanceFadeTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioToolbox\AudioChannelLayoutTest.cs">
+      <Link>AudioToolbox\AudioChannelLayoutTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioToolbox\AudioComponentTest.cs">
+      <Link>AudioToolbox\AudioComponentTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioToolbox\AudioFileGlobalInfoTest.cs">
+      <Link>AudioToolbox\AudioFileGlobalInfoTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioToolbox\AudioFileStreamTest.cs">
+      <Link>AudioToolbox\AudioFileStreamTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioToolbox\AudioFileTest.cs">
+      <Link>AudioToolbox\AudioFileTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioToolbox\AudioFormatAvailabilityTest.cs">
+      <Link>AudioToolbox\AudioFormatAvailabilityTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioToolbox\AudioFormatTest.cs">
+      <Link>AudioToolbox\AudioFormatTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioToolbox\AudioQueueTest.cs">
+      <Link>AudioToolbox\AudioQueueTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioToolbox\AudioSessionTest.cs">
+      <Link>AudioToolbox\AudioSessionTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioToolbox\AudioStreamBasicDescriptionTest.cs">
+      <Link>AudioToolbox\AudioStreamBasicDescriptionTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioToolbox\FourCCTest.cs">
+      <Link>AudioToolbox\FourCCTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioToolbox\MusicSequenceTest.cs">
+      <Link>AudioToolbox\MusicSequenceTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioToolbox\SoundBankTest.cs">
+      <Link>AudioToolbox\SoundBankTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioToolbox\SystemSoundTest.cs">
+      <Link>AudioToolbox\SystemSoundTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioUnit\AUAudioUnitFactoryTest.cs">
+      <Link>AudioUnit\AUAudioUnitFactoryTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioUnit\AUGraphTest.cs">
+      <Link>AudioUnit\AUGraphTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioUnit\AUParameterNodeTest.cs">
+      <Link>AudioUnit\AUParameterNodeTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioUnit\AudioUnitTest.cs">
+      <Link>AudioUnit\AudioUnitTest.cs</Link>
+    </Compile>
+    <Compile Include="AudioUnit\ExtAudioFileTest.cs">
+      <Link>AudioUnit\ExtAudioFileTest.cs</Link>
+    </Compile>
+    <Compile Include="CloudKit\CKDiscoverUserInfosOperationTest.cs">
+      <Link>CloudKit\CKDiscoverUserInfosOperationTest.cs</Link>
+    </Compile>
+    <Compile Include="CloudKit\CKFetchNotificationChangesOperationTest.cs">
+      <Link>CloudKit\CKFetchNotificationChangesOperationTest.cs</Link>
+    </Compile>
+    <Compile Include="CloudKit\CKFetchRecordChangesOperationTest.cs">
+      <Link>CloudKit\CKFetchRecordChangesOperationTest.cs</Link>
+    </Compile>
+    <Compile Include="CloudKit\CKFetchRecordZonesOperationTest.cs">
+      <Link>CloudKit\CKFetchRecordZonesOperationTest.cs</Link>
+    </Compile>
+    <Compile Include="CloudKit\CKFetchRecordsOperationTest.cs">
+      <Link>CloudKit\CKFetchRecordsOperationTest.cs</Link>
+    </Compile>
+    <Compile Include="CloudKit\CKFetchSubscriptionsOperationTest.cs">
+      <Link>CloudKit\CKFetchSubscriptionsOperationTest.cs</Link>
+    </Compile>
+    <Compile Include="CloudKit\CKMarkNotificationsReadOperationTest.cs">
+      <Link>CloudKit\CKMarkNotificationsReadOperationTest.cs</Link>
+    </Compile>
+    <Compile Include="CloudKit\CKModifyBadgeOperationTest.cs">
+      <Link>CloudKit\CKModifyBadgeOperationTest.cs</Link>
+    </Compile>
+    <Compile Include="CloudKit\CKModifyRecordZonesOperationTest.cs">
+      <Link>CloudKit\CKModifyRecordZonesOperationTest.cs</Link>
+    </Compile>
+    <Compile Include="CloudKit\CKModifyRecordsOperationTest.cs">
+      <Link>CloudKit\CKModifyRecordsOperationTest.cs</Link>
+    </Compile>
+    <Compile Include="CloudKit\CKModifySubscriptionsOperationTest.cs">
+      <Link>CloudKit\CKModifySubscriptionsOperationTest.cs</Link>
+    </Compile>
+    <Compile Include="CloudKit\CKQueryOperationTest.cs">
+      <Link>CloudKit\CKQueryOperationTest.cs</Link>
+    </Compile>
+    <Compile Include="CloudKit\CKUserIdentityLookupInfoTest.cs">
+      <Link>CloudKit\CKUserIdentityLookupInfoTest.cs</Link>
+    </Compile>
+    <Compile Include="Contacts\ContactFetchRequestTest.cs">
+      <Link>Contacts\ContactFetchRequestTest.cs</Link>
+    </Compile>
+    <Compile Include="Contacts\ContactFormatterTest.cs">
+      <Link>Contacts\ContactFormatterTest.cs</Link>
+    </Compile>
+    <Compile Include="Contacts\ContactStoreTest.cs">
+      <Link>Contacts\ContactStoreTest.cs</Link>
+    </Compile>
+    <Compile Include="Contacts\ContactTest.cs">
+      <Link>Contacts\ContactTest.cs</Link>
+    </Compile>
+    <Compile Include="Contacts\ContactVCardSerializationTest.cs">
+      <Link>Contacts\ContactVCardSerializationTest.cs</Link>
+    </Compile>
+    <Compile Include="Contacts\MutableContactTest.cs">
+      <Link>Contacts\MutableContactTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreAnimation\CATextLayerTests.cs">
+      <Link>CoreAnimation\CATextLayerTests.cs</Link>
+    </Compile>
+    <Compile Include="CoreAnimation\EmitterBehaviorTest.cs">
+      <Link>CoreAnimation\EmitterBehaviorTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreAnimation\EmitterCellTest.cs">
+      <Link>CoreAnimation\EmitterCellTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreAnimation\LayerTest.cs">
+      <Link>CoreAnimation\LayerTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreAnimation\MediaTimingFunctionTest.cs">
+      <Link>CoreAnimation\MediaTimingFunctionTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreAnimation\ShapeLayerTest.cs">
+      <Link>CoreAnimation\ShapeLayerTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreAnimation\TransactionTest.cs">
+      <Link>CoreAnimation\TransactionTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreAudioKit\AUViewController.cs">
+      <Link>CoreAudioKit\AUViewController.cs</Link>
+    </Compile>
+    <Compile Include="CoreBluetooth\CentralManagerTest.cs">
+      <Link>CoreBluetooth\CentralManagerTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreBluetooth\ErrorTest.cs">
+      <Link>CoreBluetooth\ErrorTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreBluetooth\PeerTest.cs">
+      <Link>CoreBluetooth\PeerTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreBluetooth\PeripheralScanningOptionsTest.cs">
+      <Link>CoreBluetooth\PeripheralScanningOptionsTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreBluetooth\UuidTest.cs">
+      <Link>CoreBluetooth\UuidTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreData\AttributeDescriptionTest.cs">
+      <Link>CoreData\AttributeDescriptionTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreData\ExpressionDescriptionTest.cs">
+      <Link>CoreData\ExpressionDescriptionTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreData\FetchRequestExpressionTest.cs">
+      <Link>CoreData\FetchRequestExpressionTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreData\FetchRequestTest.cs">
+      <Link>CoreData\FetchRequestTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreData\FetchedResultsControllerTest.cs">
+      <Link>CoreData\FetchedResultsControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreData\ManagedObjectContextTest.cs">
+      <Link>CoreData\ManagedObjectContextTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreData\ManagedObjectModelTest.cs">
+      <Link>CoreData\ManagedObjectModelTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreData\NSQueryGenerationTokenTest.cs">
+      <Link>CoreData\NSQueryGenerationTokenTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreData\PropertyDescriptionTest.cs">
+      <Link>CoreData\PropertyDescriptionTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreFoundation\BundleTest.cs">
+      <Link>CoreFoundation\BundleTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreFoundation\DispatchGroupTest.cs">
+      <Link>CoreFoundation\DispatchGroupTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreFoundation\DispatchTests.cs">
+      <Link>CoreFoundation\DispatchTests.cs</Link>
+    </Compile>
+    <Compile Include="CoreFoundation\NetworkTest.cs">
+      <Link>CoreFoundation\NetworkTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreFoundation\NotificationCenterTest.cs">
+      <Link>CoreFoundation\NotificationCenterTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreFoundation\ProxyTest.cs">
+      <Link>CoreFoundation\ProxyTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreFoundation\StringTest.cs">
+      <Link>CoreFoundation\StringTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreFoundation\UrlTest.cs">
+      <Link>CoreFoundation\UrlTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\AffineTransformTest.cs">
+      <Link>CoreGraphics\AffineTransformTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\BitmapContextTest.cs">
+      <Link>CoreGraphics\BitmapContextTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\CGImageTest.cs">
+      <Link>CoreGraphics\CGImageTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\ColorConversionInfoTest.cs">
+      <Link>CoreGraphics\ColorConversionInfoTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\ColorSpaceTest.cs">
+      <Link>CoreGraphics\ColorSpaceTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\ColorTest.cs">
+      <Link>CoreGraphics\ColorTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\ContextTest.cs">
+      <Link>CoreGraphics\ContextTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\DataConsumerTest.cs">
+      <Link>CoreGraphics\DataConsumerTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\DataProviderTest.cs">
+      <Link>CoreGraphics\DataProviderTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\FontTest.cs">
+      <Link>CoreGraphics\FontTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\FunctionTest.cs">
+      <Link>CoreGraphics\FunctionTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\GeometryTest.cs">
+      <Link>CoreGraphics\GeometryTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\GradientTest.cs">
+      <Link>CoreGraphics\GradientTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\PDFArrayTest.cs">
+      <Link>CoreGraphics\PDFArrayTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\PDFContentStreamTest.cs">
+      <Link>CoreGraphics\PDFContentStreamTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\PDFContextTest.cs">
+      <Link>CoreGraphics\PDFContextTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\PDFDocumentTest.cs">
+      <Link>CoreGraphics\PDFDocumentTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\PDFInfoTest.cs">
+      <Link>CoreGraphics\PDFInfoTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\PDFObjectTest.cs">
+      <Link>CoreGraphics\PDFObjectTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\PDFOperatorTableTest.cs">
+      <Link>CoreGraphics\PDFOperatorTableTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\PDFScannerTest.cs">
+      <Link>CoreGraphics\PDFScannerTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\PathTest.cs">
+      <Link>CoreGraphics\PathTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreGraphics\RectTest.cs">
+      <Link>CoreGraphics\RectTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreImage\CIKernelTests.cs">
+      <Link>CoreImage\CIKernelTests.cs</Link>
+    </Compile>
+    <Compile Include="CoreImage\CoreContextTest.cs">
+      <Link>CoreImage\CoreContextTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreImage\CoreVectorTest.cs">
+      <Link>CoreImage\CoreVectorTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreImage\DetectorTest.cs">
+      <Link>CoreImage\DetectorTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreImage\FilterTest.cs">
+      <Link>CoreImage\FilterTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreImage\ImageInitializationOptionsTest.cs">
+      <Link>CoreImage\ImageInitializationOptionsTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreImage\ImageTest.cs">
+      <Link>CoreImage\ImageTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreLocation\BeaconRegionTest.cs">
+      <Link>CoreLocation\BeaconRegionTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreML\MLMultiArrayTest.cs">
+      <Link>CoreML\MLMultiArrayTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreMedia\BlockBufferTest.cs">
+      <Link>CoreMedia\BlockBufferTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreMedia\CMClockOrTimebaseTest.cs">
+      <Link>CoreMedia\CMClockOrTimebaseTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreMedia\CMClockTest.cs">
+      <Link>CoreMedia\CMClockTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreMedia\CMFormatDescriptionTest.cs">
+      <Link>CoreMedia\CMFormatDescriptionTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreMedia\CMMemoryPoolTest.cs">
+      <Link>CoreMedia\CMMemoryPoolTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreMedia\CMTimeRangeTests.cs">
+      <Link>CoreMedia\CMTimeRangeTests.cs</Link>
+    </Compile>
+    <Compile Include="CoreMedia\CMTimeTests.cs">
+      <Link>CoreMedia\CMTimeTests.cs</Link>
+    </Compile>
+    <Compile Include="CoreMedia\CMTimebaseTest.cs">
+      <Link>CoreMedia\CMTimebaseTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreMedia\EnumTest.cs">
+      <Link>CoreMedia\EnumTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreMedia\SampleBufferTest.cs">
+      <Link>CoreMedia\SampleBufferTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreMidi\MidiEndpointTest.cs">
+      <Link>CoreMidi\MidiEndpointTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreMidi\MidiThruConnectionTests.cs">
+      <Link>CoreMidi\MidiThruConnectionTests.cs</Link>
+    </Compile>
+    <Compile Include="CoreMotion\AccelerometerDataTest.cs">
+      <Link>CoreMotion\AccelerometerDataTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreMotion\LogItemTest.cs">
+      <Link>CoreMotion\LogItemTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreServices\HttpMessageTest.cs">
+      <Link>CoreServices\HttpMessageTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreText\CTFrameTests.cs">
+      <Link>CoreText\CTFrameTests.cs</Link>
+    </Compile>
+    <Compile Include="CoreText\CTLineTest.cs">
+      <Link>CoreText\CTLineTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreText\CTParagraphStyleTests.cs">
+      <Link>CoreText\CTParagraphStyleTests.cs</Link>
+    </Compile>
+    <Compile Include="CoreText\FontDescriptorTest.cs">
+      <Link>CoreText\FontDescriptorTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreText\FontManagerTest.cs">
+      <Link>CoreText\FontManagerTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreText\FontTest.cs">
+      <Link>CoreText\FontTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreText\StringAttributes.cs">
+      <Link>CoreText\StringAttributes.cs</Link>
+    </Compile>
+    <Compile Include="CoreVideo\CVImageBufferTests.cs">
+      <Link>CoreVideo\CVImageBufferTests.cs</Link>
+    </Compile>
+    <Compile Include="CoreVideo\CVMetalTextureCacheTests.cs">
+      <Link>CoreVideo\CVMetalTextureCacheTests.cs</Link>
+    </Compile>
+    <Compile Include="CoreVideo\CoreVideoEnumsTest.cs">
+      <Link>CoreVideo\CoreVideoEnumsTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreVideo\PixelBufferAttributesTest.cs">
+      <Link>CoreVideo\PixelBufferAttributesTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreVideo\PixelBufferPoolTest.cs">
+      <Link>CoreVideo\PixelBufferPoolTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreVideo\PixelBufferTest.cs">
+      <Link>CoreVideo\PixelBufferTest.cs</Link>
+    </Compile>
+    <Compile Include="CoreVideo\PixelFormatDescriptionTest.cs">
+      <Link>CoreVideo\PixelFormatDescriptionTest.cs</Link>
+    </Compile>
+    <Compile Include="EventKit\AlarmTest.cs">
+      <Link>EventKit\AlarmTest.cs</Link>
+    </Compile>
+    <Compile Include="EventKit\CalendarTest.cs">
+      <Link>EventKit\CalendarTest.cs</Link>
+    </Compile>
+    <Compile Include="EventKit\EKUIBundleTest.cs">
+      <Link>EventKit\EKUIBundleTest.cs</Link>
+    </Compile>
+    <Compile Include="EventKit\EventStoreTest.cs">
+      <Link>EventKit\EventStoreTest.cs</Link>
+    </Compile>
+    <Compile Include="EventKit\RecurrenceRule.cs">
+      <Link>EventKit\RecurrenceRule.cs</Link>
+    </Compile>
+    <Compile Include="EventKit\ReminderTest.cs">
+      <Link>EventKit\ReminderTest.cs</Link>
+    </Compile>
+    <Compile Include="EventKit\StructuredLocationTest.cs">
+      <Link>EventKit\StructuredLocationTest.cs</Link>
+    </Compile>
+    <Compile Include="ExternalAccessory\AccessoryManagerTest.cs">
+      <Link>ExternalAccessory\AccessoryManagerTest.cs</Link>
+    </Compile>
+    <Compile Include="FileProvider\NSFileProviderPageTest.cs">
+      <Link>FileProvider\NSFileProviderPageTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\ArrayTest.cs">
+      <Link>Foundation\ArrayTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\AttributedStringTest.cs">
+      <Link>Foundation\AttributedStringTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\BlockOperationTest.cs">
+      <Link>Foundation\BlockOperationTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\BundleTest.cs">
+      <Link>Foundation\BundleTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\CachedUrlResponseTest.cs">
+      <Link>Foundation\CachedUrlResponseTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\CalendarTest.cs">
+      <Link>Foundation\CalendarTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\CoderTest.cs">
+      <Link>Foundation\CoderTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\CookieTest.cs">
+      <Link>Foundation\CookieTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\DateFormatterTest.cs">
+      <Link>Foundation\DateFormatterTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\DateTest.cs">
+      <Link>Foundation\DateTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\DecimalNumberTest.cs">
+      <Link>Foundation\DecimalNumberTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\DecimalTest.cs">
+      <Link>Foundation\DecimalTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\DictionaryContainerTest.cs">
+      <Link>Foundation\DictionaryContainerTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\DimensionTest.cs">
+      <Link>Foundation\DimensionTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\EncodingDetectionOptionsTest.cs">
+      <Link>Foundation\EncodingDetectionOptionsTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\FileCoordinatorTest.cs">
+      <Link>Foundation\FileCoordinatorTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\FileHandleTest.cs">
+      <Link>Foundation\FileHandleTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\FileManagerTest.cs">
+      <Link>Foundation\FileManagerTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\FormatterTests.cs">
+      <Link>Foundation\FormatterTests.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\IndexPathTest.cs">
+      <Link>Foundation\IndexPathTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\KeyedUnarchiverTest.cs">
+      <Link>Foundation\KeyedUnarchiverTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\LocaleTest.cs">
+      <Link>Foundation\LocaleTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\MutableAttributedStringTest.cs">
+      <Link>Foundation\MutableAttributedStringTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\MutableDataTest.cs">
+      <Link>Foundation\MutableDataTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\MutableStringTest.cs">
+      <Link>Foundation\MutableStringTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSArray1Test.cs">
+      <Link>Foundation\NSArray1Test.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSCharacterSetTest.cs">
+      <Link>Foundation\NSCharacterSetTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSDataTest.cs">
+      <Link>Foundation\NSDataTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSDictionary2Test.cs">
+      <Link>Foundation\NSDictionary2Test.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSDictionaryTest.cs">
+      <Link>Foundation\NSDictionaryTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSExpressionTest.cs">
+      <Link>Foundation\NSExpressionTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSInputStreamTest.cs">
+      <Link>Foundation\NSInputStreamTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSLayoutConstraintTest.cs">
+      <Link>Foundation\NSLayoutConstraintTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSLocaleTest.cs">
+      <Link>Foundation\NSLocaleTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSMutableArray1Test.cs">
+      <Link>Foundation\NSMutableArray1Test.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSMutableDictionary2Test.cs">
+      <Link>Foundation\NSMutableDictionary2Test.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSMutableDictionaryTest.cs">
+      <Link>Foundation\NSMutableDictionaryTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSMutableOrderedSet1Test.cs">
+      <Link>Foundation\NSMutableOrderedSet1Test.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSMutableOrderedSetTest.cs">
+      <Link>Foundation\NSMutableOrderedSetTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSMutableSet1Test.cs">
+      <Link>Foundation\NSMutableSet1Test.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSMutableSetTest.cs">
+      <Link>Foundation\NSMutableSetTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSOrderedSet1Test.cs">
+      <Link>Foundation\NSOrderedSet1Test.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSOrderedSetTest.cs">
+      <Link>Foundation\NSOrderedSetTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSSet1Test.cs">
+      <Link>Foundation\NSSet1Test.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSSetTest.cs">
+      <Link>Foundation\NSSetTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSStreamTest.cs">
+      <Link>Foundation\NSStreamTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSStringTest.cs">
+      <Link>Foundation\NSStringTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NSTimeZoneTest.cs">
+      <Link>Foundation\NSTimeZoneTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NetServiceTest.cs">
+      <Link>Foundation\NetServiceTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NotificationCenter.cs">
+      <Link>Foundation\NotificationCenter.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NotificationQueueTest.cs">
+      <Link>Foundation\NotificationQueueTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\NumberTest.cs">
+      <Link>Foundation\NumberTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\ObjectTest.cs">
+      <Link>Foundation\ObjectTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\OperationQueueTest.cs">
+      <Link>Foundation\OperationQueueTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\OutputStreamTest.cs">
+      <Link>Foundation\OutputStreamTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\ProtocolAttributeTest.cs">
+      <Link>Foundation\ProtocolAttributeTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\StringTest.cs">
+      <Link>Foundation\StringTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\ThreadTest.cs">
+      <Link>Foundation\ThreadTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\TimerTest.cs">
+      <Link>Foundation\TimerTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\UbiquitousKeyValueStoreTest.cs">
+      <Link>Foundation\UbiquitousKeyValueStoreTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\UrlConnectionTest.cs">
+      <Link>Foundation\UrlConnectionTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\UrlCredentialTest.cs">
+      <Link>Foundation\UrlCredentialTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\UrlProtectionSpaceTest.cs">
+      <Link>Foundation\UrlProtectionSpaceTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\UrlProtocolTest.cs">
+      <Link>Foundation\UrlProtocolTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\UrlRequestTest.cs">
+      <Link>Foundation\UrlRequestTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\UrlSessionConfigurationTest.cs">
+      <Link>Foundation\UrlSessionConfigurationTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\UrlSessionTaskMetricsTest.cs">
+      <Link>Foundation\UrlSessionTaskMetricsTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\UrlSessionTaskTest.cs">
+      <Link>Foundation\UrlSessionTaskTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\UrlSessionTaskTransactionMetricsTest.cs">
+      <Link>Foundation\UrlSessionTaskTransactionMetricsTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\UrlSessionTest.cs">
+      <Link>Foundation\UrlSessionTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\UrlTest.cs">
+      <Link>Foundation\UrlTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\UserDefaultsTest.cs">
+      <Link>Foundation\UserDefaultsTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\UuidTest.cs">
+      <Link>Foundation\UuidTest.cs</Link>
+    </Compile>
+    <Compile Include="Foundation\ZoneTest.cs">
+      <Link>Foundation\ZoneTest.cs</Link>
+    </Compile>
+    <Compile Include="GLKit\BaseEffectTest.cs">
+      <Link>GLKit\BaseEffectTest.cs</Link>
+    </Compile>
+    <Compile Include="GLKit\EffectPropertyFog.cs">
+      <Link>GLKit\EffectPropertyFog.cs</Link>
+    </Compile>
+    <Compile Include="GLKit\EffectPropertyLightTest.cs">
+      <Link>GLKit\EffectPropertyLightTest.cs</Link>
+    </Compile>
+    <Compile Include="GLKit\EffectPropertyMaterialTest.cs">
+      <Link>GLKit\EffectPropertyMaterialTest.cs</Link>
+    </Compile>
+    <Compile Include="GLKit\EffectPropertyTransformTest.cs">
+      <Link>GLKit\EffectPropertyTransformTest.cs</Link>
+    </Compile>
+    <Compile Include="GLKit\KViewTest.cs">
+      <Link>GLKit\KViewTest.cs</Link>
+    </Compile>
+    <Compile Include="GameController\ExtendedGamepadSnapshotTest.cs">
+      <Link>GameController\ExtendedGamepadSnapshotTest.cs</Link>
+    </Compile>
+    <Compile Include="GameController\GamepadSnapshotTest.cs">
+      <Link>GameController\GamepadSnapshotTest.cs</Link>
+    </Compile>
+    <Compile Include="GameKit\LeaderboardTest.cs">
+      <Link>GameKit\LeaderboardTest.cs</Link>
+    </Compile>
+    <Compile Include="GameKit\LeaderboardViewControllerTest.cs">
+      <Link>GameKit\LeaderboardViewControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="GameKit\NotificationBannerTest.cs">
+      <Link>GameKit\NotificationBannerTest.cs</Link>
+    </Compile>
+    <Compile Include="GameKit\ScoreTest.cs">
+      <Link>GameKit\ScoreTest.cs</Link>
+    </Compile>
+    <Compile Include="GameKit\SessionTest.cs">
+      <Link>GameKit\SessionTest.cs</Link>
+    </Compile>
+    <Compile Include="GameplayKit\GKAgent3DTest.cs">
+      <Link>GameplayKit\GKAgent3DTest.cs</Link>
+    </Compile>
+    <Compile Include="GameplayKit\GKComponentSystemTests.cs">
+      <Link>GameplayKit\GKComponentSystemTests.cs</Link>
+    </Compile>
+    <Compile Include="GameplayKit\GKEntityTests.cs">
+      <Link>GameplayKit\GKEntityTests.cs</Link>
+    </Compile>
+    <Compile Include="GameplayKit\GKGridGraphTests.cs">
+      <Link>GameplayKit\GKGridGraphTests.cs</Link>
+    </Compile>
+    <Compile Include="GameplayKit\GKMeshGraphTests.cs">
+      <Link>GameplayKit\GKMeshGraphTests.cs</Link>
+    </Compile>
+    <Compile Include="GameplayKit\GKNoiseMapTests.cs">
+      <Link>GameplayKit\GKNoiseMapTests.cs</Link>
+    </Compile>
+    <Compile Include="GameplayKit\GKNoiseTests.cs">
+      <Link>GameplayKit\GKNoiseTests.cs</Link>
+    </Compile>
+    <Compile Include="GameplayKit\GKOctreeTests.cs">
+      <Link>GameplayKit\GKOctreeTests.cs</Link>
+    </Compile>
+    <Compile Include="GameplayKit\GKPathTests.cs">
+      <Link>GameplayKit\GKPathTests.cs</Link>
+    </Compile>
+    <Compile Include="GameplayKit\GKPolygonObstacleTests.cs">
+      <Link>GameplayKit\GKPolygonObstacleTests.cs</Link>
+    </Compile>
+    <Compile Include="GameplayKit\GKQuadTreeTests.cs">
+      <Link>GameplayKit\GKQuadTreeTests.cs</Link>
+    </Compile>
+    <Compile Include="GameplayKit\GKStateMachineTests.cs">
+      <Link>GameplayKit\GKStateMachineTests.cs</Link>
+    </Compile>
+    <Compile Include="GameplayKit\GKStateTests.cs">
+      <Link>GameplayKit\GKStateTests.cs</Link>
+    </Compile>
+    <Compile Include="HealthKit\AnchoredObjectQueryTest.cs">
+      <Link>HealthKit\AnchoredObjectQueryTest.cs</Link>
+    </Compile>
+    <Compile Include="HealthKit\CategoryTypeIdentifierTest.cs">
+      <Link>HealthKit\CategoryTypeIdentifierTest.cs</Link>
+    </Compile>
+    <Compile Include="HealthKit\CdaDocumentSampleTest.cs">
+      <Link>HealthKit\CdaDocumentSampleTest.cs</Link>
+    </Compile>
+    <Compile Include="HealthKit\ErrorTest.cs">
+      <Link>HealthKit\ErrorTest.cs</Link>
+    </Compile>
+    <Compile Include="HealthKit\ObjectTypeTest.cs">
+      <Link>HealthKit\ObjectTypeTest.cs</Link>
+    </Compile>
+    <Compile Include="HealthKit\QuantityTypeIdentifierTest.cs">
+      <Link>HealthKit\QuantityTypeIdentifierTest.cs</Link>
+    </Compile>
+    <Compile Include="HomeKit\HMMutableSignificantTimeEventTest.cs">
+      <Link>HomeKit\HMMutableSignificantTimeEventTest.cs</Link>
+    </Compile>
+    <Compile Include="HomeKit\HMSignificantTimeEventTest.cs">
+      <Link>HomeKit\HMSignificantTimeEventTest.cs</Link>
+    </Compile>
+    <Compile Include="HttpClient\HttpClientTest.cs">
+      <Link>HttpClient\HttpClientTest.cs</Link>
+    </Compile>
+    <Compile Include="ImageIO\CGImageSourceTest.cs">
+      <Link>ImageIO\CGImageSourceTest.cs</Link>
+    </Compile>
+    <Compile Include="ImageIO\ImageDestinationTest.cs">
+      <Link>ImageIO\ImageDestinationTest.cs</Link>
+    </Compile>
+    <Compile Include="ImageIO\ImageMetadataTagTest.cs">
+      <Link>ImageIO\ImageMetadataTagTest.cs</Link>
+    </Compile>
+    <Compile Include="ImageIO\ImageMetadataTest.cs">
+      <Link>ImageIO\ImageMetadataTest.cs</Link>
+    </Compile>
+    <Compile Include="ImageIO\ImagePropertiesTest.cs">
+      <Link>ImageIO\ImagePropertiesTest.cs</Link>
+    </Compile>
+    <Compile Include="ImageIO\MutableImageMetadataTest.cs">
+      <Link>ImageIO\MutableImageMetadataTest.cs</Link>
+    </Compile>
+    <Compile Include="Intents\INIntentResolutionResultTests.cs">
+      <Link>Intents\INIntentResolutionResultTests.cs</Link>
+    </Compile>
+    <Compile Include="JavascriptCore\ContextTest.cs">
+      <Link>JavascriptCore\ContextTest.cs</Link>
+    </Compile>
+    <Compile Include="JavascriptCore\JSExportTest.cs">
+      <Link>JavascriptCore\JSExportTest.cs</Link>
+    </Compile>
+    <Compile Include="JavascriptCore\ValueTest.cs">
+      <Link>JavascriptCore\ValueTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\AnnotationViewTest.cs">
+      <Link>MapKit\AnnotationViewTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\CircleViewTest.cs">
+      <Link>MapKit\CircleViewTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\GeometryTest.cs">
+      <Link>MapKit\GeometryTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\LocalSearchRequestTest.cs">
+      <Link>MapKit\LocalSearchRequestTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\LocalSearchTest.cs">
+      <Link>MapKit\LocalSearchTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\MapRectTest.cs">
+      <Link>MapKit\MapRectTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\MapViewTest.cs">
+      <Link>MapKit\MapViewTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\OverlayPathRendererTest.cs">
+      <Link>MapKit\OverlayPathRendererTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\OverlayPathViewTest.cs">
+      <Link>MapKit\OverlayPathViewTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\OverlayViewTest.cs">
+      <Link>MapKit\OverlayViewTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\PinAnnotationViewTest.cs">
+      <Link>MapKit\PinAnnotationViewTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\PolygonTest.cs">
+      <Link>MapKit\PolygonTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\PolygonViewTest.cs">
+      <Link>MapKit\PolygonViewTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\PolylineTest.cs">
+      <Link>MapKit\PolylineTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\PolylineViewTest.cs">
+      <Link>MapKit\PolylineViewTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\ShapeTest.cs">
+      <Link>MapKit\ShapeTest.cs</Link>
+    </Compile>
+    <Compile Include="MapKit\UserTrackingBarButtonItemTest.cs">
+      <Link>MapKit\UserTrackingBarButtonItemTest.cs</Link>
+    </Compile>
+    <Compile Include="MediaAccessibility\AudibleMediaTest.cs">
+      <Link>MediaAccessibility\AudibleMediaTest.cs</Link>
+    </Compile>
+    <Compile Include="MediaAccessibility\CaptionAppearanceTest.cs">
+      <Link>MediaAccessibility\CaptionAppearanceTest.cs</Link>
+    </Compile>
+    <Compile Include="MediaPlayer\MediaItemArtworkTest.cs">
+      <Link>MediaPlayer\MediaItemArtworkTest.cs</Link>
+    </Compile>
+    <Compile Include="MediaPlayer\MediaItemTest.cs">
+      <Link>MediaPlayer\MediaItemTest.cs</Link>
+    </Compile>
+    <Compile Include="MediaPlayer\MoviePlayerControllerTest.cs">
+      <Link>MediaPlayer\MoviePlayerControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="MediaPlayer\NowPlayingInfoCenterTest.cs">
+      <Link>MediaPlayer\NowPlayingInfoCenterTest.cs</Link>
+    </Compile>
+    <Compile Include="MediaPlayer\PlayableContentManagerTest.cs">
+      <Link>MediaPlayer\PlayableContentManagerTest.cs</Link>
+    </Compile>
+    <Compile Include="MediaPlayer\RemoteCommandCenterTest.cs">
+      <Link>MediaPlayer\RemoteCommandCenterTest.cs</Link>
+    </Compile>
+    <Compile Include="MediaPlayer\SkipIntervalCommandTest.cs">
+      <Link>MediaPlayer\SkipIntervalCommandTest.cs</Link>
+    </Compile>
+    <Compile Include="MediaPlayer\VolumeViewTest.cs">
+      <Link>MediaPlayer\VolumeViewTest.cs</Link>
+    </Compile>
+    <Compile Include="MediaToolbox\AudioProcessingTapTest.cs">
+      <Link>MediaToolbox\AudioProcessingTapTest.cs</Link>
+    </Compile>
+    <Compile Include="MediaToolbox\FormatNamesTest.cs">
+      <Link>MediaToolbox\FormatNamesTest.cs</Link>
+    </Compile>
+    <Compile Include="MessageUI\MailComposeViewControllerTest.cs">
+      <Link>MessageUI\MailComposeViewControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="MessageUI\MessageComposeViewControllerTest.cs">
+      <Link>MessageUI\MessageComposeViewControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="Messages\MSMessageTest.cs">
+      <Link>Messages\MSMessageTest.cs</Link>
+    </Compile>
+    <Compile Include="Metal\ClearValueTest.cs">
+      <Link>Metal\ClearValueTest.cs</Link>
+    </Compile>
+    <Compile Include="Metal\DeviceTest.cs">
+      <Link>Metal\DeviceTest.cs</Link>
+    </Compile>
+    <Compile Include="Metal\HeapDescriptorTest.cs">
+      <Link>Metal\HeapDescriptorTest.cs</Link>
+    </Compile>
+    <Compile Include="Metal\MTLArgumentDescriptorTest.cs">
+      <Link>Metal\MTLArgumentDescriptorTest.cs</Link>
+    </Compile>
+    <Compile Include="Metal\MTLAttributeDescriptorTest.cs">
+      <Link>Metal\MTLAttributeDescriptorTest.cs</Link>
+    </Compile>
+    <Compile Include="Metal\MTLAttributeTest.cs">
+      <Link>Metal\MTLAttributeTest.cs</Link>
+    </Compile>
+    <Compile Include="Metal\MTLBufferLayoutDescriptorTest.cs">
+      <Link>Metal\MTLBufferLayoutDescriptorTest.cs</Link>
+    </Compile>
+    <Compile Include="Metal\MTLDeviceTests.cs">
+      <Link>Metal\MTLDeviceTests.cs</Link>
+    </Compile>
+    <Compile Include="Metal\MTLFunctionConstantTest.cs">
+      <Link>Metal\MTLFunctionConstantTest.cs</Link>
+    </Compile>
+    <Compile Include="Metal\MTLPipelineBufferDescriptorTests.cs">
+      <Link>Metal\MTLPipelineBufferDescriptorTests.cs</Link>
+    </Compile>
+    <Compile Include="Metal\MTLPointerTypeTests.cs">
+      <Link>Metal\MTLPointerTypeTests.cs</Link>
+    </Compile>
+    <Compile Include="Metal\MTLStageInputOutputDescriptorTest.cs">
+      <Link>Metal\MTLStageInputOutputDescriptorTest.cs</Link>
+    </Compile>
+    <Compile Include="Metal\MTLTextureReferenceType.cs">
+      <Link>Metal\MTLTextureReferenceType.cs</Link>
+    </Compile>
+    <Compile Include="Metal\MTLTileRenderPipelineColorAttachmentDescriptorTests.cs">
+      <Link>Metal\MTLTileRenderPipelineColorAttachmentDescriptorTests.cs</Link>
+    </Compile>
+    <Compile Include="Metal\MTLTileRenderPipelineDescriptor.cs">
+      <Link>Metal\MTLTileRenderPipelineDescriptor.cs</Link>
+    </Compile>
+    <Compile Include="MetalPerformanceShaders\KernelTest.cs">
+      <Link>MetalPerformanceShaders\KernelTest.cs</Link>
+    </Compile>
+    <Compile Include="MetalPerformanceShaders\MPSImageHistogramEqualizationTest.cs">
+      <Link>MetalPerformanceShaders\MPSImageHistogramEqualizationTest.cs</Link>
+    </Compile>
+    <Compile Include="MetalPerformanceShaders\MPSImageHistogramSpecificationTest.cs">
+      <Link>MetalPerformanceShaders\MPSImageHistogramSpecificationTest.cs</Link>
+    </Compile>
+    <Compile Include="MetalPerformanceShaders\MPSImageHistogramTest.cs">
+      <Link>MetalPerformanceShaders\MPSImageHistogramTest.cs</Link>
+    </Compile>
+    <Compile Include="MobileCoreServices\UTTypeTest.cs">
+      <Link>MobileCoreServices\UTTypeTest.cs</Link>
+    </Compile>
+    <Compile Include="ModelIO\MDLAnimatedValueTypesTests.cs">
+      <Link>ModelIO\MDLAnimatedValueTypesTests.cs</Link>
+    </Compile>
+    <Compile Include="ModelIO\MDLAssetTest.cs">
+      <Link>ModelIO\MDLAssetTest.cs</Link>
+    </Compile>
+    <Compile Include="ModelIO\MDLCameraTest.cs">
+      <Link>ModelIO\MDLCameraTest.cs</Link>
+    </Compile>
+    <Compile Include="ModelIO\MDLLight.cs">
+      <Link>ModelIO\MDLLight.cs</Link>
+    </Compile>
+    <Compile Include="ModelIO\MDLMaterialProperty.cs">
+      <Link>ModelIO\MDLMaterialProperty.cs</Link>
+    </Compile>
+    <Compile Include="ModelIO\MDLMesh.cs">
+      <Link>ModelIO\MDLMesh.cs</Link>
+    </Compile>
+    <Compile Include="ModelIO\MDLNoiseTexture.cs">
+      <Link>ModelIO\MDLNoiseTexture.cs</Link>
+    </Compile>
+    <Compile Include="ModelIO\MDLObject.cs">
+      <Link>ModelIO\MDLObject.cs</Link>
+    </Compile>
+    <Compile Include="ModelIO\MDLStereoscopicCameraTest.cs">
+      <Link>ModelIO\MDLStereoscopicCameraTest.cs</Link>
+    </Compile>
+    <Compile Include="ModelIO\MDLTexture.cs">
+      <Link>ModelIO\MDLTexture.cs</Link>
+    </Compile>
+    <Compile Include="ModelIO\MDLTransform.cs">
+      <Link>ModelIO\MDLTransform.cs</Link>
+    </Compile>
+    <Compile Include="ModelIO\MDLTransformComponentTest.cs">
+      <Link>ModelIO\MDLTransformComponentTest.cs</Link>
+    </Compile>
+    <Compile Include="ModelIO\MDLVertexAttribute.cs">
+      <Link>ModelIO\MDLVertexAttribute.cs</Link>
+    </Compile>
+    <Compile Include="ModelIO\MDLVoxelArrayTest.cs">
+      <Link>ModelIO\MDLVoxelArrayTest.cs</Link>
+    </Compile>
+    <Compile Include="MultipeerConnectivity\PeerIDTest.cs">
+      <Link>MultipeerConnectivity\PeerIDTest.cs</Link>
+    </Compile>
+    <Compile Include="MultipeerConnectivity\SessionTest.cs">
+      <Link>MultipeerConnectivity\SessionTest.cs</Link>
+    </Compile>
+    <Compile Include="NetworkExtension\OnDemandTest.cs">
+      <Link>NetworkExtension\OnDemandTest.cs</Link>
+    </Compile>
+    <Compile Include="NetworkExtension\VpnManagerTest.cs">
+      <Link>NetworkExtension\VpnManagerTest.cs</Link>
+    </Compile>
+    <Compile Include="ObjCRuntime\BlocksTest.cs">
+      <Link>ObjCRuntime\BlocksTest.cs</Link>
+    </Compile>
+    <Compile Include="ObjCRuntime\CategoryTest.cs">
+      <Link>ObjCRuntime\CategoryTest.cs</Link>
+    </Compile>
+    <Compile Include="ObjCRuntime\ClassTest.classlist.cs">
+      <Link>ObjCRuntime\ClassTest.classlist.cs</Link>
+    </Compile>
+    <Compile Include="ObjCRuntime\ClassTest.cs">
+      <Link>ObjCRuntime\ClassTest.cs</Link>
+    </Compile>
+    <Compile Include="ObjCRuntime\DlfcnTest.cs">
+      <Link>ObjCRuntime\DlfcnTest.cs</Link>
+    </Compile>
+    <Compile Include="ObjCRuntime\ExceptionsTest.cs">
+      <Link>ObjCRuntime\ExceptionsTest.cs</Link>
+    </Compile>
+    <Compile Include="ObjCRuntime\Messaging.cs">
+      <Link>ObjCRuntime\Messaging.cs</Link>
+    </Compile>
+    <Compile Include="ObjCRuntime\RegistrarTest.cs">
+      <Link>ObjCRuntime\RegistrarTest.cs</Link>
+    </Compile>
+    <Compile Include="ObjCRuntime\RuntimeTest.cs">
+      <Link>ObjCRuntime\RuntimeTest.cs</Link>
+    </Compile>
+    <Compile Include="ObjCRuntime\TrampolineTest.cs">
+      <Link>ObjCRuntime\TrampolineTest.cs</Link>
+    </Compile>
+    <Compile Include="OpenGLES\EAGLContext.cs">
+      <Link>OpenGLES\EAGLContext.cs</Link>
+    </Compile>
+    <Compile Include="PassKit\AddPassesViewControllerTest.cs">
+      <Link>PassKit\AddPassesViewControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="PassKit\LabeledValueTest.cs">
+      <Link>PassKit\LabeledValueTest.cs</Link>
+    </Compile>
+    <Compile Include="PassKit\ObjectTest.cs">
+      <Link>PassKit\ObjectTest.cs</Link>
+    </Compile>
+    <Compile Include="PassKit\PKPaymentRequestTest.cs">
+      <Link>PassKit\PKPaymentRequestTest.cs</Link>
+    </Compile>
+    <Compile Include="PassKit\PassLibraryTest.cs">
+      <Link>PassKit\PassLibraryTest.cs</Link>
+    </Compile>
+    <Compile Include="PassKit\PassTest.cs">
+      <Link>PassKit\PassTest.cs</Link>
+    </Compile>
+    <Compile Include="PdfKit\PdfAnnotationTest.cs">
+      <Link>PdfKit\PdfAnnotationTest.cs</Link>
+    </Compile>
+    <Compile Include="Photos\FetchResultTest.cs">
+      <Link>Photos\FetchResultTest.cs</Link>
+    </Compile>
+    <Compile Include="Photos\PhotoLibraryTest.cs">
+      <Link>Photos\PhotoLibraryTest.cs</Link>
+    </Compile>
+    <Compile Include="PushKit\PushRegistryTest.cs">
+      <Link>PushKit\PushRegistryTest.cs</Link>
+    </Compile>
+    <Compile Include="QuickLook\PreviewControllerTest.cs">
+      <Link>QuickLook\PreviewControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="ReplayKit\BroadcastHandlerTest.cs">
+      <Link>ReplayKit\BroadcastHandlerTest.cs</Link>
+    </Compile>
+    <Compile Include="SafariServices\ReadingListTest.cs">
+      <Link>SafariServices\ReadingListTest.cs</Link>
+    </Compile>
+    <Compile Include="SceneKit\GeometrySourceTest.cs">
+      <Link>SceneKit\GeometrySourceTest.cs</Link>
+    </Compile>
+    <Compile Include="SceneKit\NodeTest.cs">
+      <Link>SceneKit\NodeTest.cs</Link>
+    </Compile>
+    <Compile Include="SceneKit\StructTest.cs">
+      <Link>SceneKit\StructTest.cs</Link>
+    </Compile>
+    <Compile Include="Security\CertificateTest.cs">
+      <Link>Security\CertificateTest.cs</Link>
+    </Compile>
+    <Compile Include="Security\IdentityTest.cs">
+      <Link>Security\IdentityTest.cs</Link>
+    </Compile>
+    <Compile Include="Security\ImportExportTest.cs">
+      <Link>Security\ImportExportTest.cs</Link>
+    </Compile>
+    <Compile Include="Security\KeyChainTest.cs">
+      <Link>Security\KeyChainTest.cs</Link>
+    </Compile>
+    <Compile Include="Security\KeyTest.cs">
+      <Link>Security\KeyTest.cs</Link>
+    </Compile>
+    <Compile Include="Security\PolicyTest.cs">
+      <Link>Security\PolicyTest.cs</Link>
+    </Compile>
+    <Compile Include="Security\RecordTest.cs">
+      <Link>Security\RecordTest.cs</Link>
+    </Compile>
+    <Compile Include="Security\SecSharedCredentialTest.cs">
+      <Link>Security\SecSharedCredentialTest.cs</Link>
+    </Compile>
+    <Compile Include="Security\SecureTransportTest.cs">
+      <Link>Security\SecureTransportTest.cs</Link>
+    </Compile>
+    <Compile Include="Security\TrustTest.cs">
+      <Link>Security\TrustTest.cs</Link>
+    </Compile>
+    <Compile Include="Simd\MatrixFloat2x2Test.cs">
+      <Link>Simd\MatrixFloat2x2Test.cs</Link>
+    </Compile>
+    <Compile Include="Simd\MatrixFloat3x3Test.cs">
+      <Link>Simd\MatrixFloat3x3Test.cs</Link>
+    </Compile>
+    <Compile Include="Simd\MatrixFloat4x3Test.cs">
+      <Link>Simd\MatrixFloat4x3Test.cs</Link>
+    </Compile>
+    <Compile Include="Simd\MatrixFloat4x4Test.cs">
+      <Link>Simd\MatrixFloat4x4Test.cs</Link>
+    </Compile>
+    <Compile Include="Simd\NMatrix4dTest.cs">
+      <Link>Simd\NMatrix4dTest.cs</Link>
+    </Compile>
+    <Compile Include="Simd\NVector3dTest.cs">
+      <Link>Simd\NVector3dTest.cs</Link>
+    </Compile>
+    <Compile Include="Simd\VectorFloat3Test.cs">
+      <Link>Simd\VectorFloat3Test.cs</Link>
+    </Compile>
+    <Compile Include="SpriteKit\FieldNodeTest.cs">
+      <Link>SpriteKit\FieldNodeTest.cs</Link>
+    </Compile>
+    <Compile Include="SpriteKit\KeyframeSequenceTest.cs">
+      <Link>SpriteKit\KeyframeSequenceTest.cs</Link>
+    </Compile>
+    <Compile Include="SpriteKit\PhysicsBodyTest.cs">
+      <Link>SpriteKit\PhysicsBodyTest.cs</Link>
+    </Compile>
+    <Compile Include="SpriteKit\PhysicsJointFixedTest.cs">
+      <Link>SpriteKit\PhysicsJointFixedTest.cs</Link>
+    </Compile>
+    <Compile Include="SpriteKit\PhysicsJointLimitTest.cs">
+      <Link>SpriteKit\PhysicsJointLimitTest.cs</Link>
+    </Compile>
+    <Compile Include="SpriteKit\PhysicsWorldTest.cs">
+      <Link>SpriteKit\PhysicsWorldTest.cs</Link>
+    </Compile>
+    <Compile Include="SpriteKit\SK3DNodeTest.cs">
+      <Link>SpriteKit\SK3DNodeTest.cs</Link>
+    </Compile>
+    <Compile Include="SpriteKit\SKShapeNodeTest.cs">
+      <Link>SpriteKit\SKShapeNodeTest.cs</Link>
+    </Compile>
+    <Compile Include="SpriteKit\SKTransformNodeTest.cs">
+      <Link>SpriteKit\SKTransformNodeTest.cs</Link>
+    </Compile>
+    <Compile Include="SpriteKit\SpriteNodeTest.cs">
+      <Link>SpriteKit\SpriteNodeTest.cs</Link>
+    </Compile>
+    <Compile Include="SpriteKit\TextureAtlasTest.cs">
+      <Link>SpriteKit\TextureAtlasTest.cs</Link>
+    </Compile>
+    <Compile Include="SpriteKit\TextureTest.cs">
+      <Link>SpriteKit\TextureTest.cs</Link>
+    </Compile>
+    <Compile Include="SpriteKit\UniformTest.cs">
+      <Link>SpriteKit\UniformTest.cs</Link>
+    </Compile>
+    <Compile Include="SpriteKit\WarpGeometryGridTest.cs">
+      <Link>SpriteKit\WarpGeometryGridTest.cs</Link>
+    </Compile>
+    <Compile Include="StoreKit\ReceiptRefreshRequestTest.cs">
+      <Link>StoreKit\ReceiptRefreshRequestTest.cs</Link>
+    </Compile>
+    <Compile Include="System.Net.Http\MessageHandlers.cs">
+      <Link>System.Net.Http\MessageHandlers.cs</Link>
+    </Compile>
+    <Compile Include="SystemConfiguration\CaptiveNetworkTest.cs">
+      <Link>SystemConfiguration\CaptiveNetworkTest.cs</Link>
+    </Compile>
+    <Compile Include="SystemConfiguration\NetworkReachabilityTest.cs">
+      <Link>SystemConfiguration\NetworkReachabilityTest.cs</Link>
+    </Compile>
+    <Compile Include="SystemConfiguration\StatusCodeErrorTest.cs">
+      <Link>SystemConfiguration\StatusCodeErrorTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\AccessibilityTest.cs">
+      <Link>UIKit\AccessibilityTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\ActionSheetTest.cs">
+      <Link>UIKit\ActionSheetTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\ActivityIndicatorViewTest.cs">
+      <Link>UIKit\ActivityIndicatorViewTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\AlertViewDelegateTest.cs">
+      <Link>UIKit\AlertViewDelegateTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\AlertViewTest.cs">
+      <Link>UIKit\AlertViewTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\AppearanceTest.cs">
+      <Link>UIKit\AppearanceTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\ApplicationTest.cs">
+      <Link>UIKit\ApplicationTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\BarButtonItemTest.cs">
+      <Link>UIKit\BarButtonItemTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\ButtonTest.cs">
+      <Link>UIKit\ButtonTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\CollectionViewControllerTest.cs">
+      <Link>UIKit\CollectionViewControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\CollectionViewTransitionLayoutTest.cs">
+      <Link>UIKit\CollectionViewTransitionLayoutTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\ColorTest.cs">
+      <Link>UIKit\ColorTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\ControlTest.cs">
+      <Link>UIKit\ControlTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\DatePickerTest.cs">
+      <Link>UIKit\DatePickerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\DeviceTest.cs">
+      <Link>UIKit\DeviceTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\DictationPhrase.cs">
+      <Link>UIKit\DictationPhrase.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\DirectionalEdgeInsetsTest.cs">
+      <Link>UIKit\DirectionalEdgeInsetsTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\EdgeInsetsTest.cs">
+      <Link>UIKit\EdgeInsetsTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\FloatRangeTest.cs">
+      <Link>UIKit\FloatRangeTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\FontTest.cs">
+      <Link>UIKit\FontTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\GestureRecognizerTest.cs">
+      <Link>UIKit\GestureRecognizerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\GraphicsRendererTest.cs">
+      <Link>UIKit\GraphicsRendererTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\GuidedAccessRestrictionTest.cs">
+      <Link>UIKit\GuidedAccessRestrictionTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\ImageTest.cs">
+      <Link>UIKit\ImageTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\ImageViewTest.cs">
+      <Link>UIKit\ImageViewTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\LabelTest.cs">
+      <Link>UIKit\LabelTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\LayoutConstraintTest.cs">
+      <Link>UIKit\LayoutConstraintTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\LayoutManagerTest.cs">
+      <Link>UIKit\LayoutManagerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\LocalNotificationTest.cs">
+      <Link>UIKit\LocalNotificationTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\NavigationBarTest.cs">
+      <Link>UIKit\NavigationBarTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\NavigationControllerTest.cs">
+      <Link>UIKit\NavigationControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\NavigationItemTest.cs">
+      <Link>UIKit\NavigationItemTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\NibTest.cs">
+      <Link>UIKit\NibTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\PageControlTest.cs">
+      <Link>UIKit\PageControlTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\PageViewControllerTest.cs">
+      <Link>UIKit\PageViewControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\PanGestureRecognizerTest.cs">
+      <Link>UIKit\PanGestureRecognizerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\PasteboardTest.cs">
+      <Link>UIKit\PasteboardTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\PickerViewTest.cs">
+      <Link>UIKit\PickerViewTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\PopoverBackgroundViewTest.cs">
+      <Link>UIKit\PopoverBackgroundViewTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\PopoverControllerTest.cs">
+      <Link>UIKit\PopoverControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\PopoverPresentationControllerTest.cs">
+      <Link>UIKit\PopoverPresentationControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\ProgressViewTest.cs">
+      <Link>UIKit\ProgressViewTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\ReferenceLibraryViewControllerTest.cs">
+      <Link>UIKit\ReferenceLibraryViewControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\ScrollViewTest.cs">
+      <Link>UIKit\ScrollViewTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\SearchBarTest.cs">
+      <Link>UIKit\SearchBarTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\SearchDisplayControllerTest.cs">
+      <Link>UIKit\SearchDisplayControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\SegmentedControlTest.cs">
+      <Link>UIKit\SegmentedControlTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\SimpleTextPrintFormatterTest.cs">
+      <Link>UIKit\SimpleTextPrintFormatterTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\SliderTest.cs">
+      <Link>UIKit\SliderTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\SplitViewControllerTest.cs">
+      <Link>UIKit\SplitViewControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\StepperTest.cs">
+      <Link>UIKit\StepperTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\StringAttributesTest.cs">
+      <Link>UIKit\StringAttributesTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\SwitchTest.cs">
+      <Link>UIKit\SwitchTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\TabBarControllerTest.cs">
+      <Link>UIKit\TabBarControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\TabBarTest.cs">
+      <Link>UIKit\TabBarTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\TableViewCellTest.cs">
+      <Link>UIKit\TableViewCellTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\TableViewControllerTest.cs">
+      <Link>UIKit\TableViewControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\TableViewTest.cs">
+      <Link>UIKit\TableViewTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\TarBarItemTest.cs">
+      <Link>UIKit\TarBarItemTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\TextAttachmentTest.cs">
+      <Link>UIKit\TextAttachmentTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\TextContainerTest.cs">
+      <Link>UIKit\TextContainerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\TextFieldTest.cs">
+      <Link>UIKit\TextFieldTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\TextViewTest.cs">
+      <Link>UIKit\TextViewTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\ToolbarTest.cs">
+      <Link>UIKit\ToolbarTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\UIAlertControllerTest.cs">
+      <Link>UIKit\UIAlertControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\UIContentSizeCategoryTest.cs">
+      <Link>UIKit\UIContentSizeCategoryTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\UIDocumentTest.cs">
+      <Link>UIKit\UIDocumentTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\UIDragDropSessionExtensionsTest.cs">
+      <Link>UIKit\UIDragDropSessionExtensionsTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\UIPasteConfigurationSupportingTest.cs">
+      <Link>UIKit\UIPasteConfigurationSupportingTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\UISearchControllerTest.cs">
+      <Link>UIKit\UISearchControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\UISpringLoadedInteractionSupportingTest.cs">
+      <Link>UIKit\UISpringLoadedInteractionSupportingTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\UIStackViewTest.cs">
+      <Link>UIKit\UIStackViewTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\VibrancyEffectTest.cs">
+      <Link>UIKit\VibrancyEffectTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\ViewControllerTest.cs">
+      <Link>UIKit\ViewControllerTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\ViewTest.cs">
+      <Link>UIKit\ViewTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\WebViewTest.cs">
+      <Link>UIKit\WebViewTest.cs</Link>
+    </Compile>
+    <Compile Include="UIKit\WindowTest.cs">
+      <Link>UIKit\WindowTest.cs</Link>
+    </Compile>
+    <Compile Include="VideoToolbox\VTCompressionSessionTests.cs">
+      <Link>VideoToolbox\VTCompressionSessionTests.cs</Link>
+    </Compile>
+    <Compile Include="VideoToolbox\VTDecompressionSessionTests.cs">
+      <Link>VideoToolbox\VTDecompressionSessionTests.cs</Link>
+    </Compile>
+    <Compile Include="VideoToolbox\VTFrameSiloTests.cs">
+      <Link>VideoToolbox\VTFrameSiloTests.cs</Link>
+    </Compile>
+    <Compile Include="VideoToolbox\VTMultiPassStorageTests.cs">
+      <Link>VideoToolbox\VTMultiPassStorageTests.cs</Link>
+    </Compile>
+    <Compile Include="VideoToolbox\VTUtilitiesTests.cs">
+      <Link>VideoToolbox\VTUtilitiesTests.cs</Link>
+    </Compile>
+    <Compile Include="VideoToolbox\VTVideoEncoderListTests.cs">
+      <Link>VideoToolbox\VTVideoEncoderListTests.cs</Link>
+    </Compile>
+    <Compile Include="iAd\BannerViewTest.cs">
+      <Link>iAd\BannerViewTest.cs</Link>
+    </Compile>
+    <Compile Include="iAd\ViewControllerExtensionsTest.cs">
+      <Link>iAd\ViewControllerExtensionsTest.cs</Link>
+    </Compile>
+    <Compile Include="mono\ConfigTest.cs">
+      <Link>mono\ConfigTest.cs</Link>
+    </Compile>
+    <Compile Include="mono\Symbols.cs">
+      <Link>mono\Symbols.cs</Link>
+    </Compile>
+    <Compile Include="mono\bug18634.cs">
+      <Link>mono\bug18634.cs</Link>
+    </Compile>
+    <Compile Include="mono\bug26989.cs">
+      <Link>mono\bug26989.cs</Link>
     </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
@@ -313,7 +1844,6 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Security\openssl_crt.der">
-        <LogicalName>monotouchtest.Security.openssl_crt.der</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -170,12 +170,19 @@ namespace xharness
 
 				yield return new TestData { Variation = "Release", MTouchExtraArgs = "", Debug = false, Profiling = false };
 				yield return new TestData { Variation = "AssemblyBuildTarget: SDK framework (release)", MTouchExtraArgs = "--assembly-build-target=@sdk=framework=Xamarin.Sdk --assembly-build-target=@all=staticobject", Debug = false, Profiling = false };
+
+				switch (test.TestName) {
+				case "monotouch-test":
+					yield return new TestData { Variation = "Debug (dynamic registrar removed)", MTouchExtraArgs = "--linker-optimize=+remove-dynamic-registrar", Debug = true, Profiling = false };
+					break;
+				}
 				break;
 			case "iPhoneSimulator":
 				switch (test.TestName) {
 				case "monotouch-test":
 					// The default is to run monotouch-test with the dynamic registrar (in the simulator), so that's already covered
 					yield return new TestData { Variation = "Debug (static registrar)", MTouchExtraArgs = "--registrar:static", Debug = true, Profiling = false };
+					yield return new TestData { Variation = "Debug (static registrar, with dynamic registrar removed)", MTouchExtraArgs = "--registrar:static --linker-optimize=+remove-dynamic-registrar", Debug = true, Profiling = false };
 					break;
 				}
 				break;

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -43,6 +43,7 @@ namespace Xamarin.Bundler {
 		public bool DeadStrip = true;
 		public bool EnableDebug;
 		internal RuntimeOptions RuntimeOptions;
+		public Optimizations Optimizations = new Optimizations ();
 		public RegistrarMode Registrar = RegistrarMode.Default;
 		public RegistrarOptions RegistrarOptions = RegistrarOptions.Default;
 		public SymbolMode SymbolMode;
@@ -77,6 +78,16 @@ namespace Xamarin.Bundler {
 		public Application (string[] arguments)
 		{
 			Cache = new Cache (arguments);
+		}
+
+		public bool DynamicRegistrationSupported {
+			get {
+#if MONOMAC // FIXME remove this ifdef
+				return Optimizations.RemoveDynamicRegistrar != true;
+#else
+				return Optimizations.RemoveDynamicRegistrar.Value != true;
+#endif
+			}
 		}
 
 		// This is just a name for this app to show in log/error messages, etc.

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -126,6 +126,15 @@ namespace Xamarin.Bundler {
 			options.Add ("root-assembly:", "Specifies any root assemblies. There must be at least one root assembly, usually the main executable.", (v) => {
 				app.RootAssemblies.Add (v);
 			});
+			options.Add ("linker-optimize=", "A comma-delimited list of optimizations to enable/disable. Example: --optimize=+remove-uithread-checks will make the linker remove the UI thread checks. Use 'all' to enable or disable all optimizations.\n" +
+					"Available optimizations:\n" +
+					"    remove-uithread-checks: By default enabled for release builds. Remove all UI Thread checks (makes the app smaller, and slightly faster at runtime).\n" +
+					"    remove-dynamic-registrar: By default enabled when the static registrar is enabled. Removes the dynamic registrar (makes the app smaller).\n" +
+					"    inline-setupblock-calls: By default enabled when removing the dynamic registrar (this is a required optimization to be able to remove the dynamic registrar). Does some work at build time to avoid doing the same work at runtime (faster at runtime, at the cost of a very small code increase per SetupBlock call, which is compensated for many times over if the dynamic registrar is successfully removed). There may be certain cases where calls to SetupBlock can't be inlined, in which case you'll get a build error if attempting to remove the dynamic registrar (asking you to disable the 'remove dynamic registrar' optimization)\n" +
+					"    inline-isdirectbinding: By default enabled for release builds. HELP HELP HELP.\n",
+					(v) => {
+						app.Optimizations.Parse (v.Split (','));
+					});
 			options.Add (new Mono.Options.ResponseFileSource ());
 		}
 

--- a/tools/common/Optimizations.cs
+++ b/tools/common/Optimizations.cs
@@ -1,0 +1,68 @@
+namespace Xamarin.Bundler {
+	public class Optimizations
+	{
+		public const string REMOVE_UITHREAD_CHECKS = "remove-uithread-checks";
+		public bool? RemoveUIThreadChecks;
+		public bool? InlineSetupBlock;
+		public bool? InlineIsDirectBinding;
+		public bool? RemoveDynamicRegistrar;
+		public bool? InlineIntPtrSize;
+
+		public void Parse (params string [] options)
+		{
+			foreach (var option in options)
+				Parse (option);
+		}
+
+		public void Parse (string option)
+		{
+			if (option == null || option.Length < 2)
+				throw ErrorHelper.CreateError (9999, "?");
+
+			bool enabled;
+			string opt;
+			switch (option [0]) {
+			case '-':
+				enabled = false;
+				opt = option.Substring (1);
+				break;
+			case '+':
+				enabled = true;
+				opt = option.Substring (1);
+				break;
+			default:
+				opt = option;
+				enabled = true;
+				break;
+			}
+
+			switch (opt) {
+			case "remove-dynamic-registrar":
+				RemoveDynamicRegistrar = enabled;
+				break;
+			case REMOVE_UITHREAD_CHECKS:
+				RemoveUIThreadChecks = enabled;
+				break;
+			case "inline-setupblock":
+				InlineSetupBlock = enabled;
+				break;
+			case "inline-isdirectbinding":
+				InlineIsDirectBinding = enabled;
+				break;
+			case "inline-intptr-size":
+				InlineIntPtrSize = enabled;
+				break;
+			case "all":
+				RemoveDynamicRegistrar = enabled;
+				RemoveUIThreadChecks = enabled;
+				InlineSetupBlock = enabled;
+				InlineIsDirectBinding = enabled;
+				InlineIntPtrSize = enabled;
+				break;
+			default:
+				ErrorHelper.Warning (9999, $"Unknown optimization: {opt}");
+				break;
+			}
+		}
+	}
+}

--- a/tools/linker/CoreRemoveAttributes.cs
+++ b/tools/linker/CoreRemoveAttributes.cs
@@ -1,20 +1,42 @@
 using System;
 using System.Collections.Generic;
 using Mono.Cecil;
+using Mono.Collections.Generic;
+using Xamarin.Tuner;
 
-namespace Xamarin.Linker {
+namespace Xamarin.Linker
+{
 
 	// this can be used (directly) with Xamarin.Mac and as the base of Xamarin.iOS step
-	public class CoreRemoveAttributes : MobileRemoveAttributes {
-		
+	public class CoreRemoveAttributes : MobileRemoveAttributes
+	{
+		protected DerivedLinkContext LinkContext {
+			get {
+				return (DerivedLinkContext) base.context;
+			}
+		}
+
 		protected override bool IsRemovedAttribute (CustomAttribute attribute)
 		{
 			// note: this also avoid calling FullName (which allocates a string)
 			var attr_type = attribute.Constructor.DeclaringType;
 			switch (attr_type.Name) {
+			case "AdoptsAttribute":
+			case "BlockProxyAttribute":
+			case "LinkerOptimizeAttribute":
+			case "NativeAttribute":
+			case "ReleaseAttribute":
+			case "UserDelegateTypeAttribute":
+				return attr_type.Namespace == Namespaces.ObjCRuntime && !LinkContext.DynamicRegistrationSupported;
+			//case "ExportAttribute":
+			//case "ModelAttribute":
+			//case "RegisterAttribute":
+			//case "ProtocolAttribute":
+			case "ProtocolMemberAttribute":
+				return attr_type.Namespace == Namespaces.Foundation && !LinkContext.DynamicRegistrationSupported;
 			case "AdviceAttribute":
 			case "FieldAttribute":
-			case "PreserveAttribute":	// the ApplyPreserveAttribute substep is executed before this
+			case "PreserveAttribute":       // the ApplyPreserveAttribute substep is executed before this
 			case "LinkerSafeAttribute":
 				return attr_type.Namespace == Namespaces.Foundation;
 			// used for documentation, not at runtime
@@ -50,27 +72,69 @@ namespace Xamarin.Linker {
 				case "AvailabilityBaseAttribute":
 				case "DeprecatedAttribute":
 				case "IntroducedAttribute":
-					var dict = context.Annotations.GetCustomAnnotations ("Availability");
-					List<Tuple<CustomAttribute,TypeReference>> attribs;
-					object attribObjects;
-					if (!dict.TryGetValue (provider, out attribObjects)) {
-						attribs = new List<Tuple<CustomAttribute, TypeReference>> ();
-						dict [provider] = attribs;
-					} else {
-						attribs = (List<Tuple<CustomAttribute, TypeReference>>) attribObjects;
-					}
-					// Make sure the attribute is resolved, since after removing the attribute
-					// it won't be able to do it. The 'CustomAttribute.Resolve' method is private, but fetching
-					// any property will cause it to be called.
-					// We also need to store the constructor's DeclaringType separately, because it may
-					// be nulled out from the constructor by the linker if the attribute type itself is linked away.
-					var dummy = attribute.HasConstructorArguments;
-					attribs.Add (new Tuple<CustomAttribute, TypeReference> (attribute, attribute.Constructor.DeclaringType));
+					StoreAttributeAsAnnotation ("Availability", provider, attribute);
+					break;
+				case "AdoptsAttribute":
+				case "BlockProxyAttribute":
+				case "NativeAttribute":
+				case "ReleaseAttribute":
+				case "UserDelegateTypeAttribute":
+					StoreAttributeAsAnnotation (attr_type.Name, provider, attribute);
+					break;
+				}
+			} else if (attr_type.Namespace == Namespaces.Foundation) {
+				switch (attr_type.Name) {
+				//case "ExportAttribute":
+				//case "ModelAttribute":
+				//case "RegisterAttribute":
+				case "ProtocolAttribute":
+				case "ProtocolMemberAttribute":
+					StoreAttributeAsAnnotation (attr_type.Name, provider, attribute);
+					break;
+				}
+			} else if (attr_type.Namespace == "System.Runtime.CompilerServices") {
+				switch (attr_type.Name) {
+				case "CompilerGeneratedAttribute":
+					StoreAttributeAsAnnotation (attr_type.Name, provider, attribute);
 					break;
 				}
 			}
 
 			base.WillRemoveAttribute (provider, attribute);
+		}
+
+		void StoreAttributeAsAnnotation (string name, ICustomAttributeProvider provider, CustomAttribute attribute)
+		{
+			var dict = context.Annotations.GetCustomAnnotations (name);
+			List<ICustomAttribute> attribs;
+			object attribObjects;
+			if (!dict.TryGetValue (provider, out attribObjects)) {
+				attribs = new List<ICustomAttribute> ();
+				dict [provider] = attribs;
+			} else {
+				attribs = (List<ICustomAttribute>) attribObjects;
+			}
+			// Make sure the attribute is resolved, since after removing the attribute
+			// it won't be able to do it. The 'CustomAttribute.Resolve' method is private, but fetching
+			// any property will cause it to be called.
+			// We also need to store the constructor's DeclaringType separately, because it may
+			// be nulled out from the constructor by the linker if the attribute type itself is linked away.
+			var dummy = attribute.HasConstructorArguments;
+			attribs.Add (new AttributeStorage { Attribute = attribute, AttributeType = attribute.Constructor.DeclaringType } );
+		}
+
+		class AttributeStorage : ICustomAttribute
+		{
+			public CustomAttribute Attribute;
+			public TypeReference AttributeType { get; set; }
+
+			public bool HasFields => Attribute.HasFields;
+			public bool HasProperties => Attribute.HasProperties;
+			public bool HasConstructorArguments => Attribute.HasConstructorArguments;
+
+			public Collection<CustomAttributeNamedArgument> Fields => Attribute.Fields;
+			public Collection<CustomAttributeNamedArgument> Properties => Attribute.Properties;
+			public Collection<CustomAttributeArgument> ConstructorArguments => Attribute.ConstructorArguments;
 		}
 	}
 }

--- a/tools/linker/MobileExtensions.cs
+++ b/tools/linker/MobileExtensions.cs
@@ -23,9 +23,27 @@ namespace Xamarin.Linker {
 			return false;
 		}
 
-		static bool HasGeneratedCodeAttribute (ICustomAttributeProvider provider)
+		public static bool HasCustomAttribute (this ICustomAttributeProvider provider, DerivedLinkContext context, string @namespace, string name)
 		{
-			return provider.HasCustomAttribute ("System.Runtime.CompilerServices", "CompilerGeneratedAttribute");
+			if (provider?.HasCustomAttributes == true) {
+				foreach (CustomAttribute attribute in provider.CustomAttributes) {
+					TypeReference tr = attribute.Constructor.DeclaringType;
+					if (tr.Is (@namespace, name))
+						return true;
+				}
+			}
+
+			return context?.GetCustomAttributes (provider, @namespace, name)?.Count > 0;
+		}
+
+		static bool HasGeneratedCodeAttribute (ICustomAttributeProvider provider, DerivedLinkContext context)
+		{
+			return provider.HasCustomAttribute (context, "System.Runtime.CompilerServices", "CompilerGeneratedAttribute");
+		}
+
+		static bool HasOptimizableAttribute (ICustomAttributeProvider provider, DerivedLinkContext context)
+		{
+			return provider.HasCustomAttribute (context, Namespaces.ObjCRuntime, "LinkerOptimizeAttribute");
 		}
 
 		static PropertyDefinition GetPropertyByAccessor (MethodDefinition method)
@@ -39,15 +57,22 @@ namespace Xamarin.Linker {
 
 		public static bool IsGeneratedCode (this MethodDefinition self, DerivedLinkContext link_context)
 		{
-			if (link_context.GeneratedCode != null)
-				return link_context.GeneratedCode.Contains (self);
-
 			// check the property too
 			if (self.IsGetter || self.IsSetter) {
-				if (HasGeneratedCodeAttribute (GetPropertyByAccessor (self)))
+				if (HasGeneratedCodeAttribute (GetPropertyByAccessor (self), link_context))
 					return true;
 			}
-			return HasGeneratedCodeAttribute (self);
+			return HasGeneratedCodeAttribute (self, link_context);
+		}
+
+		public static bool IsOptimizableCode (this MethodDefinition self, DerivedLinkContext link_context)
+		{
+			if (self.IsGetter || self.IsSetter) {
+				var accessor = GetPropertyByAccessor (self);
+				if (HasOptimizableAttribute (accessor, link_context))
+					return true;
+			}
+			return HasOptimizableAttribute (self, link_context);
 		}
 	}
 }

--- a/tools/linker/MobileSweepStep.cs
+++ b/tools/linker/MobileSweepStep.cs
@@ -6,6 +6,8 @@ using Mono.Cecil;
 using Mono.Linker;
 using Mono.Linker.Steps;
 
+using Xamarin.Tuner;
+
 namespace Xamarin.Linker {
 
 	// MobileMarkStep process a bit more data and that can be used to sweep
@@ -19,6 +21,10 @@ namespace Xamarin.Linker {
 		}
 
 		public AssemblyAction CurrentAction { get; private set; }
+
+		public DerivedLinkContext LinkContext {
+			get { return (DerivedLinkContext) base.Context; }
+		}
 
 		protected override void Process ()
 		{

--- a/tools/linker/MonoTouch.Tuner/MonoTouchSweepStep.cs
+++ b/tools/linker/MonoTouch.Tuner/MonoTouchSweepStep.cs
@@ -50,5 +50,16 @@ namespace MonoTouch.Tuner {
 					attributes.RemoveAt (i--);
 			}
 		}
+
+		protected override void InterfaceRemoved (TypeDefinition type, InterfaceImplementation iface)
+		{
+			base.InterfaceRemoved (type, iface);
+
+			List<TypeDefinition> list;
+			if (!LinkContext.ProtocolImplementations.TryGetValue (type, out list))
+				LinkContext.ProtocolImplementations [type] = list = new List<TypeDefinition> ();
+			list.Add (iface.InterfaceType.Resolve ());
+			System.Console.WriteLine ($"Removed interface implementation: {type.FullName} does not implement {iface.InterfaceType.FullName} anymore.");
+		}
 	}
 }

--- a/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs
@@ -1,4 +1,5 @@
 // Copyright 2012-2014, 2016 Xamarin Inc. All rights reserved.
+//#define TRACE
 using System;
 using Mono.Tuner;
 using Mono.Cecil;
@@ -12,7 +13,7 @@ namespace MonoTouch.Tuner {
 		// If the type currently being processed is a direct binding or not.
 		// A null value means it's not a constant value, and can't be inlined.
 		bool? isdirectbinding_constant;
-		
+
 		public OptimizeGeneratedCodeSubStep (LinkerOptions options)
 		{
 			Options = options;
@@ -20,7 +21,7 @@ namespace MonoTouch.Tuner {
 			Console.WriteLine ("OptimizeGeneratedCodeSubStep Arch {0} Device: {1}, EnsureUiThread: {2}, FAT 32+64 {3}", Arch, Device, EnsureUIThread, IsDualBuild);
 #endif
 		}
-		
+
 		public int Arch {
 			get { return Options.Arch; }
 		}
@@ -28,13 +29,38 @@ namespace MonoTouch.Tuner {
 		public bool Device {
 			get { return Options.Device; }
 		}
-		
+
 		public bool EnsureUIThread {
 			get { return Options.EnsureUIThread; }
 		}
 
 		public bool IsDualBuild {
 			get { return Options.IsDualBuild; }
+		}
+
+		public bool InlineSetupBlock {
+			get {
+				// Enabled by default always.
+				return LinkContext.App.Optimizations.InlineSetupBlock != false;
+			}
+		}
+
+		MethodDefinition setupblock_def;
+		MethodReference GetBlockSetupImpl (MethodDefinition caller)
+		{
+			if (setupblock_def == null) {
+				var type = LinkContext.GetAssembly (Driver.GetProductAssembly (LinkContext.Target.App)).MainModule.GetType (Namespaces.ObjCRuntime, "BlockLiteral");
+				foreach (var method in type.Methods) {
+					if (method.Name != "SetupBlockImpl")
+						continue;
+					setupblock_def = method;
+					setupblock_def.IsPublic = true;
+					break;
+				}
+				if (setupblock_def == null)
+					throw new NotImplementedException ();
+			}
+			return caller.Module.ImportReference (setupblock_def);
 		}
 
 		LinkerOptions Options { get; set; }
@@ -55,13 +81,18 @@ namespace MonoTouch.Tuner {
 			// For non-fat apps (the AppStore allows 64bits only iOS apps) then it's better to be applied
 			//
 			// TODO: we could make this an option "optimize for size vs optimize for speed" in the future
-			ApplyIntPtrSizeOptimization = ((Profile.Current as BaseProfile).ProductAssembly == assembly.Name.Name) || !IsDualBuild;
+			if (LinkContext.App.Optimizations.InlineIntPtrSize.HasValue) {
+				ApplyIntPtrSizeOptimization = LinkContext.App.Optimizations.InlineIntPtrSize.Value;
+			} else {
+				ApplyIntPtrSizeOptimization = ((Profile.Current as BaseProfile).ProductAssembly == assembly.Name.Name) || !IsDualBuild;
+			}
+
 			base.Process (assembly);
 		}
 
 		protected override void Process (TypeDefinition type)
 		{
-			if (!HasGeneratedCode)
+			if (!HasOptimizableCode)
 				return;
 
 			isdirectbinding_constant = type.IsNSObject (LinkContext) ? type.GetIsDirectBindingConstant (LinkContext) : null;
@@ -73,19 +104,30 @@ namespace MonoTouch.Tuner {
 			if (!method.HasBody)
 				return;
 
-			if (method.IsGeneratedCode (LinkContext) && (IsExtensionType || IsExport (method))) {
+			if (method.IsOptimizableCode (LinkContext)) {
+				// We optimize methods that have the [LinkerOptimize] attribute,
+			} else if (method.IsGeneratedCode (LinkContext) && (IsExtensionType || IsExport (method))) {
 				// We optimize methods that have the [GeneratedCodeAttribute] and is either an extension type or an exported method
 			} else {
 				// but it would be too risky to apply on user-generated code
 				return;
 			}
 			
+			if (!LinkContext.DynamicRegistrationSupported && method.Name == "get_DynamicRegistrationSupported" && method.DeclaringType.Is ("ObjCRuntime", "Runtime")) {
+				// Rewrite to return 'false'
+				var instr = method.Body.Instructions;
+				instr.Clear ();
+				instr.Add (Instruction.Create (OpCodes.Ldc_I4_0));
+				instr.Add (Instruction.Create (OpCodes.Ret));
+				return; // nothing else to do here.
+			}
+
 			var instructions = method.Body.Instructions;
 			for (int i = 0; i < instructions.Count; i++) {
 				var ins = instructions [i];
 				switch (ins.OpCode.Code) {
 				case Code.Call:
-					ProcessCalls (method, ins);
+					i += ProcessCalls (method, ins);
 					break;
 				case Code.Ldsfld:
 					ProcessLoadStaticField (method, ins);
@@ -96,9 +138,60 @@ namespace MonoTouch.Tuner {
 			EliminateDeadCode (method);
 		}
 
-		void ProcessCalls (MethodDefinition caller, Instruction ins)
+		TypeReference InflateType (GenericInstanceType git, TypeReference type)
+		{
+			var gt = type as GenericParameter;
+			if (gt != null)
+				return git.GenericArguments [gt.Position];
+			if (type is TypeSpecification)
+				throw new NotImplementedException ();
+			return type;
+		}
+
+		MethodReference InflateMethod (TypeReference inflatedDeclaringType, MethodDefinition method)
+		{
+			var git = inflatedDeclaringType as GenericInstanceType;
+			if (git == null)
+				return method;
+			var mr = new MethodReference (method.Name, InflateType (git, method.ReturnType), git);
+			if (method.HasParameters) {
+				for (int i = 0; i < method.Parameters.Count; i++) {
+					var p = new ParameterDefinition (method.Parameters [i].Name, method.Parameters [i].Attributes, InflateType (git, method.Parameters [i].ParameterType));
+					mr.Parameters.Add (p);
+				}
+			}
+			return mr;
+		}
+
+		bool IsSubclassed (TypeDefinition type, TypeDefinition byType)
+		{
+			if (byType.Is (type.Namespace, type.Name))
+				return true;
+			if (byType.HasNestedTypes) {
+				foreach (var ns in byType.NestedTypes) {
+					if (IsSubclassed (type, ns))
+						return true;
+				}
+			}
+			return false;
+		}
+
+		bool IsSubclassed (TypeDefinition type)
+		{
+			foreach (var a in context.GetAssemblies ()) {
+				foreach (var s in a.MainModule.Types) {
+					if (IsSubclassed (type, s))
+						return true;
+				}
+			}
+			return false;
+		}
+
+		// returns the number of instructions added (if positive) or removed (if negative)
+		int ProcessCalls (MethodDefinition caller, Instruction ins)
 		{
 			var mr = ins.Operand as MethodReference;
+
 			switch (mr?.Name) {
 			case "EnsureUIThread":
 				ProcessEnsureUIThread (caller, ins);
@@ -109,7 +202,106 @@ namespace MonoTouch.Tuner {
 			case "get_IsDirectBinding":
 				ProcessIsDirectBinding (caller, ins);
 				break;
+			case "SetupBlock":
+			case "SetupBlockUnsafe":
+				// This will optimize calls to SetupBlock and SetupBlockUnsafe by calculating the signature for the block
+				// (which both SetupBlock and SetupBlockUnsafe do), and then rewrite the code to call SetupBlockImpl instead
+				// (which takes the block signature as an argument instead of calculating it). This is required when
+				// removing the dynamic registrar, because calculating the block signature is done in the dynamic registrar.
+				if (!InlineSetupBlock)
+					return 0;
+				if (!mr.DeclaringType.Is (Namespaces.ObjCRuntime, "BlockLiteral"))
+					return 0;
+
+				var prev = ins.Previous;
+				if (prev.OpCode.StackBehaviourPop != StackBehaviour.Pop0) {
+					Driver.Log (1, "Failed to optimize {0}': for instruction '{1}' expected previous instruction '{2}' to be Pop0", caller, prev.Next, prev);
+					return 0;
+				} else if (prev.OpCode.StackBehaviourPush != StackBehaviour.Push1) {
+					Driver.Log (1, "Failed to optimize {0}': for instruction '{1}' expected previous instruction '{2}' to be Push1", caller, prev.Next, prev);
+					return 0;
+				}
+				prev = prev.Previous;
+				TypeReference delegateType = null;
+
+				if (prev.OpCode.StackBehaviourPop != StackBehaviour.Pop0) {
+					Driver.Log (1, "Failed to optimize {0}': for instruction '{1}' expected previous instruction '{2}' to be Pop0", caller, prev.Next, prev);
+					return 0;
+				} else if (prev.OpCode.StackBehaviourPush != StackBehaviour.Push1) {
+					Driver.Log (1, "Failed to optimize {0}': for instruction '{1}' expected previous instruction '{2}' to be Push1", caller, prev.Next, prev);
+					return 0;
+				} else if (prev.OpCode.Code == Code.Ldsfld) {
+					delegateType = ((FieldReference) prev.Operand).Resolve ().FieldType;
+				} else {
+					Driver.Log (1, "Failed to optimize {0}': for instruction '{1}' expected previous instruction '{2}' to be Ldsfld", caller, prev.Next, prev);
+					return 0;
+				}
+
+				// Calculate the block signature
+				TypeReference userDelegateType = null;
+				var delegateTypeDefinition = delegateType.Resolve ();
+				foreach (var attrib in delegateTypeDefinition.CustomAttributes) {
+					var attribType = attrib.Constructor.DeclaringType;
+					if (!attribType.Is (Namespaces.ObjCRuntime, "UserDelegateTypeAttribute"))
+						continue;
+					userDelegateType = attrib.ConstructorArguments [0].Value as TypeReference;
+					break;
+				}
+				bool blockSignature = false;
+				string signature = null;
+				MethodReference userMethod = null;
+				if (userDelegateType != null) {
+					var userDelegateTypeDefinition = userDelegateType.Resolve ();
+					MethodDefinition userMethodDefinition = null;
+					foreach (var method in userDelegateTypeDefinition.Methods) {
+						if (method.Name != "Invoke")
+							continue;
+						userMethodDefinition = method;
+						break;
+					}
+					if (userMethodDefinition == null)
+						throw new NotImplementedException ();
+					blockSignature = true;
+					userMethod = InflateMethod (userDelegateType, userMethodDefinition);
+				} else if (delegateType.Is ("System", "Action`1") && (delegateType is GenericInstanceType git) && git.GenericArguments [0].Is ("System", "IntPtr")) {
+					signature = "v@?";
+				} else {
+					Driver.Log (0, "Failed to optimize {0}: for instruction '{1}' could not find the UserDelegateTypeAttribute on {2}", caller, ins, delegateType.FullName);
+					return 0;
+				}
+				if (signature == null) {
+					try {
+						var parameters = new TypeReference [userMethod.Parameters.Count];
+						for (int p = 0; p < parameters.Length; p++)
+							parameters [p] = userMethod.Parameters [p].ParameterType;
+						signature = LinkContext.Target.StaticRegistrar.ComputeSignature (userMethod.DeclaringType, false, userMethod.ReturnType, parameters, isBlockSignature: blockSignature);
+					} catch (Exception e) {
+						Driver.Log (1, "Failed to optimize {0}: for instruction '{1}': {2}", caller, ins, e.Message);
+						signature = "BROKEN SIGNATURE"; // FIXME: fix the broken binding
+					}
+				}
+
+				var instructions = caller.Body.Instructions;
+				var index = instructions.IndexOf (ins);
+				instructions.Insert (index, Instruction.Create (OpCodes.Ldstr, signature));
+				instructions.Insert (index, Instruction.Create (mr.Name == "SetupBlockUnsafe" ? OpCodes.Ldc_I4_0 : OpCodes.Ldc_I4_1));
+				ins.Operand = GetBlockSetupImpl (caller);
+
+				Driver.Log (1, "Optimized {0} ('{1}') with delegate type {2} and signature {3}", caller, ins, delegateType.FullName, signature);
+
+				return 2;
+			case "get_DynamicRegistrationSupported":
+				if (LinkContext.DynamicRegistrationSupported)
+					return 0;
+				
+				if (!mr.DeclaringType.Is (Namespaces.ObjCRuntime, "Runtime"))
+					return 0;
+				
+				ProcessIsDynamicSupported (caller, ins, false);
+				break;
 			}
+
+			return 0;
 		}
 				
 		// https://app.asana.com/0/77259014252/77812690163
@@ -142,9 +334,30 @@ namespace MonoTouch.Tuner {
 			ins.Operand = null;
 		}
 
+		void ProcessIsDynamicSupported (MethodDefinition caller, Instruction ins, bool value)
+		{
+			const string operation = "inline Runtime.IsDynamicSupported";
+
+			/* FIXME: check for user-settable optimization condition */
+
+			// Verify we're checking the right Runtime.IsDynamicSupported call
+			var mr = ins.Operand as MethodReference;
+			if (!mr.DeclaringType.Is (Namespaces.ObjCRuntime, "Runtime"))
+				return;
+			
+			if (!ValidateInstruction (caller, ins, operation, Code.Call))
+				return;
+
+			// We're fine, inline the Runtime.Arch condition
+			// The enum values are IsDynamicSupported condition
+			ins.OpCode = LinkContext.DynamicRegistrationSupported ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0;
+			ins.Operand = null;
+		}
+
 		void ProcessEnsureUIThread (MethodDefinition caller, Instruction ins)
 		{
 			const string operation = "remove calls to UIApplication::EnsureUIThread";
+
 
 			if (EnsureUIThread)
 				return;

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -131,6 +131,7 @@ mmp_sources = \
 	$(TOP)/tools/common/CoreResolver.cs \
 	$(TOP)/tools/common/DerivedLinkContext.cs \
 	$(TOP)/tools/common/StringUtils.cs \
+	$(TOP)/tools/common/Optimizations.cs \
 	$(TOP)/src/Foundation/ConnectAttribute.cs \
 	$(TOP)/src/Foundation/ExportAttribute.cs \
 	$(TOP)/src/ObjCRuntime/ArgumentSemantic.cs \

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -317,6 +317,9 @@
     <Compile Include="..\common\DerivedLinkContext.cs">
       <Link>external\DerivedLinkContext.cs</Link>
     </Compile>
+    <Compile Include="..\common\Optimizations.cs">
+      <Link>external\Optimizations.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\ObjCRuntime\Registrar.core.cs">
       <Link>external\Registrar.core.cs</Link>
     </Compile>

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -112,7 +112,10 @@ namespace Xamarin.Bundler {
 		public bool ManagedStrip = true;
 		public List<string> NoSymbolStrip = new List<string> ();
 		
-		public bool? ThreadCheck;
+		public bool? ThreadCheck {
+			get { return Optimizations.RemoveUIThreadChecks.HasValue ? !Optimizations.RemoveUIThreadChecks.Value : (bool?) null; } 
+			set { Optimizations.RemoveUIThreadChecks = value.HasValue ? !value.Value : (bool?) null; }
+		}
 		public DlsymOptions DlsymOptions;
 		public List<Tuple<string, bool>> DlsymAssemblies;
 		public bool? UseMonoFramework;

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -138,6 +138,7 @@ MTOUCH_SOURCES = \
 	$(TOP)/tools/common/DerivedLinkContext.cs \
 	$(TOP)/tools/common/Target.cs \
 	$(TOP)/tools/common/CompilerFlags.cs \
+    $(TOP)/tools/common/Optimizations.cs \
 	$(TOP)/src/Foundation/ExportAttribute.cs \
 	$(TOP)/src/Foundation/ConnectAttribute.cs \
 	$(XAMARIN_MACDEV_PATH)/Xamarin.MacDev/PListObject.cs \

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -148,8 +148,6 @@ namespace MonoTouch.Tuner {
 			sub.Add (new CoreRemoveSecurity ());
 			sub.Add (new OptimizeGeneratedCodeSubStep (options));
 			sub.Add (new RemoveUserResourcesSubStep (options));
-			// OptimizeGeneratedCodeSubStep and RemoveUserResourcesSubStep needs [GeneratedCode] so it must occurs before RemoveAttributes
-			sub.Add (new RemoveAttributes ());
 			// http://bugzilla.xamarin.com/show_bug.cgi?id=1408
 			if (options.LinkAway)
 				sub.Add (new RemoveCode (options));
@@ -195,6 +193,15 @@ namespace MonoTouch.Tuner {
 				pipeline.AppendStep (new MonoTouchTypeMapStep ());
 
 				pipeline.AppendStep (GetSubSteps (options));
+
+				// RemoveUserResourcesSubStep needs [GeneratedCode] so it must occurs before RemoveAttributes
+				// OptimizeGeneratedCodeSubStep also needs several other attributes to properly inline code
+				// Unfortunately SubStepDispatcher doesn't process substeps sequentially (it first runs all the substeps for all fields, then for all methods, etc)
+				// which means that the only way to ensure no attributes are removed before running the OptimizeGeneratedCodeSubStep 
+				// is to put it in a different SubStepDispatcher
+				var attributeRemover = new SubStepDispatcher ();
+				attributeRemover.Add (new RemoveAttributes ());
+				pipeline.AppendStep (attributeRemover);
 
 				pipeline.AppendStep (new PreserveCode (options));
 

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -669,6 +669,7 @@ namespace Xamarin.Bundler
 						sw.WriteLine ("\tsetenv (\"MONO_GC_PARAMS\", \"{0}\", 1);", app.MonoGCParams);
 					foreach (var kvp in app.EnvironmentVariables)
 						sw.WriteLine ("\tsetenv (\"{0}\", \"{1}\", 1);", kvp.Key.Replace ("\"", "\\\""), kvp.Value.Replace ("\"", "\\\""));
+					sw.WriteLine ("\txamarin_supports_dynamic_registration = {0};", app.DynamicRegistrationSupported ? "TRUE" : "FALSE");
 					sw.WriteLine ("}");
 					sw.WriteLine ();
 					sw.Write ("int ");
@@ -941,11 +942,21 @@ namespace Xamarin.Bundler
 			return 0;
 		}
 
+		public static void Dump (string msg, params string[] extra)
+		{
+			//var t = ((global::Mono.Cecil.TypeDefinitionCollection) Xamarin.Bundler.Driver.Application.Targets [0].Assemblies ["Xamarin.iOS"].AssemblyDefinition.MainModule.Types).GetType ("ObjCRuntime", "Trampolines").NestedTypes [1470];
+			//Console.WriteLine ($"{msg} {t.FullName}: {t.CustomAttributes.Count} {string.Join (", ", extra)}");
+			//if (t.CustomAttributes.Count < 2)
+				//Console.WriteLine ("STOP");
+		}
+
+		public static Application Application;
 		static Application ParseArguments (string [] args, out Action a)
 		{
 			var action = Action.None;
+			var assemblies = new List<string> ();
 			var app = new Application (args);
-
+			Application = app;
 			if (extra_args != null) {
 				var l = new List<string> (args);
 				foreach (var s in extra_args.Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries))

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -357,6 +357,9 @@
     <Compile Include="..\common\CoreResolver.cs">
       <Link>common\CoreResolver.cs</Link>
     </Compile>
+    <Compile Include="..\common\Optimizations.cs">
+      <Link>external\Optimizations.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Core" />


### PR DESCRIPTION
This is an early version of an optimization that will make the dynamic
registrar removable by the linker.

Expected consequences:

* Smaller app.
* Faster startup, because as much as possible will be done at build time, and
  if information is needed, it will be stored in a format that's quick and
  easy to access at runtime (i.e. not in managed attributes).
* Smaller minimum memory usage, because less work will be done at startup.

Hopefully this will fix (or at least improve) bug #[56022](https://bugzilla.xamarin.com/show_bug.cgi?id=56022).

First: there are many minor issues (whitespace changes, inconsistent code,
dead code, debug code/spew, etc), no need to comment on those, I'm aware of
them :smile:

A very incomplete list of changes, in no particular order:

* Add a [LinkerOptimize] attribute, to tell the linker what to optimize (in
  OptimizeGeneratedCodeSubStep)
* We want to optimize manually written code, and it makes more sense to add a
  new attribute than to re-use [GeneratedCode] (since it won't be generated
  code)
* MonoTouchMarkTypeStep tries to determine whether the dynamic registrar can
  be removed, and sets a flag.
* There's a new Runtime.DynamicRegistrationSupported property, which the
  linker rewrites to a constant false value if MonoTouchMarkTypeStep
  determined that the dynamic registrar could be removed
* The linker also rewrites all calls to
  Runtime.get_DynamicRegistrationSupported to a constant value, and removes
  the resulting dead code.
* The linker also tries to rewrite some code that requires the dynamic
  registrar to code that doesn't (in particular BlockLiteral.SetupBlock
  requires the dynamic registrar to calculate the native signature of the
  block; I've added a BlockLiteral.SetupBlockImpl that takes the signature as
  an additional argument, and then the linker can calculate the signature at
  build time and rewrite the call from SetupBlock to SetupBlockImpl).
* If everything that actually uses the dynamic registrar is removed, than the
  linker will also remove the dynamic registrar itself.
* There's a new --linker-optimize=... mtouch/mmp command line argument which
  can be used to enable/disable specific optimizations. This is currently
  half-done. Auto-detected/enabled optimizations can be forcefully enabled
  using this mechanism (which is needed so that we can test removal of the
  dynamic registrar in monotouch-test, since monotouch-test uses features that
  require the dynamic registrar, and the linker is smart enough to avoid
  removing the dynamic registrar in this case)
* The static registrar creates a map of which protocols each managed type
  implements. It also creates a map of which managed type to instantiate given
  a native protocol (the WrapperType property of the Protocol attribute).
* The linker will by default mark interfaces implemented by a (marked) type,
  but for protocols we override this behavior to only mark the interface if
  the type implements any methods from the (protocol) interface.
* Additional tests:
        * Run monotouch-test with both the dynamic and static registrar in the
          simulator
        * Run monotouch-test with both the dynamic registrar forcibly removed, and
          without forcing anything, on device. Force is needed because the linker
          will (correctly) detect that monotouch-test uses features that require
          the dynamic registrar (in some of the tests).