### PR TITLE
[mtouch] Update validations around --interpreter

### DIFF
--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -251,6 +251,8 @@ Xcode 10 does not support building 32-bit applications.
 
 Change the architecture in the project's Mac Build options to 'x86_64' in order to build a 64-bit application.
 
+<!-- 0140-0142 taken my mtouch -->
+
 ## MM1xxx: file copy / symlinks (project related)
 
 <a name="MM1034" />

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -949,12 +949,14 @@ It might be a broken file or a broken symlink (after decompressing an archive) t
 
 <a name="MT0141"/>
 
-### MT0141: The interpreter is not supported in the simulator. Do not pass --interpreter when building for the simulator.
+### MT0141: The interpreter is not supported in the simulator. Switching to REPL which provide the same extra features on the simulator.
 
-This error occurs when enabling the interpreter on a simulator build.
+This warning is shown when enabling the interpreter on a simulator build.
 
 The interpreter is only available for device builds as an complete or partial alternative to the ahead-of-time (AOT) compilation.
 In contrast simulator builds are using just-in-time compilation which negates most advantages of the interpreter.
+
+However it is possible to test features such as `dynamic` and `System.Reflection.Emit `on the simulator using the existing REPL (read–eval–print loop) support on the simulator. This feature is automatically enabled when `--interpreter` is used on simulator builds. However the JIT remains the only option available on the simulator, while AOT and interpreter are for devices only.
 
 # MT1xxx: Project related error messages
 

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -958,6 +958,11 @@ In contrast simulator builds are using just-in-time compilation which negates mo
 
 However it is possible to test features such as `dynamic` and `System.Reflection.Emit `on the simulator using the existing REPL (read–eval–print loop) support on the simulator. This feature is automatically enabled when `--interpreter` is used on simulator builds. However the JIT remains the only option available on the simulator, while AOT and interpreter are for devices only.
 
+### MT0142: Cannot find the assembly '{assembly}', passed as an argument to --interpreter.
+
+This warning is shown if the assemblies names given to the `--interpreter` option (either to interpret them or not) cannot be found.
+
+
 # MT1xxx: Project related error messages
 
 ### MT10xx: Installer / mtouch

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1821,19 +1821,19 @@ public class B
 		}
 
 		[Test]
