### PR TITLE
[src] Properly annotate designated initializers in many frameworks

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -1037,7 +1037,13 @@ namespace XamCore.AVFoundation {
 	[NoWatch]
 	[iOS (8,0)][Mac (10,10)]
 	[BaseType (typeof (AVAudioNode))]
+	[DisableDefaultCtor] // designated
 	interface AVAudioEnvironmentNode : AVAudioMixing {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[Export ("nextAvailableInputBus")]
 		nuint NextAvailableInputBus { get; }
 
@@ -1366,7 +1372,13 @@ namespace XamCore.AVFoundation {
 	[Watch (3,0)]
 	[iOS (8,0)][Mac (10,10)]
 	[BaseType (typeof (AVAudioNode))]
+	[DisableDefaultCtor] // designated
 	interface AVAudioMixerNode : AVAudioMixing {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[Export ("outputVolume")]
 		float OutputVolume { get; set; } /* float, not CGFloat */
 
@@ -1579,7 +1591,12 @@ namespace XamCore.AVFoundation {
 	[Watch (3,0)]
 	[iOS (8,0)][Mac (10,10)]
 	[BaseType (typeof (AVAudioNode))]
+	[DisableDefaultCtor] // designated
 	interface AVAudioPlayerNode : AVAudioMixing {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
 
 		[Export ("playing")]
 		bool Playing { [Bind ("isPlaying")] get; }

--- a/src/callkit.cs
+++ b/src/callkit.cs
@@ -119,7 +119,12 @@ namespace XamCore.CallKit {
 
 	[iOS (10, 0)]
 	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor] // designated
 	interface CXAction : NSCopying, NSSecureCoding {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
 
 		[Export ("UUID", ArgumentSemantic.Copy)]
 		NSUuid Uuid { get; }

--- a/src/cloudkit.cs
+++ b/src/cloudkit.cs
@@ -415,7 +415,13 @@ namespace XamCore.CloudKit {
 	[Deprecated (PlatformName.MacOSX, 10, 12, message : "Use 'CKDiscoverAllUserIdentitiesOperation' instead.")]
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[BaseType (typeof (CKOperation))]
+	[DisableDefaultCtor] // designated
 	interface CKDiscoverAllContactsOperation {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[NullAllowed] // by default this property is null
 		[Export ("discoverAllContactsCompletionBlock", ArgumentSemantic.Copy)]
 		Action<CKDiscoveredUserInfo[], NSError> DiscoverAllContactsHandler { get; set; }
@@ -426,7 +432,12 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[NoWatch]
 	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor] // designated
 	interface CKDiscoveredUserInfo : NSCoding, NSCopying, NSSecureCoding {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
 
 		[Export ("userRecordID", ArgumentSemantic.Copy)]
 		CKRecordID UserRecordId { get; }
@@ -464,7 +475,12 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[NoWatch]
 	[BaseType (typeof (CKOperation))]
+	[DisableDefaultCtor] // designated
 	interface CKDiscoverUserInfosOperation {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
 
 		[Export ("initWithEmailAddresses:userRecordIDs:")]
 		IntPtr Constructor (string [] emailAddresses, CKRecordID [] userRecordIDs);
@@ -518,7 +534,13 @@ namespace XamCore.CloudKit {
 	[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
 	[Deprecated (PlatformName.WatchOS, 4, 0, message : "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
 	[Deprecated (PlatformName.TvOS, 11, 0, message : "Use 'CKDatabaseSubscription', 'CKFetchDatabaseChangesOperation' and 'CKFetchRecordZoneChangesOperation' instead.")]
+	[DisableDefaultCtor] // designated
 	interface CKFetchNotificationChangesOperation {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[Export ("initWithPreviousServerChangeToken:")]
 		IntPtr Constructor ([NullAllowed] CKServerChangeToken previousServerChangeToken);
 
@@ -564,7 +586,12 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[NoWatch]
 	[BaseType (typeof (CKDatabaseOperation))]
+	[DisableDefaultCtor] // designated
 	interface CKFetchRecordChangesOperation {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
 
 		[Export ("initWithRecordZoneID:previousServerChangeToken:")]
 		IntPtr Constructor (CKRecordZoneID recordZoneID, [NullAllowed] CKServerChangeToken previousServerChangeToken);
@@ -619,8 +646,13 @@ namespace XamCore.CloudKit {
 
 	[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(CKDatabaseOperation))]
+	[DisableDefaultCtor] // designated
 	interface CKFetchRecordZoneChangesOperation
 	{
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[Export ("initWithRecordZoneIDs:optionsByRecordZoneID:")]
 		IntPtr Constructor (CKRecordZoneID[] recordZoneIDs, [NullAllowed] NSDictionary<CKRecordZoneID, CKFetchRecordZoneChangesOptions> optionsByRecordZoneID);
 
@@ -668,11 +700,15 @@ namespace XamCore.CloudKit {
 	delegate void CKFetchRecordsCompletedHandler (NSDictionary recordsByRecordId, NSError error);
 
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
-#if XAMCORE_4_0 || WATCH // does not work on watchOS, existiong init* does not allow null to be used to fake it
-	[DisableDefaultCtor]
-#endif
+	[DisableDefaultCtor] // designated
 	[BaseType (typeof (CKDatabaseOperation))]
 	interface CKFetchRecordsOperation {
+
+#if !WATCH // does not work on watchOS, existiong init* does not allow null to be used to fake it
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+#endif
 
 		[Export ("initWithRecordIDs:")]
 		IntPtr Constructor (CKRecordID [] recordIds);
@@ -715,11 +751,16 @@ namespace XamCore.CloudKit {
 	delegate void CKRecordZoneCompleteHandler (NSDictionary recordZonesByZoneId, NSError operationError);
 
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
-#if XAMCORE_4_0 || WATCH // does not work on watchOS, existiong init* does not allow null to be used to fake it
-	[DisableDefaultCtor]
-#endif
 	[BaseType (typeof (CKDatabaseOperation))]
+	[DisableDefaultCtor] // designated
 	interface CKFetchRecordZonesOperation {
+
+#if !WATCH // does not work on watchOS, existiong init* does not allow null to be used to fake it
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+#endif
+
 		[Export ("initWithRecordZoneIDs:")]
 		IntPtr Constructor (CKRecordZoneID [] zoneIds);
 
@@ -746,7 +787,12 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[NoWatch]
 	[BaseType (typeof (CKDatabaseOperation))]
+	[DisableDefaultCtor] // designated
 	interface CKFetchSubscriptionsOperation {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
 
 		[Export ("initWithSubscriptionIDs:")]
 		IntPtr Constructor (string [] subscriptionIds);
@@ -917,7 +963,12 @@ namespace XamCore.CloudKit {
 	[iOS (8,0), Mac (10,10, onlyOn64 : true)]
 	[NoWatch]
 	[BaseType (typeof (CKDatabaseOperation))]
+	[DisableDefaultCtor] // designated
 	interface CKModifySubscriptionsOperation {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
 
 		[Export ("initWithSubscriptionsToSave:subscriptionIDsToDelete:")]
 		IntPtr Constructor ([NullAllowed] CKSubscription [] subscriptionsToSave, [NullAllowed] string [] subscriptionIdsToDelete);
@@ -1232,11 +1283,15 @@ namespace XamCore.CloudKit {
 	}
 
 	[iOS (8,0), Watch (3,0), TV (10,0), Mac (10,10, onlyOn64 : true)]
-#if XAMCORE_4_0 || WATCH // does not work on watchOS, existiong init* does not allow null to be used to fake it
-	[DisableDefaultCtor]
-#endif
 	[BaseType (typeof (CKDatabaseOperation))]
+	[DisableDefaultCtor] // designated
 	interface CKQueryOperation {
+
+#if !WATCH // does not work on watchOS, existiong init* does not allow null to be used to fake it
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+#endif
 
 		[Field ("CKQueryOperationMaximumResults")][Internal]
 		IntPtr _MaximumResults { get; set; }
@@ -1690,7 +1745,12 @@ namespace XamCore.CloudKit {
 	[TV (9,1)]
 	[Watch (3,0)]
 	[BaseType (typeof (CKDatabaseOperation))]
+	[DisableDefaultCtor] // designated
 	interface CKFetchWebAuthTokenOperation {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
 
 		[Export ("initWithAPIToken:")]
 		IntPtr Constructor (string token);
@@ -1706,8 +1766,13 @@ namespace XamCore.CloudKit {
 
 	[iOS (10,0), TV (10,0), Watch (3,0), Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(CKOperation))]
+	[DisableDefaultCtor] // designated
 	interface CKDiscoverUserIdentitiesOperation
 	{
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[Export ("initWithUserIdentityLookupInfos:")]
 		IntPtr Constructor (CKUserIdentityLookupInfo[] userIdentityLookupInfos);
 
@@ -1723,8 +1788,13 @@ namespace XamCore.CloudKit {
 
 	[NoTV, iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(CKOperation))]
+	[DisableDefaultCtor] // designated
 	interface CKDiscoverAllUserIdentitiesOperation
 	{
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[NullAllowed, Export ("userIdentityDiscoveredBlock", ArgumentSemantic.Copy)]
 		Action<CKUserIdentity> Discovered { get; set; }
 
@@ -1734,8 +1804,13 @@ namespace XamCore.CloudKit {
 
 	[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(CKOperation))]
+	[DisableDefaultCtor] // designated
 	interface CKFetchShareParticipantsOperation
 	{
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[Export ("initWithUserIdentityLookupInfos:")]
 		IntPtr Constructor (CKUserIdentityLookupInfo[] userIdentityLookupInfos);
 
@@ -1755,8 +1830,13 @@ namespace XamCore.CloudKit {
 
 	[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(CKOperation))]
+	[DisableDefaultCtor] // designated
 	interface CKAcceptSharesOperation
 	{
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[Export ("initWithShareMetadatas:")]
 		IntPtr Constructor (CKShareMetadata[] shareMetadatas);
 
@@ -1776,8 +1856,13 @@ namespace XamCore.CloudKit {
 
 	[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(CKOperation))]
+	[DisableDefaultCtor] // designated
 	interface CKFetchShareMetadataOperation
 	{
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[Export ("initWithShareURLs:")]
 		IntPtr Constructor (NSUrl[] shareUrls);
 
@@ -1803,8 +1888,13 @@ namespace XamCore.CloudKit {
 
 	[iOS (10,0), Watch (3,0), TV (10,0), Mac (10,12, onlyOn64 : true)]
 	[BaseType (typeof(CKDatabaseOperation))]
+	[DisableDefaultCtor] // designated
 	interface CKFetchDatabaseChangesOperation
 	{
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[Export ("initWithPreviousServerChangeToken:")]
 		IntPtr Constructor ([NullAllowed] CKServerChangeToken previousServerChangeToken);
 

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -448,8 +448,13 @@ namespace XamCore.CoreData
 	[Protocol]
 	interface NSFetchRequestResult {}
 
+	[DisableDefaultCtor] // designated
 	[BaseType (typeof (NSPersistentStoreRequest))]
 	interface NSFetchRequest : NSCoding {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
 
 		[Export ("entity", ArgumentSemantic.Retain)]
 		[NullAllowed]
@@ -1183,7 +1188,12 @@ namespace XamCore.CoreData
 	}
 
 	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor] // designated
 	interface NSManagedObjectModel : NSCoding, NSCopying {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
 
 		[Static, Export ("mergedModelFromBundles:")]
 		[return: NullAllowed]

--- a/src/gameplaykit.cs
+++ b/src/gameplaykit.cs
@@ -376,8 +376,13 @@ namespace XamCore.GameplayKit {
 
 	[iOS (9,0), Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor] // designated
 	interface GKEntity : NSCopying, NSCoding {
-		
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[Static]
 		[Export ("entity")]
 		GKEntity GetEntity ();
@@ -1131,8 +1136,13 @@ namespace XamCore.GameplayKit {
 
 	[iOS (9,0), Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor] // designated
 	interface GKRandomSource : GKRandom, NSSecureCoding, NSCopying {
-		
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[Static]
 		[Export ("sharedRandom")]
 		GKRandomSource SharedRandom { get; }
@@ -1182,8 +1192,13 @@ namespace XamCore.GameplayKit {
 
 	[iOS (9,0), Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor] // designated
 	interface GKRuleSystem {
-		
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[Export ("evaluate")]
 		void Evaluate ();
 
@@ -1279,7 +1294,13 @@ namespace XamCore.GameplayKit {
 	[iOS (9,0), Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof (NSObject))]
 	[Abstract]
+	[DisableDefaultCtor] // designated
 	interface GKState {
+
+		[Protected]
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
 
 		[NullAllowed]
 		[Export ("stateMachine", ArgumentSemantic.Weak)]

--- a/src/messages.cs
+++ b/src/messages.cs
@@ -168,9 +168,13 @@ namespace XamCore.Messages {
 
 	[iOS (10,0)]
 	[BaseType (typeof(NSObject))]
-	// note: docs says `init` can be used even if `initWithSession:` is the designated initializer
+	[DisableDefaultCtor] // designated
 	interface MSMessage : NSCopying, NSSecureCoding
 	{
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[Export ("initWithSession:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (MSSession session);

--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -1631,8 +1631,13 @@ namespace XamCore.ModelIO {
 
 	[iOS (9,0), Mac(10,11, onlyOn64 : true)]
 	[BaseType (typeof(NSObject))]
+	[DisableDefaultCtor] // designated
 	interface MDLTexture : MDLNamed
 	{
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[Static]
 		[Export ("textureNamed:")]
 		MDLTexture FromBundle (string name);

--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -564,8 +564,13 @@ namespace XamCore.PassKit {
 
 	[iOS (9,0)]
 	[BaseType (typeof(NSObject))]
+	[DisableDefaultCtor] // designated
 	interface PKAddPaymentPassRequest : NSSecureCoding
 	{
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[NullAllowed, Export ("encryptedPassData", ArgumentSemantic.Copy)]
 		NSData EncryptedPassData { get; set; }
 	

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -6923,7 +6923,13 @@ namespace XamCore.UIKit {
 	[iOS (4,0)]
 	[BaseType (typeof (NSObject))]
 	[Availability (Deprecated = Platform.iOS_10_0, Message = "Use 'UserNotifications.UNNotificationRequest' instead.")]
+	[DisableDefaultCtor] // designated
 	interface UILocalNotification : NSCoding, NSCopying {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[Export ("fireDate", ArgumentSemantic.Copy)]
 		[NullAllowed]
 		NSDate FireDate { get; set;  }
@@ -7717,7 +7723,13 @@ namespace XamCore.UIKit {
 	[iOS (3,2)]
 	[BaseType (typeof (NSObject))]
 	[ThreadSafe]
+	[DisableDefaultCtor] // designated
 	interface UIBezierPath : NSSecureCoding, NSCopying {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		// initWithFrame: --> unrecognized selector
 
 		[Export ("bezierPath"), Static]
@@ -16129,8 +16141,13 @@ namespace XamCore.UIKit {
 
 	[iOS (10,0), TV (10,0)]
 	[BaseType (typeof(NSObject))]
+	[DisableDefaultCtor] // designated
 	interface UISpringTimingParameters : UITimingCurveProvider
 	{
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
+
 		[Export ("initialVelocity")]
 		CGVector InitialVelocity { get; }
 

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -395,6 +395,14 @@ namespace Introspection {
 				if (ctor.ToString () == "Void .ctor(PKPaymentSummaryItem[])")
 					return true;
 				break;
+			case "MDLNoiseTexture":
+			case "MDLSkyCubeTexture":
+			case "MDLNormalMapTexture":
+			case "MDLUrlTexture":
+			case "MDLCheckerboardTexture":
+			case "MDLColorSwatchTexture":
+				// they don't make sense without extra arguments
+				return true;
 			}
 
 			var ep = ctor.GetParameters ();

--- a/tests/xtro-sharpie/common-AVFoundation.ignore
+++ b/tests/xtro-sharpie/common-AVFoundation.ignore
@@ -8,9 +8,6 @@
 
 ## unsorted
 
-!missing-designated-initializer! AVAudioEnvironmentNode::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! AVAudioMixerNode::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! AVAudioPlayerNode::init is missing an [DesignatedInitializer] attribute
 !missing-field! AVCoreAnimationBeginTimeAtZero not bound
 !missing-field! AVVideoCodecHEVC not bound
 !missing-field! AVVideoTransferFunction_ITU_R_2100_HLG not bound

--- a/tests/xtro-sharpie/common-CloudKit.ignore
+++ b/tests/xtro-sharpie/common-CloudKit.ignore
@@ -4,16 +4,3 @@
 ## we offer a better managed API using another selector
 !missing-selector! CKRecord::objectForKeyedSubscript: not bound
 !missing-selector! CKRecord::setObject:forKeyedSubscript: not bound
-
-
-## unsorted
-
-!missing-designated-initializer! CKAcceptSharesOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKDiscoverAllUserIdentitiesOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKDiscoverUserIdentitiesOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchDatabaseChangesOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchNotificationChangesOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchRecordZoneChangesOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchShareMetadataOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchShareParticipantsOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchWebAuthTokenOperation::init is missing an [DesignatedInitializer] attribute

--- a/tests/xtro-sharpie/common-CoreData.ignore
+++ b/tests/xtro-sharpie/common-CoreData.ignore
@@ -1,5 +1,3 @@
-!missing-designated-initializer! NSFetchRequest::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! NSManagedObjectModel::init is missing an [DesignatedInitializer] attribute
 !missing-field! NSAffectedObjectsErrorKey not bound
 !missing-field! NSCoreDataVersionNumber not bound
 !missing-field! NSErrorMergePolicy not bound

--- a/tests/xtro-sharpie/common-GameplayKit.ignore
+++ b/tests/xtro-sharpie/common-GameplayKit.ignore
@@ -1,12 +1,11 @@
 ## Fixed in XAMCORE_4_0
 !incorrect-protocol-member! GKGameModelPlayer::playerId is REQUIRED and should be abstract
 
-## unsorted
-
-!missing-designated-initializer! GKEntity::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! GKRandomSource::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! GKRuleSystem::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! GKState::init is missing an [DesignatedInitializer] attribute
+## no generator support for NSFastEnumeration / https://bugzilla.xamarin.com/show_bug.cgi?id=4391
 !missing-protocol-conformance! GKBehavior should conform to NSFastEnumeration
 !missing-protocol-conformance! GKComponentSystem should conform to NSFastEnumeration
+
+
+## unsorted
+
 !unknown-type! GKHybridStrategist bound

--- a/tests/xtro-sharpie/common-ModelIO.ignore
+++ b/tests/xtro-sharpie/common-ModelIO.ignore
@@ -5,18 +5,22 @@
 !incorrect-protocol-member! MDLTransformComponent::resetsTransform is REQUIRED and should be abstract
 !incorrect-protocol-member! MDLTransformComponent::setResetsTransform: is REQUIRED and should be abstract
 
-
-## unsorted
-
+## old @optional methods that became @required (abstract) in existing types (breaking changes)
 !incorrect-protocol-member! MDLMeshBuffer::allocator is REQUIRED and should be abstract
 !incorrect-protocol-member! MDLMeshBuffer::length is REQUIRED and should be abstract
 !incorrect-protocol-member! MDLMeshBuffer::type is REQUIRED and should be abstract
 !incorrect-protocol-member! MDLMeshBuffer::zone is REQUIRED and should be abstract
 !incorrect-protocol-member! MDLMeshBufferZone::allocator is REQUIRED and should be abstract
 !incorrect-protocol-member! MDLMeshBufferZone::capacity is REQUIRED and should be abstract
-!missing-designated-initializer! MDLTexture::init is missing an [DesignatedInitializer] attribute
-!missing-protocol-conformance! MDLAsset should conform to NSFastEnumeration
-!missing-protocol-conformance! MDLMaterial should conform to NSFastEnumeration
+
+## we only export the overload that expose an NSError
 !missing-selector! MDLAsset::exportAssetToURL: not bound
+
+## those are just doing the same as the setComponent:forProtocol: and componentConformingToProtocol:
+## objectForKeyedSubscript:'s description is: "Allows shorthand [key] syntax for componentConformingToProtocol:"
 !missing-selector! MDLObject::objectForKeyedSubscript: not bound
 !missing-selector! MDLObject::setObject:forKeyedSubscript: not bound
+
+## no generator support for FastEnumeration - https://bugzilla.xamarin.com/show_bug.cgi?id=4391
+!missing-protocol-conformance! MDLAsset should conform to NSFastEnumeration
+!missing-protocol-conformance! MDLMaterial should conform to NSFastEnumeration

--- a/tests/xtro-sharpie/iOS-CallKit.todo
+++ b/tests/xtro-sharpie/iOS-CallKit.todo
@@ -1,1 +1,0 @@
-!missing-designated-initializer! CXAction::init is missing an [DesignatedInitializer] attribute

--- a/tests/xtro-sharpie/iOS-CloudKit.todo
+++ b/tests/xtro-sharpie/iOS-CloudKit.todo
@@ -1,8 +1,0 @@
-!missing-designated-initializer! CKDiscoverAllContactsOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKDiscoverUserInfosOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchRecordChangesOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchRecordsOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchRecordZonesOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchSubscriptionsOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKModifySubscriptionsOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKQueryOperation::init is missing an [DesignatedInitializer] attribute

--- a/tests/xtro-sharpie/iOS-Messages.todo
+++ b/tests/xtro-sharpie/iOS-Messages.todo
@@ -1,1 +1,0 @@
-!missing-designated-initializer! MSMessage::init is missing an [DesignatedInitializer] attribute

--- a/tests/xtro-sharpie/iOS-PassKit.todo
+++ b/tests/xtro-sharpie/iOS-PassKit.todo
@@ -1,1 +1,0 @@
-!missing-designated-initializer! PKAddPaymentPassRequest::init is missing an [DesignatedInitializer] attribute

--- a/tests/xtro-sharpie/iOS-UIKit.todo
+++ b/tests/xtro-sharpie/iOS-UIKit.todo
@@ -2,7 +2,6 @@
 !missing-designated-initializer! NSShadow::init is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! UIBarButtonItem::init is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! UIBarItem::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! UIBezierPath::init is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! UICollectionViewLayout::init is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! UICubicTimingParameters::init is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! UIImageAsset::init is missing an [DesignatedInitializer] attribute
@@ -13,7 +12,5 @@
 !missing-designated-initializer! UITraitCollection::init is missing an [DesignatedInitializer] attribute
 
 !missing-designated-initializer! UIDragPreviewParameters::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! UILocalNotification::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! UISpringTimingParameters::init is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! UIUserNotificationAction::init is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! UIUserNotificationCategory::init is missing an [DesignatedInitializer] attribute

--- a/tests/xtro-sharpie/macOS-CloudKit.todo
+++ b/tests/xtro-sharpie/macOS-CloudKit.todo
@@ -1,8 +1,0 @@
-!missing-designated-initializer! CKDiscoverAllContactsOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKDiscoverUserInfosOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchRecordChangesOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchRecordsOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchRecordZonesOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchSubscriptionsOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKModifySubscriptionsOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKQueryOperation::init is missing an [DesignatedInitializer] attribute

--- a/tests/xtro-sharpie/tvOS-CloudKit.todo
+++ b/tests/xtro-sharpie/tvOS-CloudKit.todo
@@ -1,7 +1,0 @@
-!missing-designated-initializer! CKDiscoverUserInfosOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchRecordChangesOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchRecordsOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchRecordZonesOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKFetchSubscriptionsOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKModifySubscriptionsOperation::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! CKQueryOperation::init is missing an [DesignatedInitializer] attribute

--- a/tests/xtro-sharpie/tvOS-UIKit.ignore
+++ b/tests/xtro-sharpie/tvOS-UIKit.ignore
@@ -48,6 +48,5 @@
 
 ## unsorted
 
-!missing-designated-initializer! UISpringTimingParameters::init is missing an [DesignatedInitializer] attribute
 !unknown-native-enum! UILineBreakMode bound
 !unknown-native-enum! UITextAlignment bound

--- a/tests/xtro-sharpie/tvOS-UIKit.todo
+++ b/tests/xtro-sharpie/tvOS-UIKit.todo
@@ -2,7 +2,6 @@
 !missing-designated-initializer! NSShadow::init is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! UIBarButtonItem::init is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! UIBarItem::init is missing an [DesignatedInitializer] attribute
-!missing-designated-initializer! UIBezierPath::init is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! UICollectionViewLayout::init is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! UICubicTimingParameters::init is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! UIImageAsset::init is missing an [DesignatedInitializer] attribute

--- a/tests/xtro-sharpie/watchOS-UIKit.ignore
+++ b/tests/xtro-sharpie/watchOS-UIKit.ignore
@@ -1,5 +1,3 @@
-!missing-designated-initializer! UILocalNotification::init is missing an [DesignatedInitializer] attribute
-
 # Deprecated in iOS 9.0 (so watch 2.0) with an alternative (NSWritingDirectionFormatType in UIKit)
 # better not expose the deprecated enum since it's not available in tvOS either
 !missing-enum! NSTextWritingDirection not bound

--- a/tests/xtro-sharpie/watchOS-UIKit.todo
+++ b/tests/xtro-sharpie/watchOS-UIKit.todo
@@ -1,1 +1,0 @@
-!missing-designated-initializer! UIBezierPath::init is missing an [DesignatedInitializer] attribute


### PR DESCRIPTION
Correspond to xtro `!missing-designated-initializer!` errors