### PR TITLE
[security]: Make `SecCertificate` work with the latest runtime code.

### DIFF
--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -28,7 +28,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if XAMARIN_APPLETLS || __WATCHOS__
+#if XAMARIN_APPLETLS
 #define NATIVE_APPLE_CERTIFICATE
 #endif
 
@@ -193,7 +193,8 @@ namespace Security {
 			if (handle == IntPtr.Zero)
 				throw new ObjectDisposedException ("SecCertificate");
 
-			return new X509Certificate (handle);
+			var impl = new Mono.AppleTls.X509CertificateImplApple (handle, false);
+			return new X509Certificate (impl);
 #else
 			return new X509Certificate (GetRawData ());
 #endif


### PR DESCRIPTION
* Fix the `NATIVE_APPLE_CERTIFICATE` logic; it should only be defined when
  using `XAMARIN_APPLETLS` and not on watch.

* It is no longer allowed to construct `X509Certificate` from a native pointer,
  the `X509Certificate(IntPtr)` and `X509Certificate2(IntPtr)` constructors now
  throw an exception.  Use `X509CertificateImplAppl` directly instead.