### PR TITLE
Bump XM to 5.1 and audit fixes from `xcode10`

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -32,8 +32,8 @@ endif
 
 # TODO: reset to 0 after major/minor version bump (SRO) and increment for service releases and previews
 # Note: if not reseted to 0 we can skip a version and start with .1 or .2
-PACKAGE_VERSION_REV=4
-IOS_PACKAGE_VERSION_REV=0
+PACKAGE_VERSION_REV=0
+IOS_PACKAGE_VERSION_REV=$(PACKAGE_VERSION_REV)
 
 IOS_PRODUCT=Xamarin.iOS
 IOS_PACKAGE_NAME=Xamarin.iOS
@@ -261,7 +261,7 @@ MAC_PRODUCT=Xamarin.Mac
 MAC_PACKAGE_NAME=xamarin.mac
 MAC_PACKAGE_NAME_LOWER=$(shell echo $(MAC_PACKAGE_NAME) | tr "[:upper:]" "[:lower:]")
 
-MAC_PACKAGE_VERSION=4.99.$(PACKAGE_VERSION_REV).$(MAC_COMMIT_DISTANCE)
+MAC_PACKAGE_VERSION=5.1.$(PACKAGE_VERSION_REV).$(MAC_COMMIT_DISTANCE)
 MAC_PACKAGE_VERSION_MAJOR=$(word 1, $(subst ., ,$(MAC_PACKAGE_VERSION)))
 MAC_PACKAGE_VERSION_MINOR=$(word 2, $(subst ., ,$(MAC_PACKAGE_VERSION)))
 MAC_PACKAGE_VERSION_REV=$(PACKAGE_VERSION_REV)

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2542,7 +2542,7 @@ namespace AppKit {
 		[Mac (10,14)]
 		WindowBackground = 12,
 		[Mac (10,14)]
-		HUDWindow = 13,
+		HudWindow = 13,
 		[Mac (10,14)]
 		FullScreenUI = 15,
 		[Mac (10,14)]

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -4120,7 +4120,7 @@ namespace AppKit {
 
 		[Mac (10,14, onlyOn64: true)]
 		[Export ("colorWithSystemEffect:")]
-		NSColor WithSystemEffect (NSColorSystemEffect systemEffect);
+		NSColor FromSystemEffect (NSColorSystemEffect systemEffect);
 
 		[Mac (10, 13)]
 		[Static]
@@ -7925,16 +7925,13 @@ namespace AppKit {
 		[PostSnippet ("__mt_items_var = ItemArray();")]
 		void RemoveAllItems ();
 
-#if XAMCORE_4_0
 		[Export ("itemArray", ArgumentSemantic.Copy)]
-		NSMenuItem[] ItemArray { get; [Mac (10, 14, onlyOn64: true)] set; }
-#else
-		[Export ("itemArray")]
-		NSMenuItem [] ItemArray ();
+		NSMenuItem[] Items { get; [Mac (10, 14, onlyOn64: true)] set; }
 
-		[Mac (10, 14, onlyOn64: true)]
-		[Export ("setItemArray:")]
-		void SetItemArray (NSMenuItem [] items);
+#if !XAMCORE_4_0
+		[Obsolete ("Use 'Items' instead.")]
+		[Wrap ("Items", IsVirtual = true)]
+		NSMenuItem [] ItemArray ();
 #endif
 
 		[Export ("numberOfItems")]

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -12324,7 +12324,11 @@ namespace Foundation
 	partial interface NSFilePresenter {
 		[Abstract]
 		[Export ("presentedItemURL", ArgumentSemantic.Retain)]
+#if XAMCORE_4_0
+		NSUrl PresentedItemUrl { get; }
+#else
 		NSUrl PresentedItemURL { get; }
+#endif
 
 #if XAMCORE_2_0
 		[Abstract]


### PR DESCRIPTION
We plan to release XM 5.0 based on 15.8
So xcode10.1 support is bumped to 5.1.x

Backport of
https://github.com/xamarin/xamarin-macios/commit/b40230c09d557991b776de918b047442cd41533f