### PR TITLE
[introspection] Cache typo checks.

### DIFF
--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -830,7 +830,7 @@ namespace Introspection
 						continue;
 
 					string txt = NameCleaner (t.Name);
-					var typo = GetTypo (txt);
+					var typo = GetCachedTypo (txt);
 					if (typo.Length > 0 ) {
 						if (!Skip (t, typo)) {
 							ReportError ("Typo in TYPE: {0} - {1} ", t.Name, typo);
@@ -849,7 +849,7 @@ namespace Introspection
 							continue;
 						
 						txt = NameCleaner (f.Name);
-						typo = GetTypo (txt);
+						typo = GetCachedTypo (txt);
 						if (typo.Length > 0) {
 							if (!Skip (f, typo)) {
 								ReportError ("Typo in FIELD name: {0} - {1}, Type: {2}", f.Name, typo, t.Name);
@@ -869,7 +869,7 @@ namespace Introspection
 							continue;
 						
 						txt = NameCleaner (m.Name);
-						typo = GetTypo (txt);
+						typo = GetCachedTypo (txt);
 						if (typo.Length > 0) {
 							if (!Skip (m, typo)) {
 								ReportError ("Typo in METHOD name: {0} - {1}, Type: {2}", m.Name, typo, t.Name);
@@ -880,7 +880,7 @@ namespace Introspection
 						var parameters = m.GetParameters ();
 						foreach (ParameterInfo p in parameters) {
 							txt = NameCleaner (p.Name);
-							typo = GetTypo (txt);
+							typo = GetCachedTypo (txt);
 							if (typo.Length > 0) {
 								ReportError ("Typo in PARAMETER Name: {0} - {1}, Method: {2}, Type: {3}", p.Name, typo, m.Name, t.Name);
 								totalErrors++;
@@ -966,6 +966,14 @@ namespace Introspection
 			}
 		}
 
+		Dictionary<string, string> cached_typoes = new Dictionary<string, string> ();
+		string GetCachedTypo (string txt)
+		{
+			string rv;
+			if (!cached_typoes.TryGetValue (txt, out rv))
+				cached_typoes [txt] = rv = GetTypo (txt);
+			return rv;
+		}
 		public abstract string GetTypo (string txt);
 
 		static StringBuilder clean = new StringBuilder ();


### PR DESCRIPTION
This makes TypoTest finish in 62 seconds on Mojave instead of 411 seconds.