### PR TITLE
Use explicit and accurate targets instead of trial and error.

### DIFF
--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -211,8 +211,12 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/bmac: bmac.ikvm | $(MAC_DESTDIR)$
 
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/%.dll: $(MAC_BUILD_DIR)/%.dll | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen
 	$(Q) install -m 0755 $< $@
-	$(Q) -install -m 0644 $(<:.dll=.pdb) $(@:.dll=.pdb)
-	$(Q) -install -m 0644 $<.mdb $@.mdb
+
+$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/%.pdb: $(MAC_BUILD_DIR)/%.pdb | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen
+	$(Q) install -m 0644 $< $@
+
+$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/%.mdb: $(MAC_BUILD_DIR)/%.mdb | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen
+	$(Q) install -m 0644 $< $@
 
 $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/%.exe: $(BUILD_DIR)/common/bgen.exe | $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen
 	$(Q) install -m 0755 $< $@
@@ -222,10 +226,11 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/bgen/bgen-classic.exe: $(MACIOS_B
 	$(Q) install -m 0755 $< $@
 	$(Q) install -m 0644 $< $(@:.exe=.pdb)
 
-$(MAC_BUILD_DIR)/XamMac.BindingAttributes.dll: $(MACIOS_BINARIES_PATH)/XamMac.BindingAttributes.dll
-	$(Q) mkdir -p $(dir $@)
+$(MAC_BUILD_DIR)/XamMac.BindingAttributes.dll: $(MACIOS_BINARIES_PATH)/XamMac.BindingAttributes.dll | $(MAC_BUILD_DIR)
 	$(Q) cp $< $@
-	$(Q) cp $<.mdb $@.mdb
+
+$(MAC_BUILD_DIR)/XamMac.BindingAttributes.mdb: $(MACIOS_BINARIES_PATH)/XamMac.BindingAttributes.mdb | $(MAC_BUILD_DIR)
+	$(Q) cp $< $@
 
 $(MAC_BUILD_DIR)/Xamarin.Mac-%.BindingAttributes.dll: generator-attributes.cs Makefile.generator
 	$(Q) mkdir -p $(dir $@)


### PR DESCRIPTION
Removes these ignored error messages:

    install: build/mac/Xamarin.Mac-full.BindingAttributes.dll.mdb: No such file or directory
    make: [/work/maccore/xharness/xamarin-macios/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/bgen/Xamarin.Mac-full.BindingAttributes.dll] Error 71 (ignored)
    install: build/mac/XamMac.BindingAttributes.pdb: No such file or directory
    make: [/work/maccore/xharness/xamarin-macios/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/bgen/XamMac.BindingAttributes.dll] Error 71 (ignored)
    install: build/mac/Xamarin.Mac-mobile.BindingAttributes.dll.mdb: No such file or directory
    make: [/work/maccore/xharness/xamarin-macios/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/bgen/Xamarin.Mac-mobile.BindingAttributes.dll] Error 71 (ignored)