### PR TITLE
[d16-0] [mapkit] Add missing [NullAllowed] in initWithAnnotation:reuseIdentifier: Fixes 5345

### DIFF
--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -100,9 +100,9 @@ namespace MapKit {
 		[Export ("initWithAnnotation:reuseIdentifier:")]
 		[PostGet ("Annotation")]
 #if XAMCORE_2_0
-		IntPtr Constructor (IMKAnnotation annotation, [NullAllowed] string reuseIdentifier);
+		IntPtr Constructor ([NullAllowed] IMKAnnotation annotation, [NullAllowed] string reuseIdentifier);
 #else
-		IntPtr Constructor (NSObject annotation, [NullAllowed] string reuseIdentifier);
+		IntPtr Constructor ([NullAllowed] NSObject annotation, [NullAllowed] string reuseIdentifier);
 #endif
 	
 		[Export ("initWithFrame:")]
@@ -815,9 +815,9 @@ namespace MapKit {
 
 		[Export ("initWithAnnotation:reuseIdentifier:")]
 #if XAMCORE_2_0
-		IntPtr Constructor ([NullAllowed] IMKAnnotation annotation, string reuseIdentifier);
+		IntPtr Constructor ([NullAllowed] IMKAnnotation annotation, [NullAllowed] string reuseIdentifier);
 #else
-		IntPtr Constructor ([NullAllowed] NSObject annotation, string reuseIdentifier);
+		IntPtr Constructor ([NullAllowed] NSObject annotation, [NullAllowed] string reuseIdentifier);
 #endif
 
 		[NoTV]
@@ -1916,7 +1916,7 @@ namespace MapKit {
 		// inlined from base type
 		[Export ("initWithAnnotation:reuseIdentifier:")]
 		[PostGet ("Annotation")]
-		IntPtr Constructor (IMKAnnotation annotation, [NullAllowed] string reuseIdentifier);
+		IntPtr Constructor ([NullAllowed] IMKAnnotation annotation, [NullAllowed] string reuseIdentifier);
 
 		[Export ("titleVisibility", ArgumentSemantic.Assign)]
 		MKFeatureVisibility TitleVisibility { get; set; }


### PR DESCRIPTION
It was missing on the first argument for `MKAnnotationView` and
inconsistent on subclasses.

references: https://github.com/xamarin/xamarin-macios/issues/5345

Backport of #5346.

/cc @dalexsoto @spouliot