### PR TITLE
[AVFoundation] Mark NSExtensionRequestHandling as 64-bit only.

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -12712,10 +12712,9 @@ namespace XamCore.Foundation
 		bool IsValidForFormat (NSObject plist, NSPropertyListFormat format);
 	}
 
-#if XAMCORE_2_0 || !MONOMAC
 	interface INSExtensionRequestHandling { }
 
-	[iOS (8,0)][Mac (10,10)] // Not defined in 32-bit
+	[iOS (8,0)][Mac (10,10, onlyOn64:true)] // Not defined in 32-bit
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	interface NSExtensionRequestHandling {
@@ -12725,17 +12724,6 @@ namespace XamCore.Foundation
 		[Export ("beginRequestWithExtensionContext:")]
 		void BeginRequestWithExtensionContext (NSExtensionContext context);
 	}
-#else
-	[iOS (8,0)][Mac (10,10, onlyOn64:true)] // Not defined in 32-bit
-	[Protocol, Model]
-	[BaseType (typeof (NSObject))]
-	interface NSExtensionRequestHandling {
-		[Abstract]
-		// @required - (void)beginRequestWithExtensionContext:(NSExtensionContext *)context;
-		[Export ("beginRequestWithExtensionContext:")]
-		void BeginRequestWithExtensionContext (NSExtensionContext context);
-	}
-#endif
 
 	[Protocol]
 	interface NSLocking {

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -12719,7 +12719,6 @@ namespace XamCore.Foundation
 	[BaseType (typeof (NSObject))]
 	interface NSExtensionRequestHandling {
 		[Abstract]
-		[Mac (10,10, onlyOn64 : true)] 
 		// @required - (void)beginRequestWithExtensionContext:(NSExtensionContext *)context;
 		[Export ("beginRequestWithExtensionContext:")]
 		void BeginRequestWithExtensionContext (NSExtensionContext context);


### PR DESCRIPTION
The correct binding already existed, but for some reason it was
incorrectly duplicated/readded and marked as available in 32-bit here:
https://github.com/xamarin/xamarin-macios/commit/ca028ea15#diff-7ea102419ab3567d665e35d010e90a58R11401

So simplify the bindings by removing the incorrect version.