### PR TITLE
[builds] Only use Xcode 9.4 when we need it. Fixes #4582.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -178,7 +178,7 @@ BITCODE_CFLAGS=-fembed-bitcode-marker
 MIN_IOS_SDK_VERSION=9.0
 endif
 
-SIMULATOR_SDK=$(XCODE_DEVELOPER_ROOT)/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk
+SIMULATOR_SDK=$(XCODE_DEVELOPER_ROOT)/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(IOS_SDK_VERSION).sdk
 
 OBJC_CFLAGS=-ObjC++ -std=c++0x -fno-exceptions -stdlib=libc++
 
@@ -203,7 +203,7 @@ WATCH_CSC=$(SYSTEM_CSC) -nostdlib -noconfig -r:$(WATCH_BCL_DIR)/System.dll -r:$(
 
 DEVICE_OBJC_CFLAGS=$(OBJC_CFLAGS) $(BITCODE_CFLAGS)
 
-DEVICE_SDK=$(XCODE_DEVELOPER_ROOT)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
+DEVICE_SDK=$(XCODE_DEVELOPER_ROOT)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS$(IOS_SDK_VERSION).sdk
 DEVICE7_CFLAGS= -arch armv7  -mno-thumb -miphoneos-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(DEVICE_SDK) $(CFLAGS) $(IOS_COMMON_DEFINES)
 DEVICE7S_CFLAGS=-arch armv7s -mno-thumb -miphoneos-version-min=$(MIN_IOS_SDK_VERSION) -isysroot $(DEVICE_SDK) $(CFLAGS) $(IOS_COMMON_DEFINES)
 DEVICE64_CFLAGS=-arch arm64             -miphoneos-version-min=7.0                    -isysroot $(DEVICE_SDK) $(CFLAGS) $(IOS_COMMON_DEFINES)
@@ -222,11 +222,11 @@ XAMARIN_IPHONEOS_SDK     = $(MONOTOUCH_DEVICE_SDK)
 XAMARIN_WATCHSIMULATOR_SDK = $(MONOTOUCH_PREFIX)/SDKs/Xamarin.WatchSimulator.sdk
 XAMARIN_WATCHOS_SDK        = $(MONOTOUCH_PREFIX)/SDKs/Xamarin.WatchOS.sdk
 
-SIMULATORWATCH_SDK         = $(XCODE_DEVELOPER_ROOT)/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator.sdk
+SIMULATORWATCH_SDK         = $(XCODE_DEVELOPER_ROOT)/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator$(WATCH_SDK_VERSION).sdk
 SIMULATORWATCH_CFLAGS      = -arch i386 -mwatchos-simulator-version-min=$(MIN_WATCHOS_SDK_VERSION) -isysroot $(SIMULATORWATCH_SDK) $(CFLAGS) -g $(IOS_COMMON_DEFINES)
 SIMULATORWATCH_OBJC_CFLAGS = $(SIMULATORWATCH_CFLAGS) $(COMMON_SIMULATOR_OBJC_CFLAGS) 
 
-DEVICEWATCH_SDK         = $(XCODE_DEVELOPER_ROOT)/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk
+DEVICEWATCH_SDK         = $(XCODE_DEVELOPER_ROOT)/Platforms/WatchOS.platform/Developer/SDKs/WatchOS$(WATCH_SDK_VERSION).sdk
 DEVICEWATCH_CFLAGS      = -arch armv7k -mwatchos-version-min=$(MIN_WATCHOS_SDK_VERSION) -isysroot $(DEVICEWATCH_SDK) $(CFLAGS) -fembed-bitcode $(IOS_COMMON_DEFINES)
 DEVICEWATCH_OBJC_CFLAGS = $(DEVICEWATCH_CFLAGS) $(DEVICE_OBJC_CFLAGS)
 
@@ -235,11 +235,11 @@ DEVICEWATCH_OBJC_CFLAGS = $(DEVICEWATCH_CFLAGS) $(DEVICE_OBJC_CFLAGS)
 XAMARIN_TVSIMULATOR_SDK    = $(MONOTOUCH_PREFIX)/SDKs/Xamarin.AppleTVSimulator.sdk
 XAMARIN_TVOS_SDK           = $(MONOTOUCH_PREFIX)/SDKs/Xamarin.AppleTVOS.sdk
 
-SIMULATORTV_SDK            = $(XCODE_DEVELOPER_ROOT)/Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator.sdk
+SIMULATORTV_SDK            = $(XCODE_DEVELOPER_ROOT)/Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator$(TVOS_SDK_VERSION).sdk
 SIMULATORTV_CFLAGS         = -arch x86_64 -mtvos-simulator-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(SIMULATORTV_SDK) $(CFLAGS) -g $(IOS_COMMON_DEFINES)
 SIMULATORTV_OBJC_CFLAGS    = $(SIMULATORTV_CFLAGS) $(COMMON_SIMULATOR_OBJC_CFLAGS) 
 
-DEVICETV_SDK               = $(XCODE_DEVELOPER_ROOT)/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk
+DEVICETV_SDK               = $(XCODE_DEVELOPER_ROOT)/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS$(TVOS_SDK_VERSION).sdk
 DEVICETV_CFLAGS            = -arch arm64 -mtvos-version-min=$(MIN_TVOS_SDK_VERSION) -isysroot $(DEVICETV_SDK) $(CFLAGS) -fembed-bitcode $(IOS_COMMON_DEFINES)
 DEVICETV_OBJC_CFLAGS       = $(DEVICETV_CFLAGS) $(DEVICE_OBJC_CFLAGS)
 

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -1,9 +1,6 @@
 TOP=..
 include $(TOP)/Make.config
 
-XCODE_DEVELOPER_ROOT=$(XCODE94_DEVELOPER_ROOT)
-export DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT)
-
 PREFIX=$(abspath $(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)/)
 
 IPHONESIMULATOR_SDK=$(MONOTOUCH_PREFIX)/SDKs/MonoTouch.iphonesimulator.sdk
