### PR TITLE
[registrar] Fix resolving linked away generic types. Fixes #3523. (#3539)

### DIFF
--- a/tests/linker/ios/link all/LinkAllTest.cs
+++ b/tests/linker/ios/link all/LinkAllTest.cs
@@ -574,6 +574,23 @@ namespace LinkAll {
 			Assert.Null (oifd,  atmb.FullName + ".ObjectIdForDebugger");
 #endif
 		}
+
+		[Test]
+		public void LinkedAwayGenericTypeAsOptionalMemberInProtocol ()
+		{
+			// https://github.com/xamarin/xamarin-macios/issues/3523
+			// This test will fail at build time if it regresses (usually these types of build tests go into monotouch-test, but monotouch-test uses NSSet<T> elsewhere, which this test requires to be linked away).
+			Assert.IsNull (typeof (NSObject).Assembly.GetType (NamespacePrefix + "Foundation.NSSet`1"), "NSSet<T> must be linked away, otherwise this test is useless");
+		}
+
+		[Protocol (Name = "ProtocolWithGenericsInOptionalMember", WrapperType = typeof (ProtocolWithGenericsInOptionalMemberWrapper))]
+		[ProtocolMember (IsRequired = false, IsProperty = false, IsStatic = false, Name = "ConfigureView", Selector = "configureViewForParameters:", ParameterType = new Type [] { typeof (global::Foundation.NSSet<global::Foundation.NSString>) }, ParameterByRef = new bool [] { false })]
+		public interface IProtocolWithGenericsInOptionalMember : INativeObject, IDisposable { }
+
+		internal sealed class ProtocolWithGenericsInOptionalMemberWrapper : BaseWrapper, IProtocolWithGenericsInOptionalMember
+		{
+			public ProtocolWithGenericsInOptionalMemberWrapper (IntPtr handle, bool owns) : base (handle, owns) { }
+		}
 	}
 
 	[Introduced (PlatformName.MacOSX, 1, 0, PlatformArchitecture.Arch64)]

--- a/tests/linker/ios/link all/link all.csproj
+++ b/tests/linker/ios/link all/link all.csproj
@@ -39,7 +39,7 @@
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchArch>i386, x86_64</MtouchArch>
     <DefineConstants>LINKALL;;$(DefineConstants)</DefineConstants>
-    <MtouchExtraArgs>--optimize=all,-remove-dynamic-registrar</MtouchExtraArgs>
+    <MtouchExtraArgs>--registrar:static --optimize=all,-remove-dynamic-registrar</MtouchExtraArgs>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -482,6 +482,8 @@ namespace Registrar {
 			// this method if there's an actual need.
 			if (tr is ArrayType arrayType) {
 				return arrayType.ElementType.Resolve ();
+			} else if (tr is GenericInstanceType git) {
+				return ResolveType (git.ElementType);
 			} else {
 				var td = tr.Resolve ();
 				if (td == null)


### PR DESCRIPTION
* [registrar] Fix resolving linked away generic types. Fixes #3523.

Fixes #3523.

* [tests] Use a link all test instead of mtouch test.

It's much faster, since we're already building link all everywhere.

* [tests] Use the static registrar in all linkall simulator configurations.