### PR TITLE
[tests] Increase the timeout for 'Mac Binding Projects' from the default 5m to 15m. Fixes maccore#1125.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -828,6 +828,7 @@ namespace xharness
 				Target = "all",
 				WorkingDirectory = Path.Combine (Harness.RootDirectory, "mac-binding-project"),
 				Ignored = !IncludeMacBindingProject || !IncludeMac,
+				Timeout = TimeSpan.FromMinutes (15),
 			};
 			Tasks.Add (runMacBindingProject);
 


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/1125.