### PR TITLE
[xharness] Only run the install source tests if we're including either Mac or Simulator tests.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -641,6 +641,7 @@ namespace xharness
 				TestName = "Install Sources tests",
 				Mode = "iOS",
 				Timeout = TimeSpan.FromMinutes (60),
+				Ignored = !IncludeMac && !IncludeSimulator,
 			};
 			Tasks.Add (nunitExecutionInstallSource);
 


### PR DESCRIPTION
This means we won't be running these tests when running device tests (which is
not needed).