### PR TITLE
[Foundation] Ensure that we retain the needed data in the NSUrlSessionHandler

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -462,16 +462,6 @@ namespace Foundation {
 				data = new Queue<NSData> ();
 			}
 
-			protected override void Dispose (bool disposing)
-			{
-				lock (dataLock) {
-					foreach (var q in data)
-						q?.Dispose ();
-				}
-
-				base.Dispose (disposing);
-			}
-
 			public void Add (NSData d)
 			{
 				lock (dataLock) {

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -475,6 +475,7 @@ namespace Foundation {
 			public void Add (NSData d)
 			{
 				lock (dataLock) {
+					d.DangerousRetain ();
 					data.Enqueue (d);
 					length += (int)d.Length;
 				}
@@ -538,7 +539,7 @@ namespace Foundation {
 				if (d.Position == d.Length) {
 					lock (dataLock) {
 						// this is the same object, it was done to make the cleanup
-						data.Dequeue ();
+						data.Dequeue ().Dispose ();
 						current?.Dispose ();
 						currentStream?.Dispose ();
 						current = null;


### PR DESCRIPTION
The data is stored in a .net q and needs to be retained so that we do
not have null pointers later in the code.

This fixes bug https://bugzilla.xamarin.com/show_bug.cgi?id=61054 by ensuring that the NSData is not released until we have dealt with it. The code would have done the retain if we used a NS* collection type.

Please look at the bug report which contains a test project to use to ensure that the exception is not raised. **IF YOU GET TIMEOUTS IGNORE THEM**, that is expected.