### PR TITLE
[mtouch] Fix formatting for MT0079 and update the MT4134 test to take into account the warning. Fixes maccore#1116.

### DIFF
--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -299,7 +299,8 @@ class MyObjectErr : NSObject, IFoo1, IFoo2
 				foreach (var framework in invalidFrameworks)
 					mtouch.AssertError (4134, $"Your application is using the '{framework.Framework}' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS {framework.Version}, while you're building with the iOS {mtouch.Sdk} SDK.) Please select a newer SDK in your app's iOS Build options.");
 				mtouch.AssertErrorCount (invalidFrameworks.Length);
-				mtouch.AssertWarningCount (0);
+				mtouch.AssertWarningPattern (79, $"The recommended Xcode version for Xamarin.iOS .* is Xcode .* or later. The current Xcode version .found in /Applications/Xcode83.app/Contents/Developer. is .*.");
+				mtouch.AssertWarningCount (1);
 
 				mtouch.AssertExecute (MTouchAction.BuildSim);
 			}

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -592,7 +592,7 @@ namespace Xamarin.Bundler {
 					throw ErrorHelper.CreateError (51, "{3} {0} requires Xcode {4} or later. The current Xcode version (found in {2}) is {1}.", Constants.Version, XcodeVersion.ToString (), sdk_root, PRODUCT, min_xcode_version);
 
 				if (XcodeVersion < SdkVersions.XcodeVersion)
-					ErrorHelper.Warning (79, "The recommended Xcode version for {3} {0} is Xcode {3} or later. The current Xcode version (found in {2}) is {1}.", Constants.Version, XcodeVersion.ToString (), sdk_root, SdkVersions.Xcode, PRODUCT);
+					ErrorHelper.Warning (79, "The recommended Xcode version for {4} {0} is Xcode {3} or later. The current Xcode version (found in {2}) is {1}.", Constants.Version, XcodeVersion.ToString (), sdk_root, SdkVersions.Xcode, PRODUCT);
 			}
 
 			Driver.Log (1, "Using Xcode {0} ({2}) found in {1}", XcodeVersion, sdk_root, XcodeProductVersion);


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/1116.