### PR TITLE
[mmp] Add stripping of 32-bit dylibs to work with new App Store restr…

### DIFF
--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -235,6 +235,8 @@ Mixed-mode assemblies can not be processed by the linker.
 
 See https://msdn.microsoft.com/en-us/library/x0w2664k.aspx for more information on mixed-mode assemblies.
 
+<!-- 2015 used by mtouch -->
+
 ### <a name="MM2106"/>MM2106: Could not optimize the call to BlockLiteral.SetupBlock[Unsafe] in * at offset * because *.
 
 The linker reports this warning when it can't optimize a call to BlockLiteral.SetupBlock or Block.SetupBlockUnsafe.
@@ -257,6 +259,15 @@ To remove the warning either remove the optimization argument to mmp, or pass
 
 By default this option will be automatically enabled whenever it's possible
 and safe to do so.
+
+### <a name="MM2108"/>MM2108: '{0}' was stripped of architectures except '{1}' to comply with App Store restrictions. This could break exisiting codesigning signatures. Consider stripping the library with lipo or disabling with --optimize=-trim-architectures");
+
+The App Store now rejects applications which contain libraries and frameworks which contain 32-bit variants. The library was stripped of unused archtectures when copied into the final application bundle.
+
+This is in general safe, and will reduce application bundle size as an added benefit. However, any bundled framework that is code signed will have its signature invalidated (and resigned later if the application is signed).
+
+Consider using `lipo` to remove the unnecessary archtectures permanently from the source library. If the application is not being published to the App Store, this removal can be disabled by passing --optimize=-trim-architectures as Additional MMP Arguments.
+
 
 # MM3xxx: AOT
 
