### PR TITLE
[backport][arkit] Fix 'Vertices', 'TextureCoordinates' and 'TriangleIndices' in 'ARFaceGeometry' (#3090)

### DIFF
--- a/src/ARKit/ARCompat.cs
+++ b/src/ARKit/ARCompat.cs
@@ -1,0 +1,29 @@
+//
+// ARCompat.cs: Compatibility functions
+//
+// Authors:
+//	Vincent Dondain <vidondai@microsoft.com>
+//
+// Copyright 2017 Microsoft Inc. All rights reserved.
+//
+
+using System;
+using Vector2 = global::OpenTK.Vector2;
+using Vector3 = global::OpenTK.NVector3;
+
+namespace XamCore.ARKit {
+
+#if !XAMCORE_4_0 && IOS
+	public partial class ARFaceGeometry {
+
+		[Obsolete ("Use the 'GetVertices' method instead.")]
+		public virtual Vector3 Vertices { get; }
+
+		[Obsolete ("Use the 'GetTextureCoordinates' method instead.")]
+		public virtual Vector2 TextureCoordinates { get; }
+
+		[Obsolete ("Use the 'GetTriangleIndices' method instead.")]
+		public virtual short TriangleIndices { get; }
+	}
+#endif
+}

--- a/src/ARKit/ARFaceGeometry.cs
+++ b/src/ARKit/ARFaceGeometry.cs
@@ -1,0 +1,56 @@
+//
+// ARFaceGeometry.cs: Nicer code for ARFaceGeometry
+//
+// Authors:
+//	Vincent Dondain  <vidondai@microsoft.com>
+//
+// Copyright 2017 Microsoft Inc. All rights reserved.
+//
+
+#if XAMCORE_2_0
+
+using System;
+using System.Runtime.InteropServices;
+using Vector2 = global::OpenTK.Vector2;
+using Vector3 = global::OpenTK.NVector3;
+
+namespace XamCore.ARKit {
+	public partial class ARFaceGeometry {
+
+		// Going for GetXXX methods so we can keep the same name as the matching obsoleted property 'Vertices'.
+		public unsafe Vector3 [] GetVertices ()
+		{
+			var count = (int)VertexCount;
+			var rv = new Vector3 [count];
+			var ptr = (Vector3 *) GetRawVertices ();
+			for (int i = 0; i < count; i++)
+				rv [i] = *ptr++;
+			return rv;
+		}
+
+		// Going for GetXXX methods so we can keep the same name as the matching obsoleted property 'TextureCoordinates'.
+		public unsafe Vector2 [] GetTextureCoordinates ()
+		{
+			var count = (int)TextureCoordinateCount;
+			var rv = new Vector2 [count];
+			var ptr = (Vector2 *) GetRawTextureCoordinates ();
+			for (int i = 0; i < count; i++)
+				rv [i] = *ptr++;
+			return rv;
+		}
+
+		// Going for GetXXX methods so we can keep the same name as the matching obsoleted property 'TriangleIndices'.
+		public unsafe short [] GetTriangleIndices ()
+		{
+			// There are always 3x more 'TriangleIndices' than 'TriangleCount' since 'TriangleIndices' represents Triangles (set of three indices).
+			var count = (int)TriangleCount * 3;
+			var rv = new short [count];
+			var ptr = (short *) GetRawTriangleIndices ();
+			for (int i = 0; i < count; i++)
+				rv [i] = *ptr++;
+			return rv;
+		}
+	}
+}
+
+#endif

--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -832,26 +832,23 @@ namespace XamCore.ARKit {
 		[Export ("vertexCount")]
 		nuint VertexCount { get; }
 
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("vertices")]
-		Vector3 Vertices {
-			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-			get;
-		}
+		IntPtr GetRawVertices ();
 
 		[Export ("textureCoordinateCount")]
 		nuint TextureCoordinateCount { get; }
 
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("textureCoordinates")]
-		Vector2 TextureCoordinates {
-			[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-			get;
-		}
+		IntPtr GetRawTextureCoordinates ();
 
 		[Export ("triangleCount")]
 		nuint TriangleCount { get; }
 
+		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("triangleIndices")]
-		short TriangleIndices { get; }
+		IntPtr GetRawTriangleIndices ();
 	}
 
 	[iOS (11,0)]

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -154,6 +154,8 @@ APPKIT_SOURCES = \
 # ARKit
 
 ARKIT_SOURCES = \
+	ARKit/ARCompat.cs \
+	ARKit/ARFaceGeometry.cs \
 	ARKit/ARPointCloud.cs \
 
 # AssetsLibrary

