### PR TITLE
[builds] Fix race condition when building device runtimes.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -1109,7 +1109,7 @@ $(2): build-$(2)
 build:: build-$(2)
 clean-local:: clean-$(2)
 
-.stamp-build-$(2): $(MONO_PATH)/configure $(SDK_CONFIG) $(MONO_DEPENDENCIES)
+.stamp-build-$(2): .stamp-build-cross64 .stamp-build-cross32 $(MONO_PATH)/configure $(SDK_CONFIG) $(MONO_DEPENDENCIES)
 	$(MAKE) -C $(SDK_BUILDDIR) package-ios-$(3) $(SDK_ARGS)
 	$(Q) mkdir -p $(BUILD_DESTDIR)/$(2)
 	$(Q) $(CP) -r $(SDK_DESTDIR)/ios-$(3)-release/* $(BUILD_DESTDIR)/$(2)
@@ -1311,7 +1311,7 @@ watchos:: targetwatch
 
 .PHONY: targetwatch
 
-.stamp-build-targetwatch: $(MONO_PATH)/configure $(SDK_CONFIG) $(MONO_DEPENDENCIES)
+.stamp-build-targetwatch: .stamp-build-crosswatch $(MONO_PATH)/configure $(SDK_CONFIG) $(MONO_DEPENDENCIES)
 	$(MAKE) -C $(SDK_BUILDDIR) package-ios-targetwatch $(SDK_ARGS)
 	$(Q) mkdir -p $(BUILD_DESTDIR)/targetwatch
 	$(Q) $(CP) -r $(SDK_DESTDIR)/ios-targetwatch-release/* $(BUILD_DESTDIR)/targetwatch
@@ -1450,7 +1450,7 @@ tvos:: targettv
 
 .PHONY: targettv
 
-.stamp-build-targettv: $(MONO_PATH)/configure $(SDK_CONFIG) $(MONO_DEPENDENCIES)
+.stamp-build-targettv: .stamp-build-cross64 $(MONO_PATH)/configure $(SDK_CONFIG) $(MONO_DEPENDENCIES)
 	$(MAKE) -C $(SDK_BUILDDIR) package-ios-targettv $(SDK_ARGS)
 	$(Q) mkdir -p $(BUILD_DESTDIR)/targettv
 	$(Q) $(CP) -r $(SDK_DESTDIR)/ios-targettv-release/* $(BUILD_DESTDIR)/targettv

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -106,6 +106,11 @@ else
 		echo "The sample tests won't be triggered from public jenkins even if the 'run-sample-tests' label is set (build on internal Jenkins instead)."
 		printf "ℹ️ The sample tests won't be triggered from public jenkins even if the 'run-sample-tests' label is set (build on internal Jenkins instead)." >> "$WORKSPACE/jenkins/pr-comments.md"
 	fi
+
+	if ./jenkins/fetch-pr-labels.sh --check=disable-packaged-mono; then
+		echo "Building mono from source because the label 'disable-packaged-mono' was found."
+		CONFIGURE_FLAGS="$CONFIGURE_FLAGS --disable-packaged-mono"
+	fi
 fi
 
 


### PR DESCRIPTION
We need to complete the corresponding cross builds first, because the cross
builds will also try to configure device builds, so we might end up with two
make processes trying to configure the same target simulatenously.

Also add support for building mono from source in pull requests by using
labels.