### PR TITLE
Disable known failing device tests using xharness

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -329,19 +329,20 @@ namespace xharness
 			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bcl-test/mscorlib/mscorlib-0.csproj")), false));
 			IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bcl-test/mscorlib/mscorlib-1.csproj")), false));
 			foreach (var p in test_suites)
-				IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".csproj"))));
+				IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".csproj"))) { Name = p });
 			foreach (var p in fsharp_test_suites)
-				IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".fsproj"))));
+				IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".fsproj"))) { Name = p });
 			foreach (var p in library_projects)
-				IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".csproj")), false));
+				IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".csproj")), false) { Name = p });
 			foreach (var p in fsharp_library_projects)
-				IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".fsproj")), false));
+				IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, p + "/" + p + ".fsproj")), false) { Name = p });
 
 			foreach (var p in bcl_suites) {
 				BCLTestInfo bclTestInfo = new BCLTestInfo (this, p);
 				IOSTestProjects.Add (new iOSTestProject (Path.GetFullPath (Path.Combine (RootDirectory, "bcl-test/" + p + "/" + p + ".csproj"))) {
 					SkipwatchOSVariation = bcl_skip_watchos.Contains (p),
-					BCLInfo = bclTestInfo
+					BCLInfo = bclTestInfo,
+					Name = p
 				});
 			}
 			

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -3113,10 +3113,9 @@ function toggleAll (show)
 		public readonly BuildToolTask BuildTask;
 		public bool BuildOnly;
 
