### PR TITLE
[registrar] Don't skip models when registering assemblies.

### DIFF
--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -2292,11 +2292,6 @@ namespace XamCore.Registrar {
 				lock (this.types) {
 					foreach (TType type in types) {
 						//Trace (" Checking {0}", GetTypeFullName (type));
-						if (HasModelAttribute (type)) {
-							Trace ("{0} is a model: not registering it", GetTypeFullName (type));
-							continue;
-						}
-
 						RegisterTypeUnsafe (type, ref exceptions);
 					}
 				}


### PR DESCRIPTION
Unfortunately models are not abstract, and users can create instances of them.
This means that the type must be registered - and that's exactly what happens
when the app tries to create such an instance: the dynamic registrar will
register it.

However, previously we didn't register the type when registering all the types
in an assembly, the type would only be registered when it was needed. This
prevents the static registrar from registering it, and it always ends up using
the dynamic registrar, which means the dynamic registrar will always be
required.

By not excluding models when registering all types in an assembly these types
are also included in the generated code from the static registrar, and we're
one step closer to being able to remove the dynamic registrar when using the
static registrar.