### PR TITLE
[msbuild] Use the proper MM vs MT error code prefix

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/LoggingExtensions.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/LoggingExtensions.cs
@@ -6,6 +6,21 @@ namespace Xamarin.MacDev.Tasks
 	public static class LoggingExtensions
 	{
 		const MessageImportance TaskPropertyImportance = MessageImportance.Normal;
+		static readonly string ErrorPrefix;
+
+		static LoggingExtensions ()
+		{
+			var name = typeof (LoggingExtensions).Assembly.GetName ();
+
+			switch (name.Name) {
+			case "Xamarin.Mac.Tasks":
+				ErrorPrefix = "MM";
+				break;
+			default:
+				ErrorPrefix = "MT";
+				break;
+			}
+		}
 
 		public static void LogTaskProperty (this TaskLoggingHelper log, string propertyName, ITaskItem[] items)
 		{
@@ -62,10 +77,15 @@ namespace Xamarin.MacDev.Tasks
 		/// For every new error we need to update "docs/website/mtouch-errors.md" and "tools/mtouch/error.cs".</remarks>
 		/// <param name="errorCode">In the 7xxx range for MSBuild error.</param>
 		/// <param name="message">The error's message to be displayed in the error pad.</param>
-		/// <param name="filePath">Path to the known guilty file or MSBuild by default so we display something nice in the error pad.</param>
-		public static void MTError (this TaskLoggingHelper log, int errorCode, string message, string filePath = "MSBuild")
+		/// <param name="fileName">Path to the known guilty file or null.</param>
+		public static void LogError (this TaskLoggingHelper log, int errorCode, string fileName, string message, params object[] args)
 		{
-			log.LogError (null, $"MT{errorCode}", null, filePath, 0, 0, 0, 0, message);
+			log.LogError (null, $"{ErrorPrefix}{errorCode}", null, fileName ?? "MSBuild", 0, 0, 0, 0, message, args);
+		}
+
+		public static void LogWarning (this TaskLoggingHelper log, int errorCode, string fileName, string message, params object[] args)
+		{
+			log.LogWarning (null, $"{ErrorPrefix}{errorCode}", null, fileName ?? "MSBuild", 0, 0, 0, 0, message, args);
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/PropertyListEditorTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/PropertyListEditorTaskBase.cs
@@ -73,7 +73,7 @@ namespace Xamarin.MacDev.Tasks
 				return true;
 			case "real":
 				if (text != null && !double.TryParse (text, NumberStyles.Float, CultureInfo.InvariantCulture, out real)) {
-					Log.MTError (7045, "Unrecognized Real Format");
+					Log.LogError (7045, null, "Unrecognized Real Format");
 					return false;
 				}
 
@@ -81,7 +81,7 @@ namespace Xamarin.MacDev.Tasks
 				return true;
 			case "integer":
 				if (text != null && !int.TryParse (text, NumberStyles.Integer, CultureInfo.InvariantCulture, out integer)) {
-					Log.MTError (7045, "Unrecognized Integer Format");
+					Log.LogError (7045, null, "Unrecognized Integer Format");
 					return false;
 				}
 
@@ -89,7 +89,7 @@ namespace Xamarin.MacDev.Tasks
 				return true;
 			case "date":
 				if (text != null && !DateTime.TryParse (text, CultureInfo.InvariantCulture, DateTimeStyles.None, out date)) {
-					Log.MTError (7045, "Unrecognized Date Format");
+					Log.LogError (7045, null, "Unrecognized Date Format");
 					return false;
 				}
 
@@ -102,7 +102,7 @@ namespace Xamarin.MacDev.Tasks
 					value = new PData (new byte[0]);
 				return true;
 			default:
-				Log.MTError (7045, $"Unrecognized Type: {type}");
+				Log.LogError (7045, null, $"Unrecognized Type: {type}");
 				value = null;
 				return false;
 			}
@@ -132,7 +132,7 @@ namespace Xamarin.MacDev.Tasks
 			int i = 0;
 
 			if (path.Length == 0) {
-				Log.MTError (7046, $"Add: Entry, \"{Entry}\", Incorrectly Specified");
+				Log.LogError (7046, null, $"Add: Entry, \"{Entry}\", Incorrectly Specified");
 				return false;
 			}
 
@@ -142,7 +142,7 @@ namespace Xamarin.MacDev.Tasks
 
 				if (array != null) {
 					if (!int.TryParse (path[i], out index) || index < 0 || index >= array.Count) {
-						Log.MTError (7047, $"Add: Entry, \"{Entry}\", Contains Invalid Array Index");
+						Log.LogError (7047, null, $"Add: Entry, \"{Entry}\", Contains Invalid Array Index");
 						return false;
 					}
 
@@ -151,7 +151,7 @@ namespace Xamarin.MacDev.Tasks
 					if (!dict.TryGetValue (path[i], out current))
 						dict[path[i]] = current = new PDictionary ();
 				} else {
-					Log.MTError (7046, $"Add: Entry, \"{Entry}\", Incorrectly Specified");
+					Log.LogError (7046, null, $"Add: Entry, \"{Entry}\", Incorrectly Specified");
 					return false;
 				}
 
@@ -165,7 +165,7 @@ namespace Xamarin.MacDev.Tasks
 				if (path[i].Length == 0) {
 					index = array.Count;
 				} else if (!int.TryParse (path[i], out index) || index < 0) {
-					Log.MTError (7047, $"Add: Entry, \"{Entry}\", Contains Invalid Array Index");
+					Log.LogError (7047, null, $"Add: Entry, \"{Entry}\", Contains Invalid Array Index");
 					return false;
 				}
 
@@ -178,7 +178,7 @@ namespace Xamarin.MacDev.Tasks
 					array.Add (value);
 			} else if (dict != null) {
 				if (dict.ContainsKey (path[i])) {
-					Log.MTError (7048, $"Add: \"{Entry}\" Entry Already Exists");
+					Log.LogError (7048, null, $"Add: \"{Entry}\" Entry Already Exists");
 					return false;
 				}
 
@@ -187,7 +187,7 @@ namespace Xamarin.MacDev.Tasks
 
 				dict[path[i]] = value;
 			} else {
-				Log.MTError (7049, $"Add: Can't Add Entry, \"{Entry}\", to Parent");
+				Log.LogError (7049, null, $"Add: Can't Add Entry, \"{Entry}\", to Parent");
 				return false;
 			}
 
@@ -207,7 +207,7 @@ namespace Xamarin.MacDev.Tasks
 				case "date": plist = new PDate (DateTime.Now); break;
 				case "data": plist = new PData (new byte[1]); break;
 				default:
-					Log.MTError (7045, $"Unrecognized Type: {Type}");
+					Log.LogError (7045, null, $"Unrecognized Type: {Type}");
 					return false;
 				}
 			} else {
@@ -227,7 +227,7 @@ namespace Xamarin.MacDev.Tasks
 			int i = 0;
 
 			if (path.Length == 0) {
-				Log.MTError (7050, $"Delete: Can't Delete Entry, \"{Entry}\", from Parent");
+				Log.LogError (7050, null, $"Delete: Can't Delete Entry, \"{Entry}\", from Parent");
 				return false;
 			}
 
@@ -237,23 +237,23 @@ namespace Xamarin.MacDev.Tasks
 
 				if (array != null) {
 					if (!int.TryParse (path[i], out index) || index < 0) {
-						Log.MTError (7051, $"Delete: Entry, \"{Entry}\", Contains Invalid Array Index");
+						Log.LogError (7051, null, $"Delete: Entry, \"{Entry}\", Contains Invalid Array Index");
 						return false;
 					}
 
 					if (index >= array.Count) {
-						Log.MTError (7052, $"Delete: Entry, \"{Entry}\", Does Not Exist");
+						Log.LogError (7052, null, $"Delete: Entry, \"{Entry}\", Does Not Exist");
 						return false;
 					}
 
 					current = array[index];
 				} else if (dict != null) {
 					if (!dict.TryGetValue (path[i], out current)) {
-						Log.MTError (7052, $"Delete: Entry, \"{Entry}\", Does Not Exist");
+						Log.LogError (7052, null, $"Delete: Entry, \"{Entry}\", Does Not Exist");
 						return false;
 					}
 				} else {
-					Log.MTError (7052, $"Delete: Entry, \"{Entry}\", Does Not Exist");
+					Log.LogError (7052, null, $"Delete: Entry, \"{Entry}\", Does Not Exist");
 					return false;
 				}
 
@@ -276,7 +276,7 @@ namespace Xamarin.MacDev.Tasks
 			int i = 0;
 
 			if (path.Length == 0) {
-				Log.MTError (7053, $"Import: Entry, \"{Entry}\", Incorrectly Specified");
+				Log.LogError (7053, null, $"Import: Entry, \"{Entry}\", Incorrectly Specified");
 				return false;
 			}
 
@@ -286,7 +286,7 @@ namespace Xamarin.MacDev.Tasks
 
 				if (array != null) {
 					if (!int.TryParse (path[i], out index) || index < 0 || index >= array.Count) {
-						Log.MTError (7054, $"Import: Entry, \"{Entry}\", Contains Invalid Array Index");
+						Log.LogError (7054, null, $"Import: Entry, \"{Entry}\", Contains Invalid Array Index");
 						return false;
 					}
 
@@ -295,7 +295,7 @@ namespace Xamarin.MacDev.Tasks
 					if (!dict.TryGetValue (path[i], out current))
 						dict[path[i]] = current = new PDictionary ();
 				} else {
-					Log.MTError (7053, $"Import: Entry, \"{Entry}\", Incorrectly Specified");
+					Log.LogError (7053, null, $"Import: Entry, \"{Entry}\", Incorrectly Specified");
 					return false;
 				}
 
@@ -309,14 +309,14 @@ namespace Xamarin.MacDev.Tasks
 				if (path[i].Length == 0) {
 					index = array.Count;
 				} else if (!int.TryParse (path[i], out index) || index < 0) {
-					Log.MTError (7054, $"Import: Entry, \"{Entry}\", Contains Invalid Array Index");
+					Log.LogError (7054, null, $"Import: Entry, \"{Entry}\", Contains Invalid Array Index");
 					return false;
 				}
 
 				try {
 					value = new PData (File.ReadAllBytes (Value));
 				} catch {
-					Log.MTError (7055, $"Import: Error Reading File: {Value}", Value);
+					Log.LogError (7055, null, $"Import: Error Reading File: {Value}", Value);
 					return false;
 				}
 
@@ -328,13 +328,13 @@ namespace Xamarin.MacDev.Tasks
 				try {
 					value = new PData (File.ReadAllBytes (Value));
 				} catch {
-					Log.MTError (7055, $"Import: Error Reading File: {Value}", Value);
+					Log.LogError (7055, null, $"Import: Error Reading File: {Value}", Value);
 					return false;
 				}
 
 				dict[path[i]] = value;
 			} else {
-				Log.MTError (7056, $"Import: Can't Add Entry, \"{Entry}\", to Parent");
+				Log.LogError (7056, null, $"Import: Can't Add Entry, \"{Entry}\", to Parent");
 				return false;
 			}
 
