### PR TITLE
[tests] Add MONO_SDK_DESTDIR to config file when using system XI for tests.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -101,6 +101,7 @@ test-system.config:
 	@echo "MAC_DESTDIR=/" >> $@
 	@echo "JENKINS_RESULTS_DIRECTORY=$(abspath $(JENKINS_RESULTS_DIRECTORY))" >> $@
 	@echo "INCLUDE_DEVICE=$(INCLUDE_DEVICE)" >> $@
+	@echo "MONO_SDK_DESTDIR=$(MONO_SDK_DESTDIR)" >> $@
 
 clean-local::
 	$(Q) $(SYSTEM_XBUILD) /t:Clean /p:Platform=iPhoneSimulator /p:Configuration=$(CONFIG) $(XBUILD_VERBOSITY) tests.sln


### PR DESCRIPTION
Fixes this problem when running the VSTS device tests:

    Unhandled Exception:
    System.Collections.Generic.KeyNotFoundException: The given key 'MONO_SDK_DESTDIR' was not present in the dictionary.
      at System.Collections.Generic.Dictionary`2[TKey,TValue].get_Item (TKey key) [0x0001e] in <96207d0baa204f48a53ad6be05f5ecba>:0
      at xharness.Harness.LoadConfig () [0x001a3] in <299e29e4a95f41499aef8f7d9863ca3d>:0
      at xharness.Harness.Execute () [0x00001] in <299e29e4a95f41499aef8f7d9863ca3d>:0
      at xharness.MainClass.Main (System.String[] args) [0x003e3] in <299e29e4a95f41499aef8f7d9863ca3d>:0