### PR TITLE
[linker] Add the custom attributes removal step as an configurable optimization. Fix #3655

### DIFF
--- a/docs/website/optimizations.md
+++ b/docs/website/optimizations.md
@@ -737,3 +737,21 @@ disabled  until the correct linker annotations (e.g.
 
 The default behavior can be overridden by passing
 `--optimize=[+|-]cctor-beforefieldinit` to `mtouch` or `mmp`.
+
+## Custom Attributes Removal
+
+This optimization requires the linker to be enabled and is applied globally
+on all assemblies inside the application.
+
+This optimization removes a number of, rarely used, custom attributes from
+assemblies. In turn this allows the linker to later remove the associated
+code from the base class libraries (BCL). This help reduce both the
+metadata and code size for your application.
+
+This optimization is enabled, by default, on both Xamarin.iOS and
+Xamarin.Mac. If some of the removed custom attributes are required for
+your application you can disable this optimization, without totally
+disabling the managed linker.
+
+The default behavior can be overridden by passing
+`--optimize=[+|-]custom-attributes-removal` to `mtouch`.

--- a/docs/website/optimizations.md
+++ b/docs/website/optimizations.md
@@ -754,4 +754,4 @@ your application you can disable this optimization, without totally
 disabling the managed linker.
 
 The default behavior can be overridden by passing
-`--optimize=[+|-]custom-attributes-removal` to `mtouch`.
+`--optimize=[+|-]custom-attributes-removal` to `mtouch` or `mmp`.

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -646,7 +646,7 @@ namespace Xamarin.MMP.Tests
 						"<LinkMode>Full</LinkMode>",
 				};
 				var rv = TI.TestUnifiedExecutable (test, shouldFail: false);
-				rv.Messages.AssertWarning (132, $"Unknown optimization: '{opt}'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size, blockliteral-setupblock, register-protocols, inline-dynamic-registration-supported, static-block-to-delegate-lookup, trim-architectures, inline-is-arm64-calling-convention, cctor-beforefieldinit.");
+				rv.Messages.AssertWarning (132, $"Unknown optimization: '{opt}'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size, blockliteral-setupblock, register-protocols, inline-dynamic-registration-supported, static-block-to-delegate-lookup, trim-architectures, inline-is-arm64-calling-convention, cctor-beforefieldinit, custom-attributes-removal.");
 				rv.Messages.AssertErrorCount (0);
 			});
 		}

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -1752,7 +1752,7 @@ public class TestApp {
 				mtouch.Linker = MTouchLinker.LinkSdk;
 				mtouch.Optimize = new string [] { "foo" };
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build");
-				mtouch.AssertWarning (132, "Unknown optimization: 'foo'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size, inline-runtime-arch, blockliteral-setupblock, register-protocols, inline-dynamic-registration-supported, static-block-to-delegate-lookup, remove-dynamic-registrar, remove-unsupported-il-for-bitcode, inline-is-arm64-calling-convention, seal-and-devirtualize, cctor-beforefieldinit.");
+				mtouch.AssertWarning (132, "Unknown optimization: 'foo'. Valid optimizations are: remove-uithread-checks, dead-code-elimination, inline-isdirectbinding, inline-intptr-size, inline-runtime-arch, blockliteral-setupblock, register-protocols, inline-dynamic-registration-supported, static-block-to-delegate-lookup, remove-dynamic-registrar, remove-unsupported-il-for-bitcode, inline-is-arm64-calling-convention, seal-and-devirtualize, cctor-beforefieldinit, custom-attributes-removal.");
 			}
 		}
 
@@ -3575,7 +3575,8 @@ public partial class NotificationService : UNNotificationServiceExtension
 				mtouch.AssertWarning (2003, "Option '--optimize=inline-is-arm64-calling-convention' will be ignored since linking is disabled");
 				mtouch.AssertWarning (2003, "Option '--optimize=seal-and-devirtualize' will be ignored since linking is disabled");
 				mtouch.AssertWarning (2003, "Option '--optimize=cctor-beforefieldinit' will be ignored since linking is disabled");
-				mtouch.AssertWarningCount (13);
+				mtouch.AssertWarning (2003, "Option '--optimize=custom-attributes-removal' will be ignored since linking is disabled");
+				mtouch.AssertWarningCount (14);
 			}
 
 			using (var mtouch = new MTouchTool ()) {

--- a/tools/common/Optimizations.cs
+++ b/tools/common/Optimizations.cs
@@ -41,6 +41,7 @@ namespace Xamarin.Bundler
 			"", // dummy value to make indices match up between XM and XI
 #endif
 			"cctor-beforefieldinit",
+			"custom-attributes-removal",
 		};
 
 		enum Opt
@@ -60,6 +61,7 @@ namespace Xamarin.Bundler
 			InlineIsARM64CallingConvention,
 			SealAndDevirtualize,
 			StaticConstructorBeforeFieldInit,
+			CustomAttributesRemoval,
 		}
 
 		bool? all;
@@ -136,6 +138,11 @@ namespace Xamarin.Bundler
 		public bool? StaticConstructorBeforeFieldInit {
 			get { return values [(int) Opt.StaticConstructorBeforeFieldInit]; }
 			set { values [(int) Opt.StaticConstructorBeforeFieldInit] = value; }
+		}
+
+		public bool? CustomAttributesRemoval {
+			get { return values [(int) Opt.CustomAttributesRemoval]; }
+			set { values [(int) Opt.CustomAttributesRemoval] = value; }
 		}
 
 		public Optimizations ()
@@ -293,6 +300,10 @@ namespace Xamarin.Bundler
 			// by default we try to eliminate any .cctor we can
 			if (!StaticConstructorBeforeFieldInit.HasValue)
 				StaticConstructorBeforeFieldInit = true;
+
+			// by default we remove rarely used custom attributes
+			if (!CustomAttributesRemoval.HasValue)
+				CustomAttributesRemoval = true;
 
 			if (Driver.Verbosity > 3)
 				Driver.Log (4, "Enabled optimizations: {0}", string.Join (", ", values.Select ((v, idx) => v == true ? opt_names [idx] : string.Empty).Where ((v) => !string.IsNullOrEmpty (v))));

--- a/tools/mtouch/Tuning.cs
+++ b/tools/mtouch/Tuning.cs
@@ -150,8 +150,8 @@ namespace MonoTouch.Tuner {
 			sub.Add (new CoreRemoveSecurity ());
 			sub.Add (new OptimizeGeneratedCodeSubStep (options));
 			sub.Add (new RemoveUserResourcesSubStep (options));
-			// OptimizeGeneratedCodeSubStep and RemoveUserResourcesSubStep needs [GeneratedCode] so it must occurs before RemoveAttributes
-			sub.Add (new RemoveAttributes ());
+			if (options.Application.Optimizations.CustomAttributesRemoval == true)
+				sub.Add (new RemoveAttributes ());
 			// http://bugzilla.xamarin.com/show_bug.cgi?id=1408
 			if (options.LinkAway)
 				sub.Add (new RemoveCode (options));


### PR DESCRIPTION
This allows the optimization to be disabled in cases where one, or
many, a custom attribute(s) are required by the application at runtime.

While not ideal disabling this single step is much better than disabling
linking for the whole application.

A better approach is described in https://github.com/xamarin/xamarin-macios/issues/6048
but this configuration optimization makes sense independently of it.

Fix https://github.com/xamarin/xamarin-macios/issues/3655