### PR TITLE
[iads] Update for beta 5

### DIFF
--- a/src/iad.cs
+++ b/src/iad.cs
@@ -170,6 +170,8 @@ namespace iAd {
 
 	[Category (allowStaticMembers: true)] // Classic isn't internal so we need this
 	[BaseType (typeof (MPMoviePlayerController))]
+	[Deprecated (PlatformName.iOS, 9,0, message: "Use 'iAdPreroll_AVPlayerViewController' instead.")]
+	[Obsoleted (PlatformName.iOS, 12,0)] // header removed in xcode10 beta5
 	partial interface IAdPreroll {
 
 #if XAMCORE_2_0


### PR DESCRIPTION
Apple removed `MPMoviePlayerController_iAdPreroll.h` in beta 5.

The deprecation existed, but indirectly, on `MPMoviePlayerController`,
the type on which the category is based. IOW it's became obsoleted so
we're adding the attributes to match this.