### PR TITLE
[xcode10.2] [OpenGL] Fix MonoMacGameView .ctor when hardware acceleration isn't available

### DIFF
--- a/src/OpenGL/MonoMacGameView.cs
+++ b/src/OpenGL/MonoMacGameView.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Drawing;
 using System.ComponentModel;
+using System.Linq;
 
 using Foundation;
 using AppKit;
@@ -73,7 +74,14 @@ namespace OpenTK.Platform.MacOS
 				NSOpenGLPixelFormatAttribute.ColorSize, 24,
 				NSOpenGLPixelFormatAttribute.DepthSize, 16 };
 
-			pixelFormat = new NSOpenGLPixelFormat (attribs);
+			try {
+				pixelFormat = new NSOpenGLPixelFormat (attribs);
+			} catch (Exception) {
+				// Fails on VM because there is no hardware-acceleration
+				// https://github.com/xamarin/xamarin-macios/issues/4417
+				attribs = attribs.Skip (1).ToArray ();
+				pixelFormat = new NSOpenGLPixelFormat (attribs);
+			}
 
 			if (pixelFormat == null)
 				Console.WriteLine ("No OpenGL pixel format");

--- a/src/OpenGL/MonoMacGameView.cs
+++ b/src/OpenGL/MonoMacGameView.cs
@@ -29,7 +29,6 @@
 using System;
 using System.Drawing;
 using System.ComponentModel;
-using System.Linq;
 
 using Foundation;
 using AppKit;
@@ -68,18 +67,21 @@ namespace OpenTK.Platform.MacOS
 		public MonoMacGameView (CGRect frame, NSOpenGLContext context) : base(frame)
 		{
 			var attribs = new object [] {
-				NSOpenGLPixelFormatAttribute.Accelerated,
 				NSOpenGLPixelFormatAttribute.NoRecovery,
 				NSOpenGLPixelFormatAttribute.DoubleBuffer,
-				NSOpenGLPixelFormatAttribute.ColorSize, 24,
-				NSOpenGLPixelFormatAttribute.DepthSize, 16 };
+				NSOpenGLPixelFormatAttribute.ColorSize,
+				24,
+				NSOpenGLPixelFormatAttribute.DepthSize,
+				16,
+				NSOpenGLPixelFormatAttribute.Accelerated,
+			};
 
 			try {
 				pixelFormat = new NSOpenGLPixelFormat (attribs);
 			} catch (Exception) {
-				// Fails on VM because there is no hardware-acceleration
-				// https://github.com/xamarin/xamarin-macios/issues/4417
-				attribs = attribs.Skip (1).ToArray ();
+				// Fails on VM because there is no hardware-acceleration -> https://github.com/xamarin/xamarin-macios/issues/4417
+				// Therefore, remove 'NSOpenGLPixelFormatAttribute.Accelerated' and try again
+				attribs [attribs.Length - 1] = 0;
 				pixelFormat = new NSOpenGLPixelFormat (attribs);
 			}
 


### PR DESCRIPTION
- Fixes #4417: [XM] Add a `Create` method for the 'AppKit.NSOpenGLPixelFormat' type
  (https://github.com/xamarin/xamarin-macios/issues/4417)
- Doing `new MonoMacGameView (ContentView.Frame)` on CI fails because hardware acceleration isn't available.
  One of our samples had that code: https://github.com/xamarin/mac-samples/blob/a41f4387dc28617e4207b3759617e788aad383ed/MacOpenTK/MacOpenTK/MainWindow.cs#L40
  This made some QA sample tests fail.

Backport of #5614.

/cc @VincentDondain 