### PR TITLE
[xharness] Fix BuildOnly logic

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -374,6 +374,7 @@ namespace xharness
 					T newVariation = creator (build, task);
 					newVariation.Variation = variation;
 					newVariation.Ignored = task.Ignored || ignored;
+					newVariation.BuildOnly = task.BuildOnly;
 					rv.Add (newVariation);
 				}
 			}


### PR DESCRIPTION
https://github.com/xamarin/xamarin-macios/pull/4884 introduced the logic of only building certain `RunTestTask`.
This was meant to disable iOS Extensions as part of a fix to https://github.com/xamarin/maccore/issues/1008.
However this didn't quite work and iOS extensions were still running (and failing).
The reason being that `BuildOnly` was set to a `RunDeviceTask` that's added to a list which is then given to `CreateTestVariations` which creates new instances of `RunDeviceTask`.
We now propagate `BuildOnly` to the new variation instance.