### PR TITLE
[tests|mtouch] armv7 to arm64 in a couple of device build tests

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2498,7 +2498,7 @@ public class B
 		// non-linked device build
 		[TestCase (Target.Dev, MTouchLinker.DontLink, MTouchRegistrar.Static, "arm64")] // armv7 Xamarin.iOS.dll don't link builds are not possible anymore because we go over the code size limit,
 		[TestCase (Target.Dev, MTouchLinker.DontLink, MTouchRegistrar.Dynamic, "arm64")] // since this is out of our control we are now forcing this test to arm64. Ref. https://github.com/xamarin/xamarin-macios/issues/5512
-																						 // sdk device build
+		// sdk device build
 		[TestCase (Target.Dev, MTouchLinker.LinkSdk, MTouchRegistrar.Static, "")]
 		[TestCase (Target.Dev, MTouchLinker.LinkSdk, MTouchRegistrar.Dynamic, "")]
 		// fully linked device build

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2496,9 +2496,9 @@ public class B
 		[TestCase (Target.Dev, MTouchLinker.Unspecified, MTouchRegistrar.Static, "armv7+llvm")]
 		[TestCase (Target.Dev, MTouchLinker.Unspecified, MTouchRegistrar.Static, "armv7+llvm+thumb2")]
 		// non-linked device build
-		[TestCase (Target.Dev, MTouchLinker.DontLink, MTouchRegistrar.Static, "")]
-		[TestCase (Target.Dev, MTouchLinker.DontLink, MTouchRegistrar.Dynamic, "")]
-		// sdk device build
+		[TestCase (Target.Dev, MTouchLinker.DontLink, MTouchRegistrar.Static, "arm64")] // armv7 Xamarin.iOS.dll don't link builds are not possible anymore because we go over the code size limit,
+		[TestCase (Target.Dev, MTouchLinker.DontLink, MTouchRegistrar.Dynamic, "arm64")] // since this is out of our control we are now forcing this test to arm64. Ref. https://github.com/xamarin/xamarin-macios/issues/5512
+																						 // sdk device build
 		[TestCase (Target.Dev, MTouchLinker.LinkSdk, MTouchRegistrar.Static, "")]
 		[TestCase (Target.Dev, MTouchLinker.LinkSdk, MTouchRegistrar.Dynamic, "")]
 		// fully linked device build
@@ -2963,7 +2963,7 @@ class Test {
 
 				var tests = new [] {
 					new { Name = "linkall", Abi = "armv7s", Link = MTouchLinker.Unspecified },
-					new { Name = "dontlink", Abi = "armv7s", Link = MTouchLinker.DontLink },
+					new { Name = "dontlink", Abi = "arm64", Link = MTouchLinker.DontLink },
 					new { Name = "dual", Abi = "armv7,arm64", Link = MTouchLinker.Unspecified },
 				};
 


### PR DESCRIPTION
Our mtouch tests are currently failing when building for device + don't Link linker
configuration + armv7[1] so we modified said tests to do arm64 instead.

For more context see: https://github.com/xamarin/xamarin-macios/issues/5512

[1]:

```
Xamarin.MTouch.Registrar(Dev,DontLink,Static,"") : Expected execution to succeed, but exit code was 1, and there were 1 error(s): build
	error MT5106: Could not compile the file(s) '/private/var/folders/9t/bhhqghxd4131b5k43v0yk7yc0000gn/T/mtouch.cache/u102nsmt.f5b/armv7/Xamarin.iOS.dll.s'. Please file a bug report at http://bugzilla.xamarin.com
at Xamarin.Tests.BundlerTool.AssertExecute (System.String message) [0x00095] in :0
at Xamarin.MTouchTool.AssertExecute (Xamarin.MTouchAction action, System.String message) [0x0000d] in :0
at Xamarin.MTouch.Registrar (Xamarin.Target target, Xamarin.Tests.LinkerOption linker, Xamarin.Tests.RegistrarOption registrar, System.String abi) [0x0005a] in :0
Xamarin.MTouch.Registrar(Dev,DontLink,Dynamic,"") : Expected execution to succeed, but exit code was 1, and there were 1 error(s): build
	error MT5106: Could not compile the file(s) '/private/var/folders/9t/bhhqghxd4131b5k43v0yk7yc0000gn/T/mtouch.cache/ma2r71ts.k3p/armv7/Xamarin.iOS.dll.s'. Please file a bug report at http://bugzilla.xamarin.com
at Xamarin.Tests.BundlerTool.AssertExecute (System.String message) [0x00095] in :0
at Xamarin.MTouchTool.AssertExecute (Xamarin.MTouchAction action, System.String message) [0x0000d] in :0
at Xamarin.MTouch.Registrar (Xamarin.Target target, Xamarin.Tests.LinkerOption linker, Xamarin.Tests.RegistrarOption registrar, System.String abi) [0x0005a] in :0
Xamarin.MTouch.TestCaseMismatchedAssemblyName : Expected execution to succeed, but exit code was 1, and there were 1 error(s): build: dontlink
	error MT5106: Could not compile the file(s) '/private/var/folders/9t/bhhqghxd4131b5k43v0yk7yc0000gn/T/mtouch.cache/2i0rdomc.jnq/armv7s/Xamarin.iOS.dll.s'. Please file a bug report at http://bugzilla.xamarin.com
at Xamarin.Tests.BundlerTool.AssertExecute (System.String message) [0x00095] in :0
at Xamarin.MTouchTool.AssertExecute (Xamarin.MTouchAction action, System.String message) [0x0000d] in :0
at Xamarin.MTouch.TestCaseMismatchedAssemblyName () [0x0021e] in :0
```