### PR TITLE
[XHarness] Remove not needed dll from the test templates.

### DIFF
--- a/tests/bcl-test/BCLTests/BCLTests-mac.csproj.in
+++ b/tests/bcl-test/BCLTests/BCLTests-mac.csproj.in
@@ -106,9 +106,6 @@
     <Reference Include="xunit.runner.utility.netstandard20">
       <HintPath>..\..\..\packages\xunit.runner.utility.2.4.0\lib\netstandard2.0\xunit.runner.utility.netstandard20.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.Serialization.Formatters.Soap">
-      <HintPath>..\..\..\external\mono\mcs\class\lib\monotouch\System.Runtime.Serialization.Formatters.Soap.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions">
       <HintPath>..\..\..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
     </Reference>

--- a/tests/bcl-test/BCLTests/BCLTests-tv.csproj.in
+++ b/tests/bcl-test/BCLTests/BCLTests-tv.csproj.in
@@ -173,9 +173,6 @@
     <Reference Include="xunit.runner.utility.netstandard20">
       <HintPath>..\..\..\packages\xunit.runner.utility.2.4.0\lib\netstandard2.0\xunit.runner.utility.netstandard20.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.Serialization.Formatters.Soap">
-      <HintPath>..\..\..\external\mono\mcs\class\lib\monotouch\System.Runtime.Serialization.Formatters.Soap.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions">
       <HintPath>..\..\..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
     </Reference>

--- a/tests/bcl-test/BCLTests/BCLTests-watchos-extension.csproj.in
+++ b/tests/bcl-test/BCLTests/BCLTests-watchos-extension.csproj.in
@@ -132,9 +132,6 @@
     <Reference Include="xunit.runner.utility.netstandard20">
       <HintPath>..\..\..\packages\xunit.runner.utility.2.4.0\lib\netstandard2.0\xunit.runner.utility.netstandard20.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.Serialization.Formatters.Soap">
-      <HintPath>..\..\..\external\mono\mcs\class\lib\monotouch\System.Runtime.Serialization.Formatters.Soap.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions">
       <HintPath>..\..\..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
     </Reference>

--- a/tests/bcl-test/BCLTests/BCLTests.csproj.in
+++ b/tests/bcl-test/BCLTests/BCLTests.csproj.in
@@ -185,9 +185,6 @@
     <Reference Include="xunit.runner.utility.netstandard20">
       <HintPath>..\..\..\packages\xunit.runner.utility.2.4.0\lib\netstandard2.0\xunit.runner.utility.netstandard20.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.Serialization.Formatters.Soap">
-      <HintPath>..\..\..\external\mono\mcs\class\lib\monotouch\System.Runtime.Serialization.Formatters.Soap.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions">
       <HintPath>..\..\..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Dll added by mistake. Does not change the execution, but removes a warning. 