@@ -203,7 +200,7 @@ MAC_TARGETS = \
 
 define MacBuildTemplate
 $(2)_CPPFLAGS = \
-	-isysroot $(XCODE_MAC_SDKROOT) \
+	-isysroot $(5) \
 	-mmacosx-version-min=$(MIN_OSX_SDK_VERSION)
 $(2)_CFLAGS = -O2 -arch $(1)
 $(2)_CXXFLAGS = -O2 -arch $(1)
@@ -230,9 +227,9 @@ $(2)_CONFIGURE_ENVIRONMENT = \
 	CFLAGS="$$($(2)_CFLAGS)" \
 	CXXFLAGS="$$($(2)_CXXFLAGS)" \
 	LDFLAGS="$$($(2)_LDFLAGS)" \
-	CC="$(MAC_CC)" \
-	CXX="$(MAC_CXX)" \
-	DEVELOPER_DIR="$(XCODE_DEVELOPER_ROOT)" \
+	CC="$(MAC$(4)_CC)" \
+	CXX="$(MAC$(4)_CXX)" \
+	DEVELOPER_DIR="$(3)" \
 
 setup:: setup-$(2)
 
@@ -254,8 +251,8 @@ $(BUILD_DESTDIR)/mono-$(2): mono-wrapper.in .stamp-configure-$(2) | $(BUILD_DEST
 build-$(2): .stamp-build-$(2)
 endef
 
-$(eval $(call MacBuildTemplate,i386,mac32))
-$(eval $(call MacBuildTemplate,x86_64,mac64))
+$(eval $(call MacBuildTemplate,i386,mac32,$(XCODE94_DEVELOPER_ROOT),32,$(XCODE94_MAC_SDKROOT)))
+$(eval $(call MacBuildTemplate,x86_64,mac64,$(XCODE_DEVELOPER_ROOT),,$(XCODE_MAC_SDKROOT)))
 
 $(MONO_PATH)/mcs/class/lib/%: .stamp-build-tools64; @true
 
@@ -538,6 +535,8 @@ setup-watchbcl: .stamp-configure-watchbcl
 ifneq ($(WATCH_MONO_PATH),$(MONO_PATH))
 .stamp-configure-watchbcl: $(WATCH_MONO_PATH)/configure
 	$(Q) $(WATCHBCL_CONFIGURE_ENVIRONMENT) ./wrap-configure.sh watchbcl ../$(WATCH_MONO_PATH)/configure $(WATCHBCL_CONFIGURE_FLAGS)
+else
+.stamp-configure-watchbcl: ;
 endif
 
 build-tools-bcl: build-watchbcl
@@ -1941,8 +1940,9 @@ CROSS_CONFIGURE_ENVIRONMENT = \
 	CFLAGS="$(CROSS_CFLAGS)" \
 	CXXFLAGS="$(CROSS_CXXFLAGS)" \
 	LDFLAGS="$(CROSS_LDFLAGS)" \
-	CC="$(MAC_CC)" \
-	CXX="$(MAC_CXX)" \
+	CC="$(MAC32_CC)" \
+	CXX="$(MAC32_CXX)" \
+	DEVELOPER_DIR="$(XCODE94_DEVELOPER_ROOT)" \
 
 ifdef INCLUDE_IOS
 ifdef INCLUDE_DEVICE
@@ -2076,8 +2076,9 @@ WATCH_CONFIGURE_ENVIRONMENT = \
 	CFLAGS="$(CROSS_CFLAGS)" \
 	CXXFLAGS="$(CROSS_CXXFLAGS)" \
 	LDFLAGS="$(CROSS_LDFLAGS)" \
-	CC="$(MAC_CC)" \
-	CXX="$(MAC_CXX)" \
+	CC="$(MAC32_CC)" \
+	CXX="$(MAC32_CXX)" \
+	DEVELOPER_DIR="$(XCODE94_DEVELOPER_ROOT)" \
 
 ifdef INCLUDE_WATCH
 ifdef INCLUDE_DEVICE


### PR DESCRIPTION
Only use Xcode 9.4 to build 32-bit mac binaries, we don't need it to build
anything else.

This way we can revert 7227d8c4782f5c2a7b50c2258503539a1513431a, which is
causing issue #4582 (that commit changed variables containing SDK paths to be
SDK version agnostic, so that the variables could be used for all Xcode
versions - but that unfortunately triggers an obscure ld bug. If we don't need
those variables to refer to Xcode 9.4 paths, they can contain versions just
fine).

Fixes https://github.com/xamarin/xamarin-macios/issues/4582.