### PR TITLE
[audiotoolbox][tvos] Remove AudioFileReadPackets symbol

### DIFF
--- a/src/AudioToolbox/AudioFile.cs
+++ b/src/AudioToolbox/AudioFile.cs
@@ -754,11 +754,11 @@ namespace AudioToolbox {
 			return ReadPacketData (useCache, inStartingPacket, ref nPackets, buffer, offset, ref count, out error);
 		}
 
+#if !XAMCORE_2_0
 		[DllImport (Constants.AudioToolboxLibrary)]
 		extern static AudioFileError AudioFileReadPackets (IntPtr inAudioFile, bool inUseCache, out int numBytes,
 			[MarshalAs (UnmanagedType.LPArray)] AudioStreamPacketDescription[] packetDescriptions, long startingPacket, ref int numPackets, IntPtr buffer);
 
-#if !XAMCORE_2_0
 		[Obsolete ("Use 'ReadPacketData' instead.")]
 		public AudioFileError ReadPackets (bool useCache, out int numBytes,
 			AudioStreamPacketDescription[] packetDescriptions, long startingPacket, ref int numPackets, IntPtr buffer)

--- a/tests/xtro-sharpie/common-AudioToolbox.ignore
+++ b/tests/xtro-sharpie/common-AudioToolbox.ignore
@@ -1,6 +1,8 @@
 ## no generator support for FastEnumeration - https://bugzilla.xamarin.com/show_bug.cgi?id=4391
 !missing-protocol-conformance! AUAudioUnitBusArray should conform to NSFastEnumeration
 
+## deprecated (even removed in tvOS) and not publicly exposed in XAMCORE_2_0
+!missing-pinvoke! AudioFileReadPackets is not bound
 
 ## unsorted
 

--- a/tests/xtro-sharpie/tvOS-AudioToolbox.ignore
+++ b/tests/xtro-sharpie/tvOS-AudioToolbox.ignore
@@ -1,2 +1,0 @@
-# already obsoleted and pointed to use ReadPacketData
-!unknown-pinvoke! AudioFileReadPackets bound


### PR DESCRIPTION
The public API was removed a long time ago (with XAMCORE_2_0) but
the p/invoke was still present in the platform assemblies.

Since tvOS requires bitcode this can cause a problem when linking
natively since a direct call won't be possible. That would only
happen if the symbol is removed (from the binary, not just the
headers) and if the managed linker is not enabled (otherwise it
will always be removed).