### PR TITLE
[mtouch/mmp/docs] Improve MT0091 to include how to enable the linker. Fixes #4549.

### DIFF
--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -153,6 +153,8 @@ Xamarin.Mac requires the header files, from the SDK version specified in the err
 
 One potential, alternative solution, is to enable the managed linker. This will remove unused API including, in most cases, the new API where the header files are missing (or incomplete). However this will not work if your project uses API that was introduced in a newer SDK than the one your Xcode provides.
 
+To enable the managed linker, go to your project's Mac Build Options, and set `Linker Behavior` to either `Link Framework SDKs only` or `Link All`.
+
 A second potential, alternative solution, is use the dynamic registrar instead. This will impose a startup cost by dynamically registering types but remove the header file requirement. 
 
 A last-straw solution would be to use an older version of Xamarin.Mac, one that supports the SDK your project requires.

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -541,6 +541,8 @@ Xamarin.iOS requires the header files, from the SDK version specified in the err
 
 A potential, alternative solution is to enable the managed linker. This will remove unused API including, in most cases, the new API where the header files are missing (or incomplete). However this will not work if your project uses API that was introduced in a newer SDK than the one your Xcode provides.
 
+To enable the managed linker, go to your project's iOS Build Options, and set `Linker Behavior` to either `Link Framework SDKs only` or `Link All`.
+
 A last-straw solution would be to use an older version of Xamarin.iOS, one that supports the SDK your project requires.
 
 <!-- MT0092 used by mlaunch -->

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1089,7 +1089,7 @@ public class B : A {}
 				mtouch.Sdk = sdk_version;
 				Assert.AreEqual (1, mtouch.Execute (MTouchAction.BuildSim));
 				var xcodeVersionString = Configuration.XcodeVersion;
-				mtouch.AssertError (91, String.Format ("This version of Xamarin.iOS requires the {0} {1} SDK (shipped with Xcode {2}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only (to try to avoid the new APIs).", name, GetSdkVersion (profile), xcodeVersionString));
+				mtouch.AssertError (91, String.Format ("This version of Xamarin.iOS requires the {0} {1} SDK (shipped with Xcode {2}). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options > Linker Behavior (to try to avoid the new APIs).", name, GetSdkVersion (profile), xcodeVersionString));
 			}
 		}
 

--- a/tools/mmp/Application.cs
+++ b/tools/mmp/Application.cs
@@ -4,7 +4,7 @@ namespace Xamarin.Bundler {
 	public partial class Application
 	{
 		public const string ProductName = "Xamarin.Mac";
-		public const string Error91LinkerSuggestion = "use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only";
+		public const string Error91LinkerSuggestion = "use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only in your project's Mac Build Options > Linker Behavior";
 
 		public bool Is32Build => !Driver.Is64Bit; 
 		public bool Is64Build => Driver.Is64Bit;

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Bundler {
 	public partial class Application
 	{
 		public const string ProductName = "Xamarin.iOS";
-		public const string Error91LinkerSuggestion = "set the managed linker behaviour to Link Framework SDKs Only";
+		public const string Error91LinkerSuggestion = "set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options > Linker Behavior";
 
 		public string ExecutableName;
 		public BuildTarget BuildTarget;


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/4549.