### PR TITLE
[Tests] Fix failing mtouch tests after bcl test were removed.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2508,7 +2508,7 @@ public class B
 		[TestCase (Target.Dev, Profile.iOS, "link sdk", "Release64")]
 		[TestCase (Target.Dev, Profile.iOS, "monotouch-test", "Release64")]
 		[TestCase (Target.Dev, Profile.iOS, "mscorlib", "Release64")]
-		[TestCase (Target.Dev, Profile.iOS, "System.Core", "Release64")]
+		[TestCase (Target.Dev, Profile.iOS, "System.Data", "Release64")]
 		public void BuildTestProject (Target target, Profile profile, string testname, string configuration)
 		{
 			if (target == Target.Dev)


### PR DESCRIPTION
After commit 2619d8f5ca1ce6c1d82eac5c796f52d18c1b8ca1 the System.Core
tests does not longer exists. Which makes the mtouch test that depends
on it, fail too. This changes the test to use a present test.