### PR TITLE
[msbuild] Find source files in the Xamarin.MacDev repo as well to improve dependency tracking.

### DIFF
--- a/msbuild/Makefile
+++ b/msbuild/Makefile
@@ -20,7 +20,7 @@ MSBUILD_DIRECTORIES          =
 MSBUILD_SYMLINKS             =
 MSBUILD_TASK_ASSEMBLIES      =
 
-ALL_SOURCES:= $(shell git ls-files | sed 's/ /\\ /g')
+ALL_SOURCES:= $(shell git ls-files | sed 's/ /\\ /g') $(wildcard $(XAMARIN_MACDEV_PATH)/Xamarin.MacDev/*.cs) $(wildcard $(XAMARIN_MACDEV_PATH)/Xamarin.MacDev/*.csproj)
 CONFIG      = Debug
 
 ##


### PR DESCRIPTION
This makes 'make' rebuild the msbuild assemblies when only something in the
Xamarin.MacDev repository changes.