### PR TITLE
[generator] Reuse the [RequiresSuper] attribute from the platform assemblies.

### DIFF
--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -48,6 +48,7 @@ GENERATOR_ATTRIBUTE_SOURCES = \
 	$(TOP)/src/ObjCRuntime/PlatformAvailability2.cs \
 	$(TOP)/src/ObjCRuntime/PlatformAvailabilityShadow.cs \
 	$(TOP)/src/ObjCRuntime/Registrar.core.cs \
+	$(TOP)/src/ObjCRuntime/RequiresSuperAttribute.cs \
 
 IKVM_REFLECTION_FLAGS = -d:NO_AUTHENTICODE,STATIC,NO_SYMBOL_WRITER
 

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1542,6 +1542,7 @@ SHARED_CORE_SOURCES = \
 	ObjCRuntime/PlatformAvailabilityShadow.cs \
 	ObjCRuntime/Protocol.cs \
 	ObjCRuntime/Registrar.core.cs \
+	ObjCRuntime/RequiresSuperAttribute.cs \
 	ObjCRuntime/Selector.cs \
 	Simd/MatrixDouble4x4.cs \
 	Simd/MatrixFloat2x2.cs \
@@ -1577,7 +1578,6 @@ SHARED_SOURCES = \
 	ObjCRuntime/Registrar.cs \
 	ObjCRuntime/ReleaseAttribute.cs \
 	ObjCRuntime/RequiredFrameworkAttribute.cs \
-	ObjCRuntime/RequiresSuperAttribute.cs \
 	ObjCRuntime/Runtime.cs \
 	ObjCRuntime/Runtime.iOS.cs \
 	ObjCRuntime/Runtime.mac.cs \

--- a/src/generator-attributes.cs
+++ b/src/generator-attributes.cs
@@ -842,8 +842,3 @@ public class DefaultEnumValueAttribute : Attribute {
 	{
 	}
 }
-
-// Hint that overriding the member requires a call to the base type
-[AttributeUsage (AttributeTargets.Method | AttributeTargets.Constructor, AllowMultiple=false)]
-public class RequiresSuperAttribute : Attribute {
-}


### PR DESCRIPTION
Bindings trying to override members with that attribute would produce a

```
error BI1055: bgen: Internal error: failed to convert type 'ObjCRuntime.RequiresSuperAttribute, Xamarin.iOS, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065'. Please file a bug report (https://bugzilla.xamarin.com) with a test case.
```

Fixes https://github.com/xamarin/maccore/issues/632