### PR TITLE
[msbuild] Add CoreLocation to the frameworks needed in MyiOSFrameworkBinding. Fixes #5974.

### DIFF
--- a/msbuild/tests/MyiOSFrameworkBinding/MyiOSFrameworkBinding.csproj
+++ b/msbuild/tests/MyiOSFrameworkBinding/MyiOSFrameworkBinding.csproj
@@ -46,12 +46,12 @@
       <Kind>Framework</Kind>
       <Link>XStaticObjectTest.framework</Link>
       <LinkerFlags>-lz</LinkerFlags>
-      <Frameworks>Foundation ModelIO</Frameworks>
+      <Frameworks>CoreLocation Foundation ModelIO</Frameworks>
     </NativeReference>
     <NativeReference Include="..\..\..\tests\test-libraries\.libs\ios\XStaticArTest.framework">
       <Kind>Framework</Kind>
       <Link>XStaticArTest.framework</Link>
-      <Frameworks>Foundation ModelIO</Frameworks>
+      <Frameworks>CoreLocation Foundation ModelIO</Frameworks>
     </NativeReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes these test failures:

    1) Test Failure : Xamarin.iOS.Tasks.NativeReferencesNoEmbedding("iPhone").FrameworksEmbeddedProperly(True)
         #RunTarget-ErrorCount
    	linker command failed with exit code 1 (use -v to see invocation)
    	Native linking failed, undefined symbol: _CLLocationCoordinate2DMake. Please verify that all the necessary frameworks have been referenced and native libraries are properly linked in.
    	Native linking failed. Please review the build log.
      Expected: 0
      But was:  3

    2) Test Failure : Xamarin.iOS.Tasks.NativeReferencesNoEmbedding("iPhone").ShouldNotUnnecessarilyRebuildFinalProject(True)
         #RunTarget-ErrorCount
    	linker command failed with exit code 1 (use -v to see invocation)
    	Native linking failed, undefined symbol: _CLLocationCoordinate2DMake. Please verify that all the necessary frameworks have been referenced and native libraries are properly linked in.
    	Native linking failed. Please review the build log.
      Expected: 0
      But was:  3

Fixes https://github.com/xamarin/xamarin-macios/issues/5974.