### PR TITLE
[xharness] All variants of GuiUnit projects must be special-cased. (#3602)

### DIFF
--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -112,7 +112,8 @@ namespace xharness
 			XmlDocument doc;
 			doc = new XmlDocument ();
 			doc.LoadWithoutNetworkAccess (original_path);
-			if (System.IO.Path.GetFileName (original_path).Contains ("GuiUnit_NET")) {
+			var original_name = System.IO.Path.GetFileName (original_path);
+			if (original_name.Contains ("GuiUnit_NET") || original_name.Contains ("GuiUnit_xammac_mobile")) {
 				// The GuiUnit project files writes stuff outside their project directory using relative paths,
 				// but override that so that we don't end up with multiple cloned projects writing stuff to
 				// the same location.


### PR DESCRIPTION
This fixes an issue where multiple copies of the GuiUnit project would have
the same output directory, causing random problems when building those
projects in parallel.