### PR TITLE
[d15-9] Try to make version numbers clearer, and establish some ground rules.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -5,22 +5,20 @@ include $(TOP)/mk/subdirs.mk
 -include $(TOP)/Make.config.inc
 $(TOP)/Make.config.inc: $(TOP)/Make.config
 	@rm -f $@
-	@printf "IOS_COMMIT_DISTANCE:=$(shell LANG=C; export LANG && git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.config HEAD | grep IOS_PACKAGE_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@
-	@printf "MAC_COMMIT_DISTANCE:=$(shell LANG=C; export LANG && git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.config HEAD | grep MAC_PACKAGE_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@
+	@printf "IOS_COMMIT_DISTANCE:=$(shell LANG=C; export LANG && git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep IOS_PACKAGE_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@
+	@printf "MAC_COMMIT_DISTANCE:=$(shell LANG=C; export LANG && git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep MAC_PACKAGE_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@
 	@if which ccache > /dev/null 2>&1; then printf "ENABLE_CCACHE=1\nexport CCACHE_BASEDIR=$(abspath $(TOP)/..)\n" >> $@; echo "Found ccache on the system, enabling it"; fi
 	@if test -d $(TOP)/../maccore; then printf "ENABLE_XAMARIN=1\n" >> $@; echo "Detected the maccore repository, automatically enabled the Xamarin build"; fi
+
+include $(TOP)/Make.versions
 
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 
 #
 # /!\ README /!\
 #
-# A release branch requires updating:
-#
-# IOS_PACKAGE_VERSION (major/minor #)
-# MAC_PACKAGE_VERSION (major/minor #)
-# PACKAGE_VERSION_REV (set to 0 and increment for service releases or previews)
-# (and updating the same on master as well, to next version)
+# A release branch requires updating some variables.
+# This is done in Make.versions, not here.
 #
 
 ifeq ($(BRANCH_NAME),)
@@ -30,18 +28,12 @@ else
 CURRENT_BRANCH:=$(BRANCH_NAME)
 endif
 
-# TODO: reset to 0 after major/minor version bump (SRO) and increment for service releases and previews
-# Note: if not reseted to 0 we can skip a version and start with .1 or .2
-PACKAGE_VERSION_REV=0
-IOS_PACKAGE_VERSION_REV=$(PACKAGE_VERSION_REV)
-
 IOS_PRODUCT=Xamarin.iOS
 IOS_PACKAGE_NAME=Xamarin.iOS
 IOS_PACKAGE_NAME_LOWER=$(shell echo $(IOS_PACKAGE_NAME) | tr "[:upper:]" "[:lower:]")
-# NEVER customize IOS_PACKAGE_VERSION itself, other parts (mtouch, web updater) are using the IOS_PACKAGE_VERSION_* variables
-IOS_PACKAGE_VERSION=12.2.$(IOS_PACKAGE_VERSION_REV).$(IOS_COMMIT_DISTANCE)
 IOS_PACKAGE_VERSION_MAJOR=$(word 1, $(subst ., ,$(IOS_PACKAGE_VERSION)))
 IOS_PACKAGE_VERSION_MINOR=$(word 2, $(subst ., ,$(IOS_PACKAGE_VERSION)))
+IOS_PACKAGE_VERSION_REV:=$(word 3, $(subst ., ,$(IOS_PACKAGE_VERSION)))
 IOS_PACKAGE_VERSION_BUILD=$(IOS_COMMIT_DISTANCE)
 IOS_PACKAGE_UPDATE_ID=$(shell printf "2%02d%02d%02d%03d" $(IOS_PACKAGE_VERSION_MAJOR) $(IOS_PACKAGE_VERSION_MINOR) $(IOS_PACKAGE_VERSION_REV) $(IOS_PACKAGE_VERSION_BUILD))
 
@@ -261,10 +253,9 @@ MAC_PRODUCT=Xamarin.Mac
 MAC_PACKAGE_NAME=xamarin.mac
 MAC_PACKAGE_NAME_LOWER=$(shell echo $(MAC_PACKAGE_NAME) | tr "[:upper:]" "[:lower:]")
 
-MAC_PACKAGE_VERSION=5.2.$(PACKAGE_VERSION_REV).$(MAC_COMMIT_DISTANCE)
 MAC_PACKAGE_VERSION_MAJOR=$(word 1, $(subst ., ,$(MAC_PACKAGE_VERSION)))
 MAC_PACKAGE_VERSION_MINOR=$(word 2, $(subst ., ,$(MAC_PACKAGE_VERSION)))
