### PR TITLE
[mtouch] Provide a better (and single) error message when the interpreter is enabled in simulator builds.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -945,6 +945,15 @@ This error occurs when `mtouch` reads a binary in a `.framework` directory that 
 
 It might be a broken file or a broken symlink (after decompressing an archive) to a valid file. The native framework should be removed and replaced with a valid one. 
 
+<a name="MT0141"/>
+
+### MT0141: The interpreter is not supported in the simulator. Do not pass --interpreter when building for the simulator.
+
+This error occurs when enabling the interpreter on a simulator build.
+
+The interperter is only available for device builds as an complete or partial alternative to the ahead-of-time (AOT) compilation.
+In contrast simulator builds are using just-in-time compilation which negates most advantages of the interpreter.
+
 # MT1xxx: Project related error messages
 
 ### MT10xx: Installer / mtouch

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -951,7 +951,7 @@ It might be a broken file or a broken symlink (after decompressing an archive) t
 
 This error occurs when enabling the interpreter on a simulator build.
 
-The interperter is only available for device builds as an complete or partial alternative to the ahead-of-time (AOT) compilation.
+The interpreter is only available for device builds as an complete or partial alternative to the ahead-of-time (AOT) compilation.
 In contrast simulator builds are using just-in-time compilation which negates most advantages of the interpreter.
 
 # MT1xxx: Project related error messages

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1396,6 +1396,9 @@ namespace Xamarin.Bundler {
 			if (EnableBitCode && IsSimulatorBuild)
 				throw ErrorHelper.CreateError (84, "Bitcode is not supported in the simulator. Do not pass --bitcode when building for the simulator.");
 
+			if (UseInterpreter && IsSimulatorBuild)
+				throw ErrorHelper.CreateError (141, "The interpreter is not supported in the simulator. Do not pass --interpreter when building for the simulator.");
+
 			Namespaces.Initialize ();
 
 			if (Embeddinator) {


### PR DESCRIPTION
Before

```
clang : error : no such file or directory: '/Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/MonoTouch.iphonesimulator.sdk/usr/lib/libmono-ee-interp.a'
clang : error : no such file or directory: '/Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/MonoTouch.iphonesimulator.sdk/usr/lib/libmono-icall-table.a'
clang : error : no such file or directory: '/Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/MonoTouch.iphonesimulator.sdk/usr/lib/libmono-ilgen.a'
error MT5209 : Native linking error : clang: error: no such file or directory: '/Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/MonoTouch.iphonesimulator.sdk/usr/lib/libmono-ee-interp.a'
error MT5209 : Native linking error : clang: error: no such file or directory: '/Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/MonoTouch.iphonesimulator.sdk/usr/lib/libmono-icall-table.a'
error MT5209 : Native linking error : clang: error: no such file or directory: '/Users/poupou/git/xamarin/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/MonoTouch.iphonesimulator.sdk/usr/lib/libmono-ilgen.a'
MTOUCH : error MT5202: Native linking failed. Please review the build log.
    0 Warning(s)
    7 Error(s)
```

After

```
MTOUCH : error MT0141: The interpreter is not supported in the simulator. Do not pass --interpreter when building for the simulator.
    0 Warning(s)
    1 Error(s)
```