### PR TITLE
[mtouch/mmp] Give users more control over optimizations, and share more code between mtouch and mmp.

### DIFF
--- a/Versions-ios.plist.in
+++ b/Versions-ios.plist.in
@@ -129,5 +129,17 @@
 		<string>mono-symbol-archive</string>
 		<string>sgen-concurrent-gc</string>
 	</array>
+	<key>Optimizations</key>
+	<dict>
+		<!-- The key is the value to be passed to mtouch. The string is a very short description. Any IDE UI should also point to the documentation for the optimizations. -->
+		<key>inline-intptr-size</key>
+		<string>Inline IntPtr.Size</string>
+		<key>inline-runtime-arch</key>
+		<string>Inline NSObject.IsDirectBinding</string>
+		<key>dead-code-elimination</key>
+		<string>Dead code elimination</string>
+		<key>remove-uithread-checks</key>
+		<string>Remove UI thread checks</string>
+	</dict>
 </dict>
 </plist>

--- a/Versions-mac.plist.in
+++ b/Versions-mac.plist.in
@@ -41,5 +41,19 @@
 		<string>link-platform</string>
 		<string>hybrid-aot</string>
 	</array>
+	<key>Optimizations</key>
+	<dict>
+		<!-- The key is the value to be passed to mmp. The string is a very short description. Any IDE UI should also point to the documentation for the optimizations. -->
+		<key>inline-intptr-size</key>
+		<string>Inline IntPtr.Size</string>
+		<key>inline-runtime-arch</key>
+		<string>Inline Runtime.Arch</string>
+		<key>inline-isdirectbinding</key>
+		<string>Inline NSObject.IsDirectBinding</string>
+		<key>dead-code-elimination</key>
+		<string>Dead code elimination</string>
+		<key>remove-uithread-checks</key>
+		<string>Remove UI thread checks</string>
+	</dict>
 </dict>
 </plist>

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -639,6 +639,12 @@ This warning won't affect the application being built, however you might not be 
 
 Please report this issue to the publisher of the assembly package (e.g. nuget author) so this can be fixed in their future releases.
 
+### <a name="MT0132/>MT0132: Unknown optimization: *. Valid values are: *
+
+The specified optimization was not recognized.
+
+The accepted format is `[+|-]optimization-name`, where `optimization-name` is one of the values listed in the error message.
+
 # MT1xxx: Project related error messages
 
 ### MT10xx: Installer / mtouch

--- a/docs/website/optimizations.md
+++ b/docs/website/optimizations.md
@@ -1,0 +1,302 @@
+---
+id: 84B67E31-B217-443D-89E5-CFE1923CB14E
+title: Xamarin.iOS and Xamarin.Mac optimizations
+dateupdated: 2018-01-18
+---
+
+Optimizations
+=============
+
+This document explains the various optimizations that are applied at build time for Xamarin.iOS and Xamarin.Mac apps.
+
+Remove UIApplication.EnsureUIThread / NSApplication.EnsureUIThread
+------------------------------------------------------------------
+
+Removes calls to [UIApplication.EnsureUIThread][1] (for Xamarin.iOS) or
+`NSApplication.EnsureUIThread` (for Xamarin.Mac).
+
+This optimization will change the following type of code:
+
+```csharp
+public virtual void AddChildViewController (UIViewController childController)
+{
+	global::UIKit.UIApplication.EnsureUIThread ();
+	// ...
+}
+```
+
+into the following:
+
+```csharp
+public virtual void AddChildViewController (UIViewController childController)
+{
+	// ...
+}
+```
+
+This optimization requires the linker to be enabled, and is only applied to
+methods with the `[BindingImpl (BindingImplOptions.Optimizable)]` attribute.
+
+By default it's enabled for release builds.
+
+The default behavior can be overridden by passing `--optimize=[+|-]remove-uithread-checks` to mtouch/mmp.
+
+[1]: https://developer.xamarin.com/api/member/UIKit.UIApplication.EnsureUIThread/
+
+Inline IntPtr.Size
+------------------
+
+Inlines the constant value of IntPtr.Size according to the target platform.
+
+This optimization will change the following type of code:
+
+```csharp
+if (IntPtr.Size == 8) {
+	Console.WriteLine ("64-bit platform");
+} else {
+	Console.WriteLine ("32-bit platform");
+}
+```
+
+into the following (when building for a 64-bit platform):
+
+```csharp
+if (8 == 8) {
+	Console.WriteLine ("64-bit platform");
+} else {
+	Console.WriteLine ("32-bit platform");
+}
+```
+
+This optimization requires the linker to be enabled, and is only applied to
+methods with the `[BindingImpl (BindingImplOptions.Optimizable)]` attribute.
+
+By default it's enabled if targeting a single architecture, or for the
+platform assembly (Xamarin.iOS.dll, Xamarin.TVOS.dll, Xamarin.WatchOS.dll or
+Xamarin.Mac.dll).
+
+If targeting multiple architecture, this optimization will create different
+assemblies for the 32-bit version and the 64-bit version of the app, and both
+versions will have to be included in the app, effectively increasing the final
+app size instead of decreasing it.
+
+The default behavior can be overridden by passing `--optimize=[+|-]inline-intptr-size` to mtouch/mmp.
+
+Inline NSObject.IsDirectBinding
+-------------------------------
+
+NSObject.IsDirectBinding is an instance property that determines whether a
+particular instance is of a wrapper type or not (a wrapper type is a managed
+type that maps to a native type; for instance the managed `UIKit.UIView` type
+maps to the native `UIView` type - the opposite is a user type, in this case
+`class MyUIView : UIKit.UIView` would be a user type).
+
+It's necessary to know the value of IsDirectBinding when calling into
+Objective-C, because the value determines which version of `objc_msgSend` to
+use.
+
+Given only the following code:
+
+```csharp
+class UIView : NSObject {
+	public virtual string SomeProperty {
+		get {
+			if (IsDirectBinding) {
+				return "true";
+			} else {
+				return "false"
+			}
+		}
+	}
+}
+
+class NSUrl : NSObject {
+	public virtual string SomeOtherProperty {
+		get {
+			if (IsDirectBinding) {
+				return "true";
+			} else {
+				return "false"
+			}
+		}
+	}
+}
+
+class MyUIView : UIView {
+}
+```
+
+we can determine that in `UIView.SomeProperty` the value of `IsDirectBinding` is not a constant and can not be inlined:
+
+```csharp
+void uiView = new UIView ();
+Console.WriteLine (uiView.SomeProperty); /* prints 'true' */
+void myView = new MyUIView ();
+Console.WriteLine (myView.SomeProperty); // prints 'false'
+```
+
+however it's possible to look at the all the types in the app and determine
+that there are no types that inherit from `NSUrl`, and it's thus safe to
+inline the `IsDirectBinding` value to a constant `true`:
+
+```csharp
+void myURL = new NSUrl ();
+Console.WriteLine (myURL.SomeOtherProperty); // prints 'true'
+// There's no way to make SomeOtherProperty print anything but 'true', since there are no NSUrl subclasses.
+```
+
+In particular, this optimization will change the following type of code (this
+is the binding code for NSUrl.AbsoluteUrl):
+
+```csharp
+if (IsDirectBinding) {
+	return Runtime.GetNSObject<NSUrl> (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, Selector.GetHandle ("absoluteURL")));
+} else {
+	return Runtime.GetNSObject<NSUrl> (global::ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper (this.SuperHandle, Selector.GetHandle ("absoluteURL")));
+}
+```
+
+into the following (when it can be determined that there are no subclasses of
+NSUrl in the app):
+
+```csharp
+if (true) {
+	return Runtime.GetNSObject<NSUrl> (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, Selector.GetHandle ("absoluteURL")));
+} else {
+	return Runtime.GetNSObject<NSUrl> (global::ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper (this.SuperHandle, Selector.GetHandle ("absoluteURL")));
+}
+```
+
+This optimization requires the linker to be enabled, and is only applied to
+methods with the `[BindingImpl (BindingImplOptions.Optimizable)]` attribute.
+
+It is always enabled by default for Xamarin.iOS, and always disabled by
+default for Xamarin.Mac (because it's possible to dynamically load assemblies
+in Xamarin.Mac, it's not possible to determine that a particular class is
+never subclassed).
+
+The default behavior can be overridden by passing `--optimize=[+|-]inline-isdirectbinding` to mtouch/mmp.
+
+Inline Runtime.Arch
+-------------------
+
+This optimization will change the following type of code:
+
+```csharp
+if (Runtime.Arch == Arch.DEVICE) {
+	Console.WriteLine ("Running on device");
+} else {
+	Console.WriteLine ("Running in the simulator");
+}
+```
+
+into the following (when building for device):
+
+```csharp
+if (Arch.DEVICE == Arch.DEVICE) {
+	Console.WriteLine ("Running on device");
+} else {
+	Console.WriteLine ("Running in the simulator");
+}
+```
+
+This optimization requires the linker to be enabled, and is only applied to
+methods with the `[BindingImpl (BindingImplOptions.Optimizable)]` attribute.
+
+It is always enabled by default for Xamarin.iOS (it's not available for
+Xamarin.Mac).
+
+The default behavior can be overridden by passing `--optimize=[+|-]inline-runtime-arch` to mtouch.
+
+Dead code elimination
+---------------------
+
+This optimization will change the following type of code:
+
+```csharp
+if (true) {
+	Console.WriteLine ("Doing this");
+} else {
+	Console.WriteLine ("Not doing this");
+}
+```
+
+into:
+
+```csharp
+Console.WriteLine ("Doing this");
+```
+
+It will also evaluate constant comparisons, like this:
+
+```csharp
+if (8 == 8) {
+	Console.WriteLine ("Doing this");
+} else {
+	Console.WriteLine ("Not doing this");
+}
+```
+
+and determine that the expression `8 == 8` is a always true, and reduce it to:
+
+```csharp
+Console.WriteLine ("Doing this");
+```
+
+This is a powerful optimization when used together with the inlining
+optimizations, because it can transform the following type of code (this is
+the binding code for NFCIso15693ReadMultipleBlocksConfiguration.Range):
+
+```csharp
+NSRange ret;
+if (IsDirectBinding) {
+	if (Runtime.Arch == Arch.DEVICE) {
+		if (IntPtr.Size == 8) {
+			ret = global::ObjCRuntime.Messaging.NSRange_objc_msgSend (this.Handle, Selector.GetHandle ("range"));
+		} else {
+			global::ObjCRuntime.Messaging.NSRange_objc_msgSend_stret (out ret, this.Handle, Selector.GetHandle ("range"));
+		}
+	} else if (IntPtr.Size == 8) {
+		ret = global::ObjCRuntime.Messaging.NSRange_objc_msgSend (this.Handle, Selector.GetHandle ("range"));
+	} else {
+		ret = global::ObjCRuntime.Messaging.NSRange_objc_msgSend (this.Handle, Selector.GetHandle ("range"));
+	}
+} else {
+	if (Runtime.Arch == Arch.DEVICE) {
+		if (IntPtr.Size == 8) {
+			ret = global::ObjCRuntime.Messaging.NSRange_objc_msgSendSuper (this.SuperHandle, Selector.GetHandle ("range"));
+		} else {
+			global::ObjCRuntime.Messaging.NSRange_objc_msgSendSuper_stret (out ret, this.SuperHandle, Selector.GetHandle ("range"));
+		}
+	} else if (IntPtr.Size == 8) {
+		ret = global::ObjCRuntime.Messaging.NSRange_objc_msgSendSuper (this.SuperHandle, Selector.GetHandle ("range"));
+	} else {
+		ret = global::ObjCRuntime.Messaging.NSRange_objc_msgSendSuper (this.SuperHandle, Selector.GetHandle ("range"));
+	}
+}
+return ret;
+```
+
+into this (when building for a 64-bit device, and when also able to ensure there are no NFCIso15693ReadMultipleBlocksConfiguration subclasses in the app):
+
+```csharp
+NSRange ret;
+ret = global::ObjCRuntime.Messaging.NSRange_objc_msgSend (this.Handle, Selector.GetHandle ("range"));
+return ret;
+```
+
+The AOT compiler is already able to do eliminate dead code like this, but this
+optimization is done inside the linker, which means that the linker able to
+see that there are multiple methods that are not used anymore, and may thus be
+removed (unless used elsewhere):
+
+* global::ObjCRuntime.Messaging.NSRange_objc_msgSend_stret
+* global::ObjCRuntime.Messaging.NSRange_objc_msgSendSuper
+* global::ObjCRuntime.Messaging.NSRange_objc_msgSendSuper_stret
+
+This optimization requires the linker to be enabled, and is only applied to
+methods with the `[BindingImpl (BindingImplOptions.Optimizable)]` attribute.
+
+It is always enabled by default (when the linker is enabled).
+
+The default behavior can be overridden by passing `--optimize=[+|-]dead-code-elimination` to mtouch/mmp.

