### PR TITLE
[mtouch] add mixed-mode support

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -110,7 +110,7 @@ namespace Xamarin.iOS.Tasks
 		public bool UseInterpreter { get; set; }
 
 		[Required]
-		public bool UseInterpreterMixed { get; set; }
+		public string Interpreter { get; set; }
 
 		[Required]
 		public bool LinkerDumpDependencies { get; set; }
@@ -408,11 +408,13 @@ namespace Xamarin.iOS.Tasks
 			if (EnableSGenConc)
 				args.AddLine ("--sgen-conc");
 
-			if (UseInterpreter)
-				args.Add ("--interpreter");
-
-			if (UseInterpreterMixed)
-				args.Add ("--interp-mixed");
+			if (UseInterpreter) {
+				if (string.IsNullOrEmpty (Interpreter)) {
+					args.Add ("--interpreter");
+				} else {
+					args.Add ($"--interpreter={Interpreter}");
+				}
+			}
 
 			switch (LinkMode.ToLowerInvariant ()) {
 			case "sdkonly": args.AddLine ("--linksdkonly"); break;

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -110,6 +110,9 @@ namespace Xamarin.iOS.Tasks
 		public bool UseInterpreter { get; set; }
 
 		[Required]
+		public bool UseInterpreterMixed { get; set; }
+
+		[Required]
 		public bool LinkerDumpDependencies { get; set; }
 
 		[Required]
@@ -407,6 +410,9 @@ namespace Xamarin.iOS.Tasks
 
 			if (UseInterpreter)
 				args.Add ("--interpreter");
+
+			if (UseInterpreterMixed)
+				args.Add ("--interp-mixed");
 
 			switch (LinkMode.ToLowerInvariant ()) {
 			case "sdkonly": args.AddLine ("--linksdkonly"); break;

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -107,9 +107,6 @@ namespace Xamarin.iOS.Tasks
 		public bool EnableSGenConc { get; set; }
 
 		[Required]
-		public bool UseInterpreter { get; set; }
-
-		[Required]
 		public string Interpreter { get; set; }
 
 		[Required]
@@ -408,13 +405,8 @@ namespace Xamarin.iOS.Tasks
 			if (EnableSGenConc)
 				args.AddLine ("--sgen-conc");
 
-			if (UseInterpreter) {
-				if (string.IsNullOrEmpty (Interpreter)) {
-					args.Add ("--interpreter");
-				} else {
-					args.Add ($"--interpreter={Interpreter}");
-				}
-			}
+			if (!string.IsNullOrEmpty (Interpreter))
+				args.Add ($"--interpreter={Interpreter}");
 
 			switch (LinkMode.ToLowerInvariant ()) {
 			case "sdkonly": args.AddLine ("--linksdkonly"); break;

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -106,7 +106,6 @@ namespace Xamarin.iOS.Tasks
 		[Required]
 		public bool EnableSGenConc { get; set; }
 
-		[Required]
 		public string Interpreter { get; set; }
 
 		[Required]

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
@@ -52,7 +52,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<MtouchProjectDirectory>$(MSBuildProjectDirectory)</MtouchProjectDirectory>
 		<MtouchEnableSGenConc Condition="'$(MtouchEnableSGenConc)' == ''">False</MtouchEnableSGenConc>
 		<MtouchUseInterpreter Condition="'$(MtouchUseInterpreter)' == ''">False</MtouchUseInterpreter>
-		<MtouchUseInterpreterMixed Condition="'$(MtouchUseInterpreterMixed)' == ''">False</MtouchUseInterpreterMixed>
+		<MtouchInterpreter Condition="'$(MtouchInterpreter)' == ''">all</MtouchInterpreter>
 		<MtouchVerbosity Condition="$(MtouchVerbosity) == ''">2</MtouchVerbosity>
 
 		<IsMacEnabled>true</IsMacEnabled>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
@@ -51,8 +51,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<MtouchUseThumb Condition="'$(MtouchUseThumb)' == ''">False</MtouchUseThumb>
 		<MtouchProjectDirectory>$(MSBuildProjectDirectory)</MtouchProjectDirectory>
 		<MtouchEnableSGenConc Condition="'$(MtouchEnableSGenConc)' == ''">False</MtouchEnableSGenConc>
-		<MtouchUseInterpreter Condition="'$(MtouchUseInterpreter)' == ''">False</MtouchUseInterpreter>
-		<MtouchInterpreter Condition="'$(MtouchInterpreter)' == ''">all</MtouchInterpreter>
 		<MtouchVerbosity Condition="$(MtouchVerbosity) == ''">2</MtouchVerbosity>
 
 		<IsMacEnabled>true</IsMacEnabled>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.props
@@ -52,6 +52,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<MtouchProjectDirectory>$(MSBuildProjectDirectory)</MtouchProjectDirectory>
 		<MtouchEnableSGenConc Condition="'$(MtouchEnableSGenConc)' == ''">False</MtouchEnableSGenConc>
 		<MtouchUseInterpreter Condition="'$(MtouchUseInterpreter)' == ''">False</MtouchUseInterpreter>
+		<MtouchUseInterpreterMixed Condition="'$(MtouchUseInterpreterMixed)' == ''">False</MtouchUseInterpreterMixed>
 		<MtouchVerbosity Condition="$(MtouchVerbosity) == ''">2</MtouchVerbosity>
 
 		<IsMacEnabled>true</IsMacEnabled>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -832,7 +832,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			EnableBitcode="$(MtouchEnableBitcode)"
 			EnableSGenConc="$(MtouchEnableSGenConc)"
 			UseInterpreter="$(MtouchUseInterpreter)"
-			UseInterpreterMixed="$(MtouchUseInterpreterMixed)"
+			Interpreter="$(MtouchInterpreter)"
 			AppExtensionReferences="@(_ResolvedAppExtensionReferences)"
 			ArchiveSymbols="$(MonoSymbolArchive)"
 			Verbosity="$(MtouchVerbosity)"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -831,7 +831,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			UseThumb="$(MtouchUseThumb)"
 			EnableBitcode="$(MtouchEnableBitcode)"
 			EnableSGenConc="$(MtouchEnableSGenConc)"
-			UseInterpreter="$(MtouchUseInterpreter)"
 			Interpreter="$(MtouchInterpreter)"
 			AppExtensionReferences="@(_ResolvedAppExtensionReferences)"
 			ArchiveSymbols="$(MonoSymbolArchive)"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -832,6 +832,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			EnableBitcode="$(MtouchEnableBitcode)"
 			EnableSGenConc="$(MtouchEnableSGenConc)"
 			UseInterpreter="$(MtouchUseInterpreter)"
+			UseInterpreterMixed="$(MtouchUseInterpreterMixed)"
 			AppExtensionReferences="@(_ResolvedAppExtensionReferences)"
 			ArchiveSymbols="$(MonoSymbolArchive)"
 			Verbosity="$(MtouchVerbosity)"

--- a/tests/common/BundlerTool.cs
+++ b/tests/common/BundlerTool.cs
@@ -74,6 +74,7 @@ namespace Xamarin.Tests
 		public int Verbosity;
 		public int [] WarnAsError; // null array: nothing passed to mtouch/mmp. empty array: pass --warnaserror (which means makes all warnings errors).
 		public string [] XmlDefinitions;
+		public string Interpreter;
 
 		// These are a bit smarter
 		public bool NoPlatformAssemblyReference;
@@ -291,7 +292,12 @@ namespace Xamarin.Tests
 					sb.Append (" --xml:").Append (StringUtils.Quote (xd));
 			}
 
-
+			if (Interpreter != null) {
+				if (Interpreter.Length == 0)
+					sb.Append (" --interpreter");
+				else
+					sb.Append (" --interpreter=").Append (Interpreter);
+			}
 		}
 
 		public string CreateTemporaryDirectory ()

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1781,6 +1781,25 @@ public class B
 		}
 
 		[Test]
