### PR TITLE
[RFC] MSBuild\MMP Test Template Rework

### DIFF
--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.MMP.Tests</RootNamespace>
     <AssemblyName>mmptest</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -125,6 +126,12 @@
     <EmbeddedResource Include="..\common\mac\remoting.config">
       <Link>remoting.config</Link>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\test-template\test-template-mac\test-template-mac.csproj">
+      <Project>{A19E7BA3-FB49-480B-9C8A-07A1DA5D5EB4}</Project>
+      <Name>test-template-mac</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="CustomBuildActions.targets" />

--- a/tests/msbuild-mac/msbuild-mac.csproj
+++ b/tests/msbuild-mac/msbuild-mac.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>msbuildMac</RootNamespace>
     <AssemblyName>msbuild-mac</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -65,6 +66,12 @@
     <Compile Include="..\common\Profile.cs">
       <Link>Profile.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\test-template\test-template-mac\test-template-mac.csproj">
+      <Project>{A19E7BA3-FB49-480B-9C8A-07A1DA5D5EB4}</Project>
+      <Name>test-template-mac</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="CustomBuildActions.targets" />

--- a/tests/msbuild-mac/src/MSBuild-Smoke.cs
+++ b/tests/msbuild-mac/src/MSBuild-Smoke.cs
@@ -135,7 +135,7 @@ namespace Xamarin.MMP.Tests
 				Assert.IsTrue (File.Exists (Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/MonoBundle/SimpleClassDylib.dylib")));
 
 				StringBuilder output = new StringBuilder ();
-				Xamarin.Bundler.Driver.RunCommand ("/usr/bin/otool", "-L " + Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/MacOS/UnifiedExample"), null, output);
+				Bundler.Invoker.RunCommand ("/usr/bin/otool", "-L " + Path.Combine (tmpDir, "bin/Debug/UnifiedExample.app/Contents/MacOS/UnifiedExample"), null, output);
 				Assert.IsTrue (output.ToString ().Contains ("SimpleClassDylib.dylib"));
 			});
 		}