@@ -362,6 +373,8 @@ See the [equivalent mtouch warning](mtouch-errors.md#MT5218).
 ### <a name="MM5309">MM5309: Native linking failed with error code 1.  Check build log for details.
 
 ### <a name="MM5310">MM5310: install_name_tool failed with an error code '{0}'. Check build log for details.
+
+### <a name="MM5311">MM5311: lipo failed with an error code '{0}'. Check build log for details.
 
 <!-- MM6xxx: mmp internal tools -->
 <!-- MM7xxx: reserved -->

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -1325,6 +1325,8 @@ To remove the warning either remove the optimization argument to mtouch, or pass
 By default this option will be automatically enabled whenever it's possible
 and safe to do so.
 
+<!-- 2018 used by mmp -->
+
 # MT3xxx: AOT error messages
 
 <!--
@@ -1979,6 +1981,7 @@ An error occurred when signing the application. Please review the build log to s
 <!-- 5308 is used by mmp -->
 <!-- 5309 is used by mmp -->
 <!-- 5310 is used by mmp -->
+<!-- 5311 is used by mmp -->
 
 # MT6xxx: mtouch internal tools error messages
 

--- a/tests/common/MachO.cs
+++ b/tests/common/MachO.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Xamarin.Tests
+{
+	public static class MachO
+	{
+		public static List<string> GetArchitectures (string file)
+		{
+			var result = new List<string> ();
+
+			using (var fs = File.OpenRead (file)) {
+				using (var reader = new BinaryReader (fs)) {
+					int magic = reader.ReadInt32 ();
+					switch ((uint) magic) {
+					case 0xCAFEBABE: // little-endian fat binary
+						throw new NotImplementedException ("little endian fat binary");
+					case 0xBEBAFECA:
+						int architectures = System.Net.IPAddress.NetworkToHostOrder (reader.ReadInt32 ());
+						for (int i = 0; i < architectures; i++) {
+							result.Add (GetArch (System.Net.IPAddress.NetworkToHostOrder (reader.ReadInt32 ()), System.Net.IPAddress.NetworkToHostOrder (reader.ReadInt32 ())));
+							// skip to next entry
+							reader.ReadInt32 (); // offset
+							reader.ReadInt32 (); // size
+							reader.ReadInt32 (); // align
+						}
+						break;
+					case 0xFEEDFACE: // little-endian mach-o header
+					case 0xFEEDFACF: // little-endian 64-big mach-o header
+						result.Add (GetArch (reader.ReadInt32 (), reader.ReadInt32 ()));
+						break;
+					case 0xCFFAEDFE:
+					case 0xCEFAEDFE:
+						result.Add (GetArch (System.Net.IPAddress.NetworkToHostOrder (reader.ReadInt32 ()), System.Net.IPAddress.NetworkToHostOrder (reader.ReadInt32 ())));
+						break;
+					default:
+						throw new Exception (string.Format ("File '{0}' is neither a Universal binary nor a Mach-O binary (magic: 0x{1})", file, magic.ToString ("x")));
+					}
+				}
+			}
+
+			return result;
+		}
+
+		static string GetArch (int cputype, int cpusubtype)
+		{
+			const int ABI64 = 0x01000000;
+			const int X86 = 7;
+			const int ARM = 12;
+
+			switch (cputype) {
+			case ARM : // arm
+				switch (cpusubtype) {
+				case 6: return "armv6";
+				case 9: return "armv7";
+				case 11: return "armv7s";
+				default:
+					return "unknown arm variation: " + cpusubtype.ToString ();
+				}
+			case ARM  | ABI64:
+				switch (cpusubtype) {
+				case 0:
+					return "arm64";
+				default:
+					return "unknown arm/64 variation: " + cpusubtype.ToString ();
+				}
+			case X86: // x86
+				return "i386";
+			case X86 | ABI64: // x64
+				return "x86_64";
+			}
+
+			return string.Format ("unknown: {0}/{1}", cputype, cpusubtype);
+		}
+	}
+}

--- a/tests/common/mac/SystemMonoExample.csproj
+++ b/tests/common/mac/SystemMonoExample.csproj
@@ -19,13 +19,22 @@
     <CreatePackage>false</CreatePackage>
     <EnablePackageSigning>false</EnablePackageSigning>
     <IncludeMonoRuntime>false</IncludeMonoRuntime>
-    <UseSGen>false</UseSGen>
-    <UseRefCounting>false</UseRefCounting>
+    <WarningLevel>4</WarningLevel>
+    <Optimize>false</Optimize>
+    <DebugSymbols>true</DebugSymbols>
+   <Profiling>false</Profiling>
+%CODE%
+   </PropertyGroup>
+   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <EnableCodeSigning>false</EnableCodeSigning>
+    <CreatePackage>false</CreatePackage>
+    <EnablePackageSigning>false</EnablePackageSigning>
+    <IncludeMonoRuntime>false</IncludeMonoRuntime>
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
     <DebugSymbols>true</DebugSymbols>
 %CODE%
-  <Profiling>false</Profiling><XamMacArch>x86_64</XamMacArch><CodeSigningKey>Mac Developer</CodeSigningKey><PackageSigningKey>Developer ID Installer</PackageSigningKey></PropertyGroup>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/tests/common/mac/UnifiedExample.csproj
+++ b/tests/common/mac/UnifiedExample.csproj
@@ -13,15 +13,31 @@
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug</OutputPath>
     <EnableCodeSigning>false</EnableCodeSigning>
     <CreatePackage>false</CreatePackage>
     <EnablePackageSigning>false</EnablePackageSigning>
     <IncludeMonoRuntime>false</IncludeMonoRuntime>
-    <UseSGen>false</UseSGen>
-    <UseRefCounting>false</UseRefCounting>
+    <UseSGen>true</UseSGen>
+    <UseRefCounting>true</UseRefCounting>
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
+%CODE%
+    </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <EnableCodeSigning>false</EnableCodeSigning>
+    <CreatePackage>false</CreatePackage>
+    <EnablePackageSigning>false</EnablePackageSigning>
+    <IncludeMonoRuntime>true</IncludeMonoRuntime>
+    <UseSGen>true</UseSGen>
+    <UseRefCounting>true</UseRefCounting>
+    <LinkMode>SdkOnly</LinkMode>
 %CODE%
   </PropertyGroup>
   <ItemGroup>

--- a/tests/common/mac/XM45Example.csproj
+++ b/tests/common/mac/XM45Example.csproj
@@ -15,18 +15,28 @@
     <UseXamMacFullFramework>true</UseXamMacFullFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug</OutputPath>
     <EnableCodeSigning>false</EnableCodeSigning>
     <CreatePackage>false</CreatePackage>
     <EnablePackageSigning>false</EnablePackageSigning>
-    <IncludeMonoRuntime>false</IncludeMonoRuntime>
-    <UseSGen>false</UseSGen>
-    <UseRefCounting>false</UseRefCounting>
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
 %CODE%
     <Profiling>false</Profiling>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <EnableCodeSigning>false</EnableCodeSigning>
+    <CreatePackage>false</CreatePackage>
+    <EnablePackageSigning>false</EnablePackageSigning>
+%CODE%
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -96,6 +96,13 @@
     <Compile Include="..\common\BundlerTool.cs">
       <Link>BundlerTool.cs</Link>
     </Compile>
+    <Compile Include="src\CodeStrippingTests.cs" />
+    <Compile Include="..\common\MachO.cs">
+      <Link>MachO.cs</Link>
+    </Compile>
+    <Compile Include="..\..\tools\common\StringUtils.cs">
+      <Link>StringUtils.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/mmptest/src/CodeStrippingTests.cs
+++ b/tests/mmptest/src/CodeStrippingTests.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+using Xamarin.Utils;
+
+namespace Xamarin.MMP.Tests
+{
+	public class CodeStrippingTests
+	{
+		static Func<string, bool> LipoStripConditional = s => s.Contains ("lipo") && s.Contains ("-thin");
+		static Func<string, bool> LipoStripSkipPosixConditional = s => LipoStripConditional (s) && !s.Contains ("libMonoPosixHelper.dylib");
+
+		static Func<string, bool> DidAnyLipoStrip = output => output.SplitLines ().Any (LipoStripConditional);
+		static Func<string, bool> DidAnyLipoStripSkipPosix = output => output.SplitLines ().Any (LipoStripSkipPosixConditional);
+
+		static TI.UnifiedTestConfig CreateStripTestConfig (bool? strip, string tmpDir, string additionalMMPArgs = "")
+		{
+			TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { };
+
+			if (strip.HasValue)
+				test.CSProjConfig = $"<MonoBundlingExtraArgs>--optimize={(strip.Value ? "+" : "-")}trim-architectures {additionalMMPArgs}</MonoBundlingExtraArgs>";
+			else if (!string.IsNullOrEmpty (additionalMMPArgs))
+				test.CSProjConfig = $"<MonoBundlingExtraArgs>{additionalMMPArgs}</MonoBundlingExtraArgs>";
+			
+			return test;
+		}
+
+		void AssertStrip (string libPath, bool shouldStrip)
+		{
+			var archsFound = Xamarin.Tests.MachO.GetArchitectures (libPath);
+			if (shouldStrip) {
+				Assert.AreEqual (1, archsFound.Count, "Did not contain one archs");
+				Assert.True (archsFound.Contains ("x86_64"), "Did not contain x86_64");
+			} else {
+				Assert.AreEqual (2, archsFound.Count, "Did not contain two archs");
+				Assert.True (archsFound.Contains ("i386"), "Did not contain i386");
+				Assert.True (archsFound.Contains ("x86_64"), "Did not contain x86_64");
+			}
+		}
+
+		void StripTestCore (TI.UnifiedTestConfig test, bool debugStrips, bool releaseStrips, string libPath, bool shouldWarn)
+		{
+			string buildOutput = TI.TestUnifiedExecutable (test).BuildOutput;
+			Assert.AreEqual (debugStrips, DidAnyLipoStrip (buildOutput), "Debug lipo usage did not match expectations");
+			AssertStrip (Path.Combine (test.TmpDir, "bin/Debug/UnifiedExample.app/", libPath), shouldStrip: debugStrips);
+			Assert.AreEqual (shouldWarn && debugStrips, buildOutput.Contains ("MM2108"), "Debug warning did not match expectations");
+
+			test.Release = true;
+			buildOutput = TI.TestUnifiedExecutable (test).BuildOutput;
+			Assert.AreEqual (releaseStrips, DidAnyLipoStrip (buildOutput), "Release lipo usage did not match expectations");
+			AssertStrip (Path.Combine (test.TmpDir, "bin/Release/UnifiedExample.app/", libPath), shouldStrip: releaseStrips);
+			Assert.AreEqual (shouldWarn && releaseStrips, buildOutput.Contains ("MM2108"), "Release warning did not match expectations");
+		}
+
+		[TestCase (null, false, true)]
+		[TestCase (true, true, true)]
+		[TestCase (false, false, false)]
+		public void ShouldStripMonoPosixHelper (bool? strip, bool debugStrips, bool releaseStrips)
+		{
+			MMPTests.RunMMPTest (tmpDir =>
+			{
+				TI.UnifiedTestConfig test = CreateStripTestConfig (strip, tmpDir);
+
+				StripTestCore (test, debugStrips, releaseStrips, "Contents/MonoBundle/libMonoPosixHelper.dylib", shouldWarn: false);
+			});
+		}
+
+		[TestCase (null, false, true)]
+		[TestCase (true, true, true)]
+		[TestCase (false, false, false)]
+		public void ShouldStripUserFramework (bool? strip, bool debugStrips, bool releaseStrips)
+		{
+			MMPTests.RunMMPTest (tmpDir =>
+			{
+				var frameworkPath = FrameworkBuilder.CreateFatFramework (tmpDir);
+				TI.UnifiedTestConfig test = CreateStripTestConfig (strip, tmpDir, $"--native-reference={frameworkPath}");
+
+				StripTestCore (test, debugStrips, releaseStrips, "Contents/Frameworks/Foo.framework/Foo", shouldWarn: true);
+			});
+		}
+
+		const string MonoPosixOffset = "Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/libMonoPosixHelper.dylib";
+
+		[TestCase (true, true)]
+		[TestCase (false, false)]
+		public void ExplictStripOption_ThirdPartyLibrary_AndWarnsIfSo (bool? strip, bool shouldStrip)
+		{
+			MMPTests.RunMMPTest (tmpDir =>
+			{
+				string originalLocation = Path.Combine (TI.FindRootDirectory (), MonoPosixOffset);
+				string newLibraryLocation =  Path.Combine (tmpDir, "libTest.dylib");
+				File.Copy (originalLocation, newLibraryLocation);
+
+				TI.UnifiedTestConfig test = CreateStripTestConfig (strip, tmpDir, $" --native-reference=\"{newLibraryLocation}\"");
+				test.Release = true;
+
+				string buildOutput = TI.TestUnifiedExecutable (test).BuildOutput;
+				Assert.AreEqual (shouldStrip, DidAnyLipoStrip (buildOutput), "lipo usage did not match expectations");
+				Assert.AreEqual (shouldStrip, buildOutput.Contains ("MM2108"), "Warning did not match expectations");
+			});
+		}
+
+		void AssertNoLipoOrWarning (string buildOutput, string context)
+		{
+			Assert.False (DidAnyLipoStrip (buildOutput), "lipo incorrectly run in context: " + context + "\n" + buildOutput);
+			Assert.False (buildOutput.Contains ("MM2108"), "MM2108 incorrectly given in in context: " + context + "\n" + buildOutput);
+		}
+
+		void AssertLipoOnlyMonoPosix (string buildOutput, string context)
+		{
+			Assert.False (DidAnyLipoStripSkipPosix (buildOutput), "lipo incorrectly run in context outside of libMonoPosixHelper: " + context + "\n" + buildOutput);
+			Assert.False (buildOutput.Contains ("MM2108"), "MM2108 incorrectly given in in context: " + context + "\n" + buildOutput);
+		}
+
+		[TestCase (false)]
+		[TestCase (true)]
+		public void ThirdPartyLibrary_WithIncorrectBitness_ShouldWarnOnRelease (bool sixtyFourBits)
+		{
+			MMPTests.RunMMPTest (tmpDir =>
+			{
+				var frameworkPath = FrameworkBuilder.CreateFatFramework (tmpDir);
+
+				TI.UnifiedTestConfig test = CreateStripTestConfig (null, tmpDir, $" --native-reference=\"{frameworkPath}\"");
+
+				// Should always skip lipo/warning in Debug
+				string buildOutput = TI.TestUnifiedExecutable(test).BuildOutput;
+				AssertNoLipoOrWarning (buildOutput, "Debug");
+
+				// Should always lipo/warn in Release
+				test.Release = true;
+				buildOutput = TI.TestUnifiedExecutable (test).BuildOutput;
+				Assert.True (DidAnyLipoStrip (buildOutput), $"lipo did not run in release\n{buildOutput}");
+				Assert.True (buildOutput.Contains ("MM2108"), $"MM2108 not given in release\n{buildOutput}");
+
+			});
+		}
+
+		[TestCase]
+		public void ThirdPartyLibrary_WithCorrectBitness_ShouldNotStripOrWarn ()
+		{
+			MMPTests.RunMMPTest (tmpDir =>
+			{
+				var frameworkPath = FrameworkBuilder.CreateThinFramework (tmpDir);
+
+				TI.UnifiedTestConfig test = CreateStripTestConfig (null, tmpDir, $" --native-reference=\"{frameworkPath}\"");
+
+				string buildOutput = TI.TestUnifiedExecutable (test).BuildOutput;
+				AssertNoLipoOrWarning (buildOutput, "Debug");
+
+				test.Release = true;
+				buildOutput = TI.TestUnifiedExecutable (test).BuildOutput;
+				AssertLipoOnlyMonoPosix (buildOutput, "Release"); // libMonoPosixHelper.dylib will lipo in Release
+			});
+		}
+	}
+}

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2301,7 +2301,7 @@ public class TestApp {
 					var mono_framework = Path.Combine (app.AppPath, "Frameworks", "Mono.framework", "Mono");
 					Assert.That (mono_framework, Does.Exist, "mono framework existence");
 					// Verify that mtouch removed armv7s from the framework.
-					Assert.That (GetArchitectures (mono_framework), Is.EquivalentTo (new [] { "armv7", "arm64" }), "mono framework architectures");
+					Assert.That (MachO.GetArchitectures (mono_framework), Is.EquivalentTo (new [] { "armv7", "arm64" }), "mono framework architectures");
 				}
 			}
 		}