@@ -346,7 +346,7 @@ namespace Xamarin.MacDev.Tasks
 			switch (plist.Type) {
 			case PObjectType.Dictionary:
 				if (value.Type == PObjectType.Array) {
-					Log.MTError (7057, "Merge: Can't Add array Entries to dict");
+					Log.LogError (7057, PropertyList, "Merge: Can't Add array Entries to dict");
 					return false;
 				}
 
@@ -380,7 +380,7 @@ namespace Xamarin.MacDev.Tasks
 				}
 				break;
 			default:
-				Log.MTError (7058, "Merge: Specified Entry Must Be a Container");
+				Log.LogError (7058, PropertyList, "Merge: Specified Entry Must Be a Container");
 				return false;
 			}
 
@@ -404,23 +404,23 @@ namespace Xamarin.MacDev.Tasks
 
 					if (array != null) {
 						if (!int.TryParse (path[i], out index) || index < 0) {
-							Log.MTError (7059, $"Merge: Entry, \"{Entry}\", Contains Invalid Array Index");
+							Log.LogError (7059, PropertyList, $"Merge: Entry, \"{Entry}\", Contains Invalid Array Index");
 							return false;
 						}
 
 						if (index >= array.Count) {
-							Log.MTError (7060, $"Merge: Entry, \"{Entry}\", Does Not Exist");
+							Log.LogError (7060, PropertyList, $"Merge: Entry, \"{Entry}\", Does Not Exist");
 							return false;
 						}
 
 						current = array[index];
 					} else if (dict != null) {
 						if (!dict.TryGetValue (path[i], out current)) {
-							Log.MTError (7060, $"Merge: Entry, \"{Entry}\", Does Not Exist");
+							Log.LogError (7060, PropertyList, $"Merge: Entry, \"{Entry}\", Does Not Exist");
 							return false;
 						}
 					} else {
-						Log.MTError (7060, $"Merge: Entry, \"{Entry}\", Does Not Exist");
+						Log.LogError (7060, PropertyList, $"Merge: Entry, \"{Entry}\", Does Not Exist");
 						return false;
 					}
 
