### PR TITLE
Rework XM Binding Projects (again)

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -92,29 +92,6 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 				<TargetFrameworkName>Full</TargetFrameworkName>
 				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
 			</PropertyGroup>
-			<PropertyGroup Condition="'$(ForceNonSystemTargetFramework)' == 'true'"> <!-- Hack -->
-				<AssemblySearchPaths>$(MacBclPath);$(MacBclPath)/Facades</AssemblySearchPaths>
-			</PropertyGroup>
-		</When>
-		<When Condition=" '$(ForceNonSystemTargetFramework)' == 'true'">
-			<Choose>
-				<When Condition=" '$(TargetFrameworkVersion)' == '2.0' Or '$(TargetFrameworkVersion)' == ''">
-					<PropertyGroup>
-						<TargetFrameworkName>Modern</TargetFrameworkName>
-						<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/Xamarin.Mac</MacBclPath>
-						<TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
-						<TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
-					</PropertyGroup>
-				</When>
-				<Otherwise>
-					<PropertyGroup>
-						<TargetFrameworkName>Full</TargetFrameworkName>
-						<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
-						<UseXamMacFullFramework>true</UseXamMacFullFramework>
-						<AssemblySearchPaths>$(MacBclPath);$(MacBclPath)/Facades</AssemblySearchPaths> <!-- Hack -->
-					</PropertyGroup>
-				</Otherwise>
-			</Choose>
 		</When>
 		<Otherwise>
 			<PropertyGroup>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -12,6 +12,8 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 ***********************************************************************************************
 -->
 
+<!-- Unlike Xamarin.Mac.Common.targets, which is not shared by the ObjC Bindings targets (yet), 
+     Xamarin.Mac.Common.props is shared and truely common. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.props"
@@ -72,6 +74,42 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 
 	<PropertyGroup>
 		<IsMacEnabled>true</IsMacEnabled>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(XamarinMacFrameworkRoot)' == ''">
+		<XamarinMacFrameworkRoot>/Library/Frameworks/Xamarin.Mac.framework/Versions/Current</XamarinMacFrameworkRoot>
+	</PropertyGroup>
+
+	<Choose>
+		<When Condition=" '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
+			<PropertyGroup>
+				<TargetFrameworkName>Modern</TargetFrameworkName>
+				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/Xamarin.Mac</MacBclPath>
+			</PropertyGroup>
+		</When>
+		<When Condition=" '$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(UseXamMacFullFramework)' == 'true'">
+			<PropertyGroup>
+				<TargetFrameworkName>Full</TargetFrameworkName>
+				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
+			</PropertyGroup>
+		</When>
+		<Otherwise>
+			<PropertyGroup>
+				<TargetFrameworkName>System</TargetFrameworkName>
+				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
+			</PropertyGroup>
+		</Otherwise>
+	</Choose>
+
+	<PropertyGroup Condition="'$(TargetFrameworkName)' == 'Full'">
+		<AssemblySearchPaths>$(XamarinMacFrameworkRoot)/lib/reference/full;$(XamarinMacFrameworkRoot)/lib/mono;$(AssemblySearchPaths)</AssemblySearchPaths>
+		<ImplicitlyExpandNETStandardFacades>False</ImplicitlyExpandNETStandardFacades>
+	</PropertyGroup>
+
+	<!-- Do not resolve from the GAC in Modern or Full unless allow-unsafe-gac-resolution is passed in -->
+	<PropertyGroup Condition="'$(TargetFrameworkName)' != 'System' And !$(MonoBundlingExtraArgs.Contains('--allow-unsafe-gac-resolution'))" >
+		<AssemblySearchPaths>$([System.String]::Copy('$(AssemblySearchPaths)').Replace('{GAC}',''))</AssemblySearchPaths>
+		<AssemblySearchPaths Condition="'$(MSBuildRuntimeVersion)' != ''">$(AssemblySearchPaths.Split(';'))</AssemblySearchPaths>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.props"

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -92,6 +92,9 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 				<TargetFrameworkName>Full</TargetFrameworkName>
 				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
 			</PropertyGroup>
+			<PropertyGroup Condition="'$(ForceNonSystemTargetFramework)' == 'true'"> <!-- Hack -->
+				<AssemblySearchPaths>$(MacBclPath);$(MacBclPath)/Facades</AssemblySearchPaths>
+			</PropertyGroup>
 		</When>
 		<When Condition=" '$(ForceNonSystemTargetFramework)' == 'true'">
 			<Choose>
@@ -108,7 +111,7 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 						<TargetFrameworkName>Full</TargetFrameworkName>
 						<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
 						<UseXamMacFullFramework>true</UseXamMacFullFramework>
