### PR TITLE
Bump mono to head of 2018-02 + fix mtouch/mmp (#4171)

### DIFF
--- a/tests/common/BundlerTest.cs
+++ b/tests/common/BundlerTest.cs
@@ -301,8 +301,13 @@ class Issue4072Session : NSUrlSession {
 				bundler.AssertExecute ();
 				bundler.AssertWarning (4175, "The parameter 'completionHandler' in the method 'Issue4072Session.CreateDataTask(Foundation.NSUrl,Foundation.NSUrlSessionResponse)' has an invalid BlockProxy attribute (the type passed to the attribute does not have a 'Create' method).", "testApp.cs", 11);
 				bundler.AssertWarningCount (1);
+			}
 
+			using (var bundler = new BundlerTool ()) {
+				bundler.Profile = profile;
+				bundler.CreateTemporaryCacheDirectory ();
 				bundler.CreateTemporaryApp (profile, code: code, extraArg: "/debug-"); // Build without debug info so that the source code location isn't available.
+				bundler.Registrar = RegistrarOption.Static;
 #if !__MACOS__
 				bundler.Linker = LinkerOption.LinkAll; // This will remove the parameter name in Xamarin.iOS (the parameter name removal optimization (MetadataReducerSubStep) isn't implemented for Xamarin.Mac).
 #endif

--- a/tools/common/CoreResolver.cs
+++ b/tools/common/CoreResolver.cs
@@ -92,10 +92,7 @@ namespace Xamarin.Bundler {
 					assembly = ModuleDefinition.ReadModule (fileName, parameters).Assembly;
 					params_cache [assembly.Name.ToString ()] = parameters;
 				}
-				catch (InvalidOperationException e) {
-					// cecil use the default message so it's not very helpful to detect the root cause
-					if (!e.TargetSite.ToString ().Contains ("Void ReadSymbols(Mono.Cecil.Cil.ISymbolReader)"))
-						throw;
+				catch (SymbolsNotMatchingException) {
 					parameters.ReadSymbols = false;
 					parameters.SymbolReaderProvider = null;
 					assembly = ModuleDefinition.ReadModule (fileName, parameters).Assembly;


### PR DESCRIPTION
Backport from master

Commit list for mono/mono:

* mono/mono@1c24c158b0c [bitcode] Fix the generation of invalid llvm IR for some Span code.
* mono/mono@a49a68c6d7a [interp] Fix native to interp transition (#8957)
* mono/mono@92e11812f41 [System.Runtime.Serialization] Makes more APIs work for mobile
* mono/mono@260676f948e Bump API snapshot submodule
* mono/mono@eefdf4ed319 Bump external/cecil to b6c50e3
* mono/mono@0754926394c [2018-02] Finalize merp integration (#8869)

Diff: https://github.com/mono/mono/compare/7bdb7dd76582f305f86e35ac7bfe120d68557954...1c24c158b0cc0647adf216fd2244a094ce437611

* [mtouch][mmp] Have CoreResolver check for the new SymbolsNotMatchingException from Cecil

* [tests] Rebuild MX4175 in a separate .app to avoid debug symbol warnings

The newer cecil version is better at detecting incorrect .mdb, like the
test is using, resulting in warnings since the 2nd build (same location)
was done without symbols (so old ones were loaded).

Stale debug symbols is not the goal of the MX4175 test. Rebuilding the
.app in another directory solves the extra warning issue.