### PR TITLE
[msbuild] Set 'CopyNuGetImplementations' to true for app extensions. Fixes #4235 and #4237. (#4512) (#4648)

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.AppExtension.CSharp.targets
@@ -22,6 +22,10 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkIdentifier)' == '' And '$(TargetFrameworkVersion)' ==''">v4.5</TargetFrameworkVersion>
 
 		<DefineConstants>__UNIFIED__;__MACOS__;$(DefineConstants)</DefineConstants>
+
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<!-- See Xamarin.iOS.AppExtension.CSharp.targets for a detailed explanation of this variable -->
+		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.CSharp.targets
@@ -22,6 +22,10 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<!-- See Xamarin.iOS.AppExtension.CSharp.targets for a detailed explanation of this variable -->
+		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+
 		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
 		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
 		<_IsTVOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__TVOS__($|;)'))</_IsTVOSDefined>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.Common.targets
@@ -18,6 +18,9 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 	<PropertyGroup>
 		<IsAppExtension>True</IsAppExtension>
 		<AppBundleExtension>.appex</AppBundleExtension>
+
+		<!-- See Xamarin.iOS.AppExtension.CSharp.targets for a detailed explanation of this variable -->
+		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.TVOS.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS.AppExtension.FSharp.targets
@@ -21,6 +21,11 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.TVOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
+
+		<!-- This must be set before importing Microsoft.FSharp.targets -->
+		<!-- See Xamarin.iOS.AppExtension.CSharp.targets for a detailed explanation of this variable -->
+		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+
 		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
 		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
 		<_IsTVOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__TVOS__($|;)'))</_IsTVOSDefined>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.CSharp.targets
@@ -22,6 +22,10 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<!-- See Xamarin.iOS.AppExtension.CSharp.targets for a detailed explanation of this variable -->
+		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+
 		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
 		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
 		<_IsWATCHOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__WATCHOS__($|;)'))</_IsWATCHOSDefined>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.Common.targets
@@ -20,6 +20,10 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<IsWatchExtension>True</IsWatchExtension>
 		<AppBundleExtension>.appex</AppBundleExtension>
 		<MtouchHttpClientHandler Condition="'$(MtouchHttpClientHandler)' == ''">NSUrlSessionHandler</MtouchHttpClientHandler>
+
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<!-- See Xamarin.iOS.AppExtension.CSharp.targets for a detailed explanation of this variable -->
+		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)..\iOS\Xamarin.iOS.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.FSharp.targets
@@ -21,6 +21,11 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- Version/fx properties -->
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.WatchOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
+
+		<!-- This must be set before importing Microsoft.FSharp.targets -->
+		<!-- See Xamarin.iOS.AppExtension.CSharp.targets for a detailed explanation of this variable -->
+		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+
 		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
 		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
 		<_IsWATCHOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__WATCHOS__($|;)'))</_IsWATCHOSDefined>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.CSharp.targets
@@ -22,6 +22,23 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<!--
+			In Xamarin.iOS.Common.targets, just before the _CompileToNative target, we modify the
+			mtouch references to ensure that we get the lib assemblies for nugets, and not the ref references:
+
+			https://github.com/xamarin/xamarin-macios/blob/9e31d07ecc08a64372dd562e843c3d8950d24985/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets#L784-L791
+
+			This logic removes nuget references, and then re-adds any copy-local dll references.
+
+			This works fine in executable projects, but not in library projects (aka extensions), because nugets aren't copied for library projects:
+
+			https://github.com/NuGet/NuGet.BuildTasks/blob/cf4b0a12cf1f75e0654f28c2a9020251c41d126a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets#L86
+
+			So we need to set the CopyNuGetImplementations variable to 'true' for our library projects.
+		-->
+		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+
 		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
 		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
 		<_IsIOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__IOS__($|;)'))</_IsIOSDefined>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.FSharp.targets
@@ -22,6 +22,10 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">Xamarin.iOS</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.0</TargetFrameworkVersion>
 
