### PR TITLE
Use the zlib-helper.o library built by mono, instead of building our own.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -808,13 +808,10 @@ $(2):: build-$(2)
 build:: build-$(2)
 clean-local:: clean-$(2)
 
-# config/eglib-config.h is needed by the builds in runtime/
 .stamp-build-$(2): $(MONO_PATH)/configure $(MONO_DEPENDENCIES) $(BUILD_DESTDIR)/$(2)
 	$(MAKE) -C $(SDK_BUILDDIR) package-ios-$(3) $(SDK_ARGS)
 	$(Q) cp -r $(SDK_DESTDIR)/ios-$(4)/lib $(BUILD_DESTDIR)/$(2)
 	$(Q) cp -r $(SDK_DESTDIR)/ios-$(4)/include $(BUILD_DESTDIR)/$(2)
-	cp $(SDK_BUILDDIR)/ios-$(4)/config.h $(BUILD_DESTDIR)/$(2)/include/mono-2.0
-	cp $(SDK_BUILDDIR)/ios-$(4)/mono/eglib/eglib-config.h $(BUILD_DESTDIR)/$(2)/include/mono-2.0
 	$(Q) touch $$@
 
 build-$(2): .stamp-build-$(2)
@@ -921,8 +918,6 @@ endif
 	$(Q) mkdir -p $(BUILD_DESTDIR)/watchsimulator
 	$(Q) cp -r $(SDK_DESTDIR)/ios-simwatch-release/lib $(BUILD_DESTDIR)/watchsimulator
 	$(Q) cp -r $(SDK_DESTDIR)/ios-simwatch-release/include $(BUILD_DESTDIR)/watchsimulator
-	cp $(SDK_BUILDDIR)/ios-simwatch-release/config.h $(BUILD_DESTDIR)/watchsimulator/include/mono-2.0
-	cp $(SDK_BUILDDIR)/ios-simwatch-release/mono/eglib/eglib-config.h $(BUILD_DESTDIR)/watchsimulator/include/mono-2.0
 	$(Q) touch $@
 
 build-watchsimulator: .stamp-build-watchsimulator
@@ -1002,8 +997,6 @@ endif
 	$(Q) mkdir -p $(BUILD_DESTDIR)/tvsimulator
 	$(Q) cp -r $(SDK_DESTDIR)/ios-simtv-release/lib $(BUILD_DESTDIR)/tvsimulator
 	$(Q) cp -r $(SDK_DESTDIR)/ios-simtv-release/include $(BUILD_DESTDIR)/tvsimulator
-	cp $(SDK_BUILDDIR)/ios-simtv-release/config.h $(BUILD_DESTDIR)/tvsimulator/include/mono-2.0
-	cp $(SDK_BUILDDIR)/ios-simtv-release/mono/eglib/eglib-config.h $(BUILD_DESTDIR)/tvsimulator/include/mono-2.0
 	$(Q) touch $@
 
 build-tvsimulator: .stamp-build-tvsimulator
