### PR TITLE
[runtime] Only write to NSLog in chunks of max 4096 characters. Fixes maccore#1014.

### DIFF
--- a/runtime/xamarin-support.m
+++ b/runtime/xamarin-support.m
@@ -35,7 +35,30 @@ xamarin_log (const unsigned short *unicodeMessage)
 		fwrite ("\n", 1, 1, stdout);
 	fflush (stdout);
 #else
-	NSLog (@"%@", msg);
+	if (length > 4096) {
+		// Write in chunks of max 4096 characters; older versions of iOS seems to have a bug where NSLog may hang with long strings (!).
+		// https://github.com/xamarin/maccore/issues/1014
+		const char *utf8 = [msg UTF8String];
+		int len = strlen (utf8);
+		const int max_size = 4096;
+		while (len > 0) {
+			int chunk_size = len > max_size ? max_size : len;
+
+			// Try to not break in the middle of a line, by looking backwards for a newline
+			while (chunk_size > 0 && utf8 [chunk_size] != 0 && utf8 [chunk_size] != '\n')
+				chunk_size--;
+			if (chunk_size == 0) {
+				// No newline found, break in the middle.
+				chunk_size = len > max_size ? max_size : len;
+			}
+			NSLog (@"%.*s", chunk_size, utf8);
+
+			len -= chunk_size;
+			utf8 += chunk_size;
+		}
+	} else {
+		NSLog (@"%@", msg);
+	}
 #endif
 	[msg release];
 }


### PR DESCRIPTION
It seems older iOS versions have a bug where big(ish) chunks of string can
cause it to hang.

Fix this by not writing big strings to NSLog, instead split them up in chunks.

Fixes https://github.com/xamarin/maccore/issues/1014.