### PR TITLE
[registrar] Add token type validation.

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -4619,6 +4619,13 @@ namespace Registrar {
 		uint CreateFullTokenReference (MemberReference member)
 		{
 			var rv = (full_token_reference_count++ << 1) + 1;
+			switch (member.MetadataToken.TokenType) {
+			case TokenType.TypeDef:
+			case TokenType.Method:
+				break; // OK
+			default:
+				throw ErrorHelper.CreateError (99, $"Internal error: unsupported tokentype ({member.MetadataToken.TokenType}) for {member.FullName}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).");
+			}
 			full_token_references.AppendFormat ("\t\t{{ /* #{3} = 0x{4:X} */ \"{0}\", 0x{1:X}, 0x{2:X} }},\n", GetAssemblyName (member.Module.Assembly), member.Module.MetadataToken.ToUInt32 (), member.MetadataToken.ToUInt32 (), full_token_reference_count, rv);
 			return rv;
 		}


### PR DESCRIPTION
This should never happen, but an MT0099 at build time is much better than a
runtime exception.