### PR TITLE
[SceneKit] Add AddAnimation overload that takes a SCNAnimation

### DIFF
--- a/src/SceneKit/SCNCompat.cs
+++ b/src/SceneKit/SCNCompat.cs
@@ -8,6 +8,7 @@ using XamCore.ObjCRuntime;
 #if WATCH
 using AnimationType = global::XamCore.SceneKit.ISCNAnimationProtocol;
 #else
+using XamCore.CoreAnimation;
 using AnimationType = global::XamCore.CoreAnimation.CAAnimation;
 #endif
 
@@ -93,6 +94,20 @@ namespace XamCore.SceneKit {
 				eventHandler (animation, animatedObject, playingBackward);
 			});
 			return Create (keyTime, handler);
+		}
+	}
+#endif
+
+#if !WATCH && !XAMCORE_4_0
+	[iOS (11,0)]
+	[TV (11,0)]
+	[Mac (10,13,0, PlatformArchitecture.Arch64)]
+	static public partial class SCNAnimatableExtensions {
+		static public void AddAnimation (this ISCNAnimatable self, SCNAnimation animation, string key)
+		{
+			using (var ca = CAAnimation.FromSCNAnimation (animation))
+			using (var st = new NSString (key))
+				self.AddAnimation (ca, st);
 		}
 	}
 #endif

