### PR TITLE
[foundation] Add custom trust/certificate validation to NSUrlSessionHandler. Fix #4170

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -61,6 +61,8 @@ namespace System.Net.Http {
 namespace Foundation {
 #endif
 
+	public delegate bool NSUrlSessionHandlerTrustOverrideCallback (NSUrlSessionHandler sender, SecTrust trust);
+
 	// useful extensions for the class in order to set it in a header
 	static class NSHttpCookieExtensions
 	{
@@ -288,6 +290,18 @@ namespace Foundation {
 			set {
 				EnsureModifiability ();
 				credentials = value;
+			}
+		}
+
+		NSUrlSessionHandlerTrustOverrideCallback trustOverride;
+
+		public NSUrlSessionHandlerTrustOverrideCallback TrustOverride {
+			get {
+				return trustOverride;
+			}
+			set {
+				EnsureModifiability ();
+				trustOverride = value;
 			}
 		}
 
@@ -655,7 +669,7 @@ namespace Foundation {
 						inflight.CancellationTokenSource.Cancel (); 
 						inflight.Errored = true;
 
-						var exc = createExceptionForNSError (error);
+						var exc = inflight.Exception ?? createExceptionForNSError (error);
 						inflight.CompletionSource.TrySetException (exc);
 						inflight.Stream.TrySetException (exc);
 					} else {
@@ -705,6 +719,22 @@ namespace Foundation {
 				if (inflight == null)
 					return;
 
+				// ToCToU for the callback
+				var trustCallback = sessionHandler.TrustOverride;
+				if (trustCallback != null && challenge.ProtectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodServerTrust) {
+					if (trustCallback (sessionHandler, challenge.ProtectionSpace.ServerSecTrust)) {
+						var credential = new NSUrlCredential (challenge.ProtectionSpace.ServerSecTrust);
+						completionHandler (NSUrlSessionAuthChallengeDisposition.UseCredential, credential);
+					} else {
+						// user callback rejected the certificate, we want to set the exception, else the user will
+						// see as if the request was cancelled.
+						lock (inflight.Lock) {
+							inflight.Exception = new HttpRequestException ("An error occurred while sending the request.", new WebException ("Error: TrustFailure"));
+						}
+						completionHandler (NSUrlSessionAuthChallengeDisposition.CancelAuthenticationChallenge, null);
+					}
+					return;
+				}
 				// case for the basic auth failing up front. As per apple documentation:
 				// The URL Loading System is designed to handle various aspects of the HTTP protocol for you. As a result, you should not modify the following headers using
 				// the addValue(_:forHTTPHeaderField:) or setValue(_:forHTTPHeaderField:) methods:
@@ -717,7 +747,7 @@ namespace Foundation {
 				// but we are hiding such a situation from our users, we can nevertheless know if the header was added and deal with it. The idea is as follows,
 				// check if we are in the first attempt, if we are (PreviousFailureCount == 0), we check the headers of the request and if we do have the Auth 
 				// header, it means that we do not have the correct credentials, in any other case just do what it is expected.
-				
+
 				if (challenge.PreviousFailureCount == 0) {
 					var authHeader = inflight.Request?.Headers?.Authorization;
 					if (!(string.IsNullOrEmpty (authHeader?.Scheme) && string.IsNullOrEmpty (authHeader?.Parameter))) {
@@ -783,6 +813,7 @@ namespace Foundation {
 			public HttpRequestMessage Request { get; set; }
 			public HttpResponseMessage Response { get; set; }
 
+			public Exception Exception { get; set; }
 			public bool ResponseSent { get; set; }
 			public bool Errored { get; set; }
 			public bool Disposed { get; set; }

--- a/tests/introspection/ApiFrameworkTest.cs
+++ b/tests/introspection/ApiFrameworkTest.cs
@@ -78,10 +78,10 @@ namespace Introspection {
 			// not a framework, largely p/invokes to /usr/lib/libSystem.dylib
 			case "Darwin":
 				return true;
+#endif
 			// not directly bindings
 			case "System.Net.Http":
 				return true;
-#endif
 			default:
 				return false;
 			}

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -181,11 +181,11 @@ namespace MonoTests.System.Net.Http
 					return false;
 				};
 			} else {
-			    ServicePointManager.ServerCertificateValidationCallback = (sender, certificate, chain, errors) => {
-				    servicePointManagerCbWasExcuted = true;
-				    // return false, since we want to test that the exception is raised
-				    return false;
-			    };
+				ServicePointManager.ServerCertificateValidationCallback = (sender, certificate, chain, errors) => {
+					servicePointManagerCbWasExcuted = true;
+					// return false, since we want to test that the exception is raised
+					return false;
+				};
 			}
 
 			TestRuntime.RunAsync (DateTime.Now.AddSeconds (30), async () =>


### PR DESCRIPTION
Basic application (size) for doing an `HttpClient.GetAsync`, release/llvm, 64bits only

- NSUrlSessionHandler (master): 6.4 MB
- NSUrlSessionHandler (PR #5936): 7.7 MB
- NSUrlSessionHandler (this PR): 6.4 MB

The size increase occurs because of the reference to .net `X509*` types.
This brings a lot of additional code, including managed cryptographic
code, inside the application - even when the feature is **not** used.

The solution is to expose an API that only use native (OS) types, which
are mostly already part of the application. This has a very low impact
on existing applications.

It's still possible to hook back to .NET validation if needed (it should
not in most cases) but, in this case, the extra price will only be
_paid_ if used (and can be lower if the code is needed by something else
from the application).

In comparison using other `HttpClient` handler produce app sizes of

- HttpClientHandler (managed): 10.4 MB
- CFNetworkHandler: 6.8 MB

Based on/supersede https://github.com/xamarin/xamarin-macios/pull/5733
Fix https://github.com/xamarin/xamarin-macios/issues/4170