### PR TITLE
[mtouch] use "--aot=interp,full,[...]" for every assembly if interpreter mixed mode is enabled

### DIFF
--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -390,7 +390,7 @@ namespace Xamarin.Bundler
 			bool enable_debug_symbols = app.PackageManagedDebugSymbols;
 			bool llvm_only = app.EnableLLVMOnlyBitCode;
 			bool interp = app.IsInterpreted (Assembly.GetIdentity (filename));
-			bool interp_full = !interp && app.UseInterpreter && fname == "mscorlib.dll";
+			bool interp_full = !interp && app.UseInterpreter;
 			bool is32bit = (abi & Abi.Arch32Mask) > 0;
 			string arch = abi.AsArchString ();
 
@@ -414,8 +414,6 @@ namespace Xamarin.Bundler
 					throw ErrorHelper.CreateError (99, $"Internal error: can only enable the interpreter for mscorlib.dll when AOT-compiling assemblies (tried to interpret {fname}). Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new.");
 				args.Append ("interp,");
 			} else if (interp_full) {
-				if (fname != "mscorlib.dll")
-					throw ErrorHelper.CreateError (99, $"Internal error: can only enable the interpreter for mscorlib.dll when AOT-compiling assemblies (tried to interpret {fname}). Please file an issue at https://github.com/xamarin/xamarin-macios/issues/new."); 
 				args.Append ("interp,full,");
 			} else
 				args.Append ("full,");


### PR DESCRIPTION
The Mono AOT compiler maintains a set of signatures of compiled methods.
Those signatures are necessary to emit wrappers to enable the transition
from interpreter->AOT code. Thus, they must be collected for each
assembly.

Contributes to https://github.com/xamarin/xamarin-macios/issues/5618