### PR TITLE
[Generator] Ensure the correct error is raised when an Export is missing on a Property.

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -2300,7 +2300,10 @@ public partial class Generator : IMemberGatherer {
 					if (AttributeManager.HasAttribute<CoreImageFilterPropertyAttribute> (pi))
 						continue;
 
-					if (AttributeManager.HasAttribute<WrapAttribute> (pi.GetGetMethod ()) || AttributeManager.HasAttribute<WrapAttribute> (pi.GetSetMethod ()))
+					// we ensure that we do not get a NRE in the case we forgot and ExportAttr in a property
+					var hasWrapGet = pi.GetGetMethod () != null && AttributeManager.HasAttribute<WrapAttribute> (pi.GetGetMethod ());
+					var hasWrapSet = pi.GetSetMethod () != null && AttributeManager.HasAttribute<WrapAttribute> (pi.GetSetMethod ());
+					if (hasWrapGet || hasWrapSet)
 						continue;
 
 					throw new BindingException (1018, true, "No [Export] attribute on property {0}.{1}", t.FullName, pi.Name);

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -2300,9 +2300,11 @@ public partial class Generator : IMemberGatherer {
 					if (AttributeManager.HasAttribute<CoreImageFilterPropertyAttribute> (pi))
 						continue;
 
-					// we ensure that we do not get a NRE in the case we forgot and ExportAttr in a property
-					var hasWrapGet = pi.GetGetMethod () != null && AttributeManager.HasAttribute<WrapAttribute> (pi.GetGetMethod ());
-					var hasWrapSet = pi.GetSetMethod () != null && AttributeManager.HasAttribute<WrapAttribute> (pi.GetSetMethod ());
+					// Ensure there's a [Wrap] on either (or both) the getter and setter - since we already know there's no [Export]
+					var getMethod = pi.GetGetMethod ();
+					var hasWrapGet = getMethod != null && AttributeManager.HasAttribute<WrapAttribute> (getMethod);
+					var setMethod = pi.GetSetMethod ();
+					var hasWrapSet = setMethod != null && AttributeManager.HasAttribute<WrapAttribute> (setMethod);
 					if (hasWrapGet || hasWrapSet)
 						continue;
 

--- a/tests/generator/ErrorTests.cs
+++ b/tests/generator/ErrorTests.cs
@@ -679,5 +679,19 @@ namespace BI1063Tests {
 				bgen.AssertNoWarnings ();
 			}
 		}
+
+		[Test]
+		[TestCase (Profile.iOS)]
+		[TestCase (Profile.macOSFull)]
+		[TestCase (Profile.macOSMobile)]
+		public void MissingExportOnProperty (Profile profile)
+		{
+			var bgen = new BGenTool ();
+			bgen.Profile = profile;
+			bgen.Defines = BGenTool.GetDefaultDefines (profile);
+			bgen.CreateTemporaryBinding (File.ReadAllText (Path.Combine (Configuration.SourceRoot, "tests", "generator", "missing-export-property.cs")));
+			bgen.AssertExecuteError ("build");
+			bgen.AssertError (1018, "No [Export] attribute on property Test.NSTextInputClient.SelectedRange");
+		}
 	}
 }

--- a/tests/generator/missing-export-property.cs
+++ b/tests/generator/missing-export-property.cs
@@ -1,9 +1,5 @@
 
-#if !XAMCORE_2_0
 using Foundation;
-#else
-using Foundation;
-#endif
 
 namespace Test
 {

--- a/tests/generator/missing-export-property.cs
+++ b/tests/generator/missing-export-property.cs
@@ -1,4 +1,3 @@
-
 using Foundation;
 
 namespace Test
@@ -7,6 +6,7 @@ namespace Test
 	[Protocol, Model]
 	public interface NSTextInputClient
 	{
+		// missing [Export ("selectRange")] should report an error
 		NSRange SelectedRange { get; }
 	}
 }

--- a/tests/generator/missing-export-property.cs
+++ b/tests/generator/missing-export-property.cs
@@ -1,0 +1,16 @@
+
+#if !XAMCORE_2_0
+using Foundation;
+#else
+using Foundation;
+#endif
+
+namespace Test
+{
+	[BaseType (typeof (NSObject))]
+	[Protocol, Model]
+	public interface NSTextInputClient
+	{
+		NSRange SelectedRange { get; }
+	}
+}


### PR DESCRIPTION
The generator had a small bug in which we would get a NRE when a
property missed a Export attribute and had no WrapAttr. The issue is due
to the fact that an || is being used and does not shortcut when the
attribute is missing. In that case, the first Get check would pass and a
second attempt would happen with the set. In the case the set is missing,
we would get a NRE. The correct way is to ensure that we do have the get
and the set BEFORE the attr is checked.

The added test shows an exaple of the issue.