### PR TITLE
[mmp][mtouch] Better guard framework SDK checks

### DIFF
--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -146,7 +146,7 @@ For more details: https://developer.apple.com/news/?id=06282017a
 
 Consider updating your application and any dependencies to 64-bit.
 
-### <a name="MM0135"/>MM0135: Did not link system framework '{0}' as Xcode SDK '{1}' is too old.
+### <a name="MM0135"/>MM0135: Did not link system framework '{0}' (referenced by assembly '{1}') because it was introduced in {2} {3}, and we're using the {2} {4} SDK.
 
 Xamarin.Mac contains API bindings for the listed framework which is newer than the Xcode used. 
 

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -148,12 +148,13 @@ Consider updating your application and any dependencies to 64-bit.
 
 ### <a name="MM0135"/>MM0135: Did not link system framework '{0}' (referenced by assembly '{1}') because it was introduced in {2} {3}, and we're using the {2} {4} SDK.
 
-Xamarin.Mac contains API bindings for the listed framework which is newer than the Xcode used. 
+To build your application, Xamarin.Mac must link against system libraries, some of which depend upon the SDK version specified in the error message. Since you are using an older version of the SDK, invocations to those APIs may fail at runtime.
 
-They may fail at runtime as we are not linking against the required system framework.
+The recommended way to fix this error is to upgrade Xcode to get the needed SDK. If you have multiple versions of Xcode installed or want to use an Xcode in a non-default location, make sure to set the correct Xcode location in your IDE's preferences.
 
