### PR TITLE
[coreanimation] Add [Protocol] to CAAnimationDelegate

### DIFF
--- a/src/CoreAnimation/CACompat.cs
+++ b/src/CoreAnimation/CACompat.cs
@@ -30,6 +30,73 @@ namespace XamCore.CoreAnimation {
 			get { return CAScroll.Vertically.GetConstant (); }
 		}
 	}
+
+	partial class CAAnimation {
+		// cannot be handled by the generator (error BI1110 because it's not an protocol/interface)
+		public CAAnimationDelegate Delegate {
+			get { return WeakDelegate as CAAnimationDelegate; }
+			set { WeakDelegate = value; }
+		}
+
+		// lack of generated delegate force us to add events manually too
+
+		_CAAnimationDelegate EnsureCAAnimationDelegate ()
+		{
+			var del = Delegate;
+			if (del == null || (!(del is _CAAnimationDelegate))){
+				del = new _CAAnimationDelegate ();
+				Delegate = del;
+			}
+			return (_CAAnimationDelegate) del;
+		}
+
+#pragma warning disable 672
+		[Register]
+		sealed class _CAAnimationDelegate : CAAnimationDelegate { 
+			public _CAAnimationDelegate () { IsDirectBinding = false; }
+
+			internal EventHandler animationStarted;
+			[Preserve (Conditional = true)]
+			public override void AnimationStarted (CAAnimation anim)
+			{
+				EventHandler handler = animationStarted;
+				if (handler != null){
+					handler (anim, EventArgs.Empty);
+				}
+			}
+
+			internal EventHandler<CAAnimationStateEventArgs> animationStopped;
+			[Preserve (Conditional = true)]
+			public override void AnimationStopped (CAAnimation anim, bool finished)
+			{
+				EventHandler<CAAnimationStateEventArgs> handler = animationStopped;
+				if (handler != null){
+					var args = new CAAnimationStateEventArgs (finished);
+					handler (anim, args);
+				}
+			}
+
+		}
+#pragma warning restore 672
+
+		public event EventHandler AnimationStarted {
+			add { EnsureCAAnimationDelegate ().animationStarted += value; }
+			remove { EnsureCAAnimationDelegate ().animationStarted -= value; }
+		}
+
+		public event EventHandler<CAAnimationStateEventArgs> AnimationStopped {
+			add { EnsureCAAnimationDelegate ().animationStopped += value; }
+			remove { EnsureCAAnimationDelegate ().animationStopped -= value; }
+		}
+	}
+
+	public partial class CAAnimationStateEventArgs : EventArgs {
+		public CAAnimationStateEventArgs (bool finished)
+		{
+			this.Finished = finished;
+		}
+		public bool Finished { get; set; }
+	}
 }
 
 #endif

--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -974,7 +974,11 @@ namespace XamCore.CoreAnimation {
 		void RunAction (string eventKey, NSObject obj, [NullAllowed] NSDictionary arguments);
 	}
 	