+		<!-- This must be set before importing Microsoft.FSharp.targets -->
+		<!-- See Xamarin.iOS.AppExtension.CSharp.targets for a detailed explanation of this variable -->
+		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+
 		<_IsUnifiedDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__UNIFIED__($|;)'))</_IsUnifiedDefined>
 		<_IsMobileDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__MOBILE__($|;)'))</_IsMobileDefined>
 		<_IsIOSDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)__IOS__($|;)'))</_IsIOSDefined>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -786,6 +786,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<!-- Remove exact references, such as if a package had a framework reference to 'System' that we already have -->
 			<!-- This is exactly what "Microsoft.NuGet.Build.Tasks"'s 'ResolveNuGetPackageAssets' target is doing -->
 			<!-- Effectively 'ResolveNuGetPackageAssets' computes the NuGet packages using their json asset file, adds the full assemblies to 'ReferenceCopyLocalPaths' and outputs the resolved references via '_ReferencesFromNuGetPackages' -->
+			<!-- This requires nuget libraries to be copied locally, which by default only happens for executable projects, so we set 'CopyNuGetImplementations' to true for extensions (see comment in Xamarin.iOS.AppExtension.CSharp.targets for more info) -->
 			<ReferencePath Remove="@(_ReferencesFromNuGetPackages)" />
 			<MTouchReferencePath Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll'" />
 		</ItemGroup>

--- a/msbuild/tests/MyAppWithPackageReference/AppDelegate.cs
+++ b/msbuild/tests/MyAppWithPackageReference/AppDelegate.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Foundation;
+using UIKit;
+
+namespace MyTabbedApplication
+{
+	[Register ("AppDelegate")]
+	public partial class AppDelegate : UIApplicationDelegate
+	{
+		public override UIWindow Window {
+			get;
+			set;
+		}
+
+		// This is the main entry point of the application.
+		static void Main (string[] args)
+		{
+			Console.WriteLine (typeof (Newtonsoft.Json.JsonReader));
+			UIApplication.Main (args, null, "AppDelegate");
+		}
+	}
+}
+

--- a/msbuild/tests/MyAppWithPackageReference/Info.plist
+++ b/msbuild/tests/MyAppWithPackageReference/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>MyAppWithPackageReference</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.xamarin.MyAppWithPackageReference</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>MinimumOSVersion</key>
+	<string>9.3</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>CFBundleName</key>
+	<string>MyAppWithPackageReference</string>
+</dict>
+</plist>

--- a/msbuild/tests/MyAppWithPackageReference/MyAppWithPackageReference.csproj
+++ b/msbuild/tests/MyAppWithPackageReference/MyAppWithPackageReference.csproj
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{8FEBEE38-9A70-4434-8659-1C96138567DF}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MyAppWithPackageReference</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>MyAppWithPackageReference</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchLink>None</MtouchLink>
+    <MtouchDebug>true</MtouchDebug>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchLink>None</MtouchLink>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <MtouchArch>ARM64</MtouchArch>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <MtouchArch>ARM64</MtouchArch>
+    <CodesignKey>iPhone Developer</CodesignKey>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AppDelegate.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\MyExtensionWithPackageReference\MyExtensionWithPackageReference.csproj">
+      <Project>{D1F9F9CC-B3E5-49B2-8F71-7FF2B0B57E08}</Project>
+      <Name>MyExtensionWithPackageReference</Name>
+      <IsAppExtension>True</IsAppExtension>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/msbuild/tests/MyExtensionWithPackageReference/ActionViewController.cs
+++ b/msbuild/tests/MyExtensionWithPackageReference/ActionViewController.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Drawing;
+
+using Foundation;
+using UIKit;
+
+namespace MyExtensionWithPackageReference
+{
+	public partial class ActionViewController : UIViewController
+	{
+		public ActionViewController (IntPtr handle) : base (handle)
+		{
+			Console.WriteLine (typeof (Newtonsoft.Json.JsonReader));
+		}
+
+		partial void DoneClicked (NSObject sender)
+		{
+		}
+	}
+}
+

