### PR TITLE
[introspection] Don't process IKPictureTaker, it may crash at any time.

### DIFF
--- a/tests/introspection/Mac/MacApiCtorInitTest.cs
+++ b/tests/introspection/Mac/MacApiCtorInitTest.cs
@@ -191,6 +191,11 @@ namespace Introspection {
 				if (!Mac.CheckSystemVersion (10, 12) || IntPtr.Size != 8)
 					return true;
 				break;
+			case "MonoMac.ImageKit.IKPictureTaker":
+			case "ImageKit.IKPictureTaker":
+				// https://bugzilla.xamarin.com/show_bug.cgi?id=46624
+				// https://trello.com/c/T6vkA2QF/62-29311598-ikpicturetaker-crashes-randomly-upon-deallocation?menu=filter&filter=corenfc
+				return true;
 			}
 
 			return base.Skip (type);


### PR DESCRIPTION
See also https://bugzilla.xamarin.com/show_bug.cgi?id=46624, where the same
logic was applied to apitest.

Ref: https://trello.com/c/T6vkA2QF/62-29311598-ikpicturetaker-crashes-randomly-upon-deallocation?menu=filter&filter=corenfc