### PR TITLE
[xharness] Fix Makefile generation of grouped targets with spaces.

### DIFF
--- a/tests/xharness/MakefileGenerator.cs
+++ b/tests/xharness/MakefileGenerator.cs
@@ -211,9 +211,9 @@ namespace xharness
 				writer.WriteLine ("\t$(Q) rm -rf \".$@-failure.stamp\"");
 				foreach (var target in allTargets) {
 					if (target is MacClassicTarget)
-						writer.WriteLine ("\t$(Q) $(MAKE) \"{0}\" || echo \"{0} failed\" >> \".$@-failure.stamp\"", MakeMacClassicTargetName (target, MacTargetNameType.Run));
+						writer.WriteLine ("\t$(Q) $(MAKE) {0} || echo \"{0} failed\" >> \".$@-failure.stamp\"", MakeMacClassicTargetName (target, MacTargetNameType.Run));
 					else if (target is MacUnifiedTarget)
-						writer.WriteLine ("\t$(Q) $(MAKE) \"{0}\" || echo \"{0} failed\" >> \".$@-failure.stamp\"", MakeMacUnifiedTargetName (target, MacTargetNameType.Run));
+						writer.WriteLine ("\t$(Q) $(MAKE) {0} || echo \"{0} failed\" >> \".$@-failure.stamp\"", MakeMacUnifiedTargetName (target, MacTargetNameType.Run));
 					else
 						throw new NotImplementedException ();					
 				}
@@ -225,9 +225,9 @@ namespace xharness
 				writer.WriteLine ("\t$(Q) rm -rf \".$@-failure.stamp\"");
 				foreach (var target in allTargets) {
 					if (target is MacClassicTarget)
-						writer.WriteLine ("\t$(Q) $(MAKE) \"{0}\" || echo \"{0} failed\" >> \".$@-failure.stamp\"", MakeMacClassicTargetName (target, MacTargetNameType.Build));
+						writer.WriteLine ("\t$(Q) $(MAKE) {0} || echo \"{0} failed\" >> \".$@-failure.stamp\"", MakeMacClassicTargetName (target, MacTargetNameType.Build));
 					else if (target is MacUnifiedTarget)
-						writer.WriteLine ("\t$(Q) $(MAKE) \"{0}\" || echo \"{0} failed\" >> \".$@-failure.stamp\"", MakeMacUnifiedTargetName (target, MacTargetNameType.Build));
+						writer.WriteLine ("\t$(Q) $(MAKE) {0} || echo \"{0} failed\" >> \".$@-failure.stamp\"", MakeMacUnifiedTargetName (target, MacTargetNameType.Build));
 					else
 						throw new NotImplementedException ();
 


### PR DESCRIPTION
These targets will already be properly escaped (using backslash), so adding
quotes will cause make to treat the backslashes literally (and break).

Fixes an issue with package-tests:

    $ make package-tests
    [...]
    build-mac-classic-dont\ link failed
    build-mac-unified-dont\ link failed
    build-mac-unifiedXM45-dont\ link failed
    build-mac-unified32-dont\ link failed
    build-mac-unifiedXM4532-dont\ link failed
    build-mac-unified-link\ all failed
    build-mac-unified-link\ sdk failed
    make[4]: *** [build-mac] Error 1
    make[3]: *** [mac-test-package.zip] Error 2
    make[2]: *** [package-tests] Error 2