### PR TITLE
[d15-9] Bump Xamarin.MacDev to get fix for #5277.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 [submodule "external/Xamarin.MacDev"]
     path = external/Xamarin.MacDev
     url = ../../xamarin/Xamarin.MacDev
-    branch = d15-9
+    branch = xamarin-macios-5277-d15-9
 [submodule "external/macios-binaries"]
     path = external/macios-binaries
     url = ../../xamarin/macios-binaries


### PR DESCRIPTION
Bump Xamarin.MacDev to get fix for #5277, and use a custom Xamarin.MacDev
branch to only get this commit from Xamarin.MacDev.

Commit list for xamarin/Xamarin.MacDev:

* xamarin/Xamarin.MacDev@9b55404 Keys in property list dictionaries aren't necessarily unique. Fixes xamarin-macios#5277.

Diff: https://github.com/xamarin/Xamarin.MacDev/compare/39ea45bad4eb85358467b9f316fa6b30aa223e9c...9b554042be42c0d49fbbfb714993faabdadfc864

Fixes https://github.com/xamarin/xamarin-macios/issues/5277.