### PR TITLE
[runtime] Clean up public symbols. Fixes #5124.

### DIFF
--- a/runtime/extension-main.m
+++ b/runtime/extension-main.m
@@ -2,8 +2,14 @@
 #include "xamarin/main.h"
 #include "main-internal.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 void
 xamarin_initialize_extension_main () __attribute__ ((constructor));
+#ifdef __cplusplus
+}
+#endif
 
 void
 xamarin_initialize_extension_main ()

--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -526,7 +526,7 @@ app_initialize (xamarin_initialize_data *data)
 
 	/* other non-documented stuff... */	
 
-	initialize_cocoa_threads (NULL);
+	xamarin_initialize_cocoa_threads (NULL);
 	init_logdir ();
 	mono_set_signal_chaining (TRUE);
 	mono_set_crash_chaining (TRUE);

--- a/runtime/mono-runtime.m.t4
+++ b/runtime/mono-runtime.m.t4
@@ -147,5 +147,5 @@ bool
 
 <# } #>
 #else
-int fix_ranlib_warning_about_no_symbols;
+int xamarin_fix_ranlib_warning_about_no_symbols;
 #endif /* DYNAMIC_MONO_RUNTIME */

--- a/runtime/monotouch-debug.m
+++ b/runtime/monotouch-debug.m
@@ -43,16 +43,13 @@
 #include "product.h"
 
 // permanent connection variables
-int monodevelop_port = -1;
-int sdb_fd = -1;
-int profiler_fd = -1;
-int heapshot_fd = -1; // this is the socket to write 'heapshot' to to requests heapshots from the profiler
-int heapshot_port = -1;
-char *profiler_description = NULL; 
+static int monodevelop_port = -1;
+static int sdb_fd = -1;
+static int heapshot_fd = -1; // this is the socket to write 'heapshot' to to requests heapshots from the profiler
+static int heapshot_port = -1;
+static char *profiler_description = NULL;
 // old variables
-int output_port;
-int debug_port; 
-char *debug_host = NULL;
+static char *debug_host = NULL;
 
 enum DebuggingMode
 {
@@ -71,6 +68,7 @@ static bool connection_failed = false;
 static DebuggingMode debugging_mode = DebuggingModeWifi;
 static const char *connection_mode = "default"; // this is set from the cmd line, can be either 'usb', 'wifi', 'http' or 'none'
 
+extern "C" {
 void monotouch_connect_usb ();
 void monotouch_connect_wifi (NSMutableArray *hosts);
 void xamarin_connect_http (NSMutableArray *hosts);
@@ -80,6 +78,8 @@ void monotouch_configure_debugging ();
 void monotouch_load_profiler ();
 void monotouch_load_debugger ();
 bool monotouch_process_connection (int fd);
+void monotouch_dump_objc_api (Class klass);
+}
 
 static struct timeval wait_tv;
 static struct timespec wait_ts;
@@ -705,7 +705,7 @@ void monotouch_configure_debugging ()
 	pthread_mutex_unlock (&mutex);
 }
 
-void sdb_connect (const char *address)
+static void sdb_connect (const char *address)
 {
 	gboolean shaked;
 
@@ -719,17 +719,17 @@ void sdb_connect (const char *address)
 	return;
 }
 
-void sdb_close1 (void)
+static void sdb_close1 (void)
 {
 	shutdown (sdb_fd, SHUT_RD);
 }
 
-void sdb_close2 (void)
+static void sdb_close2 (void)
 {
 	shutdown (sdb_fd, SHUT_RDWR);
 }
 
-gboolean send_uninterrupted (int fd, const void *buf, int len)
+static gboolean send_uninterrupted (int fd, const void *buf, int len)
 {
 	int res;
 
@@ -740,7 +740,7 @@ gboolean send_uninterrupted (int fd, const void *buf, int len)
 	return res == len;
 }
 
-int recv_uninterrupted (int fd, void *buf, int len)
+static int recv_uninterrupted (int fd, void *buf, int len)
 {
 	int res;
 	int total = 0;
@@ -755,7 +755,7 @@ int recv_uninterrupted (int fd, void *buf, int len)
 	return total;
 }
 
