### PR TITLE
mono-2018-08: use coop transitions for monomac

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -62,13 +62,13 @@ XCODE_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_9.4.xip
 XCODE_DEVELOPER_ROOT=/Applications/Xcode94.app/Contents/Developer
 
 # Minimum Mono version
-MIN_MONO_VERSION=5.18.0.15
+MIN_MONO_VERSION=5.18.0.68
 MAX_MONO_VERSION=5.18.99
-MIN_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2018-08/7/f123d67e048465fdcc980059e7ec70daf9e0f7cc/MonoFramework-MDK-5.18.0.15.macos10.xamarin.universal.pkg
+MIN_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2018-08/46/ad0854917ee4a71cbdb24f5507793d5a863bb893/MonoFramework-MDK-5.18.0.68.macos10.xamarin.universal.pkg
 
 # Minimum Mono version for Xamarin.Mac apps using the system mono
-MIN_XM_MONO_VERSION=5.14.0.136
-MIN_XM_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2018-04/111/07c8f25fe536dbb7e244f965aa3f9a871f41e953/MonoFramework-MDK-5.14.0.136.macos10.xamarin.universal.pkg
+MIN_XM_MONO_VERSION=5.18.0.68
+MIN_XM_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2018-08/46/ad0854917ee4a71cbdb24f5507793d5a863bb893/MonoFramework-MDK-5.18.0.68.macos10.xamarin.universal.pkg
 
 # Minimum Visual Studio version
 MIN_VISUAL_STUDIO_URL=https://download.visualstudio.microsoft.com/download/pr/11550896/783d2219a348f93b6988fb415951788a/VisualStudioForMac-Preview-7.4.0.985.dmg

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -72,7 +72,7 @@ const char *xamarin_arch_name = "x86_64";
 const char *xamarin_arch_name = NULL;
 #endif
 
-#if TARGET_OS_WATCH
+#if TARGET_OS_WATCH || MONOMAC
 bool xamarin_is_gc_coop = true;
 #else
 bool xamarin_is_gc_coop = false;

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -342,9 +342,8 @@ public:
 #endif /* !TARGET_OS_WATCH */
 
 // Once we have one mono clone again the TARGET_OS_WATCH
-// condition should be removed (DYNAMIC_MONO_RUNTIME should still
-// be here though).
-#if TARGET_OS_WATCH && !defined (DYNAMIC_MONO_RUNTIME)
+// condition should be removed.
+#if TARGET_OS_WATCH || MONOMAC
 #define MONO_THREAD_ATTACH \
 	do { \
 		gpointer __thread_dummy; \


### PR DESCRIPTION
With `2018-08` (nee 5.18) Mono uses hybrid suspend by default.

Hybrid suspend use cooperative suspend for threads that are running managed code or native Mono runtime code (or other code such as XamMac code marked with GC Unsafe regions) and preemptive suspend for threads that are running other code (such as P/Invokes, blocking system calls, and other code marked by GC Safe regions).

Every mono API function called from XM (listed in the `runtime/exports.t4` file) has been wrapped inside to perform GC Unsafe transitions when called.

This PR changes XM to use the coop attach/detach functions.  If hybrid suspend is being used, these will ensure that when threads detach they will be left in GC Safe mode.  (If preemptive suspend is used, the coop attach/detach just amount to the same thing as the JIT attach functions from before).

Also bump the required minimum system mono version for running XM apps to 5.18.0.68.

Fixes #4723 