### PR TITLE
[d16-0] [xm] Support UseHardenendRuntime in code signing

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -247,7 +247,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			SigningKey="$(_CodeSigningKey)"
 			ExtraArgs="$(CodesignExtraArgs)"
 			IsAppExtension="$(IsAppExtension)"
-			UseHardenendRuntime="$(UseHardenendRuntime)"
+			UseHardenedRuntime="$(UseHardenedRuntime)"
 			>
 		</Codesign>
 	</Target>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -247,6 +247,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			SigningKey="$(_CodeSigningKey)"
 			ExtraArgs="$(CodesignExtraArgs)"
 			IsAppExtension="$(IsAppExtension)"
+			UseHardenendRuntime="$(UseHardenendRuntime)"
 			>
 		</Codesign>
 	</Target>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
@@ -45,6 +45,8 @@ namespace Xamarin.MacDev.Tasks
 
 		public bool IsAppExtension { get; set; }
 
+		public bool UseHardenendRuntime { get; set; }
+
 		public string ToolExe {
 			get { return toolExe ?? ToolName; }
 			set { toolExe = value; }
@@ -92,6 +94,9 @@ namespace Xamarin.MacDev.Tasks
 
 			if (IsAppExtension)
 				args.Add ("--deep");
+
+			if (UseHardenendRuntime)
+				args.Add ("-o runtime");
 
 			args.Add ("--sign");
 			args.AddQuoted (SigningKey);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
@@ -45,7 +45,7 @@ namespace Xamarin.MacDev.Tasks
 
 		public bool IsAppExtension { get; set; }
 
-		public bool UseHardenendRuntime { get; set; }
+		public bool UseHardenedRuntime { get; set; }
 
 		public string ToolExe {
 			get { return toolExe ?? ToolName; }
@@ -95,7 +95,7 @@ namespace Xamarin.MacDev.Tasks
 			if (IsAppExtension)
 				args.Add ("--deep");
 
-			if (UseHardenendRuntime)
+			if (UseHardenedRuntime)
 				args.Add ("-o runtime");
 
 			args.Add ("--sign");

--- a/tests/common/mac/ProjectTestHelpers.cs
+++ b/tests/common/mac/ProjectTestHelpers.cs
@@ -587,7 +587,15 @@ namespace TestCase
 				Console.WriteLine (output);
 				Assert.Fail ($"'nuget restore' failed for {project}");
 			}
-		} 
+		}
+
+		public static bool InJenkins
+		{
+			get {
+				var buildRev = Environment.GetEnvironmentVariable ("BUILD_REVISION");
+				return !string.IsNullOrEmpty (buildRev) && buildRev == "jenkins";
+			}
+		}
 	}
 
 	static class PlatformHelpers

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -712,7 +712,7 @@ namespace Xamarin.MMP.Tests
 				string baseCodesign = findCodesign (baseOutput);
 				Assert.False (baseCodesign.Contains ("-o runtime"), "Base codesign");
 
-				test.CSProjConfig += "<UseHardenendRuntime>true</UseHardenendRuntime><CodeSignEntitlements>Entitlements.plist</CodeSignEntitlements>";
+				test.CSProjConfig += "<UseHardenedRuntime>true</UseHardenedRuntime><CodeSignEntitlements>Entitlements.plist</CodeSignEntitlements>";
 
 				const string entitlementText = @"<?xml version=""1.0"" encoding=""UTF-8"" ?>
 <!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -701,6 +701,10 @@ namespace Xamarin.MMP.Tests
 		[Test]
 		public void HardenedRuntimeCodesignOption ()
 		{
+			// https://github.com/xamarin/xamarin-macios/issues/5653
+			if (TI.InJenkins)
+				Assert.Ignore ("Requires macOS entitlements on bots.");
+
 			RunMMPTest (tmpDir => {
 				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
 					CSProjConfig = "<EnableCodeSigning>true</EnableCodeSigning>"


### PR DESCRIPTION
- https://github.com/xamarin/xamarin-macios/issues/4288

There is some IDE work needed to full support hardened runtime, but this is enough to allow people to support it if they are willing to use a text editor on their csproj.

Backport of #5536.

/cc @chamons 