### PR TITLE
[xharness] Don't try to execute an empty collection of tests. Fixes xamarin/maccore#600.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -3402,6 +3402,11 @@ function oninitialload ()
 
 		protected override async Task ExecuteAsync ()
 		{
+			if (Tasks.All ((v) => v.Ignored)) {
+				ExecutionResult = TestExecutingResult.Ignored;
+				return;
+			}
+
 			// First build everything. This is required for the run simulator
 			// task to properly configure the simulator.
 			build_timer.Start ();


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/600.