### PR TITLE
Remove some [Sealed] in XAMCORE_4_0 where not necessary

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -8502,7 +8502,7 @@ namespace Foundation
 		NSString ChangeNotificationIsPriorKey { get; }
 #if MONOMAC
 		// Cocoa Bindings added by Kenneth J. Pouncey 2010/11/17
-#if XAMCORE_4_0
+#if !XAMCORE_4_0
 		[Sealed]
 #endif
 		[Export ("valueClassForBinding:")]

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -8502,7 +8502,9 @@ namespace Foundation
 		NSString ChangeNotificationIsPriorKey { get; }
 #if MONOMAC
 		// Cocoa Bindings added by Kenneth J. Pouncey 2010/11/17
+#if XAMCORE_4_0
 		[Sealed]
+#endif
 		[Export ("valueClassForBinding:")]
 		Class GetBindingValueClass (NSString binding);
 

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -8542,19 +8542,28 @@ namespace Foundation
 		[Export ("exposedBindings")]
 		NSString[] ExposedBindings { get; }
 #endif
+
+#if !XAMCORE_4_0
 		[Sealed]
+#endif
 		[Export ("bind:toObject:withKeyPath:options:")]
 		void Bind (NSString binding, NSObject observable, string keyPath, [NullAllowed] NSDictionary options);
 
+#if !XAMCORE_4_0
 		[Sealed]
+#endif
 		[Export ("unbind:")]
 		void Unbind (NSString binding);
 
+#if !XAMCORE_4_0
 		[Sealed]
+#endif
 		[Export ("infoForBinding:")]
 		NSDictionary GetBindingInfo (NSString binding);
 
+#if !XAMCORE_4_0
 		[Sealed]
+#endif
 		[Export ("optionDescriptionsForBinding:")]
 		NSObject[] GetBindingOptionDescriptions (NSString aBinding);
 


### PR DESCRIPTION
- Added in https://github.com/xamarin/xamarin-macios/commit/7d88592a68618176454b63ef72c66bc59acf3ee3 but in XAMCORE_4_0 we don't need it since the "bad" binding won't be there.