### PR TITLE
[CoreGraphics] Fix CGFunction to work after being disposed.

### DIFF
--- a/tests/monotouch-test/CoreGraphics/FunctionTest.cs
+++ b/tests/monotouch-test/CoreGraphics/FunctionTest.cs
@@ -37,7 +37,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 	[Preserve (AllMembers = true)]
 	public class FunctionTest {
 #if !__WATCHOS__ // FIXME: It doesn't look like this test needs to use UIKit, so it might be possible to rewrite it to run on WatchOS as well.
-		//[Test]
+		[Test]
 		public void Test ()
 		{
 			bool tested = false;


### PR DESCRIPTION
We have a test for CGFunction, and in iOS 12 the behavior changed where
previously the CGFunction was invoked immediately when rendering, it's now
retained and only called later.

This is troublesome for the test, because it disposes the managed CGFunction
when it thinks it's completed. Since the function is invoked way later, the
test now crashes. Ops.

The obvious fix is to change the test to dispose the CGFunction later. This
falls flat when finding out that "later" is undetermined. Native code retains
the CGFunction, and can do whatever it wishes with it until it's released, and
there's no way to know when that is.

OK: what about not disposing the CGFunction, and letting the GC do its job?
This also falls flat, because there's a circular reference between the native
CGFunction and the managed wrapper, preventing any of them from being released
automatically by the GC. The only way to break the circular reference is to
dispose the managed wrapper.

So, can we fix the circular reference? Unfortunately not, because we can't
monitor the native CGFunction's retain count, which is required in order to
switch the native->managed link between weak and strong according to the
retain count.

This leaves one solution (that I could come up with at least): make sure
everything works fine after disposing the managed wrapper.

This involves a few things:

* Only break the native->managed connection (the 'gch' GCHandle) when the
  native CGFunction is freed. This is accomplished by using the API provided
  by Apple for exactly that purpose (the 'release' callback field in the
  'CGFunctionCallbacks' struct).

* Use a static variable for the 'CGFunctionCallback' struct and its contents.
  This solves another potential problem: the GC could have collected the
  delegate to the 'EvaluateCallback' function at any point.

* Don't null out the 'evaluate' delegate in Dispose. This leaves the user with
  no way to break a potential circular reference through that delegate (since
  it will never be null), so provide a property that makes it possible for
  users to explicitly null out the delegate ('EvaluateFunction').

* Only call the 'evaluate' callback if it's not null.

This also has the additional advantage that test (and any customer code
running into the same issue) works without modifications.