### PR TITLE
[bgen] Add support for sequential and parallel execution of the generator within the same process.

### DIFF
--- a/src/ObjCRuntime/BindAsAttribute.cs
+++ b/src/ObjCRuntime/BindAsAttribute.cs
@@ -45,7 +45,7 @@ namespace ObjCRuntime {
 		{
 			Type = type;
 #if BGENERATOR
-			var nullable = type.IsArray ? TypeManager.GetUnderlyingNullableType (type.GetElementType ()) : TypeManager.GetUnderlyingNullableType (type);
+			var nullable = type.IsArray ? Generator.TypeManager.GetUnderlyingNullableType (type.GetElementType ()) : Generator.TypeManager.GetUnderlyingNullableType (type);
 			IsNullable = nullable != null;
 			IsValueType = IsNullable ? nullable.IsValueType : type.IsValueType;
 #endif

--- a/src/ObjCRuntime/BindAsAttribute.cs
+++ b/src/ObjCRuntime/BindAsAttribute.cs
@@ -44,17 +44,27 @@ namespace ObjCRuntime {
 		public BindAsAttribute (Type type)
 		{
 			Type = type;
-#if BGENERATOR
-			var nullable = type.IsArray ? Generator.TypeManager.GetUnderlyingNullableType (type.GetElementType ()) : Generator.TypeManager.GetUnderlyingNullableType (type);
-			IsNullable = nullable != null;
-			IsValueType = IsNullable ? nullable.IsValueType : type.IsValueType;
-#endif
 		}
 		public Type Type;
 		public Type OriginalType;
 #if BGENERATOR
-		internal readonly bool IsNullable;
-		internal readonly bool IsValueType;
+		Type nullable;
+		Type GetNullable (Generator generator)
+		{
+			if (nullable == null)
+				nullable = Type.IsArray ? generator.TypeManager.GetUnderlyingNullableType (Type.GetElementType ()) : generator.TypeManager.GetUnderlyingNullableType (Type);
+			return nullable;
+		}
+
+		internal bool IsNullable (Generator generator)
+		{
+			return GetNullable (generator) != null;
+		}
+		internal bool IsValueType (Generator generator)
+		{
+			return IsNullable (generator) ? GetNullable (generator).IsValueType : Type.IsValueType;
+
+		}
 #endif
 	}
 }

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -822,17 +822,17 @@ namespace Registrar {
 					var mi = (System.Reflection.MethodInfo) Method;
 					bool is_stret;
 #if __WATCHOS__
-					is_stret = Runtime.Arch == Arch.DEVICE ? Stret.ArmNeedStret (NativeReturnType) : Stret.X86NeedStret (NativeReturnType);
+					is_stret = Runtime.Arch == Arch.DEVICE ? Stret.ArmNeedStret (NativeReturnType, null) : Stret.X86NeedStret (NativeReturnType, null);
 #elif MONOMAC
-					is_stret = IntPtr.Size == 8 ? Stret.X86_64NeedStret (NativeReturnType) : Stret.X86NeedStret (NativeReturnType);
+					is_stret = IntPtr.Size == 8 ? Stret.X86_64NeedStret (NativeReturnType, null) : Stret.X86NeedStret (NativeReturnType, null);
 #elif __IOS__
 					if (Runtime.Arch == Arch.DEVICE) {
-						is_stret = IntPtr.Size == 4 && Stret.ArmNeedStret (NativeReturnType);
+						is_stret = IntPtr.Size == 4 && Stret.ArmNeedStret (NativeReturnType, null);
 					} else {
-						is_stret = IntPtr.Size == 4 ? Stret.X86NeedStret (NativeReturnType) : Stret.X86_64NeedStret (NativeReturnType);
+						is_stret = IntPtr.Size == 4 ? Stret.X86NeedStret (NativeReturnType, null) : Stret.X86_64NeedStret (NativeReturnType, null);
 					}
 #elif __TVOS__
-					is_stret = Runtime.Arch == Arch.SIMULATOR && Stret.X86_64NeedStret (NativeReturnType);
+					is_stret = Runtime.Arch == Arch.SIMULATOR && Stret.X86_64NeedStret (NativeReturnType, null);
 #else
 	#error unknown architecture
 #endif

--- a/src/ObjCRuntime/Stret.cs
+++ b/src/ObjCRuntime/Stret.cs
@@ -39,7 +39,6 @@ namespace ObjCRuntime
 	{
 #if BGENERATOR
 		public static BindingTouch BindingTouch;
-		static TypeManager TypeManager { get { return BindingTouch.TypeManager; } }
 #elif __UNIFIED__
 		const bool isUnified = true;
 #else
@@ -52,11 +51,11 @@ namespace ObjCRuntime
 			return members <= 4;
 		}
 
-		static bool IsHomogeneousAggregateBaseType_Armv7k (Type t)
+		static bool IsHomogeneousAggregateBaseType_Armv7k (Type t, Generator generator)
 		{
 			// https://github.com/llvm-mirror/clang/blob/82f6d5c9ae84c04d6e7b402f72c33638d1fb6bc8/lib/CodeGen/TargetInfo.cpp#L5500-L5514
 #if BGENERATOR
-			if (t == TypeManager.System_Float || t == TypeManager.System_Double || t == TypeManager.System_nfloat)
+			if (t == generator.TypeManager.System_Float || t == generator.TypeManager.System_Double || t == generator.TypeManager.System_nfloat)
 				return true;
 #else
 			if (t == typeof (float) || t == typeof (double) || t == typeof (nfloat))
@@ -66,7 +65,7 @@ namespace ObjCRuntime
 			return false;
 		}
 
-		static bool IsHomogeneousAggregate_Armv7k (List<Type> fieldTypes)
+		static bool IsHomogeneousAggregate_Armv7k (List<Type> fieldTypes, Generator generator)
 		{
 			// Very simplified version of https://github.com/llvm-mirror/clang/blob/82f6d5c9ae84c04d6e7b402f72c33638d1fb6bc8/lib/CodeGen/TargetInfo.cpp#L4051
 			// since C# supports a lot less types than clang does.
@@ -77,7 +76,7 @@ namespace ObjCRuntime
 			if (!IsHomogeneousAggregateSmallEnough_Armv7k (fieldTypes [0], fieldTypes.Count))
 				return false;
 
-			if (!IsHomogeneousAggregateBaseType_Armv7k (fieldTypes [0]))
+			if (!IsHomogeneousAggregateBaseType_Armv7k (fieldTypes [0], generator))
 				return false;
 
 			for (int i = 1; i < fieldTypes.Count; i++) {
@@ -103,13 +102,13 @@ namespace ObjCRuntime
 				if (t.Namespace != "System")
 					return false;
 #if BGENERATOR
-				return t.Assembly == TypeManager.PlatformAssembly;
+				return t.Assembly == generator.TypeManager.PlatformAssembly;
 #else
 				return t.Assembly == typeof (NSObject).Assembly;
 #endif
 			default:
 #if BGENERATOR
-				return t.Assembly == TypeManager.CorlibAssembly;
+				return t.Assembly == generator.TypeManager.CorlibAssembly;
 #else
 				return t.Assembly == typeof (object).Assembly;
 #endif
@@ -154,7 +153,7 @@ namespace ObjCRuntime
 					return false;
 
 				// Except homogeneous aggregates, which are not stret either.
-				if (IsHomogeneousAggregate_Armv7k (fieldTypes))
+				if (IsHomogeneousAggregate_Armv7k (fieldTypes, generator))
 					return false;
 			}
 

--- a/src/ObjCRuntime/Stret.cs
+++ b/src/ObjCRuntime/Stret.cs
@@ -40,7 +40,6 @@ namespace ObjCRuntime
 #if BGENERATOR
 		public static BindingTouch BindingTouch;
 		static TypeManager TypeManager { get { return BindingTouch.TypeManager; } }
-		static bool isUnified { get { return BindingTouch.Unified; } }
 #elif __UNIFIED__
 		const bool isUnified = true;
 #else
@@ -89,12 +88,15 @@ namespace ObjCRuntime
 			return true;
 		}
 
-		static bool IsMagicTypeOrCorlibType (Type t)
+		static bool IsMagicTypeOrCorlibType (Type t, Generator generator)
 		{
 			switch (t.Name) {
 			case "nint":
 			case "nuint":
 			case "nfloat":
+#if BGENERATOR
+				var isUnified = generator.UnifiedAPI;
+#endif
 				if (!isUnified)
 					return false;
 
@@ -129,7 +131,7 @@ namespace ObjCRuntime
 
 			Type t = returnType;
 
-			if (!t.IsValueType || t.IsEnum || IsMagicTypeOrCorlibType (t))
+			if (!t.IsValueType || t.IsEnum || IsMagicTypeOrCorlibType (t, generator))
 				return false;
 
 			var fieldTypes = new List<Type> ();
@@ -191,7 +193,7 @@ namespace ObjCRuntime
 		{
 			Type t = returnType;
 
-			if (!t.IsValueType || t.IsEnum || IsMagicTypeOrCorlibType (t))
+			if (!t.IsValueType || t.IsEnum || IsMagicTypeOrCorlibType (t, generator))
 				return false;
 
 			var fieldTypes = new List<Type> ();
@@ -208,12 +210,15 @@ namespace ObjCRuntime
 
 		public static bool X86_64NeedStret (Type returnType, Generator generator)
 		{
+#if BGENERATOR
+			var isUnified = generator.UnifiedAPI;
+#endif
 			if (!isUnified)
 				return false;
 
 			Type t = returnType;
 
-			if (!t.IsValueType || t.IsEnum || IsMagicTypeOrCorlibType (t))
+			if (!t.IsValueType || t.IsEnum || IsMagicTypeOrCorlibType (t, generator))
 				return false;
 
 			var fieldTypes = new List<Type> ();

--- a/src/ObjCRuntime/Stret.cs
+++ b/src/ObjCRuntime/Stret.cs
@@ -119,7 +119,7 @@ namespace ObjCRuntime
 		{
 			bool has32bitArm;
 #if BGENERATOR
-			has32bitArm = BindingTouch.CurrentPlatform != PlatformName.TvOS && BindingTouch.CurrentPlatform != PlatformName.MacOSX;
+			has32bitArm = generator.CurrentPlatform != PlatformName.TvOS && generator.CurrentPlatform != PlatformName.MacOSX;
 #elif MONOMAC || __TVOS__
 			has32bitArm = false;
 #else
@@ -138,7 +138,7 @@ namespace ObjCRuntime
 
 			bool isWatchOS;
 #if BGENERATOR
-			isWatchOS = BindingTouch.CurrentPlatform == PlatformName.WatchOS;
+			isWatchOS = generator.CurrentPlatform == PlatformName.WatchOS;
 #elif __WATCHOS__
 			isWatchOS = true;
 #else
@@ -159,7 +159,7 @@ namespace ObjCRuntime
 
 			bool isiOS;
 #if BGENERATOR
-			isiOS = BindingTouch.CurrentPlatform == PlatformName.iOS;
+			isiOS = generator.CurrentPlatform == PlatformName.iOS;
 #elif __IOS__
 			isiOS = true;
 #else

--- a/src/ObjCRuntime/Stret.cs
+++ b/src/ObjCRuntime/Stret.cs
@@ -38,7 +38,6 @@ namespace ObjCRuntime
 	class Stret
 	{
 #if BGENERATOR
-		public static BindingTouch BindingTouch;
 #elif __UNIFIED__
 		const bool isUnified = true;
 #else

--- a/src/ObjCRuntime/Stret.cs
+++ b/src/ObjCRuntime/Stret.cs
@@ -38,6 +38,7 @@ namespace ObjCRuntime
 	{
 #if BGENERATOR
 		public static BindingTouch BindingTouch;
+		static TypeManager TypeManager { get { return BindingTouch.TypeManager; } }
 		static bool isUnified { get { return BindingTouch.Unified; } }
 #elif __UNIFIED__
 		const bool isUnified = true;

--- a/src/ObjCRuntime/Stret.cs
+++ b/src/ObjCRuntime/Stret.cs
@@ -37,7 +37,8 @@ namespace ObjCRuntime
 	class Stret
 	{
 #if BGENERATOR
-		static bool isUnified = BindingTouch.Unified;
+		public static BindingTouch BindingTouch;
+		static bool isUnified { get { return BindingTouch.Unified; } }
 #elif __UNIFIED__
 		const bool isUnified = true;
 #else

--- a/src/ObjCRuntime/Stret.cs
+++ b/src/ObjCRuntime/Stret.cs
@@ -227,7 +227,7 @@ namespace ObjCRuntime
 				// Find the maximum of "field size + field offset" for each field.
 				foreach (var field in type.GetFields (BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)) {
 #if BGENERATOR
-					var fieldOffset = AttributeManager.GetCustomAttribute<FieldOffsetAttribute> (field);
+					var fieldOffset = Generator.AttributeManager.GetCustomAttribute<FieldOffsetAttribute> (field);
 #else
 					var fieldOffset = (FieldOffsetAttribute) Attribute.GetCustomAttribute (field, typeof (FieldOffsetAttribute));
 #endif
@@ -299,7 +299,7 @@ namespace ObjCRuntime
 			// composite struct
 			foreach (var field in type.GetFields (BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)) {
 #if BGENERATOR
-				var marshalAs = AttributeManager.GetCustomAttribute<MarshalAsAttribute> (field);
+				var marshalAs = Generator.AttributeManager.GetCustomAttribute<MarshalAsAttribute> (field);
 #else
 				var marshalAs = (MarshalAsAttribute) Attribute.GetCustomAttribute (field, typeof (MarshalAsAttribute));
 #endif

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -52,6 +52,7 @@ public class BindingTouch {
 
 	public Universe universe;
 	public Frameworks Frameworks;
+	public AttributeManager AttributeManager;
 
 	public TargetFramework TargetFramework {
 		get { return target_framework.Value; }
@@ -514,7 +515,7 @@ public class BindingTouch {
 				return 1;
 			}
 
-			AttributeManager.BindingTouch = this;
+			AttributeManager = new AttributeManager (this);
 			Stret.BindingTouch = this;
 			Frameworks = new Frameworks (CurrentPlatform);
 

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -51,6 +51,7 @@ public class BindingTouch {
 	List<string> libs = new List<string> ();
 
 	public Universe universe;
+	public TypeManager TypeManager = new TypeManager ();
 	public Frameworks Frameworks;
 	public AttributeManager AttributeManager;
 

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -38,7 +38,7 @@ using ObjCRuntime;
 using Foundation;
 using Xamarin.Utils;
 
-class BindingTouch {
+public class BindingTouch {
 	static TargetFramework? target_framework;
 	public static PlatformName CurrentPlatform;
 	public static bool Unified;

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -553,6 +553,7 @@ public class BindingTouch {
 			}
 
 			var nsManager = new NamespaceManager (
+				this,
 				NamespacePlatformPrefix,
 				ns == null ? firstApiDefinitionName : ns,
 				skipSystemDrawing

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -518,7 +518,6 @@ public class BindingTouch {
 			}
 
 			AttributeManager = new AttributeManager (this);
-			Stret.BindingTouch = this;
 			Frameworks = new Frameworks (CurrentPlatform);
 
 			Assembly corlib_assembly = universe.LoadFile (LocateAssembly ("mscorlib"));

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -41,6 +41,7 @@ using Xamarin.Utils;
 public class BindingTouch {
 	TargetFramework? target_framework;
 	public PlatformName CurrentPlatform;
+	public bool BindThirdPartyLibrary = true;
 	public bool Unified;
 	public bool skipSystemDrawing;
 	public string outfile;
@@ -257,7 +258,7 @@ public class BindingTouch {
 			{ "sourceonly=", "Only generates the source", v => generate_file_list = v },
 			{ "ns=", "Sets the namespace for storing helper classes", v => ns = v },
 			{ "unsafe", "Sets the unsafe flag for the build", v=> unsafef = true },
-			{ "core", "Use this to build product assemblies", v => Generator.BindThirdPartyLibrary = false },
+			{ "core", "Use this to build product assemblies", v => BindThirdPartyLibrary = false },
 			{ "r=", "Adds a reference", v => references.Add (v) },
 			{ "lib=", "Adds the directory to the search path for the compiler", v => libs.Add (StringUtils.Quote (v)) },
 			{ "compiler=", "Sets the compiler to use (Obsolete) ", v => compiler = v, true },
@@ -569,7 +570,7 @@ public class BindingTouch {
 				InlineSelectors = inline_selectors ?? (Unified && CurrentPlatform != PlatformName.MacOSX),
 			};
 
-			if (!Unified && !Generator.BindThirdPartyLibrary) {
+			if (!Unified && !BindThirdPartyLibrary) {
 				foreach (var mi in baselib.GetType (nsManager.CoreObjCRuntime + ".Messaging").GetMethods ()){
 					if (mi.Name.IndexOf ("_objc_msgSend", StringComparison.Ordinal) != -1)
 						g.RegisterMethodName (mi.Name);

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -51,6 +51,7 @@ public class BindingTouch {
 	List<string> libs = new List<string> ();
 
 	public Universe universe;
+	public Frameworks Frameworks;
 
 	public TargetFramework TargetFramework {
 		get { return target_framework.Value; }
@@ -515,6 +516,7 @@ public class BindingTouch {
 
 			AttributeManager.BindingTouch = this;
 			Stret.BindingTouch = this;
+			Frameworks = new Frameworks (CurrentPlatform);
 
 			Assembly corlib_assembly = universe.LoadFile (LocateAssembly ("mscorlib"));
 			Assembly platform_assembly = baselib;

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -69,12 +69,12 @@ class BindingTouch {
 		os.WriteOptionDescriptions (Console.Out);
 	}
 	
-	static int Main (string [] args)
+	public static int Main (string [] args)
 	{
 		try {
 			return Main2 (args);
 		} catch (Exception ex) {
-			ErrorHelper.Show (ex);
+			ErrorHelper.Show (ex, false);
 			return 1;
 		}
 	}
@@ -235,6 +235,8 @@ class BindingTouch {
 		var defines = new List<string> ();
 		string generate_file_list = null;
 		bool process_enums = false;
+
+		ErrorHelper.ClearWarningLevels ();
 
 		var os = new OptionSet () {
 			{ "h|?|help", "Displays the help", v => show_help = true },

--- a/src/btouch.cs
+++ b/src/btouch.cs
@@ -58,7 +58,7 @@ class BindingTouch {
 	}
 
 	public static string ToolName {
-		get { return Path.GetFileNameWithoutExtension (System.Reflection.Assembly.GetEntryAssembly ().Location); }
+		get { return "bgen"; }
 	}
 
 	static void ShowHelp (OptionSet os)

--- a/src/generate-frameworks.csharp
+++ b/src/generate-frameworks.csharp
@@ -26,7 +26,7 @@ Console.WriteLine ("partial class Frameworks {");
 for (int i = 0; i < names.Length; i++) {
 	var name = names [i];
 	var frameworks = allframeworks [i];
-	Console.Write ($"\tstatic readonly HashSet<string> {name} = new HashSet<string> {{\"");
+	Console.Write ($"\treadonly HashSet<string> {name} = new HashSet<string> {{\"");
 	Console.Write (string.Join ("\", \"", frameworks));
 	Console.WriteLine ("\"};");
 }
@@ -34,8 +34,8 @@ for (int i = 0; i < names.Length; i++) {
 var allArray = all.ToArray ();
 Array.Sort (allArray);
 foreach (var fw in allArray)
-	Console.WriteLine ($"\tstatic bool? _{fw.Replace (".", "")};");
+	Console.WriteLine ($"\tbool? _{fw.Replace (".", "")};");
 foreach (var fw in allArray)
-	Console.WriteLine ($"\tpublic static bool Have{fw} {{ get {{ if (!_{fw}.HasValue) _{fw} = GetValue (\"{fw}\"); return _{fw}.Value; }} }}");
+	Console.WriteLine ($"\tpublic bool Have{fw} {{ get {{ if (!_{fw}.HasValue) _{fw} = GetValue (\"{fw}\"); return _{fw}.Value; }} }}");
 Console.WriteLine ("}");
 Environment.Exit (0);

--- a/src/generator-attribute-manager.cs
+++ b/src/generator-attribute-manager.cs
@@ -5,13 +5,18 @@ using IKVM.Reflection;
 using Type = IKVM.Reflection.Type;
 using PlatformName = ObjCRuntime.PlatformName;
 
-public static class AttributeManager
+public class AttributeManager
 {
-	public static BindingTouch BindingTouch;
+	public BindingTouch BindingTouch;
+
+	public AttributeManager (BindingTouch binding_touch)
+	{
+		BindingTouch = binding_touch;
+	}
 
 	// This method gets the System.Type for a IKVM.Reflection.Type to a System.Type.
 	// It knows about our mock attribute logic, so it will return the corresponding non-mocked System.Type for a mocked IKVM.Reflection.Type.
-	static System.Type ConvertType (Type type, ICustomAttributeProvider provider)
+	System.Type ConvertType (Type type, ICustomAttributeProvider provider)
 	{
 		System.Type rv;
 		if (type.Assembly == TypeManager.CorlibAssembly) {
@@ -51,7 +56,7 @@ public static class AttributeManager
 
 	// This method gets the IKVM.Reflection.Type for a System.Type.
 	// It knows about our mock attribute logic, so it will return the mocked IKVM.Reflection.Type for a mocked System.Type.
-	static Type ConvertType (System.Type type, ICustomAttributeProvider provider)
+	Type ConvertType (System.Type type, ICustomAttributeProvider provider)
 	{
 		Type rv;
 		if (type.Assembly == typeof (int).Assembly) {
@@ -128,7 +133,7 @@ public static class AttributeManager
 		}
 	}
 
-	static IEnumerable<T> CreateAttributeInstance <T> (CustomAttributeData attribute, ICustomAttributeProvider provider) where T : System.Attribute
+	IEnumerable<T> CreateAttributeInstance <T> (CustomAttributeData attribute, ICustomAttributeProvider provider) where T : System.Attribute
 	{
 		var convertedAttributes = ConvertOldAttributes (attribute);
 		if (convertedAttributes.Any ())
@@ -214,7 +219,7 @@ public static class AttributeManager
 		return ((T) instance).Yield ();
 	}
 
-	static T [] FilterAttributes<T> (IList<CustomAttributeData> attributes, ICustomAttributeProvider provider) where T : System.Attribute
+	T [] FilterAttributes<T> (IList<CustomAttributeData> attributes, ICustomAttributeProvider provider) where T : System.Attribute
 	{
 		if (attributes == null || attributes.Count == 0)
 			return Array.Empty<T> ();
@@ -234,7 +239,7 @@ public static class AttributeManager
 		return Array.Empty<T> ();
 	}
 
-	public static T [] GetCustomAttributes<T> (ICustomAttributeProvider provider) where T : System.Attribute
+	public T [] GetCustomAttributes<T> (ICustomAttributeProvider provider) where T : System.Attribute
 	{
 		return FilterAttributes<T> (GetIKVMAttributes (provider), provider);
 	}
@@ -265,7 +270,7 @@ public static class AttributeManager
 		return false;
 	}
 
-	public static bool HasAttribute<T> (ICustomAttributeProvider provider) where T : Attribute
+	public bool HasAttribute<T> (ICustomAttributeProvider provider) where T : Attribute
 	{
 		var attribute_type = ConvertType (typeof (T), provider);
 		var attribs = GetIKVMAttributes (provider);
@@ -283,7 +288,7 @@ public static class AttributeManager
 		return false;
 	}
 
-	public static T GetCustomAttribute<T> (ICustomAttributeProvider provider) where T : System.Attribute
+	public T GetCustomAttribute<T> (ICustomAttributeProvider provider) where T : System.Attribute
 	{
 		if (provider is null)
 			return null;

--- a/src/generator-attribute-manager.cs
+++ b/src/generator-attribute-manager.cs
@@ -7,6 +7,8 @@ using PlatformName = ObjCRuntime.PlatformName;
 
 public static class AttributeManager
 {
+	public static BindingTouch BindingTouch;
+
 	// This method gets the System.Type for a IKVM.Reflection.Type to a System.Type.
 	// It knows about our mock attribute logic, so it will return the corresponding non-mocked System.Type for a mocked IKVM.Reflection.Type.
 	static System.Type ConvertType (Type type, ICustomAttributeProvider provider)

--- a/src/generator-attribute-manager.cs
+++ b/src/generator-attribute-manager.cs
@@ -8,6 +8,7 @@ using PlatformName = ObjCRuntime.PlatformName;
 public class AttributeManager
 {
 	public BindingTouch BindingTouch;
+	TypeManager TypeManager { get { return BindingTouch.TypeManager; } }
 
 	public AttributeManager (BindingTouch binding_touch)
 	{

--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -75,7 +75,7 @@ public partial class Generator {
 			var fa = AttributeManager.GetCustomAttribute<FieldAttribute> (f);
 			if (fa == null)
 				continue;
-			if (f.IsUnavailable ())
+			if (f.IsUnavailable (this))
 				continue;
 			if (fa.SymbolName == null)
 				null_field = new Tuple<FieldInfo, FieldAttribute> (f, fa);

--- a/src/generator-filters.cs
+++ b/src/generator-filters.cs
@@ -55,7 +55,7 @@ public partial class Generator {
 		var intptrctor_visibility = filter.IntPtrCtorVisibility;
 		if (intptrctor_visibility == MethodAttributes.PrivateScope) {
 			// since it was not generated code we never fixed the .ctor(IntPtr) visibility for unified
-			if (Generator.XamcoreVersion >= 3) {
+			if (XamcoreVersion >= 3) {
 				intptrctor_visibility = MethodAttributes.FamORAssem;
 			} else {
 				intptrctor_visibility = MethodAttributes.Public;

--- a/src/generator-filters.cs
+++ b/src/generator-filters.cs
@@ -106,7 +106,7 @@ public partial class Generator {
 
 		// properties
 		foreach (var p in type.GetProperties (BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)) {
-			if (p.IsUnavailable ())
+			if (p.IsUnavailable (this))
 				continue;
 			
 			print ("");

--- a/src/generator-typemanager.cs
+++ b/src/generator-typemanager.cs
@@ -4,6 +4,7 @@ using IKVM.Reflection;
 using Type = IKVM.Reflection.Type;
 
 public static class TypeManager {
+	public static BindingTouch BindingTouch;
 	public static Type System_Attribute;
 	public static Type System_Boolean;
 	public static Type System_Byte;
@@ -182,8 +183,10 @@ public static class TypeManager {
 		return type.GetEnumUnderlyingType ();
 	}
 
-	public static void Initialize (Assembly api, Assembly corlib, Assembly platform, Assembly system, Assembly binding)
+	public static void Initialize (BindingTouch binding_touch, Assembly api, Assembly corlib, Assembly platform, Assembly system, Assembly binding)
 	{
+		BindingTouch = binding_touch;
+
 		api_assembly = api;
 		corlib_assembly = corlib;
 		platform_assembly = platform;

--- a/src/generator-typemanager.cs
+++ b/src/generator-typemanager.cs
@@ -5,6 +5,7 @@ using Type = IKVM.Reflection.Type;
 
 public static class TypeManager {
 	public static BindingTouch BindingTouch;
+	static Frameworks Frameworks { get { return BindingTouch.Frameworks; } }
 	public static Type System_Attribute;
 	public static Type System_Boolean;
 	public static Type System_Byte;

--- a/src/generator-typemanager.cs
+++ b/src/generator-typemanager.cs
@@ -3,137 +3,138 @@ using System;
 using IKVM.Reflection;
 using Type = IKVM.Reflection.Type;
 
-public static class TypeManager {
-	public static BindingTouch BindingTouch;
-	static Frameworks Frameworks { get { return BindingTouch.Frameworks; } }
-	public static Type System_Attribute;
-	public static Type System_Boolean;
-	public static Type System_Byte;
-	public static Type System_Delegate;
-	public static Type System_Double;
-	public static Type System_Float;
-	public static Type System_Int16;
-	public static Type System_Int32;
-	public static Type System_Int64;
-	public static Type System_IntPtr;
-	public static Type System_Object;
-	public static Type System_SByte;
-	public static Type System_String;
-	public static Type System_String_Array;
-	public static Type System_UInt16;
-	public static Type System_UInt32;
-	public static Type System_UInt64;
-	public static Type System_Void;
+public class TypeManager {
+	BindingTouch BindingTouch;
+	Frameworks Frameworks { get { return BindingTouch.Frameworks; } }
 
-	public static Type System_nint;
-	public static Type System_nuint;
-	public static Type System_nfloat;
+	public Type System_Attribute;
+	public Type System_Boolean;
+	public Type System_Byte;
+	public Type System_Delegate;
+	public Type System_Double;
+	public Type System_Float;
+	public Type System_Int16;
+	public Type System_Int32;
+	public Type System_Int64;
+	public Type System_IntPtr;
+	public Type System_Object;
+	public Type System_SByte;
+	public Type System_String;
+	public Type System_String_Array;
+	public Type System_UInt16;
+	public Type System_UInt32;
+	public Type System_UInt64;
+	public Type System_Void;
+
+	public Type System_nint;
+	public Type System_nuint;
+	public Type System_nfloat;
 
 	/* fundamental */
-	public static Type NSObject;
-	public static Type INativeObject;
+	public Type NSObject;
+	public Type INativeObject;
 
 	/* objcruntime */
-	public static Type BlockLiteral;
-	public static Type Class;
-	public static Type Protocol;
-	public static Type Selector;
+	public Type BlockLiteral;
+	public Type Class;
+	public Type Protocol;
+	public Type Selector;
 
-	public static Type Constants;
+	public Type Constants;
 
 	/* Different binding types */
 
-	public static Type DictionaryContainerType;
+	public Type DictionaryContainerType;
 
-	public static Type ABAddressBook;
-	public static Type ABPerson;
-	public static Type ABRecord;
-	public static Type AudioBuffers;
-	public static Type AudioComponent;
-	public static Type AudioUnit;
-	public static Type AURenderEventEnumerator;
-	public static Type AVCaptureWhiteBalanceGains;
-	public static Type CATransform3D;
-	public static Type CFRunLoop;
-	public static Type CGAffineTransform;
-	public static Type CGColor;
-	public static Type CGColorSpace;
-	public static Type CGContext;
-	public static Type CGPDFDocument;
-	public static Type CGPDFPage;
-	public static Type CGGradient;
-	public static Type CGImage;
-	public static Type CGLayer;
-	public static Type CGLContext;
-	public static Type CGLPixelFormat;
-	public static Type CGPath;
-	public static Type CGVector;
-	public static Type CLLocationCoordinate2D;
-	public static Type CMAudioFormatDescription;
-	public static Type CMClock;
-	public static Type CMFormatDescription;
-	public static Type CMSampleBuffer;
-	public static Type CMTime;
-	public static Type CMTimebase;
-	public static Type CMTimeMapping;
-	public static Type CMTimeRange;
-	public static Type CMVideoFormatDescription;
-	public static Type CVImageBuffer;
-	public static Type CVPixelBuffer;
-	public static Type CVPixelBufferPool;
-	public static Type DispatchQueue;
-	public static Type DispatchData;
-	public static Type MidiEndpoint;
-	public static Type MKCoordinateSpan;
-	public static Type MTAudioProcessingTap;
-	public static Type MusicSequence;
-	public static Type NSNumber;
-	public static Type NSRange;
-	public static Type NSString;
-	public static Type NSValue;
-	public static Type NSZone;
-	public static Type SCNMatrix4;
-	public static Type SCNVector3;
-	public static Type SCNVector4;
-	public static Type SecAccessControl;
-	public static Type SecIdentity;
-	public static Type SecTrust;
-	public static Type SecProtocolMetadata;
-	public static Type SecProtocolOptions;
-	public static Type SecTrust2;
-	public static Type SecIdentity2;
-	public static Type UIEdgeInsets;
-	public static Type UIOffset;
-	public static Type NSDirectionalEdgeInsets;
+	public Type ABAddressBook;
+	public Type ABPerson;
+	public Type ABRecord;
+	public Type AudioBuffers;
+	public Type AudioComponent;
+	public Type AudioUnit;
+	public Type AURenderEventEnumerator;
+	public Type AVCaptureWhiteBalanceGains;
+	public Type CATransform3D;
+	public Type CFRunLoop;
+	public Type CGAffineTransform;
+	public Type CGColor;
+	public Type CGColorSpace;
+	public Type CGContext;
+	public Type CGPDFDocument;
+	public Type CGPDFPage;
+	public Type CGGradient;
+	public Type CGImage;
+	public Type CGLayer;
+	public Type CGLContext;
+	public Type CGLPixelFormat;
+	public Type CGPath;
+	public Type CGVector;
+	public Type CLLocationCoordinate2D;
+	public Type CMAudioFormatDescription;
+	public Type CMClock;
+	public Type CMFormatDescription;
+	public Type CMSampleBuffer;
+	public Type CMTime;
+	public Type CMTimebase;
+	public Type CMTimeMapping;
+	public Type CMTimeRange;
+	public Type CMVideoFormatDescription;
+	public Type CVImageBuffer;
+	public Type CVPixelBuffer;
+	public Type CVPixelBufferPool;
+	public Type DispatchQueue;
+	public Type DispatchData;
+	public Type MidiEndpoint;
+	public Type MKCoordinateSpan;
+	public Type MTAudioProcessingTap;
+	public Type MusicSequence;
+	public Type NSNumber;
+	public Type NSRange;
+	public Type NSString;
+	public Type NSValue;
+	public Type NSZone;
+	public Type SCNMatrix4;
+	public Type SCNVector3;
+	public Type SCNVector4;
+	public Type SecAccessControl;
+	public Type SecIdentity;
+	public Type SecTrust;
+	public Type SecProtocolMetadata;
+	public Type SecProtocolOptions;
+	public Type SecTrust2;
+	public Type SecIdentity2;
+	public Type UIEdgeInsets;
+	public Type UIOffset;
+	public Type NSDirectionalEdgeInsets;
 
-	public static Type CoreGraphics_CGPoint;
-	public static Type CoreGraphics_CGRect;
-	public static Type CoreGraphics_CGSize;
+	public Type CoreGraphics_CGPoint;
+	public Type CoreGraphics_CGRect;
+	public Type CoreGraphics_CGSize;
 
-	static Assembly api_assembly;
-	static Assembly corlib_assembly;
-	static Assembly platform_assembly;
-	static Assembly system_assembly;
-	static Assembly binding_assembly;
+	Assembly api_assembly;
+	Assembly corlib_assembly;
+	Assembly platform_assembly;
+	Assembly system_assembly;
+	Assembly binding_assembly;
 
-	public static Assembly CorlibAssembly {
+	public Assembly CorlibAssembly {
 		get { return corlib_assembly; }
 	}
 
-	public static Assembly PlatformAssembly {
+	public Assembly PlatformAssembly {
 		get { return platform_assembly; }
 		set { platform_assembly = value; }
 	}
 
-	public static Assembly SystemAssembly {
+	public Assembly SystemAssembly {
 		get { return system_assembly; }
 	}
 
-	public static Assembly BindingAssembly {
+	public Assembly BindingAssembly {
 		get { return binding_assembly; }
 	}
 
-	static Type Lookup (Assembly assembly, string @namespace, string @typename, bool inexistentOK = false)
+	Type Lookup (Assembly assembly, string @namespace, string @typename, bool inexistentOK = false)
 	{
 		string fullname;
 		string nsManagerPrefix = null;
@@ -156,7 +157,7 @@ public static class TypeManager {
 		return rv;
 	}
 
-	public static Type GetUnderlyingNullableType (Type type)
+	public Type GetUnderlyingNullableType (Type type)
 	{
 		if (!type.IsConstructedGenericType)
 			return null;
@@ -184,7 +185,7 @@ public static class TypeManager {
 		return type.GetEnumUnderlyingType ();
 	}
 
-	public static void Initialize (BindingTouch binding_touch, Assembly api, Assembly corlib, Assembly platform, Assembly system, Assembly binding)
+	public void Initialize (BindingTouch binding_touch, Assembly api, Assembly corlib, Assembly platform, Assembly system, Assembly binding)
 	{
 		BindingTouch = binding_touch;
 
@@ -214,7 +215,7 @@ public static class TypeManager {
 		System_UInt64 = Lookup (corlib_assembly, "System", "UInt64");
 		System_Void = Lookup (corlib_assembly, "System", "Void");
 
-		if (Generator.UnifiedAPI) {
+		if (BindingTouch.Unified) {
 			System_nint = Lookup (platform_assembly, "System", "nint");
 			System_nuint = Lookup (platform_assembly, "System", "nuint");
 			System_nfloat = Lookup (platform_assembly, "System", "nfloat");
@@ -230,7 +231,7 @@ public static class TypeManager {
 		Protocol = Lookup (platform_assembly, "ObjCRuntime", "Protocol");
 		Selector = Lookup (platform_assembly, "ObjCRuntime", "Selector");
 
-		if (Generator.UnifiedAPI) {
+		if (BindingTouch.Unified) {
 			Constants = Lookup (platform_assembly, "ObjCRuntime", "Constants");
 		} else {
 			Constants = Lookup (platform_assembly, "", "Constants");
@@ -322,7 +323,7 @@ public static class TypeManager {
 			NSDirectionalEdgeInsets = Lookup (platform_assembly, "UIKit", "NSDirectionalEdgeInsets");
 		}
 
-		if (Generator.UnifiedAPI) {
+		if (BindingTouch.Unified) {
 			CoreGraphics_CGRect = Lookup (platform_assembly, "CoreGraphics", "CGRect");
 			CoreGraphics_CGPoint = Lookup (platform_assembly, "CoreGraphics", "CGPoint");
 			CoreGraphics_CGSize = Lookup (platform_assembly, "CoreGraphics", "CGSize");

--- a/src/generator-typemanager.cs
+++ b/src/generator-typemanager.cs
@@ -302,10 +302,10 @@ public class TypeManager {
 			MKCoordinateSpan = Lookup (platform_assembly, "MapKit", "MKCoordinateSpan", true /* isn't in XM/Classic */);
 		if (Frameworks.HaveMediaToolbox)
 			MTAudioProcessingTap = Lookup (platform_assembly, "MediaToolbox", "MTAudioProcessingTap");
-		NSNumber = Lookup (Generator.BindThirdPartyLibrary ? platform_assembly : api_assembly, "Foundation", "NSNumber");
+		NSNumber = Lookup (binding_touch.BindThirdPartyLibrary ? platform_assembly : api_assembly, "Foundation", "NSNumber");
 		NSRange = Lookup (platform_assembly, "Foundation", "NSRange");
 		NSString = Lookup (platform_assembly, "Foundation", "NSString");
-		NSValue = Lookup (Generator.BindThirdPartyLibrary ? platform_assembly : api_assembly, "Foundation", "NSValue");
+		NSValue = Lookup (binding_touch.BindThirdPartyLibrary ? platform_assembly : api_assembly, "Foundation", "NSValue");
 		NSZone = Lookup (platform_assembly, "Foundation", "NSZone");
 		SCNVector3 = Lookup (platform_assembly, "SceneKit", "SCNVector3");
 		SCNVector4 = Lookup (platform_assembly, "SceneKit", "SCNVector4");

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -887,7 +887,7 @@ public partial class Generator : IMemberGatherer {
 	// Static version of the above (!Compat) field, set on each Go invocation, needed because some static
 	// helper methods need to access this.   This is the exact opposite of Compat.
 	public static bool UnifiedAPI { get { return BindingTouch.Unified; } }
-	public static int XamcoreVersion {
+	public int XamcoreVersion {
 		get {
 			switch (Generator.CurrentPlatform) {
 			case PlatformName.MacOSX:
@@ -3414,7 +3414,7 @@ public partial class Generator : IMemberGatherer {
 			return false;
 
 		var attrib = attribs [0];
-		return Generator.XamcoreVersion >= attrib.Version;
+		return XamcoreVersion >= attrib.Version;
 	}
 
 	public string MakeSignature (MemberInformation minfo, bool is_async, ParameterInfo[] parameters, string extra = "", bool alreadyPreserved = false)

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -638,6 +638,10 @@ public class MemberInformation
 
 public class NamespaceManager
 {
+	public BindingTouch BindingTouch;
+	PlatformName CurrentPlatform { get { return BindingTouch.CurrentPlatform; } }
+	bool UnifiedAPI { get { return BindingTouch.Unified; } }
+
 	public string Prefix { get; private set; }
 
 	// Where the core messaging lives
@@ -653,8 +657,9 @@ public class NamespaceManager
 	public ICollection<string> ImplicitNamespaces { get; private set; }
 	public ICollection<string> NamespacesThatConflictWithTypes { get; private set; }
 
-	public NamespaceManager (string prefix, string customObjCRuntimeNS, bool skipSystemDrawing)
+	public NamespaceManager (BindingTouch binding_touch, string prefix, string customObjCRuntimeNS, bool skipSystemDrawing)
 	{
+		BindingTouch = binding_touch;
 		Prefix = prefix;
 
 		CoreObjCRuntime = Get ("ObjCRuntime");
@@ -677,7 +682,7 @@ public class NamespaceManager
 			UINamespaces.Add (Get ("UIKit"));
 		if (Frameworks.HaveTwitter)
 			UINamespaces.Add (Get ("Twitter"));
-		if (Frameworks.HaveGameKit && Generator.CurrentPlatform != PlatformName.MacOSX && Generator.CurrentPlatform != PlatformName.WatchOS)
+		if (Frameworks.HaveGameKit && CurrentPlatform != PlatformName.MacOSX && CurrentPlatform != PlatformName.WatchOS)
 			UINamespaces.Add (Get ("GameKit"));
 		if (Frameworks.HaveNewsstandKit)
 			UINamespaces.Add (Get ("NewsstandKit"));
@@ -689,7 +694,7 @@ public class NamespaceManager
 			UINamespaces.Add (Get ("EventKitUI"));
 		if (Frameworks.HaveAddressBookUI)
 			UINamespaces.Add (Get ("AddressBookUI"));
-		if (Frameworks.HaveMapKit && Generator.CurrentPlatform != PlatformName.MacOSX && Generator.CurrentPlatform != PlatformName.TvOS && Generator.CurrentPlatform != PlatformName.WatchOS)
+		if (Frameworks.HaveMapKit && CurrentPlatform != PlatformName.MacOSX && CurrentPlatform != PlatformName.TvOS && CurrentPlatform != PlatformName.WatchOS)
 			UINamespaces.Add (Get ("MapKit"));
 		if (Frameworks.HaveMessageUI)
 			UINamespaces.Add (Get ("MessageUI"));
@@ -713,7 +718,7 @@ public class NamespaceManager
 
 		if (Frameworks.HaveAudioUnit)
 			ImplicitNamespaces.Add (Get ("AudioUnit"));
-		if (Frameworks.HaveContacts && Generator.UnifiedAPI)
+		if (Frameworks.HaveContacts && UnifiedAPI)
 			ImplicitNamespaces.Add (Get ("Contacts"));
 		if (Frameworks.HaveCoreAnimation)
 			ImplicitNamespaces.Add (Get ("CoreAnimation"));
@@ -723,7 +728,7 @@ public class NamespaceManager
 			ImplicitNamespaces.Add (Get ("CoreVideo"));
 		if (Frameworks.HaveCoreMedia)
 			ImplicitNamespaces.Add (Get ("CoreMedia"));
-		if (Frameworks.HaveSecurity && Generator.CurrentPlatform != PlatformName.WatchOS)
+		if (Frameworks.HaveSecurity && CurrentPlatform != PlatformName.WatchOS)
 			ImplicitNamespaces.Add (Get ("Security"));
 		if (Frameworks.HaveAVFoundation)
 			ImplicitNamespaces.Add (Get ("AVFoundation"));
@@ -733,33 +738,33 @@ public class NamespaceManager
 			ImplicitNamespaces.Add (Get ("QTKit"));
 		if (Frameworks.HaveAppKit)
 			ImplicitNamespaces.Add (Get ("AppKit"));
-		if (Frameworks.HaveCloudKit && Generator.CurrentPlatform != PlatformName.WatchOS && Generator.CurrentPlatform != PlatformName.TvOS && Generator.CurrentPlatform != PlatformName.iOS)
+		if (Frameworks.HaveCloudKit && CurrentPlatform != PlatformName.WatchOS && CurrentPlatform != PlatformName.TvOS && CurrentPlatform != PlatformName.iOS)
 			ImplicitNamespaces.Add (Get ("CloudKit"));
-		if (Frameworks.HaveCoreMotion && Generator.CurrentPlatform != PlatformName.WatchOS && Generator.CurrentPlatform != PlatformName.TvOS && Generator.CurrentPlatform != PlatformName.MacOSX)
+		if (Frameworks.HaveCoreMotion && CurrentPlatform != PlatformName.WatchOS && CurrentPlatform != PlatformName.TvOS && CurrentPlatform != PlatformName.MacOSX)
 			ImplicitNamespaces.Add (Get ("CoreMotion"));
-		if (Frameworks.HaveMapKit && Generator.CurrentPlatform != PlatformName.WatchOS && Generator.CurrentPlatform != PlatformName.TvOS && Generator.CurrentPlatform != PlatformName.MacOSX)
+		if (Frameworks.HaveMapKit && CurrentPlatform != PlatformName.WatchOS && CurrentPlatform != PlatformName.TvOS && CurrentPlatform != PlatformName.MacOSX)
 			ImplicitNamespaces.Add (Get ("MapKit"));
 		if (Frameworks.HaveUIKit)
 			ImplicitNamespaces.Add (Get ("UIKit"));
 		if (Frameworks.HaveNewsstandKit)
 			ImplicitNamespaces.Add (Get ("NewsstandKit"));
-		if (Frameworks.HaveGLKit && Generator.CurrentPlatform != PlatformName.WatchOS && Generator.CurrentPlatform != PlatformName.MacOSX)
+		if (Frameworks.HaveGLKit && CurrentPlatform != PlatformName.WatchOS && CurrentPlatform != PlatformName.MacOSX)
 			ImplicitNamespaces.Add (Get ("GLKit"));
-		if (Frameworks.HaveQuickLook && Generator.CurrentPlatform != PlatformName.WatchOS && Generator.CurrentPlatform != PlatformName.TvOS && Generator.CurrentPlatform != PlatformName.MacOSX)
+		if (Frameworks.HaveQuickLook && CurrentPlatform != PlatformName.WatchOS && CurrentPlatform != PlatformName.TvOS && CurrentPlatform != PlatformName.MacOSX)
 			ImplicitNamespaces.Add (Get ("QuickLook"));
 		if (Frameworks.HaveAddressBook)
 			ImplicitNamespaces.Add (Get ("AddressBook"));
 
-		if (Frameworks.HaveModelIO && !(Generator.CurrentPlatform == PlatformName.MacOSX && !Generator.UnifiedAPI))
+		if (Frameworks.HaveModelIO && !(CurrentPlatform == PlatformName.MacOSX && !UnifiedAPI))
 			ImplicitNamespaces.Add (Get ("ModelIO"));
-		if (Frameworks.HaveMetal && !(Generator.CurrentPlatform == PlatformName.MacOSX && !Generator.UnifiedAPI))
+		if (Frameworks.HaveMetal && !(CurrentPlatform == PlatformName.MacOSX && !UnifiedAPI))
 			ImplicitNamespaces.Add (Get ("Metal"));
 
 		if (Frameworks.HaveCoreImage)
 			ImplicitNamespaces.Add (Get ("CoreImage"));
 		if (Frameworks.HavePhotos)
 			ImplicitNamespaces.Add (Get ("Photos"));
-		if (Frameworks.HaveMediaPlayer && Generator.UnifiedAPI)
+		if (Frameworks.HaveMediaPlayer && UnifiedAPI)
 			ImplicitNamespaces.Add (Get ("MediaPlayer"));
 		if (Frameworks.HaveMessages)
 			ImplicitNamespaces.Add (Get ("Messages"));
@@ -767,7 +772,7 @@ public class NamespaceManager
 			ImplicitNamespaces.Add (Get ("GameplayKit"));
 		if (Frameworks.HaveSpriteKit)
 			ImplicitNamespaces.Add (Get ("SpriteKit"));
-		if (Frameworks.HaveFileProvider && Generator.UnifiedAPI)
+		if (Frameworks.HaveFileProvider && UnifiedAPI)
 			ImplicitNamespaces.Add (Get ("FileProvider"));
 
 		// These are both types and namespaces

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1264,8 +1264,8 @@ public partial class Generator : IMemberGatherer {
 		return type.Assembly.GetType (type.FullName + "Extensions") != null;
 	}
 
-	static Dictionary<Type,string> nsvalue_create_map;
-	static Dictionary<Type,string> NSValueCreateMap {
+	Dictionary<Type,string> nsvalue_create_map;
+	Dictionary<Type,string> NSValueCreateMap {
 		get {
 			if (nsvalue_create_map == null) {
 				nsvalue_create_map = new Dictionary<Type, string> ();
@@ -1385,8 +1385,8 @@ public partial class Generator : IMemberGatherer {
 		return temp;
 	}
 
-	static Dictionary<Type,string> nsnumber_return_map;
-	static Dictionary<Type,string> NSNumberReturnMap {
+	Dictionary<Type,string> nsnumber_return_map;
+	Dictionary<Type,string> NSNumberReturnMap {
 		get {
 			if (nsnumber_return_map == null) {
 				nsnumber_return_map = new Dictionary<Type, string> {
@@ -1412,8 +1412,8 @@ public partial class Generator : IMemberGatherer {
 		}
 	}
 
-	static Dictionary<Type,string> nsvalue_return_map;
-	static Dictionary<Type,string> NSValueReturnMap {
+	Dictionary<Type,string> nsvalue_return_map;
+	Dictionary<Type,string> NSValueReturnMap {
 		get {
 			if (nsvalue_return_map == null) {
 				nsvalue_return_map = new Dictionary<Type, string> {

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -838,7 +838,7 @@ public partial class Frameworks {
 public partial class Generator : IMemberGatherer {
 	internal bool IsPublicMode;
 
-	static NamespaceManager ns;
+	NamespaceManager ns;
 	static BindingTouch BindingTouch;
 	static Frameworks Frameworks { get { return BindingTouch.Frameworks; } }
 	public static TypeManager TypeManager { get { return BindingTouch.TypeManager; } }
@@ -905,7 +905,7 @@ public partial class Generator : IMemberGatherer {
 	StreamWriter sw, m;
 	int indent;
 
-	static public NamespaceManager NamespaceManager {
+	public NamespaceManager NamespaceManager {
 		get { return ns; }
 	}
 

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -977,8 +977,6 @@ public partial class Generator : IMemberGatherer {
 	public string BaseDir { get { return basedir; } set { basedir = value; }}
 	string basedir;
 	HashSet<string> generated_files = new HashSet<string> ();
-	public Type CoreNSObject = Generator.TypeManager.NSObject;
-	public Type SampleBufferType = Generator.TypeManager.CMSampleBuffer;
 
 	static string CoreImageMap {
 		get {
@@ -1109,8 +1107,8 @@ public partial class Generator : IMemberGatherer {
 	{
 		if (t.IsInterface) 
 			return true;
-		if (CoreNSObject != null)
-			return t.IsSubclassOf (CoreNSObject) || t == CoreNSObject; 
+		if (TypeManager.NSObject != null)
+			return t.IsSubclassOf (TypeManager.NSObject) || t == TypeManager.NSObject; 
 		return false;
 	}
 
@@ -1633,7 +1631,7 @@ public partial class Generator : IMemberGatherer {
 
 			if (Frameworks.HaveCoreMedia) {
 				// special case (false) so it needs to be before the _real_ INativeObject check
-				if (pi.ParameterType == SampleBufferType){
+				if (pi.ParameterType == TypeManager.CMSampleBuffer) {
 					pars.AppendFormat ("IntPtr {0}", pi.Name.GetSafeParamName ());
 					if (BindThirdPartyLibrary)
 						invoke.AppendFormat ("{0} == IntPtr.Zero ? null : Runtime.GetINativeObject<CMSampleBuffer> ({0}, false)", pi.Name.GetSafeParamName ());

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -149,24 +149,24 @@ public static class ReflectionExtensions {
 	public static bool IsInternal (this MemberInfo mi, Generator generator)
 	{
 		return generator.AttributeManager.HasAttribute<InternalAttribute> (mi)
-			|| (Generator.UnifiedAPI && generator.AttributeManager.HasAttribute<UnifiedInternalAttribute> (mi));
+			|| (generator.UnifiedAPI && generator.AttributeManager.HasAttribute<UnifiedInternalAttribute> (mi));
 	}
 
 	public static bool IsUnifiedInternal (this MemberInfo mi, Generator generator)
 	{
-		return (Generator.UnifiedAPI && generator.AttributeManager.HasAttribute<UnifiedInternalAttribute> (mi));
+		return (generator.UnifiedAPI && generator.AttributeManager.HasAttribute<UnifiedInternalAttribute> (mi));
 	}
 
 	public static bool IsInternal (this PropertyInfo pi, Generator generator)
 	{
 		return generator.AttributeManager.HasAttribute<InternalAttribute> (pi)
-			|| (Generator.UnifiedAPI && generator.AttributeManager.HasAttribute<UnifiedInternalAttribute> (pi));
+			|| (generator.UnifiedAPI && generator.AttributeManager.HasAttribute<UnifiedInternalAttribute> (pi));
 	}
 
 	public static bool IsInternal (this Type type, Generator generator)
 	{
 		return generator.AttributeManager.HasAttribute<InternalAttribute> (type)
-			|| (Generator.UnifiedAPI && generator.AttributeManager.HasAttribute<UnifiedInternalAttribute> (type));
+			|| (generator.UnifiedAPI && generator.AttributeManager.HasAttribute<UnifiedInternalAttribute> (type));
 	}
 	
 	public static List <MethodInfo> GatherMethods (this Type type, BindingFlags flags, Generator generator) {
@@ -886,7 +886,7 @@ public partial class Generator : IMemberGatherer {
 
 	// Static version of the above (!Compat) field, set on each Go invocation, needed because some static
 	// helper methods need to access this.   This is the exact opposite of Compat.
-	public static bool UnifiedAPI { get { return BindingTouch.Unified; } }
+	public bool UnifiedAPI { get { return BindingTouch.Unified; } }
 	public int XamcoreVersion {
 		get {
 			switch (Generator.CurrentPlatform) {
@@ -1639,7 +1639,7 @@ public partial class Generator : IMemberGatherer {
 			if (Frameworks.HaveAudioToolbox) {
 				if (pi.ParameterType == TypeManager.AudioBuffers){
 					pars.AppendFormat ("IntPtr {0}", pi.Name.GetSafeParamName ());
-					invoke.AppendFormat ("new global::{0}AudioToolbox.AudioBuffers ({1})", Generator.UnifiedAPI ? "" : "MonoTouch.", pi.Name.GetSafeParamName ());
+					invoke.AppendFormat ("new global::{0}AudioToolbox.AudioBuffers ({1})", UnifiedAPI ? "" : "MonoTouch.", pi.Name.GetSafeParamName ());
 					continue;
 				}
 			}
@@ -2485,7 +2485,7 @@ public partial class Generator : IMemberGatherer {
 		return "using (var nsn = Runtime.GetNSObject<NSNumber> (value))\n\treturn " + cast + "nsn." + propertyToCall + ";";
 	}
 
-	static Type GetCorrectGenericType (Type type)
+	Type GetCorrectGenericType (Type type)
 	{
 		if (UnifiedAPI)
 			return type;

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -73,7 +73,7 @@ public static class ReflectionExtensions {
 	public static Type GetBaseType (Type type, Generator generator)
 	{
 		BaseTypeAttribute bta = GetBaseTypeAttribute (type, generator);
-		Type base_type = bta != null ?  bta.BaseType : Generator.TypeManager.System_Object;
+		Type base_type = bta != null ?  bta.BaseType : generator.TypeManager.System_Object;
 
 		return base_type;
 	}
@@ -118,7 +118,7 @@ public static class ReflectionExtensions {
 		string owrap;
 		string nwrap;
 
-		if (parent_type != Generator.TypeManager.NSObject) {
+		if (parent_type != generator.TypeManager.NSObject) {
 			if (generator.AttributeManager.HasAttribute<ModelAttribute> (parent_type)) {
 				foreach (PropertyInfo pinfo in parent_type.GetProperties (flags)) {
 					bool toadd = true;
@@ -177,7 +177,7 @@ public static class ReflectionExtensions {
 
 		Type parent_type = GetBaseType (type, generator);
 
-		if (parent_type != Generator.TypeManager.NSObject) {
+		if (parent_type != generator.TypeManager.NSObject) {
 			if (generator.AttributeManager.HasAttribute<ModelAttribute> (parent_type))
 				foreach (MethodInfo minfo in parent_type.GetMethods ())
 					if (generator.AttributeManager.HasAttribute<ExportAttribute> (minfo))
@@ -382,7 +382,7 @@ public class GeneratedType {
 				ImplementsAppearance = true;
 		}
 		var btype = ReflectionExtensions.GetBaseType (Type, generator);
-		if (btype != Generator.TypeManager.System_Object){
+		if (btype != generator.TypeManager.System_Object){
 			Parent = btype;
 			// protected against a StackOverflowException - bug #19751
 			// it does not protect against large cycles (but good against copy/paste errors)
@@ -843,7 +843,7 @@ public partial class Generator : IMemberGatherer {
 	NamespaceManager ns;
 	static BindingTouch BindingTouch;
 	Frameworks Frameworks { get { return BindingTouch.Frameworks; } }
-	public static TypeManager TypeManager { get { return BindingTouch.TypeManager; } }
+	public TypeManager TypeManager { get { return BindingTouch.TypeManager; } }
 	public AttributeManager AttributeManager { get { return BindingTouch.AttributeManager; } }
 	Dictionary<Type,IEnumerable<string>> selectors = new Dictionary<Type,IEnumerable<string>> ();
 	Dictionary<Type,bool> need_static = new Dictionary<Type,bool> ();
@@ -1329,7 +1329,7 @@ public partial class Generator : IMemberGatherer {
 			throw new BindingException (1048, true, $"Unsupported type 'ref/out {originalType.Name.Replace ("&", string.Empty)}' decorated with [BindAs]");
 
 		var retType = TypeManager.GetUnderlyingNullableType (attrib.Type) ?? attrib.Type;
-		var isNullable = attrib.IsNullable;
+		var isNullable = attrib.IsNullable (this);
 		var isValueType = retType.IsValueType;
 		var isEnum = retType.IsEnum;
 		var parameterName = pi != null ? pi.Name.GetSafeParamName () : "value";
@@ -1880,7 +1880,7 @@ public partial class Generator : IMemberGatherer {
 
 		var bindAsAtt = GetBindAsAttribute (pi) ?? GetBindAsAttribute (propInfo);
 		if (bindAsAtt != null)
-			return bindAsAtt.IsNullable || !bindAsAtt.IsValueType;
+			return bindAsAtt.IsNullable (this) || !bindAsAtt.IsValueType (this);
 
 		if (IsWrappedType (pi.ParameterType))
 			return true;
@@ -4886,7 +4886,7 @@ public partial class Generator : IMemberGatherer {
 			this.async_initial_params = Generator.DropLast (mi.GetParameters ());
 
 			var lastType = mi.GetParameters ().Last ().ParameterType;
-			if (!lastType.IsSubclassOf (TypeManager.System_Delegate))
+			if (!lastType.IsSubclassOf (generator.TypeManager.System_Delegate))
 				throw new BindingException (1036, true, "The last parameter in the method '{0}.{1}' must be a delegate (it's '{2}').", mi.DeclaringType.FullName, mi.Name, lastType.FullName);
 			var cbParams = lastType.GetMethod ("Invoke").GetParameters ();
 			async_completion_params = cbParams;

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -833,6 +833,7 @@ public partial class Generator : IMemberGatherer {
 	internal static bool IsPublicMode;
 
 	static NamespaceManager ns;
+	static BindingTouch BindingTouch;
 	Dictionary<Type,IEnumerable<string>> selectors = new Dictionary<Type,IEnumerable<string>> ();
 	Dictionary<Type,bool> need_static = new Dictionary<Type,bool> ();
 	Dictionary<Type,bool> need_abstract = new Dictionary<Type,bool> ();
@@ -2149,8 +2150,9 @@ public partial class Generator : IMemberGatherer {
 
 	public static Generator SharedGenerator;
 	
-	public Generator (NamespaceManager nsm, bool is_public_mode, bool external, bool debug, Type [] types, Type [] strong_dictionaries)
+	public Generator (BindingTouch binding_touch, NamespaceManager nsm, bool is_public_mode, bool external, bool debug, Type [] types, Type [] strong_dictionaries)
 	{
+		BindingTouch = binding_touch;
 		ns = nsm;
 		Generator.IsPublicMode = is_public_mode;
 		this.external = external;

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -967,7 +967,7 @@ public partial class Generator : IMemberGatherer {
 	// Whether to use ZeroCopy for strings, defaults to false
 	public bool ZeroCopyStrings;
 
-	public static bool BindThirdPartyLibrary { get { return BindingTouch.BindThirdPartyLibrary; } }
+	public bool BindThirdPartyLibrary { get { return BindingTouch.BindThirdPartyLibrary; } }
 	public bool InlineSelectors;
 	public string BaseDir { get { return basedir; } set { basedir = value; }}
 	string basedir;
@@ -5973,7 +5973,7 @@ public partial class Generator : IMemberGatherer {
 		}
 	}
 
-	static string GetAssemblyName ()
+	string GetAssemblyName ()
 	{
 		if (BindThirdPartyLibrary)
 			return Path.GetFileNameWithoutExtension (BindingTouch.outfile);

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -641,6 +641,7 @@ public class NamespaceManager
 	public BindingTouch BindingTouch;
 	PlatformName CurrentPlatform { get { return BindingTouch.CurrentPlatform; } }
 	bool UnifiedAPI { get { return BindingTouch.Unified; } }
+	Frameworks Frameworks { get { return BindingTouch.Frameworks; } }
 
 	public string Prefix { get; private set; }
 
@@ -808,11 +809,17 @@ public enum EnumMode {
 }
 
 public partial class Frameworks {
-	static HashSet<string> frameworks;
-	static bool GetValue (string framework)
+	HashSet<string> frameworks;
+	readonly PlatformName CurrentPlatform;
+	public Frameworks (PlatformName current_platform)
+	{
+		CurrentPlatform = current_platform;
+	}
+
+	bool GetValue (string framework)
 	{
 		if (frameworks == null) {
-			switch (Generator.CurrentPlatform) {
+			switch (CurrentPlatform) {
 			case PlatformName.iOS:
 				frameworks = iosframeworks;
 				break;
@@ -826,7 +833,7 @@ public partial class Frameworks {
 				frameworks = macosframeworks;
 				break;
 			default:
-				throw new BindingException (1047, "Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.", Generator.CurrentPlatform);
+				throw new BindingException (1047, "Unsupported platform: {0}. Please file a bug report (https://github.com/xamarin/xamarin-macios/issues/new) with a test case.", CurrentPlatform);
 			}
 		}
 
@@ -839,6 +846,7 @@ public partial class Generator : IMemberGatherer {
 
 	static NamespaceManager ns;
 	static BindingTouch BindingTouch;
+	static Frameworks Frameworks { get { return BindingTouch.Frameworks; } }
 	Dictionary<Type,IEnumerable<string>> selectors = new Dictionary<Type,IEnumerable<string>> ();
 	Dictionary<Type,bool> need_static = new Dictionary<Type,bool> ();
 	Dictionary<Type,bool> need_abstract = new Dictionary<Type,bool> ();

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -842,7 +842,7 @@ public partial class Generator : IMemberGatherer {
 
 	NamespaceManager ns;
 	static BindingTouch BindingTouch;
-	static Frameworks Frameworks { get { return BindingTouch.Frameworks; } }
+	Frameworks Frameworks { get { return BindingTouch.Frameworks; } }
 	public static TypeManager TypeManager { get { return BindingTouch.TypeManager; } }
 	public AttributeManager AttributeManager { get { return BindingTouch.AttributeManager; } }
 	Dictionary<Type,IEnumerable<string>> selectors = new Dictionary<Type,IEnumerable<string>> ();

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -972,7 +972,7 @@ public partial class Generator : IMemberGatherer {
 	// Whether to use ZeroCopy for strings, defaults to false
 	public bool ZeroCopyStrings;
 
-	public static bool BindThirdPartyLibrary = true;
+	public static bool BindThirdPartyLibrary { get { return BindingTouch.BindThirdPartyLibrary; } }
 	public bool InlineSelectors;
 	public string BaseDir { get { return basedir; } set { basedir = value; }}
 	string basedir;

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -73,7 +73,7 @@ public static class ReflectionExtensions {
 	public static Type GetBaseType (Type type)
 	{
 		BaseTypeAttribute bta = GetBaseTypeAttribute (type);
-		Type base_type = bta != null ?  bta.BaseType : TypeManager.System_Object;
+		Type base_type = bta != null ?  bta.BaseType : Generator.TypeManager.System_Object;
 
 		return base_type;
 	}
@@ -118,7 +118,7 @@ public static class ReflectionExtensions {
 		string owrap;
 		string nwrap;
 
-		if (parent_type != TypeManager.NSObject) {
+		if (parent_type != Generator.TypeManager.NSObject) {
 			if (Generator.AttributeManager.HasAttribute<ModelAttribute> (parent_type)) {
 				foreach (PropertyInfo pinfo in parent_type.GetProperties (flags)) {
 					bool toadd = true;
@@ -177,7 +177,7 @@ public static class ReflectionExtensions {
 
 		Type parent_type = GetBaseType (type);
 
-		if (parent_type != TypeManager.NSObject) {
+		if (parent_type != Generator.TypeManager.NSObject) {
 			if (Generator.AttributeManager.HasAttribute<ModelAttribute> (parent_type))
 				foreach (MethodInfo minfo in parent_type.GetMethods ())
 					if (Generator.AttributeManager.HasAttribute<ExportAttribute> (minfo))
@@ -283,7 +283,7 @@ public class MarshalInfo {
 	{
 		PlainString = Generator.AttributeManager.HasAttribute<PlainStringAttribute> (pi);
 		Type = pi.ParameterType;
-		ZeroCopyStringMarshal = (Type == TypeManager.System_String) && PlainString == false && !Generator.AttributeManager.HasAttribute<DisableZeroCopyAttribute> (pi) && Generator.SharedGenerator.type_wants_zero_copy;
+		ZeroCopyStringMarshal = (Type == Generator.TypeManager.System_String) && PlainString == false && !Generator.AttributeManager.HasAttribute<DisableZeroCopyAttribute> (pi) && Generator.SharedGenerator.type_wants_zero_copy;
 		if (ZeroCopyStringMarshal && Generator.AttributeManager.HasAttribute<DisableZeroCopyAttribute> (mi))
 			ZeroCopyStringMarshal = false;
 		IsOut = TypeManager.IsOutParameter (pi);
@@ -389,7 +389,7 @@ public class GeneratedType {
 				ImplementsAppearance = true;
 		}
 		var btype = ReflectionExtensions.GetBaseType (Type);
-		if (btype != TypeManager.System_Object){
+		if (btype != Generator.TypeManager.System_Object){
 			Parent = btype;
 			// protected against a StackOverflowException - bug #19751
 			// it does not protect against large cycles (but good against copy/paste errors)
@@ -505,7 +505,7 @@ public class MemberInformation
 		// declaration.  If this is an inlined method, then we need to see if this was
 		// also inlined in any of the base classes.
 		if (mi.DeclaringType != type){
-			for (var baseType = ReflectionExtensions.GetBaseType (type); baseType != null && baseType != TypeManager.System_Object; baseType = ReflectionExtensions.GetBaseType (baseType)){
+			for (var baseType = ReflectionExtensions.GetBaseType (type); baseType != null && baseType != Generator.TypeManager.System_Object; baseType = ReflectionExtensions.GetBaseType (baseType)){
 				foreach (var baseMethod in gather.GetTypeContractMethods (baseType)){
 					if (baseMethod.DeclaringType != baseType && baseMethod ==  mi){
 						// We found a case, we need to flag it as new.
@@ -522,10 +522,10 @@ public class MemberInformation
 	{
 		is_basewrapper_protocol_method = isBaseWrapperProtocolMethod;
 		foreach (ParameterInfo pi in mi.GetParameters ())
-			if (pi.ParameterType.IsSubclassOf (TypeManager.System_Delegate))
+			if (pi.ParameterType.IsSubclassOf (Generator.TypeManager.System_Delegate))
 				is_unsafe = true;
 
-		if (!is_unsafe &&  mi.ReturnType.IsSubclassOf (TypeManager.System_Delegate))
+		if (!is_unsafe &&  mi.ReturnType.IsSubclassOf (Generator.TypeManager.System_Delegate))
 			is_unsafe = true;
 
 		if (selector != null) {
@@ -576,7 +576,7 @@ public class MemberInformation
 	public MemberInformation (IMemberGatherer gather, PropertyInfo pi, Type type, bool is_interface_impl = false)
 	: this (gather, (MemberInfo)pi, type, is_interface_impl, false, false, false)
 	{
-		if (pi.PropertyType.IsSubclassOf (TypeManager.System_Delegate))
+		if (pi.PropertyType.IsSubclassOf (Generator.TypeManager.System_Delegate))
 			is_unsafe = true;
 
 		var export = Generator.GetExportAttribute (pi, out wrap_method);
@@ -848,6 +848,7 @@ public partial class Generator : IMemberGatherer {
 	static NamespaceManager ns;
 	static BindingTouch BindingTouch;
 	static Frameworks Frameworks { get { return BindingTouch.Frameworks; } }
+	public static TypeManager TypeManager { get { return BindingTouch.TypeManager; } }
 	public static AttributeManager AttributeManager { get { return BindingTouch.AttributeManager; } }
 	Dictionary<Type,IEnumerable<string>> selectors = new Dictionary<Type,IEnumerable<string>> ();
 	Dictionary<Type,bool> need_static = new Dictionary<Type,bool> ();
@@ -976,8 +977,8 @@ public partial class Generator : IMemberGatherer {
 	public string BaseDir { get { return basedir; } set { basedir = value; }}
 	string basedir;
 	HashSet<string> generated_files = new HashSet<string> ();
-	public Type CoreNSObject = TypeManager.NSObject;
-	public Type SampleBufferType = TypeManager.CMSampleBuffer;
+	public Type CoreNSObject = Generator.TypeManager.NSObject;
+	public Type SampleBufferType = Generator.TypeManager.CMSampleBuffer;
 
 	static string CoreImageMap {
 		get {

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -96,7 +96,7 @@ public static class ReflectionExtensions {
 	{
 		return generator.AttributeManager.GetCustomAttributes<AvailabilityBaseAttribute> (provider)
 			.Any (attr => attr.AvailabilityKind == AvailabilityKind.Unavailable &&
-				attr.Platform == Generator.CurrentPlatform);
+				attr.Platform == generator.CurrentPlatform);
 	}
 	
 	public static AvailabilityBaseAttribute GetAvailability (this ICustomAttributeProvider attrProvider, AvailabilityKind availabilityKind, Generator generator)
@@ -104,7 +104,7 @@ public static class ReflectionExtensions {
 		return generator.AttributeManager.GetCustomAttributes<AvailabilityBaseAttribute> (attrProvider)
 			.FirstOrDefault (attr =>
 				attr.AvailabilityKind == availabilityKind &&
-					attr.Platform == Generator.CurrentPlatform
+					attr.Platform == generator.CurrentPlatform
 			);
 	}
 
@@ -867,9 +867,9 @@ public partial class Generator : IMemberGatherer {
 
 	public bool Compat { get { return !UnifiedAPI; } }
 
-	public static PlatformName CurrentPlatform { get { return BindingTouch.CurrentPlatform; } }
+	public PlatformName CurrentPlatform { get { return BindingTouch.CurrentPlatform; } }
 
-	public static string ApplicationClassName {
+	public string ApplicationClassName {
 		get {
 			switch (CurrentPlatform) {
 			case PlatformName.iOS:
@@ -889,7 +889,7 @@ public partial class Generator : IMemberGatherer {
 	public bool UnifiedAPI { get { return BindingTouch.Unified; } }
 	public int XamcoreVersion {
 		get {
-			switch (Generator.CurrentPlatform) {
+			switch (CurrentPlatform) {
 			case PlatformName.MacOSX:
 			case PlatformName.iOS:
 				return UnifiedAPI ? 2 : 1;
@@ -973,7 +973,7 @@ public partial class Generator : IMemberGatherer {
 	string basedir;
 	HashSet<string> generated_files = new HashSet<string> ();
 
-	static string CoreImageMap {
+	string CoreImageMap {
 		get {
 			switch (CurrentPlatform) {
 			case PlatformName.iOS:
@@ -988,7 +988,7 @@ public partial class Generator : IMemberGatherer {
 		}
 	}
 
-	static string CoreServicesMap {
+	string CoreServicesMap {
 		get {
 			switch (CurrentPlatform) {
 			case PlatformName.iOS:
@@ -1003,7 +1003,7 @@ public partial class Generator : IMemberGatherer {
 		}
 	}
 
-	static string PDFKitMap {
+	string PDFKitMap {
 		get {
 			switch (CurrentPlatform) {
 			case PlatformName.iOS:
@@ -2177,7 +2177,7 @@ public partial class Generator : IMemberGatherer {
 		if (Compat)
 			return AttributeManager.GetCustomAttributes<AvailabilityBaseAttribute> (t)
 				.Any (attr => attr.AvailabilityKind == AvailabilityKind.Introduced &&
-					attr.Platform == Generator.CurrentPlatform &&
+					attr.Platform == CurrentPlatform &&
 					attr.Architecture == PlatformArchitecture.Arch64);
 
 		return false;

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -67,7 +67,7 @@ public static class GeneratorExtensions
 public static class ReflectionExtensions {
 	public static BaseTypeAttribute GetBaseTypeAttribute (Type type)
 	{
-		return AttributeManager.GetCustomAttribute<BaseTypeAttribute> (type);
+		return Generator.AttributeManager.GetCustomAttribute<BaseTypeAttribute> (type);
 	}
 
 	public static Type GetBaseType (Type type)
@@ -94,14 +94,14 @@ public static class ReflectionExtensions {
 	//
 	public static bool IsUnavailable (this ICustomAttributeProvider provider)
 	{
-		return AttributeManager.GetCustomAttributes<AvailabilityBaseAttribute> (provider)
+		return Generator.AttributeManager.GetCustomAttributes<AvailabilityBaseAttribute> (provider)
 			.Any (attr => attr.AvailabilityKind == AvailabilityKind.Unavailable &&
 				attr.Platform == Generator.CurrentPlatform);
 	}
 	
 	public static AvailabilityBaseAttribute GetAvailability (this ICustomAttributeProvider attrProvider, AvailabilityKind availabilityKind)
 	{
-		return AttributeManager.GetCustomAttributes<AvailabilityBaseAttribute> (attrProvider)
+		return Generator.AttributeManager.GetCustomAttributes<AvailabilityBaseAttribute> (attrProvider)
 			.FirstOrDefault (attr =>
 				attr.AvailabilityKind == availabilityKind &&
 					attr.Platform == Generator.CurrentPlatform
@@ -119,7 +119,7 @@ public static class ReflectionExtensions {
 		string nwrap;
 
 		if (parent_type != TypeManager.NSObject) {
-			if (AttributeManager.HasAttribute<ModelAttribute> (parent_type)) {
+			if (Generator.AttributeManager.HasAttribute<ModelAttribute> (parent_type)) {
 				foreach (PropertyInfo pinfo in parent_type.GetProperties (flags)) {
 					bool toadd = true;
 					var modelea = Generator.GetExportAttribute (pinfo, out nwrap);
@@ -148,25 +148,25 @@ public static class ReflectionExtensions {
 
 	public static bool IsInternal (this MemberInfo mi)
 	{
-		return AttributeManager.HasAttribute<InternalAttribute> (mi)
-			|| (Generator.UnifiedAPI && AttributeManager.HasAttribute<UnifiedInternalAttribute> (mi));
+		return Generator.AttributeManager.HasAttribute<InternalAttribute> (mi)
+			|| (Generator.UnifiedAPI && Generator.AttributeManager.HasAttribute<UnifiedInternalAttribute> (mi));
 	}
 
 	public static bool IsUnifiedInternal (this MemberInfo mi)
 	{
-		return (Generator.UnifiedAPI && AttributeManager.HasAttribute<UnifiedInternalAttribute> (mi));
+		return (Generator.UnifiedAPI && Generator.AttributeManager.HasAttribute<UnifiedInternalAttribute> (mi));
 	}
 
 	public static bool IsInternal (this PropertyInfo pi)
 	{
-		return AttributeManager.HasAttribute<InternalAttribute> (pi)
-			|| (Generator.UnifiedAPI && AttributeManager.HasAttribute<UnifiedInternalAttribute> (pi));
+		return Generator.AttributeManager.HasAttribute<InternalAttribute> (pi)
+			|| (Generator.UnifiedAPI && Generator.AttributeManager.HasAttribute<UnifiedInternalAttribute> (pi));
 	}
 
 	public static bool IsInternal (this Type type)
 	{
-		return AttributeManager.HasAttribute<InternalAttribute> (type)
-			|| (Generator.UnifiedAPI && AttributeManager.HasAttribute<UnifiedInternalAttribute> (type));
+		return Generator.AttributeManager.HasAttribute<InternalAttribute> (type)
+			|| (Generator.UnifiedAPI && Generator.AttributeManager.HasAttribute<UnifiedInternalAttribute> (type));
 	}
 	
 	public static List <MethodInfo> GatherMethods (this Type type, BindingFlags flags) {
@@ -178,9 +178,9 @@ public static class ReflectionExtensions {
 		Type parent_type = GetBaseType (type);
 
 		if (parent_type != TypeManager.NSObject) {
-			if (AttributeManager.HasAttribute<ModelAttribute> (parent_type))
+			if (Generator.AttributeManager.HasAttribute<ModelAttribute> (parent_type))
 				foreach (MethodInfo minfo in parent_type.GetMethods ())
-					if (AttributeManager.HasAttribute<ExportAttribute> (minfo))
+					if (Generator.AttributeManager.HasAttribute<ExportAttribute> (minfo))
 						methods.Add (minfo);
 		}
 
@@ -281,10 +281,10 @@ public class MarshalInfo {
 	// Used for parameters
 	public MarshalInfo (MethodInfo mi, ParameterInfo pi)
 	{
-		PlainString = AttributeManager.HasAttribute<PlainStringAttribute> (pi);
+		PlainString = Generator.AttributeManager.HasAttribute<PlainStringAttribute> (pi);
 		Type = pi.ParameterType;
-		ZeroCopyStringMarshal = (Type == TypeManager.System_String) && PlainString == false && !AttributeManager.HasAttribute<DisableZeroCopyAttribute> (pi) && Generator.SharedGenerator.type_wants_zero_copy;
-		if (ZeroCopyStringMarshal && AttributeManager.HasAttribute<DisableZeroCopyAttribute> (mi))
+		ZeroCopyStringMarshal = (Type == TypeManager.System_String) && PlainString == false && !Generator.AttributeManager.HasAttribute<DisableZeroCopyAttribute> (pi) && Generator.SharedGenerator.type_wants_zero_copy;
+		if (ZeroCopyStringMarshal && Generator.AttributeManager.HasAttribute<DisableZeroCopyAttribute> (mi))
 			ZeroCopyStringMarshal = false;
 		IsOut = TypeManager.IsOutParameter (pi);
 	}
@@ -292,7 +292,7 @@ public class MarshalInfo {
 	// Used to return values
 	public MarshalInfo (MethodInfo mi)
 	{
-		PlainString = AttributeManager.HasAttribute<PlainStringAttribute> (AttributeManager.GetReturnTypeCustomAttributes (mi));
+		PlainString = Generator.AttributeManager.HasAttribute<PlainStringAttribute> (AttributeManager.GetReturnTypeCustomAttributes (mi));
 		Type = mi.ReturnType;
 	}
 
@@ -403,7 +403,7 @@ public class GeneratedType {
 			ParentGenerated.Children.Add (this);
 		}
 
-		if (AttributeManager.HasAttribute<CategoryAttribute> (t))
+		if (Generator.AttributeManager.HasAttribute<CategoryAttribute> (t))
 			ImplementsAppearance = false;
 	}
 	public Type Type;
@@ -436,14 +436,15 @@ class WrapPropMemberInformation
 
 	public WrapPropMemberInformation (PropertyInfo pi)
 	{
-		WrapGetter = AttributeManager.GetCustomAttribute<WrapAttribute> (pi?.GetMethod)?.MethodName;
-		WrapSetter = AttributeManager.GetCustomAttribute<WrapAttribute> (pi?.SetMethod)?.MethodName;
+		WrapGetter = Generator.AttributeManager.GetCustomAttribute<WrapAttribute> (pi?.GetMethod)?.MethodName;
+		WrapSetter = Generator.AttributeManager.GetCustomAttribute<WrapAttribute> (pi?.SetMethod)?.MethodName;
 	}
 }
 
 
 public class MemberInformation
 {
+	AttributeManager AttributeManager { get { return Generator.AttributeManager; } }
 	public readonly MemberInfo mi;
 	public readonly Type type;
 	public readonly Type category_extension_type;
@@ -565,7 +566,7 @@ public class MemberInformation
 		this.category_extension_type = category_extension_type;
 		if (category_extension_type != null) {
 			is_category_extension = true;
-			ignore_category_static_warnings = is_internal || type.IsInternal () || AttributeManager.GetCustomAttribute<CategoryAttribute> (type).AllowStaticMembers;
+			ignore_category_static_warnings = is_internal || type.IsInternal () || Generator.AttributeManager.GetCustomAttribute<CategoryAttribute> (type).AllowStaticMembers;
 		}
 
 		if (is_static || is_category_extension || is_interface_impl || is_extension_method || is_type_sealed)
@@ -583,7 +584,7 @@ public class MemberInformation
 			selector = export.Selector;
 
 		if (wrap_method != null) {
-			var wrapAtt = AttributeManager.GetCustomAttribute <WrapAttribute> (pi);
+			var wrapAtt = Generator.AttributeManager.GetCustomAttribute <WrapAttribute> (pi);
 			is_virtual_method = wrapAtt?.IsVirtual ?? false;
 		}
 		else if (is_interface_impl || is_type_sealed)
@@ -847,6 +848,7 @@ public partial class Generator : IMemberGatherer {
 	static NamespaceManager ns;
 	static BindingTouch BindingTouch;
 	static Frameworks Frameworks { get { return BindingTouch.Frameworks; } }
+	public static AttributeManager AttributeManager { get { return BindingTouch.AttributeManager; } }
 	Dictionary<Type,IEnumerable<string>> selectors = new Dictionary<Type,IEnumerable<string>> ();
 	Dictionary<Type,bool> need_static = new Dictionary<Type,bool> ();
 	Dictionary<Type,bool> need_abstract = new Dictionary<Type,bool> ();

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -841,7 +841,7 @@ public partial class Generator : IMemberGatherer {
 	internal bool IsPublicMode;
 
 	NamespaceManager ns;
-	static BindingTouch BindingTouch;
+	BindingTouch BindingTouch;
 	Frameworks Frameworks { get { return BindingTouch.Frameworks; } }
 	public TypeManager TypeManager { get { return BindingTouch.TypeManager; } }
 	public AttributeManager AttributeManager { get { return BindingTouch.AttributeManager; } }

--- a/tests/generator/BGenTool.cs
+++ b/tests/generator/BGenTool.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Tests
 		public string ResponseFile;
 		public string WarnAsError; // Set to empty string to pass /warnaserror, set to non-empty string to pass /warnaserror:<nonemptystring>
 		public string NoWarn; // Set to empty string to pass /nowarn, set to non-empty string to pass /nowarn:<nonemptystring>
+		public string Out;
 
 		protected override string ToolPath { get { return Profile == Profile.macOSClassic ? Configuration.BGenClassicPath : Configuration.BGenPath; } }
 		protected override string MessagePrefix { get { return "BI"; } }
@@ -271,7 +272,7 @@ namespace Xamarin.Tests
 		void LoadAssembly ()
 		{
 			if (assembly == null)
-				assembly = AssemblyDefinition.ReadAssembly (Path.Combine (TmpDirectory, Path.GetFileNameWithoutExtension (ApiDefinitions [0]).Replace ('-', '_') + ".dll"));
+				assembly = AssemblyDefinition.ReadAssembly (Out ?? (Path.Combine (TmpDirectory, Path.GetFileNameWithoutExtension (ApiDefinitions [0]).Replace ('-', '_') + ".dll")));
 		}
 
 		void EnsureTempDir ()
@@ -289,6 +290,7 @@ namespace Xamarin.Tests
 				ApiDefinitions.Add (api);
 			}
 			WorkingDirectory = TmpDirectory;
+			Out = Path.Combine (WorkingDirectory, "api0.dll");
 		}
 
 		public static string [] GetDefaultDefines (Profile profile)

--- a/tests/generator/generator-tests.csproj
+++ b/tests/generator/generator-tests.csproj
@@ -73,5 +73,11 @@
   <ItemGroup>
     <Folder Include="tests\" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\generator.csproj">
+      <Project>{D2EE02C0-9BFD-477D-AC92-4DE2D8490790}</Project>
+      <Name>generator</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
This has two main advantages:

* It'll be possible to step into the generator's code when debugging tests,
  since we won't be launching an external process to run bgen.

* The tests run slightly faster (32s vs 39s on my machine), since we spawn
  fewer subprocesses.

The required changes basically consist of making sure we don't have static
state anywhere. This is mostly accomplished by passing instances around
instead of relying on static API. In many cases I was able to create an
instance field with the same name as the type, which made existing code work
without change.

The only exception is error reporting: in that case we rely on a ThreadStatic
field to store the warnings-as-errors list, since otherwise the modifications
were both ugly and numerous. This will probably break if we one day start
using async in the generator, but for now it should be safe enough.

Most of the other changes were fairly mechanical: just add a parameter or a
field, and then use it.

This PR is best reviewed commit-by-commit.