### PR TITLE
[linker] Find linked away interfaces when resolving removed interfaces. Fixes #3513.

### DIFF
--- a/tools/linker/CoreSweepStep.cs
+++ b/tools/linker/CoreSweepStep.cs
@@ -31,7 +31,12 @@ namespace Xamarin.Linker {
 			// The static registrar needs access to the interfaces for protocols, so keep them around.
 			if (!LinkContext.ProtocolImplementations.TryGetValue (type, out var list))
 				LinkContext.ProtocolImplementations [type] = list = new List<TypeDefinition> ();
-			list.Add (iface.InterfaceType.Resolve ());
+			var it = iface.InterfaceType.Resolve ();
+			if (it == null) {
+				// The interface type might already have been linked away, so go look for it among those types as well
+				it = LinkContext.GetLinkedAwayType (iface.InterfaceType, out _);
+			}
+			list.Add (it);
 		}
 
 		protected override void ElementRemoved (IMetadataTokenProvider element)


### PR DESCRIPTION
The linker might remove interfaces that have already been linked away. Make
sure to look for the TypeDefinition for such interfaces among the types that
have already been linked away.

Fixes https://github.com/xamarin/xamarin-macios/issues/3513.