-						<AssemblySearchPaths>$(MacBclPath);$(MacBclPath)/Facades</AssemblySearchPaths>
+						<AssemblySearchPaths>$(MacBclPath);$(MacBclPath)/Facades</AssemblySearchPaths> <!-- Hack -->
 					</PropertyGroup>
 				</Otherwise>
 			</Choose>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -93,6 +93,26 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
 			</PropertyGroup>
 		</When>
+		<When Condition=" '$(ForceNonSystemTargetFramework)' == 'true'">
+			<Choose>
+				<When Condition=" '$(TargetFrameworkVersion)' == '2.0' Or '$(TargetFrameworkVersion)' == ''">
+					<PropertyGroup>
+						<TargetFrameworkName>Modern</TargetFrameworkName>
+						<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/Xamarin.Mac</MacBclPath>
+						<TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+						<TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
+					</PropertyGroup>
+				</When>
+				<Otherwise>
+					<PropertyGroup>
+						<TargetFrameworkName>Full</TargetFrameworkName>
+						<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
+						<UseXamMacFullFramework>true</UseXamMacFullFramework>
+						<AssemblySearchPaths>$(MacBclPath);$(MacBclPath)/Facades</AssemblySearchPaths>
+					</PropertyGroup>
+				</Otherwise>
+			</Choose>
+		</When>
 		<Otherwise>
 			<PropertyGroup>
 				<TargetFrameworkName>System</TargetFrameworkName>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -14,6 +14,9 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 ***********************************************************************************************
 -->
 
+<!-- Xamarin.Mac.Common.targets currently is not shared with Xamarin.Mac.ObjCBinding targets,
+     so be careful not to add fixes here that should go into Xamarin.Mac.Common.props which is shared -->
+
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.ArTool" AssemblyFile="Xamarin.Mac.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.Codesign" AssemblyFile="Xamarin.Mac.Tasks.dll" />
@@ -59,57 +62,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
-
-	<PropertyGroup Condition="'$(XamarinMacFrameworkRoot)' == ''">
-		<XamarinMacFrameworkRoot>/Library/Frameworks/Xamarin.Mac.framework/Versions/Current</XamarinMacFrameworkRoot>
-	</PropertyGroup>
-
-	<Choose>
-		<When Condition=" '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
-			<PropertyGroup>
-				<TargetFrameworkName>Modern</TargetFrameworkName>
-				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/Xamarin.Mac</MacBclPath>
-			</PropertyGroup>
-		</When>
-		<When Condition=" '$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(UseXamMacFullFramework)' == 'true'">
-			<PropertyGroup>
-				<TargetFrameworkName>Full</TargetFrameworkName>
-				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
-			</PropertyGroup>
-		</When>
-		<Otherwise>
-			<PropertyGroup>
-				<TargetFrameworkName>System</TargetFrameworkName>
-				<MacBclPath>$(XamarinMacFrameworkRoot)/lib/mono/4.5</MacBclPath>
-			</PropertyGroup>
-		</Otherwise>
-	</Choose>
-
-	<PropertyGroup Condition="'$(TargetFrameworkName)' == 'Full'">
-		<AssemblySearchPaths>$(XamarinMacFrameworkRoot)/lib/reference/full;$(XamarinMacFrameworkRoot)/lib/mono;$(AssemblySearchPaths)</AssemblySearchPaths>
-		<ImplicitlyExpandNETStandardFacades>False</ImplicitlyExpandNETStandardFacades>
-	</PropertyGroup>
-
-	<!-- Do not resolve from the GAC in Modern or Full unless allow-unsafe-gac-resolution is passed in -->
-	<PropertyGroup Condition="'$(TargetFrameworkName)' != 'System' And !$(MonoBundlingExtraArgs.Contains('--allow-unsafe-gac-resolution'))" >
-		<AssemblySearchPaths>$([System.String]::Copy('$(AssemblySearchPaths)').Replace('{GAC}',''))</AssemblySearchPaths>
-		<AssemblySearchPaths Condition="'$(MSBuildRuntimeVersion)' != ''">$(AssemblySearchPaths.Split(';'))</AssemblySearchPaths>
-	</PropertyGroup>
-
-	<Target Name="FixDesignTimeFacades" AfterTargets="GetReferenceAssemblyPaths" Condition="'$(OS)' != 'Windows_NT'" />
-
-	<!-- Location of Libraries -->
-	<Target Name="FixTargetFrameworkDirectory" AfterTargets="FixDesignTimeFacades" Condition="('$(OS)' != 'Windows_NT')">
-		<PropertyGroup>
-			<!-- For Modern / Full we overwrite TargetFrameworkDirectory to resolve non XM assemblies from our location only -->
-			<TargetFrameworkDirectory Condition="'$(TargetFrameworkName)' != 'System'">$(MacBclPath);@(DesignTimeFacadeDirectories)</TargetFrameworkDirectory>
-
-			<!-- For system we extend, not overwrite TargetFrameworkDirectory. -->
-			<!-- mscorlib, System, and other BCL libs must come from Mono System to prevent corlib mistmatches. Xamarin.Mac.dll must come from XM/lib/mono/4.5/ -->
-			<!-- If we find cases of other non-XM assemblies being resolved from XM paths, we can look into using CandidateAssemblyFiles but it is msbuild only. -->
-			<TargetFrameworkDirectory Condition="'$(TargetFrameworkName)' == 'System'">$(TargetFrameworkDirectory);$(MacBclPath)</TargetFrameworkDirectory>
-		</PropertyGroup>
-	</Target>
 
 	<PropertyGroup>
 		<_CanOutputAppBundle>False</_CanOutputAppBundle>
