### PR TITLE
Fix appkit warning

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -805,14 +805,6 @@ namespace AppKit {
 		[Mac (10,12)]
 		[Export ("enumerateWindowsWithOptions:usingBlock:")]
 		void EnumerateWindows (NSWindowListOptions options, NSApplicationEnumerateWindowsHandler block);
-
-		[Mac (10, 14, onlyOn64: true)]
-		[NullAllowed, Export ("appearance", ArgumentSemantic.Strong)]
-		NSAppearance Appearance { get; set; }
-
-		[Mac (10, 14, onlyOn64: true)]
-		[Export ("effectiveAppearance", ArgumentSemantic.Strong)]
-		NSAppearance EffectiveAppearance { get; }
 	}
 
 	[Static]


### PR DESCRIPTION
- NSApplication now has NSAppearanceCustomization so doesn't need to declare them explicitly