### PR TITLE
Try to fix random make failure in src/ by not using pattern rules.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -174,7 +174,10 @@ $(eval $(call IOS_TARGETS_template,native-32,--ns=ObjCRuntime,Xamarin.iOS.dll,na
 $(eval $(call IOS_TARGETS_template,native-64,--ns=ObjCRuntime,Xamarin.iOS.dll,native,native-64,64))
 
 # MonoTouch.Dialog-1
-$(IOS_BUILD_DIR)/reference/MonoTouch.Dialog-1.%: $(MACIOS_BINARIES_PATH)/MonoTouch.Dialog-Unified/ios/MonoTouch.Dialog-1.% | $(IOS_BUILD_DIR)/reference
+$(IOS_BUILD_DIR)/reference/MonoTouch.Dialog-1.dll: $(MACIOS_BINARIES_PATH)/MonoTouch.Dialog-Unified/ios/MonoTouch.Dialog-1.dll | $(IOS_BUILD_DIR)/reference
+	$(Q) cp $< $@
+
+$(IOS_BUILD_DIR)/reference/MonoTouch.Dialog-1.pdb: $(MACIOS_BINARIES_PATH)/MonoTouch.Dialog-Unified/ios/MonoTouch.Dialog-1.pdb | $(IOS_BUILD_DIR)/reference
 	$(Q) cp $< $@
 
 # MonoTouch.NUnitLite


### PR DESCRIPTION
Randomly make 3.81 says this:

    error CS0006: Metadata file 'build/ios/reference/MonoTouch.Dialog-1.dll' could not be found

The makefile seems fine, and it also doesn't happen when using make 4.21, so
this looks like a make bug.

So rewrite the troublesome rule to not be a pattern rule, and cross some fingers.