### PR TITLE
[d16-2] [xharness] Don't use a dash in the bundle identifer for watchOS projects.

### DIFF
--- a/tests/monotouch-test/CoreFoundation/BundleTest.cs
+++ b/tests/monotouch-test/CoreFoundation/BundleTest.cs
@@ -76,7 +76,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		{
 			var main = CFBundle.GetMain ();
 #if __WATCHOS__
-			var expectedBundleId = "com.xamarin.monotouch-test-watch.watchkitapp.watchkitextension";
+			var expectedBundleId = "com.xamarin.monotouch-test_watch.watchkitapp.watchkitextension";
 #elif MONOMAC
 			var expectedBundleId = "com.xamarin.xammac_tests";
 #else

--- a/tests/xharness/WatchOSTarget.cs
+++ b/tests/xharness/WatchOSTarget.cs
@@ -154,7 +154,7 @@ namespace xharness
 			XmlDocument info_plist = new XmlDocument ();
 			var target_info_plist = Path.Combine (TargetDirectory, $"Info{Suffix}-extension.plist");
 			info_plist.LoadWithoutNetworkAccess (Path.Combine (TargetDirectory, "Info.plist"));
-			BundleIdentifier = info_plist.GetCFBundleIdentifier () + "-watch";
+			BundleIdentifier = info_plist.GetCFBundleIdentifier () + "_watch";
 			if (BundleIdentifier.Length >= 58)
 				BundleIdentifier = BundleIdentifier.Substring (0, 57); // If the main app's bundle id is 58 characters (or sometimes more), then the watch extension crashes at launch. radar #29847128.
 			info_plist.SetCFBundleIdentifier (BundleIdentifier + ".watchkitapp.watchkitextension");


### PR DESCRIPTION
It causes problems with the mscorlib test project, which can't be launched properly.

I'm not sure what's the underlying cause, but here are some of the symptoms:

* The watch app actually shows up fine on the device, but:
* mlaunch isn't notified about the new process, so it thinks the app didn't
  launch.
* The new process doesn't receive any environment variables we try to give it,
  which for instance means that it won't auto-start the tests upon launch.
* If we ask mlaunch to attach with lldb, mlaunch will ask watchOS to launch
  the process in a suspended state while lldb attaches. Yet the watch app
  shows up on the device as if not asked to be suspended upon launch.

It seems that the dash (I assume, because I haven't investigated this very
deeply, I just happened to find a solution that worked) makes watchOS launch
the app as if tapped, instead of launched from an IDE.

The strangest part is that this only happens with the mscorlib test project,
not any of the other test projects we run on the watch, and they all have
dashes in their bundle identifiers... yet replacing the dash with another
character (underscore, letter, removing it altogether) all made things work as
expected.

Backport of #6114.

/cc @rolfbjarne 