### PR TITLE
[XHarness] Ignore device tests for platforms in certain bots.

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -704,6 +704,27 @@ namespace xharness
 				return string.IsNullOrEmpty (groupApps) || groupApps == "grouped";
 			}
 		}
+		
+		public bool SkipTvOSDeviceVariations {
+			get {
+				var skipTv = Environment.GetEnvironmentVariable ("SKIP_TVOS_VARIATIONS");
+				return !string.IsNullOrEmpty (skipTv) && skipTv == "true";
+			}
+		}
+		
+		public bool SkipiOSDeviceVariations {
+			get {
+				var skipiOs = Environment.GetEnvironmentVariable ("SKIP_IOS_VARIATIONS");
+				return !string.IsNullOrEmpty (skipiOs) && skipiOs == "true";
+			}
+		}
+		
+		public bool SkipWatchOSDeviceVariations {
+			get {
+				var skipWatchOS = Environment.GetEnvironmentVariable ("SKIP_WATCHOS_VARIATIONS");
+				return !string.IsNullOrEmpty (skipWatchOS) && skipWatchOS == "true";
+			}
+		}
 
 		public int Execute ()
 		{

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -704,27 +704,6 @@ namespace xharness
 				return string.IsNullOrEmpty (groupApps) || groupApps == "grouped";
 			}
 		}
-		
-		public bool SkipTvOSDeviceVariations {
-			get {
-				var skipTv = Environment.GetEnvironmentVariable ("SKIP_TVOS_VARIATIONS");
-				return !string.IsNullOrEmpty (skipTv) && skipTv == "true";
-			}
-		}
-		
-		public bool SkipiOSDeviceVariations {
-			get {
-				var skipiOs = Environment.GetEnvironmentVariable ("SKIP_IOS_VARIATIONS");
-				return !string.IsNullOrEmpty (skipiOs) && skipiOs == "true";
-			}
-		}
-		
-		public bool SkipWatchOSDeviceVariations {
-			get {
-				var skipWatchOS = Environment.GetEnvironmentVariable ("SKIP_WATCHOS_VARIATIONS");
-				return !string.IsNullOrEmpty (skipWatchOS) && skipWatchOS == "true";
-			}
-		}
 
 		public int Execute ()
 		{

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -25,6 +25,7 @@ namespace xharness
 		public bool IncludeMac = true;
 		public bool IncludeMac32 = true;
 		public bool IncludeiOS = true;
+		public bool IncludeiOS32 = true;
 		public bool IncludeiOSExtensions;
 		public bool ForceExtensionBuildOnly;
 		public bool IncludetvOS = true;
@@ -150,7 +151,10 @@ namespace xharness
 				break;
 			case TestPlatform.iOS_Unified:
 				targets = new AppRunnerTarget [] { AppRunnerTarget.Simulator_iOS32, AppRunnerTarget.Simulator_iOS64 };
-				platforms = new TestPlatform [] { TestPlatform.iOS_Unified32, TestPlatform.iOS_Unified64 };
+				if (IncludeiOS32)
+					platforms = new TestPlatform [] { TestPlatform.iOS_Unified32, TestPlatform.iOS_Unified64 };
+				else 
+					platforms = new TestPlatform [] { TestPlatform.iOS_Unified64 };
 				break;
 			case TestPlatform.iOS_TodayExtension64:
 				targets = new AppRunnerTarget[] { AppRunnerTarget.Simulator_iOS64 };
@@ -486,7 +490,7 @@ namespace xharness
 						TestName = project.Name,
 					};
 					build32.CloneTestProject (project);
