### PR TITLE
[d15-9] Bundle Make.version with the packaged XM tests to fix testing on older XM macOS versions

### DIFF
--- a/tests/package-mac-tests.sh
+++ b/tests/package-mac-tests.sh
@@ -18,6 +18,7 @@ cp -p Makefile-mac.inc $DIR/tests
 cp -p common.mk $DIR/tests
 cp -p Makefile $DIR/tests
 cp -p ../Make.config $DIR
+cp -p ../Make.versions $DIR
 cp -p test-dependencies.sh $DIR
 cp -p ../system-dependencies.sh $DIR
 mkdir -p $DIR/mk


### PR DESCRIPTION
Backport of #4938.

/cc @rolfbjarne 

Description:
