### PR TITLE
[tests][macos] Fix AuthenticodeDeformatterTest.VerifySignedAssembly failure on modern. Fixes 3207

### DIFF
--- a/tests/common/mac/MacTestMain.cs
+++ b/tests/common/mac/MacTestMain.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using Mono.Security.Cryptography;
 #if XAMCORE_2_0 || __UNIFIED__
 using AppKit;
 using Foundation;
@@ -25,6 +27,8 @@ namespace Xamarin.Mac.Tests
 #if !NO_GUI_TESTING
 			NSApplication.Init();
 #endif
+			if (CryptoConfig.CreateFromName ("MD2") == null)
+				CryptoConfig.AddAlgorithm (typeof (MD2Managed), "MD2");
 			RunTests (args);
 		}
 

--- a/tests/common/mac/MacTestMain.cs
+++ b/tests/common/mac/MacTestMain.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-using Mono.Security.Cryptography;
 #if XAMCORE_2_0 || __UNIFIED__
 using AppKit;
 using Foundation;
@@ -27,8 +26,12 @@ namespace Xamarin.Mac.Tests
 #if !NO_GUI_TESTING
 			NSApplication.Init();
 #endif
+#if MOBILE
+			// there is no machine.config supplied in the modern profile
+			// even if one is provided it would not be linker friendly
 			if (CryptoConfig.CreateFromName ("MD2") == null)
-				CryptoConfig.AddAlgorithm (typeof (MD2Managed), "MD2");
+				CryptoConfig.AddAlgorithm (typeof (Mono.Security.Cryptography.MD2Managed), "MD2");
+#endif
 			RunTests (args);
 		}
 

--- a/tests/xharness/BCLTestInfo.cs
+++ b/tests/xharness/BCLTestInfo.cs
@@ -199,6 +199,7 @@ namespace xharness
 				inputProject.SetTargetFrameworkVersion ("v2.0");
 				inputProject.RemoveNode ("UseXamMacFullFramework");
 				inputProject.AddAdditionalDefines ("MOBILE;XAMMAC");
+				inputProject.AddReference ("Mono.Security");
 				break;
 			case MacFlavors.Full:
 				inputProject.AddAdditionalDefines ("XAMMAC_4_5");

--- a/tests/xharness/ProjectFileExtensions.cs
+++ b/tests/xharness/ProjectFileExtensions.cs
@@ -245,6 +245,16 @@ namespace xharness
 			SetAssemblyReference (csproj, "Xamarin.iOS", value);
 		}
 
+		public static void AddReference (this XmlDocument csproj, string projectName)
+		{
+			var reference = csproj.SelectSingleNode ("/*/*/*[local-name() = 'Reference' and @Include = 'System']");
+			var node = csproj.CreateElement ("Reference", MSBuild_Namespace);
+			var include_attribute = csproj.CreateAttribute ("Include");
+			include_attribute.Value = projectName;
+			node.Attributes.Append (include_attribute);
+			reference.ParentNode.AppendChild (node);
+		}
+
 		public static void SetAssemblyReference (this XmlDocument csproj, string current, string value)
 		{
 			var project = csproj.ChildNodes [1];


### PR DESCRIPTION
Modern does not, by default/design, ship a machine.config file. This
means it only knowns about the default crypto shipped with .NET.

That's a problem for MD2 for which some old certificates might still
exists in the computer store, like our wrench bots.

That's generally not a problem since XM apps delegate trust to macOS
except for one case: Authenticode.

So verifying an authenticode signature can end up, thru X509Chain,
loading a certificate using MD2 without knowing how to create the
digest algorithm - and fail.

The fix is to register the algorithm manually (if not found).

https://github.com/xamarin/xamarin-macios/issues/3207