### PR TITLE
Add more details to MSBuild errors for provisioning profiles

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/DetectSigningIdentityTaskBase.cs
@@ -311,7 +311,8 @@ namespace Xamarin.MacDev.Tasks
 			if (profiles.Count == 0) {
 				foreach (var f in failures)
 					Log.LogMessage (MessageImportance.Low, "{0}", f);
-				Log.LogError ($"Could not find any available provisioning profiles for {PlatformName}.");
+				
+				Log.LogError ($"Could not find any available provisioning profiles for {AppBundleName} on {PlatformName}.");
 				return null;
 			}
 
@@ -335,7 +336,7 @@ namespace Xamarin.MacDev.Tasks
 				}) select new CodeSignIdentity { SigningKey = c, Profile = p }).ToList ();
 
 				if (pairs.Count == 0) {
-					Log.LogError ("No installed provisioning profiles match the installed " + PlatformName + " signing identities.");
+					Log.LogError ($"No installed provisioning profiles match the installed {PlatformName} {AppBundleName} signing identities.");
 					return null;
 				}
 			} else {


### PR DESCRIPTION
A lot of apps get renamed during the build process. E.g. most of our apps have an alpha or a beta version and they have separate bundle names so that you can install them side-by-side.

I usually don't know if there is an error in my build script or if the provisioning profile is really missing on the machine I'm building on. By displaying the name, the user might notice incorrect bundle names.