### PR TITLE
Make the bgen build respect the BUILD_DIR variable. Fixes maccore#959.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -96,10 +96,10 @@ $(IOS_BUILD_DIR)/native/core.dll: $(IOS_CORE_SOURCES) frameworks.sources
 		$(IOS_CORE_SOURCES)
 
 # generated_sources
-$(IOS_BUILD_DIR)/native/generated_sources: $(IOS_GENERATOR) $(IOS_APIS) $(IOS_BUILD_DIR)/native/core.dll $(IOS_BUILD_DIR)/native/Xamarin.iOS.BindingAttributes.dll ios.rsp
-	$(call Q_PROF_GEN,ios) $(IOS_GENERATE) @ios.rsp
+$(IOS_BUILD_DIR)/native/generated_sources: $(IOS_GENERATOR) $(IOS_APIS) $(IOS_BUILD_DIR)/native/core.dll $(IOS_BUILD_DIR)/native/Xamarin.iOS.BindingAttributes.dll $(BUILD_DIR)/ios.rsp
+	$(call Q_PROF_GEN,ios) $(IOS_GENERATE) @$(BUILD_DIR)/ios.rsp
 
-ios.rsp: Makefile Makefile.generator frameworks.sources
+$(BUILD_DIR)/ios.rsp: Makefile Makefile.generator frameworks.sources
 	$(Q_GEN) echo \
 		$(IOS_GENERATOR_FLAGS) \
 		$(IOS_GENERATOR_native_FLAGS) \
@@ -448,10 +448,10 @@ $(MAC_BUILD_DIR)/$(1)/core.dll: $(MAC_CORE_SOURCES) frameworks.sources
 		$(3) \
 		$$(MAC_CORE_SOURCES)
 
-$(MAC_BUILD_DIR)/$(1)/generated-sources: $$(MAC_$(1)_GENERATOR) $(MAC_APIS) $(MAC_BUILD_DIR)/$(1)/core.dll $(MAC_BUILD_DIR)/$(7) mac-$(1).rsp
-	$$(call Q_PROF_GEN,mac/$(1)) $$(MAC_$(1)_GENERATE) @mac-$(1).rsp
+$(MAC_BUILD_DIR)/$(1)/generated-sources: $$(MAC_$(1)_GENERATOR) $(MAC_APIS) $(MAC_BUILD_DIR)/$(1)/core.dll $(MAC_BUILD_DIR)/$(7) $(BUILD_DIR)/mac-$(1).rsp
+	$$(call Q_PROF_GEN,mac/$(1)) $$(MAC_$(1)_GENERATE) @$(BUILD_DIR)/mac-$(1).rsp
 
-mac-$(1).rsp: Makefile Makefile.generator frameworks.sources
+$(BUILD_DIR)/mac-$(1).rsp: Makefile Makefile.generator frameworks.sources
 	$$(Q_GEN) echo \
 		$(MAC_GENERATED_DEFINES) \
 		-compiler:$$(MAC_$(1)_CSC) \
@@ -719,10 +719,10 @@ $(WATCH_BUILD_DIR)/watch/core.dll: $(WATCHOS_CORE_SOURCES) frameworks.sources | 
 		$(WATCHOS_CORE_SOURCES)
 
 # generated_sources
-$(WATCH_BUILD_DIR)/watch/generated_sources: $(WATCH_GENERATOR) $(WATCHOS_APIS) $(WATCH_BUILD_DIR)/watch/core.dll $(WATCH_BUILD_DIR)/Xamarin.WatchOS.BindingAttributes.dll watchos.rsp
-	$(call Q_PROF_GEN,watch) $(WATCH_GENERATE) @watchos.rsp
+$(WATCH_BUILD_DIR)/watch/generated_sources: $(WATCH_GENERATOR) $(WATCHOS_APIS) $(WATCH_BUILD_DIR)/watch/core.dll $(WATCH_BUILD_DIR)/Xamarin.WatchOS.BindingAttributes.dll $(BUILD_DIR)/watchos.rsp
+	$(call Q_PROF_GEN,watch) $(WATCH_GENERATE) @$(BUILD_DIR)/watchos.rsp
 
-watchos.rsp: Makefile Makefile.generator frameworks.sources
+$(BUILD_DIR)/watchos.rsp: Makefile Makefile.generator frameworks.sources
 	$(Q_GEN) echo  \
 		-inline-selectors                                        \
 		-process-enums                                           \
@@ -931,10 +931,10 @@ $(TVOS_BUILD_DIR)/tvos/core.dll: $(TVOS_CORE_SOURCES) frameworks.sources Makefil
 		$(TVOS_CORE_SOURCES)
 
 # generated_sources
-$(TVOS_BUILD_DIR)/tvos/generated_sources: $(TVOS_GENERATOR) $(TVOS_APIS) $(TVOS_BUILD_DIR)/tvos/core.dll $(TVOS_BUILD_DIR)/Xamarin.TVOS.BindingAttributes.dll tvos.rsp
-	$(call Q_PROF_GEN,tvos) $(TVOS_GENERATE) @tvos.rsp
+$(TVOS_BUILD_DIR)/tvos/generated_sources: $(TVOS_GENERATOR) $(TVOS_APIS) $(TVOS_BUILD_DIR)/tvos/core.dll $(TVOS_BUILD_DIR)/Xamarin.TVOS.BindingAttributes.dll $(BUILD_DIR)/tvos.rsp
+	$(call Q_PROF_GEN,tvos) $(TVOS_GENERATE) @$(BUILD_DIR)/tvos.rsp
 
