### PR TITLE
Create classic snapshot of bgen and update tests/scripts

### DIFF
--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -195,7 +195,9 @@ MAC_TARGETS_DIRS +=                                     \
 
 MAC_TARGETS += \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/bgen                     \
+	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/bgen-classic             \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/bgen.exe            \
+	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/bgen-classic.exe            \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/XamMac.BindingAttributes.dll     \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/Xamarin.Mac-full.BindingAttributes.dll     \
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/Xamarin.Mac-mobile.BindingAttributes.dll     \
@@ -207,6 +209,10 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/bgen: | $(MAC_DESTDIR)$(MAC_FRAME
 	$(Q_GEN) printf "#!/bin/sh -e\n\nexec /Library/Frameworks/Mono.framework/Versions/Current/bin/mono64 --debug $(abspath $(MAC_TARGETDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/bgen.exe) \"\$$@\"\n" > $@
 	$(Q) chmod +x $@
 
+$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/bgen-classic: | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin
+	$(Q_GEN) printf "#!/bin/sh -e\n\nexec /Library/Frameworks/Mono.framework/Versions/Current/bin/mono64 --debug $(abspath $(MAC_TARGETDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/bgen-classic.exe) \"\$$@\"\n" > $@
+	$(Q) chmod +x $@
+
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/bmac: bmac.ikvm | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin
 	$(Q) install -m 0755 $< $@
 
@@ -215,6 +221,10 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/%.dll: $(MAC_BUILD_DIR)/%.dl
 	$(Q) install -m 0644 $<.mdb $@.mdb
 
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/%.exe: build/common/bgen.exe | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen
+	$(Q) install -m 0755 $< $@
+	$(Q) install -m 0644 $< $(@:.exe=.pdb)
+
+$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/bgen-classic.exe: $(MACIOS_BINARIES_PATH)/bgen.exe
 	$(Q) install -m 0755 $< $@
 	$(Q) install -m 0644 $< $(@:.exe=.pdb)
 

--- a/src/bmac.ikvm
+++ b/src/bmac.ikvm
@@ -13,6 +13,8 @@ fi
 
 ROOT_DIR=$BIN_DIR/..
 
+bgen_path=$BIN_DIR/bgen
+
 btouch_arguments=()
 for arg in "$@"; do
 	if [[ $sdk == next-arg ]]; then
@@ -41,6 +43,7 @@ sdk=$(echo $sdk | tr '[:upper:]' '[:lower:]')
 case $sdk in
 xammac)
 	refs="--target-framework=XamMac,v1.0"
+	bgen_path=$BIN_DIR/bgen-classic
 	;;
 mobile|xamarin.mac)
 	refs="--target-framework=Xamarin.Mac,Version=v2.0,Profile=Mobile"
@@ -60,4 +63,4 @@ mobile|xamarin.mac)
 	;;
 esac
 
-exec $BIN_DIR/bgen $refs "${btouch_arguments[@]}"
+exec $bgen_path $refs "${btouch_arguments[@]}"

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -352,6 +352,12 @@ namespace Xamarin.Tests
 			}
 		}
 
+		public static string BGenClassicPath {
+			get {
+				return Path.Combine (BinDirXM, "bgen-classic");
+			}
+		}
+
 		public static string MmpPath {
 			get {
 				return Path.Combine (BinDirXM, "mmp");

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -352,12 +352,6 @@ namespace Xamarin.Tests
 			}
 		}
 
-		public static string BGenClassicPath {
-			get {
-				return Path.Combine (BinDirXM, "bgen-classic");
-			}
-		}
-
 		public static string MmpPath {
 			get {
 				return Path.Combine (BinDirXM, "mmp");

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -17,7 +17,6 @@ namespace GeneratorTests
 	public class BGenTests
 	{
 		[Test]
-		[TestCase (Profile.macClassic)]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
 		public void BMac_Smoke (Profile profile)
@@ -26,7 +25,6 @@ namespace GeneratorTests
 		}
 
 		[Test]
-		[TestCase (Profile.macClassic)]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
 		public void BMac_With_Hyphen_In_Name (Profile profile)
@@ -35,7 +33,6 @@ namespace GeneratorTests
 		}
 
 		[Test]
-		[TestCase (Profile.macClassic)]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
 		public void PropertyRedefinitionMac (Profile profile)
@@ -44,7 +41,6 @@ namespace GeneratorTests
 		}
 
 		[Test]
