### PR TITLE
[monotouch-tests] Adds mono's WeakAttribute tests (Backport)

### DIFF
--- a/tests/monotouch-test/mono/MonoWeakReferenceTest.cs
+++ b/tests/monotouch-test/mono/MonoWeakReferenceTest.cs
@@ -1,0 +1,98 @@
+﻿//
+// Port of mono's unit tests for WeakAttribute from:
+// https://github.com/mono/mono/blob/5bdaef7e5f6479cc4336bb809b419e85ad706dd7/mono/tests/weak-fields.cs
+//
+// Authors:
+//	Zoltan Varga
+//	Alex Soto <alexsoto@microsoft.com>
+//
+//
+// Copyright 2018 Xamarin Inc. All rights reserved.
+//
+
+using System;
+using System.Threading;
+
+#if XAMCORE_2_0
+using Foundation;
+#else
+using MonoTouch;
+using MonoTouch.Foundation;
+#endif
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public partial class WeakReferenceTest {
+
+		[Test]
+		public void WeakTest ()
+		{
+			//Finalizable.debug = true;
+			var t = new Test ();
+			var thread = new Thread (delegate () {
+				t.Obj = new Finalizable ();
+				t.Obj2 = new Finalizable ();
+				t.Obj3 = new Finalizable ();
+				t.Obj4 = Test.retain = new Finalizable ();
+				Test.retain.a = 0x1029458;
+			});
+			thread.Start ();
+			thread.Join ();
+			GC.Collect (0);
+			GC.Collect ();
+			GC.WaitForPendingFinalizers ();
+			GC.WaitForPendingFinalizers ();
+			Assert.That (t.Obj, Is.Null, "'t.Obj' should be null");
+			Assert.That (t.Obj2, Is.Null, "'t.Obj2' should be null");
+			Assert.That (t.Obj3, Is.Not.Null, "'t.Obj3' should not be null");
+
+			//overflow the nursery, make sure we fill it
+			for (int i = 0; i < 1000 * 1000 * 10; ++i)
+				new OneField ();
+
+			Assert.That (Test.retain.a, Is.EqualTo (0x1029458), "retain.a");
+
+			Test.retain = null;
+			GC.Collect ();
+			GC.WaitForPendingFinalizers ();
+			GC.WaitForPendingFinalizers ();
+			Assert.That (t.Obj4, Is.Null, "'t.Obj4' should be null");
+		}
+	}
+
+	public class Test {
+		public static Finalizable retain;
+
+		[Weak]
+		public object Obj;
+		[Weak2]
+		public object Obj3;
+		[Weak]
+		public object Obj2;
+		[Weak]
+		public Finalizable Obj4;
+	}
+
+	[AttributeUsage (AttributeTargets.Field)]
+	public sealed class Weak2Attribute : Attribute {
+	}
+
+	public class Finalizable {
+		public int a;
+		public static bool debug;
+
+		~Finalizable ()
+		{
+			if (debug)
+				Console.WriteLine ("Finalized. {0}", a);
+		}
+	}
+
+	public class OneField {
+		int x;
+	}
+}

