### PR TITLE
[d16-0-p2] [msbuild] Fixed compilation of SceneKit assets in library projects

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -72,8 +72,13 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<_CanArchive>False</_CanArchive>
 		<_CanArchive Condition="'$(OutputType)' == 'Exe'">true</_CanArchive>
 
+		<_RequireProvisioningProfile>False</_RequireProvisioningProfile>
+		<_RequireProvisioningProfile Condition="'$(CodesignEntitlements)' != ''">True</_RequireProvisioningProfile>
+
 		<_PreparedResourceRules></_PreparedResourceRules>
 		<_AppBundleName>$(AssemblyName)</_AppBundleName>
+
+		<AppBundleExtension Condition="'$(AppBundleExtension)' == ''">.app</AppBundleExtension>
 	</PropertyGroup>
 		
 	<PropertyGroup>
@@ -435,13 +440,6 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_DetectSigningIdentity" DependsOnTargets="_DetectAppManifest">
-		<PropertyGroup>
-			<_AppBundleName>$(AssemblyName)</_AppBundleName>
-
-			<_RequireProvisioningProfile>False</_RequireProvisioningProfile>
-			<_RequireProvisioningProfile Condition="'$(CodesignEntitlements)' != ''">True</_RequireProvisioningProfile>
-		</PropertyGroup>
-
 		<DetectSigningIdentity
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
@@ -463,8 +461,8 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<Target Name="_GenerateBundleName">
 		<PropertyGroup>
-			<AppBundleDir>$(OutputPath)$(_AppBundleName).app</AppBundleDir>
-			<_AppBundlePath>$(OutputPath)$(_AppBundleName).app\</_AppBundlePath>
+			<AppBundleDir>$(OutputPath)$(_AppBundleName)$(AppBundleExtension)</AppBundleDir>
+			<_AppBundlePath>$(AppBundleDir)\</_AppBundlePath>
 			<_AppResourcesPath>$(_AppBundlePath)Contents\Resources\</_AppResourcesPath>
 		</PropertyGroup>
 	</Target>
@@ -638,7 +636,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<CompileSceneKitAssets
 			Condition="'$(IsMacEnabled)' == 'true'"
 			SessionId="$(BuildSessionId)"
-			AppBundleDir="$(AppBundleDir)"
+			AppBundleName="$(_AppBundleName)$(AppBundleExtension)"
 			ToolExe="$(CopySceneKitAssetsExe)"
 			ToolPath="$(CopySceneKitAssetsPath)"
 			SceneKitAssets="@(SceneKitAsset)"

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CompileSceneKitAssetsTaskBase.cs
@@ -19,7 +19,7 @@ namespace Xamarin.MacDev.Tasks
 		public string SessionId { get; set; }
 
 		[Required]
-		public string AppBundleDir { get; set; }
+		public string AppBundleName { get; set; }
 
 		[Required]
 		public string IntermediateOutputPath { get; set; }
@@ -62,10 +62,6 @@ namespace Xamarin.MacDev.Tasks
 		public ITaskItem[] BundleResources { get; set; }
 
 		#endregion
-		
-		string AppBundleName {
-			get { return Path.GetFileName (AppBundleDir); }
-		}
 
 		static string ToolName {
 			get { return "copySceneKitAssets"; }

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1280,7 +1280,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 		<CompileSceneKitAssets
 			SessionId="$(BuildSessionId)"
-			AppBundleDir="$(AppBundleDir)"
+			AppBundleName="$(_AppBundleName)$(AppBundleExtension)"
 			Condition="'$(IsMacEnabled)' == 'true'"
 			ToolExe="$(CopySceneKitAssetsExe)"
 			ToolPath="$(CopySceneKitAssetsPath)"


### PR DESCRIPTION
The problem is that AppBundleDir never gets defined for library projects.

Luckily, _AppBundleName and AppBundleExtension are always defined and
all we need is the directory name (i.e. MyApp.app), so this will work
just fine.

Fixes issue #5129

Backport of #5130.

/cc @spouliot @jstedfast