### PR TITLE
Semantically equivalent attributes which make PMCS conversion easier

### DIFF
--- a/src/Intents/INIntentResolutionResult.cs
+++ b/src/Intents/INIntentResolutionResult.cs
@@ -14,7 +14,7 @@ using XamCore.ObjCRuntime;
 
 namespace XamCore.Intents {
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Register ("INIntentResolutionResult", SkipRegistration = true)]
 	public sealed partial class INIntentResolutionResult<ObjectType> : INIntentResolutionResult

--- a/src/SceneKit/SCNCompat.cs
+++ b/src/SceneKit/SCNCompat.cs
@@ -63,7 +63,7 @@ namespace XamCore.SceneKit {
 		}
 
 		[iOS (9, 0)]
-		[Mac (10, 11, PlatformArchitecture.Arch64)]
+		[Mac (10, 11, 0, PlatformArchitecture.Arch64)]
 		[Obsolete ("Use 'SCNSceneRenderer_Extensions.PresentSceneAsync' instead.")]
 		public unsafe virtual Task PresentSceneAsync (SCNScene scene, global::XamCore.SpriteKit.SKTransition transition, SCNNode pointOfView)
 		{

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -7988,7 +7988,7 @@ namespace XamCore.AppKit {
 
 	}
 
-	[Mac (10, 0, PlatformArchitecture.Arch32)] 
+	[Mac (10, 0, 0, PlatformArchitecture.Arch32)] 
 	[BaseType (typeof (NSView))]
 	interface NSMenuView {
 		[Static]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -9509,7 +9509,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVCaptureDeviceTypeBuiltInTelephotoCamera")]
 		BuiltInTelephotoCamera,
 
-		[iOS (10, 0, message: "Use 'BuiltInDualCamera' instead.")]
+		[iOS (10, 0)]
 		[Deprecated (PlatformName.iOS, 10, 2, message: "Use 'BuiltInDualCamera' instead.")]
 		[Field ("AVCaptureDeviceTypeBuiltInDuoCamera")]
 		BuiltInDuoCamera,

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -39,7 +39,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Native]
 	[Flags]
@@ -49,7 +49,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Native]
 	public enum INCallRecordType : nint {
@@ -136,7 +136,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Native]
 	public enum INConditionalOperator : nint {
@@ -218,7 +218,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Native]
 	[ErrorDomain ("INIntentErrorDomain")]
@@ -239,7 +239,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Native]
 	public enum INIntentHandlingStatus : nint {
@@ -252,7 +252,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Native]
 	public enum INInteractionDirection : nint {
@@ -283,7 +283,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Native]
 	public enum INMessageAttribute : nint {
@@ -297,7 +297,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Native]
 	[Flags]
@@ -523,7 +523,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Native]
 	public enum INSearchCallHistoryIntentResponseCode : nint {
@@ -542,7 +542,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Native]
 	public enum INSearchForMessagesIntentResponseCode : nint {
@@ -573,7 +573,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Native]
 	public enum INSendMessageIntentResponseCode : nint {
@@ -604,7 +604,7 @@ namespace XamCore.Intents {
 		FailureInsufficientFunds,
 		FailureNoBankAccount,
 		[iOS (11, 0)]
-		[Mac (10, 13, PlatformArchitecture.Arch64)]
+		[Mac (10, 13, 0, PlatformArchitecture.Arch64)]
 		[Watch (4, 0)]
 		FailureNotEligible,
 		[iOS (11,1), Watch (4,1)]
@@ -651,7 +651,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Native]
 	public enum INSetMessageAttributeIntentResponseCode : nint {
@@ -717,7 +717,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Native]
 	public enum INStartAudioCallIntentResponseCode : nint {
@@ -753,7 +753,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Native]
 	public enum INStartVideoCallIntentResponseCode : nint {
@@ -844,7 +844,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Native]
 	public enum INPersonHandleType : nint {
@@ -1330,7 +1330,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	public enum INIntentIdentifier {
 		[Unavailable (PlatformName.MacOSX)]
@@ -1711,7 +1711,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -2068,7 +2068,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -2103,7 +2103,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -2141,7 +2141,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Protocol]
 	interface INCallsDomainHandling : INStartAudioCallIntentHandling, INSearchCallHistoryIntentHandling
@@ -2709,7 +2709,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -2792,7 +2792,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Abstract]
 	[BaseType (typeof (NSObject))]
@@ -2813,7 +2813,7 @@ namespace XamCore.Intents {
 	interface INIntentResolutionResult<ObjectType> : INIntentResolutionResult { }
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Abstract]
 	[BaseType (typeof (NSObject))]
@@ -2837,7 +2837,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Abstract]
 	[BaseType (typeof (NSObject))]
@@ -2848,7 +2848,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -2974,7 +2974,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3021,7 +3021,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -3075,7 +3075,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -3245,7 +3245,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3307,7 +3307,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3345,7 +3345,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -3383,7 +3383,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -4406,7 +4406,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (INIntent))]
 	interface INSearchCallHistoryIntent {
@@ -4452,7 +4452,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Protocol]
 	interface INSearchCallHistoryIntentHandling {
@@ -4492,7 +4492,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -4511,7 +4511,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (INIntent))]
 	interface INSearchForMessagesIntent {
@@ -4585,7 +4585,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Protocol]
 	interface INSearchForMessagesIntentHandling {
@@ -4627,7 +4627,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -4737,7 +4737,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (INIntent))]
 	interface INSendMessageIntent {
@@ -4781,7 +4781,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Protocol]
 	interface INSendMessageIntentHandling {
@@ -4824,7 +4824,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -5456,7 +5456,7 @@ namespace XamCore.Intents {
 	interface IINSpeakable { }
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Protocol]
 	interface INSpeakable {
@@ -5494,7 +5494,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -5516,7 +5516,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResolutionResult))]
 	[DisableDefaultCtor]
