### PR TITLE
[xharness] Improve app installation on device.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -264,7 +264,7 @@ namespace xharness
 			}
 		}
 
-		public async Task<ProcessExecutionResult> InstallAsync ()
+		public async Task<ProcessExecutionResult> InstallAsync (CancellationToken cancellation_token)
 		{
 			Initialize ();
 
@@ -288,25 +288,10 @@ namespace xharness
 			if (mode == "watchos")
 				args.Append (" --device ios,watchos");
 
-			var timeout = TimeSpan.FromMinutes (3);
-			if (mode == "watchos") {
-				var watchApp = Path.Combine (appPath, "Watch");
-				var info = new DirectoryInfo (watchApp);
-				if (info.Exists) {
-					long watchAppSize = 0;
-					foreach (var file in info.EnumerateFiles ("*", SearchOption.AllDirectories))
-						watchAppSize += file.Length;
-					// transfer speed is ~10MB/minute. Add another 50% just because transfer isn't the only thing happening, and also set it to at least 3 minutes
-					var estimatedTransferTime = watchAppSize / 1024 / 1024 / 10.0;
-					timeout = TimeSpan.FromMinutes (Math.Max (3, estimatedTransferTime * 1.5));
-					main_log.WriteLine ($"Estimated transfer speed to be {estimatedTransferTime} minutes based on the watch app size ({watchAppSize} bytes) and a speed of 10MB/s. Thus setting the install timeout to {timeout.TotalMinutes} minutes (giving it a little extra time).");
-				} else {
-					timeout = TimeSpan.FromMinutes (15);
-					main_log.WriteLine ($"Unable to determine watch app size, install timeout will be {timeout.TotalMinutes} minutes.");
-				}
-			}
+			var totalSize = Directory.GetFiles (appPath, "*", SearchOption.AllDirectories).Select ((v) => new FileInfo (v).Length).Sum ();
+			main_log.WriteLine ($"Installing '{appPath}' to '{companion_device_name ?? device_name}'. Size: {totalSize} bytes = {totalSize / 1024.0 / 1024.0:N2} MB");
 
-			return await ProcessHelper.ExecuteCommandAsync (Harness.MlaunchPath, args.ToString (), main_log, timeout);
+			return await ProcessHelper.ExecuteCommandAsync (Harness.MlaunchPath, args.ToString (), main_log, TimeSpan.FromHours (1), cancellation_token: cancellation_token);
 		}
 
 		public async Task<ProcessExecutionResult> UninstallAsync ()
@@ -919,6 +904,109 @@ namespace xharness
 				args.Append (" --devname ");
 				args.Append (StringUtils.Quote (device_name));
 			}
+		}
+	}
+
+	// Monitor the output from 'mlaunch --installdev' and cancel the installation if there's no output for 1 minute.
+	class AppInstallMonitorLog : Log {
+		public override string FullPath => throw new NotImplementedException ();
+
+		Log copy_to;
+		CancellationTokenSource cancellation_source;
+		
+		public bool CopyingApp;
+		public bool CopyingWatchApp;
+		public TimeSpan AppCopyDuration;
+		public TimeSpan WatchAppCopyDuration;
+		public Stopwatch AppCopyStart = new Stopwatch ();
+		public Stopwatch WatchAppCopyStart = new Stopwatch ();
+		public int AppPercentComplete;
+		public int WatchAppPercentComplete;
+		public long AppBytes;
+		public long WatchAppBytes;
+		public long AppTotalBytes;
+		public long WatchAppTotalBytes;
+
+		public CancellationToken CancellationToken {
+			get {
+				return cancellation_source.Token;
+			}
+		}
+
+		public AppInstallMonitorLog (Log copy_to)
+				: base (copy_to.Logs, $"Watch transfer log for {copy_to.Description}")
+		{
+			this.copy_to = copy_to;
+			cancellation_source = new CancellationTokenSource ();
+			cancellation_source.Token.Register (() => {
+				copy_to.WriteLine ("App installation cancelled: it timed out after no output for 1 minute.");
+			});
+		}
+
+		public override Encoding Encoding => copy_to.Encoding;
+		public override void Flush ()
+		{
+			copy_to.Flush ();
+		}
+
+		public override StreamReader GetReader ()
+		{
+			return copy_to.GetReader ();
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			copy_to.Dispose ();
+			cancellation_source.Dispose ();
+		}
+
+		void ResetTimer ()
+		{
+			cancellation_source.CancelAfter (TimeSpan.FromMinutes (1));
+		}
+
+		public override void WriteLine (string value)
+		{
+			var v = value.Trim ();
+			if (v.StartsWith ("Installing application bundle", StringComparison.Ordinal)) {
+				if (!CopyingApp) {
+					CopyingApp = true;
+					AppCopyStart.Start ();
+				} else if (!CopyingWatchApp) {
+					CopyingApp = false;
+					CopyingWatchApp = true;
+					AppCopyStart.Stop ();
+					WatchAppCopyStart.Start ();
+				}
+			} else if (v.StartsWith ("PercentComplete: ", StringComparison.Ordinal) && int.TryParse (v.Substring ("PercentComplete: ".Length).Trim (), out var percent)) {
+				if (CopyingApp)
+					AppPercentComplete = percent;
+				else if (CopyingWatchApp)
+					WatchAppPercentComplete = percent;
+			} else if (v.StartsWith ("NumBytes: ", StringComparison.Ordinal) && int.TryParse (v.Substring ("NumBytes: ".Length).Trim (), out var num_bytes)) {
+				if (CopyingApp) {
+					AppBytes = num_bytes;
+					AppCopyDuration = AppCopyStart.Elapsed;
+				} else if (CopyingWatchApp) {
+					WatchAppBytes = num_bytes;
+					WatchAppCopyDuration = WatchAppCopyStart.Elapsed;
+				}
+			} else if (v.StartsWith ("TotalBytes: ", StringComparison.Ordinal) && int.TryParse (v.Substring ("TotalBytes: ".Length).Trim (), out var total_bytes)) {
+				if (CopyingApp)
+					AppTotalBytes = total_bytes;
+				else if (CopyingWatchApp)
+					WatchAppTotalBytes = total_bytes;
+			}
+
+			ResetTimer ();
+
+			copy_to.WriteLine (value);
+		}
+
+		public override void Write (byte [] buffer, int offset, int count)
+		{
+			copy_to.Write (buffer, offset, count);
 		}
 	}
 }

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -574,9 +574,11 @@ namespace xharness
 					ProjectFile = project.Path,
 					MainLog = HarnessLog,
 				};
