### PR TITLE
[tests] Improve F# test's assert message.

### DIFF
--- a/tests/fsharp/FSharpTests.fs
+++ b/tests/fsharp/FSharpTests.fs
@@ -30,5 +30,4 @@ type FSharpTest () =
         let e = 5555
 
         let pr = sprintf "%d %d %d %d %d" a b c d e
-        let eq = String.Equals (pr, "1111 2222 3333 4444 5555")
-        Assert.IsTrue eq
+        Assert.AreEqual ("1111 2222 3333 4444 5555", pr)


### PR DESCRIPTION
Before in case of failure:

    [FAIL] FSharpTest.SprintfTest :   Expected: True
        But was:  False
    	  at fsharp.FSharpTest.SprintfTest () [0x00052] in /work/maccore/mono-master/xamarin-macios/tests/fsharp/FSharpTests.fs:34
    	  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)

After in case of failure:

    [FAIL] FSharpTest.SprintfTest :   String lengths are both 24. Strings differ at index 10.
      Expected: "1111 2222 3333 4444 5555"
      But was:  "1111 2222 4444 3333 5555"
      ---------------------^
    at fsharp.FSharpTest.SprintfTest () [0x00044] in /work/maccore/mono-master/xamarin-macios/tests/fsharp/FSharpTests.fs:33
    at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)