### PR TITLE
[registrar] Skip informal protocols when enumerating the protocols a type implements.

### DIFF
--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -251,7 +251,7 @@ namespace Foundation {
 			while (type != typeof (NSObject) && type != null) {
 				var attrs = type.GetCustomAttributes (typeof(ProtocolAttribute), false);
 				var protocolAttribute = (ProtocolAttribute) (attrs.Length > 0 ? attrs [0] : null);
-				if (protocolAttribute != null) {
+				if (protocolAttribute != null && !protocolAttribute.IsInformal) {
 					string name;
 
 					if (!string.IsNullOrEmpty (protocolAttribute.Name)) {

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -138,6 +138,7 @@ namespace Registrar {
 			public bool IsModel;
 			// if this type represents an ObjC protocol (!= has the protocol attribute, since that can be applied to all kinds of things).
 			public bool IsProtocol;
+			public bool IsInformalProtocol;
 			public bool IsWrapper;
 			public bool IsGeneric;
 #if !MTOUCH && !MMP
@@ -1632,7 +1633,7 @@ namespace Registrar {
 				if (interfaces [i] == null)
 					continue;
 				var baseP = RegisterTypeUnsafe (interfaces [i], ref exceptions);
-				if (baseP != null)
+				if (baseP != null && !baseP.IsInformalProtocol)
 					protocolList.Add (baseP);
 			}
 			if (protocolList.Count == 0)
@@ -1819,6 +1820,7 @@ namespace Registrar {
 				Type = type,
 				IsModel = HasModelAttribute (type),
 				IsProtocol = isProtocol,
+				IsInformalProtocol = isInformalProtocol,
 				IsGeneric = isGenericType,
 			};
 			objcType.VerifyRegisterAttribute (ref exceptions);

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -1628,13 +1628,21 @@ namespace Registrar {
 			if (interfaces == null || interfaces.Length == 0)
 				return null;
 
+			var ifaceList = new List<TType> (interfaces);
 			var protocolList = new List<ObjCType> (interfaces.Length);
-			for (int i = 0; i < interfaces.Length; i++) {
-				if (interfaces [i] == null)
+			for (int i = 0; i < ifaceList.Count; i++) {
+				if (ifaceList [i] == null)
 					continue;
-				var baseP = RegisterTypeUnsafe (interfaces [i], ref exceptions);
-				if (baseP != null && !baseP.IsInformalProtocol)
-					protocolList.Add (baseP);
+				var baseP = RegisterTypeUnsafe (ifaceList [i], ref exceptions);
+				if (baseP != null) {
+					if (baseP.IsInformalProtocol) {
+						var ifaces = GetInterfacesImpl (baseP);
+						if (ifaces != null)
+							ifaceList.AddRange (ifaces);
+					} else {
+						protocolList.Add (baseP);
+					}
+				}
 			}
 			if (protocolList.Count == 0)
 				return null;

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -5906,8 +5906,10 @@ public partial class Generator : IMemberGatherer {
 				if (!is_partial)
 					class_mod = "static ";
 			} else {
-				if (is_protocol)
-					print ("[Protocol({0})]", !string.IsNullOrEmpty (protocol.Name) ? $"Name = \"{protocol.Name}\"" : string.Empty);
+				if (is_protocol) {
+					var pName = !string.IsNullOrEmpty (protocol.Name) ? $"Name = \"{protocol.Name}\"" : string.Empty;
+					print ("[Protocol({0}{1}{2})]", pName, (!string.IsNullOrEmpty (pName) && protocol.IsInformal) ? ", " : string.Empty, protocol.IsInformal ? "IsInformal = true" : string.Empty);
+				}
 				core_image_filter = AttributeManager.HasAttribute<CoreImageFilterAttribute> (type);
 				if (!type.IsEnum && !core_image_filter) {
 					if (is_model || AttributeManager.HasAttribute<SyntheticAttribute> (type)) {


### PR DESCRIPTION
This prevents the registrars from generating this (`NSMenuValidation` is an informal protocol):

    @interface __monomac_internal_ActionDispatcher : NSObject<NSMenuValidation> {
    }
    @end

which is not correct.