### PR TITLE
[security] SecProtocolMetadata update and tests

### DIFF
--- a/src/Security/SecProtocolMetadata.cs
+++ b/src/Security/SecProtocolMetadata.cs
@@ -34,7 +34,7 @@ namespace Security {
 		extern static IntPtr sec_protocol_metadata_copy_peer_public_key (IntPtr handle);
 
 #if !COREBUILD
-		public DispatchData PeerPublicKey => new DispatchData (sec_protocol_metadata_copy_peer_public_key (GetCheckedHandle ()), owns: true);
+		public DispatchData PeerPublicKey => CreateDispatchData (sec_protocol_metadata_copy_peer_public_key (GetCheckedHandle ()));
 #endif
 		[DllImport (Constants.SecurityLibrary)]
 		extern static SslProtocol sec_protocol_metadata_get_negotiated_protocol_version (IntPtr handle);
@@ -218,6 +218,36 @@ namespace Security {
 			}
  		}
 
+#if false
+		[DllImport (Constants.SecurityLibrary)]
+		static extern /* OS_dispatch_data */ IntPtr sec_protocol_metadata_create_secret (/* OS_sec_protocol_metadata */ IntPtr metadata, /* size_t */ nuint label_len, /* const char*/ [MarshalAs(UnmanagedType.LPStr)] string label, /* size_t */ nuint exporter_length);
+
+		public DispatchData CreateSecret (string label, nuint exporterLength)
+		{
+			if (label == null)
+				throw new ArgumentNullException (nameof (label));
+			return CreateDispatchData (sec_protocol_metadata_create_secret (GetCheckedHandle (), (nuint) label.Length, label, exporterLength));
+		}
+
+		[DllImport (Constants.SecurityLibrary)]
+		static unsafe extern /* OS_dispatch_data */ IntPtr sec_protocol_metadata_create_secret_with_context (/* OS_sec_protocol_metadata */ IntPtr metadata, /* size_t */ nuint label_len, /* const char*/ [MarshalAs(UnmanagedType.LPStr)] string label, /* size_t */  nuint context_len, byte* context, /* size_t */ nuint exporter_length);
+
+		public unsafe DispatchData CreateSecret (string label, byte[] context, nuint exporterLength)
+		{
+			if (label == null)
+				throw new ArgumentNullException (nameof (label));
+			if (context == null)
+				throw new ArgumentNullException (nameof (context));
+			fixed (byte* p = context)
+				return CreateDispatchData (sec_protocol_metadata_create_secret_with_context (GetCheckedHandle (), (nuint) label.Length, label, (nuint) context.Length, p, exporterLength));
+		}
+#endif
+		// API returning `OS_dispatch_data` can also return `null` and
+		// a managed instance with (with an empty handle) is not the same
+		static DispatchData CreateDispatchData (IntPtr handle)
+		{
+			return handle == IntPtr.Zero ? null : new DispatchData (handle, owns: true);
+		}
 #endif
 	}
 }

--- a/tests/monotouch-test/Network/NWProtocolMetadataTest.cs
+++ b/tests/monotouch-test/Network/NWProtocolMetadataTest.cs
@@ -1,0 +1,52 @@
+﻿#if !__WATCHOS__
+using System;
+using Foundation;
+using Network;
+using ObjCRuntime;
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.Network {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class NWProtocolMetadataTest {
+
+		[SetUp]
+		public void SetUp ()
+		{
+			TestRuntime.AssertXcodeVersion (10,0);
+		}
+
+		[Test]
+		public void IP ()
+		{
+			using (var m = NWProtocolMetadata.CreateIPMetadata ()) {
+				Assert.That (m.IPMetadataEcnFlag, Is.EqualTo (NWIPEcnFlag.NonEct), "IPMetadataEcnFlag");
+				Assert.That (m.IPMetadataReceiveTime, Is.EqualTo (0), "IPMetadataReceiveTime");
+				Assert.True (m.IsIP, "IsIP");
+				Assert.False (m.IsTcp, "IsTcp");
+				Assert.False (m.IsUdp, "IsUdp");
+				Assert.NotNull (m.ProtocolDefinition, "ProtocolDefinition");
+				Assert.NotNull (m.SecProtocolMetadata, "SecProtocolMetadata");
+				Assert.That (m.ServiceClass, Is.EqualTo (NWServiceClass.BestEffort), "ServiceClass");
+			}
+		}
+
+		[Test]
+		public void Udp ()
+		{
+			using (var m = NWProtocolMetadata.CreateUdpMetadata ()) {
+				Assert.That (m.IPMetadataEcnFlag, Is.EqualTo (NWIPEcnFlag.NonEct), "IPMetadataEcnFlag");
+				Assert.That (m.IPMetadataReceiveTime, Is.EqualTo (0), "IPMetadataReceiveTime");
+				Assert.False (m.IsIP, "IsIP");
+				Assert.False (m.IsTcp, "IsTcp");
+				Assert.True (m.IsUdp, "IsUdp");
+				Assert.NotNull (m.ProtocolDefinition, "ProtocolDefinition");
+				Assert.NotNull (m.SecProtocolMetadata, "SecProtocolMetadata");
+				Assert.That (m.ServiceClass, Is.EqualTo (NWServiceClass.BestEffort), "ServiceClass");
+			}
+		}
+	}
+}
+#endif

