### PR TITLE
[Tests] Do not fail with timeouts. Fixes #1332

### DIFF
--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -149,10 +149,13 @@ namespace MonoTests.System.Net.Http
 				}
 			}, () => done);
 
-			Assert.IsTrue (done, "Request timedout.");
-			Assert.IsTrue (containsHeaders, "Request did not reach final destination.");
-			Assert.IsFalse (containsAuthorizarion, $"Authorization header did reach the final destination. {json}");
-			Assert.IsNull (ex, $"Exception {ex} for {json}");
+			if (!done) { // timeouts happen in the bost due to dns issues, connection issues etc.. we do not want to fail
+				Assert.Inconclusive ("Request timedout.");
+			} else {
+				Assert.IsTrue (containsHeaders, "Request did not reach final destination.");
+				Assert.IsFalse (containsAuthorizarion, $"Authorization header did reach the final destination. {json}");
+				Assert.IsNull (ex, $"Exception {ex} for {json}");
+			}
 		}
 	}
 }


### PR DESCRIPTION
The bots sometimes have issues with the network. We do not want red
builds due to a problem in the connection. Lets set the test to
inclonclusive since we cannot assert the headers that have been sent.

Fixes https://github.com/xamarin/maccore/issues/1332