### PR TITLE
Remove unnecessary references to Mono.Security.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -91,7 +91,6 @@ $(IOS_BUILD_DIR)/AssemblyInfo.cs: $(TOP)/src/AssemblyInfo.cs.in
 $(IOS_BUILD_DIR)/native/core.dll: $(IOS_CORE_SOURCES) frameworks.sources
 	$(Q) mkdir -p $(IOS_BUILD_DIR)native
 	$(call Q_PROF_CSC,ios) $(IOS_CSC) -nologo -out:$@ -target:library -debug -unsafe \
-		-r:$(IOS_LIBDIR)/Mono.Security.dll \
 		-nowarn:219,618,114,414,1635,3021,$(IOS_WARNINGS_THAT_YOU_SHOULD_FIX) \
 		-define:COREBUILD $(IOS_DEFINES) \
 		$(IOS_native_DEFINES) \
@@ -126,7 +125,6 @@ $(IOS_BUILD_DIR)/native-$(1)%Xamarin.iOS.dll $(IOS_BUILD_DIR)/native-$(1)%Xamari
 	@mkdir -p $(IOS_BUILD_DIR)/native-$(1)
 	$$(call Q_PROF_CSC,ios/$(1) bit) $$(IOS_CSC) -nologo -out:$$@ -target:library -debug -unsafe -optimize \
 		-deterministic \
-		-r:$(IOS_LIBDIR)/Mono.Security.dll \
 		$$(ARGS_$(1)) \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) $$(IOS_DEFINES) \
 		$$(IOS_native_DEFINES) \
@@ -480,7 +478,6 @@ $(MAC_BUILD_DIR)/$(1)/$(2): $(MAC_BUILD_DIR)/$(3)/generated-sources $(MAC_SOURCE
 		$$(MAC_$(3)_CSC) -nologo -out:$$@ -target:library -debug -unsafe \
 		-deterministic \
 		$$(MAC_COMMON_DEFINES),OBJECT_REF_TRACKING \
-		-r:Mono.Security.dll \
 		$$(MAC_$(3)_ARGS) \
 		$$(ARGS_$(6)) \
 		-publicsign -keyfile:$(SN_KEY) \
@@ -955,7 +952,6 @@ $(TVOS_BUILD_DIR)/tvos-64/Xamarin.TVOS%dll $(TVOS_BUILD_DIR)/tvos-64/Xamarin.TVO
 	$(call Q_PROF_CSC,tvos) $(TV_CSC) -nologo -out:$(basename $@).dll -target:library -debug -unsafe -optimize \
 		-publicsign -keyfile:$(PRODUCT_KEY_PATH) $(TVOS_DEFINES) \
 		-deterministic \
-		-r:$(TVOS_LIBDIR)/Mono.Security.dll \
 		$(ARGS_64) \
 		-nowarn:219,618,114,414,1635,3021,$(IOS_WARNINGS_THAT_YOU_SHOULD_FIX) \
 		$(TVOS_SOURCES) @$(TVOS_BUILD_DIR)/tvos/generated_sources

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -22,12 +22,6 @@ using Registrar;
 using AppKit;
 #endif
 
-#if !COREBUILD && (XAMARIN_APPLETLS || XAMARIN_NO_TLS)
-#if !MMP && !MTOUCH && !MTOUCH_TEST
-using Mono.Security.Interface;
-#endif
-#endif
-
 namespace ObjCRuntime {
 	
 	public partial class Runtime {

--- a/src/ObjCRuntime/RuntimeOptions.cs
+++ b/src/ObjCRuntime/RuntimeOptions.cs
@@ -20,12 +20,6 @@ using MonoTouch.Foundation;
 using MonoTouch.ObjCRuntime;
 #endif
 
-#if !COREBUILD && (XAMARIN_APPLETLS || XAMARIN_NO_TLS)
-#if !MTOUCH && !MMP && !MMP_TEST
-using Mono.Security.Interface;
-#endif
-#endif
-
 #if MMP || MMP_TEST || MTOUCH
 namespace Xamarin.Bundler {
 #elif SYSTEM_NET_HTTP

--- a/src/xammac.tmpl.csproj
+++ b/src/xammac.tmpl.csproj
@@ -40,7 +40,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Mono.Security" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="build\mac\mobile\**\*.cs">


### PR DESCRIPTION
Looks like the Mono.Security is no longer necessary. I checked my local Xamarin.Mac builds, but let's run it through the CI since there's a high chance I missed something obvious.