### PR TITLE
[mtouch] Fix warning in RemoveBitcodeIncompatibleCodeStep.cs

### DIFF
--- a/tools/linker/MonoTouch.Tuner/RemoveBitcodeIncompatibleCodeStep.cs
+++ b/tools/linker/MonoTouch.Tuner/RemoveBitcodeIncompatibleCodeStep.cs
@@ -7,11 +7,9 @@ using Mono.Linker.Steps;
 
 using Xamarin.Bundler;
 using Xamarin.Linker;
+using Xamarin.Tuner;
 using Mono.Linker;
 using System;
-
-using Xamarin.Tuner;
-using Xamarin.Linker;
 
 namespace MonoTouch.Tuner {
 	public class RemoveBitcodeIncompatibleCodeStep : ExceptionalSubStep {


### PR DESCRIPTION
```
/Users/poupou/git/master/xamarin-macios/tools/linker/MonoTouch.Tuner/RemoveBitcodeIncompatibleCodeStep.cs(14,7): warning CS0105: The using directive for 'Xamarin.Linker' appeared previously in this namespace [/Users/poupou/git/master/xamarin-macios/tools/mtouch/mtouch.csproj]
```