### PR TITLE
[networkextension] Obsolete NWPath and NWHostEndpoint default constructors

### DIFF
--- a/src/NetworkExtension/NECompat.cs
+++ b/src/NetworkExtension/NECompat.cs
@@ -24,6 +24,22 @@ namespace NetworkExtension {
 		}
 	}
 
+	public partial class NWPath {
+
+		[Obsolete ("This type is not meant to be user created.")]
+		public NWPath ()
+		{
+		}
+	}
+
+	public partial class NWHostEndpoint {
+
+		[Obsolete ("Use the 'Create' method instead.")]
+		public NWHostEndpoint ()
+		{
+		}
+	}
+
 	public partial class NWTcpConnectionAuthenticationDelegate : NSObject {
 
 		[Obsolete ("Use 'NWTcpConnectionAuthenticationDelegate_Extensions.EvaluateTrustAsync' instead.")]

--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -1183,6 +1183,7 @@ namespace NetworkExtension {
 	
 	[iOS (9,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof(NWEndpoint))]
+	[DisableDefaultCtor]
 	interface NWHostEndpoint
 	{
 		[Static]
@@ -1217,6 +1218,7 @@ namespace NetworkExtension {
 
 	[iOS (9,0)][Mac (10,11, onlyOn64 : true)]
 	[BaseType (typeof(NSObject))]
+	[DisableDefaultCtor]
 	interface NWPath
 	{
 		[Export ("status")]


### PR DESCRIPTION
There's nothing that indicates the types are user creatable. In addition
recent tests shows this (and similar) traces that suggest the instances
are not fully initialized.

2018-08-14 16:41:37.677780-0400 introspection[65154:688446] [] nw_path_get_mtu called with null path
2018-08-14 16:41:37.677917-0400 introspection[65154:688446] [] __nwlog_err_simulate_crash simulate crash failed "nw_path_get_mtu called with null path"
2018-08-14 16:41:37.680216-0400 introspection[65154:688446] [] nw_path_get_mtu called with null path, dumping backtrace:
        [x86_64] libnetcore-1229.202.1
    0   libnetwork.dylib                    0x00000001131b1c18 __nw_create_backtrace_string + 120
    1   libnetwork.dylib                    0x000000011315b962 nw_path_get_mtu + 274
    2   Network                             0x0000000111737a67 -[NWPath mtu] + 39
    3   Network                             0x000000011173610e -[NWPath descriptionWithIndent:showFullContent:] + 446
    4   Network                             0x0000000111736825 -[NWPath description] + 21
    5   introspection                       0x000000010484db69 xamarin_dyn_objc_msgSend + 217
    6   ???                                 0x0000000131be3755 0x0 + 5129516885
    7   ???                                 0x0000000131be73d9 0x0 + 5129532377
    8   introspection                       0x0000000104653963 mono_jit_runtime_invoke + 1443
    9   introspection                       0x0000000104732a9f mono_runtime_invoke_checked + 127
    10  introspection                       0x0000000104739de8 mono_runtime_try_invoke_array + 1160
    11  introspection                       0x00000001046da4b7 ves_icall_InternalInvoke + 647
    12  ???                                 0x0000000137b84ae1 0x0 + 5229791969
    13  ???                                 0x0000000137b8484b 0x0 + 5229791307
    14  ???                                 0x0000000137b845fb 0x0 + 5229790715
    15  ???                                 0x0000000137b83d59 0x0 + 5229788505
    16  ???                                 0x0000000137b7c2f4 0x0 + 5229757172
    17  ???                                 0x0000000136d6066b 0x0 + 5214963307
    18  ???                                 0x0000000137b7c2f4 0x0 + 5229757172
    19  ???                                 0x0000000136d6066b 0x0 + 5214963307
    20  ???                                 0x0000000137b7c2f4 0x0 + 5229757172
    21  ???                                 0x0000000136d6066b 0x0 + 5214963307
    22  ???                                 0x0000000137b7c2f4 0x0 + 5229757172
    23  ???                                 0x0000000136d6066b 0x0 + 5214963307
    24  ???                                 0x0000000137b0d76b 0x0 + 5229303659
    25  ???                                 0x0000000131bac8a1 0x0 + 5129291937
    26  introspection                       0x0000000104653963 mono_jit_runtime_invoke + 1443
    27  introspection                       0x0000000104734424 mono_runtime_try_invoke + 148
    28  introspection                       0x000000010473636f mono_runtime_invoke + 31
    29  introspection                       0x00000001044e4188 _ZL31native_to_managed_trampoline_20P11objc_objectP13objc_selectorPP11_MonoMethodj + 248
    30  introspection                       0x00000001044e8754 -[__MonoMac_NSAsyncActionDispatcher xamarinApplySelector] + 52
    31  Foundation                          0x0000000105c7bf6b __NSThreadPerformPerform + 330
    32  CoreFoundation                      0x0000000104f1bb31 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
    33  CoreFoundation                      0x0000000104f1b464 __CFRunLoopDoSources0 + 436
    34  CoreFoundation                      0x0000000104f15a4f __CFRunLoopRun + 1263
    35  CoreFoundation                      0x0000000104f15221 CFRunLoopRunSpecific + 625
    36  GraphicsServices                    0x00000001157d01dd GSEventRunModal + 62
    37  UIKitCore                           0x000000011a6e62f1 UIApplicationMain + 140
    38  ???                                 0x0000000131be4d18 0x0 + 5129522456
    39  ???                                 0x0000000131be4b93 0x0 + 5129522067
    40  introspection                       0x0000000104653963 mono_jit_runtime_invoke + 1443
    41  introspection                       0x0000000104732a9f mono_runtime_invoke_checked + 127
    42  introspection                       0x000000010473890e mono_runtime_exec_main_checked + 110
    43  introspection                       0x00000001045a132f mono_jit_exec + 287
    44  introspection                       0x000000010484b5ee xamarin_main + 2830
    45  introspection                       0x000000010484df6d main + 45
    46  libdyld.dylib                       0x00000001122915cd start + 1
    47  ???                                 0x0000000000000009 0x0 + 9

2018-08-14 17:09:22.864147-0400 introspection[78577:733530] [] nw_endpoint_get_parent_endpoint_domain called with null endpoint
2018-08-14 17:09:22.864273-0400 introspection[78577:733530] [] __nwlog_err_simulate_crash simulate crash failed "nw_endpoint_get_parent_endpoint_domain called with null endpoint"
2018-08-14 17:09:22.866190-0400 introspection[78577:733530] [] nw_endpoint_get_parent_endpoint_domain called with null endpoint, dumping backtrace:
        [x86_64] libnetcore-1229.202.1
    0   libnetwork.dylib                    0x0000000119d0bc18 __nw_create_backtrace_string + 120
    1   libnetwork.dylib                    0x0000000119c8b232 nw_endpoint_get_parent_endpoint_domain + 178
    2   Network                             0x0000000118261177 -[NWEndpoint parentEndpointDomain] + 39
    3   Network                             0x000000011824a941 -[NWHostEndpoint descriptionWithIndent:showFullContent:] + 97
    4   Network                             0x0000000118260eb5 -[NWEndpoint description] + 21
    5   introspection                       0x000000010b3a4b69 xamarin_dyn_objc_msgSend + 217
    6   ???                                 0x000000013ce75755 0x0 + 5316761429
    7   ???                                 0x000000013ce793d9 0x0 + 5316776921
    8   introspection                       0x000000010b1aa963 mono_jit_runtime_invoke + 1443
    9   introspection                       0x000000010b289a9f mono_runtime_invoke_checked + 127
    10  introspection                       0x000000010b290de8 mono_runtime_try_invoke_array + 1160
    11  introspection                       0x000000010b2314b7 ves_icall_InternalInvoke + 647
    12  ???                                 0x000000013e428bc1 0x0 + 5339515841
    13  ???                                 0x000000013e42892b 0x0 + 5339515179
    14  ???                                 0x000000013e4286db 0x0 + 5339514587
    15  ???                                 0x000000013e427e39 0x0 + 5339512377
    16  ???                                 0x000000013e4203d4 0x0 + 5339481044
    17  ???                                 0x000000013d8b875b 0x0 + 5327521627
    18  ???                                 0x000000013e4203d4 0x0 + 5339481044
    19  ???                                 0x000000013d8b875b 0x0 + 5327521627
    20  ???                                 0x000000013e4203d4 0x0 + 5339481044
    21  ???                                 0x000000013d8b875b 0x0 + 5327521627
    22  ???                                 0x000000013e4203d4 0x0 + 5339481044
    23  ???                                 0x000000013d8b875b 0x0 + 5327521627
    24  ???                                 0x000000013e3c37db 0x0 + 5339101147
    25  ???                                 0x00000001387848a1 0x0 + 5242374305
    26  introspection                       0x000000010b1aa963 mono_jit_runtime_invoke + 1443
    27  introspection                       0x000000010b28b424 mono_runtime_try_invoke + 148
    28  introspection                       0x000000010b28d36f mono_runtime_invoke + 31
    29  introspection                       0x000000010b03b188 _ZL31native_to_managed_trampoline_20P11objc_objectP13objc_selectorPP11_MonoMethodj + 248
    30  introspection                       0x000000010b03f754 -[__MonoMac_NSAsyncActionDispatcher xamarinApplySelector] + 52
    31  Foundation                          0x000000010c7d2f6b __NSThreadPerformPerform + 330
    32  CoreFoundation                      0x000000010ba72b31 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
    33  CoreFoundation                      0x000000010ba72464 __CFRunLoopDoSources0 + 436
    34  CoreFoundation                      0x000000010ba6ca4f __CFRunLoopRun + 1263
    35  CoreFoundation                      0x000000010ba6c221 CFRunLoopRunSpecific + 625
    36  GraphicsServices                    0x000000011c32a1dd GSEventRunModal + 62
    37  UIKitCore                           0x00000001212402f1 UIApplicationMain + 140
    38  ???                                 0x000000013ce76d18 0x0 + 5316767000
    39  ???                                 0x000000013ce76b93 0x0 + 5316766611
    40  introspection                       0x000000010b1aa963 mono_jit_runtime_invoke + 1443
    41  introspection                       0x000000010b289a9f mono_runtime_invoke_checked + 127
    42  introspection                       0x000000010b28f90e mono_runtime_exec_main_checked + 110
    43  introspection                       0x000000010b0f832f mono_jit_exec + 287
    44  introspection                       0x000000010b3a25ee xamarin_main + 2830
    45  introspection                       0x000000010b3a4f6d main + 45
    46  libdyld.dylib                       0x0000000118de65cd start + 1
    47  ???                                 0x0000000000000009 0x0 + 9