### PR TITLE
[tests] Skip High Sierra image filters in Classic tests. Fixes #622.

### DIFF
--- a/tests/introspection/Mac/MacCoreImageFiltersTest.cs
+++ b/tests/introspection/Mac/MacCoreImageFiltersTest.cs
@@ -40,6 +40,26 @@ namespace Introspection {
 				return false;
 			case "CICMYKHalftone": // Renamed as CICmykHalftone
 				return true;
+#if !__UNIFIED__
+			case "CIAreaMinMaxRed": 
+			case "CIAttributedTextImageGenerator":
+			case "CIBarcodeGenerator":
+			case "CIBicubicScaleTransform":
+			case "CIBlendWithBlueMask":
+			case "CIBlendWithRedMask":
+			case "CIBokehBlur":
+			case "CIColorCubesMixedWithMask":
+			case "CIColorCurves":
+			case "CIDepthBlurEffect":
+			case "CIDepthToDisparity":
+			case "CIDisparityToDepth":
+			case "CILabDeltaE":
+			case "CIMorphologyGradient":
+			case "CIMorphologyMaximum":
+			case "CIMorphologyMinimum":
+			case "CITextImageGenerator":
+				return true;
+#endif
 			default:
 				return base.Skip (nativeName);
 			}


### PR DESCRIPTION
Skip High Sierra image filters in Classic introspection tests, since the
Classic bindings won't be updated.

https://github.com/xamarin/maccore/issues/622