### PR TITLE
[runtime] Enable signal chaining for Xamarin.Mac apps. (#3631)

### DIFF
--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -528,6 +528,8 @@ app_initialize (xamarin_initialize_data *data)
 
 	initialize_cocoa_threads (NULL);
 	init_logdir ();
+	mono_set_signal_chaining (TRUE);
+	mono_set_crash_chaining (TRUE);
 }
 
 #define __XAMARIN_MAC_RELAUNCH_APP__ "__XAMARIN_MAC_RELAUNCH_APP__"


### PR DESCRIPTION
Reported in the forums: https://forums.xamarin.com/discussion/122594/xamarin-mac-signal-handling