### PR TITLE
[mmp] Fix error for `mmp --version`

### DIFF
--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -374,6 +374,9 @@ namespace Xamarin.Bundler {
 					aotOptions = new AOTOptions (forceAotVariable);
 			}
 
+			if (!targetFramework.HasValue)
+				targetFramework = TargetFramework.Default;
+
 			App.RuntimeOptions = RuntimeOptions.Create (App, http_message_provider, tls_provider);
 
 			ErrorHelper.Verbosity = verbose;
@@ -388,9 +391,6 @@ namespace Xamarin.Bundler {
 			}
 
 			bool force45From40UnifiedSystemFull = false;
-
-			if (!targetFramework.HasValue)
-				targetFramework = TargetFramework.Default;
 
 			// At least once instance of a TargetFramework of Xamarin.Mac,v2.0,(null) was found already. Assume any v2.0 implies a desire for Modern.
 			if (TargetFramework == TargetFramework.Xamarin_Mac_2_0_Mobile || TargetFramework.Version == TargetFramework.Xamarin_Mac_2_0_Mobile.Version) {


### PR DESCRIPTION
Some code now need to be initialized a few lines earlier... otherwise we
end up with an error like:

```
/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/bin/mmp --version
error MM0000: Unexpected error - Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
System.InvalidOperationException: Nullable object must have a value.
  at System.Nullable`1[T].get_Value () [0x0000d] in /Users/builder/jenkins/workspace/build-package-osx-mono/2019-02/external/bockbuild/builds/mono-x64/external/corefx/src/Common/src/CoreLib/System/Nullable.cs:48
  at Xamarin.Bundler.Driver.get_TargetFramework () [0x00001] in /Users/poupou/git/xamarin/xamarin-macios/tools/common/Driver.cs:198
  at Xamarin.Bundler.Application.get_Platform () [0x00001] in /Users/poupou/git/xamarin/xamarin-macios/tools/common/Application.cs:62
  at Xamarin.Bundler.RuntimeOptions.ParseHttpMessageHandler (Xamarin.Bundler.Application app, System.String value) [0x0002f] in /Users/poupou/git/xamarin/xamarin-macios/src/ObjCRuntime/RuntimeOptions.cs:43
  at Xamarin.Bundler.RuntimeOptions.Create (Xamarin.Bundler.Application app, System.String http_message_handler, System.String tls_provider) [0x00007] in /Users/poupou/git/xamarin/xamarin-macios/src/ObjCRuntime/RuntimeOptions.cs:34
  at Xamarin.Bundler.Driver.Main2 (System.String[] args) [0x00a78] in /Users/poupou/git/xamarin/xamarin-macios/tools/mmp/driver.cs:377
  at Xamarin.Bundler.Driver.Main (System.String[] args) [0x00015] in /Users/poupou/git/xamarin/xamarin-macios/tools/mmp/driver.cs:211
```