### PR TITLE
[macos] Fix Constants.mac.cs.in for backward compatibility

### DIFF
--- a/src/Constants.mac.cs.in
+++ b/src/Constants.mac.cs.in
@@ -63,13 +63,13 @@ namespace MonoMac {
 		public const string ScriptingBridgeLibrary = "/System/Library/Frameworks/ScriptingBridge.framework/ScriptingBridge";
 		public const string CoreDataLibrary = "/System/Library/Frameworks/CoreData.framework/CoreData";
 		public const string CoreImageLibrary = "/System/Library/Frameworks/QuartzCore.framework/Versions/A/Frameworks/CoreImage.framework/CoreImage";
-		public const string CFNetworkLibrary = "/System/Library/Frameworks/CFNetwork.framework/CFNetwork";
+		public const string CFNetworkLibrary = "/System/Library/Frameworks/CoreServices.framework/Frameworks/CFNetwork.framework/CFNetwork";
 		public const string CoreMidiLibrary = "/System/Library/Frameworks/CoreMIDI.framework/CoreMIDI";
 		public const string QuickLookLibrary = "/System/Library/Frameworks/QuickLook.framework/QuickLook";
 		public const string AVFoundationLibrary = "/System/Library/Frameworks/AVFoundation.framework/AVFoundation";
 		public const string AccelerateImageLibrary = "/System/Library/Frameworks/Accelerate.framework/Frameworks/vImage.framework/vImage";
 
-		public const string CoreBluetoothLibrary = "/System/Library/Frameworks//CoreBluetooth.framework/CoreBluetooth";
+		public const string CoreBluetoothLibrary = "/System/Library/Frameworks/IOBluetooth.framework/Versions/A/Frameworks/CoreBluetooth.framework/CoreBluetooth";
 		public const string GameKitLibrary = "/System/Library/Frameworks/GameKit.framework/GameKit";
 		public const string SceneKitLibrary = "/System/Library/Frameworks/SceneKit.framework/SceneKit";
 		public const string StoreKitLibrary = "/System/Library/Frameworks/StoreKit.framework/StoreKit";

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -1042,10 +1042,18 @@ namespace Introspection
 #if MONOMAC
 			// on macOS the file should exist on the specified path
 			// for iOS the simulator paths do not match the strings
-			if (!File.Exists (lib)) {
-				if (lib != Constants.CoreImageLibrary)
+			switch (lib) {
+			// location changed in 10.8 but it loads fine (and fixing it breaks on earlier macOS)
+			case Constants.CFNetworkLibrary:
+			// location changed in 10.10 but it loads fine (and fixing it breaks on earlier macOS)
+			case Constants.CoreBluetoothLibrary:
+			// location changed in 10.11 but it loads fine (and fixing it breaks on earlier macOS)
+			case Constants.CoreImageLibrary:
+				break;
+			default:
+				if (!File.Exists (lib))
 					return false;
-				// location changed in 10.11 but it loads fine (and fixing it breaks on earlier macOS)
+				break;
 			}
 #endif
 			var h = IntPtr.Zero;


### PR DESCRIPTION
On macOS the path changes are forward but not backward compatible.

This means we need to keep older values, as they will work on newer OS,
while the new path won't work (on older OS).

The test are updated to add exceptions for such cases - in order to
give us a better chance to spot typos (since they were some).

This should fix
https://github.com/xamarin/maccore/issues/1174
https://github.com/xamarin/maccore/issues/1175
https://github.com/xamarin/maccore/issues/1176
https://github.com/xamarin/maccore/issues/1177