### PR TITLE
[coretext] Update CTRunDelegate to work on 64 bits. Fixes #5132

### DIFF
--- a/src/CoreText/CTRunDelegate.cs
+++ b/src/CoreText/CTRunDelegate.cs
@@ -37,9 +37,9 @@ namespace CoreText {
 
 #region Run Delegate Callbacks
 	delegate void CTRunDelegateDeallocateCallback (IntPtr refCon);
-	delegate float CTRunDelegateGetAscentCallback (IntPtr refCon);
-	delegate float CTRunDelegateGetDescentCallback (IntPtr refCon);
-	delegate float CTRunDelegateGetWidthCallback (IntPtr refCon);
+	delegate nfloat CTRunDelegateGetAscentCallback (IntPtr refCon);
+	delegate nfloat CTRunDelegateGetDescentCallback (IntPtr refCon);
+	delegate nfloat CTRunDelegateGetWidthCallback (IntPtr refCon);
 
 	[StructLayout (LayoutKind.Sequential)]
 	class CTRunDelegateCallbacks {
@@ -88,6 +88,22 @@ namespace CoreText {
 		}
 #endif
 
+#if XAMCORE_4_0
+		public virtual nfloat GetAscent ()
+		{
+			return 0;
+		}
+
+		public virtual nfloat GetDescent ()
+		{
+			return 0;
+		}
+
+		public virtual nfloat GetWidth ()
+		{
+			return 0;
+		}
+#else
 		public virtual float GetAscent ()
 		{
 			return 0.0f;
@@ -102,6 +118,7 @@ namespace CoreText {
 		{
 			return 0.0f;
 		}
+#endif
 
 		internal CTRunDelegateCallbacks GetCallbacks ()
 		{
@@ -151,30 +168,30 @@ namespace CoreText {
 		}
 
 		[MonoPInvokeCallback (typeof (CTRunDelegateGetAscentCallback))]
-		static float GetAscent (IntPtr refCon)
+		static nfloat GetAscent (IntPtr refCon)
 		{
 			var self = GetOperations (refCon);
 			if (self == null)
-				return 0.0f;
-			return self.GetAscent ();
+				return 0;
+			return (nfloat) self.GetAscent ();
 		}
 
 		[MonoPInvokeCallback (typeof (CTRunDelegateGetDescentCallback))]
-		static float GetDescent (IntPtr refCon)
+		static nfloat GetDescent (IntPtr refCon)
 		{
 			var self = GetOperations (refCon);
 			if (self == null)
-				return 0.0f;
-			return self.GetDescent ();
+				return 0;
+			return (nfloat) self.GetDescent ();
 		}
 
 		[MonoPInvokeCallback (typeof (CTRunDelegateGetWidthCallback))]
-		static float GetWidth (IntPtr refCon)
+		static nfloat GetWidth (IntPtr refCon)
 		{
 			var self = GetOperations (refCon);
 			if (self == null)
-				return 0.0f;
-			return self.GetWidth ();
+				return 0;
+			return (nfloat) self.GetWidth ();
 		}
 	}
 

--- a/tests/monotouch-test/CoreText/RunTest.cs
+++ b/tests/monotouch-test/CoreText/RunTest.cs
@@ -1,9 +1,10 @@
-﻿using System;
+﻿#if !__WATCHOS__
+
+using System;
 
 using CoreGraphics;
 using CoreText;
 using Foundation;
-using UIKit;
 
 using NUnit.Framework;
 using MonoTouchFixtures.CoreGraphics;
@@ -74,3 +75,5 @@ namespace MonoTouchFixtures.CoreText {
 		}
 	}
 }
+
+#endif

--- a/tests/monotouch-test/CoreText/RunTest.cs
+++ b/tests/monotouch-test/CoreText/RunTest.cs
@@ -1,0 +1,76 @@
+﻿using System;
+
+using CoreGraphics;
+using CoreText;
+using Foundation;
+using UIKit;
+
+using NUnit.Framework;
+using MonoTouchFixtures.CoreGraphics;
+
+namespace MonoTouchFixtures.CoreText {
+
+	class MyOps : CTRunDelegateOperations {
+
+		static public bool Ascent;
+		static public bool Descent;
+		static public bool Width;
+
+		public MyOps ()
+		{
+			// to re-run the test
+			Ascent = false;
+			Descent = false;
+			Width = false;
+		}
+
+		public override float GetAscent ()
+		{
+			Ascent = true;
+			return base.GetAscent ();
+		}
+
+		public override float GetDescent ()
+		{
+			Descent = true;
+			return base.GetDescent ();
+		}
+
+		public override float GetWidth ()
+		{
+			Width = true;
+			return base.GetWidth ();
+		}
+	}
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class RunTest {
+
+		[Test]
+		public void CustomOps ()
+		{
+			using (var o = new MyOps ())
+			using (var d = new CTRunDelegate (o)) {
+				Assert.AreSame (o, d.Operations, "same");
+			}
+		}
+
+		[Test]
+		public void Runs ()
+		{
+			using (var mas = new NSMutableAttributedString ("Bonjour"))
+			using (var rd = new CTRunDelegate (new MyOps ())) {
+				var sa = new CTStringAttributes () {
+					RunDelegate = rd,
+				};
+				mas.SetAttributes (sa, new NSRange (3, 3));
+				using (var fs = new CTFramesetter (mas)) {
+					Assert.True (MyOps.Ascent, "Ascent called");
+					Assert.True (MyOps.Descent, "Descent called");
+					Assert.True (MyOps.Width, "Width called");
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Basic fix that does not require a breaking change.

It's _basic_ as it does not fix the performance comments made inside
the issue. Those are different (not a bug, an enhancement) and I'll
file a separate issue to track this.

Reference: https://github.com/xamarin/xamarin-macios/issues/5132