### PR TITLE
Report updateinfo for xamarin.ios and xamarin.mac in artifacts.json

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -243,12 +243,12 @@ def uploadFiles (glob, virtualPath)
     ])
 }
 
-def appendUpdateInfo (platform, artifacts)
+def getUpdateInfo (platform)
 {
     try {
         def (productId, versionId) = sh (returnStdout: true, script: "more package/${platform}-updateinfo").trim().split(' ')
-        artifacts += "    \"productId\": \"${productId}\",\n"
-        artifacts += "    \"versionId\": \"${versionId}\",\n"
+        return "    \"productId\": \"${productId}\",\n"
+             + "    \"versionId\": \"${versionId}\",\n"
     } catch (ex) {
         echo "Did not find updateinfo file for xamarin.${platform}"
     }
@@ -480,10 +480,9 @@ timestamps {
                                 artifacts += "    \"url\": \"${packagePrefix}/${file.name}\",\n"
                                 artifacts += "    \"md5\": \"${md5}\",\n"
                                 artifacts += "    \"sha256\": \"${sha256}\",\n"
-                                if (file.name =~ /xamarin.mac.*.pkg$/) {
-                                    appendUpdateInfo('mac', artifacts)
-                                } else if (file.name =~ /xamarin.ios.*.pkg$/) {
-                                    appendUpdateInfo('ios', artifacts)
+                                def match = file.name =~ /xamarin.(mac|ios).*.pkg$/
+                                if (match.matches()) {
+                                    artifacts += getUpdateInfo(match[0][1])
                                 }
                                 artifacts += "    \"size\": ${f_length}\n"
                                 artifacts += "  }"

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -243,6 +243,17 @@ def uploadFiles (glob, virtualPath)
     ])
 }
 
+def appendUpdateInfo (platform, artifacts)
+{
+    try {
+        def (productId, versionId) = sh (returnStdout: true, script: "more package/${platform}-updateinfo").trim().split(' ')
+        artifacts += "    \"productId\": \"${productId}\",\n"
+        artifacts += "    \"versionId\": \"${versionId}\",\n"
+    } catch (ex) {
+        echo "Did not find updateinfo file for xamarin.${platform}"
+    }
+}
+
 // There must be a better way than this hack to show a
 // message in red in the Jenkins Blue Ocean UI...
 def echoError (message)
@@ -469,6 +480,11 @@ timestamps {
                                 artifacts += "    \"url\": \"${packagePrefix}/${file.name}\",\n"
                                 artifacts += "    \"md5\": \"${md5}\",\n"
                                 artifacts += "    \"sha256\": \"${sha256}\",\n"
+                                if (file.name =~ /xamarin.mac.*.pkg$/) {
+                                    appendUpdateInfo('mac', artifacts)
+                                } else if (file.name =~ /xamarin.ios.*.pkg$/) {
+                                    appendUpdateInfo('ios', artifacts)
+                                }
                                 artifacts += "    \"size\": ${f_length}\n"
                                 artifacts += "  }"
                                 if (i < uploadingFiles.length - 1)

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -248,7 +248,7 @@ def getUpdateInfo (platform)
     try {
         def (productId, versionId) = sh (returnStdout: true, script: "more package/${platform}-updateinfo").trim().split(' ')
         return "    \"productId\": \"${productId}\",\n"
-             + "    \"versionId\": \"${versionId}\",\n"
+             + "    \"releaseId\": \"${versionId}\",\n"
     } catch (ex) {
         echo "Did not find updateinfo file for xamarin.${platform}"
     }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -480,9 +480,10 @@ timestamps {
                                 artifacts += "    \"url\": \"${packagePrefix}/${file.name}\",\n"
                                 artifacts += "    \"md5\": \"${md5}\",\n"
                                 artifacts += "    \"sha256\": \"${sha256}\",\n"
-                                def match = file.name =~ /xamarin.(mac|ios).*.pkg$/
+                                def match = file.name =~ /xamarin.(mac|ios)-(\d+(\.\d+)+).*.pkg$/
                                 if (match.matches()) {
                                     artifacts += getUpdateInfo(match[0][1])
+                                    artifacts += "    \"version\": \"${match[0][2]}\",\n"
                                 }
                                 artifacts += "    \"size\": ${f_length}\n"
                                 artifacts += "  }"


### PR DESCRIPTION
We'd like to expose the productId and versionId in artifacts.json to autofill this information in while publishing so it's less of a manual process