### PR TITLE
[metalperformanceshaders] Fix MPSImageLanczosScale base class change

### DIFF
--- a/src/MetalPerformanceShaders/MPSImageScale.cs
+++ b/src/MetalPerformanceShaders/MPSImageScale.cs
@@ -24,6 +24,7 @@ namespace XamCore.MetalPerformanceShaders {
 					IntPtr ptr = Marshal.AllocHGlobal (size_of_scale_transform);
 					try {
 						Marshal.StructureToPtr<MPSScaleTransform> (value.Value, ptr, false);
+						_SetScaleTransform (ptr);
 					}
 					finally {
 						Marshal.FreeHGlobal (ptr);

--- a/src/MetalPerformanceShaders/MPSImageScale.cs
+++ b/src/MetalPerformanceShaders/MPSImageScale.cs
@@ -9,7 +9,7 @@ using XamCore.ObjCRuntime;
 
 namespace XamCore.MetalPerformanceShaders {
 
-	public partial class MPSImageLanczosScale {
+	public partial class MPSImageScale {
 		static int size_of_scale_transform = Marshal.SizeOf (typeof(MPSScaleTransform));
 
 		public virtual MPSScaleTransform? ScaleTransform {

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1008,7 +1008,7 @@ METALPERFORMANCESHADERS_CORE_SOURCES = \
 	MetalPerformanceShaders/MPSKernel.cs \
 
 METALPERFORMANCESHADERS_SOURCES = \
-	MetalPerformanceShaders/MPSImageLanczosScale.cs \
+	MetalPerformanceShaders/MPSImageScale.cs \
 	MetalPerformanceShaders/MPSCnnConvolutionDescriptor.cs \
 	MetalPerformanceShaders/MPSCnnNeuron.cs \
 	MetalPerformanceShaders/MPSCnnKernel.cs \

--- a/src/metalperformanceshaders.cs
+++ b/src/metalperformanceshaders.cs
@@ -499,20 +499,9 @@ namespace XamCore.MetalPerformanceShaders {
 	// MPSImageResampling.h
 
 	[iOS (9,0)][Mac (10, 13, onlyOn64: true)]
-	[BaseType (typeof (MPSUnaryImageKernel))]
+	[BaseType (typeof (MPSImageScale))]
 	[DisableDefaultCtor]
 	interface MPSImageLanczosScale {
-		// scaleTransform property should be like:
-		// unsafe MPSScaleTransform* ScaleTransform { get; set; }
-		// which is both ugly and not supported by the generator
-		[Export ("scaleTransform")]
-		[Internal]
-		IntPtr _GetScaleTransform ();
-
-		[Export ("setScaleTransform:")]
-		[Internal]
-		void _SetScaleTransform (IntPtr value);
-
 		// inlining .ctor from base class
 
 		[Export ("initWithDevice:")]
@@ -1979,8 +1968,16 @@ namespace XamCore.MetalPerformanceShaders {
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device);
 
-		[NullAllowed, Export ("scaleTransform", ArgumentSemantic.Assign)]
-		MPSScaleTransform ScaleTransform { get; set; }
+		// scaleTransform property should be like:
+		// unsafe MPSScaleTransform* ScaleTransform { get; set; }
+		// which is both ugly and not supported by the generator
+		[Export ("scaleTransform")]
+		[Internal]
+		IntPtr _GetScaleTransform ();
+
+		[Export ("setScaleTransform:")]
+		[Internal]
+		void _SetScaleTransform (IntPtr value);
 
 		[Export ("initWithCoder:device:")]
 		[DesignatedInitializer]

--- a/tests/monotouch-test/MetalPerformanceShaders/ImageScaleTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/ImageScaleTest.cs
@@ -1,0 +1,56 @@
+﻿#if !__WATCHOS__
+
+using System;
+using Foundation;
+
+#if XAMCORE_2_0
+using Metal;
+using MetalPerformanceShaders;
+#else
+using MonoTouch.Metal;
+using MonoTouch.MetalPerformanceShaders;
+#endif
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.MetalPerformanceShaders {
+
+	[TestFixture]
+	public class ImageScaleTest {
+
+		IMTLDevice device;
+
+		[TestFixtureSetUp]
+		public void Metal ()
+		{
+			TestRuntime.AssertXcodeVersion (9,0);
+
+			device = MTLDevice.SystemDefault;
+			// some older hardware won't have a default
+			if (device == null)
+				Assert.Inconclusive ("Metal is not supported");
+		}
+
+		[Test]
+		public void ScaleTransform ()
+		{
+			var st = new MPSScaleTransform () {
+				ScaleX = 1,
+				ScaleY = 2,
+				TranslateX = 3,
+				TranslateY = 4,
+			};
+			using (var scale = new MPSImageScale (device)) {
+				scale.ScaleTransform = st;
+				// roundtrip with our (non generated) code
+				var rt = scale.ScaleTransform.Value;
+				Assert.That (rt.ScaleX, Is.EqualTo (st.ScaleX), "ScaleX");
+				Assert.That (rt.ScaleY, Is.EqualTo (st.ScaleY), "ScaleY");
+				Assert.That (rt.TranslateX, Is.EqualTo (st.TranslateX), "TranslateX");
+				Assert.That (rt.TranslateY, Is.EqualTo (st.TranslateY), "TranslateY");
+			}
+		}
+	}
+}
+
+#endif

--- a/tests/xtro-sharpie/iOS-MetalPerformanceShaders.todo
+++ b/tests/xtro-sharpie/iOS-MetalPerformanceShaders.todo
@@ -1,1 +1,0 @@
-!wrong-base-type! MPSImageLanczosScale expected MPSImageScale actual MPSUnaryImageKernel

--- a/tests/xtro-sharpie/macOS-MetalPerformanceShaders.todo
+++ b/tests/xtro-sharpie/macOS-MetalPerformanceShaders.todo
@@ -1,1 +1,0 @@
-!wrong-base-type! MPSImageLanczosScale expected MPSImageScale actual MPSUnaryImageKernel

--- a/tests/xtro-sharpie/tvOS-MetalPerformanceShaders.todo
+++ b/tests/xtro-sharpie/tvOS-MetalPerformanceShaders.todo
@@ -1,1 +1,0 @@
-!wrong-base-type! MPSImageLanczosScale expected MPSImageScale actual MPSUnaryImageKernel


### PR DESCRIPTION
Sadly this creates a breaking change since the `ScaleTransform`
property was re-introduced with an incorrect signature in the new
base class `MPSImageScale`

Unless someone has an idea how to avoid it (I don't see an option)
then we'll have to document it in the 15.7 release notes.