### PR TITLE
[tests] Ignore RuntimeTest.MainThreadDeallocationTest if all optimizations are enabled and not linking everything. Fixes #4566.

### DIFF
--- a/tests/bindings-test/RuntimeTest.cs
+++ b/tests/bindings-test/RuntimeTest.cs
@@ -59,6 +59,11 @@ namespace Xamarin.Tests
 		[Test]
 		public void MainThreadDeallocationTest ()
 		{
+#if OPTIMIZEALL
+			if (!TestRuntime.IsLinkAll)
+				Assert.Ignore ("This test must be processed by the linker if all optimizations are turned on.");
+#endif
+
 			ObjCBlockTester.CallAssertMainThreadBlockRelease ((callback) => {
 				callback (42);
 			});


### PR DESCRIPTION
This test contains code that requires the dynamic registrar unless the code is
optimized, and it's only optimized if the assembly is linked, which only
happens if linking all assemblies.

So disable the test if dynamic registrar is removed (which happens when all
optimizations are enabled) and the assembly isn't linked.

Fixes https://github.com/xamarin/xamarin-macios/issues/4566.