### PR TITLE
[jenkins] Clean keystore on bots before running tests

### DIFF
--- a/jenkins/run-tests.sh
+++ b/jenkins/run-tests.sh
@@ -10,5 +10,8 @@ security unlock-keychain -p `cat ~/.config/keychain`
 echo "Increase keychain unlock timeout"
 security set-keychain-settings -lut 7200
 
+# clean mono keypairs (used in tests)
+rm -rf ~/.config/.mono/keypairs/
+
 # Run tests
 make -C tests jenkins


### PR DESCRIPTION
Because if invalid data gets into the store then some unit tests
will always fail on that particular bot.

Fix https://github.com/xamarin/maccore/issues/640