### PR TITLE
[tests] Fix `ARCondigurationTest.GetSupportedVideoFormats` on older devices

### DIFF
--- a/tests/monotouch-test/ARKit/ARConfigurationTest.cs
+++ b/tests/monotouch-test/ARKit/ARConfigurationTest.cs
@@ -12,32 +12,35 @@ namespace MonoTouchFixtures.ARKit {
 	[Preserve (AllMembers = true)]
 	public class ARCondigurationTest {
 
-		[SetUp]
-		public void Setup ()
-		{
-			TestRuntime.AssertXcodeVersion (9,3);
-		}
-
 		[Test]
 		public void SupportedVideoFormats ()
 		{
+			TestRuntime.AssertXcodeVersion (9, 3);
 			var svf = ARConfiguration.SupportedVideoFormats;
 			Assert.That (svf, Is.Empty, "empty");
 		}
 
 		[Test]
-		public void GetSupportedVideoFormats ()
+		public void GetSupportedVideoFormats_9_3 ()
 		{
+			TestRuntime.AssertXcodeVersion (9, 3);
 			Assert.NotNull (ARWorldTrackingConfiguration.GetSupportedVideoFormats (), "ARWorldTrackingConfiguration");
 			Assert.NotNull (AROrientationTrackingConfiguration.GetSupportedVideoFormats (), "AROrientationTrackingConfiguration");
 			Assert.NotNull (ARFaceTrackingConfiguration.GetSupportedVideoFormats (), "ARFaceTrackingConfiguration");
-			Assert.NotNull (ARImageTrackingConfiguration.GetSupportedVideoFormats (), "ARImageTrackingConfiguration");
 			Assert.NotNull (ARObjectScanningConfiguration.GetSupportedVideoFormats (), "ARObjectScanningConfiguration");
+		}
+
+		[Test]
+		public void GetSupportedVideoFormats_10_0 ()
+		{
+			TestRuntime.AssertXcodeVersion (10, 0);
+			Assert.NotNull (ARImageTrackingConfiguration.GetSupportedVideoFormats (), "ARImageTrackingConfiguration");
 		}
 
 		[Test]
 		public void Subclasses ()
 		{
+			// note: this can be run on any xcode / OS version since it's reflection only
 			// all subclasses of ARConfiguration must (re)export 'GetSupportedVideoFormats'
 			var c = typeof (ARConfiguration);
 			foreach (var sc in c.Assembly.GetTypes ()) {


### PR DESCRIPTION
`ARImageTrackingConfiguration` requires iOS 12 (Xcode 10) so split it in
a separate test case.

Fixes https://github.com/xamarin/maccore/issues/1335