### PR TITLE
[src] Add a few missing [RequiresSuper] attributes. Fix #3253

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -15568,6 +15568,7 @@ namespace AppKit {
 		bool NeedsLayout { get; set; }
 
 		[Mac (10, 7), Export ("updateConstraints")]
+		[RequiresSuper]
 		void UpdateConstraints ();
 
 		[Mac (10, 7), Export ("updateConstraintsForSubtreeIfNeeded")]

--- a/src/cloudkit.cs
+++ b/src/cloudkit.cs
@@ -1601,7 +1601,6 @@ namespace CloudKit {
 
 		[Deprecated (PlatformName.iOS, 10,0, message: "Use 'CKQuerySubscription'.")]
 		[Deprecated (PlatformName.MacOSX, 10,12, message: "Use 'CKQuerySubscription'.")]
-		[DesignatedInitializer]
 		[Export ("initWithRecordType:predicate:subscriptionID:options:")]
 		IntPtr Constructor (string recordType, NSPredicate predicate, string subscriptionId, CKSubscriptionOptions subscriptionOptions);
 
@@ -1612,7 +1611,6 @@ namespace CloudKit {
 
 		[Deprecated (PlatformName.iOS, 10,0, message: "Use 'CKRecordZoneSubscription'.")]
 		[Deprecated (PlatformName.MacOSX, 10,12, message: "Use 'CKRecordZoneSubscription'.")]
-		[DesignatedInitializer]
 		[Export ("initWithZoneID:subscriptionID:options:")]
 		IntPtr Constructor (CKRecordZoneID zoneId, string subscriptionId, CKSubscriptionOptions subscriptionOptions);
 

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -8421,6 +8421,11 @@ namespace Foundation
 		void PrepareForInterfaceBuilder ();
 
 		[NoWatch]
+#if MONOMAC
+		// comes from NSNibAwaking category and does not requires calling super
+#else
+		[RequiresSuper] // comes from UINibLoadingAdditions category - which is decorated
+#endif
 		[Export ("awakeFromNib")]
 		void AwakeFromNib ();
 	}

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -13332,6 +13332,7 @@ namespace UIKit {
 		
 		[iOS (6,0)]
 		[Export ("updateConstraints")]
+		[RequiresSuper]
 		void UpdateConstraints ();
 
 		[iOS (6,0)]
@@ -14159,12 +14160,12 @@ namespace UIKit {
 
 		[iOS (11,0), TV (11,0)]
 		[Export ("viewLayoutMarginsDidChange")]
-		[Advice ("You must call the base method when overriding.")] // [RequiresSuper]
+		[RequiresSuper]
 		void ViewLayoutMarginsDidChange ();
 
 		[iOS (11,0), TV (11,0)]
 		[Export ("viewSafeAreaInsetsDidChange")]
-		[Advice ("You must call the base method when overriding.")] // [RequiresSuper]
+		[RequiresSuper]
 		void ViewSafeAreaInsetsDidChange ();
 
 		[NoWatch, NoTV]

--- a/tests/xtro-sharpie/Helpers.cs
+++ b/tests/xtro-sharpie/Helpers.cs
@@ -156,7 +156,11 @@ namespace Extrospection {
 			var sb = new StringBuilder ();
 			if (self.IsClassMethod)
 				sb.Append ('+');
-			sb.Append ((self.DeclContext as NamedDecl).Name);
+			if (self.DeclContext is ObjCCategoryDecl category) {
+				sb.Append (category.ClassInterface.Name);
+			} else {
+				sb.Append ((self.DeclContext as NamedDecl).Name);
+			}
 			sb.Append ("::");
 			var sel = self.Selector.ToString ();
 			sb.Append (string.IsNullOrEmpty (sel) ? self.Name : sel);
@@ -332,6 +336,7 @@ namespace Extrospection {
 				return "Foundation";
 			case "MPSCore":
 			case "MPSImage":
+			case "MPSMatrix":
 			case "MPSNeuralNetwork":
 				return "MetalPerformanceShaders";
 			case "QuartzCore":

--- a/tests/xtro-sharpie/RequiresSuperCheck.cs
+++ b/tests/xtro-sharpie/RequiresSuperCheck.cs
@@ -38,11 +38,23 @@ namespace Extrospection {
 				methods.Add (key, method);
 		}
 
+		public override void VisitObjCCategoryDecl (ObjCCategoryDecl decl, VisitKind visitKind)
+		{
+			if (visitKind != VisitKind.Enter)
+				return;
+			foreach (var d in decl.Methods)
+				Visit (d);
+		}
+
 		public override void VisitObjCMethodDecl (ObjCMethodDecl decl, VisitKind visitKind)
 		{
 			if (visitKind != VisitKind.Enter)
 				return;
+			Visit (decl);
+		}
 
+		void Visit (ObjCMethodDecl decl)
+		{
 			// don't process methods (or types) that are unavailable for the current platform
 			if (!decl.IsAvailable () || !(decl.DeclContext as Decl).IsAvailable ())
 				return;

--- a/tests/xtro-sharpie/common-CloudKit.ignore
+++ b/tests/xtro-sharpie/common-CloudKit.ignore
@@ -4,3 +4,6 @@
 ## we offer a better managed API using another selector
 !missing-selector! CKRecord::objectForKeyedSubscript: not bound
 !missing-selector! CKRecord::setObject:forKeyedSubscript: not bound
+
+## auto-generated attribute (but deprecated API where Apple removed it)
+!extra-designated-initializer! CKSubscription::initWithCoder: is incorrectly decorated with an [DesignatedInitializer] attribute


### PR DESCRIPTION
Those were missed because xtro did not scan ObjC categories for
`objc_requires_super` attributes.

Fixing the naming mapping (to consider inlined categories) also
uncovered a few API with extraneous [DesignatedInitializer] attributes
Those were deprecated (API) and moved into categories so xtro missed
the designated initializer was removed.

All your `base`, well `super` in ObjC, now belong to us :)

https://github.com/xamarin/xamarin-macios/issues/3253