### PR TITLE
[tests] Share supporting code between the mtouch and mmp tests.

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -100,6 +100,9 @@
       <Link>StringUtils.cs</Link>
     </Compile>
     <Compile Include="ProjectsTests\Bug60536.cs" />
+    <Compile Include="..\..\..\tests\common\Profile.cs">
+      <Link>Profile.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/tests/common/BundlerTool.cs
+++ b/tests/common/BundlerTool.cs
@@ -1,0 +1,363 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using NUnit.Framework;
+
+using Xamarin.Utils;
+
+namespace Xamarin.Tests
+{
+	public enum LinkerOption
+	{
+		Unspecified,
+		LinkAll,
+		LinkSdk,
+		DontLink,
+		LinkPlatform, // only applicable for XM
+	}
+
+	public enum RegistrarOption
+	{
+		Unspecified,
+		Dynamic,
+		Static,
+	}
+
+	[Flags]
+	enum I18N
+	{
+		None = 0,
+
+		CJK = 1,
+		MidEast = 2,
+		Other = 4,
+		Rare = 8,
+		West = 16,
+
+		All = CJK | MidEast | Other | Rare | West,
+		Base
+	}
+
+	// This class represents options/logic that is identical between mtouch and mmp
+	abstract class BundlerTool : Tool
+	{
+		public const string None = "None";
+
+#pragma warning disable 0649 // Field 'X' is never assigned to, and will always have its default value Y
+		// These map directly to mtouch/mmp options
+		// These options are ordered alphabetically
+		public string Abi; // This is --abi for mtouch and --arch for mmp
+		public string Cache;
+		public string [] CustomArguments; // Sometimes you want to pass invalid arguments to mtouch, in this case this array is used. No processing will be done, if quotes are required, they must be added to the arguments in the array.
+		public bool? Debug;
+		public bool? Extension;
+		public string GccFlags; // This is --gcc_flags for mtouch and --link_flags for mmp
+		public string HttpMessageHandler;
+		public I18N I18N;
+		public LinkerOption Linker;
+		public string [] LinkSkip;
+		public int [] NoWarn; // null array: nothing passed to mtouch/mmp. empty array: pass --nowarn (which means disable all warnings).
+		public string [] Optimize;
+		public Profile Profile;
+		public bool? Profiling;
+		public string [] References; // This is -r for mtouch and -a for mmp
+		public RegistrarOption Registrar;
+		public string ResponseFile;
+		public string RootAssembly;
+		public string Sdk;
+		public string SdkRoot;
+		public string TargetFramework;
+		public string TargetVer; // this is --targetver for mtouch and --minos for mmp
+		public int Verbosity;
+		public int [] WarnAsError; // null array: nothing passed to mtouch/mmp. empty array: pass --warnaserror (which means makes all warnings errors).
+		public string [] XmlDefinitions;
+
+		// These are a bit smarter
+		public bool NoPlatformAssemblyReference;
+#pragma warning restore 0649
+
+		bool IsMtouchTool {
+			get {
+				return GetType ().Name == "MTouchTool";
+			}
+		}
+
+		protected string GetVerbosity ()
+		{
+			if (Verbosity == 0) {
+				return string.Empty;
+			} else if (Verbosity > 0) {
+				return new string ('-', Verbosity).Replace ("-", "-v ");
+			} else {
+				return new string ('-', -Verbosity).Replace ("-", "-q ");
+			}
+		}
+
+		protected string ToolArguments {
+			get {
+				var sb = new StringBuilder ();
+				BuildArguments (sb);
+				return sb.ToString ();
+			}
+		}
+
+		protected virtual string GetDefaultAbi ()
+		{
+			return null;
+		}
+
+		protected virtual void BuildArguments (StringBuilder sb)
+		{
+			// Options are processed alphabetically
+
+			if (Abi == None) {
+				// add nothing
+			} else if (!string.IsNullOrEmpty (Abi)) {
+				sb.Append (IsMtouchTool ? " --abi " : " --arch ").Append (Abi);
+			} else {
+				var a = GetDefaultAbi ();
+				if (!string.IsNullOrEmpty (a)) {
+					sb.Append (IsMtouchTool ? " --abi " : " --arch ");
+					sb.Append (a);
+				}
+			}
+
+			if (!string.IsNullOrEmpty (Cache))
+				sb.Append (" --cache ").Append (StringUtils.Quote (Cache));
+
+			if (CustomArguments != null) {
+				foreach (var arg in CustomArguments) {
+					sb.Append (" ").Append (arg);
+				}
+			}
+
+			if (Debug.HasValue && Debug.Value)
+				sb.Append (" --debug");
+
+			if (Extension == true)
+				sb.Append (" --extension");
+
+			if (!string.IsNullOrEmpty (GccFlags))
+				sb.Append (IsMtouchTool ? " --gcc_flags " : " --link_flags ").Append (StringUtils.Quote (GccFlags));
+
+			if (!string.IsNullOrEmpty (HttpMessageHandler))
+				sb.Append (" --http-message-handler=").Append (StringUtils.Quote (HttpMessageHandler));
+
+			if (I18N != I18N.None) {
+				sb.Append (" --i18n ");
+				int count = 0;
+				if ((I18N & I18N.CJK) == I18N.CJK)
+					sb.Append (count++ == 0 ? string.Empty : ",").Append ("cjk");
+				if ((I18N & I18N.MidEast) == I18N.MidEast)
+					sb.Append (count++ == 0 ? string.Empty : ",").Append ("mideast");
+				if ((I18N & I18N.Other) == I18N.Other)
+					sb.Append (count++ == 0 ? string.Empty : ",").Append ("other");
+				if ((I18N & I18N.Rare) == I18N.Rare)
+					sb.Append (count++ == 0 ? string.Empty : ",").Append ("rare");
+				if ((I18N & I18N.West) == I18N.West)
+					sb.Append (count++ == 0 ? string.Empty : ",").Append ("west");
+			}
+
+			switch (Linker) {
+			case LinkerOption.LinkAll:
+			case LinkerOption.Unspecified:
+				break;
+			case LinkerOption.DontLink:
+				sb.Append (" --nolink");
+				break;
+			case LinkerOption.LinkSdk:
+				sb.Append (" --linksdkonly");
+				break;
+			case LinkerOption.LinkPlatform:
+				sb.Append (" --linkplatform");
+				break;
+			default:
+				throw new NotImplementedException ();
+			}
+
+			if (LinkSkip?.Length > 0) {
+				foreach (var ls in LinkSkip)
+					sb.Append (" --linkskip:").Append (StringUtils.Quote (ls));
+			}
+
+			if (NoWarn != null) {
+				if (NoWarn.Length > 0) {
+					sb.Append (" --nowarn:");
+					foreach (var code in NoWarn)
+						sb.Append (code).Append (',');
+					sb.Length--;
+				} else {
+					sb.Append (" --nowarn");
+				}
+			}
+
+			if (Optimize != null) {
+				foreach (var opt in Optimize)
+					sb.Append (" --optimize:").Append (opt);
+			}
+
+			if (Profiling.HasValue)
+				sb.Append (" --profiling:").Append (Profiling.Value ? "true" : "false");
+
+			if (References != null) {
+				foreach (var r in References)
+					sb.Append (IsMtouchTool ? " -r:" : " -a:").Append (StringUtils.Quote (r));
+			}
+
+			switch (Registrar) {
+			case RegistrarOption.Unspecified:
+				break;
+			case RegistrarOption.Dynamic:
+				sb.Append (" --registrar:dynamic");
+				break;
+			case RegistrarOption.Static:
+				sb.Append (" --registrar:static");
+				break;
+			default:
+				throw new NotImplementedException ();
+			}
+
+			if (!string.IsNullOrEmpty (ResponseFile))
+				sb.Append (" @").Append (StringUtils.Quote (ResponseFile));
+
+			if (!string.IsNullOrEmpty (RootAssembly))
+				sb.Append (" ").Append (StringUtils.Quote (RootAssembly));
+
+			if (Sdk == None) {
+				// do nothing	
+			} else if (!string.IsNullOrEmpty (Sdk)) {
+				sb.Append (" --sdk ").Append (Sdk);
+			} else {
+				sb.Append (" --sdk ").Append (Configuration.GetSdkVersion (Profile));
+			}
+
+			if (SdkRoot == None) {
+				// do nothing
+			} else if (!string.IsNullOrEmpty (SdkRoot)) {
+				sb.Append (" --sdkroot ").Append (StringUtils.Quote (SdkRoot));
+			} else {
+				sb.Append (" --sdkroot ").Append (StringUtils.Quote (Configuration.xcode_root));
+			}
+
+			if (TargetFramework == None) {
+				// do nothing
+			} else if (!string.IsNullOrEmpty (TargetFramework)) {
+				sb.Append (" --target-framework ").Append (TargetFramework);
+			} else if (!NoPlatformAssemblyReference) {
+				// make the implicit default the way tests have been running until now, and at the same time the very minimum to make apps build.
+				switch (Profile) {
+				case Profile.iOS:
+					sb.Append (" -r:").Append (StringUtils.Quote (Configuration.XamarinIOSDll));
+					break;
+				case Profile.tvOS:
+				case Profile.watchOS:
+					sb.Append (" --target-framework ").Append (Configuration.GetTargetFramework (Profile));
+					sb.Append (" -r:").Append (StringUtils.Quote (Configuration.GetBaseLibrary (Profile)));
+					break;
+				case Profile.macOSFull:
+				case Profile.macOSMobile:
+				case Profile.macOSSystem:
+					sb.Append (" --target-framework ").Append (Configuration.GetTargetFramework (Profile));
+					break;
+				default:
+					throw new NotImplementedException ();
+				}
+			}
+
+			if (TargetVer == None) {
+				// do nothing
+			} else if (!string.IsNullOrEmpty (TargetVer)) {
+				sb.Append (IsMtouchTool ? " --targetver " : " --minos ").Append (TargetVer);
+			}
+
+			sb.Append (" ").Append (GetVerbosity ());
+
+			if (WarnAsError != null) {
+				if (WarnAsError.Length > 0) {
+					sb.Append (" --warnaserror:");
+					foreach (var code in WarnAsError)
+						sb.Append (code).Append (',');
+					sb.Length--;
+				} else {
+					sb.Append (" --warnaserror");
+				}
+			}
+
+			if (XmlDefinitions?.Length > 0) {
+				foreach (var xd in XmlDefinitions)
+					sb.Append (" --xml:").Append (StringUtils.Quote (xd));
+			}
+
+
+		}
+
+		public string CreateTemporaryDirectory ()
+		{
+			return Xamarin.Cache.CreateTemporaryDirectory ();
+		}
+
+		public void CreateTemporaryCacheDirectory ()
+		{
+			Cache = Path.Combine (CreateTemporaryDirectory (), "mtouch-test-cache");
+			Directory.CreateDirectory (Cache);
+		}
+
+		public virtual int Execute ()
+		{
+			return Execute (ToolArguments, always_show_output: Verbosity > 0);
+		}
+
+		public virtual void AssertExecute (string message = null)
+		{
+			var rv = Execute ();
+			if (rv == 0)
+				return;
+			var errors = Messages.Where ((v) => v.IsError).ToList ();
+			Assert.Fail ($"Expected execution to succeed, but exit code was {rv}, and there were {errors.Count} error(s): {message}\n\t" +
+				     string.Join ("\n\t", errors.Select ((v) => v.ToString ())));
+		}
+
+		public abstract void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, string extraArg = "", string extraCode = null, string usings = null, bool use_csc = false);
+
+		public static string CompileTestAppExecutable (string targetDirectory, string code = null, string extraArg = "", Profile profile = Profile.iOS, string appName = "testApp", string extraCode = null, string usings = null, bool use_csc = false)
+		{
+			if (code == null)
+				code = "public class TestApp { static void Main () { System.Console.WriteLine (typeof (ObjCRuntime.Runtime).ToString ()); } }";
+			if (usings != null)
+				code = usings + "\n" + code;
+			if (extraCode != null)
+				code += extraCode;
+
+			return CompileTestAppCode ("exe", targetDirectory, code, extraArg, profile, appName, use_csc);
+		}
+
+		public static string CompileTestAppLibrary (string targetDirectory, string code, string extraArg = null, Profile profile = Profile.iOS, string appName = "testApp")
+		{
+			return CompileTestAppCode ("library", targetDirectory, code, extraArg, profile, appName);
+		}
+
+		public static string CompileTestAppCode (string target, string targetDirectory, string code, string extraArg = "", Profile profile = Profile.iOS, string appName = "testApp", bool use_csc = false)
+		{
+			var ext = target == "exe" ? "exe" : "dll";
+			var cs = Path.Combine (targetDirectory, "testApp.cs");
+			var assembly = Path.Combine (targetDirectory, appName + "." + ext);
+			var root_library = Configuration.GetBaseLibrary (profile);
+
+			File.WriteAllText (cs, code);
+
+			string output;
+			StringBuilder args = new StringBuilder ();
+			string fileName = Configuration.GetCompiler (profile, args, use_csc);
+			args.AppendFormat ($" /noconfig /t:{target} /nologo /out:{StringUtils.Quote (assembly)} /r:{StringUtils.Quote (root_library)} {StringUtils.Quote (cs)} {extraArg}");
+			if (ExecutionHelper.Execute (fileName, args.ToString (), out output) != 0) {
+				Console.WriteLine ("{0} {1}", fileName, args);
+				Console.WriteLine (output);
+				throw new Exception (output);
+			}
+
+			return assembly;
+		}
+	}
+}

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 using NUnit.Framework;
 
