### PR TITLE
[mtouch] Take into account the contents of response files when determining whether the cache is valid or not. Fixes #4033.

### DIFF
--- a/tests/common/BundlerTest.cs
+++ b/tests/common/BundlerTest.cs
@@ -21,11 +21,11 @@ namespace Xamarin
 	[TestFixture]
 	public class BundlerTests
 	{
-		[Test]
 #if __MACOS__
 		// The cache doesn't work properly in mmp yet.
 		// [TestCase (Profile.macOSMobile)]
 #else
+		[Test]
 		[TestCase (Profile.iOS)]
 #endif
 		public void ModifiedResponseFile (Profile profile)

--- a/tests/common/BundlerTest.cs
+++ b/tests/common/BundlerTest.cs
@@ -23,6 +23,37 @@ namespace Xamarin
 	{
 		[Test]
 #if __MACOS__
+		// The cache doesn't work properly in mmp yet.
+		// [TestCase (Profile.macOSMobile)]
+#else
+		[TestCase (Profile.iOS)]
+#endif
+		public void ModifiedResponseFile (Profile profile)
+		{
+			using (var bundler = new BundlerTool ()) {
+				bundler.Profile = profile;
+				bundler.CreateTemporaryCacheDirectory ();
+				bundler.CreateTemporaryApp (profile);
+				var tmpDir = bundler.CreateTemporaryDirectory ();
+				var responseFile = Path.Combine (tmpDir, "test-arguments.txt");
+				File.WriteAllText (responseFile, "");
+				bundler.ResponseFile = responseFile;
+				bundler.Linker = LinkerOption.DontLink; // faster test
+				bundler.Debug = true; // faster test
+				bundler.Verbosity = 4;
+				bundler.AssertExecute ();
+				bundler.AssertWarningCount (0);
+				bundler.AssertOutputPattern ("A full rebuild will be performed because the cache is either incomplete or entirely missing.");
+
+				File.WriteAllText (responseFile, "/linksdkonly");
+				bundler.AssertExecute ();
+				bundler.AssertWarningCount (0);
+				bundler.AssertOutputPattern ("A full rebuild has been forced because the cache for .* is not valid.");
+			}
+		}
+
+		[Test]
+#if __MACOS__
 		[TestCase (Profile.macOSMobile)]
 #else
 		[TestCase (Profile.iOS)]

--- a/tools/common/cache.cs
+++ b/tools/common/cache.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Xamarin.Utils;
 using Xamarin.Bundler;
@@ -192,9 +193,17 @@ public class Cache {
 		if (args.Count > 0)
 			sb.Append ("# [first argument, ignore] # ").AppendLine (args [0]);
 		sb.Append (Driver.GetFullPath ()).AppendLine (" \\");
-		for (int i = 1; i < args.Count; i++) {
-			switch (args [i]) {
+		CollectArgumentsForCache (args, 1, sb);
+		return sb.ToString ();
+	}
+
+	void CollectArgumentsForCache (IList<string> args, int firstArgument, StringBuilder sb)
+	{
+		for (int i = firstArgument; i < args.Count; i++) {
+			var arg = args [i];
+			switch (arg) {
 			// Remove arguments that don't affect the cache status.
+			case "":
 			case "/v":
 			case "-v":
 			case "--v":
@@ -206,11 +215,13 @@ public class Cache {
 			case "--time":
 				break;
 			default:
-				sb.Append ('\t').Append (StringUtils.Quote (args [i])).AppendLine (" \\");
+				if (arg [0] == '@')
+					CollectArgumentsForCache (File.ReadAllLines (arg.Substring (1)), 0, sb);
+				
+				sb.Append ('\t').Append (StringUtils.Quote (arg)).AppendLine (" \\");
 				break;
 			}
 		}
-		return sb.ToString ();
 	}
 
 	public bool IsCacheValid ()


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/4033.