-MAC_PACKAGE_VERSION_REV=$(PACKAGE_VERSION_REV)
+MAC_PACKAGE_VERSION_REV=$(word 3, $(subst ., ,$(MAC_PACKAGE_VERSION)))
 MAC_PACKAGE_VERSION_BUILD=$(word 4, $(subst ., ,$(MAC_PACKAGE_VERSION)))
 MAC_PACKAGE_VERSION_MAJOR_MINOR=$(MAC_PACKAGE_VERSION_MAJOR).$(MAC_PACKAGE_VERSION_MINOR)
 MAC_PACKAGE_UPDATE_ID=$(shell echo $(subst ., ,$(MAC_PACKAGE_VERSION).$(MAC_PACKAGE_VERSION_BUILD)) | awk '{printf "2%02d%02d%02d%03d",$$1,$$2,$$3,$$4}')

--- a/Make.versions
+++ b/Make.versions
@@ -1,0 +1,47 @@
+#
+# A release branch requires updating the following two variables at the bottom of this file:
+#
+# IOS_PACKAGE_VERSION (major/minor/revision #)
+# MAC_PACKAGE_VERSION (major/minor/revision #)
+#
+# Update version numbers on master as well, to the next version
+#
+
+#
+# ** Version numbers **
+#
+# Versions are defined as: Major.Minor.Revison.Build
+#
+# Major/minor (first/second numbers - max 2 digits each):
+# - Bump for major/minor releases.
+#
+# Revision (third number - max 2 digits):
+# - Reset to 0 after a major or minor bump (do not use 99 for Xcode preview
+#   branches (use 0 instead), because otherwise we can't bump it further if
+#   needed).
+# - Bump for service releases and previews.
+# - Bump if commit distance becomes > 999.
+# - Can also be bumped for other reasons (in particular there's no correlation
+#   between Preview/Service Release #X and Revision #Y).
+#   - Bumping revision to a high enough number to make it clear that there's
+#     no correlation is a valid reason to bump.
+# - The revision must be bumped at the same time for both iOS and Mac
+#   (otherwise the commit distance will differ).
+# - Also bump if the [IOS|MAC]_PACKAGE_VERSION lines change for any other
+#   reason (otherwise we end up with repeating version numbers, since the
+#   commit distance would restart at 0, while the other numbers wouldn't
+#   change).
+# - Any other problem can also usually be solved by bumping the revision.
+# - Do not refactor the revision to a separate variable, because the reason
+#   bumping the revision is a general solution for many problems is that it
+#   also resets the commit distance (which wouldn't happen if the revision was
+#   refactored to a separate variable).
+#
+# Build (fourth number - max 3 digits):
+# - Automatically calculated as the number of commits since the last time any
+#   of the other three numbers changed (technically since the corresponding
+#   line changed in git).
+#
+
+IOS_PACKAGE_VERSION=12.2.1.$(IOS_COMMIT_DISTANCE)
+MAC_PACKAGE_VERSION=5.2.1.$(MAC_COMMIT_DISTANCE)

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,19 @@ world: check-system
 
 .PHONY: check-system
 check-system:
+	@if [[ "x$(IOS_COMMIT_DISTANCE)" != "x$(MAC_COMMIT_DISTANCE)" ]]; then \
+		echo "$(COLOR_RED)*** The commit distance for Xamarin.iOS ($(IOS_COMMIT_DISTANCE)) and Xamarin.Mac ($(MAC_COMMIT_DISTANCE)) are different.$(COLOR_CLEAR)"; \
+		echo "$(COLOR_RED)*** To fix this problem, bump the revision (the third number) for both $(COLOR_GRAY)IOS_PACKAGE_NUMBER$(COLOR_RED) and $(COLOR_GRAY)MAC_PACKAGE_NUMBER$(COLOR_RED) in Make.versions.$(COLOR_CLEAR)"; \
+		echo "$(COLOR_RED)*** Once fixed, you need to commit the changes for them to pass this check.$(COLOR_CLEAR)"; \
+		exit 1; \
+	elif (( $(IOS_COMMIT_DISTANCE) > 999 || $(MAC_COMMIT_DISTANCE) > 999 )); then \
+		echo "$(COLOR_RED)*** The commit distance for Xamarin.iOS ($(IOS_COMMIT_DISTANCE)) and/or Xamarin.Mac ($(MAC_COMMIT_DISTANCE)) are > 999.$(COLOR_CLEAR)"; \
+		echo "$(COLOR_RED)*** To fix this problem, bump the revision (the third number) for both $(COLOR_GRAY)IOS_PACKAGE_NUMBER$(COLOR_RED) and $(COLOR_GRAY)MAC_PACKAGE_NUMBER$(COLOR_RED) in Make.versions.$(COLOR_CLEAR)"; \
+		echo "$(COLOR_RED)*** Once fixed, you need to commit the changes for them to pass this check.$(COLOR_CLEAR)"; \
+		exit 1; \
+	fi
 	@./system-dependencies.sh
+	@echo "Building Xamarin.iOS $(IOS_PACKAGE_VERSION) and Xamarin.Mac $(MAC_PACKAGE_VERSION)"
 
 $(DIRECTORIES):
 	$(Q) mkdir -p $@


### PR DESCRIPTION
Backport of https://github.com/xamarin/xamarin-macios/pull/4927
with 15.9 numbers