### PR TITLE
[SceneKit] Makes SCNRenderingOptions.RenderingApi use the right key

### DIFF
--- a/src/SceneKit/SCNRenderingOptions.cs
+++ b/src/SceneKit/SCNRenderingOptions.cs
@@ -9,7 +9,7 @@ namespace SceneKit
 	public partial class SCNRenderingOptions {
 		public SCNRenderingApi? RenderingApi {
 			get {
-				var val = GetNUIntValue (_RenderingApiKey);
+				var val = GetNUIntValue (SCNRenderingOptionsKeys.RenderingApiKey);
 				if (val != null)
 					return (SCNRenderingApi)(uint) val;
 				return null;
@@ -17,9 +17,9 @@ namespace SceneKit
 
 			set {
 				if (value.HasValue)
-					SetNumberValue (_RenderingApiKey, (nuint)(uint)value.Value);
+					SetNumberValue (SCNRenderingOptionsKeys.RenderingApiKey, (nuint)(uint)value.Value);
 				else
-					RemoveValue (_RenderingApiKey);
+					RemoveValue (SCNRenderingOptionsKeys.RenderingApiKey);
 			}
 		}
 	}

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -3294,8 +3294,6 @@ namespace SceneKit {
 	[StrongDictionary ("SCNRenderingOptionsKeys")]
 	interface SCNRenderingOptions
 	{
-		[Internal, Export ("SCNRenderingOptionsKeys.RenderingApiKey")]
-		NSString _RenderingApiKey { get; set; }
 
 #if XAMCORE_2_0 || !MONOMAC
 		IMTLDevice Device { get; set; }


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/4087

`SCNRenderingOptions.RenderingApi` is using the wrong key to
set its dictionary container value that should come from
`SCNRenderingOptionsKeys.RenderingApiKey`.