### PR TITLE
[Xharness] Remove the System bcl tests on tvOS

### DIFF
--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -149,6 +149,7 @@ namespace BCLTestImporter {
 		static readonly List<string> iOSIgnoredAssemblies = new List<string> {};
 
 		static readonly List<string> tvOSIgnoredAssemblies = new List<string> {
+			"monotouch_System_xunit-test.dll", // ignored due to https://github.com/xamarin/maccore/issues/1610
 		};
 
 		static readonly List<string> watcOSIgnoredAssemblies = new List<string> {


### PR DESCRIPTION
Until mono fixes the test dlls, we are ignoring the tests.

Fixes: https://github.com/xamarin/maccore/issues/1610