### PR TITLE
[tests] Package linker tests too for the packaged XM tests.

### DIFF
--- a/tests/package-mac-tests.sh
+++ b/tests/package-mac-tests.sh
@@ -9,9 +9,9 @@ mkdir -p $DIR
 
 make build-mac
 
-for app in */bin/x86/*/*.app; do
-	mkdir -p $DIR/tests/$app
-	cp -R $app $DIR/tests/$app/..
+for app in */bin/x86/*/*.app linker-mac/*/bin/x86/*/*.app; do
+	mkdir -p "$DIR/tests/$app"
+	cp -R "$app" "$DIR/tests/$app/.."
 done
 
 cp -p Makefile-mac.inc $DIR/tests


### PR DESCRIPTION
Make sure to package the linker tests when packaging XM tests (this broke
recently because the dontlink tests were moved).

Fixes this problem when running the packaged tests:

    make[2]: linker-mac/dont link/bin/x86/Debug/dont link.app/Contents/MacOS/dont link: No such file or directory
    make[2]: *** [exec-mac-classic-dont link] Error 1
    make[2]: linker-mac/dont link/bin/x86/Debug-unified/dont link.app/Contents/MacOS/dont link: No such file or directory
    make[2]: *** [exec-mac-unified-dont link] Error 1
    make[2]: linker-mac/dont link/bin/x86/Debug-unifiedXM45/dont link.app/Contents/MacOS/dont link: No such file or directory
    make[2]: *** [exec-mac-unifiedXM45-dont link] Error 1
    make[2]: linker-mac/dont link/bin/x86/Debug-unified-32/dont link.app/Contents/MacOS/dont link: No such file or directory
    make[2]: *** [exec-mac-unified32-dont link] Error 1
    make[2]: linker-mac/dont link/bin/x86/Debug-unifiedXM45-32/dont link.app/Contents/MacOS/dont link: No such file or directory
    make[2]: *** [exec-mac-unifiedXM4532-dont link] Error 1
    exec-mac-classic-dont\ link failed
    exec-mac-unified-dont\ link failed
    exec-mac-unifiedXM45-dont\ link failed
    exec-mac-unified32-dont\ link failed
    exec-mac-unifiedXM4532-dont\ link failed
    make[1]: *** [exec-mac-dontlink] Error 1