### PR TITLE
[foundation] Add missing availability attributes. Fixes #5714

### DIFF
--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -986,6 +986,8 @@ namespace Foundation  {
 		ShortGeneric
 	}
 
+	[iOS (8,0)]
+	[Mac (10,10)]
 	[Native]
 	public enum NSItemProviderErrorCode : long {
 		Unknown = -1,
@@ -1064,6 +1066,8 @@ namespace Foundation  {
 		Long
 	}
 
+	[iOS (8,0)]
+	[Mac (10,10)]
 	[Native]
 	public enum NSMassFormatterUnit : long {
 		Gram = 11,
@@ -1073,6 +1077,8 @@ namespace Foundation  {
 		Stone = (6 << 8) + 3
 	}
 
+	[iOS (8,0)]
+	[Mac (10,10)]
 	[Native]
 	public enum NSLengthFormatterUnit : long {
 		Millimeter = 8,


### PR DESCRIPTION
verified with

* NSItemProviderErrorCode: https://developer.apple.com/documentation/foundation/nsitemprovidererrorcode?language=objc
* NSLengthFormatterUnit: https://developer.apple.com/documentation/foundation/nslengthformatterunit?language=occ
* NSMassFormatterUnit: https://developer.apple.com/documentation/foundation/nsmassformatterunit?language=occ

also NSQualityOfService was mentioned but it already have the correct attributes
https://developer.apple.com/documentation/foundation/nsqualityofservice?language=occ

Fixes https://github.com/xamarin/xamarin-macios/issues/5714