### PR TITLE
[Security] Add missing SecProtocolMetadata missing API.

### DIFF
--- a/src/Security/SecProtocolMetadata.cs
+++ b/src/Security/SecProtocolMetadata.cs
@@ -80,7 +80,7 @@ namespace Security {
 #if !COREBUILD
 
 		delegate void sec_protocol_metadata_access_distinguished_names_handler_t (IntPtr block, IntPtr dispatchData);
- 		static sec_protocol_metadata_access_distinguished_names_handler_t static_DistinguishedNamesForPeer  = TrampolineDistinguishedNamesForPeer;
+ 		static sec_protocol_metadata_access_distinguished_names_handler_t static_DistinguishedNamesForPeer = TrampolineDistinguishedNamesForPeer;
 
  		[MonoPInvokeCallback (typeof (sec_protocol_metadata_access_distinguished_names_handler_t))]
  		static void TrampolineDistinguishedNamesForPeer (IntPtr block, IntPtr data)
@@ -93,31 +93,29 @@ namespace Security {
  		}
 
  		[DllImport (Constants.SecurityLibrary)]
- 		static extern unsafe void sec_protocol_metadata_access_distinguished_names (IntPtr handle, void *callback);
+		[return: MarshalAs (UnmanagedType.I1)]
+ 		static extern bool sec_protocol_metadata_access_distinguished_names (IntPtr handle, ref BlockLiteral callback);
 
  		[BindingImpl (BindingImplOptions.Optimizable)]
  		public void SetDistinguishedNamesForPeerHandler (Action<DispatchData> callback)
  		{
- 			unsafe {
- 				if (callback == null) {
- 					sec_protocol_metadata_access_distinguished_names (GetCheckedHandle (), null);
- 					return;
- 				}
+			if (callback == null)
+				throw new ArgumentNullException (nameof (callback));
 
- 				BlockLiteral block_handler = new BlockLiteral ();
- 				BlockLiteral *block_ptr_handler = &block_handler;
- 				block_handler.SetupBlockUnsafe (static_DistinguishedNamesForPeer, callback);
+			var block_handler = new BlockLiteral ();
+			block_handler.SetupBlockUnsafe (static_DistinguishedNamesForPeer, callback);
 
- 				try {
- 					sec_protocol_metadata_access_distinguished_names (GetCheckedHandle (), (void*) block_ptr_handler);
- 				} finally {
- 					block_handler.CleanupBlock ();
- 				}
- 			}
+			try {
+				if (!sec_protocol_metadata_access_distinguished_names (GetCheckedHandle (), ref block_handler)) {
+					throw new InvalidOperationException ("Distinguished names are not accessible.");
+				}
+			} finally {
+				block_handler.CleanupBlock ();
+			}
  		}
 
 		delegate void sec_protocol_metadata_access_ocsp_response_handler_t (IntPtr block, IntPtr dispatchData);
- 		static sec_protocol_metadata_access_ocsp_response_handler_t static_OcspReposeForPeer  = TrampolineOcspReposeForPeer;
+ 		static sec_protocol_metadata_access_ocsp_response_handler_t static_OcspReposeForPeer = TrampolineOcspReposeForPeer;
 
  		[MonoPInvokeCallback (typeof (sec_protocol_metadata_access_ocsp_response_handler_t))]
  		static void TrampolineOcspReposeForPeer (IntPtr block, IntPtr data)
@@ -130,31 +128,29 @@ namespace Security {
  		}
 
  		[DllImport (Constants.SecurityLibrary)]
- 		static extern unsafe void sec_protocol_metadata_access_ocsp_response (IntPtr handle, void *callback);
+		[return: MarshalAs (UnmanagedType.I1)]
+ 		static extern bool sec_protocol_metadata_access_ocsp_response (IntPtr handle, ref BlockLiteral callback);
 
  		[BindingImpl (BindingImplOptions.Optimizable)]
  		public void SetOcspResponseForPeerHandler (Action<DispatchData> callback)
  		{
- 			unsafe {
- 				if (callback == null) {
- 					sec_protocol_metadata_access_ocsp_response (GetCheckedHandle (), null);
- 					return;
- 				}
+			if (callback == null)
+				throw new ArgumentNullException (nameof (callback));
 
- 				BlockLiteral block_handler = new BlockLiteral ();
- 				BlockLiteral *block_ptr_handler = &block_handler;
- 				block_handler.SetupBlockUnsafe (static_OcspReposeForPeer, callback);
+			var block_handler = new BlockLiteral ();
+			block_handler.SetupBlockUnsafe (static_OcspReposeForPeer, callback);
 
- 				try {
- 					sec_protocol_metadata_access_ocsp_response (GetCheckedHandle (), (void*) block_ptr_handler);
- 				} finally {
- 					block_handler.CleanupBlock ();
- 				}
- 			}
+			try {
+				if (!sec_protocol_metadata_access_ocsp_response (GetCheckedHandle (), ref block_handler)) {
+					throw new InvalidOperationException ("The OSCP response is not accessible.");
+				}
+			} finally {
+				block_handler.CleanupBlock ();
+			}
  		}
 
 		delegate void sec_protocol_metadata_access_peer_certificate_chain_handler_t (IntPtr block, IntPtr certificate);
- 		static sec_protocol_metadata_access_peer_certificate_chain_handler_t static_CertificateChainForPeer  = TrampolineCertificateChainForPeer;
+ 		static sec_protocol_metadata_access_peer_certificate_chain_handler_t static_CertificateChainForPeer = TrampolineCertificateChainForPeer;
 
  		[MonoPInvokeCallback (typeof (sec_protocol_metadata_access_peer_certificate_chain_handler_t))]
  		static void TrampolineCertificateChainForPeer (IntPtr block, IntPtr certificate)
@@ -167,31 +163,29 @@ namespace Security {
  		}
 
  		[DllImport (Constants.SecurityLibrary)]
- 		static extern unsafe void sec_protocol_metadata_access_peer_certificate_chain (IntPtr handle, void *callback);
+		[return: MarshalAs (UnmanagedType.I1)]
+ 		static extern bool sec_protocol_metadata_access_peer_certificate_chain (IntPtr handle, ref BlockLiteral callback);
 
  		[BindingImpl (BindingImplOptions.Optimizable)]
  		public void SetCertificateChainForPeerHandler (Action<SecCertificate> callback)
  		{
- 			unsafe {
- 				if (callback == null) {
- 					sec_protocol_metadata_access_peer_certificate_chain (GetCheckedHandle (), null);
- 					return;
- 				}
+			if (callback == null)
+				throw new ArgumentNullException (nameof (callback));
 
- 				BlockLiteral block_handler = new BlockLiteral ();
- 				BlockLiteral *block_ptr_handler = &block_handler;
- 				block_handler.SetupBlockUnsafe (static_CertificateChainForPeer, callback);
+			var block_handler = new BlockLiteral ();
+			block_handler.SetupBlockUnsafe (static_CertificateChainForPeer, callback);
 
- 				try {
- 					sec_protocol_metadata_access_peer_certificate_chain (GetCheckedHandle (), (void*) block_ptr_handler);
- 				} finally {
- 					block_handler.CleanupBlock ();
- 				}
- 			}
+			try {
+				if (!sec_protocol_metadata_access_peer_certificate_chain (GetCheckedHandle (), ref block_handler)) {
+					throw new InvalidOperationException ("The peer certificates are not accessible.");
+				}
+			} finally {
+				block_handler.CleanupBlock ();
+			}
  		}
 
 		delegate void sec_protocol_metadata_access_supported_signature_algorithms_handler_t (IntPtr block, ushort signatureAlgorithm);
- 		static sec_protocol_metadata_access_supported_signature_algorithms_handler_t static_SignatureAlgorithmsForPeer  = TrampolineSignatureAlgorithmsForPeer;
+ 		static sec_protocol_metadata_access_supported_signature_algorithms_handler_t static_SignatureAlgorithmsForPeer = TrampolineSignatureAlgorithmsForPeer;
 
  		[MonoPInvokeCallback (typeof (sec_protocol_metadata_access_supported_signature_algorithms_handler_t))]
  		static void TrampolineSignatureAlgorithmsForPeer (IntPtr block, ushort signatureAlgorithm)
@@ -203,27 +197,25 @@ namespace Security {
  		}
 
  		[DllImport (Constants.SecurityLibrary)]
- 		static extern unsafe void sec_protocol_metadata_access_supported_signature_algorithms (IntPtr handle, void *callback);
+		[return: MarshalAs (UnmanagedType.I1)]
+ 		static extern bool sec_protocol_metadata_access_supported_signature_algorithms (IntPtr handle, ref BlockLiteral callback);
 
  		[BindingImpl (BindingImplOptions.Optimizable)]
  		public void SetSignatureAlgorithmsForPeerHandler (Action<ushort> callback)
  		{
- 			unsafe {
- 				if (callback == null){
- 					sec_protocol_metadata_access_supported_signature_algorithms (GetCheckedHandle (), null);
- 					return;
- 				}
+			if (callback == null)
+				throw new ArgumentNullException (nameof (callback));
 
- 				BlockLiteral block_handler = new BlockLiteral ();
- 				BlockLiteral *block_ptr_handler = &block_handler;
- 				block_handler.SetupBlockUnsafe (static_SignatureAlgorithmsForPeer, callback);
+			var block_handler = new BlockLiteral ();
+			block_handler.SetupBlockUnsafe (static_SignatureAlgorithmsForPeer, callback);
 
- 				try {
- 					sec_protocol_metadata_access_supported_signature_algorithms (GetCheckedHandle (), (void*) block_ptr_handler);
- 				} finally {
- 					block_handler.CleanupBlock ();
- 				}
- 			}
+			try {
+				if (!sec_protocol_metadata_access_supported_signature_algorithms (GetCheckedHandle (), ref block_handler)) {
+					throw new InvalidOperationException ("The supported signature list is not accessible.");
+				}
+			} finally {
+				block_handler.CleanupBlock ();
+			}
  		}
 
 #endif

--- a/src/Security/SecProtocolMetadata.cs
+++ b/src/Security/SecProtocolMetadata.cs
@@ -55,8 +55,12 @@ namespace Security {
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static bool sec_protocol_metadata_challenge_parameters_are_equal (IntPtr metadataA, IntPtr metadataB);
 
-		public static bool ParametersAreEqual (SecProtocolMetadata metadataA, SecProtocolMetadata metadataB)
+		public static bool ChallengeParametersAreEqual (SecProtocolMetadata metadataA, SecProtocolMetadata metadataB)
 		{
+			if (metadataA == null)
+				throw new ArgumentNullException (nameof (metadataA));
+			if (metadataB == null)
+				throw new ArgumentNullException (nameof (metadataB));
 			return sec_protocol_metadata_challenge_parameters_are_equal (metadataA.GetCheckedHandle (), metadataB.GetCheckedHandle ());
 		}
 
@@ -66,6 +70,10 @@ namespace Security {
 
 		public static bool PeersAreEqual (SecProtocolMetadata metadataA, SecProtocolMetadata metadataB)
 		{
+			if (metadataA == null)
+				throw new ArgumentNullException (nameof (metadataA));
+			if (metadataB == null)
+				throw new ArgumentNullException (nameof (metadataB));
 			return sec_protocol_metadata_peers_are_equal (metadataA.GetCheckedHandle (), metadataB.GetCheckedHandle ());
 		}
 
@@ -109,10 +117,10 @@ namespace Security {
  		}
 
 		delegate void sec_protocol_metadata_access_ocsp_response_handler_t (IntPtr block, IntPtr dispatchData);
- 		static sec_protocol_metadata_access_ocsp_response_handler_t static_OCSPReposeForPeer  = TrampolineOCSPReposeForPeer;
+ 		static sec_protocol_metadata_access_ocsp_response_handler_t static_OcspReposeForPeer  = TrampolineOcspReposeForPeer;
 
  		[MonoPInvokeCallback (typeof (sec_protocol_metadata_access_ocsp_response_handler_t))]
- 		static void TrampolineOCSPReposeForPeer (IntPtr block, IntPtr data)
+ 		static void TrampolineOcspReposeForPeer (IntPtr block, IntPtr data)
  		{
  			var del = BlockLiteral.GetTarget<Action<DispatchData>> (block);
  			if (del != null) {
@@ -125,7 +133,7 @@ namespace Security {
  		static extern unsafe void sec_protocol_metadata_access_ocsp_response (IntPtr handle, void *callback);
 
  		[BindingImpl (BindingImplOptions.Optimizable)]
- 		public void SetOCSPResponseForPeerHandler (Action<DispatchData> callback)
+ 		public void SetOcspResponseForPeerHandler (Action<DispatchData> callback)
  		{
  			unsafe {
  				if (callback == null) {
@@ -135,7 +143,7 @@ namespace Security {
 
  				BlockLiteral block_handler = new BlockLiteral ();
  				BlockLiteral *block_ptr_handler = &block_handler;
- 				block_handler.SetupBlockUnsafe (static_OCSPReposeForPeer, callback);
+ 				block_handler.SetupBlockUnsafe (static_OcspReposeForPeer, callback);
 
  				try {
  					sec_protocol_metadata_access_ocsp_response (GetCheckedHandle (), (void*) block_ptr_handler);

--- a/src/Security/SecProtocolMetadata.cs
+++ b/src/Security/SecProtocolMetadata.cs
@@ -51,9 +51,173 @@ namespace Security {
 
 		public bool EarlyDataAccepted => sec_protocol_metadata_get_early_data_accepted (GetCheckedHandle ()) != 0;
 
-		//
-		// MISSING: all the block APIs
-		//
+ 		[DllImport (Constants.SecurityLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		extern static bool sec_protocol_metadata_challenge_parameters_are_equal (IntPtr metadataA, IntPtr metadataB);
 
+		public static bool ParametersAreEqual (SecProtocolMetadata metadataA, SecProtocolMetadata metadataB)
+		{
+			return sec_protocol_metadata_challenge_parameters_are_equal (metadataA.GetCheckedHandle (), metadataB.GetCheckedHandle ());
+		}
+
+ 		[DllImport (Constants.SecurityLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		extern static bool sec_protocol_metadata_peers_are_equal (IntPtr metadataA, IntPtr metadataB);
+
+		public static bool PeersAreEqual (SecProtocolMetadata metadataA, SecProtocolMetadata metadataB)
+		{
+			return sec_protocol_metadata_peers_are_equal (metadataA.GetCheckedHandle (), metadataB.GetCheckedHandle ());
+		}
+
+#if !COREBUILD
+
+		delegate void sec_protocol_metadata_access_distinguished_names_handler_t (IntPtr block, IntPtr dispatchData);
+ 		static sec_protocol_metadata_access_distinguished_names_handler_t static_DistinguishedNamesForPeer  = TrampolineDistinguishedNamesForPeer;
+
+ 		[MonoPInvokeCallback (typeof (sec_protocol_metadata_access_distinguished_names_handler_t))]
+ 		static void TrampolineDistinguishedNamesForPeer (IntPtr block, IntPtr data)
+ 		{
+ 			var del = BlockLiteral.GetTarget<Action<DispatchData>> (block);
+ 			if (del != null) {
+ 				var dispatchData = new DispatchData (data, owns: false);
+ 				del (dispatchData);
+ 			}
+ 		}
+
+ 		[DllImport (Constants.SecurityLibrary)]
+ 		static extern unsafe void sec_protocol_metadata_access_distinguished_names (IntPtr handle, void *callback);
+
+ 		[BindingImpl (BindingImplOptions.Optimizable)]
+ 		public void SetDistinguishedNamesForPeerHandler (Action<DispatchData> callback)
+ 		{
+ 			unsafe {
+ 				if (callback == null) {
+ 					sec_protocol_metadata_access_distinguished_names (GetCheckedHandle (), null);
+ 					return;
+ 				}
+
+ 				BlockLiteral block_handler = new BlockLiteral ();
+ 				BlockLiteral *block_ptr_handler = &block_handler;
+ 				block_handler.SetupBlockUnsafe (static_DistinguishedNamesForPeer, callback);
+
+ 				try {
+ 					sec_protocol_metadata_access_distinguished_names (GetCheckedHandle (), (void*) block_ptr_handler);
+ 				} finally {
+ 					block_handler.CleanupBlock ();
+ 				}
+ 			}
+ 		}
+
+		delegate void sec_protocol_metadata_access_ocsp_response_handler_t (IntPtr block, IntPtr dispatchData);
+ 		static sec_protocol_metadata_access_ocsp_response_handler_t static_OCSPReposeForPeer  = TrampolineOCSPReposeForPeer;
+
+ 		[MonoPInvokeCallback (typeof (sec_protocol_metadata_access_ocsp_response_handler_t))]
+ 		static void TrampolineOCSPReposeForPeer (IntPtr block, IntPtr data)
+ 		{
+ 			var del = BlockLiteral.GetTarget<Action<DispatchData>> (block);
+ 			if (del != null) {
+ 				var dispatchData = new DispatchData (data, owns: false);
+ 				del (dispatchData);
+ 			}
+ 		}
+
+ 		[DllImport (Constants.SecurityLibrary)]
+ 		static extern unsafe void sec_protocol_metadata_access_ocsp_response (IntPtr handle, void *callback);
+
+ 		[BindingImpl (BindingImplOptions.Optimizable)]
+ 		public void SetOCSPResponseForPeerHandler (Action<DispatchData> callback)
+ 		{
+ 			unsafe {
+ 				if (callback == null) {
+ 					sec_protocol_metadata_access_ocsp_response (GetCheckedHandle (), null);
+ 					return;
+ 				}
+
+ 				BlockLiteral block_handler = new BlockLiteral ();
+ 				BlockLiteral *block_ptr_handler = &block_handler;
+ 				block_handler.SetupBlockUnsafe (static_OCSPReposeForPeer, callback);
+
+ 				try {
+ 					sec_protocol_metadata_access_ocsp_response (GetCheckedHandle (), (void*) block_ptr_handler);
+ 				} finally {
+ 					block_handler.CleanupBlock ();
+ 				}
+ 			}
+ 		}
+
+		delegate void sec_protocol_metadata_access_peer_certificate_chain_handler_t (IntPtr block, IntPtr certificate);
+ 		static sec_protocol_metadata_access_peer_certificate_chain_handler_t static_CertificateChainForPeer  = TrampolineCertificateChainForPeer;
+
+ 		[MonoPInvokeCallback (typeof (sec_protocol_metadata_access_peer_certificate_chain_handler_t))]
+ 		static void TrampolineCertificateChainForPeer (IntPtr block, IntPtr certificate)
+ 		{
+ 			var del = BlockLiteral.GetTarget<Action<SecCertificate>> (block);
+ 			if (del != null) {
+ 				var secCertificate = new SecCertificate (certificate, owns: false);
+ 				del (secCertificate);
+ 			}
+ 		}
+
+ 		[DllImport (Constants.SecurityLibrary)]
+ 		static extern unsafe void sec_protocol_metadata_access_peer_certificate_chain (IntPtr handle, void *callback);
+
+ 		[BindingImpl (BindingImplOptions.Optimizable)]
+ 		public void SetCertificateChainForPeerHandler (Action<SecCertificate> callback)
+ 		{
+ 			unsafe {
+ 				if (callback == null) {
+ 					sec_protocol_metadata_access_peer_certificate_chain (GetCheckedHandle (), null);
+ 					return;
+ 				}
+
+ 				BlockLiteral block_handler = new BlockLiteral ();
+ 				BlockLiteral *block_ptr_handler = &block_handler;
+ 				block_handler.SetupBlockUnsafe (static_CertificateChainForPeer, callback);
+
+ 				try {
+ 					sec_protocol_metadata_access_peer_certificate_chain (GetCheckedHandle (), (void*) block_ptr_handler);
+ 				} finally {
+ 					block_handler.CleanupBlock ();
+ 				}
+ 			}
+ 		}
+
+		delegate void sec_protocol_metadata_access_supported_signature_algorithms_handler_t (IntPtr block, ushort signatureAlgorithm);
+ 		static sec_protocol_metadata_access_supported_signature_algorithms_handler_t static_SignatureAlgorithmsForPeer  = TrampolineSignatureAlgorithmsForPeer;
+
+ 		[MonoPInvokeCallback (typeof (sec_protocol_metadata_access_supported_signature_algorithms_handler_t))]
+ 		static void TrampolineSignatureAlgorithmsForPeer (IntPtr block, ushort signatureAlgorithm)
+ 		{
+ 			var del = BlockLiteral.GetTarget<Action<ushort>> (block);
+ 			if (del != null) {
+ 				del (signatureAlgorithm);
+ 			}
+ 		}
+
+ 		[DllImport (Constants.SecurityLibrary)]
+ 		static extern unsafe void sec_protocol_metadata_access_supported_signature_algorithms (IntPtr handle, void *callback);
+
+ 		[BindingImpl (BindingImplOptions.Optimizable)]
+ 		public void SetSignatureAlgorithmsForPeerHandler (Action<ushort> callback)
+ 		{
+ 			unsafe {
+ 				if (callback == null){
+ 					sec_protocol_metadata_access_supported_signature_algorithms (GetCheckedHandle (), null);
+ 					return;
+ 				}
+
+ 				BlockLiteral block_handler = new BlockLiteral ();
+ 				BlockLiteral *block_ptr_handler = &block_handler;
+ 				block_handler.SetupBlockUnsafe (static_SignatureAlgorithmsForPeer, callback);
+
+ 				try {
+ 					sec_protocol_metadata_access_supported_signature_algorithms (GetCheckedHandle (), (void*) block_ptr_handler);
+ 				} finally {
+ 					block_handler.CleanupBlock ();
+ 				}
+ 			}
+ 		}
+
+#endif
 	}
 }

--- a/src/Security/SecProtocolMetadata.cs
+++ b/src/Security/SecProtocolMetadata.cs
@@ -57,6 +57,8 @@ namespace Security {
 
 		public static bool ChallengeParametersAreEqual (SecProtocolMetadata metadataA, SecProtocolMetadata metadataB)
 		{
+			if (metadataA == null && metadataB == null)
+				return false;  // This was tested in a native app. We do copy the behaviour.
 			if (metadataA == null)
 				throw new ArgumentNullException (nameof (metadataA));
 			if (metadataB == null)
@@ -70,6 +72,8 @@ namespace Security {
 
 		public static bool PeersAreEqual (SecProtocolMetadata metadataA, SecProtocolMetadata metadataB)
 		{
+			if (metadataA == null && metadataB == null)
+				return false;  // This was tested in a native app. We do copy the behaviour.
 			if (metadataA == null)
 				throw new ArgumentNullException (nameof (metadataA));
 			if (metadataB == null)

--- a/src/Security/SecProtocolMetadata.cs
+++ b/src/Security/SecProtocolMetadata.cs
@@ -57,12 +57,10 @@ namespace Security {
 
 		public static bool ChallengeParametersAreEqual (SecProtocolMetadata metadataA, SecProtocolMetadata metadataB)
 		{
-			if (metadataA == null && metadataB == null)
-				return false;  // This was tested in a native app. We do copy the behaviour.
 			if (metadataA == null)
-				throw new ArgumentNullException (nameof (metadataA));
-			if (metadataB == null)
-				throw new ArgumentNullException (nameof (metadataB));
+				return metadataB == null;
+			else if (metadataB == null)
+				return false; // This was tested in a native app. We do copy the behaviour.
 			return sec_protocol_metadata_challenge_parameters_are_equal (metadataA.GetCheckedHandle (), metadataB.GetCheckedHandle ());
 		}
 
@@ -72,12 +70,10 @@ namespace Security {
 
 		public static bool PeersAreEqual (SecProtocolMetadata metadataA, SecProtocolMetadata metadataB)
 		{
-			if (metadataA == null && metadataB == null)
-				return false;  // This was tested in a native app. We do copy the behaviour.
 			if (metadataA == null)
-				throw new ArgumentNullException (nameof (metadataA));
-			if (metadataB == null)
-				throw new ArgumentNullException (nameof (metadataB));
+				return metadataB == null;
+			else if (metadataB == null)
+				return false; // This was tested in a native app. We do copy the behaviour.
 			return sec_protocol_metadata_peers_are_equal (metadataA.GetCheckedHandle (), metadataB.GetCheckedHandle ());
 		}
 

--- a/tests/xtro-sharpie/iOS-Security.todo
+++ b/tests/xtro-sharpie/iOS-Security.todo
@@ -1,12 +1,7 @@
 !missing-pinvoke! sec_certificate_copy_ref is not bound
-!missing-pinvoke! sec_protocol_metadata_access_distinguished_names is not bound
-!missing-pinvoke! sec_protocol_metadata_access_ocsp_response is not bound
-!missing-pinvoke! sec_protocol_metadata_access_peer_certificate_chain is not bound
-!missing-pinvoke! sec_protocol_metadata_access_supported_signature_algorithms is not bound
 !missing-pinvoke! sec_protocol_metadata_challenge_parameters_are_equal is not bound
 !missing-pinvoke! sec_protocol_metadata_create_secret is not bound
 !missing-pinvoke! sec_protocol_metadata_create_secret_with_context is not bound
-!missing-pinvoke! sec_protocol_metadata_peers_are_equal is not bound
 !missing-pinvoke! sec_protocol_options_set_challenge_block is not bound
 !missing-pinvoke! sec_protocol_options_set_verify_block is not bound
 !missing-pinvoke! SecCertificateCopyKey is not bound

--- a/tests/xtro-sharpie/iOS-Security.todo
+++ b/tests/xtro-sharpie/iOS-Security.todo
@@ -1,5 +1,4 @@
 !missing-pinvoke! sec_certificate_copy_ref is not bound
-!missing-pinvoke! sec_protocol_metadata_challenge_parameters_are_equal is not bound
 !missing-pinvoke! sec_protocol_metadata_create_secret is not bound
 !missing-pinvoke! sec_protocol_metadata_create_secret_with_context is not bound
 !missing-pinvoke! sec_protocol_options_set_challenge_block is not bound

--- a/tests/xtro-sharpie/macOS-Security.todo
+++ b/tests/xtro-sharpie/macOS-Security.todo
@@ -1,13 +1,8 @@
 !missing-field! kSecCodeInfoRuntimeVersion not bound
 !missing-pinvoke! sec_certificate_copy_ref is not bound
-!missing-pinvoke! sec_protocol_metadata_access_distinguished_names is not bound
-!missing-pinvoke! sec_protocol_metadata_access_ocsp_response is not bound
-!missing-pinvoke! sec_protocol_metadata_access_peer_certificate_chain is not bound
-!missing-pinvoke! sec_protocol_metadata_access_supported_signature_algorithms is not bound
 !missing-pinvoke! sec_protocol_metadata_challenge_parameters_are_equal is not bound
 !missing-pinvoke! sec_protocol_metadata_create_secret is not bound
 !missing-pinvoke! sec_protocol_metadata_create_secret_with_context is not bound
-!missing-pinvoke! sec_protocol_metadata_peers_are_equal is not bound
 !missing-pinvoke! sec_protocol_options_set_challenge_block is not bound
 !missing-pinvoke! sec_protocol_options_set_verify_block is not bound
 !missing-pinvoke! SecCertificateCopyKey is not bound

--- a/tests/xtro-sharpie/macOS-Security.todo
+++ b/tests/xtro-sharpie/macOS-Security.todo
@@ -1,6 +1,5 @@
 !missing-field! kSecCodeInfoRuntimeVersion not bound
 !missing-pinvoke! sec_certificate_copy_ref is not bound
-!missing-pinvoke! sec_protocol_metadata_challenge_parameters_are_equal is not bound
 !missing-pinvoke! sec_protocol_metadata_create_secret is not bound
 !missing-pinvoke! sec_protocol_metadata_create_secret_with_context is not bound
 !missing-pinvoke! sec_protocol_options_set_challenge_block is not bound

--- a/tests/xtro-sharpie/tvOS-Security.todo
+++ b/tests/xtro-sharpie/tvOS-Security.todo
@@ -1,12 +1,7 @@
 !missing-pinvoke! sec_certificate_copy_ref is not bound
-!missing-pinvoke! sec_protocol_metadata_access_distinguished_names is not bound
-!missing-pinvoke! sec_protocol_metadata_access_ocsp_response is not bound
-!missing-pinvoke! sec_protocol_metadata_access_peer_certificate_chain is not bound
-!missing-pinvoke! sec_protocol_metadata_access_supported_signature_algorithms is not bound
 !missing-pinvoke! sec_protocol_metadata_challenge_parameters_are_equal is not bound
 !missing-pinvoke! sec_protocol_metadata_create_secret is not bound
 !missing-pinvoke! sec_protocol_metadata_create_secret_with_context is not bound
-!missing-pinvoke! sec_protocol_metadata_peers_are_equal is not bound
 !missing-pinvoke! sec_protocol_options_set_challenge_block is not bound
 !missing-pinvoke! sec_protocol_options_set_verify_block is not bound
 !missing-pinvoke! SecCertificateCopyKey is not bound

--- a/tests/xtro-sharpie/tvOS-Security.todo
+++ b/tests/xtro-sharpie/tvOS-Security.todo
@@ -1,5 +1,4 @@
 !missing-pinvoke! sec_certificate_copy_ref is not bound
-!missing-pinvoke! sec_protocol_metadata_challenge_parameters_are_equal is not bound
 !missing-pinvoke! sec_protocol_metadata_create_secret is not bound
 !missing-pinvoke! sec_protocol_metadata_create_secret_with_context is not bound
 !missing-pinvoke! sec_protocol_options_set_challenge_block is not bound

--- a/tests/xtro-sharpie/watchOS-Security.todo
+++ b/tests/xtro-sharpie/watchOS-Security.todo
@@ -1,12 +1,6 @@
 !missing-pinvoke! sec_certificate_copy_ref is not bound
-!missing-pinvoke! sec_protocol_metadata_access_distinguished_names is not bound
-!missing-pinvoke! sec_protocol_metadata_access_ocsp_response is not bound
-!missing-pinvoke! sec_protocol_metadata_access_peer_certificate_chain is not bound
-!missing-pinvoke! sec_protocol_metadata_access_supported_signature_algorithms is not bound
-!missing-pinvoke! sec_protocol_metadata_challenge_parameters_are_equal is not bound
 !missing-pinvoke! sec_protocol_metadata_create_secret is not bound
 !missing-pinvoke! sec_protocol_metadata_create_secret_with_context is not bound
-!missing-pinvoke! sec_protocol_metadata_peers_are_equal is not bound
 !missing-pinvoke! sec_protocol_options_set_challenge_block is not bound
 !missing-pinvoke! sec_protocol_options_set_verify_block is not bound
 !missing-pinvoke! SecCertificateCopyKey is not bound


### PR DESCRIPTION
This is a partial commit that contains most of the missing methods for
the handlers API on SecProtocolMetadata. The not added ones are more
complicated and will be added in a later commit.