### PR TITLE
[QuickLook] Add [ThreadSafe] to `QLThumbnailReply`

### DIFF
--- a/src/quicklook.cs
+++ b/src/quicklook.cs
@@ -162,6 +162,7 @@ namespace QuickLook {
 		void ProvideThumbnail (QLFileThumbnailRequest request, Action<QLThumbnailReply, NSError> handler);
 	}
 
+	[ThreadSafe] // Members get called inside 'QLThumbnailProvider.ProvideThumbnail' which runs on a background thread.
 	[iOS (11,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -179,6 +180,7 @@ namespace QuickLook {
 		QLThumbnailReply CreateReply (NSUrl fileUrl);
 	}
 
+	[ThreadSafe]
 	[iOS (11,0)]
 	[BaseType (typeof (NSObject))]
 	interface QLFileThumbnailRequest {


### PR DESCRIPTION
`QLThumbnailReply` and `QLFileThumbnailRequest`  members are called
from a background thread within `QLThumbnailProvider` extension
so our check on `UIApplication.EnsureUIThread ()` is not needed.

Fixes xamarin/xamarin-macios#5117