### PR TITLE
Build assemblies we ship deterministically. Fixes #3525.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -183,11 +183,11 @@ DEVICE_BIN_PATH=$(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/
 DEVICE_CC=$(IOS_CC)
 DEVICE_CXX=$(IOS_CXX)
 
-IOS_CSC=$(SYSTEM_CSC) -nostdlib -noconfig -r:$(MONOTOUCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_MONO_PATH)/System.Core.dll -r:$(MONOTOUCH_MONO_PATH)/System.Xml.dll -r:$(MONOTOUCH_MONO_PATH)/mscorlib.dll -r:$(MONOTOUCH_MONO_PATH)/System.Net.Http.dll
+IOS_CSC=$(SYSTEM_CSC) -nostdlib -noconfig -r:$(MONOTOUCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_MONO_PATH)/System.Core.dll -r:$(MONOTOUCH_MONO_PATH)/System.Xml.dll -r:$(MONOTOUCH_MONO_PATH)/mscorlib.dll -r:$(MONOTOUCH_MONO_PATH)/System.Net.Http.dll -deterministic
 IOS_MCS=$(SYSTEM_MCS) -nostdlib -r:mscorlib.dll -lib:$(MONOTOUCH_MONO_PATH)
 
-TV_CSC=$(SYSTEM_CSC) -nostdlib -noconfig -r:$(MONOTOUCH_TV_MONO_PATH)/System.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Core.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Xml.dll -r:$(MONOTOUCH_TV_MONO_PATH)/mscorlib.dll
-WATCH_CSC=$(SYSTEM_CSC) -nostdlib -noconfig -r:$(WATCH_BCL_DIR)/System.dll -r:$(WATCH_BCL_DIR)/System.Core.dll -r:$(WATCH_BCL_DIR)/System.Xml.dll -r:$(WATCH_BCL_DIR)/mscorlib.dll
+TV_CSC=$(SYSTEM_CSC) -nostdlib -noconfig -r:$(MONOTOUCH_TV_MONO_PATH)/System.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Core.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Xml.dll -r:$(MONOTOUCH_TV_MONO_PATH)/mscorlib.dll -deterministic
+WATCH_CSC=$(SYSTEM_CSC) -nostdlib -noconfig -r:$(WATCH_BCL_DIR)/System.dll -r:$(WATCH_BCL_DIR)/System.Core.dll -r:$(WATCH_BCL_DIR)/System.Xml.dll -r:$(WATCH_BCL_DIR)/mscorlib.dll -deterministic
 
 DEVICE_OBJC_CFLAGS=$(OBJC_CFLAGS) $(BITCODE_CFLAGS)
 
