### PR TITLE
[msbuild] fix creation ouf output dependency

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
@@ -145,9 +145,9 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="ILRepackOutput" />
       <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
     </Exec>
-    <Touch AlwaysCreate="true" Files="$(IntermediateOutputPath)ilrepack.txt" />
     <Message Importance="high" Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0'" />
     <Delete Files="$(IntermediateOutputPath)ilrepack.txt" Condition="'$(ExitCode)' != '0'" />
+    <Touch AlwaysCreate="true" Files="$(IntermediateOutputPath)ilrepack.txt" Condition="'$(ExitCode)' == '0'" />
     <Error Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0' And '$(ContinueOnError)' != 'true'" />
     <Delete Files="@(MergedAssemblies -> '$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" />
   </Target>

--- a/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
+++ b/msbuild/Xamarin.iOS.Tasks/Xamarin.iOS.Tasks.csproj
@@ -129,9 +129,9 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="ILRepackOutput" />
       <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
     </Exec>
-    <Touch AlwaysCreate="true" Files="$(IntermediateOutputPath)ilrepack.txt" />
     <Message Importance="high" Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0'" />
     <Delete Files="$(IntermediateOutputPath)ilrepack.txt" Condition="'$(ExitCode)' != '0'" />
+    <Touch AlwaysCreate="true" Files="$(IntermediateOutputPath)ilrepack.txt" Condition="'$(ExitCode)' == '0'" />
     <Error Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0' And '$(ContinueOnError)' != 'true'" />
     <Delete Files="@(MergedAssemblies -> '$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" />
   </Target>


### PR DESCRIPTION
attempt to fix https://github.com/mono/mono/issues/7518

`ilrepack.txt` should only be created if `ilrepack.exe` was successful.

To be honest, I've no idea what I'm doing, and it might not work for the problem we see on the bots. I had a similar issue _locally_ and this change fixed it for me, but I can't explain it really. My msbuild knowledge is pretty... bad 🙂 

That said, if I undestand the `ILRepack` task correctly, it does something like that translated to `make`:

```Makefile
ilrepack.txt: 1.dll 2.dll 3.dll 4.dll
  ilrepack /out:1.dll $^
  touch $@
```

That is funky and I think we shouldn't do that. Instead we should have a dedicated `.dll` for the merged result. Alas, I'm not able to translate that to `msbuild` words 😅 
