### PR TITLE
[runtime] Avoid using a static library initializer.

### DIFF
--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -41,18 +41,7 @@
 #include "runtime-internal.h"
 //#define DEBUG_REF_COUNTING
 
-static pthread_mutex_t refcount_mutex;
-static void
-x_init_mutex () __attribute__ ((constructor));
-
-static void
-x_init_mutex ()
-{
-	pthread_mutexattr_t attr;
-	pthread_mutexattr_init (&attr);
-	pthread_mutexattr_settype (&attr, PTHREAD_MUTEX_RECURSIVE);
-	pthread_mutex_init (&refcount_mutex, &attr);
-}
+static pthread_mutex_t refcount_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER;
 
 void *
 xamarin_marshal_return_value (MonoType *mtype, const char *type, MonoObject *retval, bool retain, MonoMethod *method, MethodDescription *desc, guint32 *exception_gchandle)


### PR DESCRIPTION
Avoid using a static library initializer by using a constant recursive mutex
initializer.

Static initializers are bad because there's a significant overhead to executing them.