-		public RunTestTask (BuildToolTask build_task, bool buildOnly = false)
+		public RunTestTask (BuildToolTask build_task)
 		{
 			BuildTask = build_task;
-			BuildOnly = buildOnly;
 
 			Jenkins = build_task.Jenkins;
 			TestProject = build_task.TestProject;

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -3100,7 +3100,7 @@ function toggleAll (show)
 
 		public RunTestTask (BuildToolTask build_task)
 		{
-			BuildTask = build_task;
+			this.BuildTask = build_task;
 
 			Jenkins = build_task.Jenkins;
 			TestProject = build_task.TestProject;
@@ -3305,23 +3305,22 @@ function toggleAll (show)
 		public RunDeviceTask (XBuildTask build_task, IEnumerable<Device> candidates)
 			: base (build_task, candidates.OrderBy ((v) => v.DebugSpeed))
 		{
-			AppRunnerTarget = GetBuildTaskPlatform (build_task);
-		}
-
-		AppRunnerTarget GetBuildTaskPlatform (XBuildTask build_task)
-		{
 			switch (build_task.Platform) {
 			case TestPlatform.iOS:
 			case TestPlatform.iOS_Unified:
 			case TestPlatform.iOS_Unified32:
 			case TestPlatform.iOS_Unified64:
-				return AppRunnerTarget.Device_iOS;
+				AppRunnerTarget = AppRunnerTarget.Device_iOS;
+				break;
 			case TestPlatform.iOS_TodayExtension64:
-				return AppRunnerTarget.Device_iOS;
+				AppRunnerTarget = AppRunnerTarget.Device_iOS;
+				break;
 			case TestPlatform.tvOS:
-				return AppRunnerTarget.Device_tvOS;
+				AppRunnerTarget = AppRunnerTarget.Device_tvOS;
+				break;
 			case TestPlatform.watchOS:
-				return AppRunnerTarget.Device_watchOS;
+				AppRunnerTarget = AppRunnerTarget.Device_watchOS;
+				break;
 			default:
 				throw new NotImplementedException ();
 			}

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -498,7 +498,7 @@ namespace xharness
 		void DisableKnownFailingDeviceTests ()
 		{
 			// https://github.com/xamarin/maccore/issues/1008
-			ForceExtensionBuildOnly = false;
+			ForceExtensionBuildOnly = true;
 
 			// https://github.com/xamarin/maccore/issues/1009 
 			foreach (var fsharp in Harness.IOSTestProjects.Where (x => x.Name == "fsharp" || x.Name == "fsharplibrary"))

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -38,6 +38,8 @@ namespace xharness
 		public Log SimulatorLoadLog;
 		public Log DeviceLoadLog;
 
+		public HashSet<string> TestsToSkipOnDevice = new HashSet<string> ();
+
 		public string LogDirectory {
 			get {
 				return Path.Combine (Harness.JENKINS_RESULTS_DIRECTORY, "tests");
@@ -371,6 +373,9 @@ namespace xharness
 			foreach (var project in Harness.IOSTestProjects) {
 				if (!project.IsExecutableProject)
 					continue;
+
+				if (TestsToSkipOnDevice.Contains (project.Name))
+					continue;
 				
 				bool ignored = !IncludeDevice;
 				if (!IsIncluded (project))
@@ -460,6 +465,8 @@ namespace xharness
 			// whatever we did automatically.
 			SelectTestsByLabel (pull_request);
 
+			DisableKnownFailingDeviceTests ();
+
 			if (!Harness.INCLUDE_IOS) {
 				MainLog.WriteLine ("The iOS build is diabled, so any iOS tests will be disabled as well.");
 				IncludeiOS = false;
@@ -479,6 +486,19 @@ namespace xharness
 				MainLog.WriteLine ("The macOS build is disabled, so any macOS tests will be disabled as well.");
 				IncludeMac = false;
 			}
+		}
+
+		void DisableKnownFailingDeviceTests ()
+		{
+			// https://github.com/xamarin/maccore/issues/1008
+			// Also hits https://github.com/xamarin/maccore/issues/1009 which will need seperate exclusion if 1008 is fixed first
+			IncludeiOSExtensions = false;
+
+			// https://github.com/xamarin/maccore/issues/1014
+			TestsToSkipOnDevice.Add ("System");
+
+			// https://github.com/xamarin/maccore/issues/1011
+			TestsToSkipOnDevice.Add ("mini");
 		}
 
 		void SelectTestsByModifiedFiles (int pull_request)

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -500,10 +500,6 @@ namespace xharness
 			// https://github.com/xamarin/maccore/issues/1008
 			ForceExtensionBuildOnly = true;
 
-			// https://github.com/xamarin/maccore/issues/1009 
-			foreach (var fsharp in Harness.IOSTestProjects.Where (x => x.Name == "fsharp" || x.Name == "fsharplibrary"))
-				fsharp.BuildOnly = true;
-
 			// https://github.com/xamarin/maccore/issues/1011
 			foreach (var mono in Harness.IOSTestProjects.Where (x => x.Name == "mini"))
 				mono.BuildOnly = true;

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -369,7 +369,7 @@ namespace xharness
 		{
 			RunDeviceTask task;
 			if (buildOnly)
-				task = RunDeviceTask.CreateBuildOnly (build_task);
+				task = new RunDeviceTask (build_task, Enumerable.Empty<Device> ()) { BuildOnly = true };
 			else
 				task = new RunDeviceTask (build_task, connected);
 			task.Ignored = ignored;
@@ -383,7 +383,7 @@ namespace xharness
 			foreach (var project in Harness.IOSTestProjects) {
 				if (!project.IsExecutableProject)
 					continue;
-
+				
 				bool ignored = !IncludeDevice;
 				if (!IsIncluded (project))
 					ignored = true;
@@ -408,7 +408,7 @@ namespace xharness
 					};
 					build32.CloneTestProject (project);
 					rv.Add (CreateRunTask (build32, Devices.Connected32BitIOS, project.BuildOnly, ignored || !IncludeiOS));
-					
+
 					var todayProject = project.AsTodayExtensionProject ();
 					var buildToday = new XBuildTask {
 						Jenkins = this,
@@ -3232,12 +3232,6 @@ function toggleAll (show)
 			this.candidates = candidates;
 		}
 
-		protected RunXITask (BuildToolTask build_task)
-			: base (build_task, buildOnly: true)
-		{
-			this.candidates = Enumerable.Empty<TDevice> ();
-		}
-
 		public override IEnumerable<Log> AggregatedLogs {
 			get {
 				var rv = base.AggregatedLogs;
@@ -3328,18 +3322,7 @@ function toggleAll (show)
 			AppRunnerTarget = GetBuildTaskPlatform (build_task);
 		}
 
-		public static RunDeviceTask CreateBuildOnly (XBuildTask build_task)
-		{
-			return new RunDeviceTask (build_task);
-		}
-
-		RunDeviceTask (XBuildTask build_task)
-			: base (build_task)
-		{
-			AppRunnerTarget = GetBuildTaskPlatform (build_task);
-		}
-
-		private AppRunnerTarget GetBuildTaskPlatform (XBuildTask build_task)
+		AppRunnerTarget GetBuildTaskPlatform (XBuildTask build_task)
 		{
 			switch (build_task.Platform) {
 			case TestPlatform.iOS:

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -365,17 +365,6 @@ namespace xharness
 			}
 		}
 
-		RunDeviceTask CreateRunTask (XBuildTask build_task, IEnumerable<Device> connected, bool buildOnly, bool ignored)
-		{
-			RunDeviceTask task;
-			if (buildOnly)
-				task = new RunDeviceTask (build_task, connected) { BuildOnly = true };
-			else
-				task = new RunDeviceTask (build_task, connected);
-			task.Ignored = ignored;
-			return task;
-		}
-
 		IEnumerable<TestTask> CreateRunDeviceTasks ()
 		{
 			var rv = new List<RunDeviceTask> ();

--- a/tests/xharness/Simulators.cs
+++ b/tests/xharness/Simulators.cs
@@ -646,11 +646,12 @@ namespace xharness
 		bool loaded;
 
 		BlockingEnumerableCollection<Device> connected_devices = new BlockingEnumerableCollection<Device> ();
-		public IEnumerable<Device> ConnectedDevices {
-			get {
-				return connected_devices;
-			}
-		}
+
+		public IEnumerable<Device> ConnectedDevices => connected_devices;
+		public IEnumerable<Device> Connected64BitIOS => connected_devices.Where (x => x.DevicePlatform == DevicePlatform.iOS && x.Supports64Bit);
+		public IEnumerable<Device> Connected32BitIOS => connected_devices.Where (x => x.DevicePlatform == DevicePlatform.iOS && x.Supports32Bit);
+		public IEnumerable<Device> ConnectedTV => connected_devices.Where (x => x.DevicePlatform == DevicePlatform.tvOS);
+		public IEnumerable<Device> ConnectedWatch => connected_devices.Where (x => x.DevicePlatform == DevicePlatform.watchOS);
 
 		public async Task LoadAsync (Log log, bool extra_data = false, bool removed_locked = false, bool force = false)
 		{

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -145,6 +145,7 @@ namespace xharness
 		public bool SkipiOSVariation;
 		public bool SkipwatchOSVariation;
 		public bool SkiptvOSVariation;
+		public bool BuildOnly;
 
 		// Optional
 		public BCLTestInfo BCLInfo { get; set; }


### PR DESCRIPTION
So far these four are disabled:

- https://github.com/xamarin/maccore/issues/1008
- https://github.com/xamarin/maccore/issues/1009
- https://github.com/xamarin/maccore/issues/1014
- https://github.com/xamarin/maccore/issues/1011

I tested locally that TestsToSkipOnDevice.Contains hits but I did not do full device test run locally.