### PR TITLE
[AVFoundation] Remove AVCaptureDataOutputSynchronizer[Delegate] from macOS.

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -3124,6 +3124,9 @@ namespace XamCore.AVFoundation {
 	interface IAVCaptureDataOutputSynchronizerDelegate {}
 	
 	[NoWatch, NoTV, iOS (11,0)]
+#if XAMCORE_4_0
+	[NoMac]
+#endif
 	[Protocol, Model]
 	[BaseType (typeof(NSObject))]
 	interface AVCaptureDataOutputSynchronizerDelegate
@@ -3134,6 +3137,9 @@ namespace XamCore.AVFoundation {
 	}
 
 	[NoWatch, NoTV, iOS (11,0)]
+#if XAMCORE_4_0
+	[NoMac]
+#endif
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
 	interface AVCaptureDataOutputSynchronizer

--- a/tests/xtro-sharpie/macOS-AVFoundation.ignore
+++ b/tests/xtro-sharpie/macOS-AVFoundation.ignore
@@ -14,6 +14,9 @@
 !missing-selector! AVCaptureConnection::setVideoMaxFrameDuration: not bound
 !missing-selector! AVCaptureConnection::videoMaxFrameDuration not bound
 
+# Incorrectly bound, fixed for XAMCORE_4_0
+!unknown-protocol! AVCaptureDataOutputSynchronizerDelegate bound
+!unknown-type! AVCaptureDataOutputSynchronizer bound
 
 ## unsorted
 
@@ -43,8 +46,6 @@
 !unknown-native-enum! AVCaptureOutputDataDroppedReason bound
 !unknown-native-enum! AVCaptureVideoStabilizationMode bound
 !unknown-native-enum! AVSpeechBoundary bound
-!unknown-protocol! AVCaptureDataOutputSynchronizerDelegate bound
-!unknown-type! AVCaptureDataOutputSynchronizer bound
 !unknown-type! AVCaptureSynchronizedData bound
 !unknown-type! AVCaptureSynchronizedDataCollection bound
 !unknown-type! AVPersistableContentKeyRequest bound


### PR DESCRIPTION
This class and protocol were incorrectly added to our macOS bindings.

The catch is that we can't remove them because it would break backwards
compatibility, so mark them for removal in XAMCORE_4_0.