### PR TITLE
[xharness] Refactor a bit to use async code for the test listener instead of a thread pool thread.

### DIFF
--- a/tests/xharness/Extensions.cs
+++ b/tests/xharness/Extensions.cs
@@ -93,5 +93,30 @@ namespace xharness
 			else
 				return false;
 		}
+
+		public static void DoNotAwait (this Task task)
+		{
+			// Don't do anything!
+			// 
+			// Here's why:
+			// If you want to run a task in the background, and you don't care about the result, this is the obvious way to do so:
+			//
+			//     DoSomethingAsync ();
+			//
+			// which works fine, but the compiler warns that:
+			// 
+			//     Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+			//
+			// One potential fix is to assign the return value to variable:
+			//
+			//     var x = DoSomethingAsync ();
+			//
+			// But this creates unnecessary variables. It's also still slightly confusing (why assign to a variable that's not used?).
+			// This extension method allows us to be more explicit:
+			// 
+			//     DoSomethingAsync ().DoNotAwait ();
+			// 
+			// This makes it abundantly clear that the intention is to not await 'DoSomething', and no warnings will be shown either.
+		}
 	}
 }


### PR DESCRIPTION
This fixes an issue where we'd consume a thread pool thread until the launch
timeout if the app launched, but the test run never started (it crashed at
launch for instance).