@@ -4032,7 +4032,7 @@ public class TestApp {
 
 		static void VerifyArchitectures (string file, string message, params string[] expected)
 		{
-			var actual = GetArchitectures (file).ToArray ();
+			var actual = MachO.GetArchitectures (file).ToArray ();
 
 			Array.Sort (expected);
 			Array.Sort (actual);
@@ -4059,74 +4059,6 @@ public class TestApp {
 				text.AppendFormat ("Expected error/warning not shown ({0}):\n\t{1}\n", msg, a);
 			if (text.Length != 0)
 				Assert.Fail (text.ToString ());
-		}
-
-		static List<string> GetArchitectures (string file)
-		{
-			var result = new List<string> ();
-
-			using (var fs = File.OpenRead (file)) {
-				using (var reader = new BinaryReader (fs)) {
-					int magic = reader.ReadInt32 ();
-					switch ((uint) magic) {
-					case 0xCAFEBABE: // little-endian fat binary
-						throw new NotImplementedException ("little endian fat binary");
-					case 0xBEBAFECA:
-						int architectures = System.Net.IPAddress.NetworkToHostOrder (reader.ReadInt32 ());
-						for (int i = 0; i < architectures; i++) {
-							result.Add (GetArch (System.Net.IPAddress.NetworkToHostOrder (reader.ReadInt32 ()), System.Net.IPAddress.NetworkToHostOrder (reader.ReadInt32 ())));
-							// skip to next entry
-							reader.ReadInt32 (); // offset
-							reader.ReadInt32 (); // size
-							reader.ReadInt32 (); // align
-						}
-						break;
-					case 0xFEEDFACE: // little-endian mach-o header
-					case 0xFEEDFACF: // little-endian 64-big mach-o header
-						result.Add (GetArch (reader.ReadInt32 (), reader.ReadInt32 ()));
-						break;
-					case 0xCFFAEDFE:
-					case 0xCEFAEDFE:
-						result.Add (GetArch (System.Net.IPAddress.NetworkToHostOrder (reader.ReadInt32 ()), System.Net.IPAddress.NetworkToHostOrder (reader.ReadInt32 ())));
-						break;
-					default:
-						throw new Exception (string.Format ("File '{0}' is neither a Universal binary nor a Mach-O binary (magic: 0x{1})", file, magic.ToString ("x")));
-					}
-				}
-			}
-
-			return result;
-		}
-
-		static string GetArch (int cputype, int cpusubtype)
-		{
-			const int ABI64 = 0x01000000;
-			const int X86 = 7;
-			const int ARM = 12;
-
-			switch (cputype) {
-			case ARM : // arm
-				switch (cpusubtype) {
-				case 6: return "armv6";
-				case 9: return "armv7";
-				case 11: return "armv7s";
-				default:
-					return "unknown arm variation: " + cpusubtype.ToString ();
-				}
-			case ARM  | ABI64:
-				switch (cpusubtype) {
-				case 0:
-					return "arm64";
-				default:
-					return "unknown arm/64 variation: " + cpusubtype.ToString ();
-				}
-			case X86: // x86
-				return "i386";
-			case X86 | ABI64: // x64
-				return "x86_64";
-			}
-
-			return string.Format ("unknown: {0}/{1}", cputype, cpusubtype);
 		}
 
 		public static void AssertDeviceAvailable ()

--- a/tests/mtouch/mtouch.csproj
+++ b/tests/mtouch/mtouch.csproj
@@ -69,6 +69,9 @@
     <Compile Include="..\common\BundlerTool.cs">
       <Link>BundlerTool.cs</Link>
     </Compile>
+    <Compile Include="..\common\MachO.cs">
+      <Link>MachO.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -134,7 +134,7 @@ namespace Xamarin.Bundler {
 #if MONOTOUCH
 					"    inline-isdirectbinding: By default enabled (requires the linker). Tries to inline calls to NSObject.IsDirectBinding to load a constant value. Makes the app smaller, and slightly faster at runtime.\n" +
 #else
-					"    inline-isdirectbinding: By default disabled, because it may  (requires the linker), because . Tries to inline calls to NSObject.IsDirectBinding to load a constant value. Makes the app smaller, and slightly faster at runtime.\n" +
+					"    inline-isdirectbinding: By default disabled, because it may require the linker. Tries to inline calls to NSObject.IsDirectBinding to load a constant value. Makes the app smaller, and slightly faster at runtime.\n" +
 #endif
 #if MONOTOUCH
 					"    remove-dynamic-registrar: By default enabled when the static registrar is enabled. Removes the dynamic registrar (makes the app smaller).\n" +
@@ -143,7 +143,12 @@ namespace Xamarin.Bundler {
 					"    blockliteral-setupblock: By default enabled when using the static registrar. Optimizes calls to BlockLiteral.SetupBlock to avoid having to calculate the block signature at runtime.\n" +
 					"    inline-intptr-size: By default enabled for builds that target a single architecture (requires the linker). Inlines calls to IntPtr.Size to load a constant value. Makes the app smaller, and slightly faster at runtime.\n" +
 					"    inline-dynamic-registration-supported: By default always enabled (requires the linker). Optimizes calls to Runtime.DynamicRegistrationSupported to be a constant value. Makes the app smaller, and slightly faster at runtime.\n" +
-					"    register-protocols: Remove unneeded metadata for protocol support. Makes the app smaller and reduces memory requirements.\n",
+					"    register-protocols: Remove unneeded metadata for protocol support. Makes the app smaller and reduces memory requirements.\n" +
+#if !MONOTOUCH
+					"    trim-architectures: Remove unneeded architectures from bundled native libraries. Makes the app smaller and is required for macOS App Store submissions.\n",
+#else
+					"",
+#endif
 					(v) => {
 						app.Optimizations.Parse (v);
 					});

--- a/tools/common/MachO.cs
+++ b/tools/common/MachO.cs
@@ -11,6 +11,25 @@ using Xamarin.Bundler;
 
 namespace Xamarin
 {
+	[Flags]
+	public enum Abi {
+		None   =   0,
+		i386   =   1,
+		ARMv6  =   2,
+		ARMv7  =   4,
+		ARMv7s =   8,
+		ARM64 =   16,
+		x86_64 =  32,
+		Thumb  =  64,
+		LLVM   = 128,
+		ARMv7k = 256,
+		SimulatorArchMask = i386 | x86_64,
+		DeviceArchMask = ARMv6 | ARMv7 | ARMv7s | ARMv7k | ARM64,
+		ArchMask = SimulatorArchMask | DeviceArchMask,
+		Arch64Mask = x86_64 | ARM64,
+		Arch32Mask = i386 | ARMv6 | ARMv7 | ARMv7s | ARMv7k,
+	}
+
 	public class MachO
 	{
 		/* definitions from: /usr/include/mach-o/loader.h */
@@ -305,7 +324,6 @@ namespace Xamarin
 			return result;
 		}
 
-#if MTOUCH
 		public static List<Abi> GetArchitectures (string file)
 		{
 			var result = new List<Abi> ();
@@ -409,7 +427,6 @@ namespace Xamarin
 			
 			return true;
 		}
-#endif
 	}
 
 	public class StaticLibrary

--- a/tools/common/Optimizations.cs
+++ b/tools/common/Optimizations.cs
@@ -23,6 +23,11 @@ namespace Xamarin.Bundler
 #else
 			"", // dummy value to make indices match up between XM and XI
 #endif
+#if MONOTOUCH
+			"", // dummy value to make indices match up between XM and XI
+#else
+			"trim-architectures",
+#endif
 		};
 
 		enum Opt
@@ -36,6 +41,7 @@ namespace Xamarin.Bundler
 			RegisterProtocols,
 			InlineDynamicRegistrationSupported,
 			RemoveDynamicRegistrar,
+			TrimArchitectures,
 		}
 
 		bool? [] values;
@@ -79,6 +85,11 @@ namespace Xamarin.Bundler
 			get { return values [(int) Opt.RemoveDynamicRegistrar]; }
 			set { values [(int) Opt.RemoveDynamicRegistrar] = value; }
 		}
