### PR TITLE
[d16-1] [runtime] Use mono_array_setref instead of mono_array_set.

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -192,6 +192,12 @@
 			"void *", "val"
 		),
 
+		new Export ("void", "mono_gc_wbarrier_set_arrayref",
+			"MonoArray *", "arr",
+			"void *", "slot_ptr",
+			"MonoObject *", "value"
+		),
+
 		#endregion
 
 		#region metadata/profiler.h

--- a/runtime/mono-runtime.h.t4
+++ b/runtime/mono-runtime.h.t4
@@ -98,10 +98,11 @@ typedef void (*mono_reference_queue_callback) (void *user_data);
 
 #define mono_array_addr(array,type,index) ((type*)(void*) mono_array_addr_with_size (array, sizeof (type), index))
 #define mono_array_get(array,type,index) ( *(type*)mono_array_addr ((array), type, (index)) )
-#define mono_array_set(array,type,index,value)	\
+#define mono_array_setref(array,index,value)	\
 	do {	\
-		type *__p = (type *) mono_array_addr ((array), type, (index));	\
-		*__p = (value);	\
+		void **__p = (void **) mono_array_addr ((array), void*, (index));	\
+		mono_gc_wbarrier_set_arrayref ((array), __p, (MonoObject*)(value));	\
+		/* *__p = (value);*/	\
 	} while (0)
 
 /* metadata/assembly.h */

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -320,7 +320,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 							for (j = 0; j < [arr count]; j++) {
 								if (e_klass == mono_get_string_class ()) {
 									NSString *sv = (NSString *) [arr objectAtIndex: j];
-									mono_array_set (m_arr, MonoString *, j, mono_string_new (mono_domain_get (), [sv UTF8String]));
+									mono_array_setref (m_arr, j, mono_string_new (mono_domain_get (), [sv UTF8String]));
 								} else {
 									MonoObject *obj;
 									id targ = [arr objectAtIndex: j];
@@ -330,7 +330,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 #if DEBUG
 									xamarin_verify_parameter (obj, sel, self, targ, i, e_klass, method);
 #endif
-									mono_array_set (m_arr, MonoObject *, j, obj);
+									mono_array_setref (m_arr, j, obj);
 								}
 							}
 

--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -270,7 +270,7 @@ namespace CoreText {
 					return;
 				}
 				Adapter.SetValue (Dictionary, CTFontFeatureKey.Selectors,
-						NSArray.FromNSObjects (v.ConvertAll (e => (NSObject) e.Dictionary)));
+						NSArray.FromNSObjects ((IList<NSObject>) v.ConvertAll (e => (NSObject) e.Dictionary)));
 			}
 		}
 	}

--- a/src/CoreText/CTFontDescriptor.cs
+++ b/src/CoreText/CTFontDescriptor.cs
@@ -263,7 +263,7 @@ namespace CoreText {
 					return;
 				}
 				Adapter.SetValue (Dictionary, CTFontDescriptorAttributeKey.Features,
-						NSArray.FromNSObjects (v.ConvertAll (e => (NSObject) e.Dictionary)));
+						NSArray.FromNSObjects ((IList<NSObject>) v.ConvertAll (e => (NSObject) e.Dictionary)));
 			}
 		}
 
@@ -280,7 +280,7 @@ namespace CoreText {
 				}
 
 				Adapter.SetValue (Dictionary, CTFontDescriptorAttributeKey.FeatureSettings,
-						NSArray.FromNSObjects (v.ConvertAll (e => (NSObject) e.Dictionary)));
+						NSArray.FromNSObjects ((IList<NSObject>) v.ConvertAll (e => (NSObject) e.Dictionary)));
 			}
 		}
 

--- a/src/Foundation/NSArray.cs
+++ b/src/Foundation/NSArray.cs
@@ -59,6 +59,16 @@ namespace Foundation {
 			return FromNativeObjects (items, count);
 		}
 
