### PR TITLE
Reorganize MMP tests

### DIFF
--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -104,6 +104,7 @@
       <Link>StringUtils.cs</Link>
     </Compile>
     <Compile Include="src\SmokeTests.cs" />
+    <Compile Include="src\RegistrarTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -105,6 +105,7 @@
     </Compile>
     <Compile Include="src\SmokeTests.cs" />
     <Compile Include="src\RegistrarTests.cs" />
+    <Compile Include="src\AssemblyReferencesTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -103,6 +103,7 @@
     <Compile Include="..\..\tools\common\StringUtils.cs">
       <Link>StringUtils.cs</Link>
     </Compile>
+    <Compile Include="src\SmokeTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/mmptest/src/AOTTests.cs
+++ b/tests/mmptest/src/AOTTests.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 namespace Xamarin.MMP.Tests
 {
 	[TestFixture]
-	public partial class MMPTests
+	public class AOTTests
 	{
 		void ValidateAOTStatus (string tmpDir, Func<FileInfo, bool> shouldAOT, string buildResults)
 		{ 
@@ -34,7 +34,7 @@ namespace Xamarin.MMP.Tests
 		// AOT unit tests can be found in tools/mmp/tests
 		[Test]
 		public void AOT_SmokeTest () {
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
 					CSProjConfig = AOTTestBaseConfig
 				};
@@ -47,7 +47,7 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void AOT_32Bit_SmokeTest ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
 					CSProjConfig = "<XamMacArch>i386</XamMacArch>" + AOTTestBaseConfig
 				};
@@ -60,7 +60,7 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void HybridAOT_WithManualStrippingOfAllLibs_SmokeTest ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
 					CSProjConfig = AOTTestHybridConfig
 				};
@@ -81,7 +81,7 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void HybridAOT_WithManualStrippingOfJustMainExe ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
 					CSProjConfig = AOTTestHybridConfig
 				};

--- a/tests/mmptest/src/AssemblyReferencesTests.cs
+++ b/tests/mmptest/src/AssemblyReferencesTests.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+
+namespace Xamarin.MMP.Tests
+{
+	[TestFixture]
+	public class AssemblyReferencesTests
+	{
+		[Test]
+		public void ShouldNotAllowReference_ToSystemDrawing ()
+		{
+			MMPTests.RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					References = " <Reference Include=\"System.Drawing\" />",
+					TestCode = "System.Drawing.RectangleF f = new System.Drawing.RectangleF ();",
+					XM45 = true
+				};
+				TI.TestUnifiedExecutable (test, shouldFail: true);
+			});
+		}
+
+		[TestCase (false)]
+		[TestCase (true)]
+		public void ShouldAllowReference_ToOpenTK (bool full)
+		{
+			MMPTests.RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					References = " <Reference Include=\"OpenTK\" />",
+					TestCode = "var matrix = new OpenTK.Matrix2 ();",
+					XM45 = full 
+				};
+				TI.TestUnifiedExecutable (test);
+			});
+		}
+
+		[Test]
+		public void AllowsUnresolvableReferences ()
+		{
+			MMPTests.RunMMPTest (tmpDir => {
+				var sb = new StringBuilder ();
+
+				// build b.dll
+				sb.Clear ();
+				sb.AppendFormat ("-target:library -out:{0}/b.dll {0}/b.cs", tmpDir);
+				File.WriteAllText (Path.Combine (tmpDir, "b.cs"), "public class B { }");
+				TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mcs", sb, "b");
+
+				// build a.dll
+				sb.Clear ();
+				sb.AppendFormat ("-target:library -out:{0}/a.dll {0}/a.cs -r:{0}/b.dll", tmpDir);
+				File.WriteAllText (Path.Combine (tmpDir, "a.cs"), "public class A { public A () { System.Console.WriteLine (typeof (B)); }}");
+				TI.RunAndAssert ("/Library/Frameworks/Mono.framework/Commands/mcs", sb, "a");
+
+				File.Delete (Path.Combine (tmpDir, "b.dll"));
+
+				// build project referencing a.dll
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					References = string.Format (" <Reference Include=\"a\" > <HintPath>{0}/a.dll</HintPath> </Reference> ", tmpDir),
+					TestCode = "System.Console.WriteLine (typeof (A));",
+				};
+				TI.GenerateAndBuildUnifiedExecutable (test);
+			});
+		}
+
+		[TestCase (false)]
+		[TestCase (true)]
+		public void UnsafeGACResolutionOptions_AllowsWindowsBaseResolution (bool full)
+		{
+			MMPTests.RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					XM45 = full,
+					TestCode = "System.Console.WriteLine (typeof (System.Windows.DependencyObject));",
+					References = "<Reference Include=\"WindowsBase\" /><Reference Include=\"System.Xaml\" />"
+				};
+
+				TI.TestUnifiedExecutable (test, shouldFail: true);
+
+				// Modern will fail terribly due to mismatch BCL, but Full should allow if we ask "nicely"
+				if (full) {
+					test.CSProjConfig = "<MonoBundlingExtraArgs>--allow-unsafe-gac-resolution</MonoBundlingExtraArgs>";
+					TI.TestUnifiedExecutable (test);
+				}
+			});
+		}
+	}
+}

