### PR TITLE
[tests] Determine at runtime instead of compile time whether LinkAll is enabled. Fixes #3812.

### DIFF
--- a/tests/bindings-test/ProtocolTest.cs
+++ b/tests/bindings-test/ProtocolTest.cs
@@ -21,10 +21,9 @@ namespace Xamarin.BindingTests
 	{
 		bool HasProtocolAttributes {
 			get {
-#if LINKALL
-				if (!Runtime.DynamicRegistrationSupported)
+				if (TestRuntime.IsLinkAll && !Runtime.DynamicRegistrationSupported)
 					return false;
-#endif
+			
 				return true;
 			}
 		}

--- a/tests/bindings-test/bindings-test-mac.csproj
+++ b/tests/bindings-test/bindings-test-mac.csproj
@@ -63,6 +63,9 @@
       <Link>Registrar.cs</Link>
     </Compile>
     <Compile Include="RegistrarBindingTest.cs" />
+    <Compile Include="..\common\TestRuntime.cs">
+      <Link>TestRuntime.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\tests\test-libraries\libtest.m">

--- a/tests/bindings-test/bindings-test.csproj
+++ b/tests/bindings-test/bindings-test.csproj
@@ -75,6 +75,9 @@
       <Link>Registrar.cs</Link>
     </Compile>
     <Compile Include="RegistrarBindingTest.cs" />
+    <Compile Include="..\common\TestRuntime.cs">
+      <Link>TestRuntime.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\tests\test-libraries\libtest.m">

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1,3 +1,10 @@
+#if __MACOS__
+#define MONOMAC
+#endif
+#if __UNIFIED__
+#define XAMCORE_2_0
+#endif
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -637,4 +644,15 @@ partial class TestRuntime
 		}
 	}
 #endif // !MONOMAC && !__TVOS__
+
+	// Determine if linkall was enabled by checking if an unused class in this assembly is still here.
+	static bool? link_all;
+	public static bool IsLinkAll {
+		get {
+			if (!link_all.HasValue)
+				link_all = typeof (TestRuntime).Assembly.GetType (typeof (TestRuntime).FullName + "+LinkerSentinel") == null;
+			return link_all.Value;
+		}
+	}
+	class LinkerSentinel { }
 }

