### PR TITLE
[mac][msbuild] Add MigrateToNewXMTFI to convert TFI to new Xamarin.Mac.NET (opt-in)

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -30,7 +30,7 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 	<!-- Story-time! MigrateToNewXMTFI is special because it un-does a lie we started telling from the 
 	beginning of Full (called Xamarin.Mac 4.5 back then). Back then, we released Modern (called Mobile) and 
 	when many customers upgraded from Classic they broke in terrible ways as none of their nugets worked. 
-	No nugets in the wild had heard of the Xamarin.Mac TFI and thus didn't support it. To "fix" this us case,
+	No nugets in the wild had heard of the Xamarin.Mac TFI and thus didn't support it. To "fix" this use case,
 	we created Full (XM 4.5) and _lied_ with our TFI claiming to be .NETFramework. Well we were close enough
 	for a vast majority of packages to work. However, this made creating Full specific package flavors impossible.
 	Now that we're getting "real" nuget support, we need to stop lying without breaking the world. We're starting by

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -27,16 +27,16 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 	</PropertyGroup>
 
 
-	<!-- Story-time! MigrateToNewXMTFI is special because it un-does a lie we started telling from the 
+	<!-- Story-time! MigrateToNewXMIdentifier is special because it un-does a lie we started telling from the 
 	beginning of Full (called Xamarin.Mac 4.5 back then). Back then, we released Modern (called Mobile) and 
 	when many customers upgraded from Classic they broke in terrible ways as none of their nugets worked. 
 	No nugets in the wild had heard of the Xamarin.Mac TFI and thus didn't support it. To "fix" this use case,
 	we created Full (XM 4.5) and _lied_ with our TFI claiming to be .NETFramework. Well we were close enough
 	for a vast majority of packages to work. However, this made creating Full specific package flavors impossible.
 	Now that we're getting "real" nuget support, we need to stop lying without breaking the world. We're starting by
-	allowing "opt-in" MigrateToNewXMTFI which will swap your declared TFI to the new hotness.
+	allowing "opt-in" MigrateToNewXMIdentifier which will swap your declared TFI to the new hotness.
 	-->
-	<PropertyGroup Condition=" '$(MigrateToNewXMTFI)' == 'true' And '$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(UseXamMacFullFramework)' == 'true' ">
+	<PropertyGroup Condition=" '$(MigrateToNewXMIdentifier)' == 'true' And '$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(UseXamMacFullFramework)' == 'true' ">
 		<TargetFrameworkIdentifier>Xamarin.Mac.NET</TargetFrameworkIdentifier>
 	</PropertyGroup>
 

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props
@@ -26,6 +26,20 @@ Copyright (C) 2013-2014 Xamarin. All rights reserved.
 		<_XamarinCommonPropsHasBeenImported>true</_XamarinCommonPropsHasBeenImported>
 	</PropertyGroup>
 
+
+	<!-- Story-time! MigrateToNewXMTFI is special because it un-does a lie we started telling from the 
+	beginning of Full (called Xamarin.Mac 4.5 back then). Back then, we released Modern (called Mobile) and 
+	when many customers upgraded from Classic they broke in terrible ways as none of their nugets worked. 
+	No nugets in the wild had heard of the Xamarin.Mac TFI and thus didn't support it. To "fix" this us case,
+	we created Full (XM 4.5) and _lied_ with our TFI claiming to be .NETFramework. Well we were close enough
+	for a vast majority of packages to work. However, this made creating Full specific package flavors impossible.
+	Now that we're getting "real" nuget support, we need to stop lying without breaking the world. We're starting by
+	allowing "opt-in" MigrateToNewXMTFI which will swap your declared TFI to the new hotness.
+	-->
+	<PropertyGroup Condition=" '$(MigrateToNewXMTFI)' == 'true' And '$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' And '$(UseXamMacFullFramework)' == 'true' ">
+		<TargetFrameworkIdentifier>Xamarin.Mac.NET</TargetFrameworkIdentifier>
+	</PropertyGroup>
+
 	<PropertyGroup>
 		<IsXBuild Condition="'$(MSBuildRuntimeVersion)' == ''">true</IsXBuild>
 		<IsXBuild Condition="'$(MSBuildRuntimeVersion)' != ''">false</IsXBuild>

--- a/tests/mmptest/mmptest.csproj
+++ b/tests/mmptest/mmptest.csproj
@@ -113,6 +113,7 @@
     <Compile Include="..\..\tools\mmp\SdkVersions.cs">
       <Link>SdkVersions.cs</Link>
     </Compile>
