### PR TITLE
[xharness] Fix creation of html reports for NUnit tests.

### DIFF
--- a/tests/xharness/Log.cs
+++ b/tests/xharness/Log.cs
@@ -45,6 +45,11 @@ namespace xharness
 			throw new NotSupportedException ();
 		}
 
+		public override void Write (char value)
+		{
+			WriteImpl (value.ToString ());
+		}
+
 		public override void Write (string value)
 		{
 			if (Timestamp)


### PR DESCRIPTION
Make sure to override all required TextWriter methods so that the LogFile gets
all the output any writers (such as the XmlWriter that is used to create the
html report for NUnit tests by applying an XSLT transform to the xml results)
writes.