### PR TITLE
[d16-0] [foundation] Fix ICE in NSUrlSessionHandler.CreateConfig on macOS 10.9. Fixes #5309

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -123,8 +123,8 @@ namespace Foundation {
 
 		static NSUrlSessionConfiguration CreateConfig ()
 		{
-			// we want the current (at the moment the instance creation is done) configuration defaults
-			var config = (NSUrlSessionConfiguration) NSUrlSessionConfiguration.DefaultSessionConfiguration.Copy ();
+			// modifying the configuration does not affect future calls
+			var config = NSUrlSessionConfiguration.DefaultSessionConfiguration;
 			// but we want, by default, the timeout from HttpClient to have precedence over the one from NSUrlSession
 			// Double.MaxValue does not work, so default to 24 hours
 			config.TimeoutIntervalForRequest = 24 * 60 * 60;


### PR DESCRIPTION
For some reason (internal type?) OSX 10.9 does not return the expected
instance type when copied.

However it turns out that the copy is not required

> Modifying the returned session configuration object does not affect any
> configuration objects returned by future calls to this method, and does
> not change the default behavior for existing sessions. It is therefore
> always safe to use the returned object as a starting point for
> additional customization.

https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1411560-defaultsessionconfiguration?language=objc

So the simpler code should fix the issue.

https://github.com/xamarin/xamarin-macios/issues/5309

Backport of #5320.

/cc @spouliot 