### PR TITLE
[security] Strongly typed key generation

### DIFF
--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -795,6 +795,21 @@ namespace Security {
 			}
 		}
 
+		[Watch (3, 0)][TV (10, 0)][Mac (10, 12)][iOS (10, 0)]
+		static public SecKey CreateRandomKey (SecKeyGenerationParameters parameters, out NSError error)
+		{
+			if (parameters == null)
+				throw new ArgumentNullException (nameof (parameters));
+			if (parameters.KeyType == null)
+				throw new ArgumentNullException (nameof (parameters.KeyType));
+			if (parameters.KeyType == SecKeyType.Invalid)
+				throw new ArgumentException (nameof (parameters.KeyType));
+
+			using (var dictionary = parameters.GetDictionary ()) {
+				return CreateRandomKey (dictionary, out error);
+			}
+		}
+
 		[Watch (3,0)][TV (10,0)][Mac (10,12)][iOS (10,0)]
 		[DllImport (Constants.SecurityLibrary)]
 		static extern IntPtr /* SecKeyRef _Nullable */ SecKeyCreateWithData (IntPtr /* CFDataRef* */ keyData, IntPtr /* CFDictionaryRef* */ attributes, out IntPtr /* CFErrorRef** */ error);

--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -562,7 +562,7 @@ namespace Security {
 			else
 				dic = new NSMutableDictionary ();
 			dic.LowlevelSetObject (type.GetConstant (), SecAttributeKey.Type);
-			dic.LowlevelSetObject (new NSNumber (keySizeInBits), SecAttributeKey.KeySizeInBits);
+			dic.LowlevelSetObject (new NSNumber (keySizeInBits), SecKeyGenerationAttributeKeys.KeySizeInBitsKey.Handle);
 			return GenerateKeyPair (dic, out publicKey, out privateKey);
 		}
 #if !MONOMAC
