### PR TITLE
[mac] Hide NSApp.Window for NSApp.DangerousWindow and note risk

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -589,13 +589,14 @@ namespace AppKit {
 		[Availability (Deprecated = Platform.Mac_10_12, Message = "Use EnumerateWindows instead.")]
 		NSWindow MakeWindowsPerform (Selector aSelector, bool inOrder);
 	
-		[Deprecated (PlatformName.MacOSX, 10, 7, message : "Remove usage or use 'DangerousWindows' instead.")]
+		[Obsolete ("Remove usage or use 'DangerousWindows' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Export ("windows")]
+		[Wrap ("DangerousWindows", IsVirtual = true)] 
 		NSWindow [] Windows { get; }
 
 		[Advice ("Use of DangerousWindows can prevent windows from leaving memory.")]
-		NSWindow [] DangerousWindows { [Wrap ("Windows")] get; }
+		[Export ("windows")]
+		NSArray<NSWindow> DangerousWindows { get; }
 	
 		[Export ("setWindowsNeedUpdate:")]
 		void SetWindowsNeedUpdate (bool needUpdate);

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -589,10 +589,12 @@ namespace AppKit {
 		[Availability (Deprecated = Platform.Mac_10_12, Message = "Use EnumerateWindows instead.")]
 		NSWindow MakeWindowsPerform (Selector aSelector, bool inOrder);
 	
+#if !XAMCORE_4_0
 		[Obsolete ("Remove usage or use 'DangerousWindows' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Wrap ("DangerousWindows", IsVirtual = true)] 
 		NSWindow [] Windows { get; }
+#endif
 
 		[Advice ("Use of DangerousWindows can prevent windows from leaving memory.")]
 		[Export ("windows")]

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -589,8 +589,13 @@ namespace AppKit {
 		[Availability (Deprecated = Platform.Mac_10_12, Message = "Use EnumerateWindows instead.")]
 		NSWindow MakeWindowsPerform (Selector aSelector, bool inOrder);
 	
+		[Deprecated (PlatformName.MacOSX, 10, 7, message : "Remove usage or use 'DangerousWindows' instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Export ("windows")]
 		NSWindow [] Windows { get; }
+
+		[Advice ("Use of DangerousWindows can prevent windows from leaving memory.")]
+		NSWindow [] DangerousWindows { [Wrap ("Windows")] get; }
 	
 		[Export ("setWindowsNeedUpdate:")]
 		void SetWindowsNeedUpdate (bool needUpdate);


### PR DESCRIPTION
- https://github.com/xamarin/xamarin-macios/issues/5350
- NSApplication.Window has been the source of internal and external
pain over the years.
- Let's make our opinion that it should not be used more visible.