### PR TITLE
Optimize NSActionDispatcher usage

### DIFF
--- a/src/AppKit/AppKitSynchronizationContext.cs
+++ b/src/AppKit/AppKitSynchronizationContext.cs
@@ -14,12 +14,12 @@ namespace AppKit {
 
 		public override void Post (SendOrPostCallback d, object state)
 		{
-			NSRunLoop.Main.BeginInvokeOnMainThread (() => d (state));
+			NSRunLoop.Main.BeginInvokeOnMainThread (d, state);
 		}
 
 		public override void Send (SendOrPostCallback d, object state)
 		{
-			NSRunLoop.Main.InvokeOnMainThread (() => d (state));
+			NSRunLoop.Main.InvokeOnMainThread (d, state);
 		}
 	}
 }

--- a/src/Foundation/NSAction.cs
+++ b/src/Foundation/NSAction.cs
@@ -54,31 +54,6 @@ namespace Foundation {
 		}
 	}
 
-	// Use this for synchronous operations
-	[Register ("__MonoMac_ActionDispatcher")]
-	internal sealed class ActionDispatcher : NSObject {
-		public const string SelectorName = "xamarinApplySelector";
-		public static readonly Selector Selector = new Selector (SelectorName);
-
-		readonly Action action;
-
-		public ActionDispatcher (Action action)
-		{
-			if (action == null)
-				throw new ArgumentNullException ("action");
-
-			this.action = action;
-			IsDirectBinding = false;
-		}
-
-		[Export (SelectorName)]
-		[Preserve (Conditional = true)]
-		public void Apply ()
-		{
-			action ();
-		}
-	}
-
 	// Used this for NSTimer support
 	[Register ("__Xamarin_NSTimerActionDispatcher")]
 	internal sealed class NSTimerActionDispatcher : NSObject {

--- a/src/Foundation/NSAction.cs
+++ b/src/Foundation/NSAction.cs
@@ -34,9 +34,7 @@ namespace Foundation {
 	[Register ("__MonoMac_NSActionDispatcher")]
 	internal sealed class NSActionDispatcher : NSObject {
 		public const string SelectorName = "xamarinApplySelector";
-#if MONOMAC
 		public static readonly Selector Selector = new Selector (SelectorName);
-#endif
 
 		readonly Action action;
 
@@ -91,9 +89,7 @@ namespace Foundation {
 	[Register ("__Xamarin_NSTimerActionDispatcher")]
 	internal sealed class NSTimerActionDispatcher : NSObject {
 		public const string SelectorName = "xamarinFireSelector:";
-#if MONOMAC
 		public static readonly Selector Selector = new Selector (SelectorName);
-#endif
 
 		readonly Action<NSTimer> action;
 

--- a/src/Foundation/NSAction.cs
+++ b/src/Foundation/NSAction.cs
@@ -159,7 +159,7 @@ namespace Foundation {
 
 	// Use this for asynchronous operations
 	[Register ("__MonoMac_NSAsyncSynchronizationContextDispatcher")]
-	internal class NSAsyncSynchronizationContextDispatcher : NSAsyncDispatcher {
+	internal sealed class NSAsyncSynchronizationContextDispatcher : NSAsyncDispatcher {
 		SendOrPostCallback d;
 		object state;
 

--- a/src/Foundation/NSAction.cs
+++ b/src/Foundation/NSAction.cs
@@ -82,6 +82,8 @@ namespace Foundation {
 	// Use this for asynchronous operations
 	[Register ("__MonoMac_NSAsyncActionDispatcher")]
 	internal class NSAsyncActionDispatcher : NSObject {
+		public const string SelectorName = "xamarinApplySelector";
+		public static readonly Selector Selector = new Selector (SelectorName);
 		GCHandle gch;
 		Action action;
 
@@ -92,7 +94,7 @@ namespace Foundation {
 			IsDirectBinding = false;
 		}
 
-		[Export (NSActionDispatcher.SelectorName)]
+		[Export (SelectorName)]
 		[Preserve (Conditional = true)]
 		public void Apply ()
 		{

--- a/src/Foundation/NSAction.cs
+++ b/src/Foundation/NSAction.cs
@@ -34,7 +34,9 @@ namespace Foundation {
 	[Register ("__MonoMac_NSActionDispatcher")]
 	internal sealed class NSActionDispatcher : NSObject {
 		public const string SelectorName = "xamarinApplySelector";
+#if MONOMAC
 		public static readonly Selector Selector = new Selector (SelectorName);
+#endif
 
 		readonly Action action;
 
@@ -60,15 +62,21 @@ namespace Foundation {
 	internal sealed class NSActionDispatcher2 : NSObject
 	{
 		public const string SelectorName = "xamarinApplySelector";
+#if MONOMAC
 		public static readonly Selector Selector = new Selector (SelectorName);
+#endif
 
 		readonly SendOrPostCallback d;
 		readonly object state;
 
 		public NSActionDispatcher2 (SendOrPostCallback d, object state)
 		{
+			if (d == null)
+				throw new ArgumentNullException (nameof (d));
+
 			this.d = d;
 			this.state = state;
+			IsDirectBinding = false;
 		}
 
 		[Export (SelectorName)]
@@ -83,7 +91,9 @@ namespace Foundation {
 	[Register ("__Xamarin_NSTimerActionDispatcher")]
 	internal sealed class NSTimerActionDispatcher : NSObject {
 		public const string SelectorName = "xamarinFireSelector:";
+#if MONOMAC
 		public static readonly Selector Selector = new Selector (SelectorName);
+#endif
 
 		readonly Action<NSTimer> action;
 
@@ -108,12 +118,17 @@ namespace Foundation {
 	[Register ("__MonoMac_NSAsyncActionDispatcher")]
 	internal class NSAsyncActionDispatcher : NSObject {
 		public const string SelectorName = "xamarinApplySelector";
+#if MONOMAC
 		public static readonly Selector Selector = new Selector (SelectorName);
+#endif
 		GCHandle gch;
 		Action action;
 
 		public NSAsyncActionDispatcher (Action action)
 		{
+			if (action == null)
+				throw new ArgumentNullException (nameof (action));
+
 			this.action = action;
 			gch = GCHandle.Alloc (this);
 			IsDirectBinding = false;
@@ -150,7 +165,9 @@ namespace Foundation {
 	internal class NSAsyncActionDispatcher2 : NSObject
 	{
 		public const string SelectorName = "xamarinApplySelector";
+#if MONOMAC
 		public static readonly Selector Selector = new Selector (SelectorName);
+#endif
 
 		GCHandle gch;
 		SendOrPostCallback d;
@@ -158,6 +175,9 @@ namespace Foundation {
 
 		public NSAsyncActionDispatcher2 (SendOrPostCallback d, object state)
 		{
+			if (d == null)
+				throw new ArgumentNullException (nameof (d));
+
 			this.d = d;
 			this.state = state;
 			gch = GCHandle.Alloc (this);
@@ -189,7 +209,7 @@ namespace Foundation {
 #endif
 			}
 		}
-#endif // !COREBUILD
 	}
+#endif // !COREBUILD
 }
 

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -576,10 +576,22 @@ namespace Foundation {
 			var d = new NSAsyncActionDispatcher (action);
 #if MONOMAC
 			Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDoneHandle, 
-			                                                NSActionDispatcher.Selector.Handle, d.Handle, false);
+		                                                        NSAsyncActionDispatcher.Selector.Handle, d.Handle, false);
 #else
 			Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone), 
-			                                                Selector.GetHandle (NSActionDispatcher.SelectorName), d.Handle, false);
+			                                                Selector.GetHandle (NSAsyncActionDispatcher.SelectorName), d.Handle, false);
+#endif
+		}
+
+		internal void BeginInvokeOnMainThread (System.Threading.SendOrPostCallback cb, object state)
+		{
+			var d = new NSAsyncActionDispatcher2 (cb, state);
+#if MONOMAC
+			Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDoneHandle,
+		                                                        NSAsyncActionDispatcher2.Selector.Handle, d.Handle, false);
+#else
+			Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone),
+			                                                Selector.GetHandle (NSAsyncActionDispatcher2.SelectorName), d.Handle, false);
 #endif
 		}
 		
@@ -588,13 +600,26 @@ namespace Foundation {
 			using (var d = new NSActionDispatcher (action)) {
 #if MONOMAC
 				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDoneHandle, 
-				                                                NSActionDispatcher.Selector.Handle, d.Handle, true);
+		                                                                NSActionDispatcher.Selector.Handle, d.Handle, true);
 #else
 				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone), 
 				                                                Selector.GetHandle (NSActionDispatcher.SelectorName), d.Handle, true);
 #endif
 			}
 		}		
+
+		internal void InvokeOnMainThread (System.Threading.SendOrPostCallback cb, object state)
+		{
+			using (var d = new NSActionDispatcher2 (cb, state)) {
+#if MONOMAC
+				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDoneHandle,
+			                                                        NSActionDispatcher2.Selector.Handle, d.Handle, true);
+#else
+				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone),
+				                                                Selector.GetHandle (NSActionDispatcher2.SelectorName), d.Handle, true);
+#endif
+			}
+		}
 
 		public static NSObject FromObject (object obj)
 		{

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -579,7 +579,7 @@ namespace Foundation {
 		                                                        NSDispatcher.Selector.Handle, d.Handle, false);
 #else
 			Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone), 
-			                                                Selector.GetHandle (NSAsyncActionDispatcher.SelectorName), d.Handle, false);
+			                                                Selector.GetHandle (NSDispatcher.SelectorName), d.Handle, false);
 #endif
 		}
 
@@ -591,7 +591,7 @@ namespace Foundation {
 		                                                        NSDispatcher.Selector.Handle, d.Handle, false);
 #else
 			Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone),
-			                                                Selector.GetHandle (NSAsyncActionDispatcher2.SelectorName), d.Handle, false);
+			                                                Selector.GetHandle (NSDispatcher.SelectorName), d.Handle, false);
 #endif
 		}
 		
