### PR TITLE
[tests] Fix NSDataTest.Https to use a site with a valid and complete certificate chain. Fixes #644. (#3549)

### DIFF
--- a/tests/monotouch-test/Foundation/NSDataTest.cs
+++ b/tests/monotouch-test/Foundation/NSDataTest.cs
@@ -145,7 +145,7 @@ namespace MonoTouchFixtures.Foundation {
 				Assert.Ignore ("NSData.FromUrl doesn't seem to work in watchOS");
 			}
 #endif
-			using (var url = new NSUrl ("https://blog.xamarin.com/robots.txt"))
+			using (var url = new NSUrl ("https://www.microsoft.com/robots.txt"))
 			using (var x = NSData.FromUrl (url)) {
 				Assert.That ((x != null) && (x.Length > 0));
 			}


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/644.