### PR TITLE
[XHarness] Do not build the test assemblies for the iOS platforms.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -331,8 +331,8 @@ ifeq ($(MONO_BUILD_FROM_SOURCE),)
 MONO_HASH:=$(shell git --git-dir=$(abspath $(TOP)/.git) --work-tree=$(abspath $(TOP)) ls-tree HEAD --full-tree -- external/mono | awk -F' ' '{printf "%s",$$3}')
 MONO_FILENAME:=ios-release-Darwin-$(MONO_HASH).zip
 MONO_URL:=https://xamjenkinsartifact.azureedge.net/mono-sdks/$(MONO_FILENAME)
-MONO_SDK_BUILDDIR:=$(abspath builds/downloads/$(basename $(MONO_FILENAME)))
-MONO_SDK_DESTDIR:=$(abspath builds/downloads/$(basename $(MONO_FILENAME)))
+MONO_SDK_BUILDDIR:=$(abspath $(TOP)/builds/downloads/$(basename $(MONO_FILENAME)))
+MONO_SDK_DESTDIR:=$(abspath $(TOP)/builds/downloads/$(basename $(MONO_FILENAME)))
 MONO_BUILD_MODE=download
 else
 MONO_SDK_BUILDDIR:=$(abspath $(MONO_PATH)/sdks/builds)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -92,6 +92,7 @@ test.config: Makefile $(TOP)/Make.config
 	@echo "JENKINS_RESULTS_DIRECTORY=$(abspath $(JENKINS_RESULTS_DIRECTORY))" >> $@
 	@echo "INCLUDE_DEVICE=$(INCLUDE_DEVICE)" >> $@
 	@echo "XCODE_DEVELOPER_ROOT=$(XCODE_DEVELOPER_ROOT)" >> $@
+	@echo "MONO_SDK_DESTDIR=$(MONO_SDK_DESTDIR)" >> $@
 
 test-system.config:
 	@rm -f $@

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -194,8 +194,6 @@ $(TOP)/tools/mtouch/SdkVersions.cs: $(TOP)/tools/common/SdkVersions.cs.in
 	@touch $@
 
 .stamp-build-mono-unit-tests: $(TOP)/.git/modules/external/mono/HEAD
-	make -j8 -C $(TOP)/external/mono/mcs/class -i do-test PROFILE=MONOTOUCH # TODO: This should not be needed and we should get the dlls from the SDK.
-	make -j8 -C $(TOP)/external/mono/mcs/class -i do-xunit-test PROFILE=MONOTOUCH # TODO: This should not be needed and we should get the dlls from the SDK.
 	make -j8 -C $(TOP)/external/mono/mcs/class -i do-test PROFILE=xammac_net_4_5 # TODO: This should not be needed and we should get the dlls from the SDK.
 	make -j8 -C $(TOP)/external/mono/mcs/class -i do-xunit-test PROFILE=xammac_net_4_5 # TODO: This should not be needed and we should get the dlls from the SDK.
 	nuget restore bcl-test/BCLTests/BCLTests.csproj

--- a/tests/xharness/BCLTestImporter/BCLTestImportTargetFactory.cs
+++ b/tests/xharness/BCLTestImporter/BCLTestImportTargetFactory.cs
@@ -22,7 +22,8 @@ namespace xharness.BCLTestImporter {
 			var plistTemplatePath = outputDir;
 
 			projectGenerator = new BCLTestProjectGenerator (outputDir, Harness.MONO_PATH, projectTemplatePath, registerTypesTemplatePath, plistTemplatePath) {
-				Override = true
+				DownloadsPath = Harness.DownloadsPath,
+				Override = true,
 			};
 		}
 		
@@ -37,11 +38,6 @@ namespace xharness.BCLTestImporter {
 					Name = $"[{prefix}] Mono {name}",
 					SkiptvOSVariation = !platforms.Contains (Platform.TvOS),
 					SkipwatchOSVariation = !platforms.Contains (Platform.WatchOS),
-					Dependency = async () => {
-						var rv = await Harness.BuildBclTests ();
-						if (!rv.Succeeded)
-							throw new Exception ($"Failed to build BCL tests, exit code: {rv.ExitCode}. Check the harness log for more details.");
-					}
 				});
 			}
 			return result;

--- a/tests/xharness/BCLTestImporter/BCLTestImportTargetFactory.cs
+++ b/tests/xharness/BCLTestImporter/BCLTestImportTargetFactory.cs
@@ -22,7 +22,7 @@ namespace xharness.BCLTestImporter {
 			var plistTemplatePath = outputDir;
 
 			projectGenerator = new BCLTestProjectGenerator (outputDir, Harness.MONO_PATH, projectTemplatePath, registerTypesTemplatePath, plistTemplatePath) {
-				DownloadsPath = Harness.DownloadsPath,
+				iOSMonoSDKPath = Harness.MONO_SDK_DESTDIR,
 				Override = true,
 			};
 		}

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -34,11 +34,6 @@ namespace xharness
 			get { return Path.GetFullPath (Path.Combine (RootDirectory, "..", "tools", "xibuild", "xibuild")); }
 		}
 
-		public string DownloadsPath
-		{
-			get { return Path.GetFullPath (Path.Combine (RootDirectory, "..", "builds", "downloads")); }
-		}
-
 		public static string Timestamp {
 			get {
 				return $"{DateTime.Now:yyyyMMdd_HHmmss}";
@@ -91,6 +86,7 @@ namespace xharness
 		public string JENKINS_RESULTS_DIRECTORY { get; set; } // Use same name as in Makefiles, so that a grep finds it.
 		public string MAC_DESTDIR { get; set; }
 		public string IOS_DESTDIR { get; set; }
+		public string MONO_SDK_DESTDIR { get; set; }
 		public bool IncludeMac32 { get; set; }
 
 		// Run
@@ -230,6 +226,7 @@ namespace xharness
 				SdkRoot = make_config ["XCODE_DEVELOPER_ROOT"];
 			if (string.IsNullOrEmpty (SdkRoot94))
 				SdkRoot94 = make_config ["XCODE94_DEVELOPER_ROOT"];
+			MONO_SDK_DESTDIR = make_config ["MONO_SDK_DESTDIR"];
 		}
 		 
 		void AutoConfigureMac ()

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -34,6 +34,11 @@ namespace xharness
 			get { return Path.GetFullPath (Path.Combine (RootDirectory, "..", "tools", "xibuild", "xibuild")); }
 		}
 
