### PR TITLE
[MetalPerformanceShaders] MPSImageNormalizedHistogram isn't available in iOS 11 as the headers claim.

### DIFF
--- a/src/metalperformanceshaders.cs
+++ b/src/metalperformanceshaders.cs
@@ -6027,7 +6027,7 @@ namespace MetalPerformanceShaders {
 		void EncodeReconstruction (IMTLCommandBuffer commandBuffer, IMTLTexture guidanceTexture, IMTLTexture coefficientsTexture, IMTLTexture destinationTexture);
 	}
 
-	[TV (11,0), iOS (11,0), Mac (10,13, onlyOn64: true)]
+	[TV (12,0), iOS (12,0), Mac (10,14, onlyOn64: true)]
 	[BaseType (typeof (MPSKernel))]
 	[DisableDefaultCtor]
 	interface MPSImageNormalizedHistogram {

--- a/tests/monotouch-test/MetalPerformanceShaders/MPSImageNormalizedHistogramTests.cs
+++ b/tests/monotouch-test/MetalPerformanceShaders/MPSImageNormalizedHistogramTests.cs
@@ -27,7 +27,7 @@ namespace MonoTouchFixtures.MetalPerformanceShaders {
 		public void Metal ()
 		{
 			TestRuntime.AssertDevice ();
-			TestRuntime.AssertXcodeVersion (9, 0);
+			TestRuntime.AssertXcodeVersion (10, 0);
 
 			device = MTLDevice.SystemDefault;
 			// some older hardware won't have a default


### PR DESCRIPTION
A simple test revels the truth:

    dyld: Symbol not found: _OBJC_CLASS_$_MPSImageNormalizedHistogram
      Referenced from: /var/containers/Bundle/Application/4DA44899-5F1D-4BF9-9C2E-B26982AE89F1/uistestappobjc.app/uistestappobjc
      Expected in: /System/Library/Frameworks/MetalPerformanceShaders.framework/MetalPerformanceShaders
     in /var/containers/Bundle/Application/4DA44899-5F1D-4BF9-9C2E-B26982AE89F1/uistestappobjc.app/uistestappobjc

This fixes this test failure on iOS 11:

    [FAIL] MPSImageNormalizedHistogramTests.Constructors : ObjCRuntime.RuntimeException : Wrapper type 'MetalPerformanceShaders.MPSImageNormalizedHistogram' is missing its native ObjectiveC class 'MPSImageNormalizedHistogram'.