### PR TITLE
[install-source] Add console runner from Nuget and fix xharness to restore nugets before attempting to build.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -529,6 +529,7 @@ namespace xharness
 				SpecifyConfiguration = false,
 				Platform = TestPlatform.iOS,
 			};
+			buildInstallSources.SolutionPath = Path.GetFullPath (Path.Combine (Harness.RootDirectory, "..", "tools", "install-source", "install-source.sln")); // this is required for nuget restore to be executed
 			var nunitExecutionInstallSource = new NUnitExecuteTask (buildInstallSources)
 			{
 				TestLibrary = Path.Combine (Harness.RootDirectory, "..", "tools", "install-source", "InstallSourcesTests", "bin", "Release", "InstallSourcesTests.dll"),

--- a/tools/install-source/InstallSourcesTests/packages.config
+++ b/tools/install-source/InstallSourcesTests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnit.Runners" version="2.6.3" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
xharness needs a solution in order to ask for a nuget restore, so make sure to
provide the path to the solution.

This fixes a build issue where the install source tests would fail to build
due to picking up the system's nunit.framework.dll because the nuget one
wasn't found/restored:

    MonoPathManglerTest.cs(8,3): error CS0619: 'TestFixtureAttribute' is obsolete: 'The NUnit framework shipped with Mono is deprecated and will be removed in a future release. It was based on NUnit 2.4 which is long outdated. Please move to the NUnit NuGet package or some other form of acquiring NUnit.'
    XamarinSourcesPathManglerTest.cs(8,3): error CS0619: 'TestFixtureAttribute' is obsolete: 'The NUnit framework shipped with Mono is deprecated and will be removed in a future release. It was based on NUnit 2.4 which is long outdated. Please move to the NUnit NuGet package or some other form of acquiring NUnit.'
    OpenTKManglerTest.cs(8,3): error CS0619: 'TestFixtureAttribute' is obsolete: 'The NUnit framework shipped with Mono is deprecated and will be removed in a future release. It was based on NUnit 2.4 which is long outdated. Please move to the NUnit NuGet package or some other form of acquiring NUnit.'
    PathManclerFactoryTests.cs(8,3): error CS0619: 'TestFixtureAttribute' is obsolete: 'The NUnit framework shipped with Mono is deprecated and will be removed in a future release. It was based on NUnit 2.4 which is long outdated. Please move to the NUnit NuGet package or some other form of acquiring NUnit.'
    OpenTKManglerTest.cs(29,4): error CS0616: 'TestCase' is not an attribute class
    OpenTKManglerTest.cs(30,4): error CS0616: 'TestCase' is not an attribute class
    MonoPathManglerTest.cs(29,4): error CS0616: 'TestCase' is not an attribute class
    MonoPathManglerTest.cs(30,4): error CS0616: 'TestCase' is not an attribute class
    MonoPathManglerTest.cs(31,4): error CS0616: 'TestCase' is not an attribute class
    XamarinSourcesPathManglerTest.cs(33,4): error CS0616: 'TestCase' is not an attribute class
    XamarinSourcesPathManglerTest.cs(35,4): error CS0616: 'TestCase' is not an attribute class
    XamarinSourcesPathManglerTest.cs(37,4): error CS0616: 'TestCase' is not an attribute class
    OpenTKManglerTest.cs(36,4): error CS0616: 'TestCase' is not an attribute class
    OpenTKManglerTest.cs(37,4): error CS0616: 'TestCase' is not an attribute class
    MonoPathManglerTest.cs(37,4): error CS0616: 'TestCase' is not an attribute class
    MonoPathManglerTest.cs(38,4): error CS0616: 'TestCase' is not an attribute class
    MonoPathManglerTest.cs(39,4): error CS0616: 'TestCase' is not an attribute class
    XamarinSourcesPathManglerTest.cs(47,4): error CS0616: 'TestCase' is not an attribute class