### PR TITLE
 [Tests] Fix the make rule that generate the test projects. Fixes #5638

### DIFF
--- a/tests/bcl-test/BCLTests/Makefile
+++ b/tests/bcl-test/BCLTests/Makefile
@@ -1,3 +1,6 @@
+TOP = ../../..
+include $(TOP)/Make.config
+
 DESTDIR ?= /usr/local/bin/
 CONFIGURATION ?= Debug
 MONO_ROOT:=../../../external/mono/
@@ -10,7 +13,7 @@ test-importer:
 
 generate-test-projects: test-importer ./RegisterType.cs.in ./BCLTests.csproj.in
 	mono ./bcl-test-importer/BCLTestImporter.exe --generate-all-projects --output=. --clean
-	mono ./bcl-test-importer/BCLTestImporter.exe --generate-all-projects --output=. --override --register-type-template=RegisterType.cs.in --project-template=. --plist-template=. --mono-root=../../../external/mono/ -iOS -v
+	mono ./bcl-test-importer/BCLTestImporter.exe --generate-all-projects --output=. --override --register-type-template=RegisterType.cs.in --project-template=. --plist-template=. --mono-root=../../../external/mono/ --sdk-download=$(MONO_SDK_DESTDIR) -iOS -v
 
 all: build-test-projects
 

