### PR TITLE
[naturallanguage] Fix helper API for `NLTagger.GetTag` and cleanup/fix other API. Fixes #4774

### DIFF
--- a/src/NaturalLanguage/Enums.cs
+++ b/src/NaturalLanguage/Enums.cs
@@ -68,7 +68,7 @@ namespace NaturalLanguage {
 	public enum NLLanguage {
 		[DefaultEnumValue]
 		[Field (null)]
-		Unevaludated,
+		Unevaluated,
 		[Field ("NLLanguageUndetermined")]
 		Undetermined,
 		[Field ("NLLanguageAmharic")]

--- a/src/NaturalLanguage/Enums.cs
+++ b/src/NaturalLanguage/Enums.cs
@@ -67,6 +67,8 @@ namespace NaturalLanguage {
 	[iOS (12,0), Mac (10,14, onlyOn64: true), TV (12,0), Watch (5,0)]
 	public enum NLLanguage {
 		[DefaultEnumValue]
+		[Field (null)]
+		Unevaludated,
 		[Field ("NLLanguageUndetermined")]
 		Undetermined,
 		[Field ("NLLanguageAmharic")]
@@ -200,71 +202,4 @@ namespace NaturalLanguage {
 		[Field ("NLTagSchemeScript")]
 		Script,
 	}
-
-	[iOS (12,0), Mac (10,14, onlyOn64: true), TV (12,0), Watch (5,0)]
-	public enum NLTag {
-		[Field ("NLTagWord")]
-		Word,
-		[Field ("NLTagPunctuation")]
-		Punctuation,
-		[Field ("NLTagWhitespace")]
-		Whitespace,
-		[Field ("NLTagOther")]
-		Other, 
-		[Field ("NLTagNoun")]
-		Noun,
-		[Field ("NLTagVerb")]
-		Verb,
-		[Field ("NLTagAdjective")]
-		Adjective,
-		[Field ("NLTagAdverb")]
-		Adverb,
-		[Field ("NLTagPronoun")]
-		Pronoun,
-		[Field ("NLTagDeterminer")]
-		Determiner,
-		[Field ("NLTagParticle")]
-		Particle,
-		[Field ("NLTagPreposition")]
-		Preposition,
-		[Field ("NLTagNumber")]
-		Number,
-		[Field ("NLTagConjunction")]
-		Conjunction,
-		[Field ("NLTagInterjection")]
-		Interjection,
-		[Field ("NLTagClassifier")]
-		Classifier,
-		[Field ("NLTagIdiom")]
-		Idiom,
-		[Field ("NLTagOtherWord")]
-		OtherWord,
-		[Field ("NLTagSentenceTerminator")]
-		SentenceTerminator,
-		[Field ("NLTagOpenQuote")]
-		OpenQuote,
-		[Field ("NLTagCloseQuote")]
-		CloseQuote,
-		[Field ("NLTagOpenParenthesis")]
-		OpenParenthesis, 
-		[Field ("NLTagCloseParenthesis")]
-		CloseParenthesis,
-		[Field ("NLTagWordJoiner")]
-		WordJoiner,
-		[Field ("NLTagDash")]
-		Dash,
-		[Field ("NLTagOtherPunctuation")]
-		OtherPunctuation,
-		[Field ("NLTagParagraphBreak")]
-		ParagraphBreak,
-		[Field ("NLTagOtherWhitespace")]
-		OtherWhitespace,
-		[Field ("NLTagPersonalName")]
-		PersonalName,
-		[Field ("NLTagPlaceName")]
-		PlaceName,
-		[Field ("NLTagOrganizationName")]
-		OrganizationName, 
-	}
-
 }

--- a/src/naturallanguage.cs
+++ b/src/naturallanguage.cs
@@ -171,10 +171,10 @@ namespace NaturalLanguage {
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("initWithTagSchemes:")]
 		[DesignatedInitializer]
-		IntPtr Constructor (NSString[] tagSchemes);
+		IntPtr Constructor ([Params] NSString[] tagSchemes);
 
 		[Wrap ("this (Array.ConvertAll (tagSchemes, e => e.GetConstant ()))")]
-		IntPtr Constructor (NLTagScheme[] tagSchemes);
+		IntPtr Constructor ([Params] NLTagScheme[] tagSchemes);
 
 		[Internal]
 		[Export ("tagSchemes", ArgumentSemantic.Copy)]
@@ -215,17 +215,18 @@ namespace NaturalLanguage {
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("tagAtIndex:unit:scheme:tokenRange:")]
 		[return: NullAllowed]
-		NSString GetTag (nuint characterIndex, NLTokenUnit unit, NSString scheme, [NullAllowed] NSRange tokenRange);
+		NSString GetTag (nuint characterIndex, NLTokenUnit unit, NSString scheme, out NSRange tokenRange);
 
-		[Wrap ("NLTagExtensions.GetValue (GetTag (characterIndex, unit, scheme.GetConstant (), tokenRange))")]
-		NLTag GetTag (nuint characterIndex, NLTokenUnit unit, NLTagScheme scheme, [NullAllowed] NSRange tokenRange);
+		[return: NullAllowed]
+		[Wrap ("GetTag (characterIndex, unit, scheme.GetConstant (), out tokenRange)")]
+		NSString GetTag (nuint characterIndex, NLTokenUnit unit, NLTagScheme scheme, out NSRange tokenRange);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("tagsInRange:unit:scheme:options:tokenRanges:")]
 		NSString[] GetTags (NSRange range, NLTokenUnit unit, NSString scheme, NLTaggerOptions options, [NullAllowed] out NSValue[] tokenRanges);
 
-		[Wrap ("Array.ConvertAll (GetTags (range, unit, scheme.GetConstant (), options, out tokenRanges), e => NLTagExtensions.GetValue (e))")]
-		NLTag[] GetTags (NSRange range, NLTokenUnit unit, NLTagScheme scheme, NLTaggerOptions options, [NullAllowed] out NSValue[] tokenRanges);
+		[Wrap ("GetTags (range, unit, scheme.GetConstant (), options, out tokenRanges)")]
+		NSString[] GetTags (NSRange range, NLTokenUnit unit, NLTagScheme scheme, NLTaggerOptions options, [NullAllowed] out NSValue[] tokenRanges);
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("setLanguage:range:")]
@@ -250,5 +251,72 @@ namespace NaturalLanguage {
 
 		[Wrap ("GetModels (tagScheme.GetConstant ())")]
 		NLModel[] GetModels (NLTagScheme tagScheme);
+	}
+
+	[iOS (12,0), Mac (10,14, onlyOn64: true), TV (12,0), Watch (5,0)]
+	[Static] // only used to compare with NSString not as input/output
+	interface NLTag {
+		[Field ("NLTagWord")]
+		NSString Word { get; }
+		[Field ("NLTagPunctuation")]
+		NSString Punctuation { get; }
+		[Field ("NLTagWhitespace")]
+		NSString Whitespace { get; }
+		[Field ("NLTagOther")]
+		NSString Other { get; }
+		[Field ("NLTagNoun")]
+		NSString Noun { get; }
+		[Field ("NLTagVerb")]
+		NSString Verb { get; }
+		[Field ("NLTagAdjective")]
+		NSString Adjective { get; }
+		[Field ("NLTagAdverb")]
+		NSString Adverb { get; }
+		[Field ("NLTagPronoun")]
+		NSString Pronoun { get; }
+		[Field ("NLTagDeterminer")]
+		NSString Determiner { get; }
+		[Field ("NLTagParticle")]
+		NSString Particle { get; }
+		[Field ("NLTagPreposition")]
+		NSString Preposition { get; }
+		[Field ("NLTagNumber")]
+		NSString Number { get; }
+		[Field ("NLTagConjunction")]
+		NSString Conjunction { get; }
+		[Field ("NLTagInterjection")]
+		NSString Interjection { get; }
+		[Field ("NLTagClassifier")]
+		NSString Classifier { get; }
+		[Field ("NLTagIdiom")]
+		NSString Idiom { get; }
+		[Field ("NLTagOtherWord")]
+		NSString OtherWord { get; }
+		[Field ("NLTagSentenceTerminator")]
+		NSString SentenceTerminator { get; }
+		[Field ("NLTagOpenQuote")]
+		NSString OpenQuote { get; }
+		[Field ("NLTagCloseQuote")]
+		NSString CloseQuote { get; }
+		[Field ("NLTagOpenParenthesis")]
+		NSString OpenParenthesis { get; }
+		[Field ("NLTagCloseParenthesis")]
+		NSString CloseParenthesis { get; }
+		[Field ("NLTagWordJoiner")]
+		NSString WordJoiner { get; }
+		[Field ("NLTagDash")]
+		NSString Dash { get; }
+		[Field ("NLTagOtherPunctuation")]
+		NSString OtherPunctuation { get; }
+		[Field ("NLTagParagraphBreak")]
+		NSString ParagraphBreak { get; }
+		[Field ("NLTagOtherWhitespace")]
+		NSString OtherWhitespace { get; }
+		[Field ("NLTagPersonalName")]
+		NSString PersonalName { get; }
+		[Field ("NLTagPlaceName")]
+		NSString PlaceName { get; }
+		[Field ("NLTagOrganizationName")]
+		NSString OrganizationName { get; }
 	}
 }

