### PR TITLE
[Mtouch] Pass ShellExceute true in CopyMSymData. Fixes 3653

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1481,7 +1481,7 @@ namespace Xamarin.Bundler {
 				return;
 
 			var p = new Process ();
-			p.StartInfo.UseShellExecute = false;
+			p.StartInfo.UseShellExecute = true;
 			p.StartInfo.RedirectStandardError = true;
 			p.StartInfo.FileName = "mono-symbolicate";
 			p.StartInfo.Arguments = $"store-symbols \"{src}\" \"{dest}\"";


### PR DESCRIPTION
Cherry-picked from https://github.com/xamarin/xamarin-macios/pull/3781