### PR TITLE
[runtime] Unconditionally write the generated bindings.

### DIFF
--- a/runtime/bindings-generator.cs
+++ b/runtime/bindings-generator.cs
@@ -66,8 +66,7 @@ namespace Xamarin.BindingMethods.Generator
 				writer.WriteLine ();
 
 				var generated_data = writer.ToString ();
-				if (!File.Exists (fn) || File.ReadAllText (fn) != generated_data)
-					File.WriteAllText (fn, generated_data);
+				File.WriteAllText (fn, generated_data);
 
 				return 0;
 			}


### PR DESCRIPTION
Otherwise we can run into cases where make things it needs to generate the
bindings, but they're identical to the previous bindings, thus nothing is
written to disk, the filestamp doesn't change, and at the next build make
continues to believe that the bindings have to be regenerated:

    $ make
    GEN      bindings-generated.m
    $ make
    GEN      bindings-generated.m
    [ad infinitum]