### PR TITLE
[src] Use a single, shared declaration for the 'close' p/invoke

### DIFF
--- a/src/CoreFoundation/DispatchSource.cs
+++ b/src/CoreFoundation/DispatchSource.cs
@@ -482,7 +482,7 @@ namespace XamCore.CoreFoundation {
 			extern static int open (string path, int flags);
 
 			[DllImport (Constants.libcLibrary)]
-			extern static int close (int fd);
+			extern internal static int close (int fd);
 			
 			public VnodeMonitor (string path, VnodeMonitorKind vnodeKind, DispatchQueue queue = null)
 			{

--- a/src/Darwin/KernelNotification.cs
+++ b/src/Darwin/KernelNotification.cs
@@ -151,9 +151,6 @@ namespace XamCore.Darwin {
 		[DllImport (Constants.SystemLibrary)]
 		extern static int /* int */ kqueue ();
 
-		[DllImport (Constants.SystemLibrary)]
-		extern static int /* int */ close (int /* int */ fd);
-
 		public KernelQueue ()
 		{
 			handle = kqueue ();
@@ -173,7 +170,7 @@ namespace XamCore.Darwin {
 		protected virtual void Dispose (bool disposing)
 		{
 			if (handle != -1){
-				close (handle);
+				CoreFoundation.DispatchSource.VnodeMonitor.close (handle);
 				handle = -1;
 			}
 		}

--- a/tests/xtro-sharpie/macOS-ObjCRuntime.ignore
+++ b/tests/xtro-sharpie/macOS-ObjCRuntime.ignore
@@ -18,7 +18,5 @@
 !unknown-pinvoke! aslresponse_free bound
 !unknown-pinvoke! aslresponse_next bound
 
-
-!unknown-pinvoke! close bound
 !unknown-pinvoke! kevent bound
 !unknown-pinvoke! kqueue bound


### PR DESCRIPTION
Beside eliminating a bit of code duplication this solve the random
(metadata order) xtro report

> ?unknown-entry? !unknown-pinvoke! close bound in 'macOS-ObjCRuntime.ignore'

because it was reported against two namespaces and we don't check
for duplicate p/invokes (largely because there's tons of them in
OpenTK)

Fixes https://github.com/xamarin/maccore/issues/602