--- a/src/SceneKit/SCNCompat.cs
+++ b/src/SceneKit/SCNCompat.cs
@@ -106,7 +106,7 @@ namespace XamCore.SceneKit {
 		static public void AddAnimation (this ISCNAnimatable self, SCNAnimation animation, string key)
 		{
 			using (var ca = CAAnimation.FromSCNAnimation (animation))
-			using (var st = new NSString (key))
+			using (var st = key != null ? new NSString (key) : null)
 				self.AddAnimation (ca, st);
 		}
 	}

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -125,7 +125,11 @@ namespace XamCore.SceneKit {
 #endif
 		[NoWatch]
 		[Export ("addAnimation:forKey:")]
+#if !XAMCORE_4_0
 		void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
+#else
+		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
+#endif
 
 #if XAMCORE_2_0
 #if XAMCORE_4_0
@@ -595,6 +599,20 @@ namespace XamCore.SceneKit {
 		nfloat ScreenSpaceAmbientOcclusionNormalThreshold { get; set; }
 
 #endif
+#if !XAMCORE_4_0
+		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
+		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
+		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
+		[Sealed]
+		[Export ("addAnimation:forKey:")]
+		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
+
+		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
+		[NoWatch]
+		[Mac (10,8), iOS (8,0)]
+		[Export ("addAnimation:forKey:")]
+		new void AddAnimation (CAAnimation animation, NSString key);
+#endif
 	}
 
 	interface ISCNCameraControlConfiguration {}
@@ -910,6 +928,20 @@ namespace XamCore.SceneKit {
 		[NoWatch, NoTV, Mac (10,13, onlyOn64: true), iOS (11,0)]
 		[NullAllowed, Export ("tessellator", ArgumentSemantic.Retain)]
 		SCNGeometryTessellator Tessellator { get; set; }
+#endif
+#if !XAMCORE_4_0
+		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
+		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
+		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
+		[Sealed]
+		[Export ("addAnimation:forKey:")]
+		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
+
+		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
+		[NoWatch]
+		[Mac (10,8), iOS (8,0)]
+		[Export ("addAnimation:forKey:")]
+		new void AddAnimation (CAAnimation animation, NSString key);
 #endif
 	}
 
@@ -1327,6 +1359,20 @@ namespace XamCore.SceneKit {
 		[Export ("lightWithMDLLight:")]
 		SCNLight FromModelLight (MDLLight mdllight);
 #endif
+#if !XAMCORE_4_0
+		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
+		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
+		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
+		[Sealed]
+		[Export ("addAnimation:forKey:")]
+		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
+
+		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
+		[NoWatch]
+		[Mac (10,8), iOS (8,0)]
+		[Export ("addAnimation:forKey:")]
+		new void AddAnimation (CAAnimation animation, NSString key);
+#endif
 	}
 
 	[Watch (3,0)]
@@ -1512,6 +1558,20 @@ namespace XamCore.SceneKit {
 		SCNColorMask ColorBufferWriteMask { get; set; }
 
 #endif
+#if !XAMCORE_4_0
+		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
+		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
+		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
+		[Sealed]
+		[Export ("addAnimation:forKey:")]
+		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
+
+		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
+		[NoWatch]
+		[Mac (10,8), iOS (8,0)]
+		[Export ("addAnimation:forKey:")]
+		new void AddAnimation (CAAnimation animation, NSString key);
+#endif
 	}
 
 	[Watch (3,0)]
@@ -1591,6 +1651,20 @@ namespace XamCore.SceneKit {
 		[Mac (10,9)]
 		[Static, Export ("materialPropertyWithContents:")]
 		SCNMaterialProperty Create (NSObject contents);
+#if !XAMCORE_4_0
+		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
+		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
+		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
+		[Sealed]
+		[Export ("addAnimation:forKey:")]
+		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
+
+		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
+		[NoWatch]
+		[Mac (10,8), iOS (8,0)]
+		[Export ("addAnimation:forKey:")]
+		new void AddAnimation (CAAnimation animation, NSString key);
+#endif
 	}
 
 #if !WATCH
@@ -1949,6 +2023,21 @@ namespace XamCore.SceneKit {
 		[Watch (4,0), TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		[Export ("rotateBy:aroundTarget:")]
 		void Rotate (SCNQuaternion worldRotation, SCNVector3 worldTarget);
+
+#if !XAMCORE_4_0
+		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
+		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
+		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
+		[Sealed]
+		[Export ("addAnimation:forKey:")]
+		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
+
+		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
+		[NoWatch]
+		[Mac (10,8), iOS (8,0)]
+		[Export ("addAnimation:forKey:")]
+		new void AddAnimation (CAAnimation animation, NSString key);
+#endif
 
 		// From SCNNode (SIMD) Category
 		// Unfortunatelly had to prefix some props Simd due to the property name is already taken
@@ -3446,6 +3535,21 @@ namespace XamCore.SceneKit {
 		[Watch (4,0), TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		[Export ("weightForTargetNamed:")]
 		nfloat GetWeight (string targetName);
+
+#if !XAMCORE_4_0
+		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
+		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
+		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
+		[Sealed]
+		[Export ("addAnimation:forKey:")]
+		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
+
+		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
+		[NoWatch]
+		[Mac (10,8), iOS (8,0)]
+		[Export ("addAnimation:forKey:")]
+		new void AddAnimation (CAAnimation animation, NSString key);
+#endif
 	}
 
 	[Watch (3,0)]
@@ -3503,7 +3607,21 @@ namespace XamCore.SceneKit {
 		[Watch (4, 0), TV (11, 0), Mac (10, 13, onlyOn64: true), iOS (11, 0)]
 		[Export ("incremental")]
 		bool Incremental { [Bind ("isIncremental")] get; set; }
-		
+
+#if !XAMCORE_4_0
+		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
+		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
+		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
+		[Sealed]
+		[Export ("addAnimation:forKey:")]
+		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
+
+		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
+		[NoWatch]
+		[Mac (10,8), iOS (8,0)]
+		[Export ("addAnimation:forKey:")]
+		new void AddAnimation (CAAnimation animation, NSString key);
+#endif
 	}
 
 	[Watch (3,0)]
@@ -3869,6 +3987,21 @@ namespace XamCore.SceneKit {
 		[iOS (9,0)][Mac (10,11)]
 		[Internal, Export ("setObject:forKeyedSubscript:")]
 		void _SetObject ([NullAllowed] NSObject obj, INSCopying key);
+
+#if !XAMCORE_4_0
+		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
+		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
+		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
+		[Sealed]
+		[Export ("addAnimation:forKey:")]
+		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
+
+		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
+		[NoWatch]
+		[Mac (10,8), iOS (8,0)]
+		[Export ("addAnimation:forKey:")]
+		new void AddAnimation (CAAnimation animation, NSString key);
+#endif
 	}
 
 	[Watch (3,0)]
@@ -4693,6 +4826,21 @@ namespace XamCore.SceneKit {
 		[Watch (4,0), TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		[Export ("particleIntensityVariation")]
 		nfloat ParticleIntensityVariation { get; set; }
+
+#if !XAMCORE_4_0
+		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
+		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
+		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
+		[Sealed]
+		[Export ("addAnimation:forKey:")]
+		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
+
+		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
+		[NoWatch]
+		[Mac (10,8), iOS (8,0)]
+		[Export ("addAnimation:forKey:")]
+		new void AddAnimation (CAAnimation animation, NSString key);
+#endif
 	}
 
 	[Watch (3,0)]
@@ -4973,6 +5121,21 @@ namespace XamCore.SceneKit {
 	
 		[Export ("stopWithBlendOutDuration:")]
 		void StopWithBlendOutDuration (double seconds);
+
+#if !XAMCORE_4_0
+		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
+		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
+		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
+		[Sealed]
+		[Export ("addAnimation:forKey:")]
+		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
+
+		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
+		[NoWatch]
+		[Mac (10,8), iOS (8,0)]
+		[Export ("addAnimation:forKey:")]
+		new void AddAnimation (CAAnimation animation, NSString key);
+#endif
 	}
 
 	[Watch (4,0), TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -611,7 +611,7 @@ namespace XamCore.SceneKit {
 		[NoWatch]
 		[Mac (10,8), iOS (8,0)]
 		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, NSString key);
+		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
 #endif
 	}
 
@@ -941,7 +941,7 @@ namespace XamCore.SceneKit {
 		[NoWatch]
 		[Mac (10,8), iOS (8,0)]
 		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, NSString key);
+		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
 #endif
 	}
 
@@ -1371,7 +1371,7 @@ namespace XamCore.SceneKit {
 		[NoWatch]
 		[Mac (10,8), iOS (8,0)]
 		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, NSString key);
+		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
 #endif
 	}
 
@@ -1570,7 +1570,7 @@ namespace XamCore.SceneKit {
 		[NoWatch]
 		[Mac (10,8), iOS (8,0)]
 		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, NSString key);
+		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
 #endif
 	}
 
@@ -1663,7 +1663,7 @@ namespace XamCore.SceneKit {
 		[NoWatch]
 		[Mac (10,8), iOS (8,0)]
 		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, NSString key);
+		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
 #endif
 	}
 
@@ -2036,7 +2036,7 @@ namespace XamCore.SceneKit {
 		[NoWatch]
 		[Mac (10,8), iOS (8,0)]
 		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, NSString key);
+		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
 #endif
 
 		// From SCNNode (SIMD) Category
@@ -3548,7 +3548,7 @@ namespace XamCore.SceneKit {
 		[NoWatch]
 		[Mac (10,8), iOS (8,0)]
 		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, NSString key);
+		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
 #endif
 	}
 