@@ -272,6 +273,18 @@ namespace Xamarin.Tests
 			}
 		}
 
+		public static string XamarinMacMobileDll {
+			get {
+				return Path.Combine (SdkRootXM, "lib", "mono", "Xamarin.Mac", "Xamarin.Mac.dll");
+			}
+		}
+
+		public static string XamarinMacFullDll {
+			get {
+				return Path.Combine (SdkRootXM, "lib", "mono", "4.5", "Xamarin.Mac.dll");
+			}
+		}
+
 		public static string SdkBinDir {
 			get {
 #if MONOMAC
@@ -376,6 +389,72 @@ namespace Xamarin.Tests
 				if (!string.IsNullOrEmpty (env))
 					return env;
 				return Path.Combine (BinDirXI, "mlaunch");
+			}
+		}
+
+		public static string GetBaseLibrary (Profile profile)
+		{
+			switch (profile) {
+			case Profile.iOS:
+				return XamarinIOSDll;
+			case Profile.tvOS:
+				return XamarinTVOSDll;
+			case Profile.watchOS:
+				return XamarinWatchOSDll;
+			case Profile.macOSMobile:
+				return XamarinMacMobileDll;
+			case Profile.macOSFull:
+				return XamarinMacFullDll;
+			default:
+				throw new NotImplementedException ();
+			}
+		}
+
+		public static string GetTargetFramework (Profile profile)
+		{
+			switch (profile) {
+			case Profile.iOS:
+				return "Xamarin.iOS,v1.0";
+			case Profile.tvOS:
+				return "Xamarin.TVOS,v1.0";
+			case Profile.watchOS:
+				return "Xamarin.WatchOS,v1.0";
+			case Profile.macOSMobile:
+				return "Xamarin.Mac,Version=v2.0,Profile=Mobile";
+			case Profile.macOSFull:
+				return "Xamarin.Mac,Version=v4.5,Profile=Full";
+			case Profile.macOSSystem:
+				return "Xamarin.Mac,Version=v4.5,Profile=System";
+			default:
+				throw new NotImplementedException ();
+			}
+		}
+
+		public static string GetSdkVersion (Profile profile)
+		{
+			switch (profile) {
+			case Profile.iOS:
+				return Configuration.sdk_version;
+			case Profile.tvOS:
+				return Configuration.tvos_sdk_version;
+			case Profile.watchOS:
+				return Configuration.watchos_sdk_version;
+			case Profile.macOSFull:
+			case Profile.macOSMobile:
+			case Profile.macOSSystem:
+				return Configuration.macos_sdk_version;
+			default:
+				throw new NotImplementedException ();
+			}
+		}
+
+		public static string GetCompiler (Profile profile, StringBuilder args, bool use_csc = false)
+		{
+			args.Append (" -lib:").Append (Path.GetDirectoryName (GetBaseLibrary (profile))).Append (' ');
+			if (use_csc) {
+				return "/Library/Frameworks/Mono.framework/Commands/csc";
+			} else {
+				return "/Library/Frameworks/Mono.framework/Commands/mcs";
 			}
 		}
 	}

