### PR TITLE
[tests] Confirm a device/sim support Metal before running MetalPerformanceShaders tests. Fixes #3237 (#3268)

### DIFF
--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramEqualizationTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramEqualizationTest.cs
@@ -20,17 +20,26 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 	[TestFixture]
 	public class MPSImageHistogramEqualizationTest
 	{
+		IMTLDevice device;
 
-		[Test]
-		public void Constructors ()
+		[TestFixtureSetUp]
+		public void Metal ()
 		{
 #if !MONOMAC
-			TestRuntime.AssertDevice ();
 			TestRuntime.AssertXcodeVersion (7, 0);
 #else
 			TestRuntime.AssertXcodeVersion (9, 0);
 #endif
 
+			device = MTLDevice.SystemDefault;
+			// some older hardware won't have a default
+			if (device == null)
+				Assert.Inconclusive ("Metal is not supported");
+		}
+
+		[Test]
+		public void Constructors ()
+		{
 			MPSImageHistogramInfo info = new MPSImageHistogramInfo ();
 			info.NumberOfHistogramEntries = 256;
 			using (var obj = new MPSImageHistogramEqualization (MTLDevice.SystemDefault, ref info)) {

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramSpecificationTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramSpecificationTest.cs
@@ -20,17 +20,26 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 	[TestFixture]
 	public class MPSImageHistogramSpecificationTest
 	{
+		IMTLDevice device;
 
-		[Test]
-		public void Constructors ()
+		[TestFixtureSetUp]
+		public void Metal ()
 		{
 #if !MONOMAC
-			TestRuntime.AssertDevice ();
 			TestRuntime.AssertXcodeVersion (7, 0);
 #else
 			TestRuntime.AssertXcodeVersion (9, 0);
 #endif
 
+			device = MTLDevice.SystemDefault;
+			// some older hardware won't have a default
+			if (device == null)
+				Assert.Inconclusive ("Metal is not supported");
+		}
+
+		[Test]
+		public void Constructors ()
+		{
 			MPSImageHistogramInfo info = new MPSImageHistogramInfo ();
 			info.NumberOfHistogramEntries = 256;
 			using (var obj = new MPSImageHistogramSpecification (MTLDevice.SystemDefault, ref info)) {

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramTest.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageHistogramTest.cs
@@ -20,17 +20,26 @@ namespace MonoTouchFixtures.MetalPerformanceShaders
 	[TestFixture]
 	public class MPSImageHistogramTest
 	{
+		IMTLDevice device;
 
-		[Test]
-		public void Constructors ()
+		[TestFixtureSetUp]
+		public void Metal ()
 		{
 #if !MONOMAC
-			TestRuntime.AssertDevice ();
 			TestRuntime.AssertXcodeVersion (7, 0);
 #else
 			TestRuntime.AssertXcodeVersion (9, 0);
 #endif
 
+			device = MTLDevice.SystemDefault;
+			// some older hardware won't have a default
+			if (device == null)
+				Assert.Inconclusive ("Metal is not supported");
+		}
+
+		[Test]
+		public void Constructors ()
+		{
 			MPSImageHistogramInfo info = new MPSImageHistogramInfo ();
 			info.NumberOfHistogramEntries = 256;
 			using (var obj = new MPSImageHistogram (MTLDevice.SystemDefault, ref info)) {


### PR DESCRIPTION
https://github.com/xamarin/xamarin-macios/issues/3237

Backport of https://github.com/xamarin/xamarin-macios/pull/3268 to 15.6