### PR TITLE
[xharness] Be resilient when trying to copying contents from an inexistent file.

### DIFF
--- a/tests/xharness/Log.cs
+++ b/tests/xharness/Log.cs
@@ -325,7 +325,12 @@ namespace xharness
 		{
 			if (startPosition == 0 || entire_file)
 				return;
-			
+
+			if (!File.Exists (CapturePath)) {
+				File.WriteAllText (Path, $"Could not capture the file '{CapturePath}' because it does not exist.");
+				return;
+			}
+
 			var currentEndPosition = endPosition;
 			if (currentEndPosition == 0)
 				currentEndPosition = new FileInfo (CapturePath).Length;


### PR DESCRIPTION
Should fix this (or at the very least not prevent xharness from writing out the report):

    21:07:30.3947450 Failed to write log: System.IO.FileNotFoundException: Could not find file '/Users/builder/Library/Logs/CoreSimulator/6DA2ED3C-B1FA-4D0B-9DD6-113E5F9A1381/system.log'.
    File name: '/Users/builder/Library/Logs/CoreSimulator/6DA2ED3C-B1FA-4D0B-9DD6-113E5F9A1381/system.log'
        at System.IO.__Error.WinIOError (System.Int32 errorCode, System.String maybeFullPath) [0x00207] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/io/__error.cs:188
        at System.IO.FileInfo.get_Length () [0x00038] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/io/fileinfo.cs:171
        at xharness.CaptureLog.Capture () [0x0004a] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/xharness/Log.cs:334
        at xharness.CaptureLog.Flush () [0x00008] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/xharness/Log.cs:373
        at xharness.Jenkins.GenerateReportImpl (System.IO.Stream stream, System.IO.StreamWriter markdown_summary) [0x017db] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/xharness/Jenkins.cs:2012
        at xharness.Jenkins.GenerateReport (System.Boolean only_if_ci) [0x00075] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/xharness/Jenkins.cs:1313