### PR TITLE
[generator] Show proper errors when failing to compile something.

### DIFF
--- a/docs/website/generator-errors.md
+++ b/docs/website/generator-errors.md
@@ -25,6 +25,10 @@ The easiest way to get exact version information is to use the **Xamarin Studio*
 
 ### <a name='BI0001'/>BI0001: The .NET runtime could not load the {mi.ReturnType.Name} type. Message: {ex.Message}
 
+### <a name='BI0002'/>BI0002: Could not compile the API bindings.
+
+This error is shown when the generated failed to compile the API bindings.
+
 ### <a name='BI0026'/>BI0026: Could not parse the command line argument '{argument}': {message}
 
 ### <a name='BI0068'/>BI0068: Invalid value for target framework: *.
@@ -49,6 +53,10 @@ This usually indicates a bug in the binding generator; please file a new issue o
 
 <!-- 1xxx: code generation -->
 <!-- 10xx: errors -->
+
+### <a name='BI1000/>'BI1000: Could not compile the generated API bindings.
+
+This indicates a bug in Xamarin.iOS/Xamarin.Mac; please [submit an issue](https://github.com/xamarin/xamarin-macios/wiki/Submitting-Bugs-&-Suggestions).
 
 ### <a name='BI1001'/>BI1001: Do not know how to make a trampoline for *
 

--- a/docs/website/generator-errors.md
+++ b/docs/website/generator-errors.md
@@ -27,7 +27,7 @@ The easiest way to get exact version information is to use the **Xamarin Studio*
 
 ### <a name='BI0002'/>BI0002: Could not compile the API bindings.
 
-This error is shown when the generated failed to compile the API bindings.
+This error is shown when the generator failed to compile the API bindings.
 
 ### <a name='BI0026'/>BI0026: Could not parse the command line argument '{argument}': {message}
 

--- a/src/generator.csproj
+++ b/src/generator.csproj
@@ -379,6 +379,9 @@
     <Compile Include="..\src\ObjCRuntime\PlatformAvailabilityShadow.cs" />
     <Compile Include="..\src\ObjCRuntime\Registrar.core.cs" />
     <Compile Include="..\src\ObjCRuntime\RequiresSuperAttribute.cs" />
+    <Compile Include="..\tools\common\Execution.cs">
+      <Link>Execution.cs</Link>
+    </Compile>
   </ItemGroup>
   <Target Name="AfterBuild">
     <Exec Command="make bgen" />

--- a/tests/generator/ErrorTests.cs
+++ b/tests/generator/ErrorTests.cs
@@ -11,6 +11,16 @@ namespace GeneratorTests
 	public class ErrorTests
 	{
 		[Test]
+		public void BI0002 ()
+		{
+			var bgen = new BGenTool ();
+			bgen.Profile = Profile.iOS;
+			bgen.CreateTemporaryBinding ("InvalidCodeHere");
+			bgen.AssertExecuteError ("build");
+			bgen.AssertError (2, "Could not compile the API bindings.");
+		}
+
+		[Test]
 		public void BI0086 ()
 		{
 			var bgen = new BGenTool ();

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -12,9 +12,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
 
 using Xamarin.MacDev;
 using Xamarin.Utils;
@@ -231,77 +229,6 @@ namespace Xamarin.Bundler {
 			if (Array.IndexOf (TargetFramework.ValidFrameworks, targetFramework.Value) == -1)
 				throw ErrorHelper.CreateError (70, "Invalid target framework: {0}. Valid target frameworks are: {1}.", targetFramework.Value, string.Join (" ", TargetFramework.ValidFrameworks.Select ((v) => v.ToString ()).ToArray ()));
 #endif
-		}
-
-		public static int RunCommand (string path, string args, string[] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
-		{
-			var info = new ProcessStartInfo (path, args);
-			info.UseShellExecute = false;
-			info.RedirectStandardInput = false;
-			info.RedirectStandardOutput = true;
-			info.RedirectStandardError = true;
-			System.Threading.ManualResetEvent stdout_completed = new System.Threading.ManualResetEvent (false);
-			System.Threading.ManualResetEvent stderr_completed = new System.Threading.ManualResetEvent (false);
-
-			if (output == null)
-				output = new StringBuilder ();
-
-			if (env != null){
-				if (env.Length % 2 != 0)
-					throw new Exception ("You passed an environment key without a value");
-
-				for (int i = 0; i < env.Length; i+= 2)
-					info.EnvironmentVariables [env[i]] = env[i+1];
-			}
-
-			if (verbose > 0)
-				Console.WriteLine ("{0} {1}", path, args);
-
-			using (var p = Process.Start (info)) {
-
-				p.OutputDataReceived += (s, e) => {
-					if (e.Data != null) {
-						lock (output)
-							output.AppendLine (e.Data);
-					} else {
-						stdout_completed.Set ();
-					}
-				};
-
-				p.ErrorDataReceived += (s, e) => {
-					if (e.Data != null) {
-						lock (output)
-							output.AppendLine (e.Data);
-					} else {
-						stderr_completed.Set ();
-					}
-				};
-
-				p.BeginOutputReadLine ();
-				p.BeginErrorReadLine ();
-
-				p.WaitForExit ();
-
-				stderr_completed.WaitOne (TimeSpan.FromSeconds (1));
-				stdout_completed.WaitOne (TimeSpan.FromSeconds (1));
-
-				if (p.ExitCode != 0) {
-					// note: this repeat the failing command line. However we can't avoid this since we're often
-					// running commands in parallel (so the last one printed might not be the one failing)
-					if (!suppressPrintOnErrors)
-						Console.Error.WriteLine ("Process exited with code {0}, command:\n{1} {2}{3}", p.ExitCode, path, args, output.Length > 0 ? "\n" + output.ToString () : string.Empty);
-					return p.ExitCode;
-				} else if (verbose > 0 && output.Length > 0 && !suppressPrintOnErrors) {
-					Console.WriteLine (output.ToString ());
-				}
-			}
-
-			return 0;
-		}
-
-		public static Task<int> RunCommandAsync (string path, string args, string [] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
-		{
-			return Task.Run (() => RunCommand (path, args, env, output, suppressPrintOnErrors));
 		}
 
 #if !MMP_TEST

--- a/tools/common/Driver.cs
+++ b/tools/common/Driver.cs
@@ -13,6 +13,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 
 using Xamarin.MacDev;
 using Xamarin.Utils;
@@ -229,6 +230,16 @@ namespace Xamarin.Bundler {
 			if (Array.IndexOf (TargetFramework.ValidFrameworks, targetFramework.Value) == -1)
 				throw ErrorHelper.CreateError (70, "Invalid target framework: {0}. Valid target frameworks are: {1}.", targetFramework.Value, string.Join (" ", TargetFramework.ValidFrameworks.Select ((v) => v.ToString ()).ToArray ()));
 #endif
+		}
+
+		public static int RunCommand (string path, string args, string [] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
+		{
+			return RunCommand (path, args, env, output, suppressPrintOnErrors, verbose);
+		}
+
+		public static Task<int> RunCommandAsync (string path, string args, string [] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
+		{
+			return RunCommandAsync (path, args, env, output, suppressPrintOnErrors, verbose);
 		}
 
 #if !MMP_TEST

--- a/tools/common/Execution.cs
+++ b/tools/common/Execution.cs
@@ -15,7 +15,13 @@ using System.Threading.Tasks;
 
 namespace Xamarin.Bundler {
 	public partial class Driver {
-		public static int RunCommand (string path, string args, string[] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
+		public static int RunCommand (string path, string args, string [] env, out StringBuilder output, bool suppressPrintOnErrors, int verbose)
+		{
+			output = new StringBuilder ();
+			return RunCommand (path, args, env, output, suppressPrintOnErrors, verbose);
+		}
+
+		public static int RunCommand (string path, string args, string[] env, StringBuilder output, bool suppressPrintOnErrors, int verbose)
 		{
 			var info = new ProcessStartInfo (path, args);
 			info.UseShellExecute = false;
@@ -81,9 +87,9 @@ namespace Xamarin.Bundler {
 			return 0;
 		}
 
-		public static Task<int> RunCommandAsync (string path, string args, string [] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
+		public static Task<int> RunCommandAsync (string path, string args, string [] env, StringBuilder output, bool suppressPrintOnErrors, int verbose)
 		{
-			return Task.Run (() => RunCommand (path, args, env, output, suppressPrintOnErrors));
+			return Task.Run (() => RunCommand (path, args, env, output, suppressPrintOnErrors, verbose));
 		}
 	}
 }

--- a/tools/common/Execution.cs
+++ b/tools/common/Execution.cs
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2014 Xamarin Inc. All rights reserved.
+ * Copyright 2019 Microsoft Corp. All rights reserved.
+ *
+ * Authors:
+ *   Rolf Bjarne Kvinge <rolf@xamarin.com>
+ *
+ */
+
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Xamarin.Bundler {
+	public partial class Driver {
+		public static int RunCommand (string path, string args, string[] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
+		{
+			var info = new ProcessStartInfo (path, args);
+			info.UseShellExecute = false;
+			info.RedirectStandardInput = false;
+			info.RedirectStandardOutput = true;
+			info.RedirectStandardError = true;
+			var stdout_completed = new ManualResetEvent (false);
+			var stderr_completed = new ManualResetEvent (false);
+
+			if (output == null)
+				output = new StringBuilder ();
+
+			if (env != null){
+				if (env.Length % 2 != 0)
+					throw new Exception ("You passed an environment key without a value");
+
+				for (int i = 0; i < env.Length; i+= 2)
+					info.EnvironmentVariables [env[i]] = env[i+1];
+			}
+
+			if (verbose > 0)
+				Console.WriteLine ("{0} {1}", path, args);
+
+			using (var p = Process.Start (info)) {
+
+				p.OutputDataReceived += (s, e) => {
+					if (e.Data != null) {
+						lock (output)
+							output.AppendLine (e.Data);
+					} else {
+						stdout_completed.Set ();
+					}
+				};
+
+				p.ErrorDataReceived += (s, e) => {
+					if (e.Data != null) {
+						lock (output)
+							output.AppendLine (e.Data);
+					} else {
+						stderr_completed.Set ();
+					}
+				};
+
+				p.BeginOutputReadLine ();
+				p.BeginErrorReadLine ();
+
+				p.WaitForExit ();
+
+				stderr_completed.WaitOne (TimeSpan.FromSeconds (1));
+				stdout_completed.WaitOne (TimeSpan.FromSeconds (1));
+
+				if (p.ExitCode != 0) {
+					// note: this repeat the failing command line. However we can't avoid this since we're often
+					// running commands in parallel (so the last one printed might not be the one failing)
+					if (!suppressPrintOnErrors)
+						Console.Error.WriteLine ("Process exited with code {0}, command:\n{1} {2}{3}", p.ExitCode, path, args, output.Length > 0 ? "\n" + output.ToString () : string.Empty);
+					return p.ExitCode;
+				} else if (verbose > 0 && output.Length > 0 && !suppressPrintOnErrors) {
+					Console.WriteLine (output.ToString ());
+				}
+			}
+
+			return 0;
+		}
+
+		public static Task<int> RunCommandAsync (string path, string args, string [] env = null, StringBuilder output = null, bool suppressPrintOnErrors = false)
+		{
+			return Task.Run (() => RunCommand (path, args, env, output, suppressPrintOnErrors));
+		}
+	}
+}

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -325,6 +325,9 @@
     <Compile Include="..\common\Driver.cs">
       <Link>external\Driver.cs</Link>
     </Compile>
+    <Compile Include="..\common\Execution.cs">
+      <Link>external\Execution.cs</Link>
+    </Compile>
     <Compile Include="..\common\StaticRegistrar.cs">
       <Link>external\StaticRegistrar.cs</Link>
     </Compile>

--- a/tools/mtouch/mtouch.csproj
+++ b/tools/mtouch/mtouch.csproj
@@ -298,6 +298,9 @@
     <Compile Include="..\common\Driver.cs">
       <Link>external\Driver.cs</Link>
     </Compile>
+    <Compile Include="..\common\Execution.cs">
+      <Link>external\Execution.cs</Link>
+    </Compile>
     <Compile Include="..\common\TargetFramework.cs">
       <Link>external\TargetFramework.cs</Link>
     </Compile>


### PR DESCRIPTION
Also move the Driver.RunCommand method in mmp/mtouch to a separate file so
that the generator can re-use it.