### PR TITLE
[XHarness] Reneable the System.IO.Compression tests.

### DIFF
--- a/tests/bcl-test/BCLTests/common-SystemIOCompressionTests.ignore
+++ b/tests/bcl-test/BCLTests/common-SystemIOCompressionTests.ignore
@@ -1,0 +1,21 @@
+# System.IO.FileNotFoundException : test.nupkg does not exist
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipDeleteEntryCheckEntries
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipEnumerateArchiveDefaultLastWriteTime
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipEnumerateEntriesCreateMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipEnumerateEntriesModifiedTime
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipEnumerateEntriesReadMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipEnumerateEntriesUpdateMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetArchiveEntryStreamLengthPositionReadMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetArchiveEntryStreamLengthPositionUpdateMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryCreateMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryDeleteReadMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryDeleteUpdateMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryOpen
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryReadMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryUpdateMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipOpenAndReopenEntry
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipOpenCloseAndReopenEntry
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipReadNonSeekableStream
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipWriteEntriesUpdateMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipWriteEntriesUpdateModeNonZeroPosition
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipWriteNonSeekableStream

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -122,7 +122,6 @@ namespace BCLTestImporter {
 			"monotouch_System.Security_test.dll", // issue https://github.com/xamarin/maccore/issues/1139
 			"monotouch_System.Runtime.Serialization.Formatters.Soap_test.dll", // issue https://github.com/xamarin/maccore/issues/1140
 			"monotouch_System.Net.Http_test.dll", // issue https://github.com/xamarin/maccore/issues/1144 and https://github.com/xamarin/maccore/issues/1145
-			"monotouch_System.IO.Compression_test.dll", // issue https://github.com/xamarin/maccore/issues/1146
 			"monotouch_System.IO.Compression.FileSystem_test.dll", // issue https://github.com/xamarin/maccore/issues/1147 and https://github.com/xamarin/maccore/issues/1148
 			"monotouch_System.Data_test.dll", // issue https://github.com/xamarin/maccore/issues/1149
 			"monotouch_System.Data.DataSetExtensions_test.dll", // issue https://github.com/xamarin/maccore/issues/1150 and https://github.com/xamarin/maccore/issues/1151


### PR DESCRIPTION
The ignored tests are because there are files missing needed that are not included as resources.

Fixes https://github.com/xamarin/maccore/issues/1146