### PR TITLE
[build] Fix makefiles to be compatible with remake v4.2.1.

### DIFF
--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -48,8 +48,8 @@ IOS_DIRECTORIES =                                                               
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.iOS                                                  \
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/msbuild/iOS                                                           \
 	$(IOS_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild-frameworks/Xamarin.iOS/v1.0/RedistList \
-	$(IOS_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/                               \
-	$(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/msbuild/iOS/               \
+	$(IOS_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild/Xamarin                                \
+	$(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/msbuild/iOS                \
 
 IOS_2_1_SYMLINKS = \
 	$(foreach target,$(IOS_BINDING_TARGETS)       ,$(IOS_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/$(notdir $(target)))       \


### PR DESCRIPTION
For some strange reason the following sometimes work with make v3.8.1:

    X/:
    	mkdir X

    X/Y: X
    	mkdir X/Y

Note how the second target specifies `X` as a dependency, but the actual
target to be executed is `X/` (additional trailing slash).

It does not work with remake (v4.2.1), nor in a simple test case like the one
above with make (v3.8.1), but it works in our own makefiles (which are
admittedly slightly more complicated).

Since it's trivial to fix, and I don't understand how it works in make in the
first place, I'm just changing it to what makes sense (and works everywhere):
remove trailing slashes from all directories that are used as targets.