### PR TITLE
[macos][security] Re-enable SSL[Get}Set]AlpnProtocols. Fixes #4001

### DIFF
--- a/src/Security/SslContext.cs
+++ b/src/Security/SslContext.cs
@@ -646,23 +646,26 @@ namespace Security {
 			return SSLSetOCSPResponse (Handle, response.Handle);
 		}
 
-#if !MONOMAC
-		[iOS (11,0)][TV (11,0)][Watch (4,0)] //[Mac (10,13)] Apple forgot to export SSLSetALPNProtocols. https://bugs.swift.org/browse/SR-6131
+		[iOS (11,0)][TV (11,0)][Watch (4,0)]
+		[Mac (10,13,4)]
 		[DllImport (Constants.SecurityLibrary)]
 		static extern /* OSStatus */ int SSLSetALPNProtocols (IntPtr /* SSLContextRef */ context, IntPtr /* CFArrayRef */ protocols);
 
-		[iOS (11,0)][TV (11,0)][Watch (4,0)] //[Mac (10,13)]  Apple forgot to export SSLSetALPNProtocols. https://bugs.swift.org/browse/SR-6131
+		[iOS (11,0)][TV (11,0)][Watch (4,0)]
+		[Mac (10,13,4)]
 		public int SetAlpnProtocols (string[] protocols)
 		{
 			using (var array = NSArray.FromStrings (protocols))
 				return SSLSetALPNProtocols (Handle, array.Handle);
 		}
 
-		[iOS (11,0)][TV (11,0)][Watch (4,0)] //[Mac (10,13)] Apple forgot to export SSLCopyALPNProtocols.
+		[iOS (11,0)][TV (11,0)][Watch (4,0)]
+		[Mac (10,13,4)]
 		[DllImport (Constants.SecurityLibrary)]
 		static extern /* OSStatus */ int SSLCopyALPNProtocols (IntPtr /* SSLContextRef */ context, ref IntPtr /* CFArrayRef* */ protocols);
 
-		[iOS (11,0)][TV (11,0)][Watch (4,0)] //[Mac (10,13)] Apple forgot to export the SSLCopyALPNProtocols.
+		[iOS (11,0)][TV (11,0)][Watch (4,0)]
+		[Mac (10,13,4)]
 		public string[] GetAlpnProtocols (out int error)
 		{
 			IntPtr protocols = IntPtr.Zero; // must be null, CFArray allocated by SSLCopyALPNProtocols
@@ -674,12 +677,12 @@ namespace Security {
 			return result;
 		}
 
-		[iOS (11,0)][TV (11,0)][Watch (4,0)] //[Mac (10,13)] Apple forgot to export the SSLCopyALPNProtocols.
+		[iOS (11,0)][TV (11,0)][Watch (4,0)]
+		[Mac (10,13,4)]
 		public string[] GetAlpnProtocols ()
 		{
 			int error;
 			return GetAlpnProtocols (out error);
 		}
-#endif
 	}
 }

--- a/tests/monotouch-test/Security/SecureTransportTest.cs
+++ b/tests/monotouch-test/Security/SecureTransportTest.cs
@@ -99,12 +99,18 @@ namespace MonoTouchFixtures.Security {
 					using (var data = new NSData ())
 						Assert.That (ssl.SetOcspResponse (data), Is.EqualTo (0), "SetOcspResponse/empty");
 
+#if MONOMAC
+					if (TestRuntime.CheckXcodeVersion (9,3)) {
+#endif
 					int error;
 					var alpn = ssl.GetAlpnProtocols (out error);
 					Assert.That (alpn, Is.Empty, "alpn");
 					Assert.That (error, Is.EqualTo ((int) SecStatusCode.Param), "GetAlpnProtocols");
 					var protocols = new [] { "HTTP/1.1", "SPDY/1" };
 					Assert.That (ssl.SetAlpnProtocols (protocols), Is.EqualTo (0), "SetAlpnProtocols");
+#if MONOMAC
+					}
+#endif
 				}
 			}
 		}

--- a/tests/monotouch-test/Security/SecureTransportTest.cs
+++ b/tests/monotouch-test/Security/SecureTransportTest.cs
@@ -99,35 +99,15 @@ namespace MonoTouchFixtures.Security {
 					using (var data = new NSData ())
 						Assert.That (ssl.SetOcspResponse (data), Is.EqualTo (0), "SetOcspResponse/empty");
 
-// Test disabled for macOS due to Apple is not shipping SSLSetALPNProtocols and SSLCopyALPNProtocols on macOS
-#if !MONOMAC
 					int error;
 					var alpn = ssl.GetAlpnProtocols (out error);
 					Assert.That (alpn, Is.Empty, "alpn");
 					Assert.That (error, Is.EqualTo ((int) SecStatusCode.Param), "GetAlpnProtocols");
 					var protocols = new [] { "HTTP/1.1", "SPDY/1" };
 					Assert.That (ssl.SetAlpnProtocols (protocols), Is.EqualTo (0), "SetAlpnProtocols");
-#endif
 				}
 			}
 		}
-
-#if MONOMAC
-		[Test]
-		public void ReenableSSLGetSetAlpnProtocols ()
-		{
-			TestRuntime.AssertXcodeVersion (9,0);
-
-			// It seems that apple forgot to ship SSLSetALPNProtocols and SSLCopyALPNProtocols in macOS
-			// there are already radars filled about this https://bugs.swift.org/browse/SR-6131
-			// So this test will fail once Apple fixes this issue. when this happens we need to do two things, reenable
-			// the API and reenable the [Get|Set]AlpnProtocols test above, the one inside 'StreamDefaults' for the mac.
-
-			IntPtr seclib = Dlfcn.dlopen (Constants.SecurityLibrary, 0);
-			Assert.IsTrue (Dlfcn.GetIndirect (seclib, "SSLSetALPNProtocols") == IntPtr.Zero, "Reenable 'SetAlpnProtocols' inside src/Security/SslContext.cs and remove this test.");
-			Assert.IsTrue (Dlfcn.GetIndirect (seclib, "SSLCopyALPNProtocols") == IntPtr.Zero, "Reenable 'GetAlpnProtocols' inside src/Security/SslContext.cs and remove this test.");
-		}
-#endif
 
 		[Test]
 		public void DatagramDefaults ()

--- a/tests/xtro-sharpie/macOS-Security.ignore
+++ b/tests/xtro-sharpie/macOS-Security.ignore
@@ -1431,7 +1431,6 @@
 !missing-pinvoke! SecVerifyTransformCreate is not bound
 !missing-pinvoke! SessionCreate is not bound
 !missing-pinvoke! SessionGetInfo is not bound
-!missing-pinvoke! SSLCopyALPNProtocols is not bound
 !missing-pinvoke! SSLCopyCertificateAuthorities is not bound
 !missing-pinvoke! SSLCopyPeerCertificates is not bound
 !missing-pinvoke! SSLCopyTrustedRoots is not bound
@@ -1448,7 +1447,6 @@
 !missing-pinvoke! SSLSetAllowsAnyRoot is not bound
 !missing-pinvoke! SSLSetAllowsExpiredCerts is not bound
 !missing-pinvoke! SSLSetAllowsExpiredRoots is not bound
-!missing-pinvoke! SSLSetALPNProtocols is not bound
 !missing-pinvoke! SSLSetCertificateAuthorities is not bound
 !missing-pinvoke! SSLSetDiffieHellmanParams is not bound
 !missing-pinvoke! SSLSetEnableCertVerify is not bound


### PR DESCRIPTION
This was fixed in macOS 10.13.4
    
https://github.com/xamarin/xamarin-macios/issues/4001