### PR TITLE
[Security] Update to Xcode 9.3 Beta 1

### DIFF
--- a/src/Security/SecStatusCodeExtensions.cs
+++ b/src/Security/SecStatusCodeExtensions.cs
@@ -1,0 +1,31 @@
+﻿// 
+// SecStatusCodeExtensions.cs
+//
+// Authors:
+//	Alex Soto (alexsoto@microsoft.com)
+// 
+// Copyright 2018 Xamarin Inc.
+//
+
+using System;
+using System.Runtime.InteropServices;
+using XamCore.ObjCRuntime;
+using XamCore.Foundation;
+
+namespace XamCore.Security {
+	public static class SecStatusCodeExtensions {
+
+		[iOS (11,3), TV (11,3), Watch (4,3)]
+		[DllImport (Constants.SecurityLibrary)]
+		extern static /* CFStringRef */ IntPtr SecCopyErrorMessageString (
+			/* OSStatus */ SecStatusCode status,
+			/* void * */ IntPtr reserved); /* always null */
+
+		[iOS (11,3), TV (11,3), Watch (4,3)] // Since Mac 10,3
+		public static string GetStatusDescription (this SecStatusCode status)
+		{
+			var ret = SecCopyErrorMessageString (status, IntPtr.Zero);
+			return Runtime.GetNSObject<NSString> (ret, owns: true);
+		}
+	}
+}

--- a/src/Security/SecureTransport.cs
+++ b/src/Security/SecureTransport.cs
@@ -95,7 +95,7 @@ namespace XamCore.Security {
 		SSLMissingExtension                     = -9861,
 		SSLBadCertificateStatusResponse         = -9862,
 		SSLCertificateRequired                  = -9863,
-		SSLUnknownPSKIdentity                   = -9864,
+		SSLUnknownPskIdentity                   = -9864,
 		SSLUnrecognizedName                     = -9865,
 	}
 

--- a/src/Security/SecureTransport.cs
+++ b/src/Security/SecureTransport.cs
@@ -82,7 +82,21 @@ namespace XamCore.Security {
 		BadConfiguration			= -9848,
 		UnexpectedRecord			= -9849,
 		SSLWeakPeerEphemeralDHKey               = -9850,
-		SSLClientHelloReceived                  = -9851 // non falta
+		SSLClientHelloReceived                  = -9851, // non falta
+		SSLTransportReset                       = -9852,
+		SSLNetworkTimeout                       = -9853,
+		SSLConfigurationFailed                  = -9854,
+		SSLUnsupportedExtension                 = -9855,
+		SSLUnexpectedMessage                    = -9856,
+		SSLDecompressFail                       = -9857,
+		SSLHandshakeFail                        = -9858,
+		SSLDecodeError                          = -9859,
+		SSLInappropriateFallback                = -9860,
+		SSLMissingExtension                     = -9861,
+		SSLBadCertificateStatusResponse         = -9862,
+		SSLCertificateRequired                  = -9863,
+		SSLUnknownPSKIdentity                   = -9864,
+		SSLUnrecognizedName                     = -9865,
 	}
 
 	// Security.framework/Headers/SecureTransport.h

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1264,6 +1264,7 @@ SECURITY_SOURCES = \
 	Security/SecIdentity.cs \
 	Security/SecPolicy.cs \
 	Security/SecSharedCredential.cs \
+	Security/SecStatusCodeExtensions.cs \
 	Security/SecTrust.cs \
 	Security/SslConnection.cs \
 	Security/SslContext.cs \

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -367,6 +367,7 @@ namespace Introspection
 			"Propogate",
 			"Psec",
 			"Psm", // Protocol/Service Multiplexer
+			"Psk",
 			"Pvrtc", // MTLBlitOption - PowerVR Texture Compression
 			"Quaterniond",
 			"Quadding",

