### PR TITLE
[generator] Ensure we don't generate code that creates pointers to local variables that then go out of scope.

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3931,11 +3931,12 @@ public partial class Generator : IMemberGatherer {
 					var et = pi.ParameterType.GetElementType ();
 					var nullable = TypeManager.GetUnderlyingNullableType (et);
 					if (nullable != null) {
-						convs.Append ("var converted = IntPtr.Zero;");
-						convs.Append ("if (value.HasValue) {");
-						convs.Append ("\tvar v = value.Value;");
-						convs.Append ("\tconverted = new IntPtr (&v);");
-						convs.Append ("}");
+						convs.Append ("var converted = IntPtr.Zero;\n");
+						convs.Append ($"var v = default ({FormatType (mi.DeclaringType, nullable)});\n");
+						convs.Append ("if (value.HasValue) {\n");
+						convs.Append ("\tv = value.Value;\n");
+						convs.Append ("\tconverted = new IntPtr (&v);\n");
+						convs.Append ("}\n");
 					}
 				}
 			}


### PR DESCRIPTION
Instead of generating the following:

```csharp
var converted = IntPtr.Zero;
if (value.HasValue) {
	var v = value.Value;
	converted = new IntPtr (&v);
}
// now 'converted' points to a local variable that is out of scope
```

do this:

```csharp
var converted = IntPtr.Zero;
var v = default (float);
if (value.HasValue) {
	v = value.Value;
	converted = new IntPtr (&v);
}
// now 'converted' points to a local variable that's still in scope
```

so that we don't store a pointer to a local variable and use that pointer
after the local variable has gone out of scope.

I'm not entirely sure this really is a problem in C#, but it doesn't hurt to
be on the safe side.

Also add newlines to the generated code to make it look nicer.

Generator diff: https://gist.github.com/rolfbjarne/225d920b7fa28d07fbeab13754cebd2a