### PR TITLE
[bcl-test-importer] Fix compiler warning about unused variable.

### DIFF
--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -16,7 +16,6 @@ namespace BCLTestImporter {
 
 		static string NUnitPattern = "monotouch_*_test.dll"; 
 		static string xUnitPattern = "monotouch_*_xunit-test.dll";
-		static string iOSReleasePattern = "ios-release-Darwin-*";
 		internal static readonly string NameKey = "%NAME%";
 		internal static readonly string ReferencesKey = "%REFERENCES%";
 		internal static readonly string RegisterTypeKey = "%REGISTER TYPE%";


### PR DESCRIPTION
Fixes this warning:

    tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs(19,17): warning CS0414: The field 'BCLTestProjectGenerator.iOSReleasePattern' is assigned but its value is never used