### PR TITLE
[build] Sprinkle -nologo to csc usages to avoid spam fest in our logs

### DIFF
--- a/opentk/Makefile.include
+++ b/opentk/Makefile.include
@@ -26,7 +26,7 @@ $(addprefix $(MAC_BUILD_DIR)/net_4_5/,OpenTK.dll): XAMMAC = -r:$(MAC_BUILD_DIR)/
 
 $(MAC_BUILD_DIR)/mobile-32/OpenTK.dll: $(MAC_OPENTK_SOURCES) $(MAC_BUILD_DIR)/mobile-32/Xamarin.Mac.dll
 	$(call Q_PROF_CSC,mac/$(VARIANT)) $(MAC_mobile_CSC) \
-		-out:$@ -target:library -debug:full -define:OPENTK_DLL -unsafe -nowarn:3021,612,618,1635 \
+		-nologo -out:$@ -target:library -debug:full -define:OPENTK_DLL -unsafe -nowarn:3021,612,618,1635 \
 		$(MAC_BOOTSTRAP_DEFINES),COREBUILD \
 		$(XAMMAC) \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) \
@@ -34,7 +34,7 @@ $(MAC_BUILD_DIR)/mobile-32/OpenTK.dll: $(MAC_OPENTK_SOURCES) $(MAC_BUILD_DIR)/mo
 
 $(MAC_BUILD_DIR)/full-32/OpenTK.dll: $(MAC_OPENTK_SOURCES) $(MAC_BUILD_DIR)/full-32/Xamarin.Mac.dll
 	$(call Q_PROF_CSC,mac/$(VARIANT)) $(MAC_full_CSC) \
-		-out:$@ -target:library -debug:full -define:OPENTK_DLL -unsafe -nowarn:3021,612,618,1635 \
+		-nologo -out:$@ -target:library -debug:full -define:OPENTK_DLL -unsafe -nowarn:3021,612,618,1635 \
 		$(MAC_BOOTSTRAP_DEFINES),COREBUILD \
 		-r:System.Drawing.dll $(XAMMAC) \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) \
@@ -43,7 +43,7 @@ $(MAC_BUILD_DIR)/full-32/OpenTK.dll: $(MAC_OPENTK_SOURCES) $(MAC_BUILD_DIR)/full
 $(MAC_BUILD_DIR)/net_4_5/OpenTK.dll: $(MAC_OPENTK_SOURCES) $(MAC_BUILD_DIR)/full-32/Xamarin.Mac.dll
 	@mkdir -p $(MAC_BUILD_DIR)/net_4_5
 	$(call Q_PROF_CSC,mac/$(VARIANT)) $(MAC_full_CSC) \
-		-out:$@ -target:library -debug:full -define:OPENTK_DLL -unsafe -nowarn:3021,612,618,1635 \
+		-nologo -out:$@ -target:library -debug:full -define:OPENTK_DLL -unsafe -nowarn:3021,612,618,1635 \
 		$(MAC_BOOTSTRAP_DEFINES),COREBUILD \
 		 $(XAMMAC) \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) \

--- a/src/Makefile
+++ b/src/Makefile
@@ -108,7 +108,7 @@ define IOS_GENERATOR_template
 # core.dll
 $(IOS_BUILD_DIR)/$(1)/core.dll: $$(IOS_CORE_SOURCES) frameworks.sources
 	@mkdir -p $(IOS_BUILD_DIR)/$(1)
-	$$(call Q_PROF_CSC,ios/$(1)) $$(IOS_CSC) -out:$$@ -target:library -debug -unsafe \
+	$$(call Q_PROF_CSC,ios/$(1)) $$(IOS_CSC) -nologo -out:$$@ -target:library -debug -unsafe \
 		-r:$(IOS_LIBDIR)/Mono.Security.dll \
 		-nowarn:219,618,114,414,1635,3021,$$(IOS_WARNINGS_THAT_YOU_SHOULD_FIX) \
 		-define:COREBUILD $$(IOS_DEFINES) \
@@ -117,7 +117,7 @@ $(IOS_BUILD_DIR)/$(1)/core.dll: $$(IOS_CORE_SOURCES) frameworks.sources
 
 # generator.exe
 $(IOS_BUILD_DIR)/$(1)/generator.exe: $$(GENERATOR_SOURCES) $(IOS_BUILD_DIR)/$(1)/core.dll
-	$$(call Q_PROF_CSC,ios/$(1)) $$(IOS_CSC) -out:$$@ -debug -unsafe \
+	$$(call Q_PROF_CSC,ios/$(1)) $$(IOS_CSC) -nologo -out:$$@ -debug -unsafe \
 		-r:$(IOS_BUILD_DIR)/$(1)/core.dll \
 		$$(GENERATOR_DEFINES)             \
 		$$(GENERATOR_SOURCES)