--- a/tests/bcl-test/BCLTests/common-SystemCoreXunit.ignore
+++ b/tests/bcl-test/BCLTests/common-SystemCoreXunit.ignore
@@ -1,0 +1,209 @@
+#  Exception messages: System.PlatformNotSupportedException : Operation is not supported on this platform.
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateClient.CreateClientStreamFromStringHandle_Valid
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateServer.InOutPipeDirection_Throws_NotSupportedException
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateServer.ValidConstructors
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateServer.InvalidPipeHandle_Throws
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerIn_ClientOut.ValidWriteAsync_ValidReadAsync_APM
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerIn_ClientOut.ReadFromPipeWithClosedPartner_ReadNoBytes
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerIn_ClientOut.ReadWithZeroLengthBuffer_Nop
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerIn_ClientOut.ReadWithNegativeCount_Throws_ArgumentOutOfRangeException
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerIn_ClientOut.ReadWithNullBuffer_Throws_ArgumentNullException
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerIn_ClientOut.ReadOnDisposedReadablePipe_Throws_ObjectDisposedException
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerIn_ClientOut.ReadPipeUnsupportedMembers_Throws_NotSupportedException
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerIn_ClientOut.ValidWrite_ValidRead
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerIn_ClientOut.CopyToAsync_InvalidArgs_Throws
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerIn_ClientOut.ValidWriteAsync_ValidReadAsync
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerIn_ClientOut.ReadWithNegativeOffset_Throws_ArgumentOutOfRangeException
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerIn_ClientOut.ReadWithOutOfBoundsArray_Throws_ArgumentException
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerIn_ClientOut.ValidWriteByte_ValidReadByte
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerIn_ClientOut.WriteToReadOnlyPipe_Throws_NotSupportedException
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerOut_ClientIn.ValidWriteAsync_ValidReadAsync
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerOut_ClientIn.ReadFromPipeWithClosedPartner_ReadNoBytes
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerOut_ClientIn.ReadWithNegativeOffset_Throws_ArgumentOutOfRangeException
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerOut_ClientIn.WriteToReadOnlyPipe_Throws_NotSupportedException
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerOut_ClientIn.ValidWriteAsync_ValidReadAsync_APM
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerOut_ClientIn.ValidWrite_ValidRead
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerOut_ClientIn.CopyToAsync_InvalidArgs_Throws
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerOut_ClientIn.ValidWriteByte_ValidReadByte
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerOut_ClientIn.ReadWithZeroLengthBuffer_Nop
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerOut_ClientIn.ReadWithNegativeCount_Throws_ArgumentOutOfRangeException
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerOut_ClientIn.ReadWithOutOfBoundsArray_Throws_ArgumentException
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerOut_ClientIn.ReadPipeUnsupportedMembers_Throws_NotSupportedException
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerOut_ClientIn.ReadOnDisposedReadablePipe_Throws_ObjectDisposedException
+System.IO.Pipes.Tests.AnonymousPipeTest_Read_ServerOut_ClientIn.ReadWithNullBuffer_Throws_ArgumentNullException
+System.IO.Pipes.Tests.AnonymousPipeTest_Specific.PipeTransmissionMode_Returns_Byte
+System.IO.Pipes.Tests.AnonymousPipeTest_Specific.ClonedClient_ActsAsOriginalClient
+System.IO.Pipes.Tests.AnonymousPipeTest_Specific.DisposeLocalCopyOfClientHandle_BeforeServerRead
+System.IO.Pipes.Tests.AnonymousPipeTest_Specific.ReadModeToByte_Accepted(serverDirection: Out, clientDirection: In)
+System.IO.Pipes.Tests.AnonymousPipeTest_Specific.ReadModeToByte_Accepted(serverDirection: In, clientDirection: Out)
+System.IO.Pipes.Tests.AnonymousPipeTest_Specific.ClonedServer_ActsAsOriginalServer
+System.IO.Pipes.Tests.AnonymousPipeTest_Specific.InvalidReadMode_Throws_ArgumentOutOfRangeException
+System.IO.Pipes.Tests.AnonymousPipeTest_Specific.MessageReadMode_Throws_NotSupportedException
+System.IO.Pipes.Tests.AnonymousPipeTest_Specific.OSX_BufferSizeNotSupported
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerIn_ClientOut.WritePipeUnsupportedMembers_Throws_NotSupportedException
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerIn_ClientOut.ValidFlush_DoesntThrow
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerIn_ClientOut.WriteWithOutOfBoundsArray_Throws_ArgumentException
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerIn_ClientOut.WriteToDisposedWriteablePipe_Throws_ObjectDisposedException
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerIn_ClientOut.WriteToPipeWithClosedPartner_Throws_IOException
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerIn_ClientOut.WriteWithNegativeOffset_Throws_ArgumentOutOfRangeException
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerIn_ClientOut.WriteWithNegativeCount_Throws_ArgumentOutOfRangeException
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerIn_ClientOut.WriteZeroLengthBuffer_Nop
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerIn_ClientOut.ReadOnWriteOnlyPipe_Throws_NotSupportedException
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerIn_ClientOut.WriteWithNullBuffer_Throws_ArgumentNullException
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerOut_ClientIn.WriteToDisposedWriteablePipe_Throws_ObjectDisposedException
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerOut_ClientIn.ValidFlush_DoesntThrow
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerOut_ClientIn.WriteWithNegativeCount_Throws_ArgumentOutOfRangeException
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerOut_ClientIn.WritePipeUnsupportedMembers_Throws_NotSupportedException
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerOut_ClientIn.WriteWithNegativeOffset_Throws_ArgumentOutOfRangeException
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerOut_ClientIn.WriteZeroLengthBuffer_Nop
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerOut_ClientIn.ReadOnWriteOnlyPipe_Throws_NotSupportedException
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerOut_ClientIn.WriteWithOutOfBoundsArray_Throws_ArgumentException
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerOut_ClientIn.WriteToPipeWithClosedPartner_Throws_IOException
+System.IO.Pipes.Tests.AnonymousPipeTest_Write_ServerOut_ClientIn.WriteWithNullBuffer_Throws_ArgumentNullException
+System.IO.Pipes.Tests.TestPipeStream.TestCheckReadWrite
+System.IO.Pipes.Tests.TestPipeStream.TestCheckPipePropertyOperations_Unix
+System.IO.Pipes.Tests.TestPipeStream.TestInitializeHandle
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateClient.NullParameters_Throws_ArgumentNullException
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateClient.CreateClientStreamFromStringHandle_Valid
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateClient.InvalidStringParameters_Throws_ArgumentException
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateClient.InvalidPipeHandle_Throws_ArgumentException
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateClient.InOutPipeDirection_Throws_NotSupportedException
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateServer.InOutPipeDirection_Throws_NotSupportedException
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateServer.ServerBadInheritabilityThrows
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateServer.InvalidBufferSize_Throws_ArgumentOutOfRangeException
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateServer.InvalidPipeDirection_Throws_ArgumentOutOfRangeException
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateServer.InvalidPipeHandle_Throws
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateServer.ValidConstructors
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateClient.InvalidStringParameters_Throws_ArgumentException(handle: "abc")
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateClient.InvalidStringParameters_Throws_ArgumentException(handle: "-1")
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateServer.InvalidBufferSize_Throws_ArgumentOutOfRangeException(direction: InOut, bufferSize: -500)
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateServer.InvalidBufferSize_Throws_ArgumentOutOfRangeException(direction: In, bufferSize: -500)
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateServer.InvalidBufferSize_Throws_ArgumentOutOfRangeException(direction: Out, bufferSize: -500)
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateServer.ServerBadInheritabilityThrows(direction: In, inheritability: 999)
+System.IO.Pipes.Tests.AnonymousPipeTest_CreateServer.ServerBadInheritabilityThrows(direction: Out, inheritability: 999)
+
+# System.NotImplementedException
+System.Linq.Expressions.Tests.ParameterTests.CanUseAsLambdaByRefParameter_String(useInterpreter: True)
+System.Linq.Expressions.Tests.ParameterTests.CanWriteToRefParameter(useInterpreter: True)
+System.Linq.Expressions.Tests.ParameterTests.CanUseAsLambdaByRefParameter(useInterpreter: True)
+System.Linq.Expressions.Tests.ParameterTests.CanUseAsLambdaByRefParameter_Bool(useInterpreter: True)
+System.Linq.Expressions.Tests.ParameterTests.CanUseAsLambdaByRefParameter_Char(useInterpreter: True)
+System.Linq.Expressions.Tests.ParameterTests.CanReadFromRefParameter(useInterpreter: True)
+System.Linq.Expressions.Tests.SwitchTests.JumpBetweenCases(useIntepreter: True)
+System.Linq.Expressions.Tests.SwitchTests.NoDefaultOrCasesSwitchWithSideEffect(useInterpreter: True)
+System.Linq.Expressions.Tests.ParameterTests.ReadAndWriteRefParameters
+System.Linq.Expressions.Tests.SwitchTests.DefaultOnlySwitchWithSideEffect(useInterpreter: True)
+System.Linq.Expressions.Tests.Compiler_Tests.CallCompiledLambdaWithTypeMissing(useInterpreter: True)
+System.Linq.Expressions.Tests.NewWithByRefParameterTests.CreateByRefAliasingCompiled
+System.Linq.Expressions.Tests.NewWithByRefParameterTests.CreateByRefThrowing(useInterpreter: True)
+System.Linq.Expressions.Tests.NewWithByRefParameterTests.CreateByRefReferencingReadonly(useInterpreter: True)
+System.Linq.Expressions.Tests.NewWithByRefParameterTests.CreateByRef(useInterpreter: True)
+System.Linq.Expressions.Tests.NewWithByRefParameterTests.CreateOut(useInterpreter: True)
+System.Linq.Expressions.Tests.InvocationTests.InvokeByRefLambda(useInterpreter: True)
+System.Linq.Expressions.Tests.ConvertTests.CustomConversionNotStandardNameFromLiftedByRef(useInterpreter: True)
+System.Linq.Expressions.Tests.ConvertTests.CustomConversionNotStandardNameFromByRef(useInterpreter: True)
+System.Linq.Expressions.Tests.OpAssign.ConvertOpWriteByRefParameterOverloadedOperator(useInterpreter: True)
+System.Dynamic.Tests.DynamicObjectTests.ByRefInvoke
+
+
+#  System.PlatformNotSupportedException : Operation is not supported on this platform. 
+System.Linq.Expressions.Tests.NewTests.GlobalMethodInMembers
+System.Linq.Expressions.Tests.NewTests.GlobalFieldInMembers
+System.Linq.Expressions.Tests.MemberBindTests.GlobalMethod
+System.Linq.Expressions.Tests.ListBindTests.GlobalMethod
+System.Linq.Expressions.Tests.InvocationTests.InvokePrivateDelegate(useInterpreter: True)
+System.Linq.Expressions.Tests.InvocationTests.InvokePrivateDelegateTypeLambda(useInterpreter: True)
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeAction(typeArgs: [typeof(int), typeof(System.Int32&), typeof(string)])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeAction(typeArgs: [typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), ...])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeAction(typeArgs: [typeof(System.Int32*), typeof(System.Int32*), typeof(System.Int32*), typeof(System.Int32*), typeof(System.Int32*), ...])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeAction(typeArgs: [typeof(System.Int32&)])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeAction(typeArgs: [typeof(string), typeof(System.Double*), typeof(int)])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeAction(typeArgs: [typeof(System.String*)])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeAction(typeArgs: [typeof(System.Int32*)])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeAction(typeArgs: [typeof(System.Collections.Generic.List<int>), typeof(System.Collections.Generic.List<int>), typeof(System.Collections.Generic.List<int>), typeof(System.Collections.Generic.List<int>), typeof(System.Collections.Generic.List<int>), ...])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeAction(typeArgs: [typeof(System.Double&), typeof(System.Double&), typeof(System.Double&), typeof(System.Double&), typeof(System.Double&), ...])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeAction(typeArgs: [typeof(int), typeof(System.String*), typeof(double)])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeAction(typeArgs: [typeof(System.String*), typeof(System.String*), typeof(System.String*), typeof(System.String*), typeof(System.String*), ...])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeFunc(typeArgs: [typeof(System.Int32*)])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeFunc(typeArgs: [typeof(int), typeof(System.Int32&), typeof(string)])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeFunc(typeArgs: [typeof(string), typeof(System.Double*), typeof(int)])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeFunc(typeArgs: [typeof(System.Int32&)])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeFunc(typeArgs: [typeof(int), typeof(System.String*), typeof(double)])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeFunc(typeArgs: [typeof(System.String*), typeof(System.String*), typeof(System.String*), typeof(System.String*), typeof(System.String*), ...])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeFunc(typeArgs: [typeof(System.Collections.Generic.List<int>), typeof(System.Collections.Generic.List<int>), typeof(System.Collections.Generic.List<int>), typeof(System.Collections.Generic.List<int>), typeof(System.Collections.Generic.List<int>), ...])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeFunc(typeArgs: [typeof(System.String*)])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeFunc(typeArgs: [typeof(System.Int32*), typeof(System.Int32*), typeof(System.Int32*), typeof(System.Int32*), typeof(System.Int32*), ...])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeFunc(typeArgs: [typeof(System.Double&), typeof(System.Double&), typeof(System.Double&), typeof(System.Double&), typeof(System.Double&), ...])
+System.Linq.Expressions.Tests.GetDelegateTypeTests.CantBeFunc(typeArgs: [typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), ...])
+System.Linq.Expressions.Tests.ConstantTests.CheckTypeConstantTest(useInterpreter: True)
+System.Linq.Expressions.Tests.ConstantTests.CheckMethodInfoConstantTest(useInterpreter: True)
+System.Linq.Expressions.Tests.CastTests.CanCastEnumTypeToUnderlyingType
+System.Linq.Expressions.Tests.CastTests.CannotCastWrongUnderlyingTypeEnumChecked
+System.Linq.Expressions.Tests.CastTests.CannotCastWrongUnderlyingTypeEnum
+System.Linq.Expressions.Tests.CastTests.CanCastUnderlyingTypeToEnumTypeChecked
+System.Linq.Expressions.Tests.CastTests.CanCastUnderlyingTypeToEnumType
+System.Linq.Expressions.Tests.CastTests.CannotCastReferenceToWrongUnderlyingTypeEnumChecked
+System.Linq.Expressions.Tests.CastTests.CanCastReferenceToUnderlyingTypeToEnumTypeChecked
+System.Linq.Expressions.Tests.CastTests.CannotCastReferenceToWrongUnderlyingTypeEnum
+System.Linq.Expressions.Tests.CastTests.CanCastEnumTypeToUnderlyingTypeChecked
+System.Linq.Expressions.Tests.CastTests.CanCastReferenceToUnderlyingTypeToEnumType
+System.Linq.Expressions.Tests.BinaryLogicalTests.Method_FalseOperatorIncorrectMethod_ThrowsArgumentException
+System.Linq.Expressions.Tests.BinaryLogicalTests.OrElse_NoMethod_TrueOperatorIncorrectMethod_ThrowsArgumentException
+System.Linq.Expressions.Tests.BinaryLogicalTests.Method_ParamsDontMatchOperator_ThrowsInvalidOperationException
+System.Linq.Expressions.Tests.BinaryLogicalTests.AndAlso_NoMethod_VoidReturnType_ThrowsArgumentException
+System.Linq.Expressions.Tests.BinaryLogicalTests.AndAlso_NoMethod_NotStatic_ThrowsInvalidOperationException
+System.Linq.Expressions.Tests.BinaryLogicalTests.AndAlso_NoMethod_TrueOperatorIncorrectMethod_ThrowsArgumentException
+System.Linq.Expressions.Tests.BinaryLogicalTests.OrElse_NoMethod_ReturnTypeNotEqualToParameterTypes_ThrowsArgumentException
+System.Linq.Expressions.Tests.BinaryLogicalTests.AndAlsoGlobalMethod
+System.Linq.Expressions.Tests.BinaryLogicalTests.AndAlso_NoMethod_ParamsDontMatchOperator_ThrowsInvalidOperationException
+System.Linq.Expressions.Tests.BinaryLogicalTests.OrElse_NoMethod_NoTrueFalseOperator_ThrowsArgumentException(name: "op_False")
+System.Linq.Expressions.Tests.BinaryLogicalTests.OrElse_NoMethod_NoTrueFalseOperator_ThrowsArgumentException(name: "op_True")
+System.Linq.Expressions.Tests.BinaryLogicalTests.Method_NoTrueFalseOperator_ThrowsArgumentException(name: "op_True")
+System.Linq.Expressions.Tests.BinaryLogicalTests.Method_NoTrueFalseOperator_ThrowsArgumentException(name: "op_False")
+System.Linq.Expressions.Tests.BinaryLogicalTests.AndAlso_NoMethod_NoTrueFalseOperator_ThrowsArgumentException(name: "op_False")
+System.Linq.Expressions.Tests.BinaryLogicalTests.AndAlso_NoMethod_NoTrueFalseOperator_ThrowsArgumentException(name: "op_True")
+System.Linq.Expressions.Tests.BinaryLogicalTests.OrElse_NoMethod_ExpressionDoesntMatchMethodParameters_ThrowsInvalidOperationException
+System.Linq.Expressions.Tests.BinaryLogicalTests.AndAlso_NoMethod_DoesntHaveTwoParameters_ThrowsInvalidOperationException(parameterCount: 3)
+System.Linq.Expressions.Tests.BinaryLogicalTests.AndAlso_NoMethod_DoesntHaveTwoParameters_ThrowsInvalidOperationException(parameterCount: 1)
+System.Linq.Expressions.Tests.BinaryLogicalTests.AndAlso_NoMethod_DoesntHaveTwoParameters_ThrowsInvalidOperationException(parameterCount: 0)
+System.Linq.Expressions.Tests.BinaryLogicalTests.OrElse_NoMethod_DoesntHaveTwoParameters_ThrowsInvalidOperationException(parameterCount: 0)
+System.Linq.Expressions.Tests.BinaryLogicalTests.OrElse_NoMethod_DoesntHaveTwoParameters_ThrowsInvalidOperationException(parameterCount: 3)
+System.Linq.Expressions.Tests.BinaryLogicalTests.OrElse_NoMethod_DoesntHaveTwoParameters_ThrowsInvalidOperationException(parameterCount: 1)
+System.Linq.Expressions.Tests.BinaryLogicalTests.Method_TrueOperatorIncorrectMethod_ThrowsArgumentException
+System.Linq.Expressions.Tests.BinaryLogicalTests.AndAlso_NoMethod_ReturnTypeNotEqualToParameterTypes_ThrowsArgumentException
+System.Linq.Expressions.Tests.BinaryLogicalTests.AndAlso_NoMethod_ExpressionDoesntMatchMethodParameters_ThrowsInvalidOperationException
+System.Linq.Expressions.Tests.BinaryLogicalTests.OrElse_NoMethod_VoidReturnType_ThrowsArgumentException
+System.Linq.Expressions.Tests.BinaryLogicalTests.OrElse_NoMethod_ParamsDontMatchOperator_ThrowsInvalidOperationException
+System.Linq.Expressions.Tests.BinaryLogicalTests.OrElse_NoMethod_NotStatic_ThrowsInvalidOperationException
+System.Linq.Expressions.Tests.OpAssign.MethodNoConvertOpWriteByRefParameter
+System.Linq.Expressions.Tests.BinaryLogicalTests.OrElseGlobalMethod
+
+#  System.ArgumentException : Missing parameter does not have a default value.
+System.Linq.Expressions.Tests.Compiler_Tests.CallCompiledLambdaWithTypeMissing
+
+# Expected: 2147483648
+# Actual:   0   Exception stack traces:   at System.Linq.Expressions.Tests.ConvertTests.VerifyNullableFloatToNullableUInt (System.Nullable`1[T] value, System.Boolean useInterpreter) [0x00035] in /Users/builder/jenkins/workspace/archive-mono/2018-08/ios/release/external/corefx/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs:11802 
+#  at System.Linq.Expressions.Tests.ConvertTests.ConvertNullableFloatToNullableUIntTest (System.Boolean useInterpreter) [0x000a7] in /Users/builder/jenkins/workspace/archive-mono/2018-08/ios/release/external/corefx/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs:3359 
+#  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
+System.Linq.Expressions.Tests.ConvertTests.ConvertNullableFloatToNullableUIntTest(useInterpreter: True)
+System.Linq.Expressions.Tests.ConvertTests.ConvertFloatToNullableUIntTest(useInterpreter: True)
+System.Linq.Expressions.Tests.ConvertTests.ConvertFloatToUIntTest(useInterpreter: True)
+System.Linq.Expressions.Tests.ConvertTests.ConvertNullableFloatToUIntTest(useInterpreter: True)
+
+# Exception messages: Assert.NotNull() Failure   Exception stack traces:   at System.Linq.Expressions.Tests.CompilerTests.VerifyEmitConstantsToIL (System.Linq.Expressions.Expression e, System.Int32 expectedCount, System.Object expectedValue) [0x0001c] in /Users/builder/jenkins/workspace/archive-mono/2018-08/ios/release/external/corefx/src/System.Linq.Expressions/tests/CompilerTests.cs:437 
+#  at System.Linq.Expressions.Tests.CompilerTests.VerifyEmitConstantsToIL[T] (T value, System.Int32 expectedCount) [0x00000] in /Users/builder/jenkins/workspace/archive-mono/2018-08/ios/release/external/corefx/src/System.Linq.Expressions/tests/CompilerTests.cs:429 
+#  at System.Linq.Expressions.Tests.CompilerTests.VerifyEmitConstantsToIL[T] (T value) [0x00000] in /Users/builder/jenkins/workspace/archive-mono/2018-08/ios/release/external/corefx/src/System.Linq.Expressions/tests/CompilerTests.cs:424 
+#  at System.Linq.Expressions.Tests.CompilerTests.EmitConstantsToIL_NonNullableValueTypes () [0x00000] in /Users/builder/jenkins/workspace/archive-mono/2018-08/ios/release/external/corefx/src/System.Linq.Expressions/tests/CompilerTests.cs:57 
+#  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
+#  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in /Users/mandel/Xamarin/xamarin-macios/master/xamarin-macios/external/mono/mcs/class/corlib/System.Reflection/MonoMethod.cs:305 
+System.Linq.Expressions.Tests.CompilerTests.EmitConstantsToIL_NonNullableValueTypes
+System.Linq.Expressions.Tests.CompilerTests.EmitConstantsToIL_ShareReferences
+System.Linq.Expressions.Tests.CompilerTests.EmitConstantsToIL_ReferenceTypes
+System.Linq.Expressions.Tests.CompilerTests.EmitConstantsToIL_NullableValueTypes
+System.Linq.Expressions.Tests.CompilerTests.EmitConstantsToIL_LiftedToClosure
+System.Linq.Expressions.Tests.CompilerTests.EmitConstantsToIL_Enums
+
+#  Exception messages: Assert.Throws() Failure
+# Expected: typeof(System.InvalidCastException)
+# Actual:   typeof(System.NotImplementedException): byref delegate
+System.Dynamic.Tests.DynamicObjectTests.ByRefMismatch

