### PR TITLE
[tests][linkall] Disable AssemblyReferences_16213. Fix #3480

### DIFF
--- a/tests/linker/ios/link all/LinkAllTest.cs
+++ b/tests/linker/ios/link all/LinkAllTest.cs
@@ -394,6 +394,7 @@ namespace LinkAll {
 		}
 
 		[Test]
+		[Ignore ("Assumption broken with mono 2017-12")]
 		public void AssemblyReferences_16213 ()
 		{
 			foreach (var assembly in typeof (System.Data.AcceptRejectRule).Assembly.GetReferencedAssemblies ()) {


### PR DESCRIPTION
Disable the canary test for System.Transactions.dll until more
investigation is done (which was the point of the test)

https://github.com/xamarin/xamarin-macios/issues/3480