### PR TITLE
[xharness] Flush the log after getting results from listing simulators/devices with mlaunch.

### DIFF
--- a/tests/xharness/Simulators.cs
+++ b/tests/xharness/Simulators.cs
@@ -705,6 +705,7 @@ namespace xharness
 							throw new Exception ("Failed to list devices.");
 						log.WriteLine ("Result:");
 						log.WriteLine (File.ReadAllText (tmpfile));
+						log.Flush ();
 
 						var doc = new XmlDocument ();
 						doc.LoadWithoutNetworkAccess (tmpfile);
@@ -738,6 +739,7 @@ namespace xharness
 				} finally {
 					connected_devices.SetCompleted ();
 					File.Delete (tmpfile);
+					log.Flush ();
 				}
 			});
 		}


### PR DESCRIPTION
Now constantly refreshing the device/simulator listing log will show the
output as mlaunch writes it, which makes the impatient me happier.