### PR TITLE
[mmp] Set DEVELOPER_DIR to our Xcode.

### DIFF
--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -8,6 +8,8 @@ MONO_CECIL_DLL=$(CECIL_PATH)/bin/$(CECIL_CONFIG)/Mono.Cecil.dll
 MONO_CECIL_MDB_DLL=$(CECIL_PATH)/bin/$(CECIL_CONFIG)/Mono.Cecil.Mdb.dll
 MONO_CECIL_FILES=$(wildcard $(CECIL_PATH)/*.cs) $(wildcard $(CECIL_PATH)/*/*.cs) $(wildcard $(CECIL_PATH)/*/*/*.cs) $(wildcard $(CECIL_PATH)/*/*/*/*.cs) $(wildcard $(CECIL_PATH)/*/*/*/*/*.cs)
 
+export DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT)
+
 $(MONO_CECIL_DLL): $(CECIL_PATH)/Mono.Cecil.csproj $(MONO_CECIL_FILES)
 	$(Q_XBUILD) cd $(CECIL_PATH) && $(SYSTEM_XBUILD) /p:Configuration=$(CECIL_CONFIG) Mono.Cecil.csproj $(XBUILD_VERBOSITY)
 


### PR DESCRIPTION
This makes it possible to build mmp (the partial static registrar code) with
the wrong system Xcode (which is not supported, but that doesn't mean we can't
try to make it mostly work to ease our lives).