--- a/tests/common/ExecutionHelper.cs
+++ b/tests/common/ExecutionHelper.cs
@@ -56,6 +56,12 @@ namespace Xamarin.Tests
 			}
 		}
 
+		public StringBuilder Output {
+			get {
+				return output;
+			}
+		}
+
 		public int Execute (string arguments, params string [] args)
 		{
 			return Execute (ToolPath, arguments, false, args);
@@ -86,7 +92,21 @@ namespace Xamarin.Tests
 			return rv;
 		}
 
-		void ParseMessages ()
+		bool IndexOfAny (string line, out int start, out int end, params string [] values)
+		{
+			foreach (var value in values) {
+				start = line.IndexOf (value);
+				if (start >= 0) {
+					end = start + value.Length;
+					return true;
+				}
+			}
+			start = -1;
+			end = -1;
+			return false;
+		}
+
+		public void ParseMessages ()
 		{
 			messages.Clear ();
 
@@ -94,15 +114,13 @@ namespace Xamarin.Tests
 				var line = l;
 				var msg = new ToolMessage ();
 				var origin = string.Empty;
-				if (line.Contains (": error ")) {
+				if (IndexOfAny (line, out var idxError, out var endError, ": error ", ":  error ")) {
 					msg.IsError = true;
-					var idx = line.IndexOf (": error ", StringComparison.Ordinal);
-					origin = line.Substring (0, idx);
-					line = line.Substring (idx + ": error ".Length);
-				} else if (line.Contains (": warning ")) {
-					var idx = line.IndexOf (": warning ", StringComparison.Ordinal);
-					origin = line.Substring (0, idx);
-					line = line.Substring (idx + ": warning ".Length);
+					origin = line.Substring (0, idxError);
+					line = line.Substring (endError);
+				} else if (IndexOfAny (line, out var idxWarning, out var endWarning, ": warning ", ":  warning ")) {
+					origin = line.Substring (0, idxWarning);
+					line = line.Substring (endWarning);
 				} else if (line.StartsWith ("error ", StringComparison.Ordinal)) {
 					msg.IsError = true;
 					line = line.Substring (6);

--- a/tests/common/ExecutionHelper.cs
+++ b/tests/common/ExecutionHelper.cs
@@ -175,6 +175,11 @@ namespace Xamarin.Tests
 			return false;
 		}
 
+		public void AssertWarningCount (int count, string message = "warnings")
+		{
+			Assert.AreEqual (count, WarningCount, message);
+		}
+
 		public void AssertErrorCount (int count, string message = "errors")
 		{
 			Assert.AreEqual (count, ErrorCount, message);

--- a/tests/common/mac/ProjectTestHelpers.cs
+++ b/tests/common/mac/ProjectTestHelpers.cs
@@ -8,10 +8,11 @@ using System.Text.RegularExpressions;
 using NUnit.Framework;
 using System.Reflection;
 using Xamarin.Utils;
+using Xamarin.Tests;
 
 namespace Xamarin.MMP.Tests
 {
-	public struct OutputText
+	public class OutputText
 	{
 		public string BuildOutput { get; private set; }
 		public string RunOutput { get; private set; }
@@ -20,6 +21,25 @@ namespace Xamarin.MMP.Tests
 		{
 			BuildOutput = buildOutput;
 			RunOutput = runOutput;
+		}
+
+		MessageTool messages;
+		internal MessageTool Messages {
+			get {
+				if (messages == null) {
+					messages = new MessageTool ();
+					messages.Output.Append (BuildOutput);
+					messages.ParseMessages ();
+				}
+				return messages;
+			}
+		}
+
+		internal class MessageTool : Tool
+		{
+			protected override string ToolPath => throw new NotImplementedException ();
+
+			protected override string MessagePrefix => "MM";
 		}
 	}
 

--- a/tests/linker-ios/link all/ILReader.cs
+++ b/tests/linker-ios/link all/ILReader.cs
@@ -1,0 +1,219 @@
+﻿//
+// ILReader to parse the byte array provided by MethodBase.GetMethodBody ().GetILAsByteArray () into better-looking IL instructions.
+//
+// Authors:
+//	Rolf Bjarne Kvinge <rolf@xamarin.com>
+//
+// Copyright 2018 Microsoft Inc. All rights reserved.
+//
+
+// Adapted code from here: https://blogs.msdn.microsoft.com/haibo_luo/2005/10/04/read-il-from-methodbody/
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Linker.Shared
+{
+	public class ILInstruction
+	{
+		public MethodBase Method;
+		public OpCode OpCode;
+		public int Offset;
+		public object Operand;
+
+		public ILInstruction (MethodBase method, int offset, OpCode opcode, object operand = null)
+		{
+			this.Method = method;
+			this.OpCode = opcode;
+			this.Offset = offset;
+			this.Operand = operand;
+		}
+
+		public override string ToString ()
+		{
+			var methodOperand = Operand as MethodBase;
+			if (methodOperand != null)
+				return $"IL_{Offset:0000} {OpCode} {methodOperand.DeclaringType.FullName}.{methodOperand.Name}";
+			return $"IL_{Offset:0000} {OpCode} {(Operand is MethodBase ? ((MethodBase) Operand).Name : Operand?.ToString ())}";
+		}
+	}
+
+	public class ILReader : IEnumerable<ILInstruction>
+	{
+		List<ILInstruction> instructions;
+
+		static OpCode [] oneByteOpcodes = new OpCode [0x100];
+		static OpCode [] twoByteOpcodes = new OpCode [0x100];
+		static ILReader ()
+		{
+			foreach (var fi in typeof (OpCodes).GetFields (BindingFlags.Public | BindingFlags.Static)) {
+				var opCode = (OpCode) fi.GetValue (null);
+				var value = (ushort) opCode.Value;
+				if (value < 0x100)
+					oneByteOpcodes [value] = opCode;
+				else if ((value & 0xff00) == 0xfe00)
+					twoByteOpcodes [value & 0xff] = opCode;
+			}
+		}
+
+		public ILReader (MethodBase method)
+		{
+			instructions = Parse (method);
+		}
+
+		IEnumerator<ILInstruction> IEnumerable<ILInstruction>.GetEnumerator ()
+		{
+			return instructions.GetEnumerator ();
+		}
+
+		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator ()
+		{
+			return instructions.GetEnumerator ();
+		}
+
+		List<ILInstruction> Parse (MethodBase method)
+		{
+			var rv = new List<ILInstruction> ();
+			var position = 0;
+
+			var body = method.GetMethodBody ();
+			if (body == null)
+				return rv;
+
+			var bytes = body.GetILAsByteArray ();
+			while (position < bytes.Length)
+				rv.Add (ReadInstruction (method, bytes, ref position));
+
+			return rv;
+		}
+
+		static ILInstruction ReadInstruction (MethodBase method, byte [] bytes, ref int position)
+		{
+			var offset = position;
+			var opCode = OpCodes.Nop;
+
+			// read first 1 or 2 bytes as opCode
+			Byte code = ReadByte (bytes, ref position);
+			if (code != 0xFE)
+				opCode = oneByteOpcodes [code];
+			else {
+				code = ReadByte (bytes, ref position);
+				opCode = twoByteOpcodes [code];
+			}
+
+			switch (opCode.OperandType) {
+			case OperandType.InlineNone:
+				return new ILInstruction (method, offset, opCode);
+
+			case OperandType.ShortInlineBrTarget:
+				return new ILInstruction (method, offset, opCode, ReadSByte (bytes, ref position));
+
+			case OperandType.InlineBrTarget:
+				return new ILInstruction (method, offset, opCode, ReadInt32 (bytes, ref position));
+
+			case OperandType.ShortInlineI:
+				return new ILInstruction (method, offset, opCode, ReadByte (bytes, ref position));
+
+			case OperandType.InlineI:
+				return new ILInstruction (method, offset, opCode, ReadInt32 (bytes, ref position));
+
+			case OperandType.InlineI8:
+				return new ILInstruction (method, offset, opCode, ReadInt64 (bytes, ref position));
+
+			case OperandType.ShortInlineR:
+				return new ILInstruction (method, offset, opCode, ReadSingle (bytes, ref position));
+
+			case OperandType.InlineR:
+				return new ILInstruction (method, offset, opCode, ReadDouble (bytes, ref position));
+
+			case OperandType.ShortInlineVar:
+				return new ILInstruction (method, offset, opCode, ReadByte (bytes, ref position));
+
+			case OperandType.InlineVar:
+				return new ILInstruction (method, offset, opCode, ReadUInt16 (bytes, ref position));
+
+			case OperandType.InlineString:
+				return new ILInstruction (method, offset, opCode, ReadInt32 (bytes, ref position));
+
+			case OperandType.InlineSig:
+				return new ILInstruction (method, offset, opCode, ReadInt32 (bytes, ref position));
+
+			case OperandType.InlineField:
+				return new ILInstruction (method, offset, opCode, ReadInt32 (bytes, ref position));
+
+			case OperandType.InlineType:
+				return new ILInstruction (method, offset, opCode, ReadInt32 (bytes, ref position));
+
+			case OperandType.InlineTok:
+				return new ILInstruction (method, offset, opCode, ReadInt32 (bytes, ref position));
+
+			case OperandType.InlineMethod:
+				return new ILInstruction (method, offset, opCode, method.Module.ResolveMethod (ReadInt32 (bytes, ref position)));
+
+			case OperandType.InlineSwitch:
+				var cases = ReadInt32 (bytes, ref position);
+				var deltas = new int [cases];
+				for (var i = 0; i < cases; i++)
+					deltas [i] = ReadInt32 (bytes, ref position);
+				return new ILInstruction (method, offset, opCode, deltas);
+
+			default:
+				throw new BadImageFormatException ("unexpected OperandType " + opCode.OperandType);
+			}
+		}
+
+		static byte ReadByte (byte[] bytes, ref int position)
+		{
+			return bytes [position++];
+		}
+
+		static sbyte ReadSByte (byte [] bytes, ref int position)
+		{
+			return (sbyte) ReadByte (bytes, ref position);
+		}
+
+		static ushort ReadUInt16 (byte [] bytes, ref int position)
+		{
+			position += 2;
+			return BitConverter.ToUInt16 (bytes, position - 2);
+		}
+
+		static uint ReadUInt32 (byte [] bytes, ref int position)
+		{
+			position += 4;
+			return BitConverter.ToUInt32 (bytes, position - 4);
+		}
+
+		static ulong ReadUInt64 (byte [] bytes, ref int position)
+		{
+			position += 8;
+			return BitConverter.ToUInt64 (bytes, position - 8);
+		}
+
+		static int ReadInt32 (byte [] bytes, ref int position)
+		{
+			position += 4;
+			return BitConverter.ToInt32 (bytes, position - 4);
+		}
+
+		static long ReadInt64 (byte [] bytes, ref int position)
+		{
+			position += 8;
+			return BitConverter.ToInt64 (bytes, position - 8);
+		}
+
+		static float ReadSingle (byte [] bytes, ref int position)
+		{
+			position += 4;
+			return BitConverter.ToSingle (bytes, position - 4);
+		}
+
+		static double ReadDouble (byte [] bytes, ref int position)
+		{
+			position += 8;
+			return BitConverter.ToDouble (bytes, position - 8);
+		}
+	}
+}

--- a/tests/linker-ios/link all/link all.csproj
+++ b/tests/linker-ios/link all/link all.csproj
@@ -25,7 +25,7 @@
     <MtouchDebug>True</MtouchDebug>
     <MtouchLink>Full</MtouchLink>
     <MtouchI18n>mideast,other</MtouchI18n>
-    <MtouchExtraArgs>--registrar=static</MtouchExtraArgs>
+    <MtouchExtraArgs>--registrar=static --optimize=all</MtouchExtraArgs>
     <MtouchArch>i386, x86_64</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
@@ -38,7 +38,7 @@
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchArch>i386, x86_64</MtouchArch>
     <DefineConstants>LINKALL;;$(DefineConstants)</DefineConstants>
-    <MtouchExtraArgs></MtouchExtraArgs>
+    <MtouchExtraArgs>--optimize=all</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>True</DebugSymbols>
@@ -53,7 +53,7 @@
     <MtouchLink>Full</MtouchLink>
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <MtouchExtraArgs>-gcc_flags="-UhoItsB0rken"</MtouchExtraArgs>
+    <MtouchExtraArgs>-gcc_flags="-UhoItsB0rken" --optimize=all</MtouchExtraArgs>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug32|iPhone' ">
@@ -69,7 +69,7 @@
     <MtouchLink>Full</MtouchLink>
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchArch>ARMv7</MtouchArch>
-    <MtouchExtraArgs>-gcc_flags="-UhoItsB0rken"</MtouchExtraArgs>
+    <MtouchExtraArgs>-gcc_flags="-UhoItsB0rken" --optimize=all</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug64|iPhone' ">
     <DebugSymbols>True</DebugSymbols>
@@ -84,7 +84,7 @@
     <MtouchLink>Full</MtouchLink>
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchArch>ARM64</MtouchArch>
-    <MtouchExtraArgs>-gcc_flags="-UhoItsB0rken"</MtouchExtraArgs>
+    <MtouchExtraArgs>-gcc_flags="-UhoItsB0rken" --optimize=all</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
@@ -97,7 +97,7 @@
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <MtouchExtraArgs>-v -v -v -v</MtouchExtraArgs>
+    <MtouchExtraArgs>--optimize=all</MtouchExtraArgs>
     <DefineConstants>LINKALL;;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release32|iPhone' ">
@@ -111,7 +111,7 @@
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchArch>ARMv7</MtouchArch>
-    <MtouchExtraArgs>-v -v -v -v</MtouchExtraArgs>
+    <MtouchExtraArgs>--optimize=all</MtouchExtraArgs>
     <DefineConstants>LINKALL;;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release64|iPhone' ">
@@ -125,7 +125,7 @@
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchArch>ARM64</MtouchArch>
-    <MtouchExtraArgs>-v -v -v -v</MtouchExtraArgs>
+    <MtouchExtraArgs>--optimize=all</MtouchExtraArgs>
     <DefineConstants>LINKALL;;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-bitcode|iPhone' ">
@@ -139,7 +139,7 @@
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchUseLlvm>true</MtouchUseLlvm>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <MtouchExtraArgs>-v -v -v -v --bitcode:full</MtouchExtraArgs>
+    <MtouchExtraArgs>--bitcode:full --optimize=all</MtouchExtraArgs>
     <DefineConstants>LINKALL;;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
@@ -181,6 +181,7 @@
       <Link>ReflectionTest.cs</Link>
     </Compile>
     <Compile Include="SerializationTest.cs" />
+    <Compile Include="ILReader.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\BundledResources\BundledResources.csproj">

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -83,6 +83,9 @@
     <Compile Include="..\common\ProductTests.cs">
       <Link>ProductTests.cs</Link>
     </Compile>
+    <Compile Include="..\common\ExecutionHelper.cs">
+      <Link>src\ExecutionHelper.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -813,5 +813,34 @@ namespace Xamarin.MMP.Tests
 				TI.TestUnifiedExecutable (test, shouldFail: false);
 			});
 		}
+
+		[Test]
+		[TestCase ("all")]
+		[TestCase ("-all")]
+		[TestCase ("remove-uithread-checks,dead-code-elimination,inline-isdirectbinding,inline-intptr-size,inline-runtime-arch")]
+		public void Optimizations (string opt)
+		{
+			RunMMPTest (tmpDir => {
+				var test = new TI.UnifiedTestConfig (tmpDir) {
+					CSProjConfig = $"<MonoBundlingExtraArgs>--optimize=${opt}</MonoBundlingExtraArgs>",
+				};
+				var rv = TI.TestUnifiedExecutable (test, shouldFail: false);
+				rv.Messages.AssertWarningCount (0);
+				rv.Messages.AssertErrorCount (0);
+			});
+		}
+
+		[Test]
+		public void MM0132 ()
+		{
+			RunMMPTest (tmpDir => {
+				var test = new TI.UnifiedTestConfig (tmpDir) {
+					CSProjConfig = $"<MonoBundlingExtraArgs>--optimize=foo</MonoBundlingExtraArgs>",
+				};
+				var rv = TI.TestUnifiedExecutable (test, shouldFail: false);
+				rv.Messages.AssertWarning (132, "Unknown optimization: 'foo'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size.");
+				rv.Messages.AssertErrorCount (0);
+			});
+		}
 	}
 }

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -817,28 +817,32 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		[TestCase ("all")]
 		[TestCase ("-all")]
