### PR TITLE
[backport][msbuild] Skip reference assemblies passed to mtouch (#3791)

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -780,6 +780,11 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Outputs="$(_NativeExecutable);$(DeviceSpecificOutputPath)mtouch.stamp">
 
 		<ItemGroup>
+			<!-- Skip the reference assemblies. There is currently no scenario where it is valid to pass them to 'mtouch'. They are impossible to AOT. Fixes: https://github.com/xamarin/xamarin-macios/issues/3199 -->
+			<!-- Remove exact references, such as if a package had a framework reference to 'System' that we already have -->
+			<!-- This is exactly what "Microsoft.NuGet.Build.Tasks"'s 'ResolveNuGetPackageAssets' target is doing -->
+			<!-- Effectively 'ResolveNuGetPackageAssets' computes the NuGet packages using their json asset file, adds the full assemblies to 'ReferenceCopyLocalPaths' and outputs the resolved references via '_ReferencesFromNuGetPackages' -->
+			<ReferencePath Remove="@(_ReferencesFromNuGetPackages)" />
 			<MTouchReferencePath Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll'" />
 		</ItemGroup>
 


### PR DESCRIPTION
- Fixes issue #3199: Could not AOT the assembly System.Runtime.CompilerServices.Unsafe.dll (MT3001)
  (https://github.com/xamarin/xamarin-macios/issues/3199)
- Test case: https://www.dropbox.com/s/kxt3isgzn74nq35/Issue3199.zip?dl=0


Given a Nuget Package added via the "package reference" mechanism and the said package having netstandard 'lib' **and** 'ref' folders;
MTouch was getting reference assemblies and was trying to AOT them. This resulted in an error as those assemblies are only facades.


'ResolveNuGetPackageAssets' computes the NuGet packages using their json asset file, adds the full assemblies to 'ReferenceCopyLocalPaths' and outputs the resolved references via '_ReferencesFromNuGetPackages'.

This is exactly what "Microsoft.NuGet.Build.Tasks"'s 'ResolveNuGetPackageAssets' target does.