### PR TITLE
Revert "[mtouch] Work around broken tvOS headers in Xcode 10 beta 1."

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2704,19 +2704,6 @@ namespace Registrar {
 
 				skip.Clear ();
 
-				if (Driver.XcodeVersion == new Version (10, 0) && @class.Type.Namespace == "TVMLKit") {
-					// TVML's headers are broken in Xcode 10 beta: rdar://40824310
-					switch (Driver.XcodeBundleVersion) {
-					case "14274.16": // beta 1
-					case "14274.19": // beta 2
-						break;
-					default:
-						ErrorHelper.Show (ErrorHelper.CreateWarning (99, $"Verify if the workaround for rdar://40824310 is still needed for Xcode 10 {Driver.XcodeBundleVersion}."));
-						break;
-					}
-					continue;
-				}
-
 				uint token_ref = uint.MaxValue;
 				if (!@class.IsProtocol && !@class.IsCategory) {
 					if (!isPlatformType)


### PR DESCRIPTION
This reverts commit 663eaeb3898c8a0be87ee0797f96504a01cee740.

Apple fixed their headers.