### PR TITLE
[monotouch-test] Adjust a few tests to cope with optimizations.

### DIFF
--- a/tests/monotouch-test/CoreFoundation/DispatchTests.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchTests.cs
@@ -58,7 +58,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		[Test]
 		public void MainQueueDispatch ()
 		{
-#if !DEBUG
+#if !DEBUG || OPTIMIZEALL
 			Assert.Ignore ("UIKitThreadAccessException is not throw, by default, on release builds (removed by the linker)");
 #endif
 			if (RunningOnSnowLeopard)
@@ -207,7 +207,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		[Test]
 		public void EverAfter ()
 		{
-#if !DEBUG
+#if !DEBUG || OPTIMIZEALL
 			Assert.Ignore ("UIKitThreadAccessException is not throw, by default, on release builds (removed by the linker)");
 #endif
 			if (RunningOnSnowLeopard)


### PR DESCRIPTION
This fixes the following test failures when building for debug with all optimizations enabled:

    DispatchTests
    	[FAIL] DispatchTests.EverAfter :   thread check hit
      Expected: same as <UIKit.UIKitThreadAccessException>
      But was:  <System.ArgumentNullException>

    		  at MonoTouchFixtures.CoreFoundation.DispatchTests.EverAfter () [0x000e1] in /Users/xamarinqa/vsts/_work/52/s/tests/monotouch-test/CoreFoundation/DispatchTests.cs:259
    		  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
    	[FAIL] DispatchTests.MainQueueDispatch :   thread check hit
      Expected: same as <UIKit.UIKitThreadAccessException>
      But was:  <System.ArgumentNullException>

    		  at MonoTouchFixtures.CoreFoundation.DispatchTests.MainQueueDispatch () [0x000d1] in /Users/xamarinqa/vsts/_work/52/s/tests/monotouch-test/CoreFoundation/DispatchTests.cs:111
    		  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)