### PR TITLE
[monotouch-test] Stop MidiThruConnectionTests.FindTest from randomly failing

### DIFF
--- a/tests/monotouch-test/CoreMidi/MidiThruConnectionTests.cs
+++ b/tests/monotouch-test/CoreMidi/MidiThruConnectionTests.cs
@@ -131,11 +131,10 @@ namespace MonoTouchFixtures.CoreMidi {
 
 			using (var connection1 = MidiThruConnection.Create ("com.xamarin.midi", cnnParams1))
 			using (var connection2 = MidiThruConnection.Create ("com.xamarin.midi", cnnParams2)) {
-				MidiError err;
-				var connections = MidiThruConnection.Find ("com.xamarin.midi", out err);
+				var connections = MidiThruConnection.Find ("com.xamarin.midi", out var err);
 				Assert.IsTrue (err == MidiError.Ok, "midi connection error");
 				Assert.NotNull (connections, "connections should not be null");
-				Assert.IsTrue (connections.Length == 2, "2 midi connections");
+				Assert.That (connections.Length, Is.GreaterThanOrEqualTo (2), "At least 2 midi connections expected");
 			}
 		}
 	}


### PR DESCRIPTION
Fixes xamarin/maccore#658

When a MidiThruConnection is created but for some reason is not disposed
the system keeps it alive even between app/simulator restarts, if you want
to clean the connections you must reset contents and settings from simulator.

In order to avoid this test from failing randomly and since the intent of the
test is to check if `MidiThruConnection.Find` works we change the assert to
`>= 2` since this is at least the number of connections we expect.