### PR TITLE
Skip CoreNFCLibrary in ApiTypoTest.ConstantsCheck on iPad

### DIFF
--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -1105,6 +1105,10 @@ namespace Introspection
 #endif
 				default:
 					if (fi.Name.EndsWith ("Library", StringComparison.Ordinal)) {
+						// NFC is currently not available on iPad
+						if (fi.Name == "CoreNFCLibrary" && UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
+							continue;
+
 						Assert.True (CheckLibrary (s), fi.Name);
 					} else {
 						Assert.Fail ($"Unknown '{fi.Name}' field cannot be verified - please fix me!");

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -1105,9 +1105,11 @@ namespace Introspection
 #endif
 				default:
 					if (fi.Name.EndsWith ("Library", StringComparison.Ordinal)) {
+#if __IOS__
 						// NFC is currently not available on iPad
 						if (fi.Name == "CoreNFCLibrary" && UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
 							continue;
+#endif
 
 						Assert.True (CheckLibrary (s), fi.Name);
 					} else {


### PR DESCRIPTION
The test was complaining about CoreNFCLibrary on my iPad.

NFC is not supported on any iPad devices at the moment: https://stackoverflow.com/questions/51532544/is-it-possible-to-use-nfc-on-the-ipad