### PR TITLE
[d16-0] [foundation] Respect HttpClient.Timeout for NSUrlSessionHandler. Fix #5190

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -121,7 +121,18 @@ namespace Foundation {
 		readonly Dictionary<NSUrlSessionTask, InflightData> inflightRequests;
 		readonly object inflightRequestsLock = new object ();
 
-		public NSUrlSessionHandler () : this (NSUrlSessionConfiguration.DefaultSessionConfiguration)
+		static NSUrlSessionConfiguration CreateConfig ()
+		{
+			// we want the current (at the moment the instance creation is done) configuration defaults
+			var config = (NSUrlSessionConfiguration) NSUrlSessionConfiguration.DefaultSessionConfiguration.Copy ();
+			// but we want, by default, the timeout from HttpClient to have precedence over the one from NSUrlSession
+			// Double.MaxValue does not work, so default to 24 hours
+			config.TimeoutIntervalForRequest = 24 * 60 * 60;
+			config.TimeoutIntervalForResource = 24 * 60 * 60;
+			return config;
+		}
+
+		public NSUrlSessionHandler () : this (CreateConfig ())
 		{
 		}
 


### PR DESCRIPTION
When `HttpClient` is used it might not be possible to set custom
properties on the handler.

This PR avoids a fight between the `HttpClient.Timeout` and the ones that
`NSURLSession` provides - making its use, as default, working as expected

It is still possible to set those custom properties when creating the
`NSUrlSessionHandler` manually, so there's no loss of functionalities.

Adding a unit test would be tricky since it depends on external sites and
requires "enough" delays to trigger (both leading to false positives over
time).

Notes
* HttpClientHandler timeout is broken -> https://github.com/mono/mono/issues/12100
* CFNetworkHandler is broken when no data is received -> https://github.com/xamarin/xamarin-macios/issues/5289

Fixes https://github.com/xamarin/xamarin-macios/issues/5190

Backport of #5290.

/cc @spouliot 