### PR TITLE
[xharness] Bump documentation tests timeout.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -908,7 +908,7 @@ namespace xharness
 				Target = "wrench-docs",
 				WorkingDirectory = Harness.RootDirectory,
 				Ignored = !IncludeDocs,
-				Timeout = TimeSpan.FromMinutes (15),
+				Timeout = TimeSpan.FromMinutes (45),
 			};
 			Tasks.Add (runDocsTests);
 


### PR DESCRIPTION
Bump the documentation tests timeout. It can take a while to run the
documentation tests when they're run in parallel with other tests.

Reference: https://github.com/xamarin/xamarin-macios/commit/85130ddbb70590545c9f217d2bd87752844ae217#commitcomment-31935455