### PR TITLE
[generator] Fix generated code for INativeObject properties in filters: we don't own such objects.

### DIFF
--- a/src/generator-filters.cs
+++ b/src/generator-filters.cs
@@ -172,7 +172,7 @@ public partial class Generator {
 		case "AVCameraCalibrationData":
 		case "CGColorSpace":
 		case "CIBarcodeDescriptor":
-			print ("return Runtime.GetINativeObject <{0}> (GetHandle (\"{1}\"), true);", propertyType, propertyName);
+			print ("return Runtime.GetINativeObject <{0}> (GetHandle (\"{1}\"), false);", propertyType, propertyName);
 			break;
 		case "CIColor":
 			print ("return GetColor (\"{0}\");", propertyName);

--- a/tests/monotouch-test/CoreImage/FilterTest.cs
+++ b/tests/monotouch-test/CoreImage/FilterTest.cs
@@ -105,8 +105,10 @@ namespace MonoTouchFixtures.CoreImage {
 				using (var cs = CGColorSpace.CreateDeviceGray ()) {
 					f.ColorSpace = cs;
 					var rc = CFGetRetainCount (cs.Handle);
-					for (int i = 0; i < 5; i++)
-						Assert.NotNull (f.ColorSpace, i.ToString ());
+					for (int i = 0; i < 5; i++) {
+						using (var fcs = f.ColorSpace)
+							Assert.NotNull (fcs, i.ToString ());
+					}
 					Assert.That (CFGetRetainCount (cs.Handle), Is.EqualTo (rc), "RetainCount");
 					f.ColorSpace = null;
 				}


### PR DESCRIPTION
Fixes a crash in the MonoTouchFixtures.CoreImage.FilterTest.ColorSpace on macOS 10.9 and 10.10:

    Assertion failed: (!space->is_singleton), function color_space_dealloc, file ColorSpaces/color-space.c, line 102.
    Stacktrace:

      at <unknown> <0xffffffff>
      at (wrapper managed-to-native) CoreGraphics.CGColorSpace.CGColorSpaceRelease (intptr) [0x00009] in <7709ef494bc84be8a727c0b1d19c4344>:0
      at CoreGraphics.CGColorSpace.Dispose (bool) [0x00016] in /Library/Frameworks/Xamarin.Mac.framework/Versions/4.99.0.103/src/Xamarin.Mac/CoreGraphics/CGColorSpace.cs:116
      at CoreGraphics.CGColorSpace.Finalize () [0x00002] in /Library/Frameworks/Xamarin.Mac.framework/Versions/4.99.0.103/src/Xamarin.Mac/CoreGraphics/CGColorSpace.cs:94
      at (wrapper runtime-invoke) object.runtime_invoke_virtual_void__this__ (object,intptr,intptr,intptr) [0x0001f] in <ea4ecc87ef1044a98fc1b5fdb59119e7>:0

    Native stacktrace:

    	0   xammac_tests                        0x000000010d55fc18 mono_handle_native_crash + 264
    	1   libsystem_platform.dylib            0x00007fff8d4a152a _sigtramp + 26
    	2   ???                                 0x0000000000000000 0x0 + 0
    	3   libsystem_c.dylib                   0x00007fff9aba76df abort + 129
    	4   libsystem_c.dylib                   0x00007fff9ab6edd8 basename + 0
    	5   CoreGraphics                        0x00007fff8c2b58b8 color_space_dealloc + 248
    	6   CoreFoundation                      0x00007fff87997af3 CFRelease + 371
    	7   ???                                 0x00000001248548cd 0x0 + 4907681997
    	8   ???                                 0x000000012416a13c 0x0 + 4900430140
    	9   xammac_tests                        0x000000010d5f7d0e mono_gc_run_finalize + 734
    	10  xammac_tests                        0x000000010d6e859a sgen_gc_invoke_finalizers + 234
    	11  xammac_tests                        0x000000010d5f9754 finalizer_thread + 756
    	12  xammac_tests                        0x000000010d6ae930 start_wrapper + 704
    	13  libsystem_pthread.dylib             0x00007fff8ae8999d _pthread_body + 131
    	14  libsystem_pthread.dylib             0x00007fff8ae8991a _pthread_body + 0
    	15  libsystem_pthread.dylib             0x00007fff8ae87351 thread_start + 13

On newer macOS versions, the API that returns a CGColorSpace returns a global
object that can't be retained/released, and thus won't crash since the
CGColorSpace is never freed.