--- a/tests/monotouch-test/Security/SecStatusCodeTest.cs
+++ b/tests/monotouch-test/Security/SecStatusCodeTest.cs
@@ -1,0 +1,40 @@
+﻿// 
+// SecStatusCodeTest.cs
+//
+// Authors:
+//	Alex Soto (alexsoto@microsoft.com)
+// 
+// Copyright 2018 Xamarin Inc.
+//
+
+using System;
+using NUnit.Framework;
+
+#if XAMCORE_2_0
+using Foundation;
+using Security;
+#else
+using MonoTouch.Foundation;
+using MonoTouch.Security;
+#endif
+
+namespace MonoTouchFixtures.Security {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class SecStatusCodeTest {
+
+		[Test]
+		public void ErrorDescriptionTest ()
+		{
+			TestRuntime.AssertXcodeVersion (9, 3);
+
+			var desc = SecStatusCode.Success.GetStatusDescription ();
+			Assert.NotNull (desc, $"{nameof (desc)} not null");
+
+			// This value generated from objc enum documentation and very unlikely to change.
+			var noErr = "No error.";
+			Assert.That (desc, Is.EqualTo (noErr), $"{nameof (desc)} == {noErr}");
+		}
+	}
+}

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -705,6 +705,7 @@
     <Compile Include="CoreVideo\CVImageBufferTests.cs" />
     <Compile Include="CoreVideo\CVMetalTextureCacheTests.cs" />
     <Compile Include="StoreKit\SKCloudServiceSetupOptionsTest.cs" />
+    <Compile Include="Security\SecStatusCodeTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/tests/xtro-sharpie/common-Security.ignore
+++ b/tests/xtro-sharpie/common-Security.ignore
@@ -15,6 +15,3 @@
 
 ## untyped enum in Security.framework/Headers/SecPolicy.h but the API use CFOptionFlags
 !unknown-native-enum! SecRevocation bound
-
-## Not bound before, my take is that enums are more descriptive
-!missing-pinvoke! SecCopyErrorMessageString is not bound

--- a/tests/xtro-sharpie/common-Security.ignore
+++ b/tests/xtro-sharpie/common-Security.ignore
@@ -15,3 +15,6 @@
 
 ## untyped enum in Security.framework/Headers/SecPolicy.h but the API use CFOptionFlags
 !unknown-native-enum! SecRevocation bound
+
+## Not bound before, my take is that enums are more descriptive
+!missing-pinvoke! SecCopyErrorMessageString is not bound

--- a/tests/xtro-sharpie/iOS-Security.todo
+++ b/tests/xtro-sharpie/iOS-Security.todo
@@ -1,1 +1,0 @@
-!missing-pinvoke! SecCopyErrorMessageString is not bound

--- a/tests/xtro-sharpie/macOS-Security.ignore
+++ b/tests/xtro-sharpie/macOS-Security.ignore
@@ -1263,7 +1263,6 @@
 !missing-pinvoke! SecCodeCopyStaticCode is not bound
 !missing-pinvoke! SecCodeGetTypeID is not bound
 !missing-pinvoke! SecCodeMapMemory is not bound
-!missing-pinvoke! SecCopyErrorMessageString is not bound
 !missing-pinvoke! SecDecodeTransformCreate is not bound
 !missing-pinvoke! SecDecryptTransformCreate is not bound
 !missing-pinvoke! SecDecryptTransformGetTypeID is not bound

--- a/tests/xtro-sharpie/tvOS-Security.todo
+++ b/tests/xtro-sharpie/tvOS-Security.todo
@@ -1,1 +1,0 @@
-!missing-pinvoke! SecCopyErrorMessageString is not bound

--- a/tests/xtro-sharpie/watchOS-Security.todo
+++ b/tests/xtro-sharpie/watchOS-Security.todo
@@ -1,1 +1,0 @@
-!missing-pinvoke! SecCopyErrorMessageString is not bound


### PR DESCRIPTION
iOS/tvOS/watchOS are identical.

On macOS there is one API addition but we do not have bindings for the container object of such API. Other than that just a bunch of availability enhancements on their side, nothing actionable for us.

Api diff:
- https://github.com/xamarin/xamarin-macios/wiki/Security-iOS-xcode9.3-beta1
- https://github.com/xamarin/xamarin-macios/wiki/Security-tvOS-xcode9.3-beta1
- https://github.com/xamarin/xamarin-macios/wiki/Security-watchOS-xcode9.3-beta1
- https://github.com/xamarin/xamarin-macios/wiki/Security-macOS-xcode9.3-beta1