### PR TITLE
[jenkins] Fix scripts to be shellcheck-happy.

### DIFF
--- a/jenkins/Makefile
+++ b/jenkins/Makefile
@@ -1,0 +1,2 @@
+all check:
+	shellcheck *.sh

--- a/jenkins/build-api-diff.sh
+++ b/jenkins/build-api-diff.sh
@@ -1,13 +1,15 @@
 #!/bin/bash -e
 
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+WORKSPACE=$(pwd)
+
 report_error ()
 {
-	printf "🔥 [Failed to create API Diff]($BUILD_URL/console) 🔥\\n" >> $WORKSPACE/jenkins/pr-comments.md
+	printf "🔥 [Failed to create API Diff](%s/console) 🔥\\n" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"
 }
 trap report_error ERR
 
-cd $WORKSPACE
 export BUILD_REVISION=jenkins
 make -j8 -C tools/apidiff jenkins-api-diff
 
-printf "✅ [API Diff (from stable)]($BUILD_URL/API_20diff_20_28from_20stable_29)\\n" >> $WORKSPACE/jenkins/pr-comments.md
+printf "✅ [API Diff (from stable)](%s/API_20diff_20_28from_20stable_29)\\n" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"

--- a/jenkins/compare.sh
+++ b/jenkins/compare.sh
@@ -1,28 +1,32 @@
 #!/bin/bash -e
 
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+WORKSPACE=$(pwd)
+
 report_error ()
 {
-	printf "🔥 [Failed to compare API and create generator diff]($BUILD_URL/console) 🔥\\n" >> $WORKSPACE/jenkins/pr-comments.md
-	touch $WORKSPACE/jenkins/failure-stamp
+	printf "🔥 [Failed to compare API and create generator diff](%s/console) 🔥\\n" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"
+	touch "$WORKSPACE/jenkins/failure-stamp"
 	exit 0
 }
 trap report_error ERR
 
-cd $WORKSPACE
 
 if ./jenkins/fetch-pr-labels.sh --check=skip-api-comparison; then
-	printf "❎ Skipped API comparison because the PR has the label 'skip-api-comparison'\\n" >> $WORKSPACE/jenkins/pr-comments.md
+	printf "❎ Skipped API comparison because the PR has the label 'skip-api-comparison'\\n" >> "$WORKSPACE/jenkins/pr-comments.md"
 	exit 0
 fi
 
-BASE=origin/pr/$ghprbPullId/merge
-if ! git rev-parse $BASE >/dev/null 2>&1; then
+# SC2154: ghprbPullId is referenced but not assigned.
+# shellcheck disable=SC2154
+BASE="origin/pr/$ghprbPullId/merge"
+if ! git rev-parse "$BASE" >/dev/null 2>&1; then
 	echo "Can't compare API and create generator diff because the pull request has conflicts that must be resolved first (the branch '$BASE' doesn't exist)."
-	printf "🔥 [Failed to compare API and create generator diff because the pull request has conflicts that must be resolved first]($BUILD_URL/console) 🔥\\n" >> $WORKSPACE/jenkins/pr-comments.md
+	printf "🔥 [Failed to compare API and create generator diff because the pull request has conflicts that must be resolved first](%s/console) 🔥\\n" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"
 	exit 0
 fi
 
-./tools/compare-commits.sh --base=$BASE^1
+./tools/compare-commits.sh --base="$BASE^1"
 
 mkdir -p jenkins-results/apicomparison
 
