### PR TITLE
[xharness] Don't only build if asked to run using the UI.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1377,6 +1377,7 @@ namespace xharness
 										writer.WriteLine ($"Test '{task.TestName}' is already executing.");
 									} else {
 										task.Reset ();
+										task.BuildOnly = false;
 										task.RunAsync ();
 									}
 								}


### PR DESCRIPTION
This makes it possible to run tests that are marked as 'BuildOnly' to see if
they've been fixed or not.

There's already a 'build' button if only a build is desired.