### PR TITLE
[xharness] Fix failure message when nunit test times out.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -2824,7 +2824,7 @@ function toggleAll (show)
 						ExecutionResult = TestExecutingResult.Running;
 						var result = await proc.RunAsync (log, true, Timeout);
 						if (result.TimedOut) {
-							FailureMessage = $"Execution timed out after {Timeout.Minutes} minutes.";
+							FailureMessage = $"Execution timed out after {Timeout.TotalMinutes} minutes.";
 							log.WriteLine (FailureMessage);
 							ExecutionResult = TestExecutingResult.TimedOut;
 						} else if (result.Succeeded) {


### PR DESCRIPTION
Fixes an issue where MTouch test would seemingly fail immediately:

    Failure: Execution timed out after 0 minutes.

when it's just saying that it failed out after [2 hours and] 0 minutes.

Fix it by showing the total number of minutes in the failure message.