### PR TITLE
[apidiff] Make temporary / stamp paths depend on APIDIFF_DIR. Fixes maccore#1522.

### DIFF
--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -167,19 +167,20 @@ all-local:: $(BUNDLE_ZIP) $(APIDIFF_DIR)/api-diff.html
 # Rules to re-create the reference infos from the curretn stable 'bundle.zip. assemblies
 
 # split the URL in words based on the path separator, and then chose the 6th word (the hash) in the bundle zip filename
-BUNDLE_ZIP=bundle-$(word 6,$(subst /, ,$(APIDIFF_REFERENCES))).zip
+BUNDLE_ZIP=$(APIDIFF_DIR)/bundle-$(word 6,$(subst /, ,$(APIDIFF_REFERENCES))).zip
 $(BUNDLE_ZIP):
 	# download to a temporary filename so interrupted downloads won't prevent re-downloads.
 	$(Q_GEN) curl -L $(APIDIFF_REFERENCES) > $@.tmp
 	$(Q) mv $@.tmp $@
 
-.unzip.stamp: $(BUNDLE_ZIP)
+UNZIP_STAMP=$(APIDIFF_DIR)/.unzip.stamp
+$(UNZIP_STAMP): $(BUNDLE_ZIP)
 	$(Q) rm -Rf temp
 	$(Q_GEN) unzip -d temp $(BUNDLE_ZIP)
 	$(Q) touch $@
 
 # the semi-colon at the end means an empty recipe, and is required for make to consider pattern rules
-temp/%.dll: .unzip.stamp ;
+temp/%.dll: $(UNZIP_STAMP) ;
 
 IOS_REFS     = $(foreach file,$(IOS_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/xi/$(file).xml)
 MAC_REFS     = $(foreach file,$(MAC_ASSEMBLIES),$(APIDIFF_DIR)/updated-references/xm/$(file).xml)
@@ -221,7 +222,7 @@ verify-reference-assemblies-mac: $(APIDIFF_DIR)/temp/native-32/Xamarin.Mac.xml $
 
 clean-local::
 	rm -rf temp references diff *.exe* api-diff.html
-	rm -rf *.dll* bundle-*.zip .unzip.stamp
+	rm -rf *.dll* bundle-*.zip $(UNZIP_STAMP)
 	rm -rf ios-*.md tvos-*.md watchos-*.md macos-*.md
 
 DIRS += $(APIDIFF_DIR)/temp $(APIDIFF_DIR)/diff
@@ -291,7 +292,7 @@ ifdef INCLUDE_TVOS
 	@echo "@MonkeyWrench: AddFile: $(CURDIR)/diff/ios-to-tvos.html"
 endif
 endif
-	$(Q) $(MAKE) .unzip.stamp
+	$(Q) $(MAKE) $(UNZIP_STAMP)
 	$(Q) $(MAKE) all -j8
 	$(Q) $(MAKE) -j8 ios-markdown tvos-markdown watchos-markdown macos-markdown
 	$(Q) $(CP) api-diff.html index.html


### PR DESCRIPTION
This fixes an issue with the api comparison since the api comparison fails if
it detects unexpected modified files. Putting the temporary files in
APIDIFF_DIR makes sure the api comparison doesn't see those files as
unexpectedly modified.

Fixes https://github.com/xamarin/maccore/issues/1522.