### PR TITLE
[ObjCRuntime] Make Class.GetHandle not handle byref types. Fixes #4254.

### DIFF
--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -107,6 +107,11 @@ namespace ObjCRuntime {
 		{
 			IntPtr @class = IntPtr.Zero;
 
+			if (type.IsByRef || type.IsPointer || type.IsArray) {
+				is_custom_type = false;
+				return IntPtr.Zero;
+			}
+
 			// We cache results in a dictionary (type_to_class) - we put failures (when @class = IntPtr.Zero) in the dictionary as well.
 			// We do as little as possible with the lock held (only fetch/add to the dictionary, nothing else)
 
@@ -211,9 +216,6 @@ namespace ObjCRuntime {
 				// Using only the dynamic registrar
 				return IntPtr.Zero;
 			}
-
-			if (type.IsByRef)
-				return IntPtr.Zero;
 
 			if (type.IsGenericType)
 				type = type.GetGenericTypeDefinition ();

--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -212,6 +212,9 @@ namespace ObjCRuntime {
 				return IntPtr.Zero;
 			}
 
+			if (type.IsByRef)
+				return IntPtr.Zero;
+
 			if (type.IsGenericType)
 				type = type.GetGenericTypeDefinition ();
 

--- a/tests/monotouch-test/ObjCRuntime/ClassTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/ClassTest.cs
@@ -85,6 +85,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 					Assert.AreEqual ("Can't register the class System.String when the dynamic registrar has been linked away.", e.Message, "exc message");
 				}
 			}
+			Assert.AreEqual (IntPtr.Zero, Class.GetHandle (typeof (NSObject).MakeByRefType ()), "NSObject&");
+			Assert.AreEqual (IntPtr.Zero, Class.GetHandle (typeof (NSObject).MakeArrayType ()), "NSObject[]");
+			Assert.AreEqual (IntPtr.Zero, Class.GetHandle (typeof (NSObject).MakePointerType ()), "NSObject*");
 		}
 
 		[Test]

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2532,6 +2532,28 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			using (var obj = new NullOutParameters ())
 				obj.Invoke_V_null_out ();
 		}
+
+		[Test]
+		public unsafe void ByrefParameter ()
+		{
+			using (var obj = new ByrefParameterTest ()) {
+				using (var param = new NSObject ()) {
+					// We want an instance of an NSObject subclass that doesn't have a managed wrapper, so we create a native NSString handle.
+					IntPtr handle = NSString.CreateNative ("ByrefParameter");
+					Messaging.void_objc_msgSend_IntPtr (obj.Handle, Selector.GetHandle ("doSomething:"), new IntPtr (&handle));
+					NSString.ReleaseNative (handle);
+				}
+			}
+		}
+
+		class ByrefParameterTest : NSObject {
+			[Export ("doSomething:")]
+			public void DoSomething (ref NSString str)
+			{
+				Assert.IsNotNull (str, "NonNull NSString&");
+				Assert.AreEqual ("ByrefParameter", str.ToString ());
+			}
+		}
 	}
 
 #if !__WATCHOS__


### PR DESCRIPTION
This is a regression between d15-6 and d15-7: it's an unindented consequence
of the changes required to link away the dynamic registrar.

This unindented consequence is non-obvious: it made Class.GetHandle
successfully look up byref types, since we're now using metadata tokens to
look up a Class from the managed Type, and it turns out the metadata tokens
are the same for byref types as the corresponding non-byref type, so
Class.GetHandle treats them identically.

This was not the behavior for Class.GetHandle in d15-6, and other code relied
on this behavior (in particular calling isKindOfClass: in Runtime.GetNSObject
with a nil class returns false, and we'd end up in a different code path that
would not try to create the managed peer with a byref type).

So make sure Class.GetHandle doesn't change its behavior compared to d15-6 by
special-casing byref types to return IntPtr.Zero.

Fixes https://github.com/xamarin/xamarin-macios/issues/4254.