### PR TITLE
[xcode10.1] [tests] Fix some tests to succeed when run on macOS 10.14

### DIFF
--- a/tests/apitest/src/EveryFrameworkSmokeTest.cs
+++ b/tests/apitest/src/EveryFrameworkSmokeTest.cs
@@ -76,6 +76,12 @@ namespace Xamarin.Mac.Tests
 				case "ExternalAccessoryLibrary":
 				case "CoreSpotlightLibrary":
 				case "BusinessChatLibrary":
+				// macOS 10.14
+				case "AdSupportLibrary":
+				case "iTunesLibraryLibrary":
+				case "NetworkLibrary":
+				case "UserNotificationsLibrary":
+				case "VideoSubscriberAccountLibrary":
 					return LoadStatus.Acceptable;
 				}
 			}
@@ -95,7 +101,7 @@ namespace Xamarin.Mac.Tests
 				// Use RTLD_NOLOAD (0x10) so we don't load, just check to see if it is in memory
 				IntPtr handle = Dlfcn.dlopen (path, 0x10);
 				if (handle == IntPtr.Zero && CheckLoadFailure (info.Name, path) == LoadStatus.FailTest)
-					failures.Add (string.Format ("{0} ({1}) failed to load but this was not expected", info.Name, path));
+					failures.Add ($"{info.Name} ({path}) failed to load but this was not expected{Environment.NewLine}");
 			}
 
 			if (failures.Count > 0)

--- a/tests/introspection/Mac/MacApiFieldTest.cs
+++ b/tests/introspection/Mac/MacApiFieldTest.cs
@@ -159,6 +159,14 @@ namespace Introspection {
 				if (Mac.CheckSystemVersion (10, 13)) // radar 32858911
 					return true;
 				goto default;
+#if !UNIFIED
+			case "InputRSSArticleDurationKey":
+			case "InputRSSFeedURLKey":
+			case "ProtocolRSSVisualizer":
+				if (Mac.CheckSystemVersion (10, 14))
+					return true;
+				goto default;
+#endif
 			default:
 				return base.Skip (p);
 			}
@@ -186,6 +194,14 @@ namespace Introspection {
 				if (Mac.Is32BitMavericks)
 					return true;
 				goto default;
+#if !UNIFIED
+			case "QCCompositionInputRSSArticleDurationKey":
+			case "QCCompositionInputRSSFeedURLKey":
+			case "QCCompositionProtocolRSSVisualizer":
+				if (Mac.CheckSystemVersion (10, 14))
+					return true;
+				goto default;
+#endif
 			default:
 				return base.Skip (constantName, libraryName);
 			}

--- a/tests/introspection/Mac/MacApiProtocolTest.cs
+++ b/tests/introspection/Mac/MacApiProtocolTest.cs
@@ -75,6 +75,16 @@ namespace Introspection {
 				case "NSTextTable":
 				case "NSTextTableBlock":
 					return true;
+#if !UNIFIED
+				// existing classic/old binary is not updated
+				case "NSAppearance":
+				case "NSBezierPath":
+				case "NSFileWrapper":
+				case "NSGradient":
+				case "NSSound":
+				case "NSShadow":
+					return true;
+#endif
 				default:
 					// CIFilter started implementing NSSecureCoding in 10.11
 					if (!Mac.CheckSystemVersion (10, 11) && (type == typeof(CIFilter) || type.IsSubclassOf (typeof(CIFilter))))

--- a/tests/introspection/Mac/MacCoreImageFiltersTest.cs
+++ b/tests/introspection/Mac/MacCoreImageFiltersTest.cs
@@ -37,7 +37,7 @@ namespace Introspection {
 			case "CIMaskedVariableBlur": // Appears removed in 10.11 but not documented
 				if (Mac.CheckSystemVersion (10, 11))
 					return true;
-				return false;
+				break;
 			case "CICMYKHalftone": // Renamed as CICmykHalftone
 				return true;
 #if !__UNIFIED__
@@ -60,9 +60,18 @@ namespace Introspection {
 			case "CITextImageGenerator":
 				return true;
 #endif
-			default:
-				return base.Skip (nativeName);
+			case "CIAreaMinMax":
+			case "CICameraCalibrationLensCorrection":
+			case "CIDither":
+			case "CIGuidedFilter":
+			case "CIMeshGenerator":
+			case "CIMix":
+			case "CISampleNearest":
+				if (IntPtr.Size == 4)
+					return true;
+				break;
 			}
+			return base.Skip (nativeName);
 		}
 	}
 }

