### PR TITLE
[CoreText] Fix GetMatchingFontDescriptors overload with sort callback, Backport of #3871

### DIFF
--- a/src/CoreText/CTFontCollection.cs
+++ b/src/CoreText/CTFontCollection.cs
@@ -205,7 +205,7 @@ namespace CoreText {
 				if (cfArrayRef == IntPtr.Zero)
 					return new CTFontDescriptor [0];
 				var matches = NSArray.ArrayFromHandle (cfArrayRef,
-						fd => new CTFontDescriptor (cfArrayRef, false));
+						fd => new CTFontDescriptor (fd, false));
 				CFObject.CFRelease (cfArrayRef);
 				return matches;
 			}

--- a/tests/monotouch-test/CoreText/CTFontCollectionTest.cs
+++ b/tests/monotouch-test/CoreText/CTFontCollectionTest.cs
@@ -1,0 +1,50 @@
+﻿//
+// Unit tests for CTFontCollection
+//
+// Author:
+//	Vincent Dondain <vidondai@microsoft.com>
+//
+// Copyright 2018 Microsoft. All rights reserved.
+//
+
+using System;
+using System.Linq;
+#if XAMCORE_2_0
+using Foundation;
+using CoreText;
+#else
+using MonoTouch.CoreText;
+using MonoTouch.Foundation;
+#endif
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.CoreText {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class CTFontCollectionTest {
+
+		[SetUp]
+		public void Setup ()
+		{
+			// CoreText was introduced in watchOS 2.2
+			TestRuntime.AssertXcodeVersion (7, 3);
+		}
+
+		[Test]
+		public void GetMatchingFontDescriptorsTest ()
+		{
+			var collection = new CTFontCollection (null);
+			var sortIsCalled = false;
+			var descList = collection.GetMatchingFontDescriptors ((CTFontDescriptor x, CTFontDescriptor y) => {
+				sortIsCalled = true;
+				return 0;
+			});
+
+			Assert.IsTrue (sortIsCalled, "GetMatchingFontDescriptors delegate is called");
+
+			// Native crash (can't assert on it) if https://github.com/xamarin/xamarin-macios/pull/3871 fix not present.
+			descList.First ().GetAttributes ();
+		}
+	}
+}


### PR DESCRIPTION
Backport of #3871 in order to avoid more merge conflicts with https://github.com/xamarin/xamarin-macios/pull/4368 and reuse test file