### PR TITLE
[backport][security] Strongly typed key generation (#3502)

### DIFF
--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -561,7 +561,7 @@ namespace Security {
 			else
 				dic = new NSMutableDictionary ();
 			dic.LowlevelSetObject (type.GetConstant (), SecAttributeKey.Type);
-			dic.LowlevelSetObject (new NSNumber (keySizeInBits), SecAttributeKey.KeySizeInBits);
+			dic.LowlevelSetObject (new NSNumber (keySizeInBits), SecKeyGenerationAttributeKeys.KeySizeInBitsKey.Handle);
 			return GenerateKeyPair (dic, out publicKey, out privateKey);
 #endif
 		}
@@ -574,11 +574,11 @@ namespace Security {
 			using (var dic = new NSMutableDictionary ()) {
 				dic.LowlevelSetObject (type.GetConstant (), SecAttributeKey.Type);
 				using (var ksib = new NSNumber (keySizeInBits)) {
-					dic.LowlevelSetObject (ksib, SecAttributeKey.KeySizeInBits);
+					dic.LowlevelSetObject (ksib, SecKeyGenerationAttributeKeys.KeySizeInBitsKey.Handle);
 					if (publicKeyAttrs != null)
-						dic.LowlevelSetObject (publicKeyAttrs.GetDictionary (), SecAttributeKey.PublicKeyAttrs);
+						dic.LowlevelSetObject (publicKeyAttrs.GetDictionary (), SecKeyGenerationAttributeKeys.PublicKeyAttrsKey.Handle);
 					if (privateKeyAttrs != null)
-						dic.LowlevelSetObject (privateKeyAttrs.GetDictionary (), SecAttributeKey.PrivateKeyAttrs);
+						dic.LowlevelSetObject (privateKeyAttrs.GetDictionary (), SecKeyGenerationAttributeKeys.PrivateKeyAttrsKey.Handle);
 					return GenerateKeyPair (dic, out publicKey, out privateKey);
 				}
 			}
@@ -789,9 +789,22 @@ namespace Security {
 		{
 			using (var ks = new NSNumber (keySizeInBits))
 			using (var md = parameters == null ? new NSMutableDictionary () : new NSMutableDictionary (parameters)) {
-				md.LowlevelSetObject (keyType.GetConstant (), SecAttributeKey.KeyType);
-				md.LowlevelSetObject (ks, SecAttributeKey.KeySizeInBits);
+				md.LowlevelSetObject (keyType.GetConstant (), SecKeyGenerationAttributeKeys.KeyTypeKey.Handle);
+				md.LowlevelSetObject (ks, SecKeyGenerationAttributeKeys.KeySizeInBitsKey.Handle);
 				return CreateRandomKey (md, out error);
+			}
+		}
+
+		[Watch (3, 0)][TV (10, 0)][Mac (10, 12)][iOS (10, 0)]
+		static public SecKey CreateRandomKey (SecKeyGenerationParameters parameters, out NSError error)
+		{
+			if (parameters == null)
+				throw new ArgumentNullException (nameof (parameters));
+			if (parameters.KeyType == SecKeyType.Invalid)
+				throw new ArgumentException ("invalid 'SecKeyType'", "SecKeyGeneration.KeyType");
+
+			using (var dictionary = parameters.GetDictionary ()) {
+				return CreateRandomKey (dictionary, out error);
 			}
 		}
 
@@ -818,9 +831,9 @@ namespace Security {
 		{
 			using (var ks = new NSNumber (keySizeInBits))
 			using (var md = parameters == null ? new NSMutableDictionary () : new NSMutableDictionary (parameters)) {
-				md.LowlevelSetObject (keyType.GetConstant (), SecAttributeKey.KeyType);
+				md.LowlevelSetObject (keyType.GetConstant (), SecKeyGenerationAttributeKeys.KeyTypeKey.Handle);
 				md.LowlevelSetObject (keyClass.GetConstant (), SecAttributeKey.KeyClass);
-				md.LowlevelSetObject (ks, SecAttributeKey.KeySizeInBits);
+				md.LowlevelSetObject (ks, SecKeyGenerationAttributeKeys.KeySizeInBitsKey.Handle);
 				return Create (keyData, md, out error);
 			}
 		}

--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -813,11 +813,11 @@ namespace Security {
 		[iOS (9,0)]
 		public SecTokenID TokenID {
 			get {
-				return SecTokenIDExtensions.GetValue (Fetch<NSString> (SecAttributeKey.TokenID));
+				return SecTokenIDExtensions.GetValue (Fetch<NSString> (SecKeyGenerationAttributeKeys.TokenIDKey.GetHandle ()));
 			}
 			set {
 				// choose wisely to avoid NSString -> string -> NSString conversion
-				SetValue ((NSObject) value.GetConstant (), SecAttributeKey.TokenID);
+				SetValue ((NSObject) value.GetConstant (), SecKeyGenerationAttributeKeys.TokenIDKey.GetHandle ());
 			}
 		}
 #endif
@@ -993,7 +993,7 @@ namespace Security {
 				if (value == null)
 					throw new ArgumentNullException ("value");
 				_secAccessControl = value;
-				SetValue (value.Handle, SecAttributeKey.AccessControl);
+				SetValue (value.Handle, SecAttributeKeys.AccessControlKey.Handle);
 			}
 		}
 
@@ -1192,7 +1192,7 @@ namespace Security {
 
 		public SecKeyType KeyType {
 			get {
-				var k = Fetch (SecAttributeKey.KeyType);
+				var k = Fetch (SecKeyGenerationAttributeKeys.KeyTypeKey.Handle);
 				if (k == IntPtr.Zero)
 					return SecKeyType.Invalid;
 				using (var s = new NSString (k))
@@ -1203,17 +1203,17 @@ namespace Security {
 				var k = value.GetConstant ();
 				if (k == null)
 					throw new ArgumentException ("Unknown value");
-				SetValue ((NSObject) k, SecAttributeKey.KeyType);
+				SetValue ((NSObject) k, SecKeyGenerationAttributeKeys.KeyTypeKey.Handle);
 			}
 		}
 
 		public int KeySizeInBits {
 			get {
-				return FetchInt (SecAttributeKey.KeySizeInBits);
+				return FetchInt (SecKeyGenerationAttributeKeys.KeySizeInBitsKey.Handle);
 			}
 					
 			set {
-				SetValue (new NSNumber (value), SecAttributeKey.KeySizeInBits);
+				SetValue (new NSNumber (value), SecKeyGenerationAttributeKeys.KeySizeInBitsKey.Handle);
 			}
 		}
 
@@ -1279,11 +1279,11 @@ namespace Security {
 
 		public bool CanWrap {
 			get {
-				return Fetch (SecAttributeKey.CanWrap) == CFBoolean.True.Handle;
+				return Fetch (SecKeyGenerationAttributeKeys.CanWrapKey.Handle) == CFBoolean.True.Handle;
 			}
 			
 			set {
-				SetValue (CFBoolean.FromBoolean (value).Handle, SecAttributeKey.CanWrap);
+				SetValue (CFBoolean.FromBoolean (value).Handle, SecKeyGenerationAttributeKeys.CanWrapKey.Handle);
 			}
 		}
 
@@ -1731,6 +1731,70 @@ namespace Security {
 		
 		public SecurityException (SecStatusCode code) : base (ToMessage (code))
 		{
+		}
+	}
+
+	public partial class SecKeyParameters : DictionaryContainer {
+		// For caching, as we can't reverse it easily.
+		SecAccessControl _secAccessControl;
+
+		[iOS (8, 0), Mac (10, 10)]
+		public SecAccessControl AccessControl {
+			get {
+				return _secAccessControl;
+			}
+			set {
+				if (value == null)
+					throw new ArgumentNullException (nameof (value));
+				_secAccessControl = value;
+				SetNativeValue (SecAttributeKeys.AccessControlKey, value);
+			}
+		}
+	}
+
+	public partial class SecKeyGenerationParameters : DictionaryContainer {
+		public SecKeyType KeyType {
+			get {
+				var type = GetNSStringValue (SecKeyGenerationAttributeKeys.KeyTypeKey);
+				if (type == null)
+					return SecKeyType.Invalid;
+				return SecKeyTypeExtensions.GetValue (type);
+			}
+
+			set {
+				var k = value.GetConstant ();
+				if (k == null)
+					throw new ArgumentException ("Unknown value for KeyType.");
+				SetStringValue (SecKeyGenerationAttributeKeys.KeyTypeKey, k);
+			}
+		}
+
+		// For caching, as we can't reverse it easily.
+		SecAccessControl _secAccessControl;
+
+		[iOS (8, 0), Mac (10, 10)]
+		public SecAccessControl AccessControl {
+			get {
+				return _secAccessControl;
+			}
+
+			set {
+				if (value == null)
+					throw new ArgumentNullException (nameof (value));
+				_secAccessControl = value;
+				SetNativeValue (SecAttributeKeys.AccessControlKey, value);
+			}
+		}
+
+		[iOS (9, 0), Mac (10, 12)]
+		public SecTokenID TokenID {
+			get {
+				return SecTokenIDExtensions.GetValue (GetNSStringValue (SecKeyGenerationAttributeKeys.TokenIDKey));
+			}
+
+			set {
+				SetStringValue (SecKeyGenerationAttributeKeys.TokenIDKey, value.GetConstant ());
+			}
 		}
 	}
 }

--- a/src/security.cs
+++ b/src/security.cs
@@ -389,6 +389,10 @@ namespace Security {
 		[Field ("kSecAttrEffectiveKeySize")]
 		NSString EffectiveKeySizeKey { get; }
 
+		[iOS (8, 0), Mac (10, 10)]
+		[Field ("kSecAttrAccessControl")]
+		NSString AccessControlKey { get; }
+
 		[Field ("kSecAttrCanEncrypt")]
 		NSString CanEncryptKey { get; }
 
@@ -409,14 +413,92 @@ namespace Security {
 	}
 
 	[Static][Internal]
+	interface SecKeyGenerationAttributeKeys : SecAttributeKeys {
+		[Field ("kSecAttrKeyType")]
+		NSString KeyTypeKey { get; }
+
+		[Field ("kSecAttrKeySizeInBits")]
+		NSString KeySizeInBitsKey { get; }
+
+		[Mac (10, 8)]
+		[Field ("kSecPrivateKeyAttrs")]
+		NSString PrivateKeyAttrsKey { get; }
+
+		[Mac (10, 8)]
+		[Field ("kSecPublicKeyAttrs")]
+		NSString PublicKeyAttrsKey { get; }
+
+		[iOS (9, 0), Mac (10, 12)]
+		[Field ("kSecAttrTokenID")]
+		NSString TokenIDKey { get; }
+
+		[Field ("kSecAttrCanWrap")]
+		NSString CanWrapKey { get; }
+	}
+
+	[StrongDictionary ("SecAttributeKeys")]
+	interface SecKeyParameters {
+		string Label { get; set; }
+
+		bool IsPermanent { get; set; }
+
+		NSData ApplicationTag { get; set; }
+
+		int EffectiveKeySize { get; set; }
+
+		bool CanEncrypt { get; set; }
+
+		bool CanDecrypt { get; set; }
+
+		bool CanDerive { get; set; }
+
+		bool CanSign { get; set; }
+
+		bool CanVerify { get; set; }
+
+		bool CanUnwrap { get; set; }
+	}
+
+	[StrongDictionary ("SecKeyGenerationAttributeKeys")]
+	interface SecKeyGenerationParameters {
+		int KeySizeInBits { get; set; }
+
+		[StrongDictionary]
+		[Export ("PrivateKeyAttrsKey")]
+		SecKeyParameters PrivateKeyAttrs { get; set; }
+
+		[StrongDictionary]
+		[Export ("PublicKeyAttrsKey")]
+		SecKeyParameters PublicKeyAttrs { get; set; }
+
+		string Label { get; set; }
+
+		bool IsPermanent { get; set; }
+
+		NSData ApplicationTag { get; set; }
+
+		int EffectiveKeySize { get; set; }
+
+		bool CanEncrypt { get; set; }
+
+		bool CanDecrypt { get; set; }
+
+		bool CanDerive { get; set; }
+
+		bool CanSign { get; set; }
+
+		bool CanVerify { get; set; }
+
+		bool CanWrap { get; set; }
+
+		bool CanUnwrap { get; set; }
+	}
+
+	[Static][Internal]
 	interface SecAttributeKey {
 		[Mac (10,9)]
 		[Field ("kSecAttrAccessible")]
 		IntPtr Accessible { get; }
-
-		[iOS (8,0), Mac(10,10)]
-		[Field ("kSecAttrAccessControl")]
-		IntPtr AccessControl { get; }
 
 		[iOS (7,0)]
 		[Mac (10,9)]
@@ -521,20 +603,6 @@ namespace Security {
 		[Field ("kSecAttrIsExtractable")]
 		IntPtr IsExtractable { get; }
 
-		[Field ("kSecAttrKeyType")]
-		IntPtr KeyType { get; }
-
-		[Field ("kSecAttrKeySizeInBits")]
-		IntPtr KeySizeInBits { get; }
-
-		[Field ("kSecAttrCanWrap")]
-		IntPtr CanWrap { get; }
-
-		[iOS (9,0)]
-		[Mac (10,12)]
-		[Field ("kSecAttrTokenID")]
-		IntPtr TokenID { get; }
-
 		[iOS (9,0)]
 		[Mac (10,12)]
 		[Field ("kSecAttrTokenIDSecureEnclave")]
@@ -551,14 +619,6 @@ namespace Security {
 		[iOS (11,0)][TV (11,0)][Watch (4,0)][Mac (10,13)]
 		[Field ("kSecAttrPersistentReference")]
 		IntPtr PersistentReference { get; }
-
-		[Mac (10,8)]
-		[Field ("kSecPrivateKeyAttrs")]
-		IntPtr PrivateKeyAttrs { get; }
-
-		[Mac (10,8)]
-		[Field ("kSecPublicKeyAttrs")]
-		IntPtr PublicKeyAttrs { get; }
 	}
 
 	[Static][Internal]

--- a/tests/monotouch-test/Security/KeyTest.cs
+++ b/tests/monotouch-test/Security/KeyTest.cs
@@ -488,5 +488,30 @@ namespace MonoTouchFixtures.Security {
 				}
 			}
 		}
+
+		[Test]
+		public void CreateRandomKeyTest ()
+		{
+			TestRuntime.AssertXcodeVersion (8, 0);
+
+			var keyGenerationParameters = new SecKeyGenerationParameters ();
+			keyGenerationParameters.KeyType = SecKeyType.EC;
+			keyGenerationParameters.KeySizeInBits = 256;
+			keyGenerationParameters.IsPermanent = false;
+			var privateKeyAttributes = new SecKeyParameters ();
+			privateKeyAttributes.AccessControl = new SecAccessControl (SecAccessible.WhenUnlockedThisDeviceOnly, SecAccessControlCreateFlags.PrivateKeyUsage | SecAccessControlCreateFlags.UserPresence);
+			privateKeyAttributes.Label = "NotDefault";
+			keyGenerationParameters.PrivateKeyAttrs = privateKeyAttributes;
+
+			NSError error;
+			var privateKey = SecKey.CreateRandomKey (keyGenerationParameters, out error);
+			var publicKey = privateKey.GetPublicKey ();
+
+			Assert.That (error, Is.EqualTo (null), "CreateRandomKey - no error");
+			Assert.That (privateKey, Is.Not.EqualTo (null), "CreateRandomKey - private key is not null");
+			Assert.That (publicKey, Is.Not.EqualTo (null), "CreateRandomKey - public key is not null");
+			Assert.Throws<ArgumentNullException> (() => { SecKey.CreateRandomKey ((SecKeyGenerationParameters) null, out _); }, "CreateRandomKey - null argument");
+			Assert.Throws<ArgumentException> (() => { SecKey.CreateRandomKey (new SecKeyGenerationParameters (), out _); }, "CreateRandomKey - invalid 'SecKeyType', empty 'SecKeyGenerationParameters'");
+		}
 	}
 }


### PR DESCRIPTION
* [security] Modifying structure of bindings

Added strong dictionary for key generation according to
https://developer.apple.com/documentation/security/certificate_key_and_trust_services/keys/key_generation_attributes
in preparation making a strongly typed key generation possible.

* Making strong dictionary and composite of other strong dictionaries.

* Implementing access control as property type of SecPublicPrivateKeyAttrs.

* Adding new overload for SecKey.CreateRandomKey.

* Moving TokenID to strongly typed property.

* Fix coding style + use nameof

* Fixing Xcode version assertion of key generation tests.

* Fixing errors in test case.

* Fixing whitespace issue.

* Resolving inheritance issue

Removing inheritance between SecKeyGenerationParameters and
SecPublicPrivateKeyAttrs and instead add the necessary properties
to SecKeyGenerationParameters. Adds redundant code, but I don't
see a way around it.

* Moving test case to appropriate test class.

* Creating necessary strong dictionaries for key generation.

* [formatting] Mono coding guidelines

Make sure you're following http://www.mono-project.com/community/contributing/coding-guidelines/
In VSMac: Preferences > Source Code > Code Formatting > C# source code > Policy Mono.

* Remove [Advice] that are specific to GenerateKeyPair

`SecKeyGenerationParameters` and `SecKeyParameters` cannot be used for `GenerateKeyPair`.

* Clarify 'ArgumentException' for invalid 'SecKeyType'

* Fixed CreateRandomKeyTest

- Renamed CreateRandomKeyWithParametersTests to CreateRandomKeyTest.
- Add messages to all asserts.

```
keyGenerationParameters = new SecKeyGenerationParameters ();
keyGenerationParameters.KeyType = SecKeyType.Invalid;
Assert.Throws<ArgumentException> (() => { SecKey.CreateRandomKey (keyGenerationParameters, out _); }, "CreateRandomKey - invalid key type");
```
- ^ didn't work because `SecKeyGenerationParameters`'s setter protects against invalid. There's no constant for invalid so null is returned.

```
Assert.That (SecKey.CreateRandomKey (keyGenerationParameters, out _), Is.EqualTo (SecStatusCode.Param), "CreateRandomKey - Param issue, invalid RSA key size");
```
- ^ `SecKey.CreateRandomKey` doesn't return a `SecStatusCode` like `GenerateKeyPair`.

* Fixes based on spouliot's input.

* Mono styling fix.