### PR TITLE
[msbuild] Avoid possible NullReferenceException in ScnToolTaskBase. Fixes #4039

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ScnToolTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/ScnToolTaskBase.cs
@@ -58,16 +58,21 @@ namespace Xamarin.MacDev.Tasks
 			var envVariables = EnvironmentVariables;
 			var index = -1;
 
-			for (int i = 0; i < envVariables.Length; i++) {
-				if (envVariables [i].StartsWith (variableName + "=", StringComparison.Ordinal)) {
-					index = i;
-					break;
+			if (envVariables == null) {
+				envVariables = new string [1];
+				index = 0;
+			} else {
+				for (int i = 0; i < envVariables.Length; i++) {
+					if (envVariables [i].StartsWith (variableName + "=", StringComparison.Ordinal)) {
+						index = i;
+						break;
+					}
 				}
-			}
 
-			if (index < 0) {
-				Array.Resize<string> (ref envVariables, envVariables.Length + 1);
-				index = envVariables.Length - 1;
+				if (index < 0) {
+					Array.Resize<string> (ref envVariables, envVariables.Length + 1);
+					index = envVariables.Length - 1;
+				}
 			}
 
 			envVariables [index] = string.Format ("{0}={1}", variableName, value);


### PR DESCRIPTION
`EnvironmentVariables` can be null (not empty) and cause the NRE in the
attached test case.

It's not clear that the extra logic is needed if we were using `xcrun`.
There's an enhancement for this https://github.com/xamarin/xamarin-macios/issues/4634

reference: https://github.com/xamarin/xamarin-macios/issues/4039