### PR TITLE
[generator] Throw PlatformNotSupportException in 32-bit mode for 64-bit-only iOS API. Fixes #4689.

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -13493,7 +13493,6 @@ namespace Foundation
 	}
 
 #if !WATCH && !TVOS
-	[Mac (10,8), iOS (11,0), NoWatch, NoTV]
 	partial interface NSFileManager {
 
 		[Mac (10, 8), Export ("trashItemAtURL:resultingItemURL:error:")]

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -13492,9 +13492,9 @@ namespace Foundation
 		NSDimension BaseUnit { get; }
 	}
 
-#if !WATCH && !TVOS
 	partial interface NSFileManager {
 
+		[iOS (11, 0), NoTV, NoWatch]
 		[Mac (10, 8), Export ("trashItemAtURL:resultingItemURL:error:")]
 		bool TrashItem (NSUrl url, out NSUrl resultingItemUrl, out NSError error);
 
@@ -13514,7 +13514,6 @@ namespace Foundation
 		[Export ("name")]
 		string Name { get; }
 	}
-#endif
 
 #if MONOMAC
 	partial interface NSFilePresenter {

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -6311,7 +6311,7 @@ public partial class Generator : IMemberGatherer {
 						sw.WriteLine ("\t\t{");
 						if (is32BitNotSupported) {
 							sw.WriteLine ("\t\t#if ARCH_32");
-							sw.WriteLine ("\t\t\tthrow new PlatformNotSupportedException ();");
+							sw.WriteLine ("\t\t\tthrow new PlatformNotSupportedException (\"This API is not supported on this version of iOS\");");
 							sw.WriteLine ("\t\t#else");
 						}
 						if (is_direct_binding_value != null)
@@ -6328,7 +6328,7 @@ public partial class Generator : IMemberGatherer {
 					sw.WriteLine ("\t\t{");
 					if (is32BitNotSupported) {
 						sw.WriteLine ("\t\t#if ARCH_32");
-						sw.WriteLine ("\t\t\tthrow new PlatformNotSupportedException ();");
+						sw.WriteLine ("\t\t\tthrow new PlatformNotSupportedException (\"This API is not supported on this version of iOS\");");
 						sw.WriteLine ("\t\t#else");
 					}
 					if (is_direct_binding_value != null)

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -3942,6 +3942,22 @@ public partial class Generator : IMemberGatherer {
 		return mi.GetAvailability (AvailabilityKind.Introduced) ?? pi.GetAvailability (AvailabilityKind.Introduced);
 	}
 
+	bool Is64BitiOSOnly (ICustomAttributeProvider provider)
+	{
+		if (BindThirdPartyLibrary)
+			return false;
+		if (BindingTouch.CurrentPlatform != PlatformName.iOS)
+			return false;
+		var attrib = provider.GetAvailability (AvailabilityKind.Introduced);
+		if (attrib == null) {
+			var minfo = provider as MemberInfo;
+			if (minfo != null && minfo.DeclaringType != null)
+				return Is64BitiOSOnly (minfo.DeclaringType);
+			return false;
+		}
+		return attrib.Version.Major >= 11; 
+	}
+
 	//
 	// Generates the code necessary to lower the MonoTouch-APIs to something suitable
 	// to be passed to Objective-C.
@@ -4754,6 +4770,12 @@ public partial class Generator : IMemberGatherer {
 				print ("get; ");
 			} else {
 				print ("get {");
+				var is32BitNotSupported = Is64BitiOSOnly (pi);
+				if (is32BitNotSupported) {
+					print ("#if ARCH_32");
+					print ("\tthrow new PlatformNotSupportedException (\"This API is not supported on this version of iOS\");");
+					print ("#else");
+				}
 				if (debug)
 					print ("Console.WriteLine (\"In {0}\");", pi.GetGetMethod ());
 				if (is_model)
@@ -4778,6 +4800,8 @@ public partial class Generator : IMemberGatherer {
 						indent--;
 					}
 				}
+				if (is32BitNotSupported)
+					print ("#endif");
 				print ("}\n");
 			}
 		}
@@ -4805,6 +4829,12 @@ public partial class Generator : IMemberGatherer {
 				print ("set; ");
 			} else {
 				print ("set {");
+				var is32BitNotSupported = Is64BitiOSOnly (pi);
+				if (is32BitNotSupported) {
+					print ("#if ARCH_32");
+					print ("\tthrow new PlatformNotSupportedException (\"This API is not supported on this version of iOS\");");
+					print ("#else");
+				}
 				if (debug)
 					print ("Console.WriteLine (\"In {0}\");", pi.GetSetMethod ());
 
@@ -4830,6 +4860,8 @@ public partial class Generator : IMemberGatherer {
 						}
 					}
 				}
