### PR TITLE
[xharness] Hide summary of test failures in an expandable block in the markdown summary.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1383,8 +1383,13 @@ namespace xharness
 			if (markdown_summary != null) {
 				markdown_summary.WriteLine ("# Test results");
 				markdown_summary.WriteLine ();
+				var details = failedTests.Any ();
+				if (details) {
+					markdown_summary.WriteLine ("<details>");
+					markdown_summary.Write ("<summary>");
+				}
 				if (allTasks.Count == 0) {
-					markdown_summary.WriteLine ($"Loading tests...");
+					markdown_summary.Write ($"Loading tests...");
 				} else if (unfinishedTests.Any ()) {
 					var list = new List<string> ();
 					var grouped = allTasks.GroupBy ((v) => v.ExecutionResult).OrderBy ((v) => (int) v.Key);
@@ -1392,16 +1397,18 @@ namespace xharness
 						list.Add ($"{@group.Key.ToString ()}: {@group.Count ()}");
 					markdown_summary.Write ($"# Test run in progress: ");
 					markdown_summary.Write (string.Join (", ", list));
-					markdown_summary.WriteLine ();
 				} else if (failedTests.Any ()) {
-					markdown_summary.WriteLine ($"{failedTests.Count ()} tests failed, {skippedTests.Count ()} tests skipped, {passedTests.Count ()} tests passed.");
+					markdown_summary.Write ($"{failedTests.Count ()} tests failed, {skippedTests.Count ()} tests skipped, {passedTests.Count ()} tests passed.");
 				} else if (skippedTests.Any ()) {
-					markdown_summary.WriteLine ($"{skippedTests.Count ()} tests skipped, {passedTests.Count ()} tests passed.");
+					markdown_summary.Write ($"{skippedTests.Count ()} tests skipped, {passedTests.Count ()} tests passed.");
 				} else if (passedTests.Any ()) {
-					markdown_summary.WriteLine ($"# All {passedTests.Count ()} tests passed");
+					markdown_summary.Write ($"# All {passedTests.Count ()} tests passed");
 				} else {
-					markdown_summary.WriteLine ($"# No tests selected.");
+					markdown_summary.Write ($"# No tests selected.");
 				}
+				if (details)
+					markdown_summary.Write ("</summary>");
+				markdown_summary.WriteLine ();
 				markdown_summary.WriteLine ();
 				if (failedTests.Any ()) {
 					markdown_summary.WriteLine ("## Failed tests");
@@ -1418,6 +1425,8 @@ namespace xharness
 						markdown_summary.WriteLine ();
 					}
 				}
+				if (details)
+					markdown_summary.WriteLine ("</details>");
 			}
 
 			using (var writer = new StreamWriter (stream)) {


### PR DESCRIPTION
Hide summary of test failures in an expandable block in the markdown summary,
so that when there are many failures it's still a summary and not pages and
pages of text.

Horror example this will fix: https://github.com/xamarin/xamarin-macios/pull/4163#issuecomment-393566282