### PR TITLE
[xharness] Fix publishing xtro's html report.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -2939,7 +2939,7 @@ function oninitialload ()
 				using (var proc = new Process ()) {
 					proc.StartInfo.FileName = "/Library/Frameworks/Mono.framework/Commands/mono";
 					var reporter = System.IO.Path.Combine (WorkingDirectory, "xtro-report/bin/Debug/xtro-report.exe");
-					var results = System.IO.Path.GetFullPath (System.IO.Path.Combine (Jenkins.LogDirectory, "..", "xtro"));
+					var results = System.IO.Path.Combine (Logs.Directory, $"xtro-{Timestamp}");
 					proc.StartInfo.Arguments = $"--debug {reporter} {WorkingDirectory} {results}";
 
 					Jenkins.MainLog.WriteLine ("Executing {0} ({1})", TestName, Mode);
@@ -2972,9 +2972,7 @@ function oninitialload ()
 					}
 					Jenkins.MainLog.WriteLine ("Executed {0} ({1})", TestName, Mode);
 
-					var output = Logs.Create ($"Report-{Timestamp}.html", "HTML Report");
-					var report = System.IO.Path.GetFullPath (System.IO.Path.Combine (results, "index.html"));
-					output.WriteLine ($"<html><head><meta http-equiv=\"refresh\" content=\"0; url={report}\" /></head></html>");
+					Logs.AddFile (System.IO.Path.Combine (results, "index.html"), "HTML Report");
 				}
 			}
 		}


### PR DESCRIPTION
1. Put xtro's results in a subdirectory of the current test's log directory,
   not a sibling directory of the root log directory (which would prevent it
   from being uploaded after a test run, since only the root log directory is
   uploaded).

2. Just add the existing index.html as the html report to the collection of
   logs, no need to create a new file pointing to it. This fixes a problem
   where the generated html file would redirect to a local file, which would
   not work when served from a web server.