### PR TITLE
[jenkins] Add support for completely skipping the public jenkins job using a label.

### DIFF
--- a/jenkins/build-api-diff.sh
+++ b/jenkins/build-api-diff.sh
@@ -9,6 +9,13 @@ report_error ()
 }
 trap report_error ERR
 
+# SC2154: ghprbPullId is referenced but not assigned.
+# shellcheck disable=SC2154
+if test -n "$ghprbPullId" && ./jenkins/fetch-pr-labels.sh --check=skip-public-jenkins; then
+	echo "Skipping API diff because the label 'skip-public-jenkins' was found."
+	exit 0
+fi
+
 export BUILD_REVISION=jenkins
 make -j8 -C tools/apidiff jenkins-api-diff
 

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -15,7 +15,7 @@ fi
 
 ls -la "$WORKSPACE/jenkins"
 echo "$WORKSPACE/jenkins/pr-comments.md:"
-cat "$WORKSPACE/jenkins/pr-comments.md"
+cat "$WORKSPACE/jenkins/pr-comments.md" || true
 
 export BUILD_REVISION=jenkins
 
@@ -27,6 +27,11 @@ if test -z "$ghprbPullId"; then
 	echo "Could not find the environment variable ghprbPullId, so forcing a device build."
 	ENABLE_DEVICE_BUILD=1
 else
+	if ./jenkins/fetch-pr-labels.sh --check=skip-public-jenkins; then
+		echo "Skipping execution because the label 'skip-public-jenkins' was found."
+		printf "ℹ️ [Skipped execution](%s/console)\\n" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"
+		exit 0
+	fi
 	echo "Listing modified files for pull request #$ghprbPullId..."
 	if git diff-tree --no-commit-id --name-only -r "origin/pr/$ghprbPullId/merge^..origin/pr/$ghprbPullId/merge" > .tmp-files; then
 		echo "Modified files found":

--- a/jenkins/compare.sh
+++ b/jenkins/compare.sh
@@ -18,6 +18,10 @@ if test -n "$ghprbPullId"; then
 		printf "❎ Skipped API comparison because the PR has the label 'skip-api-comparison'\\n" >> "$WORKSPACE/jenkins/pr-comments.md"
 		exit 0
 	fi
+	if ./jenkins/fetch-pr-labels.sh --check=skip-public-jenkins; then
+		echo "Skipping API comparison because the label 'skip-public-jenkins' was found."
+		exit 0
+	fi
 fi
 
 if test -z "$ghprbPullId"; then

--- a/jenkins/provision-deps.sh
+++ b/jenkins/provision-deps.sh
@@ -9,6 +9,13 @@ report_error ()
 }
 trap report_error ERR
 
+# SC2154: ghprbPullId is referenced but not assigned.
+# shellcheck disable=SC2154
+if test -n "$ghprbPullId" && ./jenkins/fetch-pr-labels.sh --check=skip-public-jenkins; then
+	echo "Skipping provisioning diff because the label 'skip-public-jenkins' was found."
+	exit 0
+fi
+
 ./system-dependencies.sh --provision-all
 
 echo "✅ [Provisioning succeeded]($BUILD_URL/console)" >> "$WORKSPACE/jenkins/pr-comments.md"

--- a/jenkins/run-tests.sh
+++ b/jenkins/run-tests.sh
@@ -16,6 +16,13 @@ report_error ()
 }
 trap report_error ERR
 
+# SC2154: ghprbPullId is referenced but not assigned.
+# shellcheck disable=SC2154
+if test -n "$ghprbPullId" && ./jenkins/fetch-pr-labels.sh --check=skip-public-jenkins; then
+	echo "Skipping tests because the label 'skip-public-jenkins' was found."
+	exit 0
+fi
+
 TARGET=jenkins
 PUBLISH=
 KEYCHAIN=builder


### PR DESCRIPTION
This can be useful when working on the support for private jenkins, since many
of those changes can only be tested as a pull request, and they also tend to
include a lot of commits (because nothing can be tested locally).

So until whatever needs implementing for private jenkins is complete and
working, there's no need for the public bots to do anything for such pull
requests.