### PR TITLE
[jenkins] Cherry-pick a series of fixes for internal jenkins support from the d15-8 branch

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -288,8 +288,15 @@ timestamps {
                                 def file = uploadingFiles [i]
                                 def f_length = file.length;
                                 def md5 = sh (returnStdout: true, script: "md5 -q '${file}'").trim ()
+                                def sha256 = sh (returnStdout: true, script: "shasum -a 256").trim ().split (" ") [0];
                                 manifest += "${packagePrefix}/${file.name}\n"
-                                artifacts += "  {\n    \"file\": \"${file.name}\",\n    \"url\": \"${packagePrefix}/${file.name}\",\n    \"md5\": \"${md5}\",\n    \"size\": ${f_length}\n  }"
+                                artifacts += "  {\n"
+                                artifacts += "    \"file\": \"${file.name}\",\n"
+                                artifacts += "    \"url\": \"${packagePrefix}/${file.name}\",\n"
+                                artifacts += "    \"md5\": \"${md5}\",\n"
+                                artifacts += "    \"sha256\": \"${sha256}\",\n"
+                                artifacts += "    \"size\": ${f_length}\n"
+                                artifacts += "  }"
                                 if (i < uploadingFiles.length - 1)
                                     artifacts += ","
                                 artifacts +="\n"

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -236,6 +236,7 @@ timestamps {
                         stage ('Provisioning') {
                             currentStage = "${STAGE_NAME}"
                             echo ("Building on ${env.NODE_NAME}")
+                            sh ("cd ${workspace}/xamarin-macios && ./configure --enable-xamarin")
                             sh ("${workspace}/xamarin-macios/jenkins/provision-deps.sh")
                         }
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -17,6 +17,7 @@ currentStage = null
 xiPackageFilename = null
 xmPackageFilename = null
 manifestFilename = null
+artifactsFilename = null
 reportPrefix = null
 createFinalStatus = true
 skipLocalTestRunReason = ""
@@ -279,25 +280,25 @@ timestamps {
                             virtualPath = "jenkins/${branchName}/${gitHash}/${env.BUILD_NUMBER}"
                             packagePrefix = "https://bosstoragemirror.blob.core.windows.net/wrench/${virtualPath}/package"
 
-                            // Create metadata.json and manifest
+                            // Create artifacts.json and manifest
                             def uploadingFiles = findFiles (glob: "package/*")
                             def manifest = ""
-                            def metadata = "[\n"
+                            def artifacts = "[\n"
                             for (int i = 0; i < uploadingFiles.length; i++) {
                                 def file = uploadingFiles [i]
                                 def f_length = file.length;
                                 def md5 = sh (returnStdout: true, script: "md5 -q '${file}'").trim ()
                                 manifest += "${packagePrefix}/${file.name}\n"
-                                metadata += "  {\n    \"file\": \"${file.name}\",\n    \"md5\": \"${md5}\",\n    \"size\": ${f_length}\n  }"
+                                artifacts += "  {\n    \"file\": \"${file.name}\",\n    \"md5\": \"${md5}\",\n    \"size\": ${f_length}\n  }"
                                 if (i < uploadingFiles.length - 1)
-                                    metadata += ","
-                                metadata +="\n"
+                                    artifacts += ","
+                                artifacts +="\n"
                             }
-                            metadata += "]\n"
-                            manifest += "${packagePrefix}/metadata.json\n"
+                            artifacts += "]\n"
+                            manifest += "${packagePrefix}/artifacts.json\n"
                             manifest += "${packagePrefix}/manifest\n"
                             writeFile (file: "package/manifest", text: manifest)
-                            writeFile (file: "package/metadata.json", text: metadata)
+                            writeFile (file: "package/artifacts.json", text: artifacts)
 
                             sh ("ls -la package")
                             uploadFiles ("package/*", virtualPath)
@@ -309,6 +310,7 @@ timestamps {
                             uploadFiles ("package/manifest", "jenkins/${branchName}/latest")
 
                             manifestFilename = "manifest"
+                            artifactsFilename = "artifacts.json"
                         }
 
                         stage ('Publish builds to GitHub') {
@@ -325,6 +327,10 @@ timestamps {
                             if (manifestFilename != null) {
                                 def manifestUrl = "${packagePrefix}/${manifestFilename}"
                                 utils.reportGitHubStatus (gitHash, "${manifestFilename}", "${manifestUrl}", 'SUCCESS', "${manifestFilename}")
+                            }
+                            if (artifactsFilename != null) {
+                                def artifactUrl = "${packagePrefix}/${artifactsFilename}"
+                                utils.reportGitHubStatus (gitHash, "Jenkins: Artifacts", "${artifactUrl}", 'SUCCESS', "${artifactsFilename}")
                             }
                         }
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -289,7 +289,7 @@ timestamps {
                                 def f_length = file.length;
                                 def md5 = sh (returnStdout: true, script: "md5 -q '${file}'").trim ()
                                 manifest += "${packagePrefix}/${file.name}\n"
-                                artifacts += "  {\n    \"file\": \"${file.name}\",\n    \"md5\": \"${md5}\",\n    \"size\": ${f_length}\n  }"
+                                artifacts += "  {\n    \"file\": \"${file.name}\",\n    \"url\": \"${packagePrefix}/${file.name}\",\n    \"md5\": \"${md5}\",\n    \"size\": ${f_length}\n  }"
                                 if (i < uploadingFiles.length - 1)
                                     artifacts += ","
                                 artifacts +="\n"

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -51,11 +51,11 @@ else
 	fi
 fi
 
-if test -n "$ENABLE_DEVICE_BUILD"; then
-	./configure "$CONFIGURE_FLAGS"
-else
-	./configure "$CONFIGURE_FLAGS" --disable-ios-device
+if test -z "$ENABLE_DEVICE_BUILD"; then
+	CONFIGURE_FLAGS="$CONFIGURE_FLAGS --disable-ios-device"
 fi
+# shellcheck disable=SC2086
+./configure $CONFIGURE_FLAGS
 
 make reset
 make git-clean-all


### PR DESCRIPTION
A series of fixes for internal Jenkins support were implemented on the d15-8
branch (in PR #4180); this PR is cherry-picking those fixes to master.

* [jenkins] Fix passing flags to configure.

    Quoting empty CONFIGURE_FLAGS ends up doing this:
    
        ./configure "" --disable-ios-device
    
    and since configure parses arguments until it finds an empty argument, it
    would stop parsing at the first argument, effectively not disabling the
    device build.
    
    So don't quote CONFIGURE_FLAGS when invoking configure. shellcheck doesn't
    quite like this, but the better code is much more complex, and not really
    needed, so just add an exception.

* [Jenkins] Enable xamarin before provisioning so that we auto-provision Xcode.

* [jenkins] Add sha256 checksum to artifacts.json as well.

* [jenkins] Include the url in artifacts.json

* [Jenkins] Create artifacts.json and set a GH status as 'Jenkins: Artifacts'.