### PR TITLE
[xharness] Clone XM projects.

### DIFF
--- a/tests/msbuild-mac/CustomBuildActions.targets
+++ b/tests/msbuild-mac/CustomBuildActions.targets
@@ -5,7 +5,7 @@
 	    <CreateAppBundleDependsOn>$(CreateAppBundleDependsOn);CreateNativeLibs</CreateAppBundleDependsOn>
 	</PropertyGroup>
 
-	<Target Name="CreateNativeLibs" Inputs="../common/mac/SimpleClass.m" Outputs="../mac-binding-project/bin/SimpleClassDylib.dylib">
-		<Exec Command="make bin/SimpleClassDylib.dylib" WorkingDirectory="../mac-binding-project/" />
+	<Target Name="CreateNativeLibs" Inputs="$(MSBuildThisFileDirectory)/../common/mac/SimpleClass.m" Outputs="$(MSBuildThisFileDirectory)/../mac-binding-project/bin/SimpleClassDylib.dylib">
+		<Exec Command="make bin/SimpleClassDylib.dylib" WorkingDirectory="$(MSBuildThisFileDirectory)/../mac-binding-project/" />
 	</Target>
 </Project>

--- a/tests/xammac_tests/System.ServiceModel/Net45.cs
+++ b/tests/xammac_tests/System.ServiceModel/Net45.cs
@@ -41,7 +41,7 @@ namespace MonoTouchFixtures.ServiceModel {
 		[Test]
 		public void ServiceModelShouldCreateCommunicationException ()
 		{
-			var testFolder = "../../../../../../../common/mac/TestProjects/ServiceModel_Test/ServiceModel_Test";
+			var testFolder = Path.Combine (TI.FindRootDirectory (), "../tests/common/mac/TestProjects/ServiceModel_Test/ServiceModel_Test");
 			var testResults = testFolder + "/TestResult.txt";
 			if (File.Exists (testResults))
 				File.Delete (testResults);

--- a/tests/xammac_tests/Unified45.cs
+++ b/tests/xammac_tests/Unified45.cs
@@ -11,7 +11,7 @@ namespace MonoTouchFixtures.Net45 {
 		[Test]
 		public void ProtobufShouldSerializeAndDeserialize ()
 		{
-			var testFolder = "../../../../../../../common/mac/TestProjects/Protobuf_Test/Protobuf_Test";
+			var testFolder = Path.Combine (TI.FindRootDirectory (), "../tests/common/mac/TestProjects/Protobuf_Test/Protobuf_Test");
 			var testResults = testFolder + "/TestResult.txt";
 			if (File.Exists (testResults))
 				File.Delete (testResults);
@@ -39,7 +39,7 @@ namespace MonoTouchFixtures.Net45 {
 		[Test]
 		public void Net45ShouldUseImmutableCollection ()
 		{
-			var testFolder = "../../../../../../../common/mac/TestProjects/ImmutableCollection_Test/ImmutableCollection_Test";
+			var testFolder = Path.Combine (TI.FindRootDirectory (), "../tests/common/mac/TestProjects/ImmutableCollection_Test/ImmutableCollection_Test");
 
 			StringBuilder restoreOutput = new StringBuilder ();
 
@@ -56,7 +56,7 @@ namespace MonoTouchFixtures.Net45 {
 		[Test]
 		public void BasicPCLTest ()
 		{
-			var testFolder = "../../../../../../../common/mac/TestProjects/BasicPCLTest/BasicPCLTest";
+			var testFolder = Path.Combine (TI.FindRootDirectory (), "../tests/common/mac/TestProjects/BasicPCLTest/BasicPCLTest");
 			var testResults = testFolder + "/TestResult.txt";
 			if (File.Exists (testResults))
 				File.Delete (testResults);

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -598,12 +598,13 @@ namespace xharness
 					if (project.GenerateVariations) {
 						build = new MdtoolTask ();
 						build.Platform = TestPlatform.Mac_Classic;
+						build.TestProject = project;
 					} else {
 						build = new XBuildTask ();
 						build.Platform = TestPlatform.Mac;
+						build.CloneTestProject (project);
 					}
 					build.Jenkins = this;
-					build.CloneTestProject (project);
 					build.SolutionPath = project.SolutionPath;
 					build.ProjectConfiguration = config;
 					build.ProjectPlatform = project.Platform;
@@ -633,11 +634,11 @@ namespace xharness
 					Tasks.Add (exec);
 
 					if (project.GenerateVariations) {
-						Tasks.Add (CloneExecuteTask (exec, TestPlatform.Mac_Unified, "-unified", ignored));
-						Tasks.Add (CloneExecuteTask (exec, TestPlatform.Mac_Unified32, "-unified-32", ignored));
+						Tasks.Add (CloneExecuteTask (exec, project, TestPlatform.Mac_Unified, "-unified", ignored));
+						Tasks.Add (CloneExecuteTask (exec, project, TestPlatform.Mac_Unified32, "-unified-32", ignored));
 						if (project.GenerateFull) {
-							Tasks.Add (CloneExecuteTask (exec, TestPlatform.Mac_UnifiedXM45, "-unifiedXM45", ignored));
-							Tasks.Add (CloneExecuteTask (exec, TestPlatform.Mac_UnifiedXM45_32, "-unifiedXM45-32", ignored));
+							Tasks.Add (CloneExecuteTask (exec, project, TestPlatform.Mac_UnifiedXM45, "-unifiedXM45", ignored));
+							Tasks.Add (CloneExecuteTask (exec, project, TestPlatform.Mac_UnifiedXM45_32, "-unifiedXM45-32", ignored));
 						}
 					}
 				}
@@ -731,18 +732,19 @@ namespace xharness
 			Tasks.AddRange (CreateRunDeviceTasks ());
 		}
 
-		RunTestTask CloneExecuteTask (RunTestTask task, TestPlatform platform, string suffix, bool ignore)
+		RunTestTask CloneExecuteTask (RunTestTask task, TestProject original_project, TestPlatform platform, string suffix, bool ignore)
 		{
 			var build = new XBuildTask ()
 			{
 				Platform = platform,
 				Jenkins = task.Jenkins,
-				TestProject = new TestProject (Path.ChangeExtension (AddSuffixToPath (task.ProjectFile, suffix), "csproj")),
 				ProjectConfiguration = task.ProjectConfiguration,
 				ProjectPlatform = task.ProjectPlatform,
 				SpecifyPlatform = task.BuildTask.SpecifyPlatform,
 				SpecifyConfiguration = task.BuildTask.SpecifyConfiguration,
 			};
+			var tp = new TestProject (Path.ChangeExtension (AddSuffixToPath (original_project.Path, suffix), "csproj"));
+			build.CloneTestProject (tp);
 
 			var macExec = task as MacExecuteTask;
 			if (macExec != null) {

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -603,7 +603,7 @@ namespace xharness
 						build.Platform = TestPlatform.Mac;
 					}
 					build.Jenkins = this;
-					build.TestProject = project;
+					build.CloneTestProject (project);
 					build.SolutionPath = project.SolutionPath;
 					build.ProjectConfiguration = config;
 					build.ProjectPlatform = project.Platform;

--- a/tests/xharness/ProjectFileExtensions.cs
+++ b/tests/xharness/ProjectFileExtensions.cs
@@ -748,6 +748,7 @@ namespace xharness
 				new string [] { "ObjcBindingCoreSource", "Include" },
 				new string [] { "ObjcBindingNativeLibrary", "Include" },
 				new string [] { "ObjcBindingNativeFramework", "Include" },
+				new string [] { "Import", "Project" },
 			};
 			var nodes_with_variables = new string []
 			{
@@ -756,6 +757,10 @@ namespace xharness
 			Func<string, string> convert = (input) =>
 			{
 				if (input [0] == '/')
+					return input; // This is already a full path.
+				if (input.StartsWith ("$(MSBuildExtensionsPath)", StringComparison.Ordinal))
+					return input; // This is already a full path.
+				if (input.StartsWith ("$(MSBuildBinPath)", StringComparison.Ordinal))
 					return input; // This is already a full path.
 				input = input.Replace ('\\', '/'); // make unix-style
 				input = System.IO.Path.GetFullPath (System.IO.Path.Combine (dir, input));

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -83,13 +83,12 @@ namespace xharness
 
 		public virtual TestProject Clone ()
 		{
-			return new TestProject ()
-			{
-				Path = Path,
-				IsExecutableProject = IsExecutableProject,
-				GenerateVariations = GenerateVariations,
-				Name = Name,
-			};
+			TestProject rv = (TestProject) Activator.CreateInstance (GetType ());
+			rv.Path = Path;
+			rv.IsExecutableProject = IsExecutableProject;
+			rv.GenerateVariations = GenerateVariations;
+			rv.Name = Name;
+			return rv;
 		}
 
 		internal async Task<TestProject> CreateCloneAsync (TestTask test)
@@ -168,6 +167,15 @@ namespace xharness
 		public MacTestProject (string path, bool isExecutableProject = true, bool generateVariations = true, MacFlavors targetFrameworkFlavor = MacFlavors.All) : base (path, isExecutableProject, generateVariations)
 		{
 			TargetFrameworkFlavor = targetFrameworkFlavor;
+		}
+
+		public override TestProject Clone()
+		{
+			var rv = (MacTestProject) base.Clone ();
+			rv.TargetFrameworkFlavor = TargetFrameworkFlavor;
+			rv.BCLInfo = BCLInfo;
+			rv.Platform = Platform;
+			return rv;
 		}
 	}
 }

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -110,6 +110,13 @@ namespace xharness
 			XmlDocument doc;
 			doc = new XmlDocument ();
 			doc.LoadWithoutNetworkAccess (original_path);
+			if (System.IO.Path.GetFileName (original_path).Contains ("GuiUnit_NET")) {
+				// The GuiUnit project files writes stuff outside their project directory using relative paths,
+				// but override that so that we don't end up with multiple cloned projects writing stuff to
+				// the same location.
+				doc.SetOutputPath ("bin\\$(Configuration)");
+				doc.SetNode ("DocumentationFile", "bin\\$(Configuration)\\nunitlite.xml");
+			}
 			doc.ResolveAllPaths (original_path);
 
 			foreach (var pr in doc.GetProjectReferences ()) {


### PR DESCRIPTION
Cloning projects before building them will also clone project references,
which will make it possible to build multiple projects in parallel, when those
projects have common project references.

Fixes https://github.com/xamarin/maccore/issues/624.