### PR TITLE
[introspection] Fix typo test on Mojave.

### DIFF
--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -567,6 +567,7 @@ namespace Introspection
 #if MONOMAC
 			"Abbr",
 			"Accum",
+			"Ack", // TcpSetDisableAckStretching
 			"Addin",
 			"Addons",
 			"Appactive",
@@ -590,7 +591,9 @@ namespace Introspection
 			"Descriptorfor",
 			"Dimensionsfor",
 			"Dissapearing",
+			"Distinguised", // ITLibPlaylistPropertyDistinguisedKind
 			"Dirs",
+			"Drm", // MediaItemProperty.IsDrmProtected 
 			"Editability",
 			"Eisu",
 			"Entryat",


### PR DESCRIPTION
Fixes:

    [FAIL] Typo in METHOD name: TcpSetDisableAckStretching - Ack, Type: NWProtocolOptions
    [FAIL] Typo in METHOD name: get_DrmProtected - Drm, Type: ITLibMediaItem
    [FAIL] Typo in FIELD name: DistinguisedKind - Distinguised, Type: ITLibPlaylistProperty
    [FAIL] Typo in FIELD name: IsDrmProtected - Drm, Type: MediaItemProperty