### PR TITLE
[msbuild] Fix APFS check if root file system isn't APFS.

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
@@ -342,9 +342,7 @@ namespace Xamarin.iOS.Tasks
 			get {
 				if (!is_apfs.HasValue) {
 					var exit_code = ExecutionHelper.Execute ("/bin/df", "-t apfs /", out var output, TimeSpan.FromSeconds (10));
-					if (exit_code != 0)
-						throw new Exception ($"Could not determine whether / is APFS or not. 'df -t apfs /' returned {exit_code} and said: {output}");
-					is_apfs = output.Trim ().Split ('\n').Length >= 2;
+					is_apfs = exit_code == 0 && output.Trim ().Split ('\n').Length >= 2;
 				}
 				return is_apfs.Value;
 			}


### PR DESCRIPTION
`df -t afps /` returns 1 if the root file system isn't APFS, so handle this case gracefully.

Fixes this:

    Errors and Failures:
    1) Test Error : Xamarin.iOS.Tasks.CodesignAppBundle("iPhone","Debug").CodesignAfterModifyingAppExtensionTest
       System.Exception : Could not determine whether / is APFS or not. 'df -t apfs /' returned 1 and said:
      at Xamarin.iOS.Tasks.TestBase.get_IsAPFS () [0x00051] in <c0cbc86394444f8e9cb85adb1eab6fea>:0
      at Xamarin.iOS.Tasks.TestBase.EnsureFilestampChange () [0x00001] in <c0cbc86394444f8e9cb85adb1eab6fea>:0
      at Xamarin.iOS.Tasks.CodesignAppBundle.CodesignAfterModifyingAppExtensionTest () [0x0007d] in <c0cbc86394444f8e9cb85adb1eab6fea>:0
      at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
      at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in <96207d0baa204f48a53ad6be05f5ecba>:0

Reference: [Test results](http://xamarin-storage/jenkins/xamarin-macios/jenkins-improve-docs-tests-rendering3/d10d57b8bb36824cb2dabf62989497107a1b7ca1/2/jenkins-results/tests/index.html)