### PR TITLE
[XHarness] Use better names for BCL watchOS tests. Fixes #5157

### DIFF
--- a/tests/xharness/WatchOSTarget.cs
+++ b/tests/xharness/WatchOSTarget.cs
@@ -209,7 +209,10 @@ namespace xharness
 
 		protected override void CalculateName ()
 		{
-			base.CalculateName ();
+			if (TargetDirectory.Contains ("BCLTests"))
+				Name = TestProject.Name;
+			else
+				base.CalculateName ();
 			if (MonoNativeInfo != null)
 				Name = Name + MonoNativeInfo.FlavorSuffix;
 		}


### PR DESCRIPTION
Ensure we do not use the target dir because that does not represent the
name of the test because it is shared by all of them.

Fixes https://github.com/xamarin/xamarin-macios/issues/5157