### PR TITLE
[install-source] Quiet warning.

### DIFF
--- a/tools/install-source/Program.cs
+++ b/tools/install-source/Program.cs
@@ -223,7 +223,8 @@ public class ListSourceFiles {
 			var targetDir = Path.GetDirectoryName (target);
 
 			if (String.IsNullOrEmpty (targetDir)) {
-				Console.WriteLine ($"Got empty dir for {target}");
+				if (verbose)
+					Console.WriteLine ($"Got empty dir for {target}");
 				continue;
 			}
 			


### PR DESCRIPTION
The line "Got empty dir for " is printed 6000 times when building on the bots;
this change will quiet this warning.