--- a/tests/monotouch-test/CoreFoundation/DispatchTests.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchTests.cs
@@ -181,29 +181,10 @@ namespace MonoTouchFixtures.CoreFoundation {
 		[Test]
 		public void GetGlobalQueue_Priority ()
 		{
-			string qdefault, qlow, qhigh;
-			var newDefaults = false;
-#if __IOS__
-			if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 8, 0))
-				newDefaults = true;
-#elif __WATCHOS__ || __TVOS__
-			newDefaults = true;
-#elif __MACOS__
-			if (TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 10))
-				newDefaults = true;
-#endif
-			if (newDefaults) {
-				qdefault = "com.apple.root.default-qos";
-				qlow = "com.apple.root.utility-qos";
-				qhigh = "com.apple.root.user-initiated-qos";
-			} else {
-				qdefault = "com.apple.root.default-priority";
-				qlow = "com.apple.root.low-priority";
-				qhigh = "com.apple.root.high-priority";
-			}
-			Assert.That (DispatchQueue.GetGlobalQueue (DispatchQueuePriority.Default).Label, Is.EqualTo (qdefault), "Default");
-			Assert.That (DispatchQueue.GetGlobalQueue (DispatchQueuePriority.Low).Label, Is.EqualTo (qlow), "Low");
-			Assert.That (DispatchQueue.GetGlobalQueue (DispatchQueuePriority.High).Label, Is.EqualTo (qhigh), "High");
+			// values changes in OS versions (and even in arch) but we only want to make sure we get a valid string so the prefix is enough
+			Assert.True (DispatchQueue.GetGlobalQueue (DispatchQueuePriority.Default).Label.StartsWith ("com.apple.root."), "Default");
+			Assert.True (DispatchQueue.GetGlobalQueue (DispatchQueuePriority.Low).Label.StartsWith ("com.apple.root."), "Low");
+			Assert.True (DispatchQueue.GetGlobalQueue (DispatchQueuePriority.High).Label.StartsWith ("com.apple.root."), "High");
 		}
 
 		[Test]

--- a/tests/monotouch-test/NaturalLanguage/NLTaggerTest.cs
+++ b/tests/monotouch-test/NaturalLanguage/NLTaggerTest.cs
@@ -29,14 +29,13 @@ namespace MonoTouchFixtures.NaturalLanguage {
 			using (var tagger = new NLTagger (NLTagScheme.Lemma) { String = Text })
 			using (var tag = tagger.GetTag (0, NLTokenUnit.Word, NLTagScheme.Lemma, out var range)) {
 				Assert.That (tagger.DominantLanguage, Is.EqualTo (NLLanguage.English), "DominantLanguage");
-#if !__TVOS__
-				// works everywhere expect tvOS
-				Assert.That (tag.ToString (), Is.EqualTo ("the"), "First word");
-#endif
 				Assert.That (range.Location, Is.EqualTo (0), "Location");
 				Assert.That (range.Length, Is.EqualTo (3), "Length");
+				// rdar https://trello.com/c/3oN5kuYk
+				if (tag != null)
+					Assert.That (tag.ToString (), Is.EqualTo ("the"), "First word");
 			}
-	       }
+		}
 
 		[Test]
 		public void GetTags ()


### PR DESCRIPTION
Backport of #5057.

Make the build green (or greener) which is good hygiene because freezing the `xcode10.1` branch and back porting it to `d15-9`.

/cc @spouliot 

Description:
Public bots were updated yesterday.

Fixes https://github.com/xamarin/maccore/issues/1106
Fixes https://github.com/xamarin/maccore/issues/1107