### PR TITLE
[msbuild] Don't run Xamarin.Analysis on library projects

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -91,14 +91,16 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
 
 	<!-- *** Code Analysis Setup *** -->
+	<!-- Library projects aren't supported, if we enable Xamarin.Analysis on them, we'll need to revisit the rules and deactivate some (e.g XIA0002). -->
 
 	<PropertyGroup>
-		<XamarinAnalysisTargetsFile Condition="Exists ('$(MSBuildThisFileDirectory)Xamarin.iOS.Analysis.targets')">$(MSBuildThisFileDirectory)Xamarin.iOS.Analysis.targets</XamarinAnalysisTargetsFile>
+		<!-- '$(OutputType)' == 'Exe' because we don't want to run Xamarin.Analysis on library projects, the XIA rules don't apply. -->
+		<XamarinAnalysisTargetsFile Condition="Exists ('$(MSBuildThisFileDirectory)Xamarin.iOS.Analysis.targets') And '$(OutputType)' == 'Exe'">$(MSBuildThisFileDirectory)Xamarin.iOS.Analysis.targets</XamarinAnalysisTargetsFile>
 		<IsXBuild Condition="'$(MSBuildRuntimeVersion)' == ''">true</IsXBuild>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Analysis.targets"
-			Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Analysis.targets')" />
+			Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Analysis.targets') And '$(OutputType)' == 'Exe'" />
 
 	<PropertyGroup>
 		<!-- Switching to a new property allows us to potentially switch from iPhone to simulator builds


### PR DESCRIPTION
Avoid bug #59697: iOS Library projects fail CompileEntitlements when Analysis is enabled
(https://bugzilla.xamarin.com/show_bug.cgi?id=59697)

Note: bug #59697 happens because XIA0002_TestCloudAgentReleaseRule depends on `_CompileToNative` which
depends on `CompileEntitlements` which then requires the `AppBundleDir` parameter that isn't provided
for library project.

If we ever decide to enable Xamarin.Analysis on library projects we'll have to run a subset of the rules that
doesn't include rules like XIA0002 using the same condition this fix is using.