### PR TITLE
[msbuild] Don't log notices as errors

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeCompilerToolTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeCompilerToolTask.cs
@@ -211,7 +211,7 @@ namespace Xamarin.MacDev.Tasks
 			if (plist.TryGetValue (string.Format ("com.apple.{0}.document.notices", ToolName), out array)) {
 				foreach (var item in array.OfType<PDictionary> ()) {
 					if (item.TryGetValue ("message", out message))
-						Log.LogMessage (MessageImportance.Low, "{0}", message.Value);
+						Log.LogMessage (MessageImportance.Low, "{0} notice : {1}", ToolName, message.Value);
 				}
 			}
 
@@ -235,7 +235,7 @@ namespace Xamarin.MacDev.Tasks
 					array = valuePair.Value as PArray;
 					foreach (var item in array.OfType<PDictionary> ()) {
 						if (item.TryGetValue ("message", out message))
-							Log.LogMessage (MessageImportance.Low, "{0}", message.Value);
+							Log.LogMessage (MessageImportance.Low, "{0} notice : {1}", ToolName, message.Value);
 					}
 				}
 			}
@@ -270,7 +270,7 @@ namespace Xamarin.MacDev.Tasks
 			if (plist.TryGetValue (string.Format ("com.apple.{0}.notices", ToolName), out array)) {
 				foreach (var item in array.OfType<PDictionary> ()) {
 					if (item.TryGetValue ("description", out message))
-						Log.LogWarning (ToolName, null, null, file.ItemSpec, 0, 0, 0, 0, "{0}", message.Value);
+						Log.LogMessage (MessageImportance.Low, "{0} notice : {1}", ToolName, message.Value);
 				}
 			}
 		}

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeCompilerToolTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/XcodeCompilerToolTask.cs
@@ -270,7 +270,7 @@ namespace Xamarin.MacDev.Tasks
 			if (plist.TryGetValue (string.Format ("com.apple.{0}.notices", ToolName), out array)) {
 				foreach (var item in array.OfType<PDictionary> ()) {
 					if (item.TryGetValue ("description", out message))
-						Log.LogError (ToolName, null, null, file.ItemSpec, 0, 0, 0, 0, "{0}", message.Value);
+						Log.LogWarning (ToolName, null, null, file.ItemSpec, 0, 0, 0, 0, "{0}", message.Value);
 				}
 			}
 		}


### PR DESCRIPTION
- Fixes #5065: [Xcode10.1]Could not get traitsetID for iPhone11,6 error while building with Xcode10.1 and new iOS device
  (https://github.com/xamarin/xamarin-macios/issues/5065).
- `actool` in Xcode 10.1 now outputs some `com.apple.actool.notices` (we might not have hit that before) and those make the task fail because we log them as errors (we shouldn't).