### PR TITLE
[xharness] Don't try to run aggregated tasks when none of the contained tasks built successfully.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -3557,13 +3557,18 @@ function toggleAll (show)
 			await Task.WhenAll (Tasks.Select ((v) => v.BuildAsync ()).Distinct ());
 			build_timer.Stop ();
 
+			var executingTasks = Tasks.Where ((v) => !v.Ignored && !v.Failed);
+			if (!executingTasks.Any ()) {
+				ExecutionResult = TestExecutingResult.Failed;
+				return;
+			}
+
 			using (var desktop = await NotifyBlockingWaitAsync (Jenkins.DesktopResource.AcquireExclusiveAsync ())) {
 				run_timer.Start ();
 
 				// We need to set the dialog permissions for all the apps
 				// before launching the simulator, because once launched
 				// the simulator caches the values in-memory.
-				var executingTasks = Tasks.Where ((v) => !v.Ignored && !v.Failed);
 				foreach (var task in executingTasks)
 					await task.SelectSimulatorAsync ();
 


### PR DESCRIPTION
Fixes this HarnessException when all simulator tasks for an aggregated run
simulator task fails to build (i.e. there is nothing to run):

    Harness exception for 'Tests for iOS_Unified32': System.InvalidOperationException: Sequence contains no elements
        at System.Linq.Enumerable.First[TSource] (System.Collections.Generic.IEnumerable`1[T] source) [0x0000b] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-04/external/bockbuild/builds/mono-x64/external/corefx/src/System.Linq/src/System/Linq/First.cs:16
        at xharness.AggregatedRunSimulatorTask+<ExecuteAsync>d__9.MoveNext () [0x00312] in /work/maccore/master/xamarin-macios/tests/xharness/Jenkins.cs:3582
        --- End of stack trace from previous location where exception was thrown ---
        at xharness.TestTask+<RunInternalAsync>d__92.MoveNext () [0x00113] in /work/maccore/master/xamarin-macios/tests/xharness/Jenkins.cs:2352