### PR TITLE
[xharness] Use existing (and pre-defined) defines for bitcode platforms.

### DIFF
--- a/tests/mini/AppDelegate.cs
+++ b/tests/mini/AppDelegate.cs
@@ -17,7 +17,7 @@ namespace mini
 {
 	[TestFixture]
 	class JitTests {
-#if BITCODE
+#if __WATCHOS__
 		static string[] args = new string[] { "--exclude", "!FULLAOT", "--exclude", "!BITCODE", "--verbose" };
 #else
 		static string[] args = new string[] { "--exclude", "!FULLAOT", "--verbose" };

--- a/tests/xharness/WatchOSTarget.cs
+++ b/tests/xharness/WatchOSTarget.cs
@@ -78,7 +78,6 @@ namespace xharness
 			csproj.FixArchitectures ("i386", "ARMv7k");
 			csproj.FixInfoPListInclude (suffix);
 			csproj.SetOutputType ("Library");
-			csproj.AddAdditionalDefines ("BITCODE", "iPhone", "Release");
 			csproj.AddAdditionalDefines ("XAMCORE_2_0;XAMCORE_3_0;FEATURE_NO_BSD_SOCKETS");
 			csproj.RemoveReferences ("OpenTK-1.0");
 			var ext = IsFSharp ? "fs" : "cs";


### PR DESCRIPTION
It's harder to forget setting the define if it's already set by default.

Fixes the mini tests on watchOS device:

    [FAIL] JitTests.Exceptions : System.Reflection.TargetInvocationException : Exception has been thrown by the target of an invocation.
    ----> System.ExecutionEngineException : Attempting to JIT compile method 'ExceptionTests:test_1_basic_filter_catch ()' while running in aot-only mode. See https://docs.microsoft.com/xamarin/ios/internals/limitations for more information.

since BITCODE wasn't defined everywhere it needed to be.