### PR TITLE
[mtouch] Properly deserialize cached Objective-C class symbols. Fixes #5467.

### DIFF
--- a/tools/common/Symbols.cs
+++ b/tools/common/Symbols.cs
@@ -27,19 +27,27 @@ namespace Xamarin.Bundler
 		public SymbolType Type;
 		public bool Ignore;
 
+		static string ObjectiveCPrefix {
+			get {
+				return Driver.SupportsModernObjectiveC ? "OBJC_CLASS_$_" : ".objc_class_name_";
+			}
+		}
+
 		string name;
 		public string Name {
 			get {
 				if (name != null)
 					return name;
-				if (ObjectiveCName != null) {
-					var prefix = Driver.SupportsModernObjectiveC ? "OBJC_CLASS_$_" : ".objc_class_name_";
-					return prefix + ObjectiveCName;
-				}
+				if (ObjectiveCName != null)
+					return ObjectiveCPrefix + ObjectiveCName;
 				throw ErrorHelper.CreateError (99, $"Internal error: symbol without a name (type: {Type}). Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).");
 			}
 			set {
 				name = value;
+				if (name.StartsWith (ObjectiveCPrefix, StringComparison.Ordinal)) {
+					ObjectiveCName = name.Substring (ObjectiveCPrefix.Length);
+					name = null;
+				}
 			}
 		}
 		public string ObjectiveCName;


### PR DESCRIPTION
Deserialize cached Objective-C class symbols to match how the objects looked
before serialization. This means storing the Objective-C class name in the
Symbol.ObjectiveCName field, and not the Symbol.Name field.

Fixes https://github.com/xamarin/xamarin-macios/issues/5467.