--- a/tests/common/Profile.cs
+++ b/tests/common/Profile.cs
@@ -1,0 +1,14 @@
+
+namespace Xamarin.Tests
+{
+	public enum Profile
+	{
+		None,
+		iOS,
+		tvOS,
+		watchOS,
+		macOSMobile,
+		macOSFull,
+		macOSSystem,
+	}
+}

--- a/tests/common/Profile.cs
+++ b/tests/common/Profile.cs
@@ -7,6 +7,7 @@ namespace Xamarin.Tests
 		iOS,
 		tvOS,
 		watchOS,
+		macOSClassic,
 		macOSMobile,
 		macOSFull,
 		macOSSystem,

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -17,45 +17,45 @@ namespace GeneratorTests
 	public class BGenTests
 	{
 		[Test]
-		[TestCase (Profile.macClassic)]
-		[TestCase (Profile.macFull)]
-		[TestCase (Profile.macModern)]
+		[TestCase (Profile.macOSClassic)]
+		[TestCase (Profile.macOSFull)]
+		[TestCase (Profile.macOSMobile)]
 		public void BMac_Smoke (Profile profile)
 		{
 			BuildFile (profile, "bmac_smoke.cs");
 		}
 
 		[Test]
-		[TestCase (Profile.macClassic)]
-		[TestCase (Profile.macFull)]
-		[TestCase (Profile.macModern)]
+		[TestCase (Profile.macOSClassic)]
+		[TestCase (Profile.macOSFull)]
+		[TestCase (Profile.macOSMobile)]
 		public void BMac_With_Hyphen_In_Name (Profile profile)
 		{
 			BuildFile (profile, "bmac-with-hyphen-in-name.cs");
 		}
 
 		[Test]
-		[TestCase (Profile.macClassic)]
-		[TestCase (Profile.macFull)]
-		[TestCase (Profile.macModern)]
+		[TestCase (Profile.macOSClassic)]
+		[TestCase (Profile.macOSFull)]
+		[TestCase (Profile.macOSMobile)]
 		public void PropertyRedefinitionMac (Profile profile)
 		{
 			BuildFile (profile, "property-redefination-mac.cs");
 		}
 
 		[Test]
-		[TestCase (Profile.macClassic)]
-		[TestCase (Profile.macFull)]
-		[TestCase (Profile.macModern)]
+		[TestCase (Profile.macOSClassic)]
+		[TestCase (Profile.macOSFull)]
+		[TestCase (Profile.macOSMobile)]
 		public void NSApplicationPublicEnsureMethods (Profile profile)
 		{
 			BuildFile (profile, "NSApplicationPublicEnsureMethods.cs");
 		}
 
 		[Test]
-		[TestCase (Profile.macClassic)]
-		[TestCase (Profile.macFull)]
-		[TestCase (Profile.macModern)]
+		[TestCase (Profile.macOSClassic)]
+		[TestCase (Profile.macOSFull)]
+		[TestCase (Profile.macOSMobile)]
 		public void ProtocolDuplicateAbstract (Profile profile)
 		{
 			BuildFile (profile, "protocol-duplicate-abstract.cs");
@@ -156,9 +156,9 @@ namespace GeneratorTests
 		}
 
 		[Test]
-		[TestCase (Profile.macClassic)]
-		[TestCase (Profile.macFull)]
-		[TestCase (Profile.macModern)]
+		[TestCase (Profile.macOSClassic)]
+		[TestCase (Profile.macOSFull)]
+		[TestCase (Profile.macOSMobile)]
 		public void Bug31788 (Profile profile)
 		{
 			var bgen = new BGenTool ();

--- a/tests/generator/BGenTool.cs
+++ b/tests/generator/BGenTool.cs
@@ -13,18 +13,6 @@ using Xamarin.Utils;
 
 namespace Xamarin.Tests
 {
-	public enum Profile
-	{
-		None,
-		iOS,
-		tvOS,
-		watchOS,
-		macClassic,
-		macModern,
-		macFull,
-		macSystem,
-	}
-
 	class BGenTool : Tool
 	{
 		AssemblyDefinition assembly;
@@ -40,9 +28,9 @@ namespace Xamarin.Tests
 		public string WarnAsError; // Set to empty string to pass /warnaserror, set to non-empty string to pass /warnaserror:<nonemptystring>
 		public string NoWarn; // Set to empty string to pass /nowarn, set to non-empty string to pass /nowarn:<nonemptystring>
 
-		protected override string ToolPath { get { return Profile == Profile.macClassic ? Configuration.BGenClassicPath : Configuration.BGenPath; } }
+		protected override string ToolPath { get { return Profile == Profile.macOSClassic ? Configuration.BGenClassicPath : Configuration.BGenPath; } }
 		protected override string MessagePrefix { get { return "BI"; } }
-		protected override string MessageToolName { get { return Profile == Profile.macClassic ? "bgen-classic" : "bgen"; } }
+		protected override string MessageToolName { get { return Profile == Profile.macOSClassic ? "bgen-classic" : "bgen"; } }
 
 		public BGenTool ()
 		{
@@ -81,16 +69,16 @@ namespace Xamarin.Tests
 			case Profile.watchOS:
 				targetFramework = "Xamarin.WatchOS,v1.0";
 				break;
-			case Profile.macClassic:
+			case Profile.macOSClassic:
 				targetFramework = "XamMac,v1.0";
 				break;
-			case Profile.macFull:
+			case Profile.macOSFull:
 				targetFramework = "Xamarin.Mac,Version=v4.5,Profile=Full";
 				break;
-			case Profile.macModern:
+			case Profile.macOSMobile:
 				targetFramework = "Xamarin.Mac,Version=v2.0,Profile=Mobile";
 				break;
-			case Profile.macSystem:
+			case Profile.macOSSystem:
 				targetFramework = "Xamarin.Mac,Version=v4.5,Profile=System";
 				break;
 			default:
@@ -282,11 +270,11 @@ namespace Xamarin.Tests
 		public static string [] GetDefaultDefines (Profile profile)
 		{
 			switch (profile) {
-			case Profile.macFull:
-			case Profile.macModern:
-			case Profile.macSystem:
+			case Profile.macOSFull:
+			case Profile.macOSMobile:
+			case Profile.macOSSystem:
 				return new string [] { "MONOMAC", "XAMCORE_2_0" };
-			case Profile.macClassic:
+			case Profile.macOSClassic:
 				return new string [] { "MONOMAC" };
 			case Profile.iOS:
 				return new string [] { "IOS", "XAMCORE_2_0" };

--- a/tests/generator/ErrorTests.cs
+++ b/tests/generator/ErrorTests.cs
@@ -33,9 +33,9 @@ namespace GeneratorTests
 		}
 
 		[Test]
-		[TestCase (Profile.macFull)]
-		[TestCase (Profile.macModern)]
-		[TestCase (Profile.macClassic)]
+		[TestCase (Profile.macOSFull)]
+		[TestCase (Profile.macOSMobile)]
+		[TestCase (Profile.macOSClassic)]
 		public void BI1037 (Profile profile)
 		{
 			var bgen = new BGenTool ();
@@ -47,9 +47,9 @@ namespace GeneratorTests
 		}
 
 		[Test]
-		[TestCase (Profile.macFull)]
-		[TestCase (Profile.macModern)]
-		[TestCase (Profile.macClassic)]
+		[TestCase (Profile.macOSFull)]
+		[TestCase (Profile.macOSMobile)]
+		[TestCase (Profile.macOSClassic)]
 		public void BI1038 (Profile profile)
 		{
 			var bgen = new BGenTool ();
@@ -61,9 +61,9 @@ namespace GeneratorTests
 		}
 
 		[Test]
-		[TestCase (Profile.macFull)]
-		[TestCase (Profile.macModern)]
-		[TestCase (Profile.macClassic)]
+		[TestCase (Profile.macOSFull)]
+		[TestCase (Profile.macOSMobile)]
+		[TestCase (Profile.macOSClassic)]
 		public void BI1039 (Profile profile)
 		{
 			var bgen = new BGenTool ();
@@ -75,9 +75,9 @@ namespace GeneratorTests
 		}
 
 		[Test]
-		[TestCase (Profile.macFull)]
-		[TestCase (Profile.macModern)]
-		[TestCase (Profile.macClassic)]
+		[TestCase (Profile.macOSFull)]
+		[TestCase (Profile.macOSMobile)]
+		[TestCase (Profile.macOSClassic)]
 		public void BI1040 (Profile profile)
 		{
 			var bgen = new BGenTool ();
@@ -89,9 +89,9 @@ namespace GeneratorTests
 		}
 
 		[Test]
-		[TestCase (Profile.macFull)]
-		[TestCase (Profile.macModern)]
-		[TestCase (Profile.macClassic)]
+		[TestCase (Profile.macOSFull)]
+		[TestCase (Profile.macOSMobile)]
+		[TestCase (Profile.macOSClassic)]
 		public void BI1041 (Profile profile)
 		{
 			var bgen = new BGenTool ();
@@ -537,8 +537,8 @@ namespace BI1062Tests {
 
 		[Test]
 		[TestCase (Profile.iOS)]
-		[TestCase (Profile.macFull)]
-		[TestCase (Profile.macModern)]
+		[TestCase (Profile.macOSFull)]
+		[TestCase (Profile.macOSMobile)]
 		public void WarnAsError (Profile profile)
 		{
 			const string message = "The member 'SomeMethod' is decorated with [Static] and its container class warnaserrorTests.FooObject_Extensions is decorated with [Category] this leads to hard to use code. Please inline SomeMethod into warnaserrorTests.FooObject class.";
@@ -588,8 +588,8 @@ namespace BI1062Tests {
 
 		[Test]
 		[TestCase (Profile.iOS)]
-		[TestCase (Profile.macFull)]
-		[TestCase (Profile.macModern)]
+		[TestCase (Profile.macOSFull)]
+		[TestCase (Profile.macOSMobile)]
 		public void NoWarn (Profile profile)
 		{
 			const string message = "The member 'SomeMethod' is decorated with [Static] and its container class nowarnTests.FooObject_Extensions is decorated with [Category] this leads to hard to use code. Please inline SomeMethod into nowarnTests.FooObject class.";

--- a/tests/generator/generator-tests.csproj
+++ b/tests/generator/generator-tests.csproj
@@ -61,6 +61,9 @@
     <Compile Include="GeneratorTests.cs" />
     <Compile Include="BGenTests.cs" />
     <Compile Include="Asserts.cs" />
+    <Compile Include="..\common\Profile.cs">
+      <Link>Profile.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -83,6 +83,13 @@
     <Compile Include="..\common\ExecutionHelper.cs">
       <Link>src\ExecutionHelper.cs</Link>
     </Compile>
+    <Compile Include="..\common\Profile.cs">
+      <Link>Profile.cs</Link>
+    </Compile>
+    <Compile Include="src\MmpTool.cs" />
+    <Compile Include="..\common\BundlerTool.cs">
+      <Link>BundlerTool.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/mmptest/src/MmpTool.cs
+++ b/tests/mmptest/src/MmpTool.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using Xamarin.Tests;
+
+using Xamarin.Utils;
+
+namespace Xamarin
+{
+	class MmpTool : BundlerTool, IDisposable
+	{
+		public string ApplicationName;
+		public string OutputPath;
+
+		protected override string ToolPath {
+			get { return Configuration.MmpPath; }
+		}
+
+		protected override string MessagePrefix {
+			get { return "MM"; }
+		}
+
+		public void Dispose ()
+		{
+			// Nothing to do here yet
+		}
+
+		protected override void BuildArguments (StringBuilder sb)
+		{
+			base.BuildArguments (sb);
+
+			if (!string.IsNullOrEmpty (ApplicationName))
+				sb.Append (" --name=").Append (StringUtils.Quote (ApplicationName));
+
+			if (!string.IsNullOrEmpty (OutputPath))
+				sb.Append (" --output=").Append (StringUtils.Quote (OutputPath));
+
+			switch (Profile) {
+			case Profile.macOSMobile:
+				sb.Append (" --profile=Xamarin.Mac,Version=v2.0,Profile=Mobile");
+				break;
+			case Profile.macOSFull:
+				sb.Append (" --profile=Xamarin.Mac,Version=v4.5,Profile=Full");
+				break;
+			case Profile.macOSSystem:
+				sb.Append (" --profile=Xamarin.Mac,Version=v4.5,Profile=System");
+				break;
+			default:
+				throw new NotImplementedException (Profile.ToString ());
+			}
+		}
+
+		public override void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, string extraArg = "", string extraCode = null, string usings = null, bool use_csc = false)
+		{
+			if (RootAssembly == null) {
+				OutputPath = CreateTemporaryDirectory ();
+			} else {
+				// We're rebuilding an existing executable, so just reuse that
+				OutputPath = Path.GetDirectoryName (RootAssembly);
+			}
+			ApplicationName = appName;
+			var app = Path.Combine (OutputPath, appName + ".app");
+			Directory.CreateDirectory (app);
+			RootAssembly = CompileTestAppExecutable (OutputPath, code, extraArg, profile, appName, extraCode, usings, use_csc);
+		}
+	}
+}

--- a/tests/msbuild-mac/msbuild-mac.csproj
+++ b/tests/msbuild-mac/msbuild-mac.csproj
@@ -85,6 +85,9 @@
     <Compile Include="..\common\ExecutionHelper.cs">
       <Link>ExecutionHelper.cs</Link>
     </Compile>
+    <Compile Include="..\common\Profile.cs">
+      <Link>Profile.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">

--- a/tests/mtouch/LinkerTests.cs
+++ b/tests/mtouch/LinkerTests.cs
@@ -3,6 +3,8 @@ using System.IO;
 
 using NUnit.Framework;
 
+using MTouchLinker = Xamarin.Tests.LinkerOption;
+
 namespace Xamarin.Linker
 {
 	[TestFixture]

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -20,14 +20,6 @@ namespace Xamarin
 		LaunchSim,
 	}
 
-	public enum MTouchLinker
-	{
-		Unspecified,
-		LinkAll,
-		LinkSdk,
-		DontLink,
-	}
-
 	public enum MTouchSymbolMode
 	{
 		Unspecified,
@@ -35,13 +27,6 @@ namespace Xamarin
 		Linker,
 		Code,
 		Ignore,
-	}
-
-	public enum MTouchRegistrar
-	{
-		Unspecified,
-		Dynamic,
-		Static,
 	}
 
 	public enum MTouchBitcode
@@ -52,80 +37,43 @@ namespace Xamarin
 		Marker,
 	}
 
-	[Flags]
-	enum I18N
+	class MTouchTool : BundlerTool, IDisposable
 	{
-		None = 0,
-
-		CJK = 1,
-		MidEast = 2,
-		Other = 4,
-		Rare = 8,
-		West = 16,
-
-		All = CJK | MidEast | Other | Rare | West,
-		Base
-	}
-
-	class MTouchTool : Tool, IDisposable
-	{
-		public const string None = "None";
-
 #pragma warning disable 649
 		// These map directly to mtouch options
-		public int Verbosity;
-		public string SdkRoot;
+		MTouchAction? Action; // --sim, --dev, --launchsim, etc
 		public bool? NoSign;
-		public bool? Debug;
 		public bool? FastDev;
 		public bool? Dlsym;
-		public string Sdk;
-		public string TargetVer;
-		public string [] References;
 		public string Executable;
-		public string RootAssembly;
-		public string TargetFramework;
-		public string Abi;
 		public string AppPath;
-		public string Cache;
 		public string Device; // --device
-		public MTouchLinker Linker;
-		public string [] Optimize;
 		public MTouchSymbolMode SymbolMode;
 		public bool? NoFastSim;
-		public MTouchRegistrar Registrar;
-		public I18N I18N;
-		public bool? Extension;
 		public List<MTouchTool> AppExtensions = new List<MTouchTool> ();
 		public List<string> Frameworks = new List<string> ();
-		public string HttpMessageHandler;
 		public bool? PackageMdb;
 		public bool? MSym;
 		public bool? DSym;
 		public bool? NoStrip;
 		public string NoSymbolStrip;
 		public string Mono;
-		public string GccFlags;
 
 		// These are a bit smarter
-		public Profile Profile = Profile.iOS;
-		public bool NoPlatformAssemblyReference;
 		public List<string> AssemblyBuildTargets = new List<string> ();
 		static XmlDocument device_list_cache;
 		public string LLVMOptimizations;
-		public string [] CustomArguments; // Sometimes you want to pass invalid arguments to mtouch, in this case this array is used. No processing will be done, if quotes are required, they must be added to the arguments in the array.
-		public int [] NoWarn; // null array: no passed to mtouch. empty array: pass --nowarn (which means disable all warnings).
-		public int [] WarnAsError; // null array: no passed to mtouch. empty array: pass --warnaserror (which means makes all warnings errors).
 		public MTouchBitcode Bitcode;
 		public string AotArguments;
 		public string AotOtherArguments;
-		public string [] LinkSkip;
-		public string [] XmlDefinitions;
-		public bool? Profiling;
 		public string SymbolList;
-		public string ResponseFile;
 
 #pragma warning restore 649
+
+		public MTouchTool ()
+		{
+			Profile = Profile.iOS;
+		}
 
 		public class DeviceInfo
 		{
@@ -135,17 +83,6 @@ namespace Xamarin
 			public string DeviceClass;
 
 			public DeviceInfo Companion;
-		}
-
-		string GetVerbosity ()
-		{
-			if (Verbosity == 0) {
-				return string.Empty;
-			} else if (Verbosity > 0) {
-				return new string ('-', Verbosity).Replace ("-", "-v ");
-			} else {
-				return new string ('-', -Verbosity).Replace ("-", "-q ");
-			}
 		}
 
 		public int LaunchOnDevice (DeviceInfo device, string appPath, bool waitForUnlock, bool waitForExit)
@@ -158,19 +95,32 @@ namespace Xamarin
 			return Execute ("--devname \"{0}\" --installdev \"{1}\" --sdkroot \"{2}\" {3} {4}", device.Name, appPath, Configuration.xcode_root, GetVerbosity (), devicetype == null ? string.Empty : "--device " + devicetype);
 		}
 
+		// The default is to build for the simulator
+		public override int Execute ()
+		{
+			if (!Action.HasValue)
+				Action = MTouchAction.BuildSim;
+			return base.Execute ();
+		}
+
 		public int Execute (MTouchAction action)
 		{
-			return Execute (BuildArguments (action), always_show_output: Verbosity > 0);
+			this.Action = action;
+			return base.Execute ();
+		}
+
+		// The default is to build for the simulator
+		public override void AssertExecute (string message = null)
+		{
+			if (!Action.HasValue)
+				Action = MTouchAction.BuildSim;
+			base.AssertExecute (message);
 		}
 
 		public void AssertExecute (MTouchAction action, string message = null)
 		{
-			var rv = Execute (action);
-			if (rv == 0)
-				return;
-			var errors = Messages.Where ((v) => v.IsError).ToList ();
-			Assert.Fail ($"Expected execution to succeed, but exit code was {rv}, and there were {errors.Count} error(s): {message}\n\t" +
-			             string.Join ("\n\t", errors.Select ((v) => v.ToString ())));
+			this.Action = action;
+			base.AssertExecute (message);
 		}
 
 		public void AssertExecuteFailure (MTouchAction action, string message = null)
@@ -241,29 +191,57 @@ namespace Xamarin
 			Assert.IsEmpty (failed, message);
 		}
 
-		string BuildArguments (MTouchAction action)
+		protected override string GetDefaultAbi()
 		{
-			var sb = new StringBuilder ();
 			var isDevice = false;
 
-			switch (action) {
+			switch (Action.Value) {
+			case MTouchAction.None:
+				break;
+			case MTouchAction.BuildDev:
+				isDevice = true;
+				break;
+			case MTouchAction.BuildSim:
+				isDevice = false;
+				break;
+			case MTouchAction.LaunchSim:
+				isDevice = false;
+				break;
+			default:
+				throw new NotImplementedException ();
+			}
+
+			switch (Profile) {
+			case Profile.iOS:
+				return null; // not required
+			case Profile.tvOS:
+				return isDevice ? "arm64" : "x86_64";
+			case Profile.watchOS:
+				return isDevice ? "armv7k" : "i386";
+			default:
+				throw new NotImplementedException ();
+			}
+		}
+
+		protected override void BuildArguments (StringBuilder sb)
+		{
+			base.BuildArguments (sb);
+
+			switch (Action.Value) {
 			case MTouchAction.None:
 				break;
 			case MTouchAction.BuildDev:
 				MTouch.AssertDeviceAvailable ();
 				if (AppPath == null)
 					throw new Exception ("No AppPath specified.");
-				isDevice = true;
 				sb.Append (" --dev ").Append (StringUtils.Quote (AppPath));
 				break;
 			case MTouchAction.BuildSim:
-				isDevice = false;
 				if (AppPath == null)
 					throw new Exception ("No AppPath specified.");
 				sb.Append (" --sim ").Append (StringUtils.Quote (AppPath));
 				break;
 			case MTouchAction.LaunchSim:
-				isDevice = false;
 				if (AppPath == null)
 					throw new Exception ("No AppPath specified.");
 				sb.Append (" --launchsim ").Append (StringUtils.Quote (AppPath));
@@ -271,33 +249,6 @@ namespace Xamarin
 			default:
 				throw new NotImplementedException ();
 			}
-
-			if (SdkRoot == None) {
-				// do nothing
-			} else if (!string.IsNullOrEmpty (SdkRoot)) {
-				sb.Append (" --sdkroot ").Append (StringUtils.Quote (SdkRoot));
-			} else {
-				sb.Append (" --sdkroot ").Append (StringUtils.Quote (Configuration.xcode_root));
-			}
-
-			sb.Append (" ").Append (GetVerbosity ());
-
-			if (Sdk == None) {
-				// do nothing	
-			} else if (!string.IsNullOrEmpty (Sdk)) {
-				sb.Append (" --sdk ").Append (Sdk);
-			} else {
-				sb.Append (" --sdk ").Append (MTouch.GetSdkVersion (Profile));
-			}
-
-			if (TargetVer == None) {
-				// do nothing
-			} else if (!string.IsNullOrEmpty (TargetVer)) {
-				sb.Append (" --targetver ").Append (TargetVer);
-			}
-
-			if (Debug.HasValue && Debug.Value)
-				sb.Append (" --debug");
 
 			if (FastDev.HasValue && FastDev.Value)
 				sb.Append (" --fastdev");
@@ -316,9 +267,6 @@ namespace Xamarin
 				}
 			}
 
-			if (Profiling.HasValue)
-				sb.Append (" --profiling:").Append (Profiling.Value ? "true" : "false");
-
 			if (!string.IsNullOrEmpty (SymbolList))
 				sb.Append (" --symbollist=").Append (StringUtils.Quote (SymbolList));
 
@@ -328,9 +276,6 @@ namespace Xamarin
 			if (DSym.HasValue)
 				sb.Append (" --dsym:").Append (DSym.Value ? "true" : "false");
 
-			if (Extension == true)
-				sb.Append (" --extension");
-
 			foreach (var appext in AppExtensions)
 				sb.Append (" --app-extension ").Append (StringUtils.Quote (appext.AppPath));
 
@@ -339,84 +284,12 @@ namespace Xamarin
 
 			if (!string.IsNullOrEmpty (Mono))
 				sb.Append (" --mono:").Append (StringUtils.Quote (Mono));
-
-			if (!string.IsNullOrEmpty (GccFlags))
-				sb.Append (" --gcc_flags ").Append (StringUtils.Quote (GccFlags));
-
-			if (!string.IsNullOrEmpty (HttpMessageHandler))
-				sb.Append (" --http-message-handler=").Append (StringUtils.Quote (HttpMessageHandler));
-
+			
 			if (Dlsym.HasValue)
 				sb.Append (" --dlsym:").Append (Dlsym.Value ? "true" : "false");
-
-			if (References != null) {
-				foreach (var r in References)
-					sb.Append (" -r:").Append (StringUtils.Quote (r));
-			}
-
+			
 			if (!string.IsNullOrEmpty (Executable))
 				sb.Append (" --executable ").Append (StringUtils.Quote (Executable));
-
-			if (!string.IsNullOrEmpty (RootAssembly))
-				sb.Append (" ").Append (StringUtils.Quote (RootAssembly));
-
-			if (TargetFramework == None) {
-				// do nothing
-			} else if (!string.IsNullOrEmpty (TargetFramework)) {
-				sb.Append (" --target-framework ").Append (TargetFramework);
-			} else if (!NoPlatformAssemblyReference) {
-				// make the implicit default the way tests have been running until now, and at the same time the very minimum to make apps build.
-				switch (Profile) {
-				case Profile.iOS:
-					sb.Append (" -r:").Append (StringUtils.Quote (Configuration.XamarinIOSDll));
-					break;
-				case Profile.tvOS:
-				case Profile.watchOS:
-					sb.Append (" --target-framework ").Append (MTouch.GetTargetFramework (Profile));
-					sb.Append (" -r:").Append (StringUtils.Quote (MTouch.GetBaseLibrary (Profile)));
-					break;
-				default:
-					throw new NotImplementedException ();
-				}
-			}
-
-			if (Abi == None) {
-				// add nothing
-			} else if (!string.IsNullOrEmpty (Abi)) {
-				sb.Append (" --abi ").Append (Abi);
-			} else {
-				switch (Profile) {
-				case Profile.iOS:
-					break; // not required
-				case Profile.tvOS:
-					sb.Append (isDevice ? " --abi arm64" : " --abi x86_64");
-					break;
-				case Profile.watchOS:
-					sb.Append (isDevice ? " --abi armv7k" : " --abi i386");
-					break;
-				default:
-					throw new NotImplementedException ();
-				}
-			}
-
-			switch (Linker) {
-			case MTouchLinker.LinkAll:
-			case MTouchLinker.Unspecified:
-				break;
-			case MTouchLinker.DontLink:
-				sb.Append (" --nolink");
-				break;
-			case MTouchLinker.LinkSdk:
-				sb.Append (" --linksdkonly");
-				break;
-			default:
-				throw new NotImplementedException ();
-			}
-
-			if (Optimize != null) {
-				foreach (var opt in Optimize)
-					sb.Append (" --optimize:").Append (opt);
-			}
 
 			switch (SymbolMode) {
 			case MTouchSymbolMode.Ignore:
@@ -440,71 +313,12 @@ namespace Xamarin
 			if (NoFastSim.HasValue && NoFastSim.Value)
 				sb.Append (" --nofastsim");
 
-			switch (Registrar) {
-			case MTouchRegistrar.Unspecified:
-				break;
-			case MTouchRegistrar.Dynamic:
-				sb.Append (" --registrar:dynamic");
-				break;
-			case MTouchRegistrar.Static:
-				sb.Append (" --registrar:static");
-				break;
-			default:
-				throw new NotImplementedException ();
-			}
-
-			if (I18N != I18N.None) {
-				sb.Append (" --i18n ");
-				int count = 0;
-				if ((I18N & I18N.CJK) == I18N.CJK)
-					sb.Append (count++ == 0 ? string.Empty : ",").Append ("cjk");
-				if ((I18N & I18N.MidEast) == I18N.MidEast)
-					sb.Append (count++ == 0 ? string.Empty : ",").Append ("mideast");
-				if ((I18N & I18N.Other) == I18N.Other)
-					sb.Append (count++ == 0 ? string.Empty : ",").Append ("other");
-				if ((I18N & I18N.Rare) == I18N.Rare)
-					sb.Append (count++ == 0 ? string.Empty : ",").Append ("rare");
-				if ((I18N & I18N.West) == I18N.West)
-					sb.Append (count++ == 0 ? string.Empty : ",").Append ("west");
-			}
-
-			if (!string.IsNullOrEmpty (Cache))
-				sb.Append (" --cache ").Append (StringUtils.Quote (Cache));
-
 			if (!string.IsNullOrEmpty (Device))
 				sb.Append (" --device:").Append (StringUtils.Quote (Device));
 
 			if (!string.IsNullOrEmpty (LLVMOptimizations))
 				sb.Append (" --llvm-opt=").Append (StringUtils.Quote (LLVMOptimizations));
-
-			if (CustomArguments != null) {
-				foreach (var arg in CustomArguments) {
-					sb.Append (" ").Append (arg);
-				}
-			}
-
-			if (NoWarn != null) {
-				if (NoWarn.Length > 0) {
-					sb.Append (" --nowarn:");
-					foreach (var code in NoWarn)
-						sb.Append (code).Append (',');
-					sb.Length--;
-				} else {
-					sb.Append (" --nowarn");
-				}
-			}
-
-			if (WarnAsError != null) {
-				if (WarnAsError.Length > 0) {
-					sb.Append (" --warnaserror:");
-					foreach (var code in WarnAsError)
-						sb.Append (code).Append (',');
-					sb.Length--;
-				} else {
-					sb.Append (" --warnaserror");
-				}
-			}
-
+			
 			if (Bitcode != MTouchBitcode.Unspecified)
 				sb.Append (" --bitcode:").Append (Bitcode.ToString ().ToLower ());
 
@@ -516,21 +330,6 @@ namespace Xamarin
 
 			if (!string.IsNullOrEmpty (AotOtherArguments))
 				sb.Append (" --aot-options:").Append (StringUtils.Quote (AotOtherArguments));
-
-			if (LinkSkip?.Length > 0) {
-				foreach (var ls in LinkSkip)
-					sb.Append (" --linkskip:").Append (StringUtils.Quote (ls));
-			}
-
-			if (XmlDefinitions?.Length > 0) {
-				foreach (var xd in XmlDefinitions)
-					sb.Append (" --xml:").Append (StringUtils.Quote (xd));
-			}
-
-			if (!string.IsNullOrEmpty (ResponseFile))
-				sb.Append (" @").Append (StringUtils.Quote (ResponseFile));
-
-			return sb.ToString ();
 		}
 
 		XmlDocument FetchDeviceList (bool allowCache = true)
@@ -655,6 +454,12 @@ namespace Xamarin
 			return MTouch.CompileTestAppLibrary (asm_dir, "class X {}", appName: Path.GetFileNameWithoutExtension (asm_name));
 		}
 
+		public override void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, string extraArg = "", string extraCode = null, string usings = null, bool use_csc = false)
+		{
+			Profile = profile;
+			CreateTemporaryApp (appName: appName, code: code, extraArg: extraArg, extraCode: extraCode, usings: usings, use_csc: use_csc);
+		}
+
 		public void CreateTemporaryApp (bool hasPlist = false, string appName = "testApp", string code = null, string extraArg = "", string extraCode = null, string usings = null, bool use_csc = false)
 		{
 			string testDir;
@@ -667,7 +472,7 @@ namespace Xamarin
 			var app = AppPath ?? Path.Combine (testDir, appName + ".app");
 			Directory.CreateDirectory (app);
 			AppPath = app;
-			RootAssembly = MTouch.CompileTestAppExecutable (testDir, code, extraArg, Profile, appName, extraCode, usings, use_csc);
+			RootAssembly = CompileTestAppExecutable (testDir, code, extraArg, Profile, appName, extraCode, usings, use_csc);
 
 			if (hasPlist)
 				File.WriteAllText (Path.Combine (app, "Info.plist"), CreatePlist (Profile, appName));
@@ -874,11 +679,6 @@ public partial class NotificationController : WKUserNotificationInterfaceControl
 ");
 		}
 
-		public string CreateTemporaryDirectory ()
-		{
-			return Xamarin.Cache.CreateTemporaryDirectory ();
-		}
-
 		public void CreateTemporaryApp_LinkWith ()
 		{
 			AppPath = CreateTemporaryAppDirectory ();
@@ -894,12 +694,6 @@ public partial class NotificationController : WKUserNotificationInterfaceControl
 			Directory.CreateDirectory (AppPath);
 
 			return AppPath;
-		}
-
-		public void CreateTemporaryCacheDirectory ()
-		{
-			Cache = Path.Combine (CreateTemporaryDirectory (), "mtouch-test-cache");
-			Directory.CreateDirectory (Cache);
 		}
 
 		void IDisposable.Dispose ()

--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -9,6 +9,9 @@ using Xamarin.Tests;
 using Xamarin.Utils;
 using NUnit.Framework;
 
+using MTouchLinker = Xamarin.Tests.LinkerOption;
+using MTouchRegistrar = Xamarin.Tests.RegistrarOption;
+
 namespace Xamarin
 {
 	[TestFixture]

--- a/tests/mtouch/TimingTests.cs
+++ b/tests/mtouch/TimingTests.cs
@@ -4,6 +4,11 @@ using Xamarin;
 using NUnit.Framework;
 using System.Text;
 
+using Xamarin.Tests;
+
+using MTouchLinker = Xamarin.Tests.LinkerOption;
+using MTouchRegistrar = Xamarin.Tests.RegistrarOption;
+
 namespace Xamarin.Profiler
 {
 	[TestFixture (Profile.iOS)]

--- a/tests/mtouch/mtouch.csproj
+++ b/tests/mtouch/mtouch.csproj
@@ -57,6 +57,12 @@
       <Link>ProductTests.cs</Link>
     </Compile>
     <Compile Include="StringUtilsTest.cs" />
+    <Compile Include="..\common\Profile.cs">
+      <Link>Profile.cs</Link>
+    </Compile>
+    <Compile Include="..\common\BundlerTool.cs">
+      <Link>BundlerTool.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Create a new class 'BundlerTool', which now contains most of the code in
MTouchTool that's also applicable to mmp (and the new MmpTool class).

This will make it easier to share tests between the mtouch and mmp tests.

Some tweaks are still probably required, but this should get us most of the
way.