### PR TITLE
[Vision] Removes incorrect [Abstract] from VNDetectBarcodesRequest

### DIFF
--- a/src/vision.cs
+++ b/src/vision.cs
@@ -153,7 +153,6 @@ namespace XamCore.Vision {
 	}
 
 	[TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
-	[Abstract]
 	[DisableDefaultCtor]
 	[BaseType (typeof (VNImageBasedRequest))]
 	interface VNDetectBarcodesRequest {


### PR DESCRIPTION
Fixes xamarin/xamarin-macios#3140

According to headers and documentation this should not be abstract.
This was incorrectly added by me in 89071bc19dafc2e7c0d714709866de8d90f35441
I could not find why this was added by checking headers nor I can
recall why I added it so I'll just say it was a honest mistake :) Oops... 🙈