### PR TITLE
[mtouch/mmp] Fix tracking of whether the static registrar should run again or not. Fixes #641.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -363,6 +363,21 @@ public class B : A {}
 			}
 		}
 
+		void DumpFileStats (MTouchTool mtouch)
+		{
+			if (mtouch.Verbosity < 1)
+				return;
+			var directory = mtouch.Cache;
+			var files = Directory.GetFileSystemEntries (directory, "*", SearchOption.AllDirectories).ToList ();
+			files.Sort ((string x, string y) => string.CompareOrdinal (x, y));
+			var max = files.Max ((v) => v.Length);
+
+			var format = "    {0,-" + max + "} {1}";
+			foreach (var file in  files) {
+				Console.WriteLine (format, file, File.GetLastWriteTimeUtc (file).ToString ("HH:mm:ss.fffffff"));
+			}
+		}
+
 		[Test]
 		[TestCase ("single", "", false, new string [] { } )]
 		[TestCase ("dual", "armv7,arm64", false, new string [] { })]
@@ -397,17 +412,20 @@ public class B : A {}
 					mtouch.DSym = false; // faster test
 					mtouch.MSym = false; // faster test
 					mtouch.NoStrip = true; // faster test
+					//mtouch.Verbosity = 20; // Set the mtouch verbosity to something to print the mtouch output to the terminal. This will also enable additional debug output.
 
 					var timestamp = DateTime.MinValue;
 
 					mtouch.AssertExecute (MTouchAction.BuildDev, "first build");
 					Console.WriteLine ($"{DateTime.Now} **** FIRST BUILD DONE ****");
+					DumpFileStats (mtouch);
 
 					timestamp = DateTime.Now;
 					System.Threading.Thread.Sleep (1000); // make sure all new timestamps are at least a second older. HFS+ has a 1s timestamp resolution :(
 
 					mtouch.AssertExecute (MTouchAction.BuildDev, "second build");
 					Console.WriteLine ($"{DateTime.Now} **** SECOND BUILD DONE ****");
+					DumpFileStats (mtouch);
 
 					mtouch.AssertNoneModified (timestamp, name);
 					extension.AssertNoneModified (timestamp, name);
@@ -416,6 +434,7 @@ public class B : A {}
 					new FileInfo (extension.RootAssembly).LastWriteTimeUtc = DateTime.UtcNow;
 					mtouch.AssertExecute (MTouchAction.BuildDev, "touch extension executable");
 					Console.WriteLine ($"{DateTime.Now} **** TOUCH EXTENSION EXECUTABLE DONE ****");
+					DumpFileStats (mtouch);
 					mtouch.AssertNoneModified (timestamp, name);
 					extension.AssertNoneModified (timestamp, name);
 
@@ -423,6 +442,7 @@ public class B : A {}
 					new FileInfo (mtouch.RootAssembly).LastWriteTimeUtc = DateTime.UtcNow;
 					mtouch.AssertExecute (MTouchAction.BuildDev, "touch main app executable");
 					Console.WriteLine ($"{DateTime.Now} **** TOUCH MAIN APP EXECUTABLE DONE ****");
+					DumpFileStats (mtouch);
 					mtouch.AssertNoneModified (timestamp, name);
 					extension.AssertNoneModified (timestamp, name);
 
@@ -440,6 +460,7 @@ public class B : A {}
 					extension.CreateTemporaryServiceExtension (extraCode: codeB);
 					mtouch.AssertExecute (MTouchAction.BuildDev, "change extension executable");
 					Console.WriteLine ($"{DateTime.Now} **** CHANGE EXTENSION EXECUTABLE DONE ****");
+					DumpFileStats (mtouch);
 					mtouch.AssertNoneModified (timestamp, name);
 					extension.AssertNoneModified (timestamp, name, "testServiceExtension", "testServiceExtension.aotdata.armv7", "testServiceExtension.aotdata.arm64", "testServiceExtension.dll");
 
@@ -450,6 +471,7 @@ public class B : A {}
 					mtouch.CreateTemporaryApp (extraCode: codeB);
 					mtouch.AssertExecute (MTouchAction.BuildDev, "change app executable");
 					Console.WriteLine ($"{DateTime.Now} **** CHANGE APP EXECUTABLE DONE ****");
