### PR TITLE
[mtouch][mmp] Report invalid debug symbols files. Fixes #3200

### DIFF
--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -30,6 +30,10 @@ The easiest way to get exact version information is to use the **Xamarin Studio*
 
 ### <a name="MM0008">MM0008: You should provide one root assembly only, found {0} assemblies: '{1}'
 
+### <a name="MM0009"/>MM0009: Error while loading assemblies: *.
+
+An error occurred while loading the assemblies from the root assembly references. More information may be provided in the build output.
+
 ### <a name="MM0010">MM0010: Could not parse the command line arguments: {0}
 
 <!-- 0013 is unused -->
@@ -103,6 +107,17 @@ A last-straw solution would be to use an older version of Xamarin.Mac, one that 
 ### <a name="MM0099">MM0099: Internal error {0}. Please file a bug report with a test case (http://bugzilla.xamarin.com).
 
 ### <a name="MM0114">MM0114: Hybrid AOT compilation requires all assemblies to be AOT compiled.
+
+### <a name="MT0129"/>MT0129: Debugging symbol file for '*' does not match the assembly and is ignored.
+
+The debugging symbols, either a .pdb (portable pdb only) or a .mdb file, for the specified assembly could not be loaded.
+
+This generally means the assembly is newer or older than the symbols. Since they do not match they cannot be used and the symbols are ignored.
+
+This warning won't affect the application being built, however you might not be able to debug it entirely (in particular the code from specified assembly). Also exceptions, stack traces and crash reports might be missing some information.
+
+Please report this issue to the publisher of the assembly package (e.g. nuget author) so this can be fixed in their future releases.
+
 
 # MM1xxx: file copy / symlinks (project related)
 

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -108,7 +108,7 @@ A last-straw solution would be to use an older version of Xamarin.Mac, one that 
 
 ### <a name="MM0114">MM0114: Hybrid AOT compilation requires all assemblies to be AOT compiled.
 
-### <a name="MT0129"/>MT0129: Debugging symbol file for '*' does not match the assembly and is ignored.
+### <a name="MM0129"/>MM0129: Debugging symbol file for '*' does not match the assembly and is ignored.
 
 The debugging symbols, either a .pdb (portable pdb only) or a .mdb file, for the specified assembly could not be loaded.
 

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -65,7 +65,7 @@ More than one root assembly was passed to mtouch, while there can be only one ro
 
 ### <a name="MT0009"/>MT0009: Error while loading assemblies: *.
 
-An error occurred while loading the assemblies the root assembly references. More information may be provided in the build output.
+An error occurred while loading the assemblies from the root assembly references. More information may be provided in the build output.
 
 ### <a name="MT0010"/>MT0010: Could not parse the command line arguments: *.
 
@@ -628,6 +628,16 @@ For further information see bug #[52727](https://bugzilla.xamarin.com/show_bug.c
 A failure occurred when touching a file (which is done to ensure partial builds are done correctly).
 
 This warning can most likely be ignored; in case of any problems file a bug (https://bugzilla.xamarin.com](https://bugzilla.xamarin.com/enter_bug.cgi?product=iOS)) and it will be investigated.
+
+### <a name="MT0129"/>MT0129: Debugging symbol file for '*' does not match the assembly and is ignored.
+
+The debugging symbols, either a .pdb (portable pdb only) or a .mdb file, for the specified assembly could not be loaded.
+
+This generally means the assembly is newer or older than the symbols. Since they do not match they cannot be used and the symbols are ignored.
+
+This warning won't affect the application being built, however you might not be able to debug it entirely (in particular the code from specified assembly). Also exceptions, stack traces and crash reports might be missing some information.
+
+Please report this issue to the publisher of the assembly package (e.g. nuget author) so this can be fixed in their future releases.
 
 # MT1xxx: Project related error messages
 

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1731,10 +1731,14 @@ public class TestApp {
 			}
 		}
 
