### PR TITLE
[tests] Build the native test library for macOS and create a binding project for it.

### DIFF
--- a/tests/api-shared/ObjCRuntime/Registrar.cs
+++ b/tests/api-shared/ObjCRuntime/Registrar.cs
@@ -11,7 +11,7 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-#if XAMCORE_2_0
+#if __UNIFIED__
 using Foundation;
 using ObjCRuntime;
 #elif __IOS__

--- a/tests/bindings-test/ApiDefinition.cs
+++ b/tests/bindings-test/ApiDefinition.cs
@@ -6,7 +6,11 @@ using System.Drawing;
 #if __UNIFIED__
 using ObjCRuntime;
 using Foundation;
+#if __MACOS__
+using AppKit;
+#else
 using UIKit;
+#endif
 #else
 using MonoTouch.ObjCRuntime;
 using MonoTouch.Foundation;

--- a/tests/bindings-test/ApiProtocol.cs
+++ b/tests/bindings-test/ApiProtocol.cs
@@ -6,7 +6,11 @@ using System.Drawing;
 #if __UNIFIED__
 using ObjCRuntime;
 using Foundation;
+#if __MACOS__
+using AppKit;
+#else
 using UIKit;
+#endif
 #else
 using MonoTouch.ObjCRuntime;
 using MonoTouch.Foundation;

--- a/tests/bindings-test/bindings-test-mac.csproj
+++ b/tests/bindings-test/bindings-test-mac.csproj
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{20BEA313-7E2D-4209-93C0-E4D99C72695A}</ProjectGuid>
+    <ProjectTypeGuids>{810C163F-4746-4721-8B8E-88A3673A62EA};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>bindingstestmac</RootNamespace>
+    <AssemblyName>bindings-test-mac</AssemblyName>
+    <MacResourcePrefix>Resources</MacResourcePrefix>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <DefineConstants></DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.Mac" />
+  </ItemGroup>
+  <ItemGroup>
+    <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+    <ObjcBindingApiDefinition Include="ApiDefinition.generated.cs" />
+    <ObjcBindingApiDefinition Include="ApiProtocol.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ObjcBindingCoreSource Include="StructsAndEnums.cs" />
+    <ObjcBindingCoreSource Include="StructsAndEnums.generated.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.ObjcBinding.CSharp.targets" />
+  <PropertyGroup>
+    <TestLibrariesDirectory>..\..\tests\test-libraries</TestLibrariesDirectory>
+  </PropertyGroup>
+  <ItemGroup>
+    <ObjcBindingNativeLibrary Include="..\..\tests\test-libraries\.libs\macos\libtest.a">
+      <Link>libtest.a</Link>
+    </ObjcBindingNativeLibrary>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\common\ConditionalCompilation.cs">
+      <Link>ConditionalCompilation.cs</Link>
+    </Compile>
+    <Compile Include="libtest.linkwith.cs">
+      <DependentUpon>libtest.a</DependentUpon>
+    </Compile>
+    <Compile Include="ProtocolTest.cs" />
+    <Compile Include="..\api-shared\ObjCRuntime\Registrar.cs">
+      <Link>Registrar.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\tests\test-libraries\libtest.m">
+      <Link>libtest.m</Link>
+    </None>
+    <None Include="..\..\tests\test-libraries\libtest.h">
+      <Link>libtest.h</Link>
+    </None>
+    <None Include="..\..\tests\test-libraries\libtest.structs.h">
+      <Link>libtest.structs.h</Link>
+    </None>
+    <None Include="..\..\tests\test-libraries\libtest.properties.h">
+      <Link>libtest.properties.h</Link>
+    </None>
+    <None Include="..\..\tests\test-libraries\testgenerator.cs">
+      <Link>testgenerator.cs</Link>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <GeneratedTestInput Include="..\..\tests\test-libraries\*.m" />
+    <GeneratedTestInput Include="..\..\tests\test-libraries\*.h" />
+    <GeneratedTestInput Include="..\..\tests\test-libraries\*.cs" />
+    <GeneratedTestInput Include="..\..\tests\test-libraries\Makefile" />
+    <GeneratedTestOutput Include="..\..\tests\test-libraries\.libs\macos\libtest.a" />
+    <GeneratedTestOutput Include="ApiDefinition.generated.cs" />
+    <GeneratedTestOutput Include="StructsAndEnums.generated.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\external\guiunit\src\framework\GuiUnit_xammac_mobile.csproj">
+      <Project>{EACFD119-769E-4E6C-89B7-A6CE3757C431}</Project>
+      <Name>GuiUnit_xammac_mobile</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Target Name="BeforeBuild" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)">
+    <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />
+  </Target>
+</Project>

--- a/tests/linker-mac/link all/link all-mac.csproj
+++ b/tests/linker-mac/link all/link all-mac.csproj
@@ -75,6 +75,10 @@
       <Project>{EACFD119-769E-4E6C-89B7-A6CE3757C431}</Project>
       <Name>GuiUnit_xammac_mobile</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\bindings-test\bindings-test-mac.csproj">