+		public void MT0138 ()
+		{
+			using (var mtouch = new MTouchTool ()) {
+				var tmpdir = mtouch.CreateTemporaryDirectory ();
+				mtouch.CreateTemporaryCacheDirectory ();
+
+				mtouch.CreateTemporaryApp ();
+				mtouch.WarnAsError = new int [] { 138 }; // This is just to make mtouch bail out early instead of spending time building the app when that's not what we're interested in.
+				mtouch.Interpreter = "all,-all,foo,-bar,mscorlib.dll,mscorlib";
+				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
+				mtouch.AssertError (138, "Cannot find the assembly 'foo', passed as an argument to --interpreter.");
+				mtouch.AssertError (138, "Cannot find the assembly 'bar', passed as an argument to --interpreter.");
+				mtouch.AssertError (138, "Cannot find the assembly 'mscorlib.dll', passed as an argument to --interpreter.");
+				// just the name, without the extension, is the right way.
+				mtouch.AssertErrorCount (3);
+			}
+		}
+
+		[Test]
 		[TestCase ("all")]
 		[TestCase ("-all")]
 		[TestCase ("remove-uithread-checks,dead-code-elimination,inline-isdirectbinding,inline-intptr-size,inline-runtime-arch,register-protocols")]

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -182,12 +182,15 @@ namespace xharness
 					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, Defines = "OPTIMIZEALL" };
 					yield return new TestData { Variation = "Debug (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = true, Profiling = false, Defines = "OPTIMIZEALL" };
 					yield return new TestData { Variation = "Debug (interpreter)", MTouchExtraArgs = "--interpreter", Debug = true, Profiling = false, Ignored = true, };
+					yield return new TestData { Variation = "Debug (interp-mixed)", MTouchExtraArgs = "--interp-mixed", Debug = true, Profiling = false, Ignored = true, };
 					break;
 				case "mscorlib":
 					yield return new TestData { Variation = "Debug (interpreter)", MTouchExtraArgs = "--interpreter", Debug = true, Profiling = false, Ignored = true, Undefines = "FULL_AOT_RUNTIME" };
+					yield return new TestData { Variation = "Debug (interp-mixed)", MTouchExtraArgs = "--interp-mixed", Debug = true, Profiling = false, Ignored = true, Undefines = "FULL_AOT_RUNTIME" };
 					break;
 				case "mini":
 					yield return new TestData { Variation = "Debug (interpreter)", MTouchExtraArgs = "--interpreter", Debug = true, Profiling = false, Undefines = "FULL_AOT_RUNTIME" };
+					yield return new TestData { Variation = "Debug (interp-mixed)", MTouchExtraArgs = "--interp-mixed", Debug = true, Profiling = false, Undefines = "FULL_AOT_RUNTIME" };
 					break;
 				}
 				break;

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -182,15 +182,15 @@ namespace xharness
 					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, Defines = "OPTIMIZEALL" };
 					yield return new TestData { Variation = "Debug (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = true, Profiling = false, Defines = "OPTIMIZEALL" };
 					yield return new TestData { Variation = "Debug (interpreter)", MTouchExtraArgs = "--interpreter", Debug = true, Profiling = false, Ignored = true, };
-					yield return new TestData { Variation = "Debug (interp-mixed)", MTouchExtraArgs = "--interp-mixed", Debug = true, Profiling = false, Ignored = true, };
+					yield return new TestData { Variation = "Debug (interpreter -mscorlib)", MTouchExtraArgs = "--interpreter=-mscorlib", Debug = true, Profiling = false, Ignored = true, };
 					break;
 				case "mscorlib":
 					yield return new TestData { Variation = "Debug (interpreter)", MTouchExtraArgs = "--interpreter", Debug = true, Profiling = false, Ignored = true, Undefines = "FULL_AOT_RUNTIME" };
-					yield return new TestData { Variation = "Debug (interp-mixed)", MTouchExtraArgs = "--interp-mixed", Debug = true, Profiling = false, Ignored = true, Undefines = "FULL_AOT_RUNTIME" };
+					yield return new TestData { Variation = "Debug (interpreter -mscorlib)", MTouchExtraArgs = "--interpreter=-mscorlib", Debug = true, Profiling = false, Ignored = true, Undefines = "FULL_AOT_RUNTIME" };
 					break;
 				case "mini":
 					yield return new TestData { Variation = "Debug (interpreter)", MTouchExtraArgs = "--interpreter", Debug = true, Profiling = false, Undefines = "FULL_AOT_RUNTIME" };
-					yield return new TestData { Variation = "Debug (interp-mixed)", MTouchExtraArgs = "--interp-mixed", Debug = true, Profiling = false, Undefines = "FULL_AOT_RUNTIME" };
+					yield return new TestData { Variation = "Debug (interpreter -mscorlib)", MTouchExtraArgs = "--interpreter=-mscorlib", Debug = true, Profiling = false, Undefines = "FULL_AOT_RUNTIME" };
 					break;
 				}
 				break;

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -63,8 +63,6 @@ namespace Xamarin.Bundler {
 
 		public bool? EnableCoopGC;
 		public bool EnableSGenConc;
-		public bool UseInterpreter;
-		public List<string> InterpretedAssemblies = new List<string> ();
 		public MarshalObjectiveCExceptionMode MarshalObjectiveCExceptions;
 		public MarshalManagedExceptionMode MarshalManagedExceptions;
 
@@ -92,44 +90,6 @@ namespace Xamarin.Bundler {
 			get {
 				return Optimizations.RemoveDynamicRegistrar != true;
 			}
-		}
-
-		public bool IsInterpreted (string assembly)
-		{
-			// IsAOTCompiled and IsInterpreted are not opposites: mscorlib.dll can be both.
-			if (!UseInterpreter)
-				return false;
-
-			// Go through the list of assemblies to interpret in reverse order,
-			// so that the last option passed to mtouch takes precedence.
-			for (int i = InterpretedAssemblies.Count - 1; i >= 0; i--) {
-				var opt = InterpretedAssemblies [i];
-				if (opt == "all")
-					return true;
-				else if (opt == "-all")
-					return false;
-				else if (opt == assembly)
-					return true;
-				else if (opt [0] == '-' && opt.Substring (1) == assembly)
-					return false;
-			}
-
-			// There's an implicit 'all' at the start of the list.
-			return true;
-		}
-
-		public bool IsAOTCompiled (string assembly)
-		{
-			if (!UseInterpreter)
-				return true;
-			
-			// IsAOTCompiled and IsInterpreted are not opposites: mscorlib.dll can be both:
-			// - mscorlib will always be processed by the AOT compiler to generate required wrapper functions for the interpreter to work
-			// - mscorlib might also be fully AOT-compiled (both when the interpreter is enabled and when it's not)
-			if (assembly == "mscorlib")
-				return true;
-
-			return !IsInterpreted (assembly);
 		}
 
 		// This is just a name for this app to show in log/error messages, etc.

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Bundler {
 		public bool? EnableCoopGC;
 		public bool EnableSGenConc;
 		public bool UseInterpreter;
-		public bool UseInterpreterMixed;
+		public List<string> InterpretedAssemblies = new List<string> ();
 		public MarshalObjectiveCExceptionMode MarshalObjectiveCExceptions;
 		public MarshalManagedExceptionMode MarshalManagedExceptions;
 
@@ -92,6 +92,44 @@ namespace Xamarin.Bundler {
 			get {
 				return Optimizations.RemoveDynamicRegistrar != true;
 			}
+		}
+
+		public bool IsInterpreted (string assembly)
+		{
+			// IsAOTCompiled and IsInterpreted are not opposites: mscorlib.dll can be both.
+			if (!UseInterpreter)
+				return false;
+
+			// Go through the list of assemblies to interpret in reverse order,
+			// so that the last option passed to mtouch takes precedence.
+			for (int i = InterpretedAssemblies.Count - 1; i >= 0; i--) {
+				var opt = InterpretedAssemblies [i];
+				if (opt == "all")
+					return true;
+				else if (opt == "-all")
+					return false;
+				else if (opt == assembly)
+					return true;
+				else if (opt [0] == '-' && opt.Substring (1) == assembly)
+					return false;
+			}
+
+			// There's an implicit 'all' at the start of the list.
+			return true;
+		}
+
+		public bool IsAOTCompiled (string assembly)
+		{
+			if (!UseInterpreter)
+				return true;
+			
+			// IsAOTCompiled and IsInterpreted are not opposites: mscorlib.dll can be both:
+			// - mscorlib will always be processed by the AOT compiler to generate required wrapper functions for the interpreter to work
+			// - mscorlib might also be fully AOT-compiled (both when the interpreter is enabled and when it's not)
+			if (assembly == "mscorlib")
+				return true;
+
+			return !IsInterpreted (assembly);
 		}
 
 		// This is just a name for this app to show in log/error messages, etc.

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -64,6 +64,7 @@ namespace Xamarin.Bundler {
 		public bool? EnableCoopGC;
 		public bool EnableSGenConc;
 		public bool UseInterpreter;
+		public bool UseInterpreterMixed;
 		public MarshalObjectiveCExceptionMode MarshalObjectiveCExceptions;
 		public MarshalManagedExceptionMode MarshalManagedExceptions;
 

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -462,7 +462,7 @@ namespace Xamarin.Bundler {
 			if (EnableLLVMOnlyBitCode)
 				return false;
 
-			if (UseInterpreter)
+			if (UseInterpreter || UseInterpreterMixed)
 				return true;
 
 			switch (Platform) {
@@ -2124,7 +2124,8 @@ namespace Xamarin.Bundler {
 
 		public void BundleAssemblies ()
 		{
-			var strip = !UseInterpreter && ManagedStrip && IsDeviceBuild && !EnableDebug && !PackageManagedDebugSymbols;
+			/* TODO: must be more fine-grained for UseInterpreterMixed case */
+			var strip = !UseInterpreter && !UseInterpreterMixed && ManagedStrip && IsDeviceBuild && !EnableDebug && !PackageManagedDebugSymbols;
 
 			var grouped = Targets.SelectMany ((Target t) => t.Assemblies).GroupBy ((Assembly asm) => asm.Identity);
 			foreach (var @group in grouped) {

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -116,6 +116,8 @@ namespace Xamarin.Bundler {
 		public string AotOtherArguments = string.Empty;
 		public bool? LLVMAsmWriter;
 		public Dictionary<string, string> LLVMOptimizations = new Dictionary<string, string> ();
+		public bool UseInterpreter;
+		public List<string> InterpretedAssemblies = new List<string> ();
 
 		public Dictionary<string, string> EnvironmentVariables = new Dictionary<string, string> ();
 
@@ -128,6 +130,44 @@ namespace Xamarin.Bundler {
 		public List<string> References = new List<string> ();
 		
 		public bool? BuildDSym;
+
+		public bool IsInterpreted (string assembly)
+		{
+			// IsAOTCompiled and IsInterpreted are not opposites: mscorlib.dll can be both.
+			if (!UseInterpreter)
+				return false;
+
+			// Go through the list of assemblies to interpret in reverse order,
+			// so that the last option passed to mtouch takes precedence.
+			for (int i = InterpretedAssemblies.Count - 1; i >= 0; i--) {
+				var opt = InterpretedAssemblies [i];
+				if (opt == "all")
+					return true;
+				else if (opt == "-all")
+					return false;
+				else if (opt == assembly)
+					return true;
+				else if (opt [0] == '-' && opt.Substring (1) == assembly)
+					return false;
+			}
+
+			// There's an implicit 'all' at the start of the list.
+			return true;
+		}
+
+		public bool IsAOTCompiled (string assembly)
+		{
+			if (!UseInterpreter)
+				return true;
+
+			// IsAOTCompiled and IsInterpreted are not opposites: mscorlib.dll can be both:
+			// - mscorlib will always be processed by the AOT compiler to generate required wrapper functions for the interpreter to work
+			// - mscorlib might also be fully AOT-compiled (both when the interpreter is enabled and when it's not)
+			if (assembly == "mscorlib")
+				return true;
+
+			return !IsInterpreted (assembly);
+		}
 
 		// If we're targetting a 32 bit arch.
 		bool? is32bits;

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -462,7 +462,7 @@ namespace Xamarin.Bundler {
 			if (EnableLLVMOnlyBitCode)
 				return false;
 
-			if (UseInterpreter || UseInterpreterMixed)
+			if (IsInterpreted (Assembly.GetIdentity (assembly)))
 				return true;
 
 			switch (Platform) {
@@ -2124,8 +2124,20 @@ namespace Xamarin.Bundler {
 
 		public void BundleAssemblies ()
 		{
-			/* TODO: must be more fine-grained for UseInterpreterMixed case */
-			var strip = !UseInterpreter && !UseInterpreterMixed && ManagedStrip && IsDeviceBuild && !EnableDebug && !PackageManagedDebugSymbols;
+			Assembly.StripAssembly strip = ((path) => 
+			{
+				if (!ManagedStrip)
+					return false;
+				if (!IsDeviceBuild)
+					return false;
+				if (EnableDebug)
+					return false;
+				if (PackageManagedDebugSymbols)
+					return false;
+				if (IsInterpreted (Assembly.GetIdentity (path)))
+					return false;
+				return true;
+			});
 
 			var grouped = Targets.SelectMany ((Target t) => t.Assemblies).GroupBy ((Assembly asm) => asm.Identity);
 			foreach (var @group in grouped) {

--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -58,6 +58,11 @@ namespace Xamarin.Bundler {
 					/* interpreter only requires a few stubs that are attached
 					 * to mscorlib.dll, other assemblies won't be AOT compiled */
 					return FileName == "mscorlib.dll";
+				if (App.UseInterpreterMixed)
+					/* TODO: for now, only (fully) AOT compile mscorlib.dll. We
+					 * need an additional option to drive what assemblies
+					 * should be AOT compiled */
+					return FileName == "mscorlib.dll";
 				return true;
 			}
 		}

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -1136,6 +1136,11 @@ namespace Xamarin.Bundler
 			if (App.UseInterpreter)
 				return;
 
+			if (App.UseInterpreterMixed)
+				/* TODO: not sure? we might have to continue here, depending on
+				 * the set of assemblies are AOT'd? */
+				return;
+
 			// Code in one assembly (either in a P/Invoke or a third-party library) can depend on a third-party library in another assembly.
 			// This means that we must always build assemblies only when all their dependent assemblies have been built, so that 
 			// we can link (natively) with the frameworks/dylibs for those dependent assemblies.
@@ -1484,7 +1489,7 @@ namespace Xamarin.Bundler
 				}
 			}
 
-			if (App.UseInterpreter) {
+			if (App.UseInterpreter || App.UseInterpreterMixed) {
 				string libinterp = Path.Combine (libdir, "libmono-ee-interp.a");
 				linker_flags.AddLinkWith (libinterp);
 				string libicalltable = Path.Combine (libdir, "libmono-icall-table.a");

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -456,6 +456,7 @@ namespace Xamarin.Bundler
 			bool enable_debug_symbols = app.PackageManagedDebugSymbols;
 			bool llvm_only = app.EnableLLVMOnlyBitCode;
 			bool interp = app.UseInterpreter;
+			bool interp_mixed = app.UseInterpreterMixed;
 			bool is32bit = (abi & Abi.Arch32Mask) > 0;
 			string arch = abi.AsArchString ();
 
@@ -476,6 +477,8 @@ namespace Xamarin.Bundler
 				args.Append ("llvmonly,");
 			else if (interp)
 				args.Append ("interp,");
+			else if (interp_mixed)
+				args.Append ("interp,full,");
 			else
 				args.Append ("full,");
 
@@ -641,7 +644,7 @@ namespace Xamarin.Bundler
 						sw.WriteLine ("xamarin_profiler_symbol_def xamarin_profiler_symbol = NULL;");
 					}
 
-					if (app.UseInterpreter) {
+					if (app.UseInterpreter || app.UseInterpreterMixed) {
 						sw.WriteLine ("extern \"C\" { void mono_ee_interp_init (const char *); }");
 						sw.WriteLine ("extern \"C\" { void mono_icall_table_init (void); }");
 						sw.WriteLine ("extern \"C\" { void mono_marshal_ilgen_init (void); }");
@@ -657,7 +660,7 @@ namespace Xamarin.Bundler
 
 					if (app.EnableLLVMOnlyBitCode)
 						sw.WriteLine ("\tmono_jit_set_aot_mode (MONO_AOT_MODE_LLVMONLY);");
-					else if (app.UseInterpreter) {
+					else if (app.UseInterpreter || app.UseInterpreterMixed) {
 						sw.WriteLine ("\tmono_icall_table_init ();");
 						sw.WriteLine ("\tmono_marshal_ilgen_init ();");
 						sw.WriteLine ("\tmono_method_builder_ilgen_init ();");
@@ -866,7 +869,7 @@ namespace Xamarin.Bundler
 			if (app.EnableSGenConc)
 				return false;
 
-			if (app.UseInterpreter)
+			if (app.UseInterpreter || app.UseInterpreterMixed)
 				return false;
 
 			if (app.Registrar == RegistrarMode.Static)
@@ -1248,6 +1251,7 @@ namespace Xamarin.Bundler
 				}
 			},
 			{ "interpreter", "Enable the *experimental* interpreter.", v => { app.UseInterpreter = true; }},
+			{ "interp-mixed", "Enable the *experimental* interpreter mixed with AOT mode.", v => { app.UseInterpreterMixed = true; }},
 			{ "http-message-handler=", "Specify the default HTTP message handler for HttpClient", v => { http_message_handler = v; }},
 			{ "output-format=", "Specify the output format for some commands. Possible values: Default, XML", v =>
 				{

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -475,11 +475,15 @@ namespace Xamarin.Bundler
 			args.Append (app.AotArguments);
 			if (llvm_only)
 				args.Append ("llvmonly,");
-			else if (interp)
+			else if (interp) {
+				if (fname != "mscorlib.dll")
+					throw ErrorHelper.CreateError (99, $"Internal error: can only enable the interpreter for mscorlib.dll when AOT-compiling assemblies (tried to interpret {fname}). Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.");
 				args.Append ("interp,");
-			else if (interp_full)
+			} else if (interp_full) {
+				if (fname != "mscorlib.dll")
+					throw ErrorHelper.CreateError (99, $"Internal error: can only enable the interpreter for mscorlib.dll when AOT-compiling assemblies (tried to interpret {fname}). Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new."); 
 				args.Append ("interp,full,");
-			else
+			} else
 				args.Append ("full,");
 
 			var aname = Path.GetFileNameWithoutExtension (fname);

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1254,7 +1254,7 @@ namespace Xamarin.Bundler
 				{ 
 					app.UseInterpreter = true;
 					if (!string.IsNullOrEmpty (v)) {
-							app.InterpretedAssemblies.AddRange (v.Split (new char [] { ',' }, StringSplitOptions.RemoveEmptyEntries));
+						app.InterpretedAssemblies.AddRange (v.Split (new char [] { ',' }, StringSplitOptions.RemoveEmptyEntries));
 					}
 				}
 			},


### PR DESCRIPTION
Note: Requires `mono-2018-06` to be merged, thus opened against it.

When enabling this option, mtouch will AOT compile `mscorlib.dll`.  At runtime that means every method that wasn't AOT'd will be executed by the runtime interpreter.

https://github.com/mono/mono/issues/6860

