### PR TITLE
[mtouch/mmp] Simplify and unify the code to select/create the static registrar.

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -397,6 +397,8 @@ namespace Xamarin.Bundler {
 
 		public void InitializeCommon ()
 		{
+			SelectRegistrar ();
+
 			if (RequiresXcodeHeaders && SdkVersion < SdkVersions.GetVersion (Platform)) {
 				throw ErrorHelper.CreateError (91, "This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).", ProductName, PlatformName, SdkVersions.GetVersion (Platform), SdkVersions.Xcode, Error91LinkerSuggestion);
 			}

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -59,6 +59,7 @@ namespace Xamarin.Bundler {
 		public Target (Application app)
 		{
 			this.App = app;
+			this.StaticRegistrar = new StaticRegistrar (this);
 		}
 
 		public void ExtractNativeLinkInfo (List<Exception> exceptions)

--- a/tools/mmp/Application.cs
+++ b/tools/mmp/Application.cs
@@ -17,5 +17,10 @@ namespace Xamarin.Bundler {
 			if (DeploymentTarget == null) 
 				DeploymentTarget = new Version (10, 7);
 		}
+
+		void SelectRegistrar ()
+		{
+			Driver.SelectRegistrar ();
+		}
 	}
 }

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -690,14 +690,9 @@ namespace Xamarin.Bundler {
 			}
 		}
 
-		static void Pack (IList<string> unprocessed)
+		public static void SelectRegistrar ()
 		{
-			string fx_dir = null;
-			string root_assembly = null;
-			var native_libs = new Dictionary<string, List<MethodDefinition>> ();
-
-			if (Registrar == RegistrarMode.Default)
-			{
+			if (Registrar == RegistrarMode.Default) {
 				if (!App.EnableDebug)
 					Registrar = RegistrarMode.Static;
 				else if (IsUnified && App.LinkMode == LinkMode.None && embed_mono && App.IsDefaultMarshalManagedExceptionMode && File.Exists (PartialStaticLibrary))
@@ -706,7 +701,14 @@ namespace Xamarin.Bundler {
 					Registrar = RegistrarMode.Dynamic;
 				Log (1, $"Defaulting registrar to '{Registrar}'");
 			}
-			
+		}
+
+		static void Pack (IList<string> unprocessed)
+		{
+			string fx_dir = null;
+			string root_assembly = null;
+			var native_libs = new Dictionary<string, List<MethodDefinition>> ();
+
 			if (no_executable) {
 				if (unprocessed.Count != 0) {
 					var exceptions = new List<Exception> ();

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -823,9 +823,9 @@ namespace Xamarin.Bundler {
 
 		void BuildInitialize ()
 		{
+			SelectRegistrar ();
 			Initialize ();
 			ValidateAbi ();
-			SelectRegistrar ();
 			ExtractNativeLinkInfo ();
 			SelectNativeCompiler ();
 		}
@@ -1363,9 +1363,6 @@ namespace Xamarin.Bundler {
 					Registrar = RegistrarMode.Dynamic;
 				}
 			}
-
-			foreach (var target in Targets)
-				target.SelectStaticRegistrar ();
 		}
 
 		// Select all abi from the list matching the specified mask.

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -872,17 +872,6 @@ namespace Xamarin.Bundler
 			}
 		}
 
-		public void SelectStaticRegistrar ()
-		{
-			switch (App.Registrar) {
-			case RegistrarMode.Static:
-			case RegistrarMode.Dynamic:
-			case RegistrarMode.Default:
-				StaticRegistrar = new StaticRegistrar (this);
-				break;
-			}
-		}
-
 		void AOTCompile ()
 		{
 			if (App.IsSimulatorBuild)


### PR DESCRIPTION
There's only one static registrar now, so there's no need for code to select
which one, just create the one and only.

Also unify this code between mtouch and mmp.