### PR TITLE
[xibuild] Auto-make if not already made.

### DIFF
--- a/tools/xibuild/xibuild
+++ b/tools/xibuild/xibuild
@@ -1,5 +1,10 @@
-#!/bin/sh
-ABSOLUTE_PATH=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)/`basename "${BASH_SOURCE[0]}"`
-TOOL_DIR=`dirname $ABSOLUTE_PATH`
+#!/bin/bash -e
 
-mono $TOOL_DIR/bin/Debug/xibuild.exe "$@"
+ABSOLUTE_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")
+TOOL_DIR=$(dirname "$ABSOLUTE_PATH")
+
+if ! test -f "$TOOL_DIR/bin/Debug/xibuild.exe"; then
+	make
+fi
+
+mono "$TOOL_DIR/bin/Debug/xibuild.exe" "$@"

--- a/tools/xibuild/xibuild
+++ b/tools/xibuild/xibuild
@@ -4,7 +4,7 @@ ABSOLUTE_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_S
 TOOL_DIR=$(dirname "$ABSOLUTE_PATH")
 
 if ! test -f "$TOOL_DIR/bin/Debug/xibuild.exe"; then
-	make
+	make -C "$TOOL_DIR"
 fi
 
 mono "$TOOL_DIR/bin/Debug/xibuild.exe" "$@"


### PR DESCRIPTION
Automatically make xibuild if it doesn't already exist.

Also fix the script:

* Use bash instead of sh, since it references BASH_SOURCE.
* Don't hide errors (-e).
* Fix shellcheck warnings
	* Use $(..) instead of backticks, because backticks are strongly discouraged [1].
	* Sprinkle quotes.

[1] For the curious: https://stackoverflow.com/a/4708569/183422