+				if (is32BitNotSupported)
+					print ("#endif");
 				print ("}");
 			}
 		}
@@ -5213,6 +5245,13 @@ public partial class Generator : IMemberGatherer {
 			}
 
 			print ("{");
+
+			var is32BitNotSupported = Is64BitiOSOnly ((ICustomAttributeProvider) minfo.method ?? minfo.property);
+			if (is32BitNotSupported) {
+				print ("#if ARCH_32");
+				print ("\tthrow new PlatformNotSupportedException (\"This API is not supported on this version of iOS\");");
+				print ("#else");
+			}
 			if (debug)
 				print ("\tConsole.WriteLine (\"In {0}\");", mi);
 					
@@ -5237,6 +5276,8 @@ public partial class Generator : IMemberGatherer {
 					indent--;
 				}
 			}
+			if (is32BitNotSupported)
+				print ("#endif");
 			print ("}\n");
 		}
 
@@ -6173,6 +6214,7 @@ public partial class Generator : IMemberGatherer {
 					var initSelector = (InlineSelectors || BindThirdPartyLibrary) ? "Selector.GetHandle (\"init\")" : "Selector.Init";
 					var initWithCoderSelector = (InlineSelectors || BindThirdPartyLibrary) ? "Selector.GetHandle (\"initWithCoder:\")" : "Selector.InitWithCoder";
 					string v = UnifiedAPI && class_mod == "abstract " ? "protected" : ctor_visibility;
+					var is32BitNotSupported = Is64BitiOSOnly (type);
 					if (external) {
 						if (!disable_default_ctor) {
 							GeneratedCode (sw, 2);
@@ -6184,12 +6226,19 @@ public partial class Generator : IMemberGatherer {
 							sw.WriteLine ("\t\t[Export (\"init\")]");
 							sw.WriteLine ("\t\t{0} {1} () : base (NSObjectFlag.Empty)", v, TypeName);
 							sw.WriteLine ("\t\t{");
+							if (is32BitNotSupported) {
+								sw.WriteLine ("\t\t#if ARCH_32");
+								sw.WriteLine ("\tthrow new PlatformNotSupportedException (\"This API is not supported on this version of iOS\");");
+								sw.WriteLine ("\t\t#else");
+							}
 							if (is_direct_binding_value != null)
 								sw.WriteLine ("\t\t\tIsDirectBinding = {0};", is_direct_binding_value);
 							if (debug)
 								sw.WriteLine ("\t\t\tConsole.WriteLine (\"{0}.ctor ()\");", TypeName);
 							sw.WriteLine ("\t\t\tInitializeHandle (global::{1}.IntPtr_objc_msgSend (this.Handle, global::{2}.{0}), \"init\");", initSelector, ns.Messaging, ns.CoreObjCRuntime);
 							sw.WriteLine ("\t\t\t");
+							if (is32BitNotSupported)
+								sw.WriteLine ("\t\t#endif");
 							sw.WriteLine ("\t\t}");
 						}
 					} else {
@@ -6203,12 +6252,19 @@ public partial class Generator : IMemberGatherer {
 							sw.WriteLine ("\t\t[Export (\"init\")]");
 							sw.WriteLine ("\t\t{0} {1} () : base (NSObjectFlag.Empty)", v, TypeName);
 							sw.WriteLine ("\t\t{");
+							if (is32BitNotSupported) {
+								sw.WriteLine ("\t\t#if ARCH_32");
+								sw.WriteLine ("\tthrow new PlatformNotSupportedException (\"This API is not supported on this version of iOS\");");
+								sw.WriteLine ("\t\t#else");
+							}
 							var indentation = 3;
 							WriteIsDirectBindingCondition (sw, ref indentation, is_direct_binding, is_direct_binding_value,
 							                               () => string.Format ("InitializeHandle (global::{1}.IntPtr_objc_msgSend (this.Handle, global::{2}.{0}), \"init\");", initSelector, ns.Messaging, ns.CoreObjCRuntime),
 							                               () => string.Format ("InitializeHandle (global::{1}.IntPtr_objc_msgSendSuper (this.SuperHandle, global::{2}.{0}), \"init\");", initSelector, ns.Messaging, ns.CoreObjCRuntime));
 
 							WriteMarkDirtyIfDerived (sw, type);
+							if (is32BitNotSupported)
+								sw.WriteLine ("\t\t#endif");
 							sw.WriteLine ("\t\t}");
 							sw.WriteLine ();
 						}
@@ -6225,6 +6281,11 @@ public partial class Generator : IMemberGatherer {
 							sw.WriteLine ("\t\t[Export (\"initWithCoder:\")]");
 							sw.WriteLine ("\t\t{0} {1} (NSCoder coder) : base (NSObjectFlag.Empty)", UnifiedAPI ? v : "public", TypeName);
 							sw.WriteLine ("\t\t{");
+							if (is32BitNotSupported) {
+								sw.WriteLine ("\t\t#if ARCH_32");
+								sw.WriteLine ("\tthrow new PlatformNotSupportedException (\"This API is not supported on this version of iOS\");");
+								sw.WriteLine ("\t\t#else");
+							}
 							if (nscoding) {
 								if (debug)
 									sw.WriteLine ("\t\t\tConsole.WriteLine (\"{0}.ctor (NSCoder)\");", TypeName);
@@ -6237,6 +6298,8 @@ public partial class Generator : IMemberGatherer {
 							} else {
 								sw.WriteLine ("\t\t\tthrow new InvalidOperationException (\"Type does not conform to NSCoding\");");
 							}
+							if (is32BitNotSupported)
+								sw.WriteLine ("\t\t#endif");
 							sw.WriteLine ("\t\t}");
 							sw.WriteLine ();
 						}
@@ -6246,9 +6309,16 @@ public partial class Generator : IMemberGatherer {
 						sw.WriteLine ("\t\t[EditorBrowsable (EditorBrowsableState.Advanced)]");
 						sw.WriteLine ("\t\t{0} {1} (NSObjectFlag t) : base (t)", UnifiedAPI ? "protected" : "public", TypeName);
 						sw.WriteLine ("\t\t{");
+						if (is32BitNotSupported) {
+							sw.WriteLine ("\t\t#if ARCH_32");
+							sw.WriteLine ("\t\t\tthrow new PlatformNotSupportedException ();");
+							sw.WriteLine ("\t\t#else");
+						}
 						if (is_direct_binding_value != null)
 							sw.WriteLine ("\t\t\tIsDirectBinding = {0};", is_direct_binding_value);
 						WriteMarkDirtyIfDerived (sw, type);
+						if (is32BitNotSupported)
+							sw.WriteLine ("\t\t#endif");
 						sw.WriteLine ("\t\t}");
 						sw.WriteLine ();
 					}
@@ -6256,8 +6326,15 @@ public partial class Generator : IMemberGatherer {
 					sw.WriteLine ("\t\t[EditorBrowsable (EditorBrowsableState.Advanced)]");
 					sw.WriteLine ("\t\t{0} {1} (IntPtr handle) : base (handle)", UnifiedAPI ? "protected internal" : "public", TypeName);
 					sw.WriteLine ("\t\t{");
+					if (is32BitNotSupported) {
+						sw.WriteLine ("\t\t#if ARCH_32");
+						sw.WriteLine ("\t\t\tthrow new PlatformNotSupportedException ();");
+						sw.WriteLine ("\t\t#else");
+					}
 					if (is_direct_binding_value != null)
 						sw.WriteLine ("\t\t\tIsDirectBinding = {0};", is_direct_binding_value);
+					if (is32BitNotSupported)
+						sw.WriteLine ("\t\t#endif");
 					WriteMarkDirtyIfDerived (sw, type);
 					sw.WriteLine ("\t\t}");
 					sw.WriteLine ();


### PR DESCRIPTION
Throw PlatformNotSupportedException for iOS API that was introduced in iOS 11+
in 32-bit mode, since that API is clearly not available in any 32-bit capable
iOS version.

This makes the 32-bit version of Xamarin.iOS.dll smaller (from 15.282.176
bytes to 14.575.616 bytes, ~700kb smaller - small enough that this makes the
dontlink test work in 32-bit mode again on device).

Fixes https://github.com/xamarin/xamarin-macios/issues/4689.