+					DumpFileStats (mtouch);
 					mtouch.AssertNoneModified (timestamp, name, "testApp", "testApp.aotdata.armv7", "testApp.aotdata.arm64", "testApp.exe");
 					extension.AssertNoneModified (timestamp, name);
 
@@ -460,6 +482,7 @@ public class B : A {}
 					File.WriteAllText (extension.RootAssembly + ".config", "<configuration></configuration>");
 					mtouch.AssertExecute (MTouchAction.BuildDev, "add config to extension dll");
 					Console.WriteLine ($"{DateTime.Now} **** ADD CONFIG TO EXTENSION DONE ****");
+					DumpFileStats (mtouch);
 					mtouch.AssertNoneModified (timestamp, name);
 					extension.AssertNoneModified (timestamp, name, "testServiceExtension.dll.config", "testServiceExtension", "testServiceExtension.aotdata.armv7", "testServiceExtension.aotdata.arm64");
 					CollectionAssert.Contains (Directory.EnumerateFiles (extension.AppPath, "*", SearchOption.AllDirectories).Select ((v) => Path.GetFileName (v)), "testServiceExtension.dll.config", "extension config added");
@@ -471,18 +494,19 @@ public class B : A {}
 					File.WriteAllText (mtouch.RootAssembly + ".config", "<configuration></configuration>");
 					mtouch.AssertExecute (MTouchAction.BuildDev, "add config to container exe");
 					Console.WriteLine ($"{DateTime.Now} **** ADD CONFIG TO CONTAINER DONE ****");
+					DumpFileStats (mtouch);
 					mtouch.AssertNoneModified (timestamp, name, "testApp.exe.config", "testApp", "testApp.aotdata.armv7", "testApp.aotdata.arm64");
 					extension.AssertNoneModified (timestamp, name);
 					CollectionAssert.Contains (Directory.EnumerateFiles (mtouch.AppPath, "*", SearchOption.AllDirectories).Select ((v) => Path.GetFileName (v)), "testApp.exe.config", "container config added");
 
 					timestamp = DateTime.Now;
 					System.Threading.Thread.Sleep (1000); // make sure all new timestamps are at least a second older. HFS+ has a 1s timestamp resolution :(
-
 					{
 						// Add a satellite to the extension.
 						var satellite = extension.CreateTemporarySatelliteAssembly ();
 						mtouch.AssertExecute (MTouchAction.BuildDev, "add satellite to extension");
 						Console.WriteLine ($"{DateTime.Now} **** ADD SATELLITE TO EXTENSION DONE ****");
+						DumpFileStats (mtouch);
 						mtouch.AssertNoneModified (timestamp, name, Path.GetFileName (satellite));
 						extension.AssertNoneModified (timestamp, name, Path.GetFileName (satellite));
 						extension.AssertModified (timestamp, name, Path.GetFileName (satellite));
@@ -497,6 +521,7 @@ public class B : A {}
 						var satellite = mtouch.CreateTemporarySatelliteAssembly ();
 						mtouch.AssertExecute (MTouchAction.BuildDev, "add satellite to container");
 						Console.WriteLine ($"{DateTime.Now} **** ADD SATELLITE TO CONTAINER DONE ****");
+						DumpFileStats (mtouch);
 						mtouch.AssertNoneModified (timestamp, name, Path.GetFileName (satellite));
 						extension.AssertNoneModified (timestamp, name, Path.GetFileName (satellite));
 						mtouch.AssertModified (timestamp, name, Path.GetFileName (satellite));

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -126,7 +126,13 @@ namespace Xamarin.Bundler {
 			}
 		}
 
