### PR TITLE
[tests] Fix introspection tests when running on Mojave (10.14)

### DIFF
--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -97,6 +97,11 @@ namespace Introspection {
 				case "MLMultiArrayConstraint":
 				case "VSSubscription":
 					return true; // skip
+				// xcode 10
+				case "VSAccountMetadata":
+				case "VSAccountMetadataRequest":
+				case "VSAccountProviderResponse":
+					return true;
 				}
 				break;
 			case "NSMutableCopying":
@@ -104,6 +109,10 @@ namespace Introspection {
 				// iOS 10 : test throw because of generic usage
 				case "NSMeasurement`1":
 					return true; // skip
+				// Xcode 10
+				case "UNNotificationCategory":
+				case "UNNotificationSound":
+					return true;
 				}
 				break;
 			case "NSCoding":
@@ -138,6 +147,9 @@ namespace Introspection {
 					return true;
 				// Xcode 10
 				case "NSManagedObjectID":
+				case "VSAccountMetadata":
+				case "VSAccountMetadataRequest":
+				case "VSAccountProviderResponse":
 					return true;
 				}
 				break;
@@ -182,6 +194,9 @@ namespace Introspection {
 				// beta 2
 				case "NSShadow":
 				case "NSTextAttachment":
+				case "VSAccountMetadata":
+				case "VSAccountMetadataRequest":
+				case "VSAccountProviderResponse":
 					return true;
 				}
 				break;

--- a/tests/introspection/Mac/MacApiProtocolTest.cs
+++ b/tests/introspection/Mac/MacApiProtocolTest.cs
@@ -71,6 +71,9 @@ namespace Introspection {
 				// Xcode 10 (running on macOS 10.14)
 				case "NSTextAlternatives":
 				case "QTDataReference": // no header files anymore for deprecated QuickTime
+				case "NSTextBlock":
+				case "NSTextTable":
+				case "NSTextTableBlock":
 					return true;
 				default:
 					// CIFilter started implementing NSSecureCoding in 10.11

--- a/tests/introspection/iOS/iOSApiProtocolTest.cs
+++ b/tests/introspection/iOS/iOSApiProtocolTest.cs
@@ -188,10 +188,6 @@ namespace Introspection {
 				case "MSSession":
 				case "SFContentBlockerState":
 				case "SFSafariViewControllerConfiguration":
-				case "VSAccountMetadata":
-				case "VSAccountMetadataRequest":
-				// iOS 10.2
-				case "VSAccountProviderResponse":
 				// iOS 10.3
 				case "MPMusicPlayerControllerMutableQueue":
 				case "MPMusicPlayerControllerQueue":
@@ -343,10 +339,6 @@ namespace Introspection {
 				case "MSSession":
 				case "SFContentBlockerState":
 				case "SFSafariViewControllerConfiguration":
-				case "VSAccountMetadata":
-				case "VSAccountMetadataRequest":
-				// iOS 10.2
-				case "VSAccountProviderResponse":
 				// iOS 10.3
 				case "MPMusicPlayerControllerMutableQueue":
 				case "MPMusicPlayerControllerQueue":
@@ -476,10 +468,6 @@ namespace Introspection {
 				case "HKDocumentSample":
 				case "HKCdaDocumentSample":
 				case "SFSafariViewControllerConfiguration":
-				case "VSAccountMetadata":
-				case "VSAccountMetadataRequest":
-				// iOS 10.2
-				case "VSAccountProviderResponse":
 					return true;
 				// iOS 11.0
 				case "UICollectionViewUpdateItem": // Conformance not in headers
@@ -511,7 +499,6 @@ namespace Introspection {
 				break;
 			case "NSMutableCopying":
 				switch (type.Name) {
-				case "UNNotificationSound":
 				// iOS 10.3
 				case "MPMusicPlayerControllerMutableQueue":
 				case "MPMusicPlayerControllerQueue":
@@ -520,9 +507,6 @@ namespace Introspection {
 				case "INRestaurantGuest":
 				case "INPerson":
 				case "HMCharacteristicEvent": // Selectors not available on 32 bit
-					return true;
-				// iOS 12
-				case "UNNotificationCategory":
 					return true;
 				}
 				break;


### PR DESCRIPTION
Mostly known iOS cases that are now part included in macOS.

Two failures remains until the AppKit update is merged, i.e.
both were _upgraded_ to conform to `NSSecureCoding`

```
[FAIL] NSBezierPath conforms to NSSecureCoding but does not implement INSSecureCoding
[FAIL] NSGradient conforms to NSSecureCoding but does not implement INSSecureCoding
```