### PR TITLE
[backport][avfoundation] Fix AVAudioUnitComponentManager default .ctor crash (#3314)

### DIFF
--- a/src/AVFoundation/AVCompat.cs
+++ b/src/AVFoundation/AVCompat.cs
@@ -92,6 +92,14 @@ namespace XamCore.AVFoundation {
 		}
 	}
 
+	partial class AVAudioUnitComponentManager {
+
+		[Obsolete ("Please use the static 'SharedInstance' property as this type is not meant to be created.")]
+		public AVAudioUnitComponentManager ()
+		{
+		}
+	}
+
 #if !MONOMAC
 	partial class AVSampleBufferAudioRenderer
 	{

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -12212,6 +12212,7 @@ namespace XamCore.AVFoundation {
 
 	[NoWatch, iOS (9,0), Mac (10,10)]
 	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor] // for binary compatibility this is added in AVCompat.cs w/[Obsolete]
 	interface AVAudioUnitComponentManager {
 		
 		[Export ("tagNames")]


### PR DESCRIPTION
It looks like this should not have been bound since there's a singleton-like static property to use the type.
Keeping binary compatibility.

- Fixes github issue #3303: AVAudioUnitComponentManager default .ctor can crash on macOS 10.13.3
(https://github.com/xamarin/xamarin-macios/issues/3303)