### PR TITLE
[src] Update csproj templates for platform assemblies to build correctly.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -473,7 +473,7 @@ $(MAC_BUILD_DIR)/Constants.cs: Constants.mac.cs.in Makefile $(TOP)/Make.config.i
 		$< > $@
 
 xammac.csproj: xammac.tmpl.csproj Makefile $(wildcard $(TOP)/src/*.sources)
-	@sed -e 's*<!--%FILES%-->*$(foreach file,$(MAC_SOURCES),<Compile Include="$(file)"/>)*' -e 's*<!--%APIS%-->*$(foreach file,$(MAC_APIS),<None Include="$(file)"/>)*' $< | xmllint --format - > $@
+	@sed -e 's*<!--%FILES%-->*$(foreach file,$(MAC_SOURCES) $(SHARED_SYSTEM_DRAWING_SOURCES),<Compile Include="$(file)"/>)*' -e 's*<!--%APIS%-->*$(foreach file,$(MAC_APIS),<None Include="$(file)"/>)*' $< | xmllint --format - > $@
 
 PROJECT_FILES += xammac.csproj
 

--- a/src/xamios.tmpl.csproj
+++ b/src/xamios.tmpl.csproj
@@ -8,17 +8,18 @@
     <ProjectGuid>{E1F334C3-8F77-46C9-A28B-A8E9BAEA9FE5}</ProjectGuid>
     <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
-    <RootNamespace>monotouch</RootNamespace>
-    <AssemblyName>monotouch</AssemblyName>
+    <RootNamespace></RootNamespace>
+    <AssemblyName>Xamarin.iOS</AssemblyName>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\product.snk</AssemblyOriginatorKeyFile>
+    <IntermediateOutputPath>build\IDE\obj\iOS\$(Configuration)</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>IPHONE;IOS;MINIMAL;XAMCORE_2_0</DefineConstants>
+    <OutputPath>build\IDE\bin\iOS\Debug</OutputPath>
+    <DefineConstants>IPHONE;IOS;MINIMAL;XAMCORE_2_0;MONOTOUCH</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -29,7 +30,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Release</OutputPath>
+    <OutputPath>build\IDE\bin\iOS\Release</OutputPath>
+    <DefineConstants>IPHONE;IOS;MINIMAL;XAMCORE_2_0;MONOTOUCH</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -37,14 +39,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  <PropertyGroup>
-    <CscToolExe>$(MSBuildProjectDirectory)\custom-make.sh</CscToolExe>
-  </PropertyGroup>
   <ItemGroup>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="build\ios\native\**\*.cs">
+      <Link>build\ios\native\%(RecursiveDir)%(Filename).cs</Link>
+    </Compile>
     <!--%FILES%-->
     <!--%APIS%-->
   </ItemGroup>

--- a/src/xammac.tmpl.csproj
+++ b/src/xammac.tmpl.csproj
@@ -4,18 +4,22 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{87042AD2-CDC9-4A53-9193-56226B668B88}</ProjectGuid>
+    <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
-    <RootNamespace>src</RootNamespace>
-    <AssemblyName>src</AssemblyName>
+    <RootNamespace></RootNamespace>
+    <AssemblyName>Xamarin.Mac</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\product.snk</AssemblyOriginatorKeyFile>
+    <IntermediateOutputPath>build\IDE\obj\macOS-mobile\$(Configuration)</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;MONOMAC;</DefineConstants>
+    <OutputPath>build\IDE\bin\macOS-mobile\Debug</OutputPath>
+    <DefineConstants>DEBUG;MONOMAC;XAMCORE_2_0;NO_SYSTEM_DRAWING</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -24,8 +28,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <DefineConstants>MONOMAC;</DefineConstants>
+    <OutputPath>build\IDE\bin\macOS-mobile\Release</OutputPath>
+    <DefineConstants>MONOMAC;XAMCORE_2_0;NO_SYSTEM_DRAWING</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -33,15 +37,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
     <Reference Include="Mono.Security" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="build\mac\mobile\**\*.cs">
+      <Link>build\mac\mobile\%(RecursiveDir)%(Filename).cs</Link>
+    </Compile>
     <!--%FILES%-->
     <!--%APIS%-->
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <CscToolExe>$(MSBuildProjectDirectory)\custom-make.sh</CscToolExe>
-  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/src/xamtvos.tmpl.csproj
+++ b/src/xamtvos.tmpl.csproj
@@ -8,16 +8,17 @@
     <ProjectGuid>{072C1DD1-7566-4387-B9EC-466891558ACC}</ProjectGuid>
     <ProjectTypeGuids>{06FA79CB-D6CD-4721-BB4B-1BD202089C55};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
-    <RootNamespace>xamtvos</RootNamespace>
-    <AssemblyName>xamtvos</AssemblyName>
+    <RootNamespace></RootNamespace>
+    <AssemblyName>Xamarin.TVOS</AssemblyName>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\product.snk</AssemblyOriginatorKeyFile>
+    <IntermediateOutputPath>build\IDE\obj\tvOS\$(Configuration)</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
+    <OutputPath>build\IDE\bin\tvOS\Debug</OutputPath>
     <DefineConstants>MONOTOUCH;IPHONE;TVOS;XAMCORE_2_0;XAMCORE_3_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -29,7 +30,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Release</OutputPath>
+    <OutputPath>build\IDE\bin\tvOS\Release</OutputPath>
     <DefineConstants>MONOTOUCH;TVOS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -38,14 +39,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  <PropertyGroup>
-    <CscToolExe>$(MSBuildProjectDirectory)\custom-make.sh</CscToolExe>
-  </PropertyGroup>
   <ItemGroup>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="build\tvos\tvos\**\*.cs">
+      <Link>build\tvos\tvos\%(RecursiveDir)%(Filename).cs</Link>
+    </Compile>
     <!--%FILES%-->
     <!--%APIS%-->
   </ItemGroup>

--- a/src/xamwatch.tmpl.csproj
+++ b/src/xamwatch.tmpl.csproj
@@ -8,17 +8,18 @@
     <ProjectGuid>{B84C539D-971D-4703-8ABC-E1077FDA651C}</ProjectGuid>
     <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
-    <RootNamespace>xamwatch</RootNamespace>
-    <AssemblyName>xamwatch</AssemblyName>
+    <RootNamespace></RootNamespace>
+    <AssemblyName>Xamarin.WatchOS</AssemblyName>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\product.snk</AssemblyOriginatorKeyFile>
+    <IntermediateOutputPath>build\IDE\obj\watchOS\$(Configuration)</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>MONOTOUCH;WATCH</DefineConstants>
+    <OutputPath>build\IDE\bin\watchOS\Debug</OutputPath>
+    <DefineConstants>MONOTOUCH;WATCH;XAMCORE_2_0;XAMCORE_3_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -29,8 +30,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <DefineConstants>MONOTOUCH;WATCH</DefineConstants>
+    <OutputPath>build\IDE\bin\watchOS\Release</OutputPath>
+    <DefineConstants>MONOTOUCH;WATCH;XAMCORE_2_0;XAMCORE_3_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -38,14 +39,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  <PropertyGroup>
-    <CscToolExe>$(MSBuildProjectDirectory)\custom-make.sh</CscToolExe>
-  </PropertyGroup>
   <ItemGroup>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="build\watch\watch\**\*.cs">
+      <Link>build\watch\watch\%(RecursiveDir)%(Filename).cs</Link>
+    </Compile>
     <!--%FILES%-->
     <!--%APIS%-->
   </ItemGroup>


### PR DESCRIPTION
Now that we don't use pmcs anymore, VSfM can actually understand our source code.

So in order to make the editing experience in VSfM better:

* Include all the source files in the csprojs.
* Make sure to not build into the same directories as the normal build
  process, since the csproj don't build the official version of the
  assemblies.
* Misc other fixes to make it all build.