### PR TITLE
[jenkins] Make it possible to skip API comparison by applying a label to a pull request.

### DIFF
--- a/jenkins/.gitignore
+++ b/jenkins/.gitignore
@@ -1,2 +1,3 @@
 pr-comments.md
+.tmp-labels*
 

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -33,20 +33,12 @@ else
 	rm -f .tmp-files
 
 	if test -z $ENABLE_DEVICE_BUILD; then
-		echo "Downloading labels for pull request #$ghprbPullId..."
-		if curl https://api.github.com/repos/xamarin/xamarin-macios/issues/$ghprbPullId/labels > .tmp-labels; then
-			echo "Labels found:"
-			cat .tmp-labels | grep "\"name\":" | sed 's/name": \"//' | sed 's/.*\"\(.*\)\".*/    \1/' || true
-			if grep '\"enable-device-build\"' .tmp-labels >/dev/null; then
-				ENABLE_DEVICE_BUILD=1
-				echo "Enabling device build because the label 'enable-device-build' was found."
-			else
-				echo "Not enabling device build; no label named 'enable-device-build' was found."
-			fi
+		if ./jenkins/fetch-pr-labels.sh --check=enable-device-build; then
+			ENABLE_DEVICE_BUILD=1
+			echo "Enabling device build because the label 'enable-device-build' was found."
 		else
-			echo "Failed to fetch labels for the pull request $ghprbPullId, so won't check if we're doing a device build."
+			echo "Not enabling device build; no label named 'enable-device-build' was found."
 		fi
-		rm -f .tmp-labels
 	fi
 fi
 

--- a/jenkins/compare.sh
+++ b/jenkins/compare.sh
@@ -9,6 +9,11 @@ trap report_error ERR
 
 cd $WORKSPACE
 
+if ./jenkins/fetch-pr-labels.sh --check=skip-api-comparison; then
+	printf "❎ Skipped API comparison because the PR has the label 'skip-api-comparison'\\n" >> $WORKSPACE/jenkins/pr-comments.md
+	exit 0
+fi
+
 BASE=origin/pr/$ghprbPullId/merge
 if ! git rev-parse $BASE >/dev/null 2>&1; then
 	echo "Can't compare API and create generator diff because the pull request has conflicts that must be resolved first (the branch '$BASE' doesn't exist)."

--- a/jenkins/fetch-pr-labels.sh
+++ b/jenkins/fetch-pr-labels.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -e
+
+if test -z "$ghprbPullId"; then
+	echo "Could not find the environment variable ghprbPullId, so it's not possible to fetch the labels for any pull request."
+	exit 1
+fi
+
+FORCE=
+CHECK=
+while ! test -z "$1"; do
+    case "$1" in
+		--force|-f)
+			FORCE=1
+			shift
+			;;
+		--check)
+			if test -z "$2"; then
+				echo "Missing argument to --check"
+				exit 1
+			fi
+			CHECK="$2"
+			shift 2
+			;;
+		--check=*|--check:*)
+			CHECK="${1:8}"
+			shift
+			;;
+		*)
+			echo "Unknown argument: $1"
+			exit 1
+			;;
+    esac
+done
+
+cd "$(dirname "$0")"
+
+TMPFILE=".tmp-labels-$ghprbPullId"
+if [[ x"$FORCE" == "x" && ( -f "$TMPFILE" ) ]]; then
+	echo "Not downloading labels for pull request #$ghprbPullId because they've already been downloaded."
+else
+	echo "Downloading labels for pull request #$ghprbPullId..."
+	if ! curl --silent "https://api.github.com/repos/xamarin/xamarin-macios/issues/$ghprbPullId/labels" > "$TMPFILE.dl"; then
+		echo "Failed to fetch labels for the pull request $ghprbPullId."
+		exit 1
+	fi
+	grep "\"name\":" "$TMPFILE.dl" | sed -e 's/name": \"//' -e 's/.*\"\(.*\)\".*/\1/'> "$TMPFILE" || true
+fi
+
+if test -z "$CHECK"; then
+	echo "Labels found:"
+	sed 's/^/    /' "$TMPFILE"
+else
+	if grep "^$CHECK$" "$TMPFILE" >/dev/null 2>&1; then
+		echo "The pull request $ghprbPullId contains the label $CHECK."
+	else
+		echo "The pull request $ghprbPullId does not contain the label $CHECK."
+		exit 1
+	fi
+fi


### PR DESCRIPTION
Implement support for skipping API comparison by applying a label to a pull
request.

This also required some refactoring to move existing code to fetch the labels
for a pull request to a separate script.