### PR TITLE
[Foundation] Fix compiler warnings in NSUrlSessionHandler.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -68,6 +68,7 @@ namespace Foundation {
 		{
 		}
 
+		[CLSCompliant (false)]
 		public NSUrlSessionHandler (NSUrlSessionConfiguration configuration)
 		{
 			if (configuration == null)
@@ -86,7 +87,7 @@ namespace Foundation {
 			else if ((sp & SecurityProtocolType.Tls12) != 0)
 				configuration.TLSMinimumSupportedProtocol = SslProtocol.Tls_1_2;
 
-			session = NSUrlSession.FromConfiguration (configuration, new NSUrlSessionHandlerDelegate (this), null);
+			session = NSUrlSession.FromConfiguration (configuration, (INSUrlSessionDelegate) new NSUrlSessionHandlerDelegate (this), null);
 			inflightRequests = new Dictionary<NSUrlSessionTask, InflightData> ();
 		}
 


### PR DESCRIPTION
Fix these warnings:

    src/Foundation/NSUrlSessionHandler.cs(71,57): warning CS3001: Argument type 'NSUrlSessionConfiguration' is not CLS-compliant
    src/Foundation/NSUrlSessionHandler.cs(89,14): warning CS0618: 'NSUrlSession.FromConfiguration(NSUrlSessionConfiguration, NSUrlSessionDelegate, NSOperationQueue)' is obsolete: 'Use the overload with a 'INSUrlSessionDelegate' parameter.'