### PR TITLE
[msbuild/mac] Skip reference assemblies passed to mmp

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -479,6 +479,11 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		Inputs="$(TargetDir)$(TargetFileName)"
 		Outputs="$(_AppBundlePath)Contents\MacOS\$(_AppBundleName)">
 		<ItemGroup>
+			<!-- Skip the reference assemblies. 'mmp' will fail to AOT them if passed '--aot:all'. Similar to: https://github.com/xamarin/xamarin-macios/issues/3199 -->
+			<!-- Remove exact references, such as if a package had a framework reference to 'System' that we already have -->
+			<!-- This is exactly what "Microsoft.NuGet.Build.Tasks"'s 'ResolveNuGetPackageAssets' target is doing -->
+			<!-- Effectively 'ResolveNuGetPackageAssets' computes the NuGet packages using their json asset file, adds the full assemblies to 'ReferenceCopyLocalPaths' and outputs the resolved references via '_ReferencesFromNuGetPackages' -->
+			<ReferencePath Remove="@(_ReferencesFromNuGetPackages)" />
 			<ReferenceCopyLocalAssemblyPaths Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll'" />
 		</ItemGroup>
 		<Mmp


### PR DESCRIPTION
- Similar to issue #3199: Could not AOT the assembly System.Runtime.CompilerServices.Unsafe.dll (MT3001)
  (https://github.com/xamarin/xamarin-macios/issues/3199)
- Test case: https://www.dropbox.com/s/49jxl8iftmlymes/Issue3199Test3.zip?dl=0

Problem
=======

Given a Nuget Package added via the "package reference" mechanism and the said package having netstandard `lib` **and** `ref` folders;
`mmp`, if given `--aot:all` was getting reference assemblies and couldn't AOT them as those assemblies are only facades.

Solution
========

Skipping the assemblies that have `/ref/` in their path seems like the simplest and yet most functional solution to the problem.

As it turn out, there is some logic already in place that copies the `lib` assemblies to the destination folder. It seems equivalent to marking them as "Local Copy".
What this does is that it makes those assemblies available to msbuild via `@(ReferenceCopyLocalPaths)`. This gives us the opportunity to safely remove the `ref` assemblies from `@(ReferencePath)`.

*Note: `mmp` is getting the assemblies to reference via a combination of `@(ReferencePath)` and `@(ReferenceCopyLocalPaths)`.*