### PR TITLE
[XHarness] Don't run BitcodeNotSupported BCL tests on watchOS.

### DIFF
--- a/tests/bcl-test/BCLTests/templates/watchOS/Extension/InterfaceController.cs
+++ b/tests/bcl-test/BCLTests/templates/watchOS/Extension/InterfaceController.cs
@@ -120,6 +120,7 @@ namespace monotouchtestWatchKitExtension
 					"CAS",
 					"InetAccess",
 					"NotWorkingLinqInterpreter",
+					"BitcodeNotSupported",
 				};
 
 			if (RegisterType.IsXUnit) {


### PR DESCRIPTION
Similar to PR https://github.com/xamarin/xamarin-macios/pull/5744