### PR TITLE
[CoreFoundation] Add UnmanagedFunctionPointer attribute to delegate used for native callbacks. Fixes #5447.

### DIFF
--- a/src/CoreFoundation/DispatchBlock.cs
+++ b/src/CoreFoundation/DispatchBlock.cs
@@ -170,6 +170,7 @@ namespace CoreFoundation {
 			return Wait (new DispatchTime (DispatchTime.Now, timeout));
 		}
 
+		[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 		delegate void DispatchBlockCallback (IntPtr block);
 
 		public static explicit operator Action (DispatchBlock block)


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/5447.