+      <Project>{20BEA313-7E2D-4209-93C0-E4D99C72695A}</Project>
+      <Name>bindings-test-mac</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/tests/monotouch-test/GameplayKit/GKAgent3DTest.cs
+++ b/tests/monotouch-test/GameplayKit/GKAgent3DTest.cs
@@ -26,9 +26,7 @@ using MatrixFloat3x3 = global::OpenTK.NMatrix3;
 using MatrixFloat4x4 = global::OpenTK.NMatrix4;
 using VectorFloat3 = global::OpenTK.NVector3;
 
-#if !MONOMAC
 using Bindings.Test;
-#endif
 using NUnit.Framework;
 
 namespace MonoTouchFixtures.GamePlayKit
@@ -66,14 +64,10 @@ namespace MonoTouchFixtures.GamePlayKit
 				Asserts.AreEqual (mat, obj.Rotation, "Rotation after setter");
 				var transposed3x3 = MatrixFloat3x3.Transpose ((MatrixFloat3x3) mat);
 				Asserts.AreEqual (transposed3x3, obj.Rotation3x3, "Rotation3x3 after setter");
-#if !MONOMAC
 				Asserts.AreEqual (transposed3x3, CFunctions.GetMatrixFloat3x3 (obj, "rotation"), "Rotation3x3 after setter native");
-#endif
 				obj.Rotation3x3 = mat3x3;
 				Asserts.AreEqual (mat3x3, obj.Rotation3x3, "Rotation3x3 after setter 3x3");
-#if !MONOMAC
 				Asserts.AreEqual (mat3x3, CFunctions.GetMatrixFloat3x3 (obj, "rotation"), "Rotation3x3 after setter native 3x3");
-#endif
 			}
 		}
 	}

--- a/tests/monotouch-test/ModelIO/MDLMaterialProperty.cs
+++ b/tests/monotouch-test/ModelIO/MDLMaterialProperty.cs
@@ -37,9 +37,7 @@ using MatrixFloat2x2 = global::OpenTK.NMatrix2;
 using MatrixFloat3x3 = global::OpenTK.NMatrix3;
 using MatrixFloat4x4 = global::OpenTK.NMatrix4;
 using VectorFloat3 = global::OpenTK.NVector3;
-#if !TEST_BINDINGS_UNAVAILABLE
 using Bindings.Test;
-#endif
 using NUnit.Framework;
 
 namespace MonoTouchFixtures.ModelIO {
@@ -196,16 +194,12 @@ namespace MonoTouchFixtures.ModelIO {
 				
 			using (var obj = new MDLMaterialProperty ("name", MDLMaterialSemantic.AmbientOcclusion, M4)) {
 				Asserts.AreEqual (M4, obj.Matrix4x4, "7 Matrix4x4");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (CFunctions.GetMatrixFloat4x4 (obj, "matrix4x4"), obj.MatrixFloat4x4, "7b MatrixFloat4x4");
-#endif
 				Asserts.AreEqual (MatrixFloat4x4.Transpose ((MatrixFloat4x4) M4), obj.MatrixFloat4x4, "7c MatrixFloat4x4");
 			}
 
 			using (var obj = new MDLMaterialProperty ("name", MDLMaterialSemantic.AmbientOcclusion, M4x4)) {
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (CFunctions.GetMatrixFloat4x4 (obj, "matrix4x4"), obj.MatrixFloat4x4, "7' MatrixFloat4x4");
-#endif
 				Asserts.AreEqual (M4x4, obj.MatrixFloat4x4, "7'b MatrixFloat4x4");
 			}
 

--- a/tests/monotouch-test/ModelIO/MDLTransform.cs
+++ b/tests/monotouch-test/ModelIO/MDLTransform.cs
@@ -36,9 +36,7 @@ using MatrixFloat3x3 = global::OpenTK.NMatrix3;
 using MatrixFloat4x4 = global::OpenTK.NMatrix4;
 using VectorFloat3 = global::OpenTK.NVector3;
 
-#if !TEST_BINDINGS_UNAVAILABLE
 using Bindings.Test;
-#endif
 using NUnit.Framework;
 
 namespace MonoTouchFixtures.ModelIO {
@@ -152,9 +150,7 @@ namespace MonoTouchFixtures.ModelIO {
 				Asserts.AreEqual (new Vector3 (4, 3, 2), obj.Scale, "Scale 4");
 				Asserts.AreEqual (new Vector3 (2, 3, 4), obj.Translation, "Translation 4");
 				Asserts.AreEqual (m4x4, obj.GetMatrix4x4 (), 0.0001f, "Matrix4x4 4");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (m4x4, CFunctions.GetMatrixFloat4x4 (obj, "matrix"), 0.0001f, "Matrix4x4-native 4");
-#endif
 			}
 		}
 			
@@ -210,9 +206,7 @@ namespace MonoTouchFixtures.ModelIO {
 				);
 				Asserts.AreEqual ((Matrix4) MatrixFloat4x4.Transpose (expected), obj.GetRotationMatrix (0), 0.00001f, "GetRotationMatrix");
 				Asserts.AreEqual (expected, obj.GetRotationMatrix4x4 (0), 0.00001f, "GetRotationMatrix4x4");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (expected, CFunctions.MDLTransform_GetRotationMatrix (obj, 0), 0.00001f, "GetRotationMatrix4x4 native");
-#endif
 			}
 		}
 	}

