### PR TITLE
NSTokenFieldCell and NSTokenFieldCellDelegate bindings

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -17991,7 +17991,7 @@ namespace AppKit {
 	[Protocol]
 	interface NSTokenFieldCellDelegate {		
 		[Export ("tokenFieldCell:completionsForSubstring:indexOfToken:indexOfSelectedItem:")]
-		string [] GetCompletionStrings (NSTokenFieldCell tokenFieldCell, string substring, nint tokenIndex, ref nint selectedIndex);
+		NSArray GetCompletionStrings (NSTokenFieldCell tokenFieldCell, string substring, nint tokenIndex, ref nint selectedIndex);
 		
 		[Export ("tokenFieldCell:shouldAddObjects:atIndex:")]
 		NSArray ShouldAddObjects (NSTokenFieldCell tokenFieldCell, NSArray tokens, nuint index);
@@ -18007,7 +18007,7 @@ namespace AppKit {
 		NSObject GetRepresentedObject (NSTokenFieldCell tokenFieldCell, string editingString);
 		
 		[Export ("tokenFieldCell:writeRepresentedObjects:toPasteboard:")]
-		bool WriteRepresented (NSTokenFieldCell tokenFieldCell, NSArray objects, NSPasteboard pboard);
+		bool WriteRepresentedObjects (NSTokenFieldCell tokenFieldCell, NSObject [] objects, NSPasteboard pboard);
 		
 		[Export ("tokenFieldCell:readFromPasteboard:")]
 		NSObject [] Read (NSTokenFieldCell tokenFieldCell, NSPasteboard pboard);
@@ -18062,6 +18062,7 @@ namespace AppKit {
 	}
 
 	[BaseType (typeof(NSTextFieldCell))]
+	[DisableDefaultCtor]
 	interface NSTokenFieldCell {
 		[Export ("initTextCell:")]
 		IntPtr Constructor (string aString);
@@ -18076,7 +18077,7 @@ namespace AppKit {
 		[Export ("defaultCompletionDelay")]
 		double DefaultCompletionDelay { get; }
 		
-		[Export ("tokenizingCharacterSet", ArgumentSemantic.Copy)] 
+		[Export ("tokenizingCharacterSet", ArgumentSemantic.Copy), NullAllowed] 
 		NSCharacterSet CharacterSet { get; set; }
 				
 		[Static]
@@ -19162,7 +19163,7 @@ namespace AppKit {
 		string [] GetCompletionStrings (NSTokenField tokenField, string substring, nint tokenIndex, nint selectedIndex);
 
 		[Export ("tokenField:shouldAddObjects:atIndex:")]
-		NSArray ShouldAddObjects (NSTokenField tokenField, NSArray tokens, nuint index);
+		NSObject[] ShouldAddObjects (NSTokenField tokenField, NSObject[] tokens, nuint index);
 
 		[Export ("tokenField:displayStringForRepresentedObject:")]
 		string GetDisplayString (NSTokenField tokenField, NSObject representedObject);
@@ -19175,7 +19176,7 @@ namespace AppKit {
 		NSObject GetRepresentedObject (NSTokenField tokenField, string editingString);
 
 		[Export ("tokenField:writeRepresentedObjects:toPasteboard:")]
-		bool WriteRepresented (NSTokenField tokenField, NSArray objects, NSPasteboard pboard);
+		bool WriteRepresentedObjects (NSTokenField tokenField, NSObject[] objects, NSPasteboard pboard);
 
 		[Export ("tokenField:readFromPasteboard:")]
 		NSObject [] Read (NSTokenField tokenField, NSPasteboard pboard);

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -17986,6 +17986,42 @@ namespace AppKit {
 		void SelectionIsChanging (NSNotification notification);
 	}
 
+	[BaseType (typeof(NSObject))]
+	[Model]
+	[Protocol]
+	interface NSTokenFieldCellDelegate {		
+		[Export ("tokenFieldCell:completionsForSubstring:indexOfToken:indexOfSelectedItem:")]
+		string [] GetCompletionStrings (NSTokenFieldCell tokenFieldCell, string substring, nint tokenIndex, ref nint selectedIndex);
+		
+		[Export ("tokenFieldCell:shouldAddObjects:atIndex:")]
+		NSArray ShouldAddObjects (NSTokenFieldCell tokenFieldCell, NSArray tokens, nuint index);
+		
+		[Export ("tokenFieldCell:displayStringForRepresentedObject:")]
+		string GetDisplayString (NSTokenFieldCell tokenFieldCell, NSObject representedObject);
+		
+		[Export ("tokenFieldCell:editingStringForRepresentedObject:")]
+		string GetEditingString (NSTokenFieldCell tokenFieldCell, NSObject representedObject);
+		
+		[Export ("tokenFieldCell:representedObjectForEditingString:")]
+		[return: NullAllowed]
+		NSObject GetRepresentedObject (NSTokenFieldCell tokenFieldCell, string editingString);
+		
+		[Export ("tokenFieldCell:writeRepresentedObjects:toPasteboard:")]
+		bool WriteRepresented (NSTokenFieldCell tokenFieldCell, NSArray objects, NSPasteboard pboard);
+		
+		[Export ("tokenFieldCell:readFromPasteboard:")]
+		NSObject [] Read (NSTokenFieldCell tokenFieldCell, NSPasteboard pboard);
+		
+		[Export ("tokenFieldCell:menuForRepresentedObject:")]
+		NSMenu GetMenu (NSTokenFieldCell tokenFieldCell, NSObject representedObject);
+		
+		[Export ("tokenFieldCell:hasMenuForRepresentedObject:")]
+		bool HasMenu (NSTokenFieldCell tokenFieldCell, NSObject representedObject);
+		
+		[Export ("tokenFieldCell:styleForRepresentedObject:")]
+		NSTokenStyle GetStyle (NSTokenFieldCell tokenFieldCell, NSObject representedObject);
+	}
+
 	[BaseType (typeof (NSActionCell))]
 	interface NSTextFieldCell {
 		[DesignatedInitializer]
@@ -18023,6 +18059,36 @@ namespace AppKit {
 		[Export ("wantsNotificationForMarkedText")]
 		[Override]
 		bool WantsNotificationForMarkedText { get; set; }
+	}
+
+	[BaseType (typeof(NSTextFieldCell))]
+	interface NSTokenFieldCell {
+		[Export ("initTextCell:")]
+		IntPtr Constructor (string aString);
+
+		[Export ("tokenStyle")]
+		NSTokenStyle TokenStyle { get; set; }
+		
+		[Export ("completionDelay")]
+		double CompletionDelay { get; set; }
+		
+		[Static]
+		[Export ("defaultCompletionDelay")]
+		double DefaultCompletionDelay { get; }
+		
+		[Export ("tokenizingCharacterSet", ArgumentSemantic.Copy)] 
+		NSCharacterSet CharacterSet { get; set; }
+				
+		[Static]
+		[Export ("defaultTokenizingCharacterSet")] 
+		NSCharacterSet DefaultCharacterSet { get; }
+		
+		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed] 
+		NSObject WeakDelegate { get; set; }
+		
+		[Wrap ("WeakDelegate")]
+		[Protocolize]
+		NSTokenFieldCellDelegate Delegate { get; set; }
 	}
 
 	[BaseType (typeof (NSTextFieldCell))]

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -17989,35 +17989,35 @@ namespace AppKit {
 	[BaseType (typeof(NSObject))]
 	[Model]
 	[Protocol]
-	interface NSTokenFieldCellDelegate {		
+	interface NSTokenFieldCellDelegate {
 		[Export ("tokenFieldCell:completionsForSubstring:indexOfToken:indexOfSelectedItem:")]
 		NSArray GetCompletionStrings (NSTokenFieldCell tokenFieldCell, string substring, nint tokenIndex, ref nint selectedIndex);
-		
+
 		[Export ("tokenFieldCell:shouldAddObjects:atIndex:")]
 		NSArray ShouldAddObjects (NSTokenFieldCell tokenFieldCell, NSObject[] tokens, nuint index);
-		
+
 		[Export ("tokenFieldCell:displayStringForRepresentedObject:")]
 		string GetDisplayString (NSTokenFieldCell tokenFieldCell, NSObject representedObject);
-		
+
 		[Export ("tokenFieldCell:editingStringForRepresentedObject:")]
 		string GetEditingString (NSTokenFieldCell tokenFieldCell, NSObject representedObject);
-		
+
 		[Export ("tokenFieldCell:representedObjectForEditingString:")]
 		[return: NullAllowed]
 		NSObject GetRepresentedObject (NSTokenFieldCell tokenFieldCell, string editingString);
-		
+
 		[Export ("tokenFieldCell:writeRepresentedObjects:toPasteboard:")]
 		bool WriteRepresentedObjects (NSTokenFieldCell tokenFieldCell, NSObject [] objects, NSPasteboard pboard);
-		
+
 		[Export ("tokenFieldCell:readFromPasteboard:")]
 		NSObject [] Read (NSTokenFieldCell tokenFieldCell, NSPasteboard pboard);
-		
+
 		[Export ("tokenFieldCell:menuForRepresentedObject:")]
 		NSMenu GetMenu (NSTokenFieldCell tokenFieldCell, NSObject representedObject);
-		
+
 		[Export ("tokenFieldCell:hasMenuForRepresentedObject:")]
 		bool HasMenu (NSTokenFieldCell tokenFieldCell, NSObject representedObject);
-		
+
 		[Export ("tokenFieldCell:styleForRepresentedObject:")]
 		NSTokenStyle GetStyle (NSTokenFieldCell tokenFieldCell, NSObject representedObject);
 	}
@@ -18069,24 +18069,24 @@ namespace AppKit {
 
 		[Export ("tokenStyle")]
 		NSTokenStyle TokenStyle { get; set; }
-		
+
 		[Export ("completionDelay")]
 		double CompletionDelay { get; set; }
-		
+
 		[Static]
 		[Export ("defaultCompletionDelay")]
 		double DefaultCompletionDelay { get; }
-		
+
 		[Export ("tokenizingCharacterSet", ArgumentSemantic.Copy), NullAllowed] 
 		NSCharacterSet CharacterSet { get; set; }
-				
+
 		[Static]
 		[Export ("defaultTokenizingCharacterSet")] 
 		NSCharacterSet DefaultCharacterSet { get; }
-		
+
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed] 
 		NSObject WeakDelegate { get; set; }
-		
+
 		[Wrap ("WeakDelegate")]
 		[Protocolize]
 		NSTokenFieldCellDelegate Delegate { get; set; }
@@ -19160,10 +19160,10 @@ namespace AppKit {
 	[Protocol]
 	interface NSTokenFieldDelegate {
 		[Export ("tokenField:completionsForSubstring:indexOfToken:indexOfSelectedItem:")]
-		NSArray GetCompletionStrings (NSTokenField tokenField, string substring, nint tokenIndex, ref nint selectedIndex);
+		string [] GetCompletionStrings (NSTokenField tokenField, string substring, nint tokenIndex, nint selectedIndex);
 
 		[Export ("tokenField:shouldAddObjects:atIndex:")]
-		NSArray ShouldAddObjects (NSTokenField tokenField, NSObject[] tokens, nuint index);
+		NSArray ShouldAddObjects (NSTokenField tokenField, NSArray tokens, nuint index);
 
 		[Export ("tokenField:displayStringForRepresentedObject:")]
 		string GetDisplayString (NSTokenField tokenField, NSObject representedObject);
@@ -19176,7 +19176,7 @@ namespace AppKit {
 		NSObject GetRepresentedObject (NSTokenField tokenField, string editingString);
 
 		[Export ("tokenField:writeRepresentedObjects:toPasteboard:")]
-		bool WriteRepresentedObjects (NSTokenField tokenField, NSObject[] objects, NSPasteboard pboard);
+		bool WriteRepresented (NSTokenField tokenField, NSArray objects, NSPasteboard pboard);
 
 		[Export ("tokenField:readFromPasteboard:")]
 		NSObject [] Read (NSTokenField tokenField, NSPasteboard pboard);

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -19160,7 +19160,7 @@ namespace AppKit {
 	[Protocol]
 	interface NSTokenFieldDelegate {
 		[Export ("tokenField:completionsForSubstring:indexOfToken:indexOfSelectedItem:")]
-		NSArray GetCompletionStrings (NSTokenField tokenField, string substring, nint tokenIndex, nint selectedIndex);
+		NSArray GetCompletionStrings (NSTokenField tokenField, string substring, nint tokenIndex, ref nint selectedIndex);
 
 		[Export ("tokenField:shouldAddObjects:atIndex:")]
 		NSArray ShouldAddObjects (NSTokenField tokenField, NSObject[] tokens, nuint index);

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -17994,7 +17994,7 @@ namespace AppKit {
 		NSArray GetCompletionStrings (NSTokenFieldCell tokenFieldCell, string substring, nint tokenIndex, ref nint selectedIndex);
 		
 		[Export ("tokenFieldCell:shouldAddObjects:atIndex:")]
-		NSArray ShouldAddObjects (NSTokenFieldCell tokenFieldCell, NSArray tokens, nuint index);
+		NSArray ShouldAddObjects (NSTokenFieldCell tokenFieldCell, NSObject[] tokens, nuint index);
 		
 		[Export ("tokenFieldCell:displayStringForRepresentedObject:")]
 		string GetDisplayString (NSTokenFieldCell tokenFieldCell, NSObject representedObject);
@@ -19160,10 +19160,10 @@ namespace AppKit {
 	[Protocol]
 	interface NSTokenFieldDelegate {
 		[Export ("tokenField:completionsForSubstring:indexOfToken:indexOfSelectedItem:")]
-		string [] GetCompletionStrings (NSTokenField tokenField, string substring, nint tokenIndex, nint selectedIndex);
+		NSArray GetCompletionStrings (NSTokenField tokenField, string substring, nint tokenIndex, nint selectedIndex);
 
 		[Export ("tokenField:shouldAddObjects:atIndex:")]
-		NSObject[] ShouldAddObjects (NSTokenField tokenField, NSObject[] tokens, nuint index);
+		NSArray ShouldAddObjects (NSTokenField tokenField, NSObject[] tokens, nuint index);
 
 		[Export ("tokenField:displayStringForRepresentedObject:")]
 		string GetDisplayString (NSTokenField tokenField, NSObject representedObject);

--- a/tests/xtro-sharpie/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/macOS-AppKit.ignore
@@ -623,7 +623,6 @@
 !missing-protocol! NSTextAttachmentCell not bound
 !missing-protocol! NSTextInput not bound
 !missing-protocol! NSTextLayoutOrientationProvider not bound
-!missing-protocol! NSTokenFieldCellDelegate not bound
 !missing-protocol! NSUserInterfaceItemSearching not bound
 !missing-protocol-conformance! NSApplication should conform to NSUserInterfaceValidations
 !missing-protocol-conformance! NSButton should conform to NSUserInterfaceValidations
@@ -705,8 +704,6 @@
 !missing-selector! +NSScrollView::setRulerViewClass: not bound
 !missing-selector! +NSSet::setWithCollectionViewIndexPath: not bound
 !missing-selector! +NSSet::setWithCollectionViewIndexPaths: not bound
-!missing-selector! +NSTokenFieldCell::defaultCompletionDelay not bound
-!missing-selector! +NSTokenFieldCell::defaultTokenizingCharacterSet not bound
 !missing-selector! NSApplication::activateContextHelpMode: not bound
 !missing-selector! NSApplication::application:printFiles: not bound
 !missing-selector! NSApplication::beginModalSessionForWindow:relativeToWindow: not bound
@@ -1133,14 +1130,6 @@
 !missing-selector! NSTextView::dragImageForSelectionWithEvent:origin: not bound
 !missing-selector! NSTextView::dragSelectionWithEvent:offset:slideBack: not bound
 !missing-selector! NSTextView::toggleBaseWritingDirection: not bound
-!missing-selector! NSTokenFieldCell::completionDelay not bound
-!missing-selector! NSTokenFieldCell::delegate not bound
-!missing-selector! NSTokenFieldCell::setCompletionDelay: not bound
-!missing-selector! NSTokenFieldCell::setDelegate: not bound
-!missing-selector! NSTokenFieldCell::setTokenizingCharacterSet: not bound
-!missing-selector! NSTokenFieldCell::setTokenStyle: not bound
-!missing-selector! NSTokenFieldCell::tokenizingCharacterSet not bound
-!missing-selector! NSTokenFieldCell::tokenStyle not bound
 !missing-selector! NSToolbar::fullScreenAccessoryView not bound
 !missing-selector! NSToolbar::fullScreenAccessoryViewMaxHeight not bound
 !missing-selector! NSToolbar::fullScreenAccessoryViewMinHeight not bound
@@ -1198,7 +1187,6 @@
 !missing-type! NSPDFPanel not bound
 !missing-type! NSPersistentDocument not bound
 !missing-type! NSPICTImageRep not bound
-!missing-type! NSTokenFieldCell not bound
 !unknown-field! item bound
 !unknown-field! MenuItem bound
 !unknown-field! NSAlternativeString bound


### PR DESCRIPTION
Xamarin.Mac AppKit API bindings for:

- NSTokenFieldCell: https://developer.apple.com/documentation/appkit/nstokenfieldcell?language=objc
- NSTokenFieldCellDelegate: https://developer.apple.com/documentation/appkit/nstokenfieldcelldelegate?language=objc

Both of these are effectively duplicates of NSTokenField and NSTokenFieldDelegate. Things to note:

1. I've duplicated the names 1:1 between the regular and cell apis for consistency
2. In the cell delegate I've used a `ref int` in GetCompletionStrings, while NSTokenFieldDelegate uses `int`. The [documentation](https://developer.apple.com/documentation/appkit/nstokenfieldcelldelegate/1523818-tokenfieldcell?language=objc) for that parameter specifies it allows optionally returning by reference. I'm not sure about the NSTokenFieldDelegate binding's original rationale/context, but I can also include an overload for it with a `ref int` as part of this if y'all would like.

I ran the tests in apitest-unified, apitest-unified32, introspection-unified, and introspection-unified32:  all passed (excluding some NSCoding fails on unrelated types, and a lot of presumably unrelated 'unneeded or incorrect version' fails). Built from source and it instantiates fine. 

Also removed the sharpie warnings in AppKit's xtro-sharpie ignore file. Let me know if there are any revisions or anything needed.