### PR TITLE
Fix resetting a README dependency when the hash exists, but the branch does not. Fixes #4308.

### DIFF
--- a/mk/xamarin-reset.sh
+++ b/mk/xamarin-reset.sh
@@ -18,7 +18,12 @@ if test -d "$DEPENDENCY_PATH"; then
 	if ! git log -1 --pretty=%H "$DEPENDENCY_HASH" > /dev/null 2>&1; then
 		echo "*** [$DEPENDENCY_NAME] git fetch $DEPENDENCY_REMOTE"
 		git fetch "$DEPENDENCY_REMOTE"
+	elif ! git rev-parse --verify "$DEPENDENCY_REMOTE/$DEPENDENCY_BRANCH" > /dev/null 2>&1; then
+		# Also check if we have the branch we need, we might already have the hash, but not the branch
+		echo "*** [$DEPENDENCY_NAME] git fetch $DEPENDENCY_REMOTE"
+		git fetch "$DEPENDENCY_REMOTE"
 	fi
+
 else
 	echo "*** [$DEPENDENCY_NAME] git clone $DEPENDENCY_MODULE --recursive $DEPENDENCY_DIRECTORY -b $DEPENDENCY_BRANCH --origin $DEPENDENCY_REMOTE"
 	mkdir -p "$(dirname "$DEPENDENCY_PATH")"
@@ -29,6 +34,9 @@ fi
 
 if ! git log -1 --pretty=%H "$DEPENDENCY_HASH" > /dev/null 2>&1; then
 	echo "The hash $DEPENDENCY_HASH does not exist in $DEPENDENCY_MODULE. Please verify that you pushed your changes."
+	exit 1
+elif ! git rev-parse --verify "$DEPENDENCY_REMOTE/$DEPENDENCY_BRANCH" > /dev/null 2>&1; then
+	echo "The branch $DEPENDENCY_BRANCH does not exist in $DEPENDENCY_MODULE. Please verify that you pushed your changes."
 	exit 1
 fi
 


### PR DESCRIPTION
Fix this by checking if the branch exists, and if not, fetch the repository.

Also add a better error message if the remote doesn't have the requested branch.

Fixes https://github.com/xamarin/xamarin-macios/issues/4308.