### PR TITLE
[tests] Fix compiler warning.

### DIFF
--- a/tests/common/ExecutionHelper.cs
+++ b/tests/common/ExecutionHelper.cs
@@ -43,7 +43,9 @@ namespace Xamarin.Tests
 
 		public Dictionary<string, string> EnvironmentVariables { get; set; }
 		public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds (60);
+#pragma warning disable 0649 // Field 'X' is never assigned to, and will always have its default value Y
 		public string WorkingDirectory;
+#pragma warning restore 0649
 
 		public IEnumerable<ToolMessage> Messages { get { return messages; } }
 		public List<string> OutputLines {


### PR DESCRIPTION
This file is included in several projects, some projects use property, some
don't (and report the warning). There's no harm in not setting this property
(it's expected), ignore the warning.