### PR TITLE
[makefile] Fix 'buildinfo' branch name on jenkins

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -17,29 +17,17 @@ PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 #
 # A release branch requires updating:
 #
-# PACKAGE_HEAD_BRANCH (set to the release branch name, this shows up in the IDE's version information, as well as mtouch/mmp --version)
 # IOS_PACKAGE_VERSION (major/minor #)
 # MAC_PACKAGE_VERSION (major/minor #)
 # PACKAGE_VERSION_REV (set to 0 and increment for service releases or previews)
 # (and updating the same on master as well, to next version)
 #
 
-#
-# PACKAGE_HEAD_BRANCH determines the branch name (for wrench builds) that shows up in the
-# IDE's version information, as well as mtouch/mmp --version and the AssemblyInformationalVersion
-# for product assemblies.
-#
-# For developer builds, we check with git which branch is the current one (we can't do that
-# on wrench, because wrench technically builds hashes, not branches)
-#
-# 
-PACKAGE_HEAD_BRANCH?=xcode10
-ifeq ($(CURRENT_BRANCH),)
-ifeq ($(BUILD_REVISION),)
+ifeq ($(BRANCH_NAME),)
+# BRANCH_NAME is set in Jenkins, so this is for local builds.
 CURRENT_BRANCH:=$(shell git rev-parse --abbrev-ref HEAD)
 else
-CURRENT_BRANCH:=$(PACKAGE_HEAD_BRANCH)
-endif
+CURRENT_BRANCH:=$(BRANCH_NAME)
 endif
 
 # TODO: reset to 0 after major/minor version bump (SRO) and increment for service releases and previews


### PR DESCRIPTION
- Jenkins knows the branch name $(BRANCH_NAME) which Wrench didn't.
- Fixes #4674: [Makefile] Incorrect 'HEAD' word used as branch for xcode10 pkg.
  (https://github.com/xamarin/xamarin-macios/issues/4674)