### PR TITLE
Fix HTML comments in Issue Template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,10 +1,8 @@
 <!-- 🚨 STOP 🚨 𝗦𝗧𝗢𝗣 🚨 𝑺𝑻𝑶𝑷 🚨 -->
 
-<--
+<!--
 Please fill in the *entire* template below.
-
 The template is designed to avoid unnecessary delays to confirm and fix reported issues. Issues with missing information generally end up with a `need-info` label and take significally more time to fix. Please help us help you!
-
 For more information see https://github.com/xamarin/xamarin-macios/wiki/Submitting-Bugs-&-Suggestions
 For support requests use https://www.xamarin.com/support
 -->
@@ -24,7 +22,6 @@ For support requests use https://www.xamarin.com/support
 1.
 Visual Studio: Help > About Microsoft Visual Studio > Copy Info [button]
 Visual Studio for Mac: Visual Studio > About Visual Studio > Show Details > Copy Information [button]
-
 2. Paste into the code block below (between ```)
 -->
 
@@ -35,7 +32,6 @@ Visual Studio for Mac: Visual Studio > About Visual Studio > Show Details > Copy
 
 <!--
 1. Place cursor below this comment block.
-
 2. Attach build log or link to gist (https://gist.github.com/) of the log.
 -->
 
@@ -43,7 +39,6 @@ Visual Studio for Mac: Visual Studio > About Visual Studio > Show Details > Copy
 
 <!--
 1. Place cursor below this comment block.
-
 2. Drag and drop the compressed project or files needed to reproduce.
 -->
 


### PR DESCRIPTION
Added the missing exclamation mark
New lines in the comments seemed to break the comment, so I removed them
This should prevent the template from appearing in the final issue when the user posts it