### PR TITLE
[ImageKit] Fix a few protocols to be informal.

### DIFF
--- a/src/imagekit.cs
+++ b/src/imagekit.cs
@@ -499,7 +499,7 @@ namespace XamCore.ImageKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Protocol]
+	[Protocol (IsInformal = true)]
 	interface IKImageBrowserDataSource {
 		[Abstract]
 		[Export ("numberOfItemsInImageBrowser:")]
@@ -550,7 +550,7 @@ namespace XamCore.ImageKit {
 
 	[BaseType (typeof (NSObject))]
 	[Model]
-	[Protocol]
+	[Protocol (IsInformal = true)]
 	interface IKImageBrowserItem {
 		[Abstract]
 		[Export ("imageUID")]

--- a/tests/xtro-sharpie/macOS-ImageKit.ignore
+++ b/tests/xtro-sharpie/macOS-ImageKit.ignore
@@ -1,7 +1,3 @@
 # In header as old style, unnamed enums
 !unknown-native-enum! IKCellsStyle bound
 !unknown-native-enum! IKGroupStyle bound
-
-# Informal Protocol
-!unknown-protocol! IKImageBrowserDataSource bound
-!unknown-protocol! IKImageBrowserItem bound


### PR DESCRIPTION
Both of these protocols have been informal (categories) since their
introduction in macOS 10.5 (and they've not been made real protocols either).

    $ git grep interface.*IKImageBrowserDataSource
    MacOSX10.5.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserDataSource)
    MacOSX10.6.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserDataSource)
    MacOSX10.7.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserDataSource)
    MacOSX10.8.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserDataSource)
    MacOSX10.9.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserDataSource)
    MacOSX10.10.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserDataSource)
    MacOSX10.11.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserDataSource)
    MacOSX10.12.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserDataSource)
    MacOSX10.13.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserDataSource)

    $ git grep interface.*IKImageBrowserItem
    MacOSX10.5.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserItem)
    MacOSX10.6.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserItem)
    MacOSX10.7.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserItem)
    MacOSX10.8.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserItem)
    MacOSX10.9.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserItem)
    MacOSX10.10.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserItem)
    MacOSX10.11.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserItem)
    MacOSX10.12.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserItem)
    MacOSX10.13.sdk/System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/Headers/IKImageBrowserView.h:@interface NSObject (IKImageBrowserItem)