### PR TITLE
Xcode 10.2 Beta 1 AppKit

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -8533,21 +8533,11 @@ namespace Foundation
 		// NSPlaceholders (informal) protocol
 		[Static]
 		[Export ("defaultPlaceholderForMarker:withBinding:")]
-#if XAMCORE_4_0 && MONOMAC
-		// When XAMCORE_4_0 occurs review - NSBindingSelectionMarker is 10.14 only type but GetDefaultPlaceholder is before, does it matter now?
-		NSObject GetDefaultPlaceholder (NSBindingSelectionMarker marker, NSString binding);
-#else
 		NSObject GetDefaultPlaceholder (NSObject marker, NSString binding);
-#endif
 
 		[Static]
 		[Export ("setDefaultPlaceholder:forMarker:withBinding:")]
-#if XAMCORE_4_0 && MONOMAC
-		// When XAMCORE_4_0 occurs review - NSBindingSelectionMarker is 10.14 only type but SetDefaultPlaceholder is before, does it matter now?
-		void SetDefaultPlaceholder (NSObject placeholder, NSBindingSelectionMarker marker, NSString binding);
-#else
 		void SetDefaultPlaceholder (NSObject placeholder, NSObject marker, NSString binding);
-#endif
 
 		[Export ("objectDidEndEditing:")]
 		void ObjectDidEndEditing (NSObject editor);


### PR DESCRIPTION
- NSBindingSelectionMarker version of two NSPlaceholders in XAMCORE_4_0
removed as header reverter to NSObject (as it was before)

https://github.com/xamarin/xamarin-macios/wiki/AppKit-macOS-xcode10.2-beta1