--- a/msbuild/tests/MyExtensionWithPackageReference/ActionViewController.designer.cs
+++ b/msbuild/tests/MyExtensionWithPackageReference/ActionViewController.designer.cs
@@ -1,0 +1,23 @@
+﻿//
+// This file has been generated automatically by MonoDevelop to store outlets and
+// actions made in the Xcode designer. If it is removed, they will be lost.
+// Manual changes to this file may not be handled correctly.
+//
+using Foundation;
+
+namespace MyExtensionWithPackageReference
+{
+	[Register ("ActionViewController")]
+	partial class ActionViewController
+	{
+		[Outlet]
+		UIKit.UIImageView imageView { get; set; }
+
+		[Action ("DoneClicked:")]
+		partial void DoneClicked (Foundation.NSObject sender);
+
+		void ReleaseDesignerOutlets ()
+		{
+		}
+	}
+}

--- a/msbuild/tests/MyExtensionWithPackageReference/Entitlements.plist
+++ b/msbuild/tests/MyExtensionWithPackageReference/Entitlements.plist
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/msbuild/tests/MyExtensionWithPackageReference/Info.plist
+++ b/msbuild/tests/MyExtensionWithPackageReference/Info.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>MyExtensionWithPackageReference</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.xamarin.MyAppWithPackageReference.MyExtensionWithPackageReference</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>MyExtensionWithPackageReference</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
+				<integer>0</integer>
+				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsMovieWithMaxCount</key>
+				<integer>0</integer>
+				<key>NSExtensionActivationSupportsText</key>
+				<false/>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>0</integer>
+			</dict>
+			<key>NSExtensionPointName</key>
+			<string>com.apple.ui-services</string>
+			<key>NSExtensionPointVersion</key>
+			<string>1.0</string>
+		</dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.ui-services</string>
+	</dict>
+	<key>MinimumOSVersion</key>
+	<string>9.3</string>
+</dict>
+</plist>

--- a/msbuild/tests/MyExtensionWithPackageReference/MainInterface.storyboard
+++ b/msbuild/tests/MyExtensionWithPackageReference/MainInterface.storyboard
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6154.17" systemVersion="13D65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="ObA-dk-sSI">
+	<dependencies>
+		<plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6153.11" />
+	</dependencies>
+	<scenes>
+		<!--Action View Controller - Image-->
+		<scene sceneID="7MM-of-jgj">
+			<objects>
+				<viewController title="Image" id="ObA-dk-sSI" customClass="ActionViewController" sceneMemberID="viewController">
+					<layoutGuides>
+						<viewControllerLayoutGuide type="top" id="qkL-Od-lgU" />
+						<viewControllerLayoutGuide type="bottom" id="n38-gi-rB5" />
+					</layoutGuides>
+					<view key="view" contentMode="scaleToFill" id="zMn-AG-sqS">
+						<rect key="frame" x="0.0" y="0.0" width="320" height="528" />
+						<autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" />
+						<subviews>
+							<imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="9ga-4F-77Z">
+								<rect key="frame" x="0.0" y="64" width="320" height="464" />
+							</imageView>
+							<navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NOA-Dm-cuz">
+								<rect key="frame" x="0.0" y="20" width="320" height="44" />
+								<items>
+									<navigationItem id="3HJ-uW-3hn">
+										<barButtonItem key="leftBarButtonItem" title="Done" style="done" id="WYi-yp-eM6">
+											<connections>
+												<action selector="DoneClicked" destination="ObA-dk-sSI" id="Qdu-qn-U6V" />
+											</connections>
+										</barButtonItem>
+									</navigationItem>
+								</items>
+							</navigationBar>
+						</subviews>
+						<color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite" />
+						<constraints>
+							<constraint firstAttribute="trailing" secondItem="NOA-Dm-cuz" secondAttribute="trailing" id="A05-Pj-hrr" />
+							<constraint firstItem="9ga-4F-77Z" firstAttribute="top" secondItem="NOA-Dm-cuz" secondAttribute="bottom" id="Fps-3D-QQW" />
+							<constraint firstItem="NOA-Dm-cuz" firstAttribute="leading" secondItem="zMn-AG-sqS" secondAttribute="leading" id="HxO-8t-aoh" />
+							<constraint firstAttribute="trailing" secondItem="9ga-4F-77Z" secondAttribute="trailing" id="Ozw-Hg-0yh" />
+							<constraint firstItem="9ga-4F-77Z" firstAttribute="leading" secondItem="zMn-AG-sqS" secondAttribute="leading" id="XH5-ld-ONA" />
+							<constraint firstItem="n38-gi-rB5" firstAttribute="top" secondItem="9ga-4F-77Z" secondAttribute="bottom" id="eQg-nn-Zy4" />
+							<constraint firstItem="NOA-Dm-cuz" firstAttribute="top" secondItem="qkL-Od-lgU" secondAttribute="bottom" id="we0-1t-bgp" />
+						</constraints>
+					</view>
+					<freeformSimulatedSizeMetrics key="simulatedDestinationMetrics" />
+					<size key="freeformSize" width="320" height="528" />
+					<connections>
+						<outlet property="imageView" destination="9ga-4F-77Z" id="5y6-5w-9QO" />
+						<outlet property="view" destination="zMn-AG-sqS" id="Qma-de-2ek" />
+					</connections>
+				</viewController>
+				<placeholder placeholderIdentifier="IBFirstResponder" id="X47-rx-isc" userLabel="First Responder" sceneMemberID="firstResponder" />
+			</objects>
+			<point key="canvasLocation" x="252" y="-124" />
+		</scene>
+	</scenes>
+	<simulatedMetricsContainer key="defaultSimulatedMetrics">
+		<simulatedStatusBarMetrics key="statusBar" />
+		<simulatedOrientationMetrics key="orientation" />
+		<simulatedScreenMetrics key="destination" type="retina4" />
+	</simulatedMetricsContainer>
+</document>

