### PR TITLE
Use libc++ instead of stdlibc++ when compiling with Xcode 10.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -180,7 +180,7 @@ endif
 
 SIMULATOR_SDK=$(XCODE_DEVELOPER_ROOT)/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk
 
-OBJC_CFLAGS=-ObjC++ -std=c++0x -fno-exceptions -I$(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1
+OBJC_CFLAGS=-ObjC++ -std=c++0x -fno-exceptions -stdlib=libc++
 
 COMMON_SIMULATOR_CFLAGS=-mios-simulator-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(SIMULATOR_SDK) $(CFLAGS) -g $(IOS_COMMON_DEFINES)
 SIMULATOR86_CFLAGS=$(COMMON_SIMULATOR_CFLAGS) -arch i386

--- a/tools/common/CompilerFlags.cs
+++ b/tools/common/CompilerFlags.cs
@@ -91,6 +91,14 @@ namespace Xamarin.Utils
 			SourceFiles.Add (file);
 		}
 
+		public void AddStandardCppLibrary ()
+		{
+			if (Driver.XcodeVersion.Major < 10)
+				return;
+			// Xcode 10 doesn't ship with libstdc++, so use libc++ instead.
+			AddOtherFlag ("-stdlib=libc++");
+		}
+
 		public void AddOtherFlag (string flag)
 		{
 			if (OtherFlags == null)

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -213,10 +213,10 @@ Xamarin.Mac.registrar.full.x86_64.m:   $(TOP)/src/build/mac/full-64/Xamarin.Mac.
 	$(Q) touch Xamarin.Mac.registrar.full.x86_64.m Xamarin.Mac.registrar.full.x86_64.h
 
 Xamarin.Mac.registrar.%.i386.a:   Xamarin.Mac.registrar.%.i386.m
-	$(Q_CC) xcrun -sdk macosx clang -DDEBUG -g -gdwarf-2 -x objective-c++ -o $@ -c -arch i386 $< -Wall -Wno-unguarded-availability-new -I$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/include -mmacosx-version-min=$(MIN_OSX_SDK_VERSION)
+	$(Q_CC) xcrun -sdk macosx clang -DDEBUG -g -gdwarf-2 -x objective-c++ -stdlib=libc++ -o $@ -c -arch i386 $< -Wall -Wno-unguarded-availability-new -I$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/include -mmacosx-version-min=$(MIN_OSX_SDK_VERSION)
 
 Xamarin.Mac.registrar.%.x86_64.a: Xamarin.Mac.registrar.%.x86_64.m
-	$(Q_CC) xcrun -sdk macosx clang -DDEBUG -g -gdwarf-2 -x objective-c++ -o $@ -c -arch x86_64 $< -Wall -Wno-unguarded-availability-new -I$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/include -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -fobjc-runtime=macosx
+	$(Q_CC) xcrun -sdk macosx clang -DDEBUG -g -gdwarf-2 -x objective-c++ -stdlib=libc++ -o $@ -c -arch x86_64 $< -Wall -Wno-unguarded-availability-new -I$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/include -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -fobjc-runtime=macosx
 
 Xamarin.Mac.registrar.%.a: Xamarin.Mac.registrar.%.i386.a Xamarin.Mac.registrar.%.x86_64.a
 	$(Q_LIPO) $(DEVICE_BIN_PATH)/lipo -create -output $@ $^

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1366,6 +1366,10 @@ namespace Xamarin.Bundler {
 				}
 
 				args.Append ("-liconv -x objective-c++ ");
+				if (XcodeVersion.Major > 10) {
+					// Xcode 10 doesn't ship with libstdc++
+					args.Append ("-stdlib:libc++");
+				}
 				args.Append ("-I").Append (StringUtils.Quote (Path.Combine (GetXamMacPrefix (), "include"))).Append (' ');
 				if (registrarPath != null)
 					args.Append (StringUtils.Quote (registrarPath)).Append (' ');

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -388,7 +388,7 @@ bin/Makefile/Mono.Cecil.Mdb.dll: $(MONO_CECIL_MDB_DLL) | bin/Makefile
 
 # In Xcode 10 beta 1 simd/vector.h won't compile as Objective-C++ (can't find 'cmath'), so include a directory that contains the cmath file.
 # This is filed as rdar://40824697
-REGISTRAR_CFLAGS=-I$(XCODE_DEVELOPER_ROOT)/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1
+REGISTRAR_CFLAGS=-stdlib=libc++
 
 %.registrar.ios.i386.a:   %.registrar.ios.i386.m      %.registrar.ios.i386.h
 	$(Q_CC) $(IOS_CC) -DDEBUG -g -gdwarf-2 $(SIMULATOR86_CFLAGS)    $(REGISTRAR_CFLAGS) -x objective-c++ -o $@ -c $< -Wall -Wno-unguarded-availability-new -I$(IOS_DESTDIR)$(MONOTOUCH_PREFIX)/SDKs/MonoTouch.iphonesimulator.sdk/usr/include

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -887,6 +887,7 @@ namespace Xamarin.Bundler
 					SharedLibrary = mode != AssemblyBuildTarget.StaticObject,
 					Language = "objective-c++",
 				};
+				pinvoke_task.CompilerFlags.AddStandardCppLibrary ();
 				if (pinvoke_task.SharedLibrary) {
 					if (mode == AssemblyBuildTarget.Framework) {
 						var name = Path.GetFileNameWithoutExtension (ifile);
@@ -1234,25 +1235,7 @@ namespace Xamarin.Bundler
 					if (Driver.XcodeVersion >= new Version (9, 0))
 						registrar_task.CompilerFlags.AddOtherFlag ("-Wno-unguarded-availability-new");
 
-					if (Driver.XcodeVersion >= new Version (10, 0)) {
-						// Workaround rdar://40824697, where some headers are broken
-						// and won't compile in Objective-C++ mode because they
-						// reference 'cmath', which isn't included in the individual SDKs.
-						// So add an include directory for a directory that contains a 'cmath' file
-						// (no idea if it's the right 'cmath' file, Xcode has several, and they're all different...)
-						// Since this is in fact most likely the wrong thing to do,
-						// I'm restricting this to a very specific version of Xcode,
-						// so that we can remove the hack asap once Apple fixes their headers.
-						switch (Driver.XcodeBundleVersion) {
-						case "14274.16": // beta 1
-						case "14274.19": // beta 2
-							break;
-						default:
-							ErrorHelper.Show (ErrorHelper.CreateWarning (99, $"Verify if the workaround for rdar://40824697 is still needed for Xcode 10 {Driver.XcodeBundleVersion}."));
-							break;
-						}
-						registrar_task.CompilerFlags.AddOtherFlag ($"-I{Path.Combine (Driver.DeveloperDirectory, "Toolchains", "XcodeDefault.xctoolchain", "usr", "include", "c++", "v1")}");
-					}
+					registrar_task.CompilerFlags.AddStandardCppLibrary ();
 						                                          
 					LinkWithTaskOutput (registrar_task);
 				}
@@ -1311,6 +1294,7 @@ namespace Xamarin.Bundler
 				};
 				main_task.AddDependency (generate_main_task);
 				main_task.CompilerFlags.AddDefine ("MONOTOUCH");
+				main_task.CompilerFlags.AddStandardCppLibrary ();
 				LinkWithTaskOutput (main_task);
 			}
 


### PR DESCRIPTION
Xcode 10 doesn't ship with stdlibc++ anymore, we need to use libc++ instead.

This is documented in Xcode 10's release notes:

> Building with libstdc++ was deprecated with Xcode 8 and is not supported in Xcode 10 when targeting iOS. C++ projects must now migrate to libc++ and are recommended to set a deployment target of iOS 7 or later.

This fixes a problem when compiling certain system headers as Objective-C++.

References:

* https://twitter.com/jeremyhu/status/1003882060556062720
* https://stackoverflow.com/a/50734510/183422
* https://trello.com/c/PsHpNHq6/113-40824697-scenekith-doesnt-compile-as-objective-c