### PR TITLE
Don't use .SECONDARY in makefile to work around maccore issue #762.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1170,4 +1170,6 @@ all-local:: $(ALL_TARGETS)
 
 project-files: $(PROJECT_FILES)
 
-.SECONDARY:
+# Using .SECONDARY can cause make to go into an infinite loop.
+# See https://github.com/xamarin/maccore/issues/762.
+#.SECONDARY:


### PR DESCRIPTION
This exquisite fix was implemented by the true and trusted method of trial-
and-error: I changed random stuff until things started working again.

I was also able to determine a few alternative solutions:

* Don't use parallel make (this is obviously not a viable solution).
* Use a newer make (than the 12-year-old v3.81 that ships with macOS). This
  could be a viable solution, but it's also much more invasive on developers'
  systems.

These alternative solutions all indicate that the problem is a bug in make,
and as such I won't try to understand the fix (I was managed to distill a much
smaller test case (explained in the maccore issue), but it didn't reveal
what's causing make to become confused); I'll just cross my fingers and hope
it works out.

The fix itself should be innocuous, the only visible change will be that
sometimes make will delete intermediate files, and print an (admittedly
annoying) line at the end of the build saying so ("rm file1 file2 ...").

Fixes https://github.com/xamarin/maccore/issues/762.