### PR TITLE
[xharness] Make the right queue list stay at the right when there's long text on the left.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1670,64 +1670,8 @@ namespace xharness
 					writer.WriteLine ("</ul>");
 				}
 
-				writer.WriteLine ("<div id='test-table' style='width: 100%'>");
-				if (IsServerMode) {
-					writer.WriteLine ("<div id='test-status' style='display: inline-block; margin-left: 100px;' class='autorefreshable'>");
-					if (failedTests.Count () == 0) {
-						foreach (var group in failedTests.GroupBy ((v) => v.TestName)) {
-							var enumerableGroup = group as IEnumerable<TestTask>;
-							if (enumerableGroup != null) {
-								writer.WriteLine ("<a href='#test_{2}'>{0}</a> ({1})<br />", group.Key, string.Join (", ", enumerableGroup.Select ((v) => string.Format ("<span style='color: {0}'>{1}</span>", GetTestColor (v), string.IsNullOrEmpty (v.Mode) ? v.ExecutionResult.ToString () : v.Mode)).ToArray ()), group.Key.Replace (' ', '-'));
-								continue;
-							}
-
-							throw new NotImplementedException ();
-						}
-					}
-
-					if (buildingTests.Any ()) {
-						writer.WriteLine ($"<h3>{buildingTests.Count ()} building tests:</h3>");
-						foreach (var test in buildingTests) {
-							var runTask = test as RunTestTask;
-							var buildDuration = string.Empty;
-							if (runTask != null)
-								buildDuration = runTask.BuildTask.Duration.ToString ();
-							writer.WriteLine ($"<a href='#test_{test.TestName}'>{test.TestName} ({test.Mode})</a> {buildDuration}<br />");
-						}
-					}
-
-					if (runningTests.Any ()) {
-						writer.WriteLine ($"<h3>{runningTests.Count ()} running tests:</h3>");
-						foreach (var test in runningTests) {
-							writer.WriteLine ($"<a href='#test_{test.TestName}'>{test.TestName} ({test.Mode})</a> {test.Duration.ToString ()} {test.ProgressMessage}<br />");
-						}
-					}
-
-					if (buildingQueuedTests.Any ()) {
-						writer.WriteLine ($"<h3>{buildingQueuedTests.Count ()} tests in build queue:</h3>");
-						foreach (var test in buildingQueuedTests) {
-							writer.WriteLine ($"<a href='#test_{test.TestName}'>{test.TestName} ({test.Mode})</a><br />");
-						}
-					}
-
-					if (runningQueuedTests.Any ()) {
-						writer.WriteLine ($"<h3>{runningQueuedTests.Count ()} tests in run queue:</h3>");
-						foreach (var test in runningQueuedTests) {
-							writer.WriteLine ($"<a href='#test_{test.TestName}'>{test.TestName} ({test.Mode})</a><br />");
-						}
-					}
-
-					var resources = device_resources.Values.Concat (new Resource [] { DesktopResource });
-					if (resources.Any ()) {
-						writer.WriteLine ($"<h3>Devices:</h3>");
-						foreach (var dr in resources.OrderBy ((v) => v.Description, StringComparer.OrdinalIgnoreCase)) {
-							writer.WriteLine ($"{dr.Description} - {dr.Users}/{dr.MaxConcurrentUsers} users - {dr.QueuedUsers} in queue<br />");
-						}
-					}
-				}
-				writer.WriteLine ("</div>");
-
-				writer.WriteLine ("<div id='test-list' style='float:left'>");
+				writer.WriteLine ("<div id='test-table' style='width: 100%; display: flex;'>");
+				writer.WriteLine ("<div id='test-list'>");
 				var orderedTasks = allTasks.GroupBy ((TestTask v) => v.TestName);
 
 				if (IsServerMode) {
@@ -1980,6 +1924,61 @@ namespace xharness
 					}
 					if (!singleTask)
 						writer.WriteLine ("</div>");
+				}
+				writer.WriteLine ("</div>");
+				if (IsServerMode) {
+					writer.WriteLine ("<div id='test-status' style='margin-left: 100px;' class='autorefreshable'>");
+					if (failedTests.Count () == 0) {
+						foreach (var group in failedTests.GroupBy ((v) => v.TestName)) {
+							var enumerableGroup = group as IEnumerable<TestTask>;
+							if (enumerableGroup != null) {
+								writer.WriteLine ("<a href='#test_{2}'>{0}</a> ({1})<br />", group.Key, string.Join (", ", enumerableGroup.Select ((v) => string.Format ("<span style='color: {0}'>{1}</span>", GetTestColor (v), string.IsNullOrEmpty (v.Mode) ? v.ExecutionResult.ToString () : v.Mode)).ToArray ()), group.Key.Replace (' ', '-'));
+								continue;
+							}
+
+							throw new NotImplementedException ();
+						}
+					}
+
+					if (buildingTests.Any ()) {
+						writer.WriteLine ($"<h3>{buildingTests.Count ()} building tests:</h3>");
+						foreach (var test in buildingTests) {
+							var runTask = test as RunTestTask;
+							var buildDuration = string.Empty;
+							if (runTask != null)
+								buildDuration = runTask.BuildTask.Duration.ToString ();
+							writer.WriteLine ($"<a href='#test_{test.TestName}'>{test.TestName} ({test.Mode})</a> {buildDuration}<br />");
+						}
+					}
+
+					if (runningTests.Any ()) {
+						writer.WriteLine ($"<h3>{runningTests.Count ()} running tests:</h3>");
+						foreach (var test in runningTests) {
+							writer.WriteLine ($"<a href='#test_{test.TestName}'>{test.TestName} ({test.Mode})</a> {test.Duration.ToString ()} {test.ProgressMessage}<br />");
+						}
+					}
+
+					if (buildingQueuedTests.Any ()) {
+						writer.WriteLine ($"<h3>{buildingQueuedTests.Count ()} tests in build queue:</h3>");
+						foreach (var test in buildingQueuedTests) {
+							writer.WriteLine ($"<a href='#test_{test.TestName}'>{test.TestName} ({test.Mode})</a><br />");
+						}
+					}
+
+					if (runningQueuedTests.Any ()) {
+						writer.WriteLine ($"<h3>{runningQueuedTests.Count ()} tests in run queue:</h3>");
+						foreach (var test in runningQueuedTests) {
+							writer.WriteLine ($"<a href='#test_{test.TestName}'>{test.TestName} ({test.Mode})</a><br />");
+						}
+					}
+
+					var resources = device_resources.Values.Concat (new Resource [] { DesktopResource });
+					if (resources.Any ()) {
+						writer.WriteLine ($"<h3>Devices:</h3>");
+						foreach (var dr in resources.OrderBy ((v) => v.Description, StringComparer.OrdinalIgnoreCase)) {
+							writer.WriteLine ($"{dr.Description} - {dr.Users}/{dr.MaxConcurrentUsers} users - {dr.QueuedUsers} in queue<br />");
+						}
+					}
 				}
 				writer.WriteLine ("</div>");
 				writer.WriteLine ("</div>");


### PR DESCRIPTION
Previously the queue at the right would move to the top (above the test list)
if a node with a lot of text in the test list was expanded. This is annoying
(since things would move out of view unexpectedly), so change the css so that
the queue on the right stays on the right no matter what.

This also required reordering the left and right divs in the html, which is
most of the diff.