### PR TITLE
[monotouch-test] Fix WeakReferenceTest.WeakTest to work on watchOS/LLVM.

### DIFF
--- a/tests/monotouch-test/mono/MonoWeakReferenceTest.cs
+++ b/tests/monotouch-test/mono/MonoWeakReferenceTest.cs
@@ -54,7 +54,19 @@ namespace MonoTouchFixtures {
 			for (int i = 0; i < 1000 * 1000 * 10; ++i)
 				new OneField ();
 
-			Assert.That (Test.retain.a, Is.EqualTo (0x1029458), "retain.a");
+			Exception ex = null;
+			thread = new Thread (() => {
+				try {
+					// This must be done on a separate thread so that the 'Test.retain' value doesn't
+					// show up on the main thread's stack as a temporary value in registers the
+					// GC can see.
+					Assert.That (Test.retain.a, Is.EqualTo (0x1029458), "retain.a");
+				} catch (Exception e) {
+					ex = e;
+				}
+			});
+			thread.Start ();
+			thread.Join ();
 
 			Test.retain = null;
 			GC.Collect ();


### PR DESCRIPTION
Change WeakReferenceTest.WeakTest so that it doesn't fetch values that should
be garbage collected on the main thread.

Doing so on the main thread may cause those values to stay in registers as
temporary values, thus preventing the garbage collector from collecting them.

Instead do the fetching in a background thread, whose stack won't exist
anymore once it's finished.

Fixes this test failure when running on watchOS device in release mode:

    [FAIL] WeakReferenceTest.WeakTest : 't.Obj4' should be null

The reason it only happens on watchOS in release mode, is probably because
LLVM puts temporary values in different registers than Mono's AOT compiler
does.