@@ -699,8 +651,8 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		/>
 	</Target>
 
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.XM45.xbuild.targets"
-		Condition="'$(UseXamMacFullFramework)' == 'true' And '$(IsXBuild)' == 'true' "/>
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.xbuild.targets"
+		Condition="'$(IsXBuild)' == 'true' "/>
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.msbuild.targets"
 		Condition="'$(IsXBuild)' != 'true' "/>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.props
@@ -18,6 +18,15 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.props"
 		Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.props')"/>
+	
+	<!-- Due to IDE/template bugs, many bindings projects exist in the wild withtout correct TFI/TFV tags.
+	In addition, System is not supported, so treat System as Modern or Full, depending on TFV being set-->
+	<PropertyGroup>
+		<ForceNonSystemTargetFramework>true</ForceNonSystemTargetFramework>
+	</PropertyGroup>
+
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.Common.props"
+			Condition="'$(_XamarinCommonPropsHasBeenImported)' != 'true'" />	
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.props"
 		Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.props')"/>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.props
@@ -19,25 +19,6 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.props"
 		Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.props')"/>
 
-	<PropertyGroup Condition="'$(OS)' == 'Unix'">
-		<XamarinMacFrameworkRoot Condition="'$(XamarinMacFrameworkRoot)' == '' And Exists('/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/bin')">/Library/Frameworks/Xamarin.Mac.framework/Versions/Current</XamarinMacFrameworkRoot>
-	</PropertyGroup>
-
-	<PropertyGroup>
-		<!-- If we don't have a specified version/identifier, assume Mobile -->
-		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v2.0</TargetFrameworkVersion>
-		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == '' And '$(TargetFrameworkVersion)' == 'v2.0'">Xamarin.Mac</TargetFrameworkIdentifier>
-
-		<BaseLibDllPath Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">$(XamarinMacFrameworkRoot)/lib/mono/Xamarin.Mac/Xamarin.Mac.dll</BaseLibDllPath>
-		<BaseLibDllPath Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.Mac'">$(XamarinMacFrameworkRoot)/lib/mono/4.5/Xamarin.Mac.dll</BaseLibDllPath>
-		<BTouchToolPath>$(XamarinMacFrameworkRoot)/bin/</BTouchToolPath>
-		<BTouchToolExe Condition="Exists('$(BTouchToolPath)/bgen')">bgen</BTouchToolExe>
-		<BTouchToolExe Condition="!Exists('$(BTouchToolPath)/bgen')">bmac-mobile-mono</BTouchToolExe>
-		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-
-		<DefineConstants>__UNIFIED__;__MACOS__;$(DefineConstants)</DefineConstants>
-	</PropertyGroup>
-
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.props"
 		Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.props')"/>
 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.props
@@ -19,12 +19,6 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.props"
 		Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.props')"/>
 	
-	<!-- Due to IDE/template bugs, many bindings projects exist in the wild withtout correct TFI/TFV tags.
-	In addition, System is not supported, so treat System as Modern or Full, depending on TFV being set-->
-	<PropertyGroup>
-		<ForceNonSystemTargetFramework>true</ForceNonSystemTargetFramework>
-	</PropertyGroup>
-
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.Common.props"
 			Condition="'$(_XamarinCommonPropsHasBeenImported)' != 'true'" />	
 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -24,18 +24,14 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
 
-	<Import Project="Xamarin.Mac.ObjCBinding.CSharp.props"/>
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.ObjCBinding.CSharp.props"/>
 
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+
 	<Import Project="Xamarin.Mac.ObjCBinding.Common.targets" />
 
 	<PropertyGroup>
-		<IsXBuild Condition="'$(MSBuildRuntimeVersion)' == ''">true</IsXBuild>
-		<IsXBuild Condition="'$(MSBuildRuntimeVersion)' != ''">false</IsXBuild>
-	</PropertyGroup>
-
-	<PropertyGroup>
-		<_GeneratedSourcesFileList>$(GeneratedSourcesDir)\sources.list</_GeneratedSourcesFileList>
+		<_GeneratedSourcesFileList>$(GeneratedSourcesDir)sources.list</_GeneratedSourcesFileList>
 
 		<!-- Add our own pre-build steps -->
 		<CompileDependsOn>
@@ -45,11 +41,6 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 			$(CompileDependsOn)
 		</CompileDependsOn>
 	</PropertyGroup>
