### PR TITLE
[xibuild] Fix incorrect mscorlib.dll being used

### DIFF
--- a/src/generator.csproj
+++ b/src/generator.csproj
@@ -23,7 +23,6 @@
     <Deterministic>True</Deterministic>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>

--- a/tests/generator/generator-tests.csproj
+++ b/tests/generator/generator-tests.csproj
@@ -26,7 +26,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="nunit.framework">

--- a/tools/xibuild/Main.cs
+++ b/tools/xibuild/Main.cs
@@ -206,7 +206,6 @@ namespace xibuild {
 			SetToolsetProperty ("MSBuildExtensionsPath32", MSBuildExtensionsPath);
 			SetToolsetProperty ("MSBuildExtensionsPath64", MSBuildExtensionsPath);
 			SetToolsetProperty ("RoslynTargetsPath", Path.Combine (MSBuildBin, "Roslyn"));
-			SetToolsetProperty ("TargetFrameworkRootPath", FrameworksDirectory + Path.DirectorySeparatorChar); //NOTE: Must include trailing \
 			SetToolsetProperty ("MSBuildSdksPath", MSBuildSdksPath);
 
 			dstXml.Save (targetConfigFile);


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/5760 .