### PR TITLE
[Xharness] Reenable System.Data.Sqlite tests on mac os x.

### DIFF
--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectDefinitionWorkaround.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectDefinitionWorkaround.cs
@@ -19,7 +19,7 @@ namespace BCLTestImporter
 					(assembly:"System.Core", hint:"{MONO_ROOT}mcs/class/lib/xammac_net_4_5/System.Core.dll"),
 					(assembly:"xammac_net_4_5_Mono.CSharp_test.dll", hint:"{MONO_ROOT}mcs/class/lib/xammac_net_4_5/tests/xammac_net_4_5_Mono.CSharp_test.dll"),
 				}},
-				{"MonoDataSqilteTests", new List<(string assembly, string hint)> {
+				{"MonoDataSqliteTests", new List<(string assembly, string hint)> {
 					(assembly:"mscorlib", hint:"{MONO_ROOT}mcs/class/lib/xammac_net_4_5/mscorlib.dll"),
 					(assembly:"nunitlite", hint:"{MONO_ROOT}mcs/class/lib/xammac_net_4_5/nunitlite.dll"),
 					(assembly:"Mono.Data.Sqlite", hint:"{MONO_ROOT}mcs/class/lib/xammac_net_4_5/Mono.Data.Sqlite.dll"),

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -97,7 +97,7 @@ namespace BCLTestImporter {
 			(name:"SystemSecurityTests", assemblies: new [] {"monotouch_System.Security_test.dll"}),
 			(name:"SystemServiceModelTests", assemblies: new [] {"monotouch_System.ServiceModel_test.dll"}),
 			(name:"CorlibTests", assemblies: new [] {"monotouch_corlib_test.dll"}),
-			(name:"MonoDataSquilteTests", assemblies: new [] {"monotouch_Mono.Data.Sqlite_test.dll"}),
+			(name:"MonoDataSqliteTests", assemblies: new [] {"monotouch_Mono.Data.Sqlite_test.dll"}),
 			(name:"SystemWebServicesTests", assemblies: new [] {"monotouch_System.Web.Services_test.dll"}),
 
 			// XUNIT TESTS 
@@ -146,7 +146,7 @@ namespace BCLTestImporter {
 		
 			// NUNIT Projects
 			(name:"MonoCSharpTests", assemblies: new [] {"xammac_net_4_5_Mono.CSharp_test.dll"}),
-			(name:"MonoDataSqilteTests", assemblies: new [] {"xammac_net_4_5_Mono.Data.Sqlite_test.dll"}),
+			(name:"MonoDataSqliteTests", assemblies: new [] {"xammac_net_4_5_Mono.Data.Sqlite_test.dll"}),
 			(name:"MonoDataTdsTests", assemblies: new [] {"xammac_net_4_5_Mono.Data.Tds_test.dll"}),
 			(name:"MonoPoxisTests", assemblies: new [] {"xammac_net_4_5_Mono.Posix_test.dll"}),
 			(name:"MonoSecurityTests", assemblies: new [] {"xammac_net_4_5_Mono.Security_test.dll"}),
@@ -190,7 +190,6 @@ namespace BCLTestImporter {
 			"xammac_net_4_5_I18N.Rare_test.dll",
 			"xammac_net_4_5_I18N.West_test.dll",
 			"xammac_net_4_5_Mono.CSharp_test.dll", //issue https://github.com/xamarin/maccore/issues/1186 
-			"xammac_net_4_5_Mono.Data.Sqlite_test.dll", // issue https://github.com/xamarin/maccore/issues/1187
 			"xammac_net_4_5_Mono.Posix_test.dll", // issue https://github.com/xamarin/maccore/issues/1188
 			"xammac_net_4_5_Mono.Posix_test.dll", // issues https://github.com/xamarin/maccore/issues/1189 and https://github.com/xamarin/maccore/issues/1190
 			"xammac_net_4_5_System.Core_test.dll", // issue https://github.com/xamarin/maccore/issues/1191

--- a/tools/bcl-test-importer/BCLTestImporter/RegisterTypeGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/RegisterTypeGenerator.cs
@@ -17,7 +17,7 @@ namespace BCLTestImporter {
 		// we will remove the dict and we will use the refection based method.
 		static Dictionary<string, (string testNamespace, string testAssembly, string testType)> macCache = new Dictionary<string, (string testNamespace, string testAssembly, string testType)> {
 			{"MonoCSharpTests", ("MonoTests.Visit",  "xammac_net_4_5_Mono.CSharp_test.dll", "MonoTests.Visit.ASTVisitorTest")},
-			{"MonoDataSqilteTests", ("MonoTests.Mono.Data.Sqlite",  "xammac_net_4_5_Mono.Data.Sqlite_test.dll", "MonoTests.Mono.Data.Sqlite.SqliteiOS82BugTests")},
+			{"MonoDataSqliteTests", ("MonoTests.Mono.Data.Sqlite",  "xammac_net_4_5_Mono.Data.Sqlite_test.dll", "MonoTests.Mono.Data.Sqlite.SqliteiOS82BugTests")},
 			{"MonoDataTdsTests", ("MonoTests.Mono.Data.Tds",  "xammac_net_4_5_Mono.Data.Tds_test.dll", "MonoTests.Mono.Data.Tds.TdsConnectionPoolTest")},
 			{"MonoPoxisTests", ("MonoTests.System.IO",  "xammac_net_4_5_Mono.Posix_test.dll", "MonoTests.System.IO.StdioFileStreamTest")},
 			{"MonoSecurityTests", ("MonoTests.System.Security.Cryptography",  "xammac_net_4_5_Mono.Security_test.dll", "MonoTests.System.Security.Cryptography.SHA224ManagedTest")},


### PR DESCRIPTION
Tests are reenabled and a small typo fixed.

Fixes https://github.com/xamarin/maccore/issues/1187