-gboolean sdb_send (void *buf, int len)
+static gboolean sdb_send (void *buf, int len)
 {
 	gboolean rv;
 
@@ -771,7 +771,7 @@ gboolean sdb_send (void *buf, int len)
 }
 
 
-int sdb_recv (void *buf, int len)
+static int sdb_recv (void *buf, int len)
 {
 	int rv;
 
@@ -1323,8 +1323,7 @@ monotouch_process_connection (int fd)
 				profiler_description = strdup (prof);
 #else
 				use_fd = true;
-				profiler_fd = fd;
-				profiler_description = xamarin_strdup_printf ("%s,output=#%i", prof, profiler_fd);
+				profiler_description = xamarin_strdup_printf ("%s,output=#%i", prof, fd);
 #endif
 				xamarin_set_gc_pump_enabled (false);
 			} else {
@@ -1709,6 +1708,6 @@ xamarin_is_native_debugger_attached ()
 #endif /* TARGET_OS_WATCH && !TARGET_OS_SIMULATOR */
 
 #else
-int fix_ranlib_warning_about_no_symbols_v2;
+int xamarin_fix_ranlib_warning_about_no_symbols_v2;
 #endif /* DEBUG */
 

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -386,9 +386,9 @@ xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 	}
 
 #ifdef DEBUG
-	initialize_cocoa_threads (monotouch_configure_debugging);
+	xamarin_initialize_cocoa_threads (monotouch_configure_debugging);
 #else
-	initialize_cocoa_threads (NULL);
+	xamarin_initialize_cocoa_threads (NULL);
 #endif
 
 #if defined (__arm__) || defined(__aarch64__)

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -185,7 +185,7 @@ static struct Trampolines trampolines = {
 	(void *) &xamarin_set_gchandle_trampoline,
 };
 
