### PR TITLE
[msbuild] Fix Makefile warning by removing duplicate target.

### DIFF
--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -41,7 +41,6 @@ IOS_DIRECTORIES =                                                               
 	$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/msbuild/iOS                                                           \
 	$(IOS_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild-frameworks/Xamarin.iOS/v1.0/RedistList \
 	$(IOS_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild/Xamarin                                \
-	$(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/msbuild/iOS                \
 
 IOS_2_1_SYMLINKS = \
 	$(foreach target,$(IOS_BINDING_TARGETS)       ,$(IOS_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/$(notdir $(target)))       \


### PR DESCRIPTION
Fixes this warning:

```
Makefile:317: target `/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/msbuild/iOS' given more than once in the same rule.
```

because the same directory was listed twice.