-Consider updating to a newer Xcode, or if those APIs are not used, enabling [linking](https://docs.microsoft.com/en-us/xamarin/mac/deploy-test/linker).
+Alternatively, enable the managed [linker](https://docs.microsoft.com/xamarin/mac/deploy-test/linker) to remove unused APIs, including (in most cases) the new ones which require the specified library. However, this will not work if your project requires APIs introduced in a newer SDK than the one your Xcode provides.
 
+As a last straw solution, use an older version of Xamarin.Mac that does not require these new SDKs to be present during the build process.
 
 # MM1xxx: file copy / symlinks (project related)
 

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -146,6 +146,14 @@ For more details: https://developer.apple.com/news/?id=06282017a
 
 Consider updating your application and any dependencies to 64-bit.
 
+### <a name="MM0135"/>MM0135: Did not link system framework '{0}' as Xcode SDK '{1}' is too old.
+
+Xamarin.Mac contains API bindings for the listed framework which is newer than the Xcode used. 
+
+They may fail at runtime as we are not linking against the required system framework.
+
+Consider updating to a newer Xcode, or if those APIs are not used, enabling [linking](https://docs.microsoft.com/en-us/xamarin/mac/deploy-test/linker).
+
 
 # MM1xxx: file copy / symlinks (project related)
 

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -154,7 +154,7 @@ The recommended way to fix this error is to upgrade Xcode to get the needed SDK.
 
 Alternatively, enable the managed [linker](https://docs.microsoft.com/xamarin/mac/deploy-test/linker) to remove unused APIs, including (in most cases) the new ones which require the specified library. However, this will not work if your project requires APIs introduced in a newer SDK than the one your Xcode provides.
 
-As a last straw solution, use an older version of Xamarin.Mac that does not require these new SDKs to be present during the build process.
+As a last-straw solution, use an older version of Xamarin.Mac that does not require these new SDKs to be present during the build process.
 
 # MM1xxx: file copy / symlinks (project related)
 

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -679,7 +679,7 @@ To build your application, Xamarin.iOS must link against system libraries, some 
 
 The recommended way to fix this error is to upgrade Xcode to get the needed SDK. If you have multiple versions of Xcode installed or want to use an Xcode in a non-default location, make sure to set the correct Xcode location in your IDE's preferences.
 
-Alternatively, enable the managed [linker](https://docs.microsoft.com/en-us/xamarin/ios/deploy-test/linker?tabs=vsmac) to remove unused APIs, including (in most cases) the new ones which require the specified library. However, this will not work if your project requires APIs introduced in a newer SDK than the one your Xcode provides.
+Alternatively, enable the managed [linker](https://docs.microsoft.com/en-us/xamarin/ios/deploy-test/linker) to remove unused APIs, including (in most cases) the new ones which require the specified library. However, this will not work if your project requires APIs introduced in a newer SDK than the one your Xcode provides.
 
 As a last-straw solution, use an older version of Xamarin.iOS that does not require these new SDKs to be present during the build process.
 

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -673,7 +673,7 @@ When using --recursive-directories, only 1 assembly should match
 
 <!-- 0134 used by mmp -->
 
-### <a name="MT0135"/>MT0135: Did not link system framework '{0}' as Xcode SDK '{1}' is too old.
+### <a name="MT0135"/>MT0135: Did not link system framework '{0}' (referenced by assembly '{1}') because it was introduced in {2} {3}, and we're using the {2} {4} SDK.
 
 Xamarin.iOS contains API bindings for the listed framework which is newer than the Xcode used. 
 

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -673,6 +673,15 @@ When using --recursive-directories, only 1 assembly should match
 
 <!-- 0134 used by mmp -->
 
+### <a name="MT0135"/>MT0135: Did not link system framework '{0}' as Xcode SDK '{1}' is too old.
+
+Xamarin.iOS contains API bindings for the listed framework which is newer than the Xcode used. 
+
+They may fail at runtime as we are not linking against the required system framework.
+
+Consider updating to a newer Xcode, or if those APIs are not used, enabling [linking](https://docs.microsoft.com/en-us/xamarin/mac/deploy-test/linker).
+
+
 # MT1xxx: Project related error messages
 
 ### MT10xx: Installer / mtouch

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -681,7 +681,7 @@ The recommended way to fix this error is to upgrade Xcode to get the needed SDK.
 
 Alternatively, enable the managed [linker](https://docs.microsoft.com/en-us/xamarin/ios/deploy-test/linker?tabs=vsmac) to remove unused APIs, including (in most cases) the new ones which require the specified library. However, this will not work if your project requires APIs introduced in a newer SDK than the one your Xcode provides.
 
-As a last straw solution, use an older version of Xamarin.iOS that does not require these new SDKs to be present during the build process.
+As a last-straw solution, use an older version of Xamarin.iOS that does not require these new SDKs to be present during the build process.
 
 # MT1xxx: Project related error messages
 

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -675,12 +675,13 @@ When using --recursive-directories, only 1 assembly should match
 
 ### <a name="MT0135"/>MT0135: Did not link system framework '{0}' (referenced by assembly '{1}') because it was introduced in {2} {3}, and we're using the {2} {4} SDK.
 
-Xamarin.iOS contains API bindings for the listed framework which is newer than the Xcode used. 
+To build your application, Xamarin.iOS must link against system libraries, some of which depend upon the SDK version specified in the error message. Since you are using an older version of the SDK, invocations to those APIs may fail at runtime.
 
-They may fail at runtime as we are not linking against the required system framework.
+The recommended way to fix this error is to upgrade Xcode to get the needed SDK. If you have multiple versions of Xcode installed or want to use an Xcode in a non-default location, make sure to set the correct Xcode location in your IDE's preferences.
 
-Consider updating to a newer Xcode, or if those APIs are not used, enabling [linking](https://docs.microsoft.com/en-us/xamarin/mac/deploy-test/linker).
+Alternatively, enable the managed [linker](https://docs.microsoft.com/en-us/xamarin/ios/deploy-test/linker?tabs=vsmac) to remove unused APIs, including (in most cases) the new ones which require the specified library. However, this will not work if your project requires APIs introduced in a newer SDK than the one your Xcode provides.
 
+As a last straw solution, use an older version of Xamarin.iOS that does not require these new SDKs to be present during the build process.
 
 # MT1xxx: Project related error messages
 

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -29,6 +29,7 @@ namespace Xamarin.Tests
 		public static string xcode5_root;
 		public static string xcode6_root;
 		public static string xcode72_root;
+		public static string xcode83_root;
 #if MONOMAC
 		public static string mac_xcode_root;
 #endif
@@ -208,6 +209,7 @@ namespace Xamarin.Tests
 			xcode5_root = GetVariable ("XCODE5_DEVELOPER_ROOT", "/Applications/Xcode511.app/Contents/Developer");
 			xcode6_root = GetVariable ("XCODE6_DEVELOPER_ROOT", "/Applications/Xcode601.app/Contents/Developer");
 			xcode72_root = GetVariable ("XCODE72_DEVELOPER_ROOT", "/Applications/Xcode72.app/Contents/Developer");
+			xcode83_root = GetVariable ("XCODE83_DEVELOPER_ROOT", "/Applications/Xcode83.app/Contents/Developer");
 			include_ios = !string.IsNullOrEmpty (GetVariable ("INCLUDE_IOS", ""));
 			include_mac = !string.IsNullOrEmpty (GetVariable ("INCLUDE_MAC", ""));
 			include_tvos = !string.IsNullOrEmpty (GetVariable ("INCLUDE_TVOS", ""));

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -103,6 +103,7 @@
     <Compile Include="..\..\tools\common\StringUtils.cs">
       <Link>StringUtils.cs</Link>
     </Compile>
+    <Compile Include="src\WarningTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/mmptest/src/WarningTests.cs
+++ b/tests/mmptest/src/WarningTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO;
+using NUnit.Framework;
+
+namespace Xamarin.MMP.Tests
+{
+	[TestFixture]
+	public class WarningTests
+	{
+		[Test]
+		public void MM0135 ()
+		{
+			var oldXcode = Xamarin.Tests.Configuration.xcode83_root;
+
+			if (!Directory.Exists (oldXcode))
+				Assert.Ignore ("This test requires Xcode 8.3 (or updated to a newer one that still warns MM0135).");
+
+			MMPTests.RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir);
+				var output = TI.TestUnifiedExecutable (test, environment: new string[] { "MD_APPLE_SDK_ROOT", Path.GetDirectoryName (Path.GetDirectoryName (oldXcode)) });
+				output.Messages.AssertWarningPattern (135, $"Did not link system framework");
+			});
+		}
+	}
+}

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -328,6 +328,15 @@ namespace Xamarin.Bundler {
 			return linkWith;
 		}
 
+		void AddFramework (string file)
+		{
+			Framework framework;
+			if (Driver.GetFrameworks (App).TryGetValue (file, out framework) && framework.Version > App.SdkVersion)
+				Driver.Log (3, "Not linking with the framework {0} (referenced by a module reference in {1}) because it was introduced in {2} {3}, and we're using the {2} {4} SDK.", file, FileName, App.PlatformName, framework.Version, App.SdkVersion);
+			else if (Frameworks.Add (file))
+				Driver.Log (3, "Linking with the framework {0} because it's referenced by a module reference in {1}", file, FileName);
+		}
+
 		public void ComputeLinkerFlags ()
 		{
 			foreach (var m in AssemblyDefinition.Modules) {
@@ -382,8 +391,7 @@ namespace Xamarin.Bundler {
 #if MTOUCH
 						if (!App.IsSimulatorBuild) {
 #endif
-							if (Frameworks.Add (file))
-								Driver.Log (3, "Linking with the framework {0} because it's referenced by a module reference in {1}", file, FileName);
+							AddFramework (file);
 #if MTOUCH
 						}
 #endif
@@ -415,11 +423,7 @@ namespace Xamarin.Bundler {
 						// detect frameworks
 						int f = name.IndexOf (".framework/", StringComparison.Ordinal);
 						if (f > 0) {
-							Framework framework;
-							if (Driver.GetFrameworks (App).TryGetValue (file, out framework) && framework.Version > App.SdkVersion)
-								Driver.Log (3, "Not linking with the framework {0} (referenced by a module reference in {1}) because it was introduced in {2} {3}, and we're using the {2} {4} SDK.", file, FileName, App.PlatformName, framework.Version, App.SdkVersion);
-							else if (Frameworks.Add (file))
-								Driver.Log (3, "Linking with the framework {0} because it's referenced by a module reference in {1}", file, FileName);
+							AddFramework (file);
 						} else {
 							if (UnresolvedModuleReferences == null)
 								UnresolvedModuleReferences = new HashSet<ModuleReference> ();

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -331,7 +331,7 @@ namespace Xamarin.Bundler {
 		void AddFramework (string file)
 		{
 			if (Driver.GetFrameworks (App).TryGetValue (file, out var framework) && framework.Version > App.SdkVersion)
-				ErrorHelper.Warning (135, "Did not link system framework '{0}' as Xcode SDK '{1}' is too old.", file, App.SdkVersion);
+				ErrorHelper.Warning (135, "Did not link system framework '{0}' (referenced by assembly '{1}') because it was introduced in {2} {3}, and we're using the {2} {4} SDK.", file, FileName, App.PlatformName, framework.Version, App.SdkVersion);
 			else if (Frameworks.Add (file))
 				Driver.Log (3, "Linking with the framework {0} because it's referenced by a module reference in {1}", file, FileName);
 		}

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -330,9 +330,8 @@ namespace Xamarin.Bundler {
 
 		void AddFramework (string file)
 		{
-			Framework framework;
-			if (Driver.GetFrameworks (App).TryGetValue (file, out framework) && framework.Version > App.SdkVersion)
-				Driver.Log (3, "Not linking with the framework {0} (referenced by a module reference in {1}) because it was introduced in {2} {3}, and we're using the {2} {4} SDK.", file, FileName, App.PlatformName, framework.Version, App.SdkVersion);
+			if (Driver.GetFrameworks (App).TryGetValue (file, out var framework) && framework.Version > App.SdkVersion)
+				ErrorHelper.Warning (135, "Did not link system framework '{0}' as Xcode SDK '{1}' is too old.", file, App.SdkVersion);
 			else if (Frameworks.Add (file))
 				Driver.Log (3, "Linking with the framework {0} because it's referenced by a module reference in {1}", file, FileName);
 		}


### PR DESCRIPTION
- https://github.com/xamarin/xamarin-macios/issues/3725
- These frameworks "CoreAudioKit Metal MetalKit MetalPerformanceShaders CoreNFC DeviceCheck"
 were special cased, but that special case did do an SDK check.
- Create a helper method to share check