### PR TITLE
[d16-1] [Foundation] Ensure that Connection Losts exceptions are more reliable.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -204,9 +204,7 @@ namespace Foundation {
 		void RemoveInflightData (NSUrlSessionTask task, bool cancel = true)
 		{
 			lock (inflightRequestsLock) {
-				InflightData data;
-				if (inflightRequests.TryGetValue (task, out data)) {
-					data = inflightRequests [task];
+				if (inflightRequests.TryGetValue (task, out var data)) {
 					if (cancel)
 						data.CancellationTokenSource.Cancel ();
 					data.Dispose ();

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -444,8 +444,6 @@ namespace Foundation {
 
 				// this can happen if the HTTP request times out and it is removed as part of the cancellation process
 				if (inflight != null) {
-					// set the stream as finished
-					inflight.Stream.TrySetReceivedAllData ();
 
 					// send the error or send the response back
 					if (error != null) {
@@ -461,6 +459,8 @@ namespace Foundation {
 							inflight.Stream.TrySetException (exc);
 						}
 					} else {
+						// set the stream as finished
+						inflight.Stream.TrySetReceivedAllData ();
 						inflight.Completed = true;
 						SetResponse (inflight);
 					}

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -210,8 +210,8 @@ namespace Foundation {
 					if (cancel)
 						data.CancellationTokenSource.Cancel ();
 					data.Dispose ();
+					inflightRequests.Remove (task);
 				}
-				inflightRequests.Remove (task);
 #if !MONOMAC  && !MONOTOUCH_WATCH
 				// do we need to be notified? If we have not inflightData, we do not
 				if (inflightRequests.Count == 0)


### PR DESCRIPTION
In some cases, when the connection is lost, the Stream is not set to
have an exception and continues the read as normal. We need to ensure
that the stream cannot be read when setting the response to an
exception. We block the reading, set both exceptions and continue. In
that case, the exception will be correctly raised when trying to read
from the stream.

A new check has to be done after the clean up of the stream if the
session is using caching.

Fixes https://github.com/xamarin/xamarin-macios/issues/5215

Backport of #5769.

/cc @mandel-macaque 