### PR TITLE
[Make.config] Add TODO for PACKAGE_VERSION_REV

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -13,6 +13,8 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 
 #
+# /!\ README /!\
+#
 # A release branch requires updating:
 #
 # PACKAGE_HEAD_BRANCH (set to the release branch name, this shows up in the IDE's version information, as well as mtouch/mmp --version)
@@ -38,7 +40,8 @@ else
 CURRENT_BRANCH:=$(PACKAGE_HEAD_BRANCH)
 endif
 
-# for service releases and previews
+# TODO: reset to 0 after major/minor version bump (SRO) and increment for service releases and previews
+# Note: if not reseted to 0 we can skip a version and start with .1 or .2
 PACKAGE_VERSION_REV=0
 
 IOS_PRODUCT=Xamarin.iOS


### PR DESCRIPTION
In my bump to Xcode 9.2 final: https://github.com/xamarin/xamarin-macios/pull/3081 I updated the `IOS_PACKAGE_VERSION`'s minor # (for the release) but forgot to update `PACKAGE_VERSION_REV` (genuinely didn't know about it).

In retrospect, I should have read the bloc of text a couple lines above that says: "A release branch requires updating". Therefore in a desperate attempt to avoid that future me missing this I added a `/!\ README /!\`. I also updated the comment above `PACKAGE_VERSION_REV` to better highlight the importance of resetting to 0 and a TODO to, again, help future me see this (: