### PR TITLE
[foundation] Fix typo in INSFilePresenter.P[r]esentedItemOperationQueue. Fixes #3272

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -12086,7 +12086,11 @@ namespace XamCore.Foundation
 		[Abstract]
 #endif
 		[Export ("presentedItemOperationQueue", ArgumentSemantic.Retain)]
+#if XAMCORE_4_0
+		NSOperationQueue PresentedItemOperationQueue { get; }
+#else
 		NSOperationQueue PesentedItemOperationQueue { get; }
+#endif
 
 #if DOUBLE_BLOCKS
 		[Export ("relinquishPresentedItemToReader:")]


### PR DESCRIPTION
Sadly that was not enough to trigger the typo detector test. It's also
part of a protocol, which means a .net interface so it cannot be fixed
without a breaking change. As such the fix is under `XAMCORE_4_0`

Fixes https://github.com/xamarin/xamarin-macios/issues/3272