### PR TITLE
[xharness] Propagate custom defines to referenced projects as well. Fixes maccore #655.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -245,8 +245,16 @@ namespace xharness
 							clone.Xml.AddMonoBundlingExtraArgs (bundling_extra_args, task.ProjectPlatform, configuration);
 						if (!string.IsNullOrEmpty (link_mode))
 							clone.Xml.SetNode (isMac ? "LinkMode" : "MtouchLink", link_mode, task.ProjectPlatform, configuration);
-						if (!string.IsNullOrEmpty (defines))
+						if (!string.IsNullOrEmpty (defines)) {
 							clone.Xml.AddAdditionalDefines (defines, task.ProjectPlatform, configuration);
+							if (clone.ProjectReferences != null) {
+								foreach (var pr in clone.ProjectReferences) {
+									pr.Xml.AddAdditionalDefines (defines, task.ProjectPlatform, configuration);
+									pr.Xml.Save (pr.Path);
+								}
+							}
+							
+						}
 						clone.Xml.SetNode (isMac ? "Profiling" : "MTouchProfiling", profiling ? "True" : "False", task.ProjectPlatform, configuration);
 
 						if (!debug && !isMac)

--- a/tests/xharness/ProjectFileExtensions.cs
+++ b/tests/xharness/ProjectFileExtensions.cs
@@ -661,7 +661,7 @@ namespace xharness
 					continue;
 
 				var defines = csproj.CreateElement ("DefineConstants", MSBuild_Namespace);
-				defines.InnerText = value;
+				defines.InnerText = "$(DefineConstants);" + value;
 				xmlnode.AppendChild (defines);
 				return;
 			}

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -19,6 +19,8 @@ namespace xharness
 		public bool GenerateVariations = true;
 		public string [] Configurations;
 
+		public IEnumerable<TestProject> ProjectReferences;
+
 		public TestProject ()
 		{
 		}
@@ -120,11 +122,14 @@ namespace xharness
 			}
 			doc.ResolveAllPaths (original_path);
 
+			var projectReferences = new List<TestProject> ();
 			foreach (var pr in doc.GetProjectReferences ()) {
 				var tp = new TestProject (pr.Replace ('\\', '/'));
 				await tp.CreateCopyAsync (test);
 				doc.SetProjectReferenceInclude (pr, tp.Path.Replace ('/', '\\'));
+				projectReferences.Add (tp);
 			}
+			this.ProjectReferences = projectReferences;
 
 			doc.Save (Path);
 		}


### PR DESCRIPTION
The ProtocolTest test is located in the bindings-test assembly, and it
requires certain conditional compilation defines to be set in order to behave
properly.

With this fix we correctly set these defines when cloning the bindings-test
project (in addition to when we set the defines for the main project, which is
either monotouch-test or linkall for this test).

Fixes https://github.com/xamarin/maccore/issues/655.