### PR TITLE
[xharness] Try for 30 seconds to edit TCC.db instead of just 5 seconds.

### DIFF
--- a/tests/xharness/Simulators.cs
+++ b/tests/xharness/Simulators.cs
@@ -390,7 +390,7 @@ namespace xharness
 				};
 
 			var failure = false;
-			var tcc_edit_timeout = 5;
+			var tcc_edit_timeout = 30;
 			var watch = new Stopwatch ();
 			watch.Start ();
 


### PR DESCRIPTION
Hopefully fixes an issue with monotouch-test randomly running into permission
dialogs because xharness failed to fix TCC.db because it gave up too early.