-					rv.Add (new RunDeviceTask (build32, Devices.Connected32BitIOS.Where (d => d.IsSupported (project))) { Ignored = ignored || !IncludeiOS, BuildOnly = project.BuildOnly });
+					rv.Add (new RunDeviceTask (build32, Devices.Connected32BitIOS.Where (d => d.IsSupported (project))) { Ignored = ignored || !IncludeiOS || !IncludeiOS32, BuildOnly = project.BuildOnly });
 
 					var todayProject = project.AsTodayExtensionProject ();
 					var buildToday = new XBuildTask {
@@ -687,6 +691,7 @@ namespace xharness
 			// enabled by default
 			SetEnabled (labels, "ios", ref IncludeiOS);
 			SetEnabled (labels, "tvos", ref IncludetvOS);
+			SetEnabled (labels, "ios-32", ref IncludeiOS32);
 			SetEnabled (labels, "watchos", ref IncludewatchOS);
 			SetEnabled (labels, "mac", ref IncludeMac);
 			SetEnabled (labels, "mac-classic", ref IncludeClassicMac);

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -451,7 +451,7 @@ namespace xharness
 				if (!IsIncluded (project))
 					ignored = true;
 
-				if (!project.SkipiOSVariation && !Harness.SkipiOSDeviceVariations) {
+				if (!project.SkipiOSVariation) {
 					var build64 = new XBuildTask {
 						Jenkins = this,
 						ProjectConfiguration = "Debug64",
@@ -460,7 +460,7 @@ namespace xharness
 						TestName = project.Name,
 					};
 					build64.CloneTestProject (project);
-					rv.Add (new RunDeviceTask (build64, Devices.Connected64BitIOS.Where (d => d.IsSupported (project))) { Ignored = ignored || !IncludeiOS, BuildOnly = project.BuildOnly });
+					rv.Add (new RunDeviceTask (build64, Devices.Connected64BitIOS.Where (d => d.IsSupported (project))) { Ignored = Harness.SkipiOSDeviceVariations || ignored || !IncludeiOS, BuildOnly = project.BuildOnly });
 
 					var build32 = new XBuildTask {
 						Jenkins = this,
@@ -470,7 +470,7 @@ namespace xharness
 						TestName = project.Name,
 					};
 					build32.CloneTestProject (project);
-					rv.Add (new RunDeviceTask (build32, Devices.Connected32BitIOS.Where (d => d.IsSupported (project))) { Ignored = ignored || !IncludeiOS, BuildOnly = project.BuildOnly });
+					rv.Add (new RunDeviceTask (build32, Devices.Connected32BitIOS.Where (d => d.IsSupported (project))) { Ignored = Harness.SkipiOSDeviceVariations || ignored || !IncludeiOS, BuildOnly = project.BuildOnly });
 
 					var todayProject = project.AsTodayExtensionProject ();
 					var buildToday = new XBuildTask {
@@ -481,10 +481,10 @@ namespace xharness
 						TestName = project.Name,
 					};
 					buildToday.CloneTestProject (todayProject);
-					rv.Add (new RunDeviceTask (buildToday, Devices.Connected64BitIOS.Where (d => d.IsSupported (project))) { Ignored = ignored || !IncludeiOSExtensions, BuildOnly = project.BuildOnly || ForceExtensionBuildOnly });
+					rv.Add (new RunDeviceTask (buildToday, Devices.Connected64BitIOS.Where (d => d.IsSupported (project))) { Ignored = Harness.SkipiOSDeviceVariations || ignored || !IncludeiOSExtensions, BuildOnly = project.BuildOnly || ForceExtensionBuildOnly });
 				}
 
-				if (!project.SkiptvOSVariation && !Harness.SkipTvOSDeviceVariations) {
+				if (!project.SkiptvOSVariation) {
 					var tvOSProject = project.AsTvOSProject ();
 					var buildTV = new XBuildTask {
 						Jenkins = this,
@@ -494,10 +494,10 @@ namespace xharness
 						TestName = project.Name,
 					};
 					buildTV.CloneTestProject (tvOSProject);
-					rv.Add (new RunDeviceTask (buildTV, Devices.ConnectedTV.Where (d => d.IsSupported (project))) { Ignored = ignored || !IncludetvOS, BuildOnly = project.BuildOnly });
+					rv.Add (new RunDeviceTask (buildTV, Devices.ConnectedTV.Where (d => d.IsSupported (project))) { Ignored = Harness.SkipTvOSDeviceVariations || ignored || !IncludetvOS, BuildOnly = project.BuildOnly });
 				}
 
-				if (!project.SkipwatchOSVariation && !Harness.SkipWatchOSDeviceVariations) {
+				if (!project.SkipwatchOSVariation) {
 					var watchOSProject = project.AsWatchOSProject ();
 					var buildWatch = new XBuildTask {
 						Jenkins = this,
@@ -507,7 +507,7 @@ namespace xharness
 						TestName = project.Name,
 					};
 					buildWatch.CloneTestProject (watchOSProject);
-					rv.Add (new RunDeviceTask (buildWatch, Devices.ConnectedWatch.Where (d => d.IsSupported (project))) { Ignored = ignored || !IncludewatchOS, BuildOnly = project.BuildOnly });
+					rv.Add (new RunDeviceTask (buildWatch, Devices.ConnectedWatch.Where (d => d.IsSupported (project))) { Ignored = Harness.SkipWatchOSDeviceVariations || ignored || !IncludewatchOS, BuildOnly = project.BuildOnly });
 				}
 			}
 

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -102,11 +102,11 @@ namespace xharness
 					capturedLog.WriteLine ("Failed to load:");
 					capturedLog.WriteLine (v.Exception);
 					capturedLog.Description = $"{name} Listing {v.Exception.Message})";
-				} else if (v.IsCompleted) { // TODO
+				} else if (v.IsCompleted) {
 					var devices = loadable as Devices;
 					var devicesTypes = new StringBuilder ();
 					if (devices != null) {
-						if (devices.Connected32BitIOS.Any()) {
+						if (devices.Connected32BitIOS.Any ()) {
 							devicesTypes.Append ("iOS 32 bit");
 						}
 						if (devices.Connected64BitIOS.Any ()) {
@@ -119,7 +119,7 @@ namespace xharness
 							devicesTypes.Append (devicesTypes.Length == 0 ? "watchOS" : ", watchOS");
 						}
 					}
-					capturedLog.Description = (devices == null)? $"{name} Listing (ok)." : $"{name} Listing (ok). Devices types are: {devicesTypes.ToString ()}";
+					capturedLog.Description = (devices == null || devicesTypes.Length == 0)? $"{name} Listing (ok)." : $"{name} Listing (ok). Devices types are: {devicesTypes.ToString ()}";
 				}
 			});
 		}
