### PR TITLE
[src] Change argument order to csc to fix compiler warning.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -485,7 +485,8 @@ $(MAC_BUILD_DIR)/$(1)/$(2): $(MAC_BUILD_DIR)/$(3)/generated-sources $(MAC_SOURCE
 		-nowarn:3021,1635,612,618,0219,0414,$(MAC_WARNINGS_TO_FIX) \
 		$$(MAC_CSC_FLAGS_XM) \
 		$(4) \
-		@$$< $$(MAC_SOURCES)
+		$$(MAC_SOURCES) \
+		@$$<
 
 $(MAC_BUILD_DIR)/$(1)/$(2:.dll=.pdb): $(MAC_BUILD_DIR)/$(1)/$(2)
 


### PR DESCRIPTION
Fixes these warnings:

    build/mac/mobile/Foundation/NSUrl.g.cs(41,30): warning CS0660: 'NSUrl' defines operator == or operator != but does not override Object.Equals(object o)
    build/mac/mobile/Foundation/NSUrl.g.cs(41,30): warning CS0661: 'NSUrl' defines operator == or operator != but does not override Object.GetHashCode()
    build/mac/full/Foundation/NSUrl.g.cs(41,30): warning CS0660: 'NSUrl' defines operator == or operator != but does not override Object.Equals(object o)
    build/mac/full/Foundation/NSUrl.g.cs(41,30): warning CS0661: 'NSUrl' defines operator == or operator != but does not override Object.GetHashCode()
    build/mac/full/Foundation/NSUrl.g.cs(41,30): warning CS0660: 'NSUrl' defines operator == or operator != but does not override Object.Equals(object o)
    build/mac/full/Foundation/NSUrl.g.cs(41,30): warning CS0661: 'NSUrl' defines operator == or operator != but does not override Object.GetHashCode()
    build/mac/mobile/Foundation/NSUrl.g.cs(41,30): warning CS0660: 'NSUrl' defines operator == or operator != but does not override Object.Equals(object o)
    build/mac/mobile/Foundation/NSUrl.g.cs(41,30): warning CS0661: 'NSUrl' defines operator == or operator != but does not override Object.GetHashCode()

We've already ignored these warnings in NSUrl.cs [1], but since NSUrl is a
partial class, and the warning applies to the class, it seems the order the
source files are passed to csc determines whether csc reports the warning or
not.

[1] https://github.com/xamarin/xamarin-macios/blob/1f5ba0b5c0fa3ac472dfbc1763aa4f52fbd4fd57/src/Foundation/NSUrl.cs#L30-L31