### PR TITLE
[foundation] Reduce duplication inside NSData.FromString methods

### DIFF
--- a/src/Foundation/NSData.cs
+++ b/src/Foundation/NSData.cs
@@ -72,9 +72,7 @@ namespace XamCore.Foundation {
 		
 		public static NSData FromString (string s)
 		{
-			if (s == null)
-				throw new ArgumentNullException ("s");
-			return new NSString (s).Encode (NSStringEncoding.UTF8);
+			return FromString (s, NSStringEncoding.UTF8);
 		}
 
 		public static NSData FromArray (byte [] buffer)
@@ -214,12 +212,13 @@ namespace XamCore.Foundation {
 		
 		public static NSData FromString (string s, NSStringEncoding encoding)
 		{
-			return new NSString (s).Encode (encoding);
+			using (var ns = new NSString (s))
+				return ns.Encode (encoding);
 		}
 
 		public static implicit operator NSData (string s)
 		{
-			return new NSString (s).Encode (NSStringEncoding.UTF8);
+			return FromString (s, NSStringEncoding.UTF8);
 		}
 
 		public NSString ToString (NSStringEncoding encoding)

--- a/tests/monotouch-test/Foundation/NSDataTest.cs
+++ b/tests/monotouch-test/Foundation/NSDataTest.cs
@@ -303,6 +303,23 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
+		public void FromString ()
+		{
+			Assert.Throws<ArgumentNullException> (() => NSData.FromString (null), "1-null");
+			var d = NSData.FromString (String.Empty);
+			Assert.That (d.Length, Is.EqualTo (0), "1-empty");
+
+			Assert.Throws<ArgumentNullException> (() => NSData.FromString (null, NSStringEncoding.Unicode), "2-null");
+			d = NSData.FromString (String.Empty, NSStringEncoding.Unicode);
+			Assert.That (d.Length, Is.EqualTo (2), "2-empty"); // 0xfffe unicode header
+
+			// not sure it was a good choice to throw here (but breaking it would be worse)
+			Assert.Throws<ArgumentNullException> (() => d = ((NSData) (string) null), "as-null");
+			d = (NSData) String.Empty;
+			Assert.That (d.Length, Is.EqualTo (0), "as-empty");
+		}
+
+		[Test]
 		public void Base64String ()
 		{
 			TestRuntime.AssertXcodeVersion (5, 0);
@@ -330,7 +347,7 @@ namespace MonoTouchFixtures.Foundation {
 			using (var ms = new MemoryStream (data))
 			using (var d = NSData.FromStream (ms)) {
 				// This cannot be converted to an UTF8 string and ToString should not throw
-				// so we go back to showing the result of the `descruption` selector
+				// so we go back to showing the result of the `description` selector
 				Assert.That (d.ToString (), Is.EqualTo (d.Description), "ToString");
 			}
 		}


### PR DESCRIPTION
and ensure the temporary `NSString` instance is disposed asap.

Found will debugging something else. Unit tests added to confirm there
is no behavior change when the API are used.