-
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.XM45.xbuild.targets"
-		Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And '$(IsXBuild)' == 'true' "/>
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.msbuild.targets"
-		Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And '$(IsXBuild)' == 'false' "/>
 
 	<!-- Override the CoreCompile Target to use btouch -->
 	<Target Name="_GenerateBindings"
@@ -69,6 +60,9 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 		<Message Text="BTouchEmitDebugInformation: $(BTouchEmitDebugInformation)"/>
 
 		<BTouch
+			SessionId="$(BuildSessionId)"
+			OutputPath="$(OutputPath)"
+			ObjectiveCLibraries="@(ObjcBindingNativeLibrary)"
 			AdditionalLibPaths="$(AdditionalLibPaths)"
 			AllowUnsafeBlocks="$(AllowUnsafeBlocks)"
 			ApiDefinitions="@(ObjcBindingApiDefinition)"

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -28,7 +28,7 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 
-	<Import Project="Xamarin.Mac.ObjCBinding.Common.targets" />
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.ObjCBinding.Common.targets" />
 
 	<PropertyGroup>
 		<_GeneratedSourcesFileList>$(GeneratedSourcesDir)sources.list</_GeneratedSourcesFileList>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -26,7 +26,7 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 	
 	<!-- Due to IDE/template bugs, many bindings projects exist in the wild withtout correct TFI/TFV tags.
 	In addition, System is not supported, so treat System as Modern or Full, depending on TFV being set.
-	Microsoft.CSharp.targets gives Microsoft.CSharp.targets / TargetFrameworkIdentifier default values, so we _must_ do this _before_ 
+	Microsoft.CSharp.targets gives TargetFrameworkVersion / TargetFrameworkIdentifier default values, so we _must_ do this _before_ 
 	import Microsoft.CSharp.targets. However, we can't do most of Xamarin.Mac.ObjCBinding.CSharp.props before it. -->
 
 	<Choose>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -23,10 +23,31 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
+	
+	<!-- Due to IDE/template bugs, many bindings projects exist in the wild withtout correct TFI/TFV tags.
+	In addition, System is not supported, so treat System as Modern or Full, depending on TFV being set.
+	Microsoft.CSharp.targets gives Microsoft.CSharp.targets / TargetFrameworkIdentifier default values, so we _must_ do this _before_ 
+	import Microsoft.CSharp.targets. However, we can't do most of Xamarin.Mac.ObjCBinding.CSharp.props before it. -->
 
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.ObjCBinding.CSharp.props"/>
+	<Choose>
+		<When Condition=" '$(UseXamMacFullFramework)' == '' And ( '$(TargetFrameworkVersion)' == 'v2.0' Or '$(TargetFrameworkVersion)' == '' )">
+			<PropertyGroup>
+				<TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+				<TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
+			</PropertyGroup>
+		</When>
+		<Otherwise>
+			<PropertyGroup>
+				<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+				<UseXamMacFullFramework>true</UseXamMacFullFramework>
+				<TargetFrameworkIdentifier></TargetFrameworkIdentifier>
+			</PropertyGroup>
+		</Otherwise>
+	</Choose>
 
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+	
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.ObjCBinding.CSharp.props"/>
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.ObjCBinding.Common.targets" />
 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.props
@@ -17,11 +17,24 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.props"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.props')"/>
 
-	<!-- This is used to determine whether Xamarin.Mac.Common.targets needs to import 
+	<!-- This is used to determine whether Xamarin.Mac.ObjCBinding.Common.targets needs to import 
          Xamarin.Mac.ObjCBinding.Common.props itself, or whether it has been imported previously,
          e.g. by the project itself. -->
 	<PropertyGroup>
-		<_XamarinCommonPropsHasBeenImported>true</_XamarinCommonPropsHasBeenImported>
+		<_XamarinCommonBindingPropsHasBeenImported>true</_XamarinCommonBindingPropsHasBeenImported>
+	</PropertyGroup>
+
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.Common.props"
+			Condition="'$(_XamarinCommonPropsHasBeenImported)' != 'true'" />	
+
+	<PropertyGroup>
+		<BaseLibDllPath>$(MacBclPath)/Xamarin.Mac.dll</BaseLibDllPath>
+		<BTouchToolPath>$(XamarinMacFrameworkRoot)/bin/</BTouchToolPath>
+		<BTouchToolExe Condition="Exists('$(BTouchToolPath)/bgen')">bgen</BTouchToolExe>
+		<BTouchToolExe Condition="!Exists('$(BTouchToolPath)/bgen')">bmac-mobile-mono</BTouchToolExe>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+
+		<DefineConstants>__UNIFIED__;__MACOS__;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 
 	<!-- When looking for related files to copy, look for Mono debugging files as well -->

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.props
@@ -24,9 +24,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<_XamarinCommonBindingPropsHasBeenImported>true</_XamarinCommonBindingPropsHasBeenImported>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.Common.props"
-			Condition="'$(_XamarinCommonPropsHasBeenImported)' != 'true'" />	
-
 	<PropertyGroup>
 		<BaseLibDllPath>$(MacBclPath)/Xamarin.Mac.dll</BaseLibDllPath>
 		<BTouchToolPath>$(XamarinMacFrameworkRoot)/bin/</BTouchToolPath>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.targets
