### PR TITLE
[mtouch/mmp] Unify Xcode lookup & verification code in mtouch and mmp.

### DIFF
--- a/jenkins/provision-deps.sh
+++ b/jenkins/provision-deps.sh
@@ -18,4 +18,8 @@ fi
 
 ./system-dependencies.sh --provision-all
 
+sudo rm -Rf /Developer/MonoTouch
+sudo rm -Rf /Library/Frameworks/Xamarin.iOS.framework
+sudo rm -Rf /Library/Frameworks/Xamarin.Mac.framework
+
 echo "✅ [Provisioning succeeded]($BUILD_URL/console)" >> "$WORKSPACE/jenkins/pr-comments.md"

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -68,6 +68,7 @@ namespace Xamarin.Bundler {
 
 	public static partial class Driver {
 		internal const string NAME = "mmp";
+		const string PRODUCT = "Xamarin.Mac";
 		internal static Application App = new Application (Environment.GetCommandLineArgs ());
 		static Target BuildTarget = new Target (App);
 		static List<string> references = new List<string> ();
@@ -100,7 +101,6 @@ namespace Xamarin.Bundler {
 		static string mmp_dir;
 		
 		static string mono_dir;
-		static string sdk_root;
 		static string custom_bundle_name;
 
 		static string tls_provider;
@@ -119,6 +119,8 @@ namespace Xamarin.Bundler {
 		static bool frameworks_copied_to_bundle_dir;	// Have we copied any frameworks to Foo.app/Contents/Frameworks?
 
 		const string pkg_config = "/Library/Frameworks/Mono.framework/Commands/pkg-config";
+
+		static Version min_xcode_version = new Version (6, 0);
 
 		static void ShowHelp (OptionSet os) {
 			Console.WriteLine ("mmp - Xamarin.Mac Packer");
@@ -270,7 +272,6 @@ namespace Xamarin.Bundler {
 				{ "i|icon=", "Use the specified file as the bundle icon", v => { icon = v; }},
 				{ "xml=", "Provide an extra XML definition file to the linker", v => App.Definitions.Add (v) },
 				{ "time", v => WatchLevel++ },
-				{ "sdkroot=", "Specify the location of Apple SDKs", v => sdk_root = v },
 				{ "arch=", "Specify the architecture ('i386' or 'x86_64') of the native runtime (default to 'i386')", v => { arch = v; arch_set = true; } },
 				{ "profile=", "(Obsoleted in favor of --target-framework) Specify the .NET profile to use (defaults to '" + Xamarin.Utils.TargetFramework.Default + "')", v => SetTargetFramework (v) },
 				{ "target-framework=", "Specify the .NET target framework to use (defaults to '" + Xamarin.Utils.TargetFramework.Default + "')", v => SetTargetFramework (v) },
@@ -477,7 +478,7 @@ namespace Xamarin.Bundler {
 				}
 			}
 
-			ValidateXcode ();
+			ValidateXcode (false, true);
 
 			App.Initialize ();
 
@@ -580,47 +581,6 @@ namespace Xamarin.Bundler {
 					return bool.Parse (value);
 				} catch (Exception ex) {
 					throw ErrorHelper.CreateError (26, ex, "Could not parse the command line argument '-{0}:{1}': {2}", name, value, ex.Message);
-				}
-			}
-		}
-
-
-		static void ValidateXcode ()
-		{
-			if (xcode_version == null) {
-				// Check what kind of path we got
-				if (File.Exists (Path.Combine (sdk_root, "Contents", "MacOS", "Xcode"))) {
-					// path to the Xcode.app
-					sdk_root = Path.Combine (sdk_root, "Contents", "Developer");
-				} else if (File.Exists (Path.Combine (sdk_root, "..", "MacOS", "Xcode"))) {
-					// path to Contents/Developer
-					sdk_root = Path.GetFullPath (Path.Combine (sdk_root, "..", "..", "Contents", "Developer"));
-				} else {
-					throw ErrorHelper.CreateError (57, "Cannot determine the path to Xcode.app from the sdk root '{0}'. Please specify the full path to the Xcode.app bundle.", sdk_root);
-				}
-
-				var plist_path = Path.Combine (Path.GetDirectoryName (DeveloperDirectory), "version.plist");
-				if (File.Exists (plist_path)) {
-					bool nextElement = false;
-					XmlReaderSettings settings = new XmlReaderSettings ();
-					settings.DtdProcessing = DtdProcessing.Ignore;
-					using (XmlReader reader = XmlReader.Create (plist_path, settings)) {
-						while (reader.Read()) {
-							// We want the element after CFBundleShortVersionString
-							if (reader.NodeType == XmlNodeType.Element) {
-								if (reader.Name == "key") {
-									if (reader.ReadElementContentAsString() == "CFBundleShortVersionString")
-										nextElement = true;
-								}
-								if (nextElement && reader.Name == "string") {
-									nextElement = false;
-									xcode_version = new Version (reader.ReadElementContentAsString());
-								}
-							}
-						}
-					}
-				} else {
-					throw ErrorHelper.CreateError (58, "The Xcode.app '{0}' is invalid (the file '{1}' does not exist).", Path.GetDirectoryName (Path.GetDirectoryName (DeveloperDirectory)), plist_path);
 				}
 			}
 		}
@@ -895,57 +855,6 @@ namespace Xamarin.Bundler {
 				throw new AggregateException (exceptions);
 
 			Watch ("Extracted native link info", 1);
-		}
-
-		static string FindSystemXcode ()
-		{
-			var output = new StringBuilder ();
-			if (RunCommand ("xcode-select", "-p", output: output) != 0) {
-				ErrorHelper.Warning (59, "Could not find the currently selected Xcode on the system: {0}", output.ToString ());
-				return null;
-			}
-			return output.ToString ().Trim ();
-		}
-
-		static string DeveloperDirectory {
-			get {
-				if (sdk_root == null)
-					sdk_root = LocateXcode ();
-				return sdk_root;
-			}
-		}
-
-		static string LocateXcode ()
-		{
-			// DEVELOPER_DIR overrides `xcrun` so it should have priority
-			string user_developer_directory = Environment.GetEnvironmentVariable ("DEVELOPER_DIR");
-			if (!String.IsNullOrEmpty (user_developer_directory))
-				return user_developer_directory;
-
-			// Next let's respect xcode-select -p if it exists
-			string systemXCodePath = FindSystemXcode ();
-			if (!String.IsNullOrEmpty (systemXCodePath)) {
-				if (!Directory.Exists (systemXCodePath)) {
-					ErrorHelper.Warning (60, "Could not find the currently selected Xcode on the system. 'xcode-select --print-path' returned '{0}', but that directory does not exist.", systemXCodePath);
-				}
-				else {
-					return systemXCodePath;
-				}
-			}
-
-			// Now the fallback locaions we uses to use (for backwards compat)
-			const string Xcode43Default = "/Applications/Xcode.app/Contents/Developer";
-			const string XcrunMavericks = "/Library/Developer/CommandLineTools";
-
-			if (Directory.Exists (Xcode43Default))
-				return Xcode43Default;
-
-			if (Directory.Exists (XcrunMavericks))
-				return XcrunMavericks;
-
-			// And now we give up, but don't throw like mtouch, because we don't want to change behavior (this sometimes worked it appears)
-			ErrorHelper.Warning (56, "Cannot find Xcode in any of our default locations. Please install Xcode, or pass a custom path using --sdkroot=<path>.");
-			return string.Empty;
 		}
 
 		static string MonoDirectory {

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -370,6 +370,9 @@
     <Compile Include="..\common\CoreResolver.cs">
       <Link>common\CoreResolver.cs</Link>
     </Compile>
+    <Compile Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\PListObject.cs">
+      <Link>external\PListObject.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
Share all the code to find and verify Xcode between mtouch and mmp.

Also print out the actual product version when logging which Xcode was used
(to make it easier to detect if a beta version is in use).