### PR TITLE
[WebKit] Update bindings to Xcode 10.2 Beta 1

### DIFF
--- a/src/wkwebkit.cs
+++ b/src/wkwebkit.cs
@@ -244,6 +244,10 @@ namespace WebKit
 		[Export ("javaScriptCanOpenWindowsAutomatically")]
 		bool JavaScriptCanOpenWindowsAutomatically { get; set; }
 
+		[Mac (10,14,4, onlyOn64: true), iOS (12,2)]
+		[Export ("safeBrowsingEnabled")]
+		bool SafeBrowsingEnabled { [Bind ("isSafeBrowsingEnabled")] get; set; }
+
 
 #if MONOMAC
 		[Export ("javaEnabled")]

--- a/tests/introspection/ApiAvailabilityTest.cs
+++ b/tests/introspection/ApiAvailabilityTest.cs
@@ -56,7 +56,7 @@ namespace Introspection {
 			Minimum = new Version (10,7);
 			// Need to special case macOS 'Maximum' version for OS minor subversions (can't change Constants.SdkVersion)
 			// Please comment the code below if needed
-			Maximum = new Version (10,14,1);
+			Maximum = new Version (10,14,4);
 			Filter = (AvailabilityBaseAttribute arg) => {
 				return (arg.AvailabilityKind != AvailabilityKind.Introduced) || (arg.Platform != PlatformName.MacOSX);
 			};

--- a/tests/xtro-sharpie/iOS-WebKit.todo
+++ b/tests/xtro-sharpie/iOS-WebKit.todo
@@ -1,2 +1,0 @@
-!missing-selector! WKPreferences::isSafeBrowsingEnabled not bound
-!missing-selector! WKPreferences::setSafeBrowsingEnabled: not bound

--- a/tests/xtro-sharpie/macOS-WebKit.todo
+++ b/tests/xtro-sharpie/macOS-WebKit.todo
@@ -1,2 +1,0 @@
-!missing-selector! WKPreferences::isSafeBrowsingEnabled not bound
-!missing-selector! WKPreferences::setSafeBrowsingEnabled: not bound


### PR DESCRIPTION
I deleted the diff AOT, sorry about that but here is the link https://github.com/xamarin/xamarin-macios/wiki/WebKit-iOS-xcode10.2-beta1/17fedc3bb456e758ccd51fc1b83a9609f2a9d0f5

Diff contents are the same for macOS.