### PR TITLE
[Foundation] Ensure we do raise 401 on NTLM when no creds are present.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -380,15 +380,16 @@ namespace Foundation {
 				}
 
 				if (challenge.ProtectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodNTLM) {
+					NSUrlCredential credential;
 					if (sessionHandler.Credentials != null) {
 						var credentialsToUse = sessionHandler.Credentials as NetworkCredential;
 						if (credentialsToUse == null) {
 							var uri = inflight.Request.RequestUri;
 							credentialsToUse = sessionHandler.Credentials.GetCredential (uri, "NTLM");
 						}
-						var credential = new NSUrlCredential (credentialsToUse.UserName, credentialsToUse.Password, NSUrlCredentialPersistence.ForSession);
-						completionHandler (NSUrlSessionAuthChallengeDisposition.UseCredential, credential);
+						credential = new NSUrlCredential (credentialsToUse.UserName, credentialsToUse.Password, NSUrlCredentialPersistence.ForSession);
 					}
+					completionHandler (NSUrlSessionAuthChallengeDisposition.UseCredential, credential ?? challenge.ProposedCredential);
 					return;
 				}
 				completionHandler (NSUrlSessionAuthChallengeDisposition.PerformDefaultHandling, challenge.ProposedCredential);

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -379,20 +379,17 @@ namespace Foundation {
 					}
 				}
 
-				if (challenge.ProtectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodNTLM) {
-					NSUrlCredential credential;
-					if (sessionHandler.Credentials != null) {
-						var credentialsToUse = sessionHandler.Credentials as NetworkCredential;
-						if (credentialsToUse == null) {
-							var uri = inflight.Request.RequestUri;
-							credentialsToUse = sessionHandler.Credentials.GetCredential (uri, "NTLM");
-						}
-						credential = new NSUrlCredential (credentialsToUse.UserName, credentialsToUse.Password, NSUrlCredentialPersistence.ForSession);
+				if (challenge.ProtectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodNTLM && sessionHandler.Credentials != null) {
+					var credentialsToUse = sessionHandler.Credentials as NetworkCredential;
+					if (credentialsToUse == null) {
+						var uri = inflight.Request.RequestUri;
+						credentialsToUse = sessionHandler.Credentials.GetCredential (uri, "NTLM");
 					}
-					completionHandler (NSUrlSessionAuthChallengeDisposition.UseCredential, credential ?? challenge.ProposedCredential);
-					return;
+					NSUrlCredential credential = new NSUrlCredential (credentialsToUse.UserName, credentialsToUse.Password, NSUrlCredentialPersistence.ForSession);
+					completionHandler (NSUrlSessionAuthChallengeDisposition.UseCredential, credential);
+				} else {
+					completionHandler (NSUrlSessionAuthChallengeDisposition.PerformDefaultHandling, challenge.ProposedCredential);
 				}
-				completionHandler (NSUrlSessionAuthChallengeDisposition.PerformDefaultHandling, challenge.ProposedCredential);
 			}
 		}
 


### PR DESCRIPTION
The code was not executing the completionHandler in those case were the
user did not provide the creds. We should try to get the creds and use
them or call the cb with the proposed creds.

Cherry pick from https://github.com/xamarin/xamarin-macios/pull/3794