### PR TITLE
[linker] Remove non-bitcode compatible code, and show a warning.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -1787,6 +1787,12 @@ Mixed-mode assemblies can not be processed by the linker.
 
 See https://msdn.microsoft.com/en-us/library/x0w2664k.aspx for more information on mixed-mode assemblies.
 
+### MT2105: The method {method} contains a '{handlerType}' exception clause, which is currently not supported when compiling for bitcode. This method will throw an exception if called.
+
+Currently Xamarin.iOS does not support the 'filter' exception clauses when
+compiling to bitcode. Any methods containing such code will throw a
+NotSupportedException exception.
+
 ## MT3xxx: AOT error messages
 
 <!--

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -1787,6 +1787,8 @@ Mixed-mode assemblies can not be processed by the linker.
 
 See https://msdn.microsoft.com/en-us/library/x0w2664k.aspx for more information on mixed-mode assemblies.
 
+<a name="MT2105" />
+
 ### MT2105: The method {method} contains a '{handlerType}' exception clause, which is currently not supported when compiling for bitcode. This method will throw an exception if called.
 
 Currently Xamarin.iOS does not support the 'filter' exception clauses when
@@ -1819,6 +1821,33 @@ void MyMethod ()
 	throw new NotSupportedException ("This method contains IL not supported when compiled to bitcode.");
 }
 ```
+
+<a name="MT2210" />
+<a name="MT2211" />
+<a name="MT2212" />
+<a name="MT2213" />
+<a name="MT2214" />
+<a name="MT2215" />
+<a name="MT2216" />
+<a name="MT2217" />
+<a name="MT2218" />
+<a name="MT2219" />
+
+### MT221x: Incompatible Code For Bitcode Remover failed processing `...`.
+
+Something unexpected occured when trying to remove incompatible code for
+bitcode from the application. The assembly causing the issue is named in the
+error message. In order to fix this issue the assembly will need to be
+provided in a new issue on
+[github](https://github.com/xamarin/xamarin-macios/issues/new) along with a
+complete build log with verbosity enabled (i.e. `-v -v -v -v` in the
+**Additional mtouch arguments** in the project's watchOS Build options).
+
+It's usually possible to work around this by adding
+`--optimize=-remove-unsupported-il-for-bitcode` to the **Additional mtouch arguments**
+in the project's watchOS Build options.
+
+<!-- MT2210 - MT2219 used by the above error -->
 
 ## MT3xxx: AOT error messages
 

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -1791,7 +1791,34 @@ See https://msdn.microsoft.com/en-us/library/x0w2664k.aspx for more information 
 
 Currently Xamarin.iOS does not support the 'filter' exception clauses when
 compiling to bitcode. Any methods containing such code will throw a
-NotSupportedException exception.
+NotSupportedException exception when the method is executed (the exception
+will be thrown at method entry, even if execution would follow a path that did
+not involve the 'filter' exception clause).
+
+This is an example of code that's not supported:
+
+```csharp
+void MyMethod ()
+{
+	try {
+		throw new Exception ("FilterMe");
+	} catch (Exception e)
+		when (e.Message == "FilterMe") // <- This is the filter clause.
+	{
+		Console.WriteLine ("filtered");
+	}
+}
+```
+
+This method will behave like the following example, throwing an exception at
+method entry:
+
+```csharp
+void MyMethod ()
+{
+	throw new NotSupportedException ("This method contains IL not supported when compiled to bitcode.");
+}
+```
 
 ## MT3xxx: AOT error messages
 

--- a/tests/linker/ios/link sdk/BitcodeTest.cs
+++ b/tests/linker/ios/link sdk/BitcodeTest.cs
@@ -20,8 +20,12 @@ namespace LinkSdk {
 #endif
 			if (supported) {
 				Assert.AreEqual (0, FilterClause (), "Filter me");
+				Assert.AreEqual (10, FilterClauseProperty, "Filter me getter");
+				Assert.DoesNotThrow (() => FilterClauseProperty = 20, "Filter me setter");
 			} else {
 				Assert.Throws<NotSupportedException> (() => FilterClause (), "Filter me not supported");
+				Assert.Throws<NotSupportedException> (() => { var x = FilterClauseProperty; }, "Filter me getter not supported");
+				Assert.Throws<NotSupportedException> (() => FilterClauseProperty = 30, "Filter me setter not supported");
 			}
 		}
 
@@ -35,6 +39,28 @@ namespace LinkSdk {
 				return 0;
 			} catch {
 				return 1;
+			}
+		}
+
+		// A property with a filter clause
+		// mtouch will show a warning for this property (MT2105) when building for watchOS device. This is expected.
+		static int FilterClauseProperty {
+			get {
+				try {
+					throw new Exception ("FilterMe");
+				} catch (Exception e) when (e.Message == "FilterMe") {
+					return 10;
+				} catch {
+					return 11;
+				}
+			}
+			set {
+				try {
+					throw new Exception ("FilterMe");
+				} catch (Exception e) when (e.Message == "FilterMe") {
+				} catch {
+					Assert.Fail ("Filter failure: {0}", value);
+				}
 			}
 		}
 

--- a/tests/linker/ios/link sdk/BitcodeTest.cs
+++ b/tests/linker/ios/link sdk/BitcodeTest.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using ObjCRuntime;
+
+using NUnit.Framework;
+
+namespace LinkSdk {
+	[TestFixture]
+	public class BitcodeTest {
+		[Test]
+		public void FilterClauseTest ()
+		{
+			var supported = true;
+#if __WATCHOS__
+			if (Runtime.Arch == Arch.DEVICE)
+				supported = false;
+#endif
+			if (supported) {
+				Assert.AreEqual (0, FilterClause (), "Filter me");
+			} else {
+				Assert.Throws<NotSupportedException> (() => FilterClause (), "Filter me not supported");
+			}
+		}
+
+		// A method with a filter clause
+		// mtouch will show a warning for this method (MT2105) when building for watchOS device. This is expected.
+		static int FilterClause ()
+		{
+			try {
+				throw new Exception ("FilterMe");
+			} catch (Exception e) when (e.Message == "FilterMe") {
+				return 0;
+			} catch {
+				return 1;
+			}
+		}
+
+		[Test]
+		public void FaultClauseTest ()
+		{
+			// First assert that the method that is supposed to have a fault clause actually has a fault clause.
+			// This is somewhat complicated because it's not the method we call that has the fault clause, but a generated method in a generated class.
+			// This is because we only have an indirect way of making csc produce a fault clause
+			var enumeratorType = GetType ().GetNestedTypes (BindingFlags.NonPublic).First ((v) => v.Name.Contains ($"<{nameof (FaultClause)}>"));
+			var method = enumeratorType.GetMethod ("MoveNext", BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+			var body = method.GetMethodBody ();
+			Assert.IsTrue (body.ExceptionHandlingClauses.Any ((v) => v.Flags == ExceptionHandlingClauseOptions.Fault), "Any fault clauses");
+
+			// Then assert that the method can be called successfully.
+			var rv = FaultClause ().ToArray ();
+			Assert.AreEqual (1, rv.Count (), "Count");
+			Assert.AreEqual (1, rv [0], "Item 1");
+
+		}
+
+		// The C# compiler uses fault clauses for 'using' blocks inside iterators.
+		static IEnumerable<int> FaultClause ()
+		{
+			using (var d = new Disposable ()) {
+				yield return 1;
+			}
+		}
+		class Disposable : IDisposable {
+			void IDisposable.Dispose () { }
+		}
+	}
+}

--- a/tests/linker/ios/link sdk/link sdk.csproj
+++ b/tests/linker/ios/link sdk/link sdk.csproj
@@ -192,6 +192,7 @@
     <Compile Include="..\..\CommonLinkSdkTest.cs">
       <Link>CommonLinkSdkTest.cs</Link>
     </Compile>
+    <Compile Include="BitcodeTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="LaunchScreen.storyboard" Condition="'$(TargetFrameworkIdentifier)' != 'Xamarin.WatchOS'" />

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2928,19 +2928,44 @@ class TestClass {
 			return 1;
 		}
 	}
+	static int FilterClauseProperty {
+		get {
+			try {
+				throw new System.Exception (""FilterMe"");
+			} catch (System.Exception e) when (e.Message == ""FilterMe"") {
+				return 10;
+			} catch {
+				return 11;
+			}
+		}
+		set {
+			try {
+				throw new System.Exception (""FilterMe"");
+			} catch (System.Exception e) when (e.Message == ""FilterMe"") {
+			} catch {
+				System.Console.WriteLine (""Filter failure: {0}"", value);
+			}
+		}
+	}
 }
 				";
 				ext.Profile = Profile.watchOS;
 				ext.Linker = MTouchLinker.LinkSdk;
-				ext.CreateTemporaryWatchKitExtension (extraCode: code, extraArg: "/debug");
 				ext.CreateTemporaryDirectory ();
+				ext.CreateTemporaryWatchKitExtension (extraCode: code, extraArg: "/debug");
 				ext.WarnAsError = new int [] { 2105 };
 				ext.AssertExecuteFailure (MTouchAction.BuildDev);
 				ext.AssertError (2105, "The method TestClass.FilterClause contains a 'Filter' exception clause, which is currently not supported when compiling for bitcode. This method will throw an exception if called.", "testApp.cs", 9);
-
+				ext.AssertError (2105, "The property TestClass.FilterClauseProperty contains a 'Filter' exception clause, which is currently not supported when compiling for bitcode. This property will throw an exception if called.", "testApp.cs", 19);
+				ext.AssertError (2105, "The property TestClass.FilterClauseProperty contains a 'Filter' exception clause, which is currently not supported when compiling for bitcode. This property will throw an exception if called.", "testApp.cs", 28);
+				ext.AssertErrorCount (3);
+		
 				ext.Optimize = new string [] { "remove-unsupported-il-for-bitcode" };
 				ext.AssertExecuteFailure (MTouchAction.BuildSim);
 				ext.AssertError (2105, "The method TestClass.FilterClause contains a 'Filter' exception clause, which is currently not supported when compiling for bitcode. This method will throw an exception if called.", "testApp.cs", 9);
+				ext.AssertError (2105, "The property TestClass.FilterClauseProperty contains a 'Filter' exception clause, which is currently not supported when compiling for bitcode. This property will throw an exception if called.", "testApp.cs", 19);
+				ext.AssertError (2105, "The property TestClass.FilterClauseProperty contains a 'Filter' exception clause, which is currently not supported when compiling for bitcode. This property will throw an exception if called.", "testApp.cs", 28);
+				ext.AssertErrorCount (3);
 			}
 		}
 

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1752,7 +1752,7 @@ public class TestApp {
 				mtouch.Linker = MTouchLinker.LinkSdk;
 				mtouch.Optimize = new string [] { "foo" };
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build");
-				mtouch.AssertWarning (132, "Unknown optimization: 'foo'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size, inline-runtime-arch, blockliteral-setupblock, register-protocols, inline-dynamic-registration-supported, static-block-to-delegate-lookup, remove-dynamic-registrar.");
+				mtouch.AssertWarning (132, "Unknown optimization: 'foo'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size, inline-runtime-arch, blockliteral-setupblock, register-protocols, inline-dynamic-registration-supported, static-block-to-delegate-lookup, remove-dynamic-registrar, remove-unsupported-il-for-bitcode.");
 			}
 		}
 
@@ -3569,10 +3569,11 @@ public partial class NotificationService : UNNotificationServiceExtension
 				mtouch.CreateTemporaryApp ();
 				mtouch.Linker = MTouchLinker.DontLink;
 				mtouch.Debug = true; // makes simlauncher possible, which speeds up the build
-				mtouch.Optimize = new string [] { "-inline-intptr-size" };
+				mtouch.Optimize = new string [] { "-inline-intptr-size", "remove-unsupported-il-for-bitcode" };
 				mtouch.AssertExecute (MTouchAction.BuildSim);
 				mtouch.AssertWarning (2003, "Option '--optimize=-inline-intptr-size' will be ignored since linking is disabled");
-				mtouch.AssertWarningCount (1);
+				mtouch.AssertWarning (2003, "Option '--optimize=remove-unsupported-il-for-bitcode' will be ignored since it's only applicable to watchOS.");
+				mtouch.AssertWarningCount (2);
 			}
 		}
 

--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -621,7 +621,7 @@ public partial class TodayViewController : UIViewController, INCWidgetProviding
 				File.WriteAllText (plist_path, info_plist);
 		}
 
-		public void CreateTemporaryWatchKitExtension (string code = null)
+		public void CreateTemporaryWatchKitExtension (string code = null, string extraCode = null, string extraArg = "")
 		{
 			string testDir;
 			if (RootAssembly == null) {
@@ -641,9 +641,12 @@ public partial class NotificationController : WKUserNotificationInterfaceControl
 }";
 			}
 
+			if (extraCode != null)
+				code += extraCode;
+
 			AppPath = app;
 			Extension = true;
-			RootAssembly = MTouch.CompileTestAppLibrary (testDir, code: code, profile: Profile);
+			RootAssembly = MTouch.CompileTestAppLibrary (testDir, code: code, extraArg: extraArg, profile: Profile);
 
 			File.WriteAllText (Path.Combine (app, "Info.plist"), @"<?xml version=""1.0"" encoding=""UTF-8""?>
 <!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">

--- a/tools/common/DerivedLinkContext.cs
+++ b/tools/common/DerivedLinkContext.cs
@@ -17,6 +17,12 @@ namespace Xamarin.Tuner
 		internal Target Target;
 		Symbols required_symbols;
 
+		// Any errors or warnings during the link process that won't prevent linking from continuing can be stored here.
+		// This is typically used to show as many problems as possible per build (so that the user doesn't have to fix one thing, rebuild, fix another, rebuild, fix another, etc).
+		// Obviously if the problem is such that cascading errors may end up reported, this should not be used.
+		// The errors/warnings will be shown when the linker is done.
+		public List<Exception> Exceptions = new List<Exception> ();
+
 		// SDK candidates - they will be preserved only if the application (not the SDK) uses it
 		List<ICustomAttributeProvider> srs_data_contract = new List<ICustomAttributeProvider> ();
 		List<ICustomAttributeProvider> xml_serialization = new List<ICustomAttributeProvider> ();

--- a/tools/common/Optimizations.cs
+++ b/tools/common/Optimizations.cs
@@ -140,6 +140,15 @@ namespace Xamarin.Bundler
 						continue;
 					}
 					goto default; // also requires the linker
+#if MONOTOUCH
+				case Opt.RemoveUnsupportedILForBitcode:
+					if (app.Platform != Utils.ApplePlatform.WatchOS) {
+						if (!all.HasValue) // Don't show this warning if it was enabled with --optimize=all
+							ErrorHelper.Warning (2003, $"Option '--optimize={opt_names [(int) Opt.RemoveUnsupportedILForBitcode]}' will be ignored since it's only applicable to watchOS.");
+						values [i] = false;
+					}
+					break;
+#endif
 				default:
 					if (app.LinkMode == LinkMode.None) {
 						ErrorHelper.Warning (2003, $"Option '--optimize={(values [i].Value ? "" : "-")}{opt_names [i]}' will be ignored since linking is disabled");
@@ -238,12 +247,6 @@ namespace Xamarin.Bundler
 			if (!RemoveUnsupportedILForBitcode.HasValue) {
 				// By default enabled for watchOS device builds.
 				RemoveUnsupportedILForBitcode = app.Platform == Utils.ApplePlatform.WatchOS && app.IsDeviceBuild;
-			} else if (RemoveUnsupportedILForBitcode.Value) {
-				if (app.Platform != Utils.ApplePlatform.WatchOS) {
-					if (!all.HasValue) // Don't show this warning if it was enabled with --optimize=all
-						ErrorHelper.Warning (2003, $"Option '--optimize={opt_names [(int) Opt.RemoveUnsupportedILForBitcode]}' will be ignored since it's only applicable to watchOS.");
-					RemoveUnsupportedILForBitcode = false;
-				}
 			}
 #endif
 

--- a/tools/linker/MobileExtensions.cs
+++ b/tools/linker/MobileExtensions.cs
@@ -92,7 +92,7 @@ namespace Xamarin.Linker {
 			return GetBindingImplAttribute (provider, context?.GetCustomAttributes (provider, Namespaces.ObjCRuntime, "BindingImplAttribute"));
 		}
 
-		static PropertyDefinition GetPropertyByAccessor (MethodDefinition method)
+		public static PropertyDefinition GetPropertyByAccessor (this MethodDefinition method)
 		{
 			foreach (PropertyDefinition property in method.DeclaringType.Properties) {
 				if (property.GetMethod == method || property.SetMethod == method)

--- a/tools/linker/MonoTouch.Tuner/RemoveBitcodeIncompatibleCodeStep.cs
+++ b/tools/linker/MonoTouch.Tuner/RemoveBitcodeIncompatibleCodeStep.cs
@@ -11,7 +11,6 @@ using Mono.Linker;
 using System;
 
 namespace MonoTouch.Tuner {
-	
 	public class RemoveBitcodeIncompatibleCodeStep : BaseSubStep {
 
 		LinkerOptions Options;
@@ -28,7 +27,7 @@ namespace MonoTouch.Tuner {
 				return SubStepTargets.Method | SubStepTargets.Type /* We don't care about types, but if not set a NullReferenceException occurs in BaseSubStep */;
 			}
 		}
-		
+
 		public override void ProcessMethod (MethodDefinition method)
 		{
 			if (!method.HasBody)

--- a/tools/linker/MonoTouch.Tuner/RemoveBitcodeIncompatibleCodeStep.cs
+++ b/tools/linker/MonoTouch.Tuner/RemoveBitcodeIncompatibleCodeStep.cs
@@ -1,0 +1,108 @@
+// Copyright 2012-2014, 2016 Xamarin Inc. All rights reserved.
+using System.Collections.Generic;
+using Mono.Tuner;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Linker.Steps;
+
+using Xamarin.Bundler;
+using Xamarin.Linker;
+using Mono.Linker;
+using System;
+
+namespace MonoTouch.Tuner {
+	
+	public class RemoveBitcodeIncompatibleCodeStep : BaseStep {
+
+		LinkerOptions Options;
+		MethodDefinition nse_ctor_def;
+		Dictionary<ModuleDefinition, MethodReference> nse_ctors;
+
+		public RemoveBitcodeIncompatibleCodeStep (LinkerOptions options)
+		{
+			Options = options;
+		}
+
+		protected override void ProcessAssembly (AssemblyDefinition assembly)
+		{
+			foreach (var type in assembly.MainModule.Types)
+				ProcessType (type);
+		}
+
+		void ProcessType (TypeDefinition type)
+		{
+			if (type.HasNestedTypes) {
+				foreach (var nestedType in type.NestedTypes)
+					ProcessType (nestedType);
+			}
+
+			if (type.HasMethods) {
+				foreach (var method in type.Methods)
+					ProcessMethod (method);
+			}
+
+		}
+
+		void ProcessMethod (MethodDefinition method)
+		{
+			if (!method.HasBody)
+				return;
+
+			var body = method.Body;
+			if (!body.HasExceptionHandlers)
+				return;
+
+			var anyFilterClauses = false;
+			foreach (var eh in body.ExceptionHandlers) {
+				if (eh.HandlerType == ExceptionHandlerType.Filter) {
+					anyFilterClauses = true;
+					ErrorHelper.Show (ErrorHelper.CreateWarning (Options.Application, 2105, method, $"The method {method.DeclaringType.FullName}.{method.Name} contains a '{eh.HandlerType}' exception clause, which is currently not supported when compiling for bitcode. This method will throw an exception if called."));
+					break;
+				}
+			}
+			if (!anyFilterClauses)
+				return;
+
+			body = new MethodBody (method);
+			var il = body.GetILProcessor ();
+			il.Emit (OpCodes.Ldstr, "This method contains IL not supported when compiled to bitcode.");
+			if (nse_ctor_def == null) {
+				var corlib = Context.GetAssembly ("mscorlib");
+				var nse = corlib.MainModule.GetType ("System", "NotSupportedException");
+				foreach (var ctor in nse.GetConstructors ()) {
+					if (!ctor.HasParameters)
+						continue;
+					var parameters = ctor.Parameters;
+					if (parameters.Count != 1)
+						continue;
+					if (!parameters [0].ParameterType.Is ("System", "String"))
+						continue;
+					nse_ctor_def = ctor;
+					break;
+				}
+				nse_ctors = new Dictionary<ModuleDefinition, MethodReference> ();
+			}
+			MethodReference nse_ctor;
+			if (!nse_ctors.TryGetValue (method.Module, out nse_ctor)) {
+				nse_ctors [method.Module] = nse_ctor = method.Module.ImportReference (nse_ctor_def);
+
+				// We're processing all assemblies, not linked assemblies, so
+				// make sure we're saving any changes to non-linked assemblies as well.
+				var assembly = method.Module.Assembly;
+				var action = Annotations.GetAction (assembly);
+				switch (action) {
+				case AssemblyAction.Link:
+				case AssemblyAction.Save:
+					break;
+				default:
+					Annotations.SetAction (assembly, AssemblyAction.Save);
+					break;
+				}
+			}
+			il.Emit (OpCodes.Newobj, nse_ctor);
+			il.Emit (OpCodes.Throw);
+			method.Body = body;
+
+		}
+	}
+}

--- a/tools/linker/MonoTouch.Tuner/RemoveBitcodeIncompatibleCodeStep.cs
+++ b/tools/linker/MonoTouch.Tuner/RemoveBitcodeIncompatibleCodeStep.cs
@@ -14,7 +14,7 @@ using Xamarin.Tuner;
 using Xamarin.Linker;
 
 namespace MonoTouch.Tuner {
-	public class RemoveBitcodeIncompatibleCodeStep : BaseSubStep {
+	public class RemoveBitcodeIncompatibleCodeStep : ExceptionalSubStep {
 
 		LinkerOptions Options;
 		MethodDefinition nse_ctor_def;
@@ -37,7 +37,10 @@ namespace MonoTouch.Tuner {
 			}
 		}
 
-		public override void ProcessMethod (MethodDefinition method)
+		protected override int ErrorCode => 2210;
+		protected override string Name => "Incompatible Code For Bitcode Remover";
+
+		protected override void Process (MethodDefinition method)
 		{
 			if (!context.Annotations.IsMarked (method))
 				return;

--- a/tools/mmp/Tuning.cs
+++ b/tools/mmp/Tuning.cs
@@ -72,7 +72,7 @@ namespace MonoMac.Tuner {
 
 	class Linker {
 
-		public static void Process (LinkerOptions options, out LinkContext context, out List<string> assemblies)
+		public static void Process (LinkerOptions options, out MonoMacLinkContext context, out List<string> assemblies)
 		{
 			var pipeline = CreatePipeline (options);
 
@@ -118,7 +118,7 @@ namespace MonoMac.Tuner {
 			assemblies = ListAssemblies (context);
 		}
 
-		static LinkContext CreateLinkContext (LinkerOptions options, Pipeline pipeline)
+		static MonoMacLinkContext CreateLinkContext (LinkerOptions options, Pipeline pipeline)
 		{
 			var context = new MonoMacLinkContext (pipeline, options.Resolver);
 			context.CoreAction = AssemblyAction.Link;

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1408,8 +1408,9 @@ namespace Xamarin.Bundler {
 
 			linker_options = options;
 
-			Mono.Linker.LinkContext context;
-			MonoMac.Tuner.Linker.Process (options, out context, out resolved_assemblies);
+			MonoMac.Tuner.Linker.Process (options, out var context, out resolved_assemblies);
+
+			ErrorHelper.Show (context.Exceptions);
 
 			// Idealy, this would be handled by Linker.Process above. However in the non-linking case
 			// we do not run MobileMarkStep which generates the pinvoke list. Hack around this for now

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -544,6 +544,8 @@ namespace Xamarin.Bundler
 
 			MonoTouch.Tuner.Linker.Process (LinkerOptions, out LinkContext, out assemblies);
 
+			ErrorHelper.Show (LinkContext.Exceptions);
+
 			Driver.Watch ("Link Assemblies", 1);
 		}
 
@@ -824,8 +826,6 @@ namespace Xamarin.Bundler
 			// again, and it won't do anything for the appex's sharing code with the main app (but 
 			// will still work for any appex's not sharing code).
 			allTargets.ForEach ((v) => v.linked = true);
-
-			ErrorHelper.Show (LinkContext.Exceptions);
 		}
 			
 		public void ProcessAssemblies ()

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -824,6 +824,8 @@ namespace Xamarin.Bundler
 			// again, and it won't do anything for the appex's sharing code with the main app (but 
 			// will still work for any appex's not sharing code).
 			allTargets.ForEach ((v) => v.linked = true);
+
+			ErrorHelper.Show (LinkContext.Exceptions);
 		}
 			
 		public void ProcessAssemblies ()

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -190,6 +190,10 @@ namespace MonoTouch.Tuner {
 			// We need to store the Field attribute in annotations, since it may end up removed.
 			pipeline.Append (new ProcessExportedFields ());
 
+			// We need to remove incompatible bitcode for all assemblies, not only the linked assemblies.
+			if (options.Application.Optimizations.RemoveUnsupportedILForBitcode == true)
+				pipeline.AppendStep (new RemoveBitcodeIncompatibleCodeStep (options));
+			
 			if (options.LinkMode != LinkMode.None) {
 				pipeline.Append (new CoreTypeMapStep ());
 

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -192,7 +192,7 @@ namespace MonoTouch.Tuner {
 
 			// We need to remove incompatible bitcode for all assemblies, not only the linked assemblies.
 			if (options.Application.Optimizations.RemoveUnsupportedILForBitcode == true)
-				pipeline.AppendStep (new RemoveBitcodeIncompatibleCodeStep (options));
+				pipeline.AppendStep (new SubStepDispatcher { new RemoveBitcodeIncompatibleCodeStep (options) });
 			
 			if (options.LinkMode != LinkMode.None) {
 				pipeline.Append (new CoreTypeMapStep ());

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -190,10 +190,11 @@ namespace MonoTouch.Tuner {
 			// We need to store the Field attribute in annotations, since it may end up removed.
 			pipeline.Append (new ProcessExportedFields ());
 
-			// We need to remove incompatible bitcode for all assemblies, not only the linked assemblies.
+			// We remove incompatible bitcode from all assemblies, not only the linked assemblies.
+			RemoveBitcodeIncompatibleCodeStep remove_incompatible_bitcode = null;
 			if (options.Application.Optimizations.RemoveUnsupportedILForBitcode == true)
-				pipeline.AppendStep (new SubStepDispatcher { new RemoveBitcodeIncompatibleCodeStep (options) });
-			
+				remove_incompatible_bitcode = new RemoveBitcodeIncompatibleCodeStep (options);
+
 			if (options.LinkMode != LinkMode.None) {
 				pipeline.Append (new CoreTypeMapStep ());
 
@@ -204,6 +205,13 @@ namespace MonoTouch.Tuner {
 				pipeline.Append (new RemoveResources (options.I18nAssemblies)); // remove collation tables
 
 				pipeline.Append (new MonoTouchMarkStep ());
+
+				// We only want to remove from methods that aren't already linked away, so we need to do this
+				// after the mark step. If we remove any incompatible code, we'll mark
+				// the NotSupportedException constructor we need, so we need to do this before the sweep step.
+				if (remove_incompatible_bitcode != null)
+					pipeline.AppendStep (new SubStepDispatcher { remove_incompatible_bitcode });
+				
 				pipeline.Append (new MonoTouchSweepStep (options));
 				pipeline.Append (new CleanStep ());
 
@@ -213,8 +221,10 @@ namespace MonoTouch.Tuner {
 				pipeline.Append (new FixModuleFlags ());
 			} else {
 				SubStepDispatcher sub = new SubStepDispatcher () {
-					new RemoveUserResourcesSubStep (options)
+					new RemoveUserResourcesSubStep (options),
 				};
+				if (remove_incompatible_bitcode != null)
+					sub.Add (remove_incompatible_bitcode);
 				pipeline.Append (sub);
 			}
 

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -383,6 +383,9 @@
     <Compile Include="..\..\external\mono\external\linker\linker\Linker\TypeNameParser.cs">
       <Link>Linker\TypeNameParser.cs</Link>
     </Compile>
+    <Compile Include="..\linker\MonoTouch.Tuner\RemoveBitcodeIncompatibleCodeStep.cs">
+      <Link>MonoTouch.Tuner\RemoveBitcodeIncompatibleCodeStep.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Core" />


### PR DESCRIPTION
Remove code not currently compatible with bitcode and replace it with an exception instead (otherwise we may assert at runtime).

Also show a warning when we detect this.

This is quite helpful when looking at watch device test runs to filter out failures we already know about, since this exception message is much more specific than the one mono throws ("Attempting to JIT compile method ...").

This fixes point #2 in #4763.