### PR TITLE
[xharness] Fixup paths in the Exclude attribute of Include nodes in csprojs as well.

### DIFF
--- a/tests/xharness/ProjectFileExtensions.cs
+++ b/tests/xharness/ProjectFileExtensions.cs
@@ -733,6 +733,7 @@ namespace xharness
 			{
 				new string [] { "None", "Include" },
 				new string [] { "Compile", "Include" },
+				new string [] { "Compile", "Exclude" },
 				new string [] { "ProjectReference", "Include" },
 				new string [] { "InterfaceDefinition", "Include" },
 				new string [] { "BundleResource", "Include" },


### PR DESCRIPTION
Fixes this rather puzzling build problem when building monotouch-test using xharness:

    obj/iPhoneSimulator/Debug-unified/Xamarin.iOS,Version=v1.0.AssemblyAttribute.cs(2,12): error CS0579: Duplicate 'global::System.Runtime.Versioning.TargetFrameworkAttribute' attribute

It happens only on Wrench (where it consistently fails), but it didn't happen
in the PR when this broke, nor could I reproduce it locally at first.

Initial investigation proved frustrating (searching for the file name
`Xamarin.iOS,Version=v1.0.AssemblyAttribute.cs` in the build log confirmed
that it was included multiple times on Wrench, but not locally), but after a
while I realized that there were multiple files with the same file name in the
build log:

     /Users/builder/data/lanes/1381/daf07005/source/xamarin-macios/tests/monotouch-test/obj/iPhone/Release64-unified/Xamarin.iOS,Version=v1.0.AssemblyAttribute.cs
     obj/iPhoneSimulator/Debug-unified/Xamarin.iOS,Version=v1.0.AssemblyAttribute.cs

One full path, and one relative, and one is obviously wrong.

Even more so once I realized that the full path's Platform/Configuration
(`iPhone/Release64-unified`) doesn't match the relative path's
Platform/Configuration (`iPhoneSimulator/Debug-unified`).

It's not even a test configuration we execute on Wrench, so how come the file
got there in the first place?

But it made it possible to reproduce locally: I just had to build monotouch-
test for device first, using tests.sln. Then I could reproduce the build error
when executing monotouch-test from xharness, since now I had the extraneous
file on my file system.

xharness will clone project files (to avoid parallel issues when building
multiple projects in parallel, all projects are built in their own
directories), and it turns out we didn't properly fixup all paths.

In particular the following:

    <Compile Include="**\*.cs" Exclude="obj\**">
      <Link>%(RecursiveDir)%(Filename).cs</Link>
    </Compile>

would be transformed into:

    <Compile Include="\Users\builder\data\lanes\1381\daf07005\source\xamarin-macios\tests\monotouch-test\**\*.cs" Exclude="obj\**">
      <Link>%(RecursiveDir)%(Filename).cs</Link>
    </Compile>

which meant that we'd include all files recursively in the monotouch-test
directory, excluding files from the project file's obj sub directory. And
since the project file was cloned, it would be in a different directory, and
thus not able to exclude files from the original monotouch-test/obj directory.

And with this knowledge the simple oneliner to fix it was trivial.

One mystery remained though: how was the extraneous
`Xamarin.iOS,Version=v1.0.AssemblyAttribute.cs` file generated when we don't
execute device tests on Wrench? After a while I remembered that the MTouch
tests build monotouch-test for device, even though they're not executed.

And this explains why the problem happens on wrench only: Jenkins didn't
execute the MTouch tests.