### PR TITLE
[xtro] Only return 1 in case of failure in reporter.

### DIFF
--- a/tests/xtro-sharpie/xtro-report/Reporter.cs
+++ b/tests/xtro-sharpie/xtro-report/Reporter.cs
@@ -270,7 +270,7 @@ namespace Extrospection {
 			log.Flush ();
 
 			Console.WriteLine ($"@MonkeyWrench: SetSummary: {errors} unclassified found.");
-			return errors;
+			return errors == 0 ? 0 : 1;
 		}
 	}
 }


### PR DESCRIPTION
This solves two problems:

* xharness thinks it crashed if the exit code is neither 0 nor 1, and
  helpfully says so and tries to collect crash reports, which only ends up
  being confusing.

* The exit code is byte-sized on macOS. This means that trying to return 256
  actually returns 0 (success).