### PR TITLE
Correcting NSHttpCookieStorage notifications mapping

### DIFF
--- a/src/Foundation/NSHttpCookieStorage.cs
+++ b/src/Foundation/NSHttpCookieStorage.cs
@@ -14,8 +14,8 @@ namespace Foundation {
 			if (handle == IntPtr.Zero)
 				return;
 
-			CookiesChangedNotification = Dlfcn.GetStringConstant (handle, "NSHTTPCookieManagerAcceptPolicyChangedNotification");
-			AcceptPolicyChangedNotification = Dlfcn.GetStringConstant (handle, "NSHTTPCookieManagerCookiesChangedNotification");
+			CookiesChangedNotification = Dlfcn.GetStringConstant (handle, "NSHTTPCookieManagerCookiesChangedNotification");
+			AcceptPolicyChangedNotification = Dlfcn.GetStringConstant (handle, "NSHTTPCookieManagerAcceptPolicyChangedNotification");
 		}
 #endif
 	}


### PR DESCRIPTION
Cookie changed notification was mapped to accept policy, and vice versa - correcting the mapping.