### PR TITLE
[mtouch] Don't use the native linker to create fat executables.

### DIFF
--- a/tools/mtouch/BuildTasks.mtouch.cs
+++ b/tools/mtouch/BuildTasks.mtouch.cs
@@ -337,7 +337,7 @@ namespace Xamarin.Bundler
 			// /System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore
 			// more details in https://bugzilla.xamarin.com/show_bug.cgi?id=31036
 			if (CompilerFlags.WeakFrameworks.Count > 0)
-				Target.AdjustDylibs (Target.Executable);
+				Target.AdjustDylibs (OutputFile);
 			Driver.Watch ("Native Link", 1);
 		}
 
@@ -586,6 +586,63 @@ namespace Xamarin.Bundler
 		public override string ToString ()
 		{
 			return Path.GetFileName (Input);
+		}
+	}
+
+	public class LipoTask : BuildTask
+	{
+		public IEnumerable<string> InputFiles { get; set; }
+		public string OutputFile { get; set; }
+
+		public override IEnumerable<string> Inputs {
+			get {
+				return InputFiles;
+			}
+		}
+
+		public override IEnumerable<string> Outputs {
+			get {
+				yield return OutputFile;
+			}
+		}
+
+		protected override void Execute ()
+		{
+			Application.Lipo (OutputFile, InputFiles.ToArray ());
+		}
+
+		public override string ToString ()
+		{
+			return Path.GetFileName (string.Join (",", InputFiles));
+		}
+	}
+
+
+	public class FileCopyTask : BuildTask
+	{
+		public string InputFile { get; set; }
+		public string OutputFile { get; set; }
+
+		public override IEnumerable<string> Inputs {
+			get {
+				yield return InputFile;
+			}
+		}
+
+		public override IEnumerable<string> Outputs {
+			get {
+				yield return OutputFile;
+			}
+		}
+
+		protected override void Execute ()
+		{
+			Application.UpdateFile (InputFile, OutputFile);
+		}
+
+		public override string ToString ()
+		{
+			return $"cp {InputFile} {OutputFile}";
 		}
 	}
 }


### PR DESCRIPTION
Don't use the native linker to create fat executables, instead link each
architecture separately, and then manually lipo everything together at the
end. This requires a few changes since we need to keep track of the linker
flags per architecture.

The problem is that bitcode files (.bc) do not correspond with a particular
architecture, so the linker can't distinguish between .bc files for armv7k and
.bc files for arm64_32. So if we pass all together to the linker, the linker
will add all .bc files to both architectures, thus duplicating everything (and
the linking fails with duplicate symbols errors).