### PR TITLE
[foundation/usernotifications] Use NSString to preserve localization

### DIFF
--- a/src/Foundation/NSString2.cs
+++ b/src/Foundation/NSString2.cs
@@ -106,7 +106,7 @@ namespace Foundation {
 			}
 		}
 
-#if !XAMCORE_4_0
+#if !XAMCORE_4_0 && !MONOMAC
 		[Obsolete ("Use 'GetLocalizedUserNotificationString' that takes 'NSString' to preserve localization.")]
 		public static string GetLocalizedUserNotificationString (string key, params NSObject[] arguments) {
 			return GetLocalizedUserNotificationString ((NSString) key, arguments);

--- a/src/Foundation/NSString2.cs
+++ b/src/Foundation/NSString2.cs
@@ -105,5 +105,12 @@ namespace Foundation {
 				return _characterAtIndex (idx);
 			}
 		}
+
+#if !XAMCORE_4_0
+		[Obsolete ("Use 'GetLocalizedUserNotificationString' that takes 'NSString' to preserve localization.")]
+		public static string GetLocalizedUserNotificationString (string key, params NSObject[] arguments) {
+			return GetLocalizedUserNotificationString ((NSString) key, arguments);
+		}
+#endif
 	}
 }

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -8151,7 +8151,7 @@ namespace Foundation
 		[iOS (10,0), Watch (3,0), NoTV, Mac (10,14, onlyOn64: true)]
 		[Static]
 		[Export ("localizedUserNotificationStringForKey:arguments:")]
-		string GetLocalizedUserNotificationString (string key, [Params] [NullAllowed] NSObject [] arguments);
+		NSString GetLocalizedUserNotificationString (NSString key, [Params] [NullAllowed] NSObject [] arguments);
 
 		[Export ("getParagraphStart:end:contentsEnd:forRange:")]
 		void GetParagraphPositions (out nuint paragraphStartPosition, out nuint paragraphEndPosition, out nuint contentsEndPosition, NSRange range);

--- a/src/usernotifications.cs
+++ b/src/usernotifications.cs
@@ -309,7 +309,7 @@ namespace UserNotifications {
 		[NoWatch, iOS (12,0)]
 		[Static]
 		[Export ("categoryWithIdentifier:actions:intentIdentifiers:hiddenPreviewsBodyPlaceholder:categorySummaryFormat:options:")]
-		UNNotificationCategory FromIdentifier (string identifier, UNNotificationAction[] actions, string[] intentIdentifiers, [NullAllowed] string hiddenPreviewsBodyPlaceholder, [NullAllowed] string categorySummaryFormat, UNNotificationCategoryOptions options);
+		UNNotificationCategory FromIdentifier (string identifier, UNNotificationAction[] actions, string[] intentIdentifiers, [NullAllowed] string hiddenPreviewsBodyPlaceholder, [NullAllowed] NSString categorySummaryFormat, UNNotificationCategoryOptions options);
 
 		[NoWatch, iOS (12, 0)]
 		[Export ("categorySummaryFormat")]


### PR DESCRIPTION
- Fixes #4694: NSString.GetLocalizedUserNotificationString not working with .stringsdict files
  (https://github.com/xamarin/xamarin-macios/issues/4694)
- Updated `UNNotificationCategory.FromIdentifier`'s iOS 12 overload to take a `NSString` category format to preserve localization.
- Change `GetLocalizedUserNotificationString` to only use NSString to preserve localization (similar fix to https://github.com/xamarin/xamarin-macios/pull/3266).