### PR TITLE
[xharness] Run mtouch and mmp tests when there are MSBuild changes.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -345,6 +345,7 @@ namespace xharness
 				"src/ObjCRuntime/Registrar.cs",
 				"external/mono",
 				"external/llvm",
+				"msbuild",
 			};
 			var mmp_prefixes = new string [] {
 				"tests/mmptest",
@@ -354,6 +355,7 @@ namespace xharness
 				"tools/linker",
 				"src/ObjCRuntime/Registrar.cs",
 				"external/mono",
+				"msbuild",
 			};
 			var bcl_prefixes = new string [] {
 				"tests/bcl-test",


### PR DESCRIPTION
In particular the mmp tests build a lot of project files, which means they can
find issues whenever something in the MSBuild logic changes, so run them.

They would have caught https://github.com/xamarin/maccore/issues/612 for instance.