### PR TITLE
[mtouch][mmp] Cache ReaderParameters instances in CoreResolver

### DIFF
--- a/tools/common/CoreResolver.cs
+++ b/tools/common/CoreResolver.cs
@@ -17,6 +17,7 @@ namespace Xamarin.Bundler {
 	public abstract class CoreResolver : IAssemblyResolver {
 
 		internal Dictionary<string, AssemblyDefinition> cache;
+		Dictionary<string,ReaderParameters> params_cache;
 
 		public string FrameworkDirectory { get; set; }
 		public string RootDirectory { get; set; }
@@ -26,6 +27,7 @@ namespace Xamarin.Bundler {
 		public CoreResolver ()
 		{
 			cache = new Dictionary<string, AssemblyDefinition> (NormalizedStringComparer.OrdinalIgnoreCase);
+			params_cache = new Dictionary<string, ReaderParameters> (StringComparer.Ordinal);
 		}
 
 		public IDictionary<string, AssemblyDefinition> ResolverCache { get { return cache; } }
@@ -45,7 +47,12 @@ namespace Xamarin.Bundler {
 
 		public AssemblyDefinition Resolve (AssemblyNameReference name)
 		{
-			return Resolve (name, new ReaderParameters { AssemblyResolver = this });
+			var key = name.ToString ();
+			if (!params_cache.TryGetValue (key, out ReaderParameters parameters)) {
+				parameters = new ReaderParameters { AssemblyResolver = this };
+				params_cache [key] = parameters;
+			}
+			return Resolve (name, parameters);
 		}
 
 		public abstract AssemblyDefinition Resolve (AssemblyNameReference name, ReaderParameters parameters);
@@ -83,6 +90,7 @@ namespace Xamarin.Bundler {
 				var parameters = CreateDefaultReaderParameters (fileName);
 				try {
 					assembly = ModuleDefinition.ReadModule (fileName, parameters).Assembly;
+					params_cache [assembly.Name.ToString ()] = parameters;
 				}
 				catch (InvalidOperationException e) {
 					// cecil use the default message so it's not very helpful to detect the root cause


### PR DESCRIPTION
In my test project 969828 instances (67MB) of `ReaderParameters` were
created by `CoreResolver.Resolve`, which always allocated a new one.

Since we already create them, most of the time*, we can reuse the
instances when additional members requires resolving.

* only 14 additional instances are now required