### PR TITLE
[d16-2] [foundation] Add custom trust/certificate validation to NSUrlSessionHandler. Fix #4170

### DIFF
--- a/tests/introspection/ApiFrameworkTest.cs
+++ b/tests/introspection/ApiFrameworkTest.cs
@@ -78,10 +78,10 @@ namespace Introspection {
 			// not a framework, largely p/invokes to /usr/lib/libSystem.dylib
 			case "Darwin":
 				return true;
+#endif
 			// not directly bindings
 			case "System.Net.Http":
 				return true;
-#endif
 			default:
 				return false;
 			}

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -181,11 +181,11 @@ namespace MonoTests.System.Net.Http
 					return false;
 				};
 			} else {
-			    ServicePointManager.ServerCertificateValidationCallback = (sender, certificate, chain, errors) => {
-				    servicePointManagerCbWasExcuted = true;
-				    // return false, since we want to test that the exception is raised
-				    return false;
-			    };
+				ServicePointManager.ServerCertificateValidationCallback = (sender, certificate, chain, errors) => {
+					servicePointManagerCbWasExcuted = true;
+					// return false, since we want to test that the exception is raised
+					return false;
+				};
 			}
 
 			TestRuntime.RunAsync (DateTime.Now.AddSeconds (30), async () =>


### PR DESCRIPTION
Basic application (size) for doing an `HttpClient.GetAsync`, release/llvm, 64bits only

- NSUrlSessionHandler (master): 6.4 MB
- NSUrlSessionHandler (PR #5936): 7.7 MB
- NSUrlSessionHandler (this PR): 6.4 MB

The size increase occurs because of the reference to .net `X509*` types.
This brings a lot of additional code, including managed cryptographic
code, inside the application - even when the feature is **not** used.

The solution is to expose an API that only use native (OS) types, which
are mostly already part of the application. This has a very low impact
on existing applications.

It's still possible to hook back to .NET validation if needed (it should
not in most cases) but, in this case, the extra price will only be
_paid_ if used (and can be lower if the code is needed by something else
from the application).

In comparison using other `HttpClient` handler produce app sizes of

- HttpClientHandler (managed): 10.4 MB
- CFNetworkHandler: 6.8 MB

Based on/supersede https://github.com/xamarin/xamarin-macios/pull/5733
Fix https://github.com/xamarin/xamarin-macios/issues/4170

Backport of #6103.

/cc @spouliot 