--- a/tests/monotouch-test/ARKit/ARFaceGeometryTest.cs
+++ b/tests/monotouch-test/ARKit/ARFaceGeometryTest.cs
@@ -1,0 +1,120 @@
+﻿//
+// Unit tests for ARFaceGeometry
+//
+// Authors:
+//	Vincent Dondain <vidondai@microsoft.com>
+//
+// Copyright 2017 Microsoft. All rights reserved.
+//
+
+#if XAMCORE_2_0 && __IOS__
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using ARKit;
+using Foundation;
+using NUnit.Framework;
+using ObjCRuntime;
+
+using VectorFloat2 = global::OpenTK.Vector2;
+using VectorFloat3 = global::OpenTK.NVector3;
+
+namespace MonoTouchFixtures.ARKit {
+
+	class ARFaceGeometryPoker : ARFaceGeometry {
+
+		GCHandle verticesArrayHandle;
+		GCHandle textureCoordinatesArrayHandle;
+		GCHandle indicesArrayHandle;
+		VectorFloat3 [] vertices;
+		VectorFloat2 [] textureCoordinates;
+		short [] indices;
+
+		public ARFaceGeometryPoker () : base (IntPtr.Zero)
+		{
+		}
+
+		public override nuint VertexCount => 2;
+
+		public override nuint TextureCoordinateCount => 2;
+
+		// There are always 3x more 'TriangleIndices' than 'TriangleCount' since 'TriangleIndices' represents Triangles (set of three indices).
+		// So 2 'TriangleCount' = 6 'TriangleIndices'.
+		public override nuint TriangleCount => 2;
+
+		public override IntPtr GetRawVertices ()
+		{
+			vertices = new VectorFloat3 [] { new VectorFloat3 (1, 2, 3), new VectorFloat3 (4, 5, 6) };
+			if (!verticesArrayHandle.IsAllocated)
+				verticesArrayHandle = GCHandle.Alloc (vertices, GCHandleType.Pinned);
+			return verticesArrayHandle.AddrOfPinnedObject ();
+		}
+
+		public override IntPtr GetRawTextureCoordinates ()
+		{
+			textureCoordinates = new VectorFloat2 [] { new VectorFloat2 (1, 2), new VectorFloat2 (3, 4) };
+			if (!textureCoordinatesArrayHandle.IsAllocated)
+				textureCoordinatesArrayHandle = GCHandle.Alloc (textureCoordinates, GCHandleType.Pinned);
+			return textureCoordinatesArrayHandle.AddrOfPinnedObject ();
+		}
+
+		public override IntPtr GetRawTriangleIndices ()
+		{
+			// Two triangles (set of 3 indices)
+			indices = new short [] { 1, 2, 3, 4, 5, 6 };
+			if (!indicesArrayHandle.IsAllocated)
+				indicesArrayHandle = GCHandle.Alloc (indices, GCHandleType.Pinned);
+			return indicesArrayHandle.AddrOfPinnedObject ();
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (verticesArrayHandle.IsAllocated)
+				verticesArrayHandle.Free ();
+			if (textureCoordinatesArrayHandle.IsAllocated)
+				textureCoordinatesArrayHandle.Free ();
+			if (indicesArrayHandle.IsAllocated)
+				indicesArrayHandle.Free ();
+		}
+	}
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class ARFaceGeometryTest {
+
+		[SetUp]
+		public void Setup ()
+		{
+			TestRuntime.AssertXcodeVersion (9, 0);
+		}
+
+		[Test]
+		public void VerticesTest ()
+		{
+			var face = new ARFaceGeometryPoker ();
+			var vertices = face.GetVertices ();
+			Assert.AreEqual (new VectorFloat3 (1, 2, 3), vertices [0]);
+			Assert.AreEqual (new VectorFloat3 (4, 5, 6), vertices [1]);
+		}
+
+		[Test]
+		public void TextureCoordinatesTest ()
+		{
+			var face = new ARFaceGeometryPoker ();
+			var textureCoordinates = face.GetTextureCoordinates ();
+			Assert.AreEqual (new VectorFloat2 (1, 2), textureCoordinates [0]);
+			Assert.AreEqual (new VectorFloat2 (3, 4), textureCoordinates [1]);
+		}
+
+		[Test]
+		public void TriangleIndicesTest ()
+		{
+			var face = new ARFaceGeometryPoker ();
+			Assert.AreEqual (new short [] { 1, 2, 3, 4, 5, 6 }, face.GetTriangleIndices ());
+		}
+	}
+}
+
+#endif // XAMCORE_2_0 && __IOS__

--- a/tests/xtro-sharpie/iOS-ARKit.ignore
+++ b/tests/xtro-sharpie/iOS-ARKit.ignore
@@ -3,7 +3,5 @@
 
 ## Those methods are manually bound
 !wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARPointCloud::GetRawPoints(): simd type: vector_float3
-
-## not available in this branch
-## !wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARFaceGeometry::GetRawTextureCoordinates(): simd type: vector_float2
-## !wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARFaceGeometry::GetRawVertices(): simd type: vector_float3
+!wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARFaceGeometry::GetRawTextureCoordinates(): simd type: vector_float2
+!wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARFaceGeometry::GetRawVertices(): simd type: vector_float3


### PR DESCRIPTION
_Note: asking to backport because I’m adding APIs for `ARPlaneGeometry` that are similar to the `ARFaceGeometry` APIs I fixed.
Without the backport it would be weird (APIs that are supposed to be the same are in fact different) and annoying (if you fixed your `ARFaceGeometry` APIs) to use the `xcode9.3` branch._

- Fixes bug #61056: [ARKit] TriangleIndices, Vertices and TextureCoordinates should be respectively short [], Vector3 [] and Vector2 []
(https://bugzilla.xamarin.com/show_bug.cgi?id=61056)
- Obsolete `short TriangleIndices`.
- Obsolete `Vector3 Vertices`.
- Obsolete `Vector2 TextureCoordinates`.
- Introduced new `short [] GetTriangleIndices ()`.
- Introduced new `Vector3 [] GetVertices ()`.
- Introduced new `Vector2 [] GetTextureCoordinates ()`.