@@ -20,14 +20,16 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 	<UsingTask TaskName="Microsoft.Build.Tasks.RemoveDir" AssemblyFile="Xamarin.Mac.Tasks.dll"/>
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.ObjCBinding.Common.props" 
-			Condition="'$(_XamarinCommonPropsHasBeenImported)' != 'true'" />
+			Condition="'$(_XamarinCommonBindingPropsHasBeenImported)' != 'true'" />
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets" 
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
 
-	<PropertyGroup Condition="'$(XamarinMacFrameworkRoot)' == ''">
-		<XamarinMacFrameworkRoot>/Library/Frameworks/Xamarin.Mac.framework/Versions/Current</XamarinMacFrameworkRoot>
-	</PropertyGroup>
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.xbuild.targets"
+		Condition="'$(IsXBuild)' == 'true' "/>
+	
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.msbuild.targets"
+		Condition="'$(IsXBuild)' != 'true' "/>
 
 	<!-- Add our own pre-build steps -->
 	<PropertyGroup>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.TargetFrameworkFix.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.TargetFrameworkFix.targets
@@ -1,0 +1,39 @@
+<!--
+***********************************************************************************************
+Xamarin.Mac.TargetFrameworkFix.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+This file imports the version- and platform-specific targets for the project importing
+this file. This file also defines targets to produce an error if the specified targets
+file does not exist, but the project is built anyway (command-line or IDE build).
+
+Copyright (c) 2018 Microsoft Corp. (www.microsoft.com)
+***********************************************************************************************
+-->
+
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<!-- Hack associated with TargetFrameworkDirectory. Needs to be shared by xbuild and msbuild for now. -->
+
+	<Target Name="FixDesignTimeFacades" AfterTargets="GetReferenceAssemblyPaths" Condition="'$(OS)' != 'Windows_NT'" />
+
+	<!-- Location of Libraries -->
+	<Target Name="FixTargetFrameworkDirectory" AfterTargets="FixDesignTimeFacades" Condition="('$(OS)' != 'Windows_NT')">
+		<PropertyGroup>
+			<!-- For Modern / Full we overwrite TargetFrameworkDirectory to resolve non XM assemblies from our location only -->
+			<TargetFrameworkDirectory Condition="'$(TargetFrameworkName)' != 'System'">$(MacBclPath);@(DesignTimeFacadeDirectories)</TargetFrameworkDirectory>
+
+			<!-- For system we extend, not overwrite TargetFrameworkDirectory. -->
+			<!-- mscorlib, System, and other BCL libs must come from Mono System to prevent corlib mistmatches. Xamarin.Mac.dll must come from XM/lib/mono/4.5/ -->
+			<!-- If we find cases of other non-XM assemblies being resolved from XM paths, we can look into using CandidateAssemblyFiles but it is msbuild only. -->
+			<TargetFrameworkDirectory Condition="'$(TargetFrameworkName)' == 'System'">$(TargetFrameworkDirectory);$(MacBclPath)</TargetFrameworkDirectory>
+		</PropertyGroup>
+		<ItemGroup>
+			<DesignTimeFacadeDirectories Remove="@(DesignTimeFacadeDirectories)" />
+			<DesignTimeFacadeDirectories Include="$(MacBclPath)/Facades/" />
+		</ItemGroup>
+	</Target>
+</Project>
+

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
@@ -80,6 +80,12 @@
     <None Include="Xamarin.Mac.msbuild.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Xamarin.Mac.xbuild.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Xamarin.Mac.TargetFrameworkFix.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Xamarin.Mac.Common.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.xbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.xbuild.targets
@@ -1,6 +1,6 @@
 ﻿<!--
 ***********************************************************************************************
-Xamarin.Mac.msbuild.targets
+Xamarin.Mac.xbuild.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
   created a backup copy.  Incorrect changes to this file will make it
@@ -10,19 +10,13 @@ This file imports the version- and platform-specific targets for the project imp
 this file. This file also defines targets to produce an error if the specified targets
 file does not exist, but the project is built anyway (command-line or IDE build).
 
-Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
+Copyright (C) 2015 Xamarin Inc. All rights reserved.
 ***********************************************************************************************
 -->
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<!-- MSBuild specific hacks - Teach msbuild where to find our BCL and facades -->
-
-	<!-- Location of mscorlib -->
-	<PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
-		<FrameworkPathOverride Condition="'$(TargetFrameworkName)' != 'System'">$(MacBclPath)</FrameworkPathOverride>
-	</PropertyGroup>
-
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.TargetFrameworkFix.targets"/>
-
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.Common.ImplicitFacade.msbuild.targets" Condition="'$(TargetFrameworkName)' == 'Modern' Or '$(TargetFrameworkName)' == 'Full'"/>
+	
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Mac.XM45.xbuild.targets"
+		Condition="'$(UseXamMacFullFramework)' == 'true'"/>
 </Project>

--- a/tests/bindings-test/ApiDefinition.cs
+++ b/tests/bindings-test/ApiDefinition.cs
@@ -1,7 +1,4 @@
 using System;
-#if !__WATCHOS__
-using System.Drawing;
-#endif
 
 #if __UNIFIED__
 using ObjCRuntime;
@@ -12,6 +9,9 @@ using AppKit;
 using UIKit;
 #endif
 #else
+#if !__WATCHOS__
+using System.Drawing;
+#endif
 using MonoTouch.ObjCRuntime;
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;

--- a/tests/bindings-test/ApiProtocol.cs
+++ b/tests/bindings-test/ApiProtocol.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-#if !__WATCHOS__
-using System.Drawing;
-#endif
 
 #if __UNIFIED__
 using ObjCRuntime;
@@ -12,6 +9,9 @@ using AppKit;
 using UIKit;
 #endif
 #else
+#if !__WATCHOS__
+using System.Drawing;
+#endif
 using MonoTouch.ObjCRuntime;
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;

