### PR TITLE
[mtouch/mmp] Make the mono native mode a Target-specific variable.

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -87,7 +87,7 @@ namespace Xamarin.Bundler {
 	
 		public bool Embeddinator { get; set; }
 
-		public MonoNativeMode MonoNativeMode { get; set; }
+		public List<Target> Targets = new List<Target> ();
 
 		public Application (string[] arguments)
 		{
@@ -321,7 +321,8 @@ namespace Xamarin.Bundler {
 		{
 			Namespaces.Initialize ();
 			SelectRegistrar ();
-			SelectMonoNative ();
+			foreach (var target in Targets)
+				target.SelectMonoNative ();
 
 			if (RequiresXcodeHeaders && SdkVersion < SdkVersions.GetVersion (Platform)) {
 				throw ErrorHelper.CreateError (91, "This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). Either upgrade Xcode to get the required header files or {4} (to try to avoid the new APIs).", ProductName, PlatformName, SdkVersions.GetVersion (Platform), SdkVersions.Xcode, Error91LinkerSuggestion);

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -54,6 +54,8 @@ namespace Xamarin.Bundler {
 		// Note that each 'Target' can have multiple abis: armv7+armv7s for instance.
 		public List<Abi> Abis;
 
+		public MonoNativeMode MonoNativeMode { get; set; }
+
 #if MONOMAC
 		public bool Is32Build { get { return !Driver.Is64Bit; } }
 		public bool Is64Build { get { return Driver.Is64Bit; } }

--- a/tools/mmp/Application.cs
+++ b/tools/mmp/Application.cs
@@ -22,13 +22,5 @@ namespace Xamarin.Bundler {
 		{
 			Driver.SelectRegistrar ();
 		}
-
-		void SelectMonoNative ()
-		{
-			if (DeploymentTarget >= new Version (10, 12))
-				MonoNativeMode = MonoNativeMode.Unified;
-			else
-				MonoNativeMode = MonoNativeMode.Compat;
-		}
 	}
 }

--- a/tools/mmp/Target.mmp.cs
+++ b/tools/mmp/Target.mmp.cs
@@ -1,0 +1,17 @@
+// Copyright 2019 Microsoft Corp. All rights reserved.
+
+using System;
+
+namespace Xamarin.Bundler
+{
+	partial class Target
+	{
+		public void SelectMonoNative ()
+		{
+			if (App.DeploymentTarget >= new Version (10, 12))
+				MonoNativeMode = MonoNativeMode.Unified;
+			else
+				MonoNativeMode = MonoNativeMode.Compat;
+		}
+	}
+}

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -501,6 +501,7 @@ namespace Xamarin.Bundler {
 				Profile.Current = new MacMobileProfile (arch == "x86_64" ? 64 : 32);
 
 			BuildTarget = new Target (App);
+			App.Targets.Add (BuildTarget);
 			App.InitializeCommon ();
 
 			Log ("Xamarin.Mac {0}.{1}", Constants.Version, Constants.Revision);
@@ -879,7 +880,7 @@ namespace Xamarin.Bundler {
 				name = "libmono-system-native";
 			} else {
 				// use modern libmono-native
-				switch (App.MonoNativeMode) {
+				switch (BuildTarget.MonoNativeMode) {
 				case MonoNativeMode.Unified:
 					name = "libmono-native-unified";
 					break;
@@ -887,13 +888,13 @@ namespace Xamarin.Bundler {
 					name = "libmono-native-compat";
 					break;
 				default:
-					throw ErrorHelper.CreateError (99, $"Internal error: Invalid mono native type: '{App.MonoNativeMode}'. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).");
+					throw ErrorHelper.CreateError (99, $"Internal error: Invalid mono native type: '{BuildTarget.MonoNativeMode}'. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).");
 				}
 			}
 
 			var src = Path.Combine (MonoDirectory, "lib", name + ".dylib");
 			var dest = Path.Combine (mmp_dir, "libmono-native.dylib");
-			Watch ($"Adding mono-native library {name} for {App.MonoNativeMode}.", 1);
+			Watch ($"Adding mono-native library {name} for {BuildTarget.MonoNativeMode}.", 1);
 
 			if (App.Optimizations.TrimArchitectures == true) {
 				// copy to temp directory and lipo there to avoid touching the final dest file if it's up to date
@@ -1330,7 +1331,7 @@ namespace Xamarin.Bundler {
 					} else {
 						// add modern libmono-native
 						string libmono_native_name;
-						switch (App.MonoNativeMode) {
+						switch (BuildTarget.MonoNativeMode) {
 						case MonoNativeMode.Unified:
 							libmono_native_name = "libmono-native-unified";
 							break;
@@ -1338,7 +1339,7 @@ namespace Xamarin.Bundler {
 							libmono_native_name = "libmono-native-compat";
 							break;
 						default:
-							throw ErrorHelper.CreateError (99, $"Invalid error: Invalid mono native type: '{App.MonoNativeMode}'. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).");
+							throw ErrorHelper.CreateError (99, $"Invalid error: Invalid mono native type: '{BuildTarget.MonoNativeMode}'. Please file a bug report with a test case (https://github.com/xamarin/xamarin-macios/issues/new).");
 						}
 
 						args.Append (StringUtils.Quote (Path.Combine (libdir, libmono_native_name + ".a"))).Append (' ');

--- a/tools/mmp/mmp.csproj
+++ b/tools/mmp/mmp.csproj
@@ -412,6 +412,7 @@
     <Compile Include="..\common\ClassicStaticRegistrar.cs">
       <Link>external\ClassicStaticRegistrar.cs</Link>
     </Compile>
+    <Compile Include="Target.mmp.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/tools/mtouch/BuildTasks.mtouch.cs
+++ b/tools/mtouch/BuildTasks.mtouch.cs
@@ -109,7 +109,7 @@ namespace Xamarin.Bundler
 
 		protected override void Execute ()
 		{
-			Driver.GenerateMain (Target.App, Target.Assemblies, Target.App.AssemblyName, Abi, MainM, RegistrationMethods);
+			Driver.GenerateMain (Target, Target.Assemblies, Target.App.AssemblyName, Abi, MainM, RegistrationMethods);
 		}
 	}
 

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -484,8 +484,9 @@ namespace Xamarin.Bundler
 		}
 
 		// note: this is executed under Parallel.ForEach
-		public static string GenerateMain (Application app, IEnumerable<Assembly> assemblies, string assembly_name, Abi abi, string main_source, IList<string> registration_methods)
+		public static string GenerateMain (Target target, IEnumerable<Assembly> assemblies, string assembly_name, Abi abi, string main_source, IList<string> registration_methods)
 		{
+			var app = target.App;
 			var assembly_externs = new StringBuilder ();
 			var assembly_aot_modules = new StringBuilder ();
 			var register_assemblies = new StringBuilder ();
@@ -614,12 +615,12 @@ namespace Xamarin.Bundler
 						}
 					}
 
-					if (app.MonoNativeMode != MonoNativeMode.None) {
+					if (target.MonoNativeMode != MonoNativeMode.None) {
 						string mono_native_lib;
 						if (app.LibMonoNativeLinkMode == AssemblyBuildTarget.StaticObject)
 							mono_native_lib = "__Internal";
 						else
-							mono_native_lib = app.GetLibNativeName () + ".dylib";
+							mono_native_lib = target.GetLibNativeName () + ".dylib";
 						sw.WriteLine ();
 						sw.WriteLine ($"\tmono_dllmap_insert (NULL, \"System.Native\", NULL, \"{mono_native_lib}\", NULL);");
 						sw.WriteLine ($"\tmono_dllmap_insert (NULL, \"System.Security.Cryptography.Native.Apple\", NULL, \"{mono_native_lib}\", NULL);");


### PR DESCRIPTION
The arm64_32 slice for watchOS apps will always use the 'unified' mode, while
the armv7k can be both 'unified' and 'compat' depending on the deployment
target, so we need to keep track of this per Target.

This PR does not change anything related to arm64_32, that will come in a
later PR.