### PR TITLE
[XHarness] Clean the System.Net.Http ignore file.

### DIFF
--- a/tests/bcl-test/BCLTests/common-SystemNetHttpTests.ignore
+++ b/tests/bcl-test/BCLTests/common-SystemNetHttpTests.ignore
@@ -60,8 +60,3 @@ MonoTests.System.Net.Http.HttpClientTest.Post_TransferEncodingChunked
 #  Expected: False
 #  But was:  True
 MonoTests.System.Net.Http.HttpClientTest.Post_StreamCaching
-
-#  #3
-#  Expected: True
-#  But was:  False
-MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Content_MaxResponseContentBufferSize_Error

--- a/tests/bcl-test/BCLTests/watchOS-SystemNetHttpTests.ignore
+++ b/tests/bcl-test/BCLTests/watchOS-SystemNetHttpTests.ignore
@@ -19,3 +19,4 @@ MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Error
 MonoTests.System.Net.Http.HttpClientTest.Send_Content_BomEncoding
 MonoTests.System.Net.Http.HttpClientTest.Send_Content_Get
 MonoTests.System.Net.Http.HttpClientTest.Send_Content_Put
+MonoTests.System.Net.Http.HttpClientTest.Send_Complete_Content_MaxResponseContentBufferSize_Error


### PR DESCRIPTION
Since we support categories, there is a test that does not longer needs
to be ignored in ios and tvos but needs to be in watchos (we do not yet
have the correct test assembly for the platform).