### PR TITLE
[src] Fix csc warnings.

### DIFF
--- a/src/AudioUnit/AudioUnit.cs
+++ b/src/AudioUnit/AudioUnit.cs
@@ -402,7 +402,9 @@ namespace AudioUnit
 
 	public class AudioUnit : IDisposable, ObjCRuntime.INativeObject
 	{
+#pragma warning disable 649 // Field 'AudioUnit.handle' is never assigned to, and will always have its default value
 		internal IntPtr handle;
+#pragma warning restore 649
 		public IntPtr Handle {
 			get {
 				return handle;

--- a/src/ObjCRuntime/Blocks.cs
+++ b/src/ObjCRuntime/Blocks.cs
@@ -38,6 +38,7 @@ using ObjCRuntime;
 
 namespace ObjCRuntime {
 
+#pragma warning disable 649 //  Field 'XamarinBlockDescriptor.ref_count' is never assigned to, and will always have its default value 0
 	[StructLayout (LayoutKind.Sequential)]
 #if !XAMCORE_2_0
 	public 
@@ -49,6 +50,7 @@ namespace ObjCRuntime {
 		public IntPtr dispose;
 		public IntPtr signature;
 	}
+#pragma warning restore 649
 
 	struct XamarinBlockDescriptor {
 		public BlockDescriptor descriptor;


### PR DESCRIPTION
Now that we've switched to csc, we're also delighted to get new warnings 🎉

    ObjCRuntime/Blocks.cs(54,26): warning CS0649: Field 'XamarinBlockDescriptor.descriptor' is never assigned to, and will always have its default value
    AudioUnit/AudioUnit.cs(405,19): warning CS0649: Field 'AudioUnit.handle' is never assigned to, and will always have its default value
    ObjCRuntime/Blocks.cs(55,23): warning CS0649: Field 'XamarinBlockDescriptor.ref_count' is never assigned to, and will always have its default value 0
    ObjCRuntime/Blocks.cs(54,26): warning CS0649: Field 'XamarinBlockDescriptor.descriptor' is never assigned to, and will always have its default value
    AudioUnit/AudioUnit.cs(405,19): warning CS0649: Field 'AudioUnit.handle' is never assigned to, and will always have its default value
    ObjCRuntime/Blocks.cs(55,23): warning CS0649: Field 'XamarinBlockDescriptor.ref_count' is never assigned to, and will always have its default value 0

We're so delighted that we want them gone asap 😎