### PR TITLE
Add xcode9.4 support into 15.7

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -56,8 +56,8 @@ IOS_PACKAGE_VERSION_BUILD=$(IOS_COMMIT_DISTANCE)
 IOS_PACKAGE_UPDATE_ID=$(shell printf "2%02d%02d%02d%03d" $(IOS_PACKAGE_VERSION_MAJOR) $(IOS_PACKAGE_VERSION_MINOR) $(IOS_PACKAGE_VERSION_REV) $(IOS_PACKAGE_VERSION_BUILD))
 
 XCODE_VERSION=9.4
-XCODE_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_9.4_beta2.xip
-XCODE_DEVELOPER_ROOT=/Applications/Xcode94-beta2.app/Contents/Developer
+XCODE_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_9.4.xip
+XCODE_DEVELOPER_ROOT=/Applications/Xcode94.app/Contents/Developer
 
 # Minimum Mono version
 MIN_MONO_VERSION=5.10.0.0

--- a/Make.config
+++ b/Make.config
@@ -42,22 +42,22 @@ endif
 
 # TODO: reset to 0 after major/minor version bump (SRO) and increment for service releases and previews
 # Note: if not reseted to 0 we can skip a version and start with .1 or .2
-PACKAGE_VERSION_REV=1
+PACKAGE_VERSION_REV=0
 
 IOS_PRODUCT=Xamarin.iOS
 IOS_PACKAGE_NAME=Xamarin.iOS
 IOS_PACKAGE_NAME_LOWER=$(shell echo $(IOS_PACKAGE_NAME) | tr "[:upper:]" "[:lower:]")
 # NEVER customize IOS_PACKAGE_VERSION itself, other parts (mtouch, web updater) are using the IOS_PACKAGE_VERSION_* variables
-IOS_PACKAGE_VERSION=11.10.$(PACKAGE_VERSION_REV).$(IOS_COMMIT_DISTANCE)
+IOS_PACKAGE_VERSION=11.12.$(PACKAGE_VERSION_REV).$(IOS_COMMIT_DISTANCE)
 IOS_PACKAGE_VERSION_MAJOR=$(word 1, $(subst ., ,$(IOS_PACKAGE_VERSION)))
 IOS_PACKAGE_VERSION_MINOR=$(word 2, $(subst ., ,$(IOS_PACKAGE_VERSION)))
 IOS_PACKAGE_VERSION_REV=$(PACKAGE_VERSION_REV)
 IOS_PACKAGE_VERSION_BUILD=$(IOS_COMMIT_DISTANCE)
 IOS_PACKAGE_UPDATE_ID=$(shell printf "2%02d%02d%02d%03d" $(IOS_PACKAGE_VERSION_MAJOR) $(IOS_PACKAGE_VERSION_MINOR) $(IOS_PACKAGE_VERSION_REV) $(IOS_PACKAGE_VERSION_BUILD))
 
-XCODE_VERSION=9.3
-XCODE_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_9.3.xip
-XCODE_DEVELOPER_ROOT=/Applications/Xcode93.app/Contents/Developer
+XCODE_VERSION=9.4
+XCODE_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_9.4_beta2.xip
+XCODE_DEVELOPER_ROOT=/Applications/Xcode94-beta2.app/Contents/Developer
 
 # Minimum Mono version
 MIN_MONO_VERSION=5.10.0.0
@@ -83,10 +83,10 @@ MIN_OSX_BUILD_VERSION=10.12
 MIN_OSX_VERSION_FOR_IOS=10.11
 MIN_OSX_VERSION_FOR_MAC=10.11
 
-IOS_SDK_VERSION=11.3
+IOS_SDK_VERSION=11.4
 OSX_SDK_VERSION=10.13
 WATCH_SDK_VERSION=4.3
-TVOS_SDK_VERSION=11.3
+TVOS_SDK_VERSION=11.4
 
 MIN_IOS_SDK_VERSION=6.0
 MIN_OSX_SDK_VERSION=10.7

