### PR TITLE
[registrar] Make Runtime.GetINativeObject_Static take token references instead of type names.

### DIFF
--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -170,8 +170,8 @@
 		new XDelegate ("MonoObject *", "IntPtr", "xamarin_get_inative_object_static",
 			"id", "IntPtr", "obj",
 			"bool", "bool", "owns",
-			"const char *", "string", "type_name",
-			"const char *", "string", "iface_name"
+			"unsigned int", "uint", "iface_token_ref",
+			"unsigned int", "uint", "implementation_token_ref"
 		) {
 			WrappedManagedFunction = "GetINativeObject_Static",
 			OnlyDynamicUsage = false,

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -692,14 +692,14 @@ namespace ObjCRuntime {
 			return ObjectWrapper.Convert (GetINativeObject (ptr, owns, type));
 		}
 			
-		static IntPtr GetINativeObject_Static (IntPtr ptr, bool owns, string typename, string ifacename)
+		static IntPtr GetINativeObject_Static (IntPtr ptr, bool owns, uint iface_token, uint implementation_token)
 		{
 			/* 
 			 * This method is called from generated code from the static registrar.
 			 */
 
-			var iface = Type.GetType (ifacename, true);
-			var type = Type.GetType (typename, true);
+			var iface = Class.ResolveTypeTokenReference (iface_token);
+			var type = Class.ResolveTypeTokenReference (implementation_token);
 			return ObjectWrapper.Convert (GetINativeObject (ptr, owns, iface, type));
 		}
 

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3569,7 +3569,8 @@ namespace Registrar {
 
 
 								if (nativeObjType.IsInterface) {
-									setup_call_stack.AppendLine ("mobj{0} = xamarin_get_inative_object_static (nobj, false, \"{1}\", \"{2}\");", i, GetAssemblyQualifiedName (nativeObjType), GetAssemblyQualifiedName (elementType));
+									setup_call_stack.AppendLine ("mobj{0} = xamarin_get_inative_object_static (nobj, false, 0x{1:X} /* {2} */, 0x{3:X} /* {4} */, &exception_gchandle);", i, CreateTokenReference (elementType, TokenType.TypeDef), elementType.FullName, CreateTokenReference (nativeObjType, TokenType.TypeDef), nativeObjType.FullName);
+									setup_call_stack.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
 								} else {
 									// find the MonoClass for this parameter
 									setup_call_stack.AppendLine ("MonoType *type{0};", i);
@@ -3675,7 +3676,7 @@ namespace Registrar {
 							if (isOut) {
 								setup_call_stack.AppendLine ("inobj{0} = NULL;", i);
 							} else if (td.IsInterface) {
-								setup_call_stack.AppendLine ("inobj{0} = xamarin_get_inative_object_static (*p{0}, false, \"{1}\", \"{2}\", &exception_gchandle);", i, GetAssemblyQualifiedName (nativeObjType), GetAssemblyQualifiedName (td));
+								setup_call_stack.AppendLine ("inobj{0} = xamarin_get_inative_object_static (*p{0}, false, 0x{1:X} /* {2} */, 0x{3:X} /* {4} */, &exception_gchandle);", i, CreateTokenReference (td, TokenType.TypeDef), td.FullName, CreateTokenReference (nativeObjType, TokenType.TypeDef), nativeObjType.FullName);
 								setup_call_stack.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
 							} else {
 								setup_call_stack.AppendLine ("inobj{0} = xamarin_get_inative_object_dynamic (*p{0}, false, mono_type_get_object (mono_domain_get (), type{0}), &exception_gchandle);", i);
@@ -3689,7 +3690,7 @@ namespace Registrar {
 							copyback.AppendLine ("*p{0} = (id) handle{0};", i);
 						} else {
 							if (td.IsInterface) {
-								setup_call_stack.AppendLine ("arg_ptrs [{0}] = xamarin_get_inative_object_static (p{0}, false, \"{1}\", \"{2}\", &exception_gchandle);", i, GetAssemblyQualifiedName (nativeObjType), GetAssemblyQualifiedName (td));
+								setup_call_stack.AppendLine ("arg_ptrs [{0}] = xamarin_get_inative_object_static (p{0}, false, 0x{1:X} /* {2} */, 0x{3:X} /* {4} */, &exception_gchandle);", i, CreateTokenReference (td, TokenType.TypeDef), td.FullName, CreateTokenReference (nativeObjType, TokenType.TypeDef), nativeObjType.FullName);
 							} else {
 								setup_call_stack.AppendLine ("arg_ptrs [{0}] = xamarin_get_inative_object_dynamic (p{0}, false, mono_type_get_object (mono_domain_get (), type{0}), &exception_gchandle);", i);
 							}


### PR DESCRIPTION
Saves some space in the executable by using 32-bit sized integers instead of much longer strings.