### PR TITLE
[XHarness] Reneable the SystemSecurity tests on iOS, TvOS and WatchOS

### DIFF
--- a/tests/bcl-test/BCLTests/common-SystemSecurityXunit.ignore
+++ b/tests/bcl-test/BCLTests/common-SystemSecurityXunit.ignore
@@ -1,0 +1,19 @@
+# System.PlatformNotSupportedException : Operation is not supported on this platform. 
+System.Security.Cryptography.ProtectedDataTests.ProtectedDataTests.NullEntropyEquivalence2
+System.Security.Cryptography.ProtectedDataTests.ProtectedDataTests.NullEntropyEquivalence
+System.Security.Cryptography.ProtectedDataTests.ProtectedDataTests.RoundTrip
+System.Security.Cryptography.ProtectedDataTests.ProtectedDataTests.WrongEntropy
+System.Security.Cryptography.ProtectedDataTests.ProtectedDataTests.ProtectEmptyData(scope: CurrentUser, useEntropy: False) 
+System.Security.Cryptography.ProtectedDataTests.ProtectedDataTests.ProtectEmptyData(scope: CurrentUser, useEntropy: False)
+System.Security.Cryptography.ProtectedDataTests.ProtectedDataTests.ProtectEmptyData(scope: LocalMachine, useEntropy: True) 
+System.Security.Cryptography.ProtectedDataTests.ProtectedDataTests.ProtectEmptyData(scope: LocalMachine, useEntropy: True)
+System.Security.Cryptography.ProtectedDataTests.ProtectedDataTests.ProtectEmptyData(scope: CurrentUser, useEntropy: True) 
+System.Security.Cryptography.ProtectedDataTests.ProtectedDataTests.ProtectEmptyData(scope: CurrentUser, useEntropy: True) 
+System.Security.Cryptography.ProtectedDataTests.ProtectedDataTests.ProtectEmptyData(scope: LocalMachine, useEntropy: False) 
+System.Security.Cryptography.ProtectedDataTests.ProtectedDataTests.ProtectEmptyData(scope: LocalMachine, useEntropy: False) 
+
+# Exception messages: Assert.Equal() Failure
+# Expected: Byte[] [53, 237, 196, 55, 227, ...]
+# Actual:   Byte[] [53, 237, 196, 55, 227, ...] 
+System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests.StateTests.PostDecode_Encode_net46
+System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests.StateTests.PostDecode_ContentInfo_net46

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectDefinition.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectDefinition.cs
@@ -89,12 +89,12 @@ namespace BCLTestImporter {
 					if (!types.Any ()) {
 						continue;
 					}
-					dict[Path.GetFileName (path)] = types.First (t => !t.IsAbstract && !t.IsGenericType && t.FullName.Contains ("Test"));
+					dict[Path.GetFileName (path)] = types.First (t => !t.IsGenericType && t.FullName.Contains ("Test"));
 				} catch (ReflectionTypeLoadException e) { // ReflectionTypeLoadException
 					// we did get an exception, possible reason, the type comes from an assebly not loaded, but 
 					// nevertheless we can do something about it, get all the not null types in the exception
 					// and use one of them
-					var types = e.Types.Where (t => t != null).Where (t => !t.IsAbstract && !t.IsGenericType && t.FullName.Contains ("Test"));
+					var types = e.Types.Where (t => t != null).Where (t => !t.IsGenericType && t.FullName.Contains ("Test"));
 					if (types.Any()) {
 						dict[Path.GetFileName (path)] = types.First ();
 					}

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -111,7 +111,6 @@ namespace BCLTestImporter {
 		};
 			
 		static readonly List <string> CommonIgnoredAssemblies = new List <string> {
-			"monotouch_System.Security_xunit-test.dll",// issue https://github.com/xamarin/maccore/issues/1128
 			"monotouch_System.Threading.Tasks.Dataflow_xunit-test.dll", // issue https://github.com/xamarin/maccore/issues/1132
 			"monotouch_System.Transactions_test.dll", // issue https://github.com/xamarin/maccore/issues/1134
 			"monotouch_System_test.dll", // issues https://github.com/xamarin/maccore/issues/1135


### PR DESCRIPTION
Some of the test classes are abstract, and we needed to change the
generator to ignore that fact. Before the change, we would have 0 test
cases.

Failing tests are ignored.

Fixes https://github.com/xamarin/maccore/issues/1128