### PR TITLE
[CoreFoundation] Remove mtouch-specific code.

### DIFF
--- a/src/CoreFoundation/CFAllocator.cs
+++ b/src/CoreFoundation/CFAllocator.cs
@@ -37,7 +37,7 @@ namespace CoreFoundation {
 	// CFBase.h
 	public partial class CFAllocator : INativeObject, IDisposable 
 	{
-#if !COREBUILD && !MTOUCH
+#if !COREBUILD
 		static CFAllocator Default_cf;
 		static CFAllocator SystemDefault_cf;
 		static CFAllocator Malloc_cf;
@@ -45,17 +45,6 @@ namespace CoreFoundation {
 		static CFAllocator Null_cf;
 #endif
 		IntPtr handle;
-
-#if MTOUCH
-		internal static IntPtr null_ptr;
-
-		static CFAllocator ()
-		{
-			var handle = Dlfcn.dlopen (Constants.CoreFoundationLibrary, 0);
-			null_ptr = Dlfcn.GetIntPtr (handle, "kCFAllocatorNull");
-			Dlfcn.dlclose (handle);
-		}
-#endif
 
 		public CFAllocator (IntPtr handle)
 		{
@@ -91,7 +80,7 @@ namespace CoreFoundation {
 				handle = IntPtr.Zero;
 			}
 		}
-#if !COREBUILD && !MTOUCH
+#if !COREBUILD
 		public static CFAllocator Default {
 			get {
 				return Default_cf ?? (Default_cf = new CFAllocator (default_ptr)); 

--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -42,13 +42,8 @@ namespace CoreFoundation {
 
 	[StructLayout (LayoutKind.Sequential)]
 	public struct CFRange {
-#if MTOUCH
-		IntPtr loc;
-		IntPtr len;
-#else
 		nint loc; // defined as 'long' in native code
 		nint len; // defined as 'long' in native code
-#endif
 
 		public int Location {
 			get { return (int) loc; }
@@ -73,13 +68,8 @@ namespace CoreFoundation {
 
 		public CFRange (long l, long len)
 		{
-#if MTOUCH
-			this.loc = (IntPtr) l;
-			this.len = (IntPtr) len;
-#else
 			this.loc = (nint) l;
 			this.len = (nint) len;
-#endif
 		}
 
 #if XAMCORE_2_0

--- a/src/CoreFoundation/CFUrl.cs
+++ b/src/CoreFoundation/CFUrl.cs
@@ -150,16 +150,12 @@ namespace CoreFoundation {
 				return str.ToString ();
 		}
 
-#if !MTOUCH
 		[iOS (7,0)][Mac (10,9)]
-#endif
 		[DllImport (Constants.CoreFoundationLibrary)]
 		[return: MarshalAs (UnmanagedType.I1)]
 		extern static /* Boolean */ bool CFURLIsFileReferenceURL (/* CFURLRef */IntPtr url);
 
-#if !MTOUCH
 		[iOS (7,0)][Mac (10,9)]
-#endif
 		public bool IsFileReference {
 			get {
 				return CFURLIsFileReferenceURL (handle);


### PR DESCRIPTION
Once upon a time mtouch was a MonoMac app, and at the same time needed to
be a 64-bit executable. This meant we needed a few hacks to make things work:

* The source code for CoreFoundation was included in mtouch (instead of using them from MonoMac.dll).
* A few changes were required to make the source code work in 64-bit.

These changes were conditionally done with a #if MTOUCH.

mtouch stopped being a MonoMac app a long time ago, so these mtouch-specific
changes are no longer needed, so just remove them.