### PR TITLE
[foundation] Fix empty NSData.ToArray() crash

### DIFF
--- a/src/Foundation/NSData.cs
+++ b/src/Foundation/NSData.cs
@@ -47,7 +47,8 @@ namespace Foundation {
 		public byte[] ToArray ()
 		{
 			var res = new byte [Length];
-			Marshal.Copy (Bytes, res, 0, res.Length);
+			if (Length > 0)
+				Marshal.Copy (Bytes, res, 0, res.Length);
 			return res;
 		}
 

--- a/tests/monotouch-test/Foundation/NSDataTest.cs
+++ b/tests/monotouch-test/Foundation/NSDataTest.cs
@@ -124,6 +124,15 @@ namespace MonoTouchFixtures.Foundation {
 		}
 
 		[Test]
+		public void ToEmptyArray ()
+		{
+			using (var data = NSData.FromArray (new byte[0])) {
+				var arr = data.ToArray ();
+				Assert.AreEqual (0, arr.Length, "Length");
+			}
+		}
+
+		[Test]
 		public void BytesLength ()
 		{
 			// suggested alternative for http://stackoverflow.com/q/10623162/220643


### PR DESCRIPTION
When `NSData` is empty, the `ToArray()` method throws `System.ArgumentNullException`.
In this case `NSData.Bytes` is null.

I added a length check before copying the array.
