### PR TITLE
[Registrar] Do less work when probing for assembly registration.

### DIFF
--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -2268,13 +2268,13 @@ namespace XamCore.Registrar {
 			if (assemblies.ContainsKey (assembly))
 				return;
 
-			if (!ContainsPlatformReference (assembly)) {
-				assemblies.Add (assembly, null);
+			if (SkipRegisterAssembly (assembly)) {
+				Trace ("[ASSEMBLY] Skipped registration for {0}", GetAssemblyName (assembly));
 				return;
 			}
 
-			if (SkipRegisterAssembly (assembly)) {
-				Trace ("[ASSEMBLY] Skipped registration for {0}", GetAssemblyName (assembly));
+			if (!ContainsPlatformReference (assembly)) {
+				assemblies.Add (assembly, null);
 				return;
 			}
 			


### PR DESCRIPTION
If the assembly is registered in the static registrar, skip it before trying to probe whether it has a reference or not. A dictionary lookup is way faster than probing the referenced assemblies