### PR TITLE
[tests] Run tests-docs using xharness.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -15,6 +15,7 @@ errorMessage = null
 currentStage = null
 failedStages = []
 workspace = null
+manualException = false
 
 xiPackageFilename = null
 xmPackageFilename = null
@@ -190,7 +191,7 @@ def reportFinalStatus (err, gitHash, currentStage)
         if (failedStages.size () > 0)
             comment += " in stage(s) '${failedStages.join (', ')}'"
         comment += " 🔥"
-        if (err != "")
+        if (!manualException && err != "")
             comment += " : ${err}"
         manager.addErrorBadge (comment)
         manager.buildFailure ()
@@ -724,26 +725,11 @@ timestamps {
                                                 echo ("Html report: ${reportPrefix}/tests/index.html")
                                                 def runTestResult = sh (script: "${workspace}/xamarin-macios/jenkins/run-tests.sh --target=wrench-jenkins --publish --keychain=xamarin-macios", returnStatus: true)
                                                 if (runTestResult != 0) {
-                                                    echoError ("Test run failed")
-                                                    currentBuild.result = 'FAILURE'
                                                     failedStages.add (currentStage)
-                                                }
-                                            }
-                                        }
-                                        stage ('Test docs') {
-                                            currentStage = "${STAGE_NAME}"
-                                            echo ("Building on ${env.NODE_NAME}")
-                                            def targetBranch = isPr ? githubGetPullRequestInfo () ["base"] ["ref"] : "${BRANCH_NAME}"
-                                            def hasRunDocsTestsLabel = isPr ? githubGetPullRequestLabels ().contains ("run-docs-tests") : false
-                                            def testDocs = targetBranch == "master" || hasRunDocsTestsLabel
-                                            if (!testDocs) {
-                                                echo ("Skipping docs testing, it's only done on master (current (target) branch is ${targetBranch})")
-                                            } else {
-                                                def testDocsResult = sh (script: "make -C ${workspace}/xamarin-macios/tests wrench-docs", returnStatus: true)
-                                                if (testDocsResult != 0) {
-                                                    echoError ("Test docs failed")
-                                                    currentBuild.result = 'FAILURE'
-                                                    failedStages.add (currentStage)
+                                                    manualException = true
+                                                    error ("Test run failed: ${reportPrefix}/tests/index.html")
+                                                } else {
+                                                    echo ("${currentStage} succeeded")
                                                 }
                                             }
                                         }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -93,6 +93,7 @@ test.config: Makefile $(TOP)/Make.config
 	@echo "INCLUDE_DEVICE=$(INCLUDE_DEVICE)" >> $@
 	@echo "XCODE_DEVELOPER_ROOT=$(XCODE_DEVELOPER_ROOT)" >> $@
 	@echo "MONO_SDK_DESTDIR=$(MONO_SDK_DESTDIR)" >> $@
+	@echo "ENABLE_XAMARIN=$(ENABLE_XAMARIN)" >> $@
 
 test-system.config:
 	@rm -f $@

