### PR TITLE
[coregraphics] Make MatrixOrder a normal enum instead of a nested enum

### DIFF
--- a/src/CoreGraphics/CGAffineTransform.cs
+++ b/src/CoreGraphics/CGAffineTransform.cs
@@ -107,11 +107,6 @@ namespace CoreGraphics {
 			y0 = a.x0 * b.yx + a.y0 * b.yy + b.y0;
 		}
 
-		public enum MatrixOrder {
-			Prepend = 0,
-			Append = 1,
-		}
-
 		public void Scale (nfloat sx, nfloat sy, MatrixOrder order)
 		{
 			switch (order) {

--- a/src/CoreGraphics/CGEnums.cs
+++ b/src/CoreGraphics/CGEnums.cs
@@ -1,0 +1,16 @@
+//
+// CGEnums.cs: Enumerations
+//
+// Author:
+//   Vincent Dondain (vidondai@microsoft.com)
+//
+// Copyright 2018 Microsoft
+//
+
+namespace CoreGraphics {
+
+	public enum MatrixOrder {
+		Prepend = 0,
+		Append = 1,
+	}
+}

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -440,6 +440,7 @@ COREGRAPHICS_CORE_SOURCES = \
 	CoreGraphics/CGColorSpace.cs \
 	CoreGraphics/CGContext.cs \
 	CoreGraphics/CGDisplay.cs \
+	CoreGraphics/CGEnums.cs \
 	CoreGraphics/CGGeometry.cs \
 	CoreGraphics/CGGradient.cs \
 	CoreGraphics/CGImage.cs \

--- a/tests/monotouch-test/CoreGraphics/AffineTransformTest.cs
+++ b/tests/monotouch-test/CoreGraphics/AffineTransformTest.cs
@@ -153,7 +153,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 
 			var transform2 = CGAffineTransform.MakeTranslation (1, 2);
 			// t' = [ sx 0 0 sy 0 0 ] * t – Swift equivalent
-			transform2.Scale (3, 4, CGAffineTransform.MatrixOrder.Prepend);
+			transform2.Scale (3, 4, MatrixOrder.Prepend);
 
 			Assert.AreEqual ((nfloat)3, transform2.xx);
 			Assert.AreEqual ((nfloat)0, transform2.yx);
@@ -204,7 +204,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 			Assert.AreEqual ((nfloat)3, transform.y0, "y0");
 
 			transform = new CGAffineTransform (1, 2, 3, 4, 5, 6);
-			transform.Translate (2, -3, CGAffineTransform.MatrixOrder.Prepend);
+			transform.Translate (2, -3, MatrixOrder.Prepend);
 
 			Assert.AreEqual ((nfloat)1, transform.xx, "xx");
 			Assert.AreEqual ((nfloat)2, transform.yx, "yx");
@@ -259,7 +259,7 @@ namespace MonoTouchFixtures.CoreGraphics {
 			Assert.That ((double) (-6), Is.EqualTo ((double) transform.y0).Within (0.000001), "y0");
 
 			transform = new CGAffineTransform (1, 2, 3, 4, 5, 6);
-			transform.Rotate ((nfloat)Math.PI, CGAffineTransform.MatrixOrder.Prepend);
+			transform.Rotate ((nfloat)Math.PI, MatrixOrder.Prepend);
 
 			Assert.That ((double)(-1), Is.EqualTo ((double)transform.xx).Within (0.000001), "xx");
 			Assert.That ((double)(-2), Is.EqualTo ((double)transform.yx).Within (0.000001), "yx");


### PR DESCRIPTION
This enum might prove useful to other APIs in the future so move outside of `CGAffineTransform`.