### PR TITLE
[QuickLook] Use the correct name properties in QLPreviewItem. Fixes #4450

### DIFF
--- a/src/quicklook.cs
+++ b/src/quicklook.cs
@@ -131,7 +131,7 @@ namespace QuickLook {
 		[Abstract]
 		[Export ("previewItemURL")]
 #if XAMCORE_4_0
-		NSUrl PreviewItemTitleUrl { get; }
+		NSUrl PreviewItemUrl { get; }
 #else
 		NSUrl ItemUrl { get; }
 #endif

--- a/src/quicklook.cs
+++ b/src/quicklook.cs
@@ -130,13 +130,19 @@ namespace QuickLook {
 	interface QLPreviewItem {
 		[Abstract]
 		[Export ("previewItemURL")]
+#if XAMCORE_4_0
+		NSUrl PreviewItemTitle { get; }
+#else
 		NSUrl ItemUrl { get; }
+#endif
 
+		[Export ("previewItemTitle")]
 #if !XAMCORE_4_0
 		[Abstract]
-#endif
-		[Export ("previewItemTitle")]
 		string ItemTitle { get; }
+#else
+		string PreviewItemTitle { get; }
+#endif
 	}
 
 	[iOS (11,0)]

--- a/src/quicklook.cs
+++ b/src/quicklook.cs
@@ -131,7 +131,7 @@ namespace QuickLook {
 		[Abstract]
 		[Export ("previewItemURL")]
 #if XAMCORE_4_0
-		NSUrl PreviewItemTitle { get; }
+		NSUrl PreviewItemTitleUrl { get; }
 #else
 		NSUrl ItemUrl { get; }
 #endif


### PR DESCRIPTION
Renamed properties for the next time we can make breaking changes.

Fixes https://github.com/xamarin/xamarin-macios/issues/4450