+		
+		public bool? TrimArchitectures {
+			get { return values [(int) Opt.TrimArchitectures]; }
+			set { values [(int) Opt.TrimArchitectures] = value; }
+		}
 
 		public Optimizations ()
 		{
@@ -92,6 +103,8 @@ namespace Xamarin.Bundler
 				if (!values [i].HasValue)
 					continue;
 				switch ((Opt) i) {
+				case Opt.TrimArchitectures:
+					break; // Does not require linker
 				case Opt.RegisterProtocols:
 				case Opt.RemoveDynamicRegistrar:
 					if (app.Registrar != RegistrarMode.Static) {
@@ -180,6 +193,12 @@ namespace Xamarin.Bundler
 #endif
 				}
 			}
+
+#if !MONOTOUCH
+			// By default on macOS trim-architectures for Release and not for debug 
+			if (!TrimArchitectures.HasValue)
+				TrimArchitectures = !app.EnableDebug;
+#endif
 
 			if (Driver.Verbosity > 3)
 				Driver.Log (4, "Enabled optimizations: {0}", string.Join (", ", values.Select ((v, idx) => v == true ? opt_names [idx] : string.Empty).Where ((v) => !string.IsNullOrEmpty (v))));

--- a/tools/common/StringUtils.cs
+++ b/tools/common/StringUtils.cs
@@ -65,4 +65,9 @@ namespace Xamarin.Utils {
 			return Version.Parse (v);
 		}
 	}
