### PR TITLE
[tests] Automatically rebuild 'test.config' if it can't be found.

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -103,6 +103,9 @@
     <Compile Include="..\..\..\tests\common\Profile.cs">
       <Link>Profile.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tests\common\ExecutionHelper.cs">
+      <Link>ExecutionHelper.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
This condition usually happens when I 'git clean -xfd' in tests/ and then want
to run tests from xharness.

The manual step is to run "make" in tests/, but it's better if we can do it automatically.