--- a/tests/mmptest/src/ClassicTests.cs
+++ b/tests/mmptest/src/ClassicTests.cs
@@ -9,7 +9,8 @@ using System.Reflection;
 
 namespace Xamarin.MMP.Tests
 {
-	public partial class MMPTests 
+	[TestFixture]
+	public class ClassicTests
 	{
 		bool ShouldSkipClassicTest
 		{
@@ -25,7 +26,7 @@ namespace Xamarin.MMP.Tests
 			if (ShouldSkipClassicTest)
 				return;
 
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				TI.TestClassicExecutable (tmpDir);
 			});
 		}
@@ -39,7 +40,7 @@ namespace Xamarin.MMP.Tests
 			const string IntPtrTestCase = @"NSDictionary d = new NSDictionary ();
 				NSObject o = d;
 				NSObject v = o.ValueForKey ((NSString)""count"");";
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				TI.TestClassicExecutable (tmpDir, IntPtrTestCase);
 			});
 		}
@@ -50,7 +51,7 @@ namespace Xamarin.MMP.Tests
 			if (ShouldSkipClassicTest)
 				return;
 
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				string buildOutput = TI.TestClassicExecutable (tmpDir, csprojConfig : "<IncludeMonoRuntime>true</IncludeMonoRuntime><MonoBundlingExtraArgs>--new-refcount=false</MonoBundlingExtraArgs>").BuildOutput;
 				Assert.IsTrue (buildOutput.Contains ("Disabling the new refcount logic is deprecated"), "Classic_NewRefCount_Warns did not warn as expected:\n\n", buildOutput);
 			});