--- a/Make.config
+++ b/Make.config
@@ -42,16 +42,16 @@ endif
 
 # TODO: reset to 0 after major/minor version bump (SRO) and increment for service releases and previews
 # Note: if not reseted to 0 we can skip a version and start with .1 or .2
-PACKAGE_VERSION_REV=0
+PACKAGE_VERSION_REV=1
+IOS_PACKAGE_VERSION_REV=0
 
 IOS_PRODUCT=Xamarin.iOS
 IOS_PACKAGE_NAME=Xamarin.iOS
 IOS_PACKAGE_NAME_LOWER=$(shell echo $(IOS_PACKAGE_NAME) | tr "[:upper:]" "[:lower:]")
 # NEVER customize IOS_PACKAGE_VERSION itself, other parts (mtouch, web updater) are using the IOS_PACKAGE_VERSION_* variables
-IOS_PACKAGE_VERSION=11.12.$(PACKAGE_VERSION_REV).$(IOS_COMMIT_DISTANCE)
+IOS_PACKAGE_VERSION=11.12.$(IOS_PACKAGE_VERSION_REV).$(IOS_COMMIT_DISTANCE)
 IOS_PACKAGE_VERSION_MAJOR=$(word 1, $(subst ., ,$(IOS_PACKAGE_VERSION)))
 IOS_PACKAGE_VERSION_MINOR=$(word 2, $(subst ., ,$(IOS_PACKAGE_VERSION)))
-IOS_PACKAGE_VERSION_REV=$(PACKAGE_VERSION_REV)
 IOS_PACKAGE_VERSION_BUILD=$(IOS_COMMIT_DISTANCE)
 IOS_PACKAGE_UPDATE_ID=$(shell printf "2%02d%02d%02d%03d" $(IOS_PACKAGE_VERSION_MAJOR) $(IOS_PACKAGE_VERSION_MINOR) $(IOS_PACKAGE_VERSION_REV) $(IOS_PACKAGE_VERSION_BUILD))
 

--- a/Versions-ios.plist.in
+++ b/Versions-ios.plist.in
@@ -29,6 +29,7 @@
 			<string>11.1</string>
 			<string>11.2</string>
 			<string>11.3</string>
+			<string>11.4</string>
 		</array>
 		<key>tvOS</key>
 		<array>
@@ -42,6 +43,7 @@
 			<string>11.1</string>
 			<string>11.2</string>
 			<string>11.3</string>
+			<string>11.4</string>
 		</array>
 		<key>watchOS</key>
 		<array>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeCompilerToolTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeCompilerToolTask.cs
@@ -191,7 +191,7 @@ namespace Xamarin.MacDev.Tasks
 						var plist = PDictionary.FromFile (manifest.ItemSpec);
 
 						LogWarningsAndErrors (plist, items[0]);
-					} catch (FormatException) {
+					} catch {
 					}
 
 					File.Delete (manifest.ItemSpec);

--- a/src/ClassKit/CLSContext.cs
+++ b/src/ClassKit/CLSContext.cs
@@ -1,0 +1,24 @@
+﻿//
+// CLSContext.cs
+//
+// Authors:
+//	Alex Soto  <alexsoto@microsoft.com>
+//
+// Copyright 2018 Xamarin Inc. All rights reserved.
+//
+
+#if XAMCORE_2_0
+using System;
+using XamCore.Foundation;
+using XamCore.ObjCRuntime;
+
+namespace XamCore.ClassKit {
+	public partial class CLSContext {
+
+		public CLSContextTopic Topic {
+			get => CLSContextTopicExtensions.GetValue (WeakTopic);
+			set => WeakTopic = value.GetConstant ();
+		}
+	}
+}
+#endif

--- a/src/ClassKit/CLSContext.cs
+++ b/src/ClassKit/CLSContext.cs
@@ -9,10 +9,10 @@
 
 #if XAMCORE_2_0
 using System;
-using XamCore.Foundation;
-using XamCore.ObjCRuntime;
+using Foundation;
+using ObjCRuntime;
 