--- a/tests/monotouch-test/Security/SecProtocolMetadataTest.cs
+++ b/tests/monotouch-test/Security/SecProtocolMetadataTest.cs
@@ -1,0 +1,60 @@
+﻿#if !__WATCHOS__
+using System;
+using System.Runtime.InteropServices;
+using Foundation;
+using Network;
+using ObjCRuntime;
+using Security;
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.Security {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class SecProtocolMetadataTest {
+
+		[SetUp]
+		public void SetUp ()
+		{
+			TestRuntime.AssertXcodeVersion (10,0);
+		}
+
+		[Test]
+		public void IPDefaults ()
+		{
+			using (var m = NWProtocolMetadata.CreateIPMetadata ()) {
+				var s = m.SecProtocolMetadata;
+				Assert.False (s.EarlyDataAccepted, "EarlyDataAccepted");
+				Assert.That (s.NegotiatedCipherSuite, Is.EqualTo (SslCipherSuite.SSL_NULL_WITH_NULL_NULL), "NegotiatedCipherSuite");
+				Assert.Null (s.NegotiatedProtocol, "NegotiatedProtocol");
+				Assert.That (s.NegotiatedProtocolVersion, Is.EqualTo (SslProtocol.Unknown), "NegotiatedProtocolVersion");
+				Assert.Null (s.PeerPublicKey, "PeerPublicKey");
+#if false
+				Assert.True (SecProtocolMetadata.ChallengeParametersAreEqual (s, s), "ChallengeParametersAreEqual");
+				Assert.True (SecProtocolMetadata.PeersAreEqual (s, s), "PeersAreEqual");
+#endif
+			}
+		}
+
+#if false
+		[DllImport (Constants.CoreFoundationLibrary)]
+		extern static nint CFGetRetainCount (IntPtr handle);
+
+		[Test]
+		public void CreateSecret ()
+		{
+			using (var npm = NWProtocolMetadata.CreateIPMetadata ()) {
+				// `npm` and `spm` have the same handle - same internal object satistfy both protocols
+				Console.WriteLine ($"{CFGetRetainCount (npm.Handle)}");
+				using (var spm = npm.SecProtocolMetadata) {
+					Console.WriteLine ($"{CFGetRetainCount (npm.Handle)}");
+					Console.WriteLine ($"{CFGetRetainCount (spm.Handle)}");
+					var secret = spm.CreateSecret ("test", 16); // crash
+				}
+			}
+		}
+#endif
+	}
+}
+#endif

--- a/tests/xtro-sharpie/common-Security.ignore
+++ b/tests/xtro-sharpie/common-Security.ignore
@@ -26,3 +26,7 @@
 !missing-protocol! OS_sec_protocol_metadata not bound
 !missing-protocol! OS_sec_protocol_options not bound
 !missing-protocol! OS_sec_trust not bound
+
+## test crash (API and test commented) - better test case needed
+!missing-pinvoke! sec_protocol_metadata_create_secret is not bound
+!missing-pinvoke! sec_protocol_metadata_create_secret_with_context is not bound

--- a/tests/xtro-sharpie/iOS-Security.todo
+++ b/tests/xtro-sharpie/iOS-Security.todo
@@ -1,4 +1,2 @@
-!missing-pinvoke! sec_protocol_metadata_create_secret is not bound
-!missing-pinvoke! sec_protocol_metadata_create_secret_with_context is not bound
 !missing-pinvoke! sec_protocol_options_set_challenge_block is not bound
 !missing-pinvoke! sec_protocol_options_set_verify_block is not bound

--- a/tests/xtro-sharpie/macOS-Security.todo
+++ b/tests/xtro-sharpie/macOS-Security.todo
@@ -1,5 +1,3 @@
 !missing-field! kSecCodeInfoRuntimeVersion not bound
-!missing-pinvoke! sec_protocol_metadata_create_secret is not bound
-!missing-pinvoke! sec_protocol_metadata_create_secret_with_context is not bound
 !missing-pinvoke! sec_protocol_options_set_challenge_block is not bound
 !missing-pinvoke! sec_protocol_options_set_verify_block is not bound

--- a/tests/xtro-sharpie/tvOS-Security.todo
+++ b/tests/xtro-sharpie/tvOS-Security.todo
@@ -1,4 +1,2 @@
-!missing-pinvoke! sec_protocol_metadata_create_secret is not bound
-!missing-pinvoke! sec_protocol_metadata_create_secret_with_context is not bound
 !missing-pinvoke! sec_protocol_options_set_challenge_block is not bound
 !missing-pinvoke! sec_protocol_options_set_verify_block is not bound

--- a/tests/xtro-sharpie/watchOS-Security.todo
+++ b/tests/xtro-sharpie/watchOS-Security.todo
@@ -1,4 +1,2 @@
-!missing-pinvoke! sec_protocol_metadata_create_secret is not bound
-!missing-pinvoke! sec_protocol_metadata_create_secret_with_context is not bound
 !missing-pinvoke! sec_protocol_options_set_challenge_block is not bound
 !missing-pinvoke! sec_protocol_options_set_verify_block is not bound


### PR DESCRIPTION
* Avoid `ArgumentNullException` in default/empty `SecProtocolMetadata.PeerPublicKey`
* Add two `SecProtocolMetadata.CreateSecret` API - disabled as the current tests (incomplete?) crash in unit tests
* Add basic unit tests for `[Sec|NW]ProtocolMetadata`
* Update xtro