### PR TITLE
[runtime] Use public mono API to set the pending exception. Fixes #4271.

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -239,11 +239,12 @@
 
 		#region metadata/object-internals.h
 
-		new Export (true, "void", "mono_set_pending_exception",
-			"MonoException *", "exc"
+		new Export (true, "void", "mono_runtime_set_pending_exception",
+			"MonoException *", "exc",
+			"mono_bool", "overwrite"
 		)
 		{
-			AlternativeEntryPoint = "mono_raise_exception",
+			AlternativeExpression = "return mono_raise_exception (exc);",
 		},
 
 		#endregion
@@ -674,7 +675,7 @@
 	{
 		public string ReturnType;
 		public string EntryPoint;
-		public string AlternativeEntryPoint;
+		public string AlternativeExpression;
 		public List<Arg> Arguments;
 		public bool Optional;
 

--- a/runtime/mono-runtime.m.t4
+++ b/runtime/mono-runtime.m.t4
@@ -125,8 +125,8 @@ MONO_API <#= export.ReturnType #>
 {
 <# if (export.Optional) { #>
 	if (<#= export.EntryPoint #>_func == NULL)
-<# if (!string.IsNullOrEmpty (export.AlternativeEntryPoint)) { #>
-		return <#= export.AlternativeEntryPoint #> (<#= export.ArgumentNames #>);
+<# if (!string.IsNullOrEmpty (export.AlternativeExpression)) { #>
+		<#= export.AlternativeExpression #>
 <# } else {#>
 		xamarin_assertion_message ("Could not load <#= export.EntryPoint #>\n");
 <# } #>

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2277,7 +2277,7 @@ xamarin_process_nsexception_using_mode (NSException *ns_exception, bool throwMan
 		if (exc_handle != NULL) {
 			int handle = [exc_handle getHandle];
 			MonoObject *exc = mono_gchandle_get_target (handle);
-			mono_set_pending_exception ((MonoException *) exc);
+			mono_runtime_set_pending_exception ((MonoException *) exc, false);
 		} else {
 			int handle = xamarin_create_ns_exception (ns_exception, &exception_gchandle);
 			if (exception_gchandle != 0) {
@@ -2288,7 +2288,7 @@ xamarin_process_nsexception_using_mode (NSException *ns_exception, bool throwMan
 			}
 			MONO_ENTER_GC_UNSAFE;
 			MonoObject *exc = mono_gchandle_get_target (handle);
-			mono_set_pending_exception ((MonoException *) exc);
+			mono_runtime_set_pending_exception ((MonoException *) exc, false);
 			mono_gchandle_free (handle);
 			MONO_EXIT_GC_UNSAFE;
 		}


### PR DESCRIPTION
This makes exception marshaling work with Xamarin.Mac apps that use the system
mono (such as Visual Studio for Mac, and assuming at least a v5.12 system
mono).

https://github.com/xamarin/xamarin-macios/issues/4271