--- a/msbuild/tests/MyExtensionWithPackageReference/MyExtensionWithPackageReference.csproj
+++ b/msbuild/tests/MyExtensionWithPackageReference/MyExtensionWithPackageReference.csproj
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProjectTypeGuids>{EE2C853D-36AF-4FDB-B1AD-8E90477E2198};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{D1F9F9CC-B3E5-49B2-8F71-7FF2B0B57E08}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>MyExtensionWithPackageReference</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>MyExtensionWithPackageReference</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchLink>None</MtouchLink>
+    <MtouchDebug>true</MtouchDebug>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchLink>None</MtouchLink>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <MtouchArch>ARM64</MtouchArch>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchArch>ARM64</MtouchArch>
+    <CodesignKey>iPhone Developer</CodesignKey>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+    <None Include="Entitlements.plist" />
+  </ItemGroup>
+  <ItemGroup>
+    <InterfaceDefinition Include="MainInterface.storyboard" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ActionViewController.cs" />
+    <Compile Include="ActionViewController.designer.cs">
+      <DependentUpon>ActionViewController.cs</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.AppExtension.CSharp.targets" />
+</Project>

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectReference.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ProjectReference.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.IO;
+using NUnit.Framework;
+
+using Xamarin.Tests;
+
+namespace Xamarin.iOS.Tasks
+{
+	[TestFixture ("iPhone")]
+	[TestFixture ("iPhoneSimulator")]
+	[Ignore ("https://github.com/xamarin/xamarin-macios/issues/4110")]
+	public class ProjectReferenceTests : ProjectTest
+	{
+
+		public ProjectReferenceTests (string platform) : base (platform)
+		{
+		}
+
+		[Test]
+		public void BasicTest ()
+		{
+			// We set MSBuildExtensionsPath when building with xbuild to redirect to our locally build XI/XM, but that confuses MSBuild, which uses MSBuildExtensionsPathFallbackPathsOverride instead.
+			// So if MSBuildExtensionsPath is set, move the value temporarily to MSBuildExtensionsPathFallbackPathsOverride instead, since we're using MSBuild here.
+			// This will become unnecessary when PR #4111 is merged.
+			var msbuildExtensions = Environment.GetEnvironmentVariable ("MSBuildExtensionsPath");
+			if (!string.IsNullOrEmpty (msbuildExtensions)) {
+				Environment.SetEnvironmentVariable ("MSBuildExtensionsPath", null);
+				Environment.SetEnvironmentVariable ("MSBuildExtensionsPathFallbackPathsOverride", msbuildExtensions);
+			}
+			try {
+				NugetRestore ("../MyAppWithPackageReference/MyAppWithPackageReference.csproj");
+				NugetRestore ("../MyExtensionWithPackageReference/MyExtensionWithPackageReference.csproj");
+
+				// Can't use the in-process MSBuild engine, because it complains that the project file is invalid (the attribute 'Version' in the element '<PackageReference>' is unrecognized)
+				var rv = ExecutionHelper.Execute ("msbuild", $"../MyAppWithPackageReference/MyAppWithPackageReference.csproj /p:Platform={Platform} /p:Configuration=Debug", out var output);
+				if (rv != 0) {
+					Console.WriteLine ("Build failed:");
+					Console.WriteLine (output);
+					Assert.Fail ("Build failed");
+				}
+			} finally {
+				if (!string.IsNullOrEmpty (msbuildExtensions)) {
+					Environment.SetEnvironmentVariable ("MSBuildExtensionsPath", msbuildExtensions);
+					Environment.SetEnvironmentVariable ("MSBuildExtensionsPathFallbackPathsOverride", null);
+				}
+			}
+		}
+	}
+}
+

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
@@ -3,10 +3,14 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Microsoft.Build.BuildEngine;
 using Microsoft.Build.Utilities;
 using NUnit.Framework;
 using Xamarin.MacDev;
