### PR TITLE
[SceneKit] Workaround SCNAnimationEvent breaking change introduced in iOS 11

### DIFF
--- a/src/SceneKit/SCNCompat.cs
+++ b/src/SceneKit/SCNCompat.cs
@@ -5,8 +5,10 @@ using System.Threading.Tasks;
 using XamCore.Foundation;
 using XamCore.ObjCRuntime;
 
-#if !WATCH
-using XamCore.CoreAnimation;
+#if WATCH
+using AnimationType = global::XamCore.SceneKit.ISCNAnimationProtocol;
+#else
+using AnimationType = global::XamCore.CoreAnimation.CAAnimation;
 #endif
 
 namespace XamCore.SceneKit {
@@ -77,27 +79,21 @@ namespace XamCore.SceneKit {
 #endif
 #endif
 
-#if WATCH || XAMCORE_4_0
-	[Watch (4,0)]
-	[Mac (10,9), iOS (8,0)]
-	public delegate void SCNAnimationEventHandler (ISCNAnimationProtocol animation, NSObject animatedObject, bool playingBackward);
-#else
-	[Mac (10,9), iOS (8,0)]
-	public delegate void SCNAnimationEventHandler (CAAnimation animation, NSObject animatedObject, bool playingBackward);
-#endif
 
-	public partial class SCNAnimationEvent : NSObject {
+#if !XAMCORE_4_0
+	[Mac (10,9), iOS (8,0), Watch (4,0)]
+	public delegate void SCNAnimationEventHandler (AnimationType animation, NSObject animatedObject, bool playingBackward);
+
+	public partial class SCNAnimationEvent : NSObject
+	{
 		public static SCNAnimationEvent Create (nfloat keyTime, SCNAnimationEventHandler eventHandler)
 		{
 			var handler = new Action<IntPtr, NSObject, bool> ((animationPtr, animatedObject, playingBackward) => {
-#if WATCH || XAMCORE_4_0
-				var animation = Runtime.GetINativeObject<ISCNAnimationProtocol> (animationPtr, true);
-#else
-				var animation = Runtime.GetINativeObject<CAAnimation> (animationPtr, true);
-#endif
+				var animation = Runtime.GetINativeObject<AnimationType> (animationPtr, true);
 				eventHandler (animation, animatedObject, playingBackward);
 			});
 			return Create (keyTime, handler);
 		}
 	}
+#endif
 }

--- a/src/SceneKit/SCNCompat.cs
+++ b/src/SceneKit/SCNCompat.cs
@@ -5,6 +5,10 @@ using System.Threading.Tasks;
 using XamCore.Foundation;
 using XamCore.ObjCRuntime;
 
+#if !WATCH
+using XamCore.CoreAnimation;
+#endif
+
 namespace XamCore.SceneKit {
 
 #if !XAMCORE_3_0
@@ -72,4 +76,28 @@ namespace XamCore.SceneKit {
 	}
 #endif
 #endif
+
+#if WATCH || XAMCORE_4_0
+	[Watch (4,0)]
+	[Mac (10,9), iOS (8,0)]
+	public delegate void SCNAnimationEventHandler (ISCNAnimationProtocol animation, NSObject animatedObject, bool playingBackward);
+#else
+	[Mac (10,9), iOS (8,0)]
+	public delegate void SCNAnimationEventHandler (CAAnimation animation, NSObject animatedObject, bool playingBackward);
+#endif
+
+	public partial class SCNAnimationEvent : NSObject {
+		public static SCNAnimationEvent Create (nfloat keyTime, SCNAnimationEventHandler eventHandler)
+		{
+			var handler = new Action<IntPtr, NSObject, bool> ((animationPtr, animatedObject, playingBackward) => {
+#if WATCH || XAMCORE_4_0
+				var animation = Runtime.GetINativeObject<ISCNAnimationProtocol> (animationPtr, true);
+#else
+				var animation = Runtime.GetINativeObject<CAAnimation> (animationPtr, true);
+#endif
+				eventHandler (animation, animatedObject, playingBackward);
+			});
+			return Create (keyTime, handler);
+		}
+	}
 }

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -3362,22 +3362,15 @@ namespace XamCore.SceneKit {
 		bool RendersContinuously { get; set; }
 	}
 
-#if WATCH || XAMCORE_4_0
-	[Watch (4,0)]
-	[Mac (10,9), iOS (8,0)]
-	delegate void SCNAnimationEventHandler (ISCNAnimationProtocol animation, NSObject animatedObject, bool playingBackward);
-#else
-	[Mac (10,9), iOS (8,0)]
-	delegate void SCNAnimationEventHandler (CAAnimation animation, NSObject animatedObject, bool playingBackward);
-#endif
-
 	[Watch (4,0)]
 	[Mac (10,9), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface SCNAnimationEvent {
+
+		[Internal]
 		[Static, Export ("animationEventWithKeyTime:block:")]
-		SCNAnimationEvent Create (nfloat keyTime, SCNAnimationEventHandler eventHandler);
+		SCNAnimationEvent Create (nfloat keyTime, Action<IntPtr, NSObject, bool> handler);
 	}
 
 	[Watch (3,0)]

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -44,6 +44,12 @@ using XamCore.CoreAnimation;
 using XamCore.CoreImage;
 #endif
 
+#if WATCH || XAMCORE_4_0
+using AnimationType = global::XamCore.SceneKit.ISCNAnimationProtocol;
+#else
+using AnimationType = global::XamCore.CoreAnimation.CAAnimation;
+#endif
+
 using XamCore.CoreGraphics;
 using XamCore.SpriteKit;
 // MonoMac (classic) does not support those 64bits only frameworks
@@ -3362,15 +3368,25 @@ namespace XamCore.SceneKit {
 		bool RendersContinuously { get; set; }
 	}
 
+#if XAMCORE_4_0
+	[Mac (10,9), iOS (8,0), Watch (4,0)]
+	delegate void SCNAnimationEventHandler (AnimationType animation, NSObject animatedObject, bool playingBackward);
+#endif
+
 	[Watch (4,0)]
 	[Mac (10,9), iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface SCNAnimationEvent {
 
+#if XAMCORE_4_0
+		[Static, Export ("animationEventWithKeyTime:block:")]
+		SCNAnimationEvent Create (nfloat keyTime, SCNAnimationEventHandler handler);
+#else
 		[Internal]
 		[Static, Export ("animationEventWithKeyTime:block:")]
 		SCNAnimationEvent Create (nfloat keyTime, Action<IntPtr, NSObject, bool> handler);
+#endif
 	}
 
 	[Watch (3,0)]

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -3381,7 +3381,7 @@ namespace XamCore.SceneKit {
 
 #if XAMCORE_4_0
 		[Static, Export ("animationEventWithKeyTime:block:")]
-		SCNAnimationEvent Create (nfloat keyTime, SCNAnimationEventHandler handler);
+		SCNAnimationEvent Create (nfloat keyTime, SCNAnimationEventHandler eventHandler);
 #else
 		[Internal]
 		[Static, Export ("animationEventWithKeyTime:block:")]


### PR DESCRIPTION
Fixes xamarin/xamarin-macios#3146

This workarounds an Apple breaking change (since `SCNAnimation` protocol is new in iOS 11):

The Old definition was
> typedef void (^SCNAnimationEventBlock)(CAAnimation animation, id _Nonnull animatedObject, BOOL playingBackward)

The new ObjC definition is:
> typedef void (^SCNAnimationEventBlock)(id<SCNAnimation> animation, id animatedObject, BOOL playingBackward);

and it is bound as:
> delegate void SCNAnimationEventHandler (CAAnimation animation, NSObject animatedObject, bool playingBackward);

and for watchOS and XAMCORE_4_0 it is bound as:
> delegate void SCNAnimationEventHandler (ISCNAnimationProtocol animation, NSObject animatedObject, bool playingBackward);

Fortunatelly `CAAnimation` conforms to `SCNAnimation` protocol and
we are now abusing this fact and forcing its creation with `GetINativeObject`
this way we keep a single API and we can always completely fix this
when XAMCORE_4_0 happens following suit with apple's breaking change.