### PR TITLE
[Foundation] Adds missing [Static] attribute in NSDistributedNotificationCenter.DefaultCenter

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -10260,8 +10260,9 @@ namespace Foundation
 #else
 		NSDistributedNotificationCenter GetDefaultCenter ();
 
+		[Static]
 		[Advice ("Use 'GetDefaultCenter ()' for a strongly typed version.")]
-		[Wrap ("GetDefaultCenter ()", IsVirtual = true)]
+		[Wrap ("GetDefaultCenter ()")]
 		NSObject DefaultCenter { get; }
 #endif
 


### PR DESCRIPTION
Fixes the mlaunch build:


	Xamarin.Hosting/SimulatorApplication.cs(183,51): error CS0120: An object reference is required for the non-static field, method, or property 'NSDistributedNotificationCenter.DefaultCenter'
	Xamarin.Hosting/SimulatorApplication.cs(231,51): error CS0120: An object reference is required for the non-static field, method, or property 'NSDistributedNotificationCenter.DefaultCenter'
	Xamarin.Hosting/Services.cs(1058,51): error CS0120: An object reference is required for the non-static field, method, or property 'NSDistributedNotificationCenter.DefaultCenter'