### PR TITLE
[mtouch] Unify code to detect and handle frameworks that aren't supported in the simulator. Fixes #4422.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2690,4 +2690,43 @@ namespace MonoTouchFixtures.ObjCRuntime {
 	public class SomeConsumer : NSObject, ISomeDelegate
 	{
 	}
+#if !__WATCHOS__ // no MetalKit on watchOS
+	// These classes implement Metal* protocols, so that the generated registrar code includes the corresponding Metal* headers.
+	// https://github.com/xamarin/xamarin-macios/issues/4422
+	class MetalKitTypesInTheSimulator : NSObject, MetalKit.IMTKViewDelegate {
+		public void Draw (MetalKit.MTKView view)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public void DrawableSizeWillChange (MetalKit.MTKView view, CGSize size)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+	class MetalTypesInTheSimulator : NSObject, global::Metal.IMTLDrawable {
+		public void Present ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		public void Present (double presentationTime)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+#if !__TVOS__ // MetalPerformanceShaders isn't available in the tvOS simulator either
+	class MetalPerformanceShadersTypesInTheSimulator : NSObject, global::MetalPerformanceShaders.IMPSDeviceProvider {
+		public global::Metal.IMTLDevice GetMTLDevice ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		public void Present (double presentationTime)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+#endif // !__TVOS__
+#endif // !__WATCHOS__
 }

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -368,6 +368,13 @@ namespace Xamarin.Bundler {
 					
 					string file = Path.GetFileNameWithoutExtension (name);
 
+#if !MONOMAC
+					if (App.IsSimulatorBuild && !Driver.IsFrameworkAvailableInSimulator (App, file)) {
+						Driver.Log (3, "Not linking with {0} (referenced by a module reference in {1}) because it's not available in the simulator.", file, FileName);
+						continue;
+					}
+#endif
+
 					switch (file) {
 					// special case
 					case "__Internal":
@@ -401,21 +408,6 @@ namespace Xamarin.Bundler {
 						// sub-frameworks
 						if (Frameworks.Add ("Accelerate"))
 							Driver.Log (3, "Linking with the framework Accelerate because {0} is referenced by a module reference in {1}", file, FileName);
-						break;
-					case "CoreAudioKit":
-					case "Metal":
-					case "MetalKit":
-					case "MetalPerformanceShaders":
-					case "CoreNFC":
-					case "DeviceCheck":
-						// some frameworks do not exists on simulators and will result in linker errors if we include them
-#if MTOUCH
-						if (!App.IsSimulatorBuild) {
-#endif
-							AddFramework (file);
-#if MTOUCH
-						}
-#endif
 						break;
 					case "openal32":
 						if (Frameworks.Add ("OpenAL"))

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -13,6 +13,7 @@ public class Framework
 	public string Namespace;
 	public string Name;
 	public Version Version;
+	public Version VersionAvailableInSimulator;
 }
 
 public class Frameworks : Dictionary <string, Framework>
@@ -42,7 +43,7 @@ public class Frameworks : Dictionary <string, Framework>
 		Add (@namespace, framework, new Version (major_version, minor_version, build_version));
 	}
 
-	public void Add (string @namespace, string framework, Version version)
+	public void Add (string @namespace, string framework, Version version, Version version_available_in_simulator = null)
 	{
 		var fr = new Framework () {
 #if MTOUCH || MMP
@@ -51,7 +52,8 @@ public class Frameworks : Dictionary <string, Framework>
 			Namespace = @namespace,
 #endif
 			Name = framework,
-			Version = version
+			Version = version,
+			VersionAvailableInSimulator = version_available_in_simulator ?? version,
 		};
 		base.Add (fr.Namespace, fr);
 	}
@@ -239,7 +241,7 @@ public class Frameworks : Dictionary <string, Framework>
 				{ "CloudKit", "CloudKit", 8 },
 				{ "AVKit", "AVKit", 8 },
 				{ "CoreAudioKit", "CoreAudioKit", app.IsSimulatorBuild ? 9 : 8 },
-				{ "Metal", "Metal", 8 },
+				{ "Metal", "Metal", new Version (8, 0), new Version (9, 0) },
 				{ "WebKit", "WebKit", 8 },
 				{ "NetworkExtension", "NetworkExtension", 8 },
 				{ "VideoToolbox", "VideoToolbox", 8 },
@@ -267,9 +269,9 @@ public class Frameworks : Dictionary <string, Framework>
 
 				{ "ARKit", "ARKit", 11 },
 				{ "CoreNFC", "CoreNFC", 11 },
-				{ "DeviceCheck", "DeviceCheck", 11 },
+				{ "DeviceCheck", "DeviceCheck", new Version (11, 0), new Version (int.MaxValue, int.MaxValue) /* no headers provided for simulator */ },
 				{ "IdentityLookup", "IdentityLookup", 11 },
-				{ "IOSurface", "IOSurface", 11 },
+				{ "IOSurface", "IOSurface", new Version (11, 0), new Version (int.MaxValue, int.MaxValue) /* Not available in the simulator (the header is there, but broken) */  },
 				{ "CoreML", "CoreML", 11 },
 				{ "Vision", "Vision", 11 },
 				{ "FileProvider", "FileProvider", 11 },
@@ -317,7 +319,7 @@ public class Frameworks : Dictionary <string, Framework>
 				// AVFoundation was introduced in 3.0, but the simulator SDK was broken until 3.2.
 				{ "AVFoundation", "AVFoundation", 3, app.IsSimulatorBuild ? 2 : 0 },
 				{ "CloudKit", "CloudKit", 3 },
-				{ "GameKit", "GameKit", 3 },
+				{ "GameKit", "GameKit", new Version (3, 0), new Version (3, 2) /* No headers provided for watchOS/simulator until watchOS 3.2. */ },
 				{ "SceneKit", "SceneKit", 3 },
 				{ "SpriteKit", "SpriteKit", 3 },
 				{ "UserNotifications", "UserNotifications", 3 },
@@ -366,7 +368,7 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "MediaToolbox", "MediaToolbox", 9 },
 					{ "Metal", "Metal", 9 },
 					{ "MetalKit", "MetalKit", 9 },
-					{ "MetalPerformanceShaders", "MetalPerformanceShaders", 9 },
+					{ "MetalPerformanceShaders", "MetalPerformanceShaders", new Version (9, 0), new Version (int.MaxValue, int.MaxValue) /* not available in the simulator */ },
 					{ "CoreServices", "CFNetwork", 9 },
 					{ "MobileCoreServices", "MobileCoreServices", 9 },
 					{ "ModelIO", "ModelIO", 9 },
@@ -392,9 +394,9 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "VideoSubscriberAccount", "VideoSubscriberAccount", 10 },
 					{ "VideoToolbox", "VideoToolbox", 10,2 },
 
-					{ "DeviceCheck", "DeviceCheck", 11 },
+					{ "DeviceCheck", "DeviceCheck", new Version (11, 0), new Version (int.MaxValue, int.MaxValue) /* no headers provided for simulator */ },
 					{ "CoreML", "CoreML", 11 },
-					{ "IOSurface", "IOSurface", 11 },
+					{ "IOSurface", "IOSurface", new Version (11, 0), new Version (int.MaxValue, int.MaxValue) /* Not available in the simulator (the header is there, but broken) */  },
 					{ "Vision", "Vision", 11 },
 				};
 			}

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -66,6 +66,8 @@ public class Frameworks : Dictionary <string, Framework>
 		return null;
 	}
 
