### PR TITLE
[Metal] Fixe the size of structures. Fixes #4611

### DIFF
--- a/src/Metal/Defs.cs
+++ b/src/Metal/Defs.cs
@@ -279,7 +279,9 @@ namespace Metal {
 	[StructLayout (LayoutKind.Sequential)]
 	public struct MTLQuadTessellationFactorsHalf
 	{
+		[MarshalAs (UnmanagedType.ByValArray, SizeConst = 4)]
 		public ushort[] EdgeTessellationFactor;
+		[MarshalAs (UnmanagedType.ByValArray, SizeConst = 2)]
 		public ushort[] InsideTessellationFactor;
 		
 		public MTLQuadTessellationFactorsHalf (ushort[] edgeTessellationFactor, ushort[] insideTessellationFactor)
@@ -294,6 +296,7 @@ namespace Metal {
 	[StructLayout (LayoutKind.Sequential)]
 	public struct MTLTriangleTessellationFactorsHalf
 	{
+		[MarshalAs (UnmanagedType.ByValArray, SizeConst = 3)]
 		public ushort[] EdgeTessellationFactor;
 		public ushort InsideTessellationFactor;
 		

--- a/tests/monotouch-test/Metal/StructTest.cs
+++ b/tests/monotouch-test/Metal/StructTest.cs
@@ -1,0 +1,36 @@
+#if !__WATCHOS__
+
+using System;
+using System.Runtime.InteropServices;
+
+#if XAMCORE_2_0
+using Metal;
+#else
+using MonoTouch.Metal;
+#endif
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.Metal {
+	
+	[TestFixture]
+	public class StructTest {
+		
+		[Test]
+		public void MTLQuadTessellationFactorsHalfStructSize ()
+		{
+			// tested with a native iOS app
+			Assert.AreEqual (12, Marshal.SizeOf<MTLQuadTessellationFactorsHalf> (), $"Reported size was {Marshal.SizeOf<MTLQuadTessellationFactorsHalf> ()}");
+		}
+
+		[Test]
+		public void MTLTriangleTessellationFactorsHalfStructSize ()
+		{
+			// tested with a native iOS app
+			Assert.AreEqual (8, Marshal.SizeOf<MTLTriangleTessellationFactorsHalf> (), $"Reported size was {Marshal.SizeOf<MTLTriangleTessellationFactorsHalf> ()}");
+		}
+	}
+}
+
+#endif // !__WATCHOS__
+


### PR DESCRIPTION
The structs MTLQuadTessellationFactorsHalf and
MTLTriangleTessellationFactorsHalf are wrong as per the header
definition:

typedef struct {
    /* NOTE: edgeTessellationFactor and insideTessellationFactor are interpreted as half (16-bit floats) */
    uint16_t edgeTessellationFactor[4];
    uint16_t insideTessellationFactor[2];
} MTLQuadTessellationFactorsHalf;

typedef struct {
    /* NOTE: edgeTessellationFactor and insideTessellationFactor are interpreted as half (16-bit floats) */
    uint16_t edgeTessellationFactor[3];
    uint16_t insideTessellationFactor;
} MTLTriangleTessellationFactorsHalf;

We set the arrays size to be the correct one.

Fixes https://github.com/xamarin/xamarin-macios/issues/4611