### PR TITLE
[tests] Ignore UIPreviewInteraction failing selectors

### DIFF
--- a/tests/introspection/iOS/iOSApiSelectorTest.cs
+++ b/tests/introspection/iOS/iOSApiSelectorTest.cs
@@ -320,6 +320,19 @@ namespace Introspection {
 					break;
 				}
 				break;
+			case "UIPreviewInteraction":
+				switch (name) {
+				// Selectors do not respond anymore in Xcode 10.2 beta 1.
+				case "cancelInteraction":
+				case "locationInCoordinateSpace:":
+				case "delegate":
+				case "setDelegate:":
+				case "view":
+					if (TestRuntime.CheckXcodeVersion (10, 2))
+						return true;
+					break;
+				}
+				break;
 			}
 
 			switch (name) {


### PR DESCRIPTION
Part of https://github.com/xamarin/xamarin-macios/commit/0344842a6bc074384bc3c0fdff86e602941bbef0 in `xcode10.2` branch

This happens on the latest iOS 12.1.x - but not in the 12.1 simulators
shipped with the current Xcode 10.1 stable release.

However people can hit this error while running tests on (updated)
devices so it's best to include the fix on master.