### PR TITLE
[xharness] Fix bug in Simulators.LoadAsync()

### DIFF
--- a/tests/xharness/Extensions.cs
+++ b/tests/xharness/Extensions.cs
@@ -119,23 +119,5 @@ namespace xharness
 			// 
 			// This makes it abundantly clear that the intention is to not await 'DoSomething', and no warnings will be shown either.
 		}
-
-		public static IEnumerable<T> Distinct<T> (this IEnumerable<T> collection, Func<T, T, bool> comparer)
-		{
-			var list = new List<T> ();
-			foreach (var item in collection) {
-				bool found = false;
-				for (var i = 0; i < list.Count; i++) {
-					if (comparer (list [i], item)) {
-						found = true;
-						break;
-					}
-				}
-				if (found)
-					continue;
-				list.Add (item);
-				yield return item;
-			}
-		}
 	}
 }

--- a/tests/xharness/Simulators.cs
+++ b/tests/xharness/Simulators.cs
@@ -99,7 +99,7 @@ namespace xharness
 							SelectNodes ("/MTouch/Simulator/AvailableDevicePairs/SimDevicePair").
 							Cast<XmlNode> ().
 							// There can be duplicates, so remove those.
-							Distinct ((a, b) => a.Attributes ["Gizmo"].InnerText == b.Attributes ["Gizmo"].InnerText && a.Attributes ["Companion"].InnerText == b.Attributes ["Companion"].InnerText);
+							Distinct (new SimulatorXmlNodeComparer ());
 						foreach (XmlNode sim in sim_device_pairs) {
 							available_device_pairs.Add (new SimDevicePair ()
 							{
@@ -322,6 +322,19 @@ namespace xharness
 				Target = target,
 				Log = log,
 			};
+		}
+
+		class SimulatorXmlNodeComparer : IEqualityComparer<XmlNode>
+		{
+			public bool Equals (XmlNode a, XmlNode b)
+			{
+				return a["Gizmo"].InnerText == b["Gizmo"].InnerText && a["Companion"].InnerText == b["Companion"].InnerText;
+			}
+
+			public int GetHashCode (XmlNode node)
+			{
+				return node["Gizmo"].InnerText.GetHashCode () ^ node["Companion"].InnerText.GetHashCode ();
+			}
 		}
 
 		class SimulatorEnumerable : IEnumerable<SimDevice>, IAsyncEnumerable


### PR DESCRIPTION
The "Gizmo" and "Companion" are child elements, not attributes on the SimDevicePair.

Also replaced the custom Distinct() implementation with a comparer which can be used with standard LINQ.