### PR TITLE
[generator] Flow the `[NullAllowed]` information from properties when generating `_Extensions` methods. Fixes #5408

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -5270,7 +5270,17 @@ public partial class Generator : IMemberGatherer {
 					indent++;
 					print ("using (var autorelease_pool = new NSAutoreleasePool ()) {");
 				}
-				GenerateMethodBody (minfo, minfo.method, minfo.selector, false, null, BodyOption.None, null);
+				PropertyInfo pinfo = null;
+				MethodInfo method = minfo.method;
+				bool null_allowed = false;
+				if (method.IsSpecialName) {
+					// could be a property setter where [NullAllowed] is _allowed_
+					// we do not need the information if it's a getter (it won't change generated code)
+					pinfo = GetProperty (method, getter: false, setter: true);
+					if (pinfo != null)
+						null_allowed = AttributeManager.HasAttribute<NullAllowedAttribute> (pinfo);
+				}
+				GenerateMethodBody (minfo, minfo.method, minfo.selector, null_allowed, null, BodyOption.None, null);
 				if (minfo.is_autorelease) {
 					print ("}");
 					indent--;
@@ -5296,7 +5306,16 @@ public partial class Generator : IMemberGatherer {
 			}
 		}
 	}
-	
+
+	static PropertyInfo GetProperty (MethodInfo method, bool getter = true, bool setter = true)
+	{
+		var props = method.DeclaringType.GetProperties ();
+		if (method.GetParameters ().Length == 0)
+			return !getter ? null : props.FirstOrDefault (prop => prop.GetGetMethod () == method);
+		else
+			return !setter ? null : props.FirstOrDefault (prop => prop.GetSetMethod () == method);
+	}
+
 	public string GetGeneratedTypeName (Type type)
 	{
 		var bindOnType = AttributeManager.GetCustomAttributes<BindAttribute> (type);


### PR DESCRIPTION
Otherwise we can end up without argument checks and de-reference null
arguments to get the `Handle` property.

Example from #5403 binding original issue:

```diff
diff --git a/src/appkit.cs b/src/appkit.cs
index daf22b75..48390cb8 100644
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -431,6 +431,7 @@ namespace AppKit {
        interface NSAppearanceCustomization {

                [Mac (10,9)]
+               [NullAllowed]
                [Export ("appearance", ArgumentSemantic.Strong)]
                NSAppearance Appearance { get; set; }
```

would generate

```csharp
		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
		public static void SetAppearance (this INSAppearanceCustomization This, NSAppearance value)
		{
			global::AppKit.NSApplication.EnsureUIThread ();
			global::ObjCRuntime.Messaging.void_objc_msgSend_IntPtr (This.Handle, Selector.GetHandle ("setAppearance:"), value.Handle);
		}
```

which would throw an `NullReferenceException` if `value` is `null`
because the `[NullAllowed]` on the `PropertyInfo` was not considered when
generating the extension method - at least not for the call, the null
check was fine (and removed).

Reviewing the PR **requires** checking the bot-generated "Generator Diff" too.

Tests to be added along the binding fix for #5403

Note: this replace the (now closed) PR https://github.com/xamarin/xamarin-macios/pull/5415

reference: https://github.com/xamarin/xamarin-macios/issues/5408