--- a/tests/linker/BaseOptimizeGeneratedCodeTest.cs
+++ b/tests/linker/BaseOptimizeGeneratedCodeTest.cs
@@ -27,10 +27,17 @@ namespace Linker.Shared
 	[Preserve (AllMembers = true)]
 	public abstract class BaseOptimizeGeneratedCodeTest
 	{
-#if LINKALL
+		protected void IgnoreIfNotLinkAll ()
+		{
+			if (!TestRuntime.IsLinkAll)
+				Assert.Ignore ("This test is only applicable when linking all assemblies.");
+		}
+
 		[Test]
 		public void SetupBlock_CustomDelegate ()
 		{
+			IgnoreIfNotLinkAll ();
+
 			int counter = 0;
 			var action = new Action (() => counter++);
 			Custom (action);
@@ -66,6 +73,8 @@ namespace Linker.Shared
 		[Test]
 		public void SetupBlockPerfTest ()
 		{
+			IgnoreIfNotLinkAll ();
+
 			const int iterations = 5000;
 
 			// Set the XAMARIN_IOS_SKIP_BLOCK_CHECK environment variable to skip a few expensive validation checks done in the simulator
@@ -113,6 +122,8 @@ namespace Linker.Shared
 		[Test]
 		public void SetupBlockCodeTest ()
 		{
+			IgnoreIfNotLinkAll ();
+
 			int counter = 0;
 			var action = new Action (() => counter++);
 			SetupBlockOptimized_SpecificArgument (block_callback, action);
@@ -491,6 +502,5 @@ namespace Linker.Shared
 			GC.KeepAlive (dummy208); GC.KeepAlive (dummy218); GC.KeepAlive (dummy228); GC.KeepAlive (dummy238); GC.KeepAlive (dummy248); GC.KeepAlive (dummy258); GC.KeepAlive (dummy268); GC.KeepAlive (dummy278); GC.KeepAlive (dummy288); GC.KeepAlive (dummy298);
 			GC.KeepAlive (dummy209); GC.KeepAlive (dummy219); GC.KeepAlive (dummy229); GC.KeepAlive (dummy239); GC.KeepAlive (dummy249); GC.KeepAlive (dummy259); GC.KeepAlive (dummy269); GC.KeepAlive (dummy279); GC.KeepAlive (dummy289); GC.KeepAlive (dummy299);
 		}
-#endif // LINKALL
 	}
 }

--- a/tests/linker/ios/link all/link all.csproj
+++ b/tests/linker/ios/link all/link all.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhoneSimulator\$(Configuration)-unified</OutputPath>
-    <DefineConstants>DEBUG;LINKALL;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <MtouchDebug>True</MtouchDebug>
@@ -38,7 +38,7 @@
     <MtouchLink>Full</MtouchLink>
     <MtouchI18n>mideast,other</MtouchI18n>
     <MtouchArch>i386, x86_64</MtouchArch>
-    <DefineConstants>LINKALL;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>$(DefineConstants)</DefineConstants>
     <MtouchExtraArgs>--registrar:static --optimize=all,-remove-dynamic-registrar</MtouchExtraArgs>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -47,7 +47,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhone\$(Configuration)-unified</OutputPath>
-    <DefineConstants>DEBUG;LINKALL;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
@@ -64,7 +64,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhone\$(Configuration)-unified</OutputPath>
-    <DefineConstants>DEBUG;LINKALL;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
@@ -80,7 +80,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhone\$(Configuration)-unified</OutputPath>
-    <DefineConstants>DEBUG;LINKALL;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
@@ -103,7 +103,7 @@
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchExtraArgs>--optimize=all,-remove-dynamic-registrar</MtouchExtraArgs>
-    <DefineConstants>LINKALL;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>$(DefineConstants)</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release32|iPhone' ">
@@ -118,7 +118,7 @@
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchArch>ARMv7</MtouchArch>
     <MtouchExtraArgs>--optimize=all,-remove-dynamic-registrar</MtouchExtraArgs>
-    <DefineConstants>LINKALL;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>$(DefineConstants)</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release64|iPhone' ">
@@ -133,7 +133,7 @@
     <MtouchUseLlvm>True</MtouchUseLlvm>
     <MtouchArch>ARM64</MtouchArch>
     <MtouchExtraArgs>--optimize=all,-remove-dynamic-registrar</MtouchExtraArgs>
-    <DefineConstants>LINKALL;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>$(DefineConstants)</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-bitcode|iPhone' ">
@@ -148,7 +148,7 @@
     <MtouchUseLlvm>true</MtouchUseLlvm>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchExtraArgs>--bitcode:full --optimize=all,-remove-dynamic-registrar</MtouchExtraArgs>
-    <DefineConstants>LINKALL;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>$(DefineConstants)</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
@@ -192,6 +192,9 @@
     </Compile>
     <Compile Include="SerializationTest.cs" />
     <Compile Include="ILReader.cs" />
+    <Compile Include="..\..\..\common\TestRuntime.cs">
+      <Link>TestRuntime.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="LaunchScreen.storyboard" Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" />

--- a/tests/linker/ios/link sdk/OptimizeGeneratedCodeTest.cs
+++ b/tests/linker/ios/link sdk/OptimizeGeneratedCodeTest.cs
@@ -158,10 +158,11 @@ namespace Linker.Shared {
 		}
 #endif // !__WATCHOS__
 
-#if LINKALL
 		[Test]
 		public void FinallyTest ()
 		{
+			IgnoreIfNotLinkAll ();
+
 			// bug #26415
 			FinallyTestMethod ();
 			Assert.IsTrue (finally_invoked);
@@ -186,6 +187,8 @@ namespace Linker.Shared {
 		[Test]
 		public void IntPtrSizeTest ()
 		{
+			IgnoreIfNotLinkAll ();
+
 			var S8methods = new MethodInfo []
 			{
 				GetType ().GetMethod (nameof (Size8Test), BindingFlags.NonPublic | BindingFlags.Instance),
@@ -314,6 +317,5 @@ namespace Linker.Shared {
 			if (IntPtr.Size <= 3)
 				throw new NUnit.Framework.Internal.NUnitException ("6");
 		}
-#endif
 	}
 }

--- a/tests/linker/ios/link sdk/ReflectionTest.cs
+++ b/tests/linker/ios/link sdk/ReflectionTest.cs
@@ -29,15 +29,21 @@ namespace Linker.Shared.Reflection {
 
 			var mi = this.GetType ().GetMethod ("MethodWithParameters");
 			var p = mi.GetParameters ();
-#if DEBUG || !LINKALL
-			// this optimization is only applied for release builds (not debug ones)
-			// link sdk won't touch this assembly (user code) so the parameters will be available
-			Assert.That (p [0].ToString (), Is.EqualTo ("System.String firstParameter"), "1");
-			Assert.That (p [1].ToString (), Is.EqualTo ("Int32 secondParameter"), "2");
+#if DEBUG
+			var optimized = false;
 #else
-			Assert.That (p [0].ToString (), Is.EqualTo ("System.String "), "1");
-			Assert.That (p [1].ToString (), Is.EqualTo ("Int32 "), "2");
+			var optimized = TestRuntime.IsLinkAll;
 #endif
+
+			if (!optimized) {
+				// this optimization is only applied for release builds (not debug ones)
+				// link sdk won't touch this assembly (user code) so the parameters will be available
+				Assert.That (p [0].ToString (), Is.EqualTo ("System.String firstParameter"), "1");
+				Assert.That (p [1].ToString (), Is.EqualTo ("Int32 secondParameter"), "2");
+			} else {
+				Assert.That (p [0].ToString (), Is.EqualTo ("System.String "), "1");
+				Assert.That (p [1].ToString (), Is.EqualTo ("Int32 "), "2");
+			}
 		}
 	}
 }

--- a/tests/linker/ios/link sdk/link sdk.csproj
+++ b/tests/linker/ios/link sdk/link sdk.csproj
@@ -186,6 +186,9 @@
     <Compile Include="..\..\..\common\TestRuntime.cs">
         <Link>TestRuntime.cs</Link>
     </Compile>
+    <Compile Include="..\link all\ILReader.cs">
+      <Link>ILReader.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="LaunchScreen.storyboard" Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" />

--- a/tests/linker/mac/link all/link all-mac.csproj
+++ b/tests/linker/mac/link all/link all-mac.csproj
@@ -17,7 +17,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\$(Platform)\Debug</OutputPath>
-    <DefineConstants>__UNIFIED__;__MACOS__;DEBUG;LINKALL</DefineConstants>
+    <DefineConstants>__UNIFIED__;__MACOS__;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <EnableCodeSigning>false</EnableCodeSigning>
@@ -38,7 +38,7 @@
     <DebugType></DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\$(Platform)\Release</OutputPath>
-    <DefineConstants>__UNIFIED__;__MACOS__;LINKALL</DefineConstants>
+    <DefineConstants>__UNIFIED__;__MACOS__</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <EnableCodeSigning>false</EnableCodeSigning>

--- a/tests/linker/mac/link all/link all-mac.csproj
+++ b/tests/linker/mac/link all/link all-mac.csproj
@@ -75,6 +75,9 @@
       <Link>PlatformInfo.cs</Link>
     </Compile>
     <Compile Include="OptimizeGeneratedCodeTest.cs" />
+    <Compile Include="..\..\..\common\TestRuntime.cs">
+      <Link>TestRuntime.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\external\guiunit\src\framework\GuiUnit_xammac_mobile.csproj">

--- a/tests/linker/mac/link sdk/link sdk-mac.csproj
+++ b/tests/linker/mac/link sdk/link sdk-mac.csproj
@@ -71,6 +71,9 @@
     <Compile Include="..\..\..\common\PlatformInfo.cs">
       <Link>PlatformInfo.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\common\TestRuntime.cs">
+      <Link>TestRuntime.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\external\guiunit\src\framework\GuiUnit_xammac_mobile.csproj">

--- a/tests/monotouch-test/Foundation/NSDataTest.cs
+++ b/tests/monotouch-test/Foundation/NSDataTest.cs
@@ -83,9 +83,8 @@ namespace MonoTouchFixtures.Foundation {
 		{
 			Assert.Null (NSData.FromFile ("does not exists"), "unexisting");
 #if MONOMAC // Info.Plist isn't there to load from the same location on mac
-#if !LINKALL
-			Assert.NotNull (NSData.FromFile (NSBundle.MainBundle.PathForResource ("runtime-options", "plist")), "runtime-options.plist");
-#endif
+			if (!TestRuntime.IsLinkAll)
+				Assert.NotNull (NSData.FromFile (NSBundle.MainBundle.PathForResource ("runtime-options", "plist")), "runtime-options.plist");
 #else
 			Assert.NotNull (NSData.FromFile ("Info.plist"), "Info.plist");
 #endif

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -188,8 +188,8 @@ namespace xharness
 				case "monotouch-test":
 					// The default is to run monotouch-test with the dynamic registrar (in the simulator), so that's already covered
 					yield return new TestData { Variation = "Debug (static registrar)", MTouchExtraArgs = "--registrar:static", Debug = true, Profiling = false };
-					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, LinkMode = "Full", Defines = "LINKALL;OPTIMIZEALL" };
-					yield return new TestData { Variation = "Debug (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all,-remove-uithread-checks", Debug = true, Profiling = false, LinkMode = "Full", Defines = "LINKALL;OPTIMIZEALL", Ignored = !IncludeAll };
+					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, LinkMode = "Full", Defines = "OPTIMIZEALL" };
+					yield return new TestData { Variation = "Debug (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all,-remove-uithread-checks", Debug = true, Profiling = false, LinkMode = "Full", Defines = "OPTIMIZEALL", Ignored = !IncludeAll };
 					break;
 				}
 				break;
