### PR TITLE
[introspection] CMMovementDisorderManager isn't usable for now.

### DIFF
--- a/tests/introspection/iOS/iOSApiProtocolTest.cs
+++ b/tests/introspection/iOS/iOSApiProtocolTest.cs
@@ -71,6 +71,13 @@ namespace Introspection {
 				if (!TestRuntime.CheckXcodeVersion (8, 0))
 					return true;
 				break;
+			case "CMMovementDisorderManager":
+				// From Xcode 10 beta 2:
+				// This requires a special entitlement:
+				//     Usage of CMMovementDisorderManager requires a special entitlement.  Please see for more information https://developer.apple.com/documentation/coremotion/cmmovementdisordermanager
+				// but that web page doesn't explain anything (it's mostly empty, so this is probably just lagging documentation)
+				// I also tried enabling every entitlement in Xcode, but it still didn't work.
+				return true;
 			}
 
 			return base.Skip (type);

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -138,6 +138,13 @@ namespace Introspection {
 			case "INPaymentStatusResolutionResult":
 			case "INPaymentAccountResolutionResult":
 				return true;
+			case "CMMovementDisorderManager":
+				// From Xcode 10 beta 2:
+				// This requires a special entitlement:
+				//     Usage of CMMovementDisorderManager requires a special entitlement.  Please see for more information https://developer.apple.com/documentation/coremotion/cmmovementdisordermanager
+				// but that web page doesn't explain anything (it's mostly empty, so this is probably just lagging documentation)
+				// I also tried enabling every entitlement in Xcode, but it still didn't work.
+				return true;
 #endif
 
 			default:


### PR DESCRIPTION
This fixes an assert when running introspection on watchOS:

> 2018-06-20 17:44:21.229988+0200 testCMMovementDisorderManager WatchKit Extension[4249:82943] [Health] {"msg":"Usage of CMMovementDisorderManager requires a special entitlement.  Please see for more information https://developer.apple.com/documentation/coremotion/cmmovementdisordermanager", "event":assert, "condition":isEntitled}