### PR TITLE
[msbuild] Declare which frameworks XStaticArTest.framework and XStaticObjectTest.framework need.

### DIFF
--- a/msbuild/tests/MyiOSFrameworkBinding/MyiOSFrameworkBinding.csproj
+++ b/msbuild/tests/MyiOSFrameworkBinding/MyiOSFrameworkBinding.csproj
@@ -46,10 +46,12 @@
       <Kind>Framework</Kind>
       <Link>XStaticObjectTest.framework</Link>
       <LinkerFlags>-lz</LinkerFlags>
+      <Frameworks>Foundation ModelIO</Frameworks>
     </NativeReference>
     <NativeReference Include="..\..\..\tests\test-libraries\.libs\ios\XStaticArTest.framework">
       <Kind>Framework</Kind>
       <Link>XStaticArTest.framework</Link>
+      <Frameworks>Foundation ModelIO</Frameworks>
     </NativeReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes these test failures:

```
Xamarin.iOS.Tasks.NativeReferencesNoEmbedding("iPhone").FrameworksEmbeddedProperly(True): #RunTarget-ErrorCount
        linker command failed with exit code 1 (use -v to see invocation)
        Native linking failed, undefined Objective-C class: MDLTransform. The symbol '_OBJC_CLASS_$_MDLTransform' could not be found in any of the libraries or frameworks linked with your application.
        Native linking failed. Please review the build log.
    Expected: 0
    But was: 3

Xamarin.iOS.Tasks.NativeReferencesNoEmbedding("iPhone").ShouldNotUnnecessarilyRebuildFinalProject(True): #RunTarget-ErrorCount
        linker command failed with exit code 1 (use -v to see invocation)
        Native linking failed, undefined Objective-C class: MDLTransform. The symbol '_OBJC_CLASS_$_MDLTransform' could not be found in any of the libraries or frameworks linked with your application.
        Native linking failed. Please review the build log.
    Expected: 0
    But was: 3
```

Fixes: https://github.com/xamarin/maccore/issues/1289