### PR TITLE
[linker] Implement a generic method of storing attributes the linker removes.

### DIFF
--- a/tools/common/DerivedLinkContext.cs
+++ b/tools/common/DerivedLinkContext.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 
 using Mono.Cecil;
 using Mono.Linker;
+using Mono.Collections.Generic;
 
 using XamCore.Registrar;
 using Xamarin.Bundler;
@@ -64,6 +65,68 @@ namespace Xamarin.Tuner
 			: base (pipeline, resolver)
 		{
 			UserAction = AssemblyAction.Link;
+		}
+
+		public Dictionary<IMetadataTokenProvider, object> GetAllCustomAttributes (string storage_name)
+		{
+			return Annotations?.GetCustomAnnotations (storage_name);
+		}
+
+		public List<ICustomAttribute> GetCustomAttributes (ICustomAttributeProvider provider, string storage_name)
+		{
+			var annotations = Annotations?.GetCustomAnnotations (storage_name);
+			object storage = null;
+			if (annotations?.TryGetValue (provider, out storage) != true)
+				return null;
+			return (List<ICustomAttribute>) storage;
+		}
+
+		// Stores custom attributes in the link context, so that the attribute can be retrieved and
+		// inspected even if it's linked away.
+		public void StoreCustomAttribute (ICustomAttributeProvider provider, CustomAttribute attribute, string storage_name)
+		{
+			var dict = Annotations.GetCustomAnnotations (storage_name);
+			List<ICustomAttribute> attribs;
+			object attribObjects;
+			if (!dict.TryGetValue (provider, out attribObjects)) {
+				attribs = new List<ICustomAttribute> ();
+				dict [provider] = attribs;
+			} else {
+				attribs = (List<ICustomAttribute>) attribObjects;
+			}
+			// Make sure the attribute is resolved, since after removing the attribute
+			// it won't be able to do it. The 'CustomAttribute.Resolve' method is private, but fetching
+			// any property will cause it to be called.
+			// We also need to store the constructor's DeclaringType separately, because it may
+			// be nulled out from the constructor by the linker if the attribute type itself is linked away.
+			var dummy = attribute.HasConstructorArguments;
+			attribs.Add (new AttributeStorage { Attribute = attribute, AttributeType = attribute.Constructor.DeclaringType });
+		}
+
+		public List<ICustomAttribute> GetCustomAttributes (ICustomAttributeProvider provider, string @namespace, string name)
+		{
+			// The equivalent StoreCustomAttribute method below ignores the namespace (it's not needed so far since all attribute names we care about are unique),
+			// so we need to retrieve the attributes the same way (using the name only).
+			return GetCustomAttributes (provider, name);
+		}
+
+		public void StoreCustomAttribute (ICustomAttributeProvider provider, CustomAttribute attribute)
+		{
+			StoreCustomAttribute (provider, attribute, attribute.AttributeType.Name);
+		}
+
+		class AttributeStorage : ICustomAttribute
+		{
+			public CustomAttribute Attribute;
+			public TypeReference AttributeType { get; set; }
+
+			public bool HasFields => Attribute.HasFields;
+			public bool HasProperties => Attribute.HasProperties;
+			public bool HasConstructorArguments => Attribute.HasConstructorArguments;
+
+			public Collection<CustomAttributeNamedArgument> Fields => Attribute.Fields;
+			public Collection<CustomAttributeNamedArgument> Properties => Attribute.Properties;
+			public Collection<CustomAttributeArgument> ConstructorArguments => Attribute.ConstructorArguments;
 		}
 	}
 }

--- a/tools/common/DerivedLinkContext.cs
+++ b/tools/common/DerivedLinkContext.cs
@@ -24,7 +24,6 @@ namespace Xamarin.Tuner
 		//   null = don't know, must check at runtime (can't inline)
 		//   true/false = corresponding constant value
 		Dictionary<TypeDefinition, bool?> isdirectbinding_value;
