### PR TITLE
Revert "Make the return type of NSDistributedNotificationCenter.DefaultCenter the same as the original api."

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -10255,15 +10255,7 @@ namespace Foundation
 	interface NSDistributedNotificationCenter {
 		[Static]
 		[Export ("defaultCenter")]
-#if XAMCORE_4_0
-		NSDistributedNotificationCenter DefaultCenter { get; }
-#else
-		NSDistributedNotificationCenter GetDefaultCenter ();
-
-		[Advice ("Use 'GetDefaultCenter ()' for a strongly typed version.")]
-		[Wrap ("GetDefaultCenter ()", IsVirtual = true)]
 		NSObject DefaultCenter { get; }
-#endif
 
 		[Export ("addObserver:selector:name:object:suspensionBehavior:")]
 		void AddObserver (NSObject observer, Selector selector, [NullAllowed] string notificationName, [NullAllowed] string notificationSenderc, NSNotificationSuspensionBehavior suspensionBehavior);


### PR DESCRIPTION
Reverts xamarin/xamarin-macios#4227

It broke the mlaunch build:


	Xamarin.Hosting/SimulatorApplication.cs(183,51): error CS0120: An object reference is required for the non-static field, method, or property 'NSDistributedNotificationCenter.DefaultCenter'
	Xamarin.Hosting/SimulatorApplication.cs(231,51): error CS0120: An object reference is required for the non-static field, method, or property 'NSDistributedNotificationCenter.DefaultCenter'
	Xamarin.Hosting/Services.cs(1058,51): error CS0120: An object reference is required for the non-static field, method, or property 'NSDistributedNotificationCenter.DefaultCenter'
