### PR TITLE
[uikit] Add [Advice] on UIImage.FromBundle to mention it was not thread safe before iOS9

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -7137,12 +7137,20 @@ namespace UIKit {
 		CGSize Size { get; }
 
 		// Thread-safe in iOS 9 or later according to docs.
+#if IOS
+		// tvOS started with 9.0 code base (and watchOS 2.0 came later)
+		[Advice ("This API is thread-safe only on iOS 9 and later.")]
+#endif
 		[ThreadSafe]
 		[Static] [Export ("imageNamed:")][Autorelease]
 		UIImage FromBundle (string name);
 
 #if !WATCH
 		// Thread-safe in iOS 9 or later according to docs.
+#if IOS
+		// tvOS started with 9.0 code base (and watchOS 2.0 came later)
+		[Advice ("This API is thread-safe only on iOS 9 and later.")]
+#endif
 		[ThreadSafe]
 		[iOS (8,0)]
 		[Static, Export ("imageNamed:inBundle:compatibleWithTraitCollection:")]

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -7139,7 +7139,7 @@ namespace UIKit {
 		// Thread-safe in iOS 9 or later according to docs.
 #if IOS
 		// tvOS started with 9.0 code base (and watchOS 2.0 came later)
-		[Advice ("This API is thread-safe only on iOS 9 and later.")]
+		[Advice ("This API is thread-safe only on 9.0 and later.")]
 #endif
 		[ThreadSafe]
 		[Static] [Export ("imageNamed:")][Autorelease]
@@ -7149,7 +7149,7 @@ namespace UIKit {
 		// Thread-safe in iOS 9 or later according to docs.
 #if IOS
 		// tvOS started with 9.0 code base (and watchOS 2.0 came later)
-		[Advice ("This API is thread-safe only on iOS 9 and later.")]
+		[Advice ("This API is thread-safe only on 9.0 and later.")]
 #endif
 		[ThreadSafe]
 		[iOS (8,0)]


### PR DESCRIPTION
This is related, but not a direct fix, to bug
https://bugzilla.xamarin.com/show_bug.cgi?id=40520

The original fix was made, a long time ago, in
maccore/e39d21e26dd863d019269117d4c110c3ac8ce9f5