### PR TITLE
Backport device bcl tests

### DIFF
--- a/tests/bcl-test/BCLTests/templates/common/TestRunner.Core/TcpTextWriter.cs
+++ b/tests/bcl-test/BCLTests/templates/common/TestRunner.Core/TcpTextWriter.cs
@@ -77,7 +77,7 @@ namespace BCLTests.TestRunner.Core {
 #endif
 
 			try {
-				client = new TcpClient (hostName, port);
+				client = new TcpClient (HostName, port);
 				writer = new StreamWriter (client.GetStream ());
 			}
 			catch {


### PR DESCRIPTION
This fixes present in master will fix a number of crashes we have in the VSTS tests while testing on device.