### PR TITLE
[social] Enable SLComposeServiceViewController on macOS and fix other xtro reported issues

### DIFF
--- a/src/social.cs
+++ b/src/social.cs
@@ -79,6 +79,10 @@ namespace XamCore.Social {
 		[Export ("parameters")]
 		NSDictionary Parameters { get;  }
 
+		[NoiOS] // just macOS
+		[Export ("addMultipartData:withName:type:")]
+		void AddMultipartData (NSData data, string partName, string partType);
+
 		[Export ("addMultipartData:withName:type:filename:")]
 		void AddMultipartData (NSData data, string partName, string partType, string filename);
 
@@ -130,6 +134,7 @@ namespace XamCore.Social {
 		[Export ("removeAllURLs")]
 		bool RemoveAllUrls ();
 	}
+#endif
 
 	[Mac (10,10, onlyOn64 : true)]
 	[iOS (8,0)]
@@ -209,13 +214,18 @@ namespace XamCore.Social {
 		UIViewController AutoCompletionViewController { get; set; }
 #endif
 	}
-#endif
 
 
 #if !MONOMAC
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor] // designated
 	interface SLComposeSheetConfigurationItem {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[NullAllowed] // by default this property is null
 		[Export ("title")]
 		string Title { get; set; }

--- a/tests/xtro-sharpie/iOS-Social.todo
+++ b/tests/xtro-sharpie/iOS-Social.todo
@@ -1,1 +1,0 @@
-!missing-designated-initializer! SLComposeSheetConfigurationItem::init is missing an [DesignatedInitializer] attribute

--- a/tests/xtro-sharpie/macOS-Social.ignore
+++ b/tests/xtro-sharpie/macOS-Social.ignore
@@ -1,0 +1,2 @@
+## type not part of macOS, fixed in XAMCORE_4_0
+!unknown-native-enum! SLComposeViewControllerResult bound

--- a/tests/xtro-sharpie/macOS-Social.todo
+++ b/tests/xtro-sharpie/macOS-Social.todo
@@ -1,9 +1,0 @@
-!missing-selector! SLComposeServiceViewController::charactersRemaining not bound
-!missing-selector! SLComposeServiceViewController::contentText not bound
-!missing-selector! SLComposeServiceViewController::placeholder not bound
-!missing-selector! SLComposeServiceViewController::setCharactersRemaining: not bound
-!missing-selector! SLComposeServiceViewController::setPlaceholder: not bound
-!missing-selector! SLComposeServiceViewController::textView not bound
-!missing-selector! SLRequest::addMultipartData:withName:type: not bound
-!missing-type! SLComposeServiceViewController not bound
-!unknown-native-enum! SLComposeViewControllerResult bound


### PR DESCRIPTION
* SLComposeServiceViewController has [Mac] specific stuff but was
excluded under a (too large) `#if !MONOMAC`

* SLComposeSheetConfigurationItem::init is a designated initializer

* SLRequest::addMultipartData:withName:type: is macOS-only and missing

xtro results:
!missing-designated-initializer! SLComposeSheetConfigurationItem::init is missing an [DesignatedInitializer] attribute
!missing-selector! SLComposeServiceViewController::charactersRemaining not bound
!missing-selector! SLComposeServiceViewController::contentText not bound
!missing-selector! SLComposeServiceViewController::placeholder not bound
!missing-selector! SLComposeServiceViewController::setCharactersRemaining: not bound
!missing-selector! SLComposeServiceViewController::setPlaceholder: not bound
!missing-selector! SLComposeServiceViewController::textView not bound
!missing-selector! SLRequest::addMultipartData:withName:type: not bound
!missing-type! SLComposeServiceViewController not bound