### PR TITLE
[mtouch] Add the option of always weak link a framework. Fixes #4628

### DIFF
--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -200,7 +200,7 @@ namespace Xamarin.Bundler {
 #endif
 
 						if (App.SdkVersion >= framework.Version) {
-							var add_to = App.DeploymentTarget >= framework.Version ? asm.Frameworks : asm.WeakFrameworks;
+							var add_to = framework.AlwaysWeakLinked || App.DeploymentTarget < framework.Version ? asm.WeakFrameworks : asm.Frameworks;
 							add_to.Add (framework.Name);
 							continue;
 						} else {


### PR DESCRIPTION
Linking with CoreNFC crash applications on iOS 12 on iPad (and likely
other device not supporting, or supported, for NFC).

This used to work on iOS 11.x (when introduced). The solution is to
always **weak** link CoreNFC (since we can't guess devices)

https://github.com/xamarin/xamarin-macios/issues/4628