### PR TITLE
Bump mono to head of 2018-06

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -48,8 +48,7 @@ XCODE94_DEVELOPER_ROOT=/Applications/Xcode94.app/Contents/Developer
 
 # Minimum Mono version for building XI/XM
 MIN_MONO_VERSION=5.16.0.5
-# https://github.com/mono/mono/issues/11564: 5.16.0.87+ breaks us, so make sure we don't use it.
-MAX_MONO_VERSION=5.16.0.86
+MAX_MONO_VERSION=5.16.99
 MIN_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2018-06/7/7627a5f9eeba0fd846731ad0c498556f55be1a34/MonoFramework-MDK-5.16.0.5.macos10.xamarin.universal.pkg
 
 # Minimum Mono version for Xamarin.Mac apps using the system mono


### PR DESCRIPTION
Commit list for mono/mono:

* mono/mono@7aadce3fad0 [mini] use AOT trampolines in interp mixed mode (#11767) (#11784)
* mono/mono@4bc42a87678 [interp] Don't throw exception on -1 division (#11777)
* mono/mono@b63e5378e38 [2018-06][ios] fix path for llvm invocation (#11737)
* mono/mono@bb3ae37d71a [interp] attempt to intrinsify again after a method is resolved regarding generics (#11715)
* mono/mono@78eb5303e85 [2018-06] [aot] image is usable without debug flag when interpreter is used (#11711)
* mono/mono@54cc205dd93 [2018-06] [crash] Remove duplicated il_offset (#11703)
* mono/mono@279ac406e74 [2018-06] [runtime] Fix the size calculation in mono_debug_add_method (). (#11686)
* mono/mono@1ac52d18274 [2018-06] [llvm] bump for armhf callingconv fix (#11610)
* mono/mono@eee1d634e8b [ios] remove DISABLE_POLICY_EVIDENCE (#11580)

Diff:
https://github.com/mono/mono/compare/4d7b7ab37517a13eee8b966cec9c4308ad772c0a...7aadce3fad0dd1d501e166e2dead67401d6e881b

* Revert "Mono 5.16.0.87+ breaks us, so make sure we don't use it for now. (#5088)" (#5175)

    This reverts commit 1ca7da537da1e81d56bcdeb215c63e16d2a08bdc.
    This is fixed so the restriction is not needed anymore.