### PR TITLE
[tests] Add introspection tests to ensure there are native linking instructions for all frameworks. Fixes #3976 (#4194)

### DIFF
--- a/src/Foundation/NSProxy.cs
+++ b/src/Foundation/NSProxy.cs
@@ -26,6 +26,7 @@ namespace Foundation {
 	}
 }
 
+#if !XAMCORE_4_0 || (__IOS__ || __MACOS__)
 namespace WebKit {
 	// We need to keep NSProxy if WKNavigationDelegate or IWKNavigationDelegate are used
 	// This cannot be done on an interface but the protocol won't be used without a WKWebView
@@ -34,3 +35,4 @@ namespace WebKit {
 		static Type hack = typeof (NSProxy);
 	}
 }
+#endif

--- a/src/corespotlight.cs
+++ b/src/corespotlight.cs
@@ -223,6 +223,9 @@ namespace CoreSpotlight {
 		bool MultiValued { [Bind ("isMultiValued")] get; }
 	}
 
+#if XAMCORE_4_0
+	[NoTV]
+#endif
 	[iOS (9,0)]
 	[Mac (10,13, onlyOn64: true)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]

--- a/src/photosui.cs
+++ b/src/photosui.cs
@@ -116,7 +116,7 @@ namespace PhotosUI {
 
 	[TV (10,0)]
 	[iOS (9,1)]
-	[Mac (10,12)]
+	[Mac (10,12, onlyOn64: true)]
 	[Protocol, Model]
 	[BaseType (typeof (NSObject))]
 	interface PHLivePhotoViewDelegate {

--- a/tests/introspection/ApiFrameworkTest.cs
+++ b/tests/introspection/ApiFrameworkTest.cs
@@ -1,0 +1,131 @@
+﻿#if __UNIFIED__
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using NUnit.Framework;
+
+using Foundation;
+using ObjCRuntime;
+
+
+public class Application {
+	public bool IsSimulatorBuild {
+		get {
+#if __IOS__
+			return Runtime.Arch == Arch.SIMULATOR;
+#else
+			return true;
+#endif
+		}
+	}
+}
+
+namespace Introspection {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class ApiFrameworkTest : ApiBaseTest {
+
+		HashSet<string> namespaces = new HashSet<string> ();
+		Application app = new Application ();
+
+		public bool Skip (string @namespace)
+		{
+			if (@namespace == null)
+				return true;
+			if (namespaces.Contains (@namespace))
+				return true;
+			namespaces.Add (@namespace);
+			switch (@namespace) {
+			// we always link with the CoreFoundation framework
+			case "CoreFoundation":
+				return true;
+				// not a framework but a dynamic library /usr/lib/libcompression.dylib - tracked elsewhere (p/invoke only)
+			case "Compression":
+				return true;
+			// not a framework, largely p/invokes to /usr/lib/libobjc.dylib
+			case "ObjCRuntime":
+				return true;
+			// pinvokes into OpenGL[ES]
+			case "OpenTK":
+				return true;
+			// n[u]int, nfloat and friends
+			case "System":
+			case "System.Drawing":
+				return true;
+#if __IOS__
+			// Some CF* types that requires CFNetwork which we always link with
+			// ref: tools/common/CompilerFlags.cs
+			case "CoreServices":
+				return true;
+#elif __TVOS__ && !XAMCORE_4_0
+			// mistakes (can't be fixed without breaking binary compatibility)
+			case "CoreSpotlight":
+			case "WebKit":
+				return true;
+#elif __WATCHOS__ && !XAMCORE_4_0
+			// helpers (largely enums) for AVFoundation API - no p/invokes or obj-C API that requires native linking
+			case "AudioToolbox":
+				return true;
+			// mistakes (can't be fixed without breaking binary compatibility)
+			case "WebKit":
+				return true;
+#elif __MACOS__
+			// always included, ref: tools/common/CompilerFlags.cs
+			case "CFNetwork":
+				return true;
+			// not a framework, largely p/invokes to /usr/lib/libSystem.dylib
+			case "Darwin":
+				return true;
+			// not directly bindings
+			case "System.Net.Http":
+				return true;
+#endif
+			default:
+				return false;
+			}
+		}
+
+		Frameworks GetFrameworks ()
+		{
+#if __IOS__
+			return Frameworks.GetiOSFrameworks (app);
+#elif __TVOS__
+			return Frameworks.TVOSFrameworks;
+#elif __WATCHOS__
+			return Frameworks.GetwatchOSFrameworks (app);
+#elif __MACOS__
+			return Frameworks.MacFrameworks;
+#else
+			throw new NotImplementedException ();
+#endif
+		}
+
+		[Test]
+		public void NativeFrameworks ()
+		{
+			ContinueOnFailure = true;
+			Errors = 0;
+			int n = 0;
+			var frameworks = GetFrameworks ();
+
+			foreach (Type t in Assembly.GetTypes ()) {
+				if (!t.IsPublic)
+					continue;
+				var ns = t.Namespace;
+				if (Skip (ns))
+					continue;
+				n++;
+				if (LogProgress)
+					Console.WriteLine ($"Namespace candidate '{ns}'");
+				if (frameworks.TryGetValue (ns, out var f))
+					continue;
+				// Either Skip method or Frameworks.cs needs to be updated
+				ReportError ("Unknown framework '{0}'", ns);
+			}
+			AssertIfErrors ($"{Errors} unknown frameworks found:\n{ErrorData}");
+		}
+	}
+}
+#endif

--- a/tests/introspection/Mac/introspection-mac.csproj
+++ b/tests/introspection/Mac/introspection-mac.csproj
@@ -118,6 +118,12 @@
     <Compile Include="..\ApiAvailabilityTest.cs">
       <Link>ApiAvailabilityTest.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tools\common\Frameworks.cs">
+      <Link>Frameworks.cs</Link>
+    </Compile>
+    <Compile Include="..\ApiFrameworkTest.cs">
+      <Link>ApiFrameworkTest.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">

--- a/tests/introspection/iOS/introspection-ios.csproj
+++ b/tests/introspection/iOS/introspection-ios.csproj
@@ -213,6 +213,12 @@
     <Compile Include="..\ApiAvailabilityTest.cs">
       <Link>ApiAvailabilityTest.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tools\common\Frameworks.cs">
+      <Link>Frameworks.cs</Link>
+    </Compile>
+    <Compile Include="..\ApiFrameworkTest.cs">
+      <Link>ApiFrameworkTest.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist">

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 
+#if MTOUCH || MMP
 using Mono.Cecil;
 
 using Xamarin.Bundler;
 using Registrar;
+#endif
 
 public class Framework
 {
@@ -43,7 +45,11 @@ public class Frameworks : Dictionary <string, Framework>
 	public void Add (string @namespace, string framework, Version version)
 	{
 		var fr = new Framework () {
+#if MTOUCH || MMP
 			Namespace = Driver.IsUnified ? @namespace : Registrar.Registrar.CompatNamespace + "." + @namespace,
+#else
+			Namespace = @namespace,
+#endif
 			Name = framework,
 			Version = version
 		};
@@ -81,6 +87,7 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "CoreVideo", 10, 3 },
 					{ "MobileCoreServices", "CoreServices", 10, 3 },
 					{ "OpenGL", 10, 3 },
+					{ "SearchKit", "CoreServices", 10,3 },
 					{ "SystemConfiguration", 10, 3 },
 
 					{ "CoreData", 10, 4 },
@@ -89,6 +96,7 @@ public class Frameworks : Dictionary <string, Framework>
 
 					{ "CoreAnimation", "QuartzCore", 10, 5 },
 					{ "CoreText", 10, 5 },
+					{ "PrintCore", "CoreServices", 10,5 },
 					{ "ScriptingBridge", 10, 5 },
 					{ "QuickLook", 10, 5 },
 					{ "QuartzComposer", "Quartz", 10, 5 },
@@ -128,21 +136,29 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "Hypervisor", 10, 10 },
 					{ "LocalAuthentication", 10, 10 },
 					{ "MultipeerConnectivity", 10, 10 },
+					{ "NetworkExtension", 10, 10 },
 					{ "NotificationCenter", 10, 10 },
-					{ "GameplayKit", 10, 11 },
+
 					{ "Contacts", 10, 11 },
+					{ "ContactsUI", 10, 11 },
+					{ "CoreAudioKit", 10,11 },
+					{ "GameplayKit", 10, 11 },
 					{ "Metal", 10, 11 },
 					{ "MetalKit", 10, 11 },
 					{ "ModelIO", 10, 11 },
 
 					{ "Intents", 10, 12 },
 					{ "IOSurface", "IOSurface", 10, 12 },
+					{ "Photos", "Photos", 10,12 },
+					{ "PhotosUI", "PhotosUI", 10,12 },
 					{ "SafariServices", "SafariServices", 10, 12 },
 					{ "MediaPlayer", "MediaPlayer", 10, 12, 1 },
 
 					{ "CoreML", "CoreML", 10, 13 },
-					{ "Vision", "Vision", 10, 13 },
+					{ "CoreSpotlight", "CoreSpotlight", 10,13 },
+					{ "ExternalAccessory", "ExternalAccessory", 10, 13 },
 					{ "MetalPerformanceShaders", "MetalPerformanceShaders", 10, 13 },
+					{ "Vision", "Vision", 10, 13 },
 
 					{ "BusinessChat", "BusinessChat", 10, 13, 4 },
 				};
@@ -151,7 +167,7 @@ public class Frameworks : Dictionary <string, Framework>
 		}
 	}
 
