### PR TITLE
[Network] Small change in NWParameters to use a property for RequireInterface.

### DIFF
--- a/src/Network/NWParameters.cs
+++ b/src/Network/NWParameters.cs
@@ -234,15 +234,10 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		static extern void nw_parameters_require_interface (nw_parameters_t parameters, IntPtr handleInterface);
 
-		public void RequireInterface (NWInterface iface)
-		{
-			nw_parameters_require_interface (GetCheckedHandle (), iface.GetHandle ());
-		}
-
 		[DllImport (Constants.NetworkLibrary)]
 		static extern IntPtr nw_parameters_copy_required_interface (nw_parameters_t parameters);
 
-		public NWInterface Interface {
+		public NWInterface RequireInterface {
 			get {
 				var iface = nw_parameters_copy_required_interface (GetCheckedHandle ());
 
@@ -250,6 +245,9 @@ namespace Network {
 					return null;
 
 				return new NWInterface (iface, owns: true);
+			}
+			set {
+				nw_parameters_require_interface (GetCheckedHandle (), value.GetHandle ());
 			}
 		}
 

--- a/src/Network/NWParameters.cs
+++ b/src/Network/NWParameters.cs
@@ -237,7 +237,7 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		static extern IntPtr nw_parameters_copy_required_interface (nw_parameters_t parameters);
 
-		public NWInterface RequireInterface {
+		public NWInterface RequiredInterface {
 			get {
 				var iface = nw_parameters_copy_required_interface (GetCheckedHandle ());
 

--- a/src/Network/NWProtocolMetadata.cs
+++ b/src/Network/NWProtocolMetadata.cs
@@ -48,7 +48,7 @@ namespace Network {
 
 		[DllImport (Constants.NetworkLibrary)]
 		static extern OS_nw_protocol_metadata nw_udp_create_metadata ();
-		public static NWProtocolMetadata CreateUDPMetadata ()
+		public static NWProtocolMetadata CreateUdpMetadata ()
 		{
 			return new NWProtocolMetadata (nw_udp_create_metadata (), owns: true);
 		}

--- a/tests/monotouch-test/Network/NWParametersTest.cs
+++ b/tests/monotouch-test/Network/NWParametersTest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !__WATCHOS__
+using System;
 using System.Collections.Generic;
 using System.Threading;
 #if XAMCORE_2_0
@@ -18,6 +19,8 @@ using NUnit.Framework;
 
 namespace MonoTouchFixtures.Network {
 
+	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NWParametersTest {
 
 		AutoResetEvent secureEvent;  // used to let us know the handler was indeed called.
@@ -375,3 +378,4 @@ namespace MonoTouchFixtures.Network {
 		}
 	}
 }
+#endif

--- a/tests/monotouch-test/Network/NWParametersTest.cs
+++ b/tests/monotouch-test/Network/NWParametersTest.cs
@@ -1,0 +1,377 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+#if XAMCORE_2_0
+using CoreFoundation;
+using Foundation;
+using Network;
+using ObjCRuntime;
+using Security;
+#else
+using MonoTouch.CoreFoundation;
+using MonoTouch.Foundation;
+using MonoTouch.Network;
+using MonoTouch.Security;
+#endif
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.Network {
+
+	public class NWParametersTest {
+
+		AutoResetEvent secureEvent;  // used to let us know the handler was indeed called.
+		AutoResetEvent configureEvent;  // used to let us know the handler was indeed called.
+		AutoResetEvent connectedEvent;  // used to let us know when the connection was established so that we can access the NWPath 
+		bool secureConnectionWasSet = false;
+		bool protocolConfigured = false;
+		List<NWInterface> interfaces = new List<NWInterface> ();
+
+		[SetUp]
+		public void SetUp ()
+		{
+			TestRuntime.AssertXcodeVersion (10, 0);
+			secureEvent = new AutoResetEvent(false);
+			configureEvent = new AutoResetEvent(false);
+			connectedEvent = new AutoResetEvent(false);
+			secureConnectionWasSet = false;
+			protocolConfigured = false;
+			interfaces = new List<NWInterface> ();
+			// we create a connection which we are going to use to get the availabe
+			// interfaces, that way we can later test protperties of the NWParameters class.
+			using (var parameters = NWParameters.CreateUdp ())
+			using (var endpoint = NWEndpoint.Create ("wwww.google.com", "80"))
+			using (var connection = new NWConnection (endpoint, parameters)) {
+				connection.SetStateChangeHandler (ConnectionStateHandler);
+				connection.SetQueue (DispatchQueue.MainQueue);
+				connection.Start ();
+				connectedEvent.WaitOne (500);
+				using (var path = connection.CurrentPath)
+				{
+					path.EnumerateInterfaces (EnumerateInterfacesHandler);
+				}
+			}
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			secureEvent = null;
+			secureConnectionWasSet = false;
+			protocolConfigured = false;
+			foreach (var i in interfaces) {
+				i.Dispose ();
+			}
+		}
+
+		void ConnectionStateHandler (NWConnectionState state, NWError error)
+		{
+			var errno = (SslStatus)(error != null ? error.ErrorCode : 0);
+			switch (state){
+			case NWConnectionState.Ready:
+				connectedEvent.Set ();
+				break;
+			}
+		}
+
+		void EnumerateInterfacesHandler (NWInterface nwInterface)
+		{
+			interfaces.Add (nwInterface);
+		}
+
+		Action<NWProtocolOptions> CreateTlsHandler ()
+		{
+			return (NWProtocolOptions options) => {
+				secureConnectionWasSet = true;
+				secureEvent.Set ();
+			};
+		}
+
+		Action<NWProtocolOptions> CreateConfigureProtocolHandler ()
+		{
+			return (NWProtocolOptions options) => {
+				protocolConfigured = true;
+				configureEvent.Set ();
+			};
+		}
+
+		[Test]
+		public void CreateSecureUpdTest ()
+		{
+			var setUpTls = CreateTlsHandler ();
+			var setUpProtocol = CreateConfigureProtocolHandler ();
+
+			using (var parameters = NWParameters.CreateSecureUdp (configureTls: setUpTls, configureUdp: setUpProtocol))
+			using (var endpoint = NWEndpoint.Create ("wwww.google.com", "80"))
+			using (var connection = new NWConnection (endpoint, parameters)) {
+				connection.SetQueue (DispatchQueue.MainQueue);
+				connection.Start ();
+				secureEvent.WaitOne ();
+				configureEvent.WaitOne ();
+				connection.Cancel ();
+				Assert.True (secureConnectionWasSet, "Configure TLS handler was not called.");
+				Assert.True (protocolConfigured, "Protocol configure handler was not called.");
+			}
+		}
+
+		[Test]
+		public void CreateSecureUpdTestDoNotSetUpProtocol ()
+		{
+			var setUpTls = CreateTlsHandler ();
+
+			using (var parameters = NWParameters.CreateSecureUdp (configureTls: setUpTls))
+			using (var endpoint = NWEndpoint.Create ("wwww.google.com", "80"))
+			using (var connection = new NWConnection (endpoint, parameters)) {
+				connection.SetQueue (DispatchQueue.MainQueue);
+				connection.Start ();
+				secureEvent.WaitOne ();
+				connection.Cancel ();
+				Assert.True (secureConnectionWasSet, "Configure TLS handler was not called.");
+				Assert.False (protocolConfigured, "Protocol configure handler was called.");
+			}
+		}
+
+		[Test]
+		public void CreateSecureUpdTestDoNotSetUpTls ()
+		{
+			var setUpProtocol = CreateConfigureProtocolHandler ();
+
+			using (var parameters = NWParameters.CreateSecureUdp (configureTls: null, configureUdp: setUpProtocol))
+			using (var endpoint = NWEndpoint.Create ("wwww.google.com", "80"))
+			using (var connection = new NWConnection (endpoint, parameters)) {
+				connection.SetQueue (DispatchQueue.MainQueue);
+				connection.Start ();
+				configureEvent.WaitOne ();
+				connection.Cancel ();
+				Assert.False (secureConnectionWasSet, "Configure TLS handler was not called.");
+				Assert.True (protocolConfigured, "Protocol configure handler was not called.");
+			}
+		}
+
+		[Test]
+		public void CreateSecureTcpTest ()
+		{
+			var setUpTls = CreateTlsHandler ();
+			var setUpProtocol = CreateConfigureProtocolHandler ();
+
+			using (var parameters = NWParameters.CreateSecureTcp (configureTls: setUpTls, configureTcp: setUpProtocol))
+			using (var endpoint = NWEndpoint.Create ("wwww.google.com", "80"))
+			using (var connection = new NWConnection (endpoint, parameters)) {
+				connection.SetQueue (DispatchQueue.MainQueue);
+				connection.Start ();
+				secureEvent.WaitOne ();
+				configureEvent.WaitOne ();
+				connection.Cancel ();
+				Assert.True (secureConnectionWasSet, "Configure TLS handler was not called.");
+				Assert.True (protocolConfigured, "Protocol configure handler was not called.");
+			}
+		}
+
+		[Test]
+		public void CreateSecureTcpTestDoNotSetUpProtocol ()
+		{
+			var setUpTls = CreateTlsHandler ();
+			var setUpProtocol = CreateConfigureProtocolHandler ();
+
+			using (var parameters = NWParameters.CreateSecureTcp (configureTls: setUpTls))
+			using (var endpoint = NWEndpoint.Create ("wwww.google.com", "80"))
+			using (var connection = new NWConnection (endpoint, parameters)) {
+				connection.SetQueue (DispatchQueue.MainQueue);
+				connection.Start ();
+				secureEvent.WaitOne ();
+				connection.Cancel ();
+				Assert.True (secureConnectionWasSet, "Configure TLS handler was not called.");
+				Assert.False (protocolConfigured, "Protocol configure handler was called.");
+			}
+		}
+
+		[Test]
+		public void CreateSecureTcpTestDoNotSetUpTls ()
+		{
+			var setUpProtocol = CreateConfigureProtocolHandler ();
+
+			using (var parameters = NWParameters.CreateSecureTcp (configureTls: null, configureTcp: setUpProtocol))
+			using (var endpoint = NWEndpoint.Create ("wwww.google.com", "80"))
+			using (var connection = new NWConnection (endpoint, parameters)) {
+				connection.SetQueue (DispatchQueue.MainQueue);
+				connection.Start ();
+				configureEvent.WaitOne ();
+				connection.Cancel ();
+				Assert.False (secureConnectionWasSet, "Configure TLS handler was called.");
+				Assert.True (protocolConfigured, "Protocol configure handler was not called.");
+			}
+		}
+
+		[Test]
+		public void MultiPathServicePropertyTest ()
+		{
+			using (var parameters = new NWParameters ())
+			{
+				var defaultValue = parameters.MultipathService;
+				Assert.AreEqual (defaultValue, NWMultiPathService.Disabled, "Default value changed.");
+				var newValue = NWMultiPathService.Aggregate;
+				parameters.MultipathService = newValue;
+				Assert.AreEqual (newValue, parameters.MultipathService, "New value was not stored.");
+			}
+		}
+
+		[Test]
+		public void ProtocolStackPropertyTest ()
+		{
+			using (var parameters = new NWParameters ())
+			{
+				var stack = parameters.ProtocolStack;
+				Assert.AreNotEqual (IntPtr.Zero, stack.Handle);
+			}
+		}
+
+		[Test]
+		public void LocalOnlyPropertyTest ()
+		{
+			using (var parameters = new NWParameters ())
+			{
+				var defaultValue = parameters.LocalOnly;
+				Assert.False (defaultValue, "Default value changed.");
+				parameters.LocalOnly = true;
+				Assert.True (parameters.LocalOnly, "New value was not stored.");
+			}
+		}
+
+		[Test]
+		public void PreferNoProxyPropertyTest ()
+		{
+			using (var parameters = new NWParameters ())
+			{
+				var defaultValue = parameters.PreferNoProxy;
+				Assert.False (defaultValue, "Default value changed.");
+				parameters.PreferNoProxy = true;
+				Assert.True (parameters.PreferNoProxy, "New value was not stored.");
+			}
+		}
+
+		[Test]
+		public void ExpiredDnsBehaviorPropertyTest ()
+		{
+			using (var parameters = new NWParameters ())
+			{
+				var defaultValue = parameters.ExpiredDnsBehavior;
+				Assert.AreEqual (NWParametersExpiredDnsBehavior.Default, defaultValue, "Default value changed.");
+				parameters.ExpiredDnsBehavior = NWParametersExpiredDnsBehavior.Allow;
+				Assert.AreEqual (NWParametersExpiredDnsBehavior.Allow, parameters.ExpiredDnsBehavior, "New value was not stored.");
+			}
+		}
+
+		[Test]
+		public void RequireInterfacePropertyTest ()
+		{
+
+			using (var parameters = new NWParameters ())
+			{
+				var defaultValue = parameters.RequireInterface;
+				Assert.IsNull (defaultValue, "Default value changed.");
+				// try to set a null value, we should have no issues
+				parameters.RequireInterface = null;
+				Assert.IsNull (parameters.RequireInterface, "Value should still be null.");
+				parameters.RequireInterface = interfaces[0];
+				Assert.AreNotEqual (IntPtr.Zero, parameters.RequireInterface.Handle, "New value was not set.");
+			}
+		}
+
+		[Test]
+		public void ProhibitInterfaceTest ()
+		{
+			using (var parameters = new NWParameters ())
+			{
+				Assert.Throws<ArgumentNullException> (() => parameters.ProhibitInterface (null), "");
+				Assert.AreNotEqual (0, interfaces.Count, "No network interfaces found.");
+				parameters.ProhibitInterface (interfaces[0]);
+			}
+		} 
+
+		[Test]
+		public void RequiredInterfaceTypePropertyTest ()
+		{
+			using (var parameters = new NWParameters ())
+			{
+				var defaultValue = parameters.RequiredInterfaceType;
+				Assert.AreEqual (NWInterfaceType.Other, defaultValue, "Default value changed.");
+				parameters.RequiredInterfaceType = NWInterfaceType.Wifi;
+				Assert.AreEqual (NWInterfaceType.Wifi, parameters.RequiredInterfaceType, "BNe value was not stored.");
+			}
+		}
+
+		[Test]
+		public void ProhibitInterfaceTypeTest ()
+		{
+			using (var parameters = new NWParameters ())
+			{
+				var types = new List<NWInterfaceType> ();
+				parameters.ProhibitInterfaceType (NWInterfaceType.Wifi);
+				parameters.IterateProhibitedInterfaces ((type) => {types.Add (type); return true;} );
+				Assert.True (types.Contains (NWInterfaceType.Wifi), "Type was not prohibited.");	
+			}
+		}
+
+		[Test]
+		public void ReuseLocalAddressPropertyTest ()
+		{
+			using (var parameters = new NWParameters ())
+			{
+				var defaultValue = parameters.ReuseLocalAddress;
+				Assert.False (defaultValue, "Default value changed.");
+				parameters.ReuseLocalAddress = true;
+				Assert.True (parameters.ReuseLocalAddress, "New value was not stored.");
+			}
+		}
+
+		[Test]
+		public void FastOpenEnabledPropertyTest ()
+		{
+			using (var parameters = new NWParameters ())
+			{
+				var defaultValue = parameters.FastOpenEnabled;
+				Assert.False (defaultValue, "Defalue value changed.");
+				parameters.FastOpenEnabled = true;
+				Assert.True (parameters.FastOpenEnabled, "New value was not stored.");
+			}
+		}
+
+		[Test]
+		public void ServiceClassPropertyTest ()
+		{
+			using (var parameters = new NWParameters ())
+			{
+				var defaultValue = parameters.ServiceClass;
+				Assert.AreEqual (NWServiceClass.BestEffort, defaultValue, "Default value changed.");
+				parameters.ServiceClass = NWServiceClass.InteractiveVideo;
+				Assert.AreEqual (NWServiceClass.InteractiveVideo, parameters.ServiceClass, "New value was not stored.");
+			}
+		}
+
+		[Test]
+		public void LocalEndpointPropertyTest ()
+		{
+			Assert.Ignore ("nw_parameters_copy_local_endpoint always return null. Rdar filled 44095278.");
+			using (var parameters = NWParameters.CreateUdp ())
+			using (var endpoint = NWEndpoint.Create ("wwww.google.com", "80"))
+			{
+				var defaultValue = parameters.LocalEndpoint;
+				Assert.IsNull (defaultValue, "Default value changed.");
+				parameters.LocalEndpoint = endpoint;
+				Assert.IsNotNull (parameters.LocalEndpoint, "New value was not stored.");
+			}
+		}
+
+		[Test]
+		public void IncludePeerToPeerPropertyTest ()
+		{
+			using (var parameters = new NWParameters ())
+			{
+				var defaultValue = parameters.IncludePeerToPeer;
+				Assert.False (defaultValue, "Default value changed.");
+				parameters.IncludePeerToPeer = true;
+				Assert.True (parameters.IncludePeerToPeer, "New value was not stored.");
+			}
+		}
+	}
+}

--- a/tests/monotouch-test/Network/NWParametersTest.cs
+++ b/tests/monotouch-test/Network/NWParametersTest.cs
@@ -262,18 +262,18 @@ namespace MonoTouchFixtures.Network {
 		}
 
 		[Test]
-		public void RequireInterfacePropertyTest ()
+		public void RequiredInterfacePropertyTest ()
 		{
 
 			using (var parameters = new NWParameters ())
 			{
-				var defaultValue = parameters.RequireInterface;
+				var defaultValue = parameters.RequiredInterface;
 				Assert.IsNull (defaultValue, "Default value changed.");
 				// try to set a null value, we should have no issues
-				parameters.RequireInterface = null;
-				Assert.IsNull (parameters.RequireInterface, "Value should still be null.");
-				parameters.RequireInterface = interfaces[0];
-				Assert.AreNotEqual (IntPtr.Zero, parameters.RequireInterface.Handle, "New value was not set.");
+				parameters.RequiredInterface = null;
+				Assert.IsNull (parameters.RequiredInterface, "Value should still be null.");
+				parameters.RequiredInterface = interfaces[0];
+				Assert.AreNotEqual (IntPtr.Zero, parameters.RequiredInterface.Handle, "New value was not set.");
 			}
 		}
 

--- a/tests/monotouch-test/Network/NWProtocolOptionsTest.cs
+++ b/tests/monotouch-test/Network/NWProtocolOptionsTest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !__WATCHOS__
+using System;
 #if XAMCORE_2_0
 using Foundation;
 using Network;
@@ -11,6 +12,9 @@ using MonoTouch.Network;
 using NUnit.Framework;
 
 namespace MonoTouchFixtures.Network {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
 	public class NWProtocolOptionsTest {
 
 		[SetUp]
@@ -48,3 +52,4 @@ namespace MonoTouchFixtures.Network {
 		}
 	}
 }
+#endif

--- a/tests/monotouch-test/Network/NWProtocolOptionsTest.cs
+++ b/tests/monotouch-test/Network/NWProtocolOptionsTest.cs
@@ -1,0 +1,59 @@
+﻿using System;
+#if XAMCORE_2_0
+using Foundation;
+using Network;
+using ObjCRuntime;
+#else
+using MonoTouch.Foundation;
+using MonoTouch.Network;
+#endif
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.Network {
+	public class NWProtocolOptionsTest {
+
+		[SetUp]
+		public void SetUp ()
+		{
+			TestRuntime.AssertXcodeVersion (10, 0);
+		}
+
+		[Test]
+		public void CreateTlsTest ()
+		{
+			TestRuntime.AssertSystemVersion (PlatformName.iOS, 12, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 14, throwIfOtherPlatform: false);
+
+			using (var options = NWProtocolOptions.CreateTls ()) {
+				var sec = options.TlsProtocolOptions;
+				// we cannot test much more :(
+				Assert.AreNotEqual (IntPtr.Zero, options.Handle);
+			}
+		}
+
+		[Test]
+		public void CreateTcpTest ()
+		{
+			TestRuntime.AssertSystemVersion (PlatformName.iOS, 12, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 14, throwIfOtherPlatform: false);
+
+			using (var options = NWProtocolOptions.CreateTcp ()) {
+				// we cannot test much more :(
+				Assert.AreNotEqual (IntPtr.Zero, options.Handle);
+			}
+		}
+
+		[Test]
+		public void CreateUdpTest ()
+		{
+			TestRuntime.AssertSystemVersion (PlatformName.iOS, 12, 0, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 14, throwIfOtherPlatform: false);
+
+			using (var options = NWProtocolOptions.CreateUdp ()) {
+				// we cannot test much more :(
+				Assert.AreNotEqual (IntPtr.Zero, options.Handle);
+			}
+		}
+	}
+}

--- a/tests/monotouch-test/Network/NWProtocolOptionsTest.cs
+++ b/tests/monotouch-test/Network/NWProtocolOptionsTest.cs
@@ -22,9 +22,6 @@ namespace MonoTouchFixtures.Network {
 		[Test]
 		public void CreateTlsTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 12, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 14, throwIfOtherPlatform: false);
-
 			using (var options = NWProtocolOptions.CreateTls ()) {
 				var sec = options.TlsProtocolOptions;
 				// we cannot test much more :(
@@ -35,9 +32,6 @@ namespace MonoTouchFixtures.Network {
 		[Test]
 		public void CreateTcpTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 12, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 14, throwIfOtherPlatform: false);
-
 			using (var options = NWProtocolOptions.CreateTcp ()) {
 				// we cannot test much more :(
 				Assert.AreNotEqual (IntPtr.Zero, options.Handle);
@@ -47,9 +41,6 @@ namespace MonoTouchFixtures.Network {
 		[Test]
 		public void CreateUdpTest ()
 		{
-			TestRuntime.AssertSystemVersion (PlatformName.iOS, 12, 0, throwIfOtherPlatform: false);
-			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 14, throwIfOtherPlatform: false);
-
 			using (var options = NWProtocolOptions.CreateUdp ()) {
 				// we cannot test much more :(
 				Assert.AreNotEqual (IntPtr.Zero, options.Handle);


### PR DESCRIPTION
During the tests I noticed that a method in NWParameters could be used
as a set for a property. Since the API has not yet been released, I made
the appropiate change.