-tvos.rsp: Makefile Makefile.generator frameworks.sources
+$(BUILD_DIR)/tvos.rsp: Makefile Makefile.generator frameworks.sources
 	$(Q_GEN) echo \
 		-inline-selectors                                        \
 		-process-enums                                           \

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -8,7 +8,7 @@ $(BUILD_DIR)/generator.csproj.inc: Makefile.generator $(TOP)/tools/common/create
 
 -include $(BUILD_DIR)/generator.csproj.inc
 
-$(BUILD_DIR)/common/bgen.exe: $(generator_dependencies) Makefile.generator
+$(BUILD_DIR)/common/bgen.exe: $(generator_dependencies) Makefile.generator $(BUILD_DIR)/generator-frameworks.g.cs
 	$(Q_GEN) $(SYSTEM_MSBUILD) $(XBUILD_VERBOSITY) /p:Configuration=Debug generator.csproj /p:IntermediateOutputPath=$(BUILD_DIR)/IDE/obj/common/ /p:OutputPath=$(BUILD_DIR)/common
 
 #

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -9,7 +9,7 @@ generator.csproj.inc: Makefile.generator $(TOP)/tools/common/create-makefile-fra
 -include generator.csproj.inc
 
 $(BUILD_DIR)/common/bgen.exe: $(generator_dependencies) Makefile.generator
-	$(Q_GEN) $(SYSTEM_MSBUILD) $(XBUILD_VERBOSITY) /p:Configuration=Debug generator.csproj
+	$(Q_GEN) $(SYSTEM_MSBUILD) $(XBUILD_VERBOSITY) /p:Configuration=Debug generator.csproj /p:IntermediateOutputPath=$(BUILD_DIR)/IDE/obj/common/ /p:OutputPath=$(BUILD_DIR)/common
 
 #
 # Common

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -4,7 +4,7 @@
 
 # generator.csproj.inc contains the generator_dependencies variable used to determine if the generator needs to be rebuilt or not.
 $(BUILD_DIR)/generator.csproj.inc: Makefile.generator $(TOP)/tools/common/create-makefile-fragment.sh | $(BUILD_DIR)
-	$(Q_GEN) $(TOP)/tools/common/create-makefile-fragment.sh $(CURDIR)/generator.csproj $@
+	$(Q_GEN) $(TOP)/tools/common/create-makefile-fragment.sh $(abspath $(CURDIR)/generator.csproj) $(abspath $@)
 
 -include $(BUILD_DIR)/generator.csproj.inc
 

--- a/src/Makefile.generator
+++ b/src/Makefile.generator
@@ -3,10 +3,10 @@
 #
 
 # generator.csproj.inc contains the generator_dependencies variable used to determine if the generator needs to be rebuilt or not.
-generator.csproj.inc: Makefile.generator $(TOP)/tools/common/create-makefile-fragment.sh
-	$(Q_GEN) $(TOP)/tools/common/create-makefile-fragment.sh $(CURDIR)/generator.csproj
+$(BUILD_DIR)/generator.csproj.inc: Makefile.generator $(TOP)/tools/common/create-makefile-fragment.sh | $(BUILD_DIR)
+	$(Q_GEN) $(TOP)/tools/common/create-makefile-fragment.sh $(CURDIR)/generator.csproj $@
 
--include generator.csproj.inc
+-include $(BUILD_DIR)/generator.csproj.inc
 
 $(BUILD_DIR)/common/bgen.exe: $(generator_dependencies) Makefile.generator
 	$(Q_GEN) $(SYSTEM_MSBUILD) $(XBUILD_VERBOSITY) /p:Configuration=Debug generator.csproj /p:IntermediateOutputPath=$(BUILD_DIR)/IDE/obj/common/ /p:OutputPath=$(BUILD_DIR)/common

--- a/src/generator.csproj
+++ b/src/generator.csproj
@@ -14,6 +14,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>build\common</OutputPath>
+    <IntermediateOutputPath>build\IDE\obj\common\</IntermediateOutputPath>
     <DefineConstants>DEBUG;BGENERATOR;NET_4_0;NO_AUTHENTICODE;STATIC;NO_SYMBOL_WRITER</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/tools/common/create-makefile-fragment.sh
+++ b/tools/common/create-makefile-fragment.sh
@@ -26,8 +26,12 @@ fi
 PROJECT_FILE="$1"
 PROJECT=$(basename -s .csproj "$PROJECT_FILE")
 PROJECT_DIR=$(dirname "$PROJECT_FILE")
-FRAGMENT_PATH=$PROJECT_FILE.inc
+FRAGMENT_PATH="$2"
 REFERENCES_PATH=$PROJECT-references.txt
+
+if test -z "$FRAGMENT_PATH"; then
+	FRAGMENT_PATH=$PROJECT_FILE.inc
+fi
 
 # ProjectInspector.csproj is an MSBuild file with a target
 # (WriteProjectReferences) that takes another project file as input (the


### PR DESCRIPTION
Make the bgen build respect the BUILD_DIR variable, so that the API comparison
can redirect the output as expected/desired.

Fixes https://github.com/xamarin/maccore/issues/959.