### PR TITLE
[mtouch] Ignore 'objc-missing-super-calls' warnings from clang when compiling registrar code. Fixes bugzilla #60624.

### DIFF
--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -971,8 +971,20 @@ namespace NS {
 		[Test]
 		public void NoWarnings ()
 		{
+			var code = @"
+	public partial class MyTableViewCell : UITableViewCell {
+		protected MyTableViewCell (IntPtr handle) : base (handle)
+		{
+		}
+
+		public override void AwakeFromNib ()
+		{
+			base.AwakeFromNib ();
+		}
+	}
+";
 			using (var mtouch = new MTouchTool ()) {
-				mtouch.CreateTemporaryApp ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using UIKit; using Foundation; using System;");
 				mtouch.CreateTemporaryCacheDirectory ();
 				mtouch.Registrar = MTouchRegistrar.Static;
 				mtouch.Linker = MTouchLinker.DontLink; // so that as much as possible is registered

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -1245,6 +1245,10 @@ namespace Xamarin.Bundler
 					// They still use NSPortMessage in other API though, so it can't just be removed from our bindings.
 					registrar_task.CompilerFlags.AddOtherFlag ("-Wno-receiver-forward-class");
 
+					// clang sometimes detects missing [super ...] calls, but clang doesn't know about
+					// calling super through managed code, so ignore those warnings.
+					registrar_task.CompilerFlags.AddOtherFlag ("-Wno-objc-missing-super-calls");
+
 					if (Driver.XcodeVersion >= new Version (9, 0))
 						registrar_task.CompilerFlags.AddOtherFlag ("-Wno-unguarded-availability-new");
 


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=60624.