@@ -434,12 +434,12 @@ namespace Xamarin.MacDev.Tasks
 				if (array != null) {
 					if (i > 0 || path[i].Length > 0) {
 						if (!int.TryParse (path[i], out index) || index < 0) {
-							Log.MTError (7059, $"Merge: Entry, \"{Entry}\", Contains Invalid Array Index");
+							Log.LogError (7059, PropertyList, $"Merge: Entry, \"{Entry}\", Contains Invalid Array Index");
 							return false;
 						}
 
 						if (index >= array.Count) {
-							Log.MTError (7060, $"Merge: Entry, \"{Entry}\", Does Not Exist");
+							Log.LogError (7060, PropertyList, $"Merge: Entry, \"{Entry}\", Does Not Exist");
 							return false;
 						}
 
@@ -451,7 +451,7 @@ namespace Xamarin.MacDev.Tasks
 					try {
 						value = PObject.FromFile (Value);
 					} catch {
-						Log.MTError (7061, $"Merge: Error Reading File: {Value}", Value);
+						Log.LogError (7061, PropertyList, $"Merge: Error Reading File: {Value}", Value);
 						return false;
 					}
 
@@ -461,7 +461,7 @@ namespace Xamarin.MacDev.Tasks
 				if (dict != null) {
 					if (i > 0 || path[i].Length > 0) {
 						if (!dict.TryGetValue (path[i], out root)) {
-							Log.MTError (7060, $"Merge: Entry, \"{Entry}\", Does Not Exist");
+							Log.LogError (7060, PropertyList, $"Merge: Entry, \"{Entry}\", Does Not Exist");
 							return false;
 						}
 					} else {
@@ -471,14 +471,14 @@ namespace Xamarin.MacDev.Tasks
 					try {
 						value = PObject.FromFile (Value);
 					} catch {
-						Log.MTError (7061, $"Merge: Error Reading File: {Value}", Value);
+						Log.LogError (7061, PropertyList, $"Merge: Error Reading File: {Value}", Value);
 						return false;
 					}
 
 					return Merge (root, value);
 				}
 
-				Log.MTError (7060, $"Merge: Entry, \"{Entry}\", Does Not Exist");
+				Log.LogError (7060, PropertyList, $"Merge: Entry, \"{Entry}\", Does Not Exist");
 				return false;
 			} else {
 				PObject value;
@@ -486,7 +486,7 @@ namespace Xamarin.MacDev.Tasks
 				try {
 					value = PObject.FromFile (Value);
 				} catch {
-					Log.MTError (7061, $"Merge: Error Reading File: {Value}", Value);
+					Log.LogError (7061, PropertyList, $"Merge: Error Reading File: {Value}", Value);
 					return false;
 				}
 
@@ -505,7 +505,7 @@ namespace Xamarin.MacDev.Tasks
 			int i = 0;
 
 			if (path.Length == 0) {
-				Log.MTError (7062, $"Set: Entry, \"{Entry}\", Incorrectly Specified");
+				Log.LogError (7062, PropertyList, $"Set: Entry, \"{Entry}\", Incorrectly Specified");
 				return false;
 			}
 
@@ -515,23 +515,23 @@ namespace Xamarin.MacDev.Tasks
 
 				if (array != null) {
 					if (!int.TryParse (path[i], out index) || index < 0) {
-						Log.MTError (7063, $"Set: Entry, \"{Entry}\", Contains Invalid Array Index");
+						Log.LogError (7063, PropertyList, $"Set: Entry, \"{Entry}\", Contains Invalid Array Index");
 						return false;
 					}
 
 					if (index >= array.Count) {
-						Log.MTError (7064, $"Set: Entry, \"{Entry}\", Does Not Exist");
+						Log.LogError (7064, PropertyList, $"Set: Entry, \"{Entry}\", Does Not Exist");
 						return false;
 					}
 
 					current = array[index];
 				} else if (dict != null) {
 					if (!dict.TryGetValue (path[i], out current)) {
-						Log.MTError (7064, $"Set: Entry, \"{Entry}\", Does Not Exist");
+						Log.LogError (7064, PropertyList, $"Set: Entry, \"{Entry}\", Does Not Exist");
 						return false;
 					}
 				} else {
-					Log.MTError (7064, $"Set: Entry, \"{Entry}\", Does Not Exist");
+					Log.LogError (7064, PropertyList, $"Set: Entry, \"{Entry}\", Does Not Exist");
 					return false;
 				}
 
@@ -543,12 +543,12 @@ namespace Xamarin.MacDev.Tasks
 
 			if (array != null) {
 				if (!int.TryParse (path[i], out index) || index < 0) {
-					Log.MTError (7063, $"Set: Entry, \"{Entry}\", Contains Invalid Array Index");
+					Log.LogError (7063, PropertyList, $"Set: Entry, \"{Entry}\", Contains Invalid Array Index");
 					return false;
 				}
 
 				if (index >= array.Count) {
-					Log.MTError (7064, $"Set: Entry, \"{Entry}\", Does Not Exist");
+					Log.LogError (7064, PropertyList, $"Set: Entry, \"{Entry}\", Does Not Exist");
 					return false;
 				}
 
@@ -558,7 +558,7 @@ namespace Xamarin.MacDev.Tasks
 				array[index] = value;
 			} else if (dict != null) {
 				if (!dict.TryGetValue (path[i], out value)) {
-					Log.MTError (7064, $"Set: Entry, \"{Entry}\", Does Not Exist");
+					Log.LogError (7064, PropertyList, $"Set: Entry, \"{Entry}\", Does Not Exist");
 					return false;
 				}
 
@@ -570,7 +570,7 @@ namespace Xamarin.MacDev.Tasks
 
 				dict[path[i]] = value;
 			} else {
-				Log.MTError (7064, $"Set: Entry, \"{Entry}\", Does Not Exist");
+				Log.LogError (7064, PropertyList, $"Set: Entry, \"{Entry}\", Does Not Exist");
 				return false;
 			}
 
@@ -584,7 +584,7 @@ namespace Xamarin.MacDev.Tasks
 			bool binary;
 
 			if (!Enum.TryParse (Action, out action)) {
-				Log.MTError (7065, $"Unknown PropertyList editor action: {Action}");
+				Log.LogError (7065, null, $"Unknown PropertyList editor action: {Action}");
 				return false;
 			}
 
@@ -592,7 +592,7 @@ namespace Xamarin.MacDev.Tasks
 				try {
 					plist = PObject.FromFile (PropertyList, out binary);
 				} catch (Exception ex) {
-					Log.MTError (7066, $"Error loading '{PropertyList}': {ex.Message}", PropertyList);
+					Log.LogError (7066, PropertyList, $"Error loading '{PropertyList}': {ex.Message}", PropertyList);
 					return false;
 				}
 			} else {
@@ -630,7 +630,7 @@ namespace Xamarin.MacDev.Tasks
 						File.WriteAllText (PropertyList, plist.ToXml ());
 					}
 				} catch (Exception ex) {
-					Log.MTError (7067, $"Error saving '{PropertyList}': {ex.Message}", PropertyList);
+					Log.LogError (7067, PropertyList, $"Error saving '{PropertyList}': {ex.Message}", PropertyList);
 				}
 			}
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectDebugNetworkConfigurationTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectDebugNetworkConfigurationTaskBase.cs
@@ -66,7 +66,7 @@ namespace Xamarin.iOS.Tasks
 
 								ips.Add (ipEndPoint.Address.ToString ());
 							} catch {
-								Log.MTError (7001, "Could not resolve host IPs for WiFi debugger settings.");
+								Log.LogError (7001, null, "Could not resolve host IPs for WiFi debugger settings.");
 								return false;
 							}
 						}
