### PR TITLE
[runtime] Fix crash in the x86_64 dynamic registrar.

### DIFF
--- a/runtime/trampolines-x86_64.h
+++ b/runtime/trampolines-x86_64.h
@@ -8,15 +8,14 @@ extern "C" {
 struct XamarinCallState {
 	uint64_t type;
 	uint64_t rdi;                        // 1st argument
-	union {
-		uint64_t rsi; // rsi upon entry. // 2nd argument
-		uint64_t rax; // rax upon exit.
-	};
+	uint64_t rsi; // 2nd argument
 	uint64_t rdx; // 3rd argument
 	uint64_t rcx; // 4th argument
 	uint64_t r8; // 5th argument
 	uint64_t r9; // 6th argument
 	uint64_t rbp;
+	uint64_t rax;
+	uint64_t rdx_out; // use this field as a temporary rdx field to store output. It makes the marshalling code a bit easier to have this field just after the rax field (so we can treat rax+rdx as a continuous block of 32 bytes of memory)
 	long double xmm0;
 	long double xmm1;
 	long double xmm2;

--- a/runtime/trampolines-x86_64.m
+++ b/runtime/trampolines-x86_64.m
@@ -79,8 +79,8 @@ get_primitive_size (char type)
 static void
 dump_state (struct XamarinCallState *state)
 {
-	fprintf (stderr, "type: %llu is_stret: %i self: %p SEL: %s rdi: 0x%llx rsi: 0x%llx rdx: 0x%llx rcx: 0x%llx r8: 0x%llx r9: 0x%llx rbp: 0x%llx -- xmm0: %Lf xmm1: %Lf xmm2: %Lf xmm3: %Lf xmm4: %Lf xmm5: %Lf xmm6: %Lf xmm7: %Lf\n",
-		state->type, state->is_stret (), state->self (), sel_getName (state->sel ()), state->rdi, state->rsi, state->rdx, state->rcx, state->r8, state->r9, state->rbp,
+	fprintf (stderr, "type: %llu is_stret: %i self: %p SEL: %s rdi: 0x%llx rsi: 0x%llx rdx: 0x%llx rcx: 0x%llx r8: 0x%llx r9: 0x%llx rbp: 0x%llx rax: 0x%llx rdx out: 0x%llx -- xmm0: %Lf xmm1: %Lf xmm2: %Lf xmm3: %Lf xmm4: %Lf xmm5: %Lf xmm6: %Lf xmm7: %Lf\n",
+		state->type, state->is_stret (), state->self (), sel_getName (state->sel ()), state->rdi, state->rsi, state->rdx, state->rcx, state->r8, state->r9, state->rbp, state->rax, state->rdx_out,
 		state->xmm0, state->xmm1, state->xmm2, state->xmm3, state->xmm4, state->xmm5, state->xmm6, state->xmm7);
 }
 #else


### PR DESCRIPTION
In [this][1] innocuous-looking commit I made the x86_64 dynamic registrar
crash when TRACE is defined. The underlying problem is that CallState's rsi
field is re-used as rax upon exit of the trampoline. This means that the
CallState.sel () function that gets the selector, will instead get the return
value upon exit. When TRACE is defined, we try to print the selector upon
exiting the trampoline, and since the rsi field is now the rax field, we end
up trying to print the return value as if it were a selector, and things go
slightly sideways.

[1]: https://github.com/xamarin/xamarin-macios/commit/464882d14a83