### PR TITLE
[AppKit] Fix issue 4837 by moving the category to be inline. Fixes #4837

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -23126,12 +23126,6 @@ namespace AppKit {
 		NSPrintRenderingQuality PreferredRenderingQuality { get; }
 	}
 
-	[Category, BaseType (typeof (NSResponder))]
-	partial interface NSControlEditingSupport {
-		[Mac (10, 7), Export ("validateProposedFirstResponder:forEvent:")]
-		bool ValidateProposedFirstResponder (NSResponder responder, [NullAllowed] NSEvent forEvent);
-	}
-
 	partial interface NSResponder {
 		[Mac (10, 7), Export ("wantsScrollEventsForSwipeTrackingOnAxis:")]
 		bool WantsScrollEventsForSwipeTrackingOnAxis (NSEventGestureAxis axis);
@@ -23144,6 +23138,10 @@ namespace AppKit {
 
 		[Mac (10, 8), Export ("quickLookWithEvent:")]
 		void QuickLook (NSEvent withEvent);
+
+		// From  NSControlEditingSupport category. Needs to be here to make the API easier to be used. issue 4837
+		[Mac (10, 7), Export ("validateProposedFirstResponder:forEvent:")]
+		bool ValidateProposedFirstResponder (NSResponder responder, [NullAllowed] NSEvent forEvent);
 	}
 
 	[Category, BaseType (typeof (NSResponder))]

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -23126,6 +23126,14 @@ namespace AppKit {
 		NSPrintRenderingQuality PreferredRenderingQuality { get; }
 	}
 
+#if !XAMCORE_4_0
+	[Category, BaseType (typeof (NSResponder))]
+ 	partial interface NSControlEditingSupport {
+ 		[Mac (10, 7), Export ("validateProposedFirstResponder:forEvent:")]
+ 		bool ValidateProposedFirstResponder (NSResponder responder, [NullAllowed] NSEvent forEvent);
+ 	}
+#endif
+
 	partial interface NSResponder {
 		[Mac (10, 7), Export ("wantsScrollEventsForSwipeTrackingOnAxis:")]
 		bool WantsScrollEventsForSwipeTrackingOnAxis (NSEventGestureAxis axis);


### PR DESCRIPTION
The NSControlEditingSupport needs to be inline to make the use of the
API simpler allowing users to inherit an override the method.

Fixes https://github.com/xamarin/xamarin-macios/issues/4837