### PR TITLE
[Appkit] Adds NullAllowed to NSTableCellView.ObjectValue

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -16446,7 +16446,7 @@ namespace AppKit {
 			get; set;
 		}
 
-		[Export ("objectValue", ArgumentSemantic.Retain)]
+		[Export ("objectValue", ArgumentSemantic.Retain), NullAllowed]
 		NSObject ObjectValue {
 			get; set;
 		}


### PR DESCRIPTION
Fixes xamarin/xamarin-macios#3792

`null` is allowed in `NSTableCellView.ObjectValue` property according to header definition:

```
@property (nullable, strong) id objectValue;
```