### PR TITLE
[msbuild] Use a response file in 'MTouchTaskBase'

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -113,6 +113,19 @@ It is required to specify a root assembly (typically the main executable) when b
 
 Mtouch does not recognize the command line argument mentioned in the error message.
 
+Sometimes this error happens because of how the argument is formatted in the response file passed to `mtouch`.
+
+Always use the command-line option that takes an equal sign or colon instead of a space.
+
+Do either of these:
+
+	`--foo=something`
+	`--foo:something`
+
+instead of this:
+
+	`--foo something`
+
 ### <a name="MT0019"/>MT0019: Only one --[log|install|kill|launch]dev or --[launch|debug]sim option can be used.
 
 There are several options for mtouch that can't be used simultaneously:

--- a/msbuild/Xamarin.MacDev.Tasks.Core/CommandLineArgumentBuilder.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/CommandLineArgumentBuilder.cs
@@ -34,13 +34,25 @@ namespace Xamarin.MacDev
 		/// <summary>
 		/// Adds an argument without escaping or quoting.
 		/// </summary>
-		public void Add (string argument)
+		public void Add (string argument, bool appendLine = false)
 		{
-			if (builder.Length > 0)
+			if (builder.Length > 0 && !appendLine)
 				builder.Append (' ');
 
 			builder.Append (argument);
+
+			if (appendLine)
+				builder.AppendLine ();
+
 			hash.Add (argument);
+		}
+
+		/// <summary>
+		/// Adds an argument without escaping or quoting and goes to the next line
+		/// </summary>
+		public void AddLine (string argument)
+		{
+			Add (argument, true);
 		}
 
 		/// <summary>
@@ -65,7 +77,7 @@ namespace Xamarin.MacDev
 			AddQuoted (string.Format (argumentFormat, val0));
 		}
 
-		static void AppendQuoted (StringBuilder quoted, string text)
+		static void AppendQuoted (StringBuilder quoted, string text, bool appendLine = false)
 		{
 			if (text.IndexOfAny (QuoteSpecials) != -1) {
 				quoted.Append ("\"");
@@ -80,21 +92,32 @@ namespace Xamarin.MacDev
 			} else {
 				quoted.Append (text);
 			}
+
+			if (appendLine)
+				quoted.AppendLine ();
 		}
 
 		/// <summary>Adds an argument, quoting and escaping as necessary.</summary>
 		/// <remarks>The .NET process class does not support escaped 
 		/// arguments, only quoted arguments with escaped quotes.</remarks>
-		public void AddQuoted (string argument)
+		public void AddQuoted (string argument, bool appendLine = false)
 		{
 			if (argument == null)
 				return;
 
-			if (builder.Length > 0)
+			if (builder.Length > 0 && !appendLine)
 				builder.Append (' ');
 
-			AppendQuoted (builder, argument);
+			AppendQuoted (builder, argument, appendLine);
 			hash.Add (argument);
+		}
+
+		/// <summary>
+		/// Adds an argument, quoting, escaping as necessary, and goes to the next line
+		/// </summary>
+		public void AddQuotedLine (string argument)
+		{
+			AddQuoted (argument, true);
 		}
 
 		/// <summary>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -371,70 +371,70 @@ namespace Xamarin.iOS.Tasks
 			if (!string.IsNullOrEmpty (IntermediateOutputPath)) {
 				Directory.CreateDirectory (IntermediateOutputPath);
 
-				args.AddQuoted ("--cache=" + Path.GetFullPath (IntermediateOutputPath));
+				args.AddQuotedLine ($"--cache={Path.GetFullPath (IntermediateOutputPath)}");
 			}
 
-			args.AddQuoted ((SdkIsSimulator ? "--sim=" : "--dev=") + Path.GetFullPath (AppBundleDir));
+			args.AddQuotedLine ((SdkIsSimulator ? "--sim=" : "--dev=") + Path.GetFullPath (AppBundleDir));
 
 			if (AppleSdkSettings.XcodeVersion.Major >= 5 && IPhoneSdks.MonoTouch.Version.CompareTo (new IPhoneSdkVersion (6, 3, 7)) < 0)
 				args.Add ("--compiler=clang");
 
-			args.AddQuoted ("--executable=" + ExecutableName);
+			args.AddQuotedLine ($"--executable={ExecutableName}");
 
 			if (IsAppExtension)
