### PR TITLE
[linker] Improve inlining of IsDirectBinding check to inline both true and false values.

### DIFF
--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -187,6 +187,19 @@ namespace XamCore.Foundation {
 					new Class (ClassHandle).Name));
 			}
 
+			// The authorative value for the IsDirectBinding value is the register attribute:
+			//
+			//     [Register ("MyClass", true)] // the second parameter specifies the IsDirectBinding value
+			//     class MyClass : NSObject {}
+			//
+			// Unfortunately looking up this attribute every time a class is instantiated is
+			// slow (since fetching attributes is slow), so we guess here: if the actual type
+			// of the object is in the platform assembly, then we assume IsDirectBinding=true:
+			//
+			// IsDirectBinding = (this.GetType ().Assembly == PlatformAssembly);
+			//
+			// and any subclasses in the platform assembly which is not a direct binding have
+			// to set the correct value in their constructors.
 			IsDirectBinding = (this.GetType ().Assembly == PlatformAssembly);
 			Runtime.RegisterNSObject (this, handle);
 

--- a/tools/common/DerivedLinkContext.cs
+++ b/tools/common/DerivedLinkContext.cs
@@ -19,7 +19,10 @@ namespace Xamarin.Tuner
 		List<ICustomAttributeProvider> xml_serialization = new List<ICustomAttributeProvider> ();
 
 		HashSet<TypeDefinition> cached_isnsobject;
-		HashSet<TypeDefinition> needs_isdirectbinding_check;
+		// Tristate:
+		//   null = don't know, must check at runtime (can't inline)
+		//   true/false = corresponding constant value
+		Dictionary<TypeDefinition, bool?> isdirectbinding_value;
 		HashSet<MethodDefinition> generated_code;
 
 		public HashSet<TypeDefinition> CachedIsNSObject {
@@ -27,9 +30,9 @@ namespace Xamarin.Tuner
 			set { cached_isnsobject = value; }
 		}
 