@@ -133,7 +133,7 @@ $(IOS_BUILD_DIR)/$(1)/generated_sources: $$(IOS_$(1)_GENERATOR) $$(IOS_APIS) $(I
 		-core \
 		-sourceonly=$$@ \
 		-compiler=$$(IOS_CSC) \
-		-nostdlib -noconfig \
+		-nologo -nostdlib -noconfig \
 		-no-mono-path \
 		-tmpdir=$(IOS_BUILD_DIR)/$(1) \
 		-baselib=$(IOS_BUILD_DIR)/$(1)/core.dll \
@@ -153,7 +153,7 @@ IOS_VARIANTS_TARGETS += $(IOS_BUILD_DIR)/$(1)/$(3)
 # Xamarin.iOS.dll
 $(IOS_BUILD_DIR)/$(1)/$(3): $$(IOS_SOURCES) $(IOS_BUILD_DIR)/$(4)/generated_sources $(PRODUCT_KEY_PATH)
 	@mkdir -p $(IOS_BUILD_DIR)/$(1)
-	$$(call Q_PROF_CSC,ios/$(1)) $$(IOS_CSC) -out:$$@ -target:library -debug -unsafe -optimize \
+	$$(call Q_PROF_CSC,ios/$(1)) $$(IOS_CSC) -nologo -out:$$@ -target:library -debug -unsafe -optimize \
 		-r:$(IOS_LIBDIR)/Mono.Security.dll \
 		$$(ARGS_$(6)) \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) $$(IOS_DEFINES) \
@@ -180,14 +180,14 @@ IOS_VARIANTS_TARGETS += $(addprefix $(IOS_BUILD_DIR)/$(1)/,$(4) $(5))
 
 # MonoTouch.Dialog-1
 $(IOS_BUILD_DIR)/$(1)%$(4) $(IOS_BUILD_DIR)/$(1)%$(4:.dll=.pdb): $$(IOS_SOURCES) $(IOS_BUILD_DIR)/$(1)/$(3) $$(MONOTOUCH_DIALOG_SOURCES) $(PRODUCT_KEY_PATH) $(IOS_BUILD_DIR)/reference/Xamarin.iOS.dll
-	$$(call Q_PROF_CSC,ios/$(1)) $$(IOS_CSC) -out:$$(basename $$@).dll -target:library -debug:portable -optimize -publicsign \
+	$$(call Q_PROF_CSC,ios/$(1)) $$(IOS_CSC) -nologo -out:$$(basename $$@).dll -target:library -debug:portable -optimize -publicsign \
 		-keyfile:$(PRODUCT_KEY_PATH) -r:$(IOS_BUILD_DIR)/$(1)/$(3) $(6) -r:$(MONOTOUCH_MONO_PATH)/System.Core.dll -r:$(MONOTOUCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_MONO_PATH)/System.Json.dll \
 		-nowarn:219,618,114,414,1635,3021,$$(IOS_WARNINGS_THAT_YOU_SHOULD_FIX) \
 		$$(MONOTOUCH_DIALOG_SOURCES) $$(MONOTOUCH_DIALOG_RESOURCES)
 
 # MonoTouch.NUnitLite
 $(IOS_BUILD_DIR)/$(1)%$(5) $(IOS_BUILD_DIR)/$(1)%$(5:.dll=.pdb): $$(IOS_TOUCHUNIT_SOURCES) $(IOS_BUILD_DIR)/$(1)/$(4) $(PRODUCT_KEY_PATH) $(IOS_BUILD_DIR)/reference/Xamarin.iOS.dll
-	$$(call Q_PROF_CSC,ios/$(1)) $$(IOS_CSC) -out:$$(basename $$@).dll -target:library -debug:portable -optimize -publicsign \
+	$$(call Q_PROF_CSC,ios/$(1)) $$(IOS_CSC) -nologo -out:$$(basename $$@).dll -target:library -debug:portable -optimize -publicsign \
 		-keyfile:$(PRODUCT_KEY_PATH) -r:$(IOS_BUILD_DIR)/$(1)/$(3) $(6) -r:$(IOS_BUILD_DIR)/$(1)/$(4) -r:$(MONOTOUCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_MONO_PATH)/System.Xml.dll \
 		-nowarn:3006,612,649,414,1635 \
 		-define:NUNITLITE,CLR_4_0,NET_4_5,__MOBILE__ $$(IOS_DEFINES) \