--- a/tests/bcl-test/BCLTests/common-SystemWebServicesTests.ignore
+++ b/tests/bcl-test/BCLTests/common-SystemWebServicesTests.ignore
@@ -1,0 +1,5 @@
+# System.IO.DirectoryNotFoundException: SystemWebServicesTests.app/Test/System.Web.Services.Description/test.wsdl
+MonoTests.System.Web.Services.Description.ServiceDescriptionTest.ExtensibleAttributes
+MonoTests.System.Web.Services.Description.ServiceDescriptionTest.Extensions
+MonoTests.System.Web.Services.Description.ServiceDescriptionTest.Namespaces
+MonoTests.System.Web.Services.Description.ServiceDescriptionTest.ReadAndRetrievalUrl

--- a/tests/bcl-test/BCLTests/iOS-MicrosoftCSharpXunit.ignore
+++ b/tests/bcl-test/BCLTests/iOS-MicrosoftCSharpXunit.ignore
@@ -1,0 +1,6 @@
+# Exception messages: System.ArgumentException : Missing parameter does not have a default value.
+Microsoft.CSharp.RuntimeBinder.Tests.DefaultParameterTests.MarshalAsOptionalsCorrectDefault
+
+# System.NotImplementedException
+Microsoft.CSharp.RuntimeBinder.Tests.DelegateInDynamicTests.DelegateWithOutParametersInDynamicNamedArgumentInvocation
+Microsoft.CSharp.RuntimeBinder.Tests.DelegateInDynamicTests.DelegateWithOutParameterInDynamic