-		[TestCase (Profile.macClassic)]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
 		public void NSApplicationPublicEnsureMethods (Profile profile)
@@ -53,7 +49,6 @@ namespace GeneratorTests
 		}
 
 		[Test]
-		[TestCase (Profile.macClassic)]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
 		public void ProtocolDuplicateAbstract (Profile profile)
@@ -159,7 +154,7 @@ namespace GeneratorTests
 		public void Bug31788 ()
 		{
 			var bgen = new BGenTool ();
-			bgen.Profile = Profile.macClassic;
+			bgen.Profile = Profile.macModern;
 			bgen.Defines = BGenTool.GetDefaultDefines (bgen.Profile);
 			bgen.CreateTemporaryBinding (File.ReadAllText (Path.Combine (Configuration.SourceRoot, "tests", "generator", "bug31788.cs")));
 			bgen.AssertExecute ("build");

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -17,6 +17,7 @@ namespace GeneratorTests
 	public class BGenTests
 	{
 		[Test]
+		[TestCase (Profile.macClassic)]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
 		public void BMac_Smoke (Profile profile)
@@ -25,6 +26,7 @@ namespace GeneratorTests
 		}
 
 		[Test]
+		[TestCase (Profile.macClassic)]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
 		public void BMac_With_Hyphen_In_Name (Profile profile)
@@ -33,6 +35,7 @@ namespace GeneratorTests
 		}
 
 		[Test]
+		[TestCase (Profile.macClassic)]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
 		public void PropertyRedefinitionMac (Profile profile)
@@ -41,6 +44,7 @@ namespace GeneratorTests
 		}
 
 		[Test]
+		[TestCase (Profile.macClassic)]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
 		public void NSApplicationPublicEnsureMethods (Profile profile)
@@ -49,6 +53,7 @@ namespace GeneratorTests
 		}
 
 		[Test]
+		[TestCase (Profile.macClassic)]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
 		public void ProtocolDuplicateAbstract (Profile profile)
@@ -151,10 +156,13 @@ namespace GeneratorTests
 		}
 
 		[Test]
