### PR TITLE
bump mono 2017-10 branch

### DIFF
--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -123,6 +123,7 @@ namespace MonoMac.Tuner {
 		{
 			var context = new MonoMacLinkContext (pipeline, options.Resolver);
 			context.CoreAction = AssemblyAction.Link;
+			context.UserAction = AssemblyAction.Link;
 			context.LinkSymbols = options.LinkSymbols;
 			if (options.LinkSymbols) {
 				context.SymbolReaderProvider = new DefaultSymbolReaderProvider ();

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -131,6 +131,7 @@ namespace MonoTouch.Tuner {
 		{
 			var context = new MonoTouchLinkContext (pipeline, options.Resolver);
 			context.CoreAction = options.LinkMode == LinkMode.None ? AssemblyAction.Copy : AssemblyAction.Link;
+			context.UserAction = options.LinkMode == LinkMode.None ? AssemblyAction.Copy : AssemblyAction.Link;
 			context.LinkSymbols = options.LinkSymbols;
 			context.OutputDirectory = options.OutputDirectory;
 			context.SetParameter ("debug-build", options.DebugBuild.ToString ());


### PR DESCRIPTION
Commit list for mono/mono:

* mono/mono@e65bf00e22b Merge pull request #6122 from lewurm/2017-10-interp-aot-mode-fixes
* mono/mono@8f0589ae817 [mini] Add missing try holes
* mono/mono@ab20369d5f0 [mini] Align stack when resuming to catch handler
* mono/mono@3a134a2d8c3 [mini] Add missing try holes
* mono/mono@2e775c7e390 [mini] Fix clause try hole checking
* mono/mono@a9a4166431e [loader] Don't assert on abstract methods in get_method_constrained
* mono/mono@feba66a6ceb [interp] small improvment for error reporting in interp compile method callback
* mono/mono@6fc6ca1e189 [aot] encode interp_in wrappers with proper signature
* mono/mono@73326908260 [interp] fix copy/paste-typo in n2m macro magic
* mono/mono@b64faae88c3 [aot] add more signatures for interp_in wrapper needed for iOS
* mono/mono@b3b0613ad38 Bump msbuild to bring in fix for #60770 (#6107)
* mono/mono@ddeba6e1bab [interp] fix using conv.u with string
* mono/mono@0360f420fe3 Bump API snapshot submodule
* mono/mono@2f18e7dd23c Bump cecil & linker to match master.
* mono/mono@0f53cb275c4 [interp] allow unsigned i8 in pinvoke signature

Diff: https://github.com/mono/mono/compare/c5cd0f1e7fb494cec523757b8d7f29cc95b707c9...e65bf00e22b6b410951f62234f50b12d76238e7f

https://bugzilla.xamarin.com/show_bug.cgi?id=60770


**EDIT**: new list:

    * mono/mono@63e8dc6ea17 Bump cecil
    * mono/mono@e65bf00e22b Merge pull request #6122 from lewurm/2017-10-interp-aot-mode-fixes
    * mono/mono@8f0589ae817 [mini] Add missing try holes
    * mono/mono@ab20369d5f0 [mini] Align stack when resuming to catch handler
    * mono/mono@3a134a2d8c3 [mini] Add missing try holes
    * mono/mono@2e775c7e390 [mini] Fix clause try hole checking
    * mono/mono@a9a4166431e [loader] Don't assert on abstract methods in get_method_constrained
    * mono/mono@feba66a6ceb [interp] small improvment for error reporting in interp compile method callback
    * mono/mono@6fc6ca1e189 [aot] encode interp_in wrappers with proper signature
    * mono/mono@73326908260 [interp] fix copy/paste-typo in n2m macro magic
    * mono/mono@b64faae88c3 [aot] add more signatures for interp_in wrapper needed for iOS
    * mono/mono@b3b0613ad38 Bump msbuild to bring in fix for #60770 (#6107)
    * mono/mono@ddeba6e1bab [interp] fix using conv.u with string
    * mono/mono@0360f420fe3 Bump API snapshot submodule
    * mono/mono@2f18e7dd23c Bump cecil & linker to match master.
    * mono/mono@0f53cb275c4 [interp] allow unsigned i8 in pinvoke signature

    Diff: https://github.com/mono/mono/compare/c5cd0f1e7fb494cec523757b8d7f29cc95b707c9...63e8dc6ea17c904157224a26e6b37a63a49c06da

    https://bugzilla.xamarin.com/show_bug.cgi?id=60770