### PR TITLE
[d16-0] Bump mono to get fix for mono/mono#13610.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 [submodule "external/mono"]
     path = external/mono
     url = ../../mono/mono.git
-    branch = 2018-08
+    branch = 2018-08-rc
 [submodule "external/opentk"]
     path = external/opentk
     url = ../../mono/opentk.git


### PR DESCRIPTION
Commit list for mono/mono:

* mono/mono@74451376043 [2018-08-rc][llvm] Fix the computation of size of gshared instances in emit_args_to_vtype (). (#13723)
* mono/mono@5ad371dab1b Make `System.dll` internals visible to `Mono.Android`.

Diff: https://github.com/mono/mono/compare/163f45d81ced56e0d359f35564ed217e9c0b00de...74451376043f52fee7fbae08b68e649ea35078cf