@@ -139,33 +139,35 @@ namespace xharness
 
 			AppRunnerTarget [] targets;
 			TestPlatform [] platforms;
+			bool [] ignored;
 
 			switch (buildTask.Platform) {
 			case TestPlatform.tvOS:
 				targets = new AppRunnerTarget [] { AppRunnerTarget.Simulator_tvOS };
 				platforms = new TestPlatform [] { TestPlatform.tvOS };
+				ignored = new [] { false };
 				break;
 			case TestPlatform.watchOS:
 				targets = new AppRunnerTarget [] { AppRunnerTarget.Simulator_watchOS };
 				platforms = new TestPlatform [] { TestPlatform.watchOS };
+				ignored = new [] { false };
 				break;
 			case TestPlatform.iOS_Unified:
 				targets = new AppRunnerTarget [] { AppRunnerTarget.Simulator_iOS32, AppRunnerTarget.Simulator_iOS64 };
-				if (IncludeiOS32)
-					platforms = new TestPlatform [] { TestPlatform.iOS_Unified32, TestPlatform.iOS_Unified64 };
-				else 
-					platforms = new TestPlatform [] { TestPlatform.iOS_Unified64 };
+				platforms = new TestPlatform [] { TestPlatform.iOS_Unified32, TestPlatform.iOS_Unified64 };
+				ignored = new [] { !IncludeiOS32, false};
 				break;
 			case TestPlatform.iOS_TodayExtension64:
 				targets = new AppRunnerTarget[] { AppRunnerTarget.Simulator_iOS64 };
 				platforms = new TestPlatform[] { TestPlatform.iOS_TodayExtension64 };
+				ignored = new [] { false };
 				break;
 			default:
 				throw new NotImplementedException ();
 			}
 
 			for (int i = 0; i < targets.Length; i++)
