### PR TITLE
[runtime] always use `mono_jit_set_aot_mode`

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -537,10 +537,6 @@
 			"char**", "argv"
 		),
 
-		new Export ("void", "mono_jit_set_aot_only",
-			"mono_bool", "aot_only"
-		),
-
 		new Export ("void", "mono_jit_set_aot_mode",
 			"MonoAotMode", "mode"
 		),

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -393,7 +393,6 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 
 #if defined (__arm__) || defined(__aarch64__)
 	xamarin_register_modules ();
-	mono_jit_set_aot_only (TRUE);
 #endif
 	DEBUG_LAUNCH_TIME_PRINT ("\tAOT register time");
 

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -663,7 +663,7 @@ namespace Xamarin.Bundler
 						sw.WriteLine ("\tmono_sgen_mono_ilgen_init ();");
 						sw.WriteLine ("\tmono_ee_interp_init (NULL);");
 						sw.WriteLine ("\tmono_jit_set_aot_mode (MONO_AOT_MODE_INTERP);");
-					} else
+					} else if (app.IsDeviceBuild)
 						sw.WriteLine ("\tmono_jit_set_aot_mode (MONO_AOT_MODE_FULL);");
 
 					if (assembly_location.Length > 0)

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -663,7 +663,8 @@ namespace Xamarin.Bundler
 						sw.WriteLine ("\tmono_sgen_mono_ilgen_init ();");
 						sw.WriteLine ("\tmono_ee_interp_init (NULL);");
 						sw.WriteLine ("\tmono_jit_set_aot_mode (MONO_AOT_MODE_INTERP);");
-					}
+					} else
+						sw.WriteLine ("\tmono_jit_set_aot_mode (MONO_AOT_MODE_FULL);");
 
 					if (assembly_location.Length > 0)
 						sw.WriteLine ("\txamarin_set_assembly_directories (&assembly_locations);");


### PR DESCRIPTION
`mono_jit_set_aot_only` is deprecated and accidentally broke with
https://github.com/mono/mono/pull/7887

This should fix device tests with `mono-2018-06`