### PR TITLE
[macos][notificationcenter] Fix extraneous setter on NCWidgetProviding.WidgetAllowsEditing

### DIFF
--- a/src/notificationcenter.cs
+++ b/src/notificationcenter.cs
@@ -43,7 +43,13 @@ namespace XamCore.NotificationCenter {
 
 #if MONOMAC
 		[Export ("widgetAllowsEditing")]
-		bool WidgetAllowsEditing { get; set; }
+		bool WidgetAllowsEditing {
+			get;
+#if !XAMCORE_4_0
+			[NotImplemented]
+			set;
+#endif
+		}
 
 		[Export ("widgetDidBeginEditing")]
 		void WidgetDidBeginEditing ();

--- a/tests/xtro-sharpie/macOS-NotificationCenter.todo
+++ b/tests/xtro-sharpie/macOS-NotificationCenter.todo
@@ -1,1 +1,0 @@
-!extra-protocol-member! unexpected selector NCWidgetProviding::setWidgetAllowsEditing: found


### PR DESCRIPTION
Headers match documentation
https://developer.apple.com/documentation/notificationcenter/ncwidgetproviding/1490251-widgetallowsediting?language=objc

Before XAMCORE_4_0 the setter will throw an `NotImplementedException`
which is better, and more accurate, than a native exception.

Found by xtro. Data file updated.