+	static Version NotAvailableInSimulator = new Version (int.MaxValue, int.MaxValue);
+
 	static Frameworks mac_frameworks;
 	public static Frameworks MacFrameworks {
 		get {
@@ -269,9 +271,9 @@ public class Frameworks : Dictionary <string, Framework>
 
 				{ "ARKit", "ARKit", 11 },
 				{ "CoreNFC", "CoreNFC", 11 },
-				{ "DeviceCheck", "DeviceCheck", new Version (11, 0), new Version (int.MaxValue, int.MaxValue) /* no headers provided for simulator */ },
+				{ "DeviceCheck", "DeviceCheck", new Version (11, 0), NotAvailableInSimulator /* no headers provided for simulator */ },
 				{ "IdentityLookup", "IdentityLookup", 11 },
-				{ "IOSurface", "IOSurface", new Version (11, 0), new Version (int.MaxValue, int.MaxValue) /* Not available in the simulator (the header is there, but broken) */  },
+				{ "IOSurface", "IOSurface", new Version (11, 0), NotAvailableInSimulator /* Not available in the simulator (the header is there, but broken) */  },
 				{ "CoreML", "CoreML", 11 },
 				{ "Vision", "Vision", 11 },
 				{ "FileProvider", "FileProvider", 11 },
@@ -368,7 +370,7 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "MediaToolbox", "MediaToolbox", 9 },
 					{ "Metal", "Metal", 9 },
 					{ "MetalKit", "MetalKit", 9 },
-					{ "MetalPerformanceShaders", "MetalPerformanceShaders", new Version (9, 0), new Version (int.MaxValue, int.MaxValue) /* not available in the simulator */ },
+					{ "MetalPerformanceShaders", "MetalPerformanceShaders", new Version (9, 0), NotAvailableInSimulator /* not available in the simulator */ },
 					{ "CoreServices", "CFNetwork", 9 },
 					{ "MobileCoreServices", "MobileCoreServices", 9 },
 					{ "ModelIO", "ModelIO", 9 },
@@ -394,9 +396,9 @@ public class Frameworks : Dictionary <string, Framework>
 					{ "VideoSubscriberAccount", "VideoSubscriberAccount", 10 },
 					{ "VideoToolbox", "VideoToolbox", 10,2 },
 
-					{ "DeviceCheck", "DeviceCheck", new Version (11, 0), new Version (int.MaxValue, int.MaxValue) /* no headers provided for simulator */ },
+					{ "DeviceCheck", "DeviceCheck", new Version (11, 0), NotAvailableInSimulator /* no headers provided for simulator */ },
 					{ "CoreML", "CoreML", 11 },
-					{ "IOSurface", "IOSurface", new Version (11, 0), new Version (int.MaxValue, int.MaxValue) /* Not available in the simulator (the header is there, but broken) */  },
+					{ "IOSurface", "IOSurface", new Version (11, 0), NotAvailableInSimulator /* Not available in the simulator (the header is there, but broken) */  },
 					{ "Vision", "Vision", 11 },
 				};
 			}

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2053,6 +2053,13 @@ namespace Registrar {
 			
 			namespaces.Add (ns);
 
+#if !MMP
+			if (App.IsSimulatorBuild && !Driver.IsFrameworkAvailableInSimulator (App, ns)) {
+				Driver.Log (5, "Not importing the framework {0} in the generated registrar code because it's not available in the simulator.", ns);
+				return;
+			}
+#endif
+
 			string h;
 			switch (ns) {
 #if MMP
@@ -2121,30 +2128,6 @@ namespace Registrar {
 				}
 				goto default;
 #endif
-			case "CoreAudioKit":
-				// fatal error: 'CoreAudioKit/CoreAudioKit.h' file not found
-				// radar filed with Apple - but that framework / header is not yet shipped with the iOS SDK simulator
-#if MTOUCH
-				if (IsSimulator)
-					return;
-#endif
-				goto default;
-			case "Metal":
-			case "MetalKit":
-			case "MetalPerformanceShaders": // https://trello.com/c/mrjkAO9U/518-metal-simulator
-				// #error Metal Simulator is currently unsupported
-				// this framework is _officially_ not available on the simulator (in iOS8)
-#if !MONOMAC
-				if (IsSimulator)
-					return;
-#endif
-				goto default;
-			case "GameKit":
-#if !MONOMAC
-				if (IsSimulator && App.Platform == Xamarin.Utils.ApplePlatform.WatchOS && App.SdkVersion < new Version (3, 2))
-					return; // No headers provided for watchOS/simulator until watchOS 3.2.
-#endif
-				goto default;
 			case "WatchKit":
 				// There's a bug in Xcode 7 beta 2 headers where the build fails with
 				// ObjC++ files if WatchKit.h is included before UIKit.h (radar 21651022).
@@ -2154,12 +2137,6 @@ namespace Registrar {
 				header.WriteLine ("#import <WatchKit/WatchKit.h>");
 				namespaces.Add ("UIKit");
 				return;
-			case "DeviceCheck":
-#if !MONOMAC
-				if (IsSimulator)
-					return; // No headers provided for simulator
-#endif
-				goto default;
 			case "QTKit":
 #if MONOMAC
 				if (App.SdkVersion >= MacOSTenTwelveVersion)
@@ -2167,10 +2144,6 @@ namespace Registrar {
 #endif
 				goto default;
 			case "IOSurface": // There is no IOSurface.h
-#if !MONOMAC
-				if (IsSimulator)
-					return; // Not available in the simulator (the header is there, but broken).
-#endif
 				h = "<IOSurface/IOSurfaceObjC.h>";
 				break;
 			default:
@@ -2586,21 +2559,16 @@ namespace Registrar {
 		static bool IsIntentsType (ObjCType type) => IsTypeCore (type, "Intents");
 		static bool IsExternalAccessoryType (ObjCType type) => IsTypeCore (type, "ExternalAccessory");
 
-		static bool IsMetalType (ObjCType type)
+#if !MONOMAC
+		bool IsTypeAllowedInSimulator (ObjCType type)
 		{
 			var ns = type.Type.Namespace;
 			if (!IsDualBuild)
 				ns = ns.Substring (CompatNamespace.Length + 1);
 
-			switch (ns) {
-			case "Metal":
-			case "MetalKit":
-			case "MetalPerformanceShaders":
-				return true;
-			default:
-				return false;
-			}
+			return Driver.IsFrameworkAvailableInSimulator (App, ns);
 		}
+#endif
 
 		class ProtocolInfo
 		{
@@ -2676,8 +2644,10 @@ namespace Registrar {
 
 #if !MONOMAC
 				var isPlatformType = IsPlatformType (@class.Type);
-				if (isPlatformType && IsSimulatorOrDesktop && IsMetalType (@class))
-					continue; // Metal isn't supported in the simulator.
+				if (isPlatformType && IsSimulatorOrDesktop && !IsTypeAllowedInSimulator (@class)) {
+					Driver.Log (5, "The static registrar won't generate code for {0} because its framework is not supported in the simulator.", @class.ExportedName);
+					continue; // Some types are not supported in the simulator.
+				}
 #else
 				// Don't register 64-bit only API on 32-bit XM
 				if (!Is64Bits && IsOnly64Bits (@class.Type))

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -273,6 +273,9 @@ SIMLAUNCHER_FRAMEWORKS =  \
 	-weak_framework WatchConnectivity			\
 	-weak_framework ModelIO						\
 	-weak_framework GameplayKit					\
+	-weak_framework Metal						\
+	-weak_framework MetalKit					\
+	-weak_framework MetalPerformanceShaders		\
 						\
 	-weak_framework HealthKitUI					\
 						\
@@ -297,6 +300,7 @@ SIMLAUNCHER_FRAMEWORKS =  \
 # note 2: there's no GameKit, in iOS 9 (beta 3 at least), you're supposed to reference GameCenter instead (looks fixed in beta 4)
 # note 3: there's no MetalKit or MetalPerformanceShaders in iOS 9 beta 4 - but other frameworks were added
 # note 4: GameCenter was removed in Xcode 7 beta 5, and GameKit is back.
+# note 5: Metal* seems to be supported as of some Xcode 7 beta (b2 didn't, but the final release does)
 
 # keep the above list of weak_framework in sync with mtouch.cs
 # except it is no a mistake that GameController and MediaAccessibility (#13636) are not built into simlauncher

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1676,5 +1676,19 @@ namespace Xamarin.Bundler
 				throw ErrorHelper.CreateError (71, "Unknown platform: {0}. This usually indicates a bug in Xamarin.iOS; please file a bug report at http://bugzilla.xamarin.com with a test case.", app.Platform);
 			}
 		}
+
+		public static bool IsFrameworkAvailableInSimulator (Application app, string framework)
+		{
+			if (!GetFrameworks (app).TryGetValue (framework, out var fw))
+				return true; // Unknown framework, assume it's valid for the simulator
+
+			if (fw.VersionAvailableInSimulator == null)
+				return false;
+
+			if (fw.VersionAvailableInSimulator > app.SdkVersion)
+				return false;
+
+			return true;
+		}
 	}
 }


### PR DESCRIPTION
Unify the code to detect frameworks that aren't supported in the simulator (we
had switches in two places, now this data is stored per framework).

Also remove some of the Metal frameworks for some of the platforms from these
lists (since they're now available in the simulator in some cases), which
fixes #4422.

It also seems CoreAudioKit is now available in the simulator (it wasn't in the
first Xcode 7 beta, but apparently added in a later beta. This made our
exclusion incorrect, but we never noticed).

https://github.com/xamarin/xamarin-macios/issues/4422