--- a/tests/xharness/GitHub.cs
+++ b/tests/xharness/GitHub.cs
@@ -13,35 +13,34 @@ namespace xharness
 {
 	public static class GitHub
 	{
+		public static string GetPullRequestTargetBranch (Harness harness, int pull_request)
+		{
+			if (pull_request <= 0)
+				return string.Empty;
+
+			var info = DownloadPullRequestInfo (harness, pull_request);
+			if (info.Length == 0)
+				return string.Empty;
+
+			using (var reader = JsonReaderWriterFactory.CreateJsonReader (info, new XmlDictionaryReaderQuotas ())) {
+				var doc = new XmlDocument ();
+				doc.Load (reader);
+				return doc.SelectSingleNode ("/root/base/ref").InnerText;
+			}
+		}
+
 		public static IEnumerable<string> GetLabels (Harness harness, int pull_request)
 		{
-			var path = Path.Combine (harness.LogDirectory, "pr" + pull_request + "-labels.log");
-			if (!File.Exists (path)) {
-				Directory.CreateDirectory (harness.LogDirectory);
-				using (var client = new WebClient ()) {
-					// FIXME: github returns results in pages of 30 elements
-					byte [] data;
-					try {
-						client.Headers.Add (HttpRequestHeader.UserAgent, "xamarin");
-						data = client.DownloadData ($"https://api.github.com/repos/xamarin/xamarin-macios/issues/{pull_request}/labels");
-					} catch (WebException we) {
-						harness.Log ("Could not load pull request labels: {0}\n{1}", we, new StreamReader (we.Response.GetResponseStream ()).ReadToEnd ());
-						File.WriteAllText (path, string.Empty);
-						return new string [] { };
-					}
-					var reader = JsonReaderWriterFactory.CreateJsonReader (data, new XmlDictionaryReaderQuotas ());
-					var doc = new XmlDocument ();
-					doc.Load (reader);
-					var rv = new List<string> ();
-					foreach (XmlNode node in doc.SelectNodes ("/root/item/name")) {
-						rv.Add (node.InnerText);
-					}
-					File.WriteAllLines (path, rv.ToArray ());
-					return rv;
+			var info = DownloadPullRequestInfo (harness, pull_request);
+			using (var reader = JsonReaderWriterFactory.CreateJsonReader (info, new XmlDictionaryReaderQuotas ())) {
+				var doc = new XmlDocument ();
+				doc.Load (reader);
+				var rv = new List<string> ();
+				foreach (XmlNode node in doc.SelectNodes ("/root/labels/name")) {
+					rv.Add (node.InnerText);
 				}
+				return rv;
 			}
-
-			return File.ReadAllLines (path);
 		}
 
 		public static IEnumerable<string> GetModifiedFiles (Harness harness, int pull_request)
@@ -155,11 +154,9 @@ namespace xharness
 			}
 		}
 
-		public static XmlDocument FetchPullRequest (Harness harness, int pull_request)
+		static byte[] DownloadPullRequestInfo (Harness harness, int pull_request)
 		{
 			var path = Path.Combine (harness.LogDirectory, "pr" + pull_request + ".log");
-			var doc = new XmlDocument ();
-
 			if (!File.Exists (path)) {
 				Directory.CreateDirectory (harness.LogDirectory);
 				using (var client = new WebClient ()) {
@@ -167,20 +164,16 @@ namespace xharness
 					try {
 						client.Headers.Add (HttpRequestHeader.UserAgent, "xamarin");
 						data = client.DownloadData ($"https://api.github.com/repos/xamarin/xamarin-macios/pulls/{pull_request}");
+						File.WriteAllBytes (path, data);
+						return data;
 					} catch (WebException we) {
-						harness.Log ("Could not load pull request: {0}\n{1}", we, new StreamReader (we.Response.GetResponseStream ()).ReadToEnd ());
-						return null;
+						harness.Log ("Could not load pull request info: {0}\n{1}", we, new StreamReader (we.Response.GetResponseStream ()).ReadToEnd ());
+						File.WriteAllText (path, string.Empty);
+						return new byte [0];
 					}
-					var reader = JsonReaderWriterFactory.CreateJsonReader (data, new XmlDictionaryReaderQuotas ());
-
-					doc.Load (reader);
-					doc.Save (path);
-					return doc;
 				}
 			}
-
-			doc.LoadWithoutNetworkAccess (path);
-			return doc;
+			return File.ReadAllBytes (path);
 		}
 	}
 }

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -88,6 +88,7 @@ namespace xharness
 		public string IOS_DESTDIR { get; set; }
 		public string MONO_SDK_DESTDIR { get; set; }
 		public bool IncludeMac32 { get; set; }
+		public bool ENABLE_XAMARIN { get; set; }
 
 		// Run
 		public AppRunnerTarget Target { get; set; }
@@ -227,6 +228,7 @@ namespace xharness
 			if (string.IsNullOrEmpty (SdkRoot94))
 				SdkRoot94 = make_config ["XCODE94_DEVELOPER_ROOT"];
 			MONO_SDK_DESTDIR = make_config ["MONO_SDK_DESTDIR"];
+			ENABLE_XAMARIN = make_config.ContainsKey ("ENABLE_XAMARIN") && !string.IsNullOrEmpty (make_config ["ENABLE_XAMARIN"]);
 		}
 		 
 		void AutoConfigureMac ()

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -36,6 +36,7 @@ namespace xharness
 		public bool IncludeSimulator = true;
 		public bool IncludeDevice;
 		public bool IncludeXtro;
+		public bool IncludeDocs;
 
 		public Log MainLog;
 		public Log SimulatorLoadLog;
@@ -598,7 +599,9 @@ namespace xharness
 			labels.UnionWith (Harness.Labels);
 			if (pull_request > 0)
 				labels.UnionWith (GitHub.GetLabels (Harness, pull_request));
-
+			var env_labels = Environment.GetEnvironmentVariable ("XHARNESS_LABELS");
+			if (!string.IsNullOrEmpty (env_labels))
+				labels.UnionWith (env_labels.Split (new char [] { ',' }, StringSplitOptions.RemoveEmptyEntries));
 			MainLog.WriteLine ("Found {1} label(s) in the pull request #{2}: {0}", string.Join (", ", labels.ToArray ()), labels.Count (), pull_request);
 
 			// disabled by default
@@ -624,24 +627,54 @@ namespace xharness
 			bool inc_permission_tests = Harness.IncludeSystemPermissionTests;
 			SetEnabled (labels, "system-permission", ref inc_permission_tests);
 			Harness.IncludeSystemPermissionTests = inc_permission_tests;
