### PR TITLE
[tests] Don't make the mscorlib tests exit upon suspend.

### DIFF
--- a/tests/bcl-test/mscorlib/Info.plist
+++ b/tests/bcl-test/mscorlib/Info.plist
@@ -6,8 +6,6 @@
 	<string>com.xamarin.mscorlibtests</string>
 	<key>MinimumOSVersion</key>
 	<string>6.0</string>
-	<key>UIApplicationExitsOnSuspend</key>
-	<true/>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>


### PR DESCRIPTION
It means that on watchOS they'll exit if the screen turns off.

I have no idea why we set it up like this in the first place, it's been like
this since we created the mscorlib tests ([1]).

[1]: https://github.com/xamarin/maccore/commit/76e15036e8d9f27281d1398d565feaf32bfebd8b