### PR TITLE
[xharness] Replace existing content in TCC.db. Might fix maccore#951.

### DIFF
--- a/tests/xharness/Simulators.cs
+++ b/tests/xharness/Simulators.cs
@@ -453,8 +453,8 @@ namespace xharness
 							break;
 						case 3: // Xcode 10+
 							// CREATE TABLE access (    service        TEXT        NOT NULL,     client         TEXT        NOT NULL,     client_type    INTEGER     NOT NULL,     allowed        INTEGER     NOT NULL,     prompt_count   INTEGER     NOT NULL,     csreq          BLOB,     policy_id      INTEGER,     indirect_object_identifier_type    INTEGER,     indirect_object_identifier         TEXT,     indirect_object_code_identity      BLOB,     flags          INTEGER,     last_modified  INTEGER     NOT NULL DEFAULT (CAST(strftime('%s','now') AS INTEGER)),     PRIMARY KEY (service, client, client_type, indirect_object_identifier),    FOREIGN KEY (policy_id) REFERENCES policies(id) ON DELETE CASCADE ON UPDATE CASCADE)
-							sql.AppendFormat ("INSERT INTO access VALUES('{0}','{1}',0,1,0,NULL,NULL,NULL,'UNUSED',NULL,NULL,1);", service, bundle_identifier);
-							sql.AppendFormat ("INSERT INTO access VALUES('{0}','{1}',0,1,0,NULL,NULL,NULL,'UNUSED',NULL,NULL,1);", service, bundle_identifier + ".watchkitapp");
+							sql.AppendFormat ("INSERT OR REPLACE INTO access VALUES('{0}','{1}',0,1,0,NULL,NULL,NULL,'UNUSED',NULL,NULL,1);", service, bundle_identifier);
+							sql.AppendFormat ("INSERT OR REPLACE INTO access VALUES('{0}','{1}',0,1,0,NULL,NULL,NULL,'UNUSED',NULL,NULL,1);", service, bundle_identifier + ".watchkitapp");
 							break;
 						default:
 							throw new NotImplementedException ();
@@ -474,6 +474,9 @@ namespace xharness
 			} else {
 				log.WriteLine ("Successfully edited TCC.db");
 			}
+
+			log.WriteLine ("Current TCC database contents:");
+			await ProcessHelper.ExecuteCommandAsync ("sqlite3", $"{StringUtils.Quote (TCC_db)} .dump", log, TimeSpan.FromSeconds (5));
 		}
 
 		async Task OpenSimulator (Log log)


### PR DESCRIPTION
There seems to be an issue where adding stuff to the TCC.db might fail
partially. In that case we try again, but we try to add every entry once more,
which now might fail due to existing entries.

So always replace when adding new entries in TCC.db. Also dump the database
when done to help debugging if it turns out this doesn't fix maccore#915.

Might fix https://github.com/xamarin/maccore/issues/951.