+		public string DownloadsPath
+		{
+			get { return Path.GetFullPath (Path.Combine (RootDirectory, "..", "builds", "downloads")); }
+		}
+
 		public static string Timestamp {
 			get {
 				return $"{DateTime.Now:yyyyMMdd_HHmmss}";

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestAssemblyDefinition.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestAssemblyDefinition.cs
@@ -39,12 +39,25 @@ namespace BCLTestImporter {
 		/// <param name="platform">The platform whose test directory we need.</param>
 		/// <returns>The full path of the test directory.</returns>
 		/// <exception cref="ArgumentNullException">Raised when one of the parameters is null.</exception>
-		public static string GetTestDirectory (string monoRootPath, Platform platform)
+		public static string GetTestDirectoryFromMonoPath (string monoRootPath, Platform platform)
 		{
-			if (monoRootPath == null)
+			if (string.IsNullOrEmpty (monoRootPath))
 				throw new ArgumentNullException (nameof (monoRootPath));
 			var fullPath = monoRootPath;
 			return Path.Combine (fullPath, partialPath, platformPathMatch[platform], "tests");
+		}
+
+		/// <summary>
+		/// Returns the directory from the downloads where tests can be found.
+		/// </summary>
+		/// <returns>The test directory from downloads path.</returns>
+		/// <param name="downloadsPath">Downloads path.</param>
+		/// <param name="platform">Platform whose tests we require.</param>
+		public static string GetTestDirectoryFromDownloadsPath (string downloadsPath, Platform platform)
+		{
+			if (string.IsNullOrEmpty (downloadsPath))
+				throw new ArgumentNullException (nameof (downloadsPath));
+			return Path.Combine (downloadsPath, "ios-bcl", platformPathMatch [platform], "tests"); 
 		}
 
 		public static string GetHintPathForRefenreceAssembly (string assembly, string monoRootPath, Platform plaform)
@@ -56,9 +69,14 @@ namespace BCLTestImporter {
 		/// <summary>
 		/// Returns the path of the test assembly within the mono checkout.
 		/// </summary>
-		/// <param name="monoRootPath">The root path of the mono checkout.</param>
+		/// <param name="rootPath">The root path of the mono checkout.</param>
 		/// <param name="platform">The platform we are working with.</param>
 		/// <returns>The full path of the assembly.</returns>
-		public string GetPath (string monoRootPath, Platform platform) => Path.Combine (GetTestDirectory (monoRootPath, platform), Name);
+		public string GetPath (string rootPath, Platform platform, bool wasDownloaded)
+		{
+			var testsRootPath = wasDownloaded? GetTestDirectoryFromDownloadsPath (rootPath, platform) : 
+				GetTestDirectoryFromMonoPath (rootPath, platform);
+			return Path.Combine (testsRootPath, Name);
+		}
 	}
 }

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestImporterTests/ApplicationOptionsTest.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestImporterTests/ApplicationOptionsTest.cs
@@ -32,7 +32,7 @@ namespace BCLTestImporterTests {
 			WriteJunk (plistTemplatePath);
 			outputPath = Path.Combine (tmpPath, Path.GetRandomFileName());
 			monoCheckout = Path.Combine (tmpPath, Path.GetRandomFileName());
-			var testDir = BCLTestAssemblyDefinition.GetTestDirectory (monoCheckout, platform);
+			var testDir = BCLTestAssemblyDefinition.GetTestDirectoryFromMonoPath (monoCheckout, platform);
 			
 			if (Directory.Exists (testDir)) return;
 			

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestImporterTests/BCLTestProjectGeneratorTest.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestImporterTests/BCLTestProjectGeneratorTest.cs
@@ -121,7 +121,7 @@ namespace BCLTestImporterTests {
 		{
 			var fixedPath = registerPath.Replace ("/", "\\");
 			var sb = new StringBuilder ();
-			sb.AppendLine ($"<Compile Include=\"{fixedPath}\">");
+			sb.AppendLine ($"<Compile Include=\"{registerPath}\">");
 			sb.AppendLine ($"<Link>{Path.GetFileName (registerPath)}</Link>");
 			sb.AppendLine ("</Compile>");
 			var expected = sb.ToString ();
@@ -140,7 +140,7 @@ namespace BCLTestImporterTests {
 			Assert.Contains (projectName, generatedProject);
 			Assert.DoesNotContain (BCLTestProjectGenerator.WatchOSTemplatePathKey, generatedProject);
 			Assert.DoesNotContain (BCLTestProjectGenerator.PlistKey, generatedProject);
-			Assert.Contains (plistPath.Replace ("/", "\\"), generatedProject);
+			Assert.Contains (plistPath, generatedProject);
 		}
 	}
 }

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestImporterTests/TestAssemblyDefinitionTest.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestImporterTests/TestAssemblyDefinitionTest.cs
@@ -13,7 +13,7 @@ namespace BCLTestImporterTests {
 		public void GetPathNullMonoRoot ()
 		{
 			var testAssemblyDefinition = new BCLTestAssemblyDefinition ("MONOTOUCH_System.Json.Microsoft_test.dll");
-			Assert.Throws<ArgumentNullException> (() => testAssemblyDefinition.GetPath (null, Platform.iOS));
+			Assert.Throws<ArgumentNullException> (() => testAssemblyDefinition.GetPath (null, Platform.iOS, true));
 		}
 
 		[Fact]
@@ -36,7 +36,7 @@ namespace BCLTestImporterTests {
 			var testAssemblyDefinition = new BCLTestAssemblyDefinition ("MONOTOUCH_System.Json.Microsoft_xunit-test.dll");
 			var home = Environment.GetEnvironmentVariable ("HOME");
 			var expectedPath = Path.Combine (home, "mcs/class/lib", "monotouch", "tests", testAssemblyDefinition.Name);
-			Assert.Equal (expectedPath, testAssemblyDefinition.GetPath (Environment.GetEnvironmentVariable("HOME"), Platform.iOS));
+			Assert.Equal (expectedPath, testAssemblyDefinition.GetPath (Environment.GetEnvironmentVariable("HOME"), Platform.iOS, false));
 		}
 
 		[Fact]
@@ -45,7 +45,7 @@ namespace BCLTestImporterTests {
 			var testAssemblyDefinition = new BCLTestAssemblyDefinition ("MONOTOUCH_System.Json.Microsoft_xunit-test.dll");
 			var home = Environment.GetEnvironmentVariable ("HOME");
 			var expectedPath = Path.Combine (home, "mcs/class/lib", "monotouch", "tests", testAssemblyDefinition.Name);
-			Assert.Equal (expectedPath, testAssemblyDefinition.GetPath (Environment.GetEnvironmentVariable("HOME"), Platform.TvOS));
+			Assert.Equal (expectedPath, testAssemblyDefinition.GetPath (Environment.GetEnvironmentVariable("HOME"), Platform.TvOS, false));
 		}
 
 		[Fact]
@@ -53,8 +53,8 @@ namespace BCLTestImporterTests {
 		{
 			var testAssemblyDefinition = new BCLTestAssemblyDefinition ("MONOTOUCH_System.Json.Microsoft_xunit-test.dll");
 			var home = Environment.GetEnvironmentVariable ("HOME");
-			var expectedPath = Path.Combine (home, "mcs/class/lib", "monotouch_watch", "tests", testAssemblyDefinition.Name);
-			Assert.Equal (expectedPath, testAssemblyDefinition.GetPath (Environment.GetEnvironmentVariable("HOME"), Platform.WatchOS));
+			var expectedPath = Path.Combine (home, "mcs/class/lib", "monotouch", "tests", testAssemblyDefinition.Name);
+			Assert.Equal (expectedPath, testAssemblyDefinition.GetPath (Environment.GetEnvironmentVariable("HOME"), Platform.WatchOS, false));
 		}
 
 		[Fact]
@@ -62,8 +62,8 @@ namespace BCLTestImporterTests {
 		{
 			var testAssemblyDefinition = new BCLTestAssemblyDefinition ("MONOTOUCH_System.Json.Microsoft_xunit-test.dll");
 			var home = Environment.GetEnvironmentVariable ("HOME");
-			var expectedPath = Path.Combine (home, "mcs/class/lib", "xammac", "tests", testAssemblyDefinition.Name);
-			Assert.Equal (expectedPath, testAssemblyDefinition.GetPath (Environment.GetEnvironmentVariable("HOME"), Platform.MacOSFull));
+			var expectedPath = Path.Combine (home, "mcs/class/lib", "xammac_net_4_5", "tests", testAssemblyDefinition.Name);
+			Assert.Equal (expectedPath, testAssemblyDefinition.GetPath (Environment.GetEnvironmentVariable("HOME"), Platform.MacOSFull, false));
 		}
 	}
 }

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestImporterTests/TestProjectDefinitionTest.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestImporterTests/TestProjectDefinitionTest.cs
@@ -14,7 +14,7 @@ namespace BCLTestImporterTests {
 		public void GetTypeForAssembliesNullMonoPath ()
 		{
 			var projectDefinition = new BCLTestProjectDefinition ("MyProject", new List<BCLTestAssemblyDefinition> ());	
-			Assert.Throws<ArgumentNullException> (() => projectDefinition.GetTypeForAssemblies (null, Platform.iOS));
+			Assert.Throws<ArgumentNullException> (() => projectDefinition.GetTypeForAssemblies (null, Platform.iOS, true));
 		}
 	}
 }

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectDefinition.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectDefinition.cs
@@ -65,24 +65,24 @@ namespace BCLTestImporter {
 		/// Returns the assemblies that a referenced by the given test assembly.
 		/// </summary>
 		/// <returns></returns>
-		IEnumerable<string> GetProjectAssemblyReferences (string monoRootPath, Platform platform)
+		IEnumerable<string> GetProjectAssemblyReferences (string rootPath, Platform platform, bool wasDownloaded)
 		{
 			var set = new HashSet<string> ();
 			foreach (var definition in TestAssemblies) {
-				foreach (var reference in GetAssemblyReferences (definition.GetPath (monoRootPath, platform))) {
+				foreach (var reference in GetAssemblyReferences (definition.GetPath (rootPath, platform, wasDownloaded))) {
 					set.Add (reference);
 				}
 			}
 			return set;
 		}
 		
-		public Dictionary <string, Type> GetTypeForAssemblies (string monoRootPath, Platform platform) {
+		public Dictionary <string, Type> GetTypeForAssemblies (string monoRootPath, Platform platform, bool wasDownloaded) {
 			if (monoRootPath == null)
 				throw new ArgumentNullException (nameof (monoRootPath));
 			var dict = new Dictionary <string, Type> ();
 			// loop over the paths, grab the assembly, find a type and then add it
 			foreach (var definition in TestAssemblies) {
-				var path = definition.GetPath (monoRootPath, platform);
+				var path = definition.GetPath (monoRootPath, platform, wasDownloaded);
 				var a = Assembly.LoadFile (path);
 				try {
 					var types = a.ExportedTypes;
@@ -111,17 +111,17 @@ namespace BCLTestImporter {
 		/// <param name="platform">The platform we are working with.</param>
 		/// <returns>The list of tuples (assembly name, path hint) for all the assemblies in the project.</returns>
 		public List<(string assembly, string hintPath)> GetAssemblyInclusionInformation (string monoRootPath,
-			Platform platform)
+			Platform platform, bool wasDownloaded)
 		{
 			if (monoRootPath == null)
 				throw new ArgumentNullException (nameof (monoRootPath));
 			
-			return GetProjectAssemblyReferences (monoRootPath, platform).Select (
+			return GetProjectAssemblyReferences (monoRootPath, platform, wasDownloaded).Select (
 					a => (assembly: a, 
 						hintPath: BCLTestAssemblyDefinition.GetHintPathForRefenreceAssembly (a, monoRootPath, platform))).Union (
 					TestAssemblies.Select (
 						definition => (assembly: definition.Name,
-							hintPath: definition.GetPath (monoRootPath, platform))))
+							hintPath: definition.GetPath (monoRootPath, platform, wasDownloaded))))
 				.ToList ();
 		}
 

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectDefinitionWorkaround.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectDefinitionWorkaround.cs
@@ -9,134 +9,6 @@ namespace BCLTestImporter
 	// Added for the workaround so that it does not make the code uglier
 	public partial struct BCLTestProjectDefinition
 	{
-		static Dictionary<string, List<(string assembly, string hint)>> iOSCachedAssemblyInfo =
-			new Dictionary<string, List<(string assembly, string hint)>>
-			{
-				{"SystemNumericsTests", new List<(string assembly, string hint)> {
-					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/monotouch/mscorlib.dll"),
-					(assembly:"nunitlite", hint:"{MONO_ROOT}mcs/class/lib/monotouch/nunitlite.dll"),
-					(assembly:"System.Numerics", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Numerics.dll"),
-					(assembly:"MONOTOUCH_System.Numerics_test.dll", hint:"{MONO_ROOT}mcs/class/lib/monotouch/tests/MONOTOUCH_System.Numerics_test.dll"),
-				}},
-				{"SystemRuntimeSerializationTests", new List<(string assembly, string hint)> {
-					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/monotouch/mscorlib.dll"),
-					(assembly:"System.Runtime.Serialization", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Runtime.Serialization.dll"),
-					(assembly:"System.Core", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Core.dll"),
-					(assembly:"System", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.dll"),
-					(assembly:"System.ServiceModel", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.ServiceModel.dll"),
-					(assembly:"System.Xml", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Xml.dll"),
-					(assembly:"nunitlite", hint:"{MONO_ROOT}mcs/class/lib/monotouch/nunitlite.dll"),
-					(assembly:"MONOTOUCH_System.Runtime.Serialization_test.dll", hint:"{MONO_ROOT}mcs/class/lib/monotouch/tests/MONOTOUCH_System.Runtime.Serialization_test.dll"),
-				}},
-				{"SystemXmlLinqTests", new List<(string assembly, string hint)> {
-					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/monotouch/mscorlib.dll"),
-					(assembly:"nunitlite", hint:"{MONO_ROOT}mcs/class/lib/monotouch/nunitlite.dll"),
-					(assembly:"System.Xml", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Xml.dll"),
-					(assembly:"System.Xml.Linq", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Xml.Linq.dll"),
-					(assembly:"System.Core", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Core.dll"),
-					(assembly:"MONOTOUCH_System.Xml.Linq_test.dll", hint:"{MONO_ROOT}mcs/class/lib/monotouch/tests/MONOTOUCH_System.Xml.Linq_test.dll"),
-				}},
-				{"MonoSecurityTests", new List<(string assembly, string hint)> {
-					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/monotouch/mscorlib.dll"),
-					(assembly:"nunitlite", hint:"{MONO_ROOT}mcs/class/lib/monotouch/nunitlite.dll"),
-					(assembly:"Mono.Security", hint:"{MONO_ROOT}mcs/class/lib/monotouch/Mono.Security.dll"),
-					(assembly:"MONOTOUCH_Mono.Security_test.dll", hint:"{MONO_ROOT}mcs/class/lib/monotouch/tests/MONOTOUCH_Mono.Security_test.dll"),
-				}},
-				{"SystemComponentModelDataAnnotationTests", new List<(string assembly, string hint)> {
-					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/monotouch/mscorlib.dll"),
-					(assembly:"nunitlite", hint:"{MONO_ROOT}mcs/class/lib/monotouch/nunitlite.dll"),
-					(assembly:"System.ComponentModel.DataAnnotations", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.ComponentModel.DataAnnotations.dll"),
-					(assembly:"System", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.dll"),
-					(assembly:"MONOTOUCH_System.ComponentModel.DataAnnotations_test.dll", hint:"{MONO_ROOT}mcs/class/lib/monotouch/tests/MONOTOUCH_System.ComponentModel.DataAnnotations_test.dll"),
-				}},
-				{"SystemJsonTests", new List<(string assembly, string hint)> {
-					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/monotouch/mscorlib.dll"),
-					(assembly:"nunitlite", hint:"{MONO_ROOT}mcs/class/lib/monotouch/nunitlite.dll"),
-					(assembly:"System.Json", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Json.dll"),
-					(assembly:"MONOTOUCH_System.Json_test.dll", hint:"{MONO_ROOT}mcs/class/lib/monotouch/tests/MONOTOUCH_System.Json_test.dll"),
-				}},
-				{"MonoDataTdsTests", new List<(string assembly, string hint)> {
-					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/monotouch/mscorlib.dll"),
-					(assembly:"nunitlite", hint:"{MONO_ROOT}mcs/class/lib/monotouch/nunitlite.dll"),
-					(assembly:"System", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.dll"),
-					(assembly:"Mono.Data.Tds", hint:"{MONO_ROOT}mcs/class/lib/monotouch/Mono.Data.Tds.dll"),
-					(assembly:"MONOTOUCH_Mono.Data.Tds_test.dll", hint:"{MONO_ROOT}mcs/class/lib/monotouch/tests/MONOTOUCH_Mono.Data.Tds_test.dll"),
-				}},
-				{"MonoCSharpTests", new List<(string assembly, string hint)> {
-					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/monotouch/mscorlib.dll"),
-					(assembly:"Mono.CSharp", hint:"{MONO_ROOT}mcs/class/lib/monotouch/Mono.CSharp.dll"),
-					(assembly:"nunitlite", hint:"{MONO_ROOT}mcs/class/lib/monotouch/nunitlite.dll"),
-					(assembly:"MONOTOUCH_Mono.CSharp_test.dll", hint:"{MONO_ROOT}mcs/class/lib/monotouch/tests/MONOTOUCH_Mono.CSharp_test.dll"),
-				}},
-				{"SystemJsonMicrosoftTests", new List<(string assembly, string hint)> {
-					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/monotouch/mscorlib.dll"),
-					(assembly:"nunitlite", hint:"{MONO_ROOT}mcs/class/lib/monotouch/nunitlite.dll"),
-					(assembly:"System.Json.Microsoft", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Json.Microsoft.dll"),
-					(assembly:"MONOTOUCH_System.Json.Microsoft_test.dll", hint:"{MONO_ROOT}mcs/class/lib/monotouch/tests/MONOTOUCH_System.Json.Microsoft_test.dll"),
-				}},
-				{"MonoParallelTests", new List<(string assembly, string hint)> {
-					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/monotouch/mscorlib.dll"),
-					(assembly:"nunitlite", hint:"{MONO_ROOT}mcs/class/lib/monotouch/nunitlite.dll"),
-					(assembly:"Mono.Parallel", hint:"{MONO_ROOT}mcs/class/lib/monotouch/Mono.Parallel.dll"),
-					(assembly:"System.Core", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Core.dll"),
-					(assembly:"MONOTOUCH_Mono.Parallel_test.dll", hint:"{MONO_ROOT}mcs/class/lib/monotouch/tests/MONOTOUCH_Mono.Parallel_test.dll"),
-				}},
-				{"MonoTaskletsTests", new List<(string assembly, string hint)> {
-					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/monotouch/mscorlib.dll"),
-					(assembly:"nunitlite", hint:"{MONO_ROOT}mcs/class/lib/monotouch/nunitlite.dll"),
-					(assembly:"Mono.Tasklets", hint:"{MONO_ROOT}mcs/class/lib/monotouch/Mono.Tasklets.dll"),
-					(assembly:"MONOTOUCH_Mono.Tasklets_test.dll", hint:"{MONO_ROOT}mcs/class/lib/monotouch/tests/MONOTOUCH_Mono.Tasklets_test.dll"),
-				}},
-				{"SystemThreadingTasksDataflowTests", new List<(string assembly, string hint)> {
-					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/monotouch/mscorlib.dll"),
-					(assembly:"System.Threading.Tasks.Dataflow", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Threading.Tasks.Dataflow.dll"),
-					(assembly:"System.Core", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Core.dll"),
-					(assembly:"nunitlite", hint:"{MONO_ROOT}mcs/class/lib/monotouch/nunitlite.dll"),
-					(assembly:"System", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.dll"),
-					(assembly:"MONOTOUCH_System.Threading.Tasks.Dataflow_test.dll", hint:"{MONO_ROOT}mcs/class/lib/monotouch/tests/MONOTOUCH_System.Threading.Tasks.Dataflow_test.dll"),
-				}},
-				{"SystemJsonXunit", new List<(string assembly, string hint)> {
-					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/monotouch/mscorlib.dll"),
-					(assembly:"xunit.core", hint:""),
-					(assembly:"xunit.abstractions", hint:""),
-					(assembly:"xunit.assert", hint:""),
-					(assembly:"System.Json", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Json.dll"),
-					(assembly:"System", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.dll"),
-					(assembly:"System.Core", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Core.dll"),
-					(assembly:"MONOTOUCH_System.Json_xunit-test.dll", hint:"{MONO_ROOT}mcs/class/lib/monotouch/tests/MONOTOUCH_System.Json_xunit-test.dll"),
-				}},
-				{"SystemNumericsXunit", new List<(string assembly, string hint)> {
-					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/monotouch/mscorlib.dll"),
-					(assembly:"xunit.core", hint:""),
-					(assembly:"xunit.abstractions", hint:""),
-					(assembly:"xunit.assert", hint:""),
-					(assembly:"System.Numerics", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Numerics.dll"),
-					(assembly:"System.Core", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Core.dll"),
-					(assembly:"Xunit.NetCore.Extensions", hint:""),
-					(assembly:"Microsoft.CSharp", hint:"{MONO_ROOT}mcs/class/lib/monotouch/Microsoft.CSharp.dll"),
-					(assembly:"MONOTOUCH_System.Numerics_xunit-test.dll", hint:"{MONO_ROOT}mcs/class/lib/monotouch/tests/MONOTOUCH_System.Numerics_xunit-test.dll"),
-				}},
-				{"SystemLinqXunit", new List<(string assembly, string hint)> {
-					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/monotouch/mscorlib.dll"),
-					(assembly:"System.Xml", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Xml.dll"),
-					(assembly:"xunit.core", hint:""),
-					(assembly:"xunit.abstractions", hint:""),
-					(assembly:"System.Xml.Linq", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Xml.Linq.dll"),
-					(assembly:"Xunit.NetCore.Extensions", hint:""),
-					(assembly:"System", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.dll"),
-					(assembly:"xunit.assert", hint:""),
-					(assembly:"System.Core", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Core.dll"),
-					(assembly:"MONOTOUCH_System.Xml.Linq_xunit-test.dll", hint:"{MONO_ROOT}mcs/class/lib/monotouch/tests/MONOTOUCH_System.Xml.Linq_xunit-test.dll"),
-				}},
-				{"SystemRuntimeCompilerServicesUnsafeXunit", new List<(string assembly, string hint)> {
-					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/monotouch/mscorlib.dll"),
-					(assembly:"xunit.core", hint:""),
-					(assembly:"xunit.abstractions", hint:""),
-					(assembly:"System.Runtime.CompilerServices.Unsafe", hint:"{MONO_ROOT}mcs/class/lib/monotouch/System.Runtime.CompilerServices.Unsafe.dll"),
-					(assembly:"xunit.assert", hint:""),
-					(assembly:"MONOTOUCH_System.Runtime.CompilerServices.Unsafe_xunit-test.dll", hint:"{MONO_ROOT}mcs/class/lib/monotouch/tests/MONOTOUCH_System.Runtime.CompilerServices.Unsafe_xunit-test.dll"),
-				}},
-			};
 
 		private static Dictionary<string, List<(string assembly, string hint)>> macCachedAssemblyInfo =
 			new Dictionary<string, List<(string assembly, string hint)>> {
@@ -441,8 +313,7 @@ namespace BCLTestImporter
 			case Platform.iOS:
 			case Platform.TvOS:
 			case Platform.WatchOS:
-				info = iOSCachedAssemblyInfo[Name]; 
-				break;
+				throw new InvalidOperationException ("All iOS platforms must used the dlls from the SDK and not build their own tests.");
 			case Platform.MacOSFull:
 			case Platform.MacOSModern:
 				info = macCachedAssemblyInfo[Name];

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -415,8 +415,9 @@ namespace BCLTestImporter {
 					Directory.CreateDirectory (generatedCodeDir);
 				}
 				var registerTypePath = Path.Combine (generatedCodeDir, "RegisterType.cs");
-				var registerCode = await RegisterTypeGenerator.GenerateCodeAsync (def.name, projectDefinition.IsXUnit,
-					RegisterTypesTemplatePath, Platform.WatchOS);
+				var typesPerAssembly = projectDefinition.GetTypeForAssemblies (GetReleaseDownload (Platform.iOS), Platform.WatchOS, true);
+ 				var registerCode = await RegisterTypeGenerator.GenerateCodeAsync (typesPerAssembly,
+ 					projectDefinition.IsXUnit, RegisterTypesTemplatePath);
 				using (var file = new StreamWriter (registerTypePath, false)) { // false is do not append
 					await file.WriteAsync (registerCode);
 				}
@@ -492,9 +493,10 @@ namespace BCLTestImporter {
 				}
 				var registerTypePath = Path.Combine (generatedCodeDir, "RegisterType.cs");
 
-				var registerCode = await RegisterTypeGenerator.GenerateCodeAsync (def.name, projectDefinition.IsXUnit,
-					RegisterTypesTemplatePath, Platform.iOS);
-
+				var typesPerAssembly = projectDefinition.GetTypeForAssemblies (GetReleaseDownload (Platform.iOS), Platform.iOS, true);
+ 				var registerCode = await RegisterTypeGenerator.GenerateCodeAsync (typesPerAssembly,
+ 					projectDefinition.IsXUnit, RegisterTypesTemplatePath);
+ 					
 				using (var file = new StreamWriter (registerTypePath, false)) { // false is do not append
 					await file.WriteAsync (registerCode);
 				}

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -234,7 +234,7 @@ namespace BCLTestImporter {
 		public bool Override { get; set; }
 		public string OutputDirectoryPath { get; private  set; }
 		public string MonoRootPath { get; private set; }
-		public string DownloadsPath { get; set; }
+		public string iOSMonoSDKPath { get; set; }
 		public string ProjectTemplateRootPath { get; private set; }
 		public string PlistTemplateRootPath{ get; private set; }
 		public string RegisterTypesTemplatePath { get; private set; }
@@ -260,14 +260,12 @@ namespace BCLTestImporter {
 
 		string GetReleaseDownload (Platform platform)
 		{
-			if (string.IsNullOrEmpty (DownloadsPath))
-				return null;
-			switch(platform) {
+			switch (platform) {
 			case Platform.iOS:
 			case Platform.TvOS:
 			case Platform.WatchOS:
 				// simply, try to find the dir with the pattern
-				return Directory.GetDirectories (DownloadsPath, iOSReleasePattern).First ();
+				return iOSMonoSDKPath;
 			case Platform.MacOSFull:
 			case Platform.MacOSModern:
 				return null;

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -14,8 +14,9 @@ namespace BCLTestImporter {
 	/// </summary>
 	public class BCLTestProjectGenerator {
 
-		static string NUnitPattern = "MONOTOUCH_*_test.dll"; 
-		static string xUnitPattern = "MONOTOUCH_*_xunit-test.dll";
+		static string NUnitPattern = "monotouch_*_test.dll"; 
+		static string xUnitPattern = "monotouch_*_xunit-test.dll";
+		static string iOSReleasePattern = "ios-release-Darwin-*";
 		internal static readonly string NameKey = "%NAME%";
 		internal static readonly string ReferencesKey = "%REFERENCES%";
 		internal static readonly string RegisterTypeKey = "%REGISTER TYPE%";
@@ -74,75 +75,71 @@ namespace BCLTestImporter {
 		static readonly List<(string name, string[] assemblies)> commoniOSTestProjects = new List<(string name, string[] assemblies)> {
 			// NUNIT TESTS
 
-			(name:"SystemTests", assemblies: new[] {"MONOTOUCH_System_test.dll"}),
-			(name:"SystemCoreTests", assemblies: new [] {"MONOTOUCH_System.Core_test.dll"}),
-			(name:"SystemDataTests", assemblies: new [] {"MONOTOUCH_System.Data_test.dll"}),
-			(name:"SystemNetHttpTests", assemblies: new [] {"MONOTOUCH_System.Net.Http_test.dll"}),
-			(name:"SystemNumericsTests", assemblies: new [] {"MONOTOUCH_System.Numerics_test.dll"}),
-			(name:"SystemRuntimeSerializationTests", assemblies: new [] {"MONOTOUCH_System.Runtime.Serialization_test.dll"}),
-			(name:"SystemTransactionsTests", assemblies: new [] {"MONOTOUCH_System.Transactions_test.dll"}),
-			(name:"SystemXmlTests", assemblies: new [] {"MONOTOUCH_System.Xml_test.dll"}),
-			(name:"SystemXmlLinqTests", assemblies: new [] {"MONOTOUCH_System.Xml.Linq_test.dll"}),
-			(name:"MonoSecurityTests", assemblies: new [] {"MONOTOUCH_Mono.Security_test.dll"}),
-			(name:"SystemComponentModelDataAnnotationTests", assemblies: new [] {"MONOTOUCH_System.ComponentModel.DataAnnotations_test.dll"}),
-			(name:"SystemJsonTests", assemblies: new [] {"MONOTOUCH_System.Json_test.dll"}),
-			(name:"SystemServiceModelWebTests", assemblies: new [] {"MONOTOUCH_System.ServiceModel.Web_test.dll"}),
-			(name:"MonoDataTdsTests", assemblies: new [] {"MONOTOUCH_Mono.Data.Tds_test.dll"}),
-			(name:"SystemIOCompressionTests", assemblies: new [] {"MONOTOUCH_System.IO.Compression_test.dll"}),
-			(name:"SystemIOCompressionFileSystemTests", assemblies: new [] {"MONOTOUCH_System.IO.Compression.FileSystem_test.dll"}),
-			(name:"MonoCSharpTests", assemblies: new [] {"MONOTOUCH_Mono.CSharp_test.dll"}),
-			(name:"SystemSecurityTests", assemblies: new [] {"MONOTOUCH_System.Security_test.dll"}),
-			(name:"SystemServiceModelTests", assemblies: new [] {"MONOTOUCH_System.ServiceModel_test.dll"}),
-			(name:"SystemJsonMicrosoftTests", assemblies: new [] {"MONOTOUCH_System.Json.Microsoft_test.dll"}),
-			(name:"SystemDataDataSetExtensionTests", assemblies: new [] {"MONOTOUCH_System.Data.DataSetExtensions_test.dll"}),
-			(name:"SystemRuntimeSerializationFormattersSoapTests", assemblies: new [] {"MONOTOUCH_System.Runtime.Serialization.Formatters.Soap_test.dll"}),
-			(name:"CorlibTests", assemblies: new [] {"MONOTOUCH_corlib_test.dll"}),
-			(name:"MonoParallelTests", assemblies: new [] {"MONOTOUCH_Mono.Parallel_test.dll"}),
-			(name:"MonoRuntimeTests", assemblies: new [] {"MONOTOUCH_Mono.Runtime.Tests_test.dll"}),
-			(name:"MonoTaskletsTests", assemblies: new [] {"MONOTOUCH_Mono.Tasklets_test.dll"}),
-			(name:"SystemThreadingTasksDataflowTests", assemblies: new [] {"MONOTOUCH_System.Threading.Tasks.Dataflow_test.dll"}),
+			(name:"SystemTests", assemblies: new[] {"monotouch_System_test.dll"}),
+			(name:"SystemCoreTests", assemblies: new [] {"monotouch_System.Core_test.dll"}),
+			(name:"SystemDataTests", assemblies: new [] {"monotouch_System.Data_test.dll"}),
+			(name:"SystemNetHttpTests", assemblies: new [] {"monotouch_System.Net.Http_test.dll"}),
+			(name:"SystemNumericsTests", assemblies: new [] {"monotouch_System.Numerics_test.dll"}),
+			(name:"SystemRuntimeSerializationTests", assemblies: new [] {"monotouch_System.Runtime.Serialization_test.dll"}),
+			(name:"SystemTransactionsTests", assemblies: new [] {"monotouch_System.Transactions_test.dll"}),
+			(name:"SystemXmlTests", assemblies: new [] {"monotouch_System.Xml_test.dll"}),
+			(name:"SystemXmlLinqTests", assemblies: new [] {"monotouch_System.Xml.Linq_test.dll"}),
+			(name:"MonoSecurityTests", assemblies: new [] {"monotouch_Mono.Security_test.dll"}),
+			(name:"SystemComponentModelDataAnnotationTests", assemblies: new [] {"monotouch_System.ComponentModel.DataAnnotations_test.dll"}),
+			(name:"SystemJsonTests", assemblies: new [] {"monotouch_System.Json_test.dll"}),
+			(name:"SystemServiceModelWebTests", assemblies: new [] {"monotouch_System.ServiceModel.Web_test.dll"}),
+			(name:"MonoDataTdsTests", assemblies: new [] {"monotouch_Mono.Data.Tds_test.dll"}),
+			(name:"SystemIOCompressionTests", assemblies: new [] {"monotouch_System.IO.Compression_test.dll"}),
+			(name:"SystemIOCompressionFileSystemTests", assemblies: new [] {"monotouch_System.IO.Compression.FileSystem_test.dll"}),
+			(name:"MonoCSharpTests", assemblies: new [] {"monotouch_Mono.CSharp_test.dll"}),
+			(name:"SystemSecurityTests", assemblies: new [] {"monotouch_System.Security_test.dll"}),
+			(name:"SystemServiceModelTests", assemblies: new [] {"monotouch_System.ServiceModel_test.dll"}),
+			(name:"SystemDataDataSetExtensionTests", assemblies: new [] {"monotouch_System.Data.DataSetExtensions_test.dll"}),
+			(name:"SystemRuntimeSerializationFormattersSoapTests", assemblies: new [] {"monotouch_System.Runtime.Serialization.Formatters.Soap_test.dll"}),
+			(name:"CorlibTests", assemblies: new [] {"monotouch_corlib_test.dll"}),
+			(name:"MonoRuntimeTests", assemblies: new [] {"monotouch_Mono.Runtime.Tests_test.dll"}),
 
 			// XUNIT TESTS 
 
-			(name:"SystemDataXunit", assemblies: new [] {"MONOTOUCH_System.Data_xunit-test.dll"}),
-			(name:"SystemJsonXunit", assemblies: new [] {"MONOTOUCH_System.Json_xunit-test.dll"}),
-			(name:"SystemNumericsXunit", assemblies: new [] {"MONOTOUCH_System.Numerics_xunit-test.dll"}),
-			(name:"SystemSecurityXunit", assemblies: new [] {"MONOTOUCH_System.Security_xunit-test.dll"}),
-			(name:"SystemThreadingTaskXunit", assemblies: new [] {"MONOTOUCH_System.Threading.Tasks.Dataflow_xunit-test.dll"}),
-			(name:"SystemLinqXunit", assemblies: new [] {"MONOTOUCH_System.Xml.Linq_xunit-test.dll"}),
-			(name:"SystemRuntimeCompilerServicesUnsafeXunit", assemblies: new [] {"MONOTOUCH_System.Runtime.CompilerServices.Unsafe_xunit-test.dll"}),
+			(name:"SystemDataXunit", assemblies: new [] {"monotouch_System.Data_xunit-test.dll"}),
+			(name:"SystemJsonXunit", assemblies: new [] {"monotouch_System.Json_xunit-test.dll"}),
+			(name:"SystemNumericsXunit", assemblies: new [] {"monotouch_System.Numerics_xunit-test.dll"}),
+			(name:"SystemSecurityXunit", assemblies: new [] {"monotouch_System.Security_xunit-test.dll"}),
+			(name:"SystemThreadingTaskXunit", assemblies: new [] {"monotouch_System.Threading.Tasks.Dataflow_xunit-test.dll"}),
+			(name:"SystemLinqXunit", assemblies: new [] {"monotouch_System.Xml.Linq_xunit-test.dll"}),
+			(name:"SystemRuntimeCompilerServicesUnsafeXunit", assemblies: new [] {"monotouch_System.Runtime.CompilerServices.Unsafe_xunit-test.dll"}),
 		};
 			
 		static readonly List <string> CommonIgnoredAssemblies = new List <string> {
-			"MONOTOUCH_System.Data_xunit-test.dll", // issue https://github.com/xamarin/maccore/issues/1131
-			"MONOTOUCH_System.Security_xunit-test.dll",// issue https://github.com/xamarin/maccore/issues/1128
-			"MONOTOUCH_System.Threading.Tasks.Dataflow_xunit-test.dll", // issue https://github.com/xamarin/maccore/issues/1132
-			"MONOTOUCH_System.Xml_test.dll", // issue https://github.com/xamarin/maccore/issues/1133
-			"MONOTOUCH_System.Transactions_test.dll", // issue https://github.com/xamarin/maccore/issues/1134
-			"MONOTOUCH_System_test.dll", // issues https://github.com/xamarin/maccore/issues/1135
-			"MONOTOUCH_System.ServiceModel.Web_test.dll", // issue https://github.com/xamarin/maccore/issues/1137
-			"MONOTOUCH_System.ServiceModel_test.dll", // issue https://github.com/xamarin/maccore/issues/1138
-			"MONOTOUCH_System.Security_test.dll", // issue https://github.com/xamarin/maccore/issues/1139
-			"MONOTOUCH_System.Runtime.Serialization.Formatters.Soap_test.dll", // issue https://github.com/xamarin/maccore/issues/1140
-			"MONOTOUCH_System.Net.Http_test.dll", // issue https://github.com/xamarin/maccore/issues/1144 and https://github.com/xamarin/maccore/issues/1145
-			"MONOTOUCH_System.IO.Compression_test.dll", // issue https://github.com/xamarin/maccore/issues/1146
-			"MONOTOUCH_System.IO.Compression.FileSystem_test.dll", // issue https://github.com/xamarin/maccore/issues/1147 and https://github.com/xamarin/maccore/issues/1148
-			"MONOTOUCH_System.Data_test.dll", // issue https://github.com/xamarin/maccore/issues/1149
-			"MONOTOUCH_System.Data.DataSetExtensions_test.dll", // issue https://github.com/xamarin/maccore/issues/1150 and https://github.com/xamarin/maccore/issues/1151
-			"MONOTOUCH_System.Core_test.dll", // issue https://github.com/xamarin/maccore/issues/1143
-			"MONOTOUCH_Mono.Runtime.Tests_test.dll", // issue https://github.com/xamarin/maccore/issues/1141
-			"MONOTOUCH_corlib_test.dll", // issue https://github.com/xamarin/maccore/issues/1153
-			"MONOTOUCH_Commons.Xml.Relaxng_test.dll", // not supported by xamarin
-			"MONOTOUCH_Cscompmgd_test.dll", // not supported by xamarin
-			"MONOTOUCH_I18N.CJK_test.dll",
-			"MONOTOUCH_I18N.MidEast_test.dll",
-			"MONOTOUCH_I18N.Other_test.dll",
-			"MONOTOUCH_I18N.Rare_test.dll",
-			"MONOTOUCH_I18N.West_test.dll",
-			"MONOTOUCH_Mono.C5_test.dll", // not supported by xamarin
-			"MONOTOUCH_Mono.CodeContracts_test.dll", // not supported by xamarin
-			"MONOTOUCH_Novell.Directory.Ldap_test.dll", // not supported by xamarin
-			"MONOTOUCH_Mono.Profiler.Log_xunit-test.dll", // special tests that need an extra app to connect as a profiler
+			"monotouch_System.Data_xunit-test.dll", // issue https://github.com/xamarin/maccore/issues/1131
+			"monotouch_System.Security_xunit-test.dll",// issue https://github.com/xamarin/maccore/issues/1128
+			"monotouch_System.Threading.Tasks.Dataflow_xunit-test.dll", // issue https://github.com/xamarin/maccore/issues/1132
+			"monotouch_System.Xml_test.dll", // issue https://github.com/xamarin/maccore/issues/1133
+			"monotouch_System.Transactions_test.dll", // issue https://github.com/xamarin/maccore/issues/1134
+			"monotouch_System_test.dll", // issues https://github.com/xamarin/maccore/issues/1135
+			"monotouch_System.ServiceModel.Web_test.dll", // issue https://github.com/xamarin/maccore/issues/1137
+			"monotouch_System.ServiceModel_test.dll", // issue https://github.com/xamarin/maccore/issues/1138
+			"monotouch_System.Security_test.dll", // issue https://github.com/xamarin/maccore/issues/1139
+			"monotouch_System.Runtime.Serialization.Formatters.Soap_test.dll", // issue https://github.com/xamarin/maccore/issues/1140
+			"monotouch_System.Net.Http_test.dll", // issue https://github.com/xamarin/maccore/issues/1144 and https://github.com/xamarin/maccore/issues/1145
+			"monotouch_System.IO.Compression_test.dll", // issue https://github.com/xamarin/maccore/issues/1146
+			"monotouch_System.IO.Compression.FileSystem_test.dll", // issue https://github.com/xamarin/maccore/issues/1147 and https://github.com/xamarin/maccore/issues/1148
+			"monotouch_System.Data_test.dll", // issue https://github.com/xamarin/maccore/issues/1149
+			"monotouch_System.Data.DataSetExtensions_test.dll", // issue https://github.com/xamarin/maccore/issues/1150 and https://github.com/xamarin/maccore/issues/1151
+			"monotouch_System.Core_test.dll", // issue https://github.com/xamarin/maccore/issues/1143
+			"monotouch_Mono.Runtime.Tests_test.dll", // issue https://github.com/xamarin/maccore/issues/1141
+			"monotouch_corlib_test.dll", // issue https://github.com/xamarin/maccore/issues/1153
+			"monotouch_Commons.Xml.Relaxng_test.dll", // not supported by xamarin
+			"monotouch_Cscompmgd_test.dll", // not supported by xamarin
+			"monotouch_I18N.CJK_test.dll",
+			"monotouch_I18N.MidEast_test.dll",
+			"monotouch_I18N.Other_test.dll",
+			"monotouch_I18N.Rare_test.dll",
+			"monotouch_I18N.West_test.dll",
+			"monotouch_Mono.C5_test.dll", // not supported by xamarin
+			"monotouch_Mono.CodeContracts_test.dll", // not supported by xamarin
+			"monotouch_Novell.Directory.Ldap_test.dll", // not supported by xamarin
+			"monotouch_Mono.Profiler.Log_xunit-test.dll", // special tests that need an extra app to connect as a profiler
 		};
 		
 		// list of assemblies that are going to be ignored, any project with an assemblies that is ignored will
@@ -151,15 +148,15 @@ namespace BCLTestImporter {
 		static readonly List<string> iOSIgnoredAssemblies = new List<string> {};
 
 		static readonly List<string> tvOSIgnoredAssemblies = new List<string> {
-			"MONOTOUCH_System.Xml.Linq_xunit-test.dll", // issue https://github.com/xamarin/maccore/issues/1130
-			"MONOTOUCH_System.Numerics_xunit-test.dll", // issue https://github.com/xamarin/maccore/issues/1129
+			"monotouch_System.Xml.Linq_xunit-test.dll", // issue https://github.com/xamarin/maccore/issues/1130
+			"monotouch_System.Numerics_xunit-test.dll", // issue https://github.com/xamarin/maccore/issues/1129
 		};
 
 		static readonly List<string> watcOSIgnoredAssemblies = new List<string> {
-			"MONOTOUCH_System.Xml.Linq_xunit-test.dll", // issue https://github.com/xamarin/maccore/issues/1130
-			"MONOTOUCH_System.Numerics_xunit-test.dll", // issue https://github.com/xamarin/maccore/issues/1129
-			"MONOTOUCH_Mono.Security_test.dll", // issue https://github.com/xamarin/maccore/issues/1142
-			"MONOTOUCH_Mono.Data.Tds_test.dll", // issue https://gist.github.com/mandel-macaque/d97fa28f8a73c3016d1328567da77a0b
+			"monotouch_System.Xml.Linq_xunit-test.dll", // issue https://github.com/xamarin/maccore/issues/1130
+			"monotouch_System.Numerics_xunit-test.dll", // issue https://github.com/xamarin/maccore/issues/1129
+			"monotouch_Mono.Security_test.dll", // issue https://github.com/xamarin/maccore/issues/1142
+			"monotouch_Mono.Data.Tds_test.dll", // issue https://gist.github.com/mandel-macaque/d97fa28f8a73c3016d1328567da77a0b
 		};
 
 		private static readonly List<(string name, string[] assemblies)> macTestProjects = new List<(string name, string[] assemblies)> {
@@ -237,6 +234,7 @@ namespace BCLTestImporter {
 		public bool Override { get; set; }
 		public string OutputDirectoryPath { get; private  set; }
 		public string MonoRootPath { get; private set; }
+		public string DownloadsPath { get; set; }
 		public string ProjectTemplateRootPath { get; private set; }
 		public string PlistTemplateRootPath{ get; private set; }
 		public string RegisterTypesTemplatePath { get; private set; }
@@ -258,6 +256,24 @@ namespace BCLTestImporter {
 			ProjectTemplateRootPath = projectTemplatePath ?? throw new ArgumentNullException (nameof (projectTemplatePath));
 			PlistTemplateRootPath = plistTemplatePath ?? throw new ArgumentNullException (nameof (plistTemplatePath));
 			RegisterTypesTemplatePath = registerTypesTemplatePath ?? throw new ArgumentNullException (nameof (registerTypesTemplatePath));
+		}
+
+		string GetReleaseDownload (Platform platform)
+		{
+			if (string.IsNullOrEmpty (DownloadsPath))
+				return null;
+			switch(platform) {
+			case Platform.iOS:
+			case Platform.TvOS:
+			case Platform.WatchOS:
+				// simply, try to find the dir with the pattern
+				return Directory.GetDirectories (DownloadsPath, iOSReleasePattern).First ();
+			case Platform.MacOSFull:
+			case Platform.MacOSModern:
+				return null;
+			default:
+				return null;
+			}
 		}
 
 		/// <summary>
@@ -424,7 +440,7 @@ namespace BCLTestImporter {
 							generatedProject = await GenerateWatchAppAsync (projectDefinition.Name, projetTemplate, data.plist);
 							break;
 						default:
-							generatedProject = await GenerateWatchExtensionAsync (projectDefinition.Name, projetTemplate, data.plist, registerTypePath, projectDefinition.GetCachedAssemblyInclusionInformation (MonoRootPath, Platform.WatchOS));
+							generatedProject = await GenerateWatchExtensionAsync (projectDefinition.Name, projetTemplate, data.plist, registerTypePath, projectDefinition.GetAssemblyInclusionInformation (GetReleaseDownload (Platform.WatchOS), Platform.WatchOS, true));
 							break;
 					}
 					data.project = GetProjectPath (projectDefinition.Name, appType);
@@ -494,7 +510,7 @@ namespace BCLTestImporter {
 
 				var projectTemplatePath = Path.Combine (ProjectTemplateRootPath, projectTemplateMatches[platform]);
 				var generatedProject = await GenerateAsync (projectDefinition.Name, registerTypePath,
-					projectDefinition.GetCachedAssemblyInclusionInformation (MonoRootPath, platform), projectTemplatePath, infoPlistPath);
+					projectDefinition.GetAssemblyInclusionInformation (GetReleaseDownload (platform), platform, true), projectTemplatePath, infoPlistPath);
 				var projectPath = GetProjectPath (projectDefinition.Name, platform);
 				projectPaths.Add ((name: projectDefinition.Name, path: projectPath, xunit: projectDefinition.IsXUnit));
 				using (var file = new StreamWriter (projectPath, false)) { // false is do not append
@@ -773,11 +789,12 @@ namespace BCLTestImporter {
 		/// </summary>
 		/// <param name="missingAssemblies"></param>
 		/// <returns></returns>
-		public bool AllTestAssembliesAreRan (out Dictionary<Platform, List<string>> missingAssemblies)
+		public bool AllTestAssembliesAreRan (out Dictionary<Platform, List<string>> missingAssemblies, bool wasDownloaded)
 		{
 			missingAssemblies = new Dictionary<Platform, List<string>> ();
 			foreach (var platform in new [] {Platform.iOS, Platform.TvOS}) {
-				var testDir = BCLTestAssemblyDefinition.GetTestDirectory (MonoRootPath, platform); 
+				var testDir = wasDownloaded ? BCLTestAssemblyDefinition.GetTestDirectoryFromMonoPath (MonoRootPath, platform)
+					: BCLTestAssemblyDefinition.GetTestDirectoryFromDownloadsPath (GetReleaseDownload (platform), platform); 
 				var missingAssembliesPlatform = Directory.GetFiles (testDir, NUnitPattern).Select (Path.GetFileName).Union (
 					Directory.GetFiles (testDir, xUnitPattern).Select (Path.GetFileName)).ToList ();
 				

--- a/tools/bcl-test-importer/BCLTestImporter/Program.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/Program.cs
@@ -200,7 +200,7 @@ namespace BCLTestImporter {
 					var projectGenerator = new BCLTestProjectGenerator (appOptions.Output, appOptions.MonoPath,
 						appOptions.ProjectTemplate, appOptions.RegisterTypeTemplate, appOptions.PlistTemplate);
 					outputWriter.WriteLine ("Verifying if all the test assemblies have been added.");
-					if (!appOptions.IgnoreMissingAssemblies && !projectGenerator.AllTestAssembliesAreRan (out var missingAssemblies)) {
+					if (!appOptions.IgnoreMissingAssemblies && !projectGenerator.AllTestAssembliesAreRan (out var missingAssemblies, true)) {
 						outputWriter.WriteLine ("The following test assemblies should be added to a test project or ignored.");
 						foreach (var platform in missingAssemblies.Keys) {
 							outputWriter.WriteLine ($"Platform {platform}");

--- a/tools/bcl-test-importer/BCLTestImporter/RegisterTypeGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/RegisterTypeGenerator.cs
@@ -15,25 +15,6 @@ namespace BCLTestImporter {
 		
 		// the following cache is a workaround until mono does provide the required binaries precompiled, at that point
 		// we will remove the dict and we will use the refection based method.
-		static Dictionary<string, (string testNamespace, string testAssembly, string testType)> iOSCache = new Dictionary<string, (string testNamespace, string testAssembly, string testType)> {
-			{"SystemNumericsTests", ("MonoTests.System.Numerics",  "MONOTOUCH_System.Numerics_test.dll", "MonoTests.System.Numerics.BigIntegerTest")},
-			{"SystemRuntimeSerializationTests", ("MonoTests", "MONOTOUCH_System.Runtime.Serialization_test.dll", "MonoTests.XmlComparer")},
-			{"SystemXmlLinqTests", ("MonoTests.System.Xml", "MONOTOUCH_System.Xml.Linq_test.dll", "MonoTests.System.Xml.ExtensionsTest")},
-			{"MonoSecurityTests", ("MonoTests.System.Security.Cryptography", "MONOTOUCH_Mono.Security_test.dll", "MonoTests.System.Security.Cryptography.SHA224ManagedTest")},
-			{"SystemComponentModelDataAnnotationTests", ("MonoTests.System.ComponentModel.DataAnnotations", "MONOTOUCH_System.ComponentModel.DataAnnotations_test.dll", "MonoTests.System.ComponentModel.DataAnnotations.AssociationAttributeTest")},
-			{"SystemJsonTests", ("MonoTests.System", "MONOTOUCH_System.Json_test.dll", "MonoTests.System.JsonValueTests")},
-			{"MonoDataTdsTests", ("MonoTests.Mono.Data.Tds", "MONOTOUCH_Mono.Data.Tds_test.dll", "MonoTests.Mono.Data.Tds.TdsConnectionPoolTest")},
-			{"MonoCSharpTests", ("MonoTests.Visit", "MONOTOUCH_Mono.CSharp_test.dll", "MonoTests.Visit.ASTVisitorTest")},
-			{"SystemJsonMicrosoftTests", ("MonoTests.System", "MONOTOUCH_System.Json.Microsoft_test.dll", "MonoTests.System.JsonValueTests")},
-			{"MonoParallelTests", ("MonoTests.Mono.Threading", "MONOTOUCH_Mono.Parallel_test.dll", "MonoTests.Mono.Threading.SnziTests")},
-			{"MonoTaskletsTests", ("MonoTests.System", "MONOTOUCH_Mono.Tasklets_test.dll", "MonoTests.System.ContinuationsTest")},
-			{"SystemThreadingTasksDataflowTests", ("MonoTests", "MONOTOUCH_System.Threading.Tasks.Dataflow_test.dll", "MonoTests.TestScheduler")},
-			{"SystemJsonXunit", ("System.Json.Tests", "MONOTOUCH_System.Json_xunit-test.dll", "System.Json.Tests.JsonArrayTests")},
-			{"SystemNumericsXunit", ("System.Numerics.Tests", "MONOTOUCH_System.Numerics_xunit-test.dll", "System.Numerics.Tests.GenericVectorTests")},
-			{"SystemLinqXunit", ("Microsoft.Test.ModuleCore", "MONOTOUCH_System.Xml.Linq_xunit-test.dll", "Microsoft.Test.ModuleCore.LtmContext")},
-			{"SystemRuntimeCompilerServicesUnsafeXunit", ("System.Runtime.CompilerServices", "MONOTOUCH_System.Runtime.CompilerServices.Unsafe_xunit-test.dll", "System.Runtime.CompilerServices.UnsafeTests")},
-		};
-		
 		static Dictionary<string, (string testNamespace, string testAssembly, string testType)> macCache = new Dictionary<string, (string testNamespace, string testAssembly, string testType)> {
 			{"MonoCSharpTests", ("MonoTests.Visit",  "xammac_net_4_5_Mono.CSharp_test.dll", "MonoTests.Visit.ASTVisitorTest")},
 			{"MonoDataSqilteTests", ("MonoTests.Mono.Data.Sqlite",  "xammac_net_4_5_Mono.Data.Sqlite_test.dll", "MonoTests.Mono.Data.Sqlite.SqliteiOS82BugTests")},
@@ -77,8 +58,7 @@ namespace BCLTestImporter {
 			case Platform.iOS:
 			case Platform.TvOS:
 			case Platform.WatchOS:
-				cache = iOSCache;
-				break;
+				throw new InvalidOperationException ("All iOS projects should be using the sdk test assemblies and not compile them.");
 			case Platform.MacOSFull:
 			case Platform.MacOSModern:
 				cache = macCache;


### PR DESCRIPTION
We now download the ios Mono sdk which means that there is no need for
us to build the test assemblies on iOS, WatchOS and tvOS BUT we need to
do so for the Mac tests.

The change includes:
  1. Use fo the downloaded test assemblies.
  2. Removal of the dependency of building them in the tests.
  3. Move back to using reflection for the project generation.
  4. Remove the cached project details added in the workaround.

PS: Assemblies use lower case in the SDK and some tests had to be updated.