### PR TITLE
[simlauncher] Link with the IdentityLookup framework.

### DIFF
--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -294,7 +294,9 @@ SIMLAUNCHER_FRAMEWORKS =  \
 						\
 	-weak_framework ARKit					\
 	-weak_framework FileProvider			\
-	-weak_framework FileProviderUI
+	-weak_framework FileProviderUI			\
+						\
+	-weak_framework IdentityLookup			\
 
 # note: there _was_ no CoreAudioKit.framework or Metal.framework for the simulator (before recent iOS9 betas)
 # note 2: there's no GameKit, in iOS 9 (beta 3 at least), you're supposed to reference GameCenter instead (looks fixed in beta 4)


### PR DESCRIPTION
This makes it possible to use types from the IdentityLookup when using
simlauncher.