### PR TITLE
[runtime] Remove specialized function for getting the Selector/Class handle of a managed Selector/Class instance.

### DIFF
--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -61,14 +61,6 @@
 			"SEL", "IntPtr", "ptr"
 		) { WrappedManagedFunction = "GetSelector" },
 
-		new XDelegate ("Class", "IntPtr", "xamarin_get_class_handle",
-			"MonoObject *", "IntPtr", "obj"
-		) { WrappedManagedFunction = "GetClassHandle" },
-
-		new XDelegate ("SEL", "IntPtr", "xamarin_get_selector_handle",
-			"MonoObject *", "IntPtr", "obj"
-		) { WrappedManagedFunction = "GetSelectorHandle" },
-
 		new XDelegate ("void", "void", "xamarin_get_method_for_selector",
 			"Class", "IntPtr", "cls",
 			"SEL", "IntPtr", "sel",

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -63,10 +63,10 @@ xamarin_marshal_return_value (MonoType *mtype, const char *type, MonoObject *ret
 	/* Any changes in this method probably need to be reflected in the static registrar as well */
 	switch (type [0]) {
 		case _C_CLASS:
-			return xamarin_get_class_handle (retval, exception_gchandle);
+			return xamarin_get_handle_for_inativeobject (retval, exception_gchandle);
 
 		case _C_SEL:
-			return xamarin_get_selector_handle (retval, exception_gchandle);
+			return xamarin_get_handle_for_inativeobject (retval, exception_gchandle);
 
 		case _C_PTR: {
 			MonoClass *klass = mono_class_from_mono_type (mtype);

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3492,10 +3492,10 @@ namespace XamCore.Registrar {
 						setup_return.AppendLine ("mt_dummy_use (retval);");
 						setup_return.AppendLine ("res = retobj;");
 					} else if (type.IsPlatformType ("ObjCRuntime", "Selector")) {
-						setup_return.AppendLine ("res = xamarin_get_selector_handle (retval, &exception_gchandle);");
+						setup_return.AppendLine ("res = (SEL) xamarin_get_handle_for_inativeobject (retval, &exception_gchandle);");
 						setup_return.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
 					} else if (type.IsPlatformType ("ObjCRuntime", "Class")) {
-						setup_return.AppendLine ("res = xamarin_get_class_handle (retval, &exception_gchandle);");
+						setup_return.AppendLine ("res = (Class) xamarin_get_handle_for_inativeobject (retval, &exception_gchandle);");
 						setup_return.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
 					} else if (SharedStatic.IsNativeObject (type)) {
 						setup_return.AppendLine ("{0} retobj;", rettype);


### PR DESCRIPTION
The existing function to get the handle of an INativeObject works just as fine.