### PR TITLE
Fix API diff markdown and make sure wrench shows the link to the .md files

### DIFF
--- a/tools/apidiff/.gitignore
+++ b/tools/apidiff/.gitignore
@@ -8,3 +8,4 @@ ios-*.md
 tvos-*.md
 watchos-*.md
 macos-*.md
+xamarin-*.md

--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -275,12 +275,12 @@ ifdef INCLUDE_TVOS
 endif
 endif
 	$(Q) $(MAKE) all -j8
+	$(Q) $(MAKE) -j8 ios-markdown tvos-markdown watchos-markdown macos-markdown
 	$(Q) cp api-diff.html index.html
 	@echo "@MonkeyWrench: AddFile: $(CURDIR)/index.html"
 	@echo "@MonkeyWrench: AddFile: $(CURDIR)/api-diff.html"
 	@# remove empty files so they're not uploaded
 	@-find $(CURDIR)/diff -size 0 | xargs rm
-	$(MAKE) -j8 ios-markdown tvos-markdown watchos-markdown macos-markdown
 ifdef INCLUDE_IOS
 	$(MAKE) verify-reference-assemblies-ios -j8
 endif


### PR DESCRIPTION
The existing Makefile copy api-diff.html to index.html before it was
updated with the .md links.

The mono-api-html.exe was reversing the diff (old/new) sections.