### PR TITLE
[jenkins] If provisioning an old mono fails with error 56, try again a few more times. Fixes maccore#1098.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -319,13 +319,7 @@ def runXamarinMacTests (url, macOS, maccore_hash, xamarin_macios_hash)
             def t = "dontlink (system)"
             try {
                 // install oldest supported mono
-                sh ('''
-                    cd mac-test-package
-                    URL=`grep "^MIN_XM_MONO_URL=" Make.config | sed 's/.*=//'`
-                    curl -L "$URL" --output old-mono.pkg
-                    sudo installer -pkg old-mono.pkg -target /
-                    mono --version
-                    ''')
+                sh ("./prepare-packaged-macos-tests.sh --install-old-mono")
                 // run dontlink tests using the system mono
                 sh ("make -C mac-test-package/tests exec-mac-system-dontlink")
             } catch (error) {


### PR DESCRIPTION
It seems curl can randomly fail with error 56, so if that happens, try again a
few more times before giving up.

Fixes https://github.com/xamarin/maccore/issues/1098.