### PR TITLE
[UIKit] Don't crash if UIGestureRecognizer.Dispose is called multiple times. Fixes #5899.

### DIFF
--- a/src/UIKit/UIGestureRecognizer.cs
+++ b/src/UIKit/UIGestureRecognizer.cs
@@ -43,6 +43,9 @@ namespace UIKit {
 			var savedHandle = Handle;
 			recognizers = null;
 			
+			if (copyOfRecognizers == null)
+				return;
+
 			DangerousRetain (savedHandle);
 			NSRunLoop.Main.BeginInvokeOnMainThread (() => {
 				foreach (var kv in copyOfRecognizers)

--- a/tests/monotouch-test/UIKit/GestureRecognizerTest.cs
+++ b/tests/monotouch-test/UIKit/GestureRecognizerTest.cs
@@ -28,6 +28,14 @@ namespace MonoTouchFixtures.UIKit {
 	public class GestureRecognizerTest {
 
 		[Test]
+		public void DoubleDispose ()
+		{
+			using (var gr = new UIGestureRecognizer ()) {
+				gr.Dispose ();
+			}
+		}
+
+		[Test]
 		public void Null ()
 		{
 			using (var gr = new UIGestureRecognizer (Null)) {


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/5899.