### PR TITLE
Always set variables to allow for downloading mono package.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -327,10 +327,10 @@ JENKINS_RESULTS_DIRECTORY ?= $(abspath $(TOP)/jenkins-results)
 CP:=$(shell df -t apfs / >/dev/null 2>&1 && echo "cp -c" || echo "cp")
 
 # Setup various variables depending on whether mono is downloaded or built from source
-ifeq ($(MONO_BUILD_FROM_SOURCE),)
 MONO_HASH:=$(shell git --git-dir=$(abspath $(TOP)/.git) --work-tree=$(abspath $(TOP)) ls-tree HEAD --full-tree -- external/mono | awk -F' ' '{printf "%s",$$3}')
 MONO_FILENAME:=ios-release-Darwin-$(MONO_HASH).zip
 MONO_URL:=https://xamjenkinsartifact.azureedge.net/mono-sdks/$(MONO_FILENAME)
+ifeq ($(MONO_BUILD_FROM_SOURCE),)
 MONO_SDK_BUILDDIR:=$(abspath $(TOP)/builds/downloads/$(basename $(MONO_FILENAME)))
 MONO_SDK_DESTDIR:=$(abspath $(TOP)/builds/downloads/$(basename $(MONO_FILENAME)))
 MONO_BUILD_MODE=download


### PR DESCRIPTION
Even if we don't end up using those variable during a normal build (when
building from source), it can still be useful that commands like `make download`
continue to work.

It also fixes a make warning:

    Making all in builds
    Makefile:16: warning: overriding commands for target `downloads/'
    Makefile:9: warning: ignoring old commands for target `downloads/'