--- a/tests/monotouch-test/ObjCRuntime/CategoryTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/CategoryTest.cs
@@ -10,8 +10,8 @@ using Foundation;
 #if !MONOMAC
 using UIKit;
 using NativeException = Foundation.MonoTouchException;
-using Bindings.Test;
 #endif
+using Bindings.Test;
 using ObjCRuntime;
 #if !__TVOS__
 using MapKit;

--- a/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
@@ -86,7 +86,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			Runtime.MarshalObjectiveCException -= ObjExceptionHandler;
 		}
 
-		// Simulator/desktop only
+		// Simulator/desktop only (except for watchOS, where it works everywhere)
 		[Test]
 		public void ObjCException ()
 		{
@@ -95,9 +95,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				Assert.Ignore ("This test requires wrapper functions, which are not enabled for monotouch-test on device.");
 #endif
 
-#if !DEBUG && !__WATCHOS__ && !__MACOS__
-			if (Runtime.Arch != Arch.DEVICE)
-				Assert.Ignore ("This test only works in debug mode in the simulator.");
+#if !DEBUG && !__WATCHOS__
+			Assert.Ignore ("This test only works in debug mode in the simulator.");
 #endif
 			InstallHandlers ();
 
@@ -132,7 +131,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 		}
 
-		// Simulator/desktop only test
+		// Simulator/desktop only test (except for watchOS, where it works everywhere)
 		[Test]
 		public void ManagedExceptionPassthrough ()
 		{
@@ -143,9 +142,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				Assert.Ignore ("This test requires wrapper functions, which are not enabled for monotouch-test on device.");
 #endif
 
-#if !DEBUG && !__WATCHOS__ && !__MACOS__
-			if (Runtime.Arch != Arch.DEVICE)
-				Assert.Ignore ("This test only works in debug mode in the simulator.");
+#if !DEBUG && !__WATCHOS__
+			Assert.Ignore ("This test only works in debug mode in the simulator.");
 #endif
 			var hasDebugger = global::System.Diagnostics.Debugger.IsAttached;
 

--- a/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/ExceptionsTest.cs
@@ -9,8 +9,8 @@ using Foundation;
 using ObjCRuntime;
 #if !MONOMAC
 using UIKit;
-using Bindings.Test;
 #endif
+using Bindings.Test;
 #else
 using MonoTouch;
 using MonoTouch.Foundation;
@@ -19,6 +19,12 @@ using MonoTouch.UIKit;
 #endif
 
 using NUnit.Framework;
+
+#if __MACOS__
+using ObjCException = Foundation.ObjCException;
+#else
+using ObjCException = Foundation.MonoTouchException;
+#endif
 
 namespace MonoTouchFixtures.ObjCRuntime {
 	
@@ -80,16 +86,16 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			Runtime.MarshalObjectiveCException -= ObjExceptionHandler;
 		}
 
-#if !MONOMAC // Simulator only
+		// Simulator/desktop only
 		[Test]
 		public void ObjCException ()
 		{
-#if !__WATCHOS__
+#if !__WATCHOS__ && !__MACOS__
 			if (Runtime.Arch == Arch.DEVICE)
 				Assert.Ignore ("This test requires wrapper functions, which are not enabled for monotouch-test on device.");
 #endif
 
-#if !DEBUG && !__WATCHOS__
+#if !DEBUG && !__WATCHOS__ && !__MACOS__
 			if (Runtime.Arch != Arch.DEVICE)
 				Assert.Ignore ("This test only works in debug mode in the simulator.");
 #endif
@@ -97,12 +103,12 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 			try {
 				using (var e = new ObjCExceptionTest ()) {
-					MonoTouchException thrownException = null;
+					ObjCException thrownException = null;
 					try {
 						objcTargetMode = MarshalObjectiveCExceptionMode.ThrowManagedException;
 						e.ThrowObjCException ();
 						Assert.Fail ("managed exception not thrown");
-					} catch (MonoTouchException ex) {
+					} catch (ObjCException ex) {
 						thrownException = ex;
 					}
 					Assert.AreEqual ("exception was thrown", thrownException.Reason, "objc reason");
@@ -116,9 +122,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				UninstallHandlers ();
 			}
 		}
-#endif
 
-#if !MONOMAC // ObjCExceptionTest is from the iOS only Bindings.Test
 		class ManagedExceptionTest : ObjCExceptionTest {
 			public Exception Exception;
 			public override void ThrowManagedException ()
@@ -127,20 +131,19 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				throw Exception;
 			}
 		}
-#endif
 
-#if !MONOMAC // Simulator only test, mac doesn't have simulator.
+		// Simulator/desktop only test
 		[Test]
 		public void ManagedExceptionPassthrough ()
 		{
 			Exception thrownException = null;
 
-#if !__WATCHOS__
+#if !__WATCHOS__ && !__MACOS__
 			if (Runtime.Arch == Arch.DEVICE)
 				Assert.Ignore ("This test requires wrapper functions, which are not enabled for monotouch-test on device.");
 #endif
 
-#if !DEBUG && !__WATCHOS__
+#if !DEBUG && !__WATCHOS__ && !__MACOS__
 			if (Runtime.Arch != Arch.DEVICE)
 				Assert.Ignore ("This test only works in debug mode in the simulator.");
 #endif
@@ -189,9 +192,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 						Assert.AreSame (e.Exception, thrownException, "exception");
 					} else {
 						Assert.AreNotSame (e.Exception, thrownException, "exception");
-						Assert.AreSame (typeof (MonoTouchException), thrownException.GetType (), "2 thrown type");
-						Assert.AreEqual ("Caught exception", ((MonoTouchException) thrownException).Name, "2 thrown name");
-						Assert.AreEqual ("exception was rethrown", ((MonoTouchException) thrownException).Reason, "2 thrown reason");
+						Assert.AreSame (typeof (ObjCException), thrownException.GetType (), "2 thrown type");
+						Assert.AreEqual ("Caught exception", ((ObjCException) thrownException).Name, "2 thrown name");
+						Assert.AreEqual ("exception was rethrown", ((ObjCException) thrownException).Reason, "2 thrown reason");
 					}
 					if (hasDebugger) {
 						Assert.AreEqual (0, objcEventArgs.Count, "2 objc exception");
@@ -224,6 +227,5 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				UninstallHandlers ();      
 			}
 		}
