### PR TITLE
[foundation] Add NSBundle.GetLocalizedString returning an NSString. Fixes #41292

### DIFF
--- a/src/Foundation/NSBundle.cs
+++ b/src/Foundation/NSBundle.cs
@@ -7,12 +7,27 @@ using XamCore.ObjCRuntime;
 
 namespace XamCore.Foundation {
 	public partial class NSBundle : NSObject {
+
+#if !XAMCORE_4_0
+		[Obsolete ("Use 'GetLocalizedString' instead.")]
+		public virtual string LocalizedString (string key, string value, string table)
+		{
+			return (string) GetLocalizedString ((NSString) key, (NSString) value, (NSString) table);
+		}
+
+		[Obsolete ("Use 'GetLocalizedString' instead.")]
 		public string LocalizedString (string key, string comment) {
 			return LocalizedString (key, "", "");
 		}
 
+		[Obsolete ("Use 'GetLocalizedString' instead.")]
 		public string LocalizedString (string key, string val, string table, string comment) {
 			return LocalizedString (key, val, table);
+		}
+#endif
+		public NSString GetLocalizedString (string key, string value = null, string table = null)
+		{
+			return GetLocalizedString ((NSString) key, (NSString) value, (NSString) table);
 		}
 
 		public string [] PathsForResources (string fileExtension) {

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -9206,7 +9206,7 @@ namespace XamCore.Foundation
 		string PathForResource (string name, [NullAllowed] string ofType, string subpath, string localizationName);
 
 		[Export ("localizedStringForKey:value:table:")]
-		string LocalizedString ([NullAllowed] string key, [NullAllowed] string value, [NullAllowed] string table);
+		NSString GetLocalizedString ([NullAllowed] NSString key, [NullAllowed] NSString value, [NullAllowed] NSString table);
 
 		[Export ("objectForInfoDictionaryKey:")]
 		NSObject ObjectForInfoDictionary (string key);

--- a/tests/monotouch-test/CoreFoundation/BundleTest.cs
+++ b/tests/monotouch-test/CoreFoundation/BundleTest.cs
@@ -163,7 +163,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		{
 			var main = CFBundle.GetMain ();
 			var localizations = CFBundle.GetLocalizations (main.Url);
-			Assert.AreEqual (0, localizations.Length);
+			Assert.AreEqual (1, localizations.Length);
 		}
 
 		[Test]

--- a/tests/monotouch-test/Foundation/BundleTest.cs
+++ b/tests/monotouch-test/Foundation/BundleTest.cs
@@ -136,7 +136,7 @@ namespace MonoTouchFixtures.Foundation {
 		{
 			string [] locz = main.PreferredLocalizations;
 			Assert.That (locz.Length, Is.GreaterThanOrEqualTo (1), "Length");
-			Assert.That (locz, Contains.Item ("en"), "en");
+			Assert.That (locz, Contains.Item ("Base"), "Base");
 		}
 
 		[Test]
@@ -148,6 +148,58 @@ namespace MonoTouchFixtures.Foundation {
 			// on iOS8 device this now ends with "/StoreKit/sandboxReceipt" 
 			// instead of "/StokeKit/receipt"
 			Assert.That (main.AppStoreReceiptUrl.AbsoluteString, Is.StringEnding ("eceipt"), "AppStoreReceiptUrl");
+		}
+
+#if !XAMCORE_4_0
+		[Test]
+		public void LocalizedString ()
+		{
+			// null values are fine
+			var l2 = main.LocalizedString (null, null);
+			Assert.That (l2.Length, Is.EqualTo (0), "null,null");
+			var l3 = main.LocalizedString (null, null, null);
+			Assert.That (l3.Length, Is.EqualTo (0), "null,null,null");
+			var l4 = main.LocalizedString (null, null, null, null);
+			Assert.That (l4.Length, Is.EqualTo (0), "null,null,null,null");
+
+			// NoKey does not exists so the same string is returned
+			l2 = main.LocalizedString ("NoKey", null);
+			Assert.That (l2, Is.EqualTo ("NoKey"), "string,null");
+			l3 = main.LocalizedString ("NoKey", null, null);
+			Assert.That (l3, Is.EqualTo ("NoKey"), "string,null,null");
+			l4 = main.LocalizedString ("NoKey", null, null, null);
+			Assert.That (l4, Is.EqualTo ("NoKey"), "string,null,null,null");
+
+			// TestKey exists (Localizable.strings) and returns TestValue
+			l2 = main.LocalizedString ("TestKey", null);
+			Assert.That (l2, Is.EqualTo ("TestValue"), "string,null-2");
+			l3 = main.LocalizedString ("TestKey", null, null);
+			Assert.That (l3, Is.EqualTo ("TestValue"), "string,null,null-2");
+			l4 = main.LocalizedString ("TestKey", null, null, null);
+			Assert.That (l4, Is.EqualTo ("TestValue"), "string,null,null,null-2");
+		}
+#endif
+
+		[Test]
+		public void GetLocalizedString ()
+		{
+			// null values are fine
+			using (var l = main.GetLocalizedString (null, null, null))
+				Assert.That (l.Length, Is.EqualTo (0), "null,null,null");
+
+			// NoKey does not exists so the same string is returned
+			using (var l = main.GetLocalizedString ("NoKey", null, null))
+				Assert.That (l.ToString (), Is.EqualTo ("NoKey"), "string,null,null");
+			using (var key = new NSString ("NoKey"))
+			using (var l = main.GetLocalizedString (key, null, null))
+				Assert.That (l.ToString (), Is.EqualTo ("NoKey"), "NString,null,null");
+
+			// TestKey exists (Localizable.strings) and returns TestValue
+			using (var l = main.GetLocalizedString ("TestKey", null, null))
+				Assert.That (l.ToString (), Is.EqualTo ("TestValue"), "string,null,null-2");
+			using (var key = new NSString ("TestKey"))
+			using (var l = main.GetLocalizedString (key, null, null))
+				Assert.That (l.ToString (), Is.EqualTo ("TestValue"), "NString,null,null-2");
 		}
 	}
 }

--- a/tests/monotouch-test/Resources/Base.lproj/Localizable.strings
+++ b/tests/monotouch-test/Resources/Base.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+﻿"TestKey"="TestValue";

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -273,6 +273,7 @@
     <Folder Include="CoreML\" />
     <Folder Include="PdfKit\" />
     <Folder Include="FileProvider\" />
+    <Folder Include="Resources\Base.lproj\" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="AudioToolbox\1.caf" />
@@ -308,6 +309,7 @@
     <BundleResource Include="Resources\xamarin2.png" />
     <BundleResource Include="xamvideotest.mp4" />
     <BundleResource Include="CoreImage\xamarinmonkey.heic" />
+    <BundleResource Include="Resources\Base.lproj\Localizable.strings" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Security\openssl_crt.der">

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -173,6 +173,7 @@
   <ItemGroup>
     <Folder Include="EmbeddedResources\" />
     <Folder Include="System.ServiceModel\" />
+	<Folder Include="..\monotouch-test\BundleResourceResources\Base.lproj\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\external\guiunit\src\framework\GuiUnit_xammac_mobile.csproj">
@@ -183,6 +184,9 @@
   <ItemGroup>
     <BundleResource Include="..\monotouch-test\CoreImage\xamarinmonkey.heic">
       <Link>CoreImage\xamarinmonkey.heic</Link>
+    </BundleResource>
+	<BundleResource Include="..\monotouch-test\Resources\Base.lproj\Localizable.strings" >
+      <Link>Base.lproj\Localizable.strings</Link>
     </BundleResource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />


### PR DESCRIPTION
The original, now obsoleted, `LocalizedString` API returned a .net
`string` which does not work in most cases.

Different versions of iOS seems to return different (public or internal)
subclasses of `NSString` that are understood by other API (like NSString
`localizedStringWithFormat:`) for further customization.

Our logic to convert NSString to string is correct but it cannot
recreate the custom, required subclass to continue the localization.

So the new API return an `NSString` publicly (which is actually a
subclass) that can do the required job.

Adding a test in monotouch-test is presently blocked by #3265 [2]

[1] https://bugzilla.xamarin.com/show_bug.cgi?id=41292
[2] https://github.com/xamarin/xamarin-macios/issues/3265