### PR TITLE
[xcode10.1] [mediaplayer] Fix NRE in MPNowPlayingInfoCenter wrt null dictionary entries. Fixes #4988

### DIFF
--- a/src/MediaPlayer/MPNowPlayingInfoCenter.cs
+++ b/src/MediaPlayer/MPNowPlayingInfoCenter.cs
@@ -210,13 +210,10 @@ namespace MediaPlayer {
 
 		bool TryGetValue (NSDictionary source, NSObject key, out NSObject result)
 		{
-			var b = false;
 			result = null;
-			if (key != null) {
-				source.TryGetValue (key, out result);
-				b = true;
-			}
-			return b;
+			if (key != null)
+				return source.TryGetValue (key, out result);
+			return false;
 		}
 	}
 	


### PR DESCRIPTION
Backport of #4992.

/cc @spouliot 

Description:
The custom `TryGetValue` could return `true` and an `out null`. That was
fine for many items, e.g. converting `null` to `NSString` or `NSDate` is
fine.

However this cause an `NullReferenceException` when trying to create
arrays (thru `NSArray`) or converting `NSNumber` into value types.

The _normal_ `TryGetValue` behavior fixes this - and avoid extraneous
(and non-required) conversions of `null` items.

ref: https://github.com/xamarin/xamarin-macios/issues/4988