### PR TITLE
[macos][audiotoolbox] Enable some existing API for XM

### DIFF
--- a/src/AudioToolbox/MusicPlayer.cs
+++ b/src/AudioToolbox/MusicPlayer.cs
@@ -8,7 +8,7 @@
 //
 //
 
-#if IOS || TVOS
+#if !WATCH
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/AudioToolbox/MusicSequence.cs
+++ b/src/AudioToolbox/MusicSequence.cs
@@ -7,7 +7,7 @@
 // Copyright 2012-2014 Xamarin Inc.
 //
 
-#if IOS || TVOS
+#if !WATCH
 
 using System;
 using System.Collections.Generic;

--- a/src/AudioToolbox/MusicTrack.cs
+++ b/src/AudioToolbox/MusicTrack.cs
@@ -11,7 +11,7 @@
 //       MusicTrackNewAUPresetEvent
 //
 
-#if IOS || TVOS
+#if !WATCH
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -908,10 +908,9 @@ namespace XamCore.AVFoundation {
 	[BaseType (typeof (NSObject))]
 	interface AVAudioEngine {
 
-#if !MONOMAC && !WATCH
+		[NoWatch]
 		[Export ("musicSequence"), NullAllowed]
 		MusicSequence MusicSequence { get; set; }
-#endif
 
 		[Export ("outputNode")]
 		AVAudioOutputNode OutputNode { get; }

--- a/tests/xtro-sharpie/macOS-AVFoundation.todo
+++ b/tests/xtro-sharpie/macOS-AVFoundation.todo
@@ -1,6 +1,3 @@
-!missing-selector! AVAudioEngine::musicSequence not bound
-!missing-selector! AVAudioEngine::setMusicSequence: not bound
-
 !missing-selector! AVPlayerItem::preferredMaximumResolution not bound
 !missing-selector! AVPlayerItem::setPreferredMaximumResolution: not bound
 !missing-selector! AVPlayerItem::isContentAuthorizedForPlayback not bound

--- a/tests/xtro-sharpie/macOS-AudioToolbox.ignore
+++ b/tests/xtro-sharpie/macOS-AudioToolbox.ignore
@@ -105,8 +105,6 @@
 !missing-pinvoke! CAClockStart is not bound
 !missing-pinvoke! CAClockStop is not bound
 !missing-pinvoke! CAClockTranslateTime is not bound
-!missing-pinvoke! DisposeMusicPlayer is not bound
-!missing-pinvoke! DisposeMusicSequence is not bound
 !missing-pinvoke! ExtAudioFileCreateNew is not bound
 !missing-pinvoke! ExtAudioFileOpen is not bound
 !missing-pinvoke! GetNameFromSoundBank is not bound

--- a/tests/xtro-sharpie/macOS-AudioToolbox.ignore
+++ b/tests/xtro-sharpie/macOS-AudioToolbox.ignore
@@ -6,10 +6,6 @@
 !missing-enum! CAClockSyncMode not bound
 !missing-enum! CAClockTimebase not bound
 !missing-enum! CAClockTimeFormat not bound
-!missing-enum! MusicSequenceFileFlags not bound
-!missing-enum! MusicSequenceFileTypeID not bound
-!missing-enum! MusicSequenceLoadFlags not bound
-!missing-enum! MusicSequenceType not bound
 !missing-pinvoke! AudioCodecAppendInputBufferList is not bound
 !missing-pinvoke! AudioCodecAppendInputData is not bound
 !missing-pinvoke! AudioCodecGetProperty is not bound
@@ -116,64 +112,13 @@
 !missing-pinvoke! GetNameFromSoundBank is not bound
 !missing-pinvoke! MusicDevicePrepareInstrument is not bound
 !missing-pinvoke! MusicDeviceReleaseInstrument is not bound
-!missing-pinvoke! MusicPlayerGetBeatsForHostTime is not bound
-!missing-pinvoke! MusicPlayerGetHostTimeForBeats is not bound
-!missing-pinvoke! MusicPlayerGetPlayRateScalar is not bound
-!missing-pinvoke! MusicPlayerGetSequence is not bound
-!missing-pinvoke! MusicPlayerGetTime is not bound
-!missing-pinvoke! MusicPlayerIsPlaying is not bound
-!missing-pinvoke! MusicPlayerPreroll is not bound
-!missing-pinvoke! MusicPlayerSetPlayRateScalar is not bound
-!missing-pinvoke! MusicPlayerSetSequence is not bound
-!missing-pinvoke! MusicPlayerSetTime is not bound
-!missing-pinvoke! MusicPlayerStart is not bound
-!missing-pinvoke! MusicPlayerStop is not bound
-!missing-pinvoke! MusicSequenceBarBeatTimeToBeats is not bound
-!missing-pinvoke! MusicSequenceBeatsToBarBeatTime is not bound
-!missing-pinvoke! MusicSequenceDisposeTrack is not bound
-!missing-pinvoke! MusicSequenceFileCreate is not bound
-!missing-pinvoke! MusicSequenceFileCreateData is not bound
-!missing-pinvoke! MusicSequenceFileLoad is not bound
-!missing-pinvoke! MusicSequenceFileLoadData is not bound
-!missing-pinvoke! MusicSequenceGetAUGraph is not bound
-!missing-pinvoke! MusicSequenceGetBeatsForSeconds is not bound
-!missing-pinvoke! MusicSequenceGetIndTrack is not bound
-!missing-pinvoke! MusicSequenceGetInfoDictionary is not bound
-!missing-pinvoke! MusicSequenceGetSecondsForBeats is not bound
-!missing-pinvoke! MusicSequenceGetSequenceType is not bound
-!missing-pinvoke! MusicSequenceGetTempoTrack is not bound
-!missing-pinvoke! MusicSequenceGetTrackCount is not bound
-!missing-pinvoke! MusicSequenceGetTrackIndex is not bound
 !missing-pinvoke! MusicSequenceLoadSMFDataWithFlags is not bound
 !missing-pinvoke! MusicSequenceLoadSMFWithFlags is not bound
-!missing-pinvoke! MusicSequenceNewTrack is not bound
-!missing-pinvoke! MusicSequenceReverse is not bound
 !missing-pinvoke! MusicSequenceSaveMIDIFile is not bound
 !missing-pinvoke! MusicSequenceSaveSMFData is not bound
-!missing-pinvoke! MusicSequenceSetAUGraph is not bound
 !missing-pinvoke! MusicSequenceSetMIDIEndpoint is not bound
-!missing-pinvoke! MusicSequenceSetSequenceType is not bound
-!missing-pinvoke! MusicSequenceSetUserCallback is not bound
-!missing-pinvoke! MusicTrackClear is not bound
-!missing-pinvoke! MusicTrackCopyInsert is not bound
-!missing-pinvoke! MusicTrackCut is not bound
 !missing-pinvoke! MusicTrackGetDestMIDIEndpoint is not bound
-!missing-pinvoke! MusicTrackGetProperty is not bound
-!missing-pinvoke! MusicTrackGetSequence is not bound
-!missing-pinvoke! MusicTrackMerge is not bound
-!missing-pinvoke! MusicTrackMoveEvents is not bound
 !missing-pinvoke! MusicTrackNewExtendedControlEvent is not bound
-!missing-pinvoke! MusicTrackNewExtendedNoteEvent is not bound
-!missing-pinvoke! MusicTrackNewExtendedTempoEvent is not bound
-!missing-pinvoke! MusicTrackNewMetaEvent is not bound
-!missing-pinvoke! MusicTrackNewMIDIChannelEvent is not bound
-!missing-pinvoke! MusicTrackNewMIDINoteEvent is not bound
-!missing-pinvoke! MusicTrackNewMIDIRawDataEvent is not bound
-!missing-pinvoke! MusicTrackNewUserEvent is not bound
 !missing-pinvoke! MusicTrackSetDestMIDIEndpoint is not bound
-!missing-pinvoke! MusicTrackSetDestNode is not bound
-!missing-pinvoke! MusicTrackSetProperty is not bound
-!missing-pinvoke! NewMusicPlayer is not bound
-!missing-pinvoke! NewMusicSequence is not bound
 !missing-pinvoke! NewMusicTrackFrom is not bound
 !missing-protocol! AUCocoaUIBase not bound


### PR DESCRIPTION
and this allows adding (missing) `AVAudioEngine.MusicSequence` for
AVFoundation.

Updated xtro files.