@@ -3620,7 +3620,7 @@ namespace XamCore.SceneKit {
 		[NoWatch]
 		[Mac (10,8), iOS (8,0)]
 		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, NSString key);
+		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
 #endif
 	}
 
@@ -4000,7 +4000,7 @@ namespace XamCore.SceneKit {
 		[NoWatch]
 		[Mac (10,8), iOS (8,0)]
 		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, NSString key);
+		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
 #endif
 	}
 
@@ -4839,7 +4839,7 @@ namespace XamCore.SceneKit {
 		[NoWatch]
 		[Mac (10,8), iOS (8,0)]
 		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, NSString key);
+		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
 #endif
 	}
 
@@ -5134,7 +5134,7 @@ namespace XamCore.SceneKit {
 		[NoWatch]
 		[Mac (10,8), iOS (8,0)]
 		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, NSString key);
+		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
 #endif
 	}
 

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -599,20 +599,6 @@ namespace XamCore.SceneKit {
 		nfloat ScreenSpaceAmbientOcclusionNormalThreshold { get; set; }
 
 #endif
-#if !XAMCORE_4_0
-		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
-		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
-		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
-		[Sealed]
-		[Export ("addAnimation:forKey:")]
-		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
-
-		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
-		[NoWatch]
-		[Mac (10,8), iOS (8,0)]
-		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
-#endif
 	}
 
 	interface ISCNCameraControlConfiguration {}
