### PR TITLE
[ObjCRuntime] Verify the system mono version at launch.

### DIFF
--- a/src/Constants.mac.cs.in
+++ b/src/Constants.mac.cs.in
@@ -33,6 +33,7 @@ namespace MonoMac {
 		public const string Version = "@VERSION@";
 		internal const string Revision = "@REVISION@";
 		public const string SdkVersion = "@OSX_SDK_VERSION@";
+		internal const string MinMonoVersion = "@MIN_XM_MONO_VERSION@";
 
 		public const string AddressBookLibrary = "/System/Library/Frameworks/AddressBook.framework/AddressBook";
 		public const string AppKitLibrary = "/System/Library/Frameworks/AppKit.framework/AppKit";

--- a/src/Makefile
+++ b/src/Makefile
@@ -413,6 +413,7 @@ $(MAC_BUILD_DIR)/Constants.cs: Constants.mac.cs.in Makefile $(TOP)/Make.config.i
 			-e "s/@VERSION@/$(MAC_PACKAGE_VERSION_MAJOR).$(MAC_PACKAGE_VERSION_MINOR).$(MAC_PACKAGE_VERSION_REV)/g" \
 			-e 's/@REVISION@/$(MAC_COMMIT_DISTANCE) ($(CURRENT_BRANCH_SED_ESCAPED): $(shell git log -1 --pretty=%h))/g' \
 			-e "s/@OSX_SDK_VERSION@/$(OSX_SDK_VERSION)/g" \
+			-e "s/@MIN_XM_MONO_VERSION@/$(MIN_XM_MONO_VERSION)/g" \
 		$< > $@
 
 $(PROJECT_DIR)/xammac.csproj: xammac.tmpl.csproj Makefile $(wildcard $(TOP)/src/*.sources)


### PR DESCRIPTION
This makes Visual Studio for Mac show a better error message when the system mono is too old:

    FATAL ERROR [2018-12-19 08:07:50Z]: Visual Studio failed to start. Some of the assemblies required to run Visual Studio (for example gtk-sharp)may not be properly installed in the GAC.
    System.Exception: Toolkit could not be loaded ---> System.NotSupportedException: This version of Xamarin.Mac requires Mono 5.18.0.185, but found Mono 5.16.0.209.
      at ObjCRuntime.Runtime.VerifyMonoVersion () [0x000b4] in /work/maccore/master/xamarin-macios/src/ObjCRuntime/Runtime.mac.cs:150
      at ObjCRuntime.Runtime.EnsureInitialized () [0x00030] in /work/maccore/master/xamarin-macios/src/ObjCRuntime/Runtime.mac.cs:117
      at AppKit.NSApplication.Init () [0x00016] in /work/maccore/master/xamarin-macios/src/AppKit/NSApplication.cs:56
      at Xwt.Mac.NSApplicationInitializer.Initialize () [0x00051] in /work/monodevelop/monodevelop/main/external/xwt/Xwt.XamMac/Xwt.Mac/NSApplicationInitializer.cs:44
      at Xwt.Mac.MacEngine.InitializeApplication () [0x00001] in /work/monodevelop/monodevelop/main/external/xwt/Xwt.XamMac/Xwt.Mac/MacEngine.cs:48

instead of (from https://github.com/mono/monodevelop/issues/6779):

    FATAL ERROR [2018-12-17 14:05:44Z]: Visual Studio failed to start. Some of the assemblies required to run Visual Studio (for example gtk-sharp)may not be properly installed in the GAC.
    System.Exception: Toolkit could not be loaded ---> System.NullReferenceException: Object reference not set to an instance of an object
      at (wrapper managed-to-native) System.Object.wrapper_native_0x102f47470()
      at ObjCRuntime.Runtime.EnsureInitialized () [0x00041] in /Library/Frameworks/Xamarin.Mac.framework/Versions/5.6.0.1/src/Xamarin.Mac/ObjCRuntime/Runtime.mac.cs:118
      at AppKit.NSApplication.Init () [0x00016] in /Library/Frameworks/Xamarin.Mac.framework/Versions/5.6.0.1/src/Xamarin.Mac/AppKit/NSApplication.cs:56
      at Xwt.Mac.NSApplicationInitializer.Initialize () [0x00046] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/external/xwt/Xwt.XamMac/Xwt.Mac/NSApplicationInitializer.cs:44
      at Xwt.Mac.MacEngine.InitializeApplication () [0x00000] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/external/xwt/Xwt.XamMac/Xwt.Mac/MacEngine.cs:48