### PR TITLE
[xharness] Create simulators if they don't already exist.

### DIFF
--- a/tests/xharness/Simulators.cs
+++ b/tests/xharness/Simulators.cs
@@ -113,117 +113,140 @@ namespace xharness
 			});
 		}
 
-		public async Task<SimDevice []> FindAsync (AppRunnerTarget target, Log log)
+		string CreateName (string devicetype, string runtime)
+		{
+			var runtime_name = supported_runtimes?.Where ((v) => v.Identifier == runtime).FirstOrDefault ()?.Name ?? Path.GetExtension (runtime).Substring (1);
+			var device_name = supported_device_types?.Where ((v) => v.Identifier == devicetype).FirstOrDefault ()?.Name ?? Path.GetExtension (devicetype).Substring (1);
+			return $"{device_name} ({runtime_name}) - created by xharness";
+		}
+
+		async Task<IEnumerable<SimDevice>> FindOrCreateDevicesAsync (Log log, string runtime, string devicetype)
+		{
+			if (runtime == null || devicetype == null)
+				return null;
+			
+			var devices = AvailableDevices.Where ((SimDevice v) => v.SimRuntime == runtime && v.SimDeviceType == devicetype);
+			if (devices.Any ())
+				return devices;
+			
+			var rv = await Harness.ExecuteXcodeCommandAsync ("simctl", $"create {StringUtils.Quote (CreateName (devicetype, runtime))} {devicetype} {runtime}", log, TimeSpan.FromMinutes (1));
+			if (!rv.Succeeded) {
+				log.WriteLine ($"Could not create device for runtime={runtime} and device type={devicetype}.");
+				return null;
+			}
+
+			await LoadAsync (log, force: true);
+
+			devices = AvailableDevices.Where ((SimDevice v) => v.SimRuntime == runtime && v.SimDeviceType == devicetype);
+			if (!devices.Any ()) {
+				log.WriteLine ($"No devices loaded after creating it? runtime={runtime} device type={devicetype}.");
+				return null;
+			}
+
+			return devices;
+		}
+
+		async Task<SimDevicePair> FindOrCreateDevicePairAsync (Log log, IEnumerable<SimDevice> devices, IEnumerable<SimDevice> companion_devices)
+		{
+			// Check if we already have a device pair with the specified devices
+			var pairs = AvailableDevicePairs.Where ((SimDevicePair pair) => {
+				if (!devices.Any ((v) => v.UDID == pair.Gizmo))
+					return false;
+				if (!companion_devices.Any ((v) => v.UDID == pair.Companion))
+					return false;
+				return true;
+			});
+
+			if (!pairs.Any ()) {
+				// No device pair. Create one.
+				var device = devices.First ();
+				var companion_device = companion_devices.First ();
+				log.WriteLine ($"Creating device pair for '{device.Name}' and '{companion_device.Name}'");
+				var rv = await Harness.ExecuteXcodeCommandAsync ("simctl", $"pair {device.UDID} {companion_device.UDID}", log, TimeSpan.FromMinutes (1));
+				if (!rv.Succeeded) {
+					log.WriteLine ($"Could not create device pair for '{device.Name}' ({device.UDID}) and '{companion_device.Name}' ({companion_device.UDID})");
+					return null;
+				}
+				await LoadAsync (log, force: true);
+
+				pairs = AvailableDevicePairs.Where ((SimDevicePair pair) => {
+					if (!devices.Any ((v) => v.UDID == pair.Gizmo))
+						return false;
+					if (!companion_devices.Any ((v) => v.UDID == pair.Companion))
+						return false;
+					return true;
+				});
+			}
+
+			return pairs.FirstOrDefault ();
+		}
+
+		public async Task<SimDevice []> FindAsync (AppRunnerTarget target, Log log, bool create_if_needed = true)
 		{
 			SimDevice [] simulators = null;
 
-			string [] simulator_devicetypes;
+			string simulator_devicetype;
 			string simulator_runtime;
-			string [] companion_devicetypes = null;
+			string companion_devicetype = null;
 			string companion_runtime = null;
 
 			switch (target) {
 			case AppRunnerTarget.Simulator_iOS32:
-				simulator_devicetypes = new string [] { "com.apple.CoreSimulator.SimDeviceType.iPhone-5" };
+				simulator_devicetype = "com.apple.CoreSimulator.SimDeviceType.iPhone-5";
 				simulator_runtime = "com.apple.CoreSimulator.SimRuntime.iOS-10-3";
 				break;
 			case AppRunnerTarget.Simulator_iOS64:
-				simulator_devicetypes = new string [] { "com.apple.CoreSimulator.SimDeviceType.iPhone-6" };
+				simulator_devicetype = "com.apple.CoreSimulator.SimDeviceType.iPhone-X";
 				simulator_runtime = "com.apple.CoreSimulator.SimRuntime.iOS-" + Xamarin.SdkVersions.iOS.Replace ('.', '-');
 				break;
 			case AppRunnerTarget.Simulator_iOS:
-				simulator_devicetypes = new string [] { "com.apple.CoreSimulator.SimDeviceType.iPhone-5" };
+				simulator_devicetype = "com.apple.CoreSimulator.SimDeviceType.iPhone-5";
 				simulator_runtime = "com.apple.CoreSimulator.SimRuntime.iOS-" + Xamarin.SdkVersions.iOS.Replace ('.', '-');
 				break;
 			case AppRunnerTarget.Simulator_tvOS:
-				simulator_devicetypes = new string [] { "com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p" };
+				simulator_devicetype = "com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p";
 				simulator_runtime = "com.apple.CoreSimulator.SimRuntime.tvOS-" + Xamarin.SdkVersions.TVOS.Replace ('.', '-');
 				break;
 			case AppRunnerTarget.Simulator_watchOS:
-				simulator_devicetypes = new string [] { "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-38mm", "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-2-38mm" };
+				simulator_devicetype = "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-3-38mm";
 				simulator_runtime = "com.apple.CoreSimulator.SimRuntime.watchOS-" + Xamarin.SdkVersions.WatchOS.Replace ('.', '-');
-				companion_devicetypes = new string [] { "com.apple.CoreSimulator.SimDeviceType.iPhone-6s" };
+				companion_devicetype = "com.apple.CoreSimulator.SimDeviceType.iPhone-X";
 				companion_runtime = "com.apple.CoreSimulator.SimRuntime.iOS-" + Xamarin.SdkVersions.iOS.Replace ('.', '-');
 				break;
 			default:
 				throw new Exception (string.Format ("Unknown simulator target: {0}", target));
 			}
 
-			var devices = AvailableDevices.Where ((SimDevice v) =>
-			{
-				if (v.SimRuntime != simulator_runtime)
-					return false;
+			var devices = await FindOrCreateDevicesAsync (log, simulator_runtime, simulator_devicetype);
+			var companion_devices = await FindOrCreateDevicesAsync (log, companion_runtime, companion_devicetype);
 
-				if (!simulator_devicetypes.Contains (v.SimDeviceType))
-					return false;
-
-				if (target == AppRunnerTarget.Simulator_watchOS)
-					return AvailableDevicePairs.Any ((SimDevicePair pair) => pair.Companion == v.UDID || pair.Gizmo == v.UDID);
-
-				return true;
-			});
-
-			SimDevice candidate = null;
-
-			foreach (var device in devices) {
-				var data = device;
-				var secondaryData = (SimDevice) null;
-				var nodeCompanions = AvailableDevicePairs.Where ((SimDevicePair v) => v.Companion == device.UDID);
-				var nodeGizmos = AvailableDevicePairs.Where ((SimDevicePair v) => v.Gizmo == device.UDID);
-
-				if (nodeCompanions.Any ()) {
-					var gizmo_udid = nodeCompanions.First ().Gizmo;
-					var node = AvailableDevices.Where ((SimDevice v) => v.UDID == gizmo_udid);
-					secondaryData = node.First ();
-				} else if (nodeGizmos.Any ()) {
-					var companion_udid = nodeGizmos.First ().Companion;
-					var node = AvailableDevices.Where ((SimDevice v) => v.UDID == companion_udid);
-					secondaryData = node.First ();
-				}
-				if (secondaryData != null) {
-					simulators = new SimDevice [] { data, secondaryData };
-					break;
-				} else {
-					candidate = data;
-				}
+			if (devices?.Any () != true) {
+				log.WriteLine ($"Could not find or create devices runtime={simulator_runtime} and device type={simulator_devicetype}.");
+				return null;
 			}
 
-			if (simulators == null && candidate == null && target == AppRunnerTarget.Simulator_watchOS) {
-				// We might be only missing device pairs to match phone + watch.
-				var watchDevices = AvailableDevices.Where ((SimDevice v) => { return v.SimRuntime == simulator_runtime && simulator_devicetypes.Contains (v.SimDeviceType); });
-				var companionDevices = AvailableDevices.Where ((SimDevice v) => { return v.SimRuntime == companion_runtime && companion_devicetypes.Contains (v.SimDeviceType); });
-				if (!watchDevices.Any () || !companionDevices.Any ()) {
-					log.WriteLine ($"Could not find both watch devices for <runtime={simulator_runtime} and device type={string.Join (";", simulator_devicetypes)}> and companion device for <runtime={companion_runtime} and device type {string.Join (";", companion_devicetypes)}>");
+			if (companion_runtime == null) {
+				simulators = new SimDevice [] { devices.First () };
+			} else {
+				if (companion_devices?.Any () != true) {
+					log.WriteLine ($"Could not find or create companion devices runtime={companion_runtime} and device type={companion_devicetype}.");
 					return null;
 				}
-				var watchDevice = watchDevices.First ();
-				var companionDevice = companionDevices.First ();
 
-				log.WriteLine ($"Creating device pair for '{watchDevice.Name}' and '{companionDevice.Name}'");
-				var rv = await Harness.ExecuteXcodeCommandAsync ("simctl", $"pair {watchDevice.UDID} {companionDevice.UDID}", log, TimeSpan.FromMinutes (1));
-				if (!rv.Succeeded) {
-					log.WriteLine ($"Could not create device pair, so could not find simulator for runtime={simulator_runtime} and device type={string.Join ("; ", simulator_devicetypes)}.");
+				var pair = await FindOrCreateDevicePairAsync (log, devices, companion_devices);
+				if (pair == null) {
+					log.WriteLine ($"Could not find or create device pair runtime={companion_runtime} and device type={companion_devicetype}.");
 					return null;
 				}
-				available_device_pairs.Add (new SimDevicePair ()
-				{
-					Companion = companionDevice.UDID,
-					Gizmo = watchDevice.UDID,
-					UDID = $"<created for {companionDevice.UDID} and {watchDevice.UDID}",
-				});
-				simulators = new SimDevice [] { watchDevice, companionDevice };
+
+				simulators = new SimDevice [] {
+					devices.First ((v) => v.UDID == pair.Gizmo), 
+					companion_devices.First ((v) => v.UDID == pair.Companion),
+				};
 			}
 
 			if (simulators == null) {
-				if (candidate == null) {
-					log.WriteLine ($"Could not find simulator for runtime={simulator_runtime} and device type={string.Join (";", simulator_devicetypes)}.");
-					return null;
-				}
-				simulators = new SimDevice [] { candidate };
-			}
-
-			if (simulators == null) {
-				log.WriteLine ("Could not find simulator");
+				log.WriteLine ($"Could not find simulator for runtime={simulator_runtime} and device type={simulator_devicetype}.");
 				return null;
 			}
 


### PR DESCRIPTION
Create any needed simulators, instead of relying on them already existing (or
someone manually creating them).

A nice side effect is that it will become possible to delete all simulators on
a bot (to reclaim space), and they'll be re-created when needed.