### PR TITLE
[Foundation] Make adding/removing observers in NSNotificationCenter thread safe.

### DIFF
--- a/src/Foundation/NSNotificationCenter.cs
+++ b/src/Foundation/NSNotificationCenter.cs
@@ -121,25 +121,28 @@ namespace Foundation {
 
 		void AddObserverToList (NSObject observer, string aName, NSObject anObject)
 		{
-			__mt_ObserverList_var.Add (new ObservedData { Observer = observer, Name = aName, Object = anObject });
+			lock (__mt_ObserverList_var)
+				__mt_ObserverList_var.Add (new ObservedData { Observer = observer, Name = aName, Object = anObject });
 			MarkDirty ();
 		}
 
 		void RemoveObserversFromList (NSObject observer, string aName, NSObject anObject)
 		{
-			for (int i = __mt_ObserverList_var.Count - 1; i >= 0; i--) {
-				ObservedData od = __mt_ObserverList_var [i];
+			lock (__mt_ObserverList_var) {
+				for (int i = __mt_ObserverList_var.Count - 1; i >= 0; i--) {
+					ObservedData od = __mt_ObserverList_var [i];
 
-				if (observer != od.Observer)
-					continue;
+					if (observer != od.Observer)
+						continue;
 
-				if (aName != null && aName != od.Name)
-					continue;
+					if (aName != null && aName != od.Name)
+						continue;
 
-				if (anObject != null && anObject != od.Object)
-					continue;
+					if (anObject != null && anObject != od.Object)
+						continue;
 
-				__mt_ObserverList_var.RemoveAt (i);
+					__mt_ObserverList_var.RemoveAt (i);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
NSNotificationCenter is thread-safe, so that observers can be added and
removed in multiple threads simultaneously.

Unfortunately our own helper code wasn't, so make sure to fix that by locking
around all accesses to the observer list.

And add a test case as well.