### PR TITLE
[metal] Fix 'indirectRenderCommandAtIndex' binding

### DIFF
--- a/src/metal.cs
+++ b/src/metal.cs
@@ -3310,7 +3310,7 @@ namespace Metal {
 
 		[Abstract]
 		[Export ("indirectRenderCommandAtIndex:")]
-		IMTLIndirectRenderCommand CreateIndirectRenderCommand (nuint commandIndex);
+		IMTLIndirectRenderCommand GetCommand (nuint commandIndex);
 	}
 
 	[NoiOS, NoTV, Mac (10,14, onlyOn64: true)]


### PR DESCRIPTION
`CreateIndirectRenderCommand` implies we're creating the command while this API "returns the CPU-based indirect render command at the given index of the indirect command buffer". Moving to `GetCommand` which is more accurate.