### PR TITLE
Add NSUrl.IsFileReferenceUrl

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -5465,6 +5465,9 @@ namespace Foundation
 
 		[Export ("isFileURL")]
 		bool IsFileUrl { get; }
+		
+		[Export ("isFileReferenceURL")]
+		bool IsFileReferenceUrl { get; }
 
 		[Export ("parameterString")]
 		string ParameterString { get;}


### PR DESCRIPTION
Useful to know when the url is a file reference, so you can call NSUrl.FilePathUrl to get the real url.

See https://developer.apple.com/documentation/foundation/nsurl/1408507-isfilereferenceurl?language=objc

This API exists on all platforms, iOS 4+, macOS 10.6+, tvOS 9+, watchOS 2+.