### PR TITLE
[mmp] Bump project file to v4.6 to fix compiler error when building in VSfM.

### DIFF
--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -7,7 +7,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>linker</RootNamespace>
     <AssemblyName>mmp</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <UseXamMacFullFramework>true</UseXamMacFullFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Fixes:

    xamarin-macios/external/mono/external/linker/linker/Linker.Steps/MarkStep.cs(310,60,310,73): error CS0117: 'Array' does not contain a definition for 'Empty'