### PR TITLE
[modelio] Update for Xcode 10 beta 2

### DIFF
--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -1638,13 +1638,33 @@ namespace ModelIO {
 		[Export ("init")]
 		IntPtr Constructor ();
 
+#if !XAMCORE_4_0
+		[Static]
+		[Obsolete ("Use 'FromName' instead.")]
+		[Wrap ("FromName (name)")]
+		MDLTexture FromBundle (string name);
+#endif
+
 		[Static]
 		[Export ("textureNamed:")]
-		MDLTexture FromBundle (string name);
+		MDLTexture FromName (string name);
+
+#if !XAMCORE_4_0
+		[Static]
+		[Obsolete ("Use 'FromName' instead.")]
+		[Wrap ("FromName (name, bundleOrNil)")]
+		MDLTexture FromBundle (string name, [NullAllowed] NSBundle bundleOrNil);
+#endif
 
 		[Static]
 		[Export ("textureNamed:bundle:")]
-		MDLTexture FromBundle (string name, [NullAllowed] NSBundle bundleOrNil);
+		MDLTexture FromName (string name, [NullAllowed] NSBundle bundleOrNil);
+
+		[TV (12,0), Mac (10,14, onlyOn64: true), iOS (12,0)]
+		[Static]
+		[Export ("textureNamed:assetResolver:")]
+		[return: NullAllowed]
+		MDLTexture FromName (string name, IMDLAssetResolver resolver);
 
 		[Static]
 		[Export ("textureCubeWithImagesNamed:")]
@@ -1771,7 +1791,12 @@ namespace ModelIO {
 
 	[iOS (9,0), Mac(10,11, onlyOn64 : true)]
 	[BaseType (typeof(NSObject))]
+	[DisableDefaultCtor] // designated
 	interface MDLTransform : MDLTransformComponent, NSCopying {
+
+		[DesignatedInitializer]
+		[Export ("init")]
+		IntPtr Constructor ();
 
 		[Export ("initWithTransformComponent:")]
 		IntPtr Constructor (IMDLTransformComponent component);

--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -1640,31 +1640,31 @@ namespace ModelIO {
 
 #if !XAMCORE_4_0
 		[Static]
-		[Obsolete ("Use 'FromName' instead.")]
-		[Wrap ("FromName (name)")]
+		[Obsolete ("Use 'CreateTexture' instead.")]
+		[Wrap ("CreateTexture (name)")]
 		MDLTexture FromBundle (string name);
 #endif
 
 		[Static]
 		[Export ("textureNamed:")]
-		MDLTexture FromName (string name);
+		MDLTexture CreateTexture (string name);
 
 #if !XAMCORE_4_0
 		[Static]
-		[Obsolete ("Use 'FromName' instead.")]
-		[Wrap ("FromName (name, bundleOrNil)")]
+		[Obsolete ("Use 'CreateTexture' instead.")]
+		[Wrap ("CreateTexture (name, bundleOrNil)")]
 		MDLTexture FromBundle (string name, [NullAllowed] NSBundle bundleOrNil);
 #endif
 
 		[Static]
 		[Export ("textureNamed:bundle:")]
-		MDLTexture FromName (string name, [NullAllowed] NSBundle bundleOrNil);
+		MDLTexture CreateTexture (string name, [NullAllowed] NSBundle bundleOrNil);
 
 		[TV (12,0), Mac (10,14, onlyOn64: true), iOS (12,0)]
 		[Static]
 		[Export ("textureNamed:assetResolver:")]
 		[return: NullAllowed]
-		MDLTexture FromName (string name, IMDLAssetResolver resolver);
+		MDLTexture CreateTexture (string name, IMDLAssetResolver resolver);
 
 		[Static]
 		[Export ("textureCubeWithImagesNamed:")]
@@ -1791,12 +1791,8 @@ namespace ModelIO {
 
 	[iOS (9,0), Mac(10,11, onlyOn64 : true)]
 	[BaseType (typeof(NSObject))]
-	[DisableDefaultCtor] // designated
+	[DesignatedDefaultCtor]
 	interface MDLTransform : MDLTransformComponent, NSCopying {
-
-		[DesignatedInitializer]
-		[Export ("init")]
-		IntPtr Constructor ();
 
 		[Export ("initWithTransformComponent:")]
 		IntPtr Constructor (IMDLTransformComponent component);

--- a/tests/xtro-sharpie/iOS-ModelIO.todo
+++ b/tests/xtro-sharpie/iOS-ModelIO.todo
@@ -1,2 +1,0 @@
-!missing-designated-initializer! MDLTransform::init is missing an [DesignatedInitializer] attribute
-!missing-selector! +MDLTexture::textureNamed:assetResolver: not bound

--- a/tests/xtro-sharpie/macOS-ModelIO.todo
+++ b/tests/xtro-sharpie/macOS-ModelIO.todo
@@ -1,2 +1,0 @@
-!missing-designated-initializer! MDLTransform::init is missing an [DesignatedInitializer] attribute
-!missing-selector! +MDLTexture::textureNamed:assetResolver: not bound

--- a/tests/xtro-sharpie/tvOS-ModelIO.todo
+++ b/tests/xtro-sharpie/tvOS-ModelIO.todo
@@ -1,2 +1,0 @@
-!missing-designated-initializer! MDLTransform::init is missing an [DesignatedInitializer] attribute
-!missing-selector! +MDLTexture::textureNamed:assetResolver: not bound


### PR DESCRIPTION
Renamed and obsoleted 'FromBundle' in favor of 'FromName' for consistency with new API and because I believe it was a mistake anyway.
For instance 'textureNamed:' was 'FromBundle', there's no mention of the bundle there.