### PR TITLE
[mac] Fix logic to include branch name in packages. Fixes #4990

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ $(MAC_DESTDIR)$(MAC_FRAMEWORK_DIR)/Commands:
 $(MAC_DESTDIR)/$(MAC_FRAMEWORK_CURRENT_DIR)/buildinfo: Make.config.inc .git/index | $(MAC_DESTDIR)/$(MAC_FRAMEWORK_CURRENT_DIR)
 	$(Q_GEN) echo "Version: $(MAC_PACKAGE_VERSION)" > $@
 	$(Q) echo "Hash: $(shell git log --oneline -1 --pretty=%h)" >> $@
-	$(Q) echo "Branch: $(shell git symbolic-ref --short HEAD)" >> $@
+	$(Q) echo "Branch: $(CURRENT_BRANCH)" >> $@
 	$(Q) echo "Build date: $(shell date '+%Y-%m-%d %H:%M:%S%z')" >> $@
 
 $(MAC_DESTDIR)/$(MAC_FRAMEWORK_CURRENT_DIR)/updateinfo: Make.config.inc


### PR DESCRIPTION
so it can be reported inside VSM.

The logic was not updated (for XM) with the simpler one we can use
on the internal Jenkins bots.

ref: https://github.com/xamarin/xamarin-macios/issues/4990