### PR TITLE
[mtouch] Make the SealerSubStep a configurable optimization

### DIFF
--- a/docs/website/optimizations.md
+++ b/docs/website/optimizations.md
@@ -696,3 +696,24 @@ It is always enabled by default (when the linker is enabled).
 
 The default behavior can be overridden by passing
 `--optimize=[+|-]inline-is-arm64-calling-convention` to mtouch/mmp.
+
+## Seal and Devirtualize
+
+This optimization requires the linker to be enabled and is applied globally
+on all code inside the application.
+
+When the linker _knows_ all the code inside an application it can do global
+optimization like:
+* sealing types (if not subclassed);
+* mark method has final (if not overriden in subclasses); and
+* devirtualize methods (if never overriden)
+
+The changes allow the AOT compiler to apply further optimizations when 
+generating native code.
+
+This optimization is not safe when dynamically loading code. As such it does
+not exists for Xamarin.Mac. For Xamarin.iOS it is enabled, by default,
+unless the interpreter is used.
+
+The default behavior can be overridden by passing
+`--optimize=[+|-]seal-and-devirtualize` to `mtouch`.

--- a/docs/website/optimizations.md
+++ b/docs/website/optimizations.md
@@ -704,15 +704,15 @@ on all code inside the application.
 
 When the linker _knows_ all the code inside an application it can do global
 optimization like:
-* sealing types (if not subclassed);
-* mark method has final (if not overriden in subclasses); and
+* seal types (if not subclassed);
+* mark method as final (if not overriden in subclasses); and
 * devirtualize methods (if never overriden)
 
 The changes allow the AOT compiler to apply further optimizations when 
 generating native code.
 
 This optimization is not safe when dynamically loading code. As such it does
-not exists for Xamarin.Mac. For Xamarin.iOS it is enabled, by default,
+not exist for Xamarin.Mac. For Xamarin.iOS it is enabled, by default,
 unless the interpreter is used.
 
 The default behavior can be overridden by passing

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1752,7 +1752,7 @@ public class TestApp {
 				mtouch.Linker = MTouchLinker.LinkSdk;
 				mtouch.Optimize = new string [] { "foo" };
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build");
-				mtouch.AssertWarning (132, "Unknown optimization: 'foo'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size, inline-runtime-arch, blockliteral-setupblock, register-protocols, inline-dynamic-registration-supported, static-block-to-delegate-lookup, remove-dynamic-registrar, remove-unsupported-il-for-bitcode, inline-is-arm64-calling-convention.");
+				mtouch.AssertWarning (132, "Unknown optimization: 'foo'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size, inline-runtime-arch, blockliteral-setupblock, register-protocols, inline-dynamic-registration-supported, static-block-to-delegate-lookup, remove-dynamic-registrar, remove-unsupported-il-for-bitcode, inline-is-arm64-calling-convention, seal-and-devirtualize.");
 			}
 		}
 
@@ -3563,7 +3563,8 @@ public partial class NotificationService : UNNotificationServiceExtension
 				mtouch.AssertWarning (2003, "Option '--optimize=remove-dynamic-registrar' will be ignored since the static registrar is not enabled");
 				mtouch.AssertWarning (2003, "Option '--optimize=static-block-to-delegate-lookup' will be ignored since the static registrar is not enabled");
 				mtouch.AssertWarning (2003, "Option '--optimize=inline-is-arm64-calling-convention' will be ignored since linking is disabled");
-				mtouch.AssertWarningCount (11);
+				mtouch.AssertWarning (2003, "Option '--optimize=seal-and-devirtualize' will be ignored since linking is disabled");
+				mtouch.AssertWarningCount (12);
 			}
 
 			using (var mtouch = new MTouchTool ()) {

--- a/tools/common/Optimizations.cs
+++ b/tools/common/Optimizations.cs
@@ -35,6 +35,11 @@ namespace Xamarin.Bundler
 			"", // dummy value to make indices match up between XM and XI
 #endif
 			"inline-is-arm64-calling-convention",
+#if MONOTOUCH
+			"seal-and-devirtualize",
+#else
+			"", // dummy value to make indices match up between XM and XI
+#endif
 		};
 
 		enum Opt
@@ -52,6 +57,7 @@ namespace Xamarin.Bundler
 			TrimArchitectures,
 			RemoveUnsupportedILForBitcode,
 			InlineIsARM64CallingConvention,
+			SealAndDevirtualize,
 		}
 
 		bool? all;
@@ -117,6 +123,13 @@ namespace Xamarin.Bundler
 			get { return values [(int) Opt.InlineIsARM64CallingConvention]; }
 			set { values [(int) Opt.InlineIsARM64CallingConvention] = value; }
 		}
+
+#if MONOTOUCH
+		public bool? SealAndDevirtualize {
+			get { return values [(int) Opt.SealAndDevirtualize]; }
+			set { values [(int) Opt.SealAndDevirtualize] = value; }
+		}
+#endif
 
 		public Optimizations ()
 		{
@@ -254,6 +267,11 @@ namespace Xamarin.Bundler
 			if (!RemoveUnsupportedILForBitcode.HasValue) {
 				// By default enabled for watchOS device builds.
 				RemoveUnsupportedILForBitcode = app.Platform == Utils.ApplePlatform.WatchOS && app.IsDeviceBuild;
+			}
+
+			if (!SealAndDevirtualize.HasValue) {
+				// by default run the linker SealerSubStep unless the interpreter is enabled
+				SealAndDevirtualize = !app.UseInterpreter;
 			}
 #endif
 			// By default Runtime.IsARM64CallingConvention inlining is always enabled.

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -165,7 +165,8 @@ namespace MonoTouch.Tuner {
 		{
 			SubStepDispatcher sub = new SubStepDispatcher ();
 			sub.Add (new MetadataReducerSubStep ());
-			sub.Add (new SealerSubStep ());
+			if (options.Application.Optimizations.SealAndDevirtualize == true)
+				sub.Add (new SealerSubStep ());
 			return sub;
 		}
 


### PR DESCRIPTION
document it and adjust the optimization tests.

This allows the optimization to be:
* disabled (if ever needed) on fully AOT'ed applications
* re-enabled for the interpreter (at your own risk)