### PR TITLE
 [XHarness] Reneable the SystemNetHttpTests on iOS, TvOS and WatchOS.

### DIFF
--- a/tests/bcl-test/BCLTests/Info-tv.plist.in
+++ b/tests/bcl-test/BCLTests/Info-tv.plist.in
@@ -31,5 +31,10 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/AppIcon.appiconset</string>
+	<key>NSAppTransportSecurity</key>
+		<dict>
+ 			<key>NSAllowsArbitraryLoads</key>
+			<true/>
+		</dict>
 </dict>
 </plist>

--- a/tests/bcl-test/BCLTests/Info-watchos-extension.plist.in
+++ b/tests/bcl-test/BCLTests/Info-watchos-extension.plist.in
@@ -35,5 +35,10 @@
       <key>NSExtensionPointIdentifier</key>
       <string>com.apple.watchkit</string>
     </dict>
+    	<key>NSAppTransportSecurity</key>
+		<dict>
+			<key>NSAllowsArbitraryLoads</key>
+			<true/>
+		</dict>
   </dict>
 </plist>

--- a/tests/bcl-test/BCLTests/Info.plist
+++ b/tests/bcl-test/BCLTests/Info.plist
@@ -32,5 +32,10 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/AppIcon.appiconset</string>
+	<key>NSAppTransportSecurity</key>
+		<dict>
+			<key>NSAllowsArbitraryLoads</key>
+			<true/>
+		</dict>
 </dict>
 </plist>

--- a/tests/bcl-test/BCLTests/Info.plist.in
+++ b/tests/bcl-test/BCLTests/Info.plist.in
@@ -32,5 +32,10 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/AppIcon.appiconset</string>
+	<key>NSAppTransportSecurity</key>
+		<dict>
+			<key>NSAllowsArbitraryLoads</key>
+			<true/>
+		</dict>
 </dict>
 </plist>

--- a/tests/bcl-test/BCLTests/common-SystemNetHttpTests.ignore
+++ b/tests/bcl-test/BCLTests/common-SystemNetHttpTests.ignore
@@ -1,0 +1,32 @@
+# #1
+#  Expected: instance of <System.Net.Http.HttpRequestException>
+#  But was:  <System.Net.WebException>
+MonoTests.System.Net.Http.HttpClientTest.WildcardConnect
+MonoTests.System.Net.Http.HttpClientTest.Send_Transfer_Encoding_Custom
+
+#  Error Domain=NSURLErrorDomain Code=-1022 "The resource could not be loaded because the App Transport Security policy requires the use of a secure connection."
+MonoTests.System.Net.Http.HttpClientTest.Send_Transfer_Encoding_Chunked
+MonoTests.System.Net.Http.HttpClientTest.Send_Content_Put_CustomStream
+MonoTests.System.Net.Http.HttpClientTest.Send_Content_Put
+MonoTests.System.Net.Http.HttpClientTest.Send_Content_Get
+MonoTests.System.Net.Http.HttpClientTest.Send_Content_BomEncoding
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Version_1_0
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_NoContent_Put
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_NoContent_Post
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_NoContent_Delete
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Error
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Default
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_CustomHeaders_SpecialSeparators
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_CustomHeaders_Host
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_CustomHeaders
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Content_MaxResponseContentBufferSize
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Content
+MonoTests.System.Net.Http.HttpClientTest.Post_TransferEncodingChunked
+MonoTests.System.Net.Http.HttpClientTest.Post_StreamCaching
+MonoTests.System.Net.Http.HttpClientTest.GetString_Many
+
+#  #3
+#  Expected: True
+#  But was:  False
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Content_MaxResponseContentBufferSize_Error
+MonoTests.System.Net.Http.HttpClientTest.GetByteArray_ServerError

--- a/tests/bcl-test/BCLTests/common-SystemNetHttpTests.ignore
+++ b/tests/bcl-test/BCLTests/common-SystemNetHttpTests.ignore
@@ -4,29 +4,64 @@
 MonoTests.System.Net.Http.HttpClientTest.WildcardConnect
 MonoTests.System.Net.Http.HttpClientTest.Send_Transfer_Encoding_Custom
 
-#  Error Domain=NSURLErrorDomain Code=-1022 "The resource could not be loaded because the App Transport Security policy requires the use of a secure connection."
+# #102
+#  Expected: False
+#  But was:  True
 MonoTests.System.Net.Http.HttpClientTest.Send_Transfer_Encoding_Chunked
+
+# #2
+#  Expected: True
+#  But was:  False
 MonoTests.System.Net.Http.HttpClientTest.Send_Content_Put_CustomStream
-MonoTests.System.Net.Http.HttpClientTest.Send_Content_Put
-MonoTests.System.Net.Http.HttpClientTest.Send_Content_Get
-MonoTests.System.Net.Http.HttpClientTest.Send_Content_BomEncoding
+
+#  #102
+#  Expected: False
+#  But was:  True
 MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Version_1_0
+
+# #102
+#  Expected: False
+#  But was:  True
 MonoTests.System.Net.Http.HttpClientTest.Send_Complete_NoContent_Put
+
+# #102
+#  Expected: False
+#  But was:  True
 MonoTests.System.Net.Http.HttpClientTest.Send_Complete_NoContent_Post
