### PR TITLE
[xharness] Adjust colors a bit.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1098,9 +1098,13 @@ namespace xharness
 
 		string GetTestColor (IEnumerable<TestTask> tests)
 		{
-			if (tests.All ((v) => v.Succeeded))
-				return "green";
-			else if (tests.Any ((v) => v.Crashed))
+			if (!tests.Any ())
+				return "black";
+
+			var first = tests.First ();
+			if (tests.All ((v) => v.ExecutionResult == first.ExecutionResult))
+				return GetTestColor (first);
+			if (tests.Any ((v) => v.Crashed))
 				return "maroon";
 			else if (tests.Any ((v) => v.TimedOut))
 				return "purple";
@@ -1108,10 +1112,6 @@ namespace xharness
 				return "darkred";
 			else if (tests.Any ((v) => v.Failed))
 				return "red";
-			else if (tests.All ((v) => v.Building))
-				return "darkblue";
-			else if (tests.All ((v) => v.InProgress))
-				return "blue";
 			else if (tests.Any ((v) => v.NotStarted))
 				return "black";
 			else if (tests.Any ((v) => v.Ignored))


### PR DESCRIPTION
When determining the color for a collection of tests, first check if the
execution result is identical for all tests in the collection, in which case
just use the corresponding color for a single test.