### PR TITLE
[XHarness] Reneable the System.Transaction tests on Mac OS X.

### DIFF
--- a/tests/bcl-test/BCLTests/macOSModern-SystemTransactionsTests.ignore
+++ b/tests/bcl-test/BCLTests/macOSModern-SystemTransactionsTests.ignore
@@ -1,0 +1,90 @@
+# System.TypeLoadException : Could not set up parent class, due to: Could not load type of field 'System.Configuration.ConfigurationSection:section_handler' (1) due to: Could not resolve type with token 01000051 from typeref 
+MonoTests.System.Transactions.TransactionScopeTest.TransactionScopeWithInvalidTimeSpanThrows
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction8a
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction8
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction6e
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction6d
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction6c
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction6b
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction6a
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction10b
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction10a
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction10
+MonoTests.System.Transactions.EnlistTest.Vol2_Rollback
+MonoTests.System.Transactions.EnlistTest.Vol2_Dur1_Fail5
+MonoTests.System.Transactions.EnlistTest.Vol2_Dur1_Fail4
+MonoTests.System.Transactions.EnlistTest.Vol2_Dur1_Fail3
+MonoTests.System.Transactions.EnlistTest.Vol2_Dur1_Fail1
+MonoTests.System.Transactions.EnlistTest.Vol2_Dur1
+MonoTests.System.Transactions.EnlistTest.Vol2_Dur0_SPC
+MonoTests.System.Transactions.EnlistTest.Vol2_Committed
+MonoTests.System.Transactions.EnlistTest.Vol1_Rollback
+MonoTests.System.Transactions.EnlistTest.Vol1_Dur0_Pspe1
+MonoTests.System.Transactions.EnlistTest.Vol1_Dur0_Fail3
+MonoTests.System.Transactions.EnlistTest.Vol1_Dur0_Fail2
+MonoTests.System.Transactions.EnlistTest.Vol1_Dur0_Fail1
+MonoTests.System.Transactions.EnlistTest.Vol1_Dur0_2PC
+MonoTests.System.Transactions.EnlistTest.Vol1_Dur0
+MonoTests.System.Transactions.EnlistTest.Vol1_Committed
+MonoTests.System.Transactions.EnlistTest.Vol0_Dur1_Pspe1
+MonoTests.System.Transactions.EnlistTest.Vol0_Dur1_Fail
+MonoTests.System.Transactions.EnlistTest.Vol0_Dur1
+MonoTests.System.Transactions.EnlistTest.Vol0_Dur0_Pspe2
+MonoTests.System.Transactions.EnlistTest.Vol2SPC_Committed
+MonoTests.System.Transactions.EnlistTest.Vol1SPC_Committed
+MonoTests.System.Transactions.EnlistTest.Vol0_Dur0_Pspe1
+MonoTests.System.Transactions.EnlistTest.TransactionDispose3
+MonoTests.System.Transactions.EnlistTest.TransactionCompleted_Rollback
+MonoTests.System.Transactions.EnlistTest.TransactionCompleted_Committed
+
+# Expected: System.InvalidOperationException
+# but was: System.TypeInitializationException : The type initializer for 'System.Transactions.TransactionScope' threw an exception.
+MonoTests.System.Transactions.TransactionScopeTest.TransactionScopeCompleted3
+MonoTests.System.Transactions.TransactionScopeTest.TransactionScopeCompleted2
+MonoTests.System.Transactions.TransactionScopeTest.TransactionScopeCompleted1
+
+#  Ambient transaction exists (before)
+# Expected: null
+# But was:  <System.Transactions.CommittableTransaction>
+MonoTests.System.Transactions.TransactionScopeTest.TransactionScopeCommit
+MonoTests.System.Transactions.TransactionScopeTest.TransactionScopeAbort
+MonoTests.System.Transactions.TransactionScopeTest.RMFail2
+MonoTests.System.Transactions.TransactionScopeTest.RMFail1
+MonoTests.System.Transactions.TransactionScopeTest.NestedTransactionScope9
+MonoTests.System.Transactions.TransactionScopeTest.NestedTransactionScope8a
+MonoTests.System.Transactions.TransactionScopeTest.NestedTransactionScope8
+MonoTests.System.Transactions.TransactionScopeTest.NestedTransactionScope7
+MonoTests.System.Transactions.TransactionScopeTest.NestedTransactionScope6
+MonoTests.System.Transactions.TransactionScopeTest.NestedTransactionScope5
+MonoTests.System.Transactions.TransactionScopeTest.NestedTransactionScope4
+MonoTests.System.Transactions.TransactionScopeTest.NestedTransactionScope3
+MonoTests.System.Transactions.TransactionScopeTest.NestedTransactionScope2
+MonoTests.System.Transactions.TransactionScopeTest.NestedTransactionScope13
+MonoTests.System.Transactions.TransactionScopeTest.NestedTransactionScope12
+MonoTests.System.Transactions.TransactionScopeTest.NestedTransactionScope10
+MonoTests.System.Transactions.TransactionScopeTest.NestedTransactionScope1
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransactionRollback 
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransactionCommit
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction5
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction4
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction3
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction2
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction16
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction15
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction14
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction13
+MonoTests.System.Transactions.TransactionScopeTest.ExplicitTransaction1
+
+# Expected: 1
+#  But was:  0
+MonoTests.System.Transactions.EnlistTest.Vol2_Throwing_On_Second_Prepare
+MonoTests.System.Transactions.EnlistTest.Vol2_Throwing_On_Rollback
+MonoTests.System.Transactions.EnlistTest.Vol2_Throwing_On_First_Rollback_And_Second_Prepare
+MonoTests.System.Transactions.EnlistTest.Vol2_Throwing_On_First_Prepare_And_Second_Rollback
+MonoTests.System.Transactions.EnlistTest.Vol2_Throwing_On_First_Prepare
+MonoTests.System.Transactions.EnlistTest.Vol2_Throwing_On_Commit
+MonoTests.System.Transactions.EnlistTest.Vol2SPC_Throwing_On_Commit
+MonoTests.System.Transactions.EnlistTest.Vol1SPC_Throwing_On_Commit
+MonoTests.System.Transactions.EnlistTest.Vol1_Throwing_On_Rollback
+MonoTests.System.Transactions.EnlistTest.Vol1_Throwing_On_Prepare
+MonoTests.System.Transactions.EnlistTest.Vol1_Throwing_On_Commit

