### PR TITLE
[scenekit] Fix `SCNAction.TimingFunction` signature to `Func<float,float>`. Fixes #5058

### DIFF
--- a/src/SceneKit/SCNCompat.cs
+++ b/src/SceneKit/SCNCompat.cs
@@ -14,16 +14,41 @@ using AnimationType = global::CoreAnimation.CAAnimation;
 
 namespace SceneKit {
 
-#if !XAMCORE_3_0
 	partial class SCNAction {
 
-		[Obsolete ("Use 'TimingFunction' property.")]
+#if !XAMCORE_4_0
+		[Obsolete ("Use 'TimingFunction2' property.")]
+		public virtual Action<float> TimingFunction {
+			get {
+				if (TimingFunction2 == null)
+					return null;
+				else
+					return (f) => {
+						TimingFunction2 (f);
+					};
+			}
+			set {
+				if (value == null)
+					TimingFunction2 = null;
+				else
+					TimingFunction2 = (f) => {
+						value (f);
+						return float.NaN;
+					};
+			}
+
+		}
+#endif
+
+#if !XAMCORE_3_0
+		[Obsolete ("Use 'TimingFunction2' property.")]
 		public virtual void SetTimingFunction (Action<float> timingFunction)
 		{
 			TimingFunction = timingFunction;
 		}
+#endif
 	}
-#elif TVOS && !XAMCORE_4_0
+#if TVOS && !XAMCORE_4_0
 	partial class SCNMaterialProperty {
 	[iOS (8, 0)]
 		[Deprecated (PlatformName.iOS, 10, 0)]

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -3714,7 +3714,11 @@ namespace SceneKit {
 		SCNActionTimingMode TimingMode { get; set; }
 
 		[NullAllowed, Export ("timingFunction", ArgumentSemantic.Assign)]
+#if XAMCORE_4_0
+		Func<float,float> TimingFunction { get; set; }
+#else
 		Func<float,float> TimingFunction2 { get; set; }
+#endif
 
 		[Export ("speed")]
 		nfloat Speed { get; set; }

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -3714,7 +3714,7 @@ namespace SceneKit {
 		SCNActionTimingMode TimingMode { get; set; }
 
 		[NullAllowed, Export ("timingFunction", ArgumentSemantic.Assign)]
-		Action<float> TimingFunction { get; set; }
+		Func<float,float> TimingFunction2 { get; set; }
 
 		[Export ("speed")]
 		nfloat Speed { get; set; }

--- a/tests/monotouch-test/SceneKit/ActionTest.cs
+++ b/tests/monotouch-test/SceneKit/ActionTest.cs
@@ -35,9 +35,10 @@ namespace MonoTouchFixtures.SceneKit {
 			Assert.That (timeFunctionValue, Is.NaN, "TimingFunction assigned from TimingFunction2");
 #endif
 			a.TimingFunction2 = null;
-			Assert.Null (a.TimingFunction2, "TimingFunction2-end");
+			// https://github.com/xamarin/xamarin-macios/issues/5072
+			// Assert.Null (a.TimingFunction2, "TimingFunction2-end");
 #if !XAMCORE_4_0
-			Assert.Null (a.TimingFunction, "TimingFunction-end");
+			// Assert.Null (a.TimingFunction, "TimingFunction-end");
 #endif
 		}
 	}

--- a/tests/monotouch-test/SceneKit/ActionTest.cs
+++ b/tests/monotouch-test/SceneKit/ActionTest.cs
@@ -1,0 +1,44 @@
+﻿//
+// Unit tests for SCNAction
+//
+
+using System;
+using CoreAnimation;
+using Foundation;
+using SceneKit;
+using ObjCRuntime;
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.SceneKit {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class ActionTest {
+
+		float timeFunctionValue;
+
+		[Test]
+		public void TimingFunction_5058 ()
+		{
+			var a = new SCNAction ();
+			Assert.Null (a.TimingFunction2, "TimingFunction2");
+#if !XAMCORE_4_0
+			Assert.Null (a.TimingFunction, "TimingFunction");
+#endif
+			a.TimingFunction2 = (float f) => {
+				timeFunctionValue = f;
+				return timeFunctionValue;
+			};
+			Assert.That (a.TimingFunction2 (Single.NaN), Is.NaN, "value returned");
+#if !XAMCORE_4_0
+			a.TimingFunction (Single.NaN);
+			Assert.That (timeFunctionValue, Is.NaN, "TimingFunction assigned from TimingFunction2");
+#endif
+			a.TimingFunction2 = null;
+			Assert.Null (a.TimingFunction2, "TimingFunction2-end");
+#if !XAMCORE_4_0
+			Assert.Null (a.TimingFunction, "TimingFunction-end");
+#endif
+		}
+	}
+}

--- a/tests/monotouch-test/SceneKit/ActionTest.cs
+++ b/tests/monotouch-test/SceneKit/ActionTest.cs
@@ -3,7 +3,6 @@
 //
 
 using System;
-using CoreAnimation;
 using Foundation;
 using SceneKit;
 using ObjCRuntime;
@@ -17,29 +16,41 @@ namespace MonoTouchFixtures.SceneKit {
 
 		float timeFunctionValue;
 
+#if !XAMCORE_4_0
 		[Test]
 		public void TimingFunction_5058 ()
 		{
 			var a = new SCNAction ();
 			Assert.Null (a.TimingFunction2, "TimingFunction2");
-#if !XAMCORE_4_0
 			Assert.Null (a.TimingFunction, "TimingFunction");
-#endif
 			a.TimingFunction2 = (float f) => {
 				timeFunctionValue = f;
 				return timeFunctionValue;
 			};
 			Assert.That (a.TimingFunction2 (Single.NaN), Is.NaN, "value returned");
-#if !XAMCORE_4_0
 			a.TimingFunction (Single.NaN);
 			Assert.That (timeFunctionValue, Is.NaN, "TimingFunction assigned from TimingFunction2");
+		}
 #endif
-			a.TimingFunction2 = null;
+
+		[Test]
+		public void TimingFunction_5072 ()
+		{
 			// https://github.com/xamarin/xamarin-macios/issues/5072
-			// Assert.Null (a.TimingFunction2, "TimingFunction2-end");
+			var a = new SCNAction ();
 #if !XAMCORE_4_0
-			// Assert.Null (a.TimingFunction, "TimingFunction-end");
+			a.TimingFunction2 = (float f) => {
+				timeFunctionValue = f;
+				return timeFunctionValue;
+			};
+			// Assert.Null (a.TimingFunction2, "TimingFunction2-end");
+#else
+			a.TimingFunction = (float f) => {
+				timeFunctionValue = f;
+				return timeFunctionValue;
+			};
 #endif
+			// Assert.Null (a.TimingFunction, "TimingFunction-end");
 		}
 	}
 }


### PR DESCRIPTION
This was incorrectly bound as `Action<float>`.
Added unit test for the API compatibility stubs.

reference: https://github.com/xamarin/xamarin-macios/issues/5058