### PR TITLE
[mtouch] Disable native code sharing if the interpreter settings differ between the main app and app extensions. Fixes #5365.

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1092,6 +1092,18 @@ namespace Xamarin.Bundler {
 					}
 				}
 
+				if (UseInterpreter != appex.UseInterpreter) {
+					ErrorHelper.Warning (113, "Native code sharing has been disabled for the extension '{0}' because {1}", appex.Name, $"the interpreter settings are different between the container app ({(UseInterpreter ? "Enabled" : "Disabled")}) and the extension ({(appex.UseInterpreter ? "Enabled" : "Disabled")}).");
+					continue;
+				} else if (UseInterpreter) {
+					var appAssemblies = new HashSet<string> (InterpretedAssemblies);
+					var appexAssemblies = new HashSet<string> (appex.InterpretedAssemblies);
+					if (!appAssemblies.SetEquals (appexAssemblies)) {
+						ErrorHelper.Warning (113, "Native code sharing has been disabled for the extension '{0}' because {1}", appex.Name, $"the interpreted assemblies are different between the container app ({(InterpretedAssemblies.Count == 0 ? "all assemblies" : string.Join (", ", InterpretedAssemblies))}) and the extension ({(appex.InterpretedAssemblies.Count == 0 ? "all assemblies" : string.Join (", ", appex.InterpretedAssemblies))}).");
+						continue;
+					}
+				}
+
 				// Check that the Abis are matching
 				foreach (var abi in appex.Abis) {
 					var matching = abis.FirstOrDefault ((v) => (v & Abi.ArchMask) == (abi & Abi.ArchMask));


### PR DESCRIPTION
We can't share native code between apps and app extensions if the interpreter
settings differ between them, so detect this scenario and automatically
disable native code sharing.

Fixes https://github.com/xamarin/xamarin-macios/issues/5365.