### PR TITLE
[msbuild] Avoid an NRE in BtouchTask when an invalid extra argument is provided

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/BTouchTaskBase.cs
@@ -202,15 +202,20 @@ namespace Xamarin.MacDev.Tasks {
 					{ "projectdir",   projectDir },
 					// Apparently msbuild doesn't propagate the solution path, so we can't get it.
 					// { "solutiondir",  proj.ParentSolution != null ? proj.ParentSolution.BaseDirectory : proj.BaseDirectory },
-					{ "targetpath",   Path.Combine (Path.GetDirectoryName (target), Path.GetFileName (target)) },
-					{ "targetdir",    Path.GetDirectoryName (target) },
-					{ "targetname",   Path.GetFileName (target) },
-					{ "targetext",    Path.GetExtension (target) },
 				};
+				// OutputAssembly is optional so it can be null
+				if (target != null) {
+					var d = Path.GetDirectoryName (target);
+					var n = Path.GetFileName (target);
+					customTags.Add ("targetpath", Path.Combine (d, n));
+					customTags.Add ("targetdir", d);
+					customTags.Add ("targetname", n);
+					customTags.Add ("targetext", Path.GetExtension (target));
+				}
 
 				for (int i = 0; i < extraArgs.Length; i++) {
 					var argument = extraArgs[i];
-
+					cmd.AppendTextUnquoted (" ");
 					cmd.AppendTextUnquoted (StringParserService.Parse (argument, customTags));
 				}
 			}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/BTouchTaskTest.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/BTouchTaskTest.cs
@@ -9,11 +9,7 @@ namespace Xamarin.iOS.Tasks
 {
 	class CustomBTouchTask : BTouch
 	{
-		public CustomBTouchTask ()
-		{
-		}
-
-		public new string GenerateCommandLineCommands ()
+		public string GetCommandLineCommands ()
 		{
 			return base.GenerateCommandLineCommands ();
 		}
@@ -30,7 +26,7 @@ namespace Xamarin.iOS.Tasks
 			task.ApiDefinitions = new[] { new TaskItem ("apidefinition.cs") };
 			task.References = new[] { new TaskItem ("a.dll"), new TaskItem ("b.dll"), new TaskItem ("c.dll") };
 
-			var args = task.GenerateCommandLineCommands ();
+			var args = task.GetCommandLineCommands ();
 			Assert.IsTrue (args.Contains ("-r " + Path.Combine (Environment.CurrentDirectory, "a.dll")), "#1a");
 			Assert.IsTrue (args.Contains ("-r " + Path.Combine (Environment.CurrentDirectory, "b.dll")), "#1b");
 			Assert.IsTrue (args.Contains ("-r " + Path.Combine (Environment.CurrentDirectory, "c.dll")), "#1c");
@@ -45,9 +41,9 @@ namespace Xamarin.iOS.Tasks
 			task.References = new[] { new TaskItem ("a.dll"), new TaskItem ("b.dll"), new TaskItem ("c.dll") };
 			task.ProjectDir = "~/"; // not important, but required (so can't be null)
 
-			task.OutputAssembly = null; // default, but important for the bug iset n case that default changes)
+			task.OutputAssembly = null; // default, but important for the bug (in case that default changes)
 			task.ExtraArgs = "-invalid";
-			var args = task.GenerateCommandLineCommands ();
+			var args = task.GetCommandLineCommands ();
 			Assert.That (args.Contains (" -invalid"), "incorrect ExtraArg not causing an exception");
 		}
 	}

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/BTouchTaskTest.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/BTouchTaskTest.cs
@@ -22,29 +22,34 @@ namespace Xamarin.iOS.Tasks
 	[TestFixture]
 	public class BTouchTaskTests : TestBase
 	{
-		CustomBTouchTask Task {
-			get; set;
-		}
-
-		public override void Setup ()
-		{
-			base.Setup ();
-
-			Task = CreateTask<CustomBTouchTask> ();
-
-			Task.ApiDefinitions = new [] { new TaskItem ("apidefinition.cs") };
-			Task.References = new [] { new TaskItem ("a.dll"), new TaskItem ("b.dll"), new TaskItem ("c.dll") };
-		}
-
 		[Test]
 		public void StandardCommandline ()
 		{
-			var args = Task.GenerateCommandLineCommands ();
+			var task = CreateTask<CustomBTouchTask> ();
+
+			task.ApiDefinitions = new[] { new TaskItem ("apidefinition.cs") };
+			task.References = new[] { new TaskItem ("a.dll"), new TaskItem ("b.dll"), new TaskItem ("c.dll") };
+
+			var args = task.GenerateCommandLineCommands ();
 			Assert.IsTrue (args.Contains ("-r " + Path.Combine (Environment.CurrentDirectory, "a.dll")), "#1a");
 			Assert.IsTrue (args.Contains ("-r " + Path.Combine (Environment.CurrentDirectory, "b.dll")), "#1b");
 			Assert.IsTrue (args.Contains ("-r " + Path.Combine (Environment.CurrentDirectory, "c.dll")), "#1c");
 		}
 
+		[Test]
+		public void Bug656983 ()
+		{
+			var task = CreateTask<CustomBTouchTask> ();
+
+			task.ApiDefinitions = new[] { new TaskItem ("apidefinition.cs") };
+			task.References = new[] { new TaskItem ("a.dll"), new TaskItem ("b.dll"), new TaskItem ("c.dll") };
+			task.ProjectDir = "~/"; // not important, but required (so can't be null)
+
+			task.OutputAssembly = null; // default, but important for the bug iset n case that default changes)
+			task.ExtraArgs = "-invalid";
+			var args = task.GenerateCommandLineCommands ();
+			Assert.That (args.Contains (" -invalid"), "incorrect ExtraArg not causing an exception");
+		}
 	}
 }
 


### PR DESCRIPTION
The task itself should not throw. An invalid argument is an error that
should (and is) reported by `btouch` itself (and the task picks it up).
This makes the error reporting much more useful and the way an exception
is reported, from Windows, is also confusing
```
MessagingRemoteException: An error occured on client Build4110732 while executing a reply for topic xvs/Build/4.11.0.732/execute-task/ClassLibrary1/6e85b94002fBTouch ArgumentNullException: Value cannot be null.
```

Unit tests added.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/656983