### PR TITLE
[jenkins] Remove any system versions of XI/XM to make absolutely sure nothing in our build requires them.

### DIFF
--- a/jenkins/provision-deps.sh
+++ b/jenkins/provision-deps.sh
@@ -18,4 +18,8 @@ fi
 
 ./system-dependencies.sh --provision-all
 
+sudo rm -Rf /Developer/MonoTouch
+sudo rm -Rf /Library/Frameworks/Xamarin.iOS.framework
+sudo rm -Rf /Library/Frameworks/Xamarin.Mac.framework
+
 echo "✅ [Provisioning succeeded]($BUILD_URL/console)" >> "$WORKSPACE/jenkins/pr-comments.md"


### PR DESCRIPTION
Completely remove XI/XM from the system when provisioning a bot, so that we can be absolutely sure nothing in our build and/or test setup tries to use them.