### PR TITLE
[mmptest] Fix compiler warning by not including code we get from a reference.

### DIFF
--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -76,9 +76,6 @@
     <Compile Include="..\mtouch\Cache.cs">
       <Link>Cache.cs</Link>
     </Compile>
-    <Compile Include="..\..\tools\common\StringUtils.cs">
-      <Link>StringUtils.cs</Link>
-    </Compile>
     <Compile Include="src\NetStandardTests.cs" />
     <Compile Include="..\common\ProductTests.cs">
       <Link>ProductTests.cs</Link>


### PR DESCRIPTION
Fixes this:

    tests/common/mac/ProjectTestHelpers.cs(154,22): warning CS0436: The type 'StringUtils' in 'tests/mmptest/../../tools/common/StringUtils.cs' conflicts with the imported type 'StringUtils' in 'mmp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/mmptest/../../tools/common/StringUtils.cs'.
    tests/common/Configuration.cs(162,53): warning CS0436: The type 'StringUtils' in 'tests/mmptest/../../tools/common/StringUtils.cs' conflicts with the imported type 'StringUtils' in 'mmp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'tests/mmptest/../../tools/common/StringUtils.cs'.