### PR TITLE
[xharness] Rework BCL test importation to not bail out completely if something went wrong.

### DIFF
--- a/tests/xharness/BCLTestImporter/BCLTestImportTargetFactory.cs
+++ b/tests/xharness/BCLTestImporter/BCLTestImportTargetFactory.cs
@@ -32,12 +32,13 @@ namespace xharness.BCLTestImporter {
 		{
 			var result = new List<iOSTestProject> ();
 			// generate all projects, then create a new iOSTarget per project
-			foreach (var (name, path, xunit, platforms) in projectGenerator.GenerateAlliOSTestProjects ()) {
+			foreach (var (name, path, xunit, platforms, failure) in projectGenerator.GenerateAlliOSTestProjects ()) {
 				var prefix = xunit ? "xUnit" : "NUnit";
 				result.Add (new iOSTestProject (path) {
 					Name = $"[{prefix}] Mono {name}",
 					SkiptvOSVariation = !platforms.Contains (Platform.TvOS),
 					SkipwatchOSVariation = !platforms.Contains (Platform.WatchOS),
+					FailureMessage = failure,
 				});
 			}
 			return result;
@@ -51,12 +52,13 @@ namespace xharness.BCLTestImporter {
 			else
 				platform = Platform.MacOSModern;
 			var result = new List<MacTestProject> ();
-			foreach (var (name, path, xunit) in projectGenerator.GenerateAllMacTestProjects (platform)) {
+			foreach (var (name, path, xunit, failure) in projectGenerator.GenerateAllMacTestProjects (platform)) {
 				var prefix = xunit ? "xUnit" : "NUnit";
 				result.Add (new MacTestProject (path, targetFrameworkFlavor: flavor, generateVariations: false) {
 					Name = $"[{prefix}] Mono {name}",
 					Platform = "AnyCPU",
 					IsExecutableProject = true,
+					FailureMessage = failure,
 					Dependency = async () => {
 						var rv = await Harness.BuildBclTests ();
 						if (!rv.Succeeded)

--- a/tests/xharness/TestProject.cs
+++ b/tests/xharness/TestProject.cs
@@ -20,6 +20,7 @@ namespace xharness
 		public bool GenerateVariations = true;
 		public string [] Configurations;
 		public Func<Task> Dependency;
+		public string FailureMessage;
 
 		public IEnumerable<TestProject> ProjectReferences;
 

--- a/tools/bcl-test-importer/BCLTestImporter/RegisterTypeGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/RegisterTypeGenerator.cs
@@ -78,20 +78,24 @@ namespace BCLTestImporter {
 			}
 		}
 
-		public static async Task<string> GenerateCodeAsync (Dictionary<string, Type> typeRegistration, bool isXunit,
+		public static async Task<string> GenerateCodeAsync ((string FailureMessage, Dictionary<string, Type> Types) typeRegistration, bool isXunit,
 			string templatePath)
 		{
 			var importStringBuilder = new StringBuilder ();
 			var keyValuesStringBuilder = new StringBuilder ();
 			var namespaces = new List<string> ();  // keep track of the namespaces to remove warnings
-			foreach (var a in typeRegistration.Keys) {
-				var t = typeRegistration [a];
-				if (!string.IsNullOrEmpty (t.Namespace)) {
-					if (!namespaces.Contains (t.Namespace)) {
-						namespaces.Add (t.Namespace);
-						importStringBuilder.AppendLine ($"using {t.Namespace};");
+			if (!string.IsNullOrEmpty (typeRegistration.FailureMessage)) {
+				keyValuesStringBuilder.AppendLine ($"#error {typeRegistration.FailureMessage}");
+			} else {
+				foreach (var a in typeRegistration.Types.Keys) {
+					var t = typeRegistration.Types [a];
+					if (!string.IsNullOrEmpty (t.Namespace)) {
+						if (!namespaces.Contains (t.Namespace)) {
+							namespaces.Add (t.Namespace);
+							importStringBuilder.AppendLine ($"using {t.Namespace};");
+						}
+						keyValuesStringBuilder.AppendLine ($"\t\t\t{{ \"{a}\", typeof ({t.FullName})}}, ");
 					}
-					keyValuesStringBuilder.AppendLine ($"\t\t\t{{ \"{a}\", typeof ({t.FullName})}}, ");
 				}
 			}
 			
@@ -104,8 +108,5 @@ namespace BCLTestImporter {
 				return result;
 			}
 		}
-		
-		// Generates the code for the type registration using the give path to the template to use
-		public static string GenerateCode (Dictionary <string, Type> typeRegistration, bool isXunit, string templatePath) => GenerateCodeAsync (typeRegistration, isXunit, templatePath).Result;
 	}
 }


### PR DESCRIPTION
Rework BCL test importation to generate projects that won't compile instead of
giving up completely in case of generation failure.

This means that xharness can still be used for non-BCL tests even if the
generation of the BCL tests fail.