### PR TITLE
[mtouch] Display a specific error is a .framework binary is invalid. Fixes #5028

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -915,7 +915,9 @@ Alternatively, enable the managed [linker](https://docs.microsoft.com/en-us/xama
 
 As a last-straw solution, use an older version of Xamarin.iOS that does not require these new SDKs to be present during the build process.
 
-### <a name="MT0136"/>MT0136: Cannot find the assembly {assembly} referenced from {assembly}.
+<a name="MT0136"/>
+
+### MT0136: Cannot find the assembly {assembly} referenced from {assembly}.
 
 This warning occurs when an assembly passed to mtouch contains a reference to
 another assembly that can't be found.
@@ -923,7 +925,9 @@ another assembly that can't be found.
 mtouch may in certain cases still find references at a later point, which
 means that if the build otherwise succeeds, this warning can be ignored.
 
-### <a name="MT0137"/>MT0137: Cannot find the assembly {assembly}, referenced by an attribute in {assembly}.
+<a name="MT0137"/>
+
+### MT0137: Cannot find the assembly {assembly}, referenced by an attribute in {assembly}.
 
 This warning occurs when an attribute contains a reference to another assembly
 that can't be found.
@@ -932,6 +936,14 @@ mtouch may in certain cases still find references at a later point, which
 means that if the build otherwise succeeds, this warning can be ignored.
 
 <!-- 0138-0139: used by mmp -->
+
+<a name="MT0140"/>
+
+### MT0140: File '{framework_filename}' is not a valid framework.
+
+This error occurs when `mtouch` reads a binary in a `.framework` directory that is not a valid executable.
+
+It might be a broken file or a broken symlink (after decompressing an archive) to a valid file. The native framework should be removed and replaced with a valid one. 
 
 # MT1xxx: Project related error messages
 

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1667,7 +1667,13 @@ namespace Xamarin.Bundler {
 						throw ErrorHelper.CreateError (99, $"Internal error: 'can't convert frameworks to frameworks: {files.First ()}'. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).");
 					var framework_src = files.First ();
 					var framework_filename = Path.Combine (framework_src, Path.GetFileNameWithoutExtension (framework_src));
-					if (!MachO.IsDynamicFramework (framework_filename)) {
+					var dynamic = false;
+					try {
+						dynamic = MachO.IsDynamicFramework (framework_filename);
+					} catch (Exception e) {
+						throw ErrorHelper.CreateError (140, e, $"File '{framework_filename}' is not a valid framework.");
+					}
+					if (!dynamic) {
 						Driver.Log (1, "The framework {0} is a framework of static libraries, and will not be copied to the app.", framework_src);
 					} else {
 						var macho_file = Path.Combine (targetPath, Path.GetFileNameWithoutExtension (framework_src));


### PR DESCRIPTION
Instead of a generic `MT0000` caused by an exception reading the magic
numbers of the binary framework file.

This was caused be uncompressing an archive, with a symlink, into a
file system that does not support symlinks (on Windows).

ref: https://github.com/xamarin/xamarin-macios/issues/5028