--- a/tests/monotouch-test/NaturalLanguage/NLLanguageRecognizerTest.cs
+++ b/tests/monotouch-test/NaturalLanguage/NLLanguageRecognizerTest.cs
@@ -7,17 +7,10 @@
 // Copyright 2018 Microsoft Corp. All rights reserved.
 //
 
-#if !__WATCHOS__ 
-
 using System;
 using System.Collections.Generic;
-#if XAMCORE_2_0
 using Foundation;
 using NaturalLanguage;
-#else
-using MonoTouch.Foundation;
-using MonoTouch.NaturalLanguage;
-#endif
 using NUnit.Framework;
 
 namespace MonoTouchFixtures.NaturalLanguage {
@@ -41,38 +34,26 @@ namespace MonoTouchFixtures.NaturalLanguage {
 		}
 
 		[Test]
-		public void GetLanguageHypothesesTest ()
+		public void Process ()
 		{
 			using (var recognizer = new NLLanguageRecognizer ()) {
 				var languages = new Dictionary<NLLanguage, double> () {
 					{ NLLanguage.German, 1 },
 					{ NLLanguage.Spanish, 10 },
 				};
+				Assert.That (recognizer.LanguageHints.Count, Is.EqualTo (0), "LanguageHints/0");
 				recognizer.LanguageHints = languages;
+				Assert.That (recognizer.LanguageHints.Count, Is.EqualTo (2), "LanguageHints/2");
 
+				Assert.That (recognizer.DominantLanguage, Is.EqualTo (NLLanguage.Unevaludated), "DominantLanguage/Pre-Process");
 				var text = "Die Kleinen haben friedlich zusammen gespielt.";
 				recognizer.Process (text);
+				Assert.That (recognizer.DominantLanguage, Is.EqualTo (NLLanguage.German), "DominantLanguage/Post-Process");
+
 				// just test that we do return something. We are not testing the API perse.
 				var hypo = recognizer.GetLanguageHypotheses (5);
-				Assert.AreNotEqual (0, hypo.Keys.Count);
-			}
-		}
-
-		[Test]
-		public void LanguageHintsTest ()
-		{
-			var languages = new Dictionary<NLLanguage, double> () {
-				{ NLLanguage.German, 1 },
-				{ NLLanguage.Spanish, 10 },
-			};
-			using (var recognizer = new NLLanguageRecognizer ()) {
-				// testing setter
-				recognizer.LanguageHints = languages;
-				// testing getter
-				Assert.AreEqual (languages.Keys.Count, recognizer.LanguageHints.Keys.Count, "Size");
+				Assert.That (hypo.Count, Is.GreaterThan (0), "GetLanguageHypotheses");
 			}
 		}
 	}
 }
