### PR TITLE
[modelio] MDLVoxelArray should have a base type of MDLObject

### DIFF
--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -2089,13 +2089,7 @@ namespace ModelIO {
 	}
 
 	[iOS (9,0),Mac(10,11, onlyOn64 : true)]
-	[BaseType (
-#if MONOMAC && !XAMCORE_4_0
-		typeof(NSObject)
-#else
-		typeof(MDLObject)
-#endif
-	)]
+	[BaseType (typeof(MDLObject))]
 	[DisableDefaultCtor]
 	interface MDLVoxelArray
 	{

--- a/tests/xtro-sharpie/macOS-ModelIO.todo
+++ b/tests/xtro-sharpie/macOS-ModelIO.todo
@@ -1,1 +1,0 @@
-!wrong-base-type! MDLVoxelArray expected MDLObject actual NSObject


### PR DESCRIPTION
Moving the base type to `MDLObject` wasn't a breaking change on macOS.
There is no reason for the ifdef and xtro reports the issue correctly.