### PR TITLE
[tests] Allow 11 frameworks in linked XM apps. Fixes maccore GH #615.

### DIFF
--- a/tests/mmptest/src/FrameworkLinksTests.cs
+++ b/tests/mmptest/src/FrameworkLinksTests.cs
@@ -115,8 +115,8 @@ namespace Xamarin.MMP.Tests
 			AssertAppKitLinkage (status);
 
 			// We expect a few number of entires, which should not grow much over time
-			// Today - Foundation, AppKit, Security, QuartzCore, CoreFoundation, CFNetwork, Carbon, CoreServices
-			Assert.Less (status.Count, 10, "Found more framework entries in clang invocation then expected - {0}\n{1}", status.Count, string.Join (" ", clangParts));
+			// Today - Foundation, AppKit, Security, QuartzCore, CoreFoundation, CFNetwork, Carbon, CoreServices, CoreData, Quartz, CloudKit
+			Assert.Less (status.Count, 11, "Found more framework entries in clang invocation then expected - {0}\n{1}", string.Join (" ", status.Select ((v) => v.Key)), string.Join (" ", clangParts));
 
 			AssertFrameworkMinOSRespected (status);
 		}


### PR DESCRIPTION
Fixes this test failure:

    1) Failed : Xamarin.MMP.Tests.MMPTests.UnifiedWithLinking_ShouldHaveFewFrameworkClangLines
      Found more framework entries in clang invocation then expected - Foundation AppKit QuartzCore CoreData Quartz CoreFoundation CoreServices Security Carbon CloudKit
    		xcrun -sdk macosx clang -mmacosx-version-min=10.7 -arch x86_64 -fobjc-runtime=macosx -Wno-unguarded-availability-new -ObjC -framework Foundation -framework AppKit -framework QuartzCore -framework CoreData -framework Quartz -framework CoreFoundation -framework CoreServices -framework Security -framework Carbon -weak_framework CloudKit -u _xamarin_timezone_get_data -u _xamarin_get_block_descriptor /work/maccore/master/xamarin-macios/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/libxammac.a -o /work/maccore/master/xamarin-macios/tests/mmptest/bin/Debug/tmp-test-dir/Xamarin.MMP.Tests.MMPTests.RunMMPTest/bin/Debug/UnifiedExample.app/Contents/MacOS/UnifiedExample -D_THREAD_SAFE -I/work/maccore/master/xamarin-macios/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/pkgconfig/../../include/mono-2.0   /work/maccore/master/xamarin-macios/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/pkgconfig/../../lib/libmonosgen-2.0.a -liconv -x objective-c++ -I/work/maccore/master/xamarin-macios/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/include /work/maccore/master/xamarin-macios/tests/mmptest/bin/Debug/tmp-test-dir/Xamarin.MMP.Tests.MMPTests.RunMMPTest/obj/Debug/mmp-cache/registrar.m -fno-caret-diagnostics -fno-diagnostics-fixit-info -isysroot /Applications/Xcode92.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk /work/maccore/master/xamarin-macios/tests/mmptest/bin/Debug/tmp-test-dir/Xamarin.MMP.Tests.MMPTests.RunMMPTest/obj/Debug/mmp-cache/main.m
      Expected: less than 10
      But was:  10

This regressed in 4da8016db4330bde0a09b4a5453a26427ca6685d, where new API is
partially unremovable by the linker, and as such causes XM to link with more
frameworks at build time.

This is expected, so change the test to accept more frameworks (11).

Fixes https://github.com/xamarin/maccore/issues/615.