### PR TITLE
[avfoundation] Deprecate 'AVMediaTypeTimedMetadata'

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -164,8 +164,10 @@ namespace AVFoundation {
 		Timecode = 5,
 
 		[NoTV]
-		[Availability (Obsoleted = Platform.iOS_6_0)]
-		[Availability (Obsoleted = Platform.Mac_10_8)]
+		[Obsoleted (PlatformName.iOS, 6,0)]
+		[Deprecated (PlatformName.iOS, 12,0, message: "Always 'null'.")]
+		[Obsoleted (PlatformName.MacOSX, 10,8)]
+		[Deprecated (PlatformName.MacOSX, 10,14, message: "Always 'null'.")]
 		[Field ("AVMediaTypeTimedMetadata")] // last header where I can find this: iOS 5.1 SDK, 10.7 only on Mac
 		TimedMetadata = 6,
 

--- a/tests/monotouch-test/AVFoundation/CaptureDeviceTest.cs
+++ b/tests/monotouch-test/AVFoundation/CaptureDeviceTest.cs
@@ -33,8 +33,13 @@ namespace MonoTouchFixtures.AVFoundation {
 			Compare (AVMediaType.Subtitle, AVMediaTypes.Subtitle);
 			Compare (AVMediaType.Text, AVMediaTypes.Text);
 			Compare (AVMediaType.Timecode, AVMediaTypes.Timecode);
-			//Compare (AVMediaType.TimedMetadata, AVMediaTypes.TimedMetadata);
 			Compare (AVMediaType.Video, AVMediaTypes.Video);
+
+			// obsoleted in iOS 6, removed in iOS12
+			if (TestRuntime.CheckSDKVersion (12,0))
+				Assert.Null (AVMediaType.TimedMetadata, "AVMediaTypeTimedMetadata");
+			else
+				Compare (AVMediaType.TimedMetadata, AVMediaTypes.TimedMetadata);
 		}
 	}
 }

--- a/tests/monotouch-test/AVFoundation/CaptureDeviceTest.cs
+++ b/tests/monotouch-test/AVFoundation/CaptureDeviceTest.cs
@@ -3,6 +3,7 @@ using System;
 #if XAMCORE_2_0
 using Foundation;
 using AVFoundation;
+using ObjCRuntime;
 #else
 using MonoTouch.AVFoundation;
 using MonoTouch.Foundation;
@@ -36,7 +37,7 @@ namespace MonoTouchFixtures.AVFoundation {
 			Compare (AVMediaType.Video, AVMediaTypes.Video);
 
 			// obsoleted in iOS 6, removed in iOS12
-			if (TestRuntime.CheckSDKVersion (12,0))
+			if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 12,0))
 				Assert.Null (AVMediaType.TimedMetadata, "AVMediaTypeTimedMetadata");
 			else
 				Compare (AVMediaType.TimedMetadata, AVMediaTypes.TimedMetadata);


### PR DESCRIPTION
AVMediaTypeTimedMetadata has been obsoleted since iOS 6 but was totally
removed (returns null) in iOS 12.

Adjust test and provide a (better) deprecation warning for developers.