### PR TITLE
[tests] Ignore UIPreviewInteraction failing selectors for now

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -39,7 +39,7 @@ IOS_PACKAGE_UPDATE_ID=$(shell printf "2%02d%02d%02d%03d" $(IOS_PACKAGE_VERSION_M
 
 # Xcode version should have both a major and a minor version (even if the minor version is 0)
 XCODE_VERSION=10.2
-XCODE_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_10.2.xip
+XCODE_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_10.2_beta.xip
 XCODE_DEVELOPER_ROOT=/Applications/Xcode102-beta1.app/Contents/Developer
 
 XCODE94_VERSION=9.4

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -188,6 +188,18 @@ partial class TestRuntime
 #else
 				throw new NotImplementedException ();
 #endif
+			case 2:
+#if __WATCHOS__
+				return CheckWatchOSSystemVersion (5, 2);
+#elif __TVOS__
+				return ChecktvOSSystemVersion (12, 2);
+#elif __IOS__
+				return CheckiOSSystemVersion (12, 2);
+#elif MONOMAC
+				return CheckMacSystemVersion (10, 14, 4);
+#else
+				throw new NotImplementedException ();
+#endif
 			default:
 				throw new NotImplementedException ();
 			}

--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -317,6 +317,19 @@ namespace Introspection {
 					break;
 				}
 				break;
+			case "UIPreviewInteraction":
+				switch (name) {
+				// Selectors do not respond anymore in Xcode 10.2 beta 1.
+				case "cancelInteraction":
+				case "locationInCoordinateSpace:":
+				case "delegate":
+				case "setDelegate:":
+				case "view":
+					if (TestRuntime.CheckXcodeVersion (10, 2))
+						return true;
+					break;
+				}
+				break;
 			}
 
 			switch (name) {


### PR DESCRIPTION
- With Xcode 10.2 beta 1 these selectors do not respond anymore.
  Still investigating why as part of https://github.com/xamarin/xamarin-macios/issues/5471
- Fix Make.config Xcode xip url.