### PR TITLE
Add support for building on Jenkins.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -33,11 +33,13 @@ PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 # on wrench, because wrench technically builds hashes, not branches)
 #
 # 
-PACKAGE_HEAD_BRANCH=master
+PACKAGE_HEAD_BRANCH?=master
+ifeq ($(CURRENT_BRANCH),)
 ifeq ($(BUILD_REVISION),)
 CURRENT_BRANCH:=$(shell git rev-parse --abbrev-ref HEAD)
 else
 CURRENT_BRANCH:=$(PACKAGE_HEAD_BRANCH)
+endif
 endif
 
 # TODO: reset to 0 after major/minor version bump (SRO) and increment for service releases and previews

--- a/Make.config
+++ b/Make.config
@@ -84,6 +84,7 @@ MIN_OSX_VERSION_FOR_IOS=10.11
 MIN_OSX_VERSION_FOR_MAC=10.11
 
 IOS_SDK_VERSION=11.4
+# When bumping OSX_SDK_VERSION also update the macOS version where we execute on bots in jenkins/Jenkinsfile (in the 'node' element)
 OSX_SDK_VERSION=10.13
 WATCH_SDK_VERSION=4.3
 TVOS_SDK_VERSION=11.4

--- a/Makefile
+++ b/Makefile
@@ -179,13 +179,11 @@ endif
 
 package:
 	mkdir -p ../package
-	$(MAKE) -C ../maccore package
+	$(MAKE) -C $(MACCORE_PATH) package
 	# copy .pkg, .zip and *updateinfo to the packages directory to be uploaded to storage
