### PR TITLE
Optimize calls to BlockLiteral.SetupBlock to inject the block signature.

### DIFF
--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -232,6 +232,10 @@ The linker reports this warning when it can't optimize a call to BlockLiteral.Se
 The message will point to the method that calls BlockLiteral.SetupBlock[Unsafe], and
 it may also give clues as to why the call couldn't be optimized.
 
+Please file an [issue](https://github.com/xamarin/xamarin-macios/issues/new)
+along with a complete build log so that we can investigate what went wrong and
+possibly enable more scenarios in the future.
+
 # MM3xxx: AOT
 
 ## MM30xx: AOT (general) errors
@@ -267,6 +271,18 @@ the registrar couldn't compute it.
 
 This means that the block signature has to be computed at runtime, which is
 somewhat slower.
+
+There are currently two possible reasons for this warning:
+
+1. The type of the managed delegate is either a `System.Delegate` or
+   `System.MulticastDelegate`. These types don't represent a specific signature,
+   which means the registrar can't compute the corresponding native signature
+   either. In this case the fix is to use a specific delegate type for the
+   block (alternatively the warning can be ignored by adding `--nowarn:4173`
+   as an additional mmp argument in the project's Mac Build options).
+2. The registrar can't find the `Invoke` method of the delegate. This
+   shouldn't happen, so please file an [issue](https://github.com/xamarin/xamarin-macios/issues/new)
+   with a test project so that we can fix it.
 
 # MM5xxx: GCC and toolchain
 

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -259,7 +259,7 @@ it may also give clues as to why the call couldn't be optimized.
 
 ### <a name="MM4134">MM4134: Your application is using the '{0}' framework, which isn't included in the MacOS SDK you're using to build your app (this framework was introduced in OSX {2}, while you're building with the MacOS {1} SDK.) This configuration is not supported with the static registrar (pass --registrar:dynamic as an additional mmp argument in your project's Mac Build option to select). Alternatively select a newer SDK in your app's Mac Build options.
 
-### <a name="MT4173"/>MT4173: The registrar can't compute the block signature for the delegate of type {delegate-type} in the method {method} because *.
+### <a name="MM4173"/>MM4173: The registrar can't compute the block signature for the delegate of type {delegate-type} in the method {method} because *.
 
 This is a warning indicating that the registrar couldn't inject the block
 signature of the specified method into the generated registrar code, because

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -225,6 +225,13 @@ Mixed-mode assemblies can not be processed by the linker.
 
 See https://msdn.microsoft.com/en-us/library/x0w2664k.aspx for more information on mixed-mode assemblies.
 
+### <a name="MM2106"/>MM2106: Could not optimize the call to BlockLiteral.SetupBlock[Unsafe] in * at offset * because *.
+
+The linker reports this warning when it can't optimize a call to BlockLiteral.SetupBlock or Block.SetupBlockUnsafe.
+
+The message will point to the method that calls BlockLiteral.SetupBlock[Unsafe], and
+it may also give clues as to why the call couldn't be optimized.
+
 # MM3xxx: AOT
 
 ## MM30xx: AOT (general) errors
@@ -251,6 +258,15 @@ See https://msdn.microsoft.com/en-us/library/x0w2664k.aspx for more information 
 ## MM41xx: registrar
 
 ### <a name="MM4134">MM4134: Your application is using the '{0}' framework, which isn't included in the MacOS SDK you're using to build your app (this framework was introduced in OSX {2}, while you're building with the MacOS {1} SDK.) This configuration is not supported with the static registrar (pass --registrar:dynamic as an additional mmp argument in your project's Mac Build option to select). Alternatively select a newer SDK in your app's Mac Build options.
+
+### <a name="MT4173"/>MT4173: The registrar can't compute the block signature for the delegate of type {delegate-type} in the method {method} because *.
+
+This is a warning indicating that the registrar couldn't inject the block
+signature of the specified method into the generated registrar code, because
+the registrar couldn't compute it.
+
+This means that the block signature has to be computed at runtime, which is
+somewhat slower.
 
 # MM5xxx: GCC and toolchain
 

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -1307,6 +1307,10 @@ The linker reports this warning when it can't optimize a call to BlockLiteral.Se
 The message will point to the method that calls BlockLiteral.SetupBlock[Unsafe], and
 it may also give clues as to why the call couldn't be optimized.
 
+Please file an [issue](https://github.com/xamarin/xamarin-macios/issues/new)
+along with a complete build log so that we can investigate what went wrong and
+possibly enable more scenarios in the future.
+
 # MT3xxx: AOT error messages
 
 <!--
@@ -1665,6 +1669,18 @@ the registrar couldn't compute it.
 
 This means that the block signature has to be computed at runtime, which is
 somewhat slower.
+
+There are currently two possible reasons for this warning:
+
+1. The type of the managed delegate is either a `System.Delegate` or
+   `System.MulticastDelegate`. These types don't represent a specific signature,
+   which means the registrar can't compute the corresponding native signature
+   either. In this case the fix is to use a specific delegate type for the
+   block (alternatively the warning can be ignored by adding `--nowarn:4173`
+   as an additional mtouch argument in the project's iOS Build options).
+2. The registrar can't find the `Invoke` method of the delegate. This
+   shouldn't happen, so please file an [issue](https://github.com/xamarin/xamarin-macios/issues/new)
+   with a test project so that we can fix it.
 
 # MT5xxx: GCC and toolchain error messages
 

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -1300,6 +1300,13 @@ See https://msdn.microsoft.com/en-us/library/x0w2664k.aspx for more information 
 
 The `[BindingImpl]` attribute on the mentioned member is invalid. The expected format is `[BindingImpl (BindingImplOptions.ValueA | BindingImplOptions.ValueB)]`.
 
+### <a name="MT2106"/>MT2106: Could not optimize the call to BlockLiteral.SetupBlock[Unsafe] in * at offset * because *.
+
+The linker reports this warning when it can't optimize a call to BlockLiteral.SetupBlock or Block.SetupBlockUnsafe.
+
+The message will point to the method that calls BlockLiteral.SetupBlock[Unsafe], and
+it may also give clues as to why the call couldn't be optimized.
+
 # MT3xxx: AOT error messages
 
 <!--
@@ -1649,6 +1656,15 @@ with a test case and we'll evaluate it.
 
 [1]: https://bugzilla.xamarin.com/enter_bug.cgi?product=iOS
 [2]: https://bugzilla.xamarin.com/enter_bug.cgi?product=iOS&component=General&bug_severity=enhancement
+
+### <a name="MT4173"/>MT4173: The registrar can't compute the block signature for the delegate of type {delegate-type} in the method {method} because *.
+
+This is a warning indicating that the registrar couldn't inject the block
+signature of the specified method into the generated registrar code, because
+the registrar couldn't compute it.
+
+This means that the block signature has to be computed at runtime, which is
+somewhat slower.
 
 # MT5xxx: GCC and toolchain error messages
 

--- a/docs/website/optimizations.md
+++ b/docs/website/optimizations.md
@@ -310,12 +310,12 @@ Optimize calls to BlockLiteral.SetupBlock
 
 The Xamarin.iOS/Mac runtime needs to know the block signature when creating an
 Objective-C block for a managed delegate. This might be a fairly expensive
-operation, and this optimization will calculate the block signature at build
-time, and modify the IL to call a SetupBlock variation that takes the
-signature as an argument instead, avoiding the need for calculating the
-signature at runtime.
+operation. This optimization will calculate the block signature at build time,
+and modify the IL to call a `SetupBlock` method that takes the signature as an
+argument instead. Doing this avoids the need for calculating the signature at
+runtime.
 
-Benchmarks show that this speeds up calling a block 10-15x.
+Benchmarks show that this speeds up calling a block by a factor of 10 to 15.
 
 It will transform the following [code](https://github.com/xamarin/xamarin-macios/blob/018f7153441d9d7e0f58e2046f39eeb46f1ff480/src/UIKit/UIAccessibility.cs#L198-L211):
 
@@ -342,8 +342,9 @@ public static void RequestGuidedAccessSession (bool enable, Action<bool> complet
 This optimization requires the linker to be enabled, and is only applied to
 methods with the `[BindingImpl (BindingImplOptions.Optimizable)]` attribute.
 
-It is is enabled by default when using the static registrar (which is enabled
-by default when building for device (iOS) or building for release (macOS)).
+It is enabled by default when using the static registrar (in Xamarin.iOS the
+static registrar is enabled by default for device builds, and in Xamarin.Mac
+the static registrar is enabled by default for release builds).
 
 The default behavior can be overridden by passing `--optimize=[+|-]blockliteral-setupblock` to mtouch/mmp.
 

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -46,7 +46,8 @@
 
 		new XDelegate ("id", "IntPtr", "xamarin_create_delegate_proxy",
 			"MonoObject *", "IntPtr", "method",
-			"MonoObject *", "IntPtr", "block"
+			"MonoObject *", "IntPtr", "block",
+			"const char *", "IntPtr", "signature"
 		) { WrappedManagedFunction = "CreateDelegateProxy" },
 
 		new XDelegate ("void", "void", "xamarin_register_entry_assembly",

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2077,10 +2077,10 @@ xamarin_get_delegate_for_block_parameter (MonoMethod *method, int par, void *nat
 }
 
 id
-xamarin_get_block_for_delegate (MonoMethod *method, MonoObject *delegate, guint32 *exception_gchandle)
+xamarin_get_block_for_delegate (MonoMethod *method, MonoObject *delegate, const char *signature, guint32 *exception_gchandle)
 {
 	// COOP: accesses managed memory: unsafe mode.
-	return delegates.create_delegate_proxy ((MonoObject *) mono_method_get_object (mono_domain_get (), method, NULL), delegate, exception_gchandle);
+	return delegates.create_delegate_proxy ((MonoObject *) mono_method_get_object (mono_domain_get (), method, NULL), delegate, signature, exception_gchandle);
 }
 
 void

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -71,7 +71,7 @@ xamarin_marshal_return_value (MonoType *mtype, const char *type, MonoObject *ret
 		case _C_PTR: {
 			MonoClass *klass = mono_class_from_mono_type (mtype);
 			if (mono_class_is_delegate (klass)) {
-				return xamarin_get_block_for_delegate (method, retval, exception_gchandle);
+				return xamarin_get_block_for_delegate (method, retval, NULL, exception_gchandle);
 			} else {
 				return *(void **) mono_object_unbox (retval);
 			}

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -142,7 +142,7 @@ MonoType *		xamarin_get_parameter_type (MonoMethod *managed_method, int index);
 MonoObject *	xamarin_get_nsobject_with_type_for_ptr (id self, bool owns, MonoType* type, guint32 *exception_gchandle);
 MonoObject *	xamarin_get_nsobject_with_type_for_ptr_created (id self, bool owns, MonoType *type, int32_t *created, guint32 *exception_gchandle);
 int *			xamarin_get_delegate_for_block_parameter (MonoMethod *method, int par, void *nativeBlock, guint32 *exception_gchandle);
-id              xamarin_get_block_for_delegate (MonoMethod *method, MonoObject *delegate, guint32 *exception_gchandle);
+id              xamarin_get_block_for_delegate (MonoMethod *method, MonoObject *delegate, const char *signature /* NULL allowed, but requires the dynamic registrar at runtime to compute */, guint32 *exception_gchandle);
 id				xamarin_get_nsobject_handle (MonoObject *obj);
 void			xamarin_set_nsobject_handle (MonoObject *obj, id handle);
 uint8_t         xamarin_get_nsobject_flags (MonoObject *obj);

--- a/src/AddressBook/ABAddressBook.cs
+++ b/src/AddressBook/ABAddressBook.cs
@@ -207,6 +207,7 @@ namespace XamCore.AddressBook {
 		extern unsafe static void ABAddressBookRequestAccessWithCompletion (IntPtr addressbook, void * completion);
 
 		[iOS (6,0)]
+		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void RequestAccess (Action<bool,NSError> onCompleted)
 		{
 			if (onCompleted == null)

--- a/src/AudioToolbox/SystemSound.cs
+++ b/src/AudioToolbox/SystemSound.cs
@@ -192,6 +192,7 @@ namespace XamCore.AudioToolbox {
 		}
 
 		[iOS (9,0)][Mac (10,11)]
+		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void PlayAlertSound (Action onCompletion)
 		{
 			if (onCompletion == null)
@@ -224,6 +225,7 @@ namespace XamCore.AudioToolbox {
 		}
 
 		[iOS (9,0)][Mac (10,11)]
+		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void PlaySystemSound (Action onCompletion)
 		{
 			if (onCompletion == null)

--- a/src/CoreFoundation/DispatchBlock.cs
+++ b/src/CoreFoundation/DispatchBlock.cs
@@ -21,6 +21,7 @@ namespace XamCore.CoreFoundation {
 		// You must invoke ->CleanupBlock after you have transferred ownership to
 		// the unmanaged code to release the resources allocated on the managed side
 		//
+		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static unsafe void Invoke (Action codeToRun, Action<IntPtr> invoker)
 		{
 			BlockLiteral *block_ptr;

--- a/src/CoreText/CTLine.cs
+++ b/src/CoreText/CTLine.cs
@@ -251,6 +251,7 @@ namespace XamCore.CoreText {
  		}
 		
 		[iOS (9,0)][Mac (10,11)]
+		[BindingImpl (BindingImplOptions.Optimizable)]
 		public void EnumerateCaretOffsets (CaretEdgeEnumerator enumerator)
 		{
 			if (enumerator == null)

--- a/src/Metal/MTLDevice.cs
+++ b/src/Metal/MTLDevice.cs
@@ -64,6 +64,7 @@ namespace XamCore.Metal {
 		unsafe static extern IntPtr MTLCopyAllDevicesWithObserver (ref IntPtr observer, void* handler);
 
 		[Mac (10, 13, onlyOn64: true), NoiOS, NoWatch, NoTV]
+		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static IMTLDevice [] GetAllDevices (ref NSObject observer, MTLDeviceNotificationHandler handler)
 		{
 			if (observer == null)

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -2314,10 +2314,9 @@ namespace XamCore.Registrar {
 
 		public string ComputeSignature (TType DeclaringType, TMethod Method, ObjCMember member = null, bool isCategoryInstance = false, bool isBlockSignature = false)
 		{
-			var success = true;
-			var signature = new StringBuilder ();
 			bool is_ctor;
 			var method = member as ObjCMethod;
+			TType return_type = null;
 
 			if (Method != null) {
 				is_ctor = IsConstructor (Method);
@@ -2325,16 +2324,8 @@ namespace XamCore.Registrar {
 				is_ctor = method.IsConstructor;
 			}
 
-			if (is_ctor) {
-				signature.Append ('@');
-			} else {
-				var ReturnType = Method != null ? GetReturnType (Method) : method.NativeReturnType;
-				signature.Append (ToSignature (ReturnType, member, ref success));
-				if (!success)
-					throw CreateException (4104, Method ?? method.Method, "The registrar cannot marshal the return value of type `{0}` in the method `{1}.{2}`.", GetTypeFullName (ReturnType), GetTypeFullName (DeclaringType), GetDescriptiveMethodName (Method ?? method.Method));
-			}
-
-			signature.Append (isBlockSignature ? "@?" : "@:");
+			if (!is_ctor)
+				return_type = Method != null ? GetReturnType (Method) : method.NativeReturnType;
 
 			TType[] parameters;
 			if (Method != null) {
@@ -2343,6 +2334,26 @@ namespace XamCore.Registrar {
 				parameters = method.NativeParameters;
 			}
 
+			return ComputeSignature (DeclaringType, is_ctor, return_type, parameters, Method, member, isCategoryInstance, isBlockSignature);
+		}
+
+		public string ComputeSignature (TType declaring_type, bool is_ctor, TType return_type, TType [] parameters, TMethod mi = null, ObjCMember member = null, bool isCategoryInstance = false, bool isBlockSignature = false)
+		{
+			var success = true;
+			var signature = new StringBuilder ();
+			if (mi == null)
+				mi = (member as ObjCMethod)?.Method;
+			
+			if (is_ctor) {
+				signature.Append ('@');
+			} else {
+				signature.Append (ToSignature (return_type, member, ref success));
+				if (!success)
+					throw CreateException (4104, mi, "The registrar cannot marshal the return value of type `{0}` in the method `{1}.{2}`.", GetTypeFullName (return_type), GetTypeFullName (declaring_type), GetDescriptiveMethodName (mi));
+			}
+
+			signature.Append (isBlockSignature ? "@?" : "@:");
+
 			if (parameters != null) {
 				for (int i = 0; i < parameters.Length; i++) {
 					if (i == 0 && isCategoryInstance)
@@ -2350,14 +2361,18 @@ namespace XamCore.Registrar {
 					var type = parameters [i];
 					if (IsByRef (type)) {
 						signature.Append ("^");
-						signature.Append (ToSignature (GetElementType (type), member, ref success));
+						var elementType = GetElementType (type);
+						if (IsNullable (elementType)) {
+							signature.Append (ToSignature (GetNullableType (elementType), member, ref success));
+						} else {
+							signature.Append (ToSignature (elementType, member, ref success));
+						}
 					} else {
 						signature.Append (ToSignature (type, member, ref success));
 					}
 					if (!success) {
-						var mi = Method ?? method.Method;
 						throw CreateException (4136, mi, "The registrar cannot marshal the parameter type '{0}' of the parameter '{1}' in the method '{2}.{3}'",
-							GetTypeFullName (GetParameters (mi) [i]), GetParameterName (mi, i), GetTypeFullName (DeclaringType), GetDescriptiveMethodName (mi));
+							GetTypeFullName (parameters [i]), GetParameterName (mi, i), GetTypeFullName (declaring_type), GetDescriptiveMethodName (mi));
 					}
 				}
 			}

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -2371,6 +2371,12 @@ namespace XamCore.Registrar {
 						signature.Append (ToSignature (type, member, ref success));
 					}
 					if (!success) {
+						if (mi != null) {
+							// The input 'parameters' might be closed generic types, and thus might not correspond exactly with the source code.
+							// By fetching the parameters from the method again, we attempt to report the parameter type as close as possible
+							// to the source code.
+							parameters = GetParameters (mi);
+						}
 						throw CreateException (4136, mi, "The registrar cannot marshal the parameter type '{0}' of the parameter '{1}' in the method '{2}.{3}'",
 							GetTypeFullName (parameters [i]), GetParameterName (mi, i), GetTypeFullName (declaring_type), GetDescriptiveMethodName (mi));
 					}

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -402,9 +402,9 @@ namespace XamCore.ObjCRuntime {
 			return ObjectWrapper.Convert (CreateBlockProxy ((MethodInfo) ObjectWrapper.Convert (method), block));
 		}
 			
-		static IntPtr CreateDelegateProxy (IntPtr method, IntPtr @delegate)
+		static IntPtr CreateDelegateProxy (IntPtr method, IntPtr @delegate, IntPtr signature)
 		{
-			return BlockLiteral.GetBlockForDelegate ((MethodInfo) ObjectWrapper.Convert (method), ObjectWrapper.Convert (@delegate));
+			return BlockLiteral.GetBlockForDelegate ((MethodInfo) ObjectWrapper.Convert (method), ObjectWrapper.Convert (@delegate), Marshal.PtrToStringAuto (signature));
 		}
 
 		static unsafe Assembly GetEntryAssembly ()

--- a/src/Security/SecSharedCredential.cs
+++ b/src/Security/SecSharedCredential.cs
@@ -35,6 +35,7 @@ namespace XamCore.Security {
 		} 
 
 		[iOS (8,0)]
+		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static void AddSharedWebCredential (string domainName, string account, string password, Action<NSError> handler)
 		{
 			if (domainName == null)
@@ -97,6 +98,7 @@ namespace XamCore.Security {
 #endif
 
 		[iOS (8,0)]
+		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static void RequestSharedWebCredential (string domainName, string account, Action<SecSharedCredentialInfo[], NSError> handler)
 		{
 			Action<NSArray, NSError> onComplete = (NSArray a, NSError e) => {

--- a/src/UIKit/UIAccessibility.cs
+++ b/src/UIKit/UIAccessibility.cs
@@ -196,6 +196,7 @@ namespace XamCore.UIKit {
 		extern unsafe static void UIAccessibilityRequestGuidedAccessSession (/* BOOL */ bool enable, /* void(^completionHandler)(BOOL didSucceed) */ void * completionHandler);
 
 		[iOS (7,0)]
+		[BindingImpl (BindingImplOptions.Optimizable)]
 		public static void RequestGuidedAccessSession (bool enable, Action<bool> completionHandler)
 		{
 			unsafe {

--- a/tests/bindings-test/StructsAndEnums.cs
+++ b/tests/bindings-test/StructsAndEnums.cs
@@ -20,6 +20,9 @@ namespace Bindings.Test
 		public static extern int theUltimateAnswer ();
 
 		[DllImport ("__Internal")]
+		public static extern void x_call_block (ref BlockLiteral block);
+
+		[DllImport ("__Internal")]
 		public static extern void x_get_matrix_float2x2 (IntPtr self, string sel, out float r0c0, out float r0c1, out float r1c0, out float r1c1);
 
 		[DllImport ("__Internal")]

--- a/tests/common/ApiTest.cs
+++ b/tests/common/ApiTest.cs
@@ -1,0 +1,94 @@
+// Tests are common to both mtouch and mmp
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+
+using NUnit.Framework;
+
+using Mono.Cecil;
+
+using Xamarin.Tests;
+
+namespace Xamarin.ApiTest
+{
+	[TestFixture]
+	public class BlockLiteral
+	{
+		[Test]
+#if MONOTOUCH
+		[TestCase (Profile.iOS)]
+		[TestCase (Profile.watchOS)]
+		[TestCase (Profile.tvOS)]
+#else
+		[TestCase (Profile.macOSMobile)]
+		[TestCase (Profile.macOSMobile)]
+#endif
+		public void AlwaysOptimizable (Profile profile)
+		{
+			// This test ensures that all methods that call BlockLiteral.SetupBlock[Impl] have an [BindingImpl (BindingImplOptions.Optimizable)] attribute.
+
+			var dll = Configuration.GetBaseLibrary (profile);
+			var asm = AssemblyDefinition.ReadAssembly (dll);
+
+			var failures = new List<string> ();
+
+			foreach (var type in asm.MainModule.GetTypes ()) {
+				if (type.Name == "BlockLiteral")
+					continue;
+
+				foreach (var method in type.Methods) {
+					if (!method.HasBody)
+						continue;
+					var callsSetupBlock = false;
+					foreach (var instr in method.Body.Instructions) {
+						var mr = instr.Operand as MethodReference;
+						if (mr == null)
+							continue;
+						if (mr.DeclaringType.Name != "BlockLiteral")
+							continue;
+						if (mr.Name != "SetupBlock" && mr.Name != "SetupBlockUnsafe")
+							continue;
+						callsSetupBlock = true;
+						break;
+					}
+					if (!callsSetupBlock)
+						continue;
+
+					// This method calls BlockLiteral.SetupBlock. Ensure it has a [BindingImpl (BindingImplOptions.Optimizable)] attribute.
+					var isOptimizable = IsOptimizable (method);
+					if (!isOptimizable && (method.IsGetter || method.IsSetter)) {
+						var property = method.DeclaringType.Properties.FirstOrDefault ((v) => v.GetMethod == method || v.SetMethod == method);
+						isOptimizable = IsOptimizable (property);
+					}
+					foreach (var ca in method.CustomAttributes) {
+						if (ca.AttributeType.Name != "BindingImplAttribute")
+							continue;
+						var value = (int) ca.ConstructorArguments [0].Value;
+						if ((value & 0x2) == 0x2) { // BindingImplOptions.Optimizable = 2
+							isOptimizable = true;
+							break;
+						}
+					}
+					if (!isOptimizable)
+						failures.Add ($"The method {method.FullName} calls BlockLiteral.SetupBlock[Unsafe], but it does not have a [BindingImpl (BindingImplOptions.Optimizable)] attribute.");
+				}
+			}
+
+			CollectionAssert.IsEmpty (failures, "All methods calling SetupBlock[Unsafe] must be optimizable");
+		}
+
+		bool IsOptimizable (ICustomAttributeProvider provider)
+		{
+			foreach (var ca in provider.CustomAttributes) {
+				if (ca.AttributeType.Name != "BindingImplAttribute")
+					continue;
+				var value = (int) ca.ConstructorArguments [0].Value;
+				if ((value & 0x2) == 0x2) // BindingImplOptions.Optimizable = 2
+					return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/tests/common/ApiTest.cs
+++ b/tests/common/ApiTest.cs
@@ -22,7 +22,7 @@ namespace Xamarin.ApiTest
 		[TestCase (Profile.tvOS)]
 #else
 		[TestCase (Profile.macOSMobile)]
-		[TestCase (Profile.macOSMobile)]
+		[TestCase (Profile.macOSFull)]
 #endif
 		public void AlwaysOptimizable (Profile profile)
 		{

--- a/tests/common/BundlerTest.cs
+++ b/tests/common/BundlerTest.cs
@@ -1,0 +1,143 @@
+// Tests are common to both mtouch and mmp
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+
+using NUnit.Framework;
+
+using Mono.Cecil;
+
+using Xamarin.Tests;
+
+#if MONOTOUCH
+using BundlerTool = Xamarin.MTouchTool;
+#else
+using BundlerTool = Xamarin.MmpTool;
+#endif
+
+namespace Xamarin
+{
+	[TestFixture]
+	public class BundlerTests
+	{
+		[Test]
+#if __MACOS__
+		[TestCase (Profile.macOSMobile)]
+#else
+		[TestCase (Profile.iOS)]
+#endif
+		public void MX2106 (Profile profile)
+		{
+			using (var bundler = new BundlerTool ()) {
+				var code = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+class T {
+	[BindingImpl (BindingImplOptions.Optimizable)]
+	void SetupBlockOptimized_Delegate (Action callback, Delegate block_callback)
+	{
+		BlockLiteral block = new BlockLiteral ();
+		block.SetupBlock (block_callback, callback);
+		// don't need anything here, since this won't be executed
+		block.CleanupBlock ();
+	}
+
+	[BindingImpl (BindingImplOptions.Optimizable)]
+	void SetupBlockOptimized_MulticastDelegate (Action callback, MulticastDelegate block_callback)
+	{
+		BlockLiteral block = new BlockLiteral ();
+		block.SetupBlock (block_callback, callback);
+		// don't need anything here, since this won't be executed
+		block.CleanupBlock ();
+	}
+
+	static void Main ()
+	{
+		Console.WriteLine (typeof (NSObject));
+	}
+}
+";
+				bundler.Profile = profile;
+				bundler.CreateTemporaryCacheDirectory ();
+				bundler.CreateTemporaryApp (profile, code: code, extraArg: "/debug:full");
+				bundler.Linker = LinkerOption.LinkAll;
+				bundler.Optimize = new string [] { "blockliteral-setupblock" };
+				bundler.AssertExecute ();
+				bundler.AssertWarning (2106, "Could not optimize the call to BlockLiteral.SetupBlock in System.Void T::SetupBlockOptimized_Delegate(System.Action,System.Delegate) because the type of the value passed as the first argument (the trampoline) is System.Delegate, which makes it impossible to compute the block signature.", "testApp.cs", 10);
+				bundler.AssertWarning (2106, "Could not optimize the call to BlockLiteral.SetupBlock in System.Void T::SetupBlockOptimized_MulticastDelegate(System.Action,System.MulticastDelegate) because the type of the value passed as the first argument (the trampoline) is System.MulticastDelegate, which makes it impossible to compute the block signature.", "testApp.cs", 19);
+				bundler.AssertWarningCount (2);
+			}
+		}
+
+		[Test]
+#if __MACOS__
+		[TestCase (Profile.macOSMobile)]
+#else
+		[TestCase (Profile.iOS)]
+#endif
+		public void MX4105 (Profile profile)
+		{
+			using (var bundler = new BundlerTool ()) {
+				var code = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+class D : NSObject {
+	[Export (""d1:"")]
+	public void D1 (Delegate d)
+	{
+	}
+
+	[Export (""d2:"")]
+	public void D2 (MulticastDelegate d)
+	{
+	}
+
+	[Export (""d3:"")]
+	public void D3 (Action d)
+	{
+		// This should not show errors
+	}
+
+	[Export (""d4"")]
+	public Delegate D4 ()
+	{
+		return null;
+	}
+
+	[Export (""d5"")]
+	public MulticastDelegate D5 ()
+	{
+		return null;
+	}
+
+	[Export (""d6"")]
+	public Action D6 ()
+	{
+		return null;
+	}
+
+	static void Main ()
+	{
+		Console.WriteLine (typeof (NSObject));
+	}
+}
+";
+				bundler.Profile = profile;
+				bundler.CreateTemporaryCacheDirectory ();
+				bundler.CreateTemporaryApp (profile, code: code, extraArg: "/debug:full");
+				bundler.Optimize = new string [] { "blockliteral-setupblock" };
+				bundler.Registrar = RegistrarOption.Static;
+				bundler.AssertExecuteFailure ();
+				bundler.AssertError (4105, "The registrar cannot marshal the parameter of type `System.Delegate` in signature for method `D.D1`.");
+				bundler.AssertError (4105, "The registrar cannot marshal the parameter of type `System.MulticastDelegate` in signature for method `D.D2`.");
+				bundler.AssertWarning (4173, "The registrar can't compute the block signature for the delegate of type System.Delegate in the method D.D4 because System.Delegate doesn't have a specific signature.", "testApp.cs", 24);
+				bundler.AssertWarning (4173, "The registrar can't compute the block signature for the delegate of type System.MulticastDelegate in the method D.D5 because System.MulticastDelegate doesn't have a specific signature.", "testApp.cs", 30);
+				bundler.AssertErrorCount (2);
+				bundler.AssertWarningCount (2);
+			}
+		}
+	}
+}

--- a/tests/common/BundlerTool.cs
+++ b/tests/common/BundlerTool.cs
@@ -319,6 +319,11 @@ namespace Xamarin.Tests
 				     string.Join ("\n\t", errors.Select ((v) => v.ToString ())));
 		}
 
+		public void AssertExecuteFailure (string message = null)
+		{
+			Assert.AreEqual (1, Execute (), message);
+		}
+
 		public abstract void CreateTemporaryApp (Profile profile, string appName = "testApp", string code = null, string extraArg = "", string extraCode = null, string usings = null, bool use_csc = false);
 
 		public static string CompileTestAppExecutable (string targetDirectory, string code = null, string extraArg = "", Profile profile = Profile.iOS, string appName = "testApp", string extraCode = null, string usings = null, bool use_csc = false)

--- a/tests/common/ExecutionHelper.cs
+++ b/tests/common/ExecutionHelper.cs
@@ -290,21 +290,23 @@ namespace Xamarin.Tests
 			Assert.Fail (string.Format ("The warning '{0}{1:0000}: {2}' was not found in the output:\n{3}", prefix, number, messagePattern, string.Join ("\n", details.ToArray ())));
 		}
 
-		public void AssertWarning (int number, string message)
+		public void AssertWarning (int number, string message, string filename = null, int? linenumber = null)
 		{
-			AssertWarning (MessagePrefix, number, message);
+			AssertWarning (MessagePrefix, number, message, filename, linenumber);
 		}
 
-		public void AssertWarning (string prefix, int number, string message)
+		public void AssertWarning (string prefix, int number, string message, string filename = null, int? linenumber = null)
 		{
 			if (!messages.Any ((msg) => msg.Prefix == prefix && msg.Number == number))
 				Assert.Fail (string.Format ("The warning '{0}{1:0000}' was not found in the output.", prefix, number));
 
-			if (messages.Any ((msg) => msg.Message == message))
-				return;
+			var matches = messages.Where ((msg) => msg.Message == message);
+			if (!matches.Any ()) {
+				var details = messages.Where ((msg) => msg.Prefix == prefix && msg.Number == number && msg.Message != message).Select ((msg) => string.Format ("\tMessage #{2} did not match:\n\t\tactual:   '{0}'\n\t\texpected: '{1}'", msg.Message, message, messages.IndexOf (msg) + 1));
+				Assert.Fail (string.Format ("The warning '{0}{1:0000}: {2}' was not found in the output:\n{3}", prefix, number, message, string.Join ("\n", details.ToArray ())));
+			}
 
-			var details = messages.Where ((msg) => msg.Prefix == prefix && msg.Number == number && msg.Message != message).Select ((msg) => string.Format ("\tMessage #{2} did not match:\n\t\tactual:   '{0}'\n\t\texpected: '{1}'", msg.Message, message, messages.IndexOf (msg) + 1));
-			Assert.Fail (string.Format ("The warning '{0}{1:0000}: {2}' was not found in the output:\n{3}", prefix, number, message, string.Join ("\n", details.ToArray ())));
+			AssertFilename (prefix, number, message, matches, filename, linenumber);
 		}
 
 		public void AssertNoWarnings ()

--- a/tests/linker/BaseOptimizeGeneratedCodeTest.cs
+++ b/tests/linker/BaseOptimizeGeneratedCodeTest.cs
@@ -27,6 +27,7 @@ namespace Linker.Shared
 	[Preserve (AllMembers = true)]
 	public abstract class BaseOptimizeGeneratedCodeTest
 	{
+#if LINKALL
 		[Test]
 		public void SetupBlock_CustomDelegate ()
 		{
@@ -490,5 +491,6 @@ namespace Linker.Shared
 			GC.KeepAlive (dummy208); GC.KeepAlive (dummy218); GC.KeepAlive (dummy228); GC.KeepAlive (dummy238); GC.KeepAlive (dummy248); GC.KeepAlive (dummy258); GC.KeepAlive (dummy268); GC.KeepAlive (dummy278); GC.KeepAlive (dummy288); GC.KeepAlive (dummy298);
 			GC.KeepAlive (dummy209); GC.KeepAlive (dummy219); GC.KeepAlive (dummy229); GC.KeepAlive (dummy239); GC.KeepAlive (dummy249); GC.KeepAlive (dummy259); GC.KeepAlive (dummy269); GC.KeepAlive (dummy279); GC.KeepAlive (dummy289); GC.KeepAlive (dummy299);
 		}
+#endif // LINKALL
 	}
 }

--- a/tests/linker/BaseOptimizeGeneratedCodeTest.cs
+++ b/tests/linker/BaseOptimizeGeneratedCodeTest.cs
@@ -27,5 +27,468 @@ namespace Linker.Shared
 	[Preserve (AllMembers = true)]
 	public class BaseOptimizeGeneratedCodeTest
 	{
+		[Test]
+		public void SetupBlock_CustomDelegate ()
+		{
+			int counter = 0;
+			var action = new Action (() => counter++);
+			Custom (action);
+			CustomWithAttribute (action);
+			Assert.AreEqual (1, counter, "Counter");
+		}
+
+		delegate void CustomDelegate (IntPtr block);
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		unsafe void Custom (Action callback)
+		{
+			BlockLiteral block = new BlockLiteral ();
+			CustomDelegate block_callback = BlockCallback;
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		[UserDelegateType (typeof (Action))]
+		delegate void CustomDelegateWithAttribute (IntPtr block);
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		unsafe void CustomWithAttribute (Action callback)
+		{
+			BlockLiteral block = new BlockLiteral ();
+			CustomDelegateWithAttribute block_callback = BlockCallback;
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		[Test]
+		public void SetupBlockPerfTest ()
+		{
+			const int iterations = 5000;
+
+			// Set the XAMARIN_IOS_SKIP_BLOCK_CHECK environment variable to skip a few expensive validation checks done in the simulator
+			var skipBlockCheck = Environment.GetEnvironmentVariable ("XAMARIN_IOS_SKIP_BLOCK_CHECK");
+			try {
+				Environment.SetEnvironmentVariable ("XAMARIN_IOS_SKIP_BLOCK_CHECK", "1");
+				var unoptimizedCounter = 0;
+				var unoptimizedAction = new Action (() => unoptimizedCounter++);
+
+				var optimizedCounter = 0;
+				var optimizedAction = new Action (() => optimizedCounter++);
+
+				// Warm up
+				SetupBlockOptimized (optimizedAction);
+				SetupBlockUnoptimized (unoptimizedAction);
+
+				// Run unoptimized
+				var unoptimizedWatch = System.Diagnostics.Stopwatch.StartNew ();
+				unoptimizedCounter = 0;
+				for (var i = 0; i < iterations; i++)
+					SetupBlockUnoptimized (unoptimizedAction);
+				unoptimizedWatch.Stop ();
+				Assert.AreEqual (iterations, unoptimizedCounter, "Unoptimized Counter");
+
+				// Run optimized
+				var optimizedWatch = System.Diagnostics.Stopwatch.StartNew ();
+				optimizedCounter = 0;
+				for (var i = 0; i < iterations; i++)
+					SetupBlockOptimized (optimizedAction);
+				optimizedWatch.Stop ();
+				Assert.AreEqual (iterations, optimizedCounter, "Optimized Counter");
+
+				//Console.WriteLine ("Optimized: {0} ms", optimizedWatch.ElapsedMilliseconds);
+				//Console.WriteLine ("Unoptimized: {0} ms", unoptimizedWatch.ElapsedMilliseconds);
+				//Console.WriteLine ("Speedup: {0}x", unoptimizedWatch.ElapsedTicks / (double) optimizedWatch.ElapsedTicks);
+				// My testing found a 12-16x speedup on device and a 15-20x speedup in the simulator/desktop.
+				// Setting to 8 to have a margin for random stuff happening, but this may still have to be adjusted.
+				var speedup = 8;
+				Assert.That (unoptimizedWatch.ElapsedTicks / (double) optimizedWatch.ElapsedTicks, Is.GreaterThan (speedup), $"At least {speedup}x speedup");
+			} finally {
+				Environment.SetEnvironmentVariable ("XAMARIN_IOS_SKIP_BLOCK_CHECK", skipBlockCheck);
+			}
+		}
+
+		[Test]
+		public void SetupBlockCodeTest ()
+		{
+			int counter = 0;
+			var action = new Action (() => counter++);
+			SetupBlockOptimized_SpecificArgument (block_callback, action);
+			SetupBlockOptimized_SpecificArgument (action, block_callback);
+			SetupBlockOptimized_SpecificArgument (action, 0, block_callback);
+			SetupBlockOptimized_SpecificArgument (action, 0, 1, block_callback);
+			SetupBlockOptimized_SpecificArgument (action, 0, 1, 2, block_callback);
+			SetupBlockOptimized_SpecificArgument (action, 0, 1, 2, 3, block_callback);
+			SetupBlockOptimized_SpecificArgument (action, 0, 1, 2, 3, 4, block_callback);
+			SetupBlockOptimized_SpecificArgument (action, 0, 1, 2, 3, 4, 5, block_callback: block_callback);
+			SetupBlockOptimized_SpecificArgument (action, 0, 1, 2, 3, 4, 5, 6, block_callback: block_callback);
+			SetupBlockOptimized_LoadField (action);
+			SetupBlockOptimized_LoadStaticField (action);
+			SetupBlockOptimized_CallVirtualMethod (action);
+			SetupBlockOptimized_CallStaticMethod (action);
+			SetupBlockOptimized_LoadLocalVariable0 (action);
+			SetupBlockOptimized_LoadLocalVariable1 (action);
+			SetupBlockOptimized_LoadLocalVariable2 (action);
+			SetupBlockOptimized_LoadLocalVariable3 (action);
+			SetupBlockOptimized_LoadLocalVariable4 (action);
+			SetupBlockOptimized_LoadLocalVariable (action);
+
+			Assert.AreEqual (19, counter, "Counter");
+		}
+
+		[DllImport (Constants.libcLibrary)]
+		extern static void dispatch_sync (IntPtr queue, IntPtr block);
+		static Action<IntPtr> block_callback = BlockCallback;
+
+		[MonoPInvokeCallback (typeof (Action<IntPtr>))]
+		unsafe static void BlockCallback (IntPtr block)
+		{
+			var descriptor = (BlockLiteral*) block;
+			var del = (Action) (descriptor->Target);
+			del ();
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		unsafe void SetupBlockOptimized (Action callback)
+		{
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		unsafe void SetupBlockUnoptimized (Action callback)
+		{
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_SpecificArgument (Action<IntPtr> block_callback, Action callback)
+		{
+			// ldarg_0
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_SpecificArgument (Action callback, Action<IntPtr> block_callback)
+		{
+			// ldarg_1
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_SpecificArgument (Action callback, int dummy1, Action<IntPtr> block_callback)
+		{
+			// ldarg_2
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_SpecificArgument (Action callback, int dummy1, int dummy2, Action<IntPtr> block_callback)
+		{
+			// ldarg_3
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_SpecificArgument (Action callback, int dummy1, int dummy2, int dummy3, Action<IntPtr> block_callback)
+		{
+			// ldarg_S
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_SpecificArgument (Action callback, int dummy1, int dummy2, int dummy3, int dummy4, Action<IntPtr> block_callback)
+		{
+			// ldarg_S
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_SpecificArgument (Action callback, int dummy1, int dummy2, int dummy3, int dummy4, int dummy5, Action<IntPtr> block_callback)
+		{
+			// ldarg_S
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_SpecificArgument (
+			Action callback,
+			int dummy000 = 0, int dummy010 = 0, int dummy020 = 0, int dummy030 = 0, int dummy040 = 0, int dummy050 = 0, int dummy060 = 0, int dummy070 = 0, int dummy080 = 0, int dummy090 = 0,
+			int dummy001 = 0, int dummy011 = 0, int dummy021 = 0, int dummy031 = 0, int dummy041 = 0, int dummy051 = 0, int dummy061 = 0, int dummy071 = 0, int dummy081 = 0, int dummy091 = 0,
+			int dummy002 = 0, int dummy012 = 0, int dummy022 = 0, int dummy032 = 0, int dummy042 = 0, int dummy052 = 0, int dummy062 = 0, int dummy072 = 0, int dummy082 = 0, int dummy092 = 0,
+			int dummy003 = 0, int dummy013 = 0, int dummy023 = 0, int dummy033 = 0, int dummy043 = 0, int dummy053 = 0, int dummy063 = 0, int dummy073 = 0, int dummy083 = 0, int dummy093 = 0,
+			int dummy004 = 0, int dummy014 = 0, int dummy024 = 0, int dummy034 = 0, int dummy044 = 0, int dummy054 = 0, int dummy064 = 0, int dummy074 = 0, int dummy084 = 0, int dummy094 = 0,
+			int dummy005 = 0, int dummy015 = 0, int dummy025 = 0, int dummy035 = 0, int dummy045 = 0, int dummy055 = 0, int dummy065 = 0, int dummy075 = 0, int dummy085 = 0, int dummy095 = 0,
+			int dummy006 = 0, int dummy016 = 0, int dummy026 = 0, int dummy036 = 0, int dummy046 = 0, int dummy056 = 0, int dummy066 = 0, int dummy076 = 0, int dummy086 = 0, int dummy096 = 0,
+			int dummy007 = 0, int dummy017 = 0, int dummy027 = 0, int dummy037 = 0, int dummy047 = 0, int dummy057 = 0, int dummy067 = 0, int dummy077 = 0, int dummy087 = 0, int dummy097 = 0,
+			int dummy008 = 0, int dummy018 = 0, int dummy028 = 0, int dummy038 = 0, int dummy048 = 0, int dummy058 = 0, int dummy068 = 0, int dummy078 = 0, int dummy088 = 0, int dummy098 = 0,
+			int dummy009 = 0, int dummy019 = 0, int dummy029 = 0, int dummy039 = 0, int dummy049 = 0, int dummy059 = 0, int dummy069 = 0, int dummy079 = 0, int dummy089 = 0, int dummy099 = 0,
+
+			int dummy100 = 0, int dummy110 = 0, int dummy120 = 0, int dummy130 = 0, int dummy140 = 0, int dummy150 = 0, int dummy160 = 0, int dummy170 = 0, int dummy180 = 0, int dummy190 = 0,
+			int dummy101 = 0, int dummy111 = 0, int dummy121 = 0, int dummy131 = 0, int dummy141 = 0, int dummy151 = 0, int dummy161 = 0, int dummy171 = 0, int dummy181 = 0, int dummy191 = 0,
+			int dummy102 = 0, int dummy112 = 0, int dummy122 = 0, int dummy132 = 0, int dummy142 = 0, int dummy152 = 0, int dummy162 = 0, int dummy172 = 0, int dummy182 = 0, int dummy192 = 0,
+			int dummy103 = 0, int dummy113 = 0, int dummy123 = 0, int dummy133 = 0, int dummy143 = 0, int dummy153 = 0, int dummy163 = 0, int dummy173 = 0, int dummy183 = 0, int dummy193 = 0,
+			int dummy104 = 0, int dummy114 = 0, int dummy124 = 0, int dummy134 = 0, int dummy144 = 0, int dummy154 = 0, int dummy164 = 0, int dummy174 = 0, int dummy184 = 0, int dummy194 = 0,
+			int dummy105 = 0, int dummy115 = 0, int dummy125 = 0, int dummy135 = 0, int dummy145 = 0, int dummy155 = 0, int dummy165 = 0, int dummy175 = 0, int dummy185 = 0, int dummy195 = 0,
+			int dummy106 = 0, int dummy116 = 0, int dummy126 = 0, int dummy136 = 0, int dummy146 = 0, int dummy156 = 0, int dummy166 = 0, int dummy176 = 0, int dummy186 = 0, int dummy196 = 0,
+			int dummy107 = 0, int dummy117 = 0, int dummy127 = 0, int dummy137 = 0, int dummy147 = 0, int dummy157 = 0, int dummy167 = 0, int dummy177 = 0, int dummy187 = 0, int dummy197 = 0,
+			int dummy108 = 0, int dummy118 = 0, int dummy128 = 0, int dummy138 = 0, int dummy148 = 0, int dummy158 = 0, int dummy168 = 0, int dummy178 = 0, int dummy188 = 0, int dummy198 = 0,
+			int dummy109 = 0, int dummy119 = 0, int dummy129 = 0, int dummy139 = 0, int dummy149 = 0, int dummy159 = 0, int dummy169 = 0, int dummy179 = 0, int dummy189 = 0, int dummy199 = 0,
+
+			int dummy200 = 0, int dummy210 = 0, int dummy220 = 0, int dummy230 = 0, int dummy240 = 0, int dummy250 = 0, int dummy260 = 0, int dummy270 = 0, int dummy280 = 0, int dummy290 = 0,
+			int dummy201 = 0, int dummy211 = 0, int dummy221 = 0, int dummy231 = 0, int dummy241 = 0, int dummy251 = 0, int dummy261 = 0, int dummy271 = 0, int dummy281 = 0, int dummy291 = 0,
+			int dummy202 = 0, int dummy212 = 0, int dummy222 = 0, int dummy232 = 0, int dummy242 = 0, int dummy252 = 0, int dummy262 = 0, int dummy272 = 0, int dummy282 = 0, int dummy292 = 0,
+			int dummy203 = 0, int dummy213 = 0, int dummy223 = 0, int dummy233 = 0, int dummy243 = 0, int dummy253 = 0, int dummy263 = 0, int dummy273 = 0, int dummy283 = 0, int dummy293 = 0,
+			int dummy204 = 0, int dummy214 = 0, int dummy224 = 0, int dummy234 = 0, int dummy244 = 0, int dummy254 = 0, int dummy264 = 0, int dummy274 = 0, int dummy284 = 0, int dummy294 = 0,
+			int dummy205 = 0, int dummy215 = 0, int dummy225 = 0, int dummy235 = 0, int dummy245 = 0, int dummy255 = 0, int dummy265 = 0, int dummy275 = 0, int dummy285 = 0, int dummy295 = 0,
+			int dummy206 = 0, int dummy216 = 0, int dummy226 = 0, int dummy236 = 0, int dummy246 = 0, int dummy256 = 0, int dummy266 = 0, int dummy276 = 0, int dummy286 = 0, int dummy296 = 0,
+			int dummy207 = 0, int dummy217 = 0, int dummy227 = 0, int dummy237 = 0, int dummy247 = 0, int dummy257 = 0, int dummy267 = 0, int dummy277 = 0, int dummy287 = 0, int dummy297 = 0,
+			int dummy208 = 0, int dummy218 = 0, int dummy228 = 0, int dummy238 = 0, int dummy248 = 0, int dummy258 = 0, int dummy268 = 0, int dummy278 = 0, int dummy288 = 0, int dummy298 = 0,
+			int dummy209 = 0, int dummy219 = 0, int dummy229 = 0, int dummy239 = 0, int dummy249 = 0, int dummy259 = 0, int dummy269 = 0, int dummy279 = 0, int dummy289 = 0, int dummy299 = 0,
+
+			Action<IntPtr> block_callback = null
+		)
+		{
+			// ldarg
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		Action<IntPtr> block_callback_instance_field;
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_LoadField (Action callback)
+		{
+			// ldfld
+			BlockLiteral block = new BlockLiteral ();
+			block_callback_instance_field = block_callback;
+			block.SetupBlock (block_callback_instance_field, callback);
+			block_callback_instance_field = null;
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_LoadStaticField (Action callback)
+		{
+			// ldsfld
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		protected virtual Action<IntPtr> GetBlockCallbackInstance ()
+		{
+			return block_callback;
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_CallVirtualMethod (Action callback)
+		{
+			// calli
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (GetBlockCallbackInstance (), callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		static Action<IntPtr> GetBlockCallbackStatic ()
+		{
+			return block_callback;
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_CallStaticMethod (Action callback)
+		{
+			// call
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (GetBlockCallbackStatic (), callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_LoadLocalVariable0 (Action callback)
+		{
+			var block_callback = BaseOptimizeGeneratedCodeTest.block_callback; // ldloc_0
+
+			// Load the trampoline from a instance method call
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_LoadLocalVariable1 (Action callback)
+		{
+			int dummy0 = 0;
+			var block_callback = BaseOptimizeGeneratedCodeTest.block_callback; // ldloc_1
+
+			// Load the trampoline from a instance method call
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+
+			// Use the variables so that the compiler doesn't optimize them away
+			GC.KeepAlive (dummy0);
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_LoadLocalVariable2 (Action callback)
+		{
+			int dummy0 = 0, dummy1 = 0;
+			var block_callback = BaseOptimizeGeneratedCodeTest.block_callback; // ldloc_2
+
+			// Load the trampoline from a instance method call
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+
+			// Use the variables so that the compiler doesn't optimize them away
+			GC.KeepAlive (dummy0);
+			GC.KeepAlive (dummy1);
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_LoadLocalVariable3 (Action callback)
+		{
+			int dummy0 = 0, dummy1 = 0, dummy2 = 0;
+			var block_callback = BaseOptimizeGeneratedCodeTest.block_callback; // ldloc_3
+
+			// Load the trampoline from a instance method call
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+
+			// Use the variables so that the compiler doesn't optimize them away
+			GC.KeepAlive (dummy0);
+			GC.KeepAlive (dummy1);
+			GC.KeepAlive (dummy2);
+		}
+		
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_LoadLocalVariable4 (Action callback)
+		{
+			int dummy0 = 0, dummy1 = 0, dummy2 = 0, dummy3 = 0;
+			var block_callback = BaseOptimizeGeneratedCodeTest.block_callback; // ldloc_S
+
+			// Load the trampoline from a instance method call
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+
+			// Use the variables so that the compiler doesn't optimize them away
+			GC.KeepAlive (dummy0);
+			GC.KeepAlive (dummy1);
+			GC.KeepAlive (dummy2);
+			GC.KeepAlive (dummy3);
+		}
+
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		void SetupBlockOptimized_LoadLocalVariable (Action callback)
+		{
+			int dummy000 = 0, dummy010 = 0, dummy020 = 0, dummy030 = 0, dummy040 = 0, dummy050 = 0, dummy060 = 0, dummy070 = 0, dummy080 = 0, dummy090 = 0;
+			int dummy001 = 0, dummy011 = 0, dummy021 = 0, dummy031 = 0, dummy041 = 0, dummy051 = 0, dummy061 = 0, dummy071 = 0, dummy081 = 0, dummy091 = 0;
+			int dummy002 = 0, dummy012 = 0, dummy022 = 0, dummy032 = 0, dummy042 = 0, dummy052 = 0, dummy062 = 0, dummy072 = 0, dummy082 = 0, dummy092 = 0;
+			int dummy003 = 0, dummy013 = 0, dummy023 = 0, dummy033 = 0, dummy043 = 0, dummy053 = 0, dummy063 = 0, dummy073 = 0, dummy083 = 0, dummy093 = 0;
+			int dummy004 = 0, dummy014 = 0, dummy024 = 0, dummy034 = 0, dummy044 = 0, dummy054 = 0, dummy064 = 0, dummy074 = 0, dummy084 = 0, dummy094 = 0;
+			int dummy005 = 0, dummy015 = 0, dummy025 = 0, dummy035 = 0, dummy045 = 0, dummy055 = 0, dummy065 = 0, dummy075 = 0, dummy085 = 0, dummy095 = 0;
+			int dummy006 = 0, dummy016 = 0, dummy026 = 0, dummy036 = 0, dummy046 = 0, dummy056 = 0, dummy066 = 0, dummy076 = 0, dummy086 = 0, dummy096 = 0;
+			int dummy007 = 0, dummy017 = 0, dummy027 = 0, dummy037 = 0, dummy047 = 0, dummy057 = 0, dummy067 = 0, dummy077 = 0, dummy087 = 0, dummy097 = 0;
+			int dummy008 = 0, dummy018 = 0, dummy028 = 0, dummy038 = 0, dummy048 = 0, dummy058 = 0, dummy068 = 0, dummy078 = 0, dummy088 = 0, dummy098 = 0;
+			int dummy009 = 0, dummy019 = 0, dummy029 = 0, dummy039 = 0, dummy049 = 0, dummy059 = 0, dummy069 = 0, dummy079 = 0, dummy089 = 0, dummy099 = 0;
+			int dummy100 = 0, dummy110 = 0, dummy120 = 0, dummy130 = 0, dummy140 = 0, dummy150 = 0, dummy160 = 0, dummy170 = 0, dummy180 = 0, dummy190 = 0;
+			int dummy101 = 0, dummy111 = 0, dummy121 = 0, dummy131 = 0, dummy141 = 0, dummy151 = 0, dummy161 = 0, dummy171 = 0, dummy181 = 0, dummy191 = 0;
+			int dummy102 = 0, dummy112 = 0, dummy122 = 0, dummy132 = 0, dummy142 = 0, dummy152 = 0, dummy162 = 0, dummy172 = 0, dummy182 = 0, dummy192 = 0;
+			int dummy103 = 0, dummy113 = 0, dummy123 = 0, dummy133 = 0, dummy143 = 0, dummy153 = 0, dummy163 = 0, dummy173 = 0, dummy183 = 0, dummy193 = 0;
+			int dummy104 = 0, dummy114 = 0, dummy124 = 0, dummy134 = 0, dummy144 = 0, dummy154 = 0, dummy164 = 0, dummy174 = 0, dummy184 = 0, dummy194 = 0;
+			int dummy105 = 0, dummy115 = 0, dummy125 = 0, dummy135 = 0, dummy145 = 0, dummy155 = 0, dummy165 = 0, dummy175 = 0, dummy185 = 0, dummy195 = 0;
+			int dummy106 = 0, dummy116 = 0, dummy126 = 0, dummy136 = 0, dummy146 = 0, dummy156 = 0, dummy166 = 0, dummy176 = 0, dummy186 = 0, dummy196 = 0;
+			int dummy107 = 0, dummy117 = 0, dummy127 = 0, dummy137 = 0, dummy147 = 0, dummy157 = 0, dummy167 = 0, dummy177 = 0, dummy187 = 0, dummy197 = 0;
+			int dummy108 = 0, dummy118 = 0, dummy128 = 0, dummy138 = 0, dummy148 = 0, dummy158 = 0, dummy168 = 0, dummy178 = 0, dummy188 = 0, dummy198 = 0;
+			int dummy109 = 0, dummy119 = 0, dummy129 = 0, dummy139 = 0, dummy149 = 0, dummy159 = 0, dummy169 = 0, dummy179 = 0, dummy189 = 0, dummy199 = 0;
+			int dummy200 = 0, dummy210 = 0, dummy220 = 0, dummy230 = 0, dummy240 = 0, dummy250 = 0, dummy260 = 0, dummy270 = 0, dummy280 = 0, dummy290 = 0;
+			int dummy201 = 0, dummy211 = 0, dummy221 = 0, dummy231 = 0, dummy241 = 0, dummy251 = 0, dummy261 = 0, dummy271 = 0, dummy281 = 0, dummy291 = 0;
+			int dummy202 = 0, dummy212 = 0, dummy222 = 0, dummy232 = 0, dummy242 = 0, dummy252 = 0, dummy262 = 0, dummy272 = 0, dummy282 = 0, dummy292 = 0;
+			int dummy203 = 0, dummy213 = 0, dummy223 = 0, dummy233 = 0, dummy243 = 0, dummy253 = 0, dummy263 = 0, dummy273 = 0, dummy283 = 0, dummy293 = 0;
+			int dummy204 = 0, dummy214 = 0, dummy224 = 0, dummy234 = 0, dummy244 = 0, dummy254 = 0, dummy264 = 0, dummy274 = 0, dummy284 = 0, dummy294 = 0;
+			int dummy205 = 0, dummy215 = 0, dummy225 = 0, dummy235 = 0, dummy245 = 0, dummy255 = 0, dummy265 = 0, dummy275 = 0, dummy285 = 0, dummy295 = 0;
+			int dummy206 = 0, dummy216 = 0, dummy226 = 0, dummy236 = 0, dummy246 = 0, dummy256 = 0, dummy266 = 0, dummy276 = 0, dummy286 = 0, dummy296 = 0;
+			int dummy207 = 0, dummy217 = 0, dummy227 = 0, dummy237 = 0, dummy247 = 0, dummy257 = 0, dummy267 = 0, dummy277 = 0, dummy287 = 0, dummy297 = 0;
+			int dummy208 = 0, dummy218 = 0, dummy228 = 0, dummy238 = 0, dummy248 = 0, dummy258 = 0, dummy268 = 0, dummy278 = 0, dummy288 = 0, dummy298 = 0;
+			int dummy209 = 0, dummy219 = 0, dummy229 = 0, dummy239 = 0, dummy249 = 0, dummy259 = 0, dummy269 = 0, dummy279 = 0, dummy289 = 0, dummy299 = 0;
+			var block_callback = BaseOptimizeGeneratedCodeTest.block_callback; // ldloc
+
+			// Load the trampoline from a instance method call
+			BlockLiteral block = new BlockLiteral ();
+			block.SetupBlock (block_callback, callback);
+			Bindings.Test.CFunctions.x_call_block (ref block);
+			block.CleanupBlock ();
+
+			// Use the variables so that the compiler doesn't optimize them away
+			GC.KeepAlive (dummy000); GC.KeepAlive (dummy010); GC.KeepAlive (dummy020); GC.KeepAlive (dummy030); GC.KeepAlive (dummy040); GC.KeepAlive (dummy050); GC.KeepAlive (dummy060); GC.KeepAlive (dummy070); GC.KeepAlive (dummy080); GC.KeepAlive (dummy090);
+			GC.KeepAlive (dummy001); GC.KeepAlive (dummy011); GC.KeepAlive (dummy021); GC.KeepAlive (dummy031); GC.KeepAlive (dummy041); GC.KeepAlive (dummy051); GC.KeepAlive (dummy061); GC.KeepAlive (dummy071); GC.KeepAlive (dummy081); GC.KeepAlive (dummy091);
+			GC.KeepAlive (dummy002); GC.KeepAlive (dummy012); GC.KeepAlive (dummy022); GC.KeepAlive (dummy032); GC.KeepAlive (dummy042); GC.KeepAlive (dummy052); GC.KeepAlive (dummy062); GC.KeepAlive (dummy072); GC.KeepAlive (dummy082); GC.KeepAlive (dummy092);
+			GC.KeepAlive (dummy003); GC.KeepAlive (dummy013); GC.KeepAlive (dummy023); GC.KeepAlive (dummy033); GC.KeepAlive (dummy043); GC.KeepAlive (dummy053); GC.KeepAlive (dummy063); GC.KeepAlive (dummy073); GC.KeepAlive (dummy083); GC.KeepAlive (dummy093);
+			GC.KeepAlive (dummy004); GC.KeepAlive (dummy014); GC.KeepAlive (dummy024); GC.KeepAlive (dummy034); GC.KeepAlive (dummy044); GC.KeepAlive (dummy054); GC.KeepAlive (dummy064); GC.KeepAlive (dummy074); GC.KeepAlive (dummy084); GC.KeepAlive (dummy094);
+			GC.KeepAlive (dummy005); GC.KeepAlive (dummy015); GC.KeepAlive (dummy025); GC.KeepAlive (dummy035); GC.KeepAlive (dummy045); GC.KeepAlive (dummy055); GC.KeepAlive (dummy065); GC.KeepAlive (dummy075); GC.KeepAlive (dummy085); GC.KeepAlive (dummy095);
+			GC.KeepAlive (dummy006); GC.KeepAlive (dummy016); GC.KeepAlive (dummy026); GC.KeepAlive (dummy036); GC.KeepAlive (dummy046); GC.KeepAlive (dummy056); GC.KeepAlive (dummy066); GC.KeepAlive (dummy076); GC.KeepAlive (dummy086); GC.KeepAlive (dummy096);
+			GC.KeepAlive (dummy007); GC.KeepAlive (dummy017); GC.KeepAlive (dummy027); GC.KeepAlive (dummy037); GC.KeepAlive (dummy047); GC.KeepAlive (dummy057); GC.KeepAlive (dummy067); GC.KeepAlive (dummy077); GC.KeepAlive (dummy087); GC.KeepAlive (dummy097);
+			GC.KeepAlive (dummy008); GC.KeepAlive (dummy018); GC.KeepAlive (dummy028); GC.KeepAlive (dummy038); GC.KeepAlive (dummy048); GC.KeepAlive (dummy058); GC.KeepAlive (dummy068); GC.KeepAlive (dummy078); GC.KeepAlive (dummy088); GC.KeepAlive (dummy098);
+			GC.KeepAlive (dummy009); GC.KeepAlive (dummy019); GC.KeepAlive (dummy029); GC.KeepAlive (dummy039); GC.KeepAlive (dummy049); GC.KeepAlive (dummy059); GC.KeepAlive (dummy069); GC.KeepAlive (dummy079); GC.KeepAlive (dummy089); GC.KeepAlive (dummy099);
+			GC.KeepAlive (dummy100); GC.KeepAlive (dummy110); GC.KeepAlive (dummy120); GC.KeepAlive (dummy130); GC.KeepAlive (dummy140); GC.KeepAlive (dummy150); GC.KeepAlive (dummy160); GC.KeepAlive (dummy170); GC.KeepAlive (dummy180); GC.KeepAlive (dummy190);
+			GC.KeepAlive (dummy101); GC.KeepAlive (dummy111); GC.KeepAlive (dummy121); GC.KeepAlive (dummy131); GC.KeepAlive (dummy141); GC.KeepAlive (dummy151); GC.KeepAlive (dummy161); GC.KeepAlive (dummy171); GC.KeepAlive (dummy181); GC.KeepAlive (dummy191);
+			GC.KeepAlive (dummy102); GC.KeepAlive (dummy112); GC.KeepAlive (dummy122); GC.KeepAlive (dummy132); GC.KeepAlive (dummy142); GC.KeepAlive (dummy152); GC.KeepAlive (dummy162); GC.KeepAlive (dummy172); GC.KeepAlive (dummy182); GC.KeepAlive (dummy192);
+			GC.KeepAlive (dummy103); GC.KeepAlive (dummy113); GC.KeepAlive (dummy123); GC.KeepAlive (dummy133); GC.KeepAlive (dummy143); GC.KeepAlive (dummy153); GC.KeepAlive (dummy163); GC.KeepAlive (dummy173); GC.KeepAlive (dummy183); GC.KeepAlive (dummy193);
+			GC.KeepAlive (dummy104); GC.KeepAlive (dummy114); GC.KeepAlive (dummy124); GC.KeepAlive (dummy134); GC.KeepAlive (dummy144); GC.KeepAlive (dummy154); GC.KeepAlive (dummy164); GC.KeepAlive (dummy174); GC.KeepAlive (dummy184); GC.KeepAlive (dummy194);
+			GC.KeepAlive (dummy105); GC.KeepAlive (dummy115); GC.KeepAlive (dummy125); GC.KeepAlive (dummy135); GC.KeepAlive (dummy145); GC.KeepAlive (dummy155); GC.KeepAlive (dummy165); GC.KeepAlive (dummy175); GC.KeepAlive (dummy185); GC.KeepAlive (dummy195);
+			GC.KeepAlive (dummy106); GC.KeepAlive (dummy116); GC.KeepAlive (dummy126); GC.KeepAlive (dummy136); GC.KeepAlive (dummy146); GC.KeepAlive (dummy156); GC.KeepAlive (dummy166); GC.KeepAlive (dummy176); GC.KeepAlive (dummy186); GC.KeepAlive (dummy196);
+			GC.KeepAlive (dummy107); GC.KeepAlive (dummy117); GC.KeepAlive (dummy127); GC.KeepAlive (dummy137); GC.KeepAlive (dummy147); GC.KeepAlive (dummy157); GC.KeepAlive (dummy167); GC.KeepAlive (dummy177); GC.KeepAlive (dummy187); GC.KeepAlive (dummy197);
+			GC.KeepAlive (dummy108); GC.KeepAlive (dummy118); GC.KeepAlive (dummy128); GC.KeepAlive (dummy138); GC.KeepAlive (dummy148); GC.KeepAlive (dummy158); GC.KeepAlive (dummy168); GC.KeepAlive (dummy178); GC.KeepAlive (dummy188); GC.KeepAlive (dummy198);
+			GC.KeepAlive (dummy109); GC.KeepAlive (dummy119); GC.KeepAlive (dummy129); GC.KeepAlive (dummy139); GC.KeepAlive (dummy149); GC.KeepAlive (dummy159); GC.KeepAlive (dummy169); GC.KeepAlive (dummy179); GC.KeepAlive (dummy189); GC.KeepAlive (dummy199);
+			GC.KeepAlive (dummy200); GC.KeepAlive (dummy210); GC.KeepAlive (dummy220); GC.KeepAlive (dummy230); GC.KeepAlive (dummy240); GC.KeepAlive (dummy250); GC.KeepAlive (dummy260); GC.KeepAlive (dummy270); GC.KeepAlive (dummy280); GC.KeepAlive (dummy290);
+			GC.KeepAlive (dummy201); GC.KeepAlive (dummy211); GC.KeepAlive (dummy221); GC.KeepAlive (dummy231); GC.KeepAlive (dummy241); GC.KeepAlive (dummy251); GC.KeepAlive (dummy261); GC.KeepAlive (dummy271); GC.KeepAlive (dummy281); GC.KeepAlive (dummy291);
+			GC.KeepAlive (dummy202); GC.KeepAlive (dummy212); GC.KeepAlive (dummy222); GC.KeepAlive (dummy232); GC.KeepAlive (dummy242); GC.KeepAlive (dummy252); GC.KeepAlive (dummy262); GC.KeepAlive (dummy272); GC.KeepAlive (dummy282); GC.KeepAlive (dummy292);
+			GC.KeepAlive (dummy203); GC.KeepAlive (dummy213); GC.KeepAlive (dummy223); GC.KeepAlive (dummy233); GC.KeepAlive (dummy243); GC.KeepAlive (dummy253); GC.KeepAlive (dummy263); GC.KeepAlive (dummy273); GC.KeepAlive (dummy283); GC.KeepAlive (dummy293);
+			GC.KeepAlive (dummy204); GC.KeepAlive (dummy214); GC.KeepAlive (dummy224); GC.KeepAlive (dummy234); GC.KeepAlive (dummy244); GC.KeepAlive (dummy254); GC.KeepAlive (dummy264); GC.KeepAlive (dummy274); GC.KeepAlive (dummy284); GC.KeepAlive (dummy294);
+			GC.KeepAlive (dummy205); GC.KeepAlive (dummy215); GC.KeepAlive (dummy225); GC.KeepAlive (dummy235); GC.KeepAlive (dummy245); GC.KeepAlive (dummy255); GC.KeepAlive (dummy265); GC.KeepAlive (dummy275); GC.KeepAlive (dummy285); GC.KeepAlive (dummy295);
+			GC.KeepAlive (dummy206); GC.KeepAlive (dummy216); GC.KeepAlive (dummy226); GC.KeepAlive (dummy236); GC.KeepAlive (dummy246); GC.KeepAlive (dummy256); GC.KeepAlive (dummy266); GC.KeepAlive (dummy276); GC.KeepAlive (dummy286); GC.KeepAlive (dummy296);
+			GC.KeepAlive (dummy207); GC.KeepAlive (dummy217); GC.KeepAlive (dummy227); GC.KeepAlive (dummy237); GC.KeepAlive (dummy247); GC.KeepAlive (dummy257); GC.KeepAlive (dummy267); GC.KeepAlive (dummy277); GC.KeepAlive (dummy287); GC.KeepAlive (dummy297);
+			GC.KeepAlive (dummy208); GC.KeepAlive (dummy218); GC.KeepAlive (dummy228); GC.KeepAlive (dummy238); GC.KeepAlive (dummy248); GC.KeepAlive (dummy258); GC.KeepAlive (dummy268); GC.KeepAlive (dummy278); GC.KeepAlive (dummy288); GC.KeepAlive (dummy298);
+			GC.KeepAlive (dummy209); GC.KeepAlive (dummy219); GC.KeepAlive (dummy229); GC.KeepAlive (dummy239); GC.KeepAlive (dummy249); GC.KeepAlive (dummy259); GC.KeepAlive (dummy269); GC.KeepAlive (dummy279); GC.KeepAlive (dummy289); GC.KeepAlive (dummy299);
+		}
 	}
 }

--- a/tests/linker/BaseOptimizeGeneratedCodeTest.cs
+++ b/tests/linker/BaseOptimizeGeneratedCodeTest.cs
@@ -25,7 +25,7 @@ using NUnit.Framework;
 namespace Linker.Shared
 {
 	[Preserve (AllMembers = true)]
-	public class BaseOptimizeGeneratedCodeTest
+	public abstract class BaseOptimizeGeneratedCodeTest
 	{
 		[Test]
 		public void SetupBlock_CustomDelegate ()

--- a/tests/linker/BaseOptimizeGeneratedCodeTest.cs
+++ b/tests/linker/BaseOptimizeGeneratedCodeTest.cs
@@ -1,0 +1,31 @@
+//
+// Unit tests for the linker's OptimizeGeneratedCodeSubStep.
+//
+// This class is included in both Xamarin.Mac and Xamarin.iOS's link all tests
+//
+// Authors:
+//	Rolf Bjarne Kvinge <rolf@xamarin.com>
+//
+// Copyright 2018 Microsoft Inc. All rights reserved.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+using Foundation;
+using ObjCRuntime;
+
+using NUnit.Framework;
+
+namespace Linker.Shared
+{
+	[Preserve (AllMembers = true)]
+	public class BaseOptimizeGeneratedCodeTest
+	{
+	}
+}

--- a/tests/linker/BaseOptimizeGeneratedCodeTest.cs
+++ b/tests/linker/BaseOptimizeGeneratedCodeTest.cs
@@ -35,7 +35,7 @@ namespace Linker.Shared
 			var action = new Action (() => counter++);
 			Custom (action);
 			CustomWithAttribute (action);
-			Assert.AreEqual (1, counter, "Counter");
+			Assert.AreEqual (2, counter, "Counter");
 		}
 
 		delegate void CustomDelegate (IntPtr block);

--- a/tests/linker/ios/link all/link all.csproj
+++ b/tests/linker/ios/link all/link all.csproj
@@ -27,6 +27,7 @@
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchExtraArgs>--registrar=static --optimize=all</MtouchExtraArgs>
     <MtouchArch>i386, x86_64</MtouchArch>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>
@@ -39,6 +40,7 @@
     <MtouchArch>i386, x86_64</MtouchArch>
     <DefineConstants>LINKALL;;$(DefineConstants)</DefineConstants>
     <MtouchExtraArgs>--optimize=all</MtouchExtraArgs>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>True</DebugSymbols>
@@ -55,6 +57,7 @@
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchExtraArgs>-gcc_flags="-UhoItsB0rken" --optimize=all</MtouchExtraArgs>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug32|iPhone' ">
     <DebugSymbols>True</DebugSymbols>
@@ -70,6 +73,7 @@
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchArch>ARMv7</MtouchArch>
     <MtouchExtraArgs>-gcc_flags="-UhoItsB0rken" --optimize=all</MtouchExtraArgs>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug64|iPhone' ">
     <DebugSymbols>True</DebugSymbols>
@@ -85,6 +89,7 @@
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchArch>ARM64</MtouchArch>
     <MtouchExtraArgs>-gcc_flags="-UhoItsB0rken" --optimize=all</MtouchExtraArgs>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
@@ -99,6 +104,7 @@
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchExtraArgs>--optimize=all</MtouchExtraArgs>
     <DefineConstants>LINKALL;;$(DefineConstants)</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release32|iPhone' ">
     <DebugType>none</DebugType>
@@ -113,6 +119,7 @@
     <MtouchArch>ARMv7</MtouchArch>
     <MtouchExtraArgs>--optimize=all</MtouchExtraArgs>
     <DefineConstants>LINKALL;;$(DefineConstants)</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release64|iPhone' ">
     <DebugType>none</DebugType>
@@ -127,6 +134,7 @@
     <MtouchArch>ARM64</MtouchArch>
     <MtouchExtraArgs>--optimize=all</MtouchExtraArgs>
     <DefineConstants>LINKALL;;$(DefineConstants)</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-bitcode|iPhone' ">
     <DebugType>none</DebugType>
@@ -141,6 +149,7 @@
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchExtraArgs>--bitcode:full --optimize=all</MtouchExtraArgs>
     <DefineConstants>LINKALL;;$(DefineConstants)</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/linker/ios/link all/link all.csproj
+++ b/tests/linker/ios/link all/link all.csproj
@@ -168,6 +168,7 @@
     <Compile Include="AttributeTest.cs" />
     <Compile Include="InterfacesTest.cs" />
     <Compile Include="DataContractTest.cs" />
+    <Compile Include="..\..\BaseOptimizeGeneratedCodeTest.cs" />
     <Compile Include="..\link sdk\OptimizeGeneratedCodeTest.cs">
       <Link>OptimizeGeneratedCodeTest.cs</Link>
     </Compile>

--- a/tests/linker/ios/link sdk/OptimizeGeneratedCodeTest.cs
+++ b/tests/linker/ios/link sdk/OptimizeGeneratedCodeTest.cs
@@ -67,7 +67,7 @@ namespace Linker.Shared {
 	[TestFixture]
 	// we want the test to be availble if we use the linker
 	[Preserve (AllMembers = true)]
-	public class OptimizeGeneratedCodeTest {
+	public class OptimizeGeneratedCodeTest : BaseOptimizeGeneratedCodeTest {
 		
 		// tests related to IL re-writting inside OptimizeGeneratedCodeSubStep
 		

--- a/tests/linker/ios/link sdk/link sdk.csproj
+++ b/tests/linker/ios/link sdk/link sdk.csproj
@@ -26,6 +26,7 @@
     <MtouchExtraArgs>-v -v -disable-thread-check -xml=${ProjectDir}/extra-linker-defs.xml</MtouchExtraArgs>
     <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchLink>SdkOnly</MtouchLink>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>
@@ -36,6 +37,7 @@
     <MtouchExtraArgs>-v -v -xml=${ProjectDir}/extra-linker-defs.xml</MtouchExtraArgs>
     <MtouchArch>i386, x86_64</MtouchArch>
     <DefineConstants>DO_NOT_REMOVE;;$(DefineConstants)</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>True</DebugSymbols>
@@ -50,6 +52,7 @@
     <MtouchExtraArgs>-v -v -xml=${ProjectDir}/extra-linker-defs.xml "--dlsym:-link sdk" -gcc_flags="-UhoItsB0rken"</MtouchExtraArgs>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug32|iPhone' ">
     <DebugSymbols>True</DebugSymbols>
@@ -64,6 +67,7 @@
     <MtouchExtraArgs>-v -v -xml=${ProjectDir}/extra-linker-defs.xml "--dlsym:-link sdk" -gcc_flags="-UhoItsB0rken"</MtouchExtraArgs>
     <MtouchArch>ARMv7</MtouchArch>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug64|iPhone' ">
     <DebugSymbols>True</DebugSymbols>
@@ -78,6 +82,7 @@
     <MtouchExtraArgs>-v -v -xml=${ProjectDir}/extra-linker-defs.xml "--dlsym:-link sdk" -gcc_flags="-UhoItsB0rken"</MtouchExtraArgs>
     <MtouchArch>ARM64</MtouchArch>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
@@ -90,6 +95,7 @@
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <DefineConstants>DO_NOT_REMOVE;XAMARIN_APPLETLS;;$(DefineConstants)</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release32|iPhone' ">
     <DebugType>none</DebugType>
@@ -102,6 +108,7 @@
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchArch>ARMv7</MtouchArch>
     <DefineConstants>DO_NOT_REMOVE;XAMARIN_APPLETLS;;$(DefineConstants)</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release64|iPhone' ">
     <DebugType>none</DebugType>
@@ -114,6 +121,7 @@
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchArch>ARM64</MtouchArch>
     <DefineConstants>DO_NOT_REMOVE;XAMARIN_APPLETLS;;$(DefineConstants)</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-bitcode|iPhone' ">
     <DebugType>none</DebugType>
@@ -126,6 +134,7 @@
     <MtouchUseLlvm>true</MtouchUseLlvm>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <DefineConstants>DO_NOT_REMOVE;XAMARIN_APPLETLS;;$(DefineConstants)</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -197,6 +206,10 @@
     <ProjectReference Include="..\..\..\BundledResources\BundledResources.csproj">
       <Project>{FE6EDEE9-ADF6-4F42-BCF2-B68C0A44EC3D}</Project>
       <Name>BundledResources</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\bindings-test\bindings-test.csproj">
+      <Project>{D6667423-EDD8-4B50-9D98-1AC5D8A8A4EA}</Project>
+      <Name>bindings-test</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/tests/linker/ios/link sdk/link sdk.csproj
+++ b/tests/linker/ios/link sdk/link sdk.csproj
@@ -159,6 +159,7 @@
     <Compile Include="LinkSdkRegressionTest.cs" />
     <Compile Include="Bug1820Test.cs" />
     <Compile Include="Bug2096Test.cs" />
+    <Compile Include="..\..\BaseOptimizeGeneratedCodeTest.cs" />
     <Compile Include="OptimizeGeneratedCodeTest.cs" />
     <Compile Include="AotBugs.cs" />
     <Compile Include="CryptoTest.cs" />

--- a/tests/linker/mac/link all/OptimizeGeneratedCodeTest.cs
+++ b/tests/linker/mac/link all/OptimizeGeneratedCodeTest.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+using Foundation;
+
+using NUnit.Framework;
+
+namespace Linker.Shared
+{
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class OptimizeGeneratedCodeTest : BaseOptimizeGeneratedCodeTest
+	{
+	}
+}

--- a/tests/linker/mac/link all/link all-mac.csproj
+++ b/tests/linker/mac/link all/link all-mac.csproj
@@ -65,10 +65,12 @@
     <Compile Include="..\..\..\common\mac\Mac.cs">
       <Link>Mac.cs</Link>
     </Compile>
+    <Compile Include="..\..\BaseOptimizeGeneratedCodeTest.cs" />
     <Compile Include="LinkAllTest.cs" />
     <Compile Include="..\..\..\common\PlatformInfo.cs">
       <Link>PlatformInfo.cs</Link>
     </Compile>
+    <Compile Include="OptimizeGeneratedCodeTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\external\guiunit\src\framework\GuiUnit_xammac_mobile.csproj">

--- a/tests/linker/mac/link all/link all-mac.csproj
+++ b/tests/linker/mac/link all/link all-mac.csproj
@@ -17,7 +17,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\$(Platform)\Debug</OutputPath>
-    <DefineConstants>__UNIFIED__;__MACOS__;DEBUG</DefineConstants>
+    <DefineConstants>__UNIFIED__;__MACOS__;DEBUG;LINKALL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <EnableCodeSigning>false</EnableCodeSigning>
@@ -38,7 +38,7 @@
     <DebugType></DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\$(Platform)\Release</OutputPath>
-    <DefineConstants>__UNIFIED__;__MACOS__</DefineConstants>
+    <DefineConstants>__UNIFIED__;__MACOS__;LINKALL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <EnableCodeSigning>false</EnableCodeSigning>

--- a/tests/linker/mac/link all/link all-mac.csproj
+++ b/tests/linker/mac/link all/link all-mac.csproj
@@ -31,6 +31,8 @@
     <LinkMode>Full</LinkMode>
     <XamMacArch></XamMacArch>
     <AOTMode>None</AOTMode>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <MonoBundlingExtraArgs>--optimize=all</MonoBundlingExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DebugType></DebugType>
@@ -49,6 +51,8 @@
     <HttpClientHandler></HttpClientHandler>
     <XamMacArch></XamMacArch>
     <AOTMode>None</AOTMode>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <MonoBundlingExtraArgs>--optimize=all</MonoBundlingExtraArgs>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -15,14 +15,14 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>__UNIFIED__;DEBUG;XAMCORE_2_0;MONOMAC;MMP_TEST</DefineConstants>
+    <DefineConstants>__UNIFIED__;DEBUG;XAMCORE_2_0;MONOMAC;MMP_TEST;__MACOS__</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\Release</OutputPath>
-    <DefineConstants>__UNIFIED__;XAMCORE_2_0;MONOMAC;MMP_TEST</DefineConstants>
+    <DefineConstants>__UNIFIED__;XAMCORE_2_0;MONOMAC;MMP_TEST;__MACOS__</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -82,6 +82,12 @@
     </Compile>
     <Compile Include="..\common\ExecutionHelper.cs">
       <Link>src\ExecutionHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\common\ApiTest.cs">
+      <Link>src\ApiTest.cs</Link>
+    </Compile>
+    <Compile Include="..\common\BundlerTest.cs">
+      <Link>src\BundlerTest.cs</Link>
     </Compile>
     <Compile Include="..\common\Profile.cs">
       <Link>Profile.cs</Link>

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -842,7 +842,7 @@ namespace Xamarin.MMP.Tests
 						"<LinkMode>Full</LinkMode>",
 				};
 				var rv = TI.TestUnifiedExecutable (test, shouldFail: false);
-				rv.Messages.AssertWarning (132, $"Unknown optimization: '{opt}'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size.");
+				rv.Messages.AssertWarning (132, $"Unknown optimization: '{opt}'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size, blockliteral-setupblock.");
 				rv.Messages.AssertErrorCount (0);
 			});
 		}

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1639,7 +1639,7 @@ public class TestApp {
 				mtouch.Linker = MTouchLinker.LinkSdk;
 				mtouch.Optimize = new string [] { "foo" };
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build");
-				mtouch.AssertWarning (132, "Unknown optimization: 'foo'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size, inline-runtime-arch.");
+				mtouch.AssertWarning (132, "Unknown optimization: 'foo'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size, inline-runtime-arch, blockliteral-setupblock.");
 			}
 		}
 
@@ -3265,7 +3265,8 @@ public partial class NotificationService : UNNotificationServiceExtension
 				mtouch.AssertWarning (2003, "Option '--optimize=inline-isdirectbinding' will be ignored since linking is disabled");
 				mtouch.AssertWarning (2003, "Option '--optimize=inline-intptr-size' will be ignored since linking is disabled");
 				mtouch.AssertWarning (2003, "Option '--optimize=inline-runtime-arch' will be ignored since linking is disabled");
-				mtouch.AssertWarningCount (5);
+				mtouch.AssertWarning (2003, "Option '--optimize=blockliteral-setupblock' will be ignored since linking is disabled");
+				mtouch.AssertWarningCount (6);
 			}
 
 			using (var mtouch = new MTouchTool ()) {

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -41,7 +41,7 @@ namespace Xamarin
 	{
 #pragma warning disable 649
 		// These map directly to mtouch options
-		MTouchAction? Action; // --sim, --dev, --launchsim, etc
+		public MTouchAction? Action; // --sim, --dev, --launchsim, etc
 		public bool? NoSign;
 		public bool? FastDev;
 		public bool? Dlsym;
@@ -125,7 +125,8 @@ namespace Xamarin
 
 		public void AssertExecuteFailure (MTouchAction action, string message = null)
 		{
-			NUnit.Framework.Assert.AreEqual (1, Execute (action), message);
+			Action = action;
+			NUnit.Framework.Assert.AreEqual (1, Execute (), message);
 		}
 
 		// Assert that none of the files in the app has changed (except 'except' files)

--- a/tests/mtouch/mtouch.csproj
+++ b/tests/mtouch/mtouch.csproj
@@ -57,6 +57,12 @@
       <Link>ProductTests.cs</Link>
     </Compile>
     <Compile Include="StringUtilsTest.cs" />
+    <Compile Include="..\common\ApiTest.cs">
+      <Link>ApiTest.cs</Link>
+    </Compile>
+    <Compile Include="..\common\BundlerTest.cs">
+      <Link>BundlerTest.cs</Link>
+    </Compile>
     <Compile Include="..\common\Profile.cs">
       <Link>Profile.cs</Link>
     </Compile>

--- a/tests/test-libraries/Makefile
+++ b/tests/test-libraries/Makefile
@@ -55,7 +55,7 @@ clean-$(1):
 	rm -Rf .libs/$(1)
 
 CLEAN_TARGETS += clean-$(1)
-EXTRA_DEPENDENCIES = libtest.h $(GENERATED_FILES)
+EXTRA_DEPENDENCIES = libtest.h $(GENERATED_FILES) rename.h
 
 .libs/$(1)/libtest-object.%.o: export EXTRA_DEFINES=-DPREFIX=1
 .libs/$(1)/libtest-ar.%.o: export EXTRA_DEFINES=-DPREFIX=2

--- a/tests/test-libraries/libtest.h
+++ b/tests/test-libraries/libtest.h
@@ -14,6 +14,9 @@ extern "C" {
 int theUltimateAnswer ();
 void useZLib ();
 
+typedef void (^x_block_callback)();
+void x_call_block (x_block_callback block);
+
 void x_get_matrix_float2x2 (id self, const char *sel, float* r0c0, float* r0c1, float* r1c0, float* r1c1);
 void x_get_matrix_float3x3 (id self, const char *sel, float* r0c0, float* r0c1, float* r0c2, float* r1c0, float* r1c1, float* r1c2, float* r2c0, float* r2c1, float* r2c2);
 void x_get_matrix_float4x4 (id self, const char *sel, float* r0c0, float* r0c1, float* r0c2, float* r0c3, float* r1c0, float* r1c1, float* r1c2, float* r1c3, float* r2c0, float* r2c1, float* r2c2, float* r2c3, float* r3c0, float* r3c1, float* r3c2, float* r3c3);

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -17,6 +17,11 @@ void useZLib ()
 	printf ("ZLib version: %s\n", zlibVersion ());
 }
 
+void x_call_block (x_block_callback block)
+{
+	block ();
+}
+
 typedef matrix_float2x2 (*func_x_get_matrix_float2x2_msgSend) (id self, SEL sel);
 void
 x_get_matrix_float2x2 (id self, const char *sel,

--- a/tests/test-libraries/rename.h
+++ b/tests/test-libraries/rename.h
@@ -60,6 +60,7 @@
 	#define x_get_matrix_float4x3 object_x_get_matrix_float4x3
 	#define x_get_matrix_float3x3 object_x_get_matrix_float3x3
 	#define x_get_matrix_float2x2 object_x_get_matrix_float2x2
+	#define x_call_block          object_x_call_block
 #elif PREFIX == 2
 	#define theUltimateAnswer ar_theUltimateAnswer
 	#define useZLib           ar_useZLib
@@ -121,6 +122,7 @@
 	#define x_get_matrix_float4x3 ar_x_get_matrix_float4x3
 	#define x_get_matrix_float3x3 ar_x_get_matrix_float3x3
 	#define x_get_matrix_float2x2 ar_x_get_matrix_float2x2
+	#define x_call_block          ar_x_call_block
 #else
 // keep original names
 #endif

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -138,6 +138,7 @@ namespace Xamarin.Bundler {
 #if MONOTOUCH
 					"    inline-runtime-arch: By default always enabled (requires the linker). Inlines calls to ObjCRuntime.Runtime.Arch to load a constant value. Makes the app smaller, and slightly faster at runtime.\n" +
 #endif
+					"    blockliteral-setupblock: By default enabled when using the static registrar. Optimizes calls to BlockLiteral.SetupBlock to avoid having to calculate the block signature at runtime.\n" +
 					"    inline-intptr-size: By default enabled for builds that target a single architecture (requires the linker). Inlines calls to IntPtr.Size to load a constant value. Makes the app smaller, and slightly faster at runtime.\n",
 					(v) => {
 						app.Optimizations.Parse (v);

--- a/tools/common/Optimizations.cs
+++ b/tools/common/Optimizations.cs
@@ -12,7 +12,10 @@ namespace Xamarin.Bundler
 			"inline-intptr-size",
 #if MONOTOUCH
 			"inline-runtime-arch",
+#else
+			"", // dummy value to make indices match up between XM and XI
 #endif
+			"blockliteral-setupblock",
 		};
 
 		bool? [] values;
@@ -39,6 +42,10 @@ namespace Xamarin.Bundler
 			set { values [4] = value; }
 		}
 #endif
+		public bool? OptimizeBlockLiteralSetupBlock {
+			get { return values [5]; }
+			set { values [5] = value; }
+		}
 
 		public Optimizations ()
 		{
@@ -86,6 +93,10 @@ namespace Xamarin.Bundler
 				InlineRuntimeArch = true;
 #endif
 
+			// We try to optimize calls to BlockLiteral.SetupBlock if the static registrar is enabled
+			if (!OptimizeBlockLiteralSetupBlock.HasValue)
+				OptimizeBlockLiteralSetupBlock = app.Registrar == RegistrarMode.Static;
+
 			if (Driver.Verbosity > 3)
 				Driver.Log (4, "Enabled optimizations: {0}", string.Join (", ", values.Select ((v, idx) => v == true ? opt_names [idx] : string.Empty).Where ((v) => !string.IsNullOrEmpty (v))));
 		}
@@ -131,7 +142,7 @@ namespace Xamarin.Bundler
 					values [i] = enabled;
 				}
 				if (!found)
-					ErrorHelper.Warning (132, $"Unknown optimization: '{opt}'. Valid optimizations are: {string.Join (", ", opt_names)}.");
+					ErrorHelper.Warning (132, $"Unknown optimization: '{opt}'. Valid optimizations are: {string.Join (", ", opt_names.Where ((v) => !string.IsNullOrEmpty (v)))}.");
 			}
 		}
 	}

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3379,7 +3379,7 @@ namespace XamCore.Registrar {
 							setup_call_stack.AppendLine ("}");
 						}
 					} else {
-						throw ErrorHelper.CreateError (4105,
+						throw ErrorHelper.CreateError (App, 4105, method.Method,
 						                              "The registrar cannot marshal the parameter of type `{0}` in signature for method `{1}`.",
 						                              type.FullName, descriptiveMethodName);
 					}

--- a/tools/linker/CoreOptimizeGeneratedCode.cs
+++ b/tools/linker/CoreOptimizeGeneratedCode.cs
@@ -556,7 +556,7 @@ namespace Xamarin.Linker {
 				var ins = instructions [i];
 				switch (ins.OpCode.Code) {
 				case Code.Call:
-					ProcessCalls (method, ins);
+					i += ProcessCalls (method, ins);
 					break;
 				case Code.Ldsfld:
 					ProcessLoadStaticField (method, ins);
@@ -567,7 +567,8 @@ namespace Xamarin.Linker {
 			EliminateDeadCode (method);
 		}
 
-		protected virtual void ProcessCalls (MethodDefinition caller, Instruction ins)
+		// Returns the number of instructions add (or removed).
+		protected virtual int ProcessCalls (MethodDefinition caller, Instruction ins)
 		{
 			var mr = ins.Operand as MethodReference;
 			switch (mr?.Name) {
@@ -580,7 +581,12 @@ namespace Xamarin.Linker {
 			case "get_IsDirectBinding":
 				ProcessIsDirectBinding (caller, ins);
 				break;
+			case "SetupBlock":
+			case "SetupBlockUnsafe":
+				return ProcessSetupBlock (caller, ins);
 			}
+
+			return 0;
 		}
 
 		protected virtual void ProcessLoadStaticField (MethodDefinition caller, Instruction ins)
@@ -662,6 +668,232 @@ namespace Xamarin.Linker {
 			// call System.Boolean Foundation.NSObject::get_IsDirectBinding()
 			ins.OpCode = isdirectbinding_constant.Value ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0;
 			ins.Operand = null;
+		}
+
+		int ProcessSetupBlock (MethodDefinition caller, Instruction ins)
+		{
+			if (Optimizations.OptimizeBlockLiteralSetupBlock != true)
+				return 0;
+
+			// This will optimize calls to SetupBlock and SetupBlockUnsafe by calculating the signature for the block
+			// (which both SetupBlock and SetupBlockUnsafe do), and then rewrite the code to call SetupBlockImpl instead
+			// (which takes the block signature as an argument instead of calculating it). This is required to
+			// remove the dynamic registrar, because calculating the block signature is done in the dynamic registrar.
+			//
+			// This code is a mirror of the code in BlockLiteral.SetupBlock (to calculate the block signature).
+			var mr = ins.Operand as MethodReference;
+			if (!mr.DeclaringType.Is (Namespaces.ObjCRuntime, "BlockLiteral"))
+				return 0;
+
+			string signature = null;
+			try {
+				// We need to figure out the type of the first argument to the call to SetupBlock[Impl].
+				// 
+				// Example sequence:
+				//
+				// ldsfld ObjCRuntime.Trampolines/DJSContextExceptionHandler ObjCRuntime.Trampolines/SDJSContextExceptionHandler::Handler
+				// ldarg.1
+				// call System.Void ObjCRuntime.BlockLiteral::SetupBlockUnsafe(System.Delegate, System.Delegate)
+				// 
+
+				// Locating the instruction that loads the first argument can be complicated, so we simplify by making a few assumptions:
+				// 1. The instruction immediately before the call instruction (which would load the last argument) is a Push1/Pop0 instruction. 
+				//    This avoids running into trouble when the instruction does something else (it could be a any other instruction, which would throw off the next calculations)
+				// 2. We have a whitelist of instructions we know how to calculate the type for, and which we use on the second to last instruction before the call instruction
+
+				// First verify the Push1/Pop0 behavior in point 1.
+				var prev = ins.Previous;
+				while (prev.OpCode.Code == Code.Nop)
+					prev = prev.Previous; // Skip any nops.
+				if (prev.OpCode.StackBehaviourPush != StackBehaviour.Push1) {
+					ErrorHelper.Show (ErrorHelper.CreateWarning (Options.Application, 2106, caller, ins, "Could not optimize the call to BlockLiteral.{2} in {0} at offset {1} because the previous instruction was unexpected ({3})", caller, ins.Offset, mr.Name, prev));
+					return 0;
+				} else if (prev.OpCode.StackBehaviourPop != StackBehaviour.Pop0) {
+					ErrorHelper.Show (ErrorHelper.CreateWarning (Options.Application, 2106, caller, ins, "Could not optimize the call to BlockLiteral.{2} in {0} at offset {1} because the previous instruction was unexpected ({3})", caller, ins.Offset, mr.Name, prev));
+					return 0;
+				}
+
+				var loadTrampolineInstruction = prev.Previous;
+				while (loadTrampolineInstruction.OpCode.Code == Code.Nop)
+					loadTrampolineInstruction = loadTrampolineInstruction.Previous; // Skip any nops.
+
+				// Then find the type of the previous instruction (the first argument to SetupBlock[Unsafe])
+				var trampolineDelegateType = GetPushedType (caller, loadTrampolineInstruction);
+				if (trampolineDelegateType == null) {
+					ErrorHelper.Show (ErrorHelper.CreateWarning (Options.Application, 2106, caller, ins, "Could not optimize the call to BlockLiteral.{2} in {0} at offset {1} because could not determine the type of the delegate type of the first argument (instruction: {3})", caller, ins.Offset, mr.Name, loadTrampolineInstruction));
+					return 0;
+				}
+
+				if (trampolineDelegateType.Is ("System", "Delegate") || trampolineDelegateType.Is ("System", "MulticastDelegate")) {
+					ErrorHelper.Show (ErrorHelper.CreateWarning (Options.Application, 2106, caller, ins, "Could not optimize the call to BlockLiteral.{2} in {0} because the type of the value passed as the first argument (the trampoline) is {1}, which makes it impossible to compute the block signature.", caller, trampolineDelegateType.FullName, mr.Name));
+					return 0;
+				}
+
+				// Calculate the block signature.
+				var blockSignature = false;
+				MethodReference userMethod = null;
+
+				// First look for any [UserDelegateType] attributes on the trampoline delegate type.
+				var userDelegateType = GetUserDelegateType (trampolineDelegateType);
+				if (userDelegateType != null) {
+					var userMethodDefinition = GetDelegateInvoke (userDelegateType);
+					userMethod = InflateMethod (userDelegateType, userMethodDefinition);
+					blockSignature = true;
+				} else {
+					// Couldn't find a [UserDelegateType] attribute, use the type of the actual trampoline instead.
+					var userMethodDefinition = GetDelegateInvoke (trampolineDelegateType);
+					userMethod = InflateMethod (trampolineDelegateType, userMethodDefinition);
+					blockSignature = false;
+				}
+
+				// No luck finding the signature, so give up.
+				if (userMethod == null) {
+					ErrorHelper.Show (ErrorHelper.CreateWarning (Options.Application, 2106, caller, ins, "Could not optimize the call to BlockLiteral.SetupBlock in {0} at offset {1} because no [UserDelegateType] attribute could be found on {2}.", caller, ins.Offset, trampolineDelegateType.FullName));
+					return 0;
+				}
+
+				var parameters = new TypeReference [userMethod.Parameters.Count];
+				for (int p = 0; p < parameters.Length; p++)
+					parameters [p] = userMethod.Parameters [p].ParameterType;
+				signature = LinkContext.Target.StaticRegistrar.ComputeSignature (userMethod.DeclaringType, false, userMethod.ReturnType, parameters, userMethod.Resolve (), isBlockSignature: blockSignature);
+			} catch (Exception e) {
+				ErrorHelper.Show (ErrorHelper.CreateWarning (Options.Application, 2106, e, caller, ins, "Could not optimize the call to BlockLiteral.SetupBlock in {0} at offset {1}: {2}.", caller, ins.Offset, e.Message));
+				return 0;
+			}
+
+			// We got the information we need: rewrite the IL.
+			var instructions = caller.Body.Instructions;
+			var index = instructions.IndexOf (ins);
+			// Inject the extra arguments
+			instructions.Insert (index, Instruction.Create (OpCodes.Ldstr, signature));
+			instructions.Insert (index, Instruction.Create (mr.Name == "SetupBlockUnsafe" ? OpCodes.Ldc_I4_0 : OpCodes.Ldc_I4_1));
+			// Change the call to call SetupBlockImpl instead
+			ins.Operand = GetBlockSetupImpl (caller, ins);
+
+			//Driver.Log (4, "Optimized call to BlockLiteral.SetupBlock in {0} at offset {1} with delegate type {2} and signature {3}", caller, ins.Offset, delegateType.FullName, signature);
+			return 2;
+		}
+
+		// Returns the type of the value pushed on the stack by the given instruction.
+		// Returns null for unknown instructions, or for instructions that don't push anything on the stack.
+		TypeReference GetPushedType (MethodDefinition method, Instruction ins)
+		{
+			var index = 0;
+			switch (ins.OpCode.Code) {
+			case Code.Ldloc_0:
+			case Code.Ldarg_0:
+				index = 0;
+				break;
+			case Code.Ldloc_1:
+			case Code.Ldarg_1:
+				index = 1;
+				break;
+			case Code.Ldloc_2:
+			case Code.Ldarg_2:
+				index = 2;
+				break;
+			case Code.Ldloc_3:
+			case Code.Ldarg_3:
+				index = 3;
+				break;
+			case Code.Ldloc:
+			case Code.Ldloc_S:
+				return ((VariableDefinition) ins.Operand).VariableType;
+			case Code.Ldarg:
+			case Code.Ldarg_S:
+				return ((ParameterDefinition) ins.Operand).ParameterType;
+			case Code.Ldfld:
+			case Code.Ldsfld:
+				return ((FieldReference) ins.Operand).FieldType;
+			case Code.Call:
+			case Code.Calli:
+			case Code.Callvirt:
+				return ((MethodReference) ins.Operand).ReturnType;
+			default:
+				return null;
+			}
+
+			switch (ins.OpCode.Code) {
+			case Code.Ldloc:
+			case Code.Ldloc_0:
+			case Code.Ldloc_1:
+			case Code.Ldloc_2:
+			case Code.Ldloc_3:
+				return method.Body.Variables [index].VariableType;
+			case Code.Ldarg:
+			case Code.Ldarg_0:
+			case Code.Ldarg_1:
+			case Code.Ldarg_2:
+			case Code.Ldarg_3:
+				if (method.IsStatic) {
+					return method.Parameters [index].ParameterType;
+				} else if (index == 0) {
+					return method.DeclaringType;
+				} else {
+					return method.Parameters [index - 1].ParameterType;
+				}
+			default:
+				return null;
+			}
+		}
+
+		// Find the value of the [UserDelegateType] attribute on the specified delegate
+		TypeReference GetUserDelegateType (TypeReference delegateType)
+		{
+			var delegateTypeDefinition = delegateType.Resolve ();
+			foreach (var attrib in delegateTypeDefinition.CustomAttributes) {
+				var attribType = attrib.AttributeType;
+				if (!attribType.Is (Namespaces.ObjCRuntime, "UserDelegateTypeAttribute"))
+					continue;
+				return attrib.ConstructorArguments [0].Value as TypeReference;
+			}
+			return null;
+		}
+
+		MethodDefinition GetDelegateInvoke (TypeReference delegateType)
+		{
+			var td = delegateType.Resolve ();
+			foreach (var method in td.Methods) {
+				if (method.Name == "Invoke")
+					return method;
+			}
+			return null;
+		}
+
+		MethodDefinition setupblock_def;
+		MethodReference GetBlockSetupImpl (MethodDefinition caller, Instruction ins)
+		{
+			if (setupblock_def == null) {
+				var type = LinkContext.GetAssembly (Driver.GetProductAssembly (LinkContext.Target.App)).MainModule.GetType (Namespaces.ObjCRuntime, "BlockLiteral");
+				foreach (var method in type.Methods) {
+					if (method.Name != "SetupBlockImpl")
+						continue;
+					setupblock_def = method;
+					setupblock_def.IsPublic = true; // Make sure the method is callable from the optimized code.
+					break;
+				}
+				if (setupblock_def == null)
+					throw ErrorHelper.CreateError (Options.Application, 99, caller, ins, $"Internal error: could not find the method {Namespaces.ObjCRuntime}.BlockLiteral.SetupBlockImpl. Please file a bug report with a test case (https://bugzilla.xamarin.com).");
+			}
+			return caller.Module.ImportReference (setupblock_def);
+		}
+
+		MethodReference InflateMethod (TypeReference inflatedDeclaringType, MethodDefinition openMethod)
+		{
+			var git = inflatedDeclaringType as GenericInstanceType;
+			if (git == null)
+				return openMethod;
+
+			var inflatedReturnType = TypeReferenceExtensions.InflateGenericType (git, openMethod.ReturnType);
+			var mr = new MethodReference (openMethod.Name, inflatedReturnType, git);
+			if (openMethod.HasParameters) { 
+				for (int i = 0; i < openMethod.Parameters.Count; i++) {
+					var inflatedParameterType = TypeReferenceExtensions.InflateGenericType (git, openMethod.Parameters [i].ParameterType);
+					var p = new ParameterDefinition (openMethod.Parameters [i].Name, openMethod.Parameters [i].Attributes, inflatedParameterType);
+					mr.Parameters.Add (p);
+				}
+			}
+			return mr;
 		}
 	}
 }


### PR DESCRIPTION
Optimize calls to BlockLiteral.SetupBlock[Unsafe] to calculate the block
signature at build time, and inject it into the call site.

This makes block invocations 10-15x faster (I've added tests that asserts at
least an 8x increase, along with numerous other tests for this optimization).

It's also required in order to be able to remove the dynamic registrar code in
the future (since calculating the block signature at runtime requires the
dynamic registrar).