-		HashSet<MethodDefinition> generated_code;
 
 		public HashSet<TypeDefinition> CachedIsNSObject {
 			get { return cached_isnsobject; }
@@ -34,11 +33,6 @@ namespace Xamarin.Tuner
 		public Dictionary<TypeDefinition, bool?> IsDirectBindingValue {
 			get { return isdirectbinding_value; }
 			set { isdirectbinding_value = value; }
-		}
-
-		public HashSet<MethodDefinition> GeneratedCode {
-			get { return generated_code; }
-			set { generated_code = value; }
 		}
 
 		public IList<ICustomAttributeProvider> DataContract {

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -528,7 +528,7 @@ namespace XamCore.Registrar {
 		readonly Version MacOSTenTwelveVersion = new Version (10,12);
 #endif
 
-		public Mono.Linker.LinkContext LinkContext {
+		public Xamarin.Tuner.DerivedLinkContext LinkContext {
 			get {
 				return Target?.LinkContext;
 			}
@@ -537,7 +537,7 @@ namespace XamCore.Registrar {
 		Dictionary<IMetadataTokenProvider, object> AvailabilityAnnotations {
 			get {
 				if (availability_annotations == null)
-					availability_annotations = LinkContext?.Annotations?.GetCustomAnnotations ("Availability");
+					availability_annotations = LinkContext?.GetAllCustomAttributes ("Availability");
 				return availability_annotations;
 			}
 		}
@@ -1354,12 +1354,7 @@ namespace XamCore.Registrar {
 			}
 		}
 
-		void CollectAvailabilityAttributes (IEnumerable<CustomAttribute> attributes, ref List<AvailabilityBaseAttribute> list)
-		{
-			CollectAvailabilityAttributes (attributes.Select ((v) => new Tuple<CustomAttribute, TypeReference> (v, v.Constructor.DeclaringType)), ref list);
-		}
-
-		void CollectAvailabilityAttributes (IEnumerable<Tuple<CustomAttribute, TypeReference>> attributes, ref List<AvailabilityBaseAttribute> list)
+		void CollectAvailabilityAttributes (IEnumerable<ICustomAttribute> attributes, ref List<AvailabilityBaseAttribute> list)
 		{
 			PlatformName currentPlatform;
 #if MTOUCH
@@ -1380,9 +1375,8 @@ namespace XamCore.Registrar {
 			currentPlatform = global::XamCore.ObjCRuntime.PlatformName.MacOSX;
 #endif
 
-			foreach (var tuple in attributes) {
-				var ca = tuple.Item1;
-				var caType = tuple.Item2;
+			foreach (var ca in attributes) {
+				var caType = ca.AttributeType;
 				if (caType.Namespace != ObjCRuntime)
 					continue;
 				
@@ -1511,7 +1505,7 @@ namespace XamCore.Registrar {
 			if (AvailabilityAnnotations != null) {
 				object attribObjects;
 				if (AvailabilityAnnotations.TryGetValue (td, out attribObjects))
-					CollectAvailabilityAttributes ((List<Tuple<CustomAttribute, TypeReference>>) attribObjects, ref rv);
+					CollectAvailabilityAttributes ((IEnumerable<ICustomAttribute>) attribObjects, ref rv);
 			}
 
 			return rv;

--- a/tools/linker/CoreRemoveAttributes.cs
+++ b/tools/linker/CoreRemoveAttributes.cs
@@ -2,11 +2,19 @@ using System;
 using System.Collections.Generic;
 using Mono.Cecil;
 
+using Xamarin.Tuner;
+
 namespace Xamarin.Linker {
 
 	// this can be used (directly) with Xamarin.Mac and as the base of Xamarin.iOS step
 	public class CoreRemoveAttributes : MobileRemoveAttributes {
 		
+		protected DerivedLinkContext LinkContext {
+			get {
+				return (DerivedLinkContext) base.context;
+			}
+		}
+
 		protected override bool IsRemovedAttribute (CustomAttribute attribute)
 		{
 			// note: this also avoid calling FullName (which allocates a string)
@@ -50,22 +58,7 @@ namespace Xamarin.Linker {
 				case "AvailabilityBaseAttribute":
 				case "DeprecatedAttribute":
 				case "IntroducedAttribute":
-					var dict = context.Annotations.GetCustomAnnotations ("Availability");
-					List<Tuple<CustomAttribute,TypeReference>> attribs;
-					object attribObjects;
-					if (!dict.TryGetValue (provider, out attribObjects)) {
-						attribs = new List<Tuple<CustomAttribute, TypeReference>> ();
-						dict [provider] = attribs;
-					} else {
-						attribs = (List<Tuple<CustomAttribute, TypeReference>>) attribObjects;
-					}
-					// Make sure the attribute is resolved, since after removing the attribute
-					// it won't be able to do it. The 'CustomAttribute.Resolve' method is private, but fetching
-					// any property will cause it to be called.
-					// We also need to store the constructor's DeclaringType separately, because it may
-					// be nulled out from the constructor by the linker if the attribute type itself is linked away.
-					var dummy = attribute.HasConstructorArguments;
-					attribs.Add (new Tuple<CustomAttribute, TypeReference> (attribute, attribute.Constructor.DeclaringType));
+					LinkContext.StoreCustomAttribute (provider, attribute, "Availability");
 					break;
 				}
 			}

--- a/tools/linker/MobileExtensions.cs
+++ b/tools/linker/MobileExtensions.cs
@@ -10,6 +10,15 @@ namespace Xamarin.Linker {
 
 	public static class MobileExtensions {
 
+		// This method will look in any stored attributes in the link context as well as the provider itself.
+		public static bool HasCustomAttribute (this ICustomAttributeProvider provider, DerivedLinkContext context, string @namespace, string name)
+		{
+			if (provider?.HasCustomAttribute (@namespace, name) == true)
+				return true;
+			
+			return context?.GetCustomAttributes (provider, @namespace, name)?.Count > 0;
+		}
+
 		public static bool HasCustomAttribute (this ICustomAttributeProvider provider, string @namespace, string name)
 		{
 			if (provider == null || !provider.HasCustomAttributes)
@@ -23,9 +32,9 @@ namespace Xamarin.Linker {
 			return false;
 		}
 
-		static bool HasGeneratedCodeAttribute (ICustomAttributeProvider provider)
+		static bool HasGeneratedCodeAttribute (ICustomAttributeProvider provider, DerivedLinkContext context)
 		{
-			return provider.HasCustomAttribute ("System.Runtime.CompilerServices", "CompilerGeneratedAttribute");
+			return provider.HasCustomAttribute (context, "System.Runtime.CompilerServices", "CompilerGeneratedAttribute");
 		}
 
 		static PropertyDefinition GetPropertyByAccessor (MethodDefinition method)
@@ -39,15 +48,12 @@ namespace Xamarin.Linker {
 
 		public static bool IsGeneratedCode (this MethodDefinition self, DerivedLinkContext link_context)
 		{
-			if (link_context.GeneratedCode != null)
-				return link_context.GeneratedCode.Contains (self);
-
 			// check the property too
 			if (self.IsGetter || self.IsSetter) {
-				if (HasGeneratedCodeAttribute (GetPropertyByAccessor (self)))
+				if (HasGeneratedCodeAttribute (GetPropertyByAccessor (self), link_context))
 					return true;
 			}
-			return HasGeneratedCodeAttribute (self);
+			return HasGeneratedCodeAttribute (self, link_context);
 		}
 	}
 }

--- a/tools/linker/MonoTouch.Tuner/MonoTouchTypeMap.cs
+++ b/tools/linker/MonoTouch.Tuner/MonoTouchTypeMap.cs
@@ -24,7 +24,6 @@ namespace MonoTouch.Tuner {
 	public class MonoTouchTypeMapStep : TypeMapStep {
 		HashSet<TypeDefinition> cached_isnsobject = new HashSet<TypeDefinition> ();
 		Dictionary<TypeDefinition, bool?> isdirectbinding_value = new Dictionary<TypeDefinition, bool?> ();
-		HashSet<MethodDefinition> generated_code = new HashSet<MethodDefinition> ();
 
 		DerivedLinkContext LinkContext {
 			get {
@@ -38,22 +37,12 @@ namespace MonoTouch.Tuner {
 
 			LinkContext.CachedIsNSObject = cached_isnsobject;
 			LinkContext.IsDirectBindingValue = isdirectbinding_value;
-			LinkContext.GeneratedCode = generated_code;
 		}
 
 		protected override void MapType (TypeDefinition type)
 		{
 			base.MapType (type);
 
-			// we'll remove [GeneratedCode] in RemoveAttribute but we need this information later
-			// when processing Dispose methods in MonoTouchMarkStep
-			if (type.HasMethods) {
-				foreach (MethodDefinition m in type.Methods) {
-					if (m.IsGeneratedCode (LinkContext))
-						generated_code.Add (m);
-				}
-			}
-			
 			// additional checks for NSObject to check if the type is a *generated* bindings
 			// bonus: we cache, for every type, whether or not it inherits from NSObject (very useful later)
 			if (!IsNSObject (type))

--- a/tools/linker/MonoTouch.Tuner/RemoveAttributes.cs
+++ b/tools/linker/MonoTouch.Tuner/RemoveAttributes.cs
@@ -153,5 +153,21 @@ namespace MonoTouch.Tuner {
 #endif
 			return false;
 		}
+
+		protected override void WillRemoveAttribute (ICustomAttributeProvider provider, CustomAttribute attribute)
+		{
+			var attr_type = attribute.AttributeType;
+			switch (attr_type.Namespace) {
+			case "System.Runtime.CompilerServices":
+				switch (attr_type.Name) {
+				case "CompilerGeneratedAttribute":
+					LinkContext.StoreCustomAttribute (provider, attribute);
+					break;
+				}
+				break;
+			}
+
+			base.WillRemoveAttribute (provider, attribute);
+		}
 	}
 }


### PR DESCRIPTION
[linker] Implement a generic method of storing attributes the linker removes.

Implement a generic method of storing attributes the linker removes, so
that those attributes can be accessed after the linker has linked them away.

Also change existing code to take advantage of the new API (for
[CompilerGenerated] and several availability attributes).

There doesn't seem to be any measurable performance difference when building
the link all tests.