### PR TITLE
[xharness] Fix 'MtouchExtraArgs' casing. Fixes #3516 and #3517.

### DIFF
--- a/tests/xharness/ProjectFileExtensions.cs
+++ b/tests/xharness/ProjectFileExtensions.cs
@@ -324,7 +324,7 @@ namespace xharness
 
 		public static void AddExtraMtouchArgs (this XmlDocument csproj, string value, string platform, string configuration)
 		{
-			AddToNode (csproj, "MTouchExtraArgs", value, platform, configuration);
+			AddToNode (csproj, "MtouchExtraArgs", value, platform, configuration);
 		}
 
 		public static void AddMonoBundlingExtraArgs (this XmlDocument csproj, string value, string platform, string configuration)


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/3516.
Fixes https://github.com/xamarin/xamarin-macios/issues/3517.