@@ -283,10 +283,10 @@ MAC_FRAMEWORK_VERSIONED_DIR = $(MAC_FRAMEWORK_DIR)/Versions/$(MAC_PACKAGE_VERSIO
 MAC_FRAMEWORK_CURRENT_DIR = $(MAC_FRAMEWORK_DIR)/Versions/$(MAC_INSTALL_VERSION)
 
 MOBILE_BCL_DIR = $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/Xamarin.Mac
-MAC_mobile_CSC = $(SYSTEM_CSC) -nostdlib -noconfig -r:$(MOBILE_BCL_DIR)/System.dll -r:$(MOBILE_BCL_DIR)/System.Core.dll -r:$(MOBILE_BCL_DIR)/System.Xml.dll -r:$(MOBILE_BCL_DIR)/mscorlib.dll -r:$(MOBILE_BCL_DIR)/System.Net.Http.dll
+MAC_mobile_CSC = $(SYSTEM_CSC) -nostdlib -noconfig -r:$(MOBILE_BCL_DIR)/System.dll -r:$(MOBILE_BCL_DIR)/System.Core.dll -r:$(MOBILE_BCL_DIR)/System.Xml.dll -r:$(MOBILE_BCL_DIR)/mscorlib.dll -r:$(MOBILE_BCL_DIR)/System.Net.Http.dll -deterministic
 
 FULL_BCL_DIR = $(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/lib/mono/4.5
-MAC_full_CSC = $(SYSTEM_CSC) -nostdlib -noconfig -r:$(FULL_BCL_DIR)/System.dll -r:$(FULL_BCL_DIR)/System.Core.dll -r:$(FULL_BCL_DIR)/System.Xml.dll -r:$(FULL_BCL_DIR)/mscorlib.dll -r:$(FULL_BCL_DIR)/System.Net.Http.dll
+MAC_full_CSC = $(SYSTEM_CSC) -nostdlib -noconfig -r:$(FULL_BCL_DIR)/System.dll -r:$(FULL_BCL_DIR)/System.Core.dll -r:$(FULL_BCL_DIR)/System.Xml.dll -r:$(FULL_BCL_DIR)/mscorlib.dll -r:$(FULL_BCL_DIR)/System.Net.Http.dll -deterministic
 
 MAC_PACKAGE_FILENAME=$(MAC_PACKAGE_NAME_LOWER)-$(MAC_PACKAGE_VERSION).pkg
 MAC_PACKAGE_DMG_FILENAME=$(MAC_PACKAGE_NAME_LOWER)-$(MAC_PACKAGE_VERSION).dmg

--- a/src/Makefile
+++ b/src/Makefile
@@ -151,6 +151,7 @@ IOS_VARIANTS_TARGETS += $(IOS_BUILD_DIR)/$(1)/$(3)
 $(IOS_BUILD_DIR)/$(1)/$(3): $$(IOS_SOURCES) $(IOS_BUILD_DIR)/$(4)/generated_sources $(PRODUCT_KEY_PATH)
 	@mkdir -p $(IOS_BUILD_DIR)/$(1)
 	$$(call Q_PROF_CSC,ios/$(1)) $$(IOS_CSC) -nologo -out:$$@ -target:library -debug -unsafe -optimize \
+		-deterministic \
 		-r:$(IOS_LIBDIR)/Mono.Security.dll \
 		$$(ARGS_$(6)) \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) $$(IOS_DEFINES) \
@@ -182,6 +183,7 @@ $(IOS_BUILD_DIR)/reference/MonoTouch.Dialog-1.%: $(MACIOS_BINARIES_PATH)/MonoTou
 # MonoTouch.NUnitLite
 $(IOS_BUILD_DIR)/$(1)%$(5) $(IOS_BUILD_DIR)/$(1)%$(5:.dll=.pdb): $$(IOS_TOUCHUNIT_SOURCES) $(IOS_BUILD_DIR)/$(1)/$(4) $(PRODUCT_KEY_PATH) $(IOS_BUILD_DIR)/reference/Xamarin.iOS.dll
 	$$(call Q_PROF_CSC,ios/$(1)) $$(IOS_CSC) -nologo -out:$$(basename $$@).dll -target:library -debug:portable -optimize -publicsign \
+		-deterministic \
 		-keyfile:$(PRODUCT_KEY_PATH) -r:$(IOS_BUILD_DIR)/$(1)/$(3) $(6) -r:$(IOS_BUILD_DIR)/$(1)/$(4) -r:$(MONOTOUCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_MONO_PATH)/System.Xml.dll \
 		-nowarn:3006,612,649,414,1635 \
 		-define:NUNITLITE,CLR_4_0,NET_4_5,__MOBILE__ $$(IOS_DEFINES) \
@@ -514,6 +516,7 @@ $(MAC_BUILD_DIR)/$(1)/$(2): $(MAC_BUILD_DIR)/$(3)/generated-sources $(MAC_SOURCE
 	@mkdir -p $(MAC_BUILD_DIR)/$(1)
 	$$(call Q_PROF_CSC,mac/$(1)) \
 		$$(MAC_$(3)_CSC) -nologo -out:$$@ -target:library -debug -unsafe \
+		-deterministic \
 		$$(MAC_COMMON_DEFINES),OBJECT_REF_TRACKING \
 		-r:Mono.Security.dll \
 		$$(MAC_$(3)_ARGS) \
@@ -784,6 +787,7 @@ $(WATCH_BUILD_DIR)/watch/generated_sources: $(WATCH_GENERATOR) $(WATCHOS_APIS) $
 $(WATCH_BUILD_DIR)/watch-32/Xamarin.WatchOS%dll $(WATCH_BUILD_DIR)/watch-32/Xamarin.WatchOS%pdb: $(WATCHOS_SOURCES) $(WATCH_BUILD_DIR)/watch/generated_sources $(PRODUCT_KEY_PATH) | $(WATCH_BUILD_DIR)/watch-32
 	$(call Q_PROF_CSC,watch) $(WATCH_CSC) -nologo -out:$(basename $@).dll -target:library -debug -unsafe -optimize \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) $(WATCH_DEFINES) \
+		-deterministic \
 		$(ARGS_32) \
 		-nowarn:219,618,114,414,1635,3021,$(IOS_WARNINGS_THAT_YOU_SHOULD_FIX) \
 		$(WATCHOS_SOURCES) @$(WATCH_BUILD_DIR)/watch/generated_sources
@@ -804,6 +808,7 @@ $(WATCH_BUILD_DIR)/reference/MonoTouch.NUnitLite%dll $(WATCH_BUILD_DIR)/referenc
 		-keyfile:$(PRODUCT_KEY_PATH) -r:$(WATCH_BUILD_DIR)/reference/Xamarin.WatchOS.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/mscorlib.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/System.dll -r:$(MONOTOUCH_WATCH_MONO_PATH)/System.Xml.dll \
 		-nowarn:3006,612,649,414,1635 \
 		-define:NUNITLITE,CLR_4_0,NET_4_5,__MOBILE__ $(WATCH_DEFINES) \
+		-deterministic \
 		$(WATCHOS_TOUCHUNIT_SOURCES)
 
 # System.Drawing.Primitives.dll is special
@@ -997,6 +1002,7 @@ $(TVOS_BUILD_DIR)/tvos/generated_sources: $(TVOS_GENERATOR) $(TVOS_APIS) $(TVOS_
 $(TVOS_BUILD_DIR)/tvos-64/Xamarin.TVOS%dll $(TVOS_BUILD_DIR)/tvos-64/Xamarin.TVOS%pdb: $(TVOS_SOURCES) $(TVOS_BUILD_DIR)/tvos/generated_sources $(PRODUCT_KEY_PATH) | $(TVOS_BUILD_DIR)/tvos-64
 	$(call Q_PROF_CSC,tvos) $(TV_CSC) -nologo -out:$(basename $@).dll -target:library -debug -unsafe -optimize \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) $(TVOS_DEFINES) \
+		-deterministic \
 		-r:$(TVOS_LIBDIR)/Mono.Security.dll \
 		$(ARGS_64) \
 		-nowarn:219,618,114,414,1635,3021,$(IOS_WARNINGS_THAT_YOU_SHOULD_FIX) \
@@ -1017,6 +1023,7 @@ $(TVOS_BUILD_DIR)/reference/MonoTouch.NUnitLite%dll $(TVOS_BUILD_DIR)/reference/
 		-keyfile:$(PRODUCT_KEY_PATH) -r:$(TVOS_BUILD_DIR)/reference/Xamarin.TVOS.dll -r:$(TVOS_BUILD_DIR)/reference/MonoTouch.Dialog-1.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.dll -r:$(MONOTOUCH_TV_MONO_PATH)/System.Xml.dll \
 		-nowarn:3006,612,649,414,1635 \
 		-define:NUNITLITE,CLR_4_0,NET_4_5,__MOBILE__ $(TVOS_DEFINES) \
+		-deterministic \
 		$(TVOS_TOUCHUNIT_SOURCES)
 	@touch $(basename $@).dll $(basename $@).pdb
 

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -54,7 +54,7 @@ IKVM_REFLECTION_FLAGS = -d:NO_AUTHENTICODE,STATIC,NO_SYMBOL_WRITER
 
 $(BUILD_DIR)/common/bgen.exe: $(GENERATOR_SOURCES) $(IKVM_REFLECTION_SOURCES) $(GENERATOR_ATTRIBUTE_SOURCES) Makefile.generator
 	$(Q) mkdir -p $(BUILD_DIR)/common
-	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug:portable -out:$@ $(IKVM_REFLECTION_FLAGS) $(GENERATOR_DEFINES) $(IKVM_REFLECTION_SOURCES) $(GENERATOR_ATTRIBUTE_SOURCES) $(GENERATOR_SOURCES)
+	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug:portable -out:$@ $(IKVM_REFLECTION_FLAGS) $(GENERATOR_DEFINES) $(IKVM_REFLECTION_SOURCES) $(GENERATOR_ATTRIBUTE_SOURCES) $(GENERATOR_SOURCES) -deterministic
 
 # The command-line arguments in the csproj are currently kept up-to-date manually
 generator.csproj: generator-ikvm.csproj.in Makefile.generator
@@ -122,11 +122,11 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bgen/bgen.exe: $(BUILD_DIR)/common/bgen.ex
 
 $(IOS_BUILD_DIR)/native/Xamarin.iOS.BindingAttributes.dll: generator-attributes.cs Makefile.generator
 	$(Q) mkdir -p $(dir $@)
-	$(Q_GEN) $(SYSTEM_CSC) -nologo -out:$@ -debug generator-attributes.cs -target:library
+	$(Q_GEN) $(SYSTEM_CSC) -nologo -out:$@ -debug generator-attributes.cs -target:library -deterministic
 
 $(IOS_BUILD_DIR)/native/monotouch.BindingAttributes.dll: generator-attributes.cs Makefile.generator
 	$(Q) mkdir -p $(dir $@)
-	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug -out:$@ -debug generator-attributes.cs -target:library
+	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug -out:$@ -debug generator-attributes.cs -target:library -deterministic
 
 #
 # Xamarin.Watch (bwatch)
@@ -151,7 +151,7 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bgen/%.dll: $(WATCH_BUILD_DIR)/%.dll | $(I
 
 $(WATCH_BUILD_DIR)/Xamarin.WatchOS.BindingAttributes.dll: generator-attributes.cs Makefile.generator
 	$(Q) mkdir -p $(dir $@)
-	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug -out:$@ -debug generator-attributes.cs -target:library
+	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug -out:$@ -debug generator-attributes.cs -target:library -deterministic
 
 # #
 # # Xamarin.TVOS (btv)
@@ -176,7 +176,7 @@ $(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/lib/bgen/%.dll: $(TVOS_BUILD_DIR)/%.dll | $(IO
 
 $(TVOS_BUILD_DIR)/Xamarin.TVOS.BindingAttributes.dll: generator-attributes.cs Makefile.generator
 	$(Q) mkdir -p $(dir $@)
-	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug -out:$@ -debug generator-attributes.cs -target:library
+	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug -out:$@ -debug generator-attributes.cs -target:library -deterministic
 
 #
 # Xamarin.Mac (bmac)
@@ -234,7 +234,7 @@ $(MAC_BUILD_DIR)/XamMac.BindingAttributes.mdb: $(MACIOS_BINARIES_PATH)/XamMac.Bi
 
 $(MAC_BUILD_DIR)/Xamarin.Mac-%.BindingAttributes.dll: generator-attributes.cs Makefile.generator
 	$(Q) mkdir -p $(dir $@)
-	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug -out:$@ -debug generator-attributes.cs -target:library
+	$(Q_GEN) $(SYSTEM_CSC) -nologo -debug -out:$@ -debug generator-attributes.cs -target:library -deterministic
 
 bgen:	\
 	$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/bin/bgen                     \

--- a/src/OpenGLES/Makefile-1.0.include
+++ b/src/OpenGLES/Makefile-1.0.include
@@ -29,7 +29,7 @@ IOS_OPENTK_1_0_CORE_SOURCES = \
 OPENTK_1_0_SOURCES:=$(shell grep "Compile Include" OpenTK.csproj | sed 's/.*Include="//' | sed 's/".*//' | sed 's_\\_/_g' )
 
 OPENTK_1_0_DEPENDENCIES = Makefile OpenGLES/Makefile-1.0.include $(OPENTK_1_0_SOURCES) opentk.csproj
-OPENTK_1_0_CSC_FLAGS = -warn:0 -unsafe -target:library -noconfig -publicsign -debug:portable -optimize -define:MONOTOUCH -define:IPHONE -define:MOBILE -d:MINIMAL $(OPENTK_1_0_SOURCES) -keyfile:$(PRODUCT_KEY_PATH) -define:OPENTK_1_0
+OPENTK_1_0_CSC_FLAGS = -warn:0 -unsafe -target:library -noconfig -publicsign -debug:portable -optimize -define:MONOTOUCH -define:IPHONE -define:MOBILE -d:MINIMAL $(OPENTK_1_0_SOURCES) -keyfile:$(PRODUCT_KEY_PATH) -define:OPENTK_1_0 -deterministic
 
 # Xamarin.iOS
 

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -151,7 +151,7 @@ LOCAL_MMP = \
 	Mono.Cecil.Mdb.dll \
 
 mmp.exe: Makefile $(MONO_CECIL_DLL) $(MONO_CECIL_MDB_DLL) $(mmp_sources) config config_mobile Info.plist.tmpl Info-framework.plist.tmpl $(tuner_sources) $(linker_resources)
-	$(Q_CSC) $(SYSTEM_CSC) -unsafe -out:mmp.exe $(DEFINES) -r:$(MONO_CECIL_DLL) -r:$(MONO_CECIL_MDB_DLL) -r:Mono.Security.dll  -resource:config -resource:config_mobile -resource:machine.4_5.config -resource:Info.plist.tmpl -resource:Info-framework.plist.tmpl $(linker_resources:%=-resource:%) $(tuner_sources) $(mmp_sources) -debug:portable -nologo
+	$(Q_CSC) $(SYSTEM_CSC) -unsafe -out:mmp.exe $(DEFINES) -r:$(MONO_CECIL_DLL) -r:$(MONO_CECIL_MDB_DLL) -r:Mono.Security.dll  -resource:config -resource:config_mobile -resource:machine.4_5.config -resource:Info.plist.tmpl -resource:Info-framework.plist.tmpl $(linker_resources:%=-resource:%) $(tuner_sources) $(mmp_sources) -debug:portable -nologo -deterministic
 	$(Q) cp $(MONO_CECIL_DLL) $(MONO_CECIL_MDB_DLL) .
 
 Mono.Cecil.dll: $(MONO_CECIL_DLL)

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -329,7 +329,7 @@ MTOUCH_DEFINES= -define:ENABLE_BITCODE_ON_IOS
 endif
 
 MTOUCH_COMPILE_DEPS = $(MTOUCH_SOURCES) $(MONO_CECIL_DLL) $(MONO_CECIL_MDB_DLL) Makefile $(LINKER_RESOURCES)
-MTOUCH_COMPILE_ARGS = -unsafe $(IOS_DEFINES) -r:$(MONO_CECIL_DLL) -r:$(MONO_CECIL_MDB_DLL) -r:System.Xml.Linq.dll $(MTOUCH_SOURCES) -nowarn:0436 $(LINKER_RESOURCES:%=-resource:%) $(MTOUCH_DEFINES) -debug:portable -nologo
+MTOUCH_COMPILE_ARGS = -unsafe $(IOS_DEFINES) -r:$(MONO_CECIL_DLL) -r:$(MONO_CECIL_MDB_DLL) -r:System.Xml.Linq.dll $(MTOUCH_SOURCES) -nowarn:0436 $(LINKER_RESOURCES:%=-resource:%) $(MTOUCH_DEFINES) -debug:portable -nologo -deterministic
 
 # bin/Debug/mtouch.exe is used from mtouch.csproj when debugging
 bin/Debug/mtouch.exe: $(MTOUCH_COMPILE_DEPS)


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/3525.