### PR TITLE
[tests][intro] Clean up old and some non-required availability attributes

### DIFF
--- a/src/AVFoundation/AVCaptureVideoPreviewLayer.cs
+++ b/src/AVFoundation/AVCaptureVideoPreviewLayer.cs
@@ -12,7 +12,7 @@ namespace XamCore.AVFoundation {
 
 		public enum InitMode {
 			WithConnection,
-			[iOS (8,0), Mac (10,2)]
+			[iOS (8,0), Mac (10,7)]
 			WithNoConnection,
 		}
 

--- a/src/AVFoundation/AVTypes.cs
+++ b/src/AVFoundation/AVTypes.cs
@@ -259,7 +259,7 @@ namespace XamCore.AVFoundation {
 		[DllImport (Constants.AVFoundationLibrary)]
 		static extern /* CGRect */ RectangleF AVMakeRectWithAspectRatioInsideRect (/* CGSize */ SizeF aspectRatio, /* CGRect */ RectangleF boundingRect);
 
-		[Mac (10,7)][iOS (4,0)]
+		[Mac (10,7)]
 		public static RectangleF WithAspectRatio (this RectangleF self, SizeF aspectRatio)
 		{
 			return AVMakeRectWithAspectRatioInsideRect (aspectRatio, self);

--- a/src/AVFoundation/AVUrlAssetOptions.cs
+++ b/src/AVFoundation/AVUrlAssetOptions.cs
@@ -57,7 +57,6 @@ namespace XamCore.AVFoundation {
 			}
 		}
 
-		[iOS (5,0)]
 		public AVAssetReferenceRestrictions? ReferenceRestrictions {
 			set {
 				SetNumberValue (AVUrlAsset.ReferenceRestrictionsKey, (nuint?) (ulong?) value);

--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -41,7 +41,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[Native]
 	// NSInteger - AVAssetExportSession.h
 	public enum AVAssetExportSessionStatus : nint {
@@ -54,7 +53,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[Native]
 	// NSInteger - AVAssetReader.h
 	public enum AVAssetReaderStatus : nint {
@@ -66,7 +64,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,1)]
 	[Native]
 	// NSInteger - AVAssetWriter.h
 	public enum AVAssetWriterStatus : nint {
@@ -78,7 +75,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoTV, NoWatch]
-	[iOS (4,0)]
 	[Native]
 	// NSInteger - AVCaptureSession.h
 	public enum AVCaptureVideoOrientation : nint {
@@ -90,7 +86,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[iOS (4,0)]
 	[Native]
 	// NSInteger - AVCaptureDevice.h
 	public enum AVCaptureFlashMode : nint {
@@ -99,7 +94,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[iOS (4,0)]
 	[Native]
 	// NSInteger - AVCaptureDevice.h
 	public enum AVCaptureTorchMode : nint {
@@ -108,7 +102,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[iOS (4,0)]
 	[Native]
 	// NSInteger - AVCaptureDevice.h
 	public enum AVCaptureFocusMode : nint {
@@ -129,7 +122,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[iOS (4,0)]
 	[Native]
 	// NSInteger - AVCaptureDevice.h
 	public enum AVCaptureDevicePosition : nint {
@@ -140,7 +132,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[iOS (4,0)]
 	[Native]
 	// NSInteger - AVCaptureDevice.h
 	public enum AVCaptureExposureMode : nint {
@@ -149,7 +140,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[iOS (4,0)]
 	[Native]
 	// NSInteger - AVCaptureDevice.h
 	public enum AVCaptureWhiteBalanceMode : nint {
@@ -159,7 +149,6 @@ namespace XamCore.AVFoundation {
 #if !MONOMAC || !XAMCORE_4_0
 	[Flags]
 	[NoTV]
-	[iOS (4,0)]
 	[Native]
 	[Deprecated (PlatformName.iOS, 6, 0)]
 	// NSUInteger - AVAudioSession.h
@@ -213,7 +202,6 @@ namespace XamCore.AVFoundation {
 		DecoderTemporarilyUnavailable = -11839,
 		EncoderTemporarilyUnavailable = -11840,
 		InvalidVideoComposition = -11841,
-		//[iOS (5,1)]
 		ReferenceForbiddenByReferencePolicy = -11842,
 		InvalidOutputURLPathExtension = -11843,
 		ScreenCaptureFailed = -11844,
@@ -260,7 +248,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[Native]
 	// NSInteger - AVPlayer.h
 	public enum AVPlayerActionAtItemEnd : nint {
@@ -270,7 +257,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[Native]
 	// NSInteger - AVPlayerItem.h
 	public enum AVPlayerItemStatus : nint {
@@ -280,7 +266,6 @@ namespace XamCore.AVFoundation {
 #if !MONOMAC || !XAMCORE_4_0
 	[NoTV]
 	[Flags]
-	[iOS (4,0)]
 	[Native]
 	[Deprecated (PlatformName.iOS, 6, 0)]
 	// declared as AVAudioSessionSetActiveOptions (NSUInteger) - AVAudioSession.h
@@ -290,7 +275,6 @@ namespace XamCore.AVFoundation {
 #endif
 
 	[NoWatch]
-	[iOS (4,0)]
 	[Native]
 	// NSInteger - AVAsynchronousKeyValueLoading.h
 	public enum AVKeyValueStatus : nint {
@@ -298,7 +282,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[Native]
 	// NSInteger - AVPlayer.h
 	public enum AVPlayerStatus : nint {

--- a/src/AddressBook/ABAddressBook.cs
+++ b/src/AddressBook/ABAddressBook.cs
@@ -310,7 +310,6 @@ namespace XamCore.AddressBook {
 		[DllImport (Constants.AddressBookLibrary)]
 		extern static IntPtr ABAddressBookCopyArrayOfAllPeopleInSource (IntPtr addressBook, IntPtr source);
 
-		[iOS (4,0)]
 		public ABPerson [] GetPeople (ABRecord source)
 		{
 			if (source == null)
@@ -323,7 +322,6 @@ namespace XamCore.AddressBook {
 		[DllImport (Constants.AddressBookLibrary)]
 		extern static IntPtr ABAddressBookCopyArrayOfAllPeopleInSourceWithSortOrdering (IntPtr addressBook, IntPtr source, ABPersonSortBy sortOrdering);
 
-		[iOS (4,0)]
 		public ABPerson [] GetPeople (ABRecord source, ABPersonSortBy sortOrdering)
 		{
 			if (source == null)
@@ -354,7 +352,6 @@ namespace XamCore.AddressBook {
 		[DllImport (Constants.AddressBookLibrary)]
 		extern static IntPtr ABAddressBookCopyArrayOfAllGroupsInSource (IntPtr addressBook, IntPtr source);
 
-		[iOS (4,0)]
 		public ABGroup[] GetGroups (ABRecord source)
 		{
 			if (source == null)

--- a/src/AddressBook/ABGroup.cs
+++ b/src/AddressBook/ABGroup.cs
@@ -78,7 +78,6 @@ namespace XamCore.AddressBook {
 		[DllImport (Constants.AddressBookLibrary)]
 		extern static IntPtr ABGroupCreateInSource (IntPtr source);
 
-		[iOS (4,0)]
 		public ABGroup (ABRecord source)
 			: base (IntPtr.Zero, true)
 		{
@@ -107,7 +106,6 @@ namespace XamCore.AddressBook {
 		[DllImport (Constants.AddressBookLibrary)]
 		extern static IntPtr ABGroupCopySource (IntPtr group);
 
-		[iOS (4,0)]
 		public ABRecord Source {
 			get {
 				var h = ABGroupCopySource (Handle);

--- a/src/AddressBook/ABPerson.cs
+++ b/src/AddressBook/ABPerson.cs
@@ -82,7 +82,6 @@ namespace XamCore.AddressBook {
 
 	[Deprecated (PlatformName.iOS, 9, 0, message : "Use the 'Contacts' API instead.")]
 	[Native]
-	[iOS (4,1)]
 	public enum ABPersonImageFormat : nint_compat_int {
 		Thumbnail = 0,
 		OriginalSize = 2
@@ -595,7 +594,6 @@ namespace XamCore.AddressBook {
 		[DllImport (Constants.AddressBookLibrary)]
 		extern static IntPtr ABPersonCreateInSource (IntPtr source);
 
-		[iOS (4,0)]
 		public ABPerson (ABRecord source)
 			: base (IntPtr.Zero, true)
 		{
@@ -793,7 +791,6 @@ namespace XamCore.AddressBook {
 		[DllImport (Constants.AddressBookLibrary)]
 		extern static IntPtr ABPersonCopySource (IntPtr group);
 
-		[iOS (4,0)]
 		public ABRecord Source {
 			get {
 				var h = ABPersonCopySource (Handle);
@@ -1034,7 +1031,6 @@ namespace XamCore.AddressBook {
 		[DllImport (Constants.AddressBookLibrary)]
 		extern static IntPtr ABPersonCopyArrayOfAllLinkedPeople (IntPtr person);
 
-		[iOS (4,0)]
 		public ABPerson[] GetLinkedPeople ()
 		{
 			var linked = ABPersonCopyArrayOfAllLinkedPeople (Handle);
@@ -1044,7 +1040,6 @@ namespace XamCore.AddressBook {
 		[DllImport (Constants.AddressBookLibrary)]
 		extern static IntPtr ABPersonCopyImageDataWithFormat (IntPtr handle, nint format);
 		
-		[iOS (4,1)]
 		public NSData GetImage (ABPersonImageFormat format)
 		{
 #if ARCH_32
@@ -1057,7 +1052,6 @@ namespace XamCore.AddressBook {
 		[DllImport (Constants.AddressBookLibrary)]
 		extern static IntPtr ABPersonCreateVCardRepresentationWithPeople (IntPtr people);
 
-		[iOS (5,0)]
 		public static NSData GetVCards (params ABPerson[] people)
 		{
 			if (people == null)
@@ -1075,7 +1069,6 @@ namespace XamCore.AddressBook {
 		[DllImport (Constants.AddressBookLibrary)]
 		extern static IntPtr ABPersonCreatePeopleInSourceWithVCardRepresentation (IntPtr source, IntPtr vCardData);
 
-		[iOS (5,0)]
 		public static ABPerson[] CreateFromVCard (ABRecord source, NSData vCardData)
 		{
 			if (vCardData == null)

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1819,13 +1819,11 @@ namespace XamCore.AppKit {
 	public enum NSPathStyle : nint {
 #if XAMCORE_2_0
 		Standard,
-		[Mac (10, 5)]
 		[Deprecated (PlatformName.MacOSX, 10, 7)]
 		NavigationBar,
 		PopUp
 #else
 		NSPathStyleStandard,
-		[Mac (10, 5)]
 		[Deprecated (PlatformName.MacOSX, 10, 7)]
 		NSPathStyleNavigationBar,
 		NSPathStylePopUp

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -116,7 +116,6 @@ namespace XamCore.AppKit {
 		DestinationAtop,
 		XOR,
 		PlusDarker,
-		[Mac (10, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use NSCompositeSourceOver instead.")]
 		Highlight,
 		PlusLighter,
@@ -139,10 +138,8 @@ namespace XamCore.AppKit {
 
 	[Native]
 	public enum NSBackingStore : nuint_compat_int {
-		[Mac (10, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'Buffered' instead.")]
 		Retained, 
-		[Mac (10, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'Buffered' instead.")]
 		Nonretained, 
 		Buffered,
@@ -230,7 +227,6 @@ namespace XamCore.AppKit {
 
 #if !XAMCORE_4_0
 	[Native]
-	[Mac (10, 0)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use formatters instead.")]
 	public enum NSType : nuint_compat_int {
 	    Any			= 0,
@@ -1624,7 +1620,6 @@ namespace XamCore.AppKit {
 		Default, Regular, Small
 	}
 
-	[Mac (10, 0)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use NSAlertButtonReturn instead.")]
 #if !XAMCORE_4_0
 	[Native]
@@ -1639,7 +1634,6 @@ namespace XamCore.AppKit {
 	}
 
 #if !XAMCORE_4_0
-	[Mac (10, 0)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use NSModalResponse instead.")]
 	[Native]
 	public enum NSPanelButtonType : nint {
@@ -2007,10 +2001,8 @@ namespace XamCore.AppKit {
 		AccumSize          =  14,
 		MinimumPolicy      =  51,
 		MaximumPolicy      =  52,
-		[Mac (10, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 7)]
 		OffScreen          =  53,
-		[Mac (10, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 6)]
 		FullScreen         =  54,
 		SampleBuffers      =  55,
@@ -2021,24 +2013,19 @@ namespace XamCore.AppKit {
 		Supersample        =  60,
 		SampleAlpha        =  61,
 		RendererID         =  70,
-		[Mac (10, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		SingleRenderer     =  71,
 		NoRecovery         =  72,
 		Accelerated        =  73,
 		ClosestPolicy      =  74,
 		BackingStore       =  76,
-		[Mac (10, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		Window             =  80,
-		[Mac (10, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		Compliant          =  83,
 		ScreenMask         =  84,
-		[Mac (10, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 7)]
 		PixelBuffer        =  90,
-		[Mac (10, 3)]
 		[Deprecated (PlatformName.MacOSX, 10, 7)]
 		RemotePixelBuffer  =  91,
 		AllowOfflineRenderers = 96,

--- a/src/AppKit/NSLayoutManager.cs
+++ b/src/AppKit/NSLayoutManager.cs
@@ -18,7 +18,6 @@ namespace XamCore.AppKit {
 		}
 #endif
 
-		[Mac (10, 0)]
 		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		public CGRect [] GetRectArray (NSRange glyphRange, NSRange selectedGlyphRange, NSTextContainer textContainer)
 		{

--- a/src/AssetsLibrary/ALAssetsGroup.cs
+++ b/src/AssetsLibrary/ALAssetsGroup.cs
@@ -40,7 +40,6 @@ namespace XamCore.AssetsLibrary {
 			}
 		}
 
-		[iOS (5,0)]
 		public NSUrl PropertyUrl {
 			get {
 				return (NSUrl) ValueForProperty (_PropertyUrl);

--- a/src/AudioToolbox/AudioConverter.cs
+++ b/src/AudioToolbox/AudioConverter.cs
@@ -479,7 +479,6 @@ namespace XamCore.AudioToolbox
 			return AudioConverterConvertBuffer (handle, input.Length, input, ref outSize, output);
 		}
 
-		[iOS (5,0)]
 		public AudioConverterError ConvertComplexBuffer (int numberPCMFrames, AudioBuffers inputData, AudioBuffers outputData)
 		{
 			if (inputData == null)

--- a/src/AudioToolbox/AudioSession.cs
+++ b/src/AudioToolbox/AudioSession.cs
@@ -302,7 +302,6 @@ namespace XamCore.AudioToolbox {
 		[DllImport (Constants.AudioToolboxLibrary)]
 		extern static AudioSessionErrors AudioSessionSetActiveWithFlags ([MarshalAs (UnmanagedType.I1)] bool active, AudioSessionActiveFlags inFlags);
 
-		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 7, 0)]
 		public static AudioSessionErrors SetActive (bool active, AudioSessionActiveFlags flags)
 		{
@@ -427,7 +426,6 @@ namespace XamCore.AudioToolbox {
 			}
 		}
 
-		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "AudioSession[Get|Set]Property are deprecated in iOS7")]
 		public static AudioSessionInterruptionType InterruptionType {
 			get {
@@ -442,14 +440,12 @@ namespace XamCore.AudioToolbox {
 			}
 		}
 
-		[iOS (5,0)]
 		static public AccessoryInfo[] InputSources {
 			get {
 				return ExtractAccessoryInfo (GetIntPtr (AudioSessionProperty.InputSources), InputSourceKey_ID, InputSourceKey_Description);
 			}
 		}
 
-		[iOS (5,0)]
 		static public AccessoryInfo[] OutputDestinations {
 			get {
 				return ExtractAccessoryInfo (GetIntPtr (AudioSessionProperty.OutputDestinations), OutputDestinationKey_ID, OutputDestinationKey_Description);
@@ -474,7 +470,6 @@ namespace XamCore.AudioToolbox {
 
 		/* Could not test what sort of unique CFNumberRef value it's
 
-		[iOS (5,0)]
 		static public int InputSource {
 			get {
 				return GetInt (AudioSessionProperty.InputSource);
@@ -484,7 +479,6 @@ namespace XamCore.AudioToolbox {
 			}
 		}
 
-		[iOS (5,0)]
 		static public int OutputDestination {
 			get {
 				return GetInt (AudioSessionProperty.OutputDestination);
@@ -569,14 +563,12 @@ namespace XamCore.AudioToolbox {
 			return result;
 		}
 
-		[iOS (5,0)]
 		static public AudioSessionInputRouteKind InputRoute {
 			get {
 				return GetInputRoute ((NSArray) AudioRouteDescription [AudioRouteKey_Inputs]);
 			}
 		}
 		
-		[iOS (5,0)]
 		static public AudioSessionOutputRouteKind [] OutputRoutes {
 			get {
 				return GetOutputRoutes ((NSArray) AudioRouteDescription [AudioRouteKey_Outputs]);
@@ -701,7 +693,6 @@ namespace XamCore.AudioToolbox {
 			}
 		}
 		
-		[iOS (5,0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "AudioSession[Get|Set]Property are deprecated in iOS7")]
 		static public AudioSessionMode Mode {
 			get {
@@ -712,7 +703,6 @@ namespace XamCore.AudioToolbox {
 			}
 		}
 
-		[iOS (5,0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "AudioSession[Get|Set]Property are deprecated in iOS7")]
 		static public bool InputGainAvailable {
 			get {
@@ -720,7 +710,6 @@ namespace XamCore.AudioToolbox {
 			}
 		}
 
-		[iOS (5,0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "AudioSession[Get|Set]Property are deprecated in iOS7")]
 		static public float InputGainScalar {
 			get {
@@ -859,7 +848,6 @@ namespace XamCore.AudioToolbox {
 			}
 		}
 
-		[iOS (5,0)]
 		public static event Action<bool> InputGainBecameAvailable {
 			add {
 				AddListenerEvent (AudioSessionProperty.InputGainAvailable, value, 
@@ -870,7 +858,6 @@ namespace XamCore.AudioToolbox {
 			}
 		}
 
-		[iOS (5,0)]
 		public static event Action<float> InputGainScalarChanged {
 			add {
 				AddListenerEvent (AudioSessionProperty.InputGainScalar, value, 
@@ -881,7 +868,6 @@ namespace XamCore.AudioToolbox {
 			}
 		}
 
-		[iOS (5,0)]
 		public static event Action<AccessoryInfo[]> InputSourcesChanged {
 			add {
 				AddListenerEvent (AudioSessionProperty.InputSources, value, 
@@ -892,7 +878,6 @@ namespace XamCore.AudioToolbox {
 			}
 		}
 
-		[iOS (5,0)]
 		public static event Action<AccessoryInfo[]> OutputDestinationsChanged {
 			add {
 				AddListenerEvent (AudioSessionProperty.OutputDestinations, value, 

--- a/src/AudioUnit/AudioComponentDescription.cs
+++ b/src/AudioUnit/AudioComponentDescription.cs
@@ -118,7 +118,6 @@ namespace XamCore.AudioUnit
 		Delay=0x64656c79, // 'dely'
 
 		[iOS (8, 0)]
-		[Mac (10, 5)]
 		SampleDelay=0x73646c79, // 'sdly'
 		Distortion=0x64697374, // 'dist'
 		BandPassFilter=0x62706173, // 'bpas'

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -1382,13 +1382,10 @@ namespace XamCore.AudioUnit
 		ReverbRoomType = 10,
 		UsesInternalReverb = 1005,
 		SpatializationAlgorithm = 3000,
-		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 9, 0)]
 		DistanceParams = 3010,
-		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 9, 0)]
 		AttenuationCurve = 3013,
-		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 9, 0)]
 		RenderingFlags = 3003,
 
@@ -1660,7 +1657,6 @@ namespace XamCore.AudioUnit
 	[iOS (8, 0)]
 	public enum SpatialMixerRenderingFlags {
 		InterAuralDelay = (1 << 0),
-		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 9, 0)]
 		DistanceAttenuation = (1 << 2),
 	}

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -727,7 +727,6 @@ namespace XamCore.AudioUnit
 			return AudioUnitSetProperty (handle, AudioUnitPropertyIDType.SampleRate, scope, 0, ref sampleRate, sizeof (double));
 		}
 
-		[iOS (5,0)]
 		public AudioUnitStatus MusicDeviceMIDIEvent (uint status, uint data1, uint data2, uint offsetSampleFrame = 0)
 		{
 			return MusicDeviceMIDIEvent (handle, status, data1, data2, offsetSampleFrame);

--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -1272,14 +1272,11 @@ namespace XamCore.AudioUnit
 		Nickname = 54,
 		OfflineRender = 37,
 		[iOS (8, 0)]
-		[Mac (10, 3)]
 		ParameterIDName = 34,
 		[iOS (8, 0)]
-		[Mac (10, 3)]
 		ParameterStringFromValue = 33,
 		ParameterClumpName = 35,
 		[iOS (8, 0)]
-		[Mac (10, 3)]
 		ParameterValueFromString = 38,
 		ContextName = 25,
 		PresentationLatency = 40,

--- a/src/CoreBluetooth/Enums.cs
+++ b/src/CoreBluetooth/Enums.cs
@@ -27,7 +27,6 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	// NSInteger -> CBCentralManager.h
-	[iOS (5, 0)]
 	[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'CBManagerState' instead.")]
 	[NoWatch]
 	[Native]

--- a/src/CoreBluetooth/GuidWrapper.cs
+++ b/src/CoreBluetooth/GuidWrapper.cs
@@ -59,7 +59,6 @@ namespace XamCore.CoreBluetooth {
 		}
 
 #if !TVOS && !WATCH
-		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0)]
 		[Obsoleted (PlatformName.iOS, 9, 0, message : "Use 'RetrievePeripheralsWithIdentifiers' instead.")]
 		public void RetrievePeripherals (CBUUID [] peripheralUuids)

--- a/src/CoreBluetooth/PeripheralConnectionOptions.cs
+++ b/src/CoreBluetooth/PeripheralConnectionOptions.cs
@@ -100,7 +100,6 @@ namespace XamCore.CoreBluetooth {
 #endif
 
 #if !XAMCORE_2_0
-		[iOS (5,0)]
 		[Obsolete ("Use 'NotifyOnDisconnection' property instead.")]
 		public bool NotifyOnDisconnectionKey {
 			set {
@@ -109,7 +108,6 @@ namespace XamCore.CoreBluetooth {
 		}
 #endif
 
-		[iOS (5,0)]
 		public bool? NotifyOnDisconnection {
 			get {
 				return GetBoolValue (CBCentralManager.OptionNotifyOnDisconnectionKey);

--- a/src/CoreData/Enums.cs
+++ b/src/CoreData/Enums.cs
@@ -65,10 +65,8 @@ namespace XamCore.CoreData {
 	public enum NSFetchRequestResultType : nuint {
 		ManagedObject = 0x00,
 		ManagedObjectID = 0x01,
-		[iOS (3, 0)]
 		[Mac (10, 6)]
 		DictionaryResultType = 0x02,
-		[iOS (3, 0)]
 		[Mac (10, 6)]
 		NSCountResultType = 0x04
 	}

--- a/src/CoreData/Enums.cs
+++ b/src/CoreData/Enums.cs
@@ -65,9 +65,7 @@ namespace XamCore.CoreData {
 	public enum NSFetchRequestResultType : nuint {
 		ManagedObject = 0x00,
 		ManagedObjectID = 0x01,
-		[Mac (10, 6)]
 		DictionaryResultType = 0x02,
-		[Mac (10, 6)]
 		NSCountResultType = 0x04
 	}
 

--- a/src/CoreFoundation/CFProxySupport.cs
+++ b/src/CoreFoundation/CFProxySupport.cs
@@ -254,7 +254,7 @@ namespace XamCore.CoreFoundation {
 		}
 #endif
 		
-		[iOS (4,0)][Mac (10,7)]
+		[Mac (10,7)]
 		public NSString AutoConfigurationJavaScript {
 			get {
 				if (AutoConfigurationJavaScriptKey == null)

--- a/src/CoreGraphics/CGContext.cs
+++ b/src/CoreGraphics/CGContext.cs
@@ -1294,7 +1294,6 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static /* CGPathRef */ IntPtr CGContextCopyPath (/* CGContextRef */ IntPtr context);
 
-		[iOS (4,0)]
 		public CGPath CopyPath ()
 		{
 			var r = CGContextCopyPath (handle);
@@ -1304,7 +1303,6 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetAllowsFontSmoothing (/* CGContextRef */ IntPtr context, bool shouldSubpixelPositionFonts);
 
-		[iOS (4,0)]
 		public void SetAllowsFontSmoothing (bool allows)
 		{
 			CGContextSetAllowsFontSmoothing (handle, allows);
@@ -1313,7 +1311,6 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetAllowsFontSubpixelPositioning (/* CGContextRef */ IntPtr context, bool allowsFontSubpixelPositioning);
 
-		[iOS (4,0)]
 		public void SetAllowsSubpixelPositioning (bool allows)
 		{
 			CGContextSetAllowsFontSubpixelPositioning (handle, allows);
@@ -1322,7 +1319,6 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetAllowsFontSubpixelQuantization (/* CGContextRef */ IntPtr context, bool shouldSubpixelQuantizeFonts);
 
-		[iOS (4,0)]
 		public void SetAllowsFontSubpixelQuantization (bool allows)
 		{
 			CGContextSetAllowsFontSubpixelQuantization (handle, allows);
@@ -1331,7 +1327,6 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetShouldSubpixelPositionFonts (/* CGContextRef */ IntPtr context, bool shouldSubpixelPositionFonts);
 
-		[iOS (4,0)]
 		public void SetShouldSubpixelPositionFonts (bool shouldSubpixelPositionFonts)
 		{
 			CGContextSetShouldSubpixelPositionFonts (handle, shouldSubpixelPositionFonts);
@@ -1340,7 +1335,6 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		extern static void CGContextSetShouldSubpixelQuantizeFonts (/* CGContextRef */ IntPtr context, bool shouldSubpixelQuantizeFonts);
 
-		[iOS (4,0)]
 		public void ShouldSubpixelQuantizeFonts (bool shouldSubpixelQuantizeFonts)
 		{
 			CGContextSetShouldSubpixelQuantizeFonts (handle, shouldSubpixelQuantizeFonts);

--- a/src/CoreGraphics/CGImageProperties.cs
+++ b/src/CoreGraphics/CGImageProperties.cs
@@ -545,7 +545,6 @@ namespace XamCore.CoreGraphics {
 		{
 		}
 
-		[iOS (5,0)]
 		public string Author {
 			get {
 				return GetStringValue (Keys.PNGAuthor);
@@ -555,7 +554,6 @@ namespace XamCore.CoreGraphics {
 			}
 		}
 
-		[iOS (5,0)]
 		public string Description {
 			get {
 				return GetStringValue (Keys.PNGDescription);
@@ -574,7 +572,6 @@ namespace XamCore.CoreGraphics {
 			}
 		}
 
-		[iOS (5,0)]
 		public string Software {
 			get {
 				return GetStringValue (Keys.PNGSoftware);
@@ -602,7 +599,6 @@ namespace XamCore.CoreGraphics {
 			}
 		}
 
-		[iOS (5,0)]
 		public string Title {
 			get {
 				return GetStringValue (Keys.PNGTitle);

--- a/src/CoreGraphics/CGPath.cs
+++ b/src/CoreGraphics/CGPath.cs
@@ -73,7 +73,7 @@ namespace XamCore.CoreGraphics {
 			handle = CGPathCreateMutable ();
 		}
 
-		[Mac(10,7)][iOS (5,0)]
+		[Mac(10,7)]
 		public CGPath (CGPath reference, CGAffineTransform transform)
 		{
 			if (reference == null)
@@ -571,25 +571,25 @@ namespace XamCore.CoreGraphics {
 			/* CGFloat */ nfloat [] lengths,
 			/* size_t */ nint count);
 
-		[Mac(10,7)][iOS (5,0)]
+		[Mac(10,7)]
 		public CGPath CopyByDashingPath (CGAffineTransform transform, nfloat [] lengths)
 		{
 			return CopyByDashingPath (transform, lengths, 0);
 		}
 
-		[Mac(10,7)][iOS (5,0)]
+		[Mac(10,7)]
 		public unsafe CGPath CopyByDashingPath (CGAffineTransform transform, nfloat [] lengths, nfloat phase)
 		{
 			return MakeMutable (CGPathCreateCopyByDashingPath (handle, &transform, phase, lengths, lengths == null ? 0 : lengths.Length));
 		}
 
-		[Mac(10,7)][iOS (5,0)]
+		[Mac(10,7)]
 		public CGPath CopyByDashingPath (nfloat [] lengths)
 		{
 			return CopyByDashingPath (lengths, 0);
 		}
 
-		[Mac(10,7)][iOS (5,0)]
+		[Mac(10,7)]
 		public unsafe CGPath CopyByDashingPath (nfloat [] lengths, nfloat phase)
 		{
 			var path = CGPathCreateCopyByDashingPath (handle, null, phase, lengths, lengths == null ? 0 : lengths.Length);
@@ -604,13 +604,13 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		unsafe extern static IntPtr CGPathCreateCopyByStrokingPath (/* CGPathRef */ IntPtr path, CGAffineTransform *transform, nfloat lineWidth, CGLineCap lineCap, CGLineJoin lineJoin, /* CGFloat */ nfloat miterLimit);
 
-		[Mac(10,7)][iOS (5,0)]
+		[Mac(10,7)]
 		public unsafe CGPath CopyByStrokingPath (CGAffineTransform transform, nfloat lineWidth, CGLineCap lineCap, CGLineJoin lineJoin, nfloat miterLimit)
 		{
 			return MakeMutable (CGPathCreateCopyByStrokingPath (handle, &transform, lineWidth, lineCap, lineJoin, miterLimit));
 		}
 
-		[Mac(10,7)][iOS (5,0)]
+		[Mac(10,7)]
 		public unsafe CGPath CopyByStrokingPath (nfloat lineWidth, CGLineCap lineCap, CGLineJoin lineJoin, nfloat miterLimit)
 		{
 			return MakeMutable (CGPathCreateCopyByStrokingPath (handle, null, lineWidth, lineCap, lineJoin, miterLimit));
@@ -630,13 +630,13 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		unsafe extern static IntPtr CGPathCreateWithEllipseInRect (CGRect boundingRect, CGAffineTransform *transform);
 
-		[Mac(10,7)][iOS (5,0)]
+		[Mac(10,7)]
 		static public unsafe CGPath EllipseFromRect (CGRect boundingRect, CGAffineTransform transform)
 		{
 			return MakeMutable (CGPathCreateWithEllipseInRect (boundingRect, &transform));
 		}
 
-		[Mac(10,7)][iOS (5,0)]
+		[Mac(10,7)]
 		static public unsafe CGPath EllipseFromRect (CGRect boundingRect)
 		{
 			return MakeMutable (CGPathCreateWithEllipseInRect (boundingRect, null));
@@ -645,13 +645,13 @@ namespace XamCore.CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		unsafe extern static IntPtr CGPathCreateWithRect (CGRect boundingRect, CGAffineTransform *transform);
 
-		[Mac(10,7)][iOS (5,0)]
+		[Mac(10,7)]
 		static public unsafe CGPath FromRect (CGRect rectangle, CGAffineTransform transform)
 		{
 			return MakeMutable (CGPathCreateWithRect (rectangle, &transform));
 		}
 
-		[Mac(10,7)][iOS (5,0)]
+		[Mac(10,7)]
 		static public unsafe CGPath FromRect (CGRect rectangle)
 		{
 			return MakeMutable (CGPathCreateWithRect (rectangle, null));

--- a/src/CoreLocation/CLEnums.cs
+++ b/src/CoreLocation/CLEnums.cs
@@ -41,12 +41,8 @@ namespace XamCore.CoreLocation {
 		Denied,              
 		Network,             
 		HeadingFailure,
-
-		[iOS (4,0)]
 		RegionMonitoringDenied,
-		[iOS (4,0)]
 		RegionMonitoringFailure,
-		[iOS (4,0)]
 		RegionMonitoringSetupDelayed,
 		
 		// ios5 osx10.8

--- a/src/CoreMedia/CMBlockBuffer.cs
+++ b/src/CoreMedia/CMBlockBuffer.cs
@@ -40,7 +40,7 @@ namespace XamCore.CoreMedia {
 		PermitEmptyReference	= (1<<3)
 	}
 
-	[iOS (4,0), Mac (10,7)]
+	[Mac (10,7)]
 	public class CMBlockBuffer : ICMAttachmentBearer, IDisposable {
 		internal IntPtr handle;
 		internal CMCustomBlockAllocator customAllocator;

--- a/src/CoreMedia/CMFormatDescription.cs
+++ b/src/CoreMedia/CMFormatDescription.cs
@@ -36,7 +36,6 @@ namespace XamCore.CoreMedia {
 		ValueNotAvailable   = -12718,
 	}
 
-	[iOS (4,0)]
 	public class CMFormatDescription : INativeObject, IDisposable {
 		internal IntPtr handle;
 
@@ -361,7 +360,6 @@ namespace XamCore.CoreMedia {
 #endif
 	}
 
-	[iOS (4,0)]
 	public class CMAudioFormatDescription : CMFormatDescription {
 		
 		internal CMAudioFormatDescription (IntPtr handle)
@@ -377,7 +375,6 @@ namespace XamCore.CoreMedia {
 		// TODO: Move more audio specific methods here
 	}
 
-	[iOS (4,0)]
 	public partial class CMVideoFormatDescription : CMFormatDescription {
 		
 		internal CMVideoFormatDescription (IntPtr handle)

--- a/src/CoreMedia/CMSampleBuffer.cs
+++ b/src/CoreMedia/CMSampleBuffer.cs
@@ -50,7 +50,6 @@ namespace XamCore.CoreMedia {
 		Invalidated						= -12744,
 	}
 
-	[iOS (4,0)]
 	public class CMSampleBuffer : ICMAttachmentBearer 
 #if !COREBUILD
 	, IDisposable

--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -2068,7 +2068,6 @@ namespace XamCore.CoreText {
 			[In] CGGlyph [] glyphs, [In] CGPoint [] positions, nint count,
 			/* CGContextRef __nonnull */ IntPtr context);
 
-		[iOS(4,2)]
 		public void DrawGlyphs (CGContext context, CGGlyph [] glyphs, CGPoint [] positions)
 		{
 			if (context == null)
@@ -2086,7 +2085,6 @@ namespace XamCore.CoreText {
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern nint CTFontGetLigatureCaretPositions (IntPtr handle, CGGlyph glyph, [Out] nfloat [] positions, nint max);
 
-		[iOS(4,2)]
 		public nint GetLigatureCaretPositions (CGGlyph glyph, nfloat [] positions)
 		{
 			if (positions == null)

--- a/src/CoreText/CTFontManager.cs
+++ b/src/CoreText/CTFontManager.cs
@@ -168,12 +168,10 @@ namespace XamCore.CoreText {
 			}
 		}
 
-		[Mac (10,6)]
 		[iOS (7,0)]
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern /* CFArrayRef */ IntPtr CTFontManagerCreateFontDescriptorsFromURL (/* CFURLRef */ IntPtr fileURL);
 
-		[Mac (10,6)]
 		[iOS (7,0)]
 		public static CTFontDescriptor[] GetFonts (NSUrl url)
 		{

--- a/src/CoreText/CTFontManager.cs
+++ b/src/CoreText/CTFontManager.cs
@@ -51,7 +51,6 @@ namespace XamCore.CoreText {
 		PromptUser = 3,
 	}
 
-	[iOS (4,1)]
 	public partial class CTFontManager {
 
 #if MONOMAC

--- a/src/CoreText/CTFrame.cs
+++ b/src/CoreText/CTFrame.cs
@@ -41,7 +41,6 @@ namespace XamCore.CoreText {
 		RightToLeft = 1
 	}
 
-	[iOS (4,2)]
 	public enum CTFramePathFillRule {
 		EvenOdd,
 		WindingNumber
@@ -51,13 +50,9 @@ namespace XamCore.CoreText {
 
 		public static readonly NSString Progression;
 
-		[iOS (4,2)]
 		public static readonly NSString PathFillRule;
-		[iOS (4,2)]
 		public static readonly NSString PathWidth;
-		[iOS (4,3)]
 		public static readonly NSString ClippingPaths;
-		[iOS (4,3)]
 		public static readonly NSString PathClippingPath;
 		
 		static CTFrameAttributeKey ()

--- a/src/CoreText/CTParagraphStyle.cs
+++ b/src/CoreText/CTParagraphStyle.cs
@@ -81,7 +81,6 @@ namespace XamCore.CoreText {
 		LineHeightMultiple      = 7,
 		MaximumLineHeight       = 8,
 		MinimumLineHeight       = 9,
-		[iOS (3, 2)]
 		[Deprecated (PlatformName.iOS, 6, 0, message : "Please use MaximumLineSpacing")]
 		[Mac (10, 5)]
 		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Please use MaximumLineSpacing")]

--- a/src/CoreText/CTParagraphStyle.cs
+++ b/src/CoreText/CTParagraphStyle.cs
@@ -82,7 +82,6 @@ namespace XamCore.CoreText {
 		MaximumLineHeight       = 8,
 		MinimumLineHeight       = 9,
 		[Deprecated (PlatformName.iOS, 6, 0, message : "Please use MaximumLineSpacing")]
-		[Mac (10, 5)]
 		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Please use MaximumLineSpacing")]
 		LineSpacing             = 10,
 		ParagraphSpacing        = 11,

--- a/src/CoreVideo/CVBuffer.cs
+++ b/src/CoreVideo/CVBuffer.cs
@@ -35,7 +35,6 @@ namespace XamCore.CoreVideo {
 
 	// CVBuffer.h
 	[Watch (4,0)]
-	[iOS (4,0)]
 	public partial class CVBuffer : INativeObject
 #if !COREBUILD
 		, IDisposable

--- a/src/CoreVideo/CVImageBuffer.cs
+++ b/src/CoreVideo/CVImageBuffer.cs
@@ -35,7 +35,6 @@ using XamCore.CoreGraphics;
 namespace XamCore.CoreVideo {
 
 	// CVImageBuffer.h
-	[iOS (4,0)]
 	[Watch (4,0)]
 	public partial class CVImageBuffer : CVBuffer {
 #if !COREBUILD

--- a/src/CoreVideo/CVPixelBuffer.cs
+++ b/src/CoreVideo/CVPixelBuffer.cs
@@ -15,7 +15,6 @@ using XamCore.Foundation;
 namespace XamCore.CoreVideo {
 
 	[Watch (4,0)]
-	[iOS (4,0)]
 	public partial class CVPixelBuffer : CVImageBuffer {
 #if !COREBUILD
 		[DllImport (Constants.CoreVideoLibrary, EntryPoint = "CVPixelBufferGetTypeID")]

--- a/src/CoreVideo/CVPixelBufferPool.cs
+++ b/src/CoreVideo/CVPixelBufferPool.cs
@@ -17,7 +17,6 @@ namespace XamCore.CoreVideo {
 
 	// CVPixelBufferPool.h
 	[Watch (4,0)]
-	[iOS (4,0)]
 	public partial class CVPixelBufferPool : INativeObject
 #if !COREBUILD
 		, IDisposable

--- a/src/CoreVideo/CVPixelFormatDescription.cs
+++ b/src/CoreVideo/CVPixelFormatDescription.cs
@@ -34,7 +34,6 @@ using XamCore.Foundation;
 namespace XamCore.CoreVideo {
 
 	[Watch (4,0)]
-	[iOS (4,0)]
 	public static class CVPixelFormatDescription {
 #if !COREBUILD
 		public static readonly NSString NameKey;

--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -188,7 +188,6 @@ namespace XamCore.Foundation  {
 		Week = 256,
 		Weekday = 512,
 		WeekdayOrdinal = 1024,
-		[Mac (10, 6)]
 		Quarter = 2048,
 
 		[Mac (10, 7)]

--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -190,28 +190,21 @@ namespace XamCore.Foundation  {
 		Weekday = 512,
 		WeekdayOrdinal = 1024,
 		[Mac (10, 6)]
-		[iOS (4, 0)]
 		Quarter = 2048,
 
 		[Mac (10, 7)]
-		[iOS (5, 0)]
 		WeekOfMonth = (1 << 12),
 		[Mac (10, 7)]
-		[iOS (5, 0)]
 		WeekOfYear = (1 << 13),
 		[Mac (10, 7)]
-		[iOS (5, 0)]
 		YearForWeakOfYear = (1 << 14),
 
 		[Mac (10, 7)]
-		[iOS (5, 0)]
 		Nanosecond = (1 << 15),
 
 		[Mac (10, 7)]
-		[iOS (5, 0)]
 		Calendar = (1 << 20),
 		[Mac (10, 7)]
-		[iOS (5, 0)]
 		TimeZone = (1 << 21),
 	}
 
@@ -239,21 +232,15 @@ namespace XamCore.Foundation  {
 		Coordinated = 1 << 2,
 #endif
 			
-		[iOS (4,0)]
 		FileProtectionNone = 0x10000000,
-		[iOS (4,0)]
 		FileProtectionComplete = 0x20000000,
-		[iOS (4,0)]
 		FileProtectionMask = 0xf0000000,
-		[iOS (5,0)]
 		FileProtectionCompleteUnlessOpen = 0x30000000,
-		[iOS (5,0)]
 		FileProtectionCompleteUntilFirstUserAuthentication = 0x40000000,
 	}
 	
 	public delegate void NSSetEnumerator (NSObject obj, ref bool stop);
 
-	[iOS (4,0)]
 	[Native]
 	public enum NSOperationQueuePriority : nint {
 		VeryLow = -8, Low = -4, Normal = 0, High = 4, VeryHigh = 8
@@ -556,7 +543,6 @@ namespace XamCore.Foundation  {
 		Or
 	}	
 
-	[iOS (4,0)]
 	[Flags]
 	[Native]
 	public enum NSVolumeEnumerationOptions : nuint_compat_int {
@@ -566,7 +552,6 @@ namespace XamCore.Foundation  {
 		ProduceFileReferenceUrls = 1 << 2,
 	}
 
-	[iOS (4,0)]
 	[Flags]
 	[Native]
 	public enum NSDirectoryEnumerationOptions : nuint_compat_int {
@@ -576,7 +561,6 @@ namespace XamCore.Foundation  {
 		SkipsHiddenFiles             = 1 << 2,
 	}
 
-	[iOS (4,0)]
 	[Flags]
 	[Native]
 	public enum NSFileManagerItemReplacementOptions : nuint_compat_int {
@@ -1168,13 +1152,10 @@ namespace XamCore.Foundation  {
 		Dash          = 1 << 7,
 		Replacement   = 1 << 8,
 		Correction    = 1 << 9,
-		[iOS (4, 0)]
 		[Mac (10, 7)]
 		RegularExpression  = 1 << 10,
-		[iOS (4, 0)]
 		[Mac (10, 7)]
 		PhoneNumber        = 1 << 11,
-		[iOS (4, 0)]
 		[Mac (10, 7)]
 		TransitInformation = 1 << 12,
 	}

--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -213,10 +213,7 @@ namespace XamCore.Foundation  {
 	public enum NSDataReadingOptions : nuint {
 		Mapped =   1 << 0,
 		Uncached = 1 << 1,
-
-		[iOS (5,0)]
 		Coordinated = 1 << 2,
-		[iOS (5,0)]
 		MappedAlways = 1 << 3
 	}
 

--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -183,7 +183,6 @@ namespace XamCore.Foundation  {
 		Hour = 32,
 		Minute = 64,
 		Second = 128,
-		[Mac (10, 4)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[Deprecated (PlatformName.iOS, 8, 0)]
 		Week = 256,

--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -185,7 +185,6 @@ namespace XamCore.Foundation  {
 		Second = 128,
 		[Mac (10, 4)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
-		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0)]
 		Week = 256,
 		Weekday = 512,

--- a/src/Foundation/NSUserDefaults.cs
+++ b/src/Foundation/NSUserDefaults.cs
@@ -9,7 +9,6 @@ namespace XamCore.Foundation {
 	}
 
 	public partial class NSUserDefaults {
-		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0)]
 		[Mac (10, 9)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]

--- a/src/GameKit/GameKit.cs
+++ b/src/GameKit/GameKit.cs
@@ -24,7 +24,6 @@ namespace XamCore.GameKit {
 #endif
 	[NoWatch]
 	[Native]
-	[iOS (3, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0)]
 	public enum GKPeerPickerConnectionType : nuint_compat_int {
 		Online = 1 << 0,
@@ -32,7 +31,6 @@ namespace XamCore.GameKit {
 	}
 
 	// untyped enum -> GKPublicConstants.h
-	[iOS (3, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0)]
 	[ErrorDomain ("GKVoiceChatServiceErrorDomain")]
 	public enum GKVoiceChatServiceError {
@@ -57,7 +55,6 @@ namespace XamCore.GameKit {
 #endif
 
 	// untyped enum -> GKPublicConstants.h
-	[iOS (3, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0)]
 	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10)]
@@ -67,7 +64,6 @@ namespace XamCore.GameKit {
 	} 
 
 	// untyped enum -> GKPublicConstants.h
-	[iOS (3, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0)]
 	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10)]
@@ -78,7 +74,6 @@ namespace XamCore.GameKit {
 	}
 
 	// untyped enum -> GKPublicConstants.h
-	[iOS (3, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0)]
 	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10)]
@@ -91,21 +86,18 @@ namespace XamCore.GameKit {
 	}
 
 	// NSInteger -> GKLeaderboard.h
-	[iOS (4,0)]
 	[Native]
 	public enum GKLeaderboardTimeScope : nint {
 		Today, Week, AllTime
 	}
 
 	// NSInteger -> GKLeaderboard.h
-	[iOS (4,0)]
 	[Native]
 	public enum GKLeaderboardPlayerScope : nint {
 		Global, FriendsOnly
 	}
 
 	// NSInteger -> GKError.h
-	[iOS (4,0)]
 	[Native]
 	[ErrorDomain ("GKErrorDomain")]
 	public enum GKError : nint {
@@ -183,7 +175,6 @@ namespace XamCore.GameKit {
 	}
 
 	// NSInteger -> GKMatch.h
-	[iOS (4, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0)]
 	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10)]
@@ -193,14 +184,12 @@ namespace XamCore.GameKit {
 	}
 
 	// NSInteger -> GKMatch.h
-	[iOS (4,0)]
 	[Native]
 	public enum GKPlayerConnectionState : nint {
 		Unknown, Connected, Disconnected
 	}
 
 	// NSInteger -> GKVoiceChat.h
-	[iOS (4,0)]
 	[Native]
 	public enum GKVoiceChatPlayerState : nint {
 		Connected,
@@ -211,28 +200,24 @@ namespace XamCore.GameKit {
 	}
 
 	// NSInteger -> GKPlayer.h
-	[iOS (5,0)]
 	[Native]
 	public enum GKPhotoSize : nint {
 		Small, Normal
 	}
 
 	// NSInteger -> GKTurnBasedMatch.h
-	[iOS (5,0)]
 	[Native]
 	public enum GKTurnBasedMatchStatus : nint {
 		Unknown, Open, Ended, Matching
 	}
 
 	// NSInteger -> GKTurnBasedMatch.h
-	[iOS (5,0)]
 	[Native]
 	public enum GKTurnBasedParticipantStatus : nint {
 		Unknown, Invited, Declined, Matching, Active, Done
 	}
 
 	// NSInteger -> GKTurnBasedMatch.h
-	[iOS (5,0)]
 	[Native]
 	public enum GKTurnBasedMatchOutcome : nint {
 		None, Quit, Won, Lost, Tied, TimeExpired,

--- a/src/GameKit/GameKit2.cs
+++ b/src/GameKit/GameKit2.cs
@@ -357,7 +357,6 @@ namespace XamCore.GameKit {
 
 #if !XAMCORE_2_0
 	public partial class GKScore {
-		[iOS (4, 1)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'LeaderboardIdentifier' instead.")]
 		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'LeaderboardIdentifier' instead.")]

--- a/src/MapKit/MapKit.cs
+++ b/src/MapKit/MapKit.cs
@@ -78,7 +78,6 @@ namespace XamCore.MapKit {
 
 	// MKGeometry.h
 	[StructLayout (LayoutKind.Sequential)]
-	[iOS (4,0)]
 	[Mac (10,9, onlyOn64 : true)]
 	public struct MKMapPoint {
 		public double X, Y;
@@ -131,7 +130,6 @@ namespace XamCore.MapKit {
 
 	// MKGeometry.h
 	[StructLayout (LayoutKind.Sequential)]
-	[iOS (4,0)]
 	public struct MKMapSize {
 		public double Width, Height;
 		
@@ -180,7 +178,6 @@ namespace XamCore.MapKit {
 
 	// MKGeometry.h
 	[StructLayout (LayoutKind.Sequential)]
-	[iOS (4,0)]
 	[Mac (10,9, onlyOn64 : true)]
 	public struct MKMapRect {
 		[TV (9,2)]

--- a/src/MediaPlayer/MediaPlayer.cs
+++ b/src/MediaPlayer/MediaPlayer.cs
@@ -118,25 +118,19 @@ namespace XamCore.MediaPlayer {
 		AudioITunesU = 1 << 3,
 		AnyAudio     = 0x00ff,
 		
-		[iOS (5,0)]
 		[Mac (10,12,2)]
 		Movie = 1 << 8,
-		[iOS (5,0)]
 		[Mac (10,12,2)]
 		TVShow = 1 << 9,
-		[iOS (5,0)]
 		[Mac (10,12,2)]
 		VideoPodcast = 1 << 10,
-		[iOS (5,0)]
 		[Mac (10,12,2)]
 		MusicVideo = 1 << 11,
-		[iOS (5,0)]
 		[Mac (10,12,2)]
 		VideoITunesU = 1 << 12,
 		[iOS (7,0)]
 		[Mac (10,12,2)]
 		HomeVideo = 1 << 13,
-		[iOS (5,0)]
 		[Mac (10,12,2)]
 		TypeAnyVideo = 0xff00,
 #if XAMCORE_2_0

--- a/src/UIKit/UIAccessibility.cs
+++ b/src/UIKit/UIAccessibility.cs
@@ -50,7 +50,6 @@ namespace XamCore.UIKit {
 		[DllImport (Constants.UIKitLibrary)]
 		extern static /* BOOL */ bool UIAccessibilityIsMonoAudioEnabled ();
 
-		[iOS (5,0)]
 		static public bool IsMonoAudioEnabled {
 			get {
 				return UIAccessibilityIsMonoAudioEnabled ();
@@ -86,7 +85,6 @@ namespace XamCore.UIKit {
 		[DllImport (Constants.UIKitLibrary)]
 		extern static /* BOOL */ bool UIAccessibilityIsClosedCaptioningEnabled ();
 
-		[iOS (5,0)]
 		static public bool IsClosedCaptioningEnabled {
 			get {
 				return UIAccessibilityIsClosedCaptioningEnabled ();
@@ -153,14 +151,12 @@ namespace XamCore.UIKit {
 		[DllImport (Constants.UIKitLibrary)]
 		extern static void UIAccessibilityZoomFocusChanged (/* UIAccessibilityZoomType */ IntPtr type, CGRect frame, IntPtr view);
 
-		[iOS (5,0)]
 		public static void ZoomFocusChanged (UIAccessibilityZoomType type, CGRect frame, UIView view)
 		{
 			UIAccessibilityZoomFocusChanged ((IntPtr) type, frame, view != null ? view.Handle : IntPtr.Zero);
 		}
 
 		// UIAccessibilityZoom.h
-		[iOS (5,0)]
 		[DllImport (Constants.UIKitLibrary, EntryPoint = "UIAccessibilityRegisterGestureConflictWithZoom")]
 		extern public static void RegisterGestureConflictWithZoom ();
 

--- a/src/UIKit/UIBarItem.cs
+++ b/src/UIKit/UIBarItem.cs
@@ -21,14 +21,12 @@ using TextAttributes = XamCore.UIKit.UITextAttributes;
 
 namespace XamCore.UIKit {
 	public partial class UIBarItem {
-		[iOS (5,0)]
 		public void SetTitleTextAttributes (TextAttributes attributes, UIControlState state)
 		{
 			using (var dict = attributes == null ? null : attributes.Dictionary)
 				_SetTitleTextAttributes (dict, state);
 		}
 
-		[iOS (5,0)]
 		public TextAttributes GetTitleTextAttributes (UIControlState state)
 		{
 			using (var d = _GetTitleTextAttributes (state)){

--- a/src/UIKit/UIDevice.cs
+++ b/src/UIKit/UIDevice.cs
@@ -22,7 +22,6 @@ namespace XamCore.UIKit {
 			}
 		}
 
-		[iOS (4,0)]
 		public bool IsMultitaskingSupported {
 			get {
 				Selector mtsupported = new Selector ("isMultitaskingSupported");

--- a/src/UIKit/UIEnums.cs
+++ b/src/UIKit/UIEnums.cs
@@ -20,14 +20,8 @@ namespace XamCore.UIKit {
 		High,
 		Medium,
 		Low,
-
-		[iOS (4,0)]
 		At640x480,
-
-		[iOS (5,0)]
 		At1280x720,
-
-		[iOS (5,0)]
 		At960x540
 	}
 
@@ -43,7 +37,6 @@ namespace XamCore.UIKit {
 	// NSInteger -> UIAlertView.h
 	[Native]
 	[NoTV][NoWatch]
-	[iOS (5,0)]
 	public enum UIAlertViewStyle : nint {
 		Default,
 		SecureTextInput,
@@ -90,8 +83,6 @@ namespace XamCore.UIKit {
 		FastForward,
 		Undo,
 		Redo,
-
-		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 11, 0)]
 		PageCurl
 	} 
@@ -144,25 +135,15 @@ namespace XamCore.UIKit {
 		None,
 		MotionShake,
 
-		[iOS (4,0)]
 		RemoteControlPlay                 = 100,
-		[iOS (4,0)]
 		RemoteControlPause                = 101,
-		[iOS (4,0)]
 		RemoteControlStop                 = 102,
-		[iOS (4,0)]
 		RemoteControlTogglePlayPause      = 103,
-		[iOS (4,0)]
 		RemoteControlNextTrack            = 104,
-		[iOS (4,0)]
 		RemoteControlPreviousTrack        = 105,
-		[iOS (4,0)]
 		RemoteControlBeginSeekingBackward = 106,
-		[iOS (4,0)]
 		RemoteControlEndSeekingBackward   = 107,
-		[iOS (4,0)]
 		RemoteControlBeginSeekingForward  = 108,
-		[iOS (4,0)]
 		RemoteControlEndSeekingForward    = 109,
 	}			
 	
@@ -276,14 +257,12 @@ namespace XamCore.UIKit {
 	// NSInteger -> UIBarCommon.h
 	[Native]
 	[NoWatch]
-	[iOS (5,0)]
 	public enum UIBarMetrics : nint {
 		Default,
 		Compact,
 		DefaultPrompt = 101,
 		CompactPrompt,
 
-		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'UIBarMetrics.Compat' instead.")]
 		LandscapePhone = Compact,
 
@@ -364,7 +343,6 @@ namespace XamCore.UIKit {
 	// NSInteger -> UIDocument.h
 	[Native]
 	[NoTV][NoWatch]
-	[iOS (5,0)]
 	public enum UIDocumentChangeKind : nint {
 		Done, Undone, Redone, Cleared
 	}
@@ -372,7 +350,6 @@ namespace XamCore.UIKit {
 	// NSInteger -> UIDocument.h
 	[Native]
 	[NoTV][NoWatch]
-	[iOS (5,0)]
 	public enum UIDocumentSaveOperation : nint {
 		ForCreating, ForOverwriting
 	}
@@ -381,7 +358,6 @@ namespace XamCore.UIKit {
 	[Native]
 	[Flags]
 	[NoTV][NoWatch]
-	[iOS (5,0)]
 	public enum UIDocumentState : nuint_compat_int {
 		Normal = 0,
 		Closed = 1 << 0,
@@ -503,8 +479,6 @@ namespace XamCore.UIKit {
 		Plain,
 		Bordered,
 		Bar,
-
-		[iOS (4,0)]
 		Bezeled
 	}
 
@@ -555,15 +529,12 @@ namespace XamCore.UIKit {
 		Bottom,
 		None,
 		Middle,
-
-		[iOS (5,0)]
 		Automatic = 100
 	}
 
 	// #defines over UIBarPosition -> NSInteger -> UIBarCommon.h
 	[Native]
 	[NoTV][NoWatch]
-	[iOS (5,0)]
 	public enum UIToolbarPosition : nint {
 		Any, Bottom, Top
 	}
@@ -762,10 +733,7 @@ namespace XamCore.UIKit {
 	public enum UIDataDetectorType : nuint {
 		PhoneNumber            = 1 << 0,
 		Link                   = 1 << 1,
-
-		[iOS (4,0)]
 		Address                = 1 << 2,
-		[iOS (4,0)]
 		CalendarEvent          = 1 << 3,
 
 		[iOS (10,0)]
@@ -840,8 +808,6 @@ namespace XamCore.UIKit {
 		Badge   = 1 << 0,
 		Sound   = 1 << 1,
 		Alert   = 1 << 2,
-
-		[iOS (5,0)]
 		NewsstandContentAvailability = 1 << 3
 	}
 
@@ -945,7 +911,6 @@ namespace XamCore.UIKit {
 	// NSInteger -> UIApplication.h
 	[Native]
 	[NoWatch]
-	[iOS (5,0)]
 	public enum UIUserInterfaceLayoutDirection : nint {
 		LeftToRight, RightToLeft
 	}
@@ -964,7 +929,6 @@ namespace XamCore.UIKit {
 	// NSInteger -> UIApplication.h
 	[Native]
 	[NoWatch]
-	[iOS (4,0)]
 	public enum UIApplicationState : nint {
 		Active,
 		Inactive,
@@ -975,7 +939,6 @@ namespace XamCore.UIKit {
 	[Native]
 	[Flags]
 	[NoWatch]
-	[iOS (4,0)]
 	public enum UIViewAnimationOptions : nuint_compat_int {
 		LayoutSubviews            = 1 <<  0,
 		AllowUserInteraction      = 1 <<  1,
@@ -1017,7 +980,6 @@ namespace XamCore.UIKit {
 	// untyped (and unamed) enum -> UIPrintError.h
 	// note: it looks unused by any API
 	[NoTV][NoWatch]
-	[iOS (4,2)]
 	[ErrorDomain ("UIPrintErrorDomain")]
 	public enum UIPrintError {
 		NotAvailable = 1,
@@ -1029,7 +991,6 @@ namespace XamCore.UIKit {
 	// NSInteger -> UIPrintInfo.h
 	[Native]
 	[NoTV][NoWatch]
-	[iOS (4,2)]
 	public enum UIPrintInfoDuplex : nint {
 		None,
 		LongEdge,
@@ -1039,7 +1000,6 @@ namespace XamCore.UIKit {
 	// NSInteger -> UIPrintInfo.h
 	[Native]
 	[NoTV][NoWatch]
-	[iOS (4,2)]
 	public enum UIPrintInfoOrientation : nint {
 		Portrait,
 		Landscape,
@@ -1048,7 +1008,6 @@ namespace XamCore.UIKit {
 	// NSInteger -> UIPrintInfo.h
 	[Native]
 	[NoTV][NoWatch]
-	[iOS (4,2)]
 	public enum UIPrintInfoOutputType : nint {
 		General,
 		Photo,
@@ -1059,7 +1018,6 @@ namespace XamCore.UIKit {
 	// NSInteger -> UIAccessibility.h
 	[Native]
 	[NoWatch]
-	[iOS (4,2)]
 	public enum UIAccessibilityScrollDirection : nint {
 		Right = 1,
 		Left,
@@ -1072,7 +1030,6 @@ namespace XamCore.UIKit {
 	// NSInteger -> UIScreen.h
 	[Native]
 	[NoWatch]
-	[iOS (5,0)]
 	public enum UIScreenOverscanCompensation : nint {
 		Scale, InsetBounds,
 		None,
@@ -1083,14 +1040,12 @@ namespace XamCore.UIKit {
 	// NSInteger -> UISegmentedControl.h
 	[Native]
 	[NoWatch]
-	[iOS (5,0)]
 	public enum UISegmentedControlSegment : nint {
 		Any, Left, Center, Right, Alone
 	}
 
 	// NSInteger -> UISearchBar.h
 	[Native]
-	[iOS (5,0)]
 	[NoWatch]
 	public enum UISearchBarIcon : nint {
 		Search,
@@ -1105,7 +1060,6 @@ namespace XamCore.UIKit {
 	// NSInteger -> UIPageViewController.h
 	[Native]
 	[NoWatch]
-	[iOS (5,0)]
 	public enum UIPageViewControllerNavigationOrientation : nint {
 		Horizontal, Vertical
 	}
@@ -1113,7 +1067,6 @@ namespace XamCore.UIKit {
 	// NSInteger -> UIPageViewController.h
 	[Native]
 	[NoWatch]
-	[iOS (5,0)]
 	public enum UIPageViewControllerSpineLocation : nint {
 		None, Min, Mid, Max
 	}
@@ -1121,7 +1074,6 @@ namespace XamCore.UIKit {
 	// NSInteger -> UIPageViewController.h
 	[Native]
 	[NoWatch]
-	[iOS (5,0)]
 	public enum UIPageViewControllerNavigationDirection : nint {
 		Forward, Reverse
 	}
@@ -1129,7 +1081,6 @@ namespace XamCore.UIKit {
 	// NSInteger -> UIPageViewController.h
 	[Native]
 	[NoWatch]
-	[iOS (5,0)]
 	public enum UIPageViewControllerTransitionStyle : nint {
 		PageCurl, Scroll
 	}

--- a/src/UIKit/UIGraphics.cs
+++ b/src/UIKit/UIGraphics.cs
@@ -44,7 +44,6 @@ namespace XamCore.UIKit {
 		public extern static void BeginImageContext (CGSize size);
 
 		[DllImport (Constants.UIKitLibrary, EntryPoint="UIGraphicsBeginImageContextWithOptions")]
-		[iOS (4,0)]
 		public extern static void BeginImageContextWithOptions (CGSize size, bool opaque, nfloat scale);
 	
 		[DllImport (Constants.UIKitLibrary)]

--- a/src/UIKit/UIOffset.cs
+++ b/src/UIKit/UIOffset.cs
@@ -15,7 +15,6 @@ using XamCore.ObjCRuntime;
 namespace XamCore.UIKit {
 
 	// UIGeometry.h
-	[iOS (5,0)]
 	public struct UIOffset {
 
 		// API match for UIOffsetZero field/constant

--- a/src/UIKit/UIPopoverController.cs
+++ b/src/UIKit/UIPopoverController.cs
@@ -9,7 +9,6 @@ namespace XamCore.UIKit {
 
 	public partial class UIPopoverController {
 
-		[iOS (5,0)]
 		// cute helper to avoid using `Class` in the public API
 		public virtual Type PopoverBackgroundViewType {
 			get {

--- a/src/UIKit/UIStringDrawing.cs
+++ b/src/UIKit/UIStringDrawing.cs
@@ -9,7 +9,6 @@ using XamCore.ObjCRuntime;
 
 namespace XamCore.UIKit {
 	public unsafe static partial class UIStringDrawing  {
-		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use NSString.DrawString(CGPoint, UIStringAttributes) instead.")]
 		public static CGSize DrawString (this string This, CGPoint point, UIFont font)
 		{
@@ -17,7 +16,6 @@ namespace XamCore.UIKit {
 				return self.DrawString (point, font);
 		}
 
-		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use NSString.DrawString(CGRect, UIStringAttributes) instead.")]
 		public static CGSize DrawString (this string This, CGPoint point, global::System.nfloat width, UIFont font, UILineBreakMode breakMode)
 		{
@@ -25,7 +23,6 @@ namespace XamCore.UIKit {
 				return self.DrawString (point, width, font, breakMode);
 		}
 
-		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use NSString.DrawString(CGRect, UIStringAttributes) instead.")]
 		public static CGSize DrawString (this string This, CGPoint point, global::System.nfloat width, UIFont font, global::System.nfloat fontSize, UILineBreakMode breakMode, UIBaselineAdjustment adjustment)
 		{
@@ -33,7 +30,6 @@ namespace XamCore.UIKit {
 				return self.DrawString (point, width, font, fontSize, breakMode, adjustment);
 		}
 
-		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use NSString.DrawString(CGRect, UIStringAttributes) instead.")]
 		public static CGSize DrawString (this string This, CGPoint point, global::System.nfloat width, UIFont font, global::System.nfloat minFontSize, ref global::System.nfloat actualFontSize, UILineBreakMode breakMode, UIBaselineAdjustment adjustment)
 		{
@@ -41,7 +37,6 @@ namespace XamCore.UIKit {
 				return self.DrawString (point, width, font, minFontSize, ref actualFontSize, breakMode, adjustment);
 		}
 
-		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use NSString.DrawString(CGRect, UIStringAttributes) instead.")]
 		public static CGSize DrawString (this string This, CGRect rect, UIFont font)
 		{
@@ -49,7 +44,6 @@ namespace XamCore.UIKit {
 				return self.DrawString (rect, font);
 		}
 
-		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use NSString.DrawString(CGRect, UIStringAttributes) instead.")]
 		public static CGSize DrawString (this string This, CGRect rect, UIFont font, UILineBreakMode mode)
 		{
@@ -57,7 +51,6 @@ namespace XamCore.UIKit {
 				return self.DrawString (rect, font, mode);
 		}
 
-		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use NSString.DrawString(CGRect, UIStringAttributes) instead.")]
 		public static CGSize DrawString (this string This, CGRect rect, UIFont font, UILineBreakMode mode, UITextAlignment alignment)
 		{
@@ -65,7 +58,6 @@ namespace XamCore.UIKit {
 				return self.DrawString (rect, font, mode, alignment);
 		}
 
-		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use NSString.GetSizeUsingAttributes(UIStringAttributes) instead.")]
 		public static CGSize StringSize (this string This, UIFont font)
 		{
@@ -73,7 +65,6 @@ namespace XamCore.UIKit {
 				return self.StringSize (font);
 		}
 
-		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext) instead.")]
 		public static CGSize StringSize (this string This, UIFont font, global::System.nfloat forWidth, UILineBreakMode breakMode)
 		{
@@ -81,7 +72,6 @@ namespace XamCore.UIKit {
 				return self.StringSize (font, forWidth, breakMode);
 		}
 
-		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext) instead.")]
 		public static CGSize StringSize (this string This, UIFont font, CGSize constrainedToSize)
 		{
@@ -89,7 +79,6 @@ namespace XamCore.UIKit {
 				return self.StringSize (font, constrainedToSize);
 		}
 
-		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext) instead.")]
 		public static CGSize StringSize (this string This, UIFont font, CGSize constrainedToSize, UILineBreakMode lineBreakMode)
 		{
@@ -97,7 +86,6 @@ namespace XamCore.UIKit {
 				return self.StringSize (font, constrainedToSize, lineBreakMode);
 		}
 
-		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0)]
 		public static CGSize StringSize (this string This, UIFont font, global::System.nfloat minFontSize, ref global::System.nfloat actualFontSize, global::System.nfloat forWidth, UILineBreakMode lineBreakMode)
 		{

--- a/src/accounts.cs
+++ b/src/accounts.cs
@@ -8,7 +8,6 @@ using XamCore.Foundation;
 
 namespace XamCore.Accounts {
 	
-	[iOS (5,0)]
 	[Mac (10,8, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	interface ACAccount : NSSecureCoding {
@@ -48,7 +47,6 @@ namespace XamCore.Accounts {
 #endif
 	}
 
-	[iOS (5,0)]
 	[Mac (10,8, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	interface ACAccountCredential : NSSecureCoding {
@@ -69,7 +67,6 @@ namespace XamCore.Accounts {
 	delegate void ACAccountStoreRemoveCompletionHandler (bool success, NSError error);
 	delegate void ACRequestCompletionHandler (bool granted, NSError error);
 	
-	[iOS (5,0)]
 	[Mac (10,8, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	interface ACAccountStore {
@@ -120,7 +117,6 @@ namespace XamCore.Accounts {
 		void RemoveAccount (ACAccount account, ACAccountStoreRemoveCompletionHandler completionHandler);
 	}
 
-	[iOS (5,0)]
 	[Mac (10,8, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	interface ACAccountType : NSSecureCoding {

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -2214,7 +2214,6 @@ namespace XamCore.AppKit {
 		[Export ("imageHugsTitle")]
 		bool ImageHugsTitle { get; set; }
 
-		[Mac (10,5)]
 		[Export ("imageScaling")]
 		NSImageScale ImageScaling { get; set; }
 
@@ -5048,7 +5047,6 @@ namespace XamCore.AppKit {
 		bool ExplicitlyIncluded { [Bind ("isExplicitlyIncluded")] get; }
 	}
 
-	[Mac (10,5)]
 	[BaseType (typeof(NSArrayController))]
 	interface NSDictionaryController
 	{
@@ -19177,7 +19175,6 @@ namespace XamCore.AppKit {
 		bool Autovalidates { get; set; }
 	}
 
-	[Mac (10,5)]
 	[BaseType (typeof (NSToolbarItem))]
 	interface NSToolbarItemGroup
 	{
@@ -23800,7 +23797,6 @@ namespace XamCore.AppKit {
 		[Field ("NSAccessibilityShownMenuAttribute")]
 		NSString ShownMenuAttribute { get; }
 
-		[Mac (10, 5)]
 		[Field ("NSAccessibilityValueDescriptionAttribute")]
 		NSString ValueDescriptionAttribute { get; }
 
@@ -23911,7 +23907,6 @@ namespace XamCore.AppKit {
 		[Field ("NSAccessibilityInsertionPointLineNumberAttribute")]
 		NSString InsertionPointLineNumberAttribute { get; }
 
-		[Mac (10, 5)]
 		[Field ("NSAccessibilitySelectedTextRangesAttribute")]
 		NSString SelectedTextRangesAttribute { get; }
 
@@ -24480,7 +24475,6 @@ namespace XamCore.AppKit {
 		[Field ("NSAccessibilityTextLinkSubrole")]
 		NSString TextLinkSubrole { get; }
 
-		[Mac (10, 5)]
 		[Field ("NSAccessibilityTimelineSubrole")]
 		NSString TimelineSubrole { get; }
 

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -274,7 +274,7 @@ namespace XamCore.AppKit {
 		[Static, Export ("alertWithError:")]
 		NSAlert WithError (NSError  error);
 	
-		[Availability (Introduced = Platform.Mac_10_3, Deprecated = Platform.Mac_10_10, Message = "Use constructor instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use constructor instead.")]
 		[Static, Export ("alertWithMessageText:defaultButton:alternateButton:otherButton:informativeTextWithFormat:")]
 		NSAlert WithMessage([NullAllowed] string message, [NullAllowed] string defaultButton, [NullAllowed] string alternateButton, [NullAllowed]  string otherButton, string full);
 	
@@ -324,7 +324,7 @@ namespace XamCore.AppKit {
 		[Export ("runModal")]
 		nint RunModal ();
 	
-		[Availability (Introduced = Platform.Mac_10_3, Deprecated = Platform.Mac_10_10, Message = "Use BeginSheetModalForWindow (NSWindow sheetWindow, Action<nint> handler) instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use BeginSheetModalForWindow (NSWindow sheetWindow, Action<nint> handler) instead.")]
 		[Export ("beginSheetModalForWindow:modalDelegate:didEndSelector:contextInfo:")]
 		void BeginSheet ([NullAllowed] NSWindow  window, [NullAllowed] NSObject modalDelegate, [NullAllowed] Selector didEndSelector, IntPtr contextInfo);
 
@@ -505,15 +505,15 @@ namespace XamCore.AppKit {
 		[Export ("cancelUserAttentionRequest:")]
 		void CancelUserAttentionRequest (nint request);
 	
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10, Message = "Use NSWindow.BeginSheet instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use NSWindow.BeginSheet instead.")]
 		[Export ("beginSheet:modalForWindow:modalDelegate:didEndSelector:contextInfo:")]
 		void BeginSheet (NSWindow sheet, NSWindow docWindow, [NullAllowed] NSObject modalDelegate, [NullAllowed] Selector didEndSelector, IntPtr contextInfo);
 	
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10, Message = "Use NSWindow.EndSheet instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use NSWindow.EndSheet instead.")]
 		[Export ("endSheet:")]
 		void EndSheet (NSWindow sheet);
 	
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_9)]
+		[Availability (Deprecated = Platform.Mac_10_9)]
 		[Export ("endSheet:returnCode:")]
 		void EndSheet (NSWindow  sheet, nint returnCode);
 	
@@ -1634,11 +1634,11 @@ namespace XamCore.AppKit {
 		[Export ("lastVisibleColumn")]
 		nint LastVisibleColumn { get; }
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10, Message = "Use the item based NSBrowser instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use the item based NSBrowser instead.")]
 		[Export ("columnOfMatrix:")]
 		nint ColumnOfMatrix (NSMatrix matrix);
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10, Message = "Use the item based NSBrowser instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use the item based NSBrowser instead.")]
 		[Export ("matrixInColumn:")]
 		NSMatrix MatrixInColumn (nint column);
 
@@ -1745,7 +1745,7 @@ namespace XamCore.AppKit {
 		[Export ("doubleAction")]
 		Selector DoubleAction { get; set; }
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10, Message = "Use the item based NSBrowser instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use the item based NSBrowser instead.")]
 		[Export ("matrixClass")]
 		Class MatrixClass { get; [Bind ("setMatrixClass:")] set; }
 
@@ -2636,7 +2636,7 @@ namespace XamCore.AppKit {
 		[Export ("autoscroll:")]
 		bool Autoscroll (NSEvent  theEvent);
 	
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10, Message = "Use ConstrainBoundsRect instead.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use ConstrainBoundsRect instead.")]
 		[Export ("constrainScrollPoint:")]
 		CGPoint ConstrainScrollPoint (CGPoint newOrigin);
 
@@ -2661,7 +2661,7 @@ namespace XamCore.AppKit {
 
 	[Category, BaseType (typeof (NSCoder))]
 	partial interface NSCoderAppKitAddons {
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_9)]
+		[Availability (Deprecated = Platform.Mac_10_9)]
 		[Export ("decodeNXColor")]
 		NSColor DecodeNXColor ();
 	}
@@ -6659,7 +6659,7 @@ namespace XamCore.AppKit {
 		nfloat Black { get; }
 	}
 
-	[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+	[Availability (Deprecated = Platform.Mac_10_10)]
 	[BaseType (typeof (NSMatrix))]
 	partial interface NSForm  {
 		[Export ("initWithFrame:")]
@@ -6852,7 +6852,7 @@ namespace XamCore.AppKit {
 		[Static, Export ("restoreGraphicsState")]
 		void GlobalRestoreGraphicsState ();
 	
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Static, Export ("setGraphicsState:")]
 		void SetGraphicsState (nint gState);
 	
@@ -7109,7 +7109,7 @@ namespace XamCore.AppKit {
 		[Export ("initWithData:")]
 		IntPtr Constructor (NSData epsData);
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("prepareGState")]
 		void PrepareGState ();
 
@@ -7988,7 +7988,7 @@ namespace XamCore.AppKit {
 
 	}
 
-	[Mac (10, 0, 0, PlatformArchitecture.Arch32)] 
+	[Mac (10, 0, 0, PlatformArchitecture.Arch32)] // kept for the arch limitation
 	[BaseType (typeof (NSView))]
 	interface NSMenuView {
 		[Static]
@@ -8222,7 +8222,7 @@ namespace XamCore.AppKit {
 		CGLPixelFormat CGLPixelFormat { get; }
 	}
 
-	[Availability (Introduced = Platform.Mac_10_2, Deprecated = Platform.Mac_10_7)]
+	[Availability (Deprecated = Platform.Mac_10_7)]
 	[BaseType (typeof (NSObject))]
 	interface NSOpenGLPixelBuffer {
 		[Export ("initWithTextureTarget:textureInternalFormat:textureMaxMipMapLevel:pixelsWide:pixelsHigh:")]
@@ -8261,11 +8261,11 @@ namespace XamCore.AppKit {
 		// [Export ("initWithCGLContextObj:")]
 		// IntPtr Constructor (IntPtr cglContext);
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		[Export ("setFullScreen")]
 		void SetFullScreen ();
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		[Export ("setOffScreen:width:height:rowbytes:")]
 		void SetOffScreen (IntPtr baseaddr, int /* GLsizei = int32_t */ width, int /* GLsizei = int32_t */ height, int /* GLint = int32_t */ rowbytes);
 
@@ -8290,7 +8290,7 @@ namespace XamCore.AppKit {
 		[Export ("currentContext")]
 		NSOpenGLContext CurrentContext { get; }
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_8)]
+		[Availability (Deprecated = Platform.Mac_10_8)]
 		[Export ("copyAttributesFromContext:withMask:")]
 		void CopyAttributes (NSOpenGLContext context, uint /* GLbitfield = uint32_t */ mask);
 
@@ -8300,32 +8300,32 @@ namespace XamCore.AppKit {
 		[Export ("getValues:forParameter:")]
 		void GetValues (IntPtr vals, NSOpenGLContextParameter param);
 
-		[Availability (Introduced = Platform.Mac_10_2, Deprecated = Platform.Mac_10_8)]
+		[Availability (Deprecated = Platform.Mac_10_8)]
 		[Export ("createTexture:fromView:internalFormat:")]
 		void CreateTexture (int /* GLenum = uint32_t */ targetIdentifier, NSView view, int /* GLenum = uint32_t */ format);
 
 		[Export ("CGLContextObj")]
 		CGLContext CGLContext { get; }
 
-		[Availability (Introduced = Platform.Mac_10_3, Deprecated = Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		[Export ("setPixelBuffer:cubeMapFace:mipMapLevel:currentVirtualScreen:")]
 		void SetPixelBuffer (NSOpenGLPixelBuffer pixelBuffer, NSGLTextureCubeMap face, int /* GLint = int32_t */ level, int /* GLint = int32_t */ screen);
 
-		[Availability (Introduced = Platform.Mac_10_3, Deprecated = Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		[Export ("pixelBuffer")]
 		NSOpenGLPixelBuffer PixelBuffer { get; }
 
-		[Availability (Introduced = Platform.Mac_10_3, Deprecated = Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		[Export ("pixelBufferCubeMapFace")]
 		int PixelBufferCubeMapFace { get; } /* GLenum = uint32_t */
 
-		[Availability (Introduced = Platform.Mac_10_3, Deprecated = Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		[Export ("pixelBufferMipMapLevel")]
 		int PixelBufferMipMapLevel { get; } /* GLint = int32_t */
 
 		// TODO: fixme enumerations
 		// GL_FRONT, GL_BACK, GL_AUX0
-		[Availability (Introduced = Platform.Mac_10_3, Deprecated = Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		[Export ("setTextureImageToPixelBuffer:colorBuffer:")]
 		void SetTextureImage (NSOpenGLPixelBuffer pixelBuffer, NSGLColorBuffer source);
 
@@ -8867,22 +8867,22 @@ namespace XamCore.AppKit {
 		[Export ("bestRepresentationForDevice:")]
 		NSImageRep BestRepresentationForDevice ([NullAllowed] NSDictionary deviceDescription);
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Static]
 		[Export ("imageUnfilteredFileTypes")]
 		NSObject [] ImageUnfilteredFileTypes ();
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Static]
 		[Export ("imageUnfilteredPasteboardTypes")]
 		string [] ImageUnfilteredPasteboardTypes ();
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Static]
 		[Export ("imageFileTypes")]
 		string [] ImageFileTypes { get; }
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Static]
 		[Export ("imagePasteboardTypes")]
 		string [] ImagePasteboardTypes { get; }
@@ -9645,12 +9645,12 @@ namespace XamCore.AppKit {
 		//[Export ("registeredImageRepClasses")]
 		//Class [] RegisteredImageRepClasses ();
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Static]
 		[Export ("imageRepClassForFileType:")]
 		Class ImageRepClassForFileType (string type);
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Static]
 		[Export ("imageRepClassForPasteboardType:")]
 		Class ImageRepClassForPasteboardType (string type);
@@ -9667,22 +9667,22 @@ namespace XamCore.AppKit {
 		[Export ("canInitWithData:")]
 		bool CanInitWithData (NSData data);
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Static]
 		[Export ("imageUnfilteredFileTypes")]
 		string [] ImageUnfilteredFileTypes { get; }
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Static]
 		[Export ("imageUnfilteredPasteboardTypes")]
 		string [] ImageUnfilteredPasteboardTypes { get; }
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Static]
 		[Export ("imageFileTypes")]
 		string [] ImageFileTypes { get; }
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Static]
 		[Export ("imagePasteboardTypes")]
 		string [] ImagePasteboardTypes { get; }
@@ -10601,7 +10601,7 @@ namespace XamCore.AppKit {
 
 		[Internal]
 		[Export ("rectArrayForGlyphRange:withinSelectedGlyphRange:inTextContainer:rectCount:")]
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_11)]
+		[Availability (Deprecated = Platform.Mac_10_11)]
 		IntPtr GetRectArray (NSRange glyphRange, NSRange selectedGlyphRange, IntPtr textContainerHandle, out nuint rectCount);
 
 		[Export ("boundingRectForGlyphRange:inTextContainer:")]
@@ -12900,12 +12900,12 @@ namespace XamCore.AppKit {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frameRect);
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_7, Message = "Use GetScrollerWidth instead.")]
+		[Availability (Deprecated = Platform.Mac_10_7, Message = "Use GetScrollerWidth instead.")]
 		[Static]
 		[Export ("scrollerWidth")]
 		nfloat ScrollerWidth { get; }
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_7, Message = "Use GetScrollerWidth instead.")]
+		[Availability (Deprecated = Platform.Mac_10_7, Message = "Use GetScrollerWidth instead.")]
 		[Static]
 		[Export ("scrollerWidthForControlSize:")]
 		nfloat ScrollerWidthForControlSize (NSControlSize controlSize);
@@ -12985,12 +12985,12 @@ namespace XamCore.AppKit {
 
 	[BaseType (typeof (NSView))]
 	partial interface NSScrollView : NSTextFinderBarContainer {
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		[Static]
 		[Export ("frameSizeForContentSize:hasHorizontalScroller:hasVerticalScroller:borderType:")]
 		CGSize FrameSizeForContentSize (CGSize cSize, bool hFlag, bool vFlag, NSBorderType aType);
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		[Static]
 		[Export ("contentSizeForFrameSize:hasHorizontalScroller:hasVerticalScroller:borderType:")]
 		CGSize ContentSizeForFrame (CGSize fSize, bool hFlag, bool vFlag, NSBorderType aType);
@@ -15156,27 +15156,27 @@ namespace XamCore.AppKit {
 		[Export ("centerScanRect:")]
 		CGRect CenterScanRect (CGRect aRect);
 
-		[Availability (Introduced = Platform.Mac_10_5, Deprecated = Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		[Export ("convertPointToBase:")]
 		CGPoint ConvertPointToBase (CGPoint aPoint);
 
-		[Availability (Introduced = Platform.Mac_10_5, Deprecated = Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		[Export ("convertPointFromBase:")]
 		CGPoint ConvertPointFromBase (CGPoint aPoint);
 
-		[Availability (Introduced = Platform.Mac_10_5, Deprecated = Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		[Export ("convertSizeToBase:")]
 		CGSize ConvertSizeToBase (CGSize aSize);
 
-		[Availability (Introduced = Platform.Mac_10_5, Deprecated = Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		[Export ("convertSizeFromBase:")]
 		CGSize ConvertSizeFromBase (CGSize aSize);
 
-		[Availability (Introduced = Platform.Mac_10_5, Deprecated = Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		[Export ("convertRectToBase:")]
 		CGRect ConvertRectToBase (CGRect aRect);
 
-		[Availability (Introduced = Platform.Mac_10_5, Deprecated = Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		[Export ("convertRectFromBase:")]
 		CGRect ConvertRectFromBase (CGRect aRect);
 
@@ -15246,23 +15246,23 @@ namespace XamCore.AppKit {
 		[Export ("viewWillDraw")]
 		void ViewWillDraw ();
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("gState")]
 		nint GState ();
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("allocateGState")]
 		void AllocateGState ();
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("releaseGState")]
 		void ReleaseGState ();
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("setUpGState")]
 		void SetUpGState ();
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("renewGState")]
 		void RenewGState ();
 
@@ -15344,7 +15344,7 @@ namespace XamCore.AppKit {
 		[Export ("updateTrackingAreas")]
 		void UpdateTrackingAreas ();
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("shouldDrawColor")]
 		bool ShouldDrawColor { get; }
 
@@ -15482,7 +15482,7 @@ namespace XamCore.AppKit {
 		[Export ("beginDraggingSessionWithItems:event:source:")]
 		NSDraggingSession BeginDraggingSession (NSDraggingItem [] items, NSEvent evnt, [Protocolize] NSDraggingSource source);
 
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_7, Message = "Use BeginDraggingSession instead.")]
+		[Availability (Deprecated = Platform.Mac_10_7, Message = "Use BeginDraggingSession instead.")]
 		[Export ("dragImage:at:offset:event:pasteboard:source:slideBack:")]
 		void DragImage (NSImage anImage, CGPoint viewLocation, CGSize initialOffset, NSEvent theEvent, NSPasteboard pboard, NSObject sourceObj, bool slideFlag);
 
@@ -16530,35 +16530,35 @@ namespace XamCore.AppKit {
 		[Export ("frameOfCellAtColumn:row:")]
 		CGRect GetCellFrame (nint column, nint row);
 	
-		[Availability (Introduced = Platform.Mac_10_5, Deprecated = Platform.Mac_10_10, Message = "Use View Based TableView and GetView.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use View Based TableView and GetView.")]
 		[Export ("preparedCellAtColumn:row:")]
 		NSCell GetCell (nint column, nint row );
 	
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10, Message = "Use a View Based TableView with an NSTextField.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use a View Based TableView with an NSTextField.")]
 		[Export ("textShouldBeginEditing:")]
 		bool TextShouldBeginEditing (NSText textObject);
 	
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10, Message = "Use a View Based TableView with an NSTextField.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use a View Based TableView with an NSTextField.")]
 		[Export ("textShouldEndEditing:")]
 		bool TextShouldEndEditing (NSText textObject);
 	
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10, Message = "Use a View Based TableView with an NSTextField.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use a View Based TableView with an NSTextField.")]
 		[Export ("textDidBeginEditing:")]
 		void TextDidBeginEditing (NSNotification notification);
 	
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10, Message = "Use a View Based TableView with an NSTextField.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use a View Based TableView with an NSTextField.")]
 		[Export ("textDidEndEditing:")]
 		void TextDidEndEditing (NSNotification notification);
 	
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10, Message = "Use a View Based TableView with an NSTextField.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use a View Based TableView with an NSTextField.")]
 		[Export ("textDidChange:")]
 		void TextDidChange (NSNotification notification);
 	
-		[Availability (Introduced = Platform.Mac_10_6, Deprecated = Platform.Mac_10_10, Message = "Use a View Based TableView; observe the window’s firstResponder for focus change notifications.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use a View Based TableView; observe the window’s firstResponder for focus change notifications.")]
 		[Export ("shouldFocusCell:atColumn:row:")]
 		bool ShouldFocusCell (NSCell cell, nint column, nint row );
 	
-		[Availability (Introduced = Platform.Mac_10_6, Deprecated = Platform.Mac_10_10, Message = "Use a View Based TableView; directly interact with a particular view as required and call PerformClick on it, if necessary.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use a View Based TableView; directly interact with a particular view as required and call PerformClick on it, if necessary.")]
 		[Export ("performClickOnCellAtColumn:row:")]
 		void PerformClick (nint column, nint row );
 	
@@ -16661,7 +16661,7 @@ namespace XamCore.AppKit {
 		[Export ("autosaveTableColumns")]
 		bool AutosaveTableColumns { get; set; }
 	
-		[Availability (Introduced = Platform.Mac_10_5, Deprecated = Platform.Mac_10_10, Message = "Use a View Based TableView; observe the window’s firstResponder.")]
+		[Availability (Deprecated = Platform.Mac_10_10, Message = "Use a View Based TableView; observe the window’s firstResponder.")]
 		[Export ("focusedColumn")]
 		nint FocusedColumn { get; set; }
 
@@ -19647,7 +19647,7 @@ namespace XamCore.AppKit {
 		[Export ("contentAspectRatio")]
 		CGSize ContentAspectRatio  { get; set; }
 	
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("useOptimizedDrawing:")]
 		void UseOptimizedDrawing (bool flag);
 	
@@ -19826,11 +19826,11 @@ namespace XamCore.AppKit {
 		[Export ("preventsApplicationTerminationWhenModal")]
 		bool PreventsApplicationTerminationWhenModal  { get; set; }
 	
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_7, Message = "Use ConvertRectToScreen instead.")]
+		[Availability (Deprecated = Platform.Mac_10_7, Message = "Use ConvertRectToScreen instead.")]
 		[Export ("convertBaseToScreen:")]
 		CGPoint ConvertBaseToScreen (CGPoint aPoint);
 	
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_7, Message = "Use ConvertRectFromScreen instead.")]
+		[Availability (Deprecated = Platform.Mac_10_7, Message = "Use ConvertRectFromScreen instead.")]
 		[Export ("convertScreenToBase:")]
 		CGPoint ConvertScreenToBase (CGPoint aPoint);
 	
@@ -19843,7 +19843,7 @@ namespace XamCore.AppKit {
 		[Export ("performZoom:")]
 		void PerformZoom ([NullAllowed] NSObject sender);
 	
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("gState")]
 		nint GState ();
 	
@@ -19901,7 +19901,7 @@ namespace XamCore.AppKit {
 		[Export ("deepestScreen")]
 		NSScreen DeepestScreen { get; }
 	
-		[Availability (Introduced = Platform.Mac_10_0, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("canStoreColor")]
 		bool CanStoreColor { get; }
 	
@@ -20059,7 +20059,7 @@ namespace XamCore.AppKit {
 		[Export ("graphicsContext")]
 		NSGraphicsContext GraphicsContext { get; }
 	
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_7)]
+		[Availability (Deprecated = Platform.Mac_10_7)]
 		[Export ("userSpaceScaleFactor")]
 		nfloat UserSpaceScaleFactor { get; }
 	
@@ -24166,13 +24166,11 @@ namespace XamCore.AppKit {
 		[Field ("NSAccessibilityLabelValueAttribute")]
 		NSString LabelValueAttribute { get; }
 
-		[Mac (10, 1)]
-		[Obsolete]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message: "Use 'NSAccessibility' methods instead.")]
 		[Field ("NSAccessibilityMatteHoleAttribute")]
 		NSString MatteHoleAttribute { get; }
 
-		[Mac (10, 1)]
-		[Obsolete]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message: "Use 'NSAccessibility' methods instead.")]
 		[Field ("NSAccessibilityMatteContentUIElementAttribute")]
 		NSString MatteContentUIElementAttribute { get; }
 

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -11300,59 +11300,45 @@ namespace XamCore.AppKit {
 		[Field ("NSPasteboardNameDrag")]
 		NSString NSPasteboardNameDrag { get; }
 
-		[Mac (10,6)]
 		[Field ("NSPasteboardTypeString")]
 		NSString NSPasteboardTypeString { get; }
 
-		[Mac (10,6)]
 		[Field ("NSPasteboardTypePDF")]
 		NSString NSPasteboardTypePDF { get; }
 
-		[Mac (10,6)]
 		[Field ("NSPasteboardTypeTIFF")]
 		NSString NSPasteboardTypeTIFF { get; }
 
-		[Mac (10,6)]
 		[Field ("NSPasteboardTypePNG")]
 		NSString NSPasteboardTypePNG { get; }
 
-		[Mac (10,6)]
 		[Field ("NSPasteboardTypeRTF")]
 		NSString NSPasteboardTypeRTF { get; }
 
-		[Mac (10,6)]
 		[Field ("NSPasteboardTypeRTFD")]
 		NSString NSPasteboardTypeRTFD { get; }
 
-		[Mac (10,6)]
 		[Field ("NSPasteboardTypeHTML")]
 		NSString NSPasteboardTypeHTML { get; }
 
-		[Mac (10,6)]
 		[Field ("NSPasteboardTypeTabularText")]
 		NSString NSPasteboardTypeTabularText { get; }
 
-		[Mac (10,6)]
 		[Field ("NSPasteboardTypeFont")]
 		NSString NSPasteboardTypeFont { get; }
 
-		[Mac (10,6)]
 		[Field ("NSPasteboardTypeRuler")]
 		NSString NSPasteboardTypeRuler { get; }
 
-		[Mac (10,6)]
 		[Field ("NSPasteboardTypeColor")]
 		NSString NSPasteboardTypeColor { get; }
 
-		[Mac (10,6)]
 		[Field ("NSPasteboardTypeSound")]
 		NSString NSPasteboardTypeSound { get; }
 
-		[Mac (10,6)]
 		[Field ("NSPasteboardTypeMultipleTextSelection")]
 		NSString NSPasteboardTypeMultipleTextSelection { get; }
 
-		[Mac (10,6)]
 		[Field ("NSPasteboardTypeFindPanelSearchOptions")]
 		NSString NSPasteboardTypeFindPanelSearchOptions { get; }
 
@@ -13901,7 +13887,6 @@ namespace XamCore.AppKit {
 		[Wrap ("CheckString (stringToCheck, range, checkingTypes, options == null ? null : options.Dictionary, tag, out orthography, out wordCount)")]
 		NSTextCheckingResult [] CheckString (string stringToCheck, NSRange range, NSTextCheckingTypes checkingTypes, NSTextCheckingOptions options, nint tag, out NSOrthography orthography, out nint wordCount);
 
-		[Mac (10,6)]
 		[Export ("requestCheckingOfString:range:types:options:inSpellDocumentWithTag:completionHandler:")]
 		nint RequestChecking (string stringToCheck, NSRange range, NSTextCheckingTypes checkingTypes, [NullAllowed] NSDictionary options, nint tag, Action<nint, NSTextCheckingResult [], NSOrthography, nint> completionHandler);
 
@@ -17303,7 +17288,6 @@ namespace XamCore.AppKit {
 		[Export ("sizeOfLabel:")]
 		CGSize SizeOfLabel (bool computeMin);
 
-		[Mac (10,6)]
 		[Export ("toolTip")]
 		string ToolTip { get; set; }
 
@@ -18820,7 +18804,6 @@ namespace XamCore.AppKit {
 		[Export ("windowLevel")]
 		NSWindowLevel WindowLevel { get; }
 
-		[Mac (10,6)]
 		[Export ("drawsVerticallyForCharacterAtIndex:")]
 		bool DrawsVertically (nuint charIndex);
 	}
@@ -20936,19 +20919,15 @@ namespace XamCore.AppKit {
 		[Notification ("SharedWorkspace.NotificationCenter")]
 		NSString ActiveSpaceDidChangeNotification { get; }
 
-		[Mac (10,6)]
 		[Field ("NSWorkspaceLaunchConfigurationAppleEvent")]
 		NSString LaunchConfigurationAppleEvent { get; }
 
-		[Mac (10,6)]
 		[Field ("NSWorkspaceLaunchConfigurationArguments")]
 		NSString LaunchConfigurationArguments { get; }
 
-		[Mac (10,6)]
 		[Field ("NSWorkspaceLaunchConfigurationEnvironment")]
 		NSString LaunchConfigurationEnvironment { get; }
 
-		[Mac (10,6)]
 		[Field ("NSWorkspaceLaunchConfigurationArchitecture")]
 		NSString LaunchConfigurationArchitecture { get; }
 		
@@ -23633,27 +23612,22 @@ namespace XamCore.AppKit {
 		[Field ("NSAccessibilitySelectedColumnsChangedNotification")]
 		NSString SelectedColumnsChangedNotification { get; }
 
-		[Mac (10, 6)]
 		[Notification]
 		[Field ("NSAccessibilityRowExpandedNotification")]
 		NSString RowExpandedNotification { get; }
 
-		[Mac (10, 6)]
 		[Notification]
 		[Field ("NSAccessibilityRowCollapsedNotification")]
 		NSString RowCollapsedNotification { get; }
 
-		[Mac (10, 6)]
 		[Notification]
 		[Field ("NSAccessibilitySelectedCellsChangedNotification")]
 		NSString SelectedCellsChangedNotification { get; }
 
-		[Mac (10, 6)]
 		[Notification]
 		[Field ("NSAccessibilityUnitsChangedNotification")]
 		NSString UnitsChangedNotification { get; }
 
-		[Mac (10, 6)]
 		[Notification]
 		[Field ("NSAccessibilitySelectedChildrenMovedNotification")]
 		NSString SelectedChildrenMovedNotification { get; }
@@ -24075,67 +24049,51 @@ namespace XamCore.AppKit {
 		[Field ("NSAccessibilitySortDirectionAttribute")]
 		NSString SortDirectionAttribute { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilitySelectedCellsAttribute")]
 		NSString SelectedCellsAttribute { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityVisibleCellsAttribute")]
 		NSString VisibleCellsAttribute { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityRowHeaderUIElementsAttribute")]
 		NSString RowHeaderUIElementsAttribute { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityColumnHeaderUIElementsAttribute")]
 		NSString ColumnHeaderUIElementsAttribute { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityCellForColumnAndRowParameterizedAttribute")]
 		NSString CellForColumnAndRowParameterizedAttribute { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityRowIndexRangeAttribute")]
 		NSString RowIndexRangeAttribute { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityColumnIndexRangeAttribute")]
 		NSString ColumnIndexRangeAttribute { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityHorizontalUnitsAttribute")]
 		NSString HorizontalUnitsAttribute { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityVerticalUnitsAttribute")]
 		NSString VerticalUnitsAttribute { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityHorizontalUnitDescriptionAttribute")]
 		NSString HorizontalUnitDescriptionAttribute { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityVerticalUnitDescriptionAttribute")]
 		NSString VerticalUnitDescriptionAttribute { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityLayoutPointForScreenPointParameterizedAttribute")]
 		NSString LayoutPointForScreenPointParameterizedAttribute { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityLayoutSizeForScreenSizeParameterizedAttribute")]
 		NSString LayoutSizeForScreenSizeParameterizedAttribute { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityScreenPointForLayoutPointParameterizedAttribute")]
 		NSString ScreenPointForLayoutPointParameterizedAttribute { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityScreenSizeForLayoutSizeParameterizedAttribute")]
 		NSString ScreenSizeForLayoutSizeParameterizedAttribute { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityHandlesAttribute")]
 		NSString HandlesAttribute { get; }
 
@@ -24478,19 +24436,15 @@ namespace XamCore.AppKit {
 		[Field ("NSAccessibilityTimelineSubrole")]
 		NSString TimelineSubrole { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilitySortButtonSubrole")]
 		NSString SortButtonSubrole { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityRatingIndicatorSubrole")]
 		NSString RatingIndicatorSubrole { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityContentListSubrole")]
 		NSString ContentListSubrole { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityDefinitionListSubrole")]
 		NSString DefinitionListSubrole { get; }
 
@@ -24608,23 +24562,18 @@ namespace XamCore.AppKit {
 		[Field ("NSAccessibilitySelectedColumnsChangedNotification")]
 		NSString SelectedColumnsChangedNotification { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityRowExpandedNotification")]
 		NSString RowExpandedNotification { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityRowCollapsedNotification")]
 		NSString RowCollapsedNotification { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilitySelectedCellsChangedNotification")]
 		NSString SelectedCellsChangedNotification { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityUnitsChangedNotification")]
 		NSString UnitsChangedNotification { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilitySelectedChildrenMovedNotification")]
 		NSString SelectedChildrenMovedNotification { get; }
 
@@ -25115,7 +25064,6 @@ namespace XamCore.AppKit {
 	}
 #endif
 
-	[Mac (10,6)]
 	[BaseType (typeof(CAOpenGLLayer))]
 	interface NSOpenGLLayer
 	{

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -23982,7 +23982,6 @@ namespace XamCore.AppKit {
 		[Field ("NSAccessibilityMisspelledTextAttribute")]
 		NSString MisspelledTextAttribute { get; }
 
-		[Mac (10, 4)]
 		[Field ("NSAccessibilityMarkedMisspelledTextAttribute")]
 		NSString MarkedMisspelledTextAttribute { get; }	
 
@@ -24382,22 +24381,18 @@ namespace XamCore.AppKit {
 		[Field ("NSAccessibilityLinkRole")]
 		NSString LinkRole { get; }
 
-		[Mac (10, 5)]
 		[Field ("NSAccessibilityDisclosureTriangleRole")]
 		NSString DisclosureTriangleRole { get; }
 
-		[Mac (10, 5)]
 		[Field ("NSAccessibilityGridRole")]
 		NSString GridRole { get; }
 
 		[Field ("NSAccessibilityRelevanceIndicatorRole")]
 		NSString RelevanceIndicatorRole { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityLevelIndicatorRole")]
 		NSString LevelIndicatorRole { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityCellRole")]
 		NSString CellRole { get; }
 
@@ -24405,15 +24400,12 @@ namespace XamCore.AppKit {
 		[Field ("NSAccessibilityPopoverRole")]
 		NSString PopoverRole { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityLayoutAreaRole")]
 		NSString LayoutAreaRole { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityLayoutItemRole")]
 		NSString LayoutItemRole { get; }
 
-		[Mac (10, 6)]
 		[Field ("NSAccessibilityHandleRole")]
 		NSString HandleRole { get; }
 

--- a/src/assetslibrary.cs
+++ b/src/assetslibrary.cs
@@ -90,7 +90,6 @@ namespace XamCore.AssetsLibrary {
 		[Notification (typeof (ALAssetLibraryChangedEventArgs))]
 		NSString ChangedNotification { get; }
 
-		[iOS (5,0)]
 		[Export ("groupForURL:resultBlock:failureBlock:")]
 #if XAMCORE_2_0
 		void GroupForUrl (NSUrl groupURL, Action<ALAssetsGroup> resultBlock, Action<NSError> failureBlock);
@@ -98,7 +97,6 @@ namespace XamCore.AssetsLibrary {
 		void GroupForUrl (NSUrl groupURL, ALAssetsLibraryGroupResult resultBlock, ALAssetsLibraryAccessFailure failureBlock);
 #endif
 
-		[iOS (5,0)]
 		[Export ("addAssetsGroupAlbumWithName:resultBlock:failureBlock:")]
 #if XAMCORE_2_0
 		void AddAssetsGroupAlbum (string name, Action<ALAssetsGroup> resultBlock, Action<NSError> failureBlock);
@@ -193,19 +191,15 @@ namespace XamCore.AssetsLibrary {
 		[Field ("ALAssetTypeUnknown"), Internal]
 		NSString _TypeUnknown { get; }
 
-		[iOS (5,0)]
 		[Export ("originalAsset")]
 		ALAsset OriginalAsset { get;  }
 
-		[iOS (5,0)]
 		[Export ("editable")]
 		bool Editable { [Bind ("isEditable")] get;  }
 
-		[iOS (5,0)]
 		[Export ("aspectRatioThumbnail")]
 		CGImage AspectRatioThumbnail ();
 
-		[iOS (5,0)]
 		[Export ("writeModifiedImageDataToSavedPhotosAlbum:metadata:completionBlock:")]
 		[Async]
 #if XAMCORE_2_0
@@ -214,7 +208,6 @@ namespace XamCore.AssetsLibrary {
 		void WriteModifiedImageToSavedToPhotosAlbum (NSData imageData, NSDictionary metadata,  [NullAllowed] ALAssetsLibraryWriteCompletionDelegate completionBlock);
 #endif
 
-		[iOS (5,0)]
 		[Export ("writeModifiedVideoAtPathToSavedPhotosAlbum:completionBlock:")]
 		[Async]
 #if XAMCORE_2_0
@@ -223,7 +216,6 @@ namespace XamCore.AssetsLibrary {
 		void WriteModifiedVideoToSavedPhotosAlbum (NSUrl videoPathURL,  [NullAllowed] ALAssetsLibraryWriteCompletionDelegate completionBlock);
 #endif
 
-		[iOS (5,0)]
 		[Export ("setImageData:metadata:completionBlock:")]
 		[Async]
 #if XAMCORE_2_0
@@ -232,7 +224,6 @@ namespace XamCore.AssetsLibrary {
 		void SetImageData (NSData imageData, NSDictionary metadata,  [NullAllowed] ALAssetsLibraryWriteCompletionDelegate completionBlock);
 #endif
 
-		[iOS (5,0)]
 		[Export ("setVideoAtPath:completionBlock:")]
 		[Async]
 #if XAMCORE_2_0
@@ -278,11 +269,9 @@ namespace XamCore.AssetsLibrary {
 		[Export ("scale")]
 		float Scale { get; } /* float, not CGFloat */
 
-		[iOS (5,0)]
 		[Export ("filename")]
 		string Filename { get; }
 		
-		[iOS (5,1)]
 		[Export ("dimensions")]
 		CGSize Dimensions { get; }
 	}
@@ -304,11 +293,9 @@ namespace XamCore.AssetsLibrary {
 	delegate void ALAssetsEnumerator (ALAsset result, nint index, ref bool stop);
 
 #if !XAMCORE_2_0
-	[iOS (5,0)]
 	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use the 'Photos' API instead.")]
 	delegate void ALAssetsLibraryGroupResult (ALAssetsGroup group);
 
-	[iOS (5,0)]
 	[Availability (Deprecated = Platform.iOS_9_0, Message = "Use the 'Photos' API instead.")]
 	delegate void ALAssetsLibraryAccessFailure (NSError error);
 #endif
@@ -346,15 +333,12 @@ namespace XamCore.AssetsLibrary {
 		[Field ("ALAssetsGroupPropertyPersistentID"), Internal]
 		NSString _PersistentID { get; }
 
-		[iOS (5,0)]
 		[Export ("editable")]
 		bool Editable { [Bind ("isEditable")] get;  }
 
-		[iOS (5,0)]
 		[Export ("addAsset:")]
 		bool AddAsset (ALAsset asset);
 
-		[iOS (5,0)]
 		[Field ("ALAssetsGroupPropertyURL"), Internal]
 		NSString _PropertyUrl { get; }
 	}

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -8596,7 +8596,7 @@ namespace XamCore.AVFoundation {
 		[Internal]
 		IntPtr InitWithConnection (AVCaptureSession session);
 
-		[iOS (8,0), Mac (10,2)]
+		[iOS (8,0), Mac (10,7)]
 		[Internal]
 		[Export ("initWithSessionWithNoConnection:")]
 		IntPtr InitWithNoConnection (AVCaptureSession session);
@@ -11481,7 +11481,7 @@ namespace XamCore.AVFoundation {
 		[Notification]
 		NSString FailedToDecodeNotification { get; }
 
-		[iOS (8, 0), Mac (10,0)]
+		[iOS (8, 0), Mac (10,10)]
 		[Field ("AVSampleBufferDisplayLayerFailedToDecodeNotificationErrorKey")]
 		NSString FailedToDecodeNotificationErrorKey { get; }
 	}

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -185,7 +185,6 @@ namespace XamCore.AVFoundation {
 #if !XAMCORE_4_0
 	[Obsolete ("Use AVMediaTypes enum values")]
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))][Static]
 	interface AVMediaType {
 		[Field ("AVMediaTypeVideo")]
@@ -326,27 +325,27 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMediaCharacteristicUsesWideGamutColorSpace")]
 		UsesWideGamutColorSpace = 4,
 
-		[Mac (10, 8), iOS (5,0)]
+		[Mac (10, 8)]
 		[Field ("AVMediaCharacteristicIsMainProgramContent")]
 		IsMainProgramContent = 5,
 
-		[Mac (10, 8)][iOS (5,0)]
+		[Mac (10, 8)]
 		[Field ("AVMediaCharacteristicIsAuxiliaryContent")]
 		IsAuxiliaryContent = 6,
 
-		[Mac (10, 8)][iOS (5,0)]
+		[Mac (10, 8)]
 		[Field ("AVMediaCharacteristicContainsOnlyForcedSubtitles")]
 		ContainsOnlyForcedSubtitles = 7,
 
-		[Mac (10, 8)][iOS (5,0)]
+		[Mac (10, 8)]
 		[Field ("AVMediaCharacteristicTranscribesSpokenDialogForAccessibility")]
 		TranscribesSpokenDialogForAccessibility = 8,
 
-		[Mac (10, 8)][iOS (5,0)]
+		[Mac (10, 8)]
 		[Field ("AVMediaCharacteristicDescribesMusicAndSoundForAccessibility")]
 		DescribesMusicAndSoundForAccessibility = 9,
 
-		[Mac (10, 8)][iOS (5,0)]
+		[Mac (10, 8)]
 		[Field ("AVMediaCharacteristicDescribesVideoForAccessibility")]
 		DescribesVideoForAccessibility = 10,
 
@@ -371,7 +370,6 @@ namespace XamCore.AVFoundation {
 #if !XAMCORE_4_0
 	[Obsolete ("Use AVMediaCharacteristics enum values")]
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))][Static]
 	interface AVMediaCharacteristic {
 		[Field ("AVMediaCharacteristicVisual")]
@@ -390,27 +388,27 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMediaCharacteristicUsesWideGamutColorSpace")]
 		NSString UsesWideGamutColorSpace { get; }
 
-		[Mac (10, 8)][iOS (5,0)]
+		[Mac (10, 8)]
 		[Field ("AVMediaCharacteristicIsMainProgramContent")]
 		NSString IsMainProgramContent { get; }
 
-		[Mac (10, 8)][iOS (5,0)]
+		[Mac (10, 8)]
 		[Field ("AVMediaCharacteristicIsAuxiliaryContent")]
 		NSString IsAuxiliaryContent { get; }
 
-		[Mac (10, 8)][iOS (5,0)]
+		[Mac (10, 8)]
 		[Field ("AVMediaCharacteristicContainsOnlyForcedSubtitles")]
 		NSString ContainsOnlyForcedSubtitles { get; }
 
-		[Mac (10, 8)][iOS (5,0)]
+		[Mac (10, 8)]
 		[Field ("AVMediaCharacteristicTranscribesSpokenDialogForAccessibility")]
 		NSString TranscribesSpokenDialogForAccessibility { get; }
 
-		[Mac (10, 8)][iOS (5,0)]
+		[Mac (10, 8)]
 		[Field ("AVMediaCharacteristicDescribesMusicAndSoundForAccessibility")]
 		NSString DescribesMusicAndSoundForAccessibility { get; }
 
-		[Mac (10, 8)][iOS (5,0)]
+		[Mac (10, 8)]
 		[Field ("AVMediaCharacteristicDescribesVideoForAccessibility")]
 		NSString DescribesVideoForAccessibility { get;  }
 #if !MONOMAC
@@ -537,7 +535,6 @@ namespace XamCore.AVFoundation {
 
 #if !XAMCORE_4_0
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))][Static]
 	[Obsolete ("Use AVFileTypes enum values")]
 	interface AVFileType {
@@ -626,7 +623,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))][Static]
 	interface AVVideo {
 		[Field ("AVVideoCodecKey")]
@@ -671,7 +667,6 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoH264EntropyModeKey")]
 		NSString H264EntropyModeKey { get; }
 
-		[iOS (4, 0)]
 		[Mac (10, 7)]
 		[TV (9, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'AVVideoCodecType' enum instead.")]
@@ -680,7 +675,6 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoCodecH264")]
 		NSString CodecH264 { get; }
 		
-		[iOS (4, 0)]
 		[Mac (10, 7)]
 		[TV (9, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'AVVideoCodecType' enum instead.")]
@@ -708,7 +702,6 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoHeightKey")]
 		NSString HeightKey { get; }
 
-		[iOS (5,0)]
 		[Field ("AVVideoScalingModeKey")]
 		NSString ScalingModeKey { get; }
 		
@@ -724,7 +717,6 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoProfileLevelKey")]
 		NSString ProfileLevelKey { get; }
 
-		[iOS (5,0)]
 		[Field ("AVVideoQualityKey")]
 		NSString QualityKey { get; }
 		
@@ -740,15 +732,13 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoProfileLevelH264Main31")]
 		NSString ProfileLevelH264Main31 { get; }
 
-		[iOS (5,0)]
 		[Field ("AVVideoProfileLevelH264Baseline41")]
 		NSString ProfileLevelH264Baseline41 { get; }
 
-		[iOS (5,0)][Mac (10, 8)]
+		[Mac (10, 8)]
 		[Field ("AVVideoProfileLevelH264Main32")]
 		NSString ProfileLevelH264Main32 { get; }
 
-		[iOS (5,0)]
 		[Field ("AVVideoProfileLevelH264Main41")]
 		NSString ProfileLevelH264Main41 { get; }
 
@@ -799,7 +789,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (5,0)]
 	[Static]
 	interface AVVideoScalingModeKey
 	{
@@ -1500,30 +1489,24 @@ namespace XamCore.AVFoundation {
 		[Export ("averagePowerForChannel:")]
 		float AveragePower (nuint channelNumber); // defined as 'float'
 
-		[iOS (4,0)]
 		[Export ("deviceCurrentTime")]
 		double DeviceCurrentTime { get;  }
 
-		[iOS (4,0)]
 		[Export ("pan")]
 		float Pan { get; set; } // defined as 'float'
 
-		[iOS (4,0)]
 		[Export ("playAtTime:")]
 		bool PlayAtTime (double time);
 
-		[iOS (4,0)]
 		[Export ("settings")][Protected]
 		NSDictionary WeakSettings { get;  }
 
 		[Wrap ("WeakSettings")]
 		AudioSettings SoundSetting { get; }
 
-		[iOS (5,0)]
 		[Export ("enableRate")]
 		bool EnableRate { get; set; }
 
-		[iOS (5,0)]
 		[Export ("rate")]
 		float Rate { get; set; } // defined as 'float'		
 #if !MONOMAC
@@ -1565,7 +1548,6 @@ namespace XamCore.AVFoundation {
 
 		// Deprecated in iOS 6.0 but we have same C# signature
 		[NoTV]
-		[iOS (4,0)]
 		[Export ("audioPlayerEndInterruption:withFlags:")]
 		void EndInterruption (AVAudioPlayer player, AVAudioSessionInterruptionFlags flags);
 
@@ -1761,7 +1743,6 @@ namespace XamCore.AVFoundation {
 
 		// Deprecated in iOS 6.0 but we have same C# signature as a method that was deprecated in iOS 8.0
 		[Availability (Deprecated = Platform.iOS_8_0)]
-		[iOS (4,0)]
 		[Export ("audioRecorderEndInterruption:withFlags:")]
 		void EndInterruption (AVAudioRecorder recorder, AVAudioSessionInterruptionFlags flags);
 
@@ -1827,11 +1808,9 @@ namespace XamCore.AVFoundation {
 		[Export ("category")]
 		NSString Category { get;  }
 
-		[iOS (5,0)]
 		[Export ("mode")]
 		NSString Mode { get; }
 
-		[iOS (5,0)]
 		[Export ("setMode:error:")]
 		bool SetMode (NSString mode, out NSError error);
 	
@@ -1884,23 +1863,18 @@ namespace XamCore.AVFoundation {
 		[Field ("AVAudioSessionCategoryAudioProcessing")]
 		NSString CategoryAudioProcessing { get; }
 
-		[iOS (5,0)]
 		[Field ("AVAudioSessionModeDefault")]
 		NSString ModeDefault { get; }
 
-		[iOS (5,0)]
 		[Field ("AVAudioSessionModeVoiceChat")]
 		NSString ModeVoiceChat { get; }
 
-		[iOS (5,0)]
 		[Field ("AVAudioSessionModeVideoRecording")]
 		NSString ModeVideoRecording { get; }
 
-		[iOS (5,0)]
 		[Field ("AVAudioSessionModeMeasurement")]
 		NSString ModeMeasurement { get; }
 
-		[iOS (5,0)]
 		[Field ("AVAudioSessionModeGameChat")]
 		NSString ModeGameChat { get; }
 
@@ -2317,7 +2291,6 @@ namespace XamCore.AVFoundation {
 		[Export ("inputIsAvailableChanged:")]
 		void InputIsAvailableChanged (bool isInputAvailable);
 	
-		[iOS (4,0)]
 		[Export ("endInterruptionWithFlags:")]
 		void EndInterruption (AVAudioSessionInterruptionFlags flags);
 	}
@@ -2807,7 +2780,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** initialization method -init cannot be sent to an abstract object of class AVAsset: Create a concrete instance!
 	[DisableDefaultCtor]
@@ -2825,7 +2797,6 @@ namespace XamCore.AVFoundation {
 		CGAffineTransform PreferredTransform { get;  }
 
 		[Export ("naturalSize")]
-		[iOS (4, 0)]
 		[Deprecated (PlatformName.iOS, 5, 0, message : "Use 'NaturalSize/PreferredTransform' as appropriate on the video track instead.")]
 		[Mac (10, 7)]
 		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Use 'NaturalSize/PreferredTransform' as appropriate on the video track instead.")]
@@ -2880,60 +2851,47 @@ namespace XamCore.AVFoundation {
 		[Wrap ("GetMetadataForFormat (new NSString (format.GetConstant ()))")]
 		AVMetadataItem [] GetMetadataForFormat (AVMetadataFormat format);
 
-		[iOS (4,2)]
 		[Export ("hasProtectedContent")]
 		bool ProtectedContent { get; }
 
-		[iOS (4,3)]
 		[Export ("availableChapterLocales")]
 		NSLocale [] AvailableChapterLocales { get; }
 
-		[iOS (4,3)]
 		[Export ("chapterMetadataGroupsWithTitleLocale:containingItemsWithCommonKeys:")]
 		AVTimedMetadataGroup [] GetChapterMetadataGroups (NSLocale forLocale, [NullAllowed] AVMetadataItem [] commonKeys);
 
-		[iOS (4,3)]
 		[Export ("isPlayable")]
 		bool Playable { get; }
 
-		[iOS (4,3)]
 		[Export ("isExportable")]
 		bool Exportable { get; }
 
-		[iOS (4,3)]
 		[Export ("isReadable")]
 		bool Readable { get; }
 
-		[iOS (4,3)]
 		[Export ("isComposable")]
 		bool Composable { get; }
 
 		// 5.0 APIs:
-		[iOS (5,0)]
 		[Static, Export ("assetWithURL:")]
 		AVAsset FromUrl (NSUrl url);
 
-		[iOS (5, 0)]
 		[Mac (10,8)]
 		[Export ("availableMediaCharacteristicsWithMediaSelectionOptions")]
 		string [] AvailableMediaCharacteristicsWithMediaSelectionOptions { get; }
 
 #if !MONOMAC
-		[iOS (5,0)]
 		[Export ("compatibleWithSavedPhotosAlbum")]
 		bool CompatibleWithSavedPhotosAlbum  { [Bind ("isCompatibleWithSavedPhotosAlbum")] get; }
 #endif
 
-		[iOS (5, 0)]
 		[Mac (10,8)]
 		[Export ("creationDate"), NullAllowed]
 		AVMetadataItem CreationDate { get; }
 
-		[iOS (5,0)]
 		[Export ("referenceRestrictions")]
 		AVAssetReferenceRestrictions ReferenceRestrictions { get; }
 
-		[iOS (5,0)]
 		[Mac (10,8)]
 		[return: NullAllowed]
 		[Export ("mediaSelectionGroupForMediaCharacteristic:")]
@@ -3442,11 +3400,9 @@ namespace XamCore.AVFoundation {
 		NSString ApertureModeEncodedPixels { get; }
 
 		// 5.0 APIs
-		[iOS (5,0)]
 		[Export ("requestedTimeToleranceBefore", ArgumentSemantic.Assign)]
 		CMTime RequestedTimeToleranceBefore { get; set;  }
 
-		[iOS (5,0)]
 		[Export ("requestedTimeToleranceAfter", ArgumentSemantic.Assign)]
 		CMTime RequestedTimeToleranceAfter { get; set;  }
 
@@ -3463,7 +3419,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,1)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[AVAssetReader initWithAsset:error:] invalid parameter not satisfying: asset != ((void*)0)
 	[DisableDefaultCtor]
@@ -3505,7 +3460,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,1)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** initialization method -init cannot be sent to an abstract object of class AVAssetReaderOutput: Create a concrete instance!
 	[DisableDefaultCtor]
@@ -3517,7 +3471,6 @@ namespace XamCore.AVFoundation {
 		[Export ("copyNextSampleBuffer")]
 		CMSampleBuffer CopyNextSampleBuffer ();
 
-		[iOS (5,0)]
 		[Export ("alwaysCopiesSampleData")]
 		bool AlwaysCopiesSampleData { get; set; }
 
@@ -3573,7 +3526,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,1)]
 	[BaseType (typeof (AVAssetReaderOutput))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[AVAssetReaderTrackOutput initWithTrack:outputSettings:] invalid parameter not satisfying: track != ((void*)0)
 	[DisableDefaultCtor]
@@ -3615,7 +3567,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,1)]
 	[BaseType (typeof (AVAssetReaderOutput))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[AVAssetReaderAudioMixOutput initWithAudioTracks:audioSettings:] invalid parameter not satisfying: audioTracks != ((void*)0)
 	[DisableDefaultCtor]
@@ -3661,7 +3612,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,1)]
 	[BaseType (typeof (AVAssetReaderOutput))]
 	// crash application if 'init' is called
 	[DisableDefaultCtor]
@@ -3872,7 +3822,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,1)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[AVAssetWriter initWithURL:fileType:error:] invalid parameter not satisfying: outputURL != ((void*)0)
 	[DisableDefaultCtor]
@@ -3976,7 +3925,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,1), Mac (10, 7)]
+	[Mac (10, 7)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[AVAssetWriterInput initWithMediaType:outputSettings:] invalid parameter not satisfying: mediaType != ((void*)0)
 	[DisableDefaultCtor]
@@ -4190,7 +4139,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,1)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** -[AVAssetWriterInputPixelBufferAdaptor initWithAssetWriterInput:sourcePixelBufferAttributes:] invalid parameter not satisfying: input != ((void*)0)
 	[DisableDefaultCtor]
@@ -4240,7 +4188,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (AVAsset), Name="AVURLAsset")]
 	// 'init' returns NIL
 	[DisableDefaultCtor]
@@ -4285,19 +4232,15 @@ namespace XamCore.AVFoundation {
 		[Field ("AVURLAssetPreferPreciseDurationAndTimingKey")]
 		NSString PreferPreciseDurationAndTimingKey { get; }
 
-		[iOS (5,0)]
 		[Field ("AVURLAssetReferenceRestrictionsKey")]
 		NSString ReferenceRestrictionsKey { get; }
 
-		[iOS (5,0)]
 		[Static, Export ("audiovisualMIMETypes")]
 		string [] AudiovisualMimeTypes { get; }
 
-		[iOS (5,0)]
 		[Static, Export ("audiovisualTypes")]
 		string [] AudiovisualTypes { get; }
 
-		[iOS (5,0)]
 		[Static, Export ("isPlayableExtendedMIMEType:")]
 		bool IsPlayable (string extendedMimeType);
 
@@ -4403,7 +4346,6 @@ namespace XamCore.AVFoundation {
 		[Export ("metadataForFormat:")]
 		AVMetadataItem [] MetadataForFormat (string format);
 
-		[iOS (5,0)]
 		[Export ("isPlayable")]
 		bool Playable { get; }
 
@@ -4562,7 +4504,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (5,0), Mac (10, 8)]
+	[Mac (10, 8)]
 	[BaseType (typeof (NSObject))]
 	interface AVMediaSelectionGroup : NSCopying {
 		[Export ("options")]
@@ -4605,7 +4547,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (5,0), Mac (10, 8)]
+	[Mac (10, 8)]
 	[BaseType (typeof (NSObject))]
 	interface AVMediaSelectionOption : NSCopying {
 		[Export ("mediaType")]
@@ -4847,7 +4789,7 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMetadataQuickTimeUserDataKeyPhonogramRights")]
 		NSString QuickTimeUserDataKeyPhonogramRights { get; }
 
-		[Mac (10, 8)][iOS (5,0)]
+		[Mac (10, 8)]
 		[Field ("AVMetadataQuickTimeUserDataKeyTaggedCharacteristic")]
 		NSString QuickTimeUserDataKeyTaggedCharacteristic { get; }
 		
@@ -5227,7 +5169,6 @@ namespace XamCore.AVFoundation {
 		[Field ("AVMetadataID3MetadataKeyCommercial")]
 		NSString ID3MetadataKeyCommercial { get; }
 
-		[iOS (4, 0)]
 		[Deprecated (PlatformName.iOS, 9, 0)]
 		[Mac (10, 7)]
 		[Deprecated (PlatformName.MacOSX, 10, 11)]
@@ -6400,7 +6341,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)][Mac (10,7)]
+	[Mac (10,7)]
 	[BaseType (typeof (NSObject))]
 	interface AVMetadataItem : NSMutableCopying {
 		[Export ("commonKey", ArgumentSemantic.Copy), NullAllowed]
@@ -6450,7 +6391,6 @@ namespace XamCore.AVFoundation {
 		AVMetadataItem [] FilterWithItemFilter (AVMetadataItem [] metadataItems, AVMetadataItemFilter metadataItemFilter);
 #endif
 
-		[iOS (4,2)]
 		[Export ("duration")]
 		CMTime Duration { get; [NotImplemented] set; }
 
@@ -7143,7 +7083,6 @@ namespace XamCore.AVFoundation {
 #endif
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (AVMetadataItem))]
 	interface AVMutableMetadataItem {
 		[NullAllowed] // by default this property is null
@@ -7154,7 +7093,6 @@ namespace XamCore.AVFoundation {
 		[Export ("metadataItem"), Static]
 		AVMutableMetadataItem Create ();
 
-		[iOS (4,2)]
 		[Export ("duration")]
 		[Override]
 		CMTime Duration { get; set; }
@@ -7207,7 +7145,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (AVAssetTrack))]
 	// 'init' returns NIL
 	[DisableDefaultCtor]
@@ -7217,7 +7154,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (AVCompositionTrack))]
 	// 'init' returns NIL
 	[DisableDefaultCtor]
@@ -7262,7 +7198,6 @@ namespace XamCore.AVFoundation {
 		float PreferredVolume { get; set; } // defined as 'float'
 
 		// 5.0
-		[iOS (5,0)]
 		[Export ("insertTimeRanges:ofTracks:atTime:error:")]
 		bool InsertTimeRanges (NSValue[] cmTimeRanges, AVAssetTrack [] tracks, CMTime startTime, out NSError error);
 	}
@@ -7317,7 +7252,6 @@ namespace XamCore.AVFoundation {
 	}
 	
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVAssetTrackSegment {
 		[Export ("empty")]
@@ -7329,7 +7263,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (AVAsset))]
 	interface AVComposition : NSMutableCopying {
 		[Export ("tracks")]
@@ -7369,7 +7302,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (AVComposition))]
 	interface AVMutableComposition {
 		
@@ -7431,7 +7363,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (AVAssetTrackSegment))]
 	interface AVCompositionTrackSegment {
 		[Export ("sourceURL"), NullAllowed]
@@ -7461,7 +7392,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	// 'init' returns NIL
 	[DisableDefaultCtor]
@@ -7591,11 +7521,9 @@ namespace XamCore.AVFoundation {
 		NSString PresetPassthrough { get; }
 
 		// 5.0 APIs
-		[iOS (5,0)]
 		[Export ("asset", ArgumentSemantic.Retain)]
 		AVAsset Asset { get; }
 
-		[iOS (5,0)]
 		[Export ("estimatedOutputFileLength")]
 		long EstimatedOutputFileLength { get; }
 
@@ -7664,14 +7592,12 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
-	[iOS (4,0)]
 	interface AVAudioMix : NSMutableCopying {
 		[Export ("inputParameters", ArgumentSemantic.Copy)]
 		AVAudioMixInputParameters [] InputParameters { get;  }
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (AVAudioMix))]
 	interface AVMutableAudioMix {
 		[NullAllowed] // by default this property is null
@@ -7683,7 +7609,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVAudioMixInputParameters : NSMutableCopying {
 		[Export ("trackID")]
@@ -7767,7 +7692,6 @@ namespace XamCore.AVFoundation {
 	}
 	
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVVideoComposition : NSMutableCopying {
 		[Export ("frameDuration")]
@@ -7785,7 +7709,6 @@ namespace XamCore.AVFoundation {
 		[Export ("renderScale")]
 		float RenderScale { get; [NotImplemented] set; } // defined as 'float'
 #endif
-		[iOS (5,0)]
 		[Export ("isValidForAsset:timeRange:validationDelegate:")]
 		bool IsValidForAsset ([NullAllowed] AVAsset asset, CMTimeRange timeRange, [Protocolize] [NullAllowed] AVVideoCompositionValidationHandling validationDelegate);
 
@@ -7846,7 +7769,6 @@ namespace XamCore.AVFoundation {
 	}
 	
 	[NoWatch]
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -7866,7 +7788,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (AVVideoComposition))]
 	interface AVMutableVideoComposition {
 		[Export ("frameDuration", ArgumentSemantic.Assign)]
@@ -7923,7 +7844,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0), Mac (10, 7)]
+	[Mac (10, 7)]
 	[BaseType (typeof (NSObject))]
 	interface AVVideoCompositionInstruction : NSSecureCoding, NSMutableCopying {
 		[Export ("timeRange")]
@@ -7957,7 +7878,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (AVVideoCompositionInstruction))]
 	interface AVMutableVideoCompositionInstruction {
 		[Export ("timeRange", ArgumentSemantic.Assign)]
@@ -7983,7 +7903,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0), Mac (10, 7)]
+	[Mac (10, 7)]
 	[BaseType (typeof (NSObject))]
 	interface AVVideoCompositionLayerInstruction : NSSecureCoding, NSMutableCopying {
 		[Export ("trackID", ArgumentSemantic.Assign)]
@@ -8000,7 +7920,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (AVVideoCompositionLayerInstruction))]
 	interface AVMutableVideoCompositionLayerInstruction {
 		[Export ("trackID", ArgumentSemantic.Assign)]
@@ -8036,7 +7955,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVVideoCompositionCoreAnimationTool {
 		[Static]
@@ -8087,7 +8005,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVCaptureSession {
 
@@ -8154,11 +8071,9 @@ namespace XamCore.AVFoundation {
 		[Field ("AVCaptureSessionPreset640x480")]
 		NSString Preset640x480 { get; }
 		
-		[iOS (4,0)]
 		[Field ("AVCaptureSessionPreset1280x720")]
 		NSString Preset1280x720 { get; }
 #if !MONOMAC
-		[iOS (5,0)]
 		[Field ("AVCaptureSessionPreset1920x1080")]
 		NSString Preset1920x1080 { get; }
 
@@ -8167,15 +8082,12 @@ namespace XamCore.AVFoundation {
 		NSString Preset3840x2160 { get; }
 #endif
 
-		[iOS (5,0)]
 		[Field ("AVCaptureSessionPresetiFrame960x540")]
 		NSString PresetiFrame960x540 { get; }
 
-		[iOS (5,0)]
 		[Field ("AVCaptureSessionPresetiFrame1280x720")]
 		NSString PresetiFrame1280x720 { get; }
 
-		[iOS (5,0)]
 		[Field ("AVCaptureSessionPreset352x288")]
 		NSString Preset352x288 { get; }
 
@@ -8269,7 +8181,6 @@ namespace XamCore.AVFoundation {
 	[NoWatch]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	[iOS (4,0)]
 	interface AVCaptureConnection {
 		
 		[iOS (8,0), Mac (10,7)]
@@ -8317,31 +8228,25 @@ namespace XamCore.AVFoundation {
 		[Export ("isVideoOrientationSupported")]
 		bool SupportsVideoOrientation { get; }
 
-		[iOS (5,0)]
 		[Export ("supportsVideoMinFrameDuration"), Internal]
 		bool _SupportsVideoMinFrameDuration { [Bind ("isVideoMinFrameDurationSupported")] get;  }
 
-		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0 /* Only deprecated on iOS */)]
 		[Mac (10, 7)]
 		[Export ("videoMinFrameDuration")]
 		CMTime VideoMinFrameDuration { get; set;  }
 #if !MONOMAC
-		[iOS (5,0)]
 		[Export ("supportsVideoMaxFrameDuration"), Internal]
 		bool _SupportsVideoMaxFrameDuration { [Bind ("isVideoMaxFrameDurationSupported")] get;  }
 
 		[Export ("videoMaxFrameDuration")]
-		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0 /* Only deprecated on iOS */)] 
 		[Mac (10, 7)] 
 		CMTime VideoMaxFrameDuration { get; set;  }
 
-		[iOS (5,0)]
 		[Export ("videoMaxScaleAndCropFactor")]
 		nfloat VideoMaxScaleAndCropFactor { get;  }
 
-		[iOS (5,0)]
 		[Export ("videoScaleAndCropFactor")]
 		nfloat VideoScaleAndCropFactor { get; set;  }
 #endif
@@ -8397,7 +8302,6 @@ namespace XamCore.AVFoundation {
 	[NoWatch]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	[iOS (4,0)]
 	interface AVCaptureAudioChannel {
 		[Export ("peakHoldLevel")]
 		float PeakHoldLevel { get;  } // defined as 'float'
@@ -8417,7 +8321,6 @@ namespace XamCore.AVFoundation {
 	[NoWatch]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	[iOS (4,0)]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: Cannot instantiate AVCaptureInput because it is an abstract superclass.
 	[DisableDefaultCtor]
 	interface AVCaptureInput {
@@ -8431,7 +8334,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface AVCaptureInputPort {
@@ -8490,7 +8392,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[iOS (4,0)]
 	[BaseType (typeof (AVCaptureInput))]
 	// crash application if 'init' is called
 	[DisableDefaultCtor]
@@ -8584,7 +8485,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 #if XAMCORE_4_0
 	[Abstract] // as per docs
@@ -8595,7 +8495,6 @@ namespace XamCore.AVFoundation {
 		[Export ("connections")]
 		AVCaptureConnection [] Connections { get; }
 
-		[iOS (5,0)]
 		[Export ("connectionWithMediaType:")]
 		AVCaptureConnection ConnectionFromMediaType (NSString avMediaType);
 
@@ -8648,7 +8547,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[iOS (4,0)]
 	[BaseType (typeof (CALayer))]
 	interface AVCaptureVideoPreviewLayer {
 		[NullAllowed] // by default this property is null
@@ -8734,7 +8632,6 @@ namespace XamCore.AVFoundation {
 
 	[NoTV]
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (AVCaptureOutput))]
 	interface AVCaptureVideoDataOutput {
 		[Export ("sampleBufferDelegate")]
@@ -8808,7 +8705,6 @@ namespace XamCore.AVFoundation {
 	[NoWatch]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	[iOS (4,0)]
 	[Model]
 	[Protocol]
 	interface AVCaptureVideoDataOutputSampleBufferDelegate {
@@ -8825,7 +8721,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[iOS (4,0)]
 	[BaseType (typeof (AVCaptureOutput))]
 	interface AVCaptureAudioDataOutput {
 		[Export ("sampleBufferDelegate")]
@@ -8869,7 +8764,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[NoTV]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -8925,7 +8819,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[BaseType (typeof (AVCaptureOutput))]
-	[iOS (4,0)]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: Cannot instantiate AVCaptureFileOutput because it is an abstract superclass.
 	[DisableDefaultCtor]
 	[NoTV]
@@ -8970,7 +8863,6 @@ namespace XamCore.AVFoundation {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[iOS (4, 0)]
 	[Protocol]
 	[NoTV]
 	[NoWatch]
@@ -9377,7 +9269,6 @@ namespace XamCore.AVFoundation {
 	}
 #endif
 	
-	[iOS (4,0)]
 	[BaseType (typeof (AVCaptureFileOutput))]
 	[NoTV]
 	[NoWatch]
@@ -9414,7 +9305,6 @@ namespace XamCore.AVFoundation {
 
 	[NoTV]
 	[NoWatch]
-	[iOS (4,0)]
 	[Availability (Deprecated = Platform.iOS_10_0, Message = "Use 'AVCapturePhotoOutput' instead.")]
 	[BaseType (typeof (AVCaptureOutput))]
 	interface AVCaptureStillImageOutput {
@@ -9532,7 +9422,6 @@ namespace XamCore.AVFoundation {
 	[NoWatch]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	[iOS (4,0)]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: Cannot instantiate a AVCaptureDevice directly.
 	[DisableDefaultCtor]
 	interface AVCaptureDevice {
@@ -9668,20 +9557,16 @@ namespace XamCore.AVFoundation {
 		[Export ("subjectAreaChangeMonitoringEnabled")]
 		bool SubjectAreaChangeMonitoringEnabled { [Bind ("isSubjectAreaChangeMonitoringEnabled")] get; set; }
 		
-		[iOS (5,0)]
 		[Export ("isFlashAvailable")]
 		bool FlashAvailable { get;  }
 
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_10_0, Message="Use 'AVCapturePhotoOutput.IsFlashScene' instead.")]
-		[iOS (5,0)]
+		[Availability (Deprecated = Platform.iOS_10_0, Message="Use 'AVCapturePhotoOutput.IsFlashScene' instead.")]
 		[Export ("isFlashActive")]
 		bool FlashActive { get; }
 
-		[iOS (5,0)]
 		[Export ("isTorchAvailable")]
 		bool TorchAvailable { get; }
 
-		[iOS (5,0)]
 		[Export ("torchLevel")]
 		float TorchLevel { get; } // defined as 'float'
 
@@ -10135,7 +10020,6 @@ namespace XamCore.AVFoundation {
 	delegate void AVCaptureCompletionHandler (CMSampleBuffer imageDataSampleBuffer, NSError error);
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVPlayer {
 		[Export ("currentItem"), NullAllowed]
@@ -10228,12 +10112,10 @@ namespace XamCore.AVFoundation {
 		bool UsesAirPlayVideoWhileAirPlayScreenIsActive { get; set;  }
 #endif
 
-		[iOS (5,0)]
 		[Export ("seekToTime:completionHandler:")]
 		[Async]
 		void Seek (CMTime time, AVCompletion completion);
 
-		[iOS (5,0)]
 		[Export ("seekToTime:toleranceBefore:toleranceAfter:completionHandler:")]
 		[Async]
 		void Seek (CMTime time, CMTime toleranceBefore, CMTime toleranceAfter, AVCompletion completion);
@@ -10438,7 +10320,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[BaseType (typeof (AVMetadataGroup))]
-	[iOS (4,3)]
 	interface AVTimedMetadataGroup : NSMutableCopying {
 		[Export ("timeRange")]
 		CMTimeRange TimeRange { get; [NotImplemented] set; }
@@ -10482,7 +10363,6 @@ namespace XamCore.AVFoundation {
 	}
 		
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	// 'init' returns NIL
 	[DisableDefaultCtor]
@@ -10572,64 +10452,52 @@ namespace XamCore.AVFoundation {
 		[Notification]
 		NSString DidPlayToEndTimeNotification { get; }
 
-		[iOS (4,3)]
 		[Field ("AVPlayerItemFailedToPlayToEndTimeNotification")]
 		[Notification (typeof (AVPlayerItemErrorEventArgs))]
 		NSString ItemFailedToPlayToEndTimeNotification { get; }
 
-		[iOS (4,3)]
 		[Field ("AVPlayerItemFailedToPlayToEndTimeErrorKey")]
 		NSString ItemFailedToPlayToEndTimeErrorKey { get; }
 
-		[iOS (4,3)]
 		[Export ("accessLog"), NullAllowed]
 		AVPlayerItemAccessLog AccessLog { get; }
 
-		[iOS (4,3)]
 		[Export ("errorLog"), NullAllowed]
 		AVPlayerItemErrorLog ErrorLog { get; }
 
-		[iOS (4,3)]
 		[Export ("currentDate"), NullAllowed]
 		NSDate CurrentDate { get; }
 
-		[iOS (4,3)]
 		[Export ("duration")]
 		CMTime Duration { get; }
 
-		[iOS (5,0)]
 		[Export ("canPlayFastReverse")]
 		bool CanPlayFastReverse { get;  }
 
-		[iOS (5,0)]
 		[Export ("canPlayFastForward")]
 		bool CanPlayFastForward { get; }
 
-		[iOS (5,0)]
 		[Field ("AVPlayerItemTimeJumpedNotification")]
 		[Notification]
 		NSString TimeJumpedNotification { get; }
 
-		[iOS (5,0)]
 		[Export ("seekToTime:completionHandler:")]
 		[Async]
 		void Seek (CMTime time, AVCompletion completion);
 
-		[iOS (5,0)]
 		[Export ("cancelPendingSeeks")]
 		void CancelPendingSeeks ();
 
-		[iOS (5,0)]
 		[Export ("seekToTime:toleranceBefore:toleranceAfter:completionHandler:")]
 		[Async]
 		void Seek (CMTime time, CMTime toleranceBefore, CMTime toleranceAfter, AVCompletion completion);
 
-		[iOS (5,0), Mac (10, 8)]
+		[Mac (10, 8)]
 		[Export ("selectMediaOption:inMediaSelectionGroup:")]
 		void SelectMediaOption ([NullAllowed] AVMediaSelectionOption mediaSelectionOption, AVMediaSelectionGroup mediaSelectionGroup);
 
 		[return: NullAllowed]
-		[iOS (5,0), Mac (10, 8)]
+		[Mac (10, 8)]
 		[Export ("selectedMediaOptionInMediaSelectionGroup:")]
 		AVMediaSelectionOption SelectedMediaOption (AVMediaSelectionGroup inMediaSelectionGroup);
 
@@ -11025,7 +10893,6 @@ namespace XamCore.AVFoundation {
 		[Field ("AVVideoCodecKey")]
 		NSString CodecKey { get; }
 		
-		[iOS (5,0)]
 		[Field ("AVVideoScalingModeKey")]
 		NSString ScalingModeKey { get; }
 		
@@ -11149,7 +11016,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
-	[iOS (4,3)]
 	interface AVPlayerItemAccessLog : NSCopying {
 		
 		[Export ("events")]
@@ -11164,7 +11030,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
-	[iOS (4,3)]
 	interface AVPlayerItemErrorLog : NSCopying {
 		[Export ("events")]
 		AVPlayerItemErrorLogEvent [] Events { get; }
@@ -11178,9 +11043,7 @@ namespace XamCore.AVFoundation {
 	
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
-	[iOS (4,3)]
 	interface AVPlayerItemAccessLogEvent : NSCopying {
-		[iOS (4, 3)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'NumberOfMediaRequests' instead.")]
 		[Mac (10, 7)]
 		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use 'NumberOfMediaRequests' instead.")]
@@ -11283,7 +11146,6 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
-	[iOS (4,3)]
 	interface AVPlayerItemErrorLogEvent : NSCopying {
 		[Export ("date"), NullAllowed]
 		NSDate Date { get; }
@@ -11346,7 +11208,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (CALayer))]
 	interface AVPlayerLayer {
 		[NullAllowed] // by default this property is null
@@ -11424,7 +11285,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	interface AVPlayerItemTrack {
 		[Export ("enabled", ArgumentSemantic.Assign)]
@@ -11451,7 +11311,6 @@ namespace XamCore.AVFoundation {
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[iOS (4,0)]
 	[Protocol]
 	interface AVAsynchronousKeyValueLoading {
 		[Abstract]
@@ -11467,7 +11326,6 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,1)]
 	[BaseType (typeof (AVPlayer))]
 	interface AVQueuePlayer {
 		
@@ -11629,7 +11487,7 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch]
-	[iOS (4,0), BaseType (typeof (CALayer))]
+	[BaseType (typeof (CALayer))]
 	interface AVSynchronizedLayer {
 		[Static, Export ("synchronizedLayerWithPlayerItem:")]
 		AVSynchronizedLayer FromPlayerItem (AVPlayerItem playerItem);

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -10099,15 +10099,15 @@ namespace XamCore.AVFoundation {
 
 #if !MONOMAC
 		// 5.0
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_6_0, Message = "Use 'AllowsExternalPlayback' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'AllowsExternalPlayback' instead.")]
 		[Export ("allowsAirPlayVideo")]
 		bool AllowsAirPlayVideo { get; set;  }
 
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_6_0, Message = "Use 'ExternalPlaybackActive' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'ExternalPlaybackActive' instead.")]
 		[Export ("airPlayVideoActive")]
 		bool AirPlayVideoActive { [Bind ("isAirPlayVideoActive")] get;  }
 
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_6_0, Message = "Use 'UsesExternalPlaybackWhileExternalScreenIsActive' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'UsesExternalPlaybackWhileExternalScreenIsActive' instead.")]
 		[Export ("usesAirPlayVideoWhileAirPlayScreenIsActive")]
 		bool UsesAirPlayVideoWhileAirPlayScreenIsActive { get; set;  }
 #endif

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -1560,7 +1560,7 @@ namespace XamCore.AVFoundation {
 		void BeginInterruption (AVAudioPlayer  player);
 	
 		[Export ("audioPlayerEndInterruption:")]
-		[Availability (Introduced = Platform.iOS_2_2, Deprecated = Platform.iOS_6_0)]
+		[Availability (Deprecated = Platform.iOS_6_0)]
 		void EndInterruption (AVAudioPlayer player);
 
 		// Deprecated in iOS 6.0 but we have same C# signature
@@ -1800,7 +1800,7 @@ namespace XamCore.AVFoundation {
 		[NoWatch]
 		[Wrap ("WeakDelegate")]
 		[Protocolize]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0, Message = "Use 'AVAudioSession.Notification.Observe*' methods instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'AVAudioSession.Notification.Observe*' methods instead.")]
 		[NoTV]
 		AVAudioSessionDelegate Delegate { get; set;  }
 	
@@ -1809,14 +1809,14 @@ namespace XamCore.AVFoundation {
 
 		[NoTV]
 		[Export ("setActive:withFlags:error:")]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0, Message = "Use 'SetActive (bool, AVAudioSessionSetActiveOptions, out NSError)' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'SetActive (bool, AVAudioSessionSetActiveOptions, out NSError)' instead.")]
 		bool SetActive (bool beActive, AVAudioSessionFlags flags, out NSError outError);
 
 		[Export ("setCategory:error:")]
 		bool SetCategory (NSString theCategory, out NSError outError);
 	
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_6_0, Message = "Use 'SetPreferredSampleRate' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'SetPreferredSampleRate' instead.")]
 		[Export ("setPreferredHardwareSampleRate:error:")]
 		bool SetPreferredHardwareSampleRate (double sampleRate, out NSError outError);
 	
@@ -1837,7 +1837,7 @@ namespace XamCore.AVFoundation {
 	
 		[NoTV]
 		[Export ("preferredHardwareSampleRate")]
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_6_0, Message = "Use 'PreferredSampleRate' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'PreferredSampleRate' instead.")]
 		double PreferredHardwareSampleRate { get;  }
 	
 		[NoWatch]
@@ -1846,22 +1846,22 @@ namespace XamCore.AVFoundation {
 	
 		[NoTV]
 		[Export ("inputIsAvailable")]
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_6_0)]
+		[Availability (Deprecated = Platform.iOS_6_0)]
 		bool InputIsAvailable { get;  }
 	
 		[NoTV]
 		[Export ("currentHardwareSampleRate")]
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_6_0, Message = "Use 'SampleRate' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'SampleRate' instead.")]
 		double CurrentHardwareSampleRate { get;  }
 
 		[NoTV]
 		[Export ("currentHardwareInputNumberOfChannels")]
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_6_0, Message = "Use 'InputNumberOfChannels' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'InputNumberOfChannels' instead.")]
 		nint CurrentHardwareInputNumberOfChannels { get;  }
 	
 		[NoTV]
 		[Export ("currentHardwareOutputNumberOfChannels")]
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_6_0, Message = "Use 'OutputNumberOfChannels' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'OutputNumberOfChannels' instead.")]
 		nint CurrentHardwareOutputNumberOfChannels { get;  }
 
 		[Field ("AVAudioSessionCategoryAmbient")]
@@ -1880,7 +1880,7 @@ namespace XamCore.AVFoundation {
 		NSString CategoryPlayAndRecord { get; }
 
 		[NoTV][NoWatch]
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_10_0)] // FIXME: Find the new value to use
+		[Availability (Deprecated = Platform.iOS_10_0)] // FIXME: Find the new value to use
 		[Field ("AVAudioSessionCategoryAudioProcessing")]
 		NSString CategoryAudioProcessing { get; }
 
@@ -3944,7 +3944,7 @@ namespace XamCore.AVFoundation {
 		void CancelWriting ();
 
 		[Export ("finishWriting")]
-		[Availability (Introduced = Platform.iOS_4_1, Deprecated = Platform.iOS_6_0, Message = "Use the asynchronous 'FinishWriting (NSAction completionHandler)' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use the asynchronous 'FinishWriting (NSAction completionHandler)' instead.")]
 		bool FinishWriting ();
 
 		[Mac (10,9)]
@@ -8670,23 +8670,23 @@ namespace XamCore.AVFoundation {
 
 #if !MONOMAC
 		[Export ("orientation")]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0, Message = "Use 'AVCaptureConnection.VideoOrientation' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'AVCaptureConnection.VideoOrientation' instead.")]
 		AVCaptureVideoOrientation Orientation { get; set;  }
 
 		[Export ("automaticallyAdjustsMirroring")]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0, Message = "Use 'AVCaptureConnection.AutomaticallyAdjustsVideoMirroring' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'AVCaptureConnection.AutomaticallyAdjustsVideoMirroring' instead.")]
 		bool AutomaticallyAdjustsMirroring { get; set;  }
 
 		[Export ("mirrored")]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0, Message = "Use 'AVCaptureConnection.VideoMirrored' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'AVCaptureConnection.VideoMirrored' instead.")]
 		bool Mirrored { [Bind ("isMirrored")] get; set;  }
 
 		[Export ("isMirroringSupported")]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0, Message = "Use 'AVCaptureConnection.IsVideoMirroringSupported' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'AVCaptureConnection.IsVideoMirroringSupported' instead.")]
 		bool MirroringSupported { get; }
 
 		[Export ("isOrientationSupported")]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0, Message = "Use 'AVCaptureConnection.IsVideoOrientationSupported' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'AVCaptureConnection.IsVideoOrientationSupported' instead.")]
 		bool OrientationSupported { get; }
 
 #endif
@@ -8754,7 +8754,7 @@ namespace XamCore.AVFoundation {
 		AVVideoSettingsCompressed CompressedVideoSetting { get; set; }
 
 		[Export ("minFrameDuration")]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_5_0, Message = "Use 'AVCaptureConnection.MinVideoFrameDuration' instead.")]
+		[Availability (Deprecated = Platform.iOS_5_0, Message = "Use 'AVCaptureConnection.MinVideoFrameDuration' instead.")]
 		CMTime MinFrameDuration { get; set;  }
 
 		[Export ("alwaysDiscardsLateVideoFrames")]
@@ -9415,7 +9415,7 @@ namespace XamCore.AVFoundation {
 	[NoTV]
 	[NoWatch]
 	[iOS (4,0)]
-	[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_10_0, Message = "Use 'AVCapturePhotoOutput' instead.")]
+	[Availability (Deprecated = Platform.iOS_10_0, Message = "Use 'AVCapturePhotoOutput' instead.")]
 	[BaseType (typeof (AVCaptureOutput))]
 	interface AVCaptureStillImageOutput {
 		[Export ("availableImageDataCVPixelFormatTypes")]
@@ -9591,11 +9591,11 @@ namespace XamCore.AVFoundation {
 		[Export ("supportsAVCaptureSessionPreset:")]
 		bool SupportsAVCaptureSessionPreset (string preset);
 
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_10_0, Message="Use 'AVCapturePhotoSettings.FlashMode' instead.")]
+		[Availability (Deprecated = Platform.iOS_10_0, Message="Use 'AVCapturePhotoSettings.FlashMode' instead.")]
 		[Export ("flashMode")]
 		AVCaptureFlashMode FlashMode { get; set;  }
 
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_10_0, Message="Use 'AVCapturePhotoOutput.SupportedFlashModes' instead.")]
+		[Availability (Deprecated = Platform.iOS_10_0, Message="Use 'AVCapturePhotoOutput.SupportedFlashModes' instead.")]
 		[Export ("isFlashModeSupported:")]
 		bool IsFlashModeSupported (AVCaptureFlashMode flashMode);
 

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -443,19 +443,15 @@ namespace XamCore.CoreAnimation {
 		[Protocolize]
 		CALayerDelegate Delegate { get; set; }
 
-		[iOS (3,2)]
 		[Export ("shadowColor")]
 		CGColor ShadowColor { get; set; }
 
-		[iOS (3,2)]
 		[Export ("shadowOffset")]
 		CGSize ShadowOffset { get; set; }
 
-		[iOS (3,2)]
 		[Export ("shadowOpacity")]
 		float ShadowOpacity { get; set; } /* float, not CGFloat */
 
-		[iOS (3,2)]
 		[Export ("shadowRadius")]
 		nfloat ShadowRadius { get; set; }
 
@@ -558,16 +554,13 @@ namespace XamCore.CoreAnimation {
 		void AddConstraint (CAConstraint c);
 #endif
 
-		[iOS (3,2)]
 		[Export ("shouldRasterize")]
 		bool ShouldRasterize { get; set; }
 
 		[NullAllowed]
-		[iOS (3,2)]
 		[Export ("shadowPath")]
 		CGPath ShadowPath { get; set; }
 
-		[iOS (3,2)]
 		[Export ("rasterizationScale")]
 		nfloat RasterizationScale { get; set; }
 
@@ -771,11 +764,9 @@ namespace XamCore.CoreAnimation {
 		[Export ("strokeColor")] [NullAllowed]
 		CGColor StrokeColor { get; set; }
 
-		[iOS (4,2)]
 		[Export ("strokeStart")]
 		nfloat StrokeStart { get; set; }
 
-		[iOS (4,2)]
 		[Export ("strokeEnd")]
 		nfloat StrokeEnd { get; set; }
 
@@ -844,7 +835,6 @@ namespace XamCore.CoreAnimation {
 		Natural,
 	}
 
-	[iOS (3,2)]
 	[BaseType (typeof (CALayer))]
 	interface CATextLayer {
 		[Export ("layer"), New, Static]
@@ -1013,7 +1003,6 @@ namespace XamCore.CoreAnimation {
 		void DidChangeValueForKey (string key);
 
 		[Export ("shouldArchiveValueForKey:")]
-		[iOS (4,0)]
 		bool ShouldArchiveValueForKey ([NullAllowed] string key);
 
 		[Field ("kCATransitionFade")]
@@ -1333,7 +1322,6 @@ namespace XamCore.CoreAnimation {
 		[Export ("setValue:forKey:")]
 		void SetValueForKey ([NullAllowed] NSObject anObject, NSString key);
 
-		[iOS (4,0)]
 		[Static, Export ("completionBlock"), NullAllowed]
 		NSAction CompletionBlock { get; set; }
 
@@ -1491,7 +1479,6 @@ namespace XamCore.CoreAnimation {
 	}
 #endif
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface CAEmitterCell : CAMediaTiming, NSSecureCoding {
 		[NullAllowed] // by default this property is null
@@ -1621,7 +1608,6 @@ namespace XamCore.CoreAnimation {
 		nfloat ContentsScale { get; set; }
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (CALayer))]
 	interface CAEmitterLayer {
 		[Export ("layer"), New, Static]

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -46,7 +46,6 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	[Watch (4,0)]
-	[iOS (5,0)]
 	[Mac (10, 7)]
 	[BaseType (typeof (CBManager), Delegates=new[] {"WeakDelegate"}, Events = new[] { typeof (CBCentralManagerDelegate)})]
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
@@ -85,7 +84,7 @@ namespace XamCore.CoreBluetooth {
 		[NoWatch]
 		[Mac (10, 7, onlyOn64: true)] // Was removed from 32-bit in 10.13 unannounced
 		[Export ("retrieveConnectedPeripherals")]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_9_0, Message = "Use 'RetrievePeripheralsWithIdentifiers' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_9_0, Message = "Use 'RetrievePeripheralsWithIdentifiers' instead.")]
 		void RetrieveConnectedPeripherals ();
 
 		[Export ("scanForPeripheralsWithServices:options:"), Internal]
@@ -277,7 +276,6 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	[Watch (4,0)]
-	[iOS (5,0)]
 	[Static]
 	interface CBAdvertisement {
 		[Field ("CBAdvertisementDataServiceUUIDsKey")]
@@ -310,7 +308,6 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	[Watch (4,0)]
-	[iOS (5,0)]
 	[BaseType (typeof (CBAttribute))]
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
 	interface CBCharacteristic {
@@ -386,7 +383,6 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	[Watch (4,0)]
-	[iOS (5,0)]
 	[BaseType (typeof (CBAttribute))]
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
 	interface CBDescriptor {
@@ -413,7 +409,6 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	[Watch (4,0)]
-	[iOS (5,0)]
 	[BaseType (typeof (CBPeer), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof (CBPeripheralDelegate)})]
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
 	interface CBPeripheral : NSCopying {
@@ -569,7 +564,6 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	[Watch (4,0)]
-	[iOS (5,0)]
 	[BaseType (typeof (CBAttribute))]
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
 	interface CBService {
@@ -622,7 +616,6 @@ namespace XamCore.CoreBluetooth {
 	}
 
 	[Watch (4,0)]
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // crash (at dispose time) on OSX
 	interface CBUUID : NSCopying {
@@ -638,7 +631,7 @@ namespace XamCore.CoreBluetooth {
 		[Export ("UUIDWithData:")]
 		CBUUID FromData (NSData theData);
 
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_9_0)]
+		[Availability (Deprecated = Platform.iOS_9_0)]
 		[NoWatch]
 		[Static]
 		[Export ("UUIDWithCFUUID:")]

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -1870,7 +1870,7 @@ namespace XamCore.CoreData
 #endif // !WATCH && !TVOS
 
 #if MONOMAC
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_5)]
+		[Availability (Deprecated = Platform.Mac_10_5)]
 		[Static, Export ("metadataForPersistentStoreWithURL:error:")]
 		NSDictionary MetadataForPersistentStoreWithUrl (NSUrl url, out NSError error);
 #endif

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -221,7 +221,6 @@ namespace XamCore.CoreData
 		[Export ("valueTransformerName")]
 		string ValueTransformerName { get; set; }
 
-		[iOS (5,0)]
 		[Export ("allowsExternalBinaryDataStorage")]
 		bool AllowsExternalBinaryDataStorage { get; set; }
 	}
@@ -309,10 +308,8 @@ namespace XamCore.CoreData
 		[Export ("versionHashModifier")]
 		string VersionHashModifier { get; set; }
 
-		[iOS (5,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("compoundIndexes", ArgumentSemantic.Retain)]
-		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'NSEntityDescription.Indexes' instead.")]
 		[Mac (10, 7)]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'NSEntityDescription.Indexes' instead.")]
@@ -499,34 +496,27 @@ namespace XamCore.CoreData
 		[NullAllowed]
 		NSPropertyDescription [] PropertiesToFetch { get; set; }
 
-		[iOS (5,0)]
 		[Static]
 		[Export ("fetchRequestWithEntityName:")]
 		// note: Xcode 6.3 changed the return value type from `NSFetchRequest*` to `instancetype`
 		NSFetchRequest FromEntityName (string entityName);
 
-		[iOS (5,0)]
 		[Export ("initWithEntityName:")]
 		IntPtr Constructor (string entityName);
 
-		[iOS (5,0)]
 		[NullAllowed, Export ("entityName", ArgumentSemantic.Strong)]
 		string EntityName { get; }
 
-		[iOS (5,0)]
 		[Export ("fetchBatchSize")]
 		nint FetchBatchSize { get; set; }
 
-		[iOS (5,0)]
 		[Export ("shouldRefreshRefetchedObjects")]
 		bool ShouldRefreshRefetchedObjects { get; set; }
 
-		[iOS (5,0)]
 		[Export ("havingPredicate", ArgumentSemantic.Retain)]
 		[NullAllowed]
 		NSPredicate HavingPredicate { get; set; }
 
-		[iOS (5,0)]
 		[Export ("propertiesToGroupBy", ArgumentSemantic.Copy)]
 		[NullAllowed]
 		NSPropertyDescription [] PropertiesToGroupBy { get; set; }
@@ -647,7 +637,6 @@ namespace XamCore.CoreData
 
 	interface INSFetchedResultsSectionInfo {}
 #endif
-	[iOS (5,0)]
 	// 	NSInvalidArgumentException *** -loadMetadata: cannot be sent to an abstract object of class NSIncrementalStore: Create a concrete instance!
 	//	Apple doc quote: "NSIncrementalStore is an abstract superclass..."
 #if XAMCORE_4_0 // bad API -> should be an abstract type (breaking change)
@@ -702,7 +691,6 @@ namespace XamCore.CoreData
 
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSIncrementalStoreNode {
 		[Export ("initWithObjectID:withValues:version:")]
@@ -762,7 +750,7 @@ namespace XamCore.CoreData
 		[Export ("objectID", ArgumentSemantic.Strong)]
 		NSManagedObjectID ObjectID { get; }
 		
-		[iOS (3, 0), Mac (10,6)]
+		[Mac (10,6)]
 		[Static, Export ("contextShouldIgnoreUnmodeledPropertyChanges")]
 		bool ContextShouldIgnoreUnModeledPropertyChanges { get; }
 
@@ -883,7 +871,6 @@ namespace XamCore.CoreData
 		[Export ("validateForUpdate:")]
 		bool ValidateForUpdate (out NSError error);
 
-		[iOS (5,0)]
 		[Export ("hasChanges")]
 		bool HasChanges { get; }
 
@@ -1016,24 +1003,18 @@ namespace XamCore.CoreData
 		bool Save (out NSError error);
 
 #if !WATCH && !TVOS
-		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use a queue style context and 'PerformAndWait' instead.")]
-		[Mac (10, 4)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use a queue style context and 'PerformAndWait' instead.")]
 		[Export ("lock")]
 		new void Lock ();
 
-		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use a queue style context and 'PerformAndWait' instead.")]
-		[Mac (10, 4)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use a queue style context and 'PerformAndWait' instead.")]
 		[Export ("unlock")]
 		new void Unlock ();
 
 		[NoTV]
-		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use a queue style context and 'Perform' instead.")]
-		[Mac (10, 4)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use a queue style context and 'Perform' instead.")]
 		[Export ("tryLock")]
 		bool TryLock { get; }
@@ -1058,28 +1039,22 @@ namespace XamCore.CoreData
 		void MergeChangesFromContextDidSaveNotification (NSNotification notification);
 
 		[DesignatedInitializer]
-		[iOS (5,0)]
 		[Export ("initWithConcurrencyType:")]
 		IntPtr Constructor (NSManagedObjectContextConcurrencyType ct);
 
-		[iOS (5,0)]
 		[Export ("performBlock:")]
 		void Perform (/* non null */ NSAction action);
 
-		[iOS (5,0)]
 		[Export ("performBlockAndWait:")]
 		void PerformAndWait (/* non null */ NSAction action);
 
-		[iOS (5,0)]
 		[Export ("userInfo", ArgumentSemantic.Strong)]
 		NSMutableDictionary UserInfo { get; }
 
-		[iOS (5,0)]
 		[Export ("concurrencyType")]
 		NSManagedObjectContextConcurrencyType ConcurrencyType { get; }
 
 		//Detected properties
-		[iOS (5,0)]
 		// default is null, but setting it to null again would crash the app
 		[NullAllowed, Export ("parentContext", ArgumentSemantic.Retain)]
 		NSManagedObjectContext ParentContext { get; set; }
@@ -1314,7 +1289,7 @@ namespace XamCore.CoreData
 
 	}
 
-	[iOS (5,0)][Mac (10, 7)]
+	[Mac (10, 7)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface NSMergeConflict {
@@ -1357,7 +1332,6 @@ namespace XamCore.CoreData
 #endif
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface NSMergePolicy {
@@ -1462,7 +1436,6 @@ namespace XamCore.CoreData
 		void CancelMigrationWithError (NSError error);
 
 		// 5.0
-		[iOS (5,0)]
 		[Export ("usesStoreSpecificMigrationManager")]
 		bool UsesStoreSpecificMigrationManager { get; set; }
 	}
@@ -1677,7 +1650,6 @@ namespace XamCore.CoreData
 		[Export ("willRemoveFromPersistentStoreCoordinator:")]
 		void WillRemoveFromPersistentStoreCoordinator ([NullAllowed] NSPersistentStoreCoordinator coordinator);
 
-		[iOS (5,0)]
 		[Field ("NSPersistentStoreSaveConflictsErrorKey")]
 		NSString SaveConflictsErrorKey { get; }
 
@@ -1807,9 +1779,7 @@ namespace XamCore.CoreData
 		[Static, Export ("registerStoreClass:forStoreType:")]
 		void RegisterStoreClass (Class storeClass, NSString storeType);
 
-		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 9, 0, message : "Use the method that takes an out NSError parameter.")]
-		[Mac (10, 5)]
 		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use the method that takes an out NSError parameter.")]
 		[Static, Export ("metadataForPersistentStoreOfType:URL:error:")]
 		[return: NullAllowed]
@@ -1820,7 +1790,7 @@ namespace XamCore.CoreData
 		[return: NullAllowed]
 		NSDictionary<NSString, NSObject> GetMetadata (string storeType, NSUrl url, [NullAllowed] NSDictionary options, out NSError error);
 
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_9_0, Message = "Use the method that takes an out NSError parameter.")]
+		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use the method that takes an out NSError parameter.")]
 		[Static, Export ("setMetadata:forPersistentStoreOfType:URL:error:")]
 		bool SetMetadata (NSDictionary metadata, NSString storeType, NSUrl url, out NSError error);
 		
@@ -1885,16 +1855,16 @@ namespace XamCore.CoreData
 		NSManagedObjectID ManagedObjectIDForURIRepresentation (NSUrl url);
 
 #if !WATCH && !TVOS
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_8_0, Message="Use 'PerformAndWait' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message="Use 'PerformAndWait' instead.")]
 		[Export ("lock")]
 		new void Lock ();
 
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_8_0, Message="Use 'PerformAndWait' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message="Use 'PerformAndWait' instead.")]
 		[Export ("unlock")]
 		new void Unlock ();
 
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_8_0, Message="Use 'Perform' instead.")]
+		[Availability (Deprecated = Platform.iOS_8_0, Message="Use 'Perform' instead.")]
 		[Export ("tryLock")]
 		bool TryLock { get; }
 #endif // !WATCH && !TVOS
@@ -1984,7 +1954,6 @@ namespace XamCore.CoreData
 		NSString WillRemoveStoreNotification { get; }
 		
 		// 5.0
-		[iOS (5,0)]
 		[Export ("executeRequest:withContext:error:")]
 		[return: NullAllowed]
 #if XAMCORE_4_0
@@ -1995,17 +1964,17 @@ namespace XamCore.CoreData
 
 		[NoWatch][NoTV]
 		[Notification]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_10_0, Message = "Please see the release notes and Core Data documentation.")]
+		[Availability (Deprecated = Platform.iOS_10_0, Message = "Please see the release notes and Core Data documentation.")]
 		[Field ("NSPersistentStoreDidImportUbiquitousContentChangesNotification")]
 		NSString DidImportUbiquitousContentChangesNotification { get; }
 
 		[NoWatch][NoTV]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_10_0, Message = "Please see the release notes and Core Data documentation.")]
+		[Availability (Deprecated = Platform.iOS_10_0, Message = "Please see the release notes and Core Data documentation.")]
 		[Field ("NSPersistentStoreUbiquitousContentNameKey")]
 		NSString PersistentStoreUbiquitousContentNameKey { get; }
 
 		[NoWatch][NoTV]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_10_0, Message = "Please see the release notes and Core Data documentation.")]
+		[Availability (Deprecated = Platform.iOS_10_0, Message = "Please see the release notes and Core Data documentation.")]
 		[Field ("NSPersistentStoreUbiquitousContentURLKey")]
 #if XAMCORE_4_0
 		NSString PersistentStoreUbiquitousContentUrlKey { get; }
@@ -2014,7 +1983,6 @@ namespace XamCore.CoreData
 #endif
 
 #if !MONOMAC
-		[iOS (5,0)]
 		[Field ("NSPersistentStoreFileProtectionKey")]
 		NSString PersistentStoreFileProtectionKey { get; }
 #endif
@@ -2029,7 +1997,7 @@ namespace XamCore.CoreData
 		[NoWatch][NoTV]
 		[iOS (7,0), Mac (10, 9)]
 		[Static]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_10_0, Message = "Please see the release notes and Core Data documentation.")]
+		[Availability (Deprecated = Platform.iOS_10_0, Message = "Please see the release notes and Core Data documentation.")]
 		[Export ("removeUbiquitousContentAndPersistentStoreAtURL:options:error:")]
 		bool RemoveUbiquitousContentAndPersistentStore (NSUrl storeUrl, NSDictionary options, out NSError error);
 
@@ -2196,9 +2164,7 @@ namespace XamCore.CoreData
 		NSDictionary UserInfo { get; set; }
 
 		[Export ("indexed")]
-		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'NSEntityDescription.Indexes' instead.")]
-		[Mac (10, 5)]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'NSEntityDescription.Indexes' instead.")]
 		bool Indexed { [Bind ("isIndexed")] get; set; }
 
@@ -2213,15 +2179,11 @@ namespace XamCore.CoreData
 		string RenamingIdentifier { get; set; }
 
 		// 5.0
-		[iOS (5,0)]
 		[Export ("indexedBySpotlight")]
 		bool IndexedBySpotlight { [Bind ("isIndexedBySpotlight")]get; set; }
 
-		[iOS (5,0)]
 		[Export ("storedInExternalRecord")]
-		[iOS (3, 0)]
 		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'CoreSpotlight' integration instead.")]
-		[Mac (10, 5)]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'CoreSpotlight' integration instead.")]
 		bool StoredInExternalRecord { [Bind ("isStoredInExternalRecord")]get; set; }
 	}
@@ -2269,7 +2231,6 @@ namespace XamCore.CoreData
 		NSData VersionHash { get; }
 
 		// 5.0
-		[iOS (5,0)]
 		[Export ("ordered")]
 		bool Ordered { [Bind ("isOrdered")]get; set; }
 	}

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -750,7 +750,6 @@ namespace XamCore.CoreData
 		[Export ("objectID", ArgumentSemantic.Strong)]
 		NSManagedObjectID ObjectID { get; }
 		
-		[Mac (10,6)]
 		[Static, Export ("contextShouldIgnoreUnmodeledPropertyChanges")]
 		bool ContextShouldIgnoreUnModeledPropertyChanges { get; }
 

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -49,7 +49,6 @@ using XamCore.ImageKit;
 namespace XamCore.CoreImage {
 
 	[BaseType (typeof (NSObject))]
-	[iOS (5,0)]
 	[DisableDefaultCtor]
 	interface CIColor : NSSecureCoding, NSCopying {
 		[Static]
@@ -202,7 +201,6 @@ namespace XamCore.CoreImage {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[iOS (5,0)]
 	[DisableDefaultCtor]
 	interface CIContext {
 		// When we bind OpenGL add these:
@@ -286,7 +284,6 @@ namespace XamCore.CoreImage {
 		void Render (CIImage image, IMTLTexture texture, [NullAllowed] IMTLCommandBuffer commandBuffer, CGRect bounds, [NullAllowed] CGColorSpace colorSpace);
 #endif
 
-		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'DrawImage (image, CGRect, CGRect)' instead.")]
 		[Mac (10, 4)]
 		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Use 'DrawImage (image, CGRect, CGRect)' instead.")]
@@ -488,7 +485,6 @@ namespace XamCore.CoreImage {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[iOS (5,0)]
 	[DisableDefaultCtor] //  In iOS8 they expose custom filters, we expose a protected one in CIFilter.cs
 	interface CIFilter : NSSecureCoding, NSCopying {
 		[Export ("inputKeys")]
@@ -834,14 +830,12 @@ namespace XamCore.CoreImage {
 		NSSet ActiveKeys { get; }
 	}
 
-	[iOS (5,0)]
 	[Static]
 	interface CIFilterOutputKey {
 		[Field ("kCIOutputImageKey", "+CoreImage")]
 		NSString Image  { get; }
 	}
 	
-	[iOS (5,0)]
 	[Static]
 	interface CIFilterInputKey {
 		[Field ("kCIInputBackgroundImageKey", "+CoreImage")]
@@ -955,7 +949,6 @@ namespace XamCore.CoreImage {
 		NSString DisparityImage { get; }
 	}
 		
-	[iOS (5,0)]
 	[Static]
 	interface CIFilterAttributes {
 		[Field ("kCIAttributeFilterName", "+CoreImage")]
@@ -1071,7 +1064,6 @@ namespace XamCore.CoreImage {
 		NSString Available_iOS { get; }
 	}
 
-	[iOS (5,0)]
 	[Static]
 	interface CIFilterCategory {
 		[Field ("kCICategoryDistortionEffect", "+CoreImage")]
@@ -1323,7 +1315,6 @@ namespace XamCore.CoreImage {
 	}
 	
 	[BaseType (typeof (NSObject))]
-	[iOS (5,0)]
 	[DisableDefaultCtor]
 	interface CIImage : NSSecureCoding, NSCopying {
 		[Static]
@@ -1596,11 +1587,9 @@ namespace XamCore.CoreImage {
 		[Export ("extent")]
 		CGRect Extent { get; }
 
-		[iOS (5,0)]
 		[Export ("properties"), Internal]
 		NSDictionary WeakProperties { get; }
 
-		[iOS (5,0)]
 		[Wrap ("WeakProperties")]
 		CoreGraphics.CGImageProperties Properties { get; }
 
@@ -1625,11 +1614,9 @@ namespace XamCore.CoreImage {
 		int FormatRGBAf { get; } /* CIFormat = int */
 
 		[Field ("kCIFormatBGRA8")]
-		[iOS (5,0)]
 		int FormatBGRA8 { get; } /* CIFormat = int */
 
 		[Field ("kCIFormatRGBA8")]
-		[iOS (5,0)]
 		int FormatRGBA8 { get; } /* CIFormat = int */
 
 		[Field ("kCIFormatABGR8")]
@@ -1718,15 +1705,12 @@ namespace XamCore.CoreImage {
 
 #if !MONOMAC
 		// UIKit extensions
-		[iOS (5,0)]
 		[Export ("initWithImage:")]
 		IntPtr Constructor (UIImage image);
 
-		[iOS (5,0)]
 		[Export ("initWithImage:options:")]
 		IntPtr Constructor (UIImage image, [NullAllowed] NSDictionary options);
 
-		[iOS (5,0)]
 		[Wrap ("this (image, options == null ? null : options.Dictionary)")]
 		IntPtr Constructor (UIImage image, [NullAllowed] CIImageInitializationOptions options);
 #endif
@@ -2201,7 +2185,6 @@ namespace XamCore.CoreImage {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[iOS (5,0)]
 	[DisableDefaultCtor]
 	interface CIVector : NSSecureCoding, NSCopying {
 		[Static, Internal, Export ("vectorWithValues:count:")]
@@ -2242,17 +2225,14 @@ namespace XamCore.CoreImage {
 		CIVector FromString (string representation);
 
 		[Mac (10,9)]
-		[iOS (5,0)]
 		[Export ("initWithCGPoint:")]
 		IntPtr Constructor (CGPoint p);
 
 		[Mac (10,9)]
-		[iOS (5,0)]
 		[Export ("initWithCGRect:")]
 		IntPtr Constructor (CGRect r);
 
 		[Mac (10,9)]
-		[iOS (5,0)]
 		[Export ("initWithCGAffineTransform:")]
 		IntPtr Constructor (CGAffineTransform r);
 		
@@ -2308,7 +2288,6 @@ namespace XamCore.CoreImage {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[iOS (5,0)]
 	[DisableDefaultCtor]
 	interface CIDetector {
 		[Static, Export ("detectorOfType:context:options:"), Internal]
@@ -2390,7 +2369,6 @@ namespace XamCore.CoreImage {
 	}
 	
 	[BaseType (typeof (NSObject))]
-	[iOS (5,0)]
 	[DisableDefaultCtor]
 	interface CIFeature {
 		[Export ("type", ArgumentSemantic.Retain)]
@@ -2416,7 +2394,6 @@ namespace XamCore.CoreImage {
 	}
 
 	[BaseType (typeof (CIFeature))]
-	[iOS (5,0)]
 	[DisableDefaultCtor]
 	interface CIFaceFeature {
 		[Export ("hasLeftEyePosition", ArgumentSemantic.Assign)]

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -285,7 +285,6 @@ namespace XamCore.CoreImage {
 #endif
 
 		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'DrawImage (image, CGRect, CGRect)' instead.")]
-		[Mac (10, 4)]
 		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Use 'DrawImage (image, CGRect, CGRect)' instead.")]
 		[Export ("drawImage:atPoint:fromRect:")]
 		void DrawImage (CIImage image, CGPoint atPoint, CGRect fromRect);
@@ -544,7 +543,6 @@ namespace XamCore.CoreImage {
 		NSUrl FilterLocalizedReferenceDocumentation (string filterName);
 
 #if MONOMAC && !XAMCORE_4_0
-		[Mac(10,4)]
 		[Static]
 		[Export ("registerFilterName:constructor:classAttributes:")]
 		void RegisterFilterName (string name, NSObject constructorObject, NSDictionary classAttributes);
@@ -1388,7 +1386,6 @@ namespace XamCore.CoreImage {
 #if MONOMAC && !XAMCORE_4_0
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Static]
-		[Mac(10,4)]
 		[Export ("imageWithCVImageBuffer:options:")]
 		CIImage FromImageBuffer (CVImageBuffer imageBuffer, [NullAllowed] NSDictionary dict);
 #else
@@ -1525,7 +1522,6 @@ namespace XamCore.CoreImage {
 		IntPtr Constructor (CVImageBuffer imageBuffer);
 
 #if MONOMAC && !XAMCORE_4_0
-		[Mac(10,4)]
 		[Export ("initWithCVImageBuffer:options:")]
 		IntPtr Constructor (CVImageBuffer imageBuffer, [NullAllowed] NSDictionary dict);
 #else

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -108,11 +108,9 @@ namespace XamCore.CoreLocation {
 		double Distancefrom (CLLocation  location);
 #endif
 
-		[iOS (3,2)]
 		[Export ("distanceFromLocation:")]
 		double DistanceFrom (CLLocation location);
 
-		[iOS (4,2)]
 		[Export ("initWithCoordinate:altitude:horizontalAccuracy:verticalAccuracy:course:speed:timestamp:")]
 		IntPtr Constructor (CLLocationCoordinate2D coordinate, double altitude, double hAccuracy, double vAccuracy, double course, double speed, NSDate timestamp);
 
@@ -186,7 +184,6 @@ namespace XamCore.CoreLocation {
 		[Export ("stopUpdatingLocation")]
 		void StopUpdatingLocation ();
 
-		[iOS (4,0)]
 		[Export ("locationServicesEnabled"), Static]
 		bool LocationServicesEnabled { get; }
 
@@ -209,28 +206,24 @@ namespace XamCore.CoreLocation {
 #endif
 	
 		[NoWatch][NoTV]
-		[iOS (3,2)]
 		[Mac (10,7)]
-		[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_6_0)]
+		[Availability (Deprecated = Platform.iOS_6_0)]
 		// Default property value is null but it cannot be set to that value
 		// it crash when a null is provided
 		[Export ("purpose")]
 		string Purpose { get; set; }
 
 		[NoWatch][NoTV]
-		[iOS (4,0)]
 		[Mac (10,7)]
 		[Export ("headingAvailable"), Static]
 		bool HeadingAvailable { get; }
 
 		[NoWatch][NoTV]
-		[iOS (4,0)]
 		[Mac (10,7)]
 		[Export ("significantLocationChangeMonitoringAvailable"), Static]
 		bool SignificantLocationChangeMonitoringAvailable { get; }
 
 		[NoWatch][NoTV]
-		[iOS (4, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'IsMonitoringAvailable' instead.")]
 		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'IsMonitoringAvailable' instead.")]
@@ -238,7 +231,6 @@ namespace XamCore.CoreLocation {
 		bool RegionMonitoringAvailable { get; }
 
 		[NoWatch][NoTV]
-		[iOS (4, 0)]
 		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'IsMonitoringAvailable' and 'AuthorizationStatus' instead.")]
 		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'IsMonitoringAvailable' and 'AuthorizationStatus' instead.")]
@@ -247,61 +239,51 @@ namespace XamCore.CoreLocation {
 
 #if !MONOMAC
 		[NoWatch][NoTV]
-		[iOS (4,0)]
 		[Export ("headingOrientation", ArgumentSemantic.Assign)]
 		CLDeviceOrientation HeadingOrientation { get; set; }
 
 		[NoWatch][NoTV]
 		[Export ("heading", ArgumentSemantic.Copy)]
-		[iOS (4,0)]
 		CLHeading Heading { get; }
 #endif
 
 		[NoWatch][NoTV]
 		[Export ("maximumRegionMonitoringDistance")]
-		[iOS (4,0)]
 		[Mac (10,8)]
 		double MaximumRegionMonitoringDistance { get; }
 
 		[NoWatch][NoTV]
 		[Export ("monitoredRegions", ArgumentSemantic.Copy)]
-		[iOS (4,0)]
 		[Mac (10,8)]
 		NSSet MonitoredRegions { get; }
 
 		[NoWatch][NoTV]
-		[iOS (4,0)]
 		[Mac (10,7)]
 		[Export ("startMonitoringSignificantLocationChanges")]
 		void StartMonitoringSignificantLocationChanges ();
 
 		[NoWatch][NoTV]
-		[iOS (4,0)]
 		[Mac (10,7)]
 		[Export ("stopMonitoringSignificantLocationChanges")]
 		void StopMonitoringSignificantLocationChanges ();
 
 #if !MONOMAC
 		[NoWatch][NoTV]
-		[iOS (4,0)]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0)]
+		[Availability (Deprecated = Platform.iOS_6_0)]
 		[Export ("startMonitoringForRegion:desiredAccuracy:")]
 		void StartMonitoring (CLRegion region, double desiredAccuracy);
 #endif
 
 		[NoWatch][NoTV]
-		[iOS (4,0)]
 		[Mac (10,8)]
 		[Export ("stopMonitoringForRegion:")]
 		void StopMonitoring (CLRegion region);
 
-		[iOS (4,2)]
 		[Mac (10,7)]
 		[Export ("authorizationStatus")][Static]
 		CLAuthorizationStatus Status { get; }
 
 		[NoWatch][NoTV]
-		[iOS (5,0)]
 		[Mac (10,8)]
 		[Export ("startMonitoringForRegion:")]
 		void StartMonitoring (CLRegion region);
@@ -431,25 +413,21 @@ namespace XamCore.CoreLocation {
 		void Failed (CLLocationManager manager, NSError error);
 
 		[NoWatch][NoTV]
-		[iOS (4,0)]
 		[Mac (10,8)]
 		[Export ("locationManager:didEnterRegion:"), EventArgs ("CLRegion")]
 		void RegionEntered (CLLocationManager manager, CLRegion region);
 
 		[NoWatch][NoTV]
-		[iOS (4,0)]
 		[Mac (10,8)]
 		[Export ("locationManager:didExitRegion:"), EventArgs ("CLRegion")]
 		void RegionLeft (CLLocationManager manager, CLRegion region);
 
 		[NoWatch][NoTV]
-		[iOS (4,0)]
 		[Mac (10,8)]
 		[Export ("locationManager:monitoringDidFailForRegion:withError:"), EventArgs ("CLRegionError")]
 		void MonitoringFailed (CLLocationManager manager, CLRegion region, NSError error);
 
 		[NoWatch][NoTV]
-		[iOS (5,0)]
 		[Mac (10,8)]
 		[Export ("locationManager:didStartMonitoringForRegion:"), EventArgs ("CLRegion")]
 		void DidStartMonitoringForRegion (CLLocationManager manager, CLRegion region);
@@ -474,7 +452,6 @@ namespace XamCore.CoreLocation {
 		void DidVisit (CLLocationManager manager, CLVisit visit);
 #endif
 
-		[iOS (4,2)]
 		[Export ("locationManager:didChangeAuthorizationStatus:"), EventArgs ("CLAuthorizationChanged")]
 		void AuthorizationChanged (CLLocationManager manager, CLAuthorizationStatus status);
 
@@ -510,7 +487,6 @@ namespace XamCore.CoreLocation {
 		double FilterNone { get; }
 	}
 		
-	[iOS (4,0)]
 	[Mac (10,7)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // will crash, see CoreLocation.cs for compatibility stubs
@@ -551,7 +527,6 @@ namespace XamCore.CoreLocation {
 		bool NotifyOnExit { get; set; }
 	}
 
-	[iOS (5,0)]
 	[Mac (10,8)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // will crash, see CoreLocation.cs for compatibility stubs
@@ -700,7 +675,6 @@ namespace XamCore.CoreLocation {
 	delegate void CLGeocodeCompletionHandler (CLPlacemark [] placemarks, NSError error);
 
 	[Mac (10,8)]
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface CLGeocoder {
 		[Export ("isGeocoding")]

--- a/src/coremotion.cs
+++ b/src/coremotion.cs
@@ -15,7 +15,6 @@ using XamCore.UIKit;
 using System;
 
 namespace XamCore.CoreMotion {
-	[iOS (4,0)]
 	[BaseType (typeof (CMLogItem))]
 	[DisableDefaultCtor] // will crash, see Extra.cs for compatibility stubs
 	interface CMAccelerometerData : NSSecureCoding {
@@ -34,7 +33,6 @@ namespace XamCore.CoreMotion {
 		NSDate StartDate { get; }
 	}
 
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // will crash, see Extra.cs for compatibility stubs
 	interface CMLogItem : NSSecureCoding, NSCopying {
@@ -47,7 +45,6 @@ namespace XamCore.CoreMotion {
 	delegate void CMDeviceMotionHandler (CMDeviceMotion motion, NSError error);
 
 	[BaseType (typeof (NSObject))]
-	[iOS (4,0)]
 	interface CMMotionManager {
 		[Export ("accelerometerAvailable")]
 		bool AccelerometerAvailable { [Bind ("isAccelerometerAvailable")] get;  }
@@ -112,57 +109,44 @@ namespace XamCore.CoreMotion {
 		[Export ("stopDeviceMotionUpdates")]
 		void StopDeviceMotionUpdates ();
 
-		[iOS (5,0)]
 		[Export ("magnetometerUpdateInterval")]
 		double MagnetometerUpdateInterval { get; set; }
 
-		[iOS (5,0)]
 		[Export ("magnetometerAvailable")]
 		bool MagnetometerAvailable { [Bind ("isMagnetometerAvailable")] get; }
 
-		[iOS (5,0)]
 		[Export ("magnetometerActive")]
 		bool MagnetometerActive { [Bind ("isMagnetometerActive")] get; }
 
-		[iOS (5,0)]
 		[Export ("magnetometerData")]
 		CMMagnetometerData MagnetometerData { get; }
 
-		[iOS (5,0)]
 		[Export ("startMagnetometerUpdates")]
 		void StartMagnetometerUpdates ();
 
-		[iOS (5,0)]
 		[Export ("startMagnetometerUpdatesToQueue:withHandler:")]
 		void StartMagnetometerUpdates (NSOperationQueue queue, CMMagnetometerHandler handler);
 
-		[iOS (5,0)]
 		[Export ("stopMagnetometerUpdates")]
 		void StopMagnetometerUpdates ();
 
-		[iOS (5,0)]
 		[Export ("availableAttitudeReferenceFrames"), Static]
 		CMAttitudeReferenceFrame AvailableAttitudeReferenceFrames { get; }
 
-		[iOS (5,0)]
 		[Export ("attitudeReferenceFrame")]
 		CMAttitudeReferenceFrame AttitudeReferenceFrame { get; }
 
-		[iOS (5,0)]
 		[Export ("startDeviceMotionUpdatesUsingReferenceFrame:")]
 		void StartDeviceMotionUpdates (CMAttitudeReferenceFrame referenceFrame);
 
-		[iOS (5,0)]
 		[Export ("startDeviceMotionUpdatesUsingReferenceFrame:toQueue:withHandler:")]
 		void StartDeviceMotionUpdates (CMAttitudeReferenceFrame referenceFrame, NSOperationQueue queue, CMDeviceMotionHandler handler);
 
-		[iOS (5,0)]
 		[Export ("showsDeviceMovementDisplay")]
 		bool ShowsDeviceMovementDisplay { get; set; }
 	}
 
 	[BaseType (typeof (NSObject))]
-	[iOS (4,0)]
 	//<quote>You access CMAttitude objects through the attitude property of each CMDeviceMotion objects passed to an application.</quote>
 	[DisableDefaultCtor] // will crash, see Extra.cs for compatibility stubs
 	interface CMAttitude : NSSecureCoding, NSCopying {
@@ -186,7 +170,6 @@ namespace XamCore.CoreMotion {
 	}
 
 	[BaseType (typeof (CMLogItem))]
-	[iOS (4,0)]
 	[DisableDefaultCtor] // will crash, see Extra.cs for compatibility stubs
 	interface CMDeviceMotion : NSSecureCoding {
 		[Export ("rotationRate")]
@@ -201,7 +184,6 @@ namespace XamCore.CoreMotion {
 		[Export ("attitude")]
 		CMAttitude Attitude { get; }
 
-		[iOS (5,0)]
 		[Export ("magneticField")]
 		CMCalibratedMagneticField MagneticField { get; }
 
@@ -211,7 +193,6 @@ namespace XamCore.CoreMotion {
 	}
 
 	[BaseType (typeof (CMLogItem))]
-	[iOS (4,0)]
 	[DisableDefaultCtor] // will crash, see Extra.cs for compatibility stubs
 	interface CMGyroData : NSSecureCoding {
 		[Export ("rotationRate")]
@@ -219,14 +200,12 @@ namespace XamCore.CoreMotion {
 	}
 
 	[BaseType (typeof (CMLogItem))]
-	[iOS (5,0)]
 	[DisableDefaultCtor] // will crash, see Extra.cs for compatibility stubs
 	interface CMMagnetometerData : NSSecureCoding {
 		[Export ("magneticField")]
 		CMMagneticField MagneticField { get; }
 	}
 
-	[iOS (5,0)]
 	delegate void CMMagnetometerHandler (CMMagnetometerData magnetometerData, NSError error);
 
 	[NoWatch]

--- a/src/coretelephony.cs
+++ b/src/coretelephony.cs
@@ -3,7 +3,6 @@ using XamCore.ObjCRuntime;
 using System;
 
 namespace XamCore.CoreTelephony {
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	interface CTCall {
 		[Availability (Deprecated = Platform.iOS_10_0, Message = "Use 'CallKit' instead.")]
@@ -69,7 +68,6 @@ namespace XamCore.CoreTelephony {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[iOS (4,0)]
 	interface CTTelephonyNetworkInfo {
 		[Export ("subscriberCellularProvider", ArgumentSemantic.Retain)]
 		CTCarrier SubscriberCellularProvider { get; }
@@ -92,7 +90,6 @@ namespace XamCore.CoreTelephony {
 
 	[Deprecated (PlatformName.iOS, 10, 0, message: "Replaced by 'CXCallObserver' from 'CallKit'.")]
 	[BaseType (typeof (NSObject))]
-	[iOS (4,0)]
 	interface CTCallCenter {
 		[Availability (Deprecated = Platform.iOS_10_0, Message = "Use 'CallKit' instead.")]
 		[NullAllowed] // by default this property is null
@@ -110,7 +107,6 @@ namespace XamCore.CoreTelephony {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[iOS (4,0)]
 	interface CTCarrier {
 		[Export ("mobileCountryCode")]
 		string MobileCountryCode { get;  }

--- a/src/coretext.cs
+++ b/src/coretext.cs
@@ -18,7 +18,6 @@ namespace XamCore.CoreText {
 #else
 	[Partial]
 #endif
-	[iOS (3,2)]
 	interface CTFontFeatureKey {
 		[Field ("kCTFontFeatureTypeIdentifierKey")]
 		NSString Identifier { get; }
@@ -38,7 +37,6 @@ namespace XamCore.CoreText {
 #else
 	[Partial]
 #endif
-	[iOS (3,2)]
 	interface CTFontFeatureSelectorKey {
 		[Field ("kCTFontFeatureSelectorIdentifierKey")]
 		NSString Identifier { get; }
@@ -54,7 +52,6 @@ namespace XamCore.CoreText {
 	}
 
 	[Static]
-	[iOS (3,2)]
 	interface CTFontVariationAxisKey {
 
 		[Field ("kCTFontVariationAxisIdentifierKey")]

--- a/src/eventkit.cs
+++ b/src/eventkit.cs
@@ -28,7 +28,6 @@ using XamCore.UIKit;
 
 namespace XamCore.EventKit {
 
-	[iOS (5,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 #if XAMCORE_2_0 || MONOMAC
@@ -51,7 +50,6 @@ namespace XamCore.EventKit {
 		bool Refresh ();
 	}
 
-	[iOS (5,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (EKObject))]
 #if XAMCORE_4_0	
@@ -61,7 +59,7 @@ namespace XamCore.EventKit {
 #if !MONOMAC
 		// Never made avaialble on MonoMac
 		[Export ("UUID")]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_6_0, Message = "Use 'CalendarItemIdentifier' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'CalendarItemIdentifier' instead.")]
 		string UUID { get;  }
 #endif
 
@@ -138,7 +136,6 @@ namespace XamCore.EventKit {
 		string CalendarItemExternalIdentifier { get;  }
 	}
 	
-	[iOS (5,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (EKObject))]
 	interface EKSource {
@@ -150,7 +147,7 @@ namespace XamCore.EventKit {
 
 #if !MONOMAC
 		[Export ("calendars")]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0, Message = "Use 'GetCalendars (EKEntityType)' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'GetCalendars (EKEntityType)' instead.")]
 		NSSet Calendars { get;  }
 #endif
 
@@ -188,7 +185,6 @@ namespace XamCore.EventKit {
 #endif
 	}
 
-	[iOS (4,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (EKObject))]
 	[DisableDefaultCtor] // Documentation says to use the static methods FromDate/FromTimeInterval to create instances
@@ -232,7 +228,6 @@ namespace XamCore.EventKit {
 #endif
 	}
 
-	[iOS (4,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (EKObject))]
 	[DisableDefaultCtor]
@@ -257,26 +252,21 @@ namespace XamCore.EventKit {
 		[Export ("supportedEventAvailabilities")]
 		EKCalendarEventAvailability SupportedEventAvailabilities { get; }
 
-		[iOS (5,0)]
 		[Export ("calendarIdentifier")]
 		string CalendarIdentifier { get;  }
 
-		[iOS (5,0)]
 		[Export ("subscribed")]
 		bool Subscribed { [Bind ("isSubscribed")] get;  }
 
-		[iOS (5,0)]
 		[Export ("immutable")]
 		bool Immutable { [Bind ("isImmutable")] get;  }
 
 #if !MONOMAC
-		[iOS (5,0)]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0, Message = "Use 'Create (EKEntityType, EKEventStore)' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'Create (EKEntityType, EKEventStore)' instead.")]
 		[Static, Export ("calendarWithEventStore:")]
 		EKCalendar FromEventStore (EKEventStore eventStore);
 #endif
 
-		[iOS (5,0)]
 		[Export ("source", ArgumentSemantic.Retain)]
 		EKSource Source { get; set; }
 
@@ -290,7 +280,6 @@ namespace XamCore.EventKit {
 		EKCalendar Create (EKEntityType entityType, EKEventStore eventStore);
 	}
 
-	[iOS (4,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (EKCalendarItem))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: You must use [EKEvent eventWithStore:] to create an event
@@ -342,7 +331,7 @@ namespace XamCore.EventKit {
 		[Export ("birthdayPersonUniqueID")]
 		string BirthdayPersonUniqueID { get; }
 #else
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_9_0, Message = "Replaced by 'BirthdayContactIdentifier'.")]
+		[Availability (Deprecated = Platform.iOS_9_0, Message = "Replaced by 'BirthdayContactIdentifier'.")]
 		[Export ("birthdayPersonID")]
 		nint BirthdayPersonID { get;  }
 #endif
@@ -351,7 +340,6 @@ namespace XamCore.EventKit {
 		string BirthdayContactIdentifier { get; }
 	}
 
-	[iOS (4,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (EKObject))]
 #if XAMCORE_3_0
@@ -379,7 +367,7 @@ namespace XamCore.EventKit {
 //		ABPerson GetPerson (ABAddressBook addressBook);
 #else
 #if !WATCH
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_9_0, Message = "Replaced by 'ContactPredicate'.")]
+		[Availability (Deprecated = Platform.iOS_9_0, Message = "Replaced by 'ContactPredicate'.")]
 		[Export ("ABRecordWithAddressBook:")]
 		ABRecord GetRecord (ABAddressBook addressBook);
 #endif // !WATCH
@@ -395,7 +383,6 @@ namespace XamCore.EventKit {
 		NSPredicate ContactPredicate { get; }
 	}
 
-	[iOS (4,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	interface EKRecurrenceEnd : NSCopying {
@@ -414,7 +401,6 @@ namespace XamCore.EventKit {
 		EKRecurrenceEnd FromOccurrenceCount (nint occurrenceCount);
 	}
 
-	[iOS (4,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	interface EKRecurrenceDayOfWeek : NSCopying {
@@ -450,7 +436,6 @@ namespace XamCore.EventKit {
 		EKRecurrenceDayOfWeek FromDay (EKDay dayOfTheWeek, nint weekNumber);
 #endif
 
-		[iOS (5,0)]
 		[Export ("initWithDayOfTheWeek:weekNumber:")]
 #if XAMCORE_4_0
 		IntPtr Constructor (EKWeekday dayOfTheWeek, nint weekNumber);
@@ -459,7 +444,6 @@ namespace XamCore.EventKit {
 #endif
 	}
 
-	[iOS (4,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (EKObject))]
 	interface EKRecurrenceRule : NSCopying {
@@ -517,7 +501,6 @@ namespace XamCore.EventKit {
 
 	}
 
-	[iOS (4,0)]
 	[Mac (10,8, onlyOn64: true)]
 	[BaseType (typeof (NSObject))]
 	interface EKEventStore {
@@ -530,7 +513,7 @@ namespace XamCore.EventKit {
 
 #if !MONOMAC
 		[Export ("calendars")]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0, Message = "Use 'GetCalendars' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'GetCalendars' instead.")]
 		EKCalendar [] Calendars { get;  }
 #endif
 
@@ -563,50 +546,40 @@ namespace XamCore.EventKit {
 		[Notification]
 		NSString ChangedNotification { get; }
 
-		[iOS (5,0)]
 		[Export ("sources")]
 		EKSource [] Sources { get; }
 
-		[iOS (5,0)]
 		[return: NullAllowed]
 		[Export ("sourceWithIdentifier:")]
 		EKSource GetSource (string identifier);
 
-		[iOS (5,0)]
 		[Export ("calendarWithIdentifier:")]
 		EKCalendar GetCalendar (string identifier);
 
 		[NoWatch]
-		[iOS (5,0)]
 		[Export ("saveCalendar:commit:error:")]
 		bool SaveCalendar (EKCalendar calendar, bool commit, out NSError error);
 
 		[NoWatch]
-		[iOS (5,0)]
 		[Export ("removeCalendar:commit:error:")]
 		bool RemoveCalendar (EKCalendar calendar, bool commit, out NSError error);
 
 		[NoWatch]
-		[iOS (5,0)]
 		[Export ("saveEvent:span:commit:error:")]
 		bool SaveEvent (EKEvent ekEvent, EKSpan span, bool commit, out NSError error);
 
 		[NoWatch]
-		[iOS (5,0)]
 		[Export ("removeEvent:span:commit:error:")]
 		bool RemoveEvent (EKEvent ekEvent, EKSpan span, bool commit, out NSError error);
 
 		[NoWatch]
-		[iOS (5,0)]
 		[Export ("commit:")]
 		bool Commit (out NSError error);
 
-		[iOS (5,0)]
 		[Export ("reset")]
 		void Reset ();
 
 		[NoWatch]
-		[iOS (5,0)]
 		[Export ("refreshSourcesIfNecessary")]
 		void RefreshSourcesIfNecessary ();
 

--- a/src/eventkitui.cs
+++ b/src/eventkitui.cs
@@ -32,17 +32,14 @@ namespace XamCore.EventKitUI {
 		[Export ("allowsCalendarPreview")]
 		bool AllowsCalendarPreview { get; set;  }
 
-		[iOS (4,2)]
 		[Export ("delegate", ArgumentSemantic.Weak), NullAllowed]
 		NSObject WeakDelegate { get; set; }
 		
-		[iOS (4,2)]
 		[Wrap ("WeakDelegate")]
 		[Protocolize]
 		EKEventViewDelegate Delegate { get; set;  }
 	}
 
-	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -92,7 +89,6 @@ namespace XamCore.EventKitUI {
 		EKCalendar GetDefaultCalendarForNewEvents (EKEventEditViewController controller);
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (UIViewController),
 		   Delegates = new string [] { "WeakDelegate" },
 		   Events=new Type [] {typeof (EKCalendarChooserDelegate)})]
@@ -133,7 +129,6 @@ namespace XamCore.EventKitUI {
 		NSSet SelectedCalendars { get; set;  }
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -9918,7 +9918,6 @@ namespace XamCore.Foundation
 
 		[Export ("resolve")]
 		[Deprecated (PlatformName.iOS, 2, 0, message : "Use 'Resolve (double)' instead.")]
-		[Mac (10, 2)]
 		[Deprecated (PlatformName.MacOSX, 10, 4, message : "Use 'Resolve (double)' instead.")]
 		[NoWatch]
 		void Resolve ();

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -896,82 +896,82 @@ namespace XamCore.Foundation
 
 #if MONOMAC
 	// Obsolete, but the only API surfaced by WebKit.WebHistory.
-	[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10, Message="Use NSCalendar and NSDateComponents.")]
+	[Availability (Deprecated = Platform.Mac_10_10, Message="Use NSCalendar and NSDateComponents.")]
 	[BaseType (typeof (NSDate))]
 	interface NSCalendarDate {
 		[Export ("initWithString:calendarFormat:locale:")]
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		IntPtr Constructor (string description, string calendarFormat, NSObject locale);
 
 		[Export ("initWithString:calendarFormat:")]
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		IntPtr Constructor (string description, string calendarFormat);
 
 		[Export ("initWithString:")]
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		IntPtr Constructor (string description);
 
 		[Export ("initWithYear:month:day:hour:minute:second:timeZone:")]
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		IntPtr Constructor (nint year, nuint month, nuint day, nuint hour, nuint minute, nuint second, NSTimeZone aTimeZone);
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("dateByAddingYears:months:days:hours:minutes:seconds:")]
 		NSCalendarDate DateByAddingYears (nint year, nint month, nint day, nint hour, nint minute, nint second);
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("dayOfCommonEra")]
 		nint DayOfCommonEra { get; }
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("dayOfMonth")]
 		nint DayOfMonth { get; }
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("dayOfWeek")]
 		nint DayOfWeek { get; }
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("dayOfYear")]
 		nint DayOfYear { get; }
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("hourOfDay")]
 		nint HourOfDay { get; }
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("minuteOfHour")]
 		nint MinuteOfHour { get; }
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("monthOfYear")]
 		nint MonthOfYear { get; }
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("secondOfMinute")]
 		nint SecondOfMinute { get; }
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("yearOfCommonEra")]
 		nint YearOfCommonEra { get; }
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("calendarFormat")]
 		string CalendarFormat { get; set; }
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("descriptionWithCalendarFormat:locale:")]
 		string GetDescription (string calendarFormat, NSObject locale);
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("descriptionWithCalendarFormat:")]
 		string GetDescription (string calendarFormat);
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("descriptionWithLocale:")]
 		string GetDescription (NSLocale locale);
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_10)]
+		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Export ("timeZone")]
 		NSTimeZone TimeZone { get; set; }
 	}
@@ -1520,7 +1520,6 @@ namespace XamCore.Foundation
 		nint Nanosecond { get; set; }
 
 		[Export ("week")]
-		[Mac (10, 4)]
 		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use 'WeekOfMonth' or 'WeekOfYear' instead.")]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'WeekOfMonth' or 'WeekOfYear' instead.")]
 		nint Week { get; set; }

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -5095,12 +5095,10 @@ namespace XamCore.Foundation
 		
 	[BaseType (typeof (NSObject))]
 	interface NSUserDefaults {
-		[Mac (10,6)]
 		[Export ("URLForKey:")]
 		[return: NullAllowed]
 		NSUrl URLForKey (string defaultName);
 
-		[Mac (10,6)]
 		[Export ("setURL:forKey:")]
 		void SetURL ([NullAllowed] NSUrl url, string defaultName);
 
@@ -9221,7 +9219,6 @@ namespace XamCore.Foundation
 		[Export ("pathForSoundResource:")]
 		string PathForSoundResource (string resource);
 
-		[Mac (10,6)]
 		[Export ("URLForImageResource:")]
 		NSUrl GetUrlForImageResource (string resource);
 
@@ -12735,7 +12732,6 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // An uncaught exception was raised: *** -range cannot be sent to an abstract object of class NSTextCheckingResult: Create a concrete instance!
-	[Mac (10, 6)]
 	interface NSTextCheckingResult : NSSecureCoding, NSCopying {
 		[Export ("resultType")]
 		NSTextCheckingType ResultType { get;  }
@@ -12901,71 +12897,53 @@ namespace XamCore.Foundation
 
 	[StrongDictionary ("NSTextChecking")]
 	interface NSTextCheckingAddressComponents {
-		[Mac (10, 6)]
 		string Name { get; }
 
-		[Mac (10, 6)]
 		string JobTitle { get; }
 
-		[Mac (10, 6)]
 		string Organization { get; }
 
-		[Mac (10, 6)]
 		string Street { get; }
 
-		[Mac (10, 6)]
 		string City { get; }
 
-		[Mac (10, 6)]
 		string State { get; }
 
 		[Export ("ZipKey")]
-		[Mac (10, 6)]
 		string ZIP { get; }
 
-		[Mac (10, 6)]
 		string Country { get; }
 
-		[Mac (10, 6)]
 		string Phone { get; }
 	}
 
 	[Static]
 	interface NSTextChecking {
 		[Field ("NSTextCheckingNameKey")]
-		[Mac (10, 6)]
 		NSString NameKey { get; }
 
 		[Field ("NSTextCheckingJobTitleKey")]
-		[Mac (10, 6)]
 		NSString JobTitleKey { get; }
 
 		[Field ("NSTextCheckingOrganizationKey")]
-		[Mac (10, 6)]
 		NSString OrganizationKey { get; }
 
 		[Field ("NSTextCheckingStreetKey")]
-		[Mac (10, 6)]
 		NSString StreetKey { get; }
 
 		[Field ("NSTextCheckingCityKey")]
-		[Mac (10, 6)]
 		NSString CityKey { get; }
 
 		[Field ("NSTextCheckingStateKey")]
-		[Mac (10, 6)]
 		NSString StateKey { get; }
 
 		[Field ("NSTextCheckingZIPKey")]
-		[Mac (10, 6)]
 		NSString ZipKey { get; }
 
 		[Field ("NSTextCheckingCountryKey")]
-		[Mac (10, 6)]
 		NSString CountryKey { get; }
 
 		[Field ("NSTextCheckingPhoneKey")]
-		[Mac (10, 6)]
 		NSString PhoneKey { get; }
 
 		[Field ("NSTextCheckingAirlineKey")]

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -1530,7 +1530,6 @@ namespace XamCore.Foundation
 		[Export ("week")]
 		[Mac (10, 4)]
 		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use 'WeekOfMonth' or 'WeekOfYear' instead.")]
-		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'WeekOfMonth' or 'WeekOfYear' instead.")]
 		nint Week { get; set; }
 
@@ -10021,7 +10020,6 @@ namespace XamCore.Foundation
 		void Publish (NSNetServiceOptions options);
 
 		[Export ("resolve")]
-		[iOS (2, 0)]
 		[Deprecated (PlatformName.iOS, 2, 0, message : "Use 'Resolve (double)' instead.")]
 		[Mac (10, 2)]
 		[Deprecated (PlatformName.MacOSX, 10, 4, message : "Use 'Resolve (double)' instead.")]
@@ -13206,7 +13204,6 @@ namespace XamCore.Foundation
 		string Name { get; [NullAllowed] set; }
 	}
 
-	[iOS (2,0)]
 	[BaseType (typeof(NSObject))]
 	interface NSCondition : NSLocking
 	{

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -684,83 +684,83 @@ namespace XamCore.Foundation
 		NSString IslamicUmmAlQuraCalendar { get; }
 
 		[Export ("eraSymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] EraSymbols { get; }
 
 		[Export ("longEraSymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] LongEraSymbols { get; }
 
 		[Export ("monthSymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] MonthSymbols { get; }
 
 		[Export ("shortMonthSymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] ShortMonthSymbols { get; }
 
 		[Export ("veryShortMonthSymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] VeryShortMonthSymbols { get; }
 
 		[Export ("standaloneMonthSymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] StandaloneMonthSymbols { get; }
 
 		[Export ("shortStandaloneMonthSymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] ShortStandaloneMonthSymbols { get; }
 
 		[Export ("veryShortStandaloneMonthSymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] VeryShortStandaloneMonthSymbols { get; }
 
 		[Export ("weekdaySymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] WeekdaySymbols { get; }
 
 		[Export ("shortWeekdaySymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] ShortWeekdaySymbols { get; }
 
 		[Export ("veryShortWeekdaySymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] VeryShortWeekdaySymbols { get; }
 
 		[Export ("standaloneWeekdaySymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] StandaloneWeekdaySymbols { get; }
 
 		[Export ("shortStandaloneWeekdaySymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] ShortStandaloneWeekdaySymbols { get; }
 
 		[Export ("veryShortStandaloneWeekdaySymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] VeryShortStandaloneWeekdaySymbols { get; }
 
 		[Export ("quarterSymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] QuarterSymbols { get; }
 
 		[Export ("shortQuarterSymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] ShortQuarterSymbols { get; }
 
 		[Export ("standaloneQuarterSymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] StandaloneQuarterSymbols { get; }
 
 		[Export ("shortStandaloneQuarterSymbols")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string [] ShortStandaloneQuarterSymbols { get; }
 
 		[Export ("AMSymbol")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string AMSymbol { get; }
 
 		[Export ("PMSymbol")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		string PMSymbol { get; }
 
 		[Export ("compareDate:toDate:toUnitGranularity:")]
@@ -1516,7 +1516,7 @@ namespace XamCore.Foundation
 		nint Second { get; set; }
 
 		[Export ("nanosecond")]
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		nint Nanosecond { get; set; }
 
 		[Export ("week")]
@@ -1531,15 +1531,15 @@ namespace XamCore.Foundation
 		[Export ("weekdayOrdinal")]
 		nint WeekdayOrdinal { get; set; }
 
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		[Export ("weekOfMonth")]
 		nint WeekOfMonth { get; set; }
 
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		[Export ("weekOfYear")]
 		nint WeekOfYear { get; set; }
 		
-		[Mac(10,7)][iOS(5,0)]
+		[Mac(10,7)]
 		[Export ("yearForWeekOfYear")]
 		nint YearForWeekOfYear { get; set; }
 

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -3222,7 +3222,6 @@ namespace XamCore.Foundation
 		NSString QueryUpdateRemovedItemsKey { get; }
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -3234,7 +3233,6 @@ namespace XamCore.Foundation
 		NSObject ReplacementValueForAttributevalue (NSMetadataQuery query, string attributeName, NSObject value);
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 #if XAMCORE_4_0
 	[DisableDefaultCtor] // points to nothing so access properties crash the apps
@@ -3261,7 +3259,6 @@ namespace XamCore.Foundation
 		NSObject [] Attributes { get; }
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSMetadataQueryAttributeValueTuple {
 		[Export ("attribute")]
@@ -3274,7 +3271,6 @@ namespace XamCore.Foundation
 		nint Count { get; }
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSMetadataQueryResultGroup {
 		[Export ("attribute")]
@@ -4112,7 +4108,6 @@ namespace XamCore.Foundation
 
 	delegate void NSLingusticEnumerator (NSString tag, NSRange tokenRange, NSRange sentenceRange, ref bool stop);
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSLinguisticTagger {
 		[DesignatedInitializer]
@@ -4206,7 +4201,6 @@ namespace XamCore.Foundation
 
 	delegate void LinguisticTagEnumerator (string tag, NSRange tokenRange, bool stop);
 
-	[iOS (5,0)]
 	[Static]
 	interface NSLinguisticTag {
 		[Field ("NSLinguisticTagSchemeTokenType")]
@@ -4729,7 +4723,6 @@ namespace XamCore.Foundation
 	
 	[Category, BaseType (typeof (NSOrderedSet))]
 	partial interface NSKeyValueSorting_NSOrderedSet {
-		[iOS (5,0)]
 		[Export ("sortedArrayUsingDescriptors:")]
 		NSObject [] GetSortedArray (NSSortDescriptor [] sortDescriptors);
 	}
@@ -4738,13 +4731,13 @@ namespace XamCore.Foundation
 	[Category, BaseType (typeof (NSMutableArray))]
 #pragma warning restore 618
 	partial interface NSSortDescriptorSorting_NSMutableArray {
-		[iOS (5,0), Export ("sortUsingDescriptors:")]
+		[Export ("sortUsingDescriptors:")]
 		void SortUsingDescriptors (NSSortDescriptor [] sortDescriptors);
 	}
 
 	[Category, BaseType (typeof (NSMutableOrderedSet))]
 	partial interface NSKeyValueSorting_NSMutableOrderedSet {
-		[iOS (5,0), Export ("sortUsingDescriptors:")]
+		[Export ("sortUsingDescriptors:")]
 		void SortUsingDescriptors (NSSortDescriptor [] sortDescriptors);
 	}
 	
@@ -4887,7 +4880,6 @@ namespace XamCore.Foundation
 		NSUbiquitousKeyValueStoreChangeReason ChangeReason { get; }
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 #if WATCH
 	[Advice ("Not available on watchOS")]
@@ -5567,155 +5559,117 @@ namespace XamCore.Foundation
 		NSString VolumeSupportsCasePreservedNamesKey { get; }
 
 		// 5.0 Additions
-		[iOS (5,0)]
 		[Field ("NSURLKeysOfUnsetValuesKey")]
 		NSString KeysOfUnsetValuesKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLFileResourceIdentifierKey")]
 		NSString FileResourceIdentifierKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeIdentifierKey")]
 		NSString VolumeIdentifierKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLPreferredIOBlockSizeKey")]
 		NSString PreferredIOBlockSizeKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLIsReadableKey")]
 		NSString IsReadableKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLIsWritableKey")]
 		NSString IsWritableKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLIsExecutableKey")]
 		NSString IsExecutableKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLIsMountTriggerKey")]
 		NSString IsMountTriggerKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLFileSecurityKey")]
 		NSString FileSecurityKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeKey")]
 		NSString FileResourceTypeKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeNamedPipe")]
 		NSString FileResourceTypeNamedPipe { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeCharacterSpecial")]
 		NSString FileResourceTypeCharacterSpecial { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeDirectory")]
 		NSString FileResourceTypeDirectory { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeBlockSpecial")]
 		NSString FileResourceTypeBlockSpecial { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeRegular")]
 		NSString FileResourceTypeRegular { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeSymbolicLink")]
 		NSString FileResourceTypeSymbolicLink { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeSocket")]
 		NSString FileResourceTypeSocket { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLFileResourceTypeUnknown")]
 		NSString FileResourceTypeUnknown { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLTotalFileSizeKey")]
 		NSString TotalFileSizeKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLTotalFileAllocatedSizeKey")]
 		NSString TotalFileAllocatedSizeKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeSupportsRootDirectoryDatesKey")]
 		NSString VolumeSupportsRootDirectoryDatesKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeSupportsVolumeSizesKey")]
 		NSString VolumeSupportsVolumeSizesKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeSupportsRenamingKey")]
 		NSString VolumeSupportsRenamingKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeSupportsAdvisoryFileLockingKey")]
 		NSString VolumeSupportsAdvisoryFileLockingKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeSupportsExtendedSecurityKey")]
 		NSString VolumeSupportsExtendedSecurityKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeIsBrowsableKey")]
 		NSString VolumeIsBrowsableKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeMaximumFileSizeKey")]
 		NSString VolumeMaximumFileSizeKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeIsEjectableKey")]
 		NSString VolumeIsEjectableKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeIsRemovableKey")]
 		NSString VolumeIsRemovableKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeIsInternalKey")]
 		NSString VolumeIsInternalKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeIsAutomountedKey")]
 		NSString VolumeIsAutomountedKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeIsLocalKey")]
 		NSString VolumeIsLocalKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeIsReadOnlyKey")]
 		NSString VolumeIsReadOnlyKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeCreationDateKey")]
 		NSString VolumeCreationDateKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeURLForRemountingKey")]
 		NSString VolumeURLForRemountingKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeUUIDStringKey")]
 		NSString VolumeUUIDStringKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeNameKey")]
 		NSString VolumeNameKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLVolumeLocalizedNameKey")]
 		NSString VolumeLocalizedNameKey { get; }
 
@@ -5759,15 +5713,12 @@ namespace XamCore.Foundation
 		[Field ("NSURLVolumeAvailableCapacityForOpportunisticUsageKey")]
 		NSString VolumeAvailableCapacityForOpportunisticUsageKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLIsUbiquitousItemKey")]
 		NSString IsUbiquitousItemKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLUbiquitousItemHasUnresolvedConflictsKey")]
 		NSString UbiquitousItemHasUnresolvedConflictsKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLUbiquitousItemIsDownloadedKey")]
 		NSString UbiquitousItemIsDownloadedKey { get; }
 
@@ -5775,22 +5726,18 @@ namespace XamCore.Foundation
 		[Availability (Deprecated = Platform.iOS_7_0)]
 		NSString UbiquitousItemIsDownloadingKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLUbiquitousItemIsUploadedKey")]
 		NSString UbiquitousItemIsUploadedKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSURLUbiquitousItemIsUploadingKey")]
 		NSString UbiquitousItemIsUploadingKey { get; }
 
 		[Field ("NSURLUbiquitousItemPercentDownloadedKey")]
-		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'NSMetadataQuery.UbiquitousItemPercentDownloadedKey' on 'NSMetadataItem' instead.")]
 		[Mac (10, 7)]
 		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Use 'NSMetadataQuery.UbiquitousItemPercentDownloadedKey' on 'NSMetadataItem' instead.")]
 		NSString UbiquitousItemPercentDownloadedKey { get; }
 
-		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 6, 0, message : "Use 'NSMetadataQuery.UbiquitousItemPercentUploadedKey' on 'NSMetadataItem' instead.")]
 		[Mac (10, 7)]
 		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Use 'NSMetadataQuery.UbiquitousItemPercentUploadedKey' on 'NSMetadataItem' instead.")]
@@ -5833,7 +5780,6 @@ namespace XamCore.Foundation
 		[Field ("NSURLUbiquitousSharedItemPermissionsReadWrite")]
 		NSString UbiquitousSharedItemPermissionsReadWrite { get; }
 
-		[iOS (5,1)]
 		[Mac (10, 8)]
 		[Field ("NSURLIsExcludedFromBackupKey")]
 		NSString IsExcludedFromBackupKey { get; }
@@ -6287,7 +6233,6 @@ namespace XamCore.Foundation
 		[Export ("cancelAuthenticationChallenge:")]
 		void CancelAuthenticationChallenge (NSUrlAuthenticationChallenge challenge);
 
-		[iOS (5,0)]
 		[Export ("performDefaultHandlingForAuthenticationChallenge:")]
 #if XAMCORE_2_0
 		void PerformDefaultHandling (NSUrlAuthenticationChallenge challenge);
@@ -6296,7 +6241,6 @@ namespace XamCore.Foundation
 		void PerformDefaultHandlingForChallenge (NSUrlAuthenticationChallenge challenge);
 #endif
 
-		[iOS (5,0)]
 		[Export ("rejectProtectionSpaceAndContinueWithChallenge:")]
 #if XAMCORE_2_0
 		void RejectProtectionSpaceAndContinue (NSUrlAuthenticationChallenge challenge);
@@ -6355,20 +6299,16 @@ namespace XamCore.Foundation
 		void Unschedule (NSRunLoop aRunLoop, NSRunLoopMode forMode);
 
 #if !MONOMAC
-		[iOS (5,0)]
 		[Export ("originalRequest")]
 		NSUrlRequest OriginalRequest { get; }
 
-		[iOS (5,0)]
 		[Export ("currentRequest")]
 		NSUrlRequest CurrentRequest { get; }
 #endif
 		[Export ("setDelegateQueue:")]
-		[iOS (5,0)]
 		void SetDelegateQueue (NSOperationQueue queue);
 
 		[NoWatch]
-		[iOS (5,0)]
 		[Static]
 		[Export ("sendAsynchronousRequest:queue:completionHandler:")]
 		[Async (ResultTypeName = "NSUrlAsyncResult", MethodName="SendRequestAsync")]
@@ -6376,7 +6316,6 @@ namespace XamCore.Foundation
 		
 #if IOS
 		// Extension from iOS5, NewsstandKit
-		[iOS (5,0)]
 		[Export ("newsstandAssetDownload", ArgumentSemantic.Weak)]
 		XamCore.NewsstandKit.NKAssetDownload NewsstandAssetDownload { get; }
 #endif
@@ -7289,23 +7228,18 @@ namespace XamCore.Foundation
 		[Notification]
 		NSString WillUndoChangeNotification { get; }
 
-		[iOS (5,0)]
 		[Export ("setActionIsDiscardable:")]
 		void SetActionIsDiscardable (bool discardable);
 
-		[iOS (5,0)]
 		[Export ("undoActionIsDiscardable")]
 		bool UndoActionIsDiscardable { get; }
 
-		[iOS (5,0)]
 		[Export ("redoActionIsDiscardable")]
 		bool RedoActionIsDiscardable { get; }
 
-		[iOS (5,0)]
 		[Field ("NSUndoManagerGroupIsDiscardableKey")]
 		NSString GroupIsDiscardableKey { get; }
 
-		[iOS (5,0)]
 		[Field ("NSUndoManagerDidCloseUndoGroupNotification")]
 		[Notification (typeof (NSUndoManagerCloseUndoGroupEventArgs))]
 		NSString DidCloseUndoGroupNotification { get; }
@@ -7763,15 +7697,12 @@ namespace XamCore.Foundation
 		[Advanced, Field ("NSStreamNetworkServiceTypeVoIP")]
 		NSString NetworkServiceTypeVoIP { get; }
 
-		[iOS (5,0)]
 		[Advanced, Field ("NSStreamNetworkServiceTypeVideo")]
 		NSString NetworkServiceTypeVideo { get; }
 
-		[iOS (5,0)]
 		[Advanced, Field ("NSStreamNetworkServiceTypeBackground")]
 		NSString NetworkServiceTypeBackground { get; }
 
-		[iOS (5,0)]
 		[Advanced, Field ("NSStreamNetworkServiceTypeVoice")]
 		NSString NetworkServiceTypeVoice { get; }
 
@@ -8705,7 +8636,6 @@ namespace XamCore.Foundation
 	interface NSOrderedSet<TKey> : NSOrderedSet {}
 #endif
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSOrderedSet : NSSecureCoding, NSMutableCopying {
 		[Export ("initWithObject:")]
@@ -8800,7 +8730,6 @@ namespace XamCore.Foundation
 	interface NSMutableOrderedSet<TKey> : NSMutableOrderedSet {}
 #endif
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSOrderedSet))]
 	interface NSMutableOrderedSet {
 		[Export ("initWithObject:")]
@@ -9130,7 +9059,6 @@ namespace XamCore.Foundation
 		[Export ("cookieAcceptPolicy")]
 		NSHttpCookieAcceptPolicy AcceptPolicy { get; set; }
 
-		[iOS (5,0)]
 		[Export ("sortedCookiesUsingDescriptors:")]
 		NSHttpCookie [] GetSortedCookies (NSSortDescriptor [] sortDescriptors);
 
@@ -9170,7 +9098,6 @@ namespace XamCore.Foundation
 		[Export ("initWithURL:MIMEType:expectedContentLength:textEncodingName:")]
 		IntPtr Constructor (NSUrl url, string mimetype, nint expectedContentLength, [NullAllowed] string textEncodingName);
 
-		[iOS (5,0)]
 		[Export ("initWithURL:statusCode:HTTPVersion:headerFields:")]
 		IntPtr Constructor (NSUrl url, nint statusCode, string httpVersion, NSDictionary headerFields);
 		
@@ -9553,15 +9480,12 @@ namespace XamCore.Foundation
 		[Export ("containsIndexes:")]
 		bool Contains (NSIndexSet indexes);
 
-		[iOS (5,0)]
 		[Export ("enumerateRangesUsingBlock:")]
 		void EnumerateRanges (NSRangeIterator iterator);
 
-		[iOS (5,0)]
 		[Export ("enumerateRangesWithOptions:usingBlock:")]
 		void EnumerateRanges (NSEnumerationOptions opts, NSRangeIterator iterator);
 
-		[iOS (5,0)]
 		[Export ("enumerateRangesInRange:options:usingBlock:")]
 		void EnumerateRanges (NSRange range, NSEnumerationOptions opts, NSRangeIterator iterator);
 
@@ -9871,7 +9795,6 @@ namespace XamCore.Foundation
 		IntPtr MethodReturnType { get; }
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject), Name="NSJSONSerialization")]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: *** +[NSJSONSerialization allocWithZone:]: Do not create instances of NSJSONSerialization in this release
 	[DisableDefaultCtor]
@@ -10431,11 +10354,9 @@ namespace XamCore.Foundation
 		[Export ("valueWithDirectionalEdgeInsets:")]
 		NSValue FromDirectionalEdgeInsets (NSDirectionalEdgeInsets insets);
 
-		[iOS (5,0)]
 		[Export ("valueWithUIOffset:")][Static]
 		NSValue FromUIOffset (UIKit.UIOffset insets);
 
-		[iOS (5,0)]
 		[Export ("UIOffsetValue")]
 		UIOffset UIOffsetValue { get; }
 
@@ -11661,7 +11582,6 @@ namespace XamCore.Foundation
 
 	interface INSFilePresenter {}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface NSFileCoordinator {
 		[Static, Export ("addFilePresenter:")][PostGet ("FilePresenters")]
@@ -11724,7 +11644,7 @@ namespace XamCore.Foundation
 		[Export ("itemAtURL:willMoveToURL:")]
 		void WillMove (NSUrl oldUrl, NSUrl newUrl);
 
-		[iOS (5,0)][Mac (10,7)]
+		[Mac (10,7)]
 		[Export ("purposeIdentifier")]
 		string PurposeIdentifier { get; set; }
 
@@ -12219,7 +12139,6 @@ namespace XamCore.Foundation
 
 	delegate void NSFileVersionNonlocalVersionsCompletionHandler ([NullAllowed] NSFileVersion[] nonlocalFileVersions, [NullAllowed] NSError error);
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: -[NSFileVersion init]: You have to use one of the factory methods to instantiate NSFileVersion.
 	[DisableDefaultCtor]
@@ -12515,14 +12434,12 @@ namespace XamCore.Foundation
 
 	[Category, BaseType (typeof (NSOrderedSet))]
 	partial interface NSPredicateSupport_NSOrderedSet {
-		[iOS (5,0)]
 		[Export ("filteredOrderedSetUsingPredicate:")]
 		NSOrderedSet FilterUsingPredicate (NSPredicate p);
 	}
 	
 	[Category, BaseType (typeof (NSMutableOrderedSet))]
 	partial interface NSPredicateSupport_NSMutableOrderedSet {
-		[iOS (5,0)]
 		[Export ("filterUsingPredicate:")]
 		void FilterUsingPredicate (NSPredicate p);
 	}

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -175,7 +175,6 @@ namespace XamCore.Foundation
 	interface NSAttributedStringDocumentAttributes { }
 #endif
 
-	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	partial interface NSAttributedString : NSCoding, NSMutableCopying, NSSecureCoding
 	#if MONOMAC
@@ -516,7 +515,6 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject),
 		   Delegates=new string [] { "WeakDelegate" },
 		   Events=new Type [] { typeof (NSCacheDelegate)} )]
-	[iOS (4,0)]
 	interface NSCache {
 		[Export ("objectForKey:")]
 		NSObject ObjectForKey (NSObject key);
@@ -979,7 +977,6 @@ namespace XamCore.Foundation
 	}
 #endif
 
-	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	interface NSCharacterSet : NSSecureCoding, NSMutableCopying {
 		[Static, Export ("alphanumericCharacterSet", ArgumentSemantic.Copy)]
@@ -1440,7 +1437,6 @@ namespace XamCore.Foundation
 		void GetBytes (IntPtr buffer, NSRange range);
 
 		[Export ("rangeOfData:options:range:")]
-		[iOS (4,0)]
 		NSRange Find (NSData dataToFind, NSDataSearchOptions searchOptions, NSRange searchRange);
 
 		[iOS (7,0), Mac (10, 9)] // 10.9
@@ -1483,22 +1479,18 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSObject))]
 	interface NSDateComponents : NSSecureCoding, NSCopying, INSCopying, INSSecureCoding, INativeObject {
-		[iOS (4,0)]
 		[NullAllowed] // by default this property is null
 		[Export ("timeZone", ArgumentSemantic.Copy)]
 		NSTimeZone TimeZone { get; set; }
 
 		[NullAllowed] // by default this property is null
 		[Export ("calendar", ArgumentSemantic.Copy)]
-		[iOS (4,0)]
 		NSCalendar Calendar { get; set; }
 
 		[Export ("quarter")]
-		[iOS (4,0)]
 		nint Quarter { get; set; }
 
 		[Export ("date")]
-		[iOS (4,0)]
 		NSDate Date { get; }
 
 		//Detected properties
@@ -1994,7 +1986,6 @@ namespace XamCore.Foundation
 		[Export ("fileDescriptor")]
 		int FileDescriptor { get; } /* int, not NSInteger */
 
-		[iOS (5,0)]
 		[Export ("setReadabilityHandler:")]
 #if XAMCORE_2_0
 		void SetReadabilityHandler ([NullAllowed] Action<NSFileHandle> readCallback);
@@ -2002,7 +1993,6 @@ namespace XamCore.Foundation
 		void SetReadabilityHandler ([NullAllowed] NSFileHandleUpdateHandler readCallback);
 #endif
 
-		[iOS (5,0)]
 		[Export ("setWriteabilityHandler:")]
 #if XAMCORE_2_0
 		void SetWriteabilityHandle ([NullAllowed] Action<NSFileHandle> writeCallback);
@@ -2360,7 +2350,6 @@ namespace XamCore.Foundation
 
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject), Delegates=new string [] { "Delegate" }, Events=new Type [] { typeof (NSMetadataQueryDelegate)})]
 	interface NSMetadataQuery {
 		[Export ("startQuery")]
@@ -3376,7 +3365,6 @@ namespace XamCore.Foundation
 	
 	interface NSMutableArray<TValue> : NSMutableArray {}
 
-	[iOS (3,2)]
 	[BaseType (typeof (NSAttributedString))]
 	interface NSMutableAttributedString {
 		[Export ("initWithString:")]
@@ -4671,7 +4659,6 @@ namespace XamCore.Foundation
 		bool IsSubsetOf (NSSet other);
 		
 		[Export ("enumerateObjectsUsingBlock:")]
-		[iOS (4,0)]
 		void Enumerate (NSSetEnumerator enumerator);
 
 		[Internal]
@@ -5117,12 +5104,12 @@ namespace XamCore.Foundation
 		
 	[BaseType (typeof (NSObject))]
 	interface NSUserDefaults {
-		[Mac (10,6)][iOS (4,0)]
+		[Mac (10,6)]
 		[Export ("URLForKey:")]
 		[return: NullAllowed]
 		NSUrl URLForKey (string defaultName);
 
-		[Mac (10,6)][iOS (4,0)]
+		[Mac (10,6)]
 		[Export ("setURL:forKey:")]
 		void SetURL ([NullAllowed] NSUrl url, string defaultName);
 
@@ -5785,7 +5772,7 @@ namespace XamCore.Foundation
 		NSString UbiquitousItemIsDownloadedKey { get; }
 
 		[Field ("NSURLUbiquitousItemIsDownloadingKey")]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0)]
+		[Availability (Deprecated = Platform.iOS_7_0)]
 		NSString UbiquitousItemIsDownloadingKey { get; }
 
 		[iOS (5,0)]
@@ -8587,7 +8574,6 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-	[iOS (4,0)]
 	interface NSOperation {
 		[Export ("start")]
 		void Start ();
@@ -8651,7 +8637,6 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSOperation))]
-	[iOS (4,0)]
 	interface NSBlockOperation {
 		[Static]
 		[Export ("blockOperationWithBlock:")]
@@ -8665,7 +8650,6 @@ namespace XamCore.Foundation
 	}
 
 	[BaseType (typeof (NSObject))]
-	[iOS (4,0)]
 	interface NSOperationQueue {
 		[Export ("addOperation:")][PostGet ("Operations")]
 		void AddOperation ([NullAllowed] NSOperation op);
@@ -9325,43 +9309,33 @@ namespace XamCore.Foundation
 #endif
 
 		[Export ("bundleURL")]
-		[iOS (4,0)]
 		NSUrl BundleUrl { get; }
 		
 		[Export ("resourceURL")]
-		[iOS (4,0)]
 		NSUrl ResourceUrl { get; }
 
 		[Export ("executableURL")]
-		[iOS (4,0)]
 		NSUrl ExecutableUrl { get; }
 
 		[Export ("URLForAuxiliaryExecutable:")]
-		[iOS (4,0)]
 		NSUrl UrlForAuxiliaryExecutable (string executable);
 
 		[Export ("privateFrameworksURL")]
-		[iOS (4,0)]
 		NSUrl PrivateFrameworksUrl { get; }
 
 		[Export ("sharedFrameworksURL")]
-		[iOS (4,0)]
 		NSUrl SharedFrameworksUrl { get; }
 
 		[Export ("sharedSupportURL")]
-		[iOS (4,0)]
 		NSUrl SharedSupportUrl { get; }
 
 		[Export ("builtInPlugInsURL")]
-		[iOS (4,0)]
 		NSUrl BuiltInPluginsUrl { get; }
 
 		[Export ("initWithURL:")]
-		[iOS (4,0)]
 		IntPtr Constructor (NSUrl url);
 		
 		[Static, Export ("bundleWithURL:")]
-		[iOS (4,0)]
 		NSBundle FromUrl (NSUrl url);
 
 		[Export ("preferredLocalizations")]
@@ -10223,7 +10197,6 @@ namespace XamCore.Foundation
 		[PostSnippet ("RemoveObserversFromList (observer, aName, anObject);")]
 		void RemoveObserver (NSObject observer, [NullAllowed] string aName, [NullAllowed] NSObject anObject);
 
-		[iOS (4,0)]
 		[Export ("addObserverForName:object:queue:usingBlock:")]
 #if XAMCORE_2_0
 		NSObject AddObserver ([NullAllowed] string name, [NullAllowed] NSObject obj, [NullAllowed] NSOperationQueue queue, Action<NSNotification> handler);
@@ -10418,22 +10391,22 @@ namespace XamCore.Foundation
 #endif
 #else
 #if !WATCH
-		[Static, Export ("valueWithCMTime:"), iOS (4,0)]
+		[Static, Export ("valueWithCMTime:")]
 		NSValue FromCMTime (CMTime time);
 		
-		[Export ("CMTimeValue"), iOS (4,0)]
+		[Export ("CMTimeValue")]
 		CMTime CMTimeValue { get; }
 		
-		[Static, Export ("valueWithCMTimeMapping:"), iOS (4,0)]
+		[Static, Export ("valueWithCMTimeMapping:")]
 		NSValue FromCMTimeMapping (CMTimeMapping timeMapping);
 		
-		[Export ("CMTimeMappingValue"), iOS (4,0)]
+		[Export ("CMTimeMappingValue")]
 		CMTimeMapping CMTimeMappingValue { get; }
 		
-		[Static, Export ("valueWithCMTimeRange:"), iOS (4,0)]
+		[Static, Export ("valueWithCMTimeRange:")]
 		NSValue FromCMTimeRange (CMTimeRange timeRange);
 		
-		[Export ("CMTimeRangeValue"), iOS (4,0)]
+		[Export ("CMTimeRangeValue")]
 		CMTimeRange CMTimeRangeValue { get; }
 #endif
 		
@@ -11659,7 +11632,6 @@ namespace XamCore.Foundation
 	}
 	
 	[BaseType (typeof (NSMutableData))]
-	[iOS (4,0)]
 	interface NSPurgeableData : NSSecureCoding, NSMutableCopying, NSDiscardableContent {
 	}
 
@@ -11856,23 +11828,18 @@ namespace XamCore.Foundation
 		NSString Busy { get; }
 
 #if !MONOMAC
-		[iOS (4,0)]
 		[Field ("NSFileProtectionKey")]
 		NSString FileProtectionKey { get; }
 
-		[iOS (4,0)]
 		[Field ("NSFileProtectionNone")]
 		NSString FileProtectionNone { get; }
 
-		[iOS (4,0)]
 		[Field ("NSFileProtectionComplete")]
 		NSString FileProtectionComplete { get; }
 
-		[iOS (5,0)]
 		[Field ("NSFileProtectionCompleteUnlessOpen")]
 		NSString FileProtectionCompleteUnlessOpen { get; }
 
-		[iOS (5,0)]
 		[Field ("NSFileProtectionCompleteUntilFirstUserAuthentication")]
 		NSString FileProtectionCompleteUntilFirstUserAuthentication  { get; }
 #endif
@@ -11993,27 +11960,21 @@ namespace XamCore.Foundation
 		[Export ("createFileAtPath:contents:attributes:")]
 		bool CreateFile (string path, NSData data, [NullAllowed] NSDictionary attr);
 
-		[iOS (4,0)]
 		[Export ("contentsOfDirectoryAtURL:includingPropertiesForKeys:options:error:")]
 		NSUrl[] GetDirectoryContent (NSUrl url, [NullAllowed] NSArray properties, NSDirectoryEnumerationOptions options, out NSError error);
 
-		[iOS (4,0)]
 		[Export ("copyItemAtURL:toURL:error:")]
 		bool Copy (NSUrl srcUrl, NSUrl dstUrl, out NSError error);
 
-		[iOS (4,0)]
 		[Export ("moveItemAtURL:toURL:error:")]
 		bool Move (NSUrl srcUrl, NSUrl dstUrl, out NSError error);
 
-		[iOS (4,0)]
 		[Export ("linkItemAtURL:toURL:error:")]
 		bool Link (NSUrl srcUrl, NSUrl dstUrl, out NSError error);
 
-		[iOS (4,0)]
 		[Export ("removeItemAtURL:error:")]
 		bool Remove ([NullAllowed] NSUrl url, out NSError error);
 
-		[iOS (4,0)]
 		[Export ("enumeratorAtURL:includingPropertiesForKeys:options:errorHandler:")]
 #if XAMCORE_2_0
 		NSDirectoryEnumerator GetEnumerator (NSUrl url, [NullAllowed] NSString[] keys, NSDirectoryEnumerationOptions options, [NullAllowed] NSEnumerateErrorHandler handler);
@@ -12021,19 +11982,15 @@ namespace XamCore.Foundation
 		NSDirectoryEnumerator GetEnumerator (NSUrl url, [NullAllowed] NSArray properties, NSDirectoryEnumerationOptions options, [NullAllowed] NSEnumerateErrorHandler handler);
 #endif
 
-		[iOS (4,0)]
 		[Export ("URLForDirectory:inDomain:appropriateForURL:create:error:")]
 		NSUrl GetUrl (NSSearchPathDirectory directory, NSSearchPathDomain domain, [NullAllowed] NSUrl url, bool shouldCreate, out NSError error);
 
-		[iOS (4,0)]
 		[Export ("URLsForDirectory:inDomains:")]
 		NSUrl[] GetUrls (NSSearchPathDirectory directory, NSSearchPathDomain domains);
 
-		[iOS (4,0)]
 		[Export ("replaceItemAtURL:withItemAtURL:backupItemName:options:resultingItemURL:error:")]
 		bool Replace (NSUrl originalItem, NSUrl newItem, [NullAllowed] string backupItemName, NSFileManagerItemReplacementOptions options, out NSUrl resultingURL, out NSError error);
 
-		[iOS (4,0)]
 		[Export ("mountedVolumeURLsIncludingResourceValuesForKeys:options:")]
 		NSUrl[] GetMountedVolumes ([NullAllowed] NSArray properties, NSVolumeEnumerationOptions options);
 
@@ -12046,35 +12003,27 @@ namespace XamCore.Foundation
 		//[Export ("stringWithFileSystemRepresentation:length:")]
 		//string StringWithFileSystemRepresentation (const char str, uint len);
 
-		[iOS (5,0)]
 		[Export ("createDirectoryAtURL:withIntermediateDirectories:attributes:error:")]
 		bool CreateDirectory (NSUrl url, bool createIntermediates, [NullAllowed] NSDictionary attributes, out NSError error);
 
-		[iOS (5,0)]
                 [Export ("createSymbolicLinkAtURL:withDestinationURL:error:")]
                 bool CreateSymbolicLink (NSUrl url, NSUrl destURL, out NSError error);
 
-		[iOS (5,0)]
                 [Export ("setUbiquitous:itemAtURL:destinationURL:error:")]
                 bool SetUbiquitous (bool flag, NSUrl url, NSUrl destinationUrl, out NSError error);
 
-		[iOS (5,0)]
                 [Export ("isUbiquitousItemAtURL:")]
                 bool IsUbiquitous (NSUrl url);
 
-		[iOS (5,0)]
                 [Export ("startDownloadingUbiquitousItemAtURL:error:")]
                 bool StartDownloadingUbiquitous (NSUrl url, out NSError error);
 
-		[iOS (5,0)]
                 [Export ("evictUbiquitousItemAtURL:error:")]
                 bool EvictUbiquitous (NSUrl url, out NSError error);
 
-		[iOS (5,0)]
                 [Export ("URLForUbiquityContainerIdentifier:")]
                 NSUrl GetUrlForUbiquityContainer ([NullAllowed] string containerIdentifier);
 
-		[iOS (5,0)]
                 [Export ("URLForPublishingUbiquitousItemAtURL:expirationDate:error:")]
                 NSUrl GetUrlForPublishingUbiquitousItem (NSUrl url, out NSDate expirationDate, out NSError error);
 
@@ -12527,7 +12476,6 @@ namespace XamCore.Foundation
 	delegate bool NSPredicateEvaluator (NSObject evaluatedObject, NSDictionary bindings);
 	
 	[BaseType (typeof (NSObject))]
-	[iOS (4,0)]
 	// 'init' returns NIL
 	[DisableDefaultCtor]
 	interface NSPredicate : NSSecureCoding, NSCopying {
@@ -12872,7 +12820,6 @@ namespace XamCore.Foundation
 
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // An uncaught exception was raised: *** -range cannot be sent to an abstract object of class NSTextCheckingResult: Create a concrete instance!
-	[iOS (4, 0)]
 	[Mac (10, 6)]
 	interface NSTextCheckingResult : NSSecureCoding, NSCopying {
 		[Export ("resultType")]
@@ -12898,7 +12845,6 @@ namespace XamCore.Foundation
 		double TimeInterval { get; }
 
 		[Export ("components")]
-		[iOS (4, 0)]
 		[Mac (10, 7)]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSDictionary WeakComponents { get; }
@@ -12919,12 +12865,10 @@ namespace XamCore.Foundation
 
 //		NSRegularExpression isn't bound
 //		[Export ("regularExpression")]
-//		[iOS (4, 0)]
 //		[Mac (10, 7)]
 //		NSRegularExpression RegularExpression { get; }
 
 		[Export ("phoneNumber")]
-		[iOS (4, 0)]
 		[Mac (10, 7)]
 		string PhoneNumber { get; }
 
@@ -12936,17 +12880,14 @@ namespace XamCore.Foundation
 		NSTextCheckingAddressComponents AddressComponents { get; }
 
 		[Export ("numberOfRanges")]
-		[iOS (4, 0)]
 		[Mac (10, 7)]
 		nuint NumberOfRanges { get; }
 
 		[Export ("rangeAtIndex:")]
-		[iOS (4, 0)]
 		[Mac (10, 7)]
 		NSRange RangeAtIndex (nuint idx);
 
 		[Export ("resultByAdjustingRangesWithOffset:")]
-		[iOS (5, 0)]
 		[Mac (10, 7)]
 		NSTextCheckingResult ResultByAdjustingRanges (nint offset);
 
@@ -13009,20 +12950,17 @@ namespace XamCore.Foundation
 
 //		NSRegularExpression isn't bound
 //		[Export ("regularExpressionCheckingResultWithRanges:count:regularExpression:")]
-//		[iOS (4, 0)]
 //		[Mac (10, 7)]
 //		[Internal] // FIXME
 //		NSTextCheckingResult RegularExpressionCheckingResult (ref NSRange ranges, nuint count, NSRegularExpression regularExpression);
 
 		[Static]
 		[Export ("phoneNumberCheckingResultWithRange:phoneNumber:")]
-		[iOS (4, 0)]
 		[Mac (10, 7)]
 		NSTextCheckingResult PhoneNumberCheckingResult (NSRange range, string phoneNumber);
 
 		[Static]
 		[Export ("transitInformationCheckingResultWithRange:components:")]
-		[iOS (4, 0)]
 		[Mac (10, 7)]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSTextCheckingResult TransitInformationCheckingResult (NSRange range, NSDictionary components);
@@ -13039,51 +12977,40 @@ namespace XamCore.Foundation
 
 	[StrongDictionary ("NSTextChecking")]
 	interface NSTextCheckingTransitComponents {
-		[iOS (4, 0)]
 		[Mac (10, 7)]
 		string Airline { get; }
 
-		[iOS (4, 0)]
 		[Mac (10, 7)]
 		string Flight { get; }
 	}
 
 	[StrongDictionary ("NSTextChecking")]
 	interface NSTextCheckingAddressComponents {
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		string Name { get; }
 
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		string JobTitle { get; }
 
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		string Organization { get; }
 
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		string Street { get; }
 
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		string City { get; }
 
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		string State { get; }
 
 		[Export ("ZipKey")]
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		string ZIP { get; }
 
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		string Country { get; }
 
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		string Phone { get; }
 	}
@@ -13091,57 +13018,46 @@ namespace XamCore.Foundation
 	[Static]
 	interface NSTextChecking {
 		[Field ("NSTextCheckingNameKey")]
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		NSString NameKey { get; }
 
 		[Field ("NSTextCheckingJobTitleKey")]
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		NSString JobTitleKey { get; }
 
 		[Field ("NSTextCheckingOrganizationKey")]
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		NSString OrganizationKey { get; }
 
 		[Field ("NSTextCheckingStreetKey")]
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		NSString StreetKey { get; }
 
 		[Field ("NSTextCheckingCityKey")]
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		NSString CityKey { get; }
 
 		[Field ("NSTextCheckingStateKey")]
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		NSString StateKey { get; }
 
 		[Field ("NSTextCheckingZIPKey")]
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		NSString ZipKey { get; }
 
 		[Field ("NSTextCheckingCountryKey")]
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		NSString CountryKey { get; }
 
 		[Field ("NSTextCheckingPhoneKey")]
-		[iOS (4, 0)]
 		[Mac (10, 6)]
 		NSString PhoneKey { get; }
 
 		[Field ("NSTextCheckingAirlineKey")]
-		[iOS (4, 0)]
 		[Mac (10, 7)]
 		NSString AirlineKey { get; }
 
 		[Field ("NSTextCheckingFlightKey")]
-		[iOS (4, 0)]
 		[Mac (10, 7)]
 		NSString FlightKey { get; }
 	}

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -82,7 +82,7 @@ namespace XamCore.GameKit {
 	[NoWatch]
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_7_0, Message = "Use 'MCBrowserViewController' from the 'MultipeerConnectivity' framework instead.")]
+	[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'MCBrowserViewController' from the 'MultipeerConnectivity' framework instead.")]
 	interface GKPeerPickerController {
 		[Export ("connectionTypesMask", ArgumentSemantic.Assign)]
 		GKPeerPickerConnectionType ConnectionTypesMask { get; set; }
@@ -136,7 +136,7 @@ namespace XamCore.GameKit {
 	[NoWatch] // deprecated in 2.0 (but framework not added before 3.0)
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_7_0, Message = "Use 'GKVoiceChat' instead.")]
+	[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'GKVoiceChat' instead.")]
 	interface GKVoiceChatService {
 
 		[Export ("defaultVoiceChatService")][Static]
@@ -218,7 +218,6 @@ namespace XamCore.GameKit {
 	[NoTV]
 	[NoWatch] // deprecated in 2.0 (but framework not added before 3.0)
 	[BaseType (typeof (NSObject))]
-	[iOS (3, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'MultipeerConnectivity.MCSession' instead.")]
 	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'MultipeerConnectivity.MCSession' instead.")]
@@ -879,7 +878,6 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[iOS (4,2)]
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(GKMatchDelegate)})]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: -[__NSCFDictionary setObject:forKey:]: attempt to insert nil value (key: 1500388194)
 	// <quote>Your application never directly allocates GKMatch objects.</quote> http://developer.apple.com/library/ios/#documentation/GameKit/Reference/GKMatch_Ref/Reference/Reference.html
@@ -945,7 +943,6 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -987,7 +984,6 @@ namespace XamCore.GameKit {
 		[NoTV]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'ShouldReinviteDisconnectedPlayer' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'ShouldReinviteDisconnectedPlayer' instead.")]
-		[iOS (5,0)]
 		[Export ("match:shouldReinvitePlayer:"), DelegateName ("GKMatchReinvitation"), DefaultValue (true)]
 		bool ShouldReinvitePlayer (GKMatch match, string playerId);
 
@@ -995,7 +991,7 @@ namespace XamCore.GameKit {
 		[Export ("match:didReceiveData:fromRemotePlayer:"), EventArgs ("GKMatchReceivedDataFromRemotePlayer")]
 		void DataReceivedFromPlayer (GKMatch match, NSData data, GKPlayer player);
 
-		[iOS (4,1), Mac (10,8)] //Yes, the header file says it was available in 4.1 and 10.8...
+		[Mac (10,8)] //Yes, the header file says it was available in 4.1 and 10.8...
 		[Export ("match:player:didChangeConnectionState:"), EventArgs ("GKMatchConnectionChanged")]
 		void StateChangedForPlayer (GKMatch match, GKPlayer player, GKPlayerConnectionState state);
 
@@ -1011,7 +1007,6 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	interface GKVoiceChat {
 		[Export ("name", ArgumentSemantic.Copy)]
@@ -1237,7 +1232,6 @@ namespace XamCore.GameKit {
 	[Mac (10,8)]
 #else
 	[BaseType (typeof (UINavigationController), Delegates=new string [] { "WeakMatchmakerDelegate" }, Events=new Type [] {typeof(GKMatchmakerViewControllerDelegate)})]
-	[iOS (4,2)]
 #endif
 	// iOS 6 -> Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: <GKMatchmakerViewController: 0x16101160>: must use one of the designated initializers
 	[DisableDefaultCtor]

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -309,7 +309,7 @@ namespace XamCore.GameKit {
 #endif
 
 	[Watch (3,0)]
-	[iOS (4,2), Mac (10, 8)]
+	[Mac (10, 8)]
 	[BaseType (typeof (NSObject))]
 	interface GKLeaderboard {
 		[Export ("timeScope", ArgumentSemantic.Assign)]
@@ -363,7 +363,6 @@ namespace XamCore.GameKit {
 		[NoTV]
 		[NoWatch] // deprecated in 2.0 (but framework not added before 3.0)
 		[Static]
-		[iOS (5,0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'SetDefaultLeaderboard' on 'GKLocalPlayer' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'SetDefaultLeaderboard' on 'GKLocalPlayer' instead.")]
 		[Export ("setDefaultLeaderboard:withCompletionHandler:")]
@@ -463,7 +462,6 @@ namespace XamCore.GameKit {
 	}
 
 	[Watch (3,0)]
-	[iOS (4,2)]
 	[BaseType (typeof (GKBasePlayer))]
 	// note: NSSecureCoding conformity is undocumented - but since it's a runtime check (on ObjC) we still need it
 	interface GKPlayer : NSSecureCoding {
@@ -490,7 +488,6 @@ namespace XamCore.GameKit {
 		NSString DidChangeNotificationNameNotification { get; }
 
 		[NoWatch]
-		[iOS (5,0)]
 		[Export ("loadPhotoForSize:withCompletionHandler:")]
 		[Async]
 		void LoadPhoto (GKPhotoSize size, [NullAllowed] GKPlayerPhotoLoaded onCompleted);
@@ -514,7 +511,6 @@ namespace XamCore.GameKit {
 	}
 
 	[Watch (3,0)]
-	[iOS (4,1)]
 	[BaseType (typeof (NSObject))]
 	interface GKScore : NSSecureCoding {
 		[NoWatch]
@@ -570,7 +566,6 @@ namespace XamCore.GameKit {
 
 		[NoWatch]
 		[NoTV]
-		[iOS (4, 1)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'LeaderboardIdentifier' instead.")]
 		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'LeaderboardIdentifier' instead.")]
@@ -585,7 +580,6 @@ namespace XamCore.GameKit {
 
 		[NoWatch]
 		[NoTV]
-		[iOS (4, 1)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'ReportScores' instead.")]
 		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'ReportScores' instead.")]
@@ -597,11 +591,9 @@ namespace XamCore.GameKit {
 		void ReportScore ([NullAllowed] GKNotificationHandler errorHandler);
 #endif
 
-		[iOS (5,0)]
 		[Export ("context", ArgumentSemantic.Assign)]
 		ulong Context { get; set; }
 
-		[iOS (5,0)]
 		[Export ("shouldSetDefaultLeaderboard", ArgumentSemantic.Assign)]
 		bool ShouldSetDefaultLeaderboard { get; set; }
 
@@ -653,7 +645,6 @@ namespace XamCore.GameKit {
 
 	[NoWatch]
 	[NoTV]
-	[iOS (4,2)]
 	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'GKGameCenterViewController' instead.")]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKGameCenterViewController' instead.")]
 	[BaseType (typeof (NSObject))]
@@ -669,7 +660,6 @@ namespace XamCore.GameKit {
 	}
 
 	[NoTV][NoWatch]
-	[iOS (4, 2)]
 	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'GKGameCenterViewController' instead.")]
 	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKGameCenterViewController' instead.")]
@@ -704,7 +694,6 @@ namespace XamCore.GameKit {
 	}
 
 	[Watch (3,0)]
-	[iOS (4,2)]
 	[Mac (10, 8)]
 	[BaseType (typeof (GKPlayer))]
 	interface GKLocalPlayer {
@@ -1048,7 +1037,6 @@ namespace XamCore.GameKit {
 		void SetPlayerVoiceChatStateChangeHandler (Action<GKPlayer,GKVoiceChatPlayerState> handler);
 
 		[NoTV]
-		[iOS (5,0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'Players' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'Players' instead.")]
 		[Export ("playerIDs")]
@@ -1263,19 +1251,16 @@ namespace XamCore.GameKit {
 #endif
 
 		[NoTV]
-		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0)]
 		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[Export ("defaultInvitationMessage", ArgumentSemantic.Copy)]
 		string DefaultInvitationMessage { get; set;  }
 
-		[iOS (5,0)]
 		[Export ("addPlayersToMatch:")]
 		void AddPlayersToMatch (GKMatch match);
 
 		[NoTV]
-		[iOS (5,0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'SetHostedPlayerConnected (GKPlayer,bool)' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'SetHostedPlayerConnected (GKPlayer,bool)' instead.")]
 		[Export ("setHostedPlayer:connected:")]
@@ -1289,7 +1274,6 @@ namespace XamCore.GameKit {
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[iOS (4,2)]
 	[Protocol]
 	interface GKMatchmakerViewControllerDelegate {
 		[Abstract]
@@ -1323,7 +1307,6 @@ namespace XamCore.GameKit {
 		void DidFindHostedPlayers (GKMatchmakerViewController viewController, GKPlayer [] playerIDs);
 
 		[NoTV]
-		[iOS (5,0)]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'HostedPlayerDidAccept' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'HostedPlayerDidAccept' instead.")]
 		[Export ("matchmakerViewController:didReceiveAcceptFromHostedPlayer:"), EventArgs ("GKPlayer")]
@@ -1335,7 +1318,7 @@ namespace XamCore.GameKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[iOS (4,2)][Mac (10, 8)]
+	[Mac (10, 8)]
 	[Watch (3,0)]
 	interface GKAchievement : NSSecureCoding {
 		[NoTV]
@@ -1395,7 +1378,6 @@ namespace XamCore.GameKit {
 		void ReportAchievement ([NullAllowed] GKNotificationHandler completionHandler);
 #endif
 
-		[iOS (5,0)]
 		[Export ("showsCompletionBanner", ArgumentSemantic.Assign)]
 		bool ShowsCompletionBanner { get; set;  }
 
@@ -1486,7 +1468,7 @@ namespace XamCore.GameKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[iOS (4,2)][Mac (10, 8)]
+	[Mac (10, 8)]
 	[Watch (3,0)]
 	interface GKAchievementDescription : NSSecureCoding {
 		[Export ("identifier", ArgumentSemantic.Copy)]
@@ -1557,7 +1539,6 @@ namespace XamCore.GameKit {
 
 	[NoWatch]
 	[NoTV]
-	[iOS (4, 1)]
 	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'GKGameCenterViewController' instead.")]
 	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKGameCenterViewController' instead.")]
@@ -1574,7 +1555,6 @@ namespace XamCore.GameKit {
 	}
 
 	[NoTV][NoWatch]
-	[iOS (4, 1)]
 	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'GKGameCenterViewController' instead.")]
 	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKGameCenterViewController' instead.")]
@@ -1623,7 +1603,6 @@ namespace XamCore.GameKit {
 	interface GKFriendRequestComposeViewController 
 #else
 	[NoTV]
-	[iOS (4,2)]
 	[Deprecated (PlatformName.iOS, 10, 0)]
 	[BaseType (typeof (UINavigationController), Events=new Type [] { typeof (GKFriendRequestComposeViewControllerDelegate)}, Delegates=new string[] {"WeakComposeViewDelegate"})]
 	interface GKFriendRequestComposeViewController : UIAppearance
@@ -1674,7 +1653,6 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[iOS (5,0)]
 	[BaseType(typeof(NSObject))]
 	partial interface GKNotificationBanner {
 		[Static, Export ("showBannerWithTitle:message:completionHandler:")]
@@ -1687,7 +1665,6 @@ namespace XamCore.GameKit {
 		void Show ([NullAllowed] string title, [NullAllowed] string message, double durationSeconds, [NullAllowed] Action completionHandler);
 	}
 
-	[iOS (5,0)]
 	[Watch (3,0)]
 	[BaseType (typeof (NSObject))]
 	interface GKTurnBasedParticipant {
@@ -1719,7 +1696,6 @@ namespace XamCore.GameKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
-	[iOS (5, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'GKLocalPlayer.RegisterListener' with an object that implements 'IGKTurnBasedEventListener'.")]
 	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'GKLocalPlayer.RegisterListener' with an object that implements 'IGKTurnBasedEventListener'.")]
@@ -1735,13 +1711,11 @@ namespace XamCore.GameKit {
 		[Abstract]
 #endif
 		[Export ("handleInviteFromGameCenter:")]
-		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0)]
 		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		void HandleInviteFromGameCenter (NSString [] playersToInvite);
 
-		[iOS (5, 0)]
 		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'HandleTurnEvent' instead.")]
 		[Mac (10, 8)]
 		[Deprecated (PlatformName.MacOSX, 10, 9, message : "Use 'HandleTurnEvent' instead.")]
@@ -1768,7 +1742,6 @@ namespace XamCore.GameKit {
 	}
 
 	[NoTV]
-	[iOS (5, 0)]
 	[Deprecated (PlatformName.iOS, 7, 0, message : "Use GKLocalPlayer.RegisterListener with an object that implements IGKTurnBasedEventListener.")]
 	[Mac (10, 8)]
 	[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use GKLocalPlayer.RegisterListener with an object that implements IGKTurnBasedEventListener.")]
@@ -1787,16 +1760,12 @@ namespace XamCore.GameKit {
 		GKTurnBasedEventHandler SharedTurnBasedEventHandler { get; }
 	}
 
-	[iOS (5,0)]
 	delegate void GKTurnBasedMatchRequest (GKTurnBasedMatch match, NSError error);
 
-	[iOS (5,0)]
 	delegate void GKTurnBasedMatchesRequest (GKTurnBasedMatch [] matches, NSError error);
 
-	[iOS (5,0)]
 	delegate void GKTurnBasedMatchData (NSData matchData, NSError error);
 
-	[iOS (5,0)]
 	[Watch (3,0)]
 	[BaseType (typeof (NSObject))]
 	interface GKTurnBasedMatch {
@@ -1983,7 +1952,6 @@ namespace XamCore.GameKit {
 	[BaseType (typeof (NSViewController))]
 	interface GKTurnBasedMatchmakerViewController
 #else
-	[iOS (5,0)]
 	[BaseType (typeof (UINavigationController))]
 	interface GKTurnBasedMatchmakerViewController : UIAppearance
 #endif
@@ -2003,7 +1971,6 @@ namespace XamCore.GameKit {
 	}
 
 	[NoWatch]
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]

--- a/src/glkit.cs
+++ b/src/glkit.cs
@@ -64,7 +64,6 @@ namespace XamCore.GLKit {
 	}
 
 	[Mac (10,8, onlyOn64 : true)]
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface GLKBaseEffect : GLKNamedEffect {
 		[Export ("colorMaterialEnabled", ArgumentSemantic.Assign)]
@@ -120,13 +119,11 @@ namespace XamCore.GLKit {
 	}
 
 	[Mac (10,8, onlyOn64 : true)]
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface GLKEffectProperty {
 	}
 
 	[Mac (10,8, onlyOn64 : true)]
-	[iOS (5,0)]
 	[BaseType (typeof (GLKEffectProperty))]
 	interface GLKEffectPropertyFog {
 		[Export ("mode", ArgumentSemantic.Assign)]
@@ -149,7 +146,6 @@ namespace XamCore.GLKit {
 	}
 
 	[Mac (10,8, onlyOn64 : true)]
-	[iOS (5,0)]
 	[BaseType (typeof (GLKEffectProperty))]
 	interface GLKEffectPropertyLight {
 		[Export ("position", ArgumentSemantic.Assign)]
@@ -192,7 +188,6 @@ namespace XamCore.GLKit {
 	}
 
 	[Mac (10,8, onlyOn64 : true)]
-	[iOS (5,0)]
 	[BaseType (typeof (GLKEffectProperty))]
 	interface GLKEffectPropertyMaterial {
 		[Export ("diffuseColor", ArgumentSemantic.Assign)]
@@ -212,7 +207,6 @@ namespace XamCore.GLKit {
 	}
 
 	[Mac (10,8, onlyOn64 : true)]
-	[iOS (5,0)]
 	[BaseType (typeof (GLKEffectProperty))]
 	interface GLKEffectPropertyTexture {
 		[Export ("target", ArgumentSemantic.Assign)]
@@ -230,7 +224,6 @@ namespace XamCore.GLKit {
 	}
 
 	[Mac (10,8, onlyOn64 : true)]
-	[iOS (5,0)]
 	[BaseType (typeof (GLKEffectProperty))]
 	interface GLKEffectPropertyTransform {
 		[Export ("normalMatrix")]
@@ -293,7 +286,6 @@ namespace XamCore.GLKit {
 	{
 	}
 		
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -304,7 +296,6 @@ namespace XamCore.GLKit {
 	}
 
 	[Mac (10,8, onlyOn64 : true)]
-	[iOS (5,0)]
 	[BaseType (typeof (GLKBaseEffect))]
 	interface GLKReflectionMapEffect : GLKNamedEffect {
 		[Export ("textureCubeMap")]
@@ -315,7 +306,6 @@ namespace XamCore.GLKit {
 	}
 	
 	[Mac (10,8, onlyOn64 : true)]
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface GLKSkyboxEffect : GLKNamedEffect {
 		[Export ("center", ArgumentSemantic.Assign)]
@@ -378,7 +368,6 @@ namespace XamCore.GLKit {
 	}
 	
 	[Mac (10,8, onlyOn64 : true)]
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface GLKTextureInfo : NSCopying {
 		[Export ("width")]
@@ -420,7 +409,6 @@ namespace XamCore.GLKit {
 
 	delegate void GLKTextureLoaderCallback (GLKTextureInfo textureInfo, NSError error);
 
-	[iOS (5,0)]
 	[Mac (10, 8, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	interface GLKTextureLoader {
@@ -525,7 +513,6 @@ namespace XamCore.GLKit {
 	}
 
 #if !MONOMAC
-	[iOS (5,0)]
 	[BaseType (typeof (UIView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof (GLKViewDelegate)})]
 	interface GLKView {
 		[Export ("initWithFrame:")]
@@ -579,7 +566,6 @@ namespace XamCore.GLKit {
 		void DeleteDrawable ();
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -589,7 +575,6 @@ namespace XamCore.GLKit {
 		void DrawInRect (GLKView view, CGRect rect);
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (UIViewController))]
 	interface GLKViewController : GLKViewDelegate {
 		[Export ("initWithNibName:bundle:")]
@@ -638,7 +623,6 @@ namespace XamCore.GLKit {
 		void Update ();
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]

--- a/src/iad.cs
+++ b/src/iad.cs
@@ -18,7 +18,6 @@ using XamCore.AVKit;
 
 namespace XamCore.iAd {
 
-	[iOS (4,0)]
 	[Deprecated (PlatformName.iOS, 10, 0)]
 	[BaseType (typeof (UIView), Delegates=new string [] {"WeakDelegate"}, Events=new Type [] {typeof (ADBannerViewDelegate)})]
 	interface ADBannerView {
@@ -50,7 +49,7 @@ namespace XamCore.iAd {
 		[Export ("bannerViewActionInProgress")]
 		bool BannerViewActionInProgress { [Bind ("isBannerViewActionInProgress")] get;  }
 
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0)]
+		[Availability (Deprecated = Platform.iOS_6_0)]
 		[NullAllowed] // by default this property is null
 		[Export ("requiredContentSizeIdentifiers", ArgumentSemantic.Copy)]
 		NSSet RequiredContentSizeIdentifiers { get; set;  }
@@ -58,35 +57,34 @@ namespace XamCore.iAd {
 		[Export ("cancelBannerViewAction")]
 		void CancelBannerViewAction ();
 
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0)]
+		[Availability (Deprecated = Platform.iOS_6_0)]
 		[NullAllowed] // by default this property is null
 		[Export ("currentContentSizeIdentifier", ArgumentSemantic.Copy)]
 		string CurrentContentSizeIdentifier { get; set; }
 
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_6_0)]
+		[Availability (Deprecated = Platform.iOS_6_0)]
 		[Static, Export ("sizeFromBannerContentSizeIdentifier:")]
 		CGSize SizeFromContentSizeIdentifier (string sizeIdentifier);
 
 #if !XAMCORE_3_0
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_4_2)]
+		[Availability (Deprecated = Platform.iOS_4_2)]
 		[Field ("ADBannerContentSizeIdentifier320x50")]
 		NSString SizeIdentifier320x50 { get; }
 
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_4_2)]
+		[Availability (Deprecated = Platform.iOS_4_2)]
 		[Field ("ADBannerContentSizeIdentifier480x32")]
 		NSString SizeIdentifier480x32 { get; }
 #endif
 
-		[Availability (Introduced = Platform.iOS_4_2, Deprecated = Platform.iOS_6_0)]
+		[Availability (Deprecated = Platform.iOS_6_0)]
 		[Field ("ADBannerContentSizeIdentifierLandscape")]
 		NSString SizeIdentifierLandscape { get; }
 
-		[Availability (Introduced = Platform.iOS_4_2, Deprecated = Platform.iOS_6_0)]
+		[Availability (Deprecated = Platform.iOS_6_0)]
 		[Field ("ADBannerContentSizeIdentifierPortrait")]
 		NSString SizeIdentifierPortrait { get; }
 	}
 
-	[iOS (4,0)]
 	[Deprecated (PlatformName.iOS, 10, 0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
@@ -104,7 +102,6 @@ namespace XamCore.iAd {
 		[Export ("bannerViewActionDidFinish:")]
 		void ActionFinished (ADBannerView banner);
 
-		[iOS (5,0)]
 		[Export ("bannerViewWillLoadAd:"), EventArgs ("EventArgs", true, true)]
 		void WillLoad (ADBannerView bannerView);
 	}
@@ -167,7 +164,6 @@ namespace XamCore.iAd {
 		[Export ("interstitialAdActionDidFinish:")]
 		void ActionFinished (ADInterstitialAd interstitialAd);
 
-		[iOS (5,0)]
 		[Export ("interstitialAdWillLoad:"), EventArgs ("EventArgs", true, true)]
 		void WillLoad (ADInterstitialAd interstitialAd);
 	}

--- a/src/iad.cs
+++ b/src/iad.cs
@@ -129,7 +129,7 @@ namespace XamCore.iAd {
 		bool PresentInView (UIView containerView);
 
 		[Export ("presentFromViewController:")]
-		[Availability (Introduced = Platform.iOS_4_3, Deprecated = Platform.iOS_7_0, Message = "Use extension method 'UIViewController.RequestInterstitialAdPresentation' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use extension method 'UIViewController.RequestInterstitialAdPresentation' instead.")]
 		void PresentFromViewController (UIViewController viewController);
 	}
 

--- a/src/imageio.cs
+++ b/src/imageio.cs
@@ -34,7 +34,6 @@ using System;
 
 namespace XamCore.ImageIO {
 
-	[iOS (4,0)]
 	[Static]
 	// Bad name should end with Keys
 	interface CGImageProperties {

--- a/src/imageio.cs
+++ b/src/imageio.cs
@@ -514,19 +514,19 @@ namespace XamCore.ImageIO {
 		NSString PNGsRGBIntent { get; }
 		[Field ("kCGImagePropertyPNGChromaticities")]
 		NSString PNGChromaticities { get; }
-		[iOS (5,0)][Field ("kCGImagePropertyPNGAuthor")]
+		[Field ("kCGImagePropertyPNGAuthor")]
 		NSString PNGAuthor { get; }
-		[iOS (5,0)][Field ("kCGImagePropertyPNGCopyright")]
+		[Field ("kCGImagePropertyPNGCopyright")]
 		NSString PNGCopyright { get; }
-		[iOS (5,0)][Field ("kCGImagePropertyPNGCreationTime")]
+		[Field ("kCGImagePropertyPNGCreationTime")]
 		NSString PNGCreationTime { get; }
-		[iOS (5,0)][Field ("kCGImagePropertyPNGDescription")]
+		[Field ("kCGImagePropertyPNGDescription")]
 		NSString PNGDescription { get; }
-		[iOS (5,0)][Field ("kCGImagePropertyPNGModificationTime")]
+		[Field ("kCGImagePropertyPNGModificationTime")]
 		NSString PNGModificationTime { get; }
-		[iOS (5,0)][Field ("kCGImagePropertyPNGSoftware")]
+		[Field ("kCGImagePropertyPNGSoftware")]
 		NSString PNGSoftware { get; }
-		[iOS (5,0)][Field ("kCGImagePropertyPNGTitle")]
+		[Field ("kCGImagePropertyPNGTitle")]
 		NSString PNGTitle { get; }
 
 		[iOS (9,0)][Mac (10,11)]

--- a/src/imageio.cs
+++ b/src/imageio.cs
@@ -604,121 +604,121 @@ namespace XamCore.ImageIO {
 		[Field ("kCGImagePropertyDNGLensInfo")]
 		NSString DNGLensInfo { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGBlackLevel")]
 		NSString DNGBlackLevel { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGWhiteLevel")]
 		NSString DNGWhiteLevel { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGCalibrationIlluminant1")]
 		NSString DNGCalibrationIlluminant1 { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGCalibrationIlluminant2")]
 		NSString DNGCalibrationIlluminant2 { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGColorMatrix1")]
 		NSString DNGColorMatrix1 { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGColorMatrix2")]
 		NSString DNGColorMatrix2 { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGCameraCalibration1")]
 		NSString DNGCameraCalibration1 { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGCameraCalibration2")]
 		NSString DNGCameraCalibration2 { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGAsShotNeutral")]
 		NSString DNGAsShotNeutral { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGAsShotWhiteXY")]
 		NSString DNGAsShotWhiteXY { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGBaselineExposure")]
 		NSString DNGBaselineExposure { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGBaselineNoise")]
 		NSString DNGBaselineNoise { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGBaselineSharpness")]
 		NSString DNGBaselineSharpness { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGPrivateData")]
 		NSString DNGPrivateData { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGCameraCalibrationSignature")]
 		NSString DNGCameraCalibrationSignature { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGProfileCalibrationSignature")]
 		NSString DNGProfileCalibrationSignature { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGNoiseProfile")]
 		NSString DNGNoiseProfile { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGWarpRectilinear")]
 		NSString DNGWarpRectilinear { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGWarpFisheye")]
 		NSString DNGWarpFisheye { get; }
 
-		[iOS (10,0)][Mac (12,0)]
+		[iOS (10,0)][Mac (10,12)]
 		[Watch (3,0)]
 		[TV (10,0)]
 		[Field ("kCGImagePropertyDNGFixVignetteRadial")]

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -56,7 +56,7 @@ namespace XamCore.MapKit {
 
 #if MONOMAC || XAMCORE_2_0
 		[Export ("setCoordinate:")]
-		[Mac (10,9), iOS (4,0)]
+		[Mac (10,9)]
 		void SetCoordinate (CLLocationCoordinate2D value);
 #endif
 	}
@@ -154,17 +154,14 @@ namespace XamCore.MapKit {
 		UIView RightCalloutAccessoryView { get; set; }
 	
 		[NoTV]
-		[iOS (4,2)]
 		[Export ("setDragState:animated:")]
 		void SetDragState (MKAnnotationViewDragState newDragState, bool animated);
 
 		[Export ("dragState")]
 		[NoTV]
-		[iOS (4,0)]
 		MKAnnotationViewDragState DragState { get; set;  }
 
 		[NoTV]
-		[iOS (4,0)]
 		[Export ("draggable")]
 		bool Draggable { [Bind ("isDraggable")] get; set;  }
 
@@ -205,7 +202,6 @@ namespace XamCore.MapKit {
 
 	[ThreadSafe]
 	[TV (9,2)]
-	[iOS (4,0)]
 	[Mac (10,9, onlyOn64 : true)]
 	[BaseType (typeof (MKShape))]
 	interface MKCircle : MKOverlay {
@@ -229,7 +225,7 @@ namespace XamCore.MapKit {
 
 #if !MONOMAC && !TVOS
 	[BaseType (typeof (MKOverlayPathView))]
-	[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_7_0, Message = "Use 'MKCircleRenderer' instead.")]
+	[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'MKCircleRenderer' instead.")]
 	interface MKCircleView {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
@@ -527,7 +523,6 @@ namespace XamCore.MapKit {
 		[Export ("annotationVisibleRect")]
 		CGRect AnnotationVisibleRect { get; }
 
-		[iOS (4,0)]
 		[Export ("addOverlay:")][PostGet ("Overlays")]
 #if XAMCORE_2_0
 		void AddOverlay (IMKOverlay overlay);
@@ -535,7 +530,6 @@ namespace XamCore.MapKit {
 		void AddOverlay (NSObject overlay);
 #endif
 
-		[iOS (4,0)]
 		[Export ("addOverlays:")][PostGet ("Overlays")]
 #if XAMCORE_2_0
 		void AddOverlays (IMKOverlay [] overlays);
@@ -543,7 +537,6 @@ namespace XamCore.MapKit {
 		void AddOverlays (NSObject [] overlays);
 #endif
 
-		[iOS (4,0)]
 		[Export ("removeOverlay:")][PostGet ("Overlays")]
 #if XAMCORE_2_0
 		void RemoveOverlay (IMKOverlay overlay);
@@ -551,7 +544,6 @@ namespace XamCore.MapKit {
 		void RemoveOverlay (NSObject overlay);
 #endif
 
-		[iOS (4,0)]
 		[Export ("removeOverlays:")][PostGet ("Overlays")]
 #if XAMCORE_2_0
 		void RemoveOverlays ([Params] IMKOverlay [] overlays);
@@ -559,7 +551,6 @@ namespace XamCore.MapKit {
 		void RemoveOverlays ([Params] NSObject [] overlays);
 #endif
 
-		[iOS (4,0)]
 		[Export ("overlays")]
 #if XAMCORE_2_0
 		IMKOverlay [] Overlays { get;  }
@@ -567,7 +558,6 @@ namespace XamCore.MapKit {
 		NSObject [] Overlays { get;  }
 #endif
 
-		[iOS (4,0)]
 		[Export ("insertOverlay:atIndex:")][PostGet ("Overlays")]
 #if XAMCORE_2_0
 		void InsertOverlay (IMKOverlay overlay, nint index);
@@ -575,7 +565,6 @@ namespace XamCore.MapKit {
 		void InsertOverlay (NSObject overlay, nint index);
 #endif
 
-		[iOS (4,0)]
 		[Export ("insertOverlay:aboveOverlay:")][PostGet ("Overlays")]
 #if XAMCORE_2_0
 		void InsertOverlayAbove (IMKOverlay overlay, IMKOverlay sibling);
@@ -583,7 +572,6 @@ namespace XamCore.MapKit {
 		void InsertOverlayAbove (NSObject overlay, NSObject sibling);
 #endif
 
-		[iOS (4,0)]
 		[Export ("insertOverlay:belowOverlay:")][PostGet ("Overlays")]
 #if XAMCORE_2_0
 		void InsertOverlayBelow (IMKOverlay overlay, IMKOverlay sibling);
@@ -591,29 +579,24 @@ namespace XamCore.MapKit {
 		void InsertOverlayBelow (NSObject overlay, NSObject sibling);
 #endif
 
-		[iOS (4,0)]
 		[Export ("exchangeOverlayAtIndex:withOverlayAtIndex:")]
 		void ExchangeOverlays (nint index1, nint index2);
 
-		[iOS (4,0)]
 		[Export ("mapRectThatFits:")]
 		MKMapRect MapRectThatFits (MKMapRect mapRect);
 
-		[iOS (4,0)]
 		[Export ("setVisibleMapRect:edgePadding:animated:")]
 		void SetVisibleMapRect (MKMapRect mapRect, UIEdgeInsets edgePadding, bool animate);
 
-		[iOS (4,0)]
 		[Export ("setVisibleMapRect:animated:")]
 		void SetVisibleMapRect (MKMapRect mapRect, bool animate);
 
-		[iOS (4,0)]
 		[Export ("mapRectThatFits:edgePadding:")]
 		MKMapRect MapRectThatFits (MKMapRect mapRect, UIEdgeInsets edgePadding);
 
 #if !MONOMAC && !TVOS
 		[Export ("viewForOverlay:")]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_7_0, Message = "Use 'MKOverlayRenderer.RendererForOverlay' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'MKOverlayRenderer.RendererForOverlay' instead.")]
 #if XAMCORE_2_0
 		MKOverlayView ViewForOverlay (IMKOverlay overlay);
 #else
@@ -621,20 +604,16 @@ namespace XamCore.MapKit {
 #endif
 #endif // !MONOMAC && !TVOS
 
-		[iOS (4,0)]
 		[Export ("visibleMapRect")]
 		MKMapRect VisibleMapRect { get; set;  }
 
-		[iOS (4,2)]
 		[Export ("annotationsInMapRect:")]
 		NSSet GetAnnotations (MKMapRect mapRect);
 
 #if !MONOMAC
-		[iOS (5,0)]
 		[Export ("userTrackingMode")]
 		MKUserTrackingMode UserTrackingMode { get; set; }
 		
-		[iOS (5,0)]
 		[Export ("setUserTrackingMode:animated:")]
 		void SetUserTrackingMode (MKUserTrackingMode trackingMode, bool animated);
 #endif
@@ -758,13 +737,12 @@ namespace XamCore.MapKit {
 #endif // !MONOMAC
 
 		[NoTV]
-		[iOS (4,0)]
 		[Export ("mapView:annotationView:didChangeDragState:fromOldState:"), EventArgs ("MKMapViewDragState")]
 		void ChangedDragState (MKMapView mapView, MKAnnotationView annotationView, MKAnnotationViewDragState newState, MKAnnotationViewDragState oldState);
 
 #if !MONOMAC && !TVOS
 		[Export ("mapView:viewForOverlay:"), DelegateName ("MKMapViewOverlay"), DefaultValue (null)]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_7_0, Message = "Use 'MKOverlayRenderer.RendererForOverlay' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'MKOverlayRenderer.RendererForOverlay' instead.")]
 #if XAMCORE_2_0
 		MKOverlayView GetViewForOverlay (MKMapView mapView, IMKOverlay overlay);
 #else
@@ -772,36 +750,29 @@ namespace XamCore.MapKit {
 #endif // XAMCORE_2_0
 
 		[Export ("mapView:didAddOverlayViews:"), EventArgs ("MKOverlayViews")]
-		[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_7_0, Message = "Use 'DidAddOverlayRenderers' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'DidAddOverlayRenderers' instead.")]
 		void DidAddOverlayViews (MKMapView mapView, MKOverlayView overlayViews);
 #endif // !MONOMAC && !TVOS
 
-		[iOS (4,0)]
 		[Export ("mapView:didSelectAnnotationView:"), EventArgs ("MKAnnotationView")]
 		void DidSelectAnnotationView (MKMapView mapView, MKAnnotationView view);
 
-		[iOS (4,0)]
 		[Export ("mapView:didFailToLocateUserWithError:"), EventArgs ("NSError", true)]
 		void DidFailToLocateUser (MKMapView mapView, NSError error);
 
-		[iOS (4,0)]
 		[Export ("mapView:didDeselectAnnotationView:"), EventArgs ("MKAnnotationView")]
 		void DidDeselectAnnotationView (MKMapView mapView, MKAnnotationView view);
 
-		[iOS (4,0)]
 		[Export ("mapViewWillStartLocatingUser:")]
 		void WillStartLocatingUser (MKMapView mapView);
 
-		[iOS (4,0)]
 		[Export ("mapViewDidStopLocatingUser:")]
 		void DidStopLocatingUser (MKMapView mapView);
 
-		[iOS (4,0)]
 		[Export ("mapView:didUpdateUserLocation:"), EventArgs ("MKUserLocation")]
 		void DidUpdateUserLocation (MKMapView mapView, MKUserLocation userLocation);
 
 #if !MONOMAC
-		[iOS (5,0)]
 		[Export ("mapView:didChangeUserTrackingMode:animated:"), EventArgs ("MMapViewUserTracking")]
 #if XAMCORE_2_0
 		void DidChangeUserTrackingMode (MKMapView mapView, MKUserTrackingMode mode, bool animated);
@@ -924,7 +895,7 @@ namespace XamCore.MapKit {
 		
 #if IOS
 	[BaseType (typeof (NSObject))]
-	[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_5_0, Message = "Use 'CoreLocation.CLGeocoder' instead.")]
+	[Availability (Deprecated = Platform.iOS_5_0, Message = "Use 'CoreLocation.CLGeocoder' instead.")]
 	// crash (at least) at Dispose time when instance is created by 'init'
 	[DisableDefaultCtor]
 	interface MKReverseGeocoder {
@@ -950,7 +921,6 @@ namespace XamCore.MapKit {
 		[Export ("cancel")]
 		void Cancel ();
 	
-		[iOS (3,2)]
 		[Export ("placemark")]
 		MKPlacemark Placemark { get; }
 	}
@@ -970,7 +940,7 @@ namespace XamCore.MapKit {
 	}
 #pragma warning restore 618
 
-	[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_7_0, Message = "Use 'MKOverlayRenderer' instead.")]
+	[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'MKOverlayRenderer' instead.")]
 	[BaseType (typeof (UIView))]
 	interface MKOverlayView {
 		[Export ("overlay")]
@@ -1021,7 +991,7 @@ namespace XamCore.MapKit {
 		void SetNeedsDisplay (MKMapRect mapRect, /* MKZoomScale */ nfloat zoomScale);
 	}
 
-	[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_7_0, Message = "Use 'MKOverlayPathRenderer' instead.")]
+	[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'MKOverlayPathRenderer' instead.")]
 	[BaseType (typeof (MKOverlayView))]
 	interface MKOverlayPathView {
 		[Export ("initWithOverlay:")]
@@ -1087,7 +1057,6 @@ namespace XamCore.MapKit {
 
 #if !WATCH
 	[TV (9,2)]
-	[iOS (4,0)]
 	[Mac (10,9, onlyOn64 : true)]
 #if XAMCORE_2_0 || MONOMAC
 	[BaseType (typeof (NSObject))]
@@ -1114,7 +1083,6 @@ namespace XamCore.MapKit {
 
 	[TV (9,2)]
 	[Mac (10,9, onlyOn64 : true)]
-	[iOS (4,0)]
 	[BaseType (typeof (MKShape))]
 	interface MKPointAnnotation {
 		[Export ("coordinate")]
@@ -1122,7 +1090,7 @@ namespace XamCore.MapKit {
 }
 
 #if !MONOMAC && !TVOS
-	[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_7_0, Message = "Use 'MKPolygonRenderer' instead.")]
+	[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'MKPolygonRenderer' instead.")]
 	[BaseType (typeof (MKOverlayPathView))]
 	interface MKPolygonView {
 		[Export ("initWithFrame:")]
@@ -1139,7 +1107,6 @@ namespace XamCore.MapKit {
 
 	[ThreadSafe]
 	[TV (9,2)]
-	[iOS (4,0)]
 	[Mac (10,9, onlyOn64 : true)]
 	[BaseType (typeof (MKMultiPoint))]
 	interface MKPolygon : MKOverlay {
@@ -1176,7 +1143,6 @@ namespace XamCore.MapKit {
 
 	[ThreadSafe]
 	[TV (9,2)]
-	[iOS (4,0)]
 	[Mac (10,9, onlyOn64 : true)]
 	[BaseType (typeof (MKMultiPoint))]
 	interface MKPolyline : MKOverlay {
@@ -1198,7 +1164,7 @@ namespace XamCore.MapKit {
 	}
 
 #if !MONOMAC && !TVOS
-	[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_7_0, Message = "Use 'MKPolylineRenderer' instead.")]
+	[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'MKPolylineRenderer' instead.")]
 	[BaseType (typeof (MKOverlayPathView))]
 	interface MKPolylineView {
 		[Export ("initWithFrame:")]
@@ -1215,7 +1181,6 @@ namespace XamCore.MapKit {
 
 	[BaseType (typeof (MKShape))]
 	[TV (9,2)]
-	[iOS (4,0)]
 	[Mac (10,9, onlyOn64 : true)]
 	interface MKMultiPoint {
 		[Export ("points"), Internal]
@@ -1249,14 +1214,12 @@ namespace XamCore.MapKit {
 		string Subtitle { get; set; }
 		
 		[NoTV]
-		[iOS (5,0)]
 		[Export ("heading", ArgumentSemantic.Retain)]
 		CLHeading Heading { get; }
 	}
 
 #if !MONOMAC
 	[NoTV]
-	[iOS (5,0)]
 	[BaseType (typeof (UIBarButtonItem))]
 	interface MKUserTrackingBarButtonItem {
 		[NullAllowed] // by default this property is null

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -1029,7 +1029,7 @@ namespace XamCore.MediaPlayer {
 
 	[NoMac]
 	[NoTV]
-	[Availability (Introduced = Platform.iOS_4_0, Deprecated = Platform.iOS_9_0)]
+	[Availability (Deprecated = Platform.iOS_9_0)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: MPTimedMetadata cannot be created directly
 	[DisableDefaultCtor]

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -37,7 +37,6 @@ namespace XamCore.MediaPlayer {
 		[Export ("valueForProperty:")]
 		NSObject ValueForProperty (NSString property);
 
-		[iOS (4,0)]
 		[Export ("enumerateValuesForProperties:usingBlock:")]
 		void EnumerateValues (NSSet propertiesToEnumerate, MPMediaItemEnumerator enumerator);
 
@@ -58,116 +57,93 @@ namespace XamCore.MediaPlayer {
 #endif
 	interface MPMediaItem {
 #endif
-		[NoMac][NoTV]
-		[iOS (4,2)]
 		[NoMac]
 		[NoTV]
 		[Export ("persistentIDPropertyForGroupingType:")][Static]
 		string GetPersistentIDProperty (MPMediaGrouping groupingType);
 
-		[NoMac][NoTV]
-		[iOS (4,2)]
 		[NoMac]
 		[NoTV]
 		[Export ("titlePropertyForGroupingType:")][Static]
 		string GetTitleProperty (MPMediaGrouping groupingType);
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyPersistentID")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString PersistentIDProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyAlbumPersistentID")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString AlbumPersistentIDProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyArtistPersistentID")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString ArtistPersistentIDProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyAlbumArtistPersistentID")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString AlbumArtistPersistentIDProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyGenrePersistentID")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString GenrePersistentIDProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyComposerPersistentID")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString ComposerPersistentIDProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyPodcastPersistentID")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString PodcastPersistentIDProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyMediaType")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString MediaTypeProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyTitle")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString TitleProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyAlbumTitle")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString AlbumTitleProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyArtist")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString ArtistProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyAlbumArtist")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString AlbumArtistProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyGenre")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString GenreProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyComposer")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString ComposerProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyPlaybackDuration")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString PlaybackDurationProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyAlbumTrackNumber")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString AlbumTrackNumberProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyAlbumTrackCount")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString AlbumTrackCountProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyDiscNumber")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString DiscNumberProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyDiscCount")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString DiscCountProperty { get; }
 
-		[iOS (3,0), Mac (10,13,1, onlyOn64: true)]
+		[Mac (10,13,1, onlyOn64: true)]
 		[Field ("MPMediaItemPropertyArtwork")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString ArtworkProperty { get; }
@@ -177,62 +153,50 @@ namespace XamCore.MediaPlayer {
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString IsExplicitProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyLyrics")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString LyricsProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyIsCompilation")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString IsCompilationProperty { get; }
 
-		[iOS (4,0)]
 		[Field ("MPMediaItemPropertyReleaseDate")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString ReleaseDateProperty { get; }
 
-		[iOS (4,0)]
 		[Field ("MPMediaItemPropertyBeatsPerMinute")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString BeatsPerMinuteProperty { get; }
 
-		[iOS (4,0)]
 		[Field ("MPMediaItemPropertyComments")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString CommentsProperty { get; }
 
-		[iOS (4,0)]
 		[Field ("MPMediaItemPropertyAssetURL")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString AssetURLProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyPlayCount")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString PlayCountProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertySkipCount")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString SkipCountProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyRating")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString RatingProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyLastPlayedDate")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString LastPlayedDateProperty { get; }
 
-		[iOS (4,0)]
 		[Field ("MPMediaItemPropertyUserGrouping")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString UserGroupingProperty { get; }
 
-		[iOS (3,0)]
 		[Field ("MPMediaItemPropertyPodcastTitle")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		NSString PodcastTitleProperty { get; }
@@ -588,11 +552,9 @@ namespace XamCore.MediaPlayer {
 		[Export ("genresQuery")][Static]
 		MPMediaQuery genresQuery { get; }
 #endif
-		[iOS (4,2)]
 		[Export ("collectionSections")]
 		MPMediaQuerySection [] CollectionSections { get; }
 
-		[iOS (4,2)]
 		[Export ("itemSections")]
 		MPMediaQuerySection [] ItemSections { get; }
 	}
@@ -778,42 +740,34 @@ namespace XamCore.MediaPlayer {
 		void Stop ();
 
 		[Abstract]
-		[iOS (3,2)]
 		[Export ("pause")]
 		void Pause ();
 		
 		[Abstract]
-		[iOS (3,2)]
 		[Export ("prepareToPlay")]
 		void PrepareToPlay ();
 
 		[Abstract]
-		[iOS (3,2)]
 		[Export ("isPreparedToPlay")]
 		bool IsPreparedToPlay { get; }
 
 		[Abstract]
-		[iOS (3,2)]
 		[Export ("currentPlaybackTime")]
 		double CurrentPlaybackTime { get; set; }
 
 		[Abstract]
-		[iOS (3,2)]
 		[Export ("currentPlaybackRate")]
 		float CurrentPlaybackRate { get; set; } // float, not CGFloat
 
 		[Abstract]
-		[iOS (3,2)]
 		[Export ("beginSeekingForward")]
 		void BeginSeekingForward ();
 
 		[Abstract]
-		[iOS (3,2)]
 		[Export ("beginSeekingBackward")]
 		void BeginSeekingBackward ();
 
 		[Abstract]
-		[iOS (3,2)]
 		[Export ("endSeeking")]
 		void EndSeeking ();
 	}
@@ -829,50 +783,41 @@ namespace XamCore.MediaPlayer {
 
 		[Export ("backgroundColor", ArgumentSemantic.Retain)]
 		// <quote>You should avoid using this property. It is available only when you use the initWithContentURL: method to initialize the movie player controller object.</quote>
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_3_2, Obsoleted = Platform.iOS_8_0, Message = "Do not use; this API was removed and is not always available.")]
+		[Availability (Deprecated = Platform.iOS_3_2, Obsoleted = Platform.iOS_8_0, Message = "Do not use; this API was removed and is not always available.")]
 		UIColor BackgroundColor { get; set; }
 
 		[Export ("scalingMode")]
 		MPMovieScalingMode ScalingMode { get; set; }
 
 		[Export ("movieControlMode")]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_3_2, Obsoleted = Platform.iOS_8_0, Message = "Do not use; this API was removed.")]
+		[Availability (Deprecated = Platform.iOS_3_2, Obsoleted = Platform.iOS_8_0, Message = "Do not use; this API was removed.")]
 		MPMovieControlMode MovieControlMode { get; set; }
 
-		[iOS (3,2)]
 		[Export ("initialPlaybackTime")]
 		double InitialPlaybackTime { get; set; }
 
-		[iOS (3,2)]
 		[NullAllowed] // by default this property is null
 		[Export ("contentURL", ArgumentSemantic.Copy)]
 		NSUrl ContentUrl { get; set; }
 
-		[iOS (3,2)]
 		[Export ("view")]
 		UIView View { get; }
 
-		[iOS (3,2)]
 		[Export ("backgroundView")]
 		UIView BackgroundView { get; }
 		
-		[iOS (3,2)]
 		[Export ("playbackState")]
 		MPMoviePlaybackState PlaybackState { get; }
 
-		[iOS (3,2)]
 		[Export ("loadState")]
 		MPMovieLoadState LoadState { get; }
 
-		[iOS (3,2)]
 		[Export ("controlStyle")]
 		MPMovieControlStyle ControlStyle { get; set; }
 
-		[iOS (3,2)]
 		[Export ("repeatMode")]
 		MPMovieRepeatMode RepeatMode { get; set; }
 
-		[iOS (3,2)]
 		[Export ("shouldAutoplay")]
 		bool ShouldAutoplay { get; set; }
 
@@ -880,74 +825,59 @@ namespace XamCore.MediaPlayer {
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
 		bool UseApplicationAudioSession { get; set; }
 
-		[iOS (3,2)]
 		[Export ("fullscreen")]
 		bool Fullscreen { [Bind ("isFullscreen")] get; set; }
 
-		[iOS (3,2)]
 		[Export ("setFullscreen:animated:")]
 		void SetFullscreen (bool fullscreen, bool animated);
 
-		[iOS (4,3)]
 		[Export ("allowsAirPlay")]
 		bool AllowsAirPlay { get; set; }
 
-		[iOS (5,0)]
 		[Export ("airPlayVideoActive")]
 		bool AirPlayVideoActive { [Bind ("isAirPlayVideoActive")] get; }
 
 		[Availability (Deprecated = Platform.iOS_9_0)]
-		[iOS (4,3)]
 		[Export ("accessLog")]
 		MPMovieAccessLog AccessLog { get; }
 
 		[Availability (Deprecated = Platform.iOS_9_0)]
-		[iOS (4,3)]
 		[Export ("errorLog")]
 		MPMovieErrorLog ErrorLog { get; }
 
 		// Brought it from the MPMediaPlayback.h
 
 		[Export ("thumbnailImageAtTime:timeOption:")]
-		[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_7_0, Message = "Use 'RequestThumbnails' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'RequestThumbnails' instead.")]
 		UIImage ThumbnailImageAt (double time, MPMovieTimeOption timeOption);
 
-		[iOS (3,2)]
 		[Export ("requestThumbnailImagesAtTimes:timeOption:")]
 		void RequestThumbnails (NSNumber [] doubleNumbers, MPMovieTimeOption timeOption);
 
-		[iOS (3,2)]
 		[Export ("cancelAllThumbnailImageRequests")]
 		void CancelAllThumbnailImageRequests ();
 
 		//
 		// From interface MPMovieProperties
 		//
-		[iOS (3,2)]
 		[Export ("movieMediaTypes")]
 		MPMovieMediaType MovieMediaTypes { get; }
 
-		[iOS (3,2)]
 		[Export ("movieSourceType")]
 		MPMovieSourceType SourceType { get; set; }
 
-		[iOS (3,2)]
 		[Export ("duration")]
 		double Duration { get; }
 
-		[iOS (3,2)]
 		[Export ("playableDuration")]
 		double PlayableDuration { get; }
 
-		[iOS (3,2)]
 		[Export ("naturalSize")]
 		CGSize NaturalSize { get; }
 
-		[iOS (3,2)]
 		[Export ("endPlaybackTime")]
 		double EndPlaybackTime { get; set; }
 
-		[iOS (4,0)]
 		[Export ("timedMetadata")]
 		MPTimedMetadata [] TimedMetadata { get; }
 
@@ -962,141 +892,116 @@ namespace XamCore.MediaPlayer {
 		NSString PlaybackDidFinishNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMoviePlayerPlaybackDidFinishReasonUserInfoKey")] // NSNumber (MPMovieFinishReason)
 		NSString PlaybackDidFinishReasonUserInfoKey { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMoviePlayerPlaybackStateDidChangeNotification")]
 		[Notification]
 		NSString PlaybackStateDidChangeNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMoviePlayerLoadStateDidChangeNotification")]
 		[Notification]
 		NSString LoadStateDidChangeNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMoviePlayerNowPlayingMovieDidChangeNotification")]
 		[Notification]
 		NSString NowPlayingMovieDidChangeNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMoviePlayerWillEnterFullscreenNotification")]
 		[Notification (typeof (MPMoviePlayerFullScreenEventArgs))]
 		[Notification]
 		NSString WillEnterFullscreenNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMoviePlayerDidEnterFullscreenNotification")]
 		[Notification]
 		NSString DidEnterFullscreenNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMoviePlayerWillExitFullscreenNotification")]
 		[Notification (typeof (MPMoviePlayerFullScreenEventArgs))]
 		NSString WillExitFullscreenNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMoviePlayerDidExitFullscreenNotification")]
 		[Notification]
 		NSString DidExitFullscreenNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMoviePlayerFullscreenAnimationDurationUserInfoKey")]
 		NSString FullscreenAnimationDurationUserInfoKey { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMoviePlayerFullscreenAnimationCurveUserInfoKey")]
 		NSString FullscreenAnimationCurveUserInfoKey { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMovieMediaTypesAvailableNotification")]
 		[Notification]
 		NSString TypesAvailableNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMovieSourceTypeAvailableNotification")]
 		[Notification]
 		NSString SourceTypeAvailableNotification { get; }
 
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMovieDurationAvailableNotification")]
 		[Notification]
 		NSString DurationAvailableNotification { get;  }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMovieNaturalSizeAvailableNotification")]
 		[Notification]
 		NSString NaturalSizeAvailableNotification { get;  }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMoviePlayerThumbnailImageRequestDidFinishNotification")]
 		[Notification (typeof (MPMoviePlayerThumbnailEventArgs))]
 		NSString ThumbnailImageRequestDidFinishNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMoviePlayerThumbnailImageKey")]
 		NSString ThumbnailImageKey { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMoviePlayerThumbnailTimeKey")]
 		NSString ThumbnailTimeKey { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (3,2)]
 		[Field ("MPMoviePlayerThumbnailErrorKey")]
 		NSString ThumbnailErrorKey { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (4,0)]
 		[Field ("MPMoviePlayerTimedMetadataUpdatedNotification")]
 		[Notification (typeof (MPMoviePlayerTimedMetadataEventArgs))]
 		NSString TimedMetadataUpdatedNotification { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (4,0)]
 		[Field ("MPMoviePlayerTimedMetadataUserInfoKey")]
 		NSString TimedMetadataUserInfoKey { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (4,0)]
 		[Field ("MPMoviePlayerTimedMetadataKeyName")]
 		NSString TimedMetadataKeyName { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (4,0)]
 		[Field ("MPMoviePlayerTimedMetadataKeyInfo")]
 		NSString TimedMetadataKeyInfo { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (4,0)]
 		[Field ("MPMoviePlayerTimedMetadataKeyMIMEType")]
 		NSString TimedMetadataKeyMIMEType { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (4,0)]
 		[Field ("MPMoviePlayerTimedMetadataKeyDataType")]
 		NSString TimedMetadataKeyDataType { get; }
 		
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (4,0)]
 		[Field ("MPMoviePlayerTimedMetadataKeyLanguageCode")]
 		NSString TimedMetadataKeyLanguageCode { get; }
 
@@ -1116,7 +1021,6 @@ namespace XamCore.MediaPlayer {
 		NSString MoviePlayerReadyForDisplayDidChangeNotification { get; }
 
 		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'AVPlayerViewController' (AVKit) instead.")]
-		[iOS (5,0)]
 		[Field ("MPMoviePlayerIsAirPlayVideoActiveDidChangeNotification")]
 		[Notification]
 		NSString MPMoviePlayerIsAirPlayVideoActiveDidChangeNotification { get; }
@@ -1163,7 +1067,7 @@ namespace XamCore.MediaPlayer {
 		MPMoviePlayerController MoviePlayer { get; }
 
 		// Directly removed, shows up in iOS 6.1 SDK, but not any later SDKs.
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_7_0, Message = "Do not use; this API was removed.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Obsoleted = Platform.iOS_7_0, Message = "Do not use; this API was removed.")]
 		[Export ("shouldAutorotateToInterfaceOrientation:")]
 		bool ShouldAutorotateToInterfaceOrientation (UIInterfaceOrientation orientation);
 	}
@@ -1198,11 +1102,10 @@ namespace XamCore.MediaPlayer {
 		[Export ("shuffleMode")]
 		MPMusicShuffleMode ShuffleMode { get; set; }
 
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_7_0, Message = "Use 'MPVolumeView' for volume control instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'MPVolumeView' for volume control instead.")]
 		[Export ("volume")]
 		float Volume { get; set; } // nfloat, not CGFloat
 
-		[iOS (5,0)]
 		[Export ("indexOfNowPlayingItem")]
 		nuint IndexOfNowPlayingItem { get; }
 

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -1251,7 +1251,6 @@ namespace XamCore.MediaPlayer {
 
 	[NoMac]
 	[NoTV]
-	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: MPMediaQuerySection is a read-only object
 	[DisableDefaultCtor]
@@ -1264,7 +1263,6 @@ namespace XamCore.MediaPlayer {
 	}
 
 	[Mac (10,12,2, onlyOn64: true)]
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInvalidArgumentException Reason: -init is not supported, use +defaultCenter
 	[DisableDefaultCtor]

--- a/src/messageui.cs
+++ b/src/messageui.cs
@@ -69,7 +69,6 @@ namespace XamCore.MessageUI {
 		bool TextMessageAvailability { get; }
 	}
 	
-	[iOS (4,0)]
 	[BaseType (typeof (UINavigationController))]
 	interface MFMessageComposeViewController : UIAppearance {
 		[Export ("messageComposeDelegate", ArgumentSemantic.Assign), NullAllowed]

--- a/src/messageui.cs
+++ b/src/messageui.cs
@@ -124,12 +124,10 @@ namespace XamCore.MessageUI {
 		[Export ("disableUserAttachments")]
 		void DisableUserAttachments ();
 
-		[iOS (5,0)]
 		[Field ("MFMessageComposeViewControllerTextMessageAvailabilityDidChangeNotification")]
 		[Notification (typeof (MFMessageAvailabilityChangedEventArgs))]
 		NSString TextMessageAvailabilityDidChangeNotification { get; }
 
-		[iOS (5,0)]
 		[Field ("MFMessageComposeViewControllerTextMessageAvailabilityKey")]
 		NSString TextMessageAvailabilityKey { get; }
 

--- a/src/mobilecoreservices.cs
+++ b/src/mobilecoreservices.cs
@@ -388,7 +388,7 @@ namespace XamCore.MobileCoreServices {
 		NSString Presentation { get; }
 		
 		[Field ("kUTTypeDatabase", "+CoreServices")]
-		[Mac (10,4), iOS(8,0)]
+		[iOS(8,0)]
 		NSString Database { get; }
 		
 		[Field ("kUTTypeVCard", "+CoreServices")]

--- a/src/mobilecoreservices.cs
+++ b/src/mobilecoreservices.cs
@@ -12,39 +12,30 @@ namespace XamCore.MobileCoreServices {
 		NSString Content { get; }
 		
 		[Field ("kUTTypeCompositeContent", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString CompositeContent { get; }
 		 
 		[Field ("kUTTypeMessage", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Message { get; }
 		
 		[Field ("kUTTypeContact", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Contact { get; }
 		
 		[Field ("kUTTypeArchive", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Archive { get; }
 		
 		[Field ("kUTTypeDiskImage", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString DiskImage { get; }
 		
 		[Field ("kUTTypeData", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Data { get; }
 		
 		[Field ("kUTTypeDirectory", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Directory { get; }
 		
 		[Field ("kUTTypeResolvable", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Resolvable { get; }
 		
 		[Field ("kUTTypeSymLink", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString SymLink { get; }
 		
 		[Field ("kUTTypeExecutable", "+CoreServices")]
@@ -52,15 +43,12 @@ namespace XamCore.MobileCoreServices {
 		NSString Executable { get; }
 		
 		[Field ("kUTTypeMountPoint", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString MountPoint { get; }
 		
 		[Field ("kUTTypeAliasFile", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString AliasFile { get; }
 		
 		[Field ("kUTTypeAliasRecord", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString AliasRecord { get; }
 		
 		[Field ("kUTTypeURLBookmarkData", "+CoreServices")]
@@ -68,31 +56,24 @@ namespace XamCore.MobileCoreServices {
 		NSString URLBookmarkData { get; }
 		
 		[Field ("kUTTypeURL", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString URL { get; }
 		
 		[Field ("kUTTypeFileURL", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString FileURL { get; }
 		
 		[Field ("kUTTypeText", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Text { get; }
 		
 		[Field ("kUTTypePlainText", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString PlainText { get; }
 		
 		[Field ("kUTTypeUTF8PlainText", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString UTF8PlainText { get; }
 		
 		[Field ("kUTTypeUTF16ExternalPlainText", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString UTF16ExternalPlainText { get; }
 		
 		[Field ("kUTTypeUTF16PlainText", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString UTF16PlainText { get; }
 		
 		[Field ("kUTTypeDelimitedText", "+CoreServices")]
@@ -112,19 +93,15 @@ namespace XamCore.MobileCoreServices {
 		NSString UTF8TabSeparatedText { get; }
 		
 		[Field ("kUTTypeRTF", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString RTF { get; }
 		
 		[Field ("kUTTypeHTML", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString HTML { get; }
 		
 		[Field ("kUTTypeXML", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString XML { get; }
 		
 		[Field ("kUTTypeSourceCode", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString SourceCode { get; }
 		
 		[Field ("kUTTypeAssemblyLanguageSource", "+CoreServices")]
@@ -132,31 +109,24 @@ namespace XamCore.MobileCoreServices {
 		NSString AssemblyLanguageSource { get; }
 		
 		[Field ("kUTTypeCSource", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString CSource { get; }
 		
 		[Field ("kUTTypeObjectiveCSource", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString ObjectiveCSource { get; }
 		
 		[Field ("kUTTypeCPlusPlusSource", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString CPlusPlusSource { get; }
 		
 		[Field ("kUTTypeObjectiveCPlusPlusSource", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString ObjectiveCPlusPlusSource { get; }
 		
 		[Field ("kUTTypeCHeader", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString CHeader { get; }
 		
 		[Field ("kUTTypeCPlusPlusHeader", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString CPlusPlusHeader { get; }
 		
 		[Field ("kUTTypeJavaSource", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString JavaSource { get; }
 		
 		[Field ("kUTTypeScript", "+CoreServices")]
@@ -216,67 +186,51 @@ namespace XamCore.MobileCoreServices {
 		NSString BinaryPropertyList { get; }
 		
 		[Field ("kUTTypePDF", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString PDF { get; }
 		
 		[Field ("kUTTypeRTFD", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString RTFD { get; }
 		
 		[Field ("kUTTypeFlatRTFD", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString FlatRTFD { get; }
 		
 		[Field ("kUTTypeTXNTextAndMultimediaData", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString TXNTextAndMultimediaData { get; }
 		
 		[Field ("kUTTypeWebArchive", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString WebArchive { get; }
 		
 		[Field ("kUTTypeImage", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Image { get; }
 		
 		[Field ("kUTTypeJPEG", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString JPEG { get; }
 		
 		[Field ("kUTTypeJPEG2000", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString JPEG2000 { get; }
 		
 		[Field ("kUTTypeTIFF", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString TIFF { get; }
 		
 		[Field ("kUTTypePICT", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString PICT { get; }
 		
 		[Field ("kUTTypeGIF", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString GIF { get; }
 		
 		[Field ("kUTTypePNG", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString PNG { get; }
 		
 		[Field ("kUTTypeQuickTimeImage", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString QuickTimeImage { get; }
 		
 		[Field ("kUTTypeAppleICNS", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString AppleICNS { get; }
 		
 		[Field ("kUTTypeBMP", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString BMP { get; }
 		
 		[Field ("kUTTypeICO", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString ICO { get; }
 		
 		[Field ("kUTTypeRawImage", "+CoreServices")]
@@ -288,27 +242,21 @@ namespace XamCore.MobileCoreServices {
 		NSString ScalableVectorGraphics { get; }
 		
 		[Field ("kUTTypeAudiovisualContent", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString AudiovisualContent { get; }
 		
 		[Field ("kUTTypeMovie", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Movie { get; }
 		
 		[Field ("kUTTypeVideo", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Video { get; }
 		
 		[Field ("kUTTypeAudio", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Audio { get; }
 		
 		[Field ("kUTTypeQuickTimeMovie", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString QuickTimeMovie { get; }
 		
 		[Field ("kUTTypeMPEG", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString MPEG { get; }
 		
 		[Field ("kUTTypeMPEG2Video", "+CoreServices")]
@@ -320,19 +268,15 @@ namespace XamCore.MobileCoreServices {
 		NSString MPEG2TransportStream { get; }
 		
 		[Field ("kUTTypeMP3", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString MP3 { get; }
 		
 		[Field ("kUTTypeMPEG4", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString MPEG4 { get; }
 		
 		[Field ("kUTTypeMPEG4Audio", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString MPEG4Audio { get; }
 		
 		[Field ("kUTTypeAppleProtectedMPEG4Audio", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString AppleProtectedMPEG4Audio { get; }
 		
 		[Field ("kUTTypeAppleProtectedMPEG4Video", "+CoreServices")]
@@ -364,19 +308,15 @@ namespace XamCore.MobileCoreServices {
 		NSString M3UPlaylist { get; }
 		
 		[Field ("kUTTypeFolder", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Folder { get; }
 		
 		[Field ("kUTTypeVolume", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Volume { get; }
 		
 		[Field ("kUTTypePackage", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Package { get; }
 		
 		[Field ("kUTTypeBundle", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Bundle { get; }
 		
 		[Field ("kUTTypePluginBundle", "+CoreServices")]
@@ -396,19 +336,15 @@ namespace XamCore.MobileCoreServices {
 		NSString XPCService { get; }
 		
 		[Field ("kUTTypeFramework", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Framework { get; }
 		
 		[Field ("kUTTypeApplication", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString Application { get; }
 		
 		[Field ("kUTTypeApplicationBundle", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString ApplicationBundle { get; }
 		
 		[Field ("kUTTypeApplicationFile", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString ApplicationFile { get; }
 		
 		[Field ("kUTTypeUnixExecutable", "+CoreServices")]
@@ -456,7 +392,6 @@ namespace XamCore.MobileCoreServices {
 		NSString Database { get; }
 		
 		[Field ("kUTTypeVCard", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString VCard { get; }
 		
 		[Field ("kUTTypeToDoItem", "+CoreServices")]
@@ -476,7 +411,6 @@ namespace XamCore.MobileCoreServices {
 		NSString InternetLocation { get; }
 		
 		[Field ("kUTTypeInkText", "+CoreServices")]
-		[Mac (10,4), iOS(3,0)]
 		NSString InkText { get; }
 		
 		[Field ("kUTTypeFont", "+CoreServices")]

--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -957,7 +957,7 @@ namespace XamCore.ModelIO {
 		MDLMesh CreateCylindroid (float height, Vector2 radii, nuint radialSegments, nuint verticalSegments, MDLGeometryType geometryType, bool inwardNormals, [NullAllowed] IMDLMeshBufferAllocator allocator);
 
 		[Static]
-		[iOS (10,2), Mac (12,1,1), TV (10,1)]
+		[iOS (10,2), Mac (10,12,2), TV (10,1)]
 		[Export ("newCapsuleWithHeight:radii:radialSegments:verticalSegments:hemisphereSegments:geometryType:inwardNormals:allocator:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		MDLMesh CreateCapsule (float height, Vector2 radii, nuint radialSegments, nuint verticalSegments, nuint hemisphereSegments, MDLGeometryType geometryType, bool inwardNormals, [NullAllowed] IMDLMeshBufferAllocator allocator);
@@ -972,7 +972,7 @@ namespace XamCore.ModelIO {
 		MDLMesh CreateIcosahedron (float radius, bool inwardNormals, [NullAllowed] IMDLMeshBufferAllocator allocator);
 
 		[Static]
-		[iOS (10,2), Mac (12,1,1), TV (10,1)]
+		[iOS (10,2), Mac (10,12,2), TV (10,1)]
 		[Export ("newIcosahedronWithRadius:inwardNormals:geometryType:allocator:")]
 		MDLMesh CreateIcosahedron (float radius, bool inwardNormals, MDLGeometryType geometryType, [NullAllowed] IMDLMeshBufferAllocator allocator);
 
@@ -1146,7 +1146,7 @@ namespace XamCore.ModelIO {
 		IntPtr Constructor (float smoothness, [NullAllowed] string name, Vector2i textureDimensions, int channelCount, MDLTextureChannelEncoding channelEncoding, bool grayscale);
 
 		[Internal]
-		[iOS (10,2), Mac (12,1,1)]
+		[iOS (10,2), Mac (10,12,2)]
 		[Export ("initCellularNoiseWithFrequency:name:textureDimensions:channelEncoding:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		IntPtr InitCellularNoiseWithFrequency (float frequency, [NullAllowed] string name, Vector2i textureDimensions, MDLTextureChannelEncoding channelEncoding);
@@ -1215,7 +1215,7 @@ namespace XamCore.ModelIO {
 		[Export ("objectAtPath:")]
 		MDLObject GetObject (string path);
 
-		[iOS (10,2), Mac (12,1,1), TV (10,1)]
+		[iOS (10,2), Mac (10,12,2), TV (10,1)]
 		[Export ("enumerateChildObjectsOfClass:root:usingBlock:stopPointer:")]
 		void EnumerateChildObjects (Class objectClass, MDLObject root, MDLObjectHandler handler, ref bool stop);
 
@@ -1614,7 +1614,7 @@ namespace XamCore.ModelIO {
 		[NullAllowed, Export ("topology", ArgumentSemantic.Retain)]
 		MDLSubmeshTopology Topology {
 			get;
-			[iOS (10,2), Mac (12,1,1), TV (10,1)]
+			[iOS (10,2), Mac (10,12,2), TV (10,1)]
 			set;
 		}
 

--- a/src/newsstandkit.cs
+++ b/src/newsstandkit.cs
@@ -11,7 +11,6 @@ using XamCore.ObjCRuntime;
 
 namespace XamCore.NewsstandKit {
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	// <quote>You create an NKAssetDownload instance using the NKIssue method addAssetWithRequest:</quote> -> http://developer.apple.com/library/ios/#documentation/StoreKit/Reference/NKAssetDownload_Class/NKAssetDownload/NKAssetDownload.html
 	// init returns NIL
@@ -33,7 +32,6 @@ namespace XamCore.NewsstandKit {
 		NSUrlConnection DownloadWithDelegate ([Protocolize] NSUrlConnectionDownloadDelegate downloadDelegate);
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	// <quote>An NKIssue object must have a name and a date. When you create the object using the addIssueWithName:date: method of the NKLibrary class, you must supply these two values.</quote>
 	// http://developer.apple.com/library/ios/#documentation/StoreKit/Reference/NKIssue_Class/NKIssue/NKIssue.html#//apple_ref/occ/cl/NKIssue
@@ -63,7 +61,6 @@ namespace XamCore.NewsstandKit {
 		NSString DownloadCompletedNotification { get; }
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	// init returns NIL -> sharedLibrary
 	[DisableDefaultCtor]

--- a/src/quicklook.cs
+++ b/src/quicklook.cs
@@ -40,7 +40,6 @@ using System.ComponentModel;
 
 namespace XamCore.QuickLook {
 #if !MONOMAC
-	[iOS (4,0)]
 	[BaseType (typeof (UIViewController), Delegates = new string [] { "WeakDelegate" }, Events=new Type [] { typeof (QLPreviewControllerDelegate)})]
 	interface QLPreviewController {
 		[Export ("initWithNibName:bundle:")]
@@ -79,7 +78,6 @@ namespace XamCore.QuickLook {
 		void RefreshCurrentPreviewItem ();
 	}
 
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -94,7 +92,6 @@ namespace XamCore.QuickLook {
 		QLPreviewItem GetPreviewItem (QLPreviewController controller, nint index);
 	}
 
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -111,11 +108,9 @@ namespace XamCore.QuickLook {
 #if !MONOMAC
 		// UIView and UIImage do not exists in MonoMac
 		
-		[iOS (4,2)]
 		[Export ("previewController:frameForPreviewItem:inSourceView:"), DelegateName ("QLFrame"), DefaultValue (typeof (CGRect))]
 		CGRect FrameForPreviewItem (QLPreviewController controller, [Protocolize] QLPreviewItem item, ref UIView view);
 		
-		[iOS (4,2)]
 		[Export ("previewController:transitionImageForPreviewItem:contentRect:"), DelegateName ("QLTransition"), DefaultValue (null)]
 		UIImage TransitionImageForPreviewItem (QLPreviewController controller, [Protocolize] QLPreviewItem item, CGRect contentRect);
 
@@ -128,7 +123,6 @@ namespace XamCore.QuickLook {
 
 	interface IQLPreviewItem {}
 
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]

--- a/src/quicklookUI.cs
+++ b/src/quicklookUI.cs
@@ -33,7 +33,6 @@ namespace XamCore.QuickLookUI {
 		NSObject TransitionImageForPreviewItem (QLPreviewPanel panel, [Protocolize] QLPreviewItem item, CGRect contentRect);
 	}
 	
-	[Mac (10,6)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	interface QLPreviewItem {
@@ -61,7 +60,6 @@ namespace XamCore.QuickLookUI {
 		void EndPreviewPanelControl (QLPreviewPanel panel);
 	}
 
-	[Mac (10,6)]
 	[BaseType (typeof (NSPanel))]
 	interface QLPreviewPanel {
 		[Export ("currentController")]

--- a/src/scriptingbridge.cs
+++ b/src/scriptingbridge.cs
@@ -51,7 +51,6 @@ namespace XamCore.ScriptingBridge {
 	}
 
 #pragma warning disable 0618 // SBElement can only access children elements via NSMutableArray base type
-	[Mac (10,5)]
 	[BaseType (typeof (NSMutableArray))]
 	[DisableDefaultCtor] // *** -[SBElementArray init]: should never be used.
 	interface SBElementArray {

--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -1222,7 +1222,7 @@ namespace XamCore.SpriteKit {
 		[Static, Export ("labelNodeWithText:")]
 		SKLabelNode FromText ([NullAllowed] string text);
 
-		[TV (11,0), Watch (4,0), Mac (13,0), iOS (11,0)]
+		[TV (11,0), Watch (4,0), Mac (10,13), iOS (11,0)]
 		[Static]
 		[Export ("labelNodeWithAttributedText:")]
 		SKLabelNode FromText ([NullAllowed] NSAttributedString attributedText);
@@ -1233,15 +1233,15 @@ namespace XamCore.SpriteKit {
 		[Export ("horizontalAlignmentMode")]
 		SKLabelHorizontalAlignmentMode HorizontalAlignmentMode { get; set; }
 
-		[TV (11,0), Watch (4,0), Mac (13,0), iOS (11,0)]
+		[TV (11,0), Watch (4,0), Mac (10,13), iOS (11,0)]
 		[Export ("numberOfLines")]
 		nint NumberOfLines { get; set; }
 
-		[TV (11,0), Watch (4,0), Mac (13,0), iOS (11,0)]
+		[TV (11,0), Watch (4,0), Mac (10,13), iOS (11,0)]
 		[Export ("lineBreakMode", ArgumentSemantic.Assign)]
 		NSLineBreakMode LineBreakMode { get; set; }
 
-		[TV (11,0), Watch (4,0), Mac (13,0), iOS (11,0)]
+		[TV (11,0), Watch (4,0), Mac (10,13), iOS (11,0)]
 		[Export ("preferredMaxLayoutWidth")]
 		nfloat PreferredMaxLayoutWidth { get; set; }
 
@@ -1252,7 +1252,7 @@ namespace XamCore.SpriteKit {
 		[NullAllowed] // nullable in Xcode7 headers and caught by introspection tests
 		string Text { get; set; }
 
-		[TV (11,0), Watch (4,0), Mac (13,0), iOS (11,0)]
+		[TV (11,0), Watch (4,0), Mac (10,13), iOS (11,0)]
 		[NullAllowed, Export ("attributedText", ArgumentSemantic.Copy)]
 		NSAttributedString AttributedText { get; set; }
 
@@ -3456,7 +3456,7 @@ namespace XamCore.SpriteKit {
 		bool ShowsFields { get; set; }
 	}
 
-	[TV (11,0), Watch (4,0), Mac (13,0), iOS (11,0)]
+	[TV (11,0), Watch (4,0), Mac (10,13), iOS (11,0)]
 	[BaseType (typeof(SKNode))]
 	interface SKTransformNode {
 		[Export ("xRotation")]

--- a/src/storekit.cs
+++ b/src/storekit.cs
@@ -80,7 +80,7 @@ namespace XamCore.StoreKit {
 #if !MONOMAC
 		[Static]
 		[Export ("paymentWithProductIdentifier:")]
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_5_0, Message = "Use 'FromProduct (SKProduct)'' after fetching the list of available products from 'SKProductRequest' instead.")]
+		[Availability (Deprecated = Platform.iOS_5_0, Message = "Use 'FromProduct (SKProduct)'' after fetching the list of available products from 'SKProductRequest' instead.")]
 		SKPayment CreateFrom (string identifier);
 #endif
 
@@ -112,7 +112,7 @@ namespace XamCore.StoreKit {
 
 		[Static]
 		[Export ("paymentWithProductIdentifier:")]
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_5_0, Message = "Use 'PaymentWithProduct (SKProduct)' after fetching the list of available products from 'SKProductRequest' instead.")]
+		[Availability (Deprecated = Platform.iOS_5_0, Message = "Use 'PaymentWithProduct (SKProduct)' after fetching the list of available products from 'SKProductRequest' instead.")]
 		SKMutablePayment PaymentWithProduct (string identifier);
 
 		[NullAllowed] // by default this property is null
@@ -288,7 +288,7 @@ namespace XamCore.StoreKit {
 		string TransactionIdentifier { get; }
 
 #if !MONOMAC
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_7_0, Message = "Use 'NSBundle.AppStoreReceiptUrl' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'NSBundle.AppStoreReceiptUrl' instead.")]
 		[Export ("transactionReceipt")]
 		NSData TransactionReceipt { get; }
 #endif

--- a/src/twitter.cs
+++ b/src/twitter.cs
@@ -20,7 +20,7 @@ namespace XamCore.Twitter {
 	delegate void TWTweetComposeHandler (TWTweetComposeViewControllerResult result);
 #endif
 	
-	[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_6_0, Message = "Use the 'Social' framework.")]
+	[Availability (Deprecated = Platform.iOS_6_0, Message = "Use the 'Social' framework.")]
 	[BaseType (typeof (NSObject))]
 	interface TWRequest {
 		[NullAllowed] // by default this property is null
@@ -50,7 +50,7 @@ namespace XamCore.Twitter {
 		void PerformRequest (TWRequestHandler handler);
 	}
 
-	[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_6_0, Message = "Use the 'Social' framework.")]
+	[Availability (Deprecated = Platform.iOS_6_0, Message = "Use the 'Social' framework.")]
 	[BaseType (typeof (UIViewController))]
 	interface TWTweetComposeViewController {
 		[Export ("initWithNibName:bundle:")]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -1367,7 +1367,7 @@ namespace XamCore.UIKit {
 #if !WATCH
 	[NoTV]
 	[BaseType (typeof (NSObject))]
-	[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_5_0, Message = "Use 'CoreMotion' instead.")]
+	[Availability (Deprecated = Platform.iOS_5_0, Message = "Use 'CoreMotion' instead.")]
 	interface UIAcceleration {
 		[Export ("timestamp")]
 		double Time { get; }
@@ -1384,7 +1384,7 @@ namespace XamCore.UIKit {
 
 	[NoTV]
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIAccelerometerDelegate)})]
-	[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_5_0, Message = "Use 'CoreMotion' instead.")]
+	[Availability (Deprecated = Platform.iOS_5_0, Message = "Use 'CoreMotion' instead.")]
 	interface UIAccelerometer {
 		[Static] [Export ("sharedAccelerometer")]
 		UIAccelerometer SharedAccelerometer { get; }
@@ -2804,7 +2804,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoWatch]
-	[iOS (2,0)]
 	[BaseType (typeof (UIResponder))]
 	interface UIApplication {
 		[Static, ThreadSafe]
@@ -2883,7 +2882,7 @@ namespace XamCore.UIKit {
 
 		[NoTV]
 		[Export ("setStatusBarHidden:animated:")]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_3_2, Message = "Use 'SetStatusBarHidden (bool, UIStatusBarAnimation)' instead.")]
+		[Availability (Deprecated = Platform.iOS_3_2, Message = "Use 'SetStatusBarHidden (bool, UIStatusBarAnimation)' instead.")]
 		void SetStatusBarHidden (bool hidden, bool animated);
 
 		[NoTV]
@@ -5033,19 +5032,19 @@ namespace XamCore.UIKit {
 		[Export ("groupTableViewBackgroundColor")][Static]
 		UIColor GroupTableViewBackgroundColor { get; }
 
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0)]
+		[Availability (Deprecated = Platform.iOS_7_0)]
 		[NoWatch][NoTV]
 		[Export ("viewFlipsideBackgroundColor")][Static]
 		UIColor ViewFlipsideBackgroundColor { get; }
 
 		[iOS (3,2)]
-		[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_7_0)]
+		[Availability (Deprecated = Platform.iOS_7_0)]
 		[NoWatch][NoTV]
 		[Export ("scrollViewTexturedBackgroundColor")][Static]
 		UIColor ScrollViewTexturedBackgroundColor { get; }
 
 		[iOS (5,0)]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0)]
+		[Availability (Deprecated = Platform.iOS_7_0)]
 		[NoWatch][NoTV]
 		[Static, Export ("underPageBackgroundColor")]
 		UIColor UnderPageBackgroundColor { get; }
@@ -6445,17 +6444,17 @@ namespace XamCore.UIKit {
 		//
 
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_3_2)]
+		[Availability (Deprecated = Platform.iOS_3_2)]
 		[Field ("UIKeyboardCenterBeginUserInfoKey")]
 		NSString CenterBeginUserInfoKey { get; }
 
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_3_2)]
+		[Availability (Deprecated = Platform.iOS_3_2)]
 		[Field ("UIKeyboardCenterEndUserInfoKey")]
 		NSString CenterEndUserInfoKey { get; }
 
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_3_2)]
+		[Availability (Deprecated = Platform.iOS_3_2)]
 		[Field ("UIKeyboardBoundsUserInfoKey")]
 		NSString BoundsUserInfoKey { get; }
 #endif
@@ -8024,7 +8023,7 @@ namespace XamCore.UIKit {
 
 		[NoTV]
 		[Export ("minimumFontSize")]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_6_0, Message = "Use 'MinimumScaleFactor' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'MinimumScaleFactor' instead.")]
 		nfloat MinimumFontSize { get; set; }
 
 		[Export ("baselineAdjustment")]
@@ -8343,11 +8342,11 @@ namespace XamCore.UIKit {
 	[iOS (3,2)]
 	[Protocol]
 	interface UIDocumentInteractionControllerDelegate {
-		[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_6_0)]
+		[Availability (Deprecated = Platform.iOS_6_0)]
 		[Export ("documentInteractionController:canPerformAction:"), DelegateName ("UIDocumentInteractionProbe"), DefaultValue (false)]
 		bool CanPerformAction (UIDocumentInteractionController controller, [NullAllowed] Selector action);
 
-		[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_6_0)]
+		[Availability (Deprecated = Platform.iOS_6_0)]
 		[Export ("documentInteractionController:performAction:"), DelegateName ("UIDocumentInteractionProbe"), DefaultValue (false)]
 		bool PerformAction (UIDocumentInteractionController controller, [NullAllowed] Selector action);
 		
@@ -8408,7 +8407,7 @@ namespace XamCore.UIKit {
 
 #if !XAMCORE_3_0
 		[Export ("allowsImageEditing")]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_3_1)]
+		[Availability (Deprecated = Platform.iOS_3_1)]
 		bool AllowsImageEditing { get; set; }
 #endif
 
@@ -8514,7 +8513,7 @@ namespace XamCore.UIKit {
 	[Protocol]
 	interface UIImagePickerControllerDelegate {
 #if !XAMCORE_3_0
-		[Availability (Introduced = Platform.iOS_2_0, Obsoleted = Platform.iOS_3_0)]
+		[Availability (Obsoleted = Platform.iOS_3_0)]
 		[Export ("imagePickerController:didFinishPickingImage:editingInfo:"), EventArgs ("UIImagePickerImagePicked")]
 		void FinishedPickingImage (UIImagePickerController picker, UIImage image, NSDictionary editingInfo);
 #endif
@@ -10834,7 +10833,7 @@ namespace XamCore.UIKit {
 
 		[Export ("segmentedControlStyle")]
 		[NoTV][NoWatch]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0, Message = "The 'SegmentedControlStyle' property no longer has any effect.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "The 'SegmentedControlStyle' property no longer has any effect.")]
 		UISegmentedControlStyle ControlStyle { get; set; }
 
 		[Export ("momentary")]
@@ -11479,19 +11478,19 @@ namespace XamCore.UIKit {
 		string BadgeValue { get; set; } 
 
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0, Message = "Use the '(string, UIImage, UIImage)' constructor or the 'Image' and 'SelectedImage' properties along with 'RenderingMode = UIImageRenderingMode.AlwaysOriginal'.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use the '(string, UIImage, UIImage)' constructor or the 'Image' and 'SelectedImage' properties along with 'RenderingMode = UIImageRenderingMode.AlwaysOriginal'.")]
 		[Export ("setFinishedSelectedImage:withFinishedUnselectedImage:")]
 		[PostGet ("FinishedSelectedImage")]
 		[PostGet ("FinishedUnselectedImage")]
 		void SetFinishedImages ([NullAllowed] UIImage selectedImage, [NullAllowed] UIImage unselectedImage);
 
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0)]
+		[Availability (Deprecated = Platform.iOS_7_0)]
 		[Export ("finishedSelectedImage")]
 		UIImage FinishedSelectedImage { get; }
 
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_7_0)]
+		[Availability (Deprecated = Platform.iOS_7_0)]
 		[Export ("finishedUnselectedImage")]
 		UIImage FinishedUnselectedImage { get; }
 
@@ -11955,7 +11954,7 @@ namespace XamCore.UIKit {
 		UIView GetViewForFooter (UITableView tableView, nint section);
 
 #if !XAMCORE_3_0
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_3_0)]
+		[Availability (Deprecated = Platform.iOS_3_0)]
 		[Export ("tableView:accessoryTypeForRowWithIndexPath:")]
 		UITableViewCellAccessory AccessoryForRow (UITableView tableView, NSIndexPath indexPath);
 #endif
@@ -12307,7 +12306,7 @@ namespace XamCore.UIKit {
 		UIView GetViewForFooter (UITableView tableView, nint section);
 
 #if !XAMCORE_3_0
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_3_0)]
+		[Availability (Deprecated = Platform.iOS_3_0)]
 		[Export ("tableView:accessoryTypeForRowWithIndexPath:")]
 		UITableViewCellAccessory AccessoryForRow (UITableView tableView, NSIndexPath indexPath);
 #endif
@@ -13312,7 +13311,7 @@ namespace XamCore.UIKit {
 
 		[NoTV]
 		[Export ("contentStretch")]
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_6_0, Message = "Use 'CreateResizableImage' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'CreateResizableImage' instead.")]
 		CGRect ContentStretch { get; set; }
 
 		[Static] [Export ("beginAnimations:context:")]
@@ -13822,7 +13821,7 @@ namespace XamCore.UIKit {
 
 		[NoTV]
 		[Export ("viewDidUnload")]
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_6_0)]
+		[Availability (Deprecated = Platform.iOS_6_0)]
 		void ViewDidUnload ();
 
 		[Export ("isViewLoaded")]
@@ -13855,12 +13854,12 @@ namespace XamCore.UIKit {
 
 		[NoTV]
 		[Export ("presentModalViewController:animated:")]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_6_0, Message = "Use 'PresentViewController (UIViewController, bool, NSAction)' instead and set the 'ModalViewController' property to true.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'PresentViewController (UIViewController, bool, NSAction)' instead and set the 'ModalViewController' property to true.")]
 		void PresentModalViewController (UIViewController modalViewController, bool animated);
 
 		[NoTV]
 		[Export ("dismissModalViewControllerAnimated:")]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_6_0, Message = "Use 'DismissViewController (bool, NSAction)' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'DismissViewController (bool, NSAction)' instead.")]
 #if XAMCORE_2_0
 		void DismissModalViewController (bool animated);
 #else
@@ -13869,7 +13868,7 @@ namespace XamCore.UIKit {
 		
 		[NoTV]
 		[Export ("modalViewController")]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_6_0, Message = "Use 'PresentedViewController' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'PresentedViewController' instead.")]
 		UIViewController ModalViewController { get; }
 
 		[Export ("modalTransitionStyle", ArgumentSemantic.Assign)]
@@ -13877,7 +13876,7 @@ namespace XamCore.UIKit {
 
 		[NoTV]
 		[Export ("wantsFullScreenLayout", ArgumentSemantic.Assign)]
-		[Availability (Introduced = Platform.iOS_3_0, Deprecated = Platform.iOS_7_0, Message = "Use 'EdgesForExtendedLayout', 'ExtendedLayoutIncludesOpaqueBars' and 'AutomaticallyAdjustsScrollViewInsets' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'EdgesForExtendedLayout', 'ExtendedLayoutIncludesOpaqueBars' and 'AutomaticallyAdjustsScrollViewInsets' instead.")]
 		bool WantsFullScreenLayout { get; set; }
 
 		[Export ("parentViewController")][NullAllowed]
@@ -13890,7 +13889,7 @@ namespace XamCore.UIKit {
 
 		[NoTV]
 		[Export ("shouldAutorotateToInterfaceOrientation:")]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_6_0, Message = "Use both 'GetSupportedInterfaceOrientations' and 'PreferredInterfaceOrientationForPresentation' instead.")]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use both 'GetSupportedInterfaceOrientations' and 'PreferredInterfaceOrientationForPresentation' instead.")]
 		bool ShouldAutorotateToInterfaceOrientation (UIInterfaceOrientation toInterfaceOrientation);
 
 		[NoTV]
@@ -14001,7 +14000,7 @@ namespace XamCore.UIKit {
 
 		// This is defined in a category in UIPopoverSupport.h: UIViewController (UIPopoverController)
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_3_2, Deprecated = Platform.iOS_7_0, Message = "Use 'PreferredContentSize' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'PreferredContentSize' instead.")]
 		[Export ("contentSizeForViewInPopover")]
 		CGSize ContentSizeForViewInPopover { get; set; }
 
@@ -14036,7 +14035,7 @@ namespace XamCore.UIKit {
 
 		[NoTV]
 		[iOS (5,0)]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_6_0)]
+		[Availability (Deprecated = Platform.iOS_6_0)]
 		[Export ("viewWillUnload")]
 		void ViewWillUnload ();
 
@@ -14090,7 +14089,7 @@ namespace XamCore.UIKit {
 		void AttemptRotationToDeviceOrientation ();
 
 		[NoTV]
-		[Availability (Introduced = Platform.iOS_5_0, Deprecated = Platform.iOS_6_0)]
+		[Availability (Deprecated = Platform.iOS_6_0)]
 		[Export ("automaticallyForwardAppearanceAndRotationMethodsToChildViewControllers")]
 		/*PROTECTED*/ bool AutomaticallyForwardAppearanceAndRotationMethodsToChildViewControllers { get; }
 
@@ -15614,7 +15613,7 @@ namespace XamCore.UIKit {
 	[BaseType (typeof (NSObject))]
 	interface UITextInputMode : NSSecureCoding {
 		[Export ("currentInputMode"), NullAllowed][Static]
-		[Availability (Introduced = Platform.iOS_4_2, Deprecated = Platform.iOS_7_0)]
+		[Availability (Deprecated = Platform.iOS_7_0)]
 		[NoTV]
 		UITextInputMode CurrentInputMode { get; }
 
@@ -16151,73 +16150,73 @@ namespace XamCore.UIKit {
 	interface UIStringDrawing {
 		// note: duplicate from maccore's foundation.cs where it's binded on NSString2 (for Classic)
 		[ThreadSafe]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.DrawString (CGPoint, UIStringAttributes)' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.DrawString (CGPoint, UIStringAttributes)' instead.")]
 		[Export ("drawAtPoint:withFont:")]
 		CGSize DrawString (CGPoint point, UIFont font);
 
 		// note: duplicate from maccore's foundation.cs where it's binded on NSString2 (for Classic)
 		[ThreadSafe]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.DrawString (CGRect, UIStringAttributes)' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.DrawString (CGRect, UIStringAttributes)' instead.")]
 		[Export ("drawAtPoint:forWidth:withFont:lineBreakMode:")]
 		CGSize DrawString (CGPoint point, nfloat width, UIFont font, UILineBreakMode breakMode);
 
 		// note: duplicate from maccore's foundation.cs where it's binded on NSString2 (for Classic)
 		[ThreadSafe]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.DrawString (CGRect, UIStringAttributes)' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.DrawString (CGRect, UIStringAttributes)' instead.")]
 		[Export ("drawAtPoint:forWidth:withFont:fontSize:lineBreakMode:baselineAdjustment:")]
 		CGSize DrawString (CGPoint point, nfloat width, UIFont font, nfloat fontSize, UILineBreakMode breakMode, UIBaselineAdjustment adjustment);
 
 		// note: duplicate from maccore's foundation.cs where it's binded on NSString2 (for Classic)
 		[ThreadSafe]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.DrawString (CGRect, UIStringAttributes)' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.DrawString (CGRect, UIStringAttributes)' instead.")]
 		[Export ("drawAtPoint:forWidth:withFont:minFontSize:actualFontSize:lineBreakMode:baselineAdjustment:")]
 		CGSize DrawString (CGPoint point, nfloat width, UIFont font, nfloat minFontSize, ref nfloat actualFontSize, UILineBreakMode breakMode, UIBaselineAdjustment adjustment);
 
 		// note: duplicate from maccore's foundation.cs where it's binded on NSString2 (for Classic)
 		[ThreadSafe]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.DrawString (CGRect, UIStringAttributes)' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.DrawString (CGRect, UIStringAttributes)' instead.")]
 		[Export ("drawInRect:withFont:")]
 		CGSize DrawString (CGRect rect, UIFont font);
 
 		// note: duplicate from maccore's foundation.cs where it's binded on NSString2 (for Classic)
 		[ThreadSafe]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.DrawString (CGRect, UIStringAttributes)' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.DrawString (CGRect, UIStringAttributes)' instead.")]
 		[Export ("drawInRect:withFont:lineBreakMode:")]
 		CGSize DrawString (CGRect rect, UIFont font, UILineBreakMode mode);
 
 		// note: duplicate from maccore's foundation.cs where it's binded on NSString2 (for Classic)
 		[ThreadSafe]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.DrawString (CGRect, UIStringAttributes)' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.DrawString (CGRect, UIStringAttributes)' instead.")]
 		[Export ("drawInRect:withFont:lineBreakMode:alignment:")]
 		CGSize DrawString (CGRect rect, UIFont font, UILineBreakMode mode, UITextAlignment alignment);
 
 		// note: duplicate from maccore's foundation.cs where it's binded on NSString2 (for Classic)
 		[ThreadSafe]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.GetSizeUsingAttributes (UIStringAttributes)' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.GetSizeUsingAttributes (UIStringAttributes)' instead.")]
 		[Export ("sizeWithFont:")]
 		CGSize StringSize (UIFont font);
 
 		// note: duplicate from maccore's foundation.cs where it's binded on NSString2 (for Classic)
 		[ThreadSafe]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead.")]
 		[Export ("sizeWithFont:forWidth:lineBreakMode:")]
 		CGSize StringSize (UIFont font, nfloat forWidth, UILineBreakMode breakMode);
 
 		// note: duplicate from maccore's foundation.cs where it's binded on NSString2 (for Classic)
 		[ThreadSafe]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead.")]
 		[Export ("sizeWithFont:constrainedToSize:")]
 		CGSize StringSize (UIFont font, CGSize constrainedToSize);
 
 		// note: duplicate from maccore's foundation.cs where it's binded on NSString2 (for Classic)
 		[ThreadSafe]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead.")]
+		[Availability (Deprecated = Platform.iOS_7_0, Message = "Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead.")]
 		[Export ("sizeWithFont:constrainedToSize:lineBreakMode:")]
 		CGSize StringSize (UIFont font, CGSize constrainedToSize, UILineBreakMode lineBreakMode);
 
 		// note: duplicate from maccore's foundation.cs where it's binded on NSString2 (for Classic)
 		[ThreadSafe]
-		[Availability (Introduced = Platform.iOS_2_0, Deprecated = Platform.iOS_7_0)]
+		[Availability (Deprecated = Platform.iOS_7_0)]
 		// Wait for guidance here: https://devforums.apple.com/thread/203655
 		//[Obsolete ("Deprecated on iOS7.   No guidance.")]
 		[Export ("sizeWithFont:minFontSize:actualFontSize:forWidth:lineBreakMode:")]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -1449,7 +1449,6 @@ namespace XamCore.UIKit {
 		[Export ("accessibilityFrame")]
 		CGRect AccessibilityFrame { get; set; }
 
-		[iOS (5,0)]
 		[Export ("accessibilityActivationPoint")]
 		CGPoint AccessibilityActivationPoint { get; set; }
 
@@ -1457,11 +1456,9 @@ namespace XamCore.UIKit {
 		[Export ("accessibilityLanguage", ArgumentSemantic.Retain)]
 		string AccessibilityLanguage { get; set; }
 
-		[iOS (5,0)]
 		[Export ("accessibilityElementsHidden")]
 		bool AccessibilityElementsHidden { get; set; }
 
-		[iOS (5,0)]
 		[Export ("accessibilityViewIsModal")]
 		bool AccessibilityViewIsModal { get; set; }
 
@@ -1519,14 +1516,11 @@ namespace XamCore.UIKit {
 		[Field ("UIAccessibilityTraitAdjustable")]
 		long TraitAdjustable { get; }
 
-		[iOS (5,0)]
 		[Field ("UIAccessibilityTraitAllowsDirectInteraction")]
 		long TraitAllowsDirectInteraction { get; }
 
-		[iOS (5,0)]
 		[Field ("UIAccessibilityTraitCausesPageTurn")]
 		long TraitCausesPageTurn { get; }
-
 
 		[iOS (10,0), TV (10,0), Watch (3,0)]
 		[Field ("UIAccessibilityTraitTabBar")]
@@ -1550,13 +1544,11 @@ namespace XamCore.UIKit {
 		NSString VoiceOverStatusDidChangeNotification { get; }
 
 		[NoWatch]
-		[iOS (5,0)]
 		[Field ("UIAccessibilityMonoAudioStatusDidChangeNotification")]
 		[Notification]
 		NSString MonoAudioStatusDidChangeNotification { get; }
 
 		[NoWatch]
-		[iOS (5,0)]
 		[Field ("UIAccessibilityClosedCaptioningStatusDidChangeNotification")]
 		[Notification]
 		NSString ClosedCaptioningStatusDidChangeNotification { get; }
@@ -1582,7 +1574,6 @@ namespace XamCore.UIKit {
 		[Field ("UIAccessibilityAnnouncementNotification")]
 		int AnnouncementNotification { get; } // This is int, not nint
 
-		[iOS (4,2)]
 		[Field ("UIAccessibilityPageScrolledNotification")]
 		int PageScrolledNotification { get; } // This is int, not nint
 
@@ -1981,11 +1972,9 @@ namespace XamCore.UIKit {
 #if !XAMCORE_2_0
 		[New] // To avoid the warning that we are overwriting the method in NSObject
 #endif
-		[iOS (4,2)]
 		[Export ("accessibilityScroll:")]
 		bool AccessibilityScroll (UIAccessibilityScrollDirection direction);
 
-		[iOS (5,0)]
 		[Export ("accessibilityPerformEscape")]
 		bool AccessibilityPerformEscape ();
 
@@ -2103,11 +2092,9 @@ namespace XamCore.UIKit {
 		[Export ("dismissWithClickedButtonIndex:animated:")]
 		void DismissWithClickedButtonIndex (nint buttonIndex, bool animated);
 
-		[iOS (3,2)]
 		[Export ("showFromBarButtonItem:animated:")]
 		void ShowFrom (UIBarButtonItem item, bool animated);
 
-		[iOS (3,2)]
 		[Export ("showFromRect:inView:animated:")]
 		void ShowFrom (CGRect rect, UIView inView, bool animated);
 	}
@@ -2436,11 +2423,11 @@ namespace XamCore.UIKit {
 		[Export ("dismissWithClickedButtonIndex:animated:")]
 		void DismissWithClickedButtonIndex (nint index, bool animated);
 
-		[iOS (5,0)]
+
 		[Export ("alertViewStyle", ArgumentSemantic.Assign)]
 		UIAlertViewStyle AlertViewStyle { get; set;  }
 
-		[iOS (5,0)]
+
 		[Export ("textFieldAtIndex:")]
 		UITextField GetTextField (nint textFieldIndex);
 	}
@@ -2468,7 +2455,6 @@ namespace XamCore.UIKit {
 		[Export ("alertView:didDismissWithButtonIndex:"), EventArgs ("UIButton")]
 		void Dismissed (UIAlertView alertView, nint buttonIndex);
 
-		[iOS (5,0)]
 		[Export ("alertViewShouldEnableFirstOtherButton:"), DelegateName ("UIAlertViewPredicate"), DefaultValue (true)]
 		bool ShouldEnableFirstOtherButton (UIAlertView alertView);
 	}
@@ -2876,7 +2862,6 @@ namespace XamCore.UIKit {
 		bool StatusBarHidden { [Bind ("isStatusBarHidden")] get; set; }
 
 		[NoTV]
-		[iOS (3,2)]
 		[Export ("setStatusBarHidden:withAnimation:")]
 		void SetStatusBarHidden (bool state, UIStatusBarAnimation animation);
 
@@ -2987,28 +2972,25 @@ namespace XamCore.UIKit {
 		[Field ("UIApplicationLaunchOptionsRemoteNotificationKey")]
 		NSString LaunchOptionsRemoteNotificationKey { get; }
 
-		[iOS (3,2)]
 		[Field ("UIApplicationLaunchOptionsAnnotationKey")]
 		NSString LaunchOptionsAnnotationKey { get; }
 		
-		[iOS (4,0)]
 		[Export ("applicationState")]
 		UIApplicationState ApplicationState { get; }
 
-		[iOS (4,0), ThreadSafe]
+		[ThreadSafe]
 		[Export ("backgroundTimeRemaining")]
 		double BackgroundTimeRemaining { get; }
 
-		[iOS (4,0), ThreadSafe]
+		[ThreadSafe]
 		[Export ("beginBackgroundTaskWithExpirationHandler:")]
 		nint BeginBackgroundTask ([NullAllowed] NSAction backgroundTimeExpired);
 
-		[iOS (4,0), ThreadSafe]
+		[ThreadSafe]
 		[Export ("endBackgroundTask:")]
 		void EndBackgroundTask (nint taskId);
 
 		[NoTV]
-		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'PushKit' instead.")]
 		[Export ("setKeepAliveTimeout:handler:")]
 		bool SetKeepAliveTimeout (double timeout, [NullAllowed] NSAction handler);
@@ -3018,13 +3000,11 @@ namespace XamCore.UIKit {
 		[Export ("clearKeepAliveTimeout")]
 		void ClearKeepAliveTimeout ();
 		
-		[iOS (4,0)]
 		[Export ("protectedDataAvailable")]
 		bool ProtectedDataAvailable { [Bind ("isProtectedDataAvailable")] get; }
 
 		// from @interface UIApplication (UILocalNotifications)
 		[NoTV]
-		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UNUserNotificationCenter.AddNotificationRequest' instead.")]
 		[Export ("presentLocalNotificationNow:")]
 #if XAMCORE_2_0
@@ -3035,93 +3015,77 @@ namespace XamCore.UIKit {
 
 		// from @interface UIApplication (UILocalNotifications)
 		[NoTV]
-		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UNUserNotificationCenter.AddNotificationRequest' instead.")]
 		[Export ("scheduleLocalNotification:")]
 		void ScheduleLocalNotification (UILocalNotification notification);
 
 		// from @interface UIApplication (UILocalNotifications)
 		[NoTV]
-		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UNUserNotificationCenter.RemovePendingNotificationRequests' instead.")]
 		[Export ("cancelLocalNotification:")]
 		void CancelLocalNotification (UILocalNotification notification);
 
 		// from @interface UIApplication (UILocalNotifications)
 		[NoTV]
-		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UNUserNotificationCenter.RemoveAllPendingNotificationRequests' instead.")]
 		[Export ("cancelAllLocalNotifications")]
 		void CancelAllLocalNotifications ();
 
 		// from @interface UIApplication (UILocalNotifications)
 		[NoTV]
-		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UNUserNotificationCenter.GetPendingNotificationRequests' instead.")]
 		[Export ("scheduledLocalNotifications", ArgumentSemantic.Copy)]
 		UILocalNotification [] ScheduledLocalNotifications { get; set; }
 
 		// from @interface UIApplication (UIRemoteControlEvents)
-		[iOS (4,0)]
 		[Export ("beginReceivingRemoteControlEvents")]
 		void BeginReceivingRemoteControlEvents ();
 
 		// from @interface UIApplication (UIRemoteControlEvents)
-		[iOS (4,0)]
 		[Export ("endReceivingRemoteControlEvents")]
 		void EndReceivingRemoteControlEvents ();
 
-		[iOS (4,0)]
 		[Field ("UIBackgroundTaskInvalid")]
 		nint BackgroundTaskInvalid { get; }
 
-		[iOS (4,0)]
 		[Field ("UIMinimumKeepAliveTimeout")]
 		double /* NSTimeInternal */ MinimumKeepAliveTimeout { get; }
 
-		[iOS (4,0)]
 		[Field ("UIApplicationProtectedDataWillBecomeUnavailable")]
 		[Notification]
 		NSString ProtectedDataWillBecomeUnavailable { get; }
 		
-		[iOS (4,0)]
 		[Field ("UIApplicationProtectedDataDidBecomeAvailable")]
 		[Notification]
 		NSString ProtectedDataDidBecomeAvailable { get; }
 		
-		[iOS (4,0)]
 		[Field ("UIApplicationLaunchOptionsLocationKey")]
 		NSString LaunchOptionsLocationKey { get; }
 		
-		[iOS (4,0)]
 		[Field ("UIApplicationDidEnterBackgroundNotification")]
 		[Notification]
 		NSString DidEnterBackgroundNotification { get; }
 		
-		[iOS (4,0)]
 		[Field ("UIApplicationWillEnterForegroundNotification")]
 		[Notification]
 		NSString WillEnterForegroundNotification { get; }
 		
 		[NoTV]
-		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UNUserNotificationCenterDelegate.DidReceiveNotificationResponse' instead.")]
 		[Field ("UIApplicationLaunchOptionsLocalNotificationKey")]
 		NSString LaunchOptionsLocalNotificationKey { get; }
 
-		[iOS (5,0)]
+
 		[Export ("userInterfaceLayoutDirection")]
 		UIUserInterfaceLayoutDirection UserInterfaceLayoutDirection { get; }
 
 		// from @interface UIApplication (UINewsstand)
 		[NoTV]
-		[iOS (5,0)]
 		[Deprecated (PlatformName.iOS, 9, 0)]
 		[Export ("setNewsstandIconImage:")]
 		void SetNewsstandIconImage ([NullAllowed] UIImage image);
 
 		[NoTV]
-		[iOS (5,0)]
 		[Field ("UIApplicationLaunchOptionsNewsstandDownloadsKey")]
 		NSString LaunchOptionsNewsstandDownloadsKey { get; }
 
@@ -3604,25 +3568,20 @@ namespace XamCore.UIKit {
 		void ReceivedRemoteNotification (UIApplication application, NSDictionary userInfo);
 
 		[NoTV]
-		[iOS (4,0)]
 		[Deprecated (PlatformName.iOS, 10, 0, message: "Use 'UNUserNotificationCenterDelegate.WillPresentNotification/DidReceiveNotificationResponse' instead.")]
 		[Export ("application:didReceiveLocalNotification:")]
 		void ReceivedLocalNotification (UIApplication application, UILocalNotification notification);
 
-		[iOS (4,0)]
 		[Export ("applicationDidEnterBackground:")]
 		void DidEnterBackground (UIApplication application);
 		
 		[Export ("applicationWillEnterForeground:")]
-		[iOS (4,0)]
 		void WillEnterForeground (UIApplication application);
 		
 		[Export ("applicationProtectedDataWillBecomeUnavailable:")]
-		[iOS (4,0)]
 		void ProtectedDataWillBecomeUnavailable (UIApplication application);
 		
 		[Export ("applicationProtectedDataDidBecomeAvailable:")]
-		[iOS (4,0)]
 		void ProtectedDataDidBecomeAvailable (UIApplication application);
 
 		[NoTV]
@@ -3638,7 +3597,7 @@ namespace XamCore.UIKit {
 		[Wrap ("OpenUrl(app, url, options.Dictionary)")]
 		bool OpenUrl (UIApplication app, NSUrl url, UIApplicationOpenUrlOptions options);
 		
-		[iOS (5,0)]
+
 		[Export ("window", ArgumentSemantic.Retain), NullAllowed]
 		UIWindow Window { get; set; }
 
@@ -3804,22 +3763,22 @@ namespace XamCore.UIKit {
 		nint Tag { get; set; }
 
 		[NoTV]
-		[iOS (5,0)]
+
 		[NullAllowed] // by default this property is null
 		[Export ("landscapeImagePhone", ArgumentSemantic.Retain)]
 		UIImage LandscapeImagePhone { get; set;  }
 
 		[NoTV]
-		[iOS (5,0)]
+
 		[Export ("landscapeImagePhoneInsets")]
 		UIEdgeInsets LandscapeImagePhoneInsets { get; set;  }
 
-		[iOS (5,0)]
+
 		[Export ("setTitleTextAttributes:forState:"), Internal]
 		[Appearance]
 		void _SetTitleTextAttributes ([NullAllowed] NSDictionary attributes, UIControlState state);
 
-		[iOS (5,0)]
+
 		[Export ("titleTextAttributesForState:"), Internal]
 		[Appearance]
 		NSDictionary _GetTitleTextAttributes (UIControlState state);
@@ -3895,12 +3854,12 @@ namespace XamCore.UIKit {
 		[Export ("tag")][Override]
 		nint Tag { get; set; }
 
-		[iOS (5,0)]
+
 		[Export ("tintColor", ArgumentSemantic.Retain), NullAllowed]
 		[Appearance]
 		UIColor TintColor { get; set;  }
 
-		[iOS (5,0)]
+
 		[Export ("initWithImage:landscapeImagePhone:style:target:action:"), PostGet ("Image")]
 #if !TVOS
 		[PostGet ("LandscapeImagePhone")]
@@ -3908,68 +3867,68 @@ namespace XamCore.UIKit {
 		[PostGet ("Target")]
 		IntPtr Constructor ([NullAllowed] UIImage image, [NullAllowed] UIImage landscapeImagePhone, UIBarButtonItemStyle style, [NullAllowed] NSObject target, [NullAllowed] Selector action);
 
-		[iOS (5,0)]
+
 		[Export ("setBackgroundImage:forState:barMetrics:")]
 		[Appearance]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIControlState state, UIBarMetrics barMetrics);
 
-		[iOS (5,0)]
+
 		[Export ("backgroundImageForState:barMetrics:")]
 		[Appearance]
 		UIImage GetBackgroundImage (UIControlState state, UIBarMetrics barMetrics);
 
-		[iOS (5,0)]
+
 		[Export ("setBackgroundVerticalPositionAdjustment:forBarMetrics:")]
 		[Appearance]
 		void SetBackgroundVerticalPositionAdjustment (nfloat adjustment, UIBarMetrics forBarMetrics);
 
-		[iOS (5,0)]
+
 		[Export ("backgroundVerticalPositionAdjustmentForBarMetrics:")]
 		[Appearance]
 		nfloat GetBackgroundVerticalPositionAdjustment (UIBarMetrics forBarMetrics);
 
-		[iOS (5,0)]
+
 		[Export ("setTitlePositionAdjustment:forBarMetrics:")]
 		[Appearance]
 		void SetTitlePositionAdjustment (UIOffset adjustment, UIBarMetrics barMetrics);
 
-		[iOS (5,0)]
+
 		[Export ("titlePositionAdjustmentForBarMetrics:")]
 		[Appearance]
 		UIOffset GetTitlePositionAdjustment (UIBarMetrics barMetrics);
 
 		[NoTV]
-		[iOS (5,0)]
+
 		[Export ("setBackButtonBackgroundImage:forState:barMetrics:")]
 		[Appearance]
 		void SetBackButtonBackgroundImage ([NullAllowed] UIImage backgroundImage, UIControlState forState, UIBarMetrics barMetrics);
 
 		[NoTV]
-		[iOS (5,0)]
+
 		[Export ("backButtonBackgroundImageForState:barMetrics:")]
 		[Appearance]
 		UIImage GetBackButtonBackgroundImage (UIControlState forState, UIBarMetrics barMetrics);
 
 		[NoTV]
-		[iOS (5,0)]
+
 		[Export ("setBackButtonTitlePositionAdjustment:forBarMetrics:")]
 		[Appearance]
 		void SetBackButtonTitlePositionAdjustment (UIOffset adjustment, UIBarMetrics barMetrics);
 
 		[NoTV]
-		[iOS (5,0)]
+
 		[Export ("backButtonTitlePositionAdjustmentForBarMetrics:")]
 		[Appearance]
 		UIOffset GetBackButtonTitlePositionAdjustment (UIBarMetrics barMetrics);
 
 		[NoTV]
-		[iOS (5,0)]
+
 		[Export ("setBackButtonBackgroundVerticalPositionAdjustment:forBarMetrics:")]
 		[Appearance]
 		void SetBackButtonBackgroundVerticalPositionAdjustment (nfloat adjustment, UIBarMetrics barMetrics);
 
 		[NoTV]
-		[iOS (5,0)]
+
 		[Export ("backButtonBackgroundVerticalPositionAdjustmentForBarMetrics:")]
 		[Appearance]
 		nfloat GetBackButtonBackgroundVerticalPositionAdjustment (UIBarMetrics barMetrics);
@@ -5037,25 +4996,25 @@ namespace XamCore.UIKit {
 		[Export ("viewFlipsideBackgroundColor")][Static]
 		UIColor ViewFlipsideBackgroundColor { get; }
 
-		[iOS (3,2)]
+
 		[Availability (Deprecated = Platform.iOS_7_0)]
 		[NoWatch][NoTV]
 		[Export ("scrollViewTexturedBackgroundColor")][Static]
 		UIColor ScrollViewTexturedBackgroundColor { get; }
 
-		[iOS (5,0)]
+
 		[Availability (Deprecated = Platform.iOS_7_0)]
 		[NoWatch][NoTV]
 		[Static, Export ("underPageBackgroundColor")]
 		UIColor UnderPageBackgroundColor { get; }
 
 		[NoWatch]
-		[iOS (5,0)]
+
 		[Static, Export ("colorWithCIColor:")]
 		UIColor FromCIColor (CIColor color);
 
 		[NoWatch]
-		[iOS (5,0)]
+
 		[Export ("initWithCIColor:")]
 		IntPtr Constructor (CIColor ciColor);
 
@@ -5176,7 +5135,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: do not call -[UIDocument init] - the designated initializer is -[UIDocument initWithFileURL:
 	[DisableDefaultCtor]
@@ -5689,7 +5647,6 @@ namespace XamCore.UIKit {
 		[Export ("xHeight")]
 		nfloat xHeight { get; }
 
-		[iOS (4,0)]
 		[Export ("lineHeight")]
 		nfloat LineHeight { get; }
 
@@ -5928,7 +5885,6 @@ namespace XamCore.UIKit {
 	}
 
 #if !WATCH
-	[iOS (3,2)]
 	[BaseType (typeof(NSObject), Delegates=new string [] {"WeakDelegate"}, Events=new Type[] {typeof (UIGestureRecognizerDelegate)})]
 	interface UIGestureRecognizer {
 		[DesignatedInitializer]
@@ -6076,7 +6032,7 @@ namespace XamCore.UIKit {
 
 	[NoWatch]
 	[BaseType (typeof(NSObject))]
-	[Model][iOS (3,2)]
+	[Model]
 	[Protocol]
 	interface UIGestureRecognizerDelegate {
 		[Export ("gestureRecognizer:shouldReceiveTouch:"), DefaultValue (true), DelegateName ("UITouchEventArgs")]
@@ -6365,7 +6321,7 @@ namespace XamCore.UIKit {
 		bool SecureTextEntry { [Bind ("isSecureTextEntry")] get; set;  }
 
 		[Abstract]
-		[iOS (5,0)]
+
 		[Export ("spellCheckingType")]
 		UITextSpellCheckingType SpellCheckingType { get; set; }
 
@@ -6427,13 +6383,13 @@ namespace XamCore.UIKit {
 		NSString DidHideNotification { get; }
 
 		[NoTV]
-		[iOS (5,0)]
+
 		[Field("UIKeyboardWillChangeFrameNotification")]
 		[Notification (typeof (UIKeyboardEventArgs))]
 		NSString WillChangeFrameNotification { get; }
 		
 		[NoTV]
-		[iOS (5,0)]
+
 		[Field("UIKeyboardDidChangeFrameNotification")]
 		[Notification (typeof (UIKeyboardEventArgs))]
 		NSString DidChangeFrameNotification { get; }
@@ -6462,22 +6418,22 @@ namespace XamCore.UIKit {
 		// Keys
 		//
 		[NoTV]
-		[iOS (3,2)]
+
 		[Field ("UIKeyboardAnimationCurveUserInfoKey")]
 		NSString AnimationCurveUserInfoKey { get; }
 
 		[NoTV]
-		[iOS (3,2)]
+
 		[Field ("UIKeyboardAnimationDurationUserInfoKey")]
 		NSString AnimationDurationUserInfoKey { get; }
 
 		[NoTV]
-		[iOS (3,2)]
+
 		[Field ("UIKeyboardFrameEndUserInfoKey")]
 		NSString FrameEndUserInfoKey { get; }
 
 		[NoTV]
-		[iOS (3,2)]
+
 		[Field ("UIKeyboardFrameBeginUserInfoKey")]
 		NSString FrameBeginUserInfoKey { get; }
 
@@ -6525,7 +6481,6 @@ namespace XamCore.UIKit {
 		NSString DiscoverabilityTitle { get; set; }
 	}
 
-	[iOS (5,0)]
 	[Protocol]
 	interface UIKeyInput : UITextInputTraits {
 		[Abstract]
@@ -6719,15 +6674,12 @@ namespace XamCore.UIKit {
 		[Notification]
 		NSString CurrentInputModeDidChangeNotification { get; }
 		
-		[iOS (5,1)]
 		[Export ("dictationRecognitionFailed")]
 		void DictationRecognitionFailed ();
 		
-		[iOS (5,1)]
 		[Export ("dictationRecordingDidEnd")]
 		void DictationRecordingDidEnd ();
 		
-		[iOS (5,1)]
 		[Export ("insertDictationResult:")]
 		void InsertDictationResult (NSArray dictationResult);
 
@@ -6802,7 +6754,6 @@ namespace XamCore.UIKit {
 
 	}
 
-	[iOS (5,0)]
 #if XAMCORE_2_0
 	[BaseType (typeof (NSObject))]
 	interface UITextInputStringTokenizer : UITextInputTokenizer{
@@ -6919,7 +6870,6 @@ namespace XamCore.UIKit {
 #endif // !WATCH
 
 	[NoTV]
-	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	[Availability (Deprecated = Platform.iOS_10_0, Message = "Use 'UserNotifications.UNNotificationRequest' instead.")]
 	interface UILocalNotification : NSCoding, NSCopying {
@@ -6989,7 +6939,6 @@ namespace XamCore.UIKit {
 	}
 	
 #if !WATCH
-	[iOS (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UILongPressGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7009,7 +6958,6 @@ namespace XamCore.UIKit {
 		nint NumberOfTapsRequired { get; set; }
 	}
 
-	[iOS (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UITapGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7023,7 +6971,6 @@ namespace XamCore.UIKit {
 		nuint NumberOfTouchesRequired { get; set; }
 	}
 
-	[iOS (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UIPanGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7113,7 +7060,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[iOS (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UIRotationGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7127,7 +7073,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[iOS (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UIPinchGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7140,7 +7085,6 @@ namespace XamCore.UIKit {
 		nfloat Velocity { get; }
 	}
 
-	[iOS (3,2)]
 	[BaseType (typeof(UIGestureRecognizer))]
 	interface UISwipeGestureRecognizer {
 		[Export ("initWithTarget:action:")]
@@ -7179,7 +7123,7 @@ namespace XamCore.UIKit {
 		[Export ("isAnimating")]
 		bool IsAnimating { get; }
 
-		[iOS (5,0)]
+
 		[Export ("color", ArgumentSemantic.Retain), NullAllowed]
 		[Appearance]
 		UIColor Color { get; set; }
@@ -7247,7 +7191,7 @@ namespace XamCore.UIKit {
 		UIImage FromImage (CGImage image, nfloat scale, UIImageOrientation orientation);
 
 #if !WATCH
-		[iOS (5,0)]
+
 		[Static][Export ("imageWithCIImage:")][Autorelease]
 		[ThreadSafe]			
 		UIImage FromImage (CIImage image);
@@ -7325,22 +7269,21 @@ namespace XamCore.UIKit {
 		[ThreadSafe]
 		nint TopCapHeight { get; }
 
-		[iOS (4,0)]
 		[Export ("scale")]
 		[ThreadSafe]
 		nfloat CurrentScale { get; }
 
-		[iOS (5,0)]
+
 		[Static, Export ("animatedImageNamed:duration:")][Autorelease]
 		[ThreadSafe]
 		UIImage CreateAnimatedImage (string name, double duration);
 
-		[iOS (5,0)]
+
 		[Static, Export ("animatedImageWithImages:duration:")][Autorelease]
 		[ThreadSafe]
 		UIImage CreateAnimatedImage (UIImage [] images, double duration);
 
-		[iOS (5,0)]
+
 		[Static, Export ("animatedResizableImageNamed:capInsets:duration:")][Autorelease]
 		[ThreadSafe]
 		UIImage CreateAnimatedImage (string name, UIEdgeInsets capInsets, double duration);
@@ -7350,7 +7293,7 @@ namespace XamCore.UIKit {
 		IntPtr Constructor (CGImage cgImage);
 
 #if !WATCH
-		[iOS (5,0)]
+
 		[Export ("initWithCIImage:")]
 		[ThreadSafe]
 		IntPtr Constructor (CIImage ciImage);
@@ -7361,28 +7304,28 @@ namespace XamCore.UIKit {
 		IntPtr Constructor (CGImage cgImage, nfloat scale,  UIImageOrientation orientation);
 
 #if !WATCH
-		[iOS (5,0)]
+
 		[Export ("CIImage")]
 		[ThreadSafe]
 		CIImage CIImage { get; }
 #endif // !WATCH
 		
-		[iOS (5,0)]
+
 		[Export ("images")]
 		[ThreadSafe]
 		UIImage [] Images { get; }
 
-		[iOS (5,0)]
+
 		[Export ("duration")]
 		[ThreadSafe]
 		double Duration { get; }
 
-		[iOS (5,0)]
+
 		[Export ("resizableImageWithCapInsets:")][Autorelease]
 		[ThreadSafe]
 		UIImage CreateResizableImage (UIEdgeInsets capInsets);
 
-		[iOS (5,0)]
+
 		[Export ("capInsets")]
 		[ThreadSafe]
 		UIEdgeInsets CapInsets { get; }
@@ -7517,7 +7460,7 @@ namespace XamCore.UIKit {
 		[Export ("touchesForWindow:")]
 		NSSet TouchesForWindow (UIWindow window);
 		
-		[iOS (3,2)]
+
 		[Export ("touchesForGestureRecognizer:")]
 		NSSet TouchesForGestureRecognizer (UIGestureRecognizer window);
 
@@ -7589,7 +7532,7 @@ namespace XamCore.UIKit {
 		[Export ("rootViewController", ArgumentSemantic.Retain)]
 		UIViewController RootViewController { get; set; }
 
-		[iOS (3,2)]
+
 		[Export ("screen", ArgumentSemantic.Retain)]
 		UIScreen Screen { get; set; }
 
@@ -7713,7 +7656,6 @@ namespace XamCore.UIKit {
 	}
 #endif // !WATCH
 	
-	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
 	interface UIBezierPath : NSSecureCoding, NSCopying {
@@ -7820,7 +7762,6 @@ namespace XamCore.UIKit {
 		[Internal, Export ("setLineDash:count:phase:")]
 		void SetLineDash (IntPtr fvalues, nint count, nfloat phase);
 
-		[iOS (4,0)]
 		[Export ("addArcWithCenter:radius:startAngle:endAngle:clockwise:")]
 		void AddArc (CGPoint center, nfloat radius, nfloat startAngle, nfloat endAngle, bool clockWise);
 
@@ -8231,7 +8172,7 @@ namespace XamCore.UIKit {
 		[Export ("proximityState")]
 		bool ProximityState { get; }
 
-		[iOS (3,2)]
+
 		[Internal]
 		[Export ("userInterfaceIdiom")]
 		UIUserInterfaceIdiom _UserInterfaceIdiom { get; }
@@ -8255,11 +8196,9 @@ namespace XamCore.UIKit {
 		[Notification]
 		NSString ProximityStateDidChangeNotification { get; }
 		
-		[iOS (4,0)]
 		[Export ("isMultitaskingSupported"), Internal]
 		bool _IsMultitaskingSupported { get; }
 
-		[iOS (4,2)]
 		[Export ("playInputClick")]
 		void PlayInputClick ();
 
@@ -8268,7 +8207,6 @@ namespace XamCore.UIKit {
 		NSUuid IdentifierForVendor { get;  }
 	}
 	
-	[iOS (5,1)]
 	[BaseType (typeof (NSObject))]
 	interface UIDictationPhrase {
 		[Export ("alternativeInterpretations")]
@@ -8279,7 +8217,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[iOS (3,2)]
 	[BaseType (typeof (NSObject), Delegates=new string [] {"WeakDelegate"}, Events=new Type [] {typeof (UIDocumentInteractionControllerDelegate)})]
 	interface UIDocumentInteractionController {
 		[Export ("interactionControllerWithURL:"), Static]
@@ -8339,7 +8276,6 @@ namespace XamCore.UIKit {
 	[NoTV]
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[iOS (3,2)]
 	[Protocol]
 	interface UIDocumentInteractionControllerDelegate {
 		[Availability (Deprecated = Platform.iOS_6_0)]
@@ -8526,7 +8462,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[iOS (5,0)]
 	[BaseType (typeof (UIDocument))]
 	// *** Assertion failure in -[UIManagedDocument init], /SourceCache/UIKit_Sim/UIKit-1914.84/UIDocument.m:258
 	[DisableDefaultCtor]
@@ -8590,11 +8525,11 @@ namespace XamCore.UIKit {
 		[Export ("menuFrame")]
 		CGRect MenuFrame { get; } 
 		
-		[iOS (3,2)]
+
 		[Export ("arrowDirection")]
 		UIMenuControllerArrowDirection ArrowDirection { get; set; }
 
-		[iOS (3,2)]
+
 		[NullAllowed] // by default this property is null
 		[Export ("menuItems", ArgumentSemantic.Copy)]
 		UIMenuItem [] MenuItems { get; set; }
@@ -8621,7 +8556,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	interface UIMenuItem {
 		[DesignatedInitializer] // TODO: Add an overload that takes an Action maybe?
@@ -8685,7 +8619,7 @@ namespace XamCore.UIKit {
 		[PostGet ("Items")] // that will [PostGet] TopItem too
 		void SetItems (UINavigationItem [] items, bool animated);
 
-		[iOS (5,0)]
+
 		[NullAllowed] // by default this property is null
 		[Export ("titleTextAttributes", ArgumentSemantic.Copy), Internal]
 		[Appearance]
@@ -8695,22 +8629,22 @@ namespace XamCore.UIKit {
 		[Appearance]
 		UIStringAttributes TitleTextAttributes { get; set; }
 
-		[iOS (5,0)]
+
 		[Export ("setBackgroundImage:forBarMetrics:")]
 		[Appearance]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIBarMetrics barMetrics);
 
-		[iOS (5,0)]
+
 		[Export ("backgroundImageForBarMetrics:")]
 		[Appearance]
 		UIImage GetBackgroundImage (UIBarMetrics forBarMetrics);
 
-		[iOS (5,0)]
+
 		[Export ("setTitleVerticalPositionAdjustment:forBarMetrics:")]
 		[Appearance]
 		void SetTitleVerticalPositionAdjustment (nfloat adjustment, UIBarMetrics barMetrics);
 
-		[iOS (5,0)]
+
 		[Export ("titleVerticalPositionAdjustmentForBarMetrics:")]
 		[Appearance]
 		nfloat GetTitleVerticalPositionAdjustment (UIBarMetrics barMetrics);
@@ -8844,28 +8778,28 @@ namespace XamCore.UIKit {
 		[Export ("setRightBarButtonItem:animated:")][PostGet ("RightBarButtonItem")]
 		void SetRightBarButtonItem ([NullAllowed] UIBarButtonItem item, bool animated);
 
-		[iOS (5,0)]
+
 		[NullAllowed] // by default this property is null
 		[Export ("leftBarButtonItems", ArgumentSemantic.Copy)]
 		[PostGet ("LeftBarButtonItem")]
 		UIBarButtonItem [] LeftBarButtonItems { get; set;  }
 
-		[iOS (5,0)]
+
 		[NullAllowed] // by default this property is null
 		[Export ("rightBarButtonItems", ArgumentSemantic.Copy)]
 		[PostGet ("RightBarButtonItem")]
 		UIBarButtonItem [] RightBarButtonItems { get; set;  }
 
 		[NoTV]
-		[iOS (5,0)]
+
 		[Export ("leftItemsSupplementBackButton")]
 		bool LeftItemsSupplementBackButton { get; set;  }
 
-		[iOS (5,0)]
+
 		[Export ("setLeftBarButtonItems:animated:")][PostGet ("LeftBarButtonItems")]
 		void SetLeftBarButtonItems (UIBarButtonItem [] items, bool animated);
 
-		[iOS (5,0)]
+
 		[Export ("setRightBarButtonItems:animated:")][PostGet ("RightBarButtonItems")]
 		void SetRightBarButtonItems (UIBarButtonItem [] items, bool animated);
 
@@ -9099,7 +9033,6 @@ namespace XamCore.UIKit {
 		UIColor CurrentPageIndicatorTintColor { get; set;  }
 	}
 	
-	[iOS (5,0)]
 	[BaseType (typeof (UIViewController),
 		   Delegates = new string [] { "WeakDelegate", "WeakDataSource" },
 		   Events = new Type [] { typeof (UIPageViewControllerDelegate), typeof (UIPageViewControllerDataSource)} )]
@@ -9157,7 +9090,6 @@ namespace XamCore.UIKit {
 		NSString OptionInterPageSpacingKey { get; }
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -9185,7 +9117,6 @@ namespace XamCore.UIKit {
 		UIInterfaceOrientation GetPreferredInterfaceOrientationForPresentation (UIPageViewController pageViewController);
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -9700,31 +9631,31 @@ namespace XamCore.UIKit {
 		[Export ("progress")]
 		float Progress { get; set; } // This is float, not nfloat.
 
-		[iOS (5,0)]
+
 		[Export ("progressTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIColor ProgressTintColor { get; set;  }
 
-		[iOS (5,0)]
+
 		[Export ("trackTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIColor TrackTintColor { get; set;  }
 
-		[iOS (5,0)]
+
 		[Export ("progressImage", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIImage ProgressImage { get; set;  }
 
-		[iOS (5,0)]
+
 		[Export ("trackImage", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIImage TrackImage { get; set;  }
 
-		[iOS (5,0)]
+
 		[Export ("setProgress:animated:")]
 		void SetProgress (float progress /* this is float, not nfloat */, bool animated);
 
@@ -9795,7 +9726,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[iOS (5,0)]
 	[BaseType (typeof (UIViewController))]
 	// iOS6 returns the following (confusing) message with the default .ctor:
 	// Objective-C exception thrown.  Name: NSGenericException Reason: -[UIReferenceLibraryViewController initWithNibName:bundle:] is not a valid initializer. You must call -[UIReferenceLibraryViewController initWithTerm:].
@@ -9805,12 +9735,12 @@ namespace XamCore.UIKit {
 		[PostGet ("NibBundle")]
 		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
-		[iOS (5,0)]
+
 		[Export ("dictionaryHasDefinitionForTerm:"), Static]
 		bool DictionaryHasDefinitionForTerm (string term);
 
 		[DesignatedInitializer]
-		[iOS (5,0)]
+
 		[Export ("initWithTerm:")]
 		IntPtr Constructor (string term);
 	}
@@ -9871,19 +9801,16 @@ namespace XamCore.UIKit {
 		NSUndoManager UndoManager { get; }
 
 		// 3.2
-		[iOS (3,2)]
+
 		[Export ("inputAccessoryView")]
 		UIView InputAccessoryView { get; }
 
-		[iOS (3,2)]
 		[Export ("inputView")]
 		UIView InputView { get; }
 
-		[iOS (3,2)]
 		[Export ("reloadInputViews")]
 		void ReloadInputViews ();
 
-		[iOS (4,0)]
 		[Export ("remoteControlReceivedWithEvent:")]
 		void RemoteControlReceived  ([NullAllowed] UIEvent theEvent);
 
@@ -9907,11 +9834,9 @@ namespace XamCore.UIKit {
 		[Export ("delete:")]
 		void Delete ([NullAllowed] NSObject sender);
 		
-		[iOS (5,0)]	
 		[Export ("makeTextWritingDirectionLeftToRight:")]
 		void MakeTextWritingDirectionLeftToRight ([NullAllowed] NSObject sender);
 	
-		[iOS (5,0)]	
 		[Export ("makeTextWritingDirectionRightToLeft:")]
 		void MakeTextWritingDirectionRightToLeft ([NullAllowed] NSObject sender);
 
@@ -10026,11 +9951,11 @@ namespace XamCore.UIKit {
 		UIScreen MainScreen { get; }
 
 		[NoTV] // Xcode 7.2
-		[iOS (3,2)]
+
 		[Export ("availableModes", ArgumentSemantic.Copy)]
 		UIScreenMode [] AvailableModes { get; }
 
-		[iOS (3,2)]
+
 		[NullAllowed] // by default this property is null
 		[Export ("currentMode", ArgumentSemantic.Retain)]
 		UIScreenMode CurrentMode {
@@ -10041,23 +9966,18 @@ namespace XamCore.UIKit {
 		}
 
 		[NoTV] // Xcode 7.2
-		[iOS (4,3)]
 		[Export ("preferredMode", ArgumentSemantic.Retain)]
 		UIScreenMode PreferredMode { get; }
 
-		[iOS (4,3)]
 		[Export ("mirroredScreen", ArgumentSemantic.Retain)]
 		UIScreen MirroredScreen { get; }
 			
-		[iOS (3,2)]
 		[Export ("screens")][Static]
 		UIScreen [] Screens { get; }
 
-		[iOS (4,0)]
 		[Export ("scale")]
 		nfloat Scale { get; }
 
-		[iOS (4,0)]
 		[Export ("displayLinkWithTarget:selector:")]
 		CoreAnimation.CADisplayLink CreateDisplayLink (NSObject target, Selector sel);
 
@@ -10066,20 +9986,20 @@ namespace XamCore.UIKit {
 		nint MaximumFramesPerSecond { get; }
 
 		[NoTV]
-		[iOS (5,0)]
+
 		[Export ("brightness")]
 		nfloat Brightness { get; set; }
 
 		[NoTV]
-		[iOS (5,0)]
+
 		[Export ("wantsSoftwareDimming")]
 		bool WantsSoftwareDimming { get; set; }
 
-		[iOS (5,0)]
+
 		[Export ("overscanCompensation")]
 		UIScreenOverscanCompensation OverscanCompensation { get; set; }
 
-		[iOS (5,0)]
+
 		[Field ("UIScreenBrightnessDidChangeNotification")]
 		[Notification]
 		NSString BrightnessDidChangeNotification { get; }
@@ -10281,12 +10201,12 @@ namespace XamCore.UIKit {
 		[Export ("scrollsToTop")]
 		bool ScrollsToTop { get; set; } 
 
-		[iOS (5,0)]
+
 		[Export ("panGestureRecognizer")]
 		UIPanGestureRecognizer PanGestureRecognizer { get; }
 
 		[NoTV]
-		[iOS (5,0)]
+
 		[Export ("pinchGestureRecognizer")]
 		UIPinchGestureRecognizer PinchGestureRecognizer { get; }
 		
@@ -10347,15 +10267,15 @@ namespace XamCore.UIKit {
 		[Export ("scrollViewDidEndZooming:withView:atScale:"), EventArgs ("ZoomingEnded")]
 		void ZoomingEnded (UIScrollView scrollView, UIView withView, nfloat atScale);
 
-		[iOS (3,2)]
+
 		[Export ("scrollViewDidZoom:"), EventArgs ("UIScrollView")]
 		void DidZoom (UIScrollView scrollView);
 		
-		[iOS (3,2)]
+
 		[Export ("scrollViewWillBeginZooming:withView:"), EventArgs ("UIScrollViewZooming")]
 		void ZoomingStarted (UIScrollView scrollView, UIView view);
 
-		[iOS (5,0)]
+
 		[Export ("scrollViewWillEndDragging:withVelocity:targetContentOffset:"), EventArgs ("WillEndDragging")]
 		void WillEndDragging (UIScrollView scrollView, CGPoint velocity, ref CGPoint targetContentOffset);
 
@@ -10439,91 +10359,86 @@ namespace XamCore.UIKit {
 
 		// 3.2
 		[NoTV]
-		[iOS (3,2)]
 		[Export ("searchResultsButtonSelected")]
 		bool SearchResultsButtonSelected { [Bind ("isSearchResultsButtonSelected")] get; set; }
 
 		[NoTV]
-		[iOS (3,2)]
 		[Export ("showsSearchResultsButton")]
 		bool ShowsSearchResultsButton { get; set; }
 
 		// 5.0
-		[iOS (5,0)]
 		[Export ("backgroundImage", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIImage BackgroundImage { get; set;  }
 
-		[iOS (5,0)]
 		[Export ("scopeBarBackgroundImage", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIImage ScopeBarBackgroundImage { get; set;  }
 
-		[iOS (5,0)]
 		[Export ("searchFieldBackgroundPositionAdjustment")]
 		UIOffset SearchFieldBackgroundPositionAdjustment { get; set;  }
 
-		[iOS (5,0)]
+
 		[Export ("searchTextPositionAdjustment")]
 		UIOffset SearchTextPositionAdjustment { get; set;  }
 
-		[iOS (5,0)]
+
 		[Export ("setSearchFieldBackgroundImage:forState:")]
 		[Appearance]
 		void SetSearchFieldBackgroundImage ([NullAllowed] UIImage backgroundImage, UIControlState state);
 
-		[iOS (5,0)]
+
 		[Export ("searchFieldBackgroundImageForState:")]
 		[Appearance]
 		UIImage GetSearchFieldBackgroundImage (UIControlState state);
 
-		[iOS (5,0)]
+
 		[Export ("setImage:forSearchBarIcon:state:")]
 		[Appearance]
 		void SetImageforSearchBarIcon ([NullAllowed] UIImage iconImage, UISearchBarIcon icon, UIControlState state);
 
-		[iOS (5,0)]
+
 		[Export ("imageForSearchBarIcon:state:")]
 		[Appearance]
 		UIImage GetImageForSearchBarIcon (UISearchBarIcon icon, UIControlState state);
 
-		[iOS (5,0)]
+
 		[Export ("setScopeBarButtonBackgroundImage:forState:")]
 		[Appearance]
 		void SetScopeBarButtonBackgroundImage ([NullAllowed] UIImage backgroundImage, UIControlState state);
 
-		[iOS (5,0)]
+
 		[Export ("scopeBarButtonBackgroundImageForState:")]
 		[Appearance]
 		UIImage GetScopeBarButtonBackgroundImage (UIControlState state);
 
-		[iOS (5,0)]
+
 		[Export ("setScopeBarButtonDividerImage:forLeftSegmentState:rightSegmentState:")]
 		[Appearance]
 		void SetScopeBarButtonDividerImage ([NullAllowed] UIImage dividerImage, UIControlState leftState, UIControlState rightState);
 
-		[iOS (5,0)]
+
 		[Export ("scopeBarButtonDividerImageForLeftSegmentState:rightSegmentState:")]
 		[Appearance]
 		UIImage GetScopeBarButtonDividerImage (UIControlState leftState, UIControlState rightState);
 
-		[iOS (5,0)]
+
 		[Export ("setScopeBarButtonTitleTextAttributes:forState:"), Internal]
 		[Appearance]
 		void _SetScopeBarButtonTitle (NSDictionary attributes, UIControlState state);
 
-		[iOS (5,0)]
+
 		[Export ("scopeBarButtonTitleTextAttributesForState:"), Internal]
 		[Appearance]
 		NSDictionary _GetScopeBarButtonTitleTextAttributes (UIControlState state);
 
-		[iOS (5,0)]
+
 		[Export ("setPositionAdjustment:forSearchBarIcon:")]
 		void SetPositionAdjustmentforSearchBarIcon (UIOffset adjustment, UISearchBarIcon icon);
 
-		[iOS (5,0)]
+
 		[Export ("positionAdjustmentForSearchBarIcon:")]
 		UIOffset GetPositionAdjustmentForSearchBarIcon (UISearchBarIcon icon);
 
@@ -10610,7 +10525,7 @@ namespace XamCore.UIKit {
 		void SelectedScopeButtonIndexChanged (UISearchBar searchBar, nint selectedScope);
 
 		[NoTV]
-		[iOS (3,2)]
+
 		[Export ("searchBarResultsListButtonClicked:"), EventArgs ("UISearchBar")]
 		void ListButtonClicked (UISearchBar searchBar);
 	}
@@ -10740,7 +10655,7 @@ namespace XamCore.UIKit {
 		[Protocolize]
 		UITableViewDelegate SearchResultsDelegate { get; set; }
 
-		[iOS (5,0)]
+
 		[NullAllowed] // by default this property is null
 		[Export ("searchResultsTitle", ArgumentSemantic.Copy)]
 		string SearchResultsTitle { get; set;  }
@@ -10887,46 +10802,46 @@ namespace XamCore.UIKit {
 		[Export ("selectedSegmentIndex")]
 		nint SelectedSegment { get; set; }
 
-		[iOS (5,0)]
+
 		[Export ("apportionsSegmentWidthsByContent")]
 		bool ApportionsSegmentWidthsByContent { get; set; }
 
-		[iOS (5,0)]
+
 		[Export ("setBackgroundImage:forState:barMetrics:")]
 		[Appearance]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIControlState state, UIBarMetrics barMetrics);
 
-		[iOS (5,0)]
+
 		[Export ("backgroundImageForState:barMetrics:")]
 		[Appearance]
 		UIImage GetBackgroundImage (UIControlState state, UIBarMetrics barMetrics);
 
-		[iOS (5,0)]
+
 		[Export ("setDividerImage:forLeftSegmentState:rightSegmentState:barMetrics:")]
 		[Appearance]
 		void SetDividerImage ([NullAllowed] UIImage dividerImage, UIControlState leftSegmentState, UIControlState rightSegmentState, UIBarMetrics barMetrics);
 
-		[iOS (5,0)]
+
 		[Export ("dividerImageForLeftSegmentState:rightSegmentState:barMetrics:")]
 		[Appearance]
 		UIImage DividerImageForLeftSegmentStaterightSegmentStatebarMetrics (UIControlState leftState, UIControlState rightState, UIBarMetrics barMetrics);
 
-		[iOS (5,0)]
+
 		[Export ("setTitleTextAttributes:forState:"), Internal]
 		[Appearance]
 		void _SetTitleTextAttributes (NSDictionary attributes, UIControlState state);
 
-		[iOS (5,0)]
+
 		[Export ("titleTextAttributesForState:"), Internal]
 		[Appearance]
 		NSDictionary _GetTitleTextAttributes (UIControlState state);
 
-		[iOS (5,0)]
+
 		[Export ("setContentPositionAdjustment:forSegmentType:barMetrics:")]
 		[Appearance]
 		void SetContentPositionAdjustment (UIOffset adjustment, UISegmentedControlSegment leftCenterRightOrAlone, UIBarMetrics barMetrics);
 
-		[iOS (5,0)]
+
 		[Export ("contentPositionAdjustmentForSegmentType:barMetrics:")]
 		[Appearance]
 		UIOffset ContentPositionAdjustment (UISegmentedControlSegment leftCenterRightOrAlone, UIBarMetrics barMetrics);
@@ -11011,19 +10926,19 @@ namespace XamCore.UIKit {
 		[Export ("thumbRectForBounds:trackRect:value:")]
 		CGRect ThumbRectForBounds (CGRect bounds, CGRect trackRect, float value /* This is float, not nfloat */);
 
-		[iOS (5,0)]
+
 		[Export ("minimumTrackTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIColor MinimumTrackTintColor { get; set; }
 
-		[iOS (5,0)]
+
 		[Export ("maximumTrackTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIColor MaximumTrackTintColor { get; set; }
 
-		[iOS (5,0)]
+
 		[Export ("thumbTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
@@ -11199,7 +11114,7 @@ namespace XamCore.UIKit {
 		[Export ("setOn:animated:")]
 		void SetState (bool newState, bool animated);
 
-		[iOS (5,0)]
+
 		[Export ("onTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
@@ -11269,20 +11184,20 @@ namespace XamCore.UIKit {
 		bool IsCustomizing { get; }
 
 		[NoTV]
-		[iOS (5,0)]
+
 		[Export ("selectedImageTintColor", ArgumentSemantic.Retain)]
 		[Availability (Deprecated = Platform.iOS_8_0)]
 		[NullAllowed]
 		[Appearance]
 		UIColor SelectedImageTintColor { get; set;  }
 
-		[iOS (5,0)]
+
 		[Export ("backgroundImage", ArgumentSemantic.Retain)]
 		[NullAllowed]
 		[Appearance]
 		UIImage BackgroundImage { get; set;  }
 
-		[iOS (5,0)]
+
 		[Export ("selectionIndicatorImage", ArgumentSemantic.Retain)]
 		[NullAllowed]
 		[Appearance]
@@ -11494,7 +11409,7 @@ namespace XamCore.UIKit {
 		[Export ("finishedUnselectedImage")]
 		UIImage FinishedUnselectedImage { get; }
 
-		[iOS (5,0)]
+
 		[Export ("titlePositionAdjustment")]
 		[Appearance]
 		UIOffset TitlePositionAdjustment { get; set; }
@@ -11691,7 +11606,7 @@ namespace XamCore.UIKit {
 		UITableViewCell DequeueReusableCell (NSString identifier);
 
 		// 3.2
-		[iOS (3,2)]
+
 		[Export ("backgroundView", ArgumentSemantic.Retain), NullAllowed]
 		UIView BackgroundView { get; set; }
 
@@ -11699,31 +11614,31 @@ namespace XamCore.UIKit {
 		[Field ("UITableViewIndexSearch")]
 		NSString IndexSearch { get; }
 
-		[iOS (5,0)]
+
 		[Field ("UITableViewAutomaticDimension")]
 		nfloat AutomaticDimension { get; }
 
-		[iOS (5,0)]
+
 		[Export ("allowsMultipleSelection")]
                 bool AllowsMultipleSelection { get; set;  }
 
-		[iOS (5,0)]
+
                 [Export ("allowsMultipleSelectionDuringEditing")]
                 bool AllowsMultipleSelectionDuringEditing { get; set;  }
 
-		[iOS (5,0)]
+
                 [Export ("moveSection:toSection:")]
                 void MoveSection (nint fromSection, nint toSection);
 
-		[iOS (5,0)]
+
                 [Export ("moveRowAtIndexPath:toIndexPath:")]
                 void MoveRow (NSIndexPath fromIndexPath, NSIndexPath toIndexPath);
 
-		[iOS (5,0)]
+
                 [Export ("indexPathsForSelectedRows")]
                 NSIndexPath [] IndexPathsForSelectedRows { get; }
 
-		[iOS (5,0)]
+
 		[Export ("registerNib:forCellReuseIdentifier:")]
 #if XAMCORE_2_0
 		void RegisterNibForCellReuse ([NullAllowed] UINib nib, NSString reuseIdentifier);
@@ -12000,15 +11915,15 @@ namespace XamCore.UIKit {
 
 		// Copy Paste support
 		
-		[iOS (5,0)]
+
                 [Export ("tableView:shouldShowMenuForRowAtIndexPath:")]
                 bool ShouldShowMenu (UITableView tableView, NSIndexPath rowAtindexPath);
 
-		[iOS (5,0)]
+
                 [Export ("tableView:canPerformAction:forRowAtIndexPath:withSender:")]
                 bool CanPerformAction (UITableView tableView, Selector action, NSIndexPath indexPath, [NullAllowed] NSObject sender);
 
-		[iOS (5,0)]
+
                 [Export ("tableView:performAction:forRowAtIndexPath:withSender:")]
                 void PerformAction (UITableView tableView, Selector action, NSIndexPath indexPath, [NullAllowed] NSObject sender);
 		
@@ -12192,7 +12107,7 @@ namespace XamCore.UIKit {
 		[Export ("didTransitionToState:")]
 		void DidTransitionToState (UITableViewCellState mask);
 
-		[iOS (5,0)]
+
 		[Export ("multipleSelectionBackgroundView", ArgumentSemantic.Retain), NullAllowed]
 		UIView MultipleSelectionBackgroundView { get; set; }
 
@@ -12230,7 +12145,7 @@ namespace XamCore.UIKit {
 		[Export ("tableView", ArgumentSemantic.Retain)]
 		UITableView TableView { get; set; }
 
-		[iOS (3,2)]
+
 		[Export ("clearsSelectionOnViewWillAppear")]
 		bool ClearsSelectionOnViewWillAppear { get; set; }
 
@@ -12351,15 +12266,15 @@ namespace XamCore.UIKit {
 		nint IndentationLevel (UITableView tableView, NSIndexPath indexPath);
 
 		// Copy Paste support
-		[iOS (5,0)]
+
 		[Export ("tableView:shouldShowMenuForRowAtIndexPath:")]
 		bool ShouldShowMenu (UITableView tableView, NSIndexPath rowAtindexPath);
 
-		[iOS (5,0)]
+
 		[Export ("tableView:canPerformAction:forRowAtIndexPath:withSender:")]
 		bool CanPerformAction (UITableView tableView, Selector action, NSIndexPath indexPath, NSObject sender);
 
-		[iOS (5,0)]
+
 		[Export ("tableView:performAction:forRowAtIndexPath:withSender:")]
 		void PerformAction (UITableView tableView, Selector action, NSIndexPath indexPath, NSObject sender);
 
@@ -12600,11 +12515,11 @@ namespace XamCore.UIKit {
 		void DrawPlaceholder (CGRect rect);
 
 		// 3.2
-		[iOS (3,2)]
+
 		[Export ("inputAccessoryView", ArgumentSemantic.Retain)][NullAllowed]
 		UIView InputAccessoryView { get; set; }
 
-		[iOS (3,2)]
+
 		[Export ("inputView", ArgumentSemantic.Retain)][NullAllowed]
 		UIView InputView { get; set; }
 
@@ -12732,12 +12647,12 @@ namespace XamCore.UIKit {
 		UIDataDetectorType DataDetectorTypes { get; set; }
 
 		// 3.2
-		[iOS (3,2)]
+
 		[NullAllowed] // by default this property is null
 		[Export ("inputAccessoryView", ArgumentSemantic.Retain)]
 		UIView InputAccessoryView { get; set; }
 
-		[iOS (3,2)]
+
 		[Export ("inputView", ArgumentSemantic.Retain)][NullAllowed]
 		UIView InputView { get; set; }
 
@@ -12874,12 +12789,12 @@ namespace XamCore.UIKit {
 		//[Export ("setItems:animated:")][PostGet ("Items")]
 		//void SetItems (UIBarButtonItem [] items, bool animated);
 
-		[iOS (5,0)]
+
 		[Export ("setBackgroundImage:forToolbarPosition:barMetrics:")]
 		[Appearance]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIToolbarPosition position, UIBarMetrics barMetrics);
 
-		[iOS (5,0)]
+
 		[Export ("backgroundImageForToolbarPosition:barMetrics:")]
 		[Appearance]
 		UIImage GetBackgroundImage (UIToolbarPosition position, UIBarMetrics barMetrics);
@@ -12959,7 +12874,7 @@ namespace XamCore.UIKit {
 		UITouchPhase Phase { get; }
 
 		// 3.2
-		[iOS (3,2)]
+
 		[Export ("gestureRecognizers", ArgumentSemantic.Copy)]
 		UIGestureRecognizer[] GestureRecognizers { get; }
 
@@ -13357,54 +13272,46 @@ namespace XamCore.UIKit {
 		bool AnimationsEnabled { [Bind ("areAnimationsEnabled")] get; [Bind ("setAnimationsEnabled:")] set; }
 
 		// 3.2:
-		[iOS (3,2)]
+
 		[Export ("addGestureRecognizer:"), PostGet ("GestureRecognizers")]
 		void AddGestureRecognizer (UIGestureRecognizer gestureRecognizer);
 
-		[iOS (3,2)]
+
 		[Export ("removeGestureRecognizer:"), PostGet ("GestureRecognizers")]
 		void RemoveGestureRecognizer (UIGestureRecognizer gestureRecognizer);
 
-		[iOS (3,2)]
+
 		[NullAllowed] // by default this property is null
 		[Export ("gestureRecognizers", ArgumentSemantic.Copy)]
 		UIGestureRecognizer[] GestureRecognizers { get; set; }
 
-		[iOS (4,0)]
 		[Static, Export ("animateWithDuration:animations:")]
 		void Animate (double duration, /* non null */ NSAction animation);
 
-		[iOS (4,0)]
 		[Static, Export ("animateWithDuration:animations:completion:")]
 		[Async]
 		void AnimateNotify (double duration, /* non null */ NSAction animation, [NullAllowed] UICompletionHandler completion);
 		
-		[iOS (4,0)]
 		[Static, Export ("animateWithDuration:delay:options:animations:completion:")]
 		[Async]
 		void AnimateNotify (double duration, double delay, UIViewAnimationOptions options, /* non null */ NSAction animation, [NullAllowed] UICompletionHandler completion);
 
-		[iOS (4,0)]
 		[Static, Export ("transitionFromView:toView:duration:options:completion:")]
 		[Async]
 		void TransitionNotify (UIView fromView, UIView toView, double duration, UIViewAnimationOptions options, [NullAllowed] UICompletionHandler completion);
 
-		[iOS (4,0)]
 		[Static, Export ("transitionWithView:duration:options:animations:completion:")]
 		[Async]
 		void TransitionNotify (UIView withView, double duration, UIViewAnimationOptions options, [NullAllowed] NSAction animation, [NullAllowed] UICompletionHandler completion);
 
-		[iOS (4,0)]
 		[Export ("contentScaleFactor")]
 		nfloat ContentScaleFactor { get; set; }
 
 		[NoTV]
-		[iOS (4,2)]
 		[Export ("viewPrintFormatter")]
 		UIViewPrintFormatter ViewPrintFormatter { get; }
 
 		[NoTV]
-		[iOS (4,2)]
 		[Export ("drawRect:forViewPrintFormatter:")]
 		void DrawRect (CGRect area, UIViewPrintFormatter formatter);
 
@@ -13961,7 +13868,7 @@ namespace XamCore.UIKit {
 		[Export ("hidesBottomBarWhenPushed")]
 		bool HidesBottomBarWhenPushed { get; set; }
 
-		[iOS (3,2)]
+
 		[Export ("splitViewController", ArgumentSemantic.Retain)]
 		UISplitViewController SplitViewController { get; }
 
@@ -13980,7 +13887,7 @@ namespace XamCore.UIKit {
 		void SetToolbarItems ([NullAllowed] UIBarButtonItem [] items, bool animated);
 
 		// These come in 3.2
-		[iOS (3,2)]
+
 		[Export ("modalPresentationStyle", ArgumentSemantic.Assign)]
 		UIModalPresentationStyle ModalPresentationStyle { get; set; }
 
@@ -14005,85 +13912,85 @@ namespace XamCore.UIKit {
 		CGSize ContentSizeForViewInPopover { get; set; }
 
 		// This is defined in a category in UIPopoverSupport.h: UIViewController (UIPopoverController)
-		[iOS (3,2)]
+
 		[Export ("modalInPopover")]
 		bool ModalInPopover { [Bind ("isModalInPopover")] get; set; }
 
-		[iOS (4,3)] // It seems apple added a setter now but seems it is a mistake on new property radar:27929872
+		// It seems apple added a setter now but seems it is a mistake on new property radar:27929872
 		[Export ("disablesAutomaticKeyboardDismissal")]
 		bool DisablesAutomaticKeyboardDismissal { get; }
 
-		[iOS (5,0)]
+
 		[Export ("storyboard", ArgumentSemantic.Retain)]
 		UIStoryboard Storyboard { get;  }
 
-		[iOS (5,0)]
+
 		[Export ("presentedViewController")]
 		UIViewController PresentedViewController { get;  }
 
-		[iOS (5,0)]
+
 		[Export ("presentingViewController")]
 		UIViewController PresentingViewController { get;  }
 
-		[iOS (5,0)]
+
 		[Export ("definesPresentationContext", ArgumentSemantic.Assign)]
 		bool DefinesPresentationContext { get; set;  }
 
-		[iOS (5,0)]
+
 		[Export ("providesPresentationContextTransitionStyle", ArgumentSemantic.Assign)]
 		bool ProvidesPresentationContextTransitionStyle { get; set;  }
 
 		[NoTV]
-		[iOS (5,0)]
+
 		[Availability (Deprecated = Platform.iOS_6_0)]
 		[Export ("viewWillUnload")]
 		void ViewWillUnload ();
 
-		[iOS (5,0)]
+
 		[Export ("performSegueWithIdentifier:sender:")]
 		void PerformSegue (string identifier, [NullAllowed] NSObject sender);
 
-		[iOS (5,0)]
+
 		[Export ("prepareForSegue:sender:")]
 		void PrepareForSegue (UIStoryboardSegue segue, [NullAllowed] NSObject sender);
 
-		[iOS (5,0)]
+
 		[Export ("viewWillLayoutSubviews")]
 		void ViewWillLayoutSubviews ();
 
-		[iOS (5,0)]
+
 		[Export ("viewDidLayoutSubviews")]
 		void ViewDidLayoutSubviews ();
 
-		[iOS (5,0)]
+
 		[Export ("isBeingPresented")]
 		bool IsBeingPresented { get; }
 
-		[iOS (5,0)]
+
 		[Export ("isBeingDismissed")]
 		bool IsBeingDismissed { get; }
 
-		[iOS (5,0)]
+
 		[Export ("isMovingToParentViewController")]
 		bool IsMovingToParentViewController { get; }
 
-		[iOS (5,0)]
+
 		[Export ("isMovingFromParentViewController")]
 		bool IsMovingFromParentViewController { get; }
 
-		[iOS (5,0)]
+
 		[Export ("presentViewController:animated:completion:")]
 		[Async]
 		void PresentViewController (UIViewController viewControllerToPresent, bool animated, [NullAllowed] NSAction completionHandler);
 
-		[iOS (5,0)]
+
 		[Export ("dismissViewControllerAnimated:completion:")]
 		[Async]
 		void DismissViewController (bool animated, [NullAllowed] NSAction completionHandler);
 
 		// UIViewControllerRotation
 		[NoTV]
-		[iOS (5,0)]
+
 		[Static]
 		[Export ("attemptRotationToDeviceOrientation")]
 		void AttemptRotationToDeviceOrientation ();
@@ -14093,40 +14000,40 @@ namespace XamCore.UIKit {
 		[Export ("automaticallyForwardAppearanceAndRotationMethodsToChildViewControllers")]
 		/*PROTECTED*/ bool AutomaticallyForwardAppearanceAndRotationMethodsToChildViewControllers { get; }
 
-		[iOS (5,0)]
+
 		[Export ("childViewControllers")]
 		/*PROTECTED, MUSTCALLBASE*/ UIViewController [] ChildViewControllers { get;  }
 
-		[iOS (5,0)]
+
 		[Export ("addChildViewController:")]
 		[PostGet ("ChildViewControllers")]
 		/*PROTECTED, MUSTCALLBASE*/ void AddChildViewController (UIViewController childController);
 
-		[iOS (5,0)]
+
 		[Export ("removeFromParentViewController")]
 		/*PROTECTED, MUSTCALLBASE*/ void RemoveFromParentViewController ();
 
-		[iOS (5,0)]
+
 		[Export ("transitionFromViewController:toViewController:duration:options:animations:completion:")]
 		[Async]
 		/*PROTECTED, MUSTCALLBASE*/ void Transition (UIViewController fromViewController, UIViewController toViewController, double duration, UIViewAnimationOptions options, /* non null */ NSAction animations, UICompletionHandler completionHandler);
 
-		[iOS (5,0)]
+
 		[Export ("willMoveToParentViewController:")]
 		void WillMoveToParentViewController ([NullAllowed] UIViewController parent);
 
-		[iOS (5,0)]
+
 		[Export ("didMoveToParentViewController:")]
 		void DidMoveToParentViewController ([NullAllowed] UIViewController parent);
 
 		//
 		// Exposed in iOS 6.0, but they existed and are now officially supported on iOS 5.0
 		//
-		[iOS (5,0)]
+
 		[Export ("beginAppearanceTransition:animated:")]
 		void BeginAppearanceTransition (bool isAppearing, bool animated);
 
-		[iOS (5,0)]
+
 		[Export ("endAppearanceTransition")]
 		void EndAppearanceTransition ();
 		
@@ -14897,19 +14804,15 @@ namespace XamCore.UIKit {
 		[Export ("dataDetectorTypes")]
 		UIDataDetectorType DataDetectorTypes { get; set; }
 
-		[iOS (4,0)]
 		[Export ("allowsInlineMediaPlayback")]
 		bool AllowsInlineMediaPlayback { get; set; }
 		
-		[iOS (4,0)]
 		[Export ("mediaPlaybackRequiresUserAction")]
 		bool MediaPlaybackRequiresUserAction { get; set; }
 
-		[iOS (5,0)]
 		[Export ("scrollView", ArgumentSemantic.Retain)]
 		UIScrollView ScrollView { get; }
 
-		[iOS (5,0)]
 		[Export ("mediaPlaybackAllowsAirPlay")]
 		bool MediaPlaybackAllowsAirPlay { get; set; }
 
@@ -14968,7 +14871,6 @@ namespace XamCore.UIKit {
 		void LoadFailed (UIWebView webView, NSError error);
 	}
 
-	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	interface UITextChecker {
 		[Export ("rangeOfMisspelledWordInString:range:startingAt:wrap:language:")]
@@ -15085,7 +14987,6 @@ namespace XamCore.UIKit {
 		NSString Password { get; }
 	}
 	
-	[iOS (3,2)]
 	[BaseType (typeof (UIViewController), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UISplitViewControllerDelegate)})]
 	interface UISplitViewController {
 		[Export ("initWithNibName:bundle:")]
@@ -15103,7 +15004,6 @@ namespace XamCore.UIKit {
 		[Export ("delegate", ArgumentSemantic.Assign)][NullAllowed]
 		NSObject WeakDelegate { get; set; }
 		
-		[iOS (5,1)]
 		[Export ("presentsWithGesture")]
 		bool PresentsWithGesture { get; set; }
 
@@ -15159,7 +15059,6 @@ namespace XamCore.UIKit {
 		UISplitViewControllerPrimaryEdge PrimaryEdge { get; set; }
 	}
 
-	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -15190,7 +15089,7 @@ namespace XamCore.UIKit {
 		void WillShowViewController (UISplitViewController svc, UIViewController aViewController, UIBarButtonItem button);
 
 		[NoTV]
-		[iOS (5,0)]
+
 		[Export ("splitViewController:shouldHideViewController:inOrientation:"), DelegateName ("UISplitViewControllerHidePredicate"), DefaultValue (true)]
 		[Availability (Deprecated = Platform.iOS_8_0, Message="Use 'UISearchController' instead.")]
 		bool ShouldHideViewController (UISplitViewController svc, UIViewController viewController, UIInterfaceOrientation inOrientation);
@@ -15245,7 +15144,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[iOS (5,0)]
 	[BaseType (typeof (UIControl))]
 	interface UIStepper {
 		[Export ("initWithFrame:")]
@@ -15317,7 +15215,6 @@ namespace XamCore.UIKit {
 		UIImage GetDecrementImage (UIControlState state);
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	interface UIStoryboard {
 		[Static]
@@ -15340,7 +15237,6 @@ namespace XamCore.UIKit {
 	}
 
 	[Availability (Deprecated = Platform.iOS_9_0)]
-	[iOS (5,0)]
 	[DisableDefaultCtor] // as it subclass UIStoryboardSegue we end up with the same error
 	[BaseType (typeof (UIStoryboardSegue))]
 	interface UIStoryboardPopoverSegue {
@@ -15351,7 +15247,6 @@ namespace XamCore.UIKit {
 		UIPopoverController PopoverController { get;  }
 	}
 
-	[iOS (5,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: Don't call -[UIStoryboardSegue init]
 	interface UIStoryboardSegue {
@@ -15410,7 +15305,6 @@ namespace XamCore.UIKit {
 		UIEdgeInsets GetContentViewInsets ();
 	}
 	
-	[iOS (5,0)]
 	[BaseType (typeof (UIView))]
 	interface UIPopoverBackgroundView : UIPopoverBackgroundViewMethods {
 		[Export ("initWithFrame:")]
@@ -15429,7 +15323,6 @@ namespace XamCore.UIKit {
 		bool WantsDefaultContentAppearance { get; }
 	}
 		
-	[iOS (3,2)]
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIPopoverControllerDelegate)})]
 	[DisableDefaultCtor] // bug #1786
 	interface UIPopoverController : UIAppearanceContainer {
@@ -15474,12 +15367,12 @@ namespace XamCore.UIKit {
 		void Dismiss (bool animated);
 		
 		// @property (nonatomic, readwrite) UIEdgeInsets popoverLayoutMargins
-		[iOS (5,0)][Export ("popoverLayoutMargins")]
+[Export ("popoverLayoutMargins")]
 		UIEdgeInsets PopoverLayoutMargins { get; set; }
 		
 		// @property (nonatomic, readwrite, retain) Class popoverBackgroundViewClass
 		// Class is not pretty so we'll expose it manually as a System.Type
-		[iOS (5,0)][Internal][Export ("popoverBackgroundViewClass", ArgumentSemantic.Retain)]
+[Internal][Export ("popoverBackgroundViewClass", ArgumentSemantic.Retain)]
 		IntPtr PopoverBackgroundViewClass { get; set; }
 
 		[iOS (7,0)]
@@ -15487,7 +15380,6 @@ namespace XamCore.UIKit {
 		UIColor BackgroundColor { get; set; }
 	}
 
-	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -15599,7 +15491,6 @@ namespace XamCore.UIKit {
 		void WillRepositionPopover (UIPopoverPresentationController popoverPresentationController, ref CGRect targetRect, ref UIView inView);
 	}
 	
-	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	interface UIScreenMode {
 		[Export ("pixelAspectRatio")]
@@ -15609,7 +15500,6 @@ namespace XamCore.UIKit {
 		CGSize Size { get; }
 	}
 
-	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	interface UITextInputMode : NSSecureCoding {
 		[Export ("currentInputMode"), NullAllowed][Static]
@@ -15624,7 +15514,7 @@ namespace XamCore.UIKit {
 		[Notification]
 		NSString CurrentInputModeDidChangeNotification { get; }
 
-		[iOS (5,0)]
+
 		[Static]
 		[Export ("activeInputModes")]
 		UITextInputMode [] ActiveInputModes { get; }
@@ -15726,7 +15616,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	interface UIPrintPaper {
 		[Export ("bestPaperForPageSize:withPapersFromArray:")][Static]
@@ -15740,7 +15629,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	interface UIPrintPageRenderer {
 		[Export ("footerHeight")]
@@ -15831,7 +15719,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[iOS (4,2)]
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIPrintInteractionControllerDelegate)})]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: -[UIPrintInteractionController init] not allowed
 	[DisableDefaultCtor]
@@ -15928,7 +15815,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	// Objective-C exception thrown.  Name: NSGenericException Reason: -[UIPrintInfo init] not allowed
 	[DisableDefaultCtor]
@@ -15959,7 +15845,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[iOS (4,2)]
 	[BaseType (typeof (UIPrintFormatter))]
 	interface UIViewPrintFormatter {
 		[Export ("view")]
@@ -16002,7 +15887,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[iOS (4,2)]
 	[BaseType (typeof (UIPrintFormatter))]
 	// accessing the properties fails with 7.0GM if the default `init` is used to create the instance, e.g. 
 	// [UISimpleTextPrintFormatter color]: unrecognized selector sent to instance 0x18bd70d0
@@ -16037,7 +15921,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[iOS (4,2)]
 	[BaseType (typeof (NSObject))]
 	interface UIPrintFormatter : NSCopying {
 
@@ -16075,7 +15958,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoTV]
-	[iOS (4,2)]
 	[BaseType (typeof (UIPrintFormatter))]
 #if XAMCORE_4_0
 	[DisableDefaultCtor] // nonfunctional (and it doesn't show up in the header anyway)
@@ -16491,7 +16373,6 @@ namespace XamCore.UIKit {
 	// at the moment there is no API that require a specific UIAccessibilityIdentification
 	// implementation, so we don't provide a Model class (for now at least).
 	[NoWatch]
-	[iOS (5, 0)]
 	[Protocol]
 	interface UIAccessibilityIdentification {
 		[Abstract]
@@ -16690,7 +16571,7 @@ namespace XamCore.UIKit {
 		[Export ("initWithDocumentTypes:inMode:")]
 		IntPtr Constructor (string [] allowedUTIs, UIDocumentPickerMode mode);
 
-		[Advice ("This method will be deprecated in a future release and should be avoided. Instead, use 'UIDocumentPickerViewController (NSUrl[], UIDocumentPickerMode)'.")]
+		[Advice ("This method will be deprecated in a future release and should be avoided. Instead, use 'UIDocumentPickerViewController (NSUrl[], UIDocumentPickerMode)'.")]
 		[DesignatedInitializer]
 		[Export ("initWithURL:inMode:")]
 		IntPtr Constructor (NSUrl url, UIDocumentPickerMode mode);
@@ -16784,7 +16665,6 @@ namespace XamCore.UIKit {
 	}
 
 	[NoWatch]
-	[iOS (5,0)]
 	[Protocol]
 	interface UIAccessibilityReadingContent {
 

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -2423,10 +2423,8 @@ namespace XamCore.UIKit {
 		[Export ("dismissWithClickedButtonIndex:animated:")]
 		void DismissWithClickedButtonIndex (nint index, bool animated);
 
-
 		[Export ("alertViewStyle", ArgumentSemantic.Assign)]
 		UIAlertViewStyle AlertViewStyle { get; set;  }
-
 
 		[Export ("textFieldAtIndex:")]
 		UITextField GetTextField (nint textFieldIndex);
@@ -3075,7 +3073,6 @@ namespace XamCore.UIKit {
 		[Field ("UIApplicationLaunchOptionsLocalNotificationKey")]
 		NSString LaunchOptionsLocalNotificationKey { get; }
 
-
 		[Export ("userInterfaceLayoutDirection")]
 		UIUserInterfaceLayoutDirection UserInterfaceLayoutDirection { get; }
 
@@ -3597,7 +3594,6 @@ namespace XamCore.UIKit {
 		[Wrap ("OpenUrl(app, url, options.Dictionary)")]
 		bool OpenUrl (UIApplication app, NSUrl url, UIApplicationOpenUrlOptions options);
 		
-
 		[Export ("window", ArgumentSemantic.Retain), NullAllowed]
 		UIWindow Window { get; set; }
 
@@ -3763,21 +3759,17 @@ namespace XamCore.UIKit {
 		nint Tag { get; set; }
 
 		[NoTV]
-
 		[NullAllowed] // by default this property is null
 		[Export ("landscapeImagePhone", ArgumentSemantic.Retain)]
 		UIImage LandscapeImagePhone { get; set;  }
 
 		[NoTV]
-
 		[Export ("landscapeImagePhoneInsets")]
 		UIEdgeInsets LandscapeImagePhoneInsets { get; set;  }
-
 
 		[Export ("setTitleTextAttributes:forState:"), Internal]
 		[Appearance]
 		void _SetTitleTextAttributes ([NullAllowed] NSDictionary attributes, UIControlState state);
-
 
 		[Export ("titleTextAttributesForState:"), Internal]
 		[Appearance]
@@ -3854,11 +3846,9 @@ namespace XamCore.UIKit {
 		[Export ("tag")][Override]
 		nint Tag { get; set; }
 
-
 		[Export ("tintColor", ArgumentSemantic.Retain), NullAllowed]
 		[Appearance]
 		UIColor TintColor { get; set;  }
-
 
 		[Export ("initWithImage:landscapeImagePhone:style:target:action:"), PostGet ("Image")]
 #if !TVOS
@@ -3867,68 +3857,56 @@ namespace XamCore.UIKit {
 		[PostGet ("Target")]
 		IntPtr Constructor ([NullAllowed] UIImage image, [NullAllowed] UIImage landscapeImagePhone, UIBarButtonItemStyle style, [NullAllowed] NSObject target, [NullAllowed] Selector action);
 
-
 		[Export ("setBackgroundImage:forState:barMetrics:")]
 		[Appearance]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIControlState state, UIBarMetrics barMetrics);
-
 
 		[Export ("backgroundImageForState:barMetrics:")]
 		[Appearance]
 		UIImage GetBackgroundImage (UIControlState state, UIBarMetrics barMetrics);
 
-
 		[Export ("setBackgroundVerticalPositionAdjustment:forBarMetrics:")]
 		[Appearance]
 		void SetBackgroundVerticalPositionAdjustment (nfloat adjustment, UIBarMetrics forBarMetrics);
-
 
 		[Export ("backgroundVerticalPositionAdjustmentForBarMetrics:")]
 		[Appearance]
 		nfloat GetBackgroundVerticalPositionAdjustment (UIBarMetrics forBarMetrics);
 
-
 		[Export ("setTitlePositionAdjustment:forBarMetrics:")]
 		[Appearance]
 		void SetTitlePositionAdjustment (UIOffset adjustment, UIBarMetrics barMetrics);
-
 
 		[Export ("titlePositionAdjustmentForBarMetrics:")]
 		[Appearance]
 		UIOffset GetTitlePositionAdjustment (UIBarMetrics barMetrics);
 
 		[NoTV]
-
 		[Export ("setBackButtonBackgroundImage:forState:barMetrics:")]
 		[Appearance]
 		void SetBackButtonBackgroundImage ([NullAllowed] UIImage backgroundImage, UIControlState forState, UIBarMetrics barMetrics);
 
 		[NoTV]
-
 		[Export ("backButtonBackgroundImageForState:barMetrics:")]
 		[Appearance]
 		UIImage GetBackButtonBackgroundImage (UIControlState forState, UIBarMetrics barMetrics);
 
 		[NoTV]
-
 		[Export ("setBackButtonTitlePositionAdjustment:forBarMetrics:")]
 		[Appearance]
 		void SetBackButtonTitlePositionAdjustment (UIOffset adjustment, UIBarMetrics barMetrics);
 
 		[NoTV]
-
 		[Export ("backButtonTitlePositionAdjustmentForBarMetrics:")]
 		[Appearance]
 		UIOffset GetBackButtonTitlePositionAdjustment (UIBarMetrics barMetrics);
 
 		[NoTV]
-
 		[Export ("setBackButtonBackgroundVerticalPositionAdjustment:forBarMetrics:")]
 		[Appearance]
 		void SetBackButtonBackgroundVerticalPositionAdjustment (nfloat adjustment, UIBarMetrics barMetrics);
 
 		[NoTV]
-
 		[Export ("backButtonBackgroundVerticalPositionAdjustmentForBarMetrics:")]
 		[Appearance]
 		nfloat GetBackButtonBackgroundVerticalPositionAdjustment (UIBarMetrics barMetrics);
@@ -4996,12 +4974,10 @@ namespace XamCore.UIKit {
 		[Export ("viewFlipsideBackgroundColor")][Static]
 		UIColor ViewFlipsideBackgroundColor { get; }
 
-
 		[Availability (Deprecated = Platform.iOS_7_0)]
 		[NoWatch][NoTV]
 		[Export ("scrollViewTexturedBackgroundColor")][Static]
 		UIColor ScrollViewTexturedBackgroundColor { get; }
-
 
 		[Availability (Deprecated = Platform.iOS_7_0)]
 		[NoWatch][NoTV]
@@ -5009,12 +4985,10 @@ namespace XamCore.UIKit {
 		UIColor UnderPageBackgroundColor { get; }
 
 		[NoWatch]
-
 		[Static, Export ("colorWithCIColor:")]
 		UIColor FromCIColor (CIColor color);
 
 		[NoWatch]
-
 		[Export ("initWithCIColor:")]
 		IntPtr Constructor (CIColor ciColor);
 
@@ -6321,7 +6295,6 @@ namespace XamCore.UIKit {
 		bool SecureTextEntry { [Bind ("isSecureTextEntry")] get; set;  }
 
 		[Abstract]
-
 		[Export ("spellCheckingType")]
 		UITextSpellCheckingType SpellCheckingType { get; set; }
 
@@ -6383,13 +6356,11 @@ namespace XamCore.UIKit {
 		NSString DidHideNotification { get; }
 
 		[NoTV]
-
 		[Field("UIKeyboardWillChangeFrameNotification")]
 		[Notification (typeof (UIKeyboardEventArgs))]
 		NSString WillChangeFrameNotification { get; }
 		
 		[NoTV]
-
 		[Field("UIKeyboardDidChangeFrameNotification")]
 		[Notification (typeof (UIKeyboardEventArgs))]
 		NSString DidChangeFrameNotification { get; }
@@ -6418,22 +6389,18 @@ namespace XamCore.UIKit {
 		// Keys
 		//
 		[NoTV]
-
 		[Field ("UIKeyboardAnimationCurveUserInfoKey")]
 		NSString AnimationCurveUserInfoKey { get; }
 
 		[NoTV]
-
 		[Field ("UIKeyboardAnimationDurationUserInfoKey")]
 		NSString AnimationDurationUserInfoKey { get; }
 
 		[NoTV]
-
 		[Field ("UIKeyboardFrameEndUserInfoKey")]
 		NSString FrameEndUserInfoKey { get; }
 
 		[NoTV]
-
 		[Field ("UIKeyboardFrameBeginUserInfoKey")]
 		NSString FrameBeginUserInfoKey { get; }
 
@@ -7123,7 +7090,6 @@ namespace XamCore.UIKit {
 		[Export ("isAnimating")]
 		bool IsAnimating { get; }
 
-
 		[Export ("color", ArgumentSemantic.Retain), NullAllowed]
 		[Appearance]
 		UIColor Color { get; set; }
@@ -7191,7 +7157,6 @@ namespace XamCore.UIKit {
 		UIImage FromImage (CGImage image, nfloat scale, UIImageOrientation orientation);
 
 #if !WATCH
-
 		[Static][Export ("imageWithCIImage:")][Autorelease]
 		[ThreadSafe]			
 		UIImage FromImage (CIImage image);
@@ -7273,16 +7238,13 @@ namespace XamCore.UIKit {
 		[ThreadSafe]
 		nfloat CurrentScale { get; }
 
-
 		[Static, Export ("animatedImageNamed:duration:")][Autorelease]
 		[ThreadSafe]
 		UIImage CreateAnimatedImage (string name, double duration);
 
-
 		[Static, Export ("animatedImageWithImages:duration:")][Autorelease]
 		[ThreadSafe]
 		UIImage CreateAnimatedImage (UIImage [] images, double duration);
-
 
 		[Static, Export ("animatedResizableImageNamed:capInsets:duration:")][Autorelease]
 		[ThreadSafe]
@@ -7293,7 +7255,6 @@ namespace XamCore.UIKit {
 		IntPtr Constructor (CGImage cgImage);
 
 #if !WATCH
-
 		[Export ("initWithCIImage:")]
 		[ThreadSafe]
 		IntPtr Constructor (CIImage ciImage);
@@ -7304,27 +7265,22 @@ namespace XamCore.UIKit {
 		IntPtr Constructor (CGImage cgImage, nfloat scale,  UIImageOrientation orientation);
 
 #if !WATCH
-
 		[Export ("CIImage")]
 		[ThreadSafe]
 		CIImage CIImage { get; }
 #endif // !WATCH
 		
-
 		[Export ("images")]
 		[ThreadSafe]
 		UIImage [] Images { get; }
-
 
 		[Export ("duration")]
 		[ThreadSafe]
 		double Duration { get; }
 
-
 		[Export ("resizableImageWithCapInsets:")][Autorelease]
 		[ThreadSafe]
 		UIImage CreateResizableImage (UIEdgeInsets capInsets);
-
 
 		[Export ("capInsets")]
 		[ThreadSafe]
@@ -8172,7 +8128,6 @@ namespace XamCore.UIKit {
 		[Export ("proximityState")]
 		bool ProximityState { get; }
 
-
 		[Internal]
 		[Export ("userInterfaceIdiom")]
 		UIUserInterfaceIdiom _UserInterfaceIdiom { get; }
@@ -8525,10 +8480,8 @@ namespace XamCore.UIKit {
 		[Export ("menuFrame")]
 		CGRect MenuFrame { get; } 
 		
-
 		[Export ("arrowDirection")]
 		UIMenuControllerArrowDirection ArrowDirection { get; set; }
-
 
 		[NullAllowed] // by default this property is null
 		[Export ("menuItems", ArgumentSemantic.Copy)]
@@ -8619,7 +8572,6 @@ namespace XamCore.UIKit {
 		[PostGet ("Items")] // that will [PostGet] TopItem too
 		void SetItems (UINavigationItem [] items, bool animated);
 
-
 		[NullAllowed] // by default this property is null
 		[Export ("titleTextAttributes", ArgumentSemantic.Copy), Internal]
 		[Appearance]
@@ -8629,16 +8581,13 @@ namespace XamCore.UIKit {
 		[Appearance]
 		UIStringAttributes TitleTextAttributes { get; set; }
 
-
 		[Export ("setBackgroundImage:forBarMetrics:")]
 		[Appearance]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIBarMetrics barMetrics);
 
-
 		[Export ("backgroundImageForBarMetrics:")]
 		[Appearance]
 		UIImage GetBackgroundImage (UIBarMetrics forBarMetrics);
-
 
 		[Export ("setTitleVerticalPositionAdjustment:forBarMetrics:")]
 		[Appearance]
@@ -8778,12 +8727,10 @@ namespace XamCore.UIKit {
 		[Export ("setRightBarButtonItem:animated:")][PostGet ("RightBarButtonItem")]
 		void SetRightBarButtonItem ([NullAllowed] UIBarButtonItem item, bool animated);
 
-
 		[NullAllowed] // by default this property is null
 		[Export ("leftBarButtonItems", ArgumentSemantic.Copy)]
 		[PostGet ("LeftBarButtonItem")]
 		UIBarButtonItem [] LeftBarButtonItems { get; set;  }
-
 
 		[NullAllowed] // by default this property is null
 		[Export ("rightBarButtonItems", ArgumentSemantic.Copy)]
@@ -8791,14 +8738,11 @@ namespace XamCore.UIKit {
 		UIBarButtonItem [] RightBarButtonItems { get; set;  }
 
 		[NoTV]
-
 		[Export ("leftItemsSupplementBackButton")]
 		bool LeftItemsSupplementBackButton { get; set;  }
 
-
 		[Export ("setLeftBarButtonItems:animated:")][PostGet ("LeftBarButtonItems")]
 		void SetLeftBarButtonItems (UIBarButtonItem [] items, bool animated);
-
 
 		[Export ("setRightBarButtonItems:animated:")][PostGet ("RightBarButtonItems")]
 		void SetRightBarButtonItems (UIBarButtonItem [] items, bool animated);
@@ -9631,30 +9575,25 @@ namespace XamCore.UIKit {
 		[Export ("progress")]
 		float Progress { get; set; } // This is float, not nfloat.
 
-
 		[Export ("progressTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIColor ProgressTintColor { get; set;  }
-
 
 		[Export ("trackTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIColor TrackTintColor { get; set;  }
 
-
 		[Export ("progressImage", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIImage ProgressImage { get; set;  }
 
-
 		[Export ("trackImage", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIImage TrackImage { get; set;  }
-
 
 		[Export ("setProgress:animated:")]
 		void SetProgress (float progress /* this is float, not nfloat */, bool animated);
@@ -9735,12 +9674,10 @@ namespace XamCore.UIKit {
 		[PostGet ("NibBundle")]
 		IntPtr Constructor ([NullAllowed] string nibName, [NullAllowed] NSBundle bundle);
 
-
 		[Export ("dictionaryHasDefinitionForTerm:"), Static]
 		bool DictionaryHasDefinitionForTerm (string term);
 
 		[DesignatedInitializer]
-
 		[Export ("initWithTerm:")]
 		IntPtr Constructor (string term);
 	}
@@ -9951,10 +9888,8 @@ namespace XamCore.UIKit {
 		UIScreen MainScreen { get; }
 
 		[NoTV] // Xcode 7.2
-
 		[Export ("availableModes", ArgumentSemantic.Copy)]
 		UIScreenMode [] AvailableModes { get; }
-
 
 		[NullAllowed] // by default this property is null
 		[Export ("currentMode", ArgumentSemantic.Retain)]
@@ -9986,19 +9921,15 @@ namespace XamCore.UIKit {
 		nint MaximumFramesPerSecond { get; }
 
 		[NoTV]
-
 		[Export ("brightness")]
 		nfloat Brightness { get; set; }
 
 		[NoTV]
-
 		[Export ("wantsSoftwareDimming")]
 		bool WantsSoftwareDimming { get; set; }
 
-
 		[Export ("overscanCompensation")]
 		UIScreenOverscanCompensation OverscanCompensation { get; set; }
-
 
 		[Field ("UIScreenBrightnessDidChangeNotification")]
 		[Notification]
@@ -10201,12 +10132,10 @@ namespace XamCore.UIKit {
 		[Export ("scrollsToTop")]
 		bool ScrollsToTop { get; set; } 
 
-
 		[Export ("panGestureRecognizer")]
 		UIPanGestureRecognizer PanGestureRecognizer { get; }
 
 		[NoTV]
-
 		[Export ("pinchGestureRecognizer")]
 		UIPinchGestureRecognizer PinchGestureRecognizer { get; }
 		
@@ -10267,14 +10196,11 @@ namespace XamCore.UIKit {
 		[Export ("scrollViewDidEndZooming:withView:atScale:"), EventArgs ("ZoomingEnded")]
 		void ZoomingEnded (UIScrollView scrollView, UIView withView, nfloat atScale);
 
-
 		[Export ("scrollViewDidZoom:"), EventArgs ("UIScrollView")]
 		void DidZoom (UIScrollView scrollView);
 		
-
 		[Export ("scrollViewWillBeginZooming:withView:"), EventArgs ("UIScrollViewZooming")]
 		void ZoomingStarted (UIScrollView scrollView, UIView view);
-
 
 		[Export ("scrollViewWillEndDragging:withVelocity:targetContentOffset:"), EventArgs ("WillEndDragging")]
 		void WillEndDragging (UIScrollView scrollView, CGPoint velocity, ref CGPoint targetContentOffset);
@@ -10380,64 +10306,51 @@ namespace XamCore.UIKit {
 		[Export ("searchFieldBackgroundPositionAdjustment")]
 		UIOffset SearchFieldBackgroundPositionAdjustment { get; set;  }
 
-
 		[Export ("searchTextPositionAdjustment")]
 		UIOffset SearchTextPositionAdjustment { get; set;  }
-
 
 		[Export ("setSearchFieldBackgroundImage:forState:")]
 		[Appearance]
 		void SetSearchFieldBackgroundImage ([NullAllowed] UIImage backgroundImage, UIControlState state);
 
-
 		[Export ("searchFieldBackgroundImageForState:")]
 		[Appearance]
 		UIImage GetSearchFieldBackgroundImage (UIControlState state);
-
 
 		[Export ("setImage:forSearchBarIcon:state:")]
 		[Appearance]
 		void SetImageforSearchBarIcon ([NullAllowed] UIImage iconImage, UISearchBarIcon icon, UIControlState state);
 
-
 		[Export ("imageForSearchBarIcon:state:")]
 		[Appearance]
 		UIImage GetImageForSearchBarIcon (UISearchBarIcon icon, UIControlState state);
-
 
 		[Export ("setScopeBarButtonBackgroundImage:forState:")]
 		[Appearance]
 		void SetScopeBarButtonBackgroundImage ([NullAllowed] UIImage backgroundImage, UIControlState state);
 
-
 		[Export ("scopeBarButtonBackgroundImageForState:")]
 		[Appearance]
 		UIImage GetScopeBarButtonBackgroundImage (UIControlState state);
-
 
 		[Export ("setScopeBarButtonDividerImage:forLeftSegmentState:rightSegmentState:")]
 		[Appearance]
 		void SetScopeBarButtonDividerImage ([NullAllowed] UIImage dividerImage, UIControlState leftState, UIControlState rightState);
 
-
 		[Export ("scopeBarButtonDividerImageForLeftSegmentState:rightSegmentState:")]
 		[Appearance]
 		UIImage GetScopeBarButtonDividerImage (UIControlState leftState, UIControlState rightState);
-
 
 		[Export ("setScopeBarButtonTitleTextAttributes:forState:"), Internal]
 		[Appearance]
 		void _SetScopeBarButtonTitle (NSDictionary attributes, UIControlState state);
 
-
 		[Export ("scopeBarButtonTitleTextAttributesForState:"), Internal]
 		[Appearance]
 		NSDictionary _GetScopeBarButtonTitleTextAttributes (UIControlState state);
 
-
 		[Export ("setPositionAdjustment:forSearchBarIcon:")]
 		void SetPositionAdjustmentforSearchBarIcon (UIOffset adjustment, UISearchBarIcon icon);
-
 
 		[Export ("positionAdjustmentForSearchBarIcon:")]
 		UIOffset GetPositionAdjustmentForSearchBarIcon (UISearchBarIcon icon);
@@ -10655,7 +10568,6 @@ namespace XamCore.UIKit {
 		[Protocolize]
 		UITableViewDelegate SearchResultsDelegate { get; set; }
 
-
 		[NullAllowed] // by default this property is null
 		[Export ("searchResultsTitle", ArgumentSemantic.Copy)]
 		string SearchResultsTitle { get; set;  }
@@ -10802,45 +10714,36 @@ namespace XamCore.UIKit {
 		[Export ("selectedSegmentIndex")]
 		nint SelectedSegment { get; set; }
 
-
 		[Export ("apportionsSegmentWidthsByContent")]
 		bool ApportionsSegmentWidthsByContent { get; set; }
-
 
 		[Export ("setBackgroundImage:forState:barMetrics:")]
 		[Appearance]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIControlState state, UIBarMetrics barMetrics);
 
-
 		[Export ("backgroundImageForState:barMetrics:")]
 		[Appearance]
 		UIImage GetBackgroundImage (UIControlState state, UIBarMetrics barMetrics);
-
 
 		[Export ("setDividerImage:forLeftSegmentState:rightSegmentState:barMetrics:")]
 		[Appearance]
 		void SetDividerImage ([NullAllowed] UIImage dividerImage, UIControlState leftSegmentState, UIControlState rightSegmentState, UIBarMetrics barMetrics);
 
-
 		[Export ("dividerImageForLeftSegmentState:rightSegmentState:barMetrics:")]
 		[Appearance]
 		UIImage DividerImageForLeftSegmentStaterightSegmentStatebarMetrics (UIControlState leftState, UIControlState rightState, UIBarMetrics barMetrics);
-
 
 		[Export ("setTitleTextAttributes:forState:"), Internal]
 		[Appearance]
 		void _SetTitleTextAttributes (NSDictionary attributes, UIControlState state);
 
-
 		[Export ("titleTextAttributesForState:"), Internal]
 		[Appearance]
 		NSDictionary _GetTitleTextAttributes (UIControlState state);
 
-
 		[Export ("setContentPositionAdjustment:forSegmentType:barMetrics:")]
 		[Appearance]
 		void SetContentPositionAdjustment (UIOffset adjustment, UISegmentedControlSegment leftCenterRightOrAlone, UIBarMetrics barMetrics);
-
 
 		[Export ("contentPositionAdjustmentForSegmentType:barMetrics:")]
 		[Appearance]
@@ -10926,18 +10829,15 @@ namespace XamCore.UIKit {
 		[Export ("thumbRectForBounds:trackRect:value:")]
 		CGRect ThumbRectForBounds (CGRect bounds, CGRect trackRect, float value /* This is float, not nfloat */);
 
-
 		[Export ("minimumTrackTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIColor MinimumTrackTintColor { get; set; }
 
-
 		[Export ("maximumTrackTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
 		[NullAllowed]
 		UIColor MaximumTrackTintColor { get; set; }
-
 
 		[Export ("thumbTintColor", ArgumentSemantic.Retain)]
 		[Appearance]
@@ -11184,19 +11084,16 @@ namespace XamCore.UIKit {
 		bool IsCustomizing { get; }
 
 		[NoTV]
-
 		[Export ("selectedImageTintColor", ArgumentSemantic.Retain)]
 		[Availability (Deprecated = Platform.iOS_8_0)]
 		[NullAllowed]
 		[Appearance]
 		UIColor SelectedImageTintColor { get; set;  }
 
-
 		[Export ("backgroundImage", ArgumentSemantic.Retain)]
 		[NullAllowed]
 		[Appearance]
 		UIImage BackgroundImage { get; set;  }
-
 
 		[Export ("selectionIndicatorImage", ArgumentSemantic.Retain)]
 		[NullAllowed]
@@ -11409,7 +11306,6 @@ namespace XamCore.UIKit {
 		[Export ("finishedUnselectedImage")]
 		UIImage FinishedUnselectedImage { get; }
 
-
 		[Export ("titlePositionAdjustment")]
 		[Appearance]
 		UIOffset TitlePositionAdjustment { get; set; }
@@ -11606,7 +11502,6 @@ namespace XamCore.UIKit {
 		UITableViewCell DequeueReusableCell (NSString identifier);
 
 		// 3.2
-
 		[Export ("backgroundView", ArgumentSemantic.Retain), NullAllowed]
 		UIView BackgroundView { get; set; }
 
@@ -11614,30 +11509,23 @@ namespace XamCore.UIKit {
 		[Field ("UITableViewIndexSearch")]
 		NSString IndexSearch { get; }
 
-
 		[Field ("UITableViewAutomaticDimension")]
 		nfloat AutomaticDimension { get; }
-
 
 		[Export ("allowsMultipleSelection")]
                 bool AllowsMultipleSelection { get; set;  }
 
-
                 [Export ("allowsMultipleSelectionDuringEditing")]
                 bool AllowsMultipleSelectionDuringEditing { get; set;  }
-
 
                 [Export ("moveSection:toSection:")]
                 void MoveSection (nint fromSection, nint toSection);
 
-
                 [Export ("moveRowAtIndexPath:toIndexPath:")]
                 void MoveRow (NSIndexPath fromIndexPath, NSIndexPath toIndexPath);
 
-
                 [Export ("indexPathsForSelectedRows")]
                 NSIndexPath [] IndexPathsForSelectedRows { get; }
-
 
 		[Export ("registerNib:forCellReuseIdentifier:")]
 #if XAMCORE_2_0
@@ -11915,14 +11803,11 @@ namespace XamCore.UIKit {
 
 		// Copy Paste support
 		
-
                 [Export ("tableView:shouldShowMenuForRowAtIndexPath:")]
                 bool ShouldShowMenu (UITableView tableView, NSIndexPath rowAtindexPath);
 
-
                 [Export ("tableView:canPerformAction:forRowAtIndexPath:withSender:")]
                 bool CanPerformAction (UITableView tableView, Selector action, NSIndexPath indexPath, [NullAllowed] NSObject sender);
-
 
                 [Export ("tableView:performAction:forRowAtIndexPath:withSender:")]
                 void PerformAction (UITableView tableView, Selector action, NSIndexPath indexPath, [NullAllowed] NSObject sender);
@@ -12107,7 +11992,6 @@ namespace XamCore.UIKit {
 		[Export ("didTransitionToState:")]
 		void DidTransitionToState (UITableViewCellState mask);
 
-
 		[Export ("multipleSelectionBackgroundView", ArgumentSemantic.Retain), NullAllowed]
 		UIView MultipleSelectionBackgroundView { get; set; }
 
@@ -12144,7 +12028,6 @@ namespace XamCore.UIKit {
 
 		[Export ("tableView", ArgumentSemantic.Retain)]
 		UITableView TableView { get; set; }
-
 
 		[Export ("clearsSelectionOnViewWillAppear")]
 		bool ClearsSelectionOnViewWillAppear { get; set; }
@@ -12266,14 +12149,11 @@ namespace XamCore.UIKit {
 		nint IndentationLevel (UITableView tableView, NSIndexPath indexPath);
 
 		// Copy Paste support
-
 		[Export ("tableView:shouldShowMenuForRowAtIndexPath:")]
 		bool ShouldShowMenu (UITableView tableView, NSIndexPath rowAtindexPath);
 
-
 		[Export ("tableView:canPerformAction:forRowAtIndexPath:withSender:")]
 		bool CanPerformAction (UITableView tableView, Selector action, NSIndexPath indexPath, NSObject sender);
-
 
 		[Export ("tableView:performAction:forRowAtIndexPath:withSender:")]
 		void PerformAction (UITableView tableView, Selector action, NSIndexPath indexPath, NSObject sender);
@@ -12515,10 +12395,8 @@ namespace XamCore.UIKit {
 		void DrawPlaceholder (CGRect rect);
 
 		// 3.2
-
 		[Export ("inputAccessoryView", ArgumentSemantic.Retain)][NullAllowed]
 		UIView InputAccessoryView { get; set; }
-
 
 		[Export ("inputView", ArgumentSemantic.Retain)][NullAllowed]
 		UIView InputView { get; set; }
@@ -12789,11 +12667,9 @@ namespace XamCore.UIKit {
 		//[Export ("setItems:animated:")][PostGet ("Items")]
 		//void SetItems (UIBarButtonItem [] items, bool animated);
 
-
 		[Export ("setBackgroundImage:forToolbarPosition:barMetrics:")]
 		[Appearance]
 		void SetBackgroundImage ([NullAllowed] UIImage backgroundImage, UIToolbarPosition position, UIBarMetrics barMetrics);
-
 
 		[Export ("backgroundImageForToolbarPosition:barMetrics:")]
 		[Appearance]
@@ -12874,10 +12750,8 @@ namespace XamCore.UIKit {
 		UITouchPhase Phase { get; }
 
 		// 3.2
-
 		[Export ("gestureRecognizers", ArgumentSemantic.Copy)]
 		UIGestureRecognizer[] GestureRecognizers { get; }
-
 
 		[iOS (8,0)]
 		[Export ("majorRadius")]
@@ -13272,14 +13146,11 @@ namespace XamCore.UIKit {
 		bool AnimationsEnabled { [Bind ("areAnimationsEnabled")] get; [Bind ("setAnimationsEnabled:")] set; }
 
 		// 3.2:
-
 		[Export ("addGestureRecognizer:"), PostGet ("GestureRecognizers")]
 		void AddGestureRecognizer (UIGestureRecognizer gestureRecognizer);
 
-
 		[Export ("removeGestureRecognizer:"), PostGet ("GestureRecognizers")]
 		void RemoveGestureRecognizer (UIGestureRecognizer gestureRecognizer);
-
 
 		[NullAllowed] // by default this property is null
 		[Export ("gestureRecognizers", ArgumentSemantic.Copy)]
@@ -13868,7 +13739,6 @@ namespace XamCore.UIKit {
 		[Export ("hidesBottomBarWhenPushed")]
 		bool HidesBottomBarWhenPushed { get; set; }
 
-
 		[Export ("splitViewController", ArgumentSemantic.Retain)]
 		UISplitViewController SplitViewController { get; }
 
@@ -13912,7 +13782,6 @@ namespace XamCore.UIKit {
 		CGSize ContentSizeForViewInPopover { get; set; }
 
 		// This is defined in a category in UIPopoverSupport.h: UIViewController (UIPopoverController)
-
 		[Export ("modalInPopover")]
 		bool ModalInPopover { [Bind ("isModalInPopover")] get; set; }
 
@@ -13920,69 +13789,53 @@ namespace XamCore.UIKit {
 		[Export ("disablesAutomaticKeyboardDismissal")]
 		bool DisablesAutomaticKeyboardDismissal { get; }
 
-
 		[Export ("storyboard", ArgumentSemantic.Retain)]
 		UIStoryboard Storyboard { get;  }
-
 
 		[Export ("presentedViewController")]
 		UIViewController PresentedViewController { get;  }
 
-
 		[Export ("presentingViewController")]
 		UIViewController PresentingViewController { get;  }
 
-
 		[Export ("definesPresentationContext", ArgumentSemantic.Assign)]
 		bool DefinesPresentationContext { get; set;  }
-
 
 		[Export ("providesPresentationContextTransitionStyle", ArgumentSemantic.Assign)]
 		bool ProvidesPresentationContextTransitionStyle { get; set;  }
 
 		[NoTV]
-
 		[Availability (Deprecated = Platform.iOS_6_0)]
 		[Export ("viewWillUnload")]
 		void ViewWillUnload ();
 
-
 		[Export ("performSegueWithIdentifier:sender:")]
 		void PerformSegue (string identifier, [NullAllowed] NSObject sender);
-
 
 		[Export ("prepareForSegue:sender:")]
 		void PrepareForSegue (UIStoryboardSegue segue, [NullAllowed] NSObject sender);
 
-
 		[Export ("viewWillLayoutSubviews")]
 		void ViewWillLayoutSubviews ();
-
 
 		[Export ("viewDidLayoutSubviews")]
 		void ViewDidLayoutSubviews ();
 
-
 		[Export ("isBeingPresented")]
 		bool IsBeingPresented { get; }
-
 
 		[Export ("isBeingDismissed")]
 		bool IsBeingDismissed { get; }
 
-
 		[Export ("isMovingToParentViewController")]
 		bool IsMovingToParentViewController { get; }
-
 
 		[Export ("isMovingFromParentViewController")]
 		bool IsMovingFromParentViewController { get; }
 
-
 		[Export ("presentViewController:animated:completion:")]
 		[Async]
 		void PresentViewController (UIViewController viewControllerToPresent, bool animated, [NullAllowed] NSAction completionHandler);
-
 
 		[Export ("dismissViewControllerAnimated:completion:")]
 		[Async]
@@ -13990,7 +13843,6 @@ namespace XamCore.UIKit {
 
 		// UIViewControllerRotation
 		[NoTV]
-
 		[Static]
 		[Export ("attemptRotationToDeviceOrientation")]
 		void AttemptRotationToDeviceOrientation ();
@@ -14000,28 +13852,22 @@ namespace XamCore.UIKit {
 		[Export ("automaticallyForwardAppearanceAndRotationMethodsToChildViewControllers")]
 		/*PROTECTED*/ bool AutomaticallyForwardAppearanceAndRotationMethodsToChildViewControllers { get; }
 
-
 		[Export ("childViewControllers")]
 		/*PROTECTED, MUSTCALLBASE*/ UIViewController [] ChildViewControllers { get;  }
-
 
 		[Export ("addChildViewController:")]
 		[PostGet ("ChildViewControllers")]
 		/*PROTECTED, MUSTCALLBASE*/ void AddChildViewController (UIViewController childController);
 
-
 		[Export ("removeFromParentViewController")]
 		/*PROTECTED, MUSTCALLBASE*/ void RemoveFromParentViewController ();
-
 
 		[Export ("transitionFromViewController:toViewController:duration:options:animations:completion:")]
 		[Async]
 		/*PROTECTED, MUSTCALLBASE*/ void Transition (UIViewController fromViewController, UIViewController toViewController, double duration, UIViewAnimationOptions options, /* non null */ NSAction animations, UICompletionHandler completionHandler);
 
-
 		[Export ("willMoveToParentViewController:")]
 		void WillMoveToParentViewController ([NullAllowed] UIViewController parent);
-
 
 		[Export ("didMoveToParentViewController:")]
 		void DidMoveToParentViewController ([NullAllowed] UIViewController parent);
@@ -14029,10 +13875,8 @@ namespace XamCore.UIKit {
 		//
 		// Exposed in iOS 6.0, but they existed and are now officially supported on iOS 5.0
 		//
-
 		[Export ("beginAppearanceTransition:animated:")]
 		void BeginAppearanceTransition (bool isAppearing, bool animated);
-
 
 		[Export ("endAppearanceTransition")]
 		void EndAppearanceTransition ();
@@ -15089,7 +14933,6 @@ namespace XamCore.UIKit {
 		void WillShowViewController (UISplitViewController svc, UIViewController aViewController, UIBarButtonItem button);
 
 		[NoTV]
-
 		[Export ("splitViewController:shouldHideViewController:inOrientation:"), DelegateName ("UISplitViewControllerHidePredicate"), DefaultValue (true)]
 		[Availability (Deprecated = Platform.iOS_8_0, Message="Use 'UISearchController' instead.")]
 		bool ShouldHideViewController (UISplitViewController svc, UIViewController viewController, UIInterfaceOrientation inOrientation);
@@ -15513,7 +15356,6 @@ namespace XamCore.UIKit {
 		[Field ("UITextInputCurrentInputModeDidChangeNotification")]
 		[Notification]
 		NSString CurrentInputModeDidChangeNotification { get; }
-
 
 		[Static]
 		[Export ("activeInputModes")]

--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -3084,7 +3084,6 @@ namespace XamCore.WebKit {
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlButtonElement {
 
-		[Mac (10,6)]
 		[Export ("autofocus")]
 		bool Autofocus { get; set; }
 
@@ -3103,7 +3102,6 @@ namespace XamCore.WebKit {
 		[Export ("value")]
 		string Value { get; set; }
 
-		[Mac (10,6)]
 		[Export ("willValidate")]
 		bool WillValidate { get; }
 
@@ -3317,7 +3315,6 @@ namespace XamCore.WebKit {
 		[Export ("contentDocument", ArgumentSemantic.Retain)]
 		DomDocument ContentDocument { get; }
 
-		[Mac (10,6)]
 		[Export ("contentWindow", ArgumentSemantic.Retain)]
 		DomAbstractView ContentWindow { get; }
 	}

--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -424,11 +424,9 @@ namespace XamCore.WebKit {
 		[Export ("expandEntityReferences")]
 		bool ExpandEntityReferences { get; }
 
-		[Mac (10,5)]
 		[Export ("referenceNode", ArgumentSemantic.Retain)]
 		DomNode ReferenceNode { get; }
 
-		[Mac (10,5)]
 		[Export ("pointerBeforeReferenceNode")]
 		bool PointerBeforeReferenceNode { get; }
 
@@ -2909,39 +2907,30 @@ namespace XamCore.WebKit {
 		[Export ("accessKey")]
 		string AccessKey { get; set; }
 
-		[Mac (10,5)]
 		[Export ("hashName")]
 		string HashName { get; }
 
-		[Mac (10,5)]
 		[Export ("host")]
 		string Host { get; }
 
-		[Mac (10,5)]
 		[Export ("hostname")]
 		string Hostname { get; }
 
-		[Mac (10,5)]
 		[Export ("pathname")]
 		string Pathname { get; }
 
-		[Mac (10,5)]
 		[Export ("port")]
 		string Port { get; }
 
-		[Mac (10,5)]
 		[Export ("protocol")]
 		string Protocol { get; }
 
-		[Mac (10,5)]
 		[Export ("search")]
 		string Search { get; }
 
-		[Mac (10,5)]
 		[Export ("text")]
 		string Text { get; }
 
-		[Mac (10,5)]
 		[Export ("absoluteLinkURL", ArgumentSemantic.Copy)]
 		NSUrl AbsoluteImageUrl { get; }
 	}
@@ -3010,27 +2999,21 @@ namespace XamCore.WebKit {
 		[Export ("accessKey")]
 		string AccessKey { get; set; }
 
-		[Mac (10,5)]
 		[Export ("hashName")]
 		string HashName { get; }
 
-		[Mac (10,5)]
 		[Export ("host")]
 		string Host { get; }
 
-		[Mac (10,5)]
 		[Export ("hostname")]
 		string Hostname { get; }
 
-		[Mac (10,5)]
 		[Export ("pathname")]
 		string Pathname { get; }
 
-		[Mac (10,5)]
 		[Export ("port")]
 		string Port { get; }
 
-		[Mac (10,5)]
 		[Export ("protocol")]
 		string Protocol { get; }
 
@@ -3379,35 +3362,27 @@ namespace XamCore.WebKit {
 		[Export ("width")]
 		int Width { get; set; } /* int, not NSInteger */
 
-		[Mac (10,5)]
 		[Export ("complete")]
 		bool Complete { get; }
 
-		[Mac (10,5)]
 		[Export ("lowsrc")]
 		string Lowsrc { get; set; }
 
-		[Mac (10,5)]
 		[Export ("naturalHeight")]
 		int NaturalHeight { get; } /* int, not NSInteger */
 
-		[Mac (10,5)]
 		[Export ("naturalWidth")]
 		int NaturalWidth { get; } /* int, not NSInteger */
 
-		[Mac (10,5)]
 		[Export ("x")]
 		int X { get; } /* int, not NSInteger */
 
-		[Mac (10,5)]
 		[Export ("y")]
 		int Y { get; } /* int, not NSInteger */
 
-		[Mac (10,5)]
 		[Export ("altDisplayString")]
 		string AltDisplayString { get; }
 
-		[Mac (10,5)]
 		[Export ("absoluteImageURL", ArgumentSemantic.Copy)]
 		NSUrl AbsoluteImageUrl { get; }
 	}
@@ -3795,19 +3770,15 @@ namespace XamCore.WebKit {
 		[Export ("value")]
 		string Value { get; set; }
 
-		[Mac (10,6)]
 		[Export ("willValidate")]
 		bool WillValidate { get; }
 
-		[Mac (10,6)]
 		[Export ("item:")]
 		DomNode GetItem (uint /* unsigned int */ index);
 
-		[Mac (10,6)]
 		[Export ("namedItem:")]
 		DomNode NamedItem (string name);
 
-		[Mac (10,5)]
 		[Export ("add:before:")]
 		void Add (DomHtmlElement element, DomHtmlElement before);
 

--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -401,7 +401,6 @@ namespace XamCore.WebKit {
 
 	interface IDomNodeFilter {}
 
-	[Mac (10,4)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject), Name="DOMNodeFilter")]
 	interface DomNodeFilter {
@@ -410,7 +409,6 @@ namespace XamCore.WebKit {
 		short AcceptNode (DomNode n);
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomObject), Name="DOMNodeIterator")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomNodeIterator {
@@ -2873,7 +2871,6 @@ namespace XamCore.WebKit {
 		DomFileList Files { get; set; }
 	}
 
-		[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLAnchorElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlAnchorElement {
@@ -2908,7 +2905,7 @@ namespace XamCore.WebKit {
 		[Export ("type")]
 		string Type { get; set; }
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_8)]
+		[Availability (Deprecated = Platform.Mac_10_8)]
 		[Export ("accessKey")]
 		string AccessKey { get; set; }
 
@@ -2949,7 +2946,6 @@ namespace XamCore.WebKit {
 		NSUrl AbsoluteImageUrl { get; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLAppletElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlAppletElement {
@@ -2988,7 +2984,6 @@ namespace XamCore.WebKit {
 		string Width { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLAreaElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlAreaElement {
@@ -3011,7 +3006,7 @@ namespace XamCore.WebKit {
 		[Export ("target")]
 		string Target { get; set; }
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_8)]
+		[Availability (Deprecated = Platform.Mac_10_8)]
 		[Export ("accessKey")]
 		string AccessKey { get; set; }
 
@@ -3039,16 +3034,13 @@ namespace XamCore.WebKit {
 		[Export ("protocol")]
 		string Protocol { get; }
 
-		[Mac (10,5)]
 		[Export ("search")]
 		string Search { get; }
 
-		[Mac (10,5)]
 		[Export ("absoluteLinkURL", ArgumentSemantic.Copy)]
 		NSUrl AbsoluteImageUrl { get; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLBRElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlBRElement {
@@ -3057,7 +3049,6 @@ namespace XamCore.WebKit {
 		string Clear { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLBaseElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlBaseElement {
@@ -3069,7 +3060,6 @@ namespace XamCore.WebKit {
 		string Target { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLBaseFontElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlBaseFontElement {
@@ -3084,7 +3074,6 @@ namespace XamCore.WebKit {
 		string Size { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLBodyElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlBodyElement {
@@ -3108,7 +3097,6 @@ namespace XamCore.WebKit {
 		string VLink { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLButtonElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlButtonElement {
@@ -3136,16 +3124,14 @@ namespace XamCore.WebKit {
 		[Export ("willValidate")]
 		bool WillValidate { get; }
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_8)]
+		[Availability (Deprecated = Platform.Mac_10_8)]
 		[Export ("accessKey")]
 		string AccessKey { get; set; }
 
-		[Mac (10,5)]
 		[Export ("click")]
 		void Click ();
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLDListElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlDListElement {
@@ -3154,7 +3140,6 @@ namespace XamCore.WebKit {
 		bool Compact { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLDirectoryElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlDirectoryElement {
@@ -3163,7 +3148,6 @@ namespace XamCore.WebKit {
 		bool Compact { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLDivElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlDivElement {
@@ -3172,7 +3156,6 @@ namespace XamCore.WebKit {
 		string Align { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLEmbedElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlEmbedElement {
@@ -3196,7 +3179,6 @@ namespace XamCore.WebKit {
 		int Width { get; set; } /* int, not NSInteger */
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLFieldSetElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlFieldSetElement {
@@ -3205,7 +3187,6 @@ namespace XamCore.WebKit {
 		DomHtmlFormElement Form { get; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLFontElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlFontElement {
@@ -3220,7 +3201,6 @@ namespace XamCore.WebKit {
 		string Size { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLFrameElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlFrameElement {
@@ -3252,24 +3232,19 @@ namespace XamCore.WebKit {
 		[Export ("contentDocument", ArgumentSemantic.Retain)]
 		DomDocument ContentDocument { get; }
 
-		[Mac (10,5)]
 		[Export ("contentWindow", ArgumentSemantic.Retain)]
 		DomAbstractView ContentWindow { get; }
 
-		[Mac (10,5)]
 		[Export ("location")]
 		string Location { get; set; }
 
-		[Mac (10,5)]
 		[Export ("width")]
 		int Width { get; } /* int, not NSInteger */
 
-		[Mac (10,5)]
 		[Export ("height")]
 		int Height { get; } /* int, not NSInteger */
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLFrameSetElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlFrameSetElement {
@@ -3281,7 +3256,6 @@ namespace XamCore.WebKit {
 		string Rows { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLHRElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlHRElement {
@@ -3299,7 +3273,6 @@ namespace XamCore.WebKit {
 		string Width { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLHeadElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlHeadElement {
@@ -3308,7 +3281,6 @@ namespace XamCore.WebKit {
 		string Profile { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLHeadingElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlHeadingElement {
@@ -3317,7 +3289,6 @@ namespace XamCore.WebKit {
 		string Align { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLHtmlElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlHtmlElement {
@@ -3326,7 +3297,6 @@ namespace XamCore.WebKit {
 		string Version { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLIFrameElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlIFrameElement {
@@ -3369,7 +3339,6 @@ namespace XamCore.WebKit {
 		DomAbstractView ContentWindow { get; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLImageElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlImageElement {
@@ -3443,7 +3412,6 @@ namespace XamCore.WebKit {
 		NSUrl AbsoluteImageUrl { get; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLLIElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlLIElement {
@@ -3455,7 +3423,6 @@ namespace XamCore.WebKit {
 		int Value { get; set; } /* int, not NSInteger */
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLLabelElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlLabelElement {
@@ -3466,12 +3433,11 @@ namespace XamCore.WebKit {
 		[Export ("htmlFor")]
 		string HtmlFor { get; set; }
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_8)]
+		[Availability (Deprecated = Platform.Mac_10_8)]
 		[Export ("accessKey")]
 		string AccessKey { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLLegendElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlLegendElement {
@@ -3482,12 +3448,11 @@ namespace XamCore.WebKit {
 		[Export ("align")]
 		string Align { get; set; }
 
-		[Availability (Introduced = Platform.Mac_10_4, Deprecated = Platform.Mac_10_8)]
+		[Availability (Deprecated = Platform.Mac_10_8)]
 		[Export ("accessKey")]
 		string AccessKey { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLLinkElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlLinkElement {
@@ -3519,16 +3484,13 @@ namespace XamCore.WebKit {
 		[Export ("type")]
 		string Type { get; set; }
 
-		[Mac (10,4)]
 		[Export ("sheet", ArgumentSemantic.Retain)]
 		DomStyleSheet Sheet { get; }
 
-		[Mac (10,5)]
 		[Export ("absoluteLinkURL", ArgumentSemantic.Copy)]
 		NSUrl AbsoluteImageUrl { get; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLMapElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlMapElement {
@@ -3540,7 +3502,6 @@ namespace XamCore.WebKit {
 		string Name { get; set; }
 	}
 
-	[Mac (10,5)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLMarqueeElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlMarqueeElement {
@@ -3552,7 +3513,6 @@ namespace XamCore.WebKit {
 		void Stop ();
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLMenuElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlMenuElement {
@@ -3561,7 +3521,6 @@ namespace XamCore.WebKit {
 		bool Compact { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLMetaElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlMetaElement {
@@ -3579,7 +3538,6 @@ namespace XamCore.WebKit {
 		string Scheme { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLModElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlModElement {
@@ -3591,7 +3549,6 @@ namespace XamCore.WebKit {
 		string DateTime { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLOListElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlOListElement {
@@ -3606,7 +3563,6 @@ namespace XamCore.WebKit {
 		string Type { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLObjectElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlObjectElement {
@@ -3665,12 +3621,10 @@ namespace XamCore.WebKit {
 		[Export ("contentDocument", ArgumentSemantic.Retain)]
 		DomDocument ContentDocument { get; }
 
-		[Mac (10,5)]
 		[Export ("absoluteImageURL", ArgumentSemantic.Copy)]
 		NSUrl AbsoluteImageUrl { get; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLOptGroupElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlOptGroupElement {
@@ -3682,7 +3636,6 @@ namespace XamCore.WebKit {
 		string Label { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLOptionElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlOptionElement {
@@ -3712,12 +3665,10 @@ namespace XamCore.WebKit {
 		int Index { get; } /* int, not NSInteger */
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomObject), Name="DOMHTMLOptionsCollection")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlOptionsCollection {
 
-		[Mac (10,5)]
 		[Export ("selectedIndex")]
 		int SelectedIndex { get; set; } /* int, not NSInteger */
 
@@ -3727,11 +3678,9 @@ namespace XamCore.WebKit {
 		[Export ("namedItem:")]
 		DomNode NamedItem (string name);
 
-		[Mac (10,5)]
 		[Export ("add:index:")]
 		void Add (DomHtmlOptionElement option, uint /* unsigned int */ index);
 
-		[Mac (10,6)]
 		[Export ("remove:")]
 		void Remove (uint /* unsigned int */ index);
 
@@ -3739,7 +3688,6 @@ namespace XamCore.WebKit {
 		DomNode GetItem (uint /* unsigned int */ index);
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLParagraphElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlParagraphElement {
@@ -3748,7 +3696,6 @@ namespace XamCore.WebKit {
 		string Align { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLParamElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlParamElement {
@@ -3766,7 +3713,6 @@ namespace XamCore.WebKit {
 		string ValueType { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLPreElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlPreElement {
@@ -3774,12 +3720,10 @@ namespace XamCore.WebKit {
 		[Export ("width")]
 		int Width { get; set; } /* int, not NSInteger */
 
-		[Mac (10,5)]
 		[Export ("wrap")]
 		bool Wrap { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLQuoteElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlQuoteElement {
@@ -3788,7 +3732,6 @@ namespace XamCore.WebKit {
 		string Cite { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLScriptElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlScriptElement {
@@ -3815,12 +3758,10 @@ namespace XamCore.WebKit {
 		string Type { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLSelectElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlSelectElement {
 
-		[Mac (10,6)]
 		[Export ("autofocus")]
 		bool Autofocus { get; set; }
 
@@ -3874,7 +3815,6 @@ namespace XamCore.WebKit {
 		void Remove (int /* int, not NSInteger */ index);
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLStyleElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlStyleElement {
@@ -3888,12 +3828,10 @@ namespace XamCore.WebKit {
 		[Export ("type")]
 		string Type { get; set; }
 
-		[Mac (10,4)]
 		[Export ("sheet", ArgumentSemantic.Retain)]
 		DomStyleSheet Sheet { get; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLTableCaptionElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlTableCaptionElement {
@@ -3902,7 +3840,6 @@ namespace XamCore.WebKit {
 		string Align { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLTableCellElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlTableCellElement {
@@ -3953,7 +3890,6 @@ namespace XamCore.WebKit {
 		string Width { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLTableColElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlTableColElement {
@@ -3977,7 +3913,6 @@ namespace XamCore.WebKit {
 		string Width { get; set; }
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLTableElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlTableElement {
@@ -4049,7 +3984,6 @@ namespace XamCore.WebKit {
 		void DeleteRow (int /* int, not NSInteger */ index);
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLTableRowElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlTableRowElement {
@@ -4085,7 +4019,6 @@ namespace XamCore.WebKit {
 		void DeleteCell (int /* int, not NSInteger */ index);
 	}
 
-	[Mac (10,4)]
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLTableSectionElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
 	interface DomHtmlTableSectionElement {

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -53,7 +53,7 @@ namespace Introspection {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.WatchOS);
 			};
 #else
-			Minimum = new Version (10,6);
+			Minimum = new Version (10,7);
 			Maximum = new Version (10,13,2); // setting OSX_SDK_VERSION to 10.13.2 (instead of 10.13 breaks other assumptions)
 			Filter = (AvailabilityBaseAttribute arg) => {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.MacOSX);

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -53,7 +53,7 @@ namespace Introspection {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.WatchOS);
 			};
 #else
-			Minimum = new Version (10,5);
+			Minimum = new Version (10,6);
 			Maximum = new Version (10,13,2); // setting OSX_SDK_VERSION to 10.13.2 (instead of 10.13 breaks other assumptions)
 			Filter = (AvailabilityBaseAttribute arg) => {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.MacOSX);

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -1,0 +1,119 @@
+﻿//
+// Availability tests for introspection
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien.pouliot@microsoft.com>
+//
+// Copyright 2017 Microsoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
+using System.Reflection;
+using NUnit.Framework;
+
+#if XAMCORE_2_0
+using ObjCRuntime;
+#else
+#if MONOMAC
+using MonoMac.ObjCRuntime;
+#else
+using MonoTouch.ObjCRuntime;
+#endif
+#endif
+
+namespace Introspection {
+
+	public class ApiAvailabilityTest : ApiBaseTest {
+	
+		protected Version Minimum { get; set; }
+		protected Version Maximum { get; set; }
+		protected Func<AvailabilityBaseAttribute,bool> Filter { get; set; }
+
+		public ApiAvailabilityTest ()
+		{
+#if __IOS__
+			Minimum = new Version (3,0);
+			Maximum = new Version (11,2);
+			Filter = (AvailabilityBaseAttribute arg) => {
+				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.iOS);
+			};
+#elif __TVOS__
+			Minimum = new Version (9,0);
+			Maximum = new Version (11,2);
+			Filter = (AvailabilityBaseAttribute arg) => {
+				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.TvOS);
+			};
+#elif __WATCHOS__
+			Minimum = new Version (2,0);
+			Maximum = new Version (4,2);
+			Filter = (AvailabilityBaseAttribute arg) => {
+				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.WatchOS);
+			};
+#else
+			Minimum = new Version (10,6);
+			Maximum = new Version (10,13);
+			Filter = (AvailabilityBaseAttribute arg) => {
+				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.MacOSX);
+			};
+#endif
+		}
+
+		[Test]
+		public void Introduced ()
+		{
+			//LogProgress = true;
+			Errors = 0;
+			foreach (Type t in Assembly.GetTypes ()) {
+				if (LogProgress)
+					Console.WriteLine ($"T: {t}");
+				var ta = CheckAvailability (t);
+				foreach (var m in t.GetMembers ()) {
+					if (LogProgress)
+						Console.WriteLine ($"M: {m}");
+					var ma = CheckAvailability (m);
+					if (ta == null || ma == null)
+						continue;
+					// Duplicate checks, e.g. same attribute on member and type (extranous metadata)
+					if (ma.Version == ta.Version) {
+//						AddErrorLine ($"[FAIL] {ma.Version} (Member) == {ta.Version} (Type) on '{m}'.");
+					}
+					// Consistency checks, e.g. member lower than type
+					// note: that's valid in some cases, like a new base type being introduced
+					if (ma.Version < ta.Version) {
+//						AddErrorLine ($"[FAIL] {ma.Version} (Member) < {ta.Version} (Type) on '{m}'.");
+					}
+				}
+			}
+			AssertIfErrors ("{0} API with unneeded or incorrect version information", Errors);
+		}
+
+		protected AvailabilityBaseAttribute CheckAvailability (ICustomAttributeProvider cap)
+		{
+			var attrs = cap.GetCustomAttributes (false);
+			foreach (var a in attrs) {
+				if (a is AvailabilityBaseAttribute aa) {
+					if (Filter (aa))
+						continue;
+					if (aa.Version < Minimum)
+						AddErrorLine ($"[FAIL] {aa.Version} < {Minimum} (Min) on '{cap}'.");
+					if (aa.Version > Maximum)
+						AddErrorLine ($"[FAIL] {aa.Version} > {Maximum} (Max) on '{cap}.'");
+					return aa;
+				}
+			}
+			return null;
+		}
+	}
+}

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -36,27 +36,25 @@ namespace Introspection {
 
 		public ApiAvailabilityTest ()
 		{
+			Maximum = Version.Parse (Constants.SdkVersion);
 #if __IOS__
 			Minimum = new Version (6,0);
-			Maximum = new Version (11,2);
 			Filter = (AvailabilityBaseAttribute arg) => {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.iOS);
 			};
 #elif __TVOS__
 			Minimum = new Version (9,0);
-			Maximum = new Version (11,2);
 			Filter = (AvailabilityBaseAttribute arg) => {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.TvOS);
 			};
 #elif __WATCHOS__
 			Minimum = new Version (2,0);
-			Maximum = new Version (4,2);
 			Filter = (AvailabilityBaseAttribute arg) => {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.WatchOS);
 			};
 #else
-			Minimum = new Version (10,4);
-			Maximum = new Version (10,13,2);
+			Minimum = new Version (10,5);
+			Maximum = new Version (10,13,2); // setting OSX_SDK_VERSION to 10.13.2 (instead of 10.13 breaks other assumptions)
 			Filter = (AvailabilityBaseAttribute arg) => {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.MacOSX);
 			};

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -63,7 +63,7 @@ namespace Introspection {
 			};
 #else
 			Minimum = new Version (10,7);
-			Maximum = new Version (10,13);
+			Maximum = new Version (10,13,2);
 			Filter = (AvailabilityBaseAttribute arg) => {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.MacOSX);
 			};
@@ -101,6 +101,15 @@ namespace Introspection {
 			AssertIfErrors ("{0} API with unneeded or incorrect version information", Errors);
 		}
 
+#if XAMCORE_4_0
+		[Test]
+		public void Deprecated ()
+		{
+			// TODO warn about any API deprecated before the minimum (e.g. < iOS 6).
+			// Those should not be exposed in future profiles.
+		}
+#endif
+
 		protected AvailabilityBaseAttribute CheckAvailability (ICustomAttributeProvider cap)
 		{
 			var attrs = cap.GetCustomAttributes (false);
@@ -108,8 +117,10 @@ namespace Introspection {
 				if (a is AvailabilityBaseAttribute aa) {
 					if (Filter (aa))
 						continue;
+#if !MONOMAC
 					if (aa.Version < Minimum)
 						AddErrorLine ($"[FAIL] {aa.Version} < {Minimum} (Min) on '{cap}'.");
+#endif
 					if (aa.Version > Maximum)
 						AddErrorLine ($"[FAIL] {aa.Version} > {Maximum} (Max) on '{cap}'.");
 					return aa;

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -44,7 +44,7 @@ namespace Introspection {
 		public ApiAvailabilityTest ()
 		{
 #if __IOS__
-			Minimum = new Version (3,0);
+			Minimum = new Version (4,0);
 			Maximum = new Version (11,2);
 			Filter = (AvailabilityBaseAttribute arg) => {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.iOS);
@@ -109,7 +109,7 @@ namespace Introspection {
 					if (aa.Version < Minimum)
 						AddErrorLine ($"[FAIL] {aa.Version} < {Minimum} (Min) on '{cap}'.");
 					if (aa.Version > Maximum)
-						AddErrorLine ($"[FAIL] {aa.Version} > {Maximum} (Max) on '{cap}.'");
+						AddErrorLine ($"[FAIL] {aa.Version} > {Maximum} (Max) on '{cap}'.");
 					return aa;
 				}
 			}

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -44,7 +44,7 @@ namespace Introspection {
 		public ApiAvailabilityTest ()
 		{
 #if __IOS__
-			Minimum = new Version (4,0);
+			Minimum = new Version (5,0);
 			Maximum = new Version (11,2);
 			Filter = (AvailabilityBaseAttribute arg) => {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.iOS);

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -44,7 +44,7 @@ namespace Introspection {
 		public ApiAvailabilityTest ()
 		{
 #if __IOS__
-			Minimum = new Version (5,0);
+			Minimum = new Version (6,0);
 			Maximum = new Version (11,2);
 			Filter = (AvailabilityBaseAttribute arg) => {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.iOS);
@@ -62,7 +62,7 @@ namespace Introspection {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.WatchOS);
 			};
 #else
-			Minimum = new Version (10,6);
+			Minimum = new Version (10,7);
 			Maximum = new Version (10,13);
 			Filter = (AvailabilityBaseAttribute arg) => {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.MacOSX);
@@ -87,11 +87,13 @@ namespace Introspection {
 						continue;
 					// Duplicate checks, e.g. same attribute on member and type (extranous metadata)
 					if (ma.Version == ta.Version) {
+// about 4000
 //						AddErrorLine ($"[FAIL] {ma.Version} (Member) == {ta.Version} (Type) on '{m}'.");
 					}
 					// Consistency checks, e.g. member lower than type
 					// note: that's valid in some cases, like a new base type being introduced
 					if (ma.Version < ta.Version) {
+// about 8000
 //						AddErrorLine ($"[FAIL] {ma.Version} (Member) < {ta.Version} (Type) on '{m}'.");
 					}
 				}

--- a/tests/introspection/Mac/introspection-mac.csproj
+++ b/tests/introspection/Mac/introspection-mac.csproj
@@ -115,6 +115,9 @@
       <Link>TestRuntime.cs</Link>
     </Compile>
     <Compile Include="MacApiTypoTest.cs" />
+    <Compile Include="..\ApiAvailabilityTest.cs">
+      <Link>ApiAvailabilityTest.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">

--- a/tests/introspection/iOS/introspection-ios.csproj
+++ b/tests/introspection/iOS/introspection-ios.csproj
@@ -210,6 +210,9 @@
     <Compile Include="..\..\common\TestRuntime.cs">
       <Link>TestRuntime.cs</Link>
     </Compile>
+    <Compile Include="..\ApiAvailabilityTest.cs">
+      <Link>ApiAvailabilityTest.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist">


### PR DESCRIPTION
We normally frown on large scale _cosmetic_ changes, mostly because it breaks git's history (very useful) and makes merging branches harder and more error prone (very annoying).

However we require, right now, such changes to remove our old, mcs-based, pre-processor (pmcs) so it's a _good_ time to address the old, unneeded availability attributes - since most of them are re-written for our next milestone.

This won't change the final application size in most cases, as the linker removes them, but it will make the (unlinked) platform assemblies smaller. This means they will load faster (e.g. by mtouch, mmp, IDE, workbooks...) and will reduce the time/memory needed to reflect them.