### PR TITLE
[tests][test-libraries] Fix struct declarations to not create symbols everywhere.

### DIFF
--- a/tests/test-libraries/testgenerator.cs
+++ b/tests/test-libraries/testgenerator.cs
@@ -156,7 +156,8 @@ static class C {
 			for (int i = 0; i < s.Length; i++) {
 				w.Append (GetNativeName (s [i])).Append (" x").Append (i).Append ("; ");
 			}
-			w.AppendLine ($"}} S{s};");
+			w.AppendLine ($"}};");
+			w.AppendLine ($"typedef struct S{s} S{s};");
 		}
 
 		File.WriteAllText ("libtest.structs.h", w.ToString ());


### PR DESCRIPTION
This fixes a build problem with the interdependent-binding-projects test:

    clang : error : linker command failed with exit code 1 (use -v to see invocation) [.../tests/xharness/tmp-test-dir/interdependent-binding-projects2601/interdependent-binding-projects-tvos.csproj]
    MTOUCH : error MT5212: Native linking failed, duplicate symbol: '_Sssss'. [.../tests/xharness/tmp-test-dir/interdependent-binding-projects2601/interdependent-binding-projects-tvos.csproj]
    MTOUCH : error MT5212: Native linking failed, duplicate symbol: '_Ssss'. [.../tests/xharness/tmp-test-dir/interdependent-binding-projects2601/interdependent-binding-projects-tvos.csproj]
    MTOUCH : error MT5212: Native linking failed, duplicate symbol: '_Sss'. [.../tests/xharness/tmp-test-dir/interdependent-binding-projects2601/interdependent-binding-projects-tvos.csproj]