### PR TITLE
[macos][webkit] Allow a null DomRange inside WebView.SetSelectedDomRange. Fixes #3206

### DIFF
--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -2653,7 +2653,7 @@ namespace XamCore.WebKit {
 		void ToggleSmartInsertDelete (NSObject sender);
 
 		[Export ("setSelectedDOMRange:affinity:")]
-		void SetSelectedDomRange (DomRange range, NSSelectionAffinity selectionAffinity);
+		void SetSelectedDomRange ([NullAllowed] DomRange range, NSSelectionAffinity selectionAffinity);
 
 		[Export ("selectedDOMRange")]
 		DomRange SelectedDomRange { get; }


### PR DESCRIPTION
as documented in
https://developer.apple.com/documentation/webkit/webview/1408363-setselecteddomrange?language=objc

Reference:
https://github.com/xamarin/xamarin-macios/issues/3206