### PR TITLE
[xharness] Ask mono to not attach gdb/ldb when XM tests crash.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -2782,6 +2782,7 @@ function oninitialload ()
 					proc.StartInfo.EnvironmentVariables ["MONO_DEBUG"] = "no-gdb-backtrace";
 					Jenkins.MainLog.WriteLine ("Executing {0} ({1})", TestName, Mode);
 					var log = Logs.Create ($"execute-{Platform}-{Timestamp}.txt", "Execution log");
+					log.Timestamp = true;
 					log.WriteLine ("{0} {1}", proc.StartInfo.FileName, proc.StartInfo.Arguments);
 					if (!Harness.DryRun) {
 						ExecutionResult = TestExecutingResult.Running;


### PR DESCRIPTION
Attaching gdb/ldb usually hangs, thus causing the test run to time out instead
of finishing early (due to the crash).

Also bump the timeout for finding crash reports to 60 seconds when the tests
crash, since macOS can be quite slow to create the crash report.