### PR TITLE
[generator] Fix BI0000 when no argument semantics are present on a property. Fixes #5444

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -4526,7 +4526,7 @@ public partial class Generator : IMemberGatherer {
 	
 	bool DoesPropertyNeedDirtyCheck (PropertyInfo pi, ExportAttribute ea) 
 	{
-		switch (ea.ArgumentSemantic) {
+		switch (ea?.ArgumentSemantic) {
 		case ArgumentSemantic.Copy:
 		case ArgumentSemantic.Retain: // same as Strong
 		case ArgumentSemantic.None:

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -561,6 +561,9 @@ namespace GeneratorTests
 			Assert.AreEqual (modelName, attrib.ConstructorArguments [0].Value, "Custom ObjC name");
 		}
 
+		[Test]
+		public void GHIssue5444 () => BuildFile (Profile.iOS, "ghissue5444.cs");
+
 		BGenTool BuildFile (Profile profile, params string [] filenames)
 		{
 			return BuildFile (profile, true, false, filenames);

--- a/tests/generator/ghissue5444.cs
+++ b/tests/generator/ghissue5444.cs
@@ -1,0 +1,19 @@
+using Foundation;
+using ObjCRuntime;
+
+namespace GHIssue5444 {
+
+	[BaseType (typeof (NSObject))]
+	interface CardScheme {
+		[Export ("colorScheme", ArgumentSemantic.Assign)]
+		new NSString ColorScheme { get; set; }
+
+		[Export ("shapeScheme", ArgumentSemantic.Assign)]
+		new NSString ShapeScheme { get; set; }
+
+		NSString SemanticColorScheme {
+			[Wrap ("Runtime.GetNSObject<NSString> (ColorScheme.Handle, false)")] get;
+			[Wrap ("ColorScheme = value")] set;
+		}
+	}
+}


### PR DESCRIPTION
This can happen if a `[Wrap]` is used on the property getter (and setter)
instead of directly on the property.

In such condition we can safely assume that no dirty check is needed and
can continue with, unmodified, generation (using the wrapped content).

reference: https://github.com/xamarin/xamarin-macios/issues/5444