### PR TITLE
[master] [msbuild] Implement support for faking the watchOS 4.3 SDK. Fixes #4810.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -36,6 +36,8 @@ namespace Xamarin.iOS.Tasks
 		[Required]
 		public bool Debug { get; set; }
 
+		public bool UseFakeWatchOS4_3Sdk { get; set; }
+
 		public string DebugIPAddresses { get; set; }
 
 		public string ResourceRules { get; set; }
@@ -154,28 +156,66 @@ namespace Xamarin.iOS.Tasks
 			plist.SetIfNotPresent (ManifestKeys.CFBundleVersion, "1.0");
 			plist.SetIfNotPresent (ManifestKeys.CFBundleShortVersionString, plist.GetCFBundleVersion ());
 
+			string dtCompiler = null;
+			string dtPlatformBuild = null;
+			string dtSDKBuild = null;
+			string dtPlatformName = null;
+			string dtPlatformVersion = null;
+			string dtXcode = null;
+			string dtXcodeBuild = null;
+
 			if (!SdkIsSimulator) {
-				SetValue (plist, "DTCompiler", sdkSettings.DTCompiler);
-				SetValue (plist, "DTPlatformBuild", dtSettings.DTPlatformBuild);
-				SetValue (plist, "DTSDKBuild", sdkSettings.DTSDKBuild);
+				dtCompiler = sdkSettings.DTCompiler;
+				dtPlatformBuild = dtSettings.DTPlatformBuild;
+				dtSDKBuild = sdkSettings.DTSDKBuild;
 			}
 
-			plist.SetIfNotPresent ("DTPlatformName", SdkPlatform.ToLowerInvariant ());
+			dtPlatformName = SdkPlatform.ToLowerInvariant ();
 			if (!SdkIsSimulator)
-				SetValue (plist, "DTPlatformVersion", dtSettings.DTPlatformVersion);
+				dtPlatformVersion = dtSettings.DTPlatformVersion;
 
-			var sdkName = sdkSettings.CanonicalName;
+			var dtSDKName = sdkSettings.CanonicalName;
 			// older sdksettings didn't have a canonicalname for sim
-			if (SdkIsSimulator && string.IsNullOrEmpty (sdkName)) {
+			if (SdkIsSimulator && string.IsNullOrEmpty (dtSDKName)) {
 				var deviceSdkSettings = currentSDK.GetSdkSettings (sdkVersion, false);
-				sdkName = deviceSdkSettings.AlternateSDK;
+				dtSDKName = deviceSdkSettings.AlternateSDK;
 			}
-			SetValue (plist, "DTSDKName", sdkName);
 
 			if (!SdkIsSimulator) {
-				SetValue (plist, "DTXcode", AppleSdkSettings.DTXcode);
-				SetValue (plist, "DTXcodeBuild", dtSettings.DTXcodeBuild);
+				dtXcode = AppleSdkSettings.DTXcode;
+				dtXcodeBuild = dtSettings.DTXcodeBuild;
 			}
+
+			if (UseFakeWatchOS4_3Sdk) {
+				// This is a workaround for https://github.com/xamarin/xamarin-macios/issues/4810
+				if (Framework == PlatformFramework.WatchOS) {
+					if (dtPlatformBuild != null)
+						dtPlatformBuild = "15T212";
+					if (dtPlatformVersion != null)
+						dtPlatformVersion = "4.3";
+					if (dtSDKBuild != null)
+						dtSDKBuild = "15T212";
+					if (dtSDKName != null)
+						dtSDKName = "watchos4.3";
+					if (dtXcode != null)
+						dtXcode = "0940";
+					if (dtXcodeBuild != null)
+						dtXcodeBuild = "9F1027a";
+				} else {
+					Log.LogWarning ("Can only fake the watchOS 4.3 SDK when building for watchOS.");
+				}
+			}
+
+			Log.LogWarning($"UseFakeWatchOS4_3Sdk: {UseFakeWatchOS4_3Sdk} Framework: {Framework}");
+
+			SetValueIfNotNull (plist, "DTCompiler", dtCompiler);
+			SetValueIfNotNull (plist, "DTPlatformBuild", dtPlatformBuild);
+			SetValueIfNotNull (plist, "DTSDKBuild", dtSDKBuild);
+			plist.SetIfNotPresent ("DTPlatformName", dtPlatformName);
+			SetValueIfNotNull (plist, "DTPlatformVersion", dtPlatformVersion);
+			SetValue (plist, "DTSDKName", dtSDKName);
+			SetValueIfNotNull (plist, "DTXcode", dtXcode);
+			SetValueIfNotNull (plist, "DTXcodeBuild", dtXcodeBuild);
 
 			SetDeviceFamily (plist);
 
@@ -233,6 +273,13 @@ namespace Xamarin.iOS.Tasks
 			plist.Save (CompiledAppManifest.ItemSpec, true, true);
 
 			return !Log.HasLoggedErrors;
+		}
+
+		void SetValueIfNotNull (PDictionary dict, string key, string value)
+		{
+			if (value == null)
+				return;
+			SetValue (dict, key, value);
 		}
 
 		void SetRequiredArchitectures (PDictionary plist)

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileAppManifestTaskBase.cs
@@ -206,8 +206,6 @@ namespace Xamarin.iOS.Tasks
 				}
 			}
 
-			Log.LogWarning($"UseFakeWatchOS4_3Sdk: {UseFakeWatchOS4_3Sdk} Framework: {Framework}");
-
 			SetValueIfNotNull (plist, "DTCompiler", dtCompiler);
 			SetValueIfNotNull (plist, "DTPlatformBuild", dtPlatformBuild);
 			SetValueIfNotNull (plist, "DTSDKBuild", dtSDKBuild);

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS.AppExtension.Common.targets
@@ -24,6 +24,8 @@ Copyright (C) 2015-2016 Xamarin. All rights reserved.
 		<!-- This must be set before importing Microsoft.CSharp.targets -->
 		<!-- See Xamarin.iOS.AppExtension.CSharp.targets for a detailed explanation of this variable -->
 		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+
+		<UseFakeWatchOS4_3Sdk Condition="'$(UseFakeWatchOS4_3Sdk)' == ''">True</UseFakeWatchOS4_3Sdk>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)..\iOS\Xamarin.iOS.Common.targets" />

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -701,6 +701,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			SdkPlatform="$(_SdkPlatform)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
 			DebugIPAddresses="$(_DebugIPAddresses)"
+			UseFakeWatchOS4_3Sdk="$(UseFakeWatchOS4_3Sdk)"
 			>
 		</CompileAppManifest>
 


### PR DESCRIPTION
Backport of #4873.

/cc @rolfbjarne 

Description:
The App Store requires the arm64_32 architecture when building with Xcode 10.

Unfortunately we don't support arm64_32 quite yet, so we need to make the App
Store think watch extensions were built with Xcode 9.4 in order to pass
validation.

Fixes https://github.com/xamarin/xamarin-macios/issues/4810.