### PR TITLE
[arkit] Fix crash in ARConfiguration.SupportedVideoFormats. Fixes #5347

### DIFF
--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -710,10 +710,17 @@ namespace ARKit {
 		[Export ("isSupported")]
 		bool IsSupported { get; }
 
+#if !XAMCORE_4_0
+		// even if static - it's abstract
 		[iOS (11,3)]
 		[Static]
-		[Export ("supportedVideoFormats")]
-		ARVideoFormat[] SupportedVideoFormats { get; }
+		[Obsolete ("This is an abstract static method. You need to call 'GetSupportedVideoFormats ()' from a subclass to get results.")]
+		ARVideoFormat[] SupportedVideoFormats {
+			// avoid the native exception leading to a crash
+			[Wrap ("Array.Empty<ARVideoFormat> ()")]
+			get;
+		}
+#endif
 
 		[iOS (11,3)]
 		[Export ("videoFormat", ArgumentSemantic.Strong)]
@@ -733,6 +740,11 @@ namespace ARKit {
 	[NoWatch, NoTV, NoMac]
 	[BaseType (typeof (ARConfiguration))]
 	interface ARWorldTrackingConfiguration {
+
+		[iOS (11,3)]
+		[Static]
+		[Export ("supportedVideoFormats")]
+		ARVideoFormat[] GetSupportedVideoFormats ();
 
 		[iOS (11,3)]
 		[Export ("autoFocusEnabled")]
@@ -766,6 +778,12 @@ namespace ARKit {
 	[NoWatch, NoTV, NoMac]
 	[BaseType (typeof(ARConfiguration))]
 	interface AROrientationTrackingConfiguration {
+
+		[iOS (11,3)]
+		[Static]
+		[Export ("supportedVideoFormats")]
+		ARVideoFormat[] GetSupportedVideoFormats ();
+
 		[iOS (11,3)]
 		[Export ("autoFocusEnabled")]
 		bool AutoFocusEnabled { [Bind ("isAutoFocusEnabled")] get; set; }
@@ -795,7 +813,12 @@ namespace ARKit {
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
 	[BaseType (typeof(ARConfiguration))]
-	interface ARFaceTrackingConfiguration {}
+	interface ARFaceTrackingConfiguration {
+		[iOS (11,3)]
+		[Static]
+		[Export ("supportedVideoFormats")]
+		ARVideoFormat[] GetSupportedVideoFormats ();
+	}
 
 	[iOS (11,0)]
 	[NoWatch, NoTV, NoMac]
@@ -1225,6 +1248,10 @@ namespace ARKit {
 	[NoWatch, NoTV, NoMac]
 	[BaseType (typeof(ARConfiguration))]
 	interface ARImageTrackingConfiguration {
+		[Static]
+		[Export ("supportedVideoFormats")]
+		ARVideoFormat[] GetSupportedVideoFormats ();
+
 		[Export ("autoFocusEnabled")]
 		bool AutoFocusEnabled { [Bind ("isAutoFocusEnabled")] get; set; }
 
@@ -1239,6 +1266,10 @@ namespace ARKit {
 	[NoWatch, NoTV, NoMac]
 	[BaseType (typeof(ARConfiguration))]
 	interface ARObjectScanningConfiguration {
+		[Static]
+		[Export ("supportedVideoFormats")]
+		ARVideoFormat[] GetSupportedVideoFormats ();
+
 		[Export ("autoFocusEnabled")]
 		bool AutoFocusEnabled { [Bind ("isAutoFocusEnabled")] get; set; }
 

--- a/tests/monotouch-test/ARKit/ARConfigurationTest.cs
+++ b/tests/monotouch-test/ARKit/ARConfigurationTest.cs
@@ -1,0 +1,47 @@
+﻿#if XAMCORE_2_0 && __IOS__
+
+using System;
+using System.Reflection;
+using ARKit;
+using Foundation;
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.ARKit {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class ARCondigurationTest {
+
+		[Test]
+		public void SupportedVideoFormats ()
+		{
+			var svf = ARConfiguration.SupportedVideoFormats;
+			Assert.That (svf, Is.Empty, "empty");
+		}
+
+		[Test]
+		public void GetSupportedVideoFormats ()
+		{
+			Assert.NotNull (ARWorldTrackingConfiguration.GetSupportedVideoFormats (), "ARWorldTrackingConfiguration");
+			Assert.NotNull (AROrientationTrackingConfiguration.GetSupportedVideoFormats (), "AROrientationTrackingConfiguration");
+			Assert.NotNull (ARFaceTrackingConfiguration.GetSupportedVideoFormats (), "ARFaceTrackingConfiguration");
+			Assert.NotNull (ARImageTrackingConfiguration.GetSupportedVideoFormats (), "ARImageTrackingConfiguration");
+			Assert.NotNull (ARObjectScanningConfiguration.GetSupportedVideoFormats (), "ARObjectScanningConfiguration");
+		}
+
+		[Test]
+		public void Subclasses ()
+		{
+			// all subclasses of ARConfiguration must (re)export 'GetSupportedVideoFormats'
+			var c = typeof (ARConfiguration);
+			foreach (var sc in c.Assembly.GetTypes ()) {
+				if (!sc.IsSubclassOf (c))
+					continue;
+				var m = sc.GetMethod ("GetSupportedVideoFormats", BindingFlags.Static | BindingFlags.Public);
+				Assert.NotNull (m, sc.FullName);
+			}
+		}
+	}
+}
+
+#endif


### PR DESCRIPTION
Even if 'supportedVideoFormats' is static the type is abstract.

> Important
> ARConfiguration is an abstract base class, so its implementation of
> this property always returns an empty array. Read this property from
> the configuration subclass you plan to use for your AR session, such
> as ARWorldTrackingConfiguration or ARFaceTrackingConfiguration.
https://developer.apple.com/documentation/arkit/arconfiguration/2942261-supportedvideoformats?language=objc

and this behave differently in Objective-C (than .net) as every (static)
method will be different (and not a single implementation like C#).

The existing implementation (as a property) calls `ARConfiguration`
implementation which simply throws a (native) exception

> NSInvalidArgumentException Reason: Supported video formats should be called on individual configuration class

The solution is to obsolete the property (can't be subclassed in .net
since it's static) and add, only on the subclasses, a method that
call the 'supportedVideoFormats' selector on the current (not base)
type.

Added unit test to detect the addition of newer subclasses - since they
will also need to expose this method.

reference: https://github.com/xamarin/xamarin-macios/issues/5347