### PR TITLE
[tests] Fix TextureAtlasTest.Empty to not crash due to Apple not liking null callbacks.

### DIFF
--- a/tests/monotouch-test/SpriteKit/TextureAtlasTest.cs
+++ b/tests/monotouch-test/SpriteKit/TextureAtlasTest.cs
@@ -26,6 +26,11 @@ namespace MonoTouchFixtures.SpriteKit {
 	[Preserve (AllMembers = true)]
 	public class TextureAtlasTest {
 
+		// Apple bug ?
+		void CrashAvoider ()
+		{
+		}
+
 		[Test]
 		public void Empty ()
 		{
@@ -35,11 +40,11 @@ namespace MonoTouchFixtures.SpriteKit {
 			using (var atlas = new SKTextureAtlas ()) {
 				Assert.That (atlas.TextureNames, Is.Empty, "TextureNames");
 
-				// completionHandler is optional
-				SKTextureAtlas.PreloadTextures (new [] { atlas }, null);
+				// this completionHandler is *NOT* optional -> crash if null
+				SKTextureAtlas.PreloadTextures (new [] { atlas }, CrashAvoider);
 
-				// completionHandler is optional
-				atlas.Preload (null);
+				// this completionHandler is *NOT* optional -> crash if null
+				atlas.Preload (CrashAvoider);
 
 				// that returns a texture, calling 'MissingResource.png' (128 x 128)
 				using (var texture = atlas.TextureNamed ("ship")) {


### PR DESCRIPTION
Fixes this crash when running the xammac tests:

    ***** Empty
    Stacktrace:

    Native stacktrace:

    	0   xammac_tests                        0x000000010a89f5d8 mono_handle_native_crash + 264
    	1   xammac_tests                        0x000000010a807616 altstack_handle_and_restore + 70
    	2   SpriteKit                           0x00007fff39dc1b09 __51+[SKTexture preloadTextures:withCompletionHandler:]_block_invoke.286 + 9
    	3   libdispatch.dylib                   0x00007fff55e62e08 _dispatch_client_callout + 8
    	4   libdispatch.dylib                   0x00007fff55e75ed1 _dispatch_continuation_pop + 472
    	5   libdispatch.dylib                   0x00007fff55e6d783 _dispatch_async_redirect_invoke + 703
    	6   libdispatch.dylib                   0x00007fff55e649f9 _dispatch_root_queue_drain + 515
    	7   libdispatch.dylib                   0x00007fff55e647a5 _dispatch_worker_thread3 + 101
    	8   libsystem_pthread.dylib             0x00007fff561b4169 _pthread_wqthread + 1387
    	9   libsystem_pthread.dylib             0x00007fff561b3be9 start_wqthread + 13