### PR TITLE
[master] [uikit] Duplicate bindings for 'UIScrollView.ContentOffset' to get correct availability information. Fixes #4893

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -9718,6 +9718,10 @@ namespace UIKit {
 		[Export ("initWithFrame:")]
 		IntPtr Constructor (CGRect frame);
 
+		// moved to UIFocusItemScrollableContainer in iOS 12 - but that makes the availability information incorrect (so `new` is used to avoid compiler warnings)
+		[Export ("contentOffset")]
+		new CGPoint ContentOffset { get; set; }
+
 		[Export ("contentSize")]
 		new CGSize ContentSize { get; set; }
 


### PR DESCRIPTION
Backport of #4982.

/cc @rolfbjarne @spouliot

Description:
`ContentOffset` was moved to `UIFocusItemScrollableContainer` in iOS 12.
Since it's a new protocol it's decorated as introduced in iOS 12 - but
the API was actually already available for a long time.

The _trick_ is to keep the original binding inside `UIScrollView`
so it overrides the protocol and keeps the correct availability info.
It requires adding `new` to bindings to avoid compiler warnings.

reference: https://github.com/xamarin/xamarin-macios/issues/4893