### PR TITLE
[tests][mono-native] Adjust logic which is causing tests to fail on tvOS.

### DIFF
--- a/tests/mono-native/Introspection.cs
+++ b/tests/mono-native/Introspection.cs
@@ -109,11 +109,7 @@ namespace Xamarin.Tests
 				if (MonoNativeConfig.LinkMode != MonoNativeLinkMode.Static) {
 					var symbol = Dlfcn.dlsym (dylib, "mono_native_initialize");
 
-#if MONOTOUCH_TV || MONOTOUCH_WATCH // on tvOS/watchOS we emit a native reference for P/Invokes in all assemblies (thus dlsym won't find any symbols)
-					Assert.That (symbol, Is.EqualTo (IntPtr.Zero), "dlsym() not found mono_native_initialize()");
-#else
 					Assert.That (symbol, Is.Not.EqualTo (IntPtr.Zero), "dlsym() found mono_native_initialize()");
-#endif
 				}
 			} finally {
 				Dlfcn.dlclose (dylib);

--- a/tests/mono-native/Introspection.cs
+++ b/tests/mono-native/Introspection.cs
@@ -106,10 +106,17 @@ namespace Xamarin.Tests
 			Assert.That (dylib, Is.Not.EqualTo (IntPtr.Zero), "dlopen()ed mono-native");
 
 			try {
-				if (MonoNativeConfig.LinkMode != MonoNativeLinkMode.Static) {
-					var symbol = Dlfcn.dlsym (dylib, "mono_native_initialize");
+#if MONOTOUCH_TV || MONOTOUCH_WATCH // on tvOS/watchOS we emit a native reference for P/Invokes in all assemblies, so we'll strip away the 'mono_native_initialize' symbol when we're linking statically (since we don't need the symbol).
+				var has_symbol = MonoNativeConfig.LinkMode != MonoNativeLinkMode.Static;
+#else
+				var has_symbol = true;
+#endif
+				var symbol = Dlfcn.dlsym (dylib, "mono_native_initialize");
 
+				if (has_symbol) {
 					Assert.That (symbol, Is.Not.EqualTo (IntPtr.Zero), "dlsym() found mono_native_initialize()");
+				} else {
+					Assert.That (symbol, Is.EqualTo (IntPtr.Zero), "dlsym() did not find mono_native_initialize()");
 				}
 			} finally {
 				Dlfcn.dlclose (dylib);

--- a/tests/mono-native/Introspection.cs
+++ b/tests/mono-native/Introspection.cs
@@ -107,7 +107,7 @@ namespace Xamarin.Tests
 
 			try {
 #if MONOTOUCH_TV || MONOTOUCH_WATCH // on tvOS/watchOS we emit a native reference for P/Invokes in all assemblies, so we'll strip away the 'mono_native_initialize' symbol when we're linking statically (since we don't need the symbol).
-				var has_symbol = MonoNativeConfig.LinkMode != MonoNativeLinkMode.Static;
+				var has_symbol = MonoNativeConfig.LinkMode != MonoNativeLinkMode.Static || Runtime.Arch == Arch.SIMULATOR;
 #else
 				var has_symbol = true;
 #endif


### PR DESCRIPTION
Fixes this when running on tvOS using dylibs:

> [FAIL] Introspection.CheckSymbols : dlsym() not found mono_native_initialize()

Now:

* If on iOS, we'll always have the `mono_native_initialize` symbol, because the symbol is used in P/Invoke in a user assembly (the test assembly itself), and mtouch will make the AOT-compiled code use dlsym for P/Invokes in user assemblies (and when using dlsym we can't (native) strip away the symbol).
* If on watchOS or tvOS, we'll have the symbol when we're loading `mono_native_initialize` from a dylib. If loading `mono_native_initialize` from a static library, we can (native) strip away the symbol because mtouch will make the AOT-compiled P/Invoke use a static reference to the native symbol, and thus the `mono_native_initialize` symbol will not be present in the executable.