### PR TITLE
[xharness] Don't make a potentially blocking call to enumerate device candidates in VerifyRun.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -3118,7 +3118,7 @@ function toggleAll (show)
 			if (Finished)
 				return;
 
-			VerifyRun ();
+			await VerifyRunAsync ();
 			if (Finished)
 				return;
 
@@ -3133,7 +3133,7 @@ function toggleAll (show)
 		protected abstract Task RunTestAsync ();
 		// VerifyRun is called in ExecuteAsync to verify that the task can be executed/run.
 		// Typically used to fail tasks that don't have an available device.
-		public virtual void VerifyRun () { }
+		public virtual Task VerifyRunAsync () { return Task.CompletedTask; }
 
 		public override void Reset ()
 		{
@@ -3207,11 +3207,15 @@ function toggleAll (show)
 			set { throw new NotImplementedException (); }
 		}
 
-		public override void VerifyRun ()
+		public override async Task VerifyRunAsync ()
 		{
-			base.VerifyRun ();
+			await base.VerifyRunAsync ();
 
-			if (!candidates.Any ()) {
+			var enumerable = candidates;
+			var asyncEnumerable = enumerable as IAsyncEnumerable;
+			if (asyncEnumerable != null)
+				await asyncEnumerable.ReadyTask;
+			if (!enumerable.Any ()) {
 				ExecutionResult = TestExecutingResult.Skipped;
 				FailureMessage = "No applicable devices found.";
 			}


### PR DESCRIPTION
Enumerating device candidates can block (if the devices haven't been populated
yet), so make the whole thing async-based instead.