### PR TITLE
[tools] Improve error reporting when trying to create API/generator diff for a pull request with conflicts.

### DIFF
--- a/jenkins/compare.sh
+++ b/jenkins/compare.sh
@@ -8,7 +8,15 @@ report_error ()
 trap report_error ERR
 
 cd $WORKSPACE
-./tools/compare-commits.sh --base=origin/pr/$ghprbPullId/merge^1
+
+BASE=origin/pr/$ghprbPullId/merge
+if ! git rev-parse $BASE >/dev/null 2>&1; then
+	echo "Can't compare API and create generator diff because the pull request has conflicts that must be resolved first (the branch '$BASE' doesn't exist)."
+	printf "🔥 [Failed to compare API and create generator diff because the pull request has conflicts that must be resolved first]($BUILD_URL/console) 🔥\\n" >> $WORKSPACE/jenkins/pr-comments.md
+	exit 0
+fi
+
+./tools/compare-commits.sh --base=$BASE^1
 
 mkdir -p jenkins-results/apicomparison
 


### PR DESCRIPTION
We can't create an API/generator diff for a pull request with conflicts, so
detect this scenario and show a better error than this (from #3961):

    Comparing the changes between origin/pr/3961/merge^1 and HEAD:
    fatal: ambiguous argument 'origin/pr/3961/merge^1..HEAD': unknown revision or path not in the working tree.
    Use '--' to separate paths from revisions, like this:
    'git <command> [<revision>...] -- [<file>...]'
    fatal: ambiguous argument 'origin/pr/3961/merge^1': unknown revision or path not in the working tree.
    Use '--' to separate paths from revisions, like this:
    'git <command> [<revision>...] -- [<file>...]'