### PR TITLE
[2018-08][watchos] Use mono_dangerous_add_raw_internal_call for watchOS icalls

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -311,6 +311,11 @@
 			"const void *", "method"
 		),
 
+		new Export (true, "void", "mono_dangerous_add_raw_internal_call",
+			"const char *", "name",
+			"const void *", "method"
+		),
+
 		new Export ("MonoMethodSignature *", "mono_method_signature",
 			"MonoMethod *", "method"
 		),


### PR DESCRIPTION
With mono/mono@5756ba4 we added a new `mono_dangerous_add_raw_internal_call` function to register new icalls - icalls added with `mono_add_internal_call` run in GC Safe mode; icalls added with the new API run in GC Unsafe mode.

For hybrid suspend this means that icalls added with `mono_add_internal_call` can continue to be oblivious to the thread state (GC Safe / GC Unsafe) and can continue to make blocking calls, run for unbounded amounts of time without safepointing, etc.

For coop and hybrid suspend icalls added with `mono_dangerous_add_raw_internal_call` have to be thread state aware - they start in GC Unsafe mode and must switch to GC Safe around OS calls, blocking operations, or loops that run for a long time without safepointing.

This PR ensures that on watchOS icalls are registered using the new function so that they continue to run in GC Unsafe mode.