### PR TITLE
[xharness] Implement getting a reader for captured logs.

### DIFF
--- a/tests/xharness/Log.cs
+++ b/tests/xharness/Log.cs
@@ -366,6 +366,15 @@ namespace xharness
 			}
 		}
 
+		public override StreamReader GetReader ()
+		{
+			if (File.Exists (CapturePath)) {
+				return new StreamReader (new FileStream (CapturePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+			} else {
+				return new StreamReader (new MemoryStream ());
+			}
+		}
+
 		public override void Flush ()
 		{
 			base.Flush ();


### PR DESCRIPTION
Fixes an exception that might occur if the code that generates the html report
tries to process such logs (by trying to read them).