### PR TITLE
[linker] Fix sealer to handle method overrides

### DIFF
--- a/tools/linker/MonoTouch.Tuner/SealerSubStep.cs
+++ b/tools/linker/MonoTouch.Tuner/SealerSubStep.cs
@@ -84,7 +84,8 @@ namespace Xamarin.Linker.Steps {
 					// sanity (disable IsSealed == true above)
 					//if (type.IsSealed)
 					//	Console.WriteLine ();
-					continue;
+					if (AreMarked (overrides))
+						continue;
 				}
 
 				// we can seal the method (final in IL / !virtual in C#)


### PR DESCRIPTION
The current code did not consider that overrides could be swept later,
if unused/unmarked by the linker, so we were missing opportunities to
make methods as final.