### PR TITLE
[mtouch] Ignore linker warnings about our own libraries being built for iOS 7.0 when deployment target is iOS 6.0. Fixes #5092.

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1868,6 +1868,9 @@ namespace Xamarin.Bundler {
 					continue;
 				} else if (line.Contains ("was built for newer iOS version (5.1.1) than being linked (5.1)")) {
 					continue;
+				} else if (line.Contains ("was built for newer iOS version (7.0) than being linked (6.0)") && 
+					line.Contains (Driver.GetProductSdkDirectory (target.App))) {
+					continue;
 				}
 
 				if (line.Contains ("Undefined symbols for architecture")) {


### PR DESCRIPTION
Only the arm64 slice are built for iOS 7.0 (because that's when arm64 was
introduced), the arm7(s) slices are built for iOS 6.0, which means it's safe
to ignore this warning.

Fixes https://github.com/xamarin/xamarin-macios/issues/5092.