### PR TITLE
[XHarness] Make TvOS and WatchOS use their test dlls.

### DIFF
--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestAssemblyDefinition.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestAssemblyDefinition.cs
@@ -10,8 +10,8 @@ namespace BCLTestImporter {
 		static string partialPath = "mcs/class/lib";
 		static Dictionary <Platform, string> platformPathMatch = new Dictionary <Platform, string> {
 			{Platform.iOS, "monotouch"},
-			{Platform.WatchOS, "monotouch"},
-			{Platform.TvOS, "monotouch"},
+			{Platform.WatchOS, "monotouch_watch"},
+			{Platform.TvOS, "monotouch_tv"},
 			{Platform.MacOSFull, "xammac_net_4_5"},
 			{Platform.MacOSModern, "xammac_net_4_5"},
 		};
@@ -30,6 +30,18 @@ namespace BCLTestImporter {
 			// the following pattern is used when generating xunit test
 			// assemblies
 			IsXUnit = name.Contains ("_xunit-test");
+		}
+		
+		public string GetName (Platform platform)
+		{
+			switch (platform) {
+			case Platform.WatchOS:
+				return Name.Replace ("monotouch_", "monotouch_watch_");
+			case Platform.TvOS:
+				return Name.Replace ("monotouch_", "monotouch_tv_");
+			default:
+				return Name;
+			}
 		}
 
 		/// <summary>
@@ -76,7 +88,7 @@ namespace BCLTestImporter {
 		{
 			var testsRootPath = wasDownloaded? GetTestDirectoryFromDownloadsPath (rootPath, platform) : 
 				GetTestDirectoryFromMonoPath (rootPath, platform);
-			return Path.Combine (testsRootPath, Name);
+			return Path.Combine (testsRootPath, GetName (platform));
 		}
 	}
 }

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectDefinition.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -131,7 +131,7 @@ namespace BCLTestImporter {
 					a => (assembly: a, 
 						hintPath: BCLTestAssemblyDefinition.GetHintPathForRefenreceAssembly (a, monoRootPath, platform))).Union (
 					TestAssemblies.Select (
-						definition => (assembly: definition.Name,
+						definition => (assembly: definition.GetName (platform),
 							hintPath: definition.GetPath (monoRootPath, platform, wasDownloaded))))
 				.ToList ();
 

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -357,7 +357,17 @@ namespace BCLTestImporter {
 			return sb.ToString ();
 		}
 
-		internal static string GetCommonIgnoreFileName (string projectName) => $"common-{projectName}.ignore";
+		internal static string GetCommonIgnoreFileName (string name, Platform platform)
+		{
+			switch (platform) {
+			case Platform.TvOS:
+				return $"common-{name.Replace ("monotouch_tv_", "monotouch_")}.ignore";
+			case Platform.WatchOS:
+				return $"common-{name.Replace ("monotouch_watch_", "monotouch_")}.ignore";
+			default:
+				return $"common-{name}.ignore";
+			}
+		} 
 		
 		internal static string[] GetIgnoreFileNames (string name, Platform platform)
 		{
@@ -375,14 +385,13 @@ namespace BCLTestImporter {
 			default:
 				return null;
 			}
-
 		}
 		
 		internal static IEnumerable<string> GetIgnoreFiles (string templatePath, string projectName, List<(string assembly, string hintPath)> assemblies, Platform platform)
 		{
 			// check if the common and plaform paths can be found in the template path, if they are, we return them
 			var templateDir = Path.GetDirectoryName (templatePath);
-			var commonIgnore = Path.Combine (templateDir, GetCommonIgnoreFileName (projectName));
+			var commonIgnore = Path.Combine (templateDir, GetCommonIgnoreFileName (projectName, platform));
 			if (File.Exists (commonIgnore))
 				yield return commonIgnore;
 			foreach (var platformFile in GetIgnoreFileNames (projectName, platform)) {
@@ -393,7 +402,7 @@ namespace BCLTestImporter {
 			// do we have ignores per files and not the project name? Add them
 			foreach (var (assembly, hintPath) in assemblies) {
 				foreach (var platformFile in GetIgnoreFileNames (assembly, platform)) {
-					var commonAssemblyIgnore = Path.Combine (templateDir, GetCommonIgnoreFileName (assembly));
+					var commonAssemblyIgnore = Path.Combine (templateDir, GetCommonIgnoreFileName (assembly, platform));
 					if (File.Exists (commonAssemblyIgnore))
 						yield return commonAssemblyIgnore;
 					var platformAssemblyIgnore = Path.Combine (templateDir, platformFile);

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -465,7 +465,7 @@ namespace BCLTestImporter {
 
 				if (!projectDefinition.Validate ())
 					throw new InvalidOperationException ("xUnit and NUnit assemblies cannot be mixed in a test project.");
-				var generatedCodeDir = Path.Combine (generatedDir, projectDefinition.Name);
+				var generatedCodeDir = Path.Combine (generatedDir, projectDefinition.Name, "watch");
 				if (!Directory.Exists (generatedCodeDir)) {
 					Directory.CreateDirectory (generatedCodeDir);
 				}
@@ -550,7 +550,7 @@ namespace BCLTestImporter {
 				if (!projectDefinition.Validate ())
 					throw new InvalidOperationException ("xUnit and NUnit assemblies cannot be mixed in a test project.");
 				// generate the required type registration info
-				var generatedCodeDir = Path.Combine (generatedDir, projectDefinition.Name);
+				var generatedCodeDir = Path.Combine (generatedDir, projectDefinition.Name, (platform == Platform.iOS)?"ios": "tv");
 				if (!Directory.Exists (generatedCodeDir)) {
 					Directory.CreateDirectory (generatedCodeDir);
 				}
@@ -572,7 +572,7 @@ namespace BCLTestImporter {
 					using (var file = new StreamWriter (projectPath, false)) { // false is do not append
 						await file.WriteAsync (generatedProject);
 					}
-					var typesPerAssembly = projectDefinition.GetTypeForAssemblies (GetReleaseDownload (Platform.iOS), Platform.iOS, true);
+					var typesPerAssembly = projectDefinition.GetTypeForAssemblies (GetReleaseDownload (Platform.iOS), platform, true);
 					var registerCode = await RegisterTypeGenerator.GenerateCodeAsync (typesPerAssembly,
 						projectDefinition.IsXUnit, RegisterTypesTemplatePath);
 
@@ -603,7 +603,7 @@ namespace BCLTestImporter {
 				if (!projectDefinition.Validate ())
 					throw new InvalidOperationException ("xUnit and NUnit assemblies cannot be mixed in a test project.");
 				// generate the required type registration info
-				var generatedCodeDir = Path.Combine (generatedDir, projectDefinition.Name);
+				var generatedCodeDir = Path.Combine (generatedDir, projectDefinition.Name, "mac");
 				Directory.CreateDirectory (generatedCodeDir);
 				var registerTypePath = Path.Combine (generatedCodeDir, "RegisterType-mac.cs");
 

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -147,6 +147,7 @@ namespace BCLTestImporter {
 
 		static readonly List<string> watcOSIgnoredAssemblies = new List<string> {
 			"monotouch_Mono.Security_test.dll",
+			"monotouch_Mono.Data.Tds_test.dll", // not present in the watch tests dlls
 		};
 
 		private static readonly List<(string name, string[] assemblies, string group)> macTestProjects = new List<(string name, string[] assemblies, string group)> {

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -369,9 +369,9 @@ namespace BCLTestImporter {
 			case Platform.MacOSModern:
 				return new string [] { $"macOSModern-{name}.ignore", $"macOS-{name}.ignore" };
 			case Platform.TvOS:
-				return new string [] { $"tvOS-{name}.ignore" };
+				return new string [] { $"tvOS-{name.Replace ("monotouch_tv_", "monotouch_")}.ignore" };
 			case Platform.WatchOS:
-				return new string [] { $"watchOS-{name}.ignore" };
+				return new string [] { $"watchOS-{name.Replace ("monotouch_watch_", "monotouch_")}.ignore" };
 			default:
 				return null;
 			}


### PR DESCRIPTION
Up to this commit the test dlls used for the bcl were from iOS. Since
the Mono SDK provides the dlls for both missing platforms (TvOS and
WatchOS) we can now use the correct path for the dlls.

There is a small trick to minimize the project generation, since there
is a simple string.Replace, the logic now checks the platform under
test and does:

* TvOS - Goes from monotouch_TEST_NAME to monotouch_tv_TEST_NAME
* WatchOS - Gores from monotouch_TEST_NAME to monotouch_watch_TEST_NAME