### PR TITLE
Hand-process troublesome attributes to fit pmcs conversion tooling

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1968,13 +1968,13 @@ namespace XamCore.AppKit {
 		SurfaceOrder = 235,
 		SurfaceOpacity = 236,
 
-		[Lion] SurfaceBackingSize = 304,
-		[Lion] ReclaimResources = 308,
-		[Lion] CurrentRendererID = 309,
-		[Lion] GpuVertexProcessing = 310,
-		[Lion] GpuFragmentProcessing = 311,
-		[Lion] HasDrawable = 314,
-		[Lion] MpsSwapsInFlight = 315
+		[Mac (10, 7)] SurfaceBackingSize = 304,
+		[Mac (10, 7)] ReclaimResources = 308,
+		[Mac (10, 7)] CurrentRendererID = 309,
+		[Mac (10, 7)] GpuVertexProcessing = 310,
+		[Mac (10, 7)] GpuFragmentProcessing = 311,
+		[Mac (10, 7)] HasDrawable = 314,
+		[Mac (10, 7)] MpsSwapsInFlight = 315
 	}
 	
 	public enum NSSurfaceOrder {
@@ -1985,10 +1985,10 @@ namespace XamCore.AppKit {
 	public enum NSOpenGLPixelFormatAttribute : uint_compat_int { // uint32_t NSOpenGLPixelFormatAttribute
 		AllRenderers       =   1,
 		DoubleBuffer       =   5,
-		[Lion] TripleBuffer = 3,
+		[Mac (10, 7)] TripleBuffer = 3,
 #if !XAMCORE_4_0
 		[Obsolete ("Use 'TripleBuffer' instead.")]
-		[Lion] TrippleBuffer = TripleBuffer,
+		[Mac (10, 7)] TrippleBuffer = TripleBuffer,
 #endif
 		Stereo             =   6,
 		AuxBuffers         =   7,
@@ -2030,7 +2030,7 @@ namespace XamCore.AppKit {
 		AcceleratedCompute =  97,
 
 		// Specify the profile
-		[Lion] OpenGLProfile = 99,
+		[Mac (10, 7)] OpenGLProfile = 99,
 		VirtualScreenCount = 128,
 
 		[Availability (Deprecated = Platform.Mac_10_5)]
@@ -2067,7 +2067,7 @@ namespace XamCore.AppKit {
 		FormatCacheSize = 501,
 		ClearFormatCache = 502,
 		RetainRenderers = 503,
-		[Lion] UseBuildCache = 506,
+		[Mac (10, 7)] UseBuildCache = 506,
 		[Availability (Deprecated = Platform.Mac_10_4)]
 		ResetLibrary = 504
 	}
@@ -2370,7 +2370,7 @@ namespace XamCore.AppKit {
 		Default = 0, None = 2, DocumentWindow, UtilityWindow, AlertPanel
 	}
 
-	[Lion]
+	[Mac (10, 7)]
 	[Native]
 	public enum NSTextFinderAction : nint {
 		ShowFindInterface = 1,

--- a/src/AppKit/NSAccessibility.cs
+++ b/src/AppKit/NSAccessibility.cs
@@ -218,7 +218,7 @@ namespace XamCore.AppKit
 			return NSArray.ArrayFromHandle<NSObject> (handle);
 		}
 
-		[Introduced (PlatformName.MacOSX, 10, 9)]
+		[Mac (10, 9)]
 		[DllImport (Constants.AppKitLibrary)]
 		static extern bool NSAccessibilitySetMayContainProtectedContent (bool flag);
 

--- a/src/AppKit/NSColor.cs
+++ b/src/AppKit/NSColor.cs
@@ -247,7 +247,7 @@ namespace XamCore.AppKit {
 			}
 		}
 
-		[MountainLion][Obsolete ("Use 'UnderPageBackgroundColor' instead.")]
+		[Mac (10, 8)][Obsolete ("Use 'UnderPageBackgroundColor' instead.")]
 		public static NSColor UnderPageBackground {
 			get {
 				return UnderPageBackgroundColor;

--- a/src/AppKit/NSStringAttributes.cs
+++ b/src/AppKit/NSStringAttributes.cs
@@ -362,13 +362,13 @@ namespace XamCore.AppKit
 			set { Set (NSStringAttributeKey.MarkedClauseSegment, value); }
 		}
 
-		[Lion]
+		[Mac (10, 7)]
 		public NSTextLayoutOrientation? VerticalGlyphForm {
 			get { return (NSTextLayoutOrientation?)GetInt32Value (NSStringAttributeKey.VerticalGlyphForm); }
 			set { SetNumberValue (NSStringAttributeKey.VerticalGlyphForm, (int?)value); }
 		}
 
-		[MountainLion]
+		[Mac (10, 8)]
 		public NSTextAlternatives TextAlternatives {
 			get { return Get (NSStringAttributeKey.TextAlternatives, handle => new NSTextAlternatives (handle)); }
 			set { SetNativeValue (NSStringAttributeKey.TextAlternatives, value); }
@@ -520,13 +520,13 @@ namespace XamCore.AppKit
 			set { Set (NSAttributedString.MarkedClauseSegmentAttributeName, value); }
 		}
 
-		[Lion]
+		[Mac (10, 7)]
 		public NSTextLayoutOrientation? VerticalGlyphForm {
 			get { return (NSTextLayoutOrientation?)GetInt32Value (NSAttributedString.VerticalGlyphFormAttributeName); }
 			set { SetNumberValue (NSAttributedString.VerticalGlyphFormAttributeName, (int?)value); }
 		}
 
-		[MountainLion]
+		[Mac (10, 8)]
 		public NSTextAlternatives TextAlternatives {
 			get { return Get (NSAttributedString.TextAlternativesAttributeName, handle => new NSTextAlternatives (handle)); }
 			set { SetNativeValue (NSAttributedString.TextAlternativesAttributeName, value); }

--- a/src/AppKit/XEnums.cs
+++ b/src/AppKit/XEnums.cs
@@ -11,7 +11,7 @@ using XamCore.ObjCRuntime;
 
 namespace XamCore.AppKit {
 
-	[Lion]
+	[Mac (10, 7)]
 	[Native]
 	public enum NSTextLayoutOrientation : nint {
 		Horizontal,
@@ -33,14 +33,14 @@ namespace XamCore.AppKit {
 	}
 #endif
 
-	[Lion]
+	[Mac (10, 7)]
 	[Native]
 	public enum NSPrintRenderingQuality : nint {
 		Best,
 		Responsive
 	}
 
-	[Lion]
+	[Mac (10, 7)]
 	[Native]
 	public enum NSCorrectionIndicatorType : nint {
 		Default = 0,
@@ -48,7 +48,7 @@ namespace XamCore.AppKit {
 		Guesses
 	}
 
-	[Lion]
+	[Mac (10, 7)]
 	[Native]
 	public enum NSCorrectionResponse : nint {
 		None,
@@ -59,7 +59,7 @@ namespace XamCore.AppKit {
 		Reverted
 	}
 
-	[Lion]
+	[Mac (10, 7)]
 	[Native]
 	public enum NSTextFinderMatchingType : nint {
 		Contains = 0,

--- a/src/AppKit/XEnums.cs
+++ b/src/AppKit/XEnums.cs
@@ -19,7 +19,7 @@ namespace XamCore.AppKit {
 	}
 
 #if !XAMCORE_2_0
-	[Lion, Flags]
+	[Mac (10, 7), Flags]
 	[Native]
 	public enum NSTableViewAnimationOptions : nuint_compat_int {
 		EffectFade = 0x1,

--- a/src/AudioToolbox/AudioType.cs
+++ b/src/AudioToolbox/AudioType.cs
@@ -144,8 +144,8 @@ namespace XamCore.AudioToolbox {
 		const int AudioUnitSampleFractionBits = 24;
 		const AudioFormatFlags AudioFormatFlagIsBigEndian = 0;
 
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Canonical is no longer encouraged, since fixed-point no longer provides a performance advantage over floating point. 'AudioFormatFlagsNativeFloatPacked' is preffered instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Canonical is no longer encouraged, since fixed-point no longer provides a performance advantage over floating point. 'AudioFormatFlagsNativeFloatPacked' is preffered instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Canonical is no longer encouraged, since fixed-point no longer provides a performance advantage over floating point. 'AudioFormatFlagsNativeFloatPacked' is preffered instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Canonical is no longer encouraged, since fixed-point no longer provides a performance advantage over floating point. 'AudioFormatFlagsNativeFloatPacked' is preffered instead.")]
 		public static readonly AudioFormatFlags AudioFormatFlagsAudioUnitCanonical = AudioFormatFlags.IsSignedInteger | (BitConverter.IsLittleEndian ? 0 : AudioFormatFlags.IsBigEndian) |
 			AudioFormatFlags.IsPacked | AudioFormatFlags.IsNonInterleaved | (AudioFormatFlags) (AudioUnitSampleFractionBits << (int)AudioFormatFlags.LinearPCMSampleFractionShift);
 		

--- a/src/AudioToolbox/AudioType.cs
+++ b/src/AudioToolbox/AudioType.cs
@@ -144,7 +144,8 @@ namespace XamCore.AudioToolbox {
 		const int AudioUnitSampleFractionBits = 24;
 		const AudioFormatFlags AudioFormatFlagIsBigEndian = 0;
 
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Canonical is no longer encouraged, since fixed-point no longer provides a performance advantage over floating point. 'AudioFormatFlagsNativeFloatPacked' is preffered instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Canonical is no longer encouraged, since fixed-point no longer provides a performance advantage over floating point. 'AudioFormatFlagsNativeFloatPacked' is preffered instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Canonical is no longer encouraged, since fixed-point no longer provides a performance advantage over floating point. 'AudioFormatFlagsNativeFloatPacked' is preffered instead.")]
 		public static readonly AudioFormatFlags AudioFormatFlagsAudioUnitCanonical = AudioFormatFlags.IsSignedInteger | (BitConverter.IsLittleEndian ? 0 : AudioFormatFlags.IsBigEndian) |
 			AudioFormatFlags.IsPacked | AudioFormatFlags.IsNonInterleaved | (AudioFormatFlags) (AudioUnitSampleFractionBits << (int)AudioFormatFlags.LinearPCMSampleFractionShift);
 		

--- a/src/AudioUnit/AudioComponentDescription.cs
+++ b/src/AudioUnit/AudioComponentDescription.cs
@@ -117,7 +117,8 @@ namespace XamCore.AudioUnit
 		ParametricEQ=0x706d6571, // 'pmeq'
 		Delay=0x64656c79, // 'dely'
 
-		[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_5)]
+		[Availability (Introduced = Platform.iOS_8_0)]
+		[Availability (Introduced = Platform.Mac_10_5)]
 		SampleDelay=0x73646c79, // 'sdly'
 		Distortion=0x64697374, // 'dist'
 		BandPassFilter=0x62706173, // 'bpas'

--- a/src/AudioUnit/AudioComponentDescription.cs
+++ b/src/AudioUnit/AudioComponentDescription.cs
@@ -117,8 +117,8 @@ namespace XamCore.AudioUnit
 		ParametricEQ=0x706d6571, // 'pmeq'
 		Delay=0x64656c79, // 'dely'
 
-		[Introduced (PlatformName.iOS, 8, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 5)]
+		[iOS (8, 0)]
+		[Mac (10, 5)]
 		SampleDelay=0x73646c79, // 'sdly'
 		Distortion=0x64697374, // 'dist'
 		BandPassFilter=0x62706173, // 'bpas'

--- a/src/AudioUnit/AudioComponentDescription.cs
+++ b/src/AudioUnit/AudioComponentDescription.cs
@@ -117,8 +117,8 @@ namespace XamCore.AudioUnit
 		ParametricEQ=0x706d6571, // 'pmeq'
 		Delay=0x64656c79, // 'dely'
 
-		[Availability (Introduced = Platform.iOS_8_0)]
-		[Availability (Introduced = Platform.Mac_10_5)]
+		[Introduced (PlatformName.iOS, 8, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 5)]
 		SampleDelay=0x73646c79, // 'sdly'
 		Distortion=0x64697374, // 'dist'
 		BandPassFilter=0x62706173, // 'bpas'

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -1272,12 +1272,15 @@ namespace XamCore.AudioUnit
 		ParameterHistoryInfo = 53,
 		Nickname = 54,
 		OfflineRender = 37,
-		[Availability (Introduced = Platform.iOS_8_0 |Platform.Mac_10_3)]
+		[Availability (Introduced = Platform.iOS_8_0)]
+		[Availability (Introduced = Platform.Mac_10_3)]
 		ParameterIDName = 34,
-		[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_3)]
+		[Availability (Introduced = Platform.iOS_8_0)]
+		[Availability (Introduced = Platform.Mac_10_3)]
 		ParameterStringFromValue = 33,
 		ParameterClumpName = 35,
-		[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_3)]
+		[Availability (Introduced = Platform.iOS_8_0)]
+		[Availability (Introduced = Platform.Mac_10_3)]
 		ParameterValueFromString = 38,
 		ContextName = 25,
 		PresentationLatency = 40,
@@ -1664,11 +1667,14 @@ namespace XamCore.AudioUnit
 		BeganToRender = 0x02,
 		BeganToRenderLate = 0x04,
 
-		[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_8_0)]
+		[Availability (Introduced = Platform.Mac_10_10)]
 		Loop                   = 0x08,
-		[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_8_0)]
+		[Availability (Introduced = Platform.Mac_10_10)]
 		Interrupt              = 0x10,
-		[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_8_0)]
+		[Availability (Introduced = Platform.Mac_10_10)]
 		InterruptAtLoop        = 0x20
 	}
 

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -1272,15 +1272,15 @@ namespace XamCore.AudioUnit
 		ParameterHistoryInfo = 53,
 		Nickname = 54,
 		OfflineRender = 37,
-		[Availability (Introduced = Platform.iOS_8_0)]
-		[Availability (Introduced = Platform.Mac_10_3)]
+		[Introduced (PlatformName.iOS, 8, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 3)]
 		ParameterIDName = 34,
-		[Availability (Introduced = Platform.iOS_8_0)]
-		[Availability (Introduced = Platform.Mac_10_3)]
+		[Introduced (PlatformName.iOS, 8, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 3)]
 		ParameterStringFromValue = 33,
 		ParameterClumpName = 35,
-		[Availability (Introduced = Platform.iOS_8_0)]
-		[Availability (Introduced = Platform.Mac_10_3)]
+		[Introduced (PlatformName.iOS, 8, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 3)]
 		ParameterValueFromString = 38,
 		ContextName = 25,
 		PresentationLatency = 40,
@@ -1667,14 +1667,14 @@ namespace XamCore.AudioUnit
 		BeganToRender = 0x02,
 		BeganToRenderLate = 0x04,
 
-		[Availability (Introduced = Platform.iOS_8_0)]
-		[Availability (Introduced = Platform.Mac_10_10)]
+		[Introduced (PlatformName.iOS, 8, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 10)]
 		Loop                   = 0x08,
-		[Availability (Introduced = Platform.iOS_8_0)]
-		[Availability (Introduced = Platform.Mac_10_10)]
+		[Introduced (PlatformName.iOS, 8, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 10)]
 		Interrupt              = 0x10,
-		[Availability (Introduced = Platform.iOS_8_0)]
-		[Availability (Introduced = Platform.Mac_10_10)]
+		[Introduced (PlatformName.iOS, 8, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 10)]
 		InterruptAtLoop        = 0x20
 	}
 

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -1272,15 +1272,15 @@ namespace XamCore.AudioUnit
 		ParameterHistoryInfo = 53,
 		Nickname = 54,
 		OfflineRender = 37,
-		[Introduced (PlatformName.iOS, 8, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 3)]
+		[iOS (8, 0)]
+		[Mac (10, 3)]
 		ParameterIDName = 34,
-		[Introduced (PlatformName.iOS, 8, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 3)]
+		[iOS (8, 0)]
+		[Mac (10, 3)]
 		ParameterStringFromValue = 33,
 		ParameterClumpName = 35,
-		[Introduced (PlatformName.iOS, 8, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 3)]
+		[iOS (8, 0)]
+		[Mac (10, 3)]
 		ParameterValueFromString = 38,
 		ContextName = 25,
 		PresentationLatency = 40,
@@ -1667,14 +1667,14 @@ namespace XamCore.AudioUnit
 		BeganToRender = 0x02,
 		BeganToRenderLate = 0x04,
 
-		[Introduced (PlatformName.iOS, 8, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[iOS (8, 0)]
+		[Mac (10, 10)]
 		Loop                   = 0x08,
-		[Introduced (PlatformName.iOS, 8, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[iOS (8, 0)]
+		[Mac (10, 10)]
 		Interrupt              = 0x10,
-		[Introduced (PlatformName.iOS, 8, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[iOS (8, 0)]
+		[Mac (10, 10)]
 		InterruptAtLoop        = 0x20
 	}
 

--- a/src/CFNetwork/CFHTTPStream.cs
+++ b/src/CFNetwork/CFHTTPStream.cs
@@ -20,7 +20,8 @@ namespace XamCore.CoreServices {
 #endif
 
 	// all fields constants that this is using are deprecated in Xcode 7
-	[Availability (Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11, Message = "Use 'NSUrlSession'.")]
+	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'NSUrlSession'.")]
+	[Availability (Deprecated = Platform.Mac_10_11, Message = "Use 'NSUrlSession'.")]
 	public partial class CFHTTPStream : CFReadStream {
 
 		internal CFHTTPStream (IntPtr handle)

--- a/src/CFNetwork/CFHTTPStream.cs
+++ b/src/CFNetwork/CFHTTPStream.cs
@@ -20,8 +20,8 @@ namespace XamCore.CoreServices {
 #endif
 
 	// all fields constants that this is using are deprecated in Xcode 7
-	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'NSUrlSession'.")]
-	[Availability (Deprecated = Platform.Mac_10_11, Message = "Use 'NSUrlSession'.")]
+	[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'NSUrlSession'.")]
+	[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'NSUrlSession'.")]
 	public partial class CFHTTPStream : CFReadStream {
 
 		internal CFHTTPStream (IntPtr handle)

--- a/src/CloudKit/Enums.cs
+++ b/src/CloudKit/Enums.cs
@@ -153,7 +153,8 @@ namespace XamCore.CloudKit
 	// NSInteger -> CKSubscription.h
 
 	[NoWatch]
-	[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_10 , Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12, Message = "Use 'CKQuerySubscriptionOptions' instead.")]
+	[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'CKQuerySubscriptionOptions' instead.")]
+	[Availability (Introduced = Platform.Mac_10_10 , Deprecated = Platform.Mac_10_12, Message = "Use 'CKQuerySubscriptionOptions' instead.")]
 	[Flags]
 	[Native]
 	public enum CKSubscriptionOptions : nuint {

--- a/src/CloudKit/Enums.cs
+++ b/src/CloudKit/Enums.cs
@@ -153,9 +153,9 @@ namespace XamCore.CloudKit
 	// NSInteger -> CKSubscription.h
 
 	[NoWatch]
-	[Introduced (PlatformName.iOS, 8, 0)]
+	[iOS (8, 0)]
 	[Deprecated (PlatformName.iOS, 10, 0, message : "Use 'CKQuerySubscriptionOptions' instead.")]
-	[Introduced (PlatformName.MacOSX, 10, 10)]
+	[Mac (10, 10)]
 	[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'CKQuerySubscriptionOptions' instead.")]
 	[Flags]
 	[Native]

--- a/src/CloudKit/Enums.cs
+++ b/src/CloudKit/Enums.cs
@@ -153,8 +153,10 @@ namespace XamCore.CloudKit
 	// NSInteger -> CKSubscription.h
 
 	[NoWatch]
-	[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'CKQuerySubscriptionOptions' instead.")]
-	[Availability (Introduced = Platform.Mac_10_10 , Deprecated = Platform.Mac_10_12, Message = "Use 'CKQuerySubscriptionOptions' instead.")]
+	[Introduced (PlatformName.iOS, 8, 0)]
+	[Deprecated (PlatformName.iOS, 10, 0, message : "Use 'CKQuerySubscriptionOptions' instead.")]
+	[Introduced (PlatformName.MacOSX, 10, 10)]
+	[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'CKQuerySubscriptionOptions' instead.")]
 	[Flags]
 	[Native]
 	public enum CKSubscriptionOptions : nuint {

--- a/src/CloudKit/Enums.cs
+++ b/src/CloudKit/Enums.cs
@@ -8,7 +8,7 @@ namespace XamCore.CloudKit
 	// NSInteger -> CKContainer.h
 	[Watch (3,0)]
 	[iOS (8,0)]
-	[Availability (Platform.Mac_10_10)]
+	[Mac (10, 10)]
 	[Native]
 	public enum CKAccountStatus : nint {
 		CouldNotDetermine = 0,
@@ -20,7 +20,7 @@ namespace XamCore.CloudKit
 	// NSUInteger -> CKContainer.h
 	[Watch (3,0)]
 	[iOS (8,0)]
-	[Availability (Platform.Mac_10_10)]
+	[Mac (10, 10)]
 	[Native]
 	[Flags]
 	public enum CKApplicationPermissions : nuint {
@@ -30,7 +30,7 @@ namespace XamCore.CloudKit
 	// NSInteger -> CKContainer.h
 	[Watch (3,0)]
 	[iOS (8,0)]
-	[Availability (Platform.Mac_10_10)]
+	[Mac (10, 10)]
 	[Native]
 	public enum CKApplicationPermissionStatus : nint {
 		InitialState = 0,
@@ -42,7 +42,7 @@ namespace XamCore.CloudKit
 	// NSInteger -> CKError.h
 	[Watch (3,0)]
 	[iOS (8,0)]
-	[Availability (Platform.Mac_10_10)]
+	[Mac (10, 10)]
 	[Native]
 	[ErrorDomain ("CKErrorDomain")]
 	public enum CKErrorCode : nint {
@@ -86,7 +86,7 @@ namespace XamCore.CloudKit
 	// NSInteger -> CKModifyRecordsOperation.h
 	[Watch (3,0)]
 	[iOS (8,0)]
-	[Availability (Platform.Mac_10_10)]
+	[Mac (10, 10)]
 	[Native]
 	public enum CKRecordSavePolicy : nint {
 		SaveIfServerRecordUnchanged = 0,
@@ -97,7 +97,7 @@ namespace XamCore.CloudKit
 	// NSInteger -> CKNotification.h
 	[Watch (3,0)]
 	[iOS (8,0)]
-	[Availability (Platform.Mac_10_10)]
+	[Mac (10, 10)]
 	[Native]
 	public enum CKNotificationType : nint {
 		Query = 1,
@@ -109,7 +109,7 @@ namespace XamCore.CloudKit
 	// NSInteger -> CKNotification.h
 	[Watch (3,0)]
 	[iOS (8,0)]
-	[Availability (Platform.Mac_10_10)]
+	[Mac (10, 10)]
 	[Native]
 	public enum CKQueryNotificationReason : nint {
 		RecordCreated = 1,
@@ -120,7 +120,7 @@ namespace XamCore.CloudKit
 	// NSUInteger -> CKRecordZone.h
 	[Watch (3,0)]
 	[iOS (8,0)]
-	[Availability (Platform.Mac_10_10)]
+	[Mac (10, 10)]
 	[Flags]
 	[Native]
 	public enum CKRecordZoneCapabilities : nuint {
@@ -132,7 +132,7 @@ namespace XamCore.CloudKit
 	// NSUInteger -> CKReference.h
 	[Watch (3,0)]
 	[iOS (8,0)]
-	[Availability (Platform.Mac_10_10)]
+	[Mac (10, 10)]
 	[Native]
 	public enum CKReferenceAction : nuint {
 		None = 0,
@@ -142,7 +142,7 @@ namespace XamCore.CloudKit
 	// NSInteger -> CKSubscription.h
 	[NoWatch]
 	[iOS (8,0)]
-	[Availability (Platform.Mac_10_10)]
+	[Mac (10, 10)]
 	[Native]
 	public enum CKSubscriptionType : nint {
 		Query = 1,

--- a/src/CoreBluetooth/Enums.cs
+++ b/src/CoreBluetooth/Enums.cs
@@ -27,7 +27,7 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	// NSInteger -> CBCentralManager.h
-	[Introduced (PlatformName.iOS, 5, 0)]
+	[iOS (5, 0)]
 	[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'CBManagerState' instead.")]
 	[NoWatch]
 	[Native]
@@ -41,7 +41,7 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	// NSInteger -> CBPeripheralManager.h
-	[Introduced (PlatformName.iOS, 6, 0)]
+	[iOS (6, 0)]
 	[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'CBManagerState' instead.")]
 	[NoWatch]
 	[Native]

--- a/src/CoreData/Enums.cs
+++ b/src/CoreData/Enums.cs
@@ -65,11 +65,11 @@ namespace XamCore.CoreData {
 	public enum NSFetchRequestResultType : nuint {
 		ManagedObject = 0x00,
 		ManagedObjectID = 0x01,
-		[Availability (Introduced = Platform.iOS_3_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 3, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		DictionaryResultType = 0x02,
-		[Availability (Introduced = Platform.iOS_3_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 3, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		NSCountResultType = 0x04
 	}
 

--- a/src/CoreData/Enums.cs
+++ b/src/CoreData/Enums.cs
@@ -65,9 +65,11 @@ namespace XamCore.CoreData {
 	public enum NSFetchRequestResultType : nuint {
 		ManagedObject = 0x00,
 		ManagedObjectID = 0x01,
-		[Availability (Introduced = Platform.iOS_3_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_3_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		DictionaryResultType = 0x02,
-		[Availability (Introduced = Platform.iOS_3_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_3_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		NSCountResultType = 0x04
 	}
 

--- a/src/CoreData/Enums.cs
+++ b/src/CoreData/Enums.cs
@@ -65,11 +65,11 @@ namespace XamCore.CoreData {
 	public enum NSFetchRequestResultType : nuint {
 		ManagedObject = 0x00,
 		ManagedObjectID = 0x01,
-		[Introduced (PlatformName.iOS, 3, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (3, 0)]
+		[Mac (10, 6)]
 		DictionaryResultType = 0x02,
-		[Introduced (PlatformName.iOS, 3, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (3, 0)]
+		[Mac (10, 6)]
 		NSCountResultType = 0x04
 	}
 

--- a/src/CoreFoundation/CFStream.cs
+++ b/src/CoreFoundation/CFStream.cs
@@ -239,14 +239,14 @@ namespace XamCore.CoreFoundation {
 		}
 #if !WATCH
 		// CFHTTPStream.h in CFNetwork.framework (not CoreFoundation)
-		[Availability (Deprecated = Platform.iOS_9_0)]
-		[Availability (Deprecated = Platform.Mac_10_11)]
+		[Deprecated (PlatformName.iOS, 9, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[DllImport (Constants.CFNetworkLibrary)]
 		internal extern static /* CFReadStreamRef __nonnull */ IntPtr CFReadStreamCreateForHTTPRequest (
 			/* CFAllocatorRef __nullable */ IntPtr alloc, /* CFHTTPMessageRef __nonnull */ IntPtr request);
 
-		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'NSUrlSession'.")]
-		[Availability (Deprecated = Platform.Mac_10_11, Message = "Use 'NSUrlSession'.")]
+		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'NSUrlSession'.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'NSUrlSession'.")]
 		public static CFHTTPStream CreateForHTTPRequest (CFHTTPMessage request)
 		{
 			if (request == null)

--- a/src/CoreFoundation/CFStream.cs
+++ b/src/CoreFoundation/CFStream.cs
@@ -239,12 +239,14 @@ namespace XamCore.CoreFoundation {
 		}
 #if !WATCH
 		// CFHTTPStream.h in CFNetwork.framework (not CoreFoundation)
-		[Availability (Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.Mac_10_11)]
 		[DllImport (Constants.CFNetworkLibrary)]
 		internal extern static /* CFReadStreamRef __nonnull */ IntPtr CFReadStreamCreateForHTTPRequest (
 			/* CFAllocatorRef __nullable */ IntPtr alloc, /* CFHTTPMessageRef __nonnull */ IntPtr request);
 
-		[Availability (Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11, Message = "Use 'NSUrlSession'.")]
+		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'NSUrlSession'.")]
+		[Availability (Deprecated = Platform.Mac_10_11, Message = "Use 'NSUrlSession'.")]
 		public static CFHTTPStream CreateForHTTPRequest (CFHTTPMessage request)
 		{
 			if (request == null)

--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -259,8 +259,8 @@ namespace XamCore.CoreFoundation {
 			}
 		}
 	
-		[Availability (Deprecated = Platform.iOS_6_0)]
-		[Availability (Deprecated = Platform.Mac_10_9)]
+		[Deprecated (PlatformName.iOS, 6, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		public static DispatchQueue CurrentQueue {
 			get {
 				return new DispatchQueue (dispatch_get_current_queue (), false);

--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -259,7 +259,8 @@ namespace XamCore.CoreFoundation {
 			}
 		}
 	
-		[Availability (Deprecated = Platform.iOS_6_0 | Platform.Mac_10_9)]
+		[Availability (Deprecated = Platform.iOS_6_0)]
+		[Availability (Deprecated = Platform.Mac_10_9)]
 		public static DispatchQueue CurrentQueue {
 			get {
 				return new DispatchQueue (dispatch_get_current_queue (), false);

--- a/src/CoreGraphics/CGColorSpace.cs
+++ b/src/CoreGraphics/CGColorSpace.cs
@@ -391,8 +391,8 @@ namespace XamCore.CoreGraphics {
 			return ptr == IntPtr.Zero ? null : new CGColorSpace (ptr, true);
 		}
 
-		[Introduced (PlatformName.iOS, 10, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 12)]
+		[iOS (10, 0)]
+		[Mac (10, 12)]
 		public static CGColorSpace CreateIccData (NSData data)
 		{
 			return CreateIccData (data.GetHandle ());

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -70,7 +70,8 @@ namespace XamCore.CoreGraphics {
 	}
 
 	// untyped enum -> CGContext.h
-	[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9)]
+	[Availability (Deprecated = Platform.iOS_7_0)]
+	[Availability (Deprecated = Platform.Mac_10_9)]
 	public enum CGTextEncoding {
 		FontSpecific,
 		MacRoman
@@ -980,7 +981,8 @@ namespace XamCore.CoreGraphics {
 		extern static void CGContextSelectFont (/* CGContextRef */ IntPtr c,
 			/* const char* __nullable */ string name, /* CGFloat */ nfloat size, CGTextEncoding textEncoding);
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
 		public void SelectFont (string name, nfloat size, CGTextEncoding textEncoding)
 		{
 			CGContextSelectFont (handle, name, size, textEncoding);
@@ -1012,7 +1014,8 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowText (/* CGContextRef */ IntPtr c, /* const char* __nullable */ string s, /* size_t */ nint length);
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
 		public void ShowText (string str, int count)
 		{
 			if (str == null)
@@ -1022,7 +1025,8 @@ namespace XamCore.CoreGraphics {
 			CGContextShowText (handle, str, count);
 		}
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
 		public void ShowText (string str)
 		{
 			CGContextShowText (handle, str, str == null ? 0 : str.Length);
@@ -1031,7 +1035,8 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowText (/* CGContextRef */ IntPtr c, /* const char* __nullable */ byte[] bytes, /* size_t */ nint length);
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
 		public void ShowText (byte[] bytes, int count)
 		{
 			if (bytes == null)
@@ -1041,7 +1046,8 @@ namespace XamCore.CoreGraphics {
 			CGContextShowText (handle, bytes, count);
 		}
 		
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
 		public void ShowText (byte[] bytes)
 		{
 			CGContextShowText (handle, bytes, bytes == null ? 0 : bytes.Length);
@@ -1051,13 +1057,15 @@ namespace XamCore.CoreGraphics {
 		extern static void CGContextShowTextAtPoint (/* CGContextRef __nullable */ IntPtr c, /* CGFloat */ nfloat x, 
 			/* CGFloat */ nfloat y, /* const char* __nullable */ string str, /* size_t */ nint length);
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
 		public void ShowTextAtPoint (nfloat x, nfloat y, string str, int length)
 		{
 			CGContextShowTextAtPoint (handle, x, y, str, length);
 		}
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
 		public void ShowTextAtPoint (nfloat x, nfloat y, string str)
 		{
 			CGContextShowTextAtPoint (handle, x, y, str, str == null ? 0 : str.Length);
@@ -1080,13 +1088,15 @@ namespace XamCore.CoreGraphics {
 		extern static void CGContextShowGlyphs (/* CGContextRef __nullable */ IntPtr c,
 			/* const CGGlyph * __nullable */ ushort [] glyphs, /* size_t */ nint count);
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
 		public void ShowGlyphs (ushort [] glyphs)
 		{
 			CGContextShowGlyphs (handle, glyphs, glyphs == null ? 0 : glyphs.Length);
 		}
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
 		public void ShowGlyphs (ushort [] glyphs, int count)
 		{
 			if (glyphs == null)
@@ -1100,7 +1110,8 @@ namespace XamCore.CoreGraphics {
 		extern static void CGContextShowGlyphsAtPoint (/* CGContextRef */ IntPtr context, /* CGFloat */ nfloat x,
 			/* CGFloat */ nfloat y, /* const CGGlyph * __nullable */ ushort [] glyphs, /* size_t */ nint count);
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
 		public void ShowGlyphsAtPoint (nfloat x, nfloat y, ushort [] glyphs, int count)
 		{
 			if (glyphs == null)
@@ -1110,7 +1121,8 @@ namespace XamCore.CoreGraphics {
 			CGContextShowGlyphsAtPoint (handle, x, y, glyphs, count);
 		}
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
 		public void ShowGlyphsAtPoint (nfloat x, nfloat y, ushort [] glyphs)
 		{
 			CGContextShowGlyphsAtPoint (handle, x, y, glyphs, glyphs == null ? 0 : glyphs.Length);
@@ -1121,7 +1133,8 @@ namespace XamCore.CoreGraphics {
 			/* const CGGlyph * __nullable */ ushort [] glyphs,
 			/* const CGSize * __nullable */ CGSize [] advances, /* size_t */ nint count);
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
+		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
 		public void ShowGlyphsWithAdvances (ushort [] glyphs, CGSize [] advances, int count)
 		{
 			if (glyphs == null)

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -70,8 +70,8 @@ namespace XamCore.CoreGraphics {
 	}
 
 	// untyped enum -> CGContext.h
-	[Availability (Deprecated = Platform.iOS_7_0)]
-	[Availability (Deprecated = Platform.Mac_10_9)]
+	[Deprecated (PlatformName.iOS, 7, 0)]
+	[Deprecated (PlatformName.MacOSX, 10, 9)]
 	public enum CGTextEncoding {
 		FontSpecific,
 		MacRoman
@@ -981,8 +981,8 @@ namespace XamCore.CoreGraphics {
 		extern static void CGContextSelectFont (/* CGContextRef */ IntPtr c,
 			/* const char* __nullable */ string name, /* CGFloat */ nfloat size, CGTextEncoding textEncoding);
 
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
-		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use the 'CoreText' API instead.")]
 		public void SelectFont (string name, nfloat size, CGTextEncoding textEncoding)
 		{
 			CGContextSelectFont (handle, name, size, textEncoding);
@@ -1014,8 +1014,8 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowText (/* CGContextRef */ IntPtr c, /* const char* __nullable */ string s, /* size_t */ nint length);
 
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
-		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use the 'CoreText' API instead.")]
 		public void ShowText (string str, int count)
 		{
 			if (str == null)
@@ -1025,8 +1025,8 @@ namespace XamCore.CoreGraphics {
 			CGContextShowText (handle, str, count);
 		}
 
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
-		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use the 'CoreText' API instead.")]
 		public void ShowText (string str)
 		{
 			CGContextShowText (handle, str, str == null ? 0 : str.Length);
@@ -1035,8 +1035,8 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextShowText (/* CGContextRef */ IntPtr c, /* const char* __nullable */ byte[] bytes, /* size_t */ nint length);
 
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
-		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use the 'CoreText' API instead.")]
 		public void ShowText (byte[] bytes, int count)
 		{
 			if (bytes == null)
@@ -1046,8 +1046,8 @@ namespace XamCore.CoreGraphics {
 			CGContextShowText (handle, bytes, count);
 		}
 		
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
-		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use the 'CoreText' API instead.")]
 		public void ShowText (byte[] bytes)
 		{
 			CGContextShowText (handle, bytes, bytes == null ? 0 : bytes.Length);
@@ -1057,15 +1057,15 @@ namespace XamCore.CoreGraphics {
 		extern static void CGContextShowTextAtPoint (/* CGContextRef __nullable */ IntPtr c, /* CGFloat */ nfloat x, 
 			/* CGFloat */ nfloat y, /* const char* __nullable */ string str, /* size_t */ nint length);
 
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
-		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use the 'CoreText' API instead.")]
 		public void ShowTextAtPoint (nfloat x, nfloat y, string str, int length)
 		{
 			CGContextShowTextAtPoint (handle, x, y, str, length);
 		}
 
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
-		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use the 'CoreText' API instead.")]
 		public void ShowTextAtPoint (nfloat x, nfloat y, string str)
 		{
 			CGContextShowTextAtPoint (handle, x, y, str, str == null ? 0 : str.Length);
@@ -1088,15 +1088,15 @@ namespace XamCore.CoreGraphics {
 		extern static void CGContextShowGlyphs (/* CGContextRef __nullable */ IntPtr c,
 			/* const CGGlyph * __nullable */ ushort [] glyphs, /* size_t */ nint count);
 
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
-		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use the 'CoreText' API instead.")]
 		public void ShowGlyphs (ushort [] glyphs)
 		{
 			CGContextShowGlyphs (handle, glyphs, glyphs == null ? 0 : glyphs.Length);
 		}
 
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
-		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use the 'CoreText' API instead.")]
 		public void ShowGlyphs (ushort [] glyphs, int count)
 		{
 			if (glyphs == null)
@@ -1110,8 +1110,8 @@ namespace XamCore.CoreGraphics {
 		extern static void CGContextShowGlyphsAtPoint (/* CGContextRef */ IntPtr context, /* CGFloat */ nfloat x,
 			/* CGFloat */ nfloat y, /* const CGGlyph * __nullable */ ushort [] glyphs, /* size_t */ nint count);
 
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
-		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use the 'CoreText' API instead.")]
 		public void ShowGlyphsAtPoint (nfloat x, nfloat y, ushort [] glyphs, int count)
 		{
 			if (glyphs == null)
@@ -1121,8 +1121,8 @@ namespace XamCore.CoreGraphics {
 			CGContextShowGlyphsAtPoint (handle, x, y, glyphs, count);
 		}
 
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
-		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use the 'CoreText' API instead.")]
 		public void ShowGlyphsAtPoint (nfloat x, nfloat y, ushort [] glyphs)
 		{
 			CGContextShowGlyphsAtPoint (handle, x, y, glyphs, glyphs == null ? 0 : glyphs.Length);
@@ -1133,8 +1133,8 @@ namespace XamCore.CoreGraphics {
 			/* const CGGlyph * __nullable */ ushort [] glyphs,
 			/* const CGSize * __nullable */ CGSize [] advances, /* size_t */ nint count);
 
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the 'CoreText' API instead.")]
-		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use the 'CoreText' API instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use the 'CoreText' API instead.")]
 		public void ShowGlyphsWithAdvances (ushort [] glyphs, CGSize [] advances, int count)
 		{
 			if (glyphs == null)

--- a/src/CoreLocation/CLLocationDistance.cs
+++ b/src/CoreLocation/CLLocationDistance.cs
@@ -44,7 +44,7 @@ namespace XamCore.CoreLocation {
 		static double? max_distance;
 		static double? filter_none;
 		
-		[Since (6, 0)]
+		[iOS (6, 0)]
 		public static double MaxDistance {
 			get {
 				if (max_distance == null)

--- a/src/CoreMedia/CMBufferQueue.cs
+++ b/src/CoreMedia/CMBufferQueue.cs
@@ -298,7 +298,7 @@ namespace XamCore.CoreMedia {
 		extern static /* size_t */ nint CMBufferQueueGetTotalSize (/* CMBufferQueueRef */ IntPtr queue);
 
 		[iOS (7,1)]
-		[Availability (Platform.Mac_10_10)]
+		[Mac (10, 10)]
 		public nint GetTotalSize ()
 		{
 			return CMBufferQueueGetTotalSize (handle);

--- a/src/CoreMedia/CMSync.cs
+++ b/src/CoreMedia/CMSync.cs
@@ -212,7 +212,8 @@ namespace XamCore.CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMTimebaseRef */ IntPtr CMTimebaseGetMasterTimebase (/* CMTimebaseRef */ IntPtr timebase);
 
-		[Availability (Introduced = Platform.iOS_6_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11, Message="Use 'CopyMasterTimebase' instead.")]
+		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_9_0, Message="Use 'CopyMasterTimebase' instead.")]
+		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_11, Message="Use 'CopyMasterTimebase' instead.")]
 		public CMTimebase GetMasterTimebase ()
 		{
 			var ptr = CMTimebaseGetMasterTimebase (Handle);
@@ -225,7 +226,8 @@ namespace XamCore.CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMClockRef */ IntPtr CMTimebaseGetMasterClock (/* CMTimebaseRef */ IntPtr timebase);
 
-		[Availability (Introduced = Platform.iOS_6_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11, Message="Use 'CopyMasterClock' instead.")]
+		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_9_0, Message="Use 'CopyMasterClock' instead.")]
+		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_11, Message="Use 'CopyMasterClock' instead.")]
 		public CMClock GetMasterClock ()
 		{
 			var ptr = CMTimebaseGetMasterClock (Handle);
@@ -238,7 +240,8 @@ namespace XamCore.CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMClockOrTimebaseRef */ IntPtr CMTimebaseGetMaster (/* CMTimebaseRef */ IntPtr timebase);
 
-		[Availability (Introduced = Platform.iOS_6_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11, Message="Use 'CopyMaster' instead.")]
+		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_9_0, Message="Use 'CopyMaster' instead.")]
+		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_11, Message="Use 'CopyMaster' instead.")]
 		public CMClockOrTimebase GetMaster ()
 		{
 			var ptr = CMTimebaseGetMaster (Handle);
@@ -251,7 +254,8 @@ namespace XamCore.CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMClockRef */ IntPtr CMTimebaseGetUltimateMasterClock (/* CMTimebaseRef */ IntPtr timebase);
 
-		[Availability (Introduced = Platform.iOS_6_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11, Message="Use 'CopyUltimateMasterClock' instead.")]
+		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_9_0, Message="Use 'CopyUltimateMasterClock' instead.")]
+		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_11, Message="Use 'CopyUltimateMasterClock' instead.")]
 		public CMClock GetUltimateMasterClock ()
 		{
 			var ptr  = CMTimebaseGetUltimateMasterClock (Handle);

--- a/src/CoreMedia/CMSync.cs
+++ b/src/CoreMedia/CMSync.cs
@@ -212,9 +212,9 @@ namespace XamCore.CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMTimebaseRef */ IntPtr CMTimebaseGetMasterTimebase (/* CMTimebaseRef */ IntPtr timebase);
 
-		[Introduced (PlatformName.iOS, 6, 0)]
+		[iOS (6, 0)]
 		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'CopyMasterTimebase' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'CopyMasterTimebase' instead.")]
 		public CMTimebase GetMasterTimebase ()
 		{
@@ -228,9 +228,9 @@ namespace XamCore.CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMClockRef */ IntPtr CMTimebaseGetMasterClock (/* CMTimebaseRef */ IntPtr timebase);
 
-		[Introduced (PlatformName.iOS, 6, 0)]
+		[iOS (6, 0)]
 		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'CopyMasterClock' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'CopyMasterClock' instead.")]
 		public CMClock GetMasterClock ()
 		{
@@ -244,9 +244,9 @@ namespace XamCore.CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMClockOrTimebaseRef */ IntPtr CMTimebaseGetMaster (/* CMTimebaseRef */ IntPtr timebase);
 
-		[Introduced (PlatformName.iOS, 6, 0)]
+		[iOS (6, 0)]
 		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'CopyMaster' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'CopyMaster' instead.")]
 		public CMClockOrTimebase GetMaster ()
 		{
@@ -260,9 +260,9 @@ namespace XamCore.CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMClockRef */ IntPtr CMTimebaseGetUltimateMasterClock (/* CMTimebaseRef */ IntPtr timebase);
 
-		[Introduced (PlatformName.iOS, 6, 0)]
+		[iOS (6, 0)]
 		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'CopyUltimateMasterClock' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'CopyUltimateMasterClock' instead.")]
 		public CMClock GetUltimateMasterClock ()
 		{

--- a/src/CoreMedia/CMSync.cs
+++ b/src/CoreMedia/CMSync.cs
@@ -212,8 +212,10 @@ namespace XamCore.CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMTimebaseRef */ IntPtr CMTimebaseGetMasterTimebase (/* CMTimebaseRef */ IntPtr timebase);
 
-		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_9_0, Message="Use 'CopyMasterTimebase' instead.")]
-		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_11, Message="Use 'CopyMasterTimebase' instead.")]
+		[Introduced (PlatformName.iOS, 6, 0)]
+		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'CopyMasterTimebase' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'CopyMasterTimebase' instead.")]
 		public CMTimebase GetMasterTimebase ()
 		{
 			var ptr = CMTimebaseGetMasterTimebase (Handle);
@@ -226,8 +228,10 @@ namespace XamCore.CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMClockRef */ IntPtr CMTimebaseGetMasterClock (/* CMTimebaseRef */ IntPtr timebase);
 
-		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_9_0, Message="Use 'CopyMasterClock' instead.")]
-		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_11, Message="Use 'CopyMasterClock' instead.")]
+		[Introduced (PlatformName.iOS, 6, 0)]
+		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'CopyMasterClock' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'CopyMasterClock' instead.")]
 		public CMClock GetMasterClock ()
 		{
 			var ptr = CMTimebaseGetMasterClock (Handle);
@@ -240,8 +244,10 @@ namespace XamCore.CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMClockOrTimebaseRef */ IntPtr CMTimebaseGetMaster (/* CMTimebaseRef */ IntPtr timebase);
 
-		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_9_0, Message="Use 'CopyMaster' instead.")]
-		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_11, Message="Use 'CopyMaster' instead.")]
+		[Introduced (PlatformName.iOS, 6, 0)]
+		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'CopyMaster' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'CopyMaster' instead.")]
 		public CMClockOrTimebase GetMaster ()
 		{
 			var ptr = CMTimebaseGetMaster (Handle);
@@ -254,8 +260,10 @@ namespace XamCore.CoreMedia {
 		[DllImport(Constants.CoreMediaLibrary)]
 		extern static /* CMClockRef */ IntPtr CMTimebaseGetUltimateMasterClock (/* CMTimebaseRef */ IntPtr timebase);
 
-		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_9_0, Message="Use 'CopyUltimateMasterClock' instead.")]
-		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_11, Message="Use 'CopyUltimateMasterClock' instead.")]
+		[Introduced (PlatformName.iOS, 6, 0)]
+		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'CopyUltimateMasterClock' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'CopyUltimateMasterClock' instead.")]
 		public CMClock GetUltimateMasterClock ()
 		{
 			var ptr  = CMTimebaseGetUltimateMasterClock (Handle);

--- a/src/CoreMedia/CMTime.cs
+++ b/src/CoreMedia/CMTime.cs
@@ -241,7 +241,7 @@ namespace XamCore.CoreMedia {
 		extern static CMTime CMTimeMultiplyByRatio (CMTime time, /* int32_t */ int multiplier, /* int32_t */ int divisor);
 
 		[iOS (7,1)]
-		[Availability (Platform.Mac_10_10)]
+		[Mac (10, 10)]
 		public static CMTime Multiply (CMTime time, int multiplier, int divisor)
 		{
 			return CMTimeMultiplyByRatio (time, multiplier, divisor);

--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -172,7 +172,8 @@ namespace XamCore.CoreText {
 		AllTypographicFeatures   = 0,
 		Ligatures                = 1,
 		CursiveConnection        = 2,
-		[Availability (Deprecated = Platform.iOS_6_0 | Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.iOS_6_0)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		LetterCase               = 3,
 		VerticalSubstitution     = 4,
 		LinguisticRearrangement  = 5,
@@ -480,7 +481,8 @@ namespace XamCore.CoreText {
 		}
 	}
 
-	[Availability (Deprecated = Platform.iOS_6_0 | Platform.Mac_10_7)]
+	[Availability (Deprecated = Platform.iOS_6_0)]
+	[Availability (Deprecated = Platform.Mac_10_7)]
 	public class CTFontFeatureLetterCase : CTFontFeatureSelectors
 	{
 		public enum Selector
@@ -1056,9 +1058,11 @@ namespace XamCore.CoreText {
 	{
 		public enum Selector
 		{
-			[Availability (Deprecated = Platform.iOS_5_1 | Platform.Mac_10_8)]
+			[Availability (Deprecated = Platform.iOS_5_1)]
+			[Availability (Deprecated = Platform.Mac_10_8)]
 			NoRubyKana           = 0,
-			[Availability (Deprecated = Platform.iOS_5_1 | Platform.Mac_10_8)]
+			[Availability (Deprecated = Platform.iOS_5_1)]
+			[Availability (Deprecated = Platform.Mac_10_8)]
 			RubyKana             = 1,
 			RubyKanaOn           = 2,
 			RubyKanaOff          = 3
@@ -1148,9 +1152,11 @@ namespace XamCore.CoreText {
 	{
 		public enum Selector
 		{
-			[Availability (Deprecated = Platform.iOS_5_1 | Platform.Mac_10_8)]
+			[Availability (Deprecated = Platform.iOS_5_1)]
+			[Availability (Deprecated = Platform.Mac_10_8)]
 			NoCJKItalicRoman     = 0,
-			[Availability (Deprecated = Platform.iOS_5_1 | Platform.Mac_10_8)]
+			[Availability (Deprecated = Platform.iOS_5_1)]
+			[Availability (Deprecated = Platform.Mac_10_8)]
 			CJKItalicRoman       = 1,
 			CJKItalicRomanOn     = 2,
 			CJKItalicRomanOff    = 3

--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -172,8 +172,8 @@ namespace XamCore.CoreText {
 		AllTypographicFeatures   = 0,
 		Ligatures                = 1,
 		CursiveConnection        = 2,
-		[Availability (Deprecated = Platform.iOS_6_0)]
-		[Availability (Deprecated = Platform.Mac_10_7)]
+		[Deprecated (PlatformName.iOS, 6, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 7)]
 		LetterCase               = 3,
 		VerticalSubstitution     = 4,
 		LinguisticRearrangement  = 5,
@@ -481,8 +481,8 @@ namespace XamCore.CoreText {
 		}
 	}
 
-	[Availability (Deprecated = Platform.iOS_6_0)]
-	[Availability (Deprecated = Platform.Mac_10_7)]
+	[Deprecated (PlatformName.iOS, 6, 0)]
+	[Deprecated (PlatformName.MacOSX, 10, 7)]
 	public class CTFontFeatureLetterCase : CTFontFeatureSelectors
 	{
 		public enum Selector
@@ -1058,11 +1058,11 @@ namespace XamCore.CoreText {
 	{
 		public enum Selector
 		{
-			[Availability (Deprecated = Platform.iOS_5_1)]
-			[Availability (Deprecated = Platform.Mac_10_8)]
+			[Deprecated (PlatformName.iOS, 5, 1)]
+			[Deprecated (PlatformName.MacOSX, 10, 8)]
 			NoRubyKana           = 0,
-			[Availability (Deprecated = Platform.iOS_5_1)]
-			[Availability (Deprecated = Platform.Mac_10_8)]
+			[Deprecated (PlatformName.iOS, 5, 1)]
+			[Deprecated (PlatformName.MacOSX, 10, 8)]
 			RubyKana             = 1,
 			RubyKanaOn           = 2,
 			RubyKanaOff          = 3
@@ -1152,11 +1152,11 @@ namespace XamCore.CoreText {
 	{
 		public enum Selector
 		{
-			[Availability (Deprecated = Platform.iOS_5_1)]
-			[Availability (Deprecated = Platform.Mac_10_8)]
+			[Deprecated (PlatformName.iOS, 5, 1)]
+			[Deprecated (PlatformName.MacOSX, 10, 8)]
 			NoCJKItalicRoman     = 0,
-			[Availability (Deprecated = Platform.iOS_5_1)]
-			[Availability (Deprecated = Platform.Mac_10_8)]
+			[Deprecated (PlatformName.iOS, 5, 1)]
+			[Deprecated (PlatformName.MacOSX, 10, 8)]
 			CJKItalicRoman       = 1,
 			CJKItalicRomanOn     = 2,
 			CJKItalicRomanOff    = 3

--- a/src/CoreText/CTParagraphStyle.cs
+++ b/src/CoreText/CTParagraphStyle.cs
@@ -81,7 +81,8 @@ namespace XamCore.CoreText {
 		LineHeightMultiple      = 7,
 		MaximumLineHeight       = 8,
 		MinimumLineHeight       = 9,
-		[Availability (Introduced = Platform.iOS_3_2 | Platform.Mac_10_5, Deprecated = Platform.iOS_6_0 | Platform.Mac_10_8, Message="Please use MaximumLineSpacing")]
+		[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_6_0, Message="Please use MaximumLineSpacing")]
+		[Availability (Introduced = Platform.Mac_10_5, Deprecated = Platform.Mac_10_8, Message="Please use MaximumLineSpacing")]
 		LineSpacing             = 10,
 		ParagraphSpacing        = 11,
 		ParagraphSpacingBefore  = 12,

--- a/src/CoreText/CTParagraphStyle.cs
+++ b/src/CoreText/CTParagraphStyle.cs
@@ -81,9 +81,9 @@ namespace XamCore.CoreText {
 		LineHeightMultiple      = 7,
 		MaximumLineHeight       = 8,
 		MinimumLineHeight       = 9,
-		[Introduced (PlatformName.iOS, 3, 2)]
+		[iOS (3, 2)]
 		[Deprecated (PlatformName.iOS, 6, 0, message : "Please use MaximumLineSpacing")]
-		[Introduced (PlatformName.MacOSX, 10, 5)]
+		[Mac (10, 5)]
 		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Please use MaximumLineSpacing")]
 		LineSpacing             = 10,
 		ParagraphSpacing        = 11,

--- a/src/CoreText/CTParagraphStyle.cs
+++ b/src/CoreText/CTParagraphStyle.cs
@@ -81,8 +81,10 @@ namespace XamCore.CoreText {
 		LineHeightMultiple      = 7,
 		MaximumLineHeight       = 8,
 		MinimumLineHeight       = 9,
-		[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_6_0, Message="Please use MaximumLineSpacing")]
-		[Availability (Introduced = Platform.Mac_10_5, Deprecated = Platform.Mac_10_8, Message="Please use MaximumLineSpacing")]
+		[Introduced (PlatformName.iOS, 3, 2)]
+		[Deprecated (PlatformName.iOS, 6, 0, message : "Please use MaximumLineSpacing")]
+		[Introduced (PlatformName.MacOSX, 10, 5)]
+		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Please use MaximumLineSpacing")]
 		LineSpacing             = 10,
 		ParagraphSpacing        = 11,
 		ParagraphSpacingBefore  = 12,

--- a/src/CoreVideo/CVImageBuffer.cs
+++ b/src/CoreVideo/CVImageBuffer.cs
@@ -212,7 +212,7 @@ namespace XamCore.CoreVideo {
 #endif
 
 #if MONOMAC 
-		[MountainLion]
+		[Mac (10, 8)]
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static /* CGColorSpaceRef */ IntPtr CVImageBufferCreateColorSpaceFromAttachments (/* CFDictionaryRef */ IntPtr attachments);
 

--- a/src/EventKit/EKEnums.cs
+++ b/src/EventKit/EKEnums.cs
@@ -79,7 +79,8 @@ namespace XamCore.EventKit {
 
 	// untyped enum -> EKTypes.h
 	// Special note: some API (like `dayOfWeek:` and `dayOfWeek:weekNumber:` use an `NSInteger` instead of the enum
-	[Availability (Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11, Message = "Use 'EKWeekday'.")]
+	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'EKWeekday'.")]
+	[Availability (Deprecated = Platform.Mac_10_11, Message = "Use 'EKWeekday'.")]
 	public enum EKDay {
 		NotSet = 0,
 		Sunday = 1,

--- a/src/EventKit/EKEnums.cs
+++ b/src/EventKit/EKEnums.cs
@@ -79,8 +79,8 @@ namespace XamCore.EventKit {
 
 	// untyped enum -> EKTypes.h
 	// Special note: some API (like `dayOfWeek:` and `dayOfWeek:weekNumber:` use an `NSInteger` instead of the enum
-	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'EKWeekday'.")]
-	[Availability (Deprecated = Platform.Mac_10_11, Message = "Use 'EKWeekday'.")]
+	[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'EKWeekday'.")]
+	[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'EKWeekday'.")]
 	public enum EKDay {
 		NotSet = 0,
 		Sunday = 1,

--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -183,34 +183,36 @@ namespace XamCore.Foundation  {
 		Hour = 32,
 		Minute = 64,
 		Second = 128,
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_8_0)]
+		[Introduced (PlatformName.MacOSX, 10, 4)]
+		[Deprecated (PlatformName.MacOSX, 10, 10)]
+		[Introduced (PlatformName.iOS, 2, 0)]
+		[Deprecated (PlatformName.iOS, 8, 0)]
 		Week = 256,
 		Weekday = 512,
 		WeekdayOrdinal = 1024,
-		[Availability (Introduced = Platform.Mac_10_6)]
-		[Availability (Introduced = Platform.iOS_4_0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
 		Quarter = 2048,
 
-		[Availability (Introduced = Platform.Mac_10_7)]
-		[Availability (Introduced = Platform.iOS_5_0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Introduced (PlatformName.iOS, 5, 0)]
 		WeekOfMonth = (1 << 12),
-		[Availability (Introduced = Platform.Mac_10_7)]
-		[Availability (Introduced = Platform.iOS_5_0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Introduced (PlatformName.iOS, 5, 0)]
 		WeekOfYear = (1 << 13),
-		[Availability (Introduced = Platform.Mac_10_7)]
-		[Availability (Introduced = Platform.iOS_5_0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Introduced (PlatformName.iOS, 5, 0)]
 		YearForWeakOfYear = (1 << 14),
 
-		[Availability (Introduced = Platform.Mac_10_7)]
-		[Availability (Introduced = Platform.iOS_5_0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Introduced (PlatformName.iOS, 5, 0)]
 		Nanosecond = (1 << 15),
 
-		[Availability (Introduced = Platform.Mac_10_7)]
-		[Availability (Introduced = Platform.iOS_5_0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Introduced (PlatformName.iOS, 5, 0)]
 		Calendar = (1 << 20),
-		[Availability (Introduced = Platform.Mac_10_7)]
-		[Availability (Introduced = Platform.iOS_5_0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Introduced (PlatformName.iOS, 5, 0)]
 		TimeZone = (1 << 21),
 	}
 
@@ -691,11 +693,11 @@ namespace XamCore.Foundation  {
 	public enum NSFileCoordinatorReadingOptions : nuint_compat_int {
 		WithoutChanges = 1,
 		ResolvesSymbolicLink = 1 << 1,
-		[Availability (Introduced = Platform.Mac_10_10)]
-		[Availability (Introduced = Platform.iOS_8_0)]
+		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[Introduced (PlatformName.iOS, 8, 0)]
 		ImmediatelyAvailableMetadataOnly = 1 << 2,
-		[Availability (Introduced = Platform.Mac_10_10)]
-		[Availability (Introduced = Platform.iOS_8_0)]
+		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[Introduced (PlatformName.iOS, 8, 0)]
 		ForUploading = 1 << 3
 	}
 
@@ -887,28 +889,28 @@ namespace XamCore.Foundation  {
 		None = 0,
 		WrapCalendarComponents = 1 << 0,
 
-		[Availability (Introduced = Platform.Mac_10_9)]
-		[Availability (Introduced = Platform.iOS_7_0)]
+		[Introduced (PlatformName.MacOSX, 10, 9)]
+		[Introduced (PlatformName.iOS, 7, 0)]
 		MatchStrictly = 1 << 1,
-		[Availability (Introduced = Platform.Mac_10_9)]
-		[Availability (Introduced = Platform.iOS_7_0)]
+		[Introduced (PlatformName.MacOSX, 10, 9)]
+		[Introduced (PlatformName.iOS, 7, 0)]
 		SearchBackwards = 1 << 2,
 
-		[Availability (Introduced = Platform.Mac_10_9)]
-		[Availability (Introduced = Platform.iOS_7_0)]
+		[Introduced (PlatformName.MacOSX, 10, 9)]
+		[Introduced (PlatformName.iOS, 7, 0)]
 		MatchPreviousTimePreservingSmallerUnits = 1 << 8,
-		[Availability (Introduced = Platform.Mac_10_9)]
-		[Availability (Introduced = Platform.iOS_7_0)]
+		[Introduced (PlatformName.MacOSX, 10, 9)]
+		[Introduced (PlatformName.iOS, 7, 0)]
 		MatchNextTimePreservingSmallerUnits = 1 << 9,
-		[Availability (Introduced = Platform.Mac_10_9)]
-		[Availability (Introduced = Platform.iOS_7_0)]
+		[Introduced (PlatformName.MacOSX, 10, 9)]
+		[Introduced (PlatformName.iOS, 7, 0)]
 		MatchNextTime = 1 << 10,
 
-		[Availability (Introduced = Platform.Mac_10_9)]
-		[Availability (Introduced = Platform.iOS_7_0)]
+		[Introduced (PlatformName.MacOSX, 10, 9)]
+		[Introduced (PlatformName.iOS, 7, 0)]
 		MatchFirst = 1 << 12,
-		[Availability (Introduced = Platform.Mac_10_9)]
-		[Availability (Introduced = Platform.iOS_7_0)]
+		[Introduced (PlatformName.MacOSX, 10, 9)]
+		[Introduced (PlatformName.iOS, 7, 0)]
 		MatchLast = 1 << 13,
 	}
 	
@@ -1020,8 +1022,8 @@ namespace XamCore.Foundation  {
 	}
 
 	[Native]
-	[Availability (Introduced = Platform.Mac_10_10)]
-	[Availability (Introduced = Platform.iOS_8_0)]
+	[Introduced (PlatformName.MacOSX, 10, 10)]
+	[Introduced (PlatformName.iOS, 8, 0)]
 	public enum NSDateComponentsFormatterUnitsStyle : nint {
 		Positional = 0,
 		Abbreviated,
@@ -1034,8 +1036,8 @@ namespace XamCore.Foundation  {
 
 	[Flags]
 	[Native]
-	[Availability (Introduced = Platform.Mac_10_10)]
-	[Availability (Introduced = Platform.iOS_8_0)]
+	[Introduced (PlatformName.MacOSX, 10, 10)]
+	[Introduced (PlatformName.iOS, 8, 0)]
 	public enum NSDateComponentsFormatterZeroFormattingBehavior : nuint {
 		None = (0),
 		Default = (1 << 0),
@@ -1047,8 +1049,8 @@ namespace XamCore.Foundation  {
 	}
 
 	[Native]
-	[Availability (Introduced = Platform.Mac_10_10)]
-	[Availability (Introduced = Platform.iOS_8_0)]
+	[Introduced (PlatformName.MacOSX, 10, 10)]
+	[Introduced (PlatformName.iOS, 8, 0)]
 	public enum NSFormattingContext : nint {
 		Unknown = 0,
 		Dynamic = 1,
@@ -1058,8 +1060,8 @@ namespace XamCore.Foundation  {
 		MiddleOfSentence = 5
 	}
 
-	[Availability (Introduced = Platform.Mac_10_10)]
-	[Availability (Introduced = Platform.iOS_8_0)]
+	[Introduced (PlatformName.MacOSX, 10, 10)]
+	[Introduced (PlatformName.iOS, 8, 0)]
 	[Native]
 	public enum NSDateIntervalFormatterStyle : nuint {
 		None = 0,
@@ -1069,8 +1071,8 @@ namespace XamCore.Foundation  {
 		Full = 4
 	}
 
-	[Availability (Introduced = Platform.Mac_10_10)]
-	[Availability (Introduced = Platform.iOS_8_0)]
+	[Introduced (PlatformName.MacOSX, 10, 10)]
+	[Introduced (PlatformName.iOS, 8, 0)]
 	[Native]
 	public enum NSEnergyFormatterUnit : nint {
 		Joule = 11,
@@ -1079,8 +1081,8 @@ namespace XamCore.Foundation  {
 		Kilocalorie = (7 << 8) + 2
 	}
 
-	[Availability (Introduced = Platform.Mac_10_10)]
-	[Availability (Introduced = Platform.iOS_8_0)]
+	[Introduced (PlatformName.MacOSX, 10, 10)]
+	[Introduced (PlatformName.iOS, 8, 0)]
 	[Native]
 	public enum NSFormattingUnitStyle : nint {
 		Short = 1,
@@ -1167,14 +1169,14 @@ namespace XamCore.Foundation  {
 		Dash          = 1 << 7,
 		Replacement   = 1 << 8,
 		Correction    = 1 << 9,
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_7)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
 		RegularExpression  = 1 << 10,
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_7)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
 		PhoneNumber        = 1 << 11,
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_7)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
 		TransitInformation = 1 << 12,
 	}
 

--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -183,26 +183,34 @@ namespace XamCore.Foundation  {
 		Hour = 32,
 		Minute = 64,
 		Second = 128,
-		[Availability (Introduced = Platform.Mac_10_4 | Platform.iOS_2_0, Deprecated = Platform.Mac_10_10 | Platform.iOS_8_0)]
+		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_8_0)]
 		Week = 256,
 		Weekday = 512,
 		WeekdayOrdinal = 1024,
-		[Availability (Introduced = Platform.Mac_10_6 | Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
 		Quarter = 2048,
 
-		[Availability (Introduced = Platform.Mac_10_7 | Platform.iOS_5_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_5_0)]
 		WeekOfMonth = (1 << 12),
-		[Availability (Introduced = Platform.Mac_10_7 | Platform.iOS_5_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_5_0)]
 		WeekOfYear = (1 << 13),
-		[Availability (Introduced = Platform.Mac_10_7 | Platform.iOS_5_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_5_0)]
 		YearForWeakOfYear = (1 << 14),
 
-		[Availability (Introduced = Platform.Mac_10_7 | Platform.iOS_5_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_5_0)]
 		Nanosecond = (1 << 15),
 
-		[Availability (Introduced = Platform.Mac_10_7 | Platform.iOS_5_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_5_0)]
 		Calendar = (1 << 20),
-		[Availability (Introduced = Platform.Mac_10_7 | Platform.iOS_5_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_5_0)]
 		TimeZone = (1 << 21),
 	}
 
@@ -683,9 +691,11 @@ namespace XamCore.Foundation  {
 	public enum NSFileCoordinatorReadingOptions : nuint_compat_int {
 		WithoutChanges = 1,
 		ResolvesSymbolicLink = 1 << 1,
-		[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0)]
+		[Availability (Introduced = Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_8_0)]
 		ImmediatelyAvailableMetadataOnly = 1 << 2,
-		[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0)]
+		[Availability (Introduced = Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_8_0)]
 		ForUploading = 1 << 3
 	}
 
@@ -877,21 +887,28 @@ namespace XamCore.Foundation  {
 		None = 0,
 		WrapCalendarComponents = 1 << 0,
 
-		[Availability (Introduced = Platform.Mac_10_9 | Platform.iOS_7_0)]
+		[Availability (Introduced = Platform.Mac_10_9)]
+		[Availability (Introduced = Platform.iOS_7_0)]
 		MatchStrictly = 1 << 1,
-		[Availability (Introduced = Platform.Mac_10_9 | Platform.iOS_7_0)]
+		[Availability (Introduced = Platform.Mac_10_9)]
+		[Availability (Introduced = Platform.iOS_7_0)]
 		SearchBackwards = 1 << 2,
 
-		[Availability (Introduced = Platform.Mac_10_9 | Platform.iOS_7_0)]
+		[Availability (Introduced = Platform.Mac_10_9)]
+		[Availability (Introduced = Platform.iOS_7_0)]
 		MatchPreviousTimePreservingSmallerUnits = 1 << 8,
-		[Availability (Introduced = Platform.Mac_10_9 | Platform.iOS_7_0)]
+		[Availability (Introduced = Platform.Mac_10_9)]
+		[Availability (Introduced = Platform.iOS_7_0)]
 		MatchNextTimePreservingSmallerUnits = 1 << 9,
-		[Availability (Introduced = Platform.Mac_10_9 | Platform.iOS_7_0)]
+		[Availability (Introduced = Platform.Mac_10_9)]
+		[Availability (Introduced = Platform.iOS_7_0)]
 		MatchNextTime = 1 << 10,
 
-		[Availability (Introduced = Platform.Mac_10_9 | Platform.iOS_7_0)]
+		[Availability (Introduced = Platform.Mac_10_9)]
+		[Availability (Introduced = Platform.iOS_7_0)]
 		MatchFirst = 1 << 12,
-		[Availability (Introduced = Platform.Mac_10_9 | Platform.iOS_7_0)]
+		[Availability (Introduced = Platform.Mac_10_9)]
+		[Availability (Introduced = Platform.iOS_7_0)]
 		MatchLast = 1 << 13,
 	}
 	
@@ -1003,7 +1020,8 @@ namespace XamCore.Foundation  {
 	}
 
 	[Native]
-	[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Introduced = Platform.Mac_10_10)]
+	[Availability (Introduced = Platform.iOS_8_0)]
 	public enum NSDateComponentsFormatterUnitsStyle : nint {
 		Positional = 0,
 		Abbreviated,
@@ -1016,7 +1034,8 @@ namespace XamCore.Foundation  {
 
 	[Flags]
 	[Native]
-	[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Introduced = Platform.Mac_10_10)]
+	[Availability (Introduced = Platform.iOS_8_0)]
 	public enum NSDateComponentsFormatterZeroFormattingBehavior : nuint {
 		None = (0),
 		Default = (1 << 0),
@@ -1028,7 +1047,8 @@ namespace XamCore.Foundation  {
 	}
 
 	[Native]
-	[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Introduced = Platform.Mac_10_10)]
+	[Availability (Introduced = Platform.iOS_8_0)]
 	public enum NSFormattingContext : nint {
 		Unknown = 0,
 		Dynamic = 1,
@@ -1038,7 +1058,8 @@ namespace XamCore.Foundation  {
 		MiddleOfSentence = 5
 	}
 
-	[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Introduced = Platform.Mac_10_10)]
+	[Availability (Introduced = Platform.iOS_8_0)]
 	[Native]
 	public enum NSDateIntervalFormatterStyle : nuint {
 		None = 0,
@@ -1048,7 +1069,8 @@ namespace XamCore.Foundation  {
 		Full = 4
 	}
 
-	[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Introduced = Platform.Mac_10_10)]
+	[Availability (Introduced = Platform.iOS_8_0)]
 	[Native]
 	public enum NSEnergyFormatterUnit : nint {
 		Joule = 11,
@@ -1057,7 +1079,8 @@ namespace XamCore.Foundation  {
 		Kilocalorie = (7 << 8) + 2
 	}
 
-	[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Introduced = Platform.Mac_10_10)]
+	[Availability (Introduced = Platform.iOS_8_0)]
 	[Native]
 	public enum NSFormattingUnitStyle : nint {
 		Short = 1,
@@ -1144,11 +1167,14 @@ namespace XamCore.Foundation  {
 		Dash          = 1 << 7,
 		Replacement   = 1 << 8,
 		Correction    = 1 << 9,
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
 		RegularExpression  = 1 << 10,
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
 		PhoneNumber        = 1 << 11,
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
 		TransitInformation = 1 << 12,
 	}
 

--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -183,36 +183,36 @@ namespace XamCore.Foundation  {
 		Hour = 32,
 		Minute = 64,
 		Second = 128,
-		[Introduced (PlatformName.MacOSX, 10, 4)]
+		[Mac (10, 4)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
-		[Introduced (PlatformName.iOS, 2, 0)]
+		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0)]
 		Week = 256,
 		Weekday = 512,
 		WeekdayOrdinal = 1024,
-		[Introduced (PlatformName.MacOSX, 10, 6)]
-		[Introduced (PlatformName.iOS, 4, 0)]
+		[Mac (10, 6)]
+		[iOS (4, 0)]
 		Quarter = 2048,
 
-		[Introduced (PlatformName.MacOSX, 10, 7)]
-		[Introduced (PlatformName.iOS, 5, 0)]
+		[Mac (10, 7)]
+		[iOS (5, 0)]
 		WeekOfMonth = (1 << 12),
-		[Introduced (PlatformName.MacOSX, 10, 7)]
-		[Introduced (PlatformName.iOS, 5, 0)]
+		[Mac (10, 7)]
+		[iOS (5, 0)]
 		WeekOfYear = (1 << 13),
-		[Introduced (PlatformName.MacOSX, 10, 7)]
-		[Introduced (PlatformName.iOS, 5, 0)]
+		[Mac (10, 7)]
+		[iOS (5, 0)]
 		YearForWeakOfYear = (1 << 14),
 
-		[Introduced (PlatformName.MacOSX, 10, 7)]
-		[Introduced (PlatformName.iOS, 5, 0)]
+		[Mac (10, 7)]
+		[iOS (5, 0)]
 		Nanosecond = (1 << 15),
 
-		[Introduced (PlatformName.MacOSX, 10, 7)]
-		[Introduced (PlatformName.iOS, 5, 0)]
+		[Mac (10, 7)]
+		[iOS (5, 0)]
 		Calendar = (1 << 20),
-		[Introduced (PlatformName.MacOSX, 10, 7)]
-		[Introduced (PlatformName.iOS, 5, 0)]
+		[Mac (10, 7)]
+		[iOS (5, 0)]
 		TimeZone = (1 << 21),
 	}
 
@@ -693,11 +693,11 @@ namespace XamCore.Foundation  {
 	public enum NSFileCoordinatorReadingOptions : nuint_compat_int {
 		WithoutChanges = 1,
 		ResolvesSymbolicLink = 1 << 1,
-		[Introduced (PlatformName.MacOSX, 10, 10)]
-		[Introduced (PlatformName.iOS, 8, 0)]
+		[Mac (10, 10)]
+		[iOS (8, 0)]
 		ImmediatelyAvailableMetadataOnly = 1 << 2,
-		[Introduced (PlatformName.MacOSX, 10, 10)]
-		[Introduced (PlatformName.iOS, 8, 0)]
+		[Mac (10, 10)]
+		[iOS (8, 0)]
 		ForUploading = 1 << 3
 	}
 
@@ -889,28 +889,28 @@ namespace XamCore.Foundation  {
 		None = 0,
 		WrapCalendarComponents = 1 << 0,
 
-		[Introduced (PlatformName.MacOSX, 10, 9)]
-		[Introduced (PlatformName.iOS, 7, 0)]
+		[Mac (10, 9)]
+		[iOS (7, 0)]
 		MatchStrictly = 1 << 1,
-		[Introduced (PlatformName.MacOSX, 10, 9)]
-		[Introduced (PlatformName.iOS, 7, 0)]
+		[Mac (10, 9)]
+		[iOS (7, 0)]
 		SearchBackwards = 1 << 2,
 
-		[Introduced (PlatformName.MacOSX, 10, 9)]
-		[Introduced (PlatformName.iOS, 7, 0)]
+		[Mac (10, 9)]
+		[iOS (7, 0)]
 		MatchPreviousTimePreservingSmallerUnits = 1 << 8,
-		[Introduced (PlatformName.MacOSX, 10, 9)]
-		[Introduced (PlatformName.iOS, 7, 0)]
+		[Mac (10, 9)]
+		[iOS (7, 0)]
 		MatchNextTimePreservingSmallerUnits = 1 << 9,
-		[Introduced (PlatformName.MacOSX, 10, 9)]
-		[Introduced (PlatformName.iOS, 7, 0)]
+		[Mac (10, 9)]
+		[iOS (7, 0)]
 		MatchNextTime = 1 << 10,
 
-		[Introduced (PlatformName.MacOSX, 10, 9)]
-		[Introduced (PlatformName.iOS, 7, 0)]
+		[Mac (10, 9)]
+		[iOS (7, 0)]
 		MatchFirst = 1 << 12,
-		[Introduced (PlatformName.MacOSX, 10, 9)]
-		[Introduced (PlatformName.iOS, 7, 0)]
+		[Mac (10, 9)]
+		[iOS (7, 0)]
 		MatchLast = 1 << 13,
 	}
 	
@@ -1022,8 +1022,8 @@ namespace XamCore.Foundation  {
 	}
 
 	[Native]
-	[Introduced (PlatformName.MacOSX, 10, 10)]
-	[Introduced (PlatformName.iOS, 8, 0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	public enum NSDateComponentsFormatterUnitsStyle : nint {
 		Positional = 0,
 		Abbreviated,
@@ -1036,8 +1036,8 @@ namespace XamCore.Foundation  {
 
 	[Flags]
 	[Native]
-	[Introduced (PlatformName.MacOSX, 10, 10)]
-	[Introduced (PlatformName.iOS, 8, 0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	public enum NSDateComponentsFormatterZeroFormattingBehavior : nuint {
 		None = (0),
 		Default = (1 << 0),
@@ -1049,8 +1049,8 @@ namespace XamCore.Foundation  {
 	}
 
 	[Native]
-	[Introduced (PlatformName.MacOSX, 10, 10)]
-	[Introduced (PlatformName.iOS, 8, 0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	public enum NSFormattingContext : nint {
 		Unknown = 0,
 		Dynamic = 1,
@@ -1060,8 +1060,8 @@ namespace XamCore.Foundation  {
 		MiddleOfSentence = 5
 	}
 
-	[Introduced (PlatformName.MacOSX, 10, 10)]
-	[Introduced (PlatformName.iOS, 8, 0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum NSDateIntervalFormatterStyle : nuint {
 		None = 0,
@@ -1071,8 +1071,8 @@ namespace XamCore.Foundation  {
 		Full = 4
 	}
 
-	[Introduced (PlatformName.MacOSX, 10, 10)]
-	[Introduced (PlatformName.iOS, 8, 0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum NSEnergyFormatterUnit : nint {
 		Joule = 11,
@@ -1081,8 +1081,8 @@ namespace XamCore.Foundation  {
 		Kilocalorie = (7 << 8) + 2
 	}
 
-	[Introduced (PlatformName.MacOSX, 10, 10)]
-	[Introduced (PlatformName.iOS, 8, 0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum NSFormattingUnitStyle : nint {
 		Short = 1,
@@ -1169,14 +1169,14 @@ namespace XamCore.Foundation  {
 		Dash          = 1 << 7,
 		Replacement   = 1 << 8,
 		Correction    = 1 << 9,
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[iOS (4, 0)]
+		[Mac (10, 7)]
 		RegularExpression  = 1 << 10,
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[iOS (4, 0)]
+		[Mac (10, 7)]
 		PhoneNumber        = 1 << 11,
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[iOS (4, 0)]
+		[Mac (10, 7)]
 		TransitInformation = 1 << 12,
 	}
 

--- a/src/Foundation/NSCalendar.cs
+++ b/src/Foundation/NSCalendar.cs
@@ -39,11 +39,11 @@ namespace XamCore.Foundation {
 	public enum NSCalendarType {
 		Gregorian, Buddhist, Chinese, Hebrew, Islamic, IslamicCivil, Japanese, [Obsolete] RepublicOfChina, Persian, Indian, ISO8601,
 		Coptic, EthiopicAmeteAlem, EthiopicAmeteMihret,
-		[Introduced (PlatformName.MacOSX, 10, 10)]
-		[Introduced (PlatformName.iOS, 8, 0)]
+		[Mac (10, 10)]
+		[iOS (8, 0)]
 		IslamicTabular,
-		[Introduced (PlatformName.MacOSX, 10, 10)]
-		[Introduced (PlatformName.iOS, 8, 0)]
+		[Mac (10, 10)]
+		[iOS (8, 0)]
 		IslamicUmmAlQura,
 #pragma warning disable 612 // RepublicOfChina is obsolete
 		Taiwan = RepublicOfChina

--- a/src/Foundation/NSCalendar.cs
+++ b/src/Foundation/NSCalendar.cs
@@ -39,9 +39,11 @@ namespace XamCore.Foundation {
 	public enum NSCalendarType {
 		Gregorian, Buddhist, Chinese, Hebrew, Islamic, IslamicCivil, Japanese, [Obsolete] RepublicOfChina, Persian, Indian, ISO8601,
 		Coptic, EthiopicAmeteAlem, EthiopicAmeteMihret,
-		[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0)]
+		[Availability (Introduced = Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_8_0)]
 		IslamicTabular,
-		[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0)]
+		[Availability (Introduced = Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_8_0)]
 		IslamicUmmAlQura,
 #pragma warning disable 612 // RepublicOfChina is obsolete
 		Taiwan = RepublicOfChina

--- a/src/Foundation/NSCalendar.cs
+++ b/src/Foundation/NSCalendar.cs
@@ -39,11 +39,11 @@ namespace XamCore.Foundation {
 	public enum NSCalendarType {
 		Gregorian, Buddhist, Chinese, Hebrew, Islamic, IslamicCivil, Japanese, [Obsolete] RepublicOfChina, Persian, Indian, ISO8601,
 		Coptic, EthiopicAmeteAlem, EthiopicAmeteMihret,
-		[Availability (Introduced = Platform.Mac_10_10)]
-		[Availability (Introduced = Platform.iOS_8_0)]
+		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[Introduced (PlatformName.iOS, 8, 0)]
 		IslamicTabular,
-		[Availability (Introduced = Platform.Mac_10_10)]
-		[Availability (Introduced = Platform.iOS_8_0)]
+		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[Introduced (PlatformName.iOS, 8, 0)]
 		IslamicUmmAlQura,
 #pragma warning disable 612 // RepublicOfChina is obsolete
 		Taiwan = RepublicOfChina

--- a/src/Foundation/NSUserDefaults.cs
+++ b/src/Foundation/NSUserDefaults.cs
@@ -9,7 +9,8 @@ namespace XamCore.Foundation {
 	}
 
 	public partial class NSUserDefaults {
-		[Availability (Introduced = Platform.iOS_2_0 | Platform.Mac_10_9, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0)]
+		[Availability (Introduced = Platform.Mac_10_9, Deprecated = Platform.Mac_10_10)]
 		public NSUserDefaults (string name) : this (name, NSUserDefaultsType.UserName)
 		{
 		}

--- a/src/Foundation/NSUserDefaults.cs
+++ b/src/Foundation/NSUserDefaults.cs
@@ -9,8 +9,10 @@ namespace XamCore.Foundation {
 	}
 
 	public partial class NSUserDefaults {
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0)]
-		[Availability (Introduced = Platform.Mac_10_9, Deprecated = Platform.Mac_10_10)]
+		[Introduced (PlatformName.iOS, 2, 0)]
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 9)]
+		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		public NSUserDefaults (string name) : this (name, NSUserDefaultsType.UserName)
 		{
 		}

--- a/src/Foundation/NSUserDefaults.cs
+++ b/src/Foundation/NSUserDefaults.cs
@@ -9,9 +9,9 @@ namespace XamCore.Foundation {
 	}
 
 	public partial class NSUserDefaults {
-		[Introduced (PlatformName.iOS, 2, 0)]
+		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 9)]
+		[Mac (10, 9)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		public NSUserDefaults (string name) : this (name, NSUserDefaultsType.UserName)
 		{

--- a/src/GameKit/GKLocalPlayerListener.cs
+++ b/src/GameKit/GKLocalPlayerListener.cs
@@ -10,8 +10,8 @@ namespace XamCore.GameKit {
 		// but generator changes now catch this. Stub it out to prevent API break
 		[Unavailable (PlatformName.TvOS, PlatformArchitecture.All)]
 		[Deprecated (PlatformName.iOS, 8,0, message: "Use 'DidRequestMatchWithOtherPlayers' instead.")]
-		[Introduced (PlatformName.iOS, 7,0)]
-		[Introduced (PlatformName.MacOSX, 10,10)]
+		[iOS (7,0)]
+		[Mac (10,10)]
 		[Obsolete ("Use 'DidRequestMatch (GKPlayer player, GKPlayer[] recipientPlayers)' instead.")]
 		public virtual void DidRequestMatchWithPlayers (GKPlayer player, string[] playerIDsToInvite)
 		{

--- a/src/GameKit/GameKit.cs
+++ b/src/GameKit/GameKit.cs
@@ -55,16 +55,20 @@ namespace XamCore.GameKit {
 #endif
 
 	// untyped enum -> GKPublicConstants.h
-	[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_7_0)]
-	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10)]
+	[Introduced (PlatformName.iOS, 3, 0)]
+	[Deprecated (PlatformName.iOS, 7, 0)]
+	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Deprecated (PlatformName.MacOSX, 10, 10)]
 	public enum GKSendDataMode {
 		Reliable,
 		Unreliable,
 	} 
 
 	// untyped enum -> GKPublicConstants.h
-	[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_7_0)]
-	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10)]
+	[Introduced (PlatformName.iOS, 3, 0)]
+	[Deprecated (PlatformName.iOS, 7, 0)]
+	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Deprecated (PlatformName.MacOSX, 10, 10)]
 	public enum GKSessionMode {
 	    Server, 
 	    Client,
@@ -72,8 +76,10 @@ namespace XamCore.GameKit {
 	}
 
 	// untyped enum -> GKPublicConstants.h
-	[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_7_0)]
-	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10)]
+	[Introduced (PlatformName.iOS, 3, 0)]
+	[Deprecated (PlatformName.iOS, 7, 0)]
+	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Deprecated (PlatformName.MacOSX, 10, 10)]
 	public enum GKPeerConnectionState {
 		Available,
 		Unavailable,
@@ -175,8 +181,10 @@ namespace XamCore.GameKit {
 	}
 
 	// NSInteger -> GKMatch.h
-	[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_7_0)]
-	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10)]
+	[Introduced (PlatformName.iOS, 4, 0)]
+	[Deprecated (PlatformName.iOS, 7, 0)]
+	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Deprecated (PlatformName.MacOSX, 10, 10)]
 	[Native]
 	public enum GKMatchSendDataMode : nint {
 		Reliable, Unreliable

--- a/src/GameKit/GameKit.cs
+++ b/src/GameKit/GameKit.cs
@@ -55,14 +55,16 @@ namespace XamCore.GameKit {
 #endif
 
 	// untyped enum -> GKPublicConstants.h
-	[Availability (Introduced = Platform.iOS_3_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10)]
+	[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_7_0)]
+	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10)]
 	public enum GKSendDataMode {
 		Reliable,
 		Unreliable,
 	} 
 
 	// untyped enum -> GKPublicConstants.h
-	[Availability (Introduced = Platform.iOS_3_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10)]
+	[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_7_0)]
+	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10)]
 	public enum GKSessionMode {
 	    Server, 
 	    Client,
@@ -70,7 +72,8 @@ namespace XamCore.GameKit {
 	}
 
 	// untyped enum -> GKPublicConstants.h
-	[Availability (Introduced = Platform.iOS_3_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10)]
+	[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_7_0)]
+	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10)]
 	public enum GKPeerConnectionState {
 		Available,
 		Unavailable,
@@ -172,7 +175,8 @@ namespace XamCore.GameKit {
 	}
 
 	// NSInteger -> GKMatch.h
-	[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10)]
+	[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_7_0)]
+	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10)]
 	[Native]
 	public enum GKMatchSendDataMode : nint {
 		Reliable, Unreliable

--- a/src/GameKit/GameKit.cs
+++ b/src/GameKit/GameKit.cs
@@ -55,9 +55,9 @@ namespace XamCore.GameKit {
 #endif
 
 	// untyped enum -> GKPublicConstants.h
-	[Introduced (PlatformName.iOS, 3, 0)]
+	[iOS (3, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10)]
 	public enum GKSendDataMode {
 		Reliable,
@@ -65,9 +65,9 @@ namespace XamCore.GameKit {
 	} 
 
 	// untyped enum -> GKPublicConstants.h
-	[Introduced (PlatformName.iOS, 3, 0)]
+	[iOS (3, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10)]
 	public enum GKSessionMode {
 	    Server, 
@@ -76,9 +76,9 @@ namespace XamCore.GameKit {
 	}
 
 	// untyped enum -> GKPublicConstants.h
-	[Introduced (PlatformName.iOS, 3, 0)]
+	[iOS (3, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10)]
 	public enum GKPeerConnectionState {
 		Available,
@@ -181,9 +181,9 @@ namespace XamCore.GameKit {
 	}
 
 	// NSInteger -> GKMatch.h
-	[Introduced (PlatformName.iOS, 4, 0)]
+	[iOS (4, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10)]
 	[Native]
 	public enum GKMatchSendDataMode : nint {

--- a/src/GameKit/GameKit2.cs
+++ b/src/GameKit/GameKit2.cs
@@ -357,9 +357,9 @@ namespace XamCore.GameKit {
 
 #if !XAMCORE_2_0
 	public partial class GKScore {
-		[Introduced (PlatformName.iOS, 4, 1)]
+		[iOS (4, 1)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'LeaderboardIdentifier' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'LeaderboardIdentifier' instead.")]
 		public string Category {
 			get { return category; }

--- a/src/GameKit/GameKit2.cs
+++ b/src/GameKit/GameKit2.cs
@@ -357,7 +357,8 @@ namespace XamCore.GameKit {
 
 #if !XAMCORE_2_0
 	public partial class GKScore {
-		[Availability (Introduced = Platform.iOS_4_1 | Platform.Mac_10_8, Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'LeaderboardIdentifier' instead.")]
+		[Availability (Introduced = Platform.iOS_4_1, Deprecated = Platform.iOS_8_0, Message = "Use 'LeaderboardIdentifier' instead.")]
+		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'LeaderboardIdentifier' instead.")]
 		public string Category {
 			get { return category; }
 			set { category = value; }

--- a/src/GameKit/GameKit2.cs
+++ b/src/GameKit/GameKit2.cs
@@ -357,8 +357,10 @@ namespace XamCore.GameKit {
 
 #if !XAMCORE_2_0
 	public partial class GKScore {
-		[Availability (Introduced = Platform.iOS_4_1, Deprecated = Platform.iOS_8_0, Message = "Use 'LeaderboardIdentifier' instead.")]
-		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'LeaderboardIdentifier' instead.")]
+		[Introduced (PlatformName.iOS, 4, 1)]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'LeaderboardIdentifier' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'LeaderboardIdentifier' instead.")]
 		public string Category {
 			get { return category; }
 			set { category = value; }

--- a/src/HealthKit/Enums.cs
+++ b/src/HealthKit/Enums.cs
@@ -322,8 +322,8 @@ namespace XamCore.HealthKit
 		Lacrosse,
 		MartialArts,
 		MindAndBody,
-		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'MixedCardio' or 'HighIntensityIntervalTraining' instead.")]
-		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'MixedCardio' or 'HighIntensityIntervalTraining' instead.")]
+		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'MixedCardio' or 'HighIntensityIntervalTraining' instead.")]
+		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'MixedCardio' or 'HighIntensityIntervalTraining' instead.")]
 		MixedMetabolicCardioTraining,
 		PaddleSports,
 		Play,

--- a/src/HealthKit/Enums.cs
+++ b/src/HealthKit/Enums.cs
@@ -322,7 +322,8 @@ namespace XamCore.HealthKit
 		Lacrosse,
 		MartialArts,
 		MindAndBody,
-		[Availability (Deprecated = Platform.iOS_11_0 | Platform.Watch_4_0, Message = "Use 'MixedCardio' or 'HighIntensityIntervalTraining' instead.")]
+		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'MixedCardio' or 'HighIntensityIntervalTraining' instead.")]
+		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'MixedCardio' or 'HighIntensityIntervalTraining' instead.")]
 		MixedMetabolicCardioTraining,
 		PaddleSports,
 		Play,

--- a/src/ImageIO/CGImageDestination.cs
+++ b/src/ImageIO/CGImageDestination.cs
@@ -57,13 +57,16 @@ namespace XamCore.ImageIO {
 		[iOS (7,0), Mac (10,8)]
 		public DateTime? DateTime { get; set; }
 
-		[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0)]
+		[Availability (Introduced = Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_8_0)]
 		public int? ImageMaxPixelSize { get; set; }
 
-		[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0)]
+		[Availability (Introduced = Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_8_0)]
 		public bool EmbedThumbnail { get; set; }
 
-		[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0)]
+		[Availability (Introduced = Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_8_0)]
 		public bool ShouldExcludeGPS { get; set; }
 
 		[iOS (9,3)][Mac (10,12)]
@@ -147,7 +150,8 @@ namespace XamCore.ImageIO {
 		[iOS (7,0), Mac (10,8)]
 		public bool ShouldExcludeXMP { get; set; }
 
-		[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0)]
+		[Availability (Introduced = Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_8_0)]
 		public bool ShouldExcludeGPS { get; set; }
 
 		[iOS (7,0), Mac (10,8)]

--- a/src/ImageIO/CGImageDestination.cs
+++ b/src/ImageIO/CGImageDestination.cs
@@ -57,16 +57,16 @@ namespace XamCore.ImageIO {
 		[iOS (7,0), Mac (10,8)]
 		public DateTime? DateTime { get; set; }
 
-		[Availability (Introduced = Platform.Mac_10_10)]
-		[Availability (Introduced = Platform.iOS_8_0)]
+		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[Introduced (PlatformName.iOS, 8, 0)]
 		public int? ImageMaxPixelSize { get; set; }
 
-		[Availability (Introduced = Platform.Mac_10_10)]
-		[Availability (Introduced = Platform.iOS_8_0)]
+		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[Introduced (PlatformName.iOS, 8, 0)]
 		public bool EmbedThumbnail { get; set; }
 
-		[Availability (Introduced = Platform.Mac_10_10)]
-		[Availability (Introduced = Platform.iOS_8_0)]
+		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[Introduced (PlatformName.iOS, 8, 0)]
 		public bool ShouldExcludeGPS { get; set; }
 
 		[iOS (9,3)][Mac (10,12)]
@@ -150,8 +150,8 @@ namespace XamCore.ImageIO {
 		[iOS (7,0), Mac (10,8)]
 		public bool ShouldExcludeXMP { get; set; }
 
-		[Availability (Introduced = Platform.Mac_10_10)]
-		[Availability (Introduced = Platform.iOS_8_0)]
+		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[Introduced (PlatformName.iOS, 8, 0)]
 		public bool ShouldExcludeGPS { get; set; }
 
 		[iOS (7,0), Mac (10,8)]

--- a/src/ImageIO/CGImageDestination.cs
+++ b/src/ImageIO/CGImageDestination.cs
@@ -57,16 +57,16 @@ namespace XamCore.ImageIO {
 		[iOS (7,0), Mac (10,8)]
 		public DateTime? DateTime { get; set; }
 
-		[Introduced (PlatformName.MacOSX, 10, 10)]
-		[Introduced (PlatformName.iOS, 8, 0)]
+		[Mac (10, 10)]
+		[iOS (8, 0)]
 		public int? ImageMaxPixelSize { get; set; }
 
-		[Introduced (PlatformName.MacOSX, 10, 10)]
-		[Introduced (PlatformName.iOS, 8, 0)]
+		[Mac (10, 10)]
+		[iOS (8, 0)]
 		public bool EmbedThumbnail { get; set; }
 
-		[Introduced (PlatformName.MacOSX, 10, 10)]
-		[Introduced (PlatformName.iOS, 8, 0)]
+		[Mac (10, 10)]
+		[iOS (8, 0)]
 		public bool ShouldExcludeGPS { get; set; }
 
 		[iOS (9,3)][Mac (10,12)]
@@ -150,8 +150,8 @@ namespace XamCore.ImageIO {
 		[iOS (7,0), Mac (10,8)]
 		public bool ShouldExcludeXMP { get; set; }
 
-		[Introduced (PlatformName.MacOSX, 10, 10)]
-		[Introduced (PlatformName.iOS, 8, 0)]
+		[Mac (10, 10)]
+		[iOS (8, 0)]
 		public bool ShouldExcludeGPS { get; set; }
 
 		[iOS (7,0), Mac (10,8)]

--- a/src/Intents/INIntentResolutionResult.cs
+++ b/src/Intents/INIntentResolutionResult.cs
@@ -13,9 +13,9 @@ using XamCore.Foundation;
 using XamCore.ObjCRuntime;
 
 namespace XamCore.Intents {
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Register ("INIntentResolutionResult", SkipRegistration = true)]
 	public sealed partial class INIntentResolutionResult<ObjectType> : INIntentResolutionResult
 		where ObjectType : class, INativeObject 

--- a/src/LocalAuthentication/LAEnums.cs
+++ b/src/LocalAuthentication/LAEnums.cs
@@ -5,7 +5,7 @@ using XamCore.Foundation;
 namespace XamCore.LocalAuthentication {
 
 	[iOS (8,0)]
-	[Availability (Platform.Mac_10_10)]
+	[Mac (10, 10)]
 	[Native]
 	public enum LAPolicy : nint {
 		[Mac (10,12,2)]
@@ -14,7 +14,7 @@ namespace XamCore.LocalAuthentication {
 	}
 
 	[iOS (8,0)]
-	[Availability (Platform.Mac_10_10)]
+	[Mac (10, 10)]
 	[Native]
 	[ErrorDomain ("LAErrorDomain")]
 	public enum LAStatus : nint {

--- a/src/MediaPlayer/MPPlayableContentDelegate.cs
+++ b/src/MediaPlayer/MPPlayableContentDelegate.cs
@@ -27,7 +27,7 @@ namespace XamCore.MediaPlayer {
 #if !XAMCORE_4_0
 	public partial class MPPlayableContentDataSource : NSObject {
 		[Unavailable (PlatformName.MacOSX, PlatformArchitecture.All)]
-		[Introduced (PlatformName.iOS, 10, 0)]
+		[iOS (10, 0)]
 		[Obsolete ("Use 'MPPlayableContentDataSource_Extensions.GetContentItemAsync' instead.")]
 		public unsafe virtual Task<MPContentItem> GetContentItemAsync (string identifier)
 		{

--- a/src/MediaToolbox/MTAudioProcessingTap.cs
+++ b/src/MediaToolbox/MTAudioProcessingTap.cs
@@ -53,7 +53,7 @@ using XamCore.CoreMedia;
 
 namespace XamCore.MediaToolbox
 {
-	[Since (6,0)][Mavericks]
+	[Since (6,0)][Mac (10, 9)]
 	public class MTAudioProcessingTap : INativeObject
 #if !COREBUILD
 		, IDisposable

--- a/src/MediaToolbox/MTAudioProcessingTap.cs
+++ b/src/MediaToolbox/MTAudioProcessingTap.cs
@@ -53,7 +53,7 @@ using XamCore.CoreMedia;
 
 namespace XamCore.MediaToolbox
 {
-	[Since (6,0)][Mac (10, 9)]
+	[iOS (6,0)][Mac (10, 9)]
 	public class MTAudioProcessingTap : INativeObject
 #if !COREBUILD
 		, IDisposable

--- a/src/SafariServices/SSEnums.cs
+++ b/src/SafariServices/SSEnums.cs
@@ -60,12 +60,12 @@ namespace XamCore.SafariServices {
 	}
 
 	[NoiOS]
-	[Mac (10,12,4, only64: true)]
+	[Mac (10,12,4, onlyOn64: true)]
 	[Native]
 	public enum SFSafariServicesVersion : nint {
 		V10_0,
 		V10_1,
-		[Mac (10,13, only64: true)]
+		[Mac (10,13, onlyOn64: true)]
 		V11_0,
 	}
 }

--- a/src/SceneKit/Defs.cs
+++ b/src/SceneKit/Defs.cs
@@ -18,8 +18,8 @@ using Vector4 = global::OpenTK.Vector4;
 namespace XamCore.SceneKit {
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_8)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 8)]
+	[iOS (8, 0)]
 	[Native] // untyped enum (SceneKitTypes.h) but described as the value of `code` for `NSError` which is an NSInteger
 	[ErrorDomain ("SCNErrorDomain")]
 	public enum SCNErrorCode : nint {
@@ -27,8 +27,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_8)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 8)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNGeometryPrimitiveType : nint {
 		Triangles,
@@ -40,8 +40,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_8)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 8)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNTransparencyMode : nint {
 		AOne,
@@ -55,16 +55,16 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_8)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 8)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNCullMode : nint {
 		Back, Front
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_8)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 8)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNFilterMode : nint {
 		None,
@@ -73,8 +73,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_8)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 8)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNWrapMode : nint {
 		Clamp = 1,
@@ -85,8 +85,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_8)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 8)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNSceneSourceStatus : nint {
 		Error = -1,
@@ -97,8 +97,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_9)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 9)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNChamferMode : nint {
 		Both,
@@ -107,8 +107,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_9)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 9)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNMorpherCalculationMode : nint {
 		Normalized,
@@ -116,8 +116,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNActionTimingMode : nint {
 		Linear,
@@ -127,8 +127,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNShadowMode : nint {
 		Forward,
@@ -137,8 +137,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNPhysicsBodyType : nint {
 		Static,
@@ -147,8 +147,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNPhysicsFieldScope : nint {
 		InsideExtent,
@@ -156,8 +156,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNParticleSortingMode : nint {
 		None,
@@ -168,8 +168,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNParticleBlendMode : nint {
 		Additive,
@@ -181,8 +181,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNParticleOrientationMode : nint {
 		BillboardScreenAligned,
@@ -192,8 +192,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNParticleBirthLocation : nint {
 		Surface,
@@ -202,8 +202,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNParticleBirthDirection : nint {
 		Constant,
@@ -212,8 +212,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNParticleImageSequenceAnimationMode : nint {
 		Repeat,
@@ -222,8 +222,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNParticleInputMode : nint {
 		OverLife,
@@ -232,8 +232,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNParticleModifierStage : nint {
 		PreDynamics,
@@ -243,8 +243,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum SCNParticleEvent : nint {
 		Birth,

--- a/src/SceneKit/Defs.cs
+++ b/src/SceneKit/Defs.cs
@@ -18,7 +18,8 @@ using Vector4 = global::OpenTK.Vector4;
 namespace XamCore.SceneKit {
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_8 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_8)]
+	[Availability (Platform.iOS_8_0)]
 	[Native] // untyped enum (SceneKitTypes.h) but described as the value of `code` for `NSError` which is an NSInteger
 	[ErrorDomain ("SCNErrorDomain")]
 	public enum SCNErrorCode : nint {
@@ -26,7 +27,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_8 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_8)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNGeometryPrimitiveType : nint {
 		Triangles,
@@ -38,7 +40,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_8 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_8)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNTransparencyMode : nint {
 		AOne,
@@ -52,14 +55,16 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_8 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_8)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNCullMode : nint {
 		Back, Front
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_8 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_8)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNFilterMode : nint {
 		None,
@@ -68,7 +73,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_8 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_8)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNWrapMode : nint {
 		Clamp = 1,
@@ -79,7 +85,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_8 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_8)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNSceneSourceStatus : nint {
 		Error = -1,
@@ -90,7 +97,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_9 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_9)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNChamferMode : nint {
 		Both,
@@ -99,7 +107,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_9 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_9)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNMorpherCalculationMode : nint {
 		Normalized,
@@ -107,7 +116,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNActionTimingMode : nint {
 		Linear,
@@ -117,7 +127,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNShadowMode : nint {
 		Forward,
@@ -126,7 +137,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNPhysicsBodyType : nint {
 		Static,
@@ -135,7 +147,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNPhysicsFieldScope : nint {
 		InsideExtent,
@@ -143,7 +156,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleSortingMode : nint {
 		None,
@@ -154,7 +168,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleBlendMode : nint {
 		Additive,
@@ -166,7 +181,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleOrientationMode : nint {
 		BillboardScreenAligned,
@@ -176,7 +192,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleBirthLocation : nint {
 		Surface,
@@ -185,7 +202,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleBirthDirection : nint {
 		Constant,
@@ -194,7 +212,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleImageSequenceAnimationMode : nint {
 		Repeat,
@@ -203,7 +222,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleInputMode : nint {
 		OverLife,
@@ -212,7 +232,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleModifierStage : nint {
 		PreDynamics,
@@ -222,7 +243,8 @@ namespace XamCore.SceneKit {
 	}
 
 	[Watch (3,0)]
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum SCNParticleEvent : nint {
 		Birth,

--- a/src/SceneKit/SCNCompat.cs
+++ b/src/SceneKit/SCNCompat.cs
@@ -18,14 +18,14 @@ namespace XamCore.SceneKit {
 	}
 #elif TVOS && !XAMCORE_4_0
 	partial class SCNMaterialProperty {
-	[Introduced (PlatformName.iOS, 8, 0)]
+	[iOS (8, 0)]
 		[Deprecated (PlatformName.iOS, 10, 0)]
 		[Deprecated (PlatformName.TvOS, 10, 0, message: "This API has been totally removed on tvOS.")]
 		public virtual NSObject BorderColor { get; set; }
 	}
 
 	partial class SCNRenderer {
-		[Introduced (PlatformName.iOS, 8, 0)]
+		[iOS (8, 0)]
 		[Deprecated (PlatformName.iOS, 9, 0)]
 		[Deprecated (PlatformName.TvOS, 10, 0, message: "This API has been totally removed on tvOS.")]
 		public virtual void Render ()
@@ -55,15 +55,15 @@ namespace XamCore.SceneKit {
 #if !XAMCORE_4_0
 #if XAMCORE_2_0 || !MONOMAC
 	public abstract partial class SCNSceneRenderer : NSObject {
-		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[Mac (10, 10)]
 		[Obsolete ("Use 'SCNSceneRenderer_Extensions.PrepareAsync' instead.")]
 		public unsafe virtual Task<bool> PrepareAsync (NSObject[] objects)
 		{
 			return SCNSceneRenderer_Extensions.PrepareAsync (this, objects);
 		}
 
-		[Introduced (PlatformName.iOS, 9, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 11, PlatformArchitecture.Arch64)]
+		[iOS (9, 0)]
+		[Mac (10, 11, PlatformArchitecture.Arch64)]
 		[Obsolete ("Use 'SCNSceneRenderer_Extensions.PresentSceneAsync' instead.")]
 		public unsafe virtual Task PresentSceneAsync (SCNScene scene, global::XamCore.SpriteKit.SKTransition transition, SCNNode pointOfView)
 		{

--- a/src/SceneKit/SCNJavaScript.cs
+++ b/src/SceneKit/SCNJavaScript.cs
@@ -17,7 +17,8 @@ using XamCore.JavaScriptCore;
 
 namespace XamCore.SceneKit
 {
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	public static class SCNJavaScript
 	{
 		[DllImport (Constants.SceneKitLibrary)]

--- a/src/SceneKit/SCNJavaScript.cs
+++ b/src/SceneKit/SCNJavaScript.cs
@@ -17,8 +17,8 @@ using XamCore.JavaScriptCore;
 
 namespace XamCore.SceneKit
 {
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	public static class SCNJavaScript
 	{
 		[DllImport (Constants.SceneKitLibrary)]

--- a/src/SceneKit/SCNPhysicsShape.cs
+++ b/src/SceneKit/SCNPhysicsShape.cs
@@ -76,7 +76,8 @@ namespace XamCore.SceneKit
 		}
 	}
 
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	public enum SCNPhysicsShapeType
 	{
 		ConvexHull,
@@ -84,7 +85,8 @@ namespace XamCore.SceneKit
 		ConcavePolyhedron
 	}
 
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	public class SCNPhysicsShapeOptions
 	{
 		public SCNPhysicsShapeType? ShapeType { get; set; }

--- a/src/SceneKit/SCNPhysicsShape.cs
+++ b/src/SceneKit/SCNPhysicsShape.cs
@@ -76,8 +76,8 @@ namespace XamCore.SceneKit
 		}
 	}
 
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	public enum SCNPhysicsShapeType
 	{
 		ConvexHull,
@@ -85,8 +85,8 @@ namespace XamCore.SceneKit
 		ConcavePolyhedron
 	}
 
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	public class SCNPhysicsShapeOptions
 	{
 		public SCNPhysicsShapeType? ShapeType { get; set; }

--- a/src/SceneKit/SCNSkinner.cs
+++ b/src/SceneKit/SCNSkinner.cs
@@ -50,14 +50,14 @@ namespace XamCore.SceneKit {
 			return nsa;
 		}
 
-		[Availability (Platform.Mac_10_10)]
-		[Availability (Platform.iOS_8_0)]
+		[Mac (10, 10)]
+		[iOS (8, 0)]
 		public SCNMatrix4 [] BoneInverseBindTransforms {
 			get { return FromNSArray (_BoneInverseBindTransforms); }
 		}
 
-		[Availability (Platform.Mac_10_10)]
-		[Availability (Platform.iOS_8_0)]
+		[Mac (10, 10)]
+		[iOS (8, 0)]
 		public static SCNSkinner Create (SCNGeometry baseGeometry,
 			SCNNode [] bones, SCNMatrix4 [] boneInverseBindTransforms,
 			SCNGeometrySource boneWeights, SCNGeometrySource boneIndices)

--- a/src/SceneKit/SCNSkinner.cs
+++ b/src/SceneKit/SCNSkinner.cs
@@ -50,12 +50,14 @@ namespace XamCore.SceneKit {
 			return nsa;
 		}
 
-		[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+		[Availability (Platform.Mac_10_10)]
+		[Availability (Platform.iOS_8_0)]
 		public SCNMatrix4 [] BoneInverseBindTransforms {
 			get { return FromNSArray (_BoneInverseBindTransforms); }
 		}
 
-		[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+		[Availability (Platform.Mac_10_10)]
+		[Availability (Platform.iOS_8_0)]
 		public static SCNSkinner Create (SCNGeometry baseGeometry,
 			SCNNode [] bones, SCNMatrix4 [] boneInverseBindTransforms,
 			SCNGeometrySource boneWeights, SCNGeometrySource boneIndices)

--- a/src/Security/Enums.cs
+++ b/src/Security/Enums.cs
@@ -429,8 +429,8 @@ namespace XamCore.Security {
 		Invalid,
 		Proceed,
 
-		[Availability (Deprecated = Platform.iOS_7_0)]
-		[Availability (Deprecated = Platform.Mac_10_9)]
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		Confirm,
 		Deny,
 		Unspecified,

--- a/src/Security/Enums.cs
+++ b/src/Security/Enums.cs
@@ -429,7 +429,8 @@ namespace XamCore.Security {
 		Invalid,
 		Proceed,
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9)]
+		[Availability (Deprecated = Platform.iOS_7_0)]
+		[Availability (Deprecated = Platform.Mac_10_9)]
 		Confirm,
 		Deny,
 		Unspecified,

--- a/src/Security/SslContext.cs
+++ b/src/Security/SslContext.cs
@@ -504,10 +504,12 @@ namespace XamCore.Security {
 		}
 
 		[DllImport (Constants.SecurityLibrary)]
-		[Availability (Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.Mac_10_11)]
 		extern unsafe static /* OSStatus */ SslStatus SSLSetEncryptionCertificate (/* SSLContextRef */ IntPtr context, /* CFArrayRef */ IntPtr certRefs);
 
-		[Availability (Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11, Message = "Export ciphers are not available anymore.")]
+		[Availability (Deprecated = Platform.iOS_9_0, Message = "Export ciphers are not available anymore.")]
+		[Availability (Deprecated = Platform.Mac_10_11, Message = "Export ciphers are not available anymore.")]
 		public SslStatus SetEncryptionCertificate (SecIdentity identify, IEnumerable<SecCertificate> certificates)
 		{
 			using (var array = Bundle (identify, certificates)) {
@@ -542,7 +544,8 @@ namespace XamCore.Security {
 		// TODO: Headers say /* Deprecated, does nothing */ but we are not completly sure about it since there is no deprecation macro
 		// Plus they added new members to SslSessionStrengthPolicy enum opened radar://23379052 https://trello.com/c/NbdTLVD3
 		// Xcode 8 beta 1: the P/Invoke was removed completely.
-		[Availability (Deprecated = Platform.iOS_9_2 | Platform.Mac_10_11, Unavailable = Platform.iOS_10_0 | Platform.Mac_10_12, Message = "'SetSessionStrengthPolicy' is not available anymore.")]
+		[Availability (Deprecated = Platform.iOS_9_2, Unavailable = Platform.iOS_10_0, Message = "'SetSessionStrengthPolicy' is not available anymore.")]
+		[Availability (Deprecated = Platform.Mac_10_11, Unavailable = Platform.Mac_10_12, Message = "'SetSessionStrengthPolicy' is not available anymore.")]
 		[Obsolete ("'SetSessionStrengthPolicy' is not available anymore.")]
 		public SslStatus SetSessionStrengthPolicy (SslSessionStrengthPolicy policyStrength)
 		{

--- a/src/Security/SslContext.cs
+++ b/src/Security/SslContext.cs
@@ -504,12 +504,12 @@ namespace XamCore.Security {
 		}
 
 		[DllImport (Constants.SecurityLibrary)]
-		[Availability (Deprecated = Platform.iOS_9_0)]
-		[Availability (Deprecated = Platform.Mac_10_11)]
+		[Deprecated (PlatformName.iOS, 9, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		extern unsafe static /* OSStatus */ SslStatus SSLSetEncryptionCertificate (/* SSLContextRef */ IntPtr context, /* CFArrayRef */ IntPtr certRefs);
 
-		[Availability (Deprecated = Platform.iOS_9_0, Message = "Export ciphers are not available anymore.")]
-		[Availability (Deprecated = Platform.Mac_10_11, Message = "Export ciphers are not available anymore.")]
+		[Deprecated (PlatformName.iOS, 9, 0, message : "Export ciphers are not available anymore.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Export ciphers are not available anymore.")]
 		public SslStatus SetEncryptionCertificate (SecIdentity identify, IEnumerable<SecCertificate> certificates)
 		{
 			using (var array = Bundle (identify, certificates)) {
@@ -544,8 +544,10 @@ namespace XamCore.Security {
 		// TODO: Headers say /* Deprecated, does nothing */ but we are not completly sure about it since there is no deprecation macro
 		// Plus they added new members to SslSessionStrengthPolicy enum opened radar://23379052 https://trello.com/c/NbdTLVD3
 		// Xcode 8 beta 1: the P/Invoke was removed completely.
-		[Availability (Deprecated = Platform.iOS_9_2, Unavailable = Platform.iOS_10_0, Message = "'SetSessionStrengthPolicy' is not available anymore.")]
-		[Availability (Deprecated = Platform.Mac_10_11, Unavailable = Platform.Mac_10_12, Message = "'SetSessionStrengthPolicy' is not available anymore.")]
+		[Deprecated (PlatformName.iOS, 9, 2)]
+		[Unavailable (PlatformName.iOS, message : "'SetSessionStrengthPolicy' is not available anymore.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
+		[Unavailable (PlatformName.MacOSX, message : "'SetSessionStrengthPolicy' is not available anymore.")]
 		[Obsolete ("'SetSessionStrengthPolicy' is not available anymore.")]
 		public SslStatus SetSessionStrengthPolicy (SslSessionStrengthPolicy policyStrength)
 		{

--- a/src/SpriteKit/SKShapeNode.cs
+++ b/src/SpriteKit/SKShapeNode.cs
@@ -15,8 +15,8 @@ using XamCore.ObjCRuntime;
 namespace XamCore.SpriteKit {
 	public partial class SKShapeNode : SKNode {
 
-		[Introduced (PlatformName.iOS, 8, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[iOS (8, 0)]
+		[Mac (10, 10)]
 		public static SKShapeNode FromPoints (CGPoint [] points)
 		{
 			if (points == null)
@@ -25,8 +25,8 @@ namespace XamCore.SpriteKit {
 			return FromPoints (ref points[0], (nuint) points.Length);
 		}
 
-		[Introduced (PlatformName.iOS, 8, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[iOS (8, 0)]
+		[Mac (10, 10)]
 		public static SKShapeNode FromPoints (CGPoint [] points, int offset, int length)
 		{
 			if (points == null)
@@ -37,8 +37,8 @@ namespace XamCore.SpriteKit {
 			return FromPoints (ref points [offset], (nuint) length);
 		}
 
-		[Introduced (PlatformName.iOS, 8, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[iOS (8, 0)]
+		[Mac (10, 10)]
 		public static SKShapeNode FromSplinePoints (CGPoint [] points)
 		{
 			if (points == null)
@@ -47,8 +47,8 @@ namespace XamCore.SpriteKit {
 			return FromSplinePoints (ref points[0], (nuint) points.Length);
 		}
 
-		[Introduced (PlatformName.iOS, 8, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[iOS (8, 0)]
+		[Mac (10, 10)]
 		public static SKShapeNode FromSplinePoints (CGPoint [] points, int offset, int length)
 		{
 			if (points == null)

--- a/src/UIKit/UIView.cs
+++ b/src/UIKit/UIView.cs
@@ -50,9 +50,9 @@ namespace XamCore.UIKit {
 			
 #if !XAMCORE_2_0
 		[CompilerGenerated]
-		[Since (4,2)]
+		[iOS (4,2)]
 		public virtual bool EnableInputClicksWhenVisible {
-			[Since (4,2)]
+			[iOS (4,2)]
 			[Export ("enableInputClicksWhenVisible")]
 			get {
 				global::MonoTouch.UIKit.UIApplication.EnsureUIThread ();

--- a/src/WKWebKit/Defs.cs
+++ b/src/WKWebKit/Defs.cs
@@ -13,7 +13,8 @@ using XamCore.ObjCRuntime;
 
 namespace XamCore.WebKit
 {
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum WKNavigationType : nint {
 		LinkActivated,
@@ -24,28 +25,32 @@ namespace XamCore.WebKit
 		Other = -1
 	}
 
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum WKNavigationActionPolicy : nint {
 		Cancel,
 		Allow
 	}
 
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum WKNavigationResponsePolicy : nint {
 		Cancel,
 		Allow
 	}
 
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	public enum WKUserScriptInjectionTime : nint {
 		AtDocumentStart,
 		AtDocumentEnd
 	}
 
-	[Availability (Platform.Mac_10_10 | Platform.iOS_8_0)]
+	[Availability (Platform.Mac_10_10)]
+	[Availability (Platform.iOS_8_0)]
 	[Native]
 	[ErrorDomain ("WKErrorDomain")]
 	public enum WKErrorCode : nint {
@@ -94,7 +99,7 @@ namespace XamCore.WebKit
 #endif
 	}
 
-	[iOS (10,0)][Mac (10,12, only64: true)]
+	[iOS (10,0)][Mac (10,12, onlyOn64: true)]
 	[Native]
 	[Flags]
 	public enum WKAudiovisualMediaTypes : nuint	{

--- a/src/WKWebKit/Defs.cs
+++ b/src/WKWebKit/Defs.cs
@@ -13,8 +13,8 @@ using XamCore.ObjCRuntime;
 
 namespace XamCore.WebKit
 {
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum WKNavigationType : nint {
 		LinkActivated,
@@ -25,32 +25,32 @@ namespace XamCore.WebKit
 		Other = -1
 	}
 
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum WKNavigationActionPolicy : nint {
 		Cancel,
 		Allow
 	}
 
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum WKNavigationResponsePolicy : nint {
 		Cancel,
 		Allow
 	}
 
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	public enum WKUserScriptInjectionTime : nint {
 		AtDocumentStart,
 		AtDocumentEnd
 	}
 
-	[Availability (Platform.Mac_10_10)]
-	[Availability (Platform.iOS_8_0)]
+	[Mac (10, 10)]
+	[iOS (8, 0)]
 	[Native]
 	[ErrorDomain ("WKErrorDomain")]
 	public enum WKErrorCode : nint {
@@ -72,7 +72,7 @@ namespace XamCore.WebKit
 	}
 
 #if !MONOMAC || !XAMCORE_4_0
-	[Availability (Platform.iOS_8_0)]
+	[iOS (8, 0)]
 	[Native]
 	public enum WKSelectionGranularity : nint {
 		Dynamic, Character

--- a/src/accounts.cs
+++ b/src/accounts.cs
@@ -55,11 +55,11 @@ namespace XamCore.Accounts {
 		[Export ("initWithOAuthToken:tokenSecret:")]
 		IntPtr Constructor (string oauthToken, string tokenSecret);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("initWithOAuth2Token:refreshToken:expiryDate:")]
 		IntPtr Constructor (string oauth2Token, string refreshToken, NSDate expiryDate);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("oauthToken", ArgumentSemantic.Copy)]
 		string OAuthToken { get; set;  }
@@ -98,18 +98,18 @@ namespace XamCore.Accounts {
 		[Notification]
 		NSString ChangeNotification { get; }
 		
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("renewCredentialsForAccount:completion:")]
 		[Async]
 		void RenewCredentials (ACAccount account, Action<ACAccountCredentialRenewResult,NSError> completionHandler);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Protected]
 		[Export ("requestAccessToAccountsWithType:options:completion:")]
 		[Async]
 		void RequestAccess (ACAccountType accountType, [NullAllowed] NSDictionary options, ACRequestCompletionHandler completion);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Wrap ("RequestAccess (accountType, options == null ? null : options.Dictionary, completion)")]
 		[Async]
 		void RequestAccess (ACAccountType accountType, [NullAllowed] AccountStoreOptions options, ACRequestCompletionHandler completion);

--- a/src/accounts.cs
+++ b/src/accounts.cs
@@ -8,7 +8,7 @@ using XamCore.Foundation;
 
 namespace XamCore.Accounts {
 	
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Mac (10,8, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	interface ACAccount : NSSecureCoding {
@@ -42,13 +42,13 @@ namespace XamCore.Accounts {
 #endif
 
 #if !MONOMAC
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("userFullName")]
 		string UserFullName { get; }
 #endif
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Mac (10,8, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	interface ACAccountCredential : NSSecureCoding {
@@ -69,7 +69,7 @@ namespace XamCore.Accounts {
 	delegate void ACAccountStoreRemoveCompletionHandler (bool success, NSError error);
 	delegate void ACRequestCompletionHandler (bool granted, NSError error);
 	
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Mac (10,8, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	interface ACAccountStore {
@@ -120,7 +120,7 @@ namespace XamCore.Accounts {
 		void RemoveAccount (ACAccount account, ACAccountStoreRemoveCompletionHandler completionHandler);
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Mac (10,8, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	interface ACAccountType : NSSecureCoding {
@@ -140,19 +140,19 @@ namespace XamCore.Accounts {
 
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use Sina Weibo SDK instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use Sina Weibo SDK instead.")]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("ACAccountTypeIdentifierSinaWeibo")]
 		NSString SinaWeibo { get; }
 
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use Facebook SDK instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use Facebook SDK instead.")]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("ACAccountTypeIdentifierFacebook")]
 		NSString Facebook { get; }
 
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use Tencent Weibo SDK instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use Tencent Weibo SDK instead.")]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,9)]
 		[Field ("ACAccountTypeIdentifierTencentWeibo")]
 		NSString TencentWeibo { get; }
@@ -167,7 +167,7 @@ namespace XamCore.Accounts {
 
 	[Deprecated (PlatformName.iOS, 11, 0, message: "Use Facebook SDK instead.")]
 	[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use Facebook SDK instead.")]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[Mac (10,8, onlyOn64 : true)]
 	[Static]
 	interface ACFacebookKey {
@@ -184,7 +184,7 @@ namespace XamCore.Accounts {
 
 	[Deprecated (PlatformName.iOS, 11, 0, message: "Use Facebook SDK instead.")]
 	[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use Facebook SDK instead.")]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[Mac (10,8, onlyOn64 : true)]
 	[Static]
 	interface ACFacebookAudienceValue
@@ -201,7 +201,7 @@ namespace XamCore.Accounts {
 
 	[Deprecated (PlatformName.iOS, 11, 0, message: "Use Tencent Weibo SDK instead.")]
 	[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use Tencent Weibo SDK instead.")]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Mac (10,9, onlyOn64 : true)]
 	[Static]
 	interface ACTencentWeiboKey {

--- a/src/adsupport.cs
+++ b/src/adsupport.cs
@@ -13,7 +13,7 @@ using System;
 
 namespace XamCore.AdSupport {
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface ASIdentifierManager {

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -7988,7 +7988,7 @@ namespace XamCore.AppKit {
 
 	}
 
-	[Introduced (PlatformName.MacOSX, 10, 0, PlatformArchitecture.Arch32)] 
+	[Mac (10, 0, PlatformArchitecture.Arch32)] 
 	[BaseType (typeof (NSView))]
 	interface NSMenuView {
 		[Static]
@@ -23849,7 +23849,7 @@ namespace XamCore.AppKit {
 		[Field ("NSAccessibilityDocumentAttribute")]
 		NSString DocumentAttribute { get; }
 
-		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[Mac (10, 10)]
 		[Field ("NSAccessibilityActivationPointAttribute")]
 		NSString ActivationPointAttribute { get; }
 
@@ -24659,11 +24659,11 @@ namespace XamCore.AppKit {
 
 	[Static]
 	interface NSAccessibilityNotificationUserInfoKeys {
-		[Introduced (PlatformName.MacOSX, 10, 9)]
+		[Mac (10, 9)]
 		[Field ("NSAccessibilityUIElementsKey")]
 		NSString UIElementsKey { get; }
 
-		[Introduced (PlatformName.MacOSX, 10, 9)]
+		[Mac (10, 9)]
 		[Field ("NSAccessibilityPriorityKey")]
 		NSString PriorityKey { get; }
 

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -21865,12 +21865,10 @@ namespace XamCore.AppKit {
 		void RemoveItems (NSIndexSet indexes, [NullAllowed] NSObject parent, NSTableViewAnimationOptions animationOptions);
 
 		// - (void)insertRowsAtIndexes:(NSIndexSet *)indexes withAnimation:(NSTableViewAnimationOptions)animationOptions UNAVAILABLE_ATTRIBUTE;
-		[Availability (Unavailable = Platform.Mac_Version)]
 		[Export ("insertRowsAtIndexes:withAnimation:")]
 		void InsertRows (NSIndexSet indexes, NSTableViewAnimationOptions animationOptions);
 
 		// - (void)removeRowsAtIndexes:(NSIndexSet *)indexes withAnimation:(NSTableViewAnimationOptions)animationOptions UNAVAILABLE_ATTRIBUTE;
-		[Availability (Unavailable = Platform.Mac_Version)]
 		[Export ("removeRowsAtIndexes:withAnimation:")]
 		void RemoveRows (NSIndexSet indexes, NSTableViewAnimationOptions animationOptions);
 #else
@@ -21880,11 +21878,9 @@ namespace XamCore.AppKit {
 		[Lion, Export ("removeItemsAtIndexes:inParent:withAnimation:")]
 		void RemoveItems (NSIndexSet indexes, [NullAllowed] NSObject parent, NSTableViewAnimation animationOptions);
 
-		[Availability (Unavailable = Platform.Mac_Version)]
 		[Export ("insertRowsAtIndexes:withAnimation:")]
 		void InsertRows (NSIndexSet indexes, NSTableViewAnimation animationOptions);
 
-		[Availability (Unavailable = Platform.Mac_Version)]
 		[Export ("removeRowsAtIndexes:withAnimation:")]
 		void RemoveRows (NSIndexSet indexes, NSTableViewAnimation animationOptions);
 #endif

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -255,17 +255,17 @@ namespace XamCore.AppKit {
 		[Export ("duration")]
 		double Duration { get; set; }
 
-		[Lion, Export ("completionHandler", ArgumentSemantic.Copy)]
+		[Mac (10, 7), Export ("completionHandler", ArgumentSemantic.Copy)]
 		NSAction CompletionHandler { get; set; }
 
 		[Static]
-		[Lion, Export ("runAnimationGroup:completionHandler:")]
+		[Mac (10, 7), Export ("runAnimationGroup:completionHandler:")]
 		void RunAnimation (Action<NSAnimationContext> changes, [NullAllowed] NSAction completionHandler);
 
-		[Lion, Export ("timingFunction", ArgumentSemantic.Strong)]
+		[Mac (10, 7), Export ("timingFunction", ArgumentSemantic.Strong)]
 		CAMediaTimingFunction TimingFunction { get; set; }
 
-		[MountainLion, Export ("allowsImplicitAnimation")]
+		[Mac (10, 8), Export ("allowsImplicitAnimation")]
 		bool AllowsImplicitAnimation { get; set; }
 	}
 
@@ -653,19 +653,19 @@ namespace XamCore.AppKit {
 		[Export ("orderFrontColorPanel:")]
 		void OrderFrontColorPanel (NSObject sender);
 
-		[Lion, Export ("disableRelaunchOnLogin"), ThreadSafe]
+		[Mac (10, 7), Export ("disableRelaunchOnLogin"), ThreadSafe]
 		void DisableRelaunchOnLogin ();
 
-		[Lion, Export ("enableRelaunchOnLogin"), ThreadSafe]
+		[Mac (10, 7), Export ("enableRelaunchOnLogin"), ThreadSafe]
 		void EnableRelaunchOnLogin ();
 
-		[Lion, Export ("enabledRemoteNotificationTypes")]
+		[Mac (10, 7), Export ("enabledRemoteNotificationTypes")]
 		NSRemoteNotificationType EnabledRemoteNotificationTypes ();
 
-		[Lion, Export ("registerForRemoteNotificationTypes:")]
+		[Mac (10, 7), Export ("registerForRemoteNotificationTypes:")]
 		void RegisterForRemoteNotificationTypes (NSRemoteNotificationType types);
 
-		[Lion, Export ("unregisterForRemoteNotifications")]
+		[Mac (10, 7), Export ("unregisterForRemoteNotifications")]
 		void UnregisterForRemoteNotifications ();
 
 		[Notification, Field ("NSApplicationDidBecomeActiveNotification")]
@@ -710,13 +710,13 @@ namespace XamCore.AppKit {
 		[Notification, Field ("NSApplicationDidChangeScreenParametersNotification")]
 		NSString DidChangeScreenParametersNotification { get; }
 
-		[Lion, Field ("NSApplicationLaunchIsDefaultLaunchKey")]
+		[Mac (10, 7), Field ("NSApplicationLaunchIsDefaultLaunchKey")]
 		NSString LaunchIsDefaultLaunchKey  { get; }
 
-		[Lion, Field ("NSApplicationLaunchRemoteNotificationKey")]
+		[Mac (10, 7), Field ("NSApplicationLaunchRemoteNotificationKey")]
 		NSString LaunchRemoteNotificationKey { get; }
 
-		[Lion, Field ("NSApplicationLaunchUserNotificationKey")]
+		[Mac (10, 7), Field ("NSApplicationLaunchUserNotificationKey")]
 		NSString LaunchUserNotificationKey { get; }
 
 		[Notification, Field ("NSApplicationDidFinishRestoringWindowsNotification")]
@@ -899,19 +899,19 @@ namespace XamCore.AppKit {
 		void OrderFrontStandardAboutPanelWithOptions (NSDictionary optionsDictionary);
 #endif
 
-		[Lion, Export ("application:didRegisterForRemoteNotificationsWithDeviceToken:"), EventArgs ("NSData")]
+		[Mac (10, 7), Export ("application:didRegisterForRemoteNotificationsWithDeviceToken:"), EventArgs ("NSData")]
 		void RegisteredForRemoteNotifications (NSApplication application, NSData deviceToken);
 
-		[Lion, Export ("application:didFailToRegisterForRemoteNotificationsWithError:"), EventArgs ("NSError", true)]
+		[Mac (10, 7), Export ("application:didFailToRegisterForRemoteNotificationsWithError:"), EventArgs ("NSError", true)]
 		void FailedToRegisterForRemoteNotifications (NSApplication application, NSError error);
 
-		[Lion, Export ("application:didReceiveRemoteNotification:"), EventArgs ("NSDictionary")]
+		[Mac (10, 7), Export ("application:didReceiveRemoteNotification:"), EventArgs ("NSDictionary")]
 		void ReceivedRemoteNotification (NSApplication application, NSDictionary userInfo);
 
-		[Lion, Export ("application:willEncodeRestorableState:"), EventArgs ("NSCoder")]
+		[Mac (10, 7), Export ("application:willEncodeRestorableState:"), EventArgs ("NSCoder")]
 		void WillEncodeRestorableState (NSApplication app, NSCoder encoder);
 
-		[Lion, Export ("application:didDecodeRestorableState:"), EventArgs ("NSCoder")]
+		[Mac (10, 7), Export ("application:didDecodeRestorableState:"), EventArgs ("NSCoder")]
 		void DecodedRestorableState (NSApplication app, NSCoder state);
 
 #if XAMCORE_2_0
@@ -2560,13 +2560,13 @@ namespace XamCore.AppKit {
 		[Export ("interiorBackgroundStyle")]
 		NSBackgroundStyle InteriorBackgroundStyle { get; }
 	
-		[Lion, Export ("draggingImageComponentsWithFrame:inView:")]
+		[Mac (10, 7), Export ("draggingImageComponentsWithFrame:inView:")]
 		NSDraggingImageComponent [] GenerateDraggingImageComponents (CGRect frame, NSView view);
 
-		[Lion, Export ("drawFocusRingMaskWithFrame:inView:")]
+		[Mac (10, 7), Export ("drawFocusRingMaskWithFrame:inView:")]
 		void DrawFocusRing (CGRect cellFrameMask, NSView inControlView);
 
-		[Lion, Export ("focusRingMaskBoundsForFrame:inView:")]
+		[Mac (10, 7), Export ("focusRingMaskBoundsForFrame:inView:")]
 		CGRect GetFocusRingMaskBounds (CGRect cellFrame, NSView controlView);
 	}
 
@@ -5340,86 +5340,86 @@ namespace XamCore.AppKit {
 		[Export ("hasUndoManager")]
 		bool HasUndoManager { get; set; }
 
-		[Lion, Export ("performActivityWithSynchronousWaiting:usingBlock:")]
+		[Mac (10, 7), Export ("performActivityWithSynchronousWaiting:usingBlock:")]
 		void PerformActivity (bool waitSynchronously, NSAction activityCompletionHandler);
 
-		[Lion, Export ("continueActivityUsingBlock:")]
+		[Mac (10, 7), Export ("continueActivityUsingBlock:")]
 		void ContinueActivity (NSAction resume);
 
-		[Lion, Export ("continueAsynchronousWorkOnMainThreadUsingBlock:")]
+		[Mac (10, 7), Export ("continueAsynchronousWorkOnMainThreadUsingBlock:")]
 		void ContinueAsynchronousWorkOnMainThread (NSAction work);
 
-		[Lion, Export ("performSynchronousFileAccessUsingBlock:")]
+		[Mac (10, 7), Export ("performSynchronousFileAccessUsingBlock:")]
 		void PerformSynchronousFileAccess (NSAction fileAccessCallback);
 
-		[Lion, Export ("performAsynchronousFileAccessUsingBlock:")]
+		[Mac (10, 7), Export ("performAsynchronousFileAccessUsingBlock:")]
 		void PerformAsynchronousFileAccess (NSAction ioCode);
 
-		[Lion, Export ("isEntireFileLoaded")]
+		[Mac (10, 7), Export ("isEntireFileLoaded")]
 		bool IsEntireFileLoaded { get; }
 
-		[Lion, Export ("unblockUserInteraction")]
+		[Mac (10, 7), Export ("unblockUserInteraction")]
 		void UnblockUserInteraction ();
 
-		[Lion, Export ("autosavingIsImplicitlyCancellable")]
+		[Mac (10, 7), Export ("autosavingIsImplicitlyCancellable")]
 		bool AutosavingIsImplicitlyCancellable { get; }
 
-		[Lion, Export ("saveToURL:ofType:forSaveOperation:completionHandler:")]
+		[Mac (10, 7), Export ("saveToURL:ofType:forSaveOperation:completionHandler:")]
 		void SaveTo (NSUrl url, string typeName, NSSaveOperationType saveOperation, NSDocumentCompletionHandler completionHandler);
 
-		[Lion, Export ("canAsynchronouslyWriteToURL:ofType:forSaveOperation:")]
+		[Mac (10, 7), Export ("canAsynchronouslyWriteToURL:ofType:forSaveOperation:")]
 		bool CanWriteAsynchronously (NSUrl toUrl, string typeName, NSSaveOperationType saveOperation);
 
-		[Lion, Export ("checkAutosavingSafetyAndReturnError:")]
+		[Mac (10, 7), Export ("checkAutosavingSafetyAndReturnError:")]
 		bool CheckAutosavingSafety (out NSError outError);
 
-		[Lion, Export ("scheduleAutosaving")]
+		[Mac (10, 7), Export ("scheduleAutosaving")]
 		void ScheduleAutosaving ();
 
-		[Lion, Export ("autosaveWithImplicitCancellability:completionHandler:")]
+		[Mac (10, 7), Export ("autosaveWithImplicitCancellability:completionHandler:")]
 		void Autosave (bool autosavingIsImplicitlyCancellable, NSDocumentCompletionHandler completionHandler);
 
 		[Static]
-		[Lion, Export ("autosavesInPlace")]
+		[Mac (10, 7), Export ("autosavesInPlace")]
 		bool AutosavesInPlace ();
 
 		[Static]
-		[Lion, Export ("preservesVersions")]
+		[Mac (10, 7), Export ("preservesVersions")]
 		bool PreservesVersions ();
 
-		[Lion, Export ("duplicateDocument:")]
+		[Mac (10, 7), Export ("duplicateDocument:")]
 		void DuplicateDocument (NSObject sender);
 
-		[Lion, Export ("duplicateDocumentWithDelegate:didDuplicateSelector:contextInfo:"), Internal]
+		[Mac (10, 7), Export ("duplicateDocumentWithDelegate:didDuplicateSelector:contextInfo:"), Internal]
 		void _DuplicateDocument ([NullAllowed] NSObject cbackobject, [NullAllowed] Selector didDuplicateSelector, IntPtr contextInfo);
 
-		[Lion, Export ("duplicateAndReturnError:")]
+		[Mac (10, 7), Export ("duplicateAndReturnError:")]
 		NSDocument Duplicate (out NSError outError);
 
-		[Lion, Export ("isInViewingMode")]
+		[Mac (10, 7), Export ("isInViewingMode")]
 		bool IsInViewingMode { get; }
 
-		[Lion, Export ("changeCountTokenForSaveOperation:")]
+		[Mac (10, 7), Export ("changeCountTokenForSaveOperation:")]
 		NSObject ChangeCountToken (NSSaveOperationType saveOperation);
 
-		[Lion, Export ("updateChangeCountWithToken:forSaveOperation:")]
+		[Mac (10, 7), Export ("updateChangeCountWithToken:forSaveOperation:")]
 		void UpdateChangeCount (NSObject changeCountToken, NSSaveOperationType saveOperation);
 
-		[Lion, Export ("willNotPresentError:")]
+		[Mac (10, 7), Export ("willNotPresentError:")]
 		void WillNotPresentError (NSError error);
 
 #if !XAMCORE_2_0
-		[Lion, Export ("setDisplayName:")]
+		[Mac (10, 7), Export ("setDisplayName:")]
 		[Obsolete ("Use the 'DisplayName' property instead.")]
 		[Sealed]
 		void SetDisplayName ([NullAllowed] string displayNameOrNull);
 #endif
 
-		[Lion, Export ("restoreDocumentWindowWithIdentifier:state:completionHandler:")]
+		[Mac (10, 7), Export ("restoreDocumentWindowWithIdentifier:state:completionHandler:")]
 		void RestoreDocumentWindow (string identifier, NSCoder state, NSWindowCompletionHandler completionHandler);
 
 		// This one comes from the NSRestorableState category ('@interface NSResponder (NSRestorableState)')
-		[Lion, Export ("encodeRestorableStateWithCoder:")]
+		[Mac (10, 7), Export ("encodeRestorableStateWithCoder:")]
 		void EncodeRestorableState (NSCoder coder);
 
 		// This one comes from the NSRestorableState category ('@interface NSResponder (NSRestorableState)')
@@ -8664,13 +8664,13 @@ namespace XamCore.AppKit {
 		[Export ("outlineViewSelectionDidChange:")]
 		void SelectionDidChange (NSNotification notification);
 
-		[Lion, Export ("outlineView:rowViewForItem:")]
+		[Mac (10, 7), Export ("outlineView:rowViewForItem:")]
 		NSTableRowView RowViewForItem (NSOutlineView outlineView, NSObject item);
 
-		[Lion, Export ("outlineView:didAddRowView:forRow:")]
+		[Mac (10, 7), Export ("outlineView:didAddRowView:forRow:")]
 		void DidAddRowView (NSOutlineView outlineView, NSTableRowView rowView, nint row);
 
-		[Lion, Export ("outlineView:didRemoveRowView:forRow:")]
+		[Mac (10, 7), Export ("outlineView:didRemoveRowView:forRow:")]
 		void DidRemoveRowView (NSOutlineView outlineView, NSTableRowView rowView, nint row);
 	}
 	
@@ -12500,17 +12500,17 @@ namespace XamCore.AppKit {
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		NSMenu Menu { get; set; }
 
-		[Lion, Export ("encodeRestorableStateWithCoder:")]
+		[Mac (10, 7), Export ("encodeRestorableStateWithCoder:")]
 		void EncodeRestorableState (NSCoder coder);
 
-		[Lion, Export ("restoreStateWithCoder:")]
+		[Mac (10, 7), Export ("restoreStateWithCoder:")]
 		void RestoreState (NSCoder coder);
 
-		[Lion, Export ("invalidateRestorableState")]
+		[Mac (10, 7), Export ("invalidateRestorableState")]
 		void InvalidateRestorableState ();
 
 		[Static]
-		[Lion, Export ("restorableStateKeyPaths", ArgumentSemantic.Copy)]
+		[Mac (10, 7), Export ("restorableStateKeyPaths", ArgumentSemantic.Copy)]
 		string [] RestorableStateKeyPaths ();
 
 		[Mac (10, 7)]
@@ -12874,16 +12874,16 @@ namespace XamCore.AppKit {
 		[Export ("userSpaceScaleFactor")]
 		nfloat UserSpaceScaleFactor { get; }
 
-		[Lion, Export ("convertRectToBacking:")]
+		[Mac (10, 7), Export ("convertRectToBacking:")]
 		CGRect ConvertRectToBacking (CGRect aRect);
 
-		[Lion, Export ("convertRectFromBacking:")]
+		[Mac (10, 7), Export ("convertRectFromBacking:")]
 		CGRect ConvertRectfromBacking (CGRect aRect);
 
-		[Lion, Export ("backingAlignedRect:options:")]
+		[Mac (10, 7), Export ("backingAlignedRect:options:")]
 		CGRect GetBackingAlignedRect (CGRect globalScreenCoordRect, NSAlignmentOptions options);
 
-		[Lion, Export ("backingScaleFactor")]
+		[Mac (10, 7), Export ("backingScaleFactor")]
 		nfloat BackingScaleFactor { get; }
 
 		[Mac (10,9)]
@@ -12961,21 +12961,21 @@ namespace XamCore.AppKit {
 		nfloat KnobProportion { get; set; }
 		
 		[Static]
-		[Lion, Export ("isCompatibleWithOverlayScrollers")]
+		[Mac (10, 7), Export ("isCompatibleWithOverlayScrollers")]
 		bool CompatibleWithOverlayScrollers { get; }
 		
-		[Lion, Export ("knobStyle")]
+		[Mac (10, 7), Export ("knobStyle")]
 		NSScrollerKnobStyle KnobStyle { get; set; }
 		
 		[Static]
-		[Lion, Export ("preferredScrollerStyle")]
+		[Mac (10, 7), Export ("preferredScrollerStyle")]
 		NSScrollerStyle PreferredScrollerStyle { get; }
 		
 		[Export ("scrollerStyle")]
 		NSScrollerStyle ScrollerStyle { get; set; }
 		
 		[Static]
-		[Lion, Export ("scrollerWidthForControlSize:scrollerStyle:")]
+		[Mac (10, 7), Export ("scrollerWidthForControlSize:scrollerStyle:")]
 		nfloat GetScrollerWidth (NSControlSize forControlSize, NSScrollerStyle scrollerStyle);
 		
 		[Notification, Field ("NSPreferredScrollerStyleDidChangeNotification")]
@@ -13084,56 +13084,56 @@ namespace XamCore.AppKit {
 		NSRulerView VerticalRulerView { get; set; }
 
 		[Static]
-		[Lion, Export ("contentSizeForFrameSize:horizontalScrollerClass:verticalScrollerClass:borderType:controlSize:scrollerStyle:")]
+		[Mac (10, 7), Export ("contentSizeForFrameSize:horizontalScrollerClass:verticalScrollerClass:borderType:controlSize:scrollerStyle:")]
 		CGSize GetContentSizeForFrame (CGSize forFrameSize, Class horizontalScrollerClass, Class verticalScrollerClass, NSBorderType borderType, NSControlSize controlSize, NSScrollerStyle scrollerStyle);
         
-        	[Lion, Export ("findBarPosition")]
+        	[Mac (10, 7), Export ("findBarPosition")]
         	NSScrollViewFindBarPosition FindBarPosition { get; set; }
 
-        	[Lion, Export ("flashScrollers")]
+        	[Mac (10, 7), Export ("flashScrollers")]
         	void FlashScrollers ();
         
 		[Static]
-		[Lion, Export ("frameSizeForContentSize:horizontalScrollerClass:verticalScrollerClass:borderType:controlSize:scrollerStyle:")]
+		[Mac (10, 7), Export ("frameSizeForContentSize:horizontalScrollerClass:verticalScrollerClass:borderType:controlSize:scrollerStyle:")]
 		CGSize GetFrameSizeForContent (CGSize contentSize, Class horizontalScrollerClass, Class verticalScrollerClass, NSBorderType borderType, NSControlSize controlSize, NSScrollerStyle scrollerStyle);
 		
-		[Lion, Export ("horizontalScrollElasticity")]
+		[Mac (10, 7), Export ("horizontalScrollElasticity")]
 		NSScrollElasticity HorizontalScrollElasticity { get; set; }
         
-        	[Lion, Export ("scrollerKnobStyle")]
+        	[Mac (10, 7), Export ("scrollerKnobStyle")]
         	NSScrollerKnobStyle ScrollerKnobStyle { get; set; }
         
-        	[Lion, Export ("scrollerStyle")]
+        	[Mac (10, 7), Export ("scrollerStyle")]
         	NSScrollerStyle ScrollerStyle { get; set; }
         
-		[Lion, Export ("usesPredominantAxisScrolling")]
+		[Mac (10, 7), Export ("usesPredominantAxisScrolling")]
         	bool UsesPredominantAxisScrolling { get; set; }
 
-		[Lion, Export ("verticalScrollElasticity")]
+		[Mac (10, 7), Export ("verticalScrollElasticity")]
 		NSScrollElasticity VerticalScrollElasticity { get; set; }
 
-		[MountainLion, Export ("allowsMagnification")]
+		[Mac (10, 8), Export ("allowsMagnification")]
 		bool AllowsMagnification { get; set; }
 
-		[MountainLion, Export ("magnification")]
+		[Mac (10, 8), Export ("magnification")]
 		nfloat Magnification { get; set; }
 
-		[MountainLion, Export ("maxMagnification")]
+		[Mac (10, 8), Export ("maxMagnification")]
 		nfloat MaxMagnification { get; set; }
 
-		[MountainLion, Export ("minMagnification")]
+		[Mac (10, 8), Export ("minMagnification")]
 		nfloat MinMagnification { get; set; }
 
-		[MountainLion, Export ("magnifyToFitRect:")]
+		[Mac (10, 8), Export ("magnifyToFitRect:")]
 		void MagnifyToFitRect (CGRect rect);
 
-		[MountainLion, Export ("setMagnification:centeredAtPoint:")]
+		[Mac (10, 8), Export ("setMagnification:centeredAtPoint:")]
 		void SetMagnification (nfloat magnification, CGPoint centeredAtPoint);
 
-		[MountainLion, Notification, Field ("NSScrollViewWillStartLiveMagnifyNotification")]
+		[Mac (10, 8), Notification, Field ("NSScrollViewWillStartLiveMagnifyNotification")]
 		NSString WillStartLiveMagnifyNotification { get; }
 
-		[MountainLion, Notification, Field ("NSScrollViewDidEndLiveMagnifyNotification")]
+		[Mac (10, 8), Notification, Field ("NSScrollViewDidEndLiveMagnifyNotification")]
 		NSString DidEndLiveMagnifyNotification { get; }
 
 		[Mac (10,9), Notification, Field ("NSScrollViewDidLiveScrollNotification")]
@@ -14184,14 +14184,14 @@ namespace XamCore.AppKit {
 		[Export ("removeArrangedSubview:")]
 		void RemoveArrangedSubview (NSView view);
 
-		[MountainLion, Export ("holdingPriorityForSubviewAtIndex:")]
+		[Mac (10, 8), Export ("holdingPriorityForSubviewAtIndex:")]
 		#if XAMCORE_2_0
 				float /*NSLayoutPriority*/ HoldingPriorityForSubview (nint subviewIndex);
 #else
 		float /*NSLayoutPriority*/ HoldingPriorityForSubviewAtIndex (nint subviewIndex);
 		#endif
 
-		[MountainLion, Export ("setHoldingPriority:forSubviewAtIndex:")]
+		[Mac (10, 8), Export ("setHoldingPriority:forSubviewAtIndex:")]
 		void SetHoldingPriority (float /*NSLayoutPriority*/ priority, nint subviewIndex);
 
 		[Notification (typeof (NSSplitViewDividerIndexEventArgs))]
@@ -14856,7 +14856,7 @@ namespace XamCore.AppKit {
 
 	[Protocol]
 	interface NSUserInterfaceItemIdentification {
-		[Lion, Export ("identifier", ArgumentSemantic.Copy)]
+		[Mac (10, 7), Export ("identifier", ArgumentSemantic.Copy)]
 		string Identifier { get; set; }
 	}
 
@@ -15532,87 +15532,87 @@ namespace XamCore.AppKit {
 		[Notification, Field ("NSViewDidUpdateTrackingAreasNotification")]
 		NSString UpdatedTrackingAreasNotification { get; }
 
-		[Lion, Export ("constraints")]
+		[Mac (10, 7), Export ("constraints")]
 		NSLayoutConstraint [] Constraints { get; }
 		
-		[Lion, Export ("addConstraint:")][PostGet ("Constraints")]
+		[Mac (10, 7), Export ("addConstraint:")][PostGet ("Constraints")]
 		void AddConstraint (NSLayoutConstraint constraint);
 
-		[Lion, Export ("addConstraints:")][PostGet ("Constraints")]
+		[Mac (10, 7), Export ("addConstraints:")][PostGet ("Constraints")]
 		void AddConstraints (NSLayoutConstraint [] constraints);
 
-		[Lion, Export ("removeConstraint:")][PostGet ("Constraints")]
+		[Mac (10, 7), Export ("removeConstraint:")][PostGet ("Constraints")]
 		void RemoveConstraint (NSLayoutConstraint constraint);
 
-		[Lion, Export ("removeConstraints:")][PostGet ("Constraints")]
+		[Mac (10, 7), Export ("removeConstraints:")][PostGet ("Constraints")]
 		void RemoveConstraints (NSLayoutConstraint [] constraints);
 
-		[Lion, Export ("layoutSubtreeIfNeeded")]
+		[Mac (10, 7), Export ("layoutSubtreeIfNeeded")]
 		void LayoutSubtreeIfNeeded ();
 
-		[Lion, Export ("layout")]
+		[Mac (10, 7), Export ("layout")]
 		void Layout ();
 
-		[Lion, Export ("needsUpdateConstraints")]
+		[Mac (10, 7), Export ("needsUpdateConstraints")]
 		bool NeedsUpdateConstraints { get; set; }
 
-		[Lion, Export ("needsLayout")]
+		[Mac (10, 7), Export ("needsLayout")]
 		bool NeedsLayout { get; set; }
 
-		[Lion, Export ("updateConstraints")]
+		[Mac (10, 7), Export ("updateConstraints")]
 		void UpdateConstraints ();
 
-		[Lion, Export ("updateConstraintsForSubtreeIfNeeded")]
+		[Mac (10, 7), Export ("updateConstraintsForSubtreeIfNeeded")]
 		void UpdateConstraintsForSubtreeIfNeeded ();
 
 		[Static]
-		[Lion, Export ("requiresConstraintBasedLayout")]
+		[Mac (10, 7), Export ("requiresConstraintBasedLayout")]
 		bool RequiresConstraintBasedLayout ();
 
 		//Detected properties
-		[Lion, Export ("translatesAutoresizingMaskIntoConstraints")]
+		[Mac (10, 7), Export ("translatesAutoresizingMaskIntoConstraints")]
 		bool TranslatesAutoresizingMaskIntoConstraints { get; set; }
 
-		[Lion, Export ("alignmentRectForFrame:")]
+		[Mac (10, 7), Export ("alignmentRectForFrame:")]
 		CGRect GetAlignmentRectForFrame (CGRect frame);
 
-		[Lion, Export ("frameForAlignmentRect:")]
+		[Mac (10, 7), Export ("frameForAlignmentRect:")]
 		CGRect GetFrameForAlignmentRect (CGRect alignmentRect);
 
-		[Lion, Export ("alignmentRectInsets")]
+		[Mac (10, 7), Export ("alignmentRectInsets")]
 		NSEdgeInsets AlignmentRectInsets { get; }
 
-		[Lion, Export ("baselineOffsetFromBottom")]
+		[Mac (10, 7), Export ("baselineOffsetFromBottom")]
 		nfloat BaselineOffsetFromBottom { get; }
 
-		[Lion, Export ("intrinsicContentSize")]
+		[Mac (10, 7), Export ("intrinsicContentSize")]
 		CGSize IntrinsicContentSize { get; }
 
-		[Lion, Export ("invalidateIntrinsicContentSize")]
+		[Mac (10, 7), Export ("invalidateIntrinsicContentSize")]
 		void InvalidateIntrinsicContentSize ();
 
-		[Lion, Export ("contentHuggingPriorityForOrientation:")]
+		[Mac (10, 7), Export ("contentHuggingPriorityForOrientation:")]
 		float /* NSLayoutPriority = float */ GetContentHuggingPriorityForOrientation (NSLayoutConstraintOrientation orientation);
 
-		[Lion, Export ("setContentHuggingPriority:forOrientation:")]
+		[Mac (10, 7), Export ("setContentHuggingPriority:forOrientation:")]
 		void SetContentHuggingPriorityForOrientation (float /* NSLayoutPriority = float */ priority, NSLayoutConstraintOrientation orientation);
 
-		[Lion, Export ("contentCompressionResistancePriorityForOrientation:")]
+		[Mac (10, 7), Export ("contentCompressionResistancePriorityForOrientation:")]
 		float /* NSLayoutPriority = float */ GetContentCompressionResistancePriority (NSLayoutConstraintOrientation orientation);
 
-		[Lion, Export ("setContentCompressionResistancePriority:forOrientation:")]
+		[Mac (10, 7), Export ("setContentCompressionResistancePriority:forOrientation:")]
 		void SetContentCompressionResistancePriority (float /* NSLayoutPriority = float */ priority, NSLayoutConstraintOrientation orientation);
 
-		[Lion, Export ("fittingSize")]
+		[Mac (10, 7), Export ("fittingSize")]
 		CGSize FittingSize { get; }
 
-		[Lion, Export ("constraintsAffectingLayoutForOrientation:")]
+		[Mac (10, 7), Export ("constraintsAffectingLayoutForOrientation:")]
 		NSLayoutConstraint [] GetConstraintsAffectingLayout (NSLayoutConstraintOrientation orientation);
 
-		[Lion, Export ("hasAmbiguousLayout")]
+		[Mac (10, 7), Export ("hasAmbiguousLayout")]
 		bool HasAmbiguousLayout { get; }
 
-		[Lion, Export ("exerciseAmbiguityInLayout")]
+		[Mac (10, 7), Export ("exerciseAmbiguityInLayout")]
 		void ExerciseAmbiguityInLayout ();
 
 		[Availability (Deprecated = Platform.Mac_10_8)]
@@ -15652,7 +15652,7 @@ namespace XamCore.AppKit {
 		[Export ("noteFocusRingMaskChanged")]
 		void NoteFocusRingMaskChanged ();
 
-		[Lion, Export ("isDrawingFindIndicator")]
+		[Mac (10, 7), Export ("isDrawingFindIndicator")]
 		bool IsDrawingFindIndicator { get; }
 		
 		[Export ("dataWithEPSInsideRect:")]
@@ -15718,46 +15718,46 @@ namespace XamCore.AppKit {
 		[Export ("locationOfPrintRect:")]
 		CGPoint LocationOfPrintRect (CGRect aRect);
 
-		[Lion, Export ("wantsBestResolutionOpenGLSurface")]
+		[Mac (10, 7), Export ("wantsBestResolutionOpenGLSurface")]
 		bool WantsBestResolutionOpenGLSurface { get; set; }
 
-		[Lion, Export ("backingAlignedRect:options:")]
+		[Mac (10, 7), Export ("backingAlignedRect:options:")]
 		CGRect BackingAlignedRect (CGRect aRect, NSAlignmentOptions options);
 
-		[Lion, Export ("convertRectFromBacking:")]
+		[Mac (10, 7), Export ("convertRectFromBacking:")]
 		CGRect ConvertRectFromBacking (CGRect aRect);
 
-		[Lion, Export ("convertRectToBacking:")]
+		[Mac (10, 7), Export ("convertRectToBacking:")]
 		CGRect ConvertRectToBacking (CGRect aRect);
 
-		[Lion, Export ("convertRectFromLayer:")]
+		[Mac (10, 7), Export ("convertRectFromLayer:")]
 		CGRect ConvertRectFromLayer (CGRect aRect);
 
-		[Lion, Export ("convertRectToLayer:")]
+		[Mac (10, 7), Export ("convertRectToLayer:")]
 		CGRect ConvertRectToLayer (CGRect aRect);
 
-		[Lion, Export ("convertPointFromBacking:")]
+		[Mac (10, 7), Export ("convertPointFromBacking:")]
 		CGPoint ConvertPointFromBacking (CGPoint aPoint);
 
-		[Lion, Export ("convertPointToBacking:")]
+		[Mac (10, 7), Export ("convertPointToBacking:")]
 		CGPoint ConvertPointToBacking (CGPoint aPoint);
 
-		[Lion, Export ("convertPointFromLayer:")]
+		[Mac (10, 7), Export ("convertPointFromLayer:")]
 		CGPoint ConvertPointFromLayer (CGPoint aPoint);
 
-		[Lion, Export ("convertPointToLayer:")]
+		[Mac (10, 7), Export ("convertPointToLayer:")]
 		CGPoint ConvertPointToLayer (CGPoint aPoint);
 
-		[Lion, Export ("convertSizeFromBacking:")]
+		[Mac (10, 7), Export ("convertSizeFromBacking:")]
 		CGSize ConvertSizeFromBacking (CGSize aSize);
 
-		[Lion, Export ("convertSizeToBacking:")]
+		[Mac (10, 7), Export ("convertSizeToBacking:")]
 		CGSize ConvertSizeToBacking (CGSize aSize);
 
-		[Lion, Export ("convertSizeFromLayer:")]
+		[Mac (10, 7), Export ("convertSizeFromLayer:")]
 		CGSize ConvertSizeFromLayer (CGSize aSize);
 
-		[Lion, Export ("convertSizeToLayer:")]
+		[Mac (10, 7), Export ("convertSizeToLayer:")]
 		CGSize ConvertSizeToLayer (CGSize aSize);
 
 		[Availability (Introduced = Platform.Mac_10_7)]
@@ -16227,11 +16227,11 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSObject))]
 	partial interface NSTableColumn : NSUserInterfaceItemIdentification, NSCoding {
-		[Lion, Export ("initWithIdentifier:")]
+		[Mac (10, 7), Export ("initWithIdentifier:")]
 		[Sealed]
 		IntPtr Constructor (string identifier);
 
-		[Lion, Export ("initWithIdentifier:")]
+		[Mac (10, 7), Export ("initWithIdentifier:")]
 		IntPtr Constructor (NSString identifier);
 
 #if !XAMCORE_2_0
@@ -17718,7 +17718,7 @@ namespace XamCore.AppKit {
 		[Export ("importsGraphics")]
 		bool ImportsGraphics { get; set; }
 
-		[MountainLion, Export ("preferredMaxLayoutWidth")]
+		[Mac (10, 8), Export ("preferredMaxLayoutWidth")]
 		nfloat PreferredMaxLayoutWidth { get; set; }
 
 		[Mac (10,10)]
@@ -20130,53 +20130,53 @@ namespace XamCore.AppKit {
 		IntPtr WindowRef { get; }
 
 		// This one comes from the NSUserInterfaceRestoration category ('@interface NSWindow (NSUserInterfaceRestoration)')
-		[Lion, Export ("disableSnapshotRestoration")]
+		[Mac (10, 7), Export ("disableSnapshotRestoration")]
 		void DisableSnapshotRestoration ();
 
 		// This one comes from the NSUserInterfaceRestoration category ('@interface NSWindow (NSUserInterfaceRestoration)')
-		[Lion, Export ("enableSnapshotRestoration")]
+		[Mac (10, 7), Export ("enableSnapshotRestoration")]
 		void EnableSnapshotRestoration ();
 
 		// This one comes from the NSUserInterfaceRestoration category ('@interface NSWindow (NSUserInterfaceRestoration)')
-		[Lion, Export ("restorable")]
+		[Mac (10, 7), Export ("restorable")]
 		bool Restorable { [Bind ("isRestorable")]get; set; }
 
 		// This one comes from the NSUserInterfaceRestoration category ('@interface NSWindow (NSUserInterfaceRestoration)')
-		[Lion, Export ("restorationClass")]
+		[Mac (10, 7), Export ("restorationClass")]
 		Class RestorationClass { get; set; }
 
 		//Detected properties
-		[Lion, Export ("updateConstraintsIfNeeded")]
+		[Mac (10, 7), Export ("updateConstraintsIfNeeded")]
 		void UpdateConstraintsIfNeeded ();
 
-		[Lion, Export ("layoutIfNeeded")]
+		[Mac (10, 7), Export ("layoutIfNeeded")]
 		void LayoutIfNeeded ();
 
-		[Lion, Export ("setAnchorAttribute:forOrientation:")]
+		[Mac (10, 7), Export ("setAnchorAttribute:forOrientation:")]
 		void SetAnchorAttribute (NSLayoutAttribute layoutAttribute, NSLayoutConstraintOrientation forOrientation);
 
-		[Lion, Export ("visualizeConstraints:")]
+		[Mac (10, 7), Export ("visualizeConstraints:")]
 		void VisualizeConstraints ([NullAllowed] NSLayoutConstraint [] constraints);
 
-		[Lion, Export ("convertRectToScreen:")]
+		[Mac (10, 7), Export ("convertRectToScreen:")]
 		CGRect ConvertRectToScreen (CGRect aRect);
 
-		[Lion, Export ("convertRectFromScreen:")]
+		[Mac (10, 7), Export ("convertRectFromScreen:")]
 		CGRect ConvertRectFromScreen (CGRect aRect);
 
-		[Lion, Export ("convertRectToBacking:")]
+		[Mac (10, 7), Export ("convertRectToBacking:")]
 		CGRect ConvertRectToBacking (CGRect aRect);
 
-		[Lion, Export ("convertRectFromBacking:")]
+		[Mac (10, 7), Export ("convertRectFromBacking:")]
 		CGRect ConvertRectFromBacking (CGRect aRect);
 
-		[Lion, Export ("backingAlignedRect:options:")]
+		[Mac (10, 7), Export ("backingAlignedRect:options:")]
 		CGRect BackingAlignedRect (CGRect aRect, NSAlignmentOptions options);
 
-		[Lion, Export ("backingScaleFactor")]
+		[Mac (10, 7), Export ("backingScaleFactor")]
 		nfloat BackingScaleFactor { get; }
 
-		[Lion, Export ("toggleFullScreen:")]
+		[Mac (10, 7), Export ("toggleFullScreen:")]
 		void ToggleFullScreen ([NullAllowed] NSObject sender);
 
 		//Detected properties
@@ -20247,25 +20247,25 @@ namespace XamCore.AppKit {
 		[Field ("NSWindowWillEnterFullScreenNotification")]
 		NSString WillEnterFullScreenNotification { get; }
 
-		[Lion, Field ("NSWindowDidEnterFullScreenNotification")]
+		[Mac (10, 7), Field ("NSWindowDidEnterFullScreenNotification")]
 		NSString DidEnterFullScreenNotification { get; }
 
-		[Lion, Field ("NSWindowWillExitFullScreenNotification")]
+		[Mac (10, 7), Field ("NSWindowWillExitFullScreenNotification")]
 		NSString WillExitFullScreenNotification { get; }
 
-		[Lion, Field ("NSWindowDidExitFullScreenNotification")]
+		[Mac (10, 7), Field ("NSWindowDidExitFullScreenNotification")]
 		NSString DidExitFullScreenNotification { get; }
 
-		[Lion, Field ("NSWindowWillEnterVersionBrowserNotification")]
+		[Mac (10, 7), Field ("NSWindowWillEnterVersionBrowserNotification")]
 		NSString WillEnterVersionBrowserNotification { get; }
 
-		[Lion, Field ("NSWindowDidEnterVersionBrowserNotification")]
+		[Mac (10, 7), Field ("NSWindowDidEnterVersionBrowserNotification")]
 		NSString DidEnterVersionBrowserNotification { get; }
 
-		[Lion, Field ("NSWindowWillExitVersionBrowserNotification")]
+		[Mac (10, 7), Field ("NSWindowWillExitVersionBrowserNotification")]
 		NSString WillExitVersionBrowserNotification { get; }
 
-		[Lion, Field ("NSWindowDidExitVersionBrowserNotification")]
+		[Mac (10, 7), Field ("NSWindowDidExitVersionBrowserNotification")]
 		NSString DidExitVersionBrowserNotification { get; }
 #endif
 
@@ -20600,61 +20600,61 @@ namespace XamCore.AppKit {
 		[Export ("windowDidEndLiveResize:"), EventArgs ("NSNotification")]
 		void DidEndLiveResize (NSNotification notification);
 
-		[Lion, Export ("windowWillEnterFullScreen:"), EventArgs ("NSNotification")]
+		[Mac (10, 7), Export ("windowWillEnterFullScreen:"), EventArgs ("NSNotification")]
 		void WillEnterFullScreen (NSNotification notification);
 
-		[Lion, Export ("windowDidEnterFullScreen:"), EventArgs ("NSNotification")]
+		[Mac (10, 7), Export ("windowDidEnterFullScreen:"), EventArgs ("NSNotification")]
 		void DidEnterFullScreen (NSNotification notification);
 
-		[Lion, Export ("windowWillExitFullScreen:"), EventArgs ("NSNotification")]
+		[Mac (10, 7), Export ("windowWillExitFullScreen:"), EventArgs ("NSNotification")]
 		void WillExitFullScreen (NSNotification  notification);
 		
-		[Lion, Export ("windowDidExitFullScreen:"), EventArgs ("NSNotification")]
+		[Mac (10, 7), Export ("windowDidExitFullScreen:"), EventArgs ("NSNotification")]
 		void DidExitFullScreen (NSNotification notification);
 
-		[Lion, Export ("windowDidFailToEnterFullScreen:"), EventArgs ("NSWindow")]
+		[Mac (10, 7), Export ("windowDidFailToEnterFullScreen:"), EventArgs ("NSWindow")]
 		void DidFailToEnterFullScreen (NSWindow window);
 
-		[Lion, Export ("windowDidFailToExitFullScreen:"), EventArgs ("NSWindow")]
+		[Mac (10, 7), Export ("windowDidFailToExitFullScreen:"), EventArgs ("NSWindow")]
 		void DidFailToExitFullScreen (NSWindow window);
 		
-		[Lion, Export ("window:willUseFullScreenContentSize:"), DelegateName ("NSWindowSize"), DefaultValueFromArgument ("proposedSize")]
+		[Mac (10, 7), Export ("window:willUseFullScreenContentSize:"), DelegateName ("NSWindowSize"), DefaultValueFromArgument ("proposedSize")]
 		CGSize WillUseFullScreenContentSize (NSWindow  window, CGSize proposedSize);
 		
-		[Lion, Export ("window:willUseFullScreenPresentationOptions:"), DelegateName ("NSWindowApplicationPresentationOptions"), DefaultValueFromArgument ("proposedOptions")]
+		[Mac (10, 7), Export ("window:willUseFullScreenPresentationOptions:"), DelegateName ("NSWindowApplicationPresentationOptions"), DefaultValueFromArgument ("proposedOptions")]
 		NSApplicationPresentationOptions WillUseFullScreenPresentationOptions (NSWindow  window, NSApplicationPresentationOptions proposedOptions);
 		
-		[Lion, Export ("customWindowsToEnterFullScreenForWindow:"), DelegateName ("NSWindowWindows"), DefaultValue (null)]
+		[Mac (10, 7), Export ("customWindowsToEnterFullScreenForWindow:"), DelegateName ("NSWindowWindows"), DefaultValue (null)]
 		NSWindow[] CustomWindowsToEnterFullScreen (NSWindow  window);
 
-		[Lion, Export ("customWindowsToExitFullScreenForWindow:"), DelegateName ("NSWindowWindows"), DefaultValue (null)]
+		[Mac (10, 7), Export ("customWindowsToExitFullScreenForWindow:"), DelegateName ("NSWindowWindows"), DefaultValue (null)]
 		NSWindow[] CustomWindowsToExitFullScreen (NSWindow  window);
 
-		[Lion, Export ("window:startCustomAnimationToEnterFullScreenWithDuration:"), EventArgs("NSWindowDuration")]
+		[Mac (10, 7), Export ("window:startCustomAnimationToEnterFullScreenWithDuration:"), EventArgs("NSWindowDuration")]
 		void StartCustomAnimationToEnterFullScreen (NSWindow  window, double duration);
 
-		[Lion, Export ("window:startCustomAnimationToExitFullScreenWithDuration:"), EventArgs("NSWindowDuration")]
+		[Mac (10, 7), Export ("window:startCustomAnimationToExitFullScreenWithDuration:"), EventArgs("NSWindowDuration")]
 		void StartCustomAnimationToExitFullScreen (NSWindow  window, double duration);
 
-		[Lion, Export ("window:willEncodeRestorableState:"), EventArgs ("NSWindowCoder")]
+		[Mac (10, 7), Export ("window:willEncodeRestorableState:"), EventArgs ("NSWindowCoder")]
 		void WillEncodeRestorableState(NSWindow window, NSCoder coder);
 		
-		[Lion, Export ("window:didDecodeRestorableState:"), EventArgs ("NSWindowCoder")]
+		[Mac (10, 7), Export ("window:didDecodeRestorableState:"), EventArgs ("NSWindowCoder")]
 		void DidDecodeRestorableState(NSWindow window, NSCoder coder);
 		
-		[Lion, Export ("window:willResizeForVersionBrowserWithMaxPreferredSize:maxAllowedSize:"), DelegateName ("NSWindowSizeSize"), DefaultValueFromArgument ("maxPreferredSize")]
+		[Mac (10, 7), Export ("window:willResizeForVersionBrowserWithMaxPreferredSize:maxAllowedSize:"), DelegateName ("NSWindowSizeSize"), DefaultValueFromArgument ("maxPreferredSize")]
 		CGSize WillResizeForVersionBrowser(NSWindow window, CGSize maxPreferredSize, CGSize maxAllowedSize);
 		
-		[Lion, Export ("windowWillEnterVersionBrowser:"), EventArgs ("NSNotification")]
+		[Mac (10, 7), Export ("windowWillEnterVersionBrowser:"), EventArgs ("NSNotification")]
 		void WillEnterVersionBrowser (NSNotification notification);
 		
-		[Lion, Export ("windowDidEnterVersionBrowser:"), EventArgs ("NSNotification")]
+		[Mac (10, 7), Export ("windowDidEnterVersionBrowser:"), EventArgs ("NSNotification")]
 		void DidEnterVersionBrowser (NSNotification notification);
 		
-		[Lion, Export ("windowWillExitVersionBrowser:"), EventArgs ("NSNotification")]
+		[Mac (10, 7), Export ("windowWillExitVersionBrowser:"), EventArgs ("NSNotification")]
 		void WillExitVersionBrowser (NSNotification notification);
 		
-		[Lion, Export ("windowDidExitVersionBrowser:"), EventArgs ("NSNotification")]
+		[Mac (10, 7), Export ("windowDidExitVersionBrowser:"), EventArgs ("NSNotification")]
 		void DidExitVersionBrowser (NSNotification notification);
 
 		[Availability (Introduced = Platform.Mac_10_7)]
@@ -21733,30 +21733,30 @@ namespace XamCore.AppKit {
 	}
 
 	partial interface NSCollectionViewDelegate {
-		[Lion, Export ("collectionView:pasteboardWriterForItemAtIndex:")]
+		[Mac (10, 7), Export ("collectionView:pasteboardWriterForItemAtIndex:")]
 #if XAMCORE_2_0
 		INSPasteboardWriting PasteboardWriterForItem (NSCollectionView collectionView, nuint index);
 #else
 		NSPasteboardWriting PasteboardWriterForItemAtIndex (NSCollectionView collectionView, nuint index);
 #endif
 
-		[Lion, Export ("collectionView:updateDraggingItemsForDrag:")]
+		[Mac (10, 7), Export ("collectionView:updateDraggingItemsForDrag:")]
 		void UpdateDraggingItemsForDrag (NSCollectionView collectionView, [Protocolize (4)] NSDraggingInfo draggingInfo);
 
-		[Lion, Export ("collectionView:draggingSession:willBeginAtPoint:forItemsAtIndexes:")]
+		[Mac (10, 7), Export ("collectionView:draggingSession:willBeginAtPoint:forItemsAtIndexes:")]
 		void DraggingSessionWillBegin (NSCollectionView collectionView, NSDraggingSession draggingSession,
 			CGPoint screenPoint, NSIndexSet indexes);
 
-		[Lion, Export ("collectionView:draggingSession:endedAtPoint:dragOperation:")]
+		[Mac (10, 7), Export ("collectionView:draggingSession:endedAtPoint:dragOperation:")]
 		void DraggingSessionEnded (NSCollectionView collectionView, NSDraggingSession draggingSession,
 			CGPoint screenPoint, NSDragOperation dragOperation);
 	}
 
 	partial interface NSColor {
-		[Lion, Static, Export ("colorWithGenericGamma22White:alpha:")]
+		[Mac (10, 7), Static, Export ("colorWithGenericGamma22White:alpha:")]
 		NSColor FromGamma22White (nfloat white, nfloat alpha);
 
-		[Lion, Static, Export ("colorWithSRGBRed:green:blue:alpha:")]
+		[Mac (10, 7), Static, Export ("colorWithSRGBRed:green:blue:alpha:")]
 		NSColor FromSrgb (nfloat red, nfloat green, nfloat blue, nfloat alpha);
 
 		[Notification, Field ("NSSystemColorsDidChangeNotification")]
@@ -21764,24 +21764,24 @@ namespace XamCore.AppKit {
 	}
 
 	partial interface NSDocumentController {
-		[Lion, Export ("duplicateDocumentWithContentsOfURL:copying:displayName:error:")]
+		[Mac (10, 7), Export ("duplicateDocumentWithContentsOfURL:copying:displayName:error:")]
 		NSDocument DuplicateDocumentWithContentsOfUrl (NSUrl url, bool duplicateByCopying,
 			[NullAllowed] string displayName, out NSError error);
 
 #if !XAMCORE_2_0
-		[Lion, Export ("openDocumentWithContentsOfURL:display:completionHandler:")]
+		[Mac (10, 7), Export ("openDocumentWithContentsOfURL:display:completionHandler:")]
 		[Obsolete ("Use 'OpenDocument' instead.")]
 		[Sealed]
 		void OpenDocumentWithContentsOfUrl (NSUrl url, bool displayDocument,
 			OpenDocumentCompletionHandler completionHandler);
 #endif
 
-		[Lion, Export ("reopenDocumentForURL:withContentsOfURL:display:completionHandler:")]
+		[Mac (10, 7), Export ("reopenDocumentForURL:withContentsOfURL:display:completionHandler:")]
 		void ReopenDocumentForUrl ([NullAllowed] NSUrl url, NSUrl contentsUrl,
 			bool displayDocument, OpenDocumentCompletionHandler completionHandler);
 	}
 
-	[Lion, Model]
+	[Mac (10, 7), Model]
 	interface NSTextLayoutOrientationProvider {
 		[Export ("layoutOrientation")]
 		NSTextLayoutOrientation LayoutOrientation { get; }
@@ -21793,7 +21793,7 @@ namespace XamCore.AppKit {
 		//   ./AppKit/NSLayoutManager.g.cs(1015,44): error CS1503: Argument `#1'
 		//   cannot convert `ushort[]' expression to type `MonoMac.Foundation.NSObject[]'
 		//
-		// [Lion, Export ("showCGGlyphs:positions:count:font:matrix:attributes:inContext:")]
+		// [Mac (10, 7), Export ("showCGGlyphs:positions:count:font:matrix:attributes:inContext:")]
 		// void ShowCGGlyphs (CGGlyph [] glyphs, CGPoint [] positions, uint glyphCount, NSFont font,
 		// 	NSAffineTransform textMatrix, NSDictionary attributes, NSGraphicsContext graphicsContext);
 	}
@@ -21852,16 +21852,16 @@ namespace XamCore.AppKit {
 		NSString ItemDidCollapseNotification { get; }
 
 		// - (void)moveItemAtIndex:(NSInteger)fromIndex inParent:(id)oldParent toIndex:(NSInteger)toIndex inParent:(id)newParent NS_AVAILABLE_MAC(10_7);
-		[Lion, Export ("moveItemAtIndex:inParent:toIndex:inParent:")]
+		[Mac (10, 7), Export ("moveItemAtIndex:inParent:toIndex:inParent:")]
 		void MoveItem (nint fromIndex, [NullAllowed] NSObject oldParent, nint toIndex, [NullAllowed] NSObject newParent);
 
 #if !XAMCORE_2_0
 		// - (void)insertItemsAtIndexes:(NSIndexSet *)indexes inParent:(id)parent withAnimation:(NSTableViewAnimationOptions)animationOptions NS_AVAILABLE_MAC(10_7);
-		[Lion, Export ("insertItemsAtIndexes:inParent:withAnimation:")]
+		[Mac (10, 7), Export ("insertItemsAtIndexes:inParent:withAnimation:")]
 		void InsertItems (NSIndexSet indexes, [NullAllowed] NSObject parent, NSTableViewAnimationOptions animationOptions);
 
 		// - (void)removeItemsAtIndexes:(NSIndexSet *)indexes inParent:(id)parent withAnimation:(NSTableViewAnimationOptions)animationOptions NS_AVAILABLE_MAC(10_7);
-		[Lion, Export ("removeItemsAtIndexes:inParent:withAnimation:")]
+		[Mac (10, 7), Export ("removeItemsAtIndexes:inParent:withAnimation:")]
 		void RemoveItems (NSIndexSet indexes, [NullAllowed] NSObject parent, NSTableViewAnimationOptions animationOptions);
 
 		// - (void)insertRowsAtIndexes:(NSIndexSet *)indexes withAnimation:(NSTableViewAnimationOptions)animationOptions UNAVAILABLE_ATTRIBUTE;
@@ -21872,10 +21872,10 @@ namespace XamCore.AppKit {
 		[Export ("removeRowsAtIndexes:withAnimation:")]
 		void RemoveRows (NSIndexSet indexes, NSTableViewAnimationOptions animationOptions);
 #else
-		[Lion, Export ("insertItemsAtIndexes:inParent:withAnimation:")]
+		[Mac (10, 7), Export ("insertItemsAtIndexes:inParent:withAnimation:")]
 		void InsertItems (NSIndexSet indexes, [NullAllowed] NSObject parent, NSTableViewAnimation animationOptions);
 
-		[Lion, Export ("removeItemsAtIndexes:inParent:withAnimation:")]
+		[Mac (10, 7), Export ("removeItemsAtIndexes:inParent:withAnimation:")]
 		void RemoveItems (NSIndexSet indexes, [NullAllowed] NSObject parent, NSTableViewAnimation animationOptions);
 
 		[Export ("insertRowsAtIndexes:withAnimation:")]
@@ -21892,7 +21892,7 @@ namespace XamCore.AppKit {
 
 	partial interface NSOutlineViewDataSource {
 		// - (id <NSPasteboardWriting>)outlineView:(NSOutlineView *)outlineView pasteboardWriterForItem:(id)item NS_AVAILABLE_MAC(10_7);
-		[Lion, Export ("outlineView:pasteboardWriterForItem:")]
+		[Mac (10, 7), Export ("outlineView:pasteboardWriterForItem:")]
 #if XAMCORE_2_0
 		INSPasteboardWriting PasteboardWriterForItem (NSOutlineView outlineView, NSObject item);
 #else
@@ -21900,15 +21900,15 @@ namespace XamCore.AppKit {
 #endif
 
 		// - (void)outlineView:(NSOutlineView *)outlineView draggingSession:(NSDraggingSession *)session willBeginAtPoint:(NSPoint)screenPoint forItems:(NSArray *)draggedItems NS_AVAILABLE_MAC(10_7);
-		[Lion, Export ("outlineView:draggingSession:willBeginAtPoint:forItems:")]
+		[Mac (10, 7), Export ("outlineView:draggingSession:willBeginAtPoint:forItems:")]
 		void DraggingSessionWillBegin (NSOutlineView outlineView, NSDraggingSession session, CGPoint screenPoint, NSArray draggedItems);
 
 		// - (void)outlineView:(NSOutlineView *)outlineView draggingSession:(NSDraggingSession *)session endedAtPoint:(NSPoint)screenPoint operation:(NSDragOperation)operation NS_AVAILABLE_MAC(10_7);
-		[Lion, Export ("outlineView:draggingSession:endedAtPoint:operation:")]
+		[Mac (10, 7), Export ("outlineView:draggingSession:endedAtPoint:operation:")]
 		void DraggingSessionEnded (NSOutlineView outlineView, NSDraggingSession session, CGPoint screenPoint, NSDragOperation operation);
 
 		// - (void)outlineView:(NSOutlineView *)outlineView updateDraggingItemsForDrag:(id <NSDraggingInfo>)draggingInfo NS_AVAILABLE_MAC(10_7);
-		[Lion, Export ("outlineView:updateDraggingItemsForDrag:")]
+		[Mac (10, 7), Export ("outlineView:updateDraggingItemsForDrag:")]
 		void UpdateDraggingItemsForDrag (NSOutlineView outlineView, [Protocolize (4)] NSDraggingInfo draggingInfo);
 	}
 
@@ -22009,35 +22009,35 @@ namespace XamCore.AppKit {
 		[Notification]
 		NSString WillEnterFullScreenNotification { get; }
 
-		[Lion, Field ("NSWindowDidEnterFullScreenNotification")]
+		[Mac (10, 7), Field ("NSWindowDidEnterFullScreenNotification")]
 		[Notification]
 		NSString DidEnterFullScreenNotification { get; }
 
-		[Lion, Field ("NSWindowWillExitFullScreenNotification")]
+		[Mac (10, 7), Field ("NSWindowWillExitFullScreenNotification")]
 		[Notification]
 		NSString WillExitFullScreenNotification { get; }
 
-		[Lion, Field ("NSWindowDidExitFullScreenNotification")]
+		[Mac (10, 7), Field ("NSWindowDidExitFullScreenNotification")]
 		[Notification]
 		NSString DidExitFullScreenNotification { get; }
 
-		[Lion, Field ("NSWindowWillEnterVersionBrowserNotification")]
+		[Mac (10, 7), Field ("NSWindowWillEnterVersionBrowserNotification")]
 		[Notification]
 		NSString WillEnterVersionBrowserNotification { get; }
 
-		[Lion, Field ("NSWindowDidEnterVersionBrowserNotification")]
+		[Mac (10, 7), Field ("NSWindowDidEnterVersionBrowserNotification")]
 		[Notification]
 		NSString DidEnterVersionBrowserNotification { get; }
 
-		[Lion, Field ("NSWindowWillExitVersionBrowserNotification")]
+		[Mac (10, 7), Field ("NSWindowWillExitVersionBrowserNotification")]
 		[Notification]
 		NSString WillExitVersionBrowserNotification { get; }
 
-		[Lion, Field ("NSWindowDidExitVersionBrowserNotification")]
+		[Mac (10, 7), Field ("NSWindowDidExitVersionBrowserNotification")]
 		[Notification]
 		NSString DidExitVersionBrowserNotification { get; }
 
-		[Lion, Field ("NSWindowDidChangeBackingPropertiesNotification")]
+		[Mac (10, 7), Field ("NSWindowDidChangeBackingPropertiesNotification")]
 		[Notification (typeof (NSWindowBackingPropertiesEventArgs))]
 		NSString DidChangeBackingPropertiesNotification { get; }
 
@@ -22105,84 +22105,84 @@ namespace XamCore.AppKit {
 	}
 
 	partial interface NSPrintOperation {
-		[Lion, Export ("preferredRenderingQuality")]
+		[Mac (10, 7), Export ("preferredRenderingQuality")]
 		NSPrintRenderingQuality PreferredRenderingQuality { get; }
 	}
 
 	[Category, BaseType (typeof (NSResponder))]
 	partial interface NSControlEditingSupport {
-		[Lion, Export ("validateProposedFirstResponder:forEvent:")]
+		[Mac (10, 7), Export ("validateProposedFirstResponder:forEvent:")]
 		bool ValidateProposedFirstResponder (NSResponder responder, [NullAllowed] NSEvent forEvent);
 	}
 
 	partial interface NSResponder {
-		[Lion, Export ("wantsScrollEventsForSwipeTrackingOnAxis:")]
+		[Mac (10, 7), Export ("wantsScrollEventsForSwipeTrackingOnAxis:")]
 		bool WantsScrollEventsForSwipeTrackingOnAxis (NSEventGestureAxis axis);
 
-		[Lion, Export ("supplementalTargetForAction:sender:")]
+		[Mac (10, 7), Export ("supplementalTargetForAction:sender:")]
 		NSObject SupplementalTargetForAction (Selector action, [NullAllowed] NSObject sender);
 
-		[MountainLion, Export ("smartMagnifyWithEvent:")]
+		[Mac (10, 8), Export ("smartMagnifyWithEvent:")]
 		void SmartMagnify (NSEvent withEvent);
 
-		[MountainLion, Export ("quickLookWithEvent:")]
+		[Mac (10, 8), Export ("quickLookWithEvent:")]
 		void QuickLook (NSEvent withEvent);
 	}
 
 	[Category, BaseType (typeof (NSResponder))]
 	partial interface NSStandardKeyBindingMethods {
-		[MountainLion, Export ("quickLookPreviewItems:")]
+		[Mac (10, 8), Export ("quickLookPreviewItems:")]
 		void QuickLookPreviewItems (NSObject sender);
 	}
 
 	[Category, BaseType (typeof (NSView))]
 	partial interface NSRulerMarkerClientViewDelegation {
-		[Lion, Export ("rulerView:locationForPoint:")]
+		[Mac (10, 7), Export ("rulerView:locationForPoint:")]
 		nfloat RulerViewLocation (NSRulerView ruler, CGPoint locationForPoint);
 
-		[Lion, Export ("rulerView:pointForLocation:")]
+		[Mac (10, 7), Export ("rulerView:pointForLocation:")]
 		CGPoint RulerViewPoint (NSRulerView ruler, nfloat pointForLocation);
 	}
 
 	[Category, BaseType (typeof (NSResponder))]
 	partial interface NSTextFinderSupport {
-		[Lion, Export ("performTextFinderAction:")]
+		[Mac (10, 7), Export ("performTextFinderAction:")]
 		void PerformTextFinderAction ([NullAllowed] NSObject sender);
 	}
 
 	partial interface NSRunningApplication {
-		[Lion, Static, Export ("terminateAutomaticallyTerminableApplications")]
+		[Mac (10, 7), Static, Export ("terminateAutomaticallyTerminableApplications")]
 		void TerminateAutomaticallyTerminableApplications ();
 	}
 
 	partial interface NSPasteboard {
-		[Lion, Field ("NSPasteboardTypeTextFinderOptions")]
+		[Mac (10, 7), Field ("NSPasteboardTypeTextFinderOptions")]
 		NSString PasteboardTypeTextFinderOptions { get; }
 	}
 
 	delegate void NSSpellCheckerShowCorrectionIndicatorOfTypeHandler (string acceptedString);
 
 	partial interface NSSpellChecker {
-		[Lion, Export ("correctionForWordRange:inString:language:inSpellDocumentWithTag:")]
+		[Mac (10, 7), Export ("correctionForWordRange:inString:language:inSpellDocumentWithTag:")]
 		string GetCorrection (NSRange forWordRange, string inString, string language, nint inSpellDocumentWithTag);
 
-		[Lion, Export ("languageForWordRange:inString:orthography:")]
+		[Mac (10, 7), Export ("languageForWordRange:inString:orthography:")]
 		string GetLanguage (NSRange forWordRange, string inString, NSOrthography orthography);
 
-		[Lion, Export ("recordResponse:toCorrection:forWord:language:inSpellDocumentWithTag:")]
+		[Mac (10, 7), Export ("recordResponse:toCorrection:forWord:language:inSpellDocumentWithTag:")]
 		void RecordResponse (NSCorrectionResponse response, string toCorrection, string forWord, string language, nint inSpellDocumentWithTag);
 
-		[Lion, Export ("dismissCorrectionIndicatorForView:")]
+		[Mac (10, 7), Export ("dismissCorrectionIndicatorForView:")]
 		void DismissCorrectionIndicator (NSView forView);
 
-		[Lion, Export ("showCorrectionIndicatorOfType:primaryString:alternativeStrings:forStringInRect:view:completionHandler:")]
+		[Mac (10, 7), Export ("showCorrectionIndicatorOfType:primaryString:alternativeStrings:forStringInRect:view:completionHandler:")]
 		void ShowCorrectionIndicatorOfType (NSCorrectionIndicatorType type, string primaryString, string [] alternativeStrings,
 			CGRect forStringInRect, NSRulerView view, NSSpellCheckerShowCorrectionIndicatorOfTypeHandler completionHandler);
 
-		[Lion, Static, Export ("isAutomaticTextReplacementEnabled")]
+		[Mac (10, 7), Static, Export ("isAutomaticTextReplacementEnabled")]
 		bool IsAutomaticTextReplacementEnabled { get; }
 
-		[Lion, Static, Export ("isAutomaticSpellingCorrectionEnabled")]
+		[Mac (10, 7), Static, Export ("isAutomaticSpellingCorrectionEnabled")]
 		bool IsAutomaticSpellingCorrectionEnabled { get; }
 
 		[Field ("NSTextCheckingOrthographyKey")]
@@ -22209,13 +22209,13 @@ namespace XamCore.AppKit {
 		[Field ("NSTextCheckingDocumentAuthorKey")]
 		NSString TextCheckingDocumentAuthorKey { get; }
 
-		[Lion, Field ("NSTextCheckingRegularExpressionsKey")]
+		[Mac (10, 7), Field ("NSTextCheckingRegularExpressionsKey")]
 		NSString TextCheckingRegularExpressionsKey { get; }
 
-		[Lion, Notification, Field ("NSSpellCheckerDidChangeAutomaticSpellingCorrectionNotification")]
+		[Mac (10, 7), Notification, Field ("NSSpellCheckerDidChangeAutomaticSpellingCorrectionNotification")]
 		NSString DidChangeAutomaticSpellingCorrectionNotification { get; }
 
-		[Lion, Notification, Field ("NSSpellCheckerDidChangeAutomaticTextReplacementNotification")]
+		[Mac (10, 7), Notification, Field ("NSSpellCheckerDidChangeAutomaticTextReplacementNotification")]
 		NSString DidChangeAutomaticTextReplacementNotification { get; }
 
 		[Mac (10, 12)]
@@ -22253,25 +22253,25 @@ namespace XamCore.AppKit {
 	}
 
 	partial interface NSTextView : NSTextLayoutOrientationProvider {
-		[Lion, Export ("setLayoutOrientation:")]
+		[Mac (10, 7), Export ("setLayoutOrientation:")]
 		void SetLayoutOrientation (NSTextLayoutOrientation theOrientation);
 
-		[Lion, Export ("changeLayoutOrientation:")]
+		[Mac (10, 7), Export ("changeLayoutOrientation:")]
 		void ChangeLayoutOrientation (NSObject sender);
 
-		[Lion, Export ("usesInspectorBar")]
+		[Mac (10, 7), Export ("usesInspectorBar")]
 		bool UsesInspectorBar { get; set; }
 
-		[Lion, Export ("usesFindBar")]
+		[Mac (10, 7), Export ("usesFindBar")]
 		bool UsesFindBar { get; set; }
 
-		[Lion, Export ("incrementalSearchingEnabled")]
+		[Mac (10, 7), Export ("incrementalSearchingEnabled")]
 		bool IsIncrementalSearchingEnabled {[Bind ("isIncrementalSearchingEnabled")]get; set; }
 
-		[Lion, Export ("quickLookPreviewableItemsInRanges:")]
+		[Mac (10, 7), Export ("quickLookPreviewableItemsInRanges:")]
 		NSArray QuickLookPreviewableItemsInRanges (NSArray ranges);
 
-		[Lion, Export ("updateQuickLookPreviewPanel")]
+		[Mac (10, 7), Export ("updateQuickLookPreviewPanel")]
 		void UpdateQuickLookPreviewPanel ();
 
 		[Notification (typeof (NSTextViewWillChangeNotifyingTextViewEventArgs))]
@@ -22288,13 +22288,13 @@ namespace XamCore.AppKit {
 
 	partial interface NSView {
 
-		[MountainLion, Export ("wantsUpdateLayer")]
+		[Mac (10, 8), Export ("wantsUpdateLayer")]
 		bool WantsUpdateLayer { get; }
 
-		[MountainLion, Export ("updateLayer")]
+		[Mac (10, 8), Export ("updateLayer")]
 		void UpdateLayer ();
 
-		[MountainLion, Export ("rectForSmartMagnificationAtPoint:inRect:")]
+		[Mac (10, 8), Export ("rectForSmartMagnificationAtPoint:inRect:")]
 		CGRect RectForSmartMagnificationAtPoint (CGPoint atPoint, CGRect inRect);
 	}
 
@@ -22302,7 +22302,7 @@ namespace XamCore.AppKit {
 	[Category, BaseType (typeof (NSApplication))]
 	partial interface NSRemoteNotifications_NSApplication {
 
-		[MountainLion, Field ("NSApplicationLaunchUserNotificationKey", "AppKit")]
+		[Mac (10, 8), Field ("NSApplicationLaunchUserNotificationKey", "AppKit")]
 		NSString NSApplicationLaunchUserNotificationKey { get; }
 	}
 #endif
@@ -22326,34 +22326,34 @@ namespace XamCore.AppKit {
 		[Field ("NSControlTextDidChangeNotification")]
 		NSString TextDidChangeNotification { get; }
 
-		[MountainLion, Export ("allowsExpansionToolTips")]
+		[Mac (10, 8), Export ("allowsExpansionToolTips")]
 		bool AllowsExpansionToolTips { get; set; }
 	}
 
 	partial interface NSMatrix {
 
-		[MountainLion, Export ("autorecalculatesCellSize")]
+		[Mac (10, 8), Export ("autorecalculatesCellSize")]
 		bool AutoRecalculatesCellSize { get; set; }
 	}
 
 	partial interface NSForm {
 
-		[MountainLion, Export ("preferredTextFieldWidth")]
+		[Mac (10, 8), Export ("preferredTextFieldWidth")]
 		nfloat PreferredTextFieldWidth { get; set; }
 	}
 
 	partial interface NSFormCell {
 
-		[MountainLion, Export ("preferredTextFieldWidth")]
+		[Mac (10, 8), Export ("preferredTextFieldWidth")]
 		nfloat PreferredTextFieldWidth { get; set; }
 	}
 
 	partial interface NSColor {
 
-		[MountainLion, Static, Export ("underPageBackgroundColor")]
+		[Mac (10, 8), Static, Export ("underPageBackgroundColor")]
 		NSColor UnderPageBackgroundColor { get; }
 
-		[MountainLion, Static, Export ("colorWithCGColor:")]
+		[Mac (10, 8), Static, Export ("colorWithCGColor:")]
 		NSColor FromCGColor (CGColor cgColor);
 	}
 
@@ -22361,10 +22361,10 @@ namespace XamCore.AppKit {
 
 	partial interface NSCustomImageRep {
 
-		[MountainLion, Export ("initWithSize:flipped:drawingHandler:")]
+		[Mac (10, 8), Export ("initWithSize:flipped:drawingHandler:")]
 		IntPtr Constructor (CGSize size, bool flipped, NSCustomImageRepDrawingHandler drawingHandler);
 
-		[MountainLion, Export ("drawingHandler")]
+		[Mac (10, 8), Export ("drawingHandler")]
 		NSCustomImageRepDrawingHandler DrawingHandler { get; }
 	}
 
@@ -22377,58 +22377,58 @@ namespace XamCore.AppKit {
 
 	partial interface NSDocument {
 
-		[MountainLion, Export ("draft")]
+		[Mac (10, 8), Export ("draft")]
 		bool IsDraft { [Bind ("isDraft")] get; set; }
 
-		[MountainLion, Export ("backupFileURL")]
+		[Mac (10, 8), Export ("backupFileURL")]
 		NSUrl BackupFileUrl { get; }
 
-		[MountainLion, Export ("browseDocumentVersions:")]
+		[Mac (10, 8), Export ("browseDocumentVersions:")]
 		void BrowseDocumentVersions (NSObject sender);
 
-		[MountainLion, Static, Export ("autosavesDrafts")]
+		[Mac (10, 8), Static, Export ("autosavesDrafts")]
 		bool AutoSavesDrafts { get; }
 
-		[MountainLion, Export ("renameDocument:")]
+		[Mac (10, 8), Export ("renameDocument:")]
 		void RenameDocument (NSObject sender);
 
-		[MountainLion, Export ("moveDocumentToUbiquityContainer:")]
+		[Mac (10, 8), Export ("moveDocumentToUbiquityContainer:")]
 		void MoveDocumentToUbiquityContainer (NSObject sender);
 
-		[MountainLion, Export ("moveDocument:")]
+		[Mac (10, 8), Export ("moveDocument:")]
 		void MoveDocument (NSObject sender);
 
-		[MountainLion, Export ("moveDocumentWithCompletionHandler:")]
+		[Mac (10, 8), Export ("moveDocumentWithCompletionHandler:")]
 		void MoveDocumentWithCompletionHandler (NSDocumentMoveCompletionHandler completionHandler);
 
-		[MountainLion, Export ("moveToURL:completionHandler:")]
+		[Mac (10, 8), Export ("moveToURL:completionHandler:")]
 		void MoveToUrl (NSUrl url, NSDocumentMoveToUrlCompletionHandler completionHandler);
 
-		[MountainLion, Export ("lockDocument:")]
+		[Mac (10, 8), Export ("lockDocument:")]
 		void LockDocument (NSObject sender);
 
-		[MountainLion, Export ("unlockDocument:")]
+		[Mac (10, 8), Export ("unlockDocument:")]
 		void UnlockDocument (NSObject sender);
 
-		[MountainLion, Export ("lockDocumentWithCompletionHandler:")]
+		[Mac (10, 8), Export ("lockDocumentWithCompletionHandler:")]
 		void LockDocumentWithCompletionHandler (NSDocumentLockDocumentCompletionHandler completionHandler);
 
-		[MountainLion, Export ("lockWithCompletionHandler:")]
+		[Mac (10, 8), Export ("lockWithCompletionHandler:")]
 		void LockWithCompletionHandler (NSDocumentLockCompletionHandler completionHandler);
 
-		[MountainLion, Export ("unlockDocumentWithCompletionHandler:")]
+		[Mac (10, 8), Export ("unlockDocumentWithCompletionHandler:")]
 		void UnlockDocumentWithCompletionHandler (NSDocumentUnlockDocumentCompletionHandler completionHandler);
 
-		[MountainLion, Export ("unlockWithCompletionHandler:")]
+		[Mac (10, 8), Export ("unlockWithCompletionHandler:")]
 		void UnlockWithCompletionHandler (NSDocumentUnlockCompletionHandler completionHandler);
 
-		[MountainLion, Export ("isLocked")]
+		[Mac (10, 8), Export ("isLocked")]
 		bool IsLocked { get; }
 
-		[MountainLion, Export ("defaultDraftName")]
+		[Mac (10, 8), Export ("defaultDraftName")]
 		string DefaultDraftName { get; }
 
-		[MountainLion, Static, Export ("usesUbiquitousStorage")]
+		[Mac (10, 8), Static, Export ("usesUbiquitousStorage")]
 		bool UsesUbiquitousStorage { get; }
 
 		[Mac (10,13)]
@@ -22441,10 +22441,10 @@ namespace XamCore.AppKit {
 
 	partial interface NSDocumentController {
 
-		[MountainLion, Export ("beginOpenPanelWithCompletionHandler:")]
+		[Mac (10, 8), Export ("beginOpenPanelWithCompletionHandler:")]
 		void BeginOpenPanelWithCompletionHandler (NSDocumentControllerOpenPanelWithCompletionHandler completionHandler);
 
-		[MountainLion, Export ("beginOpenPanel:forTypes:completionHandler:")]
+		[Mac (10, 8), Export ("beginOpenPanel:forTypes:completionHandler:")]
 		void BeginOpenPanel (NSOpenPanel openPanel, NSArray inTypes, NSDocumentControllerOpenPanelResultHandler completionHandler);
 
 		[Mac (10, 13)]
@@ -22458,7 +22458,7 @@ namespace XamCore.AppKit {
 
 	partial interface NSImage {
 
-		[MountainLion, Static, Export ("imageWithSize:flipped:drawingHandler:")]
+		[Mac (10, 8), Static, Export ("imageWithSize:flipped:drawingHandler:")]
 #if XAMCORE_2_0
 		NSImage ImageWithSize (CGSize size, bool flipped, NSCustomImageRepDrawingHandler drawingHandler);
 #else
@@ -22468,7 +22468,7 @@ namespace XamCore.AppKit {
 
 	partial interface NSNib {
 
-		[MountainLion, Export ("initWithNibData:bundle:")]
+		[Mac (10, 8), Export ("initWithNibData:bundle:")]
 		IntPtr Constructor (NSData nibData, NSBundle bundle);
 	}
 
@@ -22487,62 +22487,62 @@ namespace XamCore.AppKit {
 	[Category, BaseType (typeof (NSSegmentedCell))]
 	partial interface NSSegmentBackgroundStyle_NSSegmentedCell {
 
-		[MountainLion, Field ("NSSharingServiceNamePostOnFacebook")]
+		[Mac (10, 8), Field ("NSSharingServiceNamePostOnFacebook")]
 		NSString SharingServiceNamePostOnFacebook { get; }
 
-		[MountainLion, Field ("NSSharingServiceNamePostOnTwitter")]
+		[Mac (10, 8), Field ("NSSharingServiceNamePostOnTwitter")]
 		NSString SharingServiceNamePostOnTwitter { get; }
 
-		[MountainLion, Field ("NSSharingServiceNamePostOnSinaWeibo")]
+		[Mac (10, 8), Field ("NSSharingServiceNamePostOnSinaWeibo")]
 		NSString SharingServiceNamePostOnSinaWeibo { get; }
 
-		[MountainLion, Field ("NSSharingServiceNameComposeEmail")]
+		[Mac (10, 8), Field ("NSSharingServiceNameComposeEmail")]
 		NSString SharingServiceNameComposeEmail { get; }
 
-		[MountainLion, Field ("NSSharingServiceNameComposeMessage")]
+		[Mac (10, 8), Field ("NSSharingServiceNameComposeMessage")]
 		NSString SharingServiceNameComposeMessage { get; }
 
-		[MountainLion, Field ("NSSharingServiceNameSendViaAirDrop")]
+		[Mac (10, 8), Field ("NSSharingServiceNameSendViaAirDrop")]
 		NSString SharingServiceNameSendViaAirDrop { get; }
 
-		[MountainLion, Field ("NSSharingServiceNameAddToSafariReadingList")]
+		[Mac (10, 8), Field ("NSSharingServiceNameAddToSafariReadingList")]
 		NSString SharingServiceNameAddToSafariReadingList { get; }
 
-		[MountainLion, Field ("NSSharingServiceNameAddToIPhoto")]
+		[Mac (10, 8), Field ("NSSharingServiceNameAddToIPhoto")]
 		NSString SharingServiceNameAddToIPhoto { get; }
 
-		[MountainLion, Field ("NSSharingServiceNameAddToAperture")]
+		[Mac (10, 8), Field ("NSSharingServiceNameAddToAperture")]
 		NSString SharingServiceNameAddToAperture { get; }
 
-		[MountainLion, Field ("NSSharingServiceNameUseAsTwitterProfileImage")]
+		[Mac (10, 8), Field ("NSSharingServiceNameUseAsTwitterProfileImage")]
 		NSString SharingServiceNameUseAsTwitterProfileImage { get; }
 
-		[MountainLion, Field ("NSSharingServiceNameUseAsDesktopPicture")]
+		[Mac (10, 8), Field ("NSSharingServiceNameUseAsDesktopPicture")]
 		NSString SharingServiceNameUseAsDesktopPicture { get; }
 
-		[MountainLion, Field ("NSSharingServiceNamePostImageOnFlickr")]
+		[Mac (10, 8), Field ("NSSharingServiceNamePostImageOnFlickr")]
 		NSString SharingServiceNamePostImageOnFlickr { get; }
 
-		[MountainLion, Field ("NSSharingServiceNamePostVideoOnVimeo")]
+		[Mac (10, 8), Field ("NSSharingServiceNamePostVideoOnVimeo")]
 		NSString SharingServiceNamePostVideoOnVimeo { get; }
 
-		[MountainLion, Field ("NSSharingServiceNamePostVideoOnYouku")]
+		[Mac (10, 8), Field ("NSSharingServiceNamePostVideoOnYouku")]
 		NSString SharingServiceNamePostVideoOnYouku { get; }
 
-		[MountainLion, Field ("NSSharingServiceNamePostVideoOnTudou")]
+		[Mac (10, 8), Field ("NSSharingServiceNamePostVideoOnTudou")]
 		NSString SharingServiceNamePostVideoOnTudou { get; }
 	}
 
 	[Category, BaseType (typeof (NSTextView))]
 	partial interface NSTextView_SharingService {
 
-		[MountainLion, Export ("orderFrontSharingServicePicker:")]
+		[Mac (10, 8), Export ("orderFrontSharingServicePicker:")]
 		void OrderFrontSharingServicePicker (NSObject sender);
 	}
 
 	/*partial interface NSTextViewDelegate {
 
-		[MountainLion, Export ("textView:willShowSharingServicePicker:forItems:"), DelegateName (...)]
+		[Mac (10, 8), Export ("textView:willShowSharingServicePicker:forItems:"), DelegateName (...)]
 		NSSharingServicePicker WillShowSharingService (NSTextView textView,
 			NSSharingServicePicker servicePicker, NSArray forItems);
 	}*/
@@ -22552,7 +22552,7 @@ namespace XamCore.AppKit {
 		string AlternativeString { get; }
 	}
 
-	[MountainLion, BaseType (typeof (NSObject))]
+	[Mac (10, 8), BaseType (typeof (NSObject))]
 	partial interface NSTextAlternatives {
 
 		[Export ("initWithPrimaryString:alternativeStrings:")]
@@ -22567,7 +22567,7 @@ namespace XamCore.AppKit {
 		[Export ("noteSelectedAlternativeString:")]
 		void NoteSelectedAlternativeString (string alternativeString);
 
-		[MountainLion, Notification (typeof (NSTextAlternativesSelectedAlternativeStringEventArgs)),
+		[Mac (10, 8), Notification (typeof (NSTextAlternativesSelectedAlternativeStringEventArgs)),
 			Field ("NSTextAlternativesSelectedAlternativeStringNotification")]
 		NSString SelectedAlternativeStringNotification { get; }
 	}

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -732,12 +732,12 @@ namespace XamCore.AppKit {
 		bool RestoreWindowWithIdentifier (string identifier, NSCoder state, NSWindowCompletionHandler onCompletion);
 
 		// This one comes from the NSRestorableStateExtension category ('@interface NSApplication (NSRestorableStateExtension)')
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("extendStateRestoration")]
 		void ExtendStateRestoration ();
 
 		// This one comes from the NSRestorableStateExtension category ('@interface NSApplication (NSRestorableStateExtension)')
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("completeStateRestoration")]
 		void CompleteStateRestoration ();
 
@@ -2679,7 +2679,7 @@ namespace XamCore.AppKit {
 		bool Selected { [Bind ("isSelected")]get; set; }
 
 		[Export ("imageView", ArgumentSemantic.Assign)]
-		[Lion]
+		[Mac (10, 7)]
 		NSImageView ImageView { get; set;  }
 
 		[Export ("textField", ArgumentSemantic.Assign)]
@@ -2755,7 +2755,7 @@ namespace XamCore.AppKit {
 		[Export ("backgroundColors", ArgumentSemantic.Copy), NullAllowed]
 		NSColor [] BackgroundColors { get; set; }
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("frameForItemAtIndex:withNumberOfItems:")]
 		CGRect FrameForItemAtIndex (nint index, nint numberOfItems);
 
@@ -3871,7 +3871,7 @@ namespace XamCore.AppKit {
 		[Export ("patternImage")]
 		NSImage PatternImage { get; }
 
-		[MountainLion]
+		[Mac (10, 8)]
 		[Export ("CGColor")]
 		CGColor CGColor { get; }
 
@@ -4588,7 +4588,7 @@ namespace XamCore.AppKit {
 		[Export ("takeIntegerValueFrom:")]
 		void TakeIntegerValueFrom (NSObject sender);
 
-		[Export ("invalidateIntrinsicContentSizeForCell:"), Lion]
+		[Export ("invalidateIntrinsicContentSizeForCell:"), Mac (10, 7)]
 		void InvalidateIntrinsicContentSizeForCell (NSCell cell);
 
 		//Detected properties
@@ -4800,7 +4800,7 @@ namespace XamCore.AppKit {
 		[Export ("contextualMenuCursor")]
 		NSCursor ContextualMenuCursor { get; }
 
-		[Lion]
+		[Mac (10, 7)]
 		[Static]
 		[Export ("IBeamCursorForVerticalLayout")]
 		NSCursor IBeamCursorForVerticalLayout { get; }
@@ -5293,7 +5293,7 @@ namespace XamCore.AppKit {
 		void ShouldCloseWindowController (NSWindowController windowController, NSObject delegateObject, Selector shouldCloseSelector, IntPtr contextInfo);
 
 		[Export ("displayName")]
-		string DisplayName { get; [Lion][NullAllowed] set; }
+		string DisplayName { get; [Mac (10, 7)][NullAllowed] set; }
 
 		[Export ("windowForSheet")]
 		NSWindow WindowForSheet { get; }
@@ -5525,7 +5525,7 @@ namespace XamCore.AppKit {
 		[Export ("openDocumentWithContentsOfURL:display:error:")]
 		NSObject OpenDocument (NSUrl url, bool displayDocument, out NSError outError);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("openDocumentWithContentsOfURL:display:completionHandler:")]
 		void OpenDocument (NSUrl url, bool display, OpenDocumentCompletionHandler completionHandler);
 
@@ -5597,7 +5597,7 @@ namespace XamCore.AppKit {
 		double AutosavingDelay { get; set; }
 	}
 
-	[Lion]
+	[Mac (10, 7)]
 	[BaseType (typeof (NSObject))]
 	interface NSDraggingImageComponent {
 		[Export ("key", ArgumentSemantic.Copy)]
@@ -5718,25 +5718,25 @@ namespace XamCore.AppKit {
 #if XAMCORE_4_0
 		[Abstract]
 #endif
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("animatesToDestination")]
 		bool AnimatesToDestination { get; set; }
 
 #if XAMCORE_4_0
 		[Abstract]
 #endif
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("numberOfValidItemsForDrop")]
 		nint NumberOfValidItemsForDrop { get; set; }
 
 #if XAMCORE_4_0
 		[Abstract]
 #endif
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("draggingFormation")]
 		NSDraggingFormation DraggingFormation { get; set; } 
 
-		[Lion]
+		[Mac (10, 7)]
 		[Internal]
 		[Export ("enumerateDraggingItemsWithOptions:forView:classes:searchOptions:usingBlock:")]
 		void EnumerateDraggingItems (NSDraggingItemEnumerationOptions enumOpts, NSView view, IntPtr classArray,
@@ -6229,7 +6229,7 @@ namespace XamCore.AppKit {
 		void _GetAdvancements (IntPtr advancements, IntPtr glyphs, nuint glyphCount);
 	}
 
-	[Lion]
+	[Mac (10, 7)]
 	interface NSFontCollectionChangedEventArgs {
 		[Internal, Export ("NSFontCollectionActionKey")]
 		NSString _Action { get; }
@@ -6244,7 +6244,7 @@ namespace XamCore.AppKit {
 		NSNumber _Visibility { get; }
 	}
 
-	[Lion]
+	[Mac (10, 7)]
 	[BaseType (typeof (NSObject))]
 	interface NSFontCollection : NSSecureCoding, NSMutableCopying {
 		[Static]
@@ -6348,7 +6348,7 @@ namespace XamCore.AppKit {
 		
 	}
 
-	[Lion]
+	[Mac (10, 7)]
 	[BaseType (typeof (NSFontCollection))]
 	[DisableDefaultCtor]
 	interface NSMutableFontCollection {
@@ -7380,42 +7380,42 @@ namespace XamCore.AppKit {
 		[Export ("mouseCoalescingEnabled")]
 		bool MouseCoalescingEnabled { [Bind ("isMouseCoalescingEnabled")]get; set; }
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("hasPreciseScrollingDeltas")]
 		[DebuggerBrowsable (DebuggerBrowsableState.Never)]
 		bool HasPreciseScrollingDeltas { get; }
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("scrollingDeltaX")]
 		[DebuggerBrowsable (DebuggerBrowsableState.Never)]
 		nfloat ScrollingDeltaX { get; }
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("scrollingDeltaY")]
 		[DebuggerBrowsable (DebuggerBrowsableState.Never)]
 		nfloat ScrollingDeltaY { get; }
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("momentumPhase")]
 		[DebuggerBrowsable (DebuggerBrowsableState.Never)]
 		NSEventPhase MomentumPhase { get; }
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("isDirectionInvertedFromDevice")]
 		[DebuggerBrowsable (DebuggerBrowsableState.Never)]
 		bool IsDirectionInvertedFromDevice { get; }
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("phase")]
 		[DebuggerBrowsable (DebuggerBrowsableState.Never)]
 		NSEventPhase Phase { get; }
 
-		[Lion]
+		[Mac (10, 7)]
 		[Static]
 		[Export ("isSwipeTrackingFromScrollEventsEnabled")]
 		bool IsSwipeTrackingFromScrollEventsEnabled { get; }
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("trackSwipeEventWithOptions:dampenAmountThresholdMin:max:usingHandler:")]
 		void TrackSwipeEvent (NSEventSwipeTrackingOptions options, nfloat minDampenThreshold, nfloat maxDampenThreshold, NSEventTrackHandler trackingHandler);
 
@@ -8615,7 +8615,7 @@ namespace XamCore.AppKit {
 		[Export ("outlineView:dataCellForTableColumn:item:"), NoDefaultValue]
 		NSCell GetCell (NSOutlineView outlineView, NSTableColumn tableColumn, NSObject item);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("outlineView:viewForTableColumn:item:"), NoDefaultValue]
 		NSView GetView (NSOutlineView outlineView, [NullAllowed] NSTableColumn tableColumn, NSObject item);
 	
@@ -10247,7 +10247,7 @@ namespace XamCore.AppKit {
 	}
 #endif // XAMCORE_2_0
 
-	[Lion]
+	[Mac (10, 7)]
 	[BaseType (typeof (NSObject))]
 	interface NSLayoutConstraint : NSAnimatablePropertyContainer {
 		[Static]
@@ -12513,7 +12513,7 @@ namespace XamCore.AppKit {
 		[Lion, Export ("restorableStateKeyPaths", ArgumentSemantic.Copy)]
 		string [] RestorableStateKeyPaths ();
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("wantsForwardedScrollEventsForAxis:")]
 		bool WantsForwardedScrollEventsForAxis (NSEventGestureAxis axis);
 
@@ -14860,7 +14860,7 @@ namespace XamCore.AppKit {
 		string Identifier { get; set; }
 	}
 
-	[Lion]
+	[Mac (10, 7)]
 	[Protocol]
 #if !XAMCORE_4_0
 	[Model]
@@ -14970,20 +14970,20 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSObject)), Model, Protocol]
 	partial interface NSTextFinderBarContainer {
-		[Abstract, Export ("findBarVisible"), Lion]
+		[Abstract, Export ("findBarVisible"), Mac (10, 7)]
 		bool FindBarVisible { [Bind ("isFindBarVisible")] get; set;  }
 
-		[Abstract, Export ("findBarView", ArgumentSemantic.Retain), Lion]
+		[Abstract, Export ("findBarView", ArgumentSemantic.Retain), Mac (10, 7)]
 		NSView FindBarView { get; set; }
 
-		[Abstract, Export ("findBarViewDidChangeHeight"), Lion]
+		[Abstract, Export ("findBarViewDidChangeHeight"), Mac (10, 7)]
 		void FindBarViewDidChangeHeight ();
 
 		[Export ("contentView")]
 		NSView ContentView { get; }
 	}
 
-	[Lion]
+	[Mac (10, 7)]
 	[BaseType (typeof (NSObject))]
 	partial interface NSTextFinder : NSCoding {
 		[Export ("client", ArgumentSemantic.Assign)]
@@ -16140,7 +16140,7 @@ namespace XamCore.AppKit {
 
 	interface INSViewControllerPresentationAnimator {}
 
-	[MountainLion]
+	[Mac (10, 8)]
 	[BaseType (typeof (NSViewController),
 		Delegates = new [] { "WeakDelegate" },
 		Events = new [] { typeof (NSPageControllerDelegate) })]
@@ -16285,7 +16285,7 @@ namespace XamCore.AppKit {
 		string Title { get; set; }
 	}
 
-	[Lion]
+	[Mac (10, 7)]
 	[BaseType (typeof (NSView))]
 	interface NSTableRowView : NSAccessibilityRow {
 		[Export ("selectionHighlightStyle")]
@@ -16345,7 +16345,7 @@ namespace XamCore.AppKit {
 		bool NextRowSelected { [Bind ("isNextRowSelected")] get; set; }
 	}
 
-	[Lion]
+	[Mac (10, 7)]
 	[BaseType (typeof (NSView))]
 	partial interface NSTableCellView {
 		[Export ("backgroundStyle")]
@@ -16665,61 +16665,61 @@ namespace XamCore.AppKit {
 		[Export ("focusedColumn")]
 		nint FocusedColumn { get; set; }
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("effectiveRowSizeStyle")]
 		NSTableViewRowSizeStyle EffectiveRowSizeStyle { get; }
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("viewAtColumn:row:makeIfNecessary:")]
 		NSView GetView (nint column, nint row, bool makeIfNecessary);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("rowViewAtRow:makeIfNecessary:")]
 		NSTableRowView GetRowView (nint row, bool makeIfNecessary);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("rowForView:")]
 		nint RowForView (NSView view);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("columnForView:")]
 		nint ColumnForView (NSView view);
 
 		// According to the header identifier should be non-null but example in 
 		// https://bugzilla.xamarin.com/show_bug.cgi?id=36496 shows actual behavior differs
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("makeViewWithIdentifier:owner:")]
 		NSView MakeView ([NullAllowed]string identifier, [NullAllowed]NSObject owner);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("enumerateAvailableRowViewsUsingBlock:")]
 		void EnumerateAvailableRowViews (NSTableViewRowHandler callback);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("beginUpdates")]
 		void BeginUpdates ();
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("endUpdates")]
 		void EndUpdates ();
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("insertRowsAtIndexes:withAnimation:")]
 		void InsertRows (NSIndexSet indexes, NSTableViewAnimation animationOptions);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("removeRowsAtIndexes:withAnimation:")]
 		void RemoveRows (NSIndexSet indexes, NSTableViewAnimation animationOptions);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("moveRowAtIndex:toIndex:")]
 		void MoveRow (nint oldIndex, nint newIndex);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("rowSizeStyle")]
 		NSTableViewRowSizeStyle RowSizeStyle { get; set; }
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("floatsGroupRows")]
 		bool FloatsGroupRows { get; set; }
 
@@ -16844,19 +16844,19 @@ namespace XamCore.AppKit {
 		[Export ("tableViewSelectionIsChanging:"), EventArgs ("NSNotification")]
 		void SelectionIsChanging (NSNotification notification);
 
-		[Lion]
+		[Mac (10, 7)]
                 [Export ("tableView:viewForTableColumn:row:"), DelegateName ("NSTableViewViewGetter"), NoDefaultValue]
                 NSView GetViewForItem (NSTableView tableView, NSTableColumn tableColumn, nint row);
 
-		[Lion]
+		[Mac (10, 7)]
                 [Export ("tableView:rowViewForRow:"), DelegateName ("NSTableViewRowGetter"), DefaultValue (null)]
                 NSTableRowView CoreGetRowView (NSTableView tableView, nint row);
 
-		[Lion]
+		[Mac (10, 7)]
                 [Export ("tableView:didAddRowView:forRow:"), EventArgs ("NSTableViewRow")]
                 void DidAddRowView (NSTableView tableView, NSTableRowView rowView, nint row);
 
-		[Lion]
+		[Mac (10, 7)]
                 [Export ("tableView:didRemoveRowView:forRow:"), EventArgs ("NSTableViewRow")]
                 void DidRemoveRowView (NSTableView tableView, NSTableRowView rowView, nint row);
 
@@ -16894,7 +16894,7 @@ namespace XamCore.AppKit {
 		[Export ("tableView:namesOfPromisedFilesDroppedAtDestination:forDraggedRowsWithIndexes:")]
 		string [] FilesDropped (NSTableView tableView, NSUrl dropDestination, NSIndexSet indexSet );
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("tableView:pasteboardWriterForRow:")]
 #if XAMCORE_2_0
 		INSPasteboardWriting GetPasteboardWriterForRow (NSTableView tableView, nint row);
@@ -16902,15 +16902,15 @@ namespace XamCore.AppKit {
 		NSPasteboardWriting GetPasteboardWriterForRow (NSTableView tableView, nint row);
 #endif
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("tableView:draggingSession:willBeginAtPoint:forRowIndexes:")]
 		void DraggingSessionWillBegin (NSTableView tableView, NSDraggingSession draggingSession, CGPoint willBeginAtScreenPoint, NSIndexSet rowIndexes);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("tableView:draggingSession:endedAtPoint:operation:")]
 		void DraggingSessionEnded (NSTableView tableView, NSDraggingSession draggingSession, CGPoint endedAtScreenPoint, NSDragOperation operation);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("tableView:updateDraggingItemsForDrag:")]
 		void UpdateDraggingItems (NSTableView tableView, [Protocolize (4)] NSDraggingInfo draggingInfo);
 	}
@@ -17024,23 +17024,23 @@ namespace XamCore.AppKit {
 		[Export ("tableView:namesOfPromisedFilesDroppedAtDestination:forDraggedRowsWithIndexes:")]
 		string [] FilesDropped (NSTableView tableView, NSUrl dropDestination, NSIndexSet indexSet );
 		
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("tableView:viewForTableColumn:row:")]
 		NSView GetViewForItem (NSTableView tableView, NSTableColumn tableColumn, nint row);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("tableView:rowViewForRow:")]
 		NSTableRowView GetRowView (NSTableView tableView, nint row);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("tableView:didAddRowView:forRow:")]
 		void DidAddRowView (NSTableView tableView, NSTableRowView rowView, nint row);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("tableView:didRemoveRowView:forRow:")]
 		void DidRemoveRowView (NSTableView tableView, NSTableRowView rowView, nint row);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("tableView:pasteboardWriterForRow:")]
 #if XAMCORE_2_0
 		INSPasteboardWriting GetPasteboardWriterForRow (NSTableView tableView, nint row);
@@ -17048,15 +17048,15 @@ namespace XamCore.AppKit {
 		NSPasteboardWriting GetPasteboardWriterForRow (NSTableView tableView, nint row);
 #endif
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("tableView:draggingSession:willBeginAtPoint:forRowIndexes:")]
 		void DraggingSessionWillBegin (NSTableView tableView, NSDraggingSession draggingSession, CGPoint willBeginAtScreenPoint, NSIndexSet rowIndexes);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("tableView:draggingSession:endedAtPoint:operation:")]
 		void DraggingSessionEnded (NSTableView tableView, NSDraggingSession draggingSession, CGPoint endedAtScreenPoint, NSDragOperation operation);
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("tableView:updateDraggingItemsForDrag:")]
 		void UpdateDraggingItems (NSTableView tableView, [Protocolize (4)] NSDraggingInfo draggingInfo);
 	}
@@ -20424,7 +20424,7 @@ namespace XamCore.AppKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	[Lion]
+	[Mac (10, 7)]
 	partial interface NSWindowRestoration {
 		[Static]
 		[Export ("restoreWindowWithIdentifier:state:completionHandler:")]
@@ -20847,11 +20847,11 @@ namespace XamCore.AppKit {
 		[Export ("runningApplications"), ThreadSafe]
 		NSRunningApplication [] RunningApplications { get; }
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("frontmostApplication")]
 		NSRunningApplication FrontmostApplication { get; }
 
-		[Lion]
+		[Mac (10, 7)]
 		[Export ("menuBarOwningApplication")]
 		NSRunningApplication MenuBarOwningApplication { get; }
 
@@ -21325,10 +21325,10 @@ namespace XamCore.AppKit {
 
 	// Start of NSSharingService.h
 	
-	[MountainLion]
+	[Mac (10, 8)]
 	delegate void NSSharingServiceHandler ();
 	
-	[MountainLion]
+	[Mac (10, 8)]
 	[BaseType (typeof (NSObject),
 	           Delegates=new string [] {"WeakDelegate"},
 	Events=new Type [] { typeof (NSSharingServiceDelegate) })]
@@ -21446,7 +21446,7 @@ namespace XamCore.AppKit {
 		NSString NSSharingServiceNameCloudSharing { get; }
 	}
 	
-	[MountainLion]
+	[Mac (10, 8)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -21495,7 +21495,7 @@ namespace XamCore.AppKit {
 		void Stopped (NSSharingService sharingService, CKShare share);
 	}
 
-	[MountainLion]
+	[Mac (10, 8)]
 	[BaseType (typeof (NSObject),
 	           Delegates=new string [] {"WeakDelegate"},
 	Events=new Type [] { typeof (NSSharingServicePickerDelegate) })]
@@ -21517,7 +21517,7 @@ namespace XamCore.AppKit {
 
 	interface INSSharingServicePickerDelegate {}
 
-	[MountainLion]
+	[Mac (10, 8)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -7988,7 +7988,7 @@ namespace XamCore.AppKit {
 
 	}
 
-	[Availability (Introduced = Platform.Mac_10_0 | Platform.Mac_Arch32)]
+	[Introduced (PlatformName.MacOSX, 10, 0, PlatformArchitecture.Arch32)] 
 	[BaseType (typeof (NSView))]
 	interface NSMenuView {
 		[Static]
@@ -21865,12 +21865,12 @@ namespace XamCore.AppKit {
 		void RemoveItems (NSIndexSet indexes, [NullAllowed] NSObject parent, NSTableViewAnimationOptions animationOptions);
 
 		// - (void)insertRowsAtIndexes:(NSIndexSet *)indexes withAnimation:(NSTableViewAnimationOptions)animationOptions UNAVAILABLE_ATTRIBUTE;
-		[Availability (Unavailable = Platform.iOS_Version | Platform.Mac_Version)]
+		[Availability (Unavailable = Platform.Mac_Version)]
 		[Export ("insertRowsAtIndexes:withAnimation:")]
 		void InsertRows (NSIndexSet indexes, NSTableViewAnimationOptions animationOptions);
 
 		// - (void)removeRowsAtIndexes:(NSIndexSet *)indexes withAnimation:(NSTableViewAnimationOptions)animationOptions UNAVAILABLE_ATTRIBUTE;
-		[Availability (Unavailable = Platform.iOS_Version | Platform.Mac_Version)]
+		[Availability (Unavailable = Platform.Mac_Version)]
 		[Export ("removeRowsAtIndexes:withAnimation:")]
 		void RemoveRows (NSIndexSet indexes, NSTableViewAnimationOptions animationOptions);
 #else
@@ -21880,11 +21880,11 @@ namespace XamCore.AppKit {
 		[Lion, Export ("removeItemsAtIndexes:inParent:withAnimation:")]
 		void RemoveItems (NSIndexSet indexes, [NullAllowed] NSObject parent, NSTableViewAnimation animationOptions);
 
-		[Availability (Unavailable = Platform.iOS_Version | Platform.Mac_Version)]
+		[Availability (Unavailable = Platform.Mac_Version)]
 		[Export ("insertRowsAtIndexes:withAnimation:")]
 		void InsertRows (NSIndexSet indexes, NSTableViewAnimation animationOptions);
 
-		[Availability (Unavailable = Platform.iOS_Version | Platform.Mac_Version)]
+		[Availability (Unavailable = Platform.Mac_Version)]
 		[Export ("removeRowsAtIndexes:withAnimation:")]
 		void RemoveRows (NSIndexSet indexes, NSTableViewAnimation animationOptions);
 #endif

--- a/src/assetslibrary.cs
+++ b/src/assetslibrary.cs
@@ -90,7 +90,7 @@ namespace XamCore.AssetsLibrary {
 		[Notification (typeof (ALAssetLibraryChangedEventArgs))]
 		NSString ChangedNotification { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("groupForURL:resultBlock:failureBlock:")]
 #if XAMCORE_2_0
 		void GroupForUrl (NSUrl groupURL, Action<ALAssetsGroup> resultBlock, Action<NSError> failureBlock);
@@ -98,7 +98,7 @@ namespace XamCore.AssetsLibrary {
 		void GroupForUrl (NSUrl groupURL, ALAssetsLibraryGroupResult resultBlock, ALAssetsLibraryAccessFailure failureBlock);
 #endif
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("addAssetsGroupAlbumWithName:resultBlock:failureBlock:")]
 #if XAMCORE_2_0
 		void AddAssetsGroupAlbum (string name, Action<ALAssetsGroup> resultBlock, Action<NSError> failureBlock);
@@ -106,29 +106,29 @@ namespace XamCore.AssetsLibrary {
 		void AddAssetsGroupAlbum (string name, ALAssetsLibraryGroupResult resultBlock, ALAssetsLibraryAccessFailure failureBlock);
 #endif
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Static]
 		[Export ("authorizationStatus")]
 		ALAuthorizationStatus AuthorizationStatus { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Static]
 		[Export ("disableSharedPhotoStreamsSupport")]
 		void DisableSharedPhotoStreamsSupport ();
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("ALAssetLibraryUpdatedAssetsKey")]
 		NSString UpdatedAssetsKey { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("ALAssetLibraryInsertedAssetGroupsKey")]
 		NSString InsertedAssetGroupsKey { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("ALAssetLibraryUpdatedAssetGroupsKey")]
 		NSString UpdatedAssetGroupsKey { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("ALAssetLibraryDeletedAssetGroupsKey")]
 		NSString DeletedAssetGroupsKey { get; }
 	}
@@ -180,7 +180,7 @@ namespace XamCore.AssetsLibrary {
 		[Field ("ALAssetPropertyURLs"), Internal]
 		NSString _PropertyURLs { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("ALAssetPropertyAssetURL"), Internal]
 		NSString _PropertyAssetURL { get; }
 
@@ -193,19 +193,19 @@ namespace XamCore.AssetsLibrary {
 		[Field ("ALAssetTypeUnknown"), Internal]
 		NSString _TypeUnknown { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("originalAsset")]
 		ALAsset OriginalAsset { get;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("editable")]
 		bool Editable { [Bind ("isEditable")] get;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("aspectRatioThumbnail")]
 		CGImage AspectRatioThumbnail ();
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("writeModifiedImageDataToSavedPhotosAlbum:metadata:completionBlock:")]
 		[Async]
 #if XAMCORE_2_0
@@ -214,7 +214,7 @@ namespace XamCore.AssetsLibrary {
 		void WriteModifiedImageToSavedToPhotosAlbum (NSData imageData, NSDictionary metadata,  [NullAllowed] ALAssetsLibraryWriteCompletionDelegate completionBlock);
 #endif
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("writeModifiedVideoAtPathToSavedPhotosAlbum:completionBlock:")]
 		[Async]
 #if XAMCORE_2_0
@@ -223,7 +223,7 @@ namespace XamCore.AssetsLibrary {
 		void WriteModifiedVideoToSavedPhotosAlbum (NSUrl videoPathURL,  [NullAllowed] ALAssetsLibraryWriteCompletionDelegate completionBlock);
 #endif
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setImageData:metadata:completionBlock:")]
 		[Async]
 #if XAMCORE_2_0
@@ -232,7 +232,7 @@ namespace XamCore.AssetsLibrary {
 		void SetImageData (NSData imageData, NSDictionary metadata,  [NullAllowed] ALAssetsLibraryWriteCompletionDelegate completionBlock);
 #endif
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setVideoAtPath:completionBlock:")]
 		[Async]
 #if XAMCORE_2_0
@@ -278,11 +278,11 @@ namespace XamCore.AssetsLibrary {
 		[Export ("scale")]
 		float Scale { get; } /* float, not CGFloat */
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("filename")]
 		string Filename { get; }
 		
-		[Since (5,1)]
+		[iOS (5,1)]
 		[Export ("dimensions")]
 		CGSize Dimensions { get; }
 	}
@@ -304,11 +304,11 @@ namespace XamCore.AssetsLibrary {
 	delegate void ALAssetsEnumerator (ALAsset result, nint index, ref bool stop);
 
 #if !XAMCORE_2_0
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use the 'Photos' API instead.")]
 	delegate void ALAssetsLibraryGroupResult (ALAssetsGroup group);
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use the 'Photos' API instead.")]
 	delegate void ALAssetsLibraryAccessFailure (NSError error);
 #endif
@@ -346,15 +346,15 @@ namespace XamCore.AssetsLibrary {
 		[Field ("ALAssetsGroupPropertyPersistentID"), Internal]
 		NSString _PersistentID { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("editable")]
 		bool Editable { [Bind ("isEditable")] get;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("addAsset:")]
 		bool AddAsset (ALAsset asset);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("ALAssetsGroupPropertyURL"), Internal]
 		NSString _PropertyUrl { get; }
 	}

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -161,7 +161,8 @@ namespace XamCore.AVFoundation {
 		Timecode = 5,
 
 		[NoTV]
-		[Availability (Obsoleted = Platform.iOS_6_0 | Platform.Mac_10_8)]
+		[Availability (Obsoleted = Platform.iOS_6_0)]
+		[Availability (Obsoleted = Platform.Mac_10_8)]
 		[Field ("AVMediaTypeTimedMetadata")] // last header where I can find this: iOS 5.1 SDK, 10.7 only on Mac
 		TimedMetadata = 6,
 
@@ -207,7 +208,8 @@ namespace XamCore.AVFoundation {
 
 		[NoTV][NoWatch]
 		[Field ("AVMediaTypeTimedMetadata")] // last header where I can find this: iOS 5.1 SDK, 10.7 only on Mac
-		[Availability (Obsoleted = Platform.iOS_6_0 | Platform.Mac_10_8)]
+		[Availability (Obsoleted = Platform.iOS_6_0)]
+		[Availability (Obsoleted = Platform.Mac_10_8)]
 		NSString TimedMetadata { get; }
 
 		[Field ("AVMediaTypeMuxed")]
@@ -669,15 +671,21 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoH264EntropyModeKey")]
 		NSString H264EntropyModeKey { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7 | Platform.TV_9_0, Deprecated = Platform.iOS_11_0 | Platform.Mac_10_13 | Platform.TV_11_0, Message = "Use 'AVVideoCodecType' enum instead.")]
+		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_11_0, Message = "Use 'AVVideoCodecType' enum instead.")]
+		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_13, Message = "Use 'AVVideoCodecType' enum instead.")]
+		[Availability (Introduced = Platform.TV_9_0, Deprecated = Platform.TV_11_0, Message = "Use 'AVVideoCodecType' enum instead.")]
 		[Field ("AVVideoCodecH264")]
 		NSString CodecH264 { get; }
 		
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7 | Platform.TV_9_0, Deprecated = Platform.iOS_11_0 | Platform.Mac_10_13 | Platform.TV_11_0, Message = "Use 'AVVideoCodecType' enum instead.")]
+		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_11_0, Message = "Use 'AVVideoCodecType' enum instead.")]
+		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_13, Message = "Use 'AVVideoCodecType' enum instead.")]
+		[Availability (Introduced = Platform.TV_9_0, Deprecated = Platform.TV_11_0, Message = "Use 'AVVideoCodecType' enum instead.")]
 		[Field ("AVVideoCodecJPEG")]
 		NSString CodecJPEG { get; }
 		
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7 | Platform.TV_9_0, Deprecated = Platform.iOS_11_0 | Platform.Mac_10_13 | Platform.TV_11_0, Message = "Use 'AVVideoCodecType' enum instead.")]
+		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_11_0, Message = "Use 'AVVideoCodecType' enum instead.")]
+		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_13, Message = "Use 'AVVideoCodecType' enum instead.")]
+		[Availability (Introduced = Platform.TV_9_0, Deprecated = Platform.TV_11_0, Message = "Use 'AVVideoCodecType' enum instead.")]
 		[NoiOS, NoTV, Mac (10,7)]
 		[Field ("AVVideoCodecAppleProRes4444")]
 		NSString AppleProRes4444 { get; }
@@ -2810,7 +2818,8 @@ namespace XamCore.AVFoundation {
 		CGAffineTransform PreferredTransform { get;  }
 
 		[Export ("naturalSize")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7, Deprecated = Platform.iOS_5_0 | Platform.Mac_10_8, Message = "Use 'NaturalSize/PreferredTransform' as appropriate on the video track instead.")]
+		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_5_0, Message = "Use 'NaturalSize/PreferredTransform' as appropriate on the video track instead.")]
+		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_8, Message = "Use 'NaturalSize/PreferredTransform' as appropriate on the video track instead.")]
 		CGSize NaturalSize { get;  }
 
 		[TV (11,2), NoWatch, NoMac, NoiOS]
@@ -5209,7 +5218,8 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMetadataID3MetadataKeyCommercial")]
 		NSString ID3MetadataKeyCommercial { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7, Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11)]
+		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_9_0)]
+		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_11)]
 		[Field ("AVMetadataID3MetadataKeyCommerical")]
 		NSString ID3MetadataKeyCommerical { get; }
 		
@@ -6097,7 +6107,8 @@ namespace XamCore.AVFoundation {
 			[Field ("AVMetadataIdentifierID3MetadataCommercial")]
 			NSString Commercial { get; }
 
-			[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_10, Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11)]
+			[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0)]
+			[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_11)]
 			[Field ("AVMetadataIdentifierID3MetadataCommerical")]
 			NSString Commerical { get; }
 			
@@ -8298,7 +8309,8 @@ namespace XamCore.AVFoundation {
 		bool _SupportsVideoMinFrameDuration { [Bind ("isVideoMinFrameDurationSupported")] get;  }
 
 		[Since (5,0)]
-		[Availability (Introduced = Platform.iOS_5_0 | Platform.Mac_10_7, Deprecated = Platform.iOS_7_0 /* Only deprecated on iOS */)]
+		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0 /* Only deprecated on iOS */)]
+		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.iOS_7_0 /* Only deprecated on iOS */)]
 		[Export ("videoMinFrameDuration")]
 		CMTime VideoMinFrameDuration { get; set;  }
 #if !MONOMAC
@@ -8308,7 +8320,7 @@ namespace XamCore.AVFoundation {
 
 		[Since (5,0)]
 		[Export ("videoMaxFrameDuration")]
-		[Availability (Introduced = Platform.iOS_5_0 | Platform.Mac_10_7, Deprecated = Platform.iOS_7_0 /* Only deprecated on iOS */)]
+		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.iOS_7_0 /* Only deprecated on iOS */)]
 		CMTime VideoMaxFrameDuration { get; set;  }
 
 		[Since (5,0)]
@@ -11154,7 +11166,8 @@ namespace XamCore.AVFoundation {
 	[BaseType (typeof (NSObject))]
 	[Since (4,3)]
 	interface AVPlayerItemAccessLogEvent : NSCopying {
-		[Availability (Introduced = Platform.iOS_4_3 | Platform.Mac_10_7, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9, Message = "Use 'NumberOfMediaRequests' instead.")]
+		[Availability (Introduced = Platform.iOS_4_3, Deprecated = Platform.iOS_7_0, Message = "Use 'NumberOfMediaRequests' instead.")]
+		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_9, Message = "Use 'NumberOfMediaRequests' instead.")]
 		[Export ("numberOfSegmentsDownloaded")]
 		nint SegmentedDownloadedCount { get; }
 

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -8320,7 +8320,8 @@ namespace XamCore.AVFoundation {
 
 		[Since (5,0)]
 		[Export ("videoMaxFrameDuration")]
-		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.iOS_7_0 /* Only deprecated on iOS */)]
+		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0 /* Only deprecated on iOS */)] 
+		[Availability (Introduced = Platform.Mac_10_7)] 
 		CMTime VideoMaxFrameDuration { get; set;  }
 
 		[Since (5,0)]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -2825,8 +2825,10 @@ namespace XamCore.AVFoundation {
 		CGAffineTransform PreferredTransform { get;  }
 
 		[Export ("naturalSize")]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_5_0, Message = "Use 'NaturalSize/PreferredTransform' as appropriate on the video track instead.")]
-		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_8, Message = "Use 'NaturalSize/PreferredTransform' as appropriate on the video track instead.")]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Deprecated (PlatformName.iOS, 5, 0, message : "Use 'NaturalSize/PreferredTransform' as appropriate on the video track instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Use 'NaturalSize/PreferredTransform' as appropriate on the video track instead.")]
 		CGSize NaturalSize { get;  }
 
 		[TV (11,2), NoWatch, NoMac, NoiOS]
@@ -5225,8 +5227,10 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMetadataID3MetadataKeyCommercial")]
 		NSString ID3MetadataKeyCommercial { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_9_0)]
-		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_11)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Deprecated (PlatformName.iOS, 9, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Field ("AVMetadataID3MetadataKeyCommerical")]
 		NSString ID3MetadataKeyCommerical { get; }
 		
@@ -6114,8 +6118,10 @@ namespace XamCore.AVFoundation {
 			[Field ("AVMetadataIdentifierID3MetadataCommercial")]
 			NSString Commercial { get; }
 
-			[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0)]
-			[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_11)]
+			[Introduced (PlatformName.iOS, 8, 0)]
+			[Deprecated (PlatformName.iOS, 9, 0)]
+			[Introduced (PlatformName.MacOSX, 10, 10)]
+			[Deprecated (PlatformName.MacOSX, 10, 11)]
 			[Field ("AVMetadataIdentifierID3MetadataCommerical")]
 			NSString Commerical { get; }
 			
@@ -8316,8 +8322,9 @@ namespace XamCore.AVFoundation {
 		bool _SupportsVideoMinFrameDuration { [Bind ("isVideoMinFrameDurationSupported")] get;  }
 
 		[Since (5,0)]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0 /* Only deprecated on iOS */)]
-		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.iOS_7_0 /* Only deprecated on iOS */)]
+		[Introduced (PlatformName.iOS, 5, 0)]
+		[Deprecated (PlatformName.iOS, 7, 0 /* Only deprecated on iOS */)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
 		[Export ("videoMinFrameDuration")]
 		CMTime VideoMinFrameDuration { get; set;  }
 #if !MONOMAC
@@ -8327,8 +8334,9 @@ namespace XamCore.AVFoundation {
 
 		[Since (5,0)]
 		[Export ("videoMaxFrameDuration")]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0 /* Only deprecated on iOS */)] 
-		[Availability (Introduced = Platform.Mac_10_7)] 
+		[Introduced (PlatformName.iOS, 5, 0)]
+		[Deprecated (PlatformName.iOS, 7, 0 /* Only deprecated on iOS */)] 
+		[Introduced (PlatformName.MacOSX, 10, 7)] 
 		CMTime VideoMaxFrameDuration { get; set;  }
 
 		[Since (5,0)]
@@ -11174,8 +11182,10 @@ namespace XamCore.AVFoundation {
 	[BaseType (typeof (NSObject))]
 	[Since (4,3)]
 	interface AVPlayerItemAccessLogEvent : NSCopying {
-		[Availability (Introduced = Platform.iOS_4_3, Deprecated = Platform.iOS_7_0, Message = "Use 'NumberOfMediaRequests' instead.")]
-		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_9, Message = "Use 'NumberOfMediaRequests' instead.")]
+		[Introduced (PlatformName.iOS, 4, 3)]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'NumberOfMediaRequests' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use 'NumberOfMediaRequests' instead.")]
 		[Export ("numberOfSegmentsDownloaded")]
 		nint SegmentedDownloadedCount { get; }
 

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -4172,7 +4172,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[DisableDefaultCtor] // Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[AVAssetWriterInputGroup initWithInputs:defaultInput:] invalid parameter not satisfying: inputs != ((void*)0)
-	[iOS (7,0), Mavericks, BaseType (typeof (AVMediaSelectionGroup))]
+	[iOS (7,0), Mac (10, 9), BaseType (typeof (AVMediaSelectionGroup))]
 	interface AVAssetWriterInputGroup {
 	
 		[Static, Export ("assetWriterInputGroupWithInputs:defaultInput:")]
@@ -7995,7 +7995,7 @@ namespace XamCore.AVFoundation {
 		[Export ("getOpacityRampForTime:startOpacity:endOpacity:timeRange:")]
 		bool GetOpacityRamp (CMTime time, ref float /* defined as 'float*' */ startOpacity, ref float /* defined as 'float*' */ endOpacity, ref CMTimeRange timeRange);
 
-		[iOS (7,0), Mavericks, Export ("getCropRectangleRampForTime:startCropRectangle:endCropRectangle:timeRange:")]
+		[iOS (7,0), Mac (10, 9), Export ("getCropRectangleRampForTime:startCropRectangle:endCropRectangle:timeRange:")]
 		bool GetCrop (CMTime time, ref CGRect startCropRectangle, ref CGRect endCropRectangle, ref CMTimeRange timeRange);
 	}
 
@@ -8321,7 +8321,6 @@ namespace XamCore.AVFoundation {
 		[Export ("supportsVideoMinFrameDuration"), Internal]
 		bool _SupportsVideoMinFrameDuration { [Bind ("isVideoMinFrameDurationSupported")] get;  }
 
-		[iOS (5,0)]
 		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0 /* Only deprecated on iOS */)]
 		[Mac (10, 7)]
@@ -8332,7 +8331,6 @@ namespace XamCore.AVFoundation {
 		[Export ("supportsVideoMaxFrameDuration"), Internal]
 		bool _SupportsVideoMaxFrameDuration { [Bind ("isVideoMaxFrameDurationSupported")] get;  }
 
-		[iOS (5,0)]
 		[Export ("videoMaxFrameDuration")]
 		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0 /* Only deprecated on iOS */)] 
@@ -8449,7 +8447,7 @@ namespace XamCore.AVFoundation {
 		[Export ("input")]
 		AVCaptureInput Input  { get; }
 
-		[iOS (7,0), Mavericks, Export ("clock", ArgumentSemantic.Copy)]
+		[iOS (7,0), Mac (10, 9), Export ("clock", ArgumentSemantic.Copy)]
 		CMClock Clock { get; }
 	}
 

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -671,26 +671,33 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoH264EntropyModeKey")]
 		NSString H264EntropyModeKey { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_11_0, Message = "Use 'AVVideoCodecType' enum instead.")]
-		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_13, Message = "Use 'AVVideoCodecType' enum instead.")]
-		[Availability (Introduced = Platform.TV_9_0, Deprecated = Platform.TV_11_0, Message = "Use 'AVVideoCodecType' enum instead.")]
+		[iOS (4, 0)]
+		[Mac (10, 7)]
+		[TV (9, 0)]
+		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'AVVideoCodecType' enum instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'AVVideoCodecType' enum instead.")]
+		[Deprecated (PlatformName.TvOS, 11, 0, message : "Use 'AVVideoCodecType' enum instead.")]
 		[Field ("AVVideoCodecH264")]
 		NSString CodecH264 { get; }
 		
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_11_0, Message = "Use 'AVVideoCodecType' enum instead.")]
-		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_13, Message = "Use 'AVVideoCodecType' enum instead.")]
-		[Availability (Introduced = Platform.TV_9_0, Deprecated = Platform.TV_11_0, Message = "Use 'AVVideoCodecType' enum instead.")]
+		[iOS (4, 0)]
+		[Mac (10, 7)]
+		[TV (9, 0)]
+		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'AVVideoCodecType' enum instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'AVVideoCodecType' enum instead.")]
+		[Deprecated (PlatformName.TvOS, 11, 0, message : "Use 'AVVideoCodecType' enum instead.")]
 		[Field ("AVVideoCodecJPEG")]
 		NSString CodecJPEG { get; }
 		
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_11_0, Message = "Use 'AVVideoCodecType' enum instead.")]
-		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_13, Message = "Use 'AVVideoCodecType' enum instead.")]
-		[Availability (Introduced = Platform.TV_9_0, Deprecated = Platform.TV_11_0, Message = "Use 'AVVideoCodecType' enum instead.")]
+		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'AVVideoCodecType' enum instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'AVVideoCodecType' enum instead.")]
+		[Deprecated (PlatformName.TvOS, 11, 0, message : "Use 'AVVideoCodecType' enum instead.")]
 		[NoiOS, NoTV, Mac (10,7)]
 		[Field ("AVVideoCodecAppleProRes4444")]
 		NSString AppleProRes4444 { get; }
 
-		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_13, Message = "Use 'AVVideoCodecType' enum instead.")]
+		[Mac (10, 7)]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'AVVideoCodecType' enum instead.")]
 		[NoiOS, NoTV, Mac (10,7)]
 		[Field ("AVVideoCodecAppleProRes422")]
 		NSString AppleProRes422 { get; }

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -2825,9 +2825,9 @@ namespace XamCore.AVFoundation {
 		CGAffineTransform PreferredTransform { get;  }
 
 		[Export ("naturalSize")]
-		[Introduced (PlatformName.iOS, 4, 0)]
+		[iOS (4, 0)]
 		[Deprecated (PlatformName.iOS, 5, 0, message : "Use 'NaturalSize/PreferredTransform' as appropriate on the video track instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Mac (10, 7)]
 		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Use 'NaturalSize/PreferredTransform' as appropriate on the video track instead.")]
 		CGSize NaturalSize { get;  }
 
@@ -5227,9 +5227,9 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMetadataID3MetadataKeyCommercial")]
 		NSString ID3MetadataKeyCommercial { get; }
 
-		[Introduced (PlatformName.iOS, 4, 0)]
+		[iOS (4, 0)]
 		[Deprecated (PlatformName.iOS, 9, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Mac (10, 7)]
 		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Field ("AVMetadataID3MetadataKeyCommerical")]
 		NSString ID3MetadataKeyCommerical { get; }
@@ -6118,9 +6118,9 @@ namespace XamCore.AVFoundation {
 			[Field ("AVMetadataIdentifierID3MetadataCommercial")]
 			NSString Commercial { get; }
 
-			[Introduced (PlatformName.iOS, 8, 0)]
+			[iOS (8, 0)]
 			[Deprecated (PlatformName.iOS, 9, 0)]
-			[Introduced (PlatformName.MacOSX, 10, 10)]
+			[Mac (10, 10)]
 			[Deprecated (PlatformName.MacOSX, 10, 11)]
 			[Field ("AVMetadataIdentifierID3MetadataCommerical")]
 			NSString Commerical { get; }
@@ -7135,7 +7135,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVFragmentedMovieTrackSegmentsDidChangeNotification")]
 		NSString SegmentsDidChangeNotification { get; }
 
-		[Introduced (PlatformName.MacOSX, 10, 10)]
+		[Mac (10, 10)]
 		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use either 'AVFragmentedMovieTrackTimeRangeDidChangeNotification' or 'AVFragmentedMovieTrackSegmentsDidChangeNotification' instead. In either case, you can assume that the sender's 'TotalSampleDataLength' has changed.")]
 		[Field ("AVFragmentedMovieTrackTotalSampleDataLengthDidChangeNotification")]
 		NSString TotalSampleDataLengthDidChangeNotification { get; }
@@ -8322,9 +8322,9 @@ namespace XamCore.AVFoundation {
 		bool _SupportsVideoMinFrameDuration { [Bind ("isVideoMinFrameDurationSupported")] get;  }
 
 		[Since (5,0)]
-		[Introduced (PlatformName.iOS, 5, 0)]
+		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0 /* Only deprecated on iOS */)]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Mac (10, 7)]
 		[Export ("videoMinFrameDuration")]
 		CMTime VideoMinFrameDuration { get; set;  }
 #if !MONOMAC
@@ -8334,9 +8334,9 @@ namespace XamCore.AVFoundation {
 
 		[Since (5,0)]
 		[Export ("videoMaxFrameDuration")]
-		[Introduced (PlatformName.iOS, 5, 0)]
+		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0 /* Only deprecated on iOS */)] 
-		[Introduced (PlatformName.MacOSX, 10, 7)] 
+		[Mac (10, 7)] 
 		CMTime VideoMaxFrameDuration { get; set;  }
 
 		[Since (5,0)]
@@ -9511,7 +9511,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVCaptureDeviceTypeBuiltInTelephotoCamera")]
 		BuiltInTelephotoCamera,
 
-		[Introduced (PlatformName.iOS, 10, 0, message: "Use 'BuiltInDualCamera' instead.")]
+		[iOS (10, 0, message: "Use 'BuiltInDualCamera' instead.")]
 		[Deprecated (PlatformName.iOS, 10, 2, message: "Use 'BuiltInDualCamera' instead.")]
 		[Field ("AVCaptureDeviceTypeBuiltInDuoCamera")]
 		BuiltInDuoCamera,
@@ -11182,9 +11182,9 @@ namespace XamCore.AVFoundation {
 	[BaseType (typeof (NSObject))]
 	[Since (4,3)]
 	interface AVPlayerItemAccessLogEvent : NSCopying {
-		[Introduced (PlatformName.iOS, 4, 3)]
+		[iOS (4, 3)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'NumberOfMediaRequests' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Mac (10, 7)]
 		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use 'NumberOfMediaRequests' instead.")]
 		[Export ("numberOfSegmentsDownloaded")]
 		nint SegmentedDownloadedCount { get; }

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -109,7 +109,7 @@ namespace XamCore.AVFoundation {
 	delegate AVAudioBuffer AVAudioConverterInputHandler (uint inNumberOfPackets, out AVAudioConverterInputStatus outStatus);
 
 	[NoWatch]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	interface AVAsynchronousVideoCompositionRequest : NSCopying {
@@ -173,7 +173,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMediaTypeMetadataObject")]
 		MetadataObject = 8,
 
-		[Since (6,0)][Mac (10,8)]
+		[iOS (6,0)][Mac (10,8)]
 		[Field ("AVMediaTypeMetadata")]
 		Metadata = 9,
 
@@ -185,7 +185,7 @@ namespace XamCore.AVFoundation {
 #if !XAMCORE_4_0
 	[Obsolete ("Use AVMediaTypes enum values")]
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))][Static]
 	interface AVMediaType {
 		[Field ("AVMediaTypeVideo")]
@@ -219,7 +219,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMediaTypeMetadataObject")]
 		NSString MetadataObject { get; }
 
-		[Since (6,0)][Mac (10,8)]
+		[iOS (6,0)][Mac (10,8)]
 		[Field ("AVMediaTypeMetadata")]
 		NSString Metadata { get; }
 	}
@@ -330,27 +330,27 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMediaCharacteristicIsMainProgramContent")]
 		IsMainProgramContent = 5,
 
-		[Mac (10, 8)][Since (5,0)]
+		[Mac (10, 8)][iOS (5,0)]
 		[Field ("AVMediaCharacteristicIsAuxiliaryContent")]
 		IsAuxiliaryContent = 6,
 
-		[Mac (10, 8)][Since (5,0)]
+		[Mac (10, 8)][iOS (5,0)]
 		[Field ("AVMediaCharacteristicContainsOnlyForcedSubtitles")]
 		ContainsOnlyForcedSubtitles = 7,
 
-		[Mac (10, 8)][Since (5,0)]
+		[Mac (10, 8)][iOS (5,0)]
 		[Field ("AVMediaCharacteristicTranscribesSpokenDialogForAccessibility")]
 		TranscribesSpokenDialogForAccessibility = 8,
 
-		[Mac (10, 8)][Since (5,0)]
+		[Mac (10, 8)][iOS (5,0)]
 		[Field ("AVMediaCharacteristicDescribesMusicAndSoundForAccessibility")]
 		DescribesMusicAndSoundForAccessibility = 9,
 
-		[Mac (10, 8)][Since (5,0)]
+		[Mac (10, 8)][iOS (5,0)]
 		[Field ("AVMediaCharacteristicDescribesVideoForAccessibility")]
 		DescribesVideoForAccessibility = 10,
 
-		[NoMac][Since (6,0)]
+		[NoMac][iOS (6,0)]
 		[Field ("AVMediaCharacteristicEasyToRead")]
 		EasyToRead = 11,
 
@@ -371,7 +371,7 @@ namespace XamCore.AVFoundation {
 #if !XAMCORE_4_0
 	[Obsolete ("Use AVMediaCharacteristics enum values")]
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))][Static]
 	interface AVMediaCharacteristic {
 		[Field ("AVMediaCharacteristicVisual")]
@@ -390,31 +390,31 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMediaCharacteristicUsesWideGamutColorSpace")]
 		NSString UsesWideGamutColorSpace { get; }
 
-		[Mac (10, 8)][Since (5,0)]
+		[Mac (10, 8)][iOS (5,0)]
 		[Field ("AVMediaCharacteristicIsMainProgramContent")]
 		NSString IsMainProgramContent { get; }
 
-		[Mac (10, 8)][Since (5,0)]
+		[Mac (10, 8)][iOS (5,0)]
 		[Field ("AVMediaCharacteristicIsAuxiliaryContent")]
 		NSString IsAuxiliaryContent { get; }
 
-		[Mac (10, 8)][Since (5,0)]
+		[Mac (10, 8)][iOS (5,0)]
 		[Field ("AVMediaCharacteristicContainsOnlyForcedSubtitles")]
 		NSString ContainsOnlyForcedSubtitles { get; }
 
-		[Mac (10, 8)][Since (5,0)]
+		[Mac (10, 8)][iOS (5,0)]
 		[Field ("AVMediaCharacteristicTranscribesSpokenDialogForAccessibility")]
 		NSString TranscribesSpokenDialogForAccessibility { get; }
 
-		[Mac (10, 8)][Since (5,0)]
+		[Mac (10, 8)][iOS (5,0)]
 		[Field ("AVMediaCharacteristicDescribesMusicAndSoundForAccessibility")]
 		NSString DescribesMusicAndSoundForAccessibility { get; }
 
-		[Mac (10, 8)][Since (5,0)]
+		[Mac (10, 8)][iOS (5,0)]
 		[Field ("AVMediaCharacteristicDescribesVideoForAccessibility")]
 		NSString DescribesVideoForAccessibility { get;  }
 #if !MONOMAC
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVMediaCharacteristicEasyToRead")]
 		NSString EasyToRead { get; }
 #endif
@@ -445,7 +445,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMetadataFormatID3Metadata")]
 		FormatID3Metadata = 2,
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVMetadataFormatISOUserData")]
 		FormatISOUserData = 3,
 
@@ -494,15 +494,15 @@ namespace XamCore.AVFoundation {
 		[Field ("AVFileType3GPP2")]
 		ThreeGpp2 = 10,
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVFileTypeMPEGLayer3")]
 		MpegLayer3 = 11,
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVFileTypeSunAU")]
 		SunAU = 12,
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVFileTypeAC3")]
 		AC3 = 13,
 
@@ -537,7 +537,7 @@ namespace XamCore.AVFoundation {
 
 #if !XAMCORE_4_0
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))][Static]
 	[Obsolete ("Use AVFileTypes enum values")]
 	interface AVFileType {
@@ -575,15 +575,15 @@ namespace XamCore.AVFoundation {
 		[Field ("AVFileType3GPP2")]
 		NSString ThreeGpp2 { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVFileTypeMPEGLayer3")]
 		NSString MpegLayer3 { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVFileTypeSunAU")]
 		NSString SunAU { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVFileTypeAC3")]
 		NSString AC3 { get; }
 
@@ -607,7 +607,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[Since (7,0)] // And OSX 10.7
+	[iOS (7,0)] // And OSX 10.7
 	[DisableDefaultCtor] // crash -> immutable and you can get them but not set them (i.e. no point in creating them)
 	[BaseType (typeof (NSObject))]
 	interface AVFrameRateRange {
@@ -626,22 +626,22 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))][Static]
 	interface AVVideo {
 		[Field ("AVVideoCodecKey")]
 		NSString CodecKey { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVVideoMaxKeyFrameIntervalDurationKey")]
 		NSString MaxKeyFrameIntervalDurationKey { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,10)]
 		[Field ("AVVideoAllowFrameReorderingKey")]
 		NSString AllowFrameReorderingKey { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,10)]
 		[Field ("AVVideoAverageNonDroppableFrameRateKey")]
 		NSString AverageNonDroppableFrameRateKey { get; }
@@ -651,22 +651,22 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoEncoderSpecificationKey")]
 		NSString EncoderSpecificationKey { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,10)]
 		[Field ("AVVideoExpectedSourceFrameRateKey")]
 		NSString ExpectedSourceFrameRateKey { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,10)]
 		[Field ("AVVideoH264EntropyModeCABAC")]
 		NSString H264EntropyModeCABAC { get; }
 
-		[Since (7, 0)]
+		[iOS (7, 0)]
 		[Mac (10,10)]
 		[Field ("AVVideoH264EntropyModeCAVLC")]
 		NSString H264EntropyModeCAVLC { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,10)]
 		[Field ("AVVideoH264EntropyModeKey")]
 		NSString H264EntropyModeKey { get; }
@@ -708,7 +708,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoHeightKey")]
 		NSString HeightKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("AVVideoScalingModeKey")]
 		NSString ScalingModeKey { get; }
 		
@@ -724,7 +724,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoProfileLevelKey")]
 		NSString ProfileLevelKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("AVVideoQualityKey")]
 		NSString QualityKey { get; }
 		
@@ -740,35 +740,35 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoProfileLevelH264Main31")]
 		NSString ProfileLevelH264Main31 { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("AVVideoProfileLevelH264Baseline41")]
 		NSString ProfileLevelH264Baseline41 { get; }
 
-		[Since (5,0)][Mac (10, 8)]
+		[iOS (5,0)][Mac (10, 8)]
 		[Field ("AVVideoProfileLevelH264Main32")]
 		NSString ProfileLevelH264Main32 { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("AVVideoProfileLevelH264Main41")]
 		NSString ProfileLevelH264Main41 { get; }
 
-		[Since (6,0), Mac (10, 9)]
+		[iOS (6,0), Mac (10, 9)]
 		[Field ("AVVideoProfileLevelH264High40")]
 		NSString ProfileLevelH264High40 { get; }
 
-		[Since (6,0), Mac (10, 9)]
+		[iOS (6,0), Mac (10, 9)]
 		[Field ("AVVideoProfileLevelH264High41")]
 		NSString ProfileLevelH264High41 { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVVideoProfileLevelH264BaselineAutoLevel")]
 		NSString ProfileLevelH264BaselineAutoLevel { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVVideoProfileLevelH264MainAutoLevel")]
 		NSString ProfileLevelH264MainAutoLevel { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVVideoProfileLevelH264HighAutoLevel")]
 		NSString ProfileLevelH264HighAutoLevel { get; }
 
@@ -799,7 +799,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Static]
 	interface AVVideoScalingModeKey
 	{
@@ -1500,41 +1500,41 @@ namespace XamCore.AVFoundation {
 		[Export ("averagePowerForChannel:")]
 		float AveragePower (nuint channelNumber); // defined as 'float'
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("deviceCurrentTime")]
 		double DeviceCurrentTime { get;  }
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("pan")]
 		float Pan { get; set; } // defined as 'float'
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("playAtTime:")]
 		bool PlayAtTime (double time);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("settings")][Protected]
 		NSDictionary WeakSettings { get;  }
 
 		[Wrap ("WeakSettings")]
 		AudioSettings SoundSetting { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("enableRate")]
 		bool EnableRate { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("rate")]
 		float Rate { get; set; } // defined as 'float'		
 #if !MONOMAC
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("channelAssignments", ArgumentSemantic.Copy), NullAllowed]
 		AVAudioSessionChannelDescription [] ChannelAssignments { get; set; }
 #endif
-		[Since (7,0), Mac (10,9), Export ("initWithData:fileTypeHint:error:")]
+		[iOS (7,0), Mac (10,9), Export ("initWithData:fileTypeHint:error:")]
 		IntPtr Constructor (NSData data, [NullAllowed] string fileTypeHint, out NSError outError);
 
-		[Since (7,0), Mac (10,9), Export ("initWithContentsOfURL:fileTypeHint:error:")]
+		[iOS (7,0), Mac (10,9), Export ("initWithContentsOfURL:fileTypeHint:error:")]
 		IntPtr Constructor (NSUrl url, [NullAllowed] string fileTypeHint, out NSError outError);
 
 		[iOS (10, 0), TV (10,0), Mac (10,12)]
@@ -1565,12 +1565,12 @@ namespace XamCore.AVFoundation {
 
 		// Deprecated in iOS 6.0 but we have same C# signature
 		[NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("audioPlayerEndInterruption:withFlags:")]
 		void EndInterruption (AVAudioPlayer player, AVAudioSessionInterruptionFlags flags);
 
 		//[Availability (Deprecated = Platform.iOS_8_0)]
-		//[Since (6,0)]
+		//[iOS (6,0)]
 		//[Export ("audioPlayerEndInterruption:withOptions:")]
 		//void EndInterruption (AVAudioPlayer player, AVAudioSessionInterruptionFlags flags);
 #endif
@@ -1717,19 +1717,19 @@ namespace XamCore.AVFoundation {
 		[Export ("averagePowerForChannel:")]
 		float AveragePower (nuint channelNumber); // defined as 'float'
 #if !MONOMAC
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("channelAssignments", ArgumentSemantic.Copy), NullAllowed]
 		AVAudioSessionChannelDescription [] ChannelAssignments { get; set; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("recordAtTime:")]
 		bool RecordAt (double time);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("recordAtTime:forDuration:")]
 		bool RecordAt (double time, double duration);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("deviceCurrentTime")]
 		double DeviceCurrentTime { get; }
 #endif
@@ -1761,12 +1761,12 @@ namespace XamCore.AVFoundation {
 
 		// Deprecated in iOS 6.0 but we have same C# signature as a method that was deprecated in iOS 8.0
 		[Availability (Deprecated = Platform.iOS_8_0)]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("audioRecorderEndInterruption:withFlags:")]
 		void EndInterruption (AVAudioRecorder recorder, AVAudioSessionInterruptionFlags flags);
 
 		//[Availability (Deprecated = Platform.iOS_8_0)]
-		//[Since (6,0)]
+		//[iOS (6,0)]
 		//[Export ("audioRecorderEndInterruption:withOptions:")]
 		//void EndInterruption (AVAudioRecorder recorder, AVAudioSessionInterruptionFlags flags);
 #endif
@@ -1827,11 +1827,11 @@ namespace XamCore.AVFoundation {
 		[Export ("category")]
 		NSString Category { get;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("mode")]
 		NSString Mode { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setMode:error:")]
 		bool SetMode (NSString mode, out NSError error);
 	
@@ -1884,27 +1884,27 @@ namespace XamCore.AVFoundation {
 		[Field ("AVAudioSessionCategoryAudioProcessing")]
 		NSString CategoryAudioProcessing { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("AVAudioSessionModeDefault")]
 		NSString ModeDefault { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("AVAudioSessionModeVoiceChat")]
 		NSString ModeVoiceChat { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("AVAudioSessionModeVideoRecording")]
 		NSString ModeVideoRecording { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("AVAudioSessionModeMeasurement")]
 		NSString ModeMeasurement { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("AVAudioSessionModeGameChat")]
 		NSString ModeGameChat { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("setActive:withOptions:error:")]
 		bool SetActive (bool active, AVAudioSessionSetActiveOptions options, out NSError outError);
 
@@ -1912,7 +1912,7 @@ namespace XamCore.AVFoundation {
 		[Export ("availableCategories")]
 		string [] AvailableCategories { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("setCategory:withOptions:error:")]
 		bool SetCategory (string category, AVAudioSessionCategoryOptions options, out NSError outError);
 		
@@ -1920,7 +1920,7 @@ namespace XamCore.AVFoundation {
 		[Export ("setCategory:mode:options:error:")]
 		bool SetCategory (string category, string mode, AVAudioSessionCategoryOptions options, out NSError outError);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("categoryOptions")]
 		AVAudioSessionCategoryOptions CategoryOptions { get;  }
 
@@ -1928,100 +1928,100 @@ namespace XamCore.AVFoundation {
 		[Export ("availableModes")]
 		string [] AvailableModes { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("overrideOutputAudioPort:error:")]
 		bool OverrideOutputAudioPort (AVAudioSessionPortOverride portOverride, out NSError outError);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("otherAudioPlaying")]
 		bool OtherAudioPlaying { [Bind ("isOtherAudioPlaying")] get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("currentRoute")]
 		AVAudioSessionRouteDescription CurrentRoute { get;  }
 
-		[NoWatch, Since (6,0)]
+		[NoWatch, iOS (6,0)]
 		[Export ("setPreferredSampleRate:error:")]
 		bool SetPreferredSampleRate (double sampleRate, out NSError error);
 		
-		[NoWatch, Since (6,0)]
+		[NoWatch, iOS (6,0)]
 		[Export ("preferredSampleRate")]
 		double PreferredSampleRate { get;  }
 
 		[NoWatch]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("inputGain")]
 		float InputGain { get;  } // defined as 'float'
 
 		[NoWatch]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("inputGainSettable")]
 		bool InputGainSettable { [Bind ("isInputGainSettable")] get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("inputAvailable")]
 		bool InputAvailable { [Bind ("isInputAvailable")] get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("sampleRate")]
 		double SampleRate { get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("inputNumberOfChannels")]
 		nint InputNumberOfChannels { get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("outputNumberOfChannels")]
 		nint OutputNumberOfChannels { get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("outputVolume")]
 		float OutputVolume { get;  } // defined as 'float'
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("inputLatency")]
 		double InputLatency { get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("outputLatency")]
 		double OutputLatency { get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("IOBufferDuration")]
 		double IOBufferDuration { get;  }
 
 		[NoWatch]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("setInputGain:error:")]
 		bool SetInputGain (float /* defined as 'float' */ gain, out NSError outError);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionInterruptionNotification")]
 		[Notification (typeof (AVAudioSessionInterruptionEventArgs))]
 		NSString InterruptionNotification { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionRouteChangeNotification")]
 		[Notification (typeof (AVAudioSessionRouteChangeEventArgs))]
 		NSString RouteChangeNotification { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionMediaServicesWereResetNotification")]
 		[Notification]
 		NSString MediaServicesWereResetNotification { get; }
 
-		[Since (7,0), Notification, Field ("AVAudioSessionMediaServicesWereLostNotification")]
+		[iOS (7,0), Notification, Field ("AVAudioSessionMediaServicesWereLostNotification")]
 		NSString MediaServicesWereLostNotification { get; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionCategoryMultiRoute")]
 		NSString CategoryMultiRoute { get; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionModeMoviePlayback")]
 		NSString ModeMoviePlayback { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("AVAudioSessionModeVideoChat")]
 		NSString ModeVideoChat { get; }
 
@@ -2029,177 +2029,177 @@ namespace XamCore.AVFoundation {
 		[Field ("AVAudioSessionModeSpokenAudio")]
 		NSString ModeSpokenAudio { get; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionPortLineIn")]
 		NSString PortLineIn { get; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionPortBuiltInMic")]
 		NSString PortBuiltInMic { get; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionPortHeadsetMic")]
 		NSString PortHeadsetMic { get; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionPortLineOut")]
 		NSString PortLineOut { get; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionPortHeadphones")]
 		NSString PortHeadphones { get; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionPortBluetoothA2DP")]
 		NSString PortBluetoothA2DP { get; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionPortBuiltInReceiver")]
 		NSString PortBuiltInReceiver { get; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionPortBuiltInSpeaker")]
 		NSString PortBuiltInSpeaker { get; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionPortHDMI")]
 		NSString PortHdmi { get; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionPortAirPlay")]
 		NSString PortAirPlay { get; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionPortBluetoothHFP")]
 		NSString PortBluetoothHfp { get; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("AVAudioSessionPortUSBAudio")]
 		NSString PortUsbAudio { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("AVAudioSessionPortBluetoothLE")]
 		NSString PortBluetoothLE { get; }
 
-		[Since (7,1)]
+		[iOS (7,1)]
 		[Field ("AVAudioSessionPortCarAudio")]
 		NSString PortCarAudio { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[UnifiedInternal, Field ("AVAudioSessionLocationUpper")]
 		NSString LocationUpper { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[UnifiedInternal, Field ("AVAudioSessionLocationLower")]
 		NSString LocationLower { get; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("inputDataSources"), NullAllowed]
 		AVAudioSessionDataSourceDescription [] InputDataSources { get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("inputDataSource")]
 		AVAudioSessionDataSourceDescription InputDataSource { get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("outputDataSources"), NullAllowed]
 		AVAudioSessionDataSourceDescription [] OutputDataSources { get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("outputDataSource")]
 		AVAudioSessionDataSourceDescription OutputDataSource { get;  }
 		
 		[NoWatch]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("setInputDataSource:error:")]
 		[PostGet ("InputDataSource")]
 		bool SetInputDataSource ([NullAllowed] AVAudioSessionDataSourceDescription dataSource, out NSError outError);
 
 		[NoWatch]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("setOutputDataSource:error:")]
 		[PostGet ("OutputDataSource")]
 		bool SetOutputDataSource ([NullAllowed] AVAudioSessionDataSourceDescription dataSource, out NSError outError);
 
 		[NoTV]
 		[Watch (4,0)]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("requestRecordPermission:")]
 		void RequestRecordPermission (AVPermissionGranted responseCallback);
 
-		[NoWatch, Since (7,0)]
+		[NoWatch, iOS (7,0)]
 		[Export ("setPreferredInput:error:")]
 		bool SetPreferredInput ([NullAllowed] AVAudioSessionPortDescription inPort, out NSError outError);
 
-		[NoWatch, Since (7,0)]
+		[NoWatch, iOS (7,0)]
 		[Export ("preferredInput", ArgumentSemantic.Copy), NullAllowed]
 		AVAudioSessionPortDescription PreferredInput { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("availableInputs")]
 		AVAudioSessionPortDescription [] AvailableInputs { get; }
 
 		[NoWatch]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("setPreferredInputNumberOfChannels:error:")]
 		bool SetPreferredInputNumberOfChannels (nint count, out NSError outError);
 	
 		[NoWatch]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("preferredInputNumberOfChannels")]
 		nint GetPreferredInputNumberOfChannels ();
 	
 		[NoWatch]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("setPreferredOutputNumberOfChannels:error:")]
 		bool SetPreferredOutputNumberOfChannels (nint count, out NSError outError);
 	
 		[NoWatch]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("preferredOutputNumberOfChannels")]
 		nint GetPreferredOutputNumberOfChannels ();
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("maximumInputNumberOfChannels")]
 		nint MaximumInputNumberOfChannels { get; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("maximumOutputNumberOfChannels")]
 		nint MaximumOutputNumberOfChannels { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[UnifiedInternal, Field ("AVAudioSessionOrientationTop")]
 		NSString OrientationTop { get; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[UnifiedInternal, Field ("AVAudioSessionOrientationBottom")]
 		NSString OrientationBottom { get; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[UnifiedInternal, Field ("AVAudioSessionOrientationFront")]
 		NSString OrientationFront { get; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[UnifiedInternal, Field ("AVAudioSessionOrientationBack")]
 		NSString OrientationBack { get; }
 
-		[Since (8,0)]
+		[iOS (8,0)]
 		[Field ("AVAudioSessionOrientationLeft")]
 		NSString OrientationLeft { get; }
 
-		[Since (8,0)]
+		[iOS (8,0)]
 		[Field ("AVAudioSessionOrientationRight")]
 		NSString OrientationRight { get; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[UnifiedInternal, Field ("AVAudioSessionPolarPatternOmnidirectional")]
 		NSString PolarPatternOmnidirectional { get; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[UnifiedInternal, Field ("AVAudioSessionPolarPatternCardioid")]
 		NSString PolarPatternCardioid { get; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[UnifiedInternal, Field ("AVAudioSessionPolarPatternSubcardioid")]
 		NSString PolarPatternSubcardioid { get; }
 
@@ -2231,7 +2231,7 @@ namespace XamCore.AVFoundation {
 		AVAudioSessionRouteSharingPolicy RouteSharingPolicy { get; }
 	}
 	
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVAudioSessionDataSourceDescription {
 		[Export ("dataSourceID")]
@@ -2241,42 +2241,42 @@ namespace XamCore.AVFoundation {
 		string DataSourceName { get;  }
 
 #if XAMCORE_2_0
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("location", ArgumentSemantic.Copy)]
 		[Internal]
 		NSString Location_ { get; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("orientation", ArgumentSemantic.Copy)]
 		[Internal]
 		NSString Orientation_ { get; }
 #else
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("location", ArgumentSemantic.Copy), NullAllowed]
 		string Location { get; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("orientation", ArgumentSemantic.Copy), NullAllowed]
 		string Orientation { get; }
 #endif
 
 		[NoWatch]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[UnifiedInternal, Export ("supportedPolarPatterns")]
 		NSString [] SupportedPolarPatterns { get; }
 	
 		[NoWatch]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[UnifiedInternal, Export ("selectedPolarPattern", ArgumentSemantic.Copy)]
 		NSString SelectedPolarPattern { get; }
 	
 		[NoWatch]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[UnifiedInternal, Export ("preferredPolarPattern", ArgumentSemantic.Copy)]
 		NSString PreferredPolarPattern { get; }
 	
 		[NoWatch]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[UnifiedInternal, Export ("setPreferredPolarPattern:error:")]
 		bool SetPreferredPolarPattern ([NullAllowed] NSString pattern, out NSError outError);
 		
@@ -2317,13 +2317,13 @@ namespace XamCore.AVFoundation {
 		[Export ("inputIsAvailableChanged:")]
 		void InputIsAvailableChanged (bool isInputAvailable);
 	
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("endInterruptionWithFlags:")]
 		void EndInterruption (AVAudioSessionInterruptionFlags flags);
 	}
 
 	[Watch (3,0)]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVAudioSessionChannelDescription {
 		[Export ("channelName")]
@@ -2335,13 +2335,13 @@ namespace XamCore.AVFoundation {
 		[Export ("channelNumber")]
 		nint ChannelNumber { get;  }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("channelLabel")]
 		int /* AudioChannelLabel = UInt32 */ ChannelLabel { get; }
 	}
 
 	[Watch (3,0)]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVAudioSessionPortDescription {
 		[Export ("portType")]
@@ -2360,7 +2360,7 @@ namespace XamCore.AVFoundation {
 		[Export ("channels"), NullAllowed]
 		AVAudioSessionChannelDescription [] Channels { get;  }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("dataSources"), NullAllowed]
 #if XAMCORE_4_0
 		AVAudioSessionDataSourceDescription [] DataSources { get; }
@@ -2369,24 +2369,24 @@ namespace XamCore.AVFoundation {
 #endif
 
 		[NoWatch]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("selectedDataSource", ArgumentSemantic.Copy), NullAllowed]
 		AVAudioSessionDataSourceDescription SelectedDataSource { get; }
 
 		[NoWatch]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("preferredDataSource", ArgumentSemantic.Copy), NullAllowed]
 		AVAudioSessionDataSourceDescription PreferredDataSource { get; }
 
 		[NoWatch]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("setPreferredDataSource:error:")]
 		bool SetPreferredDataSource ([NullAllowed] AVAudioSessionDataSourceDescription dataSource, out NSError outError);
 		
 	}
 
 	[Watch (3,0)]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVAudioSessionRouteDescription {
 		[Export ("inputs")]
@@ -2807,7 +2807,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** initialization method -init cannot be sent to an abstract object of class AVAsset: Create a concrete instance!
 	[DisableDefaultCtor]
@@ -2880,60 +2880,60 @@ namespace XamCore.AVFoundation {
 		[Wrap ("GetMetadataForFormat (new NSString (format.GetConstant ()))")]
 		AVMetadataItem [] GetMetadataForFormat (AVMetadataFormat format);
 
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("hasProtectedContent")]
 		bool ProtectedContent { get; }
 
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Export ("availableChapterLocales")]
 		NSLocale [] AvailableChapterLocales { get; }
 
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Export ("chapterMetadataGroupsWithTitleLocale:containingItemsWithCommonKeys:")]
 		AVTimedMetadataGroup [] GetChapterMetadataGroups (NSLocale forLocale, [NullAllowed] AVMetadataItem [] commonKeys);
 
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Export ("isPlayable")]
 		bool Playable { get; }
 
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Export ("isExportable")]
 		bool Exportable { get; }
 
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Export ("isReadable")]
 		bool Readable { get; }
 
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Export ("isComposable")]
 		bool Composable { get; }
 
 		// 5.0 APIs:
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Static, Export ("assetWithURL:")]
 		AVAsset FromUrl (NSUrl url);
 
-		[Since (5, 0)]
+		[iOS (5, 0)]
 		[Mac (10,8)]
 		[Export ("availableMediaCharacteristicsWithMediaSelectionOptions")]
 		string [] AvailableMediaCharacteristicsWithMediaSelectionOptions { get; }
 
 #if !MONOMAC
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("compatibleWithSavedPhotosAlbum")]
 		bool CompatibleWithSavedPhotosAlbum  { [Bind ("isCompatibleWithSavedPhotosAlbum")] get; }
 #endif
 
-		[Since (5, 0)]
+		[iOS (5, 0)]
 		[Mac (10,8)]
 		[Export ("creationDate"), NullAllowed]
 		AVMetadataItem CreationDate { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("referenceRestrictions")]
 		AVAssetReferenceRestrictions ReferenceRestrictions { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Mac (10,8)]
 		[return: NullAllowed]
 		[Export ("mediaSelectionGroupForMediaCharacteristic:")]
@@ -2949,12 +2949,12 @@ namespace XamCore.AVFoundation {
 		[Async ("LoadValuesTaskAsync")]
 		void LoadValuesAsynchronously (string [] keys, NSAction handler);
 
-		[Since (6, 0)]
+		[iOS (6, 0)]
 		[Mac (10,8)]
 		[Export ("chapterMetadataGroupsBestMatchingPreferredLanguages:")]
 		AVTimedMetadataGroup [] GetChapterMetadataGroupsBestMatchingPreferredLanguages (string [] languages);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,9)]
 		[Export ("trackGroups", ArgumentSemantic.Copy)]
 		AVAssetTrackGroup [] TrackGroups { get; }
@@ -3442,20 +3442,20 @@ namespace XamCore.AVFoundation {
 		NSString ApertureModeEncodedPixels { get; }
 
 		// 5.0 APIs
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("requestedTimeToleranceBefore", ArgumentSemantic.Assign)]
 		CMTime RequestedTimeToleranceBefore { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("requestedTimeToleranceAfter", ArgumentSemantic.Assign)]
 		CMTime RequestedTimeToleranceAfter { get; set;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Mac (10,9)]
 		[Export ("asset")]
 		AVAsset Asset { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,9)]
 		[Export ("customVideoCompositor", ArgumentSemantic.Copy), NullAllowed]
 		[Protocolize]
@@ -3463,7 +3463,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,1)]
+	[iOS (4,1)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[AVAssetReader initWithAsset:error:] invalid parameter not satisfying: asset != ((void*)0)
 	[DisableDefaultCtor]
@@ -3505,7 +3505,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,1)]
+	[iOS (4,1)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** initialization method -init cannot be sent to an abstract object of class AVAssetReaderOutput: Create a concrete instance!
 	[DisableDefaultCtor]
@@ -3517,7 +3517,7 @@ namespace XamCore.AVFoundation {
 		[Export ("copyNextSampleBuffer")]
 		CMSampleBuffer CopyNextSampleBuffer ();
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("alwaysCopiesSampleData")]
 		bool AlwaysCopiesSampleData { get; set; }
 
@@ -3573,7 +3573,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,1)]
+	[iOS (4,1)]
 	[BaseType (typeof (AVAssetReaderOutput))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[AVAssetReaderTrackOutput initWithTrack:outputSettings:] invalid parameter not satisfying: track != ((void*)0)
 	[DisableDefaultCtor]
@@ -3607,7 +3607,7 @@ namespace XamCore.AVFoundation {
 		[Export ("outputSettings"), NullAllowed]
 		NSDictionary OutputSettings { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,9)]
 		[Export ("audioTimePitchAlgorithm", ArgumentSemantic.Copy)]
 		// DOC: this is a AVAudioTimePitch value
@@ -3615,7 +3615,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,1)]
+	[iOS (4,1)]
 	[BaseType (typeof (AVAssetReaderOutput))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[AVAssetReaderAudioMixOutput initWithAudioTracks:audioSettings:] invalid parameter not satisfying: audioTracks != ((void*)0)
 	[DisableDefaultCtor]
@@ -3653,7 +3653,7 @@ namespace XamCore.AVFoundation {
 		[Wrap ("AudioSettings"), NullAllowed]
 		AudioSettings Settings { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10, 9)]
 		[Export ("audioTimePitchAlgorithm", ArgumentSemantic.Copy)]
 		// This is an AVAudioTimePitch constant
@@ -3661,7 +3661,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,1)]
+	[iOS (4,1)]
 	[BaseType (typeof (AVAssetReaderOutput))]
 	// crash application if 'init' is called
 	[DisableDefaultCtor]
@@ -3697,14 +3697,14 @@ namespace XamCore.AVFoundation {
 		[Wrap ("WeakVideoSettings"), NullAllowed]
 		CVPixelBufferAttributes UncompressedVideoSettings { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("customVideoCompositor", ArgumentSemantic.Copy), NullAllowed]
 		[Protocolize]
 		AVVideoCompositing CustomVideoCompositor { get; }
 	}
 
 	[NoWatch]
-	[Since (6,0), Mac (10, 9)]
+	[iOS (6,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 #if XAMCORE_2_0
 	[DisableDefaultCtor] // no valid handle, docs now says "You do not create resource loader objects yourself."
@@ -3727,7 +3727,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (6,0), Mac (10, 9)]
+	[iOS (6,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -3738,7 +3738,7 @@ namespace XamCore.AVFoundation {
 		[Export ("resourceLoader:shouldWaitForLoadingOfRequestedResource:")]
 		bool ShouldWaitForLoadingOfRequestedResource (AVAssetResourceLoader resourceLoader, AVAssetResourceLoadingRequest loadingRequest);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("resourceLoader:didCancelLoadingRequest:")]
 		void DidCancelLoadingRequest (AVAssetResourceLoader resourceLoader, AVAssetResourceLoadingRequest loadingRequest);
 
@@ -3756,7 +3756,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0), Mac (10, 9)]
+	[iOS (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // crash at 'description' - not meant to be used callable (it's used from a property getter)
 	interface AVAssetResourceLoadingDataRequest {
@@ -3778,7 +3778,7 @@ namespace XamCore.AVFoundation {
 	}
 	
 	[NoWatch]
-	[Since (6,0), Mac (10, 9)]
+	[iOS (6,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 #if XAMCORE_2_0
 	[DisableDefaultCtor] // not meant be be user created (resource loader job, see documentation)
@@ -3813,27 +3813,27 @@ namespace XamCore.AVFoundation {
 		NSString StreamingContentKeyRequestRequiresPersistentKey { get; }
 #endif
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("isCancelled")]
 		bool IsCancelled { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("contentInformationRequest"), NullAllowed]
 		AVAssetResourceLoadingContentInformationRequest ContentInformationRequest { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("dataRequest"), NullAllowed]
 		AVAssetResourceLoadingDataRequest DataRequest { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("response", ArgumentSemantic.Copy), NullAllowed]
 		NSUrlResponse Response { get; set; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("redirect", ArgumentSemantic.Copy), NullAllowed]
 		NSUrlRequest Redirect { get; set; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("finishLoading")]
 		void FinishLoading ();
 	}
@@ -3847,7 +3847,7 @@ namespace XamCore.AVFoundation {
 	
 
 	[NoWatch]
-	[Since (7,0), Mac (10, 9)]
+	[iOS (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 #if XAMCORE_2_0
 	[DisableDefaultCtor] // no valid handle, the instance is received (not created) -> see doc
@@ -3872,7 +3872,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,1)]
+	[iOS (4,1)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[AVAssetWriter initWithURL:fileType:error:] invalid parameter not satisfying: outputURL != ((void*)0)
 	[DisableDefaultCtor]
@@ -3948,7 +3948,7 @@ namespace XamCore.AVFoundation {
 		bool FinishWriting ();
 
 		[Mac (10,9)]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("finishWritingWithCompletionHandler:")]
 		[Async]
 		void FinishWriting (NSAction completionHandler);
@@ -3957,11 +3957,11 @@ namespace XamCore.AVFoundation {
 		int /* CMTimeScale = int32_t */ MovieTimeScale { get; set; }
 
 		[Mac (10,9)]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("canAddInputGroup:")]
 		bool CanAddInputGroup (AVAssetWriterInputGroup inputGroup);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,9)]
 		[Export ("addInputGroup:")]
 		void AddInputGroup (AVAssetWriterInputGroup inputGroup);
@@ -3976,36 +3976,36 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,1), Mac (10, 7)]
+	[iOS (4,1), Mac (10, 7)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[AVAssetWriterInput initWithMediaType:outputSettings:] invalid parameter not satisfying: mediaType != ((void*)0)
 	[DisableDefaultCtor]
 	interface AVAssetWriterInput {
-		[Since (6,0), Mac (10, 8)]
+		[iOS (6,0), Mac (10, 8)]
 		[DesignatedInitializer]
 		[Protected]
 		[Export ("initWithMediaType:outputSettings:sourceFormatHint:")]
 		IntPtr Constructor (string mediaType, [NullAllowed] NSDictionary outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
-		[Since (6,0), Mac (10, 8)]
+		[iOS (6,0), Mac (10, 8)]
 		[Wrap ("this (mediaType, outputSettings == null ? null : outputSettings.Dictionary, sourceFormatHint)")]
 		IntPtr Constructor (string mediaType, [NullAllowed] AudioSettings outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
-		[Since (6,0), Mac (10, 8)]
+		[iOS (6,0), Mac (10, 8)]
 		[Wrap ("this (mediaType, outputSettings == null ? null : outputSettings.Dictionary, sourceFormatHint)")]
 		IntPtr Constructor (string mediaType, [NullAllowed] AVVideoSettingsCompressed outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
-		[Since (6,0), Mac (10, 8)]
+		[iOS (6,0), Mac (10, 8)]
 		[Static, Internal]
 		[Export ("assetWriterInputWithMediaType:outputSettings:sourceFormatHint:")]
 		AVAssetWriterInput Create (string mediaType, [NullAllowed] NSDictionary outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
-		[Since (6,0), Mac (10, 8)]
+		[iOS (6,0), Mac (10, 8)]
 		[Static]
 		[Wrap ("Create(mediaType, outputSettings == null ? null : outputSettings.Dictionary, sourceFormatHint)")]
 		AVAssetWriterInput Create (string mediaType, [NullAllowed] AudioSettings outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
-		[Since (6,0), Mac (10, 8)]
+		[iOS (6,0), Mac (10, 8)]
 		[Static]
 		[Wrap ("Create(mediaType, outputSettings == null ? null : outputSettings.Dictionary, sourceFormatHint)")]
 		AVAssetWriterInput Create (string mediaType, [NullAllowed] AVVideoSettingsCompressed outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
@@ -4066,35 +4066,35 @@ namespace XamCore.AVFoundation {
 		[Export ("mediaTimeScale")]
 		int /* CMTimeScale = int32_t */ MediaTimeScale { get; set; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("languageCode", ArgumentSemantic.Copy), NullAllowed]
 		string LanguageCode { get; set; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("extendedLanguageTag", ArgumentSemantic.Copy), NullAllowed]
 		string ExtendedLanguageTag { get; set; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("naturalSize")]
 		CGSize NaturalSize { get; set; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("preferredVolume")]
 		float PreferredVolume { get; set; } // defined as 'float'
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("marksOutputTrackAsEnabled")]
 		bool MarksOutputTrackAsEnabled { get; set; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("canAddTrackAssociationWithTrackOfInput:type:")]
 		bool CanAddTrackAssociationWithTrackOfInput (AVAssetWriterInput input, NSString trackAssociationType);
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("addTrackAssociationWithTrackOfInput:type:")]
 		void AddTrackAssociationWithTrackOfInput (AVAssetWriterInput input, NSString trackAssociationType);
 		
-		[Since (6,0), Mac (10, 8)]
+		[iOS (6,0), Mac (10, 8)]
 		[Export ("sourceFormatHint"), NullAllowed]
 		CMFormatDescription SourceFormatHint { get; }
 
@@ -4172,7 +4172,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[DisableDefaultCtor] // Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[AVAssetWriterInputGroup initWithInputs:defaultInput:] invalid parameter not satisfying: inputs != ((void*)0)
-	[Since (7,0), Mavericks, BaseType (typeof (AVMediaSelectionGroup))]
+	[iOS (7,0), Mavericks, BaseType (typeof (AVMediaSelectionGroup))]
 	interface AVAssetWriterInputGroup {
 	
 		[Static, Export ("assetWriterInputGroupWithInputs:defaultInput:")]
@@ -4190,7 +4190,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,1)]
+	[iOS (4,1)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[AVAssetWriterInputPixelBufferAdaptor initWithAssetWriterInput:sourcePixelBufferAttributes:] invalid parameter not satisfying: input != ((void*)0)
 	[DisableDefaultCtor]
@@ -4240,7 +4240,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (AVAsset), Name="AVURLAsset")]
 	// 'init' returns NIL
 	[DisableDefaultCtor]
@@ -4285,23 +4285,23 @@ namespace XamCore.AVFoundation {
 		[Field ("AVURLAssetPreferPreciseDurationAndTimingKey")]
 		NSString PreferPreciseDurationAndTimingKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("AVURLAssetReferenceRestrictionsKey")]
 		NSString ReferenceRestrictionsKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Static, Export ("audiovisualMIMETypes")]
 		string [] AudiovisualMimeTypes { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Static, Export ("audiovisualTypes")]
 		string [] AudiovisualTypes { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Static, Export ("isPlayableExtendedMIMEType:")]
 		bool IsPlayable (string extendedMimeType);
 
-		[Since (6,0), Mac (10, 9)]
+		[iOS (6,0), Mac (10, 9)]
 		[Export ("resourceLoader")]
 		AVAssetResourceLoader ResourceLoader { get;  }
 
@@ -4403,20 +4403,20 @@ namespace XamCore.AVFoundation {
 		[Export ("metadataForFormat:")]
 		AVMetadataItem [] MetadataForFormat (string format);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("isPlayable")]
 		bool Playable { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("availableTrackAssociationTypes")]
 		NSString [] AvailableTrackAssociationTypes { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,10)]
 		[Export ("minFrameDuration")]
 		CMTime MinFrameDuration { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("associatedTracksOfType:")]
 		AVAssetTrack [] GetAssociatedTracks (NSString avAssetTrackTrackAssociationType);
 
@@ -4530,7 +4530,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0), Mac (10, 9)]
+	[iOS (7,0), Mac (10, 9)]
 	[Category, BaseType (typeof (AVAssetTrack))]
 	interface AVAssetTrackTrackAssociation {
 		[Field ("AVTrackAssociationTypeAudioFallback")]
@@ -4554,7 +4554,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0), Mac (10, 9)]
+	[iOS (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	interface AVAssetTrackGroup : NSCopying {
 		[Export ("trackIDs", ArgumentSemantic.Copy)]
@@ -4562,7 +4562,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (5,0), Mac (10, 8)]
+	[iOS (5,0), Mac (10, 8)]
 	[BaseType (typeof (NSObject))]
 	interface AVMediaSelectionGroup : NSCopying {
 		[Export ("options")]
@@ -4605,7 +4605,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (5,0), Mac (10, 8)]
+	[iOS (5,0), Mac (10, 8)]
 	[BaseType (typeof (NSObject))]
 	interface AVMediaSelectionOption : NSCopying {
 		[Export ("mediaType")]
@@ -4639,15 +4639,15 @@ namespace XamCore.AVFoundation {
 		[Export ("propertyList")]
 		NSObject PropertyList { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("displayName")]
 		string DisplayName { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("displayNameWithLocale:")]
 		string GetDisplayName (NSLocale locale);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("extendedLanguageTag"), NullAllowed]
 		string ExtendedLanguageTag { get; }
 	}
@@ -4847,7 +4847,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMetadataQuickTimeUserDataKeyPhonogramRights")]
 		NSString QuickTimeUserDataKeyPhonogramRights { get; }
 
-		[Mac (10, 8)][Since (5,0)]
+		[Mac (10, 8)][iOS (5,0)]
 		[Field ("AVMetadataQuickTimeUserDataKeyTaggedCharacteristic")]
 		NSString QuickTimeUserDataKeyTaggedCharacteristic { get; }
 		
@@ -4878,42 +4878,42 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMetadata3GPUserDataKeyDescription")]
 		NSString K3GPUserDataKeyDescription { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyCollection")]
 		NSString K3GPUserDataKeyCollection { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyUserRating")]
 		NSString K3GPUserDataKeyUserRating { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyThumbnail")]
 		NSString K3GPUserDataKeyThumbnail { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyAlbumAndTrack")]
 		NSString K3GPUserDataKeyAlbumAndTrack { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyKeywordList")]
 		NSString K3GPUserDataKeyKeywordList { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyMediaClassification")]
 		NSString K3GPUserDataKeyMediaClassification { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyMediaRating")]
 		NSString K3GPUserDataKeyMediaRating { get; }
 
 #if !XAMCORE_4_0
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVMetadataFormatISOUserData")]
 		[Obsolete ("Use 'AVMetadataFormat' enum values")]
 		NSString KFormatISOUserData { get; }
 #endif
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVMetadataKeySpaceISOUserData")]
 		NSString KKeySpaceISOUserData { get; }
 		
@@ -6400,7 +6400,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0)][Mac (10,7)]
+	[iOS (4,0)][Mac (10,7)]
 	[BaseType (typeof (NSObject))]
 	interface AVMetadataItem : NSMutableCopying {
 		[Export ("commonKey", ArgumentSemantic.Copy), NullAllowed]
@@ -6445,12 +6445,12 @@ namespace XamCore.AVFoundation {
 		AVMetadataItem [] FilterWithKey (AVMetadataItem [] metadataItems, NSObject key, string keySpace);
 
 #if !MONOMAC
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static, Export ("metadataItemsFromArray:filteredByMetadataItemFilter:")]
 		AVMetadataItem [] FilterWithItemFilter (AVMetadataItem [] metadataItems, AVMetadataItemFilter metadataItemFilter);
 #endif
 
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("duration")]
 		CMTime Duration { get; [NotImplemented] set; }
 
@@ -6461,7 +6461,7 @@ namespace XamCore.AVFoundation {
 		[Async ("LoadValuesTaskAsync")]
 		void LoadValuesAsynchronously (string [] keys, [NullAllowed] NSAction handler);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Static, Export ("metadataItemsFromArray:filteredAndSortedAccordingToPreferredLanguages:")]
 		AVMetadataItem [] FilterFromPreferredLanguages (AVMetadataItem [] metadataItems, string [] preferredLanguages);
 
@@ -6522,7 +6522,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0), Mac (10, 9)]
+	[iOS (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // for binary compatibility this is added in AVMetadataItemFilter.cs w/[Obsolete]
 	interface AVMetadataItemFilter {
@@ -6532,7 +6532,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[Since (6,0)][Mac (10,10, onlyOn64:true)]
+	[iOS (6,0)][Mac (10,10, onlyOn64:true)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: Cannot instantiate AVMetadataObject because it is an abstract superclass.
 	[DisableDefaultCtor]
@@ -6596,22 +6596,22 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMetadataObjectTypeUPCECode")]
 		NSString TypeUPCECode { get; }
 
-		[NoTV, Since (8,0), NoMac]
+		[NoTV, iOS (8,0), NoMac]
 		[Field ("AVMetadataObjectTypeInterleaved2of5Code")]
 		NSString TypeInterleaved2of5Code { get; }
 		
-		[NoTV, Since (8,0), NoMac]
+		[NoTV, iOS (8,0), NoMac]
 		[Field ("AVMetadataObjectTypeITF14Code")]
 		NSString TypeITF14Code { get; }
 		
-		[NoTV, Since (8,0), NoMac]
+		[NoTV, iOS (8,0), NoMac]
 		[Field ("AVMetadataObjectTypeDataMatrixCode")]
 		NSString TypeDataMatrixCode { get; }
 	}
 
 	[NoWatch]
 	[NoTV]
-	[Since (6,0)][Mac (10,10, onlyOn64:true)]
+	[iOS (6,0)][Mac (10,10, onlyOn64:true)]
 	[BaseType (typeof (AVMetadataObject))]
 	interface AVMetadataFaceObject : NSCopying {
 		[Export ("hasRollAngle")]
@@ -6633,7 +6633,7 @@ namespace XamCore.AVFoundation {
 	[NoWatch]
 	[NoTV]
 	[NoMac]
-	[Since (7,0), BaseType (typeof (AVMetadataObject))]
+	[iOS (7,0), BaseType (typeof (AVMetadataObject))]
 	interface AVMetadataMachineReadableCodeObject {
 		[NullAllowed]
 		[Export ("corners", ArgumentSemantic.Copy)]
@@ -7143,7 +7143,7 @@ namespace XamCore.AVFoundation {
 #endif
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (AVMetadataItem))]
 	interface AVMutableMetadataItem {
 		[NullAllowed] // by default this property is null
@@ -7154,7 +7154,7 @@ namespace XamCore.AVFoundation {
 		[Export ("metadataItem"), Static]
 		AVMutableMetadataItem Create ();
 
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("duration")]
 		[Override]
 		CMTime Duration { get; set; }
@@ -7207,7 +7207,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (AVAssetTrack))]
 	// 'init' returns NIL
 	[DisableDefaultCtor]
@@ -7217,7 +7217,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (AVCompositionTrack))]
 	// 'init' returns NIL
 	[DisableDefaultCtor]
@@ -7262,7 +7262,7 @@ namespace XamCore.AVFoundation {
 		float PreferredVolume { get; set; } // defined as 'float'
 
 		// 5.0
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("insertTimeRanges:ofTracks:atTime:error:")]
 		bool InsertTimeRanges (NSValue[] cmTimeRanges, AVAssetTrack [] tracks, CMTime startTime, out NSError error);
 	}
@@ -7317,7 +7317,7 @@ namespace XamCore.AVFoundation {
 	}
 	
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVAssetTrackSegment {
 		[Export ("empty")]
@@ -7329,7 +7329,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (AVAsset))]
 	interface AVComposition : NSMutableCopying {
 		[Export ("tracks")]
@@ -7369,7 +7369,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (AVComposition))]
 	interface AVMutableComposition {
 		
@@ -7431,7 +7431,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (AVAssetTrackSegment))]
 	interface AVCompositionTrackSegment {
 		[Export ("sourceURL"), NullAllowed]
@@ -7461,7 +7461,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	// 'init' returns NIL
 	[DisableDefaultCtor]
@@ -7591,15 +7591,15 @@ namespace XamCore.AVFoundation {
 		NSString PresetPassthrough { get; }
 
 		// 5.0 APIs
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("asset", ArgumentSemantic.Retain)]
 		AVAsset Asset { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("estimatedOutputFileLength")]
 		long EstimatedOutputFileLength { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Mac (10, 9)]
 		[Static, Export ("determineCompatibilityOfExportPreset:withAsset:outputFileType:completionHandler:")]
 		[Async]
@@ -7609,7 +7609,7 @@ namespace XamCore.AVFoundation {
 		[Wrap ("DetermineCompatibilityOfExportPreset (presetName, asset, outputFileType.GetConstant (), isCompatibleResult)")]
 		void DetermineCompatibilityOfExportPreset (string presetName, AVAsset asset, [NullAllowed] AVFileTypes outputFileType, Action<bool> isCompatibleResult);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Mac (10, 9)]
 		[Export ("determineCompatibleFileTypesWithCompletionHandler:")]
 		[Async]
@@ -7620,14 +7620,14 @@ namespace XamCore.AVFoundation {
 		AVMetadataItemFilter MetadataItemFilter { get; set; }
 
 		[Mac (10,9)]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("customVideoCompositor", ArgumentSemantic.Copy)]
 		[Protocolize]
 		AVVideoCompositing CustomVideoCompositor { get; }
 
 		// DOC: Use the values from AVAudioTimePitchAlgorithm class.
 		[Mac (10,9)]
-		[Since (7, 0), Export ("audioTimePitchAlgorithm", ArgumentSemantic.Copy)]
+		[iOS (7, 0), Export ("audioTimePitchAlgorithm", ArgumentSemantic.Copy)]
 		NSString AudioTimePitchAlgorithm { get; set; }
 
 		[iOS (8,0), Mac (10,10)]
@@ -7642,7 +7642,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Static]
 	interface AVAudioTimePitchAlgorithm {
 		[NoMac]
@@ -7664,14 +7664,14 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	interface AVAudioMix : NSMutableCopying {
 		[Export ("inputParameters", ArgumentSemantic.Copy)]
 		AVAudioMixInputParameters [] InputParameters { get;  }
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (AVAudioMix))]
 	interface AVMutableAudioMix {
 		[NullAllowed] // by default this property is null
@@ -7683,7 +7683,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVAudioMixInputParameters : NSMutableCopying {
 		[Export ("trackID")]
@@ -7737,7 +7737,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
 	interface AVVideoCompositing {
@@ -7767,7 +7767,7 @@ namespace XamCore.AVFoundation {
 	}
 	
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVVideoComposition : NSMutableCopying {
 		[Export ("frameDuration")]
@@ -7785,15 +7785,15 @@ namespace XamCore.AVFoundation {
 		[Export ("renderScale")]
 		float RenderScale { get; [NotImplemented] set; } // defined as 'float'
 #endif
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("isValidForAsset:timeRange:validationDelegate:")]
 		bool IsValidForAsset ([NullAllowed] AVAsset asset, CMTimeRange timeRange, [Protocolize] [NullAllowed] AVVideoCompositionValidationHandling validationDelegate);
 
-		[Since (6,0), Mac (10, 9)]
+		[iOS (6,0), Mac (10, 9)]
 		[Static, Export ("videoCompositionWithPropertiesOfAsset:")]
 		AVVideoComposition FromAssetProperties (AVAsset asset);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("customVideoCompositorClass", ArgumentSemantic.Copy), NullAllowed]
 		Class CustomVideoCompositorClass { get; [NotImplemented] set; }
 
@@ -7816,7 +7816,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0), Mac (10, 9)]
+	[iOS (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	interface AVVideoCompositionRenderContext {
 		[Export ("size", ArgumentSemantic.Copy)]
@@ -7846,7 +7846,7 @@ namespace XamCore.AVFoundation {
 	}
 	
 	[NoWatch]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -7866,7 +7866,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (AVVideoComposition))]
 	interface AVMutableVideoComposition {
 		[Export ("frameDuration", ArgumentSemantic.Assign)]
@@ -7890,12 +7890,12 @@ namespace XamCore.AVFoundation {
 		AVMutableVideoComposition Create ();
 
 		// in 7.0 they declared this was available in 6.0
-		[Since (6,0), Mac (10, 9)]
+		[iOS (6,0), Mac (10, 9)]
 		[Static, Export ("videoCompositionWithPropertiesOfAsset:")]
 		AVMutableVideoComposition Create (AVAsset asset);
 
 		[NullAllowed]
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("customVideoCompositorClass", ArgumentSemantic.Retain)]
 		[Override]
 		Class CustomVideoCompositorClass { get; set; }
@@ -7923,7 +7923,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0), Mac (10, 7)]
+	[iOS (4,0), Mac (10, 7)]
 	[BaseType (typeof (NSObject))]
 	interface AVVideoCompositionInstruction : NSSecureCoding, NSMutableCopying {
 		[Export ("timeRange")]
@@ -7943,21 +7943,21 @@ namespace XamCore.AVFoundation {
 
 		// These are there because it adopts the protocol *of the same name*
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("containsTweening")]
 		bool ContainsTweening { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("requiredSourceTrackIDs")]
 		NSNumber[] RequiredSourceTrackIDs { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("passthroughTrackID")]
 		int PassthroughTrackID { get; } /* CMPersistentTrackID = int32_t */
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (AVVideoCompositionInstruction))]
 	interface AVMutableVideoCompositionInstruction {
 		[Export ("timeRange", ArgumentSemantic.Assign)]
@@ -7983,7 +7983,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0), Mac (10, 7)]
+	[iOS (4,0), Mac (10, 7)]
 	[BaseType (typeof (NSObject))]
 	interface AVVideoCompositionLayerInstruction : NSSecureCoding, NSMutableCopying {
 		[Export ("trackID", ArgumentSemantic.Assign)]
@@ -7995,12 +7995,12 @@ namespace XamCore.AVFoundation {
 		[Export ("getOpacityRampForTime:startOpacity:endOpacity:timeRange:")]
 		bool GetOpacityRamp (CMTime time, ref float /* defined as 'float*' */ startOpacity, ref float /* defined as 'float*' */ endOpacity, ref CMTimeRange timeRange);
 
-		[Since (7,0), Mavericks, Export ("getCropRectangleRampForTime:startCropRectangle:endCropRectangle:timeRange:")]
+		[iOS (7,0), Mavericks, Export ("getCropRectangleRampForTime:startCropRectangle:endCropRectangle:timeRange:")]
 		bool GetCrop (CMTime time, ref CGRect startCropRectangle, ref CGRect endCropRectangle, ref CMTimeRange timeRange);
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (AVVideoCompositionLayerInstruction))]
 	interface AVMutableVideoCompositionLayerInstruction {
 		[Export ("trackID", ArgumentSemantic.Assign)]
@@ -8026,17 +8026,17 @@ namespace XamCore.AVFoundation {
 		[Export ("setOpacity:atTime:")]
 		void SetOpacity (float /* defined as 'float' */ opacity, CMTime time);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("setCropRectangleRampFromStartCropRectangle:toEndCropRectangle:timeRange:")]
 		void SetCrop (CGRect startCropRectangle, CGRect endCropRectangle, CMTimeRange timeRange);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("setCropRectangle:atTime:")]
 		void SetCrop (CGRect cropRectangle, CMTime time);
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVVideoCompositionCoreAnimationTool {
 		[Static]
@@ -8047,7 +8047,7 @@ namespace XamCore.AVFoundation {
 		[Export ("videoCompositionCoreAnimationToolWithPostProcessingAsVideoLayer:inLayer:")]
 		AVVideoCompositionCoreAnimationTool FromLayer (CALayer videoLayer, CALayer animationLayer);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Static, Export ("videoCompositionCoreAnimationToolWithPostProcessingAsVideoLayers:inLayer:")]
 		AVVideoCompositionCoreAnimationTool FromComposedVideoFrames (CALayer [] videoLayers, CALayer inAnimationlayer);
 	}
@@ -8087,7 +8087,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVCaptureSession {
 
@@ -8154,11 +8154,11 @@ namespace XamCore.AVFoundation {
 		[Field ("AVCaptureSessionPreset640x480")]
 		NSString Preset640x480 { get; }
 		
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("AVCaptureSessionPreset1280x720")]
 		NSString Preset1280x720 { get; }
 #if !MONOMAC
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("AVCaptureSessionPreset1920x1080")]
 		NSString Preset1920x1080 { get; }
 
@@ -8167,20 +8167,20 @@ namespace XamCore.AVFoundation {
 		NSString Preset3840x2160 { get; }
 #endif
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("AVCaptureSessionPresetiFrame960x540")]
 		NSString PresetiFrame960x540 { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("AVCaptureSessionPresetiFrame1280x720")]
 		NSString PresetiFrame1280x720 { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("AVCaptureSessionPreset352x288")]
 		NSString Preset352x288 { get; }
 
 #if !MONOMAC
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("AVCaptureSessionPresetInputPriority")]
 		NSString PresetInputPriority { get; }
 #endif
@@ -8221,11 +8221,11 @@ namespace XamCore.AVFoundation {
 		[Field ("AVCaptureSessionInterruptionReasonKey")]
 		NSString InterruptionReasonKey { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("usesApplicationAudioSession")]
 		bool UsesApplicationAudioSession { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("automaticallyConfiguresApplicationAudioSession")]
 		bool AutomaticallyConfiguresApplicationAudioSession { get; set; }
 		
@@ -8238,7 +8238,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVCaptureSessionInterruptionSystemPressureStateKey")]
 		NSString InterruptionSystemPressureStateKey { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("masterClock")]
 		CMClock MasterClock { get; }
 
@@ -8269,7 +8269,7 @@ namespace XamCore.AVFoundation {
 	[NoWatch]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	interface AVCaptureConnection {
 		
 		[iOS (8,0), Mac (10,7)]
@@ -8317,54 +8317,54 @@ namespace XamCore.AVFoundation {
 		[Export ("isVideoOrientationSupported")]
 		bool SupportsVideoOrientation { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("supportsVideoMinFrameDuration"), Internal]
 		bool _SupportsVideoMinFrameDuration { [Bind ("isVideoMinFrameDurationSupported")] get;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0 /* Only deprecated on iOS */)]
 		[Mac (10, 7)]
 		[Export ("videoMinFrameDuration")]
 		CMTime VideoMinFrameDuration { get; set;  }
 #if !MONOMAC
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("supportsVideoMaxFrameDuration"), Internal]
 		bool _SupportsVideoMaxFrameDuration { [Bind ("isVideoMaxFrameDurationSupported")] get;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("videoMaxFrameDuration")]
 		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0 /* Only deprecated on iOS */)] 
 		[Mac (10, 7)] 
 		CMTime VideoMaxFrameDuration { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("videoMaxScaleAndCropFactor")]
 		nfloat VideoMaxScaleAndCropFactor { get;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("videoScaleAndCropFactor")]
 		nfloat VideoScaleAndCropFactor { get; set;  }
 #endif
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("videoPreviewLayer")]
 		AVCaptureVideoPreviewLayer VideoPreviewLayer { get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("automaticallyAdjustsVideoMirroring")]
 		bool AutomaticallyAdjustsVideoMirroring { get; set;  }
 #if !MONOMAC
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("supportsVideoStabilization")]
 		bool SupportsVideoStabilization { [Bind ("isVideoStabilizationSupported")] get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("videoStabilizationEnabled")]
 		[Availability (Deprecated = Platform.iOS_8_0, Message="Use 'ActiveVideoStabilizationMode' instead.")]
 		bool VideoStabilizationEnabled { [Bind ("isVideoStabilizationEnabled")] get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Availability (Deprecated = Platform.iOS_8_0, Message="Use 'PreferredVideoStabilizationMode' instead.")]
 		[Export ("enablesVideoStabilizationWhenAvailable")]
 		bool EnablesVideoStabilizationWhenAvailable { get; set;  }
@@ -8399,7 +8399,7 @@ namespace XamCore.AVFoundation {
 	[NoWatch]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	interface AVCaptureAudioChannel {
 		[Export ("peakHoldLevel")]
 		float PeakHoldLevel { get;  } // defined as 'float'
@@ -8419,7 +8419,7 @@ namespace XamCore.AVFoundation {
 	[NoWatch]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: Cannot instantiate AVCaptureInput because it is an abstract superclass.
 	[DisableDefaultCtor]
 	interface AVCaptureInput {
@@ -8433,7 +8433,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface AVCaptureInputPort {
@@ -8449,7 +8449,7 @@ namespace XamCore.AVFoundation {
 		[Export ("input")]
 		AVCaptureInput Input  { get; }
 
-		[Since (7,0), Mavericks, Export ("clock", ArgumentSemantic.Copy)]
+		[iOS (7,0), Mavericks, Export ("clock", ArgumentSemantic.Copy)]
 		CMClock Clock { get; }
 	}
 
@@ -8492,7 +8492,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (AVCaptureInput))]
 	// crash application if 'init' is called
 	[DisableDefaultCtor]
@@ -8586,7 +8586,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 #if XAMCORE_4_0
 	[Abstract] // as per docs
@@ -8597,20 +8597,20 @@ namespace XamCore.AVFoundation {
 		[Export ("connections")]
 		AVCaptureConnection [] Connections { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("connectionWithMediaType:")]
 		AVCaptureConnection ConnectionFromMediaType (NSString avMediaType);
 
 #if !MONOMAC
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("metadataOutputRectOfInterestForRect:")]
 		CGRect GetMetadataOutputRectOfInterestForRect (CGRect rectInOutputCoordinates);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("rectForMetadataOutputRectOfInterest:")]
 		CGRect GetRectForMetadataOutputRectOfInterest (CGRect rectInMetadataOutputCoordinates);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("transformedMetadataObjectForMetadataObject:connection:")]
 		AVMetadataObject GetTransformedMetadataObject (AVMetadataObject metadataObject, AVCaptureConnection connection);
 #endif
@@ -8650,7 +8650,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (CALayer))]
 	interface AVCaptureVideoPreviewLayer {
 		[NullAllowed] // by default this property is null
@@ -8705,26 +8705,26 @@ namespace XamCore.AVFoundation {
 		[Export ("initWithSessionWithNoConnection:")]
 		IntPtr InitWithNoConnection (AVCaptureSession session);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("connection")]
 		AVCaptureConnection Connection { get; }
 #if !MONOMAC
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("captureDevicePointOfInterestForPoint:")]
 		CGPoint CaptureDevicePointOfInterestForPoint (CGPoint pointInLayer);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("pointForCaptureDevicePointOfInterest:")]
 		CGPoint PointForCaptureDevicePointOfInterest (CGPoint captureDevicePointOfInterest);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("transformedMetadataObjectForMetadataObject:")]
 		AVMetadataObject GetTransformedMetadataObject (AVMetadataObject metadataObject);
 
-		[Since (7,0), Export ("metadataOutputRectOfInterestForRect:")]
+		[iOS (7,0), Export ("metadataOutputRectOfInterestForRect:")]
 		CGRect MapToMetadataOutputCoordinates (CGRect rectInLayerCoordinates);
 		
-		[Since (7,0), Export ("rectForMetadataOutputRectOfInterest:")]
+		[iOS (7,0), Export ("rectForMetadataOutputRectOfInterest:")]
 		CGRect MapToLayerCoordinates (CGRect rectInMetadataOutputCoordinates);
 #endif
 
@@ -8736,7 +8736,7 @@ namespace XamCore.AVFoundation {
 
 	[NoTV]
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (AVCaptureOutput))]
 	interface AVCaptureVideoDataOutput {
 		[Export ("sampleBufferDelegate")]
@@ -8787,7 +8787,7 @@ namespace XamCore.AVFoundation {
 		NSString [] AvailableVideoCodecTypes { get;  }
 
 #if !MONOMAC
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("recommendedVideoSettingsForAssetWriterWithOutputFileType:")]
 		NSDictionary GetRecommendedVideoSettingsForAssetWriter (string outputFileType);
 #endif
@@ -8810,7 +8810,7 @@ namespace XamCore.AVFoundation {
 	[NoWatch]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Model]
 	[Protocol]
 	interface AVCaptureVideoDataOutputSampleBufferDelegate {
@@ -8818,7 +8818,7 @@ namespace XamCore.AVFoundation {
 		// CMSampleBufferRef		
 		void DidOutputSampleBuffer (AVCaptureOutput captureOutput, CMSampleBuffer sampleBuffer, AVCaptureConnection connection);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("captureOutput:didDropSampleBuffer:fromConnection:")]
 		void DidDropSampleBuffer (AVCaptureOutput captureOutput, CMSampleBuffer sampleBuffer, AVCaptureConnection connection);
 	}
@@ -8827,7 +8827,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (AVCaptureOutput))]
 	interface AVCaptureAudioDataOutput {
 		[Export ("sampleBufferDelegate")]
@@ -8855,7 +8855,7 @@ namespace XamCore.AVFoundation {
 #endif
 
 #if !MONOMAC
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("recommendedAudioSettingsForAssetWriterWithOutputFileType:")]
 		NSDictionary GetRecommendedAudioSettingsForAssetWriter (string outputFileType);
 #endif
@@ -8871,7 +8871,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -8927,7 +8927,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[BaseType (typeof (AVCaptureOutput))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: Cannot instantiate AVCaptureFileOutput because it is an abstract superclass.
 	[DisableDefaultCtor]
 	[NoTV]
@@ -8972,7 +8972,7 @@ namespace XamCore.AVFoundation {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Since (4, 0)]
+	[iOS (4, 0)]
 	[Protocol]
 	[NoTV]
 	[NoWatch]
@@ -9001,7 +9001,7 @@ namespace XamCore.AVFoundation {
 #if !MONOMAC
 	[NoWatch]
 	[NoTV]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (AVCaptureOutput))]
 	interface AVCaptureMetadataOutput {
 		[Export ("metadataObjectsDelegate")]
@@ -9029,7 +9029,7 @@ namespace XamCore.AVFoundation {
 		[Export ("setMetadataObjectsDelegate:queue:")]
 		void SetDelegate ([NullAllowed][Protocolize] AVCaptureMetadataOutputObjectsDelegate objectsDelegate, [NullAllowed] DispatchQueue objectsCallbackQueue);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("rectOfInterest", ArgumentSemantic.Copy)]
 		CGRect RectOfInterest { get; set; }
 		
@@ -9037,7 +9037,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -9379,7 +9379,7 @@ namespace XamCore.AVFoundation {
 	}
 #endif
 	
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (AVCaptureFileOutput))]
 	[NoTV]
 	[NoWatch]
@@ -9416,7 +9416,7 @@ namespace XamCore.AVFoundation {
 
 	[NoTV]
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_10_0, Message = "Use 'AVCapturePhotoOutput' instead.")]
 	[BaseType (typeof (AVCaptureOutput))]
 	interface AVCaptureStillImageOutput {
@@ -9447,27 +9447,27 @@ namespace XamCore.AVFoundation {
 		bool CapturingStillImage { [Bind ("isCapturingStillImage")] get;  }
 
 #if !MONOMAC
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("automaticallyEnablesStillImageStabilizationWhenAvailable")]
 		bool AutomaticallyEnablesStillImageStabilizationWhenAvailable { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("stillImageStabilizationActive")]
 		bool IsStillImageStabilizationActive { [Bind ("isStillImageStabilizationActive")] get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("stillImageStabilizationSupported")]
 		bool IsStillImageStabilizationSupported { [Bind ("isStillImageStabilizationSupported")] get; }
 
-		[Since (8,0)]
+		[iOS (8,0)]
 		[Export ("captureStillImageBracketAsynchronouslyFromConnection:withSettingsArray:completionHandler:")]
 		void CaptureStillImageBracket (AVCaptureConnection connection, AVCaptureBracketedStillImageSettings [] settings, Action<CMSampleBuffer, AVCaptureBracketedStillImageSettings, NSError> imageHandler);
 
-		[Since (8,0)]
+		[iOS (8,0)]
 		[Export ("maxBracketedCaptureStillImageCount")]
 		nuint MaxBracketedCaptureStillImageCount { get; }
 
-		[Since (8,0)]
+		[iOS (8,0)]
 		[Export ("prepareToCaptureStillImageBracketFromConnection:withSettingsArray:completionHandler:")]
 		void PrepareToCaptureStillImageBracket (AVCaptureConnection connection, AVCaptureBracketedStillImageSettings [] settings, Action<bool,NSError> handler);
 
@@ -9534,7 +9534,7 @@ namespace XamCore.AVFoundation {
 	[NoWatch]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: Cannot instantiate a AVCaptureDevice directly.
 	[DisableDefaultCtor]
 	interface AVCaptureDevice {
@@ -9657,7 +9657,7 @@ namespace XamCore.AVFoundation {
 		[Notification]
 		NSString WasDisconnectedNotification { get; }
 
-		[Since (6, 0)]
+		[iOS (6, 0)]
 		[NoMac]
 		[Field ("AVCaptureMaxAvailableTorchLevel")]
 		float MaxAvailableTorchLevel { get; } // defined as 'float'
@@ -9688,59 +9688,59 @@ namespace XamCore.AVFoundation {
 		float TorchLevel { get; } // defined as 'float'
 
 		// 6.0
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("torchActive")]
 		bool TorchActive { [Bind ("isTorchActive")] get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("setTorchModeOnWithLevel:error:")]
 		bool SetTorchModeLevel (float /* defined as 'float' */ torchLevel, out NSError outError);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("lowLightBoostSupported")]
 		bool LowLightBoostSupported { [Bind ("isLowLightBoostSupported")] get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("lowLightBoostEnabled")]
 		bool LowLightBoostEnabled { [Bind ("isLowLightBoostEnabled")] get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("automaticallyEnablesLowLightBoostWhenAvailable")]
 		bool AutomaticallyEnablesLowLightBoostWhenAvailable { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("videoZoomFactor")]
 		nfloat VideoZoomFactor { get; set; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("rampToVideoZoomFactor:withRate:")]
 		void RampToVideoZoom (nfloat factor, float /* float, not CGFloat */ rate);
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("rampingVideoZoom")]
 		bool RampingVideoZoom { [Bind ("isRampingVideoZoom")] get; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("cancelVideoZoomRamp")]
 		void CancelVideoZoomRamp ();
 			
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("autoFocusRangeRestrictionSupported")]
 		bool AutoFocusRangeRestrictionSupported { [Bind ("isAutoFocusRangeRestrictionSupported")] get; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("autoFocusRangeRestriction")]
 		AVCaptureAutoFocusRangeRestriction AutoFocusRangeRestriction { get; set; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("smoothAutoFocusSupported")]
 		bool SmoothAutoFocusSupported { [Bind ("isSmoothAutoFocusSupported")] get; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("smoothAutoFocusEnabled")]
 		bool SmoothAutoFocusEnabled { [Bind ("isSmoothAutoFocusEnabled")] get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static, Export ("authorizationStatusForMediaType:")]
 		AVAuthorizationStatus GetAuthorizationStatus (NSString avMediaTypeToken);
 
@@ -9750,7 +9750,7 @@ namespace XamCore.AVFoundation {
 		[Wrap ("GetAuthorizationStatus (mediaType == AVAuthorizationMediaType.Video ? AVMediaTypes.Video.GetConstant () : AVMediaTypes.Audio.GetConstant ())")]
 		AVAuthorizationStatus GetAuthorizationStatus (AVAuthorizationMediaType mediaType);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static, Export ("requestAccessForMediaType:completionHandler:")]
 		[Async]
 		void RequestAccessForMediaType (NSString avMediaTypeToken, AVRequestAccessStatus completion);
@@ -9763,11 +9763,11 @@ namespace XamCore.AVFoundation {
 		void RequestAccessForMediaType (AVAuthorizationMediaType mediaType, AVRequestAccessStatus completion);
 #endif
 
-		[Since (7,0)][Mac (10,7)]
+		[iOS (7,0)][Mac (10,7)]
 		[Export ("activeFormat", ArgumentSemantic.Retain)]
 		AVCaptureDeviceFormat ActiveFormat { get; set; }
 
-		[Since (7,0)][Mac (10,7)]
+		[iOS (7,0)][Mac (10,7)]
 		[Export ("formats")]
 		AVCaptureDeviceFormat [] Formats { get; }
 
@@ -9825,12 +9825,12 @@ namespace XamCore.AVFoundation {
 		AVCaptureDeviceTransportControlsPlaybackMode TransportControlsPlaybackMode { get; }
 #endif
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,9)]
 		[Export ("activeVideoMinFrameDuration", ArgumentSemantic.Copy)]
 		CMTime ActiveVideoMinFrameDuration { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,9)]
 		[Export ("activeVideoMaxFrameDuration", ArgumentSemantic.Copy)]
 		CMTime ActiveVideoMaxFrameDuration { get; set; }
@@ -10047,7 +10047,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[Since (7,0), Mac(10,7)]
+	[iOS (7,0), Mac(10,7)]
 	[DisableDefaultCtor] // crash -> immutable, it can be set but it should be selected from tha available formats (not a custom one)
 	[BaseType (typeof (NSObject))]
 	interface AVCaptureDeviceFormat {
@@ -10137,7 +10137,7 @@ namespace XamCore.AVFoundation {
 	delegate void AVCaptureCompletionHandler (CMSampleBuffer imageDataSampleBuffer, NSError error);
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVPlayer {
 		[Export ("currentItem"), NullAllowed]
@@ -10230,21 +10230,21 @@ namespace XamCore.AVFoundation {
 		bool UsesAirPlayVideoWhileAirPlayScreenIsActive { get; set;  }
 #endif
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("seekToTime:completionHandler:")]
 		[Async]
 		void Seek (CMTime time, AVCompletion completion);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("seekToTime:toleranceBefore:toleranceAfter:completionHandler:")]
 		[Async]
 		void Seek (CMTime time, CMTime toleranceBefore, CMTime toleranceAfter, AVCompletion completion);
 
-		[Since (6,0), Mac (10,9)]
+		[iOS (6,0), Mac (10,9)]
 		[Export ("seekToDate:")]
 		void Seek (NSDate date);
 
-		[Since (6,0), Mac (10,7)]
+		[iOS (6,0), Mac (10,7)]
 		[Export ("seekToDate:completionHandler:")]
 		[Async]
 		void Seek (NSDate date, AVCompletion onComplete);
@@ -10253,24 +10253,24 @@ namespace XamCore.AVFoundation {
 		[Export ("automaticallyWaitsToMinimizeStalling")]
 		bool AutomaticallyWaitsToMinimizeStalling { get; set; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("setRate:time:atHostTime:")]
 		void SetRate (float /* defined as 'float' */ rate, CMTime itemTime, CMTime hostClockTime);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("prerollAtRate:completionHandler:")]
 		[Async]
 		void Preroll (float /* defined as 'float' */ rate, AVCompletion onComplete);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("cancelPendingPrerolls")]
 		void CancelPendingPrerolls ();
 
-		[Since (6,0), Mac (10,12)]
+		[iOS (6,0), Mac (10,12)]
 		[Export ("outputObscuredDueToInsufficientExternalProtection")]
 		bool OutputObscuredDueToInsufficientExternalProtection { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("masterClock"), NullAllowed]
 		CMClock MasterClock { get; set; }
 
@@ -10283,35 +10283,35 @@ namespace XamCore.AVFoundation {
 		bool ExternalPlaybackActive { [Bind ("isExternalPlaybackActive")] get; }
 
 #if !MONOMAC
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("usesExternalPlaybackWhileExternalScreenIsActive")]
 		bool UsesExternalPlaybackWhileExternalScreenIsActive { get; set;  }
 #endif
 
 		[Mac (10, 9)]
-		[Since (6,0)][Protected]
+		[iOS (6,0)][Protected]
 		[NullAllowed] // by default this property is null
 		[Export ("externalPlaybackVideoGravity", ArgumentSemantic.Copy)]
 		NSString WeakExternalPlaybackVideoGravity { get; set; }
 
-		[Since (7,0)][Mac (10, 7)]
+		[iOS (7,0)][Mac (10, 7)]
 		[Export ("volume")]
 		float Volume { get; set; } // defined as 'float'
 
-		[Since (7,0)][Mac (10, 7)]
+		[iOS (7,0)][Mac (10, 7)]
 		[Export ("muted")]
 		bool Muted { [Bind ("isMuted")] get; set; }
 
-		[Since (7,0)][Mac (10,9)]
+		[iOS (7,0)][Mac (10,9)]
 		[Export ("appliesMediaSelectionCriteriaAutomatically")]
 		bool AppliesMediaSelectionCriteriaAutomatically { get; set; }
 
-		[Since (7,0)][Mac (10,9)]
+		[iOS (7,0)][Mac (10,9)]
 		[return: NullAllowed]
 		[Export ("mediaSelectionCriteriaForMediaCharacteristic:")]
 		AVPlayerMediaSelectionCriteria MediaSelectionCriteriaForMediaCharacteristic (NSString avMediaCharacteristic);
 
-		[Since (7, 0)][Mac (10,9)]
+		[iOS (7, 0)][Mac (10,9)]
 		[Export ("setMediaSelectionCriteria:forMediaCharacteristic:")]
 		void SetMediaSelectionCriteria ([NullAllowed] AVPlayerMediaSelectionCriteria criteria, NSString avMediaCharacteristic);
 
@@ -10347,7 +10347,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0), Mac (10, 9)]
+	[iOS (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	interface AVPlayerMediaSelectionCriteria {
 		[Export ("preferredLanguages"), NullAllowed]
@@ -10361,7 +10361,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (6,0), Mac (10, 9)]
+	[iOS (6,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSGenericException *** -[AVTextStyleRule init] Not available.  Use initWithTextMarkupAttributes:textSelector: instead
 	interface AVTextStyleRule : NSCopying {
@@ -10440,7 +10440,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[BaseType (typeof (AVMetadataGroup))]
-	[Since (4,3)]
+	[iOS (4,3)]
 	interface AVTimedMetadataGroup : NSMutableCopying {
 		[Export ("timeRange")]
 		CMTimeRange TimeRange { get; [NotImplemented] set; }
@@ -10484,7 +10484,7 @@ namespace XamCore.AVFoundation {
 	}
 		
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	// 'init' returns NIL
 	[DisableDefaultCtor]
@@ -10574,64 +10574,64 @@ namespace XamCore.AVFoundation {
 		[Notification]
 		NSString DidPlayToEndTimeNotification { get; }
 
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Field ("AVPlayerItemFailedToPlayToEndTimeNotification")]
 		[Notification (typeof (AVPlayerItemErrorEventArgs))]
 		NSString ItemFailedToPlayToEndTimeNotification { get; }
 
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Field ("AVPlayerItemFailedToPlayToEndTimeErrorKey")]
 		NSString ItemFailedToPlayToEndTimeErrorKey { get; }
 
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Export ("accessLog"), NullAllowed]
 		AVPlayerItemAccessLog AccessLog { get; }
 
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Export ("errorLog"), NullAllowed]
 		AVPlayerItemErrorLog ErrorLog { get; }
 
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Export ("currentDate"), NullAllowed]
 		NSDate CurrentDate { get; }
 
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Export ("duration")]
 		CMTime Duration { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("canPlayFastReverse")]
 		bool CanPlayFastReverse { get;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("canPlayFastForward")]
 		bool CanPlayFastForward { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("AVPlayerItemTimeJumpedNotification")]
 		[Notification]
 		NSString TimeJumpedNotification { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("seekToTime:completionHandler:")]
 		[Async]
 		void Seek (CMTime time, AVCompletion completion);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("cancelPendingSeeks")]
 		void CancelPendingSeeks ();
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("seekToTime:toleranceBefore:toleranceAfter:completionHandler:")]
 		[Async]
 		void Seek (CMTime time, CMTime toleranceBefore, CMTime toleranceAfter, AVCompletion completion);
 
-		[Since (5,0), Mac (10, 8)]
+		[iOS (5,0), Mac (10, 8)]
 		[Export ("selectMediaOption:inMediaSelectionGroup:")]
 		void SelectMediaOption ([NullAllowed] AVMediaSelectionOption mediaSelectionOption, AVMediaSelectionGroup mediaSelectionGroup);
 
 		[return: NullAllowed]
-		[Since (5,0), Mac (10, 8)]
+		[iOS (5,0), Mac (10, 8)]
 		[Export ("selectedMediaOptionInMediaSelectionGroup:")]
 		AVMediaSelectionOption SelectedMediaOption (AVMediaSelectionGroup inMediaSelectionGroup);
 
@@ -10639,96 +10639,96 @@ namespace XamCore.AVFoundation {
 		[Export ("currentMediaSelection")]
 		AVMediaSelection CurrentMediaSelection { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("canPlaySlowForward")]
 		bool CanPlaySlowForward { get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("canPlayReverse")]
 		bool CanPlayReverse { get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("canPlaySlowReverse")]
 		bool CanPlaySlowReverse { get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("canStepForward")]
 		bool CanStepForward { get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("canStepBackward")]
 		bool CanStepBackward { get;  }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("outputs")]
 		AVPlayerItemOutput [] Outputs { get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("addOutput:")]
 		[PostGet ("Outputs")]
 		void AddOutput (AVPlayerItemOutput output);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("removeOutput:")]
 		[PostGet ("Outputs")]
 		void RemoveOutput (AVPlayerItemOutput output);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("timebase"), NullAllowed]
 		CMTimebase Timebase { get;  }
 
-		[Since (6,0), Mac (10, 9)]
+		[iOS (6,0), Mac (10, 9)]
 		[Export ("seekToDate:completionHandler:")]
 		[Async]
 		bool Seek (NSDate date, AVCompletion completion);
 
-		[Since (6,0), Mac (10, 9)]
+		[iOS (6,0), Mac (10, 9)]
 		[Export ("seekingWaitsForVideoCompositionRendering")]
 		bool SeekingWaitsForVideoCompositionRendering { get; set;  }
 
-		[Since (6,0), Mac (10, 9)]
+		[iOS (6,0), Mac (10, 9)]
 		[Export ("textStyleRules", ArgumentSemantic.Copy), NullAllowed]
 		AVTextStyleRule [] TextStyleRules { get; set;  }
 
-		[Since (6,0), Mac (10, 9)]
+		[iOS (6,0), Mac (10, 9)]
 		[Field ("AVPlayerItemPlaybackStalledNotification")]
 		[Notification]
 		NSString PlaybackStalledNotification { get; }
 		
-		[Since (6,0), Mac (10, 9)]
+		[iOS (6,0), Mac (10, 9)]
 		[Field ("AVPlayerItemNewAccessLogEntryNotification")]
 		[Notification]
 		NSString NewAccessLogEntryNotification { get; }
 		
-		[Since (6,0), Mac (10, 9)]
+		[iOS (6,0), Mac (10, 9)]
 		[Field ("AVPlayerItemNewErrorLogEntryNotification")]
 		[Notification]
 		NSString NewErrorLogEntryNotification { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Static, Export ("playerItemWithAsset:automaticallyLoadedAssetKeys:")]
 		AVPlayerItem FromAsset ([NullAllowed] AVAsset asset, [NullAllowed] NSString [] automaticallyLoadedAssetKeys);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[DesignatedInitializer]
 		[Export ("initWithAsset:automaticallyLoadedAssetKeys:")]
 		IntPtr Constructor (AVAsset asset, [NullAllowed] params NSString [] automaticallyLoadedAssetKeys);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("automaticallyLoadedAssetKeys", ArgumentSemantic.Copy)]
 		NSString [] AutomaticallyLoadedAssetKeys { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("customVideoCompositor", ArgumentSemantic.Copy), NullAllowed]
 		[Protocolize]
 		AVVideoCompositing CustomVideoCompositor { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("audioTimePitchAlgorithm", ArgumentSemantic.Copy)]
 		// DOC: Mention this is an AVAudioTimePitch constant
 		NSString AudioTimePitchAlgorithm { get; set; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("selectMediaOptionAutomaticallyInMediaSelectionGroup:")]
 		void SelectMediaOptionAutomaticallyInMediaSelectionGroup (AVMediaSelectionGroup mediaSelectionGroup);
 
@@ -10780,7 +10780,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject)), Mac (10, 8)]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** initialization method -init cannot be sent to an abstract object of class AVPlayerItemOutput: Create a concrete instance!
 	[DisableDefaultCtor]
@@ -11027,7 +11027,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoCodecKey")]
 		NSString CodecKey { get; }
 		
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("AVVideoScalingModeKey")]
 		NSString ScalingModeKey { get; }
 		
@@ -11039,7 +11039,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (AVPlayerItemOutput))]
 	interface AVPlayerItemVideoOutput {
 		[Export ("delegate", ArgumentSemantic.Weak), NullAllowed]
@@ -11084,7 +11084,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -11097,7 +11097,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -11107,7 +11107,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (AVPlayerItemOutputPushDelegate))]
 	[Model]
 	[Protocol]
@@ -11117,7 +11117,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0), Mac (10, 9)]
+	[iOS (7,0), Mac (10, 9)]
 	[BaseType (typeof (AVPlayerItemOutput))]
 	interface AVPlayerItemLegibleOutput {
 		[Export ("initWithMediaSubtypesForNativeRepresentation:")]
@@ -11151,7 +11151,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
-	[Since (4,3)]
+	[iOS (4,3)]
 	interface AVPlayerItemAccessLog : NSCopying {
 		
 		[Export ("events")]
@@ -11166,7 +11166,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
-	[Since (4,3)]
+	[iOS (4,3)]
 	interface AVPlayerItemErrorLog : NSCopying {
 		[Export ("events")]
 		AVPlayerItemErrorLogEvent [] Events { get; }
@@ -11180,7 +11180,7 @@ namespace XamCore.AVFoundation {
 	
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
-	[Since (4,3)]
+	[iOS (4,3)]
 	interface AVPlayerItemAccessLogEvent : NSCopying {
 		[iOS (4, 3)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'NumberOfMediaRequests' instead.")]
@@ -11241,43 +11241,43 @@ namespace XamCore.AVFoundation {
 		[Export ("numberOfDroppedVideoFrames")]
 		nint DroppedVideoFrameCount { get; }
 
-		[Since (6,0), Mac (10, 9)]
+		[iOS (6,0), Mac (10, 9)]
 		[Export ("numberOfMediaRequests")]
 		nint NumberOfMediaRequests { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("startupTime")]
 		double StartupTime { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("downloadOverdue")]
 		nint DownloadOverdue { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("observedMaxBitrate")]
 		double ObservedMaxBitrate { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("observedMinBitrate")]
 		double ObservedMinBitrate { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("observedBitrateStandardDeviation")]
 		double ObservedBitrateStandardDeviation { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("playbackType", ArgumentSemantic.Copy), NullAllowed]
 		string PlaybackType { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("mediaRequestsWWAN")]
 		nint MediaRequestsWWAN { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("switchBitrate")]
 		double SwitchBitrate { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("transferDuration")]
 		double TransferDuration { get; }
 
@@ -11285,7 +11285,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
-	[Since (4,3)]
+	[iOS (4,3)]
 	interface AVPlayerItemErrorLogEvent : NSCopying {
 		[Export ("date"), NullAllowed]
 		NSDate Date { get; }
@@ -11348,7 +11348,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (CALayer))]
 	interface AVPlayerLayer {
 		[NullAllowed] // by default this property is null
@@ -11379,7 +11379,7 @@ namespace XamCore.AVFoundation {
 		[Export ("isReadyForDisplay")]
 		bool ReadyForDisplay { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("videoRect")]
 		CGRect VideoRect { get;  }
 
@@ -11426,7 +11426,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVPlayerItemTrack {
 		[Export ("enabled", ArgumentSemantic.Assign)]
@@ -11435,7 +11435,7 @@ namespace XamCore.AVFoundation {
 		[Export ("assetTrack")]
 		AVAssetTrack AssetTrack { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("currentVideoFrameRate")]
 		float CurrentVideoFrameRate { get;  } // defined as 'float'
 
@@ -11453,7 +11453,7 @@ namespace XamCore.AVFoundation {
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Protocol]
 	interface AVAsynchronousKeyValueLoading {
 		[Abstract]
@@ -11469,7 +11469,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,1)]
+	[iOS (4,1)]
 	[BaseType (typeof (AVPlayer))]
 	interface AVQueuePlayer {
 		
@@ -11535,7 +11535,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVEncoderBitRatePerChannelKey")]
 		NSString AVEncoderBitRatePerChannelKey { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVEncoderBitRateStrategyKey"), Internal]
 		NSString AVEncoderBitRateStrategyKey { get; }
 
@@ -11551,27 +11551,27 @@ namespace XamCore.AVFoundation {
 		[Field ("AVChannelLayoutKey")]
 		NSString AVChannelLayoutKey { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVAudioBitRateStrategy_Constant"), Internal]
 		NSString _Constant { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVAudioBitRateStrategy_LongTermAverage"), Internal]
 		NSString _LongTermAverage { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVAudioBitRateStrategy_VariableConstrained"), Internal]
 		NSString _VariableConstrained { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVAudioBitRateStrategy_Variable"), Internal]
 		NSString _Variable { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVSampleRateConverterAlgorithm_Normal"), Internal]
 		NSString AVSampleRateConverterAlgorithm_Normal { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVSampleRateConverterAlgorithm_Mastering"), Internal]
 		NSString AVSampleRateConverterAlgorithm_Mastering { get; }
 		
@@ -11579,7 +11579,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVSampleRateConverterAlgorithm_MinimumPhase")]
 		NSString AVSampleRateConverterAlgorithm_MinimumPhase { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("AVEncoderAudioQualityForVBRKey"), Internal]
 		NSString AVEncoderAudioQualityForVBRKey { get; }
 	}
@@ -11631,7 +11631,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0), BaseType (typeof (CALayer))]
+	[iOS (4,0), BaseType (typeof (CALayer))]
 	interface AVSynchronizedLayer {
 		[Static, Export ("synchronizedLayerWithPlayerItem:")]
 		AVSynchronizedLayer FromPlayerItem (AVPlayerItem playerItem);
@@ -11643,7 +11643,7 @@ namespace XamCore.AVFoundation {
 
 #if !MONOMAC
 	[Watch (3,0)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVSpeechSynthesisVoice : NSSecureCoding {
 
@@ -11687,7 +11687,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[Watch (3,0)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVSpeechUtterance : NSCopying, NSSecureCoding {
 
@@ -11746,7 +11746,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[Watch (3,0)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject), Delegates=new string [] {"WeakDelegate"}, Events=new Type [] { typeof (AVSpeechSynthesizerDelegate)})]
 	interface AVSpeechSynthesizer {
 
@@ -11969,7 +11969,7 @@ namespace XamCore.AVFoundation {
 #endif
 
 	[NoWatch]
-	[Since (7,0)][Mac (10,9)]
+	[iOS (7,0)][Mac (10,9)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface AVOutputSettingsAssistant {

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -6556,43 +6556,43 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMetadataObjectTypeFace"), Mac (10,10)]
 		NSString TypeFace { get; }
 
-		[NoTV, Since(7,0), NoMac]
+		[NoTV, iOS (7,0), NoMac]
 		[Field ("AVMetadataObjectTypeAztecCode")]
 		NSString TypeAztecCode { get; }
 		
-		[NoTV, Since(7,0), NoMac]
+		[NoTV, iOS (7,0), NoMac]
 		[Field ("AVMetadataObjectTypeCode128Code")]
 		NSString TypeCode128Code { get; }
 		
-		[NoTV, Since(7,0), NoMac]
+		[NoTV, iOS (7,0), NoMac]
 		[Field ("AVMetadataObjectTypeCode39Code")]
 		NSString TypeCode39Code { get; }
 		
-		[NoTV, Since(7,0), NoMac]
+		[NoTV, iOS (7,0), NoMac]
 		[Field ("AVMetadataObjectTypeCode39Mod43Code")]
 		NSString TypeCode39Mod43Code { get; }
 		
-		[NoTV, Since(7,0), NoMac]
+		[NoTV, iOS (7,0), NoMac]
 		[Field ("AVMetadataObjectTypeCode93Code")]
 		NSString TypeCode93Code { get; }
 		
-		[NoTV, Since(7,0), NoMac]
+		[NoTV, iOS (7,0), NoMac]
 		[Field ("AVMetadataObjectTypeEAN13Code")]
 		NSString TypeEAN13Code { get; }
 		
-		[NoTV, Since(7,0), NoMac]
+		[NoTV, iOS (7,0), NoMac]
 		[Field ("AVMetadataObjectTypeEAN8Code")]
 		NSString TypeEAN8Code { get; }
 		
 		[Field ("AVMetadataObjectTypePDF417Code")]
-		[NoTV, Since(7,0), NoMac]
+		[NoTV, iOS (7,0), NoMac]
 		NSString TypePDF417Code { get; }
 		
-		[NoTV, Since(7,0), NoMac]
+		[NoTV, iOS (7,0), NoMac]
 		[Field ("AVMetadataObjectTypeQRCode")]
 		NSString TypeQRCode { get; }
 		
-		[NoTV, Since(7,0), NoMac]
+		[NoTV, iOS (7,0), NoMac]
 		[Field ("AVMetadataObjectTypeUPCECode")]
 		NSString TypeUPCECode { get; }
 
@@ -9668,20 +9668,20 @@ namespace XamCore.AVFoundation {
 		[Export ("subjectAreaChangeMonitoringEnabled")]
 		bool SubjectAreaChangeMonitoringEnabled { [Bind ("isSubjectAreaChangeMonitoringEnabled")] get; set; }
 		
-		[Since(5,0)]
+		[iOS (5,0)]
 		[Export ("isFlashAvailable")]
 		bool FlashAvailable { get;  }
 
 		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_10_0, Message="Use 'AVCapturePhotoOutput.IsFlashScene' instead.")]
-		[Since(5,0)]
+		[iOS (5,0)]
 		[Export ("isFlashActive")]
 		bool FlashActive { get; }
 
-		[Since(5,0)]
+		[iOS (5,0)]
 		[Export ("isTorchAvailable")]
 		bool TorchAvailable { get; }
 
-		[Since(5,0)]
+		[iOS (5,0)]
 		[Export ("torchLevel")]
 		float TorchLevel { get; } // defined as 'float'
 

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -110,7 +110,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[Since (7,0)]
-	[Mavericks]
+	[Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	interface AVAsynchronousVideoCompositionRequest : NSCopying {
 		[Export ("renderContext", ArgumentSemantic.Copy)]
@@ -330,23 +330,23 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMediaCharacteristicIsMainProgramContent")]
 		IsMainProgramContent = 5,
 
-		[MountainLion][Since (5,0)]
+		[Mac (10, 8)][Since (5,0)]
 		[Field ("AVMediaCharacteristicIsAuxiliaryContent")]
 		IsAuxiliaryContent = 6,
 
-		[MountainLion][Since (5,0)]
+		[Mac (10, 8)][Since (5,0)]
 		[Field ("AVMediaCharacteristicContainsOnlyForcedSubtitles")]
 		ContainsOnlyForcedSubtitles = 7,
 
-		[MountainLion][Since (5,0)]
+		[Mac (10, 8)][Since (5,0)]
 		[Field ("AVMediaCharacteristicTranscribesSpokenDialogForAccessibility")]
 		TranscribesSpokenDialogForAccessibility = 8,
 
-		[MountainLion][Since (5,0)]
+		[Mac (10, 8)][Since (5,0)]
 		[Field ("AVMediaCharacteristicDescribesMusicAndSoundForAccessibility")]
 		DescribesMusicAndSoundForAccessibility = 9,
 
-		[MountainLion][Since (5,0)]
+		[Mac (10, 8)][Since (5,0)]
 		[Field ("AVMediaCharacteristicDescribesVideoForAccessibility")]
 		DescribesVideoForAccessibility = 10,
 
@@ -390,27 +390,27 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMediaCharacteristicUsesWideGamutColorSpace")]
 		NSString UsesWideGamutColorSpace { get; }
 
-		[MountainLion][Since (5,0)]
+		[Mac (10, 8)][Since (5,0)]
 		[Field ("AVMediaCharacteristicIsMainProgramContent")]
 		NSString IsMainProgramContent { get; }
 
-		[MountainLion][Since (5,0)]
+		[Mac (10, 8)][Since (5,0)]
 		[Field ("AVMediaCharacteristicIsAuxiliaryContent")]
 		NSString IsAuxiliaryContent { get; }
 
-		[MountainLion][Since (5,0)]
+		[Mac (10, 8)][Since (5,0)]
 		[Field ("AVMediaCharacteristicContainsOnlyForcedSubtitles")]
 		NSString ContainsOnlyForcedSubtitles { get; }
 
-		[MountainLion][Since (5,0)]
+		[Mac (10, 8)][Since (5,0)]
 		[Field ("AVMediaCharacteristicTranscribesSpokenDialogForAccessibility")]
 		NSString TranscribesSpokenDialogForAccessibility { get; }
 
-		[MountainLion][Since (5,0)]
+		[Mac (10, 8)][Since (5,0)]
 		[Field ("AVMediaCharacteristicDescribesMusicAndSoundForAccessibility")]
 		NSString DescribesMusicAndSoundForAccessibility { get; }
 
-		[MountainLion][Since (5,0)]
+		[Mac (10, 8)][Since (5,0)]
 		[Field ("AVMediaCharacteristicDescribesVideoForAccessibility")]
 		NSString DescribesVideoForAccessibility { get;  }
 #if !MONOMAC
@@ -445,7 +445,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMetadataFormatID3Metadata")]
 		FormatID3Metadata = 2,
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVMetadataFormatISOUserData")]
 		FormatISOUserData = 3,
 
@@ -494,15 +494,15 @@ namespace XamCore.AVFoundation {
 		[Field ("AVFileType3GPP2")]
 		ThreeGpp2 = 10,
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVFileTypeMPEGLayer3")]
 		MpegLayer3 = 11,
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVFileTypeSunAU")]
 		SunAU = 12,
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVFileTypeAC3")]
 		AC3 = 13,
 
@@ -575,15 +575,15 @@ namespace XamCore.AVFoundation {
 		[Field ("AVFileType3GPP2")]
 		NSString ThreeGpp2 { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVFileTypeMPEGLayer3")]
 		NSString MpegLayer3 { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVFileTypeSunAU")]
 		NSString SunAU { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVFileTypeAC3")]
 		NSString AC3 { get; }
 
@@ -632,7 +632,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoCodecKey")]
 		NSString CodecKey { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVVideoMaxKeyFrameIntervalDurationKey")]
 		NSString MaxKeyFrameIntervalDurationKey { get; }
 
@@ -737,7 +737,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoProfileLevelH264Baseline41")]
 		NSString ProfileLevelH264Baseline41 { get; }
 
-		[Since (5,0)][MountainLion]
+		[Since (5,0)][Mac (10, 8)]
 		[Field ("AVVideoProfileLevelH264Main32")]
 		NSString ProfileLevelH264Main32 { get; }
 
@@ -745,23 +745,23 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoProfileLevelH264Main41")]
 		NSString ProfileLevelH264Main41 { get; }
 
-		[Since (6,0), Mavericks]
+		[Since (6,0), Mac (10, 9)]
 		[Field ("AVVideoProfileLevelH264High40")]
 		NSString ProfileLevelH264High40 { get; }
 
-		[Since (6,0), Mavericks]
+		[Since (6,0), Mac (10, 9)]
 		[Field ("AVVideoProfileLevelH264High41")]
 		NSString ProfileLevelH264High41 { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVVideoProfileLevelH264BaselineAutoLevel")]
 		NSString ProfileLevelH264BaselineAutoLevel { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVVideoProfileLevelH264MainAutoLevel")]
 		NSString ProfileLevelH264MainAutoLevel { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVVideoProfileLevelH264HighAutoLevel")]
 		NSString ProfileLevelH264HighAutoLevel { get; }
 
@@ -3645,7 +3645,7 @@ namespace XamCore.AVFoundation {
 		AudioSettings Settings { get; }
 
 		[Since (7,0)]
-		[Mavericks]
+		[Mac (10, 9)]
 		[Export ("audioTimePitchAlgorithm", ArgumentSemantic.Copy)]
 		// This is an AVAudioTimePitch constant
 		NSString AudioTimePitchAlgorithm { get; set; }
@@ -3688,14 +3688,14 @@ namespace XamCore.AVFoundation {
 		[Wrap ("WeakVideoSettings"), NullAllowed]
 		CVPixelBufferAttributes UncompressedVideoSettings { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("customVideoCompositor", ArgumentSemantic.Copy), NullAllowed]
 		[Protocolize]
 		AVVideoCompositing CustomVideoCompositor { get; }
 	}
 
 	[NoWatch]
-	[Since (6,0), Mavericks]
+	[Since (6,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 #if XAMCORE_2_0
 	[DisableDefaultCtor] // no valid handle, docs now says "You do not create resource loader objects yourself."
@@ -3718,7 +3718,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (6,0), Mavericks]
+	[Since (6,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -3729,7 +3729,7 @@ namespace XamCore.AVFoundation {
 		[Export ("resourceLoader:shouldWaitForLoadingOfRequestedResource:")]
 		bool ShouldWaitForLoadingOfRequestedResource (AVAssetResourceLoader resourceLoader, AVAssetResourceLoadingRequest loadingRequest);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("resourceLoader:didCancelLoadingRequest:")]
 		void DidCancelLoadingRequest (AVAssetResourceLoader resourceLoader, AVAssetResourceLoadingRequest loadingRequest);
 
@@ -3747,7 +3747,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0), Mavericks]
+	[Since (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // crash at 'description' - not meant to be used callable (it's used from a property getter)
 	interface AVAssetResourceLoadingDataRequest {
@@ -3769,7 +3769,7 @@ namespace XamCore.AVFoundation {
 	}
 	
 	[NoWatch]
-	[Since (6,0), Mavericks]
+	[Since (6,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 #if XAMCORE_2_0
 	[DisableDefaultCtor] // not meant be be user created (resource loader job, see documentation)
@@ -3804,27 +3804,27 @@ namespace XamCore.AVFoundation {
 		NSString StreamingContentKeyRequestRequiresPersistentKey { get; }
 #endif
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("isCancelled")]
 		bool IsCancelled { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("contentInformationRequest"), NullAllowed]
 		AVAssetResourceLoadingContentInformationRequest ContentInformationRequest { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("dataRequest"), NullAllowed]
 		AVAssetResourceLoadingDataRequest DataRequest { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("response", ArgumentSemantic.Copy), NullAllowed]
 		NSUrlResponse Response { get; set; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("redirect", ArgumentSemantic.Copy), NullAllowed]
 		NSUrlRequest Redirect { get; set; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("finishLoading")]
 		void FinishLoading ();
 	}
@@ -3838,7 +3838,7 @@ namespace XamCore.AVFoundation {
 	
 
 	[NoWatch]
-	[Since (7,0), Mavericks]
+	[Since (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 #if XAMCORE_2_0
 	[DisableDefaultCtor] // no valid handle, the instance is received (not created) -> see doc
@@ -3967,36 +3967,36 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,1), Lion]
+	[Since (4,1), Mac (10, 7)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[AVAssetWriterInput initWithMediaType:outputSettings:] invalid parameter not satisfying: mediaType != ((void*)0)
 	[DisableDefaultCtor]
 	interface AVAssetWriterInput {
-		[Since (6,0), MountainLion]
+		[Since (6,0), Mac (10, 8)]
 		[DesignatedInitializer]
 		[Protected]
 		[Export ("initWithMediaType:outputSettings:sourceFormatHint:")]
 		IntPtr Constructor (string mediaType, [NullAllowed] NSDictionary outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
-		[Since (6,0), MountainLion]
+		[Since (6,0), Mac (10, 8)]
 		[Wrap ("this (mediaType, outputSettings == null ? null : outputSettings.Dictionary, sourceFormatHint)")]
 		IntPtr Constructor (string mediaType, [NullAllowed] AudioSettings outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
-		[Since (6,0), MountainLion]
+		[Since (6,0), Mac (10, 8)]
 		[Wrap ("this (mediaType, outputSettings == null ? null : outputSettings.Dictionary, sourceFormatHint)")]
 		IntPtr Constructor (string mediaType, [NullAllowed] AVVideoSettingsCompressed outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
-		[Since (6,0), MountainLion]
+		[Since (6,0), Mac (10, 8)]
 		[Static, Internal]
 		[Export ("assetWriterInputWithMediaType:outputSettings:sourceFormatHint:")]
 		AVAssetWriterInput Create (string mediaType, [NullAllowed] NSDictionary outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
-		[Since (6,0), MountainLion]
+		[Since (6,0), Mac (10, 8)]
 		[Static]
 		[Wrap ("Create(mediaType, outputSettings == null ? null : outputSettings.Dictionary, sourceFormatHint)")]
 		AVAssetWriterInput Create (string mediaType, [NullAllowed] AudioSettings outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
 
-		[Since (6,0), MountainLion]
+		[Since (6,0), Mac (10, 8)]
 		[Static]
 		[Wrap ("Create(mediaType, outputSettings == null ? null : outputSettings.Dictionary, sourceFormatHint)")]
 		AVAssetWriterInput Create (string mediaType, [NullAllowed] AVVideoSettingsCompressed outputSettings, [NullAllowed] CMFormatDescription sourceFormatHint);
@@ -4057,35 +4057,35 @@ namespace XamCore.AVFoundation {
 		[Export ("mediaTimeScale")]
 		int /* CMTimeScale = int32_t */ MediaTimeScale { get; set; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("languageCode", ArgumentSemantic.Copy), NullAllowed]
 		string LanguageCode { get; set; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("extendedLanguageTag", ArgumentSemantic.Copy), NullAllowed]
 		string ExtendedLanguageTag { get; set; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("naturalSize")]
 		CGSize NaturalSize { get; set; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("preferredVolume")]
 		float PreferredVolume { get; set; } // defined as 'float'
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("marksOutputTrackAsEnabled")]
 		bool MarksOutputTrackAsEnabled { get; set; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("canAddTrackAssociationWithTrackOfInput:type:")]
 		bool CanAddTrackAssociationWithTrackOfInput (AVAssetWriterInput input, NSString trackAssociationType);
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("addTrackAssociationWithTrackOfInput:type:")]
 		void AddTrackAssociationWithTrackOfInput (AVAssetWriterInput input, NSString trackAssociationType);
 		
-		[Since (6,0), MountainLion]
+		[Since (6,0), Mac (10, 8)]
 		[Export ("sourceFormatHint"), NullAllowed]
 		CMFormatDescription SourceFormatHint { get; }
 
@@ -4292,7 +4292,7 @@ namespace XamCore.AVFoundation {
 		[Static, Export ("isPlayableExtendedMIMEType:")]
 		bool IsPlayable (string extendedMimeType);
 
-		[Since (6,0), Mavericks]
+		[Since (6,0), Mac (10, 9)]
 		[Export ("resourceLoader")]
 		AVAssetResourceLoader ResourceLoader { get;  }
 
@@ -4398,7 +4398,7 @@ namespace XamCore.AVFoundation {
 		[Export ("isPlayable")]
 		bool Playable { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("availableTrackAssociationTypes")]
 		NSString [] AvailableTrackAssociationTypes { get; }
 
@@ -4407,7 +4407,7 @@ namespace XamCore.AVFoundation {
 		[Export ("minFrameDuration")]
 		CMTime MinFrameDuration { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("associatedTracksOfType:")]
 		AVAssetTrack [] GetAssociatedTracks (NSString avAssetTrackTrackAssociationType);
 
@@ -4521,7 +4521,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0), Mavericks]
+	[Since (7,0), Mac (10, 9)]
 	[Category, BaseType (typeof (AVAssetTrack))]
 	interface AVAssetTrackTrackAssociation {
 		[Field ("AVTrackAssociationTypeAudioFallback")]
@@ -4545,7 +4545,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0), Mavericks]
+	[Since (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	interface AVAssetTrackGroup : NSCopying {
 		[Export ("trackIDs", ArgumentSemantic.Copy)]
@@ -4553,20 +4553,20 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (5,0), MountainLion]
+	[Since (5,0), Mac (10, 8)]
 	[BaseType (typeof (NSObject))]
 	interface AVMediaSelectionGroup : NSCopying {
 		[Export ("options")]
-		[MountainLion]
+		[Mac (10, 8)]
 		AVMediaSelectionOption [] Options { get;  }
 		
 		[Export ("allowsEmptySelection")]
-		[MountainLion]
+		[Mac (10, 8)]
 		bool AllowsEmptySelection { get;  }
 
 		[return: NullAllowed]
 		[Export ("mediaSelectionOptionWithPropertyList:")]
-		[MountainLion]
+		[Mac (10, 8)]
 		AVMediaSelectionOption GetMediaSelectionOptionForPropertyList (NSObject propertyList);
 
 		[Static]
@@ -4596,7 +4596,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (5,0), MountainLion]
+	[Since (5,0), Mac (10, 8)]
 	[BaseType (typeof (NSObject))]
 	interface AVMediaSelectionOption : NSCopying {
 		[Export ("mediaType")]
@@ -4630,15 +4630,15 @@ namespace XamCore.AVFoundation {
 		[Export ("propertyList")]
 		NSObject PropertyList { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("displayName")]
 		string DisplayName { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("displayNameWithLocale:")]
 		string GetDisplayName (NSLocale locale);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("extendedLanguageTag"), NullAllowed]
 		string ExtendedLanguageTag { get; }
 	}
@@ -4838,7 +4838,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMetadataQuickTimeUserDataKeyPhonogramRights")]
 		NSString QuickTimeUserDataKeyPhonogramRights { get; }
 
-		[MountainLion][Since (5,0)]
+		[Mac (10, 8)][Since (5,0)]
 		[Field ("AVMetadataQuickTimeUserDataKeyTaggedCharacteristic")]
 		NSString QuickTimeUserDataKeyTaggedCharacteristic { get; }
 		
@@ -4869,42 +4869,42 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMetadata3GPUserDataKeyDescription")]
 		NSString K3GPUserDataKeyDescription { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyCollection")]
 		NSString K3GPUserDataKeyCollection { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyUserRating")]
 		NSString K3GPUserDataKeyUserRating { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyThumbnail")]
 		NSString K3GPUserDataKeyThumbnail { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyAlbumAndTrack")]
 		NSString K3GPUserDataKeyAlbumAndTrack { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyKeywordList")]
 		NSString K3GPUserDataKeyKeywordList { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyMediaClassification")]
 		NSString K3GPUserDataKeyMediaClassification { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVMetadata3GPUserDataKeyMediaRating")]
 		NSString K3GPUserDataKeyMediaRating { get; }
 
 #if !XAMCORE_4_0
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVMetadataFormatISOUserData")]
 		[Obsolete ("Use 'AVMetadataFormat' enum values")]
 		NSString KFormatISOUserData { get; }
 #endif
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVMetadataKeySpaceISOUserData")]
 		NSString KKeySpaceISOUserData { get; }
 		
@@ -6509,7 +6509,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0), Mavericks]
+	[Since (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // for binary compatibility this is added in AVMetadataItemFilter.cs w/[Obsolete]
 	interface AVMetadataItemFilter {
@@ -7587,7 +7587,7 @@ namespace XamCore.AVFoundation {
 		long EstimatedOutputFileLength { get; }
 
 		[Since (6,0)]
-		[Mavericks]
+		[Mac (10, 9)]
 		[Static, Export ("determineCompatibilityOfExportPreset:withAsset:outputFileType:completionHandler:")]
 		[Async]
 		void DetermineCompatibilityOfExportPreset (string presetName, AVAsset asset, [NullAllowed] string outputFileType, Action<bool> isCompatibleResult);
@@ -7597,7 +7597,7 @@ namespace XamCore.AVFoundation {
 		void DetermineCompatibilityOfExportPreset (string presetName, AVAsset asset, [NullAllowed] AVFileTypes outputFileType, Action<bool> isCompatibleResult);
 
 		[Since (6,0)]
-		[Mavericks]
+		[Mac (10, 9)]
 		[Export ("determineCompatibleFileTypesWithCompletionHandler:")]
 		[Async]
 		void DetermineCompatibleFileTypes (Action<string []> compatibleFileTypesHandler);
@@ -7776,11 +7776,11 @@ namespace XamCore.AVFoundation {
 		[Export ("isValidForAsset:timeRange:validationDelegate:")]
 		bool IsValidForAsset ([NullAllowed] AVAsset asset, CMTimeRange timeRange, [Protocolize] [NullAllowed] AVVideoCompositionValidationHandling validationDelegate);
 
-		[Since (6,0), Mavericks]
+		[Since (6,0), Mac (10, 9)]
 		[Static, Export ("videoCompositionWithPropertiesOfAsset:")]
 		AVVideoComposition FromAssetProperties (AVAsset asset);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("customVideoCompositorClass", ArgumentSemantic.Copy), NullAllowed]
 		Class CustomVideoCompositorClass { get; [NotImplemented] set; }
 
@@ -7803,7 +7803,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0), Mavericks]
+	[Since (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	interface AVVideoCompositionRenderContext {
 		[Export ("size", ArgumentSemantic.Copy)]
@@ -7877,12 +7877,12 @@ namespace XamCore.AVFoundation {
 		AVMutableVideoComposition Create ();
 
 		// in 7.0 they declared this was available in 6.0
-		[Since (6,0), Mavericks]
+		[Since (6,0), Mac (10, 9)]
 		[Static, Export ("videoCompositionWithPropertiesOfAsset:")]
 		AVMutableVideoComposition Create (AVAsset asset);
 
 		[NullAllowed]
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("customVideoCompositorClass", ArgumentSemantic.Retain)]
 		[Override]
 		Class CustomVideoCompositorClass { get; set; }
@@ -7910,7 +7910,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0), Lion]
+	[Since (4,0), Mac (10, 7)]
 	[BaseType (typeof (NSObject))]
 	interface AVVideoCompositionInstruction : NSSecureCoding, NSMutableCopying {
 		[Export ("timeRange")]
@@ -7930,15 +7930,15 @@ namespace XamCore.AVFoundation {
 
 		// These are there because it adopts the protocol *of the same name*
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("containsTweening")]
 		bool ContainsTweening { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("requiredSourceTrackIDs")]
 		NSNumber[] RequiredSourceTrackIDs { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("passthroughTrackID")]
 		int PassthroughTrackID { get; } /* CMPersistentTrackID = int32_t */
 	}
@@ -7970,7 +7970,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (4,0), Lion]
+	[Since (4,0), Mac (10, 7)]
 	[BaseType (typeof (NSObject))]
 	interface AVVideoCompositionLayerInstruction : NSSecureCoding, NSMutableCopying {
 		[Export ("trackID", ArgumentSemantic.Assign)]
@@ -8013,11 +8013,11 @@ namespace XamCore.AVFoundation {
 		[Export ("setOpacity:atTime:")]
 		void SetOpacity (float /* defined as 'float' */ opacity, CMTime time);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("setCropRectangleRampFromStartCropRectangle:toEndCropRectangle:timeRange:")]
 		void SetCrop (CGRect startCropRectangle, CGRect endCropRectangle, CMTimeRange timeRange);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("setCropRectangle:atTime:")]
 		void SetCrop (CGRect cropRectangle, CMTime time);
 	}
@@ -8034,7 +8034,7 @@ namespace XamCore.AVFoundation {
 		[Export ("videoCompositionCoreAnimationToolWithPostProcessingAsVideoLayer:inLayer:")]
 		AVVideoCompositionCoreAnimationTool FromLayer (CALayer videoLayer, CALayer animationLayer);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Static, Export ("videoCompositionCoreAnimationToolWithPostProcessingAsVideoLayers:inLayer:")]
 		AVVideoCompositionCoreAnimationTool FromComposedVideoFrames (CALayer [] videoLayers, CALayer inAnimationlayer);
 	}
@@ -10279,11 +10279,11 @@ namespace XamCore.AVFoundation {
 		[Export ("externalPlaybackVideoGravity", ArgumentSemantic.Copy)]
 		NSString WeakExternalPlaybackVideoGravity { get; set; }
 
-		[Since (7,0)][Lion]
+		[Since (7,0)][Mac (10, 7)]
 		[Export ("volume")]
 		float Volume { get; set; } // defined as 'float'
 
-		[Since (7,0)][Lion]
+		[Since (7,0)][Mac (10, 7)]
 		[Export ("muted")]
 		bool Muted { [Bind ("isMuted")] get; set; }
 
@@ -10332,7 +10332,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0), Mavericks]
+	[Since (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	interface AVPlayerMediaSelectionCriteria {
 		[Export ("preferredLanguages"), NullAllowed]
@@ -10346,7 +10346,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (6,0), Mavericks]
+	[Since (6,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSGenericException *** -[AVTextStyleRule init] Not available.  Use initWithTextMarkupAttributes:textSelector: instead
 	interface AVTextStyleRule : NSCopying {
@@ -10611,12 +10611,12 @@ namespace XamCore.AVFoundation {
 		[Async]
 		void Seek (CMTime time, CMTime toleranceBefore, CMTime toleranceAfter, AVCompletion completion);
 
-		[Since (5,0), MountainLion]
+		[Since (5,0), Mac (10, 8)]
 		[Export ("selectMediaOption:inMediaSelectionGroup:")]
 		void SelectMediaOption ([NullAllowed] AVMediaSelectionOption mediaSelectionOption, AVMediaSelectionGroup mediaSelectionGroup);
 
 		[return: NullAllowed]
-		[Since (5,0), MountainLion]
+		[Since (5,0), Mac (10, 8)]
 		[Export ("selectedMediaOptionInMediaSelectionGroup:")]
 		AVMediaSelectionOption SelectedMediaOption (AVMediaSelectionGroup inMediaSelectionGroup);
 
@@ -10662,58 +10662,58 @@ namespace XamCore.AVFoundation {
 		[Export ("timebase"), NullAllowed]
 		CMTimebase Timebase { get;  }
 
-		[Since (6,0), Mavericks]
+		[Since (6,0), Mac (10, 9)]
 		[Export ("seekToDate:completionHandler:")]
 		[Async]
 		bool Seek (NSDate date, AVCompletion completion);
 
-		[Since (6,0), Mavericks]
+		[Since (6,0), Mac (10, 9)]
 		[Export ("seekingWaitsForVideoCompositionRendering")]
 		bool SeekingWaitsForVideoCompositionRendering { get; set;  }
 
-		[Since (6,0), Mavericks]
+		[Since (6,0), Mac (10, 9)]
 		[Export ("textStyleRules", ArgumentSemantic.Copy), NullAllowed]
 		AVTextStyleRule [] TextStyleRules { get; set;  }
 
-		[Since (6,0), Mavericks]
+		[Since (6,0), Mac (10, 9)]
 		[Field ("AVPlayerItemPlaybackStalledNotification")]
 		[Notification]
 		NSString PlaybackStalledNotification { get; }
 		
-		[Since (6,0), Mavericks]
+		[Since (6,0), Mac (10, 9)]
 		[Field ("AVPlayerItemNewAccessLogEntryNotification")]
 		[Notification]
 		NSString NewAccessLogEntryNotification { get; }
 		
-		[Since (6,0), Mavericks]
+		[Since (6,0), Mac (10, 9)]
 		[Field ("AVPlayerItemNewErrorLogEntryNotification")]
 		[Notification]
 		NSString NewErrorLogEntryNotification { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Static, Export ("playerItemWithAsset:automaticallyLoadedAssetKeys:")]
 		AVPlayerItem FromAsset ([NullAllowed] AVAsset asset, [NullAllowed] NSString [] automaticallyLoadedAssetKeys);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[DesignatedInitializer]
 		[Export ("initWithAsset:automaticallyLoadedAssetKeys:")]
 		IntPtr Constructor (AVAsset asset, [NullAllowed] params NSString [] automaticallyLoadedAssetKeys);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("automaticallyLoadedAssetKeys", ArgumentSemantic.Copy)]
 		NSString [] AutomaticallyLoadedAssetKeys { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("customVideoCompositor", ArgumentSemantic.Copy), NullAllowed]
 		[Protocolize]
 		AVVideoCompositing CustomVideoCompositor { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("audioTimePitchAlgorithm", ArgumentSemantic.Copy)]
 		// DOC: Mention this is an AVAudioTimePitch constant
 		NSString AudioTimePitchAlgorithm { get; set; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("selectMediaOptionAutomaticallyInMediaSelectionGroup:")]
 		void SelectMediaOptionAutomaticallyInMediaSelectionGroup (AVMediaSelectionGroup mediaSelectionGroup);
 
@@ -10766,7 +10766,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[Since (6,0)]
-	[BaseType (typeof (NSObject)), MountainLion]
+	[BaseType (typeof (NSObject)), Mac (10, 8)]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** initialization method -init cannot be sent to an abstract object of class AVPlayerItemOutput: Create a concrete instance!
 	[DisableDefaultCtor]
 	interface AVPlayerItemOutput {
@@ -11102,7 +11102,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[Since (7,0), Mavericks]
+	[Since (7,0), Mac (10, 9)]
 	[BaseType (typeof (AVPlayerItemOutput))]
 	interface AVPlayerItemLegibleOutput {
 		[Export ("initWithMediaSubtypesForNativeRepresentation:")]
@@ -11224,43 +11224,43 @@ namespace XamCore.AVFoundation {
 		[Export ("numberOfDroppedVideoFrames")]
 		nint DroppedVideoFrameCount { get; }
 
-		[Since (6,0), Mavericks]
+		[Since (6,0), Mac (10, 9)]
 		[Export ("numberOfMediaRequests")]
 		nint NumberOfMediaRequests { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("startupTime")]
 		double StartupTime { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("downloadOverdue")]
 		nint DownloadOverdue { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("observedMaxBitrate")]
 		double ObservedMaxBitrate { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("observedMinBitrate")]
 		double ObservedMinBitrate { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("observedBitrateStandardDeviation")]
 		double ObservedBitrateStandardDeviation { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("playbackType", ArgumentSemantic.Copy), NullAllowed]
 		string PlaybackType { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("mediaRequestsWWAN")]
 		nint MediaRequestsWWAN { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("switchBitrate")]
 		double SwitchBitrate { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("transferDuration")]
 		double TransferDuration { get; }
 
@@ -11362,7 +11362,7 @@ namespace XamCore.AVFoundation {
 		[Export ("isReadyForDisplay")]
 		bool ReadyForDisplay { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("videoRect")]
 		CGRect VideoRect { get;  }
 
@@ -11418,7 +11418,7 @@ namespace XamCore.AVFoundation {
 		[Export ("assetTrack")]
 		AVAssetTrack AssetTrack { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("currentVideoFrameRate")]
 		float CurrentVideoFrameRate { get;  } // defined as 'float'
 
@@ -11518,7 +11518,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVEncoderBitRatePerChannelKey")]
 		NSString AVEncoderBitRatePerChannelKey { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVEncoderBitRateStrategyKey"), Internal]
 		NSString AVEncoderBitRateStrategyKey { get; }
 
@@ -11534,27 +11534,27 @@ namespace XamCore.AVFoundation {
 		[Field ("AVChannelLayoutKey")]
 		NSString AVChannelLayoutKey { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVAudioBitRateStrategy_Constant"), Internal]
 		NSString _Constant { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVAudioBitRateStrategy_LongTermAverage"), Internal]
 		NSString _LongTermAverage { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVAudioBitRateStrategy_VariableConstrained"), Internal]
 		NSString _VariableConstrained { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVAudioBitRateStrategy_Variable"), Internal]
 		NSString _Variable { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVSampleRateConverterAlgorithm_Normal"), Internal]
 		NSString AVSampleRateConverterAlgorithm_Normal { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVSampleRateConverterAlgorithm_Mastering"), Internal]
 		NSString AVSampleRateConverterAlgorithm_Mastering { get; }
 		
@@ -11562,7 +11562,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVSampleRateConverterAlgorithm_MinimumPhase")]
 		NSString AVSampleRateConverterAlgorithm_MinimumPhase { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("AVEncoderAudioQualityForVBRKey"), Internal]
 		NSString AVEncoderAudioQualityForVBRKey { get; }
 	}

--- a/src/callkit.cs
+++ b/src/callkit.cs
@@ -16,7 +16,7 @@ using XamCore.ObjCRuntime;
 #if XAMCORE_2_0
 namespace XamCore.CallKit {
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Native]
 	public enum CXCallDirectoryEnabledStatus : nint {
 		Unknown = 0,
@@ -24,14 +24,14 @@ namespace XamCore.CallKit {
 		Enabled = 2
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[ErrorDomain ("CXErrorDomain")]
 	[Native]
 	public enum CXErrorCode : nint {
 		Unknown = 0
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[ErrorDomain ("CXErrorDomainIncomingCall")]
 	[Native]
 	public enum CXErrorCodeIncomingCallError : nint {
@@ -42,7 +42,7 @@ namespace XamCore.CallKit {
 		FilteredByBlockList = 4
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[ErrorDomain ("CXErrorDomainRequestTransaction")]
 	[Native]
 	public enum CXErrorCodeRequestTransactionError : nint {
@@ -56,7 +56,7 @@ namespace XamCore.CallKit {
 		MaximumCallGroupsReached = 7
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[ErrorDomain ("CXErrorDomainCallDirectoryManager")]
 	[Native]
 	public enum CXErrorCodeCallDirectoryManagerError : nint {
@@ -72,7 +72,7 @@ namespace XamCore.CallKit {
 		UnexpectedIncrementalRemoval = 8,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Native]
 	public enum CXPlayDtmfCallActionType : nint {
 		SingleTone = 1,
@@ -80,7 +80,7 @@ namespace XamCore.CallKit {
 		HardPause = 3
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Native]
 	public enum CXCallEndedReason : nint {
 		Failed = 1,
@@ -90,7 +90,7 @@ namespace XamCore.CallKit {
 		DeclinedElsewhere = 5
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Native]
 	public enum CXHandleType : nint {
 		Generic = 1,
@@ -98,7 +98,7 @@ namespace XamCore.CallKit {
 		EmailAddress = 3
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface CXHandle : NSCopying, NSSecureCoding {
@@ -117,7 +117,7 @@ namespace XamCore.CallKit {
 		bool IsEqual (CXHandle handle);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	interface CXAction : NSCopying, NSSecureCoding {
 
@@ -137,7 +137,7 @@ namespace XamCore.CallKit {
 		void Fail ();
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (CXCallAction))]
 	[DisableDefaultCtor]
 	interface CXAnswerCallAction {
@@ -150,7 +150,7 @@ namespace XamCore.CallKit {
 		void Fulfill (NSDate dateConnected);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface CXCall {
@@ -174,7 +174,7 @@ namespace XamCore.CallKit {
 		bool IsEqual (CXCall call);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (CXAction))]
 	[DisableDefaultCtor]
 	interface CXCallAction {
@@ -187,7 +187,7 @@ namespace XamCore.CallKit {
 		IntPtr Constructor (NSUuid callUuid);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	interface CXCallController {
 
@@ -213,7 +213,7 @@ namespace XamCore.CallKit {
 		void RequestTransaction ([NullAllowed] CXAction action, [NullAllowed] Action<NSError> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSExtensionContext))]
 	interface CXCallDirectoryExtensionContext {
 
@@ -253,7 +253,7 @@ namespace XamCore.CallKit {
 
 	interface ICXCallDirectoryExtensionContextDelegate {}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Protocol][Model]
 	[BaseType (typeof (NSObject))]
 	interface CXCallDirectoryExtensionContextDelegate {
@@ -263,7 +263,7 @@ namespace XamCore.CallKit {
 		void RequestFailed (CXCallDirectoryExtensionContext extensionContext, NSError error);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	interface CXCallDirectoryManager {
 
@@ -280,7 +280,7 @@ namespace XamCore.CallKit {
 		void GetEnabledStatusForExtension (string identifier, Action<CXCallDirectoryEnabledStatus, NSError> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	interface CXCallDirectoryProvider : NSExtensionRequestHandling {
 
@@ -288,7 +288,7 @@ namespace XamCore.CallKit {
 
 	interface ICXCallObserverDelegate { }
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	interface CXCallObserverDelegate {
@@ -298,7 +298,7 @@ namespace XamCore.CallKit {
 		void CallChanged (CXCallObserver callObserver, CXCall call);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	interface CXCallObserver {
 
@@ -309,7 +309,7 @@ namespace XamCore.CallKit {
 		void SetDelegate ([NullAllowed] ICXCallObserverDelegate aDelegate, [NullAllowed] DispatchQueue queue);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	interface CXCallUpdate : NSCopying {
 
@@ -335,7 +335,7 @@ namespace XamCore.CallKit {
 		bool HasVideo { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (CXCallAction))]
 	interface CXEndCallAction {
@@ -348,7 +348,7 @@ namespace XamCore.CallKit {
 		void Fulfill (NSDate dateEnded);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (CXCallAction), Name = "CXPlayDTMFCallAction")]
 	interface CXPlayDtmfCallAction {
@@ -367,7 +367,7 @@ namespace XamCore.CallKit {
 	interface ICXProviderDelegate { }
 
 	[Protocol, Model]
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	interface CXProviderDelegate {
 
@@ -412,7 +412,7 @@ namespace XamCore.CallKit {
 		void DidDeactivateAudioSession (CXProvider provider, AVAudioSession audioSession);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface CXProvider {
@@ -453,7 +453,7 @@ namespace XamCore.CallKit {
 		CXCallAction [] GetPendingCallActions (Class callActionClass, NSUuid callUuid);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface CXProviderConfiguration : NSCopying {
@@ -489,7 +489,7 @@ namespace XamCore.CallKit {
 		IntPtr Constructor (string localizedName);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (CXCallAction))]
 	[DisableDefaultCtor]
 	interface CXSetGroupCallAction {
@@ -502,7 +502,7 @@ namespace XamCore.CallKit {
 		NSUuid CallUuidToGroupWith { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (CXCallAction))]
 	interface CXSetHeldCallAction {
@@ -515,7 +515,7 @@ namespace XamCore.CallKit {
 		bool OnHold { [Bind ("isOnHold")] get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (CXCallAction))]
 	[DisableDefaultCtor]
 	interface CXSetMutedCallAction {
@@ -528,7 +528,7 @@ namespace XamCore.CallKit {
 		bool Muted { [Bind ("isMuted")] get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (CXCallAction))]
 	interface CXStartCallAction {
@@ -552,7 +552,7 @@ namespace XamCore.CallKit {
 		void Fulfill (NSDate dateStarted);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // there's a designated initializer that does not accept null
 	interface CXTransaction : NSCopying, NSSecureCoding {

--- a/src/cfnetwork.cs
+++ b/src/cfnetwork.cs
@@ -92,7 +92,7 @@ namespace XamCore.CoreServices {
 		// OSX headers says it's 10.9 only
 		// iOS headers says it's iOS 7.0 only (but comments talks about OSX)
 		// yet both 7.0+ and 10.9 returns null
-		[Mavericks][Since (7,0)]
+		[Mac (10, 9)][Since (7,0)]
 		[Internal][Field ("kCFHTTPAuthenticationSchemeOAuth1", "CFNetwork")]
 		NSString _AuthenticationSchemeOAuth1 { get; }
 	}

--- a/src/cfnetwork.cs
+++ b/src/cfnetwork.cs
@@ -92,7 +92,7 @@ namespace XamCore.CoreServices {
 		// OSX headers says it's 10.9 only
 		// iOS headers says it's iOS 7.0 only (but comments talks about OSX)
 		// yet both 7.0+ and 10.9 returns null
-		[Mac (10, 9)][Since (7,0)]
+		[Mac (10, 9)][iOS (7,0)]
 		[Internal][Field ("kCFHTTPAuthenticationSchemeOAuth1", "CFNetwork")]
 		NSString _AuthenticationSchemeOAuth1 { get; }
 	}

--- a/src/cfnetwork.cs
+++ b/src/cfnetwork.cs
@@ -18,31 +18,38 @@ namespace XamCore.CoreServices {
 	[Partial]
 	interface CFHTTPStream {
 
-		[Availability (Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.Mac_10_11)]
 		[Internal][Field ("kCFStreamPropertyHTTPAttemptPersistentConnection", "CFNetwork")]
 		NSString _AttemptPersistentConnection { get; }
 
-		[Availability (Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.Mac_10_11)]
 		[Internal][Field ("kCFStreamPropertyHTTPFinalURL", "CFNetwork")]
 		NSString _FinalURL { get; }
 
-		[Availability (Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.Mac_10_11)]
 		[Internal][Field ("kCFStreamPropertyHTTPFinalRequest", "CFNetwork")]
 		NSString _FinalRequest { get; }
 
-		[Availability (Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.Mac_10_11)]
 		[Internal][Field ("kCFStreamPropertyHTTPProxy", "CFNetwork")]
 		NSString _Proxy { get; }
 
-		[Availability (Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.Mac_10_11)]
 		[Internal][Field ("kCFStreamPropertyHTTPRequestBytesWrittenCount", "CFNetwork")]
 		NSString _RequestBytesWrittenCount { get; }
 
-		[Availability (Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.Mac_10_11)]
 		[Internal][Field ("kCFStreamPropertyHTTPResponseHeader", "CFNetwork")]
 		NSString _ResponseHeader { get; }
 
-		[Availability (Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.Mac_10_11)]
 		[Internal][Field ("kCFStreamPropertyHTTPShouldAutoredirect", "CFNetwork")]
 		NSString _ShouldAutoredirect { get; }
 	}

--- a/src/cfnetwork.cs
+++ b/src/cfnetwork.cs
@@ -18,38 +18,38 @@ namespace XamCore.CoreServices {
 	[Partial]
 	interface CFHTTPStream {
 
-		[Availability (Deprecated = Platform.iOS_9_0)]
-		[Availability (Deprecated = Platform.Mac_10_11)]
+		[Deprecated (PlatformName.iOS, 9, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Internal][Field ("kCFStreamPropertyHTTPAttemptPersistentConnection", "CFNetwork")]
 		NSString _AttemptPersistentConnection { get; }
 
-		[Availability (Deprecated = Platform.iOS_9_0)]
-		[Availability (Deprecated = Platform.Mac_10_11)]
+		[Deprecated (PlatformName.iOS, 9, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Internal][Field ("kCFStreamPropertyHTTPFinalURL", "CFNetwork")]
 		NSString _FinalURL { get; }
 
-		[Availability (Deprecated = Platform.iOS_9_0)]
-		[Availability (Deprecated = Platform.Mac_10_11)]
+		[Deprecated (PlatformName.iOS, 9, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Internal][Field ("kCFStreamPropertyHTTPFinalRequest", "CFNetwork")]
 		NSString _FinalRequest { get; }
 
-		[Availability (Deprecated = Platform.iOS_9_0)]
-		[Availability (Deprecated = Platform.Mac_10_11)]
+		[Deprecated (PlatformName.iOS, 9, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Internal][Field ("kCFStreamPropertyHTTPProxy", "CFNetwork")]
 		NSString _Proxy { get; }
 
-		[Availability (Deprecated = Platform.iOS_9_0)]
-		[Availability (Deprecated = Platform.Mac_10_11)]
+		[Deprecated (PlatformName.iOS, 9, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Internal][Field ("kCFStreamPropertyHTTPRequestBytesWrittenCount", "CFNetwork")]
 		NSString _RequestBytesWrittenCount { get; }
 
-		[Availability (Deprecated = Platform.iOS_9_0)]
-		[Availability (Deprecated = Platform.Mac_10_11)]
+		[Deprecated (PlatformName.iOS, 9, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Internal][Field ("kCFStreamPropertyHTTPResponseHeader", "CFNetwork")]
 		NSString _ResponseHeader { get; }
 
-		[Availability (Deprecated = Platform.iOS_9_0)]
-		[Availability (Deprecated = Platform.Mac_10_11)]
+		[Deprecated (PlatformName.iOS, 9, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Internal][Field ("kCFStreamPropertyHTTPShouldAutoredirect", "CFNetwork")]
 		NSString _ShouldAutoredirect { get; }
 	}

--- a/src/cloudkit.cs
+++ b/src/cloudkit.cs
@@ -182,7 +182,8 @@ namespace XamCore.CloudKit {
 	interface CKContainer {
 
 		[NoWatch]
-		[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_10 , Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12, Message = "Use 'CurrentUserDefaultName' instead.")]
+		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'CurrentUserDefaultName' instead.")]
+		[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'CurrentUserDefaultName' instead.")]
 		[Field ("CKOwnerDefaultName")]
 		NSString OwnerDefaultName { get; }
 
@@ -240,7 +241,8 @@ namespace XamCore.CloudKit {
 		[Async]
 		void DiscoverAllIdentities (Action<CKUserIdentity[], NSError> completionHandler);
 		
-		[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_10 , Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12, Message = "Use 'DiscoverAllIdentities' instead.")]
+		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'DiscoverAllIdentities' instead.")]
+		[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'DiscoverAllIdentities' instead.")]
 		[NoWatch]
 		[NoTV]
 		[Export ("discoverAllContactUserInfosWithCompletionHandler:")]
@@ -257,7 +259,8 @@ namespace XamCore.CloudKit {
 		[Async]
 		void DiscoverUserIdentityWithPhoneNumber (string phoneNumber, Action<CKUserIdentity, NSError> completionHandler);
 		
-		[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_10 , Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12, Message = "Use 'DiscoverUserIdentityWithEmailAddress' instead.")]
+		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'DiscoverUserIdentityWithEmailAddress' instead.")]
+		[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'DiscoverUserIdentityWithEmailAddress' instead.")]
 		[NoWatch]
 		[Export ("discoverUserInfoWithEmailAddress:completionHandler:")]
 		[Async]
@@ -268,7 +271,8 @@ namespace XamCore.CloudKit {
 		[Async]
 		void DiscoverUserIdentity (CKRecordID userRecordID, Action<CKUserIdentity, NSError> completionHandler);
 	
-		[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_10 , Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12, Message = "Use 'DiscoverUserIdentity' instead.")]
+		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'DiscoverUserIdentity' instead.")]
+		[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'DiscoverUserIdentity' instead.")]
 		[NoWatch]
 		[Export ("discoverUserInfoWithUserRecordID:completionHandler:")]
 		[Async]
@@ -399,7 +403,8 @@ namespace XamCore.CloudKit {
 
 	[NoWatch]
 	[NoTV]
-	[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_10 , Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12, Message = "Use 'CKDiscoverAllUserIdentitiesOperation' instead.")]
+	[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'CKDiscoverAllUserIdentitiesOperation' instead.")]
+	[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'CKDiscoverAllUserIdentitiesOperation' instead.")]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (CKOperation))]
 	interface CKDiscoverAllContactsOperation {
@@ -408,7 +413,8 @@ namespace XamCore.CloudKit {
 		Action<CKDiscoveredUserInfo[], NSError> DiscoverAllContactsHandler { get; set; }
 	}
 
-	[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_10 , Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12, Message = "Use 'CKUserIdentity' instead.")]
+	[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'CKUserIdentity' instead.")]
+	[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'CKUserIdentity' instead.")]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
@@ -417,11 +423,13 @@ namespace XamCore.CloudKit {
 		[Export ("userRecordID", ArgumentSemantic.Copy)]
 		CKRecordID UserRecordId { get; }
 
-		[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0, Deprecated = Platform.Mac_10_11 | Platform.iOS_9_0, Message = "Use 'DisplayContact.GivenName'.")]
+		[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_11, Message = "Use 'DisplayContact.GivenName'.")]
+		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0, Message = "Use 'DisplayContact.GivenName'.")]
 		[Export ("firstName", ArgumentSemantic.Copy)]
 		string FirstName { get; }
 
-		[Availability (Introduced = Platform.Mac_10_10 | Platform.iOS_8_0, Deprecated = Platform.Mac_10_11 | Platform.iOS_9_0, Message = "Use 'DisplayContact.FamilyName'.")]
+		[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_11, Message = "Use 'DisplayContact.FamilyName'.")]
+		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0, Message = "Use 'DisplayContact.FamilyName'.")]
 		[Export ("lastName", ArgumentSemantic.Copy)]
 		string LastName { get; }
 
@@ -439,7 +447,8 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	delegate void CKDiscoverUserInfosCompletionHandler (NSDictionary emailsToUserInfos, NSDictionary userRecordIdsToUserInfos, NSError operationError);
 
-	[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_10 , Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12, Message = "Use 'CKDiscoverUserIdentitiesOperation' instead.")]
+	[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'CKDiscoverUserIdentitiesOperation' instead.")]
+	[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'CKDiscoverUserIdentitiesOperation' instead.")]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[NoWatch]
 	[BaseType (typeof (CKOperation))]
@@ -493,8 +502,10 @@ namespace XamCore.CloudKit {
 
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (CKOperation))]
-	[Availability (Deprecated = Platform.iOS_11_0 | Platform.Mac_10_13 | Platform.Watch_4_0 | Platform.TV_11_0, 
-		Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
 	interface CKFetchNotificationChangesOperation {
 		[Export ("initWithPreviousServerChangeToken:")]
 		IntPtr Constructor ([NullAllowed] CKServerChangeToken previousServerChangeToken);
@@ -536,7 +547,8 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	delegate void CKFetchRecordChangesHandler (CKServerChangeToken serverChangeToken, NSData clientChangeTokenData, NSError operationError);
 
-	[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_10 , Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12, Message = "Use 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'CKFetchRecordZoneChangesOperation' instead.")]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[NoWatch]
 	[BaseType (typeof (CKDatabaseOperation))]
@@ -764,8 +776,10 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (CKOperation))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: You must call -[CKMarkNotificationsReadOperation initWithNotificationIDsToMarkRead:]
-	[Availability (Deprecated = Platform.iOS_11_0 | Platform.Mac_10_13 | Platform.Watch_4_0 | Platform.TV_11_0, 
-		Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
 	interface CKMarkNotificationsReadOperation {
 
 		[DesignatedInitializer]
@@ -786,7 +800,10 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
 	[DisableDefaultCtor] // does not work on watchOS, working stub provided to ease source compatibility
 	[BaseType (typeof (CKOperation))]
-	[Availability (Deprecated = Platform.iOS_11_0 | Platform.Mac_10_13 | Platform.Watch_4_0 | Platform.TV_11_0)]
+	[Availability (Deprecated = Platform.iOS_11_0)]
+	[Availability (Deprecated = Platform.Mac_10_13)]
+	[Availability (Deprecated = Platform.Watch_4_0)]
+	[Availability (Deprecated = Platform.TV_11_0)]
 	interface CKModifyBadgeOperation {
 
 		[Export ("initWithBadgeValue:")]
@@ -1022,7 +1039,8 @@ namespace XamCore.CloudKit {
 		[NullAllowed, Export ("recordID", ArgumentSemantic.Copy)]
 		CKRecordID RecordId { get; }
 
-		[Availability (Introduced = Platform.iOS_8_0 | Platform.Mac_10_10 , Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12, Message = "Use 'DatabaseScope' instead.")]
+		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'DatabaseScope' instead.")]
+		[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'DatabaseScope' instead.")]
 		[Export ("isPublicDatabase", ArgumentSemantic.UnsafeUnretained)]
 		bool IsPublicDatabase { get; }
 		
@@ -1090,8 +1108,10 @@ namespace XamCore.CloudKit {
 		// [Export ("activityStart")]
 		// ulong ActivityStart ();
 
-		[Availability (Deprecated = Platform.iOS_11_0 | Platform.Mac_10_13 | Platform.Watch_4_0 | Platform.TV_11_0, 
-			Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
 		[NullAllowed, Export ("container", ArgumentSemantic.Retain)]
 		CKContainer Container { get; set; }
 
@@ -1101,8 +1121,10 @@ namespace XamCore.CloudKit {
 		[Export ("usesBackgroundSession", ArgumentSemantic.UnsafeUnretained)]
 		bool UsesBackgroundSession { get; set; }
 
-		[Availability (Deprecated = Platform.iOS_11_0 | Platform.Mac_10_13 | Platform.Watch_4_0 | Platform.TV_11_0, 
-			Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
 		[Export ("allowsCellularAccess", ArgumentSemantic.UnsafeUnretained)]
 		bool AllowsCellularAccess { get; set; }
 
@@ -1114,20 +1136,26 @@ namespace XamCore.CloudKit {
 		[iOS (9,3)][Mac (10,11,4)]
 		[TV (9,2)]
 		[Export ("longLived")]
-		[Availability (Deprecated = Platform.iOS_11_0 | Platform.Mac_10_13 | Platform.Watch_4_0 | Platform.TV_11_0, 
-			Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
 		bool LongLived { [Bind ("isLongLived")] get; set; }
 
 		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Export ("timeoutIntervalForRequest")]
-		[Availability (Deprecated = Platform.iOS_11_0 | Platform.Mac_10_13 | Platform.Watch_4_0 | Platform.TV_11_0, 
-			Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
 		double TimeoutIntervalForRequest { get; set; }
 
 		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Export ("timeoutIntervalForResource")]
-		[Availability (Deprecated = Platform.iOS_11_0 | Platform.Mac_10_13 | Platform.Watch_4_0 | Platform.TV_11_0, 
-			Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
 		double TimeoutIntervalForResource { get; set; }
 
 		[iOS (9,3)][Mac (10,11,4)]

--- a/src/cloudkit.cs
+++ b/src/cloudkit.cs
@@ -182,8 +182,10 @@ namespace XamCore.CloudKit {
 	interface CKContainer {
 
 		[NoWatch]
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'CurrentUserDefaultName' instead.")]
-		[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'CurrentUserDefaultName' instead.")]
+		[iOS (8, 0)]
+		[Mac (10, 10)]
+		[Deprecated (PlatformName.iOS, 10, 0, message : "Use 'CurrentUserDefaultName' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'CurrentUserDefaultName' instead.")]
 		[Field ("CKOwnerDefaultName")]
 		NSString OwnerDefaultName { get; }
 
@@ -241,8 +243,10 @@ namespace XamCore.CloudKit {
 		[Async]
 		void DiscoverAllIdentities (Action<CKUserIdentity[], NSError> completionHandler);
 		
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'DiscoverAllIdentities' instead.")]
-		[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'DiscoverAllIdentities' instead.")]
+		[iOS (8, 0)]
+		[Mac (10, 10)]
+		[Deprecated (PlatformName.iOS, 10, 0, message : "Use 'DiscoverAllIdentities' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'DiscoverAllIdentities' instead.")]
 		[NoWatch]
 		[NoTV]
 		[Export ("discoverAllContactUserInfosWithCompletionHandler:")]
@@ -259,8 +263,10 @@ namespace XamCore.CloudKit {
 		[Async]
 		void DiscoverUserIdentityWithPhoneNumber (string phoneNumber, Action<CKUserIdentity, NSError> completionHandler);
 		
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'DiscoverUserIdentityWithEmailAddress' instead.")]
-		[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'DiscoverUserIdentityWithEmailAddress' instead.")]
+		[iOS (8, 0)]
+		[Mac (10, 10)]
+		[Deprecated (PlatformName.iOS, 10, 0, message : "Use 'DiscoverUserIdentityWithEmailAddress' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'DiscoverUserIdentityWithEmailAddress' instead.")]
 		[NoWatch]
 		[Export ("discoverUserInfoWithEmailAddress:completionHandler:")]
 		[Async]
@@ -271,8 +277,10 @@ namespace XamCore.CloudKit {
 		[Async]
 		void DiscoverUserIdentity (CKRecordID userRecordID, Action<CKUserIdentity, NSError> completionHandler);
 	
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'DiscoverUserIdentity' instead.")]
-		[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'DiscoverUserIdentity' instead.")]
+		[iOS (8, 0)]
+		[Mac (10, 10)]
+		[Deprecated (PlatformName.iOS, 10, 0, message : "Use 'DiscoverUserIdentity' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'DiscoverUserIdentity' instead.")]
 		[NoWatch]
 		[Export ("discoverUserInfoWithUserRecordID:completionHandler:")]
 		[Async]
@@ -403,8 +411,8 @@ namespace XamCore.CloudKit {
 
 	[NoWatch]
 	[NoTV]
-	[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'CKDiscoverAllUserIdentitiesOperation' instead.")]
-	[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'CKDiscoverAllUserIdentitiesOperation' instead.")]
+	[Deprecated (PlatformName.iOS, 10, 0, message : "Use 'CKDiscoverAllUserIdentitiesOperation' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'CKDiscoverAllUserIdentitiesOperation' instead.")]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (CKOperation))]
 	interface CKDiscoverAllContactsOperation {
@@ -413,8 +421,8 @@ namespace XamCore.CloudKit {
 		Action<CKDiscoveredUserInfo[], NSError> DiscoverAllContactsHandler { get; set; }
 	}
 
-	[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'CKUserIdentity' instead.")]
-	[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'CKUserIdentity' instead.")]
+	[Deprecated (PlatformName.iOS, 10, 0, message : "Use 'CKUserIdentity' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'CKUserIdentity' instead.")]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
@@ -423,13 +431,17 @@ namespace XamCore.CloudKit {
 		[Export ("userRecordID", ArgumentSemantic.Copy)]
 		CKRecordID UserRecordId { get; }
 
-		[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_11, Message = "Use 'DisplayContact.GivenName'.")]
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0, Message = "Use 'DisplayContact.GivenName'.")]
+		[iOS (8, 0)]
+		[Mac (10, 10)]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'DisplayContact.GivenName'.")]
+		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'DisplayContact.GivenName'.")]
 		[Export ("firstName", ArgumentSemantic.Copy)]
 		string FirstName { get; }
 
-		[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_11, Message = "Use 'DisplayContact.FamilyName'.")]
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0, Message = "Use 'DisplayContact.FamilyName'.")]
+		[iOS (8, 0)]
+		[Mac (10, 10)]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'DisplayContact.FamilyName'.")]
+		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'DisplayContact.FamilyName'.")]
 		[Export ("lastName", ArgumentSemantic.Copy)]
 		string LastName { get; }
 
@@ -447,8 +459,8 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	delegate void CKDiscoverUserInfosCompletionHandler (NSDictionary emailsToUserInfos, NSDictionary userRecordIdsToUserInfos, NSError operationError);
 
-	[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'CKDiscoverUserIdentitiesOperation' instead.")]
-	[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'CKDiscoverUserIdentitiesOperation' instead.")]
+	[Deprecated (PlatformName.iOS, 10, 0, message : "Use 'CKDiscoverUserIdentitiesOperation' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'CKDiscoverUserIdentitiesOperation' instead.")]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[NoWatch]
 	[BaseType (typeof (CKOperation))]
@@ -502,10 +514,10 @@ namespace XamCore.CloudKit {
 
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (CKOperation))]
-	[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
-	[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
-	[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
-	[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Deprecated (PlatformName.WatchOS, 4, 0, message : "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Deprecated (PlatformName.TvOS, 11, 0, message : "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
 	interface CKFetchNotificationChangesOperation {
 		[Export ("initWithPreviousServerChangeToken:")]
 		IntPtr Constructor ([NullAllowed] CKServerChangeToken previousServerChangeToken);
@@ -547,8 +559,8 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	delegate void CKFetchRecordChangesHandler (CKServerChangeToken serverChangeToken, NSData clientChangeTokenData, NSError operationError);
 
-	[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'CKFetchRecordZoneChangesOperation' instead.")]
-	[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Deprecated (PlatformName.iOS, 10, 0, message : "Use 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'CKFetchRecordZoneChangesOperation' instead.")]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[NoWatch]
 	[BaseType (typeof (CKDatabaseOperation))]
@@ -776,10 +788,10 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (CKOperation))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: You must call -[CKMarkNotificationsReadOperation initWithNotificationIDsToMarkRead:]
-	[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
-	[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
-	[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
-	[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Deprecated (PlatformName.WatchOS, 4, 0, message : "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[Deprecated (PlatformName.TvOS, 11, 0, message : "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
 	interface CKMarkNotificationsReadOperation {
 
 		[DesignatedInitializer]
@@ -800,10 +812,10 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
 	[DisableDefaultCtor] // does not work on watchOS, working stub provided to ease source compatibility
 	[BaseType (typeof (CKOperation))]
-	[Availability (Deprecated = Platform.iOS_11_0)]
-	[Availability (Deprecated = Platform.Mac_10_13)]
-	[Availability (Deprecated = Platform.Watch_4_0)]
-	[Availability (Deprecated = Platform.TV_11_0)]
+	[Deprecated (PlatformName.iOS, 11, 0)]
+	[Deprecated (PlatformName.MacOSX, 10, 13)]
+	[Deprecated (PlatformName.WatchOS, 4, 0)]
+	[Deprecated (PlatformName.TvOS, 11, 0)]
 	interface CKModifyBadgeOperation {
 
 		[Export ("initWithBadgeValue:")]
@@ -1039,8 +1051,10 @@ namespace XamCore.CloudKit {
 		[NullAllowed, Export ("recordID", ArgumentSemantic.Copy)]
 		CKRecordID RecordId { get; }
 
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_10_0, Message = "Use 'DatabaseScope' instead.")]
-		[Availability (Introduced = Platform.Mac_10_10, Deprecated = Platform.Mac_10_12, Message = "Use 'DatabaseScope' instead.")]
+		[iOS (8, 0)]
+		[Mac (10, 10)]
+		[Deprecated (PlatformName.iOS, 10, 0, message : "Use 'DatabaseScope' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'DatabaseScope' instead.")]
 		[Export ("isPublicDatabase", ArgumentSemantic.UnsafeUnretained)]
 		bool IsPublicDatabase { get; }
 		
@@ -1108,10 +1122,10 @@ namespace XamCore.CloudKit {
 		// [Export ("activityStart")]
 		// ulong ActivityStart ();
 
-		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'CKOperationConfiguration' instead.")]
-		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'CKOperationConfiguration' instead.")]
-		[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.WatchOS, 4, 0, message : "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.TvOS, 11, 0, message : "Use 'CKOperationConfiguration' instead.")]
 		[NullAllowed, Export ("container", ArgumentSemantic.Retain)]
 		CKContainer Container { get; set; }
 
@@ -1121,10 +1135,10 @@ namespace XamCore.CloudKit {
 		[Export ("usesBackgroundSession", ArgumentSemantic.UnsafeUnretained)]
 		bool UsesBackgroundSession { get; set; }
 
-		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'CKOperationConfiguration' instead.")]
-		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'CKOperationConfiguration' instead.")]
-		[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.WatchOS, 4, 0, message : "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.TvOS, 11, 0, message : "Use 'CKOperationConfiguration' instead.")]
 		[Export ("allowsCellularAccess", ArgumentSemantic.UnsafeUnretained)]
 		bool AllowsCellularAccess { get; set; }
 
@@ -1136,26 +1150,26 @@ namespace XamCore.CloudKit {
 		[iOS (9,3)][Mac (10,11,4)]
 		[TV (9,2)]
 		[Export ("longLived")]
-		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'CKOperationConfiguration' instead.")]
-		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'CKOperationConfiguration' instead.")]
-		[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.WatchOS, 4, 0, message : "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.TvOS, 11, 0, message : "Use 'CKOperationConfiguration' instead.")]
 		bool LongLived { [Bind ("isLongLived")] get; set; }
 
 		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Export ("timeoutIntervalForRequest")]
-		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'CKOperationConfiguration' instead.")]
-		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'CKOperationConfiguration' instead.")]
-		[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.WatchOS, 4, 0, message : "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.TvOS, 11, 0, message : "Use 'CKOperationConfiguration' instead.")]
 		double TimeoutIntervalForRequest { get; set; }
 
 		[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 		[Export ("timeoutIntervalForResource")]
-		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'CKOperationConfiguration' instead.")]
-		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'CKOperationConfiguration' instead.")]
-		[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.WatchOS, 4, 0, message : "Use 'CKOperationConfiguration' instead.")]
+		[Deprecated (PlatformName.TvOS, 11, 0, message : "Use 'CKOperationConfiguration' instead.")]
 		double TimeoutIntervalForResource { get; set; }
 
 		[iOS (9,3)][Mac (10,11,4)]

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -576,11 +576,11 @@ namespace XamCore.CoreAnimation {
 		[Export ("drawsAsynchronously")]
 		bool DrawsAsynchronously { get; set; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("allowsEdgeAntialiasing")]
 		bool AllowsEdgeAntialiasing { get; set; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("allowsGroupOpacity")]
 		bool AllowsGroupOpacity { get; set; }
 
@@ -1055,11 +1055,11 @@ namespace XamCore.CoreAnimation {
 		[Field ("kCAAnimationPaced")]
 		NSString AnimationPaced { get; }
 
-		[Lion] // iOS 4.0
+		[Mac (10, 7)] // iOS 4.0
 		[Field ("kCAAnimationCubic")]
 		NSString AnimationCubic { get; }
 
-		[Lion] // iOS 4.0
+		[Mac (10, 7)] // iOS 4.0
 		[Field ("kCAAnimationCubicPaced")]
 		NSString AnimationCubicPaced { get; }
 
@@ -1722,7 +1722,7 @@ namespace XamCore.CoreAnimation {
 		NSString RenderAdditive { get; }			
 	}
 
-	[Since(7,0), Mavericks]
+	[Since(7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	interface CAEmitterBehavior : NSSecureCoding {
 

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -1722,7 +1722,7 @@ namespace XamCore.CoreAnimation {
 		NSString RenderAdditive { get; }			
 	}
 
-	[Since(7,0), Mac (10, 9)]
+	[iOS (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	interface CAEmitterBehavior : NSSecureCoding {
 

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -443,19 +443,19 @@ namespace XamCore.CoreAnimation {
 		[Protocolize]
 		CALayerDelegate Delegate { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("shadowColor")]
 		CGColor ShadowColor { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("shadowOffset")]
 		CGSize ShadowOffset { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("shadowOpacity")]
 		float ShadowOpacity { get; set; } /* float, not CGFloat */
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("shadowRadius")]
 		nfloat ShadowRadius { get; set; }
 
@@ -558,29 +558,29 @@ namespace XamCore.CoreAnimation {
 		void AddConstraint (CAConstraint c);
 #endif
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("shouldRasterize")]
 		bool ShouldRasterize { get; set; }
 
 		[NullAllowed]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("shadowPath")]
 		CGPath ShadowPath { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("rasterizationScale")]
 		nfloat RasterizationScale { get; set; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Mac (10,8)]
 		[Export ("drawsAsynchronously")]
 		bool DrawsAsynchronously { get; set; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("allowsEdgeAntialiasing")]
 		bool AllowsEdgeAntialiasing { get; set; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("allowsGroupOpacity")]
 		bool AllowsGroupOpacity { get; set; }
 
@@ -771,11 +771,11 @@ namespace XamCore.CoreAnimation {
 		[Export ("strokeColor")] [NullAllowed]
 		CGColor StrokeColor { get; set; }
 
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("strokeStart")]
 		nfloat StrokeStart { get; set; }
 
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("strokeEnd")]
 		nfloat StrokeEnd { get; set; }
 
@@ -844,7 +844,7 @@ namespace XamCore.CoreAnimation {
 		Natural,
 	}
 
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof (CALayer))]
 	interface CATextLayer {
 		[Export ("layer"), New, Static]
@@ -1013,7 +1013,7 @@ namespace XamCore.CoreAnimation {
 		void DidChangeValueForKey (string key);
 
 		[Export ("shouldArchiveValueForKey:")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		bool ShouldArchiveValueForKey ([NullAllowed] string key);
 
 		[Field ("kCATransitionFade")]
@@ -1333,7 +1333,7 @@ namespace XamCore.CoreAnimation {
 		[Export ("setValue:forKey:")]
 		void SetValueForKey ([NullAllowed] NSObject anObject, NSString key);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Static, Export ("completionBlock"), NullAllowed]
 		NSAction CompletionBlock { get; set; }
 
@@ -1491,7 +1491,7 @@ namespace XamCore.CoreAnimation {
 	}
 #endif
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface CAEmitterCell : CAMediaTiming, NSSecureCoding {
 		[NullAllowed] // by default this property is null
@@ -1621,7 +1621,7 @@ namespace XamCore.CoreAnimation {
 		nfloat ContentsScale { get; set; }
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (CALayer))]
 	interface CAEmitterLayer {
 		[Export ("layer"), New, Static]

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -47,7 +47,7 @@ namespace XamCore.CoreBluetooth {
 
 	[Watch (4,0)]
 	[Since (5,0)]
-	[Lion]
+	[Mac (10, 7)]
 	[BaseType (typeof (CBManager), Delegates=new[] {"WeakDelegate"}, Events = new[] { typeof (CBCentralManagerDelegate)})]
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
 	interface CBCentralManager {

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -46,7 +46,7 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	[Watch (4,0)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Mac (10, 7)]
 	[BaseType (typeof (CBManager), Delegates=new[] {"WeakDelegate"}, Events = new[] { typeof (CBCentralManagerDelegate)})]
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
@@ -107,12 +107,12 @@ namespace XamCore.CoreBluetooth {
 		NSString OptionNotifyOnDisconnectionKey { get; }
 
 		[Mac (10,13)]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("CBConnectPeripheralOptionNotifyOnConnectionKey")]
 		NSString OptionNotifyOnConnectionKey { get; }
 
 		[Mac (10,13)]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("CBConnectPeripheralOptionNotifyOnNotificationKey")]
 		NSString OptionNotifyOnNotificationKey { get; }
 
@@ -122,39 +122,39 @@ namespace XamCore.CoreBluetooth {
 		NSString OptionStartDelayKey { get; }
 
 		[Field ("CBCentralManagerOptionRestoreIdentifierKey")]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,13)]
 		NSString OptionRestoreIdentifierKey { get; }
 
 		[Field ("CBCentralManagerRestoredStatePeripheralsKey")]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,13)]
 		NSString RestoredStatePeripheralsKey { get; }
 
 		[Field ("CBCentralManagerRestoredStateScanServicesKey")]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,13)]
 		NSString RestoredStateScanServicesKey { get; }
 
 		[Field ("CBCentralManagerRestoredStateScanOptionsKey")]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Mac (10,13)]
 		NSString RestoredStateScanOptionsKey { get; }
 
-		[Since (7,0), Mac (10,9)]
+		[iOS (7,0), Mac (10,9)]
 		[Export ("retrievePeripheralsWithIdentifiers:")]
 		CBPeripheral [] RetrievePeripheralsWithIdentifiers ([Params] NSUuid [] identifiers);
 
-		[Since (7,0), Mac (10,9)]
+		[iOS (7,0), Mac (10,9)]
 		[Export ("retrieveConnectedPeripheralsWithServices:")]
 		CBPeripheral [] RetrieveConnectedPeripherals ([Params] CBUUID []  serviceUUIDs);
 
 		[Field ("CBCentralManagerOptionShowPowerAlertKey")]
-		[Since (7,0), Mac (10,9)]
+		[iOS (7,0), Mac (10,9)]
 		NSString OptionShowPowerAlertKey { get; }
 
 		[Field ("CBCentralManagerScanOptionSolicitedServiceUUIDsKey")]
-		[Since (7,0), Mac (10,9)]
+		[iOS (7,0), Mac (10,9)]
 		NSString ScanOptionSolicitedServiceUUIDsKey { get; }
 
 		[iOS (9,0)]
@@ -202,11 +202,11 @@ namespace XamCore.CoreBluetooth {
 		[Field ("CBAdvertisementDataTxPowerLevelKey")]
 		NSString TxPowerLevelKey { get; }
 
-		[Since (7,0), Mac (10,9)]
+		[iOS (7,0), Mac (10,9)]
 		[Field ("CBAdvertisementDataIsConnectable")]
 		NSString IsConnectableKey { get; }
 
-		[Since (7,0), Mac (10,9)]
+		[iOS (7,0), Mac (10,9)]
 		[Field ("CBAdvertisementDataSolicitedServiceUUIDsKey")]
 		NSString SolicitedServiceUuidsKey { get; }
 	}
@@ -226,15 +226,15 @@ namespace XamCore.CoreBluetooth {
 	[Watch (4,0)]
 	[Static, Internal]
 	interface RestoredStateKeys {
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("CBCentralManagerRestoredStatePeripheralsKey")]
 		NSString PeripheralsKey { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("CBCentralManagerRestoredStateScanServicesKey")]
 		NSString ScanServicesKey { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("CBCentralManagerRestoredStateScanOptionsKey")]
 		NSString ScanOptionsKey { get; }
 	}
@@ -277,7 +277,7 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	[Watch (4,0)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Static]
 	interface CBAdvertisement {
 		[Field ("CBAdvertisementDataServiceUUIDsKey")]
@@ -295,22 +295,22 @@ namespace XamCore.CoreBluetooth {
 		[Field ("CBAdvertisementDataServiceDataKey")]
 		NSString DataServiceDataKey { get; }
 
-		[Since (6,0), Mac (10,9)]
+		[iOS (6,0), Mac (10,9)]
 		[Field ("CBAdvertisementDataOverflowServiceUUIDsKey")]
 		NSString DataOverflowServiceUUIDsKey { get; }
 
-		[Since (7,0), Mac (10,9)]
+		[iOS (7,0), Mac (10,9)]
 		[Field ("CBAdvertisementDataIsConnectable")]
 		NSString IsConnectable { get; }
 
-		[Since (7,0), Mac (10,9)]
+		[iOS (7,0), Mac (10,9)]
 		[Field ("CBAdvertisementDataSolicitedServiceUUIDsKey")]
 		NSString DataSolicitedServiceUUIDsKey { get; }
 
 	}
 
 	[Watch (4,0)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (CBAttribute))]
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
 	interface CBCharacteristic {
@@ -336,13 +336,13 @@ namespace XamCore.CoreBluetooth {
 		CBService Service { get; }
 
 #if !XAMCORE_2_0
-		[Since (7,0), Export ("subscribedCentrals"), Mac (10,9)]
+		[iOS (7,0), Export ("subscribedCentrals"), Mac (10,9)]
 		CBCentral [] SubscribedCentrals { get; }
 #endif
 	}
 
 	[Watch (4,0)]
-	[Since (6, 0), Mac (10,9)]
+	[iOS (6, 0), Mac (10,9)]
 	[BaseType (typeof (CBCharacteristic))]
 	[DisableDefaultCtor]
 	interface CBMutableCharacteristic {
@@ -380,13 +380,13 @@ namespace XamCore.CoreBluetooth {
 		CBDescriptor [] Descriptors { get; set; }
 
 #if XAMCORE_2_0
-		[Since (7,0), Export ("subscribedCentrals"), Mac (10,9)]
+		[iOS (7,0), Export ("subscribedCentrals"), Mac (10,9)]
 		CBCentral [] SubscribedCentrals { get; }
 #endif
 	}
 
 	[Watch (4,0)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (CBAttribute))]
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
 	interface CBDescriptor {
@@ -399,7 +399,7 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	[Watch (4,0)]
-	[Since (6, 0), Mac (10,9)]
+	[iOS (6, 0), Mac (10,9)]
 	[BaseType (typeof (CBDescriptor))]
 	[DisableDefaultCtor]
 	interface CBMutableDescriptor {
@@ -413,7 +413,7 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	[Watch (4,0)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (CBPeer), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof (CBPeripheralDelegate)})]
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
 	interface CBPeripheral : NSCopying {
@@ -484,7 +484,7 @@ namespace XamCore.CoreBluetooth {
 		System.IntPtr UUID { get; }
 #endif
 
-		[Since (7,0), Mac (10,9)]
+		[iOS (7,0), Mac (10,9)]
 		[Export ("state")]
 		CBPeripheralState State { get; }
 
@@ -550,11 +550,11 @@ namespace XamCore.CoreBluetooth {
 		[Export ("peripheralDidInvalidateServices:")]
 		void InvalidatedService (CBPeripheral peripheral);	
 
-		[Since (6, 0)]
+		[iOS (6, 0)]
 		[Export ("peripheralDidUpdateName:")]
 		void UpdatedName (CBPeripheral peripheral);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("peripheral:didModifyServices:"), EventArgs ("CBPeripheralServices")]
 		void ModifiedServices (CBPeripheral peripheral, CBService [] services);
 
@@ -569,7 +569,7 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	[Watch (4,0)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (CBAttribute))]
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
 	interface CBService {
@@ -589,7 +589,7 @@ namespace XamCore.CoreBluetooth {
 	}
 		
 	[Watch (4,0)]
-	[Since (6, 0), Mac(10,9)]
+	[iOS (6, 0), Mac(10,9)]
 	[BaseType (typeof (CBService))]
 	[DisableDefaultCtor]
 	interface CBMutableService {
@@ -622,7 +622,7 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	[Watch (4,0)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
 	interface CBUUID : NSCopying {
@@ -645,7 +645,7 @@ namespace XamCore.CoreBluetooth {
 		CBUUID FromCFUUID (IntPtr theUUID);
 		
 		[Static]
-		[Since (7,0), Mac (10,9)]
+		[iOS (7,0), Mac (10,9)]
 		[Export ("UUIDWithNSUUID:")]
 		CBUUID FromNSUuid (NSUuid theUUID);
 
@@ -733,13 +733,13 @@ namespace XamCore.CoreBluetooth {
 		NSString ServiceChangedString { get; }
 #endif // !XAMCORE_3_0
 
-		[Since (7,1)][Mac (10,10)]
+		[iOS (7,1)][Mac (10,10)]
 		[Export ("UUIDString")]
 		string Uuid { get; }
 	}
 		
 	[Watch (4,0)]
-	[Since (6,0), Mac(10,9)]
+	[iOS (6,0), Mac(10,9)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface CBATTRequest {
@@ -772,19 +772,19 @@ namespace XamCore.CoreBluetooth {
 #if MONOMAC
 		// Introduced with iOS7, but does not have NS_AVAILABLE
 		// Moved to a new base class, CBPeer, in iOS 8.
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("identifier")]
 		NSUuid Identifier { get; }
 #endif
 
 		// Introduced with iOS7, but does not have NS_AVAILABLE
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("maximumUpdateValueLength")]
 		nuint MaximumUpdateValueLength { get; }
 	}
 
 	[Watch (4,0)]
-	[Since (6, 0), Mac(10,9)]
+	[iOS (6, 0), Mac(10,9)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (CBManager), Delegates=new[] { "WeakDelegate" }, Events=new[] { typeof (CBPeripheralManagerDelegate) })]
 	interface CBPeripheralManager {
@@ -802,7 +802,7 @@ namespace XamCore.CoreBluetooth {
 		[NoTV]
 		[NoWatch]
 		[DesignatedInitializer]
-		[Since (7,0),Mac (10,9)]
+		[iOS (7,0),Mac (10,9)]
 		[Export ("initWithDelegate:queue:options:")]
 		[PostGet ("WeakDelegate")]
 		IntPtr Constructor ([Protocolize] CBPeripheralManagerDelegate peripheralDelegate, [NullAllowed] DispatchQueue queue, [NullAllowed] NSDictionary options);
@@ -855,23 +855,23 @@ namespace XamCore.CoreBluetooth {
 		void UnpublishL2CapChannel (ushort psm);
 
 		[Field ("CBPeripheralManagerOptionShowPowerAlertKey")]
-		[Since (7,0)]
+		[iOS (7,0)]
 		NSString OptionShowPowerAlertKey { get; }
 
 		[Field ("CBPeripheralManagerOptionRestoreIdentifierKey")]
-		[Since (7,0)]
+		[iOS (7,0)]
 		NSString OptionRestoreIdentifierKey { get; }
 
 		[Field ("CBPeripheralManagerRestoredStateServicesKey")]
-		[Since (7,0)]
+		[iOS (7,0)]
 		NSString RestoredStateServicesKey { get; }
 
 		[Field ("CBPeripheralManagerRestoredStateAdvertisementDataKey")]
-		[Since (7,0)]
+		[iOS (7,0)]
 		NSString RestoredStateAdvertisementDataKey { get; }
 
 #if !MONOMAC || !XAMCORE_4_0
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static]
 		[Export ("authorizationStatus")]
 		CBPeripheralManagerAuthorizationStatus AuthorizationStatus { get; }
@@ -879,7 +879,7 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	[Watch (4,0)]
-	[Since (6, 0), Mac(10,9)]
+	[iOS (6, 0), Mac(10,9)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -928,7 +928,7 @@ namespace XamCore.CoreBluetooth {
 		void DidPublishL2CapChannel (CBPeripheralManager peripheral, ushort psm, [NullAllowed] NSError error);
 	}
 
-	[Since (8, 0)]
+	[iOS (8, 0)]
 	[Mac (10,13)]
 	[Watch (4,0)]
 	[BaseType (typeof (NSObject))]
@@ -942,7 +942,7 @@ namespace XamCore.CoreBluetooth {
 		[Export ("UUID")]
 		IntPtr _UUID { get;  }
 	
-		[Since (7, 0)]
+		[iOS (7, 0)]
 		[Export ("identifier")]
 		NSUuid Identifier { get; }
 	}

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -53,7 +53,8 @@ namespace XamCore.CoreData
 
 	[NoWatch][NoTV]
 	[Native] // NUInteger -> NSPersistentStoreCoordinator.h
-	[Availability (Introduced = Platform.iOS_7_0 | Platform.Mac_10_9 , Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12, Message = "Please see the release notes and Core Data documentation.")]
+	[Availability (Introduced = Platform.iOS_7_0, Deprecated = Platform.iOS_10_0, Message = "Please see the release notes and Core Data documentation.")]
+	[Availability (Introduced = Platform.Mac_10_9 , Deprecated = Platform.Mac_10_12, Message = "Please see the release notes and Core Data documentation.")]
 	public enum NSPersistentStoreUbiquitousTransitionType : nuint_compat_int {
 		AccountAdded = 1,
 		AccountRemoved,
@@ -309,7 +310,8 @@ namespace XamCore.CoreData
 		[Since(5,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("compoundIndexes", ArgumentSemantic.Retain)]
-		[Availability (Introduced = Platform.iOS_5_0 | Platform.Mac_10_7, Deprecated = Platform.iOS_11_0 | Platform.Mac_10_13, Message = "Use 'NSEntityDescription.Indexes' instead.")]
+		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_11_0, Message = "Use 'NSEntityDescription.Indexes' instead.")]
+		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_13, Message = "Use 'NSEntityDescription.Indexes' instead.")]
 		NSPropertyDescription [] CompoundIndexes { get; set; }
 
 		[Watch (4, 0), TV (11, 0), Mac (10, 13), iOS (11, 0)]
@@ -1010,16 +1012,19 @@ namespace XamCore.CoreData
 		bool Save (out NSError error);
 
 #if !WATCH && !TVOS
-		[Availability (Introduced = Platform.iOS_3_0 | Platform.Mac_10_4, Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use a queue style context and 'PerformAndWait' instead.")]
+		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_8_0, Message = "Use a queue style context and 'PerformAndWait' instead.")]
+		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10, Message = "Use a queue style context and 'PerformAndWait' instead.")]
 		[Export ("lock")]
 		new void Lock ();
 
-		[Availability (Introduced = Platform.iOS_3_0 | Platform.Mac_10_4, Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use a queue style context and 'PerformAndWait' instead.")]
+		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_8_0, Message = "Use a queue style context and 'PerformAndWait' instead.")]
+		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10, Message = "Use a queue style context and 'PerformAndWait' instead.")]
 		[Export ("unlock")]
 		new void Unlock ();
 
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_3_0 | Platform.Mac_10_4, Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use a queue style context and 'Perform' instead.")]
+		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_8_0, Message = "Use a queue style context and 'Perform' instead.")]
+		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10, Message = "Use a queue style context and 'Perform' instead.")]
 		[Export ("tryLock")]
 		bool TryLock { get; }
 #endif // !WATCH && !TVOS
@@ -1792,7 +1797,8 @@ namespace XamCore.CoreData
 		[Static, Export ("registerStoreClass:forStoreType:")]
 		void RegisterStoreClass (Class storeClass, NSString storeType);
 
-		[Availability (Introduced = Platform.iOS_3_0 | Platform.Mac_10_5 , Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11, Message = "Use the method that takes an out NSError parameter.")]
+		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_9_0, Message = "Use the method that takes an out NSError parameter.")]
+		[Availability (Introduced = Platform.Mac_10_5 , Deprecated = Platform.Mac_10_11, Message = "Use the method that takes an out NSError parameter.")]
 		[Static, Export ("metadataForPersistentStoreOfType:URL:error:")]
 		[return: NullAllowed]
 		NSDictionary MetadataForPersistentStoreOfType (NSString storeType, NSUrl url, out NSError error);
@@ -2178,7 +2184,8 @@ namespace XamCore.CoreData
 		NSDictionary UserInfo { get; set; }
 
 		[Export ("indexed")]
-		[Availability (Introduced = Platform.iOS_3_0 | Platform.Mac_10_5 , Deprecated = Platform.iOS_11_0 | Platform.Mac_10_13, Message = "Use 'NSEntityDescription.Indexes' instead.")]
+		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_11_0, Message = "Use 'NSEntityDescription.Indexes' instead.")]
+		[Availability (Introduced = Platform.Mac_10_5 , Deprecated = Platform.Mac_10_13, Message = "Use 'NSEntityDescription.Indexes' instead.")]
 		bool Indexed { [Bind ("isIndexed")] get; set; }
 
 		[Export ("versionHash")]
@@ -2198,7 +2205,8 @@ namespace XamCore.CoreData
 
 		[Since (5,0)]
 		[Export ("storedInExternalRecord")]
-		[Availability (Introduced = Platform.iOS_3_0 | Platform.Mac_10_5 , Deprecated = Platform.iOS_11_0 | Platform.Mac_10_13, Message = "Use 'CoreSpotlight' integration instead.")]
+		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_11_0, Message = "Use 'CoreSpotlight' integration instead.")]
+		[Availability (Introduced = Platform.Mac_10_5 , Deprecated = Platform.Mac_10_13, Message = "Use 'CoreSpotlight' integration instead.")]
 		bool StoredInExternalRecord { [Bind ("isStoredInExternalRecord")]get; set; }
 	}
 

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -53,9 +53,9 @@ namespace XamCore.CoreData
 
 	[NoWatch][NoTV]
 	[Native] // NUInteger -> NSPersistentStoreCoordinator.h
-	[Introduced (PlatformName.iOS, 7, 0)]
+	[iOS (7, 0)]
 	[Deprecated (PlatformName.iOS, 10, 0, message : "Please see the release notes and Core Data documentation.")]
-	[Introduced (PlatformName.MacOSX, 10, 9)]
+	[Mac (10, 9)]
 	[Deprecated (PlatformName.MacOSX, 10, 12, message : "Please see the release notes and Core Data documentation.")]
 	public enum NSPersistentStoreUbiquitousTransitionType : nuint_compat_int {
 		AccountAdded = 1,
@@ -312,9 +312,9 @@ namespace XamCore.CoreData
 		[Since(5,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("compoundIndexes", ArgumentSemantic.Retain)]
-		[Introduced (PlatformName.iOS, 5, 0)]
+		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'NSEntityDescription.Indexes' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Mac (10, 7)]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'NSEntityDescription.Indexes' instead.")]
 		NSPropertyDescription [] CompoundIndexes { get; set; }
 
@@ -1016,24 +1016,24 @@ namespace XamCore.CoreData
 		bool Save (out NSError error);
 
 #if !WATCH && !TVOS
-		[Introduced (PlatformName.iOS, 3, 0)]
+		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use a queue style context and 'PerformAndWait' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 4)]
+		[Mac (10, 4)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use a queue style context and 'PerformAndWait' instead.")]
 		[Export ("lock")]
 		new void Lock ();
 
-		[Introduced (PlatformName.iOS, 3, 0)]
+		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use a queue style context and 'PerformAndWait' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 4)]
+		[Mac (10, 4)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use a queue style context and 'PerformAndWait' instead.")]
 		[Export ("unlock")]
 		new void Unlock ();
 
 		[NoTV]
-		[Introduced (PlatformName.iOS, 3, 0)]
+		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use a queue style context and 'Perform' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 4)]
+		[Mac (10, 4)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use a queue style context and 'Perform' instead.")]
 		[Export ("tryLock")]
 		bool TryLock { get; }
@@ -1807,9 +1807,9 @@ namespace XamCore.CoreData
 		[Static, Export ("registerStoreClass:forStoreType:")]
 		void RegisterStoreClass (Class storeClass, NSString storeType);
 
-		[Introduced (PlatformName.iOS, 3, 0)]
+		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 9, 0, message : "Use the method that takes an out NSError parameter.")]
-		[Introduced (PlatformName.MacOSX, 10, 5)]
+		[Mac (10, 5)]
 		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use the method that takes an out NSError parameter.")]
 		[Static, Export ("metadataForPersistentStoreOfType:URL:error:")]
 		[return: NullAllowed]
@@ -2196,9 +2196,9 @@ namespace XamCore.CoreData
 		NSDictionary UserInfo { get; set; }
 
 		[Export ("indexed")]
-		[Introduced (PlatformName.iOS, 3, 0)]
+		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'NSEntityDescription.Indexes' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 5)]
+		[Mac (10, 5)]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'NSEntityDescription.Indexes' instead.")]
 		bool Indexed { [Bind ("isIndexed")] get; set; }
 
@@ -2219,9 +2219,9 @@ namespace XamCore.CoreData
 
 		[Since (5,0)]
 		[Export ("storedInExternalRecord")]
-		[Introduced (PlatformName.iOS, 3, 0)]
+		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'CoreSpotlight' integration instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 5)]
+		[Mac (10, 5)]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'CoreSpotlight' integration instead.")]
 		bool StoredInExternalRecord { [Bind ("isStoredInExternalRecord")]get; set; }
 	}

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -53,8 +53,10 @@ namespace XamCore.CoreData
 
 	[NoWatch][NoTV]
 	[Native] // NUInteger -> NSPersistentStoreCoordinator.h
-	[Availability (Introduced = Platform.iOS_7_0, Deprecated = Platform.iOS_10_0, Message = "Please see the release notes and Core Data documentation.")]
-	[Availability (Introduced = Platform.Mac_10_9 , Deprecated = Platform.Mac_10_12, Message = "Please see the release notes and Core Data documentation.")]
+	[Introduced (PlatformName.iOS, 7, 0)]
+	[Deprecated (PlatformName.iOS, 10, 0, message : "Please see the release notes and Core Data documentation.")]
+	[Introduced (PlatformName.MacOSX, 10, 9)]
+	[Deprecated (PlatformName.MacOSX, 10, 12, message : "Please see the release notes and Core Data documentation.")]
 	public enum NSPersistentStoreUbiquitousTransitionType : nuint_compat_int {
 		AccountAdded = 1,
 		AccountRemoved,
@@ -310,8 +312,10 @@ namespace XamCore.CoreData
 		[Since(5,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("compoundIndexes", ArgumentSemantic.Retain)]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_11_0, Message = "Use 'NSEntityDescription.Indexes' instead.")]
-		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_13, Message = "Use 'NSEntityDescription.Indexes' instead.")]
+		[Introduced (PlatformName.iOS, 5, 0)]
+		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'NSEntityDescription.Indexes' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'NSEntityDescription.Indexes' instead.")]
 		NSPropertyDescription [] CompoundIndexes { get; set; }
 
 		[Watch (4, 0), TV (11, 0), Mac (10, 13), iOS (11, 0)]
@@ -1012,19 +1016,25 @@ namespace XamCore.CoreData
 		bool Save (out NSError error);
 
 #if !WATCH && !TVOS
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_8_0, Message = "Use a queue style context and 'PerformAndWait' instead.")]
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10, Message = "Use a queue style context and 'PerformAndWait' instead.")]
+		[Introduced (PlatformName.iOS, 3, 0)]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use a queue style context and 'PerformAndWait' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 4)]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use a queue style context and 'PerformAndWait' instead.")]
 		[Export ("lock")]
 		new void Lock ();
 
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_8_0, Message = "Use a queue style context and 'PerformAndWait' instead.")]
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10, Message = "Use a queue style context and 'PerformAndWait' instead.")]
+		[Introduced (PlatformName.iOS, 3, 0)]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use a queue style context and 'PerformAndWait' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 4)]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use a queue style context and 'PerformAndWait' instead.")]
 		[Export ("unlock")]
 		new void Unlock ();
 
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_8_0, Message = "Use a queue style context and 'Perform' instead.")]
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10, Message = "Use a queue style context and 'Perform' instead.")]
+		[Introduced (PlatformName.iOS, 3, 0)]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use a queue style context and 'Perform' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 4)]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use a queue style context and 'Perform' instead.")]
 		[Export ("tryLock")]
 		bool TryLock { get; }
 #endif // !WATCH && !TVOS
@@ -1797,8 +1807,10 @@ namespace XamCore.CoreData
 		[Static, Export ("registerStoreClass:forStoreType:")]
 		void RegisterStoreClass (Class storeClass, NSString storeType);
 
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_9_0, Message = "Use the method that takes an out NSError parameter.")]
-		[Availability (Introduced = Platform.Mac_10_5 , Deprecated = Platform.Mac_10_11, Message = "Use the method that takes an out NSError parameter.")]
+		[Introduced (PlatformName.iOS, 3, 0)]
+		[Deprecated (PlatformName.iOS, 9, 0, message : "Use the method that takes an out NSError parameter.")]
+		[Introduced (PlatformName.MacOSX, 10, 5)]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use the method that takes an out NSError parameter.")]
 		[Static, Export ("metadataForPersistentStoreOfType:URL:error:")]
 		[return: NullAllowed]
 		NSDictionary MetadataForPersistentStoreOfType (NSString storeType, NSUrl url, out NSError error);
@@ -2184,8 +2196,10 @@ namespace XamCore.CoreData
 		NSDictionary UserInfo { get; set; }
 
 		[Export ("indexed")]
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_11_0, Message = "Use 'NSEntityDescription.Indexes' instead.")]
-		[Availability (Introduced = Platform.Mac_10_5 , Deprecated = Platform.Mac_10_13, Message = "Use 'NSEntityDescription.Indexes' instead.")]
+		[Introduced (PlatformName.iOS, 3, 0)]
+		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'NSEntityDescription.Indexes' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 5)]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'NSEntityDescription.Indexes' instead.")]
 		bool Indexed { [Bind ("isIndexed")] get; set; }
 
 		[Export ("versionHash")]
@@ -2205,8 +2219,10 @@ namespace XamCore.CoreData
 
 		[Since (5,0)]
 		[Export ("storedInExternalRecord")]
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_11_0, Message = "Use 'CoreSpotlight' integration instead.")]
-		[Availability (Introduced = Platform.Mac_10_5 , Deprecated = Platform.Mac_10_13, Message = "Use 'CoreSpotlight' integration instead.")]
+		[Introduced (PlatformName.iOS, 3, 0)]
+		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'CoreSpotlight' integration instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 5)]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'CoreSpotlight' integration instead.")]
 		bool StoredInExternalRecord { [Bind ("isStoredInExternalRecord")]get; set; }
 	}
 

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -1058,28 +1058,28 @@ namespace XamCore.CoreData
 		void MergeChangesFromContextDidSaveNotification (NSNotification notification);
 
 		[DesignatedInitializer]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("initWithConcurrencyType:")]
 		IntPtr Constructor (NSManagedObjectContextConcurrencyType ct);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("performBlock:")]
 		void Perform (/* non null */ NSAction action);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("performBlockAndWait:")]
 		void PerformAndWait (/* non null */ NSAction action);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("userInfo", ArgumentSemantic.Strong)]
 		NSMutableDictionary UserInfo { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("concurrencyType")]
 		NSManagedObjectContextConcurrencyType ConcurrencyType { get; }
 
 		//Detected properties
-		[Since (5,0)]
+		[iOS (5,0)]
 		// default is null, but setting it to null again would crash the app
 		[NullAllowed, Export ("parentContext", ArgumentSemantic.Retain)]
 		NSManagedObjectContext ParentContext { get; set; }
@@ -1677,7 +1677,7 @@ namespace XamCore.CoreData
 		[Export ("willRemoveFromPersistentStoreCoordinator:")]
 		void WillRemoveFromPersistentStoreCoordinator ([NullAllowed] NSPersistentStoreCoordinator coordinator);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSPersistentStoreSaveConflictsErrorKey")]
 		NSString SaveConflictsErrorKey { get; }
 
@@ -2014,7 +2014,7 @@ namespace XamCore.CoreData
 #endif
 
 #if !MONOMAC
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSPersistentStoreFileProtectionKey")]
 		NSString PersistentStoreFileProtectionKey { get; }
 #endif
@@ -2022,40 +2022,40 @@ namespace XamCore.CoreData
 		// 7.0
 
 		[NoWatch][NoTV]
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("NSPersistentStoreUbiquitousPeerTokenOption")]
 		NSString PersistentStoreUbiquitousPeerTokenOption { get; }
 
 		[NoWatch][NoTV]
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Static]
 		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_10_0, Message = "Please see the release notes and Core Data documentation.")]
 		[Export ("removeUbiquitousContentAndPersistentStoreAtURL:options:error:")]
 		bool RemoveUbiquitousContentAndPersistentStore (NSUrl storeUrl, NSDictionary options, out NSError error);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Notification (typeof (NSPersistentStoreCoordinatorStoreChangeEventArgs))]
 		[Field ("NSPersistentStoreCoordinatorStoresWillChangeNotification")]
 		NSString StoresWillChangeNotification { get; }
 
 		[NoWatch][NoTV]
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("NSPersistentStoreRebuildFromUbiquitousContentOption")]
 		NSString RebuildFromUbiquitousContentOption { get; }
 
 		[NoWatch][NoTV]
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("NSPersistentStoreRemoveUbiquitousMetadataOption")]
 		NSString RemoveUbiquitousMetadataOption { get; }
 
 		[NoWatch][NoTV]
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("NSPersistentStoreUbiquitousContainerIdentifierKey")]
 		[Obsolete ("Use 'UbiquitousContainerIdentifierKey' instead.")]
 		NSString eUbiquitousContainerIdentifierKey { get; }
 
 		[NoWatch][NoTV]
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("NSPersistentStoreUbiquitousContainerIdentifierKey")]
 		NSString UbiquitousContainerIdentifierKey { get; }
 
@@ -2213,11 +2213,11 @@ namespace XamCore.CoreData
 		string RenamingIdentifier { get; set; }
 
 		// 5.0
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("indexedBySpotlight")]
 		bool IndexedBySpotlight { [Bind ("isIndexedBySpotlight")]get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("storedInExternalRecord")]
 		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'CoreSpotlight' integration instead.")]
@@ -2269,7 +2269,7 @@ namespace XamCore.CoreData
 		NSData VersionHash { get; }
 
 		// 5.0
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("ordered")]
 		bool Ordered { [Bind ("isOrdered")]get; set; }
 	}

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -221,7 +221,7 @@ namespace XamCore.CoreData
 		[Export ("valueTransformerName")]
 		string ValueTransformerName { get; set; }
 
-		[Since(5,0)]
+		[iOS (5,0)]
 		[Export ("allowsExternalBinaryDataStorage")]
 		bool AllowsExternalBinaryDataStorage { get; set; }
 	}
@@ -309,7 +309,7 @@ namespace XamCore.CoreData
 		[Export ("versionHashModifier")]
 		string VersionHashModifier { get; set; }
 
-		[Since(5,0)]
+		[iOS (5,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("compoundIndexes", ArgumentSemantic.Retain)]
 		[iOS (5, 0)]
@@ -499,34 +499,34 @@ namespace XamCore.CoreData
 		[NullAllowed]
 		NSPropertyDescription [] PropertiesToFetch { get; set; }
 
-		[Since(5,0)]
+		[iOS (5,0)]
 		[Static]
 		[Export ("fetchRequestWithEntityName:")]
 		// note: Xcode 6.3 changed the return value type from `NSFetchRequest*` to `instancetype`
 		NSFetchRequest FromEntityName (string entityName);
 
-		[Since(5,0)]
+		[iOS (5,0)]
 		[Export ("initWithEntityName:")]
 		IntPtr Constructor (string entityName);
 
-		[Since(5,0)]
+		[iOS (5,0)]
 		[NullAllowed, Export ("entityName", ArgumentSemantic.Strong)]
 		string EntityName { get; }
 
-		[Since(5,0)]
+		[iOS (5,0)]
 		[Export ("fetchBatchSize")]
 		nint FetchBatchSize { get; set; }
 
-		[Since(5,0)]
+		[iOS (5,0)]
 		[Export ("shouldRefreshRefetchedObjects")]
 		bool ShouldRefreshRefetchedObjects { get; set; }
 
-		[Since(5,0)]
+		[iOS (5,0)]
 		[Export ("havingPredicate", ArgumentSemantic.Retain)]
 		[NullAllowed]
 		NSPredicate HavingPredicate { get; set; }
 
-		[Since(5,0)]
+		[iOS (5,0)]
 		[Export ("propertiesToGroupBy", ArgumentSemantic.Copy)]
 		[NullAllowed]
 		NSPropertyDescription [] PropertiesToGroupBy { get; set; }
@@ -647,7 +647,7 @@ namespace XamCore.CoreData
 
 	interface INSFetchedResultsSectionInfo {}
 #endif
-	[Since(5,0)]
+	[iOS (5,0)]
 	// 	NSInvalidArgumentException *** -loadMetadata: cannot be sent to an abstract object of class NSIncrementalStore: Create a concrete instance!
 	//	Apple doc quote: "NSIncrementalStore is an abstract superclass..."
 #if XAMCORE_4_0 // bad API -> should be an abstract type (breaking change)
@@ -702,7 +702,7 @@ namespace XamCore.CoreData
 
 	}
 
-	[Since(5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSIncrementalStoreNode {
 		[Export ("initWithObjectID:withValues:version:")]
@@ -883,7 +883,7 @@ namespace XamCore.CoreData
 		[Export ("validateForUpdate:")]
 		bool ValidateForUpdate (out NSError error);
 
-		[Since(5,0)]
+		[iOS (5,0)]
 		[Export ("hasChanges")]
 		bool HasChanges { get; }
 
@@ -1314,7 +1314,7 @@ namespace XamCore.CoreData
 
 	}
 
-	[Since(5,0)][Mac (10, 7)]
+	[iOS (5,0)][Mac (10, 7)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface NSMergeConflict {
@@ -1357,7 +1357,7 @@ namespace XamCore.CoreData
 #endif
 	}
 
-	[Since(5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface NSMergePolicy {
@@ -1462,7 +1462,7 @@ namespace XamCore.CoreData
 		void CancelMigrationWithError (NSError error);
 
 		// 5.0
-		[Since(5,0)]
+		[iOS (5,0)]
 		[Export ("usesStoreSpecificMigrationManager")]
 		bool UsesStoreSpecificMigrationManager { get; set; }
 	}
@@ -1984,7 +1984,7 @@ namespace XamCore.CoreData
 		NSString WillRemoveStoreNotification { get; }
 		
 		// 5.0
-		[Since(5,0)]
+		[iOS (5,0)]
 		[Export ("executeRequest:withContext:error:")]
 		[return: NullAllowed]
 #if XAMCORE_4_0

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -1304,7 +1304,7 @@ namespace XamCore.CoreData
 
 	}
 
-	[Since(5,0)][Lion]
+	[Since(5,0)][Mac (10, 7)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface NSMergeConflict {
@@ -2010,40 +2010,40 @@ namespace XamCore.CoreData
 		// 7.0
 
 		[NoWatch][NoTV]
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("NSPersistentStoreUbiquitousPeerTokenOption")]
 		NSString PersistentStoreUbiquitousPeerTokenOption { get; }
 
 		[NoWatch][NoTV]
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Static]
 		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_10_0, Message = "Please see the release notes and Core Data documentation.")]
 		[Export ("removeUbiquitousContentAndPersistentStoreAtURL:options:error:")]
 		bool RemoveUbiquitousContentAndPersistentStore (NSUrl storeUrl, NSDictionary options, out NSError error);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Notification (typeof (NSPersistentStoreCoordinatorStoreChangeEventArgs))]
 		[Field ("NSPersistentStoreCoordinatorStoresWillChangeNotification")]
 		NSString StoresWillChangeNotification { get; }
 
 		[NoWatch][NoTV]
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("NSPersistentStoreRebuildFromUbiquitousContentOption")]
 		NSString RebuildFromUbiquitousContentOption { get; }
 
 		[NoWatch][NoTV]
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("NSPersistentStoreRemoveUbiquitousMetadataOption")]
 		NSString RemoveUbiquitousMetadataOption { get; }
 
 		[NoWatch][NoTV]
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("NSPersistentStoreUbiquitousContainerIdentifierKey")]
 		[Obsolete ("Use 'UbiquitousContainerIdentifierKey' instead.")]
 		NSString eUbiquitousContainerIdentifierKey { get; }
 
 		[NoWatch][NoTV]
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("NSPersistentStoreUbiquitousContainerIdentifierKey")]
 		NSString UbiquitousContainerIdentifierKey { get; }
 

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -286,9 +286,9 @@ namespace XamCore.CoreImage {
 		void Render (CIImage image, IMTLTexture texture, [NullAllowed] IMTLCommandBuffer commandBuffer, CGRect bounds, [NullAllowed] CGColorSpace colorSpace);
 #endif
 
-		[Introduced (PlatformName.iOS, 5, 0)]
+		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'DrawImage (image, CGRect, CGRect)' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 4)]
+		[Mac (10, 4)]
 		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Use 'DrawImage (image, CGRect, CGRect)' instead.")]
 		[Export ("drawImage:atPoint:fromRect:")]
 		void DrawImage (CIImage image, CGPoint atPoint, CGRect fromRect);

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -1299,7 +1299,7 @@ namespace XamCore.CoreImage {
 		[Field ("kCIImageColorSpace")]
 		NSString ColorSpaceKey { get; }
 
-		[MountainLion]
+		[Mac (10, 8)]
 		[Field ("kCIImageProperties")]
 		NSString PropertiesKey { get; }
 
@@ -1729,15 +1729,15 @@ namespace XamCore.CoreImage {
 		IntPtr Constructor (UIImage image, [NullAllowed] CIImageInitializationOptions options);
 #endif
 	
-		[MountainLion]
+		[Mac (10, 8)]
 		[Field ("kCIImageAutoAdjustFeatures"), Internal]
 		NSString AutoAdjustFeaturesKey { get; }
 
-		[MountainLion]
+		[Mac (10, 8)]
 		[Field ("kCIImageAutoAdjustRedEye"), Internal]
 		NSString AutoAdjustRedEyeKey { get; }
 
-		[MountainLion]
+		[Mac (10, 8)]
 		[Field ("kCIImageAutoAdjustEnhance"), Internal]
 		NSString AutoAdjustEnhanceKey { get; }
 
@@ -2321,7 +2321,7 @@ namespace XamCore.CoreImage {
 		[Field ("CIDetectorTypeFace"), Internal]
 		NSString TypeFace { get; }
 
-		[MountainLion]
+		[Mac (10, 8)]
 		[Field ("CIDetectorImageOrientation"), Internal]
 		NSString ImageOrientation { get; }
 
@@ -2350,11 +2350,11 @@ namespace XamCore.CoreImage {
 		[Field ("CIDetectorMaxFeatureCount"), Internal]
 		NSString MaxFeatureCount { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("CIDetectorEyeBlink"), Internal]
 		NSString EyeBlink { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("CIDetectorSmile"), Internal]
 		NSString Smile { get; }
 
@@ -2451,27 +2451,27 @@ namespace XamCore.CoreImage {
 		[Export ("trackingFrameCount", ArgumentSemantic.Assign)]
 		int TrackingFrameCount { get; } /* int, not NSInteger */
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("bounds", ArgumentSemantic.Assign)]
 		CGRect Bounds { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("faceAngle", ArgumentSemantic.Assign)]
 		float FaceAngle { get; } /* float, not CGFloat */
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("hasFaceAngle", ArgumentSemantic.Assign)]
 		bool HasFaceAngle { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("hasSmile", ArgumentSemantic.Assign)]
 		bool HasSmile { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("leftEyeClosed", ArgumentSemantic.Assign)]
 		bool LeftEyeClosed { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("rightEyeClosed", ArgumentSemantic.Assign)]
 		bool RightEyeClosed { get; }
 	}

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -286,8 +286,10 @@ namespace XamCore.CoreImage {
 		void Render (CIImage image, IMTLTexture texture, [NullAllowed] IMTLCommandBuffer commandBuffer, CGRect bounds, [NullAllowed] CGColorSpace colorSpace);
 #endif
 
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_6_0, Message = "Use 'DrawImage (image, CGRect, CGRect)' instead.")]
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_8, Message = "Use 'DrawImage (image, CGRect, CGRect)' instead.")]
+		[Introduced (PlatformName.iOS, 5, 0)]
+		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'DrawImage (image, CGRect, CGRect)' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 4)]
+		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Use 'DrawImage (image, CGRect, CGRect)' instead.")]
 		[Export ("drawImage:atPoint:fromRect:")]
 		void DrawImage (CIImage image, CGPoint atPoint, CGRect fromRect);
 

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -286,7 +286,8 @@ namespace XamCore.CoreImage {
 		void Render (CIImage image, IMTLTexture texture, [NullAllowed] IMTLCommandBuffer commandBuffer, CGRect bounds, [NullAllowed] CGColorSpace colorSpace);
 #endif
 
-		[Availability (Introduced = Platform.iOS_5_0 | Platform.Mac_10_4, Deprecated = Platform.iOS_6_0 | Platform.Mac_10_8, Message = "Use 'DrawImage (image, CGRect, CGRect)' instead.")]
+		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_6_0, Message = "Use 'DrawImage (image, CGRect, CGRect)' instead.")]
+		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_8, Message = "Use 'DrawImage (image, CGRect, CGRect)' instead.")]
 		[Export ("drawImage:atPoint:fromRect:")]
 		void DrawImage (CIImage image, CGPoint atPoint, CGRect fromRect);
 

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -49,7 +49,7 @@ using XamCore.ImageKit;
 namespace XamCore.CoreImage {
 
 	[BaseType (typeof (NSObject))]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[DisableDefaultCtor]
 	interface CIColor : NSSecureCoding, NSCopying {
 		[Static]
@@ -202,7 +202,7 @@ namespace XamCore.CoreImage {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[DisableDefaultCtor]
 	interface CIContext {
 		// When we bind OpenGL add these:
@@ -488,7 +488,7 @@ namespace XamCore.CoreImage {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[DisableDefaultCtor] //  In iOS8 they expose custom filters, we expose a protected one in CIFilter.cs
 	interface CIFilter : NSSecureCoding, NSCopying {
 		[Export ("inputKeys")]
@@ -576,11 +576,11 @@ namespace XamCore.CoreImage {
 		[Export ("outputImage")]
 		CIImage OutputImage { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("serializedXMPFromFilters:inputImageExtent:"), Static]
 		NSData SerializedXMP (CIFilter[] filters, CGRect extent); 
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("filterArrayFromSerializedXMP:inputImageExtent:error:"), Static]
 		CIFilter[] FromSerializedXMP (NSData xmpData, CGRect extent, out NSError error);
 #endif
@@ -834,14 +834,14 @@ namespace XamCore.CoreImage {
 		NSSet ActiveKeys { get; }
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Static]
 	interface CIFilterOutputKey {
 		[Field ("kCIOutputImageKey", "+CoreImage")]
 		NSString Image  { get; }
 	}
 	
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Static]
 	interface CIFilterInputKey {
 		[Field ("kCIInputBackgroundImageKey", "+CoreImage")]
@@ -866,63 +866,63 @@ namespace XamCore.CoreImage {
 		[Field ("kCIInputShadingImageKey", "+CoreImage")]
 		NSString ShadingImage  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputTimeKey", "+CoreImage")]
 		NSString Time  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputTransformKey", "+CoreImage")]
 		NSString Transform  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputScaleKey", "+CoreImage")]
 		NSString Scale  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputAspectRatioKey", "+CoreImage")]
 		NSString AspectRatio  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputCenterKey", "+CoreImage")]
 		NSString Center  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputRadiusKey", "+CoreImage")]
 		NSString Radius  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputAngleKey", "+CoreImage")]
 		NSString Angle  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputWidthKey", "+CoreImage")]
 		NSString Width  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputSharpnessKey", "+CoreImage")]
 		NSString Sharpness  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputIntensityKey", "+CoreImage")]
 		NSString Intensity  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputEVKey", "+CoreImage")]
 		NSString EV  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputSaturationKey", "+CoreImage")]
 		NSString Saturation  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputColorKey", "+CoreImage")]
 		NSString Color  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputBrightnessKey", "+CoreImage")]
 		NSString Brightness  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputContrastKey", "+CoreImage")]
 		NSString Contrast  { get; }
 
@@ -934,15 +934,15 @@ namespace XamCore.CoreImage {
 		[Field ("kCIInputWeightsKey", "+CoreImage")]
 		NSString WeightsKey { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputMaskImageKey", "+CoreImage")]
 		NSString MaskImage  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputTargetImageKey", "+CoreImage")]
 		NSString TargetImage  { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("kCIInputExtentKey", "+CoreImage")]
 		NSString Extent  { get; }
 
@@ -955,7 +955,7 @@ namespace XamCore.CoreImage {
 		NSString DisparityImage { get; }
 	}
 		
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Static]
 	interface CIFilterAttributes {
 		[Field ("kCIAttributeFilterName", "+CoreImage")]
@@ -1071,7 +1071,7 @@ namespace XamCore.CoreImage {
 		NSString Available_iOS { get; }
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Static]
 	interface CIFilterCategory {
 		[Field ("kCICategoryDistortionEffect", "+CoreImage")]
@@ -1323,7 +1323,7 @@ namespace XamCore.CoreImage {
 	}
 	
 	[BaseType (typeof (NSObject))]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[DisableDefaultCtor]
 	interface CIImage : NSSecureCoding, NSCopying {
 		[Static]
@@ -1358,7 +1358,7 @@ namespace XamCore.CoreImage {
 #endif
 		CIImage FromData (NSData bitmapData, nint bytesPerRow, CGSize size, int /* CIFormat = int */ pixelFormat, [NullAllowed] CGColorSpace colorSpace);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Static]
 		[Export ("imageWithTexture:size:flipped:colorSpace:")]
 		CIImage ImageWithTexture (uint /* unsigned int */ glTextureName, CGSize size, bool flipped, [NullAllowed] CGColorSpace colorspace);
@@ -1498,7 +1498,7 @@ namespace XamCore.CoreImage {
 		[Export ("initWithBitmapData:bytesPerRow:size:format:colorSpace:")]
 		IntPtr Constructor (NSData d, nint bytesPerRow, CGSize size, int /* CIFormat = int */ pixelFormat, [NullAllowed] CGColorSpace colorSpace);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("initWithTexture:size:flipped:colorSpace:")]
 		IntPtr Constructor (int /* unsigned int */ glTextureName, CGSize size, bool flipped, [NullAllowed] CGColorSpace colorSpace);
 
@@ -1596,11 +1596,11 @@ namespace XamCore.CoreImage {
 		[Export ("extent")]
 		CGRect Extent { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("properties"), Internal]
 		NSDictionary WeakProperties { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Wrap ("WeakProperties")]
 		CoreGraphics.CGImageProperties Properties { get; }
 
@@ -1613,11 +1613,11 @@ namespace XamCore.CoreImage {
 		int FormatRGBA16 { get; } /* CIFormat = int */
 
 		[Field ("kCIFormatARGB8")]
-		[Since (6,0)]
+		[iOS (6,0)]
 		int FormatARGB8 { get; } /* CIFormat = int */
 		
 		[Field ("kCIFormatRGBAh")]
-		[Since (6,0)]
+		[iOS (6,0)]
 		int FormatRGBAh { get; } /* CIFormat = int */
 
 		[iOS (8,0)]
@@ -1625,11 +1625,11 @@ namespace XamCore.CoreImage {
 		int FormatRGBAf { get; } /* CIFormat = int */
 
 		[Field ("kCIFormatBGRA8")]
-		[Since (5,0)]
+		[iOS (5,0)]
 		int FormatBGRA8 { get; } /* CIFormat = int */
 
 		[Field ("kCIFormatRGBA8")]
-		[Since (5,0)]
+		[iOS (5,0)]
 		int FormatRGBA8 { get; } /* CIFormat = int */
 
 		[Field ("kCIFormatABGR8")]
@@ -1718,15 +1718,15 @@ namespace XamCore.CoreImage {
 
 #if !MONOMAC
 		// UIKit extensions
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("initWithImage:")]
 		IntPtr Constructor (UIImage image);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("initWithImage:options:")]
 		IntPtr Constructor (UIImage image, [NullAllowed] NSDictionary options);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Wrap ("this (image, options == null ? null : options.Dictionary)")]
 		IntPtr Constructor (UIImage image, [NullAllowed] CIImageInitializationOptions options);
 #endif
@@ -1751,7 +1751,7 @@ namespace XamCore.CoreImage {
 		[Export ("autoAdjustmentFiltersWithOptions:"), Internal]
 		NSArray _GetAutoAdjustmentFilters ([NullAllowed] NSDictionary opts);
 
-		[Since (6,0)] // publicly documented in 7.0 but really available since 6.0
+		[iOS (6,0)] // publicly documented in 7.0 but really available since 6.0
 		[Mac (10,12)]
 		[Export ("regionOfInterestForImage:inRect:")]
 		CGRect GetRegionOfInterest (CIImage im, CGRect r);
@@ -2201,7 +2201,7 @@ namespace XamCore.CoreImage {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[DisableDefaultCtor]
 	interface CIVector : NSSecureCoding, NSCopying {
 		[Static, Internal, Export ("vectorWithValues:count:")]
@@ -2308,7 +2308,7 @@ namespace XamCore.CoreImage {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[DisableDefaultCtor]
 	interface CIDetector {
 		[Static, Export ("detectorOfType:context:options:"), Internal]
@@ -2336,12 +2336,12 @@ namespace XamCore.CoreImage {
 		[Field ("CIDetectorAccuracyHigh"), Internal]
 		NSString AccuracyHigh { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Mac (10,8)]
 		[Field ("CIDetectorTracking"), Internal]
 		NSString Tracking { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Mac (10,8)]
 		[Field ("CIDetectorMinFeatureSize"), Internal]
 		NSString MinFeatureSize { get; }
@@ -2352,11 +2352,11 @@ namespace XamCore.CoreImage {
 		[Field ("CIDetectorMaxFeatureCount"), Internal]
 		NSString MaxFeatureCount { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("CIDetectorEyeBlink"), Internal]
 		NSString EyeBlink { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("CIDetectorSmile"), Internal]
 		NSString Smile { get; }
 
@@ -2390,7 +2390,7 @@ namespace XamCore.CoreImage {
 	}
 	
 	[BaseType (typeof (NSObject))]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[DisableDefaultCtor]
 	interface CIFeature {
 		[Export ("type", ArgumentSemantic.Retain)]
@@ -2416,7 +2416,7 @@ namespace XamCore.CoreImage {
 	}
 
 	[BaseType (typeof (CIFeature))]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[DisableDefaultCtor]
 	interface CIFaceFeature {
 		[Export ("hasLeftEyePosition", ArgumentSemantic.Assign)]
@@ -2437,43 +2437,43 @@ namespace XamCore.CoreImage {
 		[Export ("mouthPosition", ArgumentSemantic.Assign)]
 		CGPoint MouthPosition { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("hasTrackingID", ArgumentSemantic.Assign)]
 		bool HasTrackingId { get; }
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("trackingID", ArgumentSemantic.Assign)]
 		int TrackingId { get; } /* int, not NSInteger */
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("hasTrackingFrameCount", ArgumentSemantic.Assign)]
 		bool HasTrackingFrameCount { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("trackingFrameCount", ArgumentSemantic.Assign)]
 		int TrackingFrameCount { get; } /* int, not NSInteger */
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("bounds", ArgumentSemantic.Assign)]
 		CGRect Bounds { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("faceAngle", ArgumentSemantic.Assign)]
 		float FaceAngle { get; } /* float, not CGFloat */
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("hasFaceAngle", ArgumentSemantic.Assign)]
 		bool HasFaceAngle { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("hasSmile", ArgumentSemantic.Assign)]
 		bool HasSmile { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("leftEyeClosed", ArgumentSemantic.Assign)]
 		bool LeftEyeClosed { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("rightEyeClosed", ArgumentSemantic.Assign)]
 		bool RightEyeClosed { get; }
 	}

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -230,13 +230,15 @@ namespace XamCore.CoreLocation {
 		bool SignificantLocationChangeMonitoringAvailable { get; }
 
 		[NoWatch][NoTV]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'IsMonitoringAvailable' instead.")]
+		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_7_0, Message = "Use 'IsMonitoringAvailable' instead.")]
+		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'IsMonitoringAvailable' instead.")]
 		[Export ("regionMonitoringAvailable"), Static]
 		bool RegionMonitoringAvailable { get; }
 
 		[NoWatch][NoTV]
 		[Since (4,0)]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_6_0 | Platform.Mac_10_10, Message = "Use 'IsMonitoringAvailable' and 'AuthorizationStatus' instead.")]
+		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0, Message = "Use 'IsMonitoringAvailable' and 'AuthorizationStatus' instead.")]
+		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'IsMonitoringAvailable' and 'AuthorizationStatus' instead.")]
 		[Export ("regionMonitoringEnabled"), Static]
 		bool RegionMonitoringEnabled { get; }
 
@@ -511,12 +513,14 @@ namespace XamCore.CoreLocation {
 	[DisableDefaultCtor] // will crash, see CoreLocation.cs for compatibility stubs
 	partial interface CLRegion : NSSecureCoding, NSCopying {
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'CLCircularRegion' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'CLCircularRegion' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'CLCircularRegion' instead.")]
 		[Export ("center")]
 		CLLocationCoordinate2D Center { get;  }
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'CLCircularRegion' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'CLCircularRegion' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'CLCircularRegion' instead.")]
 		[Export ("radius")]
 		double Radius { get;  }
 
@@ -524,12 +528,14 @@ namespace XamCore.CoreLocation {
 		string Identifier { get;  }
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'CLCircularRegion' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'CLCircularRegion' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'CLCircularRegion' instead.")]
 		[Export ("initCircularRegionWithCenter:radius:identifier:")]
 		IntPtr Constructor (CLLocationCoordinate2D center, double radius, string identifier);
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'CLCircularRegion' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'CLCircularRegion' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'CLCircularRegion' instead.")]
 		[Export ("containsCoordinate:")]
 		bool Contains (CLLocationCoordinate2D coordinate);
 

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -108,11 +108,11 @@ namespace XamCore.CoreLocation {
 		double Distancefrom (CLLocation  location);
 #endif
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("distanceFromLocation:")]
 		double DistanceFrom (CLLocation location);
 
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("initWithCoordinate:altitude:horizontalAccuracy:verticalAccuracy:course:speed:timestamp:")]
 		IntPtr Constructor (CLLocationCoordinate2D coordinate, double altitude, double hAccuracy, double vAccuracy, double course, double speed, NSDate timestamp);
 
@@ -186,7 +186,7 @@ namespace XamCore.CoreLocation {
 		[Export ("stopUpdatingLocation")]
 		void StopUpdatingLocation ();
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("locationServicesEnabled"), Static]
 		bool LocationServicesEnabled { get; }
 
@@ -209,7 +209,7 @@ namespace XamCore.CoreLocation {
 #endif
 	
 		[NoWatch][NoTV]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Mac (10,7)]
 		[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_6_0)]
 		// Default property value is null but it cannot be set to that value
@@ -218,13 +218,13 @@ namespace XamCore.CoreLocation {
 		string Purpose { get; set; }
 
 		[NoWatch][NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Mac (10,7)]
 		[Export ("headingAvailable"), Static]
 		bool HeadingAvailable { get; }
 
 		[NoWatch][NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Mac (10,7)]
 		[Export ("significantLocationChangeMonitoringAvailable"), Static]
 		bool SignificantLocationChangeMonitoringAvailable { get; }
@@ -238,7 +238,7 @@ namespace XamCore.CoreLocation {
 		bool RegionMonitoringAvailable { get; }
 
 		[NoWatch][NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[iOS (4, 0)]
 		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'IsMonitoringAvailable' and 'AuthorizationStatus' instead.")]
 		[Mac (10, 8)]
@@ -248,61 +248,61 @@ namespace XamCore.CoreLocation {
 
 #if !MONOMAC
 		[NoWatch][NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("headingOrientation", ArgumentSemantic.Assign)]
 		CLDeviceOrientation HeadingOrientation { get; set; }
 
 		[NoWatch][NoTV]
 		[Export ("heading", ArgumentSemantic.Copy)]
-		[Since (4,0)]
+		[iOS (4,0)]
 		CLHeading Heading { get; }
 #endif
 
 		[NoWatch][NoTV]
 		[Export ("maximumRegionMonitoringDistance")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Mac (10,8)]
 		double MaximumRegionMonitoringDistance { get; }
 
 		[NoWatch][NoTV]
 		[Export ("monitoredRegions", ArgumentSemantic.Copy)]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Mac (10,8)]
 		NSSet MonitoredRegions { get; }
 
 		[NoWatch][NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Mac (10,7)]
 		[Export ("startMonitoringSignificantLocationChanges")]
 		void StartMonitoringSignificantLocationChanges ();
 
 		[NoWatch][NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Mac (10,7)]
 		[Export ("stopMonitoringSignificantLocationChanges")]
 		void StopMonitoringSignificantLocationChanges ();
 
 #if !MONOMAC
 		[NoWatch][NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0)]
 		[Export ("startMonitoringForRegion:desiredAccuracy:")]
 		void StartMonitoring (CLRegion region, double desiredAccuracy);
 #endif
 
 		[NoWatch][NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Mac (10,8)]
 		[Export ("stopMonitoringForRegion:")]
 		void StopMonitoring (CLRegion region);
 
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Mac (10,7)]
 		[Export ("authorizationStatus")][Static]
 		CLAuthorizationStatus Status { get; }
 
 		[NoWatch][NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Mac (10,8)]
 		[Export ("startMonitoringForRegion:")]
 		void StartMonitoring (CLRegion region);
@@ -310,62 +310,62 @@ namespace XamCore.CoreLocation {
 #if !MONOMAC
 		[NoTV]
 		[Watch (4,0)]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("activityType", ArgumentSemantic.Assign)]
 		CLActivityType ActivityType  { get; set; }
 
 		[NoWatch][NoTV]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("pausesLocationUpdatesAutomatically", ArgumentSemantic.Assign)]
 		bool PausesLocationUpdatesAutomatically { get; set; }
 
 		[NoWatch][NoTV]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("allowDeferredLocationUpdatesUntilTraveled:timeout:")]
 		void AllowDeferredLocationUpdatesUntil (double distance, double timeout);
 
 		[NoWatch][NoTV]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("disallowDeferredLocationUpdates")]
 		void DisallowDeferredLocationUpdates ();
 #endif
 
 		[NoWatch][NoTV]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Mac (10,9)]
 		[Static]
 		[Export ("deferredLocationUpdatesAvailable")]
 		bool DeferredLocationUpdatesAvailable { get; }
 
 #if !MONOMAC
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("CLTimeIntervalMax")]
 		double MaxTimeInterval { get; }
 #endif
 
 		[NoWatch][NoTV]
 		[Mac (10,10)]
-		[Since (7,0), Static, Export ("isMonitoringAvailableForClass:")]
+		[iOS (7,0), Static, Export ("isMonitoringAvailableForClass:")]
 		bool IsMonitoringAvailable (Class regionClass);
 
 #if !MONOMAC
 		[NoWatch][NoTV]
-		[Since (7,0), Export ("rangedRegions", ArgumentSemantic.Copy)]
+		[iOS (7,0), Export ("rangedRegions", ArgumentSemantic.Copy)]
 		NSSet RangedRegions { get; }
 #endif
 
 		[Mac (10,10)]
 		[NoWatch][NoTV]
-		[Since (7,0), Export ("requestStateForRegion:")]
+		[iOS (7,0), Export ("requestStateForRegion:")]
 		void RequestState (CLRegion region);
 
 #if !MONOMAC
 		[NoWatch][NoTV]
-		[Since (7,0), Export ("startRangingBeaconsInRegion:")]
+		[iOS (7,0), Export ("startRangingBeaconsInRegion:")]
 		void StartRangingBeacons (CLBeaconRegion region);
 
 		[NoWatch][NoTV]
-		[Since (7,0), Export ("stopRangingBeaconsInRegion:")]
+		[iOS (7,0), Export ("stopRangingBeaconsInRegion:")]
 		void StopRangingBeacons (CLBeaconRegion region);
 
 		[NoWatch][NoTV]
@@ -432,19 +432,19 @@ namespace XamCore.CoreLocation {
 		void Failed (CLLocationManager manager, NSError error);
 
 		[NoWatch][NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Mac (10,8)]
 		[Export ("locationManager:didEnterRegion:"), EventArgs ("CLRegion")]
 		void RegionEntered (CLLocationManager manager, CLRegion region);
 
 		[NoWatch][NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Mac (10,8)]
 		[Export ("locationManager:didExitRegion:"), EventArgs ("CLRegion")]
 		void RegionLeft (CLLocationManager manager, CLRegion region);
 
 		[NoWatch][NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Mac (10,8)]
 		[Export ("locationManager:monitoringDidFailForRegion:withError:"), EventArgs ("CLRegionError")]
 		void MonitoringFailed (CLLocationManager manager, CLRegion region, NSError error);
@@ -457,16 +457,16 @@ namespace XamCore.CoreLocation {
 
 		[NoWatch][NoTV]
 		[Mac (10,10)]
-		[Since (7,0), Export ("locationManager:didDetermineState:forRegion:"), EventArgs ("CLRegionStateDetermined")]
+		[iOS (7,0), Export ("locationManager:didDetermineState:forRegion:"), EventArgs ("CLRegionStateDetermined")]
 		void DidDetermineState (CLLocationManager manager, CLRegionState state, CLRegion region);
 
 #if !MONOMAC
 		[NoWatch][NoTV]
-		[Since (7,0), Export ("locationManager:didRangeBeacons:inRegion:"), EventArgs ("CLRegionBeaconsRanged")]
+		[iOS (7,0), Export ("locationManager:didRangeBeacons:inRegion:"), EventArgs ("CLRegionBeaconsRanged")]
 		void DidRangeBeacons (CLLocationManager manager, CLBeacon [] beacons, CLBeaconRegion region);
 
 		[NoWatch][NoTV]
-		[Since (7,0), Export ("locationManager:rangingBeaconsDidFailForRegion:withError:"), EventArgs ("CLRegionBeaconsFailed")]
+		[iOS (7,0), Export ("locationManager:rangingBeaconsDidFailForRegion:withError:"), EventArgs ("CLRegionBeaconsFailed")]
 		void RangingBeaconsDidFailForRegion (CLLocationManager manager, CLBeaconRegion region, NSError error);
 
 		[NoWatch][NoTV]
@@ -475,26 +475,26 @@ namespace XamCore.CoreLocation {
 		void DidVisit (CLLocationManager manager, CLVisit visit);
 #endif
 
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("locationManager:didChangeAuthorizationStatus:"), EventArgs ("CLAuthorizationChanged")]
 		void AuthorizationChanged (CLLocationManager manager, CLAuthorizationStatus status);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("locationManager:didUpdateLocations:"), EventArgs ("CLLocationsUpdated")]
 		void LocationsUpdated (CLLocationManager manager, CLLocation[] locations);
 
 		[NoWatch][NoTV]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("locationManagerDidPauseLocationUpdates:"), EventArgs ("")]
 		void LocationUpdatesPaused (CLLocationManager manager);
 
 		[NoWatch][NoTV]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("locationManagerDidResumeLocationUpdates:"), EventArgs ("")]
 		void LocationUpdatesResumed (CLLocationManager manager);
 
 		[NoWatch][NoTV]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("locationManager:didFinishDeferredUpdatesWithError:"), EventArgs ("NSError", true)]
 		void DeferredUpdatesFinished (CLLocationManager manager, NSError error);
 	}
@@ -502,7 +502,7 @@ namespace XamCore.CoreLocation {
 	[Static]
 	partial interface CLLocationDistance {
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Mac (10,9)]
 		[Field ("CLLocationDistanceMax")]
 		double MaxDistance { get; }
@@ -511,7 +511,7 @@ namespace XamCore.CoreLocation {
 		double FilterNone { get; }
 	}
 		
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Mac (10,7)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // will crash, see CoreLocation.cs for compatibility stubs
@@ -543,16 +543,16 @@ namespace XamCore.CoreLocation {
 		[Export ("containsCoordinate:")]
 		bool Contains (CLLocationCoordinate2D coordinate);
 
-		[Since (7,0), Export ("notifyOnEntry", ArgumentSemantic.Assign)]
+		[iOS (7,0), Export ("notifyOnEntry", ArgumentSemantic.Assign)]
 		[Mac (10,10)]
 		bool NotifyOnEntry { get; set; }
 
-		[Since (7,0), Export ("notifyOnExit", ArgumentSemantic.Assign)]
+		[iOS (7,0), Export ("notifyOnExit", ArgumentSemantic.Assign)]
 		[Mac (10,10)]
 		bool NotifyOnExit { get; set; }
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Mac (10,8)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // will crash, see CoreLocation.cs for compatibility stubs
@@ -623,7 +623,7 @@ namespace XamCore.CoreLocation {
 	}
 
 	[Mac (10,10)]
-	[Since (7,0), BaseType (typeof (CLRegion))]
+	[iOS (7,0), BaseType (typeof (CLRegion))]
 #if MONOMAC
 	[DisableDefaultCtor]
 #endif
@@ -644,7 +644,7 @@ namespace XamCore.CoreLocation {
 
 #if !MONOMAC
 	[NoWatch][NoMac][NoTV]
-	[Since (7,0), BaseType (typeof (CLRegion))]
+	[iOS (7,0), BaseType (typeof (CLRegion))]
 	[DisableDefaultCtor] // nil-Handle on iOS8 if 'init' is used
 	partial interface CLBeaconRegion {
 
@@ -674,7 +674,7 @@ namespace XamCore.CoreLocation {
 	}
 
 	[NoWatch][NoMac][NoTV]
-	[Since (7,0), BaseType (typeof (NSObject))]
+	[iOS (7,0), BaseType (typeof (NSObject))]
 	partial interface CLBeacon : NSCopying, NSSecureCoding {
 
 		[Export ("proximityUUID", ArgumentSemantic.Copy)]
@@ -701,7 +701,7 @@ namespace XamCore.CoreLocation {
 	delegate void CLGeocodeCompletionHandler (CLPlacemark [] placemarks, NSError error);
 
 	[Mac (10,8)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface CLGeocoder {
 		[Export ("isGeocoding")]

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -230,15 +230,19 @@ namespace XamCore.CoreLocation {
 		bool SignificantLocationChangeMonitoringAvailable { get; }
 
 		[NoWatch][NoTV]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_7_0, Message = "Use 'IsMonitoringAvailable' instead.")]
-		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'IsMonitoringAvailable' instead.")]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'IsMonitoringAvailable' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'IsMonitoringAvailable' instead.")]
 		[Export ("regionMonitoringAvailable"), Static]
 		bool RegionMonitoringAvailable { get; }
 
 		[NoWatch][NoTV]
 		[Since (4,0)]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0, Message = "Use 'IsMonitoringAvailable' and 'AuthorizationStatus' instead.")]
-		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'IsMonitoringAvailable' and 'AuthorizationStatus' instead.")]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'IsMonitoringAvailable' and 'AuthorizationStatus' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'IsMonitoringAvailable' and 'AuthorizationStatus' instead.")]
 		[Export ("regionMonitoringEnabled"), Static]
 		bool RegionMonitoringEnabled { get; }
 
@@ -513,14 +517,14 @@ namespace XamCore.CoreLocation {
 	[DisableDefaultCtor] // will crash, see CoreLocation.cs for compatibility stubs
 	partial interface CLRegion : NSSecureCoding, NSCopying {
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'CLCircularRegion' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'CLCircularRegion' instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'CLCircularRegion' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'CLCircularRegion' instead.")]
 		[Export ("center")]
 		CLLocationCoordinate2D Center { get;  }
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'CLCircularRegion' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'CLCircularRegion' instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'CLCircularRegion' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'CLCircularRegion' instead.")]
 		[Export ("radius")]
 		double Radius { get;  }
 
@@ -528,14 +532,14 @@ namespace XamCore.CoreLocation {
 		string Identifier { get;  }
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'CLCircularRegion' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'CLCircularRegion' instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'CLCircularRegion' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'CLCircularRegion' instead.")]
 		[Export ("initCircularRegionWithCenter:radius:identifier:")]
 		IntPtr Constructor (CLLocationCoordinate2D center, double radius, string identifier);
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'CLCircularRegion' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'CLCircularRegion' instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'CLCircularRegion' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'CLCircularRegion' instead.")]
 		[Export ("containsCoordinate:")]
 		bool Contains (CLLocationCoordinate2D coordinate);
 

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -449,7 +449,7 @@ namespace XamCore.CoreLocation {
 		void MonitoringFailed (CLLocationManager manager, CLRegion region, NSError error);
 
 		[NoWatch][NoTV]
-		[Since(5,0)]
+		[iOS (5,0)]
 		[Mac (10,8)]
 		[Export ("locationManager:didStartMonitoringForRegion:"), EventArgs ("CLRegion")]
 		void DidStartMonitoringForRegion (CLLocationManager manager, CLRegion region);

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -230,18 +230,18 @@ namespace XamCore.CoreLocation {
 		bool SignificantLocationChangeMonitoringAvailable { get; }
 
 		[NoWatch][NoTV]
-		[Introduced (PlatformName.iOS, 4, 0)]
+		[iOS (4, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'IsMonitoringAvailable' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'IsMonitoringAvailable' instead.")]
 		[Export ("regionMonitoringAvailable"), Static]
 		bool RegionMonitoringAvailable { get; }
 
 		[NoWatch][NoTV]
 		[Since (4,0)]
-		[Introduced (PlatformName.iOS, 4, 0)]
+		[iOS (4, 0)]
 		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'IsMonitoringAvailable' and 'AuthorizationStatus' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'IsMonitoringAvailable' and 'AuthorizationStatus' instead.")]
 		[Export ("regionMonitoringEnabled"), Static]
 		bool RegionMonitoringEnabled { get; }

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -119,7 +119,7 @@ namespace XamCore.CoreLocation {
 		// Apple keep changing the 'introduction' of this field (5.0->8.0->5.0) but it was not available in 6.1
 		// nor in 7.0 - but it works on my iPad3 running iOS 7.1
 		[NoTV][NoWatch]
-		[iOS (7,1)][MountainLion]
+		[iOS (7,1)][Mac (10, 8)]
 		[Field ("kCLErrorUserInfoAlternateRegionKey")]
 		NSString ErrorUserInfoAlternateRegionKey { get; }
 

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -238,7 +238,6 @@ namespace XamCore.CoreLocation {
 		bool RegionMonitoringAvailable { get; }
 
 		[NoWatch][NoTV]
-		[iOS (4,0)]
 		[iOS (4, 0)]
 		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'IsMonitoringAvailable' and 'AuthorizationStatus' instead.")]
 		[Mac (10, 8)]

--- a/src/coremedia.cs
+++ b/src/coremedia.cs
@@ -19,7 +19,7 @@ namespace XamCore.CoreMedia {
 	}
 
 	[Static][Internal]
-	[Mavericks, iOS (6,0)]
+	[Mac (10, 9), iOS (6,0)]
 	interface CMTextMarkupAttributesKeys {
 		[Internal][Field ("kCMTextMarkupAttribute_ForegroundColorARGB")]
 		NSString ForegroundColorARGB { get; }

--- a/src/coremedia.cs
+++ b/src/coremedia.cs
@@ -19,7 +19,7 @@ namespace XamCore.CoreMedia {
 	}
 
 	[Static][Internal]
-	[Mavericks, Since (6,0)]
+	[Mavericks, iOS (6,0)]
 	interface CMTextMarkupAttributesKeys {
 		[Internal][Field ("kCMTextMarkupAttribute_ForegroundColorARGB")]
 		NSString ForegroundColorARGB { get; }

--- a/src/coremotion.cs
+++ b/src/coremotion.cs
@@ -15,7 +15,7 @@ using XamCore.UIKit;
 using System;
 
 namespace XamCore.CoreMotion {
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (CMLogItem))]
 	[DisableDefaultCtor] // will crash, see Extra.cs for compatibility stubs
 	interface CMAccelerometerData : NSSecureCoding {
@@ -34,7 +34,7 @@ namespace XamCore.CoreMotion {
 		NSDate StartDate { get; }
 	}
 
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // will crash, see Extra.cs for compatibility stubs
 	interface CMLogItem : NSSecureCoding, NSCopying {
@@ -47,7 +47,7 @@ namespace XamCore.CoreMotion {
 	delegate void CMDeviceMotionHandler (CMDeviceMotion motion, NSError error);
 
 	[BaseType (typeof (NSObject))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	interface CMMotionManager {
 		[Export ("accelerometerAvailable")]
 		bool AccelerometerAvailable { [Bind ("isAccelerometerAvailable")] get;  }
@@ -112,57 +112,57 @@ namespace XamCore.CoreMotion {
 		[Export ("stopDeviceMotionUpdates")]
 		void StopDeviceMotionUpdates ();
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("magnetometerUpdateInterval")]
 		double MagnetometerUpdateInterval { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("magnetometerAvailable")]
 		bool MagnetometerAvailable { [Bind ("isMagnetometerAvailable")] get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("magnetometerActive")]
 		bool MagnetometerActive { [Bind ("isMagnetometerActive")] get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("magnetometerData")]
 		CMMagnetometerData MagnetometerData { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("startMagnetometerUpdates")]
 		void StartMagnetometerUpdates ();
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("startMagnetometerUpdatesToQueue:withHandler:")]
 		void StartMagnetometerUpdates (NSOperationQueue queue, CMMagnetometerHandler handler);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("stopMagnetometerUpdates")]
 		void StopMagnetometerUpdates ();
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("availableAttitudeReferenceFrames"), Static]
 		CMAttitudeReferenceFrame AvailableAttitudeReferenceFrames { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("attitudeReferenceFrame")]
 		CMAttitudeReferenceFrame AttitudeReferenceFrame { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("startDeviceMotionUpdatesUsingReferenceFrame:")]
 		void StartDeviceMotionUpdates (CMAttitudeReferenceFrame referenceFrame);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("startDeviceMotionUpdatesUsingReferenceFrame:toQueue:withHandler:")]
 		void StartDeviceMotionUpdates (CMAttitudeReferenceFrame referenceFrame, NSOperationQueue queue, CMDeviceMotionHandler handler);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("showsDeviceMovementDisplay")]
 		bool ShowsDeviceMovementDisplay { get; set; }
 	}
 
 	[BaseType (typeof (NSObject))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	//<quote>You access CMAttitude objects through the attitude property of each CMDeviceMotion objects passed to an application.</quote>
 	[DisableDefaultCtor] // will crash, see Extra.cs for compatibility stubs
 	interface CMAttitude : NSSecureCoding, NSCopying {
@@ -186,7 +186,7 @@ namespace XamCore.CoreMotion {
 	}
 
 	[BaseType (typeof (CMLogItem))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[DisableDefaultCtor] // will crash, see Extra.cs for compatibility stubs
 	interface CMDeviceMotion : NSSecureCoding {
 		[Export ("rotationRate")]
@@ -201,7 +201,7 @@ namespace XamCore.CoreMotion {
 		[Export ("attitude")]
 		CMAttitude Attitude { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("magneticField")]
 		CMCalibratedMagneticField MagneticField { get; }
 
@@ -211,7 +211,7 @@ namespace XamCore.CoreMotion {
 	}
 
 	[BaseType (typeof (CMLogItem))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[DisableDefaultCtor] // will crash, see Extra.cs for compatibility stubs
 	interface CMGyroData : NSSecureCoding {
 		[Export ("rotationRate")]
@@ -219,26 +219,26 @@ namespace XamCore.CoreMotion {
 	}
 
 	[BaseType (typeof (CMLogItem))]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[DisableDefaultCtor] // will crash, see Extra.cs for compatibility stubs
 	interface CMMagnetometerData : NSSecureCoding {
 		[Export ("magneticField")]
 		CMMagneticField MagneticField { get; }
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	delegate void CMMagnetometerHandler (CMMagnetometerData magnetometerData, NSError error);
 
 	[NoWatch]
-	[Since (7,0)]
+	[iOS (7,0)]
 	delegate void CMStepQueryHandler (nint numberOfSteps, NSError error);
 
 	[NoWatch]
-	[Since (7,0)]
+	[iOS (7,0)]
 	delegate void CMStepUpdateHandler (nint numberOfSteps, NSDate timestamp, NSError error);
 
 	[NoWatch]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'CMPedometer' instead.")]
 	interface CMStepCounter {
@@ -351,13 +351,13 @@ namespace XamCore.CoreMotion {
 		CMAuthorizationStatus AuthorizationStatus { get; }
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	delegate void CMMotionActivityHandler (CMMotionActivity activity);
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	delegate void CMMotionActivityQueryHandler (CMMotionActivity[] activities, NSError error);
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	interface CMMotionActivityManager {
 
@@ -381,7 +381,7 @@ namespace XamCore.CoreMotion {
 		CMAuthorizationStatus AuthorizationStatus { get; }
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (CMLogItem))]
 	[DisableDefaultCtor] // <quote>You do not create instances of this class yourself.</quote>
 	interface CMMotionActivity : NSCopying, NSSecureCoding {

--- a/src/coretelephony.cs
+++ b/src/coretelephony.cs
@@ -3,7 +3,7 @@ using XamCore.ObjCRuntime;
 using System;
 
 namespace XamCore.CoreTelephony {
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	interface CTCall {
 		[Availability (Deprecated = Platform.iOS_10_0, Message = "Use 'CallKit' instead.")]
@@ -32,7 +32,7 @@ namespace XamCore.CoreTelephony {
 #endif
 
 	[Static]
-	[Since (7,0)]
+	[iOS (7,0)]
 	interface CTRadioAccessTechnology {
 		[Field ("CTRadioAccessTechnologyGPRS")]
 		NSString GPRS { get; }
@@ -69,7 +69,7 @@ namespace XamCore.CoreTelephony {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	interface CTTelephonyNetworkInfo {
 		[Export ("subscriberCellularProvider", ArgumentSemantic.Retain)]
 		CTCarrier SubscriberCellularProvider { get; }
@@ -82,7 +82,7 @@ namespace XamCore.CoreTelephony {
 		CTCarrierEventHandler CellularProviderUpdatedEventHandler { get; set; }
 #endif
 
-		[Since (7,0), Export ("currentRadioAccessTechnology")]
+		[iOS (7,0), Export ("currentRadioAccessTechnology")]
 		NSString CurrentRadioAccessTechnology { get; }
 	}
 
@@ -92,7 +92,7 @@ namespace XamCore.CoreTelephony {
 
 	[Deprecated (PlatformName.iOS, 10, 0, message: "Replaced by 'CXCallObserver' from 'CallKit'.")]
 	[BaseType (typeof (NSObject))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	interface CTCallCenter {
 		[Availability (Deprecated = Platform.iOS_10_0, Message = "Use 'CallKit' instead.")]
 		[NullAllowed] // by default this property is null
@@ -110,7 +110,7 @@ namespace XamCore.CoreTelephony {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	interface CTCarrier {
 		[Export ("mobileCountryCode")]
 		string MobileCountryCode { get;  }
@@ -129,9 +129,9 @@ namespace XamCore.CoreTelephony {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[Since (7,0)]
+	[iOS (7,0)]
 	partial interface CTSubscriber {
-		[Since (7,0), Export ("carrierToken")]
+		[iOS (7,0), Export ("carrierToken")]
 		NSData CarrierToken { get; }
 	}
 
@@ -139,7 +139,7 @@ namespace XamCore.CoreTelephony {
 	delegate void SimAuthenticationCallback (NSDictionary dictionary);
 #endif
 
-	[Since (6,0), BaseType (typeof (NSObject))]
+	[iOS (6,0), BaseType (typeof (NSObject))]
 	partial interface CTSubscriberInfo {
 		[Static]
 		[Export ("subscriber")]

--- a/src/coretext.cs
+++ b/src/coretext.cs
@@ -18,7 +18,7 @@ namespace XamCore.CoreText {
 #else
 	[Partial]
 #endif
-	[Since (3,2)]
+	[iOS (3,2)]
 	interface CTFontFeatureKey {
 		[Field ("kCTFontFeatureTypeIdentifierKey")]
 		NSString Identifier { get; }
@@ -38,7 +38,7 @@ namespace XamCore.CoreText {
 #else
 	[Partial]
 #endif
-	[Since (3,2)]
+	[iOS (3,2)]
 	interface CTFontFeatureSelectorKey {
 		[Field ("kCTFontFeatureSelectorIdentifierKey")]
 		NSString Identifier { get; }
@@ -54,7 +54,7 @@ namespace XamCore.CoreText {
 	}
 
 	[Static]
-	[Since (3,2)]
+	[iOS (3,2)]
 	interface CTFontVariationAxisKey {
 
 		[Field ("kCTFontVariationAxisIdentifierKey")]

--- a/src/eventkit.cs
+++ b/src/eventkit.cs
@@ -129,11 +129,11 @@ namespace XamCore.EventKit {
 		[Export ("removeRecurrenceRule:")]
 		void RemoveRecurrenceRule (EKRecurrenceRule rule);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("calendarItemIdentifier")]
 		string CalendarItemIdentifier { get;  }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("calendarItemExternalIdentifier")]
 		string CalendarItemExternalIdentifier { get;  }
 	}

--- a/src/eventkit.cs
+++ b/src/eventkit.cs
@@ -28,7 +28,7 @@ using XamCore.UIKit;
 
 namespace XamCore.EventKit {
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 #if XAMCORE_2_0 || MONOMAC
@@ -51,7 +51,7 @@ namespace XamCore.EventKit {
 		bool Refresh ();
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (EKObject))]
 #if XAMCORE_4_0	
@@ -138,7 +138,7 @@ namespace XamCore.EventKit {
 		string CalendarItemExternalIdentifier { get;  }
 	}
 	
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (EKObject))]
 	interface EKSource {
@@ -157,12 +157,12 @@ namespace XamCore.EventKit {
 		[Export ("sourceIdentifier")]
 		string SourceIdentifier { get; }
 
-		[Since (6, 0)]
+		[iOS (6, 0)]
 		[Export ("calendarsForEntityType:")]
 		NSSet GetCalendars (EKEntityType entityType);
 	}
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (EKObject))]
 	interface EKStructuredLocation : NSCopying {
@@ -188,7 +188,7 @@ namespace XamCore.EventKit {
 #endif
 	}
 
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (EKObject))]
 	[DisableDefaultCtor] // Documentation says to use the static methods FromDate/FromTimeInterval to create instances
@@ -208,12 +208,12 @@ namespace XamCore.EventKit {
 		[Export ("alarmWithRelativeOffset:")]
 		EKAlarm FromTimeInterval (double offsetSeconds);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("structuredLocation", ArgumentSemantic.Copy)]
 		[NullAllowed]
 		EKStructuredLocation StructuredLocation { get; set;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("proximity")]
 		EKAlarmProximity Proximity { get; set;  }
 
@@ -232,7 +232,7 @@ namespace XamCore.EventKit {
 #endif
 	}
 
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (EKObject))]
 	[DisableDefaultCtor]
@@ -257,40 +257,40 @@ namespace XamCore.EventKit {
 		[Export ("supportedEventAvailabilities")]
 		EKCalendarEventAvailability SupportedEventAvailabilities { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("calendarIdentifier")]
 		string CalendarIdentifier { get;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("subscribed")]
 		bool Subscribed { [Bind ("isSubscribed")] get;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("immutable")]
 		bool Immutable { [Bind ("isImmutable")] get;  }
 
 #if !MONOMAC
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0, Message = "Use 'Create (EKEntityType, EKEventStore)' instead.")]
 		[Static, Export ("calendarWithEventStore:")]
 		EKCalendar FromEventStore (EKEventStore eventStore);
 #endif
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("source", ArgumentSemantic.Retain)]
 		EKSource Source { get; set; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("allowedEntityTypes")]
 		EKEntityMask AllowedEntityTypes { get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Static]
 		[Export ("calendarForEntityType:eventStore:")]
 		EKCalendar Create (EKEntityType entityType, EKEventStore eventStore);
 	}
 
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (EKCalendarItem))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: You must use [EKEvent eventWithStore:] to create an event
@@ -351,7 +351,7 @@ namespace XamCore.EventKit {
 		string BirthdayContactIdentifier { get; }
 	}
 
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (EKObject))]
 #if XAMCORE_3_0
@@ -385,7 +385,7 @@ namespace XamCore.EventKit {
 #endif // !WATCH
 
 #endif
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Mac (10,9)]
 		[Export ("isCurrentUser")]
 		bool IsCurrentUser { get; }
@@ -395,7 +395,7 @@ namespace XamCore.EventKit {
 		NSPredicate ContactPredicate { get; }
 	}
 
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	interface EKRecurrenceEnd : NSCopying {
@@ -414,7 +414,7 @@ namespace XamCore.EventKit {
 		EKRecurrenceEnd FromOccurrenceCount (nint occurrenceCount);
 	}
 
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	interface EKRecurrenceDayOfWeek : NSCopying {
@@ -450,7 +450,7 @@ namespace XamCore.EventKit {
 		EKRecurrenceDayOfWeek FromDay (EKDay dayOfTheWeek, nint weekNumber);
 #endif
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("initWithDayOfTheWeek:weekNumber:")]
 #if XAMCORE_4_0
 		IntPtr Constructor (EKWeekday dayOfTheWeek, nint weekNumber);
@@ -459,7 +459,7 @@ namespace XamCore.EventKit {
 #endif
 	}
 
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (EKObject))]
 	interface EKRecurrenceRule : NSCopying {
@@ -517,7 +517,7 @@ namespace XamCore.EventKit {
 
 	}
 
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	interface EKEventStore {
@@ -563,99 +563,99 @@ namespace XamCore.EventKit {
 		[Notification]
 		NSString ChangedNotification { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("sources")]
 		EKSource [] Sources { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[return: NullAllowed]
 		[Export ("sourceWithIdentifier:")]
 		EKSource GetSource (string identifier);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("calendarWithIdentifier:")]
 		EKCalendar GetCalendar (string identifier);
 
 		[NoWatch]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("saveCalendar:commit:error:")]
 		bool SaveCalendar (EKCalendar calendar, bool commit, out NSError error);
 
 		[NoWatch]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("removeCalendar:commit:error:")]
 		bool RemoveCalendar (EKCalendar calendar, bool commit, out NSError error);
 
 		[NoWatch]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("saveEvent:span:commit:error:")]
 		bool SaveEvent (EKEvent ekEvent, EKSpan span, bool commit, out NSError error);
 
 		[NoWatch]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("removeEvent:span:commit:error:")]
 		bool RemoveEvent (EKEvent ekEvent, EKSpan span, bool commit, out NSError error);
 
 		[NoWatch]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("commit:")]
 		bool Commit (out NSError error);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("reset")]
 		void Reset ();
 
 		[NoWatch]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("refreshSourcesIfNecessary")]
 		void RefreshSourcesIfNecessary ();
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[return: NullAllowed]
 		[Export ("calendarItemWithIdentifier:")]
 		EKCalendarItem GetCalendarItem (string identifier);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("calendarItemsWithExternalIdentifier:")]
 		EKCalendarItem[] GetCalendarItems(string externalIdentifier);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("calendarsForEntityType:")]
 		EKCalendar[] GetCalendars (EKEntityType entityType);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[NullAllowed]
 		[Export ("defaultCalendarForNewReminders")]
 		EKCalendar DefaultCalendarForNewReminders { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("fetchRemindersMatchingPredicate:completion:")]
 		[Async]
 		IntPtr FetchReminders (NSPredicate predicate, Action<EKReminder[]> completion);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("cancelFetchRequest:")]
 		void CancelFetchRequest (IntPtr fetchIdentifier);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("predicateForIncompleteRemindersWithDueDateStarting:ending:calendars:")]
 		NSPredicate PredicateForIncompleteReminders ([NullAllowed] NSDate startDate, [NullAllowed] NSDate endDate, [NullAllowed] EKCalendar[] calendars);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("predicateForCompletedRemindersWithCompletionDateStarting:ending:calendars:")]
 		NSPredicate PredicateForCompleteReminders ([NullAllowed] NSDate startDate, [NullAllowed] NSDate endDate, [NullAllowed] EKCalendar[] calendars);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("predicateForRemindersInCalendars:")]
 		NSPredicate PredicateForReminders ([NullAllowed] EKCalendar[] calendars);
 
 		[NoWatch]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("removeReminder:commit:error:")]
 		bool RemoveReminder (EKReminder reminder, bool commit, out NSError error);
 
 		[NoWatch]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("saveReminder:commit:error:")]
 		bool SaveReminder (EKReminder reminder, bool commit, out NSError error);
 
@@ -667,13 +667,13 @@ namespace XamCore.EventKit {
 		[Export ("delegateSources")]
 		EKSource[] DelegateSources { get; }
 #endif
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Mac (10,9)]
 		[Export ("requestAccessToEntityType:completion:")]
 		[Async]
 		void RequestAccess (EKEntityType entityType, Action<bool, NSError> completionHandler);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Mac (10,9)]
 		[Static]
 		[Export ("authorizationStatusForEntityType:")]
@@ -682,7 +682,7 @@ namespace XamCore.EventKit {
 
 	delegate void EKEventSearchCallback (EKEvent theEvent, ref bool stop);
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (EKCalendarItem))]
 	interface EKReminder {

--- a/src/eventkitui.cs
+++ b/src/eventkitui.cs
@@ -32,17 +32,17 @@ namespace XamCore.EventKitUI {
 		[Export ("allowsCalendarPreview")]
 		bool AllowsCalendarPreview { get; set;  }
 
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("delegate", ArgumentSemantic.Weak), NullAllowed]
 		NSObject WeakDelegate { get; set; }
 		
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Wrap ("WeakDelegate")]
 		[Protocolize]
 		EKEventViewDelegate Delegate { get; set;  }
 	}
 
-	[Since (4,2)]
+	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -75,7 +75,7 @@ namespace XamCore.EventKitUI {
 		[Export ("event")]
 		EKEvent Event { get; set;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("cancelEditing")]
 		void CancelEditing ();
 	}
@@ -92,7 +92,7 @@ namespace XamCore.EventKitUI {
 		EKCalendar GetDefaultCalendarForNewEvents (EKEventEditViewController controller);
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (UIViewController),
 		   Delegates = new string [] { "WeakDelegate" },
 		   Events=new Type [] {typeof (EKCalendarChooserDelegate)})]
@@ -104,7 +104,7 @@ namespace XamCore.EventKitUI {
 		[Export ("initWithSelectionStyle:displayStyle:eventStore:")]
 		IntPtr Constructor (EKCalendarChooserSelectionStyle selectionStyle, EKCalendarChooserDisplayStyle displayStyle, EKEventStore eventStore);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("initWithSelectionStyle:displayStyle:entityType:eventStore:")]
 		IntPtr Constructor (EKCalendarChooserSelectionStyle selectionStyle, EKCalendarChooserDisplayStyle displayStyle, EKEntityType entityType, EKEventStore eventStore);
 
@@ -133,7 +133,7 @@ namespace XamCore.EventKitUI {
 		NSSet SelectedCalendars { get; set;  }
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]

--- a/src/externalaccessory.cs
+++ b/src/externalaccessory.cs
@@ -72,7 +72,7 @@ namespace XamCore.ExternalAccessory {
 		[Export ("EAAccessoryKey")]
 		EAAccessory Accessory { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("EAAccessorySelectedKey")]
 		EAAccessory Selected { get; }
 	}
@@ -104,13 +104,13 @@ namespace XamCore.ExternalAccessory {
 
 #if !XAMCORE_3_0 && !MONOMAC
 		// now exposed with the corresponding EABluetoothAccessoryPickerError enum
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("EABluetoothAccessoryPickerErrorDomain")]
 		NSString BluetoothAccessoryPickerErrorDomain { get; }
 #endif
 
 		[NoMac]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("showBluetoothAccessoryPickerWithNameFilter:completion:")]
 		[Async]
 		void ShowBluetoothAccessoryPicker ([NullAllowed] NSPredicate predicate, [NullAllowed] Action<NSError> completion);

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -1528,9 +1528,9 @@ namespace XamCore.Foundation
 		nint Nanosecond { get; set; }
 
 		[Export ("week")]
-		[Introduced (PlatformName.MacOSX, 10, 4)]
+		[Mac (10, 4)]
 		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use 'WeekOfMonth' or 'WeekOfYear' instead.")]
-		[Introduced (PlatformName.iOS, 2, 0)]
+		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'WeekOfMonth' or 'WeekOfYear' instead.")]
 		nint Week { get; set; }
 
@@ -5798,15 +5798,15 @@ namespace XamCore.Foundation
 		NSString UbiquitousItemIsUploadingKey { get; }
 
 		[Field ("NSURLUbiquitousItemPercentDownloadedKey")]
-		[Introduced (PlatformName.iOS, 5, 0)]
+		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'NSMetadataQuery.UbiquitousItemPercentDownloadedKey' on 'NSMetadataItem' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Mac (10, 7)]
 		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Use 'NSMetadataQuery.UbiquitousItemPercentDownloadedKey' on 'NSMetadataItem' instead.")]
 		NSString UbiquitousItemPercentDownloadedKey { get; }
 
-		[Introduced (PlatformName.iOS, 5, 0)]
+		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'NSMetadataQuery.UbiquitousItemPercentUploadedKey' on 'NSMetadataItem' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Mac (10, 7)]
 		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Use 'NSMetadataQuery.UbiquitousItemPercentUploadedKey' on 'NSMetadataItem' instead.")]
 		[Field ("NSURLUbiquitousItemPercentUploadedKey")]
 		NSString UbiquitousItemPercentUploadedKey { get; }
@@ -10021,9 +10021,9 @@ namespace XamCore.Foundation
 		void Publish (NSNetServiceOptions options);
 
 		[Export ("resolve")]
-		[Introduced (PlatformName.iOS, 2, 0)]
+		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 2, 0, message : "Use 'Resolve (double)' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 2)]
+		[Mac (10, 2)]
 		[Deprecated (PlatformName.MacOSX, 10, 4, message : "Use 'Resolve (double)' instead.")]
 		[NoWatch]
 		void Resolve ();
@@ -12874,8 +12874,8 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // An uncaught exception was raised: *** -range cannot be sent to an abstract object of class NSTextCheckingResult: Create a concrete instance!
-	[Introduced (PlatformName.iOS, 4, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 6)]
+	[iOS (4, 0)]
+	[Mac (10, 6)]
 	interface NSTextCheckingResult : NSSecureCoding, NSCopying {
 		[Export ("resultType")]
 		NSTextCheckingType ResultType { get;  }
@@ -12900,8 +12900,8 @@ namespace XamCore.Foundation
 		double TimeInterval { get; }
 
 		[Export ("components")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[iOS (4, 0)]
+		[Mac (10, 7)]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSDictionary WeakComponents { get; }
 
@@ -12915,19 +12915,19 @@ namespace XamCore.Foundation
 		string ReplacementString { get; }
 
 		[Export ("alternativeStrings")]
-		[Introduced (PlatformName.iOS, 7, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 9)]
+		[iOS (7, 0)]
+		[Mac (10, 9)]
 		string [] AlternativeStrings { get; }
 
 //		NSRegularExpression isn't bound
 //		[Export ("regularExpression")]
-//		[Introduced (PlatformName.iOS, 4, 0)]
-//		[Introduced (PlatformName.MacOSX, 10, 7)]
+//		[iOS (4, 0)]
+//		[Mac (10, 7)]
 //		NSRegularExpression RegularExpression { get; }
 
 		[Export ("phoneNumber")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[iOS (4, 0)]
+		[Mac (10, 7)]
 		string PhoneNumber { get; }
 
 		[Export ("addressComponents")]
@@ -12938,18 +12938,18 @@ namespace XamCore.Foundation
 		NSTextCheckingAddressComponents AddressComponents { get; }
 
 		[Export ("numberOfRanges")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[iOS (4, 0)]
+		[Mac (10, 7)]
 		nuint NumberOfRanges { get; }
 
 		[Export ("rangeAtIndex:")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[iOS (4, 0)]
+		[Mac (10, 7)]
 		NSRange RangeAtIndex (nuint idx);
 
 		[Export ("resultByAdjustingRangesWithOffset:")]
-		[Introduced (PlatformName.iOS, 5, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[iOS (5, 0)]
+		[Mac (10, 7)]
 		NSTextCheckingResult ResultByAdjustingRanges (nint offset);
 
 		// From the NSTextCheckingResultCreation category on NSTextCheckingResult
@@ -13005,27 +13005,27 @@ namespace XamCore.Foundation
 
 		[Static]
 		[Export ("correctionCheckingResultWithRange:replacementString:alternativeStrings:")]
-		[Introduced (PlatformName.iOS, 7, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 9)]
+		[iOS (7, 0)]
+		[Mac (10, 9)]
 		NSTextCheckingResult CorrectionCheckingResult (NSRange range, string replacementString, string[] alternativeStrings);
 
 //		NSRegularExpression isn't bound
 //		[Export ("regularExpressionCheckingResultWithRanges:count:regularExpression:")]
-//		[Introduced (PlatformName.iOS, 4, 0)]
-//		[Introduced (PlatformName.MacOSX, 10, 7)]
+//		[iOS (4, 0)]
+//		[Mac (10, 7)]
 //		[Internal] // FIXME
 //		NSTextCheckingResult RegularExpressionCheckingResult (ref NSRange ranges, nuint count, NSRegularExpression regularExpression);
 
 		[Static]
 		[Export ("phoneNumberCheckingResultWithRange:phoneNumber:")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[iOS (4, 0)]
+		[Mac (10, 7)]
 		NSTextCheckingResult PhoneNumberCheckingResult (NSRange range, string phoneNumber);
 
 		[Static]
 		[Export ("transitInformationCheckingResultWithRange:components:")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[iOS (4, 0)]
+		[Mac (10, 7)]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSTextCheckingResult TransitInformationCheckingResult (NSRange range, NSDictionary components);
 
@@ -13041,110 +13041,110 @@ namespace XamCore.Foundation
 
 	[StrongDictionary ("NSTextChecking")]
 	interface NSTextCheckingTransitComponents {
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[iOS (4, 0)]
+		[Mac (10, 7)]
 		string Airline { get; }
 
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[iOS (4, 0)]
+		[Mac (10, 7)]
 		string Flight { get; }
 	}
 
 	[StrongDictionary ("NSTextChecking")]
 	interface NSTextCheckingAddressComponents {
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		string Name { get; }
 
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		string JobTitle { get; }
 
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		string Organization { get; }
 
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		string Street { get; }
 
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		string City { get; }
 
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		string State { get; }
 
 		[Export ("ZipKey")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		string ZIP { get; }
 
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		string Country { get; }
 
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		string Phone { get; }
 	}
 
 	[Static]
 	interface NSTextChecking {
 		[Field ("NSTextCheckingNameKey")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		NSString NameKey { get; }
 
 		[Field ("NSTextCheckingJobTitleKey")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		NSString JobTitleKey { get; }
 
 		[Field ("NSTextCheckingOrganizationKey")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		NSString OrganizationKey { get; }
 
 		[Field ("NSTextCheckingStreetKey")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		NSString StreetKey { get; }
 
 		[Field ("NSTextCheckingCityKey")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		NSString CityKey { get; }
 
 		[Field ("NSTextCheckingStateKey")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		NSString StateKey { get; }
 
 		[Field ("NSTextCheckingZIPKey")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		NSString ZipKey { get; }
 
 		[Field ("NSTextCheckingCountryKey")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		NSString CountryKey { get; }
 
 		[Field ("NSTextCheckingPhoneKey")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 6)]
+		[iOS (4, 0)]
+		[Mac (10, 6)]
 		NSString PhoneKey { get; }
 
 		[Field ("NSTextCheckingAirlineKey")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[iOS (4, 0)]
+		[Mac (10, 7)]
 		NSString AirlineKey { get; }
 
 		[Field ("NSTextCheckingFlightKey")]
-		[Introduced (PlatformName.iOS, 4, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[iOS (4, 0)]
+		[Mac (10, 7)]
 		NSString FlightKey { get; }
 	}
 

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -6805,7 +6805,7 @@ namespace XamCore.Foundation
 		NSUrlSessionStreamTask CreateBidirectionalStream (NSNetService service);
 	}
 
-	[Since(9,0)]
+	[iOS (9,0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSUrlSessionTaskDelegate), Name="NSURLSessionStreamDelegate")]
 	interface NSUrlSessionStreamDelegate

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -1528,7 +1528,8 @@ namespace XamCore.Foundation
 		nint Nanosecond { get; set; }
 
 		[Export ("week")]
-		[Availability (Introduced = Platform.Mac_10_4 | Platform.iOS_2_0, Deprecated = Platform.Mac_10_9 | Platform.iOS_7_0, Message = "Use 'WeekOfMonth' or 'WeekOfYear' instead.")]
+		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_9, Message = "Use 'WeekOfMonth' or 'WeekOfYear' instead.")]
+		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0, Message = "Use 'WeekOfMonth' or 'WeekOfYear' instead.")]
 		nint Week { get; set; }
 
 		[Export ("weekday")]
@@ -2532,7 +2533,8 @@ namespace XamCore.Foundation
 		[Field ("NSMetadataUbiquitousItemHasUnresolvedConflictsKey")]
 		NSString UbiquitousItemHasUnresolvedConflictsKey { get; }
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9, Message="Use 'UbiquitousItemDownloadingStatusKey' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message="Use 'UbiquitousItemDownloadingStatusKey' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_9, Message="Use 'UbiquitousItemDownloadingStatusKey' instead.")]
 		[Field ("NSMetadataUbiquitousItemIsDownloadedKey")]
 		NSString UbiquitousItemIsDownloadedKey { get; }
 
@@ -5217,7 +5219,8 @@ namespace XamCore.Foundation
 		[Export ("removeVolatileDomainForName:")]
 		void RemoveVolatileDomain (string domainName);
 	
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9)]
+		[Availability (Deprecated = Platform.iOS_7_0)]
+		[Availability (Deprecated = Platform.Mac_10_9)]
 		[Export ("persistentDomainNames")]
 		string [] PersistentDomainNames ();
 	
@@ -5793,10 +5796,12 @@ namespace XamCore.Foundation
 		NSString UbiquitousItemIsUploadingKey { get; }
 
 		[Field ("NSURLUbiquitousItemPercentDownloadedKey")]
-		[Availability (Introduced = Platform.iOS_5_0 | Platform.Mac_10_7, Deprecated = Platform.iOS_6_0 | Platform.Mac_10_8, Message = "Use 'NSMetadataQuery.UbiquitousItemPercentDownloadedKey' on 'NSMetadataItem' instead.")]
+		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_6_0, Message = "Use 'NSMetadataQuery.UbiquitousItemPercentDownloadedKey' on 'NSMetadataItem' instead.")]
+		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_8, Message = "Use 'NSMetadataQuery.UbiquitousItemPercentDownloadedKey' on 'NSMetadataItem' instead.")]
 		NSString UbiquitousItemPercentDownloadedKey { get; }
 
-		[Availability (Introduced = Platform.iOS_5_0 | Platform.Mac_10_7, Deprecated = Platform.iOS_6_0 | Platform.Mac_10_8, Message = "Use 'NSMetadataQuery.UbiquitousItemPercentUploadedKey' on 'NSMetadataItem' instead.")]
+		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_6_0, Message = "Use 'NSMetadataQuery.UbiquitousItemPercentUploadedKey' on 'NSMetadataItem' instead.")]
+		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_8, Message = "Use 'NSMetadataQuery.UbiquitousItemPercentUploadedKey' on 'NSMetadataItem' instead.")]
 		[Field ("NSURLUbiquitousItemPercentUploadedKey")]
 		NSString UbiquitousItemPercentUploadedKey { get; }
 
@@ -6976,7 +6981,8 @@ namespace XamCore.Foundation
 		NSUrlSessionConfiguration EphemeralSessionConfiguration { get; }
 	
 		[Static, Export ("backgroundSessionConfiguration:")]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'CreateBackgroundSessionConfiguration' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'CreateBackgroundSessionConfiguration' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'CreateBackgroundSessionConfiguration' instead.")]
 		NSUrlSessionConfiguration BackgroundSessionConfiguration (string identifier);
 	
 		[Export ("identifier", ArgumentSemantic.Copy), NullAllowed]
@@ -10009,7 +10015,8 @@ namespace XamCore.Foundation
 		void Publish (NSNetServiceOptions options);
 
 		[Export ("resolve")]
-		[Availability (Introduced = Platform.iOS_2_0 | Platform.Mac_10_2, Deprecated = Platform.iOS_2_0 | Platform.Mac_10_4, Message = "Use 'Resolve (double)' instead.")]
+		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_2_0, Message = "Use 'Resolve (double)' instead.")]
+		[Availability (Introduced = Platform.Mac_10_2, Deprecated = Platform.Mac_10_4, Message = "Use 'Resolve (double)' instead.")]
 		[NoWatch]
 		void Resolve ();
 
@@ -10318,7 +10325,10 @@ namespace XamCore.Foundation
 	// init returns NIL
 	[DisableDefaultCtor]
 	partial interface NSValue : NSSecureCoding, NSCopying {
-		[Availability (Deprecated = Platform.Mac_10_13 | Platform.iOS_11_0 | Platform.TV_11_0 | Platform.Watch_4_0, Message="Potential for buffer overruns. Use 'StoreValueAtAddress (IntPtr, nuint)' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_13, Message="Potential for buffer overruns. Use 'StoreValueAtAddress (IntPtr, nuint)' instead.")]
+		[Availability (Deprecated = Platform.iOS_11_0, Message="Potential for buffer overruns. Use 'StoreValueAtAddress (IntPtr, nuint)' instead.")]
+		[Availability (Deprecated = Platform.TV_11_0, Message="Potential for buffer overruns. Use 'StoreValueAtAddress (IntPtr, nuint)' instead.")]
+		[Availability (Deprecated = Platform.Watch_4_0, Message="Potential for buffer overruns. Use 'StoreValueAtAddress (IntPtr, nuint)' instead.")]
 		[Export ("getValue:")]
 		void StoreValueAtAddress (IntPtr value);
 
@@ -11327,11 +11337,13 @@ namespace XamCore.Foundation
 		[Export ("hostName")]
 		string HostName { get; }
 
-		[Availability (Deprecated = Platform.Mac_10_10 | Platform.iOS_8_0, Message="Use 'OperatingSystemVersion' or 'IsOperatingSystemAtLeastVersion' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message="Use 'OperatingSystemVersion' or 'IsOperatingSystemAtLeastVersion' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message="Use 'OperatingSystemVersion' or 'IsOperatingSystemAtLeastVersion' instead.")]
 		[Export ("operatingSystem")]
 		nint OperatingSystem { get; }
 
-		[Availability (Deprecated = Platform.Mac_10_10 | Platform.iOS_8_0, Message="Use 'OperatingSystemVersionString' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message="Use 'OperatingSystemVersionString' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message="Use 'OperatingSystemVersionString' instead.")]
 		[Export ("operatingSystemName")]
 		string OperatingSystemName { get; }
 
@@ -12854,7 +12866,8 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // An uncaught exception was raised: *** -range cannot be sent to an abstract object of class NSTextCheckingResult: Create a concrete instance!
-	[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+	[Availability (Introduced = Platform.iOS_4_0)]
+	[Availability (Introduced = Platform.Mac_10_6)]
 	interface NSTextCheckingResult : NSSecureCoding, NSCopying {
 		[Export ("resultType")]
 		NSTextCheckingType ResultType { get;  }
@@ -12879,7 +12892,8 @@ namespace XamCore.Foundation
 		double TimeInterval { get; }
 
 		[Export ("components")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSDictionary WeakComponents { get; }
 
@@ -12893,16 +12907,19 @@ namespace XamCore.Foundation
 		string ReplacementString { get; }
 
 		[Export ("alternativeStrings")]
-		[Availability (Introduced = Platform.iOS_7_0 | Platform.Mac_10_9)]
+		[Availability (Introduced = Platform.iOS_7_0)]
+		[Availability (Introduced = Platform.Mac_10_9)]
 		string [] AlternativeStrings { get; }
 
 //		NSRegularExpression isn't bound
 //		[Export ("regularExpression")]
-//		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7)]
+//		[Availability (Introduced = Platform.iOS_4_0)]
+//		[Availability (Introduced = Platform.Mac_10_7)]
 //		NSRegularExpression RegularExpression { get; }
 
 		[Export ("phoneNumber")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
 		string PhoneNumber { get; }
 
 		[Export ("addressComponents")]
@@ -12913,15 +12930,18 @@ namespace XamCore.Foundation
 		NSTextCheckingAddressComponents AddressComponents { get; }
 
 		[Export ("numberOfRanges")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
 		nuint NumberOfRanges { get; }
 
 		[Export ("rangeAtIndex:")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
 		NSRange RangeAtIndex (nuint idx);
 
 		[Export ("resultByAdjustingRangesWithOffset:")]
-		[Availability (Introduced = Platform.iOS_5_0 | Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_5_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
 		NSTextCheckingResult ResultByAdjustingRanges (nint offset);
 
 		// From the NSTextCheckingResultCreation category on NSTextCheckingResult
@@ -12977,23 +12997,27 @@ namespace XamCore.Foundation
 
 		[Static]
 		[Export ("correctionCheckingResultWithRange:replacementString:alternativeStrings:")]
-		[Availability (Introduced = Platform.iOS_7_0 | Platform.Mac_10_9)]
+		[Availability (Introduced = Platform.iOS_7_0)]
+		[Availability (Introduced = Platform.Mac_10_9)]
 		NSTextCheckingResult CorrectionCheckingResult (NSRange range, string replacementString, string[] alternativeStrings);
 
 //		NSRegularExpression isn't bound
 //		[Export ("regularExpressionCheckingResultWithRanges:count:regularExpression:")]
-//		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7)]
+//		[Availability (Introduced = Platform.iOS_4_0)]
+//		[Availability (Introduced = Platform.Mac_10_7)]
 //		[Internal] // FIXME
 //		NSTextCheckingResult RegularExpressionCheckingResult (ref NSRange ranges, nuint count, NSRegularExpression regularExpression);
 
 		[Static]
 		[Export ("phoneNumberCheckingResultWithRange:phoneNumber:")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
 		NSTextCheckingResult PhoneNumberCheckingResult (NSRange range, string phoneNumber);
 
 		[Static]
 		[Export ("transitInformationCheckingResultWithRange:components:")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSTextCheckingResult TransitInformationCheckingResult (NSRange range, NSDictionary components);
 
@@ -13009,88 +13033,110 @@ namespace XamCore.Foundation
 
 	[StrongDictionary ("NSTextChecking")]
 	interface NSTextCheckingTransitComponents {
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
 		string Airline { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
 		string Flight { get; }
 	}
 
 	[StrongDictionary ("NSTextChecking")]
 	interface NSTextCheckingAddressComponents {
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		string Name { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		string JobTitle { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		string Organization { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		string Street { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		string City { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		string State { get; }
 
 		[Export ("ZipKey")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		string ZIP { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		string Country { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		string Phone { get; }
 	}
 
 	[Static]
 	interface NSTextChecking {
 		[Field ("NSTextCheckingNameKey")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		NSString NameKey { get; }
 
 		[Field ("NSTextCheckingJobTitleKey")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		NSString JobTitleKey { get; }
 
 		[Field ("NSTextCheckingOrganizationKey")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		NSString OrganizationKey { get; }
 
 		[Field ("NSTextCheckingStreetKey")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		NSString StreetKey { get; }
 
 		[Field ("NSTextCheckingCityKey")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		NSString CityKey { get; }
 
 		[Field ("NSTextCheckingStateKey")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		NSString StateKey { get; }
 
 		[Field ("NSTextCheckingZIPKey")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		NSString ZipKey { get; }
 
 		[Field ("NSTextCheckingCountryKey")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		NSString CountryKey { get; }
 
 		[Field ("NSTextCheckingPhoneKey")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_6)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_6)]
 		NSString PhoneKey { get; }
 
 		[Field ("NSTextCheckingAirlineKey")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
 		NSString AirlineKey { get; }
 
 		[Field ("NSTextCheckingFlightKey")]
-		[Availability (Introduced = Platform.iOS_4_0 | Platform.Mac_10_7)]
+		[Availability (Introduced = Platform.iOS_4_0)]
+		[Availability (Introduced = Platform.Mac_10_7)]
 		NSString FlightKey { get; }
 	}
 
@@ -13585,7 +13631,10 @@ namespace XamCore.Foundation
 		CGAffineTransform TransformStruct { get; set; }
 	}
 
-	[Availability (Deprecated = Platform.Mac_10_13 | Platform.iOS_11_0 | Platform.Watch_2_0 | Platform.TV_11_0, Message = "Use 'NSXpcConnection' instead.")]
+	[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'NSXpcConnection' instead.")]
+	[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'NSXpcConnection' instead.")]
+	[Availability (Deprecated = Platform.Watch_2_0, Message = "Use 'NSXpcConnection' instead.")]
+	[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'NSXpcConnection' instead.")]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface NSConnection {
@@ -13689,7 +13738,10 @@ namespace XamCore.Foundation
 		NSConnectionDelegate Delegate { get; set; }
 	}
 
-	[Availability (Deprecated = Platform.Mac_10_13 | Platform.iOS_11_0 | Platform.Watch_2_0 | Platform.TV_11_0, Message = "Use 'NSXpcConnection' instead.")]
+	[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'NSXpcConnection' instead.")]
+	[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'NSXpcConnection' instead.")]
+	[Availability (Deprecated = Platform.Watch_2_0, Message = "Use 'NSXpcConnection' instead.")]
+	[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'NSXpcConnection' instead.")]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -13713,7 +13765,10 @@ namespace XamCore.Foundation
 		bool AllowNewConnection (NSConnection newConnection, NSConnection parentConnection);
 	}
 
-	[Availability (Deprecated = Platform.Mac_10_13 | Platform.iOS_11_0 | Platform.Watch_2_0 | Platform.TV_11_0, Message = "Use 'NSXpcConnection' instead.")]
+	[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'NSXpcConnection' instead.")]
+	[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'NSXpcConnection' instead.")]
+	[Availability (Deprecated = Platform.Watch_2_0, Message = "Use 'NSXpcConnection' instead.")]
+	[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'NSXpcConnection' instead.")]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface NSDistantObjectRequest {

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -175,7 +175,7 @@ namespace XamCore.Foundation
 	interface NSAttributedStringDocumentAttributes { }
 #endif
 
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	partial interface NSAttributedString : NSCoding, NSMutableCopying, NSSecureCoding
 	#if MONOMAC
@@ -241,31 +241,31 @@ namespace XamCore.Foundation
 		IntPtr Constructor (NSUrl url, [NullAllowed] NSDictionary options, out NSDictionary resultDocumentAttributes, ref NSError error);
 #endif
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Wrap ("this (url, options == null ? null : options.Dictionary, out resultDocumentAttributes, ref error)")]
 		IntPtr Constructor (NSUrl url, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, ref NSError error);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("initWithData:options:documentAttributes:error:")]
 		IntPtr Constructor (NSData data, [NullAllowed] NSDictionary options, out NSDictionary resultDocumentAttributes, ref NSError error);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Wrap ("this (data, options == null ? null : options.Dictionary, out resultDocumentAttributes, ref error)")]
 		IntPtr Constructor (NSData data, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, ref NSError error);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("dataFromRange:documentAttributes:error:")]
 		NSData GetDataFromRange (NSRange range, NSDictionary attributes, ref NSError error);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Wrap ("GetDataFromRange (range, documentAttributes == null ? null : documentAttributes.Dictionary, ref error)")]
 		NSData GetDataFromRange (NSRange range, NSAttributedStringDocumentAttributes documentAttributes, ref NSError error);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("fileWrapperFromRange:documentAttributes:error:")]
 		NSFileWrapper GetFileWrapperFromRange (NSRange range, NSDictionary attributes, ref NSError error);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Wrap ("GetFileWrapperFromRange (range, documentAttributes == null ? null : documentAttributes.Dictionary, ref error)")]
 		NSFileWrapper GetFileWrapperFromRange (NSRange range, NSAttributedStringDocumentAttributes documentAttributes, ref NSError error);
 
@@ -486,23 +486,23 @@ namespace XamCore.Foundation
 		[Wrap ("this.GetDocFormat (range, options == null ? null : options.Dictionary)")]
 		NSData GetDocFormat (NSRange range, NSAttributedStringDocumentAttributes options);
 #else
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("size")]
 		CGSize Size { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("drawAtPoint:")]
 		void DrawString (CGPoint point);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("drawInRect:")]
 		void DrawString (CGRect rect);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("drawWithRect:options:context:")]
 		void DrawString (CGRect rect, NSStringDrawingOptions options, [NullAllowed] NSStringDrawingContext context);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("boundingRectWithSize:options:context:")]
 		CGRect GetBoundingRect (CGSize size, NSStringDrawingOptions options, [NullAllowed] NSStringDrawingContext context);
 #endif
@@ -516,7 +516,7 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject),
 		   Delegates=new string [] { "WeakDelegate" },
 		   Events=new Type [] { typeof (NSCacheDelegate)} )]
-	[Since (4,0)]
+	[iOS (4,0)]
 	interface NSCache {
 		[Export ("objectForKey:")]
 		NSObject ObjectForKey (NSObject key);
@@ -979,7 +979,7 @@ namespace XamCore.Foundation
 	}
 #endif
 
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	interface NSCharacterSet : NSSecureCoding, NSMutableCopying {
 		[Static, Export ("alphanumericCharacterSet", ArgumentSemantic.Copy)]
@@ -1272,31 +1272,31 @@ namespace XamCore.Foundation
 		[Export ("decodeBytesWithReturnedLength:")]
 		IntPtr DecodeBytes (out nuint length);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("allowedClasses")]
 		NSSet AllowedClasses { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("requiresSecureCoding")]
 		bool RequiresSecureCoding ();
 
-		[Since (9,0), Mac (10,11)]
+		[iOS (9,0), Mac (10,11)]
 		[Export ("decodeTopLevelObjectAndReturnError:")]
 		NSObject DecodeTopLevelObject (out NSError error);
 
-		[Since (9,0), Mac (10,11)]
+		[iOS (9,0), Mac (10,11)]
 		[Export ("decodeTopLevelObjectForKey:error:")]
 		NSObject DecodeTopLevelObject (string key, out NSError error);
 
-		[Since (9,0), Mac (10,11)]
+		[iOS (9,0), Mac (10,11)]
 		[Export ("decodeTopLevelObjectOfClass:forKey:error:")]
 		NSObject DecodeTopLevelObject (Class klass, string key, out NSError error);
 
-		[Since (9,0), Mac (10,11)]
+		[iOS (9,0), Mac (10,11)]
 		[Export ("decodeTopLevelObjectOfClasses:forKey:error:")]
 		NSObject DecodeTopLevelObject ([NullAllowed] NSSet<Class> setOfClasses, string key, out NSError error);
 
-		[Since (9,0), Mac (10,11)]
+		[iOS (9,0), Mac (10,11)]
 		[Export ("failWithError:")]
 		void Fail (NSError error);
 
@@ -1440,30 +1440,30 @@ namespace XamCore.Foundation
 		void GetBytes (IntPtr buffer, NSRange range);
 
 		[Export ("rangeOfData:options:range:")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		NSRange Find (NSData dataToFind, NSDataSearchOptions searchOptions, NSRange searchRange);
 
-		[Since (7,0), Mac (10, 9)] // 10.9
+		[iOS (7,0), Mac (10, 9)] // 10.9
 		[Export ("initWithBase64EncodedString:options:")]
 		IntPtr Constructor (string base64String, NSDataBase64DecodingOptions options);
 
-		[Since (7,0), Mac (10, 9)] // 10.9
+		[iOS (7,0), Mac (10, 9)] // 10.9
 		[Export ("initWithBase64EncodedData:options:")]
 		IntPtr Constructor (NSData base64Data, NSDataBase64DecodingOptions options);
 
-		[Since (7,0), Mac (10, 9)] // 10.9
+		[iOS (7,0), Mac (10, 9)] // 10.9
 		[Export ("base64EncodedDataWithOptions:")]
 		NSData GetBase64EncodedData (NSDataBase64EncodingOptions options);
 
-		[Since (7,0), Mac (10, 9)] // 10.9
+		[iOS (7,0), Mac (10, 9)] // 10.9
 		[Export ("base64EncodedStringWithOptions:")]
 		string GetBase64EncodedString (NSDataBase64EncodingOptions options);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("enumerateByteRangesUsingBlock:")]
 		void EnumerateByteRange (NSDataByteRangeEnumerator enumerator);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("initWithBytesNoCopy:length:deallocator:")]
 		IntPtr Constructor (IntPtr bytes, nuint length, Action<IntPtr,nuint> deallocator);
 	}
@@ -1483,22 +1483,22 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSObject))]
 	interface NSDateComponents : NSSecureCoding, NSCopying, INSCopying, INSSecureCoding, INativeObject {
-		[Since (4,0)]
+		[iOS (4,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("timeZone", ArgumentSemantic.Copy)]
 		NSTimeZone TimeZone { get; set; }
 
 		[NullAllowed] // by default this property is null
 		[Export ("calendar", ArgumentSemantic.Copy)]
-		[Since (4,0)]
+		[iOS (4,0)]
 		NSCalendar Calendar { get; set; }
 
 		[Export ("quarter")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		nint Quarter { get; set; }
 
 		[Export ("date")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		NSDate Date { get; }
 
 		//Detected properties
@@ -1573,7 +1573,7 @@ namespace XamCore.Foundation
 		nint GetValueForComponent (NSCalendarUnit unit);
 	}
 	
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSFormatter))]
 	interface NSByteCountFormatter {
 		[Export ("allowsNonnumericFormatting")]
@@ -1995,7 +1995,7 @@ namespace XamCore.Foundation
 		[Export ("fileDescriptor")]
 		int FileDescriptor { get; } /* int, not NSInteger */
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setReadabilityHandler:")]
 #if XAMCORE_2_0
 		void SetReadabilityHandler ([NullAllowed] Action<NSFileHandle> readCallback);
@@ -2003,7 +2003,7 @@ namespace XamCore.Foundation
 		void SetReadabilityHandler ([NullAllowed] NSFileHandleUpdateHandler readCallback);
 #endif
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setWriteabilityHandler:")]
 #if XAMCORE_2_0
 		void SetWriteabilityHandle ([NullAllowed] Action<NSFileHandle> writeCallback);
@@ -2295,15 +2295,15 @@ namespace XamCore.Foundation
 		[Export ("classNameForClass:")]
 		string GetClassName (Class kls);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("NSKeyedArchiveRootObjectKey")]
 		NSString RootObjectKey { get; }
 
-		[Since (6,0), Mac (10, 8)] // Yup, right, this is being "back-supported" to iOS 6
+		[iOS (6,0), Mac (10, 8)] // Yup, right, this is being "back-supported" to iOS 6
 		[Export ("setRequiresSecureCoding:")]
 		void SetRequiresSecureCoding (bool requireSecureEncoding);
 
-		[Since (6,0), Mac(10,8)] // Yup, right, this is being back-supported to iOS 6
+		[iOS (6,0), Mac(10,8)] // Yup, right, this is being back-supported to iOS 6
 		[Export ("requiresSecureCoding")]
 		bool GetRequiresSecureCoding ();
 
@@ -2351,17 +2351,17 @@ namespace XamCore.Foundation
 		[Export ("classForClassName:")]
 		Class GetClass (string codedName);
 
-		[Since (6,0), Mac (10, 8)] // Yup, right, this is being "back-supported" to iOS 6
+		[iOS (6,0), Mac (10, 8)] // Yup, right, this is being "back-supported" to iOS 6
 		[Export ("setRequiresSecureCoding:")]
 		void SetRequiresSecureCoding (bool requireSecureEncoding);
 
-		[Since (6,0), Mac(10,8)] // Yup, right, this is being back-supported to iOS 6
+		[iOS (6,0), Mac(10,8)] // Yup, right, this is being back-supported to iOS 6
 		[Export ("requiresSecureCoding")]
 		bool GetRequiresSecureCoding ();
 
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSMetadataQueryDelegate)})]
 	interface NSMetadataQuery {
 		[Export ("startQuery")]
@@ -3200,22 +3200,22 @@ namespace XamCore.Foundation
 		[Field ("NSMetadataUbiquitousSharedItemPermissionsReadWrite")]
 		NSString UbiquitousSharedItemPermissionsReadWrite { get; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[NullAllowed] // by default this property is null
 		[Export ("searchItems", ArgumentSemantic.Copy)]
 		// DOC: object is a mixture of NSString, NSMetadataItem, NSUrl
 		NSObject [] SearchItems { get; set; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[NullAllowed] // by default this property is null
 		[Export ("operationQueue", ArgumentSemantic.Retain)]
 		NSOperationQueue OperationQueue { get; set; }
 		
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("enumerateResultsUsingBlock:")]
 		void EnumerateResultsUsingBlock (NSMetadataQueryEnumerationCallback callback);
 
-		[Since (7,0), Mavericks, Export ("enumerateResultsWithOptions:usingBlock:")]
+		[iOS (7,0), Mavericks, Export ("enumerateResultsWithOptions:usingBlock:")]
 		void EnumerateResultsWithOptions (NSEnumerationOptions opts, NSMetadataQueryEnumerationCallback block);
 
 		//
@@ -3234,7 +3234,7 @@ namespace XamCore.Foundation
 		NSString QueryUpdateRemovedItemsKey { get; }
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -3246,7 +3246,7 @@ namespace XamCore.Foundation
 		NSObject ReplacementValueForAttributevalue (NSMetadataQuery query, string attributeName, NSObject value);
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 #if XAMCORE_4_0
 	[DisableDefaultCtor] // points to nothing so access properties crash the apps
@@ -3273,7 +3273,7 @@ namespace XamCore.Foundation
 		NSObject [] Attributes { get; }
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSMetadataQueryAttributeValueTuple {
 		[Export ("attribute")]
@@ -3286,7 +3286,7 @@ namespace XamCore.Foundation
 		nint Count { get; }
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSMetadataQueryResultGroup {
 		[Export ("attribute")]
@@ -3377,7 +3377,7 @@ namespace XamCore.Foundation
 	
 	interface NSMutableArray<TValue> : NSMutableArray {}
 
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof (NSAttributedString))]
 	interface NSMutableAttributedString {
 		[Export ("initWithString:")]
@@ -3434,7 +3434,7 @@ namespace XamCore.Foundation
 
 #if !MONOMAC
 		[NoTV]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'ReadFromUrl' instead.")]
 		[Export ("readFromFileURL:options:documentAttributes:error:")]
 		bool ReadFromFile (NSUrl url, NSDictionary options, ref NSDictionary returnOptions, ref NSError error);
@@ -3444,7 +3444,7 @@ namespace XamCore.Foundation
 		[Wrap ("ReadFromFile (url, options == null ? null : options.Dictionary, ref returnOptions, ref error)")]
 		bool ReadFromFile (NSUrl url, NSAttributedStringDocumentAttributes options, ref NSDictionary returnOptions, ref NSError error);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("readFromData:options:documentAttributes:error:")]
 		bool ReadFromData (NSData data, NSDictionary options, ref NSDictionary returnOptions, ref NSError error);
 		
@@ -3678,7 +3678,7 @@ namespace XamCore.Foundation
 		[Export ("writeToURL:atomically:")]
 		bool WriteToUrl (NSUrl url, bool atomically);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Static]
 		[Export ("sharedKeySetForKeys:")]
 		NSObject GetSharedKeySetForKeys (NSObject [] keys);
@@ -3851,7 +3851,7 @@ namespace XamCore.Foundation
 #if false
 		// FIXME that value is present in the header (7.0 DP 6) files but returns NULL (i.e. unusable)
 		// we're also missing other NSURLError* fields (which we should add)
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("NSURLErrorBackgroundTaskCancelledReasonKey")]
 		NSString NSUrlErrorBackgroundTaskCancelledReasonKey { get; }
 #endif
@@ -3948,7 +3948,7 @@ namespace XamCore.Foundation
 		[Static, Export ("expressionForBlock:arguments:")]
 		NSExpression FromFunction (NSExpressionCallbackHandler target, NSExpression[] parameters);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Static]
 		[Export ("expressionForAnyKey")]
 		NSExpression FromAnyKey ();
@@ -3958,7 +3958,7 @@ namespace XamCore.Foundation
 		[Export ("expressionForConditional:trueExpression:falseExpression:")]
 		NSExpression FromConditional (NSPredicate predicate, NSExpression trueExpression, NSExpression falseExpression);
 			
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("allowEvaluation")]
 		void AllowEvaluation ();
 		
@@ -4125,7 +4125,7 @@ namespace XamCore.Foundation
 
 	delegate void NSLingusticEnumerator (NSString tag, NSRange tokenRange, NSRange sentenceRange, ref bool stop);
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSLinguisticTagger {
 		[DesignatedInitializer]
@@ -4219,7 +4219,7 @@ namespace XamCore.Foundation
 
 	delegate void LinguisticTagEnumerator (string tag, NSRange tokenRange, bool stop);
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Static]
 	interface NSLinguisticTag {
 		[Field ("NSLinguisticTagSchemeTokenType")]
@@ -4397,7 +4397,7 @@ namespace XamCore.Foundation
 		[Export ("lineDirectionForLanguage:")][Static]
 		NSLocaleLanguageDirection GetLineDirection (string isoLanguageCode);
 
-		[Since (7,0)] // already in OSX 10.6
+		[iOS (7,0)] // already in OSX 10.6
 		[Static]
 		[Export ("localeWithLocaleIdentifier:")]
 		NSLocale FromLocaleIdentifier (string ident);
@@ -4672,7 +4672,7 @@ namespace XamCore.Foundation
 		bool IsSubsetOf (NSSet other);
 		
 		[Export ("enumerateObjectsUsingBlock:")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		void Enumerate (NSSetEnumerator enumerator);
 
 		[Internal]
@@ -4736,14 +4736,14 @@ namespace XamCore.Foundation
 		[Export ("reversedSortDescriptor")]
 		NSObject ReversedSortDescriptor { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("allowEvaluation")]
 		void AllowEvaluation ();
 	}
 	
 	[Category, BaseType (typeof (NSOrderedSet))]
 	partial interface NSKeyValueSorting_NSOrderedSet {
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("sortedArrayUsingDescriptors:")]
 		NSObject [] GetSortedArray (NSSortDescriptor [] sortDescriptors);
 	}
@@ -4752,13 +4752,13 @@ namespace XamCore.Foundation
 	[Category, BaseType (typeof (NSMutableArray))]
 #pragma warning restore 618
 	partial interface NSSortDescriptorSorting_NSMutableArray {
-		[Since (5,0), Export ("sortUsingDescriptors:")]
+		[iOS (5,0), Export ("sortUsingDescriptors:")]
 		void SortUsingDescriptors (NSSortDescriptor [] sortDescriptors);
 	}
 
 	[Category, BaseType (typeof (NSMutableOrderedSet))]
 	partial interface NSKeyValueSorting_NSMutableOrderedSet {
-		[Since (5,0), Export ("sortUsingDescriptors:")]
+		[iOS (5,0), Export ("sortUsingDescriptors:")]
 		void SortUsingDescriptors (NSSortDescriptor [] sortDescriptors);
 	}
 	
@@ -4811,7 +4811,7 @@ namespace XamCore.Foundation
 		[Export ("userInfo")]
 		NSObject UserInfo { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("tolerance")]
 		double Tolerance { get; set; }
 	}
@@ -4901,7 +4901,7 @@ namespace XamCore.Foundation
 		NSUbiquitousKeyValueStoreChangeReason ChangeReason { get; }
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 #if WATCH
 	[Advice ("Not available on watchOS")]
@@ -4985,7 +4985,7 @@ namespace XamCore.Foundation
 		NSString ChangedKeysKey { get; }
 	}
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject), Name="NSUUID")]
 	interface NSUuid : NSSecureCoding, NSCopying {
 		[Export ("initWithUUIDString:")]
@@ -5140,7 +5140,7 @@ namespace XamCore.Foundation
 		IntPtr InitWithUserName (string username);
 
 		[Internal]
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("initWithSuiteName:")]
 		IntPtr InitWithSuiteName (string suiteName);
 
@@ -5387,32 +5387,32 @@ namespace XamCore.Foundation
 		[Export ("URLByDeletingPathExtension")]
 		NSUrl RemovePathExtension ();
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("getFileSystemRepresentation:maxLength:")]
 		bool GetFileSystemRepresentation (IntPtr buffer, nint maxBufferLength);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("fileSystemRepresentation")]
 		IntPtr GetFileSystemRepresentationAsUtf8Ptr { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("removeCachedResourceValueForKey:")]
 		void RemoveCachedResourceValueForKey (NSString key);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("removeAllCachedResourceValues")]
 		void RemoveAllCachedResourceValues ();
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("setTemporaryResourceValue:forKey:")]
 		void SetTemporaryResourceValue (NSObject value, NSString key);
 
 		[DesignatedInitializer]
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("initFileURLWithFileSystemRepresentation:isDirectory:relativeToURL:")]
 		IntPtr Constructor (IntPtr ptrUtf8path, bool isDir, NSUrl baseURL);
 
-		[Since (7,0), Mavericks, Static, Export ("fileURLWithFileSystemRepresentation:isDirectory:relativeToURL:")]
+		[iOS (7,0), Mavericks, Static, Export ("fileURLWithFileSystemRepresentation:isDirectory:relativeToURL:")]
 		NSUrl FromUTF8Pointer (IntPtr ptrUtf8path, bool isDir, NSUrl baseURL);
 
 #if MONOMAC
@@ -5581,155 +5581,155 @@ namespace XamCore.Foundation
 		NSString VolumeSupportsCasePreservedNamesKey { get; }
 
 		// 5.0 Additions
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLKeysOfUnsetValuesKey")]
 		NSString KeysOfUnsetValuesKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLFileResourceIdentifierKey")]
 		NSString FileResourceIdentifierKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeIdentifierKey")]
 		NSString VolumeIdentifierKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLPreferredIOBlockSizeKey")]
 		NSString PreferredIOBlockSizeKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLIsReadableKey")]
 		NSString IsReadableKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLIsWritableKey")]
 		NSString IsWritableKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLIsExecutableKey")]
 		NSString IsExecutableKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLIsMountTriggerKey")]
 		NSString IsMountTriggerKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLFileSecurityKey")]
 		NSString FileSecurityKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeKey")]
 		NSString FileResourceTypeKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeNamedPipe")]
 		NSString FileResourceTypeNamedPipe { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeCharacterSpecial")]
 		NSString FileResourceTypeCharacterSpecial { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeDirectory")]
 		NSString FileResourceTypeDirectory { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeBlockSpecial")]
 		NSString FileResourceTypeBlockSpecial { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeRegular")]
 		NSString FileResourceTypeRegular { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeSymbolicLink")]
 		NSString FileResourceTypeSymbolicLink { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeSocket")]
 		NSString FileResourceTypeSocket { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeUnknown")]
 		NSString FileResourceTypeUnknown { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLTotalFileSizeKey")]
 		NSString TotalFileSizeKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLTotalFileAllocatedSizeKey")]
 		NSString TotalFileAllocatedSizeKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeSupportsRootDirectoryDatesKey")]
 		NSString VolumeSupportsRootDirectoryDatesKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeSupportsVolumeSizesKey")]
 		NSString VolumeSupportsVolumeSizesKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeSupportsRenamingKey")]
 		NSString VolumeSupportsRenamingKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeSupportsAdvisoryFileLockingKey")]
 		NSString VolumeSupportsAdvisoryFileLockingKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeSupportsExtendedSecurityKey")]
 		NSString VolumeSupportsExtendedSecurityKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeIsBrowsableKey")]
 		NSString VolumeIsBrowsableKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeMaximumFileSizeKey")]
 		NSString VolumeMaximumFileSizeKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeIsEjectableKey")]
 		NSString VolumeIsEjectableKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeIsRemovableKey")]
 		NSString VolumeIsRemovableKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeIsInternalKey")]
 		NSString VolumeIsInternalKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeIsAutomountedKey")]
 		NSString VolumeIsAutomountedKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeIsLocalKey")]
 		NSString VolumeIsLocalKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeIsReadOnlyKey")]
 		NSString VolumeIsReadOnlyKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeCreationDateKey")]
 		NSString VolumeCreationDateKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeURLForRemountingKey")]
 		NSString VolumeURLForRemountingKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeUUIDStringKey")]
 		NSString VolumeUUIDStringKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeNameKey")]
 		NSString VolumeNameKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLVolumeLocalizedNameKey")]
 		NSString VolumeLocalizedNameKey { get; }
 
@@ -5773,15 +5773,15 @@ namespace XamCore.Foundation
 		[Field ("NSURLVolumeAvailableCapacityForOpportunisticUsageKey")]
 		NSString VolumeAvailableCapacityForOpportunisticUsageKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLIsUbiquitousItemKey")]
 		NSString IsUbiquitousItemKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLUbiquitousItemHasUnresolvedConflictsKey")]
 		NSString UbiquitousItemHasUnresolvedConflictsKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLUbiquitousItemIsDownloadedKey")]
 		NSString UbiquitousItemIsDownloadedKey { get; }
 
@@ -5789,11 +5789,11 @@ namespace XamCore.Foundation
 		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0)]
 		NSString UbiquitousItemIsDownloadingKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLUbiquitousItemIsUploadedKey")]
 		NSString UbiquitousItemIsUploadedKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSURLUbiquitousItemIsUploadingKey")]
 		NSString UbiquitousItemIsUploadingKey { get; }
 
@@ -5847,7 +5847,7 @@ namespace XamCore.Foundation
 		[Field ("NSURLUbiquitousSharedItemPermissionsReadWrite")]
 		NSString UbiquitousSharedItemPermissionsReadWrite { get; }
 
-		[Since (5,1)]
+		[iOS (5,1)]
 		[Mac (10, 8)]
 		[Field ("NSURLIsExcludedFromBackupKey")]
 		NSString IsExcludedFromBackupKey { get; }
@@ -5859,30 +5859,30 @@ namespace XamCore.Foundation
 		IntPtr Constructor (NSData bookmarkData, NSUrlBookmarkResolutionOptions resolutionOptions, [NullAllowed] NSUrl relativeUrl, out bool bookmarkIsStale, out NSError error);
 
 		[Field ("NSURLPathKey")]
-		[Since (6,0)][Mac (10, 8)]
+		[iOS (6,0)][Mac (10, 8)]
 		NSString PathKey { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemDownloadingStatusKey")]
 		NSString UbiquitousItemDownloadingStatusKey { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemDownloadingErrorKey")]
 		NSString UbiquitousItemDownloadingErrorKey { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemUploadingErrorKey")]
 		NSString UbiquitousItemUploadingErrorKey { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemDownloadingStatusNotDownloaded")]
 		NSString UbiquitousItemDownloadingStatusNotDownloaded { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemDownloadingStatusDownloaded")]
 		NSString UbiquitousItemDownloadingStatusDownloaded { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemDownloadingStatusCurrent")]
 		NSString UbiquitousItemDownloadingStatusCurrent { get; }
 
@@ -6052,22 +6052,22 @@ namespace XamCore.Foundation
 
 	[Category, BaseType (typeof (NSCharacterSet))]
 	partial interface NSUrlUtilities_NSCharacterSet {
-		[Since (7,0), Static, Export ("URLUserAllowedCharacterSet", ArgumentSemantic.Copy)]
+		[iOS (7,0), Static, Export ("URLUserAllowedCharacterSet", ArgumentSemantic.Copy)]
 		NSCharacterSet UrlUserAllowedCharacterSet { get; }
 	
-		[Since (7,0), Static, Export ("URLPasswordAllowedCharacterSet", ArgumentSemantic.Copy)]
+		[iOS (7,0), Static, Export ("URLPasswordAllowedCharacterSet", ArgumentSemantic.Copy)]
 		NSCharacterSet UrlPasswordAllowedCharacterSet { get; }
 	
-		[Since (7,0), Static, Export ("URLHostAllowedCharacterSet", ArgumentSemantic.Copy)]
+		[iOS (7,0), Static, Export ("URLHostAllowedCharacterSet", ArgumentSemantic.Copy)]
 		NSCharacterSet UrlHostAllowedCharacterSet { get; }
 	
-		[Since (7,0), Static, Export ("URLPathAllowedCharacterSet", ArgumentSemantic.Copy)]
+		[iOS (7,0), Static, Export ("URLPathAllowedCharacterSet", ArgumentSemantic.Copy)]
 		NSCharacterSet UrlPathAllowedCharacterSet { get; }
 	
-		[Since (7,0), Static, Export ("URLQueryAllowedCharacterSet", ArgumentSemantic.Copy)]
+		[iOS (7,0), Static, Export ("URLQueryAllowedCharacterSet", ArgumentSemantic.Copy)]
 		NSCharacterSet UrlQueryAllowedCharacterSet { get; }
 	
-		[Since (7,0), Static, Export ("URLFragmentAllowedCharacterSet", ArgumentSemantic.Copy)]
+		[iOS (7,0), Static, Export ("URLFragmentAllowedCharacterSet", ArgumentSemantic.Copy)]
 		NSCharacterSet UrlFragmentAllowedCharacterSet { get; }
 	}
 		
@@ -6121,7 +6121,7 @@ namespace XamCore.Foundation
 		void RemoveCachedResponse (NSUrlSessionDataTask dataTask);
 	}
 	
-	[Since (7,0), Mac (10, 9)]
+	[iOS (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject), Name="NSURLComponents")]
 	partial interface NSUrlComponents : NSCopying {
 		[Export ("initWithURL:resolvingAgainstBaseURL:")]
@@ -6369,20 +6369,20 @@ namespace XamCore.Foundation
 		void Unschedule (NSRunLoop aRunLoop, NSRunLoopMode forMode);
 
 #if !MONOMAC
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("originalRequest")]
 		NSUrlRequest OriginalRequest { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("currentRequest")]
 		NSUrlRequest CurrentRequest { get; }
 #endif
 		[Export ("setDelegateQueue:")]
-		[Since (5,0)]
+		[iOS (5,0)]
 		void SetDelegateQueue (NSOperationQueue queue);
 
 		[NoWatch]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Static]
 		[Export ("sendAsynchronousRequest:queue:completionHandler:")]
 		[Async (ResultTypeName = "NSUrlAsyncResult", MethodName="SendRequestAsync")]
@@ -6390,7 +6390,7 @@ namespace XamCore.Foundation
 		
 #if IOS
 		// Extension from iOS5, NewsstandKit
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("newsstandAssetDownload", ArgumentSemantic.Weak)]
 		XamCore.NewsstandKit.NKAssetDownload NewsstandAssetDownload { get; }
 #endif
@@ -6579,11 +6579,11 @@ namespace XamCore.Foundation
 		[Export ("setDefaultCredential:forProtectionSpace:")]
 		void SetDefaultCredential (NSUrlCredential credential, NSUrlProtectionSpace forProtectionSpace);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("removeCredential:forProtectionSpace:options:")]
 		void RemoveCredential (NSUrlCredential credential, NSUrlProtectionSpace forProtectionSpace, NSDictionary options);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("NSURLCredentialStorageRemoveSynchronizableCredentials")]
 		NSString RemoveSynchronizableCredentials { get; }
 
@@ -6643,7 +6643,7 @@ namespace XamCore.Foundation
 	// but Apple has flagged these as not allowing null.
 	//
 	// Leaving the null allowed for now.
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Availability (Introduced = Platform.Mac_10_9)] // 64-bit on 10.9, but 32/64-bit on 10.10
 	[BaseType (typeof (NSObject), Name="NSURLSession")]
 #if XAMCORE_2_0
@@ -6858,7 +6858,7 @@ namespace XamCore.Foundation
 		void StopSecureConnection ();
 	}
 	
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Availability (Introduced = Platform.Mac_10_9)]
 	[BaseType (typeof (NSObject), Name="NSURLSessionTask")]
 	partial interface NSUrlSessionTask : NSCopying, NSProgressReporting
@@ -6953,17 +6953,17 @@ namespace XamCore.Foundation
 	//
 	// Empty interfaces, just to distinguish semantically their usage
 	//
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Availability (Introduced = Platform.Mac_10_9)]
 	[BaseType (typeof (NSUrlSessionTask), Name="NSURLSessionDataTask")]
 	partial interface NSUrlSessionDataTask {}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Availability (Introduced = Platform.Mac_10_9)]
 	[BaseType (typeof (NSUrlSessionDataTask), Name="NSURLSessionUploadTask")]
 	partial interface NSUrlSessionUploadTask {}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Availability (Introduced = Platform.Mac_10_9)]
 	[BaseType (typeof (NSUrlSessionTask), Name="NSURLSessionDownloadTask")]
 	partial interface NSUrlSessionDownloadTask {
@@ -6972,7 +6972,7 @@ namespace XamCore.Foundation
 	}
 	
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Availability (Introduced = Platform.Mac_10_9)]
 	[BaseType (typeof (NSObject), Name="NSURLSessionConfiguration")]
 #if XAMCORE_2_0
@@ -7079,7 +7079,7 @@ namespace XamCore.Foundation
 		bool WaitsForConnectivity { get; set; }
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Availability (Introduced = Platform.Mac_10_9)]
 	[Model, BaseType (typeof (NSObject), Name="NSURLSessionDelegate")]
 	[Protocol]
@@ -7094,7 +7094,7 @@ namespace XamCore.Foundation
 		void DidFinishEventsForBackgroundSession (NSUrlSession session);
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Availability (Introduced = Platform.Mac_10_9)]
 	[Model]
 	[BaseType (typeof (NSUrlSessionDelegate), Name="NSURLSessionTaskDelegate")]
@@ -7129,7 +7129,7 @@ namespace XamCore.Foundation
 		void TaskIsWaitingForConnectivity (NSUrlSession session, NSUrlSessionTask task);
 	}
 	
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Availability (Introduced = Platform.Mac_10_9)]
 	[Model]
 	[BaseType (typeof (NSUrlSessionTaskDelegate), Name="NSURLSessionDataDelegate")]
@@ -7152,7 +7152,7 @@ namespace XamCore.Foundation
 		void DidBecomeStreamTask (NSUrlSession session, NSUrlSessionDataTask dataTask, NSUrlSessionStreamTask streamTask);
 	}
 	
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Availability (Introduced = Platform.Mac_10_9)]
 	[Model]
 	[BaseType (typeof (NSUrlSessionTaskDelegate), Name="NSURLSessionDownloadDelegate")]
@@ -7303,23 +7303,23 @@ namespace XamCore.Foundation
 		[Notification]
 		NSString WillUndoChangeNotification { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setActionIsDiscardable:")]
 		void SetActionIsDiscardable (bool discardable);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("undoActionIsDiscardable")]
 		bool UndoActionIsDiscardable { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("redoActionIsDiscardable")]
 		bool RedoActionIsDiscardable { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSUndoManagerGroupIsDiscardableKey")]
 		NSString GroupIsDiscardableKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSUndoManagerDidCloseUndoGroupNotification")]
 		[Notification (typeof (NSUndoManagerCloseUndoGroupEventArgs))]
 		NSString DidCloseUndoGroupNotification { get; }
@@ -7454,7 +7454,7 @@ namespace XamCore.Foundation
 		[Export ("networkServiceType")]
 		NSUrlRequestNetworkServiceType NetworkServiceType { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("allowsCellularAccess")]
 		bool AllowsCellularAccess { get; }
 		
@@ -7538,7 +7538,7 @@ namespace XamCore.Foundation
 		[Export ("setObject:forKey:"), Internal]
 		void SetObject (NSObject obj, NSObject key);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Static]
 		[Export ("dictionaryWithSharedKeySet:")]
 		NSDictionary FromSharedKeySet (NSObject sharedKeyToken);
@@ -7636,7 +7636,7 @@ namespace XamCore.Foundation
 		[Export ("networkServiceType")]
 		NSUrlRequestNetworkServiceType NetworkServiceType { set; get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[New] [Export ("allowsCellularAccess")]
 		bool AllowsCellularAccess { get; set; }
 	}
@@ -7777,15 +7777,15 @@ namespace XamCore.Foundation
 		[Advanced, Field ("NSStreamNetworkServiceTypeVoIP")]
 		NSString NetworkServiceTypeVoIP { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Advanced, Field ("NSStreamNetworkServiceTypeVideo")]
 		NSString NetworkServiceTypeVideo { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Advanced, Field ("NSStreamNetworkServiceTypeBackground")]
 		NSString NetworkServiceTypeBackground { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Advanced, Field ("NSStreamNetworkServiceTypeVoice")]
 		NSString NetworkServiceTypeVoice { get; }
 
@@ -7969,15 +7969,15 @@ namespace XamCore.Foundation
 
 		// end methods from NSStringPathExtensions category
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("capitalizedStringWithLocale:")]
 		string Capitalize ([NullAllowed] NSLocale locale);
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("lowercaseStringWithLocale:")]
 		string ToLower (NSLocale locale);
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("uppercaseStringWithLocale:")]
 		string ToUpper (NSLocale locale);
 
@@ -8162,11 +8162,11 @@ namespace XamCore.Foundation
 #else
 	partial interface NSURLUtilities_NSString {
 #endif
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("stringByAddingPercentEncodingWithAllowedCharacters:")]
 		NSString CreateStringByAddingPercentEncoding (NSCharacterSet allowedCharacters);
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("stringByRemovingPercentEncoding")]
 		NSString CreateStringByRemovingPercentEncoding ();
 	
@@ -8180,7 +8180,7 @@ namespace XamCore.Foundation
 	
 #if !MONOMAC
 	// This comes from UIKit.framework/Headers/NSStringDrawing.h
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSStringDrawingContext {
 		[Export ("minimumScaleFactor")]
@@ -8588,7 +8588,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	interface NSOperation {
 		[Export ("start")]
 		void Start ();
@@ -8652,7 +8652,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSOperation))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	interface NSBlockOperation {
 		[Static]
 		[Export ("blockOperationWithBlock:")]
@@ -8666,7 +8666,7 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	interface NSOperationQueue {
 		[Export ("addOperation:")][PostGet ("Operations")]
 		void AddOperation ([NullAllowed] NSOperation op);
@@ -8722,7 +8722,7 @@ namespace XamCore.Foundation
 	interface NSOrderedSet<TKey> : NSOrderedSet {}
 #endif
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSOrderedSet : NSSecureCoding, NSMutableCopying {
 		[Export ("initWithObject:")]
@@ -8817,7 +8817,7 @@ namespace XamCore.Foundation
 	interface NSMutableOrderedSet<TKey> : NSMutableOrderedSet {}
 #endif
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSOrderedSet))]
 	interface NSMutableOrderedSet {
 		[Export ("initWithObject:")]
@@ -9147,7 +9147,7 @@ namespace XamCore.Foundation
 		[Export ("cookieAcceptPolicy")]
 		NSHttpCookieAcceptPolicy AcceptPolicy { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("sortedCookiesUsingDescriptors:")]
 		NSHttpCookie [] GetSortedCookies (NSSortDescriptor [] sortDescriptors);
 
@@ -9187,7 +9187,7 @@ namespace XamCore.Foundation
 		[Export ("initWithURL:MIMEType:expectedContentLength:textEncodingName:")]
 		IntPtr Constructor (NSUrl url, string mimetype, nint expectedContentLength, [NullAllowed] string textEncodingName);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("initWithURL:statusCode:HTTPVersion:headerFields:")]
 		IntPtr Constructor (NSUrl url, nint statusCode, string httpVersion, NSDictionary headerFields);
 		
@@ -9326,43 +9326,43 @@ namespace XamCore.Foundation
 #endif
 
 		[Export ("bundleURL")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		NSUrl BundleUrl { get; }
 		
 		[Export ("resourceURL")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		NSUrl ResourceUrl { get; }
 
 		[Export ("executableURL")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		NSUrl ExecutableUrl { get; }
 
 		[Export ("URLForAuxiliaryExecutable:")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		NSUrl UrlForAuxiliaryExecutable (string executable);
 
 		[Export ("privateFrameworksURL")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		NSUrl PrivateFrameworksUrl { get; }
 
 		[Export ("sharedFrameworksURL")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		NSUrl SharedFrameworksUrl { get; }
 
 		[Export ("sharedSupportURL")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		NSUrl SharedSupportUrl { get; }
 
 		[Export ("builtInPlugInsURL")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		NSUrl BuiltInPluginsUrl { get; }
 
 		[Export ("initWithURL:")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		IntPtr Constructor (NSUrl url);
 		
 		[Static, Export ("bundleWithURL:")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		NSBundle FromUrl (NSUrl url);
 
 		[Export ("preferredLocalizations")]
@@ -9371,7 +9371,7 @@ namespace XamCore.Foundation
 		[Export ("localizations")]
 		string [] Localizations { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("appStoreReceiptURL")]
 		NSUrl AppStoreReceiptUrl { get; }
 
@@ -9580,15 +9580,15 @@ namespace XamCore.Foundation
 		[Export ("containsIndexes:")]
 		bool Contains (NSIndexSet indexes);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("enumerateRangesUsingBlock:")]
 		void EnumerateRanges (NSRangeIterator iterator);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("enumerateRangesWithOptions:usingBlock:")]
 		void EnumerateRanges (NSEnumerationOptions opts, NSRangeIterator iterator);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("enumerateRangesInRange:options:usingBlock:")]
 		void EnumerateRanges (NSRange range, NSEnumerationOptions opts, NSRangeIterator iterator);
 
@@ -9898,7 +9898,7 @@ namespace XamCore.Foundation
 		IntPtr MethodReturnType { get; }
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject), Name="NSJSONSerialization")]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** +[NSJSONSerialization allocWithZone:]: Do not create instances of NSJSONSerialization in this release
 	[DisableDefaultCtor]
@@ -10093,7 +10093,7 @@ namespace XamCore.Foundation
 		[Export ("netService:didUpdateTXTRecordData:"), EventArgs ("NSNetServiceData")]
 		void UpdatedTxtRecordData (NSNetService sender, NSData data);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("netService:didAcceptConnectionWithInputStream:outputStream:"), EventArgs ("NSNetServiceConnection")]
 		void DidAcceptConnection (NSNetService sender, NSInputStream inputStream, NSOutputStream outputStream);
 	}
@@ -10225,7 +10225,7 @@ namespace XamCore.Foundation
 		[PostSnippet ("RemoveObserversFromList (observer, aName, anObject);")]
 		void RemoveObserver (NSObject observer, [NullAllowed] string aName, [NullAllowed] NSObject anObject);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("addObserverForName:object:queue:usingBlock:")]
 #if XAMCORE_2_0
 		NSObject AddObserver ([NullAllowed] string name, [NullAllowed] NSObject obj, [NullAllowed] NSOperationQueue queue, Action<NSNotification> handler);
@@ -10420,22 +10420,22 @@ namespace XamCore.Foundation
 #endif
 #else
 #if !WATCH
-		[Static, Export ("valueWithCMTime:"), Since (4,0)]
+		[Static, Export ("valueWithCMTime:"), iOS (4,0)]
 		NSValue FromCMTime (CMTime time);
 		
-		[Export ("CMTimeValue"), Since (4,0)]
+		[Export ("CMTimeValue"), iOS (4,0)]
 		CMTime CMTimeValue { get; }
 		
-		[Static, Export ("valueWithCMTimeMapping:"), Since (4,0)]
+		[Static, Export ("valueWithCMTimeMapping:"), iOS (4,0)]
 		NSValue FromCMTimeMapping (CMTimeMapping timeMapping);
 		
-		[Export ("CMTimeMappingValue"), Since (4,0)]
+		[Export ("CMTimeMappingValue"), iOS (4,0)]
 		CMTimeMapping CMTimeMappingValue { get; }
 		
-		[Static, Export ("valueWithCMTimeRange:"), Since (4,0)]
+		[Static, Export ("valueWithCMTimeRange:"), iOS (4,0)]
 		NSValue FromCMTimeRange (CMTimeRange timeRange);
 		
-		[Export ("CMTimeRangeValue"), Since (4,0)]
+		[Export ("CMTimeRangeValue"), iOS (4,0)]
 		CMTimeRange CMTimeRangeValue { get; }
 #endif
 		
@@ -10460,11 +10460,11 @@ namespace XamCore.Foundation
 		[Export ("valueWithDirectionalEdgeInsets:")]
 		NSValue FromDirectionalEdgeInsets (NSDirectionalEdgeInsets insets);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("valueWithUIOffset:")][Static]
 		NSValue FromUIOffset (UIKit.UIOffset insets);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("UIOffsetValue")]
 		UIOffset UIOffsetValue { get; }
 
@@ -10500,22 +10500,22 @@ namespace XamCore.Foundation
 		// Maybe we should include this inside mapkit.cs instead (it's a partial interface, so that's trivial)?
 
 		[TV (9,2)]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Static, Export ("valueWithMKCoordinate:")]
 		NSValue FromMKCoordinate (XamCore.CoreLocation.CLLocationCoordinate2D coordinate);
 
 		[TV (9,2)]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Static, Export ("valueWithMKCoordinateSpan:")]
 		NSValue FromMKCoordinateSpan (XamCore.MapKit.MKCoordinateSpan coordinateSpan);
 
 		[TV (9,2)]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("MKCoordinateValue")]
 		XamCore.CoreLocation.CLLocationCoordinate2D CoordinateValue { get; }
 
 		[TV (9,2)]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("MKCoordinateSpanValue")]
 		XamCore.MapKit.MKCoordinateSpan CoordinateSpanValue { get; }
 #endif
@@ -11370,15 +11370,15 @@ namespace XamCore.Foundation
 		[Export ("systemUptime")]
 		double SystemUptime { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("beginActivityWithOptions:reason:")]
 		NSObject BeginActivity (NSActivityOptions options, string reason);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("endActivity:")]
 		void EndActivity (NSObject activity);
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("performActivityWithOptions:reason:usingBlock:")]
 		void PerformActivity (NSActivityOptions options, string reason, NSAction runCode);
 
@@ -11408,7 +11408,7 @@ namespace XamCore.Foundation
 		[Export ("automaticTerminationSupportEnabled")]
 		bool AutomaticTerminationSupportEnabled { get; set; }
 #else
-		[Since (8,2)]
+		[iOS (8,2)]
 		[Export ("performExpiringActivityWithReason:usingBlock:")]
 		void PerformExpiringActivity (string reason, Action<bool> block);
 
@@ -11450,7 +11450,7 @@ namespace XamCore.Foundation
 		string GetFullUserName ();
 	}
 
-	[Since (7,0), Mac (10, 9)]
+	[iOS (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	partial interface NSProgress {
 	
@@ -11564,37 +11564,37 @@ namespace XamCore.Foundation
 		[Export ("old")]
 		bool Old { [Bind ("isOld")] get; }
 #endif
-		[Since (7,0), Field ("NSProgressKindFile")]
+		[iOS (7,0), Field ("NSProgressKindFile")]
 		NSString KindFile { get; }
 	
-		[Since (7,0), Field ("NSProgressEstimatedTimeRemainingKey")]
+		[iOS (7,0), Field ("NSProgressEstimatedTimeRemainingKey")]
 		NSString EstimatedTimeRemainingKey { get; }
 	
-		[Since (7,0), Field ("NSProgressThroughputKey")]
+		[iOS (7,0), Field ("NSProgressThroughputKey")]
 		NSString ThroughputKey { get; }
 	
-		[Since (7,0), Field ("NSProgressFileOperationKindKey")]
+		[iOS (7,0), Field ("NSProgressFileOperationKindKey")]
 		NSString FileOperationKindKey { get; }
 	
-		[Since (7,0), Field ("NSProgressFileOperationKindDownloading")]
+		[iOS (7,0), Field ("NSProgressFileOperationKindDownloading")]
 		NSString FileOperationKindDownloading { get; }
 	
-		[Since (7,0), Field ("NSProgressFileOperationKindDecompressingAfterDownloading")]
+		[iOS (7,0), Field ("NSProgressFileOperationKindDecompressingAfterDownloading")]
 		NSString FileOperationKindDecompressingAfterDownloading { get; }
 	
-		[Since (7,0), Field ("NSProgressFileOperationKindReceiving")]
+		[iOS (7,0), Field ("NSProgressFileOperationKindReceiving")]
 		NSString FileOperationKindReceiving { get; }
 	
-		[Since (7,0), Field ("NSProgressFileOperationKindCopying")]
+		[iOS (7,0), Field ("NSProgressFileOperationKindCopying")]
 		NSString FileOperationKindCopying { get; }
 	
-		[Since (7,0), Field ("NSProgressFileURLKey")]
+		[iOS (7,0), Field ("NSProgressFileURLKey")]
 		NSString FileURLKey { get; }
 	
-		[Since (7,0), Field ("NSProgressFileTotalCountKey")]
+		[iOS (7,0), Field ("NSProgressFileTotalCountKey")]
 		NSString FileTotalCountKey { get; }
 	
-		[Since (7,0), Field ("NSProgressFileCompletedCountKey")]
+		[iOS (7,0), Field ("NSProgressFileCompletedCountKey")]
 		NSString FileCompletedCountKey { get; }
 
 #if MONOMAC
@@ -11661,7 +11661,7 @@ namespace XamCore.Foundation
 	}
 	
 	[BaseType (typeof (NSMutableData))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	interface NSPurgeableData : NSSecureCoding, NSMutableCopying, NSDiscardableContent {
 	}
 
@@ -11691,7 +11691,7 @@ namespace XamCore.Foundation
 
 	interface INSFilePresenter {}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSFileCoordinator {
 		[Static, Export ("addFilePresenter:")][PostGet ("FilePresenters")]
@@ -11749,7 +11749,7 @@ namespace XamCore.Foundation
 		[Export ("cancel")]
 		void Cancel ();
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Mac (10, 8)]
 		[Export ("itemAtURL:willMoveToURL:")]
 		void WillMove (NSUrl oldUrl, NSUrl newUrl);
@@ -11870,11 +11870,11 @@ namespace XamCore.Foundation
 		[Field ("NSFileProtectionComplete")]
 		NSString FileProtectionComplete { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSFileProtectionCompleteUnlessOpen")]
 		NSString FileProtectionCompleteUnlessOpen { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("NSFileProtectionCompleteUntilFirstUserAuthentication")]
 		NSString FileProtectionCompleteUntilFirstUserAuthentication  { get; }
 #endif
@@ -11995,27 +11995,27 @@ namespace XamCore.Foundation
 		[Export ("createFileAtPath:contents:attributes:")]
 		bool CreateFile (string path, NSData data, [NullAllowed] NSDictionary attr);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("contentsOfDirectoryAtURL:includingPropertiesForKeys:options:error:")]
 		NSUrl[] GetDirectoryContent (NSUrl url, [NullAllowed] NSArray properties, NSDirectoryEnumerationOptions options, out NSError error);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("copyItemAtURL:toURL:error:")]
 		bool Copy (NSUrl srcUrl, NSUrl dstUrl, out NSError error);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("moveItemAtURL:toURL:error:")]
 		bool Move (NSUrl srcUrl, NSUrl dstUrl, out NSError error);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("linkItemAtURL:toURL:error:")]
 		bool Link (NSUrl srcUrl, NSUrl dstUrl, out NSError error);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("removeItemAtURL:error:")]
 		bool Remove ([NullAllowed] NSUrl url, out NSError error);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("enumeratorAtURL:includingPropertiesForKeys:options:errorHandler:")]
 #if XAMCORE_2_0
 		NSDirectoryEnumerator GetEnumerator (NSUrl url, [NullAllowed] NSString[] keys, NSDirectoryEnumerationOptions options, [NullAllowed] NSEnumerateErrorHandler handler);
@@ -12023,19 +12023,19 @@ namespace XamCore.Foundation
 		NSDirectoryEnumerator GetEnumerator (NSUrl url, [NullAllowed] NSArray properties, NSDirectoryEnumerationOptions options, [NullAllowed] NSEnumerateErrorHandler handler);
 #endif
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("URLForDirectory:inDomain:appropriateForURL:create:error:")]
 		NSUrl GetUrl (NSSearchPathDirectory directory, NSSearchPathDomain domain, [NullAllowed] NSUrl url, bool shouldCreate, out NSError error);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("URLsForDirectory:inDomains:")]
 		NSUrl[] GetUrls (NSSearchPathDirectory directory, NSSearchPathDomain domains);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("replaceItemAtURL:withItemAtURL:backupItemName:options:resultingItemURL:error:")]
 		bool Replace (NSUrl originalItem, NSUrl newItem, [NullAllowed] string backupItemName, NSFileManagerItemReplacementOptions options, out NSUrl resultingURL, out NSError error);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("mountedVolumeURLsIncludingResourceValuesForKeys:options:")]
 		NSUrl[] GetMountedVolumes ([NullAllowed] NSArray properties, NSVolumeEnumerationOptions options);
 
@@ -12048,50 +12048,50 @@ namespace XamCore.Foundation
 		//[Export ("stringWithFileSystemRepresentation:length:")]
 		//string StringWithFileSystemRepresentation (const char str, uint len);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("createDirectoryAtURL:withIntermediateDirectories:attributes:error:")]
 		bool CreateDirectory (NSUrl url, bool createIntermediates, [NullAllowed] NSDictionary attributes, out NSError error);
 
-		[Since (5,0)]
+		[iOS (5,0)]
                 [Export ("createSymbolicLinkAtURL:withDestinationURL:error:")]
                 bool CreateSymbolicLink (NSUrl url, NSUrl destURL, out NSError error);
 
-		[Since (5,0)]
+		[iOS (5,0)]
                 [Export ("setUbiquitous:itemAtURL:destinationURL:error:")]
                 bool SetUbiquitous (bool flag, NSUrl url, NSUrl destinationUrl, out NSError error);
 
-		[Since (5,0)]
+		[iOS (5,0)]
                 [Export ("isUbiquitousItemAtURL:")]
                 bool IsUbiquitous (NSUrl url);
 
-		[Since (5,0)]
+		[iOS (5,0)]
                 [Export ("startDownloadingUbiquitousItemAtURL:error:")]
                 bool StartDownloadingUbiquitous (NSUrl url, out NSError error);
 
-		[Since (5,0)]
+		[iOS (5,0)]
                 [Export ("evictUbiquitousItemAtURL:error:")]
                 bool EvictUbiquitous (NSUrl url, out NSError error);
 
-		[Since (5,0)]
+		[iOS (5,0)]
                 [Export ("URLForUbiquityContainerIdentifier:")]
                 NSUrl GetUrlForUbiquityContainer ([NullAllowed] string containerIdentifier);
 
-		[Since (5,0)]
+		[iOS (5,0)]
                 [Export ("URLForPublishingUbiquitousItemAtURL:expirationDate:error:")]
                 NSUrl GetUrlForPublishingUbiquitousItem (NSUrl url, out NSDate expirationDate, out NSError error);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Mac (10, 8)]
 		[Export ("ubiquityIdentityToken")]
 		NSObject UbiquityIdentityToken { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Mac (10, 8)]
 		[Field ("NSUbiquityIdentityDidChangeNotification")]
 		[Notification]
 		NSString UbiquityIdentityDidChangeNotification { get; }
 
-		[Since (7,0), Mac (10, 8)]
+		[iOS (7,0), Mac (10, 8)]
 		[Export ("containerURLForSecurityApplicationGroupIdentifier:")]
 		NSUrl GetContainerUrl (string securityApplicationGroupIdentifier);
 
@@ -12272,7 +12272,7 @@ namespace XamCore.Foundation
 
 	delegate void NSFileVersionNonlocalVersionsCompletionHandler ([NullAllowed] NSFileVersion[] nonlocalFileVersions, [NullAllowed] NSError error);
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: -[NSFileVersion init]: You have to use one of the factory methods to instantiate NSFileVersion.
 	[DisableDefaultCtor]
@@ -12529,7 +12529,7 @@ namespace XamCore.Foundation
 	delegate bool NSPredicateEvaluator (NSObject evaluatedObject, NSDictionary bindings);
 	
 	[BaseType (typeof (NSObject))]
-	[Since (4,0)]
+	[iOS (4,0)]
 	// 'init' returns NIL
 	[DisableDefaultCtor]
 	interface NSPredicate : NSSecureCoding, NSCopying {
@@ -12562,21 +12562,21 @@ namespace XamCore.Foundation
 		[Export ("predicateFromMetadataQueryString:")]
 		NSPredicate FromMetadataQueryString (string query);
 #endif
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("allowEvaluation")]
 		void AllowEvaluation ();
 	}
 
 	[Category, BaseType (typeof (NSOrderedSet))]
 	partial interface NSPredicateSupport_NSOrderedSet {
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("filteredOrderedSetUsingPredicate:")]
 		NSOrderedSet FilterUsingPredicate (NSPredicate p);
 	}
 	
 	[Category, BaseType (typeof (NSMutableOrderedSet))]
 	partial interface NSPredicateSupport_NSMutableOrderedSet {
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("filterUsingPredicate:")]
 		void FilterUsingPredicate (NSPredicate p);
 	}

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -10325,10 +10325,10 @@ namespace XamCore.Foundation
 	// init returns NIL
 	[DisableDefaultCtor]
 	partial interface NSValue : NSSecureCoding, NSCopying {
-		[Availability (Deprecated = Platform.Mac_10_13, Message="Potential for buffer overruns. Use 'StoreValueAtAddress (IntPtr, nuint)' instead.")]
-		[Availability (Deprecated = Platform.iOS_11_0, Message="Potential for buffer overruns. Use 'StoreValueAtAddress (IntPtr, nuint)' instead.")]
-		[Availability (Deprecated = Platform.TV_11_0, Message="Potential for buffer overruns. Use 'StoreValueAtAddress (IntPtr, nuint)' instead.")]
-		[Availability (Deprecated = Platform.Watch_4_0, Message="Potential for buffer overruns. Use 'StoreValueAtAddress (IntPtr, nuint)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message:"Potential for buffer overruns. Use 'StoreValueAtAddress (IntPtr, nuint)' instead.")]
+		[Deprecated (PlatformName.iOS, 11, 0, message:"Potential for buffer overruns. Use 'StoreValueAtAddress (IntPtr, nuint)' instead.")]
+		[Deprecated (PlatformName.TvOS, 11, 0, message:"Potential for buffer overruns. Use 'StoreValueAtAddress (IntPtr, nuint)' instead.")]
+		[Deprecated (PlatformName.WatchOS, 4, 0, message:"Potential for buffer overruns. Use 'StoreValueAtAddress (IntPtr, nuint)' instead.")]
 		[Export ("getValue:")]
 		void StoreValueAtAddress (IntPtr value);
 
@@ -13631,10 +13631,10 @@ namespace XamCore.Foundation
 		CGAffineTransform TransformStruct { get; set; }
 	}
 
-	[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'NSXpcConnection' instead.")]
-	[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'NSXpcConnection' instead.")]
-	[Availability (Deprecated = Platform.Watch_2_0, Message = "Use 'NSXpcConnection' instead.")]
-	[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'NSXpcConnection' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'NSXpcConnection' instead.")]
+	[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'NSXpcConnection' instead.")]
+	[Deprecated (PlatformName.WatchOS, 2, 0, message : "Use 'NSXpcConnection' instead.")]
+	[Deprecated (PlatformName.TvOS, 11, 0, message : "Use 'NSXpcConnection' instead.")]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface NSConnection {
@@ -13738,10 +13738,10 @@ namespace XamCore.Foundation
 		NSConnectionDelegate Delegate { get; set; }
 	}
 
-	[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'NSXpcConnection' instead.")]
-	[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'NSXpcConnection' instead.")]
-	[Availability (Deprecated = Platform.Watch_2_0, Message = "Use 'NSXpcConnection' instead.")]
-	[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'NSXpcConnection' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'NSXpcConnection' instead.")]
+	[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'NSXpcConnection' instead.")]
+	[Deprecated (PlatformName.WatchOS, 2, 0, message : "Use 'NSXpcConnection' instead.")]
+	[Deprecated (PlatformName.TvOS, 11, 0, message : "Use 'NSXpcConnection' instead.")]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -13765,10 +13765,10 @@ namespace XamCore.Foundation
 		bool AllowNewConnection (NSConnection newConnection, NSConnection parentConnection);
 	}
 
-	[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'NSXpcConnection' instead.")]
-	[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'NSXpcConnection' instead.")]
-	[Availability (Deprecated = Platform.Watch_2_0, Message = "Use 'NSXpcConnection' instead.")]
-	[Availability (Deprecated = Platform.TV_11_0, Message = "Use 'NSXpcConnection' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'NSXpcConnection' instead.")]
+	[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'NSXpcConnection' instead.")]
+	[Deprecated (PlatformName.WatchOS, 2, 0, message : "Use 'NSXpcConnection' instead.")]
+	[Deprecated (PlatformName.TvOS, 11, 0, message : "Use 'NSXpcConnection' instead.")]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface NSDistantObjectRequest {

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -3215,7 +3215,7 @@ namespace XamCore.Foundation
 		[Export ("enumerateResultsUsingBlock:")]
 		void EnumerateResultsUsingBlock (NSMetadataQueryEnumerationCallback callback);
 
-		[iOS (7,0), Mavericks, Export ("enumerateResultsWithOptions:usingBlock:")]
+		[iOS (7,0), Mac (10, 9), Export ("enumerateResultsWithOptions:usingBlock:")]
 		void EnumerateResultsWithOptions (NSEnumerationOptions opts, NSMetadataQueryEnumerationCallback block);
 
 		//
@@ -5412,7 +5412,7 @@ namespace XamCore.Foundation
 		[Export ("initFileURLWithFileSystemRepresentation:isDirectory:relativeToURL:")]
 		IntPtr Constructor (IntPtr ptrUtf8path, bool isDir, NSUrl baseURL);
 
-		[iOS (7,0), Mavericks, Static, Export ("fileURLWithFileSystemRepresentation:isDirectory:relativeToURL:")]
+		[iOS (7,0), Mac (10, 9), Static, Export ("fileURLWithFileSystemRepresentation:isDirectory:relativeToURL:")]
 		NSUrl FromUTF8Pointer (IntPtr ptrUtf8path, bool isDir, NSUrl baseURL);
 
 #if MONOMAC
@@ -13240,7 +13240,7 @@ namespace XamCore.Foundation
 #if MONOMAC
 	partial interface NSBundle {
 		// - (NSImage *)imageForResource:(NSString *)name NS_AVAILABLE_MAC(10_7);
-		[Lion, Export ("imageForResource:")]
+		[Mac (10, 7), Export ("imageForResource:")]
 		NSImage ImageForResource (string name);
 	}
 #endif
@@ -13248,7 +13248,7 @@ namespace XamCore.Foundation
 	partial interface NSAttributedString {
 
 #if MONOMAC
-		[Lion, Field ("NSTextLayoutSectionOrientation", "AppKit")]
+		[Mac (10, 7), Field ("NSTextLayoutSectionOrientation", "AppKit")]
 #else
 		[iOS (7,0)]
 		[Field ("NSTextLayoutSectionOrientation", "UIKit")]
@@ -13256,7 +13256,7 @@ namespace XamCore.Foundation
 		NSString TextLayoutSectionOrientation { get; }
 
 #if MONOMAC
-		[Lion, Field ("NSTextLayoutSectionRange", "AppKit")]
+		[Mac (10, 7), Field ("NSTextLayoutSectionRange", "AppKit")]
 #else
 		[iOS (7,0)]
 		[Field ("NSTextLayoutSectionRange", "UIKit")]
@@ -13264,7 +13264,7 @@ namespace XamCore.Foundation
 		NSString TextLayoutSectionRange { get; }
 
 #if MONOMAC
-		[Lion, Field ("NSTextLayoutSectionsAttribute", "AppKit")]
+		[Mac (10, 7), Field ("NSTextLayoutSectionsAttribute", "AppKit")]
 #else
 		[iOS (7,0)]
 		[Field ("NSTextLayoutSectionsAttribute", "UIKit")]
@@ -13281,7 +13281,7 @@ namespace XamCore.Foundation
 		[Field ("NSSpellingStateAttributeName", "AppKit")]
 		NSString SpellingStateAttributeName { get; }
 
-		[MountainLion, Field ("NSTextAlternativesAttributeName", "AppKit")]
+		[Mac (10, 8), Field ("NSTextAlternativesAttributeName", "AppKit")]
 		NSString TextAlternativesAttributeName { get; }
 		#endif
 
@@ -13422,7 +13422,7 @@ namespace XamCore.Foundation
 	[Mac (10,8), iOS (11,0), NoWatch, NoTV]
 	partial interface NSFileManager {
 
-		[MountainLion, Export ("trashItemAtURL:resultingItemURL:error:")]
+		[Mac (10, 8), Export ("trashItemAtURL:resultingItemURL:error:")]
 		bool TrashItem (NSUrl url, out NSUrl resultingItemUrl, out NSError error);
 	}
 
@@ -13439,7 +13439,7 @@ namespace XamCore.Foundation
 #if MONOMAC
 	partial interface NSFilePresenter {
 
-		[MountainLion, Export ("primaryPresentedItemURL")]
+		[Mac (10, 8), Export ("primaryPresentedItemURL")]
 		NSUrl PrimaryPresentedItemUrl { get; }
 	}
 

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -1443,27 +1443,27 @@ namespace XamCore.Foundation
 		[Since (4,0)]
 		NSRange Find (NSData dataToFind, NSDataSearchOptions searchOptions, NSRange searchRange);
 
-		[Since (7,0), Mavericks] // 10.9
+		[Since (7,0), Mac (10, 9)] // 10.9
 		[Export ("initWithBase64EncodedString:options:")]
 		IntPtr Constructor (string base64String, NSDataBase64DecodingOptions options);
 
-		[Since (7,0), Mavericks] // 10.9
+		[Since (7,0), Mac (10, 9)] // 10.9
 		[Export ("initWithBase64EncodedData:options:")]
 		IntPtr Constructor (NSData base64Data, NSDataBase64DecodingOptions options);
 
-		[Since (7,0), Mavericks] // 10.9
+		[Since (7,0), Mac (10, 9)] // 10.9
 		[Export ("base64EncodedDataWithOptions:")]
 		NSData GetBase64EncodedData (NSDataBase64EncodingOptions options);
 
-		[Since (7,0), Mavericks] // 10.9
+		[Since (7,0), Mac (10, 9)] // 10.9
 		[Export ("base64EncodedStringWithOptions:")]
 		string GetBase64EncodedString (NSDataBase64EncodingOptions options);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("enumerateByteRangesUsingBlock:")]
 		void EnumerateByteRange (NSDataByteRangeEnumerator enumerator);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("initWithBytesNoCopy:length:deallocator:")]
 		IntPtr Constructor (IntPtr bytes, nuint length, Action<IntPtr,nuint> deallocator);
 	}
@@ -2293,11 +2293,11 @@ namespace XamCore.Foundation
 		[Export ("classNameForClass:")]
 		string GetClassName (Class kls);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("NSKeyedArchiveRootObjectKey")]
 		NSString RootObjectKey { get; }
 
-		[Since (6,0), MountainLion] // Yup, right, this is being "back-supported" to iOS 6
+		[Since (6,0), Mac (10, 8)] // Yup, right, this is being "back-supported" to iOS 6
 		[Export ("setRequiresSecureCoding:")]
 		void SetRequiresSecureCoding (bool requireSecureEncoding);
 
@@ -2349,7 +2349,7 @@ namespace XamCore.Foundation
 		[Export ("classForClassName:")]
 		Class GetClass (string codedName);
 
-		[Since (6,0), MountainLion] // Yup, right, this is being "back-supported" to iOS 6
+		[Since (6,0), Mac (10, 8)] // Yup, right, this is being "back-supported" to iOS 6
 		[Export ("setRequiresSecureCoding:")]
 		void SetRequiresSecureCoding (bool requireSecureEncoding);
 
@@ -3198,18 +3198,18 @@ namespace XamCore.Foundation
 		[Field ("NSMetadataUbiquitousSharedItemPermissionsReadWrite")]
 		NSString UbiquitousSharedItemPermissionsReadWrite { get; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[NullAllowed] // by default this property is null
 		[Export ("searchItems", ArgumentSemantic.Copy)]
 		// DOC: object is a mixture of NSString, NSMetadataItem, NSUrl
 		NSObject [] SearchItems { get; set; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[NullAllowed] // by default this property is null
 		[Export ("operationQueue", ArgumentSemantic.Retain)]
 		NSOperationQueue OperationQueue { get; set; }
 		
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("enumerateResultsUsingBlock:")]
 		void EnumerateResultsUsingBlock (NSMetadataQueryEnumerationCallback callback);
 
@@ -3946,7 +3946,7 @@ namespace XamCore.Foundation
 		[Static, Export ("expressionForBlock:arguments:")]
 		NSExpression FromFunction (NSExpressionCallbackHandler target, NSExpression[] parameters);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Static]
 		[Export ("expressionForAnyKey")]
 		NSExpression FromAnyKey ();
@@ -3956,7 +3956,7 @@ namespace XamCore.Foundation
 		[Export ("expressionForConditional:trueExpression:falseExpression:")]
 		NSExpression FromConditional (NSPredicate predicate, NSExpression trueExpression, NSExpression falseExpression);
 			
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("allowEvaluation")]
 		void AllowEvaluation ();
 		
@@ -4734,7 +4734,7 @@ namespace XamCore.Foundation
 		[Export ("reversedSortDescriptor")]
 		NSObject ReversedSortDescriptor { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("allowEvaluation")]
 		void AllowEvaluation ();
 	}
@@ -4809,7 +4809,7 @@ namespace XamCore.Foundation
 		[Export ("userInfo")]
 		NSObject UserInfo { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("tolerance")]
 		double Tolerance { get; set; }
 	}
@@ -5138,7 +5138,7 @@ namespace XamCore.Foundation
 		IntPtr InitWithUserName (string username);
 
 		[Internal]
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("initWithSuiteName:")]
 		IntPtr InitWithSuiteName (string suiteName);
 
@@ -5385,28 +5385,28 @@ namespace XamCore.Foundation
 		[Export ("URLByDeletingPathExtension")]
 		NSUrl RemovePathExtension ();
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("getFileSystemRepresentation:maxLength:")]
 		bool GetFileSystemRepresentation (IntPtr buffer, nint maxBufferLength);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("fileSystemRepresentation")]
 		IntPtr GetFileSystemRepresentationAsUtf8Ptr { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("removeCachedResourceValueForKey:")]
 		void RemoveCachedResourceValueForKey (NSString key);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("removeAllCachedResourceValues")]
 		void RemoveAllCachedResourceValues ();
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("setTemporaryResourceValue:forKey:")]
 		void SetTemporaryResourceValue (NSObject value, NSString key);
 
 		[DesignatedInitializer]
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("initFileURLWithFileSystemRepresentation:isDirectory:relativeToURL:")]
 		IntPtr Constructor (IntPtr ptrUtf8path, bool isDir, NSUrl baseURL);
 
@@ -5842,7 +5842,7 @@ namespace XamCore.Foundation
 		NSString UbiquitousSharedItemPermissionsReadWrite { get; }
 
 		[Since (5,1)]
-		[MountainLion]
+		[Mac (10, 8)]
 		[Field ("NSURLIsExcludedFromBackupKey")]
 		NSString IsExcludedFromBackupKey { get; }
 
@@ -5853,30 +5853,30 @@ namespace XamCore.Foundation
 		IntPtr Constructor (NSData bookmarkData, NSUrlBookmarkResolutionOptions resolutionOptions, [NullAllowed] NSUrl relativeUrl, out bool bookmarkIsStale, out NSError error);
 
 		[Field ("NSURLPathKey")]
-		[Since (6,0)][MountainLion]
+		[Since (6,0)][Mac (10, 8)]
 		NSString PathKey { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemDownloadingStatusKey")]
 		NSString UbiquitousItemDownloadingStatusKey { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemDownloadingErrorKey")]
 		NSString UbiquitousItemDownloadingErrorKey { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemUploadingErrorKey")]
 		NSString UbiquitousItemUploadingErrorKey { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemDownloadingStatusNotDownloaded")]
 		NSString UbiquitousItemDownloadingStatusNotDownloaded { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemDownloadingStatusDownloaded")]
 		NSString UbiquitousItemDownloadingStatusDownloaded { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("NSURLUbiquitousItemDownloadingStatusCurrent")]
 		NSString UbiquitousItemDownloadingStatusCurrent { get; }
 
@@ -6115,7 +6115,7 @@ namespace XamCore.Foundation
 		void RemoveCachedResponse (NSUrlSessionDataTask dataTask);
 	}
 	
-	[Since (7,0), Mavericks]
+	[Since (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject), Name="NSURLComponents")]
 	partial interface NSUrlComponents : NSCopying {
 		[Export ("initWithURL:resolvingAgainstBaseURL:")]
@@ -6573,11 +6573,11 @@ namespace XamCore.Foundation
 		[Export ("setDefaultCredential:forProtectionSpace:")]
 		void SetDefaultCredential (NSUrlCredential credential, NSUrlProtectionSpace forProtectionSpace);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("removeCredential:forProtectionSpace:options:")]
 		void RemoveCredential (NSUrlCredential credential, NSUrlProtectionSpace forProtectionSpace, NSDictionary options);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Field ("NSURLCredentialStorageRemoveSynchronizableCredentials")]
 		NSString RemoveSynchronizableCredentials { get; }
 
@@ -10365,22 +10365,22 @@ namespace XamCore.Foundation
 		NSRange RangeValue { get; }
 
 #if MONOMAC
-		[Static, Export ("valueWithCMTime:"), Lion]
+		[Static, Export ("valueWithCMTime:"), Mac (10, 7)]
 		NSValue FromCMTime (CMTime time);
 		
-		[Export ("CMTimeValue"), Lion]
+		[Export ("CMTimeValue"), Mac (10, 7)]
 		CMTime CMTimeValue { get; }
 		
-		[Static, Export ("valueWithCMTimeMapping:"), Lion]
+		[Static, Export ("valueWithCMTimeMapping:"), Mac (10, 7)]
 		NSValue FromCMTimeMapping (CMTimeMapping timeMapping);
 		
-		[Export ("CMTimeMappingValue"), Lion]
+		[Export ("CMTimeMappingValue"), Mac (10, 7)]
 		CMTimeMapping CMTimeMappingValue { get; }
 		
-		[Static, Export ("valueWithCMTimeRange:"), Lion]
+		[Static, Export ("valueWithCMTimeRange:"), Mac (10, 7)]
 		NSValue FromCMTimeRange (CMTimeRange timeRange);
 		
-		[Export ("CMTimeRangeValue"), Lion]
+		[Export ("CMTimeRangeValue"), Mac (10, 7)]
 		CMTimeRange CMTimeRangeValue { get; }
 
 		[Export ("valueWithRect:"), Static]
@@ -11362,15 +11362,15 @@ namespace XamCore.Foundation
 		[Export ("systemUptime")]
 		double SystemUptime { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("beginActivityWithOptions:reason:")]
 		NSObject BeginActivity (NSActivityOptions options, string reason);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("endActivity:")]
 		void EndActivity (NSObject activity);
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("performActivityWithOptions:reason:usingBlock:")]
 		void PerformActivity (NSActivityOptions options, string reason, NSAction runCode);
 
@@ -11442,7 +11442,7 @@ namespace XamCore.Foundation
 		string GetFullUserName ();
 	}
 
-	[Since (7,0), Mavericks]
+	[Since (7,0), Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	partial interface NSProgress {
 	
@@ -11742,7 +11742,7 @@ namespace XamCore.Foundation
 		void Cancel ();
 
 		[Since (6,0)]
-		[MountainLion]
+		[Mac (10, 8)]
 		[Export ("itemAtURL:willMoveToURL:")]
 		void WillMove (NSUrl oldUrl, NSUrl newUrl);
 
@@ -12073,17 +12073,17 @@ namespace XamCore.Foundation
                 NSUrl GetUrlForPublishingUbiquitousItem (NSUrl url, out NSDate expirationDate, out NSError error);
 
 		[Since (6,0)]
-		[MountainLion]
+		[Mac (10, 8)]
 		[Export ("ubiquityIdentityToken")]
 		NSObject UbiquityIdentityToken { get; }
 
 		[Since (6,0)]
-		[MountainLion]
+		[Mac (10, 8)]
 		[Field ("NSUbiquityIdentityDidChangeNotification")]
 		[Notification]
 		NSString UbiquityIdentityDidChangeNotification { get; }
 
-		[Since (7,0), MountainLion]
+		[Since (7,0), Mac (10, 8)]
 		[Export ("containerURLForSecurityApplicationGroupIdentifier:")]
 		NSUrl GetContainerUrl (string securityApplicationGroupIdentifier);
 
@@ -12550,11 +12550,11 @@ namespace XamCore.Foundation
 #if MONOMAC
 		// 10.9+
 		[Static]
-		[Mavericks]
+		[Mac (10, 9)]
 		[Export ("predicateFromMetadataQueryString:")]
 		NSPredicate FromMetadataQueryString (string query);
 #endif
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("allowEvaluation")]
 		void AllowEvaluation ();
 	}
@@ -14153,7 +14153,7 @@ namespace XamCore.Foundation
 		NSString DidTerminateNotification { get; }
 	}
 
-	[MountainLion]
+	[Mac (10, 8)]
 	[BaseType (typeof (NSObject))]
 	interface NSUserNotification : NSCoding, NSCopying {
 		[Export ("title", ArgumentSemantic.Copy)]
@@ -14248,7 +14248,7 @@ namespace XamCore.Foundation
 		string Title { get; }
 	}
 	
-	[MountainLion]
+	[Mac (10, 8)]
 	[BaseType (typeof (NSObject),
 	           Delegates=new string [] {"WeakDelegate"},
 	Events=new Type [] { typeof (NSUserNotificationCenterDelegate) })]
@@ -14287,7 +14287,7 @@ namespace XamCore.Foundation
 		void RemoveAllDeliveredNotifications ();
 	}
 	
-	[MountainLion]
+	[Mac (10, 8)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -1528,8 +1528,10 @@ namespace XamCore.Foundation
 		nint Nanosecond { get; set; }
 
 		[Export ("week")]
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_9, Message = "Use 'WeekOfMonth' or 'WeekOfYear' instead.")]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0, Message = "Use 'WeekOfMonth' or 'WeekOfYear' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 4)]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use 'WeekOfMonth' or 'WeekOfYear' instead.")]
+		[Introduced (PlatformName.iOS, 2, 0)]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'WeekOfMonth' or 'WeekOfYear' instead.")]
 		nint Week { get; set; }
 
 		[Export ("weekday")]
@@ -2533,8 +2535,8 @@ namespace XamCore.Foundation
 		[Field ("NSMetadataUbiquitousItemHasUnresolvedConflictsKey")]
 		NSString UbiquitousItemHasUnresolvedConflictsKey { get; }
 
-		[Availability (Deprecated = Platform.iOS_7_0, Message="Use 'UbiquitousItemDownloadingStatusKey' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_9, Message="Use 'UbiquitousItemDownloadingStatusKey' instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'UbiquitousItemDownloadingStatusKey' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use 'UbiquitousItemDownloadingStatusKey' instead.")]
 		[Field ("NSMetadataUbiquitousItemIsDownloadedKey")]
 		NSString UbiquitousItemIsDownloadedKey { get; }
 
@@ -5219,8 +5221,8 @@ namespace XamCore.Foundation
 		[Export ("removeVolatileDomainForName:")]
 		void RemoveVolatileDomain (string domainName);
 	
-		[Availability (Deprecated = Platform.iOS_7_0)]
-		[Availability (Deprecated = Platform.Mac_10_9)]
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		[Export ("persistentDomainNames")]
 		string [] PersistentDomainNames ();
 	
@@ -5796,12 +5798,16 @@ namespace XamCore.Foundation
 		NSString UbiquitousItemIsUploadingKey { get; }
 
 		[Field ("NSURLUbiquitousItemPercentDownloadedKey")]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_6_0, Message = "Use 'NSMetadataQuery.UbiquitousItemPercentDownloadedKey' on 'NSMetadataItem' instead.")]
-		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_8, Message = "Use 'NSMetadataQuery.UbiquitousItemPercentDownloadedKey' on 'NSMetadataItem' instead.")]
+		[Introduced (PlatformName.iOS, 5, 0)]
+		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'NSMetadataQuery.UbiquitousItemPercentDownloadedKey' on 'NSMetadataItem' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Use 'NSMetadataQuery.UbiquitousItemPercentDownloadedKey' on 'NSMetadataItem' instead.")]
 		NSString UbiquitousItemPercentDownloadedKey { get; }
 
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_6_0, Message = "Use 'NSMetadataQuery.UbiquitousItemPercentUploadedKey' on 'NSMetadataItem' instead.")]
-		[Availability (Introduced = Platform.Mac_10_7, Deprecated = Platform.Mac_10_8, Message = "Use 'NSMetadataQuery.UbiquitousItemPercentUploadedKey' on 'NSMetadataItem' instead.")]
+		[Introduced (PlatformName.iOS, 5, 0)]
+		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'NSMetadataQuery.UbiquitousItemPercentUploadedKey' on 'NSMetadataItem' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
+		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Use 'NSMetadataQuery.UbiquitousItemPercentUploadedKey' on 'NSMetadataItem' instead.")]
 		[Field ("NSURLUbiquitousItemPercentUploadedKey")]
 		NSString UbiquitousItemPercentUploadedKey { get; }
 
@@ -6981,8 +6987,8 @@ namespace XamCore.Foundation
 		NSUrlSessionConfiguration EphemeralSessionConfiguration { get; }
 	
 		[Static, Export ("backgroundSessionConfiguration:")]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'CreateBackgroundSessionConfiguration' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'CreateBackgroundSessionConfiguration' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'CreateBackgroundSessionConfiguration' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'CreateBackgroundSessionConfiguration' instead.")]
 		NSUrlSessionConfiguration BackgroundSessionConfiguration (string identifier);
 	
 		[Export ("identifier", ArgumentSemantic.Copy), NullAllowed]
@@ -10015,8 +10021,10 @@ namespace XamCore.Foundation
 		void Publish (NSNetServiceOptions options);
 
 		[Export ("resolve")]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_2_0, Message = "Use 'Resolve (double)' instead.")]
-		[Availability (Introduced = Platform.Mac_10_2, Deprecated = Platform.Mac_10_4, Message = "Use 'Resolve (double)' instead.")]
+		[Introduced (PlatformName.iOS, 2, 0)]
+		[Deprecated (PlatformName.iOS, 2, 0, message : "Use 'Resolve (double)' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 2)]
+		[Deprecated (PlatformName.MacOSX, 10, 4, message : "Use 'Resolve (double)' instead.")]
 		[NoWatch]
 		void Resolve ();
 
@@ -11337,13 +11345,13 @@ namespace XamCore.Foundation
 		[Export ("hostName")]
 		string HostName { get; }
 
-		[Availability (Deprecated = Platform.Mac_10_10, Message="Use 'OperatingSystemVersion' or 'IsOperatingSystemAtLeastVersion' instead.")]
-		[Availability (Deprecated = Platform.iOS_8_0, Message="Use 'OperatingSystemVersion' or 'IsOperatingSystemAtLeastVersion' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'OperatingSystemVersion' or 'IsOperatingSystemAtLeastVersion' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'OperatingSystemVersion' or 'IsOperatingSystemAtLeastVersion' instead.")]
 		[Export ("operatingSystem")]
 		nint OperatingSystem { get; }
 
-		[Availability (Deprecated = Platform.Mac_10_10, Message="Use 'OperatingSystemVersionString' instead.")]
-		[Availability (Deprecated = Platform.iOS_8_0, Message="Use 'OperatingSystemVersionString' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'OperatingSystemVersionString' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'OperatingSystemVersionString' instead.")]
 		[Export ("operatingSystemName")]
 		string OperatingSystemName { get; }
 
@@ -12866,8 +12874,8 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // An uncaught exception was raised: *** -range cannot be sent to an abstract object of class NSTextCheckingResult: Create a concrete instance!
-	[Availability (Introduced = Platform.iOS_4_0)]
-	[Availability (Introduced = Platform.Mac_10_6)]
+	[Introduced (PlatformName.iOS, 4, 0)]
+	[Introduced (PlatformName.MacOSX, 10, 6)]
 	interface NSTextCheckingResult : NSSecureCoding, NSCopying {
 		[Export ("resultType")]
 		NSTextCheckingType ResultType { get;  }
@@ -12892,8 +12900,8 @@ namespace XamCore.Foundation
 		double TimeInterval { get; }
 
 		[Export ("components")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_7)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSDictionary WeakComponents { get; }
 
@@ -12907,19 +12915,19 @@ namespace XamCore.Foundation
 		string ReplacementString { get; }
 
 		[Export ("alternativeStrings")]
-		[Availability (Introduced = Platform.iOS_7_0)]
-		[Availability (Introduced = Platform.Mac_10_9)]
+		[Introduced (PlatformName.iOS, 7, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 9)]
 		string [] AlternativeStrings { get; }
 
 //		NSRegularExpression isn't bound
 //		[Export ("regularExpression")]
-//		[Availability (Introduced = Platform.iOS_4_0)]
-//		[Availability (Introduced = Platform.Mac_10_7)]
+//		[Introduced (PlatformName.iOS, 4, 0)]
+//		[Introduced (PlatformName.MacOSX, 10, 7)]
 //		NSRegularExpression RegularExpression { get; }
 
 		[Export ("phoneNumber")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_7)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
 		string PhoneNumber { get; }
 
 		[Export ("addressComponents")]
@@ -12930,18 +12938,18 @@ namespace XamCore.Foundation
 		NSTextCheckingAddressComponents AddressComponents { get; }
 
 		[Export ("numberOfRanges")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_7)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
 		nuint NumberOfRanges { get; }
 
 		[Export ("rangeAtIndex:")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_7)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
 		NSRange RangeAtIndex (nuint idx);
 
 		[Export ("resultByAdjustingRangesWithOffset:")]
-		[Availability (Introduced = Platform.iOS_5_0)]
-		[Availability (Introduced = Platform.Mac_10_7)]
+		[Introduced (PlatformName.iOS, 5, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
 		NSTextCheckingResult ResultByAdjustingRanges (nint offset);
 
 		// From the NSTextCheckingResultCreation category on NSTextCheckingResult
@@ -12997,27 +13005,27 @@ namespace XamCore.Foundation
 
 		[Static]
 		[Export ("correctionCheckingResultWithRange:replacementString:alternativeStrings:")]
-		[Availability (Introduced = Platform.iOS_7_0)]
-		[Availability (Introduced = Platform.Mac_10_9)]
+		[Introduced (PlatformName.iOS, 7, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 9)]
 		NSTextCheckingResult CorrectionCheckingResult (NSRange range, string replacementString, string[] alternativeStrings);
 
 //		NSRegularExpression isn't bound
 //		[Export ("regularExpressionCheckingResultWithRanges:count:regularExpression:")]
-//		[Availability (Introduced = Platform.iOS_4_0)]
-//		[Availability (Introduced = Platform.Mac_10_7)]
+//		[Introduced (PlatformName.iOS, 4, 0)]
+//		[Introduced (PlatformName.MacOSX, 10, 7)]
 //		[Internal] // FIXME
 //		NSTextCheckingResult RegularExpressionCheckingResult (ref NSRange ranges, nuint count, NSRegularExpression regularExpression);
 
 		[Static]
 		[Export ("phoneNumberCheckingResultWithRange:phoneNumber:")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_7)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
 		NSTextCheckingResult PhoneNumberCheckingResult (NSRange range, string phoneNumber);
 
 		[Static]
 		[Export ("transitInformationCheckingResultWithRange:components:")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_7)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSTextCheckingResult TransitInformationCheckingResult (NSRange range, NSDictionary components);
 
@@ -13033,110 +13041,110 @@ namespace XamCore.Foundation
 
 	[StrongDictionary ("NSTextChecking")]
 	interface NSTextCheckingTransitComponents {
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_7)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
 		string Airline { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_7)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
 		string Flight { get; }
 	}
 
 	[StrongDictionary ("NSTextChecking")]
 	interface NSTextCheckingAddressComponents {
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		string Name { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		string JobTitle { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		string Organization { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		string Street { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		string City { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		string State { get; }
 
 		[Export ("ZipKey")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		string ZIP { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		string Country { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		string Phone { get; }
 	}
 
 	[Static]
 	interface NSTextChecking {
 		[Field ("NSTextCheckingNameKey")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		NSString NameKey { get; }
 
 		[Field ("NSTextCheckingJobTitleKey")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		NSString JobTitleKey { get; }
 
 		[Field ("NSTextCheckingOrganizationKey")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		NSString OrganizationKey { get; }
 
 		[Field ("NSTextCheckingStreetKey")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		NSString StreetKey { get; }
 
 		[Field ("NSTextCheckingCityKey")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		NSString CityKey { get; }
 
 		[Field ("NSTextCheckingStateKey")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		NSString StateKey { get; }
 
 		[Field ("NSTextCheckingZIPKey")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		NSString ZipKey { get; }
 
 		[Field ("NSTextCheckingCountryKey")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		NSString CountryKey { get; }
 
 		[Field ("NSTextCheckingPhoneKey")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_6)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 6)]
 		NSString PhoneKey { get; }
 
 		[Field ("NSTextCheckingAirlineKey")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_7)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
 		NSString AirlineKey { get; }
 
 		[Field ("NSTextCheckingFlightKey")]
-		[Availability (Introduced = Platform.iOS_4_0)]
-		[Availability (Introduced = Platform.Mac_10_7)]
+		[Introduced (PlatformName.iOS, 4, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 7)]
 		NSString FlightKey { get; }
 	}
 

--- a/src/gamecontroller.cs
+++ b/src/gamecontroller.cs
@@ -18,7 +18,7 @@ using XamCore.UIKit;
 
 namespace XamCore.GameController {
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // The GCControllerElement class is never instantiated directly.
@@ -35,7 +35,7 @@ namespace XamCore.GameController {
 
 	delegate void GCControllerAxisValueChangedHandler (GCControllerAxisInput axis, float /* float, not CGFloat */ value);
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (GCControllerElement))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
@@ -50,7 +50,7 @@ namespace XamCore.GameController {
 
 	delegate void GCControllerButtonValueChanged (GCControllerButtonInput button, float /* float, not CGFloat */ buttonValue, bool pressed);
 
-	[Since (7,0), Mac (10,9, onlyOn64: true)]
+	[iOS (7,0), Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (GCControllerElement))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
 	partial interface GCControllerButtonInput {
@@ -86,7 +86,7 @@ namespace XamCore.GameController {
 
 	delegate void GCControllerDirectionPadValueChangedHandler (GCControllerDirectionPad dpad, float /* float, not CGFloat */ xValue, float /* float, not CGFloat */ yValue);
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (GCControllerElement))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
@@ -116,7 +116,7 @@ namespace XamCore.GameController {
 
 	delegate void GCGamepadValueChangedHandler (GCGamepad gamepad, GCControllerElement element);
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
@@ -153,7 +153,7 @@ namespace XamCore.GameController {
 		GCControllerButtonInput RightShoulder { get; }
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (GCGamepad))]
 	[DisableDefaultCtor]
@@ -171,7 +171,7 @@ namespace XamCore.GameController {
 
 	delegate void GCExtendedGamepadValueChangedHandler (GCExtendedGamepad gamepad, GCControllerElement element);
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
@@ -220,7 +220,7 @@ namespace XamCore.GameController {
 		GCControllerButtonInput RightTrigger { get; }
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (GCExtendedGamepad))]
 	[DisableDefaultCtor]
@@ -240,7 +240,7 @@ namespace XamCore.GameController {
 	delegate void GCControllerPausedHandler (GCController controller);
 #endif
 
-	[Since (7,0), Mac (10,9, onlyOn64: true)]
+	[iOS (7,0), Mac (10,9, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	partial interface GCController {
 

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -364,7 +364,7 @@ namespace XamCore.GameKit {
 		[NoTV]
 		[NoWatch] // deprecated in 2.0 (but framework not added before 3.0)
 		[Static]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'SetDefaultLeaderboard' on 'GKLocalPlayer' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'SetDefaultLeaderboard' on 'GKLocalPlayer' instead.")]
 		[Export ("setDefaultLeaderboard:withCompletionHandler:")]
@@ -375,24 +375,24 @@ namespace XamCore.GameKit {
 		void SetDefaultLeaderboard ([NullAllowed] string leaderboardIdentifier, [NullAllowed] GKNotificationHandler notificationHandler);
 #endif
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("groupIdentifier", ArgumentSemantic.Retain)]
 		string GroupIdentifier { get; [NotImplemented] set; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Static]
 		[Export ("loadLeaderboardsWithCompletionHandler:")]
 		[Async]
 		void LoadLeaderboards ([NullAllowed] Action<GKLeaderboard[], NSError> completionHandler);
 
-		[Since (7,0)][Mac (10,10)]
+		[iOS (7,0)][Mac (10,10)]
 		[NullAllowed]
 		[Export ("identifier", ArgumentSemantic.Copy)]
 		string Identifier { get; set; }
 
 		[NoTV]
 		[NoWatch]
-		[Since (7,0)][Mac (10,8)]
+		[iOS (7,0)][Mac (10,8)]
 		[Export ("loadImageWithCompletionHandler:")]
 		[Async]
 		void LoadImage ([NullAllowed] GKImageLoadedHandler completionHandler);
@@ -407,7 +407,7 @@ namespace XamCore.GameKit {
 	}
 
 	[Watch (3,0)]
-	[Since (7,0)][Mac (10,10)]
+	[iOS (7,0)][Mac (10,10)]
 	[BaseType (typeof (NSObject))]
 	interface GKLeaderboardSet : NSCoding, NSSecureCoding {
 
@@ -464,7 +464,7 @@ namespace XamCore.GameKit {
 	}
 
 	[Watch (3,0)]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[BaseType (typeof (GKBasePlayer))]
 	// note: NSSecureCoding conformity is undocumented - but since it's a runtime check (on ObjC) we still need it
 	interface GKPlayer : NSSecureCoding {
@@ -491,12 +491,12 @@ namespace XamCore.GameKit {
 		NSString DidChangeNotificationNameNotification { get; }
 
 		[NoWatch]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("loadPhotoForSize:withCompletionHandler:")]
 		[Async]
 		void LoadPhoto (GKPhotoSize size, [NullAllowed] GKPlayerPhotoLoaded onCompleted);
 
-		[Since (6,0)][Mac (10,8)]
+		[iOS (6,0)][Mac (10,8)]
 		[Export ("displayName")]
 		string DisplayName { get; }
 
@@ -515,7 +515,7 @@ namespace XamCore.GameKit {
 	}
 
 	[Watch (3,0)]
-	[Since (4,1)]
+	[iOS (4,1)]
 	[BaseType (typeof (NSObject))]
 	interface GKScore : NSSecureCoding {
 		[NoWatch]
@@ -530,11 +530,11 @@ namespace XamCore.GameKit {
 		IntPtr Constructor (string identifier, GKPlayer player);
 
 		[NoWatch]
-		[Since (7,0)][Mac (10,8)]
+		[iOS (7,0)][Mac (10,8)]
 		[Export ("initWithLeaderboardIdentifier:forPlayer:")]
 		IntPtr Constructor (string identifier, string playerID);
 
-		[Since (7,0)][Mac (10,8)]
+		[iOS (7,0)][Mac (10,8)]
 		[Internal][NullAllowed]
 		[Export ("initWithLeaderboardIdentifier:")]
 		IntPtr InitWithLeaderboardIdentifier (string identifier);
@@ -598,11 +598,11 @@ namespace XamCore.GameKit {
 		void ReportScore ([NullAllowed] GKNotificationHandler errorHandler);
 #endif
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("context", ArgumentSemantic.Assign)]
 		ulong Context { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("shouldSetDefaultLeaderboard", ArgumentSemantic.Assign)]
 		bool ShouldSetDefaultLeaderboard { get; set; }
 
@@ -614,18 +614,18 @@ namespace XamCore.GameKit {
 		[Export ("issueChallengeToPlayers:message:")]
 		void IssueChallengeToPlayers ([NullAllowed] string[] playerIDs, [NullAllowed] string message);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("reportScores:withCompletionHandler:"), Static]
 		[Async]
 		void ReportScores (GKScore[] scores, [NullAllowed] Action<NSError> completionHandler);
 
-		[Since (7,0)][Mac (10,10)]
+		[iOS (7,0)][Mac (10,10)]
 		[NullAllowed] // by default this property is null
 		[Export ("leaderboardIdentifier", ArgumentSemantic.Copy)]
 		string LeaderboardIdentifier { get; set; }
 
 		[NoWatch]
-		[Since (7,0)][Mac (10,10)]
+		[iOS (7,0)][Mac (10,10)]
 		[Export ("reportScores:withEligibleChallenges:withCompletionHandler:"), Static]
 		[Async]
 		void ReportScores (GKScore[] scores, [NullAllowed] GKChallenge[] challenges, [NullAllowed] Action<NSError> completionHandler);
@@ -654,7 +654,7 @@ namespace XamCore.GameKit {
 
 	[NoWatch]
 	[NoTV]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'GKGameCenterViewController' instead.")]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKGameCenterViewController' instead.")]
 	[BaseType (typeof (NSObject))]
@@ -705,7 +705,7 @@ namespace XamCore.GameKit {
 	}
 
 	[Watch (3,0)]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[Mac (10, 8)]
 	[BaseType (typeof (GKPlayer))]
 	interface GKLocalPlayer {
@@ -781,7 +781,7 @@ namespace XamCore.GameKit {
 		[NoWatch]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'LoadDefaultLeaderboardIdentifier' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'LoadDefaultLeaderboardIdentifier' instead.")]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("loadDefaultLeaderboardCategoryIDWithCompletionHandler:")]
 		[Async]
 		void LoadDefaultLeaderboardCategoryID ([NullAllowed] Action<string, NSError> completionHandler);
@@ -879,7 +879,7 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(GKMatchDelegate)})]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: -[__NSCFDictionary setObject:forKey:]: attempt to insert nil value (key: 1500388194)
 	// <quote>Your application never directly allocates GKMatch objects.</quote> http://developer.apple.com/library/ios/#documentation/GameKit/Reference/GKMatch_Ref/Reference/Reference.html
@@ -925,7 +925,7 @@ namespace XamCore.GameKit {
 		[Async]
 		void ChooseBestHostPlayer (Action<string> completionHandler);
 
-		[Since (6,0)][Mac (10,9)]
+		[iOS (6,0)][Mac (10,9)]
 		[Export ("rematchWithCompletionHandler:")]
 		[Async]
 		void Rematch ([NullAllowed] Action<GKMatch, NSError> completionHandler);
@@ -945,7 +945,7 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -987,7 +987,7 @@ namespace XamCore.GameKit {
 		[NoTV]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'ShouldReinviteDisconnectedPlayer' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'ShouldReinviteDisconnectedPlayer' instead.")]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("match:shouldReinvitePlayer:"), DelegateName ("GKMatchReinvitation"), DefaultValue (true)]
 		bool ShouldReinvitePlayer (GKMatch match, string playerId);
 
@@ -1011,7 +1011,7 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	interface GKVoiceChat {
 		[Export ("name", ArgumentSemantic.Copy)]
@@ -1053,7 +1053,7 @@ namespace XamCore.GameKit {
 		void SetPlayerVoiceChatStateChangeHandler (Action<GKPlayer,GKVoiceChatPlayerState> handler);
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'Players' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'Players' instead.")]
 		[Export ("playerIDs")]
@@ -1089,12 +1089,12 @@ namespace XamCore.GameKit {
 		[Export ("playersToInvite", ArgumentSemantic.Retain)]
 		string [] PlayersToInvite { get; set;  }
 
-		[Since (6,0)][Mac (10,8)]
+		[iOS (6,0)][Mac (10,8)]
 		[NullAllowed] // by default this property is null
 		[Export ("inviteMessage", ArgumentSemantic.Copy)]
 		string InviteMessage { get; set; }
 
-		[Since (6,0)][Mac (10,8)]
+		[iOS (6,0)][Mac (10,8)]
 		[Export ("defaultNumberOfPlayers", ArgumentSemantic.Assign)]
 		nint DefaultNumberOfPlayers { get; set; }
 
@@ -1102,7 +1102,7 @@ namespace XamCore.GameKit {
 		[NoWatch]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'RecipientResponseHandler' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'RecipientResponseHandler' instead.")]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("inviteeResponseHandler", ArgumentSemantic.Copy)]
 		Action<string, GKInviteeResponse> InviteeResponseHandler { get; set; }
@@ -1111,7 +1111,7 @@ namespace XamCore.GameKit {
 		[NullAllowed, Export ("recipientResponseHandler", ArgumentSemantic.Copy)]
 		Action<GKPlayer, GKInviteRecipientResponse> RecipientResponseHandler { get; set; }
 
-		[Since (6,0)][Mac (10,9)]
+		[iOS (6,0)][Mac (10,9)]
 		[Export ("maxPlayersAllowedForMatchOfType:"), Static]
 		nint GetMaxPlayersAllowed (GKMatchType matchType);
 
@@ -1189,30 +1189,30 @@ namespace XamCore.GameKit {
 		void QueryActivity ([NullAllowed] GKQueryHandler completionHandler);
 
 		[NoWatch]
-		[Since (6,0)][Mac (10,9)]
+		[iOS (6,0)][Mac (10,9)]
 		[Export ("matchForInvite:completionHandler:")]
 		[Async]
 		void Match (GKInvite invite, [NullAllowed] Action<GKMatch, NSError> completionHandler);
 
 		[NoTV]
-		[Since (6,0)][Mac (10, 9)]
+		[iOS (6,0)][Mac (10, 9)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'CancelPendingInvite' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'CancelPendingInvite' instead.")]
 		[Export ("cancelInviteToPlayer:")]
 		void CancelInvite (string playerID);
 
-		[Since (6,0)][Mac (10,9)]
+		[iOS (6,0)][Mac (10,9)]
 		[Export ("finishMatchmakingForMatch:")]
 		void FinishMatchmaking (GKMatch match);
 
 		[NoTV]
-		[Since (6,0)][Mac (10,9)]
+		[iOS (6,0)][Mac (10,9)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'StartBrowsingForNearbyPlayers(Action<GKPlayer, bool> handler)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'StartBrowsingForNearbyPlayers(Action<GKPlayer, bool> handler)' instead.")]
 		[Export ("startBrowsingForNearbyPlayersWithReachableHandler:")]
 		void StartBrowsingForNearbyPlayers ([NullAllowed] Action<string, bool> reachableHandler);
 
-		[Since (6,0)][Mac (10,9)]
+		[iOS (6,0)][Mac (10,9)]
 		[Export ("stopBrowsingForNearbyPlayers")]
 		void StopBrowsingForNearbyPlayers ();
 
@@ -1237,7 +1237,7 @@ namespace XamCore.GameKit {
 	[Mac (10,8)]
 #else
 	[BaseType (typeof (UINavigationController), Delegates=new string [] { "WeakMatchmakerDelegate" }, Events=new Type [] {typeof(GKMatchmakerViewControllerDelegate)})]
-	[Since (4,2)]
+	[iOS (4,2)]
 #endif
 	// iOS 6 -> Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: <GKMatchmakerViewController: 0x16101160>: must use one of the designated initializers
 	[DisableDefaultCtor]
@@ -1276,12 +1276,12 @@ namespace XamCore.GameKit {
 		[Export ("defaultInvitationMessage", ArgumentSemantic.Copy)]
 		string DefaultInvitationMessage { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("addPlayersToMatch:")]
 		void AddPlayersToMatch (GKMatch match);
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'SetHostedPlayerConnected (GKPlayer,bool)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'SetHostedPlayerConnected (GKPlayer,bool)' instead.")]
 		[Export ("setHostedPlayer:connected:")]
@@ -1295,7 +1295,7 @@ namespace XamCore.GameKit {
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[Protocol]
 	interface GKMatchmakerViewControllerDelegate {
 		[Abstract]
@@ -1329,7 +1329,7 @@ namespace XamCore.GameKit {
 		void DidFindHostedPlayers (GKMatchmakerViewController viewController, GKPlayer [] playerIDs);
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'HostedPlayerDidAccept' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'HostedPlayerDidAccept' instead.")]
 		[Export ("matchmakerViewController:didReceiveAcceptFromHostedPlayer:"), EventArgs ("GKPlayer")]
@@ -1341,7 +1341,7 @@ namespace XamCore.GameKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[Since (4,2)][Mac (10, 8)]
+	[iOS (4,2)][Mac (10, 8)]
 	[Watch (3,0)]
 	interface GKAchievement : NSSecureCoding {
 		[NoTV]
@@ -1401,7 +1401,7 @@ namespace XamCore.GameKit {
 		void ReportAchievement ([NullAllowed] GKNotificationHandler completionHandler);
 #endif
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("showsCompletionBanner", ArgumentSemantic.Assign)]
 		bool ShowsCompletionBanner { get; set;  }
 
@@ -1492,7 +1492,7 @@ namespace XamCore.GameKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[Since (4,2)][Mac (10, 8)]
+	[iOS (4,2)][Mac (10, 8)]
 	[Watch (3,0)]
 	interface GKAchievementDescription : NSSecureCoding {
 		[Export ("identifier", ArgumentSemantic.Copy)]
@@ -1551,11 +1551,11 @@ namespace XamCore.GameKit {
 		[Export ("placeholderCompletedAchievementImage")]
 		UIImage PlaceholderCompletedAchievementImage { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("groupIdentifier", ArgumentSemantic.Retain)]
 		string GroupIdentifier { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("replayable", ArgumentSemantic.Assign)]
 		bool Replayable { [Bind ("isReplayable")] get; }
 #endif
@@ -1629,7 +1629,7 @@ namespace XamCore.GameKit {
 	interface GKFriendRequestComposeViewController 
 #else
 	[NoTV]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[Deprecated (PlatformName.iOS, 10, 0)]
 	[BaseType (typeof (UINavigationController), Events=new Type [] { typeof (GKFriendRequestComposeViewControllerDelegate)}, Delegates=new string[] {"WeakComposeViewDelegate"})]
 	interface GKFriendRequestComposeViewController : UIAppearance
@@ -1680,20 +1680,20 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType(typeof(NSObject))]
 	partial interface GKNotificationBanner {
 		[Static, Export ("showBannerWithTitle:message:completionHandler:")]
 		[Async]
 		void Show ([NullAllowed] string title, [NullAllowed] string message, [NullAllowed] NSAction onCompleted);
 
-		[Since (6,0)][Mac (10,8)]
+		[iOS (6,0)][Mac (10,8)]
 		[Export ("showBannerWithTitle:message:duration:completionHandler:"), Static]
 		[Async]
 		void Show ([NullAllowed] string title, [NullAllowed] string message, double durationSeconds, [NullAllowed] Action completionHandler);
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Watch (3,0)]
 	[BaseType (typeof (NSObject))]
 	interface GKTurnBasedParticipant {
@@ -1716,7 +1716,7 @@ namespace XamCore.GameKit {
 		[Export ("matchOutcome", ArgumentSemantic.Assign)]
 		GKTurnBasedMatchOutcome MatchOutcome { get; set;  }
 
-		[Since (6,0)][Mac (10,8)]
+		[iOS (6,0)][Mac (10,8)]
 		[Export ("timeoutDate", ArgumentSemantic.Copy)]
 		NSDate TimeoutDate { get; }
 	}
@@ -1764,7 +1764,7 @@ namespace XamCore.GameKit {
 #if (XAMCORE_2_0 && !MONOMAC) || XAMCORE_4_0
 		[Abstract]
 #endif
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("handleTurnEventForMatch:didBecomeActive:")]
 		[iOS (6, 0)]
 		[Deprecated (PlatformName.iOS, 6, 0)]
@@ -1793,16 +1793,16 @@ namespace XamCore.GameKit {
 		GKTurnBasedEventHandler SharedTurnBasedEventHandler { get; }
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	delegate void GKTurnBasedMatchRequest (GKTurnBasedMatch match, NSError error);
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	delegate void GKTurnBasedMatchesRequest (GKTurnBasedMatch [] matches, NSError error);
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	delegate void GKTurnBasedMatchData (NSData matchData, NSError error);
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Watch (3,0)]
 	[BaseType (typeof (NSObject))]
 	interface GKTurnBasedMatch {
@@ -1888,94 +1888,94 @@ namespace XamCore.GameKit {
 		void EndMatchInTurn (NSData matchData, [NullAllowed] GKNotificationHandler onCompletion);
 #endif
 
-		[Since (6,0)][Mac (10,8)]
+		[iOS (6,0)][Mac (10,8)]
 		[Static]
 		[Export ("loadMatchWithID:withCompletionHandler:")]
 		[Async]
 		void LoadMatch (string matchId, [NullAllowed] Action<GKTurnBasedMatch, NSError> completionHandler);
 
-		[Since (6,0)][Mac (10,8)]
+		[iOS (6,0)][Mac (10,8)]
 		[Export ("acceptInviteWithCompletionHandler:")]
 		[Async]
 		void AcceptInvite ([NullAllowed] Action<GKTurnBasedMatch, NSError> completionHandler);
 
-		[Since (6,0)][Mac (10,8)]
+		[iOS (6,0)][Mac (10,8)]
 		[Export ("declineInviteWithCompletionHandler:")]
 		[Async]
 		void DeclineInvite ([NullAllowed] Action<GKTurnBasedMatch, NSError> completionHandler);
 
-		[Since (6,0)][Mac (10,8)]
+		[iOS (6,0)][Mac (10,8)]
 		[Export ("matchDataMaximumSize")]
 		nint MatchDataMaximumSize { get; }
 
-		[Since (6,0)][Mac (10,9)]
+		[iOS (6,0)][Mac (10,9)]
 		[Export ("rematchWithCompletionHandler:")]
 		[Async]
 		void Rematch ([NullAllowed] Action<GKTurnBasedMatch, NSError> completionHandler);
 
-		[Since (6,0)][Mac (10,9)]
+		[iOS (6,0)][Mac (10,9)]
 		[Export ("endTurnWithNextParticipants:turnTimeout:matchData:completionHandler:")]
 		[Async]
 		void EndTurn (GKTurnBasedParticipant[] nextParticipants, double timeoutSeconds, NSData matchData, [NullAllowed] Action<NSError> completionHandler);
 
-		[Since (6,0)][Mac (10,9)]
+		[iOS (6,0)][Mac (10,9)]
 		[Export ("participantQuitInTurnWithOutcome:nextParticipants:turnTimeout:matchData:completionHandler:")]
 		[Async]
 		void ParticipantQuitInTurn (GKTurnBasedMatchOutcome matchOutcome, GKTurnBasedParticipant[] nextParticipants, double timeoutSeconds, NSData matchData, [NullAllowed] Action<NSError> completionHandler);
 
-		[Since (6,0)][Mac (10,8)]
+		[iOS (6,0)][Mac (10,8)]
 		[Export ("saveCurrentTurnWithMatchData:completionHandler:")]
 		[Async]
 		void SaveCurrentTurn (NSData matchData, [NullAllowed] Action<NSError> completionHandler);
 
-		[Since (6,0)][Mac (10,9)]
+		[iOS (6,0)][Mac (10,9)]
 		[Field ("GKTurnTimeoutDefault"), Static]
 		double DefaultTimeout { get; }
 
-		[Since (6,0)][Mac (10,9)]
+		[iOS (6,0)][Mac (10,9)]
 		[Field ("GKTurnTimeoutNone"), Static]
 		double NoTimeout { get; }
 
-		[Since (7,0)][Mac (10,10)]
+		[iOS (7,0)][Mac (10,10)]
 		[Export ("exchanges", ArgumentSemantic.Retain)]
 		GKTurnBasedExchange [] Exchanges { get; }
 
-		[Since (7,0)][Mac (10,10)]
+		[iOS (7,0)][Mac (10,10)]
 		[Export ("activeExchanges", ArgumentSemantic.Retain)]
 		GKTurnBasedExchange [] ActiveExchanges { get; }
 
-		[Since (7,0)][Mac (10,10)]
+		[iOS (7,0)][Mac (10,10)]
 		[Export ("completedExchanges", ArgumentSemantic.Retain)]
 		GKTurnBasedExchange [] CompletedExchanges { get; }
 
-		[Since (7,0)][Mac (10,10)]
+		[iOS (7,0)][Mac (10,10)]
 		[Export ("exchangeDataMaximumSize")]
 		nuint ExhangeDataMaximumSize { get; }
 
-		[Since (7,0)][Mac (10,10)]
+		[iOS (7,0)][Mac (10,10)]
 		[Export ("exchangeMaxInitiatedExchangesPerPlayer")]
 		nuint ExchangeMaxInitiatedExchangesPerPlayer { get; }
 
-		[Since (7,0)][Mac (10,10)]
+		[iOS (7,0)][Mac (10,10)]
 		[Export ("setLocalizableMessageWithKey:arguments:")]
 		void SetMessage (string localizableMessage, params NSObject [] arguments);
 
-		[Since (7,0)][Mac (10,10)]
+		[iOS (7,0)][Mac (10,10)]
 		[Export ("endMatchInTurnWithMatchData:scores:achievements:completionHandler:")]
 		[Async]
 		void EndMatchInTurn (NSData matchData, [NullAllowed] GKScore [] scores, [NullAllowed] GKAchievement [] achievements, [NullAllowed] Action<NSError> completionHandler);
 
-		[Since (7,0)][Mac (10,10)]
+		[iOS (7,0)][Mac (10,10)]
 		[Export ("saveMergedMatchData:withResolvedExchanges:completionHandler:")]
 		[Async]
 		void SaveMergedMatchData (NSData matchData, GKTurnBasedExchange [] exchanges, [NullAllowed] Action<NSError> completionHandler);
 
-		[Since (7,0)][Mac (10,10)]
+		[iOS (7,0)][Mac (10,10)]
 		[Export ("sendExchangeToParticipants:data:localizableMessageKey:arguments:timeout:completionHandler:")]
 		[Async]
 		void SendExchange (GKTurnBasedParticipant [] participants, NSData data, string localizableMessage, NSObject [] arguments, double timeout, [NullAllowed] Action<GKTurnBasedExchange, NSError> completionHandler);
 
-		[Since (7,0)][Mac (10,10)]
+		[iOS (7,0)][Mac (10,10)]
 		[Export ("sendReminderToParticipants:localizableMessageKey:arguments:completionHandler:")]
 		[Async]
 		void SendReminder (GKTurnBasedParticipant [] participants, string localizableMessage, NSObject [] arguments, [NullAllowed] Action<NSError> completionHandler);
@@ -1989,7 +1989,7 @@ namespace XamCore.GameKit {
 	[BaseType (typeof (NSViewController))]
 	interface GKTurnBasedMatchmakerViewController
 #else
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (UINavigationController))]
 	interface GKTurnBasedMatchmakerViewController : UIAppearance
 #endif
@@ -2009,7 +2009,7 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -2042,7 +2042,7 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[Since (6,0)][Mac (10, 9)]
+	[iOS (6,0)][Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	interface GKChallenge : NSSecureCoding {
 		[NoTV]
@@ -2086,7 +2086,7 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[Since (6,0)][Mac (10, 9)]
+	[iOS (6,0)][Mac (10, 9)]
 	[BaseType (typeof (GKChallenge))]
 	interface GKScoreChallenge {
 
@@ -2095,7 +2095,7 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[Since (6,0)][Mac (10, 9)]
+	[iOS (6,0)][Mac (10, 9)]
 	[BaseType (typeof (GKChallenge))]
 	interface GKAchievementChallenge {
 
@@ -2104,7 +2104,7 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[Since (6,0), Mac (10,9)]
+	[iOS (6,0), Mac (10,9)]
 	[BaseType (
 #if MONOMAC
 		typeof (NSViewController),
@@ -2148,7 +2148,7 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[Model]
 	[BaseType (typeof (NSObject))]
 	[Protocol]
@@ -2291,7 +2291,7 @@ namespace XamCore.GameKit {
 		NSDate ReplyDate { get; }
 	}
 
-	[Since (7,0), Mac (10,10)]
+	[iOS (7,0), Mac (10,10)]
 	[Watch (3,0)]
 	[Model, Protocol, BaseType (typeof (NSObject))]
 	interface GKLocalPlayerListener : GKTurnBasedEventListener
@@ -2305,7 +2305,7 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[Since (7,0), Mac (10,10)]
+	[iOS (7,0), Mac (10,10)]
 	[Model, Protocol, BaseType (typeof (NSObject))]
 	interface GKChallengeListener
 	{
@@ -2323,7 +2323,7 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[Since (7,0), Mac (10,10)]
+	[iOS (7,0), Mac (10,10)]
 	[Protocol, Model, BaseType (typeof (NSObject))]
 	interface GKInviteEventListener
 	{
@@ -2342,7 +2342,7 @@ namespace XamCore.GameKit {
 		void DidRequestMatch (GKPlayer player, GKPlayer [] recipientPlayers);
 	}
 
-	[Since (7,0), Mac (10,10)]
+	[iOS (7,0), Mac (10,10)]
 	[Watch (3,0)]
 	[Model, Protocol, BaseType (typeof (NSObject))]
 	interface GKTurnBasedEventListener

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -218,12 +218,14 @@ namespace XamCore.GameKit {
 	[NoTV]
 	[NoWatch] // deprecated in 2.0 (but framework not added before 3.0)
 	[BaseType (typeof (NSObject))]
-	[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_7_0, Message = "Use 'MultipeerConnectivity.MCSession' instead.")]
-	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'MultipeerConnectivity.MCSession' instead.")]
+	[Introduced (PlatformName.iOS, 3, 0)]
+	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'MultipeerConnectivity.MCSession' instead.")]
+	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'MultipeerConnectivity.MCSession' instead.")]
 	interface GKSession {
 		[Export ("initWithSessionID:displayName:sessionMode:")]
-		[Availability (Deprecated = Platform.iOS_7_0)]
-		[Availability (Deprecated = Platform.Mac_10_10)]
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		IntPtr Constructor ([NullAllowed] string sessionID, [NullAllowed] string displayName, GKSessionMode mode);
 
 		[Export ("delegate", ArgumentSemantic.Assign)][NullAllowed]
@@ -239,8 +241,8 @@ namespace XamCore.GameKit {
 		[Export ("displayName")]
 		string DisplayName { get; }
 
-		[Availability (Deprecated = Platform.iOS_7_0)]
-		[Availability (Deprecated = Platform.Mac_10_10)]
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[Export ("sessionMode")]
 		GKSessionMode SessionMode { get; }
 		
@@ -256,8 +258,8 @@ namespace XamCore.GameKit {
 		[Export ("displayNameForPeer:")]
 		string DisplayNameForPeer (string peerID);
 
-		[Availability (Deprecated = Platform.iOS_7_0)]
-		[Availability (Deprecated = Platform.Mac_10_10)]
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[Export ("sendData:toPeers:withDataMode:error:")]
 #if XAMCORE_2_0
 		bool SendData (NSData data, string [] peers, GKSendDataMode mode, out NSError error);
@@ -265,8 +267,8 @@ namespace XamCore.GameKit {
 		bool SendData (NSData data, string [] peers, GKSendDataMode mode, IntPtr ns_error_out);
 #endif
 
-		[Availability (Deprecated = Platform.iOS_7_0)]
-		[Availability (Deprecated = Platform.Mac_10_10)]
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[Export ("sendDataToAllPeers:withDataMode:error:")]
 #if XAMCORE_2_0
 		bool SendDataToAllPeers (NSData data, GKSendDataMode mode, out NSError error);
@@ -300,8 +302,8 @@ namespace XamCore.GameKit {
 		[Export ("disconnectFromAllPeers")]
 		void DisconnectFromAllPeers ();
 
-		[Availability (Deprecated = Platform.iOS_7_0)]
-		[Availability (Deprecated = Platform.Mac_10_10)]
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[Export ("peersWithConnectionState:")]
 		string [] PeersWithConnectionState (GKPeerConnectionState state);
 	}
@@ -322,8 +324,8 @@ namespace XamCore.GameKit {
 
 		[NoWatch] // deprecated in 2.0 (but framework not added before 3.0)
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'Identifier' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'Identifier' instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'Identifier' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'Identifier' instead.")]
 		[NullAllowed] // by default this property is null
 		[Export ("category", ArgumentSemantic.Copy)]
 		string Category { get; set;  }
@@ -341,8 +343,8 @@ namespace XamCore.GameKit {
 		GKScore LocalPlayerScore { get;  }
 
 		[NoWatch] // deprecated in 2.0 (but framework not added before 3.0)
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'ctor (GKPlayer [] players)' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'ctor (GKPlayer [] players)' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'ctor (GKPlayer [] players)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'ctor (GKPlayer [] players)' instead.")]
 		[Export ("initWithPlayerIDs:")]
 		IntPtr Constructor ([NullAllowed] string [] players);
 
@@ -352,8 +354,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch] // deprecated in 2.0 (but framework not added before 3.0)
-		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'LoadLeaderboards' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use 'LoadLeaderboards' instead.")]
+		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'LoadLeaderboards' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use 'LoadLeaderboards' instead.")]
 		[Static]
 		[Export ("loadCategoriesWithCompletionHandler:")]
 		[Async (ResultTypeName = "GKCategoryResult")]
@@ -363,8 +365,8 @@ namespace XamCore.GameKit {
 		[NoWatch] // deprecated in 2.0 (but framework not added before 3.0)
 		[Static]
 		[Since (5,0)]
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'SetDefaultLeaderboard' on 'GKLocalPlayer' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'SetDefaultLeaderboard' on 'GKLocalPlayer' instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'SetDefaultLeaderboard' on 'GKLocalPlayer' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'SetDefaultLeaderboard' on 'GKLocalPlayer' instead.")]
 		[Export ("setDefaultLeaderboard:withCompletionHandler:")]
 		[Async]
 #if XAMCORE_2_0
@@ -474,8 +476,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'GKLocalPlayer.LoadFriendPlayers' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'GKLocalPlayer.LoadFriendPlayers' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'GKLocalPlayer.LoadFriendPlayers' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKLocalPlayer.LoadFriendPlayers' instead.")]
 		[Export ("isFriend")]
 		bool IsFriend { get;  }
 		
@@ -499,15 +501,15 @@ namespace XamCore.GameKit {
 		string DisplayName { get; }
 
 		[NoWatch]
-		[Availability (Introduced = Platform.iOS_9_0)]
-		[Availability (Introduced = Platform.Mac_10_11)]
+		[Introduced (PlatformName.iOS, 9, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 11)]
 		[Static]
 		[Export ("anonymousGuestPlayerWithIdentifier:")]
 		GKPlayer GetAnonymousGuestPlayer (string guestIdentifier);
 
 		[NoWatch]
-		[Availability (Introduced = Platform.iOS_9_0)]
-		[Availability (Introduced = Platform.Mac_10_11)]
+		[Introduced (PlatformName.iOS, 9, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 11)]
 		[Export ("guestIdentifier")]
 		string GuestIdentifier { get; }
 	}
@@ -517,8 +519,8 @@ namespace XamCore.GameKit {
 	[BaseType (typeof (NSObject))]
 	interface GKScore : NSSecureCoding {
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'InitWithLeaderboardIdentifier' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'InitWithLeaderboardIdentifier' instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'InitWithLeaderboardIdentifier' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'InitWithLeaderboardIdentifier' instead.")]
 		[Internal][NullAllowed]
 		[Export ("initWithCategory:")]
 		IntPtr InitWithCategory ([NullAllowed] string category);
@@ -539,8 +541,8 @@ namespace XamCore.GameKit {
 
 #if !XAMCORE_2_0
 		[NoWatch]
-		// [Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'Player' instead.")] - Unlike rest of deprecations we are just ripping out due to poor naming
-		// [Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'Player' instead.")] - Unlike rest of deprecations we are just ripping out due to poor naming
+		// [Deprecated (PlatformName.iOS, 8, 0, message : "Use 'Player' instead.")] - Unlike rest of deprecations we are just ripping out due to poor naming
+		// [Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'Player' instead.")] - Unlike rest of deprecations we are just ripping out due to poor naming
 		[Export ("playerID", ArgumentSemantic.Retain)]
 		string Player { get;  }
 
@@ -569,8 +571,10 @@ namespace XamCore.GameKit {
 
 		[NoWatch]
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_4_1, Deprecated = Platform.iOS_7_0, Message = "Use 'LeaderboardIdentifier' instead.")]
-		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'LeaderboardIdentifier' instead.")]
+		[Introduced (PlatformName.iOS, 4, 1)]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'LeaderboardIdentifier' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'LeaderboardIdentifier' instead.")]
 		[NullAllowed] // by default this property is null
 		[Export ("category", ArgumentSemantic.Copy)]
 #if XAMCORE_2_0
@@ -582,8 +586,10 @@ namespace XamCore.GameKit {
 
 		[NoWatch]
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_4_1, Deprecated = Platform.iOS_7_0, Message = "Use 'ReportScores' instead.")]
-		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'ReportScores' instead.")]
+		[Introduced (PlatformName.iOS, 4, 1)]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'ReportScores' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'ReportScores' instead.")]
 		[Export ("reportScoreWithCompletionHandler:")]
 		[Async]
 #if XAMCORE_2_0
@@ -602,8 +608,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Pass 'GKPlayers' to 'ChallengeComposeController (GKPlayer [] players, string message, ... )' and present the view controller instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Pass 'GKPlayers' to 'ChallengeComposeController (GKPlayer [] players, string message, ... )' and present the view controller instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Pass 'GKPlayers' to 'ChallengeComposeController (GKPlayer [] players, string message, ... )' and present the view controller instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Pass 'GKPlayers' to 'ChallengeComposeController (GKPlayer [] players, string message, ... )' and present the view controller instead.")]
 		[iOS (6,0), Mac (10,8)]
 		[Export ("issueChallengeToPlayers:message:")]
 		void IssueChallengeToPlayers ([NullAllowed] string[] playerIDs, [NullAllowed] string message);
@@ -649,8 +655,8 @@ namespace XamCore.GameKit {
 	[NoWatch]
 	[NoTV]
 	[Since (4,2)]
-	[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'GKGameCenterViewController' instead.")]
-	[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'GKGameCenterViewController' instead.")]
+	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'GKGameCenterViewController' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKGameCenterViewController' instead.")]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -664,8 +670,10 @@ namespace XamCore.GameKit {
 	}
 
 	[NoTV][NoWatch]
-	[Availability (Introduced = Platform.iOS_4_2, Deprecated = Platform.iOS_7_0, Message = "Use 'GKGameCenterViewController' instead.")]
-	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'GKGameCenterViewController' instead.")]
+	[Introduced (PlatformName.iOS, 4, 2)]
+	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'GKGameCenterViewController' instead.")]
+	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKGameCenterViewController' instead.")]
 #if MONOMAC
 	[BaseType (typeof (GKGameCenterViewController), Events=new Type [] { typeof (GKLeaderboardViewControllerDelegate)}, Delegates=new string [] {"WeakDelegate"})]
 	interface GKLeaderboardViewController 
@@ -706,8 +714,8 @@ namespace XamCore.GameKit {
 
 		[NoWatch]
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'LoadFriendPlayers' instead and collect the friends from the invoked callback.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'LoadFriendPlayers' instead and collect the friends from the invoked callback.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'LoadFriendPlayers' instead and collect the friends from the invoked callback.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'LoadFriendPlayers' instead and collect the friends from the invoked callback.")]
 		[Export ("friends", ArgumentSemantic.Retain)]
 		string [] Friends { get;  }
 
@@ -719,8 +727,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_6_0, Message = "Set the 'AuthenticationHandler' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_8, Message = "Set the 'AuthenticationHandler' instead.")]
+		[Deprecated (PlatformName.iOS, 6, 0, message : "Set the 'AuthenticationHandler' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Set the 'AuthenticationHandler' instead.")]
 		[Export ("authenticateWithCompletionHandler:")]
 		[Async]
 #if XAMCORE_2_0
@@ -736,8 +744,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'LoadRecentPlayers' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'LoadRecentPlayers' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'LoadRecentPlayers' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'LoadRecentPlayers' instead.")]
 		[Export ("loadFriendsWithCompletionHandler:")]
 		[Async]
 		void LoadFriends ([NullAllowed] GKFriendsHandler handler);
@@ -771,8 +779,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'LoadDefaultLeaderboardIdentifier' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'LoadDefaultLeaderboardIdentifier' instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'LoadDefaultLeaderboardIdentifier' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'LoadDefaultLeaderboardIdentifier' instead.")]
 		[Since (6,0)]
 		[Export ("loadDefaultLeaderboardCategoryIDWithCompletionHandler:")]
 		[Async]
@@ -780,8 +788,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'SetDefaultLeaderboardIdentifier' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'SetDefaultLeaderboardIdentifier' instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'SetDefaultLeaderboardIdentifier' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'SetDefaultLeaderboardIdentifier' instead.")]
 		[iOS (6,0), Mac (10,8)]
 		[Export ("setDefaultLeaderboardCategoryID:completionHandler:")]
 		[Async]
@@ -878,8 +886,8 @@ namespace XamCore.GameKit {
 	[DisableDefaultCtor]
 	interface GKMatch {
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'Players' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'Players' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'Players' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'Players' instead.")]
 		[Export ("playerIDs")]
 		string [] PlayersIDs { get;  }
 
@@ -894,8 +902,8 @@ namespace XamCore.GameKit {
 		nint ExpectedPlayerCount { get;  }
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'SendDataToAllPlayers (NSData, GKPlayer[] players, GKMatchSendDataMode mode, NSError error)' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'SendDataToAllPlayers (NSData, GKPlayer[] players, GKMatchSendDataMode mode, NSError error)' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'SendDataToAllPlayers (NSData, GKPlayer[] players, GKMatchSendDataMode mode, NSError error)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'SendDataToAllPlayers (NSData, GKPlayer[] players, GKMatchSendDataMode mode, NSError error)' instead.")]
 		[Export ("sendData:toPlayers:withDataMode:error:")]
 		// OOPS: bug we shipped with and can not realistically fix, but good news: this is deprecated (the NSError should have been an out)
 		bool SendData (NSData data, string [] players, GKMatchSendDataMode mode, out NSError error);
@@ -910,8 +918,8 @@ namespace XamCore.GameKit {
 		GKVoiceChat VoiceChatWithName (string name);
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'ChooseBestHostingPlayer' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'ChooseBestHostingPlayer' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'ChooseBestHostingPlayer' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'ChooseBestHostingPlayer' instead.")]
 		[iOS (6,0), Mac (10,9)]
 		[Export ("chooseBestHostPlayerWithCompletionHandler:")]
 		[Async]
@@ -944,14 +952,14 @@ namespace XamCore.GameKit {
 	interface GKMatchDelegate {
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'DataReceivedFromPlayer (GKMatch,NSData,GKPlayer)' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'DataReceivedFromPlayer (GKMatch,NSData,GKPlayer)' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'DataReceivedFromPlayer (GKMatch,NSData,GKPlayer)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'DataReceivedFromPlayer (GKMatch,NSData,GKPlayer)' instead.")]
 		[Export ("match:didReceiveData:fromPlayer:"), EventArgs ("GKData")]
 		void DataReceived (GKMatch match, NSData data, string playerId);
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'StateChangedForPlayer (GKMatch,GKPlayer,GKPlayerConnectionState)' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'StateChangedForPlayer (GKMatch,GKPlayer,GKPlayerConnectionState)' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'StateChangedForPlayer (GKMatch,GKPlayer,GKPlayerConnectionState)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'StateChangedForPlayer (GKMatch,GKPlayer,GKPlayerConnectionState)' instead.")]
 		[Export ("match:player:didChangeState:"), EventArgs ("GKState")]
 		void StateChanged (GKMatch match, string playerId, GKPlayerConnectionState state);
 
@@ -977,8 +985,8 @@ namespace XamCore.GameKit {
 		void Failed (GKMatch match, [NullAllowed] NSError error);
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'ShouldReinviteDisconnectedPlayer' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'ShouldReinviteDisconnectedPlayer' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'ShouldReinviteDisconnectedPlayer' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'ShouldReinviteDisconnectedPlayer' instead.")]
 		[Since (5,0)]
 		[Export ("match:shouldReinvitePlayer:"), DelegateName ("GKMatchReinvitation"), DefaultValue (true)]
 		bool ShouldReinvitePlayer (GKMatch match, string playerId);
@@ -996,8 +1004,8 @@ namespace XamCore.GameKit {
 		[DelegateName ("GKMatchReinvitationForDisconnectedPlayer"), DefaultValue (true)]
 		bool ShouldReinviteDisconnectedPlayer (GKMatch match, GKPlayer player);
 
-		[Availability (Introduced = Platform.iOS_9_0)]
-		[Availability (Introduced = Platform.Mac_10_11)]
+		[Introduced (PlatformName.iOS, 9, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 11)]
 		[Export ("match:didReceiveData:forRecipient:fromRemotePlayer:"), EventArgs ("GKDataReceivedForRecipient")]
 		void DataReceivedForRecipient (GKMatch match, NSData data, GKPlayer recipient, GKPlayer player);
 	}
@@ -1023,8 +1031,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		// the API was removed in iOS8
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'SetMuteStatus' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'SetMuteStatus' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'SetMuteStatus' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'SetMuteStatus' instead.")]
 		[Export ("setMute:forPlayer:")]
 		void SetMute (bool isMuted, string playerID);
 
@@ -1033,8 +1041,8 @@ namespace XamCore.GameKit {
 		bool IsVoIPAllowed ();
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'SetPlayerVoiceChatStateChangeHandler' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'SetPlayerVoiceChatStateChangeHandler' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'SetPlayerVoiceChatStateChangeHandler' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'SetPlayerVoiceChatStateChangeHandler' instead.")]
 		[NullAllowed] // by default this property is null
 		[Export ("playerStateUpdateHandler", ArgumentSemantic.Copy)]
 		GKPlayerStateUpdateHandler PlayerStateUpdateHandler { get; set; }
@@ -1046,8 +1054,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[Since (5,0)]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'Players' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'Players' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'Players' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'Players' instead.")]
 		[Export ("playerIDs")]
 		string [] PlayerIDs { get; }
 
@@ -1092,8 +1100,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'RecipientResponseHandler' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'RecipientResponseHandler' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'RecipientResponseHandler' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'RecipientResponseHandler' instead.")]
 		[Since (6,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("inviteeResponseHandler", ArgumentSemantic.Copy)]
@@ -1118,8 +1126,8 @@ namespace XamCore.GameKit {
 	interface GKInvite {
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'Sender' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'Sender' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'Sender' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'Sender' instead.")]
 		[Export ("inviter", ArgumentSemantic.Retain)]
 		string Inviter { get;  }
 
@@ -1155,8 +1163,8 @@ namespace XamCore.GameKit {
 		void FindMatch (GKMatchRequest request, [NullAllowed] GKNotificationMatch matchHandler);
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'FindPlayersForHostedRequest' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'FindPlayersForHostedRequest' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'FindPlayersForHostedRequest' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'FindPlayersForHostedRequest' instead.")]
 		[Export ("findPlayersForHostedMatchRequest:withCompletionHandler:")]
 		[Async]
 		void FindPlayers (GKMatchRequest request, [NullAllowed] GKFriendsHandler playerHandler);
@@ -1188,8 +1196,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[Since (6,0)][Mac (10, 9)]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'CancelPendingInvite' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'CancelPendingInvite' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'CancelPendingInvite' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'CancelPendingInvite' instead.")]
 		[Export ("cancelInviteToPlayer:")]
 		void CancelInvite (string playerID);
 
@@ -1199,8 +1207,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[Since (6,0)][Mac (10,9)]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'StartBrowsingForNearbyPlayers(Action<GKPlayer, bool> handler)' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'StartBrowsingForNearbyPlayers(Action<GKPlayer, bool> handler)' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'StartBrowsingForNearbyPlayers(Action<GKPlayer, bool> handler)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'StartBrowsingForNearbyPlayers(Action<GKPlayer, bool> handler)' instead.")]
 		[Export ("startBrowsingForNearbyPlayersWithReachableHandler:")]
 		void StartBrowsingForNearbyPlayers ([NullAllowed] Action<string, bool> reachableHandler);
 
@@ -1261,8 +1269,10 @@ namespace XamCore.GameKit {
 #endif
 
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0)]
-		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10)]
+		[Introduced (PlatformName.iOS, 5, 0)]
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[Export ("defaultInvitationMessage", ArgumentSemantic.Copy)]
 		string DefaultInvitationMessage { get; set;  }
 
@@ -1272,8 +1282,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[Since (5,0)]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'SetHostedPlayerConnected (GKPlayer,bool)' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'SetHostedPlayerConnected (GKPlayer,bool)' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'SetHostedPlayerConnected (GKPlayer,bool)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'SetHostedPlayerConnected (GKPlayer,bool)' instead.")]
 		[Export ("setHostedPlayer:connected:")]
 		void SetHostedPlayerConnected (string playerID, bool connected);
 
@@ -1306,8 +1316,8 @@ namespace XamCore.GameKit {
 		[Abstract]
 #endif
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'DidFindHostedPlayers' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'DidFindHostedPlayers' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'DidFindHostedPlayers' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'DidFindHostedPlayers' instead.")]
 		[Export ("matchmakerViewController:didFindPlayers:"), EventArgs ("GKPlayers")]
 		void DidFindPlayers (GKMatchmakerViewController viewController, string [] playerIDs);
 
@@ -1320,8 +1330,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[Since (5,0)]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'HostedPlayerDidAccept' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'HostedPlayerDidAccept' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'HostedPlayerDidAccept' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'HostedPlayerDidAccept' instead.")]
 		[Export ("matchmakerViewController:didReceiveAcceptFromHostedPlayer:"), EventArgs ("GKPlayer")]
 		void ReceivedAcceptFromHostedPlayer (GKMatchmakerViewController viewController, string playerID);
 
@@ -1335,8 +1345,8 @@ namespace XamCore.GameKit {
 	[Watch (3,0)]
 	interface GKAchievement : NSSecureCoding {
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'IsHidden' on the 'GKAchievementDescription' class instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'IsHidden' on the 'GKAchievementDescription' class instead.")]
+		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'IsHidden' on the 'GKAchievementDescription' class instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'IsHidden' on the 'GKAchievementDescription' class instead.")]
 		[Export ("hidden", ArgumentSemantic.Assign)]
 		bool Hidden { [Bind ("isHidden")] get; }
 
@@ -1382,12 +1392,12 @@ namespace XamCore.GameKit {
 #if XAMCORE_2_0
 		[NoWatch]
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use ReportAchievements '(GKAchievement[] achievements, Action<NSError> completionHandler)' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use ReportAchievements '(GKAchievement[] achievements, Action<NSError> completionHandler)' instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use ReportAchievements '(GKAchievement[] achievements, Action<NSError> completionHandler)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use ReportAchievements '(GKAchievement[] achievements, Action<NSError> completionHandler)' instead.")]
 		void ReportAchievement ([NullAllowed] Action<NSError> completionHandler);
 #else
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use ReportAchievements '(GKAchievement[] achievements, GKNotificationHandler completionHandler)' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use ReportAchievements '(GKAchievement[] achievements, GKNotificationHandler completionHandler)' instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use ReportAchievements '(GKAchievement[] achievements, GKNotificationHandler completionHandler)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use ReportAchievements '(GKAchievement[] achievements, GKNotificationHandler completionHandler)' instead.")]
 		void ReportAchievement ([NullAllowed] GKNotificationHandler completionHandler);
 #endif
 
@@ -1407,8 +1417,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Pass 'GKPlayers' to 'ChallengeComposeController(GKPlayer[] players, string message, ...)' and present the view controller instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Pass 'GKPlayers' to 'ChallengeComposeController(GKPlayer[] players, string message, ...)' and present the view controller instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Pass 'GKPlayers' to 'ChallengeComposeController(GKPlayer[] players, string message, ...)' and present the view controller instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Pass 'GKPlayers' to 'ChallengeComposeController(GKPlayer[] players, string message, ...)' and present the view controller instead.")]
 		[iOS (6,0), Mac (10,8)]
 		[Export ("issueChallengeToPlayers:message:")]
 		void IssueChallengeToPlayers ([NullAllowed] string[] playerIDs, [NullAllowed] string message);
@@ -1416,8 +1426,8 @@ namespace XamCore.GameKit {
 		[NoTV]
 		[NoWatch]
 		[iOS (6,0), Mac (10,8)]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Pass 'GKPlayers' to 'SelectChallengeablePlayers' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Pass 'GKPlayers' to 'SelectChallengeablePlayers' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Pass 'GKPlayers' to 'SelectChallengeablePlayers' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Pass 'GKPlayers' to 'SelectChallengeablePlayers' instead.")]
 		[Export ("selectChallengeablePlayerIDs:withCompletionHandler:")]
 		[Async]
 		void SelectChallengeablePlayerIDs ([NullAllowed] string[] playerIDs, [NullAllowed] Action<string[], NSError> completionHandler);
@@ -1526,8 +1536,8 @@ namespace XamCore.GameKit {
 		NSImage PlaceholderCompletedAchievementImage { get; }
 
 #else
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'LoadImage' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_8, Message = "Use 'LoadImage' instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'LoadImage' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Use 'LoadImage' instead.")]
 		[Export ("image")]
 		UIImage Image { get; }
 
@@ -1553,8 +1563,10 @@ namespace XamCore.GameKit {
 
 	[NoWatch]
 	[NoTV]
-	[Availability (Introduced = Platform.iOS_4_1, Deprecated = Platform.iOS_7_0, Message = "Use 'GKGameCenterViewController' instead.")]
-	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'GKGameCenterViewController' instead.")]
+	[Introduced (PlatformName.iOS, 4, 1)]
+	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'GKGameCenterViewController' instead.")]
+	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKGameCenterViewController' instead.")]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -1568,8 +1580,10 @@ namespace XamCore.GameKit {
 	}
 
 	[NoTV][NoWatch]
-	[Availability (Introduced = Platform.iOS_4_1, Deprecated = Platform.iOS_7_0, Message = "Use 'GKGameCenterViewController' instead.")]
-	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'GKGameCenterViewController' instead.")]
+	[Introduced (PlatformName.iOS, 4, 1)]
+	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'GKGameCenterViewController' instead.")]
+	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKGameCenterViewController' instead.")]
 #if MONOMAC
 	[BaseType (typeof (GKGameCenterViewController), Events=new Type [] { typeof (GKAchievementViewControllerDelegate)}, Delegates=new string [] {"WeakDelegate"})]
 	interface GKAchievementViewController 
@@ -1631,8 +1645,8 @@ namespace XamCore.GameKit {
 		[Export ("maxNumberOfRecipients")][Static]
 		nint MaxNumberOfRecipients { get; }
 		
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'AddRecipientPlayers' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'AddRecipientPlayers' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'AddRecipientPlayers' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'AddRecipientPlayers' instead.")]
 		[Export ("addRecipientsWithEmailAddresses:")]
 		void AddRecipientsFromEmails (string [] emailAddresses);
 
@@ -1688,8 +1702,8 @@ namespace XamCore.GameKit {
 		GKPlayer Player { get; }
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'Player' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'Player' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'Player' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'Player' instead.")]
 		[Export ("playerID", ArgumentSemantic.Copy)]
 		string PlayerID { get;  }
 
@@ -1711,8 +1725,10 @@ namespace XamCore.GameKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0, Message = "Use 'GKLocalPlayer.RegisterListener' with an object that implements 'IGKTurnBasedEventListener'.")]
-	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'GKLocalPlayer.RegisterListener' with an object that implements 'IGKTurnBasedEventListener'.")]
+	[Introduced (PlatformName.iOS, 5, 0)]
+	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'GKLocalPlayer.RegisterListener' with an object that implements 'IGKTurnBasedEventListener'.")]
+	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKLocalPlayer.RegisterListener' with an object that implements 'IGKTurnBasedEventListener'.")]
 	[Watch (3,0)]
 	interface GKTurnBasedEventHandlerDelegate {
 #if !XAMCORE_2_0
@@ -1725,17 +1741,23 @@ namespace XamCore.GameKit {
 		[Abstract]
 #endif
 		[Export ("handleInviteFromGameCenter:")]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0)]
-		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10)]
+		[Introduced (PlatformName.iOS, 5, 0)]
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		void HandleInviteFromGameCenter (NSString [] playersToInvite);
 
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0, Message = "Use 'HandleTurnEvent' instead.")]
-		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_9, Message = "Use 'HandleTurnEvent' instead.")]
+		[Introduced (PlatformName.iOS, 5, 0)]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'HandleTurnEvent' instead.")]
+		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use 'HandleTurnEvent' instead.")]
 		[Export ("handleTurnEventForMatch:")]
 		void HandleTurnEventForMatch (GKTurnBasedMatch match);
 
-		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_7_0)]
-		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10)]
+		[Introduced (PlatformName.iOS, 6, 0)]
+		[Deprecated (PlatformName.iOS, 7, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[Export ("handleMatchEnded:")]
 		void HandleMatchEnded (GKTurnBasedMatch match);
 
@@ -1744,14 +1766,18 @@ namespace XamCore.GameKit {
 #endif
 		[Since (6,0)]
 		[Export ("handleTurnEventForMatch:didBecomeActive:")]
-		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_6_0)]
-		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10)]
+		[Introduced (PlatformName.iOS, 6, 0)]
+		[Deprecated (PlatformName.iOS, 6, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		void HandleTurnEvent (GKTurnBasedMatch match, bool activated);
 	}
 
 	[NoTV]
-	[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0, Message = "Use GKLocalPlayer.RegisterListener with an object that implements IGKTurnBasedEventListener.")]
-	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use GKLocalPlayer.RegisterListener with an object that implements IGKTurnBasedEventListener.")]
+	[Introduced (PlatformName.iOS, 5, 0)]
+	[Deprecated (PlatformName.iOS, 7, 0, message : "Use GKLocalPlayer.RegisterListener with an object that implements IGKTurnBasedEventListener.")]
+	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use GKLocalPlayer.RegisterListener with an object that implements IGKTurnBasedEventListener.")]
 	[BaseType (typeof (NSObject))]
 	[Watch (3,0)]
 	interface GKTurnBasedEventHandler {
@@ -1825,8 +1851,8 @@ namespace XamCore.GameKit {
 		void LoadMatchData ([NullAllowed] GKTurnBasedMatchData onCompletion);
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'EndTurn' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use 'EndTurn' instead.")]
+		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'EndTurn' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use 'EndTurn' instead.")]
 		[Export ("endTurnWithNextParticipant:matchData:completionHandler:")]
 		[Async]
 #if XAMCORE_2_0
@@ -1836,8 +1862,8 @@ namespace XamCore.GameKit {
 #endif
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'ParticipantQuitInTurn (GKTurnBasedMatchOutcome, GKTurnBasedParticipant[], double, NSData, Action<NSError>)' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use 'ParticipantQuitInTurn (GKTurnBasedMatchOutcome, GKTurnBasedParticipant[], double, NSData, Action<NSError>)' instead.")]
+		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'ParticipantQuitInTurn (GKTurnBasedMatchOutcome, GKTurnBasedParticipant[], double, NSData, Action<NSError>)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use 'ParticipantQuitInTurn (GKTurnBasedMatchOutcome, GKTurnBasedParticipant[], double, NSData, Action<NSError>)' instead.")]
 		[Export ("participantQuitInTurnWithOutcome:nextParticipant:matchData:completionHandler:")]
 		[Async]
 #if XAMCORE_2_0
@@ -2000,8 +2026,8 @@ namespace XamCore.GameKit {
 		[Abstract]
 #endif
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'GKTurnBasedEventListener.ReceivedTurnEvent' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_11, Message = "Use 'GKTurnBasedEventListener.ReceivedTurnEvent' instead.")]
+		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'GKTurnBasedEventListener.ReceivedTurnEvent' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'GKTurnBasedEventListener.ReceivedTurnEvent' instead.")]
 		[Export ("turnBasedMatchmakerViewController:didFindMatch:")]
 		void FoundMatch (GKTurnBasedMatchmakerViewController viewController, GKTurnBasedMatch match);
 
@@ -2009,8 +2035,8 @@ namespace XamCore.GameKit {
 		[Abstract]
 #endif
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'GKTurnBasedEventListener.WantsToQuitMatch' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_11, Message = "Use 'GKTurnBasedEventListener.WantsToQuitMatch' instead.")]
+		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'GKTurnBasedEventListener.WantsToQuitMatch' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'GKTurnBasedEventListener.WantsToQuitMatch' instead.")]
 		[Export ("turnBasedMatchmakerViewController:playerQuitForMatch:")]
 		void PlayerQuitForMatch (GKTurnBasedMatchmakerViewController viewController, GKTurnBasedMatch match);
 	}
@@ -2020,14 +2046,14 @@ namespace XamCore.GameKit {
 	[BaseType (typeof (NSObject))]
 	interface GKChallenge : NSSecureCoding {
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'IssuingPlayer' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'IssuingPlayer' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'IssuingPlayer' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'IssuingPlayer' instead.")]
 		[Export ("issuingPlayerID", ArgumentSemantic.Copy)]
 		string IssuingPlayerID { get; }
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'ReceivingPlayer' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'ReceivingPlayer' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'ReceivingPlayer' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'ReceivingPlayer' instead.")]
 		[Export ("receivingPlayerID", ArgumentSemantic.Copy)]
 		string ReceivingPlayerID { get; }
 
@@ -2103,15 +2129,15 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[Export ("leaderboardTimeScope", ArgumentSemantic.Assign)]
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "This class no longer support 'LeaderboardTimeScope', will always default to 'AllTime'.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "This class no longer support 'LeaderboardTimeScope', will always default to 'AllTime'.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "This class no longer support 'LeaderboardTimeScope', will always default to 'AllTime'.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "This class no longer support 'LeaderboardTimeScope', will always default to 'AllTime'.")]
 		GKLeaderboardTimeScope LeaderboardTimeScope { get; set; }
 
 		[NoTV]
 		[NullAllowed] // by default this property is null
 		[Export ("leaderboardCategory", ArgumentSemantic.Retain)]
-		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'LeaderboardIdentifier' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'LeaderboardIdentifier' instead.")]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'LeaderboardIdentifier' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'LeaderboardIdentifier' instead.")]
 		string LeaderboardCategory { get; set; }
 
 		[NoTV]
@@ -2138,8 +2164,10 @@ namespace XamCore.GameKit {
 #if !MONOMAC
 	[NoWatch]
 	[NoTV]
-	[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_7_0, Message = "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
-	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
+	[Introduced (PlatformName.iOS, 6, 0)]
+	[Deprecated (PlatformName.iOS, 7, 0, message : "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
+	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
 	[BaseType (typeof (NSObject), Events=new[] { typeof (GKChallengeEventHandlerDelegate) }, Delegates=new[] { "WeakDelegate"})]
 	[DisableDefaultCtor]
 	[NoTV]
@@ -2158,8 +2186,10 @@ namespace XamCore.GameKit {
 
 	[NoWatch]
 	[NoTV]
-	[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_7_0, Message = "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
-	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
+	[Introduced (PlatformName.iOS, 6, 0)]
+	[Deprecated (PlatformName.iOS, 7, 0, message : "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
+	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
 	[Model]
 	[BaseType (typeof (NSObject))]
 	[Protocol]
@@ -2343,8 +2373,8 @@ namespace XamCore.GameKit {
 		[Export ("player:didRequestMatchWithOtherPlayers:")]
 		void DidRequestMatchWithOtherPlayers (GKPlayer player, GKPlayer [] playersToInvite);
 
-		[Availability (Introduced = Platform.iOS_9_0)]
-		[Availability (Introduced = Platform.Mac_10_11)]
+		[Introduced (PlatformName.iOS, 9, 0)]
+		[Introduced (PlatformName.MacOSX, 10, 11)]
 		[Export ("player:wantsToQuitMatch:")]
 		void WantsToQuitMatch (GKPlayer player, GKTurnBasedMatch match);
 	}

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -698,7 +698,7 @@ namespace XamCore.GameKit {
 
 	[Watch (3,0)]
 	[Since (4,2)]
-	[MountainLion]
+	[Mac (10, 8)]
 	[BaseType (typeof (GKPlayer))]
 	interface GKLocalPlayer {
 		[Export ("authenticated")]
@@ -1331,7 +1331,7 @@ namespace XamCore.GameKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[Since (4,2)][MountainLion]
+	[Since (4,2)][Mac (10, 8)]
 	[Watch (3,0)]
 	interface GKAchievement : NSSecureCoding {
 		[NoTV]
@@ -1482,7 +1482,7 @@ namespace XamCore.GameKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[Since (4,2)][MountainLion]
+	[Since (4,2)][Mac (10, 8)]
 	[Watch (3,0)]
 	interface GKAchievementDescription : NSSecureCoding {
 		[Export ("identifier", ArgumentSemantic.Copy)]
@@ -2016,7 +2016,7 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[Since (6,0)][Mavericks]
+	[Since (6,0)][Mac (10, 9)]
 	[BaseType (typeof (NSObject))]
 	interface GKChallenge : NSSecureCoding {
 		[NoTV]
@@ -2060,7 +2060,7 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[Since (6,0)][Mavericks]
+	[Since (6,0)][Mac (10, 9)]
 	[BaseType (typeof (GKChallenge))]
 	interface GKScoreChallenge {
 
@@ -2069,7 +2069,7 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[Since (6,0)][Mavericks]
+	[Since (6,0)][Mac (10, 9)]
 	[BaseType (typeof (GKChallenge))]
 	interface GKAchievementChallenge {
 

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -218,9 +218,9 @@ namespace XamCore.GameKit {
 	[NoTV]
 	[NoWatch] // deprecated in 2.0 (but framework not added before 3.0)
 	[BaseType (typeof (NSObject))]
-	[Introduced (PlatformName.iOS, 3, 0)]
+	[iOS (3, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'MultipeerConnectivity.MCSession' instead.")]
-	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'MultipeerConnectivity.MCSession' instead.")]
 	interface GKSession {
 		[Export ("initWithSessionID:displayName:sessionMode:")]
@@ -501,15 +501,15 @@ namespace XamCore.GameKit {
 		string DisplayName { get; }
 
 		[NoWatch]
-		[Introduced (PlatformName.iOS, 9, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 11)]
+		[iOS (9, 0)]
+		[Mac (10, 11)]
 		[Static]
 		[Export ("anonymousGuestPlayerWithIdentifier:")]
 		GKPlayer GetAnonymousGuestPlayer (string guestIdentifier);
 
 		[NoWatch]
-		[Introduced (PlatformName.iOS, 9, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 11)]
+		[iOS (9, 0)]
+		[Mac (10, 11)]
 		[Export ("guestIdentifier")]
 		string GuestIdentifier { get; }
 	}
@@ -571,9 +571,9 @@ namespace XamCore.GameKit {
 
 		[NoWatch]
 		[NoTV]
-		[Introduced (PlatformName.iOS, 4, 1)]
+		[iOS (4, 1)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'LeaderboardIdentifier' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'LeaderboardIdentifier' instead.")]
 		[NullAllowed] // by default this property is null
 		[Export ("category", ArgumentSemantic.Copy)]
@@ -586,9 +586,9 @@ namespace XamCore.GameKit {
 
 		[NoWatch]
 		[NoTV]
-		[Introduced (PlatformName.iOS, 4, 1)]
+		[iOS (4, 1)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'ReportScores' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'ReportScores' instead.")]
 		[Export ("reportScoreWithCompletionHandler:")]
 		[Async]
@@ -670,9 +670,9 @@ namespace XamCore.GameKit {
 	}
 
 	[NoTV][NoWatch]
-	[Introduced (PlatformName.iOS, 4, 2)]
+	[iOS (4, 2)]
 	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'GKGameCenterViewController' instead.")]
-	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKGameCenterViewController' instead.")]
 #if MONOMAC
 	[BaseType (typeof (GKGameCenterViewController), Events=new Type [] { typeof (GKLeaderboardViewControllerDelegate)}, Delegates=new string [] {"WeakDelegate"})]
@@ -1004,8 +1004,8 @@ namespace XamCore.GameKit {
 		[DelegateName ("GKMatchReinvitationForDisconnectedPlayer"), DefaultValue (true)]
 		bool ShouldReinviteDisconnectedPlayer (GKMatch match, GKPlayer player);
 
-		[Introduced (PlatformName.iOS, 9, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 11)]
+		[iOS (9, 0)]
+		[Mac (10, 11)]
 		[Export ("match:didReceiveData:forRecipient:fromRemotePlayer:"), EventArgs ("GKDataReceivedForRecipient")]
 		void DataReceivedForRecipient (GKMatch match, NSData data, GKPlayer recipient, GKPlayer player);
 	}
@@ -1269,9 +1269,9 @@ namespace XamCore.GameKit {
 #endif
 
 		[NoTV]
-		[Introduced (PlatformName.iOS, 5, 0)]
+		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[Export ("defaultInvitationMessage", ArgumentSemantic.Copy)]
 		string DefaultInvitationMessage { get; set;  }
@@ -1563,9 +1563,9 @@ namespace XamCore.GameKit {
 
 	[NoWatch]
 	[NoTV]
-	[Introduced (PlatformName.iOS, 4, 1)]
+	[iOS (4, 1)]
 	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'GKGameCenterViewController' instead.")]
-	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKGameCenterViewController' instead.")]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -1580,9 +1580,9 @@ namespace XamCore.GameKit {
 	}
 
 	[NoTV][NoWatch]
-	[Introduced (PlatformName.iOS, 4, 1)]
+	[iOS (4, 1)]
 	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'GKGameCenterViewController' instead.")]
-	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKGameCenterViewController' instead.")]
 #if MONOMAC
 	[BaseType (typeof (GKGameCenterViewController), Events=new Type [] { typeof (GKAchievementViewControllerDelegate)}, Delegates=new string [] {"WeakDelegate"})]
@@ -1725,9 +1725,9 @@ namespace XamCore.GameKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	[Introduced (PlatformName.iOS, 5, 0)]
+	[iOS (5, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'GKLocalPlayer.RegisterListener' with an object that implements 'IGKTurnBasedEventListener'.")]
-	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKLocalPlayer.RegisterListener' with an object that implements 'IGKTurnBasedEventListener'.")]
 	[Watch (3,0)]
 	interface GKTurnBasedEventHandlerDelegate {
@@ -1741,22 +1741,22 @@ namespace XamCore.GameKit {
 		[Abstract]
 #endif
 		[Export ("handleInviteFromGameCenter:")]
-		[Introduced (PlatformName.iOS, 5, 0)]
+		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		void HandleInviteFromGameCenter (NSString [] playersToInvite);
 
-		[Introduced (PlatformName.iOS, 5, 0)]
+		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'HandleTurnEvent' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use 'HandleTurnEvent' instead.")]
 		[Export ("handleTurnEventForMatch:")]
 		void HandleTurnEventForMatch (GKTurnBasedMatch match);
 
-		[Introduced (PlatformName.iOS, 6, 0)]
+		[iOS (6, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[Export ("handleMatchEnded:")]
 		void HandleMatchEnded (GKTurnBasedMatch match);
@@ -1766,17 +1766,17 @@ namespace XamCore.GameKit {
 #endif
 		[Since (6,0)]
 		[Export ("handleTurnEventForMatch:didBecomeActive:")]
-		[Introduced (PlatformName.iOS, 6, 0)]
+		[iOS (6, 0)]
 		[Deprecated (PlatformName.iOS, 6, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 8)]
+		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		void HandleTurnEvent (GKTurnBasedMatch match, bool activated);
 	}
 
 	[NoTV]
-	[Introduced (PlatformName.iOS, 5, 0)]
+	[iOS (5, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0, message : "Use GKLocalPlayer.RegisterListener with an object that implements IGKTurnBasedEventListener.")]
-	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use GKLocalPlayer.RegisterListener with an object that implements IGKTurnBasedEventListener.")]
 	[BaseType (typeof (NSObject))]
 	[Watch (3,0)]
@@ -2164,9 +2164,9 @@ namespace XamCore.GameKit {
 #if !MONOMAC
 	[NoWatch]
 	[NoTV]
-	[Introduced (PlatformName.iOS, 6, 0)]
+	[iOS (6, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0, message : "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
-	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
 	[BaseType (typeof (NSObject), Events=new[] { typeof (GKChallengeEventHandlerDelegate) }, Delegates=new[] { "WeakDelegate"})]
 	[DisableDefaultCtor]
@@ -2186,9 +2186,9 @@ namespace XamCore.GameKit {
 
 	[NoWatch]
 	[NoTV]
-	[Introduced (PlatformName.iOS, 6, 0)]
+	[iOS (6, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0, message : "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
-	[Introduced (PlatformName.MacOSX, 10, 8)]
+	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
 	[Model]
 	[BaseType (typeof (NSObject))]
@@ -2373,8 +2373,8 @@ namespace XamCore.GameKit {
 		[Export ("player:didRequestMatchWithOtherPlayers:")]
 		void DidRequestMatchWithOtherPlayers (GKPlayer player, GKPlayer [] playersToInvite);
 
-		[Introduced (PlatformName.iOS, 9, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 11)]
+		[iOS (9, 0)]
+		[Mac (10, 11)]
 		[Export ("player:wantsToQuitMatch:")]
 		void WantsToQuitMatch (GKPlayer player, GKTurnBasedMatch match);
 	}

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -218,10 +218,12 @@ namespace XamCore.GameKit {
 	[NoTV]
 	[NoWatch] // deprecated in 2.0 (but framework not added before 3.0)
 	[BaseType (typeof (NSObject))]
-	[Availability (Introduced = Platform.iOS_3_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'MultipeerConnectivity.MCSession' instead.")]
+	[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_7_0, Message = "Use 'MultipeerConnectivity.MCSession' instead.")]
+	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'MultipeerConnectivity.MCSession' instead.")]
 	interface GKSession {
 		[Export ("initWithSessionID:displayName:sessionMode:")]
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.iOS_7_0)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		IntPtr Constructor ([NullAllowed] string sessionID, [NullAllowed] string displayName, GKSessionMode mode);
 
 		[Export ("delegate", ArgumentSemantic.Assign)][NullAllowed]
@@ -237,7 +239,8 @@ namespace XamCore.GameKit {
 		[Export ("displayName")]
 		string DisplayName { get; }
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.iOS_7_0)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("sessionMode")]
 		GKSessionMode SessionMode { get; }
 		
@@ -253,7 +256,8 @@ namespace XamCore.GameKit {
 		[Export ("displayNameForPeer:")]
 		string DisplayNameForPeer (string peerID);
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.iOS_7_0)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("sendData:toPeers:withDataMode:error:")]
 #if XAMCORE_2_0
 		bool SendData (NSData data, string [] peers, GKSendDataMode mode, out NSError error);
@@ -261,7 +265,8 @@ namespace XamCore.GameKit {
 		bool SendData (NSData data, string [] peers, GKSendDataMode mode, IntPtr ns_error_out);
 #endif
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.iOS_7_0)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("sendDataToAllPeers:withDataMode:error:")]
 #if XAMCORE_2_0
 		bool SendDataToAllPeers (NSData data, GKSendDataMode mode, out NSError error);
@@ -295,7 +300,8 @@ namespace XamCore.GameKit {
 		[Export ("disconnectFromAllPeers")]
 		void DisconnectFromAllPeers ();
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.iOS_7_0)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("peersWithConnectionState:")]
 		string [] PeersWithConnectionState (GKPeerConnectionState state);
 	}
@@ -316,7 +322,8 @@ namespace XamCore.GameKit {
 
 		[NoWatch] // deprecated in 2.0 (but framework not added before 3.0)
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'Identifier' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'Identifier' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'Identifier' instead.")]
 		[NullAllowed] // by default this property is null
 		[Export ("category", ArgumentSemantic.Copy)]
 		string Category { get; set;  }
@@ -334,7 +341,8 @@ namespace XamCore.GameKit {
 		GKScore LocalPlayerScore { get;  }
 
 		[NoWatch] // deprecated in 2.0 (but framework not added before 3.0)
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'ctor (GKPlayer [] players)' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'ctor (GKPlayer [] players)' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'ctor (GKPlayer [] players)' instead.")]
 		[Export ("initWithPlayerIDs:")]
 		IntPtr Constructor ([NullAllowed] string [] players);
 
@@ -344,7 +352,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch] // deprecated in 2.0 (but framework not added before 3.0)
-		[Availability (Deprecated = Platform.iOS_6_0 | Platform.Mac_10_9, Message = "Use 'LoadLeaderboards' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'LoadLeaderboards' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use 'LoadLeaderboards' instead.")]
 		[Static]
 		[Export ("loadCategoriesWithCompletionHandler:")]
 		[Async (ResultTypeName = "GKCategoryResult")]
@@ -354,7 +363,8 @@ namespace XamCore.GameKit {
 		[NoWatch] // deprecated in 2.0 (but framework not added before 3.0)
 		[Static]
 		[Since (5,0)]
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'SetDefaultLeaderboard' on 'GKLocalPlayer' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'SetDefaultLeaderboard' on 'GKLocalPlayer' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'SetDefaultLeaderboard' on 'GKLocalPlayer' instead.")]
 		[Export ("setDefaultLeaderboard:withCompletionHandler:")]
 		[Async]
 #if XAMCORE_2_0
@@ -464,7 +474,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'GKLocalPlayer.LoadFriendPlayers' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'GKLocalPlayer.LoadFriendPlayers' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'GKLocalPlayer.LoadFriendPlayers' instead.")]
 		[Export ("isFriend")]
 		bool IsFriend { get;  }
 		
@@ -488,13 +499,15 @@ namespace XamCore.GameKit {
 		string DisplayName { get; }
 
 		[NoWatch]
-		[Availability (Introduced = Platform.iOS_9_0 | Platform.Mac_10_11)]
+		[Availability (Introduced = Platform.iOS_9_0)]
+		[Availability (Introduced = Platform.Mac_10_11)]
 		[Static]
 		[Export ("anonymousGuestPlayerWithIdentifier:")]
 		GKPlayer GetAnonymousGuestPlayer (string guestIdentifier);
 
 		[NoWatch]
-		[Availability (Introduced = Platform.iOS_9_0 | Platform.Mac_10_11)]
+		[Availability (Introduced = Platform.iOS_9_0)]
+		[Availability (Introduced = Platform.Mac_10_11)]
 		[Export ("guestIdentifier")]
 		string GuestIdentifier { get; }
 	}
@@ -504,7 +517,8 @@ namespace XamCore.GameKit {
 	[BaseType (typeof (NSObject))]
 	interface GKScore : NSSecureCoding {
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'InitWithLeaderboardIdentifier' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'InitWithLeaderboardIdentifier' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'InitWithLeaderboardIdentifier' instead.")]
 		[Internal][NullAllowed]
 		[Export ("initWithCategory:")]
 		IntPtr InitWithCategory ([NullAllowed] string category);
@@ -525,7 +539,8 @@ namespace XamCore.GameKit {
 
 #if !XAMCORE_2_0
 		[NoWatch]
-		// [Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'Player' instead.")] - Unlike rest of deprecations we are just ripping out due to poor naming
+		// [Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'Player' instead.")] - Unlike rest of deprecations we are just ripping out due to poor naming
+		// [Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'Player' instead.")] - Unlike rest of deprecations we are just ripping out due to poor naming
 		[Export ("playerID", ArgumentSemantic.Retain)]
 		string Player { get;  }
 
@@ -554,7 +569,8 @@ namespace XamCore.GameKit {
 
 		[NoWatch]
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_4_1 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'LeaderboardIdentifier' instead.")]
+		[Availability (Introduced = Platform.iOS_4_1, Deprecated = Platform.iOS_7_0, Message = "Use 'LeaderboardIdentifier' instead.")]
+		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'LeaderboardIdentifier' instead.")]
 		[NullAllowed] // by default this property is null
 		[Export ("category", ArgumentSemantic.Copy)]
 #if XAMCORE_2_0
@@ -566,7 +582,8 @@ namespace XamCore.GameKit {
 
 		[NoWatch]
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_4_1 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'ReportScores' instead.")]
+		[Availability (Introduced = Platform.iOS_4_1, Deprecated = Platform.iOS_7_0, Message = "Use 'ReportScores' instead.")]
+		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'ReportScores' instead.")]
 		[Export ("reportScoreWithCompletionHandler:")]
 		[Async]
 #if XAMCORE_2_0
@@ -585,7 +602,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Pass 'GKPlayers' to 'ChallengeComposeController (GKPlayer [] players, string message, ... )' and present the view controller instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Pass 'GKPlayers' to 'ChallengeComposeController (GKPlayer [] players, string message, ... )' and present the view controller instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Pass 'GKPlayers' to 'ChallengeComposeController (GKPlayer [] players, string message, ... )' and present the view controller instead.")]
 		[iOS (6,0), Mac (10,8)]
 		[Export ("issueChallengeToPlayers:message:")]
 		void IssueChallengeToPlayers ([NullAllowed] string[] playerIDs, [NullAllowed] string message);
@@ -631,7 +649,8 @@ namespace XamCore.GameKit {
 	[NoWatch]
 	[NoTV]
 	[Since (4,2)]
-	[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'GKGameCenterViewController' instead.")]
+	[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'GKGameCenterViewController' instead.")]
+	[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'GKGameCenterViewController' instead.")]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -645,7 +664,8 @@ namespace XamCore.GameKit {
 	}
 
 	[NoTV][NoWatch]
-	[Availability (Introduced = Platform.iOS_4_2 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'GKGameCenterViewController' instead.")]
+	[Availability (Introduced = Platform.iOS_4_2, Deprecated = Platform.iOS_7_0, Message = "Use 'GKGameCenterViewController' instead.")]
+	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'GKGameCenterViewController' instead.")]
 #if MONOMAC
 	[BaseType (typeof (GKGameCenterViewController), Events=new Type [] { typeof (GKLeaderboardViewControllerDelegate)}, Delegates=new string [] {"WeakDelegate"})]
 	interface GKLeaderboardViewController 
@@ -686,7 +706,8 @@ namespace XamCore.GameKit {
 
 		[NoWatch]
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'LoadFriendPlayers' instead and collect the friends from the invoked callback.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'LoadFriendPlayers' instead and collect the friends from the invoked callback.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'LoadFriendPlayers' instead and collect the friends from the invoked callback.")]
 		[Export ("friends", ArgumentSemantic.Retain)]
 		string [] Friends { get;  }
 
@@ -698,7 +719,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_6_0 | Platform.Mac_10_8, Message = "Set the 'AuthenticationHandler' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Set the 'AuthenticationHandler' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_8, Message = "Set the 'AuthenticationHandler' instead.")]
 		[Export ("authenticateWithCompletionHandler:")]
 		[Async]
 #if XAMCORE_2_0
@@ -714,7 +736,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'LoadRecentPlayers' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'LoadRecentPlayers' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'LoadRecentPlayers' instead.")]
 		[Export ("loadFriendsWithCompletionHandler:")]
 		[Async]
 		void LoadFriends ([NullAllowed] GKFriendsHandler handler);
@@ -748,7 +771,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'LoadDefaultLeaderboardIdentifier' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'LoadDefaultLeaderboardIdentifier' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'LoadDefaultLeaderboardIdentifier' instead.")]
 		[Since (6,0)]
 		[Export ("loadDefaultLeaderboardCategoryIDWithCompletionHandler:")]
 		[Async]
@@ -756,7 +780,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'SetDefaultLeaderboardIdentifier' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'SetDefaultLeaderboardIdentifier' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'SetDefaultLeaderboardIdentifier' instead.")]
 		[iOS (6,0), Mac (10,8)]
 		[Export ("setDefaultLeaderboardCategoryID:completionHandler:")]
 		[Async]
@@ -853,7 +878,8 @@ namespace XamCore.GameKit {
 	[DisableDefaultCtor]
 	interface GKMatch {
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'Players' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'Players' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'Players' instead.")]
 		[Export ("playerIDs")]
 		string [] PlayersIDs { get;  }
 
@@ -868,7 +894,8 @@ namespace XamCore.GameKit {
 		nint ExpectedPlayerCount { get;  }
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'SendDataToAllPlayers (NSData, GKPlayer[] players, GKMatchSendDataMode mode, NSError error)' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'SendDataToAllPlayers (NSData, GKPlayer[] players, GKMatchSendDataMode mode, NSError error)' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'SendDataToAllPlayers (NSData, GKPlayer[] players, GKMatchSendDataMode mode, NSError error)' instead.")]
 		[Export ("sendData:toPlayers:withDataMode:error:")]
 		// OOPS: bug we shipped with and can not realistically fix, but good news: this is deprecated (the NSError should have been an out)
 		bool SendData (NSData data, string [] players, GKMatchSendDataMode mode, out NSError error);
@@ -883,7 +910,8 @@ namespace XamCore.GameKit {
 		GKVoiceChat VoiceChatWithName (string name);
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'ChooseBestHostingPlayer' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'ChooseBestHostingPlayer' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'ChooseBestHostingPlayer' instead.")]
 		[iOS (6,0), Mac (10,9)]
 		[Export ("chooseBestHostPlayerWithCompletionHandler:")]
 		[Async]
@@ -916,12 +944,14 @@ namespace XamCore.GameKit {
 	interface GKMatchDelegate {
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'DataReceivedFromPlayer (GKMatch,NSData,GKPlayer)' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'DataReceivedFromPlayer (GKMatch,NSData,GKPlayer)' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'DataReceivedFromPlayer (GKMatch,NSData,GKPlayer)' instead.")]
 		[Export ("match:didReceiveData:fromPlayer:"), EventArgs ("GKData")]
 		void DataReceived (GKMatch match, NSData data, string playerId);
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'StateChangedForPlayer (GKMatch,GKPlayer,GKPlayerConnectionState)' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'StateChangedForPlayer (GKMatch,GKPlayer,GKPlayerConnectionState)' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'StateChangedForPlayer (GKMatch,GKPlayer,GKPlayerConnectionState)' instead.")]
 		[Export ("match:player:didChangeState:"), EventArgs ("GKState")]
 		void StateChanged (GKMatch match, string playerId, GKPlayerConnectionState state);
 
@@ -947,7 +977,8 @@ namespace XamCore.GameKit {
 		void Failed (GKMatch match, [NullAllowed] NSError error);
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'ShouldReinviteDisconnectedPlayer' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'ShouldReinviteDisconnectedPlayer' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'ShouldReinviteDisconnectedPlayer' instead.")]
 		[Since (5,0)]
 		[Export ("match:shouldReinvitePlayer:"), DelegateName ("GKMatchReinvitation"), DefaultValue (true)]
 		bool ShouldReinvitePlayer (GKMatch match, string playerId);
@@ -965,7 +996,8 @@ namespace XamCore.GameKit {
 		[DelegateName ("GKMatchReinvitationForDisconnectedPlayer"), DefaultValue (true)]
 		bool ShouldReinviteDisconnectedPlayer (GKMatch match, GKPlayer player);
 
-		[Availability (Introduced = Platform.iOS_9_0 | Platform.Mac_10_11)]
+		[Availability (Introduced = Platform.iOS_9_0)]
+		[Availability (Introduced = Platform.Mac_10_11)]
 		[Export ("match:didReceiveData:forRecipient:fromRemotePlayer:"), EventArgs ("GKDataReceivedForRecipient")]
 		void DataReceivedForRecipient (GKMatch match, NSData data, GKPlayer recipient, GKPlayer player);
 	}
@@ -991,7 +1023,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		// the API was removed in iOS8
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'SetMuteStatus' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'SetMuteStatus' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'SetMuteStatus' instead.")]
 		[Export ("setMute:forPlayer:")]
 		void SetMute (bool isMuted, string playerID);
 
@@ -1000,7 +1033,8 @@ namespace XamCore.GameKit {
 		bool IsVoIPAllowed ();
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'SetPlayerVoiceChatStateChangeHandler' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'SetPlayerVoiceChatStateChangeHandler' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'SetPlayerVoiceChatStateChangeHandler' instead.")]
 		[NullAllowed] // by default this property is null
 		[Export ("playerStateUpdateHandler", ArgumentSemantic.Copy)]
 		GKPlayerStateUpdateHandler PlayerStateUpdateHandler { get; set; }
@@ -1012,7 +1046,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[Since (5,0)]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'Players' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'Players' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'Players' instead.")]
 		[Export ("playerIDs")]
 		string [] PlayerIDs { get; }
 
@@ -1057,7 +1092,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'RecipientResponseHandler' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'RecipientResponseHandler' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'RecipientResponseHandler' instead.")]
 		[Since (6,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("inviteeResponseHandler", ArgumentSemantic.Copy)]
@@ -1082,7 +1118,8 @@ namespace XamCore.GameKit {
 	interface GKInvite {
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'Sender' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'Sender' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'Sender' instead.")]
 		[Export ("inviter", ArgumentSemantic.Retain)]
 		string Inviter { get;  }
 
@@ -1118,7 +1155,8 @@ namespace XamCore.GameKit {
 		void FindMatch (GKMatchRequest request, [NullAllowed] GKNotificationMatch matchHandler);
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'FindPlayersForHostedRequest' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'FindPlayersForHostedRequest' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'FindPlayersForHostedRequest' instead.")]
 		[Export ("findPlayersForHostedMatchRequest:withCompletionHandler:")]
 		[Async]
 		void FindPlayers (GKMatchRequest request, [NullAllowed] GKFriendsHandler playerHandler);
@@ -1150,7 +1188,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[Since (6,0)][Mac (10, 9)]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'CancelPendingInvite' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'CancelPendingInvite' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'CancelPendingInvite' instead.")]
 		[Export ("cancelInviteToPlayer:")]
 		void CancelInvite (string playerID);
 
@@ -1160,7 +1199,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[Since (6,0)][Mac (10,9)]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, message: "Use 'StartBrowsingForNearbyPlayers(Action<GKPlayer, bool> handler)' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'StartBrowsingForNearbyPlayers(Action<GKPlayer, bool> handler)' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'StartBrowsingForNearbyPlayers(Action<GKPlayer, bool> handler)' instead.")]
 		[Export ("startBrowsingForNearbyPlayersWithReachableHandler:")]
 		void StartBrowsingForNearbyPlayers ([NullAllowed] Action<string, bool> reachableHandler);
 
@@ -1221,7 +1261,8 @@ namespace XamCore.GameKit {
 #endif
 
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_5_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0)]
+		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10)]
 		[Export ("defaultInvitationMessage", ArgumentSemantic.Copy)]
 		string DefaultInvitationMessage { get; set;  }
 
@@ -1231,7 +1272,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[Since (5,0)]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'SetHostedPlayerConnected (GKPlayer,bool)' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'SetHostedPlayerConnected (GKPlayer,bool)' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'SetHostedPlayerConnected (GKPlayer,bool)' instead.")]
 		[Export ("setHostedPlayer:connected:")]
 		void SetHostedPlayerConnected (string playerID, bool connected);
 
@@ -1264,7 +1306,8 @@ namespace XamCore.GameKit {
 		[Abstract]
 #endif
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'DidFindHostedPlayers' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'DidFindHostedPlayers' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'DidFindHostedPlayers' instead.")]
 		[Export ("matchmakerViewController:didFindPlayers:"), EventArgs ("GKPlayers")]
 		void DidFindPlayers (GKMatchmakerViewController viewController, string [] playerIDs);
 
@@ -1277,7 +1320,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[Since (5,0)]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'HostedPlayerDidAccept' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'HostedPlayerDidAccept' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'HostedPlayerDidAccept' instead.")]
 		[Export ("matchmakerViewController:didReceiveAcceptFromHostedPlayer:"), EventArgs ("GKPlayer")]
 		void ReceivedAcceptFromHostedPlayer (GKMatchmakerViewController viewController, string playerID);
 
@@ -1291,7 +1335,8 @@ namespace XamCore.GameKit {
 	[Watch (3,0)]
 	interface GKAchievement : NSSecureCoding {
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_6_0 | Platform.Mac_10_10, Message = "Use 'IsHidden' on the 'GKAchievementDescription' class instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'IsHidden' on the 'GKAchievementDescription' class instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'IsHidden' on the 'GKAchievementDescription' class instead.")]
 		[Export ("hidden", ArgumentSemantic.Assign)]
 		bool Hidden { [Bind ("isHidden")] get; }
 
@@ -1337,10 +1382,12 @@ namespace XamCore.GameKit {
 #if XAMCORE_2_0
 		[NoWatch]
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use ReportAchievements '(GKAchievement[] achievements, Action<NSError> completionHandler)' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use ReportAchievements '(GKAchievement[] achievements, Action<NSError> completionHandler)' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use ReportAchievements '(GKAchievement[] achievements, Action<NSError> completionHandler)' instead.")]
 		void ReportAchievement ([NullAllowed] Action<NSError> completionHandler);
 #else
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use ReportAchievements '(GKAchievement[] achievements, GKNotificationHandler completionHandler)' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use ReportAchievements '(GKAchievement[] achievements, GKNotificationHandler completionHandler)' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use ReportAchievements '(GKAchievement[] achievements, GKNotificationHandler completionHandler)' instead.")]
 		void ReportAchievement ([NullAllowed] GKNotificationHandler completionHandler);
 #endif
 
@@ -1360,7 +1407,8 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Pass 'GKPlayers' to 'ChallengeComposeController(GKPlayer[] players, string message, ...)' and present the view controller instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Pass 'GKPlayers' to 'ChallengeComposeController(GKPlayer[] players, string message, ...)' and present the view controller instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Pass 'GKPlayers' to 'ChallengeComposeController(GKPlayer[] players, string message, ...)' and present the view controller instead.")]
 		[iOS (6,0), Mac (10,8)]
 		[Export ("issueChallengeToPlayers:message:")]
 		void IssueChallengeToPlayers ([NullAllowed] string[] playerIDs, [NullAllowed] string message);
@@ -1368,7 +1416,8 @@ namespace XamCore.GameKit {
 		[NoTV]
 		[NoWatch]
 		[iOS (6,0), Mac (10,8)]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Pass 'GKPlayers' to 'SelectChallengeablePlayers' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Pass 'GKPlayers' to 'SelectChallengeablePlayers' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Pass 'GKPlayers' to 'SelectChallengeablePlayers' instead.")]
 		[Export ("selectChallengeablePlayerIDs:withCompletionHandler:")]
 		[Async]
 		void SelectChallengeablePlayerIDs ([NullAllowed] string[] playerIDs, [NullAllowed] Action<string[], NSError> completionHandler);
@@ -1477,7 +1526,8 @@ namespace XamCore.GameKit {
 		NSImage PlaceholderCompletedAchievementImage { get; }
 
 #else
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_8, Message = "Use 'LoadImage' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'LoadImage' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_8, Message = "Use 'LoadImage' instead.")]
 		[Export ("image")]
 		UIImage Image { get; }
 
@@ -1503,7 +1553,8 @@ namespace XamCore.GameKit {
 
 	[NoWatch]
 	[NoTV]
-	[Availability (Introduced = Platform.iOS_4_1 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'GKGameCenterViewController' instead.")]
+	[Availability (Introduced = Platform.iOS_4_1, Deprecated = Platform.iOS_7_0, Message = "Use 'GKGameCenterViewController' instead.")]
+	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'GKGameCenterViewController' instead.")]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -1517,7 +1568,8 @@ namespace XamCore.GameKit {
 	}
 
 	[NoTV][NoWatch]
-	[Availability (Introduced = Platform.iOS_4_1 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'GKGameCenterViewController' instead.")]
+	[Availability (Introduced = Platform.iOS_4_1, Deprecated = Platform.iOS_7_0, Message = "Use 'GKGameCenterViewController' instead.")]
+	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'GKGameCenterViewController' instead.")]
 #if MONOMAC
 	[BaseType (typeof (GKGameCenterViewController), Events=new Type [] { typeof (GKAchievementViewControllerDelegate)}, Delegates=new string [] {"WeakDelegate"})]
 	interface GKAchievementViewController 
@@ -1579,7 +1631,8 @@ namespace XamCore.GameKit {
 		[Export ("maxNumberOfRecipients")][Static]
 		nint MaxNumberOfRecipients { get; }
 		
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'AddRecipientPlayers' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'AddRecipientPlayers' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'AddRecipientPlayers' instead.")]
 		[Export ("addRecipientsWithEmailAddresses:")]
 		void AddRecipientsFromEmails (string [] emailAddresses);
 
@@ -1635,7 +1688,8 @@ namespace XamCore.GameKit {
 		GKPlayer Player { get; }
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'Player' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'Player' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'Player' instead.")]
 		[Export ("playerID", ArgumentSemantic.Copy)]
 		string PlayerID { get;  }
 
@@ -1657,7 +1711,8 @@ namespace XamCore.GameKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	[Availability (Introduced = Platform.iOS_5_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'GKLocalPlayer.RegisterListener' with an object that implements 'IGKTurnBasedEventListener'.")]
+	[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0, Message = "Use 'GKLocalPlayer.RegisterListener' with an object that implements 'IGKTurnBasedEventListener'.")]
+	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use 'GKLocalPlayer.RegisterListener' with an object that implements 'IGKTurnBasedEventListener'.")]
 	[Watch (3,0)]
 	interface GKTurnBasedEventHandlerDelegate {
 #if !XAMCORE_2_0
@@ -1670,14 +1725,17 @@ namespace XamCore.GameKit {
 		[Abstract]
 #endif
 		[Export ("handleInviteFromGameCenter:")]
-		[Availability (Introduced = Platform.iOS_5_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0)]
+		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10)]
 		void HandleInviteFromGameCenter (NSString [] playersToInvite);
 
-		[Availability (Introduced = Platform.iOS_5_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9, Message = "Use 'HandleTurnEvent' instead.")]
+		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0, Message = "Use 'HandleTurnEvent' instead.")]
+		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_9, Message = "Use 'HandleTurnEvent' instead.")]
 		[Export ("handleTurnEventForMatch:")]
 		void HandleTurnEventForMatch (GKTurnBasedMatch match);
 
-		[Availability (Introduced = Platform.iOS_6_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_7_0)]
+		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10)]
 		[Export ("handleMatchEnded:")]
 		void HandleMatchEnded (GKTurnBasedMatch match);
 
@@ -1686,12 +1744,14 @@ namespace XamCore.GameKit {
 #endif
 		[Since (6,0)]
 		[Export ("handleTurnEventForMatch:didBecomeActive:")]
-		[Availability (Introduced = Platform.iOS_6_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_6_0 | Platform.Mac_10_10)]
+		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_6_0)]
+		[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10)]
 		void HandleTurnEvent (GKTurnBasedMatch match, bool activated);
 	}
 
 	[NoTV]
-	[Availability (Introduced = Platform.iOS_5_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use GKLocalPlayer.RegisterListener with an object that implements IGKTurnBasedEventListener.")]
+	[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0, Message = "Use GKLocalPlayer.RegisterListener with an object that implements IGKTurnBasedEventListener.")]
+	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Use GKLocalPlayer.RegisterListener with an object that implements IGKTurnBasedEventListener.")]
 	[BaseType (typeof (NSObject))]
 	[Watch (3,0)]
 	interface GKTurnBasedEventHandler {
@@ -1765,7 +1825,8 @@ namespace XamCore.GameKit {
 		void LoadMatchData ([NullAllowed] GKTurnBasedMatchData onCompletion);
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_6_0 | Platform.Mac_10_9, Message = "Use 'EndTurn' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'EndTurn' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use 'EndTurn' instead.")]
 		[Export ("endTurnWithNextParticipant:matchData:completionHandler:")]
 		[Async]
 #if XAMCORE_2_0
@@ -1775,7 +1836,8 @@ namespace XamCore.GameKit {
 #endif
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_6_0 | Platform.Mac_10_9, Message = "Use 'ParticipantQuitInTurn (GKTurnBasedMatchOutcome, GKTurnBasedParticipant[], double, NSData, Action<NSError>)' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'ParticipantQuitInTurn (GKTurnBasedMatchOutcome, GKTurnBasedParticipant[], double, NSData, Action<NSError>)' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_9, Message = "Use 'ParticipantQuitInTurn (GKTurnBasedMatchOutcome, GKTurnBasedParticipant[], double, NSData, Action<NSError>)' instead.")]
 		[Export ("participantQuitInTurnWithOutcome:nextParticipant:matchData:completionHandler:")]
 		[Async]
 #if XAMCORE_2_0
@@ -1938,7 +2000,8 @@ namespace XamCore.GameKit {
 		[Abstract]
 #endif
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11, Message = "Use 'GKTurnBasedEventListener.ReceivedTurnEvent' instead.")]
+		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'GKTurnBasedEventListener.ReceivedTurnEvent' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_11, Message = "Use 'GKTurnBasedEventListener.ReceivedTurnEvent' instead.")]
 		[Export ("turnBasedMatchmakerViewController:didFindMatch:")]
 		void FoundMatch (GKTurnBasedMatchmakerViewController viewController, GKTurnBasedMatch match);
 
@@ -1946,7 +2009,8 @@ namespace XamCore.GameKit {
 		[Abstract]
 #endif
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11, Message = "Use 'GKTurnBasedEventListener.WantsToQuitMatch' instead.")]
+		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'GKTurnBasedEventListener.WantsToQuitMatch' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_11, Message = "Use 'GKTurnBasedEventListener.WantsToQuitMatch' instead.")]
 		[Export ("turnBasedMatchmakerViewController:playerQuitForMatch:")]
 		void PlayerQuitForMatch (GKTurnBasedMatchmakerViewController viewController, GKTurnBasedMatch match);
 	}
@@ -1956,12 +2020,14 @@ namespace XamCore.GameKit {
 	[BaseType (typeof (NSObject))]
 	interface GKChallenge : NSSecureCoding {
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'IssuingPlayer' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'IssuingPlayer' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'IssuingPlayer' instead.")]
 		[Export ("issuingPlayerID", ArgumentSemantic.Copy)]
 		string IssuingPlayerID { get; }
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0 | Platform.Mac_10_10, Message = "Use 'ReceivingPlayer' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message = "Use 'ReceivingPlayer' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'ReceivingPlayer' instead.")]
 		[Export ("receivingPlayerID", ArgumentSemantic.Copy)]
 		string ReceivingPlayerID { get; }
 
@@ -2037,13 +2103,15 @@ namespace XamCore.GameKit {
 
 		[NoTV]
 		[Export ("leaderboardTimeScope", ArgumentSemantic.Assign)]
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "This class no longer support 'LeaderboardTimeScope', will always default to 'AllTime'.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "This class no longer support 'LeaderboardTimeScope', will always default to 'AllTime'.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "This class no longer support 'LeaderboardTimeScope', will always default to 'AllTime'.")]
 		GKLeaderboardTimeScope LeaderboardTimeScope { get; set; }
 
 		[NoTV]
 		[NullAllowed] // by default this property is null
 		[Export ("leaderboardCategory", ArgumentSemantic.Retain)]
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Use 'LeaderboardIdentifier' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'LeaderboardIdentifier' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use 'LeaderboardIdentifier' instead.")]
 		string LeaderboardCategory { get; set; }
 
 		[NoTV]
@@ -2070,7 +2138,8 @@ namespace XamCore.GameKit {
 #if !MONOMAC
 	[NoWatch]
 	[NoTV]
-	[Availability (Introduced = Platform.iOS_6_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
+	[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_7_0, Message = "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
+	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
 	[BaseType (typeof (NSObject), Events=new[] { typeof (GKChallengeEventHandlerDelegate) }, Delegates=new[] { "WeakDelegate"})]
 	[DisableDefaultCtor]
 	[NoTV]
@@ -2089,7 +2158,8 @@ namespace XamCore.GameKit {
 
 	[NoWatch]
 	[NoTV]
-	[Availability (Introduced = Platform.iOS_6_0 | Platform.Mac_10_8, Deprecated = Platform.iOS_7_0 | Platform.Mac_10_10, Message = "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
+	[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_7_0, Message = "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
+	[Availability (Introduced = Platform.Mac_10_8, Deprecated = Platform.Mac_10_10, Message = "Implement the 'IGKChallengeListener' interface and register a listener with 'GKLocalPlayer'.")]
 	[Model]
 	[BaseType (typeof (NSObject))]
 	[Protocol]
@@ -2273,7 +2343,8 @@ namespace XamCore.GameKit {
 		[Export ("player:didRequestMatchWithOtherPlayers:")]
 		void DidRequestMatchWithOtherPlayers (GKPlayer player, GKPlayer [] playersToInvite);
 
-		[Availability (Introduced = Platform.iOS_9_0 | Platform.Mac_10_11)]
+		[Availability (Introduced = Platform.iOS_9_0)]
+		[Availability (Introduced = Platform.Mac_10_11)]
 		[Export ("player:wantsToQuitMatch:")]
 		void WantsToQuitMatch (GKPlayer player, GKTurnBasedMatch match);
 	}

--- a/src/glkit.cs
+++ b/src/glkit.cs
@@ -64,7 +64,7 @@ namespace XamCore.GLKit {
 	}
 
 	[Mac (10,8, onlyOn64 : true)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface GLKBaseEffect : GLKNamedEffect {
 		[Export ("colorMaterialEnabled", ArgumentSemantic.Assign)]
@@ -120,13 +120,13 @@ namespace XamCore.GLKit {
 	}
 
 	[Mac (10,8, onlyOn64 : true)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface GLKEffectProperty {
 	}
 
 	[Mac (10,8, onlyOn64 : true)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (GLKEffectProperty))]
 	interface GLKEffectPropertyFog {
 		[Export ("mode", ArgumentSemantic.Assign)]
@@ -149,7 +149,7 @@ namespace XamCore.GLKit {
 	}
 
 	[Mac (10,8, onlyOn64 : true)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (GLKEffectProperty))]
 	interface GLKEffectPropertyLight {
 		[Export ("position", ArgumentSemantic.Assign)]
@@ -192,7 +192,7 @@ namespace XamCore.GLKit {
 	}
 
 	[Mac (10,8, onlyOn64 : true)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (GLKEffectProperty))]
 	interface GLKEffectPropertyMaterial {
 		[Export ("diffuseColor", ArgumentSemantic.Assign)]
@@ -212,7 +212,7 @@ namespace XamCore.GLKit {
 	}
 
 	[Mac (10,8, onlyOn64 : true)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (GLKEffectProperty))]
 	interface GLKEffectPropertyTexture {
 		[Export ("target", ArgumentSemantic.Assign)]
@@ -230,7 +230,7 @@ namespace XamCore.GLKit {
 	}
 
 	[Mac (10,8, onlyOn64 : true)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (GLKEffectProperty))]
 	interface GLKEffectPropertyTransform {
 		[Export ("normalMatrix")]
@@ -293,7 +293,7 @@ namespace XamCore.GLKit {
 	{
 	}
 		
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -304,7 +304,7 @@ namespace XamCore.GLKit {
 	}
 
 	[Mac (10,8, onlyOn64 : true)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (GLKBaseEffect))]
 	interface GLKReflectionMapEffect : GLKNamedEffect {
 		[Export ("textureCubeMap")]
@@ -315,7 +315,7 @@ namespace XamCore.GLKit {
 	}
 	
 	[Mac (10,8, onlyOn64 : true)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface GLKSkyboxEffect : GLKNamedEffect {
 		[Export ("center", ArgumentSemantic.Assign)]
@@ -378,7 +378,7 @@ namespace XamCore.GLKit {
 	}
 	
 	[Mac (10,8, onlyOn64 : true)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface GLKTextureInfo : NSCopying {
 		[Export ("width")]
@@ -420,7 +420,7 @@ namespace XamCore.GLKit {
 
 	delegate void GLKTextureLoaderCallback (GLKTextureInfo textureInfo, NSError error);
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Mac (10, 8, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	interface GLKTextureLoader {
@@ -510,7 +510,7 @@ namespace XamCore.GLKit {
 		[Field ("GLKTextureLoaderGrayscaleAsAlpha")]
 		NSString GrayscaleAsAlpha { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("GLKTextureLoaderSRGB")]
 		NSString SRGB { get; }
 
@@ -525,7 +525,7 @@ namespace XamCore.GLKit {
 	}
 
 #if !MONOMAC
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof (GLKViewDelegate)})]
 	interface GLKView {
 		[Export ("initWithFrame:")]
@@ -579,7 +579,7 @@ namespace XamCore.GLKit {
 		void DeleteDrawable ();
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -589,7 +589,7 @@ namespace XamCore.GLKit {
 		void DrawInRect (GLKView view, CGRect rect);
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (UIViewController))]
 	interface GLKViewController : GLKViewDelegate {
 		[Export ("initWithNibName:bundle:")]
@@ -638,7 +638,7 @@ namespace XamCore.GLKit {
 		void Update ();
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -2050,15 +2050,15 @@ namespace XamCore.HealthKit {
 		[Static, Export ("workoutEventWithType:date:")]
 		HKWorkoutEvent Create (HKWorkoutEventType type, NSDate date);
 
-		[Introduced (PlatformName.iOS, 10, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
-		[Introduced (PlatformName.WatchOS, 3, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[iOS (10, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Watch (3, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
 		[Static]
 		[EditorBrowsable (EditorBrowsableState.Advanced)] // this is not the one we want to be seen (compat only)
 		[Export ("workoutEventWithType:date:metadata:")]
 		HKWorkoutEvent Create (HKWorkoutEventType type, NSDate date, NSDictionary metadata);
 
-		[Introduced (PlatformName.iOS, 10, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
-		[Introduced (PlatformName.WatchOS, 3, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[iOS (10, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Watch (3, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
 		[Static]
 		[Wrap ("Create (type, date, metadata != null ? metadata.Dictionary : null)")]
 		HKWorkoutEvent Create (HKWorkoutEventType type, NSDate date, HKMetadata metadata);

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -1843,7 +1843,8 @@ namespace XamCore.HealthKit {
 		[Export ("jouleUnit")]
 		HKUnit Joule { get; }
 
-		[Availability (Deprecated = Platform.iOS_11_0 | Platform.Watch_4_0, Message = "Use 'SmallCalorie' or 'LargeCalorie' instead.")]
+		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'SmallCalorie' or 'LargeCalorie' instead.")]
+		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'SmallCalorie' or 'LargeCalorie' instead.")]
 		[Static]
 		[Export ("calorieUnit")]
 		HKUnit Calorie { get; }
@@ -2031,7 +2032,8 @@ namespace XamCore.HealthKit {
 		[Export ("type")]
 		HKWorkoutEventType Type { get; }
 
-		[Availability (Deprecated = Platform.iOS_11_0 | Watch_4_0, Message = "Use 'DateInterval' instead.")]
+		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'DateInterval' instead.")]
+		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'DateInterval' instead.")]
 		[Export ("date", ArgumentSemantic.Copy)]
 		NSDate Date { get; }
 
@@ -2043,17 +2045,20 @@ namespace XamCore.HealthKit {
 		[Wrap ("WeakMetadata")]
 		HKMetadata Metadata { get; }
 
-		[Availability (Deprecated = Platform.iOS_11_0 | Platform.Watch_4_0, Message = "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
 		[Static, Export ("workoutEventWithType:date:")]
 		HKWorkoutEvent Create (HKWorkoutEventType type, NSDate date);
 
-		[Availability (Introduced = Platform.iOS_10_0 | Platform.Watch_3_0, Deprecated = Platform.iOS_11_0 | Platform.Watch_4_0, Message = "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Availability (Introduced = Platform.iOS_10_0, Deprecated = Platform.iOS_11_0, Message = "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Availability (Introduced = Platform.Watch_3_0, Deprecated = Platform.Watch_4_0, Message = "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
 		[Static]
 		[EditorBrowsable (EditorBrowsableState.Advanced)] // this is not the one we want to be seen (compat only)
 		[Export ("workoutEventWithType:date:metadata:")]
 		HKWorkoutEvent Create (HKWorkoutEventType type, NSDate date, NSDictionary metadata);
 
-		[Availability (Introduced = Platform.iOS_10_0 | Platform.Watch_3_0, Deprecated = Platform.iOS_11_0 | Platform.Watch_4_0, Message = "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Availability (Introduced = Platform.iOS_10_0, Deprecated = Platform.iOS_11_0, Message = "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Availability (Introduced = Platform.Watch_3_0, Deprecated = Platform.Watch_4_0, Message = "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
 		[Static]
 		[Wrap ("Create (type, date, metadata != null ? metadata.Dictionary : null)")]
 		HKWorkoutEvent Create (HKWorkoutEventType type, NSDate date, HKMetadata metadata);

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -2050,15 +2050,17 @@ namespace XamCore.HealthKit {
 		[Static, Export ("workoutEventWithType:date:")]
 		HKWorkoutEvent Create (HKWorkoutEventType type, NSDate date);
 
-		[iOS (10, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
-		[Watch (3, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Watch (3,0), iOS (10,0)]
+		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
 		[Static]
 		[EditorBrowsable (EditorBrowsableState.Advanced)] // this is not the one we want to be seen (compat only)
 		[Export ("workoutEventWithType:date:metadata:")]
 		HKWorkoutEvent Create (HKWorkoutEventType type, NSDate date, NSDictionary metadata);
 
-		[iOS (10, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
-		[Watch (3, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Watch (3,0), iOS (10,0)]
+		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
 		[Static]
 		[Wrap ("Create (type, date, metadata != null ? metadata.Dictionary : null)")]
 		HKWorkoutEvent Create (HKWorkoutEventType type, NSDate date, HKMetadata metadata);

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -1843,8 +1843,8 @@ namespace XamCore.HealthKit {
 		[Export ("jouleUnit")]
 		HKUnit Joule { get; }
 
-		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'SmallCalorie' or 'LargeCalorie' instead.")]
-		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'SmallCalorie' or 'LargeCalorie' instead.")]
+		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'SmallCalorie' or 'LargeCalorie' instead.")]
+		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'SmallCalorie' or 'LargeCalorie' instead.")]
 		[Static]
 		[Export ("calorieUnit")]
 		HKUnit Calorie { get; }
@@ -2032,8 +2032,8 @@ namespace XamCore.HealthKit {
 		[Export ("type")]
 		HKWorkoutEventType Type { get; }
 
-		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'DateInterval' instead.")]
-		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'DateInterval' instead.")]
+		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'DateInterval' instead.")]
+		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'DateInterval' instead.")]
 		[Export ("date", ArgumentSemantic.Copy)]
 		NSDate Date { get; }
 
@@ -2045,20 +2045,20 @@ namespace XamCore.HealthKit {
 		[Wrap ("WeakMetadata")]
 		HKMetadata Metadata { get; }
 
-		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
-		[Availability (Deprecated = Platform.Watch_4_0, Message = "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
 		[Static, Export ("workoutEventWithType:date:")]
 		HKWorkoutEvent Create (HKWorkoutEventType type, NSDate date);
 
-		[Availability (Introduced = Platform.iOS_10_0, Deprecated = Platform.iOS_11_0, Message = "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
-		[Availability (Introduced = Platform.Watch_3_0, Deprecated = Platform.Watch_4_0, Message = "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Introduced (PlatformName.iOS, 10, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Introduced (PlatformName.WatchOS, 3, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
 		[Static]
 		[EditorBrowsable (EditorBrowsableState.Advanced)] // this is not the one we want to be seen (compat only)
 		[Export ("workoutEventWithType:date:metadata:")]
 		HKWorkoutEvent Create (HKWorkoutEventType type, NSDate date, NSDictionary metadata);
 
-		[Availability (Introduced = Platform.iOS_10_0, Deprecated = Platform.iOS_11_0, Message = "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
-		[Availability (Introduced = Platform.Watch_3_0, Deprecated = Platform.Watch_4_0, Message = "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Introduced (PlatformName.iOS, 10, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
+		[Introduced (PlatformName.WatchOS, 3, 0, message: "Use 'Create (HKWorkoutEventType, NSDateInterval, HKMetadata)' instead.")]
 		[Static]
 		[Wrap ("Create (type, date, metadata != null ? metadata.Dictionary : null)")]
 		HKWorkoutEvent Create (HKWorkoutEventType type, NSDate date, HKMetadata metadata);

--- a/src/iad.cs
+++ b/src/iad.cs
@@ -18,18 +18,18 @@ using XamCore.AVKit;
 
 namespace XamCore.iAd {
 
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Deprecated (PlatformName.iOS, 10, 0)]
 	[BaseType (typeof (UIView), Delegates=new string [] {"WeakDelegate"}, Events=new Type [] {typeof (ADBannerViewDelegate)})]
 	interface ADBannerView {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 		
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("adType")]
 		ADAdType AdType { get;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("initWithAdType:")]
 		IntPtr Constructor (ADAdType type);
 
@@ -86,7 +86,7 @@ namespace XamCore.iAd {
 		NSString SizeIdentifierPortrait { get; }
 	}
 
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Deprecated (PlatformName.iOS, 10, 0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -104,7 +104,7 @@ namespace XamCore.iAd {
 		[Export ("bannerViewActionDidFinish:")]
 		void ActionFinished (ADBannerView banner);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("bannerViewWillLoadAd:"), EventArgs ("EventArgs", true, true)]
 		void WillLoad (ADBannerView bannerView);
 	}
@@ -167,7 +167,7 @@ namespace XamCore.iAd {
 		[Export ("interstitialAdActionDidFinish:")]
 		void ActionFinished (ADInterstitialAd interstitialAd);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("interstitialAdWillLoad:"), EventArgs ("EventArgs", true, true)]
 		void WillLoad (ADInterstitialAd interstitialAd);
 	}
@@ -181,10 +181,10 @@ namespace XamCore.iAd {
 #else
 		[EditorBrowsable (EditorBrowsableState.Advanced)] // this is not the one we want to be seen (compat only)
 #endif
-		[Since (7,0), Static, Export ("preparePrerollAds")]
+		[iOS (7,0), Static, Export ("preparePrerollAds")]
 		void PreparePrerollAds ();
 
-		[Since (7,0), Export ("playPrerollAdWithCompletionHandler:")]
+		[iOS (7,0), Export ("playPrerollAdWithCompletionHandler:")]
 #if XAMCORE_2_0
 		void PlayPrerollAd (Action<NSError> completionHandler);
 #else
@@ -209,41 +209,41 @@ namespace XamCore.iAd {
 #else
 		[EditorBrowsable (EditorBrowsableState.Advanced)] // this is not the one we want to be seen (compat only)
 #endif
-		[Since (7,0), Static, Export ("prepareInterstitialAds")]
+		[iOS (7,0), Static, Export ("prepareInterstitialAds")]
 		void PrepareInterstitialAds ();
 
-		[Since (7,0), Export ("interstitialPresentationPolicy")]
+		[iOS (7,0), Export ("interstitialPresentationPolicy")]
 		ADInterstitialPresentationPolicy GetInterstitialPresentationPolicy ();
 		
-		[Since (7,0), Export ("setInterstitialPresentationPolicy:")]
+		[iOS (7,0), Export ("setInterstitialPresentationPolicy:")]
 		void SetInterstitialPresentationPolicy (ADInterstitialPresentationPolicy policy);
 
-		[Since (7,0), Export ("canDisplayBannerAds")]
+		[iOS (7,0), Export ("canDisplayBannerAds")]
 		bool GetCanDisplayBannerAds ();
 
-		[Since (7,0), Export ("setCanDisplayBannerAds:")]
+		[iOS (7,0), Export ("setCanDisplayBannerAds:")]
 		void SetCanDisplayBannerAds (bool value);
 
-		[Since (7,0), Export ("originalContentView")]
+		[iOS (7,0), Export ("originalContentView")]
 		[NullAllowed]
 		UIView GetOriginalContentView ();
 
-		[Since (7,0), Export ("isPresentingFullScreenAd")]
+		[iOS (7,0), Export ("isPresentingFullScreenAd")]
 		bool PresentingFullScreenAd ();
 
-		[Since (7,0), Export ("isDisplayingBannerAd")]
+		[iOS (7,0), Export ("isDisplayingBannerAd")]
 		bool DisplayingBannerAd ();
 
-		[Since (7,0), Export ("requestInterstitialAdPresentation")]
+		[iOS (7,0), Export ("requestInterstitialAdPresentation")]
 		bool RequestInterstitialAdPresentation ();
 
-		[Since (7,0), Export ("shouldPresentInterstitialAd")]
+		[iOS (7,0), Export ("shouldPresentInterstitialAd")]
 		bool ShouldPresentInterstitialAd ();
 	}
 
 	delegate void ADConversionDetails (NSDate appPurchaseDate, NSDate iAdImpressionDate);
 	
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface ADClient {

--- a/src/imageio.cs
+++ b/src/imageio.cs
@@ -34,7 +34,7 @@ using System;
 
 namespace XamCore.ImageIO {
 
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Static]
 	// Bad name should end with Keys
 	interface CGImageProperties {
@@ -515,19 +515,19 @@ namespace XamCore.ImageIO {
 		NSString PNGsRGBIntent { get; }
 		[Field ("kCGImagePropertyPNGChromaticities")]
 		NSString PNGChromaticities { get; }
-		[Since (5,0)][Field ("kCGImagePropertyPNGAuthor")]
+		[iOS (5,0)][Field ("kCGImagePropertyPNGAuthor")]
 		NSString PNGAuthor { get; }
-		[Since (5,0)][Field ("kCGImagePropertyPNGCopyright")]
+		[iOS (5,0)][Field ("kCGImagePropertyPNGCopyright")]
 		NSString PNGCopyright { get; }
-		[Since (5,0)][Field ("kCGImagePropertyPNGCreationTime")]
+		[iOS (5,0)][Field ("kCGImagePropertyPNGCreationTime")]
 		NSString PNGCreationTime { get; }
-		[Since (5,0)][Field ("kCGImagePropertyPNGDescription")]
+		[iOS (5,0)][Field ("kCGImagePropertyPNGDescription")]
 		NSString PNGDescription { get; }
-		[Since (5,0)][Field ("kCGImagePropertyPNGModificationTime")]
+		[iOS (5,0)][Field ("kCGImagePropertyPNGModificationTime")]
 		NSString PNGModificationTime { get; }
-		[Since (5,0)][Field ("kCGImagePropertyPNGSoftware")]
+		[iOS (5,0)][Field ("kCGImagePropertyPNGSoftware")]
 		NSString PNGSoftware { get; }
-		[Since (5,0)][Field ("kCGImagePropertyPNGTitle")]
+		[iOS (5,0)][Field ("kCGImagePropertyPNGTitle")]
 		NSString PNGTitle { get; }
 
 		[iOS (9,0)][Mac (10,11)]
@@ -903,7 +903,7 @@ namespace XamCore.ImageIO {
 		NSString FileContentsDictionary { get; }
 	}
 
-	[Since (7,0), Mac (10, 8)]
+	[iOS (7,0), Mac (10, 8)]
 	[Static]
 	interface CGImageMetadataTagNamespaces {
 		[Field ("kCGImageMetadataNamespaceExif")]
@@ -926,7 +926,7 @@ namespace XamCore.ImageIO {
 		NSString XMPRights { get; }
 	}
 
-	[Since (7,0), Mac (10, 8)]
+	[iOS (7,0), Mac (10, 8)]
 	[Static]
 	interface CGImageMetadataTagPrefixes {
 		[Field ("kCGImageMetadataPrefixExif")]
@@ -949,7 +949,7 @@ namespace XamCore.ImageIO {
 		NSString XMPRights { get; }
 	}
 
-	[Since (7,0), Mac (10, 8)]
+	[iOS (7,0), Mac (10, 8)]
 	interface CGImageMetadata {
 		[Field ("kCFErrorDomainCGImageMetadata")]
 		NSString ErrorDomain { get; }
@@ -1006,23 +1006,23 @@ namespace XamCore.ImageIO {
 		[Internal][Field ("kCGImageDestinationBackgroundColor")]
 		IntPtr kBackgroundColor { get; }
 
-		[Since (7,0), Mac (10, 8)]
+		[iOS (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageDestinationDateTime")]
 		IntPtr kDateTime { get; }
 
-		[Since (7,0), Mac (10, 8)]
+		[iOS (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageDestinationMergeMetadata")]
 		IntPtr kMergeMetadata { get; }
 
-		[Since (7,0), Mac (10, 8)]
+		[iOS (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageDestinationMetadata")]
 		IntPtr kMetadata { get; }
 
-		[Since (7,0), Mac (10, 8)]
+		[iOS (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageDestinationOrientation")]
 		IntPtr kOrientation { get; }
 
-		[Since (7,0), Mac (10, 8)]
+		[iOS (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageMetadataShouldExcludeXMP")]
 		IntPtr kShouldExcludeXMP { get; }
 
@@ -1188,15 +1188,15 @@ namespace XamCore.ImageIO {
 	[Partial]
 	interface CGCopyImageSourceOptions {
 
-		[Since (7,0), Mac (10, 8)]
+		[iOS (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageDestinationMetadata")]
 		IntPtr kMetadata { get; }
 
-		[Since (7,0), Mac (10, 8)]
+		[iOS (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageDestinationMergeMetadata")]
 		IntPtr kMergeMetadata { get; }
 
-		[Since (7,0), Mac (10, 8)]
+		[iOS (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageMetadataShouldExcludeXMP")]
 		IntPtr kShouldExcludeXMP { get; }
 
@@ -1204,11 +1204,11 @@ namespace XamCore.ImageIO {
 		[Internal][Field ("kCGImageMetadataShouldExcludeGPS")]
 		IntPtr kShouldExcludeGPS { get; }
 
-		[Since (7,0), Mac (10, 8)]
+		[iOS (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageDestinationDateTime")]
 		IntPtr kDateTime { get; }
 
-		[Since (7,0), Mac (10, 8)]
+		[iOS (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageDestinationOrientation")]
 		IntPtr kOrientation { get; }
 	}

--- a/src/imageio.cs
+++ b/src/imageio.cs
@@ -833,22 +833,22 @@ namespace XamCore.ImageIO {
 		[Field ("kCGImagePropertyMakerCanonAspectRatioInfo")]
 		NSString MakerCanonAspectRatioInfo { get; }
 
-		[Since(7,0), Mavericks]
+		[Since(7,0), Mac (10, 9)]
 		[Field ("kCGImagePropertyExifISOSpeed")]
 		NSString ExifISOSpeed { get; }
-		[Since(7,0), Mavericks]
+		[Since(7,0), Mac (10, 9)]
 		[Field ("kCGImagePropertyExifISOSpeedLatitudeyyy")]
 		NSString ExifISOSpeedLatitudeYyy { get; }
-		[Since(7,0), Mavericks]
+		[Since(7,0), Mac (10, 9)]
 		[Field ("kCGImagePropertyExifISOSpeedLatitudezzz")]
 		NSString ExifISOSpeedLatitudeZzz { get; }
-		[Since(7,0), Mavericks]
+		[Since(7,0), Mac (10, 9)]
 		[Field ("kCGImagePropertyExifRecommendedExposureIndex")]
 		NSString ExifRecommendedExposureIndex { get; }
-		[Since(7,0), Mavericks]
+		[Since(7,0), Mac (10, 9)]
 		[Field ("kCGImagePropertyExifSensitivityType")]
 		NSString ExifSensitivityType { get; }
-		[Since(7,0), Mavericks]
+		[Since(7,0), Mac (10, 9)]
 		[Field ("kCGImagePropertyExifStandardOutputSensitivity")]
 		NSString ExifStandardOutputSensitivity { get; }
 
@@ -903,7 +903,7 @@ namespace XamCore.ImageIO {
 		NSString FileContentsDictionary { get; }
 	}
 
-	[Since (7,0), MountainLion]
+	[Since (7,0), Mac (10, 8)]
 	[Static]
 	interface CGImageMetadataTagNamespaces {
 		[Field ("kCGImageMetadataNamespaceExif")]
@@ -926,7 +926,7 @@ namespace XamCore.ImageIO {
 		NSString XMPRights { get; }
 	}
 
-	[Since (7,0), MountainLion]
+	[Since (7,0), Mac (10, 8)]
 	[Static]
 	interface CGImageMetadataTagPrefixes {
 		[Field ("kCGImageMetadataPrefixExif")]
@@ -949,7 +949,7 @@ namespace XamCore.ImageIO {
 		NSString XMPRights { get; }
 	}
 
-	[Since (7,0), MountainLion]
+	[Since (7,0), Mac (10, 8)]
 	interface CGImageMetadata {
 		[Field ("kCFErrorDomainCGImageMetadata")]
 		NSString ErrorDomain { get; }
@@ -1006,23 +1006,23 @@ namespace XamCore.ImageIO {
 		[Internal][Field ("kCGImageDestinationBackgroundColor")]
 		IntPtr kBackgroundColor { get; }
 
-		[Since (7,0), MountainLion]
+		[Since (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageDestinationDateTime")]
 		IntPtr kDateTime { get; }
 
-		[Since (7,0), MountainLion]
+		[Since (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageDestinationMergeMetadata")]
 		IntPtr kMergeMetadata { get; }
 
-		[Since (7,0), MountainLion]
+		[Since (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageDestinationMetadata")]
 		IntPtr kMetadata { get; }
 
-		[Since (7,0), MountainLion]
+		[Since (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageDestinationOrientation")]
 		IntPtr kOrientation { get; }
 
-		[Since (7,0), MountainLion]
+		[Since (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageMetadataShouldExcludeXMP")]
 		IntPtr kShouldExcludeXMP { get; }
 
@@ -1188,15 +1188,15 @@ namespace XamCore.ImageIO {
 	[Partial]
 	interface CGCopyImageSourceOptions {
 
-		[Since (7,0), MountainLion]
+		[Since (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageDestinationMetadata")]
 		IntPtr kMetadata { get; }
 
-		[Since (7,0), MountainLion]
+		[Since (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageDestinationMergeMetadata")]
 		IntPtr kMergeMetadata { get; }
 
-		[Since (7,0), MountainLion]
+		[Since (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageMetadataShouldExcludeXMP")]
 		IntPtr kShouldExcludeXMP { get; }
 
@@ -1204,11 +1204,11 @@ namespace XamCore.ImageIO {
 		[Internal][Field ("kCGImageMetadataShouldExcludeGPS")]
 		IntPtr kShouldExcludeGPS { get; }
 
-		[Since (7,0), MountainLion]
+		[Since (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageDestinationDateTime")]
 		IntPtr kDateTime { get; }
 
-		[Since (7,0), MountainLion]
+		[Since (7,0), Mac (10, 8)]
 		[Internal][Field ("kCGImageDestinationOrientation")]
 		IntPtr kOrientation { get; }
 	}

--- a/src/imageio.cs
+++ b/src/imageio.cs
@@ -833,27 +833,27 @@ namespace XamCore.ImageIO {
 		[Field ("kCGImagePropertyMakerCanonAspectRatioInfo")]
 		NSString MakerCanonAspectRatioInfo { get; }
 
-		[Since(7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("kCGImagePropertyExifISOSpeed")]
 		NSString ExifISOSpeed { get; }
-		[Since(7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("kCGImagePropertyExifISOSpeedLatitudeyyy")]
 		NSString ExifISOSpeedLatitudeYyy { get; }
-		[Since(7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("kCGImagePropertyExifISOSpeedLatitudezzz")]
 		NSString ExifISOSpeedLatitudeZzz { get; }
-		[Since(7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("kCGImagePropertyExifRecommendedExposureIndex")]
 		NSString ExifRecommendedExposureIndex { get; }
-		[Since(7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("kCGImagePropertyExifSensitivityType")]
 		NSString ExifSensitivityType { get; }
-		[Since(7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Field ("kCGImagePropertyExifStandardOutputSensitivity")]
 		NSString ExifStandardOutputSensitivity { get; }
 
 #if !MONOMAC
-		[Since(7,0)]
+		[iOS (7,0)]
 		[Field ("kCGImagePropertyMakerAppleDictionary")]
 		NSString MakerAppleDictionary { get; }
 #endif

--- a/src/imageio.cs
+++ b/src/imageio.cs
@@ -910,7 +910,7 @@ namespace XamCore.ImageIO {
 		NSString Exif { get; }
 		[Field ("kCGImageMetadataNamespaceExifAux")]
 		NSString ExifAux { get; }
-		[Mavericks, Field ("kCGImageMetadataNamespaceExifEX")]
+		[Mac (10, 9), Field ("kCGImageMetadataNamespaceExifEX")]
 		NSString ExifEx { get; }
 		[Field ("kCGImageMetadataNamespaceDublinCore")]
 		NSString DublinCore { get; }
@@ -933,7 +933,7 @@ namespace XamCore.ImageIO {
 		NSString Exif { get; }
 		[Field ("kCGImageMetadataPrefixExifAux")]
 		NSString ExifAux { get; }
-		[Mavericks, Field ("kCGImageMetadataPrefixExifEX")]
+		[Mac (10, 9), Field ("kCGImageMetadataPrefixExifEX")]
 		NSString ExifEx { get; }
 		[Field ("kCGImageMetadataPrefixDublinCore")]
 		NSString DublinCore { get; }

--- a/src/inputmethodkit.cs
+++ b/src/inputmethodkit.cs
@@ -49,10 +49,10 @@ namespace XamCore.InputMethodKit {
 		[Export ("bundle")]
 		NSBundle Bundle { get; }
 
-		[Lion, Export ("paletteWillTerminate")]
+		[Mac (10, 7), Export ("paletteWillTerminate")]
 		bool PaletteWillTerminate { get; }
 
-		[Lion, Export ("lastKeyEventWasDeadKey")]
+		[Mac (10, 7), Export ("lastKeyEventWasDeadKey")]
 		bool LastKeyEventWasDeadKey { get; }
 	}
 
@@ -170,7 +170,7 @@ namespace XamCore.InputMethodKit {
 		[Export ("client")]
 		NSObject Client { get; }
 
-		[Lion, Export ("inputControllerWillClose")]
+		[Mac (10, 7), Export ("inputControllerWillClose")]
 		void InputControllerWillClose ();
 
 		[Export ("annotationSelected:forCandidate:")]
@@ -213,10 +213,10 @@ namespace XamCore.InputMethodKit {
 		[Export ("showSublist:subListDelegate:")]
 		void ShowSublist (NSObject [] candidates, NSObject delegateObject);
 
-		[Lion, Export ("selectedCandidateString")]
+		[Mac (10, 7), Export ("selectedCandidateString")]
 		NSAttributedString SelectedCandidateString { get; }
 
-		[Lion, Export ("candidateFrameTopLeft")]
+		[Mac (10, 7), Export ("candidateFrameTopLeft")]
 		NSPoint CandidateFrameTopLeft { set; }
 
 		[Export ("candidateFrame")]
@@ -235,25 +235,25 @@ namespace XamCore.InputMethodKit {
 		[Export ("dismissesAutomatically")]
 		bool DismissesAutomatically { get; set; }
 
-		[Lion, Export ("selectedCandidate")]
+		[Mac (10, 7), Export ("selectedCandidate")]
 		nint SelectedCandidate { get; }
 
-		[Lion, Export ("showChild")]
+		[Mac (10, 7), Export ("showChild")]
 		void ShowChild ();
 
-		[Lion, Export ("hideChild")]
+		[Mac (10, 7), Export ("hideChild")]
 		void HideChild ();
 
-		[Lion, Export ("attachChild:toCandidate:type:")]
+		[Mac (10, 7), Export ("attachChild:toCandidate:type:")]
 		void AttachChild (IMKCandidates child, nint candidateIdentifier, IMKStyleType theType);
 
-		[Lion, Export ("detachChild:")]
+		[Mac (10, 7), Export ("detachChild:")]
 		void DetachChild (nint candidateIdentifier);
 
-		[Lion, Export ("candidateData")]
+		[Mac (10, 7), Export ("candidateData")]
 		NSObject [] CandidateData { set; }
 
-		[Lion, Export ("selectCandidateWithIdentifier:")]
+		[Mac (10, 7), Export ("selectCandidateWithIdentifier:")]
 		bool SelectCandidateWithIdentifier (nint candidateIdentifier);
 
 		[Export ("selectCandidate:")]
@@ -262,13 +262,13 @@ namespace XamCore.InputMethodKit {
 		[Export ("showCandidates")]
 		void ShowCandidates ();
 
-		[Lion, Export ("candidateStringIdentifier:")]
+		[Mac (10, 7), Export ("candidateStringIdentifier:")]
 		nint GetCandidateIdentifier (NSObject candidateString);
 
-		[Lion, Export ("candidateIdentifierAtLineNumber:")]
+		[Mac (10, 7), Export ("candidateIdentifierAtLineNumber:")]
 		nint GetCandidateIdentifier (nint lineNumber);
 
-		[Lion, Export ("lineNumberForCandidateWithIdentifier:")]
+		[Mac (10, 7), Export ("lineNumberForCandidateWithIdentifier:")]
 		nint GetLineNumberForCandidate (nint candidateIdentifier);
 
 		[Export ("clearSelection")]

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -25,7 +25,7 @@ using XamCore.UIKit;
 
 namespace XamCore.Intents {
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Native]
@@ -38,9 +38,9 @@ namespace XamCore.Intents {
 		FailureRequiringAppLaunchServiceTemporarilyUnavailable
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Native]
 	[Flags]
 	public enum INCallCapabilityOptions : nuint {
@@ -48,9 +48,9 @@ namespace XamCore.Intents {
 		VideoCall = (1 << 1)
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Native]
 	public enum INCallRecordType : nint {
 		Unknown = 0,
@@ -63,8 +63,8 @@ namespace XamCore.Intents {
 		Voicemail,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INCancelWorkoutIntentResponseCode : nint {
@@ -81,7 +81,7 @@ namespace XamCore.Intents {
 		HandleInApp,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-native-enum! INCarAirCirculationMode bound
 	[Native]
 	public enum INCarAirCirculationMode : nint {
@@ -90,7 +90,7 @@ namespace XamCore.Intents {
 		RecirculateAir
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-native-enum! INCarAudioSource bound
 	[Native]
 	public enum INCarAudioSource : nint {
@@ -106,7 +106,7 @@ namespace XamCore.Intents {
 		HardDrive
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-native-enum! INCarDefroster bound
 	[Native]
 	public enum INCarDefroster : nint {
@@ -116,7 +116,7 @@ namespace XamCore.Intents {
 		All,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-native-enum! INCarSeat bound
 	[Native]
 	public enum INCarSeat : nint {
@@ -135,9 +135,9 @@ namespace XamCore.Intents {
 		All
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Native]
 	public enum INConditionalOperator : nint {
 		All = 0,
@@ -145,8 +145,8 @@ namespace XamCore.Intents {
 		None
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INEndWorkoutIntentResponseCode : nint {
@@ -163,7 +163,7 @@ namespace XamCore.Intents {
 		HandleInApp,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INGetAvailableRestaurantReservationBookingDefaultsIntentResponseCode : nint {
@@ -172,7 +172,7 @@ namespace XamCore.Intents {
 		Unspecified
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INGetAvailableRestaurantReservationBookingsIntentCode : nint {
@@ -182,7 +182,7 @@ namespace XamCore.Intents {
 		FailureRequestUnspecified
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INGetRestaurantGuestIntentResponseCode : nint {
@@ -190,8 +190,8 @@ namespace XamCore.Intents {
 		Failure
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INGetRideStatusIntentResponseCode : nint {
@@ -207,7 +207,7 @@ namespace XamCore.Intents {
 		FailureRequiringAppLaunchServiceTemporarilyUnavailable
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INGetUserCurrentRestaurantReservationBookingsIntentResponseCode : nint {
@@ -217,9 +217,9 @@ namespace XamCore.Intents {
 		Unspecified
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Native]
 	[ErrorDomain ("INIntentErrorDomain")]
 	public enum INIntentErrorCode : nint {
@@ -238,9 +238,9 @@ namespace XamCore.Intents {
 		ExtensionBringUpFailed = 5001,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Native]
 	public enum INIntentHandlingStatus : nint {
 		Unspecified = 0,
@@ -251,9 +251,9 @@ namespace XamCore.Intents {
 		DeferredToApplication
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Native]
 	public enum INInteractionDirection : nint {
 		Unspecified = 0,
@@ -261,8 +261,8 @@ namespace XamCore.Intents {
 		Incoming
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INListRideOptionsIntentResponseCode : nint {
@@ -282,9 +282,9 @@ namespace XamCore.Intents {
 		FailurePreviousRideNeedsFeedback,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Native]
 	public enum INMessageAttribute : nint {
 		Unknown = 0,
@@ -296,9 +296,9 @@ namespace XamCore.Intents {
 		Played,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Native]
 	[Flags]
 	public enum INMessageAttributeOptions : nuint {
@@ -310,8 +310,8 @@ namespace XamCore.Intents {
 		Played = (1UL << 4),
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INPauseWorkoutIntentResponseCode : nint {
@@ -328,8 +328,8 @@ namespace XamCore.Intents {
 		HandleInApp,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INPaymentMethodType : nint {
@@ -344,8 +344,8 @@ namespace XamCore.Intents {
 		ApplePay
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INPaymentStatus : nint {
@@ -363,8 +363,8 @@ namespace XamCore.Intents {
 		InstantMessageAddress
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-native-enum! INPhotoAttributeOptions bound
 	[Native]
 	[Flags]
@@ -395,7 +395,7 @@ namespace XamCore.Intents {
 		ProcessFilter = (1 << 23)
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-native-enum! INRadioType bound
 	[Native]
 	public enum INRadioType : nint {
@@ -407,7 +407,7 @@ namespace XamCore.Intents {
 		Dab
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INRelativeReference : nint {
@@ -416,7 +416,7 @@ namespace XamCore.Intents {
 		Previous
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INRelativeSetting : nint {
@@ -427,8 +427,8 @@ namespace XamCore.Intents {
 		Highest
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INRequestPaymentIntentResponseCode : nint {
@@ -449,8 +449,8 @@ namespace XamCore.Intents {
 		FailureTermsAndConditionsAcceptanceRequired,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INRequestRideIntentResponseCode : nint {
@@ -468,7 +468,7 @@ namespace XamCore.Intents {
 		FailureRequiringAppLaunchPreviousRideNeedsCompletion
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INRestaurantReservationUserBookingStatus : nuint {
@@ -477,8 +477,8 @@ namespace XamCore.Intents {
 		Denied
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INResumeWorkoutIntentResponseCode : nint {
@@ -495,8 +495,8 @@ namespace XamCore.Intents {
 		HandleInApp,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INRidePhase : nint {
@@ -509,7 +509,7 @@ namespace XamCore.Intents {
 		Pickup
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Native]
@@ -522,9 +522,9 @@ namespace XamCore.Intents {
 		FailureRequiringAppLaunch
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Native]
 	public enum INSearchCallHistoryIntentResponseCode : nint {
 		Unspecified = 0,
@@ -532,8 +532,8 @@ namespace XamCore.Intents {
 		ContinueInApp,
 		Failure,
 		FailureRequiringAppLaunch,
-		[Introduced (PlatformName.iOS, 10, 2)]
-		[Introduced (PlatformName.MacOSX, 10, 12, 2, PlatformArchitecture.Arch64)]
+		[iOS (10, 2)]
+		[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
 		FailureAppConfigurationRequired,
 		[iOS (11,0), Mac (10,13, onlyOn64:true), Watch (4,0)]
 		InProgress,
@@ -541,9 +541,9 @@ namespace XamCore.Intents {
 		Success,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Native]
 	public enum INSearchForMessagesIntentResponseCode : nint {
 		Unspecified = 0,
@@ -557,8 +557,8 @@ namespace XamCore.Intents {
 		FailureMessageTooManyResults,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INSearchForPhotosIntentResponseCode : nint {
@@ -567,14 +567,14 @@ namespace XamCore.Intents {
 		ContinueInApp,
 		Failure,
 		FailureRequiringAppLaunch,
-		[Introduced (PlatformName.iOS, 10, 2)]
-		[Introduced (PlatformName.MacOSX, 10, 12, 2, PlatformArchitecture.Arch64)]
+		[iOS (10, 2)]
+		[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
 		FailureAppConfigurationRequired,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Native]
 	public enum INSendMessageIntentResponseCode : nint {
 		Unspecified = 0,
@@ -586,8 +586,8 @@ namespace XamCore.Intents {
 		FailureMessageServiceNotAvailable
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INSendPaymentIntentResponseCode : nint {
@@ -603,15 +603,15 @@ namespace XamCore.Intents {
 		FailurePaymentsCurrencyUnsupported,
 		FailureInsufficientFunds,
 		FailureNoBankAccount,
-		[Introduced (PlatformName.iOS, 11, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 13, PlatformArchitecture.Arch64)]
-		[Introduced (PlatformName.WatchOS, 4, 0)]
+		[iOS (11, 0)]
+		[Mac (10, 13, PlatformArchitecture.Arch64)]
+		[Watch (4, 0)]
 		FailureNotEligible,
 		[iOS (11,1), Watch (4,1)]
 		FailureTermsAndConditionsAcceptanceRequired,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Native]
@@ -624,7 +624,7 @@ namespace XamCore.Intents {
 		FailureRequiringAppLaunch
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Native]
@@ -637,7 +637,7 @@ namespace XamCore.Intents {
 		FailureRequiringAppLaunch
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Native]
@@ -650,8 +650,8 @@ namespace XamCore.Intents {
 		FailureRequiringAppLaunch
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Native]
 	public enum INSetMessageAttributeIntentResponseCode : nint {
@@ -665,7 +665,7 @@ namespace XamCore.Intents {
 		FailureMessageAttributeNotSet
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Native]
@@ -678,7 +678,7 @@ namespace XamCore.Intents {
 		FailureRequiringAppLaunch
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Native]
@@ -692,7 +692,7 @@ namespace XamCore.Intents {
 		FailureNotSubscribed
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Native]
@@ -705,8 +705,8 @@ namespace XamCore.Intents {
 		FailureRequiringAppLaunch
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INSiriAuthorizationStatus : nint {
@@ -716,9 +716,9 @@ namespace XamCore.Intents {
 		Authorized
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Native]
 	public enum INStartAudioCallIntentResponseCode : nint {
 		Unspecified = 0,
@@ -726,11 +726,11 @@ namespace XamCore.Intents {
 		ContinueInApp,
 		Failure,
 		FailureRequiringAppLaunch,
-		[Introduced (PlatformName.iOS, 10, 2)]
-		[Introduced (PlatformName.MacOSX, 10, 12, 2, PlatformArchitecture.Arch64)]
+		[iOS (10, 2)]
+		[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
 		FailureAppConfigurationRequired,
-		[Introduced (PlatformName.iOS, 10, 2)]
-		[Introduced (PlatformName.MacOSX, 10, 12, 2, PlatformArchitecture.Arch64)]
+		[iOS (10, 2)]
+		[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
 		FailureCallingServiceNotAvailable,
 		[Watch (4,0), Mac (10,13, onlyOn64:true), iOS (11,0)]
 		FailureContactNotSupportedByApp,
@@ -738,8 +738,8 @@ namespace XamCore.Intents {
 		FailureNoValidNumber,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INStartPhotoPlaybackIntentResponseCode : nint {
@@ -748,12 +748,12 @@ namespace XamCore.Intents {
 		ContinueInApp,
 		Failure,
 		FailureRequiringAppLaunch,
-		[Introduced (PlatformName.iOS, 10, 2)]
+		[iOS (10, 2)]
 		FailureAppConfigurationRequired,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Native]
 	public enum INStartVideoCallIntentResponseCode : nint {
@@ -762,11 +762,11 @@ namespace XamCore.Intents {
 		ContinueInApp,
 		Failure,
 		FailureRequiringAppLaunch,
-		[Introduced (PlatformName.iOS, 10, 2)]
-		[Introduced (PlatformName.MacOSX, 10, 12, 2, PlatformArchitecture.Arch64)]
+		[iOS (10, 2)]
+		[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
 		FailureAppConfigurationRequired,
-		[Introduced (PlatformName.iOS, 10, 2)]
-		[Introduced (PlatformName.MacOSX, 10, 12, 2, PlatformArchitecture.Arch64)]
+		[iOS (10, 2)]
+		[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
 		FailureCallingServiceNotAvailable,
 		[Watch (4,0), iOS (11,0)]
 		FailureContactNotSupportedByApp,
@@ -774,8 +774,8 @@ namespace XamCore.Intents {
 		FailureInvalidNumber,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INStartWorkoutIntentResponseCode : nint {
@@ -792,7 +792,7 @@ namespace XamCore.Intents {
 		HandleInApp,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Native]
@@ -803,11 +803,11 @@ namespace XamCore.Intents {
 		PhotoAlbumName,
 		WorkoutActivityName = 200,
 		CarProfileName = 300,
-		[Introduced (PlatformName.iOS, 10, 3)]
+		[iOS (10, 3)]
 		CarName,
-		[Introduced (PlatformName.iOS, 10, 3)]
+		[iOS (10, 3)]
 		PaymentsOrganizationName = 400,
-		[Introduced (PlatformName.iOS, 10, 3)]
+		[iOS (10, 3)]
 		PaymentsAccountNickname,
 		[iOS (11,0)]
 		NotebookItemTitle = 500,
@@ -815,8 +815,8 @@ namespace XamCore.Intents {
 		NotebookItemGroupName,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-native-enum! INWorkoutGoalUnitType bound
 	[Native]
 	public enum INWorkoutGoalUnitType : nint {
@@ -833,8 +833,8 @@ namespace XamCore.Intents {
 		KiloCalorie
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-native-enum! INWorkoutLocationType bound
 	[Native]
 	public enum INWorkoutLocationType : nint {
@@ -843,9 +843,9 @@ namespace XamCore.Intents {
 		Indoor
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Native]
 	public enum INPersonHandleType : nint {
 		Unknown = 0,
@@ -853,8 +853,8 @@ namespace XamCore.Intents {
 		PhoneNumber
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INAccountType : nint {
@@ -868,8 +868,8 @@ namespace XamCore.Intents {
 		Saving,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INActivateCarSignalIntentResponseCode : nint {
@@ -881,8 +881,8 @@ namespace XamCore.Intents {
 		FailureRequiringAppLaunch,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INAmountType : nint {
@@ -898,8 +898,8 @@ namespace XamCore.Intents {
 		StatementBalance,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INBillType : nint {
@@ -928,8 +928,8 @@ namespace XamCore.Intents {
 		Water,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	[Flags]
@@ -938,8 +938,8 @@ namespace XamCore.Intents {
 		Visible = (1 << 1),
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INGetCarLockStatusIntentResponseCode : nint {
@@ -951,8 +951,8 @@ namespace XamCore.Intents {
 		FailureRequiringAppLaunch,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INGetCarPowerLevelStatusIntentResponseCode : nint {
@@ -964,8 +964,8 @@ namespace XamCore.Intents {
 		FailureRequiringAppLaunch,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INPayBillIntentResponseCode : nint {
@@ -979,8 +979,8 @@ namespace XamCore.Intents {
 		FailureInsufficientFunds,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INSearchForBillsIntentResponseCode : nint {
@@ -994,8 +994,8 @@ namespace XamCore.Intents {
 		FailureBillNotFound,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Native]
 	public enum INSetCarLockStatusIntentResponseCode : nint {
@@ -1329,9 +1329,9 @@ namespace XamCore.Intents {
 		SendPayment,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	public enum INIntentIdentifier {
 		[Unavailable (PlatformName.MacOSX)]
 		[Field ("INStartAudioCallIntentIdentifier")]
@@ -1443,9 +1443,9 @@ namespace XamCore.Intents {
 		GetRideStatus
 	}
 
-	[Introduced (PlatformName.iOS, 10, 2)]
-	[Introduced (PlatformName.MacOSX, 10, 12, 2, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 2)]
+	[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	enum INPersonHandleLabel {
 		[Field (null)]
 		None,
@@ -1478,9 +1478,9 @@ namespace XamCore.Intents {
 		Other,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 2)]
-	[Introduced (PlatformName.MacOSX, 10, 12, 2, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 2)]
+	[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	enum INPersonRelationship {
 		[Field (null)]
 		None,
@@ -1519,8 +1519,8 @@ namespace XamCore.Intents {
 		Manager,
 	}
 
-	[Introduced (PlatformName.iOS, 10, 2)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 2)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	enum INWorkoutNameIdentifier {
 		[Field ("INWorkoutNameIdentifierRun")]
@@ -1580,8 +1580,8 @@ namespace XamCore.Intents {
 
 	// End of enums
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Internal]
 	[Category]
@@ -1593,7 +1593,7 @@ namespace XamCore.Intents {
 		CLPlacemark _GetPlacemark (CLLocation location, [NullAllowed] string name, [NullAllowed] CNPostalAddress postalAddress);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntent))]
@@ -1625,7 +1625,7 @@ namespace XamCore.Intents {
 		string GuestProvidedSpecialRequestText { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Protocol]
@@ -1660,7 +1660,7 @@ namespace XamCore.Intents {
 		void ResolveGuestProvidedSpecialRequest (INBookRestaurantReservationIntent intent, Action<INStringResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntentResponse))]
@@ -1676,8 +1676,8 @@ namespace XamCore.Intents {
 		INRestaurantReservationUserBooking UserBooking { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -1710,9 +1710,9 @@ namespace XamCore.Intents {
 		INBooleanResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
 	interface INCallRecordTypeResolutionResult {
@@ -1764,8 +1764,8 @@ namespace XamCore.Intents {
 		INCallRecordTypeResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntent))]
 	interface INCancelWorkoutIntent {
@@ -1778,8 +1778,8 @@ namespace XamCore.Intents {
 		INSpeakableString WorkoutName { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INCancelWorkoutIntentHandling {
@@ -1801,8 +1801,8 @@ namespace XamCore.Intents {
 		void ResolveWorkoutName (INCancelWorkoutIntent intent, Action<INSpeakableStringResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -1816,7 +1816,7 @@ namespace XamCore.Intents {
 		INCancelWorkoutIntentResponseCode Code { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-type! INCarAirCirculationModeResolutionResult bound
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -1864,7 +1864,7 @@ namespace XamCore.Intents {
 		INCarAirCirculationModeResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-type! INCarAudioSourceResolutionResult bound
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -1913,7 +1913,7 @@ namespace XamCore.Intents {
 		INCarAudioSourceResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-type! INCarDefrosterResolutionResult bound
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -1962,7 +1962,7 @@ namespace XamCore.Intents {
 		INCarDefrosterResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-type! INCarSeatResolutionResult bound
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -2011,8 +2011,8 @@ namespace XamCore.Intents {
 		INCarSeatResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -2029,8 +2029,8 @@ namespace XamCore.Intents {
 		string CurrencyCode { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -2067,9 +2067,9 @@ namespace XamCore.Intents {
 		INCurrencyAmountResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface INDateComponentsRange : NSCopying, NSSecureCoding {
@@ -2102,9 +2102,9 @@ namespace XamCore.Intents {
 		EKRecurrenceRule EKRecurrenceRule { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
 	interface INDateComponentsRangeResolutionResult {
@@ -2140,9 +2140,9 @@ namespace XamCore.Intents {
 		INDateComponentsRangeResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Protocol]
 	interface INCallsDomainHandling : INStartAudioCallIntentHandling, INSearchCallHistoryIntentHandling
 #if !WATCH
@@ -2152,36 +2152,36 @@ namespace XamCore.Intents {
 #endif
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INCarCommandsDomainHandling : INActivateCarSignalIntentHandling, INSetCarLockStatusIntentHandling, INGetCarLockStatusIntentHandling, INGetCarPowerLevelStatusIntentHandling {
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INCarPlayDomainHandling : INSetAudioSourceInCarIntentHandling, INSetClimateSettingsInCarIntentHandling, INSetDefrosterSettingsInCarIntentHandling, INSetSeatSettingsInCarIntentHandling, INSetProfileInCarIntentHandling, INSaveProfileInCarIntentHandling {
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INWorkoutsDomainHandling : INStartWorkoutIntentHandling, INPauseWorkoutIntentHandling, INEndWorkoutIntentHandling, INCancelWorkoutIntentHandling, INResumeWorkoutIntentHandling {
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Protocol]
 	interface INRadioDomainHandling : INSetRadioStationIntentHandling {
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INMessagesDomainHandling : INSendMessageIntentHandling, INSearchForMessagesIntentHandling
@@ -2192,8 +2192,8 @@ namespace XamCore.Intents {
 #endif
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol] 
 	interface INPaymentsDomainHandling : INSendPaymentIntentHandling, INRequestPaymentIntentHandling, INPayBillIntentHandling, INSearchForBillsIntentHandling
@@ -2203,15 +2203,15 @@ namespace XamCore.Intents {
 	{
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INPhotosDomainHandling : INSearchForPhotosIntentHandling, INStartPhotoPlaybackIntentHandling {
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INRidesharingDomainHandling : INListRideOptionsIntentHandling, INRequestRideIntentHandling, INGetRideStatusIntentHandling 
@@ -2231,8 +2231,8 @@ namespace XamCore.Intents {
 	interface INVisualCodeDomainHandling : INGetVisualCodeIntentHandling {
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -2265,8 +2265,8 @@ namespace XamCore.Intents {
 		INDoubleResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntentResolutionResult))]
@@ -2303,8 +2303,8 @@ namespace XamCore.Intents {
 		INDateComponentsResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntent))]
 	interface INEndWorkoutIntent {
@@ -2317,8 +2317,8 @@ namespace XamCore.Intents {
 		INSpeakableString WorkoutName { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INEndWorkoutIntentHandling {
@@ -2340,8 +2340,8 @@ namespace XamCore.Intents {
 		void ResolveWorkoutName (INEndWorkoutIntent intent, Action<INSpeakableStringResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -2355,7 +2355,7 @@ namespace XamCore.Intents {
 		INEndWorkoutIntentResponseCode Code { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INIntentHandlerProviding {
@@ -2366,14 +2366,14 @@ namespace XamCore.Intents {
 		NSObject GetHandler (INIntent intent);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (NSObject))]
 	interface INExtension : INIntentHandlerProviding {
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntent))]
@@ -2387,7 +2387,7 @@ namespace XamCore.Intents {
 		INRestaurant Restaurant { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Protocol]
@@ -2410,7 +2410,7 @@ namespace XamCore.Intents {
 		void ResolveAvailableRestaurantReservationBookingDefaults (INGetAvailableRestaurantReservationBookingDefaultsIntent intent, Action<INRestaurantResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntentResponse))]
@@ -2439,7 +2439,7 @@ namespace XamCore.Intents {
 		INGetAvailableRestaurantReservationBookingDefaultsIntentResponseCode Code { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntent))]
@@ -2468,7 +2468,7 @@ namespace XamCore.Intents {
 		NSDate LatestBookingDateForResults { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Protocol]
@@ -2497,7 +2497,7 @@ namespace XamCore.Intents {
 		void ResolvePreferredBookingDateAvailableRestaurantReservationBookings (INGetAvailableRestaurantReservationBookingsIntent intent, Action<INDateComponentsResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntentResponse))]
@@ -2523,14 +2523,14 @@ namespace XamCore.Intents {
 		INRestaurantReservationBooking [] AvailableBookings { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntent))]
 	interface INGetRestaurantGuestIntent {
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Protocol]
@@ -2550,7 +2550,7 @@ namespace XamCore.Intents {
 		(INGetRestaurantGuestIntent guestIntent, Action<INGetRestaurantGuestIntentResponse> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntentResponse))]
@@ -2570,8 +2570,8 @@ namespace XamCore.Intents {
 		INGetRestaurantGuestIntentResponseCode Code { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntent))]
 	[DisableDefaultCtor] // DesignatedInitializer below
@@ -2582,8 +2582,8 @@ namespace XamCore.Intents {
 		IntPtr Constructor ();
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INGetRideStatusIntentHandling {
@@ -2612,8 +2612,8 @@ namespace XamCore.Intents {
 
 	interface IINGetRideStatusIntentResponseObserver { }
 	
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INGetRideStatusIntentResponseObserver {
@@ -2623,8 +2623,8 @@ namespace XamCore.Intents {
 		void DidUpdateRideStatus (INGetRideStatusIntentResponse response);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -2641,7 +2641,7 @@ namespace XamCore.Intents {
 		INRideStatus RideStatus { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntent))]
@@ -2668,7 +2668,7 @@ namespace XamCore.Intents {
 		NSDate EarliestBookingDateForResults { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Protocol]
@@ -2691,7 +2691,7 @@ namespace XamCore.Intents {
 		void ResolveUserCurrentRestaurantReservationBookings (INGetUserCurrentRestaurantReservationBookingsIntent intent, Action<INRestaurantResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntentResponse))]
@@ -2708,9 +2708,9 @@ namespace XamCore.Intents {
 		INRestaurantReservationUserBooking [] UserCurrentBookings { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface INImage : NSCopying, NSSecureCoding {
@@ -2757,8 +2757,8 @@ namespace XamCore.Intents {
 		void FetchImage (Action<UIImage> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -2791,9 +2791,9 @@ namespace XamCore.Intents {
 		INIntegerResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Abstract]
 	[BaseType (typeof (NSObject))]
 	interface INIntent : NSCopying, NSSecureCoding {
@@ -2812,9 +2812,9 @@ namespace XamCore.Intents {
 
 	interface INIntentResolutionResult<ObjectType> : INIntentResolutionResult { }
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Abstract]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -2836,9 +2836,9 @@ namespace XamCore.Intents {
 		//INIntentResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Abstract]
 	[BaseType (typeof (NSObject))]
 	interface INIntentResponse : NSCopying, NSSecureCoding {
@@ -2847,9 +2847,9 @@ namespace XamCore.Intents {
 		NSUserActivity UserActivity { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface INInteraction : NSSecureCoding, NSCopying {
@@ -2906,8 +2906,8 @@ namespace XamCore.Intents {
 		IntPtr _GetParameterValue (INParameter parameter);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntent))]
 	interface INListRideOptionsIntent {
@@ -2923,8 +2923,8 @@ namespace XamCore.Intents {
 		CLPlacemark DropOffLocation { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INListRideOptionsIntentHandling {
@@ -2949,8 +2949,8 @@ namespace XamCore.Intents {
 		void ResolveDropOffLocation (INListRideOptionsIntent intent, Action<INPlacemarkResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -2973,9 +2973,9 @@ namespace XamCore.Intents {
 		NSDate ExpirationDate { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface INMessage : NSCopying, NSSecureCoding {
@@ -3020,9 +3020,9 @@ namespace XamCore.Intents {
 		INMessageType MessageType { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
 	interface INMessageAttributeOptionsResolutionResult {
@@ -3074,9 +3074,9 @@ namespace XamCore.Intents {
 		INMessageAttributeOptionsResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
 	interface INMessageAttributeResolutionResult {
@@ -3088,9 +3088,9 @@ namespace XamCore.Intents {
 		INMessageAttributeResolutionResult SuccessWithResolvedMessageAttribute (INMessageAttribute resolvedMessageAttribute);
 
 		[Internal]
-		[Introduced (PlatformName.MacOSX, 10, 12)]
-		[Introduced (PlatformName.WatchOS, 3, 2)]
-		[Introduced (PlatformName.iOS, 10, 0)]
+		[Mac (10, 12)]
+		[Watch (3, 2)]
+		[iOS (10, 0)]
 		[Static]
 		[Export ("successWithResolvedValue:")]
 		INMessageAttributeResolutionResult SuccessWithResolvedValue (INMessageAttribute resolvedValue);
@@ -3128,8 +3128,8 @@ namespace XamCore.Intents {
 		INMessageAttributeResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntent))]
 	interface INPauseWorkoutIntent {
@@ -3142,8 +3142,8 @@ namespace XamCore.Intents {
 		INSpeakableString WorkoutName { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INPauseWorkoutIntentHandling {
@@ -3165,8 +3165,8 @@ namespace XamCore.Intents {
 		void ResolveWorkoutName (INPauseWorkoutIntent intent, Action<INSpeakableStringResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -3180,8 +3180,8 @@ namespace XamCore.Intents {
 		INPauseWorkoutIntentResponseCode Code { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3208,8 +3208,8 @@ namespace XamCore.Intents {
 		INPaymentMethod ApplePayPaymentMethod { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3244,9 +3244,9 @@ namespace XamCore.Intents {
 		INCurrencyAmount FeeAmount { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface INPerson : NSCopying, NSSecureCoding, INSpeakable {
@@ -3273,13 +3273,13 @@ namespace XamCore.Intents {
 		[NullAllowed, Export ("customIdentifier")]
 		string CustomIdentifier { get; }
 
-		[Introduced (PlatformName.iOS, 10, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 12, 2, PlatformArchitecture.Arch64)]
+		[iOS (10, 0)]
+		[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
 		[NullAllowed, Export ("relationship"), Protected]
 		NSString WeakRelationship { get; }
 
-		[Introduced (PlatformName.iOS, 10, 0)]
-		[Introduced (PlatformName.MacOSX, 10, 12, 2, PlatformArchitecture.Arch64)]
+		[iOS (10, 0)]
+		[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
 		[Wrap ("INPersonRelationshipExtensions.GetValue (WeakRelationship)")]
 		INPersonRelationship Relationship { get; }
 
@@ -3296,7 +3296,7 @@ namespace XamCore.Intents {
 
 		// Inlined from INInteraction (INPerson) Category
 
-		[Introduced (PlatformName.iOS, 10, 3)]
+		[iOS (10, 3)]
 		[Unavailable (PlatformName.MacOSX)]
 		[Export ("siriMatches", ArgumentSemantic.Copy), NullAllowed]
 		INPerson [] SiriMatches { get; }
@@ -3306,9 +3306,9 @@ namespace XamCore.Intents {
 		bool IsMe { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface INPersonHandle : NSCopying, NSSecureCoding {
@@ -3319,24 +3319,24 @@ namespace XamCore.Intents {
 		[Export ("type")]
 		INPersonHandleType Type { get; }
 
-		[Introduced (PlatformName.iOS, 10, 2)]
-		[Introduced (PlatformName.MacOSX, 10, 12, 2, PlatformArchitecture.Arch64)]
+		[iOS (10, 2)]
+		[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
 		[Export ("label"), NullAllowed, Protected]
 		NSString WeakLabel { get; }
 
-		[Introduced (PlatformName.iOS, 10, 2)]
-		[Introduced (PlatformName.MacOSX, 10, 12, 2, PlatformArchitecture.Arch64)]
+		[iOS (10, 2)]
+		[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
 		[Wrap ("INPersonHandleLabelExtensions.GetValue (WeakLabel)")]
 		INPersonHandleLabel Label { get; }
 
-		[Introduced (PlatformName.iOS, 10, 2)]
-		[Introduced (PlatformName.MacOSX, 10, 12, 2, PlatformArchitecture.Arch64)]
+		[iOS (10, 2)]
+		[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
 		[Wrap ("this (value, type, label.GetConstant ())")]
 		IntPtr Constructor (string value, INPersonHandleType type, INPersonHandleLabel label);
 
 		[DesignatedInitializer]
-		[Introduced (PlatformName.iOS, 10, 2)]
-		[Introduced (PlatformName.MacOSX, 10, 12, 2, PlatformArchitecture.Arch64)]
+		[iOS (10, 2)]
+		[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
 		[Export ("initWithValue:type:label:"), Protected]
 		IntPtr Constructor ([NullAllowed] string value, INPersonHandleType type, [NullAllowed] NSString stringLabel);
 
@@ -3344,9 +3344,9 @@ namespace XamCore.Intents {
 		IntPtr Constructor ([NullAllowed] string value, INPersonHandleType type);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
 	interface INPersonResolutionResult {
@@ -3382,9 +3382,9 @@ namespace XamCore.Intents {
 		INPersonResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
 	interface INPlacemarkResolutionResult {
@@ -3420,8 +3420,8 @@ namespace XamCore.Intents {
 		INPlacemarkResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 #if XAMCORE_4_0
 	[DisableDefaultCtor]
@@ -3445,8 +3445,8 @@ namespace XamCore.Intents {
 		string SiriLanguageCode { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3477,7 +3477,7 @@ namespace XamCore.Intents {
 		string CurrencyCode { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-type! INRadioTypeResolutionResult bound
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -3526,7 +3526,7 @@ namespace XamCore.Intents {
 		INRadioTypeResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -3575,7 +3575,7 @@ namespace XamCore.Intents {
 		INRelativeReferenceResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -3624,8 +3624,8 @@ namespace XamCore.Intents {
 		INRelativeSettingResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntent))]
 	interface INRequestPaymentIntent {
@@ -3644,8 +3644,8 @@ namespace XamCore.Intents {
 		string Note { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INRequestPaymentIntentHandling {
@@ -3685,8 +3685,8 @@ namespace XamCore.Intents {
 		void ResolveNote (INRequestPaymentIntent intent, Action<INStringResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -3703,8 +3703,8 @@ namespace XamCore.Intents {
 		INPaymentRecord PaymentRecord { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntent))]
 	interface INRequestRideIntent {
@@ -3714,7 +3714,7 @@ namespace XamCore.Intents {
 		[Export ("initWithPickupLocation:dropOffLocation:rideOptionName:partySize:paymentMethod:")]
 		IntPtr Constructor ([NullAllowed] CLPlacemark pickupLocation, [NullAllowed] CLPlacemark dropOffLocation, [NullAllowed] INSpeakableString rideOptionName, [NullAllowed] NSNumber partySize, [NullAllowed] INPaymentMethod paymentMethod);
 
-		[Introduced (PlatformName.iOS, 10, 3)]
+		[iOS (10, 3)]
 		[Export ("initWithPickupLocation:dropOffLocation:rideOptionName:partySize:paymentMethod:scheduledPickupTime:")]
 		[DesignatedInitializer]
 		IntPtr Constructor ([NullAllowed] CLPlacemark pickupLocation, [NullAllowed] CLPlacemark dropOffLocation, [NullAllowed] INSpeakableString rideOptionName, [NullAllowed] NSNumber partySize, [NullAllowed] INPaymentMethod paymentMethod, [NullAllowed] INDateComponentsRange scheduledPickupTime);
@@ -3734,13 +3734,13 @@ namespace XamCore.Intents {
 		[NullAllowed, Export ("paymentMethod", ArgumentSemantic.Copy)]
 		INPaymentMethod PaymentMethod { get; }
 
-		[Introduced (PlatformName.iOS, 10, 3)]
+		[iOS (10, 3)]
 		[NullAllowed, Export ("scheduledPickupTime", ArgumentSemantic.Copy)]
 		INDateComponentsRange ScheduledPickupTime { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INRequestRideIntentHandling {
@@ -3770,13 +3770,13 @@ namespace XamCore.Intents {
 		[Export ("resolvePartySizeForRequestRide:withCompletion:")]
 		void ResolvePartySize (INRequestRideIntent intent, Action<INIntegerResolutionResult> completion);
 
-		[Introduced (PlatformName.iOS, 10, 3)]
+		[iOS (10, 3)]
 		[Export ("resolveScheduledPickupTimeForRequestRide:withCompletion:")]
 		void ResolveScheduledPickupTime (INRequestRideIntent intent, Action<INDateComponentsRangeResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -3793,7 +3793,7 @@ namespace XamCore.Intents {
 		INRideStatus RideStatus { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (NSObject))]
@@ -3816,7 +3816,7 @@ namespace XamCore.Intents {
 		string RestaurantIdentifier { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INPerson))]
@@ -3834,7 +3834,7 @@ namespace XamCore.Intents {
 		string EmailAddress { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (NSObject))]
@@ -3865,7 +3865,7 @@ namespace XamCore.Intents {
 		bool PhoneNumberEditable { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[DisableDefaultCtor]
@@ -3903,7 +3903,7 @@ namespace XamCore.Intents {
 		INRestaurantGuestResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (NSObject))]
@@ -3919,7 +3919,7 @@ namespace XamCore.Intents {
 		string OfferIdentifier { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (NSObject))]
@@ -3963,7 +3963,7 @@ namespace XamCore.Intents {
 		bool RequiresPhoneNumber { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INRestaurantReservationBooking))]
@@ -3995,7 +3995,7 @@ namespace XamCore.Intents {
 		NSDate DateStatusModified { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[DisableDefaultCtor]
@@ -4033,8 +4033,8 @@ namespace XamCore.Intents {
 		INRestaurantResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntent))]
 	interface INResumeWorkoutIntent {
@@ -4047,8 +4047,8 @@ namespace XamCore.Intents {
 		INSpeakableString WorkoutName { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INResumeWorkoutIntentHandling {
@@ -4070,8 +4070,8 @@ namespace XamCore.Intents {
 		void ResolveWorkoutName (INResumeWorkoutIntent intent, Action<INSpeakableStringResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -4085,8 +4085,8 @@ namespace XamCore.Intents {
 		INResumeWorkoutIntentResponseCode Code { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -4148,8 +4148,8 @@ namespace XamCore.Intents {
 		NSSet<INCurrencyAmount> DefaultTippingOptions { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-type! INRideDriver bound
 	[BaseType (typeof (INPerson))]
 	[DisableDefaultCtor] // xcode 8.2 beta 1 -> NSInvalidArgumentException Reason: *** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[1]
@@ -4161,7 +4161,7 @@ namespace XamCore.Intents {
 		IntPtr Constructor (INPersonHandle personHandle, [NullAllowed] NSPersonNameComponents nameComponents, [NullAllowed] string displayName, [NullAllowed] INImage image, [NullAllowed] string rating, [NullAllowed] string phoneNumber);
 
 		[Export ("initWithPhoneNumber:nameComponents:displayName:image:rating:")]
-		[Introduced (PlatformName.iOS, 10,2)]
+		[iOS (10,2)]
 		[DesignatedInitializer]
 		IntPtr Constructor (string phoneNumber, [NullAllowed] NSPersonNameComponents nameComponents, [NullAllowed] string displayName, [NullAllowed] INImage image, [NullAllowed] string rating);
 
@@ -4172,8 +4172,8 @@ namespace XamCore.Intents {
 		string PhoneNumber { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -4193,8 +4193,8 @@ namespace XamCore.Intents {
 		string CurrencyCode { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -4239,8 +4239,8 @@ namespace XamCore.Intents {
 		NSUserActivity UserActivityForBookingInApplication { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -4260,8 +4260,8 @@ namespace XamCore.Intents {
 		INPriceRange PriceRange { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // xcode 8.2 beta 1 -> NSInvalidArgumentException Reason: *** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[1]
@@ -4291,8 +4291,8 @@ namespace XamCore.Intents {
 		[NullAllowed, Export ("estimatedPickupEndDate", ArgumentSemantic.Copy)]
 		NSDate EstimatedPickupEndDate { get; set; }
 
-		[Introduced (PlatformName.iOS, 10, 3)]
-		[Introduced (PlatformName.WatchOS, 3, 2)]
+		[iOS (10, 3)]
+		[Watch (3, 2)]
 		[NullAllowed, Export ("scheduledPickupTime", ArgumentSemantic.Copy)]
 		INDateComponentsRange ScheduledPickupTime { get; set; }
 
@@ -4315,8 +4315,8 @@ namespace XamCore.Intents {
 		NSUserActivity [] AdditionalActionActivities { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (NSObject))]
 	interface INRideVehicle : NSCopying, NSSecureCoding {
@@ -4337,7 +4337,7 @@ namespace XamCore.Intents {
 		INImage MapAnnotationImage { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntent))]
@@ -4347,7 +4347,7 @@ namespace XamCore.Intents {
 		[Export ("initWithProfileNumber:profileLabel:"), Internal]
 		IntPtr InitWithProfileNumberLabel ([NullAllowed] NSNumber profileNumber, [NullAllowed] string profileLabel);
 
-		[Introduced (PlatformName.iOS, 10, 2)]
+		[iOS (10, 2)]
 		[Export ("initWithProfileNumber:profileName:"), Internal]
 		IntPtr InitWithProfileNumberName ([NullAllowed] NSNumber profileNumber, [NullAllowed] string profileName);
 
@@ -4358,12 +4358,12 @@ namespace XamCore.Intents {
 		[NullAllowed, Export ("profileLabel")]
 		string ProfileLabel { get; }
 
-		[Introduced (PlatformName.iOS, 10, 2)]
+		[iOS (10, 2)]
 		[NullAllowed, Export ("profileName")]
 		string ProfileName { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Protocol]
@@ -4385,12 +4385,12 @@ namespace XamCore.Intents {
 		[Export ("resolveProfileNumberForSaveProfileInCar:withCompletion:")]
 		void ResolveProfileNumber (INSaveProfileInCarIntent intent, Action<INIntegerResolutionResult> completion);
 
-		[Introduced (PlatformName.iOS, 10, 2)]
+		[iOS (10, 2)]
 		[Export ("resolveProfileNameForSaveProfileInCar:withCompletion:")]
 		void ResolveProfileName (INSaveProfileInCarIntent intent, Action<INStringResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntentResponse))]
@@ -4405,9 +4405,9 @@ namespace XamCore.Intents {
 		INSaveProfileInCarIntentResponseCode Code { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (INIntent))]
 	interface INSearchCallHistoryIntent {
 
@@ -4451,9 +4451,9 @@ namespace XamCore.Intents {
 		NSNumber WeakUnseen { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Protocol]
 	interface INSearchCallHistoryIntentHandling {
 
@@ -4491,9 +4491,9 @@ namespace XamCore.Intents {
 		void ResolveUnseen (INSearchCallHistoryIntent intent, Action<INBooleanResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
 	interface INSearchCallHistoryIntentResponse {
@@ -4510,9 +4510,9 @@ namespace XamCore.Intents {
 		INCallRecord [] CallRecords { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (INIntent))]
 	interface INSearchForMessagesIntent {
 
@@ -4584,9 +4584,9 @@ namespace XamCore.Intents {
 		INConditionalOperator SpeakableGroupNamesOperator { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Protocol]
 	interface INSearchForMessagesIntentHandling {
 		
@@ -4626,9 +4626,9 @@ namespace XamCore.Intents {
 		void ResolveSpeakableGroupNames (INSearchForMessagesIntent intent, Action<INSpeakableStringResolutionResult []> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
 	interface INSearchForMessagesIntentResponse {
@@ -4644,8 +4644,8 @@ namespace XamCore.Intents {
 		INMessage [] Messages { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntent))]
 	interface INSearchForPhotosIntent {
@@ -4682,8 +4682,8 @@ namespace XamCore.Intents {
 		INConditionalOperator PeopleInPhotoOperator { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INSearchForPhotosIntentHandling {
@@ -4718,8 +4718,8 @@ namespace XamCore.Intents {
 		void ResolvePeopleInPhoto (INSearchForPhotosIntent intent, Action<INPersonResolutionResult []> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -4736,9 +4736,9 @@ namespace XamCore.Intents {
 		NSNumber SearchResultsCount { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (INIntent))]
 	interface INSendMessageIntent {
 
@@ -4780,9 +4780,9 @@ namespace XamCore.Intents {
 		INPerson Sender { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Protocol]
 	interface INSendMessageIntentHandling {
 
@@ -4823,9 +4823,9 @@ namespace XamCore.Intents {
 		void ResolveSpeakableGroupName (INSendMessageIntent intent, Action<INSpeakableStringResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
 	interface INSendMessageIntentResponse {
@@ -4842,8 +4842,8 @@ namespace XamCore.Intents {
 		INMessage SentMessage { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntent))]
 	interface INSendPaymentIntent {
@@ -4862,8 +4862,8 @@ namespace XamCore.Intents {
 		string Note { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INSendPaymentIntentHandling {
@@ -4903,8 +4903,8 @@ namespace XamCore.Intents {
 		void ResolveNote (INSendPaymentIntent intent, Action<INStringResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -4921,7 +4921,7 @@ namespace XamCore.Intents {
 		INPaymentRecord PaymentRecord { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntent))]
@@ -4938,7 +4938,7 @@ namespace XamCore.Intents {
 		INRelativeReference RelativeAudioSourceReference { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Protocol]
@@ -4964,7 +4964,7 @@ namespace XamCore.Intents {
 		void ResolveRelativeAudioSourceReference (INSetAudioSourceInCarIntent intent, Action<INRelativeReferenceResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntentResponse))]
@@ -4983,7 +4983,7 @@ namespace XamCore.Intents {
 	// binding files. The lack of namespace will generate the correct code for the C# compiler
 	interface NSUnitTemperature : NSUnit {}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntent))]
@@ -5032,7 +5032,7 @@ namespace XamCore.Intents {
 		INCarSeat ClimateZone { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Protocol]
@@ -5085,7 +5085,7 @@ namespace XamCore.Intents {
 		void ResolveClimateZone (INSetClimateSettingsInCarIntent intent, Action<INCarSeatResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntentResponse))]
@@ -5100,7 +5100,7 @@ namespace XamCore.Intents {
 		INSetClimateSettingsInCarIntentResponseCode Code { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntent))]
@@ -5119,7 +5119,7 @@ namespace XamCore.Intents {
 		INCarDefroster Defroster { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Protocol]
@@ -5145,7 +5145,7 @@ namespace XamCore.Intents {
 		void ResolveDefroster (INSetDefrosterSettingsInCarIntent intent, Action<INCarDefrosterResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntentResponse))]
@@ -5160,7 +5160,7 @@ namespace XamCore.Intents {
 		INSetDefrosterSettingsInCarIntentResponseCode Code { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntent))]
@@ -5177,7 +5177,7 @@ namespace XamCore.Intents {
 		INMessageAttribute Attribute { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Protocol]
@@ -5200,7 +5200,7 @@ namespace XamCore.Intents {
 		void ResolveAttribute (INSetMessageAttributeIntent intent, Action<INMessageAttributeResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntentResponse))]
@@ -5215,7 +5215,7 @@ namespace XamCore.Intents {
 		INSetMessageAttributeIntentResponseCode Code { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntent))]
@@ -5225,7 +5225,7 @@ namespace XamCore.Intents {
 		[Export ("initWithProfileNumber:profileLabel:defaultProfile:"), Internal]
 		IntPtr InitWithProfileNumberLabel ([NullAllowed] NSNumber profileNumber, [NullAllowed] string profileLabel, [NullAllowed] NSNumber defaultProfile);
 
-		[Introduced (PlatformName.iOS, 10, 2)]
+		[iOS (10, 2)]
 		[Export ("initWithProfileNumber:profileName:defaultProfile:"), Internal]
 		IntPtr InitWithProfileNumberName ([NullAllowed] NSNumber profileNumber, [NullAllowed] string profileName, [NullAllowed] NSNumber defaultProfile);
 
@@ -5236,7 +5236,7 @@ namespace XamCore.Intents {
 		[NullAllowed, Export ("profileLabel")]
 		string ProfileLabel { get; }
 
-		[Introduced (PlatformName.iOS, 10, 2)]
+		[iOS (10, 2)]
 		[NullAllowed, Export ("profileName")]
 		string ProfileName { get; }
 
@@ -5245,7 +5245,7 @@ namespace XamCore.Intents {
 		NSNumber _DefaultProfile { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Protocol]
@@ -5271,12 +5271,12 @@ namespace XamCore.Intents {
 		[Export ("resolveDefaultProfileForSetProfileInCar:withCompletion:")]
 		void ResolveDefaultProfile (INSetProfileInCarIntent intent, Action<INBooleanResolutionResult> completion);
 
-		[Introduced (PlatformName.iOS, 10, 2)]
+		[iOS (10, 2)]
 		[Export ("resolveProfileNameForSetProfileInCar:withCompletion:")]
 		void ResolveProfileName (INSetProfileInCarIntent intent, Action<INStringResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntentResponse))]
@@ -5291,7 +5291,7 @@ namespace XamCore.Intents {
 		INSetProfileInCarIntentResponseCode Code { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntent))]
@@ -5317,7 +5317,7 @@ namespace XamCore.Intents {
 		NSNumber PresetNumber { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Protocol]
@@ -5352,7 +5352,7 @@ namespace XamCore.Intents {
 		void ResolvePresetNumber (INSetRadioStationIntent intent, Action<INIntegerResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntentResponse))]
@@ -5367,7 +5367,7 @@ namespace XamCore.Intents {
 		INSetRadioStationIntentResponseCode Code { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntent))]
@@ -5400,7 +5400,7 @@ namespace XamCore.Intents {
 		INRelativeSetting RelativeLevelSetting { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Protocol]
@@ -5438,7 +5438,7 @@ namespace XamCore.Intents {
 		void ResolveRelativeLevelSetting (INSetSeatSettingsInCarIntent intent, Action<INRelativeSettingResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntentResponse))]
@@ -5455,9 +5455,9 @@ namespace XamCore.Intents {
 
 	interface IINSpeakable { }
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Protocol]
 	interface INSpeakable {
 
@@ -5493,9 +5493,9 @@ namespace XamCore.Intents {
 		string Identifier { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface INSpeakableString : INSpeakable {
@@ -5509,15 +5509,15 @@ namespace XamCore.Intents {
 		[Export ("initWithIdentifier:spokenPhrase:pronunciationHint:")]
 		IntPtr InitWithIdentifier (string identifier, string spokenPhrase, [NullAllowed] string pronunciationHint);
 
-		[Introduced (PlatformName.iOS, 10, 2)]
-		[Introduced (PlatformName.MacOSX, 10, 12, 2, PlatformArchitecture.Arch64)]
+		[iOS (10, 2)]
+		[Mac (10, 12, 2, PlatformArchitecture.Arch64)]
 		[Export ("initWithSpokenPhrase:")]
 		IntPtr Constructor (string spokenPhrase);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
 	interface INSpeakableStringResolutionResult {
@@ -5553,9 +5553,9 @@ namespace XamCore.Intents {
 		INSpeakableStringResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (INIntent))]
 	interface INStartAudioCallIntent {
 
@@ -5578,9 +5578,9 @@ namespace XamCore.Intents {
 		INPerson [] Contacts { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Protocol]
 	interface INStartAudioCallIntentHandling {
 
@@ -5605,9 +5605,9 @@ namespace XamCore.Intents {
 		void ResolveContacts (INStartAudioCallIntent intent, Action<INPersonResolutionResult []> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
 	interface INStartAudioCallIntentResponse {
@@ -5620,8 +5620,8 @@ namespace XamCore.Intents {
 		INStartAudioCallIntentResponseCode Code { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntent))]
 	interface INStartPhotoPlaybackIntent {
@@ -5658,8 +5658,8 @@ namespace XamCore.Intents {
 		INConditionalOperator PeopleInPhotoOperator { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INStartPhotoPlaybackIntentHandling {
@@ -5690,8 +5690,8 @@ namespace XamCore.Intents {
 		void ResolvePeopleInPhoto (INStartPhotoPlaybackIntent intent, Action<INPersonResolutionResult []> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -5708,8 +5708,8 @@ namespace XamCore.Intents {
 		NSNumber SearchResultsCount { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntent))]
 	interface INStartVideoCallIntent {
@@ -5722,8 +5722,8 @@ namespace XamCore.Intents {
 		INPerson [] Contacts { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Protocol]
 	interface INStartVideoCallIntentHandling {
@@ -5745,8 +5745,8 @@ namespace XamCore.Intents {
 		void ResolveContacts (INStartVideoCallIntent intent, Action<INPersonResolutionResult []> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -5760,8 +5760,8 @@ namespace XamCore.Intents {
 		INStartVideoCallIntentResponseCode Code { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntent))]
 	interface INStartWorkoutIntent {
@@ -5788,8 +5788,8 @@ namespace XamCore.Intents {
 		NSNumber _IsOpenEnded { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INStartWorkoutIntentHandling {
@@ -5823,8 +5823,8 @@ namespace XamCore.Intents {
 		void ResolveIsOpenEnded (INStartWorkoutIntent intent, Action<INBooleanResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -5838,9 +5838,9 @@ namespace XamCore.Intents {
 		INStartWorkoutIntentResponseCode Code { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntentResolutionResult))]
 	interface INStringResolutionResult {
@@ -5876,8 +5876,8 @@ namespace XamCore.Intents {
 		INStringResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntentResolutionResult))]
@@ -5914,7 +5914,7 @@ namespace XamCore.Intents {
 		INTemperatureResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (NSObject))]
@@ -5934,7 +5934,7 @@ namespace XamCore.Intents {
 		NSUrl TermsAndConditionsUrl { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (NSObject))]
@@ -5959,8 +5959,8 @@ namespace XamCore.Intents {
 		void RemoveAllVocabularyStrings ();
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-type! INWorkoutGoalUnitTypeResolutionResult bound
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntentResolutionResult))]
@@ -6011,8 +6011,8 @@ namespace XamCore.Intents {
 		INWorkoutGoalUnitTypeResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)] // xtro mac !unknown-type! INWorkoutLocationTypeResolutionResult bound
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntentResolutionResult))]
@@ -6063,9 +6063,9 @@ namespace XamCore.Intents {
 		INWorkoutLocationTypeResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.MacOSX, 10, 12, PlatformArchitecture.Arch64)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 0)]
+	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Watch (3, 2)]
 	[Category]
 	[BaseType (typeof (NSUserActivity))]
 	interface NSUserActivity_IntentsAdditions {
@@ -6074,8 +6074,8 @@ namespace XamCore.Intents {
 		INInteraction GetInteraction ();
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntent))]
@@ -6092,8 +6092,8 @@ namespace XamCore.Intents {
 		INCarSignalOptions Signals { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INActivateCarSignalIntentHandling {
@@ -6118,8 +6118,8 @@ namespace XamCore.Intents {
 		void ResolveSignals (INActivateCarSignalIntent intent, Action<INCarSignalOptionsResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
@@ -6154,8 +6154,8 @@ namespace XamCore.Intents {
 		NSDateComponents PaymentDate { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
@@ -6175,8 +6175,8 @@ namespace XamCore.Intents {
 		INSpeakableString OrganizationName { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -6213,8 +6213,8 @@ namespace XamCore.Intents {
 		INBillPayeeResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -6265,8 +6265,8 @@ namespace XamCore.Intents {
 		INBillTypeResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -6317,8 +6317,8 @@ namespace XamCore.Intents {
 		INCarSignalOptionsResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntent))]
@@ -6332,8 +6332,8 @@ namespace XamCore.Intents {
 		INSpeakableString CarName { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INGetCarLockStatusIntentHandling {
@@ -6355,8 +6355,8 @@ namespace XamCore.Intents {
 		void ResolveCarName (INGetCarLockStatusIntent intent, Action<INSpeakableStringResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntentResponse))]
@@ -6377,8 +6377,8 @@ namespace XamCore.Intents {
 		NSNumber _Locked { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntent))]
@@ -6392,8 +6392,8 @@ namespace XamCore.Intents {
 		INSpeakableString CarName { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INGetCarPowerLevelStatusIntentHandling {
@@ -6418,8 +6418,8 @@ namespace XamCore.Intents {
 	// Just to please the generator that at this point does not know the hierarchy
 	interface NSUnitLength : NSUnit { }
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntentResponse))]
@@ -6450,8 +6450,8 @@ namespace XamCore.Intents {
 		NSMeasurement<NSUnitLength> DistanceRemaining { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntent))]
@@ -6483,8 +6483,8 @@ namespace XamCore.Intents {
 		INDateComponentsRange DueDate { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INPayBillIntentHandling {
@@ -6526,8 +6526,8 @@ namespace XamCore.Intents {
 		void ResolveDueDate (INPayBillIntent intent, Action<INDateComponentsRangeResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntentResponse))]
@@ -6556,8 +6556,8 @@ namespace XamCore.Intents {
 		string TransactionNote { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
@@ -6594,8 +6594,8 @@ namespace XamCore.Intents {
 		INBalanceAmount SecondaryBalance { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -6632,8 +6632,8 @@ namespace XamCore.Intents {
 		INPaymentAccountResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
@@ -6650,8 +6650,8 @@ namespace XamCore.Intents {
 		INAmountType AmountType { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -6688,8 +6688,8 @@ namespace XamCore.Intents {
 		INPaymentAmountResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -6740,8 +6740,8 @@ namespace XamCore.Intents {
 		INPaymentStatusResolutionResult Unsupported { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntent))]
@@ -6767,8 +6767,8 @@ namespace XamCore.Intents {
 		INDateComponentsRange DueDateRange { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INSearchForBillsIntentHandling {
@@ -6804,8 +6804,8 @@ namespace XamCore.Intents {
 		void ResolveDueDateRange (INSearchForBillsIntent intent, Action<INDateComponentsRangeResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntentResponse))]
@@ -6822,8 +6822,8 @@ namespace XamCore.Intents {
 		INBillDetails [] Bills { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntent))]
@@ -6845,8 +6845,8 @@ namespace XamCore.Intents {
 		INSpeakableString CarName { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Protocol]
 	interface INSetCarLockStatusIntentHandling {
@@ -6871,8 +6871,8 @@ namespace XamCore.Intents {
 		void ResolveCarName (INSetCarLockStatusIntent intent, Action<INSpeakableStringResolutionResult> completion);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntentResponse))]
@@ -6886,8 +6886,8 @@ namespace XamCore.Intents {
 		INSetCarLockStatusIntentResponseCode Code { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 3)]
-	[Introduced (PlatformName.WatchOS, 3, 2)]
+	[iOS (10, 3)]
+	[Watch (3, 2)]
 	[Unavailable (PlatformName.MacOSX)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntentResponse))]

--- a/src/intentsui.cs
+++ b/src/intentsui.cs
@@ -18,7 +18,7 @@ using XamCore.UIKit;
 
 namespace XamCore.IntentsUI {
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Native]
 	public enum INUIHostedViewContext : nuint {
 		SiriSnippet,
@@ -37,7 +37,7 @@ namespace XamCore.IntentsUI {
 	[iOS (11,0)]
 	delegate void INUIHostedViewControllingConfigureViewHandler (bool success, NSSet<INParameter> configuredParameters, CGSize desiredSize);
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Protocol]
 	interface INUIHostedViewControlling {
 
@@ -52,7 +52,7 @@ namespace XamCore.IntentsUI {
 		void ConfigureView (NSSet<INParameter> parameters, INInteraction interaction, INUIInteractiveBehavior interactiveBehavior, INUIHostedViewContext context, INUIHostedViewControllingConfigureViewHandler completionHandler);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Category]
 	[BaseType (typeof (NSExtensionContext))]
 	interface NSExtensionContext_INUIHostedViewControlling {
@@ -68,7 +68,7 @@ namespace XamCore.IntentsUI {
 		string GetInterfaceParametersDescription ();
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Protocol]
 	interface INUIHostedViewSiriProviding {
 

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -82,7 +82,7 @@ namespace XamCore.MapKit {
 		// optional, not implemented by MKPolygon, MKPolyline and MKCircle
 		// implemented by MKTileOverlay (and defined there)
 		[OptionalImplementation]
-		[Since (7,0), Export ("canReplaceMapContent")]
+		[iOS (7,0), Export ("canReplaceMapContent")]
 		bool CanReplaceMapContent { get; }
 #endif
 	}
@@ -154,17 +154,17 @@ namespace XamCore.MapKit {
 		UIView RightCalloutAccessoryView { get; set; }
 	
 		[NoTV]
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("setDragState:animated:")]
 		void SetDragState (MKAnnotationViewDragState newDragState, bool animated);
 
 		[Export ("dragState")]
 		[NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		MKAnnotationViewDragState DragState { get; set;  }
 
 		[NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("draggable")]
 		bool Draggable { [Bind ("isDraggable")] get; set;  }
 
@@ -205,7 +205,7 @@ namespace XamCore.MapKit {
 
 	[ThreadSafe]
 	[TV (9,2)]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Mac (10,9, onlyOn64 : true)]
 	[BaseType (typeof (MKShape))]
 	interface MKCircle : MKOverlay {
@@ -244,17 +244,17 @@ namespace XamCore.MapKit {
 #endif
 	
 	[TV (9,2)]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[Mac (10,9, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	interface MKDirectionsRequest {
 		[NullAllowed] // by default this property is null
 		[Export ("destination")]
-		MKMapItem Destination { get; [Since (7,0)] set; }
+		MKMapItem Destination { get; [iOS (7,0)] set; }
 
 		[NullAllowed] // by default this property is null
 		[Export ("source")]
-		MKMapItem Source { get; [Since (7,0)] set; }
+		MKMapItem Source { get; [iOS (7,0)] set; }
 
 		[Export ("initWithContentsOfURL:")]
 		IntPtr Constructor (NSUrl url);
@@ -263,24 +263,24 @@ namespace XamCore.MapKit {
 		[Export ("isDirectionsRequestURL:")]
 		bool IsDirectionsRequestUrl (NSUrl url);
 
-		[Since (7,0), Export ("transportType")]
+		[iOS (7,0), Export ("transportType")]
 		MKDirectionsTransportType TransportType { get; set; }
 
-		[Since (7,0), Export ("requestsAlternateRoutes")]
+		[iOS (7,0), Export ("requestsAlternateRoutes")]
 		bool RequestsAlternateRoutes { get; set; }
 
 		[NullAllowed] // by default this property is null
-		[Since (7,0), Export ("departureDate", ArgumentSemantic.Copy)]
+		[iOS (7,0), Export ("departureDate", ArgumentSemantic.Copy)]
 		NSDate DepartureDate { get; set; }
 
 		[NullAllowed] // by default this property is null
-		[Since (7,0), Export ("arrivalDate", ArgumentSemantic.Copy)]
+		[iOS (7,0), Export ("arrivalDate", ArgumentSemantic.Copy)]
 		NSDate ArrivalDate { get; set; }
 	}
 #endif // !WATCH
 
 	[BaseType (typeof (NSObject))]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[TV (9,2)]
 	[Mac (10,9, onlyOn64 : true)]
 	interface MKMapItem 
@@ -527,7 +527,7 @@ namespace XamCore.MapKit {
 		[Export ("annotationVisibleRect")]
 		CGRect AnnotationVisibleRect { get; }
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("addOverlay:")][PostGet ("Overlays")]
 #if XAMCORE_2_0
 		void AddOverlay (IMKOverlay overlay);
@@ -535,7 +535,7 @@ namespace XamCore.MapKit {
 		void AddOverlay (NSObject overlay);
 #endif
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("addOverlays:")][PostGet ("Overlays")]
 #if XAMCORE_2_0
 		void AddOverlays (IMKOverlay [] overlays);
@@ -543,7 +543,7 @@ namespace XamCore.MapKit {
 		void AddOverlays (NSObject [] overlays);
 #endif
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("removeOverlay:")][PostGet ("Overlays")]
 #if XAMCORE_2_0
 		void RemoveOverlay (IMKOverlay overlay);
@@ -551,7 +551,7 @@ namespace XamCore.MapKit {
 		void RemoveOverlay (NSObject overlay);
 #endif
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("removeOverlays:")][PostGet ("Overlays")]
 #if XAMCORE_2_0
 		void RemoveOverlays ([Params] IMKOverlay [] overlays);
@@ -559,7 +559,7 @@ namespace XamCore.MapKit {
 		void RemoveOverlays ([Params] NSObject [] overlays);
 #endif
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("overlays")]
 #if XAMCORE_2_0
 		IMKOverlay [] Overlays { get;  }
@@ -567,7 +567,7 @@ namespace XamCore.MapKit {
 		NSObject [] Overlays { get;  }
 #endif
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("insertOverlay:atIndex:")][PostGet ("Overlays")]
 #if XAMCORE_2_0
 		void InsertOverlay (IMKOverlay overlay, nint index);
@@ -575,7 +575,7 @@ namespace XamCore.MapKit {
 		void InsertOverlay (NSObject overlay, nint index);
 #endif
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("insertOverlay:aboveOverlay:")][PostGet ("Overlays")]
 #if XAMCORE_2_0
 		void InsertOverlayAbove (IMKOverlay overlay, IMKOverlay sibling);
@@ -583,7 +583,7 @@ namespace XamCore.MapKit {
 		void InsertOverlayAbove (NSObject overlay, NSObject sibling);
 #endif
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("insertOverlay:belowOverlay:")][PostGet ("Overlays")]
 #if XAMCORE_2_0
 		void InsertOverlayBelow (IMKOverlay overlay, IMKOverlay sibling);
@@ -591,23 +591,23 @@ namespace XamCore.MapKit {
 		void InsertOverlayBelow (NSObject overlay, NSObject sibling);
 #endif
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("exchangeOverlayAtIndex:withOverlayAtIndex:")]
 		void ExchangeOverlays (nint index1, nint index2);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("mapRectThatFits:")]
 		MKMapRect MapRectThatFits (MKMapRect mapRect);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("setVisibleMapRect:edgePadding:animated:")]
 		void SetVisibleMapRect (MKMapRect mapRect, UIEdgeInsets edgePadding, bool animate);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("setVisibleMapRect:animated:")]
 		void SetVisibleMapRect (MKMapRect mapRect, bool animate);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("mapRectThatFits:edgePadding:")]
 		MKMapRect MapRectThatFits (MKMapRect mapRect, UIEdgeInsets edgePadding);
 
@@ -621,68 +621,68 @@ namespace XamCore.MapKit {
 #endif
 #endif // !MONOMAC && !TVOS
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("visibleMapRect")]
 		MKMapRect VisibleMapRect { get; set;  }
 
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("annotationsInMapRect:")]
 		NSSet GetAnnotations (MKMapRect mapRect);
 
 #if !MONOMAC
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("userTrackingMode")]
 		MKUserTrackingMode UserTrackingMode { get; set; }
 		
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setUserTrackingMode:animated:")]
 		void SetUserTrackingMode (MKUserTrackingMode trackingMode, bool animated);
 #endif
 
-		[Since (7,0), Export ("camera", ArgumentSemantic.Copy)]
+		[iOS (7,0), Export ("camera", ArgumentSemantic.Copy)]
 		MKMapCamera Camera { get; set; }
 
-		[Since (7,0), Export ("setCamera:animated:")]
+		[iOS (7,0), Export ("setCamera:animated:")]
 		void SetCamera (MKMapCamera camera, bool animated);
 
 		[NoTV]
-		[Since (7,0), Export ("rotateEnabled")]
+		[iOS (7,0), Export ("rotateEnabled")]
 		bool RotateEnabled { [Bind ("isRotateEnabled")] get; set; }
 
 		[NoTV]
-		[Since (7,0), Export ("pitchEnabled")]
+		[iOS (7,0), Export ("pitchEnabled")]
 		bool PitchEnabled { [Bind ("isPitchEnabled")] get; set; }
 
-		[Since (7,0), Export ("showAnnotations:animated:")]
+		[iOS (7,0), Export ("showAnnotations:animated:")]
 		void ShowAnnotations (IMKAnnotation [] annotations, bool animated);
 
-		[Since (7,0), Export ("addOverlay:level:")]
+		[iOS (7,0), Export ("addOverlay:level:")]
 		[PostGet ("Overlays")]
 		void AddOverlay (IMKOverlay overlay, MKOverlayLevel level);
 
-		[Since (7,0), Export ("addOverlays:level:")]
+		[iOS (7,0), Export ("addOverlays:level:")]
 		[PostGet ("Overlays")]
 		void AddOverlays (IMKOverlay [] overlays, MKOverlayLevel level);
 
-		[Since (7,0), Export ("exchangeOverlay:withOverlay:")]
+		[iOS (7,0), Export ("exchangeOverlay:withOverlay:")]
 		[PostGet ("Overlays")]
 		void ExchangeOverlay (IMKOverlay overlay1, IMKOverlay overlay2);
 
-		[Since (7,0), Export ("insertOverlay:atIndex:level:")]
+		[iOS (7,0), Export ("insertOverlay:atIndex:level:")]
 		[PostGet ("Overlays")]
 		void InsertOverlay (IMKOverlay overlay, nuint index, MKOverlayLevel level);
 
-		[Since (7,0), Export ("overlaysInLevel:")]
+		[iOS (7,0), Export ("overlaysInLevel:")]
 		IMKOverlay [] OverlaysInLevel (MKOverlayLevel level);
 
-		[Since (7,0), Export ("rendererForOverlay:")]
+		[iOS (7,0), Export ("rendererForOverlay:")]
 		MKOverlayRenderer RendererForOverlay (IMKOverlay overlay);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("showsPointsOfInterest")]
 		bool ShowsPointsOfInterest { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("showsBuildings")]
 		bool ShowsBuildings { get; set; }
 
@@ -758,7 +758,7 @@ namespace XamCore.MapKit {
 #endif // !MONOMAC
 
 		[NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("mapView:annotationView:didChangeDragState:fromOldState:"), EventArgs ("MKMapViewDragState")]
 		void ChangedDragState (MKMapView mapView, MKAnnotationView annotationView, MKAnnotationViewDragState newState, MKAnnotationViewDragState oldState);
 
@@ -776,32 +776,32 @@ namespace XamCore.MapKit {
 		void DidAddOverlayViews (MKMapView mapView, MKOverlayView overlayViews);
 #endif // !MONOMAC && !TVOS
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("mapView:didSelectAnnotationView:"), EventArgs ("MKAnnotationView")]
 		void DidSelectAnnotationView (MKMapView mapView, MKAnnotationView view);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("mapView:didFailToLocateUserWithError:"), EventArgs ("NSError", true)]
 		void DidFailToLocateUser (MKMapView mapView, NSError error);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("mapView:didDeselectAnnotationView:"), EventArgs ("MKAnnotationView")]
 		void DidDeselectAnnotationView (MKMapView mapView, MKAnnotationView view);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("mapViewWillStartLocatingUser:")]
 		void WillStartLocatingUser (MKMapView mapView);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("mapViewDidStopLocatingUser:")]
 		void DidStopLocatingUser (MKMapView mapView);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("mapView:didUpdateUserLocation:"), EventArgs ("MKUserLocation")]
 		void DidUpdateUserLocation (MKMapView mapView, MKUserLocation userLocation);
 
 #if !MONOMAC
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("mapView:didChangeUserTrackingMode:animated:"), EventArgs ("MMapViewUserTracking")]
 #if XAMCORE_2_0
 		void DidChangeUserTrackingMode (MKMapView mapView, MKUserTrackingMode mode, bool animated);
@@ -810,16 +810,16 @@ namespace XamCore.MapKit {
 #endif // XAMCORE_2_0
 #endif // !MONOMAC
 
-		[Since (7,0), Export ("mapView:rendererForOverlay:"), DelegateName ("MKRendererForOverlayDelegate"), DefaultValue (null)]
+		[iOS (7,0), Export ("mapView:rendererForOverlay:"), DelegateName ("MKRendererForOverlayDelegate"), DefaultValue (null)]
 		MKOverlayRenderer OverlayRenderer (MKMapView mapView, IMKOverlay overlay);
 
-		[Since (7,0), Export ("mapView:didAddOverlayRenderers:"), EventArgs ("MKDidAddOverlayRenderers")]
+		[iOS (7,0), Export ("mapView:didAddOverlayRenderers:"), EventArgs ("MKDidAddOverlayRenderers")]
 		void DidAddOverlayRenderers (MKMapView mapView, MKOverlayRenderer [] renderers);
 
-		[Since (7,0), Export ("mapViewWillStartRenderingMap:")]
+		[iOS (7,0), Export ("mapViewWillStartRenderingMap:")]
 		void WillStartRenderingMap (MKMapView mapView);
 
-		[Since (7,0), Export ("mapViewDidFinishRenderingMap:fullyRendered:"), EventArgs ("MKDidFinishRenderingMap")]
+		[iOS (7,0), Export ("mapViewDidFinishRenderingMap:fullyRendered:"), EventArgs ("MKDidFinishRenderingMap")]
 		void DidFinishRenderingMap (MKMapView mapView, bool fullyRendered);
 
 		[TV (11,0)][NoWatch][iOS (11,0)][Mac (10,13, onlyOn64: true)]
@@ -950,7 +950,7 @@ namespace XamCore.MapKit {
 		[Export ("cancel")]
 		void Cancel ();
 	
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("placemark")]
 		MKPlacemark Placemark { get; }
 	}
@@ -1087,7 +1087,7 @@ namespace XamCore.MapKit {
 
 #if !WATCH
 	[TV (9,2)]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Mac (10,9, onlyOn64 : true)]
 #if XAMCORE_2_0 || MONOMAC
 	[BaseType (typeof (NSObject))]
@@ -1114,7 +1114,7 @@ namespace XamCore.MapKit {
 
 	[TV (9,2)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (MKShape))]
 	interface MKPointAnnotation {
 		[Export ("coordinate")]
@@ -1139,7 +1139,7 @@ namespace XamCore.MapKit {
 
 	[ThreadSafe]
 	[TV (9,2)]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Mac (10,9, onlyOn64 : true)]
 	[BaseType (typeof (MKMultiPoint))]
 	interface MKPolygon : MKOverlay {
@@ -1176,7 +1176,7 @@ namespace XamCore.MapKit {
 
 	[ThreadSafe]
 	[TV (9,2)]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Mac (10,9, onlyOn64 : true)]
 	[BaseType (typeof (MKMultiPoint))]
 	interface MKPolyline : MKOverlay {
@@ -1215,7 +1215,7 @@ namespace XamCore.MapKit {
 
 	[BaseType (typeof (MKShape))]
 	[TV (9,2)]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[Mac (10,9, onlyOn64 : true)]
 	interface MKMultiPoint {
 		[Export ("points"), Internal]
@@ -1249,14 +1249,14 @@ namespace XamCore.MapKit {
 		string Subtitle { get; set; }
 		
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("heading", ArgumentSemantic.Retain)]
 		CLHeading Heading { get; }
 	}
 
 #if !MONOMAC
 	[NoTV]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (UIBarButtonItem))]
 	interface MKUserTrackingBarButtonItem {
 		[NullAllowed] // by default this property is null
@@ -1273,7 +1273,7 @@ namespace XamCore.MapKit {
 	delegate void MKLocalSearchCompletionHandler (MKLocalSearchResponse response, NSError error);
 
 	[TV (9,2)]
-	[Since (6,1)]
+	[iOS (6,1)]
 	[Mac (10,9, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
@@ -1299,7 +1299,7 @@ namespace XamCore.MapKit {
 	}
 
 	[TV (9,2)]
-	[Since (6,1)]
+	[iOS (6,1)]
 	[Mac (10,9, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
@@ -1321,7 +1321,7 @@ namespace XamCore.MapKit {
 	}
 
 	[TV (9,2)]
-	[Since (6,1)]
+	[iOS (6,1)]
 	[Mac (10,9, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
@@ -1340,7 +1340,7 @@ namespace XamCore.MapKit {
 	}
 
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (MKOverlayPathRenderer))]
+	[iOS (7,0), BaseType (typeof (MKOverlayPathRenderer))]
 	[Mac (10,9, onlyOn64 : true)]
 	partial interface MKCircleRenderer {
 
@@ -1352,7 +1352,7 @@ namespace XamCore.MapKit {
 	}
 
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (NSObject))]
+	[iOS (7,0), BaseType (typeof (NSObject))]
 	[Mac (10,9, onlyOn64 : true)]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: Cannot initialize MKDirections with nil request
 	partial interface MKDirections {
@@ -1381,7 +1381,7 @@ namespace XamCore.MapKit {
 	delegate void MKETAHandler (MKETAResponse response, NSError error);
 
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (NSObject))]
+	[iOS (7,0), BaseType (typeof (NSObject))]
 	[Mac (10,9, onlyOn64 : true)]
 	partial interface MKETAResponse {
 		[Export ("source")]
@@ -1411,7 +1411,7 @@ namespace XamCore.MapKit {
 	}
 
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (NSObject))]
+	[iOS (7,0), BaseType (typeof (NSObject))]
 	[Mac (10,9, onlyOn64 : true)]
 	partial interface MKDirectionsResponse {
 
@@ -1426,7 +1426,7 @@ namespace XamCore.MapKit {
 	}
 
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (NSObject))]
+	[iOS (7,0), BaseType (typeof (NSObject))]
 	[Mac (10,9, onlyOn64 : true)]
 	partial interface MKRoute {
 
@@ -1453,7 +1453,7 @@ namespace XamCore.MapKit {
 	}
 
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (NSObject))]
+	[iOS (7,0), BaseType (typeof (NSObject))]
 	[Mac (10,9, onlyOn64 : true)]
 	partial interface MKRouteStep {
 
@@ -1476,7 +1476,7 @@ namespace XamCore.MapKit {
 #endif // !WATCH
 
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (NSFormatter))]
+	[iOS (7,0), BaseType (typeof (NSFormatter))]
 	[Mac (10,9, onlyOn64 : true)]
 	partial interface MKDistanceFormatter {
 
@@ -1498,7 +1498,7 @@ namespace XamCore.MapKit {
 
 #if !WATCH
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (MKPolyline))]
+	[iOS (7,0), BaseType (typeof (MKPolyline))]
 	[Mac (10,9, onlyOn64 : true)]
 	partial interface MKGeodesicPolyline {
 
@@ -1512,7 +1512,7 @@ namespace XamCore.MapKit {
 	}
 
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (NSObject))]
+	[iOS (7,0), BaseType (typeof (NSObject))]
 	[Mac (10,9, onlyOn64 : true)]
 	partial interface MKMapCamera : NSCopying, NSSecureCoding {
 
@@ -1542,7 +1542,7 @@ namespace XamCore.MapKit {
 	}
 
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (NSObject))]
+	[iOS (7,0), BaseType (typeof (NSObject))]
 	[Mac (10,9, onlyOn64 : true)]
 	partial interface MKMapSnapshot {
 
@@ -1554,7 +1554,7 @@ namespace XamCore.MapKit {
 	}
 
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (NSObject))]
+	[iOS (7,0), BaseType (typeof (NSObject))]
 	[Mac (10,9, onlyOn64 : true)]
 	partial interface MKMapSnapshotOptions : NSCopying {
 
@@ -1586,7 +1586,7 @@ namespace XamCore.MapKit {
 	}
 
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (NSObject))]
+	[iOS (7,0), BaseType (typeof (NSObject))]
 	[Mac (10,9, onlyOn64 : true)]
 	partial interface MKMapSnapshotter {
 
@@ -1612,7 +1612,7 @@ namespace XamCore.MapKit {
 	delegate void MKMapSnapshotCompletionHandler (MKMapSnapshot snapshot, NSError error);
 
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (MKOverlayRenderer))]
+	[iOS (7,0), BaseType (typeof (MKOverlayRenderer))]
 	[Mac (10,9, onlyOn64 : true)]
 	[ThreadSafe]
 	partial interface MKOverlayPathRenderer {
@@ -1671,7 +1671,7 @@ namespace XamCore.MapKit {
 	}
 
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (NSObject))]
+	[iOS (7,0), BaseType (typeof (NSObject))]
 	[Mac (10,9, onlyOn64 : true)]
 	partial interface MKOverlayRenderer {
 
@@ -1722,7 +1722,7 @@ namespace XamCore.MapKit {
 	}
 
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (MKOverlayPathRenderer))]
+	[iOS (7,0), BaseType (typeof (MKOverlayPathRenderer))]
 	[Mac (10,9, onlyOn64 : true)]
 	partial interface MKPolygonRenderer {
 
@@ -1734,7 +1734,7 @@ namespace XamCore.MapKit {
 	}
 
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (MKOverlayPathRenderer))]
+	[iOS (7,0), BaseType (typeof (MKOverlayPathRenderer))]
 	[Mac (10,9, onlyOn64 : true)]
 	partial interface MKPolylineRenderer {
 
@@ -1749,10 +1749,10 @@ namespace XamCore.MapKit {
 	[TV (9,2)]
 	[Mac (10,9, onlyOn64 : true)]
 #if XAMCORE_2_0 || MONOMAC
-	[Since (7,0), BaseType (typeof (NSObject))]
+	[iOS (7,0), BaseType (typeof (NSObject))]
 	partial interface MKTileOverlay : MKOverlay {
 #else
-	[Since (7,0), BaseType (typeof (MKOverlay))]
+	[iOS (7,0), BaseType (typeof (MKOverlay))]
 	partial interface MKTileOverlay {
 #endif
 		[DesignatedInitializer]
@@ -1795,7 +1795,7 @@ namespace XamCore.MapKit {
 	delegate void MKTileOverlayLoadTileCompletionHandler (NSData tileData, NSError error);
 
 	[TV (9,2)]
-	[Since (7,0), BaseType (typeof (MKOverlayRenderer))]
+	[iOS (7,0), BaseType (typeof (MKOverlayRenderer))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: Expected a MKTileOverlay but got (null)
 	[DisableDefaultCtor] // throw in iOS8 beta 1 ^
 	[Mac (10,9, onlyOn64 : true)]

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -1105,7 +1105,7 @@ namespace XamCore.MediaPlayer {
 		[Notification]
 		NSString MediaPlaybackIsPreparedToPlayDidChangeNotification { get; }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("readyForDisplay")]
 		bool ReadyForDisplay { get;  }
 

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -37,7 +37,7 @@ namespace XamCore.MediaPlayer {
 		[Export ("valueForProperty:")]
 		NSObject ValueForProperty (NSString property);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("enumerateValuesForProperties:usingBlock:")]
 		void EnumerateValues (NSSet propertiesToEnumerate, MPMediaItemEnumerator enumerator);
 
@@ -59,115 +59,115 @@ namespace XamCore.MediaPlayer {
 	interface MPMediaItem {
 #endif
 		[NoMac][NoTV]
-		[Since (4,2)]
+		[iOS (4,2)]
 		[NoMac]
 		[NoTV]
 		[Export ("persistentIDPropertyForGroupingType:")][Static]
 		string GetPersistentIDProperty (MPMediaGrouping groupingType);
 
 		[NoMac][NoTV]
-		[Since (4,2)]
+		[iOS (4,2)]
 		[NoMac]
 		[NoTV]
 		[Export ("titlePropertyForGroupingType:")][Static]
 		string GetTitleProperty (MPMediaGrouping groupingType);
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyPersistentID")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString PersistentIDProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyAlbumPersistentID")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString AlbumPersistentIDProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyArtistPersistentID")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString ArtistPersistentIDProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyAlbumArtistPersistentID")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString AlbumArtistPersistentIDProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyGenrePersistentID")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString GenrePersistentIDProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyComposerPersistentID")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString ComposerPersistentIDProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyPodcastPersistentID")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString PodcastPersistentIDProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyMediaType")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString MediaTypeProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyTitle")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString TitleProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyAlbumTitle")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString AlbumTitleProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyArtist")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString ArtistProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyAlbumArtist")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString AlbumArtistProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyGenre")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString GenreProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyComposer")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString ComposerProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyPlaybackDuration")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString PlaybackDurationProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyAlbumTrackNumber")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString AlbumTrackNumberProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyAlbumTrackCount")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString AlbumTrackCountProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyDiscNumber")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString DiscNumberProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyDiscCount")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString DiscCountProperty { get; }
 
-		[Since (3,0), Mac (10,13,1, onlyOn64: true)]
+		[iOS (3,0), Mac (10,13,1, onlyOn64: true)]
 		[Field ("MPMediaItemPropertyArtwork")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString ArtworkProperty { get; }
@@ -177,72 +177,72 @@ namespace XamCore.MediaPlayer {
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString IsExplicitProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyLyrics")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString LyricsProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyIsCompilation")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString IsCompilationProperty { get; }
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("MPMediaItemPropertyReleaseDate")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString ReleaseDateProperty { get; }
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("MPMediaItemPropertyBeatsPerMinute")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString BeatsPerMinuteProperty { get; }
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("MPMediaItemPropertyComments")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString CommentsProperty { get; }
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("MPMediaItemPropertyAssetURL")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString AssetURLProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyPlayCount")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString PlayCountProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertySkipCount")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString SkipCountProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyRating")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString RatingProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyLastPlayedDate")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString LastPlayedDateProperty { get; }
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("MPMediaItemPropertyUserGrouping")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString UserGroupingProperty { get; }
 
-		[Since (3,0)]
+		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyPodcastTitle")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString PodcastTitleProperty { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("MPMediaItemPropertyBookmarkTime")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString BookmarkTimeProperty { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("MPMediaItemPropertyIsCloudItem")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString IsCloudItemProperty { get; }
@@ -409,11 +409,11 @@ namespace XamCore.MediaPlayer {
 		[Export ("prompt", ArgumentSemantic.Copy)]
 		string Prompt { get; set; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("showsCloudItems")]
 		bool ShowsCloudItems { get; set; }
 
-		[Since (9,2)]
+		[iOS (9,2)]
 		[Export ("showsItemsWithProtectedAssets")]
 		bool ShowsItemsWithProtectedAssets { get; set; }
 	}
@@ -588,11 +588,11 @@ namespace XamCore.MediaPlayer {
 		[Export ("genresQuery")][Static]
 		MPMediaQuery genresQuery { get; }
 #endif
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("collectionSections")]
 		MPMediaQuerySection [] CollectionSections { get; }
 
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("itemSections")]
 		MPMediaQuerySection [] ItemSections { get; }
 	}
@@ -778,42 +778,42 @@ namespace XamCore.MediaPlayer {
 		void Stop ();
 
 		[Abstract]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("pause")]
 		void Pause ();
 		
 		[Abstract]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("prepareToPlay")]
 		void PrepareToPlay ();
 
 		[Abstract]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("isPreparedToPlay")]
 		bool IsPreparedToPlay { get; }
 
 		[Abstract]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("currentPlaybackTime")]
 		double CurrentPlaybackTime { get; set; }
 
 		[Abstract]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("currentPlaybackRate")]
 		float CurrentPlaybackRate { get; set; } // float, not CGFloat
 
 		[Abstract]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("beginSeekingForward")]
 		void BeginSeekingForward ();
 
 		[Abstract]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("beginSeekingBackward")]
 		void BeginSeekingBackward ();
 
 		[Abstract]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("endSeeking")]
 		void EndSeeking ();
 	}
@@ -839,40 +839,40 @@ namespace XamCore.MediaPlayer {
 		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_3_2, Obsoleted = Platform.iOS_8_0, Message = "Do not use; this API was removed.")]
 		MPMovieControlMode MovieControlMode { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("initialPlaybackTime")]
 		double InitialPlaybackTime { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[NullAllowed] // by default this property is null
 		[Export ("contentURL", ArgumentSemantic.Copy)]
 		NSUrl ContentUrl { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("view")]
 		UIView View { get; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("backgroundView")]
 		UIView BackgroundView { get; }
 		
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("playbackState")]
 		MPMoviePlaybackState PlaybackState { get; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("loadState")]
 		MPMovieLoadState LoadState { get; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("controlStyle")]
 		MPMovieControlStyle ControlStyle { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("repeatMode")]
 		MPMovieRepeatMode RepeatMode { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("shouldAutoplay")]
 		bool ShouldAutoplay { get; set; }
 
@@ -880,15 +880,15 @@ namespace XamCore.MediaPlayer {
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
 		bool UseApplicationAudioSession { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("fullscreen")]
 		bool Fullscreen { [Bind ("isFullscreen")] get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("setFullscreen:animated:")]
 		void SetFullscreen (bool fullscreen, bool animated);
 
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Export ("allowsAirPlay")]
 		bool AllowsAirPlay { get; set; }
 
@@ -897,12 +897,12 @@ namespace XamCore.MediaPlayer {
 		bool AirPlayVideoActive { [Bind ("isAirPlayVideoActive")] get; }
 
 		[Availability (Deprecated = Platform.iOS_9_0)]
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Export ("accessLog")]
 		MPMovieAccessLog AccessLog { get; }
 
 		[Availability (Deprecated = Platform.iOS_9_0)]
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Export ("errorLog")]
 		MPMovieErrorLog ErrorLog { get; }
 
@@ -912,42 +912,42 @@ namespace XamCore.MediaPlayer {
 		[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_7_0, Message = "Use 'RequestThumbnails' instead.")]
 		UIImage ThumbnailImageAt (double time, MPMovieTimeOption timeOption);
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("requestThumbnailImagesAtTimes:timeOption:")]
 		void RequestThumbnails (NSNumber [] doubleNumbers, MPMovieTimeOption timeOption);
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("cancelAllThumbnailImageRequests")]
 		void CancelAllThumbnailImageRequests ();
 
 		//
 		// From interface MPMovieProperties
 		//
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("movieMediaTypes")]
 		MPMovieMediaType MovieMediaTypes { get; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("movieSourceType")]
 		MPMovieSourceType SourceType { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("duration")]
 		double Duration { get; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("playableDuration")]
 		double PlayableDuration { get; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("naturalSize")]
 		CGSize NaturalSize { get; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("endPlaybackTime")]
 		double EndPlaybackTime { get; set; }
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("timedMetadata")]
 		MPTimedMetadata [] TimedMetadata { get; }
 
@@ -962,141 +962,141 @@ namespace XamCore.MediaPlayer {
 		NSString PlaybackDidFinishNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMoviePlayerPlaybackDidFinishReasonUserInfoKey")] // NSNumber (MPMovieFinishReason)
 		NSString PlaybackDidFinishReasonUserInfoKey { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMoviePlayerPlaybackStateDidChangeNotification")]
 		[Notification]
 		NSString PlaybackStateDidChangeNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMoviePlayerLoadStateDidChangeNotification")]
 		[Notification]
 		NSString LoadStateDidChangeNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMoviePlayerNowPlayingMovieDidChangeNotification")]
 		[Notification]
 		NSString NowPlayingMovieDidChangeNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMoviePlayerWillEnterFullscreenNotification")]
 		[Notification (typeof (MPMoviePlayerFullScreenEventArgs))]
 		[Notification]
 		NSString WillEnterFullscreenNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMoviePlayerDidEnterFullscreenNotification")]
 		[Notification]
 		NSString DidEnterFullscreenNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMoviePlayerWillExitFullscreenNotification")]
 		[Notification (typeof (MPMoviePlayerFullScreenEventArgs))]
 		NSString WillExitFullscreenNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMoviePlayerDidExitFullscreenNotification")]
 		[Notification]
 		NSString DidExitFullscreenNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMoviePlayerFullscreenAnimationDurationUserInfoKey")]
 		NSString FullscreenAnimationDurationUserInfoKey { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMoviePlayerFullscreenAnimationCurveUserInfoKey")]
 		NSString FullscreenAnimationCurveUserInfoKey { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMovieMediaTypesAvailableNotification")]
 		[Notification]
 		NSString TypesAvailableNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMovieSourceTypeAvailableNotification")]
 		[Notification]
 		NSString SourceTypeAvailableNotification { get; }
 
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMovieDurationAvailableNotification")]
 		[Notification]
 		NSString DurationAvailableNotification { get;  }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMovieNaturalSizeAvailableNotification")]
 		[Notification]
 		NSString NaturalSizeAvailableNotification { get;  }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMoviePlayerThumbnailImageRequestDidFinishNotification")]
 		[Notification (typeof (MPMoviePlayerThumbnailEventArgs))]
 		NSString ThumbnailImageRequestDidFinishNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMoviePlayerThumbnailImageKey")]
 		NSString ThumbnailImageKey { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMoviePlayerThumbnailTimeKey")]
 		NSString ThumbnailTimeKey { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("MPMoviePlayerThumbnailErrorKey")]
 		NSString ThumbnailErrorKey { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("MPMoviePlayerTimedMetadataUpdatedNotification")]
 		[Notification (typeof (MPMoviePlayerTimedMetadataEventArgs))]
 		NSString TimedMetadataUpdatedNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("MPMoviePlayerTimedMetadataUserInfoKey")]
 		NSString TimedMetadataUserInfoKey { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("MPMoviePlayerTimedMetadataKeyName")]
 		NSString TimedMetadataKeyName { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("MPMoviePlayerTimedMetadataKeyInfo")]
 		NSString TimedMetadataKeyInfo { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("MPMoviePlayerTimedMetadataKeyMIMEType")]
 		NSString TimedMetadataKeyMIMEType { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("MPMoviePlayerTimedMetadataKeyDataType")]
 		NSString TimedMetadataKeyDataType { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("MPMoviePlayerTimedMetadataKeyLanguageCode")]
 		NSString TimedMetadataKeyLanguageCode { get; }
 
@@ -1110,7 +1110,7 @@ namespace XamCore.MediaPlayer {
 		bool ReadyForDisplay { get;  }
 
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("MPMoviePlayerReadyForDisplayDidChangeNotification")]
 		[Notification]
 		NSString MoviePlayerReadyForDisplayDidChangeNotification { get; }
@@ -1277,69 +1277,69 @@ namespace XamCore.MediaPlayer {
 		[Export ("showsVolumeSlider")]
 		bool ShowsVolumeSlider { get; set; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("setMinimumVolumeSliderImage:forState:")]
 		void SetMinimumVolumeSliderImage ([NullAllowed] UIImage image, UIControlState state);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("setMaximumVolumeSliderImage:forState:")]
 		void SetMaximumVolumeSliderImage ([NullAllowed] UIImage image, UIControlState state);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("setVolumeThumbImage:forState:")]
 		void SetVolumeThumbImage ([NullAllowed] UIImage image, UIControlState state);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("minimumVolumeSliderImageForState:")]
 		UIImage GetMinimumVolumeSliderImage (UIControlState state);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("maximumVolumeSliderImageForState:")]
 		UIImage GetMaximumVolumeSliderImage (UIControlState state);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("volumeThumbImageForState:")]
 		UIImage GetVolumeThumbImage (UIControlState state);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("volumeSliderRectForBounds:")]
 		CGRect GetVolumeSliderRect (CGRect bounds);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("volumeThumbRectForBounds:volumeSliderRect:value:")]
 		CGRect GetVolumeThumbRect (CGRect bounds, CGRect columeSliderRect, float /* float, not CGFloat */ value);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("setRouteButtonImage:forState:")]
 		void SetRouteButtonImage ([NullAllowed] UIImage image, UIControlState state);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("routeButtonImageForState:")]
 		UIImage GetRouteButtonImage (UIControlState state);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("routeButtonRectForBounds:")]
 		CGRect GetRouteButtonRect (CGRect bounds);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("wirelessRoutesAvailable")]
 		bool AreWirelessRoutesAvailable { [Bind ("areWirelessRoutesAvailable")] get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("wirelessRouteActive")]
 		bool IsWirelessRouteActive { [Bind ("isWirelessRouteActive")] get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("volumeWarningSliderImage", ArgumentSemantic.Retain)]
 		UIImage VolumeWarningSliderImage { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Notification]
 		[Field ("MPVolumeViewWirelessRoutesAvailableDidChangeNotification")]
 		NSString WirelessRoutesAvailableDidChangeNotification { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Notification]
 		[Field ("MPVolumeViewWirelessRouteActiveDidChangeNotification")]
 		NSString WirelessRouteActiveDidChangeNotification { get; }
@@ -1348,7 +1348,7 @@ namespace XamCore.MediaPlayer {
 
 	[NoMac]
 	[NoTV]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: MPMediaQuerySection is a read-only object
 	[DisableDefaultCtor]
@@ -1361,7 +1361,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	[Mac (10,12,2, onlyOn64: true)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: -init is not supported, use +defaultCenter
 	[DisableDefaultCtor]
@@ -1467,7 +1467,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	[Mac (10,12,2, onlyOn64: true)]
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // crash if used
 	interface MPContentItem {
@@ -1510,7 +1510,7 @@ namespace XamCore.MediaPlayer {
 
 	[NoMac]
 	[NoTV]
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -1550,7 +1550,7 @@ namespace XamCore.MediaPlayer {
 
 	[NoMac]
 	[NoTV]
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -1574,7 +1574,7 @@ namespace XamCore.MediaPlayer {
 
 	[NoMac]
 	[NoTV]
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: -init is invalid. Use +sharedManager. <- [sic]
 	interface MPPlayableContentManager {
@@ -1640,7 +1640,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	[Mac (10,12,2, onlyOn64: true)]
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPRemoteCommands cannot be initialized externally.
 	interface MPRemoteCommand {
@@ -1662,7 +1662,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	[Mac (10,12,2, onlyOn64: true)]
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (MPRemoteCommand))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPChangePlaybackRateCommands cannot be initialized externally.
 	interface MPChangePlaybackRateCommand {
@@ -1692,7 +1692,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	[Mac (10,12,2, onlyOn64: true)]
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (MPRemoteCommand))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPFeedbackCommands cannot be initialized externally.
 	interface MPFeedbackCommand {
@@ -1709,7 +1709,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	[Mac (10,12,2, onlyOn64: true)]
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (MPRemoteCommand))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPRatingCommands cannot be initialized externally.
 	interface MPRatingCommand {
@@ -1722,7 +1722,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	[Mac (10,12,2, onlyOn64: true)]
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (MPRemoteCommand))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPSkipIntervalCommands cannot be initialized externally.
 	interface MPSkipIntervalCommand {
@@ -1735,7 +1735,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	[Mac (10,12,2, onlyOn64: true)]
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface MPRemoteCommandCenter {
@@ -1811,7 +1811,7 @@ namespace XamCore.MediaPlayer {
 	}
 	
 	[Mac (10,12,2, onlyOn64: true)]
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPRemoteCommandEvents cannot be initialized externally.
 	interface MPRemoteCommandEvent {
@@ -1824,7 +1824,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	[Mac (10,12,2, onlyOn64: true)]
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (MPRemoteCommandEvent))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPChangePlaybackRateCommandEvents cannot be initialized externally.
 	interface MPChangePlaybackRateCommandEvent {
@@ -1834,7 +1834,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	[Mac (10,12,2, onlyOn64: true)]
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (MPRemoteCommandEvent))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPRatingCommandEvents cannot be initialized externally.
 	interface MPRatingCommandEvent {
@@ -1844,7 +1844,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	[Mac (10,12,2, onlyOn64: true)]
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (MPRemoteCommandEvent))]
 	[DisableDefaultCtor] // Name: NSGenericException Reason: MPSeekCommandEvents cannot be initialized externally.
 	interface MPSeekCommandEvent {
@@ -1854,7 +1854,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	[Mac (10,12,2, onlyOn64: true)]
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (MPRemoteCommandEvent))]
 	[DisableDefaultCtor] // NSGenericException Reason: MPSkipIntervalCommandEvents cannot be initialized externally.
 	interface MPSkipIntervalCommandEvent {
@@ -1864,7 +1864,7 @@ namespace XamCore.MediaPlayer {
 	}
 
 	[Mac (10,12,2, onlyOn64: true)]
-	[Since (7,1)]
+	[iOS (7,1)]
 	[BaseType (typeof (MPRemoteCommandEvent))]
 	[DisableDefaultCtor]
 	interface MPFeedbackCommandEvent {

--- a/src/messageui.cs
+++ b/src/messageui.cs
@@ -69,7 +69,7 @@ namespace XamCore.MessageUI {
 		bool TextMessageAvailability { get; }
 	}
 	
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (UINavigationController))]
 	interface MFMessageComposeViewController : UIAppearance {
 		[Export ("messageComposeDelegate", ArgumentSemantic.Assign), NullAllowed]
@@ -89,23 +89,23 @@ namespace XamCore.MessageUI {
 		[Export ("canSendText")]
 		bool CanSendText { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static][Export ("canSendAttachments")]
 		bool CanSendAttachments { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static][Export ("canSendSubject")]
 		bool CanSendSubject { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static][Export ("isSupportedAttachmentUTI:")]
 		bool IsSupportedAttachment (string uti);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("subject", ArgumentSemantic.Copy)]
 		string Subject { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("attachments")]
 		NSDictionary[] GetAttachments ();
 
@@ -113,32 +113,32 @@ namespace XamCore.MessageUI {
 		[NullAllowed, Export ("message", ArgumentSemantic.Copy)]
 		MSMessage Message { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("addAttachmentURL:withAlternateFilename:")]
 		bool AddAttachment (NSUrl attachmentURL, [NullAllowed] string alternateFilename);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("addAttachmentData:typeIdentifier:filename:")]
 		bool AddAttachment (NSData attachmentData, string uti, [NullAllowed] string filename);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("disableUserAttachments")]
 		void DisableUserAttachments ();
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("MFMessageComposeViewControllerTextMessageAvailabilityDidChangeNotification")]
 		[Notification (typeof (MFMessageAvailabilityChangedEventArgs))]
 		NSString TextMessageAvailabilityDidChangeNotification { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("MFMessageComposeViewControllerTextMessageAvailabilityKey")]
 		NSString TextMessageAvailabilityKey { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("MFMessageComposeViewControllerAttachmentAlternateFilename")]
 		NSString AttachmentAlternateFilename { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("MFMessageComposeViewControllerAttachmentURL")]
 		NSString AttachmentURL { get; }
 	}

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -357,7 +357,8 @@ namespace XamCore.Metal {
 		[return: NullAllowed]
 		IMTLCommandBuffer CommandBufferWithUnretainedReferences ();
 
-		[Availability (Deprecated = Platform.iOS_11_0 | Platform.Mac_10_13, Message = "Use 'MTLCaptureScope' instead.")]
+		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'MTLCaptureScope' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'MTLCaptureScope' instead.")]
 		[Abstract, Export ("insertDebugCaptureBoundary")]
 		void InsertDebugCaptureBoundary ();
 	}

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -357,8 +357,8 @@ namespace XamCore.Metal {
 		[return: NullAllowed]
 		IMTLCommandBuffer CommandBufferWithUnretainedReferences ();
 
-		[Availability (Deprecated = Platform.iOS_11_0, Message = "Use 'MTLCaptureScope' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_13, Message = "Use 'MTLCaptureScope' instead.")]
+		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'MTLCaptureScope' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'MTLCaptureScope' instead.")]
 		[Abstract, Export ("insertDebugCaptureBoundary")]
 		void InsertDebugCaptureBoundary ();
 	}

--- a/src/multipeerconnectivity.cs
+++ b/src/multipeerconnectivity.cs
@@ -20,7 +20,7 @@ using XamCore.UIKit;
 namespace XamCore.MultipeerConnectivity {
 
 	[TV (10,0)]
-	[Since (7,0)][Mac (10,10, onlyOn64 : true)]
+	[iOS (7,0)][Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: -[MCPeerID init]: unrecognized selector sent to instance 0x7d721090
 	partial interface MCPeerID : NSCopying, NSSecureCoding {
@@ -36,7 +36,7 @@ namespace XamCore.MultipeerConnectivity {
 	delegate void MCSessionNearbyConnectionDataForPeerCompletionHandler (NSData connectionData, NSError error);
 
 	[TV (10,0)]
-	[Since (7,0)][Mac (10,10, onlyOn64 : true)]
+	[iOS (7,0)][Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // crash when calling `description` selector
 	partial interface MCSession {
@@ -105,7 +105,7 @@ namespace XamCore.MultipeerConnectivity {
 	}
 
 	[TV (10,0)]
-	[Since (7,0)][Mac (10,10, onlyOn64 : true)]
+	[iOS (7,0)][Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -135,7 +135,7 @@ namespace XamCore.MultipeerConnectivity {
 	}
 
 	[TV (10,0)]
-	[Since (7,0)][Mac (10,10, onlyOn64 : true)]
+	[iOS (7,0)][Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException -[MCNearbyServiceAdvertiser init]: unrecognized selector sent to instance 0x19195e50
 	partial interface MCNearbyServiceAdvertiser {
@@ -170,7 +170,7 @@ namespace XamCore.MultipeerConnectivity {
 	delegate void MCNearbyServiceAdvertiserInvitationHandler (bool accept, [NullAllowed] MCSession session);
 
 	[TV (10,0)]
-	[Since (7,0)][Mac (10,10, onlyOn64 : true)]
+	[iOS (7,0)][Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -187,7 +187,7 @@ namespace XamCore.MultipeerConnectivity {
 	}
 
 	[TV (10,0)]
-	[Since (7,0)][Mac (10,10, onlyOn64 : true)]
+	[iOS (7,0)][Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException -[MCNearbyServiceBrowser init]: unrecognized selector sent to instance 0x15519a70
 	partial interface MCNearbyServiceBrowser {
@@ -220,7 +220,7 @@ namespace XamCore.MultipeerConnectivity {
 	}
 
 	[TV (10,0)]
-	[Since (7,0)][Mac (10,10, onlyOn64 : true)]
+	[iOS (7,0)][Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -252,7 +252,7 @@ namespace XamCore.MultipeerConnectivity {
 	[BaseType (typeof (NSViewController))]
 #else
 	[TV (10,0)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (UIViewController))]
 #endif
 	[DisableDefaultCtor] // NSInvalidArgumentException -[MCPeerPickerViewController initWithNibName:bundle:]: unrecognized selector sent to instance 0x15517b90
@@ -289,7 +289,7 @@ namespace XamCore.MultipeerConnectivity {
 	}
 
 	[TV (10,0)]
-	[Since (7,0)][Mac (10,10, onlyOn64 : true)]
+	[iOS (7,0)][Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -314,7 +314,7 @@ namespace XamCore.MultipeerConnectivity {
 	}
 
 	[TV (10,0)]
-	[Since (7,0)][Mac (10,10, onlyOn64 : true)]
+	[iOS (7,0)][Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: -[MCAdvertiserAssistant init]: unrecognized selector sent to instance 0x7ea7fa40
 	interface MCAdvertiserAssistant {
@@ -347,7 +347,7 @@ namespace XamCore.MultipeerConnectivity {
 	}
 
 	[TV (10,0)]
-	[Since (7,0)][Mac (10,10, onlyOn64 : true)]
+	[iOS (7,0)][Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]

--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -874,7 +874,8 @@ namespace XamCore.NetworkExtension {
 
 		[NullAllowed]
 		[Export ("protocol", ArgumentSemantic.Retain)]
-		[Availability (Deprecated = Platform.iOS_9_0 | Platform.Mac_10_11, Message = "Use 'ProtocolConfiguration' instead.")]
+		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'ProtocolConfiguration' instead.")]
+		[Availability (Deprecated = Platform.Mac_10_11, Message = "Use 'ProtocolConfiguration' instead.")]
 		NEVpnProtocol Protocol { get; set; }
 
 		[iOS (9,0)][Mac (10,11, onlyOn64 : true)]

--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -874,8 +874,8 @@ namespace XamCore.NetworkExtension {
 
 		[NullAllowed]
 		[Export ("protocol", ArgumentSemantic.Retain)]
-		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'ProtocolConfiguration' instead.")]
-		[Availability (Deprecated = Platform.Mac_10_11, Message = "Use 'ProtocolConfiguration' instead.")]
+		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'ProtocolConfiguration' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'ProtocolConfiguration' instead.")]
 		NEVpnProtocol Protocol { get; set; }
 
 		[iOS (9,0)][Mac (10,11, onlyOn64 : true)]

--- a/src/newsstandkit.cs
+++ b/src/newsstandkit.cs
@@ -11,7 +11,7 @@ using XamCore.ObjCRuntime;
 
 namespace XamCore.NewsstandKit {
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	// <quote>You create an NKAssetDownload instance using the NKIssue method addAssetWithRequest:</quote> -> http://developer.apple.com/library/ios/#documentation/StoreKit/Reference/NKAssetDownload_Class/NKAssetDownload/NKAssetDownload.html
 	// init returns NIL
@@ -33,7 +33,7 @@ namespace XamCore.NewsstandKit {
 		NSUrlConnection DownloadWithDelegate ([Protocolize] NSUrlConnectionDownloadDelegate downloadDelegate);
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	// <quote>An NKIssue object must have a name and a date. When you create the object using the addIssueWithName:date: method of the NKLibrary class, you must supply these two values.</quote>
 	// http://developer.apple.com/library/ios/#documentation/StoreKit/Reference/NKIssue_Class/NKIssue/NKIssue.html#//apple_ref/occ/cl/NKIssue
@@ -63,7 +63,7 @@ namespace XamCore.NewsstandKit {
 		NSString DownloadCompletedNotification { get; }
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	// init returns NIL -> sharedLibrary
 	[DisableDefaultCtor]

--- a/src/opengles.cs
+++ b/src/opengles.cs
@@ -76,7 +76,7 @@ namespace XamCore.OpenGLES {
 		[Export ("presentRenderbuffer:afterMinimumDuration:")]
 		bool _PresentRenderbufferAfterMinimumDuration (nuint target, double duration);
 
-		[Since (7,1)]
+		[iOS (7,1)]
 		[Export ("multiThreaded")]
 		bool IsMultiThreaded { [Bind ("isMultiThreaded")] get; set; }
 

--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -49,7 +49,7 @@ namespace XamCore.PassKit {
 		string SupplementarySubLocality { get; set; }
 	}
 	
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	interface PKPassLibrary {
 		[Static][Export ("isPassLibraryAvailable")]
@@ -74,7 +74,7 @@ namespace XamCore.PassKit {
 		[Export ("replacePassWithPass:")]
 		bool Replace (PKPass pass);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("addPasses:withCompletionHandler:")]
 		[Async]
 		void AddPasses (PKPass[] passes, [NullAllowed] Action<PKPassLibraryAddPassesStatus> completion);
@@ -151,7 +151,7 @@ namespace XamCore.PassKit {
 		void PresentPaymentPass (PKPaymentPass pass);
 	}
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[Static]
 	interface PKPassLibraryUserInfoKey
 	{
@@ -523,7 +523,7 @@ namespace XamCore.PassKit {
 	}
 
 #if !WATCH
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (UIViewController), Delegates = new string [] {"WeakDelegate"}, Events = new Type [] { typeof (PKAddPassesViewControllerDelegate) })]
 	// invalid null handle for default 'init'
 	[DisableDefaultCtor]
@@ -536,7 +536,7 @@ namespace XamCore.PassKit {
 		[Export ("initWithPass:")]
 		IntPtr Constructor (PKPass pass);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("initWithPasses:")]
 		IntPtr Constructor (PKPass[] pass);
 
@@ -553,7 +553,7 @@ namespace XamCore.PassKit {
 		PKAddPassesViewControllerDelegate Delegate { get; set;  }
 	}
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -660,7 +660,7 @@ namespace XamCore.PassKit {
 	}
 #endif // !WATCH
 		
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (PKObject))]
 	interface PKPass : NSSecureCoding, NSCopying {
 		[Export ("initWithData:error:")]
@@ -706,7 +706,7 @@ namespace XamCore.PassKit {
 		NSString ErrorDomain { get; }
 #endif
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("userInfo", ArgumentSemantic.Copy)]
 		NSDictionary UserInfo { get; }
 

--- a/src/qtkit.cs
+++ b/src/qtkit.cs
@@ -259,7 +259,7 @@ namespace XamCore.QTKit
 		[Field ("QTCaptureDeviceInputSourceLocalizedDisplayNameKey")]
 		NSString InputSourceLocalizedDisplayNameKey { get; }
 		
-		[IntroducedAttribute (PlatformName.MacOSX, 10, 5, PlatformArchitecture.Arch32)] 
+		[Mac (10, 5, PlatformArchitecture.Arch32)] 
 		[Field ("QTCaptureDeviceLegacySequenceGrabberAttribute")]
 		NSString LegacySequenceGrabberAttribute { get; }
 
@@ -611,20 +611,20 @@ namespace XamCore.QTKit
 
 	[BaseType (typeof (NSObject))]
 	interface QTMedia {
-		[IntroducedAttribute (PlatformName.MacOSX, 10, 3, PlatformArchitecture.Arch32)] 
-		[DeprecatedAttribute (PlatformName.MacOSX, 10, 9)] 
+		[Mac (10, 3, PlatformArchitecture.Arch32)] 
+		[Deprecated (PlatformName.MacOSX, 10, 9)] 
 		[Static, Export ("mediaWithQuickTimeMedia:error:")]
 		NSObject FromQuickTimeMedia (IntPtr quicktimeMedia, out NSError error);
 
 #if !XAMCORE_3_0
-		[IntroducedAttribute (PlatformName.MacOSX, 10, 3, PlatformArchitecture.Arch32)] 
-		[DeprecatedAttribute (PlatformName.MacOSX, 10, 9)] 
+		[Mac (10, 3, PlatformArchitecture.Arch32)] 
+		[Deprecated (PlatformName.MacOSX, 10, 9)] 
 		[Export ("initWithQuickTimeMedia:error:")]
 		IntPtr Conditions (IntPtr quicktimeMedia, out NSError error);
 #endif
 		[Sealed] // For the duplicate selector error
-		[IntroducedAttribute (PlatformName.MacOSX, 10, 3, PlatformArchitecture.Arch32)] 
-		[DeprecatedAttribute (PlatformName.MacOSX, 10, 9)] 
+		[Mac (10, 3, PlatformArchitecture.Arch32)] 
+		[Deprecated (PlatformName.MacOSX, 10, 9)] 
 		[Export ("initWithQuickTimeMedia:error:")]
 		IntPtr Constructors (IntPtr quicktimeMedia, out NSError error);
 
@@ -640,8 +640,8 @@ namespace XamCore.QTKit
 		[Export ("hasCharacteristic:")]
 		bool HasCharacteristic (string characteristic);
 
-		[IntroducedAttribute (PlatformName.MacOSX, 10, 3, PlatformArchitecture.Arch32)] 
-		[DeprecatedAttribute (PlatformName.MacOSX, 10, 9)] 
+		[Mac (10, 3, PlatformArchitecture.Arch32)] 
+		[Deprecated (PlatformName.MacOSX, 10, 9)] 
 		[Export ("quickTimeMedia")]
 		IntPtr QuickTimeMedia { get; }
 
@@ -1517,13 +1517,13 @@ namespace XamCore.QTKit
 
 	[BaseType (typeof (NSObject))]
 	interface QTTrack {
-		[IntroducedAttribute (PlatformName.MacOSX, 10, 3, PlatformArchitecture.Arch32)] 
-		[DeprecatedAttribute (PlatformName.MacOSX, 10, 9)] 
+		[Mac (10, 3, PlatformArchitecture.Arch32)] 
+		[Deprecated (PlatformName.MacOSX, 10, 9)] 
 		[Static, Export ("trackWithQuickTimeTrack:error:")]
 		NSObject FromQuickTimeTrack (IntPtr quicktimeTrack, out NSError error);
 
-		[IntroducedAttribute (PlatformName.MacOSX, 10, 3, PlatformArchitecture.Arch32)] 
-		[DeprecatedAttribute (PlatformName.MacOSX, 10, 9)] 
+		[Mac (10, 3, PlatformArchitecture.Arch32)] 
+		[Deprecated (PlatformName.MacOSX, 10, 9)] 
 		[Export ("initWithQuickTimeTrack:error:")]
 		IntPtr Constructor (IntPtr quicktimeTrack, out NSError error);
 
@@ -1539,8 +1539,8 @@ namespace XamCore.QTKit
 		[Export ("setAttribute:forKey:")]
 		void SetAttribute (NSObject value, string attributeKey);
 
-		[IntroducedAttribute (PlatformName.MacOSX, 10, 3, PlatformArchitecture.Arch32)] 
-		[DeprecatedAttribute (PlatformName.MacOSX, 10, 9)] 
+		[Mac (10, 3, PlatformArchitecture.Arch32)] 
+		[Deprecated (PlatformName.MacOSX, 10, 9)] 
 		[Export ("quickTimeTrack")]
 		IntPtr QuickTimeTrack { get; }
 

--- a/src/qtkit.cs
+++ b/src/qtkit.cs
@@ -259,7 +259,7 @@ namespace XamCore.QTKit
 		[Field ("QTCaptureDeviceInputSourceLocalizedDisplayNameKey")]
 		NSString InputSourceLocalizedDisplayNameKey { get; }
 		
-		[Availability (Introduced = Platform.Mac_10_5 | Platform.Mac_Arch32)]
+		[IntroducedAttribute (PlatformName.MacOSX, 10, 5, PlatformArchitecture.Arch32)] 
 		[Field ("QTCaptureDeviceLegacySequenceGrabberAttribute")]
 		NSString LegacySequenceGrabberAttribute { get; }
 
@@ -611,17 +611,20 @@ namespace XamCore.QTKit
 
 	[BaseType (typeof (NSObject))]
 	interface QTMedia {
-		[Availability (Introduced = Platform.Mac_10_3 | Platform.Mac_Arch32, Deprecated = Platform.Mac_10_9)]
+		[IntroducedAttribute (PlatformName.MacOSX, 10, 3, PlatformArchitecture.Arch32)] 
+		[DeprecatedAttribute (PlatformName.MacOSX, 10, 9)] 
 		[Static, Export ("mediaWithQuickTimeMedia:error:")]
 		NSObject FromQuickTimeMedia (IntPtr quicktimeMedia, out NSError error);
 
 #if !XAMCORE_3_0
-		[Availability (Introduced = Platform.Mac_10_3 | Platform.Mac_Arch32, Deprecated = Platform.Mac_10_9)]
+		[IntroducedAttribute (PlatformName.MacOSX, 10, 3, PlatformArchitecture.Arch32)] 
+		[DeprecatedAttribute (PlatformName.MacOSX, 10, 9)] 
 		[Export ("initWithQuickTimeMedia:error:")]
 		IntPtr Conditions (IntPtr quicktimeMedia, out NSError error);
 #endif
 		[Sealed] // For the duplicate selector error
-		[Availability (Introduced = Platform.Mac_10_3 | Platform.Mac_Arch32, Deprecated = Platform.Mac_10_9)]
+		[IntroducedAttribute (PlatformName.MacOSX, 10, 3, PlatformArchitecture.Arch32)] 
+		[DeprecatedAttribute (PlatformName.MacOSX, 10, 9)] 
 		[Export ("initWithQuickTimeMedia:error:")]
 		IntPtr Constructors (IntPtr quicktimeMedia, out NSError error);
 
@@ -637,7 +640,8 @@ namespace XamCore.QTKit
 		[Export ("hasCharacteristic:")]
 		bool HasCharacteristic (string characteristic);
 
-		[Availability (Introduced = Platform.Mac_10_3 | Platform.Mac_Arch32, Deprecated = Platform.Mac_10_9)]
+		[IntroducedAttribute (PlatformName.MacOSX, 10, 3, PlatformArchitecture.Arch32)] 
+		[DeprecatedAttribute (PlatformName.MacOSX, 10, 9)] 
 		[Export ("quickTimeMedia")]
 		IntPtr QuickTimeMedia { get; }
 
@@ -1513,11 +1517,13 @@ namespace XamCore.QTKit
 
 	[BaseType (typeof (NSObject))]
 	interface QTTrack {
-		[Availability (Introduced = Platform.Mac_10_3 | Platform.Mac_Arch32, Deprecated = Platform.Mac_10_9)]
+		[IntroducedAttribute (PlatformName.MacOSX, 10, 3, PlatformArchitecture.Arch32)] 
+		[DeprecatedAttribute (PlatformName.MacOSX, 10, 9)] 
 		[Static, Export ("trackWithQuickTimeTrack:error:")]
 		NSObject FromQuickTimeTrack (IntPtr quicktimeTrack, out NSError error);
 
-		[Availability (Introduced = Platform.Mac_10_3 | Platform.Mac_Arch32, Deprecated = Platform.Mac_10_9)]
+		[IntroducedAttribute (PlatformName.MacOSX, 10, 3, PlatformArchitecture.Arch32)] 
+		[DeprecatedAttribute (PlatformName.MacOSX, 10, 9)] 
 		[Export ("initWithQuickTimeTrack:error:")]
 		IntPtr Constructor (IntPtr quicktimeTrack, out NSError error);
 
@@ -1533,7 +1539,8 @@ namespace XamCore.QTKit
 		[Export ("setAttribute:forKey:")]
 		void SetAttribute (NSObject value, string attributeKey);
 
-		[Availability (Introduced = Platform.Mac_10_3 | Platform.Mac_Arch32, Deprecated = Platform.Mac_10_9)]
+		[IntroducedAttribute (PlatformName.MacOSX, 10, 3, PlatformArchitecture.Arch32)] 
+		[DeprecatedAttribute (PlatformName.MacOSX, 10, 9)] 
 		[Export ("quickTimeTrack")]
 		IntPtr QuickTimeTrack { get; }
 

--- a/src/quicklook.cs
+++ b/src/quicklook.cs
@@ -40,7 +40,7 @@ using System.ComponentModel;
 
 namespace XamCore.QuickLook {
 #if !MONOMAC
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (UIViewController), Delegates = new string [] { "WeakDelegate" }, Events=new Type [] { typeof (QLPreviewControllerDelegate)})]
 	interface QLPreviewController {
 		[Export ("initWithNibName:bundle:")]
@@ -79,7 +79,7 @@ namespace XamCore.QuickLook {
 		void RefreshCurrentPreviewItem ();
 	}
 
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -94,7 +94,7 @@ namespace XamCore.QuickLook {
 		QLPreviewItem GetPreviewItem (QLPreviewController controller, nint index);
 	}
 
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -111,11 +111,11 @@ namespace XamCore.QuickLook {
 #if !MONOMAC
 		// UIView and UIImage do not exists in MonoMac
 		
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("previewController:frameForPreviewItem:inSourceView:"), DelegateName ("QLFrame"), DefaultValue (typeof (CGRect))]
 		CGRect FrameForPreviewItem (QLPreviewController controller, [Protocolize] QLPreviewItem item, ref UIView view);
 		
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("previewController:transitionImageForPreviewItem:contentRect:"), DelegateName ("QLTransition"), DefaultValue (null)]
 		UIImage TransitionImageForPreviewItem (QLPreviewController controller, [Protocolize] QLPreviewItem item, CGRect contentRect);
 
@@ -128,7 +128,7 @@ namespace XamCore.QuickLook {
 
 	interface IQLPreviewItem {}
 
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]

--- a/src/safariservices.cs
+++ b/src/safariservices.cs
@@ -42,7 +42,7 @@ namespace XamCore.SafariServices {
 	}
 
 #if !MONOMAC
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSGenericException Misuse of SSReadingList interface. Use class method defaultReadingList.
 	partial interface SSReadingList {

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -2395,8 +2395,8 @@ namespace XamCore.SceneKit {
 
 		[NoWatch, NoTV]
 		[Export ("render")]
-		[Availability (Deprecated = Platform.Mac_10_11)]
-		[Availability (Deprecated = Platform.iOS_9_0)]
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
+		[Deprecated (PlatformName.iOS, 9, 0)]
 		void Render ();
 
 		[Mac (10,10)]

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -193,13 +193,13 @@ namespace XamCore.SceneKit {
 #if XAMCORE_2_0
 		[Abstract]
 #endif
-		[Introduced (PlatformName.WatchOS, 3, 0)]
+		[Watch (3, 0)]
 		[Deprecated (PlatformName.WatchOS, 4, 0, message: "Use 'SCNAnimationPlayer.Paused' instead.")]
-		[Introduced (PlatformName.TvOS, 9, 0)]
+		[TV (9, 0)]
 		[Deprecated (PlatformName.TvOS, 11, 0,   message: "Use 'SCNAnimationPlayer.Paused' instead.")]
-		[Introduced (PlatformName.iOS, 8, 0)]
+		[iOS (8, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0,    message: "Use 'SCNAnimationPlayer.Paused' instead.")]
-		[Introduced (PlatformName.MacOSX, 10, 9)]
+		[Mac (10, 9)]
 		[Deprecated (PlatformName.MacOSX, 10, 13,message: "Use 'SCNAnimationPlayer.Paused' instead.")]
 		[Export ("isAnimationForKeyPaused:")]
 		bool IsAnimationPaused (NSString key);

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -2395,7 +2395,8 @@ namespace XamCore.SceneKit {
 
 		[NoWatch, NoTV]
 		[Export ("render")]
-		[Availability (Deprecated = Platform.Mac_10_11 | Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.Mac_10_11)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
 		void Render ();
 
 		[Mac (10,10)]

--- a/src/security.cs
+++ b/src/security.cs
@@ -14,7 +14,7 @@ using XamCore.ObjCRuntime;
 namespace XamCore.Security {
 
 	[Static]
-	[Since (7,0)]
+	[iOS (7,0)]
 	interface SecPolicyIdentifier {
 		// they are CFString -> https://github.com/Apple-FOSS-Mirror/libsecurity_keychain/blob/master/lib/SecPolicy.cpp
 
@@ -69,7 +69,7 @@ namespace XamCore.Security {
 	}
 
 	[Static]
-	[Since (7,0)]
+	[iOS (7,0)]
 	interface SecPolicyPropertyKey {
 		[Field ("kSecPolicyOid")]
 		NSString Oid { get; }
@@ -90,7 +90,7 @@ namespace XamCore.Security {
 	}
 	
 	[Static]
-	[Since (8,0), NoMac, NoWatch]
+	[iOS (8,0), NoMac, NoWatch]
 	[NoTV] // removed in tvOS 10
 	interface SecSharedCredential {
 		[Field ("kSecSharedPassword")]
@@ -99,7 +99,7 @@ namespace XamCore.Security {
 	
 
 	[Static]
-	[Since (7,0)]
+	[iOS (7,0)]
 	interface SecTrustPropertyKey {
 		[Field ("kSecPropertyTypeTitle")]
 		NSString Title { get; }
@@ -109,7 +109,7 @@ namespace XamCore.Security {
 	}
 
 	[Static]
-	[Since (7,0), Mac (10, 9)]
+	[iOS (7,0), Mac (10, 9)]
 	interface SecTrustResultKey {
 		[Field ("kSecTrustEvaluationDate")]
 		NSString EvaluationDate { get; }

--- a/src/security.cs
+++ b/src/security.cs
@@ -51,11 +51,11 @@ namespace XamCore.Security {
 		[Field ("kSecPolicyAppleIDValidation")]
 		NSString AppleIDValidation { get; }
 			
-		[MountainLion]
+		[Mac (10, 8)]
 		[Field ("kSecPolicyAppleTimeStamping")]
 		NSString AppleTimeStamping { get; }
 
-		[Mavericks]
+		[Mac (10, 9)]
 		[Field ("kSecPolicyAppleRevocation")]
 		NSString AppleRevocation { get; }
 
@@ -80,7 +80,7 @@ namespace XamCore.Security {
 		[Field ("kSecPolicyClient")]
 		NSString Client { get; }
 
-		[Mavericks]
+		[Mac (10, 9)]
 		[Field ("kSecPolicyRevocationFlags")]
 		NSString RevocationFlags { get; }
 
@@ -109,7 +109,7 @@ namespace XamCore.Security {
 	}
 
 	[Static]
-	[Since (7,0), Mavericks]
+	[Since (7,0), Mac (10, 9)]
 	interface SecTrustResultKey {
 		[Field ("kSecTrustEvaluationDate")]
 		NSString EvaluationDate { get; }

--- a/src/social.cs
+++ b/src/social.cs
@@ -20,7 +20,7 @@ using XamCore.AppKit;
 #endif
 
 namespace XamCore.Social {
-	[Since (6,0)]
+	[iOS (6,0)]
 	[Mac (10,8, onlyOn64 : true)]
 	[Static]
 	interface SLServiceType {
@@ -44,7 +44,7 @@ namespace XamCore.Social {
 
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use Tencent Weibo SDK instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use Tencent Weibo SDK instead.")]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("SLServiceTypeTencentWeibo")]
 		[Mac (10,9)]
 		NSString TencentWeibo { get; }
@@ -57,7 +57,7 @@ namespace XamCore.Social {
 #endif
 	}
 	
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	// init -> Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: SLRequestMultiPart must be obtained through!
 	[DisableDefaultCtor]
@@ -92,7 +92,7 @@ namespace XamCore.Social {
 	}
 
 #if !MONOMAC
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (UIViewController))]
 	[DisableDefaultCtor] // see note on 'composeViewControllerForServiceType:'
 	interface SLComposeViewController {

--- a/src/speech.cs
+++ b/src/speech.cs
@@ -16,7 +16,7 @@ using XamCore.ObjCRuntime;
 namespace XamCore.Speech {
 
 	[Native]
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	public enum SFSpeechRecognitionTaskState : nint {
 		Starting = 0,
 		Running = 1,
@@ -26,7 +26,7 @@ namespace XamCore.Speech {
 	}
 
 	[Native]
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	public enum SFSpeechRecognitionTaskHint : nint {
 		Unspecified = 0,
 		Dictation = 1,
@@ -35,7 +35,7 @@ namespace XamCore.Speech {
 	}
 
 	[Native]
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	public enum SFSpeechRecognizerAuthorizationStatus : nint {
 		NotDetermined,
 		Denied,
@@ -43,7 +43,7 @@ namespace XamCore.Speech {
 		Authorized
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[DisableDefaultCtor]
 	[Abstract] // no docs (yet) but it has no means (init*) to create it, unlike its subclasses
 	[BaseType (typeof (NSObject))]
@@ -62,7 +62,7 @@ namespace XamCore.Speech {
 		string InteractionIdentifier { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (SFSpeechRecognitionRequest), Name = "SFSpeechURLRecognitionRequest")]
 	[DisableDefaultCtor]
 	interface SFSpeechUrlRecognitionRequest {
@@ -75,7 +75,7 @@ namespace XamCore.Speech {
 		NSUrl Url { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (SFSpeechRecognitionRequest))]
 	interface SFSpeechAudioBufferRecognitionRequest {
 
@@ -92,7 +92,7 @@ namespace XamCore.Speech {
 		void EndAudio ();
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	interface SFSpeechRecognitionResult : NSCopying, NSSecureCoding {
 
@@ -106,7 +106,7 @@ namespace XamCore.Speech {
 		bool Final { [Bind ("isFinal")] get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	interface SFSpeechRecognitionTask {
 
@@ -131,7 +131,7 @@ namespace XamCore.Speech {
 
 	interface ISFSpeechRecognitionTaskDelegate { }
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	interface SFSpeechRecognitionTaskDelegate {
@@ -157,7 +157,7 @@ namespace XamCore.Speech {
 
 	interface ISFSpeechRecognizerDelegate { }
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	interface SFSpeechRecognizerDelegate {
@@ -166,7 +166,7 @@ namespace XamCore.Speech {
 		void AvailabilityDidChange (SFSpeechRecognizer speechRecognizer, bool available);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	interface SFSpeechRecognizer {
 
@@ -209,7 +209,7 @@ namespace XamCore.Speech {
 		NSOperationQueue Queue { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	interface SFTranscription : NSCopying, NSSecureCoding {
 
@@ -220,7 +220,7 @@ namespace XamCore.Speech {
 		SFTranscriptionSegment [] Segments { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
 	interface SFTranscriptionSegment : NSCopying, NSSecureCoding {
 

--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -129,7 +129,7 @@ namespace XamCore.SpriteKit {
 	[BaseType (typeof (NSResponder))]
 	partial interface SKNode : NSCoding, NSCopying {
 #elif IOS || TVOS
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (UIResponder))]
 	partial interface SKNode : NSCoding, NSCopying, UIFocusItem {
 #else // WATCHOS
@@ -380,7 +380,7 @@ namespace XamCore.SpriteKit {
 	}
 #elif !WATCH
 	[NoWatch]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Category, BaseType (typeof (UITouch))]
 	partial interface SKNodeTouches_UITouch {
 
@@ -394,7 +394,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (SKNode))]
 	partial interface SKEffectNode : SKWarpable {
 
@@ -519,7 +519,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (SKEffectNode))]
 	interface SKScene
 #if (XAMCORE_2_0 || !MONOMAC) && !WATCH
@@ -683,7 +683,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (SKNode))]
 	partial interface SKSpriteNode : SKWarpable {
 
@@ -791,7 +791,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	partial interface SKKeyframeSequence : NSCoding, NSCopying {
 
@@ -842,7 +842,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (SKNode))]
 	partial interface SKEmitterNode {
 
@@ -1027,7 +1027,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (SKNode))]
 	partial interface SKShapeNode {
 
@@ -1207,7 +1207,7 @@ namespace XamCore.SpriteKit {
 	}
 
 	[Watch (3,0)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Mac (10,9, onlyOn64 : true)]
 	[BaseType (typeof (SKNode))]
 	partial interface SKLabelNode {
@@ -1298,7 +1298,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (4,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (SKNode))]
 	partial interface SKVideoNode {
 
@@ -1409,7 +1409,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (SKNode))]
 	partial interface SKCropNode {
 
@@ -1420,7 +1420,7 @@ namespace XamCore.SpriteKit {
 
 	[NoWatch]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (UIView))]
 #if XAMCORE_3_0
 	[DisableDefaultCtor]
@@ -1442,7 +1442,7 @@ namespace XamCore.SpriteKit {
 		[Export ("showsNodeCount")]
 		bool ShowsNodeCount { get; set; }
 
-		[Since (7,1), Mac(10,10)]
+		[iOS (7,1), Mac(10,10)]
 		[Export ("showsPhysics")]
 		bool ShowsPhysics { get; set; }
 
@@ -1521,7 +1521,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	partial interface SKTransition : NSCopying {
@@ -1578,7 +1578,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	partial interface SKTexture : NSCoding, NSCopying {
@@ -1685,7 +1685,7 @@ namespace XamCore.SpriteKit {
 		
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	partial interface SKTextureAtlas : NSCoding {
 
@@ -2118,7 +2118,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // <quote>To create an action, call the class method for the action you are interested in. </quote>
 	partial interface SKAction : NSCoding, NSCopying {
@@ -2533,7 +2533,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[DisableDefaultCtor] // see https://bugzilla.xamarin.com/show_bug.cgi?id=14502
 	[BaseType (typeof (NSObject))]
 	partial interface SKPhysicsBody : NSCoding, NSCopying {
@@ -2675,7 +2675,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // <quote>An SKPhysicsContact object is created automatically by Scene Kit</quote>
 	partial interface SKPhysicsContact {
@@ -2700,7 +2700,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -2718,7 +2718,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject),
 		   Delegates=new string [] {"WeakContactDelegate"},
 		   Events=new Type [] {typeof (SKPhysicsContactDelegate)})]
@@ -2776,7 +2776,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[Abstract] // <quote>You never instantiate objects of this class directly</quote>
 	partial interface SKPhysicsJoint : NSCoding {
@@ -2798,7 +2798,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (SKPhysicsJoint))]
 	[DisableDefaultCtor] // impossible to set the `anchor` using the default ctor (see #14511) 
 	partial interface SKPhysicsJointPin {
@@ -2825,7 +2825,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (SKPhysicsJoint))]
 	[DisableDefaultCtor] // impossible to set the `anchorA` and `anchorB` using the default ctor (see #14511) 
 	partial interface SKPhysicsJointSpring {
@@ -2842,7 +2842,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (SKPhysicsJoint))]
 	[DisableDefaultCtor] // https://bugzilla.xamarin.com/show_bug.cgi?id=14511
 	partial interface SKPhysicsJointFixed {
@@ -2853,7 +2853,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (SKPhysicsJoint))]
 	[DisableDefaultCtor] // impossible to set the `anchor` and `axis` using the default ctor (see #14511) 
 	partial interface SKPhysicsJointSliding {
@@ -2873,7 +2873,7 @@ namespace XamCore.SpriteKit {
 
 	[Watch (3,0)]
 	[Mac (10,9, onlyOn64 : true)]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (SKPhysicsJoint))]
 	[DisableDefaultCtor] // impossible to set the `anchorA` and `anchorB` using the default ctor (see #14511) 
 	partial interface SKPhysicsJointLimit {

--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -1736,8 +1736,8 @@ namespace XamCore.SpriteKit {
 
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0)]
-		[Availability (Deprecated = Platform.Mac_10_12)]
+		[Deprecated (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("initWithName:floatVector2:")]
 		IntPtr InitWithNameFloatVector2 (string name, Vector2 value);
 
@@ -1754,8 +1754,8 @@ namespace XamCore.SpriteKit {
 
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0)]
-		[Availability (Deprecated = Platform.Mac_10_12)]
+		[Deprecated (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("initWithName:floatVector3:")]
 		IntPtr InitWithNameFloatVector3 (string name, Vector3 value);
 
@@ -1772,8 +1772,8 @@ namespace XamCore.SpriteKit {
 		
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0)]
-		[Availability (Deprecated = Platform.Mac_10_12)]
+		[Deprecated (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("initWithName:floatVector4:")]
 		IntPtr InitWithNameFloatVector4 (string name, Vector4 value);
 
@@ -1791,8 +1791,8 @@ namespace XamCore.SpriteKit {
 #if !XAMCORE_4_0
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0)]
-		[Availability (Deprecated = Platform.Mac_10_12)]
+		[Deprecated (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("initWithName:floatMatrix2:")]
 		IntPtr InitWithNameFloatMatrix2 (string name, Matrix2 value);
 #endif
@@ -1821,8 +1821,8 @@ namespace XamCore.SpriteKit {
 #if !XAMCORE_4_0
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0)]
-		[Availability (Deprecated = Platform.Mac_10_12)]
+		[Deprecated (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("initWithName:floatMatrix3:")]
 		IntPtr InitWithNameFloatMatrix3 (string name, Matrix3 value);
 
@@ -1849,8 +1849,8 @@ namespace XamCore.SpriteKit {
 #if !XAMCORE_4_0
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0)]
-		[Availability (Deprecated = Platform.Mac_10_12)]
+		[Deprecated (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("initWithName:floatMatrix4:")]
 		IntPtr InitWithNameFloatMatrix4 (string name, Matrix4 value);
 #endif
@@ -1890,8 +1890,8 @@ namespace XamCore.SpriteKit {
 
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0)]
-		[Availability (Deprecated = Platform.Mac_10_12)]
+		[Deprecated (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("floatVector2Value")]
 		Vector2 _FloatVector2Value { get; set; }
 
@@ -1910,8 +1910,8 @@ namespace XamCore.SpriteKit {
 
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0)]
-		[Availability (Deprecated = Platform.Mac_10_12)]
+		[Deprecated (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("floatVector3Value")]
 		Vector3 _FloatVector3Value { get; set; }
 
@@ -1930,8 +1930,8 @@ namespace XamCore.SpriteKit {
 
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0)]
-		[Availability (Deprecated = Platform.Mac_10_12)]
+		[Deprecated (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("floatVector4Value")]
 		Vector4 _FloatVector4Value { get; set; }
 
@@ -1950,8 +1950,8 @@ namespace XamCore.SpriteKit {
 
 #if !XAMCORE_4_0
 		[Internal]
-		[Availability (Deprecated = Platform.iOS_10_0)]
-		[Availability (Deprecated = Platform.Mac_10_12)]
+		[Deprecated (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[NoWatch]
 		[Export ("floatMatrix2Value")]
 		Matrix2 _FloatMatrix2Value { get; set; }
@@ -1982,8 +1982,8 @@ namespace XamCore.SpriteKit {
 #if !XAMCORE_4_0
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0)]
-		[Availability (Deprecated = Platform.Mac_10_12)]
+		[Deprecated (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("floatMatrix3Value")]
 		Matrix3 _FloatMatrix3Value { get; set; }
 #endif
@@ -2013,8 +2013,8 @@ namespace XamCore.SpriteKit {
 #if !XAMCORE_4_0
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0)]
-		[Availability (Deprecated = Platform.Mac_10_12)]
+		[Deprecated (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("floatMatrix4Value")]
 		Matrix4 _FloatMatrix4Value { get; set; }
 #endif

--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -1736,7 +1736,8 @@ namespace XamCore.SpriteKit {
 
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12)]
+		[Availability (Deprecated = Platform.iOS_10_0)]
+		[Availability (Deprecated = Platform.Mac_10_12)]
 		[Export ("initWithName:floatVector2:")]
 		IntPtr InitWithNameFloatVector2 (string name, Vector2 value);
 
@@ -1753,7 +1754,8 @@ namespace XamCore.SpriteKit {
 
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12)]
+		[Availability (Deprecated = Platform.iOS_10_0)]
+		[Availability (Deprecated = Platform.Mac_10_12)]
 		[Export ("initWithName:floatVector3:")]
 		IntPtr InitWithNameFloatVector3 (string name, Vector3 value);
 
@@ -1770,7 +1772,8 @@ namespace XamCore.SpriteKit {
 		
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12)]
+		[Availability (Deprecated = Platform.iOS_10_0)]
+		[Availability (Deprecated = Platform.Mac_10_12)]
 		[Export ("initWithName:floatVector4:")]
 		IntPtr InitWithNameFloatVector4 (string name, Vector4 value);
 
@@ -1788,7 +1791,8 @@ namespace XamCore.SpriteKit {
 #if !XAMCORE_4_0
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12)]
+		[Availability (Deprecated = Platform.iOS_10_0)]
+		[Availability (Deprecated = Platform.Mac_10_12)]
 		[Export ("initWithName:floatMatrix2:")]
 		IntPtr InitWithNameFloatMatrix2 (string name, Matrix2 value);
 #endif
@@ -1817,7 +1821,8 @@ namespace XamCore.SpriteKit {
 #if !XAMCORE_4_0
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12)]
+		[Availability (Deprecated = Platform.iOS_10_0)]
+		[Availability (Deprecated = Platform.Mac_10_12)]
 		[Export ("initWithName:floatMatrix3:")]
 		IntPtr InitWithNameFloatMatrix3 (string name, Matrix3 value);
 
@@ -1844,7 +1849,8 @@ namespace XamCore.SpriteKit {
 #if !XAMCORE_4_0
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12)]
+		[Availability (Deprecated = Platform.iOS_10_0)]
+		[Availability (Deprecated = Platform.Mac_10_12)]
 		[Export ("initWithName:floatMatrix4:")]
 		IntPtr InitWithNameFloatMatrix4 (string name, Matrix4 value);
 #endif
@@ -1884,7 +1890,8 @@ namespace XamCore.SpriteKit {
 
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12)]
+		[Availability (Deprecated = Platform.iOS_10_0)]
+		[Availability (Deprecated = Platform.Mac_10_12)]
 		[Export ("floatVector2Value")]
 		Vector2 _FloatVector2Value { get; set; }
 
@@ -1903,7 +1910,8 @@ namespace XamCore.SpriteKit {
 
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12)]
+		[Availability (Deprecated = Platform.iOS_10_0)]
+		[Availability (Deprecated = Platform.Mac_10_12)]
 		[Export ("floatVector3Value")]
 		Vector3 _FloatVector3Value { get; set; }
 
@@ -1922,7 +1930,8 @@ namespace XamCore.SpriteKit {
 
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12)]
+		[Availability (Deprecated = Platform.iOS_10_0)]
+		[Availability (Deprecated = Platform.Mac_10_12)]
 		[Export ("floatVector4Value")]
 		Vector4 _FloatVector4Value { get; set; }
 
@@ -1941,7 +1950,8 @@ namespace XamCore.SpriteKit {
 
 #if !XAMCORE_4_0
 		[Internal]
-		[Availability (Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12)]
+		[Availability (Deprecated = Platform.iOS_10_0)]
+		[Availability (Deprecated = Platform.Mac_10_12)]
 		[NoWatch]
 		[Export ("floatMatrix2Value")]
 		Matrix2 _FloatMatrix2Value { get; set; }
@@ -1972,7 +1982,8 @@ namespace XamCore.SpriteKit {
 #if !XAMCORE_4_0
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12)]
+		[Availability (Deprecated = Platform.iOS_10_0)]
+		[Availability (Deprecated = Platform.Mac_10_12)]
 		[Export ("floatMatrix3Value")]
 		Matrix3 _FloatMatrix3Value { get; set; }
 #endif
@@ -2002,7 +2013,8 @@ namespace XamCore.SpriteKit {
 #if !XAMCORE_4_0
 		[Internal]
 		[NoWatch]
-		[Availability (Deprecated = Platform.iOS_10_0 | Platform.Mac_10_12)]
+		[Availability (Deprecated = Platform.iOS_10_0)]
+		[Availability (Deprecated = Platform.Mac_10_12)]
 		[Export ("floatMatrix4Value")]
 		Matrix4 _FloatMatrix4Value { get; set; }
 #endif

--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -93,7 +93,7 @@ namespace XamCore.StoreKit {
 		[Export ("quantity")]
 		nint Quantity { get; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("applicationUsername", ArgumentSemantic.Copy)]
 		string ApplicationUsername { get; }
 
@@ -127,7 +127,7 @@ namespace XamCore.StoreKit {
 		[Override]
 		NSData RequestData { get; set; }
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[NullAllowed] // by default this property is null
 		[Export ("applicationUsername", ArgumentSemantic.Copy)][New]
 		string ApplicationUsername { get; set; }
@@ -153,7 +153,7 @@ namespace XamCore.StoreKit {
 		[Export ("restoreCompletedTransactions")]
 		void RestoreCompletedTransactions ();
 
-		[Since (7,0), Mavericks]
+		[Since (7,0), Mac (10, 9)]
 		[Export ("restoreCompletedTransactionsWithApplicationUsername:")]
 		void RestoreCompletedTransactions ([NullAllowed] string username);
 

--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -19,7 +19,7 @@ using System;
 
 namespace XamCore.StoreKit {
 
-	[Since(6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	partial interface SKDownload {
 #if MONOMAC
@@ -172,19 +172,19 @@ namespace XamCore.StoreKit {
 		//
 		// iOS 6.0
 		//
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("startDownloads:")]
 		void StartDownloads (SKDownload [] downloads);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("pauseDownloads:")]
 		void PauseDownloads (SKDownload [] downloads);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("resumeDownloads:")]
 		void ResumeDownloads (SKDownload [] downloads);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("cancelDownloads:")]
 		void CancelDownloads (SKDownload [] downloads);
 
@@ -208,7 +208,7 @@ namespace XamCore.StoreKit {
 		[Export ("productIdentifier")]
 		string ProductIdentifier { get; }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("downloadable")]
 		bool Downloadable {
 #if MONOMAC
@@ -219,7 +219,7 @@ namespace XamCore.StoreKit {
 #endif
 		}
 
-		[Since(6,0)]
+		[iOS (6,0)]
 #if MONOMAC
 		[Export ("contentLengths")]
 #else
@@ -227,7 +227,7 @@ namespace XamCore.StoreKit {
 #endif
 		NSNumber [] DownloadContentLengths { get;  }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 #if MONOMAC
 		[Export ("contentVersion")]
 #else
@@ -261,7 +261,7 @@ namespace XamCore.StoreKit {
 		[Export ("paymentQueueRestoreCompletedTransactionsFinished:")]
 		void RestoreCompletedTransactionsFinished (SKPaymentQueue queue);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("paymentQueue:updatedDownloads:")]
 		void UpdatedDownloads (SKPaymentQueue queue, SKDownload [] downloads);
 
@@ -296,7 +296,7 @@ namespace XamCore.StoreKit {
 		[Export ("transactionState")]
 		SKPaymentTransactionState TransactionState { get; }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("downloads")]
 		SKDownload [] Downloads { get;  }
 	}

--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -93,7 +93,7 @@ namespace XamCore.StoreKit {
 		[Export ("quantity")]
 		nint Quantity { get; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("applicationUsername", ArgumentSemantic.Copy)]
 		string ApplicationUsername { get; }
 
@@ -127,7 +127,7 @@ namespace XamCore.StoreKit {
 		[Override]
 		NSData RequestData { get; set; }
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[NullAllowed] // by default this property is null
 		[Export ("applicationUsername", ArgumentSemantic.Copy)][New]
 		string ApplicationUsername { get; set; }
@@ -153,7 +153,7 @@ namespace XamCore.StoreKit {
 		[Export ("restoreCompletedTransactions")]
 		void RestoreCompletedTransactions ();
 
-		[Since (7,0), Mac (10, 9)]
+		[iOS (7,0), Mac (10, 9)]
 		[Export ("restoreCompletedTransactionsWithApplicationUsername:")]
 		void RestoreCompletedTransactions ([NullAllowed] string username);
 
@@ -328,7 +328,7 @@ namespace XamCore.StoreKit {
 		void RequestFailed (SKRequest request, NSError error);
 	}
 		
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Mac (10,9)]
 	[BaseType (typeof (SKRequest))]
 	interface SKReceiptRefreshRequest {
@@ -345,7 +345,7 @@ namespace XamCore.StoreKit {
 		SKReceiptProperties ReceiptProperties { get; }
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Mac (10,9)]
 	[Static, Internal]
 	interface _SKReceiptProperty {
@@ -391,7 +391,7 @@ namespace XamCore.StoreKit {
 
 #if !MONOMAC
 	[NoTV]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (UIViewController),
 		   Delegates=new string [] { "WeakDelegate" },
 		   Events   =new Type   [] { typeof (SKStoreProductViewControllerDelegate) })]
@@ -419,7 +419,7 @@ namespace XamCore.StoreKit {
 		void LoadProduct (StoreProductParameters parameters, [NullAllowed] Action<bool,NSError> callback);
 	}
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[Static]
 	interface SKStoreProductParameterKey
 	{

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -3143,17 +3143,17 @@ namespace XamCore.UIKit {
 		// 6.0
 		//
 		// from @interface UIApplication (UIStateRestoration)
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("extendStateRestoration")]
 		void ExtendStateRestoration ();
 
 		// from @interface UIApplication (UIStateRestoration)
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("completeStateRestoration")]
 		void CompleteStateRestoration ();
 
 		[NoTV]
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("supportedInterfaceOrientationsForWindow:")]
 		UIInterfaceOrientationMask SupportedInterfaceOrientationsForWindow ([Transient] UIWindow window);
 
@@ -3161,18 +3161,18 @@ namespace XamCore.UIKit {
 		[Field ("UITrackingRunLoopMode")]
 		NSString UITrackingRunLoopMode { get; }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Field ("UIApplicationStateRestorationBundleVersionKey")]
 		NSString StateRestorationBundleVersionKey { get; }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Field ("UIApplicationStateRestorationUserInterfaceIdiomKey")]
 		NSString StateRestorationUserInterfaceIdiomKey { get; }
 
 		//
 		// 7.0
 		//
-		[Since(7,0)]
+		[iOS (7,0)]
 		[Field ("UIContentSizeCategoryDidChangeNotification")]
 		[Notification (typeof (UIContentSizeCategoryChangedEventArgs))]
 		NSString ContentSizeCategoryChangedNotification { get; }
@@ -3646,32 +3646,32 @@ namespace XamCore.UIKit {
 		//
 		// 6.0
 		//
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("application:willFinishLaunchingWithOptions:")]
 		bool WillFinishLaunching (UIApplication application, NSDictionary launchOptions);
 
 		[NoTV]
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("application:supportedInterfaceOrientationsForWindow:")]
 		UIInterfaceOrientationMask GetSupportedInterfaceOrientations (UIApplication application, [Transient] UIWindow forWindow);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("application:viewControllerWithRestorationIdentifierPath:coder:")]
 		UIViewController GetViewController (UIApplication application, string [] restorationIdentifierComponents, NSCoder coder);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("application:shouldSaveApplicationState:")]
 		bool ShouldSaveApplicationState (UIApplication application, NSCoder coder);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("application:shouldRestoreApplicationState:")]
 		bool ShouldRestoreApplicationState (UIApplication application, NSCoder coder);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("application:willEncodeRestorableStateWithCoder:")]
 		void WillEncodeRestorableState (UIApplication application, NSCoder coder);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("application:didDecodeRestorableStateWithCoder:")]
 		void DidDecodeRestorableState (UIApplication application, NSCoder coder);		
 
@@ -3975,12 +3975,12 @@ namespace XamCore.UIKit {
 		[Appearance]
 		nfloat GetBackButtonBackgroundVerticalPositionAdjustment (UIBarMetrics barMetrics);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[Export ("setBackgroundImage:forState:style:barMetrics:")]
 		void SetBackgroundImage ([NullAllowed] 	UIImage backgroundImage, UIControlState state, UIBarButtonItemStyle style, UIBarMetrics barMetrics);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[Export ("backgroundImageForState:style:barMetrics:")]
 		UIImage GetBackgroundImage (UIControlState state, UIBarButtonItemStyle style, UIBarMetrics barMetrics);
@@ -7066,7 +7066,7 @@ namespace XamCore.UIKit {
 	// and does not require us to call this with initWithFrame:
 	//
 	[NoTV]
-	[Since(6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (UIControl))]
 	interface UIRefreshControl : UIAppearance {
 		[Export ("refreshing")]
@@ -7391,38 +7391,38 @@ namespace XamCore.UIKit {
 		//
 		// 6.0
 		//
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("alignmentRectInsets")]
 		[ThreadSafe]
 		UIEdgeInsets AlignmentRectInsets { get;  }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Static]
 		[Export ("imageWithData:scale:")]
 		[ThreadSafe, Autorelease]
 		UIImage LoadFromData (NSData data, nfloat scale);
 
 #if !WATCH
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Static]
 		[Export ("imageWithCIImage:scale:orientation:")]
 		[ThreadSafe, Autorelease]
 		UIImage FromImage (CIImage ciImage, nfloat scale, UIImageOrientation orientation);
 #endif // !WATCH
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("initWithData:scale:")]
 		[ThreadSafe]
 		IntPtr Constructor (NSData data, nfloat scale);
 
 #if !WATCH
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("initWithCIImage:scale:orientation:")]
 		[ThreadSafe]
 		IntPtr Constructor (CIImage ciImage, nfloat scale, UIImageOrientation orientation);
 #endif // !WATCH
 	
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("resizableImageWithCapInsets:resizingMode:")]
 		[ThreadSafe]
 		UIImage CreateResizableImage (UIEdgeInsets capInsets, UIImageResizingMode resizingMode);
@@ -7433,7 +7433,7 @@ namespace XamCore.UIKit {
 		[ThreadSafe]
 		UIImage CreateAnimatedImage (string name, UIEdgeInsets capInsets, UIImageResizingMode resizingMode, double duration);
 		
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("imageWithAlignmentRectInsets:")]
 		[ThreadSafe, Autorelease]
 		UIImage ImageWithAlignmentRectInsets (UIEdgeInsets alignmentInsets);
@@ -7825,7 +7825,7 @@ namespace XamCore.UIKit {
 		[Export ("addArcWithCenter:radius:startAngle:endAngle:clockwise:")]
 		void AddArc (CGPoint center, nfloat radius, nfloat startAngle, nfloat endAngle, bool clockWise);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("bezierPathByReversingPath")]
 		UIBezierPath BezierPathByReversingPath ();
 	}
@@ -7960,15 +7960,15 @@ namespace XamCore.UIKit {
 		//
 		// 6.0
 		//
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("currentAttributedTitle", ArgumentSemantic.Retain)]
 		NSAttributedString CurrentAttributedTitle { get;  }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("setAttributedTitle:forState:")]
 		void SetAttributedTitle (NSAttributedString title, UIControlState state);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("attributedTitleForState:")]
 		NSAttributedString GetAttributedTitle (UIControlState state);
 	}
@@ -8039,22 +8039,22 @@ namespace XamCore.UIKit {
 		//
 		// 6.0
 		//
-		[Since(6,0)]
+		[iOS (6,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("attributedText", ArgumentSemantic.Copy)]
 		NSAttributedString AttributedText { get; set;  }
 
 		[NoTV]
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("adjustsLetterSpacingToFitWidth")]
 		[Availability (Introduced = Platform.iOS_6_0, Deprecated = Platform.iOS_7_0, Message = "Use 'NSKernAttributeName' instead.")]
 		bool AdjustsLetterSpacingToFitWidth { get; set;  }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("minimumScaleFactor")]
 		nfloat MinimumScaleFactor { get; set;  }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("preferredMaxLayoutWidth")]
 		nfloat PreferredMaxLayoutWidth { get; set;  }
 
@@ -8264,7 +8264,7 @@ namespace XamCore.UIKit {
 		[Export ("playInputClick")]
 		void PlayInputClick ();
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("identifierForVendor", ArgumentSemantic.Retain)]
 		NSUuid IdentifierForVendor { get;  }
 	}
@@ -8719,7 +8719,7 @@ namespace XamCore.UIKit {
 		//
 		// 6.0
 		//
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[NullAllowed]
 		[Export ("shadowImage", ArgumentSemantic.Retain)]
@@ -9019,14 +9019,14 @@ namespace XamCore.UIKit {
 		void DidShowViewController (UINavigationController navigationController, [Transient] UIViewController viewController, bool animated);
 
 		[NoTV]
-		[Since(7,0)]
+		[iOS (7,0)]
 		[Export ("navigationControllerSupportedInterfaceOrientations:")]
 		[NoDefaultValue]
 		[DelegateName ("Func<UINavigationController,UIInterfaceOrientationMask>")]
 		UIInterfaceOrientationMask SupportedInterfaceOrientations (UINavigationController navigationController);
 
 		[NoTV]
-		[Since(7,0)]
+		[iOS (7,0)]
 		[Export ("navigationControllerPreferredInterfaceOrientationForPresentation:")]
 		[DelegateName ("Func<UINavigationController,UIInterfaceOrientation>")]
 		[NoDefaultValue]
@@ -9087,13 +9087,13 @@ namespace XamCore.UIKit {
 		[Export ("sizeForNumberOfPages:")]
 		CGSize SizeForNumberOfPages (nint pageCount);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[NullAllowed]
 		[Export ("pageIndicatorTintColor", ArgumentSemantic.Retain)]
 		UIColor PageIndicatorTintColor { get; set;  }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[NullAllowed]
 		[Export ("currentPageIndicatorTintColor", ArgumentSemantic.Retain)]
@@ -9171,7 +9171,7 @@ namespace XamCore.UIKit {
 		[DefaultValue(UIPageViewControllerSpineLocation.Mid)]
 		UIPageViewControllerSpineLocation GetSpineLocation (UIPageViewController pageViewController, UIInterfaceOrientation orientation);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("pageViewController:willTransitionToViewControllers:"), EventArgs ("UIPageViewControllerTransition")]
 		void WillTransition (UIPageViewController pageViewController, UIViewController [] pendingViewControllers);
 
@@ -11739,35 +11739,35 @@ namespace XamCore.UIKit {
 		//
 		// 6.0
 		//
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[NullAllowed]
 		[Export ("sectionIndexColor", ArgumentSemantic.Retain)]
 		UIColor SectionIndexColor { get; set;  }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[NullAllowed]
 		[Export ("sectionIndexTrackingBackgroundColor", ArgumentSemantic.Retain)]
 		UIColor SectionIndexTrackingBackgroundColor { get; set;  }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("headerViewForSection:")]
 		UITableViewHeaderFooterView GetHeaderView (nint section);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("footerViewForSection:")]
 		UITableViewHeaderFooterView GetFooterView (nint section);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("dequeueReusableCellWithIdentifier:forIndexPath:")]
 		UITableViewCell DequeueReusableCell (NSString reuseIdentifier, NSIndexPath indexPath);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("dequeueReusableHeaderFooterViewWithIdentifier:")]
 		UITableViewHeaderFooterView DequeueReusableHeaderFooterView (NSString reuseIdentifier);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("registerClass:forCellReuseIdentifier:"), Internal]
 		void RegisterClassForCellReuse (IntPtr /*Class*/ cellClass, NSString reuseIdentifier);
 
@@ -12013,35 +12013,35 @@ namespace XamCore.UIKit {
                 [Export ("tableView:performAction:forRowAtIndexPath:withSender:")]
                 void PerformAction (UITableView tableView, Selector action, NSIndexPath indexPath, [NullAllowed] NSObject sender);
 		
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("tableView:willDisplayHeaderView:forSection:")]
 		void WillDisplayHeaderView (UITableView tableView, UIView headerView, nint section);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("tableView:willDisplayFooterView:forSection:")]
 		void WillDisplayFooterView (UITableView tableView, UIView footerView, nint section);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("tableView:didEndDisplayingCell:forRowAtIndexPath:")]
 		void CellDisplayingEnded (UITableView tableView, UITableViewCell cell, NSIndexPath indexPath);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("tableView:didEndDisplayingHeaderView:forSection:")]
 		void HeaderViewDisplayingEnded (UITableView tableView, UIView headerView, nint section);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("tableView:didEndDisplayingFooterView:forSection:")]
 		void FooterViewDisplayingEnded (UITableView tableView, UIView footerView, nint section);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("tableView:shouldHighlightRowAtIndexPath:")]
 		bool ShouldHighlightRow (UITableView tableView, NSIndexPath rowIndexPath);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("tableView:didHighlightRowAtIndexPath:")]
 		void RowHighlighted (UITableView tableView, NSIndexPath rowIndexPath);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("tableView:didUnhighlightRowAtIndexPath:")]
 		void RowUnhighlighted (UITableView tableView, NSIndexPath rowIndexPath);
 
@@ -12364,35 +12364,35 @@ namespace XamCore.UIKit {
 		[Export ("tableView:performAction:forRowAtIndexPath:withSender:")]
 		void PerformAction (UITableView tableView, Selector action, NSIndexPath indexPath, NSObject sender);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("tableView:willDisplayHeaderView:forSection:")]
 		void WillDisplayHeaderView (UITableView tableView, UIView headerView, nint section);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("tableView:willDisplayFooterView:forSection:")]
 		void WillDisplayFooterView (UITableView tableView, UIView footerView, nint section);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("tableView:didEndDisplayingCell:forRowAtIndexPath:")]
 		void CellDisplayingEnded (UITableView tableView, UITableViewCell cell, NSIndexPath indexPath);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("tableView:didEndDisplayingHeaderView:forSection:")]
 		void HeaderViewDisplayingEnded (UITableView tableView, UIView headerView, nint section);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("tableView:didEndDisplayingFooterView:forSection:")]
 		void FooterViewDisplayingEnded (UITableView tableView, UIView footerView, nint section);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("tableView:shouldHighlightRowAtIndexPath:")]
 		bool ShouldHighlightRow (UITableView tableView, NSIndexPath rowIndexPath);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("tableView:didHighlightRowAtIndexPath:")]
 		void RowHighlighted (UITableView tableView, NSIndexPath rowIndexPath);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("tableView:didUnhighlightRowAtIndexPath:")]
 		void RowUnhighlighted (UITableView tableView, NSIndexPath rowIndexPath);		
 
@@ -12885,12 +12885,12 @@ namespace XamCore.UIKit {
 		[Appearance]
 		UIImage GetBackgroundImage (UIToolbarPosition position, UIBarMetrics barMetrics);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[Export ("setShadowImage:forToolbarPosition:")]
 		void SetShadowImage ([NullAllowed] UIImage shadowImage, UIToolbarPosition topOrBottom);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[Export ("shadowImageForToolbarPosition:")]
 		UIImage GetShadowImage (UIToolbarPosition topOrBottom);
@@ -13413,53 +13413,53 @@ namespace XamCore.UIKit {
 		// 6.0
 		//
 		
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("constraints")]
 		NSLayoutConstraint [] Constraints { get; }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("addConstraint:")]
 		void AddConstraint (NSLayoutConstraint constraint);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("addConstraints:")]
 		void AddConstraints (NSLayoutConstraint [] constraints);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("removeConstraint:")]
 		void RemoveConstraint (NSLayoutConstraint constraint);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("removeConstraints:")]
 		void RemoveConstraints (NSLayoutConstraint [] constraints);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("needsUpdateConstraints")]
 		bool NeedsUpdateConstraints ();
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("setNeedsUpdateConstraints")]
 		void SetNeedsUpdateConstraints ();
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Static]
 		[Export ("requiresConstraintBasedLayout")]
 		bool RequiresConstraintBasedLayout ();
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("alignmentRectForFrame:")]
 		CGRect AlignmentRectForFrame (CGRect frame);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("frameForAlignmentRect:")]
 		CGRect FrameForAlignmentRect (CGRect alignmentRect);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("alignmentRectInsets")]
 		UIEdgeInsets AlignmentRectInsets { get; }
 
 		[NoTV]
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("viewForBaselineLayout")]
 		[Availability (Deprecated = Platform.iOS_9_0, Message="Override 'ViewForFirstBaselineLayout' or 'ViewForLastBaselineLayout'.")]
 		UIView ViewForBaselineLayout { get; }
@@ -13473,72 +13473,72 @@ namespace XamCore.UIKit {
 		UIView ViewForLastBaselineLayout { get; }
 			
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("intrinsicContentSize")]
 		CGSize IntrinsicContentSize { get; }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("invalidateIntrinsicContentSize")]
 		void InvalidateIntrinsicContentSize ();
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("contentHuggingPriorityForAxis:")]
 		float ContentHuggingPriority (UILayoutConstraintAxis axis); // This returns a float, not nfloat.
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("setContentHuggingPriority:forAxis:")]
 		void SetContentHuggingPriority (float priority /* this is a float, not nfloat */, UILayoutConstraintAxis axis);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("contentCompressionResistancePriorityForAxis:")]
 		float ContentCompressionResistancePriority (UILayoutConstraintAxis axis); // This returns a float, not nfloat.
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("setContentCompressionResistancePriority:forAxis:")]
 		void SetContentCompressionResistancePriority (float priority /* this is a float, not nfloat */, UILayoutConstraintAxis axis);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("constraintsAffectingLayoutForAxis:")]
 		NSLayoutConstraint [] GetConstraintsAffectingLayout (UILayoutConstraintAxis axis);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("hasAmbiguousLayout")]
 		bool HasAmbiguousLayout { get; }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("exerciseAmbiguityInLayout")]
 		void ExerciseAmbiguityInLayout ();
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("systemLayoutSizeFittingSize:")]
 		CGSize SystemLayoutSizeFittingSize (CGSize size);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("decodeRestorableStateWithCoder:")]
 		void DecodeRestorableState (NSCoder coder);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("encodeRestorableStateWithCoder:")]
 		void EncodeRestorableState (NSCoder coder);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("restorationIdentifier", ArgumentSemantic.Copy)]
 		string RestorationIdentifier { get; set; }
 		
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("gestureRecognizerShouldBegin:")]
 		bool GestureRecognizerShouldBegin (UIGestureRecognizer gestureRecognizer);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("translatesAutoresizingMaskIntoConstraints")]
 		bool TranslatesAutoresizingMaskIntoConstraints { get; set; }
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("updateConstraintsIfNeeded")]
 		void UpdateConstraintsIfNeeded ();
 		
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("updateConstraints")]
 		void UpdateConstraints ();
 
@@ -14188,7 +14188,7 @@ namespace XamCore.UIKit {
 		[Export ("decodeRestorableStateWithCoder:")]
 		void DecodeRestorableState (NSCoder coder);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Export ("updateViewConstraints")]
 		void UpdateViewConstraints ();
 
@@ -15277,42 +15277,42 @@ namespace XamCore.UIKit {
 		// 6.0
 		//
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[Export ("setBackgroundImage:forState:")]
 		void SetBackgroundImage ([NullAllowed] UIImage image, UIControlState state);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[Export ("backgroundImageForState:")]
 		UIImage BackgroundImage (UIControlState state);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[Export ("setDividerImage:forLeftSegmentState:rightSegmentState:")]
 		void SetDividerImage ([NullAllowed] UIImage image, UIControlState leftState, UIControlState rightState);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[Export ("dividerImageForLeftSegmentState:rightSegmentState:")]
 		UIImage GetDividerImage (UIControlState leftState, UIControlState rightState);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[Export ("setIncrementImage:forState:")]
 		void SetIncrementImage ([NullAllowed] UIImage image, UIControlState state);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[Export ("incrementImageForState:")]
 		UIImage GetIncrementImage (UIControlState state);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[Export ("setDecrementImage:forState:")]
 		void SetDecrementImage ([NullAllowed] UIImage image, UIControlState state);
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[Export ("decrementImageForState:")]
 		UIImage GetDecrementImage (UIControlState state);
@@ -15373,7 +15373,7 @@ namespace XamCore.UIKit {
 		[Export ("perform")]
 		void Perform ();
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Static]
 		[Export ("segueWithIdentifier:source:destination:performHandler:")]
 		UIStoryboardSegue Create ([NullAllowed] string identifier, UIViewController source, UIViewController destination, NSAction performHandler);
@@ -15425,7 +15425,7 @@ namespace XamCore.UIKit {
 		UIPopoverArrowDirection ArrowDirection { get; set; }
 #pragma warning restore 618
 
-		[Since(6,0)]
+		[iOS (6,0)]
 		[Static, Export ("wantsDefaultContentAppearance")]
 		bool WantsDefaultContentAppearance { get; }
 	}
@@ -16090,14 +16090,14 @@ namespace XamCore.UIKit {
 		IntPtr Constructor ([NullAllowed] string text);
 	}
 
-	[Since(7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	interface UIMotionEffect : NSCoding, NSCopying {
 		[Export ("keyPathsAndRelativeValuesForViewerOffset:")]
 		NSDictionary ComputeKeyPathsAndRelativeValues (UIOffset viewerOffset);
 	}
 
-	[Since(7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (UIMotionEffect))]
 	interface UIInterpolatingMotionEffect : NSCoding {
 		[DesignatedInitializer]
@@ -16119,7 +16119,7 @@ namespace XamCore.UIKit {
 		NSObject MaximumRelativeValue { get; set;  }
 	}
 
-	[Since(7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (UIMotionEffect))]
 	interface UIMotionEffectGroup {
 		[NullAllowed] // by default this property is null

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -420,7 +420,7 @@ namespace XamCore.UIKit {
 
 	[Category, BaseType (typeof (NSMutableAttributedString))]
 	interface NSMutableAttributedStringKitAdditions {
-		[Since (7,0)] 
+		[iOS (7,0)] 
 		[Export ("fixAttributesInRange:")]
 		void FixAttributesInRange (NSRange range);
 	}
@@ -536,7 +536,7 @@ namespace XamCore.UIKit {
 #endif // XAMCORE_2_0
 
 	[NoWatch]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSLayoutConstraint {
 		[Static]
@@ -611,7 +611,7 @@ namespace XamCore.UIKit {
 	}
 #endif // !WATCH
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[ThreadSafe]
 	[BaseType (typeof (NSObject))]
 	interface NSParagraphStyle : NSSecureCoding, NSMutableCopying {
@@ -662,11 +662,11 @@ namespace XamCore.UIKit {
 		[Export ("defaultParagraphStyle")]
 		NSParagraphStyle Default { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("defaultTabInterval")]
 		nfloat DefaultTabInterval { get; [NotImplemented] set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("tabStops", ArgumentSemantic.Copy)]
 		NSTextTab[] TabStops { get; [NotImplemented] set; }
 
@@ -675,7 +675,7 @@ namespace XamCore.UIKit {
 		bool AllowsDefaultTighteningForTruncation { get; [NotImplemented] set; }
 	}
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[ThreadSafe]
 	[BaseType (typeof (NSParagraphStyle))]
 	interface NSMutableParagraphStyle {
@@ -731,12 +731,12 @@ namespace XamCore.UIKit {
 		[Override]
 		float HyphenationFactor { get; set; } // Returns a float, not nfloat.
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("defaultTabInterval")]
 		[Override]
 		nfloat DefaultTabInterval { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("tabStops", ArgumentSemantic.Copy)]
 		[Override]
 		NSTextTab[] TabStops { get; set; }
@@ -759,7 +759,7 @@ namespace XamCore.UIKit {
 		void SetParagraphStyle (NSParagraphStyle paragraphStyle);
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSTextTab : NSCoding, NSCopying, NSSecureCoding {
 
@@ -787,7 +787,7 @@ namespace XamCore.UIKit {
 
 #if !WATCH
 	[BaseType (typeof (NSObject))]
-	[Since (6,0)]
+	[iOS (6,0)]
 	interface NSShadow : NSCoding, NSCopying {
 		[Export ("shadowOffset", ArgumentSemantic.Assign)]
 		CGSize ShadowOffset { get; set; }
@@ -816,7 +816,7 @@ namespace XamCore.UIKit {
 		CGRect GetAttachmentBounds (NSTextContainer textContainer, CGRect proposedLineFragment, CGPoint glyphPosition, nuint characterIndex);
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	partial interface NSTextAttachment : NSTextAttachmentContainer, NSCoding
 #if !WATCH
@@ -863,7 +863,7 @@ namespace XamCore.UIKit {
 		}
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	partial interface NSTextContainer : NSTextLayoutOrientationProvider, NSCoding {
 
@@ -910,7 +910,7 @@ namespace XamCore.UIKit {
 		
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSMutableAttributedString), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSTextStorageDelegate)})]
 	partial interface NSTextStorage {
 		[Export ("layoutManagers")]
@@ -963,11 +963,11 @@ namespace XamCore.UIKit {
 		[Export ("ensureAttributesAreFixedInRange:")]
 		void EnsureAttributesAreFixed (NSRange range);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Notification, Internal, Field ("NSTextStorageWillProcessEditingNotification")]
 		NSString WillProcessEditingNotification { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Notification, Internal, Field ("NSTextStorageDidProcessEditingNotification")]
 		NSString DidProcessEditingNotification { get; }
 	}
@@ -984,7 +984,7 @@ namespace XamCore.UIKit {
 
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSLayoutManager : NSCoding {
 		[NullAllowed] // by default this property is null
@@ -1267,7 +1267,7 @@ namespace XamCore.UIKit {
 	
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
-	[Since (7,0)]
+	[iOS (7,0)]
 	partial interface NSLayoutManagerDelegate {
 		[Export ("layoutManager:shouldGenerateGlyphs:properties:characterIndexes:font:forGlyphRange:")]
 		nuint ShouldGenerateGlyphs (NSLayoutManager layoutManager, IntPtr glyphBuffer, IntPtr props, IntPtr charIndexes, UIFont aFont, NSRange glyphRange);
@@ -1449,7 +1449,7 @@ namespace XamCore.UIKit {
 		[Export ("accessibilityFrame")]
 		CGRect AccessibilityFrame { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("accessibilityActivationPoint")]
 		CGPoint AccessibilityActivationPoint { get; set; }
 
@@ -1457,19 +1457,19 @@ namespace XamCore.UIKit {
 		[Export ("accessibilityLanguage", ArgumentSemantic.Retain)]
 		string AccessibilityLanguage { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("accessibilityElementsHidden")]
 		bool AccessibilityElementsHidden { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("accessibilityViewIsModal")]
 		bool AccessibilityViewIsModal { get; set; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("shouldGroupAccessibilityChildren")]
 		bool ShouldGroupAccessibilityChildren { get; set; }
 
-		[Since (8,0)]
+		[iOS (8,0)]
 		[Export ("accessibilityNavigationStyle")]
 		UIAccessibilityNavigationStyle AccessibilityNavigationStyle { get; set; }
 
@@ -1482,7 +1482,7 @@ namespace XamCore.UIKit {
 		[Field ("UIAccessibilityTraitLink")]
 		long TraitLink { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("UIAccessibilityTraitHeader")]
 		long TraitHeader { get; }
 
@@ -1519,11 +1519,11 @@ namespace XamCore.UIKit {
 		[Field ("UIAccessibilityTraitAdjustable")]
 		long TraitAdjustable { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("UIAccessibilityTraitAllowsDirectInteraction")]
 		long TraitAllowsDirectInteraction { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("UIAccessibilityTraitCausesPageTurn")]
 		long TraitCausesPageTurn { get; }
 
@@ -1532,7 +1532,7 @@ namespace XamCore.UIKit {
 		[Field ("UIAccessibilityTraitTabBar")]
 		long TraitTabBar { get; }
 	
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("UIAccessibilityAnnouncementDidFinishNotification")]
 		[Notification (typeof (UIAccessibilityAnnouncementFinishedEventArgs))]
 		NSString AnnouncementDidFinishNotification { get; }
@@ -1550,25 +1550,25 @@ namespace XamCore.UIKit {
 		NSString VoiceOverStatusDidChangeNotification { get; }
 
 		[NoWatch]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("UIAccessibilityMonoAudioStatusDidChangeNotification")]
 		[Notification]
 		NSString MonoAudioStatusDidChangeNotification { get; }
 
 		[NoWatch]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("UIAccessibilityClosedCaptioningStatusDidChangeNotification")]
 		[Notification]
 		NSString ClosedCaptioningStatusDidChangeNotification { get; }
 
 		[NoWatch]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("UIAccessibilityInvertColorsStatusDidChangeNotification")]
 		[Notification]
 		NSString InvertColorsStatusDidChangeNotification { get; }
 
 		[NoWatch]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("UIAccessibilityGuidedAccessStatusDidChangeNotification")]
 		[Notification]
 		NSString GuidedAccessStatusDidChangeNotification { get; }
@@ -1582,28 +1582,28 @@ namespace XamCore.UIKit {
 		[Field ("UIAccessibilityAnnouncementNotification")]
 		int AnnouncementNotification { get; } // This is int, not nint
 
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Field ("UIAccessibilityPageScrolledNotification")]
 		int PageScrolledNotification { get; } // This is int, not nint
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("accessibilityPath", ArgumentSemantic.Copy)]
 		UIBezierPath AccessibilityPath { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("accessibilityActivate")]
 		bool AccessibilityActivate ();
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIAccessibilitySpeechAttributePunctuation")]
 		NSString SpeechAttributePunctuation { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIAccessibilitySpeechAttributeLanguage")]
 		NSString SpeechAttributeLanguage { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIAccessibilitySpeechAttributePitch")]
 		NSString SpeechAttributePitch { get; }
 
@@ -1981,19 +1981,19 @@ namespace XamCore.UIKit {
 #if !XAMCORE_2_0
 		[New] // To avoid the warning that we are overwriting the method in NSObject
 #endif
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("accessibilityScroll:")]
 		bool AccessibilityScroll (UIAccessibilityScrollDirection direction);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("accessibilityPerformEscape")]
 		bool AccessibilityPerformEscape ();
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("accessibilityPerformMagicTap")]
 		bool AccessibilityPerformMagicTap ();
 
-		[Since (8,0)]
+		[iOS (8,0)]
 		[Export ("accessibilityCustomActions"), NullAllowed]
 		UIAccessibilityCustomAction [] AccessibilityCustomActions { get; set; }
 	}
@@ -2103,11 +2103,11 @@ namespace XamCore.UIKit {
 		[Export ("dismissWithClickedButtonIndex:animated:")]
 		void DismissWithClickedButtonIndex (nint buttonIndex, bool animated);
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("showFromBarButtonItem:animated:")]
 		void ShowFrom (UIBarButtonItem item, bool animated);
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("showFromRect:inView:animated:")]
 		void ShowFrom (CGRect rect, UIView inView, bool animated);
 	}
@@ -2140,7 +2140,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	interface UIActivity {
 		[Export ("activityType")]
@@ -2167,13 +2167,13 @@ namespace XamCore.UIKit {
 		[Export ("activityDidFinish:")]
 		void Finished (bool completed);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("activityCategory"), Static]
 		UIActivityCategory Category  { get; }
 	}
 
 	[NoTV]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[Static]
 	interface UIActivityType
 	{
@@ -2204,27 +2204,27 @@ namespace XamCore.UIKit {
 		[Field ("UIActivityTypeSaveToCameraRoll")]
 		NSString SaveToCameraRoll { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIActivityTypeAddToReadingList")]
 		NSString AddToReadingList { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIActivityTypePostToFlickr")]
 		NSString PostToFlickr { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIActivityTypePostToVimeo")]
 		NSString PostToVimeo { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIActivityTypePostToTencentWeibo")]
 		NSString PostToTencentWeibo { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIActivityTypeAirDrop")]
 		NSString AirDrop { get; }
 
-		[Since (9,0)]
+		[iOS (9,0)]
 		[Field ("UIActivityTypeOpenInIBooks")]
 		NSString OpenInIBooks { get; }
 
@@ -2245,7 +2245,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSOperation))]
 	[ThreadSafe]
 	[DisableDefaultCtor] // NSInternalInconsistencyException Reason: Use initWithPlaceholderItem: to instantiate an instance of UIActivityItemProvider
@@ -2269,7 +2269,7 @@ namespace XamCore.UIKit {
 	interface IUIActivityItemSource { }
 
 	[NoTV]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -2282,21 +2282,21 @@ namespace XamCore.UIKit {
 		[Export ("activityViewController:itemForActivityType:")]
 		NSObject GetItemForActivity (UIActivityViewController activityViewController, [NullAllowed] NSString activityType);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("activityViewController:dataTypeIdentifierForActivityType:")]
 		string GetDataTypeIdentifierForActivity (UIActivityViewController activityViewController, [NullAllowed] NSString activityType);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("activityViewController:subjectForActivityType:")]
 		string GetSubjectForActivity (UIActivityViewController activityViewController, [NullAllowed] NSString activityType);
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("activityViewController:thumbnailImageForActivityType:suggestedSize:")]
 		UIImage GetThumbnailImageForActivity (UIActivityViewController activityViewController, [NullAllowed] NSString activityType, CGSize suggestedSize);
 	}
 
 	[NoTV]
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (UIViewController))]
 	[DisableDefaultCtor] // NSInternalInconsistencyException Reason: Use initWithActivityItems:applicationActivities: to instantiate an instance of UIActivityViewController
 	interface UIActivityViewController {
@@ -2436,11 +2436,11 @@ namespace XamCore.UIKit {
 		[Export ("dismissWithClickedButtonIndex:animated:")]
 		void DismissWithClickedButtonIndex (nint index, bool animated);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("alertViewStyle", ArgumentSemantic.Assign)]
 		UIAlertViewStyle AlertViewStyle { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("textFieldAtIndex:")]
 		UITextField GetTextField (nint textFieldIndex);
 	}
@@ -2468,7 +2468,7 @@ namespace XamCore.UIKit {
 		[Export ("alertView:didDismissWithButtonIndex:"), EventArgs ("UIButton")]
 		void Dismissed (UIAlertView alertView, nint buttonIndex);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("alertViewShouldEnableFirstOtherButton:"), DelegateName ("UIAlertViewPredicate"), DefaultValue (true)]
 		bool ShouldEnableFirstOtherButton (UIAlertView alertView);
 	}
@@ -2488,7 +2488,7 @@ namespace XamCore.UIKit {
 	interface UIAppearance {
 	}
 
-	[Since (9,0)]
+	[iOS (9,0)]
 	[BaseType (typeof (UIView))]
 	interface UIStackView {
 		[Export ("initWithFrame:")]
@@ -2538,14 +2538,14 @@ namespace XamCore.UIKit {
 	}
 		
 	[Static]
-	[Since (6,0)]
+	[iOS (6,0)]
 	interface UIStateRestoration {
 		[Field ("UIStateRestorationViewControllerStoryboardKey")]
 		NSString ViewControllerStoryboardKey { get; }
 
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -2571,7 +2571,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	[Since (7,0)]
+	[iOS (7,0)]
 	interface UIObjectRestoration {
 #if false
 		// a bit hard to support *static* as part of an interface / extension methods
@@ -2735,7 +2735,7 @@ namespace XamCore.UIKit {
 	}
 	
 	[Protocol]
-	[Since (6,0)]
+	[iOS (6,0)]
 	interface UIViewControllerRestoration {
 #if false
 		/* we don't generate anything for static members in protocols now, so just keep this out */
@@ -2877,7 +2877,7 @@ namespace XamCore.UIKit {
 		bool StatusBarHidden { [Bind ("isStatusBarHidden")] get; set; }
 
 		[NoTV]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("setStatusBarHidden:withAnimation:")]
 		void SetStatusBarHidden (bool state, UIStatusBarAnimation animation);
 
@@ -2988,28 +2988,28 @@ namespace XamCore.UIKit {
 		[Field ("UIApplicationLaunchOptionsRemoteNotificationKey")]
 		NSString LaunchOptionsRemoteNotificationKey { get; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("UIApplicationLaunchOptionsAnnotationKey")]
 		NSString LaunchOptionsAnnotationKey { get; }
 		
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("applicationState")]
 		UIApplicationState ApplicationState { get; }
 
-		[Since (4,0), ThreadSafe]
+		[iOS (4,0), ThreadSafe]
 		[Export ("backgroundTimeRemaining")]
 		double BackgroundTimeRemaining { get; }
 
-		[Since (4,0), ThreadSafe]
+		[iOS (4,0), ThreadSafe]
 		[Export ("beginBackgroundTaskWithExpirationHandler:")]
 		nint BeginBackgroundTask ([NullAllowed] NSAction backgroundTimeExpired);
 
-		[Since (4,0), ThreadSafe]
+		[iOS (4,0), ThreadSafe]
 		[Export ("endBackgroundTask:")]
 		void EndBackgroundTask (nint taskId);
 
 		[NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'PushKit' instead.")]
 		[Export ("setKeepAliveTimeout:handler:")]
 		bool SetKeepAliveTimeout (double timeout, [NullAllowed] NSAction handler);
@@ -3019,13 +3019,13 @@ namespace XamCore.UIKit {
 		[Export ("clearKeepAliveTimeout")]
 		void ClearKeepAliveTimeout ();
 		
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("protectedDataAvailable")]
 		bool ProtectedDataAvailable { [Bind ("isProtectedDataAvailable")] get; }
 
 		// from @interface UIApplication (UILocalNotifications)
 		[NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UNUserNotificationCenter.AddNotificationRequest' instead.")]
 		[Export ("presentLocalNotificationNow:")]
 #if XAMCORE_2_0
@@ -3036,106 +3036,106 @@ namespace XamCore.UIKit {
 
 		// from @interface UIApplication (UILocalNotifications)
 		[NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UNUserNotificationCenter.AddNotificationRequest' instead.")]
 		[Export ("scheduleLocalNotification:")]
 		void ScheduleLocalNotification (UILocalNotification notification);
 
 		// from @interface UIApplication (UILocalNotifications)
 		[NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UNUserNotificationCenter.RemovePendingNotificationRequests' instead.")]
 		[Export ("cancelLocalNotification:")]
 		void CancelLocalNotification (UILocalNotification notification);
 
 		// from @interface UIApplication (UILocalNotifications)
 		[NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UNUserNotificationCenter.RemoveAllPendingNotificationRequests' instead.")]
 		[Export ("cancelAllLocalNotifications")]
 		void CancelAllLocalNotifications ();
 
 		// from @interface UIApplication (UILocalNotifications)
 		[NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UNUserNotificationCenter.GetPendingNotificationRequests' instead.")]
 		[Export ("scheduledLocalNotifications", ArgumentSemantic.Copy)]
 		UILocalNotification [] ScheduledLocalNotifications { get; set; }
 
 		// from @interface UIApplication (UIRemoteControlEvents)
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("beginReceivingRemoteControlEvents")]
 		void BeginReceivingRemoteControlEvents ();
 
 		// from @interface UIApplication (UIRemoteControlEvents)
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("endReceivingRemoteControlEvents")]
 		void EndReceivingRemoteControlEvents ();
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("UIBackgroundTaskInvalid")]
 		nint BackgroundTaskInvalid { get; }
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("UIMinimumKeepAliveTimeout")]
 		double /* NSTimeInternal */ MinimumKeepAliveTimeout { get; }
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("UIApplicationProtectedDataWillBecomeUnavailable")]
 		[Notification]
 		NSString ProtectedDataWillBecomeUnavailable { get; }
 		
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("UIApplicationProtectedDataDidBecomeAvailable")]
 		[Notification]
 		NSString ProtectedDataDidBecomeAvailable { get; }
 		
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("UIApplicationLaunchOptionsLocationKey")]
 		NSString LaunchOptionsLocationKey { get; }
 		
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("UIApplicationDidEnterBackgroundNotification")]
 		[Notification]
 		NSString DidEnterBackgroundNotification { get; }
 		
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Field ("UIApplicationWillEnterForegroundNotification")]
 		[Notification]
 		NSString WillEnterForegroundNotification { get; }
 		
 		[NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UNUserNotificationCenterDelegate.DidReceiveNotificationResponse' instead.")]
 		[Field ("UIApplicationLaunchOptionsLocalNotificationKey")]
 		NSString LaunchOptionsLocalNotificationKey { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("userInterfaceLayoutDirection")]
 		UIUserInterfaceLayoutDirection UserInterfaceLayoutDirection { get; }
 
 		// from @interface UIApplication (UINewsstand)
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Deprecated (PlatformName.iOS, 9, 0)]
 		[Export ("setNewsstandIconImage:")]
 		void SetNewsstandIconImage ([NullAllowed] UIImage image);
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("UIApplicationLaunchOptionsNewsstandDownloadsKey")]
 		NSString LaunchOptionsNewsstandDownloadsKey { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIApplicationLaunchOptionsBluetoothCentralsKey")]
 		NSString LaunchOptionsBluetoothCentralsKey { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIApplicationLaunchOptionsBluetoothPeripheralsKey")]
 		NSString LaunchOptionsBluetoothPeripheralsKey { get; }
 
 		[NoTV]
-		[Since (9,0)]
+		[iOS (9,0)]
 		[Field ("UIApplicationLaunchOptionsShortcutItemKey")]
 		NSString LaunchOptionsShortcutItemKey { get; }
 
@@ -3178,60 +3178,60 @@ namespace XamCore.UIKit {
 		NSString ContentSizeCategoryChangedNotification { get; }
 		
 		[ThreadSafe]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("beginBackgroundTaskWithName:expirationHandler:")]
 		nint BeginBackgroundTask (string taskName, NSAction expirationHandler);
 
 		[TV (11,0)]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIApplicationBackgroundFetchIntervalMinimum")]
 		double BackgroundFetchIntervalMinimum { get; }
 
 		[TV (11,0)]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIApplicationBackgroundFetchIntervalNever")]
 		double BackgroundFetchIntervalNever { get; }
 
 		[TV (11,0)]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("setMinimumBackgroundFetchInterval:")]
 		void SetMinimumBackgroundFetchInterval (double minimumBackgroundFetchInterval);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("preferredContentSizeCategory")]
 		NSString PreferredContentSizeCategory { get; }
 
 		// from @interface UIApplication (UIStateRestoration)
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("ignoreSnapshotOnNextApplicationLaunch")]
 		void IgnoreSnapshotOnNextApplicationLaunch ();
 
 		// from @interface UIApplication (UIStateRestoration)
 		[Export ("registerObjectForStateRestoration:restorationIdentifier:")]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static]
 		void RegisterObjectForStateRestoration (IUIStateRestoring uistateRestoringObject, string restorationIdentifier);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIApplicationStateRestorationTimestampKey")]
 		NSString StateRestorationTimestampKey { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIApplicationStateRestorationSystemVersionKey")]
 		NSString StateRestorationSystemVersionKey { get; }
 
 		[TV (11,0)]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("backgroundRefreshStatus")]
 		UIBackgroundRefreshStatus BackgroundRefreshStatus { get; }
 
 		[TV (11,0)]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Notification]
 		[Field ("UIApplicationBackgroundRefreshStatusDidChangeNotification")]
 		NSString BackgroundRefreshStatusDidChangeNotification { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Notification]
 		[Field ("UIApplicationUserDidTakeScreenshotNotification")]
 		NSString UserDidTakeScreenshotNotification { get; }
@@ -3388,7 +3388,7 @@ namespace XamCore.UIKit {
 		NSDictionary<NSString,NSObject> UserInfo { get; set; }
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (UIDynamicBehavior))]
 	[DisableDefaultCtor] // Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: init is undefined for objects of type UIAttachmentBehavior
 	interface UIAttachmentBehavior {
@@ -3473,7 +3473,7 @@ namespace XamCore.UIKit {
 		NSString WeakNewValue { get; }
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Static]
 	[NoWatch]
 	public enum UIContentSizeCategory {
@@ -3605,25 +3605,25 @@ namespace XamCore.UIKit {
 		void ReceivedRemoteNotification (UIApplication application, NSDictionary userInfo);
 
 		[NoTV]
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UNUserNotificationCenterDelegate.WillPresentNotification/DidReceiveNotificationResponse' instead.")]
 		[Export ("application:didReceiveLocalNotification:")]
 		void ReceivedLocalNotification (UIApplication application, UILocalNotification notification);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("applicationDidEnterBackground:")]
 		void DidEnterBackground (UIApplication application);
 		
 		[Export ("applicationWillEnterForeground:")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		void WillEnterForeground (UIApplication application);
 		
 		[Export ("applicationProtectedDataWillBecomeUnavailable:")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		void ProtectedDataWillBecomeUnavailable (UIApplication application);
 		
 		[Export ("applicationProtectedDataDidBecomeAvailable:")]
-		[Since (4,0)]
+		[iOS (4,0)]
 		void ProtectedDataDidBecomeAvailable (UIApplication application);
 
 		[NoTV]
@@ -3639,7 +3639,7 @@ namespace XamCore.UIKit {
 		[Wrap ("OpenUrl(app, url, options.Dictionary)")]
 		bool OpenUrl (UIApplication app, NSUrl url, UIApplicationOpenUrlOptions options);
 		
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("window", ArgumentSemantic.Retain), NullAllowed]
 		UIWindow Window { get; set; }
 
@@ -3680,21 +3680,21 @@ namespace XamCore.UIKit {
 		// appropriate to implement the accessibilityPerformMagicTap method in your app delegate."
 		// ref: http://developer.apple.com/library/ios/#featuredarticles/ViewControllerPGforiPhoneOS/Accessibility/AccessibilityfromtheViewControllersPerspective.html
 		[NoTV]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("accessibilityPerformMagicTap")]
 		bool AccessibilityPerformMagicTap ();
 
 		[TV (10, 0)]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("application:didReceiveRemoteNotification:fetchCompletionHandler:")]
 		void DidReceiveRemoteNotification (UIApplication application, NSDictionary userInfo, Action<UIBackgroundFetchResult> completionHandler);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("application:handleEventsForBackgroundURLSession:completionHandler:")]
 		void HandleEventsForBackgroundUrl (UIApplication application, string sessionIdentifier, NSAction completionHandler);
 
 		[TV (11,0)]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("application:performFetchWithCompletionHandler:")]
 		void PerformFetch (UIApplication application, Action<UIBackgroundFetchResult> completionHandler);
 
@@ -3805,22 +3805,22 @@ namespace XamCore.UIKit {
 		nint Tag { get; set; }
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("landscapeImagePhone", ArgumentSemantic.Retain)]
 		UIImage LandscapeImagePhone { get; set;  }
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("landscapeImagePhoneInsets")]
 		UIEdgeInsets LandscapeImagePhoneInsets { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setTitleTextAttributes:forState:"), Internal]
 		[Appearance]
 		void _SetTitleTextAttributes ([NullAllowed] NSDictionary attributes, UIControlState state);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("titleTextAttributesForState:"), Internal]
 		[Appearance]
 		NSDictionary _GetTitleTextAttributes (UIControlState state);
@@ -3896,12 +3896,12 @@ namespace XamCore.UIKit {
 		[Export ("tag")][Override]
 		nint Tag { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("tintColor", ArgumentSemantic.Retain), NullAllowed]
 		[Appearance]
 		UIColor TintColor { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("initWithImage:landscapeImagePhone:style:target:action:"), PostGet ("Image")]
 #if !TVOS
 		[PostGet ("LandscapeImagePhone")]
@@ -3909,68 +3909,68 @@ namespace XamCore.UIKit {
 		[PostGet ("Target")]
 		IntPtr Constructor ([NullAllowed] UIImage image, [NullAllowed] UIImage landscapeImagePhone, UIBarButtonItemStyle style, [NullAllowed] NSObject target, [NullAllowed] Selector action);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setBackgroundImage:forState:barMetrics:")]
 		[Appearance]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIControlState state, UIBarMetrics barMetrics);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("backgroundImageForState:barMetrics:")]
 		[Appearance]
 		UIImage GetBackgroundImage (UIControlState state, UIBarMetrics barMetrics);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setBackgroundVerticalPositionAdjustment:forBarMetrics:")]
 		[Appearance]
 		void SetBackgroundVerticalPositionAdjustment (nfloat adjustment, UIBarMetrics forBarMetrics);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("backgroundVerticalPositionAdjustmentForBarMetrics:")]
 		[Appearance]
 		nfloat GetBackgroundVerticalPositionAdjustment (UIBarMetrics forBarMetrics);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setTitlePositionAdjustment:forBarMetrics:")]
 		[Appearance]
 		void SetTitlePositionAdjustment (UIOffset adjustment, UIBarMetrics barMetrics);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("titlePositionAdjustmentForBarMetrics:")]
 		[Appearance]
 		UIOffset GetTitlePositionAdjustment (UIBarMetrics barMetrics);
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setBackButtonBackgroundImage:forState:barMetrics:")]
 		[Appearance]
 		void SetBackButtonBackgroundImage ([NullAllowed] UIImage backgroundImage, UIControlState forState, UIBarMetrics barMetrics);
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("backButtonBackgroundImageForState:barMetrics:")]
 		[Appearance]
 		UIImage GetBackButtonBackgroundImage (UIControlState forState, UIBarMetrics barMetrics);
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setBackButtonTitlePositionAdjustment:forBarMetrics:")]
 		[Appearance]
 		void SetBackButtonTitlePositionAdjustment (UIOffset adjustment, UIBarMetrics barMetrics);
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("backButtonTitlePositionAdjustmentForBarMetrics:")]
 		[Appearance]
 		UIOffset GetBackButtonTitlePositionAdjustment (UIBarMetrics barMetrics);
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setBackButtonBackgroundVerticalPositionAdjustment:forBarMetrics:")]
 		[Appearance]
 		void SetBackButtonBackgroundVerticalPositionAdjustment (nfloat adjustment, UIBarMetrics barMetrics);
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("backButtonBackgroundVerticalPositionAdjustmentForBarMetrics:")]
 		[Appearance]
 		nfloat GetBackButtonBackgroundVerticalPositionAdjustment (UIBarMetrics barMetrics);
@@ -4008,7 +4008,7 @@ namespace XamCore.UIKit {
 		bool DisplayingRepresentativeItem { [Bind ("isDisplayingRepresentativeItem")] get; }
 	}
 	
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (UIView))]
 	interface UICollectionReusableView {
 		[Export ("initWithFrame:")]
@@ -4034,7 +4034,7 @@ namespace XamCore.UIKit {
 		UICollectionViewLayoutAttributes PreferredLayoutAttributesFittingAttributes (UICollectionViewLayoutAttributes layoutAttributes);
 	}
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (UIScrollView))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: UICollectionView must be initialized with a non-nil layout parameter
 	[DisableDefaultCtor]
@@ -4177,22 +4177,22 @@ namespace XamCore.UIKit {
 		//
 		// 7.0
 		//
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("startInteractiveTransitionToCollectionViewLayout:completion:")]
 		[Async (ResultTypeName="UICollectionViewTransitionResult")]
 		UICollectionViewTransitionLayout StartInteractiveTransition (UICollectionViewLayout newCollectionViewLayout,
 									     UICollectionViewLayoutInteractiveTransitionCompletion completion);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("setCollectionViewLayout:animated:completion:")]
 		[Async]
 		void SetCollectionViewLayout (UICollectionViewLayout layout, bool animated, UICompletionHandler completion);
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("finishInteractiveTransition")]
 		void FinishInteractiveTransition ();
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("cancelInteractiveTransition")]
 		void CancelInteractiveTransition ();
 
@@ -4291,7 +4291,7 @@ namespace XamCore.UIKit {
 	//
 	// Combined version of UICollectionViewDataSource, UICollectionViewDelegate
 	//
-	[Since (6,0)]
+	[iOS (6,0)]
 	[Model]
 	[BaseType (typeof (NSObject))]
 	[Protocol (IsInformal = true)]
@@ -4299,7 +4299,7 @@ namespace XamCore.UIKit {
 		
 	}
 	
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -4337,7 +4337,7 @@ namespace XamCore.UIKit {
 		NSIndexPath GetIndexPath (UICollectionView collectionView, string title, nint atIndex);
 	}
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[Model]
 	[Protocol]
 #if XAMCORE_3_0
@@ -4393,7 +4393,7 @@ namespace XamCore.UIKit {
 		[Export ("collectionView:performAction:forItemAtIndexPath:withSender:")]
 		void PerformAction (UICollectionView collectionView, Selector action, NSIndexPath indexPath, NSObject sender);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("collectionView:transitionLayoutForOldLayout:newLayout:")]
 		UICollectionViewTransitionLayout TransitionLayout (UICollectionView collectionView, UICollectionViewLayout fromLayout, UICollectionViewLayout toLayout);
 		[iOS (9,0)]
@@ -4427,7 +4427,7 @@ namespace XamCore.UIKit {
 		bool ShouldSpringLoadItem (UICollectionView collectionView, NSIndexPath indexPath, IUISpringLoadedInteractionContext context);
 	}
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (UICollectionReusableView))]
 	interface UICollectionViewCell {
 		[Export ("initWithFrame:")]
@@ -4456,7 +4456,7 @@ namespace XamCore.UIKit {
 		void DragStateDidChange (UICollectionViewCellDragState dragState);
 	}
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (UIViewController))]
 	interface UICollectionViewController : UICollectionViewSource, NSCoding {
 		[DesignatedInitializer]
@@ -4476,11 +4476,11 @@ namespace XamCore.UIKit {
 		[Export ("initWithCollectionViewLayout:")]
 		IntPtr Constructor (UICollectionViewLayout layout);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("collectionViewLayout")]
 		UICollectionViewLayout Layout { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("useLayoutToLayoutNavigationTransitions", ArgumentSemantic.Assign)]
 		bool UseLayoutToLayoutNavigationTransitions { get; set; }
 
@@ -4489,7 +4489,7 @@ namespace XamCore.UIKit {
 		bool InstallsStandardGestureForInteractiveMovement { get; set; }		
 	}
 	
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (UICollectionViewDelegate))]
 	[Model]
 	[Protocol]
@@ -4513,7 +4513,7 @@ namespace XamCore.UIKit {
 		CGSize GetReferenceSizeForFooter (UICollectionView collectionView, UICollectionViewLayout layout, nint section);
 	}
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (UICollectionViewLayout))]
 	interface UICollectionViewFlowLayout {
 		[Export ("minimumLineSpacing")]
@@ -4560,7 +4560,7 @@ namespace XamCore.UIKit {
 		CGSize AutomaticSize { get; }
 	}
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	interface UICollectionViewLayout : NSCoding {
 		[Export ("collectionView")]
@@ -4648,47 +4648,47 @@ namespace XamCore.UIKit {
 		[Static, Export ("layoutAttributesClass")]
 		Class LayoutAttributesClass { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static, Export ("invalidationContextClass")]
 		Class InvalidationContextClass ();
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("invalidationContextForBoundsChange:")]
 		UICollectionViewLayoutInvalidationContext GetInvalidationContextForBoundsChange (CGRect newBounds);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("indexPathsToDeleteForSupplementaryViewOfKind:")]
 		NSIndexPath [] GetIndexPathsToDeleteForSupplementaryView (NSString kind);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("indexPathsToDeleteForDecorationViewOfKind:")]
 		NSIndexPath [] GetIndexPathsToDeleteForDecorationViewOfKind (NSString kind);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("indexPathsToInsertForSupplementaryViewOfKind:")]
 		NSIndexPath [] GetIndexPathsToInsertForSupplementaryView (NSString kind);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("indexPathsToInsertForDecorationViewOfKind:")]
 		NSIndexPath [] GetIndexPathsToInsertForDecorationView (NSString kind);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("invalidateLayoutWithContext:")]
 		void InvalidateLayout (UICollectionViewLayoutInvalidationContext context);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("finalizeLayoutTransition")]
 		void FinalizeLayoutTransition ();
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("prepareForTransitionFromLayout:")]
 		void PrepareForTransitionFromLayout (UICollectionViewLayout oldLayout);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("prepareForTransitionToLayout:")]
 		void PrepareForTransitionToLayout (UICollectionViewLayout newLayout);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("targetContentOffsetForProposedContentOffset:")]
 		CGPoint TargetContentOffsetForProposedContentOffset (CGPoint proposedContentOffset);
 
@@ -4719,7 +4719,7 @@ namespace XamCore.UIKit {
 		bool FlipsHorizontallyInOppositeLayoutDirection { get; }
 	}
 	
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	interface UICollectionViewLayoutAttributes : UIDynamicItem, NSCopying {
 		[Export ("frame")]
@@ -4764,17 +4764,17 @@ namespace XamCore.UIKit {
 		[Export ("layoutAttributesForSupplementaryViewOfKind:withIndexPath:")]
 		UICollectionViewLayoutAttributes CreateForSupplementaryView (NSString kind, NSIndexPath indexPath);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("bounds")]
 		new CGRect Bounds { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("transform")]
 		new CGAffineTransform Transform { get; set; }
 		
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	interface UICollectionViewLayoutInvalidationContext {
 		[Export ("invalidateDataSourceCounts")]
@@ -4828,7 +4828,7 @@ namespace XamCore.UIKit {
 		CGPoint InteractiveMovementTarget { get; }
 	}
 	
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (UICollectionViewLayoutInvalidationContext))]
 	partial interface UICollectionViewFlowLayoutInvalidationContext {
 		[Export ("invalidateFlowLayoutDelegateMetrics")]
@@ -4838,7 +4838,7 @@ namespace XamCore.UIKit {
 		bool InvalidateFlowLayoutAttributes { get; set; }
 	}
 	
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (UICollectionViewLayout))]
 	[DisableDefaultCtor] // NSInternalInconsistencyException Reason: -[UICollectionViewTransitionLayout init] is not a valid initializer - use -initWithCurrentLayout:nextLayout: instead
 	interface UICollectionViewTransitionLayout : NSCoding {
@@ -4864,7 +4864,7 @@ namespace XamCore.UIKit {
 		nfloat TransitionProgress { get; set; }
 	}
 	
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	interface UICollectionViewUpdateItem {
 		[NullAllowed]
@@ -4879,7 +4879,7 @@ namespace XamCore.UIKit {
 		UICollectionUpdateAction UpdateAction { get;  }
 	}
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[Static]
 	interface UICollectionElementKindSectionKey
 	{
@@ -5038,25 +5038,25 @@ namespace XamCore.UIKit {
 		[Export ("viewFlipsideBackgroundColor")][Static]
 		UIColor ViewFlipsideBackgroundColor { get; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_7_0)]
 		[NoWatch][NoTV]
 		[Export ("scrollViewTexturedBackgroundColor")][Static]
 		UIColor ScrollViewTexturedBackgroundColor { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0)]
 		[NoWatch][NoTV]
 		[Static, Export ("underPageBackgroundColor")]
 		UIColor UnderPageBackgroundColor { get; }
 
 		[NoWatch]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Static, Export ("colorWithCIColor:")]
 		UIColor FromCIColor (CIColor color);
 
 		[NoWatch]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("initWithCIColor:")]
 		IntPtr Constructor (CIColor ciColor);
 
@@ -5103,7 +5103,7 @@ namespace XamCore.UIKit {
 	}
 
 #if !WATCH
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (UIDynamicBehavior),
 		   Delegates=new string [] { "CollisionDelegate" },
 		   Events=new Type [] { typeof (UICollisionBehaviorDelegate)})]
@@ -5158,7 +5158,7 @@ namespace XamCore.UIKit {
 		void RemoveAllBoundaries ();
 	}
 	
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[Protocol]
 	[Model]
@@ -5177,7 +5177,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: do not call -[UIDocument init] - the designated initializer is -[UIDocument initWithFileURL:
 	[DisableDefaultCtor]
@@ -5321,7 +5321,7 @@ namespace XamCore.UIKit {
 		void DidPause (UIDynamicAnimator animator);
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	interface UIDynamicAnimator {
 		[DesignatedInitializer]
@@ -5382,7 +5382,7 @@ namespace XamCore.UIKit {
 
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (UIDynamicBehavior))]
 	interface UIDynamicItemBehavior {
 		[DesignatedInitializer]
@@ -5479,7 +5479,7 @@ namespace XamCore.UIKit {
 
 	interface IUIDynamicItem {}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	interface UIDynamicBehavior {
 		[Export ("childBehaviors", ArgumentSemantic.Copy)]
@@ -5690,7 +5690,7 @@ namespace XamCore.UIKit {
 		[Export ("xHeight")]
 		nfloat xHeight { get; }
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("lineHeight")]
 		nfloat LineHeight { get; }
 
@@ -5700,16 +5700,16 @@ namespace XamCore.UIKit {
 		[Static] [Export ("fontNamesForFamilyName:")]
 		string [] FontNamesForFamilyName (string familyName);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("fontDescriptor")]
 		UIFontDescriptor FontDescriptor { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static, Export ("fontWithDescriptor:size:")]
 		[Internal] // bug 25511
 		IntPtr _FromDescriptor (UIFontDescriptor descriptor, nfloat pointSize);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static, Export ("preferredFontForTextStyle:")]
 		[Internal] // bug 25511
 		IntPtr _GetPreferredFontForTextStyle (NSString uiFontTextStyle);
@@ -5725,43 +5725,43 @@ namespace XamCore.UIKit {
 	}
 
 	public enum UIFontTextStyle {
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIFontTextStyleHeadline")]
 		Headline,
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIFontTextStyleBody")]
 		Body,
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIFontTextStyleSubheadline")]
 		Subheadline,
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIFontTextStyleFootnote")]
 		Footnote,
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIFontTextStyleCaption1")]
 		Caption1,
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("UIFontTextStyleCaption2")]
 		Caption2,
 
-		[Since (9,0)]
+		[iOS (9,0)]
 		[Field ("UIFontTextStyleTitle1")]
 		Title1,
 		
-		[Since (9,0)]
+		[iOS (9,0)]
 		[Field ("UIFontTextStyleTitle2")]
 		Title2,
 		
-		[Since (9,0)]
+		[iOS (9,0)]
 		[Field ("UIFontTextStyleTitle3")]
 		Title3,
 		
-		[Since (9,0)]
+		[iOS (9,0)]
 		[Field ("UIFontTextStyleCallout")]
 		Callout,
 
@@ -5771,7 +5771,7 @@ namespace XamCore.UIKit {
 		LargeTitle,
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
 	partial interface UIFontDescriptor : NSSecureCoding, NSCopying {
@@ -5929,7 +5929,7 @@ namespace XamCore.UIKit {
 	}
 
 #if !WATCH
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof(NSObject), Delegates=new string [] {"WeakDelegate"}, Events=new Type[] {typeof (UIGestureRecognizerDelegate)})]
 	interface UIGestureRecognizer {
 		[DesignatedInitializer]
@@ -6077,7 +6077,7 @@ namespace XamCore.UIKit {
 
 	[NoWatch]
 	[BaseType (typeof(NSObject))]
-	[Model][Since (3,2)]
+	[Model][iOS (3,2)]
 	[Protocol]
 	interface UIGestureRecognizerDelegate {
 		[Export ("gestureRecognizer:shouldReceiveTouch:"), DefaultValue (true), DelegateName ("UITouchEventArgs")]
@@ -6089,11 +6089,11 @@ namespace XamCore.UIKit {
 		[Export ("gestureRecognizerShouldBegin:"), DelegateName ("UIGestureProbe"), DefaultValue (true)]
 		bool ShouldBegin (UIGestureRecognizer recognizer);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:"), DelegateName ("UIGesturesProbe"), DefaultValue (false)]
 		bool ShouldBeRequiredToFailBy (UIGestureRecognizer gestureRecognizer, UIGestureRecognizer otherGestureRecognizer);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("gestureRecognizer:shouldRequireFailureOfGestureRecognizer:"), DelegateName ("UIGesturesProbe"), DefaultValue (false)]
 		bool ShouldRequireFailureOf (UIGestureRecognizer gestureRecognizer, UIGestureRecognizer otherGestureRecognizer);
 
@@ -6301,7 +6301,7 @@ namespace XamCore.UIKit {
 	}
 
 	[BaseType (typeof (UIDynamicBehavior))]
-	[Since (7,0)]
+	[iOS (7,0)]
 	interface UIGravityBehavior {
 		[DesignatedInitializer]
 		[Export ("initWithItems:")]
@@ -6366,7 +6366,7 @@ namespace XamCore.UIKit {
 		bool SecureTextEntry { [Bind ("isSecureTextEntry")] get; set;  }
 
 		[Abstract]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("spellCheckingType")]
 		UITextSpellCheckingType SpellCheckingType { get; set; }
 
@@ -6428,13 +6428,13 @@ namespace XamCore.UIKit {
 		NSString DidHideNotification { get; }
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field("UIKeyboardWillChangeFrameNotification")]
 		[Notification (typeof (UIKeyboardEventArgs))]
 		NSString WillChangeFrameNotification { get; }
 		
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field("UIKeyboardDidChangeFrameNotification")]
 		[Notification (typeof (UIKeyboardEventArgs))]
 		NSString DidChangeFrameNotification { get; }
@@ -6463,22 +6463,22 @@ namespace XamCore.UIKit {
 		// Keys
 		//
 		[NoTV]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("UIKeyboardAnimationCurveUserInfoKey")]
 		NSString AnimationCurveUserInfoKey { get; }
 
 		[NoTV]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("UIKeyboardAnimationDurationUserInfoKey")]
 		NSString AnimationDurationUserInfoKey { get; }
 
 		[NoTV]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("UIKeyboardFrameEndUserInfoKey")]
 		NSString FrameEndUserInfoKey { get; }
 
 		[NoTV]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Field ("UIKeyboardFrameBeginUserInfoKey")]
 		NSString FrameBeginUserInfoKey { get; }
 
@@ -6488,7 +6488,7 @@ namespace XamCore.UIKit {
 		NSString IsLocalUserInfoKey { get; }
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	interface UIKeyCommand : NSCopying, NSSecureCoding {
 		[NullAllowed, Export ("input")]
@@ -6526,7 +6526,7 @@ namespace XamCore.UIKit {
 		NSString DiscoverabilityTitle { get; set; }
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[Protocol]
 	interface UIKeyInput : UITextInputTraits {
 		[Abstract]
@@ -6720,36 +6720,36 @@ namespace XamCore.UIKit {
 		[Notification]
 		NSString CurrentInputModeDidChangeNotification { get; }
 		
-		[Since (5,1)]
+		[iOS (5,1)]
 		[Export ("dictationRecognitionFailed")]
 		void DictationRecognitionFailed ();
 		
-		[Since (5,1)]
+		[iOS (5,1)]
 		[Export ("dictationRecordingDidEnd")]
 		void DictationRecordingDidEnd ();
 		
-		[Since (5,1)]
+		[iOS (5,1)]
 		[Export ("insertDictationResult:")]
 		void InsertDictationResult (NSArray dictationResult);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Abstract]
 		[Export ("selectionRectsForRange:")]
 		UITextSelectionRect [] GetSelectionRects (UITextRange range);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("shouldChangeTextInRange:replacementText:")]
 		bool ShouldChangeTextInRange (UITextRange inRange, string replacementText);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("frameForDictationResultPlaceholder:")]
 		CGRect GetFrameForDictationResultPlaceholder (NSObject placeholder);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("insertDictationResultPlaceholder")]
 		NSObject InsertDictationResultPlaceholder ();
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("removeDictationResultPlaceholder:willInsertResult:")]
 		void RemoveDictationResultPlaceholder (NSObject placeholder, bool willInsertResult);
 
@@ -6803,7 +6803,7 @@ namespace XamCore.UIKit {
 
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 #if XAMCORE_2_0
 	[BaseType (typeof (NSObject))]
 	interface UITextInputStringTokenizer : UITextInputTokenizer{
@@ -6856,7 +6856,7 @@ namespace XamCore.UIKit {
 #endif
 	}
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (NSObject))]
 	interface UITextSelectionRect {
 		[Export ("rect")]
@@ -6920,7 +6920,7 @@ namespace XamCore.UIKit {
 #endif // !WATCH
 
 	[NoTV]
-	[Since (4,0)]
+	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	[Availability (Deprecated = Platform.iOS_10_0, Message = "Use 'UserNotifications.UNNotificationRequest' instead.")]
 	interface UILocalNotification : NSCoding, NSCopying {
@@ -6990,7 +6990,7 @@ namespace XamCore.UIKit {
 	}
 	
 #if !WATCH
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UILongPressGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7010,7 +7010,7 @@ namespace XamCore.UIKit {
 		nint NumberOfTapsRequired { get; set; }
 	}
 
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UITapGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7024,7 +7024,7 @@ namespace XamCore.UIKit {
 		nuint NumberOfTouchesRequired { get; set; }
 	}
 
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UIPanGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7049,7 +7049,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (UIPanGestureRecognizer))]
 	interface UIScreenEdgePanGestureRecognizer {
 
@@ -7114,7 +7114,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UIRotationGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7128,7 +7128,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UIPinchGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7141,7 +7141,7 @@ namespace XamCore.UIKit {
 		nfloat Velocity { get; }
 	}
 
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UISwipeGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7180,7 +7180,7 @@ namespace XamCore.UIKit {
 		[Export ("isAnimating")]
 		bool IsAnimating { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("color", ArgumentSemantic.Retain), NullAllowed]
 		[Appearance]
 		UIColor Color { get; set; }
@@ -7248,7 +7248,7 @@ namespace XamCore.UIKit {
 		UIImage FromImage (CGImage image, nfloat scale, UIImageOrientation orientation);
 
 #if !WATCH
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Static][Export ("imageWithCIImage:")][Autorelease]
 		[ThreadSafe]			
 		UIImage FromImage (CIImage image);
@@ -7275,12 +7275,12 @@ namespace XamCore.UIKit {
 
 		[Export ("renderingMode")]
 		[ThreadSafe]
-		[Since (7,0)]
+		[iOS (7,0)]
 		UIImageRenderingMode RenderingMode { get;  }
 
 		[Export ("imageWithRenderingMode:")]
 		[ThreadSafe]
-		[Since (7,0)]
+		[iOS (7,0)]
 		UIImage ImageWithRenderingMode (UIImageRenderingMode renderingMode);
 
 		[Export ("CGImage")]
@@ -7326,22 +7326,22 @@ namespace XamCore.UIKit {
 		[ThreadSafe]
 		nint TopCapHeight { get; }
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("scale")]
 		[ThreadSafe]
 		nfloat CurrentScale { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Static, Export ("animatedImageNamed:duration:")][Autorelease]
 		[ThreadSafe]
 		UIImage CreateAnimatedImage (string name, double duration);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Static, Export ("animatedImageWithImages:duration:")][Autorelease]
 		[ThreadSafe]
 		UIImage CreateAnimatedImage (UIImage [] images, double duration);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Static, Export ("animatedResizableImageNamed:capInsets:duration:")][Autorelease]
 		[ThreadSafe]
 		UIImage CreateAnimatedImage (string name, UIEdgeInsets capInsets, double duration);
@@ -7351,7 +7351,7 @@ namespace XamCore.UIKit {
 		IntPtr Constructor (CGImage cgImage);
 
 #if !WATCH
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("initWithCIImage:")]
 		[ThreadSafe]
 		IntPtr Constructor (CIImage ciImage);
@@ -7362,28 +7362,28 @@ namespace XamCore.UIKit {
 		IntPtr Constructor (CGImage cgImage, nfloat scale,  UIImageOrientation orientation);
 
 #if !WATCH
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("CIImage")]
 		[ThreadSafe]
 		CIImage CIImage { get; }
 #endif // !WATCH
 		
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("images")]
 		[ThreadSafe]
 		UIImage [] Images { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("duration")]
 		[ThreadSafe]
 		double Duration { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("resizableImageWithCapInsets:")][Autorelease]
 		[ThreadSafe]
 		UIImage CreateResizableImage (UIEdgeInsets capInsets);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("capInsets")]
 		[ThreadSafe]
 		UIEdgeInsets CapInsets { get; }
@@ -7427,7 +7427,7 @@ namespace XamCore.UIKit {
 		[ThreadSafe]
 		UIImage CreateResizableImage (UIEdgeInsets capInsets, UIImageResizingMode resizingMode);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Static]
 		[Export ("animatedResizableImageNamed:capInsets:resizingMode:duration:")]
 		[ThreadSafe]
@@ -7438,7 +7438,7 @@ namespace XamCore.UIKit {
 		[ThreadSafe, Autorelease]
 		UIImage ImageWithAlignmentRectInsets (UIEdgeInsets alignmentInsets);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("resizingMode")]
 		[ThreadSafe]
 		UIImageResizingMode ResizingMode { get; }
@@ -7518,7 +7518,7 @@ namespace XamCore.UIKit {
 		[Export ("touchesForWindow:")]
 		NSSet TouchesForWindow (UIWindow window);
 		
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("touchesForGestureRecognizer:")]
 		NSSet TouchesForGestureRecognizer (UIGestureRecognizer window);
 
@@ -7590,7 +7590,7 @@ namespace XamCore.UIKit {
 		[Export ("rootViewController", ArgumentSemantic.Retain)]
 		UIViewController RootViewController { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("screen", ArgumentSemantic.Retain)]
 		UIScreen Screen { get; set; }
 
@@ -7697,7 +7697,7 @@ namespace XamCore.UIKit {
 #if XAMCORE_2_0
 		[Abstract]
 #endif
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("barPosition")]
 		UIBarPosition BarPosition { get; }
 	}
@@ -7714,7 +7714,7 @@ namespace XamCore.UIKit {
 	}
 #endif // !WATCH
 	
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
 	interface UIBezierPath : NSSecureCoding, NSCopying {
@@ -7821,7 +7821,7 @@ namespace XamCore.UIKit {
 		[Internal, Export ("setLineDash:count:phase:")]
 		void SetLineDash (IntPtr fvalues, nint count, nfloat phase);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("addArcWithCenter:radius:startAngle:endAngle:clockwise:")]
 		void AddArc (CGPoint center, nfloat radius, nfloat startAngle, nfloat endAngle, bool clockWise);
 
@@ -8232,7 +8232,7 @@ namespace XamCore.UIKit {
 		[Export ("proximityState")]
 		bool ProximityState { get; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Internal]
 		[Export ("userInterfaceIdiom")]
 		UIUserInterfaceIdiom _UserInterfaceIdiom { get; }
@@ -8256,11 +8256,11 @@ namespace XamCore.UIKit {
 		[Notification]
 		NSString ProximityStateDidChangeNotification { get; }
 		
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("isMultitaskingSupported"), Internal]
 		bool _IsMultitaskingSupported { get; }
 
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("playInputClick")]
 		void PlayInputClick ();
 
@@ -8269,7 +8269,7 @@ namespace XamCore.UIKit {
 		NSUuid IdentifierForVendor { get;  }
 	}
 	
-	[Since (5,1)]
+	[iOS (5,1)]
 	[BaseType (typeof (NSObject))]
 	interface UIDictationPhrase {
 		[Export ("alternativeInterpretations")]
@@ -8280,7 +8280,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof (NSObject), Delegates=new string [] {"WeakDelegate"}, Events=new Type [] {typeof (UIDocumentInteractionControllerDelegate)})]
 	interface UIDocumentInteractionController {
 		[Export ("interactionControllerWithURL:"), Static]
@@ -8340,7 +8340,7 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Since (3,2)]
+	[iOS (3,2)]
 	[Protocol]
 	interface UIDocumentInteractionControllerDelegate {
 		[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_6_0)]
@@ -8527,7 +8527,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (UIDocument))]
 	// *** Assertion failure in -[UIManagedDocument init], /SourceCache/UIKit_Sim/UIKit-1914.84/UIDocument.m:258
 	[DisableDefaultCtor]
@@ -8591,11 +8591,11 @@ namespace XamCore.UIKit {
 		[Export ("menuFrame")]
 		CGRect MenuFrame { get; } 
 		
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("arrowDirection")]
 		UIMenuControllerArrowDirection ArrowDirection { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[NullAllowed] // by default this property is null
 		[Export ("menuItems", ArgumentSemantic.Copy)]
 		UIMenuItem [] MenuItems { get; set; }
@@ -8622,7 +8622,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	interface UIMenuItem {
 		[DesignatedInitializer] // TODO: Add an overload that takes an Action maybe?
@@ -8686,7 +8686,7 @@ namespace XamCore.UIKit {
 		[PostGet ("Items")] // that will [PostGet] TopItem too
 		void SetItems (UINavigationItem [] items, bool animated);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("titleTextAttributes", ArgumentSemantic.Copy), Internal]
 		[Appearance]
@@ -8696,22 +8696,22 @@ namespace XamCore.UIKit {
 		[Appearance]
 		UIStringAttributes TitleTextAttributes { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setBackgroundImage:forBarMetrics:")]
 		[Appearance]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIBarMetrics barMetrics);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("backgroundImageForBarMetrics:")]
 		[Appearance]
 		UIImage GetBackgroundImage (UIBarMetrics forBarMetrics);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setTitleVerticalPositionAdjustment:forBarMetrics:")]
 		[Appearance]
 		void SetTitleVerticalPositionAdjustment (nfloat adjustment, UIBarMetrics barMetrics);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("titleVerticalPositionAdjustmentForBarMetrics:")]
 		[Appearance]
 		nfloat GetTitleVerticalPositionAdjustment (UIBarMetrics barMetrics);
@@ -8728,32 +8728,32 @@ namespace XamCore.UIKit {
 		//
 		// 7.0
 		//
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Appearance]
 		[NullAllowed]
 		[Export ("barTintColor", ArgumentSemantic.Retain)]
 		UIColor BarTintColor { get; set;  }
 
 		[NoTV]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Appearance]
 		[NullAllowed]
 		[Export ("backIndicatorImage", ArgumentSemantic.Retain)]
 		UIImage BackIndicatorImage { get; set;  }
 
 		[NoTV]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Appearance]
 		[NullAllowed]
 		[Export ("backIndicatorTransitionMaskImage", ArgumentSemantic.Retain)]
 		UIImage BackIndicatorTransitionMaskImage { get; set;  }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Appearance]
 		[Export ("setBackgroundImage:forBarPosition:barMetrics:")]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIBarPosition barPosition, UIBarMetrics barMetrics);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Appearance]
 		[Export ("backgroundImageForBarPosition:barMetrics:")]
 		UIImage GetBackgroundImage (UIBarPosition barPosition, UIBarMetrics barMetrics);
@@ -8845,28 +8845,28 @@ namespace XamCore.UIKit {
 		[Export ("setRightBarButtonItem:animated:")][PostGet ("RightBarButtonItem")]
 		void SetRightBarButtonItem ([NullAllowed] UIBarButtonItem item, bool animated);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("leftBarButtonItems", ArgumentSemantic.Copy)]
 		[PostGet ("LeftBarButtonItem")]
 		UIBarButtonItem [] LeftBarButtonItems { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("rightBarButtonItems", ArgumentSemantic.Copy)]
 		[PostGet ("RightBarButtonItem")]
 		UIBarButtonItem [] RightBarButtonItems { get; set;  }
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("leftItemsSupplementBackButton")]
 		bool LeftItemsSupplementBackButton { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setLeftBarButtonItems:animated:")][PostGet ("LeftBarButtonItems")]
 		void SetLeftBarButtonItems (UIBarButtonItem [] items, bool animated);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setRightBarButtonItems:animated:")][PostGet ("RightBarButtonItems")]
 		void SetRightBarButtonItems (UIBarButtonItem [] items, bool animated);
 
@@ -8968,7 +8968,7 @@ namespace XamCore.UIKit {
 		nfloat HideShowBarDuration { get; }
 
 		[NoTV]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("interactivePopGestureRecognizer", ArgumentSemantic.Copy)]
 		UIGestureRecognizer InteractivePopGestureRecognizer { get; }
 
@@ -9032,13 +9032,13 @@ namespace XamCore.UIKit {
 		[NoDefaultValue]
 		UIInterfaceOrientation GetPreferredInterfaceOrientation (UINavigationController navigationController);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("navigationController:interactionControllerForAnimationController:")]
 		[DelegateName ("Func<UINavigationController,IUIViewControllerAnimatedTransitioning,IUIViewControllerInteractiveTransitioning>")]
 		[NoDefaultValue]
 		IUIViewControllerInteractiveTransitioning GetInteractionControllerForAnimationController (UINavigationController navigationController, IUIViewControllerAnimatedTransitioning animationController);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("navigationController:animationControllerForOperation:fromViewController:toViewController:")]
 		[DelegateName ("Func<UINavigationController,UINavigationControllerOperation,UIViewController,UIViewController,IUIViewControllerAnimatedTransitioning>")]
 		[NoDefaultValue]
@@ -9100,7 +9100,7 @@ namespace XamCore.UIKit {
 		UIColor CurrentPageIndicatorTintColor { get; set;  }
 	}
 	
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (UIViewController),
 		   Delegates = new string [] { "WeakDelegate", "WeakDataSource" },
 		   Events = new Type [] { typeof (UIPageViewControllerDelegate), typeof (UIPageViewControllerDataSource)} )]
@@ -9153,12 +9153,12 @@ namespace XamCore.UIKit {
 		[Field ("UIPageViewControllerOptionSpineLocationKey")]
 		NSString OptionSpineLocationKey { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Internal, Field ("UIPageViewControllerOptionInterPageSpacingKey")]
 		NSString OptionInterPageSpacingKey { get; }
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -9176,17 +9176,17 @@ namespace XamCore.UIKit {
 		void WillTransition (UIPageViewController pageViewController, UIViewController [] pendingViewControllers);
 
 		[NoTV]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("pageViewControllerSupportedInterfaceOrientations:")][DelegateName ("Func<UIPageViewController,UIInterfaceOrientationMask>")][DefaultValue (UIInterfaceOrientationMask.All)]
 		UIInterfaceOrientationMask SupportedInterfaceOrientations (UIPageViewController pageViewController);
 
 		[NoTV]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("pageViewControllerPreferredInterfaceOrientationForPresentation:")][DelegateName ("Func<UIPageViewController,UIInterfaceOrientation>")][DefaultValue (UIInterfaceOrientation.Portrait)]
 		UIInterfaceOrientation GetPreferredInterfaceOrientationForPresentation (UIPageViewController pageViewController);
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -9199,11 +9199,11 @@ namespace XamCore.UIKit {
 		[Export ("pageViewController:viewControllerAfterViewController:"), DelegateName ("UIPageViewGetViewController"), DefaultValue (null)]
 		UIViewController GetNextViewController (UIPageViewController pageViewController, UIViewController referenceViewController);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("presentationCountForPageViewController:"), DelegateName ("UIPageViewGetNumber"), DefaultValue (1)]
 		nint GetPresentationCount (UIPageViewController pageViewController);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("presentationIndexForPageViewController:"), DelegateName ("UIPageViewGetNumber"), DefaultValue (1)]
 		nint GetPresentationIndex (UIPageViewController pageViewController);
 	}
@@ -9505,7 +9505,7 @@ namespace XamCore.UIKit {
 		[Export ("pickerView:didSelectRow:inComponent:")]
 		void Selected (UIPickerView pickerView, nint row, nint component);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("pickerView:attributedTitleForRow:forComponent:")]
 		NSAttributedString GetAttributedTitle (UIPickerView pickerView, nint row, nint component);
 	}
@@ -9701,41 +9701,41 @@ namespace XamCore.UIKit {
 		[Export ("progress")]
 		float Progress { get; set; } // This is float, not nfloat.
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("progressTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIColor ProgressTintColor { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("trackTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIColor TrackTintColor { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("progressImage", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIImage ProgressImage { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("trackImage", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIImage TrackImage { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setProgress:animated:")]
 		void SetProgress (float progress /* this is float, not nfloat */, bool animated);
 
-		[Since (9,0)]
+		[iOS (9,0)]
 		[Export ("observedProgress")]
 		[NullAllowed]
 		NSProgress ObservedProgress { get; set; }
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (UIDynamicBehavior))]
 	partial interface UIPushBehavior {
 		[DesignatedInitializer]
@@ -9779,7 +9779,7 @@ namespace XamCore.UIKit {
 	
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (UIDynamicBehavior))]
 	[DisableDefaultCtor] // Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: init is undefined for objects of type UISnapBehavior
 	partial interface UISnapBehavior {
@@ -9796,7 +9796,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (UIViewController))]
 	// iOS6 returns the following (confusing) message with the default .ctor:
 	// Objective-C exception thrown.  Name: NSGenericException Reason: -[UIReferenceLibraryViewController initWithNibName:bundle:] is not a valid initializer. You must call -[UIReferenceLibraryViewController initWithTerm:].
@@ -9806,12 +9806,12 @@ namespace XamCore.UIKit {
 		[PostGet ("NibBundle")]
 		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("dictionaryHasDefinitionForTerm:"), Static]
 		bool DictionaryHasDefinitionForTerm (string term);
 
 		[DesignatedInitializer]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("initWithTerm:")]
 		IntPtr Constructor (string term);
 	}
@@ -9872,19 +9872,19 @@ namespace XamCore.UIKit {
 		NSUndoManager UndoManager { get; }
 
 		// 3.2
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("inputAccessoryView")]
 		UIView InputAccessoryView { get; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("inputView")]
 		UIView InputView { get; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("reloadInputViews")]
 		void ReloadInputViews ();
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("remoteControlReceivedWithEvent:")]
 		void RemoteControlReceived  ([NullAllowed] UIEvent theEvent);
 
@@ -9908,11 +9908,11 @@ namespace XamCore.UIKit {
 		[Export ("delete:")]
 		void Delete ([NullAllowed] NSObject sender);
 		
-		[Since (5,0)]	
+		[iOS (5,0)]	
 		[Export ("makeTextWritingDirectionLeftToRight:")]
 		void MakeTextWritingDirectionLeftToRight ([NullAllowed] NSObject sender);
 	
-		[Since (5,0)]	
+		[iOS (5,0)]	
 		[Export ("makeTextWritingDirectionRightToLeft:")]
 		void MakeTextWritingDirectionRightToLeft ([NullAllowed] NSObject sender);
 
@@ -9920,15 +9920,15 @@ namespace XamCore.UIKit {
 		// 6.0
 		//
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("toggleBoldface:")]
 		void ToggleBoldface ([NullAllowed] NSObject sender);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("toggleItalics:")]
 		void ToggleItalics ([NullAllowed] NSObject sender);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("toggleUnderline:")]
 		void ToggleUnderline ([NullAllowed] NSObject sender);
 
@@ -9936,23 +9936,23 @@ namespace XamCore.UIKit {
 		// 7.0
 		//
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("keyCommands")]
 		UIKeyCommand [] KeyCommands { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static, Export ("clearTextInputContextIdentifier:")]
 		void ClearTextInputContextIdentifier (NSString identifier);
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("targetForAction:withSender:")]
 		NSObject GetTargetForAction (Selector action, [NullAllowed] NSObject sender);
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("textInputContextIdentifier")]
 		NSString TextInputContextIdentifier { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("textInputMode")]
 		UITextInputMode TextInputMode { get; }
 
@@ -10027,11 +10027,11 @@ namespace XamCore.UIKit {
 		UIScreen MainScreen { get; }
 
 		[NoTV] // Xcode 7.2
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("availableModes", ArgumentSemantic.Copy)]
 		UIScreenMode [] AvailableModes { get; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[NullAllowed] // by default this property is null
 		[Export ("currentMode", ArgumentSemantic.Retain)]
 		UIScreenMode CurrentMode {
@@ -10042,23 +10042,23 @@ namespace XamCore.UIKit {
 		}
 
 		[NoTV] // Xcode 7.2
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Export ("preferredMode", ArgumentSemantic.Retain)]
 		UIScreenMode PreferredMode { get; }
 
-		[Since (4,3)]
+		[iOS (4,3)]
 		[Export ("mirroredScreen", ArgumentSemantic.Retain)]
 		UIScreen MirroredScreen { get; }
 			
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("screens")][Static]
 		UIScreen [] Screens { get; }
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("scale")]
 		nfloat Scale { get; }
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("displayLinkWithTarget:selector:")]
 		CoreAnimation.CADisplayLink CreateDisplayLink (NSObject target, Selector sel);
 
@@ -10067,20 +10067,20 @@ namespace XamCore.UIKit {
 		nint MaximumFramesPerSecond { get; }
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("brightness")]
 		nfloat Brightness { get; set; }
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("wantsSoftwareDimming")]
 		bool WantsSoftwareDimming { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("overscanCompensation")]
 		UIScreenOverscanCompensation OverscanCompensation { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("UIScreenBrightnessDidChangeNotification")]
 		[Notification]
 		NSString BrightnessDidChangeNotification { get; }
@@ -10102,7 +10102,7 @@ namespace XamCore.UIKit {
 		[Notification]
 		NSString CapturedDidChangeNotification { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[return: NullAllowed]
 		[Export ("snapshotViewAfterScreenUpdates:")]
 		UIView SnapshotView (bool afterScreenUpdates);
@@ -10282,12 +10282,12 @@ namespace XamCore.UIKit {
 		[Export ("scrollsToTop")]
 		bool ScrollsToTop { get; set; } 
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("panGestureRecognizer")]
 		UIPanGestureRecognizer PanGestureRecognizer { get; }
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("pinchGestureRecognizer")]
 		UIPinchGestureRecognizer PinchGestureRecognizer { get; }
 		
@@ -10297,7 +10297,7 @@ namespace XamCore.UIKit {
 		[Field ("UIScrollViewDecelerationRateFast")]
 		nfloat DecelerationRateFast { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("keyboardDismissMode")]
 		UIScrollViewKeyboardDismissMode KeyboardDismissMode { get; set; }
 
@@ -10348,15 +10348,15 @@ namespace XamCore.UIKit {
 		[Export ("scrollViewDidEndZooming:withView:atScale:"), EventArgs ("ZoomingEnded")]
 		void ZoomingEnded (UIScrollView scrollView, UIView withView, nfloat atScale);
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("scrollViewDidZoom:"), EventArgs ("UIScrollView")]
 		void DidZoom (UIScrollView scrollView);
 		
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("scrollViewWillBeginZooming:withView:"), EventArgs ("UIScrollViewZooming")]
 		void ZoomingStarted (UIScrollView scrollView, UIView view);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("scrollViewWillEndDragging:withVelocity:targetContentOffset:"), EventArgs ("WillEndDragging")]
 		void WillEndDragging (UIScrollView scrollView, CGPoint velocity, ref CGPoint targetContentOffset);
 
@@ -10440,104 +10440,104 @@ namespace XamCore.UIKit {
 
 		// 3.2
 		[NoTV]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("searchResultsButtonSelected")]
 		bool SearchResultsButtonSelected { [Bind ("isSearchResultsButtonSelected")] get; set; }
 
 		[NoTV]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("showsSearchResultsButton")]
 		bool ShowsSearchResultsButton { get; set; }
 
 		// 5.0
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("backgroundImage", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIImage BackgroundImage { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("scopeBarBackgroundImage", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIImage ScopeBarBackgroundImage { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("searchFieldBackgroundPositionAdjustment")]
 		UIOffset SearchFieldBackgroundPositionAdjustment { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("searchTextPositionAdjustment")]
 		UIOffset SearchTextPositionAdjustment { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setSearchFieldBackgroundImage:forState:")]
 		[Appearance]
 		void SetSearchFieldBackgroundImage ([NullAllowed] UIImage backgroundImage, UIControlState state);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("searchFieldBackgroundImageForState:")]
 		[Appearance]
 		UIImage GetSearchFieldBackgroundImage (UIControlState state);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setImage:forSearchBarIcon:state:")]
 		[Appearance]
 		void SetImageforSearchBarIcon ([NullAllowed] UIImage iconImage, UISearchBarIcon icon, UIControlState state);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("imageForSearchBarIcon:state:")]
 		[Appearance]
 		UIImage GetImageForSearchBarIcon (UISearchBarIcon icon, UIControlState state);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setScopeBarButtonBackgroundImage:forState:")]
 		[Appearance]
 		void SetScopeBarButtonBackgroundImage ([NullAllowed] UIImage backgroundImage, UIControlState state);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("scopeBarButtonBackgroundImageForState:")]
 		[Appearance]
 		UIImage GetScopeBarButtonBackgroundImage (UIControlState state);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setScopeBarButtonDividerImage:forLeftSegmentState:rightSegmentState:")]
 		[Appearance]
 		void SetScopeBarButtonDividerImage ([NullAllowed] UIImage dividerImage, UIControlState leftState, UIControlState rightState);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("scopeBarButtonDividerImageForLeftSegmentState:rightSegmentState:")]
 		[Appearance]
 		UIImage GetScopeBarButtonDividerImage (UIControlState leftState, UIControlState rightState);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setScopeBarButtonTitleTextAttributes:forState:"), Internal]
 		[Appearance]
 		void _SetScopeBarButtonTitle (NSDictionary attributes, UIControlState state);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("scopeBarButtonTitleTextAttributesForState:"), Internal]
 		[Appearance]
 		NSDictionary _GetScopeBarButtonTitleTextAttributes (UIControlState state);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setPositionAdjustment:forSearchBarIcon:")]
 		void SetPositionAdjustmentforSearchBarIcon (UIOffset adjustment, UISearchBarIcon icon);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("positionAdjustmentForSearchBarIcon:")]
 		UIOffset GetPositionAdjustmentForSearchBarIcon (UISearchBarIcon icon);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("inputAccessoryView", ArgumentSemantic.Retain)][NullAllowed]
 		UIView InputAccessoryView { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Appearance]
 		[Export ("setBackgroundImage:forBarPosition:barMetrics:")]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIBarPosition barPosition, UIBarMetrics barMetrics);
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("backgroundImageForBarPosition:barMetrics:")]
 		[Appearance]
 		UIImage BackgroundImageForBarPosition (UIBarPosition barPosition, UIBarMetrics barMetrics);
@@ -10547,24 +10547,24 @@ namespace XamCore.UIKit {
 		// (but non-clickable) and NOT in the header files (or in the UISearchBar web documentation)
 		// that makes them private API
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("setBackgroundImage:forBarMetrics:")]
 		[Appearance]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIBarMetrics barMetrics);
 	
 		// note that this one "work" on 7.x (i.e. as a private API) but does not on iOS8
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("backgroundImageForBarMetrics:")]
 		[Appearance]
 		UIImage BackgroundImageForBarMetrics (UIBarMetrics barMetrics);
 #endif
 
-		[Since (7,0), Export ("barTintColor", ArgumentSemantic.Retain)]
+		[iOS (7,0), Export ("barTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIColor BarTintColor { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("searchBarStyle")]
 		UISearchBarStyle SearchBarStyle { get; set; }
 
@@ -10611,7 +10611,7 @@ namespace XamCore.UIKit {
 		void SelectedScopeButtonIndexChanged (UISearchBar searchBar, nint selectedScope);
 
 		[NoTV]
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("searchBarResultsListButtonClicked:"), EventArgs ("UISearchBar")]
 		void ListButtonClicked (UISearchBar searchBar);
 	}
@@ -10741,16 +10741,16 @@ namespace XamCore.UIKit {
 		[Protocolize]
 		UITableViewDelegate SearchResultsDelegate { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("searchResultsTitle", ArgumentSemantic.Copy)]
 		string SearchResultsTitle { get; set;  }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("displaysSearchBarInNavigationBar", ArgumentSemantic.Assign)]
 		bool DisplaysSearchBarInNavigationBar { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("navigationItem")]
 		UINavigationItem NavigationItem { get; }
 	}
@@ -10888,46 +10888,46 @@ namespace XamCore.UIKit {
 		[Export ("selectedSegmentIndex")]
 		nint SelectedSegment { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("apportionsSegmentWidthsByContent")]
 		bool ApportionsSegmentWidthsByContent { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setBackgroundImage:forState:barMetrics:")]
 		[Appearance]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIControlState state, UIBarMetrics barMetrics);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("backgroundImageForState:barMetrics:")]
 		[Appearance]
 		UIImage GetBackgroundImage (UIControlState state, UIBarMetrics barMetrics);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setDividerImage:forLeftSegmentState:rightSegmentState:barMetrics:")]
 		[Appearance]
 		void SetDividerImage ([NullAllowed] UIImage dividerImage, UIControlState leftSegmentState, UIControlState rightSegmentState, UIBarMetrics barMetrics);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("dividerImageForLeftSegmentState:rightSegmentState:barMetrics:")]
 		[Appearance]
 		UIImage DividerImageForLeftSegmentStaterightSegmentStatebarMetrics (UIControlState leftState, UIControlState rightState, UIBarMetrics barMetrics);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setTitleTextAttributes:forState:"), Internal]
 		[Appearance]
 		void _SetTitleTextAttributes (NSDictionary attributes, UIControlState state);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("titleTextAttributesForState:"), Internal]
 		[Appearance]
 		NSDictionary _GetTitleTextAttributes (UIControlState state);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setContentPositionAdjustment:forSegmentType:barMetrics:")]
 		[Appearance]
 		void SetContentPositionAdjustment (UIOffset adjustment, UISegmentedControlSegment leftCenterRightOrAlone, UIBarMetrics barMetrics);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("contentPositionAdjustmentForSegmentType:barMetrics:")]
 		[Appearance]
 		UIOffset ContentPositionAdjustment (UISegmentedControlSegment leftCenterRightOrAlone, UIBarMetrics barMetrics);
@@ -11012,19 +11012,19 @@ namespace XamCore.UIKit {
 		[Export ("thumbRectForBounds:trackRect:value:")]
 		CGRect ThumbRectForBounds (CGRect bounds, CGRect trackRect, float value /* This is float, not nfloat */);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("minimumTrackTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIColor MinimumTrackTintColor { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("maximumTrackTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIColor MaximumTrackTintColor { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("thumbTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
@@ -11032,7 +11032,7 @@ namespace XamCore.UIKit {
 	}
 #endif // !WATCH
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[Static]
 	interface UIStringAttributeKey {
 		[Field ("NSFontAttributeName")]
@@ -11071,39 +11071,39 @@ namespace XamCore.UIKit {
 		[Field ("NSVerticalGlyphFormAttributeName")]
 		NSString VerticalGlyphForm { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("NSTextEffectAttributeName")]
 		NSString TextEffect { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("NSAttachmentAttributeName")]
 		NSString Attachment { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("NSLinkAttributeName")]
 		NSString Link { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("NSBaselineOffsetAttributeName")]
 		NSString BaselineOffset { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("NSUnderlineColorAttributeName")]
 		NSString UnderlineColor { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("NSStrikethroughColorAttributeName")]
 		NSString StrikethroughColor { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("NSObliquenessAttributeName")]
 		NSString Obliqueness { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("NSExpansionAttributeName")]
 		NSString Expansion { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Field ("NSWritingDirectionAttributeName")]
 		NSString WritingDirection { get; }
 		
@@ -11111,77 +11111,77 @@ namespace XamCore.UIKit {
 // These are internal, if we choose to expose these, we should
 // put them on a better named class
 //
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSTextEffectLetterpressStyle")]
 		NSString NSTextEffectLetterpressStyle { get; }
 
 	//
 	// Document Types
 	//
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSDocumentTypeDocumentAttribute")]
 		NSString NSDocumentTypeDocumentAttribute { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSPlainTextDocumentType")]
 		NSString NSPlainTextDocumentType { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSRTFDTextDocumentType")]
 		NSString NSRTFDTextDocumentType { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSRTFTextDocumentType")]
 		NSString NSRTFTextDocumentType { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSHTMLTextDocumentType")]
 		NSString NSHTMLTextDocumentType { get; }
 
 	//
 	//
 	//
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSCharacterEncodingDocumentAttribute")]
 		NSString NSCharacterEncodingDocumentAttribute { get; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSDefaultAttributesDocumentAttribute")]
 		NSString NSDefaultAttributesDocumentAttribute { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSPaperSizeDocumentAttribute")]
 		NSString NSPaperSizeDocumentAttribute { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSPaperMarginDocumentAttribute")]
 		NSString NSPaperMarginDocumentAttribute { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSViewSizeDocumentAttribute")]
 		NSString NSViewSizeDocumentAttribute { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSViewZoomDocumentAttribute")]
 		NSString NSViewZoomDocumentAttribute { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSViewModeDocumentAttribute")]
 		NSString NSViewModeDocumentAttribute { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSReadOnlyDocumentAttribute")]
 		NSString NSReadOnlyDocumentAttribute { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSBackgroundColorDocumentAttribute")]
 		NSString NSBackgroundColorDocumentAttribute { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSHyphenationFactorDocumentAttribute")]
 		NSString NSHyphenationFactorDocumentAttribute { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Internal, Field ("NSDefaultTabIntervalDocumentAttribute")]
 		NSString NSDefaultTabIntervalDocumentAttribute { get; }
 	}
@@ -11200,25 +11200,25 @@ namespace XamCore.UIKit {
 		[Export ("setOn:animated:")]
 		void SetState (bool newState, bool animated);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("onTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIColor OnTintColor { get; set; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[NullAllowed]
 		[Export ("thumbTintColor", ArgumentSemantic.Retain)]
 		UIColor ThumbTintColor { get; set;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[Export ("onImage", ArgumentSemantic.Retain)]
 		[NullAllowed]
 		UIImage OnImage { get; set;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Appearance]
 		[NullAllowed]
 		[Export ("offImage", ArgumentSemantic.Retain)]
@@ -11270,56 +11270,56 @@ namespace XamCore.UIKit {
 		bool IsCustomizing { get; }
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("selectedImageTintColor", ArgumentSemantic.Retain)]
 		[Availability (Deprecated = Platform.iOS_8_0)]
 		[NullAllowed]
 		[Appearance]
 		UIColor SelectedImageTintColor { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("backgroundImage", ArgumentSemantic.Retain)]
 		[NullAllowed]
 		[Appearance]
 		UIImage BackgroundImage { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("selectionIndicatorImage", ArgumentSemantic.Retain)]
 		[NullAllowed]
 		[Appearance]
 		UIImage SelectionIndicatorImage { get; set;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("shadowImage", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIImage ShadowImage { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("barTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIColor BarTintColor { get; set; }
 
 		[NoTV]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("itemPositioning")]
 		UITabBarItemPositioning ItemPositioning { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("itemWidth")]
 		nfloat ItemWidth { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("itemSpacing")]
 		nfloat ItemSpacing { get; set; }
 
 		[NoTV]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("barStyle")]
 		UIBarStyle BarStyle { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("translucent")]
 		bool Translucent { [Bind ("isTranslucent")] get; set; }
 
@@ -11420,24 +11420,24 @@ namespace XamCore.UIKit {
 		void FinishedCustomizingViewControllers (UITabBarController tabBarController, UIViewController [] viewControllers, bool changed);
 
 		[NoTV]
-		[Since (7,0), Export ("tabBarControllerSupportedInterfaceOrientations:")]
+		[iOS (7,0), Export ("tabBarControllerSupportedInterfaceOrientations:")]
 		[NoDefaultValue]
 		[DelegateName ("Func<UITabBarController,UIInterfaceOrientationMask>")]
 		UIInterfaceOrientationMask SupportedInterfaceOrientations  (UITabBarController tabBarController);
 		
 		[NoTV]
-		[Since (7,0), Export ("tabBarControllerPreferredInterfaceOrientationForPresentation:")]
+		[iOS (7,0), Export ("tabBarControllerPreferredInterfaceOrientationForPresentation:")]
 		[NoDefaultValue]
 		[DelegateName ("Func<UITabBarController,UIInterfaceOrientation>")]
 		UIInterfaceOrientation GetPreferredInterfaceOrientation  (UITabBarController tabBarController);
 		
-		[Since (7,0), Export ("tabBarController:interactionControllerForAnimationController:")]
+		[iOS (7,0), Export ("tabBarController:interactionControllerForAnimationController:")]
 		[NoDefaultValue]
 		[DelegateName ("Func<UITabBarController,IUIViewControllerAnimatedTransitioning,IUIViewControllerInteractiveTransitioning>")]
 		IUIViewControllerInteractiveTransitioning GetInteractionControllerForAnimationController (UITabBarController tabBarController,
 													 IUIViewControllerAnimatedTransitioning animationController);
 		
-		[Since (7,0), Export ("tabBarController:animationControllerForTransitionFromViewController:toViewController:")]
+		[iOS (7,0), Export ("tabBarController:animationControllerForTransitionFromViewController:toViewController:")]
 		[NoDefaultValue]
 		[DelegateName ("Func<UITabBarController,UIViewController,UIViewController,IUIViewControllerAnimatedTransitioning>")]
 		IUIViewControllerAnimatedTransitioning GetAnimationControllerForTransition (UITabBarController tabBarController,
@@ -11495,18 +11495,18 @@ namespace XamCore.UIKit {
 		[Export ("finishedUnselectedImage")]
 		UIImage FinishedUnselectedImage { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("titlePositionAdjustment")]
 		[Appearance]
 		UIOffset TitlePositionAdjustment { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("initWithTitle:image:selectedImage:")]
 		[PostGet ("Image")]
 		[PostGet ("SelectedImage")]
 		IntPtr Constructor ([NullAllowed] string title, [NullAllowed] UIImage image, [NullAllowed] UIImage selectedImage);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("selectedImage", ArgumentSemantic.Retain)][NullAllowed]
 		UIImage SelectedImage { get; set; }
 
@@ -11692,7 +11692,7 @@ namespace XamCore.UIKit {
 		UITableViewCell DequeueReusableCell (NSString identifier);
 
 		// 3.2
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("backgroundView", ArgumentSemantic.Retain), NullAllowed]
 		UIView BackgroundView { get; set; }
 
@@ -11700,31 +11700,31 @@ namespace XamCore.UIKit {
 		[Field ("UITableViewIndexSearch")]
 		NSString IndexSearch { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Field ("UITableViewAutomaticDimension")]
 		nfloat AutomaticDimension { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("allowsMultipleSelection")]
                 bool AllowsMultipleSelection { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
                 [Export ("allowsMultipleSelectionDuringEditing")]
                 bool AllowsMultipleSelectionDuringEditing { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
                 [Export ("moveSection:toSection:")]
                 void MoveSection (nint fromSection, nint toSection);
 
-		[Since (5,0)]
+		[iOS (5,0)]
                 [Export ("moveRowAtIndexPath:toIndexPath:")]
                 void MoveRow (NSIndexPath fromIndexPath, NSIndexPath toIndexPath);
 
-		[Since (5,0)]
+		[iOS (5,0)]
                 [Export ("indexPathsForSelectedRows")]
                 NSIndexPath [] IndexPathsForSelectedRows { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("registerNib:forCellReuseIdentifier:")]
 #if XAMCORE_2_0
 		void RegisterNibForCellReuse ([NullAllowed] UINib nib, NSString reuseIdentifier);
@@ -11771,7 +11771,7 @@ namespace XamCore.UIKit {
 		[Export ("registerClass:forCellReuseIdentifier:"), Internal]
 		void RegisterClassForCellReuse (IntPtr /*Class*/ cellClass, NSString reuseIdentifier);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("registerNib:forHeaderFooterViewReuseIdentifier:")]
 #if XAMCORE_2_0
 		void RegisterNibForHeaderFooterViewReuse (UINib nib, NSString reuseIdentifier);
@@ -11779,32 +11779,32 @@ namespace XamCore.UIKit {
 		void RegisterNibForHeaderFooterViewReuse (UINib nib, string reuseIdentifier);
 #endif
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("registerClass:forHeaderFooterViewReuseIdentifier:"), Internal]
 		void RegisterClassForHeaderFooterViewReuse (IntPtr /*Class*/ aClass, NSString reuseIdentifier);
 
 		//
 		// 7.0
 		//
-	        [Since (7,0)]
+	        [iOS (7,0)]
 		[Export ("estimatedRowHeight", ArgumentSemantic.Assign)]
 	        nfloat EstimatedRowHeight { get; set; }
 	
-	        [Since (7,0)]
+	        [iOS (7,0)]
 		[Export ("estimatedSectionHeaderHeight", ArgumentSemantic.Assign)]
 	        nfloat EstimatedSectionHeaderHeight { get; set; }
 		
-	        [Since (7,0)]
+	        [iOS (7,0)]
 		[Export ("estimatedSectionFooterHeight", ArgumentSemantic.Assign)]
 	        nfloat EstimatedSectionFooterHeight { get; set; }
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Appearance]
 		[NullAllowed] // by default this property is null
 		[Export ("sectionIndexBackgroundColor", ArgumentSemantic.Retain)]
 		UIColor SectionIndexBackgroundColor { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Appearance]
 		[Export ("separatorInset")]
 		UIEdgeInsets SeparatorInset { get; set; }
@@ -12001,15 +12001,15 @@ namespace XamCore.UIKit {
 
 		// Copy Paste support
 		
-		[Since (5,0)]
+		[iOS (5,0)]
                 [Export ("tableView:shouldShowMenuForRowAtIndexPath:")]
                 bool ShouldShowMenu (UITableView tableView, NSIndexPath rowAtindexPath);
 
-		[Since (5,0)]
+		[iOS (5,0)]
                 [Export ("tableView:canPerformAction:forRowAtIndexPath:withSender:")]
                 bool CanPerformAction (UITableView tableView, Selector action, NSIndexPath indexPath, [NullAllowed] NSObject sender);
 
-		[Since (5,0)]
+		[iOS (5,0)]
                 [Export ("tableView:performAction:forRowAtIndexPath:withSender:")]
                 void PerformAction (UITableView tableView, Selector action, NSIndexPath indexPath, [NullAllowed] NSObject sender);
 		
@@ -12045,15 +12045,15 @@ namespace XamCore.UIKit {
 		[Export ("tableView:didUnhighlightRowAtIndexPath:")]
 		void RowUnhighlighted (UITableView tableView, NSIndexPath rowIndexPath);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("tableView:estimatedHeightForRowAtIndexPath:")]
 		nfloat EstimatedHeight (UITableView tableView, NSIndexPath indexPath);
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("tableView:estimatedHeightForHeaderInSection:")]
 		nfloat EstimatedHeightForHeader (UITableView tableView, nint section);
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("tableView:estimatedHeightForFooterInSection:")]
 		nfloat EstimatedHeightForFooter (UITableView tableView, nint section);
 
@@ -12193,12 +12193,12 @@ namespace XamCore.UIKit {
 		[Export ("didTransitionToState:")]
 		void DidTransitionToState (UITableViewCellState mask);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("multipleSelectionBackgroundView", ArgumentSemantic.Retain), NullAllowed]
 		UIView MultipleSelectionBackgroundView { get; set; }
 
 		[NoTV]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("separatorInset")]
 		UIEdgeInsets SeparatorInset { get; set; }
 
@@ -12231,7 +12231,7 @@ namespace XamCore.UIKit {
 		[Export ("tableView", ArgumentSemantic.Retain)]
 		UITableView TableView { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("clearsSelectionOnViewWillAppear")]
 		bool ClearsSelectionOnViewWillAppear { get; set; }
 
@@ -12352,15 +12352,15 @@ namespace XamCore.UIKit {
 		nint IndentationLevel (UITableView tableView, NSIndexPath indexPath);
 
 		// Copy Paste support
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("tableView:shouldShowMenuForRowAtIndexPath:")]
 		bool ShouldShowMenu (UITableView tableView, NSIndexPath rowAtindexPath);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("tableView:canPerformAction:forRowAtIndexPath:withSender:")]
 		bool CanPerformAction (UITableView tableView, Selector action, NSIndexPath indexPath, NSObject sender);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("tableView:performAction:forRowAtIndexPath:withSender:")]
 		void PerformAction (UITableView tableView, Selector action, NSIndexPath indexPath, NSObject sender);
 
@@ -12396,15 +12396,15 @@ namespace XamCore.UIKit {
 		[Export ("tableView:didUnhighlightRowAtIndexPath:")]
 		void RowUnhighlighted (UITableView tableView, NSIndexPath rowIndexPath);		
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("tableView:estimatedHeightForRowAtIndexPath:")]
 		nfloat EstimatedHeight (UITableView tableView, NSIndexPath indexPath);
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("tableView:estimatedHeightForHeaderInSection:")]
 		nfloat EstimatedHeightForHeader (UITableView tableView, nint section);
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("tableView:estimatedHeightForFooterInSection:")]
 		nfloat EstimatedHeightForFooter (UITableView tableView, nint section);
 
@@ -12448,7 +12448,7 @@ namespace XamCore.UIKit {
 		bool ShouldSpringLoadRow (UITableView tableView, NSIndexPath indexPath, IUISpringLoadedInteractionContext context);
 	}
 
-	[Since (6,0)]
+	[iOS (6,0)]
 	[BaseType (typeof (UIView))]
 	interface UITableViewHeaderFooterView : UIAppearance, NSCoding {
 		[Export ("initWithFrame:")]
@@ -12601,11 +12601,11 @@ namespace XamCore.UIKit {
 		void DrawPlaceholder (CGRect rect);
 
 		// 3.2
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("inputAccessoryView", ArgumentSemantic.Retain)][NullAllowed]
 		UIView InputAccessoryView { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("inputView", ArgumentSemantic.Retain)][NullAllowed]
 		UIView InputView { get; set; }
 
@@ -12629,30 +12629,30 @@ namespace XamCore.UIKit {
 		// 6.0
 		//
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[NullAllowed] // by default this property is null (on 6.0, not later)
 		[Export ("attributedText", ArgumentSemantic.Copy)]
 		NSAttributedString AttributedText { get; set;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("attributedPlaceholder", ArgumentSemantic.Copy)]
 		NSAttributedString AttributedPlaceholder { get; set;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("allowsEditingTextAttributes")]
 		bool AllowsEditingTextAttributes { get; set;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("clearsOnInsertion")]
 		bool ClearsOnInsertion { get; set;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("typingAttributes", ArgumentSemantic.Copy)]
 		NSDictionary TypingAttributes { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("defaultTextAttributes", ArgumentSemantic.Copy), NullAllowed]
 		NSDictionary WeakDefaultTextAttributes { get; set; }
 	}
@@ -12733,12 +12733,12 @@ namespace XamCore.UIKit {
 		UIDataDetectorType DataDetectorTypes { get; set; }
 
 		// 3.2
-		[Since (3,2)]
+		[iOS (3,2)]
 		[NullAllowed] // by default this property is null
 		[Export ("inputAccessoryView", ArgumentSemantic.Retain)]
 		UIView InputAccessoryView { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("inputView", ArgumentSemantic.Retain)][NullAllowed]
 		UIView InputView { get; set; }
 
@@ -12758,19 +12758,19 @@ namespace XamCore.UIKit {
 		// 6.0
 		//
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("allowsEditingTextAttributes")]
 		bool AllowsEditingTextAttributes { get; set;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("attributedText", ArgumentSemantic.Copy)]
 		NSAttributedString AttributedText { get; set;  }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("clearsOnInsertion")]
 		bool ClearsOnInsertion { get; set;  }		
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("typingAttributes", ArgumentSemantic.Copy)]
 		NSDictionary TypingAttributes {
@@ -12780,33 +12780,33 @@ namespace XamCore.UIKit {
 			set;
 		}
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("selectable")]
 		bool Selectable { [Bind ("isSelectable")] get; set; }
 
 		[DesignatedInitializer]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("initWithFrame:textContainer:")]
 		[PostGet ("TextContainer")]
 		IntPtr Constructor (CGRect frame, NSTextContainer textContainer);
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("textContainer", ArgumentSemantic.Copy)]
 		NSTextContainer TextContainer { get; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("textContainerInset", ArgumentSemantic.Assign)]
 		UIEdgeInsets TextContainerInset { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("layoutManager", ArgumentSemantic.Copy)]
 		NSLayoutManager LayoutManager { get; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("textStorage", ArgumentSemantic.Retain)]
 		NSTextStorage TextStorage { get; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("linkTextAttributes", ArgumentSemantic.Copy)]
 		NSDictionary WeakLinkTextAttributes { get; set; }
 	}
@@ -12837,12 +12837,12 @@ namespace XamCore.UIKit {
 		[Export ("textViewDidChangeSelection:"), EventArgs ("UITextView")]
 		void SelectionChanged (UITextView textView);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use the 'ShouldInteractWithUrl' overload that takes 'UITextItemInteraction' instead.")]
 		[Export ("textView:shouldInteractWithURL:inRange:"), DelegateName ("Func<UITextView,NSUrl,NSRange,bool>"), DefaultValue ("true")]
 		bool ShouldInteractWithUrl (UITextView textView, NSUrl URL, NSRange characterRange);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use the 'ShouldInteractWithTextAttachment' overload that takes 'UITextItemInteraction' instead.")]
 		[Export ("textView:shouldInteractWithTextAttachment:inRange:"), DelegateName ("Func<UITextView,NSTextAttachment,NSRange,bool>"), DefaultValue ("true")]
 		bool ShouldInteractWithTextAttachment (UITextView textView, NSTextAttachment textAttachment, NSRange characterRange);
@@ -12875,12 +12875,12 @@ namespace XamCore.UIKit {
 		//[Export ("setItems:animated:")][PostGet ("Items")]
 		//void SetItems (UIBarButtonItem [] items, bool animated);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("setBackgroundImage:forToolbarPosition:barMetrics:")]
 		[Appearance]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIToolbarPosition position, UIBarMetrics barMetrics);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("backgroundImageForToolbarPosition:barMetrics:")]
 		[Appearance]
 		UIImage GetBackgroundImage (UIToolbarPosition position, UIBarMetrics barMetrics);
@@ -12895,13 +12895,13 @@ namespace XamCore.UIKit {
 		[Export ("shadowImageForToolbarPosition:")]
 		UIImage GetShadowImage (UIToolbarPosition topOrBottom);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Appearance]
 		[NullAllowed]
 		[Export ("barTintColor", ArgumentSemantic.Retain)]
 		UIColor BarTintColor { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("delegate", ArgumentSemantic.Weak), NullAllowed]
 		NSObject WeakDelegate { get; set; }
 
@@ -12960,7 +12960,7 @@ namespace XamCore.UIKit {
 		UITouchPhase Phase { get; }
 
 		// 3.2
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("gestureRecognizers", ArgumentSemantic.Copy)]
 		UIGestureRecognizer[] GestureRecognizers { get; }
 
@@ -13358,54 +13358,54 @@ namespace XamCore.UIKit {
 		bool AnimationsEnabled { [Bind ("areAnimationsEnabled")] get; [Bind ("setAnimationsEnabled:")] set; }
 
 		// 3.2:
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("addGestureRecognizer:"), PostGet ("GestureRecognizers")]
 		void AddGestureRecognizer (UIGestureRecognizer gestureRecognizer);
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("removeGestureRecognizer:"), PostGet ("GestureRecognizers")]
 		void RemoveGestureRecognizer (UIGestureRecognizer gestureRecognizer);
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[NullAllowed] // by default this property is null
 		[Export ("gestureRecognizers", ArgumentSemantic.Copy)]
 		UIGestureRecognizer[] GestureRecognizers { get; set; }
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Static, Export ("animateWithDuration:animations:")]
 		void Animate (double duration, /* non null */ NSAction animation);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Static, Export ("animateWithDuration:animations:completion:")]
 		[Async]
 		void AnimateNotify (double duration, /* non null */ NSAction animation, [NullAllowed] UICompletionHandler completion);
 		
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Static, Export ("animateWithDuration:delay:options:animations:completion:")]
 		[Async]
 		void AnimateNotify (double duration, double delay, UIViewAnimationOptions options, /* non null */ NSAction animation, [NullAllowed] UICompletionHandler completion);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Static, Export ("transitionFromView:toView:duration:options:completion:")]
 		[Async]
 		void TransitionNotify (UIView fromView, UIView toView, double duration, UIViewAnimationOptions options, [NullAllowed] UICompletionHandler completion);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Static, Export ("transitionWithView:duration:options:animations:completion:")]
 		[Async]
 		void TransitionNotify (UIView withView, double duration, UIViewAnimationOptions options, [NullAllowed] NSAction animation, [NullAllowed] UICompletionHandler completion);
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("contentScaleFactor")]
 		nfloat ContentScaleFactor { get; set; }
 
 		[NoTV]
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("viewPrintFormatter")]
 		UIViewPrintFormatter ViewPrintFormatter { get; }
 
 		[NoTV]
-		[Since (4,2)]
+		[iOS (4,2)]
 		[Export ("drawRect:forViewPrintFormatter:")]
 		void DrawRect (CGRect area, UIViewPrintFormatter formatter);
 
@@ -13464,11 +13464,11 @@ namespace XamCore.UIKit {
 		[Availability (Deprecated = Platform.iOS_9_0, Message="Override 'ViewForFirstBaselineLayout' or 'ViewForLastBaselineLayout'.")]
 		UIView ViewForBaselineLayout { get; }
 
-		[Since (9,0)]
+		[iOS (9,0)]
 		[Export ("viewForFirstBaselineLayout")]
 		UIView ViewForFirstBaselineLayout { get; }
 
-		[Since (9,0)]
+		[iOS (9,0)]
 		[Export ("viewForLastBaselineLayout")]
 		UIView ViewForLastBaselineLayout { get; }
 			
@@ -13542,7 +13542,7 @@ namespace XamCore.UIKit {
 		[Export ("updateConstraints")]
 		void UpdateConstraints ();
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Field ("UIViewNoIntrinsicMetric")]
 		nfloat NoIntrinsicMetric { get; }
 		
@@ -13557,64 +13557,64 @@ namespace XamCore.UIKit {
 		[NullAllowed]
 		[Export ("tintColor")]
 		[Appearance]
-		[Since (7,0)]
+		[iOS (7,0)]
 		UIColor TintColor { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("tintAdjustmentMode")]
 		UIViewTintAdjustmentMode TintAdjustmentMode { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("tintColorDidChange")]
 		void TintColorDidChange ();
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static, Export ("performWithoutAnimation:")]
 		void PerformWithoutAnimation (NSAction actionsWithoutAnimation);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static, Export ("performSystemAnimation:onViews:options:animations:completion:")]
 		[Async]
 		void PerformSystemAnimation (UISystemAnimation animation, UIView [] views, UIViewAnimationOptions options, NSAction parallelAnimations, UICompletionHandler completion);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static, Export ("animateKeyframesWithDuration:delay:options:animations:completion:")]
 		[Async]
 		void AnimateKeyframes (double duration, double delay, UIViewKeyframeAnimationOptions options, NSAction animations, UICompletionHandler completion);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static, Export ("addKeyframeWithRelativeStartTime:relativeDuration:animations:")]
 		void AddKeyframeWithRelativeStartTime (double frameStartTime, double frameDuration, NSAction animations);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("addMotionEffect:")]
 		[PostGet ("MotionEffects")]
 		void AddMotionEffect (UIMotionEffect effect);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("removeMotionEffect:")]
 		[PostGet ("MotionEffects")]
 		void RemoveMotionEffect (UIMotionEffect effect);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("motionEffects", ArgumentSemantic.Copy)]
 		UIMotionEffect [] MotionEffects { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("snapshotViewAfterScreenUpdates:")]
 		UIView SnapshotView (bool afterScreenUpdates);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("resizableSnapshotViewFromRect:afterScreenUpdates:withCapInsets:")]
 		[return: NullAllowed]
 		UIView ResizableSnapshotView (CGRect rect, bool afterScreenUpdates, UIEdgeInsets capInsets);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("drawViewHierarchyInRect:afterScreenUpdates:")]
 		bool DrawViewHierarchy (CGRect rect, bool afterScreenUpdates);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Static]
 		[Export ("animateWithDuration:delay:usingSpringWithDamping:initialSpringVelocity:options:animations:completion:")]
 		[Async]
@@ -13962,7 +13962,7 @@ namespace XamCore.UIKit {
 		[Export ("hidesBottomBarWhenPushed")]
 		bool HidesBottomBarWhenPushed { get; set; }
 
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("splitViewController", ArgumentSemantic.Retain)]
 		UISplitViewController SplitViewController { get; }
 
@@ -13981,7 +13981,7 @@ namespace XamCore.UIKit {
 		void SetToolbarItems ([NullAllowed] UIBarButtonItem [] items, bool animated);
 
 		// These come in 3.2
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("modalPresentationStyle", ArgumentSemantic.Assign)]
 		UIModalPresentationStyle ModalPresentationStyle { get; set; }
 
@@ -14006,85 +14006,85 @@ namespace XamCore.UIKit {
 		CGSize ContentSizeForViewInPopover { get; set; }
 
 		// This is defined in a category in UIPopoverSupport.h: UIViewController (UIPopoverController)
-		[Since (3,2)]
+		[iOS (3,2)]
 		[Export ("modalInPopover")]
 		bool ModalInPopover { [Bind ("isModalInPopover")] get; set; }
 
-		[Since (4,3)] // It seems apple added a setter now but seems it is a mistake on new property radar:27929872
+		[iOS (4,3)] // It seems apple added a setter now but seems it is a mistake on new property radar:27929872
 		[Export ("disablesAutomaticKeyboardDismissal")]
 		bool DisablesAutomaticKeyboardDismissal { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("storyboard", ArgumentSemantic.Retain)]
 		UIStoryboard Storyboard { get;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("presentedViewController")]
 		UIViewController PresentedViewController { get;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("presentingViewController")]
 		UIViewController PresentingViewController { get;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("definesPresentationContext", ArgumentSemantic.Assign)]
 		bool DefinesPresentationContext { get; set;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("providesPresentationContextTransitionStyle", ArgumentSemantic.Assign)]
 		bool ProvidesPresentationContextTransitionStyle { get; set;  }
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_6_0)]
 		[Export ("viewWillUnload")]
 		void ViewWillUnload ();
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("performSegueWithIdentifier:sender:")]
 		void PerformSegue (string identifier, [NullAllowed] NSObject sender);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("prepareForSegue:sender:")]
 		void PrepareForSegue (UIStoryboardSegue segue, [NullAllowed] NSObject sender);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("viewWillLayoutSubviews")]
 		void ViewWillLayoutSubviews ();
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("viewDidLayoutSubviews")]
 		void ViewDidLayoutSubviews ();
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("isBeingPresented")]
 		bool IsBeingPresented { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("isBeingDismissed")]
 		bool IsBeingDismissed { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("isMovingToParentViewController")]
 		bool IsMovingToParentViewController { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("isMovingFromParentViewController")]
 		bool IsMovingFromParentViewController { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("presentViewController:animated:completion:")]
 		[Async]
 		void PresentViewController (UIViewController viewControllerToPresent, bool animated, [NullAllowed] NSAction completionHandler);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("dismissViewControllerAnimated:completion:")]
 		[Async]
 		void DismissViewController (bool animated, [NullAllowed] NSAction completionHandler);
 
 		// UIViewControllerRotation
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Static]
 		[Export ("attemptRotationToDeviceOrientation")]
 		void AttemptRotationToDeviceOrientation ();
@@ -14094,97 +14094,97 @@ namespace XamCore.UIKit {
 		[Export ("automaticallyForwardAppearanceAndRotationMethodsToChildViewControllers")]
 		/*PROTECTED*/ bool AutomaticallyForwardAppearanceAndRotationMethodsToChildViewControllers { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("childViewControllers")]
 		/*PROTECTED, MUSTCALLBASE*/ UIViewController [] ChildViewControllers { get;  }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("addChildViewController:")]
 		[PostGet ("ChildViewControllers")]
 		/*PROTECTED, MUSTCALLBASE*/ void AddChildViewController (UIViewController childController);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("removeFromParentViewController")]
 		/*PROTECTED, MUSTCALLBASE*/ void RemoveFromParentViewController ();
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("transitionFromViewController:toViewController:duration:options:animations:completion:")]
 		[Async]
 		/*PROTECTED, MUSTCALLBASE*/ void Transition (UIViewController fromViewController, UIViewController toViewController, double duration, UIViewAnimationOptions options, /* non null */ NSAction animations, UICompletionHandler completionHandler);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("willMoveToParentViewController:")]
 		void WillMoveToParentViewController ([NullAllowed] UIViewController parent);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("didMoveToParentViewController:")]
 		void DidMoveToParentViewController ([NullAllowed] UIViewController parent);
 
 		//
 		// Exposed in iOS 6.0, but they existed and are now officially supported on iOS 5.0
 		//
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("beginAppearanceTransition:animated:")]
 		void BeginAppearanceTransition (bool isAppearing, bool animated);
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("endAppearanceTransition")]
 		void EndAppearanceTransition ();
 		
 		//
 		// 6.0
 		//
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("shouldPerformSegueWithIdentifier:sender:")]
 		bool ShouldPerformSegue (string segueIdentifier, NSObject sender);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("canPerformUnwindSegueAction:fromViewController:withSender:")]
 		bool CanPerformUnwind (Selector segueAction, UIViewController fromViewController, NSObject sender);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("viewControllerForUnwindSegueAction:fromViewController:withSender:")]
 		UIViewController GetViewControllerForUnwind (Selector segueAction, UIViewController fromViewController, NSObject sender);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("segueForUnwindingToViewController:fromViewController:identifier:")]
 		UIStoryboardSegue GetSegueForUnwinding (UIViewController toViewController, UIViewController fromViewController, string identifier);
 
 		[NoTV]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("supportedInterfaceOrientations")]
 		UIInterfaceOrientationMask GetSupportedInterfaceOrientations ();
 
 		[NoTV]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("preferredInterfaceOrientationForPresentation")]
 		UIInterfaceOrientation PreferredInterfaceOrientationForPresentation ();
 
 		[NoTV]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Availability (Deprecated = Platform.iOS_8_0, Message="Use Adaptive View Controllers instead.")]
 		[Export ("shouldAutomaticallyForwardRotationMethods")]
 		bool ShouldAutomaticallyForwardRotationMethods { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("shouldAutomaticallyForwardAppearanceMethods")]
 		bool ShouldAutomaticallyForwardAppearanceMethods { get; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("restorationIdentifier", ArgumentSemantic.Copy)]
 		string RestorationIdentifier { get; set; }
 
 		[NullAllowed]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("restorationClass")]
 		Class RestorationClass { get; set; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("encodeRestorableStateWithCoder:")]
 		void EncodeRestorableState (NSCoder coder);
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("decodeRestorableStateWithCoder:")]
 		void DecodeRestorableState (NSCoder coder);
 
@@ -14193,85 +14193,85 @@ namespace XamCore.UIKit {
 		void UpdateViewConstraints ();
 
 		[NoTV]
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("shouldAutorotate")]
 		bool ShouldAutorotate ();
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("edgesForExtendedLayout", ArgumentSemantic.Assign)]
 		UIRectEdge EdgesForExtendedLayout { get; set; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("extendedLayoutIncludesOpaqueBars", ArgumentSemantic.Assign)]
 		bool ExtendedLayoutIncludesOpaqueBars { get; set; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'UIScrollView.ContentInsetAdjustmentBehavior' instead.")]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'UIScrollView.ContentInsetAdjustmentBehavior' instead.")]
 		[Export ("automaticallyAdjustsScrollViewInsets", ArgumentSemantic.Assign)]
 		bool AutomaticallyAdjustsScrollViewInsets { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("preferredContentSize", ArgumentSemantic.Copy)]
 		new CGSize PreferredContentSize { get; set; }
 
 		[NoTV][NoWatch]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("preferredStatusBarStyle")]
 		UIStatusBarStyle PreferredStatusBarStyle ();
 
 		[NoTV]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("prefersStatusBarHidden")]
 		bool PrefersStatusBarHidden ();
 
 		[NoTV]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("setNeedsStatusBarAppearanceUpdate")]
 		void SetNeedsStatusBarAppearanceUpdate ();
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("applicationFinishedRestoringState")]
 		void ApplicationFinishedRestoringState ();
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("transitioningDelegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakTransitioningDelegate { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Wrap ("WeakTransitioningDelegate")]
 		[Protocolize]
 		UIViewControllerTransitioningDelegate TransitioningDelegate { get; set; }
 
 		[NoTV]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("childViewControllerForStatusBarStyle")]
 		UIViewController ChildViewControllerForStatusBarStyle ();
 
 		[NoTV]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("childViewControllerForStatusBarHidden")]
 		UIViewController ChildViewControllerForStatusBarHidden ();
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'UIView.SafeAreaLayoutGuide.TopAnchor' instead.")]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'UIView.SafeAreaLayoutGuide.TopAnchor' instead.")]
 		[Export ("topLayoutGuide")]
 		IUILayoutSupport TopLayoutGuide { get; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'UIView.SafeAreaLayoutGuide.BottomAnchor' instead.")]
 		[Deprecated (PlatformName.TvOS, 11, 0, message: "Use 'UIView.SafeAreaLayoutGuide.BottomAnchor' instead.")]
 		[Export ("bottomLayoutGuide")]
 		IUILayoutSupport BottomLayoutGuide { get; }
 		
 		[NoTV][NoWatch]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("preferredStatusBarUpdateAnimation")]
 		UIStatusBarAnimation PreferredStatusBarUpdateAnimation { get; }
 
 		[NoTV]
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("modalPresentationCapturesStatusBarAppearance", ArgumentSemantic.Assign)]
 		bool ModalPresentationCapturesStatusBarAppearance { get; set; }
 
@@ -14435,7 +14435,7 @@ namespace XamCore.UIKit {
 		void SetNeedsUpdateOfHomeIndicatorAutoHidden ();
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Protocol, Model, BaseType (typeof (NSObject))]
 	partial interface UIViewControllerContextTransitioning {
 		[Abstract]
@@ -14610,7 +14610,7 @@ namespace XamCore.UIKit {
 		UITraitEnvironmentLayoutDirection LayoutDirection { get; }
 	}
 	
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Static]
 	partial interface UITransitionContext {
 		[Field ("UITransitionContextFromViewControllerKey")]
@@ -14628,7 +14628,7 @@ namespace XamCore.UIKit {
 		NSString ToViewKey { get; }
 	}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
 	partial interface UIViewControllerAnimatedTransitioning {
@@ -14649,7 +14649,7 @@ namespace XamCore.UIKit {
 	}
 	interface IUIViewControllerAnimatedTransitioning {}
 
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Model, BaseType (typeof (NSObject))]
 	[Protocol]
 	partial interface UIViewControllerInteractiveTransitioning {
@@ -14693,7 +14693,7 @@ namespace XamCore.UIKit {
 		UIPresentationController GetPresentationControllerForPresentedViewController (UIViewController presentedViewController, [NullAllowed] UIViewController presentingViewController, UIViewController sourceViewController);
 	}
 	
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (NSObject))]
 	partial interface UIPercentDrivenInteractiveTransition : UIViewControllerInteractiveTransitioning {
 		[Export ("duration")]
@@ -14736,7 +14736,7 @@ namespace XamCore.UIKit {
 	// This protocol is only for consumption (there is no API to set a transition coordinator context,
 	// you'll be provided an existing one), so we do not provide a model to subclass.
 	//
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Protocol]
 	partial interface UIViewControllerTransitionCoordinatorContext {
 		[Abstract]
@@ -14811,7 +14811,7 @@ namespace XamCore.UIKit {
 	// This protocol is only for consumption (there is no API to set a transition coordinator,
 	// only get an existing one), so we do not provide a model to subclass.
 	//
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Protocol]
 	partial interface UIViewControllerTransitionCoordinator : UIViewControllerTransitionCoordinatorContext {
 		[Abstract]
@@ -14898,47 +14898,47 @@ namespace XamCore.UIKit {
 		[Export ("dataDetectorTypes")]
 		UIDataDetectorType DataDetectorTypes { get; set; }
 
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("allowsInlineMediaPlayback")]
 		bool AllowsInlineMediaPlayback { get; set; }
 		
-		[Since (4,0)]
+		[iOS (4,0)]
 		[Export ("mediaPlaybackRequiresUserAction")]
 		bool MediaPlaybackRequiresUserAction { get; set; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("scrollView", ArgumentSemantic.Retain)]
 		UIScrollView ScrollView { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("mediaPlaybackAllowsAirPlay")]
 		bool MediaPlaybackAllowsAirPlay { get; set; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("suppressesIncrementalRendering")]
 		bool SuppressesIncrementalRendering { get; set; }
 
-		[Since (6,0)]
+		[iOS (6,0)]
 		[Export ("keyboardDisplayRequiresUserAction")]
 		bool KeyboardDisplayRequiresUserAction { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("paginationMode")]
 		UIWebPaginationMode PaginationMode { get; set; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("paginationBreakingMode")]
 		UIWebPaginationBreakingMode PaginationBreakingMode { get; set; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("pageLength")]
 		nfloat PageLength { get; set; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("gapBetweenPages")]
 		nfloat GapBetweenPages { get; set; }
 	
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("pageCount")]
 		nint PageCount { get; }
 
@@ -14969,7 +14969,7 @@ namespace XamCore.UIKit {
 		void LoadFailed (UIWebView webView, NSError error);
 	}
 
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	interface UITextChecker {
 		[Export ("rangeOfMisspelledWordInString:range:startingAt:wrap:language:")]
@@ -15086,7 +15086,7 @@ namespace XamCore.UIKit {
 		NSString Password { get; }
 	}
 	
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof (UIViewController), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UISplitViewControllerDelegate)})]
 	interface UISplitViewController {
 		[Export ("initWithNibName:bundle:")]
@@ -15104,7 +15104,7 @@ namespace XamCore.UIKit {
 		[Export ("delegate", ArgumentSemantic.Assign)][NullAllowed]
 		NSObject WeakDelegate { get; set; }
 		
-		[Since (5,1)]
+		[iOS (5,1)]
 		[Export ("presentsWithGesture")]
 		bool PresentsWithGesture { get; set; }
 
@@ -15160,18 +15160,18 @@ namespace XamCore.UIKit {
 		UISplitViewControllerPrimaryEdge PrimaryEdge { get; set; }
 	}
 
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
 	interface UISplitViewControllerDelegate {
 		[NoTV]
-		[Since (7,0)]  // While introduced in 7.0, it was not made public, it was only publicized in iOS 8 and made retroactively supported
+		[iOS (7,0)]  // While introduced in 7.0, it was not made public, it was only publicized in iOS 8 and made retroactively supported
 		[Export ("splitViewControllerSupportedInterfaceOrientations:"), DelegateName("Func<UISplitViewController,UIInterfaceOrientationMask>"), DefaultValue(UIInterfaceOrientationMask.All)]
 		UIInterfaceOrientationMask SupportedInterfaceOrientations (UISplitViewController splitViewController);
 		
 		[NoTV]
-		[Since (7,0)]  // While introduced in 7.0, it was not made public, it was only publicized in iOS 8 and made retroactively supported
+		[iOS (7,0)]  // While introduced in 7.0, it was not made public, it was only publicized in iOS 8 and made retroactively supported
 		[Export ("splitViewControllerPreferredInterfaceOrientationForPresentation:"), DelegateName("Func<UISplitViewController,UIInterfaceOrientation>"), DefaultValue (UIInterfaceOrientation.Unknown)]
 		UIInterfaceOrientation GetPreferredInterfaceOrientationForPresentation (UISplitViewController splitViewController);
 
@@ -15191,7 +15191,7 @@ namespace XamCore.UIKit {
 		void WillShowViewController (UISplitViewController svc, UIViewController aViewController, UIBarButtonItem button);
 
 		[NoTV]
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Export ("splitViewController:shouldHideViewController:inOrientation:"), DelegateName ("UISplitViewControllerHidePredicate"), DefaultValue (true)]
 		[Availability (Deprecated = Platform.iOS_8_0, Message="Use 'UISearchController' instead.")]
 		bool ShouldHideViewController (UISplitViewController svc, UIViewController viewController, UIInterfaceOrientation inOrientation);
@@ -15246,7 +15246,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (UIControl))]
 	interface UIStepper {
 		[Export ("initWithFrame:")]
@@ -15318,7 +15318,7 @@ namespace XamCore.UIKit {
 		UIImage GetDecrementImage (UIControlState state);
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface UIStoryboard {
 		[Static]
@@ -15341,7 +15341,7 @@ namespace XamCore.UIKit {
 	}
 
 	[Availability (Deprecated = Platform.iOS_9_0)]
-	[Since (5,0)]
+	[iOS (5,0)]
 	[DisableDefaultCtor] // as it subclass UIStoryboardSegue we end up with the same error
 	[BaseType (typeof (UIStoryboardSegue))]
 	interface UIStoryboardPopoverSegue {
@@ -15352,7 +15352,7 @@ namespace XamCore.UIKit {
 		UIPopoverController PopoverController { get;  }
 	}
 
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: Don't call -[UIStoryboardSegue init]
 	interface UIStoryboardSegue {
@@ -15379,7 +15379,7 @@ namespace XamCore.UIKit {
 		UIStoryboardSegue Create ([NullAllowed] string identifier, UIViewController source, UIViewController destination, NSAction performHandler);
 	}
 
-	[Since (9,0)]
+	[iOS (9,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] 
 	interface UIStoryboardUnwindSegueSource {
@@ -15394,7 +15394,7 @@ namespace XamCore.UIKit {
 		NSObject Sender { get; }
 	}
 	
-	[Since (8,0)]
+	[iOS (8,0)]
 	[Protocol]
 	interface UIPopoverBackgroundViewMethods {
 		//
@@ -15411,7 +15411,7 @@ namespace XamCore.UIKit {
 		UIEdgeInsets GetContentViewInsets ();
 	}
 	
-	[Since (5,0)]
+	[iOS (5,0)]
 	[BaseType (typeof (UIView))]
 	interface UIPopoverBackgroundView : UIPopoverBackgroundViewMethods {
 		[Export ("initWithFrame:")]
@@ -15430,7 +15430,7 @@ namespace XamCore.UIKit {
 		bool WantsDefaultContentAppearance { get; }
 	}
 		
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIPopoverControllerDelegate)})]
 	[DisableDefaultCtor] // bug #1786
 	interface UIPopoverController : UIAppearanceContainer {
@@ -15475,20 +15475,20 @@ namespace XamCore.UIKit {
 		void Dismiss (bool animated);
 		
 		// @property (nonatomic, readwrite) UIEdgeInsets popoverLayoutMargins
-		[Since (5,0)][Export ("popoverLayoutMargins")]
+		[iOS (5,0)][Export ("popoverLayoutMargins")]
 		UIEdgeInsets PopoverLayoutMargins { get; set; }
 		
 		// @property (nonatomic, readwrite, retain) Class popoverBackgroundViewClass
 		// Class is not pretty so we'll expose it manually as a System.Type
-		[Since (5,0)][Internal][Export ("popoverBackgroundViewClass", ArgumentSemantic.Retain)]
+		[iOS (5,0)][Internal][Export ("popoverBackgroundViewClass", ArgumentSemantic.Retain)]
 		IntPtr PopoverBackgroundViewClass { get; set; }
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("backgroundColor", ArgumentSemantic.Copy)]
 		UIColor BackgroundColor { get; set; }
 	}
 
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -15499,7 +15499,7 @@ namespace XamCore.UIKit {
 		[Export ("popoverControllerShouldDismissPopover:"), DelegateName ("UIPopoverControllerCondition"), DefaultValue ("true")]
 		bool ShouldDismiss (UIPopoverController popoverController);
 		
-		[Since (7,0), Export ("popoverController:willRepositionPopoverToRect:inView:"), EventArgs ("UIPopoverControllerReposition")]
+		[iOS (7,0), Export ("popoverController:willRepositionPopoverToRect:inView:"), EventArgs ("UIPopoverControllerReposition")]
 		void WillReposition (UIPopoverController popoverController, ref CGRect rect, ref UIView view);
 	}
 
@@ -15600,7 +15600,7 @@ namespace XamCore.UIKit {
 		void WillRepositionPopover (UIPopoverPresentationController popoverPresentationController, ref CGRect targetRect, ref UIView inView);
 	}
 	
-	[Since (3,2)]
+	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	interface UIScreenMode {
 		[Export ("pixelAspectRatio")]
@@ -15610,7 +15610,7 @@ namespace XamCore.UIKit {
 		CGSize Size { get; }
 	}
 
-	[Since (4,2)]
+	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	interface UITextInputMode : NSSecureCoding {
 		[Export ("currentInputMode"), NullAllowed][Static]
@@ -15625,7 +15625,7 @@ namespace XamCore.UIKit {
 		[Notification]
 		NSString CurrentInputModeDidChangeNotification { get; }
 
-		[Since (5,0)]
+		[iOS (5,0)]
 		[Static]
 		[Export ("activeInputModes")]
 		UITextInputMode [] ActiveInputModes { get; }
@@ -15727,7 +15727,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	interface UIPrintPaper {
 		[Export ("bestPaperForPageSize:withPapersFromArray:")][Static]
@@ -15741,7 +15741,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	interface UIPrintPageRenderer {
 		[Export ("footerHeight")]
@@ -15817,7 +15817,7 @@ namespace XamCore.UIKit {
 		[Export ("printInteractionControllerDidFinishJob:"), EventArgs ("UIPrintInteraction")]
 		void DidFinishJob (UIPrintInteractionController printInteractionController);
 
-		[Since (7,0), Export ("printInteractionController:cutLengthForPaper:")]
+		[iOS (7,0), Export ("printInteractionController:cutLengthForPaper:")]
 		[NoDefaultValue]
 #if XAMCORE_2_0
 		[DelegateName ("Func<UIPrintInteractionController,UIPrintPaper,nfloat>")]
@@ -15832,7 +15832,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIPrintInteractionControllerDelegate)})]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: -[UIPrintInteractionController init] not allowed
 	[DisableDefaultCtor]
@@ -15914,7 +15914,7 @@ namespace XamCore.UIKit {
 #endif
 		PresentFromRectInView (CGRect rect, UIView view, bool animated, UIPrintInteractionCompletionHandler completion);
 
-		[Since (7,0), Export ("showsNumberOfCopies")]
+		[iOS (7,0), Export ("showsNumberOfCopies")]
 		bool ShowsNumberOfCopies { get; set; }
 
 
@@ -15929,7 +15929,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: -[UIPrintInfo init] not allowed
 	[DisableDefaultCtor]
@@ -15960,7 +15960,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[BaseType (typeof (UIPrintFormatter))]
 	interface UIViewPrintFormatter {
 		[Export ("view")]
@@ -16003,7 +16003,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[BaseType (typeof (UIPrintFormatter))]
 	// accessing the properties fails with 7.0GM if the default `init` is used to create the instance, e.g. 
 	// [UISimpleTextPrintFormatter color]: unrecognized selector sent to instance 0x18bd70d0
@@ -16027,18 +16027,18 @@ namespace XamCore.UIKit {
 		[Export ("initWithText:")]
 		IntPtr Constructor ([NullAllowed] string text);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("initWithAttributedText:")]
 		IntPtr Constructor ([NullAllowed] NSAttributedString text);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[NullAllowed]
 		[Export ("attributedText", ArgumentSemantic.Copy)]
 		NSAttributedString AttributedText { get; set; }
 	}
 
 	[NoTV]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	interface UIPrintFormatter : NSCopying {
 
@@ -16076,7 +16076,7 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[Since (4,2)]
+	[iOS (4,2)]
 	[BaseType (typeof (UIPrintFormatter))]
 #if XAMCORE_4_0
 	[DisableDefaultCtor] // nonfunctional (and it doesn't show up in the header anyway)
@@ -16227,53 +16227,53 @@ namespace XamCore.UIKit {
 
 	[Category, BaseType (typeof (NSString))]
 	interface NSStringDrawing {
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("sizeWithAttributes:")]
 		CGSize WeakGetSizeUsingAttributes (NSDictionary attributes);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Wrap ("WeakGetSizeUsingAttributes (This, attributes.Dictionary)")]
 		CGSize GetSizeUsingAttributes (UIStringAttributes attributes);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("drawAtPoint:withAttributes:")]
 		void WeakDrawString (CGPoint point, NSDictionary attributes);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Wrap ("WeakDrawString (This, point, attributes.Dictionary)")]
 		void DrawString (CGPoint point, UIStringAttributes attributes);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("drawInRect:withAttributes:")]
 		void WeakDrawString (CGRect rect, NSDictionary attributes);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Wrap ("WeakDrawString (This, rect, attributes.Dictionary)")]
 		void DrawString (CGRect rect, UIStringAttributes attributes);
 	}
 
 	[Category, BaseType (typeof (NSString))]
 	interface NSExtendedStringDrawing {
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("drawWithRect:options:attributes:context:")]
 		void WeakDrawString (CGRect rect, NSStringDrawingOptions options, NSDictionary attributes, [NullAllowed] NSStringDrawingContext context);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Wrap ("WeakDrawString (This, rect, options, attributes == null ? null : attributes.Dictionary, context)")]
 		void DrawString (CGRect rect, NSStringDrawingOptions options, UIStringAttributes attributes, [NullAllowed] NSStringDrawingContext context);
 		
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Export ("boundingRectWithSize:options:attributes:context:")]
 		CGRect WeakGetBoundingRect (CGSize size, NSStringDrawingOptions options, NSDictionary attributes, [NullAllowed] NSStringDrawingContext context);
 
-		[Since (7,0)]
+		[iOS (7,0)]
 		[Wrap ("WeakGetBoundingRect (This, size, options, attributes == null ? null : attributes.Dictionary, context)")]
 		CGRect GetBoundingRect (CGSize size, NSStringDrawingOptions options, UIStringAttributes attributes, [NullAllowed] NSStringDrawingContext context);
 	}
 
 #if !WATCH
 	[NoWatch]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[BaseType (typeof (UIView))]
 	interface UIInputView : NSCoding {
 		[DesignatedInitializer]
@@ -16450,7 +16450,7 @@ namespace XamCore.UIKit {
 	}
 		
 	[NoWatch]
-	[Since (7,0)]
+	[iOS (7,0)]
 	[Protocol]
 	[Model]
 	[BaseType (typeof (NSObject))]
@@ -16492,7 +16492,7 @@ namespace XamCore.UIKit {
 	// at the moment there is no API that require a specific UIAccessibilityIdentification
 	// implementation, so we don't provide a Model class (for now at least).
 	[NoWatch]
-	[Since (5, 0)]
+	[iOS (5, 0)]
 	[Protocol]
 	interface UIAccessibilityIdentification {
 		[Abstract]

--- a/src/usernotifications.cs
+++ b/src/usernotifications.cs
@@ -19,9 +19,9 @@ using XamCore.CoreMedia;
 
 namespace XamCore.UserNotifications {
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
+	[Watch (3, 0)]
 	[ErrorDomain ("UNErrorDomain")]
 	[Native]
 	public enum UNErrorCode : nint {
@@ -36,8 +36,8 @@ namespace XamCore.UserNotifications {
 		NotificationInvalidNoContent
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.TvOS)]
 	[Native]
 	[Flags]
@@ -48,8 +48,8 @@ namespace XamCore.UserNotifications {
 		Foreground = (1 << 2)
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.TvOS)]
 	[Native]
 	[Flags]
@@ -61,9 +61,9 @@ namespace XamCore.UserNotifications {
 		HiddenPreviewsShowSubtitle = (1 << 3),
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
+	[Watch (3, 0)]
 	[Native]
 	public enum UNAuthorizationStatus : nint {
 		NotDetermined = 0,
@@ -71,9 +71,9 @@ namespace XamCore.UserNotifications {
 		Authorized
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
+	[Watch (3, 0)]
 	[Native]
 	public enum UNNotificationSetting : nint {
 		NotSupported = 0,
@@ -81,7 +81,7 @@ namespace XamCore.UserNotifications {
 		Enabled
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.TvOS)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Native]
@@ -91,9 +91,9 @@ namespace XamCore.UserNotifications {
 		Alert
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
+	[Watch (3, 0)]
 	[Native]
 	[Flags]
 	public enum UNAuthorizationOptions : nuint {
@@ -104,9 +104,9 @@ namespace XamCore.UserNotifications {
 		CarPlay = (1 << 3)
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
+	[Watch (3, 0)]
 	[Native]
 	[Flags]
 	public enum UNNotificationPresentationOptions : nuint {
@@ -125,9 +125,9 @@ namespace XamCore.UserNotifications {
 		Never
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
+	[Watch (3, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // as per docs (not user created)
 	interface UNNotification : NSCopying, NSSecureCoding {
@@ -139,8 +139,8 @@ namespace XamCore.UserNotifications {
 		UNNotificationRequest Request { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.TvOS)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // as per docs (use FromIdentifier)
@@ -160,8 +160,8 @@ namespace XamCore.UserNotifications {
 		UNNotificationAction FromIdentifier (string identifier, string title, UNNotificationActionOptions options);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.TvOS)]
 	[BaseType (typeof (UNNotificationAction))]
 	[DisableDefaultCtor] // as per docs (use FromIdentifier)
@@ -178,8 +178,8 @@ namespace XamCore.UserNotifications {
 		string TextInputPlaceholder { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.TvOS)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // as per docs (use FromIdentifier)
@@ -200,8 +200,8 @@ namespace XamCore.UserNotifications {
 		UNNotificationAttachment FromIdentifier (string identifier, NSUrl url, [NullAllowed] NSDictionary options, [NullAllowed] out NSError error);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.TvOS)]
 	[Static]
 	[Internal]
@@ -220,8 +220,8 @@ namespace XamCore.UserNotifications {
 		NSString ThumbnailTime { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.TvOS)]
 	[StrongDictionary ("UNNotificationAttachmentOptionsKeys")]
 	interface UNNotificationAttachmentOptions {
@@ -249,8 +249,8 @@ namespace XamCore.UserNotifications {
 		double ThumbnailTimeInSeconds { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.TvOS)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // as per docs (use FromIdentifier)
@@ -283,9 +283,9 @@ namespace XamCore.UserNotifications {
 
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
+	[Watch (3, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // as per docs
 	interface UNNotificationContent : NSCopying, NSMutableCopying, NSSecureCoding {
@@ -330,9 +330,9 @@ namespace XamCore.UserNotifications {
 		NSDictionary UserInfo { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
+	[Watch (3, 0)]
 	[BaseType (typeof (UNNotificationContent))]
 	interface UNMutableNotificationContent {
 
@@ -375,9 +375,9 @@ namespace XamCore.UserNotifications {
 		NSDictionary UserInfo { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
+	[Watch (3, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface UNNotificationRequest : NSCopying, NSSecureCoding {
@@ -396,8 +396,8 @@ namespace XamCore.UserNotifications {
 		UNNotificationRequest FromIdentifier (string identifier, UNNotificationContent content, [NullAllowed] UNNotificationTrigger trigger);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.TvOS)]
 	[Static]
 	[Internal]
@@ -410,8 +410,8 @@ namespace XamCore.UserNotifications {
 		NSString Dismiss { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.TvOS)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // as per docs
@@ -433,8 +433,8 @@ namespace XamCore.UserNotifications {
 		bool IsCustomAction { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.TvOS)]
 	[BaseType (typeof (UNNotificationResponse))]
 	[DisableDefaultCtor] // as per docs
@@ -444,7 +444,7 @@ namespace XamCore.UserNotifications {
 		string UserText { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.TvOS)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (NSObject))]
@@ -459,9 +459,9 @@ namespace XamCore.UserNotifications {
 		void TimeWillExpire ();
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
+	[Watch (3, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // as per docs
 	interface UNNotificationSettings : NSCopying, NSSecureCoding {
@@ -505,8 +505,8 @@ namespace XamCore.UserNotifications {
 		UNShowPreviewsSetting ShowPreviewsSetting { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.TvOS)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // as per docs (use provided methods)
@@ -522,9 +522,9 @@ namespace XamCore.UserNotifications {
 		UNNotificationSound GetSound (string name);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
+	[Watch (3, 0)]
 	[BaseType (typeof (NSObject))]
 	[Abstract] // as per docs
 	[DisableDefaultCtor]
@@ -534,18 +534,18 @@ namespace XamCore.UserNotifications {
 		bool Repeats { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
+	[Watch (3, 0)]
 	[BaseType (typeof (UNNotificationTrigger))]
 	[DisableDefaultCtor] // as per docs (system created)
 	interface UNPushNotificationTrigger {
 	
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
+	[Watch (3, 0)]
 	[BaseType (typeof (UNNotificationTrigger))]
 	[DisableDefaultCtor] // as per doc, use supplied method (CreateTrigger)
 	interface UNTimeIntervalNotificationTrigger {
@@ -561,9 +561,9 @@ namespace XamCore.UserNotifications {
 		NSDate NextTriggerDate { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
+	[Watch (3, 0)]
 	[DisableDefaultCtor] // as per doc, use supplied method (CreateTrigger)
 	[BaseType (typeof (UNNotificationTrigger))]
 	interface UNCalendarNotificationTrigger {
@@ -579,8 +579,8 @@ namespace XamCore.UserNotifications {
 		NSDate NextTriggerDate { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[Watch (3, 0)]
 	[Unavailable (PlatformName.TvOS)]
 	[BaseType (typeof (UNNotificationTrigger))]
 	[DisableDefaultCtor] // as per doc, use supplied method (CreateTrigger)
@@ -597,9 +597,9 @@ namespace XamCore.UserNotifications {
 
 	interface IUNUserNotificationCenterDelegate { }
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
+	[Watch (3, 0)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	interface UNUserNotificationCenterDelegate {
@@ -612,9 +612,9 @@ namespace XamCore.UserNotifications {
 		void DidReceiveNotificationResponse (UNUserNotificationCenter center, UNNotificationResponse response, Action completionHandler);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
-	[Introduced (PlatformName.WatchOS, 3, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
+	[Watch (3, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface UNUserNotificationCenter {

--- a/src/usernotificationsui.cs
+++ b/src/usernotificationsui.cs
@@ -16,7 +16,7 @@ using XamCore.UserNotifications;
 
 namespace XamCore.UserNotificationsUI {
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Unavailable (PlatformName.TvOS)]
@@ -27,7 +27,7 @@ namespace XamCore.UserNotificationsUI {
 		Overlay
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Unavailable (PlatformName.TvOS)]
@@ -40,7 +40,7 @@ namespace XamCore.UserNotificationsUI {
 
 	interface IUNNotificationContentExtension { }
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Unavailable (PlatformName.TvOS)]
@@ -70,7 +70,7 @@ namespace XamCore.UserNotificationsUI {
 		void PauseMedia ();
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
+	[iOS (10, 0)]
 	[Unavailable (PlatformName.MacOSX)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Unavailable (PlatformName.TvOS)]

--- a/src/videosubscriberaccount.cs
+++ b/src/videosubscriberaccount.cs
@@ -15,8 +15,8 @@ using XamCore.UIKit;
 namespace XamCore.VideoSubscriberAccount {
 
 	[Native]
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
 	[Unavailable (PlatformName.WatchOS)]
 	[ErrorDomain ("VSErrorDomain")]
 	public enum VSErrorCode : nint {
@@ -29,8 +29,8 @@ namespace XamCore.VideoSubscriberAccount {
 	}
 
 	[Native]
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
 	[Unavailable (PlatformName.WatchOS)]
 	public enum VSAccountAccessStatus : nint {
 		NotDetermined = 0,
@@ -39,8 +39,8 @@ namespace XamCore.VideoSubscriberAccount {
 		Granted = 3
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Static]
 	[Internal]
@@ -60,8 +60,8 @@ namespace XamCore.VideoSubscriberAccount {
 		NSString AccountProviderResponseKey { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
 	[Unavailable (PlatformName.WatchOS)]
 	[StrongDictionary ("VSErrorInfoKeys")]
 	interface VSErrorInfo {
@@ -79,8 +79,8 @@ namespace XamCore.VideoSubscriberAccount {
 	interface IVSAccountManagerDelegate { }
 
 	[Protocol, Model]
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (NSObject))]
 	interface VSAccountManagerDelegate {
@@ -98,8 +98,8 @@ namespace XamCore.VideoSubscriberAccount {
 		bool ShouldAuthenticateAccountProvider (VSAccountManager accountManager, string accountProviderIdentifier);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (NSObject))]
 	interface VSAccountManager {
@@ -116,8 +116,8 @@ namespace XamCore.VideoSubscriberAccount {
 		VSAccountManagerResult Enqueue (VSAccountMetadataRequest accountMetadataRequest, Action<VSAccountMetadata, NSError> completionHandler);
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Static]
 	[Internal]
@@ -127,8 +127,8 @@ namespace XamCore.VideoSubscriberAccount {
 		NSString CheckAccessOptionPrompt { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
 	[Unavailable (PlatformName.WatchOS)]
 	[StrongDictionary ("VSCheckAccessOptionKeys")]
 	interface VSAccountManagerAccessOptions {
@@ -137,8 +137,8 @@ namespace XamCore.VideoSubscriberAccount {
 		bool CheckAccessOptionPrompt { get; set; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -148,8 +148,8 @@ namespace XamCore.VideoSubscriberAccount {
 		void Cancel ();
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (NSObject))]
 	interface VSAccountMetadata {
@@ -171,8 +171,8 @@ namespace XamCore.VideoSubscriberAccount {
 		VSAccountProviderResponse AccountProviderResponse { get; }
 	}
 
-	[Introduced (PlatformName.iOS, 10, 0)]
-	[Introduced (PlatformName.TvOS, 10, 0)]
+	[iOS (10, 0)]
+	[TV (10, 0)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (NSObject))]
 	interface VSAccountMetadataRequest {

--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -914,7 +914,7 @@ namespace XamCore.WebKit {
 		[Export ("scrollHeight")]
 		int ScrollHeight { get; } /* int, not NSInteger */
 
-		[Mavericks, Export ("className", ArgumentSemantic.Copy)]
+		[Mac (10, 9), Export ("className", ArgumentSemantic.Copy)]
 		string ClassName { get; set; }
 
 		[Export ("firstElementChild", ArgumentSemantic.Retain)]

--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -2869,7 +2869,7 @@ namespace XamCore.WebKit {
 		[Export ("form", ArgumentSemantic.Retain)]
 		DomHtmlFormElement Form { get; }
 
-		[Export ("files", ArgumentSemantic.Retain), Mavericks]
+		[Export ("files", ArgumentSemantic.Retain), Mac (10, 9)]
 		DomFileList Files { get; set; }
 	}
 

--- a/src/wkwebkit.cs
+++ b/src/wkwebkit.cs
@@ -546,7 +546,8 @@ namespace XamCore.WebKit
 		IntPtr Constructor (CGRect frame, WKWebViewConfiguration configuration);
 
 		// (instancetype)initWithCoder:(NSCoder *)coder NS_UNAVAILABLE;
-		// [Availability (Unavailable = Platform.iOS | Platform.Mac)]
+		// [Availability (Unavailable = Platform.iOS)]
+		// [Availability (Unavailable = Platform.Mac)]
 		// [Export ("initWithCoder:")]
 		// IntPtr Constructor (NSCoder coder);
 
@@ -750,7 +751,7 @@ namespace XamCore.WebKit
 		[Export ("dataDetectorTypes", ArgumentSemantic.Assign)]
 		WKDataDetectorTypes DataDetectorTypes { get; set; }
 #endif
-		[iOS (10,0)][Mac (10,12, only64: true)]
+		[iOS (10,0)][Mac (10,12, onlyOn64: true)]
 		[Export ("mediaTypesRequiringUserActionForPlayback", ArgumentSemantic.Assign)]
 		WKAudiovisualMediaTypes MediaTypesRequiringUserActionForPlayback { get; set; }
 

--- a/src/wkwebkit.cs
+++ b/src/wkwebkit.cs
@@ -546,8 +546,8 @@ namespace XamCore.WebKit
 		IntPtr Constructor (CGRect frame, WKWebViewConfiguration configuration);
 
 		// (instancetype)initWithCoder:(NSCoder *)coder NS_UNAVAILABLE;
-		// [Availability (Unavailable = Platform.iOS)]
-		// [Availability (Unavailable = Platform.Mac)]
+		// [Unavailable (PlatformName.iOS)]
+		// [Unavailable (PlatformName.MacOSX)]
 		// [Export ("initWithCoder:")]
 		// IntPtr Constructor (NSCoder coder);
 

--- a/tools/pmcs/XamarinPreprocessorVisitor.cs
+++ b/tools/pmcs/XamarinPreprocessorVisitor.cs
@@ -131,14 +131,25 @@ namespace Xamarin.Pmcs
 			);
 
 			foreach (var onlyOn64 in invocationExpression.Arguments.Skip (isTripleVersion ? 4 : 3).Take (2)) {
-				var onlyOn64BoolValue = onlyOn64 as LiteralExpression;
+				var onlyOn64Value = onlyOn64 as LiteralExpression;
 				if (onlyOn64 is NamedExpression)
-					onlyOn64BoolValue = onlyOn64.GetChild<Expression> (
+					onlyOn64Value = onlyOn64.GetChild<Expression> (
 						BinaryExpression.RightOperandRole) as LiteralExpression;
-				if (onlyOn64BoolValue != null && onlyOn64BoolValue.Value == "true")
-					invocationExpression.AddArgument (
-						new LiteralExpression ("PlatformArchitecture.Arch64"));
-				if (onlyOn64BoolValue != null)
+				if (onlyOn64Value.Value != null) {
+					switch (onlyOn64Value.Value) {
+					case "true":
+						invocationExpression.AddArgument (new LiteralExpression ("PlatformArchitecture.Arch64"));
+						break;
+					case "PlatformArchitecture.None":
+					case "PlatformArchitecture.Arch32":
+					case "PlatformArchitecture.Arch64":
+					case "PlatformArchitecture.ALl":
+						invocationExpression.AddArgument (new LiteralExpression (onlyOn64Value.Value));
+						break;
+					}
+
+				}
+				if (onlyOn64Value != null)
 					onlyOn64.Remove ();
 			}
 		}


### PR DESCRIPTION
- There are a number of constructs that were uncommon enough / difficult to handle
  that were changed by hand / vim macro:
   - Multiple platforms |'ed into one Availability attributes. This was trivial to handle
     in the preprocessor but given the limited number of bits in the shadow enum would be
     difficult to handle in the generator.
   - 32-bit arch Availability attributes were really uncommon and hand processing allowed
     them to be skipped completely
   - A few naming changes smooted transitions between old and new attribute