### PR TITLE
[msbuild] Fixes incremental build issues with frameworks from VS

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/UnpackLibraryResourcesTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/UnpackLibraryResourcesTaskBase.cs
@@ -10,7 +10,7 @@ namespace Xamarin.MacDev.Tasks
 {
 	public abstract class UnpackLibraryResourcesTaskBase : Task
 	{
-		List<ITaskItem> unpackedResources = new List<ITaskItem>();
+		List<ITaskItem> unpackedResources = new List<ITaskItem> ();
 		
 		#region Inputs
 
@@ -83,7 +83,7 @@ namespace Xamarin.MacDev.Tasks
 			}
 
 			BundleResourcesWithLogicalNames = results.ToArray ();
-			UnpackedResources = unpackedResources.ToArray();
+			UnpackedResources = unpackedResources.ToArray ();
 
 			return !Log.HasLoggedErrors;
 		}
@@ -123,9 +123,9 @@ namespace Xamarin.MacDev.Tasks
 				var path = Path.Combine (intermediatePath, rpath);
 				var file = new FileInfo (path);
 
-				var item = new TaskItem(path);
-				item.SetMetadata("LogicalName", rpath);
-				item.SetMetadata("Optimize", "false");
+				var item = new TaskItem (path);
+				item.SetMetadata ("LogicalName", rpath);
+				item.SetMetadata ("Optimize", "false");
 
 				if (file.Exists && file.LastWriteTimeUtc >= asmWriteTime) {
 					Log.LogMessage ("    Up to date: {0}", rpath);
@@ -139,7 +139,7 @@ namespace Xamarin.MacDev.Tasks
 							resource.CopyTo (stream);
 					}
 
-					unpackedResources.Add(item);
+					unpackedResources.Add (item);
 				}
 
 				yield return item;

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -684,30 +684,30 @@ namespace Xamarin.iOS.Tasks
 
 			Directory.CreateDirectory (AppBundleDir);
 
-			var result = base.Execute();
+			var result = base.Execute ();
 
-			CopiedFrameworks = GetCopiedFrameworks();
+			CopiedFrameworks = GetCopiedFrameworks ();
 
 			return result;
 		}
 
-		ITaskItem[] GetCopiedFrameworks()
+		ITaskItem[] GetCopiedFrameworks ()
 		{
-			var copiedFrameworks = new List<ITaskItem>();
-			var frameworksDir = Path.Combine(AppBundleDir, "Frameworks");
+			var copiedFrameworks = new List<ITaskItem> ();
+			var frameworksDir = Path.Combine (AppBundleDir, "Frameworks");
 
-			if (Directory.Exists(frameworksDir))
+			if (Directory.Exists (frameworksDir))
 			{
-				foreach (var dir in Directory.EnumerateDirectories(frameworksDir, "*.framework"))
+				foreach (var dir in Directory.EnumerateDirectories (frameworksDir, "*.framework"))
 				{
-					var framework = Path.Combine(dir, Path.GetFileNameWithoutExtension(dir));
+					var framework = Path.Combine (dir, Path.GetFileNameWithoutExtension (dir));
 
-					if (File.Exists(framework))
-						copiedFrameworks.Add(new TaskItem(framework));
+					if (File.Exists (framework))
+						copiedFrameworks.Add (new TaskItem (framework));
 				}
 			}
 
-			return copiedFrameworks.ToArray();
+			return copiedFrameworks.ToArray ();
 		}
 
 		string ResolveFrameworkFile (string fullName)

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -696,10 +696,8 @@ namespace Xamarin.iOS.Tasks
 			var copiedFrameworks = new List<ITaskItem> ();
 			var frameworksDir = Path.Combine (AppBundleDir, "Frameworks");
 
-			if (Directory.Exists (frameworksDir))
-			{
-				foreach (var dir in Directory.EnumerateDirectories (frameworksDir, "*.framework"))
-				{
+			if (Directory.Exists (frameworksDir)) {
+				foreach (var dir in Directory.EnumerateDirectories (frameworksDir, "*.framework")) {
 					var framework = Path.Combine (dir, Path.GetFileNameWithoutExtension (dir));
 
 					if (File.Exists (framework))

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -180,6 +180,9 @@ namespace Xamarin.iOS.Tasks
 		[Output]
 		public ITaskItem NativeExecutable { get; set; }
 
+		[Output]
+		public ITaskItem[] CopiedFrameworks { get; set; }
+
 		#endregion
 
 		public PlatformFramework Framework {
@@ -681,7 +684,30 @@ namespace Xamarin.iOS.Tasks
 
 			Directory.CreateDirectory (AppBundleDir);
 
-			return base.Execute ();
+			var result = base.Execute();
+
+			CopiedFrameworks = GetCopiedFrameworks();
+
+			return result;
+		}
+
+		ITaskItem[] GetCopiedFrameworks()
+		{
+			var copiedFrameworks = new List<ITaskItem>();
+			var frameworksDir = Path.Combine(AppBundleDir, "Frameworks");
+
+			if (Directory.Exists(frameworksDir))
+			{
+				foreach (var dir in Directory.EnumerateDirectories(frameworksDir, "*.framework"))
+				{
+					var framework = Path.Combine(dir, Path.GetFileNameWithoutExtension(dir));
+
+					if (File.Exists(framework))
+						copiedFrameworks.Add(new TaskItem(framework));
+				}
+			}
+
+			return copiedFrameworks.ToArray();
 		}
 
 		string ResolveFrameworkFile (string fullName)


### PR DESCRIPTION
Backport https://github.com/xamarin/xamarin-macios/pull/5249

Partial fix for bug 662636 - *.dylib libraries are signed during full rebuild, but not the second time

https://devdiv.visualstudio.com/DevDiv/_queries/edit/662636

There were two problems:
- VS was creating/touching each bundle resource found even if the resource wasn't unpacked on the Mac because the file was up to date. This caused the files on Windows to be changed on each build.
- VS was not updating the framework files in the app bundle on incremental builds because the MTouch didn't have an output property informing the frameworks that were copied by mtouch into the app bundle. This caused MSBuild to skip the CodesignFramework target because the frameworks remained unchanged on Windows.