### PR TITLE
[Appkit] Adds missing ModelAttribute to NSFilePromiseProviderDelegate

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -25599,7 +25599,8 @@ namespace AppKit {
 	}
 
 	[Mac (10,12)]
-	[Protocol]
+	[Protocol, Model]
+	[BaseType (typeof (NSObject))]
 	interface NSFilePromiseProviderDelegate
 	{
 		[Abstract]


### PR DESCRIPTION
Fixes xamarin/xamarin-macios#5504