### PR TITLE
[tests] Don't run mmp regression tests in parallel. Fixes maccore #645. (#3638)

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -758,12 +758,17 @@ namespace xharness
 				Jenkins = this,
 				Platform = TestPlatform.Mac,
 				TestName = "MMP Regression Tests",
-				Target = "all -j" + Environment.ProcessorCount,
+				Target = "all", // -j" + Environment.ProcessorCount,
 				WorkingDirectory = Path.Combine (Harness.RootDirectory, "mmptest", "regression"),
 				Ignored = !IncludeMmpTest || !IncludeMac,
 				Timeout = TimeSpan.FromMinutes (30),
 				SupportsParallelExecution = false, // Already doing parallel execution by running "make -jX"
 			};
+			run_mmp.CompletedTask = new Task (() =>
+			{
+				foreach (var log in Directory.GetFiles (Path.GetFullPath (run_mmp.WorkingDirectory), "*.log", SearchOption.AllDirectories))
+					run_mmp.Logs.AddFile (log, log.Substring (run_mmp.WorkingDirectory.Length + 1));
+			});
 			run_mmp.Environment.Add ("BUILD_REVISION", "jenkins"); // This will print "@MonkeyWrench: AddFile: <log path>" lines, which we can use to get the log filenames.
 			Tasks.Add (run_mmp);
 
@@ -2079,6 +2084,7 @@ function oninitialload ()
 		public Dictionary<string, string> Environment = new Dictionary<string, string> ();
 
 		public Task InitialTask; // a task that's executed before this task's ExecuteAsync method.
+		public Task CompletedTask; // a task that's executed after this task's ExecuteAsync method.
 
 		public void CloneTestProject (TestProject project)
 		{
@@ -2252,6 +2258,12 @@ function oninitialload ()
 
 				execute_task = ExecuteAsync ();
 				await execute_task;
+
+				if (CompletedTask != null) {
+					if (CompletedTask.Status == TaskStatus.Created)
+						CompletedTask.Start ();
+					await CompletedTask;
+				}
 
 				ExecutionResult = (ExecutionResult & ~TestExecutingResult.StateMask) | TestExecutingResult.Finished;
 				if ((ExecutionResult & ~TestExecutingResult.StateMask) == 0)


### PR DESCRIPTION
* [tests] Don't run mmp regression tests in parallel. Fixes maccore #645.

For some reason vstool becomes confused and starts erroring out if multiple
vstools are running at the same time.

So work around this by executing the MMP regression tests serialized.

Fixes https://github.com/xamarin/maccore/issues/645.

* [xharness] Upload the logs from the mmp regression tests.