### PR TITLE
[ObjCRuntime] Add missing .ctor to 'Class'

### DIFF
--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -64,6 +64,12 @@ namespace ObjCRuntime {
 			this.handle = handle;
 		}
 
+		[Preserve (Conditional = true)]
+		public Class (IntPtr handle, bool owns) {
+			// Class(es) can't be freed, so we ignore the 'owns' parameter.
+			this.handle = handle;
+		}
+
 		internal static Class Construct (IntPtr handle) 
 		{
 			return new Class (handle);

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -9936,9 +9936,9 @@ namespace AppKit {
 		[Export ("unregisterImageRepClass:")]
 		void UnregisterImageRepClass (Class imageRepClass);
 
-		//[Static]
-		//[Export ("registeredImageRepClasses")]
-		//Class [] RegisteredImageRepClasses ();
+		[Static]
+		[Export ("registeredImageRepClasses")]
+		Class [] GetRegisteredImageRepClasses ();
 
 		[Availability (Deprecated = Platform.Mac_10_10)]
 		[Static]

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -10765,18 +10765,17 @@ namespace Foundation
 		NSString SecureUnarchiveFromDataTransformerName { get; }
 	}
 
-	// Class [] return value is currently broken - https://github.com/xamarin/xamarin-macios/issues/4441
-// 	[Watch (5,0), TV (12,0), Mac (10,14, onlyOn64: true), iOS (12,0)]
-// 	[BaseType (typeof(NSValueTransformer))]
-// 	interface NSSecureUnarchiveFromDataTransformer {
-// 		[Static]
-// 		[Export ("allowedTopLevelClasses", ArgumentSemantic.Copy)]
-// 		Class[] AllowedTopLevelClasses { get; }
-// 
-// 		[Static]
-// 		[Wrap ("Array.ConvertAll (AllowedTopLevelClasses, c => Class.Lookup (c))")]
-// 		Type [] AllowedTopLevelTypes { get; }
-// 	}
+	[Watch (5,0), TV (12,0), Mac (10,14, onlyOn64: true), iOS (12,0)]
+	[BaseType (typeof(NSValueTransformer))]
+	interface NSSecureUnarchiveFromDataTransformer {
+		[Static]
+		[Export ("allowedTopLevelClasses", ArgumentSemantic.Copy)]
+		Class [] AllowedTopLevelClasses { get; }
+
+		[Static]
+		[Wrap ("Array.ConvertAll (AllowedTopLevelClasses, c => Class.Lookup (c))")]
+		Type [] AllowedTopLevelTypes { get; }
+	}
 	
 	[BaseType (typeof (NSValue))]
 	// init returns NIL

--- a/tests/monotouch-test/Foundation/NSKeyedUnarchiverTest.cs
+++ b/tests/monotouch-test/Foundation/NSKeyedUnarchiverTest.cs
@@ -37,16 +37,15 @@ namespace MonoTouchFixtures.Foundation
 			Assert.IsNull (error, "GetUnarchivedObject - Type []");
 		}
 
-		// Class [] return value is currently broken - https://github.com/xamarin/xamarin-macios/issues/4441
-		//[Test]
-		//public void DataTransformer_AllowedTopLevelTypes_WrapperTests ()
-		//{
-		//	TestRuntime.AssertXcodeVersion (10, 0);
+		[Test]
+		public void DataTransformer_AllowedTopLevelTypes_WrapperTests ()
+		{
+			TestRuntime.AssertXcodeVersion (10, 0);
 
-		//	Class [] classes = NSSecureUnarchiveFromDataTransformer.AllowedTopLevelClasses;
-		//	Type [] types =  NSSecureUnarchiveFromDataTransformer.AllowedTopLevelTypes;
+			Class [] classes = NSSecureUnarchiveFromDataTransformer.AllowedTopLevelClasses;
+			Type [] types =  NSSecureUnarchiveFromDataTransformer.AllowedTopLevelTypes;
 
-		//	Assert.AreEqual (classes.Length, types.Length, "Lengths not equal");
-		//}
+			Assert.AreEqual (classes.Length, types.Length, "Lengths not equal");
+		}
 	}
 }