+		public static NSArray FromNSObjects<T> (params T [] items) where T: class, INativeObject
+		{
+			return FromNativeObjects (items);
+		}
+
+		public static NSArray FromNSObjects<T> (int count, params T [] items) where T: class, INativeObject
+		{
+			return FromNativeObjects (items, count);
+		}
+
 		public static NSArray FromNSObjects<T> (Func<T, NSObject> nsobjectificator, params T [] items)
 		{
 			if (nsobjectificator == null)
@@ -104,15 +114,15 @@ namespace Foundation {
 			return FromNSObjects (nsoa);
 		}
 		
-		internal static NSArray FromNativeObjects (INativeObject[] items)
+		internal static NSArray FromNativeObjects<T> (T[] items) where T: class, INativeObject
 		{
 			if (items == null)
 				return new NSArray ();
 
-			return FromNativeObjects (items, items.Length);
+			return FromNativeObjects<T> (items, items.Length);
 		}
 
-		internal static NSArray FromNativeObjects (INativeObject [] items, nint count)
+		internal static NSArray FromNativeObjects<T> (T [] items, nint count) where T: class, INativeObject
 		{
 			if (items == null)
 				return new NSArray ();

--- a/tests/bindings-test/ApiDefinition.cs
+++ b/tests/bindings-test/ApiDefinition.cs
@@ -212,6 +212,39 @@ namespace Bindings.Test {
 
 		[Export ("outNSErrorOnStack:obj:obj:int64:i:err:")]
 		void OutNSErrorOnStack (NSObject i1, NSObject i2, NSObject i3, long i4, int i5, out NSError error);
+
+		[NullAllowed]
+		[Export ("stringArrayProperty")]
+		string[] StringArrayProperty { get; set; }
+
+		[Export ("setStringArrayMethod:")]
+		void SetStringArrayMethod ([NullAllowed] string[] array);
+
+		[return: NullAllowed]
+		[Export ("getStringArrayMethod")]
+		string[] GetStringArrayMethod ();
+
+		[NullAllowed]
+		[Export ("nsobjectArrayProperty")]
+		NSObject[] NSObjectArrayProperty { get; set; }
+
+		[Export ("setNSObjectArrayMethod:")]
+		void SetNSObjectArrayMethod ([NullAllowed] NSObject[] array);
+
+		[return: NullAllowed]
+		[Export ("getNSObjectArrayMethod")]
+		NSObject[] GetNSObjectArrayMethod ();
+
+		[NullAllowed]
+		[Export ("INSCodingArrayProperty")]
+		INSCoding[] INSCodingArrayProperty { get; set; }
+
+		[Export ("setINSCodingArrayMethod:")]
+		void SetINSCodingArrayMethod ([NullAllowed] INSCoding[] array);
+
+		[return: NullAllowed]
+		[Export ("getINSCodingArrayMethod")]
+		INSCoding[] GetINSCodingArrayMethod ();
 	}
 
 	[Protocol]

--- a/tests/test-libraries/libtest.h
+++ b/tests/test-libraries/libtest.h
@@ -110,6 +110,19 @@ typedef unsigned int (^RegistrarTestBlock) (unsigned int magic);
 
 	-(void) outNSErrorOnStack:(int)i1 i:(int)i2 i:(int)i3 i:(int)i4 i:(int)i5 i:(int)i6 err:(NSError **)err; // 6 in regs, 7th (out) in mem (on all architectures)
 	-(void) outNSErrorOnStack:(id)obj1 obj:(id)obj2 obj:(id)obj3 int64:(long long)l4 i:(int)i5 err:(NSError **)err; // 5 in regs, 6th (out) in mem (on at least x86-64)
+
+	@property (nonatomic, retain) NSArray *stringArrayProperty;
+	-(void) setStringArrayMethod:(NSArray *) array;
+	-(NSArray *) getStringArrayMethod;
+
+	@property (nonatomic, retain) NSArray *nsobjectArrayProperty;
+	-(void) setNSObjectArrayMethod: (NSArray *) array;
+	-(NSArray *) getNSObjectArrayMethod;
+
+	@property (nonatomic, retain) NSArray *INSCodingArrayProperty;
+	-(void) setINSCodingArrayMethod: (NSArray *) array;
+	-(NSArray *) getINSCodingArrayMethod;
+
 @end
 
 @protocol ProtocolAssignerProtocol

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -446,6 +446,37 @@ static UltimateMachine *shared;
 	{
 		// Nothing to do here
 	}
+
+	-(void) setStringArrayMethod:(NSArray *) array
+	{
+		self.stringArrayProperty = array;
+	}
+
+	-(NSArray *) getStringArrayMethod
+	{
+		return self.stringArrayProperty;
+	}
+
+	-(void) setNSObjectArrayMethod: (NSArray *) array
+	{
+		self.nsobjectArrayProperty = array;
+	}
+
+	-(NSArray *) getNSObjectArrayMethod
+	{
+		return self.nsobjectArrayProperty;
+	}
+
+	-(void) setINSCodingArrayMethod: (NSArray *) array
+	{
+		self.INSCodingArrayProperty = array;
+	}
+
+	-(NSArray *) getINSCodingArrayMethod
+	{
+		return self.INSCodingArrayProperty;
+	}
+
 @end
 
 @implementation ProtocolAssigner

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3542,7 +3542,7 @@ namespace Registrar {
 						setup_call_stack.AppendLine ("for (j = 0; j < [arr count]; j++) {{", i);
 						if (elementType.FullName == "System.String") {
 							setup_call_stack.AppendLine ("NSString *sv = (NSString *) [arr objectAtIndex: j];", i);
-							setup_call_stack.AppendLine ("mono_array_set (marr, MonoString *, j, mono_string_new (mono_domain_get (), [sv UTF8String]));", i);
+							setup_call_stack.AppendLine ("mono_array_setref (marr, j, mono_string_new (mono_domain_get (), [sv UTF8String]));", i);
 						} else if (IsNSObject (elementType) || (elementType.Namespace == "System" && elementType.Name == "Object") || (isNativeObject = IsNativeObject (elementType))) {
 							setup_call_stack.AppendLine ("NSObject *nobj = [arr objectAtIndex: j];");
 							setup_call_stack.AppendLine ("MonoObject *mobj{0} = NULL;", i);
@@ -3585,7 +3585,7 @@ namespace Registrar {
 								setup_call_stack.AppendLine ("xamarin_verify_parameter (mobj{0}, _cmd, self, nobj, {0}, e_class, managed_method);", i);
 							}
 							setup_call_stack.AppendLine ("}");
-							setup_call_stack.AppendLine ("mono_array_set (marr, MonoObject *, j, mobj{0});", i);
+							setup_call_stack.AppendLine ("mono_array_setref (marr, j, mobj{0});", i);
 						} else {
 							throw ErrorHelper.CreateError (App, 4111, method.Method, "The registrar cannot build a signature for type `{0}' in method `{1}`.", type.FullName, descriptiveMethodName);
 						}


### PR DESCRIPTION
Otherwise the GC won't know about the assignment, and the assigned value can
be freed if it's no longer referenced anywhere else.

This also includes an update to NSArray to make it possible to create an
NSArray from an array of INativeObjects (for the tests).

Backport of #5782.

/cc @rolfbjarne 