### PR TITLE
[Xharness] Reenable MonoPoxis tests on mac os x.

### DIFF
--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -189,8 +189,6 @@ namespace BCLTestImporter {
 			"xammac_net_4_5_I18N.Other_test.dll",
 			"xammac_net_4_5_I18N.Rare_test.dll",
 			"xammac_net_4_5_I18N.West_test.dll",
-			"xammac_net_4_5_Mono.Posix_test.dll", // issue https://github.com/xamarin/maccore/issues/1188
-			"xammac_net_4_5_Mono.Posix_test.dll", // issues https://github.com/xamarin/maccore/issues/1189 and https://github.com/xamarin/maccore/issues/1190
 			"xammac_net_4_5_System.Core_test.dll", // issue https://github.com/xamarin/maccore/issues/1191
 			"xammac_net_4_5_System.Data_test.dll", // issues https://github.com/xamarin/maccore/issues/1192 and https://github.com/xamarin/maccore/issues/1193
 			"xammac_net_4_5_System.IdentityModel_test.dll", // issues https://github.com/xamarin/maccore/issues/1194


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/1190
Fixes https://github.com/xamarin/maccore/issues/1188