### PR TITLE
[monotouch-test] Adjust DlfcnTest.OpenClose_libSystem to work with Xcode 10. Fixes #4377.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/DlfcnTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/DlfcnTest.cs
@@ -30,16 +30,14 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			IntPtr handle = Dlfcn.dlopen ("/usr/lib/libSystem.dylib", 0);
 			Assert.That (handle, Is.Not.EqualTo (IntPtr.Zero), "dlopen");
 			var err = Dlfcn.dlclose (handle);
+			var expected = 0;
 #if !MONOMAC
-			if ((Runtime.Arch == Arch.DEVICE) && TestRuntime.CheckXcodeVersion (7, 0)) {
+			if (Runtime.Arch == Arch.DEVICE && TestRuntime.CheckXcodeVersion (7, 0) && !TestRuntime.CheckXcodeVersion (10, 0)) {
 				// Apple is doing some funky stuff with dlopen... this condition is to track if this change during betas
-				Assert.That (err, Is.EqualTo (-1), "dlclose");
-			} else {
-#endif
-			Assert.That (err, Is.EqualTo (0), "dlclose");
-#if !MONOMAC
+				expected = -1;
 			}
 #endif
+			Assert.That (err, Is.EqualTo (expected), "dlclose");
 		}
 	}
 }


### PR DESCRIPTION
Fixed https://github.com/xamarin/xamarin-macios/issues/4377.