### PR TITLE
[mtouch] Don't pass -read_only_relocs to clang when compiling 64-bit code. Fixes #4735.

### DIFF
--- a/tools/mtouch/BuildTasks.mtouch.cs
+++ b/tools/mtouch/BuildTasks.mtouch.cs
@@ -486,7 +486,7 @@ namespace Xamarin.Bundler
 				throw new ArgumentNullException (nameof (install_name));
 
 			flags.AddOtherFlag ("-shared");
-			if (!App.EnableBitCode)
+			if (!App.EnableBitCode && !Target.Is64Build)
 				flags.AddOtherFlag ("-read_only_relocs suppress");
 			if (App.EnableBitCode)
 				flags.AddOtherFlag ("-lc++");


### PR DESCRIPTION
Fixes this ld warning:

    ld : warning : -read_only_relocs cannot be used with arm64

Fixes https://github.com/xamarin/xamarin-macios/issues/4735.