### PR TITLE
[XHarness] Reenable SystemTransactionsTests on iOS, TvOS and WatchOs.

### DIFF
--- a/tests/bcl-test/BCLTests/common-SystemTransactionsTests.ignore
+++ b/tests/bcl-test/BCLTests/common-SystemTransactionsTests.ignore
@@ -1,0 +1,3 @@
+# System.NotImplementedException : DTC unsupported, only SinglePhase commit supported for durable resource managers. 
+MonoTests.System.Transactions.EnlistTest.Vol0_Dur1_2PC
+MonoTests.System.Transactions.EnlistTest.Vol0_Dur2

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -110,7 +110,6 @@ namespace BCLTestImporter {
 			
 		static readonly List <string> CommonIgnoredAssemblies = new List <string> {
 			"monotouch_System.Security_xunit-test.dll",// issue https://github.com/xamarin/maccore/issues/1128
-			"monotouch_System.Transactions_test.dll", // issue https://github.com/xamarin/maccore/issues/1134
 			"monotouch_System_test.dll", // issues https://github.com/xamarin/maccore/issues/1135
 			"monotouch_System.Security_test.dll", // issue https://github.com/xamarin/maccore/issues/1139
 			"monotouch_System.Net.Http_test.dll", // issue https://github.com/xamarin/maccore/issues/1144 and https://github.com/xamarin/maccore/issues/1145


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/1134