### PR TITLE
[runtime] Use a single mono profiler for both newrefcount and NSAutoreleasePool thread hooks.

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -196,10 +196,6 @@
 
 		#region metadata/profiler.h
 
-		new Export ("void", "mono_profiler_set_events",
-			"MonoProfileFlags", "events"
-		),
-
 		new Export ("void", "mono_profiler_install",
 			"MonoProfiler *", "prof",
 			"MonoProfileFunc", "shutdown_callback"

--- a/runtime/shared.m
+++ b/runtime/shared.m
@@ -162,17 +162,6 @@ xamarin_initialize_cocoa_threads (init_cocoa_func *func)
 static CFMutableDictionaryRef xamarin_thread_hash = NULL;
 static pthread_mutex_t thread_hash_lock = PTHREAD_MUTEX_INITIALIZER;
 
-struct _MonoProfiler {
-	int dummy;
-};
-
-static MonoProfiler*
-create_thread_helper ()
-{
-	// COOP: no managed memory access: any mode.
-	return (MonoProfiler *)malloc (sizeof (MonoProfiler));
-}
-
 static void
 xamarin_thread_start (void *user_data)
 {
@@ -238,9 +227,7 @@ xamarin_install_nsautoreleasepool_hooks ()
 	// COOP: executed at startup (and no managed memory access): any mode.
 	xamarin_thread_hash = CFDictionaryCreateMutable (kCFAllocatorDefault, 0, NULL, NULL);
 
-	mono_profiler_install (create_thread_helper (), NULL);
 	mono_profiler_install_thread (thread_start, thread_end);
-	mono_profiler_set_events (MONO_PROFILE_THREADS);
 }
 	
 /* Threads & Blocks


### PR DESCRIPTION
Additionally don't use malloc'ed memory, to avoid having to free the memory.

This fixes a leak, since mono does not free the MonoProfiler argument:

    STACK OF 1 INSTANCE OF 'ROOT LEAK: <0x7fb94495c460>':
    [thread 0x10f3f85c0]:
    19  libdyld.dylib                      0x7fff6e009ed9 start + 1
    18  NameNotImportant                      0x10592dec4 main + 36  launcher.m:679
    17  NameNotImportant                      0x10592d039 xamarin_main + 1305  launcher.m:661
    16  NameNotImportant                      0x105973473 mono_main + 11731  driver.g.c:2484
    15  NameNotImportant                      0x10597020d mono_jit_exec + 349  driver.g.c:1236
    14  NameNotImportant                      0x105b4217e mono_runtime_exec_main_checked + 110  object.c:0
    13  NameNotImportant                      0x105b3af28 mono_runtime_invoke_checked + 136  object.c:2960
    12  NameNotImportant                      0x105a143a1 mono_jit_runtime_invoke + 513  mini-runtime.c:3011
    11  NameNotImportant                      0x105a103c1 mono_jit_compile_method_with_opt + 2577  mini-runtime.c:2411
    10  NameNotImportant                      0x105a21aa7 mono_jit_compile_method_inner + 1207  mini.c:4184
    9   NameNotImportant                      0x105b3b75f mono_runtime_class_init_full + 847  object.c:527
    8   NameNotImportant                      0x105b3c9d4 mono_runtime_try_invoke + 148  object.c:2960
    7   NameNotImportant                      0x105a147d3 mono_jit_runtime_invoke + 1587  mini-runtime.c:3148
    6   ???                                   0x106d00fb0 0x7fffffffffffffff + 9223372041264041905
    5   NameNotImportant                      0x105921b0c xamarin_initialize + 812  runtime.m:1412
    4   NameNotImportant                      0x10591e7e7 xamarin_install_nsautoreleasepool_hooks + 55  shared.m:241
    3   NameNotImportant                      0x105b4fd0a mono_profiler_install + 26  profiler.c:1019
    2   NameNotImportant                      0x105c3127b monoeg_malloc0 + 27  gmem.c:121
    1   libsystem_malloc.dylib             0x7fff6e1bacba calloc + 30
    0   libsystem_malloc.dylib             0x7fff6e1bad62 malloc_zone_calloc + 139

Also remove the call to mono_profiler_set_events, it doesn't do anything anymore ([1]).

[1]: https://github.com/mono/mono/blob/14b061ba65815d4580078e93c4f2df77ec84b882/mono/metadata/profiler.c#L1098-L1101