### PR TITLE
Bump mono to head of 2018-04

### DIFF
--- a/src/Compression/Compression.cs
+++ b/src/Compression/Compression.cs
@@ -202,7 +202,8 @@ namespace Compression
 			return ReadCore (new Span<byte> (array, offset, count));
 		}
 
-		public override int Read (Span<byte> destination)
+		// FIXME needs Span
+		internal override int Read (Span<byte> destination)
 		{
 			if (GetType () != typeof (CompressionStream)) {
 				// CompressStream is not sealed, and a derived type may have overridden Read(byte[], int, int) prior
@@ -312,7 +313,8 @@ namespace Compression
 			return ReadAsyncMemory (new Memory<byte>(array, offset, count), cancellationToken).AsTask ();
 		}
 
-		public override ValueTask<int> ReadAsync (Memory<byte> destination, CancellationToken cancellationToken = default(CancellationToken))
+		// FIXME needs Span
+		internal override ValueTask<int> ReadAsync (Memory<byte> destination, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			if (GetType () != typeof (CompressionStream)) {
 				// Ensure that existing streams derived from DeflateStream and that override ReadAsync(byte[],...)
@@ -405,7 +407,8 @@ namespace Compression
 			WriteCore (new ReadOnlySpan<byte> (array, offset, count));
 		}
 
-		public override void Write (ReadOnlySpan<byte> source)
+		// FIXME needs Span
+		internal override void Write (ReadOnlySpan<byte> source)
 		{
 			if (GetType () != typeof (CompressionStream)) {
 				// DeflateStream is not sealed, and a derived type may have overridden Write(byte[], int, int) prior
@@ -558,7 +561,8 @@ namespace Compression
 			return WriteAsyncMemory (new ReadOnlyMemory<byte> (array, offset, count), cancellationToken);
 		}
 
-		public override Task WriteAsync (ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
+		// FIXME needs Span
+		internal override Task WriteAsync (ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
 		{
 			if (GetType () != typeof (CompressionStream)) {
 				// Ensure that existing streams derived from DeflateStream and that override WriteAsync(byte[],...)

--- a/tools/linker/MobileProfile.cs
+++ b/tools/linker/MobileProfile.cs
@@ -172,6 +172,7 @@ namespace Xamarin.Linker {
 			"System.Threading.Overlapped",
 			"System.Threading.Tasks.Parallel",
 			"System.Threading.Tasks",
+			"System.Threading.Tasks.Extensions",
 			"System.Threading.Thread",
 			"System.Threading.ThreadPool",
 			"System.Threading.Timer",


### PR DESCRIPTION
Commit list for mono/mono:

* mono/mono@1fd01f4fd7d [2018-04] [runtime] Disable stack guard for main thread on osx (#10904)
* mono/mono@e1af6ea5e72 [sdks] One more update to get XA PR builds working on Linux (#10854)
* mono/mono@288a9254f59 [merp] Fix return value handling of posix_spawn (#10829)
* mono/mono@d95b5e57c49 [sdks] Debian Linux doesn't need to build MXE
* mono/mono@1d40dbb42e1 [SDKS] Build host runtime with correct bitness (#10776)
* mono/mono@5b9b00dd613 [crash] Fix summarize_frame assertion (#10726)
* mono/mono@99f7533b63b Bump API snapshot submodule
* mono/mono@33a0966d832 [mcs] Removes tests which depend on new public APIs
* mono/mono@4d8bdab15e8 [mcs] Don't report internal error when Span type is not available
* mono/mono@4309250dcd2 [corlib] Hide types which could conflict with System.Memory
* mono/mono@2334327c43d [offset-tool] Error out when parsing fails. (#10697)
* mono/mono@ddb9dc31f36 Bump API snapshot submodule
* mono/mono@9fca0d8760e [2018-04] [Facades] Adds System.Threading.Tasks.Extensions for mobile profiles (#9977)

Diff: https://github.com/mono/mono/compare/46ff31252daa7e594600ad39fac195d971ee27d1...1fd01f4fd7dd34a3a71a79dec074c114a6f6e1e3