### PR TITLE
[sample tests] Fix variable calculation to calculate once.

### DIFF
--- a/tests/sampletester/Makefile
+++ b/tests/sampletester/Makefile
@@ -10,7 +10,7 @@ ifneq ($(TEST_CATEGORY),)
 WHERE_CONDITION=/where "cat == $(TEST_CATEGORY)"
 endif
 
-TEST_RESULT=TestResult-$(shell date "+%Y%m%d-%H%M%S")
+TEST_RESULT:=TestResult-$(shell date "+%Y%m%d-%H%M%S")
 
 build: bin/Debug/sampletester.dll
 


### PR DESCRIPTION
Use simply expanded variable as test result filename, so that it's only
calculated once. This avoids ending up with different filenames when the
timestamp in the filename changes between calculations, such as:

    Results (nunit3) saved as /Users/vsts/agent/2.150.3/work/1/s/tests/sampletester/TestResult-20190511-100657.xml
    warning: failed to load external entity "TestResult-20190511-100658.xml"
    unable to parse TestResult-20190511-100658.xml
    make: *** [run-tests] Error 6