### PR TITLE
[xharness] Automatically pass -Os to the native linker when building watchOS extensions with the linker disabled.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -2708,7 +2708,7 @@ function toggleAll (show)
 						xbuild.StartInfo.EnvironmentVariables ["MSBuildExtensionsPath"] = null;
 					LogEvent (log, "Building {0} ({1})", TestName, Mode);
 					if (!Harness.DryRun) {
-						var timeout = TimeSpan.FromMinutes (15);
+						var timeout = TimeSpan.FromMinutes (60);
 						var result = await xbuild.RunAsync (log, true, timeout);
 						if (result.TimedOut) {
 							ExecutionResult = TestExecutingResult.TimedOut;

--- a/tests/xharness/ProjectFileExtensions.cs
+++ b/tests/xharness/ProjectFileExtensions.cs
@@ -380,6 +380,11 @@ namespace xharness
 			return string.Empty;
 		}
 
+		public static string GetMtouchLink (this XmlDocument csproj, string platform, string configuration)
+		{
+			return GetNode (csproj, "MtouchLink", platform, configuration);
+		}
+
 		public static void SetMtouchUseLlvm (this XmlDocument csproj, bool value, string platform, string configuration)
 		{
 			SetNode (csproj, "MtouchUseLlvm", true ? "true" : "false", platform, configuration);
@@ -388,6 +393,17 @@ namespace xharness
 		public static void SetMtouchUseBitcode (this XmlDocument csproj, bool value, string platform, string configuration)
 		{
 			SetNode (csproj, "MtouchEnableBitcode", true ? "true" : "false", platform, configuration);
+		}
+
+		public static IEnumerable<XmlNode> GetPropertyGroups (this XmlDocument csproj, string platform, string configuration)
+		{
+			var propertyGroups = csproj.SelectNodes ("//*[local-name() = 'PropertyGroup' and @Condition]");
+			foreach (XmlNode node in propertyGroups) {
+				if (!EvaluateCondition (node, platform, configuration))
+					continue;
+
+				yield return node;
+			}
 		}
 
 		public static void SetNode (this XmlDocument csproj, string node, string value, string platform, string configuration)
@@ -417,6 +433,16 @@ namespace xharness
 			}
 		}
 
+		public static string GetNode (this XmlDocument csproj, string name, string platform, string configuration)
+		{
+			foreach (var pg in GetPropertyGroups (csproj, platform, configuration)) {
+				foreach (XmlNode node in pg.ChildNodes)
+					if (node.Name == name)
+						return node.InnerText;
+			}
+
+			return null;
+		}
 
 		public static string GetImport (this XmlDocument csproj)
 		{

--- a/tests/xharness/WatchOSTarget.cs
+++ b/tests/xharness/WatchOSTarget.cs
@@ -84,6 +84,13 @@ namespace xharness
 			csproj.SetMtouchUseBitcode (true, "iPhone", "Release");
 			csproj.SetMtouchUseLlvm (true, "iPhone", "Release");
 
+			// Not linking a watch extensions requires passing -Os to the native compiler.
+			// https://github.com/mono/mono/issues/9867
+			var configurations = new string [] { "Debug", "Debug32", "Release", "Release32", "Release-bitcode" };
+			foreach (var c in configurations)
+				if (csproj.GetMtouchLink ("iPhone", c) == "None")
+					csproj.AddExtraMtouchArgs ("--gcc_flags=-Os", "iPhone", c);
+
 			Harness.Save (csproj, WatchOSExtensionProjectPath);
 
 			WatchOSExtensionGuid = csproj.GetProjectGuid ();


### PR DESCRIPTION
This works around https://github.com/xamarin/xamarin-macios/issues/4689 for our own unit tests.

This also requires bumping the build timeout, because unfortunately using -Os
makes builds *much, much* slower.