### PR TITLE
[tests] Use xibuild when building packaged XM tests. Fixes maccore#1169.

### DIFF
--- a/tests/package-mac-tests.sh
+++ b/tests/package-mac-tests.sh
@@ -25,7 +25,7 @@ export MSBuildExtensionsPathFallbackPathsOverride=$MAC_DESTDIR/Library/Framework
 
 make
 make .stamp-configure-projects-mac
-msbuild bindings-test/bindings-test-mac.csproj
+../tools/xibuild/xibuild -- bindings-test/bindings-test-mac.csproj
 make build-mac-dontlink build-mac-apitest build-mac-introspection build-mac-linksdk build-mac-linkall build-mac-xammac_tests build-mac-system-dontlink -j8
 
 for app in */bin/x86/*/*.app linker/mac/*/bin/x86/*/*.app introspection/Mac/bin/x86/*/*.app; do


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/1169.