-struct InitializationOptions options = { 0 };
+static struct InitializationOptions options = { 0 };
 
 struct Managed_NSObject {
 	MonoObject obj;
@@ -1388,7 +1388,7 @@ xamarin_initialize ()
 	if (!register_assembly (assembly, &exception_gchandle))
 		xamarin_process_managed_exception_gchandle (exception_gchandle);
 
-	install_nsautoreleasepool_hooks ();
+	xamarin_install_nsautoreleasepool_hooks ();
 
 #if defined (DEBUG)
 	if (xamarin_gc_pump) {

--- a/runtime/shared.h
+++ b/runtime/shared.h
@@ -18,9 +18,9 @@ extern "C" {
 #endif
 
 typedef void (init_cocoa_func) (void);
-void initialize_cocoa_threads (init_cocoa_func *func);
+void xamarin_initialize_cocoa_threads (init_cocoa_func *func);
 
-void install_nsautoreleasepool_hooks ();
+void xamarin_install_nsautoreleasepool_hooks ();
 id xamarin_init_nsthread (id obj, bool is_direct, id target, SEL sel, id arg);
 void xamarin_insert_dllmap ();
 

--- a/runtime/shared.m
+++ b/runtime/shared.m
@@ -112,7 +112,7 @@ xamarin_init_nsthread (id obj, bool is_direct, id target, SEL sel, id arg)
  * Ref: https://bugzilla.xamarin.com/show_bug.cgi?id=798
  */
 
-@interface CocoaThreadInitializer : NSObject
+@interface XamarinCocoaThreadInitializer : NSObject
 {
 	init_cocoa_func *the_func;
 }
@@ -120,7 +120,7 @@ xamarin_init_nsthread (id obj, bool is_direct, id target, SEL sel, id arg)
 -(id) initWithFunc: (init_cocoa_func *) func;
 @end
 
-@implementation CocoaThreadInitializer
+@implementation XamarinCocoaThreadInitializer
 {
 }
 -(void) entryPoint: (NSObject *) obj
@@ -144,10 +144,10 @@ xamarin_init_nsthread (id obj, bool is_direct, id target, SEL sel, id arg)
 @end
 
 void
-initialize_cocoa_threads (init_cocoa_func *func)
+xamarin_initialize_cocoa_threads (init_cocoa_func *func)
 {
 	// COOP: no managed memory access: any mode.
-	[[[CocoaThreadInitializer alloc] initWithFunc: func] autorelease];
+	[[[XamarinCocoaThreadInitializer alloc] initWithFunc: func] autorelease];
 }
 
 /* Wrapping threads with NSAutoreleasePool
@@ -233,7 +233,7 @@ thread_end (MonoProfiler *prof, uintptr_t tid)
 }
 
 void
-install_nsautoreleasepool_hooks ()
+xamarin_install_nsautoreleasepool_hooks ()
 {
 	// COOP: executed at startup (and no managed memory access): any mode.
 	xamarin_thread_hash = CFDictionaryCreateMutable (kCFAllocatorDefault, 0, NULL, NULL);

--- a/runtime/trampolines-x86_64.m
+++ b/runtime/trampolines-x86_64.m
@@ -87,7 +87,9 @@ dump_state (struct CallState *state, id self, SEL sel)
 #define dump_state(...)
 #endif
 
-const char* registers[] =  { "rdi", "rsi", "rdx", "rcx", "r8", "r9", "err"  };
+#ifdef TRACE
+static const char* registers[] =  { "rdi", "rsi", "rdx", "rcx", "r8", "r9", "err"  };
+#endif
 
 static const char *
 skip_type_name (const char *ptr)

--- a/runtime/xamarin/main.h
+++ b/runtime/xamarin/main.h
@@ -87,12 +87,6 @@ int xamarin_get_launch_mode ();
 
 int xamarin_watchextension_main (int argc, char **argv);
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
-
-#endif /* __XAMARIN_MAIN_H__ */
-
 #ifndef MONOTOUCH
 void xamarin_set_is_mkbundle (bool value); /* Not Public API, exact semantics is not defined yet */
 bool xamarin_get_is_mkbundle (); /* Not Public API, exact semantics is not defined yet */
@@ -100,3 +94,9 @@ bool xamarin_get_is_mkbundle (); /* Not Public API, exact semantics is not defin
 
 void xamarin_set_is_debug (bool value); /* Public API */
 bool xamarin_get_is_debug (); /* Public API */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* __XAMARIN_MAIN_H__ */

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -216,6 +216,7 @@ void			xamarin_free_gchandle (id self, int gchandle);
 void			xamarin_clear_gchandle (id self);
 int				xamarin_get_gchandle_with_flags (id self);
 void			xamarin_set_gchandle (id self, int gchandle);
+void			xamarin_create_gchandle (id self, void *managed_object, int flags, bool force_weak);
 void			xamarin_create_managed_ref (id self, void * managed_object, bool retain);
 void            xamarin_release_managed_ref (id self, MonoObject *managed_obj);
 void			xamarin_notify_dealloc (id self, int gchandle);

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -84,8 +84,8 @@ typedef id		(*xamarin_managed_to_id_func) (MonoObject *value, guint32 context, g
 
 id              xamarin_generate_conversion_to_native (MonoObject *value, MonoType *inputType, MonoType *outputType, MonoMethod *method, guint32 context, guint32 *exception_gchandle);
 void *          xamarin_generate_conversion_to_managed (id value, MonoType *inputType, MonoType *outputType, MonoMethod *method, guint32 *exception_gchandle, guint32 context, /*SList*/ void **free_list);
-NSNumber *      xamarin_convert_managed_to_nsnumber (MonoObject *value, MonoType *managedType, MonoType *nativeType, MonoMethod *method, guint32 *exception_gchandle);
-NSValue *       xamarin_convert_managed_to_nsvalue (MonoObject *value, MonoType *managedType, MonoType *nativeType, MonoMethod *method, guint32 *exception_gchandle);
+NSNumber *      xamarin_convert_managed_to_nsnumber (MonoObject *value, MonoClass *managedType, MonoMethod *method, guint32 context, guint32 *exception_gchandle);
+NSValue *       xamarin_convert_managed_to_nsvalue (MonoObject *value, MonoClass *managedType, MonoMethod *method, guint32 context, guint32 *exception_gchandle);
 NSString *      xamarin_convert_managed_to_nsstring (MonoObject *value, MonoType *managedType, MonoType *nativeType, MonoMethod *method, guint32 *exception_gchandle);
 MonoObject *    xamarin_convert_nsnumber_to_managed (NSNumber *value, MonoType *nativeType, MonoType *managedType, MonoMethod *method, guint32 *exception_gchandle);
 MonoObject *    xamarin_convert_nsvalue_to_managed (NSValue *value, MonoType *nativeType, MonoType *managedType, MonoMethod *method, guint32 *exception_gchandle);
@@ -103,6 +103,9 @@ xamarin_managed_to_id_func xamarin_get_smart_enum_to_nsstring_func (MonoClass *m
 
 NSArray *   xamarin_convert_managed_to_nsarray_with_func (MonoArray *array, xamarin_managed_to_id_func convert, guint32 context, guint32 *exception_gchandle);
 MonoArray * xamarin_convert_nsarray_to_managed_with_func (NSArray *array, MonoClass *managedElementType, xamarin_id_to_managed_func convert, guint32 context, guint32 *exception_gchandle);
+
+void * xamarin_nsstring_to_smart_enum (id value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
+void * xamarin_smart_enum_to_nsstring (MonoObject *value, guint32 context /* token ref */, guint32 *exception_gchandle);
 
 // Returns a pointer to the value type, which must be freed using xamarin_free.
 void *xamarin_nsnumber_to_bool   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -473,6 +473,24 @@ namespace Xamarin.Tests
 			}
 		}
 
+		public static string GetSdkPath (Profile profile, bool is_device)
+		{
+			switch (profile) {
+			case Profile.iOS:
+				return Path.Combine (MonoTouchRootDirectory, "SDKs", "MonoTouch." + (is_device ? "iphoneos" : "iphonesimulator") + ".sdk");
+			case Profile.tvOS:
+				return Path.Combine (MonoTouchRootDirectory, "SDKs", "Xamarin.AppleTV" + (is_device ? "OS" : "Simulator") + ".sdk");
+			case Profile.watchOS:
+				return Path.Combine (MonoTouchRootDirectory, "SDKs", "Xamarin.Watch" + (is_device ? "OS" : "Simulator") + ".sdk");
+			case Profile.macOSFull:
+			case Profile.macOSMobile:
+			case Profile.macOSSystem:
+				return Path.Combine (SdkRootXM, "lib");
+			default:
+				throw new NotImplementedException (profile.ToString ());
+			}
+		}
+
 		public static string GetCompiler (Profile profile, StringBuilder args, bool use_csc = false)
 		{
 			args.Append (" -lib:").Append (Path.GetDirectoryName (GetBaseLibrary (profile))).Append (' ');

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -3856,8 +3856,8 @@ public class HandlerTest
 			var missingSimlauncherSymbols = new List<string> ();
 			foreach (var symbol in only_libxamarin) {
 				switch (symbol) {
-				case "_fix_ranlib_warning_about_no_symbols": // Dummy symbol to fix linker warning
-				case "_fix_ranlib_warning_about_no_symbols_v2": // Dummy symbol to fix linker warning
+				case "_xamarin_fix_ranlib_warning_about_no_symbols": // Dummy symbol to fix linker warning
+				case "_xamarin_fix_ranlib_warning_about_no_symbols_v2": // Dummy symbol to fix linker warning
 				case "_monotouch_IntPtr_objc_msgSendSuper_IntPtr": // Classic only, this function can probably be removed when we switch to binary copy of a Classic version of libxamarin.a
 				case "_monotouch_IntPtr_objc_msgSend_IntPtr": // Classic only, this function can probably be removed when we switch to binary copy of a Classic version of libxamarin.a
 				case "_xamarin_float_objc_msgSend": // Classic only, this function can probably be removed when we switch to binary copy of a Classic version of libxamarin.a

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -796,8 +796,25 @@ public class IntentHandler : INExtension, IINRidesharingDomainHandling {
 
 		public IEnumerable<string> NativeSymbolsInExecutable {
 			get { 
-				return ExecutionHelper.Execute ("nm", $"-gUj {StringUtils.Quote (NativeExecutablePath)}", hide_output: true).Split ('\n');
+				return GetNativeSymbolsInExecutable (NativeExecutablePath);
 			}
+		}
+
+		public static IEnumerable<string> GetNativeSymbolsInExecutable (string executable)
+		{
+			IEnumerable<string> rv = ExecutionHelper.Execute ("nm", $"-gUj {StringUtils.Quote (executable)}", hide_output: true).Split ('\n');
+
+			rv = rv.Where ((v) => {
+				if (string.IsNullOrEmpty (v))
+					return false;
+
+				if (v.StartsWith (executable, StringComparison.Ordinal) && v.EndsWith (":", StringComparison.Ordinal))
+					return false;
+
+				return true;
+			});
+
+			return rv;
 		}
 
 		protected override string ToolPath {

--- a/tests/mtouch/MiscTests.cs
+++ b/tests/mtouch/MiscTests.cs
@@ -84,7 +84,8 @@ namespace Xamarin.Tests
 		public void PublicSymbols (Profile profile)
 		{
 			var paths = new HashSet<string> ();
-			paths.UnionWith (Directory.GetFileSystemEntries (Configuration.GetSdkPath (profile, true), "*.a", SearchOption.AllDirectories));
+			if (Configuration.include_device)
+				paths.UnionWith (Directory.GetFileSystemEntries (Configuration.GetSdkPath (profile, true), "*.a", SearchOption.AllDirectories));
 			paths.UnionWith (Directory.GetFileSystemEntries (Configuration.GetSdkPath (profile, false), "*.a", SearchOption.AllDirectories));
 			var failed = new StringBuilder ();
 
@@ -114,6 +115,7 @@ namespace Xamarin.Tests
 				"___mono_jit_",
 				"_sdb_options",
 				"_SystemNative_",
+				"_MapHardwareType",
 				"_gateway_from_rtm",
 				"_sgen_",
 				"_arm_patch",

--- a/tools/mtouch/monotouch-fixes.c
+++ b/tools/mtouch/monotouch-fixes.c
@@ -31,12 +31,10 @@
 // we patch the system sigaction instead.
 //
 
-int my_sigaction (int signo, const struct sigaction *__restrict act, struct sigaction *__restrict oact);
-
 typedef int (*SigAction) (int sig, const struct sigaction *__restrict act, struct sigaction *__restrict oact);
-SigAction system_sigaction = sigaction;
+static SigAction system_sigaction = sigaction;
 
-int
+static int
 my_sigaction (int sig, const struct sigaction *__restrict act, struct sigaction *__restrict oact)
 {
 	//fprintf (stderr, "my_sigaction (%i, %p: handler = %p mask = %i flags = %i, %p)\n", sig, act, act ? act->sa_handler : NULL, act ? act->sa_mask : -1, act ? act->sa_flags : -1, oact);
@@ -69,7 +67,8 @@ static const interpose_t interposers[] __attribute__ ((unused)) \
 
 #elif defined(__x86_64__)
 
-void patch_sigaction ()
+static void
+patch_sigaction ()
 {
 	// Sanity check.
 	uint64_t * func = (uint64_t *) &sigaction;


### PR DESCRIPTION
Clean up public symbols, by:

* Symbols that don't need to be public (most of them), can be private.
* Prefix all public symbols with `xamarin_`.
* Add a test to ensure we don't introduce new public symbols.
* Use C symbols instead of mangled C++ symbols, since those are easier to
  handle in the test.

This minimizes the chance of getting into a symbol clash with another native library.

Fixes https://github.com/xamarin/xamarin-macios/issues/5124.