### PR TITLE
[tests] Point MSBuild to the right Xamarin.Mac location when building packaged Xamarin.Mac tests. Fixes maccore#1115.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -91,6 +91,7 @@ test.config: Makefile $(TOP)/Make.config
 	@echo "MAC_DESTDIR=$(abspath $(MAC_DESTDIR))" >> $@
 	@echo "JENKINS_RESULTS_DIRECTORY=$(abspath $(JENKINS_RESULTS_DIRECTORY))" >> $@
 	@echo "INCLUDE_DEVICE=$(INCLUDE_DEVICE)" >> $@
+	@echo "XCODE_DEVELOPER_ROOT=$(XCODE_DEVELOPER_ROOT)" >> $@
 
 test-system.config:
 	@rm -f $@

--- a/tests/package-mac-tests.sh
+++ b/tests/package-mac-tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -ex
 
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 # Clone files instead of copying them on APFS file systems. Much faster.
 CP="cp"
 if df -t apfs / >/dev/null 2>&1; then
@@ -12,6 +14,14 @@ DIR=$(pwd)/mac-test-package/mac-test-package
 ZIP=$DIR.zip
 rm -Rf $DIR
 mkdir -p $DIR
+
+make test.config
+source test.config
+export MD_APPLE_SDK_ROOT=$(dirname $(dirname $XCODE_DEVELOPER_ROOT))
+export XAMMAC_FRAMEWORK_PATH=$MAC_DESTDIR/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
+export XamarinMacFrameworkRoot=$MAC_DESTDIR/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
+export TargetFrameworkFallbackSearchPaths=$MAC_DESTDIR/Library/Frameworks/Mono.framework/External/xbuild-frameworks
+export MSBuildExtensionsPathFallbackPathsOverride=$MAC_DESTDIR/Library/Frameworks/Mono.framework/External/xbuild
 
 make
 make .stamp-configure-projects-mac

--- a/tests/xharness/MakefileGenerator.cs
+++ b/tests/xharness/MakefileGenerator.cs
@@ -187,6 +187,10 @@ namespace xharness
 					{ "MD_APPLE_SDK_ROOT", "$(MD_APPLE_SDK_ROOT_EVALUATED)"},
 				};
 
+				// For targets with spaces, also add the non-space variation to the list.
+				allTargetNames.AddRange (allTargetNames.Where ((v) => v.IndexOf (' ') >= 0).Select ((v) => v.Replace ("\\ ", "")));
+				allTargetCleanNames.AddRange (allTargetCleanNames.Where ((v) => v.IndexOf (' ') >= 0).Select ((v) => v.Replace ("\\ ", "")));
+
 				foreach (var key in enviromentalVariables) {
 					writer.WriteLine ("{0}: export {1}:={2}", string.Join (" ", allTargetNames.ToArray ()), key.Key, key.Value);
 					writer.WriteLine ("{0}: export {1}:={2}", string.Join (" ", allTargetCleanNames.ToArray ()), key.Key, key.Value);


### PR DESCRIPTION
Also fix an issue in xharness to make sure the proper environment variables
are set for all mac targets.

Fixes https://github.com/xamarin/maccore/issues/1115.