### PR TITLE
[XHarness] Ignore corlib on tvOS until mono fixes the test dlls.

### DIFF
--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -149,6 +149,7 @@ namespace BCLTestImporter {
 		static readonly List<string> iOSIgnoredAssemblies = new List<string> {};
 
 		static readonly List<string> tvOSIgnoredAssemblies = new List<string> {
+			"monotouch_corlib_xunit-test.dll", // ignored due to https://github.com/xamarin/maccore/issues/1611 until mono fixes it
 		};
 
 		static readonly List<string> watcOSIgnoredAssemblies = new List<string> {


### PR DESCRIPTION
Test dlls are wrong so we will ignore them until mono fixes them.

Fixes: https://github.com/xamarin/maccore/issues/1611