### PR TITLE
[tests] Fix flaky SecProtocolMetadata.EarlyDataAccepted result

### DIFF
--- a/tests/monotouch-test/Security/SecProtocolMetadataTest.cs
+++ b/tests/monotouch-test/Security/SecProtocolMetadataTest.cs
@@ -25,7 +25,8 @@ namespace MonoTouchFixtures.Security {
 		{
 			using (var m = NWProtocolMetadata.CreateIPMetadata ()) {
 				var s = m.SecProtocolMetadata;
-				Assert.False (s.EarlyDataAccepted, "EarlyDataAccepted");
+				// This is mostly, but not always, returning false
+				// Assert.False (s.EarlyDataAccepted, "EarlyDataAccepted");
 				Assert.That (s.NegotiatedCipherSuite, Is.EqualTo (SslCipherSuite.SSL_NULL_WITH_NULL_NULL), "NegotiatedCipherSuite");
 				Assert.Null (s.NegotiatedProtocol, "NegotiatedProtocol");
 				Assert.That (s.NegotiatedProtocolVersion, Is.EqualTo (SslProtocol.Unknown), "NegotiatedProtocolVersion");


### PR DESCRIPTION
Result is mostly, but not always, `false` and that _might_ be due
to how we're testing the API.

ref: https://github.com/xamarin/maccore/issues/1026