### PR TITLE
[XHarness] Remove not needed ignore file for System.Core.

### DIFF
--- a/tests/bcl-test/BCLTests/common-SystemCoreTests.ignore
+++ b/tests/bcl-test/BCLTests/common-SystemCoreTests.ignore
@@ -1,2 +1,0 @@
-# System.NotSupportedException : Cannot create boxed TypedReference, ArgIterator, or RuntimeArgumentHandle Objects. 
-MonoTests.System.Linq.Expressions.ExpressionTest_Call.Connect319190


### PR DESCRIPTION
Since we support filtering via categories, we do not longer need the
ignore file in these tests.