### PR TITLE
[tests] Fix relative paths in mmptest and make cloned XM nunit projects work properly.

### DIFF
--- a/tests/mmptest/CustomBuildActions.targets
+++ b/tests/mmptest/CustomBuildActions.targets
@@ -5,7 +5,7 @@
 	    <BuildDependsOn>$(BuildDependsOn);CreateNativeLibs</BuildDependsOn>
 	</PropertyGroup>
 
-	<Target Name="CreateNativeLibs" Inputs="../common/mac/SimpleClass.m" Outputs="../mac-binding-project/bin/SimpleClassDylib.dylib;../mac-binding-project/bin/SimpleClassStatic.a;../mac-binding-project/bin/Mobile-static/MobileBinding.dll">
-		<Exec Command="make bin/SimpleClassDylib.dylib bin/SimpleClassStatic.a bin/Mobile-static/MobileBinding.dll" WorkingDirectory="../mac-binding-project/"/>
+	<Target Name="CreateNativeLibs" Inputs="$(MSBuildThisFileDirectory)/../common/mac/SimpleClass.m" Outputs="$(MSBuildThisFileDirectory)/../mac-binding-project/bin/SimpleClassDylib.dylib;$(MSBuildThisFileDirectory)/../mac-binding-project/bin/SimpleClassStatic.a;$(MSBuildThisFileDirectory)/../mac-binding-project/bin/Mobile-static/MobileBinding.dll">
+		<Exec Command="make bin/SimpleClassDylib.dylib bin/SimpleClassStatic.a bin/Mobile-static/MobileBinding.dll" WorkingDirectory="$(MSBuildThisFileDirectory)/../mac-binding-project/"/>
 	</Target>
 </Project>

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -612,7 +612,7 @@ namespace xharness
 					build.SpecifyConfiguration = build.ProjectConfiguration != "Debug";
 					RunTestTask exec;
 					if (project.IsNUnitProject) {
-						var dll = Path.Combine (Path.GetDirectoryName (project.Path), project.Xml.GetOutputAssemblyPath (build.ProjectPlatform, build.ProjectConfiguration).Replace ('\\', '/'));
+						var dll = Path.Combine (Path.GetDirectoryName (build.TestProject.Path), project.Xml.GetOutputAssemblyPath (build.ProjectPlatform, build.ProjectConfiguration).Replace ('\\', '/'));
 						exec = new NUnitExecuteTask (build) {
 							Ignored = ignored || !IncludeClassicMac,
 							TestLibrary = dll,

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -64,7 +64,12 @@ namespace Xamarin.Bundler {
 		public bool EnableSGenConc;
 		public MarshalObjectiveCExceptionMode MarshalObjectiveCExceptions;
 		public MarshalManagedExceptionMode MarshalManagedExceptions;
-		public bool IsDefaultMarshalManagedExceptionMode;
+
+		bool is_default_marshal_managed_exception_mode;
+		public bool IsDefaultMarshalManagedExceptionMode {
+			get { return is_default_marshal_managed_exception_mode || MarshalManagedExceptions == MarshalManagedExceptionMode.Default; }
+			set { is_default_marshal_managed_exception_mode = value; }
+		}
 		public List<string> RootAssemblies = new List<string> ();
 		public List<Application> SharedCodeApps = new List<Application> (); // List of appexes we're sharing code with.
 		public string RegistrarOutputLibrary;


### PR DESCRIPTION
Fixes this build problem with mmptest:

    /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/mmptest/CustomBuildActions.targets: error : Command 'make bin/SimpleClassDylib.dylib bin/SimpleClassStatic.a bin/Mobile-static/MobileBinding.dll' exited with code: 255.

Fixes https://github.com/xamarin/maccore/issues/633.