### PR TITLE
[coretext] Enable CTFont tests on watchOS and macOS. Fixes #3925

### DIFF
--- a/src/CoreGraphics/CGFont.cs
+++ b/src/CoreGraphics/CGFont.cs
@@ -32,9 +32,7 @@ using ObjCRuntime;
 using Foundation;
 using CoreFoundation;
 
-#if !MONOMAC && !WATCH
 using CoreText;
-#endif
 
 namespace CoreGraphics {
 
@@ -277,8 +275,6 @@ namespace CoreGraphics {
 		// CFStringRef kCGFontVariationAxisMaxValue;
 		// CFStringRef kCGFontVariationAxisDefaultValue;
 
-#if !WATCH
-#if !MONOMAC
 		[DllImport (Constants.CoreTextLibrary)]
 		unsafe static extern /* CTFontRef */ IntPtr CTFontCreateWithGraphicsFont (/* CGFontRef */ IntPtr graphicsFont, /* CGFloat */ nfloat size, CGAffineTransform *matrix, /* CTFontDescriptorRef */ IntPtr attributes);
 
@@ -300,13 +296,10 @@ namespace CoreGraphics {
 		{
 			return new CTFont (CTFontCreateWithGraphicsFont (handle, size, &matrix, IntPtr.Zero), true);
 		}
-#endif // !MONOMAC
 	
 #if TODO
 		ToCTFont() overloads where attributes is CTFontDescriptorRef
 #endif // TODO
-
-#endif // !WATCH
 
 		[DllImport (Constants.CoreTextLibrary, EntryPoint="CGFontGetTypeID")]
 		public extern static /* CFTypeID */ nint GetTypeID ();

--- a/tests/monotouch-test/CoreText/CTFrameTests.cs
+++ b/tests/monotouch-test/CoreText/CTFrameTests.cs
@@ -7,8 +7,6 @@
 // Copyright 2012 Xamarin Inc. All rights reserved.
 //
 
-#if !__WATCHOS__
-
 using System;
 #if XAMCORE_2_0
 using Foundation;
@@ -42,5 +40,3 @@ namespace MonoTouchFixtures.CoreText {
 		}
 	}
 }
-
-#endif // !__WATCHOS__

--- a/tests/monotouch-test/CoreText/CTLineTest.cs
+++ b/tests/monotouch-test/CoreText/CTLineTest.cs
@@ -7,8 +7,6 @@
 // Copyright 2012 Xamarin Inc. All rights reserved.
 //
 
-#if !__WATCHOS__
-
 using System;
 #if XAMCORE_2_0
 using Foundation;
@@ -51,7 +49,7 @@ namespace MonoTouchFixtures.CoreText
 		{
 			if (!TestRuntime.CheckXcodeVersion (7, 0))
 				Assert.Ignore ("Requires iOS9+ or macOS 10.11+");
-
+			
 			var sa = new CTStringAttributes ();
 			sa.ForegroundColor = UIColor.Blue.CGColor;
 			sa.Font = new CTFont ("Georgia-BoldItalic", 24);
@@ -83,5 +81,3 @@ namespace MonoTouchFixtures.CoreText
 		}
 	}
 }
-
-#endif // !__WATCHOS__

--- a/tests/monotouch-test/CoreText/CTParagraphStyleTests.cs
+++ b/tests/monotouch-test/CoreText/CTParagraphStyleTests.cs
@@ -7,8 +7,6 @@
 // Copyright 2017 Xamarin Inc. All rights reserved.
 //
 
-#if !__WATCHOS__
-
 using System;
 using NUnit.Framework;
 using System.Linq;
@@ -85,4 +83,3 @@ namespace MonoTouchFixtures.CoreText {
 		}
 	}
 }
-#endif

--- a/tests/monotouch-test/CoreText/FontDescriptorTest.cs
+++ b/tests/monotouch-test/CoreText/FontDescriptorTest.cs
@@ -7,8 +7,6 @@
 // Copyright 2012 Xamarin Inc. All rights reserved.
 //
 
-#if !__WATCHOS__
-
 using System;
 #if XAMCORE_2_0
 using Foundation;
@@ -90,5 +88,3 @@ namespace MonoTouchFixtures.CoreText {
 		}
 	}
 }
-
-#endif // !__WATCHOS__

