### PR TITLE
[jenkins] Make it possible to run internal jenkins tests on pull requests.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -224,14 +224,19 @@ timestamps {
                     }
 
                     if (isPr) {
-                        if (!githubGetPullRequestLabels ().contains ("build-package")) {
+                        def hasBuildPackage = githubGetPullRequestLabels ().contains ("build-package")
+                        def hasRunInternalTests = githubGetPullRequestLabels ().contains ("run-internal-tests")
+
+                        if (!hasBuildPackage && !hasRunInternalTests) {
                             // don't add a comment to the pull request, since the public jenkins will also add comments, which ends up being too much.
                             createFinalStatus = false
-                            echo ("Build skipped because the pull request doesn't have the label 'build-package'.")
+                            echo ("Build skipped because the pull request doesn't have either of the labels 'build-package' or 'run-internal-tests'.")
                             return
                         }
 
-                        skipLocalTestRunReason = "Not running tests here because they're run on public Jenkins."
+
+                        if (!hasRunInternalTests)
+                            skipLocalTestRunReason = "Not running tests here because they're run on public Jenkins."
                     }
 
                     dir ("${workspace}") {


### PR DESCRIPTION
Add support for the 'run-internal-tests' label on pull requests to indicate
that the internal jenkins should run tests when that label is applied.

Also make it so that either the 'run-internal-tests' or the 'build-package'
label will actually make the internal jenkins execute (otherwise the 'run-
internal-tests' label would also require the 'build-package' label, which
wouldn't be very obvious/user-friendly).