### PR TITLE
[msbuild] Add non-ui version of com.apple.AudioUnit-UI in lists

### DIFF
--- a/Versions-ios.plist.in
+++ b/Versions-ios.plist.in
@@ -94,6 +94,8 @@
 			<key>com.apple.watchkit</key>
 			<string>8.2</string>
 			<key>com.apple.AudioUnit-UI</key>
+			<string>8.2</string>
+			<key>com.apple.AudioUnit</key>
 			<string>8.0</string>
 			<key>com.apple.Safari.content-blocker</key>
 			<string>9.0</string>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Tasks/ValidateAppBundleTaskBase.cs
@@ -103,6 +103,7 @@ namespace Xamarin.iOS.Tasks
 			case "com.apple.Safari.content-blocker": // iOS
 			case "com.apple.Safari.sharedlinks-service": // iOS
 			case "com.apple.spotlight.index": // iOS
+			case "com.apple.AudioUnit": // iOS
 			case "com.apple.AudioUnit-UI": // iOS
 			case "com.apple.tv-services": // tvOS
 			case "com.apple.broadcast-services": // iOS+tvOS


### PR DESCRIPTION
- https://github.com/xamarin/xamarin-macios/issues/6087
- We have a list of supported extensions, we just didn't include the non-ui flavor