### PR TITLE
[SceneKit] Adds NullAllowed to ISCNSceneRenderer.OverlayScene - Backport to Xcode9.3

### DIFF
--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -2905,6 +2905,10 @@ namespace XamCore.SceneKit {
 		[Abstract]
 #endif
 #if XAMCORE_2_0 || !MONOMAC
+		// It seems swift has this property listed as an optional[0] and an Apple sample[1] sets this to null
+		// [0]: https://developer.apple.com/documentation/scenekit/scnscenerenderer/1524051-overlayskscene
+		// [1]: https://github.com/xamarin/xamarin-macios/issues/3392
+		[NullAllowed]
 		[Mac (10,10)]
 		[Export ("overlaySKScene", ArgumentSemantic.Retain)]
 		SKScene OverlayScene { get; set; }

--- a/tests/monotouch-test/SceneKit/SCNViewTests.cs
+++ b/tests/monotouch-test/SceneKit/SCNViewTests.cs
@@ -1,0 +1,43 @@
+﻿//
+// SCNViewTests.cs
+//
+// Authors:
+//	Alex Soto <alexsoto@microsoft.com>
+//
+//
+// Copyright 2018 Xamarin Inc. All rights reserved.
+//
+
+#if !__WATCHOS__
+using System;
+using NUnit.Framework;
+
+#if XAMCORE_2_0
+using Foundation;
+using SceneKit;
+using CoreGraphics;
+#else
+using MonoTouch.Foundation;
+using MonoTouch.SceneKit;
+using CGRect = System.Drawing.RectangleF;
+#endif
+
+namespace MonoTouchFixtures.SceneKit {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class SCNViewTests {
+
+		[Test]
+		public void NullOverlaySceneTest ()
+		{
+			// Issue: https://github.com/xamarin/xamarin-macios/issues/3392
+			TestRuntime.AssertXcodeVersion (6,0);
+
+			var view = new SCNView (new CGRect (), (NSDictionary) null);
+			Assert.NotNull (view, "View not null");
+			Assert.DoesNotThrow (() => view.OverlayScene = null, "Should not throw");
+		}
+	}
+}
+#endif


### PR DESCRIPTION
Fixes xamarin/xamarin-macios#3392

It seems swift has this property listed as an optional[0] and
an Apple sample[1] sets this to null so `ISCNSceneRenderer.OverlayScene`
needs to have `[NullAllowed]` even if ObjC headers do not have
nullability information.

[0]: https://developer.apple.com/documentation/scenekit/scnscenerenderer/1524051-overlayskscene
[1]: https://github.com/xamarin/xamarin-macios/issues/3392