### PR TITLE
Fix mlaunch build.

### DIFF
--- a/tools/common/MachO.cs
+++ b/tools/common/MachO.cs
@@ -6,6 +6,8 @@ using System.Text;
 
 #if MLAUNCH
 using Xamarin.Launcher;
+#elif XAMARIN_HOSTING
+using Xamarin.Hosting;
 #else
 using Xamarin.Bundler;
 #endif


### PR DESCRIPTION
An mlaunch fix in master required a code change in xamarin-macios; when
backporting this mlaunch fix to d16-2 the corresponding xamarin-macios fix was
not, causing the build to break.

Fixes this:

    [...]
    Build FAILED.

    "/Users/builder/jenkins/workspace/xamarin-macios/maccore/tools/mlaunch/Xamarin.Hosting/Xamarin.Hosting.sln" (default target) (1) ->
    "/Users/builder/jenkins/workspace/xamarin-macios/maccore/tools/mlaunch/Xamarin.Hosting/Xamarin.Hosting.csproj" (default target) (2) ->
    (CoreCompile target) ->
      /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tools/common/MachO.cs(10,15): error CS0234: The type or namespace name 'Bundler' does not exist in the namespace 'Xamarin' (are you missing an assembly reference?) [/Users/builder/jenkins/workspace/xamarin-macios/maccore/tools/mlaunch/Xamarin.Hosting/Xamarin.Hosting.csproj]

        0 Warning(s)
        1 Error(s)

    Time Elapsed 00:00:03.63
    make[3]: *** [Xamarin.Hosting/Xamarin.Launcher/bin/Debug/mlaunch.app] Error 1