### PR TITLE
[runtime] Implement support for an arm64 dynamic registrar.

### DIFF
--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -81,6 +81,9 @@ define NativeCompilationTemplate
 .libs/ios/%$(1).arm64.o: %.c $(EXTRA_DEPENDENCIES) | .libs/ios
 	$$(call Q_2,CC,    [ios]) $(DEVICE_CC) $(DEVICE64_CFLAGS)      $$(EXTRA_DEFINES) $(DEV64_I) -g $(2) -c $$< -o $$@ 
 
+.libs/ios/%$(1).arm64.o: %.s $(EXTRA_DEPENDENCIES) | .libs/ios
+	$$(call Q_2,ASM,   [ios]) $(DEVICE_CC) $(DEVICE64_CFLAGS)      $$(EXTRA_DEFINES) $(DEV64_I) -g $(2) -c $$< -o $$@
+
 .libs/ios/%$(1).arm64.dylib: | .libs/ios
 	$$(call Q_2,LD,    [ios]) $(DEVICE_CC) $(DEVICE64_CFLAGS)      $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(IOS_DESTDIR)$(XAMARIN_IPHONEOS_SDK)/usr/lib -fapplication-extension
 
@@ -141,6 +144,9 @@ define NativeCompilationTemplate
 
 .libs/tvos/%$(1).arm64.o: %.c $(EXTRA_DEPENDENCIES) | .libs/tvos
 	$$(call Q_2,CC,    [tvos]) $(DEVICE_CC)    $(DEVICETV_CFLAGS)            $$(EXTRA_DEFINES) $(DEV_TV_I) -g $(2) -c $$< -o $$@ 
+
+.libs/tvos/%$(1).arm64.o: %.s $(EXTRA_DEPENDENCIES) | .libs/tvos
+	$$(call Q_2,ASM,   [tvos]) $(DEVICE_CC)    $(DEVICETV_CFLAGS)            $$(EXTRA_DEFINES) $(DEV_TV_I) -g $(2) -c $$< -o $$@
 
 .libs/tvos/%$(1).arm64.dylib: | .libs/tvos
 	$$(call Q_2,LD,    [tvos]) $(DEVICE_CC)    $(DEVICETV_CFLAGS)            $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -L$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib -fapplication-extension

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -23,9 +23,10 @@ SHIPPED_HEADERS +=         \
 SHARED_SOURCES += mono-runtime.m bindings.m bindings-generated.m shared.m runtime.m trampolines.m trampolines-invoke.m xamarin-support.m nsstring-localization.m trampolines-varargs.m
 SHARED_I386_SOURCES += trampolines-i386.m trampolines-i386-asm.s trampolines-i386-objc_msgSend.s trampolines-i386-objc_msgSendSuper.s trampolines-i386-objc_msgSend_stret.s trampolines-i386-objc_msgSendSuper_stret.s
 SHARED_X86_64_SOURCES += trampolines-x86_64.m trampolines-x86_64-asm.s trampolines-x86_64-objc_msgSend.s trampolines-x86_64-objc_msgSendSuper.s trampolines-x86_64-objc_msgSend_stret.s trampolines-x86_64-objc_msgSendSuper_stret.s
+SHARED_ARM64_SOURCES += trampolines-arm64.m trampolines-arm64-asm.s
 SHARED_HEADERS += shared.h product.h delegates.h runtime-internal.h $(SHARED_INC) $(SHIPPED_HEADERS) trampolines-internal.h slinked-list.h
 
-SHARED_FILES = $(SHARED_SOURCES) $(SHARED_HEADERS) $(SHARED_I386_SOURCES) $(SHARED_X86_64_SOURCES)
+SHARED_FILES = $(SHARED_SOURCES) $(SHARED_HEADERS) $(SHARED_I386_SOURCES) $(SHARED_X86_64_SOURCES) $(SHARED_ARM64_SOURCES)
 
 EXTRA_DEPENDENCIES = $(SHARED_HEADERS) $(TOP)/Make.config
 