-		public static bool IsUptodate (string source, string target, bool check_contents = false)
+		// Checks if the source file has a time stamp later than the target file.
+		//
+		// Optionally check if the contents of the files are different after checking the timestamp.
+		//
+		// If check_stamp is true, the function will use the timestamp of a "target".stamp file
+		// if it's later than the timestamp of the "target" file itself.
+		public static bool IsUptodate (string source, string target, bool check_contents = false, bool check_stamp = true)
 		{
 			if (Driver.Force)
 				return false;
@@ -136,6 +142,14 @@ namespace Xamarin.Bundler {
 			if (!tfi.Exists) {
 				Driver.Log (3, "Target '{0}' does not exist.", target);
 				return false;
+			}
+
+			if (check_stamp) {
+				var tfi_stamp = new FileInfo (target + ".stamp");
+				if (tfi_stamp.Exists && tfi_stamp.LastWriteTimeUtc > tfi.LastWriteTimeUtc) {
+					Driver.Log (3, "Target '{0}' has a stamp file with newer timestamp ({1} > {2}), using the stamp file's timestamp", target, tfi_stamp.LastWriteTimeUtc, tfi.LastWriteTimeUtc);
+					tfi = tfi_stamp;
+				}
 			}
 
 			var sfi = new FileInfo (source);
@@ -323,7 +337,10 @@ namespace Xamarin.Bundler {
 		}
 
 		// Checks if any of the source files have a time stamp later than any of the target files.
-		public static bool IsUptodate (IEnumerable<string> sources, IEnumerable<string> targets)
+		//
+		// If check_stamp is true, the function will use the timestamp of a "target".stamp file
+		// if it's later than the timestamp of the "target" file itself.
+		public static bool IsUptodate (IEnumerable<string> sources, IEnumerable<string> targets, bool check_stamp = true)
 		{
 			if (Driver.Force)
 				return false;
@@ -354,6 +371,14 @@ namespace Xamarin.Bundler {
 				if (!tfi.Exists) {
 					Driver.Log (3, "Target '{0}' does not exist.", t);
 					return false;
+				}
+
+				if (check_stamp) {
+					var tfi_stamp = new FileInfo (t + ".stamp");
+					if (tfi_stamp.Exists && tfi_stamp.LastWriteTimeUtc > tfi.LastWriteTimeUtc) {
+						Driver.Log (3, "Target '{0}' has a stamp file with newer timestamp ({1} > {2}), using the stamp file's timestamp", t, tfi_stamp.LastWriteTimeUtc, tfi.LastWriteTimeUtc);
+						tfi = tfi_stamp;
+					}
 				}
 
 				var lwt = tfi.LastWriteTimeUtc;

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -446,7 +446,13 @@ namespace Xamarin.Bundler {
 				timestamp = DateTime.Now;
 			foreach (var filename in filenames) {
 				try {
-					new FileInfo (filename).LastWriteTime = timestamp.Value;
+					var fi = new FileInfo (filename);
+					if (!fi.Exists) {
+						using (var fo = fi.OpenWrite ()) {
+							// Create an empty file.
+						}
+					}
+					fi.LastWriteTime = timestamp.Value;
 				} catch (Exception e) {
 					ErrorHelper.Warning (128, "Could not touch the file '{0}': {1}", filename, e.Message);
 				}

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -438,5 +439,24 @@ namespace Xamarin.Bundler {
 				}
 			}
 		}
+
+		public static void Touch (IEnumerable<string> filenames, DateTime? timestamp = null)
+		{
+			if (timestamp == null)
+				timestamp = DateTime.Now;
+			foreach (var filename in filenames) {
+				try {
+					new FileInfo (filename).LastWriteTime = timestamp.Value;
+				} catch (Exception e) {
+					ErrorHelper.Warning (128, "Could not touch the file '{0}': {1}", filename, e.Message);
+				}
+			}
+		}
+
+		public static void Touch (params string [] filenames)
+		{
+			Touch ((IEnumerable<string>) filenames);
+		}
+
 	}
 }

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -305,7 +305,7 @@ namespace Xamarin.Bundler {
 			File.Move (source, target);
 		}
 
-		static void MoveIfDifferent (string path, string tmp)
+		static void MoveIfDifferent (string path, string tmp, bool use_stamp = false)
 		{
 			// Don't read the entire file into memory, it can be quite big in certain cases.
 
@@ -326,10 +326,12 @@ namespace Xamarin.Bundler {
 				FileMove (tmp, path);
 			} else {
 				Log (3, "Target {0} is up-to-date.", path);
+				if (use_stamp)
+					Driver.Touch (path + ".stamp");
 			}
 		}
 
-		public static void WriteIfDifferent (string path, string contents)
+		public static void WriteIfDifferent (string path, string contents, bool use_stamp = false)
 		{
 			var tmp = path + ".tmp";
 
@@ -342,7 +344,7 @@ namespace Xamarin.Bundler {
 				}
 
 				File.WriteAllText (tmp, contents);
-				MoveIfDifferent (path, tmp);
+				MoveIfDifferent (path, tmp, use_stamp);
 			} catch (Exception e) {
 				File.WriteAllText (path, contents);
 				ErrorHelper.Warning (1014, e, "Failed to re-use cached version of '{0}': {1}.", path, e.Message);
@@ -351,7 +353,7 @@ namespace Xamarin.Bundler {
 			}
 		}
 
-		public static void WriteIfDifferent (string path, byte[] contents)
+		public static void WriteIfDifferent (string path, byte[] contents, bool use_stamp = false)
 		{
 			var tmp = path + ".tmp";
 
@@ -363,7 +365,7 @@ namespace Xamarin.Bundler {
 				}
 
 				File.WriteAllBytes (tmp, contents);
-				MoveIfDifferent (path, tmp);
+				MoveIfDifferent (path, tmp, use_stamp);
 			} catch (Exception e) {
 				File.WriteAllBytes (path, contents);
 				ErrorHelper.Warning (1014, e, "Failed to re-use cached version of '{0}': {1}.", path, e.Message);

--- a/tools/common/PInvokeWrapperGenerator.cs
+++ b/tools/common/PInvokeWrapperGenerator.cs
@@ -63,8 +63,8 @@ namespace Xamarin.Bundler
 
 			Registrar.GeneratePInvokeWrappersEnd ();
 
-			Driver.WriteIfDifferent (HeaderPath, hdr.ToString () + "\n" + decls.ToString () + "\n" + ifaces.ToString () + "\n") ;
-			Driver.WriteIfDifferent (SourcePath, mthds.ToString () + "\n" + sb.ToString () + "\n");
+			Driver.WriteIfDifferent (HeaderPath, hdr.ToString () + "\n" + decls.ToString () + "\n" + ifaces.ToString () + "\n", true);
+			Driver.WriteIfDifferent (SourcePath, mthds.ToString () + "\n" + sb.ToString () + "\n", true);
 		}
 
 		public void ProcessMethod (MethodDefinition method)

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -4564,12 +4564,12 @@ namespace Registrar {
 
 			FlushTrace ();
 
-			Driver.WriteIfDifferent (source_path, methods.ToString ());
+			Driver.WriteIfDifferent (source_path, methods.ToString (), true);
 
 			header.AppendLine ();
 			header.AppendLine (declarations);
 			header.AppendLine (interfaces);
-			Driver.WriteIfDifferent (header_path, header.ToString ());
+			Driver.WriteIfDifferent (header_path, header.ToString (), true);
 
 			header.Dispose ();
 			header = null;

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -4508,6 +4508,9 @@ namespace Registrar {
 
 		public void Generate (IEnumerable<AssemblyDefinition> assemblies, string header_path, string source_path)
 		{
+			if (Target?.CachedLink == true)
+				throw ErrorHelper.CreateError (99, "Internal error: the static registrar should not execute unless the linker also executed (or was disabled). A potential workaround is to pass '-f' as an additional " + Driver.NAME + " argument to force a full build. Please file a bug report with a test case (https://bugzilla.xamarin.com).");
+
 			this.input_assemblies = assemblies;
 
 			foreach (var assembly in assemblies) {

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -62,6 +62,12 @@ namespace Xamarin.Bundler {
 			this.StaticRegistrar = new StaticRegistrar (this);
 		}
 
+		public bool CachedLink {
+			get {
+				return cached_link;
+			}
+		}
+
 		public void ExtractNativeLinkInfo (List<Exception> exceptions)
 		{
 			foreach (var a in Assemblies) {

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -402,7 +402,7 @@ namespace Xamarin.Bundler {
 			sb.AppendLine ("}");
 			sb.AppendLine ();
 
-			Driver.WriteIfDifferent (reference_m, sb.ToString ());
+			Driver.WriteIfDifferent (reference_m, sb.ToString (), true);
 
 #if MTOUCH
 			foreach (var abi in GetArchitectures (AssemblyBuildTarget.StaticObject)) {

--- a/tools/mmp/.gitignore
+++ b/tools/mmp/.gitignore
@@ -2,3 +2,5 @@ mmp
 temp-dir-mmp
 Xamarin.Mac.registrar.*
 SdkVersions.cs
+*.stamp
+

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -68,6 +68,7 @@ namespace Xamarin.Bundler {
 	}
 
 	public static partial class Driver {
+		internal const string NAME = "mmp";
 		internal static Application App = new Application (Environment.GetCommandLineArgs ());
 		static Target BuildTarget = new Target (App);
 		static List<string> references = new List<string> ();

--- a/tools/mtouch/.gitignore
+++ b/tools/mtouch/.gitignore
@@ -7,3 +7,5 @@ SdkVersions.cs
 simlauncher-sgen
 simlauncher32-sgen
 simlauncher64-sgen
+*.stamp
+

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -799,24 +799,6 @@ namespace Xamarin.Bundler
 			return true;
 		}
 
-		public static void Touch (IEnumerable<string> filenames, DateTime? timestamp = null)
-		{
-			if (timestamp == null)
-				timestamp = DateTime.Now;
-			foreach (var filename in filenames) {
-				try {
-					new FileInfo (filename).LastWriteTime = timestamp.Value;
-				} catch (Exception e) {
-					ErrorHelper.Warning (128, "Could not touch the file '{0}': {1}", filename, e.Message);
-				}
-			}
-		}
-
-		public static void Touch (params string [] filenames)
-		{
-			Touch ((IEnumerable<string>) filenames);
-		}
-
 		public static bool CanWeSymlinkTheApplication (Application app)
 		{
 			if (app.Platform != ApplePlatform.iOS)

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -79,6 +79,8 @@ public enum OutputFormat {
 namespace Xamarin.Bundler
 {
 	partial class Driver {
+		internal const string NAME = "mtouch";
+
 		public static void ShowHelp (OptionSet os)
 		{
 			Console.WriteLine ("mtouch - Mono Compiler for iOS");
@@ -698,7 +700,7 @@ namespace Xamarin.Bundler
 					sw.WriteLine ("}");
 
 				}
-				WriteIfDifferent (main_source, sb.ToString ());
+				WriteIfDifferent (main_source, sb.ToString (), true);
 			} catch (MonoTouchException) {
 				throw;
 			} catch (Exception e) {


### PR DESCRIPTION
The recent changes to support optimizing away the dynamic registrar caused the
Xamarin.MTouch.RebuildTest_WithExtensions test to regress.

The problem
-----------

* The linker now collects and stores information the static registrar needs.
* This information is not restored from disk when the linker realizes that it
  can reload previously linked assemblies instead of executing again.
* The static registrar runs again (for another reason).
* The information the static registrar needs isn't available, and incorrect
  output follows.

So fix 1: show an error if the static registrar runs when the linker loaded
cached results.

The exact scenario the test ran into is this:

* 1st build: everything is new and everything is built.
* 2nd build: contents of .exe changes, the linker runs again, the static
  registrar runs again, but sees that the generated output didn't change, so
  it doesn't write the new content to disk (this is an optimization to avoid
  compiling the registrar.m file again unless needed).
* 3rd build: only the .exe timestamp changes, the linker sees nothing changes
  in the contents of the .exe and loads the previously linked assemblies from
  disk, the static registrar sees that the .exe's timestamp is newer than
  registrar.m's timestamp and run again, but doesn't produce the right result
  because it doesn't have the information it needs.

Considered solutions
--------------------

1. Only track timestamps, not file contents. This is not ideal, since it will
   result in more work done: in particular for the case above, it would add a
   registrar.m compilation in build #2, and linker rerun + static registrar
   rerun + registrar.m compilation + final native link in build #3.
2. Always write the output of the static registrar, even if it hasn't changed.
   This is not ideal either, since it will also result in more work done: for
   the case above, it would add a registrar.m compilation + final native link
   in build #3.
3. Always write the output of the static registrar, but track if it changed or
   not, and if it didn't, just touch registrar.o instead of recompiling it.
   This only means the final native link in build #3 is added (see #5 for why
   this is worse than it sounds).
4. Always write the output of the static registrar, but track it it changed or
   not, and if it didn't, just touch registrar.o instead of recompiling it,
   and track that too, so that the final native link in build #3 isn't needed
   anymore. Unfortunately this may result in incorrect behavior, because now
   the msbuild tasks will detect that the executable has changed, and may run
   dsymutil + strip again. The executable didn't actually change, which means
   it would be the previously stripped executable, and thus we'd end up with
   an empty .dSYM because we ran dsymtil on an already stripped executable.
5. Idea #4, but write the output of the final link into a temporary directory
   instead of the .app, so that we could track whether we should update the
   executable in the .app or not. This is not optimal either, because
   executables can be *big* (I've seen multi-GB tvOS bitcode executables), and
   extra copies of such files should not be taken lightly.
6. Idea #4, but tell the MSBuild tasks that dsymutil/strip doesn't need to be
   rerun even if the timestamp of the executable changed. This might actually
   work, but now the solution's become quite complex.

Implemented solution
--------------------

Use stamp files to detect whether a file is up-to-date or not.

In particular:

* When we don't write to a file because the new contents are identical to the
  old contents, we now touch a .stamp file. This stamp file means "the
  accompanying file was determined to be up-to-date when the stamp was
  touched."
* When checking whether a file is up-to-date, also check for the presence of a
  .stamp file, and if it exists, use the highest timestamp between the stamp
  file and the actual file.

Now the test scenario becomes:

* 1st build: everything is new and everything is built.
* 2nd build: contents of .exe changes, the linker runs again, the static
  registrar runs again, but sees that the generated output didn't change, so
  it doesn't write the new content to disk, but it creates a registrar.m.stamp
  file to indicate the point in time when registrar.m was considered up-to-
  date.
* 3rd build: only the .exe timestamp changes, the linker sees nothing changes
  in the contents of the .exe and loads the previously linked assemblies from
  disk, the static registrar sees that the .exe's timestamp is *older* than
  registrar.m.stamp's timestamp and doesn't run again.

We only use the stamp file for source code (registrar.[m|h], main.[m|h],
pinvokes.[m|h]), since using it every time has too much potential for running
into other problems (for instance we should never create .stamp files inside
the .app).

Fixes these test failures:

    1) Failed : Xamarin.MTouch.RebuildTest_WithExtensions("single","",False,System.String[])
      single
      Expected: <empty>
      But was:  < "/Users/builder/data/lanes/5746/4123bf7e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.Tests.BundlerTool.CreateTemporaryDirectory371/testApp.app/testApp is modified, timestamp: 2/15/2018 3:04:11 PM > 2/15/2018 3:04:09 PM" >

    2) Failed : Xamarin.MTouch.RebuildTest_WithExtensions("dual","armv7,arm64",False,System.String[])
      dual
      Expected: <empty>
      But was:  < "/Users/builder/data/lanes/5746/4123bf7e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.Tests.BundlerTool.CreateTemporaryDirectory375/testApp.app/testApp is modified, timestamp: 2/15/2018 3:06:03 PM > 2/15/2018 3:06:00 PM" >

    3) Failed : Xamarin.MTouch.RebuildTest_WithExtensions("llvm","armv7+llvm",False,System.String[])
      llvm
      Expected: <empty>
      But was:  < "/Users/builder/data/lanes/5746/4123bf7e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.Tests.BundlerTool.CreateTemporaryDirectory379/testApp.app/testApp is modified, timestamp: 2/15/2018 3:07:14 PM > 2/15/2018 3:07:12 PM" >

    4) Failed : Xamarin.MTouch.RebuildTest_WithExtensions("debug","",True,System.String[])
      debug
      Expected: <empty>
      But was:  < "/Users/builder/data/lanes/5746/4123bf7e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.Tests.BundlerTool.CreateTemporaryDirectory383/testApp.app/testApp is modified, timestamp: 2/15/2018 3:08:16 PM > 2/15/2018 3:08:13 PM" >

    5) Failed : Xamarin.MTouch.RebuildTest_WithExtensions("single-framework","",False,System.String[])
      single-framework
      Expected: <empty>
      But was:  < "/Users/builder/data/lanes/5746/4123bf7e/source/xamarin-macios/tests/mtouch/bin/Debug/tmp-test-dir/Xamarin.Tests.BundlerTool.CreateTemporaryDirectory387/testApp.app/testApp is modified, timestamp: 2/15/2018 3:09:18 PM > 2/15/2018 3:09:16 PM" >

Fixes https://github.com/xamarin/maccore/issues/641