### PR TITLE
Improve generator diff to ignore changes we don't care about.

### DIFF
--- a/jenkins/compare.sh
+++ b/jenkins/compare.sh
@@ -81,7 +81,9 @@ else
 fi
 printf "\\n" >> "$WORKSPACE/jenkins/pr-comments.md"
 
-if grep "^[+-][^+-]" jenkins-results/generator-diff/generator.diff | grep -v "^.[[]assembly: AssemblyInformationalVersion" | grep -v "^[+-][[:space:]]*internal const string Revision =" >/dev/null 2>&1; then
+if ! test -s jenkins-results/generator-diff/generator.diff; then
+	printf "✅ [Generator Diff](%s) (no change)" "$URL_GENERATOR" >> "$WORKSPACE/jenkins/pr-comments.md"
+elif grep "^[+-][^+-]" jenkins-results/generator-diff/generator.diff | grep -v "^.[[]assembly: AssemblyInformationalVersion" | grep -v "^[+-][[:space:]]*internal const string Revision =" >/dev/null 2>&1; then
 	printf "ℹ️ [Generator Diff](%s) (please review changes)" "$URL_GENERATOR" >> "$WORKSPACE/jenkins/pr-comments.md"
 else
 	printf "✅ [Generator Diff](%s) (only version changes)" "$URL_GENERATOR" >> "$WORKSPACE/jenkins/pr-comments.md"

--- a/tools/compare-commits.sh
+++ b/tools/compare-commits.sh
@@ -198,7 +198,7 @@ make all-local -C "$ROOT_DIR/tools/apidiff" -j8 APIDIFF_DIR="$OUTPUT_DIR/apidiff
 # affecting that build.
 $CP -R "$ROOT_DIR/src/build" "$OUTPUT_DIR/build-new"
 cd "$OUTPUT_DIR"
-find build build-new '(' -name '*.dll' -or -name '*.mdb' -or -name '*.pdb' -or -name 'generated-sources' -or -name 'generated_sources' -or -name '*.exe' ')' -delete
+find build build-new '(' -name '*.dll' -or -name '*.pdb' -or -name 'generated-sources' -or -name 'generated_sources' -or -name '*.exe' -or -name '*.rsp' -or -name 'AssemblyInfo.cs' -or -name 'Constants.cs' -or -name 'generator.csproj.*' ')' -delete
 mkdir -p "$OUTPUT_DIR/generator-diff"
 GENERATOR_DIFF_FILE="$OUTPUT_DIR/generator-diff/index.html"
 git diff --no-index build build-new > "$OUTPUT_DIR/generator-diff/generator.diff" || true


### PR DESCRIPTION
This means we'll get an empty diff if there are no generator changes, so
update the logic that detects/reports empty generator diffs.

Also there's no need to ignore mdbs anymore, since we don't create mdbs.