### PR TITLE
Update NSUrlSessionHandler to cancel request if provided cancellationToken is already canceled.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -270,7 +270,6 @@ namespace Foundation {
 			
 			cancellationToken.Register (() => {
 				RemoveInflightData (dataTask);
-				dataTask?.Cancel ();
 				tcs.TrySetCanceled ();
 			});
 			

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -264,7 +264,7 @@ namespace Foundation {
 					});
 				}
 				
-				if (dataTask != null && dataTask.State == NSUrlSessionTaskState.Suspended)
+				if (dataTask.State == NSUrlSessionTaskState.Suspended)
 					dataTask.Resume ();
 			}
 			

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -253,7 +253,7 @@ namespace Foundation {
 
 			cancellationToken.Register (() => {
 				RemoveInflightData (dataTask);
-				dataTask?.Cancel();
+				dataTask?.Cancel ();
 				tcs.TrySetCanceled ();
 			});
 			


### PR DESCRIPTION
Update NSUrlSessionHandler to cancel request if provided cancellationToken is already canceled.

An already cancelled request is no more sent and the task nicely canceled.

It fix this issue xamarin#5333 on my tests.