### PR TITLE
[appkit] Add missing `[NullAllowed]` on `NSView.NextKeyView`. Fixes #4558

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -15866,6 +15866,7 @@ namespace AppKit {
 		[Export ("performMnemonic:")]
 		bool PerformMnemonic (string mnemonic);
 
+		[NullAllowed]
 		[Export ("nextKeyView")]
 		NSView NextKeyView { get; set; }
 


### PR DESCRIPTION
Confirmed with headers.

reference: https://github.com/xamarin/xamarin-macios/issues/4558