### PR TITLE
[ObjCRuntime] Make available a version of Runtime.GetINativeObject that takes the target type as a System.Type.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -1363,10 +1363,13 @@ namespace ObjCRuntime {
 			return implementation;
 		}
 
+		public static INativeObject GetINativeObject (IntPtr ptr, bool owns, Type target_type)
+		{
+			return GetINativeObject (ptr, owns, target_type, null);
+		}
+
 		// this method is identical in behavior to the generic one.
-		// TODO: figure out if it's possible to call the generic 
-		// implementation from native code.
-		static INativeObject GetINativeObject (IntPtr ptr, bool owns, Type target_type, Type implementation = null)
+		static INativeObject GetINativeObject (IntPtr ptr, bool owns, Type target_type, Type implementation)
 		{
 			if (ptr == IntPtr.Zero)
 				return null;


### PR DESCRIPTION
Swift-o-matic needs it, see https://github.com/xamarin/maccore/pull/1049/files#diff-eeaff638ac8b77c777e1bde26cdf6a40R1938.

Also remove a FIXME/unneeded comment. The existing Runtime.GetINativeObject
(..., Type) existed because it's hard to call a generic function from native
code, but if one day that could be figured out, then this managed function
could be removed.

Now that the function is public, we can't remove it even if we figure out how
to call the generic version, so the FIXME is no longer needed.