### PR TITLE
[healthkit] Fix typos in 'HKInsulinDeliveryReason' and 'HKBloodGlucoseMealTime' (#3503)

### DIFF
--- a/src/HealthKit/Enums.cs
+++ b/src/HealthKit/Enums.cs
@@ -534,15 +534,27 @@ namespace HealthKit
 	[Watch (4, 0), iOS (11, 0)]
 	[Native]
 	public enum HKInsulinDeliveryReason : long {
-		Asal = 1,
-		Olus,
+		Basal = 1,
+		Bolus,
+#if !XAMCORE_4_0
+		[Obsolete ("Use 'Basal' instead.")]
+		Asal = Basal,
+		[Obsolete ("Use 'Bolus' instead.")]
+		Olus = Bolus,
+#endif
 	}
 
 	[Watch (4, 0), iOS (11, 0)]
 	[Native]
 	public enum HKBloodGlucoseMealTime : long {
-		Reprandial = 1,
-		Ostprandial,
+		Preprandial = 1,
+		Postprandial,
+#if !XAMCORE_4_0
+		[Obsolete ("Use 'Preprandial' instead.")]
+		Reprandial = Preprandial,
+		[Obsolete ("Use 'Postprandial' instead.")]
+		Ostprandial = Postprandial,
+#endif
 	}
 
 	[Watch (4, 0), iOS (11, 0)]

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -91,7 +91,6 @@ namespace Introspection
 			"Anglet",
 			"Arraycollation",
 			"Argb",
-			"Asal",
 			"Asin",
 			"Atan",
 			"Ats",	// App Transport Security
@@ -339,11 +338,9 @@ namespace Introspection
 			"Ocsp", // Online Certificate Status Protocol
 			"Octree",
 			"Oid",
-			"Olus",
 			"Oneup", // TVElementKeyOneupTemplate
 			"Orthographyrange",
 			"Orth",
-			"Ostprandial",
 			"ove",
 			"Paeth", // PNG filter
 			"Parms", // short for Parameters
@@ -382,7 +379,6 @@ namespace Introspection
 			"Reinvitation",
 			"Reinvite",
 			"Rel",
-			"Reprandial",
 			"Replayable",
 			"Requestwith",
 			"Ridesharing",
@@ -763,13 +759,17 @@ namespace Introspection
 #endif
 #if !XAMCORE_4_0
 			"Actionfrom",
+			"Asal", // Typo, should be 'Basal', fixed in 'HKInsulinDeliveryReason'
 			"Attributefor",
 			"Attributest",
 			"Failwith",
 			"Imageimage",
 			"Musthold",
+			"Olus", // Typo, should be 'Bolus', fixed in 'HKInsulinDeliveryReason'
+			"Ostprandial", // Typo, should be 'Postprandial', fixed in 'HKBloodGlucoseMealTime'
 			"Pathpath",
 			"Rangefor",
+			"Reprandial", // Typo, should be 'Preprandial', fixed in 'HKBloodGlucoseMealTime'
 			"Failwith",
 			"Tearm",
 			"Theevent",


### PR DESCRIPTION
- Fixes https://github.com/xamarin/xamarin-macios/issues/3499
(HKBloodGlucoseMealTime misspellings in bindings)
- 'HKInsulinDeliveryReason' [doc](https://developer.apple.com/documentation/healthkit/hkinsulindeliveryreason?language=objc)
- 'HKBloodGlucoseMealTime' [doc](https://developer.apple.com/documentation/healthkit/hkbloodglucosemealtime?language=objc)
- Commented ApiTypoTest.