### PR TITLE
[mtouch] Fix --dot:<path> to honor the path passed.

### DIFF
--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -890,8 +890,8 @@ namespace Xamarin.Bundler {
 			CompilePInvokeWrappers ();
 			BuildApp ();
 
-			if (Driver.Dot)
-				build_tasks.Dot (Path.Combine (Cache.Location, "build.dot"));
+			if (Driver.DotFile != null)
+				build_tasks.Dot (this, Driver.DotFile.Length > 0 ? Driver.DotFile : Path.Combine (Cache.Location, "build.dot"));
 
 			Driver.Watch ("Building build tasks", 1);
 			build_tasks.Execute ();

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -123,15 +123,15 @@ namespace Xamarin.Bundler
 		//
 		// Output generation
 		static bool force = false;
-		static bool dot;
+		static string dotfile;
 		static string cross_prefix = Environment.GetEnvironmentVariable ("MONO_CROSS_PREFIX");
 		static string extra_args = Environment.GetEnvironmentVariable ("MTOUCH_ENV_OPTIONS");
 
 		static int verbose = GetDefaultVerbosity ();
 
-		public static bool Dot {
+		public static string DotFile {
 			get {
-				return dot;
+				return dotfile;
 			}
 		}
 
@@ -919,7 +919,7 @@ namespace Xamarin.Bundler
 			{ "h|?|help", "Displays the help", v => SetAction (Action.Help) },
 			{ "version", "Output version information and exit.", v => SetAction (Action.Version) },
 			{ "f|force", "Forces the recompilation of code, regardless of timestamps", v=>force = true },
-			{ "dot:", "Generate a dot file to visualize the build tree.", v => dot = true },
+			{ "dot:", "Generate a dot file to visualize the build tree.", v => dotfile = v ?? string.Empty },
 			{ "cache=", "Specify the directory where object files will be cached", v => app.Cache.Location = v },
 			{ "aot=", "Arguments to the static compiler",
 				v => app.AotArguments = v + (v.EndsWith (",", StringComparison.Ordinal) ? String.Empty : ",") + app.AotArguments


### PR DESCRIPTION
Also change output to use the full path to files as nodes, instead of just the
filename, and instead use a label to set what's shown to just the filename.

This makes the graph correct when we have multiple files with the same name,
but different paths.