### PR TITLE
[xharness] Add length consistency check when capturing a log file.

### DIFF
--- a/tests/xharness/Log.cs
+++ b/tests/xharness/Log.cs
@@ -339,6 +339,11 @@ namespace xharness
 			var currentLength = new FileInfo (CapturePath).Length;
 			var capturedLength = 0L;
 
+			if (length < 0) {
+				// The file shrank?
+				return;
+			}
+
 			if (File.Exists (Path))
 				capturedLength = new FileInfo (Path).Length;
 


### PR DESCRIPTION
Sometimes files just shrink, and we must cope.

Two possible causes I can think of:

* System log rotation.
* We erase a simulator when trying to capture its system log.

There are probably many more causes, but two is more than enough to make sure
we don't fail when it happens.