### PR TITLE
[monotouch-test] Improve diagnostic output when MessageHandlerTest fails.

### DIFF
--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -58,6 +58,8 @@ namespace MonoTests.System.Net.Http
 				try {
 					HttpClient client = new HttpClient (GetHandler (handlerType));
 					var s = await client.GetStringAsync ("http://doesnotexist.xamarin.com");
+					Console.WriteLine (s);
+					Assert.Fail ($"An exception should have been thrown, instead got:\n{s}");
 				} catch (Exception e) {
 					ex = e;
 				} finally {


### PR DESCRIPTION
Reference: https://github.com/xamarin/xamarin-macios/issues/4013