### PR TITLE
[Security] Don't call properties in the Dispose method, access the field directly.

### DIFF
--- a/src/Security/SecAccessControl.cs
+++ b/src/Security/SecAccessControl.cs
@@ -109,9 +109,9 @@ namespace Security {
 		public virtual void Dispose (bool disposing)
 #endif
 		{
-			if (Handle != IntPtr.Zero){
-				CFObject.CFRelease (Handle);
-				Handle = IntPtr.Zero;
+			if (handle != IntPtr.Zero){
+				CFObject.CFRelease (handle);
+				handle = IntPtr.Zero;
 			}
 		}
 


### PR DESCRIPTION
This is particularly important because in this case the property will try to
(re)create the handle, thus making Dispose behave incorrectly.