### PR TITLE
[javascriptcore] Update for xcode 10.2 beta 1

### DIFF
--- a/tests/xtro-sharpie/common-JavaScriptCore.ignore
+++ b/tests/xtro-sharpie/common-JavaScriptCore.ignore
@@ -100,3 +100,4 @@
 !missing-pinvoke! JSValueToObject is not bound
 !missing-pinvoke! JSValueToStringCopy is not bound
 !missing-pinvoke! JSValueUnprotect is not bound
+!missing-pinvoke! JSValueMakeSymbol is not bound

--- a/tests/xtro-sharpie/iOS-JavaScriptCore.todo
+++ b/tests/xtro-sharpie/iOS-JavaScriptCore.todo
@@ -1,1 +1,0 @@
-!missing-pinvoke! JSValueMakeSymbol is not bound

--- a/tests/xtro-sharpie/macOS-JavaScriptCore.todo
+++ b/tests/xtro-sharpie/macOS-JavaScriptCore.todo
@@ -1,1 +1,0 @@
-!missing-pinvoke! JSValueMakeSymbol is not bound

--- a/tests/xtro-sharpie/tvOS-JavaScriptCore.todo
+++ b/tests/xtro-sharpie/tvOS-JavaScriptCore.todo
@@ -1,1 +1,0 @@
-!missing-pinvoke! JSValueMakeSymbol is not bound


### PR DESCRIPTION
The only new API is a p/invoke but we only bound the ObjC (not the C) API
so the entry is moved to the common ignore file for the framework