### PR TITLE
Fix RequiresSuperAttribute

### DIFF
--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -47,6 +47,7 @@ GENERATOR_ATTRIBUTE_SOURCES = \
 	$(TOP)/src/ObjCRuntime/PlatformAvailability2.cs \
 	$(TOP)/src/ObjCRuntime/PlatformAvailabilityShadow.cs \
 	$(TOP)/src/ObjCRuntime/Registrar.core.cs \
+	$(TOP)/src/ObjCRuntime/RequiresSuperAttribute.cs \
 
 IKVM_REFLECTION_FLAGS = -d:NO_AUTHENTICODE,STATIC,NO_SYMBOL_WRITER
 

--- a/src/ObjCRuntime/RequiresSuperAttribute.cs
+++ b/src/ObjCRuntime/RequiresSuperAttribute.cs
@@ -15,7 +15,7 @@ namespace XamCore.ObjCRuntime {
 	[AttributeUsage (AttributeTargets.Method, AllowMultiple = false)]
 	public sealed class RequiresSuperAttribute : AdviceAttribute {
 		public RequiresSuperAttribute ()
-			: base ("Overriding this method requires a call to the overriden method.")
+			: base ("Overriding this method requires a call to the overridden method.")
 		{
 		}
 	}

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1542,6 +1542,7 @@ SHARED_CORE_SOURCES = \
 	ObjCRuntime/PlatformAvailabilityShadow.cs \
 	ObjCRuntime/Protocol.cs \
 	ObjCRuntime/Registrar.core.cs \
+	ObjCRuntime/RequiresSuperAttribute.cs \
 	ObjCRuntime/Selector.cs \
 	Simd/MatrixDouble4x4.cs \
 	Simd/MatrixFloat2x2.cs \
@@ -1576,7 +1577,6 @@ SHARED_SOURCES = \
 	ObjCRuntime/Registrar.cs \
 	ObjCRuntime/ReleaseAttribute.cs \
 	ObjCRuntime/RequiredFrameworkAttribute.cs \
-	ObjCRuntime/RequiresSuperAttribute.cs \
 	ObjCRuntime/Runtime.cs \
 	ObjCRuntime/Runtime.iOS.cs \
 	ObjCRuntime/Runtime.mac.cs \

--- a/src/generator-attributes.cs
+++ b/src/generator-attributes.cs
@@ -842,8 +842,3 @@ public class DefaultEnumValueAttribute : Attribute {
 	{
 	}
 }
-
-// Hint that overriding the member requires a call to the base type
-[AttributeUsage (AttributeTargets.Method | AttributeTargets.Constructor, AllowMultiple=false)]
-public class RequiresSuperAttribute : Attribute {
-}

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -14159,12 +14159,12 @@ namespace XamCore.UIKit {
 
 		[iOS (11,0), TV (11,0)]
 		[Export ("viewLayoutMarginsDidChange")]
-		[Advice ("You must call the base method when overriding.")] // [RequiresSuper]
+		[RequiresSuper]
 		void ViewLayoutMarginsDidChange ();
 
 		[iOS (11,0), TV (11,0)]
 		[Export ("viewSafeAreaInsetsDidChange")]
-		[Advice ("You must call the base method when overriding.")] // [RequiresSuper]
+		[RequiresSuper]
 		void ViewSafeAreaInsetsDidChange ();
 
 		[NoWatch, NoTV]


### PR DESCRIPTION
Looks like the wrong RequiresSuperAttribute was used by the generator (from `generator-attributes.cs`).

- Removed incorrect RequiresSuperAttribute from `generator-attributes.cs`.
- Added remaining [RequiresSuper] attributes to UIKit.
- Fixed typo in RequiresSuperAttribute.cs
- Fixed frameworks.sources so [RequiresSuper] works in the bindings files.