### PR TITLE
[xharness] Check the right (unpaired) device when determining whether a new watch device must be created or not. (#4222)

### DIFF
--- a/tests/xharness/Simulators.cs
+++ b/tests/xharness/Simulators.cs
@@ -203,7 +203,7 @@ namespace xharness
 				var unpairedDevice = unPairedDevices.FirstOrDefault ();
 				var companion_device = companion_devices.First ();
 				var device = devices.First ();
-				if (!await CreateDevicePair (log, unpairedDevice, companion_device, device.SimRuntime, device.SimDeviceType, device == null))
+				if (!await CreateDevicePair (log, unpairedDevice, companion_device, device.SimRuntime, device.SimDeviceType, unpairedDevice == null))
 					return null;
 
 				await LoadAsync (log, force: true);


### PR DESCRIPTION
This fixes a NullReferenceException when there are already paired watch devices:

    [0x700009ad7000:] EXCEPTION handling: System.NullReferenceException: Object reference not set to an instance of an object

    "<unnamed thread>" tid=0x0x700009ad7000 this=0x0x10b903ad8 , thread handle : 0x7f9ad49109a0, state : not waiting
      at xharness.Simulators/<CreateDevicePair>d__18.MoveNext () [0x001ae] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/xharness/Simulators.cs:169
      at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<bool>.Start<xharness.Simulators/<CreateDevicePair>d__18> (xharness.Simulators/<CreateDevicePair>d__18&) [0x0002c] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/AsyncMethodBuilder.cs:471
      at xharness.Simulators.CreateDevicePair (xharness.Log,xharness.SimDevice,xharness.SimDevice,string,string,bool) [0x00057] in <7c5e77efeb3146c095a26043fb517189>:0
      at xharness.Simulators/<FindOrCreateDevicePairAsync>d__19.MoveNext () [0x000fc] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/xharness/Simulators.cs:206
      at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<TResult_REF>.Start<TStateMachine_REF> (TStateMachine_REF&) [0x0002c] in <0f9df4881040473f9da7cf6c2e2cb8c3>:0
      at xharness.Simulators.FindOrCreateDevicePairAsync (xharness.Log,System.Collections.Generic.IEnumerable`1<xharness.SimDevice>,System.Collections.Generic.IEnumerable`1<xharness.SimDevice>) [0x0003f] in <7c5e77efeb3146c095a26043fb517189>:0
      at xharness.Simulators/<FindAsync>d__20.MoveNext () [0x00364] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/xharness/Simulators.cs:275