### PR TITLE
[appkit] Make NSCell and NSControl 'Formatter' accept null

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -2405,7 +2405,7 @@ namespace AppKit {
 		[Export ("keyEquivalent")]
 		string KeyEquivalent { get; }
 	
-		[Export ("formatter", ArgumentSemantic.Retain)]
+		[Export ("formatter", ArgumentSemantic.Retain), NullAllowed]
 		NSFormatter Formatter { get; set; }
 	
 		[Export ("objectValue", ArgumentSemantic.Copy), NullAllowed]
@@ -4795,7 +4795,7 @@ namespace AppKit {
 		[Export ("font")]
 		NSFont Font { get; set; }
 
-		[Export ("formatter", ArgumentSemantic.Retain)]
+		[Export ("formatter", ArgumentSemantic.Retain), NullAllowed]
 		NSObject Formatter { get; set; }
 
 		[Export ("objectValue", ArgumentSemantic.Copy)]

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -4796,7 +4796,11 @@ namespace AppKit {
 		NSFont Font { get; set; }
 
 		[Export ("formatter", ArgumentSemantic.Retain), NullAllowed]
+#if XAMCORE_4_0
+		NSFormatter Formatter { get; set; }
+#else
 		NSObject Formatter { get; set; }
+#endif
 
 		[Export ("objectValue", ArgumentSemantic.Copy)]
 		NSObject ObjectValue { get; set; }


### PR DESCRIPTION
- Fixes #6032: NSTextField.Formatter missing null-allowed
  (https://github.com/xamarin/xamarin-macios/issues/6032)
- Swift seems to have nullable [here](https://developer.apple.com/documentation/appkit/nscontrol/1428887-formatter).