### PR TITLE
[xtro] Avoid duplicate 'close' p/invoke across frameworks

### DIFF
--- a/src/CoreFoundation/DispatchSource.cs
+++ b/src/CoreFoundation/DispatchSource.cs
@@ -482,7 +482,7 @@ namespace XamCore.CoreFoundation {
 			extern static int open (string path, int flags);
 
 			[DllImport (Constants.libcLibrary)]
-			extern static int close (int fd);
+			internal extern static int close (int fd);
 			
 			public VnodeMonitor (string path, VnodeMonitorKind vnodeKind, DispatchQueue queue = null)
 			{

--- a/src/Darwin/KernelNotification.cs
+++ b/src/Darwin/KernelNotification.cs
@@ -28,6 +28,7 @@
 #if MONOMAC
 
 using System;
+using XamCore.CoreFoundation;
 using XamCore.ObjCRuntime;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
@@ -151,9 +152,6 @@ namespace XamCore.Darwin {
 		[DllImport (Constants.SystemLibrary)]
 		extern static int /* int */ kqueue ();
 
-		[DllImport (Constants.SystemLibrary)]
-		extern static int /* int */ close (int /* int */ fd);
-
 		public KernelQueue ()
 		{
 			handle = kqueue ();
@@ -173,7 +171,7 @@ namespace XamCore.Darwin {
 		protected virtual void Dispose (bool disposing)
 		{
 			if (handle != -1){
-				close (handle);
+				DispatchSource.VnodeMonitor.close (handle);
 				handle = -1;
 			}
 		}

--- a/tests/xtro-sharpie/macOS-ObjCRuntime.ignore
+++ b/tests/xtro-sharpie/macOS-ObjCRuntime.ignore
@@ -18,6 +18,6 @@
 !unknown-pinvoke! aslresponse_free bound
 !unknown-pinvoke! aslresponse_next bound
 
+## used in src/Darwin/KernelNotification.cs
 !unknown-pinvoke! kevent bound
 !unknown-pinvoke! kqueue bound
-!unknown-pinvoke! close bound


### PR DESCRIPTION
Depending on the metadata order the symbol will be reported against a
different framework and cause false positives.

Re-using one of the declaration solves this - even if they should,
ideally, be moved to a separated/shared type (like one per fx)

reference:
https://github.com/xamarin/maccore/issues/638

note: a different fix will be needed on master wrt XamCore changes