+
+			// docs is a bit special:
+			// - can only be executed if the Xamarin-specific parts of the build is enabled
+			// - enabled by default if the current branch is master (or, for a pull request, if the target branch is master)
+			var changed = SetEnabled (labels, "docs", ref IncludeDocs);
+			if (Harness.ENABLE_XAMARIN) {
+				if (!changed) { // don't override any value set using labels
+					var branchName = Environment.GetEnvironmentVariable ("BRANCH_NAME");
+					if (!string.IsNullOrEmpty (branchName)) {
+						IncludeDocs = branchName == "master";
+						if (IncludeDocs)
+							MainLog.WriteLine ("Enabled 'docs' tests because the current branch is 'master'.");
+					} else if (pull_request > 0) {
+						IncludeDocs = GitHub.GetPullRequestTargetBranch (Harness, pull_request) == "master";
+						if (IncludeDocs)
+							MainLog.WriteLine ("Enabled 'docs' tests because the target branch is 'master'.");
+					}
+				}
+			} else {
+				if (IncludeDocs) {
+					IncludeDocs = false; // could have been enabled by 'run-all-tests', so disable it if we can't run it.
+					MainLog.WriteLine ("Disabled 'docs' tests because the Xamarin-specific parts of the build are not enabled.");
+				}
+			}
 		}
 
-		void SetEnabled (HashSet<string> labels, string testname, ref bool value)
+		// Returns true if the value was changed.
+		bool SetEnabled (HashSet<string> labels, string testname, ref bool value)
 		{
 			if (labels.Contains ("skip-" + testname + "-tests")) {
 				MainLog.WriteLine ("Disabled '{0}' tests because the label 'skip-{0}-tests' is set.", testname);
 				value = false;
+				return true;
 			} else if (labels.Contains ("run-" + testname + "-tests")) {
 				MainLog.WriteLine ("Enabled '{0}' tests because the label 'run-{0}-tests' is set.", testname);
 				value = true;
+				return true;
 			} else if (labels.Contains ("skip-all-tests")) {
 				MainLog.WriteLine ("Disabled '{0}' tests because the label 'skip-all-tests' is set.", testname);
 				value = false;
+				return true;
 			} else if (labels.Contains ("run-all-tests")) {
 				MainLog.WriteLine ("Enabled '{0}' tests because the label 'run-all-tests' is set.", testname);
 				value = true;
+				return true;
 			}
 			// respect any default value
+			return false;
 		}
 
 		async Task PopulateTasksAsync ()
@@ -867,6 +900,17 @@ namespace xharness
 				WorkingDirectory = buildXtroTests.WorkingDirectory,
 			};
 			Tasks.Add (runXtroReporter);
+
+			var runDocsTests = new MakeTask {
+				Jenkins = this,
+				Platform = TestPlatform.All,
+				TestName = "Documentation",
+				Target = "wrench-docs",
+				WorkingDirectory = Harness.RootDirectory,
+				Ignored = !IncludeDocs,
+				Timeout = TimeSpan.FromMinutes (15),
+			};
+			Tasks.Add (runDocsTests);
 
 			Tasks.AddRange (CreateRunDeviceTasks ());
 		}
@@ -2044,10 +2088,11 @@ function toggleAll (show)
 
 							if (!string.IsNullOrEmpty (test.FailureMessage)) {
 								var msg = System.Web.HttpUtility.HtmlEncode (test.FailureMessage).Replace ("\n", "<br />");
+								var prefix = test.Ignored ? "Ignored" : "Failure";
 								if (test.FailureMessage.Contains ('\n')) {
-									writer.WriteLine ($"Failure:<br /> <div style='margin-left: 20px;'>{msg}</div>");
+									writer.WriteLine ($"{prefix}:<br /> <div style='margin-left: 20px;'>{msg}</div>");
 								} else {
-									writer.WriteLine ($"Failure: {msg} <br />");
+									writer.WriteLine ($"{prefix}: {msg} <br />");
 								}
 							}
 							var progressMessage = test.ProgressMessage;


### PR DESCRIPTION
Jenkins has a limitation where you can't mark a step a failure, it has to
*fail* to be reported as such.

This means that running multiple tests, and reporting a failure if any of
those tests fail is not possible.

We run into this with the normal test run + the docs tests; where we currently
don't show a red result in the UI if any of those fail.

So incorporate the test-docs step into xharness, so that we only have one
thing to in the Jenkinsfile, which makes it possible for us to fail the test
run step properly.

This also required a few upgrades to xharness to get more info for pull
requests, since the logic to enable the docs tests is a bit more complicated
than anything else we have (if the current branch (or the target branch for a
PR) is 'master' AND xamarin mode is enabled).