### PR TITLE
[msbuild] Repack all iOS Task assemblies into Xamarin.iOS.Tasks.dll

### DIFF
--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -19,7 +19,6 @@ MSBUILD_PRODUCTS             =
 MSBUILD_DIRECTORIES          =
 MSBUILD_SYMLINKS             =
 MSBUILD_TASK_ASSEMBLIES      =
-MSBUILD_REFERENCE_ASSEMBLIES =
 
 ALL_SOURCES = $(wildcard $(TOP)/msbuild/*/*.cs) $(wildcard $(TOP)/msbuild/*/*/*.cs) $(wildcard $(TOP)/msbuild/*/*/*/*.cs) *.sln $(wildcard */*.csproj) $(wildcard */packages.config)
 CONFIG      = Debug
@@ -35,14 +34,7 @@ IOS_TARGETS =                                                      \
 
 IOS_BINDING_TARGETS = $(wildcard Xamarin.ObjcBinding.Tasks/*.targets)
 
-IOS_TASK_ASSEMBLIES =         \
-	Xamarin.iOS.Tasks         \
-	Xamarin.iOS.Tasks.Core    \
-	Xamarin.MacDev.Tasks      \
-	Xamarin.MacDev.Tasks.Core \
-
-IOS_TASK_REFERENCE_ASSEMBLIES =	\
-	Xamarin.MacDev
+IOS_TASK_ASSEMBLIES = Xamarin.iOS.Tasks
 
 IOS_DIRECTORIES =                                                                                           \
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.iOS                                                  \
@@ -65,7 +57,6 @@ IOS_PRODUCTS =                                                                  
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/msbuild/iOS/FrameworkList.xml                                                       \
 	$(foreach target,$(IOS_TARGETS)               ,$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/msbuild/iOS/$(notdir $(target)))     \
 	$(foreach target,$(IOS_BINDING_TARGETS)       ,$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/msbuild/iOS/$(notdir $(target)))     \
-	$(foreach dll,$(IOS_TASK_REFERENCE_ASSEMBLIES),$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/msbuild/iOS/$(dll).dll)              \
 	$(foreach dll,$(IOS_TASK_ASSEMBLIES)          ,$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/msbuild/iOS/$(dll).dll)              \
 	$(IOS_SYMLINKS)
 
@@ -77,7 +68,6 @@ MSBUILD_PRODUCTS += all-ios
 MSBUILD_DIRECTORIES += $(IOS_DIRECTORIES)
 MSBUILD_SYMLINKS += symlinks-ios
 MSBUILD_TASK_ASSEMBLIES += $(IOS_TASK_ASSEMBLIES)
-MSBUILD_REFERENCE_ASSEMBLIES += $(IOS_TASK_REFERENCE_ASSEMBLIES)
 endif
 
 ##
@@ -156,16 +146,9 @@ endif
 MAC_TARGETS = $(wildcard Xamarin.Mac.Tasks/*.props) $(wildcard Xamarin.Mac.Tasks/*.targets)
 MAC_BINDING_TARGETS =
 
-MAC_TASK_ASSEMBLIES =         \
-	Xamarin.Mac.Tasks         \
-	Xamarin.Mac.Tasks.Core    \
-	Xamarin.MacDev.Tasks      \
-	Xamarin.MacDev.Tasks.Core \
+MAC_TASK_ASSEMBLIES = Xamarin.Mac.Tasks
 
 MAC_BINDING_TASK_ASSEMBLIES = 
-
-MAC_TASK_REFERENCE_ASSEMBLIES =	\
-	Xamarin.MacDev
 
 MAC_DIRECTORIES =                                                                                           \
 	$(MAC_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac                            \
@@ -178,7 +161,6 @@ MAC_SYMLINKS =                                                                  
 	$(MAC_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild-frameworks/Xamarin.Mac/v2.0/RedistList/FrameworkList.xml                        \
 	$(foreach target,$(MAC_TARGETS)               ,$(MAC_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/$(notdir $(target))) \
 	$(foreach target,$(MAC_BINDING_TARGETS)       ,$(MAC_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/$(notdir $(target))) \
-	$(foreach dll,$(MAC_TASK_REFERENCE_ASSEMBLIES),$(MAC_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/$(dll).dll)          \
 	$(foreach dll,$(MAC_TASK_ASSEMBLIES)          ,$(MAC_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/$(dll).dll)          \
 	$(foreach dll,$(MAC_BINDING_TASK_ASSEMBLIES)  ,$(MAC_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/$(dll).dll)          \
 
@@ -188,7 +170,6 @@ MAC_PRODUCTS =                                                                  
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/etc/mono/4.5/machine.config                                                     \
 	$(foreach target,$(MAC_TARGETS)               ,$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/msbuild/$(notdir $(target))) \
 	$(foreach target,$(MAC_BINDING_TARGETS)       ,$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/msbuild/$(notdir $(target))) \
-	$(foreach dll,$(MAC_TASK_REFERENCE_ASSEMBLIES),$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/msbuild/$(dll).dll)          \
 	$(foreach dll,$(MAC_TASK_ASSEMBLIES)          ,$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/msbuild/$(dll).dll)          \
 	$(foreach dll,$(MAC_BINDING_TASK_ASSEMBLIES)  ,$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/msbuild/$(dll).dll)          \
 	$(MAC_SYMLINKS)                                                                                                            \
@@ -201,7 +182,6 @@ MSBUILD_PRODUCTS += all-mac
 MSBUILD_DIRECTORIES += $(MAC_DIRECTORIES)
 MSBUILD_SYMLINKS += symlinks-mac
 MSBUILD_TASK_ASSEMBLIES += $(MAC_TASK_ASSEMBLIES) $(MAC_BINDING_TASK_ASSEMBLIES)
-MSBUILD_REFERENCE_ASSEMBLIES += $(MAC_TASK_REFERENCE_ASSEMBLIES)
 endif
 
 ##
@@ -316,7 +296,7 @@ all-local:: $(MSBUILD_PRODUCTS) .stamp-test-xml
 
 .build-stamp: $(ALL_SOURCES)
 	$(Q) $(SYSTEM_MONO) /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore
-	$(Q) $(SYSTEM_XBUILD) $(XBUILD_VERBOSITY)
+	$(Q) $(SYSTEM_MSBUILD) $(XBUILD_VERBOSITY)
 	$(Q) touch $@
 
 # make all the target assemblies build when any of the sources have changed
@@ -324,11 +304,6 @@ $(foreach dll,$(MSBUILD_TASK_ASSEMBLIES),$(dll)/bin/$(CONFIG)/$(dll).dll): .buil
 
 # Always remake the symlinks
 .PHONY: $(MSBUILD_SYMLINKS)
-
-# Xamarin.MacDev.dll comes from the Xamarin.MacDev repository
-# Newtonsoft.Json.dll comes from a NuGet
-$(foreach dll,$(sort $(MSBUILD_REFERENCE_ASSEMBLIES)),build/$(notdir $(dll)).dll): .build-stamp | build
-	$(Q) cp Xamarin.MacDev.Tasks.Core/bin/$(CONFIG)/$(notdir $@) $@
 
 define copyToBuild
 build/$(1).dll: $(1)/bin/$(CONFIG)/$(1).dll | build
@@ -353,4 +328,4 @@ install-local:: $(MSBUILD_PRODUCTS)
 
 # make will automatically consider files created in chained implicit rules as temporary files, and delete them afterwards
 # marking those files as .SECONDARY will prevent that deletion.
-.SECONDARY: $(foreach file,$(MSBUILD_TASK_ASSEMBLIES) $(MSBUILD_REFERENCE_ASSEMBLIES),unbuild/$(file).dll) $(foreach file,$(MSBUILD_TASK_ASSEMBLIES) $(MSBUILD_REFERENCE_ASSEMBLIES),build/$(file).dll)
+.SECONDARY: $(foreach file,$(MSBUILD_TASK_ASSEMBLIES),unbuild/$(file).dll) $(foreach file,$(MSBUILD_TASK_ASSEMBLIES),build/$(file).dll)

--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // MmpTask.cs
 //
 // Author:
@@ -98,7 +98,7 @@ namespace Xamarin.Mac.Tasks
 
 		protected override string GenerateCommandLineCommands ()
 		{
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 			bool msym;
 
 			args.Add ("/verbose");
@@ -224,7 +224,7 @@ namespace Xamarin.Mac.Tasks
 		string GetMonoBundleDirName ()
 		{
 			if (!string.IsNullOrEmpty (ExtraArguments)) {
-				var args = ProcessArgumentBuilder.Parse (ExtraArguments);
+				var args = CommandLineArgumentBuilder.Parse (ExtraArguments);
 
 				for (int i = 0; i < args.Length; i++) {
 					string arg;

--- a/msbuild/Xamarin.Mac.Tasks/Tasks/CodesignVerify.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/CodesignVerify.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Mac.Tasks
 	{
 		protected override string GenerateCommandLineCommands ()
 		{
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			args.Add ("--verify");
 			args.Add ("-vvvv");

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -15,17 +15,17 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.ArTool" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.Codesign" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.CollectBundleResources" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.CreateInstallerPackage" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.CreatePkgInfo" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.Ditto" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.FindItemWithLogicalName" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.PackLibraryResources" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.PropertyListEditor" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.SmartCopy" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.UnpackLibraryResources" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.ArTool" AssemblyFile="Xamarin.Mac.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Codesign" AssemblyFile="Xamarin.Mac.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.CollectBundleResources" AssemblyFile="Xamarin.Mac.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.CreateInstallerPackage" AssemblyFile="Xamarin.Mac.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.CreatePkgInfo" AssemblyFile="Xamarin.Mac.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Ditto" AssemblyFile="Xamarin.Mac.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.FindItemWithLogicalName" AssemblyFile="Xamarin.Mac.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.PackLibraryResources" AssemblyFile="Xamarin.Mac.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.PropertyListEditor" AssemblyFile="Xamarin.Mac.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.SmartCopy" AssemblyFile="Xamarin.Mac.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.UnpackLibraryResources" AssemblyFile="Xamarin.Mac.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.Mac.Tasks.ACTool" AssemblyFile="Xamarin.Mac.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.Mac.Tasks.CodesignVerify" AssemblyFile="Xamarin.Mac.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.Mac.Tasks.CompileAppManifest" AssemblyFile="Xamarin.Mac.Tasks.dll" />
@@ -40,19 +40,19 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<UsingTask TaskName="Xamarin.Mac.Tasks.Mmp" AssemblyFile="Xamarin.Mac.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.Mac.Tasks.ScnTool" AssemblyFile="Xamarin.Mac.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.Mac.Tasks.TextureAtlas" AssemblyFile="Xamarin.Mac.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.GenerateBundleName" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetNativeExecutableName" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetPropertyListValue" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.SymbolStrip" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.Zip" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.GenerateBundleName" AssemblyFile="Xamarin.Mac.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetNativeExecutableName" AssemblyFile="Xamarin.Mac.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetPropertyListValue" AssemblyFile="Xamarin.Mac.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.SymbolStrip" AssemblyFile="Xamarin.Mac.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Zip" AssemblyFile="Xamarin.Mac.Tasks.dll" />
 
-	<UsingTask TaskName="Microsoft.Build.Tasks.Copy" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
-	<UsingTask TaskName="Microsoft.Build.Tasks.Delete" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
-	<UsingTask TaskName="Microsoft.Build.Tasks.Exec" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
-	<UsingTask TaskName="Microsoft.Build.Tasks.MakeDir" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
-	<UsingTask TaskName="Microsoft.Build.Tasks.Move" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Microsoft.Build.Tasks.RemoveDir" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
-	<UsingTask TaskName="Microsoft.Build.Tasks.Touch" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.Copy" AssemblyFile="Xamarin.Mac.Tasks.dll"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.Delete" AssemblyFile="Xamarin.Mac.Tasks.dll"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.Exec" AssemblyFile="Xamarin.Mac.Tasks.dll"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.MakeDir" AssemblyFile="Xamarin.Mac.Tasks.dll"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.Move" AssemblyFile="Xamarin.Mac.Tasks.dll" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.RemoveDir" AssemblyFile="Xamarin.Mac.Tasks.dll"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.Touch" AssemblyFile="Xamarin.Mac.Tasks.dll"/>
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.Common.props"
 			Condition="'$(_XamarinCommonPropsHasBeenImported)' != 'true'" />

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -16,10 +16,10 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<UsingTask TaskName="Xamarin.Mac.Tasks.BTouch" AssemblyFile="Xamarin.Mac.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.Zip" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Zip" AssemblyFile="Xamarin.Mac.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.Mac.Tasks.PrepareNativeReferences" AssemblyFile="Xamarin.Mac.Tasks.dll" />
 
-	<UsingTask TaskName="Microsoft.Build.Tasks.Delete" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.Delete" AssemblyFile="Xamarin.Mac.Tasks.dll"/>
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.targets
@@ -15,9 +15,9 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.CollectBundleResources" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.CollectBundleResources" AssemblyFile="Xamarin.Mac.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.Mac.Tasks.CreateEmbeddedResources" AssemblyFile="Xamarin.Mac.Tasks.dll" />
-	<UsingTask TaskName="Microsoft.Build.Tasks.RemoveDir" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.RemoveDir" AssemblyFile="Xamarin.Mac.Tasks.dll"/>
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.ObjCBinding.Common.props" 
 			Condition="'$(_XamarinCommonPropsHasBeenImported)' != 'true'" />

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -29,7 +29,6 @@
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.Build.Tasks.v4.0" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Compile Include="Tasks\ACTool.cs" />
     <Compile Include="Tasks\BTouch.cs" />
@@ -111,5 +110,39 @@
     <None Include="Xamarin.Mac.AppExtension.Common.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\ILRepack.2.0.13\build\ILRepack.props" Condition="Exists('..\..\packages\ILRepack.2.0.13\build\ILRepack.props')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Target Name="ILRepack" AfterTargets="CoreCompile" DependsOnTargets="CoreCompile" Inputs="@(IntermediateAssembly -> '%(FullPath)')" Outputs="$(IntermediateOutputPath)ilrepack.txt" Returns="@(MergedAssemblies)" Condition="Exists(@(IntermediateAssembly -> '%(FullPath)')) And '$(ILRepack)' != 'false'">
+    <GetReferenceAssemblyPaths BypassFrameworkInstallChecks="False" TargetFrameworkMoniker="$(TargetFrameworkMoniker)">
+      <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FullFrameworkReferenceAssemblyPaths" />
+    </GetReferenceAssemblyPaths>
+    <ItemGroup>
+      <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('Xamarin')) And '%(Extension)' == '.dll'" />
+      <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('Mono')) And '%(Extension)' == '.dll'" />
+      <ReferenceCopyLocalDirs Include="@(ReferenceCopyLocalPaths -> '%(RootDir)%(Directory)')" />
+      <ReferenceCopyLocalPaths Remove="@(MergedAssemblies)" />
+      <LibDir Include="@(ReferenceCopyLocalDirs -> Distinct())" />
+    </ItemGroup>
+    <PropertyGroup>
+      <ILRepackArgs Condition="'$(AssemblyOriginatorKeyFile)' != ''">/keyfile:"$(AssemblyOriginatorKeyFile)"</ILRepackArgs>
+    </PropertyGroup>
+    <Exec Command="&quot;$(ILRepack)&quot; @(LibDir -> '/lib:&quot;%(Identity).&quot;', ' ') $(ILRepackArgs) /out:&quot;@(IntermediateAssembly -> '%(FullPath)')&quot; &quot;@(IntermediateAssembly -> '%(FullPath)')&quot; @(MergedAssemblies -> '&quot;%(FullPath)&quot;', ' ')" WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)" StandardErrorImportance="high" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="ILRepackOutput" />
+      <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
+    </Exec>
+    <Touch AlwaysCreate="true" Files="$(IntermediateOutputPath)ilrepack.txt" />
+    <Message Importance="high" Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0'" />
+    <Delete Files="$(IntermediateOutputPath)ilrepack.txt" Condition="'$(ExitCode)' != '0'" />
+    <Error Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0' And '$(ContinueOnError)' != 'true'" />
+    <Delete Files="@(MergedAssemblies -> '$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" />
+  </Target>
 </Project>

--- a/msbuild/Xamarin.Mac.Tasks/packages.config
+++ b/msbuild/Xamarin.Mac.Tasks/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="ILRepack" version="2.0.13" targetFramework="net45" />
+</packages>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/CommandLineArgumentBuilder.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/CommandLineArgumentBuilder.cs
@@ -7,7 +7,7 @@ namespace Xamarin.MacDev
 	/// <summary>
 	/// Builds a process argument string.
 	/// </summary>
-	public class ProcessArgumentBuilder
+	public class CommandLineArgumentBuilder
 	{
 		static readonly char[] QuoteSpecials = new char[] { ' ', '\\', '\'', '"', ',', ';' };
 
@@ -18,11 +18,11 @@ namespace Xamarin.MacDev
 			get; private set;
 		}
 
-		public ProcessArgumentBuilder ()
+		public CommandLineArgumentBuilder ()
 		{
 		}
 
-		public ProcessArgumentBuilder (string processPath)
+		public CommandLineArgumentBuilder (string processPath)
 		{
 			ProcessPath = processPath;
 		}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ACToolTaskBase.cs
@@ -83,7 +83,7 @@ namespace Xamarin.MacDev.Tasks
 			return id.Value == "com.apple.message-payload-provider";
 		}
 
-		protected override void AppendCommandLineArguments (IDictionary<string, string> environment, ProcessArgumentBuilder args, ITaskItem[] items)
+		protected override void AppendCommandLineArguments (IDictionary<string, string> environment, CommandLineArgumentBuilder args, ITaskItem[] items)
 		{
 			string minimumDeploymentTarget;
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ArToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ArToolTaskBase.cs
@@ -38,7 +38,7 @@ namespace Xamarin.MacDev.Tasks
 
 		protected override string GenerateCommandLineCommands ()
 		{
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			args.Add ("-r");
 			args.AddQuoted (Archive.ItemSpec);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ArchiveTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ArchiveTaskBase.cs
@@ -86,7 +86,7 @@ namespace Xamarin.MacDev.Tasks
 
 		protected static int Ditto (string source, string destination)
 		{
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			args.Add ("-rsrc");
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
@@ -194,7 +194,7 @@ namespace Xamarin.MacDev.Tasks {
 			cmd.AppendSwitch (GetTargetFrameworkArgument ());
 
 			if (!string.IsNullOrEmpty (ExtraArgs)) {
-				var extraArgs = ProcessArgumentBuilder.Parse (ExtraArgs);
+				var extraArgs = CommandLineArgumentBuilder.Parse (ExtraArgs);
 				var target = OutputAssembly;
 				string projectDir;
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
@@ -74,7 +74,7 @@ namespace Xamarin.MacDev.Tasks
 
 		string GenerateCommandLineArguments (ITaskItem item)
 		{
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			args.Add ("-v");
 			args.Add ("--force");

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignVerifyTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignVerifyTaskBase.cs
@@ -40,7 +40,7 @@ namespace Xamarin.MacDev.Tasks
 		// Note: Xamarin.Mac and Xamarin.iOS should both override this method to do pass platform-specific verify rules
 		protected override string GenerateCommandLineCommands ()
 		{
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			args.Add ("--verify");
 			args.Add ("-vvvv");

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
@@ -96,7 +96,7 @@ namespace Xamarin.MacDev.Tasks
 		int CopySceneKitAssets (string scnassets, string output, string intermediate)
 		{
 			var environment = new Dictionary<string, string> ();
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			environment.Add ("PATH", DeveloperRootBinDir);
 			environment.Add ("DEVELOPER_DIR", SdkDevPath);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CoreMLCompilerTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CoreMLCompilerTaskBase.cs
@@ -90,7 +90,7 @@ namespace Xamarin.MacDev.Tasks
 		int Compile (ITaskItem item, string outputDir, string log, string partialPlist)
 		{
 			var environment = new Dictionary<string, string> ();
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			args.Add ("compile");
 			args.AddQuoted (item.ItemSpec);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateInstallerPackageTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CreateInstallerPackageTaskBase.cs
@@ -85,7 +85,7 @@ namespace Xamarin.MacDev.Tasks
 		{
 			Log.LogMessage ("Creating installer package");
 
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			if (!string.IsNullOrEmpty(ProductDefinition)) {
 				args.Add ("--product");
@@ -116,11 +116,11 @@ namespace Xamarin.MacDev.Tasks
 			return args.ToString ();
 		}
 
-		void AppendExtraArgs (ProcessArgumentBuilder args, string extraArgs)
+		void AppendExtraArgs (CommandLineArgumentBuilder args, string extraArgs)
 		{
 			var target = this.MainAssembly.ItemSpec;
 
-			string[] argv = ProcessArgumentBuilder.Parse (extraArgs);
+			string[] argv = CommandLineArgumentBuilder.Parse (extraArgs);
 			var customTags = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase) {
 				{ "projectdir",   Path.GetDirectoryName (this.ProjectPath) },
 			// Apparently msbuild doesn't propagate the solution path, so we can't get it. - MTouchTaskBase.cs

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DittoTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DittoTaskBase.cs
@@ -37,7 +37,7 @@ namespace Xamarin.MacDev.Tasks
 
 		protected override string GenerateCommandLineCommands ()
 		{
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			args.Add ("-rsrc");
 

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IBToolTaskBase.cs
@@ -49,7 +49,7 @@ namespace Xamarin.MacDev.Tasks
 			get { return AppleSdkSettings.XcodeVersion.Major > 7 || (AppleSdkSettings.XcodeVersion.Major == 7 && AppleSdkSettings.XcodeVersion.Minor >= 2); }
 		}
 
-		protected override void AppendCommandLineArguments (IDictionary<string, string> environment, ProcessArgumentBuilder args, ITaskItem[] items)
+		protected override void AppendCommandLineArguments (IDictionary<string, string> environment, CommandLineArgumentBuilder args, ITaskItem[] items)
 		{
 			environment.Add ("IBSC_MINIMUM_COMPATIBILITY_VERSION", minimumDeploymentTarget);
 			environment.Add ("IBC_MINIMUM_COMPATIBILITY_VERSION", minimumDeploymentTarget);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalLibTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalLibTaskBase.cs
@@ -45,7 +45,7 @@ namespace Xamarin.MacDev.Tasks
 
 		protected override string GenerateCommandLineCommands ()
 		{
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			args.Add ("-o");
 			args.AddQuoted (OutputLibrary);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/MetalTaskBase.cs
@@ -63,7 +63,7 @@ namespace Xamarin.MacDev.Tasks
 			var intermediate = Path.Combine (IntermediateOutputPath, ToolName);
 			var logicalName = BundleResource.GetLogicalName (ProjectDir, prefixes, SourceFile, !string.IsNullOrEmpty(SessionId));
 			var path = Path.Combine (intermediate, logicalName);
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 			var dir = Path.GetDirectoryName (path);
 
 			if (!Directory.Exists (dir))

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ScnToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ScnToolTaskBase.cs
@@ -87,7 +87,7 @@ namespace Xamarin.MacDev.Tasks
 
 		protected override string GenerateCommandLineCommands ()
 		{
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			args.Add ("--compress");
 			args.AddQuoted (InputScene);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeCompilerToolTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeCompilerToolTask.cs
@@ -98,7 +98,7 @@ namespace Xamarin.MacDev.Tasks
 			yield break;
 		}
 
-		protected abstract void AppendCommandLineArguments (IDictionary<string, string> environment, ProcessArgumentBuilder args, ITaskItem[] items);
+		protected abstract void AppendCommandLineArguments (IDictionary<string, string> environment, CommandLineArgumentBuilder args, ITaskItem[] items);
 
 		string GetFullPathToTool ()
 		{
@@ -127,7 +127,7 @@ namespace Xamarin.MacDev.Tasks
 		protected int Compile (ITaskItem[] items, string output, ITaskItem manifest)
 		{
 			var environment = new Dictionary<string, string> ();
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			if (!string.IsNullOrEmpty (SdkBinPath))
 				environment.Add ("PATH", SdkBinPath);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ZipTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ZipTaskBase.cs
@@ -49,7 +49,7 @@ namespace Xamarin.MacDev.Tasks
 
 		protected override string GenerateCommandLineCommands ()
 		{
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			if (Recursive)
 				args.Add ("-r");

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -107,13 +107,13 @@
     <Compile Include="Tasks\ZipTaskBase.cs" />
     <Compile Include="AssetPackUtils.cs" />
     <Compile Include="BundleResource.cs" />
+    <Compile Include="CommandLineArgumentBuilder.cs" />
     <Compile Include="DataConverter.cs" />
     <Compile Include="LinkTarget.cs" />
     <Compile Include="LoggingExtensions.cs" />
     <Compile Include="NativeReferenceKind.cs" />
     <Compile Include="PathUtils.cs" />
     <Compile Include="PlatformFramework.cs" />
-    <Compile Include="ProcessArgumentBuilder.cs" />
     <Compile Include="ProcessUtils.cs" />
     <Compile Include="StringParserService.cs" />
   </ItemGroup>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Properties/AssemblyInfo.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Properties/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Xamarin.iOS.Tasks.Tests")]

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CodesignNativeLibrariesTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CodesignNativeLibrariesTaskBase.cs
@@ -75,7 +75,7 @@ namespace Xamarin.iOS.Tasks
 
 		string GenerateCommandLineArguments (string dylib)
 		{
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			args.Add ("-v");
 			args.Add ("--force");

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CodesignVerifyTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CodesignVerifyTaskBase.cs
@@ -6,7 +6,7 @@ namespace Xamarin.iOS.Tasks
 	{
 		protected override string GenerateCommandLineCommands ()
 		{
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			args.Add ("--verify");
 			args.Add ("-vvvv");

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CreateAssetPackTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CreateAssetPackTaskBase.cs
@@ -42,7 +42,7 @@ namespace Xamarin.iOS.Tasks
 
 		protected override string GenerateCommandLineCommands ()
 		{
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			args.Add ("-r", "-y");
 			args.AddQuoted (OutputFile.GetMetadata ("FullPath"));

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -40,14 +40,14 @@ namespace Xamarin.iOS.Tasks
 	{
 		class GccOptions
 		{
-			public ProcessArgumentBuilder Arguments { get; private set; }
+			public CommandLineArgumentBuilder Arguments { get; private set; }
 			public HashSet<string> WeakFrameworks { get; private set; }
 			public HashSet<string> Frameworks { get; private set; }
 			public bool Cxx { get; set; }
 
 			public GccOptions ()
 			{
-				Arguments = new ProcessArgumentBuilder ();
+				Arguments = new CommandLineArgumentBuilder ();
 				WeakFrameworks = new HashSet<string> ();
 				Frameworks = new HashSet<string> ();
 			}
@@ -282,7 +282,7 @@ namespace Xamarin.iOS.Tasks
 				// Note: these get merged into gccArgs by our caller
 				value = item.GetMetadata ("LinkerFlags");
 				if (!string.IsNullOrEmpty (value)) {
-					var linkerFlags = ProcessArgumentBuilder.Parse (value);
+					var linkerFlags = CommandLineArgumentBuilder.Parse (value);
 
 					foreach (var flag in linkerFlags)
 						gcc.Arguments.AddQuoted (flag);
@@ -353,7 +353,7 @@ namespace Xamarin.iOS.Tasks
 
 		protected override string GenerateCommandLineCommands ()
 		{
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 			TargetArchitecture architectures;
 			bool msym;
 
@@ -495,7 +495,7 @@ namespace Xamarin.iOS.Tasks
 			var gcc = new GccOptions ();
 
 			if (!string.IsNullOrEmpty (ExtraArgs)) {
-				var extraArgs = ProcessArgumentBuilder.Parse (ExtraArgs);
+				var extraArgs = CommandLineArgumentBuilder.Parse (ExtraArgs);
 				var target = MainAssembly.ItemSpec;
 				string projectDir;
 
@@ -544,7 +544,7 @@ namespace Xamarin.iOS.Tasks
 						}
 
 						if (!string.IsNullOrEmpty (flags)) {
-							var gccArgs = ProcessArgumentBuilder.Parse (flags);
+							var gccArgs = CommandLineArgumentBuilder.Parse (flags);
 
 							for (int j = 0; j < gccArgs.Length; j++)
 								gcc.Arguments.Add (StringParserService.Parse (gccArgs[j], customTags));

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ParseExtraMtouchArgsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ParseExtraMtouchArgsTaskBase.cs
@@ -29,7 +29,7 @@ namespace Xamarin.iOS.Tasks
 				NoDSymUtil = "false";
 
 			if (!string.IsNullOrEmpty (ExtraArgs)) {
-				var args = ProcessArgumentBuilder.Parse (ExtraArgs);
+				var args = CommandLineArgumentBuilder.Parse (ExtraArgs);
 
 				for (int i = 0; i < args.Length; i++) {
 					string arg;

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.ObjCBinding.CSharp.targets
@@ -16,7 +16,7 @@ Copyright (C) 2015-2016 Xamarin Inc. All rights reserved.
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<UsingTask TaskName="Xamarin.iOS.Tasks.BTouch" AssemblyFile="..\iOS\Xamarin.iOS.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.Zip" AssemblyFile="..\iOS\Xamarin.MacDev.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Zip" AssemblyFile="..\iOS\Xamarin.iOS.Tasks.dll" />
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.ObjCBinding.CSharp.targets
@@ -16,7 +16,7 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<UsingTask TaskName="Xamarin.iOS.Tasks.BTouch" AssemblyFile="$(MSBuildThisFileDirectory)..\iOS\Xamarin.iOS.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.Zip" AssemblyFile="$(MSBuildThisFileDirectory)..\iOS\Xamarin.MacDev.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Zip" AssemblyFile="$(MSBuildThisFileDirectory)..\iOS\Xamarin.iOS.Tasks.dll" />
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -15,28 +15,28 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.ArTool" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.Codesign" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.CollectBundleResources" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.ComputeBundleResourceOutputPaths" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.CoreMLCompiler" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.CreateAssetPackManifest" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.CreatePkgInfo" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.Ditto" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.DSymUtil" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.FindItemWithLogicalName" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.GenerateBundleName" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetNativeExecutableName" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetPropertyListValue" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.PackLibraryResources" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.PropertyListEditor" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.ReadItemsFromFile" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.SmartCopy" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.SpotlightIndexer" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.SymbolStrip" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.UnpackLibraryResources" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.WriteItemsToFile" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.Zip" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.ArTool" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Codesign" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.CollectBundleResources" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.ComputeBundleResourceOutputPaths" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.MacDev.Tasks.CoreMLCompiler" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.CreateAssetPackManifest" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.CreatePkgInfo" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Ditto" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.DSymUtil" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.FindItemWithLogicalName" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.GenerateBundleName" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetNativeExecutableName" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetPropertyListValue" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.PackLibraryResources" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.PropertyListEditor" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.ReadItemsFromFile" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.SmartCopy" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.SpotlightIndexer" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.SymbolStrip" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.UnpackLibraryResources" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.WriteItemsToFile" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Zip" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 
 	<UsingTask TaskName="Xamarin.iOS.Tasks.ACTool" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.iOS.Tasks.Archive" AssemblyFile="Xamarin.iOS.Tasks.dll" />
@@ -76,13 +76,13 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<UsingTask TaskName="Xamarin.iOS.Tasks.ValidateAppBundleTask" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.iOS.Tasks.WriteAssetPackManifest" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 
-	<UsingTask TaskName="Microsoft.Build.Tasks.Copy" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
-	<UsingTask TaskName="Microsoft.Build.Tasks.Delete" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
-	<UsingTask TaskName="Microsoft.Build.Tasks.Exec" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
-	<UsingTask TaskName="Microsoft.Build.Tasks.MakeDir" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
-	<UsingTask TaskName="Microsoft.Build.Tasks.Move" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
-	<UsingTask TaskName="Microsoft.Build.Tasks.RemoveDir" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
-	<UsingTask TaskName="Microsoft.Build.Tasks.Touch" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.Copy" AssemblyFile="Xamarin.iOS.Tasks.dll"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.Delete" AssemblyFile="Xamarin.iOS.Tasks.dll"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.Exec" AssemblyFile="Xamarin.iOS.Tasks.dll"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.MakeDir" AssemblyFile="Xamarin.iOS.Tasks.dll"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.Move" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.RemoveDir" AssemblyFile="Xamarin.iOS.Tasks.dll"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.Touch" AssemblyFile="Xamarin.iOS.Tasks.dll"/>
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.Common.props" 
 			Condition="'$(_XamarinCommonPropsHasBeenImported)' != 'true'" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.CSharp.targets
@@ -17,9 +17,9 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<UsingTask TaskName="Xamarin.iOS.Tasks.PrepareNativeReferences" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.iOS.Tasks.BTouch" AssemblyFile="Xamarin.iOS.Tasks.dll" />
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.Zip" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Zip" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 
-	<UsingTask TaskName="Microsoft.Build.Tasks.Delete" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.Delete" AssemblyFile="Xamarin.iOS.Tasks.dll"/>
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.ObjCBinding.Common.targets
@@ -15,9 +15,9 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<UsingTask TaskName="Xamarin.MacDev.Tasks.CollectBundleResources" AssemblyFile="Xamarin.MacDev.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.CollectBundleResources" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.iOS.Tasks.CreateEmbeddedResources" AssemblyFile="Xamarin.iOS.Tasks.dll" />
-	<UsingTask TaskName="Microsoft.Build.Tasks.RemoveDir" AssemblyFile="Xamarin.MacDev.Tasks.dll"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.RemoveDir" AssemblyFile="Xamarin.iOS.Tasks.dll"/>
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.ObjCBinding.Common.props" 
 			Condition="'$(_XamarinCommonPropsHasBeenImported)' != 'true'" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Tasks.Core.csproj
@@ -54,7 +54,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Tasks\ACToolTaskBase.cs" />
     <Compile Include="Tasks\ArchiveTaskBase.cs" />
     <Compile Include="Tasks\CodesignVerifyTaskBase.cs" />

--- a/msbuild/Xamarin.iOS.Tasks/Properties/AssemblyInfo.cs
+++ b/msbuild/Xamarin.iOS.Tasks/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo ("Xamarin.iOS.Tasks.Tests")]

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Tasks\FindWatchOS2AppBundle.cs" />
     <Compile Include="Tasks\DetectDebugNetworkConfiguration.cs" />
     <Compile Include="Tasks\CodesignNativeLibraries.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.iOS.Tasks.Core\Xamarin.iOS.Tasks.Core.csproj">
@@ -98,7 +99,11 @@
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.Build.Tasks.v4.0" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\ILRepack.2.0.13\build\ILRepack.props" Condition="Exists('..\..\packages\ILRepack.2.0.13\build\ILRepack.props')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -106,4 +111,28 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Target Name="ILRepack" AfterTargets="CoreCompile" DependsOnTargets="CoreCompile" Inputs="@(IntermediateAssembly -> '%(FullPath)')" Outputs="$(IntermediateOutputPath)ilrepack.txt" Returns="@(MergedAssemblies)" Condition="Exists(@(IntermediateAssembly -> '%(FullPath)')) And '$(ILRepack)' != 'false'">
+    <GetReferenceAssemblyPaths BypassFrameworkInstallChecks="False" TargetFrameworkMoniker="$(TargetFrameworkMoniker)">
+      <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FullFrameworkReferenceAssemblyPaths" />
+    </GetReferenceAssemblyPaths>
+    <ItemGroup>
+      <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('Xamarin')) And '%(Extension)' == '.dll'" />
+      <MergedAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(FileName)').StartsWith('Mono')) And '%(Extension)' == '.dll'" />
+      <ReferenceCopyLocalDirs Include="@(ReferenceCopyLocalPaths -> '%(RootDir)%(Directory)')" />
+      <ReferenceCopyLocalPaths Remove="@(MergedAssemblies)" />
+      <LibDir Include="@(ReferenceCopyLocalDirs -> Distinct())" />
+    </ItemGroup>
+    <PropertyGroup>
+      <ILRepackArgs Condition="'$(AssemblyOriginatorKeyFile)' != ''">/keyfile:"$(AssemblyOriginatorKeyFile)"</ILRepackArgs>
+    </PropertyGroup>
+    <Exec Command="&quot;$(ILRepack)&quot; @(LibDir -> '/lib:&quot;%(Identity).&quot;', ' ') $(ILRepackArgs) /out:&quot;@(IntermediateAssembly -> '%(FullPath)')&quot; &quot;@(IntermediateAssembly -> '%(FullPath)')&quot; @(MergedAssemblies -> '&quot;%(FullPath)&quot;', ' ')" WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)" StandardErrorImportance="high" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="ILRepackOutput" />
+      <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
+    </Exec>
+    <Touch AlwaysCreate="true" Files="$(IntermediateOutputPath)ilrepack.txt" />
+    <Message Importance="high" Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0'" />
+    <Delete Files="$(IntermediateOutputPath)ilrepack.txt" Condition="'$(ExitCode)' != '0'" />
+    <Error Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0' And '$(ContinueOnError)' != 'true'" />
+    <Delete Files="@(MergedAssemblies -> '$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" />
+  </Target>
 </Project>

--- a/msbuild/Xamarin.iOS.Tasks/packages.config
+++ b/msbuild/Xamarin.iOS.Tasks/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="ILRepack" version="2.0.13" targetFramework="net45" />
+</packages>

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/CodesignAppBundle.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/CodesignAppBundle.cs
@@ -27,7 +27,7 @@ namespace Xamarin.iOS.Tasks
 		static bool IsCodesigned (string path)
 		{
 			var psi = new ProcessStartInfo ("/usr/bin/codesign");
-			var args = new ProcessArgumentBuilder ();
+			var args = new CommandLineArgumentBuilder ();
 
 			args.Add ("--verify");
 			args.AddQuoted (path);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -36,32 +36,15 @@
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Build.Engine" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
-    <Reference Include="Mono.Cecil, Version=0.9.5.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756" />
     <Reference Include="System.Xml" />
     <Reference Include="nunit.framework">
       <HintPath>..\..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\external\Xamarin.MacDev\Xamarin.MacDev\Xamarin.MacDev.csproj">
-      <Project>{CC3D9353-20C4-467A-8522-A9DED6F0C753}</Project>
-      <Name>Xamarin.MacDev</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Xamarin.MacDev.Tasks\Xamarin.MacDev.Tasks.csproj">
-      <Project>{534D7C5A-0E1C-4C58-9E48-21B1A98919EB}</Project>
-      <Name>Xamarin.MacDev.Tasks</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Xamarin.iOS.Tasks.Core\Xamarin.iOS.Tasks.Core.csproj">
-      <Project>{93E12FA0-089C-4BC8-840F-43CFBC7927C7}</Project>
-      <Name>Xamarin.iOS.Tasks.Core</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\Xamarin.iOS.Tasks\Xamarin.iOS.Tasks.csproj">
       <Project>{44605724-8002-48E1-895F-7CB068099B6A}</Project>
       <Name>Xamarin.iOS.Tasks</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Xamarin.MacDev.Tasks.Core\Xamarin.MacDev.Tasks.Core.csproj">
-      <Project>{7B095849-6FDB-4BD2-9B59-569D81A1A809}</Project>
-      <Name>Xamarin.MacDev.Tasks.Core</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -504,6 +504,7 @@ namespace xharness
 				SpecifyPlatform = false,
 				SpecifyConfiguration = false,
 				Platform = TestPlatform.iOS,
+				UseMSBuild = true,
 			};
 			var nunitExecutioniOSMSBuild = new NUnitExecuteTask (buildiOSMSBuild)
 			{
@@ -2444,6 +2445,8 @@ function oninitialload ()
 
 	class XBuildTask : BuildProjectTask
 	{
+		public bool UseMSBuild;
+
 		protected override async Task ExecuteAsync ()
 		{
 			using (var resource = await NotifyAndAcquireDesktopResourceAsync ()) {
@@ -2452,7 +2455,7 @@ function oninitialload ()
 				await RestoreNugetsAsync (log, resource);
 
 				using (var xbuild = new Process ()) {
-					xbuild.StartInfo.FileName = "xbuild";
+					xbuild.StartInfo.FileName = UseMSBuild ? "msbuild" : "xbuild";
 					var args = new StringBuilder ();
 					args.Append ("/verbosity:diagnostic ");
 					if (SpecifyPlatform)
@@ -2462,6 +2465,8 @@ function oninitialload ()
 					args.Append (StringUtils.Quote (ProjectFile));
 					xbuild.StartInfo.Arguments = args.ToString ();
 					SetEnvironmentVariables (xbuild);
+					if (UseMSBuild)
+						xbuild.StartInfo.EnvironmentVariables ["MSBuildExtensionsPath"] = null;
 					LogProcessExecution (log, xbuild, "Building {0} ({1})", TestName, Mode);
 					if (!Harness.DryRun) {
 						var timeout = TimeSpan.FromMinutes (15);


### PR DESCRIPTION
This is the same patch as was committed/accepted in PR #3007 (and later reverted) but should
hopefully work better now that the Move task has been fixed by PR #3104.