@@ -603,7 +603,7 @@ namespace Foundation {
 		                                                                NSDispatcher.Selector.Handle, d.Handle, true);
 #else
 				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone), 
-				                                                Selector.GetHandle (NSActionDispatcher.SelectorName), d.Handle, true);
+				                                                Selector.GetHandle (NSDispatcher.SelectorName), d.Handle, true);
 #endif
 			}
 		}		
@@ -616,7 +616,7 @@ namespace Foundation {
 			                                                        NSDispatcher.Selector.Handle, d.Handle, true);
 #else
 				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone),
-				                                                Selector.GetHandle (NSActionDispatcher2.SelectorName), d.Handle, true);
+				                                                Selector.GetHandle (NSDispatcher.SelectorName), d.Handle, true);
 #endif
 			}
 		}

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -576,7 +576,7 @@ namespace Foundation {
 			var d = new NSAsyncActionDispatcher (action);
 #if MONOMAC
 			Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDoneHandle, 
-		                                                        NSAsyncActionDispatcher.Selector.Handle, d.Handle, false);
+		                                                        NSDispatcher.Selector.Handle, d.Handle, false);
 #else
 			Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone), 
 			                                                Selector.GetHandle (NSAsyncActionDispatcher.SelectorName), d.Handle, false);
@@ -585,10 +585,10 @@ namespace Foundation {
 
 		internal void BeginInvokeOnMainThread (System.Threading.SendOrPostCallback cb, object state)
 		{
-			var d = new NSAsyncActionDispatcher2 (cb, state);
+			var d = new NSAsyncSynchronizationContextDispatcher (cb, state);
 #if MONOMAC
 			Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDoneHandle,
-		                                                        NSAsyncActionDispatcher2.Selector.Handle, d.Handle, false);
+		                                                        NSDispatcher.Selector.Handle, d.Handle, false);
 #else
 			Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone),
 			                                                Selector.GetHandle (NSAsyncActionDispatcher2.SelectorName), d.Handle, false);
