### PR TITLE
[foundation] Directly call Remove in NSUrlSessionHandler

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -163,10 +163,8 @@ namespace Foundation {
 
 		void RemoveInflightData (NSUrlSessionTask task, bool cancel = true)
 		{
-			InflightData inflight;
 			lock (inflightRequestsLock)
-				if (inflightRequests.TryGetValue (task, out inflight))
-					inflightRequests.Remove (task);
+				inflightRequests.Remove (task);
 
 			if (cancel)
 				task?.Cancel ();


### PR DESCRIPTION
Small optimization. It's not needed to check if the item exists
in the dictionary to remove it, `Remove` returns `true` if the item
was present (but we do not care about the result here).