-		public void Bug31788 ()
+		[TestCase (Profile.macClassic)]
+		[TestCase (Profile.macFull)]
+		[TestCase (Profile.macModern)]
+		public void Bug31788 (Profile profile)
 		{
 			var bgen = new BGenTool ();
-			bgen.Profile = Profile.macModern;
+			bgen.Profile = profile;
 			bgen.Defines = BGenTool.GetDefaultDefines (bgen.Profile);
 			bgen.CreateTemporaryBinding (File.ReadAllText (Path.Combine (Configuration.SourceRoot, "tests", "generator", "bug31788.cs")));
 			bgen.AssertExecute ("build");

--- a/tests/generator/BGenTool.cs
+++ b/tests/generator/BGenTool.cs
@@ -40,9 +40,9 @@ namespace Xamarin.Tests
 		public string WarnAsError; // Set to empty string to pass /warnaserror, set to non-empty string to pass /warnaserror:<nonemptystring>
 		public string NoWarn; // Set to empty string to pass /nowarn, set to non-empty string to pass /nowarn:<nonemptystring>
 
-		protected override string ToolPath { get { return Configuration.BGenPath; } }
+		protected override string ToolPath { get { return Profile == Profile.macClassic ? Configuration.BGenClassicPath : Configuration.BGenPath; } }
 		protected override string MessagePrefix { get { return "BI"; } }
-		protected override string MessageToolName { get { return "bgen"; } }
+		protected override string MessageToolName { get { return Profile == Profile.macClassic ? "bgen-classic" : "bgen"; } }
 
 		public BGenTool ()
 		{

--- a/tests/generator/BGenTool.cs
+++ b/tests/generator/BGenTool.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Tests
 		iOS,
 		tvOS,
 		watchOS,
+		macClassic,
 		macModern,
 		macFull,
 		macSystem,
@@ -39,9 +40,9 @@ namespace Xamarin.Tests
 		public string WarnAsError; // Set to empty string to pass /warnaserror, set to non-empty string to pass /warnaserror:<nonemptystring>
 		public string NoWarn; // Set to empty string to pass /nowarn, set to non-empty string to pass /nowarn:<nonemptystring>
 
-		protected override string ToolPath { get { return Configuration.BGenPath; } }
+		protected override string ToolPath { get { return Profile == Profile.macClassic ? Configuration.BGenClassicPath : Configuration.BGenPath; } }
 		protected override string MessagePrefix { get { return "BI"; } }
-		protected override string MessageToolName { get { return "bgen"; } }
+		protected override string MessageToolName { get { return Profile == Profile.macClassic ? "bgen-classic" : "bgen"; } }
 
 		public BGenTool ()
 		{
@@ -79,6 +80,9 @@ namespace Xamarin.Tests
 				break;
 			case Profile.watchOS:
 				targetFramework = "Xamarin.WatchOS,v1.0";
+				break;
+			case Profile.macClassic:
+				targetFramework = "XamMac,v1.0";
 				break;
 			case Profile.macFull:
 				targetFramework = "Xamarin.Mac,Version=v4.5,Profile=Full";
@@ -282,6 +286,8 @@ namespace Xamarin.Tests
 			case Profile.macModern:
 			case Profile.macSystem:
 				return new string [] { "MONOMAC", "XAMCORE_2_0" };
+			case Profile.macClassic:
+				return new string [] { "MONOMAC" };
 			case Profile.iOS:
 				return new string [] { "IOS", "XAMCORE_2_0" };
 			default:

--- a/tests/generator/BGenTool.cs
+++ b/tests/generator/BGenTool.cs
@@ -19,7 +19,6 @@ namespace Xamarin.Tests
 		iOS,
 		tvOS,
 		watchOS,
-		macClassic,
 		macModern,
 		macFull,
 		macSystem,
@@ -40,9 +39,9 @@ namespace Xamarin.Tests
 		public string WarnAsError; // Set to empty string to pass /warnaserror, set to non-empty string to pass /warnaserror:<nonemptystring>
 		public string NoWarn; // Set to empty string to pass /nowarn, set to non-empty string to pass /nowarn:<nonemptystring>
 
-		protected override string ToolPath { get { return Profile == Profile.macClassic ? Configuration.BGenClassicPath : Configuration.BGenPath; } }
+		protected override string ToolPath { get { return Configuration.BGenPath; } }
 		protected override string MessagePrefix { get { return "BI"; } }
-		protected override string MessageToolName { get { return Profile == Profile.macClassic ? "bgen-classic" : "bgen"; } }
+		protected override string MessageToolName { get { return "bgen"; } }
 
 		public BGenTool ()
 		{
@@ -80,9 +79,6 @@ namespace Xamarin.Tests
 				break;
 			case Profile.watchOS:
 				targetFramework = "Xamarin.WatchOS,v1.0";
-				break;
-			case Profile.macClassic:
-				targetFramework = "XamMac,v1.0";
 				break;
 			case Profile.macFull:
 				targetFramework = "Xamarin.Mac,Version=v4.5,Profile=Full";
@@ -286,8 +282,6 @@ namespace Xamarin.Tests
 			case Profile.macModern:
 			case Profile.macSystem:
 				return new string [] { "MONOMAC", "XAMCORE_2_0" };
-			case Profile.macClassic:
-				return new string [] { "MONOMAC" };
 			case Profile.iOS:
 				return new string [] { "IOS", "XAMCORE_2_0" };
 			default:

--- a/tests/generator/ErrorTests.cs
+++ b/tests/generator/ErrorTests.cs
@@ -35,7 +35,6 @@ namespace GeneratorTests
 		[Test]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
-		[TestCase (Profile.macClassic)]
 		public void BI1037 (Profile profile)
 		{
 			var bgen = new BGenTool ();
@@ -49,7 +48,6 @@ namespace GeneratorTests
 		[Test]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
-		[TestCase (Profile.macClassic)]
 		public void BI1038 (Profile profile)
 		{
 			var bgen = new BGenTool ();
@@ -63,7 +61,6 @@ namespace GeneratorTests
 		[Test]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
-		[TestCase (Profile.macClassic)]
 		public void BI1039 (Profile profile)
 		{
 			var bgen = new BGenTool ();
@@ -77,7 +74,6 @@ namespace GeneratorTests
 		[Test]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
-		[TestCase (Profile.macClassic)]
 		public void BI1040 (Profile profile)
 		{
 			var bgen = new BGenTool ();
@@ -91,7 +87,6 @@ namespace GeneratorTests
 		[Test]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
-		[TestCase (Profile.macClassic)]
 		public void BI1041 (Profile profile)
 		{
 			var bgen = new BGenTool ();
@@ -537,7 +532,8 @@ namespace BI1062Tests {
 
 		[Test]
 		[TestCase (Profile.iOS)]
-		[TestCase (Profile.macClassic)]
+		[TestCase (Profile.macModern)]
+		[TestCase (Profile.macFull)]
 		public void WarnAsError (Profile profile)
 		{
 			const string message = "The member 'SomeMethod' is decorated with [Static] and its container class warnaserrorTests.FooObject_Extensions is decorated with [Category] this leads to hard to use code. Please inline SomeMethod into warnaserrorTests.FooObject class.";
@@ -587,7 +583,8 @@ namespace BI1062Tests {
 
 		[Test]
 		[TestCase (Profile.iOS)]
-		[TestCase (Profile.macClassic)]
+		[TestCase (Profile.macModern)]
+		[TestCase (Profile.macFull)]
 		public void NoWarn (Profile profile)
 		{
 			const string message = "The member 'SomeMethod' is decorated with [Static] and its container class nowarnTests.FooObject_Extensions is decorated with [Category] this leads to hard to use code. Please inline SomeMethod into nowarnTests.FooObject class.";

--- a/tests/generator/ErrorTests.cs
+++ b/tests/generator/ErrorTests.cs
@@ -35,6 +35,7 @@ namespace GeneratorTests
 		[Test]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
+		[TestCase (Profile.macClassic)]
 		public void BI1037 (Profile profile)
 		{
 			var bgen = new BGenTool ();
@@ -48,6 +49,7 @@ namespace GeneratorTests
 		[Test]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
+		[TestCase (Profile.macClassic)]
 		public void BI1038 (Profile profile)
 		{
 			var bgen = new BGenTool ();
@@ -61,6 +63,7 @@ namespace GeneratorTests
 		[Test]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
+		[TestCase (Profile.macClassic)]
 		public void BI1039 (Profile profile)
 		{
 			var bgen = new BGenTool ();
@@ -74,6 +77,7 @@ namespace GeneratorTests
 		[Test]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
+		[TestCase (Profile.macClassic)]
 		public void BI1040 (Profile profile)
 		{
 			var bgen = new BGenTool ();
@@ -87,6 +91,7 @@ namespace GeneratorTests
 		[Test]
 		[TestCase (Profile.macFull)]
 		[TestCase (Profile.macModern)]
+		[TestCase (Profile.macClassic)]
 		public void BI1041 (Profile profile)
 		{
 			var bgen = new BGenTool ();
@@ -532,8 +537,8 @@ namespace BI1062Tests {
 
 		[Test]
 		[TestCase (Profile.iOS)]
-		[TestCase (Profile.macModern)]
 		[TestCase (Profile.macFull)]
+		[TestCase (Profile.macModern)]
 		public void WarnAsError (Profile profile)
 		{
 			const string message = "The member 'SomeMethod' is decorated with [Static] and its container class warnaserrorTests.FooObject_Extensions is decorated with [Category] this leads to hard to use code. Please inline SomeMethod into warnaserrorTests.FooObject class.";
@@ -583,8 +588,8 @@ namespace BI1062Tests {
 
 		[Test]
 		[TestCase (Profile.iOS)]
-		[TestCase (Profile.macModern)]
 		[TestCase (Profile.macFull)]
+		[TestCase (Profile.macModern)]
 		public void NoWarn (Profile profile)
 		{
 			const string message = "The member 'SomeMethod' is decorated with [Static] and its container class nowarnTests.FooObject_Extensions is decorated with [Category] this leads to hard to use code. Please inline SomeMethod into nowarnTests.FooObject class.";


### PR DESCRIPTION
Previous PMCS removal changes froze XamMac.BindingAttributes.dll but not bgen.exe which causes interesting issues when we make changes there and run classic XM tests.

This can be seen here: https://github.com/xamarin/xamarin-macios/pull/3147

This PR freezes bgen-classic in macios-binaries (which will need to be added to master and bumped before this goes in) and update various scripts/tests.

This causes two test failures

https://gist.github.com/chamons/07a2a1886e3a0b0e8764eb63b5f80fdf

since f8d7c54a0f99b4bced060b2a378b1c25a22363ae updated the wording in some tests about warnings and we're using the 15.5 bgen for classic.

I lean towards just disabling all XM classic tests in generator, since we're not rebuilding. Thoughts?

I smoke tested a few classic binding scenarios to mixed results. The ancient version of the binding example in mac-samples (before I updated it to use a binding project) doesn't build, but it didn't build before this change either (due to other unrelated paths we moved). After fixing up the invocation it works. We don't have a classic binding project to test.
  