### PR TITLE
[mtouch] Rename method that clashes with new method in base class to fix compiler warning.

### DIFF
--- a/tools/linker/MobileSweepStep.cs
+++ b/tools/linker/MobileSweepStep.cs
@@ -32,13 +32,13 @@ namespace Xamarin.Linker {
 				switch (CurrentAction) {
 				case AssemblyAction.Link:
 				case AssemblyAction.Save:
-					SweepAssembly (assembly);
+					SweepAssemblyDefinition (assembly);
 					break;
 				}
 			}
 		}
 
-		protected virtual void SweepAssembly (AssemblyDefinition assembly)
+		protected virtual void SweepAssemblyDefinition (AssemblyDefinition assembly)
 		{
 			SweepMainModule (assembly.MainModule);
 		}

--- a/tools/linker/MonoTouch.Tuner/MonoTouchSweepStep.cs
+++ b/tools/linker/MonoTouch.Tuner/MonoTouchSweepStep.cs
@@ -15,9 +15,9 @@ namespace MonoTouch.Tuner {
 		{
 		}
 
-		protected override void SweepAssembly (AssemblyDefinition assembly)
+		protected override void SweepAssemblyDefinition (AssemblyDefinition assembly)
 		{
-			base.SweepAssembly (assembly);
+			base.SweepAssemblyDefinition (assembly);
 
 			if (assembly.HasCustomAttributes)
 				SweepAttributes (assembly.CustomAttributes);


### PR DESCRIPTION
Rename a method that clashes with a new method in a base class to avoid a
compiler warning about hidden inherited members.

Fixes:

    xamarin-macios/tools/linker/MobileSweepStep.cs(41,26): warning CS0114: 'MobileSweepStep.SweepAssembly(AssemblyDefinition)' hides inherited member 'SweepStep.SweepAssembly(AssemblyDefinition)'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.