### PR TITLE
[tests] Tweak a few linker tests to work in all scenarios.

### DIFF
--- a/tests/linker/ios/link all/LinkAllTest.cs
+++ b/tests/linker/ios/link all/LinkAllTest.cs
@@ -605,11 +605,10 @@ namespace LinkAll {
 			// special location when we build a shared (app and extensions) framework for mono
 			if (corlib.EndsWith ("/Frameworks/Xamarin.Sdk.framework/MonoBundle/mscorlib.dll", StringComparison.Ordinal))
 				Assert.Pass (corlib);
-#if __WATCHOS__
-			var suffix = "link all.appex/mscorlib.dll";
-#else
-			var suffix = "link all.app/mscorlib.dll";
-#endif
+
+			var bundlePath = NSBundle.MainBundle.BundlePath;
+			var isExtension = bundlePath.EndsWith (".appex", StringComparison.Ordinal);
+			var suffix = isExtension ? "link all.appex/mscorlib.dll" : "link all.app/mscorlib.dll";
 			Assert.That (corlib, Is.StringEnding (suffix), corlib);
 		}
 	}

--- a/tests/linker/ios/link sdk/BitcodeTest.cs
+++ b/tests/linker/ios/link sdk/BitcodeTest.cs
@@ -67,6 +67,9 @@ namespace LinkSdk {
 		[Test]
 		public void FaultClauseTest ()
 		{
+#if !DEBUG
+			Assert.Ignore ("Only works if IL isn't stripped (i.e. only Debug)");
+#endif
 			// First assert that the method that is supposed to have a fault clause actually has a fault clause.
 			// This is somewhat complicated because it's not the method we call that has the fault clause, but a generated method in a generated class.
 			// This is because we only have an indirect way of making csc produce a fault clause


### PR DESCRIPTION
* Improve logic with regards to app extensions vs normal apps: not only
  watchOS apps are extensions. This fixes a test failure when running the
  tests as a today extension.
* Finding fault clauses in the IL only works if we haven't stripped away the
  IL. This fixes a test failure when running the tests in release mode.