### PR TITLE
[d16-0] [registrar] Throw EntryPointNotFoundException when generating P/Invoke wrappers for objc_msgSend*_stret on arm64. Fixes #5183.

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -4760,6 +4760,11 @@ namespace Registrar {
 				}
 				sb.WriteLine (")");
 				sb.WriteLine ("{");
+				if (is_stret) {
+					sb.StringBuilder.AppendLine ("#if defined (__arm64__)");
+					sb.WriteLine ("xamarin_process_managed_exception ((MonoObject *) mono_exception_from_name_msg (mono_get_corlib (), \"System\", \"EntryPointNotFoundException\", \"{0}\"));", pinfo.EntryPoint);
+					sb.StringBuilder.AppendLine ("#else");
+				}
 				sb.WriteLine ("@try {");
 				if (!isVoid || is_stret)
 					sb.Write ("return ");
@@ -4773,6 +4778,8 @@ namespace Registrar {
 				sb.WriteLine ("} @catch (NSException *exc) {");
 				sb.WriteLine ("xamarin_process_nsexception (exc);");
 				sb.WriteLine ("}");
+				if (is_stret)
+					sb.StringBuilder.AppendLine ("#endif /* defined (__arm64__) */");
 				sb.WriteLine ("}");
 				sb.WriteLine ();
 			} else {


### PR DESCRIPTION
objc_msgSend*_stret doesn't exist on arm64, so trying to call these functions
in our generated P/Invoke wrappers will result in a clang error:

    [...]/pinvokes.m:180:69: error: 'objc_msgSend_stret' is unavailable: not available in arm64 (TaskId:243)

So instead generate a call to throw an EntryPointNotFoundException (which is
exactly what would happen if we didn't generate the P/Invoke wrapper).

Fixes https://github.com/xamarin/xamarin-macios/issues/5183.

Backport of #5312.

/cc @rolfbjarne 