### PR TITLE
[jenkins] Improve rendering of failures on older macOS bots.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -697,9 +697,7 @@ timestamps {
                                                     }
                                                 } catch (err) {
                                                     currentStage = "Running XM tests on '10.${macOS}'"
-                                                    def msg = err.getMessage ();
-                                                    if (msg == "")
-                                                        msg = "Xamarin.Mac tests on 10.${macOS} failed"
+                                                    def msg = "Xamarin.Mac tests on 10.${macOS} failed: " + err.getMessage ();
                                                     appendFileComment ("🔥 [${msg}](${env.RUN_DISPLAY_URL}) 🔥\n")
                                                     failedStages.add (currentStage)
                                                     throw err


### PR DESCRIPTION
Improve rendering of failures on older macOS bots by showing which bot things
failed on in the commit comment.

Before:

![screenshot 2018-12-19 17 25 50](https://user-images.githubusercontent.com/249268/50233197-33869c80-03b3-11e9-9e76-e6c98ba2a299.png)

After:

![screenshot 2018-12-19 17 26 09](https://user-images.githubusercontent.com/249268/50233202-34b7c980-03b3-11e9-8245-03df686d3c60.png)