### PR TITLE
[healthkit] Fix typos in 'HKInsulinDeliveryReason' and 'HKBloodGlucoseMealTime'

### DIFF
--- a/src/HealthKit/Enums.cs
+++ b/src/HealthKit/Enums.cs
@@ -534,11 +534,13 @@ namespace HealthKit
 	[Watch (4, 0), iOS (11, 0)]
 	[Native]
 	public enum HKInsulinDeliveryReason : long {
+#if !XAMCORE_4_0
 		[Obsolete ("Use 'Basal' instead.")]
 		Asal = 1,
-		Basal = Asal,
 		[Obsolete ("Use 'Bolus' instead.")]
 		Olus,
+#endif
+		Basal = Asal,
 		Bolus = Olus,
 	}
 

--- a/src/HealthKit/Enums.cs
+++ b/src/HealthKit/Enums.cs
@@ -545,11 +545,13 @@ namespace HealthKit
 	[Watch (4, 0), iOS (11, 0)]
 	[Native]
 	public enum HKBloodGlucoseMealTime : long {
+#if !XAMCORE_4_0
 		[Obsolete ("Use 'Preprandial' instead.")]
 		Reprandial = 1,
-		Preprandial = Reprandial,
 		[Obsolete ("Use 'Postprandial' instead.")]
 		Ostprandial,
+#endif
+		Preprandial = Reprandial,
 		Postprandial = Ostprandial,
 
 	}

--- a/src/HealthKit/Enums.cs
+++ b/src/HealthKit/Enums.cs
@@ -534,15 +534,24 @@ namespace HealthKit
 	[Watch (4, 0), iOS (11, 0)]
 	[Native]
 	public enum HKInsulinDeliveryReason : long {
+		[Obsolete ("Use 'Basal' instead.")]
 		Asal = 1,
+		Basal = Asal,
+		[Obsolete ("Use 'Bolus' instead.")]
 		Olus,
+		Bolus = Olus,
 	}
 
 	[Watch (4, 0), iOS (11, 0)]
 	[Native]
 	public enum HKBloodGlucoseMealTime : long {
+		[Obsolete ("Use 'Preprandial' instead.")]
 		Reprandial = 1,
+		Preprandial = Reprandial,
+		[Obsolete ("Use 'Postprandial' instead.")]
 		Ostprandial,
+		Postprandial = Ostprandial,
+
 	}
 
 	[Watch (4, 0), iOS (11, 0)]

--- a/src/HealthKit/Enums.cs
+++ b/src/HealthKit/Enums.cs
@@ -534,28 +534,27 @@ namespace HealthKit
 	[Watch (4, 0), iOS (11, 0)]
 	[Native]
 	public enum HKInsulinDeliveryReason : long {
+		Basal = 1,
+		Bolus,
 #if !XAMCORE_4_0
 		[Obsolete ("Use 'Basal' instead.")]
-		Asal = 1,
+		Asal = Basal,
 		[Obsolete ("Use 'Bolus' instead.")]
-		Olus,
+		Olus = Bolus,
 #endif
-		Basal = Asal,
-		Bolus = Olus,
 	}
 
 	[Watch (4, 0), iOS (11, 0)]
 	[Native]
 	public enum HKBloodGlucoseMealTime : long {
+		Preprandial = 1,
+		Postprandial,
 #if !XAMCORE_4_0
 		[Obsolete ("Use 'Preprandial' instead.")]
-		Reprandial = 1,
+		Reprandial = Preprandial,
 		[Obsolete ("Use 'Postprandial' instead.")]
-		Ostprandial,
+		Ostprandial = Postprandial,
 #endif
-		Preprandial = Reprandial,
-		Postprandial = Ostprandial,
-
 	}
 
 	[Watch (4, 0), iOS (11, 0)]

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -91,7 +91,7 @@ namespace Introspection
 			"Anglet",
 			"Arraycollation",
 			"Argb",
-			"Asal",
+			"Asal", // Typo, should be 'Basal', fixed in 'HKInsulinDeliveryReason'
 			"Asin",
 			"Atan",
 			"Ats",	// App Transport Security
@@ -337,11 +337,11 @@ namespace Introspection
 			"Ocsp", // Online Certificate Status Protocol
 			"Octree",
 			"Oid",
-			"Olus",
+			"Olus", // Typo, should be 'Bolus', fixed in 'HKInsulinDeliveryReason'
 			"Oneup", // TVElementKeyOneupTemplate
 			"Orthographyrange",
 			"Orth",
-			"Ostprandial",
+			"Ostprandial", // Typo, should be 'Postprandial', fixed in 'HKBloodGlucoseMealTime'
 			"ove",
 			"Paeth", // PNG filter
 			"Parms", // short for Parameters
@@ -380,7 +380,7 @@ namespace Introspection
 			"Reinvitation",
 			"Reinvite",
 			"Rel",
-			"Reprandial",
+			"Reprandial", // Typo, should be 'Preprandial', fixed in 'HKBloodGlucoseMealTime'
 			"Replayable",
 			"Requestwith",
 			"Ridesharing",

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -91,7 +91,6 @@ namespace Introspection
 			"Anglet",
 			"Arraycollation",
 			"Argb",
-			"Asal", // Typo, should be 'Basal', fixed in 'HKInsulinDeliveryReason'
 			"Asin",
 			"Atan",
 			"Ats",	// App Transport Security
@@ -337,11 +336,9 @@ namespace Introspection
 			"Ocsp", // Online Certificate Status Protocol
 			"Octree",
 			"Oid",
-			"Olus", // Typo, should be 'Bolus', fixed in 'HKInsulinDeliveryReason'
 			"Oneup", // TVElementKeyOneupTemplate
 			"Orthographyrange",
 			"Orth",
-			"Ostprandial", // Typo, should be 'Postprandial', fixed in 'HKBloodGlucoseMealTime'
 			"ove",
 			"Paeth", // PNG filter
 			"Parms", // short for Parameters
@@ -380,7 +377,6 @@ namespace Introspection
 			"Reinvitation",
 			"Reinvite",
 			"Rel",
-			"Reprandial", // Typo, should be 'Preprandial', fixed in 'HKBloodGlucoseMealTime'
 			"Replayable",
 			"Requestwith",
 			"Ridesharing",
@@ -761,13 +757,17 @@ namespace Introspection
 #endif
 #if !XAMCORE_4_0
 			"Actionfrom",
+			"Asal", // Typo, should be 'Basal', fixed in 'HKInsulinDeliveryReason'
 			"Attributefor",
 			"Attributest",
 			"Failwith",
 			"Imageimage",
 			"Musthold",
+			"Olus", // Typo, should be 'Bolus', fixed in 'HKInsulinDeliveryReason'
+			"Ostprandial", // Typo, should be 'Postprandial', fixed in 'HKBloodGlucoseMealTime'
 			"Pathpath",
 			"Rangefor",
+			"Reprandial", // Typo, should be 'Preprandial', fixed in 'HKBloodGlucoseMealTime'
 			"Failwith",
 			"Tearm",
 			"Theevent",


### PR DESCRIPTION
- Fixes https://github.com/xamarin/xamarin-macios/issues/3499
(HKBloodGlucoseMealTime misspellings in bindings)
- 'HKInsulinDeliveryReason' [doc](https://developer.apple.com/documentation/healthkit/hkinsulindeliveryreason?language=objc)
- 'HKBloodGlucoseMealTime' [doc](https://developer.apple.com/documentation/healthkit/hkbloodglucosemealtime?language=objc)
- Commented ApiTypoTest.