### PR TITLE
[src/apidiff] Don't hardcode input/output/build directories.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,8 @@
 TOP=..
 include $(TOP)/Make.config
 
+BUILD_DIR=build
+
 include $(TOP)/src/frameworks.sources
 include $(TOP)/mk/rules.mk
 
@@ -11,10 +13,10 @@ include $(TOP)/src/touch-unit.sources
 export MD_MTOUCH_SDK_ROOT=$(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)
 export XamarinMacFrameworkRoot=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
 
-MAC_BUILD_DIR=build/mac
-IOS_BUILD_DIR=build/ios
-WATCH_BUILD_DIR=build/watch
-TVOS_BUILD_DIR=build/tvos
+MAC_BUILD_DIR=$(BUILD_DIR)/mac
+IOS_BUILD_DIR=$(BUILD_DIR)/ios
+WATCH_BUILD_DIR=$(BUILD_DIR)/watch
+TVOS_BUILD_DIR=$(BUILD_DIR)/tvos
 
 include $(TOP)/opentk/Makefile.include
 
@@ -42,8 +44,8 @@ include ./Makefile.generator
 include ./generator-diff.mk
 
 COMMON_TARGET_DIRS = \
-	build/common             \
-	build/common/NativeTypes \
+	$(BUILD_DIR)/common             \
+	$(BUILD_DIR)/common/NativeTypes \
 
 ARGS_32 = -define:ARCH_32
 ARGS_64 = -define:ARCH_64
@@ -70,7 +72,7 @@ IOS_DEFINES = -define:IPHONE -define:IOS -define:MONOTOUCH -d:NET_2_0 -d:__IOS__
 IOS_native_DEFINES = -d:XAMCORE_2_0 -d:__UNIFIED__
 IOS_LIBDIR = $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/2.1
 IOS_BMONO = MONO_PATH=$(IOS_LIBDIR) $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/btouch-mono
-IOS_GENERATOR=build/common/bgen.exe
+IOS_GENERATOR=$(BUILD_DIR)/common/bgen.exe
 IOS_GENERATE=$(SYSTEM_MONO) --debug $(IOS_GENERATOR)
 IOS_native_GENERATOR=$(IOS_GENERATOR)
 IOS_native_GENERATE=$(IOS_GENERATE)
@@ -82,7 +84,7 @@ $(IOS_BUILD_DIR)/Constants.cs: Constants.iOS.cs.in Makefile $(TOP)/Make.config.i
 		$< > $@
 
 $(IOS_BUILD_DIR)/AssemblyInfo.cs: $(TOP)/src/AssemblyInfo.cs.in
-	$(Q) mkdir -p build
+	$(Q) mkdir -p $(IOS_BUILD_DIR)
 	$(call Q_PROF_GEN,ios) sed < $< > $@ 's|@PRODUCT_NAME@|$(IOS_PRODUCT)|g; s|@PACKAGE_HEAD_REV@|$(PACKAGE_HEAD_REV)|g; s|@PACKAGE_HEAD_BRANCH@|$(CURRENT_BRANCH)|g; s|@PACKAGE_VERSION_MAJOR@|$(IOS_PACKAGE_VERSION_MAJOR)|g; s|@PACKAGE_VERSION_MINOR@|$(IOS_PACKAGE_VERSION_MINOR)|g; s|@PACKAGE_VERSION_REV@|$(IOS_PACKAGE_VERSION_REV)|g; s|@PACKAGE_VERSION_BUILD@|$(IOS_PACKAGE_VERSION_BUILD)|g'
 
 $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/Version: Version.in $(TOP)/Make.config
@@ -229,10 +231,10 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/2.1/% : $(MACIOS_BINARIES_PATH)/% | $
 $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/2.1/Facades/% : $(MACIOS_BINARIES_PATH)/Facades/% | $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/2.1
 	$(Q) cp $< $@
 
-build/ios/compat/%: $(MACIOS_BINARIES_PATH)/% | build/ios/compat
+$(IOS_BUILD_DIR)/compat/%: $(MACIOS_BINARIES_PATH)/% | $(IOS_BUILD_DIR)/compat
 	$(Q) cp $< $@
 