@@ -928,20 +914,6 @@ namespace XamCore.SceneKit {
 		[NoWatch, NoTV, Mac (10,13, onlyOn64: true), iOS (11,0)]
 		[NullAllowed, Export ("tessellator", ArgumentSemantic.Retain)]
 		SCNGeometryTessellator Tessellator { get; set; }
-#endif
-#if !XAMCORE_4_0
-		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
-		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
-		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
-		[Sealed]
-		[Export ("addAnimation:forKey:")]
-		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
-
-		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
-		[NoWatch]
-		[Mac (10,8), iOS (8,0)]
-		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
 #endif
 	}
 
@@ -1359,20 +1331,6 @@ namespace XamCore.SceneKit {
 		[Export ("lightWithMDLLight:")]
 		SCNLight FromModelLight (MDLLight mdllight);
 #endif
-#if !XAMCORE_4_0
-		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
-		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
-		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
-		[Sealed]
-		[Export ("addAnimation:forKey:")]
-		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
-
-		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
-		[NoWatch]
-		[Mac (10,8), iOS (8,0)]
-		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
-#endif
 	}
 
 	[Watch (3,0)]
@@ -1558,20 +1516,6 @@ namespace XamCore.SceneKit {
 		SCNColorMask ColorBufferWriteMask { get; set; }
 
 #endif
-#if !XAMCORE_4_0
-		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
-		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
-		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
-		[Sealed]
-		[Export ("addAnimation:forKey:")]
-		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
-
-		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
-		[NoWatch]
-		[Mac (10,8), iOS (8,0)]
-		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
-#endif
 	}
 
 	[Watch (3,0)]
@@ -1651,20 +1595,6 @@ namespace XamCore.SceneKit {
 		[Mac (10,9)]
 		[Static, Export ("materialPropertyWithContents:")]
 		SCNMaterialProperty Create (NSObject contents);
-#if !XAMCORE_4_0
-		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
-		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
-		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
-		[Sealed]
-		[Export ("addAnimation:forKey:")]
-		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
-
-		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
-		[NoWatch]
-		[Mac (10,8), iOS (8,0)]
-		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
-#endif
 	}
 
 #if !WATCH
