### PR TITLE
[msbuild] Added support for Siri Intents

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/SiriIntentsKeys.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/SiriIntentsKeys.cs
@@ -1,0 +1,69 @@
+﻿//
+// SiriIntentsKeys.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Corp.
+//
+
+namespace Xamarin.MacDev.Tasks
+{
+	static class SiriIntentsKeys
+	{
+		public const string INIntentDefinitionModelVersion = "INIntentDefinitionModelVersion";
+		public const string INIntentDefinitionSystemVersion = "INIntentDefinitionSystemVersion";
+		public const string INIntentDefinitionToolsBuildVersion = "INIntentDefinitionToolsBuildVersion";
+		public const string INIntentDefinitionToolsVersion = "INIntentDefinitionToolsVersion";
+
+		public const string INEnums = "INEnums";
+		public const string INEnumName = "INEnumName";
+		public const string INEnumType = "INEnumType";
+		public const string INEnumValues = "INEnumValues";
+		public const string INEnumValueDisplayName = "INEnumValueDisplayName";
+		public const string INEnumValueDisplayNameID = "INEnumValueDisplayNameID";
+		public const string INEnumValueIndex = "INEnumValueIndex";
+		public const string INEnumValueName = "INEnumValueName";
+
+		public const string INIntents = "INIntents";
+		public const string INIntentCategory = "INIntentCategory";
+		public const string INIntentDefaultImageName = "INIntentDefaultImageName";
+		public const string INIntentDescription = "INIntentDescription";
+		public const string INIntentDescriptionID = "INIntentDescriptionID";
+		public const string INIntentLastParameterTag = "INIntentLastParameterTag";
+		public const string INIntentName = "INIntentName";
+		public const string INIntentParameterCombinations = "INIntentParameterCombinations";
+		public const string INIntentParameterCombinationIsPrimary = "INIntentParameterCombinationIsPrimary";
+		public const string INIntentParameterCombinationSubtitle = "INIntentParameterCombinationSubtitle";
+		public const string INIntentParameterCombinationSubtitleID = "INIntentParameterCombinationSubtitleID";
+		public const string INIntentParameterCombinationSupportsBackgroundExecution = "INIntentParameterCombinationSupportsBackgroundExecution";
+		public const string INIntentParameterCombinationTitle = "INIntentParameterCombinationTitle";
+		public const string INIntentParameterCombinationTitleID = "INIntentParameterCombinationTitleID";
+		public const string INIntentParameters = "INIntentParameters";
+		public const string INIntentParameterDisplayPriority = "INIntentParameterDisplayPriority";
+		public const string INIntentParameterEnumType = "INIntentParameterEnumType";
+		public const string INIntentParameterName = "INIntentParameterName";
+		public const string INIntentParameterSupportsMultipleValues = "INIntentParameterSupportsMultipleValues";
+		public const string INIntentParameterTag = "INIntentParameterTag";
+		public const string INIntentParameterType = "INIntentParameterType";
+		public const string INIntentResponse = "INIntentResponse";
+		public const string INIntentResponseCodes = "INIntentResponseCodes";
+		public const string INIntentResponseCodeFormatString = "INIntentResponseCodeFormatString";
+		public const string INIntentResponseCodeFormatStringID = "INIntentResponseCodeFormatStringID";
+		public const string INIntentResponseCodeName = "INIntentResponseCodeName";
+		public const string INIntentResponseCodeSuccess = "INIntentResponseCodeSuccess";
+		public const string INIntentResponseLastParameterTag = "INIntentResponseLastParameterTag";
+		public const string INIntentResponseParameters = "INIntentResponseParameters";
+		public const string INIntentResponseParameterDisplayPriority = "INIntentResponseParameterDisplayPriority";
+		public const string INIntentResponseParameterEnumType = "INIntentResponseParameterEnumType";
+		public const string INIntentResponseParameterName = "INIntentResponseParameterName";
+		public const string INIntentResponseParameterSupportsMultipleValues = "INIntentResponseParameterSupportsMultipleValues";
+		public const string INIntentResponseParameterTag = "INIntentResponseParameterTag";
+		public const string INIntentResponseParameterType = "INIntentResponseParameterType";
+		public const string INIntentRestrictions = "INIntentRestrictions";
+		public const string INIntentTitle = "INIntentTitle";
+		public const string INIntentTitleID = "INIntentTitleID";
+		public const string INIntentType = "INIntentType";
+		public const string INIntentUserConfirmationRequired = "INIntentUserConfirmationRequired";
+		public const string INIntentVerb = "INIntentVerb";
+	}
+}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IntentDefinitionCodegenTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IntentDefinitionCodegenTaskBase.cs
@@ -1,0 +1,619 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Collections.Generic;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.MacDev.Tasks
+{
+	public abstract class IntentDefinitionCodegenTaskBase : Task
+	{
+		static readonly string[] DefaultResponseCodes = {
+			"Unspecified", "Ready", "ContinueInApp", "InProgress", "Success", "Failure", "FailureRequiringAppLaunch"
+		};
+
+		#region Inputs
+
+		public string SessionId { get; set; }
+
+		[Required]
+		public ITaskItem IntentDefinition { get; set; }
+
+		[Required]
+		public string IntermediateOutputPath { get; set; }
+
+		[Required]
+		public string RootNamespace { get; set; }
+
+		#endregion
+
+		#region Outputs
+
+		[Output]
+		public ITaskItem[] GeneratedSources { get; set; }
+
+		#endregion
+
+		static string GetCSharpName (string name)
+		{
+			if (name.Length > 1)
+				return char.ToUpperInvariant (name[0]) + name.Substring (1);
+
+			return name.ToUpperInvariant ();
+		}
+
+		static string GetCSharpTypeName (string type)
+		{
+			switch (type) {
+			case "CurrencyAmount": return "INCurrencyAmount";
+			case "Decimal":        return "NSNumber";
+			case "Distance":       return "NSUnitLength";
+			case "Integer":        return "NSNumber";
+			case "Object":         return "INObject";
+			case "PaymentMethod":  return "INPaymentMethod";
+			case "Person":         return "INPerson";
+			case "Placemark":      return "CLPlacemark";
+			case "String":         return "NSString";
+			case "Temperature":    return "NSUnitTemperature";
+			case "URL":            return "NSUrl";
+			default: return type;
+			}
+		}
+
+		void WriteEnumDefinition (StreamWriter writer, string prefix, PDictionary enumDefinition)
+		{
+			PArray values;
+			PNumber index;
+			PString name;
+
+			if (!enumDefinition.TryGetValue (SiriIntentsKeys.INEnumName, out name))
+				return;
+
+			if (!enumDefinition.TryGetValue (SiriIntentsKeys.INEnumValues, out values))
+				return;
+
+			writer.WriteLine ("\t[Native]");
+			writer.WriteLine ("\tenum {0}{1}", prefix, name.Value);
+			writer.WriteLine ("\t{");
+			for (int i = 0; i < values.Count; i++) {
+				var valueDefinition = values[i] as PDictionary;
+
+				if (valueDefinition == null)
+					continue;
+
+				// TODO: Should this use INEnumValueDisplayName?
+				if (!valueDefinition.TryGetValue (SiriIntentsKeys.INEnumValueName, out name))
+					continue;
+
+				if (valueDefinition.TryGetValue (SiriIntentsKeys.INEnumValueIndex, out index))
+					writer.WriteLine ("\t\t{0} = {1},", GetCSharpName (name.Value), index.Value);
+				else
+					writer.WriteLine ("\t\t{0},", GetCSharpName (name.Value));
+			}
+			writer.WriteLine ("\t}");
+			writer.WriteLine ();
+		}
+
+		void WriteIntentDefinition (StreamWriter writer, string prefix, PDictionary intentDefinition)
+		{
+			writer.WriteLine ("\t[Register (\"{0}Intent\")]", prefix);
+			writer.WriteLine ("\tclass {0}Intent : INIntent", prefix);
+			writer.WriteLine ("\t{");
+
+			// write out the .ctors
+			writer.WriteLine ("\t\tpublic {0}Intent () : base (NSObjectFlag.Empty) {{ }}", prefix);
+			writer.WriteLine ();
+			writer.WriteLine ("\t\tprotected {0}Intent (IntPtr handle) : base (handle) {{ }}", prefix);
+
+			// write out the properties
+			if (intentDefinition.TryGetValue (SiriIntentsKeys.INIntentParameters, out PArray parameters)) {
+				foreach (var parameterDefinition in parameters.OfType<PDictionary> ()) {
+					bool isMultiDimensional = false;
+					string propertyName;
+					string typeName;
+
+					if (!parameterDefinition.TryGetValue (SiriIntentsKeys.INIntentParameterName, out PString parameterName))
+						continue;
+
+					if (parameterDefinition.TryGetValue (SiriIntentsKeys.INIntentParameterSupportsMultipleValues, out PBoolean multi))
+						isMultiDimensional = multi.Value;
+
+					writer.WriteLine ();
+
+					if (parameterDefinition.TryGetValue (SiriIntentsKeys.INIntentParameterEnumType, out PString enumType)) {
+						writer.WriteLine ("\t\t[Export (\"{0}\"{1})]", parameterName.Value, isMultiDimensional ? ", ArgumentSemantic.Copy" : string.Empty);
+						typeName = prefix + enumType.Value;
+					} else if (parameterDefinition.TryGetValue (SiriIntentsKeys.INIntentParameterType, out PString parameterType)) {
+						writer.WriteLine ("\t\t[Export (\"{0}\", ArgumentSemantic.Copy)]", parameterName.Value);
+						typeName = GetCSharpTypeName (parameterType.Value);
+					} else {
+						continue;
+					}
+
+					propertyName = GetCSharpName (parameterName.Value);
+
+					if (isMultiDimensional)
+						writer.WriteLine ("\t\tpublic NSArray<{0}> {1} {{ get; set; }}", typeName, propertyName);
+					else
+						writer.WriteLine ("\t\tpublic {0} {1} {{ get; set; }}", typeName, propertyName);
+				}
+			}
+
+			writer.WriteLine ("\t}");
+		}
+
+		void WriteIntentResponseCodeEnumDefinition (StreamWriter writer, string prefix, PDictionary responseDefinition)
+		{
+			writer.WriteLine ("\t[Native]");
+			writer.WriteLine ("\tenum {0}IntentResponseCode : long", prefix);
+			writer.WriteLine ("\t{");
+
+			// write out the default response code enum values
+			for (int i = 0; i < DefaultResponseCodes.Length; i++)
+				writer.WriteLine ("\t\t{0},", DefaultResponseCodes[i]);
+
+			// write out any custom response code enum values
+			if (responseDefinition.TryGetValue (SiriIntentsKeys.INIntentResponseCodes, out PArray responseCodes) && responseCodes.Count > 0) {
+				var known = new HashSet<string> (DefaultResponseCodes, StringComparer.Ordinal);
+				var first = true;
+
+				foreach (var responseCode in responseCodes.OfType<PDictionary> ()) {
+					if (!responseCode.TryGetValue (SiriIntentsKeys.INIntentResponseCodeName, out PString name))
+						continue;
+
+					var csharp = GetCSharpName (name.Value);
+
+					if (!known.Add (csharp))
+						continue;
+
+					if (first) {
+						writer.WriteLine ("\t\t{0} = 100,", csharp);
+						first = false;
+					} else {
+						writer.WriteLine ("\t\t{0},", csharp);
+					}
+				}
+			}
+
+			writer.WriteLine ("\t}");
+			writer.WriteLine ();
+		}
+
+		void WriteResponseCodeCreationMethods (StreamWriter writer, string prefix, PDictionary responseDefinition, Dictionary<string, string> parameterTypes)
+		{
+			if (!responseDefinition.TryGetValue (SiriIntentsKeys.INIntentResponseCodes, out PArray responseCodes))
+				return;
+
+			foreach (var responseCode in responseCodes.OfType<PDictionary> ()) {
+				if (!responseCode.TryGetValue (SiriIntentsKeys.INIntentResponseCodeFormatString, out PString format))
+					continue;
+
+				int startIndex = format.Value.IndexOf ("${", StringComparison.Ordinal);
+
+				if (startIndex == -1)
+					continue;
+
+				int endIndex = format.Value.IndexOf ('}', startIndex += 2);
+
+				if (endIndex == -1)
+					continue;
+
+				if (!responseCode.TryGetValue (SiriIntentsKeys.INIntentResponseCodeName, out PString name))
+					continue;
+
+				var methodName = new StringBuilder (GetCSharpName (name.Value) + "IntentResponseWith");
+				var symbolName = new StringBuilder (name.Value + "IntentResponseWith");
+				var parameters = new List<string> ();
+				bool first = true;
+
+				do {
+					var parameterName = format.Value.Substring (startIndex, endIndex - startIndex);
+
+					parameters.Add (parameterName);
+
+					if (first) {
+						var csharp = GetCSharpName (parameterName);
+
+						methodName.Append (csharp);
+						symbolName.Append (csharp);
+						first = false;
+					} else {
+						symbolName.Append (parameterName);
+					}
+
+					symbolName.Append (':');
+
+					if ((startIndex = format.Value.IndexOf ("${", endIndex + 1, StringComparison.Ordinal)) == -1)
+						break;
+
+					endIndex = format.Value.IndexOf ('}', startIndex += 2);
+				} while (endIndex != -1);
+
+				writer.WriteLine ("\t\t[Export (\"{0}\")]", symbolName);
+				writer.Write ("\t\tpublic static {0}IntentResponse {1} (", prefix, methodName);
+				for (int i = 0; i < parameters.Count; i++) {
+					if (!parameterTypes.TryGetValue (parameters[i], out string parameterType)) {
+						// FIXME: invent a proper error code value
+						Log.LogError (11111111, IntentDefinition.ItemSpec, "Unknown response parameter: {0}", parameters[i]);
+						continue;
+					}
+
+					writer.Write ("{0} {1}{2}", parameterType, parameters[i], i + 1 < parameters.Count ? ", " : string.Empty);
+				}
+
+				writer.WriteLine (")");
+				writer.WriteLine ("\t\t{");
+				writer.WriteLine ("\t\t\treturn new {0}IntentResponse ({0}IntentResponseCode.{1}, null) {{", prefix, GetCSharpName (name.Value));
+				for (int i = 0; i < parameters.Count; i++)
+					writer.WriteLine ("\t\t\t\t{0} = {1},", GetCSharpName (parameters[i]), parameters[i]);
+				writer.WriteLine ("\t\t\t};");
+				writer.WriteLine ("\t\t}");
+				writer.WriteLine ();
+			}
+		}
+
+		void WriteIntentResponseDefinition (StreamWriter writer, string prefix, PDictionary responseDefinition)
+		{
+			WriteIntentResponseCodeEnumDefinition (writer, prefix, responseDefinition);
+
+			writer.WriteLine ("\t[Register (\"{0}IntentResponse\")]", prefix);
+			writer.WriteLine ("\tclass {0}IntentResponse : INIntentResponse", prefix);
+			writer.WriteLine ("\t{");
+
+			// write out the .ctors
+			writer.WriteLine ("\t\t[Export (\"initWithCode:userActivity:\")]");
+			writer.WriteLine ("\t\tpublic {0}IntentResponse ({0}IntentResponseCode code, NSUserActivity userActivity)", prefix);
+			writer.WriteLine ("\t\t{");
+			writer.WriteLine ("\t\t\tCode = code;");
+			writer.WriteLine ("\t\t\tUserActivity = userActivity;");
+			writer.WriteLine ("\t\t}");
+			writer.WriteLine ();
+
+			if (responseDefinition.TryGetValue (SiriIntentsKeys.INIntentResponseParameters, out PArray responseParameters)) {
+				var parameterTypes = new Dictionary<string, string> (StringComparer.Ordinal);
+				var isEnumType = new Dictionary<string, bool> (StringComparer.Ordinal);
+				var parameters = new List<string> ();
+
+				foreach (var parameterDefinition in responseParameters.OfType<PDictionary> ()) {
+					var isMultiDimensional = false;
+					string typeName;
+
+					if (!parameterDefinition.TryGetValue (SiriIntentsKeys.INIntentResponseParameterName, out PString parameterName))
+						continue;
+
+					if (parameterDefinition.TryGetValue (SiriIntentsKeys.INIntentResponseParameterSupportsMultipleValues, out PBoolean multi))
+						isMultiDimensional = multi.Value;
+
+					if (parameterDefinition.TryGetValue (SiriIntentsKeys.INIntentResponseParameterEnumType, out PString enumType)) {
+						typeName = prefix + enumType.Value;
+					} else if (parameterDefinition.TryGetValue (SiriIntentsKeys.INIntentResponseParameterType, out PString parameterType)) {
+						typeName = GetCSharpTypeName (parameterType.Value);
+					} else {
+						continue;
+					}
+
+					if (isMultiDimensional)
+						typeName = "NSArray<" + typeName + ">";
+
+					if (!parameterTypes.ContainsKey (parameterName.Value)) {
+						isEnumType.Add (parameterName.Value, enumType != null && !isMultiDimensional);
+						parameterTypes.Add (parameterName.Value, typeName);
+						parameters.Add (parameterName.Value);
+					}
+				}
+
+				// write out the static create methods
+				WriteResponseCodeCreationMethods (writer, prefix, responseDefinition, parameterTypes);
+
+				// write out properties based on the parameters
+				foreach (var parameter in parameters) {
+					var semantic = isEnumType[parameter] ? ", ArgumentSemantic.Copy" : string.Empty;
+
+					writer.WriteLine ("\t\tpublic {0} {1} {{", parameterTypes[parameter], GetCSharpName (parameter));
+					writer.WriteLine ("\t\t\t[Export (\"{0}\"{1})]", parameter, semantic);
+					writer.WriteLine ("\t\t\tget;");
+					writer.WriteLine ("\t\t\t[Export (\"set{0}:\"{1})]", GetCSharpName (parameter), semantic);
+					writer.WriteLine ("\t\t\tset;");
+					writer.WriteLine ("\t\t}");
+					writer.WriteLine ();
+				}
+			}
+
+			writer.WriteLine ("\t\t[Export (\"code\")]");
+			writer.WriteLine ("\t\tpublic {0}IntentResponseCode Code {{ get; }}", prefix);
+
+			writer.WriteLine ("\t}");
+		}
+
+		void WriteIntentHandlingTrampolines (TextWriter writer, string prefix)
+		{
+			writer.WriteLine ("\t[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]");
+			writer.WriteLine ("\tstatic class {0}IntentHandlingTrampolines", prefix);
+			writer.WriteLine ("\t{");
+			writer.WriteLine ("\t\tconst string LIBOBJC_DYLIB = \"/usr/lib/libobjc.dylib\";");
+			writer.WriteLine ();
+			writer.WriteLine ("\t\t[DllImport (LIBOBJC_DYLIB, EntryPoint=\"objc_msgSend\")]");
+			writer.WriteLine ("\t\tpublic extern static IntPtr IntPtr_objc_msgSend (IntPtr receiever, IntPtr selector);");
+			writer.WriteLine ("\t\t[DllImport (LIBOBJC_DYLIB, EntryPoint=\"objc_msgSendSuper\")]");
+			writer.WriteLine ("\t\tpublic extern static IntPtr IntPtr_objc_msgSendSuper (IntPtr receiever, IntPtr selector);");
+			writer.WriteLine ("\t\t[DllImport (LIBOBJC_DYLIB, EntryPoint=\"objc_msgSend\")]");
+			writer.WriteLine ("\t\tpublic extern static IntPtr IntPtr_objc_msgSend_IntPtr (IntPtr receiever, IntPtr selector, IntPtr arg1);");
+			writer.WriteLine ("\t\t[DllImport (LIBOBJC_DYLIB, EntryPoint=\"objc_msgSendSuper\")]");
+			writer.WriteLine ("\t\tpublic extern static IntPtr IntPtr_objc_msgSendSuper_IntPtr (IntPtr receiever, IntPtr selector, IntPtr arg1);");
+			writer.WriteLine ("\t\t[DllImport (LIBOBJC_DYLIB, EntryPoint=\"objc_msgSend\")]");
+			writer.WriteLine ("\t\tpublic extern static void void_objc_msgSend_IntPtr (IntPtr receiver, IntPtr selector, IntPtr arg1);");
+			writer.WriteLine ("\t\t[DllImport (LIBOBJC_DYLIB, EntryPoint=\"objc_msgSendSuper\")]");
+			writer.WriteLine ("\t\tpublic extern static void void_objc_msgSendSuper_IntPtr (IntPtr receiver, IntPtr selector, IntPtr arg1);");
+			writer.WriteLine ("\t\t[DllImport (LIBOBJC_DYLIB, EntryPoint=\"objc_msgSend\")]");
+			writer.WriteLine ("\t\tpublic extern static void void_objc_msgSend_IntPtr_IntPtr (IntPtr receiver, IntPtr selector, IntPtr arg1, IntPtr arg2);");
+			writer.WriteLine ("\t\t[DllImport (LIBOBJC_DYLIB, EntryPoint=\"objc_msgSendSuper\")]");
+			writer.WriteLine ("\t\tpublic extern static void void_objc_msgSendSuper_IntPtr_IntPtr (IntPtr receiver, IntPtr selector, IntPtr arg1, IntPtr arg2);");
+			writer.WriteLine ("\t\t[DllImport (LIBOBJC_DYLIB)]");
+			writer.WriteLine ("\t\tstatic extern IntPtr _Block_copy (IntPtr ptr);");
+			writer.WriteLine ();
+			writer.WriteLine ("\t\t[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]");
+			writer.WriteLine ("\t\t[UserDelegateType (typeof ({0}ResponseCallback))]", prefix);
+			writer.WriteLine ("\t\tinternal delegate void D{0}ResponseCallback (IntPtr block, IntPtr response);", prefix);
+			writer.WriteLine ();
+			writer.WriteLine ("\t\tstatic internal class SD{0}ResponseCallback", prefix);
+			writer.WriteLine ("\t\t{");
+			writer.WriteLine ("\t\t\tstatic internal readonly D{0}ResponseCallback Handler = Invoke;", prefix);
+			writer.WriteLine ();
+			writer.WriteLine ("\t\t\t[MonoPInvokeCallback (typeof (D{0}ResponseCallback))]", prefix);
+			writer.WriteLine ("\t\t\tstatic unsafe void Invoke (IntPtr block, IntPtr response)");
+			writer.WriteLine ("\t\t\t{");
+			writer.WriteLine ("\t\t\t\tvar descriptor = (BlockLiteral*) block;");
+			writer.WriteLine ("\t\t\t\tvar del = ({0}ResponseCallback) (descriptor->Target);", prefix);
+			writer.WriteLine ("\t\t\t\tif (del != null)");
+			writer.WriteLine ("\t\t\t\t\tdel (Runtime.GetNSObject<{0}IntentResponse> (response));", prefix);
+			writer.WriteLine ("\t\t\t}");
+			writer.WriteLine ("\t\t}");
+			writer.WriteLine ();
+			writer.WriteLine ("\t\tinternal class NID{0}ResponseCallback", prefix);
+			writer.WriteLine ("\t\t{");
+			writer.WriteLine ("\t\t\tIntPtr blockPtr;");
+			writer.WriteLine ("\t\t\tD{0}ResponseCallback invoker;", prefix);
+			writer.WriteLine ();
+			writer.WriteLine ("\t\t\t[Preserve (Conditional=true)]");
+			writer.WriteLine ("\t\t\t[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]");
+			writer.WriteLine ("\t\t\tpublic unsafe NID{0}ResponseCallback (BlockLiteral *block)", prefix);
+			writer.WriteLine ("\t\t\t{");
+			writer.WriteLine ("\t\t\t\tblockPtr = _Block_copy ((IntPtr) block);");
+			writer.WriteLine ("\t\t\t\tinvoker = block->GetDelegateForBlock<D{0}ResponseCallback> ();", prefix);
+			writer.WriteLine ("\t\t\t}");
+			writer.WriteLine ();
+			writer.WriteLine ("\t\t\t[Preserve (Conditional=true)]");
+			writer.WriteLine ("\t\t\t[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]");
+			writer.WriteLine ("\t\t\t~NID{0}ResponseCallback ()", prefix);
+			writer.WriteLine ("\t\t\t{");
+			writer.WriteLine ("\t\t\t\tRuntime.ReleaseBlockOnMainThread (blockPtr);");
+			writer.WriteLine ("\t\t\t}");
+			writer.WriteLine ();
+			writer.WriteLine ("\t\t\t[Preserve (Conditional=true)]");
+			writer.WriteLine ("\t\t\t[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]");
+			writer.WriteLine ("\t\t\tpublic unsafe static {0}ResponseCallback Create (IntPtr block)", prefix);
+			writer.WriteLine ("\t\t\t{");
+			writer.WriteLine ("\t\t\t\tif (block == IntPtr.Zero)");
+			writer.WriteLine ("\t\t\t\t\treturn null;");
+			writer.WriteLine ("\t\t\t\tif (BlockLiteral.IsManagedBlock (block)) {");
+			writer.WriteLine ("\t\t\t\t\tvar existing_delegate = ((BlockLiteral *) block)->Target as {0}ResponseCallback;", prefix);
+			writer.WriteLine ("\t\t\t\t\tif (existing_delegate != null)");
+			writer.WriteLine ("\t\t\t\t\t\treturn existing_delegate;");
+			writer.WriteLine ("\t\t\t\t}");
+			writer.WriteLine ("\t\t\t\treturn new NID{0}ResponseCallback ((BlockLiteral *) block).Invoke;", prefix);
+			writer.WriteLine ("\t\t\t}");
+			writer.WriteLine ();
+			writer.WriteLine ("\t\t\t[Preserve (Conditional=true)]");
+			writer.WriteLine ("\t\t\t[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]");
+			writer.WriteLine ("\t\t\tunsafe void Invoke ({0}IntentResponse response)", prefix);
+			writer.WriteLine ("\t\t\t{");
+			writer.WriteLine ("\t\t\t\tinvoker (blockPtr, response == null ? IntPtr.Zero : response.Handle);");
+			writer.WriteLine ("\t\t\t}");
+			writer.WriteLine ("\t\t}");
+			writer.WriteLine ("\t}");
+		}
+
+		void WriteIntentHandlingInterface (TextWriter writer, string prefix)
+		{
+			writer.WriteLine ("\t[Protocol (Name = \"{0}IntentHandling\", WrapperType = typeof ({0}IntentHandlingWrapper))]", prefix);
+			writer.WriteLine ("\t[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"Handle{0}\", Selector = \"handle{0}:completion:\", ParameterType = new Type [] {{ typeof ({0}Intent), typeof ({0}ResponseCallback) }}, ParameterByRef = new bool [] {{ false, false }}, ParameterBlockProxy = new Type [] {{ null, typeof ({0}IntentHandlingTrampolines.NID{0}ResponseCallback) }})]", prefix);
+			writer.WriteLine ("\t[ProtocolMember (IsRequired = false, IsProperty = false, IsStatic = false, Name = \"Confirm{0}\", Selector = \"confirm{0}:completion:\", ParameterType = new Type [] {{ typeof ({0}Intent), typeof ({0}ResponseCallback) }}, ParameterByRef = new bool [] {{ false, false }}, ParameterBlockProxy = new Type [] {{ null, typeof ({0}IntentHandlingTrampolines.NID{0}ResponseCallback) }})]", prefix);
+			writer.WriteLine ("\tinterface I{0}IntentHandling : INativeObject, IDisposable", prefix);
+			writer.WriteLine ("\t{");
+			writer.WriteLine ("\t\t[Export (\"handle{0}:completion:\")]", prefix);
+			writer.WriteLine ("\t\t[Preserve (Conditional = true)]");
+			writer.WriteLine ("\t\tvoid Handle{0} ({0}Intent intent, [BlockProxy (typeof ({0}IntentHandlingTrampolines.NID{0}ResponseCallback))]{0}ResponseCallback response);", prefix);
+			writer.WriteLine ("\t}");
+		}
+
+		void WriteIntentHandlingExtensions (TextWriter writer, string prefix)
+		{
+			writer.WriteLine ("\tstatic partial class {0}IntentHandlingExtensions", prefix);
+			writer.WriteLine ("\t{");
+			writer.WriteLine ("\t\t[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]");
+			writer.WriteLine ("\t\tpublic unsafe static void Confirm{0} (this I{0}IntentHandling This, {0}Intent intent, [BlockProxy (typeof ({0}IntentHandlingTrampolines.NID{0}ResponseCallback))]{0}ResponseCallback response)", prefix);
+			writer.WriteLine ("\t\t{");
+			writer.WriteLine ("\t\t\tif (intent == null)");
+			writer.WriteLine ("\t\t\t\tthrow new ArgumentNullException (\"intent\");");
+			writer.WriteLine ();
+			writer.WriteLine ("\t\t\tif (response == null)");
+			writer.WriteLine ("\t\t\t\tthrow new ArgumentNullException (\"response\");");
+			writer.WriteLine ();
+			writer.WriteLine ("\t\t\tBlockLiteral *block_ptr_response;");
+			writer.WriteLine ("\t\t\tBlockLiteral block_response;");
+			writer.WriteLine ();
+			writer.WriteLine ("\t\t\tblock_response = new BlockLiteral ();");
+			writer.WriteLine ("\t\t\tblock_ptr_response = &block_response;");
+			writer.WriteLine ("\t\t\tblock_response.SetupBlockUnsafe ({0}IntentHandlingTrampolines.SD{0}ResponseCallback.Handler, response);", prefix);
+			writer.WriteLine ();
+			writer.WriteLine ("\t\t\t{0}IntentHandlingTrampolines.void_objc_msgSend_IntPtr_IntPtr (This.Handle, Selector.GetHandle (\"confirm{0}:completion:\"), intent.Handle, (IntPtr) block_ptr_response);", prefix);
+			writer.WriteLine ("\t\t\tblock_ptr_response->CleanupBlock ();");
+			writer.WriteLine ("\t\t}");
+			writer.WriteLine ("\t}");
+		}
+
+		void WriteIntentHandlingWrapper (TextWriter writer, string prefix)
+		{
+			writer.WriteLine ("\tsealed class {0}IntentHandlingWrapper : BaseWrapper, I{0}IntentHandling", prefix);
+			writer.WriteLine ("\t{");
+			writer.WriteLine ("\t\t[Preserve (Conditional = true)]");
+			writer.WriteLine ("\t\tpublic {0}IntentHandlingWrapper (IntPtr handle, bool owns) : base (handle, owns)", prefix);
+			writer.WriteLine ("\t\t{");
+			writer.WriteLine ("\t\t}");
+			writer.WriteLine ();
+			writer.WriteLine ("\t\t[Export (\"handle{0}:completion:\")]", prefix);
+			writer.WriteLine ("\t\t[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]");
+			writer.WriteLine ("\t\tpublic unsafe void Handle{0} ({0}Intent intent, [BlockProxy (typeof ({0}IntentHandlingTrampolines.NID{0}ResponseCallback))]{0}ResponseCallback response)", prefix);
+			writer.WriteLine ("\t\t{");
+			writer.WriteLine ("\t\t\tif (intent == null)");
+			writer.WriteLine ("\t\t\t\tthrow new ArgumentNullException (\"intent\");");
+			writer.WriteLine ();
+			writer.WriteLine ("\t\t\tif (response == null)");
+			writer.WriteLine ("\t\t\t\tthrow new ArgumentNullException (\"response\");");
+			writer.WriteLine ();
+			writer.WriteLine ("\t\t\tBlockLiteral *block_ptr_response;");
+			writer.WriteLine ("\t\t\tBlockLiteral block_response;");
+			writer.WriteLine ();
+			writer.WriteLine ("\t\t\tblock_response = new BlockLiteral ();");
+			writer.WriteLine ("\t\t\tblock_ptr_response = &block_response;");
+			writer.WriteLine ("\t\t\tblock_response.SetupBlockUnsafe ({0}IntentHandlingTrampolines.SD{0}ResponseCallback.Handler, response);", prefix);
+			writer.WriteLine ();
+			writer.WriteLine ("\t\t\t{0}IntentHandlingTrampolines.void_objc_msgSend_IntPtr_IntPtr (intent.Handle, Selector.GetHandle (\"handle{0}:completion:\"), intent.Handle, (IntPtr) block_ptr_response);", prefix);
+			writer.WriteLine ("\t\t\tblock_ptr_response->CleanupBlock ();");
+			writer.WriteLine ("\t\t}");
+			writer.WriteLine ("\t}");
+		}
+
+		void WriteIntentHandlingDefinition (TextWriter writer, string prefix)
+		{
+			writer.WriteLine ("\tdelegate void {0}ResponseCallback ({0}IntentResponse response);", prefix);
+			writer.WriteLine ();
+			WriteIntentHandlingTrampolines (writer, prefix);
+			writer.WriteLine ();
+			WriteIntentHandlingInterface (writer, prefix);
+			writer.WriteLine ();
+			WriteIntentHandlingExtensions (writer, prefix);
+			writer.WriteLine ();
+			WriteIntentHandlingWrapper (writer, prefix);
+		}
+
+		bool TryGenerateIntentBinding (string intermediateDir, PDictionary intentDefinition, Dictionary<string, PDictionary> enumDefinitions, out string path)
+		{
+			PString value;
+
+			path = null;
+
+			if (!intentDefinition.TryGetValue (SiriIntentsKeys.INIntentName, out value))
+				return false;
+
+			if (!intentDefinition.TryGetValue (SiriIntentsKeys.INIntentResponse, out PDictionary responseDefinition))
+				return false;
+
+			var name = value.Value;
+
+			path = Path.Combine (intermediateDir, name + "Intent.cs");
+
+			using (var writer = File.CreateText (path)) {
+				var enums = new HashSet<string> (StringComparer.Ordinal);
+				PArray parameters;
+
+				writer.WriteLine ("using System;");
+				writer.WriteLine ("using System.Runtime.InteropServices;");
+				writer.WriteLine ();
+				writer.WriteLine ("using Intents;");
+				writer.WriteLine ("using Foundation;");
+				writer.WriteLine ("using ObjCRuntime;");
+				writer.WriteLine ("using CoreLocation;");
+				writer.WriteLine ();
+				writer.WriteLine ("namespace {0} {{", RootNamespace);
+
+				// collect a list of enums that this class uses...
+				if (intentDefinition.TryGetValue (SiriIntentsKeys.INIntentParameters, out parameters)) {
+					foreach (var parameterDefinition in parameters.OfType<PDictionary> ()) {
+						if (parameterDefinition.TryGetValue (SiriIntentsKeys.INIntentParameterEnumType, out PString enumType))
+							enums.Add (enumType.Value);
+					}
+				}
+
+				if (responseDefinition.TryGetValue (SiriIntentsKeys.INIntentResponseParameters, out parameters)) {
+					foreach (var parameterDefinition in parameters.OfType<PDictionary> ()) {
+						if (parameterDefinition.TryGetValue (SiriIntentsKeys.INIntentResponseParameterEnumType, out PString enumType))
+							enums.Add (enumType.Value);
+					}
+				}
+
+				// write out the enum definitions
+				foreach (var enumName in enums) {
+					if (enumDefinitions.TryGetValue (enumName, out PDictionary enumDefinition))
+						WriteEnumDefinition (writer, name, enumDefinition);
+				}
+
+				WriteIntentDefinition (writer, name, intentDefinition);
+				writer.WriteLine ();
+				WriteIntentResponseDefinition (writer, name, responseDefinition);
+				writer.WriteLine ();
+				WriteIntentHandlingDefinition (writer, name);
+
+				// end of namespace
+				writer.WriteLine ("}");
+			}
+
+			return true;
+		}
+
+		public override bool Execute ()
+		{
+			var enumDefinitions = new Dictionary<string, PDictionary> (StringComparer.Ordinal);
+			PDictionary plist;
+			PArray intents;
+			PArray enums;
+
+			try {
+				plist = PDictionary.FromFile (IntentDefinition.ItemSpec);
+			} catch (Exception ex) {
+				Log.LogError (7066, IntentDefinition.ItemSpec, $"Error loading '{IntentDefinition.ItemSpec}': {ex.Message}", IntentDefinition.ItemSpec);
+				return false;
+			}
+
+			if (!plist.TryGetValue (SiriIntentsKeys.INIntents, out intents) || intents.Count == 0)
+				return true;
+
+			if (!plist.TryGetValue (SiriIntentsKeys.INEnums, out enums))
+				enums = new PArray ();
+
+			if (!Directory.Exists (IntermediateOutputPath))
+				Directory.CreateDirectory (IntermediateOutputPath);
+
+			var generated = new List<ITaskItem> ();
+
+			foreach (var enumDefinition in enums.OfType<PDictionary> ()) {
+				if (!enumDefinition.TryGetValue (SiriIntentsKeys.INEnumName, out PString name))
+					continue;
+
+				enumDefinitions.Add (name.Value, enumDefinition);
+			}
+
+			foreach (var intent in intents.OfType<PDictionary> ()) {
+				PString category;
+
+				if (!intent.TryGetValue (SiriIntentsKeys.INIntentCategory, out category))
+					continue;
+
+				if (category.Value == "system")
+					continue;
+
+				if (!TryGenerateIntentBinding (IntermediateOutputPath, intent, enumDefinitions, out string fileName))
+					continue;
+
+				generated.Add (new TaskItem (fileName));
+			}
+
+			GeneratedSources = generated.ToArray ();
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IntentDefinitionCompilerTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/IntentDefinitionCompilerTaskBase.cs
@@ -1,0 +1,83 @@
+﻿using System.IO;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.MacDev.Tasks
+{
+	public abstract class IntentDefinitionCompilerTaskBase : ToolTask
+	{
+		#region Inputs
+
+		public string SessionId { get; set; }
+
+		[Required]
+		public ITaskItem IntentDefinition { get; set; }
+
+		[Required]
+		public string IntermediateOutputPath { get; set; }
+
+		[Required]
+		public string ProjectDir { get; set; }
+
+		[Required]
+		public string ResourcePrefix { get; set; }
+
+		[Required]
+		public string SdkBinPath { get; set; }
+
+		#endregion
+
+		#region Outputs
+
+		[Output]
+		public ITaskItem BundleResource { get; set; }
+
+		#endregion
+
+		protected override string ToolName {
+			get { return "intentbuilderc"; }
+		}
+
+		protected override string GenerateFullPathToTool ()
+		{
+			if (!string.IsNullOrEmpty (ToolPath))
+				return Path.Combine (ToolPath, ToolExe);
+
+			var path = Path.Combine (SdkBinPath, ToolExe);
+
+			return File.Exists (path) ? path : ToolExe;
+		}
+
+		protected override string GenerateCommandLineCommands ()
+		{
+			var fileName = Path.GetFileName (IntentDefinition.ItemSpec);
+			var args = new CommandLineArgumentBuilder ();
+
+			args.AddQuoted (IntentDefinition.ItemSpec);
+			args.AddQuoted (IntermediateOutputPath);
+			args.AddQuoted (string.Empty);
+
+			BundleResource = new TaskItem (Path.Combine (IntermediateOutputPath, fileName));
+			BundleResource.SetMetadata ("LogicalName", fileName);
+
+			return args.ToString ();
+		}
+
+		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
+		{
+			// TODO: do proper parsing of error messages and such
+			Log.LogMessage (messageImportance, "{0}", singleLine);
+		}
+
+		public override bool Execute ()
+		{
+			var dir = Path.Combine (IntermediateOutputPath, ToolName);
+
+			if (!Directory.Exists (dir))
+				Directory.CreateDirectory (dir);
+
+			return base.Execute ();
+		}
+	}
+}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Xamarin.MacDev.Tasks.Core.csproj
@@ -55,6 +55,9 @@
     <Compile Include="MsBuildTasks\MoveTaskBase.cs" Condition="'$(OS)' == 'Windows_NT'" />
     <Compile Include="MsBuildTasks\XBuildMoveTaskBase.cs" Condition="'$(OS)' != 'Windows_NT'" />
     <Compile Include="PlatformUtils.cs" />
+    <Compile Include="Tasks\IntentDefinitionCompilerTaskBase.cs" />
+    <Compile Include="Tasks\IntentDefinitionCodegenTaskBase.cs" />
+    <Compile Include="SiriIntentsKeys.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MsBuildTasks\CopyBase.cs" />

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/IntentDefinitionCodegen.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/IntentDefinitionCodegen.cs
@@ -1,0 +1,6 @@
+﻿namespace Xamarin.MacDev.Tasks
+{
+	public class IntentDefinitionCodegen : IntentDefinitionCodegenTaskBase
+	{
+	}
+}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/IntentDefinitionCompiler.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/IntentDefinitionCompiler.cs
@@ -1,0 +1,6 @@
+﻿namespace Xamarin.MacDev.Tasks
+{
+	public class IntentDefinitionCompiler : IntentDefinitionCompilerTaskBase
+	{
+	}
+}

--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -86,6 +86,8 @@
     <Compile Include="Tasks\UnpackLibraryResources.cs" />
     <Compile Include="Tasks\WriteItemsToFile.cs" />
     <Compile Include="Tasks\Zip.cs" />
+    <Compile Include="Tasks\IntentDefinitionCompiler.cs" />
+    <Compile Include="Tasks\IntentDefinitionCodegen.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -28,6 +28,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GenerateBundleName" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetNativeExecutableName" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.GetPropertyListValue" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.IntentDefinitionCodegen" AssemblyFile="Xamarin.iOS.Tasks.dll" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.IntentDefinitionCompiler" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.PackLibraryResources" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.PropertyListEditor" AssemblyFile="Xamarin.iOS.Tasks.dll" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.ReadItemsFromFile" AssemblyFile="Xamarin.iOS.Tasks.dll" />
@@ -235,6 +237,12 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<_CoreMLModel_PartialAppManifestCache>$(DeviceSpecificIntermediateOutputPath)coremlc\_PartialAppManifest.items</_CoreMLModel_PartialAppManifestCache>
 			<_CoreMLModel_BundleResourceCache>$(DeviceSpecificIntermediateOutputPath)coremlc\_BundleResourceWithLogicalName.items</_CoreMLModel_BundleResourceCache>
 
+			<!-- intentbuilderc output caches -->
+			<_IntentDefinition_BundleResourceCache>$(DeviceSpecificIntermediateOutputPath)intentbuilderc\_BundleResourceWithLogicalName.items</_IntentDefinition_BundleResourceCache>
+
+			<!-- intent codegen output caches -->
+			<_IntentDefinition_CodegenCache>$(DeviceSpecificIntermediateOutputPath)intentcodegen\_Compile.items</_IntentDefinition_CodegenCache>
+
 			<!-- ibtool output caches -->
 			<_IBToolCache>$(DeviceSpecificIntermediateOutputPath)ibtool\_BundleResourceWithLogicalName.items</_IBToolCache>
 
@@ -248,6 +256,11 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<!-- Insert our app bundle generation step -->
 	<PropertyGroup>
+		<CoreCompileDependsOn>
+			_IntentDefinitionsCodegen;
+			$(CoreCompileDependsOn)
+		</CoreCompileDependsOn>
+		
 		<BuildDependsOn>
 			BuildOnlySettings;
 			PrepareForBuild;
@@ -332,6 +345,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			_ForgeMetal;
 			_TemperMetal;
 			_CompileCoreMLModels;
+			_CompileIntentDefinitions;
 			_PrepareResourceRules;
 			_CompileEntitlements;
 			_CompileAppManifest;
@@ -441,6 +455,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 					$(DeviceSpecificIntermediateOutputPath)ibtool;
 					$(DeviceSpecificIntermediateOutputPath)ibtool-link;
 					$(DeviceSpecificIntermediateOutputPath)ibtool-manifests;
+					$(DeviceSpecificIntermediateOutputPath)intentbuilderc;
+					$(DeviceSpecificIntermediateOutputPath)intentcodegen;
 					$(DeviceSpecificIntermediateOutputPath)ipa;
 					$(DeviceSpecificIntermediateOutputPath)metal;
 					$(DeviceSpecificIntermediateOutputPath)optimized;
@@ -465,6 +481,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			_CompileSceneKitAssets;
 			_CompileTextureAtlases;
 			_CompileCoreMLModels;
+			_CompileIntentDefinitions;
 		</_CollectBundleResourcesDependsOn>
 	</PropertyGroup>
 
@@ -1466,6 +1483,98 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<WriteItemsToFile Items="@(_CoreMLModel_BundleResources)" ItemName="_BundleResourceWithLogicalName" File="$(_CoreMLModel_BundleResourceCache)" Overwrite="true" IncludeMetadata="true" />
 		<ItemGroup>
 			<FileWrites Include="$(_CoreMLModel_PartialAppManifestCache);$(_CoreMLModel_BundleResourceCache)" />
+		</ItemGroup>
+	</Target>
+
+	<Target Name="_IntentDefinitionsCodegen" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_ComputeTargetArchitectures;_BeforeIntentDefinitionsCodegen;_ReadIntentDefinitionsCodegen;_CoreIntentDefinitionsCodegen" />
+
+	<Target Name="_BeforeIntentDefinitionsCodegen"
+		Inputs="@(IntentDefinition)"
+		Outputs="$(_IntentDefinition_CodegenCache)">
+		<!-- If any IntentDefinition is newer than the generated items list, we delete them so that the _CoreCompileIntentDefinitions
+		     target runs again and updates those lists for the next run
+		-->
+		<Delete Files="$(_IntentDefinition_CodegenCache)" />
+		<RemoveDir Directories="$(DeviceSpecificIntermediateOutputPath)intentcodegen" />
+	</Target>
+
+	<Target Name="_ReadIntentDefinitionsCodegen"	DependsOnTargets="_BeforeIntentDefinitionsCodegen">
+		<!-- If _BeforeIntentDefinitionsCodegen did not delete the generated items lists from _CoreIntentDefinitionsCodegen, then we read them
+		     since that target won't run and we need the output items that are cached in those files, which includes full metadata -->
+		<ReadItemsFromFile File="$(_IntentDefinition_CodegenCache)" Condition="Exists('$(_IntentDefinition_CodegenCache)')">
+			<Output TaskParameter="Items" ItemName="Compile" />
+		</ReadItemsFromFile>
+	</Target>
+
+	<Target Name="_CoreIntentDefinitionsCodegen" 
+		Inputs="@(IntentDefinition)"
+		Outputs="$(_IntentDefinition_CodegenCache)"
+		DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_BeforeIntentDefinitionsCodegen">
+
+		<IntentDefinitionCodegen
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			IntentDefinition="@(IntentDefinition)"
+			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)intentcodegen"
+			RootNamespace="$(RootNamespace)">
+			<Output TaskParameter="GeneratedSources" ItemName="Compile" />
+
+			<!-- Local items to be persisted to items files -->
+			<Output TaskParameter="GeneratedSources" ItemName="_IntentDefinition_GeneratedSources" />
+		</IntentDefinitionCodegen>
+
+		<!-- Cache the generated outputs items for incremental build support -->
+		<WriteItemsToFile Items="@(_IntentDefinition_GeneratedSources)" ItemName="Compile" File="$(_IntentDefinition_CodegenCache)" Overwrite="true" IncludeMetadata="true" />
+		<ItemGroup>
+			<FileWrites Include="$(_IntentDefinition_CodegenCache)" />
+		</ItemGroup>
+	</Target>
+
+	<Target Name="_CompileIntentDefinitions" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_ComputeTargetArchitectures;_BeforeCompileIntentDefinitions;_ReadCompileIntentDefinitions;_CoreCompileIntentDefinitions" />
+
+	<Target Name="_BeforeCompileIntentDefinitions"
+		Inputs="@(IntentDefinition)"
+		Outputs="$(_IntentDefinition_BundleResourceCache)">
+		<!-- If any IntentDefinition is newer than the generated items list, we delete them so that the _CoreCompileIntentDefinitions
+		     target runs again and updates those lists for the next run
+		-->
+		<Delete Files="$(_IntentDefinition_BundleResourceCache)" />
+		<RemoveDir Directories="$(DeviceSpecificIntermediateOutputPath)intentbuilderc" />
+	</Target>
+
+	<Target Name="_ReadCompileIntentDefinitions"	DependsOnTargets="_BeforeCompileIntentDefinitions">
+		<!-- If _BeforeCompileIntentDefinitions did not delete the generated items lists from _CoreCompileIntentDefinitions, then we read them
+		     since that target won't run and we need the output items that are cached in those files, which includes full metadata -->
+		<ReadItemsFromFile File="$(_IntentDefinition_BundleResourceCache)" Condition="Exists('$(_IntentDefinition_BundleResourceCache)')">
+			<Output TaskParameter="Items" ItemName="_BundleResourceWithLogicalName" />
+		</ReadItemsFromFile>
+	</Target>
+
+	<Target Name="_CoreCompileIntentDefinitions" 
+		Inputs="@(IntentDefinition)"
+		Outputs="$(_IntentDefinition_BundleResourceCache)"
+		DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_BeforeCompileIntentDefinitions">
+
+		<IntentDefinitionCompiler
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			ToolExe="$(IntentDefinitionCompilerExe)"
+			ToolPath="$(IntentDefinitionCompilerPath)"
+			IntentDefinition="@(IntentDefinition)"
+			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)intentbuilderc"
+			ProjectDir="$(MSBuildProjectDirectory)"
+			ResourcePrefix="$(IPhoneResourcePrefix)"
+			SdkBinPath="$(_SdkBinPath)">
+			<Output TaskParameter="BundleResource" ItemName="_BundleResourceWithLogicalName" />
+
+			<!-- Local items to be persisted to items files -->
+			<Output TaskParameter="BundleResource" ItemName="_IntentDefinition_BundleResources" />
+		</IntentDefinitionCompiler>
+
+		<!-- Cache the generated outputs items for incremental build support -->
+		<WriteItemsToFile Items="@(_IntentDefinition_BundleResources)" ItemName="_BundleResourceWithLogicalName" File="$(_IntentDefinition_BundleResourceCache)" Overwrite="true" IncludeMetadata="true" />
+		<ItemGroup>
+			<FileWrites Include="$(_IntentDefinition_BundleResourceCache)" />
 		</ItemGroup>
 	</Target>
 


### PR DESCRIPTION
This PR implements the MSBuild portion of the new Siri Intents feature. There are 2 parts:

1. `IntentsDefinitionCompiler` - this maps to Xcode's `intentbuilderc` which (mostly) just copies the `Intents.intentdefinition` file into the app bundle (or, in our case, copies it into an intermediate output directory and adds it to the list of bundle resources with a LogicalName set). The other thing it seems to do is set some default values for some version fields and such. We let `intentbuilderc` do its thing.
2. `IntentsDefinitionCodegen` - this duplicates Xcode's codegen step which generates Objective-C code and compiles them into object files for linking into the main app during the later build phase. For us, we generate C# source files (one per intent, just like Xcode does) and add the C# source files to the `Compile` items list.

This PR supersedes https://github.com/xamarin/xamarin-macios/pull/4775

The only changes between this PR and the previous PR is the code generator now includes logic to generate the "Handling" class which makes use of some new XI APIs introduced in master.