-build/ios/compat/Facades/System.Drawing.Primitives.dll : $(MACIOS_BINARIES_PATH)/Facades/System.Drawing.Primitives.dll | build/ios/compat/Facades
+$(IOS_BUILD_DIR)/compat/Facades/System.Drawing.Primitives.dll : $(MACIOS_BINARIES_PATH)/Facades/System.Drawing.Primitives.dll | $(IOS_BUILD_DIR)/compat/Facades
 	$(Q) cp $< $@
 
 #
@@ -485,7 +487,7 @@ $(MAC_BUILD_DIR)/AssemblyInfo.cs: $(TOP)/src/AssemblyInfo.cs.in
 xm_full_profile=--target-framework=Xamarin.Mac,Version=v4.5,Profile=Full
 xm_mobile_profile=--target-framework=Xamarin.Mac,Version=v2.0,Profile=Mobile
 
-MAC_GENERATOR=build/common/bgen.exe
+MAC_GENERATOR=$(BUILD_DIR)/common/bgen.exe
 MAC_GENERATE=$(SYSTEM_MONO) --debug $(MAC_GENERATOR)
 MAC_full_GENERATOR=$(MAC_GENERATOR)
 MAC_full_GENERATE=$(MAC_GENERATE)
@@ -702,7 +704,7 @@ all-mac: $(MAC_TARGETS)
 WATCH_DEFINES = -define:IPHONE -define:MONOTOUCH -d:NET_2_0 -d:WATCH -d:XAMCORE_2_0 -d:XAMCORE_3_0 -d:__WATCHOS__ -d:__UNIFIED__
 WATCH_LIBDIR = $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.WatchOS
 WATCH_BMONO = MONO_PATH=$(WATCH_LIBDIR)/repl $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/bwatch-mono
