### PR TITLE
Revert "[macos] Fix pdb mismatch when saving assemblies processed by mmp (#2901)"

### DIFF
--- a/tools/mmp/resolver.cs
+++ b/tools/mmp/resolver.cs
@@ -28,7 +28,6 @@ using System.Linq;
 using System.Security.Cryptography;
 
 using Mono.Cecil;
-using Mono.Cecil.Cil;
 
 namespace Xamarin.Bundler {
 	public partial class MonoMacResolver : IAssemblyResolver {
@@ -73,9 +72,7 @@ namespace Xamarin.Bundler {
 			assembly = AssemblyDefinition.ReadAssembly (fileName, new ReaderParameters 
 				{
 					AssemblyResolver = this,
-					InMemory = new FileInfo (fileName).Length < 1024 * 1024 * 100, // 100 MB
-					ReadSymbols = true,
-					SymbolReaderProvider = new DefaultSymbolReaderProvider (throwIfNoSymbol: false) 
+					InMemory = new FileInfo (fileName).Length < 1024 * 1024 * 100 // 100 MB
 				});
 			cache.Add (name, assembly);
 			return assembly;

--- a/tools/mtouch/AssemblyResolver.cs
+++ b/tools/mtouch/AssemblyResolver.cs
@@ -16,7 +16,6 @@ using System.IO;
 using System.Linq;
 
 using Mono.Cecil;
-using Mono.Cecil.Cil;
 using Mono.Tuner;
 
 using Xamarin.Bundler;
@@ -71,8 +70,6 @@ namespace MonoTouch.Tuner {
 			var parameters = new ReaderParameters ();
 			parameters.AssemblyResolver = this;
 			parameters.InMemory = new FileInfo (path).Length < 1024 * 1024 * 100; // 100 MB.
-			parameters.ReadSymbols = true;
-			parameters.SymbolReaderProvider = new DefaultSymbolReaderProvider (throwIfNoSymbol: false);
 			return parameters;
 		}
 


### PR DESCRIPTION
This reverts commit 91ded43b0b13025f4d6583e4571f1af002517348.

Discussed in https://bugzilla.xamarin.com/show_bug.cgi?id=60923