### PR TITLE
Revert "Mono 5.16.0.87+ breaks us, so make sure we don't use it for now. (#5088)"

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -48,8 +48,7 @@ XCODE94_DEVELOPER_ROOT=/Applications/Xcode94.app/Contents/Developer
 
 # Minimum Mono version for building XI/XM
 MIN_MONO_VERSION=5.16.0.5
-# https://github.com/mono/mono/issues/11564: 5.16.0.87+ breaks us, so make sure we don't use it.
-MAX_MONO_VERSION=5.16.0.86
+MAX_MONO_VERSION=5.16.99
 MIN_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2018-06/7/7627a5f9eeba0fd846731ad0c498556f55be1a34/MonoFramework-MDK-5.16.0.5.macos10.xamarin.universal.pkg
 
 # Minimum Mono version for Xamarin.Mac apps using the system mono


### PR DESCRIPTION
This reverts commit 1ca7da537da1e81d56bcdeb215c63e16d2a08bdc.

This is fixed so the restriction is not needed anymore.