-#endif
 	}
 }

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -48,9 +48,7 @@ using NativeException=MonoTouch.Foundation.MonoTouchException;
 #endif
 using OpenTK;
 using NUnit.Framework;
-#if !MONOMAC
 using Bindings.Test;
-#endif
 
 #if XAMCORE_2_0
 using RectangleF = CoreGraphics.CGRect;
@@ -2298,7 +2296,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 		}
 
-#if !MONOMAC // ObjCRegistrarTest is from Bindings.Tests, which is not currently implemented on mac
 		[Test]
 		public void BlockReturnTest ()
 		{
@@ -2325,7 +2322,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				}
 			}
 		}
-#endif
 
 		[Test]
 		public void PropertySetters ()
@@ -2351,7 +2347,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			public string B { get; set; }
 		}
 
-#if !MONOMAC // CtorChaining1 and CtorChaining2 are from Bindings.Test, which is iOS only atm
 		[Test]
 		public void ConstructorChaining ()
 		{
@@ -2372,7 +2367,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			{
 			}
 		}
-#endif
 
 		[DllImport ("/usr/lib/libobjc.dylib")]
 		static extern IntPtr class_getInstanceMethod (IntPtr cls, IntPtr sel);
@@ -2477,7 +2471,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 		}
 
-#if !MONOMAC // ObjCRegistrarTest is from Bindings.Tests, which is not currently implemented on mac
 		class NullOutParameters : ObjCRegistrarTest
 		{
 			public override void V (out NSObject n1, out NSString n2)
@@ -2493,7 +2486,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			using (var obj = new NullOutParameters ())
 				obj.Invoke_V_null_out ();
 		}
-#endif
 	}
 
 #if !__WATCHOS__

