### PR TITLE
[mmp] Show an error if trying to build a 32-bit app with Xcode 10. Fixes #4569. (#4684) (#4690)

### DIFF
--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -158,6 +158,18 @@ As a last-straw solution, use an older version of Xamarin.Mac that does not requ
 
 <!-- 0136 and 0137 used by mtouch -->
 
+#### MM0138: Building 32-bit apps is not possible when using Xcode 10. Please migrate project to the Unified API.
+
+Xcode 10 does not support building 32-bit applications.
+
+The project must be [migrated to a Unified project](https://docs.microsoft.com/en-us/xamarin/cross-platform/macios/unified/updating-mac-apps) in order to support 64-bit.
+
+#### MM0139: Building 32-bit apps is not possible when using Xcode 10. Please change the architecture in the project's Mac Build options to 'x86_64'.
+
+Xcode 10 does not support building 32-bit applications.
+
+Change the architecture in the project's Mac Build options to 'x86_64' in order to build a 64-bit application.
+
 # MM1xxx: file copy / symlinks (project related)
 
 ### <a name="MM1034">MM1034: Could not create symlink '{file}' -> '{target}': error {number}

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -699,6 +699,8 @@ that can't be found.
 mtouch may in certain cases still find references at a later point, which
 means that if the build otherwise succeeds, this warning can be ignored.
 
+<!-- 0138-0139: used by mmp -->
+
 # MT1xxx: Project related error messages
 
 ### MT10xx: Installer / mtouch

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -484,6 +484,12 @@ namespace Xamarin.Bundler {
 			// InitializeCommon needs SdkVersion set to something valid
 			ValidateSDKVersion ();
 
+			if (action != Action.RunRegistrar && XcodeVersion.Major >= 10 && !Is64Bit) {
+				if (IsClassic)
+					throw ErrorHelper.CreateError (138, "Building 32-bit apps is not possible when using Xcode 10. Please migrate project to the Unified API.");
+				throw ErrorHelper.CreateError (139, "Building 32-bit apps is not possible when using Xcode 10. Please change the architecture in the project's Mac Build options to 'x86_64'.");
+			}
+
 			// InitializeCommon needs the current profile
 			if (IsClassic)
 				Profile.Current = new MonoMacProfile ();


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/4569.

Commit list for mono/mono:

* mono/mono@d092c53b975 [eglib] Fix URI to file name conversion
* mono/mono@582f242d47f Bump xunit-binaries
* mono/mono@ad910039be2 Bump nunitlite to get NUnit2 xml output fix and failure on file not found fix (#10188)
* mono/mono@172a5333ba5 [System.Xml.Linq] Fix namespace conflict with new Xamarin.Mac namespace in test code. (#10184)
* mono/mono@f3a2216b65a backport #9800 to 2018-04
* mono/mono@07ac0897350 Bump msbuild to track mono-2018-04 (#9834)

Diff: https://github.com/mono/mono/compare/d31dbe843a556a5377a66793ee438c6f52695379...d092c53b975bae3f961d5c042efb4256037e23f2