### PR TITLE
[xharness] Make sure to cancel the test listener both for device and simulator builds.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -661,7 +661,6 @@ namespace xharness
 					}
 				}
 
-				listener.Cancel ();
 
 				// cleanup after us
 				if (EnsureCleanSimulatorState)
@@ -736,6 +735,7 @@ namespace xharness
 				}
 			}
 
+			listener.Cancel ();
 			listener.Dispose ();
 
 			// check the final status


### PR DESCRIPTION
This will make xharness not listen for tests to connect forever, decrease the
number of threads needed, and as well not print loads of aborted messages when
xharness exits:

    SimpleTcpListener: an exception occurred in processing thread: System.Threading.ThreadAbortException: Thread was being aborted.
      at xharness.SimpleTcpListener.Start () [0x0009d] in /Users/XamarinQA/vsts/_work/1/s/tests/xharness/SimpleTcpListener.cs:44
      at xharness.SimpleListener.<StartAsync>b__41_0 () [0x00002] in /Users/XamarinQA/vsts/_work/1/s/tests/xharness/SimpleListener.cs:93