### PR TITLE
[tests] Update MT4134 with new iOS 12 frameworks. Fixes maccore#954.

### DIFF
--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -291,6 +291,10 @@ class MyObjectErr : NSObject, IFoo1, IFoo2
 					new { Framework = "ARKit", Version = "11.0" },
 					new { Framework = "BusinessChat", Version = "11.3" },
 					new { Framework = "ClassKit", Version = "11.4" },
+					new { Framework = "AuthenticationServices", Version = "12.0" },
+					new { Framework = "CarPlay", Version = "12.0" },
+					new { Framework = "IdentityLookupUI", Version = "12.0" },
+					new { Framework = "NaturalLanguage", Version = "12.0" },
 				};
 				foreach (var framework in invalidFrameworks)
 					mtouch.AssertError (4134, $"Your application is using the '{framework.Framework}' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS {framework.Version}, while you're building with the iOS {mtouch.Sdk} SDK.) Please select a newer SDK in your app's iOS Build options.");


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/954.