### PR TITLE
[XHarness] Reenable SystemServiceModelTests on mac os x.

### DIFF
--- a/tests/bcl-test/BCLTests/macOS-SystemServiceModelTests.ignore
+++ b/tests/bcl-test/BCLTests/macOS-SystemServiceModelTests.ignore
@@ -1,0 +1,16 @@
+# System.IO.DirectoryNotFoundException : Could not find a part of the path
+ MonoTests.System.ServiceModel.WrappedKeySecurityTokenTest.X509WrappingToken1
+ MonoTests.System.ServiceModel.WrappedKeySecurityTokenTest.X509TokenForSymmetricKeyWrap
+ MonoTests.System.ServiceModel.WrappedKeySecurityTokenTest.UserNameToken
+ MonoTests.System.ServiceModel.WrappedKeySecurityTokenTest.CtorNullWrappingTokenReference
+ MonoTests.System.ServiceModel.WrappedKeySecurityTokenTest.CtorNullWrappingToken
+ MonoTests.System.ServiceModel.WrappedKeySecurityTokenTest.CtorNullWrappingAlgorithm
+ MonoTests.System.ServiceModel.WrappedKeySecurityTokenTest.CtorNullKey
+ MonoTests.System.ServiceModel.WrappedKeySecurityTokenTest.CtorNullId
+ MonoTests.System.ServiceModel.WrappedKeySecurityTokenTest.CreateBinarySecretKeyIdentifierClause
+ MonoTests.System.ServiceModel.WrappedKeySecurityTokenTest.BinarySecretTokenForSymmetricKeyWrap
+ MonoTests.System.ServiceModel.WrappedKeySecurityTokenTest.BinarySecretTokenForAsymmetricKeyWrap
+ MonoTests.System.ServiceModel.EndpointIdentityTest.CreateX509CertificateIdentity
+ MonoTests.System.ServiceModel.EndpointAddressTest.WriteToWSA10
+ MonoTests.System.ServiceModel.EndpointAddressTest.WriteContentsToWSA10
+ MonoTests.System.ServiceModel.Description.MetadataSetTest.ReadFrom

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -196,7 +196,6 @@ namespace BCLTestImporter {
 			"xammac_net_4_5_System.IdentityModel_test.dll", // issues https://github.com/xamarin/maccore/issues/1194
 			"xammac_net_4_5_System.IdentityModel_test.dll", // issues https://github.com/xamarin/maccore/issues/1196
 			"xammac_net_4_5_System.Security_test.dll", // issue https://github.com/xamarin/maccore/issues/1197
-			"xammac_net_4_5_System.ServiceModel_test.dll", // issues https://github.com/xamarin/maccore/issues/1198
 			"xammac_net_4_5_System_test.dll", // issues https://github.com/xamarin/maccore/issues/1199
 			"xammac_net_4_5_System.Xml_test.dll", // issues https://github.com/xamarin/maccore/issues/1201 and https://github.com/xamarin/maccore/issues/1202
 			"xammac_net_4_5_corlib_xunit-test.dll", // issues https://github.com/xamarin/maccore/issues/1203


### PR DESCRIPTION
Fixes  https://github.com/xamarin/maccore/issues/1198