### PR TITLE
[msbuild] DetectSigningIdentity fix for Mac when RequireProvisioningP…

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/CodesignAppBundle.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/CodesignAppBundle.cs
@@ -13,8 +13,9 @@ namespace Xamarin.iOS.Tasks
 {
 	[TestFixture ("iPhone", "Debug")]
 	[TestFixture ("iPhone", "Release")]
-	[TestFixture ("iPhoneSimulator", "Debug")]
-	[TestFixture ("iPhoneSimulator", "Release")]
+	// Note: Disabled because Simulator builds aren't consistently signed or not-signed, while device builds are.
+	//[TestFixture ("iPhoneSimulator", "Debug")]
+	//[TestFixture ("iPhoneSimulator", "Release")]
 	public class CodesignAppBundle : ProjectTest
 	{
 		readonly string config;


### PR DESCRIPTION
…rofile is false

* [msbuild] DetectSigningIdentity fix for Mac when RequireProvisioningProfile is false

Fixes https://github.com/xamarin/maccore/issues/612

* Disable some tests since they don't make correct assumptions anymore

* Added comment to explain why tests are disabled