### PR TITLE
[linker] Mark protocol interfaces when using the dynamic registrar.

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2078,9 +2078,19 @@ public class B
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.CreateTemporaryApp ();
 				mtouch.Linker = MTouchLinker.LinkAll;
+				mtouch.CreateTemporaryCacheDirectory ();
 				mtouch.AssertExecute (MTouchAction.BuildSim);
 
 				var load_commands = ExecutionHelper.Execute ("otool", $"-l {StringUtils.Quote (mtouch.NativeExecutablePath)}", hide_output: true);
+				Asserts.DoesNotContain ("SafariServices", load_commands, "SafariServices");
+				Asserts.DoesNotContain ("GameController", load_commands, "GameController");
+				Asserts.DoesNotContain ("NewsstandKit", load_commands, "NewsstandKit");
+
+				// Try again with the static registrar
+				mtouch.Registrar = MTouchRegistrar.Static;
+				mtouch.AssertExecute (MTouchAction.BuildSim);
+
+				load_commands = ExecutionHelper.Execute ("otool", $"-l {StringUtils.Quote (mtouch.NativeExecutablePath)}", hide_output: true);
 				Asserts.DoesNotContain ("SafariServices", load_commands, "SafariServices");
 				Asserts.DoesNotContain ("GameController", load_commands, "GameController");
 				Asserts.DoesNotContain ("QuickLook", load_commands, "QuickLook");

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -270,6 +270,7 @@ namespace xharness
 				switch (test.TestName) {
 				case "monotouch-test":
 					// The default is to run monotouch-test with the dynamic registrar (in the simulator), so that's already covered
+					yield return new TestData { Variation = "Debug (LinkSdk)", Debug = true, Profiling = false, LinkMode = "LinkSdk" };
 					yield return new TestData { Variation = "Debug (static registrar)", MTouchExtraArgs = "--registrar:static", Debug = true, Profiling = false, Undefines = "DYNAMIC_REGISTRAR" };
 					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, LinkMode = "Full", Defines = "OPTIMIZEALL", Undefines = "DYNAMIC_REGISTRAR" };
 					yield return new TestData { Variation = "Debug (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all,-remove-uithread-checks", Debug = true, Profiling = false, LinkMode = "Full", Defines = "OPTIMIZEALL", Undefines = "DYNAMIC_REGISTRAR", Ignored = !IncludeAll };

--- a/tools/linker/CoreMarkStep.cs
+++ b/tools/linker/CoreMarkStep.cs
@@ -310,6 +310,12 @@ namespace Xamarin.Linker.Steps {
 				if (isProtocol && !IgnoreScope (type.Scope)) {
 					LinkContext.StoreProtocolMethods (resolvedInterfaceType);
 				}
+			} else if (LinkContext.App.Registrar == Bundler.RegistrarMode.Dynamic) {
+				// If we're using the dynamic registrar, we need to mark interfaces that represent protocols
+				// even if it doesn't look like the interfaces are used, since we need them at runtime.
+				var isProtocol = type.IsNSObject (LinkContext) && resolvedInterfaceType.HasCustomAttribute (LinkContext, Namespaces.Foundation, "ProtocolAttribute");
+				if (isProtocol)
+					return true;
 			}
 
 			return base.ShouldMarkInterfaceImplementation (type, iface, resolvedInterfaceType);


### PR DESCRIPTION
Fixes this monotouch-test failure when using the dynamic registrar and the
linker at the same time:

    [FAIL] RegistrarTest.TestProtocolRegistration :   UIApplicationDelegate/17669
      Expected: True
      But was:  False