### PR TITLE
[ObjCRuntime] Fix a few compiler warnings by using pragmas.

### DIFF
--- a/src/ObjCRuntime/Blocks.cs
+++ b/src/ObjCRuntime/Blocks.cs
@@ -53,8 +53,10 @@ namespace ObjCRuntime {
 #pragma warning restore 649
 
 	struct XamarinBlockDescriptor {
+#pragma warning disable 649 // Field 'XamarinBlockDescriptor.descriptor' is never assigned to, and will always have its default value
 		public BlockDescriptor descriptor;
 		public volatile int ref_count;
+#pragma warning restore 649
 		// followed by variable-length string (the signature)
 	}
 


### PR DESCRIPTION
Fixes:

    ObjCRuntime/Blocks.cs(57,23): warning CS0649: Field 'XamarinBlockDescriptor.ref_count' is never assigned to, and will always have its default value 0
    ObjCRuntime/Blocks.cs(56,26): warning CS0649: Field 'XamarinBlockDescriptor.descriptor' is never assigned to, and will always have its default value
    ObjCRuntime/Blocks.cs(57,23): warning CS0649: Field 'XamarinBlockDescriptor.ref_count' is never assigned to, and will always have its default value 0
    ObjCRuntime/Blocks.cs(56,26): warning CS0649: Field 'XamarinBlockDescriptor.descriptor' is never assigned to, and will always have its default value