### PR TITLE
[security] Update for Xcode 10.2 beta 1

### DIFF
--- a/src/Security/SecTrust.cs
+++ b/src/Security/SecTrust.cs
@@ -204,5 +204,34 @@ namespace Security {
 
 			SetOCSPResponse (ocspResponses.Handle);
 		}
+
+		[iOS (12,1,1)]
+		[Watch (5,1,1)]
+		[TV (12,1,1)]
+		[Mac (10,14,2, onlyOn64: true)]
+		[DllImport (Constants.SecurityLibrary)]
+		static extern SecStatusCode /* OSStatus */ SecTrustSetSignedCertificateTimestamps (/* SecTrustRef* */ IntPtr trust, /* CFArrayRef* */ IntPtr sctArray);
+
+		[iOS (12,1,1)]
+		[Watch (5,1,1)]
+		[TV (12,1,1)]
+		[Mac (10,14,2, onlyOn64: true)]
+		public SecStatusCode SetSignedCertificateTimestamps (IEnumerable<NSData> sct)
+		{
+			if (sct == null)
+				return SecTrustSetSignedCertificateTimestamps (handle, IntPtr.Zero);
+
+			using (var array = NSArray.FromNSObjects (sct.ToArray ()))
+				return SecTrustSetSignedCertificateTimestamps (handle, array.Handle);
+		}
+
+		[iOS (12,1,1)]
+		[Watch (5,1,1)]
+		[TV (12,1,1)]
+		[Mac (10,14,2, onlyOn64: true)]
+		public SecStatusCode SetSignedCertificateTimestamps (NSArray<NSData> sct)
+		{
+			return SecTrustSetSignedCertificateTimestamps (handle, sct.GetHandle ());
+		}
 	}
 }

--- a/tests/monotouch-test/Security/TrustTest.cs
+++ b/tests/monotouch-test/Security/TrustTest.cs
@@ -402,5 +402,32 @@ namespace MonoTouchFixtures.Security {
 				Trust_FullChain (trust, policy, certs);
 			}
 		}
+
+		[Test]
+		public void Timestamps ()
+		{
+			TestRuntime.AssertXcodeVersion (10,1); // old API exposed publicly
+
+			X509Certificate2Collection certs = new X509Certificate2Collection ();
+			certs.Add (new X509Certificate2 (CertificateTest.mail_google_com));
+			certs.Add (new X509Certificate2 (CertificateTest.thawte_sgc_ca));
+			certs.Add (new X509Certificate2 (CertificateTest.verisign_class3_root));
+			using (var policy = SecPolicy.CreateSslPolicy (true, "mail.google.com"))
+			using (var trust = new SecTrust (certs, policy)) {
+				var a = new NSArray<NSData> ();
+				var e = trust.SetSignedCertificateTimestamps (a);
+				Assert.That (e, Is.EqualTo (SecStatusCode.Success), "1");
+				a = null;
+				e = trust.SetSignedCertificateTimestamps (null);
+				Assert.That (e, Is.EqualTo (SecStatusCode.Success), "2");
+
+				var i = new NSData [0];
+				e = trust.SetSignedCertificateTimestamps (i);
+				Assert.That (e, Is.EqualTo (SecStatusCode.Success), "3");
+				i = null;
+				e = trust.SetSignedCertificateTimestamps (i);
+				Assert.That (e, Is.EqualTo (SecStatusCode.Success), "4");
+			}
+		}
 	}
 }

--- a/tests/xtro-sharpie/iOS-Security.todo
+++ b/tests/xtro-sharpie/iOS-Security.todo
@@ -1,1 +1,0 @@
-!missing-pinvoke! SecTrustSetSignedCertificateTimestamps is not bound

--- a/tests/xtro-sharpie/macOS-Security.todo
+++ b/tests/xtro-sharpie/macOS-Security.todo
@@ -1,1 +1,0 @@
-!missing-pinvoke! SecTrustSetSignedCertificateTimestamps is not bound

--- a/tests/xtro-sharpie/tvOS-Security.todo
+++ b/tests/xtro-sharpie/tvOS-Security.todo
@@ -1,1 +1,0 @@
-!missing-pinvoke! SecTrustSetSignedCertificateTimestamps is not bound

--- a/tests/xtro-sharpie/watchOS-Security.todo
+++ b/tests/xtro-sharpie/watchOS-Security.todo
@@ -1,1 +1,0 @@
-!missing-pinvoke! SecTrustSetSignedCertificateTimestamps is not bound


### PR DESCRIPTION
The added `SecTrustSetSignedCertificateTimestamps` API existed in older
versions of the OS so I kept the Xcode headers availability (instead of
current SDK version).