### PR TITLE
[ObjCRuntime] Don't double-retain blocks.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -855,7 +855,6 @@ namespace ObjCRuntime {
 #endif
 		static Delegate CreateBlockProxy (MethodInfo method, IntPtr block)
 		{
-			NSObject.DangerousRetain (block);
 			return (Delegate) method.Invoke (null, new object [] { block } );
 		}
 

--- a/tests/bindings-test/ApiDefinition.cs
+++ b/tests/bindings-test/ApiDefinition.cs
@@ -284,6 +284,13 @@ namespace Bindings.Test {
 
 		[Export ("callOptionalCallback")]
 		void CallOptionalCallback ();
+
+		[Export ("testFreedBlocks")]
+		void TestFreedBlocks ();
+
+		[Static]
+		[Export ("freedBlockCount")]
+		int FreedBlockCount { get; }
 	}
 }
 

--- a/tests/bindings-test/RegistrarBindingTest.cs
+++ b/tests/bindings-test/RegistrarBindingTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 #if __UNIFIED__
 using Foundation;
@@ -63,7 +64,7 @@ namespace Xamarin.BindingTests
 			}
 		}
 
-		class BlockCallbackTester : ObjCBlockTester
+		public class BlockCallbackTester : ObjCBlockTester
 		{
 			public override void ClassCallback (Action<int> completionHandler)
 			{

--- a/tests/bindings-test/bindings-test-mac.csproj
+++ b/tests/bindings-test/bindings-test-mac.csproj
@@ -62,6 +62,7 @@
     <Compile Include="..\api-shared\ObjCRuntime\Registrar.cs">
       <Link>Registrar.cs</Link>
     </Compile>
+    <Compile Include="RegistrarBindingTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\tests\test-libraries\libtest.m">

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2034,7 +2034,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			var thread = new Thread (() => {
 				try {
 					using (var obj = new Xamarin.BindingTests.RegistrarBindingTest.BlockCallbackTester ()) {
-						for (int i = 0; i < 100; i++)
+						for (int i = 0; i < 10000; i++)
 							obj.TestFreedBlocks ();
 					}
 				} catch (Exception e) {
@@ -2045,7 +2045,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			thread.Join ();
 			GC.Collect ();
 			GC.WaitForPendingFinalizers ();
-			TestRuntime.RunAsync (DateTime.Now.AddSeconds (1), () => { }, () => ObjCBlockTester.FreedBlockCount > initialFreedCount);
+			TestRuntime.RunAsync (DateTime.Now.AddSeconds (30), () => { }, () => ObjCBlockTester.FreedBlockCount > initialFreedCount);
 			Assert.IsNull (ex, "No exceptions");
 			Assert.That (ObjCBlockTester.FreedBlockCount, Is.GreaterThan (initialFreedCount), "freed blocks");
 		}

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2027,6 +2027,30 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		}
 
 		[Test]
+		public void BlockCollection ()
+		{
+			Exception ex = null;
+			int initialFreedCount = ObjCBlockTester.FreedBlockCount;
+			var thread = new Thread (() => {
+				try {
+					using (var obj = new Xamarin.BindingTests.RegistrarBindingTest.BlockCallbackTester ()) {
+						for (int i = 0; i < 100; i++)
+							obj.TestFreedBlocks ();
+					}
+				} catch (Exception e) {
+					ex = e;
+				}
+			});
+			thread.Start ();
+			thread.Join ();
+			GC.Collect ();
+			GC.WaitForPendingFinalizers ();
+			TestRuntime.RunAsync (DateTime.Now.AddSeconds (1), () => { }, () => ObjCBlockTester.FreedBlockCount > initialFreedCount);
+			Assert.IsNull (ex, "No exceptions");
+			Assert.That (ObjCBlockTester.FreedBlockCount, Is.GreaterThan (initialFreedCount), "freed blocks");
+		}
+
+		[Test]
 		public void TestCtors ()
 		{
 			IntPtr ptr = IntPtr.Zero;

--- a/tests/test-libraries/libtest.h
+++ b/tests/test-libraries/libtest.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #include <simd/simd.h>
+#include <libkern/OSAtomic.h>
 
 #include "rename.h"
 
@@ -149,6 +150,14 @@ typedef unsigned int (^RegistrarTestBlock) (unsigned int magic);
 -(void) callClassCallback;
 -(void) callRequiredCallback;
 -(void) callOptionalCallback;
+
+-(void) testFreedBlocks;
++(int) freedBlockCount;
+@end
+
+@interface FreedNotifier : NSObject {
+}
+-(void) dealloc;
 @end
 
 #ifdef __cplusplus

--- a/tests/test-libraries/rename.h
+++ b/tests/test-libraries/rename.h
@@ -4,6 +4,7 @@
 	#define useZLib           object_useZLib
 	#define ObjCRegistrarTest object_ObjCRegistrarTest
 	#define ObjCBlockTester   object_ObjCBlockTester
+	#define FreedNotifier     object_FreedNotifier
 	#define FakeType2         object_FakeType2
 	#define UltimateMachine   object_UltimateMachine
 	#define FrameworkTest     object_FrameworkTest
@@ -67,6 +68,7 @@
 	#define useZLib           ar_useZLib
 	#define ObjCRegistrarTest ar_ObjCRegistrarTest
 	#define ObjCBlockTester   ar_ObjCBlockTester
+	#define FreedNotifier     ar_FreedNotifier
 	#define FakeType2         ar_FakeType2
 	#define UltimateMachine   ar_UltimateMachine
 	#define FrameworkTest     ar_FrameworkTest


### PR DESCRIPTION
First there was darkness; no blocks were retained.

Then came the light; and all blocks were retained [1]

Forever.

But all that once is, must one day not be,
and thus the light gave way to darkness,
and blocks were only retained as long as need be [2].

But before there was a balance, there was a crossroad.

In some places the light shone forever,
and all blocks were retained.

In other places there was a balance,
and the light shone only as long as needed.

A desire to unify arose.

Alas, it could not be.

It was a bright and sunny day

When a merge failed [3].

And all blocks were retained. Twice.

Once [here][4] and once [there][5].

For many years we could not see.

Until a dark and rainy night,
when an awareness arose.

And the desire to unify the balance could finally be fulfilled.

[1]: https://github.com/xamarin/maccore/commit/6efca92acb5d0f2b1b495a40ac2e89586200d206
[2]: https://github.com/xamarin/maccore/commit/a22f877539058b889555ae4decae0f2e9aca029c
[3]: https://github.com/xamarin/maccore/commit/befa0477cf9f3c9602d3fda6b9dee65e5bba506f
[4]: https://github.com/xamarin/xamarin-macios/blob/5158a3c00138ae9bc45979487ca6a0fbc3fccc4d/src/ObjCRuntime/Runtime.cs#L858
[5]: https://github.com/xamarin/xamarin-macios/blob/5158a3c00138ae9bc45979487ca6a0fbc3fccc4d/runtime/runtime.m#L2091