### PR TITLE
[tests] Don't try to compile the Main function in F# extensions.

### DIFF
--- a/tests/fsharp/Main.fs
+++ b/tests/fsharp/Main.fs
@@ -6,7 +6,7 @@ open UIKit
 open MonoTouch.UIKit
 #endif
 
-#if !__WATCHOS__
+#if !__WATCHOS__ && !TODAY_EXTENSION
 
 module Main = 
     [<EntryPoint>]

--- a/tests/xharness/TodayExtensionTarget.cs
+++ b/tests/xharness/TodayExtensionTarget.cs
@@ -64,7 +64,7 @@ namespace xharness
 			csproj.SetImport (IsFSharp ? "$(MSBuildExtensionsPath)\\Xamarin\\iOS\\Xamarin.iOS.AppExtension.FSharp.targets" : "$(MSBuildExtensionsPath)\\Xamarin\\iOS\\Xamarin.iOS.AppExtension.CSharp.targets");
 			csproj.FixInfoPListInclude (suffix);
 			csproj.SetOutputType ("Library");
-			csproj.AddAdditionalDefines ("XAMCORE_2_0;XAMCORE_3_0");
+			csproj.AddAdditionalDefines ("XAMCORE_2_0;XAMCORE_3_0;TODAY_EXTENSION");
 			var ext = IsFSharp ? "fs" : "cs";
 			csproj.AddCompileInclude ("TodayExtensionMain." + ext, Path.Combine (Harness.TodayExtensionTemplate, "TodayExtensionMain." + ext), true);
 			csproj.AddInterfaceDefinition (Path.Combine (Harness.TodayExtensionTemplate, "TodayView.storyboard").Replace ('/', '\\'));


### PR DESCRIPTION
The F# compiler complains that:

    /Users/xamarinqa/vsts/_work/52/s/tests/fsharp/Main.fs(13,9): error FS0433: A function labeled with the 'EntryPointAttribute' attribute must be the last declaration in the last file in the compilation sequence.

Main.fs is the last file in the project file, but the MSBuild tasks adds
another one at the end:

    obj/iPhone/Debug64-today-extension/Xamarin.iOS,Version=v1.0.AssemblyAttribute.fs

because we're building a library (in which case the MSBuild tasks assume that
there won't be any Main functions in the project, and as such it's safe to
append files to compile).

Work around this by excluding the Main function from F# extensions, it's not
needed anyway.