### PR TITLE
[msbuild] Removes CompileEntitlements target inputs

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1486,7 +1486,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CompileEntitlements" Condition="'$(_RequireCodeSigning)' == 'true' Or '$(CodesignEntitlements)' != ''" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectSigningIdentity"
-		Inputs="$(CodesignEntitlements)" Outputs="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent">
+		Outputs="$(DeviceSpecificIntermediateOutputPath)Entitlements.xcent">
 		<CompileEntitlements
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"


### PR DESCRIPTION
Since we don't require projects to contain an Entitlement.plist file we cannot use that as input, because if that file does not exist the CompileEntitlements target will be skipped. This target runs the CompileEntitlements task that generates a new Entitlements file, and that file is required to deploy the app to a device because it contains the application-identifier entitlement.

Fixes #5094