+
+using Xamarin.Tests;
+using Xamarin.Utils;
 
 namespace Xamarin.iOS.Tasks
 {
@@ -343,6 +347,16 @@ namespace Xamarin.iOS.Tasks
 		{
 			if (!Xamarin.Tests.Configuration.include_device && platform == "iPhone")
 				Assert.Ignore ("This build does not include device support.");
+		}
+
+		public static void NugetRestore (string project)
+		{
+			var rv = ExecutionHelper.Execute ("nuget", $"restore {StringUtils.Quote (project)}", out var output);
+			if (rv != 0) {
+				Console.WriteLine ("nuget restore failed:");
+				Console.WriteLine (output);
+				Assert.Fail ($"'nuget restore' failed for {project}");
+			}
 		}
 	}
 

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/Xamarin.iOS.Tasks.Tests.csproj
@@ -107,6 +107,7 @@
       <Link>ExecutionHelper.cs</Link>
     </Compile>
     <Compile Include="ProjectsTests\ProjectWithSpaces.cs" />
+    <Compile Include="ProjectsTests\ProjectReference.cs" />
     <Compile Include="ProjectsTests\ResponseFileArguments.cs" />
   </ItemGroup>
   <ItemGroup />

--- a/tests/common/mac/Finder/FinderExtensionTest.csproj
+++ b/tests/common/mac/Finder/FinderExtensionTest.csproj
@@ -4,7 +4,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{B20EB7A2-A5ED-4CB9-95B3-58209092BF69}</ProjectGuid>
-    <ProjectTypeGuids>{889C2465-30A1-4310-B175-96B1F4D843DE};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{10CE9E57-9141-4DF0-916A-2C4FD4EE2A73};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>FinderExtensionTest</RootNamespace>
     <AssemblyName>FinderExtensionTest</AssemblyName>

--- a/tests/common/mac/Share/ShareExtensionTest.csproj
+++ b/tests/common/mac/Share/ShareExtensionTest.csproj
@@ -4,7 +4,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{8D3616B0-B9BC-46E0-A67B-7D0AEA20420C}</ProjectGuid>
-    <ProjectTypeGuids>{889C2465-30A1-4310-B175-96B1F4D843DE};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{10CE9E57-9141-4DF0-916A-2C4FD4EE2A73};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>ShareExtensionTest</RootNamespace>
     <AssemblyName>ShareExtensionTest</AssemblyName>

--- a/tests/common/mac/Today/TodayExtensionTest.csproj
+++ b/tests/common/mac/Today/TodayExtensionTest.csproj
@@ -4,7 +4,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{005176FB-37A1-4308-8C2A-07B7ED3E0064}</ProjectGuid>
-    <ProjectTypeGuids>{889C2465-30A1-4310-B175-96B1F4D843DE};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{10CE9E57-9141-4DF0-916A-2C4FD4EE2A73};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>TodayExtensionTest</RootNamespace>
     <AssemblyName>TodayExtensionTest</AssemblyName>
