### PR TITLE
Fix ARM64-based CPU detection logic; take #3.

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -259,6 +259,7 @@ namespace ObjCRuntime {
 #if !XAMMAC_SYSTEM_MONO
 			UseAutoreleasePoolInThreadPool = true;
 #endif
+			IsARM64CallingConvention = GetIsARM64CallingConvention (); // Can only be done after Runtime.Arch is set (i.e. InitializePlatform has been called).
 
 			objc_exception_mode = options->MarshalObjectiveCExceptionMode;
 			managed_exception_mode = options->MarshalManagedExceptionMode;
@@ -1739,7 +1740,7 @@ namespace ObjCRuntime {
 		[DllImport (Constants.libSystemLibrary)]
 		static unsafe extern NXArchInfo* NXGetLocalArchInfo ();
 
-		public readonly static bool IsARM64CallingConvention = GetIsARM64CallingConvention ();
+		public static bool IsARM64CallingConvention;
 
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		static bool GetIsARM64CallingConvention ()


### PR DESCRIPTION
The previous implementation was broken, because:

* We called GetIsARM64CallingConvention in Runtime's static constructor.
* Runtime.Arch hadn't been set yet in the static constructor, which means it
  was Arch.DEVICE (0).
* This meant GetIsARM64CallingConvention would return true on iOS/tvOS x86-64
  simulator.

So delay the initialization of the IsARM64CallingConvention field until we've
been initialized.