@@ -5554,7 +5554,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (INIntent))]
 	interface INStartAudioCallIntent {
@@ -5579,7 +5579,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Protocol]
 	interface INStartAudioCallIntentHandling {
@@ -5606,7 +5606,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -5709,7 +5709,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntent))]
 	interface INStartVideoCallIntent {
@@ -5723,7 +5723,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Unavailable (PlatformName.WatchOS)]
 	[Protocol]
 	interface INStartVideoCallIntentHandling {
@@ -5746,7 +5746,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Unavailable (PlatformName.WatchOS)]
 	[BaseType (typeof (INIntentResponse))]
 	[DisableDefaultCtor]
@@ -5839,7 +5839,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[DisableDefaultCtor]
 	[BaseType (typeof (INIntentResolutionResult))]
@@ -6064,7 +6064,7 @@ namespace XamCore.Intents {
 	}
 
 	[iOS (10, 0)]
-	[Mac (10, 12, PlatformArchitecture.Arch64)]
+	[Mac (10, 12, 0, PlatformArchitecture.Arch64)]
 	[Watch (3, 2)]
 	[Category]
 	[BaseType (typeof (NSUserActivity))]

--- a/src/qtkit.cs
+++ b/src/qtkit.cs
@@ -259,7 +259,7 @@ namespace XamCore.QTKit
 		[Field ("QTCaptureDeviceInputSourceLocalizedDisplayNameKey")]
 		NSString InputSourceLocalizedDisplayNameKey { get; }
 		
-		[Mac (10, 5, PlatformArchitecture.Arch32)] 
+		[Mac (10, 5, 0, PlatformArchitecture.Arch32)] 
 		[Field ("QTCaptureDeviceLegacySequenceGrabberAttribute")]
 		NSString LegacySequenceGrabberAttribute { get; }
 
@@ -611,19 +611,19 @@ namespace XamCore.QTKit
 
 	[BaseType (typeof (NSObject))]
 	interface QTMedia {
-		[Mac (10, 3, PlatformArchitecture.Arch32)] 
+		[Mac (10, 3, 0, PlatformArchitecture.Arch32)] 
 		[Deprecated (PlatformName.MacOSX, 10, 9)] 
 		[Static, Export ("mediaWithQuickTimeMedia:error:")]
 		NSObject FromQuickTimeMedia (IntPtr quicktimeMedia, out NSError error);
 
 #if !XAMCORE_3_0
-		[Mac (10, 3, PlatformArchitecture.Arch32)] 
+		[Mac (10, 3, 0, PlatformArchitecture.Arch32)] 
 		[Deprecated (PlatformName.MacOSX, 10, 9)] 
 		[Export ("initWithQuickTimeMedia:error:")]
 		IntPtr Conditions (IntPtr quicktimeMedia, out NSError error);
 #endif
 		[Sealed] // For the duplicate selector error
-		[Mac (10, 3, PlatformArchitecture.Arch32)] 
+		[Mac (10, 3, 0, PlatformArchitecture.Arch32)] 
 		[Deprecated (PlatformName.MacOSX, 10, 9)] 
 		[Export ("initWithQuickTimeMedia:error:")]
 		IntPtr Constructors (IntPtr quicktimeMedia, out NSError error);
@@ -640,7 +640,7 @@ namespace XamCore.QTKit
 		[Export ("hasCharacteristic:")]
 		bool HasCharacteristic (string characteristic);
 
-		[Mac (10, 3, PlatformArchitecture.Arch32)] 
+		[Mac (10, 3, 0, PlatformArchitecture.Arch32)] 
 		[Deprecated (PlatformName.MacOSX, 10, 9)] 
 		[Export ("quickTimeMedia")]
 		IntPtr QuickTimeMedia { get; }
@@ -1517,12 +1517,12 @@ namespace XamCore.QTKit
 
 	[BaseType (typeof (NSObject))]
 	interface QTTrack {
-		[Mac (10, 3, PlatformArchitecture.Arch32)] 
+		[Mac (10, 3, 0, PlatformArchitecture.Arch32)] 
 		[Deprecated (PlatformName.MacOSX, 10, 9)] 
 		[Static, Export ("trackWithQuickTimeTrack:error:")]
 		NSObject FromQuickTimeTrack (IntPtr quicktimeTrack, out NSError error);
 
-		[Mac (10, 3, PlatformArchitecture.Arch32)] 
+		[Mac (10, 3, 0, PlatformArchitecture.Arch32)] 
 		[Deprecated (PlatformName.MacOSX, 10, 9)] 
 		[Export ("initWithQuickTimeTrack:error:")]
 		IntPtr Constructor (IntPtr quicktimeTrack, out NSError error);
@@ -1539,7 +1539,7 @@ namespace XamCore.QTKit
 		[Export ("setAttribute:forKey:")]
 		void SetAttribute (NSObject value, string attributeKey);
 
-		[Mac (10, 3, PlatformArchitecture.Arch32)] 
+		[Mac (10, 3, 0, PlatformArchitecture.Arch32)] 
 		[Deprecated (PlatformName.MacOSX, 10, 9)] 
 		[Export ("quickTimeTrack")]
 		IntPtr QuickTimeTrack { get; }


### PR DESCRIPTION
Mac (byte, byte, byte) must be Major, Minor, Point and from the compiler's perspective PlatformArchitecture is a byte. Thus we add a bunch of ,0 to distinguish. 