### PR TITLE
[ObjCRuntime] Improve MarkDirty speed by caching the IsCustomType value in our flags byte.

### DIFF
--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -139,6 +139,8 @@ enum NSObjectFlags {
 	NSObjectFlagsRegisteredToggleRef = 8,
 	NSObjectFlagsInFinalizerQueue = 16,
 	NSObjectFlagsHasManagedRef = 32,
+	NSObjectFlagsKnowsIsCustomType = 64,
+	NSObjectFlagsIsCustomType = 128,
 };
 
 struct AssemblyLocation {

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -139,7 +139,7 @@ enum NSObjectFlags {
 	NSObjectFlagsRegisteredToggleRef = 8,
 	NSObjectFlagsInFinalizerQueue = 16,
 	NSObjectFlagsHasManagedRef = 32,
-	NSObjectFlagsKnowsIsCustomType = 64,
+	// 64, // Used by SoM
 	NSObjectFlagsIsCustomType = 128,
 };
 

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -79,6 +79,8 @@ namespace Foundation {
 			RegisteredToggleRef = 8,
 			InFinalizerQueue = 16,
 			HasManagedRef = 32,
+			KnowsIsCustomType = 64,
+			IsCustomType = 128,
 		}
 
 		bool disposed { 
@@ -101,6 +103,22 @@ namespace Foundation {
 
 		internal bool InFinalizerQueue {
 			get { return ((flags & Flags.InFinalizerQueue) == Flags.InFinalizerQueue); }
+		}
+
+		bool IsCustomType {
+			get {
+				bool value;
+				var knows = (flags & Flags.KnowsIsCustomType) == Flags.KnowsIsCustomType;
+				if (!knows) {
+					value = Class.IsCustomType (GetType ());
+					flags |= Flags.KnowsIsCustomType;
+					if (value)
+						flags |= Flags.IsCustomType;
+				} else {
+					value = (flags & Flags.IsCustomType) == Flags.IsCustomType;
+				}
+				return value;		
+			}
 		}
 
 		[Export ("init")]
@@ -169,7 +187,7 @@ namespace Foundation {
 			if (IsRegisteredToggleRef)
 				return;
 
-			if (!allowCustomTypes && Class.IsCustomType (GetType ()))
+			if (!allowCustomTypes && IsCustomType)
 				return;
 			
 			IsRegisteredToggleRef = true;

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -107,14 +107,13 @@ namespace Foundation {
 
 		bool IsCustomType {
 			get {
-				bool value;
 				var value = (flags & Flags.IsCustomType) == Flags.IsCustomType;
 				if (!value) {
 					value = Class.IsCustomType (GetType ());
 					if (value)
 						flags |= Flags.IsCustomType;
 				}
-				return value;		
+				return value;
 			}
 		}
 

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -79,7 +79,7 @@ namespace Foundation {
 			RegisteredToggleRef = 8,
 			InFinalizerQueue = 16,
 			HasManagedRef = 32,
-			KnowsIsCustomType = 64,
+			// 64, // Used by SoM
 			IsCustomType = 128,
 		}
 
@@ -108,14 +108,11 @@ namespace Foundation {
 		bool IsCustomType {
 			get {
 				bool value;
-				var knows = (flags & Flags.KnowsIsCustomType) == Flags.KnowsIsCustomType;
-				if (!knows) {
+				var value = (flags & Flags.IsCustomType) == Flags.IsCustomType;
+				if (!value) {
 					value = Class.IsCustomType (GetType ());
-					flags |= Flags.KnowsIsCustomType;
 					if (value)
 						flags |= Flags.IsCustomType;
-				} else {
-					value = (flags & Flags.IsCustomType) == Flags.IsCustomType;
 				}
 				return value;		
 			}


### PR DESCRIPTION
This makes calling MarkDirty for custom types ~60x times faster.

Reference: https://xamarinhq.slack.com/archives/C03CCJHCF/p1527194568000197