### PR TITLE
[uikit] Remove old selector checks in UIDevice

### DIFF
--- a/src/UIKit/UIDevice.cs
+++ b/src/UIKit/UIDevice.cs
@@ -11,26 +11,6 @@ namespace XamCore.UIKit {
 	public
 #endif
 	partial class UIDevice {
-#if !WATCH
-		public UIUserInterfaceIdiom UserInterfaceIdiom {
-			get {
-				Selector userInterfaceIdiom = new Selector ("userInterfaceIdiom");
-				if (RespondsToSelector (userInterfaceIdiom))
-					return _UserInterfaceIdiom;
-				else
-					return UIUserInterfaceIdiom.Phone;
-			}
-		}
-
-		public bool IsMultitaskingSupported {
-			get {
-				Selector mtsupported = new Selector ("isMultitaskingSupported");
-				if (RespondsToSelector (mtsupported))
-					return _IsMultitaskingSupported;
-				return false;
-			}
-		}
-#endif
 		
 		public bool CheckSystemVersion (int major, int minor)
 		{

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -8140,9 +8140,8 @@ namespace XamCore.UIKit {
 		[Export ("proximityState")]
 		bool ProximityState { get; }
 
-		[Internal]
 		[Export ("userInterfaceIdiom")]
-		UIUserInterfaceIdiom _UserInterfaceIdiom { get; }
+		UIUserInterfaceIdiom UserInterfaceIdiom { get; }
 
 		[NoTV]
 		[Field ("UIDeviceOrientationDidChangeNotification")]
@@ -8163,8 +8162,8 @@ namespace XamCore.UIKit {
 		[Notification]
 		NSString ProximityStateDidChangeNotification { get; }
 		
-		[Export ("isMultitaskingSupported"), Internal]
-		bool _IsMultitaskingSupported { get; }
+		[Export ("isMultitaskingSupported")]
+		bool IsMultitaskingSupported { get; }
 
 		[Export ("playInputClick")]
 		void PlayInputClick ();


### PR DESCRIPTION
Those were useful, a long time ago, to use the API even on _older_
versions. This is not needed anymore and can be simplified.