### PR TITLE
[Jenkins] When running tests on VSTS do specify a device type.

### DIFF
--- a/jenkins/vsts-device-tests-set-status.sh
+++ b/jenkins/vsts-device-tests-set-status.sh
@@ -41,7 +41,7 @@ fi
 
 if test -z "$DEVICE_TYPE"; then
 	# set a default value
-	DEVICE_TYPE="iOS/AppleTv"
+	DEVICE_TYPE="iOS/tvOS"
 fi
 
 P=$(cat tmp.p)

--- a/jenkins/vsts-device-tests-set-status.sh
+++ b/jenkins/vsts-device-tests-set-status.sh
@@ -69,7 +69,7 @@ else
 			;;
 	esac
 fi
-./jenkins/add-commit-status.sh --token="$TOKEN" --hash="$BUILD_REVISION" --state="$GH_STATE" --target-url="$VSTS_BUILD_URL" --description="$DESCRIPTION" --context="VSTS: device tests"
+./jenkins/add-commit-status.sh --token="$TOKEN" --hash="$BUILD_REVISION" --state="$GH_STATE" --target-url="$VSTS_BUILD_URL" --description="$DESCRIPTION" --context="VSTS: device tests ($DEVICE_TYPE)"
 
 if test -z "$START"; then
 	# When we're done, add a GitHub comment to the commit we're testing
@@ -85,7 +85,7 @@ if test -z "$START"; then
 
 	FILE=$PWD/tests/TestSummary.md
 	if ! test -f "$FILE"; then
-		printf "🔥 Tests failed catastrophically on $DEVICE_TYPE (no summary found)\\n" >> "$MESSAGE_FILE"
+		printf "🔥 Tests failed catastrophically on $DEVICE_TYPE  (no summary found)\\n" >> "$MESSAGE_FILE"
 	else
 		cat "$FILE" >> "$MESSAGE_FILE"
 	fi


### PR DESCRIPTION
We are going to split the work between different types of devices:

- iOS
- iOS Beta
- AppleTv
- AppleTv Beta

So the idea is that before we have the beta devices and the split execution, we should be able to pass the device type so that when the person doing the monitoring can state which of the devices failed.

We add a default value so that the device test works.