### PR TITLE
[tests] Use NUnit.Runners v2.6.4 for the install sources tests.

### DIFF
--- a/tools/install-source/InstallSourcesTests/packages.config
+++ b/tools/install-source/InstallSourcesTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="NUnit.Runners" version="2.6.3" targetFramework="net40" />
+  <package id="NUnit.Runners" version="2.6.4" />
 </packages>


### PR DESCRIPTION
Since that's what all the other test suites that use NUnit v2 use, and it's
also what xharness expects (and tries to execute).

This fixes running these tests when other tests haven't already restored the
v2.6.4 nuget.