### PR TITLE
Try to solve make hang by changing something.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1170,4 +1170,6 @@ all-local:: $(ALL_TARGETS)
 
 project-files: $(PROJECT_FILES)
 
-.SECONDARY:
+# Using .SECONDARY can cause make to go into an infinite loop.
+# See https://github.com/xamarin/maccore/issues/762.
+#.SECONDARY:


### PR DESCRIPTION
Sometimes the build hangs here:

    [...]
    17:57:27 CSC      [xammac] netstandard.dll
    00:34:01 Build timed out (after 450 minutes). Marking the build as aborted.

Unfortunately I can't reproduce locally, but attaching lldb to `make` on a bot
where this happened, and manually modifying memory to enable debug output,
shows a loop pointing to the MonoTouch.Dialog-1.pdb target (the loop itself is
much bigger, but this is the part that stands out, because the prerequisites
"are being made" when they should have been completed a long time ago):

    [...]
    Considering target file `/Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tools/comparison/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.iOS/MonoTouch.Dialog-1.pdb'.
       Considering target file `../external/macios-binaries/MonoTouch.Dialog-Unified/ios/MonoTouch.Dialog-1.pdb'.
       File `../external/macios-binaries/MonoTouch.Dialog-Unified/ios/MonoTouch.Dialog-1.pdb' was considered already.
      Considering target file `/Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tools/comparison/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.iOS'.
      File `/Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tools/comparison/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.iOS' was considered already.
     Finished prerequisites of target file `/Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tools/comparison/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.iOS/MonoTouch.Dialog-1.pdb'.
    The prerequisites of `/Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tools/comparison/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.iOS/MonoTouch.Dialog-1.pdb' are being made.
    [...]

I can't find anything wrong with the corresponding target, but I believe this
is a bug in make I've seen before, where parallel make ends up confused
somehow. I don't know the exact conditions for make's bug, so I've just
changed the target somewhat to see if that works.

Hopefully fixes https://github.com/xamarin/maccore/issues/762.