### PR TITLE
[mtouch] Propagate the computed value for removal of the dynamic registrar to code shared app extensions. (#3622)

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1531,6 +1531,26 @@ public class B : A {}
 		}
 
 		[Test]
+		public void MT0113_dynamicregistrarremoval ()
+		{
+			using (var extension = new MTouchTool ()) {
+				extension.CreateTemporaryServiceExtension ();
+				extension.CreateTemporaryCacheDirectory ();
+				extension.Abi = "arm64";
+				extension.Optimize = new string [] { "remove-dynamic-registrar" };
+				extension.AssertExecute (MTouchAction.BuildDev, "build extension");
+				using (var app = new MTouchTool ()) {
+					app.AppExtensions.Add (extension);
+					app.CreateTemporaryApp ();
+					app.CreateTemporaryCacheDirectory ();
+					app.WarnAsError = new int [] { 113 };
+					app.AssertExecuteFailure (MTouchAction.BuildDev, "build app");
+					app.AssertError (113, "Native code sharing has been disabled for the extension 'testServiceExtension' because the remove-dynamic-registrar optimization differ between the container app (true) and the extension (default).");
+				}
+			}
+		}
+
+		[Test]
 		public void CodeSharingExactContentsDifferentPaths ()
 		{
 			// Test that we allow code sharing when the exact same assembly (based on file content)

--- a/tools/linker/CoreTypeMapStep.cs
+++ b/tools/linker/CoreTypeMapStep.cs
@@ -161,6 +161,16 @@ namespace MonoTouch.Tuner {
 				// been disabled, then we can remove it!
 				LinkContext.App.Optimizations.RemoveDynamicRegistrar = !dynamic_registration_support_required;
 				Driver.Log (4, "Optimization dynamic registrar removal: {0}", LinkContext.App.Optimizations.RemoveDynamicRegistrar.Value ? "enabled" : "disabled");
+#if MTOUCH
+				var app = LinkContext.App;
+				if (app.IsCodeShared) {
+					foreach (var appex in app.AppExtensions) {
+						if (!appex.IsCodeShared)
+							continue;
+						appex.Optimizations.RemoveDynamicRegistrar = app.Optimizations.RemoveDynamicRegistrar;
+					}
+				}
+#endif
 			}
 		}
 

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -976,6 +976,16 @@ namespace Xamarin.Bundler {
 					continue;
 				}
 
+				if (Optimizations.RemoveDynamicRegistrar != appex.Optimizations.RemoveDynamicRegistrar) {
+					Func<bool?, string> bool_tostr = (v) => {
+						if (!v.HasValue)
+							return "default";
+						return v.Value ? "true" : "false";
+					};
+					ErrorHelper.Warning (113, "Native code sharing has been disabled for the extension '{0}' because {1}", appex.Name, $"the remove-dynamic-registrar optimization differ between the container app ({bool_tostr (appex.Optimizations.RemoveDynamicRegistrar)}) and the extension ({bool_tostr (Optimizations.RemoveDynamicRegistrar)}).");
+					continue;
+				}
+
 				bool applicable = true;
 				// The --assembly-build-target arguments must be identical.
 				// We can probably lift this requirement (at least partially) at some point,


### PR DESCRIPTION
This fixes a startup crash in code shared app extensions due to having the
wrong value set in the runtime (the dynamic registrar was removed, but the
executable didn't know it).