### PR TITLE
[xharness] Run monotouch-test both with and without the static registrar in the simulator.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -157,6 +157,8 @@ namespace xharness
 
 		IEnumerable<TestData> GetTestData (RunTestTask test)
 		{
+			// This function returns additional test configurations (in addition to the default one) for the specific test
+
 			switch (test.ProjectPlatform) {
 			case "iPhone":
 				/* we don't add --assembly-build-target=@all=staticobject because that's the default in all our test projects */
@@ -172,6 +174,7 @@ namespace xharness
 			case "iPhoneSimulator":
 				switch (test.TestName) {
 				case "monotouch-test":
+					// The default is to run monotouch-test with the dynamic registrar (in the simulator), so that's already covered
 					yield return new TestData { Variation = "Debug (static registrar)", MTouchExtraArgs = "--registrar:static", Debug = true, Profiling = false };
 					break;
 				}

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -98,9 +98,9 @@ namespace xharness
 			return rv;
 		}
 
-		internal async Task CreateCopyAsync (TestTask test)
+		internal async Task CreateCopyAsync (TestTask test = null)
 		{
-			var directory = Xamarin.Cache.CreateTemporaryDirectory (test.TestName);
+			var directory = Xamarin.Cache.CreateTemporaryDirectory (test?.TestName ?? System.IO.Path.GetFileNameWithoutExtension (Path));
 			Directory.CreateDirectory (directory);
 			var original_path = Path;
 			Path = System.IO.Path.Combine (directory, System.IO.Path.GetFileName (Path));


### PR DESCRIPTION
This way we catch (some) problems with the static registrar without having to run on device.