### PR TITLE
[CoreBluetooth] Add availability attributes for CBUUID.CBUUIDValidRangeString.

### DIFF
--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -679,6 +679,9 @@ namespace CoreBluetooth {
 #if MONOMAC
 		[Internal]
 		[Field ("CBUUIDValidRangeString")]
+		[Introduced (PlatformName.MacOSX, 10, 12)]
+		[Deprecated (PlatformName.MacOSX, 10, 13)]
+		[Obsoleted (PlatformName.MacOSX, 10, 13)]
 		NSString CBUUIDValidRangeString { get; }
 
 		[Internal]


### PR DESCRIPTION
Fixes introspection on macOS 10.7-10.11.