### PR TITLE
[coreimage] Add new filters from Xcode 10 beta 1

### DIFF
--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -2631,40 +2631,37 @@ namespace CoreImage {
 		CIVector Extent { get; set; }
 	}
 
+	[CoreImageFilter]
+	[Abstract]
+	[iOS (9,0)]
+	[BaseType (typeof (CIFilter))]
+	interface CIReductionFilter {
+		[CoreImageFilterProperty ("inputExtent")]
+		CIVector Extent { get; set; }
+	}
+
 	[CoreImageFilter (StringCtorVisibility = MethodAttributes.Public)]
 	[iOS (9,0)]
-	[BaseType (typeof (CIFilter))]
+	[BaseType (typeof (CIReductionFilter))]
 	interface CIAreaMaximum {
-
-		[CoreImageFilterProperty ("inputExtent")]
-		CIVector Extent { get; set; }
 	}
 
 	[CoreImageFilter]
 	[iOS (9,0)]
-	[BaseType (typeof (CIFilter))]
+	[BaseType (typeof (CIReductionFilter))]
 	interface CIAreaMaximumAlpha {
-
-		[CoreImageFilterProperty ("inputExtent")]
-		CIVector Extent { get; set; }
 	}
 
 	[CoreImageFilter]
 	[iOS (9,0)]
-	[BaseType (typeof (CIFilter))]
+	[BaseType (typeof (CIReductionFilter))]
 	interface CIAreaMinimum {
-
-		[CoreImageFilterProperty ("inputExtent")]
-		CIVector Extent { get; set; }
 	}
 
 	[CoreImageFilter]
 	[iOS (9,0)]
-	[BaseType (typeof (CIFilter))]
+	[BaseType (typeof (CIReductionFilter))]
 	interface CIAreaMinimumAlpha {
-
-		[CoreImageFilterProperty ("inputExtent")]
-		CIVector Extent { get; set; }
 	}
 
 	[CoreImageFilter (StringCtorVisibility = MethodAttributes.Public)]
