### PR TITLE
[appkit] Allow `null` on `NSAppearanceCustomization.Appearance`. Fixes #5403

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -431,6 +431,7 @@ namespace AppKit {
 	interface NSAppearanceCustomization {
 
 		[Mac (10,9)]
+		[NullAllowed]
 		[Export ("appearance", ArgumentSemantic.Strong)]
 		NSAppearance Appearance { get; set; }
 

--- a/tests/apitest/src/AppKit/NSAppearance.cs
+++ b/tests/apitest/src/AppKit/NSAppearance.cs
@@ -54,5 +54,16 @@ namespace Xamarin.Mac.Tests
 
 			Assert.AreNotEqual (appearance, NSAppearance.CurrentAppearance, "NSAppearanceShouldChangeCurrentAppearance - Failed to change appearance.");
 		}
+
+#if XAMCORE_2_0
+		[Test]
+		public void NSAppearanceCustomizationNull ()
+		{
+			Asserts.EnsureYosemite ();
+
+			using (NSButton b = new NSButton ())
+				b.SetAppearance (null);
+		}
+#endif
 	}
 }


### PR DESCRIPTION
> The default value for this property is nil, which means that the
> receiver uses the appearance it inherits from the nearest ancestor that
> has set an appearance. When you set appearance to a non-nil value, the
> receiver and the views it contains use the specified appearance.
> https://developer.apple.com/documentation/appkit/nsappearancecustomization/1533925-appearance?language=objc

reference: https://github.com/xamarin/xamarin-macios/issues/5403

Unit test added. Without it we would not have found it did not work until
it was reported again (since it would have been silently ignored).

reference: https://github.com/xamarin/xamarin-macios/issues/5408