### PR TITLE
[msbuild] Fix build with Xcode 10 beta 1.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/DetectSdkLocationsTaskBase.cs
@@ -263,7 +263,11 @@ namespace Xamarin.iOS.Tasks
 			// Note: Developer/Platforms/iPhoneOS.platform/Developer/usr is a physical directory, but
 			// Developer/Platforms/iPhoneSimulator.platform/Developer/bin has always been a symlink
 			// to Developer/bin and starting with Xcode 7 Beta 2, the usr symlink no longer exists.
-			SdkUsrPath = DirExists ("SDK Usr directory", Path.Combine (platformDir, "Developer", "usr"));
+			// In Xcode 10 beta 1 Developer/Platforms/iPhoneOS.platform/Developer/usr reappeared,
+			// but since it seems incomplete don't even check for it.
+			if (AppleSdkSettings.XcodeVersion.Major < 10)
+				SdkUsrPath = DirExists ("SDK Usr directory", Path.Combine (platformDir, "Developer", "usr"));
+
 			if (string.IsNullOrEmpty (SdkUsrPath)) {
 				SdkUsrPath = DirExists ("SDK Usr directory", Path.Combine (currentSDK.DeveloperRoot, "usr"));
 				if (string.IsNullOrEmpty (SdkUsrPath))


### PR DESCRIPTION
Many years ago (in Xcode 7 according to code comment)
Developer/Platforms/iPhoneOS.platform/Developer/usr disappeared, and we coped
by looking at Developer/usr instead (and also the subsequent code to locate
the bin directory was based on the location of the usr directory).

Developer/Platforms/iPhoneOS.platform/Developer/usr reappeared in Xcode 10
beta 1, but it seems useless (for one it doesn't contain a bin directory), so
in order to try to keep things sane don't look for this directory in Xcode 10
and instead go directly for Developer/usr (which is what we've been using as
the usr directory for years anyway).

Fixes this problem when building apps with Xcode 10 beta 1:

      /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/iOS/Xamarin.iOS.Common.targets(626,3): error : Could not locate SDK bin directory [/Users/rolf/Projects/TestApp/test-app.csproj]