--- a/tests/mmptest/src/ExtensionTests.cs
+++ b/tests/mmptest/src/ExtensionTests.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 namespace Xamarin.MMP.Tests
 {
 	[TestFixture]
-	public partial class MMPTests 
+	public class ExtensionTests 
 	{
 		[Test]
 		public void TodayExtension_SmokeTest ()
@@ -18,7 +18,7 @@ namespace Xamarin.MMP.Tests
 			if (!PlatformHelpers.CheckSystemVersion (10, 10))
 				return;
 
-			RunMMPTest (tmpDir =>
+			MMPTests.RunMMPTest (tmpDir =>
 			{
 				string testPath = Path.Combine (TI.FindSourceDirectory (), @"Today/TodayExtensionTest.csproj");
 				TI.BuildProject (testPath, isUnified: true);
@@ -31,7 +31,7 @@ namespace Xamarin.MMP.Tests
 			if (!PlatformHelpers.CheckSystemVersion (10, 10))
 				return;
 
-			RunMMPTest (tmpDir =>
+			MMPTests.RunMMPTest (tmpDir =>
 			{
 				string testPath = Path.Combine (TI.FindSourceDirectory (), @"Finder/FinderExtensionTest.csproj");
 				TI.BuildProject (testPath, isUnified: true);
@@ -44,7 +44,7 @@ namespace Xamarin.MMP.Tests
 			if (!PlatformHelpers.CheckSystemVersion (10, 10))
 				return;
 
-			RunMMPTest (tmpDir =>
+			MMPTests.RunMMPTest (tmpDir =>
 			{
 				string testPath = Path.Combine (TI.FindSourceDirectory (), @"Share/ShareExtensionTest.csproj");
 				TI.BuildProject (testPath, isUnified: true);

--- a/tests/mmptest/src/FrameworkLinksTests.cs
+++ b/tests/mmptest/src/FrameworkLinksTests.cs
@@ -1,6 +1,4 @@
-﻿#define ENABLE_STATIC_REGISTRAR_TESTS
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -73,11 +71,9 @@ namespace Xamarin.MMP.Tests
 				string [] clangParts = MMPTests.GetUnifiedProjectClangInvocation (tmpDir);
 				AssertUnlinkedFrameworkStatus (clangParts);
 
-#if ENABLE_STATIC_REGISTRAR_TESTS
 				// Even with static registrar
 				clangParts = MMPTests.GetUnifiedProjectClangInvocation (tmpDir, StaticRegistrarConfig);
 				AssertUnlinkedFrameworkStatus (clangParts);
-#endif
 			});
 		}
 
@@ -101,11 +97,9 @@ namespace Xamarin.MMP.Tests
 				string[] clangParts = MMPTests.GetUnifiedProjectClangInvocation (tmpDir, LinkerEnabledConfig);
 				AssertLinkedFrameworkStatus (clangParts);
 
-#if ENABLE_STATIC_REGISTRAR_TESTS
 				// Even with static registrar
 				clangParts = MMPTests.GetUnifiedProjectClangInvocation (tmpDir, LinkerEnabledConfig + StaticRegistrarConfig);
 				AssertLinkedFrameworkStatus (clangParts);
-#endif
 			});
 		}
 

--- a/tests/mmptest/src/FrameworkLinksTests.cs
+++ b/tests/mmptest/src/FrameworkLinksTests.cs
@@ -11,7 +11,8 @@ using System.Reflection;
 
 namespace Xamarin.MMP.Tests
 {
-	public partial class MMPTests
+	[TestFixture]
+	public class FrameworkLinkTests
 	{
 		const string LinkerEnabledConfig = "<LinkMode>Full</LinkMode>";
 		const string StaticRegistrarConfig = "<MonoBundlingExtraArgs>--registrar=static</MonoBundlingExtraArgs>";
@@ -67,14 +68,14 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void UnifiedWithoutLinking_ShouldHaveManyFrameworkClangLines ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				// By default we -framework in all frameworks we bind.
-				string [] clangParts = GetUnifiedProjectClangInvocation (tmpDir);
+				string [] clangParts = MMPTests.GetUnifiedProjectClangInvocation (tmpDir);
 				AssertUnlinkedFrameworkStatus (clangParts);
 
 #if ENABLE_STATIC_REGISTRAR_TESTS
 				// Even with static registrar
-				clangParts = GetUnifiedProjectClangInvocation (tmpDir, StaticRegistrarConfig);
+				clangParts = MMPTests.GetUnifiedProjectClangInvocation (tmpDir, StaticRegistrarConfig);
 				AssertUnlinkedFrameworkStatus (clangParts);
 #endif
 			});
@@ -95,14 +96,14 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void UnifiedWithLinking_ShouldHaveFewFrameworkClangLines ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				// When we link, we should throw away pretty much everything that isn't AppKit. 
-				string[] clangParts = GetUnifiedProjectClangInvocation (tmpDir, LinkerEnabledConfig);
+				string[] clangParts = MMPTests.GetUnifiedProjectClangInvocation (tmpDir, LinkerEnabledConfig);
 				AssertLinkedFrameworkStatus (clangParts);
 
 #if ENABLE_STATIC_REGISTRAR_TESTS
 				// Even with static registrar
-				clangParts = GetUnifiedProjectClangInvocation (tmpDir, LinkerEnabledConfig + StaticRegistrarConfig);
+				clangParts = MMPTests.GetUnifiedProjectClangInvocation (tmpDir, LinkerEnabledConfig + StaticRegistrarConfig);
 				AssertLinkedFrameworkStatus (clangParts);
 #endif
 			});
@@ -125,7 +126,7 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void ProjectWithLinkToPrivateFramework_ShouldBuild ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { TestDecl = @"
 	const string MobileDeviceLibrary = ""/System/Library/PrivateFrameworks/MobileDevice.framework/MobileDevice"";
@@ -140,7 +141,7 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void ProjectWithSubFramework_ShouldBuild ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { TestDecl = @"
 	[System.Runtime.InteropServices.DllImport (""/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/LaunchServices"")]

--- a/tests/mmptest/src/LinkerTests.cs
+++ b/tests/mmptest/src/LinkerTests.cs
@@ -9,7 +9,8 @@ using System.Reflection;
 
 namespace Xamarin.MMP.Tests
 {
-	public partial class MMPTests
+	[TestFixture]
+	public class LinkerTests
 	{
 		int GetNumberOfTypesInLibrary (string path)
 		{
@@ -32,7 +33,7 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void ModernLinkingSDK_WithAllNonProductSkipped_BuildsWithSameNumberOfTypes ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				string[] dependencies = { "mscorlib", "System.Core", "System" };
 				string config = "<LinkMode>SdkOnly</LinkMode><MonoBundlingExtraArgs>--linkskip=" + dependencies.Aggregate ((arg1, arg2) => arg1 + " --linkskip=" + arg2) + "</MonoBundlingExtraArgs>";
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { CSProjConfig = config };
@@ -48,7 +49,7 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void FullLinkingSdk_BuildsWithFewerPlatformTypesOnly ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				string[] nonPlatformDependencies = { "mscorlib", "System.Core", "System" };
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { CSProjConfig = PlatformProjectConfig, XM45 = true };
 				TI.TestUnifiedExecutable (test);
@@ -68,7 +69,7 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void PlatformSDKOnClassic_ShouldNotBeSupported ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				TI.TestClassicExecutable (tmpDir, csprojConfig: "<MonoBundlingExtraArgs>--linkplatform</MonoBundlingExtraArgs>\n", includeMonoRuntime:true, shouldFail: true);
 			});
 		}
@@ -80,7 +81,7 @@ namespace Xamarin.MMP.Tests
 		[TestCase ("default")]
 		public void DynamicSymbolMode (string mode)
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				TI.UnifiedTestConfig config = new TI.UnifiedTestConfig (tmpDir) {
 					CSProjConfig = $"<MonoBundlingExtraArgs>--dynamic-symbol-mode={mode}</MonoBundlingExtraArgs>\n", 
 				};
@@ -111,7 +112,7 @@ namespace Xamarin.MMP.Tests
 		[TestCase ("sdkonly", true)]
 		public void Linking_ShouldHandleMixedModeAssemblies (string linker, bool builds_successfully)
 		{
-			RunMMPTest(tmpDir => {
+			MMPTests.RunMMPTest(tmpDir => {
 				string libraryPath = Path.Combine (TI.FindSourceDirectory (), "../MixedClassLibrary.dll");
 
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -20,7 +20,7 @@ namespace Xamarin.MMP.Tests
 		}
 
 		// TODO - We have multiple tests using this. It doesn't take that long, but is it worth caching?
-		string [] GetUnifiedProjectClangInvocation (string tmpDir, string projectConfig = "")
+		public static string [] GetUnifiedProjectClangInvocation (string tmpDir, string projectConfig = "")
 		{
 			TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { CSProjConfig = projectConfig };
 			string buildOutput = TI.TestUnifiedExecutable (test).BuildOutput;
@@ -568,7 +568,7 @@ namespace Xamarin.MMP.Tests
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir)
 				{
 					ProjectName = "MobileBinding.csproj",
-					ItemGroup = string.Format (NativeReferenceTemplate, Path.GetFullPath (SimpleDylibPath), "Dynamic"),
+					ItemGroup = string.Format (NativeReferenceTests.NativeReferenceTemplate, Path.GetFullPath (NativeReferenceTests.SimpleDylibPath), "Dynamic"),
 					StructsAndEnumsConfig = "public class UnifiedWithDepNativeRefLibTestClass {}"
 				};
 

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -133,49 +133,6 @@ namespace Xamarin.MMP.Tests
 			});
 		}
 
-		[Test]
-		public void Unified_SmokeTest ()
-		{
-			RunMMPTest (tmpDir => {
-				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir);
-				// Mobile
-				TI.TestUnifiedExecutable (test);
-				// XM45
-				test.XM45 = true;
-				TI.TestUnifiedExecutable (test);
-			});
-		}
-
-		[Test]
-		public void FSharp_SmokeTest ()
-		{
-			RunMMPTest (tmpDir => {
-				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { FSharp = true };
-				// Mobile
-				TI.TestUnifiedExecutable (test);
-				// XM45
-				test.XM45 = true;
-				TI.TestUnifiedExecutable (test);
-			});
-		}
-
-		[Test]
-		public void Mobile_SmokeTest_LinkSDK ()
-		{
-			RunMMPTest (tmpDir => {
-				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { CSProjConfig = "<LinkMode>SdkOnly</LinkMode>" };
-				TI.TestUnifiedExecutable (test);
-			});
-		}
-
-		[Test]
-		public void Mobile_SmokeTest_LinkAll ()
-		{
-			RunMMPTest (tmpDir => {
-				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { CSProjConfig = "<LinkMode>Full</LinkMode>" };
-				TI.TestUnifiedExecutable (test);
-			});
-		}
 
 		[Test]
 		public void Mobile_NewRefCount_Warns ()
@@ -275,29 +232,6 @@ namespace Xamarin.MMP.Tests
 			});
 		}
 
-		[Test]
-		public void SystemMono_SmokeTest ()
-		{
-			if (TI.FindMonoVersion () < new Version ("4.3"))
-				return;
-
-			RunMMPTest (tmpDir => {
-				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir);
-				TI.TestSystemMonoExecutable (test);
-
-				test.SystemMonoVersion = "4.5";
-				TI.TestSystemMonoExecutable (test);
-
-				test.SystemMonoVersion = "4.5.1";
-				TI.TestSystemMonoExecutable (test);
-
-				test.SystemMonoVersion = "4.6";
-				TI.TestSystemMonoExecutable (test);
-
-				test.SystemMonoVersion = "4.6.1";
-				TI.TestSystemMonoExecutable (test);
-			});
-		}
 
 		[Test]
 		public void BuildUnifiedMobile_Program_WithNonASCIIName ()

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -1,5 +1,3 @@
-#define ENABLE_STATIC_REGISTRAR_TESTS
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -69,58 +67,6 @@ namespace Xamarin.MMP.Tests
 			});
 		}
 
