### PR TITLE
[bgen] Build the frameworks.g.cs from BUILD_DIR.

### DIFF
--- a/src/generator.csproj
+++ b/src/generator.csproj
@@ -8,6 +8,8 @@
     <AssemblyName>bgen</AssemblyName>
     <RootNamespace>bgen</RootNamespace>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <BuildDir Condition="'$(BUILD_DIR)' != ''">$(BUILD_DIR)\</BuildDir>
+    <BuildDir Condition="'$(BUILD_DIR)' == ''">build\</BuildDir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -356,7 +358,7 @@
     <Compile Include="..\src\ObjCRuntime\Stret.cs"/>
     <Compile Include="..\tools\common\TargetFramework.cs"/>
     <Compile Include="..\tools\common\StringUtils.cs"/>
-    <Compile Include="build\generator-frameworks.g.cs"/>
+    <Compile Include="$(BuildDir)generator-frameworks.g.cs"/>
     <Compile Include="..\external\mono\mcs\class\Mono.Options\Mono.Options\Options.cs"/>
     <Compile Include="..\src\Foundation\AdviceAttribute.cs"/>
     <Compile Include="..\src\Foundation\ExportAttribute.cs"/>


### PR DESCRIPTION
This fixes an issue with the per-pr api/generator diff comparison, since with
this change we now build src/ with the right source code.