### PR TITLE
[Foundation] Ensure that we do not block when in the background without a background session.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -51,7 +51,7 @@ using nint = System.Int32;
 using nuint = System.UInt32;
 #endif
 
-#if !MONOMAC && !WATCH
+#if !MONOMAC
 using UIKit;
 #endif
 
@@ -124,7 +124,7 @@ namespace Foundation {
 		readonly NSUrlSession session;
 		readonly Dictionary<NSUrlSessionTask, InflightData> inflightRequests;
 		readonly object inflightRequestsLock = new object ();
-#if !MONOMAC && !WATCH
+#if !MONOMAC && !MONOTOUCH_WATCH
 		readonly bool isBackgroundSession = false;
 		NSObject notificationToken;  // needed to make sure we do not hang if not using a background session
 #endif
@@ -150,7 +150,7 @@ namespace Foundation {
 			if (configuration == null)
 				throw new ArgumentNullException (nameof (configuration));
 
-#if !MONOMAC && !WATCH
+#if !MONOMAC  && !MONOTOUCH_WATCH 
 			// if the configuration has an identifier, we are dealing with a background session, 
 			// therefore, we do not have to listen to the notifications.
 			isBackgroundSession = !string.IsNullOrEmpty (configuration.Identifier);
@@ -173,13 +173,12 @@ namespace Foundation {
 			inflightRequests = new Dictionary<NSUrlSessionTask, InflightData> ();
 		}
 
-#if !MONOMAC && !WATCH
+#if !MONOMAC  && !MONOTOUCH_WATCH
 
 		void AddNotification ()
 		{
 			if (!isBackgroundSession && notificationToken == null)
-				using (var notification = new NSString ("UIApplicationWillResignActiveNotification"))
-					notificationToken = NSNotificationCenter.DefaultCenter.AddObserver (notification, BackgroundNotificationCb);
+				notificationToken = NSNotificationCenter.DefaultCenter.AddObserver (UIApplication.WillResignActiveNotification, BackgroundNotificationCb);
 		}
 
 		void RemoveNotification ()
@@ -206,7 +205,7 @@ namespace Foundation {
 		{
 			lock (inflightRequestsLock) {
 				inflightRequests.Remove (task);
-#if !MONOMAC && !WATCH
+#if !MONOMAC  && !MONOTOUCH_WATCH
 				// do we need to be notified? If we have not inflightData, we do not
 				if (inflightRequests.Count == 0)
 					RemoveNotification ();
@@ -221,7 +220,7 @@ namespace Foundation {
 
 		protected override void Dispose (bool disposing)
 		{
-#if !MONOMAC && !WATCH
+#if !MONOMAC  && !MONOTOUCH_WATCH
 			// remove the notification if present, method checks against null
 			RemoveNotification ();
 #endif
@@ -305,7 +304,7 @@ namespace Foundation {
 			});
 
 			lock (inflightRequestsLock) {
-#if !MONOMAC && !WATCH
+#if !MONOMAC  && !MONOTOUCH_WATCH
 				// Add the notification whenever needed
 				AddNotification ();
 #endif

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -51,10 +51,6 @@ using nint = System.Int32;
 using nuint = System.UInt32;
 #endif
 
-#if !MONOMAC
-using UIKit;
-#endif
-
 #if SYSTEM_NET_HTTP
 namespace System.Net.Http {
 #else
@@ -175,6 +171,7 @@ namespace Foundation {
 			inflightRequests = new Dictionary<NSUrlSessionTask, InflightData> ();
 		}
 
+#if !MONOMAC
 		void BackgoundNotificationCb (NSNotification obj)
 		{
 			// we do not need to call the lock, we call cancel on the source, that will trigger all the needed code to 
@@ -183,6 +180,7 @@ namespace Foundation {
 				pair.Value.CompletionSource.TrySetCanceled ();
 			}
 		}
+#endif
 
 		public long MaxInputInMemory { get; set; } = long.MaxValue;
 

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -153,7 +153,8 @@ namespace Foundation {
 			// if the configuration has an identifier, we are dealing with a background session, 
 			// therefore, we do not have to listen to the notifications.
 			if (string.IsNullOrEmpty (configuration.Identifier)) {
-				notificationToken = NSNotificationCenter.DefaultCenter.AddObserver (UIApplication.WillResignActiveNotification, BackgoundNotificationCb);
+				using (var notification = new NSString ("UIApplicationWillResignActiveNotification"))
+					notificationToken = NSNotificationCenter.DefaultCenter.AddObserver (notification, BackgoundNotificationCb);
 			}
 #endif
 

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -184,8 +184,10 @@ namespace Foundation {
 
 		void RemoveNotification ()
 		{
-			if (notificationToken != null)
+			if (notificationToken != null) {
 				NSNotificationCenter.DefaultCenter.RemoveObserver (notificationToken);
+				notificationToken = null;
+			}
 		}
 
 		void BackgroundNotificationCb (NSNotification obj)


### PR DESCRIPTION
The mono threadpool gets into an unknown state when the application goes
into the background. This fix allows the task that are inflight to be
canceled when the app goes to the background allowing the application
not to hang and letting the developer retyr the request.

If a developer needs to work with the app in the background, he should
be using a background session, this fix just ensures that we are left in
a known state but does not mean that developers should use this kind of
sessions.

The MessageHandler class is just used in Mac OS X and does not have the
idea of the app going to the background, therefore the fix is not needed
in that handler.