### PR TITLE
[XHarness] Ensure that the correct values are shown on the test reports. Fixes #5639

### DIFF
--- a/tests/bcl-test/BCLTests/templates/common/TestRunner.NUnit/NUnitTestRunner.cs
+++ b/tests/bcl-test/BCLTests/templates/common/TestRunner.NUnit/NUnitTestRunner.cs
@@ -180,6 +180,7 @@ namespace Xamarin.iOS.UnitTests.NUnit
 				case TestStatus.Passed:
 					sb.Append ("\t[PASS] ");
 					PassedTests++;
+					ExecutedTests++;
 					break;
 				case TestStatus.Skipped:
 					sb.Append ("\t[IGNORED] ");
@@ -188,10 +189,12 @@ namespace Xamarin.iOS.UnitTests.NUnit
 				case TestStatus.Failed:
 					sb.Append ("\t[FAIL] ");
 					FailedTests++;
+					ExecutedTests++;
 					break;
 				case TestStatus.Inconclusive:
 					sb.Append ("\t[INCONCLUSIVE] ");
 					InconclusiveTests++;
+					ExecutedTests++;
 					break;
 				default:
 					sb.Append ("\t[INFO] ");

--- a/tests/bcl-test/BCLTests/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
+++ b/tests/bcl-test/BCLTests/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
@@ -724,6 +724,7 @@ namespace Xamarin.iOS.UnitTests.XUnit
 			}
 
 			LogFailureSummary ();
+			TotalTests += FilteredTests; // ensure that we do have in the total run the excluded ones.
 
 			bool ShouldRunAssembly (TestAssemblyInfo assemblyInfo)
 			{

--- a/tests/bcl-test/BCLTests/templates/iOSApp/ViewController.cs
+++ b/tests/bcl-test/BCLTests/templates/iOSApp/ViewController.cs
@@ -120,7 +120,7 @@ namespace BCLTests {
 				logger.Info ($"Xml result can be found {resultsFilePath}");
 			}
 			
-			logger.Info ($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.SkippedTests}");
+			logger.Info ($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
 			if (options.TerminateAfterExecution)
 				TerminateWithSuccess ();
 

--- a/tests/bcl-test/BCLTests/templates/macOS/MacTestMain.cs
+++ b/tests/bcl-test/BCLTests/templates/macOS/MacTestMain.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Mac.Tests
 				logger.Info ($"Xml result can be found {options.ResultFile}");
 			}
 			
-			logger.Info ($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.SkippedTests}");
+			logger.Info ($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
 			return runner.FailedTests != 0 ? 1 : 0;
 		}
 	}

--- a/tests/bcl-test/BCLTests/templates/tvOSApp/ViewController.cs
+++ b/tests/bcl-test/BCLTests/templates/tvOSApp/ViewController.cs
@@ -118,7 +118,7 @@ namespace BCLTests {
 				logger.Info ($"Xml result can be found {resultsFilePath}");
 			}
 			
-			logger.Info ($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.SkippedTests}");
+			logger.Info ($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
 			if (options.TerminateAfterExecution)
 				TerminateWithSuccess ();
 

--- a/tests/bcl-test/BCLTests/templates/watchOS/Extension/InterfaceController.cs
+++ b/tests/bcl-test/BCLTests/templates/watchOS/Extension/InterfaceController.cs
@@ -155,7 +155,7 @@ namespace monotouchtestWatchKitExtension
 						string resultsFilePath = runner.WriteResultsToFile ();
 						logger.Info ($"Xml result can be found {resultsFilePath}");
 					}
-					logger.Info ($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.SkippedTests}");
+					logger.Info ($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
 					if (options.TerminateAfterExecution)
 						TerminateWithSuccess ();
 				});


### PR DESCRIPTION
The results reported in the xharness run do not add up. Total tests
should include the number of skipped tests. This change ensures that the
tests results correctly add up.

Example nunit fixed tests: [NUnit] Mono SystemIOCompressionTests (total should
be 24, passed 4, ignored 20).
Example xunit fixed tests: [xUnit] Mono SystemDataXunit (total should be
1061, passed 1054, ignored 7).

Fixes https://github.com/xamarin/xamarin-macios/issues/5639