### PR TITLE
[d16-1] [msbuild] Xamarin.Mac Notary Support

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.targets
@@ -201,6 +201,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			SigningKey="$(_CodeSigningKey)"
 			ExtraArgs="$(CodesignExtraArgs)"
 			IsAppExtension="$(IsAppExtension)"
+			UseSecureTimestamp="$(UseHardenedRuntime)"
 			>
 		</Codesign>
 	</Target>
@@ -250,6 +251,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 			ExtraArgs="$(CodesignExtraArgs)"
 			IsAppExtension="$(IsAppExtension)"
 			UseHardenedRuntime="$(UseHardenedRuntime)"
+			UseSecureTimestamp="$(UseHardenedRuntime)"
 			>
 		</Codesign>
 	</Target>

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
@@ -46,6 +46,8 @@ namespace Xamarin.MacDev.Tasks
 		public bool IsAppExtension { get; set; }
 
 		public bool UseHardenedRuntime { get; set; }
+		
+		public bool UseSecureTimestamp { get; set; }
 
 		public string ToolExe {
 			get { return toolExe ?? ToolName; }
@@ -97,6 +99,9 @@ namespace Xamarin.MacDev.Tasks
 
 			if (UseHardenedRuntime)
 				args.Add ("-o runtime");
+
+			if (UseSecureTimestamp)
+				args.Add ("--timestamp");
 
 			args.Add ("--sign");
 			args.AddQuoted (SigningKey);

--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
@@ -102,6 +102,8 @@ namespace Xamarin.MacDev.Tasks
 
 			if (UseSecureTimestamp)
 				args.Add ("--timestamp");
+			else
+				args.Add ("--timestamp=none");
 
 			args.Add ("--sign");
 			args.AddQuoted (SigningKey);

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -715,7 +715,7 @@ namespace Xamarin.MMP.Tests
 				var baseOutput = TI.TestUnifiedExecutable (test);
 				string baseCodesign = findCodesign (baseOutput);
 				Assert.False (baseCodesign.Contains ("-o runtime"), "Base codesign");
-				Assert.False (baseCodesign.Contains ("--timestamp"), "Base codesign timestamp");
+				Assert.True (baseCodesign.Contains ("--timestamp=none"), "Base codesign timestamp");
 
 				test.CSProjConfig += "<UseHardenedRuntime>true</UseHardenedRuntime><CodeSignEntitlements>Entitlements.plist</CodeSignEntitlements>";
 

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -715,6 +715,7 @@ namespace Xamarin.MMP.Tests
 				var baseOutput = TI.TestUnifiedExecutable (test);
 				string baseCodesign = findCodesign (baseOutput);
 				Assert.False (baseCodesign.Contains ("-o runtime"), "Base codesign");
+				Assert.False (baseCodesign.Contains ("--timestamp"), "Base codesign timestamp");
 
 				test.CSProjConfig += "<UseHardenedRuntime>true</UseHardenedRuntime><CodeSignEntitlements>Entitlements.plist</CodeSignEntitlements>";
 
@@ -732,6 +733,8 @@ namespace Xamarin.MMP.Tests
 				var hardenedOutput = TI.TestUnifiedExecutable (test);
 				string hardenedCodesign = findCodesign (hardenedOutput);
 				Assert.True (hardenedCodesign.Contains ("-o runtime"), "Hardened codesign");
+				Assert.True (hardenedCodesign.Contains ("--timestamp"), "Hardened codesign timestamp");
+
 			});
 		}
 	}


### PR DESCRIPTION
Almost everything "just worked" after hardened runtime, once you get the certificate right.

However, we need the secure timestamp argument.

Backport of #5754.

/cc @chamons 