### PR TITLE
[jenkins] Update the urls for html reports.

### DIFF
--- a/jenkins/build-api-diff.sh
+++ b/jenkins/build-api-diff.sh
@@ -10,4 +10,4 @@ cd $WORKSPACE
 export BUILD_REVISION=jenkins
 make -j8 -C tools/apidiff jenkins-api-diff
 
-printf "✅ [API Diff (from stable)]($BUILD_URL/API_20diff_20_28from_20stable_29))\\n" >> $WORKSPACE/jenkins/pr-comments.md
+printf "✅ [API Diff (from stable)]($BUILD_URL/API_20diff_20_28from_20stable_29)\\n" >> $WORKSPACE/jenkins/pr-comments.md

--- a/jenkins/build-api-diff.sh
+++ b/jenkins/build-api-diff.sh
@@ -10,4 +10,4 @@ cd $WORKSPACE
 export BUILD_REVISION=jenkins
 make -j8 -C tools/apidiff jenkins-api-diff
 
-printf "✅ [API Diff (from stable)]($BUILD_URL/API_diff_(from_stable))\\n" >> $WORKSPACE/jenkins/pr-comments.md
+printf "✅ [API Diff (from stable)]($BUILD_URL/API_20diff_20_28from_20stable_29))\\n" >> $WORKSPACE/jenkins/pr-comments.md

--- a/jenkins/compare.sh
+++ b/jenkins/compare.sh
@@ -29,5 +29,5 @@ cp -R tools/comparison/apidiff/diff jenkins-results/apicomparison/
 cp    tools/comparison/apidiff/*.html jenkins-results/apicomparison/
 cp -R tools/comparison/generator-diff jenkins-results/generator-diff
 
-printf "✅ [API Diff (from PR only)]($BUILD_URL/API_diff_(PR_only))\\n" >> $WORKSPACE/jenkins/pr-comments.md
-printf "✅ [Generator Diff]($BUILD_URL/Generator_Diff)\\n" >> $WORKSPACE/jenkins/pr-comments.md
+printf "✅ [API Diff (from PR only)]($BUILD_URL/API_20diff_20_28PR_20only_29)\\n" >> $WORKSPACE/jenkins/pr-comments.md
+printf "✅ [Generator Diff]($BUILD_URL/Generator_20Diff)\\n" >> $WORKSPACE/jenkins/pr-comments.md

--- a/jenkins/run-tests.sh
+++ b/jenkins/run-tests.sh
@@ -2,7 +2,7 @@
 
 report_error ()
 {
-	printf "🔥 [Test run failed]($BUILD_URL/Test_Report/) 🔥\\n" >> $WORKSPACE/jenkins/pr-comments.md
+	printf "🔥 [Test run failed]($BUILD_URL/Test_20Report/) 🔥\\n" >> $WORKSPACE/jenkins/pr-comments.md
 
 	if test -f $WORKSPACE/tests/TestSummary.md; then
 		printf "\\n" >> $WORKSPACE/jenkins/pr-comments.md
@@ -29,7 +29,7 @@ rm -rf ~/.config/.mono/keypairs/
 # Run tests
 make -C tests jenkins
 
-printf "✅ [Test run succeeded]($BUILD_URL/Test_Report/)\\n" >> $WORKSPACE/jenkins/pr-comments.md
+printf "✅ [Test run succeeded]($BUILD_URL/Test_20Report/)\\n" >> $WORKSPACE/jenkins/pr-comments.md
 
 if test -f $WORKSPACE/jenkins/failure-stamp; then
 	echo "Something went wrong:"


### PR DESCRIPTION
The urls for html reports changed as a consequence of a Jenkins update [1], so
update how we construct the links accordingly.

See also:

* https://xamarinhq.slack.com/archives/C03CCJNR7/p1526646040000120
* https://xamarinhq.slack.com/archives/C03CCJNR7/p1526653512000249

[1] https://wiki.jenkins.io/display/JENKINS/HTML+Publisher+Plugin (update to v1.16)