### PR TITLE
[mtouch] Move native code sharing check for the remove-dynamic-registrar optimization until after checking the linker settings. (#3643)

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -957,16 +957,6 @@ namespace Xamarin.Bundler {
 					continue;
 				}
 
-				if (Optimizations.RemoveDynamicRegistrar != appex.Optimizations.RemoveDynamicRegistrar) {
-					Func<bool?, string> bool_tostr = (v) => {
-						if (!v.HasValue)
-							return "default";
-						return v.Value ? "true" : "false";
-					};
-					ErrorHelper.Warning (113, "Native code sharing has been disabled for the extension '{0}' because {1}", appex.Name, $"the remove-dynamic-registrar optimization differ between the container app ({bool_tostr (appex.Optimizations.RemoveDynamicRegistrar)}) and the extension ({bool_tostr (Optimizations.RemoveDynamicRegistrar)}).");
-					continue;
-				}
-
 				bool applicable = true;
 				// The --assembly-build-target arguments must be identical.
 				// We can probably lift this requirement (at least partially) at some point,
@@ -1054,6 +1044,17 @@ namespace Xamarin.Bundler {
 						applicable = false;
 						break;
 					}
+				}
+
+				// Check that the remove-dynamic-registrar optimizations are identical
+				if (Optimizations.RemoveDynamicRegistrar != appex.Optimizations.RemoveDynamicRegistrar) {
+					Func<bool?, string> bool_tostr = (v) => {
+						if (!v.HasValue)
+							return "default";
+						return v.Value ? "true" : "false";
+					};
+					ErrorHelper.Warning (113, "Native code sharing has been disabled for the extension '{0}' because {1}", appex.Name, $"the remove-dynamic-registrar optimization differ between the container app ({bool_tostr (appex.Optimizations.RemoveDynamicRegistrar)}) and the extension ({bool_tostr (Optimizations.RemoveDynamicRegistrar)}).");
+					continue;
 				}
 
 				// Check if there aren't referenced assemblies from different sources


### PR DESCRIPTION
Fixes this test failure:

1) Failed : Xamarin.MTouch.MT0113_linker
The error 'MT0113: Native code sharing has been disabled for the extension 'testServiceExtension' because the managed linker settings are different between the container app (None) and the extension (All).' was not found in the output:
	Message #1 did not match:
		actual:   'Native code sharing has been disabled for the extension 'testServiceExtension' because the remove-dynamic-registrar optimization differ between the container app (default) and the extension (false).'
		expected: 'Native code sharing has been disabled for the extension 'testServiceExtension' because the managed linker settings are different between the container app (None) and the extension (All).'

which happens because:

* Removing the dynamic registrar requires the linker, so removal of the dynamic registrar is disabled if the linker is not disabled
* This results in the app and appex having different values for the remove-dynamic-registrar option
* Thus the error message.

Technically either error is correct, but I prefer the previous one (about the
linker), because it directly assigns blame (the linker setting). Figuring out
what has to change (the linker setting) when the error message complains about
an optimization is not so straight forward for users.