### PR TITLE
[coreservices] Update up to beta 5

### DIFF
--- a/src/CFNetwork/CFHTTPMessage.cs
+++ b/src/CFNetwork/CFHTTPMessage.cs
@@ -308,14 +308,18 @@ namespace CoreServices {
 			}
 		}
 
-		// convenience enum on top of kCFHTTPAuthenticationScheme* NSString fields
+		// convenience enum on top of kCFHTTPAuthenticationScheme* fields
 		public enum AuthenticationScheme {
 			Default,
 			Basic,
 			Negotiate,
 			NTLM,
 			Digest,
-			OAuth1
+			[Mac (10, 9)][iOS (7,0)]
+			[Deprecated (PlatformName.iOS, 12,0, message: "Not available anymore.")]
+			[Deprecated (PlatformName.TvOS, 12,0, message: "Not available anymore.")]
+			[Deprecated (PlatformName.MacOSX, 10,14, message: "Not available anymore.")]
+			OAuth1,
 		}
 
 		internal static IntPtr GetAuthScheme (AuthenticationScheme scheme)
@@ -324,17 +328,17 @@ namespace CoreServices {
 			case AuthenticationScheme.Default:
 				return IntPtr.Zero;
 			case AuthenticationScheme.Basic:
-				return _AuthenticationSchemeBasic.Handle;
+				return _AuthenticationSchemeBasic;
 			case AuthenticationScheme.Negotiate:
-				return _AuthenticationSchemeNegotiate.Handle;
+				return _AuthenticationSchemeNegotiate;
 			case AuthenticationScheme.NTLM:
-				return _AuthenticationSchemeNTLM.Handle;
+				return _AuthenticationSchemeNTLM;
 			case AuthenticationScheme.Digest:
-				return _AuthenticationSchemeDigest.Handle;
+				return _AuthenticationSchemeDigest;
 			case AuthenticationScheme.OAuth1:
 				if (_AuthenticationSchemeOAuth1 == null)
 					throw new NotSupportedException ("Requires iOS 7.0 or macOS 10.9 and lower than iOS 12 or macOS 10.14");
-				return _AuthenticationSchemeOAuth1.Handle;
+				return _AuthenticationSchemeOAuth1;
 			default:
 				throw new ArgumentException ();
 			}

--- a/src/MobileCoreServices/UTType.cs
+++ b/src/MobileCoreServices/UTType.cs
@@ -210,5 +210,19 @@ namespace MobileCoreServices {
 			NSString.ReleaseNative (a);
 			return ret;
 		}
+
+		[DllImport (Constants.CoreServicesLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		static extern unsafe bool /* Boolean */ UTTypeEqual (/* CFStringRef */ IntPtr inUTI1, /* CFStringRef */ IntPtr inUTI2);
+
+		[iOS (12,0)][TV (12,0)][Watch (5,0)]
+		public static bool Equals (NSString uti1, NSString uti2)
+		{
+			if (uti1 == null)
+				return uti2 == null;
+			else if (uti2 == null)
+				return false;
+			return UTTypeEqual (uti1.Handle, uti2.Handle);
+		}
 	}
 }

--- a/src/cfnetwork.cs
+++ b/src/cfnetwork.cs
@@ -68,16 +68,16 @@ namespace CoreServices {
 		NSString _HTTPVersion2_0 { get; }
 
 		[Internal][Field ("kCFHTTPAuthenticationSchemeBasic", "CFNetwork")]
-		NSString _AuthenticationSchemeBasic { get; }
+		IntPtr _AuthenticationSchemeBasic { get; }
 
 		[Internal][Field ("kCFHTTPAuthenticationSchemeNegotiate", "CFNetwork")]
-		NSString _AuthenticationSchemeNegotiate { get; }
+		IntPtr _AuthenticationSchemeNegotiate { get; }
 
 		[Internal][Field ("kCFHTTPAuthenticationSchemeNTLM", "CFNetwork")]
-		NSString _AuthenticationSchemeNTLM { get; }
+		IntPtr _AuthenticationSchemeNTLM { get; }
 
 		[Internal][Field ("kCFHTTPAuthenticationSchemeDigest", "CFNetwork")]
-		NSString _AuthenticationSchemeDigest { get; }
+		IntPtr _AuthenticationSchemeDigest { get; }
 
 		[Internal][Field ("kCFHTTPAuthenticationUsername", "CFNetwork")]
 		NSString _AuthenticationUsername { get; }
@@ -94,6 +94,6 @@ namespace CoreServices {
 		// yet both 7.0+ and 10.9 returns null
 		[Mac (10, 9)][iOS (7,0)]
 		[Internal][Field ("kCFHTTPAuthenticationSchemeOAuth1", "CFNetwork")]
-		NSString _AuthenticationSchemeOAuth1 { get; }
+		IntPtr _AuthenticationSchemeOAuth1 { get; }
 	}
 }

--- a/tests/monotouch-test/MobileCoreServices/UTTypeTest.cs
+++ b/tests/monotouch-test/MobileCoreServices/UTTypeTest.cs
@@ -155,5 +155,14 @@ namespace MonoTouchFixtures.MobileCoreServices {
 				}
 			}
 		}
+
+		[Test]
+		public void Equals ()
+		{
+			Assert.True (UTType.Equals (null, null), "null-null");
+			Assert.False (UTType.Equals (null, UTType.PDF), "null-PDF");
+			Assert.False (UTType.Equals (UTType.PDF, null), "PDF-null");
+			Assert.True (UTType.Equals (UTType.PDF, UTType.PDF), "PDF-PDF");
+		}
 	}
 }

--- a/tests/xtro-sharpie/common-CoreServices.ignore
+++ b/tests/xtro-sharpie/common-CoreServices.ignore
@@ -1,0 +1,2 @@
+## removed in Xcode 10 (both headers and libs) but would work on older OS
+!unknown-field! kCFHTTPAuthenticationSchemeOAuth1 bound

--- a/tests/xtro-sharpie/iOS-CoreServices.todo
+++ b/tests/xtro-sharpie/iOS-CoreServices.todo
@@ -1,2 +1,0 @@
-!missing-pinvoke! UTTypeEqual is not bound
-!unknown-field! kCFHTTPAuthenticationSchemeOAuth1 bound

--- a/tests/xtro-sharpie/macOS-CoreServices.todo
+++ b/tests/xtro-sharpie/macOS-CoreServices.todo
@@ -1,1 +1,0 @@
-!unknown-field! kCFHTTPAuthenticationSchemeOAuth1 bound

--- a/tests/xtro-sharpie/macOS-LaunchServices.todo
+++ b/tests/xtro-sharpie/macOS-LaunchServices.todo
@@ -78,4 +78,3 @@
 !missing-pinvoke! UpdateIconRef is not bound
 !missing-pinvoke! UTCreateStringForOSType is not bound
 !missing-pinvoke! UTGetOSTypeFromString is not bound
-!missing-pinvoke! UTTypeEqual is not bound

--- a/tests/xtro-sharpie/tvOS-CoreServices.todo
+++ b/tests/xtro-sharpie/tvOS-CoreServices.todo
@@ -1,2 +1,0 @@
-!missing-pinvoke! UTTypeEqual is not bound
-!unknown-field! kCFHTTPAuthenticationSchemeOAuth1 bound

--- a/tests/xtro-sharpie/watchOS-CoreServices.todo
+++ b/tests/xtro-sharpie/watchOS-CoreServices.todo
@@ -1,1 +1,0 @@
-!missing-pinvoke! UTTypeEqual is not bound


### PR DESCRIPTION
Also avoid creating NSString instances for hidden constants where
only the handle is every used.