### PR TITLE
[msbuild] Fixed provisioning profile lookups for tvOS

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Tasks/CompileEntitlements.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/CompileEntitlements.cs
@@ -42,8 +42,6 @@ namespace Xamarin.Mac.Tasks
 			get { return Path.Combine (SdkDevPath, "Platforms/MacOSX.platform/Entitlements.plist"); }
 		}
 
-		protected override MobileProvisionPlatform Platform { get { return MobileProvisionPlatform.MacOS; } }
-		
 		protected override string EntitlementBundlePath { get { return Path.Combine (AppBundleDir, "Contents", "Resources"); } }
 
 		protected override PDictionary GetCompiledEntitlements (MobileProvision profile, PDictionary template)

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -262,6 +262,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			IsAppExtension="$(IsAppExtension)"
 			ProvisioningProfile="$(_ProvisioningProfile)"
 			SdkVersion="$(MacOSXSdkVersion)"
+			SdkPlatform="MacOSX"
 			SdkDevPath="$(_SdkDevPath)"
 			Debug="$(DebugSymbols)"
 			>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
@@ -41,6 +41,9 @@ namespace Xamarin.MacDev.Tasks
 		public string ProvisioningProfile { get; set; }
 
 		[Required]
+		public string SdkPlatform { get; set; }
+
+		[Required]
 		public string SdkVersion { get; set; }
 
 		#endregion
@@ -50,8 +53,6 @@ namespace Xamarin.MacDev.Tasks
 		protected abstract string DefaultEntitlementsPath { get; }
 
 		protected abstract HashSet<string> AllowedProvisioningKeys { get; }
-
-		protected abstract MobileProvisionPlatform Platform { get; }
 
 		protected abstract string EntitlementBundlePath { get; }
 
@@ -304,6 +305,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public override bool Execute ()
 		{
+			MobileProvisionPlatform platform;
 			MobileProvision profile;
 			PDictionary template;
 			PDictionary compiled;
@@ -311,8 +313,27 @@ namespace Xamarin.MacDev.Tasks
 			string path;
 			bool save;
 
+			switch (SdkPlatform) {
+			case "AppleTVSimulator":
+			case "AppleTVOS":
+				platform = MobileProvisionPlatform.tvOS;
+				break;
+			case "iPhoneSimulator":
+			case "WatchSimulator":
+			case "iPhoneOS":
+			case "WatchOS":
+				platform = MobileProvisionPlatform.iOS;
+				break;
+			case "MacOSX":
+				platform = MobileProvisionPlatform.MacOS;
+				break;
+			default:
+				Log.LogError ("Unknown SDK platform: {0}", SdkPlatform);
+				return false;
+			}
+
 			if (!string.IsNullOrEmpty (ProvisioningProfile)) {
-				if ((profile = GetMobileProvision (Platform, ProvisioningProfile)) == null) {
+				if ((profile = GetMobileProvision (platform, ProvisioningProfile)) == null) {
 					Log.LogError ("Could not locate the provisioning profile with a Name or UUID of {0}.", ProvisioningProfile);
 					return false;
 				}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
@@ -44,8 +44,6 @@ namespace Xamarin.iOS.Tasks
 			}
 		}
 
-		protected override MobileProvisionPlatform Platform { get { return MobileProvisionPlatform.iOS; } }
-
 		protected override string EntitlementBundlePath { get { return AppBundleDir; } }
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1483,6 +1483,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			IsAppExtension="$(IsAppExtension)"
 			ProvisioningProfile="$(_ProvisioningProfile)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
+			SdkPlatform="$(_SdkPlatform)"
 			SdkVersion="$(MtouchSdkVersion)"
 			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			>

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
@@ -40,6 +40,7 @@ namespace Xamarin.iOS.Tasks
 			task.Entitlements = Path.Combine ("..", "bin", "Resources", "Entitlements.plist");
 			task.IsAppExtension = false;
 			task.ProvisioningProfile = Path.Combine ("..", "bin", "Resources", "profile.mobileprovision");
+			task.SdkPlatform = "iPhoneOS";
 			task.SdkVersion = "6.1";
 
 			compiledEntitlements = task.CompiledEntitlements;


### PR DESCRIPTION
Fixes this MSBuild unit test on wrench:

```
1) Test Failure : Xamarin.iOS.Tasks.TVAppTests("TV","iPhone").BasicTest
     #RunTarget-ErrorCount
	Could not locate the provisioning profile with a Name or UUID of e822ee59-a61b-484c-a708-f0de7c938613.
  Expected: 0
  But was:  1
```

It claims to fail a provisioning profile it found earlier:

```
Task "DetectSigningIdentity"
	Using task DetectSigningIdentity from Xamarin.iOS.Tasks.DetectSigningIdentity, Xamarin.iOS.Tasks, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
	The certificate 'Developer ID Application: Xamarin Inc (7V723M9SQ5)' does not match any of the prefixes 'iPhone Developer', 'iOS Development'.
	The certificate 'Developer ID Installer: Xamarin Inc (7V723M9SQ5)' does not match any of the prefixes 'iPhone Developer', 'iOS Development'.
	The certificate 'FARSCAPE' does not match any of the prefixes 'iPhone Developer', 'iOS Development'.
	The certificate 'Mac Developer: Builder Xamarin (C9K3627T5A)' does not match any of the prefixes 'iPhone Developer', 'iOS Development'.
	Available certificates:
	    iPhone Developer: Builder Xamarin (C9K3627T5A)
	    iPhone Developer: Builder Xamarin (RH6G28WM67)
	Available profiles:
	    SJ4M429CQ6_Builder_tvOS_BuildMachine
	'161174814714746EDE30E74E75D9AC9A52F216E1' doesn't match '7D268551AD0F31B49A1FD8588B811D063730B2C2'.
	Finding matching provisioning profiles with compatible AppID, keeping only those with the longest matching (wildcard) IDs.
	Detected signing identity:
	  Code Signing Key: "iPhone Developer: Builder Xamarin (C9K3627T5A)" (161174814714746EDE30E74E75D9AC9A52F216E1)
	  Provisioning Profile: "SJ4M429CQ6_Builder_tvOS_BuildMachine" (e822ee59-a61b-484c-a708-f0de7c938613)
	  Bundle Id: com.xamarin.mytvapp
	  App Id: SJ4M429CQ6.com.xamarin.mytvapp
Done executing task "DetectSigningIdentity"
```

It depends on the set of installed provisioning profiles (which is apparently different between wrench and Jenkins), so it went unnoticed.