### PR TITLE
Make NSScreen nullable in NSWindow.ConstrainFrameRect

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -19642,7 +19642,7 @@ namespace XamCore.AppKit {
 		void EndEditingFor ([NullAllowed] NSObject anObject);
 	
 		[Export ("constrainFrameRect:toScreen:")]
-		CGRect ConstrainFrameRect (CGRect frameRect, NSScreen screen);
+		CGRect ConstrainFrameRect (CGRect frameRect, [NullAllowed] NSScreen screen);
 	
 		[Export ("setFrame:display:")]
 		void SetFrame (CGRect frameRect, bool display);


### PR DESCRIPTION
When overriding this method, the framework can feed us a null screen, e.g. when calling `NSWindow.SetFrame()`

An example stack trace:

```
2018-01-26 10:08:17.580 Rhinoceros[2975:238051] System.ArgumentNullException: Value cannot be null.
Parameter name: screen
  at AppKit.NSWindow.ConstrainFrameRect (CoreGraphics.CGRect frameRect, AppKit.NSScreen screen) [0x0000c] in <5dd442fafc4842c391a0a802c0c12c43>:0 
  at System.Windows.Forms.FormHelper.ConstrainFrameRect (CoreGraphics.CGRect frameRect, AppKit.NSScreen screen) [0x00017] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/MonoMac.Windows.Form/MonoMac.Windows.Forms/System.Windows.Forms/Form.cocoa.cs:85 
--- End of stack trace from previous location where exception was thrown ---
  at (wrapper managed-to-native) ObjCRuntime.Messaging:void_objc_msgSendSuper_CGRect_bool (intptr,intptr,CoreGraphics.CGRect,bool)
  at AppKit.NSWindow.SetFrame (CoreGraphics.CGRect frameRect, System.Boolean display) [0x00031] in <5dd442fafc4842c391a0a802c0c12c43>:0 
  at System.Windows.Forms.Form.UpdateBounds (AppKit.NSView super) [0x00055] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/MonoMac.Windows.Form/MonoMac.Windows.Forms/System.Windows.Forms/Form.cocoa.cs:529 
  at System.Windows.Forms.Control.SetBoundsInternal (System.Int32 x, System.Int32 y, System.Int32 width, System.Int32 height) [0x0001c] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/MonoMac.Windows.Form/MonoMac.Windows.Forms/System.Windows.Forms/Control.Cocoa.cs:570 
  at System.Windows.Forms.Control.SetBounds (System.Int32 x, System.Int32 y, System.Int32 width, System.Int32 height, System.Windows.Forms.BoundsSpecified specified) [0x0005a] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/MonoMac.Windows.Form/MonoMac.Windows.Forms/System.Windows.Forms/Control.cs:2370 
  at System.Windows.Forms.Control.set_Location (System.Drawing.Point value) [0x00001] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/MonoMac.Windows.Form/MonoMac.Windows.Forms/System.Windows.Forms/Control.cs:1483 
  at System.Windows.Forms.Form.set_Location (System.Drawing.Point value) [0x00001] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/MonoMac.Windows.Form/MonoMac.Windows.Forms/System.Windows.Forms/Form.cs:3179 
  at Grasshopper.GUI.GH_DocumentEditor.RestoreDialogPositionData () [0x0006d] in /Users/curtis/Projects/McNeel/rhino/src4/rhino4/Plug-ins/Grasshopper_osx/Grasshopper/GUI/GH_DocumentEditor.cs:168 
  at Grasshopper.GUI.GH_DocumentEditor.DocumentEditorFormLoad (System.Object sender, System.EventArgs e) [0x0002d] in /Users/curtis/Projects/McNeel/rhino/src4/rhino4/Plug-ins/Grasshopper_osx/Grasshopper/GUI/GH_DocumentEditor.cs:60 
  at System.Windows.Forms.Form.OnLoad (System.EventArgs e) [0x0001f] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/MonoMac.Windows.Form/MonoMac.Windows.Forms/System.Windows.Forms/Form.cs:2146 
  at System.Windows.Forms.Form.CallLoad () [0x00001] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/MonoMac.Windows.Form/MonoMac.Windows.Forms/System.Windows.Forms/Form.cocoa.cs:583 
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.Form:CallLoad ()
  at System.Windows.Forms.FormHelper.CallLoad () [0x0000f] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/MonoMac.Windows.Form/MonoMac.Windows.Forms/System.Windows.Forms/Form.cocoa.cs:134 
  at System.Windows.Forms.FormHelper.BecomeKeyWindow () [0x00008] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/MonoMac.Windows.Form/MonoMac.Windows.Forms/System.Windows.Forms/Form.cocoa.cs:146 
--- End of stack trace from previous location where exception was thrown ---
  at (wrapper managed-to-native) ObjCRuntime.Messaging:void_objc_msgSendSuper_bool (intptr,intptr,bool)
  at AppKit.NSWindow.set_IsVisible (System.Boolean value) [0x00030] in <5dd442fafc4842c391a0a802c0c12c43>:0 
  at System.Windows.Forms.Form.set_VisibleInternal (System.Boolean value) [0x00001] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/MonoMac.Windows.Form/MonoMac.Windows.Forms/System.Windows.Forms/Form.cocoa.cs:486 
  at System.Windows.Forms.Control.set_Visible (System.Boolean value) [0x00012] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/MonoMac.Windows.Form/MonoMac.Windows.Forms/System.Windows.Forms/Control.Cocoa.cs:1348 
  at System.Windows.Forms.Control.InternalShow () [0x00001] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/MonoMac.Windows.Form/MonoMac.Windows.Forms/System.Windows.Forms/Control.cs:2377 
  at System.Windows.Forms.Form.InternalShow () [0x00001] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/MonoMac.Windows.Form/MonoMac.Windows.Forms/System.Windows.Forms/Form.cocoa.cs:367 
  at System.Windows.Forms.Control.Show () [0x00001] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/MonoMac.Windows.Form/MonoMac.Windows.Forms/System.Windows.Forms/Control.cs:2382 
  at System.Windows.Forms.Form.Show (System.Windows.Forms.IWin32Window parent) [0x000ad] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/MonoMac.Windows.Form/MonoMac.Windows.Forms/System.Windows.Forms/Form.cocoa.cs:416 
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.Form:Show (System.Windows.Forms.IWin32Window)
  at Grasshopper.Plugin.Commands.ShowGrasshopperEditor (System.Boolean showUponLoad) [0x001ee] in /Users/curtis/Projects/McNeel/rhino/src4/rhino4/Plug-ins/Grasshopper_osx/Grasshopper/Plugin/GH_GrasshopperCommands.cs:73 
  at Grasshopper.Plugin.Commands.Run_Grasshopper () [0x0001f] in /Users/curtis/Projects/McNeel/rhino/src4/rhino4/Plug-ins/Grasshopper_osx/Grasshopper/Plugin/GH_GrasshopperCommands.cs:139 
  at GrasshopperPlugin.GrasshopperCommand.RunCommand (Rhino.RhinoDoc doc, Rhino.Commands.RunMode mode) [0x00010] in /Users/curtis/Projects/McNeel/rhino/src4/rhino4/Plug-ins/Grasshopper_osx/GrasshopperPlugin/GrasshopperCommands.cs:17 
  at Rhino.Commands.Command.OnRunCommand (System.Int32 commandSerialNumber, System.UInt32 docSerialNumber, System.Int32 mode) [0x00035] in /Users/curtis/Projects/McNeel/rhino/src4/DotNetSDK/rhinocommon/dotnet/rhino/rhinosdkcommand.cs:311 
```
