### PR TITLE
[tests] Confirm a device/sim support Metal before running MetalPerformanceShaders tests. Fixes #3237

### DIFF
--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramEqualizationTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramEqualizationTest.cs
@@ -26,9 +26,9 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 		public void Metal ()
 		{
 #if !MONOMAC
-			TestRuntime.AssertXcodeVersion (7,0);
+			TestRuntime.AssertXcodeVersion (7, 0);
 #else
-			TestRuntime.AssertXcodeVersion (9,0);
+			TestRuntime.AssertXcodeVersion (9, 0);
 #endif
 
 			device = MTLDevice.SystemDefault;

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramEqualizationTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramEqualizationTest.cs
@@ -20,17 +20,26 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 	[TestFixture]
 	public class MPSImageHistogramEqualizationTest
 	{
+		IMTLDevice device;
+
+		[TestFixtureSetUp]
+		public void Metal ()
+		{
+#if !MONOMAC
+			TestRuntime.AssertXcodeVersion (7,0);
+#else
+			TestRuntime.AssertXcodeVersion (9,0);
+#endif
+
+			device = MTLDevice.SystemDefault;
+			// some older hardware won't have a default
+			if (device == null)
+				Assert.Inconclusive ("Metal is not supported");
+		}
 
 		[Test]
 		public void Constructors ()
 		{
-#if !MONOMAC
-			TestRuntime.AssertDevice ();
-			TestRuntime.AssertXcodeVersion (7, 0);
-#else
-			TestRuntime.AssertXcodeVersion (9, 0);
-#endif
-
 			MPSImageHistogramInfo info = new MPSImageHistogramInfo ();
 			info.NumberOfHistogramEntries = 256;
 			using (var obj = new MPSImageHistogramEqualization (MTLDevice.SystemDefault, ref info)) {

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramSpecificationTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramSpecificationTest.cs
@@ -26,9 +26,9 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 		public void Metal ()
 		{
 #if !MONOMAC
-			TestRuntime.AssertXcodeVersion (7,0);
+			TestRuntime.AssertXcodeVersion (7, 0);
 #else
-			TestRuntime.AssertXcodeVersion (9,0);
+			TestRuntime.AssertXcodeVersion (9, 0);
 #endif
 
 			device = MTLDevice.SystemDefault;

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramSpecificationTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramSpecificationTest.cs
@@ -20,17 +20,26 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 	[TestFixture]
 	public class MPSImageHistogramSpecificationTest
 	{
+		IMTLDevice device;
+
+		[TestFixtureSetUp]
+		public void Metal ()
+		{
+#if !MONOMAC
+			TestRuntime.AssertXcodeVersion (7,0);
+#else
+			TestRuntime.AssertXcodeVersion (9,0);
+#endif
+
+			device = MTLDevice.SystemDefault;
+			// some older hardware won't have a default
+			if (device == null)
+				Assert.Inconclusive ("Metal is not supported");
+		}
 
 		[Test]
 		public void Constructors ()
 		{
-#if !MONOMAC
-			TestRuntime.AssertDevice ();
-			TestRuntime.AssertXcodeVersion (7, 0);
-#else
-			TestRuntime.AssertXcodeVersion (9, 0);
-#endif
-
 			MPSImageHistogramInfo info = new MPSImageHistogramInfo ();
 			info.NumberOfHistogramEntries = 256;
 			using (var obj = new MPSImageHistogramSpecification (MTLDevice.SystemDefault, ref info)) {

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramTest.cs
@@ -26,9 +26,9 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 		public void Metal ()
 		{
 #if !MONOMAC
-			TestRuntime.AssertXcodeVersion (7,0);
+			TestRuntime.AssertXcodeVersion (7, 0);
 #else
-			TestRuntime.AssertXcodeVersion (9,0);
+			TestRuntime.AssertXcodeVersion (9, 0);
 #endif
 
 			device = MTLDevice.SystemDefault;

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramTest.cs
@@ -20,17 +20,26 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 	[TestFixture]
 	public class MPSImageHistogramTest
 	{
+		IMTLDevice device;
+
+		[TestFixtureSetUp]
+		public void Metal ()
+		{
+#if !MONOMAC
+			TestRuntime.AssertXcodeVersion (7,0);
+#else
+			TestRuntime.AssertXcodeVersion (9,0);
+#endif
+
+			device = MTLDevice.SystemDefault;
+			// some older hardware won't have a default
+			if (device == null)
+				Assert.Inconclusive ("Metal is not supported");
+		}
 
 		[Test]
 		public void Constructors ()
 		{
-#if !MONOMAC
-			TestRuntime.AssertDevice ();
-			TestRuntime.AssertXcodeVersion (7, 0);
-#else
-			TestRuntime.AssertXcodeVersion (9, 0);
-#endif
-
 			MPSImageHistogramInfo info = new MPSImageHistogramInfo ();
 			info.NumberOfHistogramEntries = 256;
 			using (var obj = new MPSImageHistogram (MTLDevice.SystemDefault, ref info)) {


### PR DESCRIPTION
https://github.com/xamarin/xamarin-macios/issues/3237