--- a/tests/common/mac/ProjectTestHelpers.cs
+++ b/tests/common/mac/ProjectTestHelpers.cs
@@ -230,6 +230,9 @@ namespace Xamarin.MMP.Tests
 
 		public static string BuildProject (string csprojTarget, bool isUnified, bool diagnosticMSBuild = false, bool shouldFail = false, bool useMSBuild = false, bool release = false, string[] environment = null)
 		{
+			if (Environment.GetEnvironmentVariable ("XM_FORCE_MSBUILD") != null)
+				useMSBuild = true;
+
 			string rootDirectory = FindRootDirectory ();
 
 			// TODO - This is not enough for MSBuild to really work. We need stuff to have it not use system targets!

--- a/tests/common/mac/ProjectTestHelpers.cs
+++ b/tests/common/mac/ProjectTestHelpers.cs
@@ -155,6 +155,7 @@ namespace Xamarin.MMP.Tests
 			public string SystemMonoVersion { get; set; } = "";
 			public string TargetFrameworkVersion { get; set; } = "";
 			public Dictionary<string, string> PlistReplaceStrings { get; set; } = new Dictionary<string, string>();
+			public Tuple<string, string> CustomProjectReplacement { get; set; } = null;
 
 			// Binding project specific
 			public string APIDefinitionConfig { get; set; }
@@ -271,12 +272,15 @@ namespace Xamarin.MMP.Tests
 
 		static string ProjectTextReplacement (UnifiedTestConfig config, string text)
 		{
-			return text.Replace ("%CODE%", config.CSProjConfig)
+			 text = text.Replace ("%CODE%", config.CSProjConfig)
 					   .Replace ("%REFERENCES%", config.References)
 					   .Replace ("%REFERENCES_BEFORE_PLATFORM%", config.ReferencesBeforePlatform)
 					   .Replace ("%NAME%", config.AssemblyName ?? Path.GetFileNameWithoutExtension (config.ProjectName))
 					   .Replace ("%ITEMGROUP%", config.ItemGroup)
 					   .Replace ("%TARGET_FRAMEWORK_VERSION%", config.TargetFrameworkVersion);
+			if (config.CustomProjectReplacement != null)
+				text = text.Replace (config.CustomProjectReplacement.Item1, config.CustomProjectReplacement.Item2);
+			return text;
 		}
 
 		public static string RunEXEAndVerifyGUID (string tmpDir, Guid guid, string path)

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -103,6 +103,7 @@
     <Compile Include="..\..\tools\common\StringUtils.cs">
       <Link>StringUtils.cs</Link>
     </Compile>
+    <Compile Include="src\BindingProjectTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/mmptest/src/BindingProjectTests.cs
+++ b/tests/mmptest/src/BindingProjectTests.cs
@@ -13,7 +13,7 @@ namespace Xamarin.MMP.Tests
 		
 		static Tuple<string, string> BuildLinkedTestProjects (TI.UnifiedTestConfig binding, TI.UnifiedTestConfig project, string tmpDir)
 		{
-			binding.ItemGroup = MMPTests.CreateSingleNativeRef (Path.GetFullPath (MMPTests.SimpleDylibPath), "Dynamic");
+			binding.ItemGroup = NativeReferenceTests.CreateSingleNativeRef (Path.GetFullPath (NativeReferenceTests.SimpleDylibPath), "Dynamic");
 			binding.StructsAndEnumsConfig = "public class UnifiedWithDepNativeRefLibTestClass {}";
 
 			string projectPath = TI.GenerateBindingLibraryProject (binding);

--- a/tests/mmptest/src/BindingProjectTests.cs
+++ b/tests/mmptest/src/BindingProjectTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace Xamarin.MMP.Tests
+{
+	public class BindingProjectTests
+	{
+		static string BindingName (bool full) => full ? "XM45Binding" : "MobileBinding";
+		
+		static void BuildLinkedTestProjects (string tmpDir, bool full = false, bool removeTFI = false)
+		{
+			string bindingName = BindingName (full);
+			TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+				ProjectName = bindingName + ".csproj",
+				ItemGroup = MMPTests.CreateSingleNativeRef (Path.GetFullPath (MMPTests.SimpleDylibPath), "Dynamic"),
+				StructsAndEnumsConfig = "public class UnifiedWithDepNativeRefLibTestClass {}"
+			};
+
+			if (removeTFI)
+				test.CustomProjectReplacement = new Tuple<string, string> (@"<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>", "");
+
+			string projectPath = TI.GenerateBindingLibraryProject (test);
+			TI.BuildProject (projectPath, true);
+
+			string referenceCode = string.Format (@"<Reference Include=""{0}""><HintPath>{1}</HintPath></Reference>", bindingName, Path.Combine (tmpDir, "bin/Debug", bindingName + ".dll"));
+
+			test = new TI.UnifiedTestConfig (tmpDir) {
+				References = referenceCode,
+				TestCode = "System.Console.WriteLine (typeof (ExampleBinding.UnifiedWithDepNativeRefLibTestClass));",
+				XM45 = full					
+			};
+			TI.TestUnifiedExecutable (test);
+		}
+
+		[Test]
+		public void ShouldRemovePackagedLibrary_OnceInBundle ()
+		{
+			MMPTests.RunMMPTest (tmpDir => {
+				BuildLinkedTestProjects (tmpDir);
+
+				string libPath = Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/MonoBundle/MobileBinding.dll");
+				Assert.True (File.Exists (libPath));
+				string monoDisResults = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monodis", "--presources " + libPath, "monodis");
+				Assert.IsFalse (monoDisResults.Contains ("SimpleClassDylib.dylib"));
+			});
+		}
+
+		[TestCase (false, false)]
+		[TestCase (true, false)]
+		[TestCase (true, true)]
+		public void ShouldBuildWithoutErrors_AndLinkCorrectFramework (bool full, bool removeTFI)
+		{
+			MMPTests.RunMMPTest (tmpDir => {
+				BuildLinkedTestProjects (tmpDir, full, removeTFI);
+
+				string libPath = Path.Combine (tmpDir, $"bin/Debug/{(full ? "XM45Example.app" : "UnifiedExample.app")}/Contents/MonoBundle/{BindingName (full)}.dll");
+				Assert.True (File.Exists (libPath));
+				string results = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monop", "--refs -r:" + libPath, "monop");
+				string mscorlibLine = results.Split (new char[] { '\n' }).First (x => x.Contains ("mscorlib"));
+
+				string expectedVersion = full ? "4.0.0.0" : "2.0.5.0";
+				Assert.True (mscorlibLine.Contains (expectedVersion), $"{mscorlibLine} did not contain expected version {expectedVersion}");
+			});
+		}
+	}
+}

--- a/tests/mmptest/src/BindingProjectTests.cs
+++ b/tests/mmptest/src/BindingProjectTests.cs
@@ -78,8 +78,6 @@ namespace Xamarin.MMP.Tests
 		[TestCase (ProjectType.Full)]
 		public void ShouldBuildWithoutErrors_AndLinkCorrectFramework (ProjectType type)
 		{
-			// TODO - Build and test BindingProjectWithNoTag.csproj which is Modern without tags
-			// TODO - Abstract this into a helper called by multiple tests
 			MMPTests.RunMMPTest (tmpDir => {
 				var projects = GenerateTestProject (type, tmpDir);
 				var logs = BuildLinkedTestProjects (projects.Item1, projects.Item2, tmpDir);

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -560,32 +560,6 @@ namespace Xamarin.MMP.Tests
 				}
 			});
 		}	