@@ -199,10 +199,10 @@ namespace xharness
 				case "xammac tests":
 					switch (test.ProjectConfiguration) {
 					case "Release":
-						yield return new TestData { Variation = "Release (all optimizations)", MonoBundlingExtraArgs = "--registrar:static --optimize:all", Debug = false, LinkMode = "Full", Defines = "LINKALL;OPTIMIZEALL"};
+						yield return new TestData { Variation = "Release (all optimizations)", MonoBundlingExtraArgs = "--registrar:static --optimize:all", Debug = false, LinkMode = "Full", Defines = "OPTIMIZEALL"};
 						break;
 					case "Debug":
-						yield return new TestData { Variation = "Debug (all optimizations)", MonoBundlingExtraArgs = "--registrar:static --optimize:all,-remove-uithread-checks", Debug = true, LinkMode = "Full", Defines = "LINKALL;OPTIMIZEALL", Ignored = !IncludeAll };
+						yield return new TestData { Variation = "Debug (all optimizations)", MonoBundlingExtraArgs = "--registrar:static --optimize:all,-remove-uithread-checks", Debug = true, LinkMode = "Full", Defines = "OPTIMIZEALL", Ignored = !IncludeAll };
 						break;
 					}
 					break;


### PR DESCRIPTION
This way we can remove the LINKALL define, which also means nobody can forget
to define it when building using LinkAll.

https://github.com/xamarin/xamarin-macios/issues/3812