### PR TITLE
[tests][mac] Fix random failure in KeyTest.RoundtripRSAMinPKCS1

### DIFF
--- a/tests/monotouch-test/Security/KeyTest.cs
+++ b/tests/monotouch-test/Security/KeyTest.cs
@@ -119,8 +119,8 @@ namespace MonoTouchFixtures.Security {
 					Assert.That (public_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionPkcs1), Is.EqualTo (TestRuntime.CheckMacSystemVersion (10, 13)), "public/IsAlgorithmSupported/Decrypt");
 
 					using (var pub = public_key.GetPublicKey ()) {
-						// a new native instance of the key is returned (so having a new managed SecKey is fine)
-						Assert.True (pub.Handle == public_key.Handle, "public/GetPublicKey");
+						// macOS behaviour is not consistent - but the test main goal is to check we get a key
+						Assert.That (pub.Handle, Is.Not.EqualTo (IntPtr.Zero), "public/GetPublicKey");
 					}
 #else
 					Assert.True (public_key.IsAlgorithmSupported (SecKeyOperationType.Decrypt, SecKeyAlgorithm.RsaEncryptionPkcs1), "public/IsAlgorithmSupported/Decrypt");


### PR DESCRIPTION
The behaviour is not consistent on macOS (like it is on iOS)

Fixes https://github.com/xamarin/maccore/issues/671