### PR TITLE
[jenkins] Set a 1h build timeout.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -458,11 +458,13 @@ timestamps {
                         stage ('Build') {
                             currentStage = "${STAGE_NAME}"
                             echo ("Building on ${env.NODE_NAME}")
-                            withEnv ([
-                                "CURRENT_BRANCH=${branchName}",
-                                "PACKAGE_HEAD_BRANCH=${branchName}"
-                                ]) {
-                                sh ("${workspace}/xamarin-macios/jenkins/build.sh --configure-flags --enable-xamarin")
+                            timeout (time: 1, unit: 'HOURS') {
+                                withEnv ([
+                                    "CURRENT_BRANCH=${branchName}",
+                                    "PACKAGE_HEAD_BRANCH=${branchName}"
+                                    ]) {
+                                    sh ("${workspace}/xamarin-macios/jenkins/build.sh --configure-flags --enable-xamarin")
+                                }
                             }
                         }
 


### PR DESCRIPTION
Builds take approximately 30 minutes on a bot now, so 1 hour should be plenty.

This makes sure a 32-bit dialog doesn't waste 9h of bot time just sitting
there.