### PR TITLE
[monotouch-test] Make BundleTest.TestPreferredLocalizations laxer.

### DIFF
--- a/tests/monotouch-test/CoreFoundation/BundleTest.cs
+++ b/tests/monotouch-test/CoreFoundation/BundleTest.cs
@@ -179,7 +179,8 @@ namespace MonoTouchFixtures.CoreFoundation {
 			var preferred = new string [] {"en", "es"};
 			var used = CFBundle.GetPreferredLocalizations (preferred);
 			Assert.IsTrue (used.Length > 0);
-			Assert.That (used, Has.Exactly (1).EqualTo ("en"));
+			foreach (var u in used)
+				Assert.That (preferred, Contains.Item (u), u);
 		}
 
 		[Test]


### PR DESCRIPTION
Change test to verify that all preferred localizations are in the list of
available localizations (instead of hardcoding an expected result of 'en').

This makes the TestPreferredLocalizations work if the device language is 'es',
in which case the preferred language between 'en' and 'es' is obviously 'es'.