### PR TITLE
[Appkit] Fix NSApplication.NextEvent signatures.

### DIFF
--- a/src/AppKit/NSApplication.cs
+++ b/src/AppKit/NSApplication.cs
@@ -120,16 +120,6 @@ namespace AppKit {
 				throw new InvalidOperationException (string.Format("Event registration is overwriting existing delegate. Either just use events or your own delegate: {0} {1}", newDelegateValue.GetType(), internalDelegateType));
 		}
 
-#if !XAMCORE_4_0
-		[Obsolete ("Use the 'NextEvent (nuint, NSDate, [NSRunLoopMode|NSString], bool)' overloads instead.")]
-		public NSEvent NextEvent (NSEventMask mask, NSDate expiration, string mode, bool deqFlag)
-		{
-			// NSEventMask must be casted to nuint to preserve the NSEventMask.Any special value
-			// on 64 bit systems.
-			return NextEvent ((nuint)(ulong) mask, expiration, mode, deqFlag);
-		}
-#endif
-
 		public void DiscardEvents (NSEventMask mask, NSEvent lastEvent)
 		{
 			DiscardEvents ((nuint)(ulong) mask, lastEvent);

--- a/src/AppKit/NSApplication.cs
+++ b/src/AppKit/NSApplication.cs
@@ -120,12 +120,15 @@ namespace AppKit {
 				throw new InvalidOperationException (string.Format("Event registration is overwriting existing delegate. Either just use events or your own delegate: {0} {1}", newDelegateValue.GetType(), internalDelegateType));
 		}
 
+#if !XAMCORE_4_0
+		[Obsolete ("Use the 'NextEvent (nuint, NSDate, [NSRunLoopMode|NSString], bool)' overloads instead.")]
 		public NSEvent NextEvent (NSEventMask mask, NSDate expiration, string mode, bool deqFlag)
 		{
 			// NSEventMask must be casted to nuint to preserve the NSEventMask.Any special value
 			// on 64 bit systems.
 			return NextEvent ((nuint)(ulong) mask, expiration, mode, deqFlag);
 		}
+#endif
 
 		public void DiscardEvents (NSEventMask mask, NSEvent lastEvent)
 		{

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -525,6 +525,11 @@ namespace AppKit {
 		[Obsolete ("Use the 'NextEvent (nuint, NSDate, [NSRunLoopMode|NSString], bool)' overloads instead.")]
 		[Wrap ("NextEvent (mask, expiration, (NSString) mode, deqFlag)", IsVirtual = true), Protected]
 		NSEvent NextEvent (nuint mask, NSDate expiration, string mode, bool deqFlag);
+
+		// NSEventMask must be casted to nuint to preserve the NSEventMask.Any special value on 64 bit systems. NSEventMask is not [Native].
+		[Obsolete ("Use the 'NextEvent (nuint, NSDate, [NSRunLoopMode|NSString], bool)' overloads instead.")]
+		[Wrap ("NextEvent ((nuint) (ulong) mask, expiration, mode, deqFlag)")]
+		NSEvent NextEvent (NSEventMask mask, NSDate expiration, string mode, bool deqFlag);
 #endif
 
 		// NSEventMask must be casted to nuint to preserve the NSEventMask.Any special value on 64 bit systems. NSEventMask is not [Native].

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -519,8 +519,18 @@ namespace AppKit {
 		void EndSheet (NSWindow  sheet, nint returnCode);
 	
 		[Export ("nextEventMatchingMask:untilDate:inMode:dequeue:"), Protected]
+		NSEvent NextEvent (nuint mask, [NullAllowed] NSDate expiration, NSString runLoopMode, bool deqFlag);
+
+#if !XAMCORE_4_0
+		[Obsolete ("Use the 'NextEvent (nuint, NSDate, [NSRunLoopMode|NSString], bool)' overloads instead.")]
+		[Wrap ("NextEvent (mask, expiration, (NSString) mode, deqFlag)", IsVirtual = true), Protected]
 		NSEvent NextEvent (nuint mask, NSDate expiration, string mode, bool deqFlag);
-	
+#endif
+
+		// NSEventMask must be casted to nuint to preserve the NSEventMask.Any special value on 64 bit systems. NSEventMask is not [Native].
+		[Wrap ("NextEvent ((nuint) (ulong) mask, expiration, (NSString) runLoopMode.GetConstant (), deqFlag)")]
+		NSEvent NextEvent (NSEventMask mask, NSDate expiration, NSRunLoopMode runLoopMode, bool deqFlag);
+
 		[Export ("discardEventsMatchingMask:beforeEvent:"), Protected]
 		void DiscardEvents (nuint mask, NSEvent lastEvent);
 	

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -527,7 +527,7 @@ namespace AppKit {
 		NSEvent NextEvent (nuint mask, NSDate expiration, string mode, bool deqFlag);
 
 		// NSEventMask must be casted to nuint to preserve the NSEventMask.Any special value on 64 bit systems. NSEventMask is not [Native].
-		[Obsolete ("Use the 'NextEvent (nuint, NSDate, [NSRunLoopMode|NSString], bool)' overloads instead.")]
+		[Obsolete ("Use the 'NextEvent (NSEventMask, NSDate, [NSRunLoopMode|NSString], bool)' overloads instead.")]
 		[Wrap ("NextEvent ((nuint) (ulong) mask, expiration, mode, deqFlag)")]
 		NSEvent NextEvent (NSEventMask mask, NSDate expiration, string mode, bool deqFlag);
 #endif

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -519,21 +519,21 @@ namespace AppKit {
 		void EndSheet (NSWindow  sheet, nint returnCode);
 	
 		[Export ("nextEventMatchingMask:untilDate:inMode:dequeue:"), Protected]
-		NSEvent NextEvent (nuint mask, [NullAllowed] NSDate expiration, NSString runLoopMode, bool deqFlag);
+		NSEvent NextEvent (NSEventMask mask, [NullAllowed] NSDate expiration, NSString runLoopMode, bool deqFlag);
 
 #if !XAMCORE_4_0
-		[Obsolete ("Use the 'NextEvent (nuint, NSDate, [NSRunLoopMode|NSString], bool)' overloads instead.")]
-		[Wrap ("NextEvent (mask, expiration, (NSString) mode, deqFlag)", IsVirtual = true), Protected]
+		[Obsolete ("Use the 'NextEvent (NSEventMask, NSDate, [NSRunLoopMode|NSString], bool)' overloads instead.")]
+		[Wrap ("NextEvent ((NSEventMask) (ulong) mask, expiration, (NSString) mode, deqFlag)", IsVirtual = true), Protected]
 		NSEvent NextEvent (nuint mask, NSDate expiration, string mode, bool deqFlag);
 
 		// NSEventMask must be casted to nuint to preserve the NSEventMask.Any special value on 64 bit systems. NSEventMask is not [Native].
 		[Obsolete ("Use the 'NextEvent (NSEventMask, NSDate, [NSRunLoopMode|NSString], bool)' overloads instead.")]
-		[Wrap ("NextEvent ((nuint) (ulong) mask, expiration, mode, deqFlag)")]
+		[Wrap ("NextEvent (mask, expiration, mode, deqFlag)")]
 		NSEvent NextEvent (NSEventMask mask, NSDate expiration, string mode, bool deqFlag);
 #endif
 
 		// NSEventMask must be casted to nuint to preserve the NSEventMask.Any special value on 64 bit systems. NSEventMask is not [Native].
-		[Wrap ("NextEvent ((nuint) (ulong) mask, expiration, (NSString) runLoopMode.GetConstant (), deqFlag)")]
+		[Wrap ("NextEvent (mask, expiration, runLoopMode.GetConstant (), deqFlag)")]
 		NSEvent NextEvent (NSEventMask mask, NSDate expiration, NSRunLoopMode runLoopMode, bool deqFlag);
 
 		[Export ("discardEventsMatchingMask:beforeEvent:"), Protected]


### PR DESCRIPTION
Fixes xamarin/xamarin-macios#3540
Fixes xamarin/xamarin-macios#3541

The following issues are addressed:

* The `expiration` parameter must allow `null`, it is documented as such.
* The `NSApplication.NextEvent` method now has a NSRunLoopMode overload.
* The `NSApplication.NextEvent` methods  where `mode` is a `string` are now
  deprecated in favour of the `[NSRunLoopMode|NSString]` overloads since
  passing a .NET `string` does not make sense due to pointer equality.