### PR TITLE
[ImageCaptureCore] Add missing availability attribute. Fixes maccore#1126.

### DIFF
--- a/src/imagecapturecore.cs
+++ b/src/imagecapturecore.cs
@@ -119,6 +119,7 @@ namespace ImageCaptureCore {
 		[Field ("ICStatusNotificationKey")]
 		NSString NotificationKey { get; }
 
+		[Mac (10, 8)]
 		[Field ("ICStatusCodeKey")]
 		NSString CodeKey { get; }
 


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/1126.