--- a/tests/xtro-sharpie/iOS-Foundation.ignore
+++ b/tests/xtro-sharpie/iOS-Foundation.ignore
@@ -3,7 +3,3 @@
 
 ## does not exists in iOS as a type - but some API refers to it (messy)
 !unknown-type! NSPortMessage bound
-
-## Class [] return value is currently broken - https://github.com/xamarin/xamarin-macios/issues/4441
-!missing-selector! +NSSecureUnarchiveFromDataTransformer::allowedTopLevelClasses not bound
-!missing-type! NSSecureUnarchiveFromDataTransformer not bound

--- a/tests/xtro-sharpie/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/macOS-AppKit.ignore
@@ -670,7 +670,6 @@
 !missing-selector! +NSBitmapImageRep::representationOfImageRepsInArray:usingType:properties: not bound
 !missing-selector! +NSBundle::loadNibFile:externalNameTable:withZone: not bound
 !missing-selector! +NSFont::fontWithName:matrix: not bound
-!missing-selector! +NSImageRep::registeredImageRepClasses not bound
 !missing-selector! +NSInputManager::cycleToNextInputLanguage: not bound
 !missing-selector! +NSInputManager::cycleToNextInputServerInLanguage: not bound
 !missing-selector! +NSMediaLibraryBrowserController::sharedMediaLibraryBrowserController not bound

--- a/tests/xtro-sharpie/macOS-Foundation.ignore
+++ b/tests/xtro-sharpie/macOS-Foundation.ignore
@@ -1,10 +1,6 @@
 ## Only one type currently, which default returns. Currently unneeded unless they extend.
 !missing-selector! +NSDistributedNotificationCenter::notificationCenterForType: not bound
 
-## Class [] return value is currently broken - https://github.com/xamarin/xamarin-macios/issues/4441
-!missing-selector! +NSSecureUnarchiveFromDataTransformer::allowedTopLevelClasses not bound
-!missing-type! NSSecureUnarchiveFromDataTransformer not bound
-
 ## unsorted
 
 !duplicate-type-name! NSFileWrapperReadingOptions enum exists as both Foundation.NSFileWrapperReadingOptions and AppKit.NSFileWrapperReadingOptions

--- a/tests/xtro-sharpie/tvOS-Foundation.ignore
+++ b/tests/xtro-sharpie/tvOS-Foundation.ignore
@@ -7,10 +7,6 @@
 ## does not exists in iOS (or tvOS) as a type - but some API refers to it (messy)
 !unknown-type! NSPortMessage bound
 
-## Class [] return value is currently broken - https://github.com/xamarin/xamarin-macios/issues/4441
-!missing-selector! +NSSecureUnarchiveFromDataTransformer::allowedTopLevelClasses not bound
-!missing-type! NSSecureUnarchiveFromDataTransformer not bound
-
 ## unsorted
 
 !missing-selector! +NSURLConnection::sendSynchronousRequest:returningResponse:error: not bound

--- a/tests/xtro-sharpie/watchOS-Foundation.ignore
+++ b/tests/xtro-sharpie/watchOS-Foundation.ignore
@@ -3,7 +3,3 @@
 
 ## type was not marked as unavailable before Xcode9
 !unknown-type! NSUbiquitousKeyValueStore bound
-
-## Class [] return value is currently broken - https://github.com/xamarin/xamarin-macios/issues/4441
-!missing-selector! +NSSecureUnarchiveFromDataTransformer::allowedTopLevelClasses not bound
-!missing-type! NSSecureUnarchiveFromDataTransformer not bound


### PR DESCRIPTION
- Fixes #4441: [generator] Binding with return value of Class [] do not do the right thing
  (https://github.com/xamarin/xamarin-macios/issues/4441)
- Turns out the logic to put INativeObjects into NSArrays was already in place. We simply needed to add the missing (IntPtr handle, bool owns) overload to `Class`.
- Uncommented AppKit `registeredImageRepClasses` since it was using `Class []`. Tested locally and it works fine.
- Reimplemented `Foundation`'s `NSSecureUnarchiveFromDataTransformer` and its test which were also using `Class []`.