### PR TITLE
Bump XI to 11.8.1 (and XM to 4.2.1)

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -42,7 +42,7 @@ endif
 
 # TODO: reset to 0 after major/minor version bump (SRO) and increment for service releases and previews
 # Note: if not reseted to 0 we can skip a version and start with .1 or .2
-PACKAGE_VERSION_REV=0
+PACKAGE_VERSION_REV=1
 
 IOS_PRODUCT=Xamarin.iOS
 IOS_PACKAGE_NAME=Xamarin.iOS


### PR DESCRIPTION
This pull request proposes to update the revision number in preparation for the next servicing release from the `d15-6` branch.

It would also be OK to skip directly to 11.8.2 and 4.2.2 instead to align more closely with the Visual Studio 2017 version numbering (Visual Studio 2017 version 15.6.1 has just been released today), but staying in-sync with those Visual Studio revision numbers can be tricky due to narrow timing. So for the sake of simplicity, I think it would be fine just to increment the revision number in xamarin-macios by 1 after each published Xamarin.iOS + Xamarin.Mac release from the `d15-6` branch.

Or it's also fine not to worry about updating the revision number at all. In that case, feel free to close the pull request. Thanks!