### PR TITLE
[Foundation] Implement NSUrlProtocolClient properly on macOS. Fixes #3968.

### DIFF
--- a/src/Foundation/NSUrlProtocol.cs
+++ b/src/Foundation/NSUrlProtocol.cs
@@ -26,6 +26,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+using ObjCRuntime;
 
 namespace Foundation {
 	public abstract partial class NSUrlProtocol : NSObject {
@@ -39,6 +41,36 @@ namespace Foundation {
 					MarkDirty ();
 				}
 				return client;
+			}
+		}
+#endif
+#if XAMCORE_2_0 && MONOMAC && !XAMCORE_4_0
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		[Obsolete ("Use the overload that takes an 'INSUrlProtocolClient' instead.")]
+		public NSUrlProtocol (NSUrlRequest request, NSCachedUrlResponse cachedResponse, NSUrlProtocolClient client)
+			: base (NSObjectFlag.Empty)
+		{
+			if (request == null)
+				throw new ArgumentNullException ("request");
+			if (client == null)
+				throw new ArgumentNullException ("client");
+			if (IsDirectBinding) {
+				InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr_IntPtr (this.Handle, selInitWithRequest_CachedResponse_Client_Handle, request.Handle, cachedResponse == null ? IntPtr.Zero : cachedResponse.Handle, client.Handle), "initWithRequest:cachedResponse:client:");
+			} else {
+				InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper_IntPtr_IntPtr_IntPtr (this.SuperHandle, selInitWithRequest_CachedResponse_Client_Handle, request.Handle, cachedResponse == null ? IntPtr.Zero : cachedResponse.Handle, client.Handle), "initWithRequest:cachedResponse:client:");
+			}
+		}
+
+		[Obsolete ("Use 'Client' instead.")]
+		public virtual NSObject WeakClient {
+			get {
+				var client = Client;
+				if (client == null)
+					return null;
+				var nsclient = client as NSObject;
+				if (nsclient != null)
+					return nsclient;
+				return Runtime.GetNSObject (client.Handle);
 			}
 		}
 #endif

--- a/src/Foundation/NSUrlProtocolClient.cs
+++ b/src/Foundation/NSUrlProtocolClient.cs
@@ -31,7 +31,7 @@ using System;
 using ObjCRuntime;
 
 namespace Foundation {
-#if !XAMCORE_2_0 || MONOMAC
+#if !XAMCORE_2_0 || (MONOMAC && !XAMCORE_4_0)
 	public sealed class NSUrlProtocolClient : NSObject
 	{
 		public NSUrlProtocolClient (IntPtr handle)

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -12633,7 +12633,7 @@ namespace Foundation
 	}
 #endif
 
-#if XAMCORE_2_0 && !MONOMAC
+#if XAMCORE_2_0
 	// Users are not supposed to implement the NSUrlProtocolClient protocol, they're 
 	// only supposed to consume it. This is why there's no model for this protocol.
 	[Protocol (Name = "NSURLProtocolClient")]
@@ -12682,13 +12682,13 @@ namespace Foundation
 	interface NSUrlProtocol {
 		[DesignatedInitializer]
 		[Export ("initWithRequest:cachedResponse:client:")]
-#if XAMCORE_2_0 && !MONOMAC
+#if XAMCORE_2_0
 		IntPtr Constructor (NSUrlRequest request, [NullAllowed] NSCachedUrlResponse cachedResponse, INSUrlProtocolClient client);
 #else
 		IntPtr Constructor (NSUrlRequest request, [NullAllowed] NSCachedUrlResponse cachedResponse, NSUrlProtocolClient client);
 #endif
 
-#if XAMCORE_2_0 && !MONOMAC
+#if XAMCORE_2_0
 		[Export ("client")]
 		INSUrlProtocolClient Client { get; }
 #else

--- a/tests/xtro-sharpie/macOS-Foundation.ignore
+++ b/tests/xtro-sharpie/macOS-Foundation.ignore
@@ -181,7 +181,6 @@
 !missing-pinvoke! NSUnionRect is not bound
 !missing-protocol! NSSpellServerDelegate not bound
 !missing-protocol! NSURLHandleClient not bound
-!missing-protocol! NSURLProtocolClient not bound
 !missing-protocol-conformance! NSURL should conform to NSURLHandleClient
 !missing-protocol-member! NSFileManagerDelegate::fileManager:shouldCopyItemAtURL:toURL: not found
 !missing-protocol-member! NSFileManagerDelegate::fileManager:shouldLinkItemAtURL:toURL: not found


### PR DESCRIPTION
This fixes a 3 year old "temporary" workaround: https://github.com/xamarin/maccore/commit/89e981147d47833e6e8eeaeda8a9635044f10e2c

Fixes https://github.com/xamarin/xamarin-macios/issues/3968.