### PR TITLE
[runtime] Disable debugging by default for watchOS apps on device.

### DIFF
--- a/runtime/monotouch-debug.m
+++ b/runtime/monotouch-debug.m
@@ -65,7 +65,12 @@ static bool debugging_configured = false;
 static bool profiler_configured = false;
 static bool config_timedout = false;
 static bool connection_failed = false;
+#if TARGET_OS_WATCH && !TARGET_OS_SIMULATOR
+// For watchOS default to something that doesn't produce error messages when launching without an IDE (since only http works).
+static DebuggingMode debugging_mode = DebuggingModeNone;
+#else
 static DebuggingMode debugging_mode = DebuggingModeWifi;
+#endif
 static const char *connection_mode = "default"; // this is set from the cmd line, can be either 'usb', 'wifi', 'http' or 'none'
 
 extern "C" {


### PR DESCRIPTION
The previous default (Wifi) would never work; only Http mode works on watchOS
devices. This means that unless debugging was explicitly disabled (for
instance when running without debugging from the IDE), we'd try to connect in
WiFi mode (and gracefully fail, but showing error messages that are
unnecessary and potentally scary/confusing).