### PR TITLE
[CoreFoundation] Simplify DispatchQueue.MainQueue.

### DIFF
--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -265,34 +265,22 @@ namespace CoreFoundation {
 				return new DispatchQueue (dispatch_get_global_queue ((nint) (int) DispatchQueuePriority.Default, 0), false);
 			}
 		}
-#if MONOMAC
-		static DispatchQueue PInvokeDispatchGetMainQueue ()
-		{
-			return new DispatchQueue (dispatch_get_main_queue (), false);
-		}
 
-#endif
 		static IntPtr main_q;
-		static object lockobj = new object ();
 
 		public static DispatchQueue MainQueue {
 			get {
-				lock (lockobj) {
-					if (main_q == IntPtr.Zero) {
-						// Try loading the symbol from our address space first, should work everywhere
-						main_q = Dlfcn.dlsym ((IntPtr) (-2), "_dispatch_main_q");
+				if (main_q == IntPtr.Zero) {
+					// Try loading the symbol from our address space first, should work everywhere
+					main_q = Dlfcn.dlsym (Dlfcn.RTLD.Default, "_dispatch_main_q");
 
-						// Last case: this is technically not right for the simulator, as this path
-						// actually points to the MacOS library, not the one in the SDK.
-						if (main_q == IntPtr.Zero)
-							main_q = Dlfcn.GetIndirect (Libraries.System.Handle, "_dispatch_main_q");
-					}
+					if (main_q == IntPtr.Zero)
+						main_q = Dlfcn.GetIndirect (Libraries.System.Handle, "_dispatch_main_q");
+
+					if (main_q == IntPtr.Zero)
+						main_q = dispatch_get_main_queue ();
 				}
-#if MONOMAC
-				// For Snow Leopard
-				if (main_q == IntPtr.Zero)
-					return PInvokeDispatchGetMainQueue ();
-#endif
+
 				return new DispatchQueue (main_q, false);
 			}
 		}
@@ -427,11 +415,8 @@ namespace CoreFoundation {
 		// dispatch_queue_t dispatch_get_global_queue (long priority, unsigned long flags);
 		extern static IntPtr dispatch_get_global_queue (nint priority, nuint flags);
 
-#if MONOMAC
-		[Obsoleted (PlatformName.MacOSX, 10, 7)]
 		[DllImport (Constants.libcLibrary)]
 		extern static IntPtr dispatch_get_main_queue ();
-#endif
 
 		[DllImport (Constants.libcLibrary)]
 		// this returns a "const char*" so we cannot make a string out of it since it will be freed (and crash)

--- a/src/CoreFoundation/Dispatch.cs
+++ b/src/CoreFoundation/Dispatch.cs
@@ -271,14 +271,8 @@ namespace CoreFoundation {
 		public static DispatchQueue MainQueue {
 			get {
 				if (main_q == IntPtr.Zero) {
-					// Try loading the symbol from our address space first, should work everywhere
-					main_q = Dlfcn.dlsym (Dlfcn.RTLD.Default, "_dispatch_main_q");
-
-					if (main_q == IntPtr.Zero)
-						main_q = Dlfcn.GetIndirect (Libraries.System.Handle, "_dispatch_main_q");
-
-					if (main_q == IntPtr.Zero)
-						main_q = dispatch_get_main_queue ();
+					// Can't use a Field attribute because we don't support generating a call to Dlfcn.GetIndirect.
+					main_q = Dlfcn.GetIndirect (Libraries.libdispatch.Handle, "_dispatch_main_q");
 				}
 
 				return new DispatchQueue (main_q, false);
@@ -414,9 +408,6 @@ namespace CoreFoundation {
 		[DllImport (Constants.libcLibrary)]
 		// dispatch_queue_t dispatch_get_global_queue (long priority, unsigned long flags);
 		extern static IntPtr dispatch_get_global_queue (nint priority, nuint flags);
-
-		[DllImport (Constants.libcLibrary)]
-		extern static IntPtr dispatch_get_main_queue ();
 
 		[DllImport (Constants.libcLibrary)]
 		// this returns a "const char*" so we cannot make a string out of it since it will be freed (and crash)

--- a/tests/xtro-sharpie/macOS-CoreFoundation.ignore
+++ b/tests/xtro-sharpie/macOS-CoreFoundation.ignore
@@ -1,5 +1,4 @@
 ## /usr/include/dispatch/queue.h
-!unknown-pinvoke! dispatch_get_main_queue bound
 !unknown-pinvoke! dispatch_main bound
 
 ## dlfcn.h


### PR DESCRIPTION
* The dispatch_get_main_queue function doesn't exist anywhere (tested on iOS 5.1.1 - iOS 12, macOS 10.7 - 10.14), and when called from native code, it's always an inlined function, so just remove the call completely.
    
* Getting the _dispatch_main_q symbol from either the current address space, libSystem or libdispatch works fine everywhere. Looking up something in the current address space is costly (according to 'man dlsym'), so stop doing that: only look in libdispatch (since that's where the symbol actually is according to 'nm').

* I find no reason for the lock in DispatchQueue.MainQueue, nor does history reveal anything helpful, so I removed the lock.