### PR TITLE
[mmp] Remove duplicate libmono-system-native.a logic

### DIFF
--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1358,12 +1358,10 @@ namespace Xamarin.Bundler {
 
 					// libmono-system-native.a needs to be included if it exists in the mono in question
 					string libmonoNative =  Path.Combine (libdir, "libmono-system-native.a");
-					if (File.Exists (libmonoNative))
+					if (File.Exists (libmonoNative)) {
 						args.Append (StringUtils.Quote (libmonoNative)).Append (' ');
-
-					var libsystem_native_path = Path.Combine (libdir, "libmono-system-native.a");
-					args.Append (StringUtils.Quote (libsystem_native_path)).Append (' ');
-					args.Append ("-u ").Append ("_SystemNative_RealPath").Append (' '); // This keeps libmono_system_native_la-pal_io.o symbols
+						args.Append ("-u ").Append ("_SystemNative_RealPath").Append (' '); // This keeps libmono_system_native_la-pal_io.o symbols
+					}
 
 					if (profiling.HasValue && profiling.Value) {
 						args.Append (StringUtils.Quote (Path.Combine (libdir, "libmono-profiler-log.a"))).Append (' ');


### PR DESCRIPTION
- https://github.com/xamarin/xamarin-macios/pull/4980 and the mono branch merge both added it
- However both copies were not the same, one was conditional and one added an extra -u option
- This collapses them into one check