### PR TITLE
[Foundation] Make sure we use the cookies from the cookie storage. Fixes #5148

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -78,11 +78,13 @@ namespace Foundation {
 		// returns the header for a cookie
 		public static string GetHeaderValue (this NSHttpCookie cookie)
 		{
-			StringBuilder header = new StringBuilder();
-			bool first = true;
+			var header = new StringBuilder();
+			var first = true;
 			first = AppendSegment (header, first, cookie.Name, cookie.Value);
 			first = AppendSegment (header, first, NSHttpCookie.KeyPath.ToString (), cookie.Path.ToString ());
 			first = AppendSegment (header, first, NSHttpCookie.KeyDomain.ToString (), cookie.Domain.ToString ());
+			first = AppendSegment (header, first, NSHttpCookie.KeyVersion.ToString (), cookie.Version.ToString ());
+
 			if (cookie.Comment != null)
 				first = AppendSegment (header, first, NSHttpCookie.KeyComment.ToString (), cookie.Comment.ToString());
 

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -74,7 +74,6 @@ namespace Foundation {
 		public static string GetHeaderValue (this NSHttpCookie cookie)
 		{
 			var header = new StringBuilder();
-			var first = true;
 			AppendSegment (header, cookie.Name, cookie.Value);
 			AppendSegment (header, NSHttpCookie.KeyPath.ToString (), cookie.Path.ToString ());
 			AppendSegment (header, NSHttpCookie.KeyDomain.ToString (), cookie.Domain.ToString ());
@@ -330,13 +329,10 @@ namespace Foundation {
 						httpResponse.Content.Headers.TryAddWithoutValidation (v.Key.ToString (), v.Value.ToString ());
 					}
 
-					// the cookie storage knows about more cookies than the response, some of them are stored per session. In order
-					// to get all of them, we need to use the task.
-					session.Configuration.HttpCookieStorage.GetCookiesForTask (dataTask, (cookies) => {
-						for (var index = 0; index < cookies.Length; index++) {
-							httpResponse.Headers.TryAddWithoutValidation (SetCookie, cookies [index].GetHeaderValue ());
-						}
-					});
+					var cookies = session.Configuration.HttpCookieStorage.CookiesForUrl (response.Url);
+					for (var index = 0; index < cookies.Length; index++) {
+						httpResponse.Headers.TryAddWithoutValidation (SetCookie, cookies [index].GetHeaderValue ());
+					}
 
 					inflight.Response = httpResponse;
 

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -66,10 +66,8 @@ namespace Foundation {
 				builder.Append ("; ");
 
 			builder.Append (name);
-			if (value != null) {
-				builder.Append("=");
-				builder.Append(value);
-			}
+			if (value != null)
+				builder.Append ("=").Append (value);
 		}
 
 		// returns the header for a cookie

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -63,17 +63,12 @@ namespace Foundation {
 		private static bool AppendSegment(StringBuilder builder, bool first, string name, string value)
 		{
 			if (first)
-			{
 				first = false;
-			}
 			else
-			{
 				builder.Append("; ");
-			}
 
 			builder.Append(name);
-			if (value != null)
-			{
+			if (value != null) {
 				builder.Append("=");
 				builder.Append(value);
 			}

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -60,19 +60,16 @@ namespace Foundation {
 	// useful extensions for the class in order to set it in a header
 	static class NSHttpCookieExtensions
 	{
-		private static bool AppendSegment(StringBuilder builder, bool first, string name, string value)
+		static void AppendSegment(StringBuilder builder, string name, string value)
 		{
-			if (first)
-				first = false;
-			else
-				builder.Append("; ");
+			if (builder.Length > 0)
+				builder.Append ("; ");
 
-			builder.Append(name);
+			builder.Append (name);
 			if (value != null) {
 				builder.Append("=");
 				builder.Append(value);
 			}
-			return first;
 		}
 
 		// returns the header for a cookie
@@ -80,38 +77,38 @@ namespace Foundation {
 		{
 			var header = new StringBuilder();
 			var first = true;
-			first = AppendSegment (header, first, cookie.Name, cookie.Value);
-			first = AppendSegment (header, first, NSHttpCookie.KeyPath.ToString (), cookie.Path.ToString ());
-			first = AppendSegment (header, first, NSHttpCookie.KeyDomain.ToString (), cookie.Domain.ToString ());
-			first = AppendSegment (header, first, NSHttpCookie.KeyVersion.ToString (), cookie.Version.ToString ());
+			AppendSegment (header, cookie.Name, cookie.Value);
+			AppendSegment (header, NSHttpCookie.KeyPath.ToString (), cookie.Path.ToString ());
+			AppendSegment (header, NSHttpCookie.KeyDomain.ToString (), cookie.Domain.ToString ());
+			AppendSegment (header, NSHttpCookie.KeyVersion.ToString (), cookie.Version.ToString ());
 
 			if (cookie.Comment != null)
-				first = AppendSegment (header, first, NSHttpCookie.KeyComment.ToString (), cookie.Comment.ToString());
+				AppendSegment (header, NSHttpCookie.KeyComment.ToString (), cookie.Comment.ToString());
 
 			if (cookie.CommentUrl != null)
-				first = AppendSegment (header, first, NSHttpCookie.KeyCommentUrl.ToString (), cookie.CommentUrl.ToString());
+				AppendSegment (header, NSHttpCookie.KeyCommentUrl.ToString (), cookie.CommentUrl.ToString());
 
 			if (cookie.Properties.ContainsKey (NSHttpCookie.KeyDiscard))
-				first = AppendSegment (header, first, NSHttpCookie.KeyDiscard.ToString (), null);
+				AppendSegment (header, NSHttpCookie.KeyDiscard.ToString (), null);
 
 			if (cookie.ExpiresDate != null) {
 				// Format according to RFC1123; 'r' uses invariant info (DateTimeFormatInfo.InvariantInfo)
-				var dateStr = ((DateTime) cookie.ExpiresDate).ToUniversalTime().ToString("r", CultureInfo.InvariantCulture);
-				first = AppendSegment (header, first, NSHttpCookie.KeyExpires.ToString (), dateStr);
+				var dateStr = ((DateTime) cookie.ExpiresDate).ToUniversalTime ().ToString("r", CultureInfo.InvariantCulture);
+				AppendSegment (header, NSHttpCookie.KeyExpires.ToString (), dateStr);
 			}
 
 			if (cookie.Properties.ContainsKey (NSHttpCookie.KeyMaximumAge)) {
 				var timeStampString = (NSString) cookie.Properties[NSHttpCookie.KeyMaximumAge];
-				first = AppendSegment (header, first, NSHttpCookie.KeyMaximumAge.ToString (), timeStampString );
+				AppendSegment (header, NSHttpCookie.KeyMaximumAge.ToString (), timeStampString);
 			}
 
 			if (cookie.IsSecure)
-				first = AppendSegment (header, first, NSHttpCookie.KeySecure.ToString(), null);
+				AppendSegment (header, NSHttpCookie.KeySecure.ToString(), null);
 
 			if (cookie.IsHttpOnly)
-				first = AppendSegment (header, first, "httponly", null); // Apple does not show the key for the httponly
+				AppendSegment (header, "httponly", null); // Apple does not show the key for the httponly
 
-			return header.ToString();
+			return header.ToString ();
 		}
 	}
 

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -106,6 +106,7 @@ namespace MonoTests.System.Net.Http
 			}, () => areEqual);
 
 			Assert.IsTrue (areEqual, $"Cookies are different - Managed {manageCount} vs Native {nativeCount}");
+			Assert.IsNull (ex, "Exception");
 		}
 #endif
 

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -71,4 +71,43 @@ namespace MonoTests.System.Net.Http
 			// The handlers throw different types of exceptions, so we can't assert much more than that something went wrong.			
 		}
 
-	}}
+#if !__WATCHOS__
+		// ensure that we do get the same number of cookies as the managed handler
+		[TestCase]
+		public void TestNSUrlSessionHandlerCookies ()
+		{
+			bool areEqual = false;
+			var manageCount = 0;
+			var nativeCount = 0;
+			Exception ex = null;
+
+			TestRuntime.RunAsync (DateTime.Now.AddSeconds (30), async () =>
+			{
+				try {
+					var managedClient = new HttpClient (new HttpClientHandler ());
+					var managedResponse = await managedClient.GetAsync ("https://google.com");
+					if (managedResponse.Headers.TryGetValues ("Set-Cookie", out var managedCookies)) {
+						var nativeClient = new HttpClient (new NSUrlSessionHandler ());
+						var nativeResponse = await nativeClient.GetAsync ("https://google.com");
+						if (managedResponse.Headers.TryGetValues ("Set-Cookie", out var nativeCookies)) {
+							manageCount = managedCookies.Count ();
+							nativeCount = nativeCookies.Count ();
+							areEqual = manageCount == nativeCount;
+						} else {
+							manageCount = -1;
+							nativeCount = -1;
+							areEqual = false;
+						}
+					}
+					
+				} catch (Exception e) {
+					ex = e;
+				} 
+			}, () => areEqual);
+
+			Assert.IsTrue (areEqual, $"Cookies are different - Managed {manageCount} vs Native {nativeCount}");
+		}
+#endif
+
+	}
+}


### PR DESCRIPTION
The response object does not have all the cookie values, instead we must
use the cookie storage which can be used to retrieve ALL the cookies
for a task.

The header value has to be created manually because the native objects
do not expose a valid way to get the header. Tests have been added to
ensure we return the same as the managed client.

Fixes https://github.com/xamarin/xamarin-macios/issues/5148