### PR TITLE
[d16-1] [MSBuild] Fix the codesign of f# app extensions.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.AppExtension.FSharp.targets
@@ -44,8 +44,6 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 
-	<Import Project="Xamarin.iOS.AppExtension.Common.targets" />
-
 	<!-- xbuild searches multiple MSBuildExtensionsPath32, but only in the Import element so we can't determine this with a variable -->
 	<Import
 		Condition="'$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')"
@@ -59,4 +57,7 @@ Copyright (C) 2014-2016 Xamarin. All rights reserved.
 
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
+
+	<Import Project="Xamarin.iOS.AppExtension.Common.targets" />
+
 </Project>


### PR DESCRIPTION
We need to import the iOS common after the core f# ones to ensure they do
not override the wrong ones.

Fixes: https://github.com/xamarin/xamarin-macios/issues/3684

Backport of #5884.

/cc @mandel-macaque 