-namespace XamCore.ClassKit {
+namespace ClassKit {
 	public partial class CLSContext {
 
 		public CLSContextTopic Topic {

--- a/src/Constants.iOS.cs.in
+++ b/src/Constants.iOS.cs.in
@@ -119,5 +119,7 @@ namespace MonoTouch {
 		public const string PdfKitLibrary = "/System/Library/Frameworks/PDFKit.framework/PDFKit";
 		// iOS 11.3
 		public const string BusinessChatLibrary = "/System/Library/Frameworks/BusinessChat.framework/BusinessChat";
+		// iOS 11.4
+		public const string ClassKitLibrary = "/System/Library/Frameworks/ClassKit.framework/ClassKit";
 	}
 }

--- a/src/classkit.cs
+++ b/src/classkit.cs
@@ -9,15 +9,15 @@
 
 #if XAMCORE_2_0
 using System;
-using XamCore.Foundation;
-using XamCore.ObjCRuntime;
+using Foundation;
+using ObjCRuntime;
 using System.Reflection;
 
-namespace XamCore.ClassKit {
+namespace ClassKit {
 
 	[NoWatch, NoTV, NoMac, iOS (11,4)]
 	[Native]
-	enum CLSBinaryValueType : nint {
+	enum CLSBinaryValueType : long {
 		TrueFalse = 0,
 		PassFail,
 		YesNo,
@@ -25,7 +25,7 @@ namespace XamCore.ClassKit {
 
 	[NoWatch, NoTV, NoMac, iOS (11,4)]
 	[Native]
-	enum CLSContextType : nint {
+	enum CLSContextType : long {
 		None = 0,
 		App,
 		Chapter,
@@ -47,7 +47,7 @@ namespace XamCore.ClassKit {
 	[NoWatch, NoTV, NoMac, iOS (11,4)]
 	[Native]
 	[ErrorDomain ("CLSErrorCodeDomain")]
-	public enum CLSErrorCode : nint {
+	public enum CLSErrorCode : long {
 		None = 0,
 		ClassKitUnavailable,
 		InvalidArgument,

--- a/src/classkit.cs
+++ b/src/classkit.cs
@@ -1,0 +1,336 @@
+//
+// ClassKit bindings
+//
+// Authors:
+//	Alex Soto  <alexsoto@microsoft.com>
+//
+// Copyright 2018 Xamarin Inc. All rights reserved.
+//
+
+#if XAMCORE_2_0
+using System;
+using XamCore.Foundation;
+using XamCore.ObjCRuntime;
+using System.Reflection;
+
+namespace XamCore.ClassKit {
+
+	[NoWatch, NoTV, NoMac, iOS (11,4)]
+	[Native]
+	enum CLSBinaryValueType : nint {
+		TrueFalse = 0,
+		PassFail,
+		YesNo,
+	}
+
+	[NoWatch, NoTV, NoMac, iOS (11,4)]
+	[Native]
+	enum CLSContextType : nint {
+		None = 0,
+		App,
+		Chapter,
+		Section,
+		Level,
+		Page,
+		Task,
+		Challenge,
+		Quiz,
+		Exercise,
+		Lesson,
+		Book,
+		Game,
+		Document,
+		Audio,
+		Video,
+	}
+
+	[NoWatch, NoTV, NoMac, iOS (11,4)]
+	[Native]
+	[ErrorDomain ("CLSErrorCodeDomain")]
+	public enum CLSErrorCode : nint {
+		None = 0,
+		ClassKitUnavailable,
+		InvalidArgument,
+		InvalidModification,
+		AuthorizationDenied,
+		DatabaseInaccessible,
+		Limits,
+		InvalidCreate,
+		InvalidUpdate,
+		PartialFailure,
+	}
+
+	[NoWatch, NoTV, NoMac, iOS (11,4)]
+	enum CLSContextTopic {
+		[Field ("CLSContextTopicMath")]
+		Math,
+		[Field ("CLSContextTopicScience")]
+		Science,
+		[Field ("CLSContextTopicLiteracyAndWriting")]
+		LiteracyAndWriting,
+		[Field ("CLSContextTopicWorldLanguage")]
+		WorldLanguage,
+		[Field ("CLSContextTopicSocialScience")]
+		SocialScience,
+		[Field ("CLSContextTopicComputerScienceAndEngineering")]
+		ComputerScienceAndEngineering,
+		[Field ("CLSContextTopicArtsAndMusic")]
+		ArtsAndMusic,
+		[Field ("CLSContextTopicHealthAndFitness")]
+		HealthAndFitness,
+	}
+
+	[NoWatch, NoTV, NoMac, iOS (11,4)]
+	[Static]
+	interface CLSErrorUserInfoKeys {
+
+		[Field ("CLSErrorObjectKey")]
+		NSString ObjectKey { get; }
+
+		[Field ("CLSErrorUnderlyingErrorsKey")]
+		NSString UnderlyingErrorsKey { get; }
+	}
+
+	[NoWatch, NoTV, NoMac, iOS (11,4)]
+	[Static]
+	interface CLSPredicateKeyPath {
+		[Field ("CLSPredicateKeyPathDateCreated")]
+		NSString DateCreated { get; }
+
+		[Field ("CLSPredicateKeyPathIdentifier")]
+		NSString Identifier { get; }
+
+		[Field ("CLSPredicateKeyPathTitle")]
+		NSString Title { get; }
+
+		[Field ("CLSPredicateKeyPathUniversalLinkURL")]
+		NSString UniversalLinkUrl { get; }
+
+		[Field ("CLSPredicateKeyPathTopic")]
+		NSString Topic { get; }
+
+		[Field ("CLSPredicateKeyPathParent")]
+		NSString Parent { get; }
+	}
+
+	[NoWatch, NoTV, NoMac, iOS (11,4)]
+	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor]
+	interface CLSObject : NSSecureCoding {
+
+		[Export ("dateCreated", ArgumentSemantic.Strong)]
+		NSDate DateCreated { get; }
+
+		[Export ("dateLastModified", ArgumentSemantic.Strong)]
+		NSDate DateLastModified { get; }
+	}
+
+	[NoWatch, NoTV, NoMac, iOS (11,4)]
+	[BaseType (typeof (CLSObject))]
+	[DisableDefaultCtor]
+	interface CLSActivity {
+
+		[Export ("progress")]
+		double Progress { get; set; }
+
+		[Export ("duration")]
+		double Duration { get; }
+
+		[Export ("primaryActivityItem", ArgumentSemantic.Strong)]
+		CLSActivityItem PrimaryActivityItem { get; set; }
+
+		[Export ("addProgressRangeFromStart:toEnd:")]
+		void AddProgressRange (double start, double end);
+
+		[Export ("addAdditionalActivityItem:")]
+		void AddAdditionalActivityItem (CLSActivityItem activityItem);
+
+		[Export ("additionalActivityItems", ArgumentSemantic.Strong)]
+		CLSActivityItem [] AdditionalActivityItems { get; }
+
+		// From CLSActivity (Activation) Category
+
+		[Export ("started")]
+		bool Started { [Bind ("isStarted")] get; }
+
+		[Export ("start")]
+		void Start ();
+
+		[Export ("stop")]
+		void Stop ();
+	}
+
+	[NoWatch, NoTV, NoMac, iOS (11,4)]
+	[BaseType (typeof (CLSObject))]
+	[DisableDefaultCtor]
+	interface CLSActivityItem {
+
+		[Export ("title")]
+		string Title { get; set; }
+
+		[Export ("identifier")]
+		string Identifier { get; }
+	}
+
+	[NoWatch, NoTV, NoMac, iOS (11,4)]
+	[BaseType (typeof (CLSActivityItem))]
+	[DisableDefaultCtor]
+	interface CLSBinaryItem {
+
+		[Export ("value")]
+		bool Value { get; set; }
+
+		[Export ("valueType", ArgumentSemantic.Assign)]
+		CLSBinaryValueType ValueType { get; }
+
+		[Export ("initWithIdentifier:title:type:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (string identifier, string title, CLSBinaryValueType valueType);
+	}
+
+	[NoWatch, NoTV, NoMac, iOS (11,4)]
+	[BaseType (typeof (CLSObject))]
+	[DisableDefaultCtor]
+	interface CLSContext {
+
+		[Export ("identifier")]
+		string Identifier { get; }
+
+		[NullAllowed, Export ("universalLinkURL", ArgumentSemantic.Strong)]
+		NSUrl UniversalLinkUrl { get; set; }
+
+		[Export ("type", ArgumentSemantic.Assign)]
+		CLSContextType Type { get; }
+
+		[Export ("title")]
+		string Title { get; set; }
+
+		[Export ("displayOrder")]
+		nint DisplayOrder { get; set; }
+
+		[Protected]
+		[NullAllowed, Export ("topic")]
+		NSString WeakTopic { get; set; }
+
+		[Export ("initWithType:identifier:title:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (CLSContextType type, string identifier, string title);
+
+		[Export ("active")]
+		bool Active { [Bind ("isActive")] get; }
+
+		[Export ("becomeActive")]
+		void BecomeActive ();
+
+		[Export ("resignActive")]
+		void ResignActive ();
+
+		// From CLSContext (Hierarchy) Category
+
+		[NullAllowed, Export ("parent")]
+		CLSContext Parent { get; }
+
+		[Export ("removeFromParent")]
+		void RemoveFromParent ();
+
+		[Export ("addChildContext:")]
+		void AddChild (CLSContext childContext);
+
+		[Async]
+		[Export ("descendantMatchingIdentifierPath:completion:")]
+		void FindDescendantMatching (string [] identifierPath, Action<CLSContext, NSError> completion);
+
+		// From CLSContext (Activity) Category
+
+		[NullAllowed, Export ("currentActivity", ArgumentSemantic.Strong)]
+		CLSActivity CurrentActivity { get; }
+
+		[Export ("createNewActivity")]
+		CLSActivity CreateNewActivity ();
+	}
+
+	interface ICLSDataStoreDelegate { }
+
+	[NoWatch, NoTV, NoMac, iOS (11,4)]
+	[Protocol, Model]
+	[BaseType (typeof (NSObject))]
+	interface CLSDataStoreDelegate {
+
+		[Abstract]
+		[Export ("createContextForIdentifier:parentContext:parentIdentifierPath:")]
+		CLSContext CreateContext (string identifier, CLSContext parentContext, string [] parentIdentifierPath);
+	}
+
+	[NoWatch, NoTV, NoMac, iOS (11,4)]
+	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor]
+	interface CLSDataStore {
+
+		[Static]
+		[Export ("shared", ArgumentSemantic.Strong)]
+		CLSDataStore Shared { get; }
+
+		[Export ("mainAppContext", ArgumentSemantic.Strong)]
+		CLSContext MainAppContext { get; }
+
+		[NullAllowed, Export ("activeContext", ArgumentSemantic.Strong)]
+		CLSContext ActiveContext { get; }
+
+		[NullAllowed, Export ("runningActivity", ArgumentSemantic.Strong)]
+		CLSActivity RunningActivity { get; }
+
+		[Wrap ("WeakDelegate"), Protocolize]
+		[NullAllowed]
+		CLSDataStoreDelegate Delegate { get; set; }
+
+		[NullAllowed, Export ("delegate", ArgumentSemantic.Weak)]
+		NSObject WeakDelegate { get; set; }
+
+		[Async]
+		[Export ("saveWithCompletion:")]
+		void Save ([NullAllowed] Action<NSError> completion);
+
+		// From CLSDataStore (Contexts) Category
+
+		[Async]
+		[Export ("contextsMatchingPredicate:completion:")]
+		void FindContextsMatching (NSPredicate predicate, Action<CLSContext [], NSError> completion);
+
+		[Async]
+		[Export ("contextsMatchingIdentifierPath:completion:")]
+		void FindContextsMatching (string [] identifierPath, Action<CLSContext [], NSError> completion);
+
+		[Export ("removeContext:")]
+		void Remove (CLSContext context);
+	}
+
+	[NoWatch, NoTV, NoMac, iOS (11,4)]
+	[BaseType (typeof (CLSActivityItem))]
+	[DisableDefaultCtor]
+	interface CLSQuantityItem {
+
+		[Export ("quantity")]
+		double Quantity { get; set; }
+
+		[Export ("initWithIdentifier:title:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (string identifier, string title);
+	}
+
+	[NoWatch, NoTV, NoMac, iOS (11,4)]
+	[BaseType (typeof (CLSActivityItem))]
+	[DisableDefaultCtor]
+	interface CLSScoreItem {
+
+		[Export ("score")]
+		double Score { get; set; }
+
+		[Export ("maxScore")]
+		double MaxScore { get; set; }
+
+		[Export ("initWithIdentifier:title:score:maxScore:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (string identifier, string title, double score, double maxScore);
+	}
+}
+#endif

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -5115,6 +5115,16 @@ namespace Foundation
 		[TV (11,3), Mac (10,13,4, onlyOn64: true), iOS (11,3), NoWatch]
 		[NullAllowed, Export ("detectedBarcodeDescriptor", ArgumentSemantic.Copy)]
 		CIBarcodeDescriptor DetectedBarcodeDescriptor { get; }
+
+		// From NSUserActivity (CLSDeepLinks)
+
+		[NoWatch, NoTV, NoMac, iOS (11,4)]
+		[Export ("isClassKitDeepLink")]
+		bool IsClassKitDeepLink { get; }
+
+		[NoWatch, NoTV, NoMac, iOS (11,4)]
+		[NullAllowed, Export ("contextIdentifierPath", ArgumentSemantic.Strong)]
+		string[] ContextIdentifierPath { get; }
 	}
 
 	[iOS (8,0)][Mac (10,10, onlyOn64 : true)] // same as NSUserActivity

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -294,6 +294,11 @@ BUSINESSCHAT_SOURCES = \
 CALLKIT_SOURCES = \
 	CallKit/CXProvider.cs \
 
+# ClassKit
+
+CLASSKIT_SOURCES = \
+	ClassKit/CLSContext.cs \
+
 # ClockKit
 
 CLOCKKIT_CORE_SOURCES = \
@@ -1710,6 +1715,7 @@ IOS_FRAMEWORKS =         \
 	BusinessChat \
 	CallKit \
 	CFNetwork \
+	ClassKit \
 	CloudKit \
 	Contacts \
 	ContactsUI \

--- a/tests/introspection/iOS/iOSApiWeakPropertyTest.cs
+++ b/tests/introspection/iOS/iOSApiWeakPropertyTest.cs
@@ -42,6 +42,9 @@ namespace Introspection {
 			// VNImageOptions is a DictionaryContainer that exposes a Weak* NSDictionary
 			case "VNImageOptions":
 				return property.Name == "WeakProperties";
+			// NSString manually bound as smart enum CLSContextTopic
+			case "CLSContext":
+				return property.Name == "WeakTopic";
 #if !XAMCORE_3_0
 			// #37451 - setter does not exists but we have to keep it for binary compatibility
 			// OTOH we can't give it a selector (private API) even if we suspect Apple is mostly running `strings` on executable

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -261,6 +261,8 @@ public class Frameworks : Dictionary <string, Framework>
 				{ "PdfKit", "PDFKit", 11 },
 
 				{ "BusinessChat", "BusinessChat", 11, 3 },
+
+				{ "ClassKit", "ClassKit", 11,4 },
 			};
 		}
 		return ios_frameworks;

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -300,7 +300,8 @@ SIMLAUNCHER_FRAMEWORKS =  \
 	-weak_framework FileProviderUI			\
 						\
 	-weak_framework IdentityLookup			\
-	-weak_framework BusinessChat
+	-weak_framework BusinessChat			\
+	-weak_framework ClassKit
 
 # note: there _was_ no CoreAudioKit.framework or Metal.framework for the simulator (before recent iOS9 betas)
 # note 2: there's no GameKit, in iOS 9 (beta 3 at least), you're supposed to reference GameCenter instead (looks fixed in beta 4)


### PR DESCRIPTION
The PR is not final and cannot be merged until the final Xcode 9.4
release from Apple is available.
    
Since there's no macOS specific changes (at least up to beta 2) we can
directly merge into the _normal_ milestone branch and avoid having
separate branches to maintain for XI and XM (until 15.8).