### PR TITLE
[XHarness] Fix makefile to take into account the importer sources.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -202,7 +202,7 @@ $(TOP)/tools/mtouch/SdkVersions.cs: $(TOP)/tools/common/SdkVersions.cs.in
 	nuget restore bcl-test/BCLTests/BCLTests.csproj
 	$(Q) touch $@
 
-xharness/xharness.exe: $(wildcard xharness/*.cs) xharness/xharness.csproj $(TOP)/tools/mtouch/SdkVersions.cs test.config test-system.config .stamp-src-project-files
+xharness/xharness.exe: $(wildcard xharness/*.cs) $(wildcard $(TOP)/tools/bcl-test-importer/BCLTestImporter/*.cs) xharness/xharness.csproj $(TOP)/tools/mtouch/SdkVersions.cs test.config test-system.config .stamp-src-project-files
 	nuget restore xharness/xharness.csproj
 	$(Q_GEN) $(SYSTEM_MSBUILD) $(MSBUILD_VERBOSITY_QUIET) xharness/xharness.csproj
 


### PR DESCRIPTION
Ensure that when the importer sources are changed, xharness is
recompiled.