### PR TITLE
[xharness] Add UI option to not automatically uninstall apps after running a test on device.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -40,6 +40,7 @@ namespace xharness
 		public bool IncludeDocs;
 
 		public bool CleanSuccessfulTestRuns = true;
+		public bool UninstallTestApp = true;
 
 		public Log MainLog;
 		public Log SimulatorLoadLog;
@@ -1178,6 +1179,12 @@ namespace xharness
 							case "?do-not-clean":
 								CleanSuccessfulTestRuns = false;
 								break;
+							case "?uninstall-test-app":
+								UninstallTestApp = true;
+								break;
+							case "?do-not-uninstall-test-app":
+								UninstallTestApp = false;
+								break;
 							default:
 								throw new NotImplementedException (request.Url.Query);
 							}
@@ -1729,6 +1736,7 @@ namespace xharness
 	<li>Options
 			<ul>
 				<li class=""adminitem""><span id='{id_counter++}' class='autorefreshable'><a href='javascript:sendrequest (""set-option?{(CleanSuccessfulTestRuns ? "do-not-clean" : "clean")}"");'>&#x{(CleanSuccessfulTestRuns ? "2705" : "274C")} Clean successful test runs</a></span></li>
+				<li class=""adminitem""><span id='{id_counter++}' class='autorefreshable'><a href='javascript:sendrequest (""set-option?{(UninstallTestApp ? "do-not-uninstall-test-app" : "uninstall-test-app")}"");'>&#x{(UninstallTestApp ? "2705" : "274C")} Uninstall the app from device before and after the test run</a></span></li>
 			</ul>
 	</li>
 	");
@@ -3421,10 +3429,14 @@ namespace xharness
 					};
 
 					// Sometimes devices can't upgrade (depending on what has changed), so make sure to uninstall any existing apps first.
-					runner.MainLog = uninstall_log;
-					var uninstall_result = await runner.UninstallAsync ();
-					if (!uninstall_result.Succeeded)
-						MainLog.WriteLine ($"Pre-run uninstall failed, exit code: {uninstall_result.ExitCode} (this hopefully won't affect the test result)");
+					if (Jenkins.UninstallTestApp) {
+						runner.MainLog = uninstall_log;
+						var uninstall_result = await runner.UninstallAsync ();
+						if (!uninstall_result.Succeeded)
+							MainLog.WriteLine ($"Pre-run uninstall failed, exit code: {uninstall_result.ExitCode} (this hopefully won't affect the test result)");
+					} else {
+						uninstall_log.WriteLine ($"Pre-run uninstall skipped.");
+					}
 
 					if (!Failed) {
 						// Install the app
@@ -3483,10 +3495,14 @@ namespace xharness
 					}
 				} finally {
 					// Uninstall again, so that we don't leave junk behind and fill up the device.
-					runner.MainLog = uninstall_log;
-					var uninstall_result = await runner.UninstallAsync ();
-					if (!uninstall_result.Succeeded)
-						MainLog.WriteLine ($"Post-run uninstall failed, exit code: {uninstall_result.ExitCode} (this won't affect the test result)");
+					if (Jenkins.UninstallTestApp) {
+						runner.MainLog = uninstall_log;
+						var uninstall_result = await runner.UninstallAsync ();
+						if (!uninstall_result.Succeeded)
+							MainLog.WriteLine ($"Post-run uninstall failed, exit code: {uninstall_result.ExitCode} (this won't affect the test result)");
+					} else {
+						uninstall_log.WriteLine ($"Post-run uninstall skipped.");
+					}
 
 					// Also clean up after us locally.
 					if (Harness.InJenkins || Harness.InWrench || (Jenkins.CleanSuccessfulTestRuns && Succeeded))


### PR DESCRIPTION
This is useful when I want to re-run a test manually to debug failures. In
particular on the watch it's annoying to have to re-install the app.