### PR TITLE
[tests] Convert the rest of the registrar tests to new style test syntax.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -4129,24 +4129,6 @@ public class TestApp {
 			Assert.AreEqual (e, a, message);
 		}
 
-		static void VerifyOutput (string msg, string actual, params string[] expected)
-		{
-			var split = actual.Split (new char[] {'\n', '\r'}, StringSplitOptions.RemoveEmptyEntries);
-			var actual_messages = new HashSet<string> (split, new Registrar.PatternEquality ());
-			var exp_messages = new HashSet<string> (expected, new Registrar.PatternEquality ());
-
-			actual_messages.ExceptWith (exp_messages);
-			exp_messages.ExceptWith (split);
-
-			var text = new StringBuilder ();
-			foreach (var a in actual_messages)
-				text.AppendFormat ("Unexpected error/warning ({0}):\n\t{1}\n", msg, a);
-			foreach (var a in exp_messages)
-				text.AppendFormat ("Expected error/warning not shown ({0}):\n\t{1}\n", msg, a);
-			if (text.Length != 0)
-				Assert.Fail (text.ToString ());
-		}
-
 		public static void AssertDeviceAvailable ()
 		{
 			if (!Configuration.include_device)

--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -130,11 +130,19 @@ class DateMembers : NSObject {
 }
 ";
 
-			Verify (R.Static, code, false, 
-				".*/Test.cs(.*): error MT4138: The registrar cannot marshal the property type 'System.DateTime' of the property 'DateMembers.F4'.",
-				".*/Test.cs(.*): error MT4102: The registrar found an invalid type `System.DateTime` in signature for method `DateMembers.F1`. Use `Foundation.NSDate` instead.",
-				".*/Test.cs(.*): error MT4102: The registrar found an invalid type `System.DateTime` in signature for method `DateMembers.F2`. Use `Foundation.NSDate` instead.",
-				".*/Test.cs(.*): error MT4102: The registrar found an invalid type `System.DateTime` in signature for method `DateMembers.F3`. Use `Foundation.NSDate` instead.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4138, "The registrar cannot marshal the property type 'System.DateTime' of the property 'DateMembers.F4'.", "testApp.cs", 14);
+				mtouch.AssertError (4102, "The registrar found an invalid type `System.DateTime` in signature for method `DateMembers.F1`. Use `Foundation.NSDate` instead.", "testApp.cs", 5);
+				mtouch.AssertError (4102, "The registrar found an invalid type `System.DateTime` in signature for method `DateMembers.F2`. Use `Foundation.NSDate` instead.", "testApp.cs", 8);
+				mtouch.AssertError (4102, "The registrar found an invalid type `System.DateTime` in signature for method `DateMembers.F3`. Use `Foundation.NSDate` instead.", "testApp.cs", 11);
+				mtouch.AssertErrorCount (4);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -153,10 +161,18 @@ class ArgCount : NSObject {
 }
 ";
 
-			Verify (R.Static, code, false, 
-				".*/Test.cs(.*): error MT4117: The registrar found a signature mismatch in the method 'ArgCount.F1' - the selector 'F1' indicates the method takes 0 parameters, while the managed method has 1 parameters.",
-				".*/Test.cs(.*): error MT4117: The registrar found a signature mismatch in the method 'ArgCount.F2' - the selector 'F2:' indicates the method takes 1 parameters, while the managed method has 0 parameters.",
-				".*/Test.cs(.*): error MT4140: The registrar found a signature mismatch in the method 'ArgCount.F3' - the selector 'F3' indicates the variadic method takes 1 parameters, while the managed method has 0 parameters.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4117, "The registrar found a signature mismatch in the method 'ArgCount.F1' - the selector 'F1' indicates the method takes 0 parameters, while the managed method has 1 parameters.", "testApp.cs", 5);
+				mtouch.AssertError (4117, "The registrar found a signature mismatch in the method 'ArgCount.F2' - the selector 'F2:' indicates the method takes 1 parameters, while the managed method has 0 parameters.", "testApp.cs", 8);
+				mtouch.AssertError (4140, "The registrar found a signature mismatch in the method 'ArgCount.F3' - the selector 'F3' indicates the variadic method takes 1 parameters, while the managed method has 0 parameters.", "testApp.cs", 11);
+				mtouch.AssertErrorCount (3);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -175,7 +191,16 @@ class ArgCount : NSObject {
 }
 ";
 
-			Verify (R.Static, code, false, ".*/Test.cs(.*): error MT4123: The type of the variadic parameter in the variadic function 'F3(System.Int32)' must be System.IntPtr.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4123, "The type of the variadic parameter in the variadic function 'F3(System.Int32)' must be System.IntPtr.", "testApp.cs", 8);
+				mtouch.AssertErrorCount (1);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -206,30 +231,60 @@ class MyObjectErr : NSObject, IFoo1, IFoo2
 }
 ";
 
-			Verify (R.Static, str1, false, 
-				"error MT4127: Cannot register more than one interface method for the method 'MyObjectErr.GetFoo' (which is implementing 'IFoo1.GetFoo' and 'IFoo2.GetFoo').");
-
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: str1, usings: "using Foundation; using System;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4127, "Cannot register more than one interface method for the method 'MyObjectErr.GetFoo' (which is implementing 'IFoo1.GetFoo' and 'IFoo2.GetFoo').");
+				mtouch.AssertErrorCount (1);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
 		public void MT4134 ()
 		{
-			if (!Directory.Exists (Configuration.xcode6_root))
-				Assert.Ignore ("Xcode 6 ({0}) is required for this test.", Configuration.xcode6_root);
+			var xcodeRoot = Configuration.xcode83_root;
+			if (!Directory.Exists (xcodeRoot))
+				Assert.Ignore ("Xcode 8 ({0}) is required for this test.", xcodeRoot);
 			
-			// This test will have to be updated when new frameworks are introduced.
-			VerifyWithXcode (R.Static, Profile.iOS, string.Empty, false, Configuration.xcode6_root, "8.0",
-				"warning MT0079: The recommended Xcode version for Xamarin.iOS .* is Xcode .* or later. The current Xcode version .found in " + Configuration.xcode6_root + ". is 6.*.",
-				"error MT4134: Your application is using the 'Contacts' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS 9.0, while you're building with the iOS 8.0 SDK.) Please select a newer SDK in your app's iOS Build options.",
-				"error MT4134: Your application is using the 'CoreSpotlight' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS 9.0, while you're building with the iOS 8.0 SDK.) Please select a newer SDK in your app's iOS Build options.",
-				"error MT4134: Your application is using the 'GameplayKit' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS 9.0, while you're building with the iOS 8.0 SDK.) Please select a newer SDK in your app's iOS Build options.",
-				"error MT4134: Your application is using the 'MetalKit' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS 9.0, while you're building with the iOS 8.0 SDK.) Please select a newer SDK in your app's iOS Build options.",
-				"error MT4134: Your application is using the 'ModelIO' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS 9.0, while you're building with the iOS 8.0 SDK.) Please select a newer SDK in your app's iOS Build options.",
-				"error MT4134: Your application is using the 'MetalPerformanceShaders' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS 9.0, while you're building with the iOS 8.0 SDK.) Please select a newer SDK in your app's iOS Build options.",
-				"error MT4134: Your application is using the 'WatchKit' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS 8.2, while you're building with the iOS 8.0 SDK.) Please select a newer SDK in your app's iOS Build options.",
-				"error MT4134: Your application is using the 'ContactsUI' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS 9.0, while you're building with the iOS 8.0 SDK.) Please select a newer SDK in your app's iOS Build options.",
-				"error MT4134: Your application is using the 'ReplayKit' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS 9.0, while you're building with the iOS 8.0 SDK.) Please select a newer SDK in your app's iOS Build options.",
-				"error MT4134: Your application is using the 'WatchConnectivity' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS 9.0, while you're building with the iOS 8.0 SDK.) Please select a newer SDK in your app's iOS Build options.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.SdkRoot = xcodeRoot;
+				mtouch.Sdk = "10.3";
+
+				// Create a source file that references most platform types.
+				var sb = new StringBuilder ();
+				var xidll = Mono.Cecil.AssemblyDefinition.ReadAssembly (MTouch.GetBaseLibrary (mtouch.Profile));
+				var xitypes = xidll.MainModule.Types
+						.Where ((v) => v.IsPublic && !v.Name.Contains ("`"))
+						.Where ((v) => {
+							switch (v.Namespace) {
+							case "CoreML":
+							case "CoreImage":
+								// These run into other registrar errors, so just skip them
+								return false;
+							default:
+								return true;
+							}
+						});
+				sb.AppendLine ("[Preserve (AllMembers = true)] class preserveTypes { static void M () {");
+				foreach (var t in xitypes)
+					sb.AppendLine ($"System.Console.WriteLine (typeof ({t.Namespace}.{t.Name}));");
+				sb.AppendLine ("}}");
+
+				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), usings: "using System; using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.LinkSdk;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				var invalidFrameworks = new string [] { "IdentityLookup", "FileProviderUI", "FileProvider", "DeviceCheck", "CoreNFC", "Vision", "PDFKit", "IOSurface", "ARKit" };
+				foreach (var framework in invalidFrameworks)
+					mtouch.AssertError (4134, $"Your application is using the '{framework}' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS 11.0, while you're building with the iOS {mtouch.Sdk} SDK.) Please select a newer SDK in your app's iOS Build options.");
+				mtouch.AssertErrorCount (invalidFrameworks.Length);
+				mtouch.AssertWarningCount (0);
+			}
 		}
 
 		[Test]
@@ -243,9 +298,17 @@ class C : NSObject {
 	[Export ("""")]
 	public void Zap () {}
 }";
-			Verify (R.Static, code, false, 
-				".*Test.cs(.*): error MT4135: The member 'C.Bar' has an Export attribute without a selector. A selector is required.",
-				".*Test.cs(.*): error MT4135: The member 'C.Zap' has an Export attribute without a selector. A selector is required.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4135, "The member 'C.Bar' has an Export attribute without a selector. A selector is required.", "testApp.cs", 5);
+				mtouch.AssertError (4135, "The member 'C.Zap' has an Export attribute without a selector. A selector is required.", "testApp.cs", 8);
+				mtouch.AssertErrorCount (2);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 			
 		[Test]
@@ -257,8 +320,16 @@ class C : NSObject {
 	object Foo { get { return null; } }
 }
 ";
-			Verify (R.Static, code, false, 
-				".*/Test.cs(.*): error MT4138: The registrar cannot marshal the property type 'System.Object' of the property 'C.Foo'.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4138, "The registrar cannot marshal the property type 'System.Object' of the property 'C.Foo'.", "testApp.cs", 5);
+				mtouch.AssertErrorCount (1);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -273,9 +344,17 @@ class C : NSObject {
 	int P2 { get { return 0; } }
 }
 ";
-			Verify (R.Static, code, false, 
-				".*/Test.cs(.*): error MT4139: The registrar cannot marshal the property type 'System.Object' of the property 'C.P1'. Properties with the .Connect. attribute must have a property type of NSObject (or a subclass of NSObject).",
-				".*/Test.cs(.*): error MT4139: The registrar cannot marshal the property type 'System.Int32' of the property 'C.P2'. Properties with the .Connect. attribute must have a property type of NSObject (or a subclass of NSObject).");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4139, "The registrar cannot marshal the property type 'System.Object' of the property 'C.P1'. Properties with the [Connect] attribute must have a property type of NSObject (or a subclass of NSObject).", "testApp.cs", 5);
+				mtouch.AssertError (4139, "The registrar cannot marshal the property type 'System.Int32' of the property 'C.P2'. Properties with the [Connect] attribute must have a property type of NSObject (or a subclass of NSObject).", "testApp.cs", 8);
+				mtouch.AssertErrorCount (2);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -293,9 +372,17 @@ class C : NSObject {
 	new void Dealloc () {}
 }
 ";
-			Verify (R.Static, code, false,
-				".*/Test.cs(.*): error MT4141: Cannot register the selector 'retain' on the member 'C.Retain' because Xamarin.iOS implicitly registers this selector.",
-				".*/Test.cs(.*): error MT4141: Cannot register the selector 'release' on the member 'C.Release' because Xamarin.iOS implicitly registers this selector.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4141, "Cannot register the selector 'retain' on the member 'C.Retain' because Xamarin.iOS implicitly registers this selector.", "testApp.cs", 5);
+				mtouch.AssertError (4141, "Cannot register the selector 'release' on the member 'C.Release' because Xamarin.iOS implicitly registers this selector.", "testApp.cs", 8);
+				mtouch.AssertErrorCount (2);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -311,7 +398,16 @@ class C : NSObject {
 	void NativeEnum1 (Foo foo) {}
 }
 ";
-			VerifyWithXode (R.Static, code, false, "error MT4145: Invalid enum 'Foo': enums with the [Native] attribute must have a underlying enum type of either 'long' or 'ulong'.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4145, "Invalid enum 'Foo': enums with the [Native] attribute must have a underlying enum type of either 'long' or 'ulong'.");
+				mtouch.AssertErrorCount (5); // The same MT4145 is printed 5 times
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -322,7 +418,16 @@ class C : NSObject {
 class C : NSObject {
 }
 ";
-			VerifyWithXode (R.Static, code, true, "warning MT4146: The Name parameter of the Registrar attribute on the class 'C' (' C') contains an invalid character: ' ' (0x20).");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecute ();
+				mtouch.AssertWarning (4146, "The Name parameter of the Registrar attribute on the class 'C' (' C') contains an invalid character: ' ' (0x20).");
+				mtouch.AssertErrorCount (0);
+				mtouch.AssertWarningCount (1);
+			}
 		}
 
 		[Test]
@@ -333,7 +438,16 @@ class C : NSObject {
 class C : NSObject {
 }
 ";
-			VerifyWithXode (R.Static, code, false, "error MT4146: The Name parameter of the Registrar attribute on the class 'C' ('A C') contains an invalid character: ' ' (0x20).");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4146, "The Name parameter of the Registrar attribute on the class 'C' ('A C') contains an invalid character: ' ' (0x20).");
+				mtouch.AssertErrorCount (1);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 		[Test]
 		public void MT4148 ()
@@ -348,9 +462,17 @@ interface IProtocol2 {
 	void M<T> ();
 }
 ";
-			VerifyWithXode (R.Static, code, false,
-				"error MT4148: The registrar found a generic protocol: 'IProtocol`1'. Exporting generic protocols is not supported.",
-				"error MT4113: The registrar found a generic method: 'IProtocol2.M()'. Exporting generic methods is not supported, and will lead to random behavior and/or crashes");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4148, "The registrar found a generic protocol: 'IProtocol`1'. Exporting generic protocols is not supported.");
+				mtouch.AssertError (4113, "The registrar found a generic method: 'IProtocol2.M()'. Exporting generic methods is not supported, and will lead to random behavior and/or crashes");
+				mtouch.AssertErrorCount (2);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -364,8 +486,16 @@ public static class Category
 	public static void Foo (this int bar) {}
 }
 ";
-			VerifyWithXode (R.Static, code, false,
-				".*/Test.cs(.*): error MT4149: Cannot register the extension method 'Category.Foo' because the type of the first parameter ('System.Int32') does not match the category type ('Foundation.NSString').");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4149, "Cannot register the extension method 'Category.Foo' because the type of the first parameter ('System.Int32') does not match the category type ('Foundation.NSString').", "testApp.cs", 7);
+				mtouch.AssertErrorCount (1);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -377,8 +507,16 @@ public static class Category
 {
 }
 ";
-			VerifyWithXode (R.Static, code, false,
-				"error MT4150: Cannot register the type 'Category' because the category type 'System.String' in its Category attribute does not inherit from NSObject.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4150, "Cannot register the type 'Category' because the category type 'System.String' in its Category attribute does not inherit from NSObject.");
+				mtouch.AssertErrorCount (1);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -390,8 +528,16 @@ public static class Category
 {
 }
 ";
-			VerifyWithXode (R.Static, code, false,
-				"error MT4151: Cannot register the type 'Category' because the Type property in its Category attribute isn't set.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4151, "Cannot register the type 'Category' because the Type property in its Category attribute isn't set.");
+				mtouch.AssertErrorCount (1);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -408,9 +554,17 @@ public class Category2 : INativeObject
 	public IntPtr Handle { get { return IntPtr.Zero; } }
 }
 ";
-			VerifyWithXode (R.Static, code, false,
-				"error MT4152: Cannot register the type 'Category1' as a category because it implements INativeObject or subclasses NSObject.",
-				"error MT4152: Cannot register the type 'Category2' as a category because it implements INativeObject or subclasses NSObject.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4152, "Cannot register the type 'Category1' as a category because it implements INativeObject or subclasses NSObject.");
+				mtouch.AssertError (4152, "Cannot register the type 'Category2' as a category because it implements INativeObject or subclasses NSObject.");
+				mtouch.AssertErrorCount (2);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -422,8 +576,16 @@ public class Category<T>
 {
 }
 ";
-			VerifyWithXode (R.Static, code, false,
-				"error MT4153: Cannot register the type 'Category`1' as a category because it's generic.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4153, "Cannot register the type 'Category`1' as a category because it's generic.");
+				mtouch.AssertErrorCount (1);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -437,8 +599,16 @@ public class Category
 	public static void Foo<T> () {}
 }
 ";
-			VerifyWithXode (R.Static, code, false,
-				".*/Test.cs(.*): error MT4154: Cannot register the method 'Category.Foo' as a category method because it's generic.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4154, "Cannot register the method 'Category.Foo' as a category method because it's generic.", "testApp.cs", 7);
+				mtouch.AssertErrorCount (1);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		// MT4155 only happens with the dynamic registrar
@@ -456,8 +626,16 @@ public class Category2
 {
 }
 ";
-			VerifyWithXode (R.Static, code, false,
-				"error MT4156: Cannot register two categories ('Category2, Test' and 'Category1, Test') with the same native name ('C')");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4156, "Cannot register two categories ('Category2, testApp' and 'Category1, testApp') with the same native name ('C')");
+				mtouch.AssertErrorCount (1);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		// MT4157 Can't be produced using C#, since it requires using [Extension] manually:
@@ -474,8 +652,16 @@ public class Category
 	public Category () {}
 }
 ";
-			VerifyWithXode (R.Static, code, false,
-				".*/Test.cs(.*): error MT4158: Cannot register the constructor Category..ctor() in the category Category because constructors in categories are not supported.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4158, "Cannot register the constructor Category..ctor() in the category Category because constructors in categories are not supported.", "testApp.cs", 7);
+				mtouch.AssertErrorCount (1);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 			
 		[Test]
@@ -489,8 +675,16 @@ public class Category
 	public void Foo () {}
 }
 ";
-			VerifyWithXode (R.Static, code, false,
-				".*/Test.cs(.*): error MT4159: Cannot register the method 'Category.Foo' as a category method because category methods must be static.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4159, "Cannot register the method 'Category.Foo' as a category method because category methods must be static.", "testApp.cs", 7);
+				mtouch.AssertErrorCount (1);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		// This list is duplicated in src/ObjCRuntime/Registrar.cs
@@ -558,15 +752,21 @@ public struct FooD { public NSObject Obj; }
 public struct FooE { public NSObject Obj; }
 public struct FooF { public NSObject Obj; }
 ";
-			VerifyWithXode (R.Static, code, false,
-				".*/Test.cs(.*): error MT4161: The registrar found an unsupported structure 'FooA': All fields in a structure must also be structures (field 'Obj' with type 'Foundation.NSObject' is not a structure).",
-				".*/Test.cs(.*): error MT4161: The registrar found an unsupported structure 'FooB': All fields in a structure must also be structures (field 'Obj' with type 'Foundation.NSObject' is not a structure).",
-				".*/Test.cs(.*): error MT4161: The registrar found an unsupported structure 'FooC': All fields in a structure must also be structures (field 'Obj' with type 'Foundation.NSObject' is not a structure).",
-				".*/Test.cs(.*): error MT4161: The registrar found an unsupported structure 'FooD': All fields in a structure must also be structures (field 'Obj' with type 'Foundation.NSObject' is not a structure).",
-				".*/Test.cs(.*): error MT4111: The registrar cannot build a signature for type `FooE[]' in method `TestInvalidChar.Foo5`.",
-				".*/Test.cs(.*): error MT4111: The registrar cannot build a signature for type `FooF[]' in method `TestInvalidChar.Foo6`."
-
-			);
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4161, "The registrar found an unsupported structure 'FooA': All fields in a structure must also be structures (field 'Obj' with type 'Foundation.NSObject' is not a structure).", "testApp.cs", 6);
+				mtouch.AssertError (4161, "The registrar found an unsupported structure 'FooB': All fields in a structure must also be structures (field 'Obj' with type 'Foundation.NSObject' is not a structure).", "testApp.cs", 9);
+				mtouch.AssertError (4161, "The registrar found an unsupported structure 'FooC': All fields in a structure must also be structures (field 'Obj' with type 'Foundation.NSObject' is not a structure).", "testApp.cs", 12);
+				mtouch.AssertError (4161, "The registrar found an unsupported structure 'FooD': All fields in a structure must also be structures (field 'Obj' with type 'Foundation.NSObject' is not a structure).", "testApp.cs", 15);
+				mtouch.AssertError (4111, "The registrar cannot build a signature for type `FooE[]' in method `TestInvalidChar.Foo5`.", "testApp.cs", 18);
+				mtouch.AssertError (4111, "The registrar cannot build a signature for type `FooF[]' in method `TestInvalidChar.Foo6`.", "testApp.cs", 21);
+				mtouch.AssertErrorCount (6);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 
@@ -1033,120 +1233,6 @@ class H : G {
 			}
 		}
 
-		void Verify (R registrars, string code, bool success, params string [] expected_messages)
-		{
-			VerifyWithXcode (registrars,  Profile.iOS, code, success, Configuration.xcode_root, Configuration.sdk_version, expected_messages);
-		}
-
-		void Verify (R registrars, Profile profile, string code, bool success, params string [] expected_messages)
-		{
-			Verify (registrars, profile, code, success, Target.Sim, expected_messages);
-		}
-
-		void Verify (R registrars, Profile profile, string code, bool success, Target target, params string [] expected_messages)
-		{
-			VerifyWithXcode (registrars,  profile, code, success, Configuration.xcode_root, MTouch.GetSdkVersion (profile), target, expected_messages);
-		}
-
-		void VerifyWithXode (R registrars, string code, bool success, params string [] expected_messages)
-		{
-			VerifyWithXcode (registrars, Profile.iOS, code, success, Configuration.xcode_root, Configuration.sdk_version, expected_messages);
-		}
-
-		void VerifyWithXcode (R registrars, string code, bool success, string xcode, string sdk_version, params string [] expected_messages)
-		{
-			VerifyWithXcode (registrars, Profile.iOS, code, success, xcode, sdk_version, expected_messages);
-		}
-
-		void VerifyWithXcode (R registrars, Profile profile, string code, bool success, string xcode, string sdk_version, params string [] expected_messages)
-		{
-			VerifyWithXcode (registrars, profile, code, success, xcode, sdk_version, Target.Sim, expected_messages);
-		}
-
-		void VerifyWithXcode (R registrars, Profile profile, string code, bool success, string xcode, string sdk_version, Target target, params string [] expected_messages)
-		{
-			foreach (R value in Enum.GetValues (typeof (R))) {
-				if ((registrars & value) == 0)
-					continue;
-
-				if (value != R.Dynamic && value != R.Static)
-					continue;
-
-				string result = string.Empty;
-
-				var header = @"
-using System;
-using System.Collections.Generic;
-using Foundation;
-using UIKit;
-using ObjCRuntime;
-
-class Test {
-	static void Main () { Console.WriteLine (typeof (NSObject)); }
-}";
-
-				StringBuilder output = new StringBuilder ();
-				var rv = CreateTestApp (profile, header + code, "--registrar:" + value.ToString ().ToLower (), xcode, sdk_version, target, output);
-				result = output.ToString ();
-				if (rv == 0) {
-					Assert.IsTrue (success, string.Format ("Expected '{0}' to show the error(s) '{1}' with --registrar:\n\t{2}", code, string.Join ("\n\t", expected_messages), value.ToString ().ToLower ()));
-				} else {
-					Assert.IsFalse (success, string.Format ("Expected '{0}' to compile with --registrar:{1}", code, value.ToString ().ToLower ()));
-				}
-
-				var split = result.Split (new char[] {'\n', '\r'}, StringSplitOptions.RemoveEmptyEntries);
-				var actual_messages = new HashSet<string> (split, new PatternEquality ());
-				var exp_messages = new HashSet<string> (expected_messages, new PatternEquality ());
-
-				actual_messages.Remove (".*Test.app built successfully.");
-				actual_messages.Remove ("Xamarin.iOS .* using.*");
-				actual_messages.Remove ("warning MT5303: Native linking warning: warning: relocatable dylibs (e.g. embedded frameworks) are only supported on iOS 8.0 and later .*");
-				actual_messages.Remove ("warning MT5303: Native linking warning: warning: embedded dylibs/frameworks are only supported on iOS 8.0 and later (@rpath/PushKit.framework/PushKit)");
-
-				actual_messages.ExceptWith (exp_messages);
-				exp_messages.ExceptWith (split);
-
-				var text = new StringBuilder ();
-				foreach (var a in actual_messages)
-					text.AppendFormat ("Unexpected error/warning with --registrar:{0}:\n\t{1}\n", value.ToString ().ToLower (), a);
-				foreach (var a in exp_messages)
-					text.AppendFormat ("Expected with --registrar:{0} to show:\n\t{1}\n", value.ToString ().ToLower (), a);
-				if (text.Length != 0)
-					Assert.Fail (text.ToString ());
-			}
-		}
-
-
-		internal class PatternEquality : IEqualityComparer<string> 
-		{
-			public bool Equals (string x, string y)
-			{
-				if (x == y)
-					return true;
-				try {
-					if (Regex.IsMatch (x, "^" + y.Replace ("(", "[(]").Replace (")", "[)]").Replace ("[]", "[[][]]") + "$")) {
-						return true;
-					}
-				} catch {
-					// do nothing
-				}
-
-				try {
-					if (Regex.IsMatch (y, "^" +  x.Replace ("(", "[(]").Replace (")", "[)]").Replace ("[]", "[[][]]") + "$")) {
-						return true;
-					}
-				} catch {
-					// do nothing
-				}
-
-				return false;
-			}
-			public int GetHashCode (string obj)
-			{
-				return 0;
-			}
-		}
-
 		[Test]
 		public void GenericType_Warnings ()
 		{
@@ -1183,10 +1269,18 @@ class Generic3<T> : NSObject where T: System.IConvertible {}
 			[Export (""bar"")]
 			public V Bar { get; set; }
 		}";
-			Verify (R.Static, code, false, 
-				".*Test.cs.*: error MT4132: The registrar found an invalid generic return type 'V' in the property 'Open`2.FooZap'. The return type must have an 'NSObject' constraint.",
-				".*Test.cs.*: error MT4132: The registrar found an invalid generic return type 'V' in the property 'Open`2.Bar'. The return type must have an 'NSObject' constraint.",
-				".*Test.cs.*: error MT4128: The registrar found an invalid generic parameter type 'V' in the parameter arg of the method 'Open`2.Foo(V)'. The generic parameter must have an 'NSObject' constraint.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4132, "The registrar found an invalid generic return type 'V' in the property 'Open`2.FooZap'. The return type must have an 'NSObject' constraint.", "testApp.cs", 9);
+				mtouch.AssertError (4132, "The registrar found an invalid generic return type 'V' in the property 'Open`2.Bar'. The return type must have an 'NSObject' constraint.", "testApp.cs", 12);
+				mtouch.AssertError (4128, "The registrar found an invalid generic parameter type 'V' in the parameter arg of the method 'Open`2.Foo(V)'. The generic parameter must have an 'NSObject' constraint.", "testApp.cs", 6);
+				mtouch.AssertErrorCount (3);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -1206,10 +1300,18 @@ class Open<U> : NSObject
 }
 
 ";
-			Verify (R.Static, code, false, 
-				".*Test.cs.*: error MT4131: The registrar cannot export static properties in generic classes ('Open`1.Zap').",
-				".*Test.cs.*: error MT4130: The registrar cannot export static methods in generic classes ('Open`1.Foo()').",
-				".*Test.cs.*: error MT4130: The registrar cannot export static methods in generic classes ('Open`1.Foo(U)').");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4131, "The registrar cannot export static properties in generic classes ('Open`1.Zap').", "testApp.cs", 12);
+				mtouch.AssertError (4130, "The registrar cannot export static methods in generic classes ('Open`1.Foo()').", "testApp.cs", 6);
+				mtouch.AssertError (4130, "The registrar cannot export static methods in generic classes ('Open`1.Foo(U)').", "testApp.cs", 9);
+				mtouch.AssertErrorCount (3);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -1225,8 +1327,16 @@ class Open<U> : NSObject
 			}
 		}
 ";
-			Verify (R.Static, code, false, 
-				".*Test.cs.*: error MT4128: The registrar found an invalid generic parameter type 'T' in the parameter foo of the method 'Parent`1/Nested.Foo(T)'. The generic parameter must have an 'NSObject' constraint.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4128, "The registrar found an invalid generic parameter type 'T' in the parameter foo of the method 'Parent`1/Nested.Foo(T)'. The generic parameter must have an 'NSObject' constraint.", "testApp.cs", 7);
+				mtouch.AssertErrorCount (1);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -1245,8 +1355,17 @@ class Open<U> : NSObject
 		}
 ";
 
-			Verify (R.Static, code, false,
-				".*Test.cs.*: error MT4128: The registrar found an invalid generic parameter type 'T' in the parameter t of the method 'GenericTestClass`1.Arg1(T)'. The generic parameter must have an 'NSObject' constraint.");
+
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using UIKit;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4128, "The registrar found an invalid generic parameter type 'T' in the parameter t of the method 'GenericTestClass`1.Arg1(T)'. The generic parameter must have an 'NSObject' constraint.", "testApp.cs", 6);
+				mtouch.AssertErrorCount (1);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -1315,19 +1434,26 @@ class Open<U> : NSObject
 		}
 ";
 
-			Verify (R.Static, code, false, 
-				".*Test.cs.*: error MT4132: The registrar found an invalid generic return type 'U' in the property 'Open`1.BarZap'. The return type must have an 'NSObject' constraint.",
-				".*Test.cs.*: error MT4132: The registrar found an invalid generic return type 'U' in the property 'Open`1.F1'. The return type must have an 'NSObject' constraint.",
-				".*Test.cs.*: error MT4132: The registrar found an invalid generic return type 'System.Collections.Generic.List`1<System.Collections.Generic.List`1<U>>' in the property 'Open`1.F2'. The return type must have an 'NSObject' constraint.",
-				".*Test.cs.*: error MT4132: The registrar found an invalid generic return type 'System.Action`1<U>' in the property 'Open`1.F3'. The return type must have an 'NSObject' constraint.",
-				".*Test.cs.*: error MT4128: The registrar found an invalid generic parameter type 'U' in the parameter arg of the method 'Open`1.Bar(U)'. The generic parameter must have an 'NSObject' constraint.",
-				".*Test.cs.*: error MT4128: The registrar found an invalid generic parameter type 'U[]' in the parameter arg of the method 'Open`1.Zap(U[])'. The generic parameter must have an 'NSObject' constraint.",
-				".*Test.cs.*: error MT4129: The registrar found an invalid generic return type 'U' in the method 'Open`1.XyZ()'. The generic return type must have an 'NSObject' constraint.",
-				".*Test.cs.*: error MT4129: The registrar found an invalid generic return type 'System.Action`1<U>' in the method 'Open`1.ZapBar()'. The generic return type must have an 'NSObject' constraint.",
-				".*Test.cs.*: error MT4128: The registrar found an invalid generic parameter type 'System.Action`1<U>' in the parameter f of the method 'Open`1.XyZ(System.Action`1<U>)'. The generic parameter must have an 'NSObject' constraint.",
-				".*Test.cs.*: error MT4128: The registrar found an invalid generic parameter type 'System.Collections.Generic.List`1<System.Collections.Generic.List`1<System.Collections.Generic.List`1<System.Collections.Generic.List`1<U>>>>' in the parameter f of the method 'Open`1.FooZap(System.Collections.Generic.List`1<System.Collections.Generic.List`1<System.Collections.Generic.List`1<System.Collections.Generic.List`1<U>>>>)'. The generic parameter must have an 'NSObject' constraint.",
-				".*Test.cs.*: error MT4129: The registrar found an invalid generic return type 'System.Collections.Generic.List`1<System.Collections.Generic.List`1<U>>' in the method 'Open`1.ZapBoo()'. The generic return type must have an 'NSObject' constraint."
-				);
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System; using System.Collections.Generic; using ObjCRuntime;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4132, "The registrar found an invalid generic return type 'U' in the property 'Open`1.BarZap'. The return type must have an 'NSObject' constraint.", "testApp.cs", 15);
+				mtouch.AssertError (4132, "The registrar found an invalid generic return type 'U' in the property 'Open`1.F1'. The return type must have an 'NSObject' constraint.", "testApp.cs", 30);
+				mtouch.AssertError (4132, "The registrar found an invalid generic return type 'System.Collections.Generic.List`1<System.Collections.Generic.List`1<U>>' in the property 'Open`1.F2'. The return type must have an 'NSObject' constraint.", "testApp.cs", 33);
+				mtouch.AssertError (4132, "The registrar found an invalid generic return type 'System.Action`1<U>' in the property 'Open`1.F3'. The return type must have an 'NSObject' constraint.", "testApp.cs", 36);
+				mtouch.AssertError (4128, "The registrar found an invalid generic parameter type 'U' in the parameter arg of the method 'Open`1.Bar(U)'. The generic parameter must have an 'NSObject' constraint.", "testApp.cs", 6);
+				mtouch.AssertError (4128, "The registrar found an invalid generic parameter type 'U[]' in the parameter arg of the method 'Open`1.Zap(U[])'. The generic parameter must have an 'NSObject' constraint.", "testApp.cs", 9);
+				mtouch.AssertError (4129, "The registrar found an invalid generic return type 'U' in the method 'Open`1.XyZ()'. The generic return type must have an 'NSObject' constraint.", "testApp.cs", 12);
+				mtouch.AssertError (4129, "The registrar found an invalid generic return type 'System.Action`1<U>' in the method 'Open`1.ZapBar()'. The generic return type must have an 'NSObject' constraint.", "testApp.cs", 18);
+				mtouch.AssertError (4128, "The registrar found an invalid generic parameter type 'System.Action`1<U>' in the parameter f of the method 'Open`1.XyZ(System.Action`1<U>)'. The generic parameter must have an 'NSObject' constraint.", "testApp.cs", 21);
+				mtouch.AssertError (4128, "The registrar found an invalid generic parameter type 'System.Collections.Generic.List`1<System.Collections.Generic.List`1<System.Collections.Generic.List`1<System.Collections.Generic.List`1<U>>>>' in the parameter f of the method 'Open`1.FooZap(System.Collections.Generic.List`1<System.Collections.Generic.List`1<System.Collections.Generic.List`1<System.Collections.Generic.List`1<U>>>>)'. The generic parameter must have an 'NSObject' constraint.", "testApp.cs", 24);
+				mtouch.AssertError (4129, "The registrar found an invalid generic return type 'System.Collections.Generic.List`1<System.Collections.Generic.List`1<U>>' in the method 'Open`1.ZapBoo()'. The generic return type must have an 'NSObject' constraint.", "testApp.cs", 27);
+				mtouch.AssertErrorCount (11);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -1344,9 +1470,17 @@ class Open<U> : NSObject
 		}
 ";
 
-			Verify (R.Static, code, false, 
-				".*Test.cs.*: error MT4128: The registrar found an invalid generic parameter type 'U&' in the parameter arg of the method 'Open`1.Bar(U&)'. The generic parameter must have an 'NSObject' constraint.",
-				".*Test.cs.*: error MT4128: The registrar found an invalid generic parameter type 'U[]&' in the parameter arg of the method 'Open`1.Zap(U[]&)'. The generic parameter must have an 'NSObject' constraint.");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using ObjCRuntime;", extraArg: "/debug:full /unsafe");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4128, "The registrar found an invalid generic parameter type 'U&' in the parameter arg of the method 'Open`1.Bar(U&)'. The generic parameter must have an 'NSObject' constraint.", "testApp.cs", 6);
+				mtouch.AssertError (4128, "The registrar found an invalid generic parameter type 'U[]&' in the parameter arg of the method 'Open`1.Zap(U[]&)'. The generic parameter must have an 'NSObject' constraint.", "testApp.cs", 9);
+				mtouch.AssertErrorCount (2);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -1475,10 +1609,18 @@ class G : NSObject {
 }
 ";
 
-			Verify (R.Static, code, false,
-				".*Test.cs.*: error MT4113: The registrar found a generic method: 'G.Foo1(System.Int32)'. Exporting generic methods is not supported, and will lead to random behavior and/or crashes",
-				".*Test.cs.*: error MT4113: The registrar found a generic method: 'G.Foo2(System.Int32)'. Exporting generic methods is not supported, and will lead to random behavior and/or crashes",
-				".*Test.cs.*: error MT4113: The registrar found a generic method: 'G.Foo3(X)'. Exporting generic methods is not supported, and will lead to random behavior and/or crashes");
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation;", extraArg: "-debug:full");
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.Linker = MTouchLinker.DontLink; // faster test
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4113, "The registrar found a generic method: 'G.Foo1(System.Int32)'. Exporting generic methods is not supported, and will lead to random behavior and/or crashes", "testApp.cs", 6);
+				mtouch.AssertError (4113, "The registrar found a generic method: 'G.Foo2(System.Int32)'. Exporting generic methods is not supported, and will lead to random behavior and/or crashes", "testApp.cs", 9);
+				mtouch.AssertError (4113, "The registrar found a generic method: 'G.Foo3(X)'. Exporting generic methods is not supported, and will lead to random behavior and/or crashes", "testApp.cs", 12);
+				mtouch.AssertErrorCount (3);
+				mtouch.AssertNoWarnings ();
+			}
 		}
 
 		[Test]
@@ -1511,79 +1653,6 @@ class CTP4 : CTP3 {
 				mtouch.AssertNoWarnings ();
 			}
 		}
-
-#region Helper functions
-		// Creates an app with the specified source as the executable.
-		// Compiles it using smcs, will throw a McsException if it fails.
-		// Then runs mtouch to try to create an app (for device), will throw MTouchException if it fails.
-		static int CreateTestApp (Profile profile, string source, string extra_args = "", string xcode = null, string sdk_version = null, Target target = Target.Dev, StringBuilder output = null)
-		{
-			if (target == Target.Dev)
-				MTouch.AssertDeviceAvailable ();
-
-			string path = Cache.CreateTemporaryDirectory ();
-			string cs = Path.Combine (path, "Test.cs");
-			string exe = Path.Combine (path, "Test.exe");
-			File.WriteAllText (cs, source);
-			Compile (cs, profile);
-			string app = Path.Combine (path, "Test.app");
-			string cache = Path.Combine (path, "cache");
-			Directory.CreateDirectory (cache);
-			Directory.CreateDirectory (app);
-
-			if (xcode == null)
-				xcode = Configuration.xcode_root;
-
-			if (sdk_version == null)
-				sdk_version = MTouch.GetSdkVersion (profile);
-
-			return ExecutionHelper.Execute (TestTarget.ToolPath, string.Format ("{0} {10} {1} --sdk {2} -targetver {2} --abi={9} {3} --sdkroot {4} --cache {5} --nolink {7} --debug -r:{6} --target-framework:{8}", exe, app, sdk_version, extra_args, xcode, cache, MTouch.GetBaseLibrary (profile), string.Empty, MTouch.GetTargetFramework (profile), MTouch.GetArchitecture (profile, target), target == Target.Sim ? "-sim" : "-dev"), null, output, output);
-		}
-
-		// Compile the filename with mcs
-		// Does not clean up anything.
-		static void Compile (string filename, Profile profile = Profile.iOS)
-		{			
-			StringBuilder output = new StringBuilder ();
-			using (var p = new Process ()) {
-				var args = new StringBuilder ();
-				args.Append (" /unsafe /debug:full /nologo ");
-				args.Append (StringUtils.Quote (filename));
-				args.Append (" -r:").Append (StringUtils.Quote (MTouch.GetBaseLibrary (profile)));
-				p.StartInfo.FileName = MTouch.GetCompiler (profile, args);
-				p.StartInfo.Arguments = args.ToString ();
-				p.StartInfo.UseShellExecute = false;
-				p.StartInfo.RedirectStandardError = true;
-				p.StartInfo.RedirectStandardOutput = true;
-				Console.WriteLine ("{0} {1}", p.StartInfo.FileName, p.StartInfo.Arguments);
-				p.Start ();
-				p.BeginErrorReadLine ();
-				p.BeginOutputReadLine ();
-				p.ErrorDataReceived += (sender, e) => 
-				{
-					if (e.Data != null) {
-						lock (output) {
-							output.AppendLine (e.Data);
-						}
-					}
-				};
-				p.OutputDataReceived += (sender, e) => 
-				{
-					if (e.Data != null) {
-						lock (output) {
-							output.AppendLine (e.Data);
-						}
-					}
-				};
-				p.WaitForExit ();
-
-				Console.WriteLine (output);
-				
-				if (p.ExitCode != 0)
-					throw new McsException (output.ToString ());
-			}
-		}
-#endregion
 	}
 }
 


### PR DESCRIPTION
The tests should be identical, except for the MT4134 test, which I've updated
to use Xcode 8.3 (and iOS 10.3) instead of Xcode 6 (and iOS 8.0). It also
needed a few other improvements to not run into other errors before the MT4134
error the test is trying to test.