### PR TITLE
[tests][intro] Fix CoreImage location check for older macOS versions

### DIFF
--- a/src/Constants.mac.cs.in
+++ b/src/Constants.mac.cs.in
@@ -62,8 +62,8 @@ namespace MonoMac {
 		public const string CoreMediaLibrary = "/System/Library/Frameworks/CoreMedia.framework/CoreMedia";
 		public const string ScriptingBridgeLibrary = "/System/Library/Frameworks/ScriptingBridge.framework/ScriptingBridge";
 		public const string CoreDataLibrary = "/System/Library/Frameworks/CoreData.framework/CoreData";
-		public const string CoreImageLibrary = "/System/Library/Frameworks/CoreImage.framework/Versions/Current/CoreImage";
-		public const string CFNetworkLibrary = "/System/Library/Frameworks//CFNetwork.framework/CFNetwork";
+		public const string CoreImageLibrary = "/System/Library/Frameworks/QuartzCore.framework/Versions/A/Frameworks/CoreImage.framework/CoreImage";
+		public const string CFNetworkLibrary = "/System/Library/Frameworks/CFNetwork.framework/CFNetwork";
 		public const string CoreMidiLibrary = "/System/Library/Frameworks/CoreMIDI.framework/CoreMIDI";
 		public const string QuickLookLibrary = "/System/Library/Frameworks/QuickLook.framework/QuickLook";
 		public const string AVFoundationLibrary = "/System/Library/Frameworks/AVFoundation.framework/AVFoundation";

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -1042,8 +1042,11 @@ namespace Introspection
 #if MONOMAC
 			// on macOS the file should exist on the specified path
 			// for iOS the simulator paths do not match the strings
-			if (!File.Exists (lib))
-				return false;
+			if (!File.Exists (lib)) {
+				if (lib != Constants.CoreImageLibrary)
+					return false;
+				// location changed in 10.11 but it loads fine (and fixing it breaks on earlier macOS)
+			}
 #endif
 			var h = IntPtr.Zero;
 			try {


### PR DESCRIPTION
addendum to https://github.com/xamarin/xamarin-macios/pull/5159

failure on internal bots https://github.com/xamarin/xamarin-macios/commit/4f1c39a00fda2d7bbbe0fb6ed3b39261005f33f1#commitcomment-31401007