### PR TITLE
[foundation] Override Message property in NSErrorException. Fixes #4133

### DIFF
--- a/src/Foundation/NSErrorException.cs
+++ b/src/Foundation/NSErrorException.cs
@@ -55,5 +55,11 @@ namespace Foundation {
 		{
 			get {return error.UserInfo; }
 		}
+
+		public override string Message {
+			get {
+				return error.Description;
+			}
+		}
 	}
 }

--- a/tests/monotouch-test/SafariServices/ReadingListTest.cs
+++ b/tests/monotouch-test/SafariServices/ReadingListTest.cs
@@ -59,6 +59,18 @@ namespace MonoTouchFixtures.SafariServices {
 				Assert.False (rl.Add (local, null, null, out error), "Add-3");
 				Assert.That (error.Domain, Is.EqualTo ((string) SSReadingList.ErrorDomain), "Domain");
 				Assert.That (error.Code, Is.EqualTo ((nint) (int) SSReadingListError.UrlSchemeNotAllowed), "Code");
+
+				try {
+					throw new NSErrorException (error);
+				}
+				catch (NSErrorException ns) {
+					Assert.That (ns.Error.Code, Is.EqualTo (error.Code), "Code");
+					Assert.That (ns.Error.Domain, Is.EqualTo (error.Domain), "Domain");
+					Assert.That (ns.Message, Is.EqualTo (error.Description), "Message");
+				}
+				catch (Exception e) {
+					Assert.Fail (e.ToString ());
+				}
 			}
 		}
 


### PR DESCRIPTION
The default `Message` property is not every helpful. Better information
is available inside the `Error` property but it's not general (nor cross
platform) when dealing with exception.

Include unit tests (on an existing test checking NSError values)

https://github.com/xamarin/xamarin-macios/issues/4133