### PR TITLE
[xharness] Remove bitcode from tvOS apps.

### DIFF
--- a/tests/xharness/TVOSTarget.cs
+++ b/tests/xharness/TVOSTarget.cs
@@ -126,6 +126,12 @@ namespace xharness
 
 			inputProject.AddExtraMtouchArgs ("--bitcode:asmonly", "iPhone", "Release");
 			inputProject.SetMtouchUseLlvm (true, "iPhone", "Release");
+
+			// Remove bitcode from executables, since we don't need it for testing, and it makes test apps bigger (and the Apple TV might refuse to install them).
+			var configurations = new string [] { "Debug", "Debug64", "Release", "Release64" };
+			foreach (var c in configurations) {
+				inputProject.AddExtraMtouchArgs ($"--gcc_flags=-fembed-bitcode-marker", "iPhone", c);
+			}
 		}
 	}
 }


### PR DESCRIPTION
We don't need the bitcode for testing, it makes test apps bigger (so big that
the Apple TV might refuse to install them).