### PR TITLE
[msbuild] VS Incremental build fixes

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
+using System.Linq;
 using System.Diagnostics;
 
 using Parallel = System.Threading.Tasks.Parallel;
@@ -8,12 +9,15 @@ using ParallelOptions = System.Threading.Tasks.ParallelOptions;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using System.Collections.Generic;
 
 namespace Xamarin.MacDev.Tasks
 {
 	public abstract class CodesignTaskBase : Task
 	{
 		const string ToolName = "codesign";
+		const string MacOSDirName = "MacOS";
+		const string CodeSignatureDirName = "_CodeSignature";
 		string toolExe;
 
 		#region Inputs
@@ -47,6 +51,13 @@ namespace Xamarin.MacDev.Tasks
 		}
 
 		public string ToolPath { get; set; }
+
+		#endregion
+
+		#region Outputs
+
+		[Output]
+		public ITaskItem[] CodesignedFiles { get; set; }
 
 		#endregion
 
@@ -153,11 +164,64 @@ namespace Xamarin.MacDev.Tasks
 			if (Resources.Length == 0)
 				return true;
 
+			var codesignedFiles = new List<ITaskItem> ();
+
 			Parallel.ForEach (Resources, new ParallelOptions { MaxDegreeOfParallelism = Math.Max (Environment.ProcessorCount / 2, 1) }, (item) => {
 				Codesign (item);
+
+				codesignedFiles.AddRange (GetCodesignedFiles (item));
 			});
 
+			CodesignedFiles = codesignedFiles.ToArray ();
+
 			return !Log.HasLoggedErrors;
+		}
+
+		IEnumerable<ITaskItem> GetCodesignedFiles (ITaskItem item)
+		{
+			var codesignedFiles = new List<ITaskItem> ();
+
+			if (Directory.Exists (item.ItemSpec)) {
+				var codeSignaturePath = Path.Combine (item.ItemSpec, CodeSignatureDirName);
+
+				if (!Directory.Exists (codeSignaturePath))
+					return codesignedFiles;
+
+				codesignedFiles.AddRange (Directory.EnumerateFiles (codeSignaturePath).Select (x => new TaskItem (x)));
+
+				var extension = Path.GetExtension (item.ItemSpec);
+
+				if (extension == ".app" || extension == ".appex") {
+					var executableName = Path.GetFileName (item.ItemSpec);
+					var manifestPath = Path.Combine (item.ItemSpec, "Info.plist");
+
+					if (File.Exists(manifestPath)) {
+						var bundleExecutable = PDictionary.FromFile (manifestPath).GetCFBundleExecutable ();
+
+						if (!string.IsNullOrEmpty(bundleExecutable))
+							executableName = bundleExecutable;
+					}
+
+					var basePath = item.ItemSpec;
+
+					if (Directory.Exists (Path.Combine (basePath, MacOSDirName)))
+						basePath = Path.Combine (basePath, MacOSDirName);
+
+					var executablePath = Path.Combine (basePath, executableName);
+
+					if (File.Exists (executablePath))
+						codesignedFiles.Add (new TaskItem (executablePath));
+				}
+			} else if (File.Exists (item.ItemSpec)) {
+				codesignedFiles.Add (item);
+
+				var dirName = Path.GetDirectoryName (item.ItemSpec);
+
+				if (Path.GetExtension (dirName) == ".framework")
+					codesignedFiles.AddRange (Directory.EnumerateFiles (Path.Combine (dirName, CodeSignatureDirName)).Select (x => new TaskItem (x)));
+			}
+
+			return codesignedFiles;
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Collections.Generic;
 
@@ -31,7 +31,7 @@ namespace Xamarin.MacDev.Tasks
 
 		[Output]
 		[Required]
-		public string CompiledEntitlements { get; set; }
+		public ITaskItem CompiledEntitlements { get; set; }
 
 		public string Entitlements { get; set; }
 
@@ -363,8 +363,8 @@ namespace Xamarin.MacDev.Tasks
 			archived = GetArchivedExpandedEntitlements (template, compiled);
 
 			try {
-				Directory.CreateDirectory (Path.GetDirectoryName (CompiledEntitlements));
-				WriteXcent (compiled, CompiledEntitlements);
+				Directory.CreateDirectory (Path.GetDirectoryName (CompiledEntitlements.ItemSpec));
+				WriteXcent (compiled, CompiledEntitlements.ItemSpec);
 			} catch (Exception ex) {
 				Log.LogError ("Error writing xcent file '{0}': {1}", CompiledEntitlements, ex.Message);
 				return false;

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DSymUtilTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DSymUtilTaskBase.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.IO;
+using System.Linq;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -25,8 +26,26 @@ namespace Xamarin.MacDev.Tasks
 
 		#endregion
 
+		#region Outputs
+
+		[Output]
+		public ITaskItem[] DsymContentFiles { get; set; }
+
+		#endregion
+
 		protected override string ToolName {
 			get { return "dsymutil"; }
+		}
+
+		public override bool Execute ()
+		{
+			var result = base.Execute ();
+
+			var contentsDir = Path.Combine (DSymDir, "Contents");
+			if (Directory.Exists(contentsDir))
+				DsymContentFiles = Directory.EnumerateFiles (contentsDir).Select (x => new TaskItem (x)).ToArray ();
+
+			return result;
 		}
 
 		protected override string GenerateFullPathToTool ()

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileITunesMetadataTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileITunesMetadataTaskBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 
 using Microsoft.Build.Framework;
@@ -20,6 +20,7 @@ namespace Xamarin.iOS.Tasks
 
 		public ITaskItem[] ITunesMetadata { get; set; }
 
+		[Output]
 		[Required]
 		public ITaskItem OutputPath { get; set; }
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1486,7 +1486,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CompileEntitlements" Condition="'$(_RequireCodeSigning)' == 'true' Or '$(CodesignEntitlements)' != ''" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectSigningIdentity"
-		Outputs="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent">
+		Inputs="$(CodesignEntitlements)" Outputs="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent">
 		<CompileEntitlements
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
@@ -1618,7 +1618,9 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</DetectDebugNetworkConfiguration>
 	</Target>
 
-	<Target Name="_CopyAppExtensionsToBundle" DependsOnTargets="_ResolveAppExtensionReferences">
+	<Target Name="_CopyAppExtensionsToBundle" DependsOnTargets="_ResolveAppExtensionReferences" Inputs="@(_ResolvedAppExtensionReferences)" 
+		  Outputs="$(_AppBundlePath)PlugIns\%(_ResolvedAppExtensionReferences.FileName)%(_ResolvedAppExtensionReferences.Extension)">
+		
 		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '@(_ResolvedAppExtensionReferences)' != ''" Directories="$(_AppBundlePath)PlugIns" />
 
 		<Ditto

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using Microsoft.Build.Utilities;
 using NUnit.Framework;
 using Xamarin.MacDev;
 
@@ -36,14 +37,14 @@ namespace Xamarin.iOS.Tasks
 			task.AppBundleDir = AppBundlePath;
 			task.AppIdentifier = "32UV7A8CDE.com.xamarin.MySingleView";
 			task.BundleIdentifier = "com.xamarin.MySingleView";
-			task.CompiledEntitlements = Path.Combine (MonoTouchProjectObjPath, "Entitlements.xcent");
+			task.CompiledEntitlements = new TaskItem (Path.Combine (MonoTouchProjectObjPath, "Entitlements.xcent"));
 			task.Entitlements = Path.Combine ("..", "bin", "Resources", "Entitlements.plist");
 			task.IsAppExtension = false;
 			task.ProvisioningProfile = Path.Combine ("..", "bin", "Resources", "profile.mobileprovision");
 			task.SdkPlatform = "iPhoneOS";
 			task.SdkVersion = "6.1";
 
-			compiledEntitlements = task.CompiledEntitlements;
+			compiledEntitlements = task.CompiledEntitlements.ItemSpec;
 		}
 
 		[Test (Description = "Xambug #46298")]


### PR DESCRIPTION
Most of these changes are needed from VS to fix incremental build issues.

The problem here is VS runs MSBuild on Windows and remotes (most of) the task executions to the Mac. Since MSBuild is running on Windows the inputs and outputs are checked there, but the output files won't be created on Windows unless those are explicitly declared as output ITaskItems of a task. VS don't copy every file created on the Mac back to Windows because that will increase the build time unnecessarily.

For instance, the _GenerateFrameworkDebugSymbols target was using the Info.plist file created by the dsymutil tool as output, but that file was not declared as ITaskItem output of the DsymUtil task so VS didn't know that file should be created on Windows.

This doesn't mean every task should have an output property declaring ITaskItems, but if you're writing a target that will use certain files as output those files should be output of one of the tasks that target is running.

Partial fix for https://dev.azure.com/devdiv/DevDiv/_workitems/edit/710309.