-				args.Add ("--extension");
+				args.AddLine ("--extension");
 
 			if (Debug) {
 				if (FastDev && !SdkIsSimulator)
-					args.Add ("--fastdev");
+					args.AddLine ("--fastdev");
 
-				args.Add ("--debug");
+				args.AddLine ("--debug");
 			}
 
 			if (Profiling)
-				args.Add ("--profiling");
+				args.AddLine ("--profiling");
 
 			if (LinkerDumpDependencies)
-				args.Add ("--linkerdumpdependencies");
+				args.AddLine ("--linkerdumpdependencies");
 
 			if (EnableSGenConc)
-				args.Add ("--sgen-conc");
+				args.AddLine ("--sgen-conc");
 
 			switch (LinkMode.ToLowerInvariant ()) {
-			case "sdkonly": args.Add ("--linksdkonly"); break;
-			case "none":    args.Add ("--nolink"); break;
+			case "sdkonly": args.AddLine ("--linksdkonly"); break;
+			case "none":    args.AddLine ("--nolink"); break;
 			}
 
 			if (!string.IsNullOrEmpty (I18n))
-				args.AddQuotedFormat ("--i18n=" + I18n);
+				args.AddQuotedLine ($"--i18n={I18n}");
 
-			args.AddQuoted ("--sdkroot=" + SdkRoot);
+			args.AddQuotedLine ($"--sdkroot={SdkRoot}");
 
-			args.AddQuoted ("--sdk=" + SdkVersion);
+			args.AddQuotedLine ($"--sdk={SdkVersion}");
 
 			if (!minimumOSVersion.IsUseDefault)
-				args.AddQuoted ("--targetver=" + minimumOSVersion.ToString ());
+				args.AddQuotedLine ($"--targetver={minimumOSVersion.ToString ()}");
 
 			if (UseFloat32 /* We want to compile 32-bit floating point code to use 32-bit floating point operations */)
-				args.Add ("--aot-options=-O=float32");
+				args.AddLine ("--aot-options=-O=float32");
 			else
-				args.Add ("--aot-options=-O=-float32");
+				args.AddLine ("--aot-options=-O=-float32");
 
 			if (!EnableGenericValueTypeSharing)
-				args.Add ("--gsharedvt=false");
+				args.AddLine ("--gsharedvt=false");
 
 			if (LinkDescriptions != null) {
 				foreach (var desc in LinkDescriptions)
-					args.AddQuoted (string.Format ("--xml={0}", desc.ItemSpec));
+					args.AddQuotedLine ($"--xml={desc.ItemSpec}");
 			}
 
 			if (EnableBitcode) {
 				switch (Framework) {
 				case PlatformFramework.WatchOS:
-					args.Add ("--bitcode=full");
+					args.AddLine ("--bitcode=full");
 					break;
 				case PlatformFramework.TVOS:
-					args.Add ("--bitcode=asmonly");
+					args.AddLine ("--bitcode=asmonly");
 					break;
 				default:
 					throw new InvalidOperationException (string.Format ("Bitcode is currently not supported on {0}.", Framework));
@@ -442,7 +442,7 @@ namespace Xamarin.iOS.Tasks
 			}
 
 			if (!string.IsNullOrEmpty (HttpClientHandler))
-				args.Add (string.Format ("--http-message-handler={0}", HttpClientHandler));
+				args.AddLine ($"--http-message-handler={HttpClientHandler}");
 
 			string thumb = UseThumb && UseLlvm ? "+thumb2" : "";
 			string llvm = UseLlvm ? "+llvm" : "";
@@ -484,16 +484,16 @@ namespace Xamarin.iOS.Tasks
 			// Output the CompiledArchitectures
 			CompiledArchitectures = architectures.ToString ();
 
-			args.Add ("--abi=" + abi);
+			args.AddLine ($"--abi={abi}");
 
 			// output symbols to preserve when stripping
-			args.AddQuoted ("--symbollist=" + Path.GetFullPath (SymbolsList));
+			args.AddQuotedLine ($"--symbollist={Path.GetFullPath (SymbolsList)}");
 
 			// don't have mtouch generate the dsyms...
-			args.Add ("--dsym=no");
+			args.AddLine ("--dsym=no");
 
 			if (!string.IsNullOrEmpty (ArchiveSymbols) && bool.TryParse (ArchiveSymbols.Trim (), out msym))
-				args.Add ("--msym=" + (msym ? "yes" : "no"));
+				args.AddLine ($"--msym={(msym ? "yes" : "no")}");
 
 			var gcc = new GccOptions ();
 
@@ -554,7 +554,7 @@ namespace Xamarin.iOS.Tasks
 						}
 					} else {
 						// other user-defined mtouch arguments
-						args.AddQuoted (StringParserService.Parse (argument, customTags));
+						args.AddQuotedLine (StringParserService.Parse (argument, customTags));
 					}
 				}
 			}
