### PR TITLE
[xharness] Don't count the skipped tests as failed

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1367,9 +1367,10 @@ namespace xharness
 					markdown_summary.Write ($"# Test run in progress: ");
 					markdown_summary.Write (string.Join (", ", list));
 					markdown_summary.WriteLine ();
-				} else if (failedTests.Any () || skippedTests.Any ()) {
-					var skipped = skippedTests.Any () ? $" and {skippedTests.Count ()} tests skipped" : "";
-					markdown_summary.WriteLine ($"{failedTests.Count ()} tests failed, {passedTests.Count ()} tests passed{skipped}.");
+				} else if (failedTests.Any ()) {
+					markdown_summary.WriteLine ($"{failedTests.Count ()} tests failed, {skippedTests.Count ()} tests skipped, {passedTests.Count ()} tests passed.");
+				} else if (skippedTests.Any ()) {
+					markdown_summary.WriteLine ($"{skippedTests.Count ()} tests skipped, {passedTests.Count ()} tests passed.");
 				} else if (passedTests.Any ()) {
 					markdown_summary.WriteLine ($"# All {passedTests.Count ()} tests passed");
 				} else {
@@ -1694,7 +1695,7 @@ function toggleAll (show)
 				var headerColor = "black";
 				if (unfinishedTests.Any ()) {
 					; // default
-				} else if (failedTests.Any ()) {
+				} else if (failedTests.Any () || skippedTests.Any ()) {
 					headerColor = "red";
 				} else if (passedTests.Any ()) {
 					headerColor = "green";
@@ -1715,7 +1716,9 @@ function toggleAll (show)
 					writer.Write (string.Join (", ", list));
 					writer.Write (")");
 				} else if (failedTests.Any ()) {
-					writer.Write ($"{failedTests.Count ()} tests failed, {passedTests.Count ()} tests passed.");
+					writer.Write ($"{failedTests.Count ()} tests failed, {skippedTests.Count ()} tests skipped, {passedTests.Count ()} tests passed");
+				} else if (skippedTests.Any ()) {
+					writer.Write ($"{skippedTests.Count ()} tests skipped, {passedTests.Count ()} tests passed");
 				} else if (passedTests.Any ()) {
 					writer.Write ($"All {passedTests.Count ()} tests passed");
 				} else {

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1345,7 +1345,8 @@ namespace xharness
 				allTasks.AddRange (allDeviceTasks);
 			}
 
-			var failedTests = allTasks.Where ((v) => v.Failed || v.Skipped);
+			var failedTests = allTasks.Where ((v) => v.Failed);
+			var skippedTests = allTasks.Where ((v) => v.Skipped);
 			var unfinishedTests = allTasks.Where ((v) => !v.Finished);
 			var passedTests = allTasks.Where ((v) => v.Succeeded);
 			var runningTests = allTasks.Where ((v) => v.Running && !v.Waiting);
@@ -1367,7 +1368,8 @@ namespace xharness
 					markdown_summary.Write (string.Join (", ", list));
 					markdown_summary.WriteLine ();
 				} else if (failedTests.Any ()) {
-					markdown_summary.WriteLine ($"{failedTests.Count ()} tests failed, {passedTests.Count ()} tests passed.");
+					var skipped = skippedTests.Any () ? $" and {skippedTests.Count ()} tests skipped" : "";
+					markdown_summary.WriteLine ($"{failedTests.Count ()} tests failed, {passedTests.Count ()} tests passed{skipped}.");
 				} else if (passedTests.Any ()) {
 					markdown_summary.WriteLine ($"# All {passedTests.Count ()} tests passed");
 				} else {

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1695,8 +1695,10 @@ function toggleAll (show)
 				var headerColor = "black";
 				if (unfinishedTests.Any ()) {
 					; // default
-				} else if (failedTests.Any () || skippedTests.Any ()) {
+				} else if (failedTests.Any ()) {
 					headerColor = "red";
+				} else if (skippedTests.Any ()) {
+					headerColor = "orange";
 				} else if (passedTests.Any ()) {
 					headerColor = "green";
 				} else {

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1367,7 +1367,7 @@ namespace xharness
 					markdown_summary.Write ($"# Test run in progress: ");
 					markdown_summary.Write (string.Join (", ", list));
 					markdown_summary.WriteLine ();
-				} else if (failedTests.Any ()) {
+				} else if (failedTests.Any () || skippedTests.Any ()) {
 					var skipped = skippedTests.Any () ? $" and {skippedTests.Count ()} tests skipped" : "";
 					markdown_summary.WriteLine ($"{failedTests.Count ()} tests failed, {passedTests.Count ()} tests passed{skipped}.");
 				} else if (passedTests.Any ()) {


### PR DESCRIPTION
Currently we consider the failed **and** the skipped tests as failures which is confusing. The tests didn't all "fail" because some were just not ran.

This PR updates the summary message to be a little more clear.