### PR TITLE
[clockkit] Add missing 'CLKComplicationFamily' enum values

### DIFF
--- a/src/ClockKit/CLKEnums.cs
+++ b/src/ClockKit/CLKEnums.cs
@@ -25,13 +25,13 @@ namespace ClockKit {
 		[Watch (3,0)]
 		ExtraLarge = 7,
 		[Watch (5,0)]
-		GraphicCorner = 8,
+		GraphicCorner,
 		[Watch (5,0)]
-		GraphicBezel = 9,
+		GraphicBezel,
 		[Watch (5,0)]
-		GraphicCircular = 10,
+		GraphicCircular,
 		[Watch (5,0)]
-		GraphicRectangular = 11,
+		GraphicRectangular,
 	}
 
 	[Native]

--- a/src/ClockKit/CLKEnums.cs
+++ b/src/ClockKit/CLKEnums.cs
@@ -24,6 +24,14 @@ namespace ClockKit {
 		UtilitarianSmallFlat = 6,
 		[Watch (3,0)]
 		ExtraLarge = 7,
+		[Watch (5,0)]
+		GraphicCorner = 8,
+		[Watch (5,0)]
+		GraphicBezel = 9,
+		[Watch (5,0)]
+		GraphicCircular = 10,
+		[Watch (5,0)]
+		GraphicRectangular = 11,
 	}
 
 	[Native]


### PR DESCRIPTION
From Xcode 10 GM API diff: https://github.com/xamarin/xamarin-macios/wiki/ClockKit-watchOS-xcode10-GM

``` diff
--- /Applications/Xcode10-beta6.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk/System/Library/Frameworks/ClockKit.framework/Headers/CLKDefines.h	2018-08-10 17:39:53.000000000 -0400
+++ /Applications/Xcode10GM.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk/System/Library/Frameworks/ClockKit.framework/Headers/CLKDefines.h	2018-08-29 05:55:06.000000000 -0400
@@ -19,6 +19,10 @@
     CLKComplicationFamilyCircularSmall                                                        = 4,
     CLKComplicationFamilyExtraLarge CLK_AVAILABLE_WATCHOS_IOS(3_0, 10_0)                      = 7,
     
+    CLKComplicationFamilyGraphicCorner CLK_AVAILABLE_WATCHOS_IOS(5_0, 12_0)                 = 8,
+    CLKComplicationFamilyGraphicBezel CLK_AVAILABLE_WATCHOS_IOS(5_0, 12_0)                  = 9,
+    CLKComplicationFamilyGraphicCircular CLK_AVAILABLE_WATCHOS_IOS(5_0, 12_0)               = 10,
+    CLKComplicationFamilyGraphicRectangular CLK_AVAILABLE_WATCHOS_IOS(5_0, 12_0)            = 11,
 };
```

These are important enum values related to the new "graphic" complications types.