@@ -30,5 +34,5 @@ cp -R tools/comparison/apidiff/diff jenkins-results/apicomparison/
 cp    tools/comparison/apidiff/*.html jenkins-results/apicomparison/
 cp -R tools/comparison/generator-diff jenkins-results/generator-diff
 
-printf "✅ [API Diff (from PR only)]($BUILD_URL/API_20diff_20_28PR_20only_29)\\n" >> $WORKSPACE/jenkins/pr-comments.md
-printf "✅ [Generator Diff]($BUILD_URL/Generator_20Diff)\\n" >> $WORKSPACE/jenkins/pr-comments.md
+printf "✅ [API Diff (from PR only)](%s/API_20diff_20_28PR_20only_29)\\n" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"
+printf "✅ [Generator Diff](%s/Generator_20Diff)\\n" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"

--- a/jenkins/fetch-pr-labels.sh
+++ b/jenkins/fetch-pr-labels.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+# SC2154: ghprbPullId is referenced but not assigned.
+# shellcheck disable=SC2154
 if test -z "$ghprbPullId"; then
 	echo "Could not find the environment variable ghprbPullId, so it's not possible to fetch the labels for any pull request."
 	exit 1

--- a/jenkins/provision-deps.sh
+++ b/jenkins/provision-deps.sh
@@ -1,12 +1,14 @@
 #!/bin/bash -e
 
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+WORKSPACE=$(pwd)
+
 report_error ()
 {
-	echo "🔥 [Provisioning failed]($BUILD_URL/console) 🔥" >> $WORKSPACE/jenkins/pr-comments.md
+	echo "🔥 [Provisioning failed]($BUILD_URL/console) 🔥" >> "$WORKSPACE/jenkins/pr-comments.md"
 }
 trap report_error ERR
 
-cd $WORKSPACE
 ./system-dependencies.sh --provision-all
 
-echo "✅ [Provisioning succeeded]($BUILD_URL/console)" >> $WORKSPACE/jenkins/pr-comments.md
+echo "✅ [Provisioning succeeded]($BUILD_URL/console)" >> "$WORKSPACE/jenkins/pr-comments.md"

--- a/jenkins/run-tests.sh
+++ b/jenkins/run-tests.sh
@@ -1,31 +1,35 @@
 #!/bin/bash -e
 
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+WORKSPACE=$(pwd)
+
 report_error ()
 {
-	printf "🔥 [Test run failed]($BUILD_URL/Test_20Report/) 🔥\\n" >> $WORKSPACE/jenkins/pr-comments.md
+	printf "🔥 [Test run failed](%s/Test_20Report) 🔥\\n" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"
 
-	if test -f $WORKSPACE/tests/TestSummary.md; then
-		printf "\\n" >> $WORKSPACE/jenkins/pr-comments.md
-		cat $WORKSPACE/tests/TestSummary.md >> $WORKSPACE/jenkins/pr-comments.md
+	if test -f "$WORKSPACE/tests/TestSummary.md"; then
+		printf "\\n" >> "$WORKSPACE/jenkins/pr-comments.md"
+		cat "$WORKSPACE/tests/TestSummary.md" >> "$WORKSPACE/jenkins/pr-comments.md"
 	fi
 
-	touch $WORKSPACE/jenkins/failure-stamp
+	touch "$WORKSPACE/jenkins/failure-stamp"
 }
 trap report_error ERR
 
 export BUILD_REVISION=jenkins
-cd $WORKSPACE
+
 # Unlock
 security default-keychain -s builder.keychain
 security list-keychains -s builder.keychain
 echo "Unlock keychain"
-security unlock-keychain -p `cat ~/.config/keychain`
+security unlock-keychain -p "$(cat ~/.config/"$KEYCHAIN"-keychain)"
 echo "Increase keychain unlock timeout"
 security set-keychain-settings -lut 7200
 
 # Prevent dialogs from asking for permissions.
 # http://stackoverflow.com/a/40039594/183422
-security set-key-partition-list -S apple-tool:,apple: -s -k `cat ~/.config/keychain` builder.keychain
+# Discard output since there can be a *lot* of it.
+security set-key-partition-list -S apple-tool:,apple: -s -k "$(cat ~/.config/keychain)" builder.keychain >/dev/null 2>&1
 
 # clean mono keypairs (used in tests)
 rm -rf ~/.config/.mono/keypairs/
@@ -33,10 +37,10 @@ rm -rf ~/.config/.mono/keypairs/
 # Run tests
 make -C tests jenkins
 
-printf "✅ [Test run succeeded]($BUILD_URL/Test_20Report/)\\n" >> $WORKSPACE/jenkins/pr-comments.md
+printf "✅ [Test run succeeded](%s/Test_20Report/)\\n" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"
 
-if test -f $WORKSPACE/jenkins/failure-stamp; then
+if test -f "$WORKSPACE/jenkins/failure-stamp"; then
 	echo "Something went wrong:"
-	cat $WORKSPACE/jenkins/pr-comments.md
+	cat "$WORKSPACE/jenkins/pr-comments.md"
 	exit 1
 fi


### PR DESCRIPTION
A few general categories of fixes:

* Sprinkle lots of quotes everywhere.
* Don't use environment variables in the format string to printf, instead pass them as arguments.
* Don't use backticks to execute commands (it's deprecated), use the new "$(...)" syntax instead.