@@ -81,7 +81,7 @@ namespace Xamarin.iOS.Tasks
 				}
 
 				if (ips == null || ips.Count == 0) {
-					Log.MTError (7002, "This machine does not have any network adapters. This is required when debugging or profiling on device over WiFi.");
+					Log.LogError (7002, null, "This machine does not have any network adapters. This is required when debugging or profiling on device over WiFi.");
 					return false;
 				}
 			}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
@@ -88,7 +88,6 @@ namespace Xamarin.iOS.Tasks
 
 		public override bool Execute ()
 		{
-			var name = typeof (LoggingExtensions).Assembly.FullName;
 			AppleSdkSettings.Init ();
 			IPhoneSdks.Reload ();
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
@@ -88,6 +88,7 @@ namespace Xamarin.iOS.Tasks
 
 		public override bool Execute ()
 		{
+			var name = typeof (LoggingExtensions).Assembly.FullName;
 			AppleSdkSettings.Init ();
 			IPhoneSdks.Reload ();
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
@@ -36,7 +36,7 @@ namespace Xamarin.iOS.Tasks
 			var name = Path.GetFileNameWithoutExtension (path);
 			var info = Path.Combine (path, "Info.plist");
 			if (!File.Exists (info)) {
-				Log.MTError (7003, $"The App Extension '{name}' does not contain an Info.plist.");
+				Log.LogError (7003, path, $"The App Extension '{name}' does not contain an Info.plist.");
 				return;
 			}
 
@@ -44,7 +44,7 @@ namespace Xamarin.iOS.Tasks
 
 			var bundleIdentifier = plist.GetCFBundleIdentifier ();
 			if (string.IsNullOrEmpty (bundleIdentifier)) {
-				Log.MTError (7004, $"The App Extension '{name}' does not specify a CFBundleIdentifier.");
+				Log.LogError (7004, info, $"The App Extension '{name}' does not specify a CFBundleIdentifier.");
 				return;
 			}
 
@@ -54,17 +54,17 @@ namespace Xamarin.iOS.Tasks
 
 			var executable = plist.GetCFBundleExecutable ();
 			if (string.IsNullOrEmpty (executable))
-				Log.MTError (7005, $"The App Extension '{name}' does not specify a CFBundleExecutable.");
+				Log.LogError (7005, info, $"The App Extension '{name}' does not specify a CFBundleExecutable.");
 
 			if (!bundleIdentifier.StartsWith (mainBundleIdentifier + ".", StringComparison.Ordinal))
-				Log.MTError (7006, $"The App Extension '{name}' has an invalid CFBundleIdentifier ({bundleIdentifier}), it does not begin with the main app bundle's CFBundleIdentifier ({mainBundleIdentifier}).");
+				Log.LogError (7006, info, $"The App Extension '{name}' has an invalid CFBundleIdentifier ({bundleIdentifier}), it does not begin with the main app bundle's CFBundleIdentifier ({mainBundleIdentifier}).");
 
 			if (bundleIdentifier.EndsWith (".key", StringComparison.Ordinal))
-				Log.MTError (7007, $"The App Extension '{name}' has a CFBundleIdentifier ({bundleIdentifier}) that ends with the illegal suffix \".key\".");
+				Log.LogError (7007, info, $"The App Extension '{name}' has a CFBundleIdentifier ({bundleIdentifier}) that ends with the illegal suffix \".key\".");
 
 			var shortVersionString = plist.GetCFBundleShortVersionString ();
 			if (string.IsNullOrEmpty (shortVersionString))
-				Log.MTError (7008, $"The App Extension '{name}' does not specify a CFBundleShortVersionString.");
+				Log.LogError (7008, info, $"The App Extension '{name}' does not specify a CFBundleShortVersionString.");
 
 			if (shortVersionString != mainShortVersionString)
 				Log.LogWarning ("The App Extension '{0}' has a CFBundleShortVersionString ({1}) that does not match the main app bundle's CFBundleShortVersionString ({2})", name, shortVersionString, mainShortVersionString);
@@ -78,14 +78,14 @@ namespace Xamarin.iOS.Tasks
 
 			var extension = plist.Get<PDictionary> ("NSExtension");
 			if (extension == null) {
-				Log.MTError (7009, $"The App Extension '{name}' has an invalid Info.plist: it does not contain an NSExtension dictionary.");
+				Log.LogError (7009, info, $"The App Extension '{name}' has an invalid Info.plist: it does not contain an NSExtension dictionary.");
 				return;
 			}
 
 			var extensionPointIdentifier = extension.GetString ("NSExtensionPointIdentifier").Value;
 
 			if (string.IsNullOrEmpty (extensionPointIdentifier)) {
-				Log.MTError (7010, $"The App Extension '{name}' has an invalid Info.plist: the NSExtension dictionary does not contain an NSExtensionPointIdentifier value.");
+				Log.LogError (7010, info, $"The App Extension '{name}' has an invalid Info.plist: the NSExtension dictionary does not contain an NSExtensionPointIdentifier value.");
 				return;
 			}
 
@@ -118,16 +118,16 @@ namespace Xamarin.iOS.Tasks
 				var attributes = extension.Get<PDictionary> ("NSExtensionAttributes");
 
 				if (attributes == null) {
-					Log.MTError (7011, $"The WatchKit Extension '{name}' has an invalid Info.plist: the NSExtension dictionary does not contain an NSExtensionAttributes dictionary.");
+					Log.LogError (7011, info, $"The WatchKit Extension '{name}' has an invalid Info.plist: the NSExtension dictionary does not contain an NSExtensionAttributes dictionary.");
 					return;
 				}
 
 				var wkAppBundleIdentifier = attributes.GetString ("WKAppBundleIdentifier").Value;
 				var apps = Directory.GetDirectories (path, "*.app");
 				if (apps.Length == 0) {
-					Log.MTError (7012, $"The WatchKit Extension '{name}' does not contain any watch apps.");
+					Log.LogError (7012, info, $"The WatchKit Extension '{name}' does not contain any watch apps.");
 				} else if (apps.Length > 1) {
-					Log.MTError (7012, $"The WatchKit Extension '{name}' contain more than one watch apps.");
+					Log.LogError (7012, info, $"The WatchKit Extension '{name}' contain more than one watch apps.");
 				} else {
 					PObject requiredDeviceCapabilities;
 
@@ -139,15 +139,15 @@ namespace Xamarin.iOS.Tasks
 							PBoolean watchCompanion;
 
 							if (!requiredDeviceCapabilitiesDictionary.TryGetValue ("watch-companion", out watchCompanion) || !watchCompanion.Value)
-								Log.MTError (7013, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities dictionary must contain the 'watch-companion' capability with a value of 'true'.");
+								Log.LogError (7013, info, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities dictionary must contain the 'watch-companion' capability with a value of 'true'.");
 						} else if (requiredDeviceCapabilitiesArray != null) {
 							if (!requiredDeviceCapabilitiesArray.OfType<PString> ().Any (x => x.Value == "watch-companion"))
-								Log.MTError (7013, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities array must contain the 'watch-companion' capability.");
+								Log.LogError (7013, info, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities array must contain the 'watch-companion' capability.");
 						} else {
-							Log.MTError (7013, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities key must be present and contain the 'watch-companion' capability.");
+							Log.LogError (7013, info, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities key must be present and contain the 'watch-companion' capability.");
 						}
 					} else {
-						Log.MTError (7013, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities key must be present and contain the 'watch-companion' capability.");
+						Log.LogError (7013, info, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities key must be present and contain the 'watch-companion' capability.");
 					}
 
 					ValidateWatchOS1App (apps[0], name, mainBundleIdentifier, wkAppBundleIdentifier);
@@ -164,19 +164,19 @@ namespace Xamarin.iOS.Tasks
 			var name = Path.GetFileNameWithoutExtension (path);
 			var info = Path.Combine (path, "Info.plist");
 			if (!File.Exists (info)) {
-				Log.MTError (7014, $"The Watch App '{name}' does not contain an Info.plist.");
+				Log.LogError (7014, path, $"The Watch App '{name}' does not contain an Info.plist.");
 				return;
 			}
 
 			var plist = PDictionary.FromFile (info);
 			var bundleIdentifier = plist.GetCFBundleIdentifier ();
 			if (string.IsNullOrEmpty (bundleIdentifier)) {
-				Log.MTError (7015, $"The Watch App '{name}' does not specify a CFBundleIdentifier.");
+				Log.LogError (7015, info, $"The Watch App '{name}' does not specify a CFBundleIdentifier.");
 				return;
 			}
 
 			if (!bundleIdentifier.StartsWith (mainBundleIdentifier + ".", StringComparison.Ordinal))
-				Log.MTError (7016, $"The Watch App '{name}' has an invalid CFBundleIdentifier ({bundleIdentifier}), it does not begin with the main app bundle's CFBundleIdentifier ({mainBundleIdentifier}).");
+				Log.LogError (7016, info, $"The Watch App '{name}' has an invalid CFBundleIdentifier ({bundleIdentifier}), it does not begin with the main app bundle's CFBundleIdentifier ({mainBundleIdentifier}).");
 
 			var shortVersionString = plist.GetCFBundleShortVersionString ();
 			if (string.IsNullOrEmpty (shortVersionString))
@@ -194,26 +194,26 @@ namespace Xamarin.iOS.Tasks
 
 			var watchDeviceFamily = plist.GetUIDeviceFamily ();
 			if (watchDeviceFamily != IPhoneDeviceType.Watch)
-				Log.MTError (7017, $"The Watch App '{name}' does not have a valid UIDeviceFamily value. Expected 'Watch (4)' but found '{watchDeviceFamily.ToString ()} ({(int)watchDeviceFamily})'.");
+				Log.LogError (7017, info, $"The Watch App '{name}' does not have a valid UIDeviceFamily value. Expected 'Watch (4)' but found '{watchDeviceFamily.ToString ()} ({(int)watchDeviceFamily})'.");
 
 			var watchExecutable = plist.GetCFBundleExecutable ();
 			if (string.IsNullOrEmpty (watchExecutable))
-				Log.MTError (7018, $"The Watch App '{name}' does not specify a CFBundleExecutable");
+				Log.LogError (7018, info, $"The Watch App '{name}' does not specify a CFBundleExecutable");
 
 			var wkCompanionAppBundleIdentifier = plist.GetString ("WKCompanionAppBundleIdentifier").Value;
 			if (wkCompanionAppBundleIdentifier != mainBundleIdentifier)
-				Log.MTError (7019, $"The Watch App '{name}' has an invalid WKCompanionAppBundleIdentifier value ('{wkCompanionAppBundleIdentifier}'), it does not match the main app bundle's CFBundleIdentifier ('{mainBundleIdentifier}').");
+				Log.LogError (7019, info, $"The Watch App '{name}' has an invalid WKCompanionAppBundleIdentifier value ('{wkCompanionAppBundleIdentifier}'), it does not match the main app bundle's CFBundleIdentifier ('{mainBundleIdentifier}').");
 
 			PBoolean watchKitApp;
 			if (!plist.TryGetValue ("WKWatchKitApp", out watchKitApp) || !watchKitApp.Value)
-				Log.MTError (7020, $"The Watch App '{name}' has an invalid Info.plist: the WKWatchKitApp key must be present and have a value of 'true'.");
+				Log.LogError (7020, info, $"The Watch App '{name}' has an invalid Info.plist: the WKWatchKitApp key must be present and have a value of 'true'.");
 
 			if (plist.ContainsKey ("LSRequiresIPhoneOS"))
-				Log.MTError (7021, $"The Watch App '{name}' has an invalid Info.plist: the LSRequiresIPhoneOS key must not be present.");
+				Log.LogError (7021, info, $"The Watch App '{name}' has an invalid Info.plist: the LSRequiresIPhoneOS key must not be present.");
 
 			var pluginsDir = Path.Combine (path, "PlugIns");
 			if (!Directory.Exists (pluginsDir)) {
-				Log.MTError (7022, $"The Watch App '{name}' does not contain any Watch Extensions.");
+				Log.LogError (7022, path, $"The Watch App '{name}' does not contain any Watch Extensions.");
 				return;
 			}
 
@@ -224,7 +224,7 @@ namespace Xamarin.iOS.Tasks
 			}
 
 			if (count == 0)
-				Log.MTError (7022, $"The Watch App '{name}' does not contain a Watch Extension.");
+				Log.LogError (7022, pluginsDir, $"The Watch App '{name}' does not contain a Watch Extension.");
 		}
 
 		void ValidateWatchExtension (string path, string watchAppBundleIdentifier, string mainShortVersionString, string mainVersion)
@@ -232,7 +232,7 @@ namespace Xamarin.iOS.Tasks
 			var name = Path.GetFileNameWithoutExtension (path);
 			var info = Path.Combine (path, "Info.plist");
 			if (!File.Exists (info)) {
-				Log.MTError (7023, $"The Watch Extension '{name}' does not contain an Info.plist.");
+				Log.LogError (7023, path, $"The Watch Extension '{name}' does not contain an Info.plist.");
 				return;
 			}
 
@@ -240,7 +240,7 @@ namespace Xamarin.iOS.Tasks
 
 			var bundleIdentifier = plist.GetCFBundleIdentifier ();
 			if (string.IsNullOrEmpty (bundleIdentifier)) {
-				Log.MTError (7024, $"The Watch Extension '{name}' does not specify a CFBundleIdentifier.");
+				Log.LogError (7024, info, $"The Watch Extension '{name}' does not specify a CFBundleIdentifier.");
 				return;
 			}
 
@@ -250,13 +250,13 @@ namespace Xamarin.iOS.Tasks
 
 			var executable = plist.GetCFBundleExecutable ();
 			if (string.IsNullOrEmpty (executable))
-				Log.MTError (7025, $"The Watch Extension '{name}' does not specify a CFBundleExecutable.");
+				Log.LogError (7025, info, $"The Watch Extension '{name}' does not specify a CFBundleExecutable.");
 
 			if (!bundleIdentifier.StartsWith (watchAppBundleIdentifier + ".", StringComparison.Ordinal))
-				Log.MTError (7026, $"The Watch Extension '{name}' has an invalid CFBundleIdentifier ({bundleIdentifier}), it does not begin with the main app bundle's CFBundleIdentifier ({watchAppBundleIdentifier}).");
+				Log.LogError (7026, info, $"The Watch Extension '{name}' has an invalid CFBundleIdentifier ({bundleIdentifier}), it does not begin with the main app bundle's CFBundleIdentifier ({watchAppBundleIdentifier}).");
 
 			if (bundleIdentifier.EndsWith (".key", StringComparison.Ordinal))
-				Log.MTError (7027, $"The Watch Extension '{name}' has a CFBundleIdentifier ({bundleIdentifier}) that ends with the illegal suffix \".key\".");
+				Log.LogError (7027, info, $"The Watch Extension '{name}' has a CFBundleIdentifier ({bundleIdentifier}) that ends with the illegal suffix \".key\".");
 
 			var shortVersionString = plist.GetCFBundleShortVersionString ();
 			if (string.IsNullOrEmpty (shortVersionString))
@@ -274,30 +274,30 @@ namespace Xamarin.iOS.Tasks
 
 			var extension = plist.Get<PDictionary> ("NSExtension");
 			if (extension == null) {
-				Log.MTError (7028, $"The Watch Extension '{name}' has an invalid Info.plist: it does not contain an NSExtension dictionary.");
+				Log.LogError (7028, info, $"The Watch Extension '{name}' has an invalid Info.plist: it does not contain an NSExtension dictionary.");
 				return;
 			}
 
 			var extensionPointIdentifier = extension.Get<PString> ("NSExtensionPointIdentifier");
 			if (extensionPointIdentifier != null) {
 				if (extensionPointIdentifier.Value != "com.apple.watchkit")
-					Log.MTError (7029, $"The Watch Extension '{name}' has an invalid Info.plist: the NSExtensionPointIdentifier must be \"com.apple.watchkit\".");
+					Log.LogError (7029, info, $"The Watch Extension '{name}' has an invalid Info.plist: the NSExtensionPointIdentifier must be \"com.apple.watchkit\".");
 			} else {
-				Log.MTError (7029, $"The Watch Extension '{name}' has an invalid Info.plist: the NSExtension dictionary must contain an NSExtensionPointIdentifier.");
+				Log.LogError (7029, info, $"The Watch Extension '{name}' has an invalid Info.plist: the NSExtension dictionary must contain an NSExtensionPointIdentifier.");
 			}
 
 			PDictionary attributes;
 			if (!extension.TryGetValue ("NSExtensionAttributes", out attributes)) {
-				Log.MTError (7030, $"The Watch Extension '{name}' has an invalid Info.plist: the NSExtension dictionary must contain NSExtensionAttributes.");
+				Log.LogError (7030, info, $"The Watch Extension '{name}' has an invalid Info.plist: the NSExtension dictionary must contain NSExtensionAttributes.");
 				return;
 			}
 
 			var appBundleIdentifier = attributes.Get<PString> ("WKAppBundleIdentifier");
 			if (appBundleIdentifier != null) {
 				if (appBundleIdentifier.Value != watchAppBundleIdentifier)
-					Log.MTError (7031, $"The Watch Extension '{name}' has an invalid WKAppBundleIdentifier value ('{appBundleIdentifier.Value}'), it does not match the parent Watch App bundle's CFBundleIdentifier ('{watchAppBundleIdentifier}').");
+					Log.LogError (7031, info, $"The Watch Extension '{name}' has an invalid WKAppBundleIdentifier value ('{appBundleIdentifier.Value}'), it does not match the parent Watch App bundle's CFBundleIdentifier ('{watchAppBundleIdentifier}').");
 			} else {
-				Log.MTError (7031, $"The Watch Extension '{name}' has an invalid Info.plist: the NSExtensionAttributes dictionary must contain a WKAppBundleIdentifier.");
+				Log.LogError (7031, info, $"The Watch Extension '{name}' has an invalid Info.plist: the NSExtensionAttributes dictionary must contain a WKAppBundleIdentifier.");
 			}
 
 			PObject requiredDeviceCapabilities;
@@ -310,10 +310,10 @@ namespace Xamarin.iOS.Tasks
 					PBoolean watchCompanion;
 
 					if (requiredDeviceCapabilitiesDictionary.TryGetValue ("watch-companion", out watchCompanion))
-						Log.MTError (7032, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities dictionary should not contain the 'watch-companion' capability.");
+						Log.LogError (7032, info, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities dictionary should not contain the 'watch-companion' capability.");
 				} else if (requiredDeviceCapabilitiesArray != null) {
 					if (requiredDeviceCapabilitiesArray.OfType<PString> ().Any (x => x.Value == "watch-companion"))
-						Log.MTError (7032, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities array should not contain the 'watch-companion' capability.");
+						Log.LogError (7032, info, $"The WatchKit Extension '{name}' has an invalid Info.plist: the UIRequiredDeviceCapabilities array should not contain the 'watch-companion' capability.");
 				}
 			}
 		}
@@ -323,14 +323,14 @@ namespace Xamarin.iOS.Tasks
 			var name = Path.GetFileNameWithoutExtension (path);
 			var info = Path.Combine (path, "Info.plist");
 			if (!File.Exists (info)) {
-				Log.MTError (7033, $"The Watch App '{name}' does not contain an Info.plist.");
+				Log.LogError (7033, path, $"The Watch App '{name}' does not contain an Info.plist.");
 				return;
 			}
 
 			var plist = PDictionary.FromFile (info);
 			var bundleIdentifier = plist.GetCFBundleIdentifier ();
 			if (string.IsNullOrEmpty (bundleIdentifier)) {
-				Log.MTError (7034, $"The Watch App '{name}' does not specify a CFBundleIdentifier.");
+				Log.LogError (7034, info, $"The Watch App '{name}' does not specify a CFBundleIdentifier.");
 				return;
 			}
 
@@ -346,32 +346,32 @@ namespace Xamarin.iOS.Tasks
 			}
 
 			if (deviceFamily != expectedDeviceFamily)
-				Log.MTError (7035, $"The Watch App '{name}' does not have a valid UIDeviceFamily value. Expected '{expectedDeviceFamilyString}' but found '{deviceFamily.ToString ()} ({(int)deviceFamily})'.");
+				Log.LogError (7035, info, $"The Watch App '{name}' does not have a valid UIDeviceFamily value. Expected '{expectedDeviceFamilyString}' but found '{deviceFamily.ToString ()} ({(int)deviceFamily})'.");
 
 			var executable = plist.GetCFBundleExecutable ();
 			if (string.IsNullOrEmpty (executable))
-				Log.MTError (7036, $"The Watch App '{name}' does not specify a CFBundleExecutable.");
+				Log.LogError (7036, info, $"The Watch App '{name}' does not specify a CFBundleExecutable.");
 
 			if (bundleIdentifier != wkAppBundleIdentifier)
-				Log.MTError (7037, $"The WatchKit Extension '{extensionName}' has an invalid WKAppBundleIdentifier value ('{wkAppBundleIdentifier}'), it does not match the Watch App's CFBundleIdentifier ('{bundleIdentifier}').");
+				Log.LogError (7037, info, $"The WatchKit Extension '{extensionName}' has an invalid WKAppBundleIdentifier value ('{wkAppBundleIdentifier}'), it does not match the Watch App's CFBundleIdentifier ('{bundleIdentifier}').");
 
 			var companionAppBundleIdentifier = plist.Get<PString> ("WKCompanionAppBundleIdentifier");
 			if (companionAppBundleIdentifier != null) {
 				if (companionAppBundleIdentifier.Value != mainBundleIdentifier)
-					Log.MTError (7038, $"The Watch App '{name}' has an invalid WKCompanionAppBundleIdentifier value ('{companionAppBundleIdentifier.Value}'), it does not match the main app bundle's CFBundleIdentifier ('{mainBundleIdentifier}').");
+					Log.LogError (7038, info, $"The Watch App '{name}' has an invalid WKCompanionAppBundleIdentifier value ('{companionAppBundleIdentifier.Value}'), it does not match the main app bundle's CFBundleIdentifier ('{mainBundleIdentifier}').");
 			} else {
-				Log.MTError (7038, $"The Watch App '{name}' has an invalid Info.plist: the WKCompanionAppBundleIdentifier must exist and must match the main app bundle's CFBundleIdentifier.");
+				Log.LogError (7038, info, $"The Watch App '{name}' has an invalid Info.plist: the WKCompanionAppBundleIdentifier must exist and must match the main app bundle's CFBundleIdentifier.");
 			}
 
 			if (plist.ContainsKey ("LSRequiresIPhoneOS"))
-				Log.MTError (7039, $"The Watch App '{name}' has an invalid Info.plist: the LSRequiresIPhoneOS key must not be present.");
+				Log.LogError (7039, info, $"The Watch App '{name}' has an invalid Info.plist: the LSRequiresIPhoneOS key must not be present.");
 		}
 
 		public override bool Execute ()
 		{
 			var mainInfoPath = Path.Combine (AppBundlePath, "Info.plist");
 			if (!File.Exists (mainInfoPath)) {
-				Log.MTError (7040, $"The app bundle {AppBundlePath} does not contain an Info.plist.");
+				Log.LogError (7040, AppBundlePath, $"The app bundle {AppBundlePath} does not contain an Info.plist.");
 				return false;
 			}
 
@@ -379,18 +379,18 @@ namespace Xamarin.iOS.Tasks
 
 			var bundleIdentifier = plist.GetCFBundleIdentifier ();
 			if (string.IsNullOrEmpty (bundleIdentifier)) {
-				Log.MTError (7041, $"{mainInfoPath} does not specify a CFBundleIdentifier.");
+				Log.LogError (7041, mainInfoPath, $"{mainInfoPath} does not specify a CFBundleIdentifier.");
 				return false;
 			}
 
 			var executable = plist.GetCFBundleExecutable ();
 			if (string.IsNullOrEmpty (executable))
-				Log.MTError (7042, $"{mainInfoPath} does not specify a CFBundleExecutable.");
+				Log.LogError (7042, mainInfoPath, $"{mainInfoPath} does not specify a CFBundleExecutable.");
 
 			var supportedPlatforms = plist.GetArray (ManifestKeys.CFBundleSupportedPlatforms);
 			var platform = string.Empty;
 			if (supportedPlatforms == null || supportedPlatforms.Count == 0) {
-				Log.MTError (7043, $"{mainInfoPath} does not specify a CFBundleSupportedPlatforms.");
+				Log.LogError (7043, mainInfoPath, $"{mainInfoPath} does not specify a CFBundleSupportedPlatforms.");
 			} else {
 				platform = (PString) supportedPlatforms[0];
 			}
@@ -421,11 +421,11 @@ namespace Xamarin.iOS.Tasks
 
 			if (validFamilies != null) {
 				if (validFamilies.Length == 0) {
-					Log.MTError (7044, $"{mainInfoPath} does not specify a UIDeviceFamily.");
+					Log.LogError (7044, mainInfoPath, $"{mainInfoPath} does not specify a UIDeviceFamily.");
 				} else {
 					foreach (var family in deviceFamilies) {
 						if (Array.IndexOf (validFamilies, family) == -1) {
-							Log.MTError (7044, $"{mainInfoPath} is invalid: the UIDeviceFamily key must contain a value for '{family}'.");
+							Log.LogError (7044, mainInfoPath, $"{mainInfoPath} is invalid: the UIDeviceFamily key must contain a value for '{family}'.");
 						}
 					}
 				}


### PR DESCRIPTION
Up until now, when building Xamarin.Mac projects, any existing errors in MSBuild that have already been error-codeified would always log the error using the MT prefix instead of MM.

This fixes that and also makes logging more consistent with the base logging methods, but allowing for a more simplified integer error code value rather than a string.
