### PR TITLE
Fix/improve marshalling of out/ref parameters, arrays, Classes and Selectors. Fixes #5171.

### DIFF
--- a/docs/website/generator-errors.md
+++ b/docs/website/generator-errors.md
@@ -39,6 +39,12 @@ An invalid target framework was passed using the --target-framework argument. Pl
 
 This usually indicates a bug in Xamarin.iOS/Xamarin.Mac; please [file a bug report](https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
 
+### <a name='BI0099'/>BI0099: Internal error *. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).
+
+This error message is reported when an internal consistency check fails.
+
+This usually indicates a bug in binding generator; please file a new issue on [github](https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+
 # BI1xxx: code generation
 
 <!-- 1xxx: code generation -->
@@ -177,6 +183,8 @@ This usually indicates a bug in Xamarin.iOS/Xamarin.Mac; please [file a bug repo
 ### <a name='BI1062'/>BI1062: The member '*' contains ref/out parameters and must not be decorated with [Async].
 
 ### <a name='BI1063'/>BI1063: The 'WrapAttribute' can only be used at the property or at getter/setter level at a given time. Property: '*'.
+
+### <a name='BI1064'/>BI1064: Unsupported ref/out parameter type '{type}' for the parameter '{name}' in {method}.
 
 ### <a name='BI1065'/>BI1065: Unsupported parameter type '{type}' for the parameter '{name}' in {method}.
 

--- a/docs/website/generator-errors.md
+++ b/docs/website/generator-errors.md
@@ -43,7 +43,7 @@ This usually indicates a bug in Xamarin.iOS/Xamarin.Mac; please [file a bug repo
 
 This error message is reported when an internal consistency check fails.
 
-This usually indicates a bug in binding generator; please file a new issue on [github](https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
+This usually indicates a bug in the binding generator; please file a new issue on [github](https://github.com/xamarin/xamarin-macios/issues/new) with a test case.
 
 # BI1xxx: code generation
 

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -776,6 +776,16 @@ If the managed binding is from a third-party vendor, please contact the vendor.
 
 If the managed binding is shipped with Xamarin.Mac, please [submit an issue](https://github.com/xamarin/xamarin-macios/wiki/Submitting-Bugs-&-Suggestions).
 
+<a name="MM8032" />
+
+### MM8032: Unable to convert from a managed array of {type} to an NSArray.
+
+This usually indicates a bug in Objective-C binding code.
+
+If the managed binding is from a third-party vendor, please contact the vendor.
+
+If the managed binding is shipped with Xamarin.Mac, please [submit an issue](https://github.com/xamarin/xamarin-macios/wiki/Submitting-Bugs-&-Suggestions).
+
 <a name="MM8033" />
 
 ### MM8033: Unable to marshal the return value of type {type} to Objective-C.

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -797,3 +797,9 @@ This exception will have an inner exception which gives the reason for the failu
 ### MM8035: Failed to get the 'this' instance in a method call to {method}.
 
 This exception will have an inner exception which gives the reason for the failure.
+
+<a name="MM8036" />
+
+### MM8036: Failed to marshal the value at index {index}.
+
+This exception will have an inner exception which gives the reason for the failure.

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -776,6 +776,15 @@ If the managed binding is from a third-party vendor, please contact the vendor.
 
 If the managed binding is shipped with Xamarin.Mac, please [submit an issue](https://github.com/xamarin/xamarin-macios/wiki/Submitting-Bugs-&-Suggestions).
 
+<a name="MM8031" />
+
+### MM8031: Unable to convert from an NSArray to a managed array of {type}.
+This usually indicates a bug in Objective-C binding code.
+
+If the managed binding is from a third-party vendor, please contact the vendor.
+
+If the managed binding is shipped with Xamarin.Mac, please [submit an issue](https://github.com/xamarin/xamarin-macios/wiki/Submitting-Bugs-&-Suggestions).
+
 <a name="MM8032" />
 
 ### MM8032: Unable to convert from a managed array of {type} to an NSArray.

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -3565,6 +3565,16 @@ If the managed binding is from a third-party vendor, please contact the vendor.
 
 If the managed binding is shipped with Xamarin.iOS, please [submit an issue](https://github.com/xamarin/xamarin-macios/wiki/Submitting-Bugs-&-Suggestions).
 
+<a name="MT8032" />
+
+### MT8032: Unable to convert from a managed array of {type} to an NSArray.
+
+This usually indicates a bug in Objective-C binding code.
+
+If the managed binding is from a third-party vendor, please contact the vendor.
+
+If the managed binding is shipped with Xamarin.iOS, please [submit an issue](https://github.com/xamarin/xamarin-macios/wiki/Submitting-Bugs-&-Suggestions).
+
 <a name="MT8033" />
 
 ### MT8033: Unable to marshal the return value of type {type} to Objective-C.

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -3586,3 +3586,9 @@ This exception will have an inner exception which gives the reason for the failu
 ### MT8035: Failed to get the 'this' instance in a method call to {method}.
 
 This exception will have an inner exception which gives the reason for the failure.
+
+<a name="MT8036" />
+
+### MT8036: Failed to convert the value at index {index} from {type} to {type}.
+
+This exception will have an inner exception which gives the reason for the failure.

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -3565,6 +3565,15 @@ If the managed binding is from a third-party vendor, please contact the vendor.
 
 If the managed binding is shipped with Xamarin.iOS, please [submit an issue](https://github.com/xamarin/xamarin-macios/wiki/Submitting-Bugs-&-Suggestions).
 
+<a name="MT8031" />
+
+### MT8031: Unable to convert from an NSArray to a managed array of {type}.
+This usually indicates a bug in Objective-C binding code.
+
+If the managed binding is from a third-party vendor, please contact the vendor.
+
+If the managed binding is shipped with Xamarin.iOS, please [submit an issue](https://github.com/xamarin/xamarin-macios/wiki/Submitting-Bugs-&-Suggestions).
+
 <a name="MT8032" />
 
 ### MT8032: Unable to convert from a managed array of {type} to an NSArray.

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -287,6 +287,13 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 							} else if (p_klass == mono_get_string_class ()) {
 								arg_frame [ofs] = xamarin_nsstring_to_string (domain, *(NSString **) arg);
 								LOGZ (" argument %i is a ref NSString %p: %p\n", i + 1, arg, arg_frame [ofs]);
+							} else if (xamarin_is_class_array (p_klass)) {
+								arg_frame [ofs] = xamarin_nsarray_to_managed_array (*(NSArray **) arg, p, p_klass, &exception_gchandle);
+								if (exception_gchandle != 0) {
+									exception_gchandle = xamarin_get_exception_for_parameter (8029, exception_gchandle, "Unable to marshal the byref parameter", sel, method, p, i, true);
+									goto exception_handling;
+								}
+								LOGZ (" argument %i is ref NSArray (%p => %p => %p)\n", i + 1, arg, *(NSArray **) arg, arg_frame [ofs]);
 							} else {
 								exception_gchandle = xamarin_get_exception_for_parameter (8029, 0, "Unable to marshal the byref parameter", sel, method, p, i, true);
 								goto exception_handling;
@@ -568,6 +575,9 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 
 				if (value == pvalue) {
 					// No need to copy back if the value didn't change
+					// For arrays this means that we won't copy back arrays if an element in the array changed (which can happen in managed code: the array pointer and size are immutable, but array elements can change).
+					// If the developer wants to change an array element, a new array must be created and assigned to the ref parameter.
+					// This is by design: otherwise we'll have to copy arrays even though they didn't change (because we can't know if they changed without comparing every element).
 					LOGZ (" not writing back managed object to argument at index %i (%p => %p) because it didn't change\n", i, arg, value);
 					continue;
 				} else if (value == NULL) {
@@ -585,6 +595,13 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 					if (exception_gchandle != 0)
 						goto exception_handling;
 					LOGZ (" writing back managed INativeObject %p to argument at index %i (%p)\n", value, i + 1, arg);
+				} else if (xamarin_is_class_array (p_klass)) {
+					obj = xamarin_managed_array_to_nsarray ((MonoArray *) value, p, p_klass, &exception_gchandle);
+					if (exception_gchandle != 0) {
+						exception_gchandle = xamarin_get_exception_for_parameter (8030, exception_gchandle, "Unable to marshal the out/ref parameter", sel, method, p, i, false);
+						goto exception_handling;
+					}
+					LOGZ (" writing back managed array %p to argument at index %i (%p)\n", value, i + 1, arg);
 				} else {
 					exception_gchandle = xamarin_get_exception_for_parameter (8030, 0, "Unable to marshal the out/ref parameter", sel, method, p, i, false);
 					goto exception_handling;

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -67,6 +67,18 @@ xamarin_string_to_nsstring (MonoString *obj, bool retain)
 	mono_free (str);
 	return arg;
 }
+
+MonoString *
+xamarin_nsstring_to_string (MonoDomain *domain, NSString *obj)
+{
+	if (obj == NULL)
+		return NULL;
+
+	if (domain == NULL)
+		domain = mono_domain_get ();
+	return mono_string_new (domain, [obj UTF8String]);
+}
+
 void
 xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_func iterator, marshal_return_value_func marshal_return_value, void *context)
 {
@@ -361,7 +373,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 					} else {
 						if (p_klass == mono_get_string_class ()) {
 							NSString *str = (NSString *) id_arg;
-							arg_ptrs [i + mofs] = mono_string_new (domain, [str UTF8String]);
+							arg_ptrs [i + mofs] = xamarin_nsstring_to_string (domain, str);
 							LOGZ (" argument %i is NSString: %p = %s\n", i + 1, id_arg, [str UTF8String]);
 						} else if (xamarin_is_class_array (p_klass)) {
 #if DEBUG
@@ -376,7 +388,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 							for (j = 0; j < [arr count]; j++) {
 								if (e_klass == mono_get_string_class ()) {
 									NSString *sv = (NSString *) [arr objectAtIndex: j];
-									mono_array_setref (m_arr, j, mono_string_new (domain, [sv UTF8String]));
+									mono_array_setref (m_arr, j, xamarin_nsstring_to_string (domain, sv));
 								} else {
 									MonoObject *obj;
 									id targ = [arr objectAtIndex: j];

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -204,7 +204,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 			if (exception_gchandle != 0)
 				goto exception_handling;
 			if (desc->bindas [i + 1].original_type != NULL) {
-				arg_ptrs [i + mofs] = xamarin_generate_conversion_to_managed ((id) arg, mono_reflection_type_get_type (desc->bindas [i + 1].original_type), p, method, &exception_gchandle, INVALID_TOKEN_REF, (void **) &free_list);
+				arg_ptrs [i + mofs] = xamarin_generate_conversion_to_managed ((id) arg, mono_reflection_type_get_type (desc->bindas [i + 1].original_type), p, method, &exception_gchandle, (void *) INVALID_TOKEN_REF, (void **) &free_list);
 				if (exception_gchandle != 0)
 					goto exception_handling;
 				ofs++;

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -587,7 +587,6 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 						exception_gchandle = xamarin_get_exception_for_parameter (8030, 0, "Unable to marshal the out/ref parameter", sel, method, p, i, false);
 						goto exception_handling;
 					}
-					break;
 				}
 				ofs++;
 			}

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -284,6 +284,9 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 								if (exception_gchandle != 0)
 									goto exception_handling;
 								LOGZ (" argument %i is a ref ptr/INativeObject %p: %p\n", i + 1, arg, arg_frame [ofs]);
+							} else if (p_klass == mono_get_string_class ()) {
+								arg_frame [ofs] = xamarin_nsstring_to_string (domain, *(NSString **) arg);
+								LOGZ (" argument %i is a ref NSString %p: %p\n", i + 1, arg, arg_frame [ofs]);
 							} else {
 								exception_gchandle = xamarin_get_exception_for_parameter (8029, 0, "Unable to marshal the byref parameter", sel, method, p, i, true);
 								goto exception_handling;

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -611,6 +611,9 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 					goto exception_handling;
 				}
 				*(NSObject **) arg = obj;
+			} else {
+				exception_gchandle = xamarin_get_exception_for_parameter (8030, 0, "Unable to marshal the out/ref parameter", sel, method, p, i, false);
+				goto exception_handling;
 			}
 		}
 		iterator (IteratorEnd, context, NULL, 0, NULL, &exception_gchandle);

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -255,30 +255,27 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 								arg_ptrs [i + mofs] = &arg_frame [frameofs];
 								needs_writeback = TRUE;
 								LOGZ (" argument %i is an out parameter. Passing in a pointer to a NULL value.\n", i + 1);
-								break;
-							} else {
-								if (xamarin_is_class_nsobject (p_klass)) {
-									MonoObject *obj;
-									NSObject *targ = *(NSObject **) arg;
+							} else if (xamarin_is_class_nsobject (p_klass)) {
+								MonoObject *obj;
+								NSObject *targ = *(NSObject **) arg;
 
-									obj = xamarin_get_nsobject_with_type_for_ptr (targ, false, p, &exception_gchandle);
-									if (exception_gchandle != 0) {
-										exception_gchandle = xamarin_get_exception_for_parameter (8029, exception_gchandle, "Unable to marshal the byref parameter", sel, method, p, i, true);
-										goto exception_handling;
-									}
-#if DEBUG
-									xamarin_verify_parameter (obj, sel, self, targ, i, p_klass, method);
-#endif
-									arg_frame [ofs] = obj;
-									arg_ptrs [i + mofs] = &arg_frame [frameofs];
-									LOGZ (" argument %i is a ref NSObject parameter: %p = %p\n", i + 1, arg, obj);
-									needs_writeback = TRUE;
-								} else {
-									exception_gchandle = xamarin_get_exception_for_parameter (8029, 0, "Unable to marshal the byref parameter", sel, method, p, i, true);
+								obj = xamarin_get_nsobject_with_type_for_ptr (targ, false, p, &exception_gchandle);
+								if (exception_gchandle != 0) {
+									exception_gchandle = xamarin_get_exception_for_parameter (8029, exception_gchandle, "Unable to marshal the byref parameter", sel, method, p, i, true);
 									goto exception_handling;
 								}
-								break;
+#if DEBUG
+								xamarin_verify_parameter (obj, sel, self, targ, i, p_klass, method);
+#endif
+								arg_frame [ofs] = obj;
+								arg_ptrs [i + mofs] = &arg_frame [frameofs];
+								LOGZ (" argument %i is a ref NSObject parameter: %p = %p\n", i + 1, arg, obj);
+								needs_writeback = TRUE;
+							} else {
+								exception_gchandle = xamarin_get_exception_for_parameter (8029, 0, "Unable to marshal the byref parameter", sel, method, p, i, true);
+								goto exception_handling;
 							}
+							break;
 						}
 						case _C_PTR: {
 							if (mono_type_is_byref (p)) {

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -271,19 +271,12 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 									*(NSObject **) arg = NULL;
 								}
 							} else if (xamarin_is_class_nsobject (p_klass)) {
-								MonoObject *obj;
-								NSObject *targ = *(NSObject **) arg;
-
-								obj = xamarin_get_nsobject_with_type_for_ptr (targ, false, p, &exception_gchandle);
+								arg_frame [ofs] = xamarin_get_nsobject_with_type_for_ptr (*(NSObject **) arg, false, p, &exception_gchandle);
 								if (exception_gchandle != 0) {
 									exception_gchandle = xamarin_get_exception_for_parameter (8029, exception_gchandle, "Unable to marshal the byref parameter", sel, method, p, i, true);
 									goto exception_handling;
 								}
-#if DEBUG
-								xamarin_verify_parameter (obj, sel, self, targ, i, p_klass, method);
-#endif
-								arg_frame [ofs] = obj;
-								LOGZ (" argument %i is a ref NSObject parameter: %p = %p\n", i + 1, arg, obj);
+								LOGZ (" argument %i is a ref NSObject parameter: %p = %p\n", i + 1, arg, arg_frame [ofs]);
 							} else {
 								exception_gchandle = xamarin_get_exception_for_parameter (8029, 0, "Unable to marshal the byref parameter", sel, method, p, i, true);
 								goto exception_handling;

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -69,7 +69,7 @@ xamarin_marshal_return_value_impl (MonoType *mtype, const char *type, MonoObject
 			MonoClass *r_klass = mono_object_get_class ((MonoObject *) retval);
 
 			if (desc && desc->bindas [0].original_type != NULL) {
-				return xamarin_generate_conversion_to_native (retval, mono_class_get_type (r_klass), mono_reflection_type_get_type (desc->bindas [0].original_type), method, INVALID_TOKEN_REF, exception_gchandle);
+				return xamarin_generate_conversion_to_native (retval, mono_class_get_type (r_klass), mono_reflection_type_get_type (desc->bindas [0].original_type), method, (void *) INVALID_TOKEN_REF, exception_gchandle);
 			} else if (r_klass == mono_get_string_class ()) {
 				char *str = mono_string_to_utf8 ((MonoString *) retval);
 				NSString *rv = [[NSString alloc] initWithUTF8String:str];
@@ -636,7 +636,7 @@ xamarin_get_gchandle_trampoline (id self, SEL sel)
 }
 
 id
-xamarin_generate_conversion_to_native (MonoObject *value, MonoType *inputType, MonoType *outputType, MonoMethod *method, guint32 context, guint32 *exception_gchandle)
+xamarin_generate_conversion_to_native (MonoObject *value, MonoType *inputType, MonoType *outputType, MonoMethod *method, void *context, guint32 *exception_gchandle)
 {
 	// COOP: Reads managed memory, needs to be in UNSAFE mode
 	MONO_ASSERT_GC_UNSAFE;
@@ -708,7 +708,7 @@ exception_handling:
 
 
 void *
-xamarin_generate_conversion_to_managed (id value, MonoType *inputType, MonoType *outputType, MonoMethod *method, guint32 *exception_gchandle, guint32 context, /*SList*/ void **free_list)
+xamarin_generate_conversion_to_managed (id value, MonoType *inputType, MonoType *outputType, MonoMethod *method, guint32 *exception_gchandle, void *context, /*SList*/ void **free_list)
 {
 	// COOP: Reads managed memory, needs to be in UNSAFE mode
 	MONO_ASSERT_GC_UNSAFE;
@@ -787,55 +787,55 @@ exception_handling:
 
 // Returns a pointer to the value type, which must be freed using xamarin_free.
 // If called multiple times in succession, the returned pointer can be passed as the second ptr argument, and it need only be freed once done iterating.
-void *xamarin_nsnumber_to_bool   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {       BOOL *valueptr =       (BOOL *) (ptr ? ptr : xamarin_calloc (sizeof (BOOL)));       *valueptr = [number boolValue];             return valueptr; }
-void *xamarin_nsnumber_to_sbyte  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {     int8_t *valueptr =     (int8_t *) (ptr ? ptr : xamarin_calloc (sizeof (int8_t)));     *valueptr = [number charValue];             return valueptr; }
-void *xamarin_nsnumber_to_byte   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {    uint8_t *valueptr =    (uint8_t *) (ptr ? ptr : xamarin_calloc (sizeof (uint8_t)));    *valueptr = [number unsignedCharValue];     return valueptr; }
-void *xamarin_nsnumber_to_short  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {    int16_t *valueptr =    (int16_t *) (ptr ? ptr : xamarin_calloc (sizeof (int16_t)));    *valueptr = [number shortValue];            return valueptr; }
-void *xamarin_nsnumber_to_ushort (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {   uint16_t *valueptr =   (uint16_t *) (ptr ? ptr : xamarin_calloc (sizeof (uint16_t)));   *valueptr = [number unsignedShortValue];    return valueptr; }
-void *xamarin_nsnumber_to_int    (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {    int32_t *valueptr =    (int32_t *) (ptr ? ptr : xamarin_calloc (sizeof (int32_t)));    *valueptr = [number intValue];              return valueptr; }
-void *xamarin_nsnumber_to_uint   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {   uint32_t *valueptr =   (uint32_t *) (ptr ? ptr : xamarin_calloc (sizeof (uint32_t)));   *valueptr = [number unsignedIntValue];      return valueptr; }
-void *xamarin_nsnumber_to_long   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {    int64_t *valueptr =    (int64_t *) (ptr ? ptr : xamarin_calloc (sizeof (int64_t)));    *valueptr = [number longLongValue];         return valueptr; }
-void *xamarin_nsnumber_to_ulong  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {   uint64_t *valueptr =   (uint64_t *) (ptr ? ptr : xamarin_calloc (sizeof (uint64_t)));   *valueptr = [number unsignedLongLongValue]; return valueptr; }
-void *xamarin_nsnumber_to_nint   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {  NSInteger *valueptr =  (NSInteger *) (ptr ? ptr : xamarin_calloc (sizeof (NSInteger)));  *valueptr = [number integerValue];          return valueptr; }
-void *xamarin_nsnumber_to_nuint  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) { NSUInteger *valueptr = (NSUInteger *) (ptr ? ptr : xamarin_calloc (sizeof (NSUInteger))); *valueptr = [number unsignedIntegerValue];  return valueptr; }
-void *xamarin_nsnumber_to_float  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {      float *valueptr =      (float *) (ptr ? ptr : xamarin_calloc (sizeof (float)));      *valueptr = [number floatValue];            return valueptr; }
-void *xamarin_nsnumber_to_double (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {     double *valueptr =     (double *) (ptr ? ptr : xamarin_calloc (sizeof (double)));     *valueptr = [number doubleValue];           return valueptr; }
+void *xamarin_nsnumber_to_bool   (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {       BOOL *valueptr =       (BOOL *) (ptr ? ptr : xamarin_calloc (sizeof (BOOL)));       *valueptr = [number boolValue];             return valueptr; }
+void *xamarin_nsnumber_to_sbyte  (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {     int8_t *valueptr =     (int8_t *) (ptr ? ptr : xamarin_calloc (sizeof (int8_t)));     *valueptr = [number charValue];             return valueptr; }
+void *xamarin_nsnumber_to_byte   (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {    uint8_t *valueptr =    (uint8_t *) (ptr ? ptr : xamarin_calloc (sizeof (uint8_t)));    *valueptr = [number unsignedCharValue];     return valueptr; }
+void *xamarin_nsnumber_to_short  (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {    int16_t *valueptr =    (int16_t *) (ptr ? ptr : xamarin_calloc (sizeof (int16_t)));    *valueptr = [number shortValue];            return valueptr; }
+void *xamarin_nsnumber_to_ushort (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {   uint16_t *valueptr =   (uint16_t *) (ptr ? ptr : xamarin_calloc (sizeof (uint16_t)));   *valueptr = [number unsignedShortValue];    return valueptr; }
+void *xamarin_nsnumber_to_int    (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {    int32_t *valueptr =    (int32_t *) (ptr ? ptr : xamarin_calloc (sizeof (int32_t)));    *valueptr = [number intValue];              return valueptr; }
+void *xamarin_nsnumber_to_uint   (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {   uint32_t *valueptr =   (uint32_t *) (ptr ? ptr : xamarin_calloc (sizeof (uint32_t)));   *valueptr = [number unsignedIntValue];      return valueptr; }
+void *xamarin_nsnumber_to_long   (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {    int64_t *valueptr =    (int64_t *) (ptr ? ptr : xamarin_calloc (sizeof (int64_t)));    *valueptr = [number longLongValue];         return valueptr; }
+void *xamarin_nsnumber_to_ulong  (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {   uint64_t *valueptr =   (uint64_t *) (ptr ? ptr : xamarin_calloc (sizeof (uint64_t)));   *valueptr = [number unsignedLongLongValue]; return valueptr; }
+void *xamarin_nsnumber_to_nint   (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {  NSInteger *valueptr =  (NSInteger *) (ptr ? ptr : xamarin_calloc (sizeof (NSInteger)));  *valueptr = [number integerValue];          return valueptr; }
+void *xamarin_nsnumber_to_nuint  (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) { NSUInteger *valueptr = (NSUInteger *) (ptr ? ptr : xamarin_calloc (sizeof (NSUInteger))); *valueptr = [number unsignedIntegerValue];  return valueptr; }
+void *xamarin_nsnumber_to_float  (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {      float *valueptr =      (float *) (ptr ? ptr : xamarin_calloc (sizeof (float)));      *valueptr = [number floatValue];            return valueptr; }
+void *xamarin_nsnumber_to_double (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {     double *valueptr =     (double *) (ptr ? ptr : xamarin_calloc (sizeof (double)));     *valueptr = [number doubleValue];           return valueptr; }
 #if __POINTER_WIDTH__ == 32
-void *xamarin_nsnumber_to_nfloat (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {      float *valueptr =      (float *) (ptr ? ptr : xamarin_calloc (sizeof (float)));      *valueptr = [number floatValue];            return valueptr; }
+void *xamarin_nsnumber_to_nfloat (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {      float *valueptr =      (float *) (ptr ? ptr : xamarin_calloc (sizeof (float)));      *valueptr = [number floatValue];            return valueptr; }
 #elif __POINTER_WIDTH__ == 64
-void *xamarin_nsnumber_to_nfloat (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {     double *valueptr =     (double *) (ptr ? ptr : xamarin_calloc (sizeof (double)));     *valueptr = [number doubleValue];           return valueptr; }
+void *xamarin_nsnumber_to_nfloat (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {     double *valueptr =     (double *) (ptr ? ptr : xamarin_calloc (sizeof (double)));     *valueptr = [number doubleValue];           return valueptr; }
 #else
 	#error Invalid pointer size.
 #endif
 
 // Returns a pointer to the value type, which must be freed using xamarin_free.
 // If called multiple times in succession, the returned pointer can be passed as the second ptr argument, and it need only be freed once done iterating.
-void *xamarin_nsvalue_to_nsrange                (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {                NSRange *valueptr =                (NSRange *) (ptr ? ptr : xamarin_calloc (sizeof (NSRange)));                *valueptr = [value rangeValue];             return valueptr; }
+void *xamarin_nsvalue_to_nsrange                (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {                NSRange *valueptr =                (NSRange *) (ptr ? ptr : xamarin_calloc (sizeof (NSRange)));                *valueptr = [value rangeValue];             return valueptr; }
 #if HAVE_UIKIT // Yep, these CoreGraphics-looking category method is defined in UIKit.
-void *xamarin_nsvalue_to_cgaffinetransform      (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {      CGAffineTransform *valueptr =      (CGAffineTransform *) (ptr ? ptr : xamarin_calloc (sizeof (CGAffineTransform)));      *valueptr = [value CGAffineTransformValue]; return valueptr; }
-void *xamarin_nsvalue_to_cgpoint                (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {                CGPoint *valueptr =                (CGPoint *) (ptr ? ptr : xamarin_calloc (sizeof (CGPoint)));                *valueptr = [value CGPointValue];           return valueptr; }
-void *xamarin_nsvalue_to_cgrect                 (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {                 CGRect *valueptr =                 (CGRect *) (ptr ? ptr : xamarin_calloc (sizeof (CGRect)));                 *valueptr = [value CGRectValue];            return valueptr; }
-void *xamarin_nsvalue_to_cgsize                 (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {                 CGSize *valueptr =                 (CGSize *) (ptr ? ptr : xamarin_calloc (sizeof (CGSize)));                 *valueptr = [value CGSizeValue];            return valueptr; }
-void *xamarin_nsvalue_to_cgvector               (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {               CGVector *valueptr =               (CGVector *) (ptr ? ptr : xamarin_calloc (sizeof (CGVector)));               *valueptr = [value CGVectorValue];          return valueptr; }
-void *xamarin_nsvalue_to_nsdirectionaledgeinsets(NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {NSDirectionalEdgeInsets *valueptr =(NSDirectionalEdgeInsets *) (ptr ? ptr : xamarin_calloc (sizeof (NSDirectionalEdgeInsets)));*valueptr = [value directionalEdgeInsetsValue];return valueptr; }
+void *xamarin_nsvalue_to_cgaffinetransform      (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {      CGAffineTransform *valueptr =      (CGAffineTransform *) (ptr ? ptr : xamarin_calloc (sizeof (CGAffineTransform)));      *valueptr = [value CGAffineTransformValue]; return valueptr; }
+void *xamarin_nsvalue_to_cgpoint                (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {                CGPoint *valueptr =                (CGPoint *) (ptr ? ptr : xamarin_calloc (sizeof (CGPoint)));                *valueptr = [value CGPointValue];           return valueptr; }
+void *xamarin_nsvalue_to_cgrect                 (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {                 CGRect *valueptr =                 (CGRect *) (ptr ? ptr : xamarin_calloc (sizeof (CGRect)));                 *valueptr = [value CGRectValue];            return valueptr; }
+void *xamarin_nsvalue_to_cgsize                 (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {                 CGSize *valueptr =                 (CGSize *) (ptr ? ptr : xamarin_calloc (sizeof (CGSize)));                 *valueptr = [value CGSizeValue];            return valueptr; }
+void *xamarin_nsvalue_to_cgvector               (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {               CGVector *valueptr =               (CGVector *) (ptr ? ptr : xamarin_calloc (sizeof (CGVector)));               *valueptr = [value CGVectorValue];          return valueptr; }
+void *xamarin_nsvalue_to_nsdirectionaledgeinsets(NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {NSDirectionalEdgeInsets *valueptr =(NSDirectionalEdgeInsets *) (ptr ? ptr : xamarin_calloc (sizeof (NSDirectionalEdgeInsets)));*valueptr = [value directionalEdgeInsetsValue];return valueptr; }
 #endif
 #if HAVE_COREANIMATION
-void *xamarin_nsvalue_to_catransform3d          (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {          CATransform3D *valueptr =          (CATransform3D *) (ptr ? ptr : xamarin_calloc (sizeof (CATransform3D)));          *valueptr = [value CATransform3DValue];     return valueptr; }
+void *xamarin_nsvalue_to_catransform3d          (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {          CATransform3D *valueptr =          (CATransform3D *) (ptr ? ptr : xamarin_calloc (sizeof (CATransform3D)));          *valueptr = [value CATransform3DValue];     return valueptr; }
 #endif
 #if HAVE_MAPKIT // Yep, this is defined in MapKit.
-void *xamarin_nsvalue_to_cllocationcoordinate2d (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) { CLLocationCoordinate2D *valueptr = (CLLocationCoordinate2D *) (ptr ? ptr : xamarin_calloc (sizeof (CLLocationCoordinate2D))); *valueptr = [value MKCoordinateValue];      return valueptr; }
+void *xamarin_nsvalue_to_cllocationcoordinate2d (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) { CLLocationCoordinate2D *valueptr = (CLLocationCoordinate2D *) (ptr ? ptr : xamarin_calloc (sizeof (CLLocationCoordinate2D))); *valueptr = [value MKCoordinateValue];      return valueptr; }
 #endif
 #if HAVE_COREMEDIA
-void *xamarin_nsvalue_to_cmtime                 (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {                 CMTime *valueptr =                 (CMTime *) (ptr ? ptr : xamarin_calloc (sizeof (CMTime)));                 *valueptr = [value CMTimeValue];            return valueptr; }
-void *xamarin_nsvalue_to_cmtimemapping          (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {          CMTimeMapping *valueptr =          (CMTimeMapping *) (ptr ? ptr : xamarin_calloc (sizeof (CMTimeMapping)));          *valueptr = [value CMTimeMappingValue];     return valueptr; }
-void *xamarin_nsvalue_to_cmtimerange            (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {            CMTimeRange *valueptr =            (CMTimeRange *) (ptr ? ptr : xamarin_calloc (sizeof (CMTimeRange)));            *valueptr = [value CMTimeRangeValue];       return valueptr; }
+void *xamarin_nsvalue_to_cmtime                 (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {                 CMTime *valueptr =                 (CMTime *) (ptr ? ptr : xamarin_calloc (sizeof (CMTime)));                 *valueptr = [value CMTimeValue];            return valueptr; }
+void *xamarin_nsvalue_to_cmtimemapping          (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {          CMTimeMapping *valueptr =          (CMTimeMapping *) (ptr ? ptr : xamarin_calloc (sizeof (CMTimeMapping)));          *valueptr = [value CMTimeMappingValue];     return valueptr; }
+void *xamarin_nsvalue_to_cmtimerange            (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {            CMTimeRange *valueptr =            (CMTimeRange *) (ptr ? ptr : xamarin_calloc (sizeof (CMTimeRange)));            *valueptr = [value CMTimeRangeValue];       return valueptr; }
 #endif
 #if HAVE_MAPKIT
-void *xamarin_nsvalue_to_mkcoordinatespan       (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {       MKCoordinateSpan *valueptr =       (MKCoordinateSpan *) (ptr ? ptr : xamarin_calloc (sizeof (MKCoordinateSpan)));       *valueptr = [value MKCoordinateSpanValue];  return valueptr; }
+void *xamarin_nsvalue_to_mkcoordinatespan       (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {       MKCoordinateSpan *valueptr =       (MKCoordinateSpan *) (ptr ? ptr : xamarin_calloc (sizeof (MKCoordinateSpan)));       *valueptr = [value MKCoordinateSpanValue];  return valueptr; }
 #endif
-void *xamarin_nsvalue_to_scnmatrix4             (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {             SCNMatrix4 *valueptr =             (SCNMatrix4 *) (ptr ? ptr : xamarin_calloc (sizeof (SCNMatrix4)));             *valueptr = [value SCNMatrix4Value];        return valueptr; }
+void *xamarin_nsvalue_to_scnmatrix4             (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {             SCNMatrix4 *valueptr =             (SCNMatrix4 *) (ptr ? ptr : xamarin_calloc (sizeof (SCNMatrix4)));             *valueptr = [value SCNMatrix4Value];        return valueptr; }
 void *
-xamarin_nsvalue_to_scnvector3 (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle)
+xamarin_nsvalue_to_scnvector3 (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle)
 {
 #if TARGET_OS_IOS && defined (__arm__)
 	// In earlier versions of iOS [NSValue SCNVector3Value] would return 4
@@ -873,62 +873,62 @@ xamarin_nsvalue_to_scnvector3 (NSValue *value, void *ptr, MonoClass *managedType
 
 	return valueptr;
 }
-void *xamarin_nsvalue_to_scnvector4             (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {             SCNVector4 *valueptr =             (SCNVector4 *) (ptr ? ptr : xamarin_calloc (sizeof (SCNVector4)));             *valueptr = [value SCNVector4Value];        return valueptr; }
+void *xamarin_nsvalue_to_scnvector4             (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {             SCNVector4 *valueptr =             (SCNVector4 *) (ptr ? ptr : xamarin_calloc (sizeof (SCNVector4)));             *valueptr = [value SCNVector4Value];        return valueptr; }
 #if HAVE_UIKIT
-void *xamarin_nsvalue_to_uiedgeinsets           (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {           UIEdgeInsets *valueptr =           (UIEdgeInsets *) (ptr ? ptr : xamarin_calloc (sizeof (UIEdgeInsets)));           *valueptr = [value UIEdgeInsetsValue];      return valueptr; }
-void *xamarin_nsvalue_to_uioffset               (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle) {               UIOffset *valueptr =               (UIOffset *) (ptr ? ptr : xamarin_calloc (sizeof (UIOffset)));               *valueptr = [value UIOffsetValue];          return valueptr; }
+void *xamarin_nsvalue_to_uiedgeinsets           (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {           UIEdgeInsets *valueptr =           (UIEdgeInsets *) (ptr ? ptr : xamarin_calloc (sizeof (UIEdgeInsets)));           *valueptr = [value UIEdgeInsetsValue];      return valueptr; }
+void *xamarin_nsvalue_to_uioffset               (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle) {               UIOffset *valueptr =               (UIOffset *) (ptr ? ptr : xamarin_calloc (sizeof (UIOffset)));               *valueptr = [value UIOffsetValue];          return valueptr; }
 #endif
 
-id xamarin_bool_to_nsnumber   (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSNumber numberWithBool:                  *(BOOL *) mono_object_unbox (value)]; }
-id xamarin_sbyte_to_nsnumber  (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSNumber numberWithChar:                *(int8_t *) mono_object_unbox (value)]; }
-id xamarin_byte_to_nsnumber   (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSNumber numberWithUnsignedChar:       *(uint8_t *) mono_object_unbox (value)]; }
-id xamarin_short_to_nsnumber  (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSNumber numberWithShort:              *(int16_t *) mono_object_unbox (value)]; }
-id xamarin_ushort_to_nsnumber (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSNumber numberWithUnsignedShort:     *(uint16_t *) mono_object_unbox (value)]; }
-id xamarin_int_to_nsnumber    (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSNumber numberWithInt:                *(int32_t *) mono_object_unbox (value)]; }
-id xamarin_uint_to_nsnumber   (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSNumber numberWithUnsignedInt:       *(uint32_t *) mono_object_unbox (value)]; }
-id xamarin_long_to_nsnumber   (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSNumber numberWithLongLong:           *(int64_t *) mono_object_unbox (value)]; }
-id xamarin_ulong_to_nsnumber  (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSNumber numberWithUnsignedLongLong:  *(uint64_t *) mono_object_unbox (value)]; }
-id xamarin_nint_to_nsnumber   (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSNumber numberWithInteger:          *(NSInteger *) mono_object_unbox (value)]; }
-id xamarin_nuint_to_nsnumber  (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSNumber numberWithUnsignedInteger: *(NSUInteger *) mono_object_unbox (value)]; }
-id xamarin_float_to_nsnumber  (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSNumber numberWithFloat:                *(float *) mono_object_unbox (value)]; }
-id xamarin_double_to_nsnumber (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSNumber numberWithDouble:              *(double *) mono_object_unbox (value)]; }
+id xamarin_bool_to_nsnumber   (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSNumber numberWithBool:                  *(BOOL *) mono_object_unbox (value)]; }
+id xamarin_sbyte_to_nsnumber  (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSNumber numberWithChar:                *(int8_t *) mono_object_unbox (value)]; }
+id xamarin_byte_to_nsnumber   (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSNumber numberWithUnsignedChar:       *(uint8_t *) mono_object_unbox (value)]; }
+id xamarin_short_to_nsnumber  (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSNumber numberWithShort:              *(int16_t *) mono_object_unbox (value)]; }
+id xamarin_ushort_to_nsnumber (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSNumber numberWithUnsignedShort:     *(uint16_t *) mono_object_unbox (value)]; }
+id xamarin_int_to_nsnumber    (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSNumber numberWithInt:                *(int32_t *) mono_object_unbox (value)]; }
+id xamarin_uint_to_nsnumber   (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSNumber numberWithUnsignedInt:       *(uint32_t *) mono_object_unbox (value)]; }
+id xamarin_long_to_nsnumber   (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSNumber numberWithLongLong:           *(int64_t *) mono_object_unbox (value)]; }
+id xamarin_ulong_to_nsnumber  (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSNumber numberWithUnsignedLongLong:  *(uint64_t *) mono_object_unbox (value)]; }
+id xamarin_nint_to_nsnumber   (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSNumber numberWithInteger:          *(NSInteger *) mono_object_unbox (value)]; }
+id xamarin_nuint_to_nsnumber  (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSNumber numberWithUnsignedInteger: *(NSUInteger *) mono_object_unbox (value)]; }
+id xamarin_float_to_nsnumber  (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSNumber numberWithFloat:                *(float *) mono_object_unbox (value)]; }
+id xamarin_double_to_nsnumber (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSNumber numberWithDouble:              *(double *) mono_object_unbox (value)]; }
 #if __POINTER_WIDTH__ == 32
-id xamarin_nfloat_to_nsnumber (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSNumber numberWithFloat:                *(float *) mono_object_unbox (value)]; }
+id xamarin_nfloat_to_nsnumber (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSNumber numberWithFloat:                *(float *) mono_object_unbox (value)]; }
 #elif __POINTER_WIDTH__ == 64
-id xamarin_nfloat_to_nsnumber (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSNumber numberWithDouble:              *(double *) mono_object_unbox (value)]; }
+id xamarin_nfloat_to_nsnumber (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSNumber numberWithDouble:              *(double *) mono_object_unbox (value)]; }
 #else
 	#error Invalid pointer size.
 #endif
 
-id xamarin_nsrange_to_nsvalue                (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithRange:               *(NSRange *)                mono_object_unbox (value)]; }
+id xamarin_nsrange_to_nsvalue                (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithRange:               *(NSRange *)                mono_object_unbox (value)]; }
 #if HAVE_UIKIT // yep, these CoreGraphics-looking category methods are defined in UIKit
-id xamarin_cgaffinetransform_to_nsvalue      (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithCGAffineTransform:   *(CGAffineTransform *)      mono_object_unbox (value)]; }
-id xamarin_cgpoint_to_nsvalue                (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithCGPoint:             *(CGPoint *)                mono_object_unbox (value)]; }
-id xamarin_cgrect_to_nsvalue                 (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithCGRect:              *(CGRect *)                 mono_object_unbox (value)]; }
-id xamarin_cgsize_to_nsvalue                 (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithCGSize:              *(CGSize *)                 mono_object_unbox (value)]; }
-id xamarin_cgvector_to_nsvalue               (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithCGVector:            *(CGVector *)               mono_object_unbox (value)]; }
-id xamarin_nsdirectionaledgeinsets_to_nsvalue(MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithDirectionalEdgeInsets:*(NSDirectionalEdgeInsets *)mono_object_unbox (value)]; }
+id xamarin_cgaffinetransform_to_nsvalue      (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithCGAffineTransform:   *(CGAffineTransform *)      mono_object_unbox (value)]; }
+id xamarin_cgpoint_to_nsvalue                (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithCGPoint:             *(CGPoint *)                mono_object_unbox (value)]; }
+id xamarin_cgrect_to_nsvalue                 (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithCGRect:              *(CGRect *)                 mono_object_unbox (value)]; }
+id xamarin_cgsize_to_nsvalue                 (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithCGSize:              *(CGSize *)                 mono_object_unbox (value)]; }
+id xamarin_cgvector_to_nsvalue               (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithCGVector:            *(CGVector *)               mono_object_unbox (value)]; }
+id xamarin_nsdirectionaledgeinsets_to_nsvalue(MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithDirectionalEdgeInsets:*(NSDirectionalEdgeInsets *)mono_object_unbox (value)]; }
 #endif
 #if HAVE_COREANIMATION
-id xamarin_catransform3d_to_nsvalue          (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithCATransform3D:       *(CATransform3D *)          mono_object_unbox (value)]; }
+id xamarin_catransform3d_to_nsvalue          (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithCATransform3D:       *(CATransform3D *)          mono_object_unbox (value)]; }
 #endif
 #if HAVE_MAPKIT // Yep, this is defined in MapKit.
-id xamarin_cllocationcoordinate2d_to_nsvalue (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithMKCoordinate:        *(CLLocationCoordinate2D *) mono_object_unbox (value)]; }
+id xamarin_cllocationcoordinate2d_to_nsvalue (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithMKCoordinate:        *(CLLocationCoordinate2D *) mono_object_unbox (value)]; }
 #endif
 #if HAVE_COREMEDIA
-id xamarin_cmtime_to_nsvalue                 (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithCMTime:              *(CMTime *)                 mono_object_unbox (value)]; }
-id xamarin_cmtimemapping_to_nsvalue          (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithCMTimeMapping:       *(CMTimeMapping *)          mono_object_unbox (value)]; }
-id xamarin_cmtimerange_to_nsvalue            (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithCMTimeRange:         *(CMTimeRange *)            mono_object_unbox (value)]; }
+id xamarin_cmtime_to_nsvalue                 (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithCMTime:              *(CMTime *)                 mono_object_unbox (value)]; }
+id xamarin_cmtimemapping_to_nsvalue          (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithCMTimeMapping:       *(CMTimeMapping *)          mono_object_unbox (value)]; }
+id xamarin_cmtimerange_to_nsvalue            (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithCMTimeRange:         *(CMTimeRange *)            mono_object_unbox (value)]; }
 #endif
 #if HAVE_MAPKIT
-id xamarin_mkcoordinatespan_to_nsvalue       (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithMKCoordinateSpan:    *(MKCoordinateSpan *)       mono_object_unbox (value)]; }
+id xamarin_mkcoordinatespan_to_nsvalue       (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithMKCoordinateSpan:    *(MKCoordinateSpan *)       mono_object_unbox (value)]; }
 #endif
-id xamarin_scnmatrix4_to_nsvalue             (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithSCNMatrix4:          *(SCNMatrix4 *)             mono_object_unbox (value)]; }
-id xamarin_scnvector3_to_nsvalue             (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithSCNVector3:          *(SCNVector3 *)             mono_object_unbox (value)]; }
-id xamarin_scnvector4_to_nsvalue             (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithSCNVector4:          *(SCNVector4 *)             mono_object_unbox (value)]; }
+id xamarin_scnmatrix4_to_nsvalue             (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithSCNMatrix4:          *(SCNMatrix4 *)             mono_object_unbox (value)]; }
+id xamarin_scnvector3_to_nsvalue             (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithSCNVector3:          *(SCNVector3 *)             mono_object_unbox (value)]; }
+id xamarin_scnvector4_to_nsvalue             (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithSCNVector4:          *(SCNVector4 *)             mono_object_unbox (value)]; }
 #if HAVE_UIKIT
-id xamarin_uiedgeinsets_to_nsvalue           (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithUIEdgeInsets:        *(UIEdgeInsets *)           mono_object_unbox (value)]; }
-id xamarin_uioffset_to_nsvalue               (MonoObject *value, guint32 context, guint32 *exception_gchandle) { return [NSValue valueWithUIOffset:            *(UIOffset *)               mono_object_unbox (value)]; }
+id xamarin_uiedgeinsets_to_nsvalue           (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithUIEdgeInsets:        *(UIEdgeInsets *)           mono_object_unbox (value)]; }
+id xamarin_uioffset_to_nsvalue               (MonoObject *value, void *context, guint32 *exception_gchandle) { return [NSValue valueWithUIOffset:            *(UIOffset *)               mono_object_unbox (value)]; }
 #endif
 
 #pragma clang diagnostic pop
