### PR TITLE
[healthkit] Add missing static to GetClinicalType

### DIFF
--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -954,6 +954,7 @@ namespace HealthKit {
 		HKClinicalType GetClinicalType (NSString identifier);
 
 		[Watch (5,0), iOS (12,0)]
+		[Static]
 		[Wrap ("GetClinicalType (identifier.GetConstant ())")]
 		HKClinicalType GetClinicalType (HKClinicalTypeIdentifier identifier);
 	}


### PR DESCRIPTION
*Note: Credit to Paul DiPietro (@pauldipietro) for finding this when trying to use the new HealthKit APIs.*