### PR TITLE
[XHarness] Ignore System.Data tests until the correct fix lands in mono.

### DIFF
--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -143,6 +143,7 @@ namespace BCLTestImporter {
 		static readonly List<string> iOSIgnoredAssemblies = new List<string> {};
 
 		static readonly List<string> tvOSIgnoredAssemblies = new List<string> {
+			"monotouch_System.Data_xunit-test.dll", // ignore until we have PR https://github.com/mono/mono/pull/13935
 		};
 
 		static readonly List<string> watcOSIgnoredAssemblies = new List<string> {


### PR DESCRIPTION
The tests fail on device, they can be reneabled after we get PR
https://github.com/mono/mono/pull/13935 landed and backported.