### PR TITLE
[Intents] Update according to breaking changes from Apple.

### DIFF
--- a/src/intents.cs
+++ b/src/intents.cs
@@ -77,9 +77,9 @@ namespace Intents {
 		FailureRequiringAppLaunch,
 		FailureNoMatchingWorkout,
 		[NoWatch, iOS (11,0)]
-		Success,
-		[NoWatch, iOS (11,0)]
 		HandleInApp,
+		[NoWatch, iOS (11,0)]
+		Success,
 	}
 
 	[iOS (10, 0)]
@@ -159,9 +159,9 @@ namespace Intents {
 		FailureRequiringAppLaunch,
 		FailureNoMatchingWorkout,
 		[NoWatch, iOS (11,0)]
-		Success,
-		[NoWatch, iOS (11,0)]
 		HandleInApp,
+		[NoWatch, iOS (11,0)]
+		Success,
 	}
 
 	[iOS (10, 0)]
@@ -349,9 +349,9 @@ namespace Intents {
 		FailureRequiringAppLaunch,
 		FailureNoMatchingWorkout,
 		[NoWatch, iOS (11,0)]
-		Success,
-		[NoWatch, iOS (11,0)]
 		HandleInApp,
+		[NoWatch, iOS (11,0)]
+		Success,
 	}
 
 	[iOS (10, 0)]
@@ -528,9 +528,9 @@ namespace Intents {
 		FailureRequiringAppLaunch,
 		FailureNoMatchingWorkout,
 		[NoWatch, iOS (11,0)]
-		Success,
-		[NoWatch, iOS (11,0)]
 		HandleInApp,
+		[NoWatch, iOS (11,0)]
+		Success,
 	}
 
 	[iOS (10, 0)]
@@ -825,9 +825,9 @@ namespace Intents {
 		FailureOngoingWorkout,
 		FailureNoMatchingWorkout,
 		[Watch (4,0), iOS (11,0)]
-		Success,
-		[Watch (4,0), iOS (11,0)]
 		HandleInApp,
+		[Watch (4,0), iOS (11,0)]
+		Success,
 	}
 
 	[iOS (10, 0)]

--- a/src/intents.cs
+++ b/src/intents.cs
@@ -76,8 +76,10 @@ namespace Intents {
 		Failure,
 		FailureRequiringAppLaunch,
 		FailureNoMatchingWorkout,
+		[Advice ("The numerical value for this constant was different in iOS 11 and earlier iOS versions (it was 7, which is now defined as 'Success').")]
 		[NoWatch, iOS (11,0)]
 		HandleInApp,
+		[Advice ("The numerical value for this constant was different in iOS 11 and earlier iOS versions (it was 6, which is now defined as 'HandleInApp').")]
 		[NoWatch, iOS (11,0)]
 		Success,
 	}
@@ -158,8 +160,10 @@ namespace Intents {
 		Failure,
 		FailureRequiringAppLaunch,
 		FailureNoMatchingWorkout,
+		[Advice ("The numerical value for this constant was different in iOS 11 and earlier iOS versions (it was 7, which is now defined as 'Success').")]
 		[NoWatch, iOS (11,0)]
 		HandleInApp,
+		[Advice ("The numerical value for this constant was different in iOS 11 and earlier iOS versions (it was 6, which is now defined as 'HandleInApp').")]
 		[NoWatch, iOS (11,0)]
 		Success,
 	}
@@ -348,8 +352,10 @@ namespace Intents {
 		Failure,
 		FailureRequiringAppLaunch,
 		FailureNoMatchingWorkout,
+		[Advice ("The numerical value for this constant was different in iOS 11 and earlier iOS versions (it was 7, which is now defined as 'Success').")]
 		[NoWatch, iOS (11,0)]
 		HandleInApp,
+		[Advice ("The numerical value for this constant was different in iOS 11 and earlier iOS versions (it was 6, which is now defined as 'HandleInApp').")]
 		[NoWatch, iOS (11,0)]
 		Success,
 	}
@@ -527,8 +533,10 @@ namespace Intents {
 		Failure,
 		FailureRequiringAppLaunch,
 		FailureNoMatchingWorkout,
+		[Advice ("The numerical value for this constant was different in iOS 11 and earlier iOS versions (it was 7, which is now defined as 'Success').")]
 		[NoWatch, iOS (11,0)]
 		HandleInApp,
+		[Advice ("The numerical value for this constant was different in iOS 11 and earlier iOS versions (it was 6, which is now defined as 'HandleInApp').")]
 		[NoWatch, iOS (11,0)]
 		Success,
 	}
@@ -824,8 +832,10 @@ namespace Intents {
 		FailureRequiringAppLaunch,
 		FailureOngoingWorkout,
 		FailureNoMatchingWorkout,
+		[Advice ("The numerical value for this constant was different in iOS 11 and earlier iOS versions (it was 7, which is now defined as 'Success').")]
 		[Watch (4,0), iOS (11,0)]
 		HandleInApp,
+		[Advice ("The numerical value for this constant was different in iOS 11 and earlier iOS versions (it was 6, which is now defined as 'HandleInApp').")]
 		[Watch (4,0), iOS (11,0)]
 		Success,
 	}


### PR DESCRIPTION
Reference: https://trello.com/c/dtVv2a6R/131-43425168-inworkoutintentresponsecode-enum-values-changed
Reference: rdar://43425168

Working around this breaking change becomes quite complicates, so I just
exposed it instead. Customers can still work around it if needed by casting
the expected numeric value to the enum type.