### PR TITLE
[jenkins] Don't treat API/Generator diff failures as errors.

### DIFF
--- a/jenkins/compare.sh
+++ b/jenkins/compare.sh
@@ -4,6 +4,7 @@ report_error ()
 {
 	printf "🔥 [Failed to compare API and create generator diff]($BUILD_URL/console) 🔥\\n" >> $WORKSPACE/jenkins/pr-comments.md
 	touch $WORKSPACE/jenkins/failure-stamp
+	exit 0
 }
 trap report_error ERR
 


### PR DESCRIPTION
This way such failures won't make the build show up as failed, which may cause
other tooling to behave differently (and non-optimal).