### PR TITLE
[NaturalLanguage] Change return type to use double instead on nuint. Fixes #4642

### DIFF
--- a/src/NaturalLanguage/NLLanguageRecognizer.cs
+++ b/src/NaturalLanguage/NLLanguageRecognizer.cs
@@ -52,12 +52,12 @@ namespace NaturalLanguage {
 			}
 		}
 
-		public Dictionary<NLLanguage, nuint> LanguageHints
+		public Dictionary<NLLanguage, double> LanguageHints
 		{
 			get {
-				var result = new Dictionary<NLLanguage, nuint> (NativeLanguageHints.Keys.Length);
+				var result = new Dictionary<NLLanguage, double> (NativeLanguageHints.Keys.Length);
 				foreach (var k in NativeLanguageHints.Keys) {
-					result[NLLanguageExtensions.GetValue (k)] = NativeLanguageHints[k].NUIntValue;
+					result[NLLanguageExtensions.GetValue (k)] = NativeLanguageHints[k].DoubleValue;
 				}
 				return result;
 			}

--- a/src/NaturalLanguage/NLLanguageRecognizer.cs
+++ b/src/NaturalLanguage/NLLanguageRecognizer.cs
@@ -41,12 +41,12 @@ namespace NaturalLanguage {
 			return lang;
 		}
 	
-		public Dictionary<NLLanguage, nuint> GetLanguageHypotheses (nuint maxHypotheses)
+		public Dictionary<NLLanguage, double> GetLanguageHypotheses (nuint maxHypotheses)
 		{
 			using (var hypo = GetNativeLanguageHypotheses (maxHypotheses)) {
-				var result = new Dictionary<NLLanguage, nuint> (hypo.Keys.Length);
+				var result = new Dictionary<NLLanguage, double> (hypo.Keys.Length);
 				foreach (var k in hypo.Keys) {
-					result[NLLanguageExtensions.GetValue (k)] = hypo[k].NUIntValue;
+					result[NLLanguageExtensions.GetValue (k)] = hypo[k].DoubleValue;
 				}
 				return result;
 			}

--- a/tests/monotouch-test/NaturalLanguage/NLLanguageRecognizerTest.cs
+++ b/tests/monotouch-test/NaturalLanguage/NLLanguageRecognizerTest.cs
@@ -44,7 +44,7 @@ namespace MonoTouchFixtures.NaturalLanguage {
 		public void GetLanguageHypothesesTest ()
 		{
 			using (var recognizer = new NLLanguageRecognizer ()) {
-				var languages = new Dictionary<NLLanguage, nuint> () {
+				var languages = new Dictionary<NLLanguage, double> () {
 					{ NLLanguage.German, 1 },
 					{ NLLanguage.Spanish, 10 },
 				};
@@ -61,7 +61,7 @@ namespace MonoTouchFixtures.NaturalLanguage {
 		[Test]
 		public void LanguageHintsTest ()
 		{
-			var languages = new Dictionary<NLLanguage, nuint> () {
+			var languages = new Dictionary<NLLanguage, double> () {
 				{ NLLanguage.German, 1 },
 				{ NLLanguage.Spanish, 10 },
 			};


### PR DESCRIPTION
The docs or headers do not specify the exact type. Using double to be sure.

Issue: https://github.com/xamarin/xamarin-macios/issues/4642