### PR TITLE
Bump the VSfM dependency to the latest d15-6 preview.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -65,9 +65,9 @@ MAX_MONO_VERSION=5.10.99
 MIN_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2017-12/13/MonoFramework-MDK-5.10.0.15.macos10.xamarin.universal.pkg
 
 # Minimum Visual Studio version
-MIN_VISUAL_STUDIO_URL=https://bosstoragemirror.blob.core.windows.net/wrench/monodevelop-lion-dogfood-vNext/8f/8f1c13cb983138ee63bd53e09908ea5e737988cd/VisualStudioForMac-Preview-7.0.0.2728.dmg
-MIN_VISUAL_STUDIO_VERSION=7.0.0.2728
-MAX_VISUAL_STUDIO_VERSION=7.4.99
+MIN_VISUAL_STUDIO_URL=https://download.visualstudio.microsoft.com/download/pr/11550896/783d2219a348f93b6988fb415951788a/VisualStudioForMac-Preview-7.4.0.985.dmg
+MIN_VISUAL_STUDIO_VERSION=7.4.0.985
+MAX_VISUAL_STUDIO_VERSION=7.5.99
 
 # Minimum CMake version
 MIN_CMAKE_URL=https://cmake.org/files/v3.6/cmake-3.6.2-Darwin-x86_64.dmg


### PR DESCRIPTION
It seems the d15-5 version of VSfM has a non-optimal startup path, where
launching vstool takes almost 4 minutes on the bots, making it difficult to
build & run tests within the allotted time for those tests:

    $ time /Applications/Visual\ Studio.app/Contents/MacOS/vstool help
    [...]
    real	3m30.172s

So bump to the latest d15-6 preview (which takes _only_ 12 seconds to launch
on my machine), hoping it will be enough to make tests build on the bots.