-				runtasks.Add (new RunSimulatorTask (buildTask, Simulators.SelectDevices (targets [i], SimulatorLoadLog)) { Platform = platforms [i], Ignored = buildTask.Ignored });
+				runtasks.Add (new RunSimulatorTask (buildTask, Simulators.SelectDevices (targets [i], SimulatorLoadLog)) { Platform = platforms [i], Ignored = ignored[i] || buildTask.Ignored });
 
 			return runtasks;
 		}

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
@@ -451,7 +451,7 @@ namespace xharness
 				if (!IsIncluded (project))
 					ignored = true;
 
-				if (!project.SkipiOSVariation) {
+				if (!project.SkipiOSVariation && !Harness.SkipiOSDeviceVariations) {
 					var build64 = new XBuildTask {
 						Jenkins = this,
 						ProjectConfiguration = "Debug64",
@@ -484,7 +484,7 @@ namespace xharness
 					rv.Add (new RunDeviceTask (buildToday, Devices.Connected64BitIOS.Where (d => d.IsSupported (project))) { Ignored = ignored || !IncludeiOSExtensions, BuildOnly = project.BuildOnly || ForceExtensionBuildOnly });
 				}
 
-				if (!project.SkiptvOSVariation) {
+				if (!project.SkiptvOSVariation && !Harness.SkipTvOSDeviceVariations) {
 					var tvOSProject = project.AsTvOSProject ();
 					var buildTV = new XBuildTask {
 						Jenkins = this,
@@ -497,7 +497,7 @@ namespace xharness
 					rv.Add (new RunDeviceTask (buildTV, Devices.ConnectedTV.Where (d => d.IsSupported (project))) { Ignored = ignored || !IncludetvOS, BuildOnly = project.BuildOnly });
 				}
 
-				if (!project.SkipwatchOSVariation) {
+				if (!project.SkipwatchOSVariation && !Harness.SkipWatchOSDeviceVariations) {
 					var watchOSProject = project.AsWatchOSProject ();
 					var buildWatch = new XBuildTask {
 						Jenkins = this,

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -467,7 +467,7 @@ namespace xharness
 				if (!IsIncluded (project))
 					ignored = true;
 
-				if (!project.SkipiOSVariation && !Harness.SkipiOSDeviceVariations) {
+				if (!project.SkipiOSVariation) {
 					var build64 = new XBuildTask {
 						Jenkins = this,
 						ProjectConfiguration = "Debug64",
@@ -500,7 +500,7 @@ namespace xharness
 					rv.Add (new RunDeviceTask (buildToday, Devices.Connected64BitIOS.Where (d => d.IsSupported (project))) { Ignored = ignored || !IncludeiOSExtensions, BuildOnly = project.BuildOnly || ForceExtensionBuildOnly });
 				}
 
-				if (!project.SkiptvOSVariation && !Harness.SkipTvOSDeviceVariations) {
+				if (!project.SkiptvOSVariation) {
 					var tvOSProject = project.AsTvOSProject ();
 					var buildTV = new XBuildTask {
 						Jenkins = this,
@@ -513,7 +513,7 @@ namespace xharness
 					rv.Add (new RunDeviceTask (buildTV, Devices.ConnectedTV.Where (d => d.IsSupported (project))) { Ignored = ignored || !IncludetvOS, BuildOnly = project.BuildOnly });
 				}
 
-				if (!project.SkipwatchOSVariation && !Harness.SkipWatchOSDeviceVariations) {
+				if (!project.SkipwatchOSVariation) {
 					var watchOSProject = project.AsWatchOSProject ();
 					var buildWatch = new XBuildTask {
 						Jenkins = this,


### PR DESCRIPTION
If a bot does not have the required devices, such as a tvOS, we do not
want to generate the device variations for that platform. This allows to
ensure that we do not have Skipped tests for devices we do know that are
not present.