### PR TITLE
[tests] Adjust system check when running tests on older macOS versions (we don't need simulators)

### DIFF
--- a/jenkins/prepare-packaged-macos-tests.sh
+++ b/jenkins/prepare-packaged-macos-tests.sh
@@ -60,7 +60,7 @@ cd mac-test-package
 COUNTER=0
 while [[ $COUNTER -lt 5 ]]; do
 	EC=0
-	./system-dependencies.sh --provision-mono --ignore-autotools --ignore-xamarin-studio --ignore-xcode --ignore-osx --ignore-cmake || EC=$?
+	./system-dependencies.sh --provision-mono --ignore-autotools --ignore-xamarin-studio --ignore-xcode --ignore-osx --ignore-cmake --ignore-simulators || EC=$?
 	if [[ $EC -eq 56 ]]; then
 		# Sometimes we get spurious "curl: (56) SSLRead() return error -9806" errors. Trying again usually works, so lets try again a few more times.
 		# https://github.com/xamarin/maccore/issues/1098


### PR DESCRIPTION
Fixes this warning:

    make: *** tools/siminstaller: No such file or directory.  Stop.
    Can't check if simulators are available, because siminstaller failed to build.