@@ -2023,21 +1953,6 @@ namespace XamCore.SceneKit {
 		[Watch (4,0), TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		[Export ("rotateBy:aroundTarget:")]
 		void Rotate (SCNQuaternion worldRotation, SCNVector3 worldTarget);
-
-#if !XAMCORE_4_0
-		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
-		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
-		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
-		[Sealed]
-		[Export ("addAnimation:forKey:")]
-		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
-
-		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
-		[NoWatch]
-		[Mac (10,8), iOS (8,0)]
-		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
-#endif
 
 		// From SCNNode (SIMD) Category
 		// Unfortunatelly had to prefix some props Simd due to the property name is already taken
@@ -3535,21 +3450,6 @@ namespace XamCore.SceneKit {
 		[Watch (4,0), TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		[Export ("weightForTargetNamed:")]
 		nfloat GetWeight (string targetName);
-
-#if !XAMCORE_4_0
-		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
-		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
-		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
-		[Sealed]
-		[Export ("addAnimation:forKey:")]
-		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
-
-		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
-		[NoWatch]
-		[Mac (10,8), iOS (8,0)]
-		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
-#endif
 	}
 
 	[Watch (3,0)]
@@ -3607,21 +3507,6 @@ namespace XamCore.SceneKit {
 		[Watch (4, 0), TV (11, 0), Mac (10, 13, onlyOn64: true), iOS (11, 0)]
 		[Export ("incremental")]
 		bool Incremental { [Bind ("isIncremental")] get; set; }
-
-#if !XAMCORE_4_0
-		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
-		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
-		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
-		[Sealed]
-		[Export ("addAnimation:forKey:")]
-		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
-
-		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
-		[NoWatch]
-		[Mac (10,8), iOS (8,0)]
-		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
-#endif
 	}
 
 	[Watch (3,0)]
@@ -3987,21 +3872,6 @@ namespace XamCore.SceneKit {
 		[iOS (9,0)][Mac (10,11)]
 		[Internal, Export ("setObject:forKeyedSubscript:")]
 		void _SetObject ([NullAllowed] NSObject obj, INSCopying key);
-
-#if !XAMCORE_4_0
-		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
-		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
-		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
-		[Sealed]
-		[Export ("addAnimation:forKey:")]
-		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
-
-		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
-		[NoWatch]
-		[Mac (10,8), iOS (8,0)]
-		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
-#endif
 	}
 
 	[Watch (3,0)]
@@ -4826,21 +4696,6 @@ namespace XamCore.SceneKit {
 		[Watch (4,0), TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
 		[Export ("particleIntensityVariation")]
 		nfloat ParticleIntensityVariation { get; set; }
-
-#if !XAMCORE_4_0
-		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
-		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
-		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
-		[Sealed]
-		[Export ("addAnimation:forKey:")]
-		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
-
-		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
-		[NoWatch]
-		[Mac (10,8), iOS (8,0)]
-		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
-#endif
 	}
 
 	[Watch (3,0)]
@@ -5121,21 +4976,6 @@ namespace XamCore.SceneKit {
 	
 		[Export ("stopWithBlendOutDuration:")]
 		void StopWithBlendOutDuration (double seconds);
-
-#if !XAMCORE_4_0
-		// Inlined from SCNAnimatable protocol, this allows us to provide an API to be used with ISCNAnimationProtocol
-		// while XAMCORE_4_0 happens and we are able to fix the protocol itself.
-		[Mac (10,13), iOS (11,0), TV (11,0), Watch (4,0)]
-		[Sealed]
-		[Export ("addAnimation:forKey:")]
-		void AddAnimation (ISCNAnimationProtocol scnAnimation, [NullAllowed] string key);
-
-		// Needed to avoid error CS0535: `SceneKit.SCNCamera' does not implement interface member `SceneKit.ISCNAnimatable.AddAnimation(CoreAnimation.CAAnimation, Foundation.NSString)'
-		[NoWatch]
-		[Mac (10,8), iOS (8,0)]
-		[Export ("addAnimation:forKey:")]
-		new void AddAnimation (CAAnimation animation, [NullAllowed] NSString key);
-#endif
 	}
 
 	[Watch (4,0), TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]

--- a/tests/monotouch-test/SceneKit/NodeTest.cs
+++ b/tests/monotouch-test/SceneKit/NodeTest.cs
@@ -70,6 +70,9 @@ namespace MonoTouchFixtures.SceneKit {
 			using (var n = SCNNode.Create ()) {
 				n.AddAnimation (a, "key");
 				n.RemoveAllAnimations ();
+
+				n.AddAnimation (a, null);
+				n.RemoveAllAnimations ();
 			}
 		}
 	}

--- a/tests/monotouch-test/SceneKit/NodeTest.cs
+++ b/tests/monotouch-test/SceneKit/NodeTest.cs
@@ -56,7 +56,20 @@ namespace MonoTouchFixtures.SceneKit {
 				string key = "key";
 				n.AddAnimation (a, key);
 				using (var s = new NSString (key))
-					n.AddAnimation (a, key);
+					n.AddAnimation (a, s);
+			}
+		}
+
+		[Test]
+		public void AddAnimation_Overload ()
+		{
+			TestRuntime.AssertXcodeVersion (9,0);
+
+			using (var ca = CAAnimation.CreateAnimation ())
+			using (var a = SCNAnimation.FromCAAnimation (ca))
+			using (var n = SCNNode.Create ()) {
+				n.AddAnimation (a, "key");
+				n.RemoveAllAnimations ();
 			}
 		}
 	}


### PR DESCRIPTION
Fixes xamarin/xamarin-macios#3166

Apple broke `addAnimation:forKey:` API by changing `CAAnimation` parameter into a
`ISCNAnimationProtocol` that was introduced in Xcode 9 (iOS 11 and company).

We can't break the existing API but we can add an overload that
reuses the same selector with an sligthly twist in order to avoid
API ambiguity (because `CAAnimation` conforms to `SCNAnimation`) the
`key` parameter is being exposed as `string` and also being fixed
in XAMCORE_4_0 this way. `key` being a string instead of a `NSSrring`
makes sense because the `key` is just an identifier for the animation
and can be set to null so having a NET string vs a `NSString` should
make using this API a lot easier from a NET context.

The `new void AddAnimation` is used to force the generator
to generate (^.^) the `CAAnimation, NSString` overload in the
objects that implement `ISCNAnimationProtocol` else you would get
a CS0535.