### PR TITLE
[msbuild] Use AddLine when adding --interpreter to mtouch arguments.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -408,7 +408,7 @@ namespace Xamarin.iOS.Tasks
 				args.AddLine ("--sgen-conc");
 
 			if (!string.IsNullOrEmpty (Interpreter))
-				args.Add ($"--interpreter={Interpreter}");
+				args.AddLine ($"--interpreter={Interpreter}");
 
 			switch (LinkMode.ToLowerInvariant ()) {
 			case "sdkonly": args.AddLine ("--linksdkonly"); break;


### PR DESCRIPTION
So that it matches the rest if the arguments.