### PR TITLE
[generator] Use WeakDelegate in EventAndDelegateMismatch check

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -17450,7 +17450,10 @@ namespace AppKit {
 		[Export ("removeTabViewItem:")][PostGet ("Items")]
 		void Remove (NSTabViewItem tabViewItem);
 
-		[Export ("delegate",  ArgumentSemantic.Assign), NullAllowed]
+		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
+		NSObject WeakDelegate { get; set; }
+
+		[Wrap ("WeakDelegate")]
 		[Protocolize]
 		NSTabViewDelegate Delegate { get; set; }
 

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -6736,8 +6736,8 @@ public partial class Generator : IMemberGatherer {
 						//   - We're in one of two cases: The user += an Event and then assigned their own delegate or the inverse
 						//   - One of them isn't being called anymore no matter what. Throw an exception.
 						if (!BindThirdPartyLibrary) {
-							print ("if ({0} != null)", delName);
-							print ("\t{0}.EnsureEventAndDelegateAreNotMismatched ({1}, {2});", ApplicationClassName, delName, delegateTypePropertyName);
+							print ("if (Weak{0} != null)", delName);
+							print ("\t{0}.EnsureEventAndDelegateAreNotMismatched (Weak{1}, {2});", ApplicationClassName, delName, delegateTypePropertyName);
 						}
 
 						print ("_{0} del = {1} as _{0};", dtype.Name, delName);


### PR DESCRIPTION
- https://github.com/xamarin/xamarin-macios/issues/5724
- In some cases, such as surfacing an instance created from ObjC the
typed delegates can return null even if a instance is assigned (if it is not bound as a managed type).
- This means you can accidentally override the delegate without an exception.
- We can use WeakDelegate in our checks
- One type in our build complained, since it did not have a WeakDelegate. Easy to add. 