+
+# #102
+#  Expected: False
+#  But was:  True 
 MonoTests.System.Net.Http.HttpClientTest.Send_Complete_NoContent_Delete
-MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Error
+
+# #102
+#  Expected: False
+#  But was:  True 
 MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Default
-MonoTests.System.Net.Http.HttpClientTest.Send_Complete_CustomHeaders_SpecialSeparators
-MonoTests.System.Net.Http.HttpClientTest.Send_Complete_CustomHeaders_Host
+
+#  #103a
+#  Expected string length 7 but was 8. Strings differ at index 0.
+#  Expected: "chunked"
+#  But was:  "Identity" 
 MonoTests.System.Net.Http.HttpClientTest.Send_Complete_CustomHeaders
-MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Content_MaxResponseContentBufferSize
+
+# #102a
+#  Expected string length 7 but was 8. Strings differ at index 0.
+#  Expected: "chunked"
+#  But was:  "Identity"
 MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Content
+
+#  #102
+#  Expected: False
+#  But was:  True
 MonoTests.System.Net.Http.HttpClientTest.Post_TransferEncodingChunked
+
+# #102
+#  Expected: False
+#  But was:  True
 MonoTests.System.Net.Http.HttpClientTest.Post_StreamCaching
-MonoTests.System.Net.Http.HttpClientTest.GetString_Many
 
 #  #3
 #  Expected: True
 #  But was:  False
 MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Content_MaxResponseContentBufferSize_Error
-MonoTests.System.Net.Http.HttpClientTest.GetByteArray_ServerError

--- a/tests/bcl-test/BCLTests/watchOS-SystemNetHttpTests.ignore
+++ b/tests/bcl-test/BCLTests/watchOS-SystemNetHttpTests.ignore
@@ -10,3 +10,12 @@ MonoTests.System.Net.Http.HttpClientHandlerTest.Properties_Invalid
 MonoTests.System.Net.Http.HttpClientHandlerTest.Properties_Defaults
 MonoTests.System.Net.Http.HttpClientHandlerTest.Properties_AfterClientCreation
 MonoTests.System.Net.Http.HttpClientHandlerTest.Disposed
+MonoTests.System.Net.Http.HttpClientTest.GetByteArray_ServerError
+MonoTests.System.Net.Http.HttpClientTest.GetString_Many
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Content_MaxResponseContentBufferSize
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_CustomHeaders_Host
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_CustomHeaders_SpecialSeparators
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Error
+MonoTests.System.Net.Http.HttpClientTest.Send_Content_BomEncoding
+MonoTests.System.Net.Http.HttpClientTest.Send_Content_Get
+MonoTests.System.Net.Http.HttpClientTest.Send_Content_Put

--- a/tests/bcl-test/BCLTests/watchOS-SystemNetHttpTests.ignore
+++ b/tests/bcl-test/BCLTests/watchOS-SystemNetHttpTests.ignore
@@ -1,0 +1,12 @@
+# System.PlatformNotSupportedException : System.Net.Sockets.Socket:Bind is not supported on this platform.
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_ClientHandlerSettings
+MonoTests.System.Net.Http.HttpClientTest.RequestUriAfterRedirect
+MonoTests.System.Net.Http.HttpClientTest.Proxy_Disabled
+MonoTests.System.Net.Http.HttpClientTest.ModifyHandlerAfterFirstRequest_Mock
+MonoTests.System.Net.Http.HttpClientTest.ModifyHandlerAfterFirstRequest
+MonoTests.System.Net.Http.HttpClientTest.DisallowAutoRedirect
+MonoTests.System.Net.Http.HttpClientTest.CancelRequestViaProxy
+MonoTests.System.Net.Http.HttpClientHandlerTest.Properties_Invalid
+MonoTests.System.Net.Http.HttpClientHandlerTest.Properties_Defaults
+MonoTests.System.Net.Http.HttpClientHandlerTest.Properties_AfterClientCreation
+MonoTests.System.Net.Http.HttpClientHandlerTest.Disposed

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -118,7 +118,6 @@ namespace BCLTestImporter {
 			"monotouch_System_test.dll", // issues https://github.com/xamarin/maccore/issues/1135
 			"monotouch_System.Security_test.dll", // issue https://github.com/xamarin/maccore/issues/1139
 			"monotouch_System.Runtime.Serialization.Formatters.Soap_test.dll", // issue https://github.com/xamarin/maccore/issues/1140
-			"monotouch_System.Net.Http_test.dll", // issue https://github.com/xamarin/maccore/issues/1144 and https://github.com/xamarin/maccore/issues/1145
 			"monotouch_System.Core_test.dll", // issue https://github.com/xamarin/maccore/issues/1143
 			"monotouch_Mono.Runtime.Tests_test.dll", // issue https://github.com/xamarin/maccore/issues/1141
 			"monotouch_corlib_test.dll", // issue https://github.com/xamarin/maccore/issues/1153


### PR DESCRIPTION
There are two main reasons why the tests are ginored:

1. The tests do not use https.
2. WatchOS is running the iOS tests until we have the tests in the SDK
for the watch runtime.

Fixes https://github.com/xamarin/maccore/issues/1144
Fixes https://github.com/xamarin/maccore/issues/1145