--- a/tests/monotouch-test/CoreText/FontDescriptorTest.cs
+++ b/tests/monotouch-test/CoreText/FontDescriptorTest.cs
@@ -60,7 +60,7 @@ namespace MonoTouchFixtures.CoreText {
 			}
 		}
 
-#if __TVOS__
+#if __TVOS__ || __WATCHOS__
 		[Ignore ("No font with ligatures are available on the platform")] // more details in https://bugzilla.xamarin.com/show_bug.cgi?id=58929
 #endif
 		[Test]

--- a/tests/monotouch-test/CoreText/FontManagerTest.cs
+++ b/tests/monotouch-test/CoreText/FontManagerTest.cs
@@ -7,8 +7,6 @@
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
 
-#if !__WATCHOS__
-
 using System;
 using System.IO;
 #if XAMCORE_2_0
@@ -136,5 +134,3 @@ namespace MonoTouchFixtures.CoreText {
 
 	}
 }
-
-#endif // !__WATCHOS__

--- a/tests/monotouch-test/CoreText/FontTest.cs
+++ b/tests/monotouch-test/CoreText/FontTest.cs
@@ -7,8 +7,6 @@
 // Copyright 2015 Xamarin Inc. All rights reserved.
 //
 
-#if !__WATCHOS__
-
 using System;
 #if XAMCORE_2_0
 using CoreGraphics;
@@ -38,7 +36,7 @@ using nuint=global::System.UInt32;
 #endif
 
 namespace MonoTouchFixtures.CoreText {
-
+	
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class A_FontTest {
@@ -99,7 +97,6 @@ namespace MonoTouchFixtures.CoreText {
 			}
 		}
 
-#if !MONOMAC // ToCTFont not available on mac
 		[Test]
 		public void GetGlyphsForCharacters_35048 ()
 		{
@@ -111,8 +108,5 @@ namespace MonoTouchFixtures.CoreText {
 				Assert.That (gid [1], Is.EqualTo (0), "1");
 			}
 		}
-#endif
 	}
 }
-
-#endif // !__WATCHOS__

--- a/tests/monotouch-test/CoreText/StringAttributes.cs
+++ b/tests/monotouch-test/CoreText/StringAttributes.cs
@@ -7,8 +7,6 @@
 // Copyright 2012 Xamarin Inc. All rights reserved.
 //
 
-#if !__WATCHOS__
-
 using System;
 #if XAMCORE_2_0
 using Foundation;
@@ -100,5 +98,3 @@ namespace MonoTouchFixtures.CoreText
 		}
 	}
 }
-
-#endif // !__WATCHOS__

--- a/tests/monotouch-test/CoreText/StringAttributes.cs
+++ b/tests/monotouch-test/CoreText/StringAttributes.cs
@@ -54,16 +54,13 @@ namespace MonoTouchFixtures.CoreText
 			sa.UnderlineColor = UIColor.Blue.CGColor;
 			sa.UnderlineStyleModifiers = CTUnderlineStyleModifiers.PatternDashDotDot;
 
-			// CTBaseline and CTWritingDirection support is new in iOS 6.0 and cause NRE before it
-			if (TestRuntime.CheckSystemAndSDKVersion (6,0)) {
-				Assert.IsNull (sa.BaselineClass, "#0");
-				sa.BaselineClass = CTBaselineClass.IdeographicHigh;
-				Assert.AreEqual (CTBaselineClass.IdeographicHigh, sa.BaselineClass, "#1");
+			Assert.IsNull (sa.BaselineClass, "#0");
+			sa.BaselineClass = CTBaselineClass.IdeographicHigh;
+			Assert.AreEqual (CTBaselineClass.IdeographicHigh, sa.BaselineClass, "#1");
 
-				sa.SetBaselineInfo (CTBaselineClass.Roman, 13);
-				sa.SetBaselineInfo (CTBaselineClass.IdeographicHigh, 3);
-				sa.SetWritingDirection (CTWritingDirection.LeftToRight);
-			}
+			sa.SetBaselineInfo (CTBaselineClass.Roman, 13);
+			sa.SetBaselineInfo (CTBaselineClass.IdeographicHigh, 3);
+			sa.SetWritingDirection (CTWritingDirection.LeftToRight);
 
 			var size = new SizeF (300, 300);
 			UIGraphics.BeginImageContext (size);


### PR DESCRIPTION
CTFontCreateWithGraphicsFont is actually available on macOS and watchOS,
so it's enabled, in CGFont, along with its unit test.

https://github.com/xamarin/xamarin-macios/issues/3925