### PR TITLE
[XHarness] Reenable the System.ServiceModel tests from the bcl.

### DIFF
--- a/tests/bcl-test/BCLTests/common-SystemServiceModelTests.ignore
+++ b/tests/bcl-test/BCLTests/common-SystemServiceModelTests.ignore
@@ -1,0 +1,16 @@
+# #2
+#  Expected string length 66 but was 70. Strings differ at index 11.
+#  Expected: "...ot xmlns:i="http://www.w3.org/2001/XMLSchema-instance" />"
+#  But was:  "...ot>urn:uuid:03020100-0504-0706-0809-000102030405</dummy-root>"
+MonoTests.System.ServiceModel.Channels.MessageHeaderTest.TestWriteHeaderContent2
+
+# An unexpected exception type was thrown
+# Expected: System.ServiceModel.CommunicationException
+# but was: System.IO.DirectoryNotFoundException : Could not find a part of the path
+MonoTests.System.ServiceModel.Channels.MessageFaultTest.CreateFaultIncomplete4
+MonoTests.System.ServiceModel.Channels.MessageFaultTest.CreateFaultIncomplete
+MonoTests.System.ServiceModel.Channels.MessageFaultTest.CreateFault
+MonoTests.System.ServiceModel.Channels.DuplicateMesageEncodingBindingElementError 
+
+# System.ArgumentException was expected 
+MonoTests.System.ServiceModel.Channels.BindingContextTest.DuplicateMesageEncodingBindingElementError

--- a/tests/bcl-test/BCLTests/watchOS-SystemServiceModelTests.ignore
+++ b/tests/bcl-test/BCLTests/watchOS-SystemServiceModelTests.ignore
@@ -1,0 +1,9 @@
+# System.PlatformNotSupportedException : System.Net.Sockets.Socket:Bind is not supported on this platform. 
+MonoTests.System.ServiceModel.Description.ServiceEndpointTest.ListenUri
+
+#  An unexpected exception type was thrown 
+MonoTests.System.ServiceModel.ClientBase_InteractiveChannelInitializerTest.OpenBeforeDisplayInitializationUI
+MonoTests.System.ServiceModel.ClientBase_InteractiveChannelInitializerTest.NotAllowedInitializationUI
+
+# System.PlatformNotSupportedException : System.Net.Sockets.Socket:Bind is not supported on this platform.
+MonoTests.System.ServiceModel.Bug36080.Bug36080Test

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -117,7 +117,6 @@ namespace BCLTestImporter {
 			"monotouch_System.Threading.Tasks.Dataflow_xunit-test.dll", // issue https://github.com/xamarin/maccore/issues/1132
 			"monotouch_System.Transactions_test.dll", // issue https://github.com/xamarin/maccore/issues/1134
 			"monotouch_System_test.dll", // issues https://github.com/xamarin/maccore/issues/1135
-			"monotouch_System.ServiceModel_test.dll", // issue https://github.com/xamarin/maccore/issues/1138
 			"monotouch_System.Security_test.dll", // issue https://github.com/xamarin/maccore/issues/1139
 			"monotouch_System.Runtime.Serialization.Formatters.Soap_test.dll", // issue https://github.com/xamarin/maccore/issues/1140
 			"monotouch_System.Net.Http_test.dll", // issue https://github.com/xamarin/maccore/issues/1144 and https://github.com/xamarin/maccore/issues/1145


### PR DESCRIPTION
Failing tests are because:

1. Files are missing for the tests.
2. We yet do not have tests for the watch platform, we execute the iOS ones and ignore those that are not supported in the platform.