### PR TITLE
[registrar] Merge the SharedStatic class into the StaticRegistrar class.

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -204,8 +204,9 @@ namespace XamCore.Registrar {
 		}
 	}
 
-	static class SharedStatic {
-		public static bool IsPlatformType (this TypeReference type, string @namespace, string name)
+	class StaticRegistrar : Registrar
+	{
+		public static bool IsPlatformType (TypeReference type, string @namespace, string name)
 		{
 			if (Registrar.IsDualBuild) {
 				return type.Is (@namespace, name);
@@ -396,7 +397,7 @@ namespace XamCore.Registrar {
 					if (impl.Name != ifaceMethod.Name)
 						continue;
 
-					if (!SharedStatic.MethodMatch (impl, ifaceMethod))
+					if (!MethodMatch (impl, ifaceMethod))
 						continue;
 
 					List<MethodDefinition> list;
@@ -514,9 +515,7 @@ namespace XamCore.Registrar {
 
 			return tr.Is (Registrar.ObjCRuntime, Registrar.StringConstants.INativeObject);
 		}
-	}
 
-	class StaticRegistrar : Registrar{
 		public Target Target { get; private set; }
 		public bool IsSingleAssembly { get { return !string.IsNullOrEmpty (single_assembly); } }
 
@@ -660,13 +659,13 @@ namespace XamCore.Registrar {
 		{
 			CustomAttribute attrib;
 			method = GetBaseMethodInTypeHierarchy (method);
-			return SharedStatic.TryGetAttributeImpl (method.MethodReturnType, ObjCRuntime, StringConstants.ReleaseAttribute, out attrib);
+			return TryGetAttributeImpl (method.MethodReturnType, ObjCRuntime, StringConstants.ReleaseAttribute, out attrib);
 		}
 
 		protected override bool HasThisAttribute (MethodDefinition method)
 		{
 			CustomAttribute attrib;
-			return SharedStatic.TryGetAttributeImpl (method, "System.Runtime.CompilerServices", "ExtensionAttribute", out attrib);
+			return TryGetAttributeImpl (method, "System.Runtime.CompilerServices", "ExtensionAttribute", out attrib);
 		}
 
 #if MTOUCH
@@ -930,7 +929,7 @@ namespace XamCore.Registrar {
 		protected override bool IsDelegate (TypeReference tr)
 		{
 			var type = tr.Resolve ();
-			return SharedStatic.IsDelegate (type);
+			return IsDelegate (type);
 		}
 
 		protected override bool IsValueType (TypeReference type)
@@ -941,7 +940,7 @@ namespace XamCore.Registrar {
 
 		bool IsNativeEnum (TypeDefinition td)
 		{
-			return IsDualBuild && SharedStatic.HasAttribute (td, ObjCRuntime, StringConstants.NativeAttribute);
+			return IsDualBuild && HasAttribute (td, ObjCRuntime, StringConstants.NativeAttribute);
 		}
 
 		protected override bool IsNullable (TypeReference type)
@@ -1014,7 +1013,7 @@ namespace XamCore.Registrar {
 			if (a == null ^ b == null)
 				return false;
 			
-			return SharedStatic.TypeMatch (a, b);
+			return TypeMatch (a, b);
 		}
 
 		protected override bool VerifyIsConstrainedToNSObject (TypeReference type, out TypeReference constrained_type)
@@ -1081,7 +1080,7 @@ namespace XamCore.Registrar {
 
 		protected override bool IsINativeObject (TypeReference tr)
 		{
-			return SharedStatic.IsNativeObject (tr);
+			return IsNativeObject (tr);
 		}
 
 		protected override TypeReference GetBaseType (TypeReference tr)
@@ -1110,7 +1109,7 @@ namespace XamCore.Registrar {
 		protected override TypeReference GetEnumUnderlyingType (TypeReference tr)
 		{
 			var type = tr.Resolve ();
-			return SharedStatic.GetEnumUnderlyingType (type);
+			return GetEnumUnderlyingType (type);
 		}
 
 		protected override TypeReference[] GetParameters (MethodDefinition method)
@@ -1150,7 +1149,7 @@ namespace XamCore.Registrar {
 		protected override bool TryGetAttribute (TypeReference type, string attributeNamespace, string attributeType, out object attribute)
 		{
 			CustomAttribute attrib;
-			bool res = SharedStatic.TryGetAttributeImpl (type.Resolve (), attributeNamespace, attributeType, out attrib);
+			bool res = TryGetAttributeImpl (type.Resolve (), attributeNamespace, attributeType, out attrib);
 			attribute = attrib;
 			return res;
 		}
@@ -1160,7 +1159,7 @@ namespace XamCore.Registrar {
 			CustomAttribute attrib;
 			RegisterAttribute rv = null;
 
-			if (!SharedStatic.TryGetAttributeImpl (type.Resolve (), Foundation, StringConstants.RegisterAttribute, out attrib))
+			if (!TryGetAttributeImpl (type.Resolve (), Foundation, StringConstants.RegisterAttribute, out attrib))
 				return null;
 
 			if (!attrib.HasConstructorArguments) {
@@ -1207,7 +1206,7 @@ namespace XamCore.Registrar {
 			CustomAttribute attrib;
 			string name = null;
 
-			if (!SharedStatic.TryGetAttributeImpl (type.Resolve (), ObjCRuntime, StringConstants.CategoryAttribute, out attrib))
+			if (!TryGetAttributeImpl (type.Resolve (), ObjCRuntime, StringConstants.CategoryAttribute, out attrib))
 				return null;
 
 			if (!attrib.HasConstructorArguments)
@@ -1245,7 +1244,7 @@ namespace XamCore.Registrar {
 		{
 			CustomAttribute attrib;
 
-			if (!SharedStatic.TryGetAttributeImpl (type.Resolve (), Foundation, StringConstants.ProtocolAttribute, out attrib))
+			if (!TryGetAttributeImpl (type.Resolve (), Foundation, StringConstants.ProtocolAttribute, out attrib))
 				return null;
 
 			if (!attrib.HasProperties)
@@ -1518,14 +1517,14 @@ namespace XamCore.Registrar {
 
 		protected override Dictionary<MethodDefinition, List<MethodDefinition>> PrepareMethodMapping (TypeReference type)
 		{
-			return SharedStatic.PrepareInterfaceMethodMapping (type);
+			return PrepareInterfaceMethodMapping (type);
 		}
 
 		protected override TypeReference GetProtocolAttributeWrapperType (TypeReference type)
 		{
 			CustomAttribute attrib;
 
-			if (!SharedStatic.TryGetAttributeImpl (type.Resolve (), Foundation, StringConstants.ProtocolAttribute, out attrib))
+			if (!TryGetAttributeImpl (type.Resolve (), Foundation, StringConstants.ProtocolAttribute, out attrib))
 				return null;
 
 			if (attrib.HasProperties) {
@@ -1547,7 +1546,7 @@ namespace XamCore.Registrar {
 
 			property = GetBasePropertyInTypeHierarchy (property);
 
-			if (!SharedStatic.TryGetAttributeImpl (property, ObjCRuntime, "BindAsAttribute", out attrib))
+			if (!TryGetAttributeImpl (property, ObjCRuntime, "BindAsAttribute", out attrib))
 				return null;
 
 			return CreateBindAsAttribute (attrib, property);
@@ -1562,7 +1561,7 @@ namespace XamCore.Registrar {
 
 			method = GetBaseMethodInTypeHierarchy (method);
 
-			if (!SharedStatic.TryGetAttributeImpl (parameter_index == -1 ? (ICustomAttributeProvider) method.MethodReturnType : method.Parameters [parameter_index], ObjCRuntime, "BindAsAttribute", out attrib))
+			if (!TryGetAttributeImpl (parameter_index == -1 ? (ICustomAttributeProvider) method.MethodReturnType : method.Parameters [parameter_index], ObjCRuntime, "BindAsAttribute", out attrib))
 				return null;
 
 			return CreateBindAsAttribute (attrib, method);
@@ -1606,7 +1605,7 @@ namespace XamCore.Registrar {
 		{
 			CustomAttribute attrib;
 
-			if (!SharedStatic.TryGetAttributeImpl (property, Foundation, StringConstants.ConnectAttribute, out attrib))
+			if (!TryGetAttributeImpl (property, Foundation, StringConstants.ConnectAttribute, out attrib))
 				return null;
 
 			if (!attrib.HasConstructorArguments)
@@ -1705,7 +1704,7 @@ namespace XamCore.Registrar {
 			if (candidate.GetMethod != null) {
 				if (property.GetMethod == null)
 					return false;
-				if (!SharedStatic.MethodMatch (candidate.GetMethod, property.GetMethod))
+				if (!MethodMatch (candidate.GetMethod, property.GetMethod))
 					return false;
 			} else if (property.GetMethod != null) {
 				return false;
@@ -1714,7 +1713,7 @@ namespace XamCore.Registrar {
 			if (candidate.SetMethod != null) {
 				if (property.SetMethod == null)
 					return false;
-				if (!SharedStatic.MethodMatch (candidate.SetMethod, property.SetMethod))
+				if (!MethodMatch (candidate.SetMethod, property.SetMethod))
 					return false;
 			} else if (property.SetMethod != null) {
 				return false;
@@ -1746,7 +1745,7 @@ namespace XamCore.Registrar {
 				return null;
 			
 			foreach (MethodDefinition candidate in type.Methods)
-				if (SharedStatic.MethodMatch (candidate, method))
+				if (MethodMatch (candidate, method))
 					return candidate;
 			
 			return null;
@@ -2199,8 +2198,8 @@ namespace XamCore.Registrar {
 						return GetExportedTypeName (td) + " *";
 					}
 				} else if (td.IsEnum) {
-					if (IsDualBuild && SharedStatic.HasAttribute (td, ObjCRuntime, StringConstants.NativeAttribute)) {
-						switch (SharedStatic.GetEnumUnderlyingType (td).FullName) {
+					if (IsDualBuild && HasAttribute (td, ObjCRuntime, StringConstants.NativeAttribute)) {
+						switch (GetEnumUnderlyingType (td).FullName) {
 						case "System.Int64":
 							return "NSInteger";
 						case "System.UInt64":
@@ -2211,7 +2210,7 @@ namespace XamCore.Registrar {
 						}
 					}
 
-					return ToObjCParameterType (SharedStatic.GetEnumUnderlyingType (td), descriptiveMethodName, exceptions, inMethod);
+					return ToObjCParameterType (GetEnumUnderlyingType (td), descriptiveMethodName, exceptions, inMethod);
 				} else if (td.IsValueType) {
 					if (IsPlatformType (td)) {
 						CheckNamespace (td, exceptions);
@@ -2219,7 +2218,7 @@ namespace XamCore.Registrar {
 					}
 					return CheckStructure (td, descriptiveMethodName, inMethod);
 				} else {
-					return SharedStatic.ToObjCType (td);
+					return ToObjCType (td);
 				}
 			}
 		}
@@ -3059,8 +3058,8 @@ namespace XamCore.Registrar {
 					original_objctype = ToObjCParameterType (type, descriptiveMethodName, exceptions,  method.Method);
 					objctype = ToObjCParameterType (type, descriptiveMethodName, exceptions, method.Method) + "*";
 				} else if (td.IsEnum) {
-					type = SharedStatic.GetEnumUnderlyingType (td);
-					isNativeEnum = IsDualBuild && SharedStatic.HasAttribute (td, ObjCRuntime, StringConstants.NativeAttribute);
+					type = GetEnumUnderlyingType (td);
+					isNativeEnum = IsDualBuild && HasAttribute (td, ObjCRuntime, StringConstants.NativeAttribute);
 					td = type.Resolve ();
 				}
 
@@ -3196,7 +3195,7 @@ namespace XamCore.Registrar {
 						if (elementType.FullName == "System.String") {
 							setup_call_stack.AppendLine ("NSString *sv = (NSString *) [arr objectAtIndex: j];", i);
 							setup_call_stack.AppendLine ("mono_array_set (marr, MonoString *, j, mono_string_new (mono_domain_get (), [sv UTF8String]));", i);
-						} else if (IsNSObject (elementType) || (elementType.Namespace == "System" && elementType.Name == "Object") || (isNativeObject = SharedStatic.IsNativeObject (elementType))) {
+						} else if (IsNSObject (elementType) || (elementType.Namespace == "System" && elementType.Name == "Object") || (isNativeObject = IsNativeObject (elementType))) {
 							setup_call_stack.AppendLine ("NSObject *nobj = [arr objectAtIndex: j];");
 							setup_call_stack.AppendLine ("MonoObject *mobj{0} = NULL;", i);
 							setup_call_stack.AppendLine ("if (nobj) {");
@@ -3291,14 +3290,14 @@ namespace XamCore.Registrar {
 							setup_call_stack.AppendLine ("}");
 							setup_call_stack.AppendLine ("arg_ptrs [{0}] = mobj{0};", i);
 
-							if (SharedStatic.HasAttribute (paramBase, ObjCRuntime, StringConstants.TransientAttribute)) {
+							if (HasAttribute (paramBase, ObjCRuntime, StringConstants.TransientAttribute)) {
 								copyback.AppendLine ("if (created{0}) {{", i);
 								copyback.AppendLine ("xamarin_dispose (mobj{0}, &exception_gchandle);", i);
 								copyback.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
 								copyback.AppendLine ("}");
 							}
 						}
-					} else if (SharedStatic.IsNativeObject (td)) {
+					} else if (IsNativeObject (td)) {
 						TypeDefinition nativeObjType = td;
 
 						if (td.IsInterface) {
@@ -3485,13 +3484,13 @@ namespace XamCore.Registrar {
 							setup_return.AppendLine ("[retobj autorelease];");
 						setup_return.AppendLine ("mt_dummy_use (retval);");
 						setup_return.AppendLine ("res = retobj;");
-					} else if (type.IsPlatformType ("ObjCRuntime", "Selector")) {
+					} else if (IsPlatformType (type, "ObjCRuntime", "Selector")) {
 						setup_return.AppendLine ("res = (SEL) xamarin_get_handle_for_inativeobject (retval, &exception_gchandle);");
 						setup_return.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
-					} else if (type.IsPlatformType ("ObjCRuntime", "Class")) {
+					} else if (IsPlatformType (type, "ObjCRuntime", "Class")) {
 						setup_return.AppendLine ("res = (Class) xamarin_get_handle_for_inativeobject (retval, &exception_gchandle);");
 						setup_return.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
-					} else if (SharedStatic.IsNativeObject (type)) {
+					} else if (IsNativeObject (type)) {
 						setup_return.AppendLine ("{0} retobj;", rettype);
 						setup_return.AppendLine ("retobj = xamarin_get_handle_for_inativeobject ((MonoObject *) retval, &exception_gchandle);");
 						setup_return.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
@@ -3510,7 +3509,7 @@ namespace XamCore.Registrar {
 							setup_return.AppendLine ("[nsstr autorelease];");
 						setup_return.AppendLine ("mono_free (str);");
 						setup_return.AppendLine ("res = nsstr;");
-					} else if (SharedStatic.IsDelegate (type.Resolve ())) {
+					} else if (IsDelegate (type.Resolve ())) {
 						setup_return.AppendLine ("res = xamarin_get_block_for_delegate (managed_method, retval, &exception_gchandle);");
 						setup_return.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
 					} else {


### PR DESCRIPTION
The SharedStatic class is a leftover from when there were two static
registrars: the old one (OldStaticRegistrar) and the new one
(StaticRegistrar).

Since there's only one static registrar left (the old one died some time ago),
all the SharedStatic code can be put into the StaticRegistrar class.

There are no functional changes in this PR, only this refactoring.