### PR TITLE
[xtro] Don't assume a nested type when no namespace is available

### DIFF
--- a/tests/xtro-sharpie/EnumCheck.cs
+++ b/tests/xtro-sharpie/EnumCheck.cs
@@ -23,6 +23,8 @@ namespace Extrospection {
 				enums.Add (name, type);
 			else if (td.Namespace.StartsWith ("OpenTK.", StringComparison.Ordinal)) {
 				// OpenTK duplicate a lots of enums between it's versions
+			} else if (type.IsNotPublic && String.IsNullOrEmpty (type.Namespace)) {
+				// ignore special, non exposed types
 			} else {
 				var sorted = Helpers.Sort (type, td);
 				var framework = Helpers.GetFramework (sorted.Item1);

--- a/tests/xtro-sharpie/Helpers.cs
+++ b/tests/xtro-sharpie/Helpers.cs
@@ -280,7 +280,7 @@ namespace Extrospection {
 		public static string GetFramework (TypeReference type)
 		{
 			var framework = type.Namespace;
-			if (String.IsNullOrEmpty (framework))
+			if (String.IsNullOrEmpty (framework) && type.IsNested)
 				framework = type.DeclaringType.Namespace;
 			return MapFramework (framework);
 		}


### PR DESCRIPTION
That fix a NRE while running xtro

12:55:31.4682580 System.NullReferenceException: Object reference not set to an instance of an object
12:55:31.4682960   at Extrospection.Helpers.GetFramework (Mono.Cecil.TypeReference type) [0x00012] in /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/xtro-sharpie/Helpers.cs:284
12:55:31.4683110   at Extrospection.EnumCheck.VisitManagedType (Mono.Cecil.TypeDefinition type) [0x0006c] in /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/xtro-sharpie/EnumCheck.cs:28
12:55:31.4683210   at Extrospection.AssemblyReader.ProcessType (Extrospection.BaseVisitor v, Mono.Cecil.TypeDefinition type) [0x00001] in /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/xtro-sharpie/Runner.cs:78
12:55:31.4683320   at Extrospection.AssemblyReader.Load (System.String filename) [0x00079] in /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/xtro-sharpie/Runner.cs:71
12:55:31.4684210   at Extrospection.Runner.Execute (System.String pchFile, System.Collections.Generic.IEnumerable`1[T] assemblyNames) [0x000f2] in /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/xtro-sharpie/Runner.cs:41
12:55:31.4684400   at Extrospection.MainClass.Main (System.String[] args) [0x00046] in /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/xtro-sharpie/Program.cs:20

https://jenkins.mono-project.com/job/xamarin-macios-pr-builder/5845/Test_Report/

Short story: PR #3096 adds **non public** attributes without a namespace
so they take precedence over existing ones.

xtro enum check also needed to discard them.