### PR TITLE
[msbuild] Adds minimum support for XM binding projects from VS

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.CSharp.targets
@@ -81,6 +81,7 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 		<Message Text="BTouchEmitDebugInformation: $(BTouchEmitDebugInformation)"/>
 
 		<BTouch
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			OutputPath="$(OutputPath)"
 			ObjectiveCLibraries="@(ObjcBindingNativeLibrary)"
@@ -108,6 +109,7 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 
 	<Target Name="_PrepareNativeReferences" Condition="'$(DesignTimeBuild)' != 'true'">
 		<PrepareNativeReferences
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			NativeReferences="@(NativeReference)"
@@ -125,9 +127,10 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 	</Target>
 
 	<Target Name="_CompressFrameworks" Inputs="@(_NativeFrameworkResource)" Outputs="$(IntermediateOutputPath)%(_NativeFramework.Filename)%(_NativeFramework.Extension)" DependsOnTargets="_CollectNativeFrameworkResources">
-		<Delete SessionId="$(BuildSessionId)" Files="$(IntermediateOutputPath)%(_NativeFramework.Filename)%(_NativeFramework.Extension)" />
+		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(IntermediateOutputPath)%(_NativeFramework.Filename)%(_NativeFramework.Extension)" />
 
 		<Zip
+			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
 			ToolExe="$(ZipExe)"
 			ToolPath="$(ZipPath)"

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.ObjCBinding.Common.targets
@@ -67,7 +67,8 @@ Copyright (C) 2014 Xamarin Inc. All rights reserved.
 
 	<Target Name="_CollectBundleResources">
 		<CollectBundleResources
-			SessionId=""
+			Condition="'$(IsMacEnabled)' == 'true'"
+			SessionId="$(BuildSessionId)"
 			OptimizePNGs="False"
 			BundleResources="@(Content);@(BundleResource)"
 			ProjectDir="$(MSBuildProjectDirectory)"

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Tasks.csproj
@@ -107,6 +107,9 @@
     <None Include="Xamarin.Mac.ObjCBinding.CSharp.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Xamarin.Mac.ObjCBinding.CSharp.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Xamarin.Mac.AppExtension.Common.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Minimum support means:
- Letting users open XM binding projects
- Building XM binding projects offline (not connected to the Mac)