### PR TITLE
[mtouch] Add logging overloads that don't format the input.

### DIFF
--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -149,9 +149,22 @@ namespace Xamarin.Bundler
 
 		static string mtouch_dir;
 
+		public static void Log (string value)
+		{
+			Log (0, value);
+		}
+
 		public static void Log (string format, params object [] args)
 		{
 			Log (0, format, args);
+		}
+
+		public static void Log (int min_verbosity, string value)
+		{
+			if (min_verbosity > verbose)
+				return;
+
+			Console.WriteLine (value);
 		}
 
 		public static void Log (int min_verbosity, string format, params object [] args)


### PR DESCRIPTION
Sometimes we just Log a string without any format arguments. This works fine,
until the string comes from the user, and happen to contain braces, in which
case an invalid format exception is thrown.

Adding Log overloads that doesn't take format arguments (nor formats its
input) avoids this problem.