### PR TITLE
[tests] Fix NoFatCorlib to succeed when compiling a Xamarin.Sdk.framework

### DIFF
--- a/tests/linker/ios/link all/LinkAllTest.cs
+++ b/tests/linker/ios/link all/LinkAllTest.cs
@@ -579,6 +579,9 @@ namespace LinkAll {
 		public void NoFatCorlib ()
 		{
 			var corlib = typeof (int).Assembly.Location;
+			// special location when we build a shared (app and extensions) framework for mono
+			if (corlib.EndsWith ("/Frameworks/Xamarin.Sdk.framework/MonoBundle/mscorlib.dll", StringComparison.Ordinal))
+				Assert.Pass (corlib);
 #if __WATCHOS__
 			var suffix = "link all.appex/mscorlib.dll";
 #else


### PR DESCRIPTION
A different location is needed when we build the SDK as a framework
and our bots (that test on devices) are running this configuration