### PR TITLE
[mtouch] Fix parsing of --root-assembly.

### DIFF
--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -124,7 +124,7 @@ namespace Xamarin.Bundler {
 			options.Add ("ignore-dynamic-symbol:", "Specify that Xamarin.iOS/Xamarin.Mac should not try to prevent the linker from removing the specified symbol.", (v) => {
 				app.IgnoredSymbols.Add (v);
 			});
-			options.Add ("root-assembly:", "Specifies any root assemblies. There must be at least one root assembly, usually the main executable.", (v) => {
+			options.Add ("root-assembly=", "Specifies any root assemblies. There must be at least one root assembly, usually the main executable.", (v) => {
 				app.RootAssemblies.Add (v);
 			});
 			options.Add ("optimize=", "A comma-delimited list of optimizations to enable/disable. To enable an optimization, use --optimize=[+]remove-uithread-checks. To disable an optimizations: --optimize=-remove-uithread-checks. Use '+all' to enable or '-all' disable all optimizations. Only compiler-generated code or code otherwise marked as safe to optimize will be optimized.\n" +


### PR DESCRIPTION
Fix parsing of --root-assembly to make the assembly required. This also means
that `--root-assembly /path/to/assembly` (a space separator instead of colon
or equals) will now work.