-	cp ../maccore/release/*.pkg ../package
-	-cp ../maccore/release/*.zip ../package
-	-cp ../maccore/release/*updateinfo ../package
-	-cp ../maccore/tests/*.zip ../package
-	-cp ../xamarin-macios/tests/*.zip ../package
+	cp $(MACCORE_PATH)/release/*.pkg ../package
+	cp $(MACCORE_PATH)/release/*.zip ../package
+	cp $(MACCORE_PATH)/release/*updateinfo ../package
 
 install-system: install-system-ios install-system-mac
 	@# Clean up some old files

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -104,9 +104,9 @@ def reportFinalStatus (err, gitHash, currentStage)
     def status = currentBuild.currentResult
 
     if ("${status}" == "SUCCESS" && err == "") {
-        comment = "✅ [Jenkins job](${env.RUN_DISPLAY_URL}) succeeded"
+        comment = "✅ [Jenkins job](${env.RUN_DISPLAY_URL}) (on internal Jenkins) succeeded"
     } else {
-        comment = "🔥 [Jenkins job](${env.RUN_DISPLAY_URL}) failed in stage '${currentStage}' 🔥"
+        comment = "🔥 [Jenkins job](${env.RUN_DISPLAY_URL}) (on internal Jenkins) failed in stage '${currentStage}' 🔥"
         if (err != "")
             comment += " : ${err}"
         manager.addErrorBadge (comment)

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,0 +1,477 @@
+#!/bin/groovy
+
+// global variables
+repository = "xamarin/xamarin-macios"
+isPr = false
+branchName = null
+gitHash = null
+packagePrefix = null
+virtualPath = null
+xiPackageUrl = null
+xmPackageUrl = null
+utils = null
+errorMessage = null
+currentStage = null
+
+xiPackageFilename = null
+xmPackageFilename = null
+manifestFilename = null
+reportPrefix = null
+createFinalStatus = true
+skipLocalTestRunReason = ""
+
+def abortExecutingBuilds ()
+{
+    // This runs into problems with the Jenkins sandbox:
+    //      org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use method jenkins.model.Jenkins getItemByFullName java.lang.String
+    // so disable for now.
+
+    // def job = Jenkins.instance.getItemByFullName (env.JOB_NAME)
+    // for (build in job.builds) {
+    //     if (!build.isBuilding ())
+    //         continue
+
+    //     if (build.number > currentBuild.number) {
+    //         error ("There is already a newer build in progress (#${build.number})")
+    //     } else if (build.number < currentBuild.number) {
+    //         def exec = build.getExecutor ()
+    //         if (exec == null) {
+    //             echo ("No executor for build ${build.number}")
+    //         } else {
+    //             exec.interrupt (Result.ABORTED, new CauseOfInterruption.UserInterruption ("Aborted by build #${currentBuild.number}"))
+    //             echo ("Aborted previous build: #${build.number}")
+    //         }
+    //     }
+    // }
+}
+
+github_pull_request_info = null
+def githubGetPullRequestInfo ()
+{
+    if (github_pull_request_info == null && isPr) {
+        withCredentials ([string (credentialsId: 'macios_github_comment_token', variable: 'GITHUB_PAT_TOKEN')]) {
+            def url = "https://api.github.com/repos/${repository}/pulls/${env.CHANGE_ID}"
+            def outputFile = ".github-pull-request-info.json"
+            try {
+                sh ("curl -vf -H 'Authorization: token ${GITHUB_PAT_TOKEN}' --output '${outputFile}' '${url}'")
+                github_pull_request_info = readJSON (file: outputFile)
+                echo ("Got pull request info: ${github_pull_request_info}")
+            } finally {
+                sh ("rm -f ${outputFile}")
+            }
+        }
+
+    }
+    return github_pull_request_info
+}
+
+github_pull_request_labels = null
+def githubGetPullRequestLabels ()
+{
+    if (github_pull_request_labels == null) {
+        github_pull_request_labels = []
+        if (isPr) {
+            def pinfo = githubGetPullRequestInfo ()
+            def labels = pinfo ["labels"]
+            if (labels != null) {
+                for (int i = 0; i < labels.size (); i++) {
+                    def label = labels [i]
+                    github_pull_request_labels.add (label ["name"])
+                }
+            }
+            echo ("Found labels ${github_pull_request_labels} for the pull request.")
+        }
+    }
+    return github_pull_request_labels
+}
+
+def githubAddComment (url, markdown)
+{
+    def json = groovy.json.JsonOutput.toJson ([body: markdown])
+    def jsonFile = "${workspace}/xamarin-macios/jenkins/commit-comments.json"
+    try {
+        writeFile (file: "${jsonFile}", text: "${json}")
+        sh ("cat '${jsonFile}'")
+        withCredentials ([string (credentialsId: 'macios_github_comment_token', variable: 'GITHUB_COMMENT_TOKEN')]) {
+            sh ("curl -i -H 'Authorization: token ${GITHUB_COMMENT_TOKEN}' ${url} --data '@${jsonFile}'")
+        }
+    } finally {
+        sh ("rm -f ${jsonFile}")
+    }
+}
+
+def commentOnCommit (commitHash, markdown)
+{
+    githubAddComment ("https://api.github.com/repos/${repository}/commits/${commitHash}/comments", markdown)
+}
+
+def commentOnPullRequest (pullRequest, markdown)
+{
+    githubAddComment ("https://api.github.com/repos/${repository}/issues/${pullRequest}/comments", markdown)
+}
+
+def addComment (markdown)
+{
+    if (isPr) {
+        commentOnPullRequest ("${env.CHANGE_ID}", markdown)
+    } else {
+        commentOnCommit ("${gitHash}", markdown)
+    }
+}
+
+def reportFinalStatus (err, gitHash, currentStage)
+{
+    if (!createFinalStatus)
+        return
+
+    def commentFile = "${workspace}/xamarin-macios/jenkins/pr-comments.md"
+    def comment = null
+    def status = currentBuild.currentResult
+
+    if ("${status}" == "SUCCESS" && err == "") {
+        comment = "✅ [Jenkins job](${env.RUN_DISPLAY_URL}) succeeded"
+    } else {
+        comment = "🔥 [Jenkins job](${env.RUN_DISPLAY_URL}) failed in stage '${currentStage}' 🔥"
+        if (err != "")
+            comment += " : ${err}"
+        manager.addErrorBadge (comment)
+        manager.buildFailure ()
+    }
+
+    if (fileExists (commentFile))
+        comment += "\n\n" + readFile ("${commentFile}")
+
+    addComment ("${comment}")
+}
+
+def processAtMonkeyWrench (outputFile)
+{
+    def tmpfile = "atmonkeywrench.tmp"
+    try {
+        sh (script: "grep '^@MonkeyWrench: ...Summary: ' '${outputFile}' > ${tmpfile}", returnStatus: true /* don't throw exceptions if something goes wrong */)
+        def lines = readFile ("${tmpfile}").split ("\n")
+        for (int i = 0; i < lines.length; i++) {
+            def summary = lines [i].substring (27 /*"@MonkeyWrench: AddSummary: ".length*/).trim ()
+            summary = summary.replace ("<br/>", "")
+            summary = summary.replace ("<a href='", "")
+            def href_end = summary.indexOf ("'>")
+            if (href_end > 0)
+                summary = summary.substring (0, href_end)
+            echo (summary)
+        }
+    } finally {
+        sh ("rm -f '${tmpfile}'")
+    }
+}
+
+def uploadFiles (glob, virtualPath)
+{
+    step ([
+        $class: 'WAStoragePublisher',
+        allowAnonymousAccess: true,
+        cleanUpContainer: false,
+        cntPubAccess: true,
+        containerName: "wrench",
+        doNotFailIfArchivingReturnsNothing: false,
+        doNotUploadIndividualFiles: false,
+        doNotWaitForPreviousBuild: true,
+        excludeFilesPath: '',
+        filesPath: glob,
+        storageAccName: 'bosstoragemirror',
+        storageCredentialId: 'bc6a99d18d7d9ca3f6bf6b19e364d564',
+        uploadArtifactsOnlyIfSuccessful: false,
+        uploadZips: false,
+        virtualPath: virtualPath
+    ])
+}
+
+def runXamarinMacTests (url, macOS)
+{
+    try {
+        echo ("Executing on ${env.NODE_NAME}")
+        echo ("URL: ${url}")
+        sh ("env")
+        sh ("rm -f *.zip")
+        sh ("curl -L '${url}' --output mac-test-package.zip")
+        sh ("rm -rf mac-test-package")
+        sh ("unzip -o mac-test-package.zip")
+        sh ("cd mac-test-package && ./system-dependencies.sh --provision-mono --ignore-autotools --ignore-xamarin-studio --ignore-xcode --ignore-osx --ignore-cmake")
+        sh ("make -C mac-test-package/tests exec-mac-dontlink")
+        sh ("make -C mac-test-package/tests exec-mac-apitest")
+    } finally {
+        sh ("rm -rf mac-test-package *.zip")
+    }
+}
+
+timestamps {
+    node ('xamarin-macios && macos-10.13') {
+        try {
+            timeout (time: 9, unit: 'HOURS') {
+                // This runs into problems with the Jenkins sandbox:
+                // stage ("Checking for previous builds") {
+                //     abortExecutingBuilds ()
+                // }
+
+                // Hard-code a workspace, since branch-based and PR-based
+                // builds would otherwise use different workspaces, which
+                // wastes a lot of disk space.
+                workspace = "${env.HOME}/jenkins/workspace/xamarin-macios"
+                withEnv ([
+                    "PATH=/Library/Frameworks/Mono.framework/Versions/Current/Commands:${env.PATH}",
+                    "WORKSPACE=${workspace}"
+                    ]) {
+                    sh ("mkdir -p '${workspace}/xamarin-macios'")
+                    dir ("${workspace}/xamarin-macios") {
+                        stage ('Checkout') {
+                            currentStage = "${STAGE_NAME}"
+                            echo ("Building on ${env.NODE_NAME}")
+                            scmVars = checkout scm
+                            isPr = (env.CHANGE_ID && !env.CHANGE_ID.empty ? true : false)
+                            branchName = env.BRANCH_NAME
+                            if (isPr) {
+                                gitHash = sh (script: "git log -1 --pretty=%H refs/remotes/origin/${env.BRANCH_NAME}", returnStdout: true).trim ()
+                            } else {
+                                gitHash = scmVars.GIT_COMMIT
+                            }
+                            // Make sure we start from scratch
+                            sh (script: 'make git-clean-all', returnStatus: true /* don't throw exceptions if something goes wrong */)
+                            // Make really, really sure
+                            sh ('git clean -xffd')
+                            sh ('git submodule foreach --recursive git clean -xffd')
+                        }
+                    }
+
+                    if (isPr) {
+                        if (!githubGetPullRequestLabels ().contains ("build-package")) {
+                            // don't add a comment to the pull request, since the public jenkins will also add comments, which ends up being too much.
+                            createFinalStatus = false
+                            echo ("Build skipped because the pull request doesn't have the label 'build-package'.")
+                            return
+                        }
+
+                        skipLocalTestRunReason = "Not running tests here because they're run on public Jenkins."
+                    }
+
+                    dir ("${workspace}") {
+                        stage ('Provisioning') {
+                            currentStage = "${STAGE_NAME}"
+                            echo ("Building on ${env.NODE_NAME}")
+                            sh ("${workspace}/xamarin-macios/jenkins/provision-deps.sh")
+                        }
+
+                        stage ('Build') {
+                            currentStage = "${STAGE_NAME}"
+                            echo ("Building on ${env.NODE_NAME}")
+                            sh ("${workspace}/xamarin-macios/jenkins/build.sh --configure-flags --enable-xamarin")
+                        }
+
+                        stage ('Packaging') {
+                            currentStage = "${STAGE_NAME}"
+                            echo ("Building on ${env.NODE_NAME}")
+                            sh ("${workspace}/xamarin-macios/jenkins/build-package.sh")
+                            sh (script: "ls -la ${workspace}/package", returnStatus: true /* don't throw exceptions if something goes wrong */)
+                        }
+
+                        stage ('Signing') {
+                            currentStage = "${STAGE_NAME}"
+                            echo ("Building on ${env.NODE_NAME}")
+                            def xiPackages = findFiles (glob: "package/xamarin.ios-*.pkg")
+                            if (xiPackages.length > 0) {
+                                xiPackageFilename = xiPackages [0].name
+                                echo ("Created Xamarin.iOS package: ${xiPackageFilename}")
+                            }
+                            def xmPackages = findFiles (glob: "package/xamarin.mac-*.pkg")
+                            if (xmPackages.length > 0) {
+                                xmPackageFilename = xmPackages [0].name
+                                echo ("Created Xamarin.Mac package: ${xmPackageFilename}")
+                            }
+                            withCredentials ([string (credentialsId: 'codesign_keychain_pw', variable: 'PRODUCTSIGN_KEYCHAIN_PASSWORD')]) {
+                                sh ("${workspace}/xamarin-macios/jenkins/productsign.sh")
+                            }
+                        }
+
+                        stage ('Upload to Azure') {
+                            currentStage = "${STAGE_NAME}"
+                            virtualPath = "jenkins/${branchName}/${gitHash}/${env.BUILD_NUMBER}"
+                            packagePrefix = "https://bosstoragemirror.blob.core.windows.net/wrench/${virtualPath}/package"
+
+                            // Create metadata.json and manifest
+                            def uploadingFiles = findFiles (glob: "package/*")
+                            def manifest = ""
+                            def metadata = "[\n"
+                            for (int i = 0; i < uploadingFiles.length; i++) {
+                                def file = uploadingFiles [i]
+                                def f_length = file.length;
+                                def md5 = sh (returnStdout: true, script: "md5 -q '${file}'").trim ()
+                                manifest += "${packagePrefix}/${file.name}\n"
+                                metadata += "  {\n    \"file\": \"${file.name}\",\n    \"md5\": \"${md5}\",\n    \"size\": ${f_length}\n  }"
+                                if (i < uploadingFiles.length - 1)
+                                    metadata += ","
+                                metadata +="\n"
+                            }
+                            metadata += "]\n"
+                            manifest += "${packagePrefix}/metadata.json\n"
+                            manifest += "${packagePrefix}/manifest\n"
+                            writeFile (file: "package/manifest", text: manifest)
+                            writeFile (file: "package/metadata.json", text: metadata)
+
+                            sh ("ls -la package")
+                            uploadFiles ("package/*", virtualPath)
+
+                            // Also upload manifest to a predictable url (without the build number)
+                            // This manifest will be overwritten in subsequent builds (for this [PR/branch]+hash combination)
+                            uploadFiles ("package/manifest", "jenkins/${branchName}/${gitHash}")
+                            // And also create a 'latest' version (which really means 'latest built', not 'latest hash', but it will hopefully be good enough)
+                            uploadFiles ("package/manifest", "jenkins/${branchName}/latest")
+
+                            manifestFilename = "manifest"
+                        }
+
+                        stage ('Publish builds to GitHub') {
+                            currentStage = "${STAGE_NAME}"
+                            utils = load ("${workspace}/xamarin-macios/jenkins/utils.groovy")
+                            if (xiPackageFilename != null) {
+                                xiPackageUrl = "${packagePrefix}/${xiPackageFilename}"
+                                utils.reportGitHubStatus (gitHash, 'jenkins-PKG-Xamarin.iOS', "${xiPackageUrl}", 'SUCCESS', "${xiPackageFilename}")
+                            }
+                            if (xmPackageFilename != null) {
+                                xmPackageUrl = "${packagePrefix}/${xmPackageFilename}"
+                                utils.reportGitHubStatus (gitHash, 'jenkins-PKG-Xamarin.Mac', "${xmPackageUrl}", 'SUCCESS', "${xmPackageFilename}")
+                            }
+                            if (manifestFilename != null) {
+                                def manifestUrl = "${packagePrefix}/${manifestFilename}"
+                                utils.reportGitHubStatus (gitHash, '${manifestFilename}', "${manifestUrl}", 'SUCCESS', "${manifestFilename}")
+                            }
+                        }
+
+                        dir ('xamarin-macios') {
+                            stage ('Launch external tests') {
+                                currentStage = "${STAGE_NAME}"
+                                if (isPr) {
+                                    echo "Currently not launching external tests for pull requests"
+                                } else {
+                                    def outputFile = "${workspace}/xamarin-macios/wrench-launch-external.output.tmp"
+                                    try {
+                                        withCredentials ([string (credentialsId: 'macios_provisionator_pat', variable: 'PROVISIONATOR_VSTS_PAT')]) {
+                                            sh ("make -C ${workspace}/xamarin-macios/tests wrench-launch-external MAC_PACKAGE_URL=${xmPackageUrl} IOS_PACKAGE_URL=${xiPackageUrl} WRENCH_URL=${env.RUN_DISPLAY_URL} BUILD_REVISION=${gitHash} BUILD_LANE=jenkins/${branchName} BUILD_WORK_HOST=${env.NODE_NAME} 2>&1 | tee ${outputFile}")
+                                        }
+                                        processAtMonkeyWrench (outputFile)
+                                    } catch (error) {
+                                        echo ("🚫 Launching external tests failed: ${error} 🚫")
+                                        manager.addWarningBadge ("Failed to launch external tests")
+                                    } finally {
+                                        sh ("rm -f '${outputFile}'")
+                                    }
+                                }
+                            }
+
+                            stage ('Install Provisioning Profiles') {
+                                currentStage = "${STAGE_NAME}"
+                                sh ("${workspace}/maccore/tools/install-qa-provisioning-profiles.sh")
+                            }
+
+                            stage ('Publish reports') {
+                                currentStage = "${STAGE_NAME}"
+                                reportPrefix = sh (script: "${workspace}/xamarin-macios/jenkins/publish-results.sh | grep '^Url Prefix: ' | sed 's/^Url Prefix: //'", returnStdout: true).trim ()
+                                if (skipLocalTestRunReason == "") {
+                                    echo ("Html report: ${reportPrefix}/tests/index.html")
+                                } else {
+                                    echo ("Html report: ${skipLocalTestRunReason}")
+                                }
+                                echo ("API diff (from stable): ${reportPrefix}/api-diff/index.html")
+                                echo ("API diff (from previous commit / before pull request): ${reportPrefix}/apicomparison/api-diff.html")
+                                echo ("Generator diff: ${reportPrefix}/generator-diff/index.html")
+                            }
+
+                            stage ('API diff') {
+                                currentStage = "${STAGE_NAME}"
+                                def apidiffResult = sh (script: "${workspace}/xamarin-macios/jenkins/build-api-diff.sh --publish", returnStatus: true)
+                                if (apidiffResult != 0)
+                                    manager.addWarningBadge ("Failed to generate API diff")
+                                echo ("API diff (from stable): ${reportPrefix}/api-diff/index.html")
+                            }
+
+                            stage ('API & Generator comparison') {
+                                currentStage = "${STAGE_NAME}"
+                                def compareResult = sh (script: "${workspace}/xamarin-macios/jenkins/compare.sh --publish", returnStatus: true)
+                                if (compareResult != 0)
+                                    manager.addWarningBadge ("Failed to generate API / Generator diff")
+                                echo ("API diff (from previous commit / before pull request): ${reportPrefix}/apicomparison/api-diff.html")
+                                echo ("Generator diff: ${reportPrefix}/generator-diff/index.html")
+                            }
+
+                            stage ("Package XM tests") {
+                                currentStage = "${STAGE_NAME}"
+                                sh ("make -C ${workspace}/xamarin-macios/tests package-tests")
+                                uploadFiles ("tests/*.zip", virtualPath)
+                            }
+
+                            timeout (time: 6, unit: 'HOURS') {
+                                // We run tests locally and on older macOS bots in parallel.
+                                // The older macOS tests run quickly (and the bots should usually be idle),
+                                // which means that the much longer normal (local) test run should take
+                                // longer to complete (which is important since this will block until all tests
+                                // have been run, even if any older macOS bots are busy doing other things, preventing
+                                // our tests from running there), giving the older macOS bots plenty of
+                                // time to finish their test runs.
+                                stage ('Run tests parallelized') {
+                                    def builders = [:]
+
+                                    // Add test runs on older macOS versions
+                                    def url = "https://bosstoragemirror.blob.core.windows.net/wrench/${virtualPath}/tests/mac-test-package.zip"
+                                    def firstOS = sh (returnStdout: true, script: "grep ^MIN_OSX_SDK_VERSION= '${workspace}/xamarin-macios/Make.config' | sed 's/.*=//'").trim ().split ("\\.")[1].toInteger ()
+                                    def lastOS = sh (returnStdout: true, script: "grep ^OSX_SDK_VERSION= '${workspace}/xamarin-macios/Make.config' | sed 's/.*=//'").trim ().split ("\\.")[1].toInteger ()
+                                    for (os = firstOS; os < lastOS; os++) {
+                                        def macOS = "${os}" // Need to bind the label variable before the closure
+                                        builders ["XM tests on 10.${macOS}"] = {
+                                            try {
+                                                node ("xamarin-macios && macos-10.${macOS}") {
+                                                    stage ("Running XM tests on '10.${macOS}'") {
+                                                        runXamarinMacTests (url, "macOS 10.${macOS}")
+                                                    }
+                                                }
+                                            } catch (err) {
+                                                currentStage = "Running XM tests on '10.${macOS}'"
+                                                throw err
+                                            }
+                                        }
+                                    }
+
+                                    // Add standard test run
+                                    builders ["All tests"] = {
+                                        stage ('Run tests') {
+                                            currentStage = "Test run"
+                                            echo ("Building on ${env.NODE_NAME}")
+                                            if (skipLocalTestRunReason != "") {
+                                                echo (skipLocalTestRunReason)
+                                            } else {
+                                                echo ("Html report: ${reportPrefix}/tests/index.html")
+                                                sh ("${workspace}/xamarin-macios/jenkins/run-tests.sh --target=wrench-jenkins --publish --keychain=xamarin-macios")
+                                            }
+                                        }
+                                        stage ('Test docs') {
+                                            currentStage = "${STAGE_NAME}"
+                                            echo ("Building on ${env.NODE_NAME}")
+                                            sh ("make -C ${workspace}/xamarin-macios/tests wrench-docs")
+                                        }
+                                    }
+
+                                    // Run it all parallelized
+                                    parallel builders
+                                }
+                            }
+                        } // dir ("xamarin-macios")
+                    } // dir ("${workspace}")
+                }
+                reportFinalStatus ("", "${gitHash}", "${currentStage}")
+            } // timeout
+        } catch (err) {
+            reportFinalStatus ("${err}", "${gitHash}", "${currentStage}")
+        } finally {
+            stage ('Final tasks') {
+                sh (script: "${workspace}/xamarin-macios/jenkins/publish-results.sh", returnStatus: true /* don't throw exceptions if something goes wrong */)
+                sh (script: "make git-clean-all -C ${workspace}/xamarin-macios", returnStatus: true /* don't throw exceptions if something goes wrong */)
+            }
+        }
+    } // node
+} // timestamps

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -2,6 +2,7 @@
 
 // global variables
 repository = "xamarin/xamarin-macios"
