### PR TITLE
The NSBackingStore enum is not deprecated

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -138,7 +138,6 @@ namespace AppKit {
 	}
 
 	[Native]
-	[Deprecated (PlatformName.MacOSX, 10, 14)]
 	public enum NSBackingStore : ulong {
 		[Deprecated (PlatformName.MacOSX, 10, 13, message : "Use 'Buffered' instead.")]
 		Retained, 


### PR DESCRIPTION
I noticed `NSBackingStore` is marked as deprecated in our bindings when it is not - the only _value_ that is supported is `Buffered`. This is an annoyance in the IDE when programmatically creating a new `NSWindow` where an `NSBackingStore` must be provided.

* [Docs](https://developer.apple.com/documentation/appkit/nsbackingstoretype?language=objc)

```objective-c
typedef NS_ENUM(NSUInteger, NSBackingStoreType) {
    /* NSBackingStoreRetained and NSBackingStoreNonretained have effectively been synonyms of NSBackingStoreBuffered since OS X Mountain Lion.  Please switch to the equivalent NSBackingStoreBuffered.
     */
    NSBackingStoreRetained NS_DEPRECATED_WITH_REPLACEMENT_MAC("NSBackingStoreBuffered", 10_0, 10_13) = 0,
    NSBackingStoreNonretained NS_DEPRECATED_WITH_REPLACEMENT_MAC("NSBackingStoreBuffered", 10_0, 10_13) = 1,
    NSBackingStoreBuffered = 2,
};
```