@@ -71,4 +71,5 @@
     </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.AppExtension.CSharp.targets" />
+%ITEMGROUP%  
 </Project>

--- a/tests/common/mac/Today/TodayViewController.cs
+++ b/tests/common/mac/Today/TodayViewController.cs
@@ -17,7 +17,7 @@ namespace TodayExtensionTest
 		public override void ViewDidLoad ()
 		{
 			base.ViewDidLoad ();
-
+%TESTCODE%
 			// Do any additional setup after loading the view.
 		}
 

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -110,6 +110,7 @@
     <Compile Include="src\SmokeTests.cs" />
     <Compile Include="src\RegistrarTests.cs" />
     <Compile Include="src\AssemblyReferencesTests.cs" />
+    <Compile Include="src\PackageReferenceTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/mmptest/src/ExtensionTests.cs
+++ b/tests/mmptest/src/ExtensionTests.cs
@@ -20,8 +20,12 @@ namespace Xamarin.MMP.Tests
 
 			MMPTests.RunMMPTest (tmpDir =>
 			{
-				string testPath = Path.Combine (TI.FindSourceDirectory (), @"Today/TodayExtensionTest.csproj");
-				TI.BuildProject (testPath, isUnified: true);
+				TI.CopyDirectory (Path.Combine (TI.FindSourceDirectory (), @"Today"), tmpDir);
+				string project = Path.Combine (tmpDir, "Today/TodayExtensionTest.csproj");
+				string main = Path.Combine (tmpDir, "Today/TodayViewController.cs");
+				TI.CopyFileWithSubstitutions (project, project, s => s.Replace ("%ITEMGROUP%", ""));
+				TI.CopyFileWithSubstitutions (main, main, s => s.Replace ("%TESTCODE%", ""));
+				TI.BuildProject (project, isUnified: true);
 			});
 		}
 
@@ -33,8 +37,8 @@ namespace Xamarin.MMP.Tests
 
 			MMPTests.RunMMPTest (tmpDir =>
 			{
-				string testPath = Path.Combine (TI.FindSourceDirectory (), @"Finder/FinderExtensionTest.csproj");
-				TI.BuildProject (testPath, isUnified: true);
+				TI.CopyDirectory (Path.Combine (TI.FindSourceDirectory (), @"Finder"), tmpDir);
+				TI.BuildProject (Path.Combine (tmpDir, "Finder/FinderExtensionTest.csproj"), isUnified: true);
 			});
 		}
 
@@ -46,8 +50,8 @@ namespace Xamarin.MMP.Tests
 
 			MMPTests.RunMMPTest (tmpDir =>
 			{
-				string testPath = Path.Combine (TI.FindSourceDirectory (), @"Share/ShareExtensionTest.csproj");
-				TI.BuildProject (testPath, isUnified: true);
+				TI.CopyDirectory (Path.Combine (TI.FindSourceDirectory (), @"Share"), tmpDir);
+				TI.BuildProject (Path.Combine (tmpDir, "Share/ShareExtensionTest.csproj"), isUnified: true);
 			});
 		}
 	}

