### PR TITLE
Bump ObjectiveSharpie to a version that supports choosing its Xcode. (#3409)

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -71,9 +71,9 @@ MIN_CMAKE_URL=https://cmake.org/files/v3.6/cmake-3.6.2-Darwin-x86_64.dmg
 MIN_CMAKE_VERSION=2.8.8
 
 # ObjectiveSharpie min/max versions
-MIN_SHARPIE_VERSION=3.4.0
+MIN_SHARPIE_VERSION=3.4.23
 MAX_SHARPIE_VERSION=3.4.99
-MIN_SHARPIE_URL=https://download.visualstudio.microsoft.com/download/pr/100173119/c367c913219cdfa307b98fe912d07691/ObjectiveSharpie-3.4.0.pkg
+MIN_SHARPIE_URL=https://bosstoragemirror.blob.core.windows.net/objective-sharpie/builds/4cde014216e8887375f9793d3a2607529833443b/440/76194/ObjectiveSharpie-3.4.23.pkg
 
 # Minimum OSX versions
 MIN_OSX_BUILD_VERSION=10.12

--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -5,6 +5,8 @@ include $(TOP)/Make.config
 # a 64bits mono is required because of the clang requirement
 MONO ?= mono64 --debug
 
+XCODE=$(abspath $(XCODE_DEVELOPER_ROOT)/../..)
+
 all-local::
 
 clean-local::
@@ -22,7 +24,7 @@ XIOS_ARCH = arm64
 XIOS_PCH = iphoneos$(IOS_SDK_VERSION)-$(XIOS_ARCH).pch
 
 $(XIOS_PCH): .stamp-check-sharpie
-	sharpie sdk-db -s iphoneos$(IOS_SDK_VERSION) -a $(XIOS_ARCH)
+	sharpie sdk-db --xcode $(XCODE) -s iphoneos$(IOS_SDK_VERSION) -a $(XIOS_ARCH)
 
 
 XWATCHOS ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/32bits/Xamarin.WatchOS.dll
@@ -30,7 +32,7 @@ XWATCHOS_ARCH = armv7
 XWATCHOS_PCH = watchos$(WATCH_SDK_VERSION)-$(XWATCHOS_ARCH).pch
 
 $(XWATCHOS_PCH): .stamp-check-sharpie
-	sharpie sdk-db -s watchos$(WATCH_SDK_VERSION) -a $(XWATCHOS_ARCH)
+	sharpie sdk-db --xcode $(XCODE) -s watchos$(WATCH_SDK_VERSION) -a $(XWATCHOS_ARCH)
 
 XTVOS ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/Xamarin.TVOS.dll
 XTVOS_GL ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/OpenTK-1.0.dll
@@ -38,7 +40,7 @@ XTVOS_ARCH = arm64
 XTVOS_PCH = appletvos$(TVOS_SDK_VERSION)-$(XTVOS_ARCH).pch
 
 $(XTVOS_PCH): .stamp-check-sharpie
-	sharpie sdk-db -s appletvos$(TVOS_SDK_VERSION) -a $(XTVOS_ARCH)
+	sharpie sdk-db --xcode $(XCODE) -s appletvos$(TVOS_SDK_VERSION) -a $(XTVOS_ARCH)
 
 
 XMAC ?= $(TOP)/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/$(XMAC_ARCH)/mobile/Xamarin.Mac.dll
@@ -46,7 +48,7 @@ XMAC_ARCH = x86_64
 XMAC_PCH = macosx$(OSX_SDK_VERSION)-$(XMAC_ARCH).pch
 
 $(XMAC_PCH): .stamp-check-sharpie
-	sharpie sdk-db -s macosx$(OSX_SDK_VERSION) -a $(XMAC_ARCH)
+	sharpie sdk-db --xcode $(XCODE) -s macosx$(OSX_SDK_VERSION) -a $(XMAC_ARCH)
 
 
 


### PR DESCRIPTION
Bump ObjectiveSharpie to a version that supports choosing which Xcode to use,
and also change xtro to do exactly that.

Fixes https://github.com/xamarin/maccore/issues/627.

Backport of https://github.com/xamarin/xamarin-macios/pull/3409 to xcode9.3 to
ease switching back and forth with master