### PR TITLE
[CFNetwork] Ensure we do not block on redirects.

### DIFF
--- a/src/System.Net.Http/CFNetworkHandler.cs
+++ b/src/System.Net.Http/CFNetworkHandler.cs
@@ -267,6 +267,10 @@ namespace System.Net.Http
  				var status = initialRequest.StatusCode;
  				if (IsRedirect (status) && allowAutoRedirect) {
  					bucket.StreamCanBeDisposed = true;
+ 					// we do not care about the first stream cbs
+					stream.HasBytesAvailableEvent -= HandleHasBytesAvailableEvent;
+					stream.ErrorEvent -= HandleErrorEvent;
+					stream.ClosedEvent -= HandleClosedEvent;
 					// remove headers in a redirect for Authentication.
 					request.Headers.Authorization = null;
  					return await SendAsync (request, cancellationToken, false).ConfigureAwait (false);


### PR DESCRIPTION
The changes in mono are changing threading. This means that the code is
getting deadlock in the ReadStreamData.

This happens because we were not removing the handlers from the first request events.
Initially, before we had to take care about the auth headers, this was needed to init
certain internal state for the HttpContent that was exposed to the
user. With the fix of the CVE, the first request, in case of a redirect,
is garbage and is ignored. The second request is the one returned to the
user and contains all the required info.

Removing the event handlers, ensure that HandleCloseEvent is not called and
therefore ReadStream is never called.