### PR TITLE
[tests] Set the correct environment variables when executing msbuild from the mtouch tests.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1937,7 +1937,7 @@ public class B
 
 			if (!File.Exists (fn)) {
 				var csproj = Path.Combine (Configuration.SourceRoot, "tests", "bindings-test", "bindings-test" + GetProjectSuffix (profile) + ".csproj");
-				XBuild.Build (csproj, platform: "AnyCPU");
+				XBuild.BuildXI (csproj, platform: "AnyCPU");
 			}
 
 			return fn;
@@ -1950,7 +1950,7 @@ public class B
 
 			if (!File.Exists (fn)) {
 				var csproj = Path.Combine (Configuration.SourceRoot, "tests", "bindings-framework-test", "bindings-framework-test" + GetProjectSuffix (profile) + ".csproj");
-				XBuild.Build (csproj, platform: "AnyCPU");
+				XBuild.BuildXI (csproj, platform: "AnyCPU");
 			}
 
 			return fn;
@@ -2529,7 +2529,7 @@ public class B
 			}
 			var platform = target == Target.Dev ? "iPhone" : "iPhoneSimulator";
 			var csproj = Path.Combine (Configuration.SourceRoot, "tests" + subdir, testname, testname + GetProjectSuffix (profile) + ".csproj");
-			XBuild.Build (csproj, configuration, platform, timeout: TimeSpan.FromMinutes (15));
+			XBuild.BuildXI (csproj, configuration, platform, timeout: TimeSpan.FromMinutes (15));
 		}
 
 		[Test]
@@ -3080,7 +3080,7 @@ class Test {
 
 			var projectDir = Path.Combine (Configuration.SourceRoot, "tests", "link all");
 			var project = Path.Combine (projectDir, "link all.csproj");
-			XBuild.Build (project, platform: "iPhone");
+			XBuild.BuildXI (project, platform: "iPhone");
 			var appPath = Path.Combine (projectDir, "bin", "iPhone", "Debug", "link all.app");
 			foreach (var device in devices) {
 				if (mtouch.InstallOnDevice (device, appPath) != 0) {
@@ -3115,7 +3115,7 @@ class Test {
 			var containerPath = Path.Combine (projectDir, "bin", "iPhone", "Debug", "MyWatch2Container.app");
 			var appPath = Path.Combine (containerPath, "Watch", "MyWatchApp2.app");
 
-			XBuild.Build (project, platform: "iPhone");
+			XBuild.BuildXI (project, platform: "iPhone");
 			if (!Directory.Exists (appPath))
 				Assert.Fail ("Failed to build the watchOS app.");
 
@@ -4147,7 +4147,7 @@ public class Dummy {
 			File.WriteAllText (csprojpath, csproj);
 			File.WriteAllText (testfilepath, testfile);
 			File.WriteAllText (infoplistpath, MTouchTool.CreatePlist (profile, "testapp"));
-			XBuild.Build (csprojpath, configuration, platform);
+			XBuild.BuildXI (csprojpath, configuration, platform);
 			var environment_variables = new Dictionary<string, string> ();
 			if (!clean_simulator)
 				environment_variables ["SKIP_SIMULATOR_SETUP"] = "1";

--- a/tools/common/StringUtils.cs
+++ b/tools/common/StringUtils.cs
@@ -15,6 +15,17 @@ namespace Xamarin.Utils {
 		static char shellQuoteChar;
 		static char[] mustQuoteCharacters = new char [] { ' ', '\'', ',', '$', '\\' };
 
+		public static string[] Quote (params string[] array)
+		{
+			if (array == null || array.Length == 0)
+				return array;
+
+			var rv = new string [array.Length];
+			for (var i = 0; i < array.Length; i++)
+				rv [i] = Quote (array [i]);
+			return rv;
+		}
+
 		public static string Quote (string f)
 		{
 			if (String.IsNullOrEmpty (f))


### PR DESCRIPTION
This is usually not a problem, because these variables are already set when
running from the command-line or xharness. However, it shows up when running
tests directly from VSfM.