### PR TITLE
Fix behaviour of NSMenuItem.Activated on top of modal windows.

### DIFF
--- a/src/AppKit/ActionDispatcher.cs
+++ b/src/AppKit/ActionDispatcher.cs
@@ -113,5 +113,10 @@ namespace XamCore.AppKit
 			return true;
 		}
 
+		public bool WorksWhenModal
+		{
+			[Export("worksWhenModal")]
+			get { return true; }
+		}
 	}
 }


### PR DESCRIPTION
Setting NSMenuItem.Activated internally creates the ActionDispatcher object that is assigned to the Target property. When the menu item gets activated the system calls NSApplication.SendAction, which internally checks the WorksWhenModal property on the Target object before proceeding with the action. Since ActionDispatcher is not part of the normal NSResponder chain it needs to implement the property itself to ensure the event is fired even when the menu is opened from a modal window.