### PR TITLE
[foundation] Expose AllowsCellularAccess on NSUrlSessionHandler

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -267,6 +267,18 @@ namespace Foundation {
 			}
 		}
 
+		bool allowsCellularAccess;
+
+		public bool AllowsCellularAccess {
+			get {
+				return allowsCellularAccess;
+			}
+			set {
+				EnsureModifiability ();
+				allowsCellularAccess = value;
+			}
+		}
+
 		ICredentials credentials;
 
 		public ICredentials Credentials {
@@ -457,7 +469,7 @@ namespace Foundation {
 			}
 
 			var nsrequest = new NSMutableUrlRequest {
-				AllowsCellularAccess = true,
+				AllowsCellularAccess = allowsCellularAccess,
 				CachePolicy = DisableCaching ? NSUrlRequestCachePolicy.ReloadIgnoringCacheData : NSUrlRequestCachePolicy.UseProtocolCachePolicy,
 				HttpMethod = request.Method.ToString ().ToUpperInvariant (),
 				Url = NSUrl.FromString (request.RequestUri.AbsoluteUri),


### PR DESCRIPTION
This property was always set to `true` but it can be useful to turn it
off (and that was not easy with the existing implementation)