### PR TITLE
[xharness] Verify that there's at least 1GB of space left before trying to build or run each test.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -2202,6 +2202,30 @@ function toggleAll (show)
 
 		public bool RequiresXcode94;
 
+		// VerifyRun is called in RunInternalAsync/ExecuteAsync to verify that the task can be executed/run.
+		// Typically used to fail tasks that don't have an available device, or if there's not enough disk space.
+		public virtual Task VerifyRunAsync ()
+		{
+			return VerifyDiskSpaceAsync ();
+		}
+
+		static DriveInfo RootDrive;
+		protected Task VerifyDiskSpaceAsync ()
+		{
+			if (Finished)
+				return Task.CompletedTask;
+
+			if (RootDrive == null)
+				RootDrive = new DriveInfo ("/");
+			var afs = RootDrive.AvailableFreeSpace;
+			const long minSpaceRequirement = 1024 * 1024 * 1024; /* 1 GB */
+			if (afs < minSpaceRequirement) {
+				FailureMessage = $"Not enough space on the root drive '{RootDrive.Name}': {afs / (1024.0 * 1024):#.##} MB left of {minSpaceRequirement / (1024.0 * 1024):#.##} MB required";
+				ExecutionResult = TestExecutingResult.Failed;
+			}
+			return Task.CompletedTask;
+		}
+
 		public void CloneTestProject (TestProject project)
 		{
 			// Don't build in the original project directory
@@ -2369,6 +2393,10 @@ function toggleAll (show)
 			try {
 				if (InitialTask != null)
 					await InitialTask;
+				
+				await VerifyRunAsync ();
+				if (Finished)
+					return;
 
 				duration.Start ();
 
@@ -3137,6 +3165,10 @@ function toggleAll (show)
 			if (Finished)
 				return true;
 			
+			await VerifyBuildAsync ();
+			if (Finished)
+				return BuildTask.Succeeded;
+
 			ExecutionResult = TestExecutingResult.Building;
 			await BuildTask.RunAsync ();
 			if (!BuildTask.Succeeded) {
@@ -3175,9 +3207,12 @@ function toggleAll (show)
 		}
 
 		protected abstract Task RunTestAsync ();
-		// VerifyRun is called in ExecuteAsync to verify that the task can be executed/run.
-		// Typically used to fail tasks that don't have an available device.
-		public virtual Task VerifyRunAsync () { return Task.CompletedTask; }
+		// VerifyBuild is called in BuildAsync to verify that the task can be built.
+		// Typically used to fail tasks if there's not enough disk space.
+		public virtual Task VerifyBuildAsync ()
+		{
+			return VerifyDiskSpaceAsync ();
+		}
 
 		public override void Reset ()
 		{
@@ -3254,6 +3289,8 @@ function toggleAll (show)
 		public override async Task VerifyRunAsync ()
 		{
 			await base.VerifyRunAsync ();
+			if (Finished)
+				return;
 
 			var enumerable = candidates;
 			var asyncEnumerable = enumerable as IAsyncEnumerable;


### PR DESCRIPTION
If there's not enough space, then fail the test.

This might help https://github.com/xamarin/maccore/issues/965 (test run hangs).