### PR TITLE
[mmp] Ignore, by default, frameworks that cause rejection from App Store. Fix #6039

### DIFF
--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -654,7 +654,7 @@ The associated OS framework is known to be **prohibited** in Apple's Mac App Sto
 To avoid rejections `mmp` will not, by default, natively link with the mentioned framrwork.
 Any feature that use the mentioned framework will not work and might crash at runtime.
 
-If needed (e.g. not submitting to the App Store) you can ask `mmp` to link against the framework by adding `--link-prohibited-framework` to the **Addtional mmp arguments** in your project's options.
+If needed (e.g. not submitting to the App Store) you can ask `mmp` to link against the framework by adding `--link-prohibited-framework` to the **Additional mmp arguments** in your project's options.
 You can silence this warning by adding `--nowarn=5220` to the **Additional mmp arguments** in your project's options.
 
 ### MM53xx: other tools

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -643,7 +643,7 @@ The application has references to the `{nspace}` namespace of `Xamarin.Mac.dll`.
 The associated OS framework is known to be **prohibited** in Apple's Mac App Store applications.
 
 However `mmp` was instructed, using `--link-prohibited-framework`, to natively link to the associated framework.
-You can silence this warning by adding `--nowarn=5219` to the **Addtional mmp arguments** in your project's options.
+You can silence this warning by adding `--nowarn=5219` to the **Additional mmp arguments** in your project's options.
 
 <a name="MT5220" />
 

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -633,6 +633,29 @@ See the [equivalent mtouch warning](~/ios/troubleshooting/mtouch-errors.md#MT521
 <!-- 5215 used by mtouch -->
 <!-- 5216 used by mtouch -->
 <!-- 5217 used by mtouch -->
+<!-- 5218 used by mtouch -->
+
+<a name="MT5219" />
+
+#### MM5219: Linking against framework '{nspace}'. It is prohibited (rejected) by the Mac App Store
+
+The application has references to the `{nspace}` namespace of `Xamarin.Mac.dll`.
+The associated OS framework is known to be **prohibited** in Apple's Mac App Store applications.
+
+However `mmp` was instructed, using `--link-prohibited-framework`, to natively link to the associated framework.
+You can silence this warning by adding `--nowarn=5219` to the **Addtional mmp arguments** in your project's options.
+
+<a name="MT5220" />
+
+#### MM5220: Skipping framework '{nspace}'. It is prohibited (rejected) by the Mac App Store
+
+The application has references to the `{nspace}` namespace of `Xamarin.Mac.dll`.
+The associated OS framework is known to be **prohibited** in Apple's Mac App Store applications.
+To avoid rejections `mmp` will not, by default, natively link with the mentioned framrwork.
+Any feature that use the mentioned framework will not work and might crash at runtime.
+
+If needed (e.g. not submitting to the App Store) you can ask `mmp` to link against the framework by adding `--link-prohibited-framework` to the **Addtional mmp arguments** in your project's options.
+You can silence this warning by adding `--nowarn=5220` to the **Addtional mmp arguments** in your project's options.
 
 ### MM53xx: other tools
 

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -655,7 +655,7 @@ To avoid rejections `mmp` will not, by default, natively link with the mentioned
 Any feature that use the mentioned framework will not work and might crash at runtime.
 
 If needed (e.g. not submitting to the App Store) you can ask `mmp` to link against the framework by adding `--link-prohibited-framework` to the **Addtional mmp arguments** in your project's options.
-You can silence this warning by adding `--nowarn=5220` to the **Addtional mmp arguments** in your project's options.
+You can silence this warning by adding `--nowarn=5220` to the **Additional mmp arguments** in your project's options.
 
 ### MM53xx: other tools
 

--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -651,7 +651,7 @@ You can silence this warning by adding `--nowarn=5219` to the **Addtional mmp ar
 
 The application has references to the `{nspace}` namespace of `Xamarin.Mac.dll`.
 The associated OS framework is known to be **prohibited** in Apple's Mac App Store applications.
-To avoid rejections `mmp` will not, by default, natively link with the mentioned framrwork.
+To avoid rejections `mmp` will not, by default, natively link with the mentioned framework.
 Any feature that use the mentioned framework will not work and might crash at runtime.
 
 If needed (e.g. not submitting to the App Store) you can ask `mmp` to link against the framework by adding `--link-prohibited-framework` to the **Additional mmp arguments** in your project's options.

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -2825,6 +2825,8 @@ There are two main reasons for this:
 * The symbol is correct, but it's a symbol that's already preserved by normal
   means (some build options causes the exact list of dynamic symbols to vary).
 
+<!-- 5219 and 5220 used by mmp -->
+
 ### MT53xx: Other tools
 
 <!--

--- a/tests/common/BundlerTest.cs
+++ b/tests/common/BundlerTest.cs
@@ -303,7 +303,12 @@ class Issue4072Session : NSUrlSession {
 				bundler.Linker = LinkerOption.DontLink;
 				bundler.AssertExecute ();
 				bundler.AssertWarning (4175, "The parameter 'completionHandler' in the method 'Issue4072Session.CreateDataTask(Foundation.NSUrl,Foundation.NSUrlSessionResponse)' has an invalid BlockProxy attribute (the type passed to the attribute does not have a 'Create' method).", "testApp.cs", 11);
+#if __MACOS__
+				bundler.AssertWarning (5220, "Skipping framework 'QTKit'. It is prohibited (rejected) by the Mac App Store");
+				bundler.AssertWarningCount (2);
+#else
 				bundler.AssertWarningCount (1);
+#endif
 			}
 
 			using (var bundler = new BundlerTool ()) {

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -134,7 +134,7 @@ namespace Xamarin.MMP.Tests
 
 				// Due to https://bugzilla.xamarin.com/show_bug.cgi?id=48311 we can get warnings related to the registrar
 				Func<string, bool> hasLegitWarning = results =>
-					results.Split (Environment.NewLine.ToCharArray ()).Any (x => x.Contains ("warning") && !x.Contains ("deviceBrowserView:selectionDidChange:"));
+					results.Split (Environment.NewLine.ToCharArray ()).Any (x => x.Contains ("warning") && !(x.Contains ("deviceBrowserView:selectionDidChange:") || x.Contains ("It is prohibited (rejected) by the Mac App Store")));
 
 				// Mobile
 				string buildResults = TI.TestUnifiedExecutable (test).BuildOutput;

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -449,9 +449,9 @@ public class Frameworks : Dictionary <string, Framework>
 			switch (nspace) {
 			case "QTKit":
 				if (Driver.LinkProhibitedFrameworks) {
-					ErrorHelper.Warning (5219, "Linking against framework '{nspace}'. It is prohibited (rejected) by the Mac App Store");
+					ErrorHelper.Warning (5219, $"Linking against framework '{nspace}'. It is prohibited (rejected) by the Mac App Store");
 				}  else {
-					ErrorHelper.Warning (5220, "Skipping framework '{nspace}'. It is prohibited (rejected) by the Mac App Store");
+					ErrorHelper.Warning (5220, $"Skipping framework '{nspace}'. It is prohibited (rejected) by the Mac App Store");
 					continue;
 				}
 				break;

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -446,6 +446,16 @@ public class Frameworks : Dictionary <string, Framework>
 
 		// Iterate over all the namespaces and check which frameworks we need to link with.
 		foreach (var nspace in namespaces) {
+			switch (nspace) {
+			case "QTKit":
+				if (Driver.LinkProhibitedFrameworks) {
+					ErrorHelper.Warning (5219, "Linking against framework '{nspace}'. It is prohibited (rejected) by the Mac App Store");
+				}  else {
+					ErrorHelper.Warning (5220, "Skipping framework '{nspace}'. It is prohibited (rejected) by the Mac App Store");
+					continue;
+				}
+				break;
+			}
 			if (Driver.GetFrameworks (app).TryGetValue (nspace, out var framework)) {
 				if (app.SdkVersion >= framework.Version) {
 					var add_to = app.DeploymentTarget >= framework.Version ? frameworks : weak_frameworks;

--- a/tools/mmp/driver.cs
+++ b/tools/mmp/driver.cs
@@ -136,6 +136,7 @@ namespace Xamarin.Bundler {
 		public static bool IsUnifiedMobile { get; private set; }
 		public static bool IsUnified { get { return IsUnifiedFullSystemFramework || IsUnifiedMobile || IsUnifiedFullXamMacFramework; } }
 		public static bool IsClassic { get { return !IsUnified; } }
+		public static bool LinkProhibitedFrameworks { get; private set; }
 
 		public static bool Is64Bit { 
 			get {
@@ -352,6 +353,7 @@ namespace Xamarin.Bundler {
 						aotOptions = new AOTOptions (v);
 					}
 				},
+				{ "link-prohibited-frameworks", "Natively link against prohibited (rejected by AppStore) frameworks", v => { LinkProhibitedFrameworks = true; } },
 			};
 
 			AddSharedOptions (App, os);


### PR DESCRIPTION
So far this only applies to `QTKit`...

XM will now, by default, avoid natively link with QTKit unless it's
instructed to so explicitly using `--link-prohibited-frameworks`

ref: https://github.com/xamarin/xamarin-macios/issues/6039