### PR TITLE
Revert "[msbuild] VS Incremental build fixes (#5054)"

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileEntitlementsTaskBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Collections.Generic;
 
@@ -31,7 +31,7 @@ namespace Xamarin.MacDev.Tasks
 
 		[Output]
 		[Required]
-		public ITaskItem CompiledEntitlements { get; set; }
+		public string CompiledEntitlements { get; set; }
 
 		public string Entitlements { get; set; }
 
@@ -363,8 +363,8 @@ namespace Xamarin.MacDev.Tasks
 			archived = GetArchivedExpandedEntitlements (template, compiled);
 
 			try {
-				Directory.CreateDirectory (Path.GetDirectoryName (CompiledEntitlements.ItemSpec));
-				WriteXcent (compiled, CompiledEntitlements.ItemSpec);
+				Directory.CreateDirectory (Path.GetDirectoryName (CompiledEntitlements));
+				WriteXcent (compiled, CompiledEntitlements);
 			} catch (Exception ex) {
 				Log.LogError ("Error writing xcent file '{0}': {1}", CompiledEntitlements, ex.Message);
 				return false;

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DSymUtilTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DSymUtilTaskBase.cs
@@ -1,6 +1,5 @@
-using System;
+﻿using System;
 using System.IO;
-using System.Linq;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -26,26 +25,8 @@ namespace Xamarin.MacDev.Tasks
 
 		#endregion
 
-		#region Outputs
-
-		[Output]
-		public ITaskItem[] DsymContentFiles { get; set; }
-
-		#endregion
-
 		protected override string ToolName {
 			get { return "dsymutil"; }
-		}
-
-		public override bool Execute ()
-		{
-			var result = base.Execute ();
-
-			var contentsDir = Path.Combine (DSymDir, "Contents");
-			if (Directory.Exists(contentsDir))
-				DsymContentFiles = Directory.EnumerateFiles (contentsDir).Select (x => new TaskItem (x)).ToArray ();
-
-			return result;
 		}
 
 		protected override string GenerateFullPathToTool ()

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileITunesMetadataTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/CompileITunesMetadataTaskBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 
 using Microsoft.Build.Framework;
@@ -20,7 +20,6 @@ namespace Xamarin.iOS.Tasks
 
 		public ITaskItem[] ITunesMetadata { get; set; }
 
-		[Output]
 		[Required]
 		public ITaskItem OutputPath { get; set; }
 

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1486,7 +1486,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CompileEntitlements" Condition="'$(_RequireCodeSigning)' == 'true' Or '$(CodesignEntitlements)' != ''" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectSigningIdentity"
-		Inputs="$(CodesignEntitlements)" Outputs="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent">
+		Outputs="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent">
 		<CompileEntitlements
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
@@ -1618,9 +1618,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</DetectDebugNetworkConfiguration>
 	</Target>
 
-	<Target Name="_CopyAppExtensionsToBundle" DependsOnTargets="_ResolveAppExtensionReferences" Inputs="@(_ResolvedAppExtensionReferences)" 
-		  Outputs="$(_AppBundlePath)PlugIns\%(_ResolvedAppExtensionReferences.FileName)%(_ResolvedAppExtensionReferences.Extension)">
-		
+	<Target Name="_CopyAppExtensionsToBundle" DependsOnTargets="_ResolveAppExtensionReferences">
 		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true' And '@(_ResolvedAppExtensionReferences)' != ''" Directories="$(_AppBundlePath)PlugIns" />
 
 		<Ditto

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Linq;
-using Microsoft.Build.Utilities;
 using NUnit.Framework;
 using Xamarin.MacDev;
 
@@ -37,14 +36,14 @@ namespace Xamarin.iOS.Tasks
 			task.AppBundleDir = AppBundlePath;
 			task.AppIdentifier = "32UV7A8CDE.com.xamarin.MySingleView";
 			task.BundleIdentifier = "com.xamarin.MySingleView";
-			task.CompiledEntitlements = new TaskItem (Path.Combine (MonoTouchProjectObjPath, "Entitlements.xcent"));
+			task.CompiledEntitlements = Path.Combine (MonoTouchProjectObjPath, "Entitlements.xcent");
 			task.Entitlements = Path.Combine ("..", "bin", "Resources", "Entitlements.plist");
 			task.IsAppExtension = false;
 			task.ProvisioningProfile = Path.Combine ("..", "bin", "Resources", "profile.mobileprovision");
 			task.SdkPlatform = "iPhoneOS";
 			task.SdkVersion = "6.1";
 
-			compiledEntitlements = task.CompiledEntitlements.ItemSpec;
+			compiledEntitlements = task.CompiledEntitlements;
 		}
 
 		[Test (Description = "Xambug #46298")]


### PR DESCRIPTION
This reverts commit 2922becfd20eca816e3d91f76b1c1cd604c9fead. After this commit we started to get build failures for devices.

Fixes xamarin/xamarin-macios#5094 

[XI] Unittestapps fail to install on device with the error "Application is missing the application-identifier entitlement"

