### PR TITLE
[mmp] Don't apply libintl hack when you explicitly ask for that file

### DIFF
--- a/tests/mmptest/src/NativeReferencesTests.cs
+++ b/tests/mmptest/src/NativeReferencesTests.cs
@@ -210,5 +210,20 @@ namespace Xamarin.MMP.Tests
 				NativeReferenceTestCore (tmpDir, test, "MultipleNativeReferences_OnlyInvokeMMPOneTime_AndCopyEverythingIn", null, true);
 			});
 		}
+
+
+		[Test]
+		public void ReferenceNativeRefNoCodeUsage_ShouldStillCopy ()
+		{
+			MMPTests.RunMMPTest (tmpDir => {
+				TI.UnifiedTestConfig test = new TI.UnifiedTestConfig (tmpDir) {
+					XM45 = true,
+					ItemGroup = CreateSingleNativeRef ("/Library/Frameworks/Mono.framework/Libraries/libintl.dylib", "Dynamic")
+				};
+				var log = TI.TestUnifiedExecutable (test);
+				Console.WriteLine (log.BuildOutput);
+				Assert.True (File.Exists (Path.Combine (tmpDir, "bin/Debug/XM45Example.app/Contents/MonoBundle/libintl.dylib")));
+			});
+		}
 	}
 }

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -1559,7 +1559,7 @@ namespace Xamarin.Bundler {
 				return true;
 			}
 			// Shutup the warning until we decide on bug: 36478
-			if (shortendName.ToLowerInvariant () == "intl" && IsUnifiedFullXamMacFramework)
+			if (shortendName.ToLowerInvariant () == "intl" && !native_references.Any (x => x.Contains ("libintl.dylib")) && IsUnifiedFullXamMacFramework)
 				return true;
 			return false;
 		}


### PR DESCRIPTION
- A long while ago, this hack was added to mmp:
```
 	// Shutup the warning until we decide on bug: 36478
	if (shortendName.ToLowerInvariant () == "intl" && IsUnifiedFullXamMacFramework)
```
- This breaks use cases were we explicitly ask for that file, so let's
fix that for now until we can fix the root cause for real