### PR TITLE
[d15-7][mtouch] watchOS extensions are top-level containers. Fixes issue #3930. (#3934)

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -3779,6 +3779,34 @@ public partial class KeyboardViewController : UIKit.UIInputViewController
 			}
 		}
 
+		[Test]
+		public void WatchOSExtensionsWithExtensions ()
+		{
+			using (var intents_extension = new MTouchTool ()) {
+				intents_extension.Profile = Profile.watchOS;
+				intents_extension.CreateTemporaryWatchOSIntentsExtension ();
+				intents_extension.CreateTemporaryCacheDirectory ();
+				intents_extension.DSym = false; // faster test
+				intents_extension.MSym = false; // faster test
+				intents_extension.NoStrip = true; // faster test
+
+				intents_extension.AssertExecute (MTouchAction.BuildDev, "extension build");
+
+				using (var watch_extension = new MTouchTool ()) {
+					watch_extension.Profile = Profile.watchOS;
+					watch_extension.AppExtensions.Add (intents_extension);
+					watch_extension.CreateTemporaryCacheDirectory ();
+					watch_extension.CreateTemporaryWatchKitExtension ();
+					watch_extension.DSym = false; // faster test
+					watch_extension.MSym = false; // faster test
+					watch_extension.NoStrip = true; // faster test
+
+					watch_extension.AssertExecute (MTouchAction.BuildDev, "build");
+					watch_extension.AssertNoWarnings ();
+				}
+			}
+		}
+
 		public void XamarinSdkAdjustLibs ()
 		{
 			using (var exttool = new MTouchTool ()) {

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -680,6 +680,99 @@ public partial class NotificationController : WKUserNotificationInterfaceControl
 ");
 		}
 
+		public void CreateTemporaryWatchOSIntentsExtension (string code = null, string appName = "intentsExtension")
+		{
+			string testDir;
+			if (RootAssembly == null) {
+				testDir = CreateTemporaryDirectory ();
+			} else {
+				// We're rebuilding an existing executable, so just reuse that directory
+				testDir = Path.GetDirectoryName (RootAssembly);
+			}
+			var app = AppPath ?? Path.Combine (testDir, $"{appName}.appex");
+			Directory.CreateDirectory (app);
+
+			if (code == null) {
+				code = @"
+using System;
+using Foundation;
+using Intents;
+using WatchKit;
+[Register (""IntentHandler"")]
+public class IntentHandler : INExtension, IINRidesharingDomainHandling {
+	protected IntentHandler (System.IntPtr handle) : base (handle) {}
+	public void HandleRequestRide (INRequestRideIntent intent, Action<INRequestRideIntentResponse> completion)  { }
+	public void HandleListRideOptions (INListRideOptionsIntent intent, Action<INListRideOptionsIntentResponse> completion) { }
+	public void HandleRideStatus (INGetRideStatusIntent intent, Action<INGetRideStatusIntentResponse> completion) { }
+	public void StartSendingUpdates (INGetRideStatusIntent intent, IINGetRideStatusIntentResponseObserver observer) { }
+	public void StopSendingUpdates (INGetRideStatusIntent intent) { }
+}";
+			}
+
+			AppPath = app;
+			Extension = true;
+			RootAssembly = MTouch.CompileTestAppLibrary (testDir, code: code, profile: Profile.watchOS, appName: appName);
+
+			File.WriteAllText (Path.Combine (app, "Info.plist"), $@"<?xml version=""1.0"" encoding=""UTF-8""?>
+<!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
+<plist version=""1.0"">
+<dict>
+	<key>BuildMachineOSBuild</key>
+	<string>17E199</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>{appName}</string>
+	<key>CFBundleExecutable</key>
+	<string>{appName}</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.xamarin.testapp.watchkitapp.watchkitextension.intentswatch</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>{appName}</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>MinimumOSVersion</key>
+	<string>3.2</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>IntentsRestrictedWhileLocked</key>
+			<array/>
+			<key>IntentsSupported</key>
+			<array>
+				<string>INRequestRideIntent</string>
+				<string>INListRideOptionsIntent</string>
+				<string>INGetRideStatusIntent</string>
+			</array>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.intents-service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>IntentHandler</string>
+	</dict>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>4</integer>
+	</array>
+</dict>
+</plist>
+");
+		}
+
 		public void CreateTemporaryApp_LinkWith ()
 		{
 			AppPath = CreateTemporaryAppDirectory ();

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -213,7 +213,7 @@ namespace Registrar {
 			get {
 				if (protocol_member_method_map == null) {
 #if MTOUCH
-					if (App.IsExtension && App.IsCodeShared) {
+					if ((App.IsExtension && !App.IsWatchExtension) && App.IsCodeShared) {
 						protocol_member_method_map = Target.ContainerTarget.StaticRegistrar.ProtocolMemberMethodMap;
 					} else {
 						protocol_member_method_map = new Dictionary<ICustomAttribute, MethodDefinition> ();


### PR DESCRIPTION
watchOS extensions are top-level containers in our build (because we ignore
watchOS apps entirely in mtouch), so treat them as such when computing the
protocol member map.

Fixes issue https://github.com/xamarin/xamarin-macios/issues/3930.