### PR TITLE
[msbuild] Fixes NativeExecutable MTouch output prop for VS

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/MTouchTaskBase.cs
@@ -176,7 +176,6 @@ namespace Xamarin.iOS.Tasks
 
 		// This property is required for VS to write the output native executable files
 		// and ensure the Inputs/Outputs of the msbuild target works correcly
-		[Required]
 		[Output]
 		public ITaskItem NativeExecutable { get; set; }
 
@@ -684,9 +683,18 @@ namespace Xamarin.iOS.Tasks
 
 			Directory.CreateDirectory (AppBundleDir);
 
+			var executableLastWriteTime = default (DateTime);
+			var executable = Path.Combine (AppBundleDir, ExecutableName);
+
+			if (File.Exists (executable))
+				executableLastWriteTime = File.GetLastWriteTimeUtc (executable);
+
 			var result = base.Execute ();
 
 			CopiedFrameworks = GetCopiedFrameworks ();
+
+			if (File.Exists (executable) && File.GetLastWriteTimeUtc (executable) != executableLastWriteTime)
+				NativeExecutable = new TaskItem (executable);
 
 			return result;
 		}

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -800,7 +800,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			AppManifest="$(_AppBundlePath)Info.plist"
 			Architectures="$(TargetArchitectures)"
 			ExecutableName="$(_ExecutableName)"
-			NativeExecutable="$(_NativeExecutable)"
 			CompiledEntitlements="$(_CompiledEntitlements)"
 			Debug="$(MtouchDebug)"
 			EnableGenericValueTypeSharing="$(MtouchEnableGenericValueTypeSharing)"


### PR DESCRIPTION
Since the Output property was being set on each call to the MTouch task despite it changed or not VS was generating that file on Windows on each run, which breaks incremental builds. Now, we're setting it only if the executable file changed or was just created.

Bug 785284 - .dSym is not properly generated unless configuration is Release
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/785284