### PR TITLE
[xibuild] Don't redirect standard input.

### DIFF
--- a/tools/xibuild/Main.cs
+++ b/tools/xibuild/Main.cs
@@ -112,7 +112,6 @@ namespace xibuild {
 				FileName = toolPath,
 				Arguments = combinedArgs,
 				UseShellExecute = false,
-				RedirectStandardInput = true,
 			});
 
 			p.WaitForExit ();


### PR DESCRIPTION
It's not needed, and it prevents subprocesses from detecting a terminal (and
thus no colors in the output).