### PR TITLE
[XHarness] Allow to ignore files per arch or runtime.

### DIFF
--- a/tests/bcl-test/BCLTests/iOS32-CorlibTests.ignore
+++ b/tests/bcl-test/BCLTests/iOS32-CorlibTests.ignore
@@ -1,0 +1,1 @@
+MonoTests.System.IntPtrTest.Test64on32

--- a/tests/bcl-test/BCLTests/templates/common/IgnoreFileParser.cs
+++ b/tests/bcl-test/BCLTests/templates/common/IgnoreFileParser.cs
@@ -70,9 +70,9 @@ namespace BCLTests {
 #endif
 			var ignoredTests = new List<string> ();
 			foreach (var f in Directory.GetFiles (contentDir, "*.ignore")) {
+#if MONOMAC
 				// we might have some ignores depending on the arch
 				var shouldAdd = false;
-#if MONOMAC
 				if (isFull) {
 					shouldAdd = !f.Contains ("Modern");
 				} else {

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -354,18 +354,19 @@ namespace BCLTestImporter {
 
 		internal static string GetCommonIgnoreFileName (string projectName) => $"common-{projectName}.ignore";
 		
-		internal static string GetIgnoreFileName (string projectName, Platform platform)
+		internal static List<string> GetIgnoreFileName (string projectName, Platform platform)
 		{
 			switch (platform) {
 			case Platform.iOS:
-				return $"iOS-{projectName}.ignore";
+				return new List<string> { $"iOS-{projectName}.ignore", $"iOS32-{projectName}.ignore", $"iOS64-{projectName}.ignore" };
 			case Platform.MacOSFull:
+				return new List<string> { $"macOS-{projectName}.ignore", $"macOSFull-{projectName}.ignore" };
 			case Platform.MacOSModern:
-				return $"macOS-{projectName}.ignore";
+				return new List<string> { $"macOS-{projectName}.ignore", $"macOSModern-{projectName}.ignore" };
 			case Platform.TvOS:
-				return $"tvOS-{projectName}.ignore";
+				return new List<string> { $"tvOS-{projectName}.ignore" };
 			case Platform.WatchOS:
-				return $"watchOS-{projectName}.ignore";
+				return new List<string> { $"watchOS-{projectName}.ignore" };
 			default:
 				return null;
 			}
@@ -379,9 +380,13 @@ namespace BCLTestImporter {
 			var commonIgnore = Path.Combine (templateDir, GetCommonIgnoreFileName (projectName));
 			if (File.Exists (commonIgnore))
 				yield return commonIgnore;
-			var platformIgnore = Path.Combine (templateDir, GetIgnoreFileName (projectName, platform));
-			if (File.Exists (platformIgnore))
-				yield return platformIgnore;
+			var platformIgnores = GetIgnoreFileName (projectName, platform);
+			
+			foreach (var p in platformIgnores) {
+				var ignore = Path.Combine (templateDir, p);
+				if (File.Exists (ignore))
+					yield return ignore;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
Some tests migth fail on a specific arch or runtime, this commit allows
to create a ignore file per arch or runtime.

The new ignore files are:

* iOS32-ProjectName.ignore - for ios 32.
* iOS64-ProjectName.ignore - for ios 64.
* macOSFull-ProjectName.ignore - for Mac OS Full.
* macOSModern-ProjectName.ignore - for MAc OS Modern.

Fixes https://github.com/xamarin/maccore/issues/1351