### PR TITLE
[provisioning] Make sure nothing can block Xcode mv

### DIFF
--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -345,6 +345,7 @@ function install_specific_xcode () {
 		cd $PROVISION_DOWNLOAD_DIR
 		# make sure there's nothing interfering
 		rm -Rf *.app
+		rm -Rf $XCODE_ROOT
 		# extract
 		/System/Library/CoreServices/Applications/Archive\ Utility.app/Contents/MacOS/Archive\ Utility "$XCODE_DMG"
 		log "Installing Xcode $XCODE_VERSION to $XCODE_ROOT..."


### PR DESCRIPTION
The device tests would often fail on bots with the following:

```
Extracting /tmp/x-provisioning/Xcode_10.2.xip...
Archive Utility[4964:12156830] Persistent UI failed to open file file:///Users/xamarinqa/Library/Saved%20Application%20State/com.apple.archiveutility.savedState/window_2.data: No such file or directory (2)
Installing Xcode 10.2 to /Applications/Xcode102.app...
mv: rename Xcode.app to /Applications/Xcode102.app: Not a directory
```

This is because we might have an Xcode symlink already at the destination location. The simple fix is to always make sure the destination is clean before moving the extracted Xcode to it.