-				var rv = runner.InstallAsync ().Result;
-				if (!rv.Succeeded)
-					return rv.ExitCode;
+				using (var install_log = new AppInstallMonitorLog (runner.MainLog)) {
+					var rv = runner.InstallAsync (install_log.CancellationToken).Result;
+					if (!rv.Succeeded)
+						return rv.ExitCode;
+				}
 			}
 			return 0;
 		}

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1809,7 +1809,8 @@ namespace xharness
 							}
 							var progressMessage = test.ProgressMessage;
 							if (!string.IsNullOrEmpty (progressMessage))
-								writer.WriteLine (progressMessage + "<br />");
+								writer.WriteLine (HtmlFormat (progressMessage) + " <br />");
+
 							if (runTest != null) {
 								if (runTest.BuildTask.Duration.Ticks > 0) {
 									writer.WriteLine ($"Project file: {runTest.BuildTask.ProjectFile} <br />");
@@ -1985,7 +1986,7 @@ namespace xharness
 					if (runningTests.Any ()) {
 						writer.WriteLine ($"<h3>{runningTests.Count ()} running tests:</h3>");
 						foreach (var test in runningTests) {
-							writer.WriteLine ($"<a href='#test_{test.TestName}'>{test.TestName} ({test.Mode})</a> {test.Duration.ToString ()} {test.ProgressMessage}<br />");
+							writer.WriteLine ($"<a href='#test_{test.TestName}'>{test.TestName} ({test.Mode})</a> {test.Duration.ToString ()} {HtmlFormat ("\n\t" + test.ProgressMessage)}<br />");
 						}
 					}
 
@@ -3258,28 +3259,28 @@ namespace xharness
 
 	class RunDeviceTask : RunXITask<Device>
 	{
-		object lock_obj = new object ();
-		Log install_log;
+		AppInstallMonitorLog install_log;
 		public override string ProgressMessage {
 			get {
-				StreamReader reader;
-				lock (lock_obj)
-					reader = install_log?.GetReader ();
-				
-				if (reader == null)
+				var log = install_log;
+				if (log == null)
 					return base.ProgressMessage;
 
-				using (reader) {
-					var lines = reader.ReadToEnd ().Split ('\n');
-					for (int i = lines.Length - 1; i >= 0; i--) {
-						var idx = lines [i].IndexOf ("PercentComplete:", StringComparison.Ordinal);
-						if (idx == -1)
-							continue;
-						return "Install: " + lines [i].Substring (idx + "PercentComplete:".Length + 1) + "%";
-					}
-				}
-
-				return base.ProgressMessage;
+				var percent_complete = log.CopyingApp ? log.AppPercentComplete : log.WatchAppPercentComplete;
+				var bytes = log.CopyingApp ? log.AppBytes : log.WatchAppBytes;
+				var total_bytes = log.CopyingApp ? log.AppTotalBytes : log.WatchAppTotalBytes;
+				var elapsed = log.CopyingApp ? log.AppCopyDuration : log.WatchAppCopyDuration;
+				var speed_bps = elapsed.Ticks == 0 ? -1 : bytes / elapsed.TotalSeconds;
+				var estimated_left = TimeSpan.FromSeconds ((total_bytes - bytes) / speed_bps);
+				var transfer_percent = 100 * (double) bytes / (double) total_bytes;
+				var str = log.CopyingApp ? "App" : "Watch App";
+				var rv = $"{str} installation: {percent_complete}% done.\n" +
+					$"\tApp size: {total_bytes:N0} bytes ({total_bytes/1024.0/1024.0:N2} MB)\n" +
+					$"\tTransferred: {bytes:N0} bytes ({bytes / 1024.0 / 1024.0:N2} MB)\n" +
+					$"\tTransferred in {elapsed.TotalSeconds:#.#}s ({elapsed})\n" +
+					$"\tTransfer speed: {speed_bps:N0} B/s ({speed_bps / 1024.0 / 1024.0:N} MB/s, {60 * speed_bps / 1024.0 / 1024.0:N2} MB/m)\n" +
+					$"\tEstimated time left: {estimated_left.TotalSeconds:#.#}s ({estimated_left})";
+				return rv;
 			}
 		}
 
@@ -3311,8 +3312,6 @@ namespace xharness
 		{
 			Jenkins.MainLog.WriteLine ("Running '{0}' on device (candidates: '{1}')", ProjectFile, string.Join ("', '", Candidates.Select ((v) => v.Name).ToArray ()));
 
-			var install_log = Logs.Create ($"install-{Timestamp}.log", "Install log");
-			install_log.Timestamp = true;
 			var uninstall_log = Logs.Create ($"uninstall-{Timestamp}.log", "Uninstall log");
 			using (var device_resource = await NotifyBlockingWaitAsync (Jenkins.GetDeviceResources (Candidates).AcquireAnyConcurrentAsync ())) {
 				try {
@@ -3328,7 +3327,7 @@ namespace xharness
 						ProjectFile = ProjectFile,
 						Target = AppRunnerTarget,
 						LogDirectory = LogDirectory,
-						MainLog = install_log,
+						MainLog = uninstall_log,
 						DeviceName = Device.Name,
 						CompanionDeviceName = CompanionDevice?.Name,
 						Configuration = ProjectConfiguration,
@@ -3342,18 +3341,17 @@ namespace xharness
 
 					if (!Failed) {
 						// Install the app
-						lock (lock_obj)
-							this.install_log = install_log;
+						this.install_log = new AppInstallMonitorLog (Logs.Create ($"install-{Timestamp}.log", "Install log", timestamp: true));
 						try {
-							runner.MainLog = install_log;
-							var install_result = await runner.InstallAsync ();
+							runner.MainLog = this.install_log;
+							var install_result = await runner.InstallAsync (install_log.CancellationToken );
 							if (!install_result.Succeeded) {
 								FailureMessage = $"Install failed, exit code: {install_result.ExitCode}.";
 								ExecutionResult = TestExecutingResult.Failed;
 							}
 						} finally {
-							lock (lock_obj)
-								this.install_log = null;
+							this.install_log.Dispose ();
+							this.install_log = null;
 						}
 					}
 

--- a/tests/xharness/Log.cs
+++ b/tests/xharness/Log.cs
@@ -195,15 +195,17 @@ namespace xharness
 		}
 
 		// Create a new log backed with a file
-		public LogFile Create (string filename, string name)
+		public LogFile Create (string filename, string name, bool? timestamp = null)
 		{
-			return Create (Directory, filename, name);
+			return Create (Directory, filename, name, timestamp);
 		}
 
-		LogFile Create (string directory, string filename, string name)
+		LogFile Create (string directory, string filename, string name, bool? timestamp = null)
 		{
 			System.IO.Directory.CreateDirectory (directory);
 			var rv = new LogFile (this, name, Path.GetFullPath (Path.Combine (directory, filename)));
+			if (timestamp.HasValue)
+				rv.Timestamp = timestamp.Value;
 			Add (rv);
 			return rv;
 		}


### PR DESCRIPTION
* Instead of calculating a timeout based on the app size and an estimated
  transfer speed, keep transferring as long as mlaunch outputs something to
  stdout. The actual transfer speed can vary a lot, in particular if
  installing to multiple nearby watches simultaneously.

* Improve progress text in the html report during installation to include more
  statistics for the impatient.