### PR TITLE
[macos][corebluetooth] Enable CBConnectPeripheralOptionStartDelayKey on macOS

### DIFF
--- a/src/CoreBluetooth/Enums.cs
+++ b/src/CoreBluetooth/Enums.cs
@@ -116,6 +116,8 @@ namespace CoreBluetooth {
 		ConnectionLimitReached,
 		[iOS (11,0)][TV (11,0)][Mac (10,13)]
 		UnknownDevice,
+		[iOS (12,0)][TV (12,0)][Mac (10,14)][Watch (5,0)]
+		OperationNotSupported,
 	}
 
 	[Watch (4,0)]

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -115,7 +115,7 @@ namespace CoreBluetooth {
 		[Field ("CBConnectPeripheralOptionNotifyOnNotificationKey")]
 		NSString OptionNotifyOnNotificationKey { get; }
 
-		[NoMac] // xcode 9.2 beta 2 does not include this inside its macOS header files
+		[Mac (10,14)]
 		[iOS (11,2)][TV (11,2)][Watch (4,2)]
 		[Field ("CBConnectPeripheralOptionStartDelayKey")]
 		NSString OptionStartDelayKey { get; }

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -54,7 +54,6 @@ namespace Introspection {
 			};
 #else
 			Minimum = new Version (10,7);
-			Maximum = new Version (10,13,4); // setting OSX_SDK_VERSION to 10.13.4 (instead of 10.13 breaks other assumptions)
 			Filter = (AvailabilityBaseAttribute arg) => {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.MacOSX);
 			};

--- a/tests/xtro-sharpie/macOS-CoreBluetooth.todo
+++ b/tests/xtro-sharpie/macOS-CoreBluetooth.todo
@@ -1,1 +1,0 @@
-!missing-field! CBConnectPeripheralOptionStartDelayKey not bound


### PR DESCRIPTION
Headers mention macOS 10.13 but, upon verification, the latest 10.13.5
still reports the key as missing from the framework.

Also remove the 10,13,4 maximum since we now have Mac(10,14) attributes
in the platform assemblies (which solve the previous issue)