### PR TITLE
[d16-0] [mmp] Add rpath during compile and not after via install_name_tool

### DIFF
--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -812,16 +812,6 @@ namespace Xamarin.Bundler {
 				// if not then the compilation really failed
 				throw new MonoMacException (5103, true, String.Format ("Failed to compile. Error code - {0}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new", ret));
 			}
-			if (frameworks_copied_to_bundle_dir) {
-				int install_ret = XcodeRun ("install_name_tool", $"{StringUtils.Quote (AppPath)} -add_rpath @loader_path/../Frameworks");
-				if (install_ret != 0)
-					throw new MonoMacException (5310, true, "install_name_tool failed with an error code '{0}'. Check build log for details.", install_ret);
-			}
-	    		if (dylibs_copied_to_bundle_dir) {
-				int install_ret = XcodeRun ("install_name_tool", $"{StringUtils.Quote (AppPath)} -add_rpath @loader_path/../{BundleName}"); 
-				if (install_ret != 0)
-					throw new MonoMacException (5310, true, "install_name_tool failed with an error code '{0}'. Check build log for details.", ret);
-			}
 
 			if (generate_plist)
 				GeneratePList ();
@@ -1228,6 +1218,11 @@ namespace Xamarin.Bundler {
 					string finalLibPath = Path.Combine (mmp_dir, libName);
 					args.Append (StringUtils.Quote (finalLibPath)).Append (' ');
 				}
+
+				if (frameworks_copied_to_bundle_dir)
+					args.Append ("-rpath @loader_path/../Frameworks ");
+				if (dylibs_copied_to_bundle_dir)
+					args.Append ($"-rpath @loader_path/../{BundleName} ");
 
 				if (is_extension)
 					args.Append ("-e _xamarin_mac_extension_main -framework NotificationCenter").Append(' ');


### PR DESCRIPTION
- https://github.com/xamarin/xamarin-macios/issues/5243
- https://github.com/xamarin/xamarin-macios/issues/5248
- There were multiple issues where we'd run out of space and install_name_tool
would randomly fail. We can easily move these two to during initial
clang and avoid those cases.

Backport of #5251.

/cc @rolfbjarne @chamons