### PR TITLE
[tests] Fix another race condition in the MT5211 mtouch test. Fixes xamarin/maccore#1584.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -3003,7 +3003,7 @@ class Test {
 				mtouch.AssertOutputPattern (".*_OBJC_METACLASS_._Test_Subexistent in registrar.o.*");
 				mtouch.AssertOutputPattern (".*_OBJC_CLASS_._Inexistent., referenced from:.*");
 				mtouch.AssertOutputPattern (".*_OBJC_CLASS_._Test_Subexistent in registrar.o.*");
-				mtouch.AssertOutputPattern (".*ld: symbol.s. not found for architecture arm64.*");
+				mtouch.AssertOutputPattern (".*ld: symbol.s. not found for architecture.*");
 				mtouch.AssertOutputPattern (".*clang: error: linker command failed with exit code 1 .use -v to see invocation.*");
 
 				mtouch.AssertErrorPattern ("MT", 5210, "Native linking failed, undefined symbol: _OBJC_METACLASS_._Inexistent. Please verify that all the necessary frameworks have been referenced and native libraries are properly linked in.");


### PR DESCRIPTION
This is the second part to 9882746e377a586c00c06e32aa6303543c8bbe6e.

Fixes https://github.com/xamarin/maccore/issues/1584.