### PR TITLE
[homekit] Remove export for 'RemoveUser' (iOS prohibited)

### DIFF
--- a/src/HomeKit/HMHome.cs
+++ b/src/HomeKit/HMHome.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using ObjCRuntime;
 using Foundation;
 
@@ -79,6 +80,22 @@ namespace HomeKit {
 				arr.Add (HMServiceType.Slats.GetConstant ());
 
 			return GetServices (arr.ToArray ());
+		}
+
+		[NoTV]
+		[NoWatch]
+		[Introduced (PlatformName.iOS, 8,0, PlatformArchitecture.All, message: "This API in now prohibited on iOS. Use 'ManageUsers' instead.")]
+		[Obsoleted (PlatformName.iOS, 9,0, PlatformArchitecture.All, message: "This API in now prohibited on iOS. Use 'ManageUsers' instead.")]
+		public virtual void RemoveUser (HMUser user, Action<NSError> completion) {
+			throw new NotSupportedException ();
+		}
+
+		[NoTV]
+		[NoWatch]
+		[Introduced (PlatformName.iOS, 8,0, PlatformArchitecture.All, message: "This API in now prohibited on iOS. Use 'ManageUsers' instead.")]
+		[Obsoleted (PlatformName.iOS, 9,0, PlatformArchitecture.All, message: "This API in now prohibited on iOS. Use 'ManageUsers' instead.")]
+		public virtual Task RemoveUserAsync (HMUser user) {
+			throw new NotSupportedException ();
 		}
 	}
 }

--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -719,13 +719,6 @@ namespace HomeKit {
 		[Export ("addUserWithCompletionHandler:")]
 		void AddUser (Action<HMUser,NSError> completion);
 
-		[NoTV]
-		[NoWatch]
-		[Availability (Introduced = Platform.iOS_8_0, Deprecated = Platform.iOS_9_0, Message = "Use 'ManageUsers' instead.")]
-		[Async]
-		[Export ("removeUser:completionHandler:")]
-		void RemoveUser (HMUser user, Action<NSError> completion);
-
 		[iOS (9,0)]
 		[Export ("currentUser", ArgumentSemantic.Strong)]
 		HMUser CurrentUser { get; }

--- a/tests/xtro-sharpie/iOS-HomeKit.ignore
+++ b/tests/xtro-sharpie/iOS-HomeKit.ignore
@@ -1,0 +1,2 @@
+## API prohibited on iOS since Xcode 10
+!missing-selector! HMHome::removeUser:completionHandler: not bound


### PR DESCRIPTION
We want to remove the native API because it's prohibited and Apple could reject apps with it. Therefore we exposed empty stubs to avoid breaking the API.