-
-#endif // !__WATCHOS__

--- a/tests/monotouch-test/NaturalLanguage/NLLanguageRecognizerTest.cs
+++ b/tests/monotouch-test/NaturalLanguage/NLLanguageRecognizerTest.cs
@@ -45,7 +45,7 @@ namespace MonoTouchFixtures.NaturalLanguage {
 				recognizer.LanguageHints = languages;
 				Assert.That (recognizer.LanguageHints.Count, Is.EqualTo (2), "LanguageHints/2");
 
-				Assert.That (recognizer.DominantLanguage, Is.EqualTo (NLLanguage.Unevaludated), "DominantLanguage/Pre-Process");
+				Assert.That (recognizer.DominantLanguage, Is.EqualTo (NLLanguage.Unevaluated), "DominantLanguage/Pre-Process");
 				var text = "Die Kleinen haben friedlich zusammen gespielt.";
 				recognizer.Process (text);
 				Assert.That (recognizer.DominantLanguage, Is.EqualTo (NLLanguage.German), "DominantLanguage/Post-Process");

--- a/tests/monotouch-test/NaturalLanguage/NLTaggerTest.cs
+++ b/tests/monotouch-test/NaturalLanguage/NLTaggerTest.cs
@@ -28,7 +28,11 @@ namespace MonoTouchFixtures.NaturalLanguage {
 		{
 			using (var tagger = new NLTagger (NLTagScheme.Lemma) { String = Text })
 			using (var tag = tagger.GetTag (0, NLTokenUnit.Word, NLTagScheme.Lemma, out var range)) {
+				Assert.That (tagger.DominantLanguage, Is.EqualTo (NLLanguage.English), "DominantLanguage");
+#if !__TVOS__
+				// works everywhere expect tvOS
 				Assert.That (tag.ToString (), Is.EqualTo ("the"), "First word");
+#endif
 				Assert.That (range.Location, Is.EqualTo (0), "Location");
 				Assert.That (range.Length, Is.EqualTo (3), "Length");
 			}
@@ -38,6 +42,7 @@ namespace MonoTouchFixtures.NaturalLanguage {
 		public void GetTags ()
 		{
 			using (var tagger = new NLTagger (NLTagScheme.LexicalClass, NLTagScheme.Lemma) { String = Text }) {
+				Assert.That (tagger.DominantLanguage, Is.EqualTo (NLLanguage.English), "DominantLanguage");
 				var tags = tagger.GetTags (new NSRange (0, Text.Length), NLTokenUnit.Word, NLTagScheme.Lemma, NLTaggerOptions.OmitWhitespace | NLTaggerOptions.OmitPunctuation, out var ranges);
 				Assert.That (tags.Length, Is.EqualTo (ranges.Length), "Length");
 				foreach (var tag in tags)

--- a/tests/monotouch-test/NaturalLanguage/NLTaggerTest.cs
+++ b/tests/monotouch-test/NaturalLanguage/NLTaggerTest.cs
@@ -1,0 +1,48 @@
+﻿//
+// Unit tests for NLTagger
+//
+// Copyright 2018 Microsoft Corp. All rights reserved.
+//
+
+using System;
+using Foundation;
+using NaturalLanguage;
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.NaturalLanguage {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class NLTaggerTest {
+
+		const string Text = "The ripe taste of cheese improves with age, but it can not get younger nor shouldn't it.";
+
+		[SetUp]
+		public void SetUp ()
+		{
+			TestRuntime.AssertXcodeVersion (10, 0);
+		}
+
+		[Test]
+		public void GetTag ()
+		{
+			using (var tagger = new NLTagger (NLTagScheme.Lemma) { String = Text })
+			using (var tag = tagger.GetTag (0, NLTokenUnit.Word, NLTagScheme.Lemma, out var range)) {
+				Assert.That (tag.ToString (), Is.EqualTo ("the"), "First word");
+				Assert.That (range.Location, Is.EqualTo (0), "Location");
+				Assert.That (range.Length, Is.EqualTo (3), "Length");
+			}
+	       }
+
+		[Test]
+		public void GetTags ()
+		{
+			using (var tagger = new NLTagger (NLTagScheme.LexicalClass, NLTagScheme.Lemma) { String = Text }) {
+				var tags = tagger.GetTags (new NSRange (0, Text.Length), NLTokenUnit.Word, NLTagScheme.Lemma, NLTaggerOptions.OmitWhitespace | NLTaggerOptions.OmitPunctuation, out var ranges);
+				Assert.That (tags.Length, Is.EqualTo (ranges.Length), "Length");
+				foreach (var tag in tags)
+					Assert.NotNull (tag, tag);
+			}
+		}
+       }
+}


### PR DESCRIPTION
* Move `NLTag` to static class (instead of enum) since it's not used in API, except along NSString. Fixes https://github.com/xamarin/xamarin-macios/issues/4774
* Add new member to `NLLanguage` to avoid `ArgumentNullException` when it has not been evaludated (API returns `null`), see unit tests;
* Add `[Params]` to `NLTagger` constructors so they are easier to use (no need to create the array in source);
* Fix `GetTag` so it returns (`out`) the `NSRange`, it's natively a `NSRangePointer`;
* Fix `GetTag[s]` API with changes to `NLTag` de-enumification;
* Add unit tests