### PR TITLE
[Xharness] Reenable the SystemXml tests on mac os x.

### DIFF
--- a/tests/bcl-test/BCLTests/macOSFull-SystemXmlTests.ignore
+++ b/tests/bcl-test/BCLTests/macOSFull-SystemXmlTests.ignore
@@ -1,0 +1,14 @@
+# System.IO.DirectoryNotFoundException : Could not find a part of the path
+MonoTests.System.Xml.Serialization.XmlSchemaImporterTests.ImportWildcardElementAsClass
+MonoTests.System.XmlSerialization.XmlCodeExporterTests.DuplicateIdentifiers
+
+# Expected string length 566 but was 562. Strings differ at index 66.
+# Expected: "...piler.GeneratedCodeAttribute("nunit-lite-console", "0.0.0...."
+# But was:  "...piler.GeneratedCodeAttribute("SystemXmlTests", "0.0.0.0")]..."
+MonoTests.System.XmlSerialization.XmlCodeExporterTests.ExportTypeMapping_ArrayClass
+MonoTests.System.XmlSerialization.XmlCodeExporterTests.ExportTypeMapping_ArrayContainer
+MonoTests.System.XmlSerialization.XmlCodeExporterTests.ExportTypeMapping_CDataContainer
+MonoTests.System.XmlSerialization.XmlCodeExporterTests.ExportTypeMapping_ClassArrayContainer
+MonoTests.System.XmlSerialization.XmlCodeExporterTests.ExportTypeMapping_ItemChoiceType
+MonoTests.System.XmlSerialization.XmlCodeExporterTests.ExportTypeMapping_SimpleClassWithXmlAttributes
+MonoTests.System.XmlSerialization.XmlCodeExporterTests.ExportTypeMapping_ZeroFlagEnum

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -192,7 +192,7 @@ namespace BCLTestImporter {
 			(assembly: "xammac_net_4_5_System.Data_test.dll", platforms: new [] { Platform.MacOSFull, Platform.MacOSModern }), // issues https://github.com/xamarin/maccore/issues/1192 and https://github.com/xamarin/maccore/issues/1193
 			(assembly: "xammac_net_4_5_System.Security_test.dll", platforms: new [] { Platform.MacOSFull, Platform.MacOSModern }), // issue https://github.com/xamarin/maccore/issues/1197
 			(assembly: "xammac_net_4_5_System_test.dll", platforms: new [] { Platform.MacOSFull, Platform.MacOSModern }), // issues https://github.com/xamarin/maccore/issues/1199
-			(assembly: "xammac_net_4_5_System.Xml_test.dll", platforms: new [] { Platform.MacOSFull, Platform.MacOSModern }), // issues https://github.com/xamarin/maccore/issues/1201 and https://github.com/xamarin/maccore/issues/1202
+			(assembly: "xammac_net_4_5_System.Xml_test.dll", platforms: new [] { Platform.MacOSModern }), // ignored in modern because tests use System.Xml.Serialization.Advanced.SchemaImporterExtension
 			(assembly: "xammac_net_4_5_corlib_xunit-test.dll", platforms: new [] { Platform.MacOSFull, Platform.MacOSModern }), // issues https://github.com/xamarin/maccore/issues/1203
 			(assembly: "xammac_net_4_5_System.Core_xunit-test.dll", platforms: new [] { Platform.MacOSFull, Platform.MacOSModern }), // issue https://github.com/xamarin/maccore/issues/1204
 			(assembly: "xammac_net_4_5_System_xunit-test.dll", platforms: new [] { Platform.MacOSFull, Platform.MacOSModern }), // issue https://github.com/xamarin/maccore/issues/1209


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/1201
Fixes https://github.com/xamarin/maccore/issues/1202