### PR TITLE
[macos][quartzcomposer] Update for beta 1

### DIFF
--- a/src/quartzcomposer.cs
+++ b/src/quartzcomposer.cs
@@ -98,9 +98,11 @@ namespace QuartzComposer {
 		[Field ("QCCompositionInputDestinationImageKey")]
 		NSString InputDestinationImageKey { get; }
 
+		[Obsoleted (PlatformName.MacOSX, 14,0, message: "Field will return 'null'.")]
 		[Field ("QCCompositionInputRSSFeedURLKey")]
 		NSString InputRSSFeedURLKey { get; }
 
+		[Obsoleted (PlatformName.MacOSX, 14,0, message: "Field will return 'null'.")]
 		[Field ("QCCompositionInputRSSArticleDurationKey")]
 		NSString InputRSSArticleDurationKey { get; }
 
@@ -158,6 +160,7 @@ namespace QuartzComposer {
 		[Field ("QCCompositionProtocolScreenSaver")]
 		NSString ProtocolScreenSaver { get; }
 
+		[Obsoleted (PlatformName.MacOSX, 14,0, message: "Field will return 'null'.")]
 		[Field ("QCCompositionProtocolRSSVisualizer")]
 		NSString ProtocolRSSVisualizer { get; }
 
@@ -166,6 +169,7 @@ namespace QuartzComposer {
 	}
 
 
+	[Deprecated (PlatformName.MacOSX, 10,14, message: "Use 'Metal' instead.")]
 	[BaseType (typeof (CAOpenGLLayer))]
 	[DisableDefaultCtor] // return invalid handle
 	interface QCCompositionLayer {

--- a/tests/introspection/Mac/MacApiFieldTest.cs
+++ b/tests/introspection/Mac/MacApiFieldTest.cs
@@ -76,6 +76,17 @@ namespace Introspection {
 					break;
 				}
 				break;
+			// Xcode 10
+			case "QCComposition":
+				switch (p.Name) {
+				case "InputRSSArticleDurationKey":
+				case "InputRSSFeedURLKey":
+				case "ProtocolRSSVisualizer":
+					if (Mac.CheckSystemVersion (10,14)); // radar 41125938
+						return true;
+					break;
+				}
+				break;
 			}
 
 			switch (p.Name) {
@@ -186,6 +197,13 @@ namespace Introspection {
 				if (Mac.Is32BitMavericks)
 					return true;
 				goto default;
+			// Xcode 10
+			case "QCCompositionInputRSSFeedURLKey":
+			case "QCCompositionInputRSSArticleDurationKey":
+			case "QCCompositionProtocolRSSVisualizer":
+				if (Mac.CheckSystemVersion (10,14)); // radar 41125938
+					return true;
+				break;
 			default:
 				return base.Skip (constantName, libraryName);
 			}

--- a/tests/xtro-sharpie/macOS-QuartzComposer.todo
+++ b/tests/xtro-sharpie/macOS-QuartzComposer.todo
@@ -1,3 +1,10 @@
+## OpenGL deprecated in 10.14 in favor of Metal
+!missing-selector! QCRenderer::initWithCGLContext:pixelFormat:colorSpace:composition: not bound
+!missing-selector! QCRenderer::initWithOpenGLContext:pixelFormat:file: not bound
+
+
+## unsorted
+
 !missing-field! QCCompositionPickerPanelDidSelectCompositionNotification not bound
 !missing-field! QCCompositionPickerViewDidSelectCompositionNotification not bound
 !missing-field! QCCompositionRepositoryDidUpdateNotification not bound
@@ -79,9 +86,7 @@
 !missing-selector! QCPlugInViewController::initWithPlugIn:viewNibName: not bound
 !missing-selector! QCRenderer::createSnapshotImageOfType: not bound
 !missing-selector! QCRenderer::initOffScreenWithSize:colorSpace:composition: not bound
-!missing-selector! QCRenderer::initWithCGLContext:pixelFormat:colorSpace:composition: not bound
 !missing-selector! QCRenderer::initWithComposition:colorSpace: not bound
-!missing-selector! QCRenderer::initWithOpenGLContext:pixelFormat:file: not bound
 !missing-selector! QCRenderer::renderAtTime:arguments: not bound
 !missing-selector! QCRenderer::renderingTimeForTime:arguments: not bound
 !missing-selector! QCView::createSnapshotImageOfType: not bound

--- a/tests/xtro-sharpie/xtro-report/Reporter.cs
+++ b/tests/xtro-sharpie/xtro-report/Reporter.cs
@@ -61,7 +61,6 @@ namespace Extrospection {
 			case "PreferencePanes":
 			case "Python":
 			case "QD":
-			case "QuartzComposer":
 			case "QuartzFilters":
 			case "ruby":
 			case "ScreenSaver":


### PR DESCRIPTION
Nothing really new beside the OpenGL related deprecation and the fact
that 3 fields were removed, without deprecation, and this requires some
adjustments in the intro tests (while running on 10.14) to ignore them.

1) ApiFieldTest.FieldExists (Introspection.MacApiFieldTest.ApiFieldTest.FieldExists)
     3 errors found in 5680 fields validated: QCCompositionInputRSSArticleDurationKey, QCCompositionInputRSSFeedURLKey, QCCompositionProtocolRSSVisualizer
  Expected: 0
  But was:  3

  at Introspection.ApiFieldTest.FieldExists () [0x00127] in /Users/poupou/git/xcode10/xamarin-macios/tests/introspection/ApiFieldTest.cs:245
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00032] in /Users/poupou/git/xcode10/xamarin-macios/external/mono/mcs/class/corlib/System.Reflection/MonoMethod.cs:305

2) ApiFieldTest.NonNullNSStringFields (Introspection.MacApiFieldTest.ApiFieldTest.NonNullNSStringFields)
     3 errors found in 4904 fields validated: QuartzComposer.QCComposition.InputRSSArticleDurationKey, QuartzComposer.QCComposition.InputRSSFeedURLKey, QuartzComposer.QCComposition.ProtocolRSSVisualizer
  Expected: 0
  But was:  3

  at Introspection.ApiFieldTest.NonNullNSStringFields () [0x0008d] in /Users/poupou/git/xcode10/xamarin-macios/tests/introspection/ApiFieldTest.cs:214
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00032] in /Users/poupou/git/xcode10/xamarin-macios/external/mono/mcs/class/corlib/System.Reflection/MonoMethod.cs:305

That issue is filed w/Apple https://bugreport.apple.com/web/?problemID=41125938