@@ -600,7 +600,7 @@ namespace Foundation {
 			using (var d = new NSActionDispatcher (action)) {
 #if MONOMAC
 				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDoneHandle, 
-		                                                                NSActionDispatcher.Selector.Handle, d.Handle, true);
+		                                                                NSDispatcher.Selector.Handle, d.Handle, true);
 #else
 				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone), 
 				                                                Selector.GetHandle (NSActionDispatcher.SelectorName), d.Handle, true);
@@ -610,10 +610,10 @@ namespace Foundation {
 
 		internal void InvokeOnMainThread (System.Threading.SendOrPostCallback cb, object state)
 		{
-			using (var d = new NSActionDispatcher2 (cb, state)) {
+			using (var d = new NSSynchronizationContextDispatcher (cb, state)) {
 #if MONOMAC
 				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDoneHandle,
-			                                                        NSActionDispatcher2.Selector.Handle, d.Handle, true);
+			                                                        NSDispatcher.Selector.Handle, d.Handle, true);
 #else
 				Messaging.void_objc_msgSend_IntPtr_IntPtr_bool (d.Handle, Selector.GetHandle (Selector.PerformSelectorOnMainThreadWithObjectWaitUntilDone),
 				                                                Selector.GetHandle (NSActionDispatcher2.SelectorName), d.Handle, true);
@@ -764,13 +764,13 @@ namespace Foundation {
 		public virtual void Invoke (Action action, double delay)
 		{
 			var d = new NSAsyncActionDispatcher (action);
-			d.PerformSelector (NSActionDispatcher.Selector, null, delay);
+			d.PerformSelector (NSDispatcher.Selector, null, delay);
 		}
 
 		public virtual void Invoke (Action action, TimeSpan delay)
 		{
 			var d = new NSAsyncActionDispatcher (action);
-			d.PerformSelector (NSActionDispatcher.Selector, null, delay.TotalSeconds);
+			d.PerformSelector (NSDispatcher.Selector, null, delay.TotalSeconds);
 		}
 
 		internal void ClearHandle ()

--- a/src/UIKit/UIKitSynchronizationContext.cs
+++ b/src/UIKit/UIKitSynchronizationContext.cs
@@ -21,12 +21,12 @@ namespace UIKit {
 
 		public override void Post (SendOrPostCallback d, object state)
 		{
-			NSRunLoop.Main.BeginInvokeOnMainThread ( () => d (state) );
+			NSRunLoop.Main.BeginInvokeOnMainThread (d, state);
 		}
 
 		public override void Send (SendOrPostCallback d, object state)
 		{
-			NSRunLoop.Main.InvokeOnMainThread ( () => d (state) );
+			NSRunLoop.Main.InvokeOnMainThread (d, state);
 		}
 	}
 


### PR DESCRIPTION
This PR adds the following value:

1. There is no Action wrapper being constructed on async continuations,
thus on every await call we gain: 1 less allocation (lambda capture),
1 less indirected call to the actual continuation, and possibly
System.Action being removed by the linker, as its no longer used in these cases.

2. NSActionDispatcher* classes can now be linked out completely, due to
the static selector no longer being used everywhere

3. One unused class removed
