### PR TITLE
[runtime] Generate a header with the function declarations to call into managed code.

### DIFF
--- a/runtime/.gitignore
+++ b/runtime/.gitignore
@@ -5,6 +5,7 @@ Delegates.generated.cs
 delegates.h
 mono-runtime.m
 xamarin/mono-runtime.h
+xamarin/runtime-generated.h
 app-main.m
 watchextension-main.m
 tvextension-main.m

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -18,6 +18,7 @@ SHIPPED_HEADERS +=         \
 	xamarin/main.h         \
 	xamarin/trampolines.h  \
 	xamarin/runtime.h      \
+	xamarin/runtime-generated.h \
 
 SHARED_SOURCES += mono-runtime.m bindings.m bindings-generated.m shared.m runtime.m trampolines.m trampolines-invoke.m xamarin-support.m nsstring-localization.m trampolines-varargs.m
 SHARED_I386_SOURCES += trampolines-i386.m trampolines-i386-asm.s trampolines-i386-objc_msgSend.s trampolines-i386-objc_msgSendSuper.s trampolines-i386-objc_msgSend_stret.s trampolines-i386-objc_msgSendSuper_stret.s
@@ -29,6 +30,9 @@ SHARED_FILES = $(SHARED_SOURCES) $(SHARED_HEADERS) $(SHARED_I386_SOURCES) $(SHAR
 EXTRA_DEPENDENCIES = $(SHARED_HEADERS)
 
 xamarin/mono-runtime.h: mono-runtime.h.t4 exports.t4
+	$(Q_GEN) $(TT) $< -o $@
+
+xamarin/runtime-generated.h: runtime-generated.h.t4 delegates.t4
 	$(Q_GEN) $(TT) $< -o $@
 
 mono-runtime.m: mono-runtime.m.t4 exports.t4

--- a/runtime/runtime-generated.h.t4
+++ b/runtime/runtime-generated.h.t4
@@ -1,0 +1,35 @@
+// vim: set filetype=c :
+//
+// delegates.h:
+//
+// Authors:
+//   Rolf Bjarne Kvinge <rolf@xamarin.com>
+//
+// Copyright 2018 Microsoft Inc.
+//
+
+/* Functions calling into ObjCRuntime.Runtime */
+
+<#@ include file="delegates.t4" #>
+
+#ifndef __RUNTIME_GENERATED_H__
+#define __RUNTIME_GENERATED_H__
+
+#include "xamarin.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+<# foreach (var d in delegates) {
+#>
+<#= d.CReturnType #>
+<#= d.EntryPoint #> (<#= d.CArgumentSignature #>);
+
+<# } #>
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* __RUNTIME_GENERATED_H__ */

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -230,36 +230,6 @@ typedef void (*xamarin_register_assemblies_callback) ();
 extern xamarin_register_module_callback xamarin_register_modules;
 extern xamarin_register_assemblies_callback xamarin_register_assemblies;
 
-/* Functions calling into ObjCRuntime.Runtime */
-
-void        				xamarin_register_nsobject					(MonoObject *managed_obj, id native_obj, guint32 *exception_gchandle);
-void        				xamarin_register_assembly					(MonoReflectionAssembly *assembly, guint32 *exception_gchandle);
-MonoObject* 				xamarin_create_product_exception			(NSException *exc, guint32 *exception_gchandle);
-id          				xamarin_get_inative_handle					(MonoObject *managed_obj, guint32 *exception_gchandle);
-MonoObject* 				xamarin_get_block_wrapper_creator			(MonoObject *method, int parameter, guint32 *exception_gchandle);
-MonoObject*		 			xamarin_create_block_proxy					(MonoObject *method, void* block, guint32 *exception_gchandle);
-void						xamarin_register_assembly_path 				(const char *path, guint32 *exception_gchandle);
-MonoObject*					xamarin_get_class							(Class ptr, guint32 *exception_gchandle);
-MonoObject*					xamarin_get_selector						(SEL ptr, guint32 *exception_gchandle);
-Class						xamarin_get_class_handle					(MonoObject *obj, guint32 *exception_gchandle);
-SEL							xamarin_get_selector_handle					(MonoObject *obj, guint32 *exception_gchandle);
-void						xamarin_get_method_for_selector				(Class cls, SEL sel, bool is_static, MethodDescription *desc, guint32 *exception_gchandle);
-bool						xamarin_has_nsobject 						(id obj, guint32 *exception_gchandle);
-MonoObject*					xamarin_get_nsobject 						(id obj, guint32 *exception_gchandle);
-id							xamarin_get_handle_for_inativeobject		(MonoObject *obj, guint32 *exception_gchandle);
-void						xamarin_unregister_nsobject					(id native_obj, MonoObject *managed_obj, guint32 *exception_gchandle);
-MonoReflectionMethod*		xamarin_get_method_from_token				(guint32 token_ref, guint32 *exception_gchandle);
-MonoReflectionMethod*		xamarin_get_generic_method_from_token		(MonoObject *obj, guint32 token_ref, guint32 *exception_gchandle);
-MonoObject*					xamarin_try_get_or_construct_nsobject 		(id obj, guint32 *exception_gchandle);
-MonoObject*					xamarin_get_inative_object_dynamic			(id obj, bool owns, void *type, guint32 *exception_gchandle);
-MonoObject*					xamarin_get_inative_object_static			(id obj, bool owns, const char *type_name, const char *iface_name, guint32 *exception_gchandle);
-MonoObject*					xamarin_get_nsobject_with_type				(id obj, void *type, int32_t *created, guint32 *exception_gchandle);
-void						xamarin_dispose								(MonoObject *mobj, guint32 *exception_gchandle);
-bool	 					xamarin_is_parameter_transient				(MonoReflectionMethod *method, int parameter /* 0-based */, guint32 *exception_gchandle);
-bool						xamarin_is_parameter_out                    (MonoReflectionMethod *method, int parameter /* 0-based */, guint32 *exception_gchandle);
-void						xamarin_get_method_and_object_for_selector	(Class cls, SEL sel, bool is_static, id self, MonoObject **mthis, MethodDescription *desc, guint32 *exception_gchandle);
-guint32 					xamarin_create_product_exception_for_error	(int code, const char *message, guint32 *exception_gchandle);
-
 #ifdef __cplusplus
 class XamarinObject {
 public:

--- a/runtime/xamarin/xamarin.h
+++ b/runtime/xamarin/xamarin.h
@@ -12,6 +12,7 @@
 #include "main.h"
 #include "mono-runtime.h"
 #include "runtime.h"
+#include "runtime-generated.h"
 #include "trampolines.h"
 
 #endif /* __XAMARIN_H__ */


### PR DESCRIPTION
We already have the information we need to generate these function
declaration, so this prevents the need for keeping information in two
different places up-to-date.