--- a/tests/tests-mac.sln
+++ b/tests/tests-mac.sln
@@ -17,9 +17,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "apitest-unified", "apitest\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "introspection-mac", "introspection\Mac\introspection-mac.csproj", "{EA3E6B50-AE2B-4A63-BBFC-9888B93331CA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "introspection-mac-unified", "introspection\Mac\introspection-mac-unified.csproj", "{4D0F03E2-FD85-D330-562F-C7421BDF3F3C}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "introspection-mac-unified-32", "introspection\Mac\introspection-mac-unified-32.csproj", "{E0E84B58-C333-1BF3-D1EC-42EE3EA0D071}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "introspection-mac-unified", "introspection\Mac\introspection-mac-unified.csproj", "{E0E84B58-C333-1BF3-D1EC-42EE3EA0D071}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "apitest", "apitest\apitest.csproj", "{7A0EDA95-30A6-43E1-AD43-368AD95AC48B}"
 EndProject
@@ -42,6 +40,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "link sdk-mac", "linker\mac\link sdk\link sdk-mac.csproj", "{F5FF0F5E-0C30-4719-A2B1-5DAE33D1E579}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bindings-test-mac", "bindings-test\bindings-test-mac.csproj", "{20BEA313-7E2D-4209-93C0-E4D99C72695A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "introspection-mac-unified-32", "introspection\Mac\introspection-mac-unified-32.csproj", "{8FB17C3E-8642-8932-FAF9-FA0CE001FEC5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "test-template-mac", "..\tools\test-template\test-template-mac\test-template-mac.csproj", "{A19E7BA3-FB49-480B-9C8A-07A1DA5D5EB4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -149,18 +151,6 @@ Global
 		{EA3E6B50-AE2B-4A63-BBFC-9888B93331CA}.Debug|x86.Build.0 = Debug|x86
 		{EA3E6B50-AE2B-4A63-BBFC-9888B93331CA}.Release|x86.ActiveCfg = Release|x86
 		{EA3E6B50-AE2B-4A63-BBFC-9888B93331CA}.Release|x86.Build.0 = Release|x86
-		{4D0F03E2-FD85-D330-562F-C7421BDF3F3C}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{4D0F03E2-FD85-D330-562F-C7421BDF3F3C}.Debug|Any CPU.Build.0 = Debug|x86
-		{4D0F03E2-FD85-D330-562F-C7421BDF3F3C}.Release|Any CPU.ActiveCfg = Release|x86
-		{4D0F03E2-FD85-D330-562F-C7421BDF3F3C}.Release|Any CPU.Build.0 = Release|x86
-		{4D0F03E2-FD85-D330-562F-C7421BDF3F3C}.Default|Any CPU.ActiveCfg = Debug|x86
-		{4D0F03E2-FD85-D330-562F-C7421BDF3F3C}.Default|Any CPU.Build.0 = Debug|x86
-		{4D0F03E2-FD85-D330-562F-C7421BDF3F3C}.AppStore|Any CPU.ActiveCfg = Debug|x86
-		{4D0F03E2-FD85-D330-562F-C7421BDF3F3C}.AppStore|Any CPU.Build.0 = Debug|x86
-		{4D0F03E2-FD85-D330-562F-C7421BDF3F3C}.Debug|x86.ActiveCfg = Debug|x86
-		{4D0F03E2-FD85-D330-562F-C7421BDF3F3C}.Debug|x86.Build.0 = Debug|x86
-		{4D0F03E2-FD85-D330-562F-C7421BDF3F3C}.Release|x86.ActiveCfg = Release|x86
-		{4D0F03E2-FD85-D330-562F-C7421BDF3F3C}.Release|x86.Build.0 = Release|x86
 		{E0E84B58-C333-1BF3-D1EC-42EE3EA0D071}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{E0E84B58-C333-1BF3-D1EC-42EE3EA0D071}.Debug|Any CPU.Build.0 = Debug|x86
 		{E0E84B58-C333-1BF3-D1EC-42EE3EA0D071}.Release|Any CPU.ActiveCfg = Release|x86
@@ -305,5 +295,29 @@ Global
 		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.Debug|x86.Build.0 = Debug|Any CPU
 		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.Release|x86.ActiveCfg = Release|Any CPU
 		{20BEA313-7E2D-4209-93C0-E4D99C72695A}.Release|x86.Build.0 = Release|Any CPU
+		{8FB17C3E-8642-8932-FAF9-FA0CE001FEC5}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{8FB17C3E-8642-8932-FAF9-FA0CE001FEC5}.Debug|Any CPU.Build.0 = Debug|x86
+		{8FB17C3E-8642-8932-FAF9-FA0CE001FEC5}.Release|Any CPU.ActiveCfg = Release|x86
+		{8FB17C3E-8642-8932-FAF9-FA0CE001FEC5}.Release|Any CPU.Build.0 = Release|x86
+		{8FB17C3E-8642-8932-FAF9-FA0CE001FEC5}.Default|Any CPU.ActiveCfg = Debug|x86
+		{8FB17C3E-8642-8932-FAF9-FA0CE001FEC5}.Default|Any CPU.Build.0 = Debug|x86
+		{8FB17C3E-8642-8932-FAF9-FA0CE001FEC5}.AppStore|Any CPU.ActiveCfg = Debug|x86
+		{8FB17C3E-8642-8932-FAF9-FA0CE001FEC5}.AppStore|Any CPU.Build.0 = Debug|x86
+		{8FB17C3E-8642-8932-FAF9-FA0CE001FEC5}.Debug|x86.ActiveCfg = Debug|x86
+		{8FB17C3E-8642-8932-FAF9-FA0CE001FEC5}.Debug|x86.Build.0 = Debug|x86
+		{8FB17C3E-8642-8932-FAF9-FA0CE001FEC5}.Release|x86.ActiveCfg = Release|x86
+		{8FB17C3E-8642-8932-FAF9-FA0CE001FEC5}.Release|x86.Build.0 = Release|x86
+		{A19E7BA3-FB49-480B-9C8A-07A1DA5D5EB4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A19E7BA3-FB49-480B-9C8A-07A1DA5D5EB4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A19E7BA3-FB49-480B-9C8A-07A1DA5D5EB4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A19E7BA3-FB49-480B-9C8A-07A1DA5D5EB4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A19E7BA3-FB49-480B-9C8A-07A1DA5D5EB4}.Default|Any CPU.ActiveCfg = Debug|Any CPU
+		{A19E7BA3-FB49-480B-9C8A-07A1DA5D5EB4}.Default|Any CPU.Build.0 = Debug|Any CPU
+		{A19E7BA3-FB49-480B-9C8A-07A1DA5D5EB4}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{A19E7BA3-FB49-480B-9C8A-07A1DA5D5EB4}.AppStore|Any CPU.Build.0 = Debug|Any CPU
+		{A19E7BA3-FB49-480B-9C8A-07A1DA5D5EB4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A19E7BA3-FB49-480B-9C8A-07A1DA5D5EB4}.Debug|x86.Build.0 = Debug|Any CPU
+		{A19E7BA3-FB49-480B-9C8A-07A1DA5D5EB4}.Release|x86.ActiveCfg = Release|Any CPU
+		{A19E7BA3-FB49-480B-9C8A-07A1DA5D5EB4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -230,77 +230,12 @@ namespace Xamarin.Bundler {
 
 		public static int RunCommand (string path, string args, string[] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
 		{
-			Exception stdin_exc = null;
-			var info = new ProcessStartInfo (path, args);
-			info.UseShellExecute = false;
-			info.RedirectStandardInput = false;
-			info.RedirectStandardOutput = true;
-			info.RedirectStandardError = true;
-			System.Threading.ManualResetEvent stdout_completed = new System.Threading.ManualResetEvent (false);
-			System.Threading.ManualResetEvent stderr_completed = new System.Threading.ManualResetEvent (false);
-
-			if (output == null)
-				output = new StringBuilder ();
-
-			if (env != null){
-				if (env.Length % 2 != 0)
-					throw new Exception ("You passed an environment key without a value");
-
-				for (int i = 0; i < env.Length; i+= 2)
-					info.EnvironmentVariables [env[i]] = env[i+1];
-			}
-
-			if (verbose > 0)
-				Console.WriteLine ("{0} {1}", path, args);
-
-			using (var p = Process.Start (info)) {
-
-				p.OutputDataReceived += (s, e) => {
-					if (e.Data != null) {
-						lock (output)
-							output.AppendLine (e.Data);
-					} else {
-						stdout_completed.Set ();
-					}
-				};
-
-				p.ErrorDataReceived += (s, e) => {
-					if (e.Data != null) {
-						lock (output)
-							output.AppendLine (e.Data);
-					} else {
-						stderr_completed.Set ();
-					}
-				};
-
-				p.BeginOutputReadLine ();
-				p.BeginErrorReadLine ();
-
-				p.WaitForExit ();
-
-				stderr_completed.WaitOne (TimeSpan.FromSeconds (1));
-				stdout_completed.WaitOne (TimeSpan.FromSeconds (1));
-
-				if (p.ExitCode != 0) {
-					// note: this repeat the failing command line. However we can't avoid this since we're often
-					// running commands in parallel (so the last one printed might not be the one failing)
-					if (!suppressPrintOnErrors)
-						Console.Error.WriteLine ("Process exited with code {0}, command:\n{1} {2}{3}", p.ExitCode, path, args, output.Length > 0 ? "\n" + output.ToString () : string.Empty);
-					return p.ExitCode;
-				} else if (verbose > 0 && output.Length > 0 && !suppressPrintOnErrors) {
-					Console.WriteLine (output.ToString ());
-				}
-
-				if (stdin_exc != null)
-					throw stdin_exc;
-			}
-
-			return 0;
+			return Invoker.RunCommand (path, args, verbose, env, output, suppressPrintOnErrors);
 		}
 
 		public static Task<int> RunCommandAsync (string path, string args, string [] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
 		{
-			return Task.Run (() => RunCommand (path, args, env, output, suppressPrintOnErrors));
+			return Invoker.RunCommandAsync (path, args, verbose, env, output, suppressPrintOnErrors);
 		}
 
 #if !MMP_TEST

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -230,12 +230,12 @@ namespace Xamarin.Bundler {
 
 		public static int RunCommand (string path, string args, string[] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
 		{
-			return Invoker.RunCommand (path, args, verbose, env, output, suppressPrintOnErrors);
+			return Invoker.RunCommand (path, args, env, output, suppressPrintOnErrors, verbose);
 		}
 
 		public static Task<int> RunCommandAsync (string path, string args, string [] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
 		{
-			return Invoker.RunCommandAsync (path, args, verbose, env, output, suppressPrintOnErrors);
+			return Invoker.RunCommandAsync (path, args, env, output, suppressPrintOnErrors, verbose);
 		}
 
 #if !MMP_TEST

--- a/tools/common/Invoker.cs
+++ b/tools/common/Invoker.cs
@@ -84,7 +84,7 @@ namespace Xamarin.Bundler {
 			return 0;
 		}
 
-		public static Task<int> RunCommandAsync (string path, string args, int verbose, string [] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
+		public static Task<int> RunCommandAsync (string path, string args, string [] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false, int verbose = 0)
 		{
 			return Task.Run (() => RunCommand (path, args, env, output, suppressPrintOnErrors, verbose));
 		}

--- a/tools/common/Invoker.cs
+++ b/tools/common/Invoker.cs
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014 Xamarin Inc. All rights reserved.
+ *
+ * Authors:
+ *   Rolf Bjarne Kvinge <rolf@xamarin.com>
+ *
+ */
+
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Xamarin.Bundler {
+	public static class Invoker {
+
+		public static int RunCommand (string path, string args, string[] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false, int verbose = 0)
+		{
+			Exception stdin_exc = null;
+			var info = new ProcessStartInfo (path, args);
+			info.UseShellExecute = false;
+			info.RedirectStandardInput = false;
+			info.RedirectStandardOutput = true;
+			info.RedirectStandardError = true;
+			System.Threading.ManualResetEvent stdout_completed = new System.Threading.ManualResetEvent (false);
+			System.Threading.ManualResetEvent stderr_completed = new System.Threading.ManualResetEvent (false);
+
+			if (output == null)
+				output = new StringBuilder ();
+
+			if (env != null){
+				if (env.Length % 2 != 0)
+					throw new Exception ("You passed an environment key without a value");
+
+				for (int i = 0; i < env.Length; i+= 2)
+					info.EnvironmentVariables [env[i]] = env[i+1];
+			}
+
+			if (verbose > 0)
+				Console.WriteLine ("{0} {1}", path, args);
+
+			using (var p = Process.Start (info)) {
+
+				p.OutputDataReceived += (s, e) => {
+					if (e.Data != null) {
+						lock (output)
+							output.AppendLine (e.Data);
+					} else {
+						stdout_completed.Set ();
+					}
+				};
+
+				p.ErrorDataReceived += (s, e) => {
+					if (e.Data != null) {
+						lock (output)
+							output.AppendLine (e.Data);
+					} else {
+						stderr_completed.Set ();
+					}
+				};
+
+				p.BeginOutputReadLine ();
+				p.BeginErrorReadLine ();
+
+				p.WaitForExit ();
+
+				stderr_completed.WaitOne (TimeSpan.FromSeconds (1));
+				stdout_completed.WaitOne (TimeSpan.FromSeconds (1));
+
+				if (p.ExitCode != 0) {
+					// note: this repeat the failing command line. However we can't avoid this since we're often
+					// running commands in parallel (so the last one printed might not be the one failing)
+					if (!suppressPrintOnErrors)
+						Console.Error.WriteLine ("Process exited with code {0}, command:\n{1} {2}{3}", p.ExitCode, path, args, output.Length > 0 ? "\n" + output.ToString () : string.Empty);
+					return p.ExitCode;
+				} else if (verbose > 0 && output.Length > 0 && !suppressPrintOnErrors) {
+					Console.WriteLine (output.ToString ());
+				}
+
+				if (stdin_exc != null)
+					throw stdin_exc;
+			}
+
+			return 0;
+		}
+
+		public static Task<int> RunCommandAsync (string path, string args, int verbose, string [] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
+		{
+			return Task.Run (() => RunCommand (path, args, env, output, suppressPrintOnErrors, verbose));
+		}
+	}
+}

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -370,6 +370,9 @@
     <Compile Include="..\common\CoreResolver.cs">
       <Link>common\CoreResolver.cs</Link>
     </Compile>
+    <Compile Include="..\common\Invoker.cs">
+      <Link>external\Invoker.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -377,6 +377,9 @@
     <Compile Include="..\..\external\mono\external\linker\linker\Linker\TypeNameParser.cs">
       <Link>Linker\TypeNameParser.cs</Link>
     </Compile>
+    <Compile Include="..\common\Invoker.cs">
+      <Link>external\Invoker.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Core" />

--- a/tools/test-template/test-template-mac/FileTemplateEngine.cs
+++ b/tools/test-template/test-template-mac/FileTemplateEngine.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using Xamarin.Bundler;
+
+namespace Xamarin.Tests.Templating
+{
+	public class FileTemplateEngine
+	{
+		string SourceDirectory;
+		string OutputDirectory;
+
+		public FileTemplateEngine (string sourceDirectory, string outputDirectory)
+		{
+			SourceDirectory = sourceDirectory;
+			OutputDirectory = outputDirectory;
+		}
+
+		public static FileTemplateEngine WithSubdirectory (string sourceDirectory, string outputDirectory, string subDirectory)
+		{
+			return new FileTemplateEngine (Path.Combine (sourceDirectory, subDirectory), Path.Combine (outputDirectory, subDirectory));
+		}
+
+		public string CopyFile (string fileName)
+		{
+			string srcPath = Path.Combine (SourceDirectory, fileName);
+			string destPath = Path.Combine (OutputDirectory, fileName);
+
+			string text = File.ReadAllText (srcPath);
+			File.WriteAllText (destPath, text);
+			return destPath;
+		}
+
+		public string CopyFileWithSubstitutions (string fileName, IReplacement replacement, string destFileName = null)
+		{
+			string srcPath = Path.Combine (SourceDirectory, fileName);
+			string destPath = Path.Combine (OutputDirectory, destFileName ?? fileName);
+
+			string text = replacement.Apply (File.ReadAllText (srcPath));
+			File.WriteAllText (destPath, text);
+			return destPath;
+		}
+
+		public string CopyTextWithSubstitutions (string text, string fileName, IReplacement replacement)
+		{
+			string destPath = Path.Combine (OutputDirectory, fileName);
+			File.WriteAllText (destPath, replacement.Apply (text));
+			return destPath;
+		}
+
+		public void CopyDirectory (string sourceName)
+		{
+			string srcPath = Path.Combine (SourceDirectory, sourceName);
+
+			int ret = Invoker.RunCommand ("/bin/cp", $"-R {Path.Combine (SourceDirectory, sourceName)} {OutputDirectory}");
+			if (ret != 0)
+				throw new InvalidOperationException ($"CopyDirectory from {srcPath} to {OutputDirectory} failed with {ret} return code.");
+		}
+	}
+}

--- a/tools/test-template/test-template-mac/Generator/MacAppTemplateEngine.cs
+++ b/tools/test-template/test-template-mac/Generator/MacAppTemplateEngine.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.IO;
+
+namespace Xamarin.Tests.Templating
+{
+	public class MacAppTemplateEngine : TemplateEngineBase
+	{
+		public MacAppTemplateEngine (ProjectFlavor flavor, ProjectLanguage language = ProjectLanguage.CSharp) : base (new TemplateInfo (flavor, ProjectType.App, language))
+		{
+		}
+
+		public MacAppTemplateEngine (TemplateInfo info) : base (info)
+		{
+		}
+
+		public string Generate (string outputDirectory, ProjectSubstitutions projectSubstitutions, FileSubstitutions fileSubstitutions, PListSubstitutions plistReplacements = null, bool includeAssets = false)
+		{
+			plistReplacements = plistReplacements ?? PListSubstitutions.None;
+			FileTemplateEngine templateEngine = CreateEngine (outputDirectory);
+
+			if (includeAssets) {
+				templateEngine.CopyDirectory ("Icons/Assets.xcassets");
+
+				projectSubstitutions.ItemGroup += @"<ItemGroup>
+    <ImageAsset Include=""Assets.xcassets\AppIcon.appiconset\Contents.json"" />
+    <ImageAsset Include=""Assets.xcassets\AppIcon.appiconset\AppIcon-128.png"" />
+    <ImageAsset Include=""Assets.xcassets\AppIcon.appiconset\AppIcon-128%402x.png"" />
+    <ImageAsset Include=""Assets.xcassets\AppIcon.appiconset\AppIcon-16.png"" />
+    <ImageAsset Include=""Assets.xcassets\AppIcon.appiconset\AppIcon-16%402x.png"" />
+    <ImageAsset Include=""Assets.xcassets\AppIcon.appiconset\AppIcon-256%402x.png"" />
+    <ImageAsset Include=""Assets.xcassets\AppIcon.appiconset\AppIcon-32.png"" />
+    <ImageAsset Include=""Assets.xcassets\AppIcon.appiconset\AppIcon-32%402x.png"" />
+    <ImageAsset Include=""Assets.xcassets\Contents.json"" />
+  </ItemGroup>";
+
+				// HACK - Should process using CopyFileWithSubstitutions
+				plistReplacements.Replacements.Add ("</dict>", @"<key>XSAppIconAssets</key><string>Assets.xcassets/AppIcon.appiconset</string></dict>");
+			}
+
+			ReplacementGroup replacements = ReplacementGroup.Create (Replacement.Create ("%CODE%", fileSubstitutions.TestCode), Replacement.Create ("%DECL%", fileSubstitutions.TestDecl));
+			templateEngine.CopyTextWithSubstitutions (GetAppMainSourceText (), TemplateInfo.SourceName, replacements);
+
+			templateEngine.CopyFileWithSubstitutions ("Info-Unified.plist", plistReplacements.CreateReplacementAction (), "Info.plist");
+
+			return templateEngine.CopyFileWithSubstitutions (TemplateInfo.ProjectName, GetStandardProjectReplacement (projectSubstitutions));
+		}
+
+		string GetAppMainSourceText ()
+		{
+			const string FSharpMainTemplate = @"
+namespace FSharpUnifiedExample
+open System
+open AppKit
+
+module main =
+    %DECL%
+ 
+    [<EntryPoint>]
+    let main args =
+        NSApplication.Init ()
+        %CODE%
+        0";
+
+			const string MainTemplate = @"
+using Foundation;
+using AppKit;
+
+namespace TestCase
+{
+	class MainClass
+	{
+		%DECL%
+
+		static void Main (string[] args)
+		{
+			NSApplication.Init ();
+			%CODE%
+		}
+	}
+}";
+
+			return TemplateInfo.Language == ProjectLanguage.FSharp ? FSharpMainTemplate : MainTemplate;
+		}
+	}
+}

--- a/tools/test-template/test-template-mac/Generator/MacBindingTemplateEngine.cs
+++ b/tools/test-template/test-template-mac/Generator/MacBindingTemplateEngine.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Xamarin.Tests.Templating
+{
+	public class MacBindingTemplateEngine : TemplateEngineBase
+	{
+		public MacBindingTemplateEngine (ProjectFlavor flavor, ProjectLanguage language = ProjectLanguage.CSharp) : base (new TemplateInfo (flavor, ProjectType.Binding, language))
+		{
+		}
+
+		public MacBindingTemplateEngine (TemplateInfo info) : base (info)
+		{
+		}
+
+		public string Generate (string outputDirectory, ProjectSubstitutions projectSubstitutions, FileSubstitutions fileSubstitutions)
+		{
+			FileTemplateEngine templateEngine = CreateEngine (outputDirectory);
+
+			templateEngine.CopyFileWithSubstitutions ("ApiDefinition.cs", Replacement.Create ("%CODE%", fileSubstitutions.ApiDefinition));
+			templateEngine.CopyFileWithSubstitutions ("StructsAndEnums.cs", Replacement.Create ("%CODE%", fileSubstitutions.StructsAndEnums));
+
+			return templateEngine.CopyFileWithSubstitutions (TemplateInfo.ProjectName, GetStandardProjectReplacement (projectSubstitutions));
+		}
+	}
+}

--- a/tools/test-template/test-template-mac/Generator/MacLibraryTemplateEngine.cs
+++ b/tools/test-template/test-template-mac/Generator/MacLibraryTemplateEngine.cs
@@ -1,0 +1,23 @@
+﻿using System;
+namespace Xamarin.Tests.Templating
+{
+	public class MacLibraryTemplateEngine : TemplateEngineBase
+	{
+		public MacLibraryTemplateEngine (ProjectFlavor flavor, ProjectLanguage language = ProjectLanguage.CSharp) : base (new TemplateInfo (flavor, ProjectType.Library, language))
+		{
+		}
+
+		public MacLibraryTemplateEngine (TemplateInfo info) : base (info)
+		{
+		}
+
+		public string Generate (string outputDirectory, ProjectSubstitutions projectSubstitutions, FileSubstitutions fileSubstitutions)
+		{
+			FileTemplateEngine templateEngine = CreateEngine (outputDirectory);
+
+			templateEngine.CopyFileWithSubstitutions (TemplateInfo.SourceName, Replacement.Create ("%CODE%", fileSubstitutions.TestCode));
+
+			return templateEngine.CopyFileWithSubstitutions (TemplateInfo.ProjectName, GetStandardProjectReplacement (projectSubstitutions));
+		}
+	}
+}

--- a/tools/test-template/test-template-mac/Generator/NetStandardTemplateEngine.cs
+++ b/tools/test-template/test-template-mac/Generator/NetStandardTemplateEngine.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO;
+
+namespace Xamarin.Tests.Templating
+{
+	public class NetStandardTemplateEngine : TemplateEngineBase
+	{
+		public NetStandardTemplateEngine () : base (TemplateInfo.FromFiles ("NetStandardLib.csproj", "Class1.cs"))
+		{
+		}
+
+		const string NetStandardSubDir = "NetStandard";
+
+		public string GenerateLibraryProject (string outputDirectory)
+		{
+			Directory.CreateDirectory (Path.Combine (outputDirectory, NetStandardSubDir));
+
+			FileTemplateEngine templateEngine = CreateEngine (outputDirectory);
+			templateEngine.CopyFile (TemplateInfo.SourceName);
+			return templateEngine.CopyFile (TemplateInfo.ProjectName);
+		}
+
+		protected override FileTemplateEngine CreateEngine (string outputDirectory) => FileTemplateEngine.WithSubdirectory (DirectoryFinder.FindSourceDirectory (), outputDirectory, NetStandardSubDir);
+	}
+}

--- a/tools/test-template/test-template-mac/Generator/TemplateEngine.cs
+++ b/tools/test-template/test-template-mac/Generator/TemplateEngine.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Xamarin.Tests.Templating
+{
+	public enum ProjectLanguage { None, CSharp, FSharp }
+	public enum ProjectPlatform { None, macOS }
+	public enum ProjectFlavor { None, ModernXM, FullXM }
+	public enum ProjectType { None, Library, App, Binding }
+
+	public class ProjectSubstitutions
+	{
+		public string CSProjConfig { get; set; } = "";
+		public string References { get; set; } = "";
+		public string ReferencesBeforePlatform { get; set; } = "";
+		public string ItemGroup { get; set; } = "";
+		public string TargetFrameworkVersion { get; set; } = "";
+		public string AssemblyNameOverride { get; set; } = null;
+
+		public Tuple<string, string> CustomProjectReplacement { get; set; } = null;
+	}
+
+	public class FileSubstitutions
+	{
+		public string ApiDefinition { get; set; } = "";
+		public string StructsAndEnums { get; set; } = "";
+
+		public string TestCode { get; set; } = "";
+		public string TestDecl { get; set; } = "";
+	}
+
+	public class PListSubstitutions
+	{
+		public static PListSubstitutions None => new PListSubstitutions ();
+
+		public Dictionary<string, string> Replacements { get; set; } = new Dictionary<string, string> ();
+
+		public ReplacementGroup CreateReplacementAction ()
+		{
+			ReplacementGroup group = new ReplacementGroup ();
+			foreach (var item in Replacements) 
+				group.Append (Replacement.Create (item.Key, item.Value));
+			return group;
+		}
+	}
+
+	public abstract class TemplateEngineBase
+	{
+		protected TemplateInfo TemplateInfo;
+
+		protected TemplateEngineBase (TemplateInfo info)
+		{
+			TemplateInfo = info;
+		}
+
+		protected ReplacementGroup GetStandardProjectReplacement (ProjectSubstitutions config)
+		{
+			ReplacementGroup group = ReplacementGroup.Create (
+				Replacement.Create ("%CODE%", config.CSProjConfig),
+				Replacement.Create ("%REFERENCES%", config.References),
+				Replacement.Create ("%REFERENCES_BEFORE_PLATFORM%", config.ReferencesBeforePlatform),
+				Replacement.Create ("%NAME%", config.AssemblyNameOverride ?? Path.GetFileNameWithoutExtension (TemplateInfo.ProjectName)),
+				Replacement.Create ("%ITEMGROUP%", config.ItemGroup),
+				Replacement.Create ("%TARGET_FRAMEWORK_VERSION%", config.TargetFrameworkVersion));
+
+			if (config.CustomProjectReplacement != null)
+				group.Append (Replacement.Create (config.CustomProjectReplacement.Item1, config.CustomProjectReplacement.Item2));
+			return group;
+		}
+
+		protected virtual FileTemplateEngine CreateEngine (string outputDirectory) => new FileTemplateEngine (DirectoryFinder.FindSourceDirectory (), outputDirectory);
+	}
+}

--- a/tools/test-template/test-template-mac/Generator/TemplateInfo.cs
+++ b/tools/test-template/test-template-mac/Generator/TemplateInfo.cs
@@ -1,0 +1,117 @@
+﻿using System;
+
+namespace Xamarin.Tests.Templating
+{
+	public class TemplateInfo
+	{
+		public ProjectLanguage Language { get; private set; }
+		public ProjectFlavor Flavor { get; private set; }
+		public ProjectType ProjectType { get; private set; }
+
+		public TemplateInfo (ProjectFlavor flavor, ProjectType projectType, ProjectLanguage language)
+		{
+			Flavor = flavor;
+			ProjectType = projectType;
+			Language = language;
+		}
+
+		TemplateInfo (ProjectType projectType, ProjectLanguage language, string projectName)
+		{
+			ProjectType = projectType;
+			Language = language;
+			ProjectNameOverride = projectName;
+		}
+
+		TemplateInfo (string projectName, string sourceName)
+		{
+			ProjectNameOverride = projectName;
+			SourceNameOverride = sourceName;
+		}
+
+		public static TemplateInfo FromCustomProject (ProjectType projectType, ProjectLanguage language, string projectName) => new TemplateInfo (projectType, language, projectName);
+		public static TemplateInfo FromFiles (string projectName, string sourceName) => new TemplateInfo (projectName, sourceName);
+
+		string ProjectNameOverride;
+		public string ProjectName => ProjectNameOverride ?? DefaultProjectName;
+
+		string SourceNameOverride;
+		public string SourceName => SourceNameOverride ?? DefaultSourceName;
+
+		string DefaultSourceName {
+			get {
+				switch (ProjectType) {
+				case ProjectType.Library:
+					switch (Language) {
+					case ProjectLanguage.CSharp:
+						return "MyClass.cs";
+					case ProjectLanguage.FSharp:
+						return "Component1.fs";
+					}
+					break;
+				case ProjectType.App:
+					switch (Language) {
+					case ProjectLanguage.CSharp:
+						return "Main.cs";
+					case ProjectLanguage.FSharp:
+						return "Main.fs";
+					}
+					break;
+				}
+				throw new NotImplementedException ();
+			}
+		}
+
+		string DefaultProjectName {
+			get {
+				switch (Language) {
+				case ProjectLanguage.CSharp:
+					switch (Flavor) {
+					case ProjectFlavor.FullXM:
+						switch (ProjectType) {
+						case ProjectType.App:
+							return "XM45Example.csproj";
+						case ProjectType.Binding:
+							return "XM45Binding.csproj";
+						case ProjectType.Library:
+							return "XM45Library.csproj";
+						}
+						break;
+					case ProjectFlavor.ModernXM:
+						switch (ProjectType) {
+						case ProjectType.App:
+							return "UnifiedExample.csproj";
+						case ProjectType.Binding:
+							return "MobileBinding.csproj";
+						case ProjectType.Library:
+							return "UnifiedLibrary.csproj";
+						}
+						break;
+					}
+					break;
+				case ProjectLanguage.FSharp:
+					switch (Flavor) {
+					case ProjectFlavor.FullXM:
+						switch (ProjectType) {
+						case ProjectType.App:
+							return "FSharpXM45Example.fsproj";
+						case ProjectType.Library:
+							return "FSharpXM45Library.fsproj";
+						}
+						break;
+					case ProjectFlavor.ModernXM:
+						switch (ProjectType) {
+						case ProjectType.App:
+							return "FSharpUnifiedExample.fsproj";
+						case ProjectType.Library:
+							return "FSharpUnifiedLibrary.fsproj";
+						}
+						break;
+					}
+					break;
+				}
+
+				throw new NotImplementedException ();
+			}
+		}
+	}
+}

--- a/tools/test-template/test-template-mac/Replacements.cs
+++ b/tools/test-template/test-template-mac/Replacements.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Xamarin.Tests.Templating
+{
+	public interface IReplacement
+	{
+		string Apply (string text);
+	}
+
+	public class Replacement : IReplacement
+	{
+		string Token;
+		string Value;
+
+		public Replacement (string token, string value)
+		{
+			Token = token;
+			Value = value;
+		}
+
+		static public Replacement Create (string token, string value) => new Replacement (token, value);
+
+		public string Apply (string text) => text.Replace (Token, Value);
+	}
+
+	public class ReplacementGroup : IReplacement
+	{
+		List<Replacement> Replacements;
+
+		public ReplacementGroup () : this (new List<Replacement> ())
+		{
+		}
+
+		public ReplacementGroup (IEnumerable<Replacement> replacements)
+		{
+			Replacements = replacements.ToList ();
+		}
+
+		static public ReplacementGroup Create (params Replacement[] replacements) => new ReplacementGroup (replacements);
+
+		public string Apply (string text)
+		{
+			foreach (var r in Replacements)
+				text = r.Apply (text);
+			return text;
+		}
+
+		public void Append (Replacement replacement) => Replacements.Add (replacement);
+	}
+
+}

--- a/tools/test-template/test-template-mac/Utilities/DirectoryFinder.cs
+++ b/tools/test-template/test-template-mac/Utilities/DirectoryFinder.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+
+namespace Xamarin.Tests.Templating
+{
+	static class DirectoryFinder
+	{
+		public static string FindRootDirectory ()
+		{
+			var current = Assembly.GetExecutingAssembly ().Location;
+			while (!Directory.Exists (Path.Combine (current, "_mac-build")) && current.Length > 1)
+				current = Path.GetDirectoryName (current);
+			if (current.Length <= 1)
+				throw new DirectoryNotFoundException (string.Format ("Could not find the root directory starting from {0}", Environment.CurrentDirectory));
+			return Path.GetFullPath (Path.Combine (current, "_mac-build"));
+		}
+
+		public static string FindTestDirectory => Path.Combine (FindRootDirectory (), "..", "tests") + "/";
+
+		public static string FindSourceDirectory ()
+		{
+			string codeBase = Assembly.GetExecutingAssembly ().CodeBase;
+			UriBuilder uri = new UriBuilder (codeBase);
+			string path = Uri.UnescapeDataString (uri.Path);
+			string assemblyDirectory = Path.GetDirectoryName (path);
+			return Path.Combine (assemblyDirectory, FindTestDirectory + "common/mac");
+		}
+	}
+}

--- a/tools/test-template/test-template-mac/test-template-mac.csproj
+++ b/tools/test-template/test-template-mac/test-template-mac.csproj
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A19E7BA3-FB49-480B-9C8A-07A1DA5D5EB4}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Xamarin.Tests.Templating</RootNamespace>
+    <AssemblyName>test-template-mac</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Utilities\" />
+    <Folder Include="Generator\" />
+    <Folder Include="External\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="FileTemplateEngine.cs" />
+    <Compile Include="Utilities\DirectoryFinder.cs" />
+    <Compile Include="Generator\TemplateEngine.cs" />
+    <Compile Include="Generator\TemplateInfo.cs" />
+    <Compile Include="Replacements.cs" />
+    <Compile Include="Generator\NetStandardTemplateEngine.cs" />
+    <Compile Include="..\..\common\Invoker.cs">
+      <Link>External\Invoker.cs</Link>
+    </Compile>
+    <Compile Include="Generator\MacAppTemplateEngine.cs" />
+    <Compile Include="Generator\MacBindingTemplateEngine.cs" />
+    <Compile Include="Generator\MacLibraryTemplateEngine.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
I decided to burn a day and prototype how I'd rewrite ProjectTestHelpers in a less organic\terrible way. My goals were:

- Not tied to XM concepts, so we could share it with XI.
- Shim into ProjectTestHelpers API for now, we can bite off reworking the tests later
   - This means there is some ugly conversion code that will go away in time
- Simple API, as we're just really just doing a fancy copy + sed
- Support a subset of what MMP\msbuild-mac does today. If people 👍 then easy to extend:
        - Project Flavor: Full, Modern, NetStandard, etc
        - Project Type: App, Lib, Binding Project
        - Language: C#, F#

This is what I came up with.

The PR line diff count is large because I also refactored out RunCommand from Driver.cs so we could stop duplicating it in test code. It may be useful to review the commits separately because of this.

The test template API works like this:

- If you wants custom template files, create a TemplateInfo describing what you need
- You instance a TemplateEngine subclass either with a TemplateInfo or your flavor\language
    - MacAppTemplateEngine
    - MacBindingTemplateEngine
    - MacLibraryTemplateEngine
    - NetStandardTemplateEngine
- Create a number of Substitutions classes (FileSubstitutions, PListSubstitutions, ProjectSubstitutions) which describe how you want to fill in the "holes" in the templates
- You call a Generate method passing in those substitutions and any additional options.


If we want to move forward with this, my plan would go as follows:

- Flesh out test-template with new components that contain the rest of the functionality ProjectTestHelpers has (Building projects, Frameworks, etc)
- Create an initial PR that makes ProjectTestHelpers use the new API and land it
- Create a second PR that updates the mmp/msbuild-mac tests to use the new API directly and remove the shim layer
- Create a third PR that moves\renames the template files to be in a more consistent location, in prep for iOS additional files
- Create one last PR that checked in one iOS template, the infrastructure to spin it up, and a test using it.