### PR TITLE
[xharness] Display test assemblies contained in a BCL test group

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1860,6 +1860,10 @@ namespace xharness
 							writer.WriteLine ("</div>");
 							writer.WriteLine ($"<div id='logs_{log_id}' class='autorefreshable logs togglable' data-onautorefresh='{log_id}' style='display: {defaultDisplay};'>");
 
+							var testAssemblies = test.ReferencedNunitAndXunitTestAssemblies;
+							if (testAssemblies.Any ())
+								writer.WriteLine ($"Test assemblies:<br/>- {String.Join ("<br/>- ", testAssemblies)}<br />");
+
 							if (!string.IsNullOrEmpty (test.FailureMessage)) {
 								var msg = HtmlFormat (test.FailureMessage);
 								var prefix = test.Ignored ? "Ignored" : "Failure";
@@ -2318,6 +2322,26 @@ namespace xharness
 		public Logs Logs {
 			get {
 				return logs ?? (logs = new Logs (LogDirectory));
+			}
+		}
+
+		IEnumerable<string> referencedNunitAndXunitTestAssemblies;
+		public IEnumerable<string> ReferencedNunitAndXunitTestAssemblies {
+			get {
+				if (referencedNunitAndXunitTestAssemblies != null)
+					return referencedNunitAndXunitTestAssemblies;
+
+				if (TestName.Contains ("BCL tests group")) { // avoid loading unrelated projects
+					if (!File.Exists (ProjectFile))
+						return Enumerable.Empty<string> ();
+
+					var csproj = new XmlDocument ();
+					csproj.LoadWithoutNetworkAccess (ProjectFile.Replace ("\\", "/"));
+					referencedNunitAndXunitTestAssemblies = csproj.GetNunitAndXunitTestReferences ();
+				} else {
+					referencedNunitAndXunitTestAssemblies = Enumerable.Empty<string> ();
+				}
+				return referencedNunitAndXunitTestAssemblies;
 			}
 		}
 

--- a/tests/xharness/ProjectFileExtensions.cs
+++ b/tests/xharness/ProjectFileExtensions.cs
@@ -598,6 +598,17 @@ namespace xharness
 					yield return node.Attributes ["Include"].Value;
 			}
 		}
+
+		public static IEnumerable<string> GetNunitAndXunitTestReferences (this XmlDocument csproj)
+		{
+			var nodes = csproj.SelectNodes ("//*[local-name() = 'Reference']");
+			foreach (XmlNode node in nodes) {
+				var includeValue = node.Attributes ["Include"].Value;
+				if (includeValue.EndsWith ("_test.dll") || includeValue.EndsWith ("_xunit-test.dll"))
+					yield return includeValue;
+			}
+		}
+
 		public static void SetProjectReferenceValue (this XmlDocument csproj, string projectInclude, string node, string value)
 		{
 			var nameNode = csproj.SelectSingleNode ("//*[local-name() = 'ProjectReference' and @Include = '" + projectInclude + "']/*[local-name() = '" + node + "']");

--- a/tests/xharness/ProjectFileExtensions.cs
+++ b/tests/xharness/ProjectFileExtensions.cs
@@ -604,7 +604,7 @@ namespace xharness
 			var nodes = csproj.SelectNodes ("//*[local-name() = 'Reference']");
 			foreach (XmlNode node in nodes) {
 				var includeValue = node.Attributes ["Include"].Value;
-				if (includeValue.EndsWith ("_test.dll") || includeValue.EndsWith ("_xunit-test.dll"))
+				if (includeValue.EndsWith ("_test.dll", StringComparison.Ordinal) || includeValue.EndsWith ("_xunit-test.dll", StringComparison.Ordinal))
 					yield return includeValue;
 			}
 		}


### PR DESCRIPTION
Example:

![image](https://user-images.githubusercontent.com/1376924/55163535-40f9b280-516a-11e9-9af8-17f3ba74e14b.png)