--- a/tests/bcl-test/BCLTests/templates/macOS/MacTestMain.cs
+++ b/tests/bcl-test/BCLTests/templates/macOS/MacTestMain.cs
@@ -77,6 +77,11 @@ namespace Xamarin.Mac.Tests
 			}
 			
 			runner.SkipCategories (categories);
+			var skippedTests = IgnoreFileParser.ParseContentFiles (NSBundle.MainBundle.ResourcePath);
+			if (skippedTests.Any ()) {
+				// ensure that we skip those tests that have been passed via the ignore files
+				runner.SkipTests (skippedTests);
+			}
 			runner.Run (testAssemblies.ToList ());
 
 			if (options.ResultFile != null) {

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -201,7 +201,6 @@ namespace BCLTestImporter {
 			"xammac_net_4_5_System.Security_test.dll", // issue https://github.com/xamarin/maccore/issues/1197
 			"xammac_net_4_5_System.ServiceModel_test.dll", // issues https://github.com/xamarin/maccore/issues/1198
 			"xammac_net_4_5_System_test.dll", // issues https://github.com/xamarin/maccore/issues/1199
-			"xammac_net_4_5_System.Transactions_test.dll", // issues https://github.com/xamarin/maccore/issues/1200
 			"xammac_net_4_5_System.Xml_test.dll", // issues https://github.com/xamarin/maccore/issues/1201 and https://github.com/xamarin/maccore/issues/1202
 			"xammac_net_4_5_corlib_xunit-test.dll", // issues https://github.com/xamarin/maccore/issues/1203
 			"xammac_net_4_5_System.Core_xunit-test.dll", // issue https://github.com/xamarin/maccore/issues/1204
@@ -361,18 +360,19 @@ namespace BCLTestImporter {
 
 		internal static string GetCommonIgnoreFileName (string projectName) => $"common-{projectName}.ignore";
 		
-		internal static string GetIgnoreFileName (string projectName, Platform platform)
+		internal static string[] GetIgnoreFileNames (string projectName, Platform platform)
 		{
 			switch (platform) {
 			case Platform.iOS:
-				return $"iOS-{projectName}.ignore";
+				return new string [] { $"iOS-{projectName}.ignore" };
 			case Platform.MacOSFull:
+				return new string [] { $"macOSFull-{projectName}.ignore", $"macOS-{projectName}.ignore" };
 			case Platform.MacOSModern:
-				return $"macOS-{projectName}.ignore";
+				return new string [] { $"macOSModern-{projectName}.ignore", $"macOS-{projectName}.ignore" };
 			case Platform.TvOS:
-				return $"tvOS-{projectName}.ignore";
+				return new string [] { $"tvOS-{projectName}.ignore" };
 			case Platform.WatchOS:
-				return $"watchOS-{projectName}.ignore";
+				return new string [] { $"watchOS-{projectName}.ignore" };
 			default:
 				return null;
 			}
@@ -386,9 +386,11 @@ namespace BCLTestImporter {
 			var commonIgnore = Path.Combine (templateDir, GetCommonIgnoreFileName (projectName));
 			if (File.Exists (commonIgnore))
 				yield return commonIgnore;
-			var platformIgnore = Path.Combine (templateDir, GetIgnoreFileName (projectName, platform));
-			if (File.Exists (platformIgnore))
-				yield return platformIgnore;
+			foreach (var platformFile in GetIgnoreFileNames (projectName, platform)) {
+				var platformIgnore = Path.Combine (templateDir, platformFile);
+				if (File.Exists (platformIgnore))
+					yield return platformIgnore;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
Reenable the tests and ensure that the failing ones on Modern are
ignored. The bcl tests on mac os x can now make a diff between the
version (Moder/Full) to ignore files so that tests that work in a
version are not ignored in the other one.

Fixes https://github.com/xamarin/maccore/issues/1200