@@ -563,18 +563,38 @@ namespace Xamarin.iOS.Tasks
 			BuildEntitlementFlags (gcc);
 
 			foreach (var framework in gcc.Frameworks)
-				args.AddQuoted ("--framework=" + framework);
+				args.AddQuotedLine ($"--framework={framework}");
 
 			foreach (var framework in gcc.WeakFrameworks)
-				args.AddQuoted ("--weak-framework=" + framework);
+				args.AddQuotedLine ($"--weak-framework={framework}");
 
 			if (gcc.Cxx)
-				args.Add ("--cxx");
+				args.AddLine ("--cxx");
 
-			if (gcc.Arguments.Length > 0) {
-				args.Add ("--gcc_flags");
-				args.AddQuoted (gcc.Arguments.ToString ());
+			if (gcc.Arguments.Length > 0)
+				args.AddQuotedLine ($"--gcc_flags {gcc.Arguments.ToString ()}");
+
+			foreach (var asm in References) {
+				if (IsFrameworkItem(asm)) {
+					args.AddQuotedLine ($"-r={ResolveFrameworkFile (asm.ItemSpec)}");
+				} else {
+					args.AddQuotedLine ($"-r={Path.GetFullPath (asm.ItemSpec)}");
+				}
 			}
+
+			foreach (var ext in AppExtensionReferences)
+				args.AddQuotedLine ($"--app-extension={Path.GetFullPath (ext.ItemSpec)}");
+
+			args.AddLine ($"--target-framework={TargetFrameworkIdentifier},{TargetFrameworkVersion}");
+
+			args.AddQuotedLine ($"--root-assembly={Path.GetFullPath (MainAssembly.ItemSpec)}");
+
+			// We give the priority to the ExtraArgs to set the mtouch verbosity.
+			if (string.IsNullOrEmpty (ExtraArgs) || (!string.IsNullOrEmpty (ExtraArgs) && !ExtraArgs.Contains ("-q") && !ExtraArgs.Contains ("-v")))
+				args.AddLine (GetVerbosityLevel (Verbosity));
+
+			if (!string.IsNullOrWhiteSpace (License))
+				args.AddLine ($"--license={License}");
 
 			// Generate a response file
 			var responseFile = Path.GetFullPath (ResponseFilePath);
@@ -584,36 +604,16 @@ namespace Xamarin.iOS.Tasks
 
 			try {
 				using (var fs = File.Create (responseFile)) {
-					using (var writer = new StreamWriter (fs)) {
-						foreach (var asm in References) {
-							if (IsFrameworkItem (asm)) {
-								writer.Write (" -r=" + ResolveFrameworkFile (asm.ItemSpec));
-							} else {
-								writer.Write (" -r=" + Path.GetFullPath (asm.ItemSpec));
-							}
-						}
-					}
+					using (var writer = new StreamWriter (fs))
+						writer.Write (args);
 				}
 			} catch (Exception ex) {
 				Log.LogWarning ("Failed to create response file '{0}': {1}", responseFile, ex);
 			}
 
-			// Use the response file
+			// Use only the response file
+			args = new CommandLineArgumentBuilder ();
 			args.AddQuoted ($"@{responseFile}");
-
-			foreach (var ext in AppExtensionReferences)
-				args.AddQuoted ("--app-extension=" + Path.GetFullPath (ext.ItemSpec));
-
-			args.Add ("--target-framework=" + TargetFrameworkIdentifier + "," + TargetFrameworkVersion);
-
-			args.AddQuoted ("--root-assembly=" + Path.GetFullPath (MainAssembly.ItemSpec));
-
-			// We give the priority to the ExtraArgs to set the mtouch verbosity.
-			if (string.IsNullOrEmpty (ExtraArgs) || (!string.IsNullOrEmpty (ExtraArgs) && !ExtraArgs.Contains ("-q") && !ExtraArgs.Contains ("-v")))
-				args.Add (GetVerbosityLevel (Verbosity));
-
-			if (!string.IsNullOrWhiteSpace (License))
-				args.Add (string.Format("--license={0}", License));
 
 			return args.ToString ();
 		}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -377,7 +377,7 @@ namespace Xamarin.iOS.Tasks
 			args.AddQuotedLine ((SdkIsSimulator ? "--sim=" : "--dev=") + Path.GetFullPath (AppBundleDir));
 
 			if (AppleSdkSettings.XcodeVersion.Major >= 5 && IPhoneSdks.MonoTouch.Version.CompareTo (new IPhoneSdkVersion (6, 3, 7)) < 0)
