### PR TITLE
[foundation] Fix inlined 'NSUserActivity (IntentsAdditions)' to work if nothing else from Intents is used. Fixes #4894

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -5209,7 +5209,16 @@ namespace Foundation
 
 		[Watch (5,0), NoTV, NoMac, iOS (12,0)]
 		[NullAllowed, Export ("suggestedInvocationPhrase")]
-		string SuggestedInvocationPhrase { get; set; }
+		string SuggestedInvocationPhrase {
+			// This _simply_ ensure that the Intents namespace (via the enum) will be present which,
+			// in turns, means that the Intents.framework is loaded into memory and this makes the
+			// selectors (getter and setter) work at runtime. Other selectors do not need it.
+			// reference: https://github.com/xamarin/xamarin-macios/issues/4894
+			[PreSnippet ("GC.KeepAlive (Intents.INCallCapabilityOptions.AudioCall); // no-op to ensure Intents.framework is loaded into memory")]
+			get;
+			[PreSnippet ("GC.KeepAlive (Intents.INCallCapabilityOptions.AudioCall); // no-op to ensure Intents.framework is loaded into memory")]
+			set;
+		}
 
 		[Watch (5, 0), NoTV, NoMac, iOS (12, 0)]
 		[Export ("eligibleForPrediction")]


### PR DESCRIPTION
The selectors `suggestedInvocationPhrase` and `setSuggestedInvocationPhrase`
needs Intents.framework to be loaded into memory. Otherwise an exception
occurs:

```
Objective-C exception thrown. Name: NSInvalidArgumentException Reason: -[NSUserActivity setSuggestedInvocationPhrase:]: unrecognized selector sent to instance 0x19cb3f00
```

When the linker is enabled there's no clue (e.g. namespaces from
preserved types) that `Intents` is required to call the property.

The fix is to provide an hint that will force the linker to keep a type
(a small enum available in all platforms in this case) which tells
`mtouch` (based on the type's namespace) to instruct the native linker
(Apple's `ld`) to [weak]link the Intents.framework in the application
executable.

Note: other selections from the category works fine.

reference:
https://github.com/xamarin/xamarin-macios/issues/4894