### PR TITLE
[xharness] Handle failure to create a device pair for the simulator better. Fixes xamarin/maccore#830.

### DIFF
--- a/tests/xharness/Log.cs
+++ b/tests/xharness/Log.cs
@@ -25,7 +25,7 @@ namespace xharness
 
 		public abstract string FullPath { get; }
 
-		protected virtual void WriteImpl (string value)
+		internal protected virtual void WriteImpl (string value)
 		{
 			Write (Encoding.UTF8.GetBytes (value));
 		}
@@ -100,7 +100,7 @@ namespace xharness
 
 			public override string FullPath => throw new NotImplementedException ();
 
-			protected override void WriteImpl (string value)
+			internal protected override void WriteImpl (string value)
 			{
 				foreach (var log in logs)
 					log.WriteImpl (value);
@@ -258,7 +258,7 @@ namespace xharness
 		{
 		}
 
-		protected override void WriteImpl (string value)
+		internal protected override void WriteImpl (string value)
 		{
 			captured.Append (value);
 			Console.Write (value);
@@ -373,7 +373,7 @@ namespace xharness
 			Capture ();
 		}
 
-		protected override void WriteImpl (string value)
+		internal protected override void WriteImpl (string value)
 		{
 			throw new InvalidOperationException ();
 		}
@@ -398,7 +398,7 @@ namespace xharness
 
 		public override string FullPath => throw new NotImplementedException ();
 
-		protected override void WriteImpl (string value)
+		internal protected override void WriteImpl (string value)
 		{
 			OnWrite (value);
 		}


### PR DESCRIPTION
Detect if we failed to create a simulator device pair due to trying with a
watch that's already paired. We were already detecting this scenario if the
watch was a member of an available pair, but not if the watch was a member of
an _unavailable_ pair (since mlaunch doesn't list unavailable device pairs).

So detect this scenario from the error message simctl gives us instead, and in
that case create a new watch device and try to create the pair again.

Fixes https://github.com/xamarin/maccore/issues/830.