### PR TITLE
[tests] Don't run BitcodeNotSupported tests on watchOS.

### DIFF
--- a/tests/templates/WatchExtension/InterfaceController.cs
+++ b/tests/templates/WatchExtension/InterfaceController.cs
@@ -71,7 +71,7 @@ namespace monotouchtestWatchKitExtension
 		void LoadTests ()
 		{
 			runner = new WatchOSRunner ();
-			var categoryFilter = new NotFilter (new CategoryExpression ("MobileNotWorking,NotOnMac,NotWorking,ValueAdd,CAS,InetAccess,NotWorkingLinqInterpreter,RequiresBSDSockets").Filter);
+			var categoryFilter = new NotFilter (new CategoryExpression ("MobileNotWorking,NotOnMac,NotWorking,ValueAdd,CAS,InetAccess,NotWorkingLinqInterpreter,RequiresBSDSockets,BitcodeNotSupported").Filter);
 			if (!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("NUNIT_FILTER_START"))) {
 				var firstChar = Environment.GetEnvironmentVariable ("NUNIT_FILTER_START") [0];
 				var lastChar = Environment.GetEnvironmentVariable ("NUNIT_FILTER_END") [0];

--- a/tests/templates/WatchExtension/InterfaceController.fs
+++ b/tests/templates/WatchExtension/InterfaceController.fs
@@ -35,7 +35,7 @@ type InterfaceController (handle: IntPtr) =
 
     member this.LoadTests () =
         runner <- new WatchOSRunner ()
-        let ce = new CategoryExpression ("MobileNotWorking,NotOnMac,NotWorking,ValueAdd,CAS,InetAccess,NotWorkingLinqInterpreter")
+        let ce = new CategoryExpression ("MobileNotWorking,NotOnMac,NotWorking,ValueAdd,CAS,InetAccess,NotWorkingLinqInterpreter,BitcodeNotSupported")
         runner.Filter <- new NotFilter (ce.Filter)
         let tp = this.GetType ()
         runner.Add (tp.Assembly)


### PR DESCRIPTION
Ref: https://github.com/mono/mono/pull/13007