--- a/tests/monotouch-test/ObjCRuntime/TrampolineTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/TrampolineTest.cs
@@ -43,8 +43,8 @@ namespace MonoTouchFixtures.ObjCRuntime {
 	public class TrampolineTest {
 		public static readonly nfloat pi = 3.14159f;
 #if MONOMAC
-		public static bool IsSim64 { get { return false; } }
-		public static bool IsSim32 { get { return false; } }
+		public static bool IsSim64 { get { return IntPtr.Size == 8; } }
+		public static bool IsSim32 { get { return IntPtr.Size == 4; } }
 		public static bool IsArm64 { get { return false; } }
 		public static bool IsArm32 { get { return false; } }
 #else

--- a/tests/monotouch-test/SpriteKit/UniformTest.cs
+++ b/tests/monotouch-test/SpriteKit/UniformTest.cs
@@ -22,9 +22,7 @@ using MatrixFloat4x4 = global::OpenTK.NMatrix4;
 using VectorFloat3 = global::OpenTK.NVector3;
 
 using NUnit.Framework;
-#if !TEST_BINDINGS_UNAVAILABLE
 using Bindings.Test;
-#endif
 
 namespace MonoTouchFixtures.SpriteKit
 {
@@ -161,62 +159,44 @@ namespace MonoTouchFixtures.SpriteKit
 
 			using (var obj = new SKUniform ("name", M2)) {
 				Asserts.AreEqual (M2, obj.FloatMatrix2Value, "8 FloatMatrix2Value");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (M2, MatrixFloat2x2.Transpose (CFunctions.GetMatrixFloat2x2 (obj, "matrixFloat2x2Value")), "8b FloatMatrix2Value");
-#endif
 			}
 
 			using (var obj = new SKUniform ("name", M3)) {
 				Asserts.AreEqual (M3, obj.FloatMatrix3Value, "9 FloatMatrix3Value");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (M3, MatrixFloat3x3.Transpose (CFunctions.GetMatrixFloat3x3 (obj, "matrixFloat3x3Value")), "9b FloatMatrix3Value");
-#endif
 			}
 
 			using (var obj = new SKUniform ("name", M4)) {
 				Asserts.AreEqual (M4, obj.FloatMatrix4Value, "10 FloatMatrix4Value");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (M4, MatrixFloat4x4.Transpose (CFunctions.GetMatrixFloat4x4 (obj, "matrixFloat4x4Value")), "10b FloatMatrix4Value");
-#endif
 			}
 
 			using (var obj = new SKUniform ("name", M2x2)) {
 				Asserts.AreEqual (M2x2, obj.MatrixFloat2x2Value, "11 MatrixFloat2x2Value");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (M2x2, CFunctions.GetMatrixFloat2x2 (obj, "matrixFloat2x2Value"), "11b MatrixFloat2x2Value");
-#endif
 				var tmp2 = new MatrixFloat2x2 (9, 8, 7, 6);
 				obj.MatrixFloat2x2Value = tmp2;
 				Asserts.AreEqual (tmp2, obj.MatrixFloat2x2Value, "11 MatrixFloat2x2Value second");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (tmp2, CFunctions.GetMatrixFloat2x2 (obj, "matrixFloat2x2Value"), "11b MatrixFloat2x2Value second");
-#endif
 			}
 
 			using (var obj = new SKUniform ("name", M3x3)) {
 				Asserts.AreEqual (M3x3, obj.MatrixFloat3x3Value, "12 MatrixFloat3x3Value");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (M3x3, CFunctions.GetMatrixFloat3x3 (obj, "matrixFloat3x3Value"), "12b MatrixFloat3x3Value");
-#endif
 				var tmp3 = new MatrixFloat3x3 (9, 8, 7, 6, 5, 4, 3, 2, 1);
 				obj.MatrixFloat3x3Value = tmp3;
 				Asserts.AreEqual (tmp3, obj.MatrixFloat3x3Value, "12 MatrixFloat3x3Value second");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (tmp3, CFunctions.GetMatrixFloat3x3 (obj, "matrixFloat3x3Value"), "12b MatrixFloat3x3Value second");
-#endif
 			}
 
 			using (var obj = new SKUniform ("name", M4x4)) {
 				Asserts.AreEqual (M4x4, obj.MatrixFloat4x4Value, "13  MatrixFloat4x4Value");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (M4x4, CFunctions.GetMatrixFloat4x4 (obj, "matrixFloat4x4Value"), "13b FloatMatrix4Value");
-#endif
 				var tmp4 = new MatrixFloat4x4 (9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5, -6);
 				obj.MatrixFloat4x4Value = tmp4;
 				Asserts.AreEqual (tmp4, obj.MatrixFloat4x4Value, "13 MatrixFloat4x4Value second");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (tmp4, CFunctions.GetMatrixFloat4x4 (obj, "matrixFloat4x4Value"), "13b MatrixFloat4x4Value second");
-#endif
 			}
 		}
 
@@ -229,41 +209,29 @@ namespace MonoTouchFixtures.SpriteKit
 
 			using (var obj = SKUniform.Create ("name", M2x2)) {
 				Asserts.AreEqual (M2x2, obj.MatrixFloat2x2Value, "11 MatrixFloat2x2Value");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (M2x2, CFunctions.GetMatrixFloat2x2 (obj, "matrixFloat2x2Value"), "11b MatrixFloat2x2Value");
-#endif
 				var tmp2 = new MatrixFloat2x2 (9, 8, 7, 6);
 				obj.MatrixFloat2x2Value = tmp2;
 				Asserts.AreEqual (tmp2, obj.MatrixFloat2x2Value, "11 MatrixFloat2x2Value second");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (tmp2, CFunctions.GetMatrixFloat2x2 (obj, "matrixFloat2x2Value"), "11b MatrixFloat2x2Value second");
-#endif
 			}
 
 			using (var obj = SKUniform.Create ("name", M3x3)) {
 				Asserts.AreEqual (M3x3, obj.MatrixFloat3x3Value, "12 MatrixFloat3x3Value");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (M3x3, CFunctions.GetMatrixFloat3x3 (obj, "matrixFloat3x3Value"), "12b MatrixFloat3x3Value");
-#endif
 				var tmp3 = new MatrixFloat3x3 (9, 8, 7, 6, 5, 4, 3, 2, 1);
 				obj.MatrixFloat3x3Value = tmp3;
 				Asserts.AreEqual (tmp3, obj.MatrixFloat3x3Value, "12 MatrixFloat3x3Value second");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (tmp3, CFunctions.GetMatrixFloat3x3 (obj, "matrixFloat3x3Value"), "12b MatrixFloat3x3Value second");
-#endif
 			}
 
 			using (var obj = SKUniform.Create ("name", M4x4)) {
 				Asserts.AreEqual (M4x4, obj.MatrixFloat4x4Value, "13  MatrixFloat4x4Value");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (M4x4, CFunctions.GetMatrixFloat4x4 (obj, "matrixFloat4x4Value"), "13b FloatMatrix4Value");
-#endif
 				var tmp4 = new MatrixFloat4x4 (9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5, -6);
 				obj.MatrixFloat4x4Value = tmp4;
 				Asserts.AreEqual (tmp4, obj.MatrixFloat4x4Value, "13 MatrixFloat4x4Value second");
-#if !TEST_BINDINGS_UNAVAILABLE
 				Asserts.AreEqual (tmp4, CFunctions.GetMatrixFloat4x4 (obj, "matrixFloat4x4Value"), "13b MatrixFloat4x4Value second");
-#endif
 			}
 		}
 	}

--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -128,6 +128,9 @@ endif
 ifdef INCLUDE_WATCH
 $(eval $(call Template,watchos,WATCHOS,armv7k x86,i386,armv7k,WatchSimulator,WatchOS,-mwatchos-simulator-version-min=2.0,-mwatchos-version-min=2.0 -fembed-bitcode))
 endif