-		[TestCase ("remove-uithread-checks,dead-code-elimination,inline-isdirectbinding,inline-intptr-size,inline-runtime-arch")]
+		[TestCase ("remove-uithread-checks,dead-code-elimination,inline-isdirectbinding,inline-intptr-size")]
 		public void Optimizations (string opt)
 		{
 			RunMMPTest (tmpDir => {
 				var test = new TI.UnifiedTestConfig (tmpDir) {
-					CSProjConfig = $"<MonoBundlingExtraArgs>--optimize=${opt}</MonoBundlingExtraArgs>",
+					CSProjConfig = $"<MonoBundlingExtraArgs>--optimize={opt}</MonoBundlingExtraArgs>" + 
+						"<LinkMode>Full</LinkMode>",
 				};
 				var rv = TI.TestUnifiedExecutable (test, shouldFail: false);
-				rv.Messages.AssertWarningCount (0);
+				rv.Messages.AssertNoWarnings ();
 				rv.Messages.AssertErrorCount (0);
 			});
 		}
 
 		[Test]
-		public void MM0132 ()
+		[TestCase ("inline-runtime-arch")] // This is valid for Xamarin.iOS
+		[TestCase ("foo")]
+		public void MM0132 (string opt)
 		{
 			RunMMPTest (tmpDir => {
 				var test = new TI.UnifiedTestConfig (tmpDir) {
-					CSProjConfig = $"<MonoBundlingExtraArgs>--optimize=foo</MonoBundlingExtraArgs>",
+					CSProjConfig = $"<MonoBundlingExtraArgs>--optimize={opt}</MonoBundlingExtraArgs>" + 
+						"<LinkMode>Full</LinkMode>",
 				};
 				var rv = TI.TestUnifiedExecutable (test, shouldFail: false);
-				rv.Messages.AssertWarning (132, "Unknown optimization: 'foo'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size.");
+				rv.Messages.AssertWarning (132, $"Unknown optimization: '{opt}'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size.");
 				rv.Messages.AssertErrorCount (0);
 			});
 		}

