### PR TITLE
[mmp] Set DEVELOPER_DIR to our Xcode.

### DIFF
--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -1,6 +1,8 @@
 TOP=../..
 include $(TOP)/Make.config
 
+export DEVELOPER_DIR=$(XCODE_DEVELOPER_ROOT)
+
 #
 # mmp
 #


### PR DESCRIPTION
This makes it possible to build mmp (the partial static registrar code) with
the wrong system Xcode (which is not supported, but that doesn't mean we can't
try to make it mostly work to ease our lives).

I tried this in the xcode9 branch (PR #2588), and it didn't stick after the
xcode9 branch was merged to master.

I tried again a year later with the xcode10 branch (PR #4691), and once again
the commit didn't stick after the xcode10 branch was merged to master.

So now I'm trying to get this directly into master instead.

Let's see if it's still there when we branch for xcode11 next year...