### PR TITLE
[xharness] Call VerifyRun for each subtest in the aggregated simulator test run. Fixes maccore #623.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -2689,7 +2689,9 @@ function oninitialload ()
 		}
 
 		protected abstract Task RunTestAsync ();
-		protected virtual void VerifyRun () { }
+		// VerifyRun is called in ExecuteAsync to verify that the task can be executed/run.
+		// Typically used to fail tasks that don't have an available device.
+		public virtual void VerifyRun () { }
 
 		public override void Reset ()
 		{
@@ -2763,7 +2765,7 @@ function oninitialload ()
 			set { throw new NotImplementedException (); }
 		}
 
-		protected override void VerifyRun ()
+		public override void VerifyRun ()
 		{
 			base.VerifyRun ();
 
@@ -3073,6 +3075,9 @@ function oninitialload ()
 
 		protected override async Task ExecuteAsync ()
 		{
+			foreach (var task in Tasks)
+				task.VerifyRun ();
+			
 			// First build everything. This is required for the run simulator
 			// task to properly configure the simulator.
 			build_timer.Start ();


### PR DESCRIPTION
We must call VerifyRun for each subtest in the aggregated simulator test run
in order to mark those subtests as failed if there's no available device.

Fixes https://github.com/xamarin/maccore/issues/623.