### PR TITLE
[tests] Change the MT4134 test to only expect device builds to fail.

### DIFF
--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -278,7 +278,7 @@ class MyObjectErr : NSObject, IFoo1, IFoo2
 				mtouch.CreateTemporaryApp (extraCode: sb.ToString (), usings: "using System; using Foundation; using ObjCRuntime;", extraArg: "/debug:full");
 				mtouch.Linker = MTouchLinker.LinkSdk;
 				mtouch.Registrar = MTouchRegistrar.Static;
-				mtouch.AssertExecuteFailure ();
+				mtouch.AssertExecuteFailure (MTouchAction.BuildDev);
 				var invalidFrameworks = new [] {
 					new { Framework = "IdentityLookup", Version = "11.0" },
 					new { Framework = "FileProviderUI", Version = "11.0" },
@@ -296,6 +296,8 @@ class MyObjectErr : NSObject, IFoo1, IFoo2
 					mtouch.AssertError (4134, $"Your application is using the '{framework.Framework}' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS {framework.Version}, while you're building with the iOS {mtouch.Sdk} SDK.) Please select a newer SDK in your app's iOS Build options.");
 				mtouch.AssertErrorCount (invalidFrameworks.Length);
 				mtouch.AssertWarningCount (0);
+
+				mtouch.AssertExecute (MTouchAction.BuildSim);
 			}
 		}
 


### PR DESCRIPTION
As an unintended side effect of 215ab7fc1aa2f2fd64e944a8115d300630f6f32b, we
stopped reporting MT4134 errors ("Your app is using framework X, which means
you must update your Xcode") for simulator builds.

This can be either good (people's simulator builds now succeed when the
previously didn't) or bad (people's simulator builds don't always match their
device builds, since they may still get the MT4134 error for device builds).

This patch assumes we want the improved simulator builds, and adjusts the
corresponding test accordingly.