### PR TITLE
[appkit] Fix NSTabView.Delegate (missing/removed `virtual`)

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -17458,7 +17458,7 @@ namespace AppKit {
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
 		NSObject WeakDelegate { get; set; }
 
-		[Wrap ("WeakDelegate")]
+		[Wrap ("WeakDelegate", IsVirtual = true)]
 		[Protocolize]
 		NSTabViewDelegate Delegate { get; set; }
 


### PR DESCRIPTION
This was removed accidentally while fixing the generator
ref: https://github.com/xamarin/xamarin-macios/commit/35842ffc5e0d5b47d8e58410e1800f2996816846