### PR TITLE
[d16-1] [corefoundation] Add missing CFStringTransform API

### DIFF
--- a/src/CoreFoundation/CFDictionary.cs
+++ b/src/CoreFoundation/CFDictionary.cs
@@ -151,7 +151,7 @@ namespace CoreFoundation {
 		public string GetStringValue (string key)
 		{
 			using (var str = new CFString (key)) {
-				return CFString.FetchString (CFDictionaryGetValue (Handle, str.handle));
+				return CFString.FetchString (CFDictionaryGetValue (Handle, str.Handle));
 			}
 		}
 
@@ -178,14 +178,14 @@ namespace CoreFoundation {
 		public IntPtr GetIntPtrValue (string key)
 		{
 			using (var str = new CFString (key)) {
-				return CFDictionaryGetValue (Handle, str.handle);
+				return CFDictionaryGetValue (Handle, str.Handle);
 			}
 		}
 
 		public CFDictionary GetDictionaryValue (string key)
 		{
 			using (var str = new CFString (key)) {
-				var ptr = CFDictionaryGetValue (Handle, str.handle);
+				var ptr = CFDictionaryGetValue (Handle, str.Handle);
 				return ptr == IntPtr.Zero ? null : new CFDictionary (ptr);
 			}
 		}
@@ -193,7 +193,7 @@ namespace CoreFoundation {
 		public bool ContainsKey (string key)
 		{
 			using (var str = new CFString (key)) {
-				return CFDictionaryContainsKey (Handle, str.handle);
+				return CFDictionaryContainsKey (Handle, str.Handle);
 			}
 		}
 

--- a/src/CoreFoundation/CFMutableString.cs
+++ b/src/CoreFoundation/CFMutableString.cs
@@ -1,39 +1,60 @@
+// Copyright 2019 Microsoft Corporation
+
 #if !COREBUILD
 
 using System;
 using System.Runtime.InteropServices;
 
+using Foundation;
 using ObjCRuntime;
 
 namespace CoreFoundation {
 	
 	public class CFMutableString : CFString {
 
-		[DllImport (Constants.CoreFoundationLibrary, CharSet=CharSet.Unicode)]
-		static extern unsafe /* CFMutableStringRef* */ IntPtr CFStringCreateMutableWithExternalCharactersNoCopy (/* CFAllocatorRef* */ IntPtr alloc, string chars, nint numChars, nint capacity, /* CFAllocatorRef* */ IntPtr externalCharactersAllocator);
-
-		public CFMutableString (string theString, nint capacity)
+		public CFMutableString (IntPtr handle)
+			: this (handle, false)
 		{
-			if (theString == null)
-				throw new ArgumentNullException (nameof (theString));
-			
-			handle = CFStringCreateMutableWithExternalCharactersNoCopy (IntPtr.Zero, theString, theString.Length, capacity, IntPtr.Zero);
+		}
+		
+		[Preserve (Conditional = true)]
+		protected CFMutableString (IntPtr handle, bool owns)
+			: base (handle, owns)
+		{
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		static extern unsafe /* CFMutableStringRef* */ IntPtr CFStringCreateMutable (/* CFAllocatorRef* */ IntPtr alloc, nint maxLength);
 
-		public CFMutableString (nint maxLength)
+		public CFMutableString (string @string = "", nint maxLength = default (nint))
 		{
-			handle = CFStringCreateMutable (IntPtr.Zero, maxLength);
+			// not really needed - but it's consistant with other .ctor
+			if (@string == null)
+				throw new ArgumentNullException (nameof (@string));
+			Handle = CFStringCreateMutable (IntPtr.Zero, maxLength);
+			if (@string != null)
+				CFStringAppendCharacters (Handle, @string, @string.Length);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
 		static extern unsafe /* CFMutableStringRef* */ IntPtr CFStringCreateMutableCopy (/* CFAllocatorRef* */ IntPtr alloc, nint maxLength, /* CFStringRef* */ IntPtr theString);
 
-		public CFMutableString (CFString theString, nint maxLength)
+		public CFMutableString (CFString theString, nint maxLength = default (nint))
 		{
-			handle = CFStringCreateMutableCopy (IntPtr.Zero, maxLength, theString.GetHandle ());
+			if (theString == null)
+				throw new ArgumentNullException (nameof (theString));
+			Handle = CFStringCreateMutableCopy (IntPtr.Zero, maxLength, theString.GetHandle ());
+		}
+
+		[DllImport (Constants.CoreFoundationLibrary, CharSet=CharSet.Unicode)]
+		static extern unsafe void CFStringAppendCharacters (/* CFMutableStringRef* */ IntPtr theString, string chars, nint numChars);
+
+		public void Append (string @string)
+		{
+			if (@string == null)
+				throw new ArgumentNullException (nameof (@string));
+			str = null; // destroy any cached value
+			CFStringAppendCharacters (Handle, @string, @string.Length);
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary)]
@@ -42,20 +63,70 @@ namespace CoreFoundation {
 
 		public bool Transform (ref CFRange range, CFStringTransform transform, bool reverse)
 		{
-			str = null; // destroy any cached value
-			return Transform (Handle, ref range, transform.GetConstant ().GetHandle (), reverse);
+			return Transform (ref range, transform.GetConstant ().GetHandle (), reverse);
 		}
 
 		// constant documentation mention it also accept any ICT transform
 		public bool Transform (ref CFRange range, CFString transform, bool reverse)
 		{
-			str = null; // destroy any cached value
-			return CFStringTransform (Handle, ref range, transform.GetHandle (), reverse);
+			return Transform (ref range, transform.GetHandle (), reverse);
 		}
 
-		internal bool Transform (IntPtr @string, ref CFRange range, IntPtr transform, bool reverse)
+		public bool Transform (ref CFRange range, NSString transform, bool reverse)
 		{
-			return CFStringTransform (@string, ref range, transform, reverse);
+			return Transform (ref range, transform.GetHandle (), reverse);
+		}
+
+		public bool Transform (ref CFRange range, string transform, bool reverse)
+		{
+			var t = NSString.CreateNative (transform);
+			var ret = Transform (ref range, t, reverse);
+			NSString.ReleaseNative (t);
+			return ret;
+		}
+
+		bool Transform (ref CFRange range, IntPtr transform, bool reverse)
+		{
+			if (transform == IntPtr.Zero)
+				throw new ArgumentNullException (nameof (transform));
+			str = null; // destroy any cached value
+			return CFStringTransform (Handle, ref range, transform, reverse);
+		}
+
+		[DllImport (Constants.CoreFoundationLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		static extern internal bool /* Boolean */ CFStringTransform (/* CFMutableStringRef* */ IntPtr @string, /* CFRange* */ IntPtr range, /* CFStringRef* */ IntPtr transform, [MarshalAs (UnmanagedType.I1)] /* Boolean */ bool reverse);
+
+		public bool Transform (CFStringTransform transform, bool reverse)
+		{
+			return Transform (transform.GetConstant ().GetHandle (), reverse);
+		}
+
+		// constant documentation mention it also accept any ICT transform
+		public bool Transform (CFString transform, bool reverse)
+		{
+			return Transform (transform.GetHandle (), reverse);
+		}
+
+		public bool Transform (NSString transform, bool reverse)
+		{
+			return Transform (transform.GetHandle (), reverse);
+		}
+
+		public bool Transform (string transform, bool reverse)
+		{
+			var t = NSString.CreateNative (transform);
+			var ret = Transform (t, reverse);
+			NSString.ReleaseNative (t);
+			return ret;
+		}
+
+		bool Transform (IntPtr transform, bool reverse)
+		{
+			if (transform == IntPtr.Zero)
+				throw new ArgumentNullException (nameof (transform));
+			str = null; // destroy any cached value
+			return CFStringTransform (Handle, IntPtr.Zero, transform, reverse);
 		}
 	}
 }

--- a/src/CoreFoundation/CFMutableString.cs
+++ b/src/CoreFoundation/CFMutableString.cs
@@ -1,0 +1,63 @@
+#if !COREBUILD
+
+using System;
+using System.Runtime.InteropServices;
+
+using ObjCRuntime;
+
+namespace CoreFoundation {
+	
+	public class CFMutableString : CFString {
+
+		[DllImport (Constants.CoreFoundationLibrary, CharSet=CharSet.Unicode)]
+		static extern unsafe /* CFMutableStringRef* */ IntPtr CFStringCreateMutableWithExternalCharactersNoCopy (/* CFAllocatorRef* */ IntPtr alloc, string chars, nint numChars, nint capacity, /* CFAllocatorRef* */ IntPtr externalCharactersAllocator);
+
+		public CFMutableString (string theString, nint capacity)
+		{
+			if (theString == null)
+				throw new ArgumentNullException (nameof (theString));
+			
+			handle = CFStringCreateMutableWithExternalCharactersNoCopy (IntPtr.Zero, theString, theString.Length, capacity, IntPtr.Zero);
+		}
+
+		[DllImport (Constants.CoreFoundationLibrary)]
+		static extern unsafe /* CFMutableStringRef* */ IntPtr CFStringCreateMutable (/* CFAllocatorRef* */ IntPtr alloc, nint maxLength);
+
+		public CFMutableString (nint maxLength)
+		{
+			handle = CFStringCreateMutable (IntPtr.Zero, maxLength);
+		}
+
+		[DllImport (Constants.CoreFoundationLibrary)]
+		static extern unsafe /* CFMutableStringRef* */ IntPtr CFStringCreateMutableCopy (/* CFAllocatorRef* */ IntPtr alloc, nint maxLength, /* CFStringRef* */ IntPtr theString);
+
+		public CFMutableString (CFString theString, nint maxLength)
+		{
+			handle = CFStringCreateMutableCopy (IntPtr.Zero, maxLength, theString.GetHandle ());
+		}
+
+		[DllImport (Constants.CoreFoundationLibrary)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		static extern internal bool /* Boolean */ CFStringTransform (/* CFMutableStringRef* */ IntPtr @string, /* CFRange* */ ref CFRange range, /* CFStringRef* */ IntPtr transform, [MarshalAs (UnmanagedType.I1)] /* Boolean */ bool reverse);
+
+		public bool Transform (ref CFRange range, CFStringTransform transform, bool reverse)
+		{
+			str = null; // destroy any cached value
+			return Transform (Handle, ref range, transform.GetConstant ().GetHandle (), reverse);
+		}
+
+		// constant documentation mention it also accept any ICT transform
+		public bool Transform (ref CFRange range, CFString transform, bool reverse)
+		{
+			str = null; // destroy any cached value
+			return CFStringTransform (Handle, ref range, transform.GetHandle (), reverse);
+		}
+
+		internal bool Transform (IntPtr @string, ref CFRange range, IntPtr transform, bool reverse)
+		{
+			return CFStringTransform (@string, ref range, transform, reverse);
+		}
+	}
+}
+
+#endif // !COREBUILD

--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -96,11 +96,10 @@ namespace CoreFoundation {
 	
 	public class CFString
 #if !COREBUILD
-		: INativeObject, IDisposable
+		: NativeObject
 #endif
 	{
 #if !COREBUILD
-		internal IntPtr handle;
 		internal string str;
 
 		protected CFString () {}
@@ -130,42 +129,12 @@ namespace CoreFoundation {
 			if (str == null)
 				throw new ArgumentNullException ("str");
 			
-			handle = CFStringCreateWithCharacters (IntPtr.Zero, str, str.Length);
+			Handle = CFStringCreateWithCharacters (IntPtr.Zero, str, str.Length);
 			this.str = str;
-		}
-
-		~CFString ()
-		{
-			Dispose (false);
-		}
-
-		public IntPtr Handle {
-			get {
-				return handle;
-			}
 		}
 
 		[DllImport (Constants.CoreFoundationLibrary, EntryPoint="CFStringGetTypeID")]
 		public extern static nint GetTypeID ();
-		
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-#if XAMCORE_2_0
-		protected virtual void Dispose (bool disposing)
-#else
-		public virtual void Dispose (bool disposing)
-#endif
-		{
-			str = null;
-			if (handle != IntPtr.Zero){
-				CFObject.CFRelease (handle);
-				handle = IntPtr.Zero;
-			}
-		}
 		
 		public CFString (IntPtr handle)
 			: this (handle, false)
@@ -173,11 +142,9 @@ namespace CoreFoundation {
 		}
 		
 		[Preserve (Conditional = true)]
-		internal CFString (IntPtr handle, bool owns)
+		protected internal CFString (IntPtr handle, bool owns)
+			: base (handle, owns)
 		{
-			this.handle = handle;
-			if (!owns)
-				CFObject.CFRetain (handle);
 		}
 
 		// to be used when an API like CF*Get* returns a CFString
@@ -219,7 +186,7 @@ namespace CoreFoundation {
 		public static implicit operator string (CFString x)
 		{
 			if (x.str == null)
-				x.str = FetchString (x.handle);
+				x.str = FetchString (x.Handle);
 			
 			return x.str;
 		}
@@ -234,7 +201,7 @@ namespace CoreFoundation {
 				if (str != null)
 					return str.Length;
 				else
-					return (int)CFStringGetLength (handle);
+					return (int)CFStringGetLength (Handle);
 			}
 		}
 
@@ -246,7 +213,7 @@ namespace CoreFoundation {
 				if (str != null)
 					return str [(int) p];
 				else
-					return CFStringGetCharacterAtIndex (handle, p);
+					return CFStringGetCharacterAtIndex (Handle, p);
 			}
 		}
 		
@@ -254,7 +221,7 @@ namespace CoreFoundation {
 		{
 			if (str != null)
 				return str;
-			return FetchString (handle);
+			return FetchString (Handle);
 		}
 #endif // !COREBUILD
 	}

--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -103,6 +103,8 @@ namespace CoreFoundation {
 		internal IntPtr handle;
 		internal string str;
 
+		protected CFString () {}
+
 		[DllImport (Constants.CoreFoundationLibrary, CharSet=CharSet.Unicode)]
 		extern static IntPtr CFStringCreateWithCharacters (IntPtr allocator, string str, nint count);
 

--- a/src/CoreGraphics/CGColor.cs
+++ b/src/CoreGraphics/CGColor.cs
@@ -125,7 +125,7 @@ namespace CoreGraphics {
 				throw new ArgumentNullException ("name");
 			
 			using (var s = new CFString (name)){
-				handle = CGColorGetConstantColor (s.handle);
+				handle = CGColorGetConstantColor (s.Handle);
 				if (handle == IntPtr.Zero)
 					throw new ArgumentException ("name");
 				CGColorRetain (handle);

--- a/src/CoreGraphics/CGFont.cs
+++ b/src/CoreGraphics/CGFont.cs
@@ -108,7 +108,7 @@ namespace CoreGraphics {
 			if (name == null)
 				return null;
 			using (CFString s = name){
-				return new CGFont (CGFontCreateWithFontName (s.handle), true);
+				return new CGFont (CGFontCreateWithFontName (s.Handle), true);
 			}
 		}
 		
@@ -247,7 +247,7 @@ namespace CoreGraphics {
 		{
 			// note: the API is marked to accept a null CFStringRef but it currently (iOS9 beta 4) crash when provided one
 			using (var cs = new CFString (s)){
-				return CGFontGetGlyphWithGlyphName (handle, cs.handle);
+				return CGFontGetGlyphWithGlyphName (handle, cs.Handle);
 			}
 		}
 		

--- a/src/Foundation/DictionaryContainer.cs
+++ b/src/Foundation/DictionaryContainer.cs
@@ -274,7 +274,7 @@ namespace Foundation {
 				throw new ArgumentNullException ("key");
 
 			using (var str = new CFString (key)) {
-				return CFString.FetchString (CFDictionary.GetValue (Dictionary.Handle, str.handle));
+				return CFString.FetchString (CFDictionary.GetValue (Dictionary.Handle, str.Handle));
 			}
 		}
 #if XAMCORE_2_0

--- a/src/corefoundation.cs
+++ b/src/corefoundation.cs
@@ -66,4 +66,54 @@ namespace CoreFoundation {
 		NSString ErrorDomain { get; }
 	}
 #endif
+
+	enum CFStringTransform {
+		[Field ("kCFStringTransformStripCombiningMarks")]
+		StripCombiningMarks,
+
+		[Field ("kCFStringTransformToLatin")]
+		ToLatin,
+
+		[Field ("kCFStringTransformFullwidthHalfwidth")]
+		FullwidthHalfwidth,
+
+		[Field ("kCFStringTransformLatinKatakana")]
+		LatinKatakana,
+
+		[Field ("kCFStringTransformLatinHiragana")]
+		LatinHiragana,
+
+		[Field ("kCFStringTransformHiraganaKatakana")]
+		HiraganaKatakana,
+
+		[Field ("kCFStringTransformMandarinLatin")]
+		MandarinLatin,
+
+		[Field ("kCFStringTransformLatinHangul")]
+		LatinHangul,
+
+		[Field ("kCFStringTransformLatinArabic")]
+		LatinArabic,
+
+		[Field ("kCFStringTransformLatinHebrew")]
+		LatinHebrew,
+
+		[Field ("kCFStringTransformLatinThai")]
+		LatinThai,
+
+		[Field ("kCFStringTransformLatinCyrillic")]
+		LatinCyrillic,
+
+		[Field ("kCFStringTransformLatinGreek")]
+		LatinGreek,
+
+		[Field ("kCFStringTransformToXMLHex")]
+		ToXmlHex,
+
+		[Field ("kCFStringTransformToUnicodeName")]
+		ToUnicodeName,
+
+		[Field ("kCFStringTransformStripDiacritics")]
+		StripDiacritics,
+	}
 }

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -393,6 +393,7 @@ COREDATA_SOURCES = \
 
 COREFOUNDATION_CORE_SOURCES = \
 	CoreFoundation/CFIndex.cs \
+	CoreFoundation/CFMutableString.cs \
 	CoreFoundation/CFRunLoop.cs \
 	CoreFoundation/CFString.cs \
 	CoreFoundation/Dispatch.cs \

--- a/tests/introspection/ApiCMAttachmentTest.cs
+++ b/tests/introspection/ApiCMAttachmentTest.cs
@@ -282,6 +282,8 @@ namespace Introspection {
 				return af;
 			case "CFHTTPMessage":
 				return CFHTTPMessage.CreateEmpty (false);
+			case "CFMutableString":
+				return new CFMutableString ("xamarin");
 			case "CGBitmapContext":
 				byte[] data = new byte [400];
 				using (CGColorSpace space = CGColorSpace.CreateDeviceRGB ()) {

--- a/tests/monotouch-test/CoreFoundation/MutableString.cs
+++ b/tests/monotouch-test/CoreFoundation/MutableString.cs
@@ -1,10 +1,124 @@
 ﻿using System;
-namespace monotouchtest.CoreFoundation
-{
-	public class MutableString
-	{
-		public MutableString ()
+using Foundation;
+using CoreFoundation;
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.CoreFoundation {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class MutableString {
+
+		[Test]
+		public void CreateString0 ()
 		{
+			using (var s = new CFMutableString ()) {
+				Assert.That (s.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
+				Assert.That (s.ToString (), Is.Empty, "ToString");
+			}
+		}
+
+		[Test]
+		public void CreateString1 ()
+		{
+			Assert.Throws<ArgumentNullException> (() => new CFMutableString ((string)null), "null");
+			using (var s = new CFMutableString ("bonjour!")) {
+				Assert.That (s.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle-1");
+			}
+		}
+
+		[Test]
+		public void CreateString2 ()
+		{
+			using (var s = new CFMutableString ("bonjour!", 20)) {
+				Assert.That (s.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
+				Assert.That (s.ToString (), Is.EqualTo ("bonjour!"), "ToString");
+			}
+		}
+
+		[Test]
+		public void CreateCFString1 ()
+		{
+			Assert.Throws<ArgumentNullException> (() => new CFMutableString ((CFString) null), "null");
+			using (var c = new CFString ("bonjour"))
+			using (var s = new CFMutableString (c)) {
+				Assert.That (s.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
+				Assert.That (s.ToString (), Is.EqualTo ("bonjour"), "ToString");
+			}
+		}
+
+		[Test]
+		public void CreateCFString2 ()
+		{
+			using (var c = new CFString ("bonjour"))
+			using (var s = new CFMutableString (c, 4)) {
+				Assert.That (s.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
+				Assert.That (s.ToString (), Is.EqualTo ("bonjour"), "ToString");
+			}
+		}
+
+		[Test]
+		public void AppendString ()
+		{
+			using (var s = new CFMutableString ("hello")) {
+				Assert.Throws<ArgumentNullException> (() => s.Append ((string) null), "null");
+				s.Append (" world!");
+				Assert.That (s.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
+				Assert.That (s.ToString (), Is.EqualTo ("hello world!"), "ToString");
+			}
+		}
+
+		[Test]
+		public void TransformNoRangeEnum ()
+		{
+			using (var s = new CFMutableString ("Bonjour à tous!")) {
+				Assert.True (s.Transform (CFStringTransform.ToXmlHex, false), "Transform-1");
+				Assert.That (s.ToString (), Is.EqualTo ("Bonjour &#xE0; tous!"), "ToString-1");
+		
+				Assert.True (s.Transform (CFStringTransform.ToXmlHex, true), "Transform-2");
+				Assert.That (s.ToString (), Is.EqualTo ("Bonjour à tous!"), "ToString-2");
+			}
+		}
+
+		[Test]
+		public void TransformNull ()
+		{
+			using (var s = new CFMutableString ("hello")) {
+				Assert.Throws<ArgumentNullException> (() => s.Transform ((string) null, false), "null-1");
+				Assert.Throws<ArgumentNullException> (() => s.Transform ((CFString) null, true), "null-2");
+				Assert.Throws<ArgumentNullException> (() => s.Transform ((NSString) null, false), "null-3");
+				var r = new CFRange (2, 2);
+				Assert.Throws<ArgumentNullException> (() => s.Transform ((string) null, true), "null-4");
+				Assert.Throws<ArgumentNullException> (() => s.Transform ((CFString) null, false), "null-5");
+				Assert.Throws<ArgumentNullException> (() => s.Transform ((NSString) null, true), "null-6");
+			}
+		}
+
+		[Test]
+		public void TransformRangeEnum ()
+		{
+			var r = new CFRange (0, 15);
+			using (var s = new CFMutableString ("Bonjour à tous!")) {
+				Assert.True (s.Transform (ref r, CFStringTransform.ToXmlHex, false), "Transform-1");
+				Assert.That (s.ToString (), Is.EqualTo ("Bonjour &#xE0; tous!"), "ToString-1");
+				Assert.That (r.Length, Is.EqualTo (20), "Length-1");
+
+				Assert.True (s.Transform (ref r, CFStringTransform.ToXmlHex, true), "Transform-2");
+				Assert.That (s.ToString (), Is.EqualTo ("Bonjour à tous!"), "ToString-2");
+				Assert.That (r.Length, Is.EqualTo (15), "Length-2");
+			}
+		}
+
+		[Test]
+		public void TransformICU ()
+		{
+			using (var s = new CFMutableString ("hello world")) {
+				Assert.True (s.Transform ("Title", false), "Transform-1");
+				Assert.That (s.ToString (), Is.EqualTo ("Hello World"), "ToString-1");
+
+				Assert.True (s.Transform ((NSString) "Title", true), "Transform-2");
+				Assert.That (s.ToString (), Is.EqualTo ("hello world"), "ToString-2");
+			}
 		}
 	}
 }

--- a/tests/monotouch-test/CoreFoundation/MutableString.cs
+++ b/tests/monotouch-test/CoreFoundation/MutableString.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Foundation;
 using CoreFoundation;
 using NUnit.Framework;
@@ -63,11 +63,33 @@ namespace MonoTouchFixtures.CoreFoundation {
 		[Test]
 		public void AppendString ()
 		{
-			using (var s = new CFMutableString ("hello")) {
+			using (var s = new CFMutableString ()) {
 				Assert.Throws<ArgumentNullException> (() => s.Append ((string) null), "null");
-				s.Append (" world!");
+				// from NSHipster
+				s.Append ("Énġlišh långuãge lẳcks iñterêßţing diaçrïtičş!");
 				Assert.That (s.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
-				Assert.That (s.ToString (), Is.EqualTo ("hello world!"), "ToString");
+				Assert.That (s.ToString (), Is.EqualTo ("Énġlišh långuãge lẳcks iñterêßţing diaçrïtičş!"), "ToString");
+			}
+		}
+
+		[Test]
+		public void AppendString_Unicode ()
+		{
+			using (var s = new CFMutableString ("Bonjour")) {
+				s.Append (" à tous les \ud83d\udc11!");
+				Assert.That (s.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
+				// make it fail and you see the sheep printed in the touchunit runner UI :)
+				Assert.That (s.ToString (), Is.EqualTo ("Bonjour à tous les \ud83d\udc11!"), "ToString");
+			}
+		}
+
+		[Test]
+		public void AppendString_RtL ()
+		{
+			using (var s = new CFMutableString ()) {
+				s.Append ("שלום");
+				Assert.That (s.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
+				Assert.That (s.ToString (), Is.EqualTo ("שלום"), "ToString");
 			}
 		}
 

--- a/tests/monotouch-test/CoreFoundation/MutableString.cs
+++ b/tests/monotouch-test/CoreFoundation/MutableString.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace monotouchtest.CoreFoundation
+{
+	public class MutableString
+	{
+		public MutableString ()
+		{
+		}
+	}
+}

--- a/tests/monotouch-test/CoreFoundation/MutableString.cs
+++ b/tests/monotouch-test/CoreFoundation/MutableString.cs
@@ -30,6 +30,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		[Test]
 		public void CreateString2 ()
 		{
+			Assert.Throws<ArgumentException> (() => new CFMutableString ("", -1), "negative");
 			using (var s = new CFMutableString ("bonjour!", 20)) {
 				Assert.That (s.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
 				Assert.That (s.ToString (), Is.EqualTo ("bonjour!"), "ToString");
@@ -50,10 +51,12 @@ namespace MonoTouchFixtures.CoreFoundation {
 		[Test]
 		public void CreateCFString2 ()
 		{
-			using (var c = new CFString ("bonjour"))
-			using (var s = new CFMutableString (c, 4)) {
-				Assert.That (s.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
-				Assert.That (s.ToString (), Is.EqualTo ("bonjour"), "ToString");
+			using (var c = new CFString ("bonjour")) {
+				Assert.Throws<ArgumentException> (() => new CFMutableString (c, -1), "negative");
+				using (var s = new CFMutableString (c, 4)) {
+					Assert.That (s.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
+					Assert.That (s.ToString (), Is.EqualTo ("bonjour"), "ToString");
+				}
 			}
 		}
 

--- a/tests/xtro-sharpie/common-CoreFoundation.ignore
+++ b/tests/xtro-sharpie/common-CoreFoundation.ignore
@@ -194,22 +194,6 @@
 !missing-field! kCFStreamPropertySocketRemoteHostName not bound
 !missing-field! kCFStreamPropertySocketRemotePortNumber not bound
 !missing-field! kCFStringBinaryHeapCallBacks not bound
-!missing-field! kCFStringTransformFullwidthHalfwidth not bound
-!missing-field! kCFStringTransformHiraganaKatakana not bound
-!missing-field! kCFStringTransformLatinArabic not bound
-!missing-field! kCFStringTransformLatinCyrillic not bound
-!missing-field! kCFStringTransformLatinGreek not bound
-!missing-field! kCFStringTransformLatinHangul not bound
-!missing-field! kCFStringTransformLatinHebrew not bound
-!missing-field! kCFStringTransformLatinHiragana not bound
-!missing-field! kCFStringTransformLatinKatakana not bound
-!missing-field! kCFStringTransformLatinThai not bound
-!missing-field! kCFStringTransformMandarinLatin not bound
-!missing-field! kCFStringTransformStripCombiningMarks not bound
-!missing-field! kCFStringTransformStripDiacritics not bound
-!missing-field! kCFStringTransformToLatin not bound
-!missing-field! kCFStringTransformToUnicodeName not bound
-!missing-field! kCFStringTransformToXMLHex not bound
 !missing-field! kCFTimeZoneSystemTimeZoneDidChangeNotification not bound
 !missing-field! kCFTypeArrayCallBacks not bound
 !missing-field! kCFTypeBagCallBacks not bound
@@ -749,9 +733,6 @@
 !missing-pinvoke! CFStringCreateCopy is not bound
 !missing-pinvoke! CFStringCreateExternalRepresentation is not bound
 !missing-pinvoke! CFStringCreateFromExternalRepresentation is not bound
-!missing-pinvoke! CFStringCreateMutable is not bound
-!missing-pinvoke! CFStringCreateMutableCopy is not bound
-!missing-pinvoke! CFStringCreateMutableWithExternalCharactersNoCopy is not bound
 !missing-pinvoke! CFStringCreateWithBytes is not bound
 !missing-pinvoke! CFStringCreateWithBytesNoCopy is not bound
 !missing-pinvoke! CFStringCreateWithCharactersNoCopy is not bound
@@ -810,7 +791,6 @@
 !missing-pinvoke! CFStringTokenizerGetTypeID is not bound
 !missing-pinvoke! CFStringTokenizerGoToTokenAtIndex is not bound
 !missing-pinvoke! CFStringTokenizerSetString is not bound
-!missing-pinvoke! CFStringTransform is not bound
 !missing-pinvoke! CFStringTrim is not bound
 !missing-pinvoke! CFStringTrimWhitespace is not bound
 !missing-pinvoke! CFStringUppercase is not bound

--- a/tests/xtro-sharpie/common-CoreFoundation.ignore
+++ b/tests/xtro-sharpie/common-CoreFoundation.ignore
@@ -712,7 +712,6 @@
 !missing-pinvoke! CFSocketSetDefaultNameRegistryPortNumber is not bound
 !missing-pinvoke! CFSocketUnregister is not bound
 !missing-pinvoke! CFStringAppend is not bound
-!missing-pinvoke! CFStringAppendCharacters is not bound
 !missing-pinvoke! CFStringAppendCString is not bound
 !missing-pinvoke! CFStringAppendFormat is not bound
 !missing-pinvoke! CFStringAppendFormatAndArguments is not bound
@@ -733,6 +732,7 @@
 !missing-pinvoke! CFStringCreateCopy is not bound
 !missing-pinvoke! CFStringCreateExternalRepresentation is not bound
 !missing-pinvoke! CFStringCreateFromExternalRepresentation is not bound
+!missing-pinvoke! CFStringCreateMutableWithExternalCharactersNoCopy is not bound
 !missing-pinvoke! CFStringCreateWithBytes is not bound
 !missing-pinvoke! CFStringCreateWithBytesNoCopy is not bound
 !missing-pinvoke! CFStringCreateWithCharactersNoCopy is not bound


### PR DESCRIPTION
Since there's not NSString or .NET equivalent. This requires a mutable
`CFString` so the new type is also added.

Draft until unit tests are added.

Backport of #5712.

/cc @spouliot 