### PR TITLE
[Tests] Fix failing tests on iOS 8. Fixes #4437

### DIFF
--- a/tests/monotouch-test/AudioToolbox/SystemSoundTest.cs
+++ b/tests/monotouch-test/AudioToolbox/SystemSoundTest.cs
@@ -97,7 +97,7 @@ namespace MonoTouchFixtures.AudioToolbox {
 		[Test]
 		public void TestCallbackPlayAlert ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (PlatformName.iOS, 9, 0, throwIfOtherPlatform: false);
 
 			string path = Path.Combine (NSBundle.MainBundle.ResourcePath, "drum01.mp3");
 

--- a/tests/monotouch-test/UIKit/UIStackViewTest.cs
+++ b/tests/monotouch-test/UIKit/UIStackViewTest.cs
@@ -40,7 +40,7 @@ namespace MonoTouchFixtures.UIKit {
 		[Test]
 		public void InitWithFrameTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 8, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (PlatformName.iOS, 9, 0, throwIfOtherPlatform: false);
 
 			UIStackView stack = new UIStackView (new RectangleF (0, 0, 10, 10));
 			Assert.NotNull (stack, "UIStackView ctor(CGRect)");


### PR DESCRIPTION
Some of the tests fail because the assert is looking at the wrong iOS
version. Looking at the API definitions:

* UIStackView - Available in iOS 9, not iOS 8.
* AudioServicesPlayAlertSoundWithCompletion - Available in iOS 9, not
iOS 8.

All the other tests reported in the issue pass.

Issue: https://github.com/xamarin/xamarin-macios/issues/4437