@@ -574,11 +574,11 @@ namespace Security {
 			using (var dic = new NSMutableDictionary ()) {
 				dic.LowlevelSetObject (type.GetConstant (), SecAttributeKey.Type);
 				using (var ksib = new NSNumber (keySizeInBits)) {
-					dic.LowlevelSetObject (ksib, SecAttributeKey.KeySizeInBits);
+					dic.LowlevelSetObject (ksib, SecKeyGenerationAttributeKeys.KeySizeInBitsKey.Handle);
 					if (publicKeyAttrs != null)
-						dic.LowlevelSetObject (publicKeyAttrs.GetDictionary (), SecAttributeKey.PublicKeyAttrs);
+						dic.LowlevelSetObject (publicKeyAttrs.GetDictionary (), SecKeyGenerationAttributeKeys.PublicKeyAttrsKey.Handle);
 					if (privateKeyAttrs != null)
-						dic.LowlevelSetObject (privateKeyAttrs.GetDictionary (), SecAttributeKey.PrivateKeyAttrs);
+						dic.LowlevelSetObject (privateKeyAttrs.GetDictionary (), SecKeyGenerationAttributeKeys.PrivateKeyAttrsKey.Handle);
 					return GenerateKeyPair (dic, out publicKey, out privateKey);
 				}
 			}
@@ -789,8 +789,8 @@ namespace Security {
 		{
 			using (var ks = new NSNumber (keySizeInBits))
 			using (var md = parameters == null ? new NSMutableDictionary () : new NSMutableDictionary (parameters)) {
-				md.LowlevelSetObject (keyType.GetConstant (), SecAttributeKey.KeyType);
-				md.LowlevelSetObject (ks, SecAttributeKey.KeySizeInBits);
+				md.LowlevelSetObject (keyType.GetConstant (), SecKeyGenerationAttributeKeys.KeyTypeKey.Handle);
+				md.LowlevelSetObject (ks, SecKeyGenerationAttributeKeys.KeySizeInBitsKey.Handle);
 				return CreateRandomKey (md, out error);
 			}
 		}
@@ -818,9 +818,9 @@ namespace Security {
 		{
 			using (var ks = new NSNumber (keySizeInBits))
 			using (var md = parameters == null ? new NSMutableDictionary () : new NSMutableDictionary (parameters)) {
-				md.LowlevelSetObject (keyType.GetConstant (), SecAttributeKey.KeyType);
+				md.LowlevelSetObject (keyType.GetConstant (), SecKeyGenerationAttributeKeys.KeyTypeKey.Handle);
 				md.LowlevelSetObject (keyClass.GetConstant (), SecAttributeKey.KeyClass);
-				md.LowlevelSetObject (ks, SecAttributeKey.KeySizeInBits);
+				md.LowlevelSetObject (ks, SecKeyGenerationAttributeKeys.KeySizeInBitsKey.Handle);
 				return Create (keyData, md, out error);
 			}
 		}

--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -801,7 +801,7 @@ namespace Security {
 			if (parameters == null)
 				throw new ArgumentNullException (nameof (parameters));
 			if (parameters.KeyType == SecKeyType.Invalid)
-				throw new ArgumentException ("invalid 'SecKeyType'", nameof (parameters.KeyType));
+				throw new ArgumentException ("invalid 'SecKeyType'", "SecKeyGeneration.KeyType");
 
 			using (var dictionary = parameters.GetDictionary ()) {
 				return CreateRandomKey (dictionary, out error);

--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -801,7 +801,7 @@ namespace Security {
 			if (parameters == null)
 				throw new ArgumentNullException (nameof (parameters));
 			if (parameters.KeyType == SecKeyType.Invalid)
-				throw new ArgumentException (nameof (parameters.KeyType));
+				throw new ArgumentException ("invalid 'SecKeyType'", nameof (parameters.KeyType));
 
 			using (var dictionary = parameters.GetDictionary ()) {
 				return CreateRandomKey (dictionary, out error);

--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -800,8 +800,6 @@ namespace Security {
 		{
 			if (parameters == null)
 				throw new ArgumentNullException (nameof (parameters));
-			if (parameters.KeyType == null)
-				throw new ArgumentNullException (nameof (parameters.KeyType));
 			if (parameters.KeyType == SecKeyType.Invalid)
 				throw new ArgumentException (nameof (parameters.KeyType));
 

--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -1769,29 +1769,29 @@ namespace Security {
 		}
 
 		// For caching, as we can't reverse it easily.
-                SecAccessControl _secAccessControl;
+		SecAccessControl _secAccessControl;
 
-                public SecAccessControl AccessControl {
-                        get {
-                                return _secAccessControl;
-                        }
+		public SecAccessControl AccessControl {
+			get {
+				return _secAccessControl;
+			}
 
-                        set {
-                                if (value == null)
-                                        throw new ArgumentNullException (nameof (value));
-                                _secAccessControl = value;
-                                SetNativeValue (SecAttributeKeys.AccessControlKey, value);
-                        }
-                }
+			set {
+				if (value == null)
+					throw new ArgumentNullException (nameof (value));
+				_secAccessControl = value;
+				SetNativeValue (SecAttributeKeys.AccessControlKey, value);
+			}
+		}
 
 		public SecTokenID TokenID {
-                        get {
-                                return SecTokenIDExtensions.GetValue (GetNSStringValue (SecKeyGenerationAttributeKeys.TokenIDKey));
-                        }
+			get {
+				return SecTokenIDExtensions.GetValue (GetNSStringValue (SecKeyGenerationAttributeKeys.TokenIDKey));
+			}
 
-                        set {
-                                SetStringValue (SecKeyGenerationAttributeKeys.TokenIDKey, value.GetConstant ());
-                        }
-                }
+			set {
+				SetStringValue (SecKeyGenerationAttributeKeys.TokenIDKey, value.GetConstant ());
+			}
+		}
 	}
 }

--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -1744,7 +1744,7 @@ namespace Security {
 			}
 			set {
 				if (value == null)
-					throw new ArgumentNullException("value");
+					throw new ArgumentNullException (nameof (value));
 				_secAccessControl = value;
 				SetNativeValue (SecAttributeKeys.AccessControlKey, value);
 			}

--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -813,11 +813,11 @@ namespace Security {
 		[iOS (9,0)]
 		public SecTokenID TokenID {
 			get {
-				return SecTokenIDExtensions.GetValue (Fetch<NSString> (SecAttributeKey.TokenID));
+				return SecTokenIDExtensions.GetValue (Fetch<NSString> (SecKeyGenerationAttributeKeys.TokenIDKey.Handle));
 			}
 			set {
 				// choose wisely to avoid NSString -> string -> NSString conversion
-				SetValue ((NSObject) value.GetConstant (), SecAttributeKey.TokenID);
+				SetValue ((NSObject) value.GetConstant (), SecKeyGenerationAttributeKeys.TokenIDKey.Handle);
 			}
 		}
 #endif
@@ -993,7 +993,7 @@ namespace Security {
 				if (value == null)
 					throw new ArgumentNullException ("value");
 				_secAccessControl = value;
-				SetValue (value.Handle, SecAttributeKey.AccessControl);
+				SetValue (value.Handle, SecAttributeKeys.AccessControlKey.Handle);
 			}
 		}
 
@@ -1192,7 +1192,7 @@ namespace Security {
 
 		public SecKeyType KeyType {
 			get {
-				var k = Fetch (SecAttributeKey.KeyType);
+				var k = Fetch (SecKeyGenerationAttributeKeys.KeyTypeKey.Handle);
 				if (k == IntPtr.Zero)
 					return SecKeyType.Invalid;
 				using (var s = new NSString (k))
@@ -1203,17 +1203,17 @@ namespace Security {
 				var k = value.GetConstant ();
 				if (k == null)
 					throw new ArgumentException ("Unknown value");
-				SetValue ((NSObject) k, SecAttributeKey.KeyType);
+				SetValue ((NSObject) k, SecKeyGenerationAttributeKeys.KeyTypeKey.Handle);
 			}
 		}
 
 		public int KeySizeInBits {
 			get {
-				return FetchInt (SecAttributeKey.KeySizeInBits);
+				return FetchInt (SecKeyGenerationAttributeKeys.KeySizeInBitsKey.Handle);
 			}
 					
 			set {
-				SetValue (new NSNumber (value), SecAttributeKey.KeySizeInBits);
+				SetValue (new NSNumber (value), SecKeyGenerationAttributeKeys.KeySizeInBitsKey.Handle);
 			}
 		}
 
@@ -1279,11 +1279,11 @@ namespace Security {
 
 		public bool CanWrap {
 			get {
-				return Fetch (SecAttributeKey.CanWrap) == CFBoolean.True.Handle;
+				return Fetch (SecKeyGenerationAttributeKeys.CanWrapKey.Handle) == CFBoolean.True.Handle;
 			}
 			
 			set {
-				SetValue (CFBoolean.FromBoolean (value).Handle, SecAttributeKey.CanWrap);
+				SetValue (CFBoolean.FromBoolean (value).Handle, SecKeyGenerationAttributeKeys.CanWrapKey.Handle);
 			}
 		}
 

--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -1733,4 +1733,21 @@ namespace Security {
 		{
 		}
 	}
+
+	public partial class SecPublicPrivateKeyAttrs : DictionaryContainer {
+		// For caching, as we can't reverse it easily.
+		SecAccessControl _secAccessControl;
+
+		public SecAccessControl AccessControl {
+			get {
+				return _secAccessControl;
+			}
+			set {
+				if (value == null)
+					throw new ArgumentNullException("value");
+				_secAccessControl = value;
+				SetNativeValue (SecAttributeKeys.AccessControlKey, value);
+			}
+		}
+	}
 }

--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -1750,4 +1750,15 @@ namespace Security {
 			}
 		}
 	}
+
+	public partial class SecKeyGenerationParameters : DictionaryContainer {
+		public SecTokenID TokenID {
+                        get {
+                                return SecTokenIDExtensions.GetValue (GetNSStringValue (SecKeyGenerationAttributeKeys.TokenIDKey));
+                        }
+                        set {
+                                SetStringValue (SecKeyGenerationAttributeKeys.TokenIDKey, value.GetConstant ());
+                        }
+                }
+	}
 }

--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -813,11 +813,11 @@ namespace Security {
 		[iOS (9,0)]
 		public SecTokenID TokenID {
 			get {
-				return SecTokenIDExtensions.GetValue (Fetch<NSString> (SecKeyGenerationAttributeKeys.TokenIDKey.Handle));
+				return SecTokenIDExtensions.GetValue (Fetch<NSString> (SecKeyGenerationAttributeKeys.TokenIDKey.GetHandle ()));
 			}
 			set {
 				// choose wisely to avoid NSString -> string -> NSString conversion
-				SetValue ((NSObject) value.GetConstant (), SecKeyGenerationAttributeKeys.TokenIDKey.Handle);
+				SetValue ((NSObject) value.GetConstant (), SecKeyGenerationAttributeKeys.TokenIDKey.GetHandle ());
 			}
 		}
 #endif
@@ -1738,6 +1738,7 @@ namespace Security {
 		// For caching, as we can't reverse it easily.
 		SecAccessControl _secAccessControl;
 
+		[iOS (8, 0), Mac (10, 10)]
 		public SecAccessControl AccessControl {
 			get {
 				return _secAccessControl;
@@ -1771,6 +1772,7 @@ namespace Security {
 		// For caching, as we can't reverse it easily.
 		SecAccessControl _secAccessControl;
 
+		[iOS (8, 0), Mac (10, 10)]
 		public SecAccessControl AccessControl {
 			get {
 				return _secAccessControl;
@@ -1784,6 +1786,7 @@ namespace Security {
 			}
 		}
 
+		[iOS (9, 0), Mac (10, 12)]
 		public SecTokenID TokenID {
 			get {
 				return SecTokenIDExtensions.GetValue (GetNSStringValue (SecKeyGenerationAttributeKeys.TokenIDKey));

--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -1734,7 +1734,7 @@ namespace Security {
 		}
 	}
 
-	public partial class SecPublicPrivateKeyAttrs : DictionaryContainer {
+	public partial class SecKeyParameters : DictionaryContainer {
 		// For caching, as we can't reverse it easily.
 		SecAccessControl _secAccessControl;
 
@@ -1752,6 +1752,22 @@ namespace Security {
 	}
 
 	public partial class SecKeyGenerationParameters : DictionaryContainer {
+		public SecKeyType KeyType {
+			get {
+				var type = GetNSStringValue (SecKeyGenerationAttributeKeys.KeyTypeKey);
+				if (type == null)
+					return SecKeyType.Invalid;
+				return SecKeyTypeExtensions.GetValue (type);
+			}
+
+			set {
+				var k = value.GetConstant ();
+				if (k == null)
+					throw new ArgumentException ("Unknown value for KeyType.");
+				SetStringValue (SecKeyGenerationAttributeKeys.KeyTypeKey, k);
+			}
+		}
+
 		// For caching, as we can't reverse it easily.
                 SecAccessControl _secAccessControl;
 
@@ -1759,6 +1775,7 @@ namespace Security {
                         get {
                                 return _secAccessControl;
                         }
+
                         set {
                                 if (value == null)
                                         throw new ArgumentNullException (nameof (value));
@@ -1771,6 +1788,7 @@ namespace Security {
                         get {
                                 return SecTokenIDExtensions.GetValue (GetNSStringValue (SecKeyGenerationAttributeKeys.TokenIDKey));
                         }
+
                         set {
                                 SetStringValue (SecKeyGenerationAttributeKeys.TokenIDKey, value.GetConstant ());
                         }

--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -1752,6 +1752,21 @@ namespace Security {
 	}
 
 	public partial class SecKeyGenerationParameters : DictionaryContainer {
+		// For caching, as we can't reverse it easily.
+                SecAccessControl _secAccessControl;
+
+                public SecAccessControl AccessControl {
+                        get {
+                                return _secAccessControl;
+                        }
+                        set {
+                                if (value == null)
+                                        throw new ArgumentNullException (nameof (value));
+                                _secAccessControl = value;
+                                SetNativeValue (SecAttributeKeys.AccessControlKey, value);
+                        }
+                }
+
 		public SecTokenID TokenID {
                         get {
                                 return SecTokenIDExtensions.GetValue (GetNSStringValue (SecKeyGenerationAttributeKeys.TokenIDKey));

--- a/src/security.cs
+++ b/src/security.cs
@@ -347,6 +347,8 @@ namespace Security {
 
 		int EffectiveKeySize { get; set; }
 
+		NSObject AccessControl { get; set; }
+
 #if MONOMAC
 		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
 #endif
@@ -389,6 +391,10 @@ namespace Security {
 		[Field ("kSecAttrEffectiveKeySize")]
 		NSString EffectiveKeySizeKey { get; }
 
+		[iOS (8,0), Mac(10,10)]
+		[Field ("kSecAttrAccessControl")]
+		NSString AccessControlKey { get; }
+
 		[Field ("kSecAttrCanEncrypt")]
 		NSString CanEncryptKey { get; }
 
@@ -409,14 +415,53 @@ namespace Security {
 	}
 
 	[Static][Internal]
+	interface SecKeyGenerationAttributeKeys : SecAttributeKeys {
+		[Field ("kSecAttrKeyType")]
+		NSString KeyTypeKey { get; }
+
+		[Field ("kSecAttrKeySizeInBits")]
+		NSString KeySizeInBitsKey { get; }
+
+		[Mac (10,8)]
+		[Field ("kSecPrivateKeyAttrs")]
+		NSString PrivateKeyAttrsKey { get; }
+
+		[Mac (10,8)]
+		[Field ("kSecPublicKeyAttrs")]
+		NSString PublicKeyAttrsKey { get; }
+
+		[iOS (9,0)]
+		[Mac (10,12)]
+		[Field ("kSecAttrTokenID")]
+		NSString TokenIDKey { get; }
+
+		[Field ("kSecAttrCanWrap")]
+		NSString CanWrapKey { get; }
+	}
+
+	[StrongDictionary ("SecKeyGenerationAttributeKeys")]
+	interface SecKeyGenerationParameters : SecPublicPrivateKeyAttrs {
+		SecKeyType KeyType { get; set; }
+
+		int KeySizeInBits { get; set; }
+
+		NSDictionary PrivateKeyAttrs { get; set; }
+
+		NSDictionary PublicKeyAttrs { get; set; }
+
+		NSNumber TokenID { get; set; }
+
+#if MONOMAC
+		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
+#endif
+		bool CanWrap { get; set; }
+	}
+
+	[Static][Internal]
 	interface SecAttributeKey {
 		[Mac (10,9)]
 		[Field ("kSecAttrAccessible")]
 		IntPtr Accessible { get; }
-
-		[iOS (8,0), Mac(10,10)]
-		[Field ("kSecAttrAccessControl")]
-		IntPtr AccessControl { get; }
 
 		[iOS (7,0)]
 		[Mac (10,9)]
@@ -521,20 +566,6 @@ namespace Security {
 		[Field ("kSecAttrIsExtractable")]
 		IntPtr IsExtractable { get; }
 
-		[Field ("kSecAttrKeyType")]
-		IntPtr KeyType { get; }
-
-		[Field ("kSecAttrKeySizeInBits")]
-		IntPtr KeySizeInBits { get; }
-
-		[Field ("kSecAttrCanWrap")]
-		IntPtr CanWrap { get; }
-
-		[iOS (9,0)]
-		[Mac (10,12)]
-		[Field ("kSecAttrTokenID")]
-		IntPtr TokenID { get; }
-
 		[iOS (9,0)]
 		[Mac (10,12)]
 		[Field ("kSecAttrTokenIDSecureEnclave")]
@@ -551,14 +582,6 @@ namespace Security {
 		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
 		[Field ("kSecAttrPersistentReference")]
 		IntPtr PersistentReference { get; }
-
-		[Mac (10,8)]
-		[Field ("kSecPrivateKeyAttrs")]
-		IntPtr PrivateKeyAttrs { get; }
-
-		[Mac (10,8)]
-		[Field ("kSecPublicKeyAttrs")]
-		IntPtr PublicKeyAttrs { get; }
 	}
 
 	[Static][Internal]

--- a/src/security.cs
+++ b/src/security.cs
@@ -451,8 +451,6 @@ namespace Security {
 		[Export ("PublicKeyAttrsKey")]
 		SecPublicPrivateKeyAttrs PublicKeyAttrs { get; set; }
 
-		NSNumber TokenID { get; set; }
-
 #if MONOMAC
 		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
 #endif

--- a/src/security.cs
+++ b/src/security.cs
@@ -389,7 +389,7 @@ namespace Security {
 		[Field ("kSecAttrEffectiveKeySize")]
 		NSString EffectiveKeySizeKey { get; }
 
-		[iOS (8,0), Mac(10,10)]
+		[iOS (8, 0), Mac (10, 10)]
 		[Field ("kSecAttrAccessControl")]
 		NSString AccessControlKey { get; }
 

--- a/src/security.cs
+++ b/src/security.cs
@@ -437,21 +437,9 @@ namespace Security {
 		NSString CanWrapKey { get; }
 	}
 
-	[StrongDictionary ("SecKeyGenerationAttributeKeys")]
-	interface SecKeyGenerationParameters {
-		SecKeyType KeyType { get; set; }
-
-		int KeySizeInBits { get; set; }
-
-		[StrongDictionary]
-		[Export ("PrivateKeyAttrsKey")]
-		SecPublicPrivateKeyAttrs PrivateKeyAttrs { get; set; }
-
-		[StrongDictionary]
-		[Export ("PublicKeyAttrsKey")]
-		SecPublicPrivateKeyAttrs PublicKeyAttrs { get; set; }
-
-		String Label { get; set; }
+	[StrongDictionary ("SecAttributeKeys")]
+	interface SecKeyParameters {
+		string Label { get; set; }
 
 		bool IsPermanent { get; set; }
 
@@ -460,26 +448,74 @@ namespace Security {
 		int EffectiveKeySize { get; set; }
 
 #if MONOMAC
-                [Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
+		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
 #endif
-                bool CanEncrypt { get; set; }
+		bool CanEncrypt { get; set; }
 
 #if MONOMAC
-                [Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
+		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
 #endif
-                bool CanDecrypt { get; set; }
+		bool CanDecrypt { get; set; }
 
-                bool CanDerive { get; set; }
-
-#if MONOMAC
-                [Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
-#endif
-                bool CanSign { get; set; }
+		bool CanDerive { get; set; }
 
 #if MONOMAC
-                [Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
+		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
 #endif
-                bool CanVerify { get; set; }
+		bool CanSign { get; set; }
+
+#if MONOMAC
+		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
+#endif
+		bool CanVerify { get; set; }
+
+#if MONOMAC
+		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
+#endif
+		bool CanUnwrap { get; set; }
+	}
+
+	[StrongDictionary ("SecKeyGenerationAttributeKeys")]
+	interface SecKeyGenerationParameters {
+		int KeySizeInBits { get; set; }
+
+		[StrongDictionary]
+		[Export ("PrivateKeyAttrsKey")]
+		SecKeyParameters PrivateKeyAttrs { get; set; }
+
+		[StrongDictionary]
+		[Export ("PublicKeyAttrsKey")]
+		SecKeyParameters PublicKeyAttrs { get; set; }
+
+		string Label { get; set; }
+
+		bool IsPermanent { get; set; }
+
+		NSData ApplicationTag { get; set; }
+
+		int EffectiveKeySize { get; set; }
+
+#if MONOMAC
+		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
+#endif
+		bool CanEncrypt { get; set; }
+
+#if MONOMAC
+		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
+#endif
+		bool CanDecrypt { get; set; }
+
+		bool CanDerive { get; set; }
+
+#if MONOMAC
+		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
+#endif
+		bool CanSign { get; set; }
+
+#if MONOMAC
+		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
+#endif
+		bool CanVerify { get; set; }
 
 #if MONOMAC
 		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
@@ -487,9 +523,9 @@ namespace Security {
 		bool CanWrap { get; set; }
 
 #if MONOMAC
-                [Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
+		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
 #endif
-                bool CanUnwrap { get; set; }
+		bool CanUnwrap { get; set; }
 	}
 
 	[Static][Internal]

--- a/src/security.cs
+++ b/src/security.cs
@@ -347,8 +347,6 @@ namespace Security {
 
 		int EffectiveKeySize { get; set; }
 
-		NSObject AccessControl { get; set; }
-
 #if MONOMAC
 		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
 #endif

--- a/src/security.cs
+++ b/src/security.cs
@@ -445,9 +445,13 @@ namespace Security {
 
 		int KeySizeInBits { get; set; }
 
-		NSDictionary PrivateKeyAttrs { get; set; }
+		[StrongDictionary]
+		[Export ("PrivateKeyAttrsKey")]
+		SecPublicPrivateKeyAttrs PrivateKeyAttrs { get; set; }
 
-		NSDictionary PublicKeyAttrs { get; set; }
+		[StrongDictionary]
+		[Export ("PublicKeyAttrsKey")]
+		SecPublicPrivateKeyAttrs PublicKeyAttrs { get; set; }
 
 		NSNumber TokenID { get; set; }
 

--- a/src/security.cs
+++ b/src/security.cs
@@ -420,16 +420,15 @@ namespace Security {
 		[Field ("kSecAttrKeySizeInBits")]
 		NSString KeySizeInBitsKey { get; }
 
-		[Mac (10,8)]
+		[Mac (10, 8)]
 		[Field ("kSecPrivateKeyAttrs")]
 		NSString PrivateKeyAttrsKey { get; }
 
-		[Mac (10,8)]
+		[Mac (10, 8)]
 		[Field ("kSecPublicKeyAttrs")]
 		NSString PublicKeyAttrsKey { get; }
 
-		[iOS (9,0)]
-		[Mac (10,12)]
+		[iOS (9, 0), Mac (10, 12)]
 		[Field ("kSecAttrTokenID")]
 		NSString TokenIDKey { get; }
 

--- a/src/security.cs
+++ b/src/security.cs
@@ -438,7 +438,7 @@ namespace Security {
 	}
 
 	[StrongDictionary ("SecKeyGenerationAttributeKeys")]
-	interface SecKeyGenerationParameters : SecPublicPrivateKeyAttrs {
+	interface SecKeyGenerationParameters {
 		SecKeyType KeyType { get; set; }
 
 		int KeySizeInBits { get; set; }
@@ -451,10 +451,45 @@ namespace Security {
 		[Export ("PublicKeyAttrsKey")]
 		SecPublicPrivateKeyAttrs PublicKeyAttrs { get; set; }
 
+		String Label { get; set; }
+
+		bool IsPermanent { get; set; }
+
+		NSData ApplicationTag { get; set; }
+
+		int EffectiveKeySize { get; set; }
+
+#if MONOMAC
+                [Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
+#endif
+                bool CanEncrypt { get; set; }
+
+#if MONOMAC
+                [Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
+#endif
+                bool CanDecrypt { get; set; }
+
+                bool CanDerive { get; set; }
+
+#if MONOMAC
+                [Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
+#endif
+                bool CanSign { get; set; }
+
+#if MONOMAC
+                [Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
+#endif
+                bool CanVerify { get; set; }
+
 #if MONOMAC
 		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
 #endif
 		bool CanWrap { get; set; }
+
+#if MONOMAC
+                [Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
+#endif
+                bool CanUnwrap { get; set; }
 	}
 
 	[Static][Internal]

--- a/src/security.cs
+++ b/src/security.cs
@@ -447,31 +447,16 @@ namespace Security {
 
 		int EffectiveKeySize { get; set; }
 
-#if MONOMAC
-		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
-#endif
 		bool CanEncrypt { get; set; }
 
-#if MONOMAC
-		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
-#endif
 		bool CanDecrypt { get; set; }
 
 		bool CanDerive { get; set; }
 
-#if MONOMAC
-		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
-#endif
 		bool CanSign { get; set; }
 
-#if MONOMAC
-		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
-#endif
 		bool CanVerify { get; set; }
 
-#if MONOMAC
-		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
-#endif
 		bool CanUnwrap { get; set; }
 	}
 
@@ -495,36 +480,18 @@ namespace Security {
 
 		int EffectiveKeySize { get; set; }
 
-#if MONOMAC
-		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
-#endif
 		bool CanEncrypt { get; set; }
 
-#if MONOMAC
-		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
-#endif
 		bool CanDecrypt { get; set; }
 
 		bool CanDerive { get; set; }
 
-#if MONOMAC
-		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
-#endif
 		bool CanSign { get; set; }
 
-#if MONOMAC
-		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
-#endif
 		bool CanVerify { get; set; }
 
-#if MONOMAC
-		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
-#endif
 		bool CanWrap { get; set; }
 
-#if MONOMAC
-		[Advice ("On macOS when passed to 'GenerateKeyPair', 'false' seems to be the only valid value. Otherwise 'UnsupportedKeyUsageMask' is returned.")]
-#endif
 		bool CanUnwrap { get; set; }
 	}
 

--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -633,15 +633,7 @@ namespace MonoTouchFixtures.Security {
 		[Test]
 		public void CreateRandomKeyWithParametersTests ()
 		{
-#if IOS || TVOS
-			if (!TestRuntime.CheckXcodeVersion (10, 0)) return;
-#endif
-#if MONOMAC
-			if (!TestRuntime.CheckXcodeVersion (10, 12)) return;
-#endif
-#if __WATCHOS__
-			if (!TestRuntime.CheckXcodeVersion (3, 0)) return;
-#endif
+			TestRuntime.AssertXcodeVersion (8, 0);
 
 			var keyGenerationParameters = new SecKeyGenerationParameters ();
 		        keyGenerationParameters.KeyType = SecKeyType.EC;

--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -651,13 +651,13 @@ namespace MonoTouchFixtures.Security {
 			var publicKey = privateKey.GetPublicKey ();
 			Assert.That (publicKey, Is.Not.EqualTo (null));
 
-			Assert.Throws<ArgumentException> (() => { SecKey.CreateRandomKey (null, out _); }, "CreateRandomKey - null argument");
+			Assert.Throws<ArgumentException> (() => { SecKey.CreateRandomKey ((SecKeyGenerationParameters) null, out _); }, "CreateRandomKey - null argument");
 
-			var keyGenerationParameters = new SecKeyGenerationParameters ();
+			keyGenerationParameters = new SecKeyGenerationParameters ();
 			keyGenerationParameters.KeyType = SecKeyType.Invalid;
 			Assert.Throws<ArgumentException> (() => { SecKey.CreateRandomKey (keyGenerationParameters, out _); }, "CreateRandomKey - invalid key type");
 
-			var keyGenerationParameters = new SecKeyGenerationParameters ();
+			keyGenerationParameters = new SecKeyGenerationParameters ();
 			keyGenerationParameters.KeyType = SecKeyType.RSA;
 			keyGenerationParameters.KeySizeInBits = -1;
 			Assert.That (SecKey.CreateRandomKey (keyGenerationParameters, out _), Is.EqualTo (SecStatusCode.Param), "CreateRandomKey - Param issue, invalid RSA key size");

--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -636,10 +636,10 @@ namespace MonoTouchFixtures.Security {
 			TestRuntime.AssertXcodeVersion (8, 0);
 
 			var keyGenerationParameters = new SecKeyGenerationParameters ();
-		        keyGenerationParameters.KeyType = SecKeyType.EC;
-		        keyGenerationParameters.KeySizeInBits = 256;
-	                keyGenerationParameters.IsPermanent = false;
-	                var privateKeyAttributes = new SecPublicPrivateKeyAttrs ();
+			keyGenerationParameters.KeyType = SecKeyType.EC;
+			keyGenerationParameters.KeySizeInBits = 256;
+			keyGenerationParameters.IsPermanent = false;
+			var privateKeyAttributes = new SecPublicPrivateKeyAttrs ();
 			privateKeyAttributes.AccessControl = new SecAccessControl (SecAccessible.WhenUnlockedThisDeviceOnly, SecAccessControlCreateFlags.PrivateKeyUsage | SecAccessControlCreateFlags.UserPresence);
 			privateKeyAttributes.Label = "NotDefault";
 			keyGenerationParameters.PrivateKeyAttrs = privateKeyAttributes;

--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -629,40 +629,5 @@ namespace MonoTouchFixtures.Security {
 				Assert.That (attrs.Count, Is.GreaterThan (0), "private/GetAttributes");
 			}
 		}
-
-		[Test]
-		public void CreateRandomKeyWithParametersTests ()
-		{
-			TestRuntime.AssertXcodeVersion (8, 0);
-
-			var keyGenerationParameters = new SecKeyGenerationParameters ();
-			keyGenerationParameters.KeyType = SecKeyType.EC;
-			keyGenerationParameters.KeySizeInBits = 256;
-			keyGenerationParameters.IsPermanent = false;
-			var privateKeyAttributes = new SecPublicPrivateKeyAttrs ();
-			privateKeyAttributes.AccessControl = new SecAccessControl (SecAccessible.WhenUnlockedThisDeviceOnly, SecAccessControlCreateFlags.PrivateKeyUsage | SecAccessControlCreateFlags.UserPresence);
-			privateKeyAttributes.Label = "NotDefault";
-			keyGenerationParameters.PrivateKeyAttrs = privateKeyAttributes;
-
-			NSError error;
-			var privateKey = SecKey.CreateRandomKey (keyGenerationParameters, out error);
-			Assert.That (error, Is.EqualTo (null), "CreateRandomKey");
-			Assert.That (privateKey, Is.Not.EqualTo (null), "CreateRandomKey - key is null");
-			var publicKey = privateKey.GetPublicKey ();
-			Assert.That (publicKey, Is.Not.EqualTo (null));
-
-			Assert.Throws<ArgumentException> (() => { SecKey.CreateRandomKey ((SecKeyGenerationParameters) null, out _); }, "CreateRandomKey - null argument");
-
-			keyGenerationParameters = new SecKeyGenerationParameters ();
-			keyGenerationParameters.KeyType = SecKeyType.Invalid;
-			Assert.Throws<ArgumentException> (() => { SecKey.CreateRandomKey (keyGenerationParameters, out _); }, "CreateRandomKey - invalid key type");
-
-			keyGenerationParameters = new SecKeyGenerationParameters ();
-			keyGenerationParameters.KeyType = SecKeyType.RSA;
-			keyGenerationParameters.KeySizeInBits = -1;
-			Assert.That (SecKey.CreateRandomKey (keyGenerationParameters, out _), Is.EqualTo (SecStatusCode.Param), "CreateRandomKey - Param issue, invalid RSA key size");
-
-			Assert.Throws<ArgumentException> (() => { SecKey.CreateRandomKey (new SecKeyGenerationParameters (), out _); }, "CreateRandomKey - empty parameters");
-		}
 	}
 }

--- a/tests/monotouch-test/Security/KeyTest.cs
+++ b/tests/monotouch-test/Security/KeyTest.cs
@@ -490,7 +490,7 @@ namespace MonoTouchFixtures.Security {
 		}
 
 		[Test]
-		public void CreateRandomKeyWithParametersTests ()
+		public void CreateRandomKeyTest ()
 		{
 			TestRuntime.AssertXcodeVersion (8, 0);
 
@@ -505,23 +505,13 @@ namespace MonoTouchFixtures.Security {
 
 			NSError error;
 			var privateKey = SecKey.CreateRandomKey (keyGenerationParameters, out error);
-			Assert.That (error, Is.EqualTo (null), "CreateRandomKey");
-			Assert.That (privateKey, Is.Not.EqualTo (null), "CreateRandomKey - key is null");
 			var publicKey = privateKey.GetPublicKey ();
-			Assert.That (publicKey, Is.Not.EqualTo (null));
 
-			Assert.Throws<ArgumentException> (() => { SecKey.CreateRandomKey ((SecKeyGenerationParameters) null, out _); }, "CreateRandomKey - null argument");
-
-			keyGenerationParameters = new SecKeyGenerationParameters ();
-			keyGenerationParameters.KeyType = SecKeyType.Invalid;
-			Assert.Throws<ArgumentException> (() => { SecKey.CreateRandomKey (keyGenerationParameters, out _); }, "CreateRandomKey - invalid key type");
-
-			keyGenerationParameters = new SecKeyGenerationParameters ();
-			keyGenerationParameters.KeyType = SecKeyType.RSA;
-			keyGenerationParameters.KeySizeInBits = -1;
-			Assert.That (SecKey.CreateRandomKey (keyGenerationParameters, out _), Is.EqualTo (SecStatusCode.Param), "CreateRandomKey - Param issue, invalid RSA key size");
-
-			Assert.Throws<ArgumentException> (() => { SecKey.CreateRandomKey (new SecKeyGenerationParameters (), out _); }, "CreateRandomKey - empty parameters");
+			Assert.That (error, Is.EqualTo (null), "CreateRandomKey - no error");
+			Assert.That (privateKey, Is.Not.EqualTo (null), "CreateRandomKey - private key is not null");
+			Assert.That (publicKey, Is.Not.EqualTo (null), "CreateRandomKey - public key is not null");
+			Assert.Throws<ArgumentNullException> (() => { SecKey.CreateRandomKey ((SecKeyGenerationParameters) null, out _); }, "CreateRandomKey - null argument");
+			Assert.Throws<ArgumentException> (() => { SecKey.CreateRandomKey (new SecKeyGenerationParameters (), out _); }, "CreateRandomKey - invalid 'SecKeyType', empty 'SecKeyGenerationParameters'");
 		}
 	}
 }

--- a/tests/monotouch-test/Security/KeyTest.cs
+++ b/tests/monotouch-test/Security/KeyTest.cs
@@ -498,7 +498,7 @@ namespace MonoTouchFixtures.Security {
 			keyGenerationParameters.KeyType = SecKeyType.EC;
 			keyGenerationParameters.KeySizeInBits = 256;
 			keyGenerationParameters.IsPermanent = false;
-			var privateKeyAttributes = new SecPublicPrivateKeyAttrs ();
+			var privateKeyAttributes = new SecKeyParameters ();
 			privateKeyAttributes.AccessControl = new SecAccessControl (SecAccessible.WhenUnlockedThisDeviceOnly, SecAccessControlCreateFlags.PrivateKeyUsage | SecAccessControlCreateFlags.UserPresence);
 			privateKeyAttributes.Label = "NotDefault";
 			keyGenerationParameters.PrivateKeyAttrs = privateKeyAttributes;

--- a/tests/monotouch-test/Security/KeyTest.cs
+++ b/tests/monotouch-test/Security/KeyTest.cs
@@ -488,5 +488,40 @@ namespace MonoTouchFixtures.Security {
 				}
 			}
 		}
+
+		[Test]
+		public void CreateRandomKeyWithParametersTests ()
+		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+
+			var keyGenerationParameters = new SecKeyGenerationParameters ();
+			keyGenerationParameters.KeyType = SecKeyType.EC;
+			keyGenerationParameters.KeySizeInBits = 256;
+			keyGenerationParameters.IsPermanent = false;
+			var privateKeyAttributes = new SecPublicPrivateKeyAttrs ();
+			privateKeyAttributes.AccessControl = new SecAccessControl (SecAccessible.WhenUnlockedThisDeviceOnly, SecAccessControlCreateFlags.PrivateKeyUsage | SecAccessControlCreateFlags.UserPresence);
+			privateKeyAttributes.Label = "NotDefault";
+			keyGenerationParameters.PrivateKeyAttrs = privateKeyAttributes;
+
+			NSError error;
+			var privateKey = SecKey.CreateRandomKey (keyGenerationParameters, out error);
+			Assert.That (error, Is.EqualTo (null), "CreateRandomKey");
+			Assert.That (privateKey, Is.Not.EqualTo (null), "CreateRandomKey - key is null");
+			var publicKey = privateKey.GetPublicKey ();
+			Assert.That (publicKey, Is.Not.EqualTo (null));
+
+			Assert.Throws<ArgumentException> (() => { SecKey.CreateRandomKey ((SecKeyGenerationParameters) null, out _); }, "CreateRandomKey - null argument");
+
+			keyGenerationParameters = new SecKeyGenerationParameters ();
+			keyGenerationParameters.KeyType = SecKeyType.Invalid;
+			Assert.Throws<ArgumentException> (() => { SecKey.CreateRandomKey (keyGenerationParameters, out _); }, "CreateRandomKey - invalid key type");
+
+			keyGenerationParameters = new SecKeyGenerationParameters ();
+			keyGenerationParameters.KeyType = SecKeyType.RSA;
+			keyGenerationParameters.KeySizeInBits = -1;
+			Assert.That (SecKey.CreateRandomKey (keyGenerationParameters, out _), Is.EqualTo (SecStatusCode.Param), "CreateRandomKey - Param issue, invalid RSA key size");
+
+			Assert.Throws<ArgumentException> (() => { SecKey.CreateRandomKey (new SecKeyGenerationParameters (), out _); }, "CreateRandomKey - empty parameters");
+		}
 	}
 }


### PR DESCRIPTION
As discussed in #3350 and on gitter this pull request should resolve #3486. 

I have created a new strongly typed type, `SecKeyGenerationParameters`, and an overloaded method `SecKey.CreateRandomKey`, which enables parameterisation of key generation.

The properties of the `SecKeyGenerationParameters`-type is based on https://developer.apple.com/documentation/security/certificate_key_and_trust_services/keys/key_generation_attributes

NB! I might be off with the test case, but I found it appropriate to add it. Let me know what needs fixing and I will try to do that tomorrow at work.