### PR TITLE
[Foundation] Remove possible race condition with the NSUrlSessionHandler. Fixes #5511

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -249,11 +249,6 @@ namespace Foundation {
 
 			var tcs = new TaskCompletionSource<HttpResponseMessage> ();
 
-			cancellationToken.Register (() => {
-				RemoveInflightData (dataTask);
-				tcs.TrySetCanceled ();
-			});
-
 			lock (inflightRequestsLock)
 				inflightRequests.Add (dataTask, new InflightData {
 					RequestUrl = request.RequestUri.AbsoluteUri,
@@ -265,6 +260,23 @@ namespace Foundation {
 
 			if (dataTask.State == NSUrlSessionTaskState.Suspended)
 				dataTask.Resume ();
+
+			// as per documentation: 
+			// If this token is already in the canceled state, the 
+			// delegate will be run immediately and synchronously.
+			// Any exception the delegate generates will be 
+			// propagated out of this method call.
+			//
+			// The execution of the register ensures that if we 
+			// receive a already cancelled token or it is cancelled
+			// just before this call, we will cancel the task. 
+			// Other approaches are harder, since querying the state
+			// of the token does not guarantee that in the next
+			// execution a threads cancels it.
+			cancellationToken.Register (() => {
+				RemoveInflightData (dataTask);
+				tcs.TrySetCanceled ();
+			});
 
 			return await tcs.Task.ConfigureAwait (false);
 		}


### PR DESCRIPTION
The SendAsync method in the NSUrlSessionHandler is not handling the
cancellation token correctly. Moving the Register to nearly the end of
the method (just before returning the task) ensures that if we got a
already cancelled token, we execute in a sync manner the cleanup.

Using the IsCancellationRequested in this method is less optimal
because we would have to check several times:

1. When SencAsync receives the token and before it creates the inflight
data.
2. When we are going to resume the data. Since we might have created the
inflight data and at that point an other thread cancelled the request.

Fixes: https://github.com/xamarin/xamarin-macios/issues/5511