### PR TITLE
[linker] Take extra care to avoid 32/64 bits specific mscorlib.dll

### DIFF
--- a/tests/linker/ios/link all/LinkAllTest.cs
+++ b/tests/linker/ios/link all/LinkAllTest.cs
@@ -574,6 +574,13 @@ namespace LinkAll {
 			Assert.Null (oifd,  atmb.FullName + ".ObjectIdForDebugger");
 #endif
 		}
+
+		[Test]
+		public void NoFatCorlib ()
+		{
+			var corlib = typeof (int).Assembly.Location;
+			Assert.That (corlib, Is.StringEnding ("link all.app/mscorlib.dll"), "shared");
+		}
 	}
 
 	[Introduced (PlatformName.MacOSX, 1, 0, PlatformArchitecture.Arch64)]

--- a/tests/linker/ios/link all/LinkAllTest.cs
+++ b/tests/linker/ios/link all/LinkAllTest.cs
@@ -579,7 +579,12 @@ namespace LinkAll {
 		public void NoFatCorlib ()
 		{
 			var corlib = typeof (int).Assembly.Location;
-			Assert.That (corlib, Is.StringEnding ("link all.app/mscorlib.dll"), "shared");
+#if __WATCHOS__
+			var suffix = "link all.appex/mscorlib.dll";
+#else
+			var suffix = "link all.app/mscorlib.dll";
+#endif
+			Assert.That (corlib, Is.StringEnding (suffix), corlib);
 		}
 	}
 

--- a/tools/linker/MonoTouch.Tuner/MonoTouchMarkStep.cs
+++ b/tools/linker/MonoTouch.Tuner/MonoTouchMarkStep.cs
@@ -127,7 +127,7 @@ namespace MonoTouch.Tuner {
 			}
 
 			// we want to avoid separate mscorlib.dll for 32/64 bits so the arch specific code for n[u]int and nfloat must be preserved in both cases
-			// a single, slightly larger, assenmbly is much smaller thn two (slightly smaller) ones
+			// a single, slightly larger, assembly is much smaller thn two (slightly smaller) ones
 			if (LinkContext.App.IsDualBuild) {
 				switch (method.Name) {
 				case "TryParse":

--- a/tools/linker/MonoTouch.Tuner/MonoTouchMarkStep.cs
+++ b/tools/linker/MonoTouch.Tuner/MonoTouchMarkStep.cs
@@ -126,6 +126,27 @@ namespace MonoTouch.Tuner {
 				pending_serialization_constructors.Clear ();
 			}
 
+			// we want to avoid separate mscorlib.dll for 32/64 bits so the arch specific code for n[u]int and nfloat must be preserved in both cases
+			// a single, slightly larger, assenmbly is much smaller thn two (slightly smaller) ones
+			if (LinkContext.App.IsDualBuild) {
+				switch (method.Name) {
+				case "TryParse":
+					switch (method.DeclaringType.Name) {
+					case "nfloat":
+						MarkNamedMethod (GetType ("mscorlib", "System.Double"), "TryParse");
+						MarkNamedMethod (GetType ("mscorlib", "System.Single"), "TryParse");
+						break;
+					}
+					break;
+				case "Create":
+					// ARCH_32 optimization
+					if (!method.DeclaringType.Is (Namespaces.Foundation, "NSIndexPath"))
+						break;
+					MarkNamedMethod (GetType ("mscorlib", "System.Array"), "ConvertAll");
+					break;
+				}
+			}
+
 			return method;
 		}
 


### PR DESCRIPTION
We want to avoid separate `mscorlib.dll` assemblies for 32/64 bits so
the  architecture specific code for `n[u]int` and `nfloat` must be
preserved in both cases.

Because a single, slightly larger, assembly is much smaller than two
(slightly smaller) ones.

This is not a common situation since the extraneous preserved API are
often used in the application (or 3rd party code) so, in most cases,
a single `mscorlib.dll` was already used.

This merely close the gap for some cases, like our `link all` application
where this happened.