### PR TITLE
Put a binary copy of mlaunch in macios-binaries instead of in Azure. Fixes #3316.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TOP=.
-SUBDIRS=builds runtime fsharp src tools msbuild
+SUBDIRS=builds runtime fsharp src msbuild tools
 include $(TOP)/Make.config
 include $(TOP)/mk/versions.mk
 

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -185,45 +185,9 @@ namespace xharness
 			}
 		}
 
-		string mlaunch;
 		public string MlaunchPath {
 			get {
-				if (mlaunch == null) {
-					// First check if we've built mlaunch locally.
-					var filename = Path.GetFullPath (Path.Combine (IOS_DESTDIR, "Library", "Frameworks", "Xamarin.iOS.framework", "Versions", "Current", "bin", "mlaunch"));
-					if (File.Exists (filename)) {
-						Log ("Found mlaunch: {0}", filename);
-						Environment.SetEnvironmentVariable ("MLAUNCH_PATH", filename);
-						return mlaunch = filename;
-					}
-
-					// Then check if we can download mlaunch.
-					Log ("Could not find a locally built mlaunch, will try downloading it.");
-					try {
-						filename = DownloadMlaunch ();
-					} catch (Exception e) {
-						Log ("Could not download mlaunch: {0}", e);
-					}
-					if (File.Exists (filename)) {
-						Log ("Found mlaunch: {0}", filename);
-						Environment.SetEnvironmentVariable ("MLAUNCH_PATH", filename);
-						return mlaunch = filename;
-					}
-
-					// Then check if the system version of Xamarin.iOS has mlaunch.
-					// This may be a version of mlaunch we're not compatible with, since we don't control which XI version the system has.
-					Log ("Could not download mlaunch, will try the system's Xamarin.iOS.");
-					filename = "/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch";
-					if (File.Exists (filename)) {
-						Log ("Found mlaunch: {0}", filename);
-						Environment.SetEnvironmentVariable ("MLAUNCH_PATH", filename);
-						return mlaunch = filename;
-					}
-
-					throw new FileNotFoundException (string.Format ("Could not find mlaunch: {0}", filename));
-				}
-
-				return mlaunch;
+				return Path.Combine (IOS_DESTDIR, "Library", "Frameworks", "Xamarin.iOS.framework", "Versions", "Current", "bin", "mlaunch");
 			}
 		}
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,3 +1,3 @@
 TOP=..
-SUBDIRS=mmp mtouch install-source
+SUBDIRS=mmp mtouch install-source mlaunch
 include $(TOP)/Make.config

--- a/tools/mlaunch/Makefile
+++ b/tools/mlaunch/Makefile
@@ -1,0 +1,30 @@
+TOP=../..
+
+include $(TOP)/Make.config
+
+COLOR_GREEN:=$(shell tput setaf 120 2>/dev/null)
+COLOR_CLEAR:=$(shell tput sgr0 2>/dev/null)
+
+ifdef ENABLE_XAMARIN
+all-local install-local::
+	$(MAKE) -C $(MACCORE_PATH)/tools/mlaunch $@
+else
+all-local install-local::
+	$(Q) cp -R $(MACIOS_BINARIES_PATH)/mlaunch/bin/mlaunch $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin
+	$(Q) cp -R $(MACIOS_BINARIES_PATH)/mlaunch/lib/mlaunch $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib
+endif
+
+ifdef ENABLE_XAMARIN
+publish:
+	$(Q) mkdir -p $(MACIOS_BINARIES_PATH)/mlaunch/bin
+	$(Q) mkdir -p $(MACIOS_BINARIES_PATH)/mlaunch/lib
+	$(Q) cp -R $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch $(MACIOS_BINARIES_PATH)/mlaunch/bin
+	$(Q) cp -R $(IOS_DESTDIR)/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mlaunch $(MACIOS_BINARIES_PATH)/mlaunch/lib
+	$(Q) cd $(MACIOS_BINARIES_PATH) && git add mlaunch && git commit -q -m "Bump mlaunch to xamarin/maccore@$(shell cd $(MACCORE_PATH) && git log -1 --pretty=%h)" && git log -1 --pretty=short
+	$(Q) echo "$(COLOR_GREEN)A new version of mlaunch has been copied to $(MACIOS_BINARIES_PATH), and a commit created with the new version.$(COLOR_CLEAR)"
+	$(Q) echo "$(COLOR_GREEN)Please create pull request in the macios-binaries repository for the new mlaunch version, and once merged, bump the submodule in xamarin-macios.$(COLOR_CLEAR)"
+else
+publish:
+	@echo "Can't publish mlaunch binaries to the macios-binaries repository unless building mlaunch from source (by enabling the xamarin build)"
+	@exit 1
+endif

--- a/tools/mlaunch/README.md
+++ b/tools/mlaunch/README.md
@@ -1,0 +1,15 @@
+mlaunch
+-------
+
+mlaunch is a closed source tool used to interact with simulators and devices.
+
+We'll build this tool from souce if the xamarin build is enabled (configured
+with --enable-xamarin).
+
+Otherwise we'll get a binary version from the macios-binaries repository. This
+version may be somewhat out of date, but should work at least for running
+tests.
+
+To update the binary version of mlaunch in macios-binaries execute `make publish`
+in this directory (when the xamarin build is enabled, so that mlaunch
+is built from source).


### PR DESCRIPTION
If the Xamarin build is enabled, then build mlaunch from source, otherwise get it from macios-binaries.

Fixes #3316.