### PR TITLE
[Make.config] Update MIN_OSX_BUILD_VERSION

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -79,7 +79,7 @@ MAX_SHARPIE_VERSION=3.4.99
 MIN_SHARPIE_URL=https://bosstoragemirror.blob.core.windows.net/objective-sharpie/builds/4cde014216e8887375f9793d3a2607529833443b/440/76194/ObjectiveSharpie-3.4.23.pkg
 
 # Minimum OSX versions
-MIN_OSX_BUILD_VERSION=10.12
+MIN_OSX_BUILD_VERSION=10.13
 MIN_OSX_VERSION_FOR_IOS=10.11
 MIN_OSX_VERSION_FOR_MAC=10.11
 


### PR DESCRIPTION
Xcode 9.3 requires a Mac running macOS 10.13.2 or later.