-		public void MT0138 ()
+		public void MT0142 ()
 		{
 			using (var mtouch = new MTouchTool ()) {
 				var tmpdir = mtouch.CreateTemporaryDirectory ();
 				mtouch.CreateTemporaryCacheDirectory ();
 
 				mtouch.CreateTemporaryApp ();
-				mtouch.WarnAsError = new int [] { 138 }; // This is just to make mtouch bail out early instead of spending time building the app when that's not what we're interested in.
+				mtouch.WarnAsError = new int [] { 142 }; // This is just to make mtouch bail out early instead of spending time building the app when that's not what we're interested in.
 				mtouch.Interpreter = "all,-all,foo,-bar,mscorlib.dll,mscorlib";
 				mtouch.AssertExecuteFailure (MTouchAction.BuildSim, "build");
-				mtouch.AssertError (138, "Cannot find the assembly 'foo', passed as an argument to --interpreter.");
-				mtouch.AssertError (138, "Cannot find the assembly 'bar', passed as an argument to --interpreter.");
-				mtouch.AssertError (138, "Cannot find the assembly 'mscorlib.dll', passed as an argument to --interpreter.");
+				mtouch.AssertError (142, "Cannot find the assembly 'foo', passed as an argument to --interpreter.");
+				mtouch.AssertError (142, "Cannot find the assembly 'bar', passed as an argument to --interpreter.");
+				mtouch.AssertError (142, "Cannot find the assembly 'mscorlib.dll', passed as an argument to --interpreter.");
 				// just the name, without the extension, is the right way.
 				mtouch.AssertErrorCount (3);
 			}

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1408,9 +1408,6 @@ namespace Xamarin.Bundler {
 			if (EnableBitCode && IsSimulatorBuild)
 				throw ErrorHelper.CreateError (84, "Bitcode is not supported in the simulator. Do not pass --bitcode when building for the simulator.");
 
-			if (UseInterpreter && IsSimulatorBuild)
-				throw ErrorHelper.CreateError (141, "The interpreter is not supported in the simulator. Do not pass --interpreter when building for the simulator.");
-
 			Namespaces.Initialize ();
 
 			if (Embeddinator) {

--- a/tools/mtouch/Target.cs
+++ b/tools/mtouch/Target.cs
@@ -289,7 +289,7 @@ namespace Xamarin.Bundler
 
 			// Verify that there are no entries in our list of intepreted assemblies that doesn't match
 			// any of the assemblies we know about.
-			if (App.UseInterpreter) {
+			if (App.InterpretedAssemblies.Count > 0) {
 				var exceptions = new List<Exception> ();
 				foreach (var entry in App.InterpretedAssemblies) {
 					var assembly = entry;
@@ -305,7 +305,7 @@ namespace Xamarin.Bundler
 					if (Assemblies.ContainsKey (assembly))
 						continue;
 
-					exceptions.Add (ErrorHelper.CreateWarning (138, $"Cannot find the assembly '{assembly}', passed as an argument to --interpreter."));
+					exceptions.Add (ErrorHelper.CreateWarning (142, $"Cannot find the assembly '{assembly}', passed as an argument to --interpreter."));
 				}
 				ErrorHelper.ThrowIfErrors (exceptions);
 			}

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1332,7 +1332,7 @@ namespace Xamarin.Bundler
 
 				// FIXME: the interpreter only supports ARM64 right now
 				// temporary - without a check here the error happens when deploying
-				if (!app.IsArchEnabled (Abi.ARM64))
+				if (!app.IsSimulatorBuild && !app.IsArchEnabled (Abi.ARM64))
 					throw ErrorHelper.CreateError (99, "Internal error: The interpreter is currently only available for 64 bits.");
 
 				// needs to be set after the argument validations

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1069,7 +1069,7 @@ namespace Xamarin.Bundler
 			{ "abi=", "Comma-separated list of ABIs to target. Currently supported: armv7, armv7+llvm, armv7+llvm+thumb2, armv7s, armv7s+llvm, armv7s+llvm+thumb2, arm64, arm64+llvm, i386, x86_64", v => app.ParseAbi (v) },
 			{ "override-abi=", "Override any previous abi. Only used for testing.", v => { app.ClearAbi (); app.ParseAbi (v); }, true }, // Temporary command line arg until XS has better support for 64bit architectures.
 			{ "cxx", "Enable C++ support", v => { app.EnableCxx = true; }},
-			{ "enable-repl:", "Enable REPL support. For simulator only and disabling linking is recommanded.", v => { app.EnableRepl = ParseBool (v, "enable-repl"); } },
+			{ "enable-repl:", "Enable REPL support. For simulator only and disabling linking is recommended.", v => { app.EnableRepl = ParseBool (v, "enable-repl"); } },
 			{ "pie:", "Enable (default) or disable PIE (Position Independent Executable).", v => { app.EnablePie = ParseBool (v, "pie"); }},
 			{ "compiler=", "Specify the Objective-C compiler to use (valid values are gcc, g++, clang, clang++ or the full path to a GCC-compatible compiler).", v => { app.Compiler = v; }},
 			{ "fastdev", "Build an app that supports fastdev (this app will only work when launched using Xamarin Studio)", v => { app.AddAssemblyBuildTarget ("@all=dynamiclibrary"); }},


### PR DESCRIPTION
This also centralize other interpreter checks and options in the same
location (making it easier to read / update).

* Warn and switch the REPL if the interpreter is enabled on simulator

Why ? It's confusing to build the same code using different options for
simulator and devices. This is what happens if you try to use features
like `dynamic` or `System.Reflection.Emit`.

So instead of an error, we warn that the interpreter is not supported
and switch to the existing REPL mode.

The JIT remains the only option for the simulator but it allows testing
features without a device.

* Fail early if the interpreter is used on 32bits [1]

The current interpreter only works on 64 bits (so ARM64). However the
error won't be reported, back to the developer, until deployment time.

This temporary [1] fix spot the condition very early and report an error

```
error MT0099 : Internal error : The interpreter is currently only available for 64 bits.
```

instead of the current one at deploy time

```
IncorrectArchitecture: Failed to find matching arch for 32-bit Mach-O input file /private/var/installd/Library/Caches/com.apple.mobile.installd.staging/temp.tNKDlx/extracted/X.app/X
error MT1006: Could not install the application 'X.app' on the device 'Mercure': AMDeviceSecureInstallApplicationBundle returned: 0xe8000087 (kAMDIncorrectArchitectureError).

Application could not be uploaded to the device.
```

[1] https://github.com/mono/mono/issues/9871