### PR TITLE
[classkit] Update for xcode 10.2 beta 1

### DIFF
--- a/src/classkit.cs
+++ b/src/classkit.cs
@@ -21,6 +21,8 @@ namespace ClassKit {
 		TrueFalse = 0,
 		PassFail,
 		YesNo,
+		[iOS (12,2)]
+		CorrectIncorrect,
 	}
 
 	[NoWatch, NoTV, NoMac, iOS (11,4)]
@@ -290,6 +292,10 @@ namespace ClassKit {
 		[Export ("saveWithCompletion:")]
 		void Save ([NullAllowed] Action<NSError> completion);
 
+		[iOS (12,2)]
+		[Export ("completeAllAssignedActivitiesMatching:")]
+		void CompleteAllAssignedActivitiesMatching (string[] contextPath);
+
 		// From CLSDataStore (Contexts) Category
 
 		[Async]
@@ -331,6 +337,14 @@ namespace ClassKit {
 		[Export ("initWithIdentifier:title:score:maxScore:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (string identifier, string title, double score, double maxScore);
+	}
+
+	[NoWatch, NoTV, NoMac, iOS (12,2)]
+	[Protocol]
+	interface CLSContextProvider {
+		[Abstract]
+		[Export ("updateDescendantsOfContext:completion:")]
+		void UpdateDescendants (CLSContext context, Action<NSError> completion);
 	}
 }
 #endif

--- a/tests/xtro-sharpie/iOS-ClassKit.todo
+++ b/tests/xtro-sharpie/iOS-ClassKit.todo
@@ -1,2 +1,0 @@
-!missing-protocol! CLSContextProvider not bound
-!missing-selector! CLSDataStore::completeAllAssignedActivitiesMatching: not bound


### PR DESCRIPTION
All types now have availability annotations for macOS 10.14.4, however
there's no headers (yet?) for ClassKit in the macOS SDK that ships with
Xcode 10.2 beta 1.