### PR TITLE
[compare-commits] Only validate files when validating if files have unexpectedly changed.

### DIFF
--- a/tools/compare-commits.sh
+++ b/tools/compare-commits.sh
@@ -210,6 +210,7 @@ MODIFIED_FILES=$(find \
 	"$ROOT_DIR/_mac-build" \
 	"$ROOT_DIR/src" \
 	"$ROOT_DIR/tools/apidiff" \
+	-type f \
 	-newer "$OUTPUT_DIR/stamp")
 
 if test -n "$MODIFIED_FILES"; then


### PR DESCRIPTION
Fixes this problem:

    The following files were modified, and they shouldn't have been:
        /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/src

which shouldn't be reported, since the "file" in question is a directory.

Reference: https://github.com/xamarin/xamarin-macios/pull/5355#issuecomment-452400517