### PR TITLE
[uikit] Preserve method associated with `updateSearchResultsForSearchController:`. Fixes #5024

### DIFF
--- a/src/UIKit/UISearchController.cs
+++ b/src/UIKit/UISearchController.cs
@@ -5,6 +5,7 @@
 #if !WATCH
 
 using System;
+using Foundation;
 
 namespace UIKit {
 
@@ -17,6 +18,8 @@ namespace UIKit {
 				this.cback = cback;
 				IsDirectBinding = false;
 			}
+
+			[Preserve (Conditional = true)] // called back from native, no direct managed reference (except on the type itself)
 			public override void UpdateSearchResultsForSearchController (UISearchController searchController)
 			{
 				cback (searchController);

--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -1038,6 +1038,20 @@ namespace LinkSdk {
 			Assert.NotNull (provider, "provider");
 			Assert.That (provider.ID, Is.EqualTo (new Guid ("981af8af-a3a3-419a-9f01-a518e3a17c1c")), "correct provider");
 		}
+
+		[Test]
+		public void Github5024 ()
+		{
+			TestRuntime.AssertXcodeVersion (6,0);
+			var sc = new UISearchController ((UIViewController) null);
+			sc.SetSearchResultsUpdater ((vc) => { });
+
+			var a = typeof (UISearchController).AssemblyQualifiedName;
+			var n = a.Replace ("UIKit.UISearchController", "UIKit.UISearchController+__Xamarin_UISearchResultsUpdating");
+			var t = Type.GetType (n);
+			Assert.NotNull (t, "private inner type");
+			Assert.IsNotNull (t.GetMethod ("UpdateSearchResultsForSearchController"), "preserved");
+		}
 #endif // !__WATCHOS__
 
 		[Test]


### PR DESCRIPTION
This method is called back from iOS (or tvOS) so there's no managed
reference pointing to it. However we know that if it's (private inner)
type is present it's because the callback (from native) is possible so
we can preserve the method conditionally (to the type presence).

https://github.com/xamarin/xamarin-macios/issues/5024