### PR TITLE
[arkit] Introduce runWithConfiguration:

### DIFF
--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -576,7 +576,9 @@ namespace ARKit {
 		[NullAllowed, Export ("configuration", ArgumentSemantic.Copy)]
 		ARConfiguration Configuration { get; }
 
-		// 'runWithConfiguration:' selector marked as unavailable in Xcode 9 beta 5. Use 'Run (ARConfiguration configuration, ARSessionRunOptions options)' instead.
+		[Export ("runWithConfiguration:")]
+		void Run (ARConfiguration configuration);
+
 		[Export ("runWithConfiguration:options:")]
 		void Run (ARConfiguration configuration, ARSessionRunOptions options);
 

--- a/tests/xtro-sharpie/iOS-ARKit.ignore
+++ b/tests/xtro-sharpie/iOS-ARKit.ignore
@@ -1,6 +1,3 @@
-## NS_SWIFT_UNAVAILABLE("Use run(_:options:) instead")
-!missing-selector! ARSession::runWithConfiguration: not bound
-
 ## No need for a Marshal Directive on those, they were bound manually
 !wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARFaceGeometry::GetRawTextureCoordinates(): simd type: simd_float2
 !wrong-simd-missing-marshaldirective! System.IntPtr ARKit.ARFaceGeometry::GetRawVertices(): simd type: simd_float3


### PR DESCRIPTION
The comment: "'runWithConfiguration:' selector marked as unavailable in Xcode 9 beta 5"
was *wrongly* referencing 'NS_SWIFT_UNAVAILABLE("Use run(_:options:) instead")'. However that applies to swift and not objective-c, this selector is valid and lets users skip the options.

Note: tested with real-world ARKit app.