### PR TITLE
[scenekit] Correctly bind SCNHitTestOptions's SearchMode

### DIFF
--- a/src/SceneKit/SCNCompat.cs
+++ b/src/SceneKit/SCNCompat.cs
@@ -111,4 +111,16 @@ namespace SceneKit {
 		}
 	}
 #endif
+
+#if !XAMCORE_4_0
+	[Watch (3,0)]
+	public partial class SCNHitTestOptions {
+		[Obsolete ("Use 'SearchMode' instead.")]
+		public SCNHitTestSearchMode? OptionSearchMode {
+			get {
+				return (SCNHitTestSearchMode?) GetLongValue (SCNHitTest.SearchModeKey);
+			}
+		}
+	}
+#endif
 }

--- a/src/SceneKit/SCNCompat.cs
+++ b/src/SceneKit/SCNCompat.cs
@@ -118,7 +118,7 @@ namespace SceneKit {
 		[Obsolete ("Use 'SearchMode' instead.")]
 		public SCNHitTestSearchMode? OptionSearchMode {
 			get {
-				return (SCNHitTestSearchMode?) GetLongValue (SCNHitTest.SearchModeKey);
+				return SearchMode;
 			}
 		}
 	}

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -1123,9 +1123,16 @@ namespace SceneKit {
 		[Field ("SCNHitTestOptionCategoryBitMask")]
 		NSString OptionCategoryBitMaskKey { get; }
 
+#if !XAMCORE_4_0
 		[Watch (4, 0), TV (11, 0), Mac (10, 13, onlyOn64: true), iOS (11, 0)]
+		[Obsolete ("Use 'SearchModeKey' instead.")]
 		[Field ("SCNHitTestOptionSearchMode")]
 		NSString OptionSearchModeKey { get; }
+#endif
+
+		[Watch (4,0), TV (11,0), Mac (10,13, onlyOn64: true), iOS (11,0)]
+		[Field ("SCNHitTestOptionSearchMode")]
+		NSString SearchModeKey { get; }
 	}
 	
 	[Watch (3,0)]
@@ -1615,7 +1622,7 @@ namespace SceneKit {
 		bool IgnoreChildNodes { get; set; }
 		bool IgnoreHiddenNodes { get; set; }
 		SCNNode RootNode { get; set; }
-		SCNHitTestSearchMode OptionSearchMode { get; }
+		SCNHitTestSearchMode SearchMode { get; set; }
 	}
 
 	[Watch (3,0)]


### PR DESCRIPTION
- Fixes #4031: SCNHitTestOptions SearchMode bound incorrectly
(https://github.com/xamarin/xamarin-macios/issues/4031)