### PR TITLE
[msbuild] Fix detecting already signed executables. (#3743)

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1860,6 +1860,11 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			Condition="'$(IsMacEnabled)' == 'true' And ('$(_CanOutputAppBundle)' == 'true' And '%(_AppExtensionCodesignProperties.SigningKey)' != '') And Exists ('$(AppBundleDir)\..\%(_AppExtensionCodesignProperties.Identity).dSYM\Contents\Info.plist')"
 			Files="$(AppBundleDir)\..\%(_AppExtensionCodesignProperties.Identity).dSYM\Contents\Info.plist"
 		/>
+		<Touch
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true' And Exists ('$(_AppBundlePath)PlugIns\%(_AppExtensionCodesignProperties.Identity)\_CodeSignature\CodeResources')"
+			Files="$(_AppBundlePath)PlugIns\%(_AppExtensionCodesignProperties.Identity)\_CodeSignature\CodeResources"
+		/>
 	</Target>
 
 	<Target Name="_PrepareCodesignAppExtension" Condition="'$(_CanOutputAppBundle)' == 'true' And '$(IsAppExtension)' == 'true' And '@(_ResolvedAppBundleExtensions)' == ''">
@@ -1960,6 +1965,11 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' And Exists ('$(AppBundleDir).dSYM\Contents\Info.plist')"
 			Files="$(AppBundleDir).dSYM\Contents\Info.plist"
+		/>
+		<Touch
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true' And Exists ('$(_AppBundlePath)_CodeSignature\CodeResources')"
+			Files="$(_AppBundlePath)_CodeSignature\CodeResources"
 		/>
 	</Target>
 


### PR DESCRIPTION
**Note: backport from master / d15-8**

The MSBuild tasks will codesign an executable if the executable's timestamp is
later than `_CodeSignature/CodeResources`'s timestamp (or if
`_CodeSignature/CodeResources` doesn't exist).

Unfortunately, the codesign executable modifies both of those files, and the
executable last. This means that even just after running codesign, the
executable's timestamp might be later than `_CodeSignature/CodeResources`'s
timestamp (due to HFS+'s one-second timestamp resolution, this might happen
all within the same second, which means that this is a random issue: the
problem only occurs if the executable was modified at least a second later
than `_CodeSignature/CodeResources`.)

So make sure to touch `_CodeSignature/CodeResources` after running codesign,
so that the next time a build occurs (with no modifications), we don't resign
needlessly.

Fixes this (random) test failure when running the MSBuild tests:

    1) Test Failure : Xamarin.iOS.Tasks.TargetTests.RebuildExecutable_NoModifications
         #1: ../MySingleView/bin/iPhoneSimulator/Debug/MySingleView.app/MySingleView
      Expected: 2017-11-30 10:04:20.000
      But was:  2017-11-30 10:04:22.000

Fixes https://github.com/xamarin/maccore/issues/592.