@@ -196,7 +196,7 @@ $(IOS_BUILD_DIR)/$(1)%$(5) $(IOS_BUILD_DIR)/$(1)%$(5:.dll=.pdb): $$(IOS_TOUCHUNI
 # System.Drawing
 # not installed or shipped yet - must be compiled manually using "make System.Drawing.dll"
 $(IOS_BUILD_DIR)/$(1)/System.Drawing.dll: $$(IOS_SYSTEM_DRAWING_SOURCES) monotouch.dll $(PRODUCT_KEY_PATH)
-	$$(call Q_PROF_CSC,ios/$(1)) $$(IOS_CSC) -out:$$@ -target:library -debug:portable -optimize -publicsign \
+	$$(call Q_PROF_CSC,ios/$(1)) $$(IOS_CSC) -nologo -out:$$@ -target:library -debug:portable -optimize -publicsign \
 		-keyfile:$(PRODUCT_KEY_PATH) -r:$(IOS_BUILD_DIR)/$(1)/$(3) $(6) \
 		-nowarn:114,169,414,1635 $$(IOS_DEFINES) \
 		$$(IOS_SYSTEM_DRAWING_SOURCES)
@@ -488,14 +488,14 @@ define MAC_GENERATOR_template
 $(MAC_BUILD_DIR)/$(1)/core.dll: $(MAC_CORE_SOURCES) frameworks.sources
 	@mkdir -p $(MAC_BUILD_DIR)/$(1)
 	$$(call Q_PROF_CSC,mac/$(1)) \
-		$$(MAC_$(1)_CSC) -out:$$@ -target:library -debug -unsafe -nowarn:3021,612,618,1635 \
+		$$(MAC_$(1)_CSC) -nologo -out:$$@ -target:library -debug -unsafe -nowarn:3021,612,618,1635 \
 		$$(MAC_BOOTSTRAP_DEFINES) \
 		$(3) \
 		$$(MAC_CORE_SOURCES)
 
 $(MAC_BUILD_DIR)/$(1)/_bmac.exe: $(MAC_BUILD_DIR)/$(1)/core.dll $(MAC_APIS) $(GENERATOR_SOURCES)
 	$$(call Q_PROF_CSC,mac/$(1)) \
-		$$(MAC_$(1)_CSC) -out:$$@ -debug -unsafe \
+		$$(MAC_$(1)_CSC) -nologo -out:$$@ -debug -unsafe \
 		$(GENERATOR_DEFINES) \
 		-r:$$(@D)/core.dll \
 		$(GENERATOR_SOURCES)
@@ -504,6 +504,7 @@ $(MAC_BUILD_DIR)/$(1)/generated-sources: $$(MAC_$(1)_GENERATOR) $(MAC_APIS) $(MA
 	$$(call Q_PROF_GEN,mac/$(1)) $$(MAC_$(1)_GENERATE) \
 		$(MAC_GENERATED_DEFINES) \
 		-compiler:$$(MAC_$(1)_CSC) \
+		-nologo \
 		-process-enums \
 		-warnaserror:$(MAC_GENERATOR_WARNASERROR) \
 		-native-exception-marshalling \
@@ -526,7 +527,7 @@ define MAC_TARGETS_template
 $(MAC_BUILD_DIR)/$(1)/$(2): $(MAC_BUILD_DIR)/$(3)/generated-sources $(MAC_SOURCES) $(MAC_CFNETWORK_SOURCES) $(MAC_CLASSIC_SOURCES) $(SN_KEY)
 	@mkdir -p $(MAC_BUILD_DIR)/$(1)
 	$$(call Q_PROF_CSC,mac/$(1)) \
-		$$(MAC_$(3)_CSC) -out:$$@ -target:library -debug -unsafe \
+		$$(MAC_$(3)_CSC) -nologo -out:$$@ -target:library -debug -unsafe \
 		$$(MAC_COMMON_DEFINES),OBJECT_REF_TRACKING \
 		-r:Mono.Security.dll \
 		$$(MAC_$(3)_ARGS) \
@@ -763,7 +764,7 @@ $(WATCH_BUILD_DIR)/AssemblyInfo.cs: $(TOP)/src/AssemblyInfo.cs.in $(TOP)/Make.co
 
 $(WATCH_BUILD_DIR)/watch/core.dll: $(WATCHOS_CORE_SOURCES) frameworks.sources | $(WATCH_BUILD_DIR)/watch
 	@mkdir -p $(WATCH_BUILD_DIR)/watch
-	$(call Q_PROF_CSC,watch) $(WATCH_CSC) -out:$@ -target:library -debug -unsafe \
+	$(call Q_PROF_CSC,watch) $(WATCH_CSC) -nologo -out:$@ -target:library -debug -unsafe \
 		-nowarn:219,618,114,414,1635,3021,$(IOS_WARNINGS_THAT_YOU_SHOULD_FIX) \
 		-define:COREBUILD    \
 		$(WATCH_DEFINES)     \
@@ -771,7 +772,7 @@ $(WATCH_BUILD_DIR)/watch/core.dll: $(WATCHOS_CORE_SOURCES) frameworks.sources | 
 
 # generator.exe
 $(WATCH_BUILD_DIR)/watch/generator.exe: $(GENERATOR_SOURCES) $(WATCH_BUILD_DIR)/watch/core.dll
-	$(call Q_PROF_CSC,watch) $(WATCH_CSC) -out:$@ -debug -unsafe \
+	$(call Q_PROF_CSC,watch) $(WATCH_CSC) -nologo -out:$@ -debug -unsafe \
 		-r:$(WATCH_BUILD_DIR)/watch/core.dll \
 		$(GENERATOR_SOURCES)                  \
 		$(WATCH_DEFINES)     \
@@ -786,7 +787,7 @@ $(WATCH_BUILD_DIR)/watch/generated_sources: $(WATCH_GENERATOR) $(WATCHOS_APIS) $
 		-core                                                    \
 		-sourceonly=$@                                           \
 		-compiler=$(WATCH_CSC) \
-		-nostdlib -noconfig                                      \
+		-nologo -nostdlib -noconfig                              \
 		-no-mono-path                                            \
 		-tmpdir=$(WATCH_BUILD_DIR)/watch                         \
 		-baselib=$(WATCH_BUILD_DIR)/watch/core.dll               \
@@ -800,7 +801,7 @@ $(WATCH_BUILD_DIR)/watch/generated_sources: $(WATCH_GENERATOR) $(WATCHOS_APIS) $
 		--target-framework=Xamarin.WatchOS,v1.0                     \
 
 $(WATCH_BUILD_DIR)/watch-32/Xamarin.WatchOS.dll: $(WATCHOS_SOURCES) $(WATCH_BUILD_DIR)/watch/generated_sources $(PRODUCT_KEY_PATH) | $(WATCH_BUILD_DIR)/watch-32
-	$(call Q_PROF_CSC,watch) $(WATCH_CSC) -out:$@ -target:library -debug -unsafe -optimize \
+	$(call Q_PROF_CSC,watch) $(WATCH_CSC) -nologo -out:$@ -target:library -debug -unsafe -optimize \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) $(WATCH_DEFINES) \
 		$(ARGS_32) \
 		-nowarn:219,618,114,414,1635,3021,$(IOS_WARNINGS_THAT_YOU_SHOULD_FIX) \
@@ -821,7 +822,7 @@ $(WATCH_BUILD_DIR)/reference/Xamarin.WatchOS.pdb: $(WATCH_BUILD_DIR)/watch-32/Xa
 
 # MonoTouch.NUnitLite
 $(WATCH_BUILD_DIR)/reference/MonoTouch.NUnitLite.dll: $(WATCHOS_TOUCHUNIT_SOURCES) $(PRODUCT_KEY_PATH) $(WATCH_BUILD_DIR)/reference/Xamarin.WatchOS.dll
-	$(call Q_PROF_CSC,watch) $(SYSTEM_CSC) -out:$@ -target:library -debug:portable -optimize -publicsign -noconfig -nostdlib \
+	$(call Q_PROF_CSC,watch) $(SYSTEM_CSC) -nologo -out:$@ -target:library -debug:portable -optimize -publicsign -noconfig -nostdlib \
 		-keyfile:$(PRODUCT_KEY_PATH) -r:$(WATCH_BUILD_DIR)/reference/Xamarin.WatchOS.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/mscorlib.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/System.Xml.dll \
 		-nowarn:3006,612,649,414,1635 \
 		-define:NUNITLITE,CLR_4_0,NET_4_5,__MOBILE__ $(WATCH_DEFINES) \
@@ -984,7 +985,7 @@ $(TVOS_BUILD_DIR)/AssemblyInfo.cs: $(TOP)/src/AssemblyInfo.cs.in $(TOP)/Make.con
 
 $(TVOS_BUILD_DIR)/tvos/core.dll: $(TVOS_CORE_SOURCES) frameworks.sources Makefile | $(TVOS_BUILD_DIR)/tvos
 	@mkdir -p $(TVOS_BUILD_DIR)/tvos
-	$(call Q_PROF_CSC,tvos) $(TV_CSC) -out:$@ -target:library -debug -unsafe \
+	$(call Q_PROF_CSC,tvos) $(TV_CSC) -nologo -out:$@ -target:library -debug -unsafe \
 		-nowarn:219,618,114,414,1635,3021,$(IOS_WARNINGS_THAT_YOU_SHOULD_FIX) \
 		-define:COREBUILD    \
 		$(TVOS_DEFINES)     \
@@ -992,7 +993,7 @@ $(TVOS_BUILD_DIR)/tvos/core.dll: $(TVOS_CORE_SOURCES) frameworks.sources Makefil
 
 # generator.exe
 $(TVOS_BUILD_DIR)/tvos/generator.exe: $(GENERATOR_SOURCES) $(TVOS_BUILD_DIR)/tvos/core.dll
-	$(call Q_PROF_CSC,tvos) $(TV_CSC) --keep -out:$@ -debug -unsafe \
+	$(call Q_PROF_CSC,tvos) $(TV_CSC) -nologo --keep -out:$@ -debug -unsafe \
 		-r:$(TVOS_BUILD_DIR)/tvos/core.dll \
 		$(GENERATOR_SOURCES)                  \
 		$(GENERATOR_DEFINES)                  \
@@ -1006,7 +1007,7 @@ $(TVOS_BUILD_DIR)/tvos/generated_sources: $(TVOS_GENERATOR) $(TVOS_APIS) $(TVOS_
 		-core                                                    \
 		-sourceonly=$@                                           \
 		-compiler=$(TV_CSC) \
-		-nostdlib -noconfig                                      \
+		-nologo -nostdlib -noconfig                              \
 		-no-mono-path                                            \
 		-tmpdir=$(TVOS_BUILD_DIR)/tvos                         \
 		-baselib=$(TVOS_BUILD_DIR)/tvos/core.dll               \
@@ -1020,7 +1021,7 @@ $(TVOS_BUILD_DIR)/tvos/generated_sources: $(TVOS_GENERATOR) $(TVOS_APIS) $(TVOS_
 		--target-framework=Xamarin.TVOS,v1.0                     \
 
 $(TVOS_BUILD_DIR)/tvos-64/Xamarin.TVOS.dll: $(TVOS_SOURCES) $(TVOS_BUILD_DIR)/tvos/generated_sources $(PRODUCT_KEY_PATH) | $(TVOS_BUILD_DIR)/tvos-64
-	$(call Q_PROF_CSC,tvos) $(TV_CSC) -out:$@ -target:library -debug -unsafe -optimize \
+	$(call Q_PROF_CSC,tvos) $(TV_CSC) -nologo -out:$@ -target:library -debug -unsafe -optimize \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) $(TVOS_DEFINES) \
 		-r:$(TVOS_LIBDIR)/Mono.Security.dll \
 		$(ARGS_64) \
@@ -1041,7 +1042,7 @@ $(TVOS_BUILD_DIR)/reference/Xamarin.TVOS.pdb: $(TVOS_BUILD_DIR)/tvos-64/Xamarin.
 
 # MonoTouch.NUnitLite
 $(TVOS_BUILD_DIR)/reference/MonoTouch.NUnitLite%dll $(TVOS_BUILD_DIR)/reference/MonoTouch.NUnitLite%pdb: $(TVOS_TOUCHUNIT_SOURCES) $(PRODUCT_KEY_PATH) $(TVOS_BUILD_DIR)/reference/Xamarin.TVOS.dll $(TVOS_BUILD_DIR)/reference/MonoTouch.Dialog-1.dll
-	$(call Q_PROF_CSC,tvos) $(SYSTEM_CSC) -r:$(MONOTOUCH_TV_MONO_PATH)/mscorlib.dll -out:$(basename $@).dll -target:library -debug:portable -optimize -noconfig -nostdlib -publicsign \
+	$(call Q_PROF_CSC,tvos) $(SYSTEM_CSC) -nologo -r:$(MONOTOUCH_TV_MONO_PATH)/mscorlib.dll -out:$(basename $@).dll -target:library -debug:portable -optimize -noconfig -nostdlib -publicsign \
 		-keyfile:$(PRODUCT_KEY_PATH) -r:$(TVOS_BUILD_DIR)/reference/Xamarin.TVOS.dll -r:$(TVOS_BUILD_DIR)/reference/MonoTouch.Dialog-1.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Xml.dll \
 		-nowarn:3006,612,649,414,1635 \
 		-define:NUNITLITE,CLR_4_0,NET_4_5,__MOBILE__ $(TVOS_DEFINES) \
@@ -1052,7 +1053,7 @@ $(TVOS_BUILD_DIR)/%.pdb: $(TVOS_BUILD_DIR)/%.dll
 	@touch $@
 
 $(TVOS_BUILD_DIR)/reference/MonoTouch.Dialog-1%dll $(TVOS_BUILD_DIR)/reference/MonoTouch.Dialog-1%pdb: $(TVOS_BUILD_DIR)/reference/Xamarin.TVOS.dll $(TVOS_SOURCES) $(MONOTOUCH_DIALOG_SOURCES) $(PRODUCT_KEY_PATH)
-	$(call Q_PROF_CSC,tvos) $(SYSTEM_CSC) -r:$(MONOTOUCH_TV_MONO_PATH)/mscorlib.dll -out:$(basename $@).dll -target:library -debug:portable -optimize -noconfig -nostdlib -publicsign \
+	$(call Q_PROF_CSC,tvos) $(SYSTEM_CSC) -nologo -r:$(MONOTOUCH_TV_MONO_PATH)/mscorlib.dll -out:$(basename $@).dll -target:library -debug:portable -optimize -noconfig -nostdlib -publicsign \
 		-keyfile:$(PRODUCT_KEY_PATH) -r:$< -r:$(MONOTOUCH_TV_MONO_PATH)/System.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Core.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Json.dll \
 		-define:XAMCORE_2_0 -define:XAMCORE_3_0 -define:TVOS -define:__TVOS__ -define:__UNIFIED__ \
 		-nowarn:219,618,114,414,1635,3021,$(IOS_WARNINGS_THAT_YOU_SHOULD_FIX) \

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -54,7 +54,7 @@ IKVM_REFLECTION_FLAGS = -d:NO_AUTHENTICODE,STATIC,NO_SYMBOL_WRITER
 
 $(BUILD_DIR)/common/bgen.exe: $(GENERATOR_SOURCES) $(IKVM_REFLECTION_SOURCES) $(GENERATOR_ATTRIBUTE_SOURCES) Makefile.generator
 	$(Q) mkdir -p $(BUILD_DIR)/common
-	$(Q_GEN) $(SYSTEM_CSC) -debug:portable -out:$@ $(IKVM_REFLECTION_FLAGS) $(GENERATOR_DEFINES) $(IKVM_REFLECTION_SOURCES) $(GENERATOR_ATTRIBUTE_SOURCES) $(GENERATOR_SOURCES)
+	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug:portable -out:$@ $(IKVM_REFLECTION_FLAGS) $(GENERATOR_DEFINES) $(IKVM_REFLECTION_SOURCES) $(GENERATOR_ATTRIBUTE_SOURCES) $(GENERATOR_SOURCES)
 
 # The command-line arguments in the csproj are currently kept up-to-date manually
 generator.csproj: generator-ikvm.csproj.in Makefile.generator
@@ -62,9 +62,9 @@ generator.csproj: generator-ikvm.csproj.in Makefile.generator
 		-e 's^<!--%IKVM_FILES%-->^$(foreach file,$(subst /,\\,$(IKVM_REFLECTION_SOURCES)),<Compile Include="$(file)"><Link>ikvm\\$(notdir $(subst \\,/,$(file)))</Link></Compile>)^' \
 		-e 's^<!--%FILES%-->^$(foreach file,$(subst /,\\,$(GENERATOR_SOURCES) $(GENERATOR_ATTRIBUTE_SOURCES)),<Compile Include="$(file)"/>)^' \
 		-e 's^%WORKING_DIR%^$(CURDIR)^' \
-		-e 's^%IOS_UNIFIED_ARGS%^$(IOS_GENERATOR_FLAGS) -core -sourceonly=$(IOS_BUILD_DIR)/native/generated_sources -compiler=$(IOS_CSC) -nostdlib -noconfig -no-mono-path -tmpdir=$(IOS_BUILD_DIR)/native -d:XAMCORE_2_0 -baselib=$(IOS_BUILD_DIR)/native/core.dll -r=$(MONO_PATH)/mcs/class/lib/monotouch/System.dll -ns=ObjCRuntime -native-exception-marshalling --ns=ObjCRuntime $(xi_native_profile) $(IOS_APIS) --target-framework=Xamarin.iOS,v1.0^' \
-		-e 's^%TVOS_ARGS%^-inline-selectors -process-enums -warnaserror:$(TVOS_GENERATOR_WARNASERROR) -core -sourceonly=$(TVOS_BUILD_DIR)/tvos/generated_sources -compiler=$(IOS_CSC) -nostdlib -noconfig -no-mono-path -tmpdir=$(TVOS_BUILD_DIR)/tvos -baselib=$(TVOS_BUILD_DIR)/tvos/core.dll -r=$(MONO_PATH)/mcs/class/lib/monotouch_tv/System.dll -ns=ObjCRuntime -native-exception-marshalling -d:TVOS -d:XAMCORE_2_0 -d:XAMCORE_3_0 --ns:ObjCRuntime $(TVOS_APIS) --target-framework=Xamarin.TVOS,v1.0^' \
-		-e 's^%WATCHOS_ARGS%^-inline-selectors -process-enums -warnaserror:$(WATCH_GENERATOR_WARNASERROR) -core -sourceonly=$(WATCH_BUILD_DIR)/watch/generated_sources -compiler=$(IOS_CSC) -nostdlib -noconfig -no-mono-path -tmpdir=$(WATCH_BUILD_DIR)/watch -baselib=$(WATCH_BUILD_DIR)/watch/core.dll -r=$(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/System.dll -ns=ObjCRuntime -native-exception-marshalling -d:WATCH -d:XAMCORE_2_0 -d:XAMCORE_3_0 --ns:ObjCRuntime $(WATCHOS_APIS) --target-framework=Xamarin.WatchOS,v1.0^' \
+		-e 's^%IOS_UNIFIED_ARGS%^$(IOS_GENERATOR_FLAGS) -core -sourceonly=$(IOS_BUILD_DIR)/native/generated_sources -compiler=$(IOS_CSC) -nologo -nostdlib -noconfig -no-mono-path -tmpdir=$(IOS_BUILD_DIR)/native -d:XAMCORE_2_0 -baselib=$(IOS_BUILD_DIR)/native/core.dll -r=$(MONO_PATH)/mcs/class/lib/monotouch/System.dll -ns=ObjCRuntime -native-exception-marshalling --ns=ObjCRuntime $(xi_native_profile) $(IOS_APIS) --target-framework=Xamarin.iOS,v1.0^' \
+		-e 's^%TVOS_ARGS%^-inline-selectors -process-enums -warnaserror:$(TVOS_GENERATOR_WARNASERROR) -core -sourceonly=$(TVOS_BUILD_DIR)/tvos/generated_sources -compiler=$(IOS_CSC) -nologo -nostdlib -noconfig -no-mono-path -tmpdir=$(TVOS_BUILD_DIR)/tvos -baselib=$(TVOS_BUILD_DIR)/tvos/core.dll -r=$(MONO_PATH)/mcs/class/lib/monotouch_tv/System.dll -ns=ObjCRuntime -native-exception-marshalling -d:TVOS -d:XAMCORE_2_0 -d:XAMCORE_3_0 --ns:ObjCRuntime $(TVOS_APIS) --target-framework=Xamarin.TVOS,v1.0^' \
+		-e 's^%WATCHOS_ARGS%^-inline-selectors -process-enums -warnaserror:$(WATCH_GENERATOR_WARNASERROR) -core -sourceonly=$(WATCH_BUILD_DIR)/watch/generated_sources -compiler=$(IOS_CSC) -nologo -nostdlib -noconfig -no-mono-path -tmpdir=$(WATCH_BUILD_DIR)/watch -baselib=$(WATCH_BUILD_DIR)/watch/core.dll -r=$(WATCH_MONO_PATH)/mcs/class/lib/monotouch_watch/System.dll -ns=ObjCRuntime -native-exception-marshalling -d:WATCH -d:XAMCORE_2_0 -d:XAMCORE_3_0 --ns:ObjCRuntime $(WATCHOS_APIS) --target-framework=Xamarin.WatchOS,v1.0^' \
 		-e 's^%MAC_FULL_ARGS%^-d:MONOMAC -d:XAMARIN_MAC -d:XAMCORE_2_0 -compiler:$(MAC_BUILD_DIR)/full/pmcs -process-enums -warnaserror:$(MAC_GENERATOR_WARNASERROR) -native-exception-marshalling -core -sourceonly:$(MAC_BUILD_DIR)/full/generated-sources -tmpdir:$(MAC_BUILD_DIR)/full -baselib:$(MAC_BUILD_DIR)/full/core.dll -d:NO_SYSTEM_DRAWING --ns=ObjCRuntime $(xm_full_profile) $(MAC_APIS)^' \
 		-e 's^%MAC_MOBILE_ARGS%^-d:MONOMAC -d:XAMARIN_MAC -d:XAMCORE_2_0 -compiler:$(MAC_BUILD_DIR)/mobile/pmcs -process-enums -warnaserror:$(MAC_GENERATOR_WARNASERROR) -native-exception-marshalling -core -sourceonly:$(MAC_BUILD_DIR)/mobile/generated-sources -tmpdir:$(MAC_BUILD_DIR)/mobile -baselib:$(MAC_BUILD_DIR)/mobile/core.dll -d:NO_SYSTEM_DRAWING --ns=ObjCRuntime $(SHARED_SYSTEM_DRAWING_SOURCES) $(xm_mobile_profile) $(MAC_APIS)^' \
 		-e 's^%MD_MTOUCH_SDK_ROOT%^$(MD_MTOUCH_SDK_ROOT)^' \
@@ -122,11 +122,11 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bgen/bgen.exe: $(BUILD_DIR)/common/bgen.ex
 
 $(IOS_BUILD_DIR)/native/Xamarin.iOS.BindingAttributes.dll: generator-attributes.cs Makefile.generator
 	$(Q) mkdir -p $(dir $@)
-	$(Q_GEN) $(SYSTEM_CSC) -out:$@ -debug generator-attributes.cs -target:library
+	$(Q_GEN) $(SYSTEM_CSC) -nologo -out:$@ -debug generator-attributes.cs -target:library
 
 $(IOS_BUILD_DIR)/native/monotouch.BindingAttributes.dll: generator-attributes.cs Makefile.generator
 	$(Q) mkdir -p $(dir $@)
-	$(Q_GEN) $(SYSTEM_CSC) -debug -out:$@ -debug generator-attributes.cs -target:library
+	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug -out:$@ -debug generator-attributes.cs -target:library
 
 #
 # Xamarin.Watch (bwatch)
@@ -151,7 +151,7 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bgen/%.dll: $(WATCH_BUILD_DIR)/%.dll | $(I
 
 $(WATCH_BUILD_DIR)/Xamarin.WatchOS.BindingAttributes.dll: generator-attributes.cs Makefile.generator
 	$(Q) mkdir -p $(dir $@)
-	$(Q_GEN) $(SYSTEM_CSC) -debug -out:$@ -debug generator-attributes.cs -target:library
+	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug -out:$@ -debug generator-attributes.cs -target:library
 
 # #
 # # Xamarin.TVOS (btv)
@@ -176,7 +176,7 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bgen/%.dll: $(TVOS_BUILD_DIR)/%.dll | $(IO
 
 $(TVOS_BUILD_DIR)/Xamarin.TVOS.BindingAttributes.dll: generator-attributes.cs Makefile.generator
 	$(Q) mkdir -p $(dir $@)
-	$(Q_GEN) $(SYSTEM_CSC) -debug -out:$@ -debug generator-attributes.cs -target:library
+	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug -out:$@ -debug generator-attributes.cs -target:library
 
 #
 # Xamarin.Mac (bmac)
@@ -229,7 +229,7 @@ $(MAC_BUILD_DIR)/XamMac.BindingAttributes.dll: $(MACIOS_BINARIES_PATH)/XamMac.Bi
 
 $(MAC_BUILD_DIR)/Xamarin.Mac-%.BindingAttributes.dll: generator-attributes.cs Makefile.generator
 	$(Q) mkdir -p $(dir $@)
-	$(Q_GEN) $(SYSTEM_CSC) -debug -out:$@ -debug generator-attributes.cs -target:library
+	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug -out:$@ -debug generator-attributes.cs -target:library
 
 bgen:	\
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/bgen                     \

--- a/src/OpenGLES/Makefile-1.0.include
+++ b/src/OpenGLES/Makefile-1.0.include
@@ -34,12 +34,12 @@ OPENTK_1_0_CSC_FLAGS = -warn:0 -unsafe -target:library -noconfig -publicsign -de
 # Xamarin.iOS
 
 $(IOS_BUILD_DIR)/reference/OpenTK-1.0%dll $(IOS_BUILD_DIR)/reference/OpenTK-1.0%pdb: $(IOS_BUILD_DIR)/reference/Xamarin.iOS.dll $(OPENTK_1_0_DEPENDENCIES) $(IOS_BUILD_DIR)/reference/OpenTK-1.0.dll.config
-	$(call Q_PROF_CSC,ios/unified) $(IOS_CSC) -r:$(MONOTOUCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_MONO_PATH)/System.Xml.dll $(OPENTK_1_0_CSC_FLAGS) -out:$(basename $@).dll -r:$< -D:XAMCORE_2_0
+	$(call Q_PROF_CSC,ios/unified) $(IOS_CSC) -nologo -r:$(MONOTOUCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_MONO_PATH)/System.Xml.dll $(OPENTK_1_0_CSC_FLAGS) -out:$(basename $@).dll -r:$< -D:XAMCORE_2_0
 
 # Xamarin.TVOS
 
 $(TVOS_BUILD_DIR)/reference/OpenTK-1.0%dll $(TVOS_BUILD_DIR)/reference/OpenTK-1.0%pdb: $(TVOS_BUILD_DIR)/reference/Xamarin.TVOS.dll $(OPENTK_1_0_DEPENDENCIES) $(TVOS_BUILD_DIR)/reference/OpenTK-1.0.dll.config
-	$(call Q_PROF_CSC,tvos) $(SYSTEM_CSC)     $(OPENTK_1_0_CSC_FLAGS) -r:$(TVOS_LIBDIR)/System.dll -r:$(TVOS_LIBDIR)/System.Xml.dll -out:$(basename $@).dll -r:$< -D:XAMCORE_2_0 -D:XAMCORE_3_0 -D:TVOS
+	$(call Q_PROF_CSC,tvos) $(SYSTEM_CSC) -nologo $(OPENTK_1_0_CSC_FLAGS) -r:$(TVOS_LIBDIR)/System.dll -r:$(TVOS_LIBDIR)/System.Xml.dll -out:$(basename $@).dll -r:$< -D:XAMCORE_2_0 -D:XAMCORE_3_0 -D:TVOS
 
 # common targets
 
@@ -56,7 +56,7 @@ HEADERTOXML_SOURCES_1_0=   \
 	$(OPENTK_PATH)/Source/Converter/Parser.cs
 
 HeaderToXml-1.0.exe: Makefile $(HEADERTOXML_SOURCES_1_0)
-	$(Q_CSC) $(SYSTEM_CSC) -warn:0 -d:IPHONE -d:MOBILE -debug:portable -out:$@ $(HEADERTOXML_SOURCES_1_0) -r:System.Xml.Linq
+	$(Q_CSC) $(SYSTEM_CSC) -nologo -warn:0 -d:IPHONE -d:MOBILE -debug:portable -out:$@ $(HEADERTOXML_SOURCES_1_0) -r:System.Xml.Linq
 
 BIND_SOURCES_1_0=  \
 	$(OPENTK_PATH)/Source/Bind/CppSpecWriter.cs                               \
@@ -87,7 +87,7 @@ BIND_SOURCES_1_0=  \
 	$(OPENTK_PATH)/Source/Bind/Utilities.cs
 
 Bind-1.0.exe: Makefile $(BIND_SOURCES_1_0)
-	$(Q_CSC) $(SYSTEM_CSC) -warn:0 -d:IPHONE -d:MOBILE -debug:portable -out:$@ $(BIND_SOURCES_1_0) -codepage:65001
+	$(Q_CSC) $(SYSTEM_CSC) -nologo -warn:0 -d:IPHONE -d:MOBILE -debug:portable -out:$@ $(BIND_SOURCES_1_0) -codepage:65001
 
 IPHONE_GLES_HEADERS_1_0 = /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS$(IOS_SDK_VERSION).sdk/System/Library/Frameworks/OpenGLES.framework/Headers
 IPHONE_SPECS_1_0        = $(OPENTK_PATH)/Source/Bind/Specifications

--- a/src/OpenGLES/Makefile.include
+++ b/src/OpenGLES/Makefile.include
@@ -1,5 +1,5 @@
 $(IOS_BUILD_DIR)/compat/OpenTK.dll: Makefile OpenGLES/Makefile.include $(shell cat OpenTK.dll.sources) $(IOS_BUILD_DIR)/compat/monotouch.dll | $(IOS_BUILD_DIR)/compat
-	$(Q_CSC) $(IOS_CSC) -warn:0 -unsafe -target:library -debug:portable -optimize -publicsign -define:MONOTOUCH -define:IPHONE -d:MINIMAL -out:$@ @./$(@F).sources -r:$(IOS_BUILD_DIR)/compat/monotouch.dll -r:$(MONOTOUCH_MONO_PATH)/System.dll -keyfile:$(PRODUCT_KEY_PATH)
+	$(Q_CSC) $(IOS_CSC) -nologo -warn:0 -unsafe -target:library -debug:portable -optimize -publicsign -define:MONOTOUCH -define:IPHONE -d:MINIMAL -out:$@ @./$(@F).sources -r:$(IOS_BUILD_DIR)/compat/monotouch.dll -r:$(MONOTOUCH_MONO_PATH)/System.dll -keyfile:$(PRODUCT_KEY_PATH)
 	$(Q) touch $@
 
 $(IOS_BUILD_DIR)/compat/OpenTK.pdb: $(IOS_BUILD_DIR)/compat/OpenTK.dll


### PR DESCRIPTION
This commit https://github.com/xamarin/xamarin-macios/pull/3815/commits/7623ca9ec8cfd466460d1feb0f89a64795b32167 removed /nologo from the general SYSTEM_CSC declaration because it was not usable that way in every case where csc was used. This commit removes the spam fest output from src build.

I am not sure if we want to get rid of it this way or if we want a more general fix instead of sprinkling `-nologo` everywhere.