### PR TITLE
[generator/registrar] Add support for blocks in static protocol members. Fixes #41226.

### DIFF
--- a/src/Foundation/ProtocolAttribute.cs
+++ b/src/Foundation/ProtocolAttribute.cs
@@ -61,6 +61,7 @@ namespace Foundation {
 		public Type ReturnType { get; set; }
 		public Type[] ParameterType { get; set; }
 		public bool[] ParameterByRef { get; set; }
+		public Type[] ParameterBlockProxy { get; set; }
 		public bool IsVariadic { get; set; }
 
 		public Type PropertyType { get; set; }

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -797,6 +797,8 @@ namespace ObjCRuntime {
 				method = method.GetBaseDefinition ();
 			}
 
+			string selector = null;
+
 			// Might be the implementation of an interface method, so find the corresponding
 			// MethodInfo for the interface, and check for BlockProxy attributes there as well.
 			foreach (var iface in method.DeclaringType.GetInterfaces ()) {
@@ -809,6 +811,45 @@ namespace ObjCRuntime {
 						var createMethod = GetBlockProxyAttributeMethod (map.InterfaceMethods [i], parameter);
 						if (createMethod != null)
 							return createMethod;
+					}
+				}
+
+				// We store the BlockProxy type in the ProtocolMemberAttribute, so check those.
+				// We may run into binding assemblies built with earlier versions of the generator,
+				// which means we can't rely on finding the BlockProxy attribute in the ProtocolMemberAttribute.
+				if (selector == null)
+					selector = method.GetCustomAttribute<ExportAttribute> ()?.Selector ?? string.Empty;
+				if (!string.IsNullOrEmpty (selector)) {
+					var memberAttributes = iface.GetCustomAttributes<ProtocolMemberAttribute> ();
+					foreach (var attrib in memberAttributes) {
+						if (attrib.ParameterBlockProxy == null || attrib.ParameterBlockProxy.Length <= parameter || attrib.ParameterBlockProxy [parameter] == null)
+							continue; // no need to check anything if what we want isn't there
+						if (attrib.Selector != selector)
+							continue;
+						if (attrib.IsStatic != method.IsStatic)
+							continue;
+						var methodParameters = method.GetParameters ();
+						if (attrib.ParameterType.Length != methodParameters.Length)
+							continue;
+						var notApplicable = false;
+						for (int i = 0; i < methodParameters.Length; i++) {
+							var paramType = methodParameters [i].ParameterType;
+							var isByRef = paramType.IsByRef;
+							if (isByRef)
+								paramType = paramType.GetElementType ();
+							if (isByRef != attrib.ParameterByRef [i]) {
+								notApplicable = true;
+								break;
+							}
+							if (paramType != attrib.ParameterType [i]) {
+								notApplicable = true;
+								break;
+							}
+						}
+						if (notApplicable)
+							continue;
+						
+						return attrib.ParameterBlockProxy [parameter].GetMethod ("Create");
 					}
 				}
 

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -5441,6 +5441,27 @@ public partial class Generator : IMemberGatherer {
 					sb.Append (parameters [i].ParameterType.IsByRef ? "true" : "false");
 				}
 				sb.Append (" }");
+
+				var blockProxies = new string [parameters.Length];
+				var anyblockProxy = false;
+				for (int i = 0; i < parameters.Length; i++) {
+					var parType = GetCorrectGenericType (parameters [i].ParameterType);
+					if (parType.IsSubclassOf (TypeManager.System_Delegate)) {
+						var ti = MakeTrampoline (parType);
+						blockProxies [i] = $"typeof ({ns.CoreObjCRuntime}.Trampolines.{ti.NativeInvokerName})";
+						anyblockProxy = true;
+					}
+				}
+				if (anyblockProxy) {
+					sb.Append (", ParameterBlockProxy = new Type [] { ");
+					for (int i = 0; i < blockProxies.Length; i++) {
+						if (i > 0)
+							sb.Append (", ");
+						sb.Append (blockProxies [i] == null ? "null" : blockProxies [i]);
+					}
+					sb.Append (" }");
+				}
+
 				if (attrib.IsVariadic)
 					sb.Append (", IsVariadic = true");
 			}

--- a/tests/bindings-test/ApiDefinition.cs
+++ b/tests/bindings-test/ApiDefinition.cs
@@ -261,8 +261,17 @@ namespace Bindings.Test {
 		[Export ("requiredCallback:")]
 		void RequiredCallback (Action<int> completionHandler);
 
+		[Abstract]
+		[Static]
+		[Export ("requiredStaticCallback:")]
+		void RequiredStaticCallback (Action<int> completionHandler);
+
 		[Export ("optionalCallback:")]
 		void OptionalCallback (Action<int> completionHandler);
+
+		[Static]
+		[Export ("optionalStaticCallback:")]
+		void OptionalStaticCallback (Action<int> completionHandler);
 	}
 
 	interface IObjCProtocolBlockTest { }