--- a/tests/bcl-test/BCLTests/tvOS-MicrosoftCSharpXunit.ignore
+++ b/tests/bcl-test/BCLTests/tvOS-MicrosoftCSharpXunit.ignore
@@ -1,0 +1,6 @@
+# Exception messages: System.ArgumentException : Missing parameter does not have a default value.
+Microsoft.CSharp.RuntimeBinder.Tests.DefaultParameterTests.MarshalAsOptionalsCorrectDefault
+
+# System.NotImplementedException
+Microsoft.CSharp.RuntimeBinder.Tests.DelegateInDynamicTests.DelegateWithOutParametersInDynamicNamedArgumentInvocation
+Microsoft.CSharp.RuntimeBinder.Tests.DelegateInDynamicTests.DelegateWithOutParameterInDynamic

--- a/tests/bcl-test/BCLTests/watchOS-MicrosoftCSharpXunit.ignore
+++ b/tests/bcl-test/BCLTests/watchOS-MicrosoftCSharpXunit.ignore
@@ -1,0 +1,6 @@
+# Exception messages: System.ArgumentException : Missing parameter does not have a default value.
+Microsoft.CSharp.RuntimeBinder.Tests.DefaultParameterTests.MarshalAsOptionalsCorrectDefault
+
+# System.NotImplementedException
+Microsoft.CSharp.RuntimeBinder.Tests.DelegateInDynamicTests.DelegateWithOutParametersInDynamicNamedArgumentInvocation
+Microsoft.CSharp.RuntimeBinder.Tests.DelegateInDynamicTests.DelegateWithOutParameterInDynamic

