### PR TITLE
[XHarness] Remove System.Runtime.Serialization.Formatters.Soap_test from iOS, TvOS and WatchOS

### DIFF
--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -96,7 +96,6 @@ namespace BCLTestImporter {
 			(name:"MonoCSharpTests", assemblies: new [] {"monotouch_Mono.CSharp_test.dll"}),
 			(name:"SystemSecurityTests", assemblies: new [] {"monotouch_System.Security_test.dll"}),
 			(name:"SystemServiceModelTests", assemblies: new [] {"monotouch_System.ServiceModel_test.dll"}),
-			(name:"SystemRuntimeSerializationFormattersSoapTests", assemblies: new [] {"monotouch_System.Runtime.Serialization.Formatters.Soap_test.dll"}),
 			(name:"CorlibTests", assemblies: new [] {"monotouch_corlib_test.dll"}),
 
 			// XUNIT TESTS 
@@ -116,7 +115,6 @@ namespace BCLTestImporter {
 			"monotouch_System.Transactions_test.dll", // issue https://github.com/xamarin/maccore/issues/1134
 			"monotouch_System_test.dll", // issues https://github.com/xamarin/maccore/issues/1135
 			"monotouch_System.Security_test.dll", // issue https://github.com/xamarin/maccore/issues/1139
-			"monotouch_System.Runtime.Serialization.Formatters.Soap_test.dll", // issue https://github.com/xamarin/maccore/issues/1140
 			"monotouch_System.Net.Http_test.dll", // issue https://github.com/xamarin/maccore/issues/1144 and https://github.com/xamarin/maccore/issues/1145
 			"monotouch_corlib_test.dll", // issue https://github.com/xamarin/maccore/issues/1153
 			"monotouch_Commons.Xml.Relaxng_test.dll", // not supported by xamarin


### PR DESCRIPTION
As with other tests, this assembly was added when we built the tests in
the iOS makefile, but they are not present in the Mono SDK.

Fixes https://github.com/xamarin/maccore/issues/1140