-				
-		public void UnifiedWithDepNativeRefLib_ShouldHaveItRemoved_OnceInBundle ()
-		{
-			RunMMPTest (tmpDir =>
-			{
-				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir)
-				{
-					ProjectName = "MobileBinding.csproj",
-					ItemGroup = string.Format (NativeReferenceTemplate, Path.GetFullPath (SimpleDylibPath), "Dynamic"),
-					StructsAndEnumsConfig = "public class UnifiedWithDepNativeRefLibTestClass {}"
-				};
-
-				string projectPath = TI.GenerateBindingLibraryProject (test);
-				TI.BuildProject (projectPath, true);
-
-				string referenceCode = string.Format (@"<Reference Include=""MobileBinding""><HintPath>{0}</HintPath></Reference>", Path.Combine (tmpDir, "bin/Debug", "MobileBinding.dll"));
-
-				test = new TI.UnifiedTestConfig (tmpDir) { References = referenceCode, TestCode = "System.Console.WriteLine (typeof (ExampleBinding.UnifiedWithDepNativeRefLibTestClass));" };
-				TI.TestUnifiedExecutable (test);
-
-				string libPath = Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/MonoBundle/MobileBinding.dll");
-				Assert.True (File.Exists (libPath));
-				string monoDisResults = TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/monodis", new StringBuilder ("--presources " + libPath), "monodis");
-				Assert.IsFalse (monoDisResults.Contains ("SimpleClassDylib.dylib"));
-			});
-		}
 
 		public const string BundleResourceTemplate = "<ItemGroup><BundleResource Include=\"{0}\" /></ItemGroup>";
 

--- a/tests/mmptest/src/NativeReferencesTests.cs
+++ b/tests/mmptest/src/NativeReferencesTests.cs
@@ -10,10 +10,10 @@ using System.Reflection;
 namespace Xamarin.MMP.Tests
 {
 	public partial class MMPTests {
-		const string ItemGroupTemplate = @"<ItemGroup>{0}</ItemGroup>";
-		const string NativeReferenceTemplate = @"<NativeReference Include=""{0}""><IsCxx>False</IsCxx><Kind>{1}</Kind></NativeReference>";
+		public const string ItemGroupTemplate = @"<ItemGroup>{0}</ItemGroup>";
+		public const string NativeReferenceTemplate = @"<NativeReference Include=""{0}""><IsCxx>False</IsCxx><Kind>{1}</Kind></NativeReference>";
 
-		public string SimpleDylibPath {
+		public static string SimpleDylibPath {
 			get {
 				string rootDir = TI.FindRootDirectory ();
 				string buildLibPath = Path.Combine (rootDir, "../tests/mac-binding-project/bin/SimpleClassDylib.dylib");
@@ -22,7 +22,7 @@ namespace Xamarin.MMP.Tests
 			}
 		}
 
-		public string SimpleStaticPath {
+		public static string SimpleStaticPath {
 			get {
 				string rootDir = TI.FindRootDirectory ();
 				string buildLibPath = Path.Combine (rootDir, "../tests/mac-binding-project/bin/SimpleClassStatic.a");
@@ -31,7 +31,7 @@ namespace Xamarin.MMP.Tests
 			}
 		}
 
-		public string MobileStaticBindingPath {
+		public static string MobileStaticBindingPath {
 			get {
 				string rootDir = TI.FindRootDirectory ();
 				string buildLibPath = Path.Combine (rootDir, "../tests/mac-binding-project/bin/Mobile-static/MobileBinding.dll");
@@ -40,9 +40,9 @@ namespace Xamarin.MMP.Tests
 			}
 		}
 
-		string CreateNativeRefInclude (string path, string kind) => string.Format (NativeReferenceTemplate, path, kind);
-		string CreateItemGroup (IEnumerable<string> elements) => string.Format (ItemGroupTemplate, string.Concat (elements));
-		string CreateSingleNativeRef (string path, string kind) => CreateItemGroup (CreateNativeRefInclude (path, kind).FromSingleItem ());
+		public static string CreateNativeRefInclude (string path, string kind) => string.Format (NativeReferenceTemplate, path, kind);
+		public static string CreateItemGroup (IEnumerable<string> elements) => string.Format (ItemGroupTemplate, string.Concat (elements));
+		public static string CreateSingleNativeRef (string path, string kind) => CreateItemGroup (CreateNativeRefInclude (path, kind).FromSingleItem ());
 
 		string CreateCopyOfSimpleClassInTestDir (string tmpDir, string fileName = "SimpleClassDylib.dylib")
 		{

--- a/tests/test-libraries/testgenerator.cs
+++ b/tests/test-libraries/testgenerator.cs
@@ -352,9 +352,6 @@ static class C {
 		WriteFrameworkDefines (w);
 		w.AppendLine (@"
 using System;
-#if !__WATCHOS__
-using System.Drawing;
-#endif
 
 #if __UNIFIED__
 using AVFoundation;
@@ -377,6 +374,9 @@ using Security;
 using UIKit;
 #endif
 #else
+#if !__WATCHOS__
+using System.Drawing;
+#endif
 using MonoTouch.ObjCRuntime;
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;


### PR DESCRIPTION
- Make a second attempt at https://github.com/xamarin/xamarin-macios/commit/d5b50765f5997f3bf23f8cea8fda3c0733b1e7bc
- Fixes https://github.com/xamarin/xamarin-macios/issues/3608
- This time with the knowledge that "default" binding project templates have tag structure unlike "normal" XM project, so let's default correctly.