@@ -3045,11 +3042,8 @@ namespace CoreImage {
 	[CoreImageFilter]
 	[iOS (9,0)]
 	[Mac (10,9)]
-	[BaseType (typeof (CIFilter))]
+	[BaseType (typeof (CIReductionFilter))]
 	interface CIColumnAverage {
-
-		[CoreImageFilterProperty ("inputExtent")]
-		CIVector Extent { get; set; }
 	}
 
 	[CoreImageFilter]
@@ -5431,54 +5425,67 @@ namespace CoreImage {
 	[CoreImageFilter]
 	[iOS (12,0)]
 	[TV (12,0)]
-	[NoMac]
-	[BaseType (typeof (CIFilter))]
+	[Mac (10,14, onlyOn64: true)]
+	[BaseType (typeof (CIReductionFilter))]
 	interface CIAreaMinMax {
-		// FIXME https://github.com/xamarin/xamarin-macios/issues/4189
 	}
 
 	[CoreImageFilter]
 	[iOS (12,0)]
 	[TV (12,0)]
-	[NoMac]
+	[Mac (10,14, onlyOn64: true)]
 	[BaseType (typeof (CIFilter))]
 	interface CIDither {
-		// FIXME https://github.com/xamarin/xamarin-macios/issues/4189
+		[CoreImageFilterProperty ("inputIntensity")]
+		float Intensity { get; set; }
 	}
 
 	[CoreImageFilter]
 	[iOS (12,0)]
 	[TV (12,0)]
-	[NoMac]
+	[Mac (10,14, onlyOn64: true)]
 	[BaseType (typeof (CIFilter))]
 	interface CIGuidedFilter {
-		// FIXME https://github.com/xamarin/xamarin-macios/issues/4189
+		[CoreImageFilterProperty ("inputGuideImage")]
+		CIImage GuideImage { get; set; }
+		[CoreImageFilterProperty ("inputEpsilon")]
+		float Epsilon { get; set; }
+		[CoreImageFilterProperty ("inputRadius")]
+		float Radius { get; set; }
 	}
 
 	[CoreImageFilter]
 	[iOS (12,0)]
 	[TV (12,0)]
-	[NoMac]
+	[Mac (10,14, onlyOn64: true)]
 	[BaseType (typeof (CIFilter))]
 	interface CIMeshGenerator {
-		// FIXME https://github.com/xamarin/xamarin-macios/issues/4189
+		// https://github.com/xamarin/xamarin-macios/issues/4226
+		//[CoreImageFilterProperty ("inputMesh")]
+		//CIVector [] Mesh { get; set; }
+		[CoreImageFilterProperty ("inputWidth")]
+		float Width { get; set; }
+		[CoreImageFilterProperty ("inputColor")]
+		CIColor Color { get; set; }
 	}
 
 	[CoreImageFilter]
 	[iOS (12,0)]
 	[TV (12,0)]
-	[NoMac]
+	[Mac (10,14, onlyOn64: true)]
 	[BaseType (typeof (CIFilter))]
 	interface CIMix {
-		// FIXME https://github.com/xamarin/xamarin-macios/issues/4189
+		[CoreImageFilterProperty ("inputBackgroundImage")]
+		CIImage BackgroundImage { get; set; }
+		[CoreImageFilterProperty ("inputAmount")]
+		float Amount { get; set; }
 	}
 
 	[CoreImageFilter]
 	[iOS (12,0)]
 	[TV (12,0)]
-	[NoMac]
+	[Mac (10,14, onlyOn64: true)]
 	[BaseType (typeof (CIFilter))]
 	interface CISampleNearest {
-		// FIXME https://github.com/xamarin/xamarin-macios/issues/4189
 	}
 }


### PR DESCRIPTION
Complete the earlier stubs (committed to avoid tests failures) and add
`[Mac (10,14, onlyOn64: true)]` attributes on them.

This solves two XM failures when running on Mojave

```
3) ApiCoreImageFiltersTest.CheckManagedFilters (Introspection.MacCoreImageFiltersTest.ApiCoreImageFiltersTest.CheckManagedFilters)
     Managed filters not found for CIAreaMinMax, CIDither, CIGuidedFilter, CIMeshGenerator, CIMix, CISampleNearest
  Expected: 0
  But was:  6

  at Introspection.ApiCoreImageFiltersTest.CheckManagedFilters () [0x0019e] in /Users/poupou/git/xcode10/xamarin-macios/tests/introspection/ApiCoreImageFiltersTest.cs:146
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00032] in /Users/poupou/git/xcode10/xamarin-macios/external/mono/mcs/class/corlib/System.Reflection/MonoMethod.cs:305

4) ApiCoreImageFiltersTest.CheckNativeFilters (Introspection.MacCoreImageFiltersTest.ApiCoreImageFiltersTest.CheckNativeFilters)
     6 native filters missing: CIAreaMinMax, CIDither, CIGuidedFilter, CIMeshGenerator, CIMix, CISampleNearest
  Expected: 0
  But was:  6
```

Also introduce a new base type `CIReductionFilter` as found by tests

```
[WARN] CIAreaMaximum.SuperClass == CIReductionFilter (native) and CIFilter managed
[WARN] CIAreaMaximumAlpha.SuperClass == CIReductionFilter (native) and CIFilter managed
[WARN] CIAreaMinimum.SuperClass == CIReductionFilter (native) and CIFilter managed
[WARN] CIAreaMinimumAlpha.SuperClass == CIAreaMaximumAlpha (native) and CIFilter managed
```

Finally `CIMeshGenerator` is incomplete because the generator does not
support (never had to before) `NSArray` in filters, so we cannot express
`CIVector[]`. Filed as https://github.com/xamarin/xamarin-macios/issues/4226