--- a/tests/msbuild-mac/msbuild-mac.csproj
+++ b/tests/msbuild-mac/msbuild-mac.csproj
@@ -82,6 +82,9 @@
     <Compile Include="..\..\tools\common\StringUtils.cs">
       <Link>StringUtils.cs</Link>
     </Compile>
+    <Compile Include="..\common\ExecutionHelper.cs">
+      <Link>ExecutionHelper.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -90,6 +90,7 @@ namespace Xamarin
 		public string Cache;
 		public string Device; // --device
 		public MTouchLinker Linker;
+		public string [] Optimize;
 		public MTouchSymbolMode SymbolMode;
 		public bool? NoFastSim;
 		public MTouchRegistrar Registrar;
@@ -410,6 +411,11 @@ namespace Xamarin
 				break;
 			default:
 				throw new NotImplementedException ();
+			}
+
+			if (Optimize != null) {
+				foreach (var opt in Optimize)
+					sb.Append (" --optimize:").Append (opt);
 			}
 
 			switch (SymbolMode) {

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -68,6 +68,9 @@
     <Compile Include="..\common\mac\MacTestMain.cs">
       <Link>MacTestMain.cs</Link>
     </Compile>
+    <Compile Include="..\common\ExecutionHelper.cs">
+      <Link>ExecutionHelper.cs</Link>
+    </Compile>
     <Compile Include="..\api-shared\ObjCRuntime\Registrar.cs">
       <Link>Registrar.cs</Link>
     </Compile>

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -43,6 +43,7 @@ namespace Xamarin.Bundler {
 		public bool DeadStrip = true;
 		public bool EnableDebug;
 		internal RuntimeOptions RuntimeOptions;
+		public Optimizations Optimizations = new Optimizations ();
 		public RegistrarMode Registrar = RegistrarMode.Default;
 		public RegistrarOptions RegistrarOptions = RegistrarOptions.Default;
 		public SymbolMode SymbolMode;
@@ -466,6 +467,8 @@ namespace Xamarin.Bundler {
 				ErrorHelper.Warning (115, "It is recommended to reference dynamic symbols using code (--dynamic-symbol-mode=code) when bitcode is enabled.");
 			}
 #endif
+
+			Optimizations.Initialize (this);
 		}
 
 		public void RunRegistrar ()

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -126,6 +126,20 @@ namespace Xamarin.Bundler {
 			options.Add ("root-assembly:", "Specifies any root assemblies. There must be at least one root assembly, usually the main executable.", (v) => {
 				app.RootAssemblies.Add (v);
 			});
+			options.Add ("optimize=", "A comma-delimited list of optimizations to enable/disable. To enable an optimization, use --optimize=[+]remove-uithread-checks. To disable an optimizations: --optimize=-remove-uithread-checks. Use '+all' to enable or '-all' disable all optimizations. Only compiler-generated code or code otherwise marked as safe to optimize will be optimized.\n" +
+					"Available optimizations:\n" +
+					"    dead-code-elimination: By default always enabled (requires the linker). Removes IL instructions the linker can determine will never be executed. This is most useful in combination with the inline-* optimizations, since inlined conditions almost always also results in blocks of code that will never be executed.\n" +
+					"    remove-uithread-checks: By default enabled for release builds (requires the linker). Remove all UI Thread checks (makes the app smaller, and slightly faster at runtime).\n" +
+					"    inline-isdirectbinding: By default enabled (requires the linker). Tries to inline calls to NSObject.IsDirectBinding to load a constant value. Makes the app smaller, and slightly faster at runtime.\n" +
+					"    inline-intptr-size: By default enabled for builds that target a single architecture (requires the linker). Inlines calls to IntPtr.Size to load a constant value. Makes the app smaller, and slightly faster at runtime.\n" +
+#if MONOTOUCH
+					"    inline-runtime-arch: By default always enabled (requires the linker). Inlines calls to ObjCRuntime.Runtime.Arch to load a constant value. Makes the app smaller, and slightly faster at runtime.\n",
+#else
+					"",
+#endif
+					(v) => {
+						app.Optimizations.Parse (v);
+					});
 			options.Add (new Mono.Options.ResponseFileSource ());
 		}
 

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -130,13 +130,15 @@ namespace Xamarin.Bundler {
 					"Available optimizations:\n" +
 					"    dead-code-elimination: By default always enabled (requires the linker). Removes IL instructions the linker can determine will never be executed. This is most useful in combination with the inline-* optimizations, since inlined conditions almost always also results in blocks of code that will never be executed.\n" +
 					"    remove-uithread-checks: By default enabled for release builds (requires the linker). Remove all UI Thread checks (makes the app smaller, and slightly faster at runtime).\n" +
-					"    inline-isdirectbinding: By default enabled (requires the linker). Tries to inline calls to NSObject.IsDirectBinding to load a constant value. Makes the app smaller, and slightly faster at runtime.\n" +
-					"    inline-intptr-size: By default enabled for builds that target a single architecture (requires the linker). Inlines calls to IntPtr.Size to load a constant value. Makes the app smaller, and slightly faster at runtime.\n" +
 #if MONOTOUCH
-					"    inline-runtime-arch: By default always enabled (requires the linker). Inlines calls to ObjCRuntime.Runtime.Arch to load a constant value. Makes the app smaller, and slightly faster at runtime.\n",
+					"    inline-isdirectbinding: By default enabled (requires the linker). Tries to inline calls to NSObject.IsDirectBinding to load a constant value. Makes the app smaller, and slightly faster at runtime.\n" +
 #else
-					"",
+					"    inline-isdirectbinding: By default disabled, because it may  (requires the linker), because . Tries to inline calls to NSObject.IsDirectBinding to load a constant value. Makes the app smaller, and slightly faster at runtime.\n" +
 #endif
+#if MONOTOUCH
+					"    inline-runtime-arch: By default always enabled (requires the linker). Inlines calls to ObjCRuntime.Runtime.Arch to load a constant value. Makes the app smaller, and slightly faster at runtime.\n" +
+#endif
+					"    inline-intptr-size: By default enabled for builds that target a single architecture (requires the linker). Inlines calls to IntPtr.Size to load a constant value. Makes the app smaller, and slightly faster at runtime.\n",
 					(v) => {
 						app.Optimizations.Parse (v);
 					});

--- a/tools/common/Optimizations.cs
+++ b/tools/common/Optimizations.cs
@@ -1,0 +1,130 @@
+using System.Linq;
+
+namespace Xamarin.Bundler {
+	public class Optimizations
+	{
+		static string [] opt_names =
+		{
+			"remove-uithread-checks",
+			"dead-code-elimination",
+			"inline-isdirectbinding",
+			"inline-intptr-size",
+#if MONOTOUCH
+			"inline-runtime-arch",
+#endif
+		};
+
+		bool? [] values;
+
+		public bool? RemoveUIThreadChecks {
+			get { return values [0]; }
+			set { values [0] = value;  }
+		}
+		public bool? DeadCodeElimination {
+			get { return values [1]; }
+			set { values [1] = value; }
+		}
+		public bool? InlineIsDirectBinding {
+			get { return values [2]; }
+			set { values [2] = value; }
+		}
+		public bool? InlineIntPtrSize {
+			get { return values [3]; }
+			set { values [3] = value; }
+		}
+#if MONOTOUCH
+		public bool? InlineRuntimeArch {
+			get { return values [4]; }
+			set { values [4] = value; }
+		}
+#endif
+
+		public Optimizations ()
+		{
+			values = new bool? [opt_names.Length];
+		}
+
+		public void Initialize (Application app)
+		{
+			// warn if the user asked to optimize something when the linker is not enabled
+			if (app.LinkMode == LinkMode.None) {
+				for (int i = 0; i < values.Length; i++) {
+					if (!values [i].HasValue)
+						continue;
+					ErrorHelper.Warning (2003, $"Option '--optimize={(values [i].Value ? "" : "-")}{opt_names [i]}' will be ignored since linking is disabled");
+				}
+				return;
+			}
+
+			// by default we keep the code to ensure we're executing on the UI thread (for UI code) for debug builds
+			// but this can be overridden to either (a) remove it from debug builds or (b) keep it in release builds
+			if (!RemoveUIThreadChecks.HasValue)
+				RemoveUIThreadChecks = !app.EnableDebug;
+
+			// By default we always eliminate dead code.
+			if (!DeadCodeElimination.HasValue)
+				DeadCodeElimination = true;
+
+			// By default we always inline calls to NSObject.IsDirectBinding
+			if (!InlineIsDirectBinding.HasValue)
+				InlineIsDirectBinding = true;
+
+			// The default behavior for InlineIntPtrSize depends on the assembly being linked,
+			// which means we can't set it to a global constant. It's handled in the OptimizeGeneratedCodeSubStep directly.
+
+#if MONOTOUCH
+			// By default we always inline calls to Runtime.Arch
+			if (!InlineRuntimeArch.HasValue)
+				InlineRuntimeArch = true;
+#endif
+
+			if (Driver.Verbosity > 3)
+				Driver.Log (4, "Enabled optimizations: {0}", string.Join (", ", values.Select ((v, idx) => v == true ? opt_names [idx] : string.Empty).Where ((v) => !string.IsNullOrEmpty (v))));
+		}
+
+		public void Parse (string options)
+		{
+			foreach (var option in options.Split (',')) {
+				if (option == null || option.Length < 2)
+					throw ErrorHelper.CreateError (10, $"Could not parse the command line argument '--optimize={options}'");
+
+				ParseOption (option);
+			}
+		}
+
+		void ParseOption (string option)
+		{
+			bool enabled;
+			string opt;
+			switch (option [0]) {
+			case '-':
+				enabled = false;
+				opt = option.Substring (1);
+				break;
+			case '+':
+				enabled = true;
+				opt = option.Substring (1);
+				break;
+			default:
+				opt = option;
+				enabled = true;
+				break;
+			}
+
+			if (opt == "all") {
+				for (int i = 0; i < values.Length; i++)
+					values [i] = enabled;
+			} else {
+				var found = false;
+				for (int i = 0; i < values.Length; i++) {
+					if (opt_names [i] != opt)
+						continue;
+					found = true;
+					values [i] = enabled;
+				}
+				if (!found)
+					ErrorHelper.Warning (132, $"Unknown optimization: '{opt}'. Valid optimizations are: {string.Join (", ", opt_names)}.");
+			}
+		}
+	}
+}

--- a/tools/common/Optimizations.cs
+++ b/tools/common/Optimizations.cs
@@ -64,10 +64,17 @@ namespace Xamarin.Bundler {
 			// By default we always eliminate dead code.
 			if (!DeadCodeElimination.HasValue)
 				DeadCodeElimination = true;
-
-			// By default we always inline calls to NSObject.IsDirectBinding
-			if (!InlineIsDirectBinding.HasValue)
+			
+			if (!InlineIsDirectBinding.HasValue) {
+#if MONOTOUCH
+				// By default we always inline calls to NSObject.IsDirectBinding
 				InlineIsDirectBinding = true;
+#else
+				// NSObject.IsDirectBinding is not a safe optimization to apply to XM apps,
+				// because there may be additional code/assemblies we don't know about at build time.
+				InlineIsDirectBinding = false;
+#endif
+			}
 
 			// The default behavior for InlineIntPtrSize depends on the assembly being linked,
 			// which means we can't set it to a global constant. It's handled in the OptimizeGeneratedCodeSubStep directly.

--- a/tools/common/Optimizations.cs
+++ b/tools/common/Optimizations.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 
-namespace Xamarin.Bundler {
+namespace Xamarin.Bundler
+{
 	public class Optimizations
 	{
 		static string [] opt_names =
@@ -18,7 +19,7 @@ namespace Xamarin.Bundler {
 
 		public bool? RemoveUIThreadChecks {
 			get { return values [0]; }
-			set { values [0] = value;  }
+			set { values [0] = value; }
 		}
 		public bool? DeadCodeElimination {
 			get { return values [1]; }
@@ -64,7 +65,7 @@ namespace Xamarin.Bundler {
 			// By default we always eliminate dead code.
 			if (!DeadCodeElimination.HasValue)
 				DeadCodeElimination = true;
-			
+
 			if (!InlineIsDirectBinding.HasValue) {
 #if MONOTOUCH
 				// By default we always inline calls to NSObject.IsDirectBinding

--- a/tools/linker/CoreOptimizeGeneratedCode.cs
+++ b/tools/linker/CoreOptimizeGeneratedCode.cs
@@ -7,16 +7,47 @@ using Mono.Linker;
 using Mono.Tuner;
 using Xamarin.Bundler;
 
+using MonoTouch.Tuner;
+#if MONOMAC
+using MonoMac.Tuner;
+#endif
+
 namespace Xamarin.Linker {
 
 	public abstract class CoreOptimizeGeneratedCode : ExceptionalSubStep {
+		// If the type currently being processed is a direct binding or not.
+		// A null value means it's not a constant value, and can't be inlined.
+		bool? isdirectbinding_constant;
 
 		protected override string Name { get; } = "Binding Optimizer";
 		protected override int ErrorCode { get; } = 2020;
 
 		protected bool HasGeneratedCode { get; private set; }
 		protected bool IsExtensionType { get; private set; }
-		protected bool ProcessMethods { get; private set; }
+
+		protected LinkerOptions Options { get; set; }
+
+		public bool IsDualBuild {
+			get { return Options.Application.IsDualBuild; }
+		}
+
+		public int Arch {
+			get { return Options.Application.Is64Build ? 8 : 4; }
+		}
+
+		protected Optimizations Optimizations {
+			get {
+				return Options.Application.Optimizations;
+			}
+		}
+
+		// This is per assembly, so we set it in 'void Process (AssemblyDefinition)'
+		bool InlineIntPtrSize { get; set; }
+
+		public CoreOptimizeGeneratedCode (LinkerOptions options)
+		{
+			Options = options;
+		}
 
 		public override SubStepTargets Targets {
 			get { return SubStepTargets.Assembly | SubStepTargets.Type | SubStepTargets.Method; }
@@ -62,10 +93,14 @@ namespace Xamarin.Linker {
 
 		protected override void Process (TypeDefinition type)
 		{
+			if (!HasGeneratedCode)
+				return;
+
+			isdirectbinding_constant = type.IsNSObject (LinkContext) ? type.GetIsDirectBindingConstant (LinkContext) : null;
+
 			// if 'type' inherits from NSObject inside an assembly that has [GeneratedCode]
 			// or for static types used for optional members (using extensions methods), they can be optimized too
 			IsExtensionType = type.IsSealed && type.IsAbstract && type.Name.EndsWith ("_Extensions", StringComparison.Ordinal);
-			ProcessMethods = HasGeneratedCode || (!type.IsNSObject (LinkContext) && !IsExtensionType);
 		}
 
 		// [GeneratedCode] is not enough - e.g. it's used for anonymous delegates even if the 
@@ -342,8 +377,11 @@ namespace Xamarin.Linker {
 			return false;
 		}
 
-		protected static void EliminateDeadCode (MethodDefinition caller)
+		protected void EliminateDeadCode (MethodDefinition caller)
 		{
+			if (Optimizations.DeadCodeElimination != true)
+				return;
+
 			var instructions = caller.Body.Instructions;
 			var reachable = new bool [instructions.Count];
 
@@ -466,5 +504,166 @@ namespace Xamarin.Linker {
 				instructions.RemoveAt (last_reachable + 1);
 		}
 
+		protected override void Process (AssemblyDefinition assembly)
+		{
+			// The "get_Size" is a performance (over size) optimization.
+			// It always makes sense for platform assemblies because:
+			// * Xamarin.TVOS.dll only ship the 64 bits code paths (all 32 bits code is extra weight better removed)
+			// * Xamarin.WatchOS.dll only ship the 32 bits code paths (all 64 bits code is extra weight better removed)
+			// * Xamarin.iOS.dll  ship different 32/64 bits versions of the assembly anyway (nint... support)
+			//   Each is better to be optimized (it will be smaller anyway)
+			//
+			// However for fat (32/64) apps (i.e. iOS only right now) the optimization can duplicate the assembly
+			// (metadata) for 3rd parties binding projects, increasing app size for very minimal performance gains.
+			// For non-fat apps (the AppStore allows 64bits only iOS apps) then it's better to be applied
+			//
+			// TODO: we could make this an option "optimize for size vs optimize for speed" in the future
+			if (Optimizations.InlineIntPtrSize.HasValue) {
+				InlineIntPtrSize = Optimizations.InlineIntPtrSize.Value;
+			} else if (!IsDualBuild) {
+				InlineIntPtrSize = true;
+			} else {
+				InlineIntPtrSize = (Profile.Current as BaseProfile).ProductAssembly == assembly.Name.Name;
+			}
+			Driver.Log (4, "Optimization 'inline-intptr-size' enabled for assembly '{0}'.", assembly.Name);
+
+			base.Process (assembly);
+		}
+
+		protected override void Process (MethodDefinition method)
+		{
+			if (!method.HasBody)
+				return;
+
+			if (method.IsGeneratedCode (LinkContext) && (IsExtensionType || IsExport (method))) {
+				// We optimize methods that have the [GeneratedCodeAttribute] and is either an extension type or an exported method
+			} else {
+				// but it would be too risky to apply on user-generated code
+				return;
+			}
+
+			var instructions = method.Body.Instructions;
+			for (int i = 0; i < instructions.Count; i++) {
+				var ins = instructions [i];
+				switch (ins.OpCode.Code) {
+				case Code.Call:
+					ProcessCalls (method, ins);
+					break;
+				case Code.Ldsfld:
+					ProcessLoadStaticField (method, ins);
+					break;
+				}
+			}
+
+			EliminateDeadCode (method);
+		}
+
+		protected virtual void ProcessCalls (MethodDefinition caller, Instruction ins)
+		{
+			var mr = ins.Operand as MethodReference;
+			switch (mr?.Name) {
+			case "EnsureUIThread":
+				ProcessEnsureUIThread (caller, ins);
+				break;
+			case "get_Size":
+				ProcessIntPtrSize (caller, ins);
+				break;
+			case "get_IsDirectBinding":
+				ProcessIsDirectBinding (caller, ins);
+				break;
+			}
+		}
+
+		protected virtual void ProcessLoadStaticField (MethodDefinition caller, Instruction ins)
+		{
+		}
+
+		void ProcessEnsureUIThread (MethodDefinition caller, Instruction ins)
+		{
+#if MONOTOUCH
+			const string operation = "remove calls to UIApplication::EnsureUIThread";
+#else
+			const string operation = "remove calls to NSApplication::EnsureUIThread";
+#endif
+
+			if (Optimizations.RemoveUIThreadChecks != true)
+				return;
+
+			// Verify we're checking the right get_EnsureUIThread call
+			var mr = ins.Operand as MethodReference;
+#if MONOTOUCH
+			if (!mr.DeclaringType.Is (Namespaces.UIKit, "UIApplication"))
+				return;
+#else
+			if (!mr.DeclaringType.Is (Namespaces.AppKit, "NSApplication"))
+				return;
+#endif
+
+			// Verify a few assumptions before doing anything
+			if (!ValidateInstruction (caller, ins, operation, Code.Call))
+				return;
+
+			// This is simple: just remove the call
+			Nop (ins); // call void UIKit.UIApplication::EnsureUIThread()
+		}
+
+		void ProcessIntPtrSize (MethodDefinition caller, Instruction ins)
+		{
+			const string operation = "inline IntPtr.Size";
+
+			if (!InlineIntPtrSize)
+				return;
+
+			// This will optimize the following code sequence
+			// if (IntPtr.Size == 8) { ... } else { ... }
+
+			// Verify we're checking the right get_Size call
+			var mr = ins.Operand as MethodReference;
+			if (!mr.DeclaringType.Is ("System", "IntPtr"))
+				return;
+
+			// Verify a few assumptions before doing anything
+			if (!ValidateInstruction (caller, ins.Next, operation, Code.Ldc_I4_8))
+				return;
+
+			var branchInstruction = ins.Next.Next;
+			if (!ValidateInstruction (caller, branchInstruction, operation, Code.Bne_Un, Code.Bne_Un_S))
+				return;
+
+			// We're fine, inline the get_Size condition
+			ins.OpCode = Arch == 8 ? OpCodes.Ldc_I4_8 : OpCodes.Ldc_I4_4;
+			ins.Operand = null;
+		}
+
+		void ProcessIsDirectBinding (MethodDefinition caller, Instruction ins)
+		{
+			const string operation = "inline IsDirectBinding";
+
+			if (Optimizations.InlineIsDirectBinding != true)
+				return;
+
+			// If we don't know the constant isdirectbinding value, then we can't inline anything
+			if (!isdirectbinding_constant.HasValue)
+				return;
+
+			// Verify we're checking the right get_IsDirectBinding call
+			var mr = ins.Operand as MethodReference;
+			if (!mr.DeclaringType.Is (Namespaces.Foundation, "NSObject"))
+				return;
+
+			// Verify a few assumptions before doing anything
+			if (!ValidateInstruction (caller, ins.Previous, operation, Code.Ldarg_0))
+				return;
+
+			if (!ValidateInstruction (caller, ins, operation, Code.Call))
+				return;
+
+			// Clearing the branch succeeded, so clear the condition too
+			// ldarg.0
+			Nop (ins.Previous);
+			// call System.Boolean Foundation.NSObject::get_IsDirectBinding()
+			ins.OpCode = isdirectbinding_constant.Value ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0;
+			ins.Operand = null;
+		}
 	}
 }

--- a/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/OptimizeGeneratedCodeSubStep.cs
@@ -9,111 +9,18 @@ using Xamarin.Bundler;
 namespace MonoTouch.Tuner {
 	
 	public class OptimizeGeneratedCodeSubStep : CoreOptimizeGeneratedCode {
-		// If the type currently being processed is a direct binding or not.
-		// A null value means it's not a constant value, and can't be inlined.
-		bool? isdirectbinding_constant;
 		
 		public OptimizeGeneratedCodeSubStep (LinkerOptions options)
+			: base (options)
 		{
-			Options = options;
-#if DEBUG
-			Console.WriteLine ("OptimizeGeneratedCodeSubStep Arch {0} Device: {1}, EnsureUiThread: {2}, FAT 32+64 {3}", Arch, Device, EnsureUIThread, IsDualBuild);
-#endif
-		}
-		
-		public int Arch {
-			get { return Options.Arch; }
 		}
 
 		public bool Device {
 			get { return Options.Device; }
 		}
-		
-		public bool EnsureUIThread {
-			get { return Options.EnsureUIThread; }
-		}
 
-		public bool IsDualBuild {
-			get { return Options.IsDualBuild; }
-		}
-
-		LinkerOptions Options { get; set; }
-
-		bool ApplyIntPtrSizeOptimization { get; set; }
-
-		protected override void Process (AssemblyDefinition assembly)
-		{
-			// The "get_Size" is a performance (over size) optimization.
-			// It always makes sense for platform assemblies because:
-			// * Xamarin.TVOS.dll only ship the 64 bits code paths (all 32 bits code is extra weight better removed)
-			// * Xamarin.WatchOS.dll only ship the 32 bits code paths (all 64 bits code is extra weight better removed)
-			// * Xamarin.iOS.dll  ship different 32/64 bits versions of the assembly anyway (nint... support)
-			//   Each is better to be optimized (it will be smaller anyway)
-			//
-			// However for fat (32/64) apps (i.e. iOS only right now) the optimization can duplicate the assembly
-			// (metadata) for 3rd parties binding projects, increasing app size for very minimal performance gains.
-			// For non-fat apps (the AppStore allows 64bits only iOS apps) then it's better to be applied
-			//
-			// TODO: we could make this an option "optimize for size vs optimize for speed" in the future
-			ApplyIntPtrSizeOptimization = ((Profile.Current as BaseProfile).ProductAssembly == assembly.Name.Name) || !IsDualBuild;
-			base.Process (assembly);
-		}
-
-		protected override void Process (TypeDefinition type)
-		{
-			if (!HasGeneratedCode)
-				return;
-
-			isdirectbinding_constant = type.IsNSObject (LinkContext) ? type.GetIsDirectBindingConstant (LinkContext) : null;
-			base.Process (type);
-		}
-
-		protected override void Process (MethodDefinition method)
-		{
-			if (!method.HasBody)
-				return;
-
-			if (method.IsGeneratedCode (LinkContext) && (IsExtensionType || IsExport (method))) {
-				// We optimize methods that have the [GeneratedCodeAttribute] and is either an extension type or an exported method
-			} else {
-				// but it would be too risky to apply on user-generated code
-				return;
-			}
-			
-			var instructions = method.Body.Instructions;
-			for (int i = 0; i < instructions.Count; i++) {
-				var ins = instructions [i];
-				switch (ins.OpCode.Code) {
-				case Code.Call:
-					ProcessCalls (method, ins);
-					break;
-				case Code.Ldsfld:
-					ProcessLoadStaticField (method, ins);
-					break;
-				}
-			}
-
-			EliminateDeadCode (method);
-		}
-
-		void ProcessCalls (MethodDefinition caller, Instruction ins)
-		{
-			var mr = ins.Operand as MethodReference;
-			switch (mr?.Name) {
-			case "EnsureUIThread":
-				ProcessEnsureUIThread (caller, ins);
-				break;
-			case "get_Size":
-				ProcessIntPtrSize (caller, ins);
-				break;
-			case "get_IsDirectBinding":
-				ProcessIsDirectBinding (caller, ins);
-				break;
-			}
-		}
-				
 		// https://app.asana.com/0/77259014252/77812690163
-		void ProcessLoadStaticField (MethodDefinition caller, Instruction ins)
+		protected override void ProcessLoadStaticField (MethodDefinition caller, Instruction ins)
 		{
 			FieldReference fr = ins.Operand as FieldReference;
 			switch (fr?.Name) {
@@ -121,11 +28,16 @@ namespace MonoTouch.Tuner {
 				ProcessRuntimeArch (caller, ins);
 				break;
 			}
+
+			base.ProcessLoadStaticField (caller, ins);
 		}
 
 		void ProcessRuntimeArch (MethodDefinition caller, Instruction ins)
 		{
 			const string operation = "inline Runtime.Arch";
+
+			if (Optimizations.InlineRuntimeArch != true)
+				return;
 
 			// Verify we're checking the right Arch field
 			var fr = ins.Operand as FieldReference;
@@ -139,82 +51,6 @@ namespace MonoTouch.Tuner {
 			// We're fine, inline the Runtime.Arch condition
 			// The enum values are Runtime.DEVICE = 0 and Runtime.SIMULATOR = 1,
 			ins.OpCode = Device ? OpCodes.Ldc_I4_0 : OpCodes.Ldc_I4_1;
-			ins.Operand = null;
-		}
-
-		void ProcessEnsureUIThread (MethodDefinition caller, Instruction ins)
-		{
-			const string operation = "remove calls to UIApplication::EnsureUIThread";
-
-			if (EnsureUIThread)
-				return;
-
-			// Verify we're checking the right get_EnsureUIThread call
-			var mr = ins.Operand as MethodReference;
-			if (!mr.DeclaringType.Is (Namespaces.UIKit, "UIApplication"))
-				return;
-
-			// Verify a few assumptions before doing anything
-			if (!ValidateInstruction (caller, ins, operation, Code.Call))
-				return;
-
-			// This is simple: just remove the call
-			Nop (ins); // call void UIKit.UIApplication::EnsureUIThread()
-		}
-
-		void ProcessIntPtrSize (MethodDefinition caller, Instruction ins)
-		{
-			const string operation = "inline IntPtr.Size";
-
-			if (!ApplyIntPtrSizeOptimization)
-				return;
-
-			// This will optimize the following code sequence
-			// if (IntPtr.Size == 8) { ... } else { ... }
-
-			// Verify we're checking the right get_Size call
-			var mr = ins.Operand as MethodReference;
-			if (!mr.DeclaringType.Is ("System", "IntPtr"))
-				return;
-
-			// Verify a few assumptions before doing anything
-			if (!ValidateInstruction (caller, ins.Next, operation, Code.Ldc_I4_8))
-				return;
-
-			var branchInstruction = ins.Next.Next;
-			if (!ValidateInstruction (caller, branchInstruction, operation, Code.Bne_Un, Code.Bne_Un_S))
-				return;
-
-			// We're fine, inline the get_Size condition
-			ins.OpCode = Arch == 8 ? OpCodes.Ldc_I4_8 : OpCodes.Ldc_I4_4;
-			ins.Operand = null;
-		}
-
-		void ProcessIsDirectBinding (MethodDefinition caller, Instruction ins)
-		{
-			const string operation = "inline IsDirectBinding";
-
-			// If we don't know the constant isdirectbinding value, then we can't inline anything
-			if (!isdirectbinding_constant.HasValue)
-				return;
-
-			// Verify we're checking the right get_IsDirectBinding call
-			var mr = ins.Operand as MethodReference;
-			if (!mr.DeclaringType.Is (Namespaces.Foundation, "NSObject"))
-				return;
-
-			// Verify a few assumptions before doing anything
-			if (!ValidateInstruction (caller, ins.Previous, operation, Code.Ldarg_0))
-				return;
-
-			if (!ValidateInstruction (caller, ins, operation, Code.Call))
-				return;
-
-			// Clearing the branch succeeded, so clear the condition too
-			// ldarg.0
-			Nop (ins.Previous);
-			// call System.Boolean Foundation.NSObject::get_IsDirectBinding()
-			ins.OpCode = isdirectbinding_constant.Value ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0;
 			ins.Operand = null;
 		}
 	}

--- a/tools/mmp/Application.cs
+++ b/tools/mmp/Application.cs
@@ -8,6 +8,7 @@ namespace Xamarin.Bundler {
 
 		public bool Is32Build => !Driver.Is64Bit; 
 		public bool Is64Build => Driver.Is64Bit;
+		public bool IsDualBuild => false;
 
 		bool RequiresXcodeHeaders => Driver.Registrar == RegistrarMode.Static && LinkMode == LinkMode.None;
 

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -95,6 +95,7 @@ tuner_sources = \
 	$(TOP)/tools/linker/RemoveUserResourcesSubStep.cs \
 	../linker/MonoTouch.Tuner/Extensions.cs	\
 	../linker/MonoTouch.Tuner/ListExportedSymbols.cs	\
+	../linker/MonoTouch.Tuner/MonoTouchTypeMap.cs		\
 	../linker/MonoTouch.Tuner/ProcessExportedFields.cs	\
 	../linker/MonoTouch.Tuner/PreserveSmartEnumConversionsSubStep.cs		\
 	../../src/build/mac/Constants.cs
@@ -131,6 +132,7 @@ mmp_sources = \
 	$(TOP)/tools/common/CoreResolver.cs \
 	$(TOP)/tools/common/DerivedLinkContext.cs \
 	$(TOP)/tools/common/StringUtils.cs \
+	$(TOP)/tools/common/Optimizations.cs \
 	$(TOP)/src/Foundation/ConnectAttribute.cs \
 	$(TOP)/src/Foundation/ExportAttribute.cs \
 	$(TOP)/src/ObjCRuntime/ArgumentSemantic.cs \

--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -28,7 +28,6 @@ namespace MonoMac.Tuner {
 		public AssemblyResolver Resolver { get; set; }
 		public IEnumerable<string> SkippedAssemblies { get; set; }
 		public I18nAssemblies I18nAssemblies { get; set; }
-		public bool EnsureUIThread { get; set; }
 		public IList<string> ExtraDefinitions { get; set; }
 		public TargetFramework TargetFramework { get; set; }
 		public string Architecture { get; set; }
@@ -36,6 +35,7 @@ namespace MonoMac.Tuner {
 		internal RuntimeOptions RuntimeOptions { get; set; }
 		public bool SkipExportedSymbolsInSdkAssemblies { get; set; }
 		public Target Target { get; set; }
+		public Application Application { get { return Target.App; } }
 
 		public static I18nAssemblies ParseI18nAssemblies (string i18n)
 		{
@@ -157,11 +157,11 @@ namespace MonoMac.Tuner {
 			pipeline.AppendStep (new ProcessExportedFields ());
 
 			if (options.LinkMode != LinkMode.None) {
-				pipeline.AppendStep (new TypeMapStep ());
+				pipeline.AppendStep (new MonoTouchTypeMapStep ());
 
 				var subdispatcher = new SubStepDispatcher {
 					new ApplyPreserveAttribute (),
-					new OptimizeGeneratedCodeSubStep (options.EnsureUIThread),
+					new OptimizeGeneratedCodeSubStep (options),
 					new RemoveUserResourcesSubStep (),
 					new CoreRemoveAttributes (),
 					new CoreHttpMessageHandler (options),

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -85,7 +85,6 @@ namespace Xamarin.Bundler {
 		static bool no_executable;
 		static bool embed_mono = true;
 		static bool? profiling = false;
-		static bool? thread_check = null;
 		static string link_flags = null;
 		static LinkerOptions linker_options;
 		static bool? disable_lldb_attach = null;
@@ -286,8 +285,8 @@ namespace Xamarin.Bundler {
 				{ "arch=", "Specify the architecture ('i386' or 'x86_64') of the native runtime (default to 'i386')", v => { arch = v; arch_set = true; } },
 				{ "profile=", "(Obsoleted in favor of --target-framework) Specify the .NET profile to use (defaults to '" + Xamarin.Utils.TargetFramework.Default + "')", v => SetTargetFramework (v) },
 				{ "target-framework=", "Specify the .NET target framework to use (defaults to '" + Xamarin.Utils.TargetFramework.Default + "')", v => SetTargetFramework (v) },
-				{ "force-thread-check", "Keep UI thread checks inside (even release) builds", v => { thread_check = true; }},
-				{ "disable-thread-check", "Remove UI thread checks inside (even debug) builds", v => { thread_check = false; }},
+				{ "force-thread-check", "Keep UI thread checks inside (even release) builds [DEPRECATED, use --linker-optimize=-remove-uithread-checks instead]", v => { App.Optimizations.RemoveUIThreadChecks = false; }, true},
+				{ "disable-thread-check", "Remove UI thread checks inside (even debug) builds [DEPRECATED, use --linker-optimize=remove-uithread-checks instead]", v => { App.Optimizations.RemoveUIThreadChecks = true; }, true},
 				{ "registrar:", "Specify the registrar to use (dynamic [default], static, partial)", v => {
 						switch (v) {
 						case "static":
@@ -809,10 +808,6 @@ namespace Xamarin.Bundler {
 						native_libs.Add (nr, null);
 				}
 
-				// warn if we ask to remove thread checks but the linker is not enabled
-				if (App.LinkMode == LinkMode.None && thread_check.HasValue && !thread_check.Value)
-					ErrorHelper.Warning (2003, "Option '{0}' will be ignored since linking is disabled", "-disable-thread-check");
-				
 				var linked_native_libs = Link ();
 				foreach (var kvp in linked_native_libs) {
 					List<MethodDefinition> methods;
@@ -1457,9 +1452,6 @@ namespace Xamarin.Bundler {
 				TargetFramework = TargetFramework,
 				Architecture = arch,
 				RuntimeOptions = App.RuntimeOptions,
-				// by default we keep the code to ensure we're executing on the UI thread (for UI code) for debug builds
-				// but this can be overridden to either (a) remove it from debug builds or (b) keep it in release builds
-				EnsureUIThread = thread_check.HasValue ? thread_check.Value : App.EnableDebug,
 				MarshalNativeExceptionsState = !App.RequiresPInvokeWrappers ? null : new PInvokeWrapperGenerator ()
 				{
 					App = App,

--- a/tools/mmp/linker/MonoMac.Tuner/OptimizeGeneratedCodeSubStep.cs
+++ b/tools/mmp/linker/MonoMac.Tuner/OptimizeGeneratedCodeSubStep.cs
@@ -10,58 +10,9 @@ namespace MonoMac.Tuner {
 	
 	public class OptimizeGeneratedCodeSubStep : CoreOptimizeGeneratedCode {
 		
-		public OptimizeGeneratedCodeSubStep (bool ensureUiThread)
+		public OptimizeGeneratedCodeSubStep (LinkerOptions options)
+			: base (options)
 		{
-			EnsureUIThread = ensureUiThread;
-		}
-		
-		public bool EnsureUIThread { get; set; }
-		
-		public override bool IsActiveFor (AssemblyDefinition assembly)
-		{
-			// do not remove the code if we want the checks
-			if (EnsureUIThread)
-				return false;
-
-			return base.IsActiveFor (assembly);
-		}
-		
-		protected override void Process (MethodDefinition method)
-		{
-			// special processing on generated methods from NSObject-inherited types
-			// it would be too risky to apply on user-generated code
-			if (!method.HasBody || !method.IsGeneratedCode (LinkContext) || (!IsExtensionType && !IsExport (method)))
-				return;
-			
-			var instructions = method.Body.Instructions;
-			for (int i = 0; i < instructions.Count; i++) {
-				switch (instructions [i].OpCode.Code) {
-				case Code.Call:
-					ProcessCalls (method, i);
-					break;
-				}
-			}
-		}
-		
-		void ProcessCalls (MethodDefinition caller, int i)
-		{
-			var instructions = caller.Body.Instructions;
-			Instruction ins = instructions [i];
-			MethodReference md = ins.Operand as MethodReference;
-			// if it could not be resolved to a definition then it won't be NSObject
-			if (md == null)
-				return;
-			
-			switch (md.Name) {
-			case "EnsureUIThread":
-				if (EnsureUIThread || !md.DeclaringType.Is (Namespaces.AppKit, "NSApplication"))
-					return;
-#if DEBUG
-				Console.WriteLine ("\t{0} EnsureUIThread {1}", caller, EnsureUIThread);
-#endif						
-				Nop (ins);								// call void MonoMac.AppKit.NSApplication::EnsureUIThread()
-				break;
-			}
 		}
 	}
 }

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -317,6 +317,9 @@
     <Compile Include="..\common\DerivedLinkContext.cs">
       <Link>external\DerivedLinkContext.cs</Link>
     </Compile>
+    <Compile Include="..\common\Optimizations.cs">
+      <Link>external\Optimizations.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\ObjCRuntime\Registrar.core.cs">
       <Link>external\Registrar.core.cs</Link>
     </Compile>
@@ -361,6 +364,9 @@
     </Compile>
     <Compile Include="..\common\CoreResolver.cs">
       <Link>common\CoreResolver.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\master\xamarin-macios\tools\linker\MonoTouch.Tuner\MonoTouchTypeMap.cs">
+      <Link>MonoTouch.Tuner\MonoTouchTypeMap.cs</Link>
     </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -111,8 +111,7 @@ namespace Xamarin.Bundler {
 		public string SymbolList;
 		public bool ManagedStrip = true;
 		public List<string> NoSymbolStrip = new List<string> ();
-		
-		public bool? ThreadCheck;
+
 		public DlsymOptions DlsymOptions;
 		public List<Tuple<string, bool>> DlsymAssemblies;
 		public bool? UseMonoFramework;

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -138,6 +138,7 @@ MTOUCH_SOURCES = \
 	$(TOP)/tools/common/DerivedLinkContext.cs \
 	$(TOP)/tools/common/Target.cs \
 	$(TOP)/tools/common/CompilerFlags.cs \
+	$(TOP)/tools/common/Optimizations.cs \
 	$(TOP)/src/Foundation/ExportAttribute.cs \
 	$(TOP)/src/Foundation/ConnectAttribute.cs \
 	$(XAMARIN_MACDEV_PATH)/Xamarin.MacDev/PListObject.cs \

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -481,11 +481,7 @@ namespace Xamarin.Bundler
 				LinkAway = App.LinkAway,
 				ExtraDefinitions = App.Definitions,
 				Device = App.IsDeviceBuild,
-				// by default we keep the code to ensure we're executing on the UI thread (for UI code) for debug builds
-				// but this can be overridden to either (a) remove it from debug builds or (b) keep it in release builds
-				EnsureUIThread = App.ThreadCheck.HasValue ? App.ThreadCheck.Value : App.EnableDebug,
 				DebugBuild = App.EnableDebug,
-				Arch = Is64Build ? 8 : 4,
 				IsDualBuild = App.IsDualBuild,
 				DumpDependencies = App.LinkerDumpDependencies,
 				RuntimeOptions = App.RuntimeOptions,

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -27,10 +27,8 @@ namespace MonoTouch.Tuner {
 		public bool LinkSymbols { get; set; }
 		public bool LinkAway { get; set; }
 		public bool Device { get; set; }
-		public bool EnsureUIThread { get; set; }
 		public IList<string> ExtraDefinitions { get; set; }
 		public bool DebugBuild { get; set; }
-		public int Arch { get; set; }
 		public bool IsDualBuild { get; set; }
 		public bool DumpDependencies { get; set; }
 		internal PInvokeWrapperGenerator MarshalNativeExceptionsState { get; set; }

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1129,8 +1129,8 @@ namespace Xamarin.Bundler
 			{ "pie:", "Enable (default) or disable PIE (Position Independent Executable).", v => { app.EnablePie = ParseBool (v, "pie"); }},
 			{ "compiler=", "Specify the Objective-C compiler to use (valid values are gcc, g++, clang, clang++ or the full path to a GCC-compatible compiler).", v => { app.Compiler = v; }},
 			{ "fastdev", "Build an app that supports fastdev (this app will only work when launched using Xamarin Studio)", v => { app.AddAssemblyBuildTarget ("@all=dynamiclibrary"); }},
-			{ "force-thread-check", "Keep UI thread checks inside (even release) builds", v => { app.ThreadCheck = true; }},
-			{ "disable-thread-check", "Remove UI thread checks inside (even debug) builds", v => { app.ThreadCheck = false; }},
+			{ "force-thread-check", "Keep UI thread checks inside (even release) builds [DEPRECATED, use --linker-optimize=-remove-uithread-checks instead]", v => { app.Optimizations.RemoveUIThreadChecks = false; }, true},
+			{ "disable-thread-check", "Remove UI thread checks inside (even debug) builds [DEPRECATED, use --linker-optimize=remove-uithread-checks instead]", v => { app.Optimizations.RemoveUIThreadChecks = true; }, true},
 			{ "debug:", "Generate debug code in Mono for the specified assembly (set to 'all' to generate debug code for all assemblies, the default is to generate debug code for user assemblies only)",
 				v => {
 					app.EnableDebug = true;
@@ -1347,11 +1347,6 @@ namespace Xamarin.Bundler
 
 			if (action == Action.None)
 				throw new MonoTouchException (52, true, "No command specified.");
-
-			// warn if we ask to remove thread checks but the linker is not enabled
-			if (app.LinkMode == LinkMode.None && app.ThreadCheck.HasValue && !app.ThreadCheck.Value) {
-				ErrorHelper.Show (new MonoTouchException (2003, false, "Option '{0}' will be ignored since linking is disabled", "-disable-thread-check"));
-			}
 
 			if (app.SdkVersion < new Version (6, 0) && app.IsArchEnabled (Abi.ARMv7s))
 				throw new MonoTouchException (14, true, "The iOS {0} SDK does not support building applications targeting {1}", app.SdkVersion, "ARMv7s");

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -357,6 +357,9 @@
     <Compile Include="..\common\CoreResolver.cs">
       <Link>common\CoreResolver.cs</Link>
     </Compile>
+    <Compile Include="..\common\Optimizations.cs">
+      <Link>external\Optimizations.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Core" />


### PR DESCRIPTION
1. Add an --optimize flag to mtouch/mmp that allows users to select which
   optimizations to apply (or not). This makes it easier to add future
   optimizations, and allow users to disable any optimization that causes
   problems without having to disable many other features.

2. Share as much optimization code as possible between mtouch and mmp. This
   immediately gives a benefit to mmp, which has three new optimizations only
   mtouch had: NSObject.IsDirectBinding inlining, IntPtr.Size inlining and
   dead code elimination.

   This results in ~34kb of disk space saved for a linked Xamarin.Mac app:

   * link sdk: [Debug][1], [Release][2]
   * link all: [Debug][3], [Release][4]

Testing also verifies that monotouchtest ([Debug][5], [Release][6]) has not
changed size at all, which means that no default optimizations have changed
inadvertedly.

[1]: https://gist.github.com/rolfbjarne/1a2d24936f01594a57cbd42878ccde2b#link-sdk-mac--debug
[2]: https://gist.github.com/rolfbjarne/1a2d24936f01594a57cbd42878ccde2b#link-sdk-mac--release
[3]: https://gist.github.com/rolfbjarne/1a2d24936f01594a57cbd42878ccde2b#link-all-mac--debug
[4]: https://gist.github.com/rolfbjarne/1a2d24936f01594a57cbd42878ccde2b#link-all-mac--release
[5]: https://gist.github.com/rolfbjarne/1a2d24936f01594a57cbd42878ccde2b#monotouchtest-iphonedebug64
[6]: https://gist.github.com/rolfbjarne/1a2d24936f01594a57cbd42878ccde2b#monotouchtest-iphonerelease64