### PR TITLE
[linker] Refactor and simplify code optimizations.

### DIFF
--- a/tools/linker/CoreOptimizeGeneratedCode.cs
+++ b/tools/linker/CoreOptimizeGeneratedCode.cs
@@ -5,6 +5,7 @@ using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Linker;
 using Mono.Tuner;
+using Xamarin.Bundler;
 
 namespace Xamarin.Linker {
 
@@ -80,5 +81,362 @@ namespace Xamarin.Linker {
 			ins.OpCode = OpCodes.Nop;
 			ins.Operand = null;
 		}
+
+		protected static bool ValidateInstruction (MethodDefinition caller, Instruction ins, string operation, Code expected)
+		{
+			if (ins.OpCode.Code != expected) {
+				Driver.Log (1, "Could not {0} in {1} at offset {2}, expected {3} got {4}", operation, caller, ins.Offset, expected, ins);
+				return false;
+			}
+
+			return true;
+		}
+
+		protected static bool ValidateInstruction (MethodDefinition caller, Instruction ins, string operation, params Code [] expected)
+		{
+			foreach (var code in expected) {
+				if (ins.OpCode.Code == code)
+					return true;
+			}
+
+			Driver.Log (1, "Could not {0} in {1} at offset {2}, expected any of [{3}] got {4}", operation, caller, ins.Offset, string.Join (", ", expected), ins);
+			return false;
+		}
+
+		static int? GetConstantValue (Instruction ins)
+		{
+			if (ins == null)
+				return null;
+			
+			switch (ins.OpCode.Code) {
+			case Code.Ldc_I4_0:
+				return 0;
+			case Code.Ldc_I4_1:
+				return 1;
+			case Code.Ldc_I4_2:
+				return 2;
+			case Code.Ldc_I4_3:
+				return 3;
+			case Code.Ldc_I4_4:
+				return 4;
+			case Code.Ldc_I4_5:
+				return 5;
+			case Code.Ldc_I4_6:
+				return 6;
+			case Code.Ldc_I4_7:
+				return 7;
+			case Code.Ldc_I4_8:
+				return 8;
+			case Code.Ldc_I4:
+			case Code.Ldc_I4_S:
+				if (ins.Operand is int)
+					return (int) ins.Operand;
+				return null;
+#if DEBUG
+			case Code.Isinst: // We might be able to calculate a constant value here in the future
+			case Code.Ldloc:
+			case Code.Ldloca:
+			case Code.Ldloc_0:
+			case Code.Ldloc_1:
+			case Code.Ldloc_2:
+			case Code.Ldloc_3:
+			case Code.Ldloc_S:
+			case Code.Ldloca_S:
+			case Code.Ldarg:
+			case Code.Ldarg_0:
+			case Code.Ldarg_1:
+			case Code.Ldarg_2:
+			case Code.Ldarg_3:
+			case Code.Ldarg_S:
+			case Code.Ldarga:
+			case Code.Call:
+			case Code.Calli:
+			case Code.Callvirt:
+			case Code.Box:
+			case Code.Ldsfld:
+				return null; // just to not hit the CWL below
+#endif
+			default:
+#if DEBUG
+				Driver.Log (9, "Unknown conditional instruction: {0}", ins);
+#endif
+				return null;
+			}
+		}
+
+		static bool MarkInstructions (MethodDefinition method, Mono.Collections.Generic.Collection<Instruction> instructions, bool [] reachable, int start, int end)
+		{
+			if (reachable [start])
+				return true; // We've already marked this section of code
+
+			for (int i = start; i < end; i++) {
+				if (instructions [i].OpCode.Code != Code.Nop) {
+					// Not marking nop instructios makes it possible to remove catch clauses if 
+					// the protected region is only nops (or empty).
+					reachable [i] = true;
+				}
+
+				var ins = instructions [i];
+				switch (ins.OpCode.FlowControl) {
+				case FlowControl.Branch:
+					// Unconditional branch, we continue marking from the instruction that we branch to.
+					var br_target = (Instruction) ins.Operand;
+					return MarkInstructions (method, instructions, reachable, instructions.IndexOf (br_target), end);
+				case FlowControl.Cond_Branch:
+					// Conditional instruction, we need to check if we can calculate a constant value for the condition
+					var cond_target = (Instruction) ins.Operand;
+					bool? branch = null; // did we get a constant value for the condition, and if so, did we branch or not?
+					var cond_instruction_count = 0; // The number of instructions that compose the condition
+
+					switch (ins.OpCode.Code) {
+					case Code.Brtrue:
+					case Code.Brtrue_S: {
+							var v = GetConstantValue (ins?.Previous);
+							if (v.HasValue)
+								branch = v.Value != 0;
+							cond_instruction_count = 2;
+							break;
+						}
+					case Code.Brfalse:
+					case Code.Brfalse_S: {
+							var v = GetConstantValue (ins?.Previous);
+							if (v.HasValue)
+								branch = v.Value == 0;
+							cond_instruction_count = 2;
+							break;
+						}
+					case Code.Beq:
+					case Code.Beq_S: {
+							var x1 = GetConstantValue (ins?.Previous?.Previous);
+							var x2 = GetConstantValue (ins?.Previous);
+							if (x1.HasValue && x2.HasValue)
+								branch = x1.Value == x2.Value;
+							cond_instruction_count = 3;
+							break;
+						}
+					case Code.Bne_Un:
+					case Code.Bne_Un_S: {
+							var x1 = GetConstantValue (ins?.Previous?.Previous);
+							var x2 = GetConstantValue (ins?.Previous);
+							if (x1.HasValue && x2.HasValue)
+								branch = x1.Value != x2.Value;
+							cond_instruction_count = 3;
+							break;
+						}
+					case Code.Ble:
+					case Code.Ble_S:
+					case Code.Ble_Un:
+					case Code.Ble_Un_S: {
+							var x1 = GetConstantValue (ins?.Previous?.Previous);
+							var x2 = GetConstantValue (ins?.Previous);
+							if (x1.HasValue && x2.HasValue)
+								branch = x1.Value <= x2.Value;
+							cond_instruction_count = 3;
+							break;
+						}
+					case Code.Blt:
+					case Code.Blt_S:
+					case Code.Blt_Un:
+					case Code.Blt_Un_S: {
+							var x1 = GetConstantValue (ins?.Previous?.Previous);
+							var x2 = GetConstantValue (ins?.Previous);
+							if (x1.HasValue && x2.HasValue)
+								branch = x1.Value <= x2.Value;
+							cond_instruction_count = 3;
+							break;
+						}
+					case Code.Bge:
+					case Code.Bge_S:
+					case Code.Bge_Un:
+					case Code.Bge_Un_S: {
+							var x1 = GetConstantValue (ins?.Previous?.Previous);
+							var x2 = GetConstantValue (ins?.Previous);
+							if (x1.HasValue && x2.HasValue)
+								branch = x1.Value >= x2.Value;
+							cond_instruction_count = 3;
+							break;
+						}
+					case Code.Bgt:
+					case Code.Bgt_S:
+					case Code.Bgt_Un:
+					case Code.Bgt_Un_S: {
+							var x1 = GetConstantValue (ins?.Previous?.Previous);
+							var x2 = GetConstantValue (ins?.Previous);
+							if (x1.HasValue && x2.HasValue)
+								branch = x1.Value > x2.Value;
+							cond_instruction_count = 3;
+							break;
+						}
+					default:
+						Driver.Log ($"Can't optimize {0} because of unknown branch instruction: {1}", method, ins);
+						break;
+					}
+
+					if (branch.HasValue) {
+						// Make sure nothing else in the method branches into the middle of our supposedly constant condition,
+						// bypassing our constant calculation. Note that it's not a bad to branch to the _first_ instruction in
+						// the sequence (thus the +2 here), just into the middle of it.
+						if (AnyBranchTo (instructions, instructions [i - cond_instruction_count + 2], ins))
+							branch = null;
+					}
+
+					if (!branch.HasValue) {
+						// not constant, continue marking both this code sequence and the branched sequence
+						if (!MarkInstructions (method, instructions, reachable, instructions.IndexOf (cond_target), end))
+							return false;
+					} else {
+						// we can remove the branch (and the code that loads the condition), so we mark those instructions as dead.
+						for (int a = 0; a < cond_instruction_count; a++)
+							reachable [i - a] = false;
+
+						// Now continue marking according to whether we branched or not
+						if (branch.Value) {
+							// branch always taken
+							return MarkInstructions (method, instructions, reachable, instructions.IndexOf (cond_target), end);
+						} else {
+							// branch never taken
+							// continue looping
+						}
+					}
+					break;
+				case FlowControl.Call:
+				case FlowControl.Next:
+					// Nothing special, continue marking
+					break;
+				case FlowControl.Return:
+				case FlowControl.Throw:
+					// Control flow returns here, so stop marking
+					return true;
+				case FlowControl.Break:
+				case FlowControl.Meta:
+				case FlowControl.Phi:
+				default:
+					Driver.Log (4, "Can't optimize {0} because of unknown flow control for: {1}", method, ins);
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		// Check if there are any branches in the instructions that branch to anywhere between 'first' and 'last' instructions (both inclusive).
+		static bool AnyBranchTo (Mono.Collections.Generic.Collection<Instruction> instructions, Instruction first, Instruction last)
+		{
+			if (first.Offset > last.Offset) {
+				Driver.Log ($"Broken assumption: {first} is after {last}");
+				return true; // This is the safe thing to do, since it will prevent inlining
+			}
+
+			for (int i = 0; i < instructions.Count; i++) {
+				var ins = instructions [i];
+				switch (ins.OpCode.FlowControl) {
+				case FlowControl.Branch:
+				case FlowControl.Cond_Branch:
+					var target = ins.Operand as Instruction;
+					if (target != null && target.Offset >= first.Offset && target.Offset <= last.Offset)
+						return true;
+					break;
+				}
+			}
+
+			return false;
+		}
+
+		protected static void EliminateDeadCode (MethodDefinition caller)
+		{
+			var instructions = caller.Body.Instructions;
+			var reachable = new bool [instructions.Count];
+
+			// We walk the instructions in the method, starting with the first instruction,
+			// marking all reachable instructions. Any non-reachable instructions at the end
+			// can be removed.
+
+			if (!MarkInstructions (caller, instructions, reachable, 0, instructions.Count))
+				return;
+
+			// Handle exception handlers specially, they do not follow normal code flow.
+			if (caller.Body.HasExceptionHandlers) {
+				foreach (var eh in caller.Body.ExceptionHandlers) {
+					switch (eh.HandlerType) {
+					case ExceptionHandlerType.Catch:
+						// We don't need catch handlers if the protected region does not have any reachable instructions.
+						var startI = instructions.IndexOf (eh.TryStart);
+						var endI = instructions.IndexOf (eh.TryEnd);
+						var anyReachable = false;
+						for (int i = startI; i < endI; i++) {
+							if (reachable [i]) {
+								anyReachable = true;
+								break;
+							}
+						}
+						if (anyReachable) {
+							if (!MarkInstructions (caller, instructions, reachable, instructions.IndexOf (eh.HandlerStart), instructions.IndexOf (eh.HandlerEnd)))
+								return;
+						}
+						break;
+					case ExceptionHandlerType.Finally:
+						// finally clauses are always executed, even if the protected region is empty
+						if (!MarkInstructions (caller, instructions, reachable, instructions.IndexOf (eh.HandlerStart), instructions.IndexOf (eh.HandlerEnd)))
+							return;
+						break;
+					case ExceptionHandlerType.Fault:
+					case ExceptionHandlerType.Filter:
+						// FIXME: and until fixed, exit gracefully without doing anything
+						Driver.Log (4, "Unhandled exception handler: {0}, skipping dead code elimination for {1}", eh.HandlerType, caller);
+						return;
+					}
+				}
+			}
+
+			if (Array.IndexOf (reachable, false) == -1)
+				return; // entire method is reachable
+
+			// Kill branch instructions when there are only dead instructions between the branch instruction and the target of the branch
+			for (int i = 0; i < instructions.Count; i++) {
+				if (!reachable [i])
+					continue;
+
+				var ins = instructions [i];
+				if (ins.OpCode.Code != Code.Br && ins.OpCode.Code != Code.Br_S)
+					continue;
+				var target = ins.Operand as Instruction;
+				if (target == null)
+					continue;
+				if (target.Offset < ins.Offset)
+					continue; // backwards branch, keep those
+
+				var start = i + 1;
+				var end = instructions.IndexOf (target);
+				var any_reachable = false;
+				for (int k = start; k < end; k++) {
+					if (reachable [k]) {
+						any_reachable = true;
+						break;
+					}
+				}
+				if (any_reachable)
+					continue;
+
+				// The branch instruction just branches over unreachable instructions, so it can be considered unreachable too.
+				reachable [i] = false;
+			}
+
+#if TRACE
+			Console.WriteLine ($"{caller.FullName}:");
+			for (int i = 0; i < reachable.Length; i++) {
+				Console.WriteLine ($"{(reachable [i] ? "   " : "-  ")} {instructions [i]}");
+				if (!reachable [i])
+					Nop (instructions [i]);
+			}
+			Console.WriteLine ();
+#endif
+
+			// Exterminate, exterminate, exterminate
+			for (int i = 0; i < reachable.Length; i++) {
+				if (!reachable [i])
+					Nop (instructions [i]);
+			}
+		}
+
 	}
 }

--- a/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs
@@ -109,8 +109,6 @@ namespace MonoTouch.Tuner {
 				ProcessIsDirectBinding (caller, ins);
 				break;
 			}
-
-			return;
 		}
 				
 		// https://app.asana.com/0/77259014252/77812690163

--- a/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs
@@ -99,9 +99,6 @@ namespace MonoTouch.Tuner {
 		{
 			var mr = ins.Operand as MethodReference;
 			switch (mr?.Name) {
-			case "IsNewRefcountEnabled":
-				ProcessIsNewRefcountEnabled (caller, ins);
-				break;
 			case "EnsureUIThread":
 				ProcessEnsureUIThread (caller, ins);
 				break;
@@ -164,24 +161,6 @@ namespace MonoTouch.Tuner {
 
 			// This is simple: just remove the call
 			Nop (ins); // call void UIKit.UIApplication::EnsureUIThread()
-		}
-
-		void ProcessIsNewRefcountEnabled (MethodDefinition caller, Instruction ins)
-		{
-			const string operation = "inline NSObject.IsNewRefcountEnabled";
-
-			// Verify we're checking the right get_IsNewRefcountEnabled call
-			var mr = ins.Operand as MethodReference;
-			if (!mr.DeclaringType.Is (Namespaces.Foundation, "NSObject"))
-				return;
-
-			// Verify a few assumptions before doing anything
-			if (!ValidateInstruction (caller, ins, operation, Code.Call))
-				return;
-
-			// We're fine, inline the get_IsNewRefcountEnabled condition
-			ins.OpCode = OpCodes.Ldc_I4_1;
-			ins.Operand = null;
 		}
 
 		void ProcessIntPtrSize (MethodDefinition caller, Instruction ins)


### PR DESCRIPTION
We had several types of code optimizations, where we'd determine a particular
expression is a constant, then remove the condition and the code for any dead
branches.

Unfortunately each type of expression had its own logic to determine the
sequence of code to remove, each slightly different depending on the actual
conditional expression. This has led to bugs in the past, either when
switching between compilers (mcs/csc), or compilers have changed their emitted
code.

So implement a more generic version where each optimization just changes the
specific condition to a constant value, and then at the end we have a dead-
code-elimination pass that eliminates dead code based on those constant
conditions.

Additionally it will remove NOP instructions at the end of methods, because it's not verifiable IL, PEVerify complains:

    [IL]: Error: [D:\Documentos\Rolf\Xamarin\Xamarin.iOS.dll : AVFoundation.AVAssetImageGenerator::get_AppliesPreferredTrackTransform][offset 0x0000001E] fall through end of the method without returning

The result is that PEVerify shows much fewer errors, [1721][1] vs [2581][2].

This version is also a lot more defensive than the previous code, it will bail
out without doing anything if it finds a code sequence it doesn't understand.

This also makes it easier to implement other similar code optimizations.

Simple time measuring shows no slowdown in the linker, and the size
difference for monotouch-test is negligable (iPhone/Debug32):

32 bytes less for the executable:

    -rwxr-xr-x  1 rolf  staff  72890880 Jan 12 00:54:49 2018 /Users/rolf/test/old/monotouchtest.app/monotouchtest*
    -rwxr-xr-x  1 rolf  staff  72890848 Jan 12 00:56:57 2018 /Users/rolf/test/new/monotouchtest.app/monotouchtest*

12288 bytes less for Xamarin.iOS.dll (this is a debug build, a release build
would probably not show any difference at all):

    -rw-r--r--  1 rolf  staff  2506240 Jan 12 00:54:49 2018 /Users/rolf/test/old/monotouchtest.app/Xamarin.iOS.dll
    -rw-r--r--  1 rolf  staff  2493952 Jan 12 00:56:57 2018 /Users/rolf/test/new/monotouchtest.app/Xamarin.iOS.dll

[IL diff][3]

[1]: https://gist.github.com/rolfbjarne/9c8fa519a6f8e1718b125472f05ded07#file-peverify-new-txt-L1726
[2]: https://gist.github.com/rolfbjarne/9c8fa519a6f8e1718b125472f05ded07#file-peverify-old-txt-L2586
[3]: https://gist.github.com/rolfbjarne/35d5bfec1809ad2a80a7781cebe5b574