### PR TITLE
[mtouch] Find the link context for code shared app extensions in the static registrar. Fixes #3514. (#3545)

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -531,7 +531,7 @@ namespace Registrar {
 
 		public Xamarin.Tuner.DerivedLinkContext LinkContext {
 			get {
-				return Target?.LinkContext;
+				return Target?.GetLinkContext ();
 			}
 		}
 

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -62,6 +62,18 @@ namespace Xamarin.Bundler {
 			this.StaticRegistrar = new StaticRegistrar (this);
 		}
 
+		// This will find the link context, possibly looking in container targets.
+		public PlatformLinkContext GetLinkContext ()
+		{
+			if (LinkContext != null)
+				return LinkContext;
+#if MTOUCH
+			if (App.IsExtension && App.IsCodeShared)
+				return ContainerTarget.GetLinkContext ();
+#endif
+			return null;
+		}
+
 		public bool CachedLink {
 			get {
 				return cached_link;

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -105,6 +105,7 @@ namespace Xamarin.Bundler {
 		public bool IsExtension;
 		public List<string> Extensions = new List<string> (); // A list of the extensions this app contains.
 		public List<Application> AppExtensions = new List<Application> ();
+		public Application ContainerApp; // For extensions, this is the containing app
 
 		public bool? EnablePie;
 		public bool NativeStrip = true;

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -68,6 +68,14 @@ namespace Xamarin.Bundler
 			}
 		}
 
+		// If this is an app extension, this returns the equivalent (32/64bit) target for the container app.
+		// This may be null (it's possible to build an extension for 32+64bit, and the main app only for 64-bit, for instance.
+		public Target ContainerTarget {
+			get {
+				return App.ContainerApp.Targets.FirstOrDefault ((v) => v.Is32Build == Is32Build);
+			}
+		}
+
 		// This is a list of all the architectures we need to build, which may include any architectures
 		// in any extensions (but not the main app).
 		List<Abi> all_architectures;

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1380,7 +1380,9 @@ namespace Xamarin.Bundler
 						if (!File.Exists (f_path))
 							continue;
 						Action app_action;
-						app.AppExtensions.Add (ParseArguments (File.ReadAllLines (f_path), out app_action));
+						var ext = ParseArguments (File.ReadAllLines (f_path), out app_action);
+						ext.ContainerApp = app;
+						app.AppExtensions.Add (ext);
 						if (app_action != Action.Build)
 							throw ErrorHelper.CreateError (99, "Internal error: Extension build action is '{0}' when it should be 'Build'. Please file a bug report with a test case (http://bugzilla.xamarin.com).", app_action);
 					}


### PR DESCRIPTION
When code sharing is enabled, only the container app/target will have a
LinkContext.

So make sure the static registrar finds that link context when it needs
information from the linker.

Fixes https://github.com/xamarin/xamarin-macios/issues/3514.