### PR TITLE
[msbuild] Use a response file in 'MmpTaskBase'

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
+++ b/msbuild/Xamarin.Mac.Tasks.Core/Tasks/MmpTaskBase.cs
@@ -79,6 +79,9 @@ namespace Xamarin.Mac.Tasks
 		public ITaskItem [] ExplicitReferences { get; set; }
 		public ITaskItem [] NativeReferences { get; set; }
 
+		[Required]
+		public string ResponseFilePath { get; set; }
+
 		public string IntermediateOutputPath { get; set; }
 
 		[Output]
@@ -101,23 +104,23 @@ namespace Xamarin.Mac.Tasks
 			var args = new CommandLineArgumentBuilder ();
 			bool msym;
 
-			args.Add ("/verbose");
+			args.AddLine ("/verbose");
 
 			if (Debug)
-				args.Add ("/debug");
+				args.AddLine ("/debug");
 
 			if (!string.IsNullOrEmpty (OutputPath))
-				args.AddQuoted ("/output:" + Path.GetFullPath (OutputPath));
+				args.AddQuotedLine ("/output:" + Path.GetFullPath (OutputPath));
 
 			if (!string.IsNullOrEmpty (ApplicationName))
-				args.AddQuoted ("/name:" + ApplicationName);
+				args.AddQuotedLine ("/name:" + ApplicationName);
 
 			if (TargetFrameworkIdentifier == "Xamarin.Mac")
-				args.Add ("/profile:Xamarin.Mac,Version=v2.0,Profile=Mobile");
+				args.AddLine ("/profile:Xamarin.Mac,Version=v2.0,Profile=Mobile");
 			else if (UseXamMacFullFramework)
-				args.Add ($"/profile:Xamarin.Mac,Version={TargetFrameworkVersion},Profile=Full");
+				args.AddLine ($"/profile:Xamarin.Mac,Version={TargetFrameworkVersion},Profile=Full");
 			else
-				args.Add ($"/profile:Xamarin.Mac,Version={TargetFrameworkVersion},Profile=System");
+				args.AddLine ($"/profile:Xamarin.Mac,Version={TargetFrameworkVersion},Profile=System");
 
 			XamMacArch arch;
 			if (!Enum.TryParse (Architecture, true, out arch))
@@ -127,15 +130,15 @@ namespace Xamarin.Mac.Tasks
 				arch = XamMacArch.x86_64;
 
 			if (arch.HasFlag (XamMacArch.i386))
-				args.Add ("/arch:i386");
+				args.AddLine ("/arch:i386");
 
 			if (arch.HasFlag (XamMacArch.x86_64))
-				args.Add ("/arch:x86_64");
+				args.AddLine ("/arch:x86_64");
 
 			if (!string.IsNullOrEmpty (ArchiveSymbols) && bool.TryParse (ArchiveSymbols.Trim (), out msym))
-				args.Add ("--msym:" + (msym ? "yes" : "no"));
+				args.AddLine ("--msym:" + (msym ? "yes" : "no"));
 
-			args.Add (string.Format ("--http-message-handler={0}", HttpClientHandler));
+			args.AddLine (string.Format ("--http-message-handler={0}", HttpClientHandler));
 
 			if (AppManifest != null) {
 				try {
@@ -149,7 +152,7 @@ namespace Xamarin.Mac.Tasks
 					else
 						minimumDeploymentTarget = v.Value;
 
-					args.Add (string.Format("/minos={0}", minimumDeploymentTarget));
+					args.AddLine (string.Format("/minos={0}", minimumDeploymentTarget));
 				}
 				catch (Exception ex) {
 					Log.LogWarning (null, null, null, AppManifest.ItemSpec, 0, 0, 0, 0, "Error loading '{0}': {1}", AppManifest.ItemSpec, ex.Message);
@@ -157,22 +160,22 @@ namespace Xamarin.Mac.Tasks
 			}
 
 			if (Profiling)
-				args.Add ("/profiling");
+				args.AddLine ("/profiling");
 
 			if (EnableSGenConc)
-				args.Add ("/sgen-conc");
+				args.AddLine ("/sgen-conc");
 
 			switch ((LinkMode ?? string.Empty).ToLower ()) {
 			case "full":
 				break;
 			case "sdkonly":
-				args.Add ("/linksdkonly");
+				args.AddLine ("/linksdkonly");
 				break;
 			case "platform":
-				args.Add ("/linkplatform");
+				args.AddLine ("/linkplatform");
 				break;
 			default:
-				args.Add ("/nolink");
+				args.AddLine ("/nolink");
 				break;
 			}
 
@@ -184,39 +187,58 @@ namespace Xamarin.Mac.Tasks
 				if (!string.IsNullOrEmpty (ExplicitAotAssemblies))
 					aot += $",{ExplicitAotAssemblies}";
 
-				args.Add (aot);
+				args.AddLine (aot);
 			}
 
 			if (!string.IsNullOrEmpty (I18n))
