### PR TITLE
[macos][photos] Fix breaking change wrt PHLivePhotoFrameProcessingBlock

### DIFF
--- a/src/Photos/PHCompat.cs
+++ b/src/Photos/PHCompat.cs
@@ -23,7 +23,7 @@ namespace XamCore.Photos {
 	}
 #endif
 
-#if !XAMCORE_4_0 && !MONOMAC
+#if !XAMCORE_4_0
 	// incorrect signature, should have been `ref NSError`
 	[Obsolete ("Use 'PHLivePhotoFrameProcessingBlock2' instead.")]
 	public delegate CIImage PHLivePhotoFrameProcessingBlock (IPHLivePhotoFrame frame, NSError error);


### PR DESCRIPTION
API diff reported

```
Type Changed: Photos.PHLivePhotoEditingContext

Removed property:

	public virtual PHLivePhotoFrameProcessingBlock FrameProcessor { get; set; }

Removed Type Photos.PHLivePhotoFrameProcessingBlock
````