### PR TITLE
[tests] Don't run mmp regression tests in parallel. Fixes maccore #645.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -758,7 +758,7 @@ namespace xharness
 				Jenkins = this,
 				Platform = TestPlatform.Mac,
 				TestName = "MMP Regression Tests",
-				Target = "all -j" + Environment.ProcessorCount,
+				Target = "all", // -j" + Environment.ProcessorCount,
 				WorkingDirectory = Path.Combine (Harness.RootDirectory, "mmptest", "regression"),
 				Ignored = !IncludeMmpTest || !IncludeMac,
 				Timeout = TimeSpan.FromMinutes (30),


### PR DESCRIPTION
For some reason vstool becomes confused and starts erroring out if multiple
vstools are running at the same time.

So work around this by executing the MMP regression tests serialized.

Also pload the logs from the mmp regression tests to make diagnosis easier.

Fixes https://github.com/xamarin/maccore/issues/645.