-				args.AddQuoted ("/i18n:" + I18n);
+				args.AddQuotedLine ("/i18n:" + I18n);
 
 			if (ExplicitReferences != null) {
 				foreach (var asm in ExplicitReferences)
-					args.AddQuoted ("/assembly:" + Path.GetFullPath (asm.ItemSpec));
+					args.AddQuotedLine ("/assembly:" + Path.GetFullPath (asm.ItemSpec));
 			}
 
 			if (!string.IsNullOrEmpty (ApplicationAssembly.ItemSpec)) {
-				args.AddQuoted ("/root-assembly:" + Path.GetFullPath (ApplicationAssembly.ItemSpec));
+				args.AddQuotedLine ("/root-assembly:" + Path.GetFullPath (ApplicationAssembly.ItemSpec));
 			}
 
 			if (!string.IsNullOrWhiteSpace (ExtraArguments))
-				args.Add (ExtraArguments);
+				args.AddLine (ExtraArguments);
 
 			if (NativeReferences != null) {
 				foreach (var nr in NativeReferences)
-					args.AddQuoted ("/native-reference:" + Path.GetFullPath (nr.ItemSpec));
+					args.AddQuotedLine ("/native-reference:" + Path.GetFullPath (nr.ItemSpec));
 			}
 				
 			if (IsAppExtension)
-				args.AddQuoted ("/extension");
+				args.AddQuotedLine ("/extension");
 
-			args.AddQuoted ("/sdkroot:" + SdkRoot);
+			args.AddQuotedLine ("/sdkroot:" + SdkRoot);
 
 			if (!string.IsNullOrEmpty (IntermediateOutputPath)) {
 				Directory.CreateDirectory (IntermediateOutputPath);
 
-				args.AddQuoted ("--cache:" + Path.GetFullPath (IntermediateOutputPath));
+				args.AddQuotedLine ("--cache:" + Path.GetFullPath (IntermediateOutputPath));
 			}
+
+			// Generate a response file
+			var responseFile = Path.GetFullPath (ResponseFilePath);
+
+			if (File.Exists (responseFile))
+				File.Delete (responseFile);
+
+			try {
+				using (var fs = File.Create (responseFile)) {
+					using (var writer = new StreamWriter (fs))
+						writer.Write (args);
+				}
+			} catch (Exception ex) {
+				Log.LogWarning ("Failed to create response file '{0}': {1}", responseFile, ex);
+			}
+
+			// Use only the response file
+			args = new CommandLineArgumentBuilder ();
+			args.AddQuotedLine ($"@{responseFile}");
 
 			return args.ToString ();
 		}

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -502,6 +502,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			ExtraArguments="$(MonoBundlingExtraArgs)"
 			NativeReferences="@(NativeReference)"
 			ExplicitReferences="@(ReferencePath);@(ReferenceCopyLocalAssemblyPaths)"
+			ResponseFilePath="$(IntermediateOutputPath)response-file.rsp"
 			SdkRoot="$(_SdkDevPath)"
 			IntermediateOutputPath="$(IntermediateOutputPath)mmp-cache"
 			AppManifest="$(_AppManifest)"

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -427,7 +427,7 @@ namespace Xamarin.Bundler {
 
 		static void LogArguments (string [] arguments)
 		{
-			if (Verbosity < 2)
+			if (Verbosity < 1)
 				return;
 			if (!arguments.Any ((v) => v.Length > 0 && v [0] == '@'))
 				return; // no need to print arguments unless we get response files


### PR DESCRIPTION
- Fixes #3698: [msbuild] Use response file for mmp's msbuild task
(https://github.com/xamarin/xamarin-macios/issues/3698)
- Update Common/Driver to log arguments for all verbosity levels except quiet.
  This makes it so mmp's /verbose when used in a response file prints the provided arguments.
- No test yet because of lack of Xamarin.Mac msbuild task test infrastructure.
  See: https://github.com/xamarin/xamarin-macios/issues/3926