### PR TITLE
[msbuild] pass --target-platform=<platform> to copySceneKitAssets (#4630)

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
@@ -115,7 +115,7 @@ namespace Xamarin.MacDev.Tasks
 			if (AppleSdkSettings.XcodeVersion.Major >= 10) {
 				var platform = PlatformUtils.GetTargetPlatform (SdkPlatform, IsWatchApp);
 				if (platform != null)
-					args.Add ("--target-platform", platform);
+					args.AddQuotedFormat ("--target-platform={0}", platform);
 
 				args.AddQuotedFormat ("--target-version={0}", SdkVersion);
 			} else {


### PR DESCRIPTION
The copySceneKitAssets program has a poor command-line options
parser that cannot handle --target-platform and its argument
being 2 separate arguments, they have to be combined with an '='.

Fixes https://github.com/xamarin/xamarin-macios/issues/4467