### PR TITLE
[xharness] Wait for a build to finish even if it has started.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -3479,8 +3479,7 @@ function toggleAll (show)
 			Jenkins.MainLog.WriteLine ("Running XI on '{0}' ({2}) for {1}", Device?.Name, ProjectFile, Device?.UDID);
 
 			ExecutionResult = (ExecutionResult & ~TestExecutingResult.InProgressMask) | TestExecutingResult.Running;
-			if (BuildTask.NotStarted)
-				await BuildTask.RunAsync ();
+			await BuildTask.RunAsync ();
 			if (!BuildTask.Succeeded) {
 				ExecutionResult = TestExecutingResult.BuildFailure;
 				return;


### PR DESCRIPTION
Because build tasks might be shared between tests, and if another test already
started a build, this test must still wait until the build finishes.