@@ -273,6 +282,10 @@ namespace Bindings.Test {
 		[Export ("TestObject", ArgumentSemantic.Retain)]
 		IObjCProtocolBlockTest TestObject { get; set; }
 
+		[Static]
+		[Export ("TestClass")]
+		Class TestClass { get; set; }
+
 		[Export ("classCallback:")]
 		void ClassCallback (Action<int> completionHandler);
 
@@ -282,8 +295,16 @@ namespace Bindings.Test {
 		[Export ("callRequiredCallback")]
 		void CallRequiredCallback ();
 
+		[Static]
+		[Export ("callRequiredStaticCallback")]
+		void CallRequiredStaticCallback ();
+
 		[Export ("callOptionalCallback")]
 		void CallOptionalCallback ();
+
+		[Static]
+		[Export ("callOptionalStaticCallback")]
+		void CallOptionalStaticCallback ();
 
 		[Export ("testFreedBlocks")]
 		void TestFreedBlocks ();

--- a/tests/bindings-test/RegistrarBindingTest.cs
+++ b/tests/bindings-test/RegistrarBindingTest.cs
@@ -28,10 +28,16 @@ namespace Xamarin.BindingTests
 				obj.TestObject = new BlockCallbackClass ();
 				obj.CallOptionalCallback ();
 				obj.CallRequiredCallback ();
+				ObjCBlockTester.TestClass = new Class (typeof (BlockCallbackClass));
+				ObjCBlockTester.CallRequiredStaticCallback ();
+				ObjCBlockTester.CallOptionalStaticCallback ();
 
 				obj.TestObject = new BlockCallbackClassExplicit ();
 				obj.CallOptionalCallback ();
 				obj.CallRequiredCallback ();
+				ObjCBlockTester.TestClass = new Class (typeof (BlockCallbackClassExplicit));
+				ObjCBlockTester.CallRequiredStaticCallback ();
+				ObjCBlockTester.CallOptionalStaticCallback ();
 			}
 		}
 
@@ -47,6 +53,18 @@ namespace Xamarin.BindingTests
 			{
 				completionHandler (42);
 			}
+
+			[Export ("requiredStaticCallback:")]
+			public static void RequiredStaticCallback (Action<int> completionHandler)
+			{
+				completionHandler (42);
+			}
+
+			[Export ("optionalStaticCallback:")]
+			public static void OptionalStaticCallback (Action<int> completionHandler)
+			{
+				completionHandler (42);
+			}
 		}
 
 		class BlockCallbackClassExplicit : NSObject, IObjCProtocolBlockTest
@@ -59,6 +77,18 @@ namespace Xamarin.BindingTests
 
 			[Export ("optionalCallback:")]
 			public void OptionalCallback (Action<int> completionHandler)
+			{
+				completionHandler (42);
+			}
+
+			[Export ("requiredStaticCallback:")]
+			public static void RequiredStaticCallback (Action<int> completionHandler)
+			{
+				completionHandler (42);
+			}
+
+			[Export ("optionalStaticCallback:")]
+			public static void OptionalRequiredCallback (Action<int> completionHandler)
 			{
 				completionHandler (42);
 			}

--- a/tests/test-libraries/libtest.h
+++ b/tests/test-libraries/libtest.h
@@ -139,17 +139,22 @@ typedef unsigned int (^RegistrarTestBlock) (unsigned int magic);
 @protocol ObjCProtocolBlockTest
 @required
 	-(void) requiredCallback: (void (^)(int32_t magic_number))completionHandler;
+	+(void) requiredStaticCallback: (void (^)(int32_t magic_number))completionHandler;
 @optional
 	-(void) optionalCallback: (void (^)(int32_t magic_number))completionHandler;
+	+(void) optionalStaticCallback: (void (^)(int32_t magic_number))completionHandler;
 @end
 
 @interface ObjCBlockTester : NSObject {
 }
 @property (retain) NSObject<ObjCProtocolBlockTest>* TestObject;
+@property (class, retain) Class TestClass;
 -(void) classCallback: (void (^)(int32_t magic_number))completionHandler;
 -(void) callClassCallback;
 -(void) callRequiredCallback;
++(void) callRequiredStaticCallback;
 -(void) callOptionalCallback;
++(void) callOptionalStaticCallback;
 
 -(void) testFreedBlocks;
 +(int) freedBlockCount;

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -513,6 +513,16 @@ static UltimateMachine *shared;
 static volatile int freed_blocks = 0;
 
 @implementation ObjCBlockTester
+static Class _TestClass = NULL;
+
++ (Class)TestClass {
+	return _TestClass;
+}
+
++ (void)setTestClass:(Class) value {
+	_TestClass = value;
+}
+
 -(void) classCallback: (void (^)(int32_t magic_number))completionHandler
 {
 	assert (!"THIS FUNCTION SHOULD BE OVERRIDDEN");
@@ -540,10 +550,32 @@ static volatile int freed_blocks = 0;
 	assert (called);
 }
 
++(void) callRequiredStaticCallback
+{
+	__block bool called = false;
+	[self.TestClass requiredStaticCallback: ^(int magic_number)
+	{
+		assert (magic_number == 42);
+		called = true;
+	}];
+	assert (called);
+}
+
 -(void) callOptionalCallback
 {
 	__block bool called = false;
 	[self.TestObject optionalCallback: ^(int magic_number)
+	{
+		assert (magic_number == 42);
+		called = true;
+	}];
+	assert (called);
+}
+
++(void) callOptionalStaticCallback
+{
+	__block bool called = false;
+	[self.TestClass optionalStaticCallback: ^(int magic_number)
 	{
 		assert (magic_number == 42);
 		called = true;


### PR DESCRIPTION
Add support for blocks in static protocol members by adding another field to
the [ProtocolMember] attribute that specifies the block proxy type.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=41226.