@@ -83,6 +84,7 @@ MONOTOUCH_FRAMEWORKS =  \
 MONOTOUCH_SOURCE_STEMS = $(patsubst %.s,%,$(patsubst %.m,%,$(SHARED_SOURCES) $(MONOTOUCH_SOURCES)))
 MONOTOUCH_I386_SOURCE_STEMS = $(patsubst %.s,%,$(patsubst %.m,%,$(SHARED_I386_SOURCES)))
 MONOTOUCH_X86_64_SOURCE_STEMS = $(patsubst %.s,%,$(patsubst %.m,%,$(SHARED_X86_64_SOURCES)))
+MONOTOUCH_ARM64_SOURCE_STEMS = $(patsubst %.s,%,$(patsubst %.m,%,$(SHARED_ARM64_SOURCES)))
 
 #
 # PlatformTemplate contains the install targets and sets up some variables
@@ -95,6 +97,7 @@ $(2)_HEADERS       = $(MONOTOUCH_HEADERS)
 $(2)_SOURCE_STEMS  = $(MONOTOUCH_SOURCE_STEMS)
 $(2)_X86_64_SOURCE_STEMS = $(MONOTOUCH_X86_64_SOURCE_STEMS)
 $(2)_I386_SOURCE_STEMS = $(MONOTOUCH_I386_SOURCE_STEMS)
+$(2)_ARM64_SOURCE_STEMS = $(MONOTOUCH_ARM64_SOURCE_STEMS)
 $(2)_LIBRARIES     = $(MONOTOUCH_LIBS)
 ifdef INCLUDE_DEVICE
 $(2)_DEVICE_ARCHITECTURES = $(3)
