### PR TITLE
[tests] Check all architectures when verifying public symbols.

### DIFF
--- a/tests/mtouch/MTouchTool.cs
+++ b/tests/mtouch/MTouchTool.cs
@@ -803,10 +803,10 @@ public class IntentHandler : INExtension, IINRidesharingDomainHandling {
 			}
 		}
 
-		public static IEnumerable<string> GetNativeSymbolsInExecutable (string executable)
+		public static IEnumerable<string> GetNativeSymbolsInExecutable (string executable, string arch = null)
 		{
-			IEnumerable<string> rv = ExecutionHelper.Execute ("nm", $"-gUj {StringUtils.Quote (executable)}", hide_output: true).Split ('\n');
-
+			IEnumerable<string> rv = ExecutionHelper.Execute ("nm", $"{(arch == null ? string.Empty : $"-arch {arch} ")}-gUj {StringUtils.Quote (executable)}", hide_output: true).Split ('\n');
+			
 			rv = rv.Where ((v) => {
 				if (string.IsNullOrEmpty (v))
 					return false;

--- a/tests/mtouch/MiscTests.cs
+++ b/tests/mtouch/MiscTests.cs
@@ -98,6 +98,8 @@ namespace Xamarin.Tests
 				"_OBJC_CLASS_$_Xamarin",
 				"_OBJC_IVAR_$_Xamarin",
 				"__ZN13XamarinObject",
+				".objc_class_name_Xamarin", // 32-bit macOS naming scheme
+				".objc_category_name_NSObject_NonXamarinObject", // 32-bit macOS naming scheme
 				"_main",
 				 // I think these are inline functions from a header
 				"__Z7isasciii",
@@ -140,7 +142,7 @@ namespace Xamarin.Tests
 
 
 			foreach (var path in paths) {
-				var symbols = MTouchTool.GetNativeSymbolsInExecutable (path);
+				var symbols = MTouchTool.GetNativeSymbolsInExecutable (path, arch: "all");
 
 				// Remove known public symbols
 				symbols = symbols.Where ((v) => {
@@ -157,6 +159,10 @@ namespace Xamarin.Tests
 					case "_ReadZStream":
 					case "_WriteZStream":
 						return false;
+					// Helper objc_msgSend functions for arm64
+					case "_objc_msgSend_stret":
+					case "_objc_msgSendSuper_stret":
+						return false;
 					}
 
 					// Be a bit more lenient with symbols from the static registrar
@@ -166,6 +172,12 @@ namespace Xamarin.Tests
 						if (v.StartsWith ("_OBJC_IVAR_$", StringComparison.Ordinal))
 							return false;
 						if (v.StartsWith ("_OBJC_METACLASS_$", StringComparison.Ordinal))
+							return false;
+
+						// 32-bit macOS naming scheme:
+						if (v.StartsWith (".objc_class_name_", StringComparison.Ordinal))
+							return false;
+						if (v.StartsWith (".objc_category_name_", StringComparison.Ordinal))
 							return false;
 					}
 


### PR DESCRIPTION
Otherwise we'd only check x86_64 (the executing architecture) if the Mach-O
file had that architecture.

This also means updating the whitelisted symbols.