--- a/tests/monotouch-test/mono/WeakReferenceTest.cs
+++ b/tests/monotouch-test/mono/WeakReferenceTest.cs
@@ -1,0 +1,146 @@
+﻿//
+// Unit tests for WeakAttribute
+//
+// Authors:
+//	Alex Soto <alexsoto@microsoft.com>
+//
+//
+// Copyright 2018 Xamarin Inc. All rights reserved.
+//
+
+using System;
+
+#if XAMCORE_2_0
+using Foundation;
+using SpriteKit;
+using ObjCRuntime;
+#else
+using MonoTouch;
+using MonoTouch.Foundation;
+using MonoTouch.SpriteKit;
+using MonoTouch.ObjCRuntime;
+#endif
+
+using NUnit.Framework;
+using System.Threading;
+
+namespace MonoTouchFixtures {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public partial class WeakReferenceTest {
+		const int totalTestObjects = 5000;
+
+		[SetUp]
+		public void Setup ()
+		{
+#if __WATCHOS__
+			// watchOS 3.0+
+			TestRuntime.CheckWatchOSSystemVersion (3, 0);
+#else
+			// iOS 7.0+ macOS 10.9+ tvOS 9.0+
+			TestRuntime.AssertXcodeVersion (5, 0);
+#endif
+		}
+
+		[Test]
+		public void NoRetainCyclesExpectedTest ()
+		{
+			var thread = new Thread (delegate () {
+				MyParentView.weakcount = 0;
+				for (int i = 0; i < totalTestObjects; i++) {
+					var parent = new MyParentView (useWeak: true);
+					parent.TouchButton ();
+				}
+			});
+
+			thread.Start ();
+			thread.Join ();
+
+			GC.Collect (0);
+			GC.Collect ();
+			GC.WaitForPendingFinalizers ();
+			GC.WaitForPendingFinalizers ();
+
+			TestRuntime.RunAsync (DateTime.Now.AddSeconds (30), () => { }, () => MyParentView.weakcount < totalTestObjects);
+			Assert.That (MyParentView.weakcount, Is.LessThan (totalTestObjects), "No retain cycles expected");
+		}
+
+		[Test]
+		public void RetainCyclesExpectedTest ()
+		{
+			var cache = new IntPtr [totalTestObjects];
+			MyParentView.noweakcount = 0;
+			for (int i = 0; i < totalTestObjects; i++) {
+				var parent = new MyParentView (useWeak: false);
+				parent.TouchButton ();
+				cache [i] = parent.Handle;
+			}
+
+			GC.Collect (0);
+			GC.Collect ();
+			GC.WaitForPendingFinalizers ();
+			Assert.That (MyParentView.noweakcount, Is.EqualTo (totalTestObjects), "Retain cycles expected");
+
+			for (int i = 0; i < totalTestObjects; i++) {
+				using (var parent = Runtime.GetNSObject<MyParentView> (cache[i])) {
+					var child = (MyButton) parent.Children [0];
+					child.RemoveStrongRef ();
+				}
+			}
+		}
+	}
+
+	class MyParentView : SKScene {
+		public static int weakcount;
+		public static int noweakcount;
+		bool useWeak;
+
+		~MyParentView ()
+		{
+			if (useWeak)
+				weakcount--;
+			else
+				noweakcount--;
+		}
+
+		public MyParentView (bool useWeak)
+		{
+			this.useWeak = useWeak;
+			var child = new MyButton (this, useWeak);
+			child.TouchUpInside += Child_TouchUpInside;
+			AddChild (child);
+		}
+
+		public void TouchButton ()
+		{
+			((MyButton) Children [0]).FireTouch ();
+		}
+
+		void Child_TouchUpInside (object sender, EventArgs e)
+		{
+			if (useWeak)
+				weakcount++;
+			else
+				noweakcount++;
+			((MyButton) sender).TouchUpInside -= Child_TouchUpInside;
+		}
+	}
+
+	class MyButton : SKNode {
+		MyParentView strong;
+		[Weak] MyParentView weak;
+
+		public MyButton (MyParentView parent, bool useWeak)
+		{
+			if (useWeak)
+				weak = parent;
+			else
+				strong = parent;
+		}
+
+		public event EventHandler<EventArgs> TouchUpInside;
+		public void FireTouch () => TouchUpInside?.Invoke (this, EventArgs.Empty);
+		public void RemoveStrongRef () => strong = null;
+	}
+}


### PR DESCRIPTION
* [monotouch-tests] Adds mono's WeakAttribute tests

* Embrace watchOS

Unfortunately this revealed that WeakAttribute is not working for watchOS

* Port mono's WeakAttribute test to our test runner

Test Ported:
https://github.com/mono/mono/blob/5bdaef7e5f6479cc4336bb809b419e85ad706dd7/mono/tests/weak-fields.cs

* Fix object leaks and implement suggested approach from 4b9ade0c5978d826586ac8f43ec78e0bbeca33e6

* Remove debug spew and fix formating on header