### PR TITLE
[Tests] force the IP version to fix tests on bots.

### DIFF
--- a/tests/monotouch-test/Network/NWPathTest.cs
+++ b/tests/monotouch-test/Network/NWPathTest.cs
@@ -42,6 +42,10 @@ namespace MonoTouchFixtures.Network {
 			using (var parameters = NWParameters.CreateUdp ())
 			using (var endpoint = NWEndpoint.Create (host, "80"))
 			{
+				using (var protocolStack = parameters.ProtocolStack) {
+					var ipOptions = protocolStack.InternetProtocol;
+					ipOptions.IPSetVersion (NWIPVersion.Version4);
+				}
 				connection = new NWConnection (endpoint, parameters);
 				connection.SetQueue (DispatchQueue.DefaultGlobalQueue); // important, else we will get blocked
 				connection.SetStateChangeHandler (ConnectionStateHandler);


### PR DESCRIPTION
The jenkins bots are configured to use IPV6 in the default interface, which means that we need to force the version so that the default expected value is false.

Sample of the bot config:

xam-macios-mojave-1:~ builder$ ifconfig en0
en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
        options=10b<RXCSUM,TXCSUM,VLAN_HWTAGGING,AV>
        ether 0c:4d:e9:ae:63:25 
        inet6 fe80::18cc:2c0b:138:5bec%en0 prefixlen 64 secured scopeid 0x8 
        inet6 2001:4898:4030:9:14c2:b5c2:b2d2:7d97 prefixlen 64 autoconf secured 
        inet6 2001:4898:4030:9:8d60:e0af:fb2e:4e55 prefixlen 64 autoconf temporary 
        inet 10.128.35.50 netmask 0xfffffe00 broadcast 10.128.35.255
        nd6 options=201<PERFORMNUD,DAD>
        media: autoselect (1000baseT <full-duplex>)
        status: active

Fixes https://github.com/xamarin/maccore/issues/1030