### PR TITLE
[apitest] Add 'BusinessChat' to the list of 64-bit only libraries.

### DIFF
--- a/tests/apitest/src/EveryFrameworkSmokeTest.cs
+++ b/tests/apitest/src/EveryFrameworkSmokeTest.cs
@@ -75,6 +75,7 @@ namespace Xamarin.Mac.Tests
 				case "CoreMLLibrary":
 				case "ExternalAccessoryLibrary":
 				case "CoreSpotlightLibrary":
+				case "BusinessChatLibrary":
 					return LoadStatus.Acceptable;
 				}
 			}


### PR DESCRIPTION
Fixes this test failure:

    1) ExpectedLibrariesAreLoaded (Xamarin.Mac.Tests.EveryFrameworkSmokeTests.ExpectedLibrariesAreLoaded)
       BusinessChatLibrary (/System/Library/Frameworks/BusinessChat.framework/BusinessChat) failed to load but this was not expected
      at Xamarin.Mac.Tests.EveryFrameworkSmokeTests.ExpectedLibrariesAreLoaded () [0x000c5] in /Users/builder/jenkins/workspace/e-O5J4GUQCDF/xamarin-macios/tests/apitest/src/EveryFrameworkSmokeTest.cs:101
      at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
      at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00032] in /Library/Frameworks/Xamarin.Mac.framework/Versions/4.5.0.373/src/Xamarin.Mac/mcs/class/corlib/System.Reflection/MonoMethod.cs:305