### PR TITLE
[msbuild] Fixes incremental build issues with frameworks from VS

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -180,6 +180,9 @@ namespace Xamarin.iOS.Tasks
 		[Output]
 		public ITaskItem NativeExecutable { get; set; }
 
+		[Output]
+		public ITaskItem[] CopiedFrameworks { get; set; }
+
 		#endregion
 
 		public PlatformFramework Framework {
@@ -681,7 +684,30 @@ namespace Xamarin.iOS.Tasks
 
 			Directory.CreateDirectory (AppBundleDir);
 
-			return base.Execute ();
+			var result = base.Execute();
+
+			CopiedFrameworks = GetCopiedFrameworks();
+
+			return result;
+		}
+
+		ITaskItem[] GetCopiedFrameworks()
+		{
+			var copiedFrameworks = new List<ITaskItem>();
+			var frameworksDir = Path.Combine(AppBundleDir, "Frameworks");
+
+			if (Directory.Exists(frameworksDir))
+			{
+				foreach (var dir in Directory.EnumerateDirectories(frameworksDir, "*.framework"))
+				{
+					var framework = Path.Combine(dir, Path.GetFileNameWithoutExtension(dir));
+
+					if (File.Exists(framework))
+						copiedFrameworks.Add(new TaskItem(framework));
+				}
+			}
+
+			return copiedFrameworks.ToArray();
 		}
 
 		string ResolveFrameworkFile (string fullName)


### PR DESCRIPTION
Partial fix for bug 662636 - *.dylib libraries are signed during full rebuild, but not the second time

https://devdiv.visualstudio.com/DevDiv/_queries/edit/662636

There were two problems:
- VS was creating/touching each bundle resource found even if the resource wasn't unpacked on the Mac because the file was up to date. This caused the files on Windows to be changed on each build.
- VS was not updating the framework files in the app bundle on incremental builds because the MTouch didn't have an output property informing the frameworks that were copied by mtouch into the app bundle. This caused MSBuild to skip the CodesignFramework target because the frameworks remained unchanged on Windows.