### PR TITLE
[macos] Always create new NSFont instance when surfacing

### DIFF
--- a/src/AppKit/NSFont.cs
+++ b/src/AppKit/NSFont.cs
@@ -52,5 +52,138 @@ namespace AppKit {
 			}
 			return advancements;
 		}
+
+		public static NSFont FromFontName (string fontName, nfloat fontSize)
+		{
+			var ptr = _FromFontName (fontName, fontSize);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+		public static NSFont FromDescription (NSFontDescriptor fontDescriptor, nfloat fontSize)
+		{
+			var ptr = _FromDescription (fontDescriptor, fontSize);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+		public static NSFont FromDescription (NSFontDescriptor fontDescriptor, NSAffineTransform textTransform)
+		{
+			var ptr = _FromDescription (fontDescriptor, textTransform);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+		public static NSFont UserFontOfSize (nfloat fontSize)
+		{
+			var ptr = _UserFontOfSize (fontSize);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+		public static NSFont UserFixedPitchFontOfSize (nfloat fontSize)
+		{
+			var ptr = _UserFixedPitchFontOfSize (fontSize);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+		public static NSFont SystemFontOfSize (nfloat fontSize)
+		{
+			var ptr = _SystemFontOfSize (fontSize);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+		public static NSFont BoldSystemFontOfSize (nfloat fontSize)
+		{
+			var ptr = _BoldSystemFontOfSize (fontSize);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+		public static NSFont LabelFontOfSize (nfloat fontSize)
+		{
+			var ptr = _LabelFontOfSize (fontSize);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+		public static NSFont TitleBarFontOfSize (nfloat fontSize)
+		{
+			var ptr = _TitleBarFontOfSize (fontSize);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+		public static NSFont MenuFontOfSize (nfloat fontSize)
+		{
+			var ptr = _MenuFontOfSize (fontSize);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+		public static NSFont MenuBarFontOfSize (nfloat fontSize)
+		{
+			var ptr = _MenuBarFontOfSize (fontSize);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+		public static NSFont MessageFontOfSize (nfloat fontSize)
+		{
+			var ptr = _MessageFontOfSize (fontSize);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+		public static NSFont PaletteFontOfSize (nfloat fontSize)
+		{
+			var ptr = _PaletteFontOfSize (fontSize);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+		public static NSFont ToolTipsFontOfSize (nfloat fontSize)
+		{
+			var ptr = _ToolTipsFontOfSize (fontSize);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+		public static NSFont ControlContentFontOfSize (nfloat fontSize)
+		{
+			var ptr = _ControlContentFontOfSize (fontSize);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+ 		[Deprecated (PlatformName.MacOSX, 10, 13)]
+		public NSFont PrinterFont { 
+			get {
+				var ptr = _PrinterFont;
+				return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+			}
+		}
+ 
+ 		[Deprecated (PlatformName.MacOSX, 10, 13)]
+		public NSFont ScreenFont {
+			get {
+				var ptr = _ScreenFont;
+				return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+			}
+		}
+ 
+ 		[Deprecated (PlatformName.MacOSX, 10, 13)]
+		public NSFont ScreenFontWithRenderingMode (NSFontRenderingMode renderingMode)
+		{
+			var ptr = _ScreenFontWithRenderingMode (renderingMode);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+		public NSFont GetVerticalFont ()
+		{
+			var ptr = _GetVerticalFont ();
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+ 		[Mac (10,11)]
+		public static NSFont SystemFontOfSize (nfloat fontSize, nfloat weight)
+		{
+			var ptr = _SystemFontOfSize (fontSize, weight);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
+ 
+ 		[Mac (10,11)]
+		public static NSFont MonospacedDigitSystemFontOfSize (nfloat fontSize, nfloat weight)
+		{
+			var ptr = _MonospacedDigitSystemFontOfSize (fontSize, weight);
+			return ptr == IntPtr.Zero ? null : new NSFont (ptr);
+		}
 	}
 }

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -6190,28 +6190,33 @@ namespace AppKit {
 	[DisableDefaultCtor] // crash at runtime (e.g. description). Documentation state: "You don’t create NSFont objects using the alloc and init methods."
 	partial interface NSFont : NSSecureCoding, NSCopying {
 		[Static]
+		[Internal]
 		[Export ("fontWithName:size:")]
-		NSFont FromFontName (string fontName, nfloat fontSize);
+		IntPtr _FromFontName (string fontName, nfloat fontSize);
 
 		//[Static]
 		//[Export ("fontWithName:matrix:")]
 		//NSFont FromFontName (string fontName, float [] fontMatrix);
 
 		[Static]
+		[Internal]
 		[Export ("fontWithDescriptor:size:")]
-		NSFont FromDescription (NSFontDescriptor fontDescriptor, nfloat fontSize);
+		IntPtr _FromDescription (NSFontDescriptor fontDescriptor, nfloat fontSize);
 
 		[Static]
+		[Internal]
 		[Export ("fontWithDescriptor:textTransform:")]
-		NSFont FromDescription (NSFontDescriptor fontDescriptor, [NullAllowed] NSAffineTransform textTransform);
+		IntPtr _FromDescription (NSFontDescriptor fontDescriptor, [NullAllowed] NSAffineTransform textTransform);
 
 		[Static]
+		[Internal]
 		[Export ("userFontOfSize:")]
-		NSFont UserFontOfSize (nfloat fontSize);
+		IntPtr _UserFontOfSize (nfloat fontSize);
 
 		[Static]
+		[Internal]
 		[Export ("userFixedPitchFontOfSize:")]
-		NSFont UserFixedPitchFontOfSize (nfloat fontSize);
+		IntPtr _UserFixedPitchFontOfSize (nfloat fontSize);
 
 		[Static]
 		[Export ("setUserFont:")]
@@ -6222,44 +6227,54 @@ namespace AppKit {
 		void SetUserFixedPitchFont ([NullAllowed] NSFont aFont);
 
 		[Static]
+		[Internal]
 		[Export ("systemFontOfSize:")]
-		NSFont SystemFontOfSize (nfloat fontSize);
+		IntPtr _SystemFontOfSize (nfloat fontSize);
 
 		[Static]
+		[Internal]
 		[Export ("boldSystemFontOfSize:")]
-		NSFont BoldSystemFontOfSize (nfloat fontSize);
+		IntPtr _BoldSystemFontOfSize (nfloat fontSize);
 
 		[Static]
+		[Internal]
 		[Export ("labelFontOfSize:")]
-		NSFont LabelFontOfSize (nfloat fontSize);
+		IntPtr _LabelFontOfSize (nfloat fontSize);
 
 		[Static]
+		[Internal]
 		[Export ("titleBarFontOfSize:")]
-		NSFont TitleBarFontOfSize (nfloat fontSize);
+		IntPtr _TitleBarFontOfSize (nfloat fontSize);
 
 		[Static]
+		[Internal]
 		[Export ("menuFontOfSize:")]
-		NSFont MenuFontOfSize (nfloat fontSize);
+		IntPtr _MenuFontOfSize (nfloat fontSize);
 
 		[Static]
+		[Internal]
 		[Export("menuBarFontOfSize:")]
-		NSFont MenuBarFontOfSize (nfloat fontSize);
+		IntPtr _MenuBarFontOfSize (nfloat fontSize);
 
 		[Static]
+		[Internal]
 		[Export("messageFontOfSize:")]
-		NSFont MessageFontOfSize (nfloat fontSize);
+		IntPtr _MessageFontOfSize (nfloat fontSize);
 
 		[Static]
+		[Internal]
 		[Export ("paletteFontOfSize:")]
-		NSFont PaletteFontOfSize (nfloat fontSize);
+		IntPtr _PaletteFontOfSize (nfloat fontSize);
 
 		[Static]
+		[Internal]
 		[Export ("toolTipsFontOfSize:")]
-		NSFont ToolTipsFontOfSize (nfloat fontSize);
+		IntPtr _ToolTipsFontOfSize (nfloat fontSize);
 
 		[Static]
+		[Internal]
 		[Export ("controlContentFontOfSize:")]
-		NSFont ControlContentFontOfSize (nfloat fontSize);
+		IntPtr _ControlContentFontOfSize (nfloat fontSize);
 
 		[Static]
 		[Export ("systemFontSize")]
@@ -6361,15 +6376,18 @@ namespace AppKit {
 
 		[Export ("printerFont")]
 		[Deprecated (PlatformName.MacOSX, 10, 13)]
-		NSFont PrinterFont { get; }
+		[Internal]
+		IntPtr _PrinterFont { get; }
 
 		[Export ("screenFont")]
 		[Deprecated (PlatformName.MacOSX, 10, 13)]
-		NSFont ScreenFont { get; }
+		[Internal]
+		IntPtr _ScreenFont { get; }
 
 		[Export ("screenFontWithRenderingMode:")]
 		[Deprecated (PlatformName.MacOSX, 10, 13)]
-		NSFont ScreenFontWithRenderingMode (NSFontRenderingMode renderingMode);
+		[Internal]
+		IntPtr _ScreenFontWithRenderingMode (NSFontRenderingMode renderingMode);
 
 		[Export ("renderingMode")]
 		[Deprecated (PlatformName.MacOSX, 10, 13)]
@@ -6382,7 +6400,8 @@ namespace AppKit {
 		// Not a property because this causes the creation of a new font on request in the specified configuration.
 		//
 		[Export ("verticalFont")]
-		NSFont GetVerticalFont ();
+		[Internal]
+		IntPtr _GetVerticalFont ();
 
 		[Field ("NSFontFamilyAttribute")]
 		NSString FamilyAttribute { get; }
@@ -6456,12 +6475,14 @@ namespace AppKit {
 		[Mac (10,11)]
 		[Static]
 		[Export ("systemFontOfSize:weight:")]
-		NSFont SystemFontOfSize (nfloat fontSize, nfloat weight);
+		[Internal]
+		IntPtr _SystemFontOfSize (nfloat fontSize, nfloat weight);
 
 		[Mac (10,11)]
 		[Static]
 		[Export ("monospacedDigitSystemFontOfSize:weight:")]
-		NSFont MonospacedDigitSystemFontOfSize (nfloat fontSize, nfloat weight);
+		[Internal]
+		IntPtr _MonospacedDigitSystemFontOfSize (nfloat fontSize, nfloat weight);
 
 		[Mac (10,13)]
 		[Export ("boundingRectForCGGlyph:")]


### PR DESCRIPTION
- This is similar to what iOS does with UIFont
- Found in iOS originally with https://bugzilla.xamarin.com/show_bug.cgi?id=25511