### PR TITLE
[mtouch] Disable minor collections for file provider extensions.

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -472,6 +472,28 @@ namespace Xamarin.Bundler {
 			}
 		}
 
+		public string MonoGCDebug {
+			get {
+				string ret = string.Empty;
+				if (IsFileProviderExtension) {
+					// soft-heap-limit doesn't work
+					// (https://github.com/mono/mono/issues/7597), which means
+					// that we'll only get a major collection when there is
+					// 16MB of major stuff to clean up. This is a problem,
+					// because FileProviderExtensions are killed when memory
+					// usage goes above 15MB. Workaround: disable minor
+					// collections, which makes the GC run a major collection
+					// instead of a minor collection whenever needed. This may
+					// not be an appropriate workaround for extensions with an
+					// UI, because it may cause more pauses. It shouldn't be
+					// much of a problem for extensions without UI though
+					// (such as the file provider extension).
+					ret = "disable-minor";
+				}
+				return ret;
+			}
+		}
+
 		public bool IsDeviceBuild { 
 			get { return BuildTarget == BuildTarget.Device; } 
 		}
@@ -509,6 +531,12 @@ namespace Xamarin.Bundler {
 		public bool IsTodayExtension {
 			get {
 				return ExtensionIdentifier == "com.apple.widget-extension";
+			}
+		}
+
+		public bool IsFileProviderExtension {
+			get {
+				return ExtensionIdentifier == "com.apple.fileprovider-nonui";
 			}
 		}
 

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -669,6 +669,8 @@ namespace Xamarin.Bundler
 						sw.WriteLine ("\txamarin_debug_mode = TRUE;");
 					if (!string.IsNullOrEmpty (app.MonoGCParams))
 						sw.WriteLine ("\tsetenv (\"MONO_GC_PARAMS\", \"{0}\", 1);", app.MonoGCParams);
+					if (!string.IsNullOrEmpty (app.MonoGCDebug))
+						sw.WriteLine ("\tsetenv (\"MONO_GC_DEBUG\", \"{0}\", 1);", app.MonoGCDebug);
 					foreach (var kvp in app.EnvironmentVariables)
 						sw.WriteLine ("\tsetenv (\"{0}\", \"{1}\", 1);", kvp.Key.Replace ("\"", "\\\""), kvp.Value.Replace ("\"", "\\\""));
 					sw.WriteLine ("\txamarin_supports_dynamic_registration = {0};", app.DynamicRegistrationSupported ? "TRUE" : "FALSE");


### PR DESCRIPTION
Works around a mono issue: https://github.com/mono/mono/issues/7597.

This fixes the test case from https://bugzilla.xamarin.com/show_bug.cgi?id=60597.