### PR TITLE
[AppKit] Adds [NullAllowed] to NSGridCell.ContentView

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -7094,7 +7094,7 @@ namespace AppKit {
 	[DisableDefaultCtor]
 	interface NSGridCell : NSCoding
 	{
-		[Export ("contentView", ArgumentSemantic.Strong)]
+		[Export ("contentView", ArgumentSemantic.Strong), NullAllowed]
 		NSView ContentView { get; set; }
 
 		[Export ("emptyContentView", ArgumentSemantic.Strong)]


### PR DESCRIPTION
Fixes xamarin/xamarin-macios#3777

The Objective-C definition is:

```
@property (strong,nullable) __kindof NSView *contentView;
```