### PR TITLE
[jenkins] Run the 'Test docs' step even if the 'Run tests' step failed.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -709,7 +709,11 @@ timestamps {
                                                 appendFileComment ("ℹ️ Test run skipped: ${skipLocalTestRunReason}\n")
                                             } else {
                                                 echo ("Html report: ${reportPrefix}/tests/index.html")
-                                                sh ("${workspace}/xamarin-macios/jenkins/run-tests.sh --target=wrench-jenkins --publish --keychain=xamarin-macios")
+                                                def runTestResult = sh (script: "${workspace}/xamarin-macios/jenkins/run-tests.sh --target=wrench-jenkins --publish --keychain=xamarin-macios", returnStatus: true)
+                                                if (runTestResult != 0) {
+                                                    echoError ("Test run failed")
+                                                    currentBuild.result = 'FAILURE'
+                                                }
                                             }
                                         }
                                         stage ('Test docs') {
@@ -720,7 +724,11 @@ timestamps {
                                             if (!testDocs) {
                                                 echo ("Skipping docs testing, it's only done on master (current (target) branch is ${targetBranch})")
                                             } else {
-                                                sh ("make -C ${workspace}/xamarin-macios/tests wrench-docs")
+                                                def testDocsResult = sh (script: "make -C ${workspace}/xamarin-macios/tests wrench-docs", returnStatus: true)
+                                                if (testDocsResult != 0) {
+                                                    echoError ("Test docs failed")
+                                                    currentBuild.result = 'FAILURE'
+                                                }
                                             }
                                         }
                                     }


### PR DESCRIPTION
This is done by preventing the 'Run tests' failure from throwing exceptions,
and instead manually set failure modes.