### PR TITLE
[apidiff] Add q quick'n'dirty script to produce a diff between any two bundle.zip

### DIFF
--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -167,7 +167,7 @@ all-local:: $(BUNDLE_ZIP) $(APIDIFF_DIR)/api-diff.html
 # Rules to re-create the reference infos from the curretn stable 'bundle.zip. assemblies
 
 # split the URL in words based on the path separator, and then chose the 6th word (the hash) in the bundle zip filename
-BUNDLE_ZIP=$(APIDIFF_DIR)/bundle-$(word 6,$(subst /, ,$(APIDIFF_REFERENCES))).zip
+BUNDLE_ZIP ?= $(APIDIFF_DIR)/bundle-$(word 6,$(subst /, ,$(APIDIFF_REFERENCES))).zip
 $(BUNDLE_ZIP):
 	# download to a temporary filename so interrupted downloads won't prevent re-downloads.
 	$(Q) if test -f ~/Library/Caches/xamarin-macios/$(notdir $@); then \

--- a/tools/apidiff/diff-bundles.sh
+++ b/tools/apidiff/diff-bundles.sh
@@ -8,7 +8,7 @@ make clean
 rm -Rf origin
 unzip -d origin $1
 
-# copy files over (dirty!) the currennt install directories
+# copy files over (dirty!) the current install directories
 cp -r origin/2.1/ ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/2.1/
 cp -r origin/Xamarin.iOS/ ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.iOS/
 cp -r origin/Xamarin.TVOS/ ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/

--- a/tools/apidiff/diff-bundles.sh
+++ b/tools/apidiff/diff-bundles.sh
@@ -9,14 +9,14 @@ rm -Rf origin
 unzip -d origin $1
 
 # copy files over (dirty!) the current install directories
-cp -r origin/2.1/ ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/2.1/
-cp -r origin/Xamarin.iOS/ ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.iOS/
-cp -r origin/Xamarin.TVOS/ ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/
-cp -r origin/Xamarin.WatchOS/ ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.WatchOS/
+cp -cr origin/2.1/ ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/2.1/
+cp -cr origin/Xamarin.iOS/ ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.iOS/
+cp -cr origin/Xamarin.TVOS/ ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/
+cp -cr origin/Xamarin.WatchOS/ ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.WatchOS/
 
 cp origin/Xam*.dll* ../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/mono/ 
-cp -r origin/4.5/ ../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/mono/4.5/
-cp -r origin/Xamarin.Mac/ ../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/mono/Xamarin.Mac/
+cp -cr origin/4.5/ ../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/mono/4.5/
+cp -cr origin/Xamarin.Mac/ ../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/mono/Xamarin.Mac/
 
 # cleanup after ourselves
 rm -Rf origin

--- a/tools/apidiff/diff-bundles.sh
+++ b/tools/apidiff/diff-bundles.sh
@@ -21,7 +21,7 @@ cp -r origin/Xamarin.Mac/ ../../_mac-build/Library/Frameworks/Xamarin.Mac.framew
 # cleanup after ourselves
 rm -Rf origin
 
-# run Makefile using the target/currennt bundle
+# run Makefile using the target/current bundle
 BUNDLE_ZIP=$2 make jenkins-api-diff
 
 echo Custom API diff complete. You need to clean this directory and do another "make install"

--- a/tools/apidiff/diff-bundles.sh
+++ b/tools/apidiff/diff-bundles.sh
@@ -1,0 +1,27 @@
+# big, dirty hack - but a nice time saver to produce an API diff between any builds
+# ./diff-bundles.sh base.zip target.zip
+
+# anything alreaady built is wrong
+make clean
+
+# unzip the base/origin bundle zip
+rm -Rf origin
+unzip -d origin $1
+
+# copy files over (dirty!) the currennt install directories
+cp -r origin/2.1/ ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/2.1/
+cp -r origin/Xamarin.iOS/ ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.iOS/
+cp -r origin/Xamarin.TVOS/ ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.TVOS/
+cp -r origin/Xamarin.WatchOS/ ../../_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.WatchOS/
+
+cp origin/Xam*.dll* ../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/mono/ 
+cp -r origin/4.5/ ../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/mono/4.5/
+cp -r origin/Xamarin.Mac/ ../../_mac-build/Library/Frameworks/Xamarin.Mac.framework/Versions/git/lib/mono/Xamarin.Mac/
+
+# cleanup after ourselves
+rm -Rf origin
+
+# run Makefile using the target/currennt bundle
+BUNDLE_ZIP=$2 make jenkins-api-diff
+
+echo Custom API diff complete. You need to clean this directory and do another "make install"


### PR DESCRIPTION
Use for producing API diff for release notes without waiting for a PR,
bots and/or approvals...

Also useful to produce API diff between any versions, not just between
the current revision and a baseline (last stable).