@@ -1096,9 +1096,10 @@ xamarin_get_managed_to_nsvalue_func (MonoClass *managedType, MonoMethod *method,
 }
 
 void *
-xamarin_smart_enum_to_nsstring (MonoObject *value, guint32 context /* token ref */, guint32 *exception_gchandle)
+xamarin_smart_enum_to_nsstring (MonoObject *value, void *context /* token ref */, guint32 *exception_gchandle)
 {
-	if (context == INVALID_TOKEN_REF) {
+	guint32 context_ref = GPOINTER_TO_INT (context);
+	if (context_ref == INVALID_TOKEN_REF) {
 		// This requires the dynamic registrar to invoke the correct conversion function
 		int handle = mono_gchandle_new (value, FALSE);
 		NSString *rv = xamarin_convert_smart_enum_to_nsstring (GINT_TO_POINTER (handle), exception_gchandle);
@@ -1112,7 +1113,7 @@ xamarin_smart_enum_to_nsstring (MonoObject *value, guint32 context /* token ref 
 		MonoObject *retval;
 		void *arg_ptrs [1];
 
-		managed_method = xamarin_get_managed_method_for_token (context /* token ref */, exception_gchandle);
+		managed_method = xamarin_get_managed_method_for_token (context_ref /* token ref */, exception_gchandle);
 		if (*exception_gchandle != 0) return NULL;
 
 		arg_ptrs [0] = mono_object_unbox (value);
@@ -1132,12 +1133,13 @@ xamarin_smart_enum_to_nsstring (MonoObject *value, guint32 context /* token ref 
 }
 
 void *
-xamarin_nsstring_to_smart_enum (id value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle)
+xamarin_nsstring_to_smart_enum (id value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle)
 {
+	guint32 context_ref = GPOINTER_TO_INT (context);
 	int gc_handle = 0;
 	MonoObject *obj;
 
-	if (context == INVALID_TOKEN_REF) {
+	if (context_ref == INVALID_TOKEN_REF) {
 		// This requires the dynamic registrar to invoke the correct conversion function
 		void *rv = xamarin_convert_nsstring_to_smart_enum (value, mono_type_get_object (mono_domain_get (), mono_class_get_type (managedType)), exception_gchandle);
 		if (*exception_gchandle != 0)
@@ -1151,7 +1153,7 @@ xamarin_nsstring_to_smart_enum (id value, void *ptr, MonoClass *managedType, gui
 		void *arg_ptrs [1];
 		MonoObject *exception = NULL;
 
-		managed_method = xamarin_get_managed_method_for_token (context /* token ref */, exception_gchandle);
+		managed_method = xamarin_get_managed_method_for_token (context_ref /* token ref */, exception_gchandle);
 		if (*exception_gchandle != 0) return NULL;
 
 		arg_ptrs [0] = xamarin_get_nsobject_with_type_for_ptr (value, false, xamarin_get_parameter_type (managed_method, 0), exception_gchandle);
@@ -1170,7 +1172,7 @@ xamarin_nsstring_to_smart_enum (id value, void *ptr, MonoClass *managedType, gui
 		ptr = xamarin_calloc (size);
 	void *value_ptr = mono_object_unbox (obj);
 	memcpy (ptr, value_ptr, size);
-	if (context == INVALID_TOKEN_REF)
+	if (context_ref == INVALID_TOKEN_REF)
 		mono_gchandle_free (gc_handle);
 	return ptr;
 }
@@ -1188,7 +1190,7 @@ xamarin_get_smart_enum_to_nsstring_func (MonoClass *managedType, MonoMethod *met
 }
 
 NSArray *
-xamarin_convert_managed_to_nsarray_with_func (MonoArray *array, xamarin_managed_to_id_func convert, guint32 context, guint32 *exception_gchandle)
+xamarin_convert_managed_to_nsarray_with_func (MonoArray *array, xamarin_managed_to_id_func convert, void *context, guint32 *exception_gchandle)
 {
 	id *buf = NULL;
 	NSArray *rv = NULL;
@@ -1219,7 +1221,7 @@ exception_handling:
 }
 
 MonoArray *
-xamarin_convert_nsarray_to_managed_with_func (NSArray *array, MonoClass *managedElementType, xamarin_id_to_managed_func convert, guint32 context, guint32 *exception_gchandle)
+xamarin_convert_nsarray_to_managed_with_func (NSArray *array, MonoClass *managedElementType, xamarin_id_to_managed_func convert, void *context, guint32 *exception_gchandle)
 {
 	if (array == NULL)
 		return NULL;
@@ -1248,7 +1250,7 @@ exception_handling:
 }
 
 NSNumber *
-xamarin_convert_managed_to_nsnumber (MonoObject *value, MonoClass *managedType, MonoMethod *method, guint32 context, guint32 *exception_gchandle)
+xamarin_convert_managed_to_nsnumber (MonoObject *value, MonoClass *managedType, MonoMethod *method, void *context, guint32 *exception_gchandle)
 {
 	xamarin_managed_to_id_func convert = xamarin_get_managed_to_nsnumber_func (managedType, method, exception_gchandle);
 	if (*exception_gchandle != 0)
@@ -1258,7 +1260,7 @@ xamarin_convert_managed_to_nsnumber (MonoObject *value, MonoClass *managedType, 
 }
 
 NSValue *
-xamarin_convert_managed_to_nsvalue (MonoObject *value, MonoClass *managedType, MonoMethod *method, guint32 context, guint32 *exception_gchandle)
+xamarin_convert_managed_to_nsvalue (MonoObject *value, MonoClass *managedType, MonoMethod *method, void *context, guint32 *exception_gchandle)
 {
 	xamarin_managed_to_id_func convert = xamarin_get_managed_to_nsvalue_func (managedType, method, exception_gchandle);
 	if (*exception_gchandle != 0)

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -71,13 +71,7 @@ xamarin_marshal_return_value_impl (MonoType *mtype, const char *type, MonoObject
 			if (desc && desc->bindas [0].original_type != NULL) {
 				return xamarin_generate_conversion_to_native (retval, mono_class_get_type (r_klass), mono_reflection_type_get_type (desc->bindas [0].original_type), method, (void *) INVALID_TOKEN_REF, exception_gchandle);
 			} else if (r_klass == mono_get_string_class ()) {
-				char *str = mono_string_to_utf8 ((MonoString *) retval);
-				NSString *rv = [[NSString alloc] initWithUTF8String:str];
-
-				if (!retain)
-					[rv autorelease];
-				mono_free (str);
-				return (void *) rv;
+				return xamarin_string_to_nsstring ((MonoString *) retval, retain);
 			} else if (xamarin_is_class_array (r_klass)) {
 				MonoClass *e_klass = mono_class_get_element_class (r_klass);
 				bool is_string = e_klass == mono_get_string_class ();
@@ -92,13 +86,7 @@ xamarin_marshal_return_value_impl (MonoType *mtype, const char *type, MonoObject
 					MonoObject *value = mono_array_get (m_arr, MonoObject *, i);
 					
 					if (is_string) {
-						char *str = mono_string_to_utf8 ((MonoString *) value);
-						NSString *sv = [[NSString alloc] initWithUTF8String:str];
-
-						[sv autorelease];
-						mono_free (str);
-
-						v = sv;
+						v = xamarin_string_to_nsstring ((MonoString *) value, false);
 					} else {
 						v = xamarin_get_handle (value, exception_gchandle);
 						if (*exception_gchandle != 0) {

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -907,6 +907,8 @@ struct conversion_data {
 	MonoType *element_type;
 	MonoClass *element_class;
 	MonoReflectionType *element_reflection_type;
+	uint32_t iface_token_ref;
+	uint32_t implementation_token_ref;
 };
 
 id
@@ -945,6 +947,13 @@ xamarin_nsobject_to_inativeobject (id object, void *ptr, MonoClass *managedType,
 {
 	struct conversion_data * data = (struct conversion_data *) context;
 	return xamarin_get_inative_object_dynamic (object, false, data->element_reflection_type, exception_gchandle);
+}
+
+void *
+xamarin_nsobject_to_inativeobject_static (id object, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle)
+{
+	struct conversion_data * data = (struct conversion_data *) context;
+	return xamarin_get_inative_object_static (object, false, data->iface_token_ref, data->implementation_token_ref, exception_gchandle);
 }
 
 NSArray *
@@ -1021,6 +1030,17 @@ xamarin_nsarray_to_managed_inativeobject_array (NSArray *array, MonoType *array_
 	data.element_type = mono_class_get_type (data.element_class);
 	data.element_reflection_type = mono_type_get_object (data.domain, data.element_type);
 	return xamarin_convert_nsarray_to_managed_with_func (array, data.element_class, xamarin_nsobject_to_inativeobject, &data, exception_gchandle);
+}
+
+MonoArray *
+xamarin_nsarray_to_managed_inativeobject_array_static (NSArray *array, MonoType *array_type, MonoClass *element_class, uint32_t iface_token_ref, uint32_t implementation_token_ref, guint32 *exception_gchandle)
+{
+	struct conversion_data data = { 0 };
+	data.element_class = element_class == NULL ? mono_class_get_element_class (mono_class_from_mono_type (array_type)) : element_class;
+	data.element_type = mono_class_get_type (data.element_class);
+	data.iface_token_ref = iface_token_ref;
+	data.implementation_token_ref = implementation_token_ref;
+	return xamarin_convert_nsarray_to_managed_with_func (array, data.element_class, xamarin_nsobject_to_inativeobject_static, &data, exception_gchandle);
 }
 
 MonoArray *

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -1197,8 +1197,10 @@ xamarin_convert_managed_to_nsarray_with_func (MonoArray *array, xamarin_managed_
 	for (int i = 0; i < length; i++) {
 		MonoObject *value = mono_value_box (mono_domain_get (), element_class, ptr + element_size * i);
 		buf [i] = convert (value, context, exception_gchandle);
-		if (*exception_gchandle != 0)
+		if (*exception_gchandle != 0) {
+			*exception_gchandle = xamarin_get_exception_for_element_conversion_failure (*exception_gchandle, i);
 			goto exception_handling;
+		}
 	}
 	rv = [NSArray arrayWithObjects: buf count: length];
 
@@ -1225,8 +1227,10 @@ xamarin_convert_nsarray_to_managed_with_func (NSArray *array, MonoClass *managed
 	char *ptr = (char *) mono_array_addr_with_size (rv, element_size, 0);
 	for (int i = 0; i < length; i++) {
 		valueptr = convert ([array objectAtIndex: i], valueptr, managedElementType, context, exception_gchandle);
-		if (*exception_gchandle != 0)
+		if (*exception_gchandle != 0) {
+			*exception_gchandle = xamarin_get_exception_for_element_conversion_failure (*exception_gchandle, i);
 			goto exception_handling;
+		}
 		memcpy (ptr, valueptr, element_size);
 		ptr += element_size;
 	}

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -54,9 +54,10 @@ enum ArgumentSemantic /* Xcode 4.4 doesn't like this ': int' */ {
 //
 // The `value` parameter is the value to convert.
 //
-// The `ptr` parameter is optional, if passed the resulting value type will be
-// stored here. If NULL, memory is allocated and returned, and the return
-// value must be freed using `xamarin_free`.
+// The `ptr` parameter must not be passed if the managed type is a class. If
+// the managed type is a value type, `ptr` is optional, and if passed the
+// resulting value will be stored here. If NULL, memory is allocated and
+// returned, and the return value must be freed using `xamarin_free`.
 //
 // The `managedType` parameter is the managed type to convert to.
 //
@@ -73,7 +74,7 @@ enum ArgumentSemantic /* Xcode 4.4 doesn't like this ': int' */ {
 // to any exceptions that occur.
 //
 // The return value is:
-// * xamarin_id_to_managed_func: a pointer to the resulting value type. If
+// * xamarin_id_to_managed_func: a pointer to the resulting value. If
 //   `ptr` was passed, this value is also returned, otherwise newly allocated
 //   memory is returned (which must be freed with `xamarin_free`). If an
 //   exception occurs, 'ptr' is returned (and no memory allocated).

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -201,6 +201,7 @@ NSArray *   xamarin_managed_inativeobject_array_to_nsarray (MonoArray *array, gu
 MonoArray * xamarin_nsarray_to_managed_string_array (NSArray *array, guint32 *exception_gchandle);
 MonoArray * xamarin_nsarray_to_managed_nsobject_array (NSArray *array, MonoType *array_type, MonoClass *element_class, guint32 *exception_gchandle);
 MonoArray * xamarin_nsarray_to_managed_inativeobject_array (NSArray *array, MonoType *array_type, MonoClass *element_class, guint32 *exception_gchandle);
+MonoArray * xamarin_nsarray_to_managed_inativeobject_array_static (NSArray *array, MonoType *array_type, MonoClass *element_class, uint32_t iface_token_ref, uint32_t implementation_token_ref, guint32 *exception_gchandle);
 
 /* Copied from SGen */
 

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -180,6 +180,8 @@ id xamarin_uioffset_to_nsvalue               (MonoObject *value, void *context, 
 id xamarin_nsdirectionaledgeinsets_to_nsvalue(MonoObject *value, void *context, guint32 *exception_gchandle);
 
 NSString *   xamarin_string_to_nsstring (MonoString *obj, bool retain);
+// domain is optional, if NULL the function will call mono_get_domain.
+MonoString * xamarin_nsstring_to_string (MonoDomain *domain, NSString *obj);
 
 /* Copied from SGen */
 

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -79,13 +79,13 @@ enum ArgumentSemantic /* Xcode 4.4 doesn't like this ': int' */ {
 //   exception occurs, 'ptr' is returned (and no memory allocated).
 // * xamarin_managed_to_id_func: the resulting Objective-C object.
 
-typedef void *	(*xamarin_id_to_managed_func) (id value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
-typedef id		(*xamarin_managed_to_id_func) (MonoObject *value, guint32 context, guint32 *exception_gchandle);
+typedef void *	(*xamarin_id_to_managed_func) (id value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+typedef id		(*xamarin_managed_to_id_func) (MonoObject *value, void *context, guint32 *exception_gchandle);
 
-id              xamarin_generate_conversion_to_native (MonoObject *value, MonoType *inputType, MonoType *outputType, MonoMethod *method, guint32 context, guint32 *exception_gchandle);
-void *          xamarin_generate_conversion_to_managed (id value, MonoType *inputType, MonoType *outputType, MonoMethod *method, guint32 *exception_gchandle, guint32 context, /*SList*/ void **free_list);
-NSNumber *      xamarin_convert_managed_to_nsnumber (MonoObject *value, MonoClass *managedType, MonoMethod *method, guint32 context, guint32 *exception_gchandle);
-NSValue *       xamarin_convert_managed_to_nsvalue (MonoObject *value, MonoClass *managedType, MonoMethod *method, guint32 context, guint32 *exception_gchandle);
+id              xamarin_generate_conversion_to_native (MonoObject *value, MonoType *inputType, MonoType *outputType, MonoMethod *method, void *context, guint32 *exception_gchandle);
+void *          xamarin_generate_conversion_to_managed (id value, MonoType *inputType, MonoType *outputType, MonoMethod *method, guint32 *exception_gchandle, void *context, /*SList*/ void **free_list);
+NSNumber *      xamarin_convert_managed_to_nsnumber (MonoObject *value, MonoClass *managedType, MonoMethod *method, void *context, guint32 *exception_gchandle);
+NSValue *       xamarin_convert_managed_to_nsvalue (MonoObject *value, MonoClass *managedType, MonoMethod *method, void *context, guint32 *exception_gchandle);
 NSString *      xamarin_convert_managed_to_nsstring (MonoObject *value, MonoType *managedType, MonoType *nativeType, MonoMethod *method, guint32 *exception_gchandle);
 MonoObject *    xamarin_convert_nsnumber_to_managed (NSNumber *value, MonoType *nativeType, MonoType *managedType, MonoMethod *method, guint32 *exception_gchandle);
 MonoObject *    xamarin_convert_nsvalue_to_managed (NSValue *value, MonoType *nativeType, MonoType *managedType, MonoMethod *method, guint32 *exception_gchandle);
@@ -102,82 +102,82 @@ xamarin_managed_to_id_func xamarin_get_managed_to_nsvalue_func (MonoClass *manag
 xamarin_id_to_managed_func xamarin_get_nsstring_to_smart_enum_func (MonoClass *managedType, MonoMethod *method, guint32 *exception_gchandle);
 xamarin_managed_to_id_func xamarin_get_smart_enum_to_nsstring_func (MonoClass *managedType, MonoMethod *method, guint32 *exception_gchandle);
 
-NSArray *   xamarin_convert_managed_to_nsarray_with_func (MonoArray *array, xamarin_managed_to_id_func convert, guint32 context, guint32 *exception_gchandle);
-MonoArray * xamarin_convert_nsarray_to_managed_with_func (NSArray *array, MonoClass *managedElementType, xamarin_id_to_managed_func convert, guint32 context, guint32 *exception_gchandle);
+NSArray *   xamarin_convert_managed_to_nsarray_with_func (MonoArray *array, xamarin_managed_to_id_func convert, void *context, guint32 *exception_gchandle);
+MonoArray * xamarin_convert_nsarray_to_managed_with_func (NSArray *array, MonoClass *managedElementType, xamarin_id_to_managed_func convert, void *context, guint32 *exception_gchandle);
 
-void * xamarin_nsstring_to_smart_enum (id value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
-void * xamarin_smart_enum_to_nsstring (MonoObject *value, guint32 context /* token ref */, guint32 *exception_gchandle);
+void * xamarin_nsstring_to_smart_enum (id value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+void * xamarin_smart_enum_to_nsstring (MonoObject *value, void *context /* token ref */, guint32 *exception_gchandle);
 
 // Returns a pointer to the value type, which must be freed using xamarin_free.
-void *xamarin_nsnumber_to_bool   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_sbyte  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_byte   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_short  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_ushort (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_int    (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_uint   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_long   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_ulong  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_nint   (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_nuint  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_float  (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_double (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
-void *xamarin_nsnumber_to_nfloat (NSNumber *number, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_bool   (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_sbyte  (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_byte   (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_short  (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_ushort (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_int    (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_uint   (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_long   (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_ulong  (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_nint   (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_nuint  (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_float  (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_double (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+void *xamarin_nsnumber_to_nfloat (NSNumber *number, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
 
 // Returns a pointer to the value type, which must be freed using xamarin_free
-void *xamarin_nsvalue_to_nsrange                (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cgaffinetransform      (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cgpoint                (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cgrect                 (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cgsize                 (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cgvector               (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_catransform3d          (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cllocationcoordinate2d (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cmtime                 (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cmtimemapping          (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_cmtimerange            (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_mkcoordinatespan       (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_scnmatrix4             (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_scnvector3             (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_scnvector4             (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_uiedgeinsets           (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_uioffset               (NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
-void *xamarin_nsvalue_to_nsdirectionaledgeinsets(NSValue *value, void *ptr, MonoClass *managedType, guint32 context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_nsrange                (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cgaffinetransform      (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cgpoint                (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cgrect                 (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cgsize                 (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cgvector               (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_catransform3d          (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cllocationcoordinate2d (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cmtime                 (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cmtimemapping          (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_cmtimerange            (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_mkcoordinatespan       (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_scnmatrix4             (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_scnvector3             (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_scnvector4             (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_uiedgeinsets           (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_uioffset               (NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
+void *xamarin_nsvalue_to_nsdirectionaledgeinsets(NSValue *value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_ghandle);
 
-id xamarin_bool_to_nsnumber   (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
-id xamarin_sbyte_to_nsnumber  (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
-id xamarin_byte_to_nsnumber   (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
-id xamarin_short_to_nsnumber  (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
-id xamarin_ushort_to_nsnumber (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
-id xamarin_int_to_nsnumber    (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
-id xamarin_uint_to_nsnumber   (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
-id xamarin_long_to_nsnumber   (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
-id xamarin_ulong_to_nsnumber  (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
-id xamarin_nint_to_nsnumber   (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
-id xamarin_nuint_to_nsnumber  (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
-id xamarin_float_to_nsnumber  (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
-id xamarin_double_to_nsnumber (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
-id xamarin_nfloat_to_nsnumber (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
-id xamarin_nfloat_to_nsnumber (MonoObject *value, guint32 contxt, guint32 *exception_gchandle);
+id xamarin_bool_to_nsnumber   (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_sbyte_to_nsnumber  (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_byte_to_nsnumber   (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_short_to_nsnumber  (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_ushort_to_nsnumber (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_int_to_nsnumber    (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_uint_to_nsnumber   (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_long_to_nsnumber   (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_ulong_to_nsnumber  (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_nint_to_nsnumber   (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_nuint_to_nsnumber  (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_float_to_nsnumber  (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_double_to_nsnumber (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_nfloat_to_nsnumber (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_nfloat_to_nsnumber (MonoObject *value, void *context, guint32 *exception_gchandle);
 
-id xamarin_nsrange_to_nsvalue                (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_cgaffinetransform_to_nsvalue      (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_cgpoint_to_nsvalue                (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_cgrect_to_nsvalue                 (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_cgsize_to_nsvalue                 (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_cgvector_to_nsvalue               (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_catransform3d_to_nsvalue          (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_cllocationcoordinate2d_to_nsvalue (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_cmtime_to_nsvalue                 (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_cmtimemapping_to_nsvalue          (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_cmtimerange_to_nsvalue            (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_mkcoordinatespan_to_nsvalue       (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_scnmatrix4_to_nsvalue             (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_scnvector3_to_nsvalue             (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_scnvector4_to_nsvalue             (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_uiedgeinsets_to_nsvalue           (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_uioffset_to_nsvalue               (MonoObject *value, guint32 context, guint32 *exception_gchandle);
-id xamarin_nsdirectionaledgeinsets_to_nsvalue(MonoObject *value, guint32 context, guint32 *exception_gchandle);
+id xamarin_nsrange_to_nsvalue                (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_cgaffinetransform_to_nsvalue      (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_cgpoint_to_nsvalue                (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_cgrect_to_nsvalue                 (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_cgsize_to_nsvalue                 (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_cgvector_to_nsvalue               (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_catransform3d_to_nsvalue          (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_cllocationcoordinate2d_to_nsvalue (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_cmtime_to_nsvalue                 (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_cmtimemapping_to_nsvalue          (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_cmtimerange_to_nsvalue            (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_mkcoordinatespan_to_nsvalue       (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_scnmatrix4_to_nsvalue             (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_scnvector3_to_nsvalue             (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_scnvector4_to_nsvalue             (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_uiedgeinsets_to_nsvalue           (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_uioffset_to_nsvalue               (MonoObject *value, void *context, guint32 *exception_gchandle);
+id xamarin_nsdirectionaledgeinsets_to_nsvalue(MonoObject *value, void *context, guint32 *exception_gchandle);
 
 /* Copied from SGen */
 

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -179,6 +179,8 @@ id xamarin_uiedgeinsets_to_nsvalue           (MonoObject *value, void *context, 
 id xamarin_uioffset_to_nsvalue               (MonoObject *value, void *context, guint32 *exception_gchandle);
 id xamarin_nsdirectionaledgeinsets_to_nsvalue(MonoObject *value, void *context, guint32 *exception_gchandle);
 
+NSString *   xamarin_string_to_nsstring (MonoString *obj, bool retain);
+
 /* Copied from SGen */
 
 static inline void

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -181,6 +181,7 @@ id xamarin_nsdirectionaledgeinsets_to_nsvalue(MonoObject *value, void *context, 
 
 // These functions can be passed as xamarin_id_to_managed_func/xamarin_managed_to_id_func parameters
 id           xamarin_convert_string_to_nsstring (MonoObject *obj, void *context, guint32 *exception_gchandle);
+void *       xamarin_convert_nsstring_to_string (id value, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
 
 // These are simpler versions of the above string<->nsstring conversion functions.
 NSString *   xamarin_string_to_nsstring (MonoString *obj, bool retain);
@@ -189,10 +190,16 @@ MonoString * xamarin_nsstring_to_string (MonoDomain *domain, NSString *obj);
 
 // Either managed_type or managed_class has to be provided
 NSArray *   xamarin_managed_array_to_nsarray (MonoArray *array, MonoType *managed_type, MonoClass *managed_class, guint32 *exception_gchandle);
+// Either managed_type or managed_class has to be provided
+MonoArray * xamarin_nsarray_to_managed_array (NSArray *array, MonoType *managed_type, MonoClass *managed_class, guint32 *exception_gchandle);
 
 NSArray *   xamarin_managed_string_array_to_nsarray (MonoArray *array, guint32 *exception_gchandle);
 NSArray *   xamarin_managed_nsobject_array_to_nsarray (MonoArray *array, guint32 *exception_gchandle);
 NSArray *   xamarin_managed_inativeobject_array_to_nsarray (MonoArray *array, guint32 *exception_gchandle);
+
+MonoArray * xamarin_nsarray_to_managed_string_array (NSArray *array, guint32 *exception_gchandle);
+MonoArray * xamarin_nsarray_to_managed_nsobject_array (NSArray *array, MonoType *array_type, MonoClass *element_class, guint32 *exception_gchandle);
+MonoArray * xamarin_nsarray_to_managed_inativeobject_array (NSArray *array, MonoType *array_type, MonoClass *element_class, guint32 *exception_gchandle);
 
 /* Copied from SGen */
 

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -179,9 +179,20 @@ id xamarin_uiedgeinsets_to_nsvalue           (MonoObject *value, void *context, 
 id xamarin_uioffset_to_nsvalue               (MonoObject *value, void *context, guint32 *exception_gchandle);
 id xamarin_nsdirectionaledgeinsets_to_nsvalue(MonoObject *value, void *context, guint32 *exception_gchandle);
 
+// These functions can be passed as xamarin_id_to_managed_func/xamarin_managed_to_id_func parameters
+id           xamarin_convert_string_to_nsstring (MonoObject *obj, void *context, guint32 *exception_gchandle);
+
+// These are simpler versions of the above string<->nsstring conversion functions.
 NSString *   xamarin_string_to_nsstring (MonoString *obj, bool retain);
 // domain is optional, if NULL the function will call mono_get_domain.
 MonoString * xamarin_nsstring_to_string (MonoDomain *domain, NSString *obj);
+
+// Either managed_type or managed_class has to be provided
+NSArray *   xamarin_managed_array_to_nsarray (MonoArray *array, MonoType *managed_type, MonoClass *managed_class, guint32 *exception_gchandle);
+
+NSArray *   xamarin_managed_string_array_to_nsarray (MonoArray *array, guint32 *exception_gchandle);
+NSArray *   xamarin_managed_nsobject_array_to_nsarray (MonoArray *array, guint32 *exception_gchandle);
+NSArray *   xamarin_managed_inativeobject_array_to_nsarray (MonoArray *array, guint32 *exception_gchandle);
 
 /* Copied from SGen */
 

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -203,6 +203,14 @@ MonoArray * xamarin_nsarray_to_managed_nsobject_array (NSArray *array, MonoType 
 MonoArray * xamarin_nsarray_to_managed_inativeobject_array (NSArray *array, MonoType *array_type, MonoClass *element_class, guint32 *exception_gchandle);
 MonoArray * xamarin_nsarray_to_managed_inativeobject_array_static (NSArray *array, MonoType *array_type, MonoClass *element_class, uint32_t iface_token_ref, uint32_t implementation_token_ref, guint32 *exception_gchandle);
 
+void * xamarin_nsobject_to_object (id object, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+id     xamarin_object_to_nsobject (MonoObject *object, void *context, guint32 *exception_gchandle);
+
+id     xamarin_inativeobject_to_nsobject (MonoObject *object, void *context, guint32 *exception_gchandle);
+
+void * xamarin_nsobject_to_inativeobject (id object, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+void * xamarin_nsobject_to_inativeobject_static (id object, void *ptr, MonoClass *managedType, void *context, guint32 *exception_gchandle);
+
 /* Copied from SGen */
 
 static inline void

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1069,6 +1069,20 @@ public partial class Generator : IMemberGatherer {
 		return (pt == TypeManager.System_Int32 || pt == TypeManager.System_Int64 || pt == TypeManager.System_Byte || pt == TypeManager.System_Int16);
 	}
 
+	public bool IsNSObject (Type type)
+	{
+		if (type == TypeManager.NSObject)
+			return true;
+
+		if (type.IsSubclassOf (TypeManager.NSObject))
+			return true;
+
+		if (BindThirdPartyLibrary)
+			return false;
+
+		return type.IsInterface;
+	}
+
 	public string PrimitiveType (Type t, bool formatted = false, EnumMode enum_mode = EnumMode.Compat)
 	{
 		if (t == TypeManager.System_Void)
@@ -4117,19 +4131,76 @@ public partial class Generator : IMemberGatherer {
 
 			// Handle ByRef
 			if (mai.Type.IsByRef && mai.Type.GetElementType ().IsValueType == false){
-				string isForcedOwns;
-				var isForced = HasForcedAttribute (pi, out isForcedOwns);
-				by_ref_init.AppendFormat ("IntPtr {0}Value = IntPtr.Zero;\n", pi.Name.GetSafeParamName ());
+				// For out/ref parameters we support:
+				// * string and string[]
+				// * NSObject (and subclasses), and array of NSObject (and subclasses)
+				// * INativeObject subclasses (but not INativeObject itself), and array of INativeObject subclasses (but not arrays of INativeObject itself)
+				// 	* Except that we do not support arrays of Selector
+				// Modifications to an array (i.e. changing an element) are not marshalled back.
+				// If the array is modified, then a new array instance must be created and assigned to the ref/out parameter for us to marshal back any modifications.
+				var elementType = mai.Type.GetElementType ();
+				var isString = elementType == TypeManager.System_String;
+				var isINativeObject = elementType == TypeManager.INativeObject;
+				var isINativeObjectSubclass = !isINativeObject && TypeManager.INativeObject.IsAssignableFrom (elementType);
+				var isNSObject = IsNSObject (elementType);
+				var isArray = elementType.IsArray;
+				var isArrayOfString = isArray && elementType.GetElementType () == TypeManager.System_String;
+				var isArrayOfNSObject = isArray && IsNSObject (elementType.GetElementType ());
+				var isArrayOfINativeObject = isArray && elementType.GetElementType () == TypeManager.INativeObject;
+				var isArrayOfINativeObjectSubclass = isArray && TypeManager.INativeObject.IsAssignableFrom (elementType.GetElementType ());
+				var isArrayOfSelector = isArray && elementType.GetElementType () == TypeManager.Selector;
 
-				by_ref_processing.AppendLine();
-				if (mai.Type.GetElementType () == TypeManager.System_String){
-					by_ref_processing.AppendFormat("{0} = {0}Value != IntPtr.Zero ? NSString.FromHandle ({0}Value) : null;", pi.Name.GetSafeParamName ());
-				} else if (pi.ParameterType.GetElementType ().IsArray) {
-					by_ref_processing.AppendFormat ("{0} = {0}Value != IntPtr.Zero ? NSArray.ArrayFromHandle<{1}> ({0}Value) : null;", pi.Name.GetSafeParamName (), RenderType (mai.Type.GetElementType ().GetElementType ()));
-				} else if (isForced) {
-					by_ref_processing.AppendFormat("{0} = {0}Value != IntPtr.Zero ? Runtime.GetINativeObject<{1}> ({0}Value, {2}) : null;", pi.Name.GetSafeParamName (), RenderType (mai.Type.GetElementType ()), isForcedOwns);
+				if (!isString && !isArrayOfNSObject && !isNSObject && !isArrayOfString && !isINativeObjectSubclass && !isArrayOfINativeObjectSubclass || isINativeObject || isArrayOfSelector || isArrayOfINativeObject) {
+					exceptions.Add (ErrorHelper.CreateError (1064, "Unsupported ref/out parameter type '{0}' for the parameter '{1}' in {2}.{3}.", elementType.FullName, string.IsNullOrEmpty (pi.Name) ? $"#{pi.Position}" : pi.Name, mi.DeclaringType.FullName, mi.Name));
+					continue;
+				}
+
+				if (pi.IsOut) {
+					by_ref_init.AppendFormat ("IntPtr {0}Value = IntPtr.Zero;\n", pi.Name.GetSafeParamName ());
 				} else {
-					by_ref_processing.AppendFormat("{0} = {0}Value != IntPtr.Zero ? Runtime.GetNSObject<{1}> ({0}Value) : null;", pi.Name.GetSafeParamName (), RenderType (mai.Type.GetElementType ()));
+					by_ref_init.AppendFormat ("IntPtr {0}Value = ", pi.Name.GetSafeParamName ());
+					if (isString) {
+						by_ref_init.AppendFormat ("NSString.CreateNative ({0}, true);\n", pi.Name.GetSafeParamName ());
+						by_ref_init.AppendFormat ("IntPtr {0}OriginalValue = {0}Value;\n", pi.Name.GetSafeParamName ());
+					} else if (isArrayOfNSObject || isArrayOfINativeObjectSubclass) {
+						by_ref_init.Insert (0, string.Format ("NSArray {0}ArrayValue = NSArray.FromNSObjects ({0});\n", pi.Name.GetSafeParamName ()));
+						by_ref_init.AppendFormat ("{0}ArrayValue == null ? IntPtr.Zero : {0}ArrayValue.Handle;\n", pi.Name.GetSafeParamName ());
+					} else if (isArrayOfString) {
+						by_ref_init.Insert (0, string.Format ("NSArray {0}ArrayValue = {0} == null ? null : NSArray.FromStrings ({0});\n", pi.Name.GetSafeParamName ()));
+						by_ref_init.AppendFormat ("{0}ArrayValue == null ? IntPtr.Zero : {0}ArrayValue.Handle;\n", pi.Name.GetSafeParamName ());
+					} else if (isNSObject || isINativeObjectSubclass) {
+						by_ref_init.AppendFormat ("{0} == null ? IntPtr.Zero : {0}.Handle;\n", pi.Name.GetSafeParamName ());
+					} else {
+						throw ErrorHelper.CreateError (99, $"Internal error: don't know how to create ref/out (input) code for {mai.Type} in {mi}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).");
+					}
+				}
+
+				if (isString) {
+					if (!pi.IsOut)
+						by_ref_processing.AppendFormat ("if ({0}Value != {0}OriginalValue)\n\t", pi.Name.GetSafeParamName ());
+					by_ref_processing.AppendFormat ("{0} = NSString.FromHandle ({0}Value);\n", pi.Name.GetSafeParamName ());
+				} else if (isArray) {
+					if (!pi.IsOut)
+						by_ref_processing.AppendFormat ("if ({0}Value != ({0}ArrayValue == null ? IntPtr.Zero : {0}ArrayValue.Handle))\n\t", pi.Name.GetSafeParamName ());
+
+					if (isArrayOfNSObject || isArrayOfINativeObjectSubclass) {
+						by_ref_processing.AppendFormat ("{0} = NSArray.ArrayFromHandle<{1}> ({0}Value);\n", pi.Name.GetSafeParamName (), RenderType (elementType.GetElementType ()));
+					} else if (isArrayOfString) {
+						by_ref_processing.AppendFormat ("{0} = NSArray.StringArrayFromHandle ({0}Value);\n", pi.Name.GetSafeParamName ());
+					} else {
+						throw ErrorHelper.CreateError (99, $"Internal error: don't know how to create ref/out code for array {mai.Type} in {mi}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).");
+					}
+
+					if (!pi.IsOut)
+						by_ref_processing.AppendFormat ("{0}ArrayValue?.Dispose ();\n", pi.Name.GetSafeParamName ());
+				} else if (isNSObject) {
+					by_ref_processing.AppendFormat ("{0} = Runtime.GetNSObject<{1}> ({0}Value);\n", pi.Name.GetSafeParamName (), RenderType (elementType));
+				} else if (isINativeObjectSubclass) {
+					if (!pi.IsOut)
+						by_ref_processing.AppendFormat ("if ({0}Value != ({0} == null ? IntPtr.Zero : {0}.Handle))\n\t", pi.Name.GetSafeParamName ());
+					by_ref_processing.AppendFormat ("{0} = Runtime.GetINativeObject<{1}> ({0}Value, false);\n", pi.Name.GetSafeParamName (), RenderType (elementType));
+				} else {
+					throw ErrorHelper.CreateError (99, $"Internal error: don't know how to create ref/out (output) code for {mai.Type} in {mi}. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).");
 				}
 			}
 		}

--- a/tests/bindings-framework-test/XTest.framework.linkwith.cs
+++ b/tests/bindings-framework-test/XTest.framework.linkwith.cs
@@ -15,8 +15,8 @@ using System.Runtime.InteropServices;
 static class LinkWithConstants
 {
 #if __WATCHOS__
-	public const string Frameworks = "";
+	public const string Frameworks = "CoreLocation";
 #else
-	public const string Frameworks = "ModelIO";
+	public const string Frameworks = "CoreLocation ModelIO";
 #endif
 }

--- a/tests/bindings-test/bindings-test-mac.csproj
+++ b/tests/bindings-test/bindings-test-mac.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+    <ObjcBindingApiDefinition Include="..\generator\tests\ref-out-parameters.cs" />
     <ObjcBindingApiDefinition Include="ApiDefinition.generated.cs" />
     <ObjcBindingApiDefinition Include="ApiProtocol.cs" />
   </ItemGroup>

--- a/tests/bindings-test/bindings-test.csproj
+++ b/tests/bindings-test/bindings-test.csproj
@@ -47,6 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+    <ObjcBindingApiDefinition Include="..\generator\tests\ref-out-parameters.cs" />
     <ObjcBindingApiDefinition Include="ApiDefinition.generated.cs" />
     <ObjcBindingApiDefinition Include="ApiProtocol.cs" />
   </ItemGroup>

--- a/tests/bindings-test/libtest.linkwith.cs
+++ b/tests/bindings-test/libtest.linkwith.cs
@@ -16,8 +16,8 @@ public static class LibTest {
 static class LinkWithConstants
 {
 #if __WATCHOS__
-	public const string Frameworks = "Foundation";
+	public const string Frameworks = "Foundation CoreLocation";
 #else
-	public const string Frameworks = "Foundation ModelIO";
+	public const string Frameworks = "Foundation ModelIO CoreLocation";
 #endif
 }

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -588,6 +588,12 @@ namespace GeneratorTests
 		[Test]
 		public void GHIssue5692 () => BuildFile (Profile.iOS, "ghissue5692.cs");
 
+		public void RefOutParameters ()
+		{
+			BuildFile (Profile.macOSMobile, true, "tests/ref-out-parameters.cs");
+
+		}
+
 		BGenTool BuildFile (Profile profile, params string [] filenames)
 		{
 			return BuildFile (profile, true, false, filenames);

--- a/tests/generator/ErrorTests.cs
+++ b/tests/generator/ErrorTests.cs
@@ -579,6 +579,63 @@ namespace BI1063Tests {
 		}
 
 		[Test]
+		public void BI1064 ()
+		{
+			var bgen = new BGenTool {
+				Profile = Profile.iOS,
+				ProcessEnums = true
+			};
+			bgen.CreateTemporaryBinding (@"
+using System;
+using ObjCRuntime;
+using Foundation;
+
+namespace BI1064Errors
+{
+	[BaseType (typeof (NSObject))]
+	interface C
+	{
+		[Export (""testINativeObjectArray:a:b:"")]
+		void TestINativeObjectArray (int action, ref INativeObject[] refValues, out INativeObject[] outValues);
+
+		[Export (""invalid1:a:"")]
+		void TestInvalid1 (ref DateTime[] refInvalid, out DateTime[] outInvalid);
+
+		[Export (""invalid2:a:"")]
+		void TestInvalid2 (ref object[] refInvalid, out object[] outInvalid);
+
+		[Export (""invalid3:a:"")]
+		void TestInvalid3 (ref int[] refInvalid, out int[] outInvalid);
+
+		[Export (""invalid4:a:"")]
+		void TestInvalid4 (ref object refInvalid, out object outInvalid);
+
+		[Export (""testINativeObject:a:b:"")]
+		void TestINativeObject (int action, ref INativeObject refValue, out INativeObject outValue);
+
+		[Export (""testSelectorArray:a:b:"")] // Can't put SEL into NSArray (SEL isn't an NSObject)
+		void TestSelectorArray (int action, ref Selector[] refValues, out Selector[] outValues);
+	}
+}");
+			bgen.AssertExecuteError ("build");
+			bgen.AssertError (1064, "Unsupported ref/out parameter type 'ObjCRuntime.INativeObject' for the parameter 'refValue' in BI1064Errors.C.TestINativeObject.");
+			bgen.AssertError (1064, "Unsupported ref/out parameter type 'ObjCRuntime.INativeObject' for the parameter 'outValue' in BI1064Errors.C.TestINativeObject.");
+			bgen.AssertError (1064, "Unsupported ref/out parameter type 'ObjCRuntime.INativeObject[]' for the parameter 'refValues' in BI1064Errors.C.TestINativeObjectArray.");
+			bgen.AssertError (1064, "Unsupported ref/out parameter type 'ObjCRuntime.INativeObject[]' for the parameter 'outValues' in BI1064Errors.C.TestINativeObjectArray.");
+			bgen.AssertError (1064, "Unsupported ref/out parameter type 'System.DateTime[]' for the parameter 'refInvalid' in BI1064Errors.C.TestInvalid1.");
+			bgen.AssertError (1064, "Unsupported ref/out parameter type 'System.DateTime[]' for the parameter 'outInvalid' in BI1064Errors.C.TestInvalid1.");
+			bgen.AssertError (1064, "Unsupported ref/out parameter type 'System.Object[]' for the parameter 'refInvalid' in BI1064Errors.C.TestInvalid2.");
+			bgen.AssertError (1064, "Unsupported ref/out parameter type 'System.Object[]' for the parameter 'refInvalid' in BI1064Errors.C.TestInvalid2.");
+			bgen.AssertError (1064, "Unsupported ref/out parameter type 'System.Int32[]' for the parameter 'outInvalid' in BI1064Errors.C.TestInvalid3.");
+			bgen.AssertError (1064, "Unsupported ref/out parameter type 'System.Int32[]' for the parameter 'outInvalid' in BI1064Errors.C.TestInvalid3.");
+			bgen.AssertError (1064, "Unsupported ref/out parameter type 'System.Object' for the parameter 'refInvalid' in BI1064Errors.C.TestInvalid4.");
+			bgen.AssertError (1064, "Unsupported ref/out parameter type 'System.Object' for the parameter 'refInvalid' in BI1064Errors.C.TestInvalid4.");
+			bgen.AssertError (1064, "Unsupported ref/out parameter type 'ObjCRuntime.Selector[]' for the parameter 'refValues' in BI1064Errors.C.TestSelectorArray.");
+			bgen.AssertError (1064, "Unsupported ref/out parameter type 'ObjCRuntime.Selector[]' for the parameter 'outValues' in BI1064Errors.C.TestSelectorArray.");
+			bgen.AssertErrorCount (14);
+		}
+
+		[Test]
 		public void BI1065 ()
 		{
 			var bgen = new BGenTool {

--- a/tests/generator/generator-tests.csproj
+++ b/tests/generator/generator-tests.csproj
@@ -70,6 +70,7 @@
   <ItemGroup>
     <None Include="tests\is-direct-binding.cs" />
     <None Include="packages.config" />
+    <None Include="tests\ref-out-parameters.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="tests\" />

--- a/tests/generator/tests/ref-out-parameters.cs
+++ b/tests/generator/tests/ref-out-parameters.cs
@@ -1,0 +1,50 @@
+using System;
+using CoreFoundation;
+using Foundation;
+using ObjCRuntime;
+
+namespace BI1064
+{
+	[BaseType (typeof (NSObject))]
+	interface RefOutParameters
+	{
+		[Export ("testCFBundle:a:b:")]
+		void TestCFBundle (int action, ref CFBundle refValue, out CFBundle outValue);
+
+		[Export ("testINSCoding:a:b:")]
+		void TestINSCoding (int action, ref INSCoding refValue, out INSCoding outValue);
+
+		[Export ("testNSObject:a:b:")]
+		void TestNSObject (int action, ref NSObject refValue, out NSObject outValue);
+
+		[Export ("testNSValue:a:b:")]
+		void TestValue (int action, ref NSValue refValue, out NSValue outValue);
+
+		[Export ("testString:a:b:")]
+		void TestString (int action, ref string refValue, out string outValue);
+
+		[Export ("testInt:a:b:")]
+		void TestInt (int action, ref int refValue, out int outValue);
+
+		[Export ("testSelector:a:b:")]
+		void TestSelector (int action, ref Selector refValue, out Selector outValue);
+
+		[Export ("testClass:a:b:")]
+		void TestClass (int action, ref Class refValue, out Class outValue);
+
+		[Export ("testINSCodingArray:a:b:")]
+		void TestINSCodingArray (int action, ref INSCoding[] refValues, out INSCoding[] outValues);
+
+		[Export ("testNSObjectArray:a:b:")]
+		void TestNSObjectArray (int action, ref NSObject[] refValues, out NSObject[] outValues);
+
+		[Export ("testNSValueArray:a:b:")]
+		void TestNSValueArray (int action, ref NSValue[] refValues, out NSValue[] outValues);
+
+		[Export ("testStringArray:a:b:")]
+		void TestStringArray (int action, ref string[] refStrings, out string[] outStrings);
+
+		[Export ("testClassArray:a:b:")]
+		void TestClassArray (int action, ref Class [] refStrings, out Class [] outStrings);
+	}
+}

--- a/tests/monotouch-test/ObjCRuntime/Messaging.cs
+++ b/tests/monotouch-test/ObjCRuntime/Messaging.cs
@@ -245,6 +245,15 @@ namespace MonoTouch.ObjCRuntime
 		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSend_stret")]
 		public extern static void CATransform3D_objc_msgSend_stret (out CATransform3D buf, IntPtr receiver, IntPtr selector);
 #endif // !__WATCHOS__
+
+		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		public extern static void void_objc_msgSend_int_IntPtr_IntPtr (IntPtr receiver, IntPtr selector, int p1, ref IntPtr p2, out IntPtr p3);
+
+		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		public extern static void void_objc_msgSend_int_IntPtr_IntPtr (IntPtr receiver, IntPtr selector, int p1, IntPtr p2, IntPtr p3);
+
+		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		public extern static void void_objc_msgSend_int_int_int (IntPtr receiver, IntPtr selector, int p1, ref int p2, out int p3);
 	}
 }
 

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -1,10 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 
 #if XAMCORE_2_0
+using CoreFoundation;
+using MapKit;
 #if !__TVOS__ && !__WATCHOS__ && !MONOMAC
 using AddressBook;
 using AddressBookUI;
@@ -443,6 +446,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 		[DllImport ("/usr/lib/libobjc.dylib")]
 		static extern IntPtr class_getProperty (IntPtr cls, string name);
+
+		[DllImport ("/usr/lib/libobjc.dylib")]
+		internal static extern IntPtr object_getClass (IntPtr obj);
 
 		[Test]
 		public void TestNonVirtualProperty ()
@@ -2757,6 +2763,2488 @@ namespace MonoTouchFixtures.ObjCRuntime {
 					Assert.That (array, Is.EqualTo (obj.ManagedINSCodingArrayProperty), "4B");
 				}
 			}
+		}
+		[Test]
+		public void RefOutTest_CFBundle ()
+		{
+			IntPtr refValue = IntPtr.Zero;
+			IntPtr outValue = IntPtr.Zero;
+
+			using (var obj = new RefOutParametersSubclass ()) {
+				var sel = Selector.GetHandle ("testCFBundle:a:b:");
+				var dummyObj = CFBundle.GetMain ();
+				CFBundle refObj = null;
+				CFBundle outObj = null;
+				int action;
+
+				/// 1: set both to null
+				action = 1;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestCFBundle (action << 0, ref refObj, out outObj);
+				Assert.IsNull (refObj, "CFBundle-1A-ref");
+				Assert.IsNull (outObj, "CFBundle-1A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestCFBundle (action << 8, ref refObj, out outObj);
+				Assert.IsNull (refObj, "CFBundle-1M-ref");
+				Assert.IsNull (outObj, "CFBundle-1M-out");
+
+				// direct native
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "CFBundle-1DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "CFBundle-1DA-out");
+
+				// direct managed
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "CFBundle-1DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "CFBundle-1DM-out");
+
+				/// 2: verify that refValue points to something
+				action = 2;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestCFBundle (action << 0, ref refObj, out outObj);
+				Assert.AreEqual (dummyObj.Handle, refObj.Handle, "CFBundle-2A-ref");
+				Assert.AreSame (dummyObj, refObj, "CBundle-2A-ref-same");
+				Assert.IsNull (outObj, "CFBundle-2A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestCFBundle (action << 8, ref refObj, out outObj);
+				Assert.AreEqual (dummyObj.Handle, refObj.Handle, "CFBundle-2M-ref");
+				Assert.AreSame (dummyObj, refObj, "CBundle-2M-ref-same");
+				Assert.IsNull (outObj, "CFBundle-2M-out");
+
+				// direct native
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (dummyObj.Handle, refValue, "CFBundle-2DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "CFBundle-2DA-out");
+
+				// direct managed
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (dummyObj.Handle, refValue, "CFBundle-2DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "CFBundle-2DM-out");
+
+
+				/// 3 set both parameteres to the same pointer of a CFBundle
+				action = 3;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestCFBundle (action << 0, ref refObj, out outObj);
+				Assert.AreEqual (dummyObj.Handle, refObj.Handle, "CFBundle-3A-ref");
+				Assert.AreSame (dummyObj, refObj, "CBundle-3A-ref-same");
+				Assert.AreEqual (dummyObj.Handle, outObj.Handle, "CFBundle-3A-out");
+				Assert.AreNotSame (dummyObj, outObj, "CBundle-3A-ref-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestCFBundle (action << 8, ref refObj, out outObj);
+				Assert.AreEqual (dummyObj.Handle, refObj.Handle, "CFBundle-3M-ref");
+				Assert.AreNotSame (dummyObj, refObj, "CBundle-3M-ref-same");
+				Assert.AreEqual (dummyObj.Handle, outObj.Handle, "CFBundle-3M-out");
+				Assert.AreNotSame (dummyObj, outObj, "CBundle-3M-ref-out");
+
+				// direct native
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (dummyObj.Handle, refValue, "CFBundle-3DA-ref");
+				Assert.AreEqual (dummyObj.Handle, outValue, "CFBundle-3DA-out");
+
+				// direct managed
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (dummyObj.Handle, refValue, "CFBundle-3DM-ref");
+				Assert.AreEqual (dummyObj.Handle, outValue, "CFBundle-3DM-out");
+
+
+				/// 4 set both parameteres to different pointers of a CFBundle
+				action = 4;
+
+				// native
+				refObj = null; // set to null
+				outObj = null; // set to null
+				obj.TestCFBundle (action << 0, ref refObj, out outObj);
+				Assert.AreNotEqual (IntPtr.Zero, refObj.Handle, "CFBundle-4A-ref");
+				Assert.AreNotEqual (IntPtr.Zero, outObj.Handle, "CFBundle-4A-out");
+				Assert.AreNotEqual (refObj.Handle, outObj.Handle, "CBundle-4A-ref-distinct");
+
+				// managed
+				refObj = null; // set to null
+				outObj = null; // set to null
+				obj.TestCFBundle (action << 8, ref refObj, out outObj);
+				Assert.AreNotEqual (IntPtr.Zero, refObj.Handle, "CFBundle-4M-ref");
+				Assert.AreNotEqual (IntPtr.Zero, outObj.Handle, "CFBundle-4M-out");
+				Assert.AreNotEqual (refObj.Handle, outObj.Handle, "CBundle-4M-ref-distinct");
+
+				// direct native
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreNotEqual (IntPtr.Zero, refValue, "CFBundle-4DA-ref");
+				Assert.AreNotEqual (IntPtr.Zero, outValue, "CFBundle-4DA-out");
+				Assert.AreNotEqual (refValue, outValue, "CBundle-4DA-ref-distinct");
+
+				// direct managed
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreNotEqual (IntPtr.Zero, refValue, "CFBundle-4DM-ref");
+				Assert.AreNotEqual (IntPtr.Zero, outValue, "CFBundle-4DM-out");
+				Assert.AreNotEqual (refValue, outValue, "CBundle-4DM-ref-distinct");
+			}
+		}
+
+		[Test]
+		public void RefOutTest_INSCoding ()
+		{
+			IntPtr refValue = IntPtr.Zero;
+			IntPtr outValue = IntPtr.Zero;
+
+			using (var obj = new RefOutParametersSubclass ()) {
+				var sel = Selector.GetHandle ("testINSCoding:a:b:");
+				INSCoding dummyObj = new NSString ("Dummy obj");
+				INSCoding refObj = null;
+				INSCoding outObj = null;
+				int action;
+
+				/// 1: set both to null
+				action = 1;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestINSCoding (action << 0, ref refObj, out outObj);
+				Assert.IsNull (refObj, "NSCoding-1A-ref");
+				Assert.IsNull (outObj, "NSCoding-1A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestINSCoding (action << 8, ref refObj, out outObj);
+				Assert.IsNull (refObj, "NSCoding-1M-ref");
+				Assert.IsNull (outObj, "NSCoding-1M-out");
+
+				// direct native
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "NSCoding-1DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSCoding-1DA-out");
+
+				// direct managed
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "NSCoding-1DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSCoding-1DM-out");
+
+				/// 2: verify that refValue points to something
+				action = 2;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestINSCoding (action << 0, ref refObj, out outObj);
+				Assert.AreEqual (dummyObj.Handle, refObj.Handle, "NSCoding-2A-ref");
+				Assert.AreSame (dummyObj, refObj, "NSCoding-2A-ref-same");
+				Assert.IsNull (outObj, "NSCoding-2A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestINSCoding (action << 8, ref refObj, out outObj);
+				Assert.AreEqual (dummyObj.Handle, refObj.Handle, "NSCoding-2M-ref");
+				Assert.AreSame (dummyObj, refObj, "NSCoding-2M-ref-same");
+				Assert.IsNull (outObj, "NSCoding-2M-out");
+
+				// direct native
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (dummyObj.Handle, refValue, "NSCoding-2DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSCoding-2DA-out");
+
+				// direct managed
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (dummyObj.Handle, refValue, "NSCoding-2DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSCoding-2DM-out");
+
+
+				/// 3 set both parameteres to the same pointer of a NSCoding
+				action = 3;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestINSCoding (action << 0, ref refObj, out outObj);
+				Assert.AreNotEqual (dummyObj.Handle, refObj.Handle, "NSCoding-3A-ref");
+				Assert.AreNotSame (dummyObj, refObj, "NSCoding-3A-ref-same");
+				Assert.AreNotEqual (dummyObj.Handle, outObj.Handle, "NSCoding-3A-out");
+				Assert.AreNotSame (dummyObj, outObj, "NSCoding-3A-ref-out");
+				Assert.AreEqual (refObj.Handle, outObj.Handle, "NSCoding-3A-out-ref-eq");
+				Assert.AreNotSame (refObj, outObj, "NSCoding-3A-ref-out-not-safe");
+				Assert.That (refObj.GetType ().FullName, Is.StringContaining ("CodingWrapper"), "NSCoding-3A-ref-wrapper-type");
+				Assert.That (outObj.GetType ().FullName, Is.StringContaining ("CodingWrapper"), "NSCoding-3A-ref-wrapper-type");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestINSCoding (action << 8, ref refObj, out outObj);
+				Assert.AreNotEqual (dummyObj.Handle, refObj.Handle, "NSCoding-3M-ref");
+				Assert.AreNotSame (dummyObj, refObj, "NSCoding-3M-ref-same");
+				Assert.AreNotEqual (dummyObj.Handle, outObj.Handle, "NSCoding-3M-out");
+				Assert.AreNotSame (dummyObj, outObj, "NSCoding-3M-ref-out");
+				Assert.AreEqual (refObj.Handle, outObj.Handle, "NSCoding-3M-out-ref-eq");
+				Assert.AreSame (refObj, outObj, "NSCoding-3M-ref-out-not-safe");
+				Assert.That (refObj, Is.TypeOf<NSString> (), "NSCoding-3M-ref-wrapper-type");
+				Assert.That (outObj, Is.TypeOf<NSString> (), "NSCoding-3M-ref-wrapper-type");
+
+				// direct native
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreNotEqual (dummyObj.Handle, refValue, "NSCoding-3DA-ref");
+				Assert.AreNotEqual (dummyObj.Handle, outValue, "NSCoding-3DA-out");
+				Assert.AreSame (refObj, outObj, "NSCoding-3DA-out-ref-same");
+				Assert.That (refObj, Is.TypeOf<NSString> (), "NSCoding-3DA-ref-wrapper-type");
+				Assert.That (outObj, Is.TypeOf<NSString> (), "NSCoding-3DA-ref-wrapper-type");
+
+				// direct managed
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreNotEqual (dummyObj.Handle, refValue, "NSCoding-3DM-ref");
+				Assert.AreNotEqual (dummyObj.Handle, outValue, "NSCoding-3DM-out");
+				Assert.AreSame (refObj, outObj, "NSCoding-3DM-out-ref-eq");
+				Assert.That (refObj, Is.TypeOf<NSString> (), "NSCoding-3DM-ref-wrapper-type");
+				Assert.That (outObj, Is.TypeOf<NSString> (), "NSCoding-3DM-ref-wrapper-type");
+
+
+				/// 4 set both parameteres to different pointers of a NSCoding
+				action = 4;
+
+				// native
+				refObj = null; // set to null
+				outObj = null; // set to null
+				obj.TestINSCoding (action << 0, ref refObj, out outObj);
+				Assert.AreNotEqual (IntPtr.Zero, refObj.Handle, "NSCoding-4A-ref");
+				Assert.AreNotEqual (IntPtr.Zero, outObj.Handle, "NSCoding-4A-out");
+				Assert.AreNotEqual (refObj.Handle, outObj.Handle, "NSCoding-4A-ref-distinct");
+				Assert.That (refObj.GetType ().FullName, Is.StringContaining ("CodingWrapper"), "NSCoding-4A-ref-wrapper-type");
+				Assert.That (outObj.GetType ().FullName, Is.StringContaining ("CodingWrapper"), "NSCoding-4A-ref-wrapper-type");
+
+				// managed
+				refObj = null; // set to null
+				outObj = null; // set to null
+				obj.TestINSCoding (action << 8, ref refObj, out outObj);
+				Assert.AreNotEqual (IntPtr.Zero, refObj.Handle, "NSCoding-4M-ref");
+				Assert.AreNotEqual (IntPtr.Zero, outObj.Handle, "NSCoding-4M-out");
+				Assert.AreNotEqual (refObj.Handle, outObj.Handle, "NSCoding-4M-ref-distinct");
+				Assert.That (refObj, Is.TypeOf<NSString> (), "NSCoding-4M-ref-wrapper-type");
+				Assert.That (outObj, Is.TypeOf<NSString> (), "NSCoding-4M-ref-wrapper-type");
+
+				// direct native
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreNotEqual (IntPtr.Zero, refValue, "NSCoding-4DA-ref");
+				Assert.AreNotEqual (IntPtr.Zero, outValue, "NSCoding-4DA-out");
+				Assert.AreNotEqual (refValue, outValue, "NSCoding-4DA-ref-distinct");
+				Assert.That (refObj, Is.TypeOf<NSString> (), "NSCoding-4DA-ref-wrapper-type");
+				Assert.That (outObj, Is.TypeOf<NSString> (), "NSCoding-4DA-ref-wrapper-type");
+
+				// direct managed
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreNotEqual (IntPtr.Zero, refValue, "NSCoding-4DM-ref");
+				Assert.AreNotEqual (IntPtr.Zero, outValue, "NSCoding-4DM-out");
+				Assert.AreNotEqual (refValue, outValue, "NSCoding-4DM-ref-distinct");
+				Assert.That (refObj, Is.TypeOf<NSString> (), "NSCoding-4DM-ref-wrapper-type");
+				Assert.That (outObj, Is.TypeOf<NSString> (), "NSCoding-4DM-ref-wrapper-type");
+			}
+		}
+
+		[Test]
+		public void RefOutTest_NSObject ()
+		{
+			IntPtr refValue = IntPtr.Zero;
+			IntPtr outValue = IntPtr.Zero;
+
+			using (var obj = new RefOutParametersSubclass ()) {
+				var sel = Selector.GetHandle ("testNSObject:a:b:");
+				NSObject dummyObj = new NSString ("Dummy obj");
+				NSObject refObj = null;
+				NSObject outObj = null;
+				int action;
+
+				/// 1: set both to null
+				action = 1;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestNSObject (action << 0, ref refObj, out outObj);
+				Assert.IsNull (refObj, "NSObject-1A-ref");
+				Assert.IsNull (outObj, "NSObject-1A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestNSObject (action << 8, ref refObj, out outObj);
+				Assert.IsNull (refObj, "NSObject-1M-ref");
+				Assert.IsNull (outObj, "NSObject-1M-out");
+
+				// direct native
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "NSObject-1DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSObject-1DA-out");
+
+				// direct managed
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "NSObject-1DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSObject-1DM-out");
+
+				/// 2: verify that refValue points to something
+				action = 2;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestNSObject (action << 0, ref refObj, out outObj);
+				Assert.AreEqual (dummyObj.Handle, refObj.Handle, "NSObject-2A-ref");
+				Assert.AreSame (dummyObj, refObj, "NSObject-2A-ref-same");
+				Assert.IsNull (outObj, "NSObject-2A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestNSObject (action << 8, ref refObj, out outObj);
+				Assert.AreEqual (dummyObj.Handle, refObj.Handle, "NSObject-2M-ref");
+				Assert.AreSame (dummyObj, refObj, "NSObject-2M-ref-same");
+				Assert.IsNull (outObj, "NSObject-2M-out");
+
+				// direct native
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (dummyObj.Handle, refValue, "NSObject-2DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSObject-2DA-out");
+
+				// direct managed
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (dummyObj.Handle, refValue, "NSObject-2DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSObject-2DM-out");
+
+
+				/// 3 set both parameteres to the same pointer of a NSObject
+				action = 3;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestNSObject (action << 0, ref refObj, out outObj);
+				Assert.AreNotEqual (dummyObj.Handle, refObj.Handle, "NSObject-3A-ref");
+				Assert.AreNotEqual (dummyObj.Handle, outObj.Handle, "NSObject-3A-out");
+				Assert.AreSame (refObj, outObj, "NSObject-3A-ref-out-not-safe");
+				Assert.That (refObj, Is.TypeOf<NSObject> (), "NSObject-3A-ref-wrapper-type");
+				Assert.That (outObj, Is.TypeOf<NSObject> (), "NSObject-3A-ref-wrapper-type");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestNSObject (action << 8, ref refObj, out outObj);
+				Assert.AreNotEqual (dummyObj.Handle, refObj.Handle, "NSObject-3M-ref");
+				Assert.AreNotEqual (dummyObj.Handle, outObj.Handle, "NSObject-3M-out");
+				Assert.AreSame (refObj, outObj, "NSObject-3M-ref-out-not-safe");
+				Assert.That (refObj, Is.TypeOf<NSObject> (), "NSObject-3M-ref-wrapper-type");
+				Assert.That (outObj, Is.TypeOf<NSObject> (), "NSObject-3M-ref-wrapper-type");
+
+				// direct native
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreNotEqual (dummyObj.Handle, refValue, "NSObject-3DA-ref");
+				Assert.AreNotEqual (dummyObj.Handle, outValue, "NSObject-3DA-out");
+				Assert.AreEqual (refValue, outValue, "NSObject-3DA-out-ref-same");
+				Assert.That (Runtime.GetNSObject (refValue), Is.TypeOf<NSObject> (), "NSObject-3DA-ref-wrapper-type");
+				Assert.That (Runtime.GetNSObject (outValue), Is.TypeOf<NSObject> (), "NSObject-3DA-ref-wrapper-type");
+
+				// direct managed
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreNotEqual (dummyObj.Handle, refValue, "NSObject-3DM-ref");
+				Assert.AreNotEqual (dummyObj.Handle, outValue, "NSObject-3DM-out");
+				Assert.AreEqual (refValue, outValue, "NSObject-3DM-out-ref-eq");
+				Assert.That (Runtime.GetNSObject (refValue), Is.TypeOf<NSObject> (), "NSObject-3DM-ref-wrapper-type");
+				Assert.That (Runtime.GetNSObject (outValue), Is.TypeOf<NSObject> (), "NSObject-3DM-ref-wrapper-type");
+
+
+				/// 4 set both parameteres to different pointers of a NSObject
+				action = 4;
+
+				// native
+				refObj = null; // set to null
+				outObj = null; // set to null
+				obj.TestNSObject (action << 0, ref refObj, out outObj);
+				Assert.AreNotEqual (IntPtr.Zero, refObj.Handle, "NSObject-4A-ref");
+				Assert.AreNotEqual (IntPtr.Zero, outObj.Handle, "NSObject-4A-out");
+				Assert.AreNotEqual (refObj.Handle, outObj.Handle, "NSObject-4A-ref-distinct");
+				Assert.That (refObj, Is.TypeOf<NSObject> (), "NSObject-4A-ref-wrapper-type");
+				Assert.That (outObj, Is.TypeOf<NSObject> (), "NSObject-4A-ref-wrapper-type");
+
+				// managed
+				refObj = null; // set to null
+				outObj = null; // set to null
+				obj.TestNSObject (action << 8, ref refObj, out outObj);
+				Assert.AreNotEqual (IntPtr.Zero, refObj.Handle, "NSObject-4M-ref");
+				Assert.AreNotEqual (IntPtr.Zero, outObj.Handle, "NSObject-4M-out");
+				Assert.AreNotEqual (refObj.Handle, outObj.Handle, "NSObject-4M-ref-distinct");
+				Assert.That (refObj, Is.TypeOf<NSObject> (), "NSObject-4M-ref-wrapper-type");
+				Assert.That (outObj, Is.TypeOf<NSObject> (), "NSObject-4M-ref-wrapper-type");
+
+				// direct native
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreNotEqual (IntPtr.Zero, refValue, "NSObject-4DA-ref");
+				Assert.AreNotEqual (IntPtr.Zero, outValue, "NSObject-4DA-out");
+				Assert.AreNotEqual (refValue, outValue, "NSObject-4DA-ref-distinct");
+				Assert.That (Runtime.GetNSObject (refValue), Is.TypeOf<NSObject> (), "NSObject-4DA-ref-wrapper-type");
+				Assert.That (Runtime.GetNSObject (outValue), Is.TypeOf<NSObject> (), "NSObject-4DA-ref-wrapper-type");
+
+				// direct managed
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreNotEqual (IntPtr.Zero, refValue, "NSObject-4DM-ref");
+				Assert.AreNotEqual (IntPtr.Zero, outValue, "NSObject-4DM-out");
+				Assert.AreNotEqual (refValue, outValue, "NSObject-4DM-ref-distinct");
+				Assert.That (Runtime.GetNSObject (refValue), Is.TypeOf<NSObject> (), "NSObject-4DM-ref-wrapper-type");
+				Assert.That (Runtime.GetNSObject (outValue), Is.TypeOf<NSObject> (), "NSObject-4DM-ref-wrapper-type");
+			}
+		}
+
+		[Test]
+		public void RefOutTest_NSValue ()
+		{
+			IntPtr refValue = IntPtr.Zero;
+			IntPtr outValue = IntPtr.Zero;
+
+			using (var obj = new RefOutParametersSubclass ()) {
+				var sel = Selector.GetHandle ("testNSValue:a:b:");
+				var dummyObj = NSValue.FromMKCoordinate (new CLLocationCoordinate2D (3, 14));
+				NSValue refObj = null;
+				NSValue outObj = null;
+				int action;
+
+				/// 1: set both to null
+				action = 1;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestValue (action << 0, ref refObj, out outObj);
+				Assert.IsNull (refObj, "NSValue-1A-ref");
+				Assert.IsNull (outObj, "NSValue-1A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestValue (action << 8, ref refObj, out outObj);
+				Assert.IsNull (refObj, "NSValue-1M-ref");
+				Assert.IsNull (outObj, "NSValue-1M-out");
+
+				// direct native
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "NSValue-1DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSValue-1DA-out");
+
+				// direct managed
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "NSValue-1DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSValue-1DM-out");
+
+				/// 2: verify that refValue points to something
+				action = 2;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestValue (action << 0, ref refObj, out outObj);
+				Assert.AreEqual (dummyObj.Handle, refObj.Handle, "NSValue-2A-ref");
+				Assert.AreSame (dummyObj, refObj, "NSValue-2A-ref-same");
+				Assert.IsNull (outObj, "NSValue-2A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestValue (action << 8, ref refObj, out outObj);
+				Assert.AreEqual (dummyObj.Handle, refObj.Handle, "NSValue-2M-ref");
+				Assert.AreSame (dummyObj, refObj, "NSValue-2M-ref-same");
+				Assert.IsNull (outObj, "NSValue-2M-out");
+
+				// direct native
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (dummyObj.Handle, refValue, "NSValue-2DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSValue-2DA-out");
+
+				// direct managed
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (dummyObj.Handle, refValue, "NSValue-2DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSValue-2DM-out");
+
+
+				/// 3 set both parameteres to the same pointer of a NSValue
+				action = 3;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestValue (action << 0, ref refObj, out outObj);
+				Assert.AreNotEqual (dummyObj.Handle, refObj.Handle, "NSValue-3A-ref");
+				Assert.AreNotEqual (dummyObj.Handle, outObj.Handle, "NSValue-3A-out");
+				Assert.AreSame (refObj, outObj, "NSValue-3A-ref-out-not-safe");
+				Assert.That (refObj, Is.TypeOf<NSValue> (), "NSValue-3A-ref-wrapper-type");
+				Assert.That (outObj, Is.TypeOf<NSValue> (), "NSValue-3A-ref-wrapper-type");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestValue (action << 8, ref refObj, out outObj);
+				Assert.AreNotEqual (dummyObj.Handle, refObj.Handle, "NSValue-3M-ref");
+				Assert.AreNotEqual (dummyObj.Handle, outObj.Handle, "NSValue-3M-out");
+				Assert.AreSame (refObj, outObj, "NSValue-3M-ref-out-not-safe");
+				Assert.That (refObj, Is.TypeOf<NSValue> (), "NSValue-3M-ref-wrapper-type");
+				Assert.That (outObj, Is.TypeOf<NSValue> (), "NSValue-3M-ref-wrapper-type");
+
+				// direct native
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreNotEqual (dummyObj.Handle, refValue, "NSValue-3DA-ref");
+				Assert.AreNotEqual (dummyObj.Handle, outValue, "NSValue-3DA-out");
+				Assert.AreEqual (refValue, outValue, "NSValue-3DA-out-ref-same");
+				Assert.That (Runtime.GetNSObject (refValue), Is.TypeOf<NSValue> (), "NSValue-3DA-ref-wrapper-type");
+				Assert.That (Runtime.GetNSObject (outValue), Is.TypeOf<NSValue> (), "NSValue-3DA-ref-wrapper-type");
+
+				// direct managed
+				refValue = dummyObj.Handle; // set to non-null
+				outValue = dummyObj.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreNotEqual (dummyObj.Handle, refValue, "NSValue-3DM-ref");
+				Assert.AreNotEqual (dummyObj.Handle, outValue, "NSValue-3DM-out");
+				Assert.AreEqual (refValue, outValue, "NSValue-3DM-out-ref-eq");
+				Assert.That (Runtime.GetNSObject (refValue), Is.TypeOf<NSValue> (), "NSValue-3DM-ref-wrapper-type");
+				Assert.That (Runtime.GetNSObject (outValue), Is.TypeOf<NSValue> (), "NSValue-3DM-ref-wrapper-type");
+
+
+				/// 4 set both parameteres to different pointers of a NSValue
+				action = 4;
+
+				// native
+				refObj = null; // set to null
+				outObj = null; // set to null
+				obj.TestValue (action << 0, ref refObj, out outObj);
+				Assert.AreNotEqual (IntPtr.Zero, refObj.Handle, "NSValue-4A-ref");
+				Assert.AreNotEqual (IntPtr.Zero, outObj.Handle, "NSValue-4A-out");
+				Assert.AreNotEqual (refObj.Handle, outObj.Handle, "NSValue-4A-ref-distinct");
+				Assert.That (refObj, Is.TypeOf<NSValue> (), "NSValue-4A-ref-wrapper-type");
+				Assert.That (outObj, Is.TypeOf<NSValue> (), "NSValue-4A-ref-wrapper-type");
+
+				// managed
+				refObj = null; // set to null
+				outObj = null; // set to null
+				obj.TestValue (action << 8, ref refObj, out outObj);
+				Assert.AreNotEqual (IntPtr.Zero, refObj.Handle, "NSValue-4M-ref");
+				Assert.AreNotEqual (IntPtr.Zero, outObj.Handle, "NSValue-4M-out");
+				Assert.AreNotEqual (refObj.Handle, outObj.Handle, "NSValue-4M-ref-distinct");
+				Assert.That (refObj, Is.TypeOf<NSValue> (), "NSValue-4M-ref-wrapper-type");
+				Assert.That (outObj, Is.TypeOf<NSValue> (), "NSValue-4M-ref-wrapper-type");
+
+				// direct native
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreNotEqual (IntPtr.Zero, refValue, "NSValue-4DA-ref");
+				Assert.AreNotEqual (IntPtr.Zero, outValue, "NSValue-4DA-out");
+				Assert.AreNotEqual (refValue, outValue, "NSValue-4DA-ref-distinct");
+				Assert.That (Runtime.GetNSObject (refValue), Is.TypeOf<NSValue> (), "NSValue-4DA-ref-wrapper-type");
+				Assert.That (Runtime.GetNSObject (outValue), Is.TypeOf<NSValue> (), "NSValue-4DA-ref-wrapper-type");
+
+				// direct managed
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreNotEqual (IntPtr.Zero, refValue, "NSValue-4DM-ref");
+				Assert.AreNotEqual (IntPtr.Zero, outValue, "NSValue-4DM-out");
+				Assert.AreNotEqual (refValue, outValue, "NSValue-4DM-ref-distinct");
+				Assert.That (Runtime.GetNSObject (refValue), Is.TypeOf<NSValue> (), "NSValue-4DM-ref-wrapper-type");
+				Assert.That (Runtime.GetNSObject (outValue), Is.TypeOf<NSValue> (), "NSValue-4DM-ref-wrapper-type");
+			}
+		}
+
+		[Test]
+		public void RefOutTest_String ()
+		{
+			IntPtr refValue = IntPtr.Zero;
+			IntPtr outValue = IntPtr.Zero;
+
+			using (var obj = new RefOutParametersSubclass ()) {
+				var sel = Selector.GetHandle ("testString:a:b:");
+				var dummyObj = "dummy string";
+				var dummyObjHandle = NSString.CreateNative (dummyObj, true);
+				string refObj = null;
+				string outObj = null;
+				int action;
+
+				/// 1: set both to null
+				action = 1;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestString (action << 0, ref refObj, out outObj);
+				Assert.IsNull (refObj, "String-1A-ref");
+				Assert.IsNull (outObj, "String-1A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestString (action << 8, ref refObj, out outObj);
+				Assert.IsNull (refObj, "String-1M-ref");
+				Assert.IsNull (outObj, "String-1M-out");
+
+				// direct native
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "String-1DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "String-1DA-out");
+
+				// direct managed
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "String-1DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "String-1DM-out");
+
+				/// 2: verify that refValue points to something
+				action = 2;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestString (action << 0, ref refObj, out outObj);
+				Assert.AreEqual (dummyObj, refObj, "String-2A-ref");
+				Assert.IsNull (outObj, "String-2A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestString (action << 8, ref refObj, out outObj);
+				Assert.AreEqual (dummyObj, refObj, "String-2M-ref");
+				Assert.IsNull (outObj, "String-2M-out");
+
+				// direct native
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (dummyObj, NSString.FromHandle (refValue), "String-2DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "String-2DA-out");
+
+				// direct managed
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (dummyObj, NSString.FromHandle (refValue), "String-2DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "String-2DM-out");
+
+
+				/// 3 set both parameteres to the same pointer of a String
+				action = 3;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestString (action << 0, ref refObj, out outObj);
+				Assert.AreEqual ("A constant native string", refObj, "String-3A-ref");
+				Assert.AreEqual ("A constant native string", outObj, "String-3A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestString (action << 8, ref refObj, out outObj);
+				Assert.AreEqual ("A constant managed string", refObj, "String-3M-ref");
+				Assert.AreEqual ("A constant managed string", outObj, "String-3M-out");
+
+				// direct native
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreNotEqual (refValue, outValue, "String-3DA-eq"); // The managed roundtrip means 'outValue' is re-created (because it's nulled out upon entering managed code)
+				Assert.AreEqual ("A constant native string", NSString.FromHandle (refValue), "String-3DA-ref");
+				Assert.AreEqual ("A constant native string", NSString.FromHandle (outValue), "String-3DA-out");
+
+				// direct managed
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreNotEqual (refValue, outValue, "String-3DM-eq"); // The managed roundtrip means 'outValue' is re-created (because it's nulled out upon entering managed code)
+				Assert.AreEqual ("A constant managed string", NSString.FromHandle (refValue), "String-3DM-ref");
+				Assert.AreEqual ("A constant managed string", NSString.FromHandle (outValue), "String-3DM-out");
+
+
+				/// 4 set both parameteres to different pointers of a String
+				action = 4;
+
+				// native
+				refObj = null; // set to null
+				outObj = null; // set to null
+				obj.TestString (action << 0, ref refObj, out outObj);
+				Assert.AreEqual ("Hello Xamarin", refObj, "String-4A-ref-value");
+				Assert.AreEqual ("Hello Microsoft", outObj, "String-4A-out-value");
+
+				// managed
+				refObj = null; // set to null
+				outObj = null; // set to null
+				obj.TestString (action << 8, ref refObj, out outObj);
+				Assert.AreEqual ("Hello Xamarin from managed", refObj, "String-4M-ref-value");
+				Assert.AreEqual ("Hello Microsoft from managed", outObj, "String-4M-out-value");
+
+				// direct native
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual ("Hello Xamarin", NSString.FromHandle (refValue), "String-4DA-ref-value");
+				Assert.AreEqual ("Hello Microsoft", NSString.FromHandle (outValue), "String-4DA-out-value");
+
+				// direct managed
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual ("Hello Xamarin from managed", NSString.FromHandle (refValue), "String-4DM-ref-value");
+				Assert.AreEqual ("Hello Microsoft from managed", NSString.FromHandle (outValue), "String-4DM-out-value");
+			}
+		}
+
+		[Test]
+		public void RefOutTest_Int ()
+		{
+			using (var obj = new RefOutParametersSubclass ()) {
+				var sel = Selector.GetHandle ("testInt:a:b:");
+				var dummyObj = 314;
+				int refObj = 0;
+				int outObj = 0;
+				int action;
+
+				/// 1: set both to 0
+				action = 1;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestInt (action << 0, ref refObj, out outObj);
+				Assert.AreEqual (0, refObj, "Int-1A-ref");
+				Assert.AreEqual (0, outObj, "Int-1A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestInt (action << 8, ref refObj, out outObj);
+				Assert.AreEqual (0, refObj, "Int-1M-ref");
+				Assert.AreEqual (0, outObj, "Int-1M-out");
+
+				// direct native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				Messaging.void_objc_msgSend_int_int_int (obj.Handle, sel, action << 0, ref refObj, out outObj);
+				Assert.AreEqual (0, refObj, "Int-1DA-ref");
+				Assert.AreEqual (0, outObj, "Int-1DA-out");
+
+				// direct managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				Messaging.void_objc_msgSend_int_int_int (obj.Handle, sel, action << 8, ref refObj, out outObj);
+				Assert.AreEqual (0, refObj, "Int-1DM-ref");
+				Assert.AreEqual (0, outObj, "Int-1DM-out");
+
+				/// 2: N/A for testInt
+
+				/// 3 set both parameteres to the same pointer of a Int
+				action = 3;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestInt (action << 0, ref refObj, out outObj);
+				Assert.AreNotEqual (dummyObj, refObj, "Int-3A-ref");
+				Assert.AreNotEqual (dummyObj, outObj, "Int-3A-out");
+				Assert.AreEqual (refObj, outObj, "Int-3A-out-ref-eq");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				obj.TestInt (action << 8, ref refObj, out outObj);
+				Assert.AreNotEqual (dummyObj, refObj, "Int-3M-ref");
+				Assert.AreNotEqual (dummyObj, outObj, "Int-3M-out");
+				Assert.AreEqual (refObj, outObj, "Int-3M-out-ref-eq");
+
+				// direct native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				Messaging.void_objc_msgSend_int_int_int (obj.Handle, sel, action << 0, ref refObj, out outObj);
+				Assert.AreNotEqual (dummyObj, refObj, "Int-3DA-ref");
+				Assert.AreNotEqual (dummyObj, outObj, "Int-3DA-out");
+				Assert.AreEqual (refObj, outObj, "Int-3DA-out-ref-same");
+
+				// direct managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				Messaging.void_objc_msgSend_int_int_int (obj.Handle, sel, action << 8, ref refObj, out outObj);
+				Assert.AreNotEqual (dummyObj, refObj, "Int-3DM-ref");
+				Assert.AreNotEqual (dummyObj, outObj, "Int-3DM-out");
+				Assert.AreEqual (refObj, outObj, "Int-3DM-out-ref-eq");
+
+
+				/// 4 set both parameteres to different pointers of a Int
+				action = 4;
+
+				// native
+				refObj = 0; // set to 0
+				outObj = 0; // set to 0
+				obj.TestInt (action << 0, ref refObj, out outObj);
+				Assert.AreNotEqual (0, refObj, "Int-4A-ref");
+				Assert.AreNotEqual (0, outObj, "Int-4A-out");
+				Assert.AreNotEqual (refObj, outObj, "Int-4A-ref-distinct");
+
+				// managed
+				refObj = 0; // set to 0
+				outObj = 0; // set to 0
+				obj.TestInt (action << 8, ref refObj, out outObj);
+				Assert.AreNotEqual (0, refObj, "Int-4M-ref");
+				Assert.AreNotEqual (0, outObj, "Int-4M-out");
+				Assert.AreNotEqual (refObj, outObj, "Int-4M-ref-distinct");
+
+				// direct native
+				refObj = 0; // set to 0
+				outObj = 0; // set to 0
+				Messaging.void_objc_msgSend_int_int_int (obj.Handle, sel, action << 0, ref refObj, out outObj);
+				Assert.AreNotEqual (0, refObj, "Int-4DA-ref");
+				Assert.AreNotEqual (0, outObj, "Int-4DA-out");
+				Assert.AreNotEqual (refObj, outObj, "Int-4DA-ref-distinct");
+				Assert.AreEqual (3141592, refObj, "Int-4DA-ref-value");
+				Assert.AreEqual (2718282, outObj, "Int-4DA-out-value");
+
+				// direct managed
+				refObj = 0; // set to 0
+				outObj = 0; // set to 0
+				Messaging.void_objc_msgSend_int_int_int (obj.Handle, sel, action << 8, ref refObj, out outObj);
+				Assert.AreNotEqual (0, refObj, "Int-4DM-ref");
+				Assert.AreNotEqual (0, outObj, "Int-4DM-out");
+				Assert.AreNotEqual (refObj, outObj, "Int-4DM-ref-distinct");
+				Assert.AreEqual (3141592, refObj, "Int-4DM-ref-value");
+				Assert.AreEqual (2718282, outObj, "Int-4DM-out-value");
+			}
+		}
+
+		[Test]
+		public void RefOutTest_Sel ()
+		{
+			IntPtr refValue = IntPtr.Zero;
+			IntPtr outValue = IntPtr.Zero;
+
+			using (var obj = new RefOutParametersSubclass ()) {
+				var sel = Selector.GetHandle ("testSelector:a:b:");
+				var dummyObj = new Selector ("dummy string");
+				var dummyObjHandle = dummyObj.Handle;
+				Selector refObj = null;
+				Selector outObj = null;
+				TestMethod<Selector> test = obj.TestSelector;
+				int action;
+
+				/// 1: set both to null
+				action = 1;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.IsNull (refObj, "Selector-1A-ref");
+				Assert.IsNull (outObj, "Selector-1A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.IsNull (refObj, "Selector-1M-ref");
+				Assert.IsNull (outObj, "Selector-1M-out");
+
+				// direct native
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				IntPtr x = Marshal.AllocHGlobal (16);
+				//Marshal.WriteIntPtr (x, (IntPtr) 0xdeadf00d);
+				//Marshal.WriteIntPtr (x, 8, (IntPtr) 0xbabebabe);
+				//Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, x, x);
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "Selector-1DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "Selector-1DA-out");
+
+				// direct managed
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "Selector-1DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "Selector-1DM-out");
+
+				/// 2: verify that refValue points to something
+				action = 2;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.AreEqual (dummyObj, refObj, "Selector-2A-ref");
+				Assert.IsNull (outObj, "Selector-2A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.AreEqual (dummyObj, refObj, "Selector-2M-ref");
+				Assert.IsNull (outObj, "Selector-2M-out");
+
+				// direct native
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (dummyObj.Handle, refValue, "Selector-2DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "Selector-2DA-out");
+
+				// direct managed
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (dummyObj.Handle, refValue, "Selector-2DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "Selector-2DM-out");
+
+
+				/// 3 set both parameteres to the same selector
+				action = 3;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.AreEqual (Selector.GetHandle ("testSelector"), refObj.Handle, "Selector-3A-ref");
+				Assert.AreEqual (Selector.GetHandle ("testSelector"), outObj.Handle, "Selector-3A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.AreEqual (Selector.GetHandle ("testManagedSelector"), refObj.Handle, "Selector-3M-ref");
+				Assert.AreEqual (Selector.GetHandle ("testManagedSelector"), outObj.Handle, "Selector-3M-out");
+
+				// direct native
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (refValue, outValue, "Selector-3DA-eq"); // The managed roundtrip means 'outValue' is re-created (because it's nulled out upon entering managed code), but because selectors are unique, we get back the same pointer.
+				Assert.AreEqual (Selector.GetHandle ("testSelector"), refValue, "Selector-3DA-ref");
+				Assert.AreEqual (Selector.GetHandle ("testSelector"), outValue, "Selector-3DA-out");
+
+				// direct managed
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (refValue, outValue, "Selector-3DM-eq"); // The managed roundtrip means 'outValue' is re-created (because it's nulled out upon entering managed code), but because selectors are unique, we get back the same pointer.
+				Assert.AreEqual (Selector.GetHandle ("testManagedSelector"), refValue, "Selector-3DM-ref");
+				Assert.AreEqual (Selector.GetHandle ("testManagedSelector"), outValue, "Selector-3DM-out");
+
+
+				/// 4 set both parameteres to different selectors
+				action = 4;
+
+				// native
+				refObj = null; // set to null
+				outObj = null; // set to null
+				test (action << 0, ref refObj, out outObj);
+				Assert.AreEqual (Selector.GetHandle ("testSelector:a:"), refObj.Handle, "Selector-4A-ref-value");
+				Assert.AreEqual (Selector.GetHandle ("testSelector:b:"), outObj.Handle, "Selector-4A-out-value");
+
+				// managed
+				refObj = null; // set to null
+				outObj = null; // set to null
+				test (action << 8, ref refObj, out outObj);
+				Assert.AreEqual (Selector.GetHandle ("testManagedSelectorA"), refObj.Handle, "Selector-4M-ref-value");
+				Assert.AreEqual (Selector.GetHandle ("testManagedSelectorB"), outObj.Handle, "Selector-4M-out-value");
+
+				// direct native
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (Selector.GetHandle ("testSelector:a:"), refValue, "Selector-4DA-ref-value");
+				Assert.AreEqual (Selector.GetHandle ("testSelector:b:"), outValue, "Selector-4DA-out-value");
+
+				// direct managed
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (Selector.GetHandle ("testManagedSelectorA"), refValue, "Selector-4DM-ref-value");
+				Assert.AreEqual (Selector.GetHandle ("testManagedSelectorB"), outValue, "Selector-4DM-out-value");
+			}
+		}
+
+		[Test]
+		public void RefOutTest_Class ()
+		{
+			IntPtr refValue = IntPtr.Zero;
+			IntPtr outValue = IntPtr.Zero;
+
+			using (var obj = new RefOutParametersSubclass ()) {
+				var sel = Selector.GetHandle ("testClass:a:b:");
+				var dummyObj = new Class (typeof (NSObject));
+				var dummyObjHandle = dummyObj.Handle;
+				Class refObj = null;
+				Class outObj = null;
+				TestMethod<Class> test = obj.TestClass;
+				int action;
+
+				/// 1: set both to null
+				action = 1;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.IsNull (refObj, "Class-1A-ref");
+				Assert.IsNull (outObj, "Class-1A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.IsNull (refObj, "Class-1M-ref");
+				Assert.IsNull (outObj, "Class-1M-out");
+
+				// direct native
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "Class-1DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "Class-1DA-out");
+
+				// direct managed
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "Class-1DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "Class-1DM-out");
+
+				/// 2: verify that refValue points to something
+				action = 2;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.AreEqual (dummyObj, refObj, "Class-2A-ref");
+				Assert.IsNull (outObj, "Class-2A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.AreEqual (dummyObj, refObj, "Class-2M-ref");
+				Assert.IsNull (outObj, "Class-2M-out");
+
+				// direct native
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (dummyObj.Handle, refValue, "Class-2DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "Class-2DA-out");
+
+				// direct managed
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (dummyObj.Handle, refValue, "Class-2DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "Class-2DM-out");
+
+
+				/// 3 set both parameteres to the same Class
+				action = 3;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.AreEqual (Class.GetHandle ("NSString"), refObj.Handle, "Class-3A-ref");
+				Assert.AreEqual (Class.GetHandle ("NSString"), outObj.Handle, "Class-3A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.AreEqual (Class.GetHandle (typeof (SomeConsumer)), refObj.Handle, "Class-3M-ref");
+				Assert.AreEqual (Class.GetHandle (typeof (SomeConsumer)), outObj.Handle, "Class-3M-out");
+
+				// direct native
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (refValue, outValue, "String-3DA-eq"); // The managed roundtrip means 'outValue' is re-created (because it's nulled out upon entering managed code), but since Class instances are singletons, we get back the same value.
+				Assert.AreEqual (Class.GetHandle ("NSString"), refValue, "Class-3DA-ref");
+				Assert.AreEqual (Class.GetHandle ("NSString"), outValue, "Class-3DA-out");
+
+				// direct managed
+				refValue = dummyObjHandle; // set to non-null
+				outValue = dummyObjHandle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (refValue, outValue, "Class-3DM-eq"); // The managed roundtrip means 'outValue' is re-created (because it's nulled out upon entering managed code), but since Class instances are singletons, we get back the same value.
+				Assert.AreEqual (Class.GetHandle (typeof (SomeConsumer)), refValue, "Class-3DM-ref");
+				Assert.AreEqual (Class.GetHandle (typeof (SomeConsumer)), outValue, "Class-3DM-out");
+
+
+				/// 4 set both parameteres to different Classes
+				action = 4;
+
+				// native
+				refObj = null; // set to null
+				outObj = null; // set to null
+				test (action << 0, ref refObj, out outObj);
+				Assert.AreEqual (Class.GetHandle ("NSBundle"), refObj.Handle, "Class-4A-ref-value");
+				Assert.AreEqual (Class.GetHandle ("NSDate"), outObj.Handle, "Class-4A-out-value");
+
+				// managed
+				refObj = null; // set to null
+				outObj = null; // set to null
+				test (action << 8, ref refObj, out outObj);
+				Assert.AreEqual (Class.GetHandle (typeof (RefOutParametersSubclass)), refObj.Handle, "Class-4M-ref-value");
+				Assert.AreEqual (Class.GetHandle ("RefOutParameters"), outObj.Handle, "Class-4M-out-value");
+
+				// direct native
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (Class.GetHandle ("NSBundle"), refValue, "Class-4DA-ref-value");
+				Assert.AreEqual (Class.GetHandle ("NSDate"), outValue, "Class-4DA-out-value");
+
+				// direct managed
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (Class.GetHandle (typeof (RefOutParametersSubclass)), refValue, "Class-4DM-ref-value");
+				Assert.AreEqual (Class.GetHandle ("RefOutParameters"), outValue, "Class-4DM-out-value");
+			}
+		}
+
+		void AssertAreEqual (INativeObject [] expected, INativeObject [] actual, string msg)
+		{
+			if (expected == null && actual == null)
+				return;
+			if (expected == null ^ actual == null)
+				Assert.Fail ("One is null and the other is not. Expected: {0} Actual: {1}. " + msg, expected, actual);
+			Assert.AreEqual (expected.Length, actual.Length, "Length." + msg);
+			for (int i = 0; i < expected.Length; i++) {
+				Assert.AreEqual (expected [i].Handle, actual [i].Handle, $"Index #{i}: {msg}");
+			}
+		}
+
+		void AssertAreNotEqual (INativeObject [] expected, INativeObject [] actual, string msg)
+		{
+			if (expected == null && actual == null)
+				Assert.Fail ("Both are null. " + msg);
+			if (expected == null ^ actual == null)
+				return;
+			if (expected.Length != actual.Length)
+				return;
+			for (int i = 0; i < Math.Min (actual.Length, expected.Length); i++) {
+				if (expected [i].Handle != actual [i].Handle)
+					return;
+			}
+			Assert.Fail ("Both arrays are equal. " + msg);
+		}
+
+		[Test]
+		public unsafe void RefOutTest_INSCodingArray ()
+		{
+			IntPtr refValue = IntPtr.Zero;
+			IntPtr outValue = IntPtr.Zero;
+
+			using (var obj = new RefOutParametersSubclass ()) {
+				var sel = Selector.GetHandle ("testINSCodingArray:a:b:");
+				var dummyObj = new INSCoding [] { new NSString ("Dummy obj") };
+				var dummyArray = NSArray.FromNSObjects<INSCoding> (dummyObj);
+				INSCoding [] refObj = null;
+				INSCoding [] outObj = null;
+				TestMethod<INSCoding []> test = obj.TestINSCodingArray;
+				int action;
+
+				/// 1: set both to null
+				action = 1;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.IsNull (refObj, "NSCodingArray-1A-ref");
+				Assert.IsNull (outObj, "NSCodingArray-1A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.IsNull (refObj, "NSCodingArray-1M-ref");
+				Assert.IsNull (outObj, "NSCodingArray-1M-out");
+
+				// direct native
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "NSCodingArray-1DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSCodingArray-1DA-out");
+
+				// direct managed
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "NSCodingArray-1DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSCodingArray-1DM-out");
+
+				/// 2: verify that refValue points to something
+				action = 2;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				AssertAreEqual (dummyObj, refObj, "NSCodingArray-2A-ref");
+				Assert.AreSame (dummyObj, refObj, "NSCodingArray-2A-ref-same");
+				Assert.IsNull (outObj, "NSCodingArray-2A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				AssertAreEqual (dummyObj, refObj, "NSCodingArray-2M-ref");
+				Assert.AreSame (dummyObj, refObj, "NSCodingArray-2M-ref-same");
+				Assert.IsNull (outObj, "NSCodingArray-2M-out");
+
+				// direct native
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				AssertAreEqual (dummyObj, NSArray.ArrayFromHandle<INSCoding> (refValue), "NSCodingArray-2DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSCodingArray-2DA-out");
+
+				// direct managed
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				AssertAreEqual (dummyObj, NSArray.ArrayFromHandle<INSCoding> (refValue), "NSCodingArray-2DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSCodingArray-2DM-out");
+
+
+				/// 3 set both parameters to the same pointer of an NSCodingArray array
+				action = 3;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.AreNotSame (dummyObj, refObj, "NSCodingArray-3A-ref-same");
+				Assert.AreNotSame (dummyObj, outObj, "NSCodingArray-3A-ref-out");
+				AssertAreEqual (refObj, outObj, "NSCodingArray-3A-out-ref-eq");
+				Assert.AreNotSame (refObj, outObj, "NSCodingArray-3A-ref-out-not-safe");
+				Assert.That (refObj [0].GetType ().FullName, Is.StringContaining ("CodingWrapper"), "NSCodingArray-3A-ref-wrapper-type");
+				Assert.That (outObj [0].GetType ().FullName, Is.StringContaining ("CodingWrapper"), "NSCodingArray-3A-ref-wrapper-type");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.AreNotSame (dummyObj, refObj, "NSCodingArray-3M-ref-same");
+				Assert.AreNotSame (dummyObj, outObj, "NSCodingArray-3M-ref-out");
+				AssertAreEqual (refObj, outObj, "NSCodingArray-3M-ref-out-not-safe");
+				Assert.That (refObj [0], Is.TypeOf<NSString> (), "NSCodingArray-3M-ref-wrapper-type");
+				Assert.That (outObj [0], Is.TypeOf<NSString> (), "NSCodingArray-3M-ref-wrapper-type");
+
+				// direct native
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreNotSame (refValue, outValue, "NSCodingArray-3DA-out-ref-not-same");
+				AssertAreEqual (refObj, outObj, "NSCodingArray-3DA-out-ref-equal");
+				Assert.That (refObj [0], Is.TypeOf<NSString> (), "NSCodingArray-3DA-ref-wrapper-type");
+				Assert.That (outObj [0], Is.TypeOf<NSString> (), "NSCodingArray-3DA-ref-wrapper-type");
+
+				// direct managed
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreNotSame (refValue, outValue, "NSCodingArray-3DM-out-ref-not-same");
+				AssertAreEqual (refObj, outObj, "NSCodingArray-3DM-out-ref-equal");
+				Assert.That (refObj [0], Is.TypeOf<NSString> (), "NSCodingArray-3DM-ref-wrapper-type");
+				Assert.That (outObj [0], Is.TypeOf<NSString> (), "NSCodingArray-3DM-ref-wrapper-type");
+
+
+				/// 4 set both parameteres to different pointers of a NSCodingArray
+				action = 4;
+
+				// native
+				refObj = null; // set to null
+				outObj = null; // set to null
+				test (action << 0, ref refObj, out outObj);
+				Assert.IsNotNull (refObj, "NSCodingArray-4A-ref");
+				Assert.IsNotNull (outObj, "NSCodingArray-4A-out");
+				AssertAreNotEqual (refObj, outObj, "NSCodingArray-4A-ref-distinct");
+				Assert.That (refObj [0].GetType ().FullName, Is.StringContaining ("NSNumber").Or.StringContaining ("CodingWrapper"), "NSCodingArray-4A-ref-wrapper-type");
+				Assert.That (outObj [0].GetType ().FullName, Is.StringContaining ("NSNumber").Or.StringContaining ("CodingWrapper"), "NSCodingArray-4A-ref-wrapper-type");
+
+				// managed
+				refObj = null; // set to null
+				outObj = null; // set to null
+				test (action << 8, ref refObj, out outObj);
+				AssertAreNotEqual (refObj, outObj, "NSCodingArray-4M-ref-distinct");
+				Assert.That (refObj [0], Is.TypeOf<NSString> (), "NSCodingArray-4M-ref-wrapper-type");
+				Assert.That (outObj [0], Is.TypeOf<NSString> (), "NSCodingArray-4M-ref-wrapper-type");
+
+				// direct native
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				AssertAreNotEqual (NSArray.ArrayFromHandle<INSCoding> (refValue), NSArray.ArrayFromHandle<INSCoding> (outValue), "NSCodingArray-4DA-ref-distinct");
+				Assert.That (refObj [0], Is.TypeOf<NSString> (), "NSCodingArray-4DA-ref-wrapper-type");
+				Assert.That (outObj [0], Is.TypeOf<NSString> (), "NSCodingArray-4DA-ref-wrapper-type");
+
+				// direct managed
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				AssertAreNotEqual (NSArray.ArrayFromHandle<INSCoding> (refValue), NSArray.ArrayFromHandle<INSCoding> (outValue), "NSCodingArray-4DM-ref-distinct");
+				Assert.That (refObj [0], Is.TypeOf<NSString> (), "NSCodingArray-4DM-ref-wrapper-type");
+				Assert.That (outObj [0], Is.TypeOf<NSString> (), "NSCodingArray-4DM-ref-wrapper-type");
+			}
+		}
+
+		delegate void TestMethod<T> (int action, ref T refObj, out T outObj);
+
+		[Test]
+		public unsafe void RefOutTest_NSObjectArray ()
+		{
+			IntPtr refValue = IntPtr.Zero;
+			IntPtr outValue = IntPtr.Zero;
+
+			using (var obj = new RefOutParametersSubclass ()) {
+				var sel = Selector.GetHandle ("testNSObjectArray:a:b:");
+				var dummyObj = new NSObject [] { new NSString ("Dummy obj") };
+				var dummyArray = NSArray.FromNSObjects<NSObject> (dummyObj);
+				NSObject [] refObj = null;
+				NSObject [] outObj = null;
+				TestMethod<NSObject []> test = obj.TestNSObjectArray;
+				int action;
+
+				/// 1: set both to null
+				action = 1;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.IsNull (refObj, "NSObjectArray-1A-ref");
+				Assert.IsNull (outObj, "NSObjectArray-1A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.IsNull (refObj, "NSObjectArray-1M-ref");
+				Assert.IsNull (outObj, "NSObjectArray-1M-out");
+
+				// direct native
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "NSObjectArray-1DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSObjectArray-1DA-out");
+
+				// direct managed
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "NSObjectArray-1DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSObjectArray-1DM-out");
+
+				/// 2: verify that refValue points to something
+				action = 2;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				AssertAreEqual (dummyObj, refObj, "NSObjectArray-2A-ref");
+				Assert.AreSame (dummyObj, refObj, "NSObjectArray-2A-ref-same");
+				Assert.IsNull (outObj, "NSObjectArray-2A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				AssertAreEqual (dummyObj, refObj, "NSObjectArray-2M-ref");
+				Assert.AreSame (dummyObj, refObj, "NSObjectArray-2M-ref-same");
+				Assert.IsNull (outObj, "NSObjectArray-2M-out");
+
+				// direct native
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				AssertAreEqual (dummyObj, NSArray.ArrayFromHandle<NSObject> (refValue), "NSObjectArray-2DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSObjectArray-2DA-out");
+
+				// direct managed
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				AssertAreEqual (dummyObj, NSArray.ArrayFromHandle<NSObject> (refValue), "NSObjectArray-2DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSObjectArray-2DM-out");
+
+
+				/// 3 set both parameters to the same pointer of an NSObjectArray array
+				action = 3;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.AreNotSame (dummyObj, refObj, "NSObjectArray-3A-ref-same");
+				Assert.AreNotSame (dummyObj, outObj, "NSObjectArray-3A-ref-out");
+				AssertAreEqual (refObj, outObj, "NSObjectArray-3A-out-ref-eq");
+				Assert.AreNotSame (refObj, outObj, "NSObjectArray-3A-ref-out-not-safe");
+				Assert.That (refObj, Is.EquivalentTo (new NSObject [] { (NSString) "Hello", (NSString) "World" }), "NSObjectArray-3A-ref-equiv");
+				Assert.That (outObj, Is.EquivalentTo (new NSObject [] { (NSString) "Hello", (NSString) "World" }), "NSObjectArray-3A-obj-equiv");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.AreNotSame (dummyObj, refObj, "NSObjectArray-3M-ref-same");
+				Assert.AreNotSame (dummyObj, outObj, "NSObjectArray-3M-ref-out");
+				AssertAreEqual (refObj, outObj, "NSObjectArray-3M-ref-out-not-safe");
+				Assert.That (refObj, Is.EquivalentTo (new NSObject [] { (NSString) "Hello", (NSString) "World", (NSString) "from", (NSString) "managed" }), "NSObjectArray-3M-ref-equiv");
+				Assert.That (outObj, Is.EquivalentTo (new NSObject [] { (NSString) "Hello", (NSString) "World", (NSString) "from", (NSString) "managed" }), "NSObjectArray-3M-obj-equiv");
+
+				// direct native
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreNotEqual (refValue, outValue, "NSObjectArray-3DA-out-ref-not-same");
+				refObj = NSArray.ArrayFromHandle<NSObject> (refValue);
+				outObj = NSArray.ArrayFromHandle<NSObject> (outValue);
+				Assert.That (refObj, Is.EquivalentTo (new NSObject [] { (NSString) "Hello", (NSString) "World" }), "NSObjectArray-3DA-ref-equiv");
+				Assert.That (outObj, Is.EquivalentTo (new NSObject [] { (NSString) "Hello", (NSString) "World" }), "NSObjectArray-3DA-obj-equiv");
+
+				// direct managed
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreNotEqual (refValue, outValue, "NSObjectArray-3DM-out-ref-not-same");
+				refObj = NSArray.ArrayFromHandle<NSObject> (refValue);
+				outObj = NSArray.ArrayFromHandle<NSObject> (outValue);
+				Assert.That (refObj, Is.EquivalentTo (new NSObject [] { (NSString) "Hello", (NSString) "World", (NSString) "from", (NSString) "managed" }), "NSObjectArray-3DM-ref-equiv");
+				Assert.That (outObj, Is.EquivalentTo (new NSObject [] { (NSString) "Hello", (NSString) "World", (NSString) "from", (NSString) "managed" }), "NSObjectArray-3DM-obj-equiv");
+
+
+				/// 4 set both parameteres to different pointers of a NSObjectArray
+				action = 4;
+
+				// native
+				refObj = null; // set to null
+				outObj = null; // set to null
+				test (action << 0, ref refObj, out outObj);
+				Assert.That (refObj, Is.EquivalentTo (new NSObject [] { NSNumber.FromInt32 (3), NSNumber.FromInt32 (14) }), "NSObjectArray-4A-ref-equiv");
+				Assert.That (outObj, Is.EquivalentTo (new NSObject [] { (NSString) "Hello", (NSString) "Xamarin" }), "NSObjectArray-4A-obj-equiv");
+
+				// managed
+				refObj = null; // set to null
+				outObj = null; // set to null
+				test (action << 8, ref refObj, out outObj);
+				AssertAreNotEqual (refObj, outObj, "NSObjectArray-4M-ref-distinct");
+				Assert.That (refObj, Is.EquivalentTo (new NSObject [] { NSNumber.FromInt32 (2), NSNumber.FromInt32 (71) }), "NSObjectArray-4M-ref-equiv");
+				Assert.That (outObj, Is.EquivalentTo (new NSObject [] { (NSString) "Hello", (NSString) "Microsoft", (NSString) "from", (NSString) "managed" }), "NSObjectArray-4M-obj-equiv");
+
+				// direct native
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				refObj = NSArray.ArrayFromHandle<NSObject> (refValue);
+				outObj = NSArray.ArrayFromHandle<NSObject> (outValue);
+				Assert.That (refObj, Is.EquivalentTo (new NSObject [] { NSNumber.FromInt32 (3), NSNumber.FromInt32 (14) }), "NSObjectArray-4DA-ref-equiv");
+				Assert.That (outObj, Is.EquivalentTo (new NSObject [] { (NSString) "Hello", (NSString) "Xamarin" }), "NSObjectArray-4DA-obj-equiv");
+
+				// direct managed
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				refObj = NSArray.ArrayFromHandle<NSObject> (refValue);
+				outObj = NSArray.ArrayFromHandle<NSObject> (outValue);
+				Assert.That (refObj, Is.EquivalentTo (new NSObject [] { NSNumber.FromInt32 (2), NSNumber.FromInt32 (71) }), "NSObjectArray-4DM-ref-equiv");
+				Assert.That (outObj, Is.EquivalentTo (new NSObject [] { (NSString) "Hello", (NSString) "Microsoft", (NSString) "from", (NSString) "managed" }), "NSObjectArray-4DM-obj-equiv");
+			}
+		}
+
+		[Test]
+		public unsafe void RefOutTest_NSValueArray ()
+		{
+			IntPtr refValue = IntPtr.Zero;
+			IntPtr outValue = IntPtr.Zero;
+
+			using (var obj = new RefOutParametersSubclass ()) {
+				var sel = Selector.GetHandle ("testNSValueArray:a:b:");
+				var dummyObj = new NSValue [] { NSValue.FromMKCoordinate (new CLLocationCoordinate2D (3, 14)) };
+				var dummyArray = NSArray.FromNSObjects<NSValue> (dummyObj);
+				NSValue [] refObj = null;
+				NSValue [] outObj = null;
+				TestMethod<NSValue []> test = obj.TestNSValueArray;
+				int action;
+
+				/// 1: set both to null
+				action = 1;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.IsNull (refObj, "NSValueArray-1A-ref");
+				Assert.IsNull (outObj, "NSValueArray-1A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.IsNull (refObj, "NSValueArray-1M-ref");
+				Assert.IsNull (outObj, "NSValueArray-1M-out");
+
+				// direct native
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "NSValueArray-1DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSValueArray-1DA-out");
+
+				// direct managed
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "NSValueArray-1DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSValueArray-1DM-out");
+
+				/// 2: verify that refValue points to something
+				action = 2;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				AssertAreEqual (dummyObj, refObj, "NSValueArray-2A-ref");
+				Assert.AreSame (dummyObj, refObj, "NSValueArray-2A-ref-same");
+				Assert.IsNull (outObj, "NSValueArray-2A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				AssertAreEqual (dummyObj, refObj, "NSValueArray-2M-ref");
+				Assert.AreSame (dummyObj, refObj, "NSValueArray-2M-ref-same");
+				Assert.IsNull (outObj, "NSValueArray-2M-out");
+
+				// direct native
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				AssertAreEqual (dummyObj, NSArray.ArrayFromHandle<NSValue> (refValue), "NSValueArray-2DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSValueArray-2DA-out");
+
+				// direct managed
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				AssertAreEqual (dummyObj, NSArray.ArrayFromHandle<NSValue> (refValue), "NSValueArray-2DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSValueArray-2DM-out");
+
+
+				/// 3 set both parameters to the same pointer of an NSValueArray array
+				action = 3;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.AreNotSame (dummyObj, refObj, "NSValueArray-3A-ref-same");
+				Assert.AreNotSame (dummyObj, outObj, "NSValueArray-3A-ref-out");
+				AssertAreEqual (refObj, outObj, "NSValueArray-3A-out-ref-eq");
+				Assert.AreNotSame (refObj, outObj, "NSValueArray-3A-ref-out-not-safe");
+				Assert.That (refObj [0], Is.TypeOf<NSValue> (), "NSValueArray-3A-ref-wrapper-type");
+				Assert.That (outObj [0], Is.TypeOf<NSValue> (), "NSValueArray-3A-ref-wrapper-type");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.AreNotSame (dummyObj, refObj, "NSValueArray-3M-ref-same");
+				Assert.AreNotSame (dummyObj, outObj, "NSValueArray-3M-ref-out");
+				AssertAreEqual (refObj, outObj, "NSValueArray-3M-ref-out-not-safe");
+				Assert.That (refObj [0], Is.TypeOf<NSValue> (), "NSValueArray-3M-ref-wrapper-type");
+				Assert.That (outObj [0], Is.TypeOf<NSValue> (), "NSValueArray-3M-ref-wrapper-type");
+
+				// direct native
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreNotSame (refValue, outValue, "NSValueArray-3DA-out-ref-not-same");
+				AssertAreEqual (refObj, outObj, "NSValueArray-3DA-out-ref-equal");
+				Assert.That (refObj [0], Is.TypeOf<NSValue> (), "NSValueArray-3DA-ref-wrapper-type");
+				Assert.That (outObj [0], Is.TypeOf<NSValue> (), "NSValueArray-3DA-ref-wrapper-type");
+
+				// direct managed
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreNotSame (refValue, outValue, "NSValueArray-3DM-out-ref-not-same");
+				AssertAreEqual (refObj, outObj, "NSValueArray-3DM-out-ref-equal");
+				Assert.That (refObj [0], Is.TypeOf<NSValue> (), "NSValueArray-3DM-ref-wrapper-type");
+				Assert.That (outObj [0], Is.TypeOf<NSValue> (), "NSValueArray-3DM-ref-wrapper-type");
+
+
+				/// 4 set both parameteres to different pointers of a NSValueArray
+				action = 4;
+
+				// native
+				refObj = null; // set to null
+				outObj = null; // set to null
+				test (action << 0, ref refObj, out outObj);
+				Assert.IsNotNull (refObj, "NSValueArray-4A-ref");
+				Assert.IsNotNull (outObj, "NSValueArray-4A-out");
+				AssertAreNotEqual (refObj, outObj, "NSValueArray-4A-ref-distinct");
+				Assert.That (refObj [0], Is.TypeOf<NSValue> (), "NSValueArray-4A-ref-wrapper-type");
+				Assert.That (outObj [0], Is.TypeOf<NSValue> (), "NSValueArray-4A-ref-wrapper-type");
+
+				// managed
+				refObj = null; // set to null
+				outObj = null; // set to null
+				test (action << 8, ref refObj, out outObj);
+				AssertAreNotEqual (refObj, outObj, "NSValueArray-4M-ref-distinct");
+				Assert.That (refObj [0], Is.TypeOf<NSValue> (), "NSValueArray-4M-ref-wrapper-type");
+				Assert.That (outObj [0], Is.TypeOf<NSValue> (), "NSValueArray-4M-ref-wrapper-type");
+
+				// direct native
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				AssertAreNotEqual (NSArray.ArrayFromHandle<NSValue> (refValue), NSArray.ArrayFromHandle<NSValue> (outValue), "NSValueArray-4DA-ref-distinct");
+				Assert.That (refObj [0], Is.TypeOf<NSValue> (), "NSValueArray-4DA-ref-wrapper-type");
+				Assert.That (outObj [0], Is.TypeOf<NSValue> (), "NSValueArray-4DA-ref-wrapper-type");
+
+				// direct managed
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				AssertAreNotEqual (NSArray.ArrayFromHandle<NSValue> (refValue), NSArray.ArrayFromHandle<NSValue> (outValue), "NSValueArray-4DM-ref-distinct");
+				Assert.That (refObj [0], Is.TypeOf<NSValue> (), "NSValueArray-4DM-ref-wrapper-type");
+				Assert.That (outObj [0], Is.TypeOf<NSValue> (), "NSValueArray-4DM-ref-wrapper-type");
+			}
+		}
+
+		[Test]
+		public unsafe void RefOutTest_StringArray ()
+		{
+			IntPtr refValue = IntPtr.Zero;
+			IntPtr outValue = IntPtr.Zero;
+
+			using (var obj = new RefOutParametersSubclass ()) {
+				var sel = Selector.GetHandle ("testStringArray:a:b:");
+				var dummyObj = new string [] { "Hello" };
+				var dummyArray = NSArray.FromStrings (dummyObj);
+				string [] refObj = null;
+				string [] outObj = null;
+				TestMethod<string []> test = obj.TestStringArray;
+				int action;
+
+				/// 1: set both to null
+				action = 1;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.IsNull (refObj, "NSStringArray-1A-ref");
+				Assert.IsNull (outObj, "NSStringArray-1A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.IsNull (refObj, "NSStringArray-1M-ref");
+				Assert.IsNull (outObj, "NSStringArray-1M-out");
+
+				// direct native
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "NSStringArray-1DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSStringArray-1DA-out");
+
+				// direct managed
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "NSStringArray-1DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSStringArray-1DM-out");
+
+				/// 2: verify that refValue points to something
+				action = 2;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.That (dummyObj, Is.EquivalentTo (refObj), "NSStringArray-2A-ref");
+				Assert.AreSame (dummyObj, refObj, "NSStringArray-2A-ref-same");
+				Assert.IsNull (outObj, "NSStringArray-2A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.That (dummyObj, Is.EquivalentTo (refObj), "NSStringArray-2M-ref");
+				Assert.AreSame (dummyObj, refObj, "NSStringArray-2M-ref-same");
+				Assert.IsNull (outObj, "NSStringArray-2M-out");
+
+				// direct native
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.That (dummyObj, Is.EquivalentTo (NSArray.StringArrayFromHandle (refValue)), "NSStringArray-2DA-ref");
+				Assert.AreEqual (dummyArray.Handle, refValue, "NSStringArray-2DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSStringArray-2DA-out");
+
+				// direct managed
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.That (dummyObj, Is.EquivalentTo (NSArray.StringArrayFromHandle (refValue)), "NSStringArray-2DM-ref");
+				Assert.AreEqual (dummyArray.Handle, refValue, "NSStringArray-2DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSStringArray-2DM-out");
+
+
+				/// 3 set both parameters to the same pointer of an NSStringArray array
+				action = 3;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.That (outObj, Is.EquivalentTo (new string [] { "Hello", "World" }), "NSStringArray-3A-out-contents");
+				Assert.That (refObj, Is.EquivalentTo (new string [] { "Hello", "World" }), "NSStringArray-3A-ref-contents");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.That (outObj, Is.EquivalentTo (new string [] { "Hello", "Managed", "World" }), "NSStringArray-3M-out-contents");
+				Assert.That (refObj, Is.EquivalentTo (new string [] { "Hello", "Managed", "World" }), "NSStringArray-3M-ref-contents");
+
+				// direct native
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				refObj = NSArray.StringArrayFromHandle (refValue);
+				outObj = NSArray.StringArrayFromHandle (outValue);
+				Assert.That (outObj, Is.EquivalentTo (new string [] { "Hello", "World" }), "NSStringArray-3DA-out-contents");
+				Assert.That (refObj, Is.EquivalentTo (new string [] { "Hello", "World" }), "NSStringArray-3DA-ref-contents");
+
+				// direct managed
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				refObj = NSArray.StringArrayFromHandle (refValue);
+				outObj = NSArray.StringArrayFromHandle (outValue);
+				Assert.That (outObj, Is.EquivalentTo (new string [] { "Hello", "Managed", "World" }), "NSStringArray-3DM-out-contents");
+				Assert.That (refObj, Is.EquivalentTo (new string [] { "Hello", "Managed", "World" }), "NSStringArray-3DM-ref-contents");
+
+
+				/// 4 set both parameteres to different pointers of a NSStringArray
+				action = 4;
+
+				// native
+				refObj = null; // set to null
+				outObj = null; // set to null
+				test (action << 0, ref refObj, out outObj);
+				Assert.IsNotNull (refObj, "NSStringArray-4A-ref");
+				Assert.IsNotNull (outObj, "NSStringArray-4A-out");
+				Assert.That (refObj, Is.EquivalentTo (new string [] { "Hello", "Microsoft" }), "NSStringArray-4A-ref-equiv");
+				Assert.That (outObj, Is.EquivalentTo (new string [] { "Hello", "Xamarin" }), "NSStringArray-4A-obj-equiv");
+
+				// managed
+				refObj = null; // set to null
+				outObj = null; // set to null
+				test (action << 8, ref refObj, out outObj);
+				Assert.That (refObj, Is.EquivalentTo (new string [] { "Hello", "Microsoft", "from", "managed" }), "NSStringArray-4M-ref-equiv");
+				Assert.That (outObj, Is.EquivalentTo (new string [] { "Hello", "Xamarin", "from", "managed" }), "NSStringArray-4M-obj-equiv");
+
+				// direct native
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				refObj = NSArray.StringArrayFromHandle (refValue);
+				outObj = NSArray.StringArrayFromHandle (outValue);
+				Assert.That (refObj, Is.EquivalentTo (new string [] { "Hello", "Microsoft" }), "NSStringArray-4DA-ref-equiv");
+				Assert.That (outObj, Is.EquivalentTo (new string [] { "Hello", "Xamarin" }), "NSStringArray-4DA-obj-equiv");
+
+				// direct managed
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				refObj = NSArray.StringArrayFromHandle (refValue);
+				outObj = NSArray.StringArrayFromHandle (outValue);
+				Assert.That (refObj, Is.EquivalentTo (new string [] { "Hello", "Microsoft", "from", "managed" }), "NSStringArray-4DM-ref-equiv");
+				Assert.That (outObj, Is.EquivalentTo (new string [] { "Hello", "Xamarin", "from", "managed" }), "NSStringArray-4DM-obj-equiv");
+
+				/// 5 change a value in the ref input
+				/// Here we verify that changing an element in the input array is not copied back to the ref argument.
+				/// If an element needs to be changed, a new array must be created, and elements copied over, including the modified one.
+				action = 5;
+
+				// Only managed calls can be done because we need to use an NSMutableArray, and the binding code creates NSArrays when marshalling to native code.
+				Func<string [], NSMutableArray> fromStrings = (arr) => {
+				 	var rv = new NSMutableArray ((nuint) arr.Length);
+					for (int i = 0; i < arr.Length; i++)
+						rv.Add ((NSString) arr [i]);
+					return rv;
+				};
+
+				// managed
+				refObj = new string [] { "Hello", "World" };
+				test (action << 8, ref refObj, out var _);
+				// Here the array changed, because we didn't go through any binding code at all
+				Assert.That (refObj, Is.EquivalentTo (new string [] { "Hello", "Universe" }), "NSStringArray-5M-ref-equiv");
+
+				// direct managed
+				refObj = new string [] { "Hello", "World" };
+				using (var arr = fromStrings (refObj)) {
+					refValue = arr.Handle;
+					Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out var _);
+					refObj = NSArray.StringArrayFromHandle (refValue);
+					Assert.That (refObj, Is.EquivalentTo (new string [] { "Hello", "World" }), "NSStringArray-5DM-ref-equiv");
+				}
+			}
+		}
+
+		[Test]
+		public unsafe void RefOutTest_ClassArray ()
+		{
+			IntPtr refValue = IntPtr.Zero;
+			IntPtr outValue = IntPtr.Zero;
+
+			using (var obj = new RefOutParametersSubclass ()) {
+				var sel = Selector.GetHandle ("testClassArray:a:b:");
+				var dummyObj = new Class [] { new Class (typeof (NSObject)) };
+				var dummyArray = NSArray.FromIntPtrs (new IntPtr [] { Class.GetHandle (typeof (NSObject)) });
+				Class [] refObj = null;
+				Class [] outObj = null;
+				TestMethod<Class []> test = obj.TestClassArray;
+				int action;
+
+				/// 1: set both to null
+				action = 1;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.IsNull (refObj, "NSClassArray-1A-ref");
+				Assert.IsNull (outObj, "NSClassArray-1A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.IsNull (refObj, "NSClassArray-1M-ref");
+				Assert.IsNull (outObj, "NSClassArray-1M-out");
+
+				// direct native
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "NSClassArray-1DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSClassArray-1DA-out");
+
+				// direct managed
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.AreEqual (IntPtr.Zero, refValue, "NSClassArray-1DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSClassArray-1DM-out");
+
+				/// 2: verify that refValue points to something
+				action = 2;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.That (dummyObj, Is.EquivalentTo (refObj), "NSClassArray-2A-ref");
+				Assert.AreSame (dummyObj, refObj, "NSClassArray-2A-ref-same");
+				Assert.IsNull (outObj, "NSClassArray-2A-out");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.That (dummyObj, Is.EquivalentTo (refObj), "NSClassArray-2M-ref");
+				Assert.AreSame (dummyObj, refObj, "NSClassArray-2M-ref-same");
+				Assert.IsNull (outObj, "NSClassArray-2M-out");
+
+				// direct native
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				Assert.That (dummyObj, Is.EquivalentTo (NSArray.ArrayFromHandle<Class> (refValue)), "NSClassArray-2DA-ref");
+				Assert.AreEqual (dummyArray.Handle, refValue, "NSClassArray-2DA-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSClassArray-2DA-out");
+
+				// direct managed
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				Assert.That (dummyObj, Is.EquivalentTo (NSArray.ArrayFromHandle<Class> (refValue)), "NSClassArray-2DM-ref");
+				Assert.AreEqual (dummyArray.Handle, refValue, "NSClassArray-2DM-ref");
+				Assert.AreEqual (IntPtr.Zero, outValue, "NSClassArray-2DM-out");
+
+
+				/// 3 set both parameters to the same pointer of an Class array
+				action = 3;
+
+				// native
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 0, ref refObj, out outObj);
+				Assert.That (outObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSString)), new Class (typeof (NSDate)) }), "NSClassArray-3A-out-contents");
+				Assert.That (refObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSString)), new Class (typeof (NSDate)) }), "NSClassArray-3A-ref-contents");
+
+				// managed
+				refObj = dummyObj; // set to non-null
+				outObj = dummyObj; // set to non-null
+				test (action << 8, ref refObj, out outObj);
+				Assert.That (outObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSSet)), new Class (typeof (NSDictionary)) }), "NSClassArray-3M-out-contents");
+				Assert.That (refObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSSet)), new Class (typeof (NSDictionary)) }), "NSClassArray-3M-ref-contents");
+
+				// direct native
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				refObj = NSArray.ArrayFromHandle<Class> (refValue);
+				outObj = NSArray.ArrayFromHandle<Class> (outValue);
+				Assert.That (outObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSString)), new Class (typeof (NSDate)) }), "NSClassArray-3DA-out-contents");
+				Assert.That (refObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSString)), new Class (typeof (NSDate)) }), "NSClassArray-3DA-ref-contents");
+
+				// direct managed
+				refValue = dummyArray.Handle; // set to non-null
+				outValue = dummyArray.Handle; // set to non-null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				refObj = NSArray.ArrayFromHandle<Class> (refValue);
+				outObj = NSArray.ArrayFromHandle<Class> (outValue);
+				Assert.That (outObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSSet)), new Class (typeof (NSDictionary)) }), "NSClassArray-3DM-out-contents");
+				Assert.That (refObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSSet)), new Class (typeof (NSDictionary)) }), "NSClassArray-3DM-ref-contents");
+
+
+				/// 4 set both parameteres to different pointers of a NSClassArray
+				action = 4;
+
+				// native
+				refObj = null; // set to null
+				outObj = null; // set to null
+				test (action << 0, ref refObj, out outObj);
+				Assert.IsNotNull (refObj, "NSClassArray-4A-ref");
+				Assert.IsNotNull (outObj, "NSClassArray-4A-out");
+				Assert.That (refObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSString)), new Class (typeof (NSValue)) }), "NSClassArray-4A-ref-equiv");
+				Assert.That (outObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSData)), new Class (typeof (NSDate)) }), "NSClassArray-4A-obj-equiv");
+
+				// managed
+				refObj = null; // set to null
+				outObj = null; // set to null
+				test (action << 8, ref refObj, out outObj);
+				Assert.That (refObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSSet)), new Class (typeof (NSMutableSet)) }), "NSClassArray-4M-ref-equiv");
+				Assert.That (outObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSDictionary)), new Class (typeof (NSMutableDictionary)) }), "NSClassArray-4M-obj-equiv");
+
+				// direct native
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 0, ref refValue, out outValue);
+				refObj = NSArray.ArrayFromHandle<Class> (refValue);
+				outObj = NSArray.ArrayFromHandle<Class> (outValue);
+				Assert.That (refObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSString)), new Class (typeof (NSValue)) }), "NSClassArray-4DA-ref-equiv");
+				Assert.That (outObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSData)), new Class (typeof (NSDate)) }), "NSClassArray-4DA-obj-equiv");
+
+				// direct managed
+				refValue = IntPtr.Zero; // set to null
+				outValue = IntPtr.Zero; // set to null
+				Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out outValue);
+				refObj = NSArray.ArrayFromHandle<Class> (refValue);
+				outObj = NSArray.ArrayFromHandle<Class> (outValue);
+				Assert.That (refObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSSet)), new Class (typeof (NSMutableSet)) }), "NSClassArray-4DM-ref-equiv");
+				Assert.That (outObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSDictionary)), new Class (typeof (NSMutableDictionary)) }), "NSClassArray-4DM-obj-equiv");
+
+				/// 5 change a value in the ref input
+				/// Here we verify that changing an element in the input array is not copied back to the ref argument.
+				/// If an element needs to be changed, a new array must be created, and elements copied over, including the modified one.
+				action = 5;
+
+				// Only managed calls can be done because we need to use an NSMutableArray, and the binding code creates NSArrays when marshalling to native code.
+				Func<Class [], NSMutableArray> fromValues = (arr) => {
+					return new NSMutableArray<Class> (arr);
+				};
+
+				// managed
+				refObj = new Class [] { new Class (typeof (NSObject)), new Class (typeof (NSObject)) };
+				test (action << 8, ref refObj, out var _);
+				// Here the array changed, because we didn't go through any binding code at all
+				Assert.That (refObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSMutableString)), new Class (typeof (NSObject)) }), "NSClassArray-5M-ref-equiv");
+
+				// direct managed
+				refObj = new Class [] { new Class (typeof (NSObject)), new Class (typeof (NSObject)) };
+				using (var arr = fromValues (refObj)) {
+					refValue = arr.Handle;
+					Messaging.void_objc_msgSend_int_IntPtr_IntPtr (obj.Handle, sel, action << 8, ref refValue, out var _);
+					refObj = NSArray.ArrayFromHandle<Class> (refValue);
+					Assert.That (refObj, Is.EquivalentTo (new Class [] { new Class (typeof (NSObject)), new Class (typeof (NSObject)) }), "NSClassArray-5DM-ref-equiv");
+				}
+			}
+		}
+
+		class RefOutParametersSubclass : BI1064.RefOutParameters
+		{
+			public override void TestCFBundle (int action, ref CFBundle refValue, out CFBundle outValue)
+			{
+				var managedAction = (action & 0xFF00) >> 8;
+				switch (managedAction) {
+				case 0: // call native
+					base.TestCFBundle (action, ref refValue, out outValue);
+					break;
+				case 1: // set both to null
+					refValue = null;
+					outValue = null;
+					break;
+				case 2: // verify that refValue points to something
+					Assert.IsNotNull (refValue, "2");
+					outValue = null; // compiler-enforced
+					break;
+				case 3: // set both parameteres to the same pointer of a CFBundle
+					var obj = global::CoreFoundation.CFBundle.GetMain ();
+					refValue = obj;
+					outValue = obj;
+					break;
+				case 4: // set both parameteres to different pointers of a CFBundle
+					refValue = global::CoreFoundation.CFBundle.GetAll () [0];
+					outValue = global::CoreFoundation.CFBundle.GetAll () [1];
+					break;
+				default:
+					throw new NotImplementedException ();
+				}
+			}
+
+			public override void TestINSCoding (int action, ref INSCoding refValue, out INSCoding outValue)
+			{
+				var managedAction = (action & 0xFF00) >> 8;
+				switch (managedAction) {
+				case 0: // call native
+					base.TestINSCoding (action, ref refValue, out outValue);
+					break;
+				case 1: // set both to null
+					refValue = null;
+					outValue = null;
+					break;
+				case 2: // verify that refValue points to something
+					Assert.IsNotNull (refValue, "2");
+					outValue = null; // compiler-enforced
+					break;
+				case 3: // set both parameteres to the same pointer of an NSString
+					var obj = new NSString ("A managed string");
+					refValue = obj;
+					outValue = obj;
+					break;
+				case 4: // set both parameteres to different pointers of an NSString
+					refValue = new NSString ("A managed ref string");
+					outValue = new NSString ("A managed out string");
+					break;
+				default:
+					throw new NotImplementedException ();
+				}
+			}
+
+			public override void TestNSObject (int action, ref NSObject refValue, out NSObject outValue)
+			{
+				var managedAction = (action & 0xFF00) >> 8;
+				switch (managedAction) {
+				case 0: // call native
+					base.TestNSObject (action, ref refValue, out outValue);
+					break;
+				case 1: // set both to null
+					refValue = null;
+					outValue = null;
+					break;
+				case 2: // verify that refValue points to something
+					Assert.IsNotNull (refValue, "2");
+					outValue = null; // compiler-enforced
+					break;
+				case 3: // set both parameteres to the same pointer of an NSObject
+					var obj = new NSObject ();
+					refValue = obj;
+					outValue = obj;
+					break;
+				case 4: // set both parameteres to different objects
+					refValue = new NSObject ();
+					outValue = new NSObject ();
+					break;
+				default:
+					throw new NotImplementedException ();
+				}
+			}
+
+			public override void TestValue (int action, ref NSValue refValue, out NSValue outValue)
+			{
+				var managedAction = (action & 0xFF00) >> 8;
+				switch (managedAction) {
+				case 0: // call native
+					base.TestValue (action, ref refValue, out outValue);
+					break;
+				case 1: // set both to null
+					refValue = null;
+					outValue = null;
+					break;
+				case 2: // verify that refValue points to something
+					Assert.IsNotNull (refValue, "2");
+					outValue = null; // compiler-enforced
+					break;
+				case 3: // set both parameteres to the same pointer of an NSObject
+					var obj = NSValue.FromMKCoordinate (new CLLocationCoordinate2D (3, 14));
+					refValue = obj;
+					outValue = obj;
+					break;
+				case 4: // set both parameteres to different objects
+					refValue = NSValue.FromMKCoordinate (new CLLocationCoordinate2D (3, 14));
+					outValue = NSValue.FromMKCoordinate (new CLLocationCoordinate2D (2, 71)); 
+					break;
+				default:
+					throw new NotImplementedException ();
+				}
+			}
+
+			public override void TestString (int action, ref string refValue, out string outValue)
+			{
+				var managedAction = (action & 0xFF00) >> 8;
+				switch (managedAction) {
+				case 0: // call native
+					base.TestString (action, ref refValue, out outValue);
+					break;
+				case 1: // set both to null
+					refValue = null;
+					outValue = null;
+					break;
+				case 2: // verify that refValue points to something
+					Assert.IsNotNull (refValue, "2");
+					outValue = null; // compiler-enforced
+					break;
+				case 3: // set both parameteres to the same pointer of an NSObject
+					var obj = "A constant managed string";
+					refValue = obj;
+					outValue = obj;
+					break;
+				case 4: // set both parameteres to different objects
+					refValue = "Hello Xamarin from managed";
+					outValue = "Hello Microsoft from managed";
+					break;
+				default:
+					throw new NotImplementedException ();
+				}
+			}
+
+			public override void TestInt (int action, ref int refValue, out int outValue)
+			{
+				var managedAction = (action & 0xFF00) >> 8;
+				switch (managedAction) {
+				case 0: // call native
+					base.TestInt (action, ref refValue, out outValue);
+					break;
+				case 1: // set both to null
+					refValue = 0;
+					outValue = 0;
+					break;
+				case 3: // set both parameteres to the same value
+					refValue = 314159;
+					outValue = 314159;
+					break;
+				case 4: // set both parameteres to different values
+					refValue = 3141592;
+					outValue = 2718282;
+					break;
+				default:
+					throw new NotImplementedException ();
+				}
+			}
+
+			public override void TestSelector (int action, ref Selector refValue, out Selector outValue)
+			{
+				var managedAction = (action & 0xFF00) >> 8;
+				switch (managedAction) {
+				case 0: // call native
+					base.TestSelector (action, ref refValue, out outValue);
+					break;
+				case 1: // set both to null
+					refValue = null;
+					outValue = null;
+					break;
+				case 2: // verify that refValue points to something
+					Assert.IsNotNull (refValue, "TestSelector: 2");
+					outValue = null;
+					break;
+				case 3: // set both parameteres to the same value
+					var obj = new Selector ("testManagedSelector");
+					refValue = obj;
+					outValue = obj;
+					break;
+				case 4: // set both parameteres to different values
+					refValue = new Selector ("testManagedSelectorA");
+					outValue = new Selector ("testManagedSelectorB");
+					break;
+				default:
+					throw new NotImplementedException ();
+				}
+			}
+
+			public override void TestClass (int action, ref Class refValue, out Class outValue)
+			{
+				var managedAction = (action & 0xFF00) >> 8;
+				switch (managedAction) {
+				case 0: // call native
+					base.TestClass (action, ref refValue, out outValue);
+					break;
+				case 1: // set both to null
+					refValue = null;
+					outValue = null;
+					break;
+				case 2: // verify that refValue points to something
+					Assert.IsNotNull (refValue);
+					outValue = null;
+					break;
+				case 3: // set both parameteres to the same value
+					var obj = new Class (typeof (SomeConsumer));
+					refValue = obj;
+					outValue = obj;
+					break;
+				case 4: // set both parameteres to different values
+					refValue = new Class (typeof (RefOutParametersSubclass));
+					outValue = new Class (typeof (BI1064.RefOutParameters));
+					break;
+				default:
+					throw new NotImplementedException ();
+				}
+			}
+
+			public override void TestINSCodingArray (int action, ref INSCoding [] refValue, out INSCoding [] outValue)
+			{
+				var managedAction = (action & 0xFF00) >> 8;
+				switch (managedAction) {
+				case 0: // call native
+					base.TestINSCodingArray (action, ref refValue, out outValue);
+					break;
+				case 1: // set both to null
+					refValue = null;
+					outValue = null;
+					break;
+				case 2: // verify that refValue points to something
+					Assert.IsNotNull (refValue, "2");
+					outValue = null; // compiler-enforced
+					break;
+				case 3: // set both parameteres to the same pointer of an NSObject
+					var obj = new INSCoding [] { (NSString) "A constant managed string" };
+					refValue = obj;
+					outValue = obj;
+					break;
+				case 4: // set both parameteres to different objects
+					refValue = new INSCoding [] { (NSString) "Hello Xamarin from managed" };
+					outValue = new INSCoding [] { (NSString) "Hello Microsoft from managed" };
+					break;
+				default:
+					throw new NotImplementedException ();
+				}
+			}
+
+			public override void TestNSObjectArray (int action, ref NSObject [] refValue, out NSObject [] outValue)
+			{
+				var managedAction = (action & 0xFF00) >> 8;
+				switch (managedAction) {
+				case 0: // call native
+					base.TestNSObjectArray (action, ref refValue, out outValue);
+					break;
+				case 1: // set both to null
+					refValue = null;
+					outValue = null;
+					break;
+				case 2: // verify that refValue points to something
+					Assert.IsNotNull (refValue, "2");
+					outValue = null; // compiler-enforced
+					break;
+				case 3: // set both parameteres to the same pointer of an NSObject
+					var obj = new NSObject [] { (NSString) "Hello", (NSString) "World", (NSString) "from", (NSString) "managed" };
+					refValue = obj;
+					outValue = obj;
+					break;
+				case 4: // set both parameteres to different objects
+					refValue = new NSObject [] { NSNumber.FromInt32 (2), NSNumber.FromInt32 (71) };
+					outValue = new NSObject [] { (NSString) "Hello", (NSString) "Microsoft", (NSString) "from", (NSString) "managed" };
+					break;
+				default:
+					throw new NotImplementedException ();
+				}
+			}
+
+			public override void TestNSValueArray (int action, ref NSValue [] refValue, out NSValue [] outValue)
+			{
+				var managedAction = (action & 0xFF00) >> 8;
+				switch (managedAction) {
+				case 0: // call native
+					base.TestNSValueArray (action, ref refValue, out outValue);
+					break;
+				case 1: // set both to null
+					refValue = null;
+					outValue = null;
+					break;
+				case 2: // verify that refValue points to something
+					Assert.IsNotNull (refValue, "2");
+					outValue = null; // compiler-enforced
+					break;
+				case 3: // set both parameteres to the same pointer of an NSObject
+					var obj = new NSValue [] { NSValue.FromMKCoordinate (new CLLocationCoordinate2D (3, 14)), NSValue.FromMKCoordinate (new CLLocationCoordinate2D (2, 71))  };
+					refValue = obj;
+					outValue = obj;
+					break;
+				case 4: // set both parameteres to different objects
+					refValue = new NSValue [] { NSValue.FromMKCoordinate (new CLLocationCoordinate2D (3, 14)), NSValue.FromMKCoordinate (new CLLocationCoordinate2D (15, 92)) };
+					outValue = new NSValue [] { NSValue.FromMKCoordinate (new CLLocationCoordinate2D (2, 71)), NSValue.FromMKCoordinate (new CLLocationCoordinate2D (82, 82)) };
+					break;
+				default:
+					throw new NotImplementedException ();
+				}
+			}
+
+			public override void TestStringArray (int action, ref string [] refValue, out string [] outValue)
+			{
+				var managedAction = (action & 0xFF00) >> 8;
+				switch (managedAction) {
+				case 0: // call native
+					base.TestStringArray (action, ref refValue, out outValue);
+					break;
+				case 1: // set both to null
+					refValue = null;
+					outValue = null;
+					break;
+				case 2: // verify that refValue points to something
+					Assert.IsNotNull (refValue, "2");
+					outValue = null; // compiler-enforced
+					break;
+				case 3: // set both parameteres to the same pointer of an NSObject
+					var obj = new string [] { "Hello", "Managed", "World" };
+					refValue = obj;
+					outValue = obj;
+					break;
+				case 4: // set both parameteres to different objects
+					refValue = new string [] { "Hello", "Microsoft", "from", "managed" };
+					outValue = new string [] { "Hello", "Xamarin", "from", "managed" };
+					break;
+				case 5: // change a value in the ref input
+					refValue [1] = "Universe";
+					outValue = null;
+					break;
+				default:
+					throw new NotImplementedException ();
+				}
+			}
+				
+			public override void TestClassArray (int action, ref Class [] refValue, out Class [] outValue)
+			{
+				var managedAction = (action & 0xFF00) >> 8;
+				switch (managedAction) {
+				case 0: // call native
+					base.TestClassArray (action, ref refValue, out outValue);
+					break;
+				case 1: // set both to null
+					refValue = null;
+					outValue = null;
+					break;
+				case 2: // verify that refValue points to something
+					Assert.IsNotNull (refValue, "2");
+					outValue = null; // compiler-enforced
+					break;
+				case 3: // set both parameteres to the same pointer of an NSObject
+					var obj = new Class [] { new Class (typeof (NSSet)), new Class (typeof (NSDictionary)) };
+					refValue = obj;
+					outValue = obj;
+					break;
+				case 4: // set both parameteres to different objects
+					refValue = new Class [] { new Class (typeof (NSSet)), new Class (typeof (NSMutableSet)) };
+					outValue = new Class [] { new Class (typeof (NSDictionary)), new Class (typeof (NSMutableDictionary)) };
+					break;
+				case 5: // change a value in the ref input
+					refValue [1] = new Class (typeof (NSMutableString));
+					outValue = null;
+					break;
+				default:
+					throw new NotImplementedException ();
+				}
+			}
+
 		}
 	}
 

--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -624,6 +624,48 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 		}
 
+#if DYNAMIC_REGISTRAR
+		[Test]
+		public void MX8029_b ()
+		{
+			try {
+				using (var arr = new NSArray ()) {
+					Messaging.void_objc_msgSend_IntPtr (Class.GetHandle (typeof (Dummy)), Selector.GetHandle ("setIntArray:"), arr.Handle);
+					Assert.Fail ("An exception should have been thrown");
+				}
+			} catch (RuntimeException re) {
+				Assert.AreEqual (8029, re.Code, "Code");
+				Assert.AreEqual (@"Unable to marshal the array parameter #1 whose managed type is 'System.Int32[]' to managed.
+Additional information:
+	Selector: setIntArray:
+	Method: MonoTouchFixtures.ObjCRuntime.RuntimeTest/Dummy:SetIntArray (int[])
+", re.Message, "Message");
+				var inner = (RuntimeException)re.InnerException;
+				Assert.AreEqual (8031, inner.Code, "Inner Code");
+				Assert.AreEqual ("Unable to convert from an NSArray to a managed array of System.Int32.", inner.Message, "Inner Message");
+			}
+		}
+
+		[Test]
+		public void MX8033 ()
+		{
+			try {
+				Messaging.IntPtr_objc_msgSend (Class.GetHandle (typeof (Dummy)), Selector.GetHandle ("intArray"));
+				Assert.Fail ("An exception should have been thrown");
+			} catch (RuntimeException re) {
+				Assert.AreEqual (8033, re.Code, "Code");
+				Assert.AreEqual (@"Unable to marshal the return value of type 'System.Int32[]' to Objective-C.
+Additional information:
+	Selector: intArray
+	Method: MonoTouchFixtures.ObjCRuntime.RuntimeTest/Dummy:GetIntArray ()
+", re.Message, "Message");
+				var inner = (RuntimeException) re.InnerException;
+				Assert.AreEqual (8032, inner.Code, "Inner Code");
+				Assert.AreEqual ("Unable to convert from a managed array of System.Int32 to an NSArray.", inner.Message, "Inner Message");
+			}
+		}
+#endif
+
 		// does not have an IntPtr constructor
 		class Dummy : NSObject {
 			[Export ("initWithFoo:")]
@@ -641,6 +683,21 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			public static void DoSomethingElse (Dummy dummy)
 			{
 			}
+
+#if DYNAMIC_REGISTRAR
+			// This function makes the static registrar show an error, so it's only built when using the dynamic registrar.
+			[Export ("intArray")]
+			static int[] GetIntArray ()
+			{
+				return new int [] { };
+			}
+			// This function makes the static registrar show an error, so it's only built when using the dynamic registrar.
+			[Export ("setIntArray:")]
+			static void SetIntArray (int[] array)
+			{
+				Assert.Fail ("This method should never be called.");
+			}
+#endif
 		} 
 	}
 }

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -21,7 +21,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhoneSimulator\$(Configuration)-unified</OutputPath>
-    <DefineConstants>DEBUG;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>DEBUG;DYNAMIC_REGISTRAR;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>0</WarningLevel>
     <MtouchDebug>True</MtouchDebug>
@@ -36,7 +36,7 @@
     <DebugType>none</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhoneSimulator\$(Configuration)-unified</OutputPath>
-    <DefineConstants>MONOTOUCH;;$(DefineConstants)</DefineConstants>
+    <DefineConstants>MONOTOUCH;DYNAMIC_REGISTRAR;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <MtouchLink>None</MtouchLink>

--- a/tests/mtouch/RegistrarTest.cs
+++ b/tests/mtouch/RegistrarTest.cs
@@ -146,6 +146,45 @@ class DateMembers : NSObject {
 		}
 
 		[Test]
+		public void MT4111 ()
+		{
+			var code = @"
+class DateMembers : NSObject {
+	[Export (""F1:"")]
+	void F1 (int[] a) {}
+
+	[Export (""F2"")]
+	int[] F2 () { throw new Exception (); }
+
+	[Export (""F3:"")]
+	void F3 (ref int[] d) {}
+
+	[Export (""F4"")]
+	int[] F4 { get; set; }
+
+	[Export (""F5:"")]
+	void F5 (out int[] d) { throw new Exception (); }
+}
+";
+
+			using (var mtouch = new MTouchTool ()) {
+				mtouch.CreateTemporaryCacheDirectory ();
+				mtouch.CreateTemporaryApp (extraCode: code, usings: "using Foundation; using System;", extraArg: "/debug:full");
+				mtouch.Linker = MTouchLinker.DontLink;
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecuteFailure ();
+				mtouch.AssertError (4111, "The registrar cannot build a signature for type `System.Int32[]' in method `DateMembers.F1`.", "testApp.cs", 5);
+				mtouch.AssertError (4111, "The registrar cannot build a signature for type `System.Int32[]' in method `DateMembers.F2`.", "testApp.cs", 8);
+				mtouch.AssertError (4111, "The registrar cannot build a signature for type `System.Int32[]' in method `DateMembers.F3`.", "testApp.cs", 11);
+				mtouch.AssertError (4111, "The registrar cannot build a signature for type `System.Int32[]' in method `DateMembers.get_F4`.", "testApp.cs", 14);
+				mtouch.AssertError (4111, "The registrar cannot build a signature for type `System.Int32[]' in method `DateMembers.set_F4`.", "testApp.cs", 14);
+				mtouch.AssertError (4111, "The registrar cannot build a signature for type `System.Int32[]' in method `DateMembers.F5`.", "testApp.cs", 17);
+				mtouch.AssertErrorCount (6);
+				mtouch.AssertNoWarnings ();
+			}
+		}
+
+		[Test]
 		public void MT4117 ()
 		{
 			var code = @"

--- a/tests/test-libraries/libtest.h
+++ b/tests/test-libraries/libtest.h
@@ -227,6 +227,27 @@ typedef void (^outerBlock) (innerBlock callback);
 -(void) dealloc;
 @end
 
+@interface RefOutParameters : NSObject {
+}
+	-(void) testCFBundle:      (int) action a:(CFBundleRef *) refValue b:(CFBundleRef *) outValue;
+	-(void) testINSCoding:     (int) action a:(id<NSCoding>*) refValue b:(id<NSCoding>*) outValue;
+	-(void) testNSObject:      (int) action a:(id *)          refValue b:(id *)          outValue;
+	-(void) testNSValue:       (int) action a:(NSValue **)    refValue b:(NSValue **)    outValue;
+	-(void) testString:        (int) action a:(NSString **)   refValue b:(NSString **)   outValue;
+	-(void) testInt:           (int) action a:(int32_t *)     refValue b:(int32_t *)     outValue;
+	-(void) testSelector:      (int) action a:(SEL *)         refValue b:(SEL *)         outValue;
+	-(void) testClass:         (int) action a:(Class *)       refValue b:(Class *)       outValue;
+
+	-(void) testINSCodingArray:     (int) action a:(NSArray **) refValue b:(NSArray **) outValue;
+	-(void) testNSObjectArray:      (int) action a:(NSArray **) refValue b:(NSArray **) outValue;
+	-(void) testNSValueArray:       (int) action a:(NSArray **) refValue b:(NSArray **) outValue;
+	-(void) testStringArray:        (int) action a:(NSArray **) refValue b:(NSArray **) outValue;
+	// SEL can't be put into an NSArray, since it's not an NSObject.
+	-(void) testClassArray:         (int) action a:(NSArray **) refValue b:(NSArray **) outValue;
+	// Class isn't an NSObject either, but it quacks like one, so it's possible to put them in NSArrays.
+	// And Apple does (see UIAppearance appearanceWhenContainedInInstancesOfClasses for an example).
+@end
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <MapKit/MapKit.h>
 
 #include <objc/objc.h>
 #include <objc/runtime.h>
@@ -781,4 +782,439 @@ static void block_called ()
 }
 @end
 
+@implementation RefOutParameters : NSObject {
+}
+-(void) testCFBundle: (int) action a:(CFBundleRef *) refValue b:(CFBundleRef *) outValue
+{
+	// We should never get null pointers.
+	assert (refValue != NULL);
+	assert (outValue != NULL);
+
+	// out parameters from managed code should always be NULL upon entry
+	assert (*outValue == NULL);
+
+	switch (action & 0xFF) {
+	case 1: // Set both to null
+		*refValue = NULL;
+		*outValue = NULL;
+		break;
+	case 2: // verify that refValue points to something
+		assert (*refValue != NULL);
+		break;
+	case 3: // set both parameteres to the same pointer of a CFBundle
+		*refValue = CFBundleGetMainBundle ();
+		*outValue = CFBundleGetMainBundle ();
+		break;
+	case 4: // set both parameteres to different pointers of a CFBundle
+		*refValue = (CFBundleRef) CFArrayGetValueAtIndex (CFBundleGetAllBundles (), 0);
+		*outValue = (CFBundleRef) CFArrayGetValueAtIndex (CFBundleGetAllBundles (), 1);
+		break;
+	default:
+		abort ();
+	}
+}
+
+-(void) testINSCoding: (int) action a:(id<NSCoding>*) refValue b:(id<NSCoding>*) outValue
+{
+	NSString *str = NULL;
+
+	// We should never get null pointers.
+	assert (refValue != NULL);
+	assert (outValue != NULL);
+
+	// out parameters from managed code should always be NULL upon entry
+	assert (*outValue == NULL);
+
+	switch (action & 0xFF) {
+	case 1: // Set both to null
+		*refValue = NULL;
+		*outValue = NULL;
+		break;
+	case 2: // verify that refValue points to something
+		assert (*refValue != NULL);
+		break;
+	case 3: // set both parameteres to the same pointer of an NSString (which implements NSCoding)
+		str = @"Some static string";
+		*refValue = str;
+		*outValue = str;
+		return;
+	case 4: // set both parameteres to different pointers of an NSString
+		*refValue = @"A static string for ref";
+		*outValue = @"A static string for out";
+		break;
+	default:
+		abort ();
+	}
+}
+
+-(void) testNSObject: (int) action a:(id *) refValue b:(id *) outValue
+{
+	NSObject *obj = NULL;
+
+	// We should never get null pointers.
+	assert (refValue != NULL);
+	assert (outValue != NULL);
+
+	// out parameters from managed code should always be NULL upon entry
+	assert (*outValue == NULL);
+
+	switch (action & 0xFF) {
+	case 1: // Set both to null
+		*refValue = NULL;
+		*outValue = NULL;
+		break;
+	case 2: // verify that refValue points to something
+		assert (*refValue != NULL);
+		break;
+	case 3: // set both parameteres to the same pointer of an NSObject
+		obj = [NSObject new];
+		*refValue = obj;
+		*outValue = obj;
+		return;
+	case 4: // set both parameteres to different objects
+		*refValue = [NSObject new];
+		*outValue = [NSObject new];
+		break;
+	default:
+		abort ();
+	}
+}
+
+-(void) testNSValue: (int) action a:(NSValue **) refValue b:(NSValue **) outValue
+{
+	NSValue *obj = NULL;
+
+	// We should never get null pointers.
+	assert (refValue != NULL);
+	assert (outValue != NULL);
+
+	// out parameters from managed code should always be NULL upon entry
+	assert (*outValue == NULL);
+
+	switch (action & 0xFF) {
+	case 1: // Set both to null
+		*refValue = NULL;
+		*outValue = NULL;
+		break;
+	case 2: // verify that refValue points to something
+		assert (*refValue != NULL);
+		break;
+	case 3: // set both parameteres to the same pointer of an NSValue
+		obj = [NSValue valueWithMKCoordinate: CLLocationCoordinate2DMake (3, 14)];
+		*refValue = obj;
+		*outValue = obj;
+		return;
+	case 4: // set both parameteres to different objects
+		*refValue = [NSValue valueWithMKCoordinate: CLLocationCoordinate2DMake (3, 14)];
+		*outValue = [NSValue valueWithMKCoordinate: CLLocationCoordinate2DMake (2, 71)];
+		break;
+	default:
+		abort ();
+	}
+}
+
+-(void) testString: (int) action a:(NSString **) refValue b:(NSString **) outValue
+{
+	NSString *obj = NULL;
+
+	// We should never get null pointers.
+	assert (refValue != NULL);
+	assert (outValue != NULL);
+
+	// out parameters from managed code should always be NULL upon entry
+	assert (*outValue == NULL);
+
+	switch (action & 0xFF) {
+	case 1: // Set both to null
+		*refValue = NULL;
+		*outValue = NULL;
+		break;
+	case 2: // verify that refValue points to something
+		assert (*refValue != NULL);
+		break;
+	case 3: // set both parameteres to the same pointer of an NSString
+		obj = @"A constant native string";
+		*refValue = obj;
+		*outValue = obj;
+		return;
+	case 4: // set both parameteres to different objects
+		*refValue = [NSString stringWithUTF8String: "Hello Xamarin"];
+		*outValue = [NSString stringWithUTF8String: "Hello Microsoft"];
+		break;
+	default:
+		abort ();
+	}
+}
+
+-(void) testInt: (int) action a:(int32_t *) refValue b:(int32_t *) outValue
+{
+	NSString *obj = NULL;
+
+	// We should never get null pointers.
+	assert (refValue != NULL);
+	assert (outValue != NULL);
+
+	switch (action & 0xFF) {
+	case 1: // Set both to 0
+		*refValue = 0;
+		*outValue = 0;
+		break;
+	case 3: // set both parameteres to the same value
+		obj = @"A constant native string";
+		*refValue = 314159;
+		*outValue = 314159;
+		return;
+	case 4: // set both parameteres to different objects
+		*refValue = 3141592;
+		*outValue = 2718282;
+		break;
+	default:
+		abort ();
+	}
+}
+
+-(void) testSelector: (int) action a:(SEL *) refValue b:(SEL *) outValue
+{
+	SEL obj = NULL;
+
+	// We should never get null pointers.
+	assert (refValue != NULL);
+	assert (outValue != NULL);
+
+	// out parameters from managed code should always be NULL upon entry
+	assert (*outValue == NULL);
+
+	switch (action & 0xFF) {
+	case 1: // Set both to null
+		*refValue = NULL;
+		*outValue = NULL;
+		break;
+	case 2: // verify that refValue points to something
+		assert (*refValue != NULL);
+		break;
+	case 3: // set both parameteres to the same selector
+		obj = @selector (testSelector);
+		*refValue = obj;
+		*outValue = obj;
+		return;
+	case 4: // set both parameteres to different selectors
+		*refValue = @selector (testSelector:a:);
+		*outValue = @selector (testSelector:b:);
+		break;
+	default:
+		abort ();
+	}
+}
+
+-(void) testClass: (int) action a:(Class *) refValue b:(Class *) outValue
+{
+	Class obj = NULL;
+
+	// We should never get null pointers.
+	assert (refValue != NULL);
+	assert (outValue != NULL);
+
+	// out parameters from managed code should always be NULL upon entry
+	assert (*outValue == NULL);
+
+	switch (action & 0xFF) {
+	case 1: // Set both to null
+		*refValue = NULL;
+		*outValue = NULL;
+		break;
+	case 2: // verify that refValue points to something
+		assert (*refValue != NULL);
+		break;
+	case 3: // set both parameteres to the same class
+		obj = [NSString class];
+		*refValue = obj;
+		*outValue = obj;
+		return;
+	case 4: // set both parameteres to different classes
+		*refValue = [NSBundle class];
+		*outValue = [NSDate class];
+		break;
+	default:
+		abort ();
+	}
+}
+
+-(void) testINSCodingArray: (int) action a:(NSArray **) refValue b:(NSArray **) outValue
+{
+	NSArray *arr = NULL;
+
+	// We should never get null pointers.
+	assert (refValue != NULL);
+	assert (outValue != NULL);
+
+	// out parameters from managed code should always be NULL upon entry
+	assert (*outValue == NULL);
+
+	switch (action & 0xFF) {
+	case 1: // Set both to null
+		*refValue = NULL;
+		*outValue = NULL;
+		break;
+	case 2: // verify that refValue points to something
+		assert (*refValue != NULL);
+		break;
+	case 3: // set both parameteres to the same pointer of an NSArray of NSString (which implements NSCoding)
+		arr =
+		@[
+			// This looks funny, but it's to ensure we don't get strings that are statically allocated (in which case the same pointer would be returned in multiple calls, which may throw off some of our tests)
+			[[NSString stringWithUTF8String: "Hello"] stringByAppendingString: @"World"],
+			[[NSString stringWithUTF8String: "Hello"] stringByAppendingString: @"Universe"]
+		];
+		*refValue = arr;
+		*outValue = arr;
+		return;
+	case 4: // set both parameteres to different NSArrays
+		*refValue = @[@3, @14];
+		*outValue = @[[NSString stringWithUTF8String: "Hello"], [NSString stringWithUTF8String: "Xamarin"]];
+		break;
+	default:
+		abort ();
+	}
+}
+
+-(void) testNSObjectArray: (int) action a:(NSArray **) refValue b:(NSArray **) outValue
+{
+	NSArray *arr = NULL;
+
+	// We should never get null pointers.
+	assert (refValue != NULL);
+	assert (outValue != NULL);
+
+	// out parameters from managed code should always be NULL upon entry
+	assert (*outValue == NULL);
+
+	switch (action & 0xFF) {
+	case 1: // Set both to null
+		*refValue = NULL;
+		*outValue = NULL;
+		break;
+	case 2: // verify that refValue points to something
+		assert (*refValue != NULL);
+		break;
+	case 3: // set both parameteres to the same pointer of an NSArray of NSString
+		arr = @[@"Hello", @"World"];
+		*refValue = arr;
+		*outValue = arr;
+		return;
+	case 4: // set both parameteres to different NSArrays
+		*refValue = @[@3, @14];
+		*outValue = @[@"Hello", @"Xamarin"];
+		break;
+	default:
+		abort ();
+	}
+}
+
+-(void) testNSValueArray: (int) action a:(NSArray **) refValue b:(NSArray **) outValue
+{
+	NSArray *arr = NULL;
+
+	// We should never get null pointers.
+	assert (refValue != NULL);
+	assert (outValue != NULL);
+
+	// out parameters from managed code should always be NULL upon entry
+	assert (*outValue == NULL);
+
+	switch (action & 0xFF) {
+	case 1: // Set both to null
+		*refValue = NULL;
+		*outValue = NULL;
+		break;
+	case 2: // verify that refValue points to something
+		assert (*refValue != NULL);
+		break;
+	case 3: // set both parameteres to the same pointer of an NSArray of NSValue
+		arr = @[[NSValue valueWithMKCoordinate: CLLocationCoordinate2DMake (3, 14)], [NSValue valueWithMKCoordinate: CLLocationCoordinate2DMake (2, 71)]];
+		*refValue = arr;
+		*outValue = arr;
+		return;
+	case 4: // set both parameteres to different NSArrays
+		*refValue = @[[NSValue valueWithMKCoordinate: CLLocationCoordinate2DMake (3, 14)], [NSValue valueWithMKCoordinate: CLLocationCoordinate2DMake (15, 92)]];
+		*outValue = @[[NSValue valueWithMKCoordinate: CLLocationCoordinate2DMake (2, 71)], [NSValue valueWithMKCoordinate: CLLocationCoordinate2DMake (82, 82)]];
+		break;
+	default:
+		abort ();
+	}
+}
+
+-(void) testStringArray: (int) action a:(NSArray **) refValue b:(NSArray **) outValue
+{
+	NSArray *arr = NULL;
+
+	// We should never get null pointers.
+	assert (refValue != NULL);
+	assert (outValue != NULL);
+
+	// out parameters from managed code should always be NULL upon entry
+	assert (*outValue == NULL);
+
+	switch (action & 0xFF) {
+	case 1: // Set both to null
+		*refValue = NULL;
+		*outValue = NULL;
+		break;
+	case 2: // verify that refValue points to something
+		assert (*refValue != NULL);
+		break;
+	case 3: // set both parameteres to the same pointer of an NSArray of NSString
+		arr = @[@"Hello", @"World"];
+		*refValue = arr;
+		*outValue = arr;
+		return;
+	case 4: // set both parameteres to different NSArrays
+		*refValue = @[@"Hello", @"Microsoft"];
+		*outValue = @[@"Hello", @"Xamarin"];
+		break;
+	case 5: // assert that we got an immutable array
+		// We'll never get a mutable array (the binding code creates NSArrays), so assert that.
+		assert (![*refValue isKindOfClass: [NSMutableArray class]]);
+		break;
+	default:
+		abort ();
+	}
+}
+
+-(void) testClassArray: (int) action a:(NSArray **) refValue b:(NSArray **) outValue
+{
+	NSArray *arr = NULL;
+
+	// We should never get null pointers.
+	assert (refValue != NULL);
+	assert (outValue != NULL);
+
+	// out parameters from managed code should always be NULL upon entry
+	assert (*outValue == NULL);
+
+	switch (action & 0xFF) {
+	case 1: // Set both to null
+		*refValue = NULL;
+		*outValue = NULL;
+		break;
+	case 2: // verify that refValue points to something
+		assert (*refValue != NULL);
+		break;
+	case 3: // set both parameteres to the same pointer of an NSArray of NSString
+		arr = @[[NSString class], [NSDate class]];
+		*refValue = arr;
+		*outValue = arr;
+		return;
+	case 4: // set both parameteres to different NSArrays
+		*refValue = @[[NSString class], [NSValue class]];
+		*outValue = @[[NSData class], [NSDate class]];
+		break;
+	case 5: // assert that we got an immutable array
+		// We'll never get a mutable array (the binding code creates NSArrays), so assert that.
+		assert (![*refValue isKindOfClass: [NSMutableArray class]]);
+		break;
+	default:
+		abort ();
+	}
+}
+@end
 #include "libtest.decompile.m"

--- a/tests/test-libraries/rename.h
+++ b/tests/test-libraries/rename.h
@@ -10,6 +10,7 @@
 	#define FakeType2         object_FakeType2
 	#define UltimateMachine   object_UltimateMachine
 	#define FrameworkTest     object_FrameworkTest
+	#define RefOutParameters  object_RefOutParameters
 	#define Sc                object_Sc
 	#define Scc               object_Scc
 	#define Sccc              object_Sccc
@@ -78,6 +79,7 @@
 	#define FakeType2         ar_FakeType2
 	#define UltimateMachine   ar_UltimateMachine
 	#define FrameworkTest     ar_FrameworkTest
+	#define RefOutParameters  ar_RefOutParameters
 	#define Sc                ar_Sc
 	#define Scc               ar_Scc
 	#define Sccc              ar_Sccc

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -270,9 +270,9 @@ namespace xharness
 				switch (test.TestName) {
 				case "monotouch-test":
 					// The default is to run monotouch-test with the dynamic registrar (in the simulator), so that's already covered
-					yield return new TestData { Variation = "Debug (static registrar)", MTouchExtraArgs = "--registrar:static", Debug = true, Profiling = false };
-					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, LinkMode = "Full", Defines = "OPTIMIZEALL" };
-					yield return new TestData { Variation = "Debug (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all,-remove-uithread-checks", Debug = true, Profiling = false, LinkMode = "Full", Defines = "OPTIMIZEALL", Ignored = !IncludeAll };
+					yield return new TestData { Variation = "Debug (static registrar)", MTouchExtraArgs = "--registrar:static", Debug = true, Profiling = false, Undefines = "DYNAMIC_REGISTRAR" };
+					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, LinkMode = "Full", Defines = "OPTIMIZEALL", Undefines = "DYNAMIC_REGISTRAR" };
+					yield return new TestData { Variation = "Debug (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all,-remove-uithread-checks", Debug = true, Profiling = false, LinkMode = "Full", Defines = "OPTIMIZEALL", Undefines = "DYNAMIC_REGISTRAR", Ignored = !IncludeAll };
 					break;
 				}
 				break;

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3531,10 +3531,7 @@ namespace Registrar {
 							setup_call_stack.AppendLine ("a{0} = *p{0} ? mono_string_new (mono_domain_get (), [(*p{0}) UTF8String]) : NULL;", i);
 						setup_call_stack.AppendLine ("arg_ptrs [{0}] = &a{0};", i);
 						body_setup.AppendLine ("char *str{0} = NULL;", i);
-						copyback.AppendLine ("str{0} = mono_string_to_utf8 (a{0});", i);
-						copyback.AppendLine ("*p{0} = [[NSString alloc] initWithUTF8String:str{0}];", i);
-						copyback.AppendLine ("[*p{0} autorelease];", i);
-						copyback.AppendLine ("mono_free (str{0});", i);
+						copyback.AppendLine ("*p{0} = xamarin_string_to_nsstring (a{0}, false);", i);
 					} else {
 						setup_call_stack.AppendLine ("arg_ptrs [{0}] = p{0} ? mono_string_new (mono_domain_get (), [p{0} UTF8String]) : NULL;", i);
 					}
@@ -3819,11 +3816,7 @@ namespace Registrar {
 					setup_return.AppendLine ("MonoObject *value = mono_array_get ((MonoArray *) retval, MonoObject *, i);");
 					
 					if (elementType.FullName == "System.String") {
-						setup_return.AppendLine ("char *str = mono_string_to_utf8 ((MonoString *) value);");
-						setup_return.AppendLine ("NSString *sv = [[NSString alloc] initWithUTF8String:str];");
-						setup_return.AppendLine ("[sv autorelease];");
-						setup_return.AppendLine ("mono_free (str);");
-						setup_return.AppendLine ("buf [i] = sv;");
+						setup_return.AppendLine ("buf [i] = xamarin_string_to_nsstring ((MonoString *) value, false);");
 					} else if (IsNSObject (elementType)) {
 						setup_return.AppendLine ("buf [i] = xamarin_get_nsobject_handle ((MonoObject *) value);");
 					} else if (IsINativeObject (elementType)) {
@@ -3884,12 +3877,7 @@ namespace Registrar {
 						setup_return.AppendLine ("res = retobj;");
 					} else if (type.FullName == "System.String") {
 						// This should always be an NSString and never char*
-						setup_return.AppendLine ("char *str = mono_string_to_utf8 ((MonoString *) retval);");
-						setup_return.AppendLine ("NSString *nsstr = [[NSString alloc] initWithUTF8String:str];");
-						if (!retain)
-							setup_return.AppendLine ("[nsstr autorelease];");
-						setup_return.AppendLine ("mono_free (str);");
-						setup_return.AppendLine ("res = nsstr;");
+						setup_return.AppendLine ("res = xamarin_string_to_nsstring ((MonoString *) retval, {0});", retain ? "true" : "false");
 					} else if (IsDelegate (type.Resolve ())) {
 						var signature = "NULL";
 						var token = "INVALID_TOKEN_REF";

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -4521,7 +4521,7 @@ namespace Registrar {
 			if (isManagedArray) {
 				sb.AppendLine ($"xamarin_id_to_managed_func {inputName}_conv_func = (xamarin_id_to_managed_func) {func};");
 				sb.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
-				sb.AppendLine ($"{outputName} = xamarin_convert_nsarray_to_managed_with_func ({inputName}, {classVariableName}, {inputName}_conv_func, {token}, &exception_gchandle);");
+				sb.AppendLine ($"{outputName} = xamarin_convert_nsarray_to_managed_with_func ({inputName}, {classVariableName}, {inputName}_conv_func, GINT_TO_POINTER ({token}), &exception_gchandle);");
 				sb.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
 			} else {
 				var tmpName = $"{inputName}_conv_tmp";
@@ -4529,11 +4529,11 @@ namespace Registrar {
 				if (isManagedNullable) {
 					var tmpName2 = $"{inputName}_conv_ptr";
 					body_setup.AppendLine ($"void *{tmpName2} = NULL;");
-					sb.AppendLine ($"{tmpName2} = {func} ({inputName}, &{tmpName}, {classVariableName}, {token}, &exception_gchandle);");
+					sb.AppendLine ($"{tmpName2} = {func} ({inputName}, &{tmpName}, {classVariableName}, GINT_TO_POINTER ({token}), &exception_gchandle);");
 					sb.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
 					sb.AppendLine ($"{outputName} = mono_value_box (mono_domain_get (), {classVariableName}, {tmpName2});");
 				} else {
-					sb.AppendLine ($"{outputName} = {func} ({inputName}, &{tmpName}, {classVariableName}, {token}, &exception_gchandle);");
+					sb.AppendLine ($"{outputName} = {func} ({inputName}, &{tmpName}, {classVariableName}, GINT_TO_POINTER ({token}), &exception_gchandle);");
 					sb.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
 				}
 			}
@@ -4606,9 +4606,9 @@ namespace Registrar {
 			}
 
 			if (isManagedArray) {
-				sb.AppendLine ($"{outputName} = xamarin_convert_managed_to_nsarray_with_func ((MonoArray *) {inputName}, (xamarin_managed_to_id_func) {func}, {token}, &exception_gchandle);");
+				sb.AppendLine ($"{outputName} = xamarin_convert_managed_to_nsarray_with_func ((MonoArray *) {inputName}, (xamarin_managed_to_id_func) {func}, GINT_TO_POINTER ({token}), &exception_gchandle);");
 			} else {
-				sb.AppendLine ($"{outputName} = {func} ({inputName}, {token}, &exception_gchandle);");
+				sb.AppendLine ($"{outputName} = {func} ({inputName}, GINT_TO_POINTER ({token}), &exception_gchandle);");
 			}
 			sb.AppendLine ($"if (exception_gchandle != 0) goto exception_handling;");
 

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3498,7 +3498,8 @@ namespace Registrar {
 							setup_call_stack.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
 						}
 						setup_call_stack.AppendLine ("arg_ptrs [{0}] = &a{0};", i);
-						copyback.AppendLine ("*p{0} = a{0};", i);
+						copyback.AppendLine ("*p{0} = a{0} ? (SEL) xamarin_get_handle_for_inativeobject (a{0}, &exception_gchandle) : NULL;", i);
+						copyback.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
 					} else {
 						setup_call_stack.AppendLine ("arg_ptrs [{0}] = p{0} ? xamarin_get_selector (p{0}, &exception_gchandle) : NULL;", i);
 						setup_call_stack.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
@@ -3513,7 +3514,8 @@ namespace Registrar {
 							setup_call_stack.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
 						}
 						setup_call_stack.AppendLine ("arg_ptrs [{0}] = &a{0};", i);
-						copyback.AppendLine ("*p{0} = a{0};", i);
+						copyback.AppendLine ("*p{0} = a{0} ? (Class) xamarin_get_handle_for_inativeobject (a{0}, &exception_gchandle) : NULL;", i);
+						copyback.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
 					} else {
 						setup_call_stack.AppendLine ("arg_ptrs [{0}] = p{0} ? xamarin_get_class (p{0}, &exception_gchandle) : NULL;", i);
 						setup_call_stack.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3528,12 +3528,12 @@ namespace Registrar {
 					if (isRef) {
 						body_setup.AppendLine ("MonoString *a{0} = NULL;", i);
 						if (!isOut)
-							setup_call_stack.AppendLine ("a{0} = *p{0} ? mono_string_new (mono_domain_get (), [(*p{0}) UTF8String]) : NULL;", i);
+							setup_call_stack.AppendLine ("a{0} = xamarin_nsstring_to_string (NULL, *p{0});", i);
 						setup_call_stack.AppendLine ("arg_ptrs [{0}] = &a{0};", i);
 						body_setup.AppendLine ("char *str{0} = NULL;", i);
 						copyback.AppendLine ("*p{0} = xamarin_string_to_nsstring (a{0}, false);", i);
 					} else {
-						setup_call_stack.AppendLine ("arg_ptrs [{0}] = p{0} ? mono_string_new (mono_domain_get (), [p{0} UTF8String]) : NULL;", i);
+						setup_call_stack.AppendLine ("arg_ptrs [{0}] = xamarin_nsstring_to_string (NULL, p{0});", i);
 					}
 					break;
 				default:
@@ -3555,7 +3555,7 @@ namespace Registrar {
 						setup_call_stack.AppendLine ("for (j = 0; j < [arr count]; j++) {{", i);
 						if (elementType.FullName == "System.String") {
 							setup_call_stack.AppendLine ("NSString *sv = (NSString *) [arr objectAtIndex: j];", i);
-							setup_call_stack.AppendLine ("mono_array_setref (marr, j, mono_string_new (mono_domain_get (), [sv UTF8String]));", i);
+							setup_call_stack.AppendLine ("mono_array_setref (marr, j, xamarin_nsstring_to_string (NULL, sv));", i);
 						} else if (IsNSObject (elementType) || (elementType.Namespace == "System" && elementType.Name == "Object") || (isNativeObject = IsNativeObject (elementType))) {
 							setup_call_stack.AppendLine ("NSObject *nobj = [arr objectAtIndex: j];");
 							setup_call_stack.AppendLine ("MonoObject *mobj{0} = NULL;", i);

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3492,10 +3492,8 @@ namespace Registrar {
 				case "ObjCRuntime.Selector":
 				case CompatNamespace + ".ObjCRuntime.Selector":
 					if (isRef) {
-						if (isOut) {
-							body_setup.AppendLine ("void *a{0} = NULL;", i);
-						} else {
-							body_setup.AppendLine ("void *a{0} = NULL;", i);
+						body_setup.AppendLine ("MonoObject *a{0} = NULL;", i);
+						if (!isOut) {
 							setup_call_stack.AppendLine ("a{0} = *p{0} ? xamarin_get_selector (*p{0}, &exception_gchandle) : NULL;", i);
 							setup_call_stack.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
 						}
@@ -3509,10 +3507,8 @@ namespace Registrar {
 				case "ObjCRuntime.Class":
 				case CompatNamespace + ".ObjCRuntime.Class":
 					if (isRef) {
-						if (isOut) {
-							body_setup.AppendLine ("void *a{0} = NULL;", i);
-						} else {
-							body_setup.AppendLine ("void *a{0} = NULL;", i);
+						body_setup.AppendLine ("MonoObject *a{0} = NULL;", i);
+						if (!isOut) {
 							setup_call_stack.AppendLine ("a{0} = *p{0} ? xamarin_get_class (*p{0}, &exception_gchandle) : NULL;", i);
 							setup_call_stack.AppendLine ("if (exception_gchandle != 0) goto exception_handling;");
 						}


### PR DESCRIPTION
* Share much more marshalling code between the dynamic and static registrar
  (by refactoring code into separate functions used by both).
* Fix an issue with multiple out/ref parameters in the dynamic registrar.
* Throw an error instead of silently ignoring out/ref parameter types we don't
  completely understand in the dynamic registrar.
* Fix returning Class/SEL out/ref parameters in the static registrar.
* Fix returning NSString out/ref parameters in the dynamic registrar.
* Add/fix support for out/ref arrays everywhere.
* Fix support for the various supported out/ref parameter types in the
  generator.
* Add lots of tests.

Fixes https://github.com/xamarin/xamarin-macios/issues/5171.

This pull request is best reviewed commit-by-commit.