### PR TITLE
[xtro] Fix macOS Intent sanity warning

### DIFF
--- a/tests/xtro-sharpie/macOS-Intents.todo
+++ b/tests/xtro-sharpie/macOS-Intents.todo
@@ -1,6 +1,5 @@
 ## API_AVAILABLE(macosx(10.12), ios(10.0)); This is supposed to be there according to availability (Last Review: Beta 3)
 !unknown-protocol! INCallsDomainHandling bound
-!unknown-type! INSetMessageAttributeIntentResponse bound
 
 ## No availability set on headers, it is possible to be fixed later since makes sense to have in macOS
 !unknown-native-enum! INMessageAttribute bound


### PR DESCRIPTION
PR3119 was done (and tested on bots) before PR3120 that checked for
such mistakes. They were committed in the reverse order too