+    <Compile Include="src\TargetFrameworkMutateTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/tests/mmptest/src/TargetFrameworkMutateTests.cs
+++ b/tests/mmptest/src/TargetFrameworkMutateTests.cs
@@ -8,6 +8,8 @@ namespace Xamarin.MMP.Tests
 	[TestFixture]
 	public class TargetFrameworkMutateTests
 	{
+		const string MigrateCSProjTag = "<MigrateToNewXMIdentifier>true</MigrateToNewXMIdentifier>";
+
 		public bool MatchesTFI (string expected, string buildOutput)
 		{
 			string tfiLine = buildOutput.SplitLines ().FirstOrDefault (x => x.StartsWith ("TargetFrameworkIdentifier =", StringComparison.Ordinal));
@@ -34,9 +36,7 @@ namespace Xamarin.MMP.Tests
 		public void ShouldNotMutateModernWithOptInFlag ()
 		{
 			MMPTests.RunMMPTest (tmpDir => {
-				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
-					CSProjConfig = "<MigrateToNewXMTFI>true</MigrateToNewXMTFI>"
-				};
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) { CSProjConfig = MigrateCSProjTag };
 				var buildOutput = TI.TestUnifiedExecutable (test).BuildOutput;
 				Assert.True (MatchesTFI ("Xamarin.Mac", buildOutput), $"Build did not have expected TFI: {TI.PrintRedirectIfLong (buildOutput)}");
 			});
@@ -48,7 +48,7 @@ namespace Xamarin.MMP.Tests
 			MMPTests.RunMMPTest (tmpDir => {
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
 					XM45 = true,
-					CSProjConfig = "<MigrateToNewXMTFI>true</MigrateToNewXMTFI>"
+					CSProjConfig = MigrateCSProjTag
 				};
 				var buildOutput = TI.TestUnifiedExecutable (test).BuildOutput;
 				Assert.True (MatchesTFI ("Xamarin.Mac.NET", buildOutput), $"Build did not have expected TFI: {TI.PrintRedirectIfLong (buildOutput)}");

--- a/tests/mmptest/src/TargetFrameworkMutateTests.cs
+++ b/tests/mmptest/src/TargetFrameworkMutateTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using Xamarin.Utils;
+
+namespace Xamarin.MMP.Tests
+{
+	[TestFixture]
+	public class TargetFrameworkMutateTests
+	{
+		public bool MatchesTFI (string expected, string buildOutput)
+		{
+			string tfiLine = buildOutput.SplitLines ().FirstOrDefault (x => x.StartsWith ("TargetFrameworkIdentifier =", StringComparison.Ordinal));
+			if (tfiLine == null)
+				return false;
+			return tfiLine.Contains (expected);
+		}
+
+		[TestCase (true)]
+		[TestCase (false)]
+		public void ShouldNotMutateWithoutOptInFlag (bool xm45)
+		{
+			MMPTests.RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					XM45 = xm45
+				};
+				var buildOutput = TI.TestUnifiedExecutable (test).BuildOutput;
+				string standardTFI = xm45 ? ".NETFramework" : "Xamarin.Mac";
+				Assert.True (MatchesTFI (standardTFI, buildOutput), $"Build did not have expected TFI: {TI.PrintRedirectIfLong (buildOutput)}");
+			});
+		}
+
+		[Test]
+		public void ShouldNotMutateModernWithOptInFlag ()
+		{
+			MMPTests.RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					CSProjConfig = "<MigrateToNewXMTFI>true</MigrateToNewXMTFI>"
+				};
+				var buildOutput = TI.TestUnifiedExecutable (test).BuildOutput;
+				Assert.True (MatchesTFI ("Xamarin.Mac", buildOutput), $"Build did not have expected TFI: {TI.PrintRedirectIfLong (buildOutput)}");
+			});
+		}
+
+		[Test]
+		public void ShouldMutateFullWithOptInFlag ()
+		{
+			MMPTests.RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					XM45 = true,
+					CSProjConfig = "<MigrateToNewXMTFI>true</MigrateToNewXMTFI>"
+				};
+				var buildOutput = TI.TestUnifiedExecutable (test).BuildOutput;
+				Assert.True (MatchesTFI ("Xamarin.Mac.NET", buildOutput), $"Build did not have expected TFI: {TI.PrintRedirectIfLong (buildOutput)}");
+			});
+		}
+	}
+}


### PR DESCRIPTION

- https://github.com/xamarin/xamarin-macios/issues/5480
- Related: https://github.com/NuGet/NuGet.Client/pull/2572

To allow nuget to target XM Full we need to have a unique TFI (TargetFrameworkIdentifier).

However, that's a really scary change to force, so let's opt-in for now. You can set

```
<MigrateToNewXMTFI>true</MigrateToNewXMTFI>
```
in your project or

```MigrateToNewXMTFI=true msbuild project.csproj```

to try it out. 

We can convert the opt-in to an opt-out with sufficient validation \ releases.