### PR TITLE
Added: missing link color

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -3921,6 +3921,10 @@ namespace AppKit {
 		[Mac (10,10)]
 		[Static, Export ("quaternaryLabelColor")]
 		NSColor QuaternaryLabelColor { get; }
+
+		[Mac (10, 10)]
+		[Static, Export ("linkColor", ArgumentSemantic.Strong)]
+		NSColor LinkColor { get; }
 		
 		[Mac (10,12)]
 		[Static]


### PR DESCRIPTION
Hi,

Was creating binding for Mojave and noticed linkColor was missing for macOS (10,10) and have added.

Going forward what is the process for adding missing bindings, is it a case of using objective sharpie against framework and comparing with the files in repo e.g. AppKit.cs? My current requirement is to update bindings for AppKit + PhotosUI + Photos for Mojave and hoping I can help if I understand the process...

Pete