### PR TITLE
[registrar] Don't skip CoreNFC types.

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -1950,11 +1950,10 @@ namespace XamCore.Registrar {
 				header.WriteLine ("#import <WatchKit/WatchKit.h>");
 				namespaces.Add ("UIKit");
 				return;
-			case "CoreNFC":
 			case "DeviceCheck":
 #if !MONOMAC
 				if (IsSimulator)
-					return; // No headers provided for simulator, which makes sense since there is no NFC on it.
+					return; // No headers provided for simulator
 #endif
 				goto default;
 			case "QTKit":


### PR DESCRIPTION
It seems Apple started shipping CoreNFC headers some time (in a later beta)
after we first implemented (which was Xcode 9 beta 1).

Xcode 9.0, 9.1 and 9.2 all contain the exact same NFC headers (CoreNFC was
introduced with Xcode 9.0), so no version checks should be needed when removing
this exclusion.