-#if ENABLE_STATIC_REGISTRAR_TESTS
-		[Test]
-#endif
-		public void Unified_Static_RegistrarTest ()
-		{
-			if (!PlatformHelpers.CheckSystemVersion (10, 11))
-				return;
-
-			RunMMPTest (tmpDir => {
-				// First in 64-bit
-				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { CSProjConfig = "<MonoBundlingExtraArgs>--registrar=static</MonoBundlingExtraArgs><XamMacArch>x86_64</XamMacArch>" };
-				// Mobile
-				TI.TestUnifiedExecutable (test);
-				// XM45
-				test.XM45 = true;
-				TI.TestUnifiedExecutable (test);
-
-				// Now 32-bit
-				test.CSProjConfig = "<MonoBundlingExtraArgs>--registrar=static</MonoBundlingExtraArgs><XamMacArch>i386</XamMacArch>";
-				// Mobile
-				TI.TestUnifiedExecutable (test);
-				// XM45
-				test.XM45 = true;
-				TI.TestUnifiedExecutable (test);
-			});
-		}
-
-		[Test]
-		public void Unified_Static_Registrar_With_SpaceTest ()
-		{
-			if (!PlatformHelpers.CheckSystemVersion (10, 11))
-				return;
-
-			RunMMPTest (tmpDir => {
-				// First in 64-bit
-				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { CSProjConfig = "<MonoBundlingExtraArgs>--registrar=static</MonoBundlingExtraArgs><XamMacArch>x86_64</XamMacArch>" };
-				// Mobile
-				TI.TestUnifiedExecutable (test);
-				// XM45
-				test.XM45 = true;
-				TI.TestUnifiedExecutable (test);
-
-				// Now 32-bit
-				test.CSProjConfig = "<MonoBundlingExtraArgs>--registrar=static</MonoBundlingExtraArgs><XamMacArch>i386</XamMacArch>";
-				// Mobile
-				TI.TestUnifiedExecutable (test);
-				// XM45
-				test.XM45 = true;
-				TI.TestUnifiedExecutable (test);
-			}, "test withSpace");
-		}
-
 		[Test]
 		public void XM_45_NotAddingIncorrectDependencies_LicenseTest ()
 		{
@@ -132,7 +78,6 @@ namespace Xamarin.MMP.Tests
 				Assert.IsFalse (Directory.GetFiles (monoBundlePath).Any (x => x.Contains ("FSharp.Core.dll")), "F# was pulled in?");
 			});
 		}
