### PR TITLE
[msbuild] Fixes MoveTaskBase inclusion

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -51,9 +51,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <!-- XBuild does not define the MSBuildRuntimeVersion property. -->
-    <Compile Include="MsBuildTasks\MoveTaskBase.cs" Condition="'$(MSBuildRuntimeVersion)' != ''" />
-    <Compile Include="MsBuildTasks\XBuildMoveTaskBase.cs" Condition="'$(MSBuildRuntimeVersion)' == ''" />
+    <!-- Mono has a different implementation of the Move task, so when building on a Mac we need to include XBuildMoveTaskBase.cs -->
+    <Compile Include="MsBuildTasks\MoveTaskBase.cs" Condition="'$(OS)' == 'Windows_NT'" />
+    <Compile Include="MsBuildTasks\XBuildMoveTaskBase.cs" Condition="'$(OS)' != 'Windows_NT'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MsBuildTasks\CopyBase.cs" />


### PR DESCRIPTION
MoveTaskBase inherits from Microsoft.Build.Tasks.Move, and Mono has a different implementation of it, so when building from a Mac we need to include XBuildMoveTaskBase.cs instead. The previous condition does no apply any more, because we're now using MSBuild to build, but the Move task implementation didn't change so it doesn't matter if we're using Xbuild or MSBuild.

This issue is preventing us (XVS) from merging features to our master branch