### PR TITLE
[xharness] Fix retry-download-on-error-56 logic to actually work.

### DIFF
--- a/jenkins/prepare-packaged-macos-tests.sh
+++ b/jenkins/prepare-packaged-macos-tests.sh
@@ -7,9 +7,9 @@ if [[ "$1" == "--install-old-mono" ]]; then
     URL=$(grep "^MIN_XM_MONO_URL=" Make.config | sed 's/.*=//')
 
     COUNTER=0
-    EC=0
     echo "Downloading and installing $URL"
     while [[ $COUNTER -lt 5 ]]; do
+		EC=0
 		curl -s -L "$URL" --output old-mono.pkg || EC=$?
 		if [[ $EC -eq 56 ]]; then
 			# Sometimes we get spurious "curl: (56) SSLRead() return error -9806" errors. Trying again usually works, so lets try again a few more times.
@@ -58,8 +58,8 @@ unzip -o mac-test-package.zip
 cd mac-test-package
 
 COUNTER=0
-EC=0
 while [[ $COUNTER -lt 5 ]]; do
+	EC=0
 	./system-dependencies.sh --provision-mono --ignore-autotools --ignore-xamarin-studio --ignore-xcode --ignore-osx --ignore-cmake || EC=$?
 	if [[ $EC -eq 56 ]]; then
 		# Sometimes we get spurious "curl: (56) SSLRead() return error -9806" errors. Trying again usually works, so lets try again a few more times.


### PR DESCRIPTION
Fix retry-download-on-error-56 logic to not fail forever if the first time
failed by resetting the EC variable after each try.

Fixes https://github.com/xamarin/maccore/issues/1098 (third time's the charm!)