### PR TITLE
[mtouch][mmp] Add better easier, more complete timestamps to see where time is spent

### DIFF
--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -471,5 +471,27 @@ namespace Xamarin.Bundler {
 			Touch ((IEnumerable<string>) filenames);
 		}
 
+		static int watch_level;
+		static Stopwatch watch;
+
+		public static int WatchLevel {
+			get { return watch_level; }
+			set {
+				watch_level = value;
+				if ((watch_level > 0) && (watch == null)) {
+					watch = new Stopwatch ();
+					watch.Start ();
+				}
+			}
+		}
+
+		public static void Watch (string msg, int level)
+		{
+			if ((watch == null) || (level > WatchLevel))
+				return;
+			for (int i = 0; i < level; i++)
+				Console.Write ("!");
+			Console.WriteLine ("Timestamp {0}: {1} ms", msg, watch.ElapsedMilliseconds);
+		}
 	}
 }

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -179,9 +179,6 @@ namespace Xamarin.Bundler {
 		}
 					
 
-		static int watch_level;
-		static Stopwatch watch;
-
 		static AOTOptions aotOptions = null;
 
 		static string xm_framework_dir;
@@ -202,12 +199,6 @@ namespace Xamarin.Bundler {
 			}
 		}
 		
-		static void Watch (string msg, int level)
-		{
-			if (watch != null && (watch_level > level))
-				Console.WriteLine ("{0}: {1} ms", msg, watch.ElapsedMilliseconds);
-		}
-
 		public static bool EnableDebug {
 			get { return App.EnableDebug; }
 		}
@@ -281,7 +272,7 @@ namespace Xamarin.Bundler {
 				{ "q", "Quiet", v => verbose-- },
 				{ "i|icon=", "Use the specified file as the bundle icon", v => { icon = v; }},
 				{ "xml=", "Provide an extra XML definition file to the linker", v => App.Definitions.Add (v) },
-				{ "time", v => watch_level++ },
+				{ "time", v => WatchLevel++ },
 				{ "sdkroot=", "Specify the location of Apple SDKs", v => sdk_root = v },
 				{ "arch=", "Specify the architecture ('i386' or 'x86_64') of the native runtime (default to 'i386')", v => { arch = v; arch_set = true; } },
 				{ "profile=", "(Obsoleted in favor of --target-framework) Specify the .NET profile to use (defaults to '" + Xamarin.Utils.TargetFramework.Default + "')", v => SetTargetFramework (v) },
@@ -387,11 +378,6 @@ namespace Xamarin.Bundler {
 			App.RuntimeOptions = RuntimeOptions.Create (App, http_message_provider, tls_provider);
 
 			ErrorHelper.Verbosity = verbose;
-
-			if (watch_level > 0) {
-				watch = new Stopwatch ();
-				watch.Start ();
-			}
 
 			if (action == Action.Help || (args.Length == 0)) {
 				ShowHelp (os);

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1089,6 +1089,7 @@ namespace Xamarin.Bundler {
 
 			if (candidates.Count > 0)
 				SharedCodeApps.AddRange (candidates);
+			Driver.Watch ("Detect Code Sharing", 1);
 		}
 
 		void Initialize ()
@@ -1750,6 +1751,7 @@ namespace Xamarin.Bundler {
 			}
 
 			Driver.CalculateCompilerPath (this);
+			Driver.Watch ("Select Native Compiler", 1);
 		}
 
 		public string GetLibMono (AssemblyBuildTarget build_target)

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -643,6 +643,7 @@ namespace Xamarin.Bundler
 					a.LoadAssembly (a.FullPath);
 				
 				// Link!
+				Driver.Watch ("Managed Link Preparation", 1);
 				LinkAssemblies (out output_assemblies, PreBuildDirectory, sharingTargets);
 			}
 

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -78,7 +78,7 @@ public enum OutputFormat {
 
 namespace Xamarin.Bundler
 {
-	partial class Driver {
+	public partial class Driver {
 		internal const string NAME = "mtouch";
 
 		public static void ShowHelp (OptionSet os)
@@ -892,15 +892,6 @@ namespace Xamarin.Bundler
 			return PDictionary.FromFile (name);
 		}
 
-		static int watch_level;
-		static Stopwatch watch;
-
-		public static void Watch (string msg, int level)
-		{
-			if (watch != null && (watch_level > level))
-				Console.WriteLine ("{0}: {1} ms", msg, watch.ElapsedMilliseconds);
-		}
-
 		internal static bool TryParseBool (string value, out bool result)
 		{
 			if (string.IsNullOrEmpty (value)) {
@@ -1007,7 +998,7 @@ namespace Xamarin.Bundler
 			{ "gsharedvt:", "Generic sharing for value-types - always enabled [Deprecated]", v => {} },
 			{ "v", "Verbose", v => verbose++ },
 			{ "q", "Quiet", v => verbose-- },
-			{ "time", v => watch_level++ },
+			{ "time", v => WatchLevel++ },
 			{ "executable=", "Specifies the native executable name to output", v => app.ExecutableName = v },
 			{ "nofastsim", "Do not run the simulator fast-path build", v => app.NoFastSim = true },
 			{ "nodevcodeshare", "Do not share native code between extensions and main app.", v => app.NoDevCodeShare = true },
@@ -1316,11 +1307,6 @@ namespace Xamarin.Bundler
 				return 0;
 			
 			LogArguments (args);
-
-			if (watch_level > 0) {
-				watch = new Stopwatch ();
-				watch.Start ();
-			}
 
 			ErrorHelper.Verbosity = verbose;
 


### PR DESCRIPTION
* Share the stopwatch code between `mtouch` and `mmp`;

* Add more details on linker steps. Sadly substeps are executed on the
  metadata so they can't be reported individually;

* Add a few places where timestamps where missing to get better precision
  on the linking part;