### PR TITLE
[tests][introspection] Re-enable 'RPSystemBroadcastPickerView' in tests

### DIFF
--- a/tests/introspection/iOS/iOSApiCtorInitTest.cs
+++ b/tests/introspection/iOS/iOSApiCtorInitTest.cs
@@ -222,7 +222,6 @@ namespace Introspection {
 			case "INGetRestaurantGuestIntentResponse": // Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: Unable to initialize 'INGetRestaurantGuestIntentResponse'. Please make sure that your intent definition file is valid.
 				return TestRuntime.CheckXcodeVersion (10,0);
 			case "CMMovementDisorderManager": // Not available in simulator, added info to radar://41110708 
-			case "RPSystemBroadcastPickerView": // Symbol not available in simulator
 				return Runtime.Arch == Arch.SIMULATOR;
 			default:
 				return base.Skip (type);

--- a/tests/introspection/iOS/iOSApiProtocolTest.cs
+++ b/tests/introspection/iOS/iOSApiProtocolTest.cs
@@ -63,7 +63,6 @@ namespace Introspection {
 				break;
 			case "MTLFence":
 			case "MTLHeap":
-			case "RPSystemBroadcastPickerView": // Symbol not available in simulator
 				if (Runtime.Arch != Arch.DEVICE)
 					return true;
 


### PR DESCRIPTION
The type was not available in the simulator(s) before GM

ref: https://github.com/xamarin/xamarin-macios/issues/4189