### PR TITLE
[generator] Fix CMSampleBuffer usage in 3rd party bindings

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1618,7 +1618,10 @@ public partial class Generator : IMemberGatherer {
 				// special case (false) so it needs to be before the _real_ INativeObject check
 				if (pi.ParameterType == SampleBufferType){
 					pars.AppendFormat ("IntPtr {0}", pi.Name.GetSafeParamName ());
-					invoke.AppendFormat ("{0} == IntPtr.Zero ? null : new CMSampleBuffer ({0}, false)", pi.Name.GetSafeParamName ());
+					if (BindThirdPartyLibrary)
+						invoke.AppendFormat ("{0} == IntPtr.Zero ? null : Runtime.GetINativeObject<CMSampleBuffer> ({0}, false)", pi.Name.GetSafeParamName ());
+					else
+						invoke.AppendFormat ("{0} == IntPtr.Zero ? null : new CMSampleBuffer ({0}, false)", pi.Name.GetSafeParamName ());
 					continue;
 				}
 			}

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -586,6 +586,9 @@ namespace GeneratorTests
 			bgen.AssertWarning (1118, "[NullAllowed] should not be used on methods, like 'Void set_Setter(Foundation.NSString)', but only on properties, parameters and return values.");
 		}
 
+		[Test]
+		public void GHIssue5692 () => BuildFile (Profile.iOS, "ghissue5692.cs");
+
 		BGenTool BuildFile (Profile profile, params string [] filenames)
 		{
 			return BuildFile (profile, true, false, filenames);

--- a/tests/generator/ghissue5692.cs
+++ b/tests/generator/ghissue5692.cs
@@ -1,0 +1,13 @@
+using System;
+using Foundation;
+using ObjCRuntime;
+using CoreMedia;
+
+namespace GHIssue5692 {
+
+	[BaseType (typeof (NSObject))]
+	interface Foo {
+		[Export ("enumerateSampleBuffers:")]
+		void Enumerate (Action<CMSampleBuffer, NSError> handler);
+	}
+}


### PR DESCRIPTION
Fixes xamarin/xamarin-macios#5692

3rd party bindings cannot use the `.ctor(IntPtr, bool)` of
`CMSampleBuffer` because it is `private`, they must use
`Runtime.GetINativeObject<T> (IntPtr, bool)` instead.