### PR TITLE
[xharness] Store a computed make variable in a temporary variable to avoid computing it many times.

### DIFF
--- a/tests/xharness/MakefileGenerator.cs
+++ b/tests/xharness/MakefileGenerator.cs
@@ -179,10 +179,11 @@ namespace xharness
 				}
 				writer.WriteLine ("# Env Variables to use local not system XM");
 				writer.WriteLine ();
+				writer.WriteLine ("MD_APPLE_SDK_ROOT_EVALUATED:=$(shell dirname `dirname $(XCODE_DEVELOPER_ROOT)`)");
 
 				var enviromentalVariables = new Dictionary<string,string> () { { "XBUILD_FRAMEWORK_FOLDERS_PATH", "$(MAC_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild-frameworks"},
 					{ "MSBuildExtensionsPath", "$(MAC_DESTDIR)/Library/Frameworks/Mono.framework/External/xbuild"},
-					{ "MD_APPLE_SDK_ROOT", "$(shell dirname `dirname $(XCODE_DEVELOPER_ROOT)`)"}
+					{ "MD_APPLE_SDK_ROOT", "$(MD_APPLE_SDK_ROOT_EVALUATED)"}
 				};
 
 				foreach (var key in enviromentalVariables) {


### PR DESCRIPTION
This makes `make` in (with nothing to do) run 18x faster in tests/ (from 1.3s to 0.07s).