-		public HashSet<TypeDefinition> NeedsIsDirectBindingCheck {
-			get { return needs_isdirectbinding_check; }
-			set { needs_isdirectbinding_check = value; }
+		public Dictionary<TypeDefinition, bool?> IsDirectBindingValue {
+			get { return isdirectbinding_value; }
+			set { isdirectbinding_value = value; }
 		}
 
 		public HashSet<MethodDefinition> GeneratedCode {

--- a/tools/linker/MonoTouch.Tuner/Extensions.cs
+++ b/tools/linker/MonoTouch.Tuner/Extensions.cs
@@ -10,12 +10,16 @@ namespace MonoTouch.Tuner {
 
 	public static class Extensions {
 		
-		public static bool IsDirectBindingCheckRequired (this TypeDefinition type, DerivedLinkContext link_context)
+		public static bool? GetIsDirectBindingConstant (this TypeDefinition type, DerivedLinkContext link_context)
 		{
-			if (link_context.NeedsIsDirectBindingCheck == null)
-				return true;
+			if (link_context?.IsDirectBindingValue == null)
+				return null;
 			
-			return link_context.NeedsIsDirectBindingCheck.Contains (type);
+			bool? value;
+			if (link_context.IsDirectBindingValue.TryGetValue (type, out value))
+				return value;
+
+			return null;
 		}
 
 		public static bool IsPlatformType (this TypeReference type, string @namespace, string name)

--- a/tools/linker/MonoTouch.Tuner/MonoTouchTypeMap.cs
+++ b/tools/linker/MonoTouch.Tuner/MonoTouchTypeMap.cs
@@ -15,6 +15,7 @@ using Mono.Cecil;
 using Mono.Linker.Steps;
 using Mono.Tuner;
 
+using Xamarin.Bundler;
 using Xamarin.Linker;
 using Xamarin.Tuner;
 
@@ -22,7 +23,7 @@ namespace MonoTouch.Tuner {
 
 	public class MonoTouchTypeMapStep : TypeMapStep {
 		HashSet<TypeDefinition> cached_isnsobject = new HashSet<TypeDefinition> ();
-		HashSet<TypeDefinition> needs_isdirectbinding_check = new HashSet<TypeDefinition> ();
+		Dictionary<TypeDefinition, bool?> isdirectbinding_value = new Dictionary<TypeDefinition, bool?> ();
 		HashSet<MethodDefinition> generated_code = new HashSet<MethodDefinition> ();
 
 		DerivedLinkContext LinkContext {
@@ -36,7 +37,7 @@ namespace MonoTouch.Tuner {
 			base.EndProcess ();
 
 			LinkContext.CachedIsNSObject = cached_isnsobject;
-			LinkContext.NeedsIsDirectBindingCheck = needs_isdirectbinding_check;
+			LinkContext.IsDirectBindingValue = isdirectbinding_value;
 			LinkContext.GeneratedCode = generated_code;
 		}
 
@@ -59,12 +60,7 @@ namespace MonoTouch.Tuner {
 				return;
 			
 			// if not, it's a user type, the IsDirectBinding check is required by all ancestors
-			if (!IsGeneratedBindings (type, LinkContext))
-				NeedsIsDirectBindingCheck (type);
-#if DEBUG
-			else
-				Console.WriteLine ("{0} does NOT needs IsDirectBinding check", type);
-#endif
+			SetIsDirectBindingValue (type);
 		}
 		
 		// called once for each 'type' so it's a nice place to cache the result
@@ -76,41 +72,57 @@ namespace MonoTouch.Tuner {
 			cached_isnsobject.Add (type);
 			return true;
 		}
-		
-		// type has a "public .ctor (IntPtr)" with a [CompilerGenerated] attribute
-		static bool IsGeneratedBindings (TypeDefinition type, DerivedLinkContext link_context)
+
+		bool IsWrapperType (TypeDefinition type)
 		{
-			if (type.IsNested)
-				return IsGeneratedBindings (type.DeclaringType, link_context);
-			
-			if (!type.HasMethods)
+			var registerAttribute = LinkContext.StaticRegistrar.GetRegisterAttribute (type);
+			return registerAttribute?.IsWrapper == true || registerAttribute?.SkipRegistration == true;
+		}
+
+		bool IsCIFilter (TypeReference type)
+		{
+			if (type == null)
 				return false;
-			
-			foreach (MethodDefinition m in type.Methods) {
-				if (!m.IsConstructor)
-					continue;
-				if (!m.HasParameters)
-					continue;
-				if (m.Parameters.Count != 1)
-					continue;
-				if (!m.Parameters [0].ParameterType.Is ("System", "IntPtr"))
-					continue;
-				return m.IsGeneratedCode (link_context);
-			}
-			return false;
+			return type.Is (Namespaces.CoreImage, "CIFilter") || IsCIFilter (type.Resolve ().BaseType);
 		}
 		
-		void NeedsIsDirectBindingCheck (TypeDefinition type)
+		void SetIsDirectBindingValue (TypeDefinition type)
 		{
-			// all ancestors must be disallowed
-			// so we can short-circuit the recursion if we already have processed it
-			if (needs_isdirectbinding_check.Contains (type))
+			if (isdirectbinding_value.ContainsKey (type))
 				return;
-			
-			needs_isdirectbinding_check.Add (type);
-			var base_type = type.BaseType;
-			if (base_type != null)
-				NeedsIsDirectBindingCheck (base_type.Resolve ());
+
+			// We have a special implementation of CIFilters, and we do not want to 
+			// optimize anything for those classes to not risk optimizing this wrong.
+			// This means we must set the IsDirectBinding value to null for CIFilter
+			// and all its base classes to allow both code paths and determine at runtime.
+			// References:
+			// * https://github.com/xamarin/xamarin-macios/pull/3055
+			// * https://bugzilla.xamarin.com/show_bug.cgi?id=15465
+			if (IsCIFilter (type)) {
+				isdirectbinding_value [type] = null;
+				var base_type = type.BaseType.Resolve ();
+				while (base_type != null && IsNSObject (base_type)) {
+					isdirectbinding_value [base_type] = null;
+					base_type = base_type.BaseType.Resolve ();
+				}
+				return;
+			}
+
+			var isWrapperType = IsWrapperType (type);
+
+			if (!isWrapperType) {
+				isdirectbinding_value [type] = false;
+
+				// We must clear IsDirectBinding for any wrapper superclasses.
+				var base_type = type.BaseType.Resolve ();
+				while (base_type != null && IsNSObject (base_type)) {
+					if (IsWrapperType (base_type))
+						isdirectbinding_value [base_type] = null;
+					base_type = base_type.BaseType.Resolve ();
+				}
+			} else {
+				isdirectbinding_value [type] = true; // Let's try 'true' first, any derived non-wrapper classes will clear it if needed
+			}
 		}
 	}
 }

--- a/tools/linker/ObjCExtensions.cs
+++ b/tools/linker/ObjCExtensions.cs
@@ -62,6 +62,7 @@ namespace Xamarin.Linker {
 			Vision = profile.GetNamespace ("Vision");
 			IOSurface = profile.GetNamespace ("IOSurface");
 			PdfKit = profile.GetNamespace ("PdfKit");
+			CoreImage = profile.GetNamespace ("CoreImage");
 #if MONOMAC
 			PhotosUI = profile.GetNamespace ("PhotosUI");
 			IOBluetooth = profile.GetNamespace ("IOBluetooth");
@@ -149,6 +150,7 @@ namespace Xamarin.Linker {
 
 		public static string PdfKit { get; private set; }
 
+		public static string CoreImage { get; private set; }
 #if MONOMAC
 		public static string PhotosUI { get; private set; }
 		public static string IOBluetooth { get; private set; }


### PR DESCRIPTION
Previous behavior
=================

* The linker would determine if a class is a generated binding class or not.
  This was determined by the presence of a constructor taking a single IntPtr
  argument, and with a [CompilerGenerated] attribute.
* If a class was not a generated binding class, then that class and all its
  superclasses were marked as not optimizable (in the context of inlining the
  IsDirectBinding check).
* The end result was that all classes with a [CompilerGenerated] IntPtr
  constructor that weren't subclassed, were optimized (the IsDirectBinding
  value was implied to be 'true').

Unfortunately this does not match how the IsDirectBinding value is actually
computed, and is in many cases quite wrong.

Background
==========

The authorative value for the IsDirectBinding value is the register attribute:

```csharp
[Register ("MyClass", true)] // the second parameter specifies the IsDirectBinding value
class MyClass : NSObject {}
```

Due to history this second parameter is called `IsWrapper` and not
`IsDirectBinding`, but it's the exact same thing.

Unfortunately looking up this attribute every time a class is instantiated is
slow (since fetching attributes is slow), so we guess this value in NSObject's
initialization: if the actual type of the object is in the platform assembly,
then we assume IsDirectBinding=true:

```csharp
IsDirectBinding = (this.GetType ().Assembly == PlatformAssembly);
```

and any subclasses in the platform assembly which is not a direct binding have
to set the correct value in their constructors.

New behavior
============

In the linker we now track three states for the IsDirectBinding value for each
class: if it can be inlined into a constant true or false, or if it has to be
checked at runtime (a nullable bool is used, and null corresponds with this
last undetermined state).

* The linker will look at the `[Register]` attribute for a class, and:
    * If the type is CIFilter, store that IsDirectBinding=undetermined.
    * If IsWrapper=False, store that IsDirectBinding=False for that class, and
      that IsDirectBinding=undetermined for all super classes where
      IsWrapper=True.
    * If IsWrapper=True, tentatively assume IsDirectBinding=True in that class
      unless already determined to be undetermined (which will be overruled if
      a non-wrapper subclass is found later).

Results
=======

For monotouch-test, the changes are as follows:

* Classes we can now assume IsDirectBinding=true: https://gist.github.com/rolfbjarne/acd6a8cf1236562a832d6db9400afee9#file-foo-diff-L1-L25
* Classes we previously assumed incorrectly that IsDirectBinding=true: https://gist.github.com/rolfbjarne/acd6a8cf1236562a832d6db9400afee9#file-foo-diff-L27-L645
* Classes we can now assume IsDirectBinding=false: https://gist.github.com/rolfbjarne/acd6a8cf1236562a832d6db9400afee9#file-foo-diff-L647-L2281

There are also minor size improvements (in the iPhone/Debug64 configuration):

The executable is 17.632 bytes smaller:

    -rwxr-xr-x  1 rolf  staff  73038384 Jan 12 12:40 /Users/rolf/test/old/monotouchtest.app/monotouchtest
    -rwxr-xr-x  1 rolf  staff  73020752 Jan 12 12:50 /Users/rolf/test/new/monotouchtest.app/monotouchtest

Xamarin.iOS.dll is 3.072 bytes smaller (this will probably be 0 on a release (stripped) build).

    -rw-r--r--  1 rolf  staff   2522624 Jan 12 12:40 /Users/rolf/test/old/monotouchtest.app/Xamarin.iOS.dll
    -rw-r--r--  1 rolf  staff   2519552 Jan 12 12:50 /Users/rolf/test/new/monotouchtest.app/Xamarin.iOS.dll

CIFilter
========

There's a complication with CIFilters [1] [2], their implementation is
somewhat special, so we do not want to optimize anything for those classes to
not risk getting anything wrong.

[1] https://github.com/xamarin/xamarin-macios/pull/3055
[2] https://bugzilla.xamarin.com/show_bug.cgi?id=15465