### PR TITLE
[mtouch] Use full path to mono-symbolicate instead of UseShellExecute

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1481,9 +1481,9 @@ namespace Xamarin.Bundler {
 				return;
 
 			var p = new Process ();
-			p.StartInfo.UseShellExecute = true;
+			p.StartInfo.UseShellExecute = false;
 			p.StartInfo.RedirectStandardError = true;
-			p.StartInfo.FileName = "mono-symbolicate";
+			p.StartInfo.FileName = "/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono-symbolicate";
 			p.StartInfo.Arguments = $"store-symbols \"{src}\" \"{dest}\"";
 
 			try {


### PR DESCRIPTION
Fix https://github.com/xamarin/xamarin-macios/issues/3653 differently as
`UseShellExecute` cannot be used when redirecting output so the original
fix [1] caused an exception which affected it from both macOS and windows
(thru XMA) instead of being an issue only with the later.

It's not clear how the original [1] fix was validated successfully, it's
possible than an older version of mono did not throw (since that
limitation seems windows specific).

[1] https://github.com/xamarin/xamarin-macios/pull/3781