-	[BaseType (typeof (NSObject), Delegates=new string [] {"WeakDelegate"}, Events=new Type [] { typeof (CAAnimationDelegate)})]
+	[BaseType (typeof (NSObject)
+#if XAMCORE_4_0
+		, Delegates = new string [] {"WeakDelegate"}, Events = new Type [] { typeof (CAAnimationDelegate) }
+#endif
+	)]
 	interface CAAnimation : CAAction, CAMediaTiming, NSSecureCoding, NSMutableCopying, SCNAnimationProtocol {
 		[Export ("animation"), Static]
 		CAAnimation CreateAnimation ();
@@ -987,8 +991,11 @@ namespace XamCore.CoreAnimation {
 		[Export ("timingFunction", ArgumentSemantic.Strong)]
 		CAMediaTimingFunction TimingFunction { get; set; }
 	
+#if XAMCORE_4_0
+		// before that we need to be wrap this manually to avoid the BI1110 error
 		[Wrap ("WeakDelegate")]
-		CAAnimationDelegate Delegate { get; set; }
+		ICAAnimationDelegate Delegate { get; set; }
+#endif
 	
 		[Export ("delegate", ArgumentSemantic.Strong)][NullAllowed]
 		NSObject WeakDelegate { get; set; }
@@ -1086,11 +1093,19 @@ namespace XamCore.CoreAnimation {
 		#endregion
 	}
 
-	// Adding [Protocol] breaks when building with older SDKs (see bug #43825)
-	//[Protocol] // since iOS10
+	interface ICAAnimationDelegate {}
+
 	[BaseType (typeof (NSObject))]
-	[Model]
+#if IOS || TVOS
+	[Protocol (FormalSince = "10.0")]
+#elif MONOMAC
+	[Protocol (FormalSince = "10.12")]
+#elif WATCH
+	[Protocol (FormalSince = "3.0"]
+#else
 	[Synthetic]
+#endif
+	[Model]
 	interface CAAnimationDelegate {
 		[Export ("animationDidStart:")]
 		void AnimationStarted ([NullAllowed] CAAnimation anim);

--- a/tests/xtro-sharpie/common-CoreAnimation.ignore
+++ b/tests/xtro-sharpie/common-CoreAnimation.ignore
@@ -8,3 +8,11 @@
 !unknown-field! kCAEmitterBehaviorSimpleAttractor bound
 !unknown-field! kCAEmitterBehaviorValueOverLife bound
 !unknown-field! kCAEmitterBehaviorWave bound
+
+
+## unsorted
+
+!missing-field! CATransform3DIdentity not bound
+!missing-pinvoke! CATransform3DMakeScale is not bound
+!missing-pinvoke! CATransform3DMakeTranslation is not bound
+!missing-selector! CALayer::shouldArchiveValueForKey: not bound

--- a/tests/xtro-sharpie/iOS-CoreAnimation.ignore
+++ b/tests/xtro-sharpie/iOS-CoreAnimation.ignore
@@ -1,5 +1,0 @@
-!missing-field! CATransform3DIdentity not bound
-!missing-pinvoke! CATransform3DMakeScale is not bound
-!missing-pinvoke! CATransform3DMakeTranslation is not bound
-!missing-protocol! CAAnimationDelegate not bound
-!missing-selector! CALayer::shouldArchiveValueForKey: not bound

--- a/tests/xtro-sharpie/macOS-CoreAnimation.ignore
+++ b/tests/xtro-sharpie/macOS-CoreAnimation.ignore
@@ -1,15 +1,10 @@
-!missing-field! CATransform3DIdentity not bound
 !missing-field! kCARendererColorSpace not bound
-!missing-pinvoke! CATransform3DMakeScale is not bound
-!missing-pinvoke! CATransform3DMakeTranslation is not bound
-!missing-protocol! CAAnimationDelegate not bound
 !missing-protocol! CALayoutManager not bound
 !missing-protocol-conformance! CAConstraintLayoutManager should conform to CALayoutManager
 !missing-selector! +CALayer::layerWithRemoteClientId: not bound
 !missing-selector! +CARenderer::rendererWithCGLContext:options: not bound
 !missing-selector! +CARenderer::rendererWithMTLTexture:options: not bound
 !missing-selector! CAConstraint::offset not bound
-!missing-selector! CALayer::shouldArchiveValueForKey: not bound
 !missing-selector! CAMetalLayer::colorspace not bound
 !missing-selector! CAMetalLayer::setColorspace: not bound
 !missing-selector! CAMetalLayer::setWantsExtendedDynamicRangeContent: not bound

--- a/tests/xtro-sharpie/tvOS-CoreAnimation.ignore
+++ b/tests/xtro-sharpie/tvOS-CoreAnimation.ignore
@@ -1,5 +1,0 @@
-!missing-field! CATransform3DIdentity not bound
-!missing-pinvoke! CATransform3DMakeScale is not bound
-!missing-pinvoke! CATransform3DMakeTranslation is not bound
-!missing-protocol! CAAnimationDelegate not bound
-!missing-selector! CALayer::shouldArchiveValueForKey: not bound


### PR DESCRIPTION
This now formal `CAAnimationDelegate` protocol had to be reverted [1]
because we did not support `FormalSince` at the time - and this broke the
static registrar when used with older SDK. Support was added in [2] but
did not include `CAAnimationDelegate` (but `CALayerDelegate` was fixed).

Because this was not a protocol the `Delegate` property expose it as a
`CAAnimationDelegate`, the concrete/model type, and not an interface.

The workaround so `ICAAnimationDelegate` can be used, thru the
`WeakDelegate`, requires to manually re-bind some API because the
generator won't allow this anymore (it's bad to expose a [Model]
when a [Protocol] exists).

xtro data updated

[1] https://github.com/xamarin/xamarin-macios/pull/698
[2] https://github.com/xamarin/xamarin-macios/pull/2130