### PR TITLE
[registrar] Validate input to 'Adopts' attribute

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -2350,6 +2350,10 @@ complicated to get it right when doing it manually.
 
 If this is not the case, please file a [bug report](https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
 
+### MT4177: The 'ProtocolType' parameter of the 'Adopts' attribute used in class '*' contains an invalid character. Value used: '*' Invalid Char: '*'.
+
+The name of an Objective-C protocol can't contain certain characters which means that the `Adopts` attribute on the corresponding managed class can't have the `ProtocolType` parameter containing them. Please refer to the provided error message and fix accordingly.
+
 # MT5xxx: GCC and toolchain error messages
 
 ### MT51xx: Compilation


### PR DESCRIPTION
Fixes xamarin/xamarin-macios#4107

We currently generate invalid registrar code when we get invalid input
in 'Adopts' attribute, this can happen because 'Adopts' can take a
plain string. We now generate a better error MT4177 instead of
generating invalid registrar.m/h code.

This might seem like a "breaking change" because it "errors out" a build
but since we generated bad `registrar.m/h` there is no way this is shipping
out there.