### PR TITLE
[runtime] Fix exception marshalling when the dynamic registrar is removed.

### DIFF
--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -47,7 +47,7 @@
 			"int", "int", "exc_handle"
 		) {
 			WrappedManagedFunction = "UnwrapNSException",
-			OnlyDynamicUsage = true,
+			OnlyDynamicUsage = false,
 		},
 
 		new XDelegate ("MonoObject *", "IntPtr", "xamarin_get_block_wrapper_creator",
@@ -232,7 +232,7 @@
 			"MonoReflectionType *", "IntPtr", "type"
 		) {
 			WrappedManagedFunction = "TypeGetFullName",
-			OnlyDynamicUsage = true,
+			OnlyDynamicUsage = false,
 		},
 
 		new XDelegate ("char *", "IntPtr", "xamarin_lookup_managed_type_name",


### PR DESCRIPTION
This can be reproduced by running monotouch-test with all optimizations in
Debug mode (because some of the exception marshalling tests are only enabled
in debug mode), so add such a configuration to xharness. To avoid bloating PR
builds, this configuration is only enabled when running all tests (either
manually selecting all tests for a PR, or on Wrench, where everything is
always tested).