### PR TITLE
[xharness] Don't recursively print diagnostics for processes when printing diagnostics times out in the first place. Fixes maccore#1163.

### DIFF
--- a/tests/xharness/Process_Extensions.cs
+++ b/tests/xharness/Process_Extensions.cs
@@ -56,17 +56,17 @@ namespace xharness
 
 	public static class Process_Extensions
 	{
-		public static async Task<ProcessExecutionResult> RunAsync (this Process process, Log log, CancellationToken? cancellation_token = null)
+		public static async Task<ProcessExecutionResult> RunAsync (this Process process, Log log, CancellationToken? cancellation_token = null, bool? diagnostics = null)
 		{
-			return await RunAsync (process, log, log, log, cancellation_token: cancellation_token);
+			return await RunAsync (process, log, log, log, cancellation_token: cancellation_token, diagnostics: diagnostics);
 		}
 
-		public static Task<ProcessExecutionResult> RunAsync (this Process process, Log log, bool append = true, TimeSpan? timeout = null, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null)
+		public static Task<ProcessExecutionResult> RunAsync (this Process process, Log log, bool append = true, TimeSpan? timeout = null, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null, bool? diagnostics = null)
 		{
-			return RunAsync (process, log, log, log, timeout, environment_variables, cancellation_token);
+			return RunAsync (process, log, log, log, timeout, environment_variables, cancellation_token, diagnostics);
 		}
 
-		public static async Task<ProcessExecutionResult> RunAsync (this Process process, Log log, TextWriter StdoutStream, TextWriter StderrStream, TimeSpan? timeout = null, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null)
+		public static async Task<ProcessExecutionResult> RunAsync (this Process process, Log log, TextWriter StdoutStream, TextWriter StderrStream, TimeSpan? timeout = null, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null, bool? diagnostics = null)
 		{
 			var stdout_completion = new TaskCompletionSource<bool> ();
 			var stderr_completion = new TaskCompletionSource<bool> ();
@@ -164,22 +164,22 @@ namespace xharness
 			return rv;
 		}
 
-		public static Task KillTreeAsync (this Process @this, Log log, bool diagnostics = true)
+		public static Task KillTreeAsync (this Process @this, Log log, bool? diagnostics = true)
 		{
 			return KillTreeAsync (@this.Id, log, diagnostics);
 		}
 
-		public static async Task KillTreeAsync (int pid, Log log, bool diagnostics = true)
+		public static async Task KillTreeAsync (int pid, Log log, bool? diagnostics = true)
 		{
 			var pids = new List<int> ();
 			GetChildrenPS (log, pids, pid);
-			if (diagnostics) {
+			if (diagnostics == true) {
 				log.WriteLine ($"Pids to kill: {string.Join (", ", pids.Select ((v) => v.ToString ()).ToArray ())}");
 				using (var ps = new Process ()) {
 					log.WriteLine ("Writing process list:");
 					ps.StartInfo.FileName = "ps";
 					ps.StartInfo.Arguments = "-A -o pid,ruser,ppid,pgid,%cpu=%CPU,%mem=%MEM,flags=FLAGS,lstart,rss,vsz,tty,state,time,command";
-					await ps.RunAsync (log, true, TimeSpan.FromSeconds (5));
+					await ps.RunAsync (log, true, TimeSpan.FromSeconds (5), diagnostics: false);
 				}
 
 				foreach (var diagnose_pid in pids) {
@@ -197,7 +197,7 @@ namespace xharness
 							File.WriteAllText (template, commands.ToString ());
 
 							log.WriteLine ($"Printing backtrace for pid={pid}");
-							await dbg.RunAsync (log, true, TimeSpan.FromSeconds (30));
+							await dbg.RunAsync (log, true, TimeSpan.FromSeconds (30), diagnostics: false);
 						}
 					} finally {
 						try {

--- a/tests/xharness/Process_Extensions.cs
+++ b/tests/xharness/Process_Extensions.cs
@@ -138,7 +138,7 @@ namespace xharness
 			{
 				if (timeout.HasValue) {
 					if (!process.WaitForExit ((int) timeout.Value.TotalMilliseconds)) {
-						process.KillTreeAsync (log, true).Wait ();
+						process.KillTreeAsync (log, diagnostics).Wait ();
 						rv.TimedOut = true;
 						lock (StderrStream)
 							log.WriteLine ($"Execution timed out after {timeout.Value.TotalSeconds} seconds and the process was killed.");

--- a/tests/xharness/Process_Extensions.cs
+++ b/tests/xharness/Process_Extensions.cs
@@ -138,7 +138,7 @@ namespace xharness
 			{
 				if (timeout.HasValue) {
 					if (!process.WaitForExit ((int) timeout.Value.TotalMilliseconds)) {
-						process.KillTreeAsync (log, diagnostics).Wait ();
+						process.KillTreeAsync (log, diagnostics ?? true).Wait ();
 						rv.TimedOut = true;
 						lock (StderrStream)
 							log.WriteLine ($"Execution timed out after {timeout.Value.TotalSeconds} seconds and the process was killed.");


### PR DESCRIPTION
Recursively printing diagnostics can leave us with _many_ lldb processes, each
pretty much hanging, and the system overloaded, which, in the worst case
scenario, would require a hard reboot.

Most commonly the "only" thing that happens is an OutOfMemoryException when
the OS eventually tells xharness NO to launching new processes.

Fixes https://github.com/xamarin/maccore/issues/1163.