-WATCH_GENERATOR=build/common/bgen.exe
+WATCH_GENERATOR=$(BUILD_DIR)/common/bgen.exe
 WATCH_GENERATE=$(SYSTEM_MONO) --debug $(WATCH_GENERATOR)
 WATCH_GENERATED_DEFINES= -d:WATCH -d:XAMCORE_3_0 -d:XAMCORE_2_0 -d:__UNIFIED__
 WATCH_BCL_DIR = $(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch
@@ -932,7 +934,7 @@ endif
 TVOS_DEFINES = -define:IPHONE -define:MONOTOUCH -d:NET_2_0 -d:TVOS -d:XAMCORE_2_0 -d:XAMCORE_3_0 -d:__TVOS__ $(APPLETLS_DEFINES) -d:__UNIFIED__
 TVOS_LIBDIR = $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/Xamarin.TVOS
 TVOS_BMONO = MONO_PATH=$(TVOS_LIBDIR)/repl $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/bin/btv-mono
-TVOS_GENERATOR=build/common/bgen.exe
+TVOS_GENERATOR=$(BUILD_DIR)/common/bgen.exe
 TVOS_GENERATE=$(SYSTEM_MONO) --debug $(TVOS_GENERATOR)
 TVOS_GENERATED_DEFINES= -d:TVOS -d:XAMCORE_3_0 -d:XAMCORE_2_0 -d:__UNIFIED__
 TV_MCS = $(SYSTEM_MCS) -nostdlib -noconfig -r:$(MONOTOUCH_TV_MONO_PATH)/System.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Core.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Xml.dll -r:$(MONOTOUCH_TV_MONO_PATH)/mscorlib.dll
@@ -1177,7 +1179,7 @@ SHARED_PATH := ../runtime
 $(SHARED_PATH)/Delegates.generated.cs: $(SHARED_PATH)/Delegates.cs.t4 $(SHARED_PATH)/delegates.t4
 	$(Q) $(MAKE) -C $(SHARED_PATH) Delegates.generated.cs
 
-build/common/NativeTypes/%.cs: $(TOP)/src/NativeTypes/%.tt | build/common/NativeTypes
+$(BUILD_DIR)/common/NativeTypes/%.cs: $(TOP)/src/NativeTypes/%.tt | $(BUILD_DIR)/common/NativeTypes
 	$(Q_GEN) $(TT) $< -o $@ 1>/dev/null
 
 $(COMMON_TARGET_DIRS):

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -11,7 +11,7 @@ GENERATOR_SOURCES =                                             \
 	$(TOP)/src/ObjCRuntime/Stret.cs                    \
 	$(TOP)/tools/common/TargetFramework.cs             \
 	$(TOP)/tools/common/StringUtils.cs				   \
-	build/generator-frameworks.g.cs                    \
+	$(BUILD_DIR)/generator-frameworks.g.cs                    \
 	$(MONO_PATH)/mcs/class/Mono.Options/Mono.Options/Options.cs \
 
 GENERATOR_DEFINES = -d:BGENERATOR -d:NET_4_0
@@ -51,8 +51,8 @@ GENERATOR_ATTRIBUTE_SOURCES = \
 
 IKVM_REFLECTION_FLAGS = -d:NO_AUTHENTICODE,STATIC,NO_SYMBOL_WRITER
 
-build/common/bgen.exe: $(GENERATOR_SOURCES) $(IKVM_REFLECTION_SOURCES) $(GENERATOR_ATTRIBUTE_SOURCES) Makefile.generator
-	$(Q) mkdir -p build/common
+$(BUILD_DIR)/common/bgen.exe: $(GENERATOR_SOURCES) $(IKVM_REFLECTION_SOURCES) $(GENERATOR_ATTRIBUTE_SOURCES) Makefile.generator
+	$(Q) mkdir -p $(BUILD_DIR)/common
 	$(Q_GEN) $(SYSTEM_CSC) -debug:portable -out:$@ $(IKVM_REFLECTION_FLAGS) $(GENERATOR_DEFINES) $(IKVM_REFLECTION_SOURCES) $(GENERATOR_ATTRIBUTE_SOURCES) $(GENERATOR_SOURCES)
 
 # The command-line arguments in the csproj are currently kept up-to-date manually
@@ -76,7 +76,7 @@ PROJECT_FILES += generator.csproj
 # Common
 #
 
-build/generator-frameworks.g.cs: frameworks.sources Makefile.generator generate-frameworks.csharp
+$(BUILD_DIR)/generator-frameworks.g.cs: frameworks.sources Makefile.generator generate-frameworks.csharp
 	@mkdir -p $(dir $@)
 	@./generate-frameworks.csharp '$(IOS_FRAMEWORKS)' '$(MAC_FRAMEWORKS)' '$(WATCHOS_FRAMEWORKS)' '$(TVOS_FRAMEWORKS)' > $@
 
@@ -115,7 +115,7 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bgen/%.dll: $(IOS_BUILD_DIR)/native/%.dll 
 	$(Q) install -m 0755 $< $@
 	$(Q) install -m 0644 $<.mdb $@.mdb
 
-$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bgen/bgen.exe: build/common/bgen.exe | $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bgen
+$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bgen/bgen.exe: $(BUILD_DIR)/common/bgen.exe | $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bgen
 	$(Q) install -m 0755 $< $@
 	$(Q) install -m 0644 $< $(@:.exe=.pdb)
 
@@ -212,7 +212,7 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/%.dll: $(MAC_BUILD_DIR)/%.dl
 	$(Q) install -m 0755 $< $@
 	$(Q) install -m 0644 $<.mdb $@.mdb
 
-$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/%.exe: build/common/bgen.exe | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen
+$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/%.exe: $(BUILD_DIR)/common/bgen.exe | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen
 	$(Q) install -m 0755 $< $@
 	$(Q) install -m 0644 $< $(@:.exe=.pdb)
 

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1524,8 +1524,8 @@ SHARED_API_SOURCES = \
 
 SHARED_CORE_SOURCES = \
 	MonoPInvokeCallbackAttribute.cs \
-	build/common/NativeTypes/Drawing.cs \
-	build/common/NativeTypes/Primitives.cs \
+	$(BUILD_DIR)/common/NativeTypes/Drawing.cs \
+	$(BUILD_DIR)/common/NativeTypes/Primitives.cs \
 	ObjCRuntime/AlphaAttribute.cs \
 	ObjCRuntime/ArgumentSemantic.cs \
 	ObjCRuntime/BindAsAttribute.cs \

--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -10,6 +10,8 @@ ifdef SKIP_ADDED_APIS
 ADD_REGEX = "-a:.?"
 endif
 
+APIDIFF_DIR=.
+
 MONO_API_HTML_DIR = $(MONO_PATH)/mcs/tools/mono-api-html
 MONO_API_INFO_DIR = $(MONO_PATH)/mcs/tools/corcompare
 MONO_API_INFO = $(MONO_API_INFO_DIR)/bin/Debug/mono-api-info.exe
@@ -48,19 +50,19 @@ MAC_ARCH_ASSEMBLIES = native-32/Xamarin.Mac native-64/Xamarin.Mac
 # create api info. Directory hierarchy is based on installed hierarchy
 # (XM goes into temp/xm, and XI goes into temp/xi)
 
-temp/xi/%.xml: $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/%.dll $(MONO_API_INFO)
+$(APIDIFF_DIR)/temp/xi/%.xml: $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/%.dll $(MONO_API_INFO)
 	$(Q) mkdir -p $(dir $@)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
 
-temp/xm/%.xml: $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/%.dll $(MONO_API_INFO)
+$(APIDIFF_DIR)/temp/xm/%.xml: $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/%.dll $(MONO_API_INFO)
 	$(Q) mkdir -p $(dir $@)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
 
-temp/native-%/Xamarin.Mac.xml: $(TOP)/src/build/mac/mobile-%/Xamarin.Mac.dll $(MONO_API_INFO)
+$(APIDIFF_DIR)/temp/native-%/Xamarin.Mac.xml: $(TOP)/src/build/mac/mobile-%/Xamarin.Mac.dll $(MONO_API_INFO)
 	$(Q) mkdir -p $(dir $@)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
 
-temp/native-%/Xamarin.iOS.xml: $(TOP)/src/build/ios/native-%/Xamarin.iOS.dll $(MONO_API_INFO)
+$(APIDIFF_DIR)/temp/native-%/Xamarin.iOS.xml: $(TOP)/src/build/ios/native-%/Xamarin.iOS.dll $(MONO_API_INFO)
 	$(Q) mkdir -p $(dir $@)
 	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $@
 
@@ -70,16 +72,16 @@ temp/native-%/Xamarin.iOS.xml: $(TOP)/src/build/ios/native-%/Xamarin.iOS.dll $(M
 # to run mono-api-html every time even if none of the
 # dependencies changed)
 
-diff/%.html: temp/%.xml references/%.xml $(MONO_API_HTML)
+$(APIDIFF_DIR)/diff/%.html: $(APIDIFF_DIR)/temp/%.xml $(APIDIFF_DIR)/references/%.xml $(MONO_API_HTML)
 	$(Q) mkdir -p $(dir $@)
-	$(QF_GEN) mono --debug $(MONO_API_HTML) $(NEW_REGEX) $(ADD_REGEX) references/$*.xml temp/$*.xml -i 'INSObjectProtocol' $@
+	$(QF_GEN) mono --debug $(MONO_API_HTML) $(NEW_REGEX) $(ADD_REGEX) $(APIDIFF_DIR)/references/$*.xml $(APIDIFF_DIR)/temp/$*.xml -i 'INSObjectProtocol' $@
 	$(Q) touch $@
 
 # this is a hack to show the difference between iOS and tvOS
-diff/ios-to-tvos.html: temp/xi/Xamarin.iOS/Xamarin.iOS.xml temp/xi/Xamarin.TVOS/Xamarin.TVOS.xml
+$(APIDIFF_DIR)/diff/ios-to-tvos.html: $(APIDIFF_DIR)/temp/xi/Xamarin.iOS/Xamarin.iOS.xml $(APIDIFF_DIR)/temp/xi/Xamarin.TVOS/Xamarin.TVOS.xml
 	$(Q) mkdir -p $(dir $@)
-	$(Q) sed -e 's_<assembly name="Xamarin.TVOS" version="0.0.0.0">_<assembly name="Xamarin.iOS" version="0.0.0.0">_' temp/xi/Xamarin.TVOS/Xamarin.TVOS.xml > temp/Xamarin.TVOS-as-iOS.xml
-	$(QF_GEN) mono --debug $(MONO_API_HTML) $< temp/Xamarin.TVOS-as-iOS.xml $@
+	$(Q) sed -e 's_<assembly name="Xamarin.TVOS" version="0.0.0.0">_<assembly name="Xamarin.iOS" version="0.0.0.0">_' $(APIDIFF_DIR)/temp/xi/Xamarin.TVOS/Xamarin.TVOS.xml > $(APIDIFF_DIR)/temp/Xamarin.TVOS-as-iOS.xml
+	$(QF_GEN) mono --debug $(MONO_API_HTML) $< $(APIDIFF_DIR)/temp/Xamarin.TVOS-as-iOS.xml $@
 
 # our api-info and api-html binaries
 
@@ -91,12 +93,12 @@ $(MONO_API_INFO): $(wildcard $(MONO_API_INFO_DIR)/*.*)
 
 # create diff files for all the assemblies per platform
 
-mac-api-diff.html:     $(foreach file,$(MAC_ASSEMBLIES),diff/xm/$(file).html)
-ios-api-diff.html:     $(foreach file,$(IOS_ASSEMBLIES),diff/xi/$(file).html)
-watchos-api-diff.html: $(foreach file,$(WATCHOS_ASSEMBLIES),diff/xi/$(file).html)
-tvos-api-diff.html:    $(foreach file,$(TVOS_ASSEMBLIES),diff/xi/$(file).html)
+$(APIDIFF_DIR)/mac-api-diff.html:     $(foreach file,$(MAC_ASSEMBLIES),$(APIDIFF_DIR)/diff/xm/$(file).html)
+$(APIDIFF_DIR)/ios-api-diff.html:     $(foreach file,$(IOS_ASSEMBLIES),$(APIDIFF_DIR)/diff/xi/$(file).html)
+$(APIDIFF_DIR)/watchos-api-diff.html: $(foreach file,$(WATCHOS_ASSEMBLIES),$(APIDIFF_DIR)/diff/xi/$(file).html)
+$(APIDIFF_DIR)/tvos-api-diff.html:    $(foreach file,$(TVOS_ASSEMBLIES),$(APIDIFF_DIR)/diff/xi/$(file).html)
 
-%-api-diff.html:
+$(APIDIFF_DIR)/%-api-diff.html:
 	$(Q) rm -f $@
 	$(Q) touch $@-toc
 	$(Q_GEN) for file in $?; do \
@@ -117,36 +119,36 @@ tvos-api-diff.html:    $(foreach file,$(TVOS_ASSEMBLIES),diff/xi/$(file).html)
 	$(Q) rm -f $@-toc
 
 ifdef INCLUDE_MAC
-API_DIFF_DEPENDENCIES += mac-api-diff.html
+API_DIFF_DEPENDENCIES += $(APIDIFF_DIR)/mac-api-diff.html
 endif
 ifdef INCLUDE_IOS
-API_DIFF_DEPENDENCIES += ios-api-diff.html
+API_DIFF_DEPENDENCIES += $(APIDIFF_DIR)/ios-api-diff.html
 ifdef INCLUDE_WATCH
-API_DIFF_DEPENDENCIES += watchos-api-diff.html
+API_DIFF_DEPENDENCIES += $(APIDIFF_DIR)/watchos-api-diff.html
 endif
 ifdef INCLUDE_TVOS
-API_DIFF_DEPENDENCIES += tvos-api-diff.html
-API_DIFF_DEPENDENCIES += diff/ios-to-tvos.html
+API_DIFF_DEPENDENCIES += $(APIDIFF_DIR)/tvos-api-diff.html
+API_DIFF_DEPENDENCIES += $(APIDIFF_DIR)/diff/ios-to-tvos.html
 endif
 endif
 
-api-diff.html: $(API_DIFF_DEPENDENCIES)
+$(APIDIFF_DIR)/api-diff.html: $(API_DIFF_DEPENDENCIES)
 	$(QF_GEN) echo "<h1>API diffs</h1>" > $@
 ifdef INCLUDE_IOS
-	$(Q) if [[ "x0" != "x`stat -L -f %z ios-api-diff.html`" ]]; then  \
+	$(Q) if [[ "x0" != "x`stat -L -f %z $(APIDIFF_DIR)/ios-api-diff.html`" ]]; then  \
 		echo "<h2><a href='ios-api-diff.html'>Xamarin.iOS API diff</a></h2>" >> $@; \
 	else \
 		echo "<h2>Xamarin.iOS API diff is empty</h2>" >> $@; \
 	fi;
 ifdef INCLUDE_TVOS
-	$(Q) if [[ "x0" != "x`stat -L -f %z tvos-api-diff.html`" ]]; then  \
+	$(Q) if [[ "x0" != "x`stat -L -f %z $(APIDIFF_DIR)/tvos-api-diff.html`" ]]; then  \
 		echo "<h2><a href='tvos-api-diff.html'>Xamarin.TVOS API diff</a></h2>" >> $@; \
 	else \
 		echo "<h2>Xamarin.TVOS API diff is empty</h2>" >> $@; \
 	fi;
 endif
 ifdef INCLUDE_WATCH
-	$(Q) if [[ "x0" != "x`stat -L -f %z watchos-api-diff.html`" ]]; then  \
+	$(Q) if [[ "x0" != "x`stat -L -f %z $(APIDIFF_DIR)/watchos-api-diff.html`" ]]; then  \
 		echo "<h2><a href='watchos-api-diff.html'>Xamarin.WatchOS API diff</a></h2>" >> $@; \
 	else \
 		echo "<h2>Xamarin.WatchOS API diff is empty</h2>" >> $@; \
@@ -154,7 +156,7 @@ ifdef INCLUDE_WATCH
 endif
 endif
 ifdef INCLUDE_MAC
-	$(Q) if [[ "x0" != "x`stat -L -f %z mac-api-diff.html`" ]]; then  \
+	$(Q) if [[ "x0" != "x`stat -L -f %z $(APIDIFF_DIR)/mac-api-diff.html`" ]]; then  \
 		echo "<h2><a href='mac-api-diff.html'>Xamarin.Mac API diff</a></h2>" >> $@; \
 	else \
 		echo "<h2>Xamarin.Mac API diff is empty</h2>" >> $@; \
@@ -164,24 +166,24 @@ endif
 # easy-to-type helper targets.
 # one rule to create all the api diffs
 
-all-local:: api-diff.html
+all-local:: $(APIDIFF_DIR)/api-diff.html
 
 # Rules to re-create the reference infos. The rules target the updated-references
 # directory, so that they're only invoked manually (otherwise the reference infos
 # would be updated every time the assemblies change, which is not what we want).
 
-IOS_REFS     = $(foreach file,$(IOS_ASSEMBLIES),updated-references/xi/$(file).xml)
-MAC_REFS     = $(foreach file,$(MAC_ASSEMBLIES),updated-references/xm/$(file).xml)
-WATCHOS_REFS = $(foreach file,$(WATCHOS_ASSEMBLIES),updated-references/xi/$(file).xml)
-TVOS_REFS    = $(foreach file,$(TVOS_ASSEMBLIES),updated-references/xi/$(file).xml)
+IOS_REFS     = $(foreach file,$(IOS_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/xi/$(file).xml)
+MAC_REFS     = $(foreach file,$(MAC_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/xm/$(file).xml)
+WATCHOS_REFS = $(foreach file,$(WATCHOS_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/xi/$(file).xml)
+TVOS_REFS    = $(foreach file,$(TVOS_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/xi/$(file).xml)
 
-updated-references/xi/%.xml: $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/%.dll $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@) $(dir references/xi/$*)
-	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o references/xi/$*.xml
+$(APIDIFF_DIR)/updated-references/xi/%.xml: $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/mono/%.dll $(MONO_API_INFO)
+	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/xi/$*)
+	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $(APIDIFF_DIR)/references/xi/$*.xml
 
-updated-references/xm/%.xml: $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/%.dll $(MONO_API_INFO)
-	$(Q) mkdir -p $(dir $@) $(dir references/xm/$*)
-	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o references/xm/$*.xml
+$(APIDIFF_DIR)/updated-references/xm/%.xml: $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/%.dll $(MONO_API_INFO)
+	$(Q) mkdir -p $(dir $@) $(dir $(APIDIFF_DIR)/references/xm/$*)
+	$(QF_GEN) mono --debug $(MONO_API_INFO) $< -o $(APIDIFF_DIR)/references/xm/$*.xml
 
 update-tvos-refs: $(TVOS_REFS)
 update-watchos-refs: $(WATCHOS_REFS)
@@ -192,19 +194,19 @@ update-refs: $(WATCHOS_REFS) $(TVOS_REFS) $(IOS_REFS) $(MAC_REFS)
 
 # targets to verify that the 32-bit and 64-bit assemblies have identical API.
 
-verify-reference-assemblies-ios: temp/native-32/Xamarin.iOS.xml temp/native-64/Xamarin.iOS.xml
-	$(Q) diff temp/native-32/Xamarin.iOS.xml temp/native-64/Xamarin.iOS.xml -u
+verify-reference-assemblies-ios: $(APIDIFF_DIR)/temp/native-32/Xamarin.iOS.xml $(APIDIFF_DIR)/temp/native-64/Xamarin.iOS.xml
+	$(Q) diff $(APIDIFF_DIR)/temp/native-32/Xamarin.iOS.xml $(APIDIFF_DIR)/temp/native-64/Xamarin.iOS.xml -u
 	@echo iOS reference assemblies are identical
 
-verify-reference-assemblies-mac: temp/native-32/Xamarin.Mac.xml temp/native-64/Xamarin.Mac.xml
-	$(Q) diff temp/native-32/Xamarin.Mac.xml temp/native-64/Xamarin.Mac.xml -u
+verify-reference-assemblies-mac: $(APIDIFF_DIR)/temp/native-32/Xamarin.Mac.xml $(APIDIFF_DIR)/temp/native-64/Xamarin.Mac.xml
+	$(Q) diff $(APIDIFF_DIR)/temp/native-32/Xamarin.Mac.xml $(APIDIFF_DIR)/temp/native-64/Xamarin.Mac.xml -u
 	@echo Mac reference assemblies are identical
 
 clean-local::
 	rm -rf temp updated-references diff *.exe* api-diff.html
 	rm -rf *.dll*
 
-DIRS += temp diff
+DIRS += $(APIDIFF_DIR)/temp $(APIDIFF_DIR)/diff
 
 # dir creation target
 $(DIRS):
@@ -212,10 +214,10 @@ $(DIRS):
 
 # make will automatically consider files created in chained implicit rules as temporary files, and delete them afterwards
 # marking those files as .SECONDARY will prevent that deletion.
-.SECONDARY: $(foreach file,$(IOS_ASSEMBLIES),temp/xi/$(file).xml)
-.SECONDARY: $(foreach file,$(MAC_ASSEMBLIES),temp/xm/$(file).xml)
-.SECONDARY: $(foreach file,$(WATCHOS_ASSEMBLIES),temp/xi/$(file).xml)
-.SECONDARY: $(foreach file,$(TVOS_ASSEMBLIES),temp/xi/$(file).xml)
+.SECONDARY: $(foreach file,$(IOS_ASSEMBLIES),$(APIDIFF_DIR)/temp/xi/$(file).xml)
+.SECONDARY: $(foreach file,$(MAC_ASSEMBLIES),$(APIDIFF_DIR)/temp/xm/$(file).xml)
+.SECONDARY: $(foreach file,$(WATCHOS_ASSEMBLIES),$(APIDIFF_DIR)/temp/xi/$(file).xml)
+.SECONDARY: $(foreach file,$(TVOS_ASSEMBLIES),$(APIDIFF_DIR)/temp/xi/$(file).xml)
 
 wrench-api-diff:
 	@echo "@MonkeyWrench: AddDirectory: $(CURDIR)/diff/xi/Xamarin.iOS"


### PR DESCRIPTION
Don't hardcode input/output/build directories, but instead make them
overridable.

This will make it easy to:

* Checkout a different hash
* Build (just) src/, into a separate directory that doesn't affect the
  existing assemblies.
* Compute apidiff between the existing assemblies and the newly built ones.
* Compute the diff for the generated source code.

This is coming in a later PR.