### PR TITLE
[iTunesLibrary] Fix typo & confusion.

### DIFF
--- a/src/Constants.mac.cs.in
+++ b/src/Constants.mac.cs.in
@@ -146,6 +146,6 @@ namespace MonoMac {
 		public const string NaturalLanguageLibrary = "/System/Library/Frameworks/Frameworks/NaturalLanguage.framework/NaturalLanguage";
 		public const string VideoSubscriberAccountLibrary = "/System/Library/Frameworks/VideoSubscriberAccount.framework/VideoSubscriberAccount";
 		public const string UserNotificationsLibrary = "/System/Library/Frameworks/UserNotifications.framework/UserNotifications";
-		public const string iTunesLibraryLibrary = "/System/Library/Frameworks/iTunesLibrary.framewor/iTunesLibrary";
+		public const string iTunesLibraryLibrary = "/System/Library/Frameworks/iTunesLibrary.framework/iTunesLibrary";
 	}
 }

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -134,7 +134,6 @@ public class Frameworks : Dictionary <string, Framework>
 
 					{ "AVKit", 10, 9 },
 					{ "GameController", 10, 9 },
-					{ "ITunesLibrary", "iTunesLibrary", 10, 9 },
 					{ "MapKit", 10, 9 },
 					{ "MediaAccessibility", 10, 9 },
 					{ "MediaLibrary", 10, 9 },


### PR DESCRIPTION
I'm not sure why we have an entry in our list of frameworks claiming that
iTunesLibrary was introduced in macOS 10.9, when we didn't have any bindings
for the library back then.

In any case we also have an entry for iTunesLibrary in our list of frameworks
claiming that iTunesLibrary was introduced in macOS 10.14.

I looked at some of Apple's documentation for the types in iTunesLibrary, and
they all claim to be introduced in macOS 10.13 [2].

And to make matters even more interesting, Apple's documentation for the
framework itself states the library is in
/Library/Frameworks/iTunesLibrary.framework, and ships with iTunes 11.0+ [1]
(which is introduced in 2012).

Then I looked at a macOS 10.14 machine, and the framework is available at
/System/Library/Frameworks/iTunesLibrary.framework, and
/Library/Frameworks/iTunesLibrary.framework is just a symlink there
(/System/Library/Frameworks/iTunesLibrary.framework does not exist on my macOS
10.13 machines, while /Library/Frameworks/iTunesLibrary.framework does). From
this I conclude that the framework was converted into a
system framework in macOS 10.14, and as such our claim that the framework was
introduced in 10.14 is at least somewhat right.

So treat iTunesLibrary as any other framework introduced in macOS 10.14, and
remove our (duplicated) framework entry for 10.9 (for which we didn't have any
bindings anyway).

Also fix the path to the framework, I'm wonder how this got past our tests in
the first place.

[1] https://developer.apple.com/documentation/ituneslibrary: "... located at /Library/Frameworks/iTunesLibrary.framework ... The iTunes Library framework is available to users running iTunes v11.0 or above."
[2] https://developer.apple.com/documentation/ituneslibrary/itlibrary?language=objc