### PR TITLE
[xharness] Fix finding labels in pull requests.

### DIFF
--- a/tests/xharness/GitHub.cs
+++ b/tests/xharness/GitHub.cs
@@ -46,7 +46,7 @@ namespace xharness
 				var doc = new XmlDocument ();
 				doc.Load (reader);
 				var rv = new List<string> ();
-				foreach (XmlNode node in doc.SelectNodes ("/root/labels/name")) {
+				foreach (XmlNode node in doc.SelectNodes ("/root/labels/item/name")) {
 					rv.Add (node.InnerText);
 				}
 				return rv;


### PR DESCRIPTION
Looks like this regressed in
https://github.com/xamarin/xamarin-macios/commit/61bf0db817030c0912a42c43bd8382e69c0f4937#diff-b01110f512ec4a442e37213063a11758R39;
since then no manual labels have been applied to test runs in public jenkins.