### PR TITLE
[tests] Fix apitest to ignore CoreSpotlight on 32-bit since it's 64-bit only.

### DIFF
--- a/tests/apitest/src/EveryFrameworkSmokeTest.cs
+++ b/tests/apitest/src/EveryFrameworkSmokeTest.cs
@@ -74,6 +74,7 @@ namespace Xamarin.Mac.Tests
 				case "VisionLibrary":
 				case "CoreMLLibrary":
 				case "ExternalAccessoryLibrary":
+				case "CoreSpotlightLibrary":
 					return LoadStatus.Acceptable;
 				}
 			}


### PR DESCRIPTION
Fixes this test failure on High Sierra:

    Xamarin.Mac.Tests.EveryFrameworkSmokeTests.ExpectedLibrariesAreLoaded: CoreSpotlightLibrary (/System/Library/Frameworks/CoreSpotlight.framework/CoreSpotlight) failed to load but this was not expected