### PR TITLE
[Backport][SceneKit] Workaround SCNAnimationEvent breaking change introduced in iOS 11 (#3160)

### DIFF
--- a/src/SceneKit/SCNCompat.cs
+++ b/src/SceneKit/SCNCompat.cs
@@ -5,6 +5,12 @@ using System.Threading.Tasks;
 using XamCore.Foundation;
 using XamCore.ObjCRuntime;
 
+#if WATCH
+using AnimationType = global::XamCore.SceneKit.ISCNAnimationProtocol;
+#else
+using AnimationType = global::XamCore.CoreAnimation.CAAnimation;
+#endif
+
 namespace XamCore.SceneKit {
 
 #if !XAMCORE_3_0
@@ -71,5 +77,23 @@ namespace XamCore.SceneKit {
 		}
 	}
 #endif
+#endif
+
+
+#if !XAMCORE_4_0
+	[Mac (10,9), iOS (8,0), Watch (4,0)]
+	public delegate void SCNAnimationEventHandler (AnimationType animation, NSObject animatedObject, bool playingBackward);
+
+	public partial class SCNAnimationEvent : NSObject
+	{
+		public static SCNAnimationEvent Create (nfloat keyTime, SCNAnimationEventHandler eventHandler)
+		{
+			var handler = new Action<IntPtr, NSObject, bool> ((animationPtr, animatedObject, playingBackward) => {
+				var animation = Runtime.GetINativeObject<AnimationType> (animationPtr, true);
+				eventHandler (animation, animatedObject, playingBackward);
+			});
+			return Create (keyTime, handler);
+		}
+	}
 #endif
 }

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -44,6 +44,12 @@ using XamCore.CoreAnimation;
 using XamCore.CoreImage;
 #endif
 
+#if WATCH || XAMCORE_4_0
+using AnimationType = global::XamCore.SceneKit.ISCNAnimationProtocol;
+#else
+using AnimationType = global::XamCore.CoreAnimation.CAAnimation;
+#endif
+
 using XamCore.CoreGraphics;
 using XamCore.SpriteKit;
 // MonoMac (classic) does not support those 64bits only frameworks
@@ -3361,13 +3367,9 @@ namespace XamCore.SceneKit {
 		bool RendersContinuously { get; set; }
 	}
 
-#if WATCH || XAMCORE_4_0
-	[Watch (4,0)]
-	[Mac (10,9), iOS (8,0)]
-	delegate void SCNAnimationEventHandler (ISCNAnimationProtocol animation, NSObject animatedObject, bool playingBackward);
-#else
-	[Mac (10,9), iOS (8,0)]
-	delegate void SCNAnimationEventHandler (CAAnimation animation, NSObject animatedObject, bool playingBackward);
+#if XAMCORE_4_0
+	[Mac (10,9), iOS (8,0), Watch (4,0)]
+	delegate void SCNAnimationEventHandler (AnimationType animation, NSObject animatedObject, bool playingBackward);
 #endif
 
 	[Watch (4,0)]
@@ -3375,8 +3377,15 @@ namespace XamCore.SceneKit {
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface SCNAnimationEvent {
+
+#if XAMCORE_4_0
 		[Static, Export ("animationEventWithKeyTime:block:")]
 		SCNAnimationEvent Create (nfloat keyTime, SCNAnimationEventHandler eventHandler);
+#else
+		[Internal]
+		[Static, Export ("animationEventWithKeyTime:block:")]
+		SCNAnimationEvent Create (nfloat keyTime, Action<IntPtr, NSObject, bool> handler);
+#endif
 	}
 
 	[Watch (3,0)]


### PR DESCRIPTION
This fixes xamarin-macios#3145 and xamarin/xamarin-macios#3146

This workarounds an Apple breaking change (since `SCNAnimation` protocol is new in iOS 11):

The Old definition was
> typedef void (^SCNAnimationEventBlock)(CAAnimation animation, id _Nonnull animatedObject, BOOL playingBackward)

The new ObjC definition is:
> typedef void (^SCNAnimationEventBlock)(id<SCNAnimation> animation, id animatedObject, BOOL playingBackward);

and it is bound as:
> delegate void SCNAnimationEventHandler (CAAnimation animation, NSObject animatedObject, bool playingBackward);

and for watchOS and XAMCORE_4_0 it is bound as:
> delegate void SCNAnimationEventHandler (ISCNAnimationProtocol animation, NSObject animatedObject, bool playingBackward);

Fortunatelly `CAAnimation` conforms to `SCNAnimation` protocol and
we are now abusing this fact and forcing its creation with `GetINativeObject`
this way we keep a single API and we can always completely fix this
when XAMCORE_4_0 happens following suit with apple's breaking change.