### PR TITLE
[macos][imagekit] Add a deprecation warning on IKImageBrowserView

### DIFF
--- a/src/imagekit.cs
+++ b/src/imagekit.cs
@@ -343,6 +343,7 @@ namespace XamCore.ImageKit {
 		NSString PlaceHolderLayer { get; }
 	}
 
+	[Deprecated (PlatformName.MacOSX, 10,14, message: "Use 'NSCollectionView' instead.")]
 	[BaseType (typeof (NSView), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (IKImageBrowserDelegate)})]
 	interface IKImageBrowserView {
 		//@category IKImageBrowserView (IKMainMethods)


### PR DESCRIPTION
It's a _early_ warning since it mention 10.14