### PR TITLE
[tests] Disable some old-style tests on wrench, long live the new-style tests.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -314,10 +314,7 @@ wrench-mac-introspection:
 	@echo Not here anymore
 
 wrench-mac-xammac_tests:
-	@# This entire target can be removed when merging to master.
-	$(Q) $(MAKE) run-mac-xammac_tests
-	$(Q) $(MAKE) clean-mac-xammac_tests
-	git clean -xfdq
+	@echo Not here anymore
 else
 wrench-mac-%:
 	@echo "Mac tests have been disabled [$@]"
@@ -355,8 +352,7 @@ wrench-jenkins: xharness/xharness.exe
 	$(Q) if test -e $@-failed.stamp; then EC=`cat $@-failed.stamp`; rm -f $@-failed.stamp; exit $$EC; fi
 
 wrench-xtro:
-	git clean -xfdq
-	make -C xtro-sharpie wrench
+	@echo Not here anymore
 
 jenkins: xharness/xharness.exe
 	$(Q) $(SYSTEM_MONO) --debug $< $(XHARNESS_VERBOSITY) --jenkins --autoconf --rootdir $(CURDIR) --sdkroot $(XCODE_DEVELOPER_ROOT)


### PR DESCRIPTION
These were accidentally not disabled when we started running tests on Wrench
like we do on Jenkins.

So disable them, to avoid duplicate work on Wrench.