### PR TITLE
[Foundation] Add support to the ServerCertificateValidationCallback on the NSUrlSessionHandler

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -453,7 +453,7 @@ namespace Foundation {
 					if (error != null) {
 						inflight.Errored = true;
 
-						// if the exception was set by one of the delefate methods, used it, else use the one
+						// if the exception was set by one of the delegate methods, used it, else use the one
 						// from the error.
 						var exc = inflight.Exception ?? createExceptionForNSError (error);
 						inflight.CompletionSource.TrySetException (exc);

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -91,6 +91,8 @@ namespace MonoTests.System.Net.Http
 					var managedResponse = await managedClient.GetAsync ("https://google.com");
 					if (managedResponse.Headers.TryGetValues ("Set-Cookie", out var managedCookies)) {
 						var nativeClient = new HttpClient (new NSUrlSessionHandler ());
+						// ensure we do not have this set from other tests, is a singleton :/
+						//ServicePointManager.ServerCertificateValidationCallback = null;
 						var nativeResponse = await nativeClient.GetAsync ("https://google.com");
 						if (managedResponse.Headers.TryGetValues ("Set-Cookie", out var nativeCookies)) {
 							manageCount = managedCookies.Count ();
@@ -157,6 +159,96 @@ namespace MonoTests.System.Net.Http
 			} else {
 				Assert.IsFalse (containsAuthorizarion, $"Authorization header did reach the final destination. {json}");
 				Assert.IsNull (ex, $"Exception {ex} for {json}");
+			}
+		}
+		
+#if !__WATCHOS__
+		[TestCase (typeof (HttpClientHandler))]
+#endif
+		[TestCase (typeof (NSUrlSessionHandler))]
+		public void RejectSslCertificatesServicePointManager (Type handlerType)
+		{
+			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+
+			bool servicePointManagerCbWasExcuted = false;
+			bool done = false;
+			Exception ex = null;
+			
+			ServicePointManager.ServerCertificateValidationCallback = (sender, certificate, chain, errors) => {
+				servicePointManagerCbWasExcuted = true;
+				// return false, since we want to test that the exception is raised
+				return false;
+			};
+			
+			TestRuntime.RunAsync (DateTime.Now.AddSeconds (30), async () =>
+			{
+				try {
+					HttpClient client = new HttpClient (GetHandler (handlerType));
+					client.BaseAddress = new Uri ("https://httpbin.org");
+					var byteArray = new UTF8Encoding ().GetBytes ("username:password");
+					client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue ("Basic", Convert.ToBase64String(byteArray));
+					var result = await client.GetAsync ("https://httpbin.org/redirect/3");
+				} catch (Exception e) {
+					ex = e;
+				} finally {
+					done = true;
+					ServicePointManager.ServerCertificateValidationCallback = null;
+				}
+			}, () => done);
+
+			if (!done) { // timeouts happen in the bost due to dns issues, connection issues etc.. we do not want to fail
+				Assert.Inconclusive ("Request timedout.");
+			} else {
+				// assert the exception type
+				Assert.IsInstanceOfType (typeof (HttpRequestException), ex);
+				Assert.IsNotNull (ex.InnerException);
+				Assert.IsInstanceOfType (typeof (WebException), ex.InnerException);
+			}
+		}
+		
+#if !__WATCHOS__
+		[TestCase (typeof (HttpClientHandler))]
+#endif
+		[TestCase (typeof (NSUrlSessionHandler))]
+		public void AcceptSslCertificatesServicePointManager (Type handlerType)
+		{
+			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
+			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
+
+			bool servicePointManagerCbWasExcuted = false;
+			bool done = false;
+			Exception ex = null;
+			
+			ServicePointManager.ServerCertificateValidationCallback = (sender, certificate, chain, errors) => {
+				servicePointManagerCbWasExcuted = true;
+				return true;
+			};
+			
+			TestRuntime.RunAsync (DateTime.Now.AddSeconds (30), async () =>
+			{
+				try {
+					HttpClient client = new HttpClient (GetHandler (handlerType));
+					client.BaseAddress = new Uri ("https://httpbin.org");
+					var byteArray = new UTF8Encoding ().GetBytes ("username:password");
+					client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue ("Basic", Convert.ToBase64String(byteArray));
+					var result = await client.GetAsync ("https://httpbin.org/redirect/3");
+				} catch (Exception e) {
+					ex = e;
+				} finally {
+					done = true;
+					ServicePointManager.ServerCertificateValidationCallback = null;
+				}
+			}, () => done);
+
+			if (!done) { // timeouts happen in the bost due to dns issues, connection issues etc.. we do not want to fail
+				Assert.Inconclusive ("Request timedout.");
+			} else {
+				// assert that we did not get an exception
+				if (ex != null && ex.InnerException != null) {
+					// we could get here.. if we have a diff issue, in that case, lets get the exception message and assert is not the trust issue
+					Assert.AreNotEqual (ex.InnerException.Message, "Error: TrustFailure");
+				}
 			}
 		}
 	}

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -91,8 +91,6 @@ namespace MonoTests.System.Net.Http
 					var managedResponse = await managedClient.GetAsync ("https://google.com");
 					if (managedResponse.Headers.TryGetValues ("Set-Cookie", out var managedCookies)) {
 						var nativeClient = new HttpClient (new NSUrlSessionHandler ());
-						// ensure we do not have this set from other tests, is a singleton :/
-						//ServicePointManager.ServerCertificateValidationCallback = null;
 						var nativeResponse = await nativeClient.GetAsync ("https://google.com");
 						if (managedResponse.Headers.TryGetValues ("Set-Cookie", out var nativeCookies)) {
 							manageCount = managedCookies.Count ();


### PR DESCRIPTION
This changes allows to use the service point manager callback within the
NSUrlSessionHanlder.

The logic is as follows:

1. Check that the challange is about the ssl cert.
2. Convert the SecTrust info to the managed objects.
3. Call the users cb.
4. If user returns true, continue, else, cancel and create an exception
similar to the one used in the managed code.

Fixes https://github.com/xamarin/xamarin-macios/issues/4170