### PR TITLE
[xharness] Only build the BCL tests when we need them.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -195,11 +195,14 @@ $(TOP)/tools/mtouch/SdkVersions.cs: $(TOP)/tools/common/SdkVersions.cs.in
 	@$(MAKE) -C $(TOP)/src project-files
 	@touch $@
 
-xharness/xharness.exe: $(wildcard xharness/*.cs) xharness/xharness.csproj $(TOP)/tools/mtouch/SdkVersions.cs test.config test-system.config .stamp-src-project-files
+.stamp-build-mono-unit-tests: $(TOP)/.git/modules/external/mono/HEAD
 	make -j8 -C $(TOP)/external/mono/mcs/class -i do-test PROFILE=MONOTOUCH # TODO: This should not be needed and we should get the dlls from the SDK.
 	make -j8 -C $(TOP)/external/mono/mcs/class -i do-xunit-test PROFILE=MONOTOUCH # TODO: This should not be needed and we should get the dlls from the SDK.
-	nuget restore xharness/xharness.csproj
 	nuget restore bcl-test/BCLTests/BCLTests.csproj
+	$(Q) touch $@
+
+xharness/xharness.exe: $(wildcard xharness/*.cs) xharness/xharness.csproj $(TOP)/tools/mtouch/SdkVersions.cs test.config test-system.config .stamp-src-project-files
+	nuget restore xharness/xharness.csproj
 	$(Q_GEN) $(SYSTEM_XIBUILD) -- $(MSBUILD_VERBOSITY_QUIET) xharness/xharness.csproj
 
 killall:

--- a/tests/xharness/BCLTestImporter/BCLTestImportTargetFactory.cs
+++ b/tests/xharness/BCLTestImporter/BCLTestImportTargetFactory.cs
@@ -27,16 +27,22 @@ namespace xharness.BCLTestImporter {
 		}
 		
 		// generate all the different test targets.
-		public List<iOSTestProject> GetBclTargets ()
+		public List<iOSTestProject> GetBclTargets (Harness harness)
 		{
 			var result = new List<iOSTestProject> ();
 			// generate all projects, then create a new iOSTarget per project
-			foreach (var (name, path, xunit, platforms) in projectGenerator.GenerateAllTestProjects ()) {
+			foreach (var (name, path, xunit, platforms, generate) in projectGenerator.GenerateAllTestProjects ()) {
 				var prefix = xunit ? "xUnit" : "NUnit";
 				result.Add (new iOSTestProject (path) { 
 					Name = $"[{prefix}] Mono {name}",
 					SkiptvOSVariation=!platforms.Contains (Platform.TvOS),
-					SkipwatchOSVariation=!platforms.Contains (Platform.WatchOS)
+					SkipwatchOSVariation=!platforms.Contains (Platform.WatchOS),
+					Dependency = async () => {
+						var rv = await harness.BuildBclTests ();
+						if (!rv.Succeeded)
+							throw new Exception ($"Failed to build BCL tests, exit code: {rv.ExitCode}. Check the harness log for more details.");
+						await generate ();
+					},
 				});
 			}
 			return result;

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -356,7 +356,7 @@ namespace xharness
 
 			// add all the tests that are using the precompiled mono assemblies
 			var monoImportTestFactory = new BCLTestImportTargetFactory (this);
-			foreach (var target in monoImportTestFactory.GetBclTargets ()) {
+			foreach (var target in monoImportTestFactory.GetBclTargets (this)) {
 				IOSTestProjects.Add (target);
 			}
 
@@ -828,6 +828,14 @@ namespace xharness
 			}
 
 			return rv;
+		}
+
+		Task<ProcessExecutionResult> build_bcl_tests;
+		public Task<ProcessExecutionResult> BuildBclTests ()
+		{
+			if (build_bcl_tests == null)
+				build_bcl_tests = ProcessHelper.ExecuteCommandAsync ("make", $".stamp-build-mono-unit-tests -C {StringUtils.Quote (Path.GetFullPath (RootDirectory))}", HarnessLog, TimeSpan.FromMinutes (30));
+			return build_bcl_tests;
 		}
 	}
 

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -57,6 +57,7 @@ namespace xharness
 		public Devices Devices = new Devices ();
 
 		List<TestTask> Tasks = new List<TestTask> ();
+		Dictionary<string, MakeTask> DependencyTasks = new Dictionary<string, MakeTask> ();
 
 		internal static Resource DesktopResource = new Resource ("Desktop", Environment.ProcessorCount);
 
@@ -348,6 +349,7 @@ namespace xharness
 							Platform = pair.Item2,
 							Ignored = pair.Item3,
 							TestName = project.Name,
+							Dependency = project.Dependency,
 						};
 						derived.CloneTestProject (pair.Item1);
 						var simTasks = CreateRunSimulatorTaskAsync (derived);
@@ -2206,6 +2208,7 @@ function toggleAll (show)
 		public string ProjectPlatform;
 		public Dictionary<string, string> Environment = new Dictionary<string, string> ();
 
+		public Func<Task> Dependency; // a task that's feteched and awaited before this task's ExecuteAsync method
 		public Task InitialTask; // a task that's executed before this task's ExecuteAsync method.
 		public Task CompletedTask; // a task that's executed after this task's ExecuteAsync method.
 
@@ -2402,6 +2405,9 @@ function toggleAll (show)
 			ExecutionResult = (ExecutionResult & ~TestExecutingResult.StateMask) | TestExecutingResult.InProgress;
 
 			try {
+				if (Dependency != null)
+					await Dependency ();
+
 				if (InitialTask != null)
 					await InitialTask;
 				

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -18,6 +18,7 @@ namespace xharness
 		public bool IsNUnitProject;
 		public bool GenerateVariations = true;
 		public string [] Configurations;
+		public Func<Task> Dependency;
 
 		public IEnumerable<TestProject> ProjectReferences;
 

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -292,10 +292,68 @@ namespace BCLTestImporter {
 			return false;
 		}
 
-		async Task<List<(string name, string path, bool xunit)>> GenerateWatchOSTestProjectsAsync (
+		async Task GenerateWatch (string generatedDir, BCLTestProjectDefinition projectDefinition, string rootProjectPath, (string name, string[] assemblies) def)
+		{
+			var generatedCodeDir = Path.Combine (generatedDir, projectDefinition.Name);
+			if (!Directory.Exists (generatedCodeDir)) {
+				Directory.CreateDirectory (generatedCodeDir);
+			}
+			var registerTypePath = Path.Combine (generatedCodeDir, "RegisterType.cs");
+			var typesPerAssembly = projectDefinition.GetTypeForAssemblies (MonoRootPath, Platform.WatchOS);
+			var registerCode = await RegisterTypeGenerator.GenerateCodeAsync (typesPerAssembly,
+				projectDefinition.IsXUnit, RegisterTypesTemplatePath);
+			using (var file = new StreamWriter (registerTypePath, false)) { // false is do not append
+				await file.WriteAsync (registerCode);
+			}
+			// create the plist for each of the apps
+			var projectData = new Dictionary<WatchAppType, (string plist, string project)> ();
+			foreach (var appType in new [] { WatchAppType.Extension, WatchAppType.App }) {
+				(string plist, string project) data;
+				var plistTemplate = Path.Combine (PlistTemplateRootPath, watchOSPlistTemplateMatches [appType]);
+				var plist = await BCLTestInfoPlistGenerator.GenerateCodeAsync (plistTemplate, projectDefinition.Name);
+				data.plist = GetPListPath (generatedCodeDir, appType);
+				using (var file = new StreamWriter (data.plist, false)) { // false is do not append
+					await file.WriteAsync (plist);
+				}
+
+				string generatedProject;
+				var projetTemplate = Path.Combine (ProjectTemplateRootPath, watchOSProjectTemplateMatches [appType]);
+				switch (appType) {
+				case WatchAppType.App:
+					generatedProject = await GenerateWatchAppAsync (projectDefinition.Name, projetTemplate, data.plist);
+					break;
+				default:
+					generatedProject = await GenerateWatchExtensionAsync (projectDefinition.Name, projetTemplate, data.plist, registerTypePath, projectDefinition.GetAssemblyInclusionInformation (MonoRootPath, Platform.WatchOS));
+					break;
+				}
+				data.project = GetProjectPath (projectDefinition.Name, appType);
+				using (var file = new StreamWriter (data.project, false)) { // false is do not append
+					await file.WriteAsync (generatedProject);
+				}
+
+				projectData [appType] = data;
+			} // foreach app type
+
+			var rootPlistTemplate = Path.Combine (PlistTemplateRootPath, plistTemplateMatches [Platform.WatchOS]);
+			var rootPlist = await BCLTestInfoPlistGenerator.GenerateCodeAsync (rootPlistTemplate, projectDefinition.Name);
+			var infoPlistPath = GetPListPath (generatedCodeDir, Platform.WatchOS);
+			using (var file = new StreamWriter (infoPlistPath, false)) { // false is do not append
+				await file.WriteAsync (rootPlist);
+			}
+
+			var projectTemplatePath = Path.Combine (ProjectTemplateRootPath, projectTemplateMatches [Platform.WatchOS]);
+			using (var file = new StreamWriter (rootProjectPath, false)) // false is do not append
+			using (var reader = new StreamReader (projectTemplatePath)) {
+				var template = await reader.ReadToEndAsync ();
+				var generatedRootProject = GenerateWatchProject (def.name, template, infoPlistPath);
+				await file.WriteAsync (generatedRootProject);
+			}
+		}
+
+		List<(string name, string path, bool xunit, Func<Task> generate)> GenerateWatchOSTestProjects (
 			IEnumerable<(string name, string[] assemblies)> projects, string generatedDir)
 		{
-			var projectPaths = new List<(string name, string path, bool xunit)> ();
+			var projectPaths = new List<(string name, string path, bool xunit, Func<Task> generate)> ();
 			foreach (var def in projects) {
 				// each watch os project requires 3 different ones:
 				// 1. The app
@@ -308,75 +366,56 @@ namespace BCLTestImporter {
 
 				if (!projectDefinition.Validate ())
 					throw new InvalidOperationException ("xUnit and NUnit assemblies cannot be mixed in a test project.");
-				var generatedCodeDir = Path.Combine (generatedDir, projectDefinition.Name);
-				if (!Directory.Exists (generatedCodeDir)) {
-					Directory.CreateDirectory (generatedCodeDir);
-				}
-				var registerTypePath = Path.Combine (generatedCodeDir, "RegisterType.cs");
-				var typesPerAssembly = projectDefinition.GetTypeForAssemblies (MonoRootPath, Platform.WatchOS);
-				var registerCode = await RegisterTypeGenerator.GenerateCodeAsync (typesPerAssembly,
-					projectDefinition.IsXUnit, RegisterTypesTemplatePath);
-				using (var file = new StreamWriter (registerTypePath, false)) { // false is do not append
-					await file.WriteAsync (registerCode);
-				}
-				// create the plist for each of the apps
-				var projectData = new Dictionary<WatchAppType, (string plist, string project)> ();
-				foreach (var appType in new [] {WatchAppType.Extension, WatchAppType.App}) {
-					(string plist, string project) data;
-					var plistTemplate = Path.Combine (PlistTemplateRootPath, watchOSPlistTemplateMatches[appType]);
-					var plist = await BCLTestInfoPlistGenerator.GenerateCodeAsync (plistTemplate, projectDefinition.Name);
-					data.plist = GetPListPath (generatedCodeDir, appType);
-					using (var file = new StreamWriter (data.plist, false)) { // false is do not append
-						await file.WriteAsync (plist);
-					}
-
-					string generatedProject;
-					var projetTemplate = Path.Combine (ProjectTemplateRootPath, watchOSProjectTemplateMatches[appType]);
-					switch (appType) {
-						case WatchAppType.App:
-							generatedProject = await GenerateWatchAppAsync (projectDefinition.Name, projetTemplate, data.plist);
-							break;
-						default:
-							generatedProject = await GenerateWatchExtensionAsync (projectDefinition.Name, projetTemplate, data.plist, registerTypePath, projectDefinition.GetAssemblyInclusionInformation (MonoRootPath, Platform.WatchOS));
-							break;
-					}
-					data.project = GetProjectPath (projectDefinition.Name, appType);
-					using (var file = new StreamWriter (data.project, false)) { // false is do not append
-						await file.WriteAsync (generatedProject);
-					}
-
-					projectData[appType] = data;
-				} // foreach app type
-				
-				var rootPlistTemplate = Path.Combine (PlistTemplateRootPath, plistTemplateMatches[Platform.WatchOS]);
-				var rootPlist = await BCLTestInfoPlistGenerator.GenerateCodeAsync (rootPlistTemplate, projectDefinition.Name);
-				var infoPlistPath = GetPListPath (generatedCodeDir, Platform.WatchOS);
-				using (var file = new StreamWriter (infoPlistPath, false)) { // false is do not append
-					await file.WriteAsync (rootPlist);
-				}
-				
-				var projectTemplatePath = Path.Combine (ProjectTemplateRootPath, projectTemplateMatches[Platform.WatchOS]);
-				var rootProjectPath = GetProjectPath (projectDefinition.Name, Platform.WatchOS);
-				using (var file = new StreamWriter (rootProjectPath, false)) // false is do not append
-				using (var reader = new StreamReader (projectTemplatePath)){
-					var template = await reader.ReadToEndAsync ();
-					var generatedRootProject = GenerateWatchProject (def.name, template, infoPlistPath);
-					await file.WriteAsync (generatedRootProject);
-				}
-
 				// we have the 3 projects we depend on, we need the root one, the one that will be used by harness
-				projectPaths.Add ((name: projectDefinition.Name, path: rootProjectPath, xunit: projectDefinition.IsXUnit));
+				var rootProjectPath = GetProjectPath (projectDefinition.Name, Platform.WatchOS);
+				var generate = new Func<Task> (() => {
+					return GenerateWatch (generatedDir, projectDefinition, rootProjectPath, def);
+				});
+				projectPaths.Add ((name: projectDefinition.Name, path: rootProjectPath, xunit: projectDefinition.IsXUnit, generate: generate));
 			} // foreach project
 
 			return projectPaths;
 		}
-		
-		async Task<List<(string name, string path, bool xunit)>> GenerateiOSTestProjectsAsync (
+
+		async Task Generate (string generatedDir, BCLTestProjectDefinition projectDefinition, string projectPath, Platform platform)
+		{
+			// generate the required type registration info
+			var generatedCodeDir = Path.Combine (generatedDir, projectDefinition.Name);
+			if (!Directory.Exists (generatedCodeDir)) {
+				Directory.CreateDirectory (generatedCodeDir);
+			}
+			var registerTypePath = Path.Combine (generatedCodeDir, "RegisterType.cs");
+
+			var typesPerAssembly = projectDefinition.GetTypeForAssemblies (MonoRootPath, platform);
+			var registerCode = await RegisterTypeGenerator.GenerateCodeAsync (typesPerAssembly,
+				projectDefinition.IsXUnit, RegisterTypesTemplatePath);
+
+			using (var file = new StreamWriter (registerTypePath, false)) { // false is do not append
+				await file.WriteAsync (registerCode);
+			}
+
+			var plistTemplate = Path.Combine (PlistTemplateRootPath, plistTemplateMatches [platform]);
+			var plist = await BCLTestInfoPlistGenerator.GenerateCodeAsync (plistTemplate, projectDefinition.Name);
+			var infoPlistPath = GetPListPath (generatedCodeDir, platform);
+			using (var file = new StreamWriter (infoPlistPath, false)) { // false is do not append
+				await file.WriteAsync (plist);
+			}
+
+			var projectTemplatePath = Path.Combine (ProjectTemplateRootPath, projectTemplateMatches [platform]);
+			var generatedProject = await GenerateAsync (projectDefinition.Name, registerTypePath,
+				projectDefinition.GetAssemblyInclusionInformation (MonoRootPath, platform), projectTemplatePath, infoPlistPath);
+
+			using (var file = new StreamWriter (projectPath, false)) { // false is do not append
+				await file.WriteAsync (generatedProject);
+			}
+		}
+
+		List<(string name, string path, bool xunit, Func<Task> generate)> GenerateiOSTestProjects (
 			IEnumerable<(string name, string[] assemblies)> projects, Platform platform, string generatedDir)
 		{
 			if (platform == Platform.WatchOS) 
 				throw new ArgumentException (nameof (platform));
-			var projectPaths = new List<(string name, string path, bool xunit)> ();
+			var projectPaths = new List<(string name, string path, bool xunit, Func<Task> generate)> ();
 			foreach (var def in projects) {
 				var projectDefinition = new BCLTestProjectDefinition (def.name, def.assemblies);
 				if (IsIgnored (projectDefinition, platform)) // some projects are ignored, so we just continue
@@ -384,36 +423,11 @@ namespace BCLTestImporter {
 
 				if (!projectDefinition.Validate ())
 					throw new InvalidOperationException ("xUnit and NUnit assemblies cannot be mixed in a test project.");
-				// generate the required type registration info
-				var generatedCodeDir = Path.Combine (generatedDir, projectDefinition.Name);
-				if (!Directory.Exists (generatedCodeDir)) {
-					Directory.CreateDirectory (generatedCodeDir);
-				}
-				var registerTypePath = Path.Combine (generatedCodeDir, "RegisterType.cs");
-
-				var typesPerAssembly = projectDefinition.GetTypeForAssemblies (MonoRootPath, platform);
-				var registerCode = await RegisterTypeGenerator.GenerateCodeAsync (typesPerAssembly,
-					projectDefinition.IsXUnit, RegisterTypesTemplatePath);
-
-				using (var file = new StreamWriter (registerTypePath, false)) { // false is do not append
-					await file.WriteAsync (registerCode);
-				}
-
-				var plistTemplate = Path.Combine (PlistTemplateRootPath, plistTemplateMatches[platform]);
-				var plist = await BCLTestInfoPlistGenerator.GenerateCodeAsync (plistTemplate, projectDefinition.Name);
-				var infoPlistPath = GetPListPath (generatedCodeDir, platform);
-				using (var file = new StreamWriter (infoPlistPath, false)) { // false is do not append
-					await file.WriteAsync (plist);
-				}
-
-				var projectTemplatePath = Path.Combine (ProjectTemplateRootPath, projectTemplateMatches[platform]);
-				var generatedProject = await GenerateAsync (projectDefinition.Name, registerTypePath,
-					projectDefinition.GetAssemblyInclusionInformation (MonoRootPath, platform), projectTemplatePath, infoPlistPath);
 				var projectPath = GetProjectPath (projectDefinition.Name, platform);
-				projectPaths.Add ((name: projectDefinition.Name, path: projectPath, xunit: projectDefinition.IsXUnit));
-				using (var file = new StreamWriter (projectPath, false)) { // false is do not append
-					await file.WriteAsync (generatedProject);
-				}
+				var generate = new Func<Task> (() => {
+					return Generate (generatedDir, projectDefinition, projectPath, platform);
+				});
+				projectPaths.Add ((name: projectDefinition.Name, path: projectPath, xunit: projectDefinition.IsXUnit, generate: generate));
 			} // foreach project
 
 			return projectPaths;
@@ -427,21 +441,21 @@ namespace BCLTestImporter {
 		/// has its own details.</param>
 		/// <param name="generatedDir">The dir where the projects will be saved.</param>
 		/// <returns></returns>
-		async Task<List<(string name, string path, bool xunit)>> GenerateTestProjectsAsync (
+		List<(string name, string path, bool xunit, Func<Task> generate)> GenerateTestProjects (
 			IEnumerable<(string name, string[] assemblies)> projects, Platform platform, string generatedDir)
 		{
-			List<(string name, string path, bool xunit)> result;
+			List<(string name, string path, bool xunit, Func<Task> generate)> result;
 			if (platform == Platform.WatchOS)
-				result = await GenerateWatchOSTestProjectsAsync (projects, generatedDir);
+				result = GenerateWatchOSTestProjects (projects, generatedDir);
 			else
-				result = await GenerateiOSTestProjectsAsync (projects, platform, generatedDir);
+				result = GenerateiOSTestProjects (projects, platform, generatedDir);
 			return result;
 		}
 		
 		// generates a project per platform of the common projects. 
-		async Task<List<(string name, string path, bool xunit, List<Platform> platforms)>> GenerateAllCommonTestProjectsAsync ()
+		List<(string name, string path, bool xunit, List<Platform> platforms, Func<Task> generate)> GenerateAllCommonTestProjects ()
 		{
-			var projectPaths = new List<(string name, string path, bool xunit, List<Platform> platforms)> ();
+			var projectPaths = new List<(string name, string path, bool xunit, List<Platform> platforms, Func<Task> generate)> ();
 			if (!isCodeGeneration)
 				throw new InvalidOperationException ("Project generator was instantiated to delete the generated code.");
 			var generatedCodePathRoot = GeneratedCodePathRoot;
@@ -449,12 +463,12 @@ namespace BCLTestImporter {
 				Directory.CreateDirectory (generatedCodePathRoot);
 			}
 
-			var projects = new Dictionary<string, (string path, bool xunit, List<Platform> platforms)> ();
+			var projects = new Dictionary<string, (string path, bool xunit, List<Platform> platforms, Func<Task> generate)> ();
 			foreach (var platform in new [] {Platform.iOS, Platform.TvOS, Platform.WatchOS}) {
-				var generated = await GenerateTestProjectsAsync (commonTestProjects, platform, generatedCodePathRoot);
-				foreach (var (name, path, xunit) in generated) {
+				var generated = GenerateTestProjects (commonTestProjects, platform, generatedCodePathRoot);
+				foreach (var (name, path, xunit, generate) in generated) {
 					if (!projects.ContainsKey (name)) {
-						projects [name] = (path, xunit, new List<Platform> { platform });
+						projects [name] = (path, xunit, new List<Platform> { platform }, generate);
 					} else {
 						projects [name].platforms.Add (platform);
 					}
@@ -463,15 +477,15 @@ namespace BCLTestImporter {
 			
 			// return the grouped projects
 			foreach (var name in projects.Keys) {
-				projectPaths.Add ((name, projects[name].path, projects[name].xunit, projects[name].platforms));
+				projectPaths.Add ((name, projects[name].path, projects[name].xunit, projects[name].platforms, projects [name].generate));
 			}
 			return projectPaths;
 		}
 		
 		// creates all the projects that have already been defined
-		public async Task<List<(string name, string path, bool xunit, List<Platform> platforms)>> GenerateAllTestProjectsAsync ()
+		public List<(string name, string path, bool xunit, List<Platform> platforms, Func<Task> generate)> GenerateAllTestProjects ()
 		{
-			var projectPaths = new List<(string name, string path, bool xunit, List<Platform> platforms)> ();
+			var projectPaths = new List<(string name, string path, bool xunit, List<Platform> platforms, Func<Task> generate)> ();
 			if (!isCodeGeneration)
 				throw new InvalidOperationException ("Project generator was instantiated to delete the generated code.");
 			var generatedCodePathRoot = GeneratedCodePathRoot;
@@ -479,13 +493,11 @@ namespace BCLTestImporter {
 				Directory.CreateDirectory (generatedCodePathRoot);
 			}
 			// generate all the common projects
-			projectPaths.AddRange (await GenerateAllCommonTestProjectsAsync ());
+			projectPaths.AddRange (GenerateAllCommonTestProjects ());
 
 			return projectPaths;
 		}
 
-		public List<(string name, string path, bool xunit, List<Platform> platforms)> GenerateAllTestProjects () => GenerateAllTestProjectsAsync ().Result;
-		
 		/// <summary>
 		/// Generates an iOS project for testing purposes. The generated project will contain the references to the
 		/// mono test assemblies to run.


### PR DESCRIPTION
Only build the BCL tests when we need them, because we can't build them when
we're running the device tests (because we don't have a built source tree in
that case).

Since the test assemblies are required when generating the BCL projects, this
means we also delay creating the BCL projects until we need them.