### PR TITLE
Reuse Libraries.*.Handle instead of dlopen'ing multiple times the same libraries.

### DIFF
--- a/src/AddressBook/ABAddressBook.cs
+++ b/src/AddressBook/ABAddressBook.cs
@@ -144,15 +144,7 @@ namespace AddressBook {
 		
 		static ABAddressBook ()
 		{
-			var handle = Dlfcn.dlopen (Constants.AddressBookLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				ErrorDomain = Dlfcn.GetStringConstant (handle, "ABAddressBookErrorDomain");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			ErrorDomain = Dlfcn.GetStringConstant (Libraries.AddressBook.Handle, "ABAddressBookErrorDomain");
 		}
 
 		~ABAddressBook ()

--- a/src/AddressBook/ABGroup.cs
+++ b/src/AddressBook/ABGroup.cs
@@ -51,15 +51,7 @@ namespace AddressBook {
 
 		internal static void Init ()
 		{
-			var handle = Dlfcn.dlopen (Constants.AddressBookLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Name = Dlfcn.GetInt32 (handle, "kABGroupNameProperty");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			Name = Dlfcn.GetInt32 (Libraries.AddressBook.Handle, "kABGroupNameProperty");
 		}
 	}
 

--- a/src/AddressBook/ABPerson.cs
+++ b/src/AddressBook/ABPerson.cs
@@ -123,39 +123,32 @@ namespace AddressBook {
 
 		internal static void Init ()
 		{
-			var handle = Dlfcn.dlopen (Constants.AddressBookLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Address             = Dlfcn.GetInt32 (handle, "kABPersonAddressProperty");
-				Birthday            = Dlfcn.GetInt32 (handle, "kABPersonBirthdayProperty");
-				CreationDate        = Dlfcn.GetInt32 (handle, "kABPersonCreationDateProperty");
-				Date                = Dlfcn.GetInt32 (handle, "kABPersonDateProperty");
-				Department          = Dlfcn.GetInt32 (handle, "kABPersonDepartmentProperty");
-				Email               = Dlfcn.GetInt32 (handle, "kABPersonEmailProperty");
-				FirstName           = Dlfcn.GetInt32 (handle, "kABPersonFirstNameProperty");
-				FirstNamePhonetic   = Dlfcn.GetInt32 (handle, "kABPersonFirstNamePhoneticProperty");
-				InstantMessage      = Dlfcn.GetInt32 (handle, "kABPersonInstantMessageProperty");
-				JobTitle            = Dlfcn.GetInt32 (handle, "kABPersonJobTitleProperty");
-				Kind                = Dlfcn.GetInt32 (handle, "kABPersonKindProperty");
-				LastName            = Dlfcn.GetInt32 (handle, "kABPersonLastNameProperty");
-				LastNamePhonetic    = Dlfcn.GetInt32 (handle, "kABPersonLastNamePhoneticProperty");
-				MiddleName          = Dlfcn.GetInt32 (handle, "kABPersonMiddleNameProperty");
-				MiddleNamePhonetic  = Dlfcn.GetInt32 (handle, "kABPersonMiddleNamePhoneticProperty");
-				ModificationDate    = Dlfcn.GetInt32 (handle, "kABPersonModificationDateProperty");
-				Nickname            = Dlfcn.GetInt32 (handle, "kABPersonNicknameProperty");
-				Note                = Dlfcn.GetInt32 (handle, "kABPersonNoteProperty");
-				Organization        = Dlfcn.GetInt32 (handle, "kABPersonOrganizationProperty");
-				Phone               = Dlfcn.GetInt32 (handle, "kABPersonPhoneProperty");
-				Prefix              = Dlfcn.GetInt32 (handle, "kABPersonPrefixProperty");
-				RelatedNames        = Dlfcn.GetInt32 (handle, "kABPersonRelatedNamesProperty");
-				Suffix              = Dlfcn.GetInt32 (handle, "kABPersonSuffixProperty");
-				Url                 = Dlfcn.GetInt32 (handle, "kABPersonURLProperty");
-				SocialProfile       = Dlfcn.GetInt32 (handle, "kABPersonSocialProfileProperty");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.AddressBook.Handle;
+			Address             = Dlfcn.GetInt32 (handle, "kABPersonAddressProperty");
+			Birthday            = Dlfcn.GetInt32 (handle, "kABPersonBirthdayProperty");
+			CreationDate        = Dlfcn.GetInt32 (handle, "kABPersonCreationDateProperty");
+			Date                = Dlfcn.GetInt32 (handle, "kABPersonDateProperty");
+			Department          = Dlfcn.GetInt32 (handle, "kABPersonDepartmentProperty");
+			Email               = Dlfcn.GetInt32 (handle, "kABPersonEmailProperty");
+			FirstName           = Dlfcn.GetInt32 (handle, "kABPersonFirstNameProperty");
+			FirstNamePhonetic   = Dlfcn.GetInt32 (handle, "kABPersonFirstNamePhoneticProperty");
+			InstantMessage      = Dlfcn.GetInt32 (handle, "kABPersonInstantMessageProperty");
+			JobTitle            = Dlfcn.GetInt32 (handle, "kABPersonJobTitleProperty");
+			Kind                = Dlfcn.GetInt32 (handle, "kABPersonKindProperty");
+			LastName            = Dlfcn.GetInt32 (handle, "kABPersonLastNameProperty");
+			LastNamePhonetic    = Dlfcn.GetInt32 (handle, "kABPersonLastNamePhoneticProperty");
+			MiddleName          = Dlfcn.GetInt32 (handle, "kABPersonMiddleNameProperty");
+			MiddleNamePhonetic  = Dlfcn.GetInt32 (handle, "kABPersonMiddleNamePhoneticProperty");
+			ModificationDate    = Dlfcn.GetInt32 (handle, "kABPersonModificationDateProperty");
+			Nickname            = Dlfcn.GetInt32 (handle, "kABPersonNicknameProperty");
+			Note                = Dlfcn.GetInt32 (handle, "kABPersonNoteProperty");
+			Organization        = Dlfcn.GetInt32 (handle, "kABPersonOrganizationProperty");
+			Phone               = Dlfcn.GetInt32 (handle, "kABPersonPhoneProperty");
+			Prefix              = Dlfcn.GetInt32 (handle, "kABPersonPrefixProperty");
+			RelatedNames        = Dlfcn.GetInt32 (handle, "kABPersonRelatedNamesProperty");
+			Suffix              = Dlfcn.GetInt32 (handle, "kABPersonSuffixProperty");
+			Url                 = Dlfcn.GetInt32 (handle, "kABPersonURLProperty");
+			SocialProfile       = Dlfcn.GetInt32 (handle, "kABPersonSocialProfileProperty");
 		}
 
 		public static int ToId (ABPersonProperty property)
@@ -239,20 +232,13 @@ namespace AddressBook {
 
 		internal static void Init ()
 		{
-			var handle = Dlfcn.dlopen (Constants.AddressBookLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				City        = Dlfcn.GetStringConstant (handle, "kABPersonAddressCityKey");
-				Country     = Dlfcn.GetStringConstant (handle, "kABPersonAddressCountryKey");
-				CountryCode = Dlfcn.GetStringConstant (handle, "kABPersonAddressCountryCodeKey");
-				State       = Dlfcn.GetStringConstant (handle, "kABPersonAddressStateKey");
-				Street      = Dlfcn.GetStringConstant (handle, "kABPersonAddressStreetKey");
-				Zip         = Dlfcn.GetStringConstant (handle, "kABPersonAddressZIPKey");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.AddressBook.Handle;
+			City        = Dlfcn.GetStringConstant (handle, "kABPersonAddressCityKey");
+			Country     = Dlfcn.GetStringConstant (handle, "kABPersonAddressCountryKey");
+			CountryCode = Dlfcn.GetStringConstant (handle, "kABPersonAddressCountryCodeKey");
+			State       = Dlfcn.GetStringConstant (handle, "kABPersonAddressStateKey");
+			Street      = Dlfcn.GetStringConstant (handle, "kABPersonAddressStreetKey");
+			Zip         = Dlfcn.GetStringConstant (handle, "kABPersonAddressZIPKey");
 		}
 	}
 
@@ -267,15 +253,7 @@ namespace AddressBook {
 
 		internal static void Init ()
 		{
-			var handle = Dlfcn.dlopen (Constants.AddressBookLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Anniversary = Dlfcn.GetStringConstant (handle, "kABPersonAnniversaryLabel");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			Anniversary = Dlfcn.GetStringConstant (Libraries.AddressBook.Handle, "kABPersonAnniversaryLabel");
 		}
 	}
 
@@ -298,16 +276,9 @@ namespace AddressBook {
 
 		internal static void Init ()
 		{
-			var handle = Dlfcn.dlopen (Constants.AddressBookLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Organization  = Dlfcn.GetNSNumber (handle, "kABPersonKindOrganization");
-				Person        = Dlfcn.GetNSNumber (handle, "kABPersonKindPerson");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.AddressBook.Handle;
+			Organization  = Dlfcn.GetNSNumber (handle, "kABPersonKindOrganization");
+			Person        = Dlfcn.GetNSNumber (handle, "kABPersonKindPerson");
 		}
 
 		public static ABPersonKind ToPersonKind (NSNumber value)
@@ -338,17 +309,11 @@ namespace AddressBook {
 
 		static ABPersonSocialProfile ()
 		{
-			var handle = Dlfcn.dlopen (Constants.AddressBookLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				URLKey = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileURLKey");
-				ServiceKey = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileServiceKey");
-				UsernameKey = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileUsernameKey");
-				UserIdentifierKey = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileUserIdentifierKey");
-			} finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.AddressBook.Handle;
+			URLKey = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileURLKey");
+			ServiceKey = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileServiceKey");
+			UsernameKey = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileUsernameKey");
+			UserIdentifierKey = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileUserIdentifierKey");
 		}
 	}
 
@@ -366,20 +331,14 @@ namespace AddressBook {
 
 		static ABPersonSocialProfileService ()
 		{
-			var handle = Dlfcn.dlopen (Constants.AddressBookLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Twitter = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileServiceTwitter");
-				GameCenter = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileServiceGameCenter");
-				Facebook = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileServiceFacebook");
-				Myspace = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileServiceMyspace");
-				LinkedIn = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileServiceLinkedIn");
-				Flickr = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileServiceFlickr");
-				SinaWeibo = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileServiceSinaWeibo");
-			} finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.AddressBook.Handle;
+			Twitter = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileServiceTwitter");
+			GameCenter = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileServiceGameCenter");
+			Facebook = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileServiceFacebook");
+			Myspace = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileServiceMyspace");
+			LinkedIn = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileServiceLinkedIn");
+			Flickr = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileServiceFlickr");
+			SinaWeibo = Dlfcn.GetStringConstant (handle, "kABPersonSocialProfileServiceSinaWeibo");
 		}		
 	}
 	
@@ -400,23 +359,16 @@ namespace AddressBook {
 
 		internal static void Init ()
 		{
-			var handle = Dlfcn.dlopen (Constants.AddressBookLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				HomeFax = Dlfcn.GetStringConstant (handle, "kABPersonPhoneHomeFAXLabel");
-				iPhone  = Dlfcn.GetStringConstant (handle, "kABPersonPhoneIPhoneLabel");
-				Main    = Dlfcn.GetStringConstant (handle, "kABPersonPhoneMainLabel");
-				Mobile  = Dlfcn.GetStringConstant (handle, "kABPersonPhoneMobileLabel");
-				Pager   = Dlfcn.GetStringConstant (handle, "kABPersonPhonePagerLabel");
-				WorkFax = Dlfcn.GetStringConstant (handle, "kABPersonPhoneWorkFAXLabel");
+			var handle = Libraries.AddressBook.Handle;
+			HomeFax = Dlfcn.GetStringConstant (handle, "kABPersonPhoneHomeFAXLabel");
+			iPhone  = Dlfcn.GetStringConstant (handle, "kABPersonPhoneIPhoneLabel");
+			Main    = Dlfcn.GetStringConstant (handle, "kABPersonPhoneMainLabel");
+			Mobile  = Dlfcn.GetStringConstant (handle, "kABPersonPhoneMobileLabel");
+			Pager   = Dlfcn.GetStringConstant (handle, "kABPersonPhonePagerLabel");
+			WorkFax = Dlfcn.GetStringConstant (handle, "kABPersonPhoneWorkFAXLabel");
 
-				// Since 5.0
-				OtherFax = Dlfcn.GetStringConstant (handle, "kABPersonPhoneOtherFAXLabel");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			// Since 5.0
+			OtherFax = Dlfcn.GetStringConstant (handle, "kABPersonPhoneOtherFAXLabel");
 		}
 	}
 
@@ -441,24 +393,17 @@ namespace AddressBook {
 
 		internal static void Init ()
 		{
-			var handle = Dlfcn.dlopen (Constants.AddressBookLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Aim     = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceAIM");
-				Icq     = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceICQ");
-				Jabber  = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceJabber");
-				Msn     = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceMSN");
-				Yahoo   = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceYahoo");
-				QQ      = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceQQ");
-				GoogleTalk = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceGoogleTalk");
-				Skype   = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceSkype");
-				Facebook   = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceFacebook");
-				GaduGadu   = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceGaduGadu");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.AddressBook.Handle;
+			Aim     = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceAIM");
+			Icq     = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceICQ");
+			Jabber  = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceJabber");
+			Msn     = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceMSN");
+			Yahoo   = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceYahoo");
+			QQ      = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceQQ");
+			GoogleTalk = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceGoogleTalk");
+			Skype   = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceSkype");
+			Facebook   = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceFacebook");
+			GaduGadu   = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceGaduGadu");
 		}
 	}
 
@@ -474,16 +419,9 @@ namespace AddressBook {
 
 		internal static void Init ()
 		{
-			var handle = Dlfcn.dlopen (Constants.AddressBookLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Service   = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceKey");
-				Username  = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageUsernameKey");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.AddressBook.Handle;
+			Service   = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageServiceKey");
+			Username  = Dlfcn.GetStringConstant (handle, "kABPersonInstantMessageUsernameKey");
 		}
 	}
 
@@ -498,15 +436,7 @@ namespace AddressBook {
 
 		internal static void Init ()
 		{
-			var handle = Dlfcn.dlopen (Constants.AddressBookLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				HomePage  = Dlfcn.GetStringConstant (handle, "kABPersonHomePageLabel");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			HomePage  = Dlfcn.GetStringConstant (Libraries.AddressBook.Handle, "kABPersonHomePageLabel");
 		}
 	}
 
@@ -531,25 +461,18 @@ namespace AddressBook {
 
 		internal static void Init ()
 		{
-			var handle = Dlfcn.dlopen (Constants.AddressBookLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Assistant = Dlfcn.GetStringConstant (handle, "kABPersonAssistantLabel");
-				Brother   = Dlfcn.GetStringConstant (handle, "kABPersonBrotherLabel");
-				Child     = Dlfcn.GetStringConstant (handle, "kABPersonChildLabel");
-				Father    = Dlfcn.GetStringConstant (handle, "kABPersonFatherLabel");
-				Friend    = Dlfcn.GetStringConstant (handle, "kABPersonFriendLabel");
-				Manager   = Dlfcn.GetStringConstant (handle, "kABPersonManagerLabel");
-				Mother    = Dlfcn.GetStringConstant (handle, "kABPersonMotherLabel");
-				Parent    = Dlfcn.GetStringConstant (handle, "kABPersonParentLabel");
-				Partner   = Dlfcn.GetStringConstant (handle, "kABPersonPartnerLabel");
-				Sister    = Dlfcn.GetStringConstant (handle, "kABPersonSisterLabel");
-				Spouse    = Dlfcn.GetStringConstant (handle, "kABPersonSpouseLabel");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.AddressBook.Handle;
+			Assistant = Dlfcn.GetStringConstant (handle, "kABPersonAssistantLabel");
+			Brother   = Dlfcn.GetStringConstant (handle, "kABPersonBrotherLabel");
+			Child     = Dlfcn.GetStringConstant (handle, "kABPersonChildLabel");
+			Father    = Dlfcn.GetStringConstant (handle, "kABPersonFatherLabel");
+			Friend    = Dlfcn.GetStringConstant (handle, "kABPersonFriendLabel");
+			Manager   = Dlfcn.GetStringConstant (handle, "kABPersonManagerLabel");
+			Mother    = Dlfcn.GetStringConstant (handle, "kABPersonMotherLabel");
+			Parent    = Dlfcn.GetStringConstant (handle, "kABPersonParentLabel");
+			Partner   = Dlfcn.GetStringConstant (handle, "kABPersonPartnerLabel");
+			Sister    = Dlfcn.GetStringConstant (handle, "kABPersonSisterLabel");
+			Spouse    = Dlfcn.GetStringConstant (handle, "kABPersonSpouseLabel");
 		}
 	}
 
@@ -566,17 +489,10 @@ namespace AddressBook {
 
 		internal static void Init ()
 		{
-			var handle = Dlfcn.dlopen (Constants.AddressBookLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Home      = Dlfcn.GetStringConstant (handle, "kABHomeLabel");
-				Other     = Dlfcn.GetStringConstant (handle, "kABOtherLabel");
-				Work      = Dlfcn.GetStringConstant (handle, "kABWorkLabel");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.AddressBook.Handle;
+			Home      = Dlfcn.GetStringConstant (handle, "kABHomeLabel");
+			Other     = Dlfcn.GetStringConstant (handle, "kABOtherLabel");
+			Work      = Dlfcn.GetStringConstant (handle, "kABWorkLabel");
 		}
 	}
 

--- a/src/AddressBook/ABSource.cs
+++ b/src/AddressBook/ABSource.cs
@@ -101,17 +101,9 @@ namespace AddressBook {
 
 		internal static void Init ()
 		{
-			var handle = Dlfcn.dlopen (Constants.AddressBookLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			
-			try {
-				Name = Dlfcn.GetInt32 (handle, "kABSourceNameProperty");
-				Type = Dlfcn.GetInt32 (handle, "kABSourceTypeProperty");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.AddressBook.Handle;
+			Name = Dlfcn.GetInt32 (handle, "kABSourceNameProperty");
+			Type = Dlfcn.GetInt32 (handle, "kABSourceTypeProperty");
 		}
 
 		public static int ToId (ABSourceProperty property)

--- a/src/AudioToolbox/AudioSession.cs
+++ b/src/AudioToolbox/AudioSession.cs
@@ -124,12 +124,10 @@ namespace AudioToolbox {
 
 		static AudioSessionRouteChangeEventArgs ()
 		{
-			var lib = Dlfcn.dlopen (Constants.AudioToolboxLibrary, 0);
+			var lib = Libraries.AudioToolbox.Handle;
 			route_change_key = Dlfcn.GetIntPtr (lib, "kAudioSession_RouteChangeKey_Reason");
 			previous_route_key = Dlfcn.GetIntPtr (lib, "kAudioSession_AudioRouteChangeKey_PreviousRouteDescription");
 			current_route_key = Dlfcn.GetIntPtr (lib, "kAudioSession_AudioRouteChangeKey_CurrentRouteDescription");
-
-			Dlfcn.dlclose (lib);
 		}
 
 		public NSDictionary Dictionary { get; private set; }
@@ -247,35 +245,33 @@ namespace AudioToolbox {
 			if (initialized)
 				return;
 
-			IntPtr lib = Dlfcn.dlopen (Constants.AudioToolboxLibrary, 0);
+			IntPtr lib = Libraries.AudioToolbox.Handle;
 			
-			AudioRouteKey_Inputs = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSession_AudioRouteKey_Inputs"));
-			AudioRouteKey_Outputs = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSession_AudioRouteKey_Outputs"));
-			AudioRouteKey_Type = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSession_AudioRouteKey_Type"));
+			AudioRouteKey_Inputs = Dlfcn.GetStringConstant (lib, "kAudioSession_AudioRouteKey_Inputs");
+			AudioRouteKey_Outputs = Dlfcn.GetStringConstant (lib, "kAudioSession_AudioRouteKey_Outputs");
+			AudioRouteKey_Type = Dlfcn.GetStringConstant (lib, "kAudioSession_AudioRouteKey_Type");
 
-			InputRoute_LineIn = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSessionInputRoute_LineIn"));
-			InputRoute_BuiltInMic = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSessionInputRoute_BuiltInMic"));
-			InputRoute_HeadsetMic = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSessionInputRoute_HeadsetMic"));
-			InputRoute_BluetoothHFP = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSessionInputRoute_BluetoothHFP"));
-			InputRoute_USBAudio = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSessionInputRoute_USBAudio"));
+			InputRoute_LineIn = Dlfcn.GetStringConstant (lib, "kAudioSessionInputRoute_LineIn");
+			InputRoute_BuiltInMic = Dlfcn.GetStringConstant (lib, "kAudioSessionInputRoute_BuiltInMic");
+			InputRoute_HeadsetMic = Dlfcn.GetStringConstant (lib, "kAudioSessionInputRoute_HeadsetMic");
+			InputRoute_BluetoothHFP = Dlfcn.GetStringConstant (lib, "kAudioSessionInputRoute_BluetoothHFP");
+			InputRoute_USBAudio = Dlfcn.GetStringConstant (lib, "kAudioSessionInputRoute_USBAudio");
 			
-			OutputRoute_LineOut = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSessionOutputRoute_LineOut"));
-			OutputRoute_Headphones = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSessionOutputRoute_Headphones"));
-			OutputRoute_BluetoothHFP = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSessionOutputRoute_BluetoothHFP"));
-			OutputRoute_BluetoothA2DP = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSessionOutputRoute_BluetoothA2DP"));
-			OutputRoute_BuiltInReceiver = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSessionOutputRoute_BuiltInReceiver"));
-			OutputRoute_BuiltInSpeaker = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSessionOutputRoute_BuiltInSpeaker"));
-			OutputRoute_USBAudio = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSessionOutputRoute_USBAudio"));
-			OutputRoute_HDMI = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSessionOutputRoute_HDMI"));
-			OutputRoute_AirPlay = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSessionOutputRoute_AirPlay"));
+			OutputRoute_LineOut = Dlfcn.GetStringConstant (lib, "kAudioSessionOutputRoute_LineOut");
+			OutputRoute_Headphones = Dlfcn.GetStringConstant (lib, "kAudioSessionOutputRoute_Headphones");
+			OutputRoute_BluetoothHFP = Dlfcn.GetStringConstant (lib, "kAudioSessionOutputRoute_BluetoothHFP");
+			OutputRoute_BluetoothA2DP = Dlfcn.GetStringConstant (lib, "kAudioSessionOutputRoute_BluetoothA2DP");
+			OutputRoute_BuiltInReceiver = Dlfcn.GetStringConstant (lib, "kAudioSessionOutputRoute_BuiltInReceiver");
+			OutputRoute_BuiltInSpeaker = Dlfcn.GetStringConstant (lib, "kAudioSessionOutputRoute_BuiltInSpeaker");
+			OutputRoute_USBAudio = Dlfcn.GetStringConstant (lib, "kAudioSessionOutputRoute_USBAudio");
+			OutputRoute_HDMI = Dlfcn.GetStringConstant (lib, "kAudioSessionOutputRoute_HDMI");
+			OutputRoute_AirPlay = Dlfcn.GetStringConstant (lib, "kAudioSessionOutputRoute_AirPlay");
 
-			InputSourceKey_ID = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSession_InputSourceKey_ID"));
-			InputSourceKey_Description = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSession_InputSourceKey_Description"));
+			InputSourceKey_ID = Dlfcn.GetStringConstant (lib, "kAudioSession_InputSourceKey_ID");
+			InputSourceKey_Description = Dlfcn.GetStringConstant (lib, "kAudioSession_InputSourceKey_Description");
 
-			OutputDestinationKey_ID = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSession_OutputDestinationKey_ID"));
-			OutputDestinationKey_Description = new NSString (Dlfcn.GetIntPtr (lib, "kAudioSession_OutputDestinationKey_Description"));
-			
-			Dlfcn.dlclose (lib);
+			OutputDestinationKey_ID = Dlfcn.GetStringConstant (lib, "kAudioSession_OutputDestinationKey_ID");
+			OutputDestinationKey_Description = Dlfcn.GetStringConstant (lib, "kAudioSession_OutputDestinationKey_Description");
 			
 			initialized = true;
 		}

--- a/src/CoreFoundation/CFDictionary.cs
+++ b/src/CoreFoundation/CFDictionary.cs
@@ -81,13 +81,9 @@ namespace CoreFoundation {
 
 		static CFDictionary ()
 		{
-			var lib = Dlfcn.dlopen (Constants.CoreFoundationLibrary, 0);
-			try {
-				KeyCallbacks = Dlfcn.GetIndirect (lib, "kCFTypeDictionaryKeyCallBacks");
-				ValueCallbacks = Dlfcn.GetIndirect (lib, "kCFTypeDictionaryValueCallBacks");
-			} finally {
-				Dlfcn.dlclose (lib);
-			}
+			var lib = Libraries.CoreFoundation.Handle;
+			KeyCallbacks = Dlfcn.GetIndirect (lib, "kCFTypeDictionaryKeyCallBacks");
+			ValueCallbacks = Dlfcn.GetIndirect (lib, "kCFTypeDictionaryValueCallBacks");
 		}
 		
 		public static CFDictionary FromObjectAndKey (INativeObject obj, INativeObject key)

--- a/src/CoreFoundation/CFException.cs
+++ b/src/CoreFoundation/CFException.cs
@@ -42,18 +42,11 @@ namespace CoreFoundation {
 
 		static CFErrorDomain ()
 		{
-			var handle = Dlfcn.dlopen (Constants.CoreFoundationLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Cocoa     = Dlfcn.GetStringConstant (handle, "kCFErrorDomainCocoa");
-				Mach      = Dlfcn.GetStringConstant (handle, "kCFErrorDomainMach");
-				OSStatus  = Dlfcn.GetStringConstant (handle, "kCFErrorDomainOSStatus");
-				Posix     = Dlfcn.GetStringConstant (handle, "kCFErrorDomainPosix");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.CoreFoundation.Handle;
+			Cocoa     = Dlfcn.GetStringConstant (handle, "kCFErrorDomainCocoa");
+			Mach      = Dlfcn.GetStringConstant (handle, "kCFErrorDomainMach");
+			OSStatus  = Dlfcn.GetStringConstant (handle, "kCFErrorDomainOSStatus");
+			Posix     = Dlfcn.GetStringConstant (handle, "kCFErrorDomainPosix");
 		}
 	}
 
@@ -67,19 +60,12 @@ namespace CoreFoundation {
 
 		static CFExceptionDataKey ()
 		{
-			var handle = Dlfcn.dlopen (Constants.CoreFoundationLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Description                 = Dlfcn.GetStringConstant (handle, "kCFErrorDescriptionKey");
-				LocalizedDescription        = Dlfcn.GetStringConstant (handle, "kCFErrorLocalizedDescriptionKey");
-				LocalizedFailureReason      = Dlfcn.GetStringConstant (handle, "kCFErrorLocalizedFailureReasonKey");
-				LocalizedRecoverySuggestion = Dlfcn.GetStringConstant (handle, "kCFErrorLocalizedRecoverySuggestionKey");
-				UnderlyingError             = Dlfcn.GetStringConstant (handle, "kCFErrorUnderlyingErrorKey");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.CoreFoundation.Handle;
+			Description                 = Dlfcn.GetStringConstant (handle, "kCFErrorDescriptionKey");
+			LocalizedDescription        = Dlfcn.GetStringConstant (handle, "kCFErrorLocalizedDescriptionKey");
+			LocalizedFailureReason      = Dlfcn.GetStringConstant (handle, "kCFErrorLocalizedFailureReasonKey");
+			LocalizedRecoverySuggestion = Dlfcn.GetStringConstant (handle, "kCFErrorLocalizedRecoverySuggestionKey");
+			UnderlyingError             = Dlfcn.GetStringConstant (handle, "kCFErrorUnderlyingErrorKey");
 		}
 	}
 

--- a/src/CoreFoundation/CFPreferences.cs
+++ b/src/CoreFoundation/CFPreferences.cs
@@ -33,22 +33,14 @@ namespace CoreFoundation
 
 		static CFPreferences ()
 		{
-			var handle = Dlfcn.dlopen (Constants.CoreFoundationLibrary, 0);
-			if (handle == IntPtr.Zero) {
-				return;
-			}
+			var handle = Libraries.CoreFoundation.Handle;
+			CurrentApplication = Dlfcn.GetStringConstant (handle, "kCFPreferencesCurrentApplication");
 
-			try {
-				CurrentApplication = Dlfcn.GetStringConstant (handle, "kCFPreferencesCurrentApplication");
-
-				/*AnyApplication = Dlfcn.GetStringConstant (handle, "kCFPreferencesAnyApplication");
-				CurrentHost = Dlfcn.GetStringConstant (handle, "kCFPreferencesCurrentHost");
-				AnyHost = Dlfcn.GetStringConstant (handle, "kCFPreferencesAnyHost");
-				CurrentUser = Dlfcn.GetStringConstant (handle, "kCFPreferencesCurrentUser");
-				AnyUser = Dlfcn.GetStringConstant (handle, "kCFPreferencesAnyUser");*/
-			} finally {
-				Dlfcn.dlclose (handle);
-			}
+			/*AnyApplication = Dlfcn.GetStringConstant (handle, "kCFPreferencesAnyApplication");
+			CurrentHost = Dlfcn.GetStringConstant (handle, "kCFPreferencesCurrentHost");
+			AnyHost = Dlfcn.GetStringConstant (handle, "kCFPreferencesAnyHost");
+			CurrentUser = Dlfcn.GetStringConstant (handle, "kCFPreferencesCurrentUser");
+			AnyUser = Dlfcn.GetStringConstant (handle, "kCFPreferencesAnyUser");*/
 		}
 
 		public static object GetAppValue (string key)

--- a/src/CoreFoundation/CFProxySupport.cs
+++ b/src/CoreFoundation/CFProxySupport.cs
@@ -60,7 +60,7 @@ namespace CoreFoundation {
 		static NSString AutoConfigurationHTTPResponseKey {
 			get {
 				if (kCFProxyAutoConfigurationHTTPResponseKey == null)
-					kCFProxyAutoConfigurationHTTPResponseKey = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFProxyAutoConfigurationHTTPResponseKey");
+					kCFProxyAutoConfigurationHTTPResponseKey = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFProxyAutoConfigurationHTTPResponseKey");
 				
 				return kCFProxyAutoConfigurationHTTPResponseKey;
 			}
@@ -71,7 +71,7 @@ namespace CoreFoundation {
 		static NSString AutoConfigurationJavaScriptKey {
 			get {
 				if (kCFProxyAutoConfigurationJavaScriptKey == null)
-					kCFProxyAutoConfigurationJavaScriptKey = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFProxyAutoConfigurationJavaScriptKey");
+					kCFProxyAutoConfigurationJavaScriptKey = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFProxyAutoConfigurationJavaScriptKey");
 				
 				return kCFProxyAutoConfigurationJavaScriptKey;
 			}
@@ -81,7 +81,7 @@ namespace CoreFoundation {
 		static NSString AutoConfigurationURLKey {
 			get {
 				if (kCFProxyAutoConfigurationURLKey == null)
-					kCFProxyAutoConfigurationURLKey = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFProxyAutoConfigurationURLKey");
+					kCFProxyAutoConfigurationURLKey = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFProxyAutoConfigurationURLKey");
 				
 				return kCFProxyAutoConfigurationURLKey;
 			}
@@ -91,7 +91,7 @@ namespace CoreFoundation {
 		static NSString HostNameKey {
 			get {
 				if (kCFProxyHostNameKey == null)
-					kCFProxyHostNameKey = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFProxyHostNameKey");
+					kCFProxyHostNameKey = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFProxyHostNameKey");
 				
 				return kCFProxyHostNameKey;
 			}
@@ -101,7 +101,7 @@ namespace CoreFoundation {
 		static NSString PasswordKey {
 			get {
 				if (kCFProxyPasswordKey == null)
-					kCFProxyPasswordKey = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFProxyPasswordKey");
+					kCFProxyPasswordKey = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFProxyPasswordKey");
 				
 				return kCFProxyPasswordKey;
 			}
@@ -111,7 +111,7 @@ namespace CoreFoundation {
 		static NSString PortNumberKey {
 			get {
 				if (kCFProxyPortNumberKey == null)
-					kCFProxyPortNumberKey = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFProxyPortNumberKey");
+					kCFProxyPortNumberKey = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFProxyPortNumberKey");
 				
 				return kCFProxyPortNumberKey;
 			}
@@ -121,7 +121,7 @@ namespace CoreFoundation {
 		static NSString ProxyTypeKey {
 			get {
 				if (kCFProxyTypeKey == null)
-					kCFProxyTypeKey = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFProxyTypeKey");
+					kCFProxyTypeKey = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFProxyTypeKey");
 				
 				return kCFProxyTypeKey;
 			}
@@ -131,7 +131,7 @@ namespace CoreFoundation {
 		static NSString UsernameKey {
 			get {
 				if (kCFProxyUsernameKey == null)
-					kCFProxyUsernameKey = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFProxyUsernameKey");
+					kCFProxyUsernameKey = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFProxyUsernameKey");
 				
 				return kCFProxyUsernameKey;
 			}
@@ -143,7 +143,7 @@ namespace CoreFoundation {
 		static NSString CFProxyTypeNone {
 			get {
 				if (kCFProxyTypeNone == null)
-					kCFProxyTypeNone = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFProxyTypeNone");
+					kCFProxyTypeNone = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFProxyTypeNone");
 				
 				return kCFProxyTypeNone;
 			}
@@ -153,7 +153,7 @@ namespace CoreFoundation {
 		static NSString CFProxyTypeAutoConfigurationURL {
 			get {
 				if (kCFProxyTypeAutoConfigurationURL == null)
-					kCFProxyTypeAutoConfigurationURL = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFProxyTypeAutoConfigurationURL");
+					kCFProxyTypeAutoConfigurationURL = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFProxyTypeAutoConfigurationURL");
 				
 				return kCFProxyTypeAutoConfigurationURL;
 			}
@@ -163,7 +163,7 @@ namespace CoreFoundation {
 		static NSString CFProxyTypeAutoConfigurationJavaScript {
 			get {
 				if (kCFProxyTypeAutoConfigurationJavaScript == null)
-					kCFProxyTypeAutoConfigurationJavaScript = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFProxyTypeAutoConfigurationJavaScript");
+					kCFProxyTypeAutoConfigurationJavaScript = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFProxyTypeAutoConfigurationJavaScript");
 				
 				return kCFProxyTypeAutoConfigurationJavaScript;
 			}
@@ -173,7 +173,7 @@ namespace CoreFoundation {
 		static NSString CFProxyTypeFTP {
 			get {
 				if (kCFProxyTypeFTP == null)
-					kCFProxyTypeFTP = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFProxyTypeFTP");
+					kCFProxyTypeFTP = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFProxyTypeFTP");
 				
 				return kCFProxyTypeFTP;
 			}
@@ -183,7 +183,7 @@ namespace CoreFoundation {
 		static NSString CFProxyTypeHTTP {
 			get {
 				if (kCFProxyTypeHTTP == null)
-					kCFProxyTypeHTTP = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFProxyTypeHTTP");
+					kCFProxyTypeHTTP = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFProxyTypeHTTP");
 				
 				return kCFProxyTypeHTTP;
 			}
@@ -193,7 +193,7 @@ namespace CoreFoundation {
 		static NSString CFProxyTypeHTTPS {
 			get {
 				if (kCFProxyTypeHTTPS == null)
-					kCFProxyTypeHTTPS = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFProxyTypeHTTPS");
+					kCFProxyTypeHTTPS = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFProxyTypeHTTPS");
 				
 				return kCFProxyTypeHTTPS;
 			}
@@ -203,7 +203,7 @@ namespace CoreFoundation {
 		static NSString CFProxyTypeSOCKS {
 			get {
 				if (kCFProxyTypeSOCKS == null)
-					kCFProxyTypeSOCKS = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFProxyTypeSOCKS");
+					kCFProxyTypeSOCKS = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFProxyTypeSOCKS");
 				
 				return kCFProxyTypeSOCKS;
 			}
@@ -344,7 +344,7 @@ namespace CoreFoundation {
 		static NSString CFNetworkProxiesHTTPEnable {
 			get {
 				if (kCFNetworkProxiesHTTPEnable == null)
-					kCFNetworkProxiesHTTPEnable = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFNetworkProxiesHTTPEnable");
+					kCFNetworkProxiesHTTPEnable = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFNetworkProxiesHTTPEnable");
 				
 				return kCFNetworkProxiesHTTPEnable;
 			}
@@ -354,7 +354,7 @@ namespace CoreFoundation {
 		static NSString CFNetworkProxiesHTTPPort {
 			get {
 				if (kCFNetworkProxiesHTTPPort == null)
-					kCFNetworkProxiesHTTPPort = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFNetworkProxiesHTTPPort");
+					kCFNetworkProxiesHTTPPort = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFNetworkProxiesHTTPPort");
 				
 				return kCFNetworkProxiesHTTPPort;
 			}
@@ -364,7 +364,7 @@ namespace CoreFoundation {
 		static NSString CFNetworkProxiesHTTPProxy {
 			get {
 				if (kCFNetworkProxiesHTTPProxy == null)
-					kCFNetworkProxiesHTTPProxy = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFNetworkProxiesHTTPProxy");
+					kCFNetworkProxiesHTTPProxy = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFNetworkProxiesHTTPProxy");
 				
 				return kCFNetworkProxiesHTTPProxy;
 			}
@@ -374,7 +374,7 @@ namespace CoreFoundation {
 		static NSString CFNetworkProxiesProxyAutoConfigEnable {
 			get {
 				if (kCFNetworkProxiesProxyAutoConfigEnable == null)
-					kCFNetworkProxiesProxyAutoConfigEnable = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFNetworkProxiesProxyAutoConfigEnable");
+					kCFNetworkProxiesProxyAutoConfigEnable = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFNetworkProxiesProxyAutoConfigEnable");
 				
 				return kCFNetworkProxiesProxyAutoConfigEnable;
 			}
@@ -385,7 +385,7 @@ namespace CoreFoundation {
 		static NSString CFNetworkProxiesProxyAutoConfigJavaScript {
 			get {
 				if (kCFNetworkProxiesProxyAutoConfigJavaScript == null)
-					kCFNetworkProxiesProxyAutoConfigJavaScript = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFNetworkProxiesProxyAutoConfigJavaScript");
+					kCFNetworkProxiesProxyAutoConfigJavaScript = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFNetworkProxiesProxyAutoConfigJavaScript");
 				
 				return kCFNetworkProxiesProxyAutoConfigJavaScript;
 			}
@@ -396,7 +396,7 @@ namespace CoreFoundation {
 		static NSString CFNetworkProxiesProxyAutoConfigURLString {
 			get {
 				if (kCFNetworkProxiesProxyAutoConfigURLString == null)
-					kCFNetworkProxiesProxyAutoConfigURLString = Dlfcn.GetStringConstant (CFNetwork.CFNetworkLibraryHandle, "kCFNetworkProxiesProxyAutoConfigURLString");
+					kCFNetworkProxiesProxyAutoConfigURLString = Dlfcn.GetStringConstant (Libraries.CFNetwork.Handle, "kCFNetworkProxiesProxyAutoConfigURLString");
 				
 				return kCFNetworkProxiesProxyAutoConfigURLString;
 			}
@@ -473,8 +473,6 @@ namespace CoreFoundation {
 	}
 	
 	public static partial class CFNetwork {
-		internal static IntPtr CFNetworkLibraryHandle = Dlfcn.dlopen (Constants.CFNetworkLibrary, 0);
-		
 		[DllImport (Constants.CFNetworkLibrary)]
 		extern static /* CFArrayRef __nullable */ IntPtr CFNetworkCopyProxiesForAutoConfigurationScript (
 			/* CFStringRef __nonnull */ IntPtr proxyAutoConfigurationScript,

--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -296,11 +296,8 @@ namespace CoreFoundation {
 
 						// Last case: this is technically not right for the simulator, as this path
 						// actually points to the MacOS library, not the one in the SDK.
-						if (main_q == IntPtr.Zero){
-							var h = Dlfcn.dlopen ("/usr/lib/libSystem.dylib", 0x0);
-							main_q = Dlfcn.GetIndirect (h, "_dispatch_main_q");
-							Dlfcn.dlclose (h);
-						}
+						if (main_q == IntPtr.Zero)
+							main_q = Dlfcn.GetIndirect (Libraries.System.Handle, "_dispatch_main_q");
 					}
 				}
 #if MONOMAC

--- a/src/CoreFoundation/DispatchData.cs
+++ b/src/CoreFoundation/DispatchData.cs
@@ -43,11 +43,10 @@ namespace CoreFoundation {
 		{
 		}
 
-		static IntPtr lib, free;
+		static IntPtr free;
 		static DispatchData ()
 		{
-			lib = Dlfcn.dlopen (Constants.libcLibrary, 0);
-			free = Marshal.ReadIntPtr (Dlfcn.dlsym (lib, "_dispatch_data_destructor_free"));
+			free = Marshal.ReadIntPtr (Dlfcn.dlsym (Libraries.LibC.Handle, "_dispatch_data_destructor_free"));
 		}
 
 		[DllImport (Constants.libcLibrary)]

--- a/src/CoreMedia/CMTime.cs
+++ b/src/CoreMedia/CMTime.cs
@@ -326,17 +326,11 @@ namespace CoreMedia {
 		
 		static CMTime ()
 		{
-			var lib = Dlfcn.dlopen (Constants.CoreMediaLibrary, 0);
-			if (lib != IntPtr.Zero) {
-				try {
-					ValueKey  = Dlfcn.GetStringConstant (lib, "kCMTimeValueKey");
-					ScaleKey  = Dlfcn.GetStringConstant (lib, "kCMTimeScaleKey");
-					EpochKey  = Dlfcn.GetStringConstant (lib, "kCMTimeEpochKey");
-					FlagsKey  = Dlfcn.GetStringConstant (lib, "kCMTimeFlagsKey");
-				} finally {
-					Dlfcn.dlclose (lib);
-				}
-			}
+			var lib = Libraries.CoreMedia.Handle;
+			ValueKey  = Dlfcn.GetStringConstant (lib, "kCMTimeValueKey");
+			ScaleKey  = Dlfcn.GetStringConstant (lib, "kCMTimeScaleKey");
+			EpochKey  = Dlfcn.GetStringConstant (lib, "kCMTimeEpochKey");
+			FlagsKey  = Dlfcn.GetStringConstant (lib, "kCMTimeFlagsKey");
 		}
 
 		[DllImport(Constants.CoreMediaLibrary)]

--- a/src/CoreMedia/CoreMedia.cs
+++ b/src/CoreMedia/CoreMedia.cs
@@ -119,28 +119,22 @@ namespace CoreMedia {
 		public static NSString TimeMappingTargetKey { get; private set; }
 
 		static CMTimeRange () {
-			var lib = Dlfcn.dlopen (Constants.CoreMediaLibrary, 0);
-			if (lib != IntPtr.Zero) {
-				try {
-					var retZero = Dlfcn.dlsym (lib, "kCMTimeRangeZero");
-					Zero = (CMTimeRange)Marshal.PtrToStructure (retZero, typeof(CMTimeRange));
+			var lib = Libraries.CoreMedia.Handle;
+			var retZero = Dlfcn.dlsym (lib, "kCMTimeRangeZero");
+			Zero = (CMTimeRange)Marshal.PtrToStructure (retZero, typeof(CMTimeRange));
 
-					var retInvalid = Dlfcn.dlsym (lib, "kCMTimeRangeInvalid");
+			var retInvalid = Dlfcn.dlsym (lib, "kCMTimeRangeInvalid");
 #if !XAMCORE_3_0
-					Invalid = (CMTimeRange)Marshal.PtrToStructure (retInvalid, typeof(CMTimeRange));
+			Invalid = (CMTimeRange)Marshal.PtrToStructure (retInvalid, typeof(CMTimeRange));
 #endif
-					InvalidRange = (CMTimeRange)Marshal.PtrToStructure (retInvalid, typeof(CMTimeRange));
+			InvalidRange = (CMTimeRange)Marshal.PtrToStructure (retInvalid, typeof(CMTimeRange));
 
-					var retMappingInvalid = Dlfcn.dlsym (lib, "kCMTimeMappingInvalid");
-					if (retMappingInvalid  != IntPtr.Zero)
-						InvalidMapping = (CMTimeRange)Marshal.PtrToStructure (retMappingInvalid, typeof(CMTimeRange));
+			var retMappingInvalid = Dlfcn.dlsym (lib, "kCMTimeMappingInvalid");
+			if (retMappingInvalid  != IntPtr.Zero)
+				InvalidMapping = (CMTimeRange)Marshal.PtrToStructure (retMappingInvalid, typeof(CMTimeRange));
 
-					TimeMappingSourceKey = Dlfcn.GetStringConstant (lib, "kCMTimeMappingSourceKey");
-					TimeMappingTargetKey = Dlfcn.GetStringConstant (lib, "kCMTimeMappingTargetKey");
-				} finally {
-					Dlfcn.dlclose (lib);
-				}
-			}
+			TimeMappingSourceKey = Dlfcn.GetStringConstant (lib, "kCMTimeMappingSourceKey");
+			TimeMappingTargetKey = Dlfcn.GetStringConstant (lib, "kCMTimeMappingTargetKey");
 		}
 #endif // !COREBUILD
 	}

--- a/src/CoreMidi/MidiServices.cs
+++ b/src/CoreMidi/MidiServices.cs
@@ -228,11 +228,7 @@ namespace CoreMidi {
 
 		static MidiObject ()
 		{
-#if MONOMAC
-			var midiLibrary = Dlfcn.dlopen (Constants.CoreMidiLibrary, 0);
-#else
 			var midiLibrary = Libraries.CoreMidi.Handle;
-#endif
 			kMIDIPropertyAdvanceScheduleTimeMuSec = Dlfcn.GetIntPtr (midiLibrary, "kMIDIPropertyAdvanceScheduleTimeMuSec");
 			kMIDIPropertyCanRoute = Dlfcn.GetIntPtr (midiLibrary, "kMIDIPropertyCanRoute");
 			kMIDIPropertyConnectionUniqueID = Dlfcn.GetIntPtr (midiLibrary, "kMIDIPropertyConnectionUniqueID");

--- a/src/CoreText/CTBaselineClass.cs
+++ b/src/CoreText/CTBaselineClass.cs
@@ -52,19 +52,13 @@ namespace CoreText {
 
 		static CTBaselineClassID ()
 		{
-			var handle = Dlfcn.dlopen (Constants.CoreTextLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Roman = Dlfcn.GetStringConstant (handle, "kCTBaselineClassRoman");
-				IdeographicCentered = Dlfcn.GetStringConstant (handle, "kCTBaselineClassIdeographicCentered");
-				IdeographicLow = Dlfcn.GetStringConstant (handle, "kCTBaselineClassIdeographicLow");
-				IdeographicHigh = Dlfcn.GetStringConstant (handle, "kCTBaselineClassIdeographicHigh");
-				Hanging = Dlfcn.GetStringConstant (handle, "kCTBaselineClassHanging");
-				Math = Dlfcn.GetStringConstant (handle, "kCTBaselineClassMath");
-			} finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.CoreText.Handle;
+			Roman = Dlfcn.GetStringConstant (handle, "kCTBaselineClassRoman");
+			IdeographicCentered = Dlfcn.GetStringConstant (handle, "kCTBaselineClassIdeographicCentered");
+			IdeographicLow = Dlfcn.GetStringConstant (handle, "kCTBaselineClassIdeographicLow");
+			IdeographicHigh = Dlfcn.GetStringConstant (handle, "kCTBaselineClassIdeographicHigh");
+			Hanging = Dlfcn.GetStringConstant (handle, "kCTBaselineClassHanging");
+			Math = Dlfcn.GetStringConstant (handle, "kCTBaselineClassMath");
 		}
 
 		public static NSString ToNSString (CTBaselineClass key)
@@ -106,15 +100,9 @@ namespace CoreText {
 
 		static CTBaselineFondID ()
 		{
-			var handle = Dlfcn.dlopen (Constants.CoreTextLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Reference = Dlfcn.GetStringConstant (handle, "kCTBaselineReferenceFont");
-				Original = Dlfcn.GetStringConstant (handle, "kCTBaselineOriginalFont");
-			} finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.CoreText.Handle;
+			Reference = Dlfcn.GetStringConstant (handle, "kCTBaselineReferenceFont");
+			Original = Dlfcn.GetStringConstant (handle, "kCTBaselineOriginalFont");
 		}
 
 		public static NSString ToNSString (CTBaselineFont key)

--- a/src/CoreText/CTFontCollection.cs
+++ b/src/CoreText/CTFontCollection.cs
@@ -43,15 +43,7 @@ namespace CoreText {
 
 		static CTFontCollectionOptionKey ()
 		{
-			var handle = Dlfcn.dlopen (Constants.CoreTextLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				RemoveDuplicates = Dlfcn.GetStringConstant (handle, "kCTFontCollectionRemoveDuplicatesOption");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			RemoveDuplicates = Dlfcn.GetStringConstant (Libraries.CoreText.Handle, "kCTFontCollectionRemoveDuplicatesOption");
 		}
 	}
 

--- a/src/CoreText/CTFontDescriptor.cs
+++ b/src/CoreText/CTFontDescriptor.cs
@@ -105,36 +105,29 @@ namespace CoreText {
 
 		static CTFontDescriptorAttributeKey ()
 		{
-			var handle = Dlfcn.dlopen (Constants.CoreTextLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Url                 = Dlfcn.GetStringConstant (handle, "kCTFontURLAttribute");
-				Name                = Dlfcn.GetStringConstant (handle, "kCTFontNameAttribute");
-				DisplayName         = Dlfcn.GetStringConstant (handle, "kCTFontDisplayNameAttribute");
-				FamilyName          = Dlfcn.GetStringConstant (handle, "kCTFontFamilyNameAttribute");
-				StyleName           = Dlfcn.GetStringConstant (handle, "kCTFontStyleNameAttribute");
-				Traits              = Dlfcn.GetStringConstant (handle, "kCTFontTraitsAttribute");
-				Variation           = Dlfcn.GetStringConstant (handle, "kCTFontVariationAttribute");
-				Size                = Dlfcn.GetStringConstant (handle, "kCTFontSizeAttribute");
-				Matrix              = Dlfcn.GetStringConstant (handle, "kCTFontMatrixAttribute");
-				CascadeList         = Dlfcn.GetStringConstant (handle, "kCTFontCascadeListAttribute");
-				CharacterSet        = Dlfcn.GetStringConstant (handle, "kCTFontCharacterSetAttribute");
-				Languages           = Dlfcn.GetStringConstant (handle, "kCTFontLanguagesAttribute");
-				BaselineAdjust      = Dlfcn.GetStringConstant (handle, "kCTFontBaselineAdjustAttribute");
-				MacintoshEncodings  = Dlfcn.GetStringConstant (handle, "kCTFontMacintoshEncodingsAttribute");
-				Features            = Dlfcn.GetStringConstant (handle, "kCTFontFeaturesAttribute");
-				FeatureSettings     = Dlfcn.GetStringConstant (handle, "kCTFontFeatureSettingsAttribute");
-				FixedAdvance        = Dlfcn.GetStringConstant (handle, "kCTFontFixedAdvanceAttribute");
-				FontOrientation     = Dlfcn.GetStringConstant (handle, "kCTFontOrientationAttribute");
-				FontFormat          = Dlfcn.GetStringConstant (handle, "kCTFontFormatAttribute");
-				RegistrationScope   = Dlfcn.GetStringConstant (handle, "kCTFontRegistrationScopeAttribute");
-				Priority            = Dlfcn.GetStringConstant (handle, "kCTFontPriorityAttribute");
-				Enabled             = Dlfcn.GetStringConstant (handle, "kCTFontEnabledAttribute");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.CoreText.Handle;
+			Url                 = Dlfcn.GetStringConstant (handle, "kCTFontURLAttribute");
+			Name                = Dlfcn.GetStringConstant (handle, "kCTFontNameAttribute");
+			DisplayName         = Dlfcn.GetStringConstant (handle, "kCTFontDisplayNameAttribute");
+			FamilyName          = Dlfcn.GetStringConstant (handle, "kCTFontFamilyNameAttribute");
+			StyleName           = Dlfcn.GetStringConstant (handle, "kCTFontStyleNameAttribute");
+			Traits              = Dlfcn.GetStringConstant (handle, "kCTFontTraitsAttribute");
+			Variation           = Dlfcn.GetStringConstant (handle, "kCTFontVariationAttribute");
+			Size                = Dlfcn.GetStringConstant (handle, "kCTFontSizeAttribute");
+			Matrix              = Dlfcn.GetStringConstant (handle, "kCTFontMatrixAttribute");
+			CascadeList         = Dlfcn.GetStringConstant (handle, "kCTFontCascadeListAttribute");
+			CharacterSet        = Dlfcn.GetStringConstant (handle, "kCTFontCharacterSetAttribute");
+			Languages           = Dlfcn.GetStringConstant (handle, "kCTFontLanguagesAttribute");
+			BaselineAdjust      = Dlfcn.GetStringConstant (handle, "kCTFontBaselineAdjustAttribute");
+			MacintoshEncodings  = Dlfcn.GetStringConstant (handle, "kCTFontMacintoshEncodingsAttribute");
+			Features            = Dlfcn.GetStringConstant (handle, "kCTFontFeaturesAttribute");
+			FeatureSettings     = Dlfcn.GetStringConstant (handle, "kCTFontFeatureSettingsAttribute");
+			FixedAdvance        = Dlfcn.GetStringConstant (handle, "kCTFontFixedAdvanceAttribute");
+			FontOrientation     = Dlfcn.GetStringConstant (handle, "kCTFontOrientationAttribute");
+			FontFormat          = Dlfcn.GetStringConstant (handle, "kCTFontFormatAttribute");
+			RegistrationScope   = Dlfcn.GetStringConstant (handle, "kCTFontRegistrationScopeAttribute");
+			Priority            = Dlfcn.GetStringConstant (handle, "kCTFontPriorityAttribute");
+			Enabled             = Dlfcn.GetStringConstant (handle, "kCTFontEnabledAttribute");
 		}
 	}
 

--- a/src/CoreText/CTFontManager.cs
+++ b/src/CoreText/CTFontManager.cs
@@ -241,18 +241,11 @@ namespace CoreText {
 		
 		static CTFontManager ()
 		{
-			var handle = Dlfcn.dlopen (Constants.CoreTextLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
+			var handle = Libraries.CoreText.Handle;
 #if !XAMCORE_3_0
-				ErrorDomain  = Dlfcn.GetStringConstant (handle, "kCTFontManagerErrorDomain");
+			ErrorDomain  = Dlfcn.GetStringConstant (handle, "kCTFontManagerErrorDomain");
 #endif
-				ErrorFontUrlsKey  = Dlfcn.GetStringConstant (handle, "kCTFontManagerErrorFontURLsKey");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			ErrorFontUrlsKey  = Dlfcn.GetStringConstant (handle, "kCTFontManagerErrorFontURLsKey");
 		}
 
 		static NSString _RegisteredFontsChangedNotification;
@@ -260,11 +253,8 @@ namespace CoreText {
 		[iOS (7,0)]
 		static NSString RegisteredFontsChangedNotification {
 			get {
-				if (_RegisteredFontsChangedNotification == null){
-					var handle = Dlfcn.dlopen (Constants.CoreTextLibrary, 0);
-					_RegisteredFontsChangedNotification = Dlfcn.GetStringConstant (handle, "kCTFontManagerRegisteredFontsChangedNotification");
-					Dlfcn.dlclose (handle);
-				}
+				if (_RegisteredFontsChangedNotification == null)
+					_RegisteredFontsChangedNotification = Dlfcn.GetStringConstant (Libraries.CoreText.Handle, "kCTFontManagerRegisteredFontsChangedNotification");
 				return _RegisteredFontsChangedNotification;
 			}
 		}

--- a/src/CoreText/CTFontNameKey.cs
+++ b/src/CoreText/CTFontNameKey.cs
@@ -79,32 +79,25 @@ namespace CoreText {
 
 		static CTFontNameKeyId ()
 		{
-			var handle = Dlfcn.dlopen (Constants.CoreTextLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Copyright     = Dlfcn.GetStringConstant (handle, "kCTFontCopyrightNameKey");
-				Family        = Dlfcn.GetStringConstant (handle, "kCTFontFamilyNameKey");
-				SubFamily     = Dlfcn.GetStringConstant (handle, "kCTFontSubFamilyNameKey");
-				Style         = Dlfcn.GetStringConstant (handle, "kCTFontStyleNameKey");
-				Unique        = Dlfcn.GetStringConstant (handle, "kCTFontUniqueNameKey");
-				Full          = Dlfcn.GetStringConstant (handle, "kCTFontFullNameKey");
-				Version       = Dlfcn.GetStringConstant (handle, "kCTFontVersionNameKey");
-				PostScript    = Dlfcn.GetStringConstant (handle, "kCTFontPostScriptNameKey");
-				Trademark     = Dlfcn.GetStringConstant (handle, "kCTFontTrademarkNameKey");
-				Manufacturer  = Dlfcn.GetStringConstant (handle, "kCTFontManufacturerNameKey");
-				Designer      = Dlfcn.GetStringConstant (handle, "kCTFontDesignerNameKey");
-				Description   = Dlfcn.GetStringConstant (handle, "kCTFontDescriptionNameKey");
-				VendorUrl     = Dlfcn.GetStringConstant (handle, "kCTFontVendorURLNameKey");
-				DesignerUrl   = Dlfcn.GetStringConstant (handle, "kCTFontDesignerURLNameKey");
-				License       = Dlfcn.GetStringConstant (handle, "kCTFontLicenseNameKey");
-				LicenseUrl    = Dlfcn.GetStringConstant (handle, "kCTFontLicenseURLNameKey");
-				SampleText    = Dlfcn.GetStringConstant (handle, "kCTFontSampleTextNameKey");
-				PostscriptCid = Dlfcn.GetStringConstant (handle, "kCTFontPostScriptCIDNameKey");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.CoreText.Handle;
+			Copyright     = Dlfcn.GetStringConstant (handle, "kCTFontCopyrightNameKey");
+			Family        = Dlfcn.GetStringConstant (handle, "kCTFontFamilyNameKey");
+			SubFamily     = Dlfcn.GetStringConstant (handle, "kCTFontSubFamilyNameKey");
+			Style         = Dlfcn.GetStringConstant (handle, "kCTFontStyleNameKey");
+			Unique        = Dlfcn.GetStringConstant (handle, "kCTFontUniqueNameKey");
+			Full          = Dlfcn.GetStringConstant (handle, "kCTFontFullNameKey");
+			Version       = Dlfcn.GetStringConstant (handle, "kCTFontVersionNameKey");
+			PostScript    = Dlfcn.GetStringConstant (handle, "kCTFontPostScriptNameKey");
+			Trademark     = Dlfcn.GetStringConstant (handle, "kCTFontTrademarkNameKey");
+			Manufacturer  = Dlfcn.GetStringConstant (handle, "kCTFontManufacturerNameKey");
+			Designer      = Dlfcn.GetStringConstant (handle, "kCTFontDesignerNameKey");
+			Description   = Dlfcn.GetStringConstant (handle, "kCTFontDescriptionNameKey");
+			VendorUrl     = Dlfcn.GetStringConstant (handle, "kCTFontVendorURLNameKey");
+			DesignerUrl   = Dlfcn.GetStringConstant (handle, "kCTFontDesignerURLNameKey");
+			License       = Dlfcn.GetStringConstant (handle, "kCTFontLicenseNameKey");
+			LicenseUrl    = Dlfcn.GetStringConstant (handle, "kCTFontLicenseURLNameKey");
+			SampleText    = Dlfcn.GetStringConstant (handle, "kCTFontSampleTextNameKey");
+			PostscriptCid = Dlfcn.GetStringConstant (handle, "kCTFontPostScriptCIDNameKey");
 		}
 
 		public static NSString ToId (CTFontNameKey key)

--- a/src/CoreText/CTFontTrait.cs
+++ b/src/CoreText/CTFontTrait.cs
@@ -43,18 +43,11 @@ namespace CoreText {
 
 		static CTFontTraitKey ()
 		{
-			var handle = Dlfcn.dlopen (Constants.CoreTextLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Symbolic  = Dlfcn.GetStringConstant (handle, "kCTFontSymbolicTrait");
-				Weight    = Dlfcn.GetStringConstant (handle, "kCTFontWeightTrait");
-				Width     = Dlfcn.GetStringConstant (handle, "kCTFontWidthTrait");
-				Slant     = Dlfcn.GetStringConstant (handle, "kCTFontSlantTrait");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.CoreText.Handle;
+			Symbolic  = Dlfcn.GetStringConstant (handle, "kCTFontSymbolicTrait");
+			Weight    = Dlfcn.GetStringConstant (handle, "kCTFontWeightTrait");
+			Width     = Dlfcn.GetStringConstant (handle, "kCTFontWidthTrait");
+			Slant     = Dlfcn.GetStringConstant (handle, "kCTFontSlantTrait");
 		}
 	}
 

--- a/src/CoreText/CTFrame.cs
+++ b/src/CoreText/CTFrame.cs
@@ -57,19 +57,12 @@ namespace CoreText {
 		
 		static CTFrameAttributeKey ()
 		{
-			var handle = Dlfcn.dlopen (Constants.CoreTextLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Progression = Dlfcn.GetStringConstant (handle, "kCTFrameProgressionAttributeName");
-				PathFillRule = Dlfcn.GetStringConstant (handle, "kCTFramePathFillRuleAttributeName");
-				PathWidth = Dlfcn.GetStringConstant (handle, "kCTFramePathWidthAttributeName");
-				ClippingPaths = Dlfcn.GetStringConstant (handle, "kCTFrameClippingPathsAttributeName");
-				PathClippingPath = Dlfcn.GetStringConstant (handle, "kCTFramePathClippingPathAttributeName");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.CoreText.Handle;
+			Progression = Dlfcn.GetStringConstant (handle, "kCTFrameProgressionAttributeName");
+			PathFillRule = Dlfcn.GetStringConstant (handle, "kCTFramePathFillRuleAttributeName");
+			PathWidth = Dlfcn.GetStringConstant (handle, "kCTFramePathWidthAttributeName");
+			ClippingPaths = Dlfcn.GetStringConstant (handle, "kCTFrameClippingPathsAttributeName");
+			PathClippingPath = Dlfcn.GetStringConstant (handle, "kCTFramePathClippingPathAttributeName");
 		}
 	}
 

--- a/src/CoreText/CTStringAttributes.cs
+++ b/src/CoreText/CTStringAttributes.cs
@@ -100,39 +100,32 @@ namespace CoreText {
 
 		static CTStringAttributeKey ()
 		{
-			var handle = Dlfcn.dlopen (Constants.CoreTextLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				Font                        = Dlfcn.GetStringConstant (handle, "kCTFontAttributeName");
-				ForegroundColorFromContext  = Dlfcn.GetStringConstant (handle, "kCTForegroundColorFromContextAttributeName");
-				KerningAdjustment           = Dlfcn.GetStringConstant (handle, "kCTKernAttributeName");
-				LigatureFormation           = Dlfcn.GetStringConstant (handle, "kCTLigatureAttributeName");
-				ForegroundColor             = Dlfcn.GetStringConstant (handle, "kCTForegroundColorAttributeName");
-				BackgroundColor             = Dlfcn.GetStringConstant (handle, "kCTBackgroundColorAttributeName");
-				ParagraphStyle              = Dlfcn.GetStringConstant (handle, "kCTParagraphStyleAttributeName");
-				StrokeWidth                 = Dlfcn.GetStringConstant (handle, "kCTStrokeWidthAttributeName");
-				StrokeColor                 = Dlfcn.GetStringConstant (handle, "kCTStrokeColorAttributeName");
-				UnderlineStyle              = Dlfcn.GetStringConstant (handle, "kCTUnderlineStyleAttributeName");
-				Superscript                 = Dlfcn.GetStringConstant (handle, "kCTSuperscriptAttributeName");
-				UnderlineColor              = Dlfcn.GetStringConstant (handle, "kCTUnderlineColorAttributeName");
-				VerticalForms               = Dlfcn.GetStringConstant (handle, "kCTVerticalFormsAttributeName");
-				HorizontalInVerticalForms   = Dlfcn.GetStringConstant (handle, "kCTHorizontalInVerticalFormsAttributeName");
-				GlyphInfo                   = Dlfcn.GetStringConstant (handle, "kCTGlyphInfoAttributeName");
-				CharacterShape              = Dlfcn.GetStringConstant (handle, "kCTCharacterShapeAttributeName");
-				RunDelegate                 = Dlfcn.GetStringConstant (handle, "kCTRunDelegateAttributeName");
-				BaselineOffset              = Dlfcn.GetStringConstant (handle, "kCTBaselineOffsetAttributeName");
+			var handle = Libraries.CoreText.Handle;
+			Font                        = Dlfcn.GetStringConstant (handle, "kCTFontAttributeName");
+			ForegroundColorFromContext  = Dlfcn.GetStringConstant (handle, "kCTForegroundColorFromContextAttributeName");
+			KerningAdjustment           = Dlfcn.GetStringConstant (handle, "kCTKernAttributeName");
+			LigatureFormation           = Dlfcn.GetStringConstant (handle, "kCTLigatureAttributeName");
+			ForegroundColor             = Dlfcn.GetStringConstant (handle, "kCTForegroundColorAttributeName");
+			BackgroundColor             = Dlfcn.GetStringConstant (handle, "kCTBackgroundColorAttributeName");
+			ParagraphStyle              = Dlfcn.GetStringConstant (handle, "kCTParagraphStyleAttributeName");
+			StrokeWidth                 = Dlfcn.GetStringConstant (handle, "kCTStrokeWidthAttributeName");
+			StrokeColor                 = Dlfcn.GetStringConstant (handle, "kCTStrokeColorAttributeName");
+			UnderlineStyle              = Dlfcn.GetStringConstant (handle, "kCTUnderlineStyleAttributeName");
+			Superscript                 = Dlfcn.GetStringConstant (handle, "kCTSuperscriptAttributeName");
+			UnderlineColor              = Dlfcn.GetStringConstant (handle, "kCTUnderlineColorAttributeName");
+			VerticalForms               = Dlfcn.GetStringConstant (handle, "kCTVerticalFormsAttributeName");
+			HorizontalInVerticalForms   = Dlfcn.GetStringConstant (handle, "kCTHorizontalInVerticalFormsAttributeName");
+			GlyphInfo                   = Dlfcn.GetStringConstant (handle, "kCTGlyphInfoAttributeName");
+			CharacterShape              = Dlfcn.GetStringConstant (handle, "kCTCharacterShapeAttributeName");
+			RunDelegate                 = Dlfcn.GetStringConstant (handle, "kCTRunDelegateAttributeName");
+			BaselineOffset              = Dlfcn.GetStringConstant (handle, "kCTBaselineOffsetAttributeName");
 
 #if !MONOMAC
-				BaselineClass               = Dlfcn.GetStringConstant (handle, "kCTBaselineClassAttributeName");
-				BaselineInfo                = Dlfcn.GetStringConstant (handle, "kCTBaselineInfoAttributeName");
-				BaselineReferenceInfo       = Dlfcn.GetStringConstant (handle, "kCTBaselineReferenceInfoAttributeName");
-				WritingDirection            = Dlfcn.GetStringConstant (handle, "kCTWritingDirectionAttributeName");
+			BaselineClass               = Dlfcn.GetStringConstant (handle, "kCTBaselineClassAttributeName");
+			BaselineInfo                = Dlfcn.GetStringConstant (handle, "kCTBaselineInfoAttributeName");
+			BaselineReferenceInfo       = Dlfcn.GetStringConstant (handle, "kCTBaselineReferenceInfoAttributeName");
+			WritingDirection            = Dlfcn.GetStringConstant (handle, "kCTWritingDirectionAttributeName");
 #endif
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
 		}
 	}
 #endregion

--- a/src/CoreText/CTTextTab.cs
+++ b/src/CoreText/CTTextTab.cs
@@ -41,15 +41,7 @@ namespace CoreText {
 
 		static CTTextTabOptionKey ()
 		{
-			var handle = Dlfcn.dlopen (Constants.CoreTextLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				ColumnTerminators = Dlfcn.GetStringConstant (handle, "kCTTabColumnTerminatorsAttributeName");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			ColumnTerminators = Dlfcn.GetStringConstant (Libraries.CoreText.Handle, "kCTTabColumnTerminatorsAttributeName");
 		}
 	}
 

--- a/src/CoreVideo/CVPixelFormatDescription.cs
+++ b/src/CoreVideo/CVPixelFormatDescription.cs
@@ -82,49 +82,42 @@ namespace CoreVideo {
 
 		static CVPixelFormatDescription ()
 		{
-			var handle = Dlfcn.dlopen (Constants.CoreVideoLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				NameKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatName");
-				ConstantKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatConstant");
-				CodecTypeKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatCodecType");
-				FourCCKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatFourCC");
-				PlanesKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatPlanes");
-				BlockWidthKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatBlockWidth");
-				BlockHeightKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatBlockHeight");
-				BitsPerBlockKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatBitsPerBlock");
-				BlockHorizontalAlignmentKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatBlockHorizontalAlignment");
-				BlockVerticalAlignmentKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatBlockVerticalAlignment");
-				BlackBlockKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatBlackBlock");
-				HorizontalSubsamplingKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatHorizontalSubsampling");
-				VerticalSubsamplingKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatVerticalSubsampling");
-				OpenGLFormatKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatOpenGLFormat");
-				OpenGLTypeKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatOpenGLType");
-				OpenGLInternalFormatKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatOpenGLInternalFormat");
-				CGBitmapInfoKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatCGBitmapInfo");
-				QDCompatibilityKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatQDCompatibility");
-				CGBitmapContextCompatibilityKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatCGBitmapContextCompatibility");
-				CGImageCompatibilityKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatCGImageCompatibility");
-				OpenGLCompatibilityKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatOpenGLCompatibility");
-				FillExtendedPixelsCallbackKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatFillExtendedPixelsCallback");
+			var handle = Libraries.CoreVideo.Handle;
+			NameKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatName");
+			ConstantKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatConstant");
+			CodecTypeKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatCodecType");
+			FourCCKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatFourCC");
+			PlanesKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatPlanes");
+			BlockWidthKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatBlockWidth");
+			BlockHeightKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatBlockHeight");
+			BitsPerBlockKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatBitsPerBlock");
+			BlockHorizontalAlignmentKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatBlockHorizontalAlignment");
+			BlockVerticalAlignmentKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatBlockVerticalAlignment");
+			BlackBlockKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatBlackBlock");
+			HorizontalSubsamplingKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatHorizontalSubsampling");
+			VerticalSubsamplingKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatVerticalSubsampling");
+			OpenGLFormatKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatOpenGLFormat");
+			OpenGLTypeKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatOpenGLType");
+			OpenGLInternalFormatKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatOpenGLInternalFormat");
+			CGBitmapInfoKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatCGBitmapInfo");
+			QDCompatibilityKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatQDCompatibility");
+			CGBitmapContextCompatibilityKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatCGBitmapContextCompatibility");
+			CGImageCompatibilityKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatCGImageCompatibility");
+			OpenGLCompatibilityKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatOpenGLCompatibility");
+			FillExtendedPixelsCallbackKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatFillExtendedPixelsCallback");
 
-				//iOS8 only
-				ContainsRgb = Dlfcn.GetStringConstant (handle, "kCVPixelFormatContainsRGB");
-				ContainsYCbCr = Dlfcn.GetStringConstant (handle, "kCVPixelFormatContainsYCbCr");
+			//iOS8 only
+			ContainsRgb = Dlfcn.GetStringConstant (handle, "kCVPixelFormatContainsRGB");
+			ContainsYCbCr = Dlfcn.GetStringConstant (handle, "kCVPixelFormatContainsYCbCr");
 
-				//iOS9 only
-				ComponentRangeKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatComponentRange");
-				ComponentRangeFullRangeKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatComponentRange_FullRange");
-				ComponentRangeVideoRangeKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatComponentRange_VideoRange");
-				ComponentRangeWideRangeKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatComponentRange_WideRange");
+			//iOS9 only
+			ComponentRangeKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatComponentRange");
+			ComponentRangeFullRangeKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatComponentRange_FullRange");
+			ComponentRangeVideoRangeKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatComponentRange_VideoRange");
+			ComponentRangeWideRangeKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatComponentRange_WideRange");
 
-				// Xcode 10
-				ContainsGrayscaleKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatContainsGrayscale");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			// Xcode 10
+			ContainsGrayscaleKey = Dlfcn.GetStringConstant (handle, "kCVPixelFormatContainsGrayscale");
 		}
 
 		// note: bad documentation, ref: https://bugzilla.xamarin.com/show_bug.cgi?id=13917

--- a/src/MediaAccessibility/MediaAccessibility.cs
+++ b/src/MediaAccessibility/MediaAccessibility.cs
@@ -78,21 +78,13 @@ namespace MediaAccessibility {
 
 		static MACaptionAppearance ()
 		{
-			var handle = Dlfcn.dlopen (Constants.MediaAccessibilityLibrary, 0);
-			if (handle == IntPtr.Zero) {
-				return;
-			}
+			var handle = Libraries.MediaAccessibility.Handle;
+			SettingsChangedNotification = Dlfcn.GetStringConstant (handle, "kMACaptionAppearanceSettingsChangedNotification");
 
-			try {
-				SettingsChangedNotification = Dlfcn.GetStringConstant (handle, "kMACaptionAppearanceSettingsChangedNotification");
-
-				MediaCharacteristicDescribesMusicAndSoundForAccessibility = Dlfcn.GetStringConstant (handle,
-					"MAMediaCharacteristicDescribesMusicAndSoundForAccessibility");
-				MediaCharacteristicTranscribesSpokenDialogForAccessibility = Dlfcn.GetStringConstant (handle,
-					"MAMediaCharacteristicTranscribesSpokenDialogForAccessibility");
-			} finally {
-				Dlfcn.dlclose (handle);
-			}
+			MediaCharacteristicDescribesMusicAndSoundForAccessibility = Dlfcn.GetStringConstant (handle,
+				"MAMediaCharacteristicDescribesMusicAndSoundForAccessibility");
+			MediaCharacteristicTranscribesSpokenDialogForAccessibility = Dlfcn.GetStringConstant (handle,
+				"MAMediaCharacteristicTranscribesSpokenDialogForAccessibility");
 		}
 #endif
 

--- a/src/ObjCRuntime/Dlfcn.cs
+++ b/src/ObjCRuntime/Dlfcn.cs
@@ -51,7 +51,24 @@ namespace ObjCRuntime {
 		static public class System {
 			static public readonly IntPtr Handle = Dlfcn.dlopen (Constants.libSystemLibrary, 0);
 		}
+		static public class LibC {
+			static public readonly IntPtr Handle = Dlfcn.dlopen (Constants.libcLibrary, 0);
+		}
+#if MONOMAC
+		static public class CoreMidi {
+			static public readonly IntPtr Handle = Dlfcn.dlopen (Constants.CoreMidiLibrary, 0);
+		}
+#endif
+#if !WATCH && !MONOMAC
+		static public class OpenGLES
+		{
+			static public readonly IntPtr Handle = Dlfcn.dlopen (Constants.OpenGLESLibrary, 0);
+		}
+#endif
 #if !WATCH
+		static public class AudioToolbox {
+			static public readonly IntPtr Handle = Dlfcn.dlopen (Constants.AudioToolboxLibrary, 0);
+		}
 		static public class MetalPerformanceShaders {
 			static public readonly IntPtr Handle = Dlfcn.dlopen (Constants.MetalPerformanceShadersLibrary, 0);
 		}

--- a/src/OpenGLES/EAGLConsts.cs
+++ b/src/OpenGLES/EAGLConsts.cs
@@ -20,18 +20,11 @@ namespace OpenGLES {
 
 		static EAGLDrawableProperty ()
 		{
-			var handle = Dlfcn.dlopen (Constants.OpenGLESLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				ColorFormat     = Dlfcn.GetStringConstant (handle, 
-						"kEAGLDrawablePropertyColorFormat");
-				RetainedBacking = Dlfcn.GetStringConstant (handle, 
-						"kEAGLDrawablePropertyRetainedBacking");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.OpenGLES.Handle;
+			ColorFormat     = Dlfcn.GetStringConstant (handle, 
+					"kEAGLDrawablePropertyColorFormat");
+			RetainedBacking = Dlfcn.GetStringConstant (handle, 
+					"kEAGLDrawablePropertyRetainedBacking");
 		}
 	}
 
@@ -43,16 +36,9 @@ namespace OpenGLES {
 
 		static EAGLColorFormat ()
 		{
-			var handle = Dlfcn.dlopen (Constants.OpenGLESLibrary, 0);
-			if (handle == IntPtr.Zero)
-				return;
-			try {
-				RGB565  = Dlfcn.GetStringConstant (handle, "kEAGLColorFormatRGB565");
-				RGBA8   = Dlfcn.GetStringConstant (handle, "kEAGLColorFormatRGBA8");
-			}
-			finally {
-				Dlfcn.dlclose (handle);
-			}
+			var handle = Libraries.OpenGLES.Handle;
+			RGB565  = Dlfcn.GetStringConstant (handle, "kEAGLColorFormatRGB565");
+			RGBA8   = Dlfcn.GetStringConstant (handle, "kEAGLColorFormatRGBA8");
 		}
 	}
 }


### PR DESCRIPTION
I've also verified that calling dlsym with a NULL handle is safe: it just
returns NULL, so we can also skip all the IntPtr.Zero handle checks.