+commentFile = null
 isPr = false
 branchName = null
 gitHash = null
@@ -94,12 +95,19 @@ def addComment (markdown)
     }
 }
 
+def appendFileComment (comment)
+{
+    if (fileExists (commentFile))
+        comment = readFile (comment) + comment
+
+    writeFile (file: commentFile, text: comment)
+}
+
 def reportFinalStatus (err, gitHash, currentStage)
 {
     if (!createFinalStatus)
         return
 
-    def commentFile = "${workspace}/xamarin-macios/jenkins/pr-comments.md"
     def comment = null
     def status = currentBuild.currentResult
 
@@ -186,6 +194,7 @@ timestamps {
                 // builds would otherwise use different workspaces, which
                 // wastes a lot of disk space.
                 workspace = "${env.HOME}/jenkins/workspace/xamarin-macios"
+                commentFile = "${workspace}/xamarin-macios/jenkins/pr-comments.md"
                 withEnv ([
                     "PATH=/Library/Frameworks/Mono.framework/Versions/Current/Commands:${env.PATH}",
                     "WORKSPACE=${workspace}"
@@ -402,6 +411,7 @@ timestamps {
                                                 }
                                             } catch (err) {
                                                 currentStage = "Running XM tests on '10.${macOS}'"
+                                                appendFileComment ("🔥 [Xamarin.Mac tests on 10.${macOS} failed](${env.RUN_DISPLAY_URL}) 🔥\n")
                                                 throw err
                                             }
                                         }
@@ -414,6 +424,7 @@ timestamps {
                                             echo ("Building on ${env.NODE_NAME}")
                                             if (skipLocalTestRunReason != "") {
                                                 echo (skipLocalTestRunReason)
+                                                appendFileComment ("ℹ️ Test run skipped: ${skipLocalTestRunReason}")
                                             } else {
                                                 echo ("Html report: ${reportPrefix}/tests/index.html")
                                                 sh ("${workspace}/xamarin-macios/jenkins/run-tests.sh --target=wrench-jenkins --publish --keychain=xamarin-macios")

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -241,7 +241,12 @@ timestamps {
                         stage ('Build') {
                             currentStage = "${STAGE_NAME}"
                             echo ("Building on ${env.NODE_NAME}")
-                            sh ("${workspace}/xamarin-macios/jenkins/build.sh --configure-flags --enable-xamarin")
+                            withEnv ([
+                                "CURRENT_BRANCH=${branchName}",
+                                "PACKAGE_HEAD_BRANCH=${branchName}"
+                                ]) {
+                                sh ("${workspace}/xamarin-macios/jenkins/build.sh --configure-flags --enable-xamarin")
+                            }
                         }
 
                         stage ('Packaging') {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -98,7 +98,7 @@ def addComment (markdown)
 def appendFileComment (comment)
 {
     if (fileExists (commentFile))
-        comment = readFile (comment) + comment
+        comment = readFile (commentFile) + comment
 
     writeFile (file: commentFile, text: comment)
 }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -20,31 +20,6 @@ reportPrefix = null
 createFinalStatus = true
 skipLocalTestRunReason = ""
 
-def abortExecutingBuilds ()
-{
-    // This runs into problems with the Jenkins sandbox:
-    //      org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use method jenkins.model.Jenkins getItemByFullName java.lang.String
-    // so disable for now.
-
-    // def job = Jenkins.instance.getItemByFullName (env.JOB_NAME)
-    // for (build in job.builds) {
-    //     if (!build.isBuilding ())
-    //         continue
-
-    //     if (build.number > currentBuild.number) {
-    //         error ("There is already a newer build in progress (#${build.number})")
-    //     } else if (build.number < currentBuild.number) {
-    //         def exec = build.getExecutor ()
-    //         if (exec == null) {
-    //             echo ("No executor for build ${build.number}")
-    //         } else {
-    //             exec.interrupt (Result.ABORTED, new CauseOfInterruption.UserInterruption ("Aborted by build #${currentBuild.number}"))
-    //             echo ("Aborted previous build: #${build.number}")
-    //         }
-    //     }
-    // }
-}
-
 github_pull_request_info = null
 def githubGetPullRequestInfo ()
 {
@@ -207,11 +182,6 @@ timestamps {
     node ('xamarin-macios && macos-10.13') {
         try {
             timeout (time: 9, unit: 'HOURS') {
-                // This runs into problems with the Jenkins sandbox:
-                // stage ("Checking for previous builds") {
-                //     abortExecutingBuilds ()
-                // }
-
                 // Hard-code a workspace, since branch-based and PR-based
                 // builds would otherwise use different workspaces, which
                 // wastes a lot of disk space.

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -429,7 +429,7 @@ timestamps {
                                             echo ("Building on ${env.NODE_NAME}")
                                             if (skipLocalTestRunReason != "") {
                                                 echo (skipLocalTestRunReason)
-                                                appendFileComment ("ℹ️ Test run skipped: ${skipLocalTestRunReason}")
+                                                appendFileComment ("ℹ️ Test run skipped: ${skipLocalTestRunReason}\n")
                                             } else {
                                                 echo ("Html report: ${reportPrefix}/tests/index.html")
                                                 sh ("${workspace}/xamarin-macios/jenkins/run-tests.sh --target=wrench-jenkins --publish --keychain=xamarin-macios")

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -324,7 +324,7 @@ timestamps {
                             }
                             if (manifestFilename != null) {
                                 def manifestUrl = "${packagePrefix}/${manifestFilename}"
-                                utils.reportGitHubStatus (gitHash, '${manifestFilename}', "${manifestUrl}", 'SUCCESS', "${manifestFilename}")
+                                utils.reportGitHubStatus (gitHash, "${manifestFilename}", "${manifestUrl}", 'SUCCESS', "${manifestFilename}")
                             }
                         }
 

--- a/jenkins/build-api-diff.sh
+++ b/jenkins/build-api-diff.sh
@@ -12,4 +12,11 @@ trap report_error ERR
 export BUILD_REVISION=jenkins
 make -j8 -C tools/apidiff jenkins-api-diff
 
-printf "✅ [API Diff (from stable)](%s/API_20diff_20_28from_20stable_29)\\n" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"
+if [[ "x$1" == "x--publish" ]]; then
+	URL_PREFIX=$(./jenkins/publish-results.sh | grep "^Url Prefix: " | sed 's/^Url Prefix: //')
+	URL="$URL_PREFIX/api-diff/index.html"
+else
+	URL="$BUILD_URL/API_20diff_20_28from_20stable_29"
+fi
+
+printf "✅ [API Diff (from stable)](%s)\\n" "$URL" >> "$WORKSPACE/jenkins/pr-comments.md"

--- a/jenkins/build-package.sh
+++ b/jenkins/build-package.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+#WORKSPACE=$(pwd)
+
+rm -Rf ../package
+make package

--- a/jenkins/compare.sh
+++ b/jenkins/compare.sh
@@ -11,15 +11,21 @@ report_error ()
 }
 trap report_error ERR
 
-
-if ./jenkins/fetch-pr-labels.sh --check=skip-api-comparison; then
-	printf "❎ Skipped API comparison because the PR has the label 'skip-api-comparison'\\n" >> "$WORKSPACE/jenkins/pr-comments.md"
-	exit 0
-fi
-
 # SC2154: ghprbPullId is referenced but not assigned.
 # shellcheck disable=SC2154
-BASE="origin/pr/$ghprbPullId/merge"
+if test -n "$ghprbPullId"; then
+	if ./jenkins/fetch-pr-labels.sh --check=skip-api-comparison; then
+		printf "❎ Skipped API comparison because the PR has the label 'skip-api-comparison'\\n" >> "$WORKSPACE/jenkins/pr-comments.md"
+		exit 0
+	fi
+fi
+
+if test -z "$ghprbPullId"; then
+	BASE=HEAD
+else
+	BASE="origin/pr/$ghprbPullId/merge"
+fi
+
 if ! git rev-parse "$BASE" >/dev/null 2>&1; then
 	echo "Can't compare API and create generator diff because the pull request has conflicts that must be resolved first (the branch '$BASE' doesn't exist)."
 	printf "🔥 [Failed to compare API and create generator diff because the pull request has conflicts that must be resolved first](%s/console) 🔥\\n" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"
@@ -34,7 +40,16 @@ cp -R tools/comparison/apidiff/diff jenkins-results/apicomparison/
 cp    tools/comparison/apidiff/*.html jenkins-results/apicomparison/
 cp -R tools/comparison/generator-diff jenkins-results/generator-diff
 
-printf "✅ [API Diff (from PR only)](%s/API_20diff_20_28PR_20only_29)" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"
+if [[ "x$1" == "x--publish" ]]; then
+	URL_PREFIX=$(./jenkins/publish-results.sh | grep "^Url Prefix: " | sed 's/^Url Prefix: //')
+	URL_API="$URL_PREFIX/apicomparison/index.html"
+	URL_GENERATOR="$URL_PREFIX/generator-diff/index.html"
+else
+	URL_API="$BUILD_URL/API_20diff_20_28PR_20only_29"
+	URL_GENERATOR="$BUILD_URL/Generator_20Diff"
+fi
+
+printf "✅ [API Diff (from PR only)](%s)" "$URL_API" >> "$WORKSPACE/jenkins/pr-comments.md"
 if ! grep "href=" jenkins-results/apicomparison/api-diff.html >/dev/null 2>&1; then
 	printf " (no change)" >> "$WORKSPACE/jenkins/pr-comments.md"
 elif perl -0777 -pe 's/<script type="text\/javascript">.*?<.script>/script removed/gs' jenkins-results/apicomparison/*.html | grep data-is-breaking; then
@@ -44,7 +59,7 @@ else
 fi
 printf "\\n" >> "$WORKSPACE/jenkins/pr-comments.md"
 
-printf "✅ [Generator Diff](%s/Generator_20Diff)" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"
+printf "✅ [Generator Diff](%s)" "$URL_GENERATOR" >> "$WORKSPACE/jenkins/pr-comments.md"
 if grep "^[+-][^+-]" jenkins-results/generator-diff/generator.diff | grep -v "^.[[]assembly: AssemblyInformationalVersion" | grep -v "^[+-][[:space:]]*internal const string Revision =" >/dev/null 2>&1; then
 	printf " (please review changes)" >> "$WORKSPACE/jenkins/pr-comments.md"
 else

--- a/jenkins/productsign.sh
+++ b/jenkins/productsign.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -ex
+#
+# productsign.sh: run productsign against any installer .pkg
+# files in the package output directory for the lane, signing
+# with the Xamarin Developer Installer identity and verifying
+# the signature's fingerprint after the fact.
+#
+# Author:
+#   Aaron Bockover <abock@xamarin.com>
+#
+# Copyright 2014 Xamarin, Inc.
+#
+
+PRODUCTSIGN_KEYCHAIN="login.keychain"
+PRODUCTSIGN_IDENTITY="Developer ID Installer: Xamarin Inc"
+PRODUCTSIGN_FINGERPRINT="3F:BE:54:B1:41:8B:F1:20:FA:B4:9D:A7:F2:5E:72:95:5A:49:21:D6"
+
+if [ -z "$PRODUCTSIGN_KEYCHAIN_PASSWORD" ]; then
+	echo "PRODUCTSIGN_KEYCHAIN_PASSWORD is not set."
+	exit 1
+fi
+
+SIGNING_DIR=$(pwd)/package-signed
+mkdir -p "$SIGNING_DIR"
+
+echo Before signing
+ls -l package
+
+security -v find-identity $PRODUCTSIGN_KEYCHAIN
+security unlock-keychain -p "$PRODUCTSIGN_KEYCHAIN_PASSWORD" "$PRODUCTSIGN_KEYCHAIN"
+
+for pkg in package/*.pkg; do
+	productsign -s "$PRODUCTSIGN_IDENTITY" "$pkg" "$SIGNING_DIR/$(basename "$pkg")" --keychain $PRODUCTSIGN_KEYCHAIN
+done
+
+echo Signing output
+ls -l "$SIGNING_DIR"
+
+mv "$SIGNING_DIR"/* package
+
+echo After signing
+ls -l package
+
+echo 'setns x=http://www.w3.org/2000/09/xmldsig#' > shell.xmllint
+echo 'cat (//xar/toc/signature/x:KeyInfo/x:X509Data/x:X509Certificate)[1]/text()' >> shell.xmllint
+
+echo Signature Verification
+for pkg in package/*.pkg; do
+	/usr/sbin/spctl -vvv --assess --type install "$pkg"
+	pkgutil --check-signature "$pkg"
+	xar -f "$pkg" --dump-toc="$pkg.toc"
+	(
+		echo '-----BEGIN CERTIFICATE-----' &&
+		xmllint --shell "$pkg.toc" < shell.xmllint | grep -Ev '^/' &&
+		echo '-----END CERTIFICATE-----'
+	) | openssl x509 -fingerprint | grep "$PRODUCTSIGN_FINGERPRINT" || exit 1
+done
+
+rm shell.xmllint

--- a/jenkins/publish-results.sh
+++ b/jenkins/publish-results.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -ex
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+WORKSPACE=$(pwd)
+
+report_error ()
+{
+	printf "🔥 [Failed to publish results](%s/console) 🔥\\n" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"
+}
+trap report_error ERR
+
+# SC2154: ghprbPullId is referenced but not assigned.
+# shellcheck disable=SC2154
+if test -n "$ghprbPullId"; then
+	BRANCH_NAME="pr$ghprbPullId"
+elif test -z "$BRANCH_NAME"; then
+	echo "Neither BRANCH_NAME nor ghprbPullId is set"
+	exit 1
+fi
+if test -z "$BUILD_NUMBER"; then
+	echo "BUILD_NUMBER is not set"
+	exit 1
+fi
+P="jenkins/xamarin-macios/${BRANCH_NAME}/$(git log -1 --pretty=%H)/${BUILD_NUMBER}"
+
+echo "Url Prefix: http://xamarin-storage/$P/jenkins-results"
+echo "Periodic Command: --periodic-interval 10 --periodic-command rsync --periodic-command-arguments '-avz --chmod=+r -e ssh $WORKSPACE/jenkins-results builder@xamarin-storage:/volume1/storage/$P'"
+
+mkdir -p "$WORKSPACE/jenkins-results"
+
+# Publish
+
+# Make sure the target directory exists
+
+# SC2029: Note that, unescaped, this expands on the client side. [Referring to $P]
+# shellcheck disable=SC2029
+ssh builder@xamarin-storage "mkdir -p /volume1/storage/$P"
+rsync -avz --chmod=+r -e ssh "$WORKSPACE/jenkins-results" "builder@xamarin-storage:/volume1/storage/$P"

--- a/jenkins/run-tests.sh
+++ b/jenkins/run-tests.sh
@@ -5,7 +5,7 @@ WORKSPACE=$(pwd)
 
 report_error ()
 {
-	printf "🔥 [Test run failed](%s/Test_20Report) 🔥\\n" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"
+	printf "🔥 [Test run failed](%s) 🔥\\n" "$URL" >> "$WORKSPACE/jenkins/pr-comments.md"
 
 	if test -f "$WORKSPACE/tests/TestSummary.md"; then
 		printf "\\n" >> "$WORKSPACE/jenkins/pr-comments.md"
@@ -16,28 +16,81 @@ report_error ()
 }
 trap report_error ERR
 
+TARGET=jenkins
+PUBLISH=
+KEYCHAIN=builder
+KEYCHAIN_PWD_FILE=~/.config/keychain
+while ! test -z "$1"; do
+	case "$1" in
+		--target=*)
+			TARGET="${1:9}"
+			shift
+			;;
+		--keychain=*)
+			KEYCHAIN="${1:11}"
+			KEYCHAIN_PWD_FILE=~/.config/$KEYCHAIN-keychain
+			shift
+			;;
+		--publish)
+			PUBLISH=1
+			shift
+			;;
+		*)
+			echo "Unknown argument: $1"
+			exit 1
+			;;
+    esac
+done
+
+if test -n "$PUBLISH"; then
+	PUBLISH_OUTPUT=$(./jenkins/publish-results.sh)
+	URL_PREFIX=$(echo "$PUBLISH_OUTPUT" | grep "^Url Prefix: " | sed 's/^Url Prefix: //')
+	URL="$URL_PREFIX/tests/index.html"
+	TESTS_PERIODIC_COMMAND=$(echo "$PUBLISH_OUTPUT" | grep "^Periodic Command: " | sed 's/^Periodic Command: //')
+	export TESTS_PERIODIC_COMMAND
+else
+	URL="$BUILD_URL/Test_20Report"
+fi
+
+
 export BUILD_REVISION=jenkins
 
 # Unlock
-security default-keychain -s builder.keychain
-security list-keychains -s builder.keychain
+if ! test -f ~/Library/Keychains/"$KEYCHAIN".keychain-db; then
+	echo "The '$KEYCHAIN' keychain is not available."
+	exit 1
+fi
+security default-keychain -s "$KEYCHAIN.keychain"
+security list-keychains -s "$KEYCHAIN.keychain"
 echo "Unlock keychain"
-security unlock-keychain -p "$(cat ~/.config/keychain)"
+security unlock-keychain -p "$(cat "$KEYCHAIN_PWD_FILE")"
 echo "Increase keychain unlock timeout"
 security set-keychain-settings -lut 7200
+security -v find-identity "$KEYCHAIN.keychain"
 
 # Prevent dialogs from asking for permissions.
 # http://stackoverflow.com/a/40039594/183422
 # Discard output since there can be a *lot* of it.
-security set-key-partition-list -S apple-tool:,apple: -s -k "$(cat ~/.config/keychain)" builder.keychain >/dev/null 2>&1
+security set-key-partition-list -S apple-tool:,apple: -s -k "$(cat "$KEYCHAIN_PWD_FILE")" "$KEYCHAIN.keychain" >/dev/null 2>&1
 
 # clean mono keypairs (used in tests)
 rm -rf ~/.config/.mono/keypairs/
 
 # Run tests
-make -C tests jenkins
+RC=0
+make -C tests "$TARGET" || RC=$?
 
-printf "✅ [Test run succeeded](%s/Test_20Report/)\\n" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"
+# upload of the final html report
+if test -n "$PUBLISH"; then
+	./jenkins/publish-results.sh
+fi
+
+if [[ x$RC != x0 ]]; then
+	report_error
+	exit $RC
+fi
+
+printf "✅ [Test run succeeded](%s)\\n" "$URL" >> "$WORKSPACE/jenkins/pr-comments.md"
 
 if test -f "$WORKSPACE/jenkins/failure-stamp"; then
 	echo "Something went wrong:"

--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -1,0 +1,11 @@
+def reportGitHubStatus(commitHash, context, backref, statusResult, statusResultMessage) {
+    step([
+        $class: 'GitHubCommitStatusSetter',
+        commitShaSource: [$class: "ManuallyEnteredShaSource", sha: commitHash],
+        contextSource: [$class: 'ManuallyEnteredCommitContextSource', context: context],
+        statusBackrefSource: [$class: 'ManuallyEnteredBackrefSource', backref: backref],
+        statusResultSource: [$class: 'ConditionalStatusResultSource', results: [[$class: 'AnyBuildResult', state: statusResult, message: statusResultMessage]]]
+    ])
+}
+
+return this


### PR DESCRIPTION
Add support for building on internal Jenkins.

Jenkins has been configured to build every branch on xamarin/xamarin-macios that contains a `jenkins/Jenkinsfile`, which means it will start working as soon as this PR is merged.

Results will be posted as statuses on each commit, which can be viewed using the url `https://github.com/xamarin/xamarin-macios/commits/<branch>`:

![screenshot 2018-06-01 11 12 57](https://user-images.githubusercontent.com/249268/40832932-c3b05eb0-658c-11e8-9670-8de5fcc23407.png)

* The `continuous-integration/jenkins/branch` status links to the jenkins job.
* The other two are XI and XM packages (the `Jenkins-` prefix will be removed once we officially switch from Wrench to Jenkins).

More detailed information will be added as a comment to each commit, which can be seen by clicking on the commit and scrolling to the bottom (url of the format `https://github.com/xamarin/xamarin-macios/commit/<sha1>`)

![screenshot 2018-06-01 11 14 33](https://user-images.githubusercontent.com/249268/40833014-fd8772f4-658c-11e8-8a35-5df46bfb16c7.png)

Unfortunately GitHub does not display the commit statuses when viewing a single commit, so to view those statuses you'll have to view the list of commits (the `/commits/` url). Tip: it's possible to use `<sha1>` instead of `<branch>` (and vice versa for that matter) if you're interested in the statuses of a particular commit.

Pull requests will also be built (only from contributors with write access), but by default nothing will be done (the job will exit immediately, although a green check mark will still show up). Jenkins will **not** add a comment in the pull request in this case.

However, if the label `build-package` [1] is set for a pull request, the internal jenkins job will run (it will do everything except the local xharness test run: this includes creating and publishing packages, creating various diffs, run tests on older macOS versions, test docs, etc). A detailed comment will also be added to the pull request (see below for multiple examples), which means that there will be two Jenkins comments: one for the public Jenkins which builds every PR, and one for the internal Jenkins [2].

[1] I don't quite like the name of the label, because it doesn't get even close to explain all that will actually happen, but `run-on-internal-jenkins-and-create-package` is a bit too long IMHO... Also it's non-obvious that this is the label to apply if the reason for executing on the internal jenkins is some other reason (for instance to test a maccore bump). Other ideas:

* `run-internal-jenkins`: doesn't make it obvious that a package will be created (which is probably the most common reason to want to run on internal jenkins)
* We could have multiple labels that mean the same thing: `build-package`, `internal-build`, `run-internal-jenkins`, etc, but it's redundant and I don't quite like it either.
* Any other ideas?

[2] I'm noticing now that these two look quite similar and this might end up confusing (the main difference is that the comment from the public jenkins will say **Build success/failure** and **Build comment file:** at the top. If something goes wrong the failure will also show up differently). Should this be made clearer?