### PR TITLE
[mtouch] Fix Xamarin.Sdk not to link with private frameworks. Fixes #61039 (#3118)

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -3538,6 +3538,44 @@ public class HandlerTest
 			}
 		}
 
+		[Test]
+		public void XamarinSdkAdjustLibs ()
+		{
+			using (var exttool = new MTouchTool ()) {
+				exttool.Profile = Profile.iOS;
+				exttool.Abi = "arm64";
+				exttool.CreateTemporaryCacheDirectory ();
+				exttool.Debug = false;
+				exttool.MSym = false;
+				exttool.Linker = MTouchLinker.DontLink;
+				exttool.TargetVer = "8.0";
+
+				exttool.CreateTemporaryServiceExtension ();
+				exttool.AssertExecute (MTouchAction.BuildDev, "build extension");
+
+				using (var apptool = new MTouchTool ()) {
+					apptool.Profile = exttool.Profile;
+					apptool.Abi = exttool.Abi;
+					apptool.Debug = exttool.Debug;
+					apptool.MSym = exttool.MSym;
+					apptool.TargetVer = exttool.TargetVer;
+					apptool.CreateTemporaryCacheDirectory ();
+					apptool.CreateTemporaryApp ();
+
+					apptool.AppExtensions.Add (exttool);
+					apptool.Linker = MTouchLinker.DontLink;
+					apptool.AssertExecute (MTouchAction.BuildDev, "build app");
+
+					var sdk = StringUtils.Quote (Path.Combine (apptool.Cache, "arm64", "Xamarin.Sdk"));
+					var shared_libraries = ExecutionHelper.Execute ("otool", $"-L {sdk}", hide_output: true);
+					Asserts.DoesNotContain ("Private", shared_libraries, "Private");
+
+					exttool.AssertNoWarnings();
+					apptool.AssertNoWarnings();
+				}
+			}
+		}
+
 #region Helper functions
 		static void RunUnitTest (Profile profile, string code, string csproj_configuration = "", string [] csproj_references = null, string configuration = "Debug", string platform = "iPhoneSimulator", bool clean_simulator = true)
 		{

--- a/tools/mtouch/BuildTasks.mtouch.cs
+++ b/tools/mtouch/BuildTasks.mtouch.cs
@@ -337,7 +337,7 @@ namespace Xamarin.Bundler
 			// /System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore
 			// more details in https://bugzilla.xamarin.com/show_bug.cgi?id=31036
 			if (CompilerFlags.WeakFrameworks.Count > 0)
-				Target.AdjustDylibs ();
+				Target.AdjustDylibs (Target.Executable);
 			Driver.Watch ("Native Link", 1);
 		}
 
@@ -349,6 +349,14 @@ namespace Xamarin.Bundler
 
 	public class LinkTask : CompileTask
 	{
+		protected override async Task ExecuteAsync ()
+		{
+			await base.ExecuteAsync ();
+			// we can't trust the native linker to pick the right (non private) framework when an older TargetVersion is used
+			if (CompilerFlags.WeakFrameworks.Count > 0)
+				Target.AdjustDylibs (OutputFile);
+		}
+
 		protected override void CompilationFailed (int exitCode)
 		{
 			throw ErrorHelper.CreateError (5216, "Native linking failed for '{0}'. Please file a bug report at http://bugzilla.xamarin.com", OutputFile);

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -1439,17 +1439,17 @@ namespace Xamarin.Bundler
 			build_tasks.Add (link_task);
 		}
 
-		public void AdjustDylibs ()
+		public static void AdjustDylibs (string output)
 		{
 			var sb = new StringBuilder ();
-			foreach (var dependency in Xamarin.MachO.GetNativeDependencies (Executable)) {
+			foreach (var dependency in Xamarin.MachO.GetNativeDependencies (output)) {
 				if (!dependency.StartsWith ("/System/Library/PrivateFrameworks/", StringComparison.Ordinal))
 					continue;
 				var fixed_dep = dependency.Replace ("/PrivateFrameworks/", "/Frameworks/");
 				sb.Append (" -change ").Append (dependency).Append (' ').Append (fixed_dep);
 			}
 			if (sb.Length > 0) {
-				var quoted_name = StringUtils.Quote (Executable);
+				var quoted_name = StringUtils.Quote (output);
 				sb.Append (' ').Append (quoted_name);
 				Driver.XcodeRun ("install_name_tool", sb.ToString ());
 				sb.Clear ();


### PR DESCRIPTION
We can't trust Apple's native linker to pick the right (non private)
framework when an older TargetVersion is used. It just prefer what's
available - even if specified with a WeakFramework :(

That was already dealt with for applications. However the native linking
of the Xamarin.Sdk.framework (code sharing with extensions) is done with
the `LinkTask` instead of the `NativeLinkTask` so it did not have the
"auto correct" code.

Unit test added.

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=61039