### PR TITLE
[ObjCRuntime] Add helper functions for resolving type/method tokens.

### DIFF
--- a/src/ObjCRuntime/Blocks.cs
+++ b/src/ObjCRuntime/Blocks.cs
@@ -259,7 +259,7 @@ namespace ObjCRuntime {
 			baseMethod = null;
 
 			if (token_ref != Runtime.INVALID_TOKEN_REF)
-				return (Type) Class.ResolveTokenReference (token_ref, 0x02000000 /* TypeDef */);
+				return Class.ResolveTypeTokenReference (token_ref);
 
 			baseMethod = minfo.GetBaseDefinition ();
 			var delegateProxies = baseMethod.ReturnTypeCustomAttributes.GetCustomAttributes (typeof (DelegateProxyAttribute), false);

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -657,12 +657,7 @@ namespace ObjCRuntime {
 
 		static unsafe IntPtr GetMethodFromToken (uint token_ref)
 		{
-			var method = Class.ResolveTokenReference (token_ref, 0x06000000);
-
-			var mb = method as MethodBase;
-			if (method != null && mb == null)
-				throw ErrorHelper.CreateError (8022, $"Expected the token reference 0x{token_ref:X} to be a method, but it's a {method.GetType ().Name}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new.");
-			
+			var method = Class.ResolveMethodTokenReference (token_ref);
 			if (method != null)
 				return ObjectWrapper.Convert (method);
 
@@ -671,19 +666,15 @@ namespace ObjCRuntime {
 
 		static unsafe IntPtr GetGenericMethodFromToken (IntPtr obj, uint token_ref)
 		{
-			var method = Class.ResolveTokenReference (token_ref, 0x06000000);
+			var method = Class.ResolveMethodTokenReference (token_ref);
 			if (method == null)
 				return IntPtr.Zero;
 
-			var mb = method as MethodBase;
-			if (mb == null)
-				throw ErrorHelper.CreateError (8022, $"Expected the token reference 0x{token_ref:X} to be a method, but it's a {method.GetType ().Name}. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new.");
-
 			var nsobj = ObjectWrapper.Convert (obj) as NSObject;
 			if (nsobj == null)
-				throw ErrorHelper.CreateError (8023, $"An instance object is required to construct a closed generic method for the open generic method: {mb.DeclaringType.FullName}.{mb.Name} (token reference: 0x{token_ref:X}). Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new.");
+				throw ErrorHelper.CreateError (8023, $"An instance object is required to construct a closed generic method for the open generic method: {method.DeclaringType.FullName}.{method.Name} (token reference: 0x{token_ref:X}). Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new.");
 
-			return ObjectWrapper.Convert (FindClosedMethod (nsobj.GetType (), mb));
+			return ObjectWrapper.Convert (FindClosedMethod (nsobj.GetType (), method));
 		}
 
 		static IntPtr TryGetOrConstructNSObjectWrapped (IntPtr ptr)
@@ -1480,7 +1471,7 @@ namespace ObjCRuntime {
 					if (token != INVALID_TOKEN_REF) {
 						var wrapper_token = xamarin_find_protocol_wrapper_type (token);
 						if (wrapper_token != INVALID_TOKEN_REF)
-							return (Type)Class.ResolveTokenReference (wrapper_token, 0x02000000 /* TypeDef */);
+							return Class.ResolveTypeTokenReference (wrapper_token);
 					}
 				}
 			}


### PR DESCRIPTION
This reduces code duplication a little bit.