+
+	static class StringExtensions
+	{
+		public static string [] SplitLines (this string s) => s.Split (new [] { Environment.NewLine }, StringSplitOptions.None);
+	}
 }

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1171,6 +1171,9 @@ namespace Xamarin.Bundler {
 			CreateDirectoryIfNeeded (frameworks_dir);
 			Application.UpdateDirectory (framework, frameworks_dir);
 			frameworks_copied_to_bundle_dir = true;
+
+			if (App.Optimizations.TrimArchitectures == true)
+				LipoLibrary (framework, Path.Combine (name, Path.Combine (frameworks_dir, name + ".framework", name)));
 		}
 
 		static int Compile ()
@@ -1632,7 +1635,7 @@ namespace Xamarin.Bundler {
 			if (ignored_assemblies.Contains (library))
 				return;
 
-			// If we're as passed in framework, ignore
+			// If we're passed in a framework, ignore
 			if (App.Frameworks.Contains (library))
 				return;
 
@@ -1695,6 +1698,11 @@ namespace Xamarin.Bundler {
 			}
 
 			bool isStaticLib = real_src.EndsWith (".a", StringComparison.Ordinal);
+			bool isDynamicLib = real_src.EndsWith (".dylib", StringComparison.Ordinal);
+
+			if (isDynamicLib && App.Optimizations.TrimArchitectures == true)
+				LipoLibrary (name, dest);
+
 			if (native_references.Contains (real_src)) {
 				if (!isStaticLib) {
 					int ret = XcodeRun ("install_name_tool -id", string.Format ("{0} {1}", StringUtils.Quote("@executable_path/../" + BundleName + "/" + name), StringUtils.Quote(dest)));
@@ -1722,6 +1730,21 @@ namespace Xamarin.Bundler {
 						ProcessNativeLibrary (processed, lib, null);
 				}
 			}
+		}
+
+		static void LipoLibrary (string name, string dest)
+		{
+			var existingArchs = Xamarin.MachO.GetArchitectures (dest);
+			// If we have less than two, it will either match by default or 
+			// we'll fail a link/launch time with a better error so bail
+			if (existingArchs.Count () < 2)
+				return;
+
+			int ret = XcodeRun ("lipo", $"{StringUtils.Quote (dest)} -thin {arch} -output {StringUtils.Quote (dest)}");
+			if (ret != 0)
+				throw new MonoMacException (5311, true, "lipo failed with an error code '{0}'. Check build log for details.", ret);
+			if (name != "MonoPosixHelper")
+				ErrorHelper.Warning (2108, $"{name} was stripped of architectures except {arch} to comply with App Store restrictions. This could break exisiting codesigning signatures. Consider stripping the library with lipo or disabling with --optimize=-trim-architectures");
 		}
 
 		static void CreateSymLink (string directory, string real, string link)
@@ -1863,10 +1886,10 @@ namespace Xamarin.Bundler {
 				if (App.EnableDebug) {
 					var mdbfile = asm + ".mdb";
 					if (File.Exists (mdbfile))
-						File.Copy (mdbfile, Path.Combine (mmp_dir, Path.GetFileName (mdbfile)), true);
+						CopyFileAndRemoveReadOnly (mdbfile, Path.Combine (mmp_dir, Path.GetFileName (mdbfile)));
 					var pdbfile = Path.ChangeExtension (asm, ".pdb");
 					if (File.Exists (pdbfile))
-						File.Copy (pdbfile, Path.Combine (mmp_dir, Path.GetFileName (pdbfile)), true);
+						CopyFileAndRemoveReadOnly (pdbfile, Path.Combine (mmp_dir, Path.GetFileName (pdbfile)));
 				}
 				if (File.Exists (configfile))
 					File.Copy (configfile, Path.Combine (mmp_dir, Path.GetFileName (configfile)), true);

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -25,25 +25,6 @@ namespace Xamarin.Bundler {
 		MarkerOnly = 3,
 	}
 
-	[Flags]
-	public enum Abi {
-		None   =   0,
-		i386   =   1,
-		ARMv6  =   2,
-		ARMv7  =   4,
-		ARMv7s =   8,
-		ARM64 =   16,
-		x86_64 =  32,
-		Thumb  =  64,
-		LLVM   = 128,
-		ARMv7k = 256,
-		SimulatorArchMask = i386 | x86_64,
-		DeviceArchMask = ARMv6 | ARMv7 | ARMv7s | ARMv7k | ARM64,
-		ArchMask = SimulatorArchMask | DeviceArchMask,
-		Arch64Mask = x86_64 | ARM64,
-		Arch32Mask = i386 | ARMv6 | ARMv7 | ARMv7s | ARMv7k,
-	}
-
 	public static class AbiExtensions {
 		public static string AsString (this Abi self)
 		{


### PR DESCRIPTION
…ictions (#3387)

- https://github.com/xamarin/xamarin-macios/issues/3367
- App Store will now fail builds if you add in a 32-bit dylib
- If you are a 32-bit app you don't need the 64-bit part of your fat
dylib anyway
- Add --optimize=-trim-architectures to allow customization of behavior, as not everyone
uses app store

In addition, while writing tests for this is was noticed that mmp tests did not "really" run Release configuration correctly in most cases. Fixing this turned out to be a bit of a pain, but necessary to correctly test this (and other things).

- Turns out that /p:configuration:debug is not sufficient to tell mmp to
do the right thing
- That, in most projects, sets the DebugSymbols property, which really
is what is checked.
- However, two of our projects did not have that, so we always did
release mmp work.
- Removed configuration property for tests and added real "Release"
configuration option