### PR TITLE
[static registrar] Make sure to include frameworks for linked away protocol types as well. (#3617)

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2763,8 +2763,7 @@ namespace Registrar {
 							any_protocols = true;
 							iface.Append (tp.Protocols [p].ProtocolName);
 							var proto = tp.Protocols [p].Type;
-							if (!IsLinkedAway (proto))
-								CheckNamespace (proto, exceptions);
+							CheckNamespace (proto, exceptions);
 						}
 					}
 					if (App.Optimizations.RegisterProtocols == true && tp.AdoptedProtocols != null) {


### PR DESCRIPTION
At some point the code wasn't able to figure out the framework for linked away
types (because linked away types don't know which assembly they belong to, and
thus we couldn't verify that the type in question was a platform type or not),
so I skipped checking the namespace for such types.

Some time later I implemented support for storing the assembly for a linked
away type separately, so that it can later be looked up, and thus it's not
necessary to exclude linked away types anymore.

This fixes a build problem with the generated registrar code (which happens
only if the INCWidgetProviding interface is linked away) when building the
linkall extension tests:

    /work/maccore/master/xamarin-macios/tests/xharness/tmp-test-dir/link all1894/obj/iPhone/Debug64-today-extension/mtouch-cache/registrar.h:319:51: error: no type or protocol named 'NCWidgetProviding'
    @interface TodayViewController : UIViewController<NCWidgetProviding> {
                                                      ^