### PR TITLE
[GameplayKit] Fix naming of GKNoise.DisplaceX

### DIFF
--- a/src/gameplaykit.cs
+++ b/src/gameplaykit.cs
@@ -1482,7 +1482,13 @@ namespace GameplayKit {
 		void RaiseToPower (GKNoise noise);
 
 		[Export ("displaceXWithNoise:yWithNoise:zWithNoise:")]
+		void Displace (GKNoise xDisplacementNoise, GKNoise yDisplacementNoise, GKNoise zDisplacementNoise);
+
+#if !XAMCORE_4_0
+		[Obsolete ("Use 'GKNoise.Displace' instead.")]
+		[Wrap ("Displace (xDisplacementNoise, yDisplacementNoise, zDisplacementNoise)", isVirtual: true)]
 		void DisplaceX (GKNoise xDisplacementNoise, GKNoise yDisplacementNoise, GKNoise zDisplacementNoise);
+#endif
 	}
 
 	[iOS (10,0), TV (10,0), Mac (10,12, onlyOn64: true)]


### PR DESCRIPTION
Fixes xamarin/xamarin-macios#3716

GKNoise.DisplaceX suggests that displacement can only be done
along one axis which is not true, according to documentation
you use the 3 (x, y, x) noise objects.

The following API suggestions where considered:

```csharp
GKNoise.Displace (xDisplacementNoise, yDisplacementNoise, zDisplacementNoise);
GKNoise.DisplaceWithNoises (x, y, z);
```

And I think just using `Displace` as the method name and let each
of the parameters clearly state their intent is best.