--- a/tools/bcl-test-importer/BCLTestImporter/ApplicationOptions.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/ApplicationOptions.cs
@@ -220,7 +220,7 @@ namespace BCLTestImporter {
 			}
 
 			message = "";
-			return false;
+			return true;
 		}
 
 		bool GenerateAllProjectsOptionsAreValid (out string message)

--- a/tools/bcl-test-importer/BCLTestImporter/ApplicationOptions.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/ApplicationOptions.cs
@@ -43,6 +43,12 @@ namespace BCLTestImporter {
 			get => monoPath;
 			set => monoPath = FixPath (value);
 		}
+		string sdkDownload;
+		public string SDKDownloadPath
+		{
+			get => sdkDownload;
+			set => sdkDownload = FixPath (value);
+		}
 		public Platform Platform { get; set; }
 		string output;
 		public string Output {
@@ -337,7 +343,8 @@ namespace BCLTestImporter {
 		{
 			return new OptionSet { 
 				{ "mono-root=", "Root directory of the mono check out that will be use to search for the unit tests."
-					+ " Example: '/Users/test/xamarin-macios/external/mono'.", p => MonoPath = p }, 
+					+ " Example: '/Users/test/xamarin-macios/external/mono'.", p => MonoPath = p },
+				{ "sdk-download=", "Path where the downloaded SDK can be found.", p => SDKDownloadPath = p},
 				{ "iOS", "Specifies that the platform to which the projects are going to be build is iOS.", i => Platform = Platform.iOS },
 				{ "watchOS", "Specifies that the platform to which the projects are going to be build is watchOS.", w => Platform = Platform.WatchOS },
 				{ "tvOS", "Specifies that the platform to which the projects are going to be build is tvOS.", t => Platform = Platform.TvOS },

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -865,7 +865,6 @@ namespace BCLTestImporter {
 				Console.WriteLine ($"Was downloaded? {wasDownloaded}");
 				var testDir = wasDownloaded ? BCLTestAssemblyDefinition.GetTestDirectoryFromDownloadsPath (GetReleaseDownload (platform), platform)
 					: BCLTestAssemblyDefinition.GetTestDirectoryFromMonoPath (MonoRootPath, platform);
-				Console.WriteLine ($"Test direcotry is {testDir}");
 				var missingAssembliesPlatform = Directory.GetFiles (testDir, NUnitPattern).Select (Path.GetFileName).Union (
 					Directory.GetFiles (testDir, xUnitPattern).Select (Path.GetFileName)).ToList ();
 				

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -96,6 +96,8 @@ namespace BCLTestImporter {
 			(name:"SystemSecurityTests", assemblies: new [] {"monotouch_System.Security_test.dll"}),
 			(name:"SystemServiceModelTests", assemblies: new [] {"monotouch_System.ServiceModel_test.dll"}),
 			(name:"CorlibTests", assemblies: new [] {"monotouch_corlib_test.dll"}),
+			(name:"MonoDataSquilteTests", assemblies: new [] {"monotouch_Mono.Data.Sqlite_test.dll"}),
+			(name:"SystemWebServicesTests", assemblies: new [] {"monotouch_System.Web.Services_test.dll"}),
 
 			// XUNIT TESTS 
 
@@ -105,6 +107,13 @@ namespace BCLTestImporter {
 			(name:"SystemSecurityXunit", assemblies: new [] {"monotouch_System.Security_xunit-test.dll"}),
 			(name:"SystemLinqXunit", assemblies: new [] {"monotouch_System.Xml.Linq_xunit-test.dll"}),
 			(name:"SystemRuntimeCompilerServicesUnsafeXunit", assemblies: new [] {"monotouch_System.Runtime.CompilerServices.Unsafe_xunit-test.dll"}),
+			(name:"SystemComponentModelCompositionXunit", assemblies: new [] {"monotouch_System.ComponentModel.Composition_xunit-test.dll"}),
+			(name:"SystemCoreXunit", assemblies: new [] {"monotouch_System.Core_xunit-test.dll"}),
+			(name:"SystemRuntimeSerializationXunit", assemblies: new [] {"monotouch_System.Runtime.Serialization_xunit-test.dll"}),
+			(name:"SystemXmlXunit", assemblies: new [] {"monotouch_System.Xml_xunit-test.dll"}),
+			(name:"SystemXunit", assemblies: new [] {"monotouch_System_xunit-test.dll"}),
+			(name:"CorlibXunit", assemblies: new [] {"monotouch_corlib_xunit-test.dll"}),
+			(name:"MicrosoftCSharpXunit", assemblies: new [] {"monotouch_Microsoft.CSharp_xunit-test.dll"}),
 		};
 			
 		static readonly List <string> CommonIgnoredAssemblies = new List <string> {
@@ -853,8 +862,10 @@ namespace BCLTestImporter {
 		{
 			missingAssemblies = new Dictionary<Platform, List<string>> ();
 			foreach (var platform in new [] {Platform.iOS, Platform.TvOS}) {
-				var testDir = wasDownloaded ? BCLTestAssemblyDefinition.GetTestDirectoryFromMonoPath (MonoRootPath, platform)
-					: BCLTestAssemblyDefinition.GetTestDirectoryFromDownloadsPath (GetReleaseDownload (platform), platform); 
+				Console.WriteLine ($"Was downloaded? {wasDownloaded}");
+				var testDir = wasDownloaded ? BCLTestAssemblyDefinition.GetTestDirectoryFromDownloadsPath (GetReleaseDownload (platform), platform)
+					: BCLTestAssemblyDefinition.GetTestDirectoryFromMonoPath (MonoRootPath, platform);
+				Console.WriteLine ($"Test direcotry is {testDir}");
 				var missingAssembliesPlatform = Directory.GetFiles (testDir, NUnitPattern).Select (Path.GetFileName).Union (
 					Directory.GetFiles (testDir, xUnitPattern).Select (Path.GetFileName)).ToList ();
 				

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -862,7 +862,6 @@ namespace BCLTestImporter {
 		{
 			missingAssemblies = new Dictionary<Platform, List<string>> ();
 			foreach (var platform in new [] {Platform.iOS, Platform.TvOS}) {
-				Console.WriteLine ($"Was downloaded? {wasDownloaded}");
 				var testDir = wasDownloaded ? BCLTestAssemblyDefinition.GetTestDirectoryFromDownloadsPath (GetReleaseDownload (platform), platform)
 					: BCLTestAssemblyDefinition.GetTestDirectoryFromMonoPath (MonoRootPath, platform);
 				var missingAssembliesPlatform = Directory.GetFiles (testDir, NUnitPattern).Select (Path.GetFileName).Union (

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -601,7 +601,7 @@ namespace BCLTestImporter {
 		/// has its own details.</param>
 		/// <param name="generatedDir">The dir where the projects will be saved.</param>
 		/// <returns></returns>
-		async Task<List<(string name, string path, bool xunit, string failure)>> GenerateTestProjectsAsync (
+		public async Task<List<(string name, string path, bool xunit, string failure)>> GenerateTestProjectsAsync (
 			IEnumerable<(string name, string[] assemblies)> projects, Platform platform, string generatedDir)
 		{
 			var result = new List<(string name, string path, bool xunit, string failure)> ();

--- a/tools/bcl-test-importer/BCLTestImporter/Program.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/Program.cs
@@ -202,7 +202,10 @@ namespace BCLTestImporter {
 				}
 				else {
 					var projectGenerator = new BCLTestProjectGenerator (appOptions.Output, appOptions.MonoPath,
-						appOptions.ProjectTemplate, appOptions.RegisterTypeTemplate, appOptions.PlistTemplate);
+						appOptions.ProjectTemplate, appOptions.RegisterTypeTemplate, appOptions.PlistTemplate) {
+						iOSMonoSDKPath = appOptions.SDKDownloadPath
+					};
+					//projectGenerator.iOSMonoSDKPath 
 					outputWriter.WriteLine ("Verifying if all the test assemblies have been added.");
 					if (!appOptions.IgnoreMissingAssemblies && !projectGenerator.AllTestAssembliesAreRan (out var missingAssemblies, true)) {
 						outputWriter.WriteLine ("The following test assemblies should be added to a test project or ignored.");

--- a/tools/bcl-test-importer/BCLTestImporter/Program.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/Program.cs
@@ -165,14 +165,18 @@ namespace BCLTestImporter {
 					info.Add (assemblyInfo);
 					outputWriter.WriteLine ($"Ref will be added for assembly: '{assemblyInfo.assembly}' hintPath: '{assemblyInfo.hintPath}'");
 				}
-				var generatedProject = BCLTestProjectGenerator.Generate (appOptions.ProjectName, appOptions.RegisterTypesPath,
-					info, appOptions.RegisterTypeTemplate, appOptions.PlistTemplate);
-				outputWriter.WriteLine ("Generated project is:");
-				outputWriter.WriteLine (generatedProject);
-				
-				using (var file = new StreamWriter (appOptions.Output, !appOptions.Override)) { // false is do not append
-					file.Write (generatedProject);
+				// build a project list with the single project that was added
+				var projectInfo = new List<(string name, string [] assemblies)> ();
+				projectInfo.Add ((appOptions.ProjectName, appOptions.TestAssemblies.ToArray ()));
+				string outputDir = Path.GetDirectoryName (appOptions.Output);
+				var generator = new BCLTestProjectGenerator (outputDir, appOptions.MonoPath, appOptions.ProjectTemplate, appOptions.RegisterTypesPath, appOptions.PlistTemplate);
+				var generatedProject = generator.GenerateTestProjectsAsync (projectInfo, appOptions.Platform, outputDir).Result;
+				// check if it was generated and did not get any errors
+				if (generatedProject.Count == 0) {
+					outputWriter.WriteError ("Internal error, the project was not generated.");
+					return 1;
 				}
+				outputWriter.WriteLine ($"Project generated too {generatedProject [0].path}");
 				return 0;
 			} else if (appOptions.GenerateTypeRegister) {
 				outputWriter.WriteLine ("Generating type register.");
@@ -182,8 +186,8 @@ namespace BCLTestImporter {
 					outputWriter.WriteLine ($"Assembly path is {path}");
 					fixedTestAssemblies.Add (path);
 				}
-				var typesPerAssembly = GetTypeForAssemblies (fixedTestAssemblies, appOptions.Verbose);
-				var generatedCode = RegisterTypeGenerator.GenerateCode (typesPerAssembly, appOptions.IsXUnit, appOptions.RegisterTypeTemplate);
+				var typesPerAssembly = ("", GetTypeForAssemblies (fixedTestAssemblies, appOptions.Verbose));
+				var generatedCode = RegisterTypeGenerator.GenerateCodeAsync (typesPerAssembly, appOptions.IsXUnit, appOptions.RegisterTypeTemplate).Result;
 				outputWriter.WriteLine ("Generated code is:");
 				outputWriter.WriteLine (generatedCode);
 				using (var file = new StreamWriter (appOptions.Output, !appOptions.Override)) { // false is do not append


### PR DESCRIPTION
Fixed the rule to generate the tests. This branch adds missing test dlls that the make rule check, or it will give an error stating that tests are missing.

This feature should be added to xharness and an issue was created for that:  https://github.com/xamarin/maccore/issues/1447

Fixes https://github.com/xamarin/xamarin-macios/issues/5638