+ifdef INCLUDE_MAC
+$(eval $(call Template,macos,MACOS,x86_64,x86_64,,MacOSX,MacOSX,-mmacosx-version-min=$(MIN_OSX_VERSION_FOR_MAC),-mmacosx-version-min=$(MIN_OSX_VERSION_FOR_MAC)))
+endif
 
 define LibTemplate
 
@@ -146,6 +149,28 @@ $(eval $(call LibTemplate,armv7s+x86,.libs/ios/libtest.armv7s.o,.libs/ios/libtes
 $(eval $(call LibTemplate,arm64+x86_64,.libs/tvos/libtest.arm64.o,.libs/tvos/libtest.x86_64.o,tvos,TVOS))
 
 $(eval $(call LibTemplate,armv7k+x86,.libs/watchos/libtest.armv7k.o,.libs/watchos/libtest.x86.o,watchos,WATCHOS))
+
+# Xamarin.Mac
+
+MAC_CLANG = DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT) $(MAC_CC)
+MAC_OBJC_CFLAGS=-ObjC++ -std=c++0x -fno-exceptions
+MAC_CFLAGS = -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -Wall -DMONOMAC -g
+MAC_LDFLAGS = -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -framework AppKit
+
+.libs/macos/libtest.%.o: libtest.m $(EXTRA_DEPENDENCIES) | .libs/macos
+	$(call Q_2,OBJC,  [mac]) $(MAC_CLANG) -arch $* -c $(MAC_OBJC_CFLAGS) $(MAC_CFLAGS) -o $@ $<
+
+.libs/macos/libtest-object.%.o: libtest.m $(EXTRA_DEPENDENCIES) | .libs/macos
+	$(call Q_2,OBJC,  [mac]) $(MAC_CLANG) -arch $* -c $(MAC_OBJC_CFLAGS) $(MAC_CFLAGS) -o $@ $< -DPREFIX=1
+
+.libs/macos/libtest-ar.%.o: libtest.m $(EXTRA_DEPENDENCIES) | .libs/macos
+	$(call Q_2,OBJC,  [mac]) $(MAC_CLANG) -arch $* -c $(MAC_OBJC_CFLAGS) $(MAC_CFLAGS) -o $@ $< -DPREFIX=2
+
+.libs/macos/libtest2.%.o: libtest2.m $(EXTRA_DEPENDENCIES) | .libs/macos
+	$(call Q_2,OBJC,  [mac]) $(MAC_CLANG) -arch $* -c $(MAC_OBJC_CFLAGS) $(MAC_CFLAGS) -o $@ $<
+
+.libs/macos:
+	$(Q) mkdir -p $@
 
 clean-local:: $(CLEAN_TARGETS)
 

--- a/tests/test-libraries/testgenerator.cs
+++ b/tests/test-libraries/testgenerator.cs
@@ -80,16 +80,16 @@ static class C {
 		new BindAsData { Managed = "NSStreamStatus", Native = "NSStreamStatus", ManagedNewExpression = "NSStreamStatus.Closed", Map = ".UInt64Value", ToNSNumberCastExpression = "(ulong) ", FromNSNumberCastExpression = "(NSStreamStatus) " },
 	};
 	static BindAsData[] bindas_nsvalue = new [] {
-		new BindAsData { Managed = "CGAffineTransform", Native = "CGAffineTransform", ManagedNewExpression = "new CGAffineTransform (1, 2, 3, 4, 5, 6)", Map = ".CGAffineTransformValue", MapFrom = "FromCGAffineTransform" },
+		new BindAsData { Managed = "CGAffineTransform", Native = "CGAffineTransform", ManagedCondition = "!__MACOS__", ManagedNewExpression = "new CGAffineTransform (1, 2, 3, 4, 5, 6)", Map = ".CGAffineTransformValue", MapFrom = "FromCGAffineTransform" },
 		new BindAsData { Managed = "NSRange", Native = "NSRange", ManagedNewExpression = "new NSRange (7, 8)", Map = ".RangeValue", MapFrom = "FromRange" },
-		new BindAsData { Managed = "CGVector", Native = "CGVector", ManagedNewExpression = "new CGVector (9, 10)", Map = ".CGVectorValue", MapFrom = "FromCGVector" },
+		new BindAsData { Managed = "CGVector", Native = "CGVector", ManagedCondition = "!__MACOS__", ManagedNewExpression = "new CGVector (9, 10)", Map = ".CGVectorValue", MapFrom = "FromCGVector" },
 		new BindAsData { Managed = "SCNMatrix4", Native = "SCNMatrix4", ManagedNewExpression = "SCNMatrix4.Identity", Map = ".SCNMatrix4Value", MapFrom = "FromSCNMatrix4" },
 		new BindAsData { Managed = "CLLocationCoordinate2D", Native = "CLLocationCoordinate2D", ManagedNewExpression = "new CLLocationCoordinate2D (11, 12)", Map = ".CoordinateValue", MapFrom = "FromMKCoordinate" },
 		new BindAsData { Managed = "SCNVector3", Native = "SCNVector3", ManagedNewExpression = "new SCNVector3 (13, 14, 15)", Map = ".Vector3Value", MapFrom = "FromVector" },
 		new BindAsData { Managed = "SCNVector4", Native = "SCNVector4", ManagedNewExpression = "new SCNVector4 (16, 17, 18, 19)", Map = ".Vector4Value", MapFrom = "FromVector" },
-		new BindAsData { Managed = "CGPoint", Native = "CGPoint", ManagedCondition = "XAMCORE_2_0", ManagedNewExpression = "new CGPoint (19, 20)", Map = ".CGPointValue", MapFrom = "FromCGPoint" },
-		new BindAsData { Managed = "CGSize", Native = "CGSize", ManagedCondition = "XAMCORE_2_0", ManagedNewExpression = "new CGSize (21, 22)", Map = ".CGSizeValue", MapFrom = "FromCGSize" },
-		new BindAsData { Managed = "CGRect", Native = "CGRect", ManagedCondition = "XAMCORE_2_0", ManagedNewExpression = "new CGRect (23, 24, 25, 26)", Map = ".CGRectValue", MapFrom = "FromCGRect" },
+		new BindAsData { Managed = "CGPoint", Native = "CGPoint", ManagedCondition = "XAMCORE_2_0 && !__MACOS__", ManagedNewExpression = "new CGPoint (19, 20)", Map = ".CGPointValue", MapFrom = "FromCGPoint" },
+		new BindAsData { Managed = "CGSize", Native = "CGSize", ManagedCondition = "XAMCORE_2_0 && !__MACOS__", ManagedNewExpression = "new CGSize (21, 22)", Map = ".CGSizeValue", MapFrom = "FromCGSize" },
+		new BindAsData { Managed = "CGRect", Native = "CGRect", ManagedCondition = "XAMCORE_2_0 && !__MACOS__", ManagedNewExpression = "new CGRect (23, 24, 25, 26)", Map = ".CGRectValue", MapFrom = "FromCGRect" },
 		new BindAsData { Managed = "UIEdgeInsets", Native = "UIEdgeInsets", ManagedCondition = "HAVE_UIKIT", ManagedNewExpression = "new UIEdgeInsets (27, 28, 29, 30)", Map = ".UIEdgeInsetsValue", MapFrom = "FromUIEdgeInsets" },
 		new BindAsData { Managed = "UIOffset", Native = "UIOffset", ManagedCondition = "HAVE_UIKIT", ManagedNewExpression = "new UIOffset (31, 32)", Map = ".UIOffsetValue", MapFrom = "FromUIOffset" },
 		new BindAsData { Managed = "MKCoordinateSpan", Native = "MKCoordinateSpan", ManagedCondition = "HAVE_MAPKIT", ManagedNewExpression = "new MKCoordinateSpan (33, 34)", Map = ".CoordinateSpanValue", MapFrom = "FromMKCoordinateSpan" },
@@ -324,6 +324,10 @@ static class C {
 	static void WriteFrameworkDefines (StringBuilder w)
 	{
 		w.AppendLine (@"
+#if __UNIFIED__
+#define XAMCORE_2_0
+#endif
+
 #if __IOS__ || __MACOS__ || __TVOS__
 #define HAVE_COREANIMATION
 #endif
@@ -790,7 +794,11 @@ using Security;
 using UIKit;
 #endif
 using MonoTouchException=ObjCRuntime.RuntimeException;
+#if __MACOS__
+using NativeException=Foundation.ObjCException;
+#else
 using NativeException=Foundation.MonoTouchException;
+#endif
 #else
 using MonoTouch;
 using MonoTouch.Foundation;
@@ -1454,7 +1462,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 	static void WriteTrampolineTests ()
 	{
 		var w = new StringBuilder ();
-
+		WriteFrameworkDefines (w);
 		w.AppendLine (@"
 using System;
 using System.Runtime.InteropServices;

--- a/tests/tests-mac.sln
+++ b/tests/tests-mac.sln
@@ -41,6 +41,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "link all-mac", "linker-mac\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "link sdk-mac", "linker-mac\link sdk\link sdk-mac.csproj", "{F5FF0F5E-0C30-4719-A2B1-5DAE33D1E579}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bindings-test-mac", "bindings-test\bindings-test-mac.csproj", "{20BEA313-7E2D-4209-93C0-E4D99C72695A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -291,5 +293,17 @@ Global
 		{F5FF0F5E-0C30-4719-A2B1-5DAE33D1E579}.Debug|x86.Build.0 = Debug|x86
 		{F5FF0F5E-0C30-4719-A2B1-5DAE33D1E579}.Release|x86.ActiveCfg = Release|x86
 		{F5FF0F5E-0C30-4719-A2B1-5DAE33D1E579}.Release|x86.Build.0 = Release|x86
+		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.Default|Any CPU.ActiveCfg = Debug|Any CPU
+		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.Default|Any CPU.Build.0 = Debug|Any CPU
+		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.AppStore|Any CPU.Build.0 = Debug|Any CPU
+		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.Debug|x86.Build.0 = Debug|Any CPU
+		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.Release|x86.ActiveCfg = Release|Any CPU
+		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -17,7 +17,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\x86\Debug</OutputPath>
-    <DefineConstants>__UNIFIED__;DEBUG;MONOMAC;XAMCORE_2_0;TEST_BINDINGS_UNAVAILABLE</DefineConstants>
+    <DefineConstants>__UNIFIED__;DEBUG;MONOMAC;XAMCORE_2_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <EnableCodeSigning>false</EnableCodeSigning>
@@ -38,7 +38,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\x86\Release</OutputPath>
-    <DefineConstants>__UNIFIED__;MONOMAC;XAMCORE_2_0;TEST_BINDINGS_UNAVAILABLE</DefineConstants>
+    <DefineConstants>__UNIFIED__;MONOMAC;XAMCORE_2_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <EnableCodeSigning>false</EnableCodeSigning>
@@ -71,14 +71,11 @@
     <Compile Include="..\common\ExecutionHelper.cs">
       <Link>ExecutionHelper.cs</Link>
     </Compile>
-    <Compile Include="..\api-shared\ObjCRuntime\Registrar.cs">
-      <Link>Registrar.cs</Link>
-    </Compile>
-    <Compile Include="..\monotouch-test\ObjCRuntime\RegistrarTest.cs">
-      <Link>ObjCRuntime\RegistrarTest.cs</Link>
-    </Compile>
     <Compile Include="..\api-shared\ObjCRuntime\RegistrarTest.cs">
       <Link>api-shared\ObjCRuntime\RegistrarTest.cs</Link>
+    </Compile>
+    <Compile Include="..\api-shared\CoreFoundation\CFNotificationCenterTest.cs">
+      <Link>CoreFoundation\CFNotificationCenterTest.cs</Link>
     </Compile>
     <Compile Include="..\EmbeddedResources\ResourcesTest.cs">
       <Link>EmbeddedResources\ResourcesTest.cs</Link>
@@ -91,21 +88,11 @@
     <Compile Include="..\..\tools\common\StringUtils.cs">
       <Link>StringUtils.cs</Link>
     </Compile>
-    <Compile Include="..\monotouch-test\**\*.cs" Exclude="..\monotouch-test\obj\**;..\monotouch-test\ObjCRuntime\TrampolineTest.generated.cs;..\monotouch-test\ObjCRuntime\RegistrarTest.generated.cs">
+    <Compile Include="..\monotouch-test\**\*.cs" Exclude="..\monotouch-test\obj\**">
       <Link>%(RecursiveDir)%(Filename).cs</Link>
     </Compile>
-    <Compile Include="..\monotouch-test\MetalPerformanceShaders\KernelTest.cs">
-      <Link>MetalPerformanceShaders\KernelTest.cs</Link>
-    </Compile>
-    <Compile Include="..\monotouch-test\MetalPerformanceShaders\MPSImageHistogramEqualizationTest.cs">
-      <Link>MetalPerformanceShaders\MPSImageHistogramEqualizationTest.cs</Link>
-    </Compile>
-    <Compile Include="..\monotouch-test\MetalPerformanceShaders\MPSImageHistogramSpecificationTest.cs">
-      <Link>MetalPerformanceShaders\MPSImageHistogramSpecificationTest.cs</Link>
-    </Compile>
-    <Compile Include="..\monotouch-test\MetalPerformanceShaders\MPSImageHistogramTest.cs">
-      <Link>MetalPerformanceShaders\MPSImageHistogramTest.cs</Link>
-    </Compile>
+    <Compile Include="..\..\tests\test-libraries\TrampolineTest.generated.cs" />
+    <Compile Include="..\..\tests\test-libraries\RegistrarTest.generated.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />
@@ -183,6 +170,10 @@
       <Project>{EACFD119-769E-4E6C-89B7-A6CE3757C431}</Project>
       <Name>GuiUnit_xammac_mobile</Name>
     </ProjectReference>
+    <ProjectReference Include="..\bindings-test\bindings-test-mac.csproj">
+      <Project>{20BEA313-7E2D-4209-93C0-E4D99C72695A}</Project>
+      <Name>bindings-test-mac</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="..\monotouch-test\CoreImage\xamarinmonkey.heic">
@@ -193,4 +184,18 @@
     </BundleResource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
+  <PropertyGroup>
+    <TestLibrariesDirectory>..\..\tests\test-libraries</TestLibrariesDirectory>
+  </PropertyGroup>
+  <ItemGroup>
+    <GeneratedTestInput Include="..\..\tests\test-libraries\*.m" />
+    <GeneratedTestInput Include="..\..\tests\test-libraries\*.h" />
+    <GeneratedTestInput Include="..\..\tests\test-libraries\*.cs" />
+    <GeneratedTestInput Include="..\..\tests\test-libraries\Makefile" />
+    <GeneratedTestOutput Include="..\..\tests\test-libraries\TrampolineTest.generated.cs" />
+    <GeneratedTestOutput Include="..\..\tests\test-libraries\RegistrarTest.generated.cs" />
+  </ItemGroup>
+  <Target Name="BeforeBuild" Inputs="@(GeneratedTestInput)" Outputs="@(GeneratedTestOutput)">
+    <Exec Command="make -j8 -C $(TestLibrariesDirectory)" />
+  </Target>
 </Project>


### PR DESCRIPTION
Also add the new binding project to the xammac and link all XM test projects,
which allows us to stop excluding tests that require the native library and
the corresponding bindings.