### PR TITLE
[Runtime] Small fix for the runtime.h exposed by Emb-4000. Fixes #4442

### DIFF
--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -86,7 +86,7 @@ typedef struct __attribute__((packed)) {
 typedef struct __attribute__((packed)) {
 	const uint32_t *protocol_tokens; // an array of token references to managed interfaces that represent protocols
 	// __unsafe_unretained needed to prevent "error: pointer to non-const type 'const Protocol *' with no explicit ownership" in Embeddinator
-	const __unsafe_unretained Protocol **protocols; // the corresponding native protocols
+	const __unsafe_unretained Protocol * const * protocols; // the corresponding native protocols
 } MTProtocolMap;
 
 struct MTRegistrationMap;


### PR DESCRIPTION
This fixes issue #4442 by fixing a small struct issues.

https://github.com/xamarin/xamarin-macios/issues/4442

This is a back port of https://github.com/xamarin/xamarin-macios/pull/4663