### PR TITLE
[msbuild] Fixed embedding of provisioning profiles for tvOS

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/EmbedMobileProvisionTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/EmbedMobileProvisionTaskBase.cs
@@ -20,11 +20,32 @@ namespace Xamarin.iOS.Tasks
 		[Required]
 		public string ProvisioningProfile { get; set; }
 
+		[Required]
+		public string SdkPlatform { get; set; }
+
 		#endregion
 
 		public override bool Execute ()
 		{
-			var profile = MobileProvisionIndex.GetMobileProvision (MobileProvisionPlatform.iOS, ProvisioningProfile);
+			MobileProvisionPlatform platform;
+
+			switch (SdkPlatform) {
+			case "AppleTVSimulator":
+			case "AppleTVOS":
+				platform = MobileProvisionPlatform.tvOS;
+				break;
+			case "iPhoneSimulator":
+			case "WatchSimulator":
+			case "iPhoneOS":
+			case "WatchOS":
+				platform = MobileProvisionPlatform.iOS;
+				break;
+			default:
+				Log.LogError ("Unknown SDK platform: {0}", SdkPlatform);
+				return false;
+			}
+
+			var profile = MobileProvisionIndex.GetMobileProvision (platform, ProvisioningProfile);
 
 			if (profile == null) {
 				Log.LogError ("Could not locate the provisioning profile with a Name or UUID of {0}.", ProvisioningProfile);

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1466,6 +1466,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			Condition="'$(IsMacEnabled)' == 'true'"
 			AppBundleDir="$(AppBundleDir)"
 			ProvisioningProfile="$(_ProvisioningProfile)"
+			SdkPlatform="$(_SdkPlatform)"
 			>
 		</EmbedMobileProvision>
 	</Target>


### PR DESCRIPTION
Instead of hard-coding the platform as iOS for the EmbedMobileProvision
task, use the SdkPlatform to determine the appropriate platform to use
in the MobileProvisionIndex query.

This is a follow-up fix with near identical changes to the
CompileEntitlements fix for tvOS.