### PR TITLE
Xcode 10.2 b1 GameController APIs

### DIFF
--- a/src/GameController/Enums.cs
+++ b/src/GameController/Enums.cs
@@ -22,6 +22,6 @@ namespace GameController {
 	[Native]
 	public enum GCMicroGamepadSnapshotDataVersion : long
 	{
-		Version1 = 0x0100
+		Version1 = 0x0100,
 	}
 }

--- a/src/GameController/Enums.cs
+++ b/src/GameController/Enums.cs
@@ -1,0 +1,27 @@
+//
+// Enums.cs
+//
+// Authors:
+//   Chris Hamons (chris.hamons@xamarin.com)
+//
+// Copyright 2019 Microsoft Corporation 
+
+using System;
+
+using ObjCRuntime;
+using Foundation;
+
+namespace GameController {
+	[Native]
+	public enum GCExtendedGamepadSnapshotDataVersion : long
+	{
+		Version1 = 0x0100,
+		Version2 = 0x0101,
+	}
+	
+	[Native]
+	public enum GCMicroGamepadSnapshotDataVersion : long
+	{
+		Version1 = 0x0100
+	}
+}

--- a/src/GameController/GCExtendedGamepadSnapshot.cs
+++ b/src/GameController/GCExtendedGamepadSnapshot.cs
@@ -99,6 +99,7 @@ namespace GameController {
 		bool RightThumbstickButton;
 
 		[DllImport (Constants.GameControllerLibrary)]
+		[TV (12, 2), Mac (10, 14, 4, onlyOn64: true), iOS (12, 2)]
 		static extern /* NSData * __nullable */ IntPtr NSDataFromGCExtendedGamepadSnapshotData (
 			/* GCExtendedGamepadSnapshotData * __nullable */ ref GCExtendedGamepadSnapshotData snapshotData);
 
@@ -118,9 +119,7 @@ namespace GameController {
 			/* NSData * __nullable */ IntPtr data);
 		
 		[DllImport (Constants.GameControllerLibrary)]
-		[Introduced (PlatformName.iOS, 12, 2)]
-		[Introduced (PlatformName.MacOSX, 10, 14, 4)]
-		[Introduced (PlatformName.TvOS, 12, 2)]
+		[TV (12, 2), Mac (10, 14, 4, onlyOn64: true), iOS (12, 2)]
 		static extern bool GCExtendedGamepadSnapshotDataFromNSData (
 			/* GCExtendedGamepadSnapshotData * __nullable */ out GCExtendedGamepadSnapshotData snapshotData, 
 			/* NSData * __nullable */ IntPtr data);
@@ -134,9 +133,7 @@ namespace GameController {
 			return GCExtendedGamepadSnapShotDataV100FromNSData (out snapshotData, data == null ? IntPtr.Zero : data.Handle);
 		}
 		
-		[Introduced (PlatformName.iOS, 12, 2)]
-		[Introduced (PlatformName.MacOSX, 10, 14, 4)]
-		[Introduced (PlatformName.TvOS, 12, 2)]
+		[TV (12, 2), Mac (10, 14, 4, onlyOn64: true), iOS (12, 2)]
 		public static bool TryGetExtendedSnapShotData (NSData data, out GCExtendedGamepadSnapshotData snapshotData)
 		{
 			return GCExtendedGamepadSnapshotDataFromNSData (out snapshotData, data == null ? IntPtr.Zero : data.Handle);

--- a/src/GameController/GCExtendedGamepadSnapshot.cs
+++ b/src/GameController/GCExtendedGamepadSnapshot.cs
@@ -18,6 +18,9 @@ namespace GameController {
 	[StructLayout (LayoutKind.Sequential, Pack = 1)]
 	[iOS (7,0)]
 	[Mac (10,9, onlyOn64: true)]
+	[Deprecated (PlatformName.iOS, message: "Use 'GCExtendedGamepadSnapshotData' instead.")]
+	[Deprecated (PlatformName.MacOSX, message: "Use 'GCExtendedGamepadSnapshotData' instead.")]
+	[Deprecated (PlatformName.TvOS, message: "Use 'GCExtendedGamepadSnapshotData' instead.")]
 	public struct GCExtendedGamepadSnapShotDataV100 {
 
 		// Standard information
@@ -47,12 +50,6 @@ namespace GameController {
 		public float /* float_t = float */ LeftTrigger;
 		public float /* float_t = float */ RightTrigger;
 
-		// radar: https://trello.com/c/7FoGTORD (GCExtendedGamepadSnapShotDataV100 struct size / alignment not backward compatible)
-		// [TV (12, 1), Mac (10, 14, 1, onlyOn64: true), iOS (12, 1)]
-		// public bool LeftThumbstickButton;
-		// [TV (12, 1), Mac (10, 14, 1, onlyOn64: true), iOS (12, 1)]
-		// public bool RightThumbstickButton;
-
 		[DllImport (Constants.GameControllerLibrary)]
 		static extern /* NSData * __nullable */ IntPtr NSDataFromGCExtendedGamepadSnapShotDataV100 (
 			/* GCExtendedGamepadSnapShotDataV100 * __nullable */ ref GCExtendedGamepadSnapShotDataV100 snapshotData);
@@ -60,6 +57,56 @@ namespace GameController {
 		public NSData ToNSData ()
 		{
 			var p = NSDataFromGCExtendedGamepadSnapShotDataV100 (ref this);
+			return p == IntPtr.Zero ? null : new NSData (p);
+		}
+	}
+	
+	// float_t are 4 bytes (at least for ARM64)
+	[StructLayout (LayoutKind.Sequential, Pack = 1)]
+	[iOS (7,0)]
+	[Mac (10,9, onlyOn64: true)]
+	public struct GCExtendedGamepadSnapshotData {
+
+		// Standard information
+		public ushort /* uint16_t */ Version;
+		public ushort /* uint16_t */ Size;
+
+		// Extended gamepad data
+		// Axes in the range [-1.0, 1.0]
+		public float /* float_t = float */ DPadX;
+		public float /* float_t = float */ DPadY;
+
+		// Buttons in the range [0.0, 1.0]
+		public float /* float_t = float */ ButtonA;
+		public float /* float_t = float */ ButtonB;
+		public float /* float_t = float */ ButtonX;
+		public float /* float_t = float */ ButtonY;
+		public float /* float_t = float */ LeftShoulder;
+		public float /* float_t = float */ RightShoulder;
+
+		// Axes in the range [-1.0, 1.0]
+		public float /* float_t = float */ LeftThumbstickX;
+		public float /* float_t = float */ LeftThumbstickY;
+		public float /* float_t = float */ RightThumbstickX;
+		public float /* float_t = float */ RightThumbstickY;
+
+		// Buttons in the range [0.0, 1.0]
+		public float /* float_t = float */ LeftTrigger;
+		public float /* float_t = float */ RightTrigger;
+
+		[TV (12, 2), Mac (10, 14, 4, onlyOn64: true), iOS (12, 2)]
+		bool LeftThumbstickButton;
+		
+		[TV (12, 2), Mac (10, 14, 4, onlyOn64: true), iOS (12, 2)]
+		bool RightThumbstickButton;
+
+		[DllImport (Constants.GameControllerLibrary)]
+		static extern /* NSData * __nullable */ IntPtr NSDataFromGCExtendedGamepadSnapshotData (
+			/* GCExtendedGamepadSnapshotData * __nullable */ ref GCExtendedGamepadSnapshotData snapshotData);
+
+		public NSData ToNSData ()
+		{
+			var p = NSDataFromGCExtendedGamepadSnapshotData (ref this);
 			return p == IntPtr.Zero ? null : new NSData (p);
 		}
 	}
@@ -71,10 +118,24 @@ namespace GameController {
 		static extern bool GCExtendedGamepadSnapShotDataV100FromNSData (
 			/* GCExtendedGamepadSnapShotDataV100 * __nullable */ out GCExtendedGamepadSnapShotDataV100 snapshotData, 
 			/* NSData * __nullable */ IntPtr data);
+		
+		[DllImport (Constants.GameControllerLibrary)]
+		static extern bool GCExtendedGamepadSnapshotDataFromNSData (
+			/* GCExtendedGamepadSnapshotData * __nullable */ out GCExtendedGamepadSnapshotData snapshotData, 
+			/* NSData * __nullable */ IntPtr data);
 
+
+		[Deprecated (PlatformName.iOS, message: "Use 'TryGetExtendedSnapShotData' instead.")]
+		[Deprecated (PlatformName.MacOSX, message: "Use 'TryGetExtendedSnapShotData' instead.")]
+		[Deprecated (PlatformName.TvOS, message: "Use 'TryGetExtendedSnapShotData' instead.")]
 		public static bool TryGetSnapShotData (NSData data, out GCExtendedGamepadSnapShotDataV100 snapshotData)
 		{
 			return GCExtendedGamepadSnapShotDataV100FromNSData (out snapshotData, data == null ? IntPtr.Zero : data.Handle);
+		}
+		
+		public static bool TryGetExtendedSnapShotData (NSData data, out GCExtendedGamepadSnapshotData snapshotData)
+		{
+			return GCExtendedGamepadSnapshotDataFromNSData (out snapshotData, data == null ? IntPtr.Zero : data.Handle);
 		}
 	}
 }

--- a/src/GameController/GCExtendedGamepadSnapshot.cs
+++ b/src/GameController/GCExtendedGamepadSnapshot.cs
@@ -18,9 +18,9 @@ namespace GameController {
 	[StructLayout (LayoutKind.Sequential, Pack = 1)]
 	[iOS (7,0)]
 	[Mac (10,9, onlyOn64: true)]
-	[Deprecated (PlatformName.iOS, message: "Use 'GCExtendedGamepadSnapshotData' instead.")]
-	[Deprecated (PlatformName.MacOSX, message: "Use 'GCExtendedGamepadSnapshotData' instead.")]
-	[Deprecated (PlatformName.TvOS, message: "Use 'GCExtendedGamepadSnapshotData' instead.")]
+	[Deprecated (PlatformName.iOS, 12, 2, message: "Use 'GCExtendedGamepadSnapshotData' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 14, 4, message: "Use 'GCExtendedGamepadSnapshotData' instead.")]
+	[Deprecated (PlatformName.TvOS, 12, 2, message: "Use 'GCExtendedGamepadSnapshotData' instead.")]
 	public struct GCExtendedGamepadSnapShotDataV100 {
 
 		// Standard information
@@ -63,8 +63,6 @@ namespace GameController {
 	
 	// float_t are 4 bytes (at least for ARM64)
 	[StructLayout (LayoutKind.Sequential, Pack = 1)]
-	[iOS (7,0)]
-	[Mac (10,9, onlyOn64: true)]
 	public struct GCExtendedGamepadSnapshotData {
 
 		// Standard information
@@ -120,19 +118,25 @@ namespace GameController {
 			/* NSData * __nullable */ IntPtr data);
 		
 		[DllImport (Constants.GameControllerLibrary)]
+		[Introduced (PlatformName.iOS, 12, 2)]
+		[Introduced (PlatformName.MacOSX, 10, 14, 4)]
+		[Introduced (PlatformName.TvOS, 12, 2)]
 		static extern bool GCExtendedGamepadSnapshotDataFromNSData (
 			/* GCExtendedGamepadSnapshotData * __nullable */ out GCExtendedGamepadSnapshotData snapshotData, 
 			/* NSData * __nullable */ IntPtr data);
 
 
-		[Deprecated (PlatformName.iOS, message: "Use 'TryGetExtendedSnapShotData' instead.")]
-		[Deprecated (PlatformName.MacOSX, message: "Use 'TryGetExtendedSnapShotData' instead.")]
-		[Deprecated (PlatformName.TvOS, message: "Use 'TryGetExtendedSnapShotData' instead.")]
+		[Deprecated (PlatformName.iOS, 12, 2, message: "Use 'TryGetExtendedSnapShotData' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 14, 4, message: "Use 'TryGetExtendedSnapShotData' instead.")]
+		[Deprecated (PlatformName.TvOS, 12, 2, message: "Use 'TryGetExtendedSnapShotData' instead.")]
 		public static bool TryGetSnapShotData (NSData data, out GCExtendedGamepadSnapShotDataV100 snapshotData)
 		{
 			return GCExtendedGamepadSnapShotDataV100FromNSData (out snapshotData, data == null ? IntPtr.Zero : data.Handle);
 		}
 		
+		[Introduced (PlatformName.iOS, 12, 2)]
+		[Introduced (PlatformName.MacOSX, 10, 14, 4)]
+		[Introduced (PlatformName.TvOS, 12, 2)]
 		public static bool TryGetExtendedSnapShotData (NSData data, out GCExtendedGamepadSnapshotData snapshotData)
 		{
 			return GCExtendedGamepadSnapshotDataFromNSData (out snapshotData, data == null ? IntPtr.Zero : data.Handle);

--- a/src/GameController/GCExtendedGamepadSnapshot.cs
+++ b/src/GameController/GCExtendedGamepadSnapshot.cs
@@ -103,6 +103,7 @@ namespace GameController {
 		static extern /* NSData * __nullable */ IntPtr NSDataFromGCExtendedGamepadSnapshotData (
 			/* GCExtendedGamepadSnapshotData * __nullable */ ref GCExtendedGamepadSnapshotData snapshotData);
 
+		[TV (12, 2), Mac (10, 14, 4, onlyOn64: true), iOS (12, 2)]
 		public NSData ToNSData ()
 		{
 			var p = NSDataFromGCExtendedGamepadSnapshotData (ref this);

--- a/src/GameController/GCMicroGamepadSnapshot.cs
+++ b/src/GameController/GCMicroGamepadSnapshot.cs
@@ -90,14 +90,10 @@ namespace GameController {
 		}
 		
 		[DllImport (Constants.GameControllerLibrary)]
-		[Introduced (PlatformName.iOS, 12, 2)]
-		[Introduced (PlatformName.MacOSX, 10, 14, 4)]
-		[Introduced (PlatformName.TvOS, 12, 2)]
+		[TV (12, 2), Mac (10, 14, 4, onlyOn64: true), iOS (12, 2)]
 		static extern bool GCMicroGamepadSnapshotDataFromNSData (out GCMicroGamepadSnapshotData snapshotData, /* NSData */ IntPtr data);
 
-		[Introduced (PlatformName.iOS, 12, 2)]
-		[Introduced (PlatformName.MacOSX, 10, 14, 4)]
-		[Introduced (PlatformName.TvOS, 12, 2)]
+		[TV (12, 2), Mac (10, 14, 4, onlyOn64: true), iOS (12, 2)]
 		public static bool TryGetSnapshotData (NSData data, out GCMicroGamepadSnapshotData snapshotData)
 		{
 			return GCMicroGamepadSnapshotDataFromNSData (out snapshotData, data == null ? IntPtr.Zero : data.Handle);

--- a/src/GameController/GCMicroGamepadSnapshot.cs
+++ b/src/GameController/GCMicroGamepadSnapshot.cs
@@ -62,9 +62,11 @@ namespace GameController {
 		public float /* float_t = float */ ButtonX;
 
 		[DllImport (Constants.GameControllerLibrary)]
+		[TV (12, 2), Mac (10, 14, 4, onlyOn64: true), iOS (12, 2)]
 		static extern /* NSData * __nullable */ IntPtr NSDataFromGCMicroGamepadSnapshotData (
 			/* __nullable */ ref GCMicroGamepadSnapshotData snapshotData);
 
+		[TV (12, 2), Mac (10, 14, 4, onlyOn64: true), iOS (12, 2)]
 		public NSData ToNSData ()
 		{
 			var p = NSDataFromGCMicroGamepadSnapshotData (ref this);

--- a/src/GameController/GCMicroGamepadSnapshot.cs
+++ b/src/GameController/GCMicroGamepadSnapshot.cs
@@ -14,6 +14,9 @@ namespace GameController {
 	// GCMicroGamepadSnapshot.h
 	// float_t are 4 bytes (at least for ARM64)
 	[StructLayout (LayoutKind.Sequential, Pack = 1)]
+	[Deprecated (PlatformName.iOS, message: "Use 'GCMicroGamepadSnapshotData' instead.")]
+	[Deprecated (PlatformName.MacOSX, message: "Use 'GCMicroGamepadSnapshotData' instead.")]
+	[Deprecated (PlatformName.TvOS, message: "Use 'GCMicroGamepadSnapshotData' instead.")]
 	public struct GCMicroGamepadSnapShotDataV100 {
 
 		// Standard information
@@ -40,6 +43,37 @@ namespace GameController {
 		}
 	}
 
+	[iOS (10,0), TV (9,0), Mac (10,12, onlyOn64: true)]
+	// GCMicroGamepadSnapshot.h
+	// float_t are 4 bytes (at least for ARM64)
+	[StructLayout (LayoutKind.Sequential, Pack = 1)]
+	public struct GCMicroGamepadSnapshotData {
+
+		// Standard information
+		public ushort /* uint16_t */ Version;
+		public ushort /* uint16_t */ Size;
+
+		// Standard gamepad data
+		// Axes in the range [-1.0, 1.0]
+		public float /* float_t = float */ DPadX;
+		public float /* float_t = float */ DPadY;
+
+		// Buttons in the range [0.0, 1.0]
+		public float /* float_t = float */ ButtonA;
+		public float /* float_t = float */ ButtonX;
+
+		[DllImport (Constants.GameControllerLibrary)]
+		static extern /* NSData * __nullable */ IntPtr NSDataFromGCMicroGamepadSnapshotData (
+			/* __nullable */ ref GCMicroGamepadSnapshotData snapshotData);
+
+		public NSData ToNSData ()
+		{
+			var p = NSDataFromGCMicroGamepadSnapshotData (ref this);
+			return p == IntPtr.Zero ? null : new NSData (p);
+		}
+	}
+
+
 	public partial class GCMicroGamepadSnapshot {
 
 		// GCGamepadSnapshot.h
@@ -48,11 +82,25 @@ namespace GameController {
 		static extern bool GCMicroGamepadSnapShotDataV100FromNSData (out GCMicroGamepadSnapShotDataV100 snapshotData, /* NSData */ IntPtr data);
 
 		[Mac (10, 12)]
+		[Deprecated (PlatformName.iOS, message: "Use 'TryGetSnapshotData (NSData, out GCMicroGamepadSnapshotData)' instead.")]
+		[Deprecated (PlatformName.MacOSX, message: "Use 'TryGetSnapshotData (NSData, out GCMicroGamepadSnapshotData)' instead.")]
+		[Deprecated (PlatformName.TvOS, message: "Use 'TryGetSnapshotData (NSData, out GCMicroGamepadSnapshotData)' instead.")]
 		public static bool TryGetSnapshotData (NSData data, out GCMicroGamepadSnapShotDataV100 snapshotData)
 		{
 			return GCMicroGamepadSnapShotDataV100FromNSData (out snapshotData, data == null ? IntPtr.Zero : data.Handle);
 		}
+		
+		[DllImport (Constants.GameControllerLibrary)]
+		[Mac (10, 12)]
+		static extern bool GCMicroGamepadSnapshotDataFromNSData (out GCMicroGamepadSnapshotData snapshotData, /* NSData */ IntPtr data);
+
+		[Mac (10, 12)]
+		public static bool TryGetSnapshotData (NSData data, out GCMicroGamepadSnapshotData snapshotData)
+		{
+			return GCMicroGamepadSnapshotDataFromNSData (out snapshotData, data == null ? IntPtr.Zero : data.Handle);
+		}
+
 	}
 }
 
-#endif // IOS || TVOS
+#endif 

--- a/src/GameController/GCMicroGamepadSnapshot.cs
+++ b/src/GameController/GCMicroGamepadSnapshot.cs
@@ -14,9 +14,9 @@ namespace GameController {
 	// GCMicroGamepadSnapshot.h
 	// float_t are 4 bytes (at least for ARM64)
 	[StructLayout (LayoutKind.Sequential, Pack = 1)]
-	[Deprecated (PlatformName.iOS, message: "Use 'GCMicroGamepadSnapshotData' instead.")]
-	[Deprecated (PlatformName.MacOSX, message: "Use 'GCMicroGamepadSnapshotData' instead.")]
-	[Deprecated (PlatformName.TvOS, message: "Use 'GCMicroGamepadSnapshotData' instead.")]
+	[Deprecated (PlatformName.iOS, 12, 2, message: "Use 'GCMicroGamepadSnapshotData' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 14, 4, message: "Use 'GCMicroGamepadSnapshotData' instead.")]
+	[Deprecated (PlatformName.TvOS, 12, 2, message: "Use 'GCMicroGamepadSnapshotData' instead.")]
 	public struct GCMicroGamepadSnapShotDataV100 {
 
 		// Standard information
@@ -43,7 +43,6 @@ namespace GameController {
 		}
 	}
 
-	[iOS (10,0), TV (9,0), Mac (10,12, onlyOn64: true)]
 	// GCMicroGamepadSnapshot.h
 	// float_t are 4 bytes (at least for ARM64)
 	[StructLayout (LayoutKind.Sequential, Pack = 1)]
@@ -82,19 +81,23 @@ namespace GameController {
 		static extern bool GCMicroGamepadSnapShotDataV100FromNSData (out GCMicroGamepadSnapShotDataV100 snapshotData, /* NSData */ IntPtr data);
 
 		[Mac (10, 12)]
-		[Deprecated (PlatformName.iOS, message: "Use 'TryGetSnapshotData (NSData, out GCMicroGamepadSnapshotData)' instead.")]
-		[Deprecated (PlatformName.MacOSX, message: "Use 'TryGetSnapshotData (NSData, out GCMicroGamepadSnapshotData)' instead.")]
-		[Deprecated (PlatformName.TvOS, message: "Use 'TryGetSnapshotData (NSData, out GCMicroGamepadSnapshotData)' instead.")]
+		[Deprecated (PlatformName.iOS, 12, 2, message: "Use 'TryGetSnapshotData (NSData, out GCMicroGamepadSnapshotData)' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 14, 4, message: "Use 'TryGetSnapshotData (NSData, out GCMicroGamepadSnapshotData)' instead.")]
+		[Deprecated (PlatformName.TvOS, 12, 2, message: "Use 'TryGetSnapshotData (NSData, out GCMicroGamepadSnapshotData)' instead.")]
 		public static bool TryGetSnapshotData (NSData data, out GCMicroGamepadSnapShotDataV100 snapshotData)
 		{
 			return GCMicroGamepadSnapShotDataV100FromNSData (out snapshotData, data == null ? IntPtr.Zero : data.Handle);
 		}
 		
 		[DllImport (Constants.GameControllerLibrary)]
-		[Mac (10, 12)]
+		[Introduced (PlatformName.iOS, 12, 2)]
+		[Introduced (PlatformName.MacOSX, 10, 14, 4)]
+		[Introduced (PlatformName.TvOS, 12, 2)]
 		static extern bool GCMicroGamepadSnapshotDataFromNSData (out GCMicroGamepadSnapshotData snapshotData, /* NSData */ IntPtr data);
 
-		[Mac (10, 12)]
+		[Introduced (PlatformName.iOS, 12, 2)]
+		[Introduced (PlatformName.MacOSX, 10, 14, 4)]
+		[Introduced (PlatformName.TvOS, 12, 2)]
 		public static bool TryGetSnapshotData (NSData data, out GCMicroGamepadSnapshotData snapshotData)
 		{
 			return GCMicroGamepadSnapshotDataFromNSData (out snapshotData, data == null ? IntPtr.Zero : data.Handle);

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -792,6 +792,7 @@ FOUNDATION_SOURCES = \
 # GameController
 
 GAMECONTROLLER_CORE_SOURCES = \
+	GameController/Enums.cs \
 	GameController/GCController.cs \
 
 GAMECONTROLLER_SOURCES = \

--- a/src/gamecontroller.cs
+++ b/src/gamecontroller.cs
@@ -245,6 +245,10 @@ namespace GameController {
 
 		[Export ("initWithController:snapshotData:")]
 		IntPtr Constructor (GCController controller, NSData data);
+
+		[TV (12, 2), Mac (10, 14, 4, onlyOn64: true), iOS (12, 2)]
+		[Field ("GCCurrentExtendedGamepadSnapshotDataVersion")]
+		GCExtendedGamepadSnapshotDataVersion DataVersion { get; }
 	}
 
 #if !XAMCORE_2_0
@@ -400,6 +404,10 @@ namespace GameController {
 
 		[Export ("initWithController:snapshotData:")]
 		IntPtr Constructor (GCController controller, NSData data);
+
+		[TV (12, 2), Mac (10, 14, 4, onlyOn64: true), iOS (12, 2)]
+		[Field ("GCCurrentMicroGamepadSnapshotDataVersion")]
+		GCMicroGamepadSnapshotDataVersion DataVersion { get; }
 	}
 
 	[Mac (10,12, onlyOn64: true)]

--- a/tests/xtro-sharpie/iOS-GameController.todo
+++ b/tests/xtro-sharpie/iOS-GameController.todo
@@ -1,8 +1,0 @@
-!missing-enum! GCExtendedGamepadSnapshotDataVersion not bound
-!missing-enum! GCMicroGamepadSnapshotDataVersion not bound
-!missing-field! GCCurrentExtendedGamepadSnapshotDataVersion not bound
-!missing-field! GCCurrentMicroGamepadSnapshotDataVersion not bound
-!missing-pinvoke! GCExtendedGamepadSnapshotDataFromNSData is not bound
-!missing-pinvoke! GCMicroGamepadSnapshotDataFromNSData is not bound
-!missing-pinvoke! NSDataFromGCExtendedGamepadSnapshotData is not bound
-!missing-pinvoke! NSDataFromGCMicroGamepadSnapshotData is not bound

--- a/tests/xtro-sharpie/macOS-GameController.todo
+++ b/tests/xtro-sharpie/macOS-GameController.todo
@@ -1,8 +1,0 @@
-!missing-enum! GCExtendedGamepadSnapshotDataVersion not bound
-!missing-enum! GCMicroGamepadSnapshotDataVersion not bound
-!missing-field! GCCurrentExtendedGamepadSnapshotDataVersion not bound
-!missing-field! GCCurrentMicroGamepadSnapshotDataVersion not bound
-!missing-pinvoke! GCExtendedGamepadSnapshotDataFromNSData is not bound
-!missing-pinvoke! GCMicroGamepadSnapshotDataFromNSData is not bound
-!missing-pinvoke! NSDataFromGCExtendedGamepadSnapshotData is not bound
-!missing-pinvoke! NSDataFromGCMicroGamepadSnapshotData is not bound

--- a/tests/xtro-sharpie/tvOS-GameController.todo
+++ b/tests/xtro-sharpie/tvOS-GameController.todo
@@ -1,8 +1,0 @@
-!missing-enum! GCExtendedGamepadSnapshotDataVersion not bound
-!missing-enum! GCMicroGamepadSnapshotDataVersion not bound
-!missing-field! GCCurrentExtendedGamepadSnapshotDataVersion not bound
-!missing-field! GCCurrentMicroGamepadSnapshotDataVersion not bound
-!missing-pinvoke! GCExtendedGamepadSnapshotDataFromNSData is not bound
-!missing-pinvoke! GCMicroGamepadSnapshotDataFromNSData is not bound
-!missing-pinvoke! NSDataFromGCExtendedGamepadSnapshotData is not bound
-!missing-pinvoke! NSDataFromGCMicroGamepadSnapshotData is not bound


### PR DESCRIPTION
See [diff](https://gist.github.com/chamons/aa8691ec3d900744675022a6a10a7e3c) for GCExtendedGamepadSnapshotData since it's an extension of existing tyype.

See [diff](https://gist.github.com/chamons/092ae1a0efbc90abea4664a98960e133) for GCMicroGamepadSnapshotData as well.