### PR TITLE
[Foundation] Fix NSDictionary string indexers.

### DIFF
--- a/src/Foundation/NSDictionary.cs
+++ b/src/Foundation/NSDictionary.cs
@@ -359,8 +359,11 @@ namespace Foundation {
 			get {
 				if (key == null)
 					throw new ArgumentNullException ("key");
-				using (var nss = new NSString (key)){
-					return ObjectForKey (nss);
+				var nss = NSString.CreateNative (key, false);
+				try {
+					return Runtime.GetNSObject (LowlevelObjectForKey (nss));
+				} finally {
+					NSString.ReleaseNative (nss);
 				}
 			}
 			set {

--- a/src/Foundation/NSMutableDictionary.cs
+++ b/src/Foundation/NSMutableDictionary.cs
@@ -267,15 +267,22 @@ namespace Foundation {
 			get {
 				if (key == null)
 					throw new ArgumentNullException ("key");
-				using (var nss = new NSString (key)){
-					return ObjectForKey (nss);
+				var nss = NSString.CreateNative (key, false);
+				try {
+					return Runtime.GetNSObject (LowlevelObjectForKey (nss));
+				} finally {
+					NSString.ReleaseNative (nss);
 				}
 			}
 			set {
 				if (key == null)
 					throw new ArgumentNullException ("key");
-				using (var nss = new NSString (key))
-					SetObject (value, nss);
+				var nss = NSString.CreateNative (key, false);
+				try {
+					LowlevelSetObject (value, nss);
+				} finally {
+					NSString.ReleaseNative (nss);
+				}
 			}
 		}
 

--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -292,9 +292,6 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void FinalizationRaceCondition ()
 		{
-			if ((IntPtr.Size == 8) && TestRuntime.CheckXcodeVersion (7, 0))
-				Assert.Ignore ("NSString retainCount is nuint.MaxValue, so we won't collect them");
-			
 #if __WATCHOS__
 			if (Runtime.Arch == Arch.DEVICE)
 				Assert.Ignore ("This test uses too much memory for the watch.");


### PR DESCRIPTION
Creating a new NSString doesn't always lead to creating a new NSString, which
will obviously cause trouble.

The scenario is:

* An NSString with the value @"Bye" is added to an NSDictionary, with the same
  string as both the key and the value.

* The (managed) string indexer is used to try to get the value back. The
  string indexer would call 'new NSString ("Bye")', which would create a new
  managed NSString, and maybe a new native NSString (or maybe it would re-use
  an existing NSString). Then the handle of this NSString would be passed to
  the native API, and the same handle would come back as the result (since the
  same string is both the key and the value). We'd call Runtime.GetNSString on
  the returned handle, get back the same managed instance that was created
  just before the call to the native method. Finally, just before returning
  this managed instance from the indexer, we'd dispose it... since it was
  created in a 'using' block. Then we'd return a disposed NSString object from
  the indexer. Ops.

The fix is to not create a managed wrapper for the NSString handle we need to
pass to the native API, but create and free the native NSString object without
using a managed wrapper.