### PR TITLE
[mk] Put shell code in shell scripts and add support for switching between different remotes for dependencies.

### DIFF
--- a/mk/xamarin-reset.sh
+++ b/mk/xamarin-reset.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+
+DEPENDENCY_NAME="$1"
+
+# Calculate the remote from the format: git@github.com:<remote>/<repo>.git
+DEPENDENCY_REMOTE=${DEPENDENCY_MODULE/git@github.com:/}
+DEPENDENCY_REMOTE=${DEPENDENCY_REMOTE%%/*}
+
+if test -d "$DEPENDENCY_PATH"; then
+	cd "$DEPENDENCY_PATH"
+	# Check if we have the remote we need
+	if ! git config "remote.$DEPENDENCY_REMOTE.url" > /dev/null; then
+		echo "*** [$DEPENDENCY_NAME] git remote add -f '$DEPENDENCY_REMOTE' '$DEPENDENCY_MODULE'"
+		git remote add -f "$DEPENDENCY_REMOTE" "$DEPENDENCY_MODULE"
+	fi
+
+	# Check if we have the hash we need
+	if ! git log -1 --pretty=%H "$DEPENDENCY_HASH" > /dev/null 2>&1; then
+		echo "*** [$DEPENDENCY_NAME] git fetch $DEPENDENCY_REMOTE"
+		git fetch "$DEPENDENCY_REMOTE"
+	fi
+else
+	echo "*** [$DEPENDENCY_NAME] git clone $DEPENDENCY_MODULE --recursive $DEPENDENCY_DIRECTORY -b $DEPENDENCY_BRANCH --origin $DEPENDENCY_REMOTE"
+	mkdir -p "$(dirname "$DEPENDENCY_PATH")"
+	cd "$(dirname "$DEPENDENCY_PATH")"
+	git clone "$DEPENDENCY_MODULE" --recursive "$DEPENDENCY_DIRECTORY" -b "$DEPENDENCY_BRANCH" --origin "$DEPENDENCY_REMOTE"
+	cd "$DEPENDENCY_DIRECTORY"
+fi
+
+if ! git log -1 --pretty=%H "$DEPENDENCY_HASH" > /dev/null 2>&1; then
+	echo "The hash $DEPENDENCY_HASH does not exist in $DEPENDENCY_MODULE. Please verify that you pushed your changes."
+	exit 1
+fi
+
+if test -z "$DEPENDENCY_IGNORE_VERSION"; then
+	if git rev-parse --verify "$DEPENDENCY_BRANCH" >/dev/null 2>&1; then
+		# branch already exists
+		echo "*** [$DEPENDENCY_NAME] git checkout -f $DEPENDENCY_BRANCH"
+		git checkout -f "$DEPENDENCY_BRANCH"
+	else
+		# branch does not exist
+		echo "*** [$DEPENDENCY_NAME] git checkout -f -b $DEPENDENCY_BRANCH $DEPENDENCY_REMOTE/$DEPENDENCY_BRANCH"
+		git checkout -f -b "$DEPENDENCY_BRANCH" "$DEPENDENCY_REMOTE/$DEPENDENCY_BRANCH"
+	fi
+	echo "*** [$DEPENDENCY_NAME] git reset --hard $DEPENDENCY_HASH"
+	git reset --hard "$DEPENDENCY_HASH"
+fi
+
+echo "*** [$DEPENDENCY_NAME] git submodule update --init --recursive"
+git submodule update --init --recursive
+

--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -6,9 +6,6 @@ MACCORE_DIRECTORY := maccore
 MACCORE_MODULE    := git@github.com:xamarin/maccore.git
 MACCORE_VERSION   := $(shell cd $(MACCORE_PATH) 2> /dev/null && git rev-parse HEAD 2> /dev/null)
 MACCORE_BRANCH    := $(shell cd $(MACCORE_PATH) 2> /dev/null && git symbolic-ref --short HEAD 2> /dev/null)
-MACCORE_REMOTE    := origin
-MACCORE_BRANCH_AND_REMOTE := $(NEEDED_MACCORE_BRANCH) $(MACCORE_REMOTE)/$(NEEDED_MACCORE_BRANCH)
-NEEDED_MACCORE_REMOTE := $(MACCORE_REMOTE)
 
 define CheckVersionTemplate
 check-$(1)::
@@ -52,27 +49,19 @@ test-$(1)::
 	@echo "   $(2)_MODULE=$($(2)_MODULE)"
 	@echo "   NEEDED_$(2)_VERSION=$(NEEDED_$(2)_VERSION)"
 	@echo "   $(2)_VERSION=$($(2)_VERSION)"
-	@echo "   $(2)_BRANCH_AND_REMOTE=$($(2)_BRANCH_AND_REMOTE)"
 	@echo "   NEEDED_$(2)_BRANCH=$(NEEDED_$(2)_BRANCH)"
-	@echo "   NEEDED_$(2)_REMOTE=$(NEEDED_$(2)_REMOTE)"
 	@echo "   $(2)_BRANCH=$($(2)_BRANCH)"
 	@echo "   $(2)_PATH=$($(2)_PATH) => $(abspath $($(2)_PATH))"
 
 reset-$(1)::
-	@if test -d $($(2)_PATH); then \
-		if ! (cd $($(2)_PATH) && git show $(NEEDED_$(2)_VERSION) >/dev/null 2>&1 && git log -1 $(NEEDED_$(2)_REMOTE) >/dev/null 2>&1) ; then \
-			echo "*** git fetch `basename $$($(2)_PATH)`" && (cd $($(2)_PATH) && git fetch); \
-		fi;  \
-	else \
-		echo "*** git clone $($(2)_MODULE) --recursive $($(2)_DIRECTORY) -b $(NEEDED_$(2)_BRANCH)"; \
-		mkdir -p `dirname $($(2)_PATH)`; \
-		(cd $(abspath $($(2)_PATH)/..) && git clone $($(2)_MODULE) --recursive $($(2)_DIRECTORY) -b $(NEEDED_$(2)_BRANCH)); \
-	fi
-	@if test x$$(IGNORE_$(2)_VERSION) = "x"; then \
-		echo "*** [$(1)] git checkout -f" $(NEEDED_$(2)_BRANCH) && (cd $($(2)_PATH) && git checkout -f $(NEEDED_$(2)_BRANCH) || git checkout -f -b $($(2)_BRANCH_AND_REMOTE)); \
-		echo "*** [$(1)] git reset --hard $(NEEDED_$(2)_VERSION)" && (cd $($(2)_PATH) && git reset --hard $(NEEDED_$(2)_VERSION)); \
-	fi
-	@echo "*** [$(1)] git submodule update --init --recursive" && (cd $($(2)_PATH) && git submodule update --init --recursive)
+	$(Q) \
+	DEPENDENCY_PATH=$($(2)_PATH) \
+	DEPENDENCY_MODULE=$($(2)_MODULE) \
+	DEPENDENCY_HASH=$(NEEDED_$(2)_VERSION) \
+	DEPENDENCY_BRANCH=$(NEEDED_$(2)_BRANCH) \
+	DEPENDENCY_DIRECTORY=$($(2)_DIRECTORY) \
+	DEPENDENCY_IGNORE_VERSION=$(IGNORE_$(2)_VERSION) \
+		$(TOP)/mk/xamarin-reset.sh $(1)
 	@touch $(THISDIR)/.stamp-reset-$(1)
 
 print-$(1)::


### PR DESCRIPTION
Put the shell code for resetting README dependencies in a shell script instead
of embedded in the Makefile so that it's easier to write, read and debug.

Also add support for switching between different remotes for README
dependencies (this means that `make reset-X` will now work fine if `X`'s
remote changed).

A side effect is that all README dependencies will now end up with a 'xamarin'
remote in addition to the 'origin' remote, but there should be no other
side effects.