-		public static string GetCompiler (Profile profile, StringBuilder args)
+		public static string GetCompiler (Profile profile, StringBuilder args, bool use_csc = false)
 		{
 			args.Append (" -lib:").Append (Path.GetDirectoryName (GetBaseLibrary (profile))).Append (' ');
-			return "/Library/Frameworks/Mono.framework/Commands/mcs";
+			if (use_csc) {
+				return "/Library/Frameworks/Mono.framework/Commands/csc";
+			} else {
+				return "/Library/Frameworks/Mono.framework/Commands/mcs";
+			}
 		}
 
 		static string GetConfiguration (Profile profile)
@@ -3539,6 +3543,56 @@ public class HandlerTest
 		}
 
 		[Test]
+		[TestCase (true)]
+		[TestCase (false)]
+		public void SymbolsOutOfDate1 (bool use_csc)
+		{
+			using (var mtouch = new MTouchTool ()) {
+				// Compile the managed executable twice, the second time without debugging symbols, which will cause the debugging symbols to become stale
+				mtouch.CreateTemporaryApp (extraArg: "/debug:full", use_csc: use_csc);
+				mtouch.CreateTemporaryApp ();
+				mtouch.Linker = MTouchLinker.DontLink; // makes the test faster
+				mtouch.Debug = true; // makes the test faster because it makes simlauncher possible
+				mtouch.AssertExecute (MTouchAction.BuildSim);
+			}
+		}
+
+		[Test]
+		[TestCase (true)]
+		[TestCase (false)]
+		public void SymbolsOutOfDate2 (bool use_csc)
+		{
+			using (var mtouch = new MTouchTool ()) {
+				// Compile the managed executable twice, both times with debugging symbols, but restore the debugging symbols from the first build so that they're stale
+				mtouch.CreateTemporaryApp (extraArg: "/debug:full", use_csc: use_csc);
+				var symbol_file = use_csc ? Path.ChangeExtension (mtouch.RootAssembly, "pdb") : mtouch.RootAssembly + ".mdb";
+				var symbols = File.ReadAllBytes (symbol_file);
+				mtouch.CreateTemporaryApp (extraArg: "/debug:full", use_csc: use_csc);
+				File.WriteAllBytes (symbol_file, symbols);
+				mtouch.Linker = MTouchLinker.DontLink; // makes the test faster
+				mtouch.Debug = true; // makes the test faster because it makes simlauncher possible
+				mtouch.AssertExecute (MTouchAction.BuildSim);
+			}
+		}
+
+		[Test]
+		[TestCase (true, true)]
+		[TestCase (false, true)]
+		[TestCase (true, false)]
+		[TestCase (false, false)]
+		public void SymbolsBroken1 (bool use_csc, bool compile_with_debug_symbols)
+		{
+			using (var mtouch = new MTouchTool ()) {
+				// (Over)write invalid data in the debug symbol file
+				mtouch.CreateTemporaryApp (use_csc, extraArg: compile_with_debug_symbols ? "/debug:full" : string.Empty);
+				var symbol_file = use_csc ? Path.ChangeExtension (mtouch.RootAssembly, "pdb") : mtouch.RootAssembly + ".mdb";
+				File.WriteAllText (symbol_file, "invalid stuff");
+				mtouch.Linker = MTouchLinker.DontLink; // makes the test faster
+				mtouch.Debug = true; // makes the test faster because it makes simlauncher possible
+				mtouch.AssertExecute (MTouchAction.BuildSim);
+			}
+		}
+
 		public void XamarinSdkAdjustLibs ()
 		{
 			using (var exttool = new MTouchTool ()) {
@@ -3693,7 +3747,7 @@ public class Dummy {
 			ExecutionHelper.Execute ("mono", $"{StringUtils.Quote (Path.Combine (Configuration.RootPath, "tests", "xharness", "xharness.exe"))} --run {StringUtils.Quote (csprojpath)} --target ios-simulator-64 --sdkroot {Configuration.xcode_root} --logdirectory {StringUtils.Quote (Path.Combine (tmpdir, "log.txt"))} --configuration {configuration}", environmentVariables: environment_variables);
 		}
 
-		public static string CompileTestAppExecutable (string targetDirectory, string code = null, string extraArg = "", Profile profile = Profile.iOS, string appName = "testApp", string extraCode = null, string usings = null)
+		public static string CompileTestAppExecutable (string targetDirectory, string code = null, string extraArg = "", Profile profile = Profile.iOS, string appName = "testApp", string extraCode = null, string usings = null, bool use_csc = false)
 		{
 			if (code == null)
 				code = "public class TestApp { static void Main () { System.Console.WriteLine (typeof (ObjCRuntime.Runtime).ToString ()); } }";
@@ -3702,7 +3756,7 @@ public class Dummy {
 			if (extraCode != null)
 				code += extraCode;
 
-			return CompileTestAppCode ("exe", targetDirectory, code, extraArg, profile, appName);
+			return CompileTestAppCode ("exe", targetDirectory, code, extraArg, profile, appName, use_csc);
 		}
 
 		public static string CompileTestAppLibrary (string targetDirectory, string code, string extraArg = null, Profile profile = Profile.iOS, string appName = "testApp")
@@ -3710,7 +3764,7 @@ public class Dummy {
 			return CompileTestAppCode ("library", targetDirectory, code, extraArg, profile, appName);
 		}
 
-		public static string CompileTestAppCode (string target, string targetDirectory, string code, string extraArg = "", Profile profile = Profile.iOS, string appName = "testApp")
+		public static string CompileTestAppCode (string target, string targetDirectory, string code, string extraArg = "", Profile profile = Profile.iOS, string appName = "testApp", bool use_csc = false)
 		{
 			var ext = target == "exe" ? "exe" : "dll";
 			var cs = Path.Combine (targetDirectory, "testApp.cs");
@@ -3721,7 +3775,7 @@ public class Dummy {
 
 			string output;
 			StringBuilder args = new StringBuilder ();
-			string fileName = GetCompiler (profile, args);
+			string fileName = GetCompiler (profile, args, use_csc);
 			args.AppendFormat ($" /noconfig /t:{target} /nologo /out:{StringUtils.Quote (assembly)} /r:{StringUtils.Quote (root_library)} {StringUtils.Quote (cs)} {extraArg}");
 			if (ExecutionHelper.Execute (fileName, args.ToString (), out output) != 0) {
 				Console.WriteLine ("{0} {1}", fileName, args);

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -649,7 +649,7 @@ namespace Xamarin
 			return MTouch.CompileTestAppLibrary (asm_dir, "class X {}", appName: Path.GetFileNameWithoutExtension (asm_name));
 		}
 
-		public void CreateTemporaryApp (bool hasPlist = false, string appName = "testApp", string code = null, string extraArg = "", string extraCode = null, string usings = null)
+		public void CreateTemporaryApp (bool hasPlist = false, string appName = "testApp", string code = null, string extraArg = "", string extraCode = null, string usings = null, bool use_csc = false)
 		{
 			string testDir;
 			if (RootAssembly == null) {
@@ -661,7 +661,7 @@ namespace Xamarin
 			var app = AppPath ?? Path.Combine (testDir, appName + ".app");
 			Directory.CreateDirectory (app);
 			AppPath = app;
-			RootAssembly = MTouch.CompileTestAppExecutable (testDir, code, extraArg, Profile, appName, extraCode, usings);
+			RootAssembly = MTouch.CompileTestAppExecutable (testDir, code, extraArg, Profile, appName, extraCode, usings, use_csc);
 
 			if (hasPlist)
 				File.WriteAllText (Path.Combine (app, "Info.plist"), CreatePlist (Profile, appName));

--- a/tools/common/CoreResolver.cs
+++ b/tools/common/CoreResolver.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+#if MTOUCH
+using ProductException=Xamarin.Bundler.MonoTouchException;
+#else
+using ProductException=Xamarin.Bundler.MonoMacException;
+#endif
+
+namespace Xamarin.Bundler {
+
+	public abstract class CoreResolver : IAssemblyResolver {
+
+		internal Dictionary<string, AssemblyDefinition> cache;
+
+		public string FrameworkDirectory { get; set; }
+		public string RootDirectory { get; set; }
+		public string ArchDirectory { get; set; }
+
+
+		public CoreResolver ()
+		{
+			cache = new Dictionary<string, AssemblyDefinition> (NormalizedStringComparer.OrdinalIgnoreCase);
+		}
+
+		public IDictionary<string, AssemblyDefinition> ResolverCache { get { return cache; } }
+
+		public IDictionary ToResolverCache ()
+		{
+			var resolver_cache = new Dictionary<string, AssemblyDefinition> (NormalizedStringComparer.OrdinalIgnoreCase);
+			foreach (var pair in cache)
+				resolver_cache.Add (pair.Key, pair.Value);
+
+			return resolver_cache;
+		}
+
+		public void Dispose ()
+		{
+		}
+
+		public AssemblyDefinition Resolve (AssemblyNameReference name)
+		{
+			return Resolve (name, new ReaderParameters { AssemblyResolver = this });
+		}
+
+		public abstract AssemblyDefinition Resolve (AssemblyNameReference name, ReaderParameters parameters);
+
+		protected ReaderParameters CreateDefaultReaderParameters (string path)
+		{
+			var parameters = new ReaderParameters ();
+			parameters.AssemblyResolver = this;
+			parameters.InMemory = new FileInfo (path).Length < 1024 * 1024 * 100; // 100 MB.
+			parameters.ReadSymbols = true;
+			parameters.SymbolReaderProvider = new DefaultSymbolReaderProvider (throwIfNoSymbol: false);
+			return parameters;
+		}
+
+		public virtual AssemblyDefinition Load (string fileName)
+		{
+			if (!File.Exists (fileName))
+				return null;
+
+			AssemblyDefinition assembly;
+			var name = Path.GetFileNameWithoutExtension (fileName);
+			if (cache.TryGetValue (name, out assembly))
+				return assembly;
+
+			try {
+				fileName = Target.GetRealPath (fileName);
+
+				// Check the architecture-specific directory
+				if (Path.GetDirectoryName (fileName) == FrameworkDirectory && !string.IsNullOrEmpty (ArchDirectory)) {
+					var archName = Path.Combine (ArchDirectory, Path.GetFileName (fileName));
+					if (File.Exists (archName))
+						fileName = archName;
+				}
+
+				var parameters = CreateDefaultReaderParameters (fileName);
+				try {
+					assembly = ModuleDefinition.ReadModule (fileName, parameters).Assembly;
+				}
+				catch (InvalidOperationException e) {
+					// cecil use the default message so it's not very helpful to detect the root cause
+					if (!e.TargetSite.ToString ().Contains ("Void ReadSymbols(Mono.Cecil.Cil.ISymbolReader)"))
+						throw;
+					ErrorHelper.Show (ErrorHelper.CreateWarning (129, $"Debugging symbol file for '{fileName}' does not match the assembly and is ignored."));
+					parameters.ReadSymbols = false;
+					parameters.SymbolReaderProvider = null;
+					assembly = ModuleDefinition.ReadModule (fileName, parameters).Assembly;
+				}
+			}
+			catch (Exception e) {
+				throw new ProductException (9, true, e, "Error while loading assemblies: {0}", fileName);
+			}
+			cache.Add (name, assembly);
+			return assembly;
+		}
+
+		protected AssemblyDefinition SearchDirectory (string name, string directory, string extension = ".dll")
+		{
+			var file = DirectoryGetFile (directory, name + extension);
+			if (file.Length > 0)
+				return Load (file);
+			return null;
+		}
+
+		static string DirectoryGetFile (string directory, string file)
+		{
+			var files = Directory.GetFiles (directory, file);
+			if (files != null && files.Length > 0)
+				return files [0];
+
+			return String.Empty;
+		}
+	}
+}

--- a/tools/common/CoreResolver.cs
+++ b/tools/common/CoreResolver.cs
@@ -88,10 +88,11 @@ namespace Xamarin.Bundler {
 					// cecil use the default message so it's not very helpful to detect the root cause
 					if (!e.TargetSite.ToString ().Contains ("Void ReadSymbols(Mono.Cecil.Cil.ISymbolReader)"))
 						throw;
-					ErrorHelper.Show (ErrorHelper.CreateWarning (129, $"Debugging symbol file for '{fileName}' does not match the assembly and is ignored."));
 					parameters.ReadSymbols = false;
 					parameters.SymbolReaderProvider = null;
 					assembly = ModuleDefinition.ReadModule (fileName, parameters).Assembly;
+					// only report the warning (on symbols) if we can actually load the assembly itself (otherwise it's more confusing than helpful)
+					ErrorHelper.Show (ErrorHelper.CreateWarning (129, $"Debugging symbol file for '{fileName}' does not match the assembly and is ignored."));
 				}
 			}
 			catch (Exception e) {

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -128,6 +128,7 @@ mmp_sources = \
 	$(TOP)/tools/common/Target.cs \
 	$(TOP)/tools/common/Application.cs \
 	$(TOP)/tools/common/Assembly.cs \
+	$(TOP)/tools/common/CoreResolver.cs \
 	$(TOP)/tools/common/DerivedLinkContext.cs \
 	$(TOP)/tools/common/StringUtils.cs \
 	$(TOP)/src/Foundation/ConnectAttribute.cs \

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1912,7 +1912,7 @@ namespace Xamarin.Bundler {
 			if (AssemblySwapInfo.AssemblyNeedsSwappedOut (path))
 				path = AssemblySwapInfo.GetSwappedAssemblyPath (path);
 
-			var assembly = BuildTarget.Resolver.AddAssembly (path);
+			var assembly = BuildTarget.Resolver.Load (path);
 			if (assembly == null)
 				ErrorHelper.Warning (1501, "Can not resolve reference: {0}", path);
 			return assembly;
@@ -1921,7 +1921,7 @@ namespace Xamarin.Bundler {
 		static AssemblyDefinition AddAssemblyReferenceToResolver (string reference)
 		{
 			if (AssemblySwapInfo.ReferencedNeedsSwappedOut (reference))
-				return BuildTarget.Resolver.AddAssembly (AssemblySwapInfo.GetSwappedReference (reference));
+				return BuildTarget.Resolver.Load (AssemblySwapInfo.GetSwappedReference (reference));
 
 			return BuildTarget.Resolver.Resolve (reference);
 		}

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -359,6 +359,9 @@
     <Compile Include="..\common\StringUtils.cs">
       <Link>external\StringUtils.cs</Link>
     </Compile>
+    <Compile Include="..\common\CoreResolver.cs">
+      <Link>common\CoreResolver.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/tools/mmp/resolver.cs
+++ b/tools/mmp/resolver.cs
@@ -21,87 +21,31 @@
  * THE SOFTWARE.
  */
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Security.Cryptography;
 
 using Mono.Cecil;
-using Mono.Cecil.Cil;
 
 namespace Xamarin.Bundler {
-	public partial class MonoMacResolver : IAssemblyResolver {
+	public partial class MonoMacResolver : CoreResolver {
 		public static bool IsClassic { get { return Driver.IsClassic; } }
 		public static bool IsUnified { get { return Driver.IsUnified; } }
-
-		public string FrameworkDirectory { get; set; }
-		public string RootDirectory { get; set; }
-		public string ArchDirectory { get; set; }
 
 		public List <string> CommandLineAssemblies { get; set; }
 		public List<Exception> Exceptions = new List<Exception> ();
 
-		Dictionary<string, AssemblyDefinition> cache;
-
-		public MonoMacResolver ()
-		{
-			cache = new Dictionary<string, AssemblyDefinition> ();
-		}
-
-		public IDictionary<string, AssemblyDefinition> ResolverCache { get { return cache; } }
-
-		public IDictionary ToResolverCache ()
-		{
-			var resolver_cache = new Hashtable ();
-			foreach (var pair in cache)
-				resolver_cache.Add (pair.Key, pair.Value);
-
-			return resolver_cache;
-		}
-
-		public AssemblyDefinition AddAssembly (string fileName)
-		{
-			if (!File.Exists (fileName))
-				return null;
-
-			AssemblyDefinition assembly;
-			var name = Path.GetFileNameWithoutExtension (fileName);
-			if (cache.TryGetValue (name, out assembly))
-				return assembly;
-
-			assembly = AssemblyDefinition.ReadAssembly (fileName, new ReaderParameters 
-				{
-					AssemblyResolver = this,
-					InMemory = new FileInfo (fileName).Length < 1024 * 1024 * 100, // 100 MB
-					ReadSymbols = true,
-					SymbolReaderProvider = new DefaultSymbolReaderProvider (throwIfNoSymbol: false) 
-				});
-			cache.Add (name, assembly);
-			return assembly;
-		}
 
 		public AssemblyDefinition GetAssembly (string fileName)
 		{
 			return Resolve (Path.GetFileNameWithoutExtension (fileName));
 		}
 
-		public AssemblyDefinition Resolve (string fullName, ReaderParameters parameters)
-		{
-			return Resolve (AssemblyNameReference.Parse (fullName), parameters);
-		}
-
 		public AssemblyDefinition Resolve (string fullName)
 		{
-			return Resolve (fullName, new ReaderParameters { AssemblyResolver = this });
+			return Resolve (AssemblyNameReference.Parse (fullName), new ReaderParameters { AssemblyResolver = this });
 		}
 
-		public AssemblyDefinition Resolve (AssemblyNameReference reference)
-		{
-			return Resolve (reference, new ReaderParameters { AssemblyResolver = this });
-		}
-
-		public AssemblyDefinition Resolve (AssemblyNameReference reference, ReaderParameters parameters)
+		public override AssemblyDefinition Resolve (AssemblyNameReference reference, ReaderParameters parameters)
 		{
 			var name = reference.Name;
 
@@ -115,7 +59,7 @@ namespace Xamarin.Bundler {
 						return false;
 					return String.Compare (name, Path.GetFileNameWithoutExtension (t), StringComparison.Ordinal) == 0;
 				});
-				assembly = String.IsNullOrEmpty (cmdasm) ? null : AddAssembly (cmdasm);
+				assembly = String.IsNullOrEmpty (cmdasm) ? null : Load (cmdasm);
 				if (assembly != null)
 					return assembly;
 			}
@@ -137,37 +81,11 @@ namespace Xamarin.Bundler {
 					return assembly;
 			}
 
-			assembly = SearchDirectory (name, RootDirectory);
+			assembly = SearchDirectory (name, RootDirectory, ".exe");
 			if (assembly != null)
 				return assembly;
 
 			return null;
-		}
-
-		AssemblyDefinition SearchDirectory (string name, string directory)
-		{
-			var file = DirectoryGetFile (directory, name + ".dll");
-			if (file.Length > 0)
-				return AddAssembly (file);
-
-			file = DirectoryGetFile (directory, name + ".exe");
-			if (file.Length > 0)
-				return AddAssembly (file);
-
-			return null;
-		}
-
-		static string DirectoryGetFile (string directory, string file)
-		{
-			var files = Directory.GetFiles (directory, file);
-			if (files != null && files.Length > 0)
-				return files [0];
-
-			return "";
-		}
-
-		public void Dispose ()
-		{
 		}
 	}
 }

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -134,6 +134,7 @@ MTOUCH_SOURCES = \
 	BuildTasks.mtouch.cs \
 	$(TOP)/tools/common/Application.cs \
 	$(TOP)/tools/common/Assembly.cs \
+	$(TOP)/tools/common/CoreResolver.cs \
 	$(TOP)/tools/common/DerivedLinkContext.cs \
 	$(TOP)/tools/common/Target.cs \
 	$(TOP)/tools/common/CompilerFlags.cs \

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -354,6 +354,9 @@
     <Compile Include="..\common\StringUtils.cs">
       <Link>StringUtils.cs</Link>
     </Compile>
+    <Compile Include="..\common\CoreResolver.cs">
+      <Link>common\CoreResolver.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Core" />


### PR DESCRIPTION
Try to read the assembly with symbols and, if that fails, warn and
fallback to loading them without symbols.

This fixes cases were it's not easy to update or delete (e.g. nuget)
bad symbols files - so this cannot be an error without causing a lot
of pain.

However it needs to be reported, otherwise it wont be fixed (by the
publisher) and it can limit the debugability of the application and
the usefulness of the stacktraces.

Finally merge most of the resolver's code between mtouch and mmp so
we don't have to fix such issue twice anymore.

note: this needs to be slightly updated once we get a version of cecil
that can give us a more precise error message.

Also bring Rolf's tests from
https://github.com/xamarin/xamarin-macios/pull/3079

reference:
https://github.com/xamarin/xamarin-macios/issues/3200