### PR TITLE
[Compression] Ensure that we do link against libcompression.

### DIFF
--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -364,6 +364,7 @@ namespace Xamarin.Bundler {
 						Driver.Log (3, "Linking with {0} because it's referenced by a module reference in {1}", file, FileName);
 						break;
 					case "libsqlite3":
+					case "libcompression":
 						// remove lib prefix
 						LinkerFlags.Add ("-l" + file.Substring (3));
 						Driver.Log (3, "Linking with {0} because it's referenced by a module reference in {1}", file, FileName);


### PR DESCRIPTION
We need to pass libcrompession in the linking flags, which was not
present and makes the build fail.