### PR TITLE
[msbuild] Unbreak netstd2 project msbuild support

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.TargetFrameworkFix.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.TargetFrameworkFix.targets
@@ -17,8 +17,6 @@ Copyright (c) 2018 Microsoft Corp. (www.microsoft.com)
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<!-- Hack associated with TargetFrameworkDirectory. Needs to be shared by xbuild and msbuild for now. -->
 
-	<Target Name="FixDesignTimeFacades" AfterTargets="GetReferenceAssemblyPaths" Condition="'$(OS)' != 'Windows_NT'" />
-
 	<!-- Location of Libraries -->
 	<Target Name="FixTargetFrameworkDirectory" AfterTargets="FixDesignTimeFacades" Condition="('$(OS)' != 'Windows_NT')">
 		<PropertyGroup>
@@ -30,6 +28,9 @@ Copyright (c) 2018 Microsoft Corp. (www.microsoft.com)
 			<!-- If we find cases of other non-XM assemblies being resolved from XM paths, we can look into using CandidateAssemblyFiles but it is msbuild only. -->
 			<TargetFrameworkDirectory Condition="'$(TargetFrameworkName)' == 'System'">$(TargetFrameworkDirectory);$(MacBclPath)</TargetFrameworkDirectory>
 		</PropertyGroup>
+	</Target>
+
+	<Target Name="FixDesignTimeFacades" AfterTargets="GetReferenceAssemblyPaths" Condition="('$(OS)' != 'Windows_NT')">
 		<ItemGroup>
 			<DesignTimeFacadeDirectories Remove="@(DesignTimeFacadeDirectories)" />
 			<DesignTimeFacadeDirectories Include="$(MacBclPath)/Facades/" />


### PR DESCRIPTION
- https://github.com/xamarin/xamarin-macios/issues/4067
- Broken by https://github.com/xamarin/xamarin-macios/commit/371a1d54e782c0044e984b5407079080cff50164
- The refactor into Xamarin.Mac.TargetFrameworkFix.targets was incorrect, and the ItemGroup needed
to be run after GetReferenceAssemblyPaths, not after FixDesignTimeFacades.
- This would have been caught by existing tests, but they were not enabled due to msbuild redirect issue.