@@ -1094,8 +1087,6 @@ clean-local:: clean-$(2)
 	$(MAKE) -C $(SDK_BUILDDIR) package-ios-$(3) $(SDK_ARGS)
 	$(Q) mkdir -p $(BUILD_DESTDIR)/$(2)
 	$(Q) cp -r $(SDK_DESTDIR)/ios-$(3)-release/* $(BUILD_DESTDIR)/$(2)
-	$(Q) cp -r $(SDK_BUILDDIR)/ios-$(3)-release/config.h $(BUILD_DESTDIR)/$(2)/include/mono-2.0
-	$(Q) cp -r $(SDK_BUILDDIR)/ios-$(3)-release/mono/eglib/eglib-config.h $(BUILD_DESTDIR)/$(2)/include/mono-2.0
 	$(Q) touch $$@
 
 build-$(2): .stamp-build-$(2)
@@ -1270,8 +1261,6 @@ watchos:: targetwatch
 	$(MAKE) -C $(SDK_BUILDDIR) package-ios-targetwatch $(SDK_ARGS)
 	$(Q) mkdir -p $(BUILD_DESTDIR)/targetwatch
 	$(Q) cp -r $(SDK_DESTDIR)/ios-targetwatch-release/* $(BUILD_DESTDIR)/targetwatch
-	$(Q) cp -r $(SDK_BUILDDIR)/ios-targetwatch-release/config.h $(BUILD_DESTDIR)/targetwatch/include/mono-2.0
-	$(Q) cp -r $(SDK_BUILDDIR)/ios-targetwatch-release/mono/eglib/eglib-config.h $(BUILD_DESTDIR)/targetwatch/include/mono-2.0
 	$(Q) touch $@
 
 build-targetwatch: .stamp-build-targetwatch
@@ -1383,8 +1372,6 @@ tvos:: targettv
 	$(MAKE) -C $(SDK_BUILDDIR) package-ios-targettv $(SDK_ARGS)
 	$(Q) mkdir -p $(BUILD_DESTDIR)/targettv
 	$(Q) cp -r $(SDK_DESTDIR)/ios-targettv-release/* $(BUILD_DESTDIR)/targettv
-	$(Q) cp -r $(SDK_BUILDDIR)/ios-targettv-release/config.h $(BUILD_DESTDIR)/targettv/include/mono-2.0
-	$(Q) cp -r $(SDK_BUILDDIR)/ios-targettv-release/mono/eglib/eglib-config.h $(BUILD_DESTDIR)/targettv/include/mono-2.0
 	$(Q) touch $@
 
 build-targettv: .stamp-build-targettv

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -3,18 +3,18 @@ builds_root=$(TOP)/builds
 
 # helpful rules to compile things for the various architectures
 
-COMMON_I:= -I. -I$(mono_root) -I$(mono_root)/mono/eglib -I$(mono_root)/mono/metadata 
-SIM32_I := $(COMMON_I) -I$(BUILD_DESTDIR)/simulator86/include/mono-2.0
-SIM64_I := $(COMMON_I) -I$(BUILD_DESTDIR)/simulator64/include/mono-2.0
-DEV7_I  := $(COMMON_I) -I$(BUILD_DESTDIR)/target7/include/mono-2.0
-DEV7s_I := $(COMMON_I) -I$(BUILD_DESTDIR)/target7s/include/mono-2.0
-DEV64_I := $(COMMON_I) -I$(BUILD_DESTDIR)/target64/include/mono-2.0
+COMMON_I:= -I.
+SIM32_I := $(COMMON_I)
+SIM64_I := $(COMMON_I)
+DEV7_I  := $(COMMON_I)
+DEV7s_I := $(COMMON_I)
+DEV64_I := $(COMMON_I)
 
-SIMW_I  := $(COMMON_I) -I$(BUILD_DESTDIR)/watchsimulator/include/mono-2.0
-DEVW_I  := $(COMMON_I) -I$(BUILD_DESTDIR)/targetwatch/include/mono-2.0
+SIMW_I  := $(COMMON_I)
+DEVW_I  := $(COMMON_I)
 
-SIM_TV_I:= $(COMMON_I) -I$(BUILD_DESTDIR)/tvsimulator/include/mono-2.0
-DEV_TV_I:= $(COMMON_I) -I$(BUILD_DESTDIR)/targettv/include/mono-2.0
+SIM_TV_I:= $(COMMON_I)
+DEV_TV_I:= $(COMMON_I)
 
 define NativeCompilationTemplate
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -50,9 +50,6 @@ bindings-generator.exe: bindings-generator.cs
 bindings-generated.m: bindings-generator.exe
 	$(Q_GEN) $(SYSTEM_MONO) --debug $< $@
 
-zlib-helper.c: $(MONO_PATH)/support/zlib-helper.c
-	$(Q) ln -fs $< $@
-
 # our makefiles don't support building the same source file multiple times with different defines,
 # so just symlink extension-main.m to another file and compile that instead.
 app-main.m watchextension-main.m tvextension-main.m: extension-main.m
@@ -83,7 +80,7 @@ MONOTOUCH_FRAMEWORKS =  \
 	Xamarin             \
 	Xamarin-debug       \
 
-MONOTOUCH_SOURCE_STEMS = $(patsubst %.s,%,$(patsubst %.m,%,$(SHARED_SOURCES) $(MONOTOUCH_SOURCES))) zlib-helper
+MONOTOUCH_SOURCE_STEMS = $(patsubst %.s,%,$(patsubst %.m,%,$(SHARED_SOURCES) $(MONOTOUCH_SOURCES)))
 MONOTOUCH_I386_SOURCE_STEMS = $(patsubst %.s,%,$(patsubst %.m,%,$(SHARED_I386_SOURCES)))
 MONOTOUCH_X86_64_SOURCE_STEMS = $(patsubst %.s,%,$(patsubst %.m,%,$(SHARED_X86_64_SOURCES)))
 
@@ -312,6 +309,20 @@ $(eval $(call LibTemplate,ios,IOS))
 $(eval $(call LibTemplate,watchos,WATCHOS))
 $(eval $(call LibTemplate,tvos,TVOS))
 
+SDK_BUILDDIR=$(MONO_PATH)/sdks/builds
+
+ZLIB_HELPER_IOS_armv7      = $(SDK_BUILDDIR)/ios-target32-release/support/zlib-helper.o
+ZLIB_HELPER_IOS_armv7s     = $(SDK_BUILDDIR)/ios-target32s-release/support/zlib-helper.o
+ZLIB_HELPER_IOS_arm64      = $(SDK_BUILDDIR)/ios-target64-release/support/zlib-helper.o
+ZLIB_HELPER_IOS_x86        = $(SDK_BUILDDIR)/ios-sim32-release/support/zlib-helper.o
+ZLIB_HELPER_IOS_x86_64     = $(SDK_BUILDDIR)/ios-sim64-release/support/zlib-helper.o
+
+ZLIB_HELPER_WATCHOS_armv7k = $(SDK_BUILDDIR)/ios-targetwatch-release/support/zlib-helper.o
+ZLIB_HELPER_WATCHOS_x86    = $(SDK_BUILDDIR)/ios-simwatch-release/support/zlib-helper.o
+
+ZLIB_HELPER_TVOS_arm64     = $(SDK_BUILDDIR)/ios-targettv-release/support/zlib-helper.o
+ZLIB_HELPER_TVOS_x86_64    = $(SDK_BUILDDIR)/ios-simtv-release/support/zlib-helper.o
+
 #
 # LibXamarinTemplate (and LibXamarinArchTemplate) builds libxamarin.a
 #
@@ -328,12 +339,12 @@ define LibXamarinTemplate
 $(1)$(3)_COMMON_DYLIB_FLAGS = -lmonosgen-2.0 -Wl,-install_name,libxamarin$(4).dylib -framework Foundation -framework CFNetwork -framework UIKit -lz
 $(1)$(3)_COMMON_FRAMEWORK_FLAGS = -framework Mono -Wl,-install_name,@rpath/Xamarin$(4).framework/Xamarin$(4) -framework Foundation -framework CFNetwork -framework UIKit -lz
 
-x86_$(1)$(3)_OBJECTS    = $$(patsubst %,.libs/$(1)/%$(4).x86.o,$$($(2)_SOURCE_STEMS))    $$(patsubst %,.libs/$(1)/%$(4).x86.o,$$($(2)_I386_SOURCE_STEMS))
-x86_64_$(1)$(3)_OBJECTS = $$(patsubst %,.libs/$(1)/%$(4).x86_64.o,$$($(2)_SOURCE_STEMS)) $$(patsubst %,.libs/$(1)/%$(4).x86_64.o,$$($(2)_X86_64_SOURCE_STEMS))
-armv7_$(1)$(3)_OBJECTS  = $$(patsubst %,.libs/$(1)/%$(4).armv7.o,$$($(2)_SOURCE_STEMS))
-armv7s_$(1)$(3)_OBJECTS = $$(patsubst %,.libs/$(1)/%$(4).armv7s.o,$$($(2)_SOURCE_STEMS))
-armv7k_$(1)$(3)_OBJECTS = $$(patsubst %,.libs/$(1)/%$(4).armv7k.o,$$($(2)_SOURCE_STEMS))
-arm64_$(1)$(3)_OBJECTS  = $$(patsubst %,.libs/$(1)/%$(4).arm64.o,$$($(2)_SOURCE_STEMS))
+x86_$(1)$(3)_OBJECTS    = $(ZLIB_HELPER_$(2)_x86)    $$(patsubst %,.libs/$(1)/%$(4).x86.o,$$($(2)_SOURCE_STEMS))    $$(patsubst %,.libs/$(1)/%$(4).x86.o,$$($(2)_I386_SOURCE_STEMS))
+x86_64_$(1)$(3)_OBJECTS = $(ZLIB_HELPER_$(2)_x86_64) $$(patsubst %,.libs/$(1)/%$(4).x86_64.o,$$($(2)_SOURCE_STEMS)) $$(patsubst %,.libs/$(1)/%$(4).x86_64.o,$$($(2)_X86_64_SOURCE_STEMS))
+armv7_$(1)$(3)_OBJECTS  = $(ZLIB_HELPER_$(2)_armv7)  $$(patsubst %,.libs/$(1)/%$(4).armv7.o,$$($(2)_SOURCE_STEMS))
+armv7s_$(1)$(3)_OBJECTS = $(ZLIB_HELPER_$(2)_armv7s) $$(patsubst %,.libs/$(1)/%$(4).armv7s.o,$$($(2)_SOURCE_STEMS))
+armv7k_$(1)$(3)_OBJECTS = $(ZLIB_HELPER_$(2)_armv7k) $$(patsubst %,.libs/$(1)/%$(4).armv7k.o,$$($(2)_SOURCE_STEMS))
+arm64_$(1)$(3)_OBJECTS  = $(ZLIB_HELPER_$(2)_arm64)  $$(patsubst %,.libs/$(1)/%$(4).arm64.o,$$($(2)_SOURCE_STEMS))
 
 $$(foreach arch,$$($(2)_ARCHITECTURES),$$(eval $$(call LibXamarinArchTemplate,$(1),$(2),$(3),$(4),$$(arch))))
 


### PR DESCRIPTION
This also makes it possible to simplify/remove some of our build logic.