-				args.Add ("--compiler=clang");
+				args.AddLine ("--compiler=clang");
 
 			args.AddQuotedLine ($"--executable={ExecutableName}");
 
@@ -572,7 +572,7 @@ namespace Xamarin.iOS.Tasks
 				args.AddLine ("--cxx");
 
 			if (gcc.Arguments.Length > 0)
-				args.AddQuotedLine ($"--gcc_flags {gcc.Arguments.ToString ()}");
+				args.AddQuotedLine ($"--gcc_flags={gcc.Arguments.ToString ()}");
 
 			foreach (var asm in References) {
 				if (IsFrameworkItem(asm)) {

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -811,6 +811,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			Profiling="$(MtouchProfiling)"
 			ProjectDir="$(MtouchProjectDirectory)"
 			References="@(ReferencePath);@(MTouchReferencePath)"
+			ResponseFilePath="$(DeviceSpecificIntermediateOutputPath)response-file.rsp"
 			SdkRoot="$(_SdkDevPath)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
 			SdkVersion="$(MtouchSdkVersion)"

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/MTouchTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/MTouchTaskTests.cs
@@ -52,6 +52,7 @@ namespace Xamarin.iOS.Tasks
 			Task.IntermediateOutputPath = Path.Combine ("obj", "mtouch-cache");
 			Task.MainAssembly = new TaskItem ("Main.exe");
 			Task.References = new [] { new TaskItem ("a.dll"), new TaskItem ("b.dll"), new TaskItem ("c.dll") };
+			Task.ResponseFilePath = Path.Combine (Path.GetTempPath (), "response-file.rsp");
 			Task.SdkRoot = "/path/to/sdkroot";
 			Task.SdkVersion = "6.1";
 			Task.SymbolsList = Path.Combine (Path.GetTempPath (), "mtouch-symbol-list");
@@ -199,6 +200,27 @@ namespace Xamarin.iOS.Tasks
 
 				Assert.IsTrue (args.Contains (expectedPath));
 			}
+		}
+
+		[Test]
+		public void ResponseFileTest ()
+		{
+			var args = Task.GenerateCommandLineCommands ();
+			Assert.IsTrue (args.Contains ($"@{Task.ResponseFilePath}"), "#@response-file");
+
+			string responseFile = "";
+			// Check that the response file contains all the references
+			try {
+				using (StreamReader sr = new StreamReader (Task.ResponseFilePath))
+					responseFile = sr.ReadToEnd ();
+			} catch (Exception e) {
+				Assert.Fail ($"The file could not be read: {e.Message}");
+			}
+
+			Assert.IsTrue (responseFile.Contains ("-r="), "#-r=");
+			Assert.IsTrue (responseFile.Contains ("a.dll"), "#a.dll");
+			Assert.IsTrue (responseFile.Contains ("b.dll"), "#b.dll");
+			Assert.IsTrue (responseFile.Contains ("c.dll"), "#c.dll");
 		}
 
 		[TestCase("Xamarin.iOS", "Xamarin.iOS")]


### PR DESCRIPTION
The cause of the warning: "warning MSB6002: The command-line for the 'MTouch' task is too long"
was the number of references that can be passed to `mtouch`. Now all those references (-r) are written in
a response file which in turn is passed to mtouch.

- Fixes bug #56501: MSB6002 command-line for MTouch task is too long, > 32000 characters
(https://bugzilla.xamarin.com/show_bug.cgi?id=56501)
- The response file is created in the device sepcific folder, as `response-file.rsp`. It is re-created every time.
- Added msbuild test to ensure the response file is created by `GenerateCommandLineCommands` and that
  it includes all the references.
- Introduce `AddLine` and `AddQuotedLine` which we use to populate the response file (and go to the next line).
- Move to C# 7 syntax for string replacement.
- Update all tests in MTouchTaskTests to use the response file since the arguments are no longer passed directly to mtouch.