### PR TITLE
Update binding_types_reference_guide.md

### DIFF
--- a/docs/website/binding_types_reference_guide.md
+++ b/docs/website/binding_types_reference_guide.md
@@ -1473,7 +1473,7 @@ managed exceptions.
 
 Currently only a few `objc_msgSend` signatures are supported (you will find out
 if a signature isn't supported when native linking of an app that uses the
-binding fails with a missing monotouch_*_objc_msgSend* symbol), but more can be
+binding fails with a missing xamarin_*_objc_msgSend* symbol), but more can be
 added at request.
 
 


### PR DESCRIPTION
Fix function name to match code - trampolines in runtime code are prefixed with `xamarin` since the unification of Xamarin.iOS and Xamarin.Mac.