### PR TITLE
[msbuild] Correctly determine whether Xamarin.Mac builds require a p…

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -475,6 +475,9 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<Target Name="_DetectSigningIdentity" DependsOnTargets="_DetectAppManifest">
 		<PropertyGroup>
 			<_AppBundleName>$(AssemblyName)</_AppBundleName>
+
+			<_RequireProvisioningProfile>False</_RequireProvisioningProfile>
+			<_RequireProvisioningProfile Condition="'$(CodesignEntitlements)' != ''">True</_RequireProvisioningProfile>
 		</PropertyGroup>
 
 		<DetectSigningIdentity
@@ -484,6 +487,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			AppManifest="$(_AppManifest)"
 			Keychain="$(CodesignKeychain)"
 			RequireCodeSigning="$(EnableCodeSigning)"
+			RequireProvisioningProfile="$(_RequireProvisioningProfile)"
 			SdkPlatform="MacOSX"
 			ProvisioningProfile="$(CodeSignProvision)"
 			SigningKey="$(CodeSigningKey)">


### PR DESCRIPTION
…rovisioning profile

Fixes issue #3674

The problem is that the Xamarin.Mac targets did not set the
RequireProvisioningProfile property on the DetectSigningIdentity
task which meant that it defaulted to 'false'.

When that property is 'false', the DetectSigningIdentity logic
would shortcut to not doing a provisioning profile lookup.

This was therefor causing the build to not use a provisioning
profile which caused the build to improperly codesign the app
bundle.