### PR TITLE
[mtouch] Consider deployment and simulator availability versions for frameworks. Fixes #5753

### DIFF
--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -449,8 +449,20 @@ namespace Xamarin.Bundler {
 		{
 			if (Driver.GetFrameworks (App).TryGetValue (file, out var framework) && framework.Version > App.SdkVersion)
 				ErrorHelper.Warning (135, "Did not link system framework '{0}' (referenced by assembly '{1}') because it was introduced in {2} {3}, and we're using the {2} {4} SDK.", file, FileName, App.PlatformName, framework.Version, App.SdkVersion);
-			else if (Frameworks.Add (file))
-				Driver.Log (3, "Linking with the framework {0} because it's referenced by a module reference in {1}", file, FileName);
+			else {
+#if MTOUCH
+				var strong = (framework == null) || (App.DeploymentTarget >= (App.IsSimulatorBuild ? framework.VersionAvailableInSimulator ?? framework.Version : framework.Version));
+#else
+				var strong = (framework == null) || (App.DeploymentTarget >= framework.Version);
+#endif
+				if (strong) {
+					if (Frameworks.Add (file))
+						Driver.Log (3, "Linking with the framework {0} because it's referenced by a module reference in {1}", file, FileName);
+				} else {
+					if (WeakFrameworks.Add (file))
+						Driver.Log (3, "Linking (weakly) with the framework {0} because it's referenced by a module reference in {1}", file, FileName);
+				}
+			}
 		}
 
 		public string GetCompressionLinkingFlag ()


### PR DESCRIPTION
E.g. `MetalPerformanceShaders` is unusable in 10.3.1 on the simulator so
trying to build with the static registrar cause simlauncher to be rebuilt
with a **strong** (and not _weak_) reference to the framework. This cause
a crash then the application start

```
Dyld Error Message:
  Library not loaded: /System/Library/Frameworks/MetalPerformanceShaders.framework/MetalPerformanceShaders
  Referenced from: /Users/USER/Library/Developer/CoreSimulator/Devices/95679F95-CCE7-4733-8376-35E91E97039C/data/Containers/Bundle/Application/0F665B2D-ADAC-4CA0-BD04-33E968B3F268/FailerApp.app/FailerApp
  Reason: no suitable image found.  Did find:
	/System/Library/Frameworks/MetalPerformanceShaders.framework/MetalPerformanceShaders: mach-o, but not built for iOS simulator
```

ref: https://github.com/xamarin/xamarin-macios/issues/5753