-
 
 		[Test]
 		public void Mobile_NewRefCount_Warns ()
@@ -231,7 +176,6 @@ namespace Xamarin.MMP.Tests
 				Assert.IsTrue (!output.Contains ("Could not register the assembly"), "Unified_HelloWorld_ShouldHaveNoRegistrarWarnings - XM45 had registrar issues: \n" + output);
 			});
 		}
-
 
 		[Test]
 		public void BuildUnifiedMobile_Program_WithNonASCIIName ()
@@ -564,9 +508,7 @@ namespace Xamarin.MMP.Tests
 			});
 		}
 
-#if ENABLE_STATIC_REGISTRAR_TESTS
 		[Test]
-#endif
 		public void UnifiedDebugBuilds_ShouldLinkToPartialStatic_UnlessDisabled ()
 		{
 			RunMMPTest (tmpDir =>

--- a/tests/mmptest/src/NativeReferencesTests.cs
+++ b/tests/mmptest/src/NativeReferencesTests.cs
@@ -9,11 +9,11 @@ using System.Reflection;
 
 namespace Xamarin.MMP.Tests
 {
-	public partial class MMPTests {
-		const string ItemGroupTemplate = @"<ItemGroup>{0}</ItemGroup>";
-		const string NativeReferenceTemplate = @"<NativeReference Include=""{0}""><IsCxx>False</IsCxx><Kind>{1}</Kind></NativeReference>";
+	public class NativeReferenceTests {
+		public const string ItemGroupTemplate = @"<ItemGroup>{0}</ItemGroup>";
+		public const string NativeReferenceTemplate = @"<NativeReference Include=""{0}""><IsCxx>False</IsCxx><Kind>{1}</Kind></NativeReference>";
 
-		public string SimpleDylibPath {
+		public static string SimpleDylibPath {
 			get {
 				string rootDir = TI.FindRootDirectory ();
 				string buildLibPath = Path.Combine (rootDir, "../tests/mac-binding-project/bin/SimpleClassDylib.dylib");
@@ -81,7 +81,7 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void Unified_WithNativeReferences_InMainProjectWorks ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				// Could be any dylib not in /System
 				const string SystemLibPath = "/Library/Frameworks/Mono.framework/Versions/Current/lib/libsqlite3.0.dylib";
 
@@ -107,7 +107,7 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void Unified_WithStaticNativeRef_ClangIncludesOurStaticLib ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { ItemGroup = CreateSingleNativeRef (SimpleStaticPath, "Static") };
 				NativeReferenceTestCore (tmpDir, test, "Unified_WithNativeReferences_InMainProjectWorks - Static", null, true, false, s => {
 					string clangLine = s.Split ('\n').First (x => x.Contains ("xcrun -sdk macosx clang"));
@@ -119,7 +119,7 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void Unified_WithStaticNativeRef_32bit ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
 					CSProjConfig = "<XamMacArch>i386</XamMacArch>",
 					References = $"<Reference Include=\"SimpleBinding_static\"><HintPath>{MobileStaticBindingPath}</HintPath></Reference>",
@@ -132,7 +132,7 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void Unified_WithNativeReferences_MissingLibrariesActAsExpected ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { ItemGroup = CreateSingleNativeRef ("/Library/Frameworks/ALibThatDoesNotExist.dylib", "Dynamic") };
 				NativeReferenceTestCore (tmpDir, test, "Unified_WithNativeReferences_MissingLibrariesActAsExpected - Nonexistant", null, false);
 
@@ -149,7 +149,7 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void Unified_WithNativeReferences_IgnoredWorks ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
 					ItemGroup = CreateSingleNativeRef (Path.GetFullPath (SimpleDylibPath), "Dynamic"),
 					CSProjConfig = string.Format (@"<MonoBundlingExtraArgs>--ignore-native-library=""{0}""</MonoBundlingExtraArgs>", Path.GetFullPath (SimpleDylibPath))
@@ -162,7 +162,7 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void Unified_WithNativeReferences_ReadOnlyNativeLib ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				string filePath = CreateCopyOfSimpleClassInTestDir (tmpDir);
 				File.SetAttributes (filePath, FileAttributes.ReadOnly);
 
@@ -176,7 +176,7 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void NativeReference_WithDllImportOfSamePath_Builds ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				string filePath = CreateCopyOfSimpleClassInTestDir (tmpDir);
 
 				// Use absolute path here and in TestDecl to trigger bug
@@ -195,7 +195,7 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void MultipleNativeReferences_OnlyInvokeMMPOneTime_AndCopyEverythingIn ()
 		{
-			RunMMPTest (tmpDir => {
+			MMPTests.RunMMPTest (tmpDir => {
 				string firstPath = CreateCopyOfSimpleClassInTestDir (tmpDir);
 				string secondPath = CreateCopyOfSimpleClassInTestDir (tmpDir, "SeconClassDylib.dylib");
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {

--- a/tests/mmptest/src/NetStandardTests.cs
+++ b/tests/mmptest/src/NetStandardTests.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 
 namespace Xamarin.MMP.Tests {
 	[TestFixture]
-	public partial class NetStandardTests {
+	public class NetStandardTests {
 		// [Test] https://bugzilla.xamarin.com/show_bug.cgi?id=53164
 		public void ModernUsingNetStandardLib_SmokeTest ()
 		{

--- a/tests/mmptest/src/RegistrarTests.cs
+++ b/tests/mmptest/src/RegistrarTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Xamarin.MMP.Tests
+{
+	[TestFixture]
+	public class RegistrarTests
+	{
+		[TestCase (false, "x86_64")]
+		[TestCase (true, "x86_64")]
+		[TestCase (false, "i386")]
+		[TestCase (true, "i386")]
+		public void SmokeTest (bool full, string arch)
+		{
+			if (!PlatformHelpers.CheckSystemVersion (10, 11))
+				return;
+
+			MMPTests.RunMMPTest (tmpDir => {
+				// First in 64-bit
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					CSProjConfig = $"<MonoBundlingExtraArgs>--registrar=static</MonoBundlingExtraArgs><XamMacArch>{arch}</XamMacArch>",
+					XM45 = full
+				};
+				var output = TI.TestUnifiedExecutable (test).RunOutput;
+
+				Assert.IsTrue (!output.Contains ("Could not register the assembly"), "Could not register the assembly errors found:\n" + output);
+			});
+		}
+
+		[TestCase (false, "x86_64")]
+		[TestCase (true, "x86_64")]
+		[TestCase (false, "i386")]
+		[TestCase (true, "i386")]
+		public void DirectoryContainsSpaces (bool full, string arch)
+		{
+			if (!PlatformHelpers.CheckSystemVersion (10, 11))
+				return;
+
+			MMPTests.RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					CSProjConfig = $"<MonoBundlingExtraArgs>--registrar=static</MonoBundlingExtraArgs><XamMacArch>{arch}</XamMacArch>",
+					XM45 = full
+				};
+			}, "test withSpace");
+		}
+
+	}
+}

--- a/tests/mmptest/src/SmokeTests.cs
+++ b/tests/mmptest/src/SmokeTests.cs
@@ -1,10 +1,73 @@
 ﻿using System;
-namespace Xamarin.MMP.Tests.src
+
+using NUnit.Framework;
+
+namespace Xamarin.MMP.Tests
 {
+	[TestFixture]
 	public class SmokeTests
 	{
-		public SmokeTests ()
+		[TestCase (false)]
+		[TestCase (true)]
+		public void Unified_SmokeTest (bool full)
 		{
+			MMPTests.RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					XM45 = full
+				};
+				TI.TestUnifiedExecutable (test);
+			});
 		}
+
+		[TestCase (false)]
+		[TestCase (true)]
+		public void FSharp_SmokeTest (bool full)
+		{
+			MMPTests.RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					FSharp = true,
+					XM45 = full
+				};
+				TI.TestUnifiedExecutable (test);
+			});
+		}
+
+		[Test]
+		public void Modern_SmokeTest_LinkSDK ()
+		{
+			MMPTests.RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { CSProjConfig = "<LinkMode>SdkOnly</LinkMode>" };
+				TI.TestUnifiedExecutable (test);
+			});
+		}
+
+		[Test]
+		public void Modern_SmokeTest_LinkAll ()
+		{
+			MMPTests.RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { CSProjConfig = "<LinkMode>Full</LinkMode>" };
+				TI.TestUnifiedExecutable (test);
+			});
+		}
+
+		[TestCase ("")]
+		[TestCase ("4.5")]
+		[TestCase ("4.5.1")]
+		[TestCase ("4.6")]
+		[TestCase ("4.6.1")]
+		[TestCase ("4.7")]
+		public void SystemMono_SmokeTest (string version)
+		{
+			if (TI.FindMonoVersion () < new Version ("4.3"))
+				return;
+
+			MMPTests.RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					SystemMonoVersion = version
+				};
+				TI.TestSystemMonoExecutable (test);
+			});
+		}
+
 	}
 }

--- a/tests/mmptest/src/SmokeTests.cs
+++ b/tests/mmptest/src/SmokeTests.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace Xamarin.MMP.Tests.src
+{
+	public class SmokeTests
+	{
+		public SmokeTests ()
+		{
+		}
+	}
+}


### PR DESCRIPTION
- Only test changes.
- I split out each test in a patch for review if desired, but can be squashed on land.
- More refactoring later, but this at least is "less terrible"