### PR TITLE
[jenkins] Adjust global timeout.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -396,7 +396,7 @@ timestamps {
     def mainMacOSVersion = 14
     node ("xamarin-macios && macos-10.${mainMacOSVersion}") {
         try {
-            timeout (time: 9, unit: 'HOURS') {
+            timeout (time: 15, unit: 'HOURS') {
                 // Hard-code a workspace, since branch-based and PR-based
                 // builds would otherwise use different workspaces, which
                 // wastes a lot of disk space.


### PR DESCRIPTION
We have a 13-hour timeout for running the tests [1], but that won't work if
the timeout for the entire Jenkins pipeline is lower, so adjust the timeout
for the entire Jenkins pipeline to be more than the sum of all the nested
timeouts.

[1] https://github.com/xamarin/xamarin-macios/commit/94fe39b11806bb61fac7646d5f6faccfdfe9c7b4#diff-68c8473bbe1d4346ecff3d74522a31f8R675