### PR TITLE
[tests|mmp] Bump mmp's WarningTests to use Xcode 9.4

### DIFF
--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Tests
 		public static string xcode6_root;
 		public static string xcode72_root;
 		public static string xcode83_root;
+		public static string xcode94_root;
 #if MONOMAC
 		public static string mac_xcode_root;
 #endif
@@ -210,6 +211,7 @@ namespace Xamarin.Tests
 			xcode6_root = GetVariable ("XCODE6_DEVELOPER_ROOT", "/Applications/Xcode601.app/Contents/Developer");
 			xcode72_root = GetVariable ("XCODE72_DEVELOPER_ROOT", "/Applications/Xcode72.app/Contents/Developer");
 			xcode83_root = GetVariable ("XCODE83_DEVELOPER_ROOT", "/Applications/Xcode83.app/Contents/Developer");
+			xcode94_root = GetVariable ("XCODE94_DEVELOPER_ROOT", "/Applications/Xcode94.app/Contents/Developer");
 			include_ios = !string.IsNullOrEmpty (GetVariable ("INCLUDE_IOS", ""));
 			include_mac = !string.IsNullOrEmpty (GetVariable ("INCLUDE_MAC", ""));
 			include_tvos = !string.IsNullOrEmpty (GetVariable ("INCLUDE_TVOS", ""));

--- a/tests/mmptest/src/WarningTests.cs
+++ b/tests/mmptest/src/WarningTests.cs
@@ -10,10 +10,10 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void MM0135 ()
 		{
-			var oldXcode = Xamarin.Tests.Configuration.xcode83_root;
+			var oldXcode = Xamarin.Tests.Configuration.xcode94_root;
 
 			if (!Directory.Exists (oldXcode))
-				Assert.Ignore ("This test requires Xcode 8.3 (or updated to a newer one that still warns MM0135).");
+				Assert.Ignore ("This test requires Xcode 9.4 (or updated to a newer one that still warns MM0135).");
 
 			MMPTests.RunMMPTest (tmpDir => {
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir);


### PR DESCRIPTION
Fixes xamarin/maccore#1390

Apple removed `NSTextViewIvars.sharedData` in mojave which is needed to link
using Xcode 8.3 so we bumped WarningTests to use Xcode 9.4 which also reproduces
the behaviour the test expects and we ensure that the test is run because we
also require Xcode 9.4 to be there.