### PR TITLE
[msbuild] Add space to arguments when adding a newline at the end as well.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/CommandLineArgumentBuilder.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/CommandLineArgumentBuilder.cs
@@ -36,7 +36,7 @@ namespace Xamarin.MacDev
 		/// </summary>
 		public void Add (string argument, bool appendLine = false)
 		{
-			if (builder.Length > 0 && !appendLine)
+			if (builder.Length > 0)
 				builder.Append (' ');
 
 			builder.Append (argument);


### PR DESCRIPTION
Example (previous behavior):

    args.Add ("-a");
    args.AddLine ("-b")
    args.Add ("-c");

would result in:

    -a-b
    -c

which is obviously not correct.

New result:

    -a -b
    -c

which is much better.