@@ -332,7 +335,7 @@ x86_64_$(1)$(3)_OBJECTS = $$(patsubst %,.libs/$(1)/%$(4).x86_64.o,$$($(2)_SOURCE
 armv7_$(1)$(3)_OBJECTS  = $$(patsubst %,.libs/$(1)/%$(4).armv7.o,$$($(2)_SOURCE_STEMS))
 armv7s_$(1)$(3)_OBJECTS = $$(patsubst %,.libs/$(1)/%$(4).armv7s.o,$$($(2)_SOURCE_STEMS))
 armv7k_$(1)$(3)_OBJECTS = $$(patsubst %,.libs/$(1)/%$(4).armv7k.o,$$($(2)_SOURCE_STEMS))
-arm64_$(1)$(3)_OBJECTS  = $$(patsubst %,.libs/$(1)/%$(4).arm64.o,$$($(2)_SOURCE_STEMS))
+arm64_$(1)$(3)_OBJECTS  = $$(patsubst %,.libs/$(1)/%$(4).arm64.o,$$($(2)_SOURCE_STEMS))  $$(patsubst %,.libs/$(1)/%$(4).arm64.o,$$($(2)_ARM64_SOURCE_STEMS))
 
 $$(foreach arch,$$($(2)_ARCHITECTURES),$$(eval $$(call LibXamarinArchTemplate,$(1),$(2),$(3),$(4),$$(arch))))
 

--- a/runtime/trampolines-arm64-asm.s
+++ b/runtime/trampolines-arm64-asm.s
@@ -1,0 +1,126 @@
+#
+# store all parameters in a consistent way, and send it off to managed code.
+# we need to store:
+#   x0-x9, x16
+#   q0-q7
+#   x29, x30 (for the stack frame)
+#   an unknown amount of stack space, but we can pass a pointer to the start of this area.
+# in total we need 11*64bits registers + 8*128bits registers + 2*64bits register = 232 bytes.
+# the 128 bit registers need to be 16-byte aligned, so there's a register-sized padding before the qX registers, thus total 240 bytes.
+# in addition we store a copy of x0 and x1 as _self and _sel, so that we can get those values even if
+# x0 and x1 change (which they might very well do after processing the return value, so 240 + 2*8 = 256 bytes.
+#
+# upon return we may need to write to:
+#   x0, x1
+#   q0, q1, q2, q3
+#
+
+#if __arm64__
+
+.subsections_via_symbols
+.text
+.align 2
+_xamarin_arm64_common_trampoline:
+	mov x9, sp ;#Save sp to a temporary register
+	sub sp, sp, #256 ;# allocate 224 bytes from the stack (stack must always be 16-byte aligned) + 16 bytes for the stack frame + 8*2 bytes for _self and _sel
+
+	# Create stack frame
+	stp x29, x30, [sp, #0x00]
+	mov x29, sp
+
+	stp x16, x9, [sp, #0x10]
+	stp  x0, x1, [sp, #0x20]
+	stp  x2, x3, [sp, #0x30]
+	stp  x4, x5, [sp, #0x40]
+	stp  x6, x7, [sp, #0x50]
+	str  x8,     [sp, #0x60]
+
+	stp  q0, q1, [sp, #0x70]
+	stp  q2, q3, [sp, #0x90]
+	stp  q4, q5, [sp, #0xb0]
+	stp  q6, q7, [sp, #0xd0]
+
+	add x0, sp, #0x10 ;# the first two pointers are the stack frame (x29, x30), the rest is a pointer to a XamarinCallState struct.
+	bl	_xamarin_arch_trampoline
+
+	# get return value(s)
+
+	ldp x16, x9, [sp, #0x10]
+	ldp  x0, x1, [sp, #0x20]
+	ldp  x2, x3, [sp, #0x30]
+	ldp  x4, x5, [sp, #0x40]
+	ldp  x6, x7, [sp, #0x50]
+	ldr  x8,     [sp, #0x60]
+
+	ldp  q0, q1, [sp, #0x70]
+	ldp  q2, q3, [sp, #0x90]
+	ldp  q4, q5, [sp, #0xb0]
+	ldp  q6, q7, [sp, #0xd0]
+
+	ldp	x29, x30, [sp, #0x00]
+	add sp, sp, #256 ;# deallocate 224 bytes from the stack + 16 bytes for stack frame + 8*2 bytes for _self and _sel
+
+	ret
+
+#
+# trampolines
+#
+
+.globl _xamarin_trampoline
+_xamarin_trampoline:
+	mov	x16, #0x0
+	b	_xamarin_arm64_common_trampoline
+
+.globl _xamarin_static_trampoline
+_xamarin_static_trampoline:
+	mov	x16, #0x1
+	b	_xamarin_arm64_common_trampoline
+
+.globl _xamarin_ctor_trampoline
+_xamarin_ctor_trampoline:
+	mov	x16, #0x2
+	b _xamarin_arm64_common_trampoline
+
+.globl _xamarin_fpret_single_trampoline
+_xamarin_fpret_single_trampoline:
+	mov	x16, #0x4
+	b _xamarin_arm64_common_trampoline
+
+.globl _xamarin_static_fpret_single_trampoline
+_xamarin_static_fpret_single_trampoline:
+	mov	x16, #0x5
+	b _xamarin_arm64_common_trampoline
+
+.globl _xamarin_fpret_double_trampoline
+_xamarin_fpret_double_trampoline:
+	mov	x16, #0x8
+	b _xamarin_arm64_common_trampoline
+
+.globl _xamarin_static_fpret_double_trampoline
+_xamarin_static_fpret_double_trampoline:
+	mov	x16, #0x9
+	b _xamarin_arm64_common_trampoline
+
+.globl _xamarin_stret_trampoline
+_xamarin_stret_trampoline:
+	mov	x16, #0x10
+	b _xamarin_arm64_common_trampoline
+
+.globl _xamarin_static_stret_trampoline
+_xamarin_static_stret_trampoline:
+	mov	x16, #0x11
+	b _xamarin_arm64_common_trampoline
+
+.globl _xamarin_longret_trampoline
+_xamarin_longret_trampoline:
+	mov	x16, #0x20
+	b _xamarin_arm64_common_trampoline
+
+.globl _xamarin_static_longret_trampoline
+_xamarin_static_longret_trampoline:
+	mov	x16, #0x21
+	b _xamarin_arm64_common_trampoline
+
+# etc...
+
+#endif

--- a/runtime/trampolines-arm64.h
+++ b/runtime/trampolines-arm64.h
@@ -1,0 +1,69 @@
+#ifndef __TRAMPOLINES_ARM64_H__
+#define __TRAMPOLINES_ARM64_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct BigDouble {
+	union {
+		__int128 bits;
+		long double d;
+		struct f {
+			float f1;
+			float f2;
+		};
+		struct f f;
+	};
+};
+
+struct XamarinCallState {
+	uint64_t type;
+	uint64_t sp;
+	uint64_t x0;
+	uint64_t x1;
+	uint64_t x2;
+	uint64_t x3;
+	uint64_t x4;
+	uint64_t x5;
+	uint64_t x6;
+	uint64_t x7;
+	uint64_t x8;
+
+	struct BigDouble q0;
+	struct BigDouble q1;
+	struct BigDouble q2;
+	struct BigDouble q3;
+	struct BigDouble q4;
+	struct BigDouble q5;
+	struct BigDouble q6;
+	struct BigDouble q7;
+
+	// Make a copy of x0/x1, so the sel() and self () functions return the correct values even after putting return values to x0/x1.
+	id _self;
+	SEL _sel;
+
+	bool is_stret () { return false; }
+	id self () { return _self; }
+	SEL sel () { return _sel; }
+};
+
+struct ParamIterator {
+	struct XamarinCallState *state;
+	int ngrn; // Next General-purpose Register Number
+	int nsrn; // Next SIMD and Floating-point Register Number
+	uint8_t *nsaa; // Next stacked argument address.
+
+	// computed values
+	uint64_t *x;
+	struct BigDouble *q;
+};
+
+void xamarin_arch_trampoline (struct XamarinCallState *state);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* __TRAMPOLINES_ARM64_H__ */
+

--- a/runtime/trampolines-arm64.m
+++ b/runtime/trampolines-arm64.m
@@ -1,0 +1,320 @@
+
+#if defined(__arm64__)
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <objc/objc.h>
+#include <objc/runtime.h>
+#include <objc/message.h>
+
+#include "trampolines-internal.h"
+#include "xamarin/runtime.h"
+#include "runtime-internal.h"
+#include "trampolines-arm64.h"
+#include "product.h"
+
+/*
+ * https://developer.apple.com/library/archive/documentation/Xcode/Conceptual/iPhoneOSABIReference/Articles/ARM64FunctionCallingConventions.html
+ *
+ * Standard arm64 calling convention:
+ * Input:
+ *   x0 - x7 (x8 too in some cases)
+ *   q0 - q7 (simd/floating point)
+ * Output:
+ *   same as input
+ *
+ */
+
+#ifdef TRACE
+static void
+dump_state (struct XamarinCallState *state, const char *prefix)
+{
+	fprintf (stderr, "%stype: %llu self: %p SEL: %s sp: 0x%llx x0: 0x%llx x1: 0x%llx x2: 0x%llx x3: 0x%llx x4: 0x%llx x5: 0x%llx x6: 0x%llx x7: 0x%llx x8: 0x%llx -- q0: %Lf q1: %Lf q2: %Lf q3: %Lf q4: %Lf q5: %Lf q6: %Lf q7: %Lf\n",
+		prefix, state->type, state->self (), sel_getName (state->sel ()), state->sp, state->x0, state->x1, state->x2, state->x3, state->x4, state->x5, state->x6, state->x7, state->x8,
+		state->q0.d, state->q1.d, state->q2.d, state->q3.d, state->q4.d, state->q5.d, state->q6.d, state->q7.d);
+}
+#else
+#define dump_state(...)
+#endif
+
+static int
+param_read_primitive (struct ParamIterator *it, const char *type_ptr, void *target, size_t total_size, guint32 *exception_gchandle)
+{
+	// COOP: does not access managed memory: any mode.
+	char type = *type_ptr;
+	LOGZ ("        reading primitive %c. total size: %i nsrn: %i ngrn: %i nsaa: %p\n", type, (int) total_size, it->nsrn, it->ngrn, it->nsaa);
+
+	switch (type) {
+	case _C_FLT: {
+		if (it->nsrn < 8) {
+			if (target != NULL) {
+				*(float *) target = *(float *) &it->q [it->nsrn];
+				LOGZ ("        reading float at q%i into %p: %f\n", it->nsrn, target, *(float *) target);
+			}
+			it->nsrn++;
+		} else {
+			if (target != NULL) {
+				*(float *) target = *(float *) it->nsaa;
+				LOGZ ("        reading float at stack %p into %p: %f\n", it->nsaa, target, *(float *) target);
+			}
+			it->nsaa += 4;
+		}
+		return 4;
+	}
+	case _C_DBL: {
+		if (it->nsrn < 8) {
+			if (target != NULL) {
+				*(double *) target = *(double *) &it->q [it->nsrn];
+				LOGZ ("        reading double at q%i into %p: %f\n", it->nsrn, target, *(double *) target);
+			}
+			it->nsrn++;
+		} else {
+			if (target != NULL) {
+				*(double *) target = *(double *) it->nsaa;
+				LOGZ ("        reading double at stack %p into %p: %f\n", it->nsaa, target, *(double *) target);
+			}
+			it->nsaa += 8;
+		}
+		return 8;
+	}
+	default: {
+		size_t size = xamarin_get_primitive_size (type);
+
+		if (size == 0)
+			return 0;
+
+		uint8_t *ptr;
+		bool read_register = it->ngrn < 8;
+
+		if (read_register) {
+			ptr = (uint8_t *) &it->x [it->ngrn];
+			if (target != NULL) {
+				LOGZ ("        reading primitive of size %i from x%i into %p: ", (int) size, it->ngrn, target);
+			}
+			it->ngrn++;
+		} else {
+			ptr = (uint8_t *) it->nsaa;
+			if (target != NULL) {
+				LOGZ ("        reading primitive of size %i from %p into %p: ",  (int) size, ptr, target);
+			}
+			it->nsaa += size;
+		}
+
+		if (target == NULL) {
+			LOGZ (" not reading, since target is NULL.\n");
+			return size;
+		}
+
+		switch (size) {
+		case 8:
+			*(uint64_t *) target = *(uint64_t *) ptr;
+			LOGZ ("0x%llx = %llu\n", * (uint64_t *) target, * (uint64_t *) target);
+			break;
+		case 4:
+			*(uint32_t *) target = *(uint32_t *) ptr;
+			LOGZ ("0x%x = %u\n", * (uint32_t *) target, * (uint32_t *) target);
+			break;
+		case 2:
+			*(uint16_t *) target = *(uint16_t *) ptr;
+			LOGZ ("0x%x = %u\n", (int) * (uint32_t *) target, (int) * (uint32_t *) target);
+			break;
+		case 1:
+			*(uint8_t *) target = *(uint8_t *) ptr;
+			LOGZ ("0x%x = %u = '%c'\n", (int) * (uint8_t *) target, (int) * (uint8_t *) target, (char) * (uint8_t *) target);
+			break;
+		default:
+			*exception_gchandle = xamarin_create_mt_exception (xamarin_strdup_printf (PRODUCT ": Cannot marshal parameter type %c (size: %i): invalid size.\n", type, (int) size));
+			return 0;
+		}
+
+		return size;
+	}
+	}
+}
+
+static void
+param_iter_next (enum IteratorAction action, void *context, const char *type, size_t size, void *target, guint32 *exception_gchandle)
+{
+	// COOP: does not access managed memory: any mode.
+	struct ParamIterator *it = (struct ParamIterator *) context;
+
+	if (action == IteratorStart) {
+		it->ngrn = 2; // we already have two arguments: self + SEL
+		it->nsrn = 0;
+		it->nsaa = (uint8_t *) it->state->sp;
+		it->x = &it->state->x0;
+		it->q = &it->state->q0;
+		LOGZ ("    initialized parameter iterator. next register: %i next fp register: %i next stack pointer: %p\n", it->ngrn, it->nsrn, it->nsaa);
+		return;
+	} else if (action == IteratorEnd) {
+		return;
+	}
+
+	// target must be at least pointer sized, and we need to zero it out first.
+	if (target != NULL)
+		*(uint64_t *) target = 0;
+
+	char struct_name [5]; // we don't care about structs with more than 4 fields.
+	xamarin_collapse_struct_name (type, struct_name, sizeof (struct_name), exception_gchandle);
+	if (*exception_gchandle != 0)
+		return;
+
+	if (size > 16 && strcmp (struct_name, "dddd") && strcmp (struct_name, "ddd")) {
+		LOGZ ("    reading parameter passed by reference. type: %s size: %i nsaa: %p\n", type, (int) size, it->nsaa);
+		// passed on the stack
+		if (target != NULL)
+			memcpy (target, it->nsaa, size);
+		// increment stack pointer
+		it->nsaa += size;
+		return;
+	}
+
+	if (*struct_name == 0) {
+		*exception_gchandle = xamarin_create_mt_exception (xamarin_strdup_printf (PRODUCT ": Cannot marshal parameter type %s, collapsed type name is empty\n", type));
+		return;
+	}
+
+	// passed in registers (and on the stack if not enough registers)
+	LOGZ ("    reading parameter from registers/stack. type: %s (collapsed: %s) size: %i\n", type, struct_name, (int) size);
+	const char *t = struct_name;
+	uint8_t *targ = (uint8_t *) target;
+	do {
+		int c = param_read_primitive (it, t, targ, size, exception_gchandle);
+		if (*exception_gchandle != 0)
+			return;
+		if (targ != NULL)
+			targ += c;
+	} while (*++t);
+}
+
+static void
+marshal_return_value (void *context, const char *type, size_t size, void *vvalue, MonoType *mtype, bool retain, MonoMethod *method, MethodDescription *desc, guint32 *exception_gchandle)
+{
+	// COOP: accessing managed memory (as input), so must be in unsafe mode.
+	MONO_ASSERT_GC_UNSAFE;
+
+	char struct_name[5];
+	MonoObject *value = (MonoObject *) vvalue;
+	struct ParamIterator *it = (struct ParamIterator *) context;
+
+	LOGZ ("    marshalling return value %p as %s with size %i\n", value, type, (int) size);
+
+	switch (type [0]) {
+	case _C_FLT:
+		// single floating point return value
+		it->state->q0.f.f1 = *(float *) mono_object_unbox (value);
+		break;
+	case _C_DBL:
+		// double floating point return value
+		it->state->q0.d = *(double *) mono_object_unbox (value);
+		break;
+	case _C_STRUCT_B:
+		/*
+		 * Structures, this is ugly, but not as bad as x86_64.
+		 *
+		 * A) Structures of 1 to 4 fields of the same floating point type (float or double), are passed in the q[0-3] registers.
+		 * B) Any other structure > 16 bytes is passed by reference (pointer to memory in x8)
+		 * C) Structures <= 16 bytes are passed in x0 and x1 as needed. Each register can contain multiple fields.
+		 */
+
+		xamarin_collapse_struct_name (type, struct_name, sizeof (struct_name), exception_gchandle);
+		if (*exception_gchandle != 0)
+			return;
+
+		if ((size == 32 && !strncmp (struct_name, "dddd", 4)) ||
+			(size == 24 && !strncmp (struct_name, "ddd", 3)) ||
+			(size == 16 && !strncmp (struct_name, "dd", 2)) ||
+			(size == 8 && !strncmp (struct_name, "d", 1))) {
+			LOGZ ("        marshalling as %i doubles (struct name: %s)\n", (int) size / 8, struct_name);
+			double* ptr = (double *) mono_object_unbox (value);
+			for (int i = 0; i < size / 8; i++) {
+				LOGZ ("        #%i: %f\n", i, ptr [i]);
+				it->q [i].d = ptr [i];
+			}
+		} else if ((size == 16 && !strncmp (struct_name, "ffff", 4)) ||
+				   (size == 12 && !strncmp (struct_name, "fff", 3)) ||
+				   (size == 8 && !strncmp (struct_name, "ff", 2)) ||
+				   (size == 4 && !strncmp (struct_name, "f", 1))) {
+			LOGZ ("        marshalling as %i floats (struct name: %s)\n", (int) size / 4, struct_name);
+			float* ptr = (float *) mono_object_unbox (value);
+			for (int i = 0; i < size / 4; i++) {
+				LOGZ ("        #%i: %f\n", i, ptr [i]);
+				it->q [i].f.f1 = ptr [i];
+			}
+		} else if (size > 16) {
+			LOGZ ("        marshalling as stret through x8\n");
+			memcpy ((void *) it->state->x8, mono_object_unbox (value), size);
+		} else {
+			LOGZ ("        marshalling as composite values in x0 and x1\n");
+			it->state->x0 = 0;
+			it->state->x1 = 0;
+			memcpy (&it->state->x0, mono_object_unbox (value), size);
+		}
+		break;
+	// For primitive types we get a pointer to the actual value
+	case _C_BOOL: // signed char
+	case _C_CHR:
+	case _C_UCHR:
+		it->state->x0 = *(uint8_t *) mono_object_unbox (value);
+		break;
+	case _C_SHT:
+	case _C_USHT:
+		it->state->x0 = *(uint16_t *) mono_object_unbox (value);
+		break;
+	case _C_INT:
+	case _C_UINT:
+		it->state->x0 = *(uint32_t *) mono_object_unbox (value);
+		break;
+	case _C_LNG:
+	case _C_ULNG:
+	case _C_LNG_LNG:
+	case _C_ULNG_LNG:
+		it->state->x0 = *(uint64_t *) mono_object_unbox (value);
+		break;
+
+	// For pointer types we get the value itself.
+	case _C_CLASS:
+	case _C_SEL:
+	case _C_ID:
+	case _C_CHARPTR:
+	case _C_PTR:
+		if (value == NULL) {
+			it->state->x0 = 0;
+			break;
+		}
+
+		it->state->x0 = (uint64_t) xamarin_marshal_return_value (it->state->sel (), mtype, type, value, retain, method, desc, exception_gchandle);
+		break;
+	case _C_VOID:
+		break;
+	case '|': // direct pointer value
+	default:
+		if (size == 8) {
+			it->state->x0 = (uint64_t) value;
+		} else {
+			*exception_gchandle = xamarin_create_mt_exception (xamarin_strdup_printf (PRODUCT ": Cannot marshal return type %s (size: %i)\n", type, (int) size));
+		}
+		break;
+	}
+}
+
+void
+xamarin_arch_trampoline (struct XamarinCallState *state)
+{
+	// COOP: called from ObjC, and does not access managed memory.
+	MONO_ASSERT_GC_SAFE;
+
+	state->_self = (id) state->x0;
+	state->_sel = (SEL) state->x1;
+
+	dump_state (state, "BEGIN: ");
+	struct ParamIterator iter;
+	iter.state = state;
+	xamarin_invoke_trampoline ((enum TrampolineType) state->type, state->self (), state->sel (), param_iter_next, marshal_return_value, &iter);
+	dump_state (state, "END: ");
+}
+
+#endif /* __arm64__ */

--- a/runtime/trampolines-internal.h
+++ b/runtime/trampolines-internal.h
@@ -6,7 +6,7 @@
 #include "xamarin/mono-runtime.h"
 #include "xamarin/runtime.h"
 
-#define TRACE
+//#define TRACE
 #ifdef TRACE
 #define LOGZ(...) fprintf (stderr, __VA_ARGS__);
 #else

--- a/runtime/trampolines-varargs.m
+++ b/runtime/trampolines-varargs.m
@@ -1,4 +1,4 @@
-﻿#if !defined (__i386__) && !defined (__x86_64__)
+#if !defined (__i386__) && !defined (__x86_64__) && !defined (__arm64__)
 #define __VARARGS_TRAMPOLINES__ 1
 #endif
 

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -36,6 +36,7 @@ int			xamarin_get_gchandle_trampoline (id self, SEL sel);
 void		xamarin_set_gchandle_trampoline (id self, SEL sel, int gc_handle);
 
 int			xamarin_get_frame_length (id self, SEL sel);
+bool		xamarin_collapse_struct_name (const char *type, char struct_name[], int max_char, guint32 *exception_gchandle);
 guint32		xamarin_create_mt_exception (char *msg);
 size_t		xamarin_get_primitive_size (char type);
 

--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -814,42 +814,8 @@ namespace Registrar {
 			/*FIXME try to guess the name of the missing library - quite trivial for monotouch.dll*/
 			// types decorated with [Model] attribute are not registered (see registrar.cs and regression from #769)
 			if (type.IsWrapper && !type.IsModel) {
-				if (!IsSimulatorOrDesktop) {
-					// This can happen when Apple introduces new types and puts them as base types for already
-					// existing types. We can't throw any exceptions in that case, since the derived class
-					// can still be used in older iOS versions.
-
-					// Hardcode these types to ignore any loading errors.
-					// We could also look at the AvailabilityAttribute, but it would require us
-					// to not link it away anymore like we currently do.
-
-#if !COREBUILD && !MONOMAC && !WATCH
-					var major = -1;
-					switch (type.Name) {
-					case "PKObject":
-					case "CBAttribute":
-					case "CBPeer":
-						major = 8;
-						break;
-					case "GKGameCenterViewController":
-						major = 6;
-						break;
-					case "CBManager":
-					case "GKBasePlayer":
-						major = 10;
-						break;
-					}
-					if ((major > 0) && !UIDevice.CurrentDevice.CheckSystemVersion (major, 0))
-						return;
-#endif
-
-					// a missing [Model] attribute will cause this error on devices (e.g. bug #4864)
-					throw ErrorHelper.CreateError (8005, "Wrapper type '{0}' is missing its native ObjectiveC class '{1}'.", type.Type.FullName, type.Name);
-				} else {
-					/*On simulator this is a common issue since we eagerly register all types. This is an issue with unlinked
-					monotouch.dll since we don't link all frameworks most of the time. */
-					return;
-				}
+				// This is a common issue if we use the dynamic registrar, since we eagerly register all types.
+				return;
 			}
 
 			if (type.IsFakeProtocol)

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -222,6 +222,7 @@ namespace xharness
 
 			// 32-bit interpreter doesn't work yet: https://github.com/mono/mono/issues/9871
 			var supports_interpreter = test.Platform != TestPlatform.iOS_Unified32;
+			var supports_dynamic_registrar_on_device = test.Platform == TestPlatform.iOS_Unified64 || test.Platform == TestPlatform.tvOS;
 
 			switch (test.ProjectPlatform) {
 			case "iPhone":
@@ -239,6 +240,8 @@ namespace xharness
 
 				switch (test.TestName) {
 				case "monotouch-test":
+					if (supports_dynamic_registrar_on_device)
+						yield return new TestData { Variation = "Debug (dynamic registrar)", MTouchExtraArgs = "--registrar:dynamic", Debug = true, Profiling = false };
 					yield return new TestData { Variation = "Release (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = false, Profiling = false, Defines = "OPTIMIZEALL" };
 					yield return new TestData { Variation = "Debug (all optimizations)", MTouchExtraArgs = "--registrar:static --optimize:all", Debug = true, Profiling = false, Defines = "OPTIMIZEALL" };
 					yield return new TestData { Variation = "Debug: SGenConc", MTouchExtraArgs = "", Debug = true, Profiling = false, MonoNativeLinkMode = MonoNativeLinkMode.Static, EnableSGenConc = true};


### PR DESCRIPTION
This is required in order to execute downloaded assemblies (or any other
assembly not known at compile time) on device.