### PR TITLE
[XHarness] Remove not needed ignore file for System.Transactions.

### DIFF
--- a/tests/bcl-test/BCLTests/common-SystemTransactionsTests.ignore
+++ b/tests/bcl-test/BCLTests/common-SystemTransactionsTests.ignore
@@ -1,3 +1,0 @@
-# System.NotImplementedException : DTC unsupported, only SinglePhase commit supported for durable resource managers. 
-MonoTests.System.Transactions.EnlistTest.Vol0_Dur1_2PC
-MonoTests.System.Transactions.EnlistTest.Vol0_Dur2


### PR DESCRIPTION
Since we support filtering via categories, we do not longer need the
ignore file in these tests.