### PR TITLE
[mtouch] Pass outfile= to the AOT compiler when compiling to full llvm as well.

### DIFF
--- a/tools/mtouch/Assembly.cs
+++ b/tools/mtouch/Assembly.cs
@@ -247,7 +247,8 @@ namespace Xamarin.Bundler {
 			var asm = Path.Combine (asm_dir, Path.GetFileName (assembly_path)) + ".s";
 			var data = Path.Combine (asm_dir, Path.GetFileNameWithoutExtension (assembly_path)) + ".aotdata" + "." + arch;
 			var llvm_aot_ofile = "";
-			var asm_output = "";
+			var asm_output = (string) null;
+			var other_output = string.Empty;
 			var is_llvm = (abi & Abi.LLVM) == Abi.LLVM;
 
 			Directory.CreateDirectory (asm_dir);
@@ -262,6 +263,7 @@ namespace Xamarin.Bundler {
 				// In llvm-only mode, the AOT compiler emits a .bc file and no .s file for JITted code
 				llvm_aot_ofile = Path.Combine (asm_dir, Path.GetFileName (assembly_path)) + ".bc";
 				aotInfo.BitcodeFiles.Add (llvm_aot_ofile);
+				other_output = Path.Combine (asm_dir, Path.GetFileName (assembly_path)) + "-output";
 			} else if (is_llvm) {
 				if (Driver.GetLLVMAsmWriter (App)) {
 					llvm_aot_ofile = Path.Combine (asm_dir, Path.GetFileName (assembly_path)) + "-llvm.s";
@@ -280,7 +282,7 @@ namespace Xamarin.Bundler {
 			aotInfo.AotDataFiles.Add (data);
 
 			var aotCompiler = Driver.GetAotCompiler (App, Target.Is64Build);
-			var aotArgs = Driver.GetAotArguments (App, assembly_path, abi, build_dir, asm_output, llvm_aot_ofile, data);
+			var aotArgs = Driver.GetAotArguments (App, assembly_path, abi, build_dir, asm_output ?? other_output, llvm_aot_ofile, data);
 			var task = new AOTTask
 			{
 				Assembly = this,

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -447,12 +447,9 @@ namespace Xamarin.Bundler
 			if (enable_llvm)
 				args.Append ("llvm-path=").Append (MonoTouchDirectory).Append (is32bit ? "/LLVM36/bin/," : "/LLVM/bin/,");
 
-			if (!llvm_only)
-				args.Append ("outfile=").Append (StringUtils.Quote (outputFile));
-			if (!llvm_only && enable_llvm)
-				args.Append (",");
+			args.Append ("outfile=").Append (StringUtils.Quote (outputFile));
 			if (enable_llvm)
-				args.Append ("llvm-outfile=").Append (StringUtils.Quote (llvmOutputFile));
+				args.Append (",llvm-outfile=").Append (StringUtils.Quote (llvmOutputFile));
 			args.Append (" \"").Append (filename).Append ("\"");
 			return args.ToString ();
 		}


### PR DESCRIPTION
The AOT compiler uses the 'outfile' as the base for a temporary .bc file. If
it's not set, the path to the assembly is used as the base instead. This does
not work if we compile the same assembly to multiple architectures (for
instance armv7k+arm64_32), because the temporary file will clash between those
AOT compilations.

This is not a problem for iOS (armv7+armv7s) because we don't compile to
bitcode (.bc files) on iOS.