### PR TITLE
[msbuild] Sleep before and after touching files on non-APFS file systems.

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/CodesignAppBundle.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/CodesignAppBundle.cs
@@ -76,7 +76,7 @@ namespace Xamarin.iOS.Tasks
 				appexDsymTimestamps = Directory.EnumerateFiles (appexDsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
 			}
 
-			Thread.Sleep (1000);
+			EnsureFilestampChange ();
 
 			// Rebuild w/ no changes
 			BuildProject ("MyTabbedApplication", Platform, config, clean: false);
@@ -130,7 +130,7 @@ namespace Xamarin.iOS.Tasks
 
 			AssertProperlyCodesigned (expectedCodesignResults);
 
-			Thread.Sleep (1000);
+			EnsureFilestampChange ();
 
 			// replace "bool imageFound = false;" with "bool imageFound = true;" so that we force the appex to get rebuilt
 			text = text.Replace ("bool imageFound = false;", "bool imageFound = true;");
@@ -160,7 +160,7 @@ namespace Xamarin.iOS.Tasks
 
 			AssertProperlyCodesigned (expectedCodesignResults);
 
-			Thread.Sleep (1000);
+			EnsureFilestampChange ();
 
 			// Rebuild w/ no changes
 			BuildProject ("MyWatch2Container", Platform, config, clean: false);
@@ -183,7 +183,7 @@ namespace Xamarin.iOS.Tasks
 
 			AssertProperlyCodesigned (expectedCodesignResults);
 
-			Thread.Sleep (1000);
+			EnsureFilestampChange ();
 
 			// replace "bool imageFound = false;" with "bool imageFound = true;" so that we force the appex to get rebuilt
 			text = text.Replace ("{0} awake with context", "{0} The Awakening...");

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/CoreMLCompiler.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/CoreMLCompiler.cs
@@ -38,7 +38,7 @@ namespace Xamarin.iOS.Tasks
 
 			AssertCompiledModelExists ("SqueezeNet");
 
-			Thread.Sleep (1000);
+			EnsureFilestampChange ();
 
 			// Rebuild w/ no changes
 			BuildProject ("MyCoreMLApp", Platform, "Debug", clean: false);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ReleaseBuild.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/ReleaseBuild.cs
@@ -33,7 +33,7 @@ namespace Xamarin.iOS.Tasks
 			var timestamps = Directory.EnumerateFiles (AppBundlePath, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
 			var dsymTimestamps = Directory.EnumerateFiles (dsymDir, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
 
-			Thread.Sleep (1000);
+			EnsureFilestampChange ();
 
 			// Rebuild w/ no changes
 			BuildProject ("MyReleaseBuild", Platform, "Release", clean: false);
@@ -47,7 +47,7 @@ namespace Xamarin.iOS.Tasks
 			foreach (var file in dsymTimestamps.Keys)
 				Assert.AreEqual (dsymTimestamps[file], newDSymTimestamps[file], "#2: " + file);
 
-			Thread.Sleep (1000);
+			EnsureFilestampChange ();
 
 			// Rebuild after changing MtouchUseLlvm
 			File.Copy (csproj, bak, true);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
@@ -270,11 +270,11 @@ namespace Xamarin.iOS.Tasks
 			// all the input files into the temporary directory. This means that any timestamps modified as
 			// part of the original build will definitely be newer than the timestamps written during the
 			// execution of the test fixture 'setup' method.
-			Thread.Sleep (1000);
+			EnsureFilestampChange ();
 			RunTarget (MonoTouchProject, TargetName.Build);
 			var timestamps = Directory.EnumerateFiles (AppBundlePath, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
 
-			Thread.Sleep (1000);
+			EnsureFilestampChange ();
 			RunTarget (MonoTouchProject, TargetName.Build);
 			var newTimestamps = Directory.EnumerateFiles (AppBundlePath, "*.*", SearchOption.AllDirectories).ToDictionary (file => file, file => GetLastModified (file));
 
@@ -304,7 +304,7 @@ namespace Xamarin.iOS.Tasks
 			RunTarget (LibraryProject, TargetName.Build);
 			var timestamp = GetLastModified (libraryPath);
 
-			Thread.Sleep (1000);
+			EnsureFilestampChange ();
 			RunTarget (LibraryProject, TargetName.Build);
 			Assert.AreEqual (timestamp, GetLastModified (libraryPath));
 		}
@@ -496,7 +496,7 @@ namespace Xamarin.iOS.Tasks
 			projectInstance = project.CreateProjectInstance ();
 
 			// Put a thread.sleep so that we get noticeable timestamps.
-			Thread.Sleep (1000);
+			EnsureFilestampChange ();
 
 			// Re-save the original plist (adding app icon).
 			plistCopy.Save (path, true);

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Utilities;
@@ -331,7 +332,29 @@ namespace Xamarin.iOS.Tasks
 		{
 			if (!File.Exists (file))
 				Assert.Fail ("Expected file '{0}' did not exist", file);
+			EnsureFilestampChange ();
 			File.SetLastWriteTimeUtc (file, DateTime.UtcNow);
+			EnsureFilestampChange ();
+		}
+
+		static bool? is_apfs;
+		public static bool IsAPFS {
+			get {
+				if (!is_apfs.HasValue) {
+					var exit_code = ExecutionHelper.Execute ("/bin/df", "-t apfs /", out var output, TimeSpan.FromSeconds (10));
+					if (exit_code != 0)
+						throw new Exception ($"Could not determine whether / is APFS or not. 'df -t apfs /' returned {exit_code} and said: {output}");
+					is_apfs = output.Trim ().Split ('\n').Length >= 2;
+				}
+				return is_apfs.Value;
+			}
+		}
+
+		public static void EnsureFilestampChange ()
+		{
+			if (IsAPFS)
+				return;
+			Thread.Sleep (1000);
 		}
 
 		public void RunTarget (Project project, string target, int expectedErrorCount = 0)


### PR DESCRIPTION
Hopefully fixes these tests:

    Xamarin.iOS.Tasks.TargetTests.RebuildLibrary_TouchBundleResource: Expected: not 2018-12-18 17:15:05.000
    But was: 2018-12-18 17:15:05.000

    Xamarin.iOS.Tasks.TargetTests.RebuildLibrary_TouchEmbeddedResource: Expected: not 2018-12-18 17:15:07.000
    But was: 2018-12-18 17:15:07.000

    Xamarin.iOS.Tasks.TargetTests.RebuildLibrary_TouchStoryboard: Expected: not 2018-12-18 17:15:09.000
    But was: 2018-12-18 17:15:09.000

Additionally change existing sleeping code to not sleep when running on APFS.
Should make test runs slightly faster.

Fixes https://github.com/xamarin/maccore/issues/1291.