### PR TITLE
[MMP] Allow resolving assemblies to the ones passed in command line a…

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -524,10 +524,10 @@ namespace Xamarin.Bundler {
 			var resolver = new PlatformResolver () {
 				FrameworkDirectory = Driver.GetPlatformFrameworkDirectory (this),
 				RootDirectory = Path.GetDirectoryName (RootAssembly),
-			};
 #if MMP
-			resolver.RecursiveSearchDirectories.AddRange (Driver.RecursiveSearchDirectories);
+				CommandLineAssemblies = RootAssemblies,
 #endif
+			};
 
 			if (Platform == ApplePlatform.iOS || Platform == ApplePlatform.MacOSX) {
 				if (Is32Build) {

--- a/tools/common/CoreResolver.cs
+++ b/tools/common/CoreResolver.cs
@@ -102,17 +102,17 @@ namespace Xamarin.Bundler {
 			return assembly;
 		}
 
-		protected AssemblyDefinition SearchDirectory (string name, string directory, string extension = ".dll", bool recursive = false)
+		protected AssemblyDefinition SearchDirectory (string name, string directory, string extension = ".dll")
 		{
-			var file = DirectoryGetFile (directory, name + extension, recursive);
+			var file = DirectoryGetFile (directory, name + extension);
 			if (file.Length > 0)
 				return Load (file);
 			return null;
 		}
 
-		static string DirectoryGetFile (string directory, string file, bool recursive)
+		static string DirectoryGetFile (string directory, string file)
 		{
-			var files = Directory.GetFiles (directory, file, recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+			var files = Directory.GetFiles (directory, file);
 			if (files != null && files.Length > 0) {
 				if (files.Length > 1) {
 					ErrorHelper.Warning (133, "Found more than 1 assembly matching '{0}', choosing first:{1}{2}", file, Environment.NewLine, string.Join ("\n", files));

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -83,7 +83,6 @@ namespace Xamarin.Bundler {
 		static string app_name;
 		static bool generate_plist;
 		public static RegistrarMode Registrar { get { return App.Registrar; } private set { App.Registrar = value; } }
-		public static List<string> RecursiveSearchDirectories { get; } = new List<string> ();
 		static bool no_executable;
 		static bool embed_mono = true;
 		static bool? profiling = false;
@@ -310,10 +309,6 @@ namespace Xamarin.Bundler {
 						default:
 							throw new MonoMacException (20, true, "The valid options for '{0}' are '{1}'.", "--registrar", "dynamic, static, partial, or default");
 						}
-					}
-				},
-				{ "recursive-directories:", "Specify extra recursive search directories to use when probing assemblies", v => {
-						RecursiveSearchDirectories.AddRange (v.Split (Path.PathSeparator));
 					}
 				},
 				{ "sdk=", "Specifies the SDK version to compile against (version, for example \"10.9\")",

--- a/tools/mmp/resolver.cs
+++ b/tools/mmp/resolver.cs
@@ -31,8 +31,6 @@ namespace Xamarin.Bundler {
 		public static bool IsClassic { get { return Driver.IsClassic; } }
 		public static bool IsUnified { get { return Driver.IsUnified; } }
 
-		public List<string> RecursiveSearchDirectories { get; } = new List<string> ();
-
 		public List <string> CommandLineAssemblies { get; set; }
 		public List<Exception> Exceptions = new List<Exception> ();
 
@@ -86,12 +84,6 @@ namespace Xamarin.Bundler {
 			assembly = SearchDirectory (name, RootDirectory, ".exe");
 			if (assembly != null)
 				return assembly;
-
-			foreach (var directory in RecursiveSearchDirectories) {
-				assembly = SearchDirectory (name, directory, recursive: true);
-				if (assembly != null)
-					return assembly;
-			}
 
 			return null;
 		}


### PR DESCRIPTION
…rgs (#3575)

* [MMP] Revert recursive search dirs changes
* [MMP] Allow resolving assemblies to the ones passed in command line args

This is what actually makes the MonoMacResolver actually resolve to
assemblies given as arguments.

This mirrors the behaviour of Pack, which is called on the other
code-path (that's not --runregistrar)

https://github.com/xamarin/xamarin-macios/blob/3113c5d2b5cca730372177e9b1cee17062a959ff/tools/mmp/driver.cs#L513

This is a cherry pick of https://github.com/xamarin/xamarin-macios/pull/3575 to d15-7