### PR TITLE
[Make.config] Set IOS_PACKAGE_VERSION_REV

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -33,16 +33,17 @@ endif
 # TODO: reset to 0 after major/minor version bump (SRO) and increment for service releases and previews
 # Note: if not reseted to 0 we can skip a version and start with .1 or .2
 PACKAGE_VERSION_REV=0
+IOS_PACKAGE_VERSION_REV=$(PACKAGE_VERSION_REV)
 
 IOS_PRODUCT=Xamarin.iOS
 IOS_PACKAGE_NAME=Xamarin.iOS
 IOS_PACKAGE_NAME_LOWER=$(shell echo $(IOS_PACKAGE_NAME) | tr "[:upper:]" "[:lower:]")
 # NEVER customize IOS_PACKAGE_VERSION itself, other parts (mtouch, web updater) are using the IOS_PACKAGE_VERSION_* variables
-IOS_PACKAGE_VERSION=12.2.$(PACKAGE_VERSION_REV).$(IOS_COMMIT_DISTANCE)
+IOS_PACKAGE_VERSION=12.2.$(IOS_PACKAGE_VERSION_REV).$(IOS_COMMIT_DISTANCE)
 IOS_PACKAGE_VERSION_MAJOR=$(word 1, $(subst ., ,$(IOS_PACKAGE_VERSION)))
 IOS_PACKAGE_VERSION_MINOR=$(word 2, $(subst ., ,$(IOS_PACKAGE_VERSION)))
 IOS_PACKAGE_VERSION_BUILD=$(IOS_COMMIT_DISTANCE)
-IOS_PACKAGE_UPDATE_ID=$(shell printf "2%02d%02d%02d%03d" $(IOS_PACKAGE_VERSION_MAJOR) $(IOS_PACKAGE_VERSION_MINOR) $(PACKAGE_VERSION_REV) $(IOS_PACKAGE_VERSION_BUILD))
+IOS_PACKAGE_UPDATE_ID=$(shell printf "2%02d%02d%02d%03d" $(IOS_PACKAGE_VERSION_MAJOR) $(IOS_PACKAGE_VERSION_MINOR) $(IOS_PACKAGE_VERSION_REV) $(IOS_PACKAGE_VERSION_BUILD))
 
 # Xcode version should have both a major and a minor version (even if the minor version is 0)
 XCODE_VERSION=10.0


### PR DESCRIPTION
If this isn't set the `Constants.*.cs.in` files won't have the proper version values. E.g: '12.3.' instead of '12.3.0'.