### PR TITLE
Improve MachO support to read LC_BUILD_VERSION and static libraries.

### DIFF
--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -1589,6 +1589,16 @@ The format of a file can be verified using the `file` command from a terminal:
 
     file -arch all -l /path/to/file
 
+### MT1605: Invalid entry * in the static library *: *
+
+An error occurred while processing the MachO file in question.
+
+Please make sure the file is a valid Mach-O static library.
+
+The format of a file can be verified using the `file` command from a terminal:
+
+    file -arch all -l /path/to/file
+
 ## MT2xxx: Linker error messages
 
 <!--

--- a/tests/common/ProductTests.cs
+++ b/tests/common/ProductTests.cs
@@ -38,15 +38,15 @@ namespace Xamarin.Tests
 		}
 
 		[Test]
-		[TestCase (Profile.macOSSystem, MachO.LoadCommands.MinMacOSX, MachO.Platform.PLATFORM_MACOS)]
-		[TestCase (Profile.macOSFull, MachO.LoadCommands.MinMacOSX, MachO.Platform.PLATFORM_MACOS)]
-		[TestCase (Profile.macOSMobile, MachO.LoadCommands.MinMacOSX, MachO.Platform.PLATFORM_MACOS)]
-		[TestCase (Profile.iOS, MachO.LoadCommands.MiniPhoneOS, MachO.Platform.PLATFORM_IOSSIMULATOR, false)]
-		[TestCase (Profile.iOS, MachO.LoadCommands.MiniPhoneOS, MachO.Platform.PLATFORM_IOS, true)]
-		[TestCase (Profile.watchOS, MachO.LoadCommands.MinwatchOS, MachO.Platform.PLATFORM_WATCHOSSIMULATOR, false)]
-		[TestCase (Profile.watchOS, MachO.LoadCommands.MinwatchOS, MachO.Platform.PLATFORM_WATCHOS, true)]
-		[TestCase (Profile.tvOS, MachO.LoadCommands.MintvOS, MachO.Platform.PLATFORM_TVOSSIMULATOR, false)]
-		[TestCase (Profile.tvOS, MachO.LoadCommands.MintvOS, MachO.Platform.PLATFORM_TVOS, true)]
+		[TestCase (Profile.macOSSystem, MachO.LoadCommands.MinMacOSX, MachO.Platform.MacOS)]
+		[TestCase (Profile.macOSFull, MachO.LoadCommands.MinMacOSX, MachO.Platform.MacOS)]
+		[TestCase (Profile.macOSMobile, MachO.LoadCommands.MinMacOSX, MachO.Platform.MacOS)]
+		[TestCase (Profile.iOS, MachO.LoadCommands.MiniPhoneOS, MachO.Platform.IOSSimulator, false)]
+		[TestCase (Profile.iOS, MachO.LoadCommands.MiniPhoneOS, MachO.Platform.IOS, true)]
+		[TestCase (Profile.watchOS, MachO.LoadCommands.MinwatchOS, MachO.Platform.WatchOSSimulator, false)]
+		[TestCase (Profile.watchOS, MachO.LoadCommands.MinwatchOS, MachO.Platform.WatchOS, true)]
+		[TestCase (Profile.tvOS, MachO.LoadCommands.MintvOS, MachO.Platform.TvOSSimulator, false)]
+		[TestCase (Profile.tvOS, MachO.LoadCommands.MintvOS, MachO.Platform.TvOS, true)]
 		public void MinOSVersion (Profile profile, MachO.LoadCommands load_command, MachO.Platform platform, bool device = false)
 		{
 			if (device)

--- a/tools/common/MachO.cs
+++ b/tools/common/MachO.cs
@@ -138,14 +138,14 @@ namespace Xamarin
 		}
 
 		public enum Platform : uint {
-			PLATFORM_MACOS = 1,
-			PLATFORM_IOS = 2,
-			PLATFORM_TVOS = 3,
-			PLATFORM_WATCHOS = 4,
-			PLATFORM_BRIDGEOS = 5,
-			PLATFORM_IOSSIMULATOR = 7,
-			PLATFORM_TVOSSIMULATOR = 8,
-			PLATFORM_WATCHOSSIMULATOR = 9,
+			MacOS = 1,
+			IOS = 2,
+			TvOS = 3,
+			WatchOS = 4,
+			BridgeOS = 5,
+			IOSSimulator = 7,
+			TvOSSimulator = 8,
+			WatchOSSimulator = 9,
 		}
 
 		internal static uint FromBigEndian (uint number)


### PR DESCRIPTION
* Add support for reading LC_BUILD_VERSION. This is needed to properly process
  Mach-O files with a recent minOS version.
* Add support for reading Mach-O files inside ar archives.
* Augment ProductTests.MinOSVersion to test static libraries as well.