### PR TITLE
[d15-9][mmp] Add support for mono 5.18 by pulling in libmono-system-native.a

### DIFF
--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1352,6 +1352,13 @@ namespace Xamarin.Bundler {
 
 					args.Append (StringUtils.Quote (lib)).Append (' ');
 
+					// libmono-system-native.a needs to be included if it exists in the mono in question
+					string libmonoNative =  Path.Combine (libdir, "libmono-system-native.a");
+					if (File.Exists (libmonoNative)) {
+						args.Append (StringUtils.Quote (libmonoNative)).Append (' ');
+						args.Append ("-u ").Append ("_SystemNative_RealPath").Append (' '); // This keeps libmono_system_native_la-pal_io.o symbols
+					}
+
 					if (profiling.HasValue && profiling.Value) {
 						args.Append (StringUtils.Quote (Path.Combine (libdir, "libmono-profiler-log.a"))).Append (' ');
 						args.Append ("-u _mono_profiler_init_log -lz ");


### PR DESCRIPTION
- https://github.com/xamarin/xamarin-macios/issues/5324
- Patch tweaked over multiple commits in master so applied directly instead of cherry-pick