### PR TITLE
[UIKit] Reintroduce UIScrollView.ContentOffset.

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -9717,6 +9717,9 @@ namespace UIKit {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
+		[Export ("contentOffset")]
+		new CGPoint ContentOffset { get; set; }
+
 		[Export ("contentSize")]
 		new CGSize ContentSize { get; set; }
 


### PR DESCRIPTION
In iOS 12 this property was moved to a protocol, but that protocol's
availability attributes limits it to iOS 12, not iOS 2 where this property was
originally introduced.

This is problematic, because it means we'll throw a
PlatformNotSupportedException if someone tries to call it on 32-bit iOS.

So put the property back on UIScrollView, so that the generated code ends up
with the right availability attributes (and a correct 32-bit implementation).