### PR TITLE
[interp] fix mixed mode in Release configuration

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -197,14 +197,17 @@ namespace xharness
 					yield return new TestData { Variation = "Debug (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = true, Profiling = false, Defines = "OPTIMIZEALL" };
 					yield return new TestData { Variation = "Debug (interpreter)", MTouchExtraArgs = "--interpreter", Debug = true, Profiling = false, };
 					yield return new TestData { Variation = "Debug (interpreter -mscorlib)", MTouchExtraArgs = "--interpreter=-mscorlib", Debug = true, Profiling = false, };
+					yield return new TestData { Variation = "Release (interpreter -mscorlib)", MTouchExtraArgs = "--interpreter=-mscorlib", Debug = false, Profiling = false, };
 					break;
 				case "mscorlib":
 					yield return new TestData { Variation = "Debug (interpreter)", MTouchExtraArgs = "--interpreter", Debug = true, Profiling = false, Undefines = "FULL_AOT_RUNTIME" };
 					yield return new TestData { Variation = "Debug (interpreter -mscorlib)", MTouchExtraArgs = "--interpreter=-mscorlib", Debug = true, Profiling = false, Ignored = true, Undefines = "FULL_AOT_RUNTIME" };
+					yield return new TestData { Variation = "Release (interpreter -mscorlib)", MTouchExtraArgs = "--interpreter=-mscorlib", Debug = false, Profiling = false, Undefines = "FULL_AOT_RUNTIME" };
 					break;
 				case "mini":
 					yield return new TestData { Variation = "Debug (interpreter)", MTouchExtraArgs = "--interpreter", Debug = true, Profiling = false, Undefines = "FULL_AOT_RUNTIME" };
 					yield return new TestData { Variation = "Debug (interpreter -mscorlib)", MTouchExtraArgs = "--interpreter=-mscorlib", Debug = true, Profiling = false, Undefines = "FULL_AOT_RUNTIME" };
+					yield return new TestData { Variation = "Release (interpreter -mscorlib)", MTouchExtraArgs = "--interpreter=-mscorlib", Debug = false , Profiling = false, Undefines = "FULL_AOT_RUNTIME" };
 					break;
 				}
 				break;

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -201,7 +201,7 @@ namespace xharness
 					break;
 				case "mscorlib":
 					yield return new TestData { Variation = "Debug (interpreter)", MTouchExtraArgs = "--interpreter", Debug = true, Profiling = false, Undefines = "FULL_AOT_RUNTIME" };
-					yield return new TestData { Variation = "Debug (interpreter -mscorlib)", MTouchExtraArgs = "--interpreter=-mscorlib", Debug = true, Profiling = false, Ignored = true, Undefines = "FULL_AOT_RUNTIME" };
+					yield return new TestData { Variation = "Debug (interpreter -mscorlib)", MTouchExtraArgs = "--interpreter=-mscorlib", Debug = true, Profiling = false, Undefines = "FULL_AOT_RUNTIME" };
 					yield return new TestData { Variation = "Release (interpreter -mscorlib)", MTouchExtraArgs = "--interpreter=-mscorlib", Debug = false, Profiling = false, Undefines = "FULL_AOT_RUNTIME" };
 					break;
 				case "mini":

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -2175,7 +2175,13 @@ namespace Xamarin.Bundler {
 					return false;
 				if (PackageManagedDebugSymbols)
 					return false;
-				if (IsInterpreted (Assembly.GetIdentity (path)))
+				/* FIXME: should be `if (IsInterpreted (Assembly.GetIdentity (path)))`.
+				 * The problem is that in mixed mode we can't do the transition
+				 * between "interp"->"aot'd methods using gsharedvt", so we
+				 * fall back to the interp and thus need the IL not to be
+				 * stripped out. Once Mono supports this, we can add back the
+				 * more precise check. */
+				if (UseInterpreter)
 					return false;
 				return true;
 			});

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -2180,7 +2180,8 @@ namespace Xamarin.Bundler {
 				 * between "interp"->"aot'd methods using gsharedvt", so we
 				 * fall back to the interp and thus need the IL not to be
 				 * stripped out. Once Mono supports this, we can add back the
-				 * more precise check. */
+				 * more precise check.
+				 * See https://github.com/mono/mono/issues/11942 */
 				if (UseInterpreter)
 					return false;
 				return true;


### PR DESCRIPTION
Depends on ~~https://github.com/xamarin/xamarin-macios/pull/5229~~ https://github.com/xamarin/xamarin-macios/pull/5241

* Enable mscorlib mixed mode testing
* Enable Release configuration mixed mode testing
* Do not strip assemblies when Interpreter is used (applies to Release configuration as well).

Longer story: I played around with gMusic. While it worked fine in the Debug configuration with `--interpreter=-mscorlib`, it didn't in the Release configuration. The symptoms were weird, the crashes looked like memory corruptions, but _very_ deterministic. Since Release uses LLVM, I suspected some problems with mixed mode (which shouldn't be the case _in theory_, since the interface regarding mixed mode should be the same as our regular FullAOT backend). I added a test profile to mono so I can reproduce it on Desktop https://github.com/mono/mono/pull/11847 But no luck, either on amd64/macOS and arm64/linux, both were fine. I circled back to Xamarin.iOS and added more debugging and noticed that some methods from `mscorlib.dll` were still executed in the interpreter, for example
```
System.Collections.Generic.Dictionary`2<System.Type, Registrar.Registrar/ObjCType>:TryGetValue
```
runs in the interpreter. This is expected, because mixed mode doesn't support the transition from interpreter to gsharedvt compiled AOT methods (yet: https://github.com/mono/mono/issues/11942). So I considered this fine and looked in other areas for a while, after coming back to it and adding _more_ debugging where I realized that those methods executing weird code. In fact, they only execute a `ret` instruction and that's it. WTF? 🙂 Turned out, in Release configuration `mono-cil-strip` is performed on assemblies that are AOT compiled and replaces the method body with a `ret` instruction. I wish it would replace it with something that crashes, but now I know 😄 