### PR TITLE
[UIKit] Fix typo. Fixes bug #54544 'Binding typo DarkerSystemColosEnabled'

### DIFF
--- a/src/UIKit/UIAccessibility.cs
+++ b/src/UIKit/UIAccessibility.cs
@@ -238,11 +238,21 @@ namespace UIKit {
 		static extern bool UIAccessibilityDarkerSystemColorsEnabled ();
 
 		[iOS (8,0)]
+		public static bool DarkerSystemColorsEnabled {
+			get {
+				return UIAccessibilityDarkerSystemColorsEnabled ();
+			}
+		}
+
+#if !XAMCORE_4_0
+		[iOS (8,0)]
+		[Obsolete ("Use 'DarkerSystemColorsEnabled' instead.")]
 		public static bool DarkerSystemColosEnabled {
 			get {
 				return UIAccessibilityDarkerSystemColorsEnabled ();
 			}
 		}
+#endif
 
 		[iOS (8,0)]
 		[DllImport (Constants.UIKitLibrary)]


### PR DESCRIPTION
Fixes bug https://bugzilla.xamarin.com/show_bug.cgi?id=54544 by adding the correct method, deprecating the current one and removing it in XamCore 4.