### PR TITLE
[xharness] Log the environment variables in the execution logs

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -2883,6 +2884,8 @@ function toggleAll (show)
 					}
 					proc.StartInfo.Arguments = args.ToString ();
 					SetEnvironmentVariables (proc);
+					foreach (DictionaryEntry de in proc.StartInfo.EnvironmentVariables)
+						log.WriteLine ($"export {de.Key}={de.Value}");
 					Jenkins.MainLog.WriteLine ("Executing {0} ({1})", TestName, Mode);
 					if (!Harness.DryRun) {
 						ExecutionResult = TestExecutingResult.Running;


### PR DESCRIPTION
While trying to debug an msbuild unit tests it was not possible to
successfully copy/paste the command from the execution log and
run it in a shell.

It's not that hard to run xharness and figure it out - but the
same can happen on bots (which could be harder).

So that little change prints out the host and xharness changes
to the environment variables to make copy/pasters life even
lazier :)