-#if MTOUCH
+#if MTOUCH || __IOS__ || __TVOS__ || __WATCHOS__
 	static Frameworks ios_frameworks;
 	public static Frameworks GetiOSFrameworks (Application app)
 	{
@@ -273,6 +289,7 @@ public class Frameworks : Dictionary <string, Framework>
 	{
 		if (watch_frameworks == null) {
 			watch_frameworks = new Frameworks {
+				{ "Accelerate", "Accelerate", 2 },
 				// The CFNetwork framework is in the SDK, but there are no headers inside the framework, so don't enable yet.
 				// { "CFNetwork", "CFNetwork", 2 },
 				{ "ClockKit", "ClockKit", 2 },
@@ -295,6 +312,8 @@ public class Frameworks : Dictionary <string, Framework>
 				{ "WatchConnectivity", "WatchConnectivity", 2 },
 				{ "WatchKit", "WatchKit", 2 },
 
+				{ "CoreText", "CoreText", 2,2 },
+
 				// AVFoundation was introduced in 3.0, but the simulator SDK was broken until 3.2.
 				{ "AVFoundation", "AVFoundation", 3, app.IsSimulatorBuild ? 2 : 0 },
 				{ "CloudKit", "CloudKit", 3 },
@@ -304,7 +323,9 @@ public class Frameworks : Dictionary <string, Framework>
 				{ "UserNotifications", "UserNotifications", 3 },
 				{ "Intents", "Intents", 3,2 },
 
+				{ "CoreBluetooth", "CoreBluetooth", 4 },
 				{ "CoreML", "CoreML", 4 },
+				{ "CoreVideo", "CoreVideo", 4 },
 			};
 		}
 		return watch_frameworks;
@@ -342,9 +363,11 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "JavaScriptCore", "JavaScriptCore", 9 },
 					{ "MediaAccessibility", "MediaAccessibility", 9 },
 					{ "MediaPlayer", "MediaPlayer", 9 },
+					{ "MediaToolbox", "MediaToolbox", 9 },
 					{ "Metal", "Metal", 9 },
 					{ "MetalKit", "MetalKit", 9 },
 					{ "MetalPerformanceShaders", "MetalPerformanceShaders", 9 },
+					{ "CoreServices", "CFNetwork", 9 },
 					{ "MobileCoreServices", "MobileCoreServices", 9 },
 					{ "ModelIO", "ModelIO", 9 },
 					{ "OpenGLES", "OpenGLES", 9 },
@@ -380,6 +403,7 @@ public class Frameworks : Dictionary <string, Framework>
 	}
 #endif
 
+#if MTOUCH || MMP
 	public static void Gather (Application app, AssemblyDefinition product_assembly, HashSet<string> frameworks, HashSet<string> weak_frameworks)
 	{
 		var namespaces = new HashSet<string> ();
@@ -401,5 +425,5 @@ public class Frameworks : Dictionary <string, Framework>
 			}
 		}
 	}
-
+#endif
 }


### PR DESCRIPTION
Backport from master to d15-8

* [tests] Add introspection tests to ensure there are native linking instructions for all frameworks. Fixes #3976

or a good, documented (in test code) reason for not needing it.

https://github.com/xamarin/xamarin-macios/issues/3976

* Fix failures

- static registrar failed on 32bits because one type in PhotoUI missed
  its `onlyOn64: true`

- link with the top, not the sub-frameworks

* [tvos] Fix mistakes in tvOS where some extranous types triggered unrequired/unavailable (or missing) frameworks

* [watchos] Fix watchOS frameworks mapping