### PR TITLE
Bump mono to head of 2017-12

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 [submodule "external/mono"]
     path = external/mono
     url = ../../mono/mono.git
-    branch = 2017-10
+    branch = 2017-12
 [submodule "external/MonoTouch.Dialog"]
     path = external/MonoTouch.Dialog
     url = ../../migueldeicaza/MonoTouch.Dialog.git


### PR DESCRIPTION
Commit list for mono/mono:

* mono/mono@f12e936ca30 [packaging] Remove FSharp patches that are no longer required
* mono/mono@39773399400 [packaging] Windows: remove FSharp.Core from GAC (#6345)
* mono/mono@cb15effa2fc Emit the weak field indexes table using the MONO_AOT_TABLE code, so it works with separate aot data files/bitcode.
* mono/mono@2ad3f0bf9ed Bug 60088 - Assertion at ../../../../external/mono/mono/mini/debugger-agent.c:4765, condition `array->len == 1' not met (#7004)
* mono/mono@899599b951a Bump nunitlite
* mono/mono@3da56339ece [2017-12] Update F# to 4.1.33 (#7020)
* mono/mono@a0af42ab186 [corlib] Pass null-terminated string for logging (#6954)
* mono/mono@aab818fbf3c Revert mkbundle defaulting behavior made in ca8b8bd346

Diff: https://github.com/mono/mono/compare/4b1745401d5b5fb1525a84d7fd47dec2b7e2844c...f12e936ca302312769fc4ab950470ad918f1add5