### PR TITLE
[macos][quartzcomposer] Update for beta 4

### DIFF
--- a/src/quartzcomposer.cs
+++ b/src/quartzcomposer.cs
@@ -98,11 +98,11 @@ namespace QuartzComposer {
 		[Field ("QCCompositionInputDestinationImageKey")]
 		NSString InputDestinationImageKey { get; }
 
-		[Obsoleted (PlatformName.MacOSX, 14,0, message: "Field will return 'null'.")]
+		[Deprecated (PlatformName.MacOSX, 10,14, message: "Use 'Metal' instead.")]
 		[Field ("QCCompositionInputRSSFeedURLKey")]
 		NSString InputRSSFeedURLKey { get; }
 
-		[Obsoleted (PlatformName.MacOSX, 14,0, message: "Field will return 'null'.")]
+		[Deprecated (PlatformName.MacOSX, 10,14, message: "Use 'Metal' instead.")]
 		[Field ("QCCompositionInputRSSArticleDurationKey")]
 		NSString InputRSSArticleDurationKey { get; }
 
@@ -160,7 +160,7 @@ namespace QuartzComposer {
 		[Field ("QCCompositionProtocolScreenSaver")]
 		NSString ProtocolScreenSaver { get; }
 
-		[Obsoleted (PlatformName.MacOSX, 14,0, message: "Field will return 'null'.")]
+		[Deprecated (PlatformName.MacOSX, 10,14, message: "Use 'Metal' instead.")]
 		[Field ("QCCompositionProtocolRSSVisualizer")]
 		NSString ProtocolRSSVisualizer { get; }
 

--- a/tests/introspection/Mac/MacApiFieldTest.cs
+++ b/tests/introspection/Mac/MacApiFieldTest.cs
@@ -76,17 +76,6 @@ namespace Introspection {
 					break;
 				}
 				break;
-			// Xcode 10
-			case "QCComposition":
-				switch (p.Name) {
-				case "InputRSSArticleDurationKey":
-				case "InputRSSFeedURLKey":
-				case "ProtocolRSSVisualizer":
-					if (Mac.CheckSystemVersion (10,14)); // radar 41125938
-						return true;
-					break;
-				}
-				break;
 			}
 
 			switch (p.Name) {
@@ -167,9 +156,9 @@ namespace Introspection {
 			case "_AuthenticationSchemeOAuth1":
 				return true;
 			case "CBUUIDValidRangeString":
-				if (Mac.CheckSystemVersion (10, 13)); // radar 32858911
+				if (Mac.CheckSystemVersion (10, 13)) // radar 32858911
 					return true;
-				break;
+				goto default;
 			default:
 				return base.Skip (p);
 			}
@@ -179,9 +168,9 @@ namespace Introspection {
 		{
 			switch (constantName) {
 			case "CBUUIDValidRangeString":
-				if (Mac.CheckSystemVersion (10, 13)); // radar 32858911
+				if (Mac.CheckSystemVersion (10, 13)) // radar 32858911
 					return true;
-				break;
+				goto default;
 			// Only there for API compat
 			case "kSecUseNoAuthenticationUI":
 			case "kSecUseOperationPrompt":
@@ -197,13 +186,6 @@ namespace Introspection {
 				if (Mac.Is32BitMavericks)
 					return true;
 				goto default;
-			// Xcode 10
-			case "QCCompositionInputRSSFeedURLKey":
-			case "QCCompositionInputRSSArticleDurationKey":
-			case "QCCompositionProtocolRSSVisualizer":
-				if (Mac.CheckSystemVersion (10,14)); // radar 41125938
-					return true;
-				break;
 			default:
 				return base.Skip (constantName, libraryName);
 			}


### PR DESCRIPTION
Apple re-added some constants that were dropped without any clue (and we
filed a rdar for it since it's a breaking change to remove them).

It's now clear that it's deprecated and why
`QC_GL_DEPRECATED(10_5, 10_14);`

so we can update the attribute (and fix the version).

note: also fix extra `;` in `CBUUIDValidRangeString` tests while removing
the special case added earlier (from beta 1)