### PR TITLE
[mtouch] Rename temporary directories so the order assemblies move is clearer.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -357,7 +357,7 @@ public class B : A {}
 				mtouch.CreateTemporaryCacheDirectory ();
 				mtouch.Verbosity = 4; // This is required to get the debug output we're testing for
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build 1");
-				mtouch.AssertOutputPattern ("Linking .*/testApp.exe into .*/PreBuild using mode 'None'");
+				mtouch.AssertOutputPattern ("Linking .*/testApp.exe into .*/2-PreBuild using mode 'None'");
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build 2");
 				mtouch.AssertOutputPattern ("Cached assemblies reloaded.");
 			}

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -783,15 +783,15 @@ namespace Xamarin.Bundler
 			//   its GUID).
 			// 
 
-			LinkDirectory = Path.Combine (ArchDirectory, "Link");
+			LinkDirectory = Path.Combine (ArchDirectory, "1-Link");
 			if (!Directory.Exists (LinkDirectory))
 				Directory.CreateDirectory (LinkDirectory);
 
-			PreBuildDirectory = Path.Combine (ArchDirectory, "PreBuild");
+			PreBuildDirectory = Path.Combine (ArchDirectory, "2-PreBuild");
 			if (!Directory.Exists (PreBuildDirectory))
 				Directory.CreateDirectory (PreBuildDirectory);
 			
-			BuildDirectory = Path.Combine (ArchDirectory, "Build");
+			BuildDirectory = Path.Combine (ArchDirectory, "3-Build");
 			if (!Directory.Exists (BuildDirectory))
 				Directory.CreateDirectory (BuildDirectory);
 


### PR DESCRIPTION
I implemented this myself, but I can never remember in which order assemblies
go from one directory to another during the build.

So number these temporary directories, so that even the most forgetful minds
can understand without having to remember anything.