### PR TITLE
[mtouch/mmp] Always show the complete version.

### DIFF
--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -492,7 +492,7 @@ namespace Xamarin.Bundler {
 
 			App.InitializeCommon ();
 
-			Log ("Xamarin.Mac {0}{1}", Constants.Version, verbose > 0 ? "." + Constants.Revision : string.Empty);
+			Log ("Xamarin.Mac {0}.{1}", Constants.Version, Constants.Revision);
 
 			if (verbose > 0)
 				Console.WriteLine ("Selected target framework: {0}; API: {1}", targetFramework, IsClassic ? "Classic" : "Unified");

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1339,7 +1339,7 @@ namespace Xamarin.Bundler
 				throw new MonoTouchException (25, true, "No SDK version was provided. Please add --sdk=X.Y to specify which {0} SDK should be used to build your application.", app.PlatformName);
 
 			var framework_dir = GetFrameworkDirectory (app);
-			Driver.Log ("Xamarin.iOS {0}{1} using framework: {2}", Constants.Version, verbose > 1 ? "." + Constants.Revision : string.Empty, framework_dir);
+			Driver.Log ("Xamarin.iOS {0}.{1} using framework: {2}", Constants.Version, Constants.Revision, framework_dir);
 
 			if (action == Action.None)
 				throw new MonoTouchException (52, true, "No command specified.");


### PR DESCRIPTION
This makes failure diagnosis based on the exact XI/XM version much easier when
builds aren't verbose.

Example: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/632392