### PR TITLE
[generator] Warn if [NullAllowed] is used on methods. Fixes #4416

### DIFF
--- a/docs/website/generator-errors.md
+++ b/docs/website/generator-errors.md
@@ -216,6 +216,14 @@ This usually indicates a bug in Xamarin.iOS/Xamarin.Mac; please [file a bug repo
 
 ### <a name='BI1117'/>BI1117: The member '*' is decorated with [Static] and its container class * is decorated with [Category] this leads to hard to use code. Please inline * into * class.
 
+### <a name='BI1118'/>[NullAllowed] should not be used on methods, like '*', but only on properties, parameters and return values.
+
+The `[NullAllowed]` attribute should not be allowed on methods but it could break existing binding projects.
+
+Historically it was used on property setters. However using the attribute on _other_ methods can be misleading, e.g. should it apply to all parameters, the return value... and its presence/action can be misinterpreted in code reviews leading to binding bugs.
+
+To fix this warning use the `[NullAllowed]` attribute onnly on parameters, properties or return values.
+
 <!-- 2xxx: reserved -->
 <!-- 3xxx: reserved -->
 <!-- 4xxx: reserved -->

--- a/docs/website/generator-errors.md
+++ b/docs/website/generator-errors.md
@@ -222,7 +222,7 @@ The `[NullAllowed]` attribute should not be allowed on methods but it could brea
 
 Historically it was used on property setters. However using the attribute on _other_ methods can be misleading, e.g. should it apply to all parameters, the return value... and its presence/action can be misinterpreted in code reviews leading to binding bugs.
 
-To fix this warning use the `[NullAllowed]` attribute onnly on parameters, properties or return values.
+To fix this warning use the `[NullAllowed]` attribute only on parameters, properties or return values.
 
 <!-- 2xxx: reserved -->
 <!-- 3xxx: reserved -->

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -4096,6 +4096,9 @@ public partial class Generator : IMemberGatherer {
 		if (null_allowed_override)
 			return;
 
+		if (AttributeManager.HasAttribute<NullAllowedAttribute> (mi))
+			ErrorHelper.Show (new BindingException (1118, false, $"[NullAllowed] should not be used on methods, like '{mi}', but only on properties, parameters and return values."));
+
 		foreach (var pi in mi.GetParameters ()) {
 			var needs_null_check = ParameterNeedsNullCheck (pi, mi, propInfo);
 			if (!needs_null_check)
@@ -4808,7 +4811,10 @@ public partial class Generator : IMemberGatherer {
 		if (pi.CanWrite){
 			var setter = pi.GetSetMethod ();
 			var ba = GetBindAttribute (setter);
-			bool null_allowed = AttributeManager.HasAttribute<NullAllowedAttribute> (pi) || AttributeManager.HasAttribute<NullAllowedAttribute> (setter);
+			bool null_allowed = AttributeManager.HasAttribute<NullAllowedAttribute> (setter);
+			if (null_allowed)
+				ErrorHelper.Show (new BindingException (1118, false, $"[NullAllowed] should not be used on methods, like '{setter}', but only on properties, parameters and return values."));
+			null_allowed |= AttributeManager.HasAttribute<NullAllowedAttribute> (pi);
 			var not_implemented_attr = AttributeManager.GetCustomAttribute<NotImplementedAttribute> (setter);
 			string sel;
 

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -564,6 +564,28 @@ namespace GeneratorTests
 		[Test]
 		public void GHIssue5444 () => BuildFile (Profile.iOS, "ghissue5444.cs");
 
+		[Test]
+		public void GH5416_method ()
+		{
+			var bgen = new BGenTool ();
+			bgen.Profile = Profile.iOS;
+			bgen.AddTestApiDefinition ("ghissue5416b.cs");
+			bgen.CreateTemporaryBinding ();
+			bgen.AssertExecute ("build");
+			bgen.AssertWarning (1118, "[NullAllowed] should not be used on methods, like 'NSString Method(Foundation.NSDate, Foundation.NSObject)', but only on properties, parameters and return values.");
+		}
+
+		[Test]
+		public void GH5416_setter ()
+		{
+			var bgen = new BGenTool ();
+			bgen.Profile = Profile.iOS;
+			bgen.AddTestApiDefinition ("ghissue5416a.cs");
+			bgen.CreateTemporaryBinding ();
+			bgen.AssertExecute ("build");
+			bgen.AssertWarning (1118, "[NullAllowed] should not be used on methods, like 'Void set_Setter(Foundation.NSString)', but only on properties, parameters and return values.");
+		}
+
 		BGenTool BuildFile (Profile profile, params string [] filenames)
 		{
 			return BuildFile (profile, true, false, filenames);

--- a/tests/generator/ghissue5416a.cs
+++ b/tests/generator/ghissue5416a.cs
@@ -1,0 +1,11 @@
+using Foundation;
+using ObjCRuntime;
+
+namespace GHIssue5416 {
+
+	[BaseType (typeof (NSObject))]
+	interface NullAllowedWarning {
+		[Export ("setter", ArgumentSemantic.Assign)]
+		NSString Setter { get; [NullAllowed] set; }
+	}
+}

--- a/tests/generator/ghissue5416b.cs
+++ b/tests/generator/ghissue5416b.cs
@@ -1,0 +1,12 @@
+using Foundation;
+using ObjCRuntime;
+
+namespace GHIssue5416 {
+
+	[BaseType (typeof (NSObject))]
+	interface NullAllowedWarning {
+		[Export ("methodWhen:data:", ArgumentSemantic.Assign)]
+		[NullAllowed]
+		NSString Method (NSDate d, NSObject o);
+	}
+}


### PR DESCRIPTION
The `[NullAllowed]` attribute should not be allowed on methods but it could
break existing binding projects.

Historically it was used on property setters. However using the attribute
on _other_ methods can be misleading, e.g. should it apply to all
parameters, the return value... and its presence/action can be
misinterpreted in code reviews leading to binding bugs.

reference: https://github.com/xamarin/xamarin-macios/issues/5416