### PR TITLE
[registrar] Don't throw NRE when finding methods that almost implement optional protocol members.

### DIFF
--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -872,6 +872,103 @@ class X : ReplayKit.RPBroadcastControllerDelegate
 		}
 
 		[Test]
+		public void MT4174 ()
+		{
+			using (var mtouch = new MTouchTool ()) {
+				var code = @"
+namespace NS {
+	using System;
+	using Foundation;
+	using ObjCRuntime;
+
+	public class Consumer : NSObject, IProtocolWithOptionalMembers
+	{
+		[Export (""resolveRecipientsForSearchForMessages:withCompletion:"")]
+		public void ResolveRecipients (int arg, Action<bool> completion)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+
+
+	[Protocol (Name = ""INSendMessageIntentHandling"", WrapperType = typeof (ProtocolWithOptionalMembersWrapper))]
+	[ProtocolMember (IsRequired = false, IsProperty = false, IsStatic = false, Name = ""ResolveRecipients"", Selector = ""resolveRecipientsForSendMessage:withCompletion:"", ParameterType = new Type [] { typeof (bool), typeof (global::System.Action<bool>) }, ParameterByRef = new bool [] { false, false })]
+	public interface IProtocolWithOptionalMembers : INativeObject, IDisposable
+	{
+	}
+
+	public static partial class ProtocolWithOptionalMembers_Extensions {
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		public static void ResolveRecipients (this IProtocolWithOptionalMembers This, bool arg, [BlockProxy (typeof (NIDActionArity1V89))]global::System.Action<bool> completion)
+		{
+		}
+	}
+
+	internal sealed class ProtocolWithOptionalMembersWrapper : BaseWrapper, IProtocolWithOptionalMembers {
+		[Preserve (Conditional = true)]
+		public ProtocolWithOptionalMembersWrapper (IntPtr handle, bool owns)
+			: base (handle, owns)
+		{
+		}
+	}
+
+	[UserDelegateType (typeof (global::System.Action<bool>))]
+	internal delegate void DActionArity1V89 (IntPtr block, IntPtr obj);
+
+	static internal class SDActionArity1V89 {
+		static internal readonly DActionArity1V89 Handler = Invoke;
+
+		[MonoPInvokeCallback (typeof (DActionArity1V89))]
+		static void Invoke (IntPtr block, IntPtr obj) {
+			throw new NotImplementedException ();
+		}
+	}
+
+	internal class NIDActionArity1V89 {
+		IntPtr blockPtr;
+		DActionArity1V89 invoker;
+
+		[Preserve (Conditional=true)]
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		public NIDActionArity1V89 (ref BlockLiteral block)
+		{
+			throw new NotImplementedException ();
+		}
+
+		[Preserve (Conditional=true)]
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		~NIDActionArity1V89 ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		[Preserve (Conditional=true)]
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		public static global::System.Action<bool> Create (IntPtr block)
+		{
+			throw new NotImplementedException ();
+		}
+
+		[Preserve (Conditional=true)]
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		void Invoke (bool obj)
+		{
+		}
+	}
+}
+
+";
+				mtouch.Linker = MTouchLinker.DontLink; // faster
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.CreateTemporaryApp (extraCode: code, extraArg: "-debug");
+				mtouch.WarnAsError = new int [] { 4174 };
+				mtouch.AssertExecuteFailure ("build");
+				mtouch.AssertError (4174, "Unable to locate the block to delegate conversion method for the method NS.Consumer.ResolveRecipients's parameter #2.", "testApp.cs", 11);
+				mtouch.AssertErrorCount (1);
+			}
+		}
+
+		[Test]
 		public void NoWarnings ()
 		{
 			using (var mtouch = new MTouchTool ()) {

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -4096,8 +4096,12 @@ namespace Registrar {
 							if (!TypeMatch (pMethod.Parameters [i], method.Parameters [i].ParameterType))
 								continue;
 						MethodDefinition extensionMethod = pMethod.Method;
-						if (extensionMethod == null)
+						if (extensionMethod == null) {
 							MapProtocolMember (obj_method.Method, out extensionMethod);
+							if (extensionMethod == null)
+								return null;
+						}
+													
 						var createMethod = GetBlockProxyAttributeMethod (extensionMethod, parameter + 1);
 						if (createMethod != null)
 							return createMethod;


### PR DESCRIPTION
If a class implements a protocol with optional members, and that class also exports methods whose selectors match an optional member, but the signature doesn't match, we must show a useful warning instead of erroring out due to a NullReferenceException.

Fixes this:

    System.NullReferenceException: Object reference not set to an instance of an object
      at Registrar.StaticRegistrar.GetBlockProxyAttributeMethod (Mono.Cecil.MethodDefinition method, System.Int32 parameter) [0x00001] in /Users/builder/data/lanes/1381/9de35b83/source/xamarin-macios/tools/common/StaticRegistrar.cs:4113
      at Registrar.StaticRegistrar.GetBlockWrapperCreator (Registrar.Registrar+ObjCMethod obj_method, System.Int32 parameter) [0x001e1] in /Users/builder/data/lanes/1381/9de35b83/source/xamarin-macios/tools/common/StaticRegistrar.cs:4101
      at Registrar.StaticRegistrar.Specialize (Registrar.AutoIndentStringBuilder sb, Registrar.Registrar+ObjCMethod method, System.Collections.Generic.List`1[T] exceptions) [0x0216b] in /Users/builder/data/lanes/1381/9de35b83/source/xamarin-macios/tools/common/StaticRegistrar.cs:3683

when building the msbuild/tests/MyWatchKit2IntentsExtension project.