### PR TITLE
[linker] Set flag when processing ParameterInfo.get_Name from XML files. Fixes #4978

### DIFF
--- a/tools/linker/MonoTouch.Tuner/MonoTouchMarkStep.cs
+++ b/tools/linker/MonoTouch.Tuner/MonoTouchMarkStep.cs
@@ -105,6 +105,7 @@ namespace MonoTouch.Tuner {
 				if (current_method == null) {
 					// This can happen if ParameterInfo.get_Name is preserved in an xml file
 					Annotations.GetCustomAnnotations ("ParameterInfo").Add (method, null);
+					parameter_info = true;
 				} else {
 					var a = current_method.DeclaringType.Module.Assembly;
 					if (!Profile.IsSdkAssembly (a) && !Profile.IsProductAssembly (a)) {


### PR DESCRIPTION
Commit https://github.com/xamarin/xamarin-macios/commit/996d90614b0a16fc01a943985885bde626ff7b1a fixed the use of XML files. However it did not set the flags so if it's used in both XML and in code then the dictionary is being added twice, which throws an exception like

```
error MT2102: Error processing the method 'System.Boolean SignalGo.Shared.Helpers.ReflectionHelper/d__0::MoveNext()' in the assembly 'SignalGo.Shared.dll': An item with the same key has already been added. Key: System.String System.Reflection.ParameterInfo::get_Name()
```

reference: https://github.com/xamarin/xamarin-macios/issues/4978