### PR TITLE
[XHarness] Reneable Mono.Security tests on WatchOS.

### DIFF
--- a/tests/bcl-test/BCLTests/watchOS-MonoSecurityTests.ignore
+++ b/tests/bcl-test/BCLTests/watchOS-MonoSecurityTests.ignore
@@ -1,0 +1,2 @@
+# System.TypeLoadException : Could not resolve type with token 010000c6 from typeref (expected class 'Mono.Net.Security.NoReflectionHelper' in assembly 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089')
+MonoTests.Mono.Security.TestProvider.GetProvider

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -137,7 +137,6 @@ namespace BCLTestImporter {
 		};
 
 		static readonly List<string> watcOSIgnoredAssemblies = new List<string> {
-			"monotouch_Mono.Security_test.dll", // issue https://github.com/xamarin/maccore/issues/1142
 		};
 
 		private static readonly List<(string name, string[] assemblies)> macTestProjects = new List<(string name, string[] assemblies)> {


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/1142