### PR TITLE
[generator] Add support for [DesignatedInitializer]. Fix #3247

### DIFF
--- a/docs/website/binding_types_reference_guide.md
+++ b/docs/website/binding_types_reference_guide.md
@@ -305,8 +305,16 @@ public interface UIActionSheetDelegate {
 }
 ```
 
- <a name="DisableDefaultCtorAttribute" />
+ <a name="DesignatedDefaultCtorAttribute" />
 
+## DesignatedDefaultCtorAttribute
+
+When this attribute is applied to the interface definition it will generate
+a `[DesignatedInitializer]` attribute on the default (generated) constructor
+which maps to the `init` selector.
+
+
+ <a name="DisableDefaultCtorAttribute" />
 
 ## DisableDefaultCtorAttribute
 
@@ -1265,6 +1273,15 @@ one for each parameter that the callback takes.
 Use this property to customize the name of the generated
 async methods.   The default is to use the name of the method
 and append the text "Async", you can use this to change this default.
+
+
+## DesignatedInitializerAttribute
+
+When this attribute is applied to a constructor it will generate the same
+`[DesignatedInitializer]` in the final platform assembly. This is to help
+the IDE indicate which constructor should be used in subclasses.
+
+This should map to ObjC/clang use of `__attribute__((objc_designated_initializer))`.
 
 
 ## DisableZeroCopyAttribute

--- a/src/generator-attributes.cs
+++ b/src/generator-attributes.cs
@@ -684,6 +684,20 @@ public class DesignatedInitializerAttribute : Attribute {
 }
 
 //
+// Apple this attribute to ObjC types where the default `init` selector 
+// is decorated with `NS_DESIGNATED_INITIALIZER`
+//
+// The generator will produce a `[DesignatedInitializer]` when generating the
+// default constructor when `[DesignatedDefaultCtor]` is present on the type
+//
+[AttributeUsage (AttributeTargets.Interface)]
+public class DesignatedDefaultCtorAttribute : Attribute {
+	public DesignatedDefaultCtorAttribute ()
+	{
+	}
+}
+
+//
 // Apply this attribute to a method that you want an async version of a callback method.
 //
 // Use the ResultType or ResultTypeName attribute to describe any composite value to be by the Task object.

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -2373,6 +2373,8 @@ public partial class Generator : IMemberGatherer {
 						continue;
 					else if (attr is DesignatedInitializerAttribute)
 						continue;
+					else if (attr is DesignatedDefaultCtorAttribute)
+						continue;
 					else if (attr is AvailabilityBaseAttribute)
 						continue;
 					else if (attr is RequiresSuperAttribute)
@@ -6085,6 +6087,10 @@ public partial class Generator : IMemberGatherer {
 					if (external) {
 						if (!disable_default_ctor) {
 							GeneratedCode (sw, 2);
+							foreach (var ta in AttributeManager.GetCustomAttributes<DesignatedDefaultCtorAttribute> (type)) {
+								sw.WriteLine ("\n\n[DesignatedInitializer]");
+								break;
+							}
 							sw.WriteLine ("\t\t[EditorBrowsable (EditorBrowsableState.Advanced)]");
 							sw.WriteLine ("\t\t[Export (\"init\")]");
 							sw.WriteLine ("\t\t{0} {1} () : base (NSObjectFlag.Empty)", v, TypeName);
@@ -6100,6 +6106,10 @@ public partial class Generator : IMemberGatherer {
 					} else {
 						if (!disable_default_ctor) {
 							GeneratedCode (sw, 2);
+							foreach (var ta in AttributeManager.GetCustomAttributes<DesignatedDefaultCtorAttribute> (type)) {
+								sw.WriteLine ("\t\t[DesignatedInitializer]");
+								break;
+							}
 							sw.WriteLine ("\t\t[EditorBrowsable (EditorBrowsableState.Advanced)]");
 							sw.WriteLine ("\t\t[Export (\"init\")]");
 							sw.WriteLine ("\t\t{0} {1} () : base (NSObjectFlag.Empty)", v, TypeName);


### PR DESCRIPTION
Add an easier syntax for automatically generated default .ctor/init
what needs to be decorated with `[DesignatedInitializer]`.

The current way of doing this requires a bit too much work.
More details in:
https://github.com/xamarin/xamarin-macios/issues/3247

Generator diff: https://gist.github.com/spouliot/2675be8ce15ab473ed7c573403d7eb47

Note that this includes the Foundation and UIKit fixes (reported
by xtro). Those will be committed separately once this is merged.