--- a/tests/mmptest/src/PackageReferenceTests.cs
+++ b/tests/mmptest/src/PackageReferenceTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Xamarin.MMP.Tests
+{
+	[TestFixture]
+	public class PackageReferenceTests
+	{
+		const string PackageReference = @"<ItemGroup><PackageReference Include = ""Newtonsoft.Json"" Version = ""10.0.3"" /></ItemGroup>";
+		const string TestCode = @"var output = Newtonsoft.Json.JsonConvert.SerializeObject (new int[] { 1, 2, 3 });";
+
+		// [TestCase (true)] https://github.com/xamarin/xamarin-macios/issues/4110
+		// [TestCase (false)] https://github.com/xamarin/xamarin-macios/issues/4110
+		public void AppsWithPackageReferencs_BuildAndRun (bool full)
+		{
+			MMPTests.RunMMPTest (tmpDir => {
+				var config = new TI.UnifiedTestConfig (tmpDir) {
+					ItemGroup = PackageReference,
+					TestCode = TestCode + @"			if (output == ""[1,2,3]"")
+				",
+					XM45 = full
+				};
+				TI.AddGUIDTestCode (config);
+
+				string project = TI.GenerateUnifiedExecutableProject (config);
+				TI.NugetRestore (project);
+				TI.BuildProject (project, true, useMSBuild: true);
+				TI.RunGeneratedUnifiedExecutable (config);
+			});
+		}
+
+		// [Test] https://github.com/xamarin/xamarin-macios/issues/4110
+		public void ExtensionProjectPackageReferencs_Build ()
+		{
+			MMPTests.RunMMPTest (tmpDir => {
+				TI.CopyDirectory (Path.Combine (TI.FindSourceDirectory (), @"Today"), tmpDir);
+
+				string project = Path.Combine (tmpDir, "Today/TodayExtensionTest.csproj");
+				string main = Path.Combine (tmpDir, "Today/TodayViewController.cs");
+
+				TI.CopyFileWithSubstitutions (project, project, s => s.Replace ("%ITEMGROUP%", PackageReference));
+				TI.CopyFileWithSubstitutions (main, main, s => s.Replace ("%TESTCODE%", TestCode));
+
+				TI.NugetRestore (project);
+				string output = TI.BuildProject (Path.Combine (tmpDir, "Today/TodayExtensionTest.csproj"), isUnified: true, useMSBuild: true);
+				Assert.IsTrue (!output.Contains ("MM2013"));
+			});
+		}
+	}
+}


### PR DESCRIPTION
Backport of https://github.com/xamarin/xamarin-macios/pull/4512 to `xcode10`

* [msbuild] Set 'CopyNuGetImplementations' to true for app extensions. Fixes #4235 and #4237.

In Xamarin.iOS.Common.targets, just before the _CompileToNative target, we
modify the mtouch references to ensure that we get the lib assemblies for
nugets, and not the ref references:

https://github.com/xamarin/xamarin-macios/blob/9e31d07ecc08a64372dd562e843c3d8950d24985/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets#L784-L791

This logic removes nuget references, and then re-adds any copy-local dll
references.

This works fine in executable projects, but not in library projects (aka
extensions), because nugets aren't copied for library projects:

https://github.com/NuGet/NuGet.BuildTasks/blob/cf4b0a12cf1f75e0654f28c2a9020251c41d126a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets#L86

So we need to set the CopyNuGetImplementations variable to 'true' for our
library projects.

Fixes https://github.com/xamarin/xamarin-macios/issues/4235.
Fixes https://github.com/xamarin/xamarin-macios/issues/4237.

* [tests] Redirect MSBuildExtensionsPath to MSBuildExtensionsPathFallbackPathsOverride when running msbuild for package reference tests.

This fixes a problem where nuget restore would fail for projects with
PackageReferences, because a variable would be empty and msbould would try to
write to /:

    nuget restore ../MyAppWithPackageReference/MyAppWithPackageReference.csproj
    MSBuild auto-detection: using msbuild version '15.0' from '/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/'.
    Restoring packages for /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/msbuild/tests/MyAppWithPackageReference/MyAppWithPackageReference.csproj...
    Committing restore...
    Generating MSBuild file /MyAppWithPackageReference.csproj.nuget.g.props.
    Path / is a directory

This will become unnecessary when PR #4111 is merged.

* Add Xamarin.Mac test showing that fix is not needed (?!?)

* Add AppExtension test with packagereference

* Make extension actually have json code generated

* Fix ProjectTypeGuids of checked in extension projects, as they were not openable in VSfM

* XM extension test now correctly fails

* Now that we have a failing test, fix XM same as rest of platforms

* Disable XM tests due to msbuild redirect sadness

* Disable iOS tests as well due to #4110

* Disable iOS tests by using the Ignore attribute.

Disable tests by using the Ignore attribute, because just commenting out the
TestCase attributes makes the test fail:

    1) NotRunnable : Xamarin.iOS.Tasks.ProjectReferenceTests.BasicTest
       No suitable constructor was found