### PR TITLE
[xharness] Don't try to add additional information to xml logs. Fixes maccore#827.

### DIFF
--- a/tests/xharness/SimpleListener.cs
+++ b/tests/xharness/SimpleListener.cs
@@ -44,7 +44,9 @@ namespace xharness
 $@"[Local Date/Time:	{DateTime.Now}]
 [Remote Address:	{remote}]";
 				if (XmlOutput) {
-					xml_data = local_data;
+					// This can end up creating invalid xml randomly:
+					// https://github.com/xamarin/maccore/issues/827
+					//xml_data = local_data;
 				} else {
 					output_writer.WriteLine (local_data);
 				}


### PR DESCRIPTION
Don't try to inject additional information into xml logs, it seems we may
corrupt the xml file.

Fixes https://github.com/xamarin/maccore/issues/827.