### PR TITLE
[xharness] Always build the test libraries before doing anything else. (#3601)

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -874,6 +874,7 @@ namespace xharness
 					populating = false;
 				}).Wait ();
 				GenerateReport ();
+				BuildTestLibraries ();
 				if (!IsServerMode) {
 					foreach (var task in Tasks)
 						tasks.Add (task.RunAsync ());
@@ -890,6 +891,11 @@ namespace xharness
 
 		public bool IsServerMode {
 			get { return Harness.JenkinsConfiguration == "server"; }
+		}
+
+		void BuildTestLibraries ()
+		{
+			ProcessHelper.ExecuteCommandAsync ("make", $"all -j{Environment.ProcessorCount} -C {StringUtils.Quote (Path.Combine (Harness.RootDirectory, "test-libraries"))}", MainLog, TimeSpan.FromMinutes (1)).Wait ();
 		}
 
 		Task RunTestServer ()


### PR DESCRIPTION
Fixes an issue where multiple projects would try to build the test libraries simultaneously.