### PR TITLE
[tests] Use latest version of NUnit for test projects to get support for parallelized tests.

### DIFF
--- a/tests/generator/generator-tests.csproj
+++ b/tests/generator/generator-tests.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -28,7 +29,7 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil">
       <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.dll</HintPath>
@@ -66,8 +67,8 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
     <None Include="tests\is-direct-binding.cs" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="tests\" />

--- a/tests/generator/packages.config
+++ b/tests/generator/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net461" />
-  <package id="NUnit" version="3.7.1" targetFramework="net461" />
-  <package id="NUnit.ConsoleRunner" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" targetFramework="net461" />
+  <package id="NUnit" version="3.11.0" targetFramework="net461" />
+  <package id="NUnit.ConsoleRunner" version="3.9.0" targetFramework="net461" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net461" />
 </packages>

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -31,7 +32,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.3.5.0\lib\net40\nunit.framework.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.3.11.0\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="mmp">
       <HintPath>..\..\_mac-build\Library\Frameworks\Xamarin.Mac.framework\Versions\git\lib\mmp\mmp.exe</HintPath>
@@ -121,8 +122,6 @@
     <None Include="..\common\mac\MacTestMain.cs">
       <Link>MacTestMain.cs</Link>
     </None>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/mmptest/packages.config
+++ b/tests/mmptest/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.ConsoleRunner" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.Extension.NUnitV2Driver" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net40" />
-  <package id="NUnit.Extension.VSProjectLoader" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.Runners" version="3.5.0" targetFramework="net40" />
+  <package id="NUnit" version="3.11.0" targetFramework="net40" />
+  <package id="NUnit.ConsoleRunner" version="3.9.0" targetFramework="net40" />
+  <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net40" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net40" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net40" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.5" targetFramework="net40" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net40" />
+  <package id="NUnit.Runners" version="3.9.0" targetFramework="net40" />
 </packages>

--- a/tests/msbuild-mac/msbuild-mac.csproj
+++ b/tests/msbuild-mac/msbuild-mac.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -31,14 +32,11 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.3.5.0\lib\net40\nunit.framework.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.3.11.0\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="src\MSBuild-Smoke.cs" />
@@ -65,6 +63,9 @@
     <Compile Include="..\common\Profile.cs">
       <Link>Profile.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="CustomBuildActions.targets" />

--- a/tests/msbuild-mac/packages.config
+++ b/tests/msbuild-mac/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.ConsoleRunner" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.Extension.NUnitV2Driver" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net40" />
-  <package id="NUnit.Extension.VSProjectLoader" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.Runners" version="3.5.0" targetFramework="net40" />
+  <package id="NUnit" version="3.11.0" targetFramework="net40" />
+  <package id="NUnit.ConsoleRunner" version="3.9.0" targetFramework="net40" />
+  <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net40" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net40" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net40" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.5" targetFramework="net40" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net40" />
+  <package id="NUnit.Runners" version="3.9.0" targetFramework="net40" />
 </packages>

--- a/tests/mtouch/mtouch.csproj
+++ b/tests/mtouch/mtouch.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -24,7 +25,7 @@
     <Reference Include="Mono.Posix" />
     <Reference Include="System.Xml" />
     <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.3.5.0\lib\net40\nunit.framework.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.3.11.0\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/mtouch/packages.config
+++ b/tests/mtouch/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.ConsoleRunner" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.Extension.NUnitV2Driver" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net40" />
-  <package id="NUnit.Extension.VSProjectLoader" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.Runners" version="3.5.0" targetFramework="net40" />
+  <package id="NUnit" version="3.11.0" targetFramework="net40" />
+  <package id="NUnit.ConsoleRunner" version="3.9.0" targetFramework="net40" />
+  <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net40" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net40" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net40" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.5" targetFramework="net40" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net40" />
+  <package id="NUnit.Runners" version="3.9.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Also update xharness to automatically find the correct nunit-console
executable for NUnit tests.