### PR TITLE
[monotouch-test] Tweak DnsFailure a bit.

### DIFF
--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -59,7 +59,6 @@ namespace MonoTests.System.Net.Http
 					HttpClient client = new HttpClient (GetHandler (handlerType));
 					var s = await client.GetStringAsync ("http://doesnotexist.xamarin.com");
 					Console.WriteLine (s);
-					Assert.Fail ($"An exception should have been thrown, instead got:\n{s}");
 				} catch (Exception e) {
 					ex = e;
 				} finally {
@@ -67,6 +66,7 @@ namespace MonoTests.System.Net.Http
 				}
 			}, () => done);
 
+			Assert.IsTrue (done, "Did not time out");
 			Assert.IsNotNull (ex, "Exception");
 			// The handlers throw different types of exceptions, so we can't assert much more than that something went wrong.			
 		}


### PR DESCRIPTION
* Make it clearer when a timeout happens that a timeout happened by asserting
  exactly that.
* Don't assert after getting the (unexpected) result from the network request,
  since asserting will throw an exception, which will be caught and stored,
  and then later in the test we assert that an exception was thrown. So
  asserting just after a successful network request effectively hides any
  failures, since we're now passing because of the assertion exception. Ops.