### PR TITLE
[jenkins] Print out the environment for debug purposes.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -395,6 +395,7 @@ timestamps {
                         stage ('Checkout') {
                             currentStage = "${STAGE_NAME}"
                             echo ("Building on ${env.NODE_NAME}")
+                            sh ("env | sort") // Print out environment for debug purposes
                             scmVars = checkout scm
                             isPr = (env.CHANGE_ID && !env.CHANGE_ID.empty ? true : false)
                             branchName = env.BRANCH_NAME

--- a/jenkins/run-tests.sh
+++ b/jenkins/run-tests.sh
@@ -3,6 +3,9 @@
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 WORKSPACE=$(pwd)
 
+# Print out environment for debug purposes
+env | sort
+
 report_error ()
 {
 	printf "🔥 [Test run failed](%s) 🔥\\n" "$URL" >> "$WORKSPACE/jenkins/pr-comments.md"


### PR DESCRIPTION
This can be quite useful when writing new CI logic.