### PR TITLE
Add xtro test for [Deprecated] attributes and fix up usages

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -3731,6 +3731,7 @@ namespace AppKit {
 		NSColor SelectedControl { get; }
 
 		[Static]
+		[Deprecated (PlatformName.MacOSX)]
 		[Export ("secondarySelectedControlColor")]
 		NSColor SecondarySelectedControl { get; }
 
@@ -3821,6 +3822,7 @@ namespace AppKit {
 		NSColor HeaderText { get; }
 
 		[Static]
+		[Deprecated (PlatformName.MacOSX)]
 		[Export ("alternateSelectedControlColor")]
 		NSColor AlternateSelectedControl { get; }
 
@@ -3829,6 +3831,7 @@ namespace AppKit {
 		NSColor AlternateSelectedControlText { get; }
 
 		[Static]
+		[Advice ("Use 'AlternatingContentBackgroundColors instead.")]
 		[Export ("controlAlternatingRowBackgroundColors")]
 		NSColor [] ControlAlternatingRowBackgroundColors ();
 
@@ -5757,6 +5760,7 @@ namespace AppKit {
 		[Export ("runModalOpenPanel:forTypes:")]
 		nint RunModalOpenPanel (NSOpenPanel openPanel, string [] types);
 
+		[Deprecated (PlatformName.MacOSX, 10, 7, message: "Use 'OpenDocument (NSUrl, bool, OpenDocumentCompletionHandler)' instead.")]
 		[Export ("openDocumentWithContentsOfURL:display:error:")]
 		NSObject OpenDocument (NSUrl url, bool displayDocument, out NSError outError);
 
@@ -5767,6 +5771,7 @@ namespace AppKit {
 		[Export ("makeDocumentWithContentsOfURL:ofType:error:")]
 		NSObject MakeDocument (NSUrl url, string typeName, out NSError outError);
 
+		[Deprecated (PlatformName.MacOSX, 10, 7, message: "Use 'ReopenDocumentForUrl (NSUrl, NSUrl, bool, OpenDocumentCompletionHandler)' instead.")]
 		[Export ("reopenDocumentForURL:withContentsOfURL:error:")]
 		bool ReopenDocument (NSUrl url, NSUrl contentsUrl, out NSError outError);
 
@@ -6790,6 +6795,7 @@ namespace AppKit {
 		[Export ("sendAction")]
 		bool SendAction { get; }
 
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Export ("delegate", ArgumentSemantic.Assign)][NullAllowed]
 		NSObject WeakDelegate { get; set; } 
 
@@ -6802,24 +6808,31 @@ namespace AppKit {
 		[Export ("convertAttributes:")]
 		NSDictionary ConvertAttributes (NSDictionary attributes);
 
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSFontDescriptor.MatchingFontDescriptors' instead.")]
 		[Export ("availableFontNamesMatchingFontDescriptor:")]
 		string [] AvailableFontNamesMatchingFontDescriptor (NSFontDescriptor descriptor);
 
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSFontCollection.AllFontCollectionNames' instead.")]
 		[Export ("collectionNames")]
 		string [] CollectionNames { get; }
 
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSFontCollection.GetMatchingDescriptors ()' instead.")]
 		[Export ("fontDescriptorsInCollection:")]
 		NSArray FontDescriptorsInCollection (string collectionNames);
 
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSFontCollection.ShowFontCollection (NSFontCollection, string, NSFontCollectionVisibility, out NSError)' instead.")]
 		[Export ("addCollection:options:")]
 		bool AddCollection (string collectionName, NSFontCollectionOptions collectionOptions);
 
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'HideFontCollection (string, NSFontCollectionVisibility, out NSError)' instead.")]
 		[Export ("removeCollection:")]
 		bool RemoveCollection (string collectionName);
 
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSMutableFontCollection AddQueryForDescriptors' instead.")]
 		[Export ("addFontDescriptors:toCollection:")]
 		void AddFontDescriptors (NSFontDescriptor [] descriptors, string collectionName);
 
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSMutableFontCollection RemoveQueryForDescriptors' instead.")]
 		[Export ("removeFontDescriptor:fromCollection:")]
 		void RemoveFontDescriptor (NSFontDescriptor descriptor, string collection);
 
@@ -7998,13 +8011,16 @@ namespace AppKit {
 		[Export ("size")]
 		CGSize Size { get; }
 
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Static]
 		[Export ("menuZone")]
 		NSZone MenuZone { get; }
 
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Export ("helpRequested:")]
 		void HelpRequested (NSEvent eventPtr);
 
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Export ("isTornOff")]
 		bool IsTornOff { get; }
 
@@ -8042,6 +8058,7 @@ namespace AppKit {
 		[Export ("showsStateColumn")]
 		bool ShowsStateColumn { get; set; }
 
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Export ("menuChangedMessagesEnabled")]
 		bool MenuChangedMessagesEnabled { get; set; }
 
@@ -11919,30 +11936,39 @@ namespace AppKit {
 		[Export ("pageSizeForPaper:")]
 		CGSize PageSizeForPaper (string paperName); 
 
+		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		[Export ("statusForTable:")]
 		NSPrinterTableStatus StatusForTable (string tableName);
 
+		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		[Export ("isKey:inTable:")]
 		bool IsKeyInTable (string key, string table);
 
+		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		[Export ("booleanForKey:inTable:")]
 		bool BooleanForKey (string key, string table);
 
+		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		[Export ("floatForKey:inTable:")]
 		float /* float, not CGFloat */ FloatForKey (string key, string table);
 
+		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		[Export ("intForKey:inTable:")]
 		int /* int, not NSInteger */ IntForKey (string key, string table);
 
+		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		[Export ("rectForKey:inTable:")]
 		CGRect RectForKey (string key, string table);
 
+		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		[Export ("sizeForKey:inTable:")]
 		CGSize SizeForKey (string key, string table);
 
+		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		[Export ("stringForKey:inTable:")]
 		string StringForKey (string key, string table);
 
+		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		[Export ("stringListForKey:inTable:")]
 		string [] StringListForKey (string key, string table);
 
@@ -14315,6 +14341,7 @@ namespace AppKit {
 		string PlaybackDeviceID { get; set; }
 
 		// FIXME: Poor docs, no type defined for the array elements
+		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		[Export ("channelMapping")]
 		NSObject ChannelMapping { get; set; }
 	}
@@ -15941,6 +15968,7 @@ namespace AppKit {
 		[Export ("drawPageBorderWithSize:")]
 		void DrawPageBorder (CGSize borderSize);
 		
+		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Never called.")]
 		[Export ("drawSheetBorderWithSize:")]
 		void DrawSheetBorder (CGSize borderSize);
 		
@@ -17146,6 +17174,7 @@ namespace AppKit {
 		[Export ("tableView:acceptDrop:row:dropOperation:")]
 		bool AcceptDrop (NSTableView tableView, [Protocolize (4)] NSDraggingInfo info, nint row, NSTableViewDropOperation dropOperation);
 	
+		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'NSFilePromiseReceiver' instead.")]
 		[Export ("tableView:namesOfPromisedFilesDroppedAtDestination:forDraggedRowsWithIndexes:")]
 		string [] FilesDropped (NSTableView tableView, NSUrl dropDestination, NSIndexSet indexSet );
 
@@ -18491,6 +18520,7 @@ namespace AppKit {
 		[Export ("isSimpleRectangularTextContainer")]
 		bool IsSimpleRectangularTextContainer { get; }
 
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Export ("containsPoint:")]
 		bool ContainsPoint (CGPoint point);
 
@@ -18640,6 +18670,7 @@ namespace AppKit {
 	interface NSTextInput
 	{
 		[Abstract]
+		[Deprecated (PlatformName.MacOSX, 10, 6)]
 		[Export ("insertText:")]
 		void InsertText (NSObject insertString);
 
@@ -18755,6 +18786,7 @@ namespace AppKit {
 		[Export ("lowerBaseline:")]
 		void LowerBaseline (NSObject sender);
 
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use unicode characters via the character palette.")]
 		[Export ("toggleTraditionalCharacterShape:")]
 		void ToggleTraditionalCharacterShape (NSObject sender);
 
@@ -20339,6 +20371,7 @@ namespace AppKit {
 		[Export ("gState")]
 		nint GState ();
 	
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("setOneShot:")]
 		void SetOneShot (bool flag);
 	
@@ -20414,9 +20447,11 @@ namespace AppKit {
 		[Export ("sharingType")]
 		NSWindowSharingType SharingType  { get; set; }
 	
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("preferredBackingLocation")]
 		NSWindowBackingLocation PreferredBackingLocation  { get; set; }
 	
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("backingLocation")]
 		NSWindowBackingLocation BackingLocation { get; }
 	
@@ -21241,6 +21276,7 @@ namespace AppKit {
 		[Export ("openFile:withApplication:andDeactivate:"), ThreadSafe]
 		bool OpenFile (string fullPath, [NullAllowed] string appName, bool deactivate);
 		
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSWorkspace.OpenUrl' instead.")]
 		[Export ("openFile:fromImage:at:inView:"), ThreadSafe]
 		bool OpenFile (string fullPath, NSImage anImage, CGPoint point, NSView aView);
 		
@@ -21304,6 +21340,7 @@ namespace AppKit {
 		[Export ("getFileSystemInfoForPath:isRemovable:isWritable:isUnmountable:description:type:"), ThreadSafe]
 		bool GetFileSystemInfo (string fullPath, out bool removableFlag, out bool writableFlag, out bool unmountableFlag, out string description, out string fileSystemType);
 		
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Export ("performFileOperation:source:destination:files:tag:"), ThreadSafe]
 		bool PerformFileOperation (NSString workspaceOperation, string source, string destination, string[] files, out nint tag);
 		
@@ -21319,9 +21356,11 @@ namespace AppKit {
 		[Export ("hideOtherApplications")]
 		void HideOtherApplications ();
 		
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Export ("mountedLocalVolumePaths")]
 		string[] MountedLocalVolumePaths { get; }
 		
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Export ("mountedRemovableMedia")]
 		string[] MountedRemovableMedia {  get; }
 		
@@ -21341,9 +21380,11 @@ namespace AppKit {
 		[Export ("openURLs:withAppBundleIdentifier:options:additionalEventParamDescriptor:launchIdentifiers:"), ThreadSafe]
 		bool _OpenUrls (NSUrl[] urls, string bundleIdentifier, NSWorkspaceLaunchOptions options, NSAppleEventDescriptor descriptor, [NullAllowed] string[] identifiers);
 		
+		[Deprecated (PlatformName.MacOSX, 10, 7, message: "Use 'NSWorkspace.RunningApplications' instead.")]
 		[Export ("launchedApplications")]
 		NSDictionary [] LaunchedApplications { get; }
 		
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSWorkspace.FrontmostApplication' instead.")]
 		[Export ("activeApplication")]
 		NSDictionary ActiveApplication { get; }
 		
@@ -22262,6 +22303,7 @@ namespace AppKit {
 		NSRange GlyphRangeForCharacterRange (NSRange charRange, out NSRange actualCharRange);
 
 		// TODO: could use a higher level API
+		[Deprecated (PlatformName.MacOSX, 10, 13)]
 		[Export ("getGlyphsInRange:glyphs:characterIndexes:glyphInscriptions:elasticBits:bidiLevels:")]
 		nuint GetGlyphsInRange (NSRange glyphsRange, IntPtr glyphBuffer, IntPtr charIndexBuffer, IntPtr inscribeBuffer, IntPtr elasticBuffer, IntPtr bidiLevelBuffer);
 

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -3831,7 +3831,7 @@ namespace AppKit {
 		NSColor AlternateSelectedControlText { get; }
 
 		[Static]
-		[Advice ("Use 'AlternatingContentBackgroundColors instead.")]
+		[Advice ("Use 'AlternatingContentBackgroundColors' instead.")]
 		[Export ("controlAlternatingRowBackgroundColors")]
 		NSColor [] ControlAlternatingRowBackgroundColors ();
 
@@ -5771,7 +5771,7 @@ namespace AppKit {
 		[Export ("makeDocumentWithContentsOfURL:ofType:error:")]
 		NSObject MakeDocument (NSUrl url, string typeName, out NSError outError);
 
-		[Deprecated (PlatformName.MacOSX, 10, 7, message: "Use 'ReopenDocumentForUrl (NSUrl, NSUrl, bool, OpenDocumentCompletionHandler)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 7, message: "Use 'NSDocumentController.ReopenDocumentForUrl (NSUrl, NSUrl, bool, OpenDocumentCompletionHandler)' instead.")]
 		[Export ("reopenDocumentForURL:withContentsOfURL:error:")]
 		bool ReopenDocument (NSUrl url, NSUrl contentsUrl, out NSError outError);
 
@@ -6828,11 +6828,11 @@ namespace AppKit {
 		[Export ("removeCollection:")]
 		bool RemoveCollection (string collectionName);
 
-		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSMutableFontCollection AddQueryForDescriptors' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSMutableFontCollection.AddQueryForDescriptors' instead.")]
 		[Export ("addFontDescriptors:toCollection:")]
 		void AddFontDescriptors (NSFontDescriptor [] descriptors, string collectionName);
 
-		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSMutableFontCollection RemoveQueryForDescriptors' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSMutableFontCollection.RemoveQueryForDescriptors' instead.")]
 		[Export ("removeFontDescriptor:fromCollection:")]
 		void RemoveFontDescriptor (NSFontDescriptor descriptor, string collection);
 
@@ -14340,7 +14340,6 @@ namespace AppKit {
 		[Export ("playbackDeviceIdentifier")]
 		string PlaybackDeviceID { get; set; }
 
-		// FIXME: Poor docs, no type defined for the array elements
 		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		[Export ("channelMapping")]
 		NSObject ChannelMapping { get; set; }

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -3731,7 +3731,7 @@ namespace AppKit {
 		NSColor SelectedControl { get; }
 
 		[Static]
-		[Deprecated (PlatformName.MacOSX)]
+		[Deprecated (PlatformName.MacOSX, message: "Use 'SelectedContentBackgroundColor' instead.")]
 		[Export ("secondarySelectedControlColor")]
 		NSColor SecondarySelectedControl { get; }
 
@@ -3822,7 +3822,7 @@ namespace AppKit {
 		NSColor HeaderText { get; }
 
 		[Static]
-		[Deprecated (PlatformName.MacOSX)]
+		[Deprecated (PlatformName.MacOSX, message : "Use 'SelectedContentBackgroundColor' instead.")]
 		[Export ("alternateSelectedControlColor")]
 		NSColor AlternateSelectedControl { get; }
 

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -1827,6 +1827,7 @@ namespace AVFoundation {
 		AVAudioSession SharedInstance ();
 	
 		[NoWatch]
+		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use 'AVAudioSession.Notification.Observe*' methods instead.")]
 		[Export ("delegate", ArgumentSemantic.Assign)][NullAllowed]
 		[NoTV]
 		NSObject WeakDelegate { get; set;  }
@@ -2339,6 +2340,7 @@ namespace AVFoundation {
 		AVAudioSessionRouteDescription PreviousRoute { get; }
 	}
 	
+	[Deprecated (PlatformName.iOS, 6, 0)]
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
@@ -3989,7 +3991,8 @@ namespace AVFoundation {
 		void CancelWriting ();
 
 		[Export ("finishWriting")]
-		[Availability (Deprecated = Platform.iOS_6_0, Message = "Use the asynchronous 'FinishWriting (NSAction completionHandler)' instead.")]
+		[Deprecated (PlatformName.iOS, 6, 0, message: "Use the asynchronous 'FinishWriting (NSAction completionHandler)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 9, message: "Use the asynchronous 'FinishWriting (NSAction completionHandler)' instead.")]
 		bool FinishWriting ();
 
 		[Mac (10,9)]
@@ -9412,11 +9415,13 @@ namespace AVFoundation {
 		[Export ("livePhotoAutoTrimmingEnabled")]
 		bool IsLivePhotoAutoTrimmingEnabled { [Bind ("isLivePhotoAutoTrimmingEnabled")] get; set; }
 
+		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'AVCapturePhoto.FileDataRepresentation' instead.")]
 		[Static]
 		[Export ("JPEGPhotoDataRepresentationForJPEGSampleBuffer:previewPhotoSampleBuffer:")]
 		[return: NullAllowed]
 		NSData GetJpegPhotoDataRepresentation (CMSampleBuffer JPEGSampleBuffer, [NullAllowed] CMSampleBuffer previewPhotoSampleBuffer);
 
+		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'AVCapturePhoto.FileDataRepresentation' instead.")]
 		[Static]
 		[Export ("DNGPhotoDataRepresentationForRawSampleBuffer:previewPhotoSampleBuffer:")]
 		[return: NullAllowed]
@@ -10298,6 +10303,8 @@ namespace AVFoundation {
 		[Export ("actionAtItemEnd")]
 		AVPlayerActionAtItemEnd ActionAtItemEnd { get; set;  }
 
+		[Deprecated (PlatformName.MacOSX, 10, 13)]
+		[Deprecated (PlatformName.iOS, 11, 0)]
 		[Export ("closedCaptionDisplayEnabled")]
 		bool ClosedCaptionDisplayEnabled { [Bind ("isClosedCaptionDisplayEnabled")] get; set;  }
 
@@ -10713,12 +10720,18 @@ namespace AVFoundation {
 		[Export ("stepByCount:")]
 		void StepByCount (nint stepCount);
 
+		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'Seek (NSDate, AVCompletion)' instead.")]
+		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'Seek (NSDate, AVCompletion)' instead.")]
 		[Export ("seekToDate:")]
 		bool Seek (NSDate date);
 
+		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'Seek (CMTime, AVCompletion)' instead.")]
+		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'Seek (CMTime, AVCompletion)' instead.")]
 		[Export ("seekToTime:")]
 		void Seek (CMTime time);
 		
+		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'Seek (CMTime, CMTime, CMTime, AVCompletion)' instead.")]
+		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'Seek (CMTime, CMTime, CMTime, AVCompletion)' instead.")]
 		[Export ("seekToTime:toleranceBefore:toleranceAfter:")]
 		void Seek (CMTime time, CMTime toleranceBefore, CMTime toleranceAfter);
 
@@ -10775,6 +10788,8 @@ namespace AVFoundation {
 
 		[return: NullAllowed]
 		[Mac (10, 8)]
+		[Deprecated (PlatformName.iOS, 11, 0, message: "Use 'CurrentMediaSelection' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use 'CurrentMediaSelection' instead.")]
 		[Export ("selectedMediaOptionInMediaSelectionGroup:")]
 		AVMediaSelectionOption SelectedMediaOption (AVMediaSelectionGroup inMediaSelectionGroup);
 
@@ -12892,6 +12907,7 @@ namespace AVFoundation {
 		NSData FileDataRepresentation { get; }
 
 		[iOS (11,0)]
+		[Deprecated (PlatformName.iOS, 12, 0, message: "Use 'GetFileDataRepresentation' instead.")]
 		[Export ("fileDataRepresentationWithReplacementMetadata:replacementEmbeddedThumbnailPhotoFormat:replacementEmbeddedThumbnailPixelBuffer:replacementDepthData:")]
 		[return: NullAllowed]
 		NSData GetFileDataRepresentation ([NullAllowed] NSDictionary<NSString, NSObject> replacementMetadata, [NullAllowed] NSDictionary<NSString, NSObject> replacementEmbeddedThumbnailPhotoFormat, [NullAllowed] CVPixelBuffer replacementEmbeddedThumbnailPixelBuffer, [NullAllowed] AVDepthData replacementDepthData);

--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -501,7 +501,8 @@ namespace CoreBluetooth {
 	[Model]
 	[Protocol]
 	interface CBPeripheralDelegate {
-		[Availability (Deprecated=Platform.iOS_8_0, Message="Use 'RssiRead' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'RssiRead' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'RssiRead' instead.")]
 		[Export ("peripheralDidUpdateRSSI:error:"), EventArgs ("NSError", true)]
 		void RssiUpdated (CBPeripheral peripheral, NSError error);
 
@@ -636,6 +637,8 @@ namespace CoreBluetooth {
 		CBUUID FromData (NSData theData);
 
 		[Availability (Deprecated = Platform.iOS_9_0)]
+		[Deprecated (PlatformName.MacOSX, 10, 13)]
+		[Deprecated (PlatformName.iOS, 9, 0)]
 		[NoWatch]
 		[Static]
 		[Export ("UUIDWithCFUUID:")]

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -1817,8 +1817,8 @@ namespace CoreData
 		[return: NullAllowed]
 		NSDictionary<NSString, NSObject> GetMetadata (string storeType, NSUrl url, [NullAllowed] NSDictionary options, out NSError error);
 
-		[Deprecated (PlatformName.iOS, 9, 0, message:"Use the method that takes an out NSError parameter.")]
-		[Deprecated (PlatformName.MacOSX, 10, 11, message:"Use the method that takes an out NSError parameter.")]
+		[Deprecated (PlatformName.iOS, 9, 0, message : "Use the method that takes an 'out NSError' parameter.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use the method that takes an 'out NSError' parameter.")]
 		[Static, Export ("setMetadata:forPersistentStoreOfType:URL:error:")]
 		bool SetMetadata (NSDictionary metadata, NSString storeType, NSUrl url, out NSError error);
 		

--- a/src/coredata.cs
+++ b/src/coredata.cs
@@ -313,10 +313,10 @@ namespace CoreData
 
 		[NullAllowed] // by default this property is null
 		[Export ("compoundIndexes", ArgumentSemantic.Retain)]
-		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'NSEntityDescription.Indexes' instead.")]
 		[Mac (10, 7)]
+		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'NSEntityDescription.Indexes' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'NSEntityDescription.Indexes' instead.")]
-		[Deprecated (PlatformName.TvOS, 9, 0, message : "Use 'NSEntityDescription.Indexes' instead.")]
+		[Deprecated (PlatformName.TvOS, 11, 0, message : "Use 'NSEntityDescription.Indexes' instead.")]
 		[Deprecated (PlatformName.WatchOS, 4, 0, message : "Use 'NSEntityDescription.Indexes' instead.")]
 		NSPropertyDescription [] CompoundIndexes { get; set; }
 
@@ -909,6 +909,7 @@ namespace CoreData
 	}
 	
 	[BaseType (typeof (NSObject))]
+	[DisableDefaultCtor]
 	interface NSManagedObjectContext : NSCoding
 #if !WATCH && !TVOS
 	, NSLocking
@@ -917,7 +918,11 @@ namespace CoreData
 	, NSEditor, NSEditorRegistration
 #endif
 	{
-
+		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'NSManagedObjectContext (NSManagedObjectContextConcurrencyType)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSManagedObjectContext (NSManagedObjectContextConcurrencyType)' instead.")]
+		[Export ("init")]
+		IntPtr Constructor ();
+		
 		[NullAllowed] // by default this property is null
 		[Export ("persistentStoreCoordinator", ArgumentSemantic.Retain)]
 		NSPersistentStoreCoordinator PersistentStoreCoordinator { get; set; }
@@ -1812,7 +1817,8 @@ namespace CoreData
 		[return: NullAllowed]
 		NSDictionary<NSString, NSObject> GetMetadata (string storeType, NSUrl url, [NullAllowed] NSDictionary options, out NSError error);
 
-		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use the method that takes an out NSError parameter.")]
+		[Deprecated (PlatformName.iOS, 9, 0, message:"Use the method that takes an out NSError parameter.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message:"Use the method that takes an out NSError parameter.")]
 		[Static, Export ("setMetadata:forPersistentStoreOfType:URL:error:")]
 		bool SetMetadata (NSDictionary metadata, NSString storeType, NSUrl url, out NSError error);
 		
@@ -1878,16 +1884,19 @@ namespace CoreData
 		NSManagedObjectID ManagedObjectIDForURIRepresentation (NSUrl url);
 
 #if !WATCH && !TVOS
-		[Availability (Deprecated = Platform.iOS_8_0, Message="Use 'PerformAndWait' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'PerformAndWait' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message: "Use 'PerformAndWait' instead.")]
 		[Export ("lock")]
 		new void Lock ();
 
-		[Availability (Deprecated = Platform.iOS_8_0, Message="Use 'PerformAndWait' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'PerformAndWait' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message: "Use 'PerformAndWait' instead.")]
 		[Export ("unlock")]
 		new void Unlock ();
 
 		[NoTV]
-		[Availability (Deprecated = Platform.iOS_8_0, Message="Use 'Perform' instead.")]
+		[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'Perform' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message: "Use 'Perform' instead.")]
 		[Export ("tryLock")]
 		bool TryLock { get; }
 #endif // !WATCH && !TVOS
@@ -2020,7 +2029,8 @@ namespace CoreData
 		[NoWatch][NoTV]
 		[iOS (7,0), Mac (10, 9)]
 		[Static]
-		[Availability (Deprecated = Platform.iOS_10_0, Message = "Please see the release notes and Core Data documentation.")]
+		[Deprecated (PlatformName.iOS, 10, 0, message: "Please see the release notes and Core Data documentation.")]
+		[Deprecated (PlatformName.MacOSX, 10, 12, message: "Please see the release notes and Core Data documentation.")]
 		[Export ("removeUbiquitousContentAndPersistentStoreAtURL:options:error:")]
 		bool RemoveUbiquitousContentAndPersistentStore (NSUrl storeUrl, NSDictionary options, out NSError error);
 
@@ -2189,7 +2199,7 @@ namespace CoreData
 		[Export ("indexed")]
 		[Deprecated (PlatformName.iOS, 11, 0, message : "Use 'NSEntityDescription.Indexes' instead.")]
 		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'NSEntityDescription.Indexes' instead.")]
-		[Deprecated (PlatformName.TvOS, 9, 0, message : "Use 'NSEntityDescription.Indexes' instead.")]
+		[Deprecated (PlatformName.TvOS, 11, 0, message : "Use 'NSEntityDescription.Indexes' instead.")]
 		[Deprecated (PlatformName.WatchOS, 4, 0, message : "Use 'NSEntityDescription.Indexes' instead.")]
 		bool Indexed { [Bind ("isIndexed")] get; set; }
 

--- a/src/coreimage.cs
+++ b/src/coreimage.cs
@@ -248,10 +248,12 @@ namespace CoreImage {
 		CIContext Create ();
 
 #if !MONOMAC
+		[Deprecated (PlatformName.iOS, 12, 0)]
 		[Static]
 		[Export ("contextWithEAGLContext:")]
 		CIContext FromContext (EAGLContext eaglContext);
 
+		[Deprecated (PlatformName.iOS, 12, 0)]
 		[Static]
 		[Export ("contextWithEAGLContext:options:")]
 		CIContext FromContext (EAGLContext eaglContext, [NullAllowed] NSDictionary dictionary);
@@ -359,6 +361,7 @@ namespace CoreImage {
 		int OfflineGPUCount { get; }
 
 		[Mac(10,11)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("contextForOfflineGPUAtIndex:")]
 		[Static]
 		CIContext FromOfflineGpu (int gpuIndex);
@@ -1347,10 +1350,12 @@ namespace CoreImage {
 		CIImage FromCGImage (CGImage image, [NullAllowed] CIImageInitializationOptionsWithMetadata options);
 
 #if MONOMAC
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Static]
 		[Export ("imageWithCGLayer:")]
 		CIImage FromLayer (CGLayer layer);
 
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Static]
 		[Export ("imageWithCGLayer:options:")]
 		CIImage FromLayer (CGLayer layer, NSDictionary options);
@@ -1366,6 +1371,8 @@ namespace CoreImage {
 		CIImage FromData (NSData bitmapData, nint bytesPerRow, CGSize size, int /* CIFormat = int */ pixelFormat, [NullAllowed] CGColorSpace colorSpace);
 
 		[iOS (6,0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Static]
 		[Export ("imageWithTexture:size:flipped:colorSpace:")]
 		CIImage ImageWithTexture (uint /* unsigned int */ glTextureName, CGSize size, bool flipped, [NullAllowed] CGColorSpace colorspace);
@@ -1481,9 +1488,11 @@ namespace CoreImage {
 		IntPtr Constructor (CGImage image, [NullAllowed] CIImageInitializationOptionsWithMetadata options);
 
 #if MONOMAC
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'CIImage (CGImage)' instead.")]
 		[Export ("initWithCGLayer:")]
 		IntPtr Constructor (CGLayer layer);
 
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'CIImage (CGImage)' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		[Export ("initWithCGLayer:options:")]
 		IntPtr Constructor (CGLayer layer, [NullAllowed] NSDictionary d);
@@ -1505,6 +1514,8 @@ namespace CoreImage {
 		IntPtr Constructor (NSData d, nint bytesPerRow, CGSize size, int /* CIFormat = int */ pixelFormat, [NullAllowed] CGColorSpace colorSpace);
 
 		[iOS (6,0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("initWithTexture:size:flipped:colorSpace:")]
 		IntPtr Constructor (int /* unsigned int */ glTextureName, CGSize size, bool flipped, [NullAllowed] CGColorSpace colorSpace);
 
@@ -2079,9 +2090,13 @@ namespace CoreImage {
 		[Static, Export ("kernelsWithString:")]
 		CIKernel [] FromPrograms (string coreImageShaderProgram);
 #endif
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Static, Export ("kernelsWithString:")]
 		CIKernel [] FromProgramMultiple (string coreImageShaderProgram);
 
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Static, Export ("kernelWithString:")]
 		CIKernel FromProgramSingle (string coreImageShaderProgram);
 
@@ -2122,6 +2137,8 @@ namespace CoreImage {
 
 		// Note: the API is supported in iOS 8, but with iOS 9, they guarantee
 		// a more derived result
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[New, Static, Export ("kernelWithString:")]
 		CIColorKernel FromProgramSingle (string coreImageShaderProgram);
 	}
@@ -2135,6 +2152,8 @@ namespace CoreImage {
 
 		// Note: the API is supported in iOS 8, but with iOS 9, they guarantee
 		// a more derived result
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[New, Static, Export ("kernelWithString:")]
 		CIWarpKernel FromProgramSingle (string coreImageShaderProgram);
 	}
@@ -2205,6 +2224,7 @@ namespace CoreImage {
 		[Export ("loadNonExecutablePlugIns")]
 		void LoadNonExecutablePlugIns ();
 
+		[Deprecated (PlatformName.MacOSX, 10, 7)]
 		[Static]
 		[Export ("loadPlugIn:allowNonExecutable:")]
 		void LoadPlugIn (NSUrl pluginUrl, bool allowNonExecutable);
@@ -5200,6 +5220,8 @@ namespace CoreImage {
 	[DisableDefaultCtor] // Handle is nil for `init`
 	interface CIBlendKernel {
 
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Static]
 		[Export ("kernelWithString:")]
 		[return: NullAllowed]

--- a/src/coretelephony.cs
+++ b/src/coretelephony.cs
@@ -151,6 +151,7 @@ namespace CoreTelephony {
 	[iOS (7,0)]
 	partial interface CTSubscriber {
 		[iOS (7,0), Export ("carrierToken")]
+		[Deprecated (PlatformName.iOS, 11, 0)]
 		NSData CarrierToken { get; }
 	}
 

--- a/src/corewlan.cs
+++ b/src/corewlan.cs
@@ -376,6 +376,7 @@ namespace CoreWlan {
 		[Internal]
 		NSSet _InterfaceNames { get; }
 		 
+		[Deprecated (PlatformName.MacOSX, 10, 10, message: "Use `CWWiFiClient.FromName` instead.")]
 		[Export ("initWithInterfaceName:")]
 		IntPtr Constructor ([NullAllowed]string name);
 		 

--- a/src/corewlan.cs
+++ b/src/corewlan.cs
@@ -376,7 +376,7 @@ namespace CoreWlan {
 		[Internal]
 		NSSet _InterfaceNames { get; }
 		 
-		[Deprecated (PlatformName.MacOSX, 10, 10, message: "Use `CWWiFiClient.FromName` instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message: "Use 'CWWiFiClient.FromName' instead.")]
 		[Export ("initWithInterfaceName:")]
 		IntPtr Constructor ([NullAllowed]string name);
 		 

--- a/src/eventkit.cs
+++ b/src/eventkit.cs
@@ -223,6 +223,7 @@ namespace EventKit {
 		[Export ("soundName")]
 		string SoundName { get; set; }
 
+		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		[Export ("url", ArgumentSemantic.Copy)]
 		NSUrl Url { get; set; }
 #endif
@@ -633,6 +634,7 @@ namespace EventKit {
 		bool SaveReminder (EKReminder reminder, bool commit, out NSError error);
 
 #if MONOMAC
+		[Deprecated (PlatformName.MacOSX, 10, 9)]
 		[Export ("initWithAccessToEntityTypes:")]
 		IntPtr Constructor (EKEntityMask accessToEntityTypes);
 

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -415,9 +415,11 @@ namespace Foundation
 		[Wrap ("this (data, options == null ? null : options.Dictionary, out resultDocumentAttributes, out error)")]
 		IntPtr Constructor (NSData data, NSAttributedStringDocumentAttributes options, out NSDictionary resultDocumentAttributes, out NSError error);
 
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSAttributedString (NSUrl, NSDictionary, out NSDictionary, ref NSError)' instead.")]
 		[Export ("initWithPath:documentAttributes:")]
 		IntPtr Constructor (string path, out NSDictionary resultDocumentAttributes);
 
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSAttributedString (NSUrl, NSDictionary, out NSDictionary, ref NSError)' instead.")]
 		[Export ("initWithURL:documentAttributes:")]
 		IntPtr Constructor (NSUrl url, out NSDictionary resultDocumentAttributes);
 
@@ -460,6 +462,7 @@ namespace Foundation
 		[Export ("nextWordFromIndex:forward:")]
 		nuint GetNextWord (nuint fromIndex, bool isForward);
 
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSDataDetector' instead.")]
 		[Export ("URLAtIndex:effectiveRange:")]
 		NSUrl GetUrl (nuint index, out NSRange effectiveRange);
 
@@ -5430,6 +5433,10 @@ namespace Foundation
 	, QLPreviewItem
 #endif
 	{
+		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'NSUrlComponents' instead.")]
+		[Deprecated (PlatformName.WatchOS, 2, 0, message : "Use 'NSUrlComponents' instead.")]
+		[Deprecated (PlatformName.TvOS, 9, 0, message : "Use 'NSUrlComponents' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'NSUrlComponents' instead.")]
 		[Export ("initWithScheme:host:path:")]
 		IntPtr Constructor (string scheme, string host, string path);
 
@@ -6468,6 +6475,9 @@ namespace Foundation
 		[Export ("setDelegateQueue:")]
 		void SetDelegateQueue (NSOperationQueue queue);
 
+		[Deprecated (PlatformName.iOS, 9, 0, message : "Use 'NSUrlSession.CreateDataTask' instead.")]
+		[Deprecated (PlatformName.TvOS, 9, 0, message : "Use 'NSUrlSession.CreateDataTask' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message : "Use 'NSUrlSession.CreateDataTask' instead.")]
 		[NoWatch]
 		[Static]
 		[Export ("sendAsynchronousRequest:queue:completionHandler:")]
@@ -8558,12 +8568,15 @@ namespace Foundation
 		void SetDefaultPlaceholder (NSObject placeholder, NSObject marker, NSString binding);
 #endif
 
+		[Deprecated (PlatformName.MacOSX, message: "Now on 'NSEditor' protocol.")]
 		[Export ("objectDidEndEditing:")]
 		void ObjectDidEndEditing (NSObject editor);
 
+		[Deprecated (PlatformName.MacOSX, message: "Now on 'NSEditor' protocol.")]
 		[Export ("commitEditing")]
 		bool CommitEditing ();
 
+		[Deprecated (PlatformName.MacOSX, message: "Now on 'NSEditor' protocol.")]
 		[Export ("commitEditingWithDelegate:didCommitSelector:contextInfo:")]
 		//void CommitEditingWithDelegateDidCommitSelectorContextInfo (NSObject objDelegate, Selector didCommitSelector, IntPtr contextInfo);
 		void CommitEditing (NSObject objDelegate, Selector didCommitSelector, IntPtr contextInfo);
@@ -8780,6 +8793,10 @@ namespace Foundation
 		void WaitUntilFinished ();
 
 		[Export ("threadPriority")]
+		[Deprecated (PlatformName.iOS, 8, 0)]
+		[Deprecated (PlatformName.WatchOS, 2, 0)]
+		[Deprecated (PlatformName.TvOS, 9, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		double ThreadPriority { get; set; }
 
 		//Detected properties
@@ -9449,6 +9466,7 @@ namespace Foundation
 
 		// https://developer.apple.com/library/mac/#documentation/Cocoa/Reference/ApplicationKit/Classes/NSBundle_AppKitAdditions/Reference/Reference.html
 		[Static]
+		[Deprecated (PlatformName.MacOSX, 10, 8)]
 		[Export ("loadNibNamed:owner:")]
 		bool LoadNib (string nibName, NSObject owner);
 
@@ -12752,9 +12770,11 @@ namespace Foundation
 		[Static, Export ("canResumeDownloadDecodedWithEncodingMIMEType:")]
 		bool CanResumeDownloadDecodedWithEncodingMimeType (string mimeType);
 
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSURLSession' instead.")]
 		[Export ("initWithRequest:delegate:")]
 		IntPtr Constructor (NSUrlRequest request, NSObject delegate1);
 
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'NSURLSession' instead.")]
 		[Export ("initWithResumeData:delegate:path:")]
 		IntPtr Constructor (NSData resumeData, NSObject delegate1, string path);
 
@@ -13877,6 +13897,10 @@ namespace Foundation
 		void Reply ([NullAllowed] NSException exception);
 	}
 
+	[Deprecated (PlatformName.TvOS, 11, 0)]
+	[Deprecated (PlatformName.WatchOS, 4, 0)]
+	[Deprecated (PlatformName.iOS, 11, 0)]
+	[Deprecated (PlatformName.MacOSX, 10, 13)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface NSPortNameServer {

--- a/src/gamekit.cs
+++ b/src/gamekit.cs
@@ -792,6 +792,8 @@ namespace GameKit {
 		void GenerateIdentityVerificationSignature ([NullAllowed] GKIdentityVerificationSignatureHandler completionHandler);
 
 		[iOS (8,0), Mac (10,10)]
+		[Deprecated (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 11)]
 		[Async]
 		[Export ("loadFriendPlayersWithCompletionHandler:")]
 		void LoadFriendPlayers ([NullAllowed] Action<GKPlayer [], NSError> completionHandler);
@@ -936,7 +938,7 @@ namespace GameKit {
 
 		[NoTV]
 		[Deprecated (PlatformName.iOS, 8, 0, message : "Use 'StateChangedForPlayer (GKMatch,GKPlayer,GKPlayerConnectionState)' instead.")]
-		[Deprecated (PlatformName.MacOSX, 10, 10, message : "Use 'StateChangedForPlayer (GKMatch,GKPlayer,GKPlayerConnectionState)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 8, message : "Use 'StateChangedForPlayer (GKMatch,GKPlayer,GKPlayerConnectionState)' instead.")]
 		[Export ("match:player:didChangeState:"), EventArgs ("GKState")]
 		void StateChanged (GKMatch match, string playerId, GKPlayerConnectionState state);
 
@@ -1060,6 +1062,8 @@ namespace GameKit {
 		[NoTV]
 		[NoWatch]
 		[NullAllowed] // by default this property is null
+		[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'Recipients' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message: "Use 'Recipients' instead.")]
 		[Export ("playersToInvite", ArgumentSemantic.Retain)]
 		string [] PlayersToInvite { get; set;  }
 
@@ -1129,6 +1133,8 @@ namespace GameKit {
 		GKMatchmaker SharedMatchmaker { get; }
 
 		[NoTV]
+		[Deprecated (PlatformName.iOS, 7, 0, message : "Use 'GKLocalPlayer.RegisterListener' with an object that implements 'IGKInviteEventListenerProtocol'.")]
+		[Deprecated (PlatformName.MacOSX, 10, 10, message: "Use 'GKLocalPlayer.RegisterListener' with an object that implements 'IGKInviteEventListenerProtocol'.")]
 		[NullAllowed, Export ("inviteHandler", ArgumentSemantic.Copy)]
 		GKInviteHandler InviteHandler { get; set; }
 

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -481,23 +481,23 @@ namespace HealthKit {
 
 		[NoiOS]
 		[Watch (2,0)]
-		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use `HKWorkoutSession.Start` instead.")]
+		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use 'HKWorkoutSession.Start' instead.")]
 		[Export ("startWorkoutSession:")]
 		void StartWorkoutSession (HKWorkoutSession workoutSession);
 
 		[NoiOS]
 		[Watch (2,0)]
-		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use `HKWorkoutSession.End` instead.")]
+		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use 'HKWorkoutSession.End' instead.")]
 		[Export ("endWorkoutSession:")]
 		void EndWorkoutSession (HKWorkoutSession workoutSession);
 
 		[Watch (3,0), NoiOS]
-		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use `HKWorkoutSession.Pause` instead.")]
+		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use 'HKWorkoutSession.Pause' instead.")]
 		[Export ("pauseWorkoutSession:")]
 		void PauseWorkoutSession (HKWorkoutSession workoutSession);
 
 		[Watch (3,0), NoiOS]
-		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use `HKWorkoutSession.Resume` instead.")]
+		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use 'HKWorkoutSession.Resume' instead.")]
 		[Export ("resumeWorkoutSession:")]
 		void ResumeWorkoutSession (HKWorkoutSession workoutSession);
 

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -469,6 +469,8 @@ namespace HealthKit {
 		void HandleAuthorizationForExtension (Action<bool, NSError> completion);
 
 		[iOS (9,0)]
+		[Deprecated (PlatformName.WatchOS, 4, 0)]
+		[Deprecated (PlatformName.iOS, 11, 0)]
 		[Export ("splitTotalEnergy:startDate:endDate:resultsHandler:")]
 		void SplitTotalEnergy (HKQuantity totalEnergy, NSDate startDate, NSDate endDate, Action<HKQuantity, HKQuantity, NSError> resultsHandler);
 
@@ -479,19 +481,23 @@ namespace HealthKit {
 
 		[NoiOS]
 		[Watch (2,0)]
+		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use `HKWorkoutSession.Start` instead.")]
 		[Export ("startWorkoutSession:")]
 		void StartWorkoutSession (HKWorkoutSession workoutSession);
 
 		[NoiOS]
 		[Watch (2,0)]
+		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use `HKWorkoutSession.End` instead.")]
 		[Export ("endWorkoutSession:")]
 		void EndWorkoutSession (HKWorkoutSession workoutSession);
 
 		[Watch (3,0), NoiOS]
+		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use `HKWorkoutSession.Pause` instead.")]
 		[Export ("pauseWorkoutSession:")]
 		void PauseWorkoutSession (HKWorkoutSession workoutSession);
 
 		[Watch (3,0), NoiOS]
+		[Deprecated (PlatformName.WatchOS, 5, 0, message: "Use `HKWorkoutSession.Resume` instead.")]
 		[Export ("resumeWorkoutSession:")]
 		void ResumeWorkoutSession (HKWorkoutSession workoutSession);
 

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -822,7 +822,8 @@ namespace MapKit {
 
 		[NoTV]
 		[Export ("pinColor")]
-		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use 'PinTintColor' instead.")]
+		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'PinTintColor' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 11, message: "Use 'PinTintColor' instead.")]
 		MKPinAnnotationColor PinColor { get; set; }
 	
 		[Export ("animatesDrop")]

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -1578,6 +1578,7 @@ namespace MediaPlayer {
 		void InitializePlaybackQueue (MPPlayableContentManager contentManager, Action<NSError> completionHandler);
 
 		[iOS (9,3)]
+		[Deprecated (PlatformName.iOS, 12, 0, message: "Use Intents framework API instead.")]
 		[Export ("playableContentManager:initializePlaybackQueueWithContentItems:completionHandler:")]
 		void InitializePlaybackQueue (MPPlayableContentManager contentManager, [NullAllowed] MPContentItem[] contentItems, Action<NSError> completionHandler);
 	}

--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -1578,7 +1578,7 @@ namespace MediaPlayer {
 		void InitializePlaybackQueue (MPPlayableContentManager contentManager, Action<NSError> completionHandler);
 
 		[iOS (9,3)]
-		[Deprecated (PlatformName.iOS, 12, 0, message: "Use Intents framework API instead.")]
+		[Deprecated (PlatformName.iOS, 12, 0, message: "Use the Intents framework API instead.")]
 		[Export ("playableContentManager:initializePlaybackQueueWithContentItems:completionHandler:")]
 		void InitializePlaybackQueue (MPPlayableContentManager contentManager, [NullAllowed] MPContentItem[] contentItems, Action<NSError> completionHandler);
 	}

--- a/src/metalperformanceshaders.cs
+++ b/src/metalperformanceshaders.cs
@@ -788,6 +788,9 @@ namespace MetalPerformanceShaders {
 		[Export ("b")]
 		float B { get; }
 
+		[Deprecated (PlatformName.TvOS, 12, 0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("initWithDevice:a:b:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device, float a, float b);
@@ -803,6 +806,9 @@ namespace MetalPerformanceShaders {
 		[Export ("a")]
 		float A { get; }
 
+		[Deprecated (PlatformName.TvOS, 12, 0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("initWithDevice:a:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device, float a);
@@ -815,6 +821,9 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor]
 	interface MPSCnnNeuronSigmoid {
 
+		[Deprecated (PlatformName.TvOS, 12, 0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device);
@@ -831,6 +840,9 @@ namespace MetalPerformanceShaders {
 		[Export ("b")]
 		float B { get; }
 
+		[Deprecated (PlatformName.TvOS, 12, 0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("initWithDevice:a:b:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device, float a, float b);
@@ -843,6 +855,9 @@ namespace MetalPerformanceShaders {
 	[DisableDefaultCtor]
 	interface MPSCnnNeuronAbsolute {
 
+		[Deprecated (PlatformName.TvOS, 12, 0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device);
@@ -875,9 +890,13 @@ namespace MetalPerformanceShaders {
 		nuint Groups { get; set; }
 
 		[NullAllowed, Export ("neuron", ArgumentSemantic.Retain)]
+		[Deprecated (PlatformName.TvOS, 11, 0)]
+		[Deprecated (PlatformName.iOS, 11, 0)]
 		MPSCnnNeuron Neuron { get; set; }
 
 		[Static]
+		[Deprecated (PlatformName.TvOS, 11, 0)]
+		[Deprecated (PlatformName.iOS, 11, 0)]
 		[Export ("cnnConvolutionDescriptorWithKernelWidth:kernelHeight:inputFeatureChannels:outputFeatureChannels:neuronFilter:")]
 		MPSCnnConvolutionDescriptor GetConvolutionDescriptor (nuint kernelWidth, nuint kernelHeight, nuint inputFeatureChannels, nuint outputFeatureChannels, [NullAllowed] MPSCnnNeuron neuronFilter);
 
@@ -896,22 +915,37 @@ namespace MetalPerformanceShaders {
 		void SetBatchNormalizationParameters (IntPtr /* float* */ mean, IntPtr /* float* */ variance, [NullAllowed] IntPtr /* float* */ gamma, [NullAllowed] IntPtr /* float* */ beta, float epsilon);
 
 		[TV (11, 0), iOS (11, 0)]
+		[Deprecated (PlatformName.TvOS, 11, 3)]
+		[Deprecated (PlatformName.iOS, 11, 3)]
+		[Deprecated (PlatformName.MacOSX, 10, 13, 4)]
 		[Export ("setNeuronType:parameterA:parameterB:")]
 		void SetNeuronType (MPSCnnNeuronType neuronType, float parameterA, float parameterB);
 
 		[TV (11, 0), iOS (11, 0)]
+		[Deprecated (PlatformName.TvOS, 11, 3)]
+		[Deprecated (PlatformName.iOS, 11, 3)]
+		[Deprecated (PlatformName.MacOSX, 10, 13, 4)]
 		[Export ("neuronType")]
 		MPSCnnNeuronType NeuronType { get; }
 
 		[TV (11, 0), iOS (11, 0)]
+		[Deprecated (PlatformName.TvOS, 11, 3)]
+		[Deprecated (PlatformName.iOS, 11, 3)]
+		[Deprecated (PlatformName.MacOSX, 10, 13, 4)]
 		[Export ("neuronParameterA")]
 		float NeuronParameterA { get; }
 
 		[TV (11, 0), iOS (11, 0)]
+		[Deprecated (PlatformName.TvOS, 11, 3)]
+		[Deprecated (PlatformName.iOS, 11, 3)]
+		[Deprecated (PlatformName.MacOSX, 10, 13, 4)]
 		[Export ("neuronParameterB")]
 		float NeuronParameterB { get; }
 
 		[TV (11, 0), iOS (11, 0)]
+		[Deprecated (PlatformName.TvOS, 11, 3)]
+		[Deprecated (PlatformName.iOS, 11, 3)]
+		[Deprecated (PlatformName.MacOSX, 10, 13, 4)]
 		[Export ("setNeuronToPReLUWithParametersA:")]
 		void SetNeuronToPReLU (NSData A);
 
@@ -961,6 +995,8 @@ namespace MetalPerformanceShaders {
 		[Export ("groups")]
 		nuint Groups { get; }
 
+		[Deprecated (PlatformName.TvOS, 11, 0)]
+		[Deprecated (PlatformName.iOS, 11, 0)]
 		[NullAllowed, Export ("neuron")]
 		MPSCnnNeuron Neuron { get; }
 
@@ -997,18 +1033,30 @@ namespace MetalPerformanceShaders {
 		nuint ChannelMultiplier { get; }
 
 		[TV (11, 0), iOS (11, 0)]
+		[Deprecated (PlatformName.TvOS, 12, 0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("neuronType")]
 		MPSCnnNeuronType NeuronType { get; }
 
 		[TV (11, 0), iOS (11, 0)]
+		[Deprecated (PlatformName.TvOS, 12, 0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("neuronParameterA")]
 		float NeuronParameterA { get; }
 
 		[TV (11, 0), iOS (11, 0)]
+		[Deprecated (PlatformName.TvOS, 12, 0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("neuronParameterB")]
 		float NeuronParameterB { get; }
 
 		[TV (11,2), iOS (11,2), Mac (10,13,2, onlyOn64: true)]
+		[Deprecated (PlatformName.TvOS, 12, 0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("neuronParameterC")]
 		float NeuronParameterC { get; }
 
@@ -1432,10 +1480,14 @@ namespace MetalPerformanceShaders {
 		nuint RowBytes { get; set; }
 
 		[Static]
+		[Deprecated (PlatformName.TvOS, 11, 0)]
+		[Deprecated (PlatformName.iOS, 11, 0)]
 		[Export ("matrixDescriptorWithDimensions:columns:rowBytes:dataType:")]
 		MPSMatrixDescriptor Create (nuint rows, nuint columns, nuint rowBytes, MPSDataType dataType);
 
 		[Static]
+		[Deprecated (PlatformName.TvOS, 11, 0)]
+		[Deprecated (PlatformName.iOS, 11, 0)]
 		[Export ("rowBytesFromColumns:dataType:")]
 		nuint GetRowBytesFromColumns (nuint columns, MPSDataType dataType);
 
@@ -2146,6 +2198,9 @@ namespace MetalPerformanceShaders {
 		[Export ("b")]
 		float B { get; }
 
+		[Deprecated (PlatformName.TvOS, 12, 0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("initWithDevice:a:b:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device, float a, float b);
@@ -2161,6 +2216,9 @@ namespace MetalPerformanceShaders {
 		[Export ("b")]
 		float B { get; }
 
+		[Deprecated (PlatformName.TvOS, 12, 0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("initWithDevice:a:b:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device, float a, float b);
@@ -2170,6 +2228,9 @@ namespace MetalPerformanceShaders {
 	[BaseType (typeof(MPSCnnNeuron), Name = "MPSCNNNeuronSoftSign")]
 	[DisableDefaultCtor]
 	interface MPSCnnNeuronSoftSign {
+		[Deprecated (PlatformName.TvOS, 12, 0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("initWithDevice:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device);
@@ -2182,6 +2243,9 @@ namespace MetalPerformanceShaders {
 		[Export ("a")]
 		float A { get; }
 
+		[Deprecated (PlatformName.TvOS, 12, 0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("initWithDevice:a:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device, float a);
@@ -2197,6 +2261,9 @@ namespace MetalPerformanceShaders {
 		[Export ("b")]
 		float B { get; }
 
+		[Deprecated (PlatformName.TvOS, 12, 0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("initWithDevice:a:b:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device, float a, float b);
@@ -2802,6 +2869,9 @@ namespace MetalPerformanceShaders {
 		[Export ("nodeWithSource:a:b:")]
 		MPSCnnNeuronLinearNode Create (MPSNNImageNode sourceNode, float a, float b);
 
+		[Deprecated (PlatformName.TvOS, 12, 0)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("initWithSource:a:b:")]
 		IntPtr Constructor (MPSNNImageNode sourceNode, float a, float b);
 
@@ -3186,6 +3256,9 @@ namespace MetalPerformanceShaders {
 	[BaseType (typeof(MPSKernel))]
 	[DisableDefaultCtor] // There is a DesignatedInitializer, file a bug if needed.
 	interface MPSNNGraph : NSCopying, NSSecureCoding {
+		[Deprecated (PlatformName.TvOS, 11, 3)]
+		[Deprecated (PlatformName.iOS, 11, 3)]
+		[Deprecated (PlatformName.MacOSX, 10, 13, 4)]
 		[Export ("initWithDevice:resultImage:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (IMTLDevice device, MPSNNImageNode resultImage);

--- a/src/networkextension.cs
+++ b/src/networkextension.cs
@@ -727,6 +727,8 @@ namespace NetworkExtension {
 		NWPath DefaultPath { get; }
 
 		[iOS (10,0)][Mac (10,12, onlyOn64 : true)]
+		[Deprecated (PlatformName.iOS, 12, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 14)]
 		[Export ("displayMessage:completionHandler:")]
 		[Async]
 		void DisplayMessage (string message, Action<bool> completionHandler);

--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -90,7 +90,7 @@ namespace PassKit {
 
 		[iOS (8,0)]
 		[Static,Export ("isPaymentPassActivationAvailable")]
-		[Availability (Deprecated = Platform.iOS_9_0, Message = "Use the library's instance 'IsLibraryPaymentPassActivationAvailable' property instead.")]
+		[Deprecated (PlatformName.iOS, 9, 0, message: "Use the library's instance 'IsLibraryPaymentPassActivationAvailable' property instead.")]
 		bool IsPaymentPassActivationAvailable { get; }
 
 		[iOS (9,0)]
@@ -105,6 +105,7 @@ namespace PassKit {
 
 		[NoWatch]
 		[iOS (8,0)]
+		[Deprecated (PlatformName.iOS, 9, 0, message: "Use `ActivatePaymentPass (PKPaymentPass, NSData, Action<bool, NSError> completion)` instead.")]
 		[Async]
 		[Export ("activatePaymentPass:withActivationCode:completion:")]
 		void ActivatePaymentPass (PKPaymentPass paymentPass, string activationCode, [NullAllowed] Action<bool, NSError> completion);
@@ -245,6 +246,7 @@ namespace PassKit {
 		[EventArgs ("PKPaymentRequestShippingMethodUpdate")]
 		void DidSelectShippingMethod2 (PKPaymentAuthorizationViewController controller, PKShippingMethod shippingMethod, Action<PKPaymentRequestShippingMethodUpdate> completion);
 
+		[Deprecated (PlatformName.iOS, 9, 0)]
 		[Export ("paymentAuthorizationViewController:didSelectShippingAddress:completion:")]
 		[EventArgs ("PKPaymentShippingAddressSelected")]
 		void DidSelectShippingAddress (PKPaymentAuthorizationViewController controller, ABRecord address, PKPaymentShippingAddressSelected completion);

--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -105,7 +105,7 @@ namespace PassKit {
 
 		[NoWatch]
 		[iOS (8,0)]
-		[Deprecated (PlatformName.iOS, 9, 0, message: "Use `ActivatePaymentPass (PKPaymentPass, NSData, Action<bool, NSError> completion)` instead.")]
+		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'ActivatePaymentPass (PKPaymentPass, NSData, Action<bool, NSError> completion)' instead.")]
 		[Async]
 		[Export ("activatePaymentPass:withActivationCode:completion:")]
 		void ActivatePaymentPass (PKPaymentPass paymentPass, string activationCode, [NullAllowed] Action<bool, NSError> completion);

--- a/src/pdfkit.cs
+++ b/src/pdfkit.cs
@@ -550,7 +550,7 @@ namespace PdfKit {
 		IntPtr Constructor (CGRect bounds, PdfAnnotationKey annotationType, [NullAllowed] NSDictionary properties);
 
 		[Deprecated (PlatformName.iOS, 11, 0, message: "Use '.ctor (CGRect, PDFAnnotationKey, NSDictionary)' instead.")]
-		[Deprecated (PlatformName.MacOSX, 10, 13, message: "Use '.ctor (CGRect, PDFAnnotationKey, NSDictionary)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 12, message: "Use '.ctor (CGRect, PDFAnnotationKey, NSDictionary)' instead.")]
 		[Export ("initWithBounds:")]
 		IntPtr Constructor (CGRect bounds);
 
@@ -1516,7 +1516,7 @@ namespace PdfKit {
 		CGAffineTransform GetTransform (PdfDisplayBox box);
 
 		[NoiOS]
-		[Mac (10,12)]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("drawWithBox:")]
 		void Draw (PdfDisplayBox box);
 
@@ -1533,6 +1533,7 @@ namespace PdfKit {
 		NSImage GetThumbnail (CGSize size, PdfDisplayBox box);
 
 		[NoiOS]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("transformContextForBox:")]
 		void TransformContext (PdfDisplayBox box);
 
@@ -1875,10 +1876,12 @@ namespace PdfKit {
 		[Export ("highlightedSelections")]
 		PdfSelection [] HighlightedSelections { get; set; }
 
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("takePasswordFrom:")]
 		void TakePasswordFrom (NSObject sender);
 
 		[NoiOS]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("drawPage:")]
 		void DrawPage (PdfPage page);
 
@@ -1891,6 +1894,7 @@ namespace PdfKit {
 		void DrawPagePost (PdfPage page, CGContext context);
 
 		[NoiOS]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("drawPagePost:")]
 		void DrawPagePost (PdfPage page);
 

--- a/src/replaykit.cs
+++ b/src/replaykit.cs
@@ -127,8 +127,8 @@ namespace ReplayKit {
 	[BaseType (typeof (NSObject))]
 	interface RPScreenRecorderDelegate {
 
-		[Deprecated (PlatformName.TvOS, 11,0, message: "Use 'DidStopRecording(RPScreenRecorder,RPPreviewViewController,NSError)' instead.")]
-		[Deprecated (PlatformName.iOS, 11,0, message: "Use 'DidStopRecording(RPScreenRecorder,RPPreviewViewController,NSError)' instead.")]
+		[Deprecated (PlatformName.TvOS, 10,0, message: "Use 'DidStopRecording(RPScreenRecorder,RPPreviewViewController,NSError)' instead.")]
+		[Deprecated (PlatformName.iOS, 10,0, message: "Use 'DidStopRecording(RPScreenRecorder,RPPreviewViewController,NSError)' instead.")]
 		[Export ("screenRecorder:didStopRecordingWithError:previewViewController:")]
 		void DidStopRecording (RPScreenRecorder screenRecorder, NSError error, [NullAllowed] RPPreviewViewController previewViewController);
 

--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -870,6 +870,9 @@ namespace SpriteKit {
 		[Export ("particleZPosition")]
 		nfloat ParticleZPosition { get; set; }
 
+		[Deprecated (PlatformName.iOS, 8, 0)]
+		[Deprecated (PlatformName.TvOS, 8, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[Export ("particleZPositionRange")]
 		nfloat ParticleZPositionRange { get; set; }
 
@@ -1010,6 +1013,9 @@ namespace SpriteKit {
 		uint FieldBitMask { get; set; } /* uint32_t */
 
 		[iOS (8,0), Mac(10,10)]
+		[Deprecated (PlatformName.iOS, 8, 0)]
+		[Deprecated (PlatformName.TvOS, 8, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 10)]
 		[Export ("particleZPositionSpeed")]
 		nfloat ParticleZPositionSpeed { get; set; }
 
@@ -1461,6 +1467,9 @@ namespace SpriteKit {
 		[Export ("asynchronous")]
 		bool Asynchronous { [Bind ("isAsynchronous")] get; set; }
 
+		[Deprecated (PlatformName.iOS, 10, 0)]
+		[Deprecated (PlatformName.TvOS, 10, 0)]
+		[Deprecated (PlatformName.MacOSX, 10, 12)]
 		[Export ("frameInterval")]
 		nint FrameInterval { get; set; }
 

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -1712,7 +1712,7 @@ namespace UIKit {
 
 	[NoTV]
 	[BaseType (typeof (UIView), KeepRefUntil="Dismissed", Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIActionSheetDelegate)})]
-	[Deprecated (PlatformName.iOS, 8, 3, message: "Use UIAlertController with 'UIAlertControllerStyle.ActionSheet' instead.")]
+	[Deprecated (PlatformName.iOS, 8, 3, message: "Use 'UIAlertController' with 'UIAlertControllerStyle.ActionSheet' instead.")]
 	interface UIActionSheet {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
@@ -14899,7 +14899,7 @@ namespace UIKit {
 		
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIPopoverControllerDelegate)})]
 	[DisableDefaultCtor] // bug #1786
-	[Deprecated (PlatformName.iOS, 9, 0, message: "Use UIViewController with style of 'UIModalPresentationStyle.Popover' or UIPopoverPresentationController' instead.")]
+	[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'UIViewController' with style of 'UIModalPresentationStyle.Popover' or UIPopoverPresentationController' instead.")]
 	interface UIPopoverController : UIAppearanceContainer {
 		[Export ("initWithContentViewController:")][PostGet ("ContentViewController")]
 		IntPtr Constructor (UIViewController viewController);

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -1712,6 +1712,7 @@ namespace UIKit {
 
 	[NoTV]
 	[BaseType (typeof (UIView), KeepRefUntil="Dismissed", Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIActionSheetDelegate)})]
+	[Deprecated (PlatformName.iOS, 8, 3, message: "Use UIAlertController with 'UIAlertControllerStyle.ActionSheet' instead.")]
 	interface UIActionSheet {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
@@ -1780,6 +1781,7 @@ namespace UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
+	[Deprecated (PlatformName.iOS, 8, 3)]
 	interface UIActionSheetDelegate {
 
 		[Export ("actionSheet:clickedButtonAtIndex:"), EventArgs ("UIButton")]
@@ -2109,6 +2111,7 @@ namespace UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
+	[Deprecated (PlatformName.iOS, 9, 0)]
 	interface UIAlertViewDelegate {
 		[Export ("alertView:clickedButtonAtIndex:"), EventArgs ("UIButton")]
 		void Clicked (UIAlertView alertview, nint buttonIndex);
@@ -2524,18 +2527,22 @@ namespace UIKit {
 
 		[NoTV]
 		[Export ("statusBarStyle")]
+		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'UIViewController.PreferredStatusBarStyle' instead.")]
 		UIStatusBarStyle StatusBarStyle { get; set; }
 		
 		[NoTV]
+		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'UIViewController.PreferredStatusBarStyle' instead.")]
 		[Export ("setStatusBarStyle:animated:")]
 		void SetStatusBarStyle (UIStatusBarStyle statusBarStyle, bool animated);
 
 		[NoTV]
 		[Export ("statusBarHidden")]
+		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'UIViewController.PrefersStatusBarHidden' instead.")]
 		bool StatusBarHidden { [Bind ("isStatusBarHidden")] get; set; }
 
 		[NoTV]
 		[Export ("setStatusBarHidden:withAnimation:")]
+		[Deprecated (PlatformName.iOS, 9, 0, message: "Use 'UIViewController.PrefersStatusBarHidden' instead.")]
 		void SetStatusBarHidden (bool state, UIStatusBarAnimation animation);
 
 		[NoTV]
@@ -2545,10 +2552,12 @@ namespace UIKit {
 
 		[NoTV]
 		[Export ("statusBarOrientation")]
+		[Deprecated (PlatformName.iOS, 9, 0)]
 		UIInterfaceOrientation StatusBarOrientation { get; set; }
 		
 		[NoTV]
 		[Export ("setStatusBarOrientation:animated:")]
+		[Deprecated (PlatformName.iOS, 9, 0)]
 		void SetStatusBarOrientation (UIInterfaceOrientation orientation, bool animated);
 
 		[NoTV]
@@ -13602,10 +13611,12 @@ namespace UIKit {
 		bool CanPerformUnwind (Selector segueAction, UIViewController fromViewController, NSObject sender);
 
 		[iOS (6,0)]
+		[Deprecated (PlatformName.iOS, 9, 0)]
 		[Export ("viewControllerForUnwindSegueAction:fromViewController:withSender:")]
 		UIViewController GetViewControllerForUnwind (Selector segueAction, UIViewController fromViewController, NSObject sender);
 
 		[iOS (6,0)]
+		[Deprecated (PlatformName.iOS, 9, 0)]
 		[Export ("segueForUnwindingToViewController:fromViewController:identifier:")]
 		UIStoryboardSegue GetSegueForUnwinding (UIViewController toViewController, UIViewController fromViewController, string identifier);
 
@@ -14888,6 +14899,7 @@ namespace UIKit {
 		
 	[BaseType (typeof (NSObject), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] {typeof(UIPopoverControllerDelegate)})]
 	[DisableDefaultCtor] // bug #1786
+	[Deprecated (PlatformName.iOS, 9, 0, message: "Use UIViewController with style of 'UIModalPresentationStyle.Popover' or UIPopoverPresentationController' instead.")]
 	interface UIPopoverController : UIAppearanceContainer {
 		[Export ("initWithContentViewController:")][PostGet ("ContentViewController")]
 		IntPtr Constructor (UIViewController viewController);
@@ -14946,6 +14958,7 @@ namespace UIKit {
 	[BaseType (typeof (NSObject))]
 	[Model]
 	[Protocol]
+	[Deprecated (PlatformName.iOS, 9, 0)]
 	interface UIPopoverControllerDelegate {
 		[Export ("popoverControllerDidDismissPopover:"), EventArgs ("UIPopoverController")]
 		void DidDismiss (UIPopoverController popoverController);

--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -4115,6 +4115,7 @@ namespace WebKit {
 
 	[BaseType (typeof (DomHtmlElement), Name="DOMHTMLTableSectionElement")]
 	[DisableDefaultCtor] // ObjCException: +[<TYPE> init]: should never be used
+	[Deprecated (PlatformName.MacOSX, 10, 14)]
 	interface DomHtmlTableSectionElement {
 
 		[Export ("align")]

--- a/tests/xtro-sharpie/AttributeHelpers.cs
+++ b/tests/xtro-sharpie/AttributeHelpers.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Clang;
+using Clang.Ast;
+using Mono.Cecil;
+
+namespace Extrospection
+{
+	public static class AttributeHelpers
+	{
+		// These both return out Version and bool as you can have an an attribute with no version (null) which is different no matching attribute at all
+		public static bool FindDeprecated (IEnumerable<CustomAttribute> attributes, out Version version)
+		{
+			foreach (var attribute in attributes.Where (x => HasDeprecated (x, Helpers.Platform)))
+				return GetPlatformVersion (attribute, out version);
+
+			version = null;
+			return false;
+		}
+
+		public static bool FindObsolete (IEnumerable<CustomAttribute> attributes, out Version version)
+		{
+			foreach (var attribute in attributes.Where (x => HasObsoleted (x, Helpers.Platform)))
+				return GetPlatformVersion (attribute, out version);
+
+			version = null;
+			return false;
+		}
+
+		public static bool HasDeprecated (CustomAttribute attribute, Platforms platform) => HasMatchingPlatformAttribute ("DeprecatedAttribute", attribute, platform);
+		public static bool HasObsoleted (CustomAttribute attribute, Platforms platform) => HasMatchingPlatformAttribute ("ObsoletedAttribute", attribute, platform);
+
+		static bool HasMatchingPlatformAttribute (string expectedAttributeName, CustomAttribute attribute, Platforms platform)
+		{
+			if (attribute.Constructor.DeclaringType.Name == expectedAttributeName) {
+				byte attrPlatform = (byte)attribute.ConstructorArguments[0].Value;
+				if (attrPlatform == Helpers.GetPlatformManagedValue (platform))
+					return true;
+			}
+			return false;
+		}
+
+		public static bool HasAdviced (IEnumerable<CustomAttribute> attributes)
+		{
+			return attributes.Any (x => x.Constructor.DeclaringType.Name == "AdviceAttribute");
+		}
+
+		static bool GetPlatformVersion (CustomAttribute attribute, out Version version)
+		{
+			// Three different Attribute flavors
+			// (PlatformName platform, PlatformArchitecture architecture = PlatformArchitecture.None, string message = null)
+			// (PlatformName platform, int majorVersion, int minorVersion, PlatformArchitecture architecture = PlatformArchitecture.None, string message = null)
+			// (PlatformName platform, int majorVersion, int minorVersion, int subminorVersion, PlatformArchitecture architecture = PlatformArchitecture.None, string message = null)
+			switch (attribute.ConstructorArguments.Count) {
+			case 3:
+				version = null;
+				return true;
+			case 5:
+				version = new Version ((int)attribute.ConstructorArguments[1].Value, (int)attribute.ConstructorArguments[2].Value);
+				return true;
+			case 6:
+				version = new Version ((int)attribute.ConstructorArguments[1].Value, (int)attribute.ConstructorArguments[2].Value, (int)attribute.ConstructorArguments[3].Value);
+				return true;
+			default:
+				throw new InvalidOperationException ("GetPlatformVersion with unexpected number of arguments {attribute.ConstructorArguments.Count}");
+			}
+		}
+
+		public static bool FindObjcDeprecated (IEnumerable<Attr> attrs, out VersionTuple version)
+		{
+			AvailabilityAttr attr = attrs.OfType<AvailabilityAttr> ().FirstOrDefault (x => !x.Deprecated.IsEmpty && x.Platform.Name == Helpers.ClangPlatformName);
+			if (attr != null) {
+				version = attr.Deprecated;
+				return true;
+			} else {
+				version = VersionTuple.Empty;
+				return false;
+			}
+		}
+	}
+}

--- a/tests/xtro-sharpie/DeprecatedCheck.cs
+++ b/tests/xtro-sharpie/DeprecatedCheck.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Clang;
+using Clang.Ast;
+using Mono.Cecil;
+
+namespace Extrospection
+{
+	public class DeprecatedCheck : BaseVisitor
+	{
+		Dictionary<string, VersionTuple> ObjCDeprecatedItems = new Dictionary<string, VersionTuple> ();
+		Dictionary<string, VersionTuple> ObjCDeprecatedSelectors = new Dictionary<string, VersionTuple> ();
+
+		List<TypeDefinition> ManagedTypes = new List<TypeDefinition> ();
+
+		public override void End ()
+		{
+			foreach (var objcEntry in ObjCDeprecatedItems)
+				ProcessObjcEntry (objcEntry.Key, objcEntry.Value);
+
+			foreach (var objcEntry in ObjCDeprecatedSelectors)
+				ProcessObjcSelector (objcEntry.Key, objcEntry.Value);
+		}
+
+		void ProcessObjcEntry (string objcClassName, VersionTuple objcVersion)
+		{
+			TypeDefinition managedType = ManagedTypes.FirstOrDefault (x => Helpers.GetName (x) == objcClassName && x.IsPublic);
+			if (managedType != null) {					
+				var framework = Helpers.GetFramework (managedType);
+				if (framework != null)
+					ProcessItem (managedType, Helpers.GetName (managedType), objcVersion, framework);
+			}
+		}
+
+		void ProcessObjcSelector (string fullname, VersionTuple objcVersion)
+		{
+			string[] nameParts = fullname.Split (new string[] { "::" }, StringSplitOptions.None);
+
+			string objcClassName = nameParts[0];
+			string selector = nameParts[1];
+
+			TypeDefinition managedType = ManagedTypes.FirstOrDefault (x => Helpers.GetName (x) == objcClassName);
+			if (managedType != null) {
+				var framework = Helpers.GetFramework (managedType);
+				if (framework == null)
+					return;
+
+				// If the entire type is deprecated, call it good enough
+				if (HasAnyDeprecationAttribute (managedType.CustomAttributes))
+					return;
+
+				var matchingMethod = managedType.Methods.FirstOrDefault (x => x.GetSelector () == selector && x.IsPublic);
+				if (matchingMethod != null)
+					ProcessItem (matchingMethod, fullname, objcVersion, framework);
+			}
+		}
+
+		public void ProcessItem (ICustomAttributeProvider item, string itemName, VersionTuple objcVersion, string framework)
+		{
+			// Our bindings do not need have [Deprecated] for ancicent versions we don't support anymore
+			if (VersionHelpers.VersionTooOldToCare (objcVersion))
+				return;
+
+			// In some cases we've used [Advice] when entire types are deprecated
+			if (HasAnyAdviceAttribute (item))
+				return;
+
+			if (!HasAnyDeprecationAttribute (item.CustomAttributes))
+			{
+				Log.On (framework).Add ($"!deprecated-attribute-missing! {itemName} missing a [Deprecated] attribute");
+				return;
+			}
+
+			// Don't version check us when Apple does __attribute__((availability(macos, introduced=10.0, deprecated=100000)));
+			if (objcVersion.Major == 100000)
+				return;
+
+			// Some APIs have both a [Deprecated] and [Obsoleted]. Bias towards [Obsoleted].
+			Version managedVersion;
+			bool foundObsoleted = AttributeHelpers.FindObsolete (item.CustomAttributes, out managedVersion);
+			if (foundObsoleted) {
+				if (managedVersion != null && !ManagedBeforeOrEqualToObjcVersion (objcVersion, managedVersion))
+					Log.On (framework).Add ($"!deprecated-attribute-wrong! {itemName} has {managedVersion} not {objcVersion} on [Obsoleted] attribute");
+				return;
+			}
+
+			bool foundDeprecated = AttributeHelpers.FindDeprecated (item.CustomAttributes, out managedVersion);
+			if (foundDeprecated && managedVersion != null && !ManagedBeforeOrEqualToObjcVersion (objcVersion, managedVersion))
+				Log.On (framework).Add ($"!deprecated-attribute-wrong! {itemName} has {managedVersion} not {objcVersion} on [Deprecated] attribute");
+		}
+
+		public static bool ManagedBeforeOrEqualToObjcVersion (VersionTuple objcVersionTuple, Version managedVersion)
+		{
+			// Often header files will soft deprecate APIs versions before a formal deprecation (10.7 soft vs 10.10 formal). Accept older deprecation values
+			return managedVersion <= VersionHelpers.Convert (objcVersionTuple);
+		}
+
+		static bool HasAnyAdviceAttribute (ICustomAttributeProvider item)
+		{
+			if (AttributeHelpers.HasAdviced (item.CustomAttributes))
+				return true;
+
+			// Properites are a special case for [Advice], as it is generated on the property itself and not the individual get_ \ set_ methods
+			// Cecil does not have a link between the MethodDefinition we have and the hosting PropertyDefinition, so we have to dig to find the match
+			if (item is MethodDefinition method) {
+				PropertyDefinition property = method.DeclaringType.Properties.FirstOrDefault (p => p.GetMethod == method || p.SetMethod == method);
+				if (property != null && AttributeHelpers.HasAdviced (property.CustomAttributes))
+					return true;
+			}
+			return false;
+		}
+
+		static bool HasAnyDeprecationAttribute (IEnumerable<CustomAttribute> attributes)
+		{
+			// This allows us to accept [Deprecated (iOS)] for watch and tv, which many of our bindings currently have
+			// If we want to force seperate tv\watch attributes remove GetRelatedPlatforms and just check Helpers.Platform
+			Platforms[] platforms = GetRelatedPlatforms ();
+			foreach (var attribute in attributes) {
+				if (platforms.Any (x => AttributeHelpers.HasDeprecated (attribute, x)) || platforms.Any (x => AttributeHelpers.HasObsoleted (attribute, x)))
+					return true;
+			}
+			return false;
+		}
+
+		static Platforms[] GetRelatedPlatforms ()
+		{
+			// TV and Watch also implictly accept iOS
+			switch (Helpers.Platform)
+			{
+			case Platforms.macOS:
+				return new Platforms[] { Platforms.macOS };
+			case Platforms.iOS:
+				return new Platforms[] { Platforms.iOS };
+			case Platforms.tvOS:
+				return new Platforms[] { Platforms.iOS, Platforms.tvOS };
+			case Platforms.watchOS:
+				return new Platforms[] { Platforms.iOS, Platforms.watchOS };
+			default:
+				throw new InvalidOperationException ($"Unknown {Helpers.Platform} in GetPlatforms");
+			}
+		}
+
+		public override void VisitManagedType (TypeDefinition type)
+		{
+			ManagedTypes.Add (type);
+		}
+
+		public override void VisitObjCCategoryDecl (ObjCCategoryDecl decl, VisitKind visitKind) => VisitItem (decl, visitKind);
+		public override void VisitObjCInterfaceDecl (ObjCInterfaceDecl decl, VisitKind visitKind) => VisitItem (decl, visitKind);
+
+		void VisitItem (NamedDecl decl, VisitKind visitKind)
+		{
+			if (visitKind == VisitKind.Enter && AttributeHelpers.FindObjcDeprecated (decl.Attrs, out VersionTuple version))
+				ObjCDeprecatedItems[decl.Name] = version;
+		}
+
+		public override void VisitObjCMethodDecl (ObjCMethodDecl decl, VisitKind visitKind)
+		{
+			if (visitKind == VisitKind.Enter && AttributeHelpers.FindObjcDeprecated(decl.Attrs, out VersionTuple version))
+				ObjCDeprecatedSelectors[decl.QualifiedName] = version;
+		}
+	}
+}

--- a/tests/xtro-sharpie/Helpers.cs
+++ b/tests/xtro-sharpie/Helpers.cs
@@ -8,7 +8,15 @@ using Mono.Cecil;
 using Clang.Ast;
 
 namespace Extrospection {
-	
+
+	public enum Platforms
+	{
+		macOS,
+		iOS,
+		watchOS,
+		tvOS,
+	}
+
 	public static partial class Helpers {
 
 		// the original name can be lost and, if not registered (e.g. enums), might not be available
@@ -55,15 +63,43 @@ namespace Extrospection {
 			return index < 0 ? source : source.Substring (0, index) + replace + source.Substring (index + find.Length);
 		}
 
-		public enum Platforms
+		public static Platforms Platform { get; set; }
+
+		public static int GetPlatformManagedValue (Platforms platform)
 		{
-			macOS,
-			iOS,
-			watchOS,
-			tvOS,
+			// None, MacOSX, iOS, WatchOS, TvOS
+			switch (platform) {
+			case Platforms.macOS:
+				return 1;
+			case Platforms.iOS:
+				return 2;
+			case Platforms.watchOS:
+				return 3;
+			case Platforms.tvOS:
+				return 4;
+			default:
+				throw new InvalidOperationException ($"Unexpected Platform {Platform} in GetPlatformManagedValue");
+			}
 		}
 
-		public static Platforms Platform { get; set; }
+		// Clang.Ast.AvailabilityAttr.Platform.Name
+		public static string ClangPlatformName
+		{
+			get {
+				switch (Helpers.Platform) {
+				case Platforms.macOS:
+					return "macos";
+				case Platforms.iOS:
+					return "ios";
+				case Platforms.watchOS:
+					return "watchos";
+				case Platforms.tvOS:
+					return "tvos";
+				default:
+					throw new InvalidOperationException ($"Unexpected Platform {Platform} in ClangPlatformName");
+				}
+			}
+		}
 
 		public static bool IsAvailable (this Decl decl)
 		{

--- a/tests/xtro-sharpie/Runner.cs
+++ b/tests/xtro-sharpie/Runner.cs
@@ -27,7 +27,7 @@ namespace Extrospection {
 				new SelectorCheck (),
 				new SimdCheck (),
 				new RequiresSuperCheck (),
-				// new DeprecatedCheck ()
+				new DeprecatedCheck ()
 //				new ListNative (), // for debug
 			};
 			foreach (var assemblyName in assemblyNames) {

--- a/tests/xtro-sharpie/Runner.cs
+++ b/tests/xtro-sharpie/Runner.cs
@@ -27,18 +27,19 @@ namespace Extrospection {
 				new SelectorCheck (),
 				new SimdCheck (),
 				new RequiresSuperCheck (),
+				// new DeprecatedCheck ()
 //				new ListNative (), // for debug
 			};
 			foreach (var assemblyName in assemblyNames) {
 				var name = Path.GetFileNameWithoutExtension (assemblyName);
 				if (name.EndsWith (".iOS", StringComparison.Ordinal))
-					Helpers.Platform = Helpers.Platforms.iOS;
+					Helpers.Platform = Platforms.iOS;
 				else if (name.EndsWith (".Mac", StringComparison.Ordinal))
-					Helpers.Platform = Helpers.Platforms.macOS;
+					Helpers.Platform = Platforms.macOS;
 				else if (name.EndsWith (".WatchOS", StringComparison.Ordinal))
-					Helpers.Platform = Helpers.Platforms.watchOS;
+					Helpers.Platform = Platforms.watchOS;
 				else if (name.EndsWith (".TVOS", StringComparison.Ordinal))
-					Helpers.Platform = Helpers.Platforms.tvOS;
+					Helpers.Platform = Platforms.tvOS;
 				managed_reader.Load (assemblyName);
 			}
 

--- a/tests/xtro-sharpie/Runner.cs
+++ b/tests/xtro-sharpie/Runner.cs
@@ -27,7 +27,7 @@ namespace Extrospection {
 				new SelectorCheck (),
 				new SimdCheck (),
 				new RequiresSuperCheck (),
-				new DeprecatedCheck ()
+				new DeprecatedCheck (),
 //				new ListNative (), // for debug
 			};
 			foreach (var assemblyName in assemblyNames) {

--- a/tests/xtro-sharpie/VersionHelpers.cs
+++ b/tests/xtro-sharpie/VersionHelpers.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Clang;
+using static Extrospection.Helpers;
+
+namespace Extrospection
+{
+	public static class VersionHelpers
+	{
+		public static Version Convert (VersionTuple version)
+		{
+			uint major = version.Major;
+			uint minor = version.Minor.HasValue ? version.Minor.Value : 0;
+			if (version.Subminor.HasValue)
+				return new Version ((int)major, (int)minor, (int)version.Subminor.Value);
+			else
+				return new Version ((int)major, (int)minor);
+		}
+
+		public static bool VersionTooOldToCare (VersionTuple version)
+		{
+			switch (Helpers.Platform) {
+			case Platforms.iOS:
+				return version.Major < 6;
+			case Platforms.macOS:
+				return version.Minor < 7;
+			case Platforms.tvOS:
+				return version.Major < 9;
+			case Platforms.watchOS:
+				return version.Major < 2;
+			default:
+				throw new InvalidOperationException ($"Unknown platform {Platform} in VersionTooOldToCare");
+			}
+		}
+	}
+}

--- a/tests/xtro-sharpie/common-CloudKit.ignore
+++ b/tests/xtro-sharpie/common-CloudKit.ignore
@@ -7,6 +7,7 @@
 
 ## auto-generated attribute (but deprecated API where Apple removed it)
 !extra-designated-initializer! CKSubscription::initWithCoder: is incorrectly decorated with an [DesignatedInitializer] attribute
+!deprecated-attribute-missing! CKSubscription::initWithCoder: missing a [Deprecated] attribute
 
 ## Formalizes a protocol for getting and setting keys on a CKRecord.
 ## Not intended to be used directly by client code

--- a/tests/xtro-sharpie/common-PassKit.ignore
+++ b/tests/xtro-sharpie/common-PassKit.ignore
@@ -1,2 +1,5 @@
+## Was bound as both static and instance and already deprecated
+!deprecated-attribute-missing! PKPassLibrary::isPaymentPassActivationAvailable missing a [Deprecated] attribute
+
 ## made optional in xcode9 beta 3 since it was replaced with newer API
 !incorrect-protocol-member! PKPaymentAuthorizationControllerDelegate::paymentAuthorizationController:didAuthorizePayment:completion: is OPTIONAL and should NOT be abstract

--- a/tests/xtro-sharpie/iOS-AVFoundation.ignore
+++ b/tests/xtro-sharpie/iOS-AVFoundation.ignore
@@ -10,3 +10,6 @@
 
 ## https://github.com/xamarin/xamarin-macios/issues/3213 should be fixed before conformance to 'AVQueuedSampleBufferRendering' is restored.
 !missing-protocol-conformance! AVSampleBufferDisplayLayer should conform to AVQueuedSampleBufferRendering (defined in 'AVSampleBufferDisplayLayerQueueManagement' category)
+
+# Deprecated in iOS 6.0 but we have same C# signature as a method that was deprecated in iOS 8.0
+!deprecated-attribute-wrong! AVAudioRecorderDelegate::audioRecorderEndInterruption:withFlags: has 8.0 not 6.0 on [Deprecated] attribute

--- a/tests/xtro-sharpie/xtro-sharpie.csproj
+++ b/tests/xtro-sharpie/xtro-sharpie.csproj
@@ -20,7 +20,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <Commandlineparameters>../../iphoneos9.2-arm64.pch /Library/Frameworks/Xamarin.iOS.framework/Versions/Current//lib/64bits/Xamarin.iOS.dll</Commandlineparameters>
+    <Commandlineparameters>../../iphoneos12.0-arm64.pch /Library/Frameworks/Xamarin.iOS.framework/Versions/Current//lib/64bits/Xamarin.iOS.dll</Commandlineparameters>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -88,6 +88,9 @@
     <Compile Include="Log.cs" />
     <Compile Include="RequiresSuperCheck.cs" />
     <Compile Include="Filter.cs" />
+    <Compile Include="DeprecatedCheck.cs" />
+    <Compile Include="AttributeHelpers.cs" />
+    <Compile Include="VersionHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
- https://github.com/xamarin/xamarin-macios/issues/4431

A few notes about decisions made that we should (re)-consider:

- We have a number of combination Obsoleted\Deprecated where Apple soft deprecated and then removed or hard deprecated later. I bias towards the obsoleted one where there both, which combines with the second decision...
- We have a large number of attributes with versions older than the official deprecation, generally done during soft deprecations, comments in the headers, or Apple just changing their mind.
   - I went with the rule of "a deprecation must be older or equal to the xtro result" to not warn due to this
- We have a number of missing TV\Watch deprecation attributes that have iOS. I could have played copy paste a bunch of attributes, but for now I said "if we are doing tv or watch, count an ios attribute as good enough.
   - If this is lame, we can remove the chunk of code (I commented it) and fix them all up. This PR got long enough already
- Apple sets some deprecations with `deprecated=100000` and in that case, I say any number we use is good, as long as it has a deprecation
- In some cases, we use [Advice] for ^ or other reasons, so I accept [Advice] in place of other attributes.

It may be easier to review each commit individually.