### PR TITLE
[PDFkit] Fix kPDFDestinationUnspecifiedValue availability

### DIFF
--- a/src/pdfkit.cs
+++ b/src/pdfkit.cs
@@ -1090,6 +1090,7 @@ namespace PdfKit {
 	[BaseType (typeof (NSObject), Name = "PDFDestination")]
 	interface PdfDestination : NSCopying {
 
+		[Mac (10,13)] // This used to be a calculated macro and promoted to an actual field in 10.13.
 		[Field ("kPDFDestinationUnspecifiedValue")]
 		nfloat UnspecifiedValue { get; }
 


### PR DESCRIPTION
This used to be a calculated macro and got promoted to a field
in macOS 10.13. This will fix intro in older macOS versions.