### PR TITLE
[runtime] Rename CallState to XamarinCallState to keep the public namespace cleaner.

### DIFF
--- a/runtime/trampolines-i386-asm.s
+++ b/runtime/trampolines-i386-asm.s
@@ -29,11 +29,11 @@ _xamarin_i386_common_trampoline:
 	movl	%esp, %ebp
 .cfi_def_cfa_register %ebp
 
-	pushl	%esi # we use %esi as a pointer to our CallState struct. It's a preserved register, so we need to save it.
+	pushl	%esi # we use %esi as a pointer to our XamarinCallState struct. It's a preserved register, so we need to save it.
 
-	subl	$0x24,	%esp	# allocate 32 bytes from the stack. 24 bytes for our CallState struct + 4 bytes for the parameters to xamarin_arch_trampoline + alignment.
+	subl	$0x24,	%esp	# allocate 32 bytes from the stack. 24 bytes for our XamarinCallState struct + 4 bytes for the parameters to xamarin_arch_trampoline + alignment.
 
-	# %esi points our CallState structure (on the stack)
+	# %esi points our XamarinCallState structure (on the stack)
 	movl	%esp,	%esi
 	addl	$0x4,	%esi
 
@@ -44,7 +44,7 @@ _xamarin_i386_common_trampoline:
 	addl	$0x4,	   %ecx
 	movl	%ecx,	12(%esi) # esp (at entry to this function)
 
-	movl	%esi,	  (%esp) # 1st argument to xamarin_arch_trampoline, a pointer to the CallState structure.
+	movl	%esi,	  (%esp) # 1st argument to xamarin_arch_trampoline, a pointer to the XamarinCallState structure.
 	call	_xamarin_arch_trampoline
 
 	# get return value(s)

--- a/runtime/trampolines-i386.h
+++ b/runtime/trampolines-i386.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-struct CallState {
+struct XamarinCallState {
 	uint32_t type; // the type of trampoline
 	uint32_t eax; // undefined on entry, return value upon exit
 	uint32_t edx; // undefined on entry, return value upon exit
@@ -20,12 +20,12 @@ struct CallState {
 };
 
 struct ParamIterator {
-	struct CallState *state;
+	struct XamarinCallState *state;
 	uint8_t *stack_next;
 	uint8_t *stret;
 };
 
-void xamarin_arch_trampoline (struct CallState *state);
+void xamarin_arch_trampoline (struct XamarinCallState *state);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/runtime/trampolines-i386.m
+++ b/runtime/trampolines-i386.m
@@ -32,7 +32,7 @@ create_mt_exception (char *msg)
 
 #ifdef TRACE
 static void
-dump_state (struct CallState *state)
+dump_state (struct XamarinCallState *state)
 {
 	fprintf (stderr, "type: %u is_stret: %i self: %p SEL: %s eax: 0x%x edx: 0x%x esp: 0x%x -- double_ret: %f float_ret: %f\n",
 		state->type, state->is_stret (), state->self (), sel_getName (state->sel ()), state->eax, state->edx, state->esp,
@@ -181,7 +181,7 @@ marshal_return_value (void *context, const char *type, size_t size, void *vvalue
 }
 
 void
-xamarin_arch_trampoline (struct CallState *state)
+xamarin_arch_trampoline (struct XamarinCallState *state)
 {
 	dump_state (state);
 	struct ParamIterator iter;

--- a/runtime/trampolines-varargs.h
+++ b/runtime/trampolines-varargs.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-struct CallState {
+struct XamarinCallState {
 	enum TrampolineType type; // the type of trampoline
 	id self;
 	SEL sel;
@@ -22,7 +22,7 @@ struct CallState {
 };
 
 struct ParamIterator {
-	struct CallState *state;
+	struct XamarinCallState *state;
 	va_list ap;
 };
 

--- a/runtime/trampolines-varargs.m
+++ b/runtime/trampolines-varargs.m
@@ -35,7 +35,7 @@ create_mt_exception (char *msg)
 
 #ifdef TRACE
 static void
-dump_state (struct CallState *state)
+dump_state (struct XamarinCallState *state)
 {
 	PRINT ("type: %u is_stret: %i self: %p SEL: %s -- double_ret: %f float_ret: %f longlong_ret: %llu ptr_ret: %p\n",
 		state->type, (state->type & Tramp_Stret) == Tramp_Stret, state->self, sel_getName (state->sel),
@@ -49,7 +49,7 @@ static void
 param_iter_next (enum IteratorAction action, void *context, const char *type, size_t size, void *target, guint32 *exception_gchandle)
 {
 	struct ParamIterator *it = (struct ParamIterator *) context;
-	struct CallState *state = it->state;
+	struct XamarinCallState *state = it->state;
 	
 	if (action == IteratorStart) {
 		va_copy (it->ap, state->ap);
@@ -93,7 +93,7 @@ marshal_return_value (void *context, const char *type, size_t size, void *vvalue
 {
 	MonoObject *value = (MonoObject *) vvalue;
 	struct ParamIterator *it = (struct ParamIterator *) context;
-	struct CallState *state = it->state;
+	struct XamarinCallState *state = it->state;
 
 	LOGZ (" marshalling return value %p as %s\n", value, type);
 
@@ -173,7 +173,7 @@ marshal_return_value (void *context, const char *type, size_t size, void *vvalue
 }
 
 static void
-xamarin_varargs_trampoline (struct CallState *state)
+xamarin_varargs_trampoline (struct XamarinCallState *state)
 {
 	dump_state (state);
 	struct ParamIterator iter;
@@ -185,7 +185,7 @@ xamarin_varargs_trampoline (struct CallState *state)
 double
 xamarin_fpret_double_trampoline (id self, SEL sel, ...)
 {
-	struct CallState state;
+	struct XamarinCallState state;
 	state.type = Tramp_FpretDouble;
 	state.self = self;
 	state.sel = sel;
@@ -199,7 +199,7 @@ xamarin_fpret_double_trampoline (id self, SEL sel, ...)
 float
 xamarin_fpret_single_trampoline (id self, SEL sel, ...)
 {
-	struct CallState state;
+	struct XamarinCallState state;
 	state.type = Tramp_FpretSingle;
 	state.self = self;
 	state.sel = sel;
@@ -213,7 +213,7 @@ xamarin_fpret_single_trampoline (id self, SEL sel, ...)
 long long
 xamarin_longret_trampoline (id self, SEL sel, ...)
 {
-	struct CallState state;
+	struct XamarinCallState state;
 	state.type = Tramp_LongRet;
 	state.self = self;
 	state.sel = sel;
@@ -227,7 +227,7 @@ xamarin_longret_trampoline (id self, SEL sel, ...)
 void
 xamarin_stret_trampoline (void *buffer, id self, SEL sel, ...)
 {
-	struct CallState state;
+	struct XamarinCallState state;
 	state.type = Tramp_Stret;
 	state.self = self;
 	state.sel = sel;
@@ -240,7 +240,7 @@ xamarin_stret_trampoline (void *buffer, id self, SEL sel, ...)
 void *
 xamarin_trampoline (id self, SEL sel, ...)
 {
-	struct CallState state;
+	struct XamarinCallState state;
 	state.type = Tramp_Default;
 	state.self = self;
 	state.sel = sel;
@@ -254,7 +254,7 @@ xamarin_trampoline (id self, SEL sel, ...)
 void *
 xamarin_ctor_trampoline (id self, SEL sel, ...)
 {
-	struct CallState state;
+	struct XamarinCallState state;
 	state.type = Tramp_Ctor;
 	state.self = self;
 	state.sel = sel;
@@ -268,7 +268,7 @@ xamarin_ctor_trampoline (id self, SEL sel, ...)
 void *
 xamarin_static_trampoline (id self, SEL sel, ...)
 {
-	struct CallState state;
+	struct XamarinCallState state;
 	state.type = Tramp_Static;
 	state.self = self;
 	state.sel = sel;
@@ -282,7 +282,7 @@ xamarin_static_trampoline (id self, SEL sel, ...)
 float
 xamarin_static_fpret_single_trampoline (id self, SEL sel, ...)
 {
-	struct CallState state;
+	struct XamarinCallState state;
 	state.type = Tramp_StaticFpretSingle;
 	state.self = self;
 	state.sel = sel;
@@ -296,7 +296,7 @@ xamarin_static_fpret_single_trampoline (id self, SEL sel, ...)
 double
 xamarin_static_fpret_double_trampoline (id self, SEL sel, ...)
 {
-	struct CallState state;
+	struct XamarinCallState state;
 	state.type = Tramp_StaticFpretDouble;
 	state.self = self;
 	state.sel = sel;
@@ -310,7 +310,7 @@ xamarin_static_fpret_double_trampoline (id self, SEL sel, ...)
 long long
 xamarin_static_longret_trampoline (id self, SEL sel, ...)
 {
-	struct CallState state;
+	struct XamarinCallState state;
 	state.type = Tramp_StaticLongRet;
 	state.self = self;
 	state.sel = sel;
@@ -324,7 +324,7 @@ xamarin_static_longret_trampoline (id self, SEL sel, ...)
 void
 xamarin_static_stret_trampoline (void *buffer, id self, SEL sel, ...)
 {
-	CallState state;
+	XamarinCallState state;
 	state.type = Tramp_StaticStret;
 	state.self = self;
 	state.sel = sel;

--- a/runtime/trampolines-x86_64.h
+++ b/runtime/trampolines-x86_64.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-struct CallState {
+struct XamarinCallState {
 	uint64_t type;
 	uint64_t rdi;                        // 1st argument
 	union {
@@ -32,13 +32,13 @@ struct CallState {
 };
 
 struct ParamIterator {
-	struct CallState *state;
+	struct XamarinCallState *state;
 	int byte_count;
 	int float_count;
 	uint8_t *stack_next;
 };
 
-void xamarin_arch_trampoline (struct CallState *state);
+void xamarin_arch_trampoline (struct XamarinCallState *state);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/runtime/trampolines-x86_64.m
+++ b/runtime/trampolines-x86_64.m
@@ -77,7 +77,7 @@ get_primitive_size (char type)
 
 #ifdef TRACE
 static void
-dump_state (struct CallState *state)
+dump_state (struct XamarinCallState *state)
 {
 	fprintf (stderr, "type: %llu is_stret: %i self: %p SEL: %s rdi: 0x%llx rsi: 0x%llx rdx: 0x%llx rcx: 0x%llx r8: 0x%llx r9: 0x%llx rbp: 0x%llx -- xmm0: %Lf xmm1: %Lf xmm2: %Lf xmm3: %Lf xmm4: %Lf xmm5: %Lf xmm6: %Lf xmm7: %Lf\n",
 		state->type, state->is_stret (), state->self (), sel_getName (state->sel ()), state->rdi, state->rsi, state->rdx, state->rcx, state->r8, state->r9, state->rbp,
@@ -532,7 +532,7 @@ marshal_return_value (void *context, const char *type, size_t size, void *vvalue
 }
 
 void
-xamarin_arch_trampoline (struct CallState *state)
+xamarin_arch_trampoline (struct XamarinCallState *state)
 {
 	// COOP: called from ObjC, and does not access managed memory.
 	MONO_ASSERT_GC_SAFE;

--- a/tests/mtouch/MiscTests.cs
+++ b/tests/mtouch/MiscTests.cs
@@ -98,6 +98,7 @@ namespace Xamarin.Tests
 				"_OBJC_CLASS_$_Xamarin",
 				"_OBJC_IVAR_$_Xamarin",
 				"__ZN13XamarinObject",
+				"__ZN16XamarinCallState",
 				".objc_class_name_Xamarin", // 32-bit macOS naming scheme
 				".objc_category_name_NSObject_NonXamarinObject", // 32-bit macOS naming scheme
 				"_main",


### PR DESCRIPTION
Also ignore the corresponding public symbols in the PublicSymbols test.

This was introduced in 464882d14a83a13f9fd6a3d9df2ca4d844933e36 (changes to
the CallState struct made the compiler create public symbols).

Fixes these test failures:

    1) Failed : Xamarin.Tests.Misc.PublicSymbols(iOS)
      Failed libraries
      Expected: <empty>
      But was:  "/work/maccore/master/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/MonoTouch.iphoneos.sdk/usr/lib/libxamarin-debug.a:
    	__ZN9CallState3selEv
    	__ZN9CallState4selfEv
    	__ZN9CallState8is_stretEv
    	__ZN9CallState3selEv
    	__ZN9CallState4selfEv
    	__ZN9CallState8is_stretEv
    /work/maccore/master/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/MonoTouch.iphonesimulator.sdk/usr/lib/libxamarin-debug.a:
    	__ZN9CallState3selEv
    	__ZN9CallState4selfEv
    	__ZN9CallState8is_stretEv
    	__ZN9CallState3selEv
    	__ZN9CallState4selfEv
    	__ZN9CallState8is_stretEv
    "
      at Xamarin.Tests.Misc.PublicSymbols (Xamarin.Tests.Profile profile) [0x00259] in /work/maccore/master/xamarin-macios/tests/mtouch/MiscTests.cs:196

    2) Failed : Xamarin.Tests.Misc.PublicSymbols(tvOS)
      Failed libraries
      Expected: <empty>
      But was:  "/work/maccore/master/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/Xamarin.AppleTVOS.sdk/usr/lib/libxamarin-debug.a:
    	__ZN9CallState3selEv
    	__ZN9CallState4selfEv
    	__ZN9CallState8is_stretEv
    /work/maccore/master/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/Xamarin.AppleTVSimulator.sdk/usr/lib/libxamarin-debug.a:
    	__ZN9CallState3selEv
    	__ZN9CallState4selfEv
    	__ZN9CallState8is_stretEv
    "
      at Xamarin.Tests.Misc.PublicSymbols (Xamarin.Tests.Profile profile) [0x00259] in /work/maccore/master/xamarin-macios/tests/mtouch/MiscTests.cs:196

    3) Failed : Xamarin.Tests.Misc.PublicSymbols(watchOS)
      Failed libraries
      Expected: <empty>
      But was:  "/work/maccore/master/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/Xamarin.WatchOS.sdk/usr/lib/libxamarin-debug.a:
    	__ZN9CallState3selEv
    	__ZN9CallState4selfEv
    	__ZN9CallState8is_stretEv
    /work/maccore/master/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/SDKs/Xamarin.WatchSimulator.sdk/usr/lib/libxamarin-debug.a:
    	__ZN9CallState3selEv
    	__ZN9CallState4selfEv
    	__ZN9CallState8is_stretEv
    "
      at Xamarin.Tests.Misc.PublicSymbols (Xamarin.Tests.Profile profile) [0x00259] in /work/maccore/master/xamarin-macios/tests/mtouch/MiscTests.cs:196

    4) Failed : Xamarin.Tests.Misc.PublicSymbols(macOSMobile)
      Failed libraries
      Expected: <empty>
      But was:  "/work/maccore/master/xamarin-macios/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/libxammac-debug.a:
    	__ZN9CallState3selEv
    	__ZN9CallState4selfEv
    	__ZN9CallState8is_stretEv
    	__ZN9CallState3selEv
    	__ZN9CallState4selfEv
    	__ZN9CallState8is_stretEv
    /work/maccore/master/xamarin-macios/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/libxammac-system-debug.a:
    	__ZN9CallState3selEv
    	__ZN9CallState4selfEv
    	__ZN9CallState8is_stretEv
    	__ZN9CallState3selEv
    	__ZN9CallState4selfEv
    	__ZN9CallState8is_stretEv
    /work/maccore/master/xamarin-macios/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/libxammac-system.a:
    	__ZN9CallState3selEv
    	__ZN9CallState4selfEv
    	__ZN9CallState8is_stretEv
    	__ZN9CallState3selEv
    	__ZN9CallState4selfEv
    	__ZN9CallState8is_stretEv
    /work/maccore/master/xamarin-macios/_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/libxammac.a:
    	__ZN9CallState3selEv
    	__ZN9CallState4selfEv
    	__ZN9CallState8is_stretEv
    	__ZN9CallState3selEv
    	__ZN9CallState4selfEv
    	__ZN9CallState8is_stretEv
    "
      at Xamarin.Tests.Misc.PublicSymbols (Xamarin.Tests.Profile profile) [0x00259] in /work/maccore/master/xamarin-macios/tests/mtouch/MiscTests.cs:196