### PR TITLE
[builds] Simplify and speed up build a bit.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -294,7 +294,7 @@ endef
 $(eval $(call MacBuildTemplate,i386,mac32,$(XCODE94_DEVELOPER_ROOT),32,$(XCODE94_MAC_SDKROOT)))
 $(eval $(call MacBuildTemplate,x86_64,mac64,$(XCODE_DEVELOPER_ROOT),,$(XCODE_MAC_SDKROOT)))
 
-$(MONO_PATH)/mcs/class/lib/%: .stamp-build-tools64; @true
+$(MONO_PATH)/mcs/class/lib/%: .stamp-build-tools64;
 
 define MacInstallBclTemplate
 
@@ -547,9 +547,6 @@ ios-facade-check: $(IOS_BCL_TARGETS)
 	$(Q) rm -f .$@*
 
 watch-facade-check: $(WATCH_BCL_TARGETS)
-	@true
-
-disabled-watch-facade-check: $(WATCH_BCL_TARGETS)
 	$(Q) rm -f .$@*
 	$(Q) echo $(WATCHOS_FACADE_ASSEMBLIES) | tr ' ' '\n' | sort > .$@1
 	$(Q) ls -1 $(MONO_PATH)/mcs/class/lib/monotouch_watch/Facades | grep dll$$ | sed 's/[.]dll//' | sort > .$@2
@@ -678,19 +675,10 @@ $(IOS_BCL_TARGETS_DIRS) $(WATCH_BCL_TARGETS_DIRS) $(TVOS_BCL_TARGETS_DIRS):
 .SECONDARY:
 
 install-tools-tvos: $(TVOS_BCL_TARGETS) tvos-facade-check
-	@true
-
 install-tools-watch: $(WATCH_BCL_TARGETS) watch-facade-check
-	@true
-
 install-tools-ios: $(IOS_BCL_TARGETS) ios-facade-check
-	@true
-
 install-tools-mac: $(MAC_BCL_TARGETS) mac-facade-check
-	@true
-
 build-watchbcl: $(WATCH_BCL_TARGETS)
-	@true
 
 $(IOS_BCL_TARGETS): .stamp-build-tools64
 $(TVOS_BCL_TARGETS): .stamp-build-tools64
@@ -708,7 +696,6 @@ build-tools64: $(WATCH_BCL_TARGETS)
 endif
 
 build-tools64: $(MAC_BCL_TARGETS)
-	@true
 
 verify-signature:
 	for file in $(PREFIX)/lib/mono/2.1/*.dll; do \
@@ -1457,8 +1444,8 @@ LLVM32_TARGETS = \
 	$(PREFIX)/LLVM36/bin/opt \
 	$(PREFIX)/LLVM36/bin/llc \
 
-$(MONO_SDK_DESTDIR)/llvm-llvm64/bin/%: .stamp-build-llvm64; @true
-$(MONO_SDK_DESTDIR)/llvm36-llvm32/bin/%: .stamp-build-llvm32; @true
+$(MONO_SDK_DESTDIR)/llvm-llvm64/bin/%: .stamp-build-llvm64;
+$(MONO_SDK_DESTDIR)/llvm36-llvm32/bin/%: .stamp-build-llvm32;
 
 $(PREFIX)/LLVM/bin/%: $(MONO_SDK_DESTDIR)/llvm-llvm64/bin/% | $(PREFIX)/LLVM/bin
 	$(call Q_2,INSTALL ,[LLVM64]) install -c -m 0755 $(INSTALL_STRIP_FLAG) $^ $@


### PR DESCRIPTION
There's no need to use 'true' to create a recipe that does nothing: a single
semi-colon is enough (and for the install-tools* and build-tools64 targets I
don't see a need for an empty recipe in any case). This saves ~2.2k 'true'
subprocesses during a make with everything already built (and a second of
build time; a rebuild in builds/ when everything is already built now takes
~2s on my machine instead of ~3s).