### PR TITLE
Annotate NullAllowed for ToolTip properties in AppKit

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -8214,7 +8214,7 @@ namespace AppKit {
 		[Export ("hidden")]
 		bool Hidden { [Bind ("isHidden")] get; set; }
 
-		[Export ("toolTip")]
+		[Export ("toolTip"), NullAllowed]
 		string ToolTip { get; set; }
 
 		[Mac (10, 13)]
@@ -8916,7 +8916,7 @@ namespace AppKit {
 		void DidDragTableColumn (NSOutlineView outlineView, NSTableColumn tableColumn);
 		
 		[Export ("outlineView:toolTipForCell:rect:tableColumn:item:mouseLocation:")]
-		string ToolTipForCell (NSOutlineView outlineView, NSCell cell, ref CGRect rect, NSTableColumn tableColumn, NSObject item, CGPoint mouseLocation);
+		string ToolTipForCell (NSOutlineView outlineView, NSCell cell, ref CGRect rect, [NullAllowed] NSTableColumn tableColumn, NSObject item, CGPoint mouseLocation);
 	
 		[Export ("outlineView:heightOfRowByItem:"), NoDefaultValue]
 		nfloat GetRowHeight (NSOutlineView outlineView, NSObject item);
@@ -10299,6 +10299,7 @@ namespace AppKit {
 		void SetToolTipForCell ([NullAllowed] string toolTipString, NSCell cell);
 
 		[Export ("toolTipForCell:")]
+		[return: NullAllowed]
 		string ToolTipForCell (NSCell cell);
 
 		//Detected properties
@@ -13704,6 +13705,7 @@ namespace AppKit {
 		void SetToolTip ([NullAllowed] string toolTip, nint forSegment);
 
 		[Export ("toolTipForSegment:")]
+		[return: NullAllowed]
 		string GetToolTip (nint forSegment);
 
 		[Export ("setTag:forSegment:")]
@@ -14843,7 +14845,7 @@ namespace AppKit {
 		bool Enabled { [Bind ("isEnabled")]get; set; }
 
 		[Availability (Deprecated = Platform.Mac_10_10, Message = "Soft-deprecation, forwards message to button, but will be gone in the future.")]
-		[Export ("toolTip")]
+		[Export ("toolTip"), NullAllowed]
 		string ToolTip { get; set; }
 
 		[Availability (Deprecated = Platform.Mac_10_10, Message = "Soft-deprecation, forwards message to button, but will be gone in the future.")]
@@ -15756,7 +15758,7 @@ namespace AppKit {
 		[Export ("postsBoundsChangedNotifications")]
 		bool PostsBoundsChangedNotifications { get; set; }
 
-		[Export ("toolTip")]
+		[Export ("toolTip"), NullAllowed]
 		string ToolTip { get; set; }
 				
 		[Export ("registerForDraggedTypes:")]
@@ -16565,7 +16567,7 @@ namespace AppKit {
 		[Export ("resizingMask")]
 		NSTableColumnResizing ResizingMask { get; set; }
 	
-		[Export ("headerToolTip")]
+		[Export ("headerToolTip"), NullAllowed]
 		string HeaderToolTip { get; set; }
 	
 		[Export ("hidden")]
@@ -17619,7 +17621,7 @@ namespace AppKit {
 		[Export ("sizeOfLabel:")]
 		CGSize SizeOfLabel (bool computeMin);
 
-		[Export ("toolTip")]
+		[Export ("toolTip"), NullAllowed]
 		string ToolTip { get; set; }
 
 		[Mac (10,10)]
@@ -19336,6 +19338,7 @@ namespace AppKit {
 		void DidChangeTypingAttributes (NSNotification notification);
 
 		[Export ("textView:willDisplayToolTip:forCharacterAtIndex:"), DelegateName ("NSTextViewTooltip"), DefaultValueFromArgument ("tooltip")]
+		[return: NullAllowed]
 		string WillDisplayToolTip (NSTextView textView, string tooltip, nuint characterIndex);
 
 		[Export ("textView:completions:forPartialWordRange:indexOfSelectedItem:"), DelegateName ("NSTextViewCompletion"), DefaultValue (null)]
@@ -19634,7 +19637,7 @@ namespace AppKit {
 		[Export ("paletteLabel")]
 		string PaletteLabel { get; set; }
 
-		[Export ("toolTip")]
+		[Export ("toolTip"), NullAllowed]
 		string ToolTip { get; set; }
 
 		[Export ("menuFormRepresentation", ArgumentSemantic.Retain)]
@@ -23206,7 +23209,7 @@ namespace AppKit {
 	partial interface NSTableViewDelegate {
 
 		[Export ("tableView:toolTipForCell:rect:tableColumn:row:mouseLocation:"), DelegateName ("NSTableViewToolTip"), DefaultValue ("null")]
-		NSString GetToolTip (NSTableView tableView, NSCell cell, ref CGRect rect, NSTableColumn tableColumn, nint row, CGPoint mouseLocation);
+		NSString GetToolTip (NSTableView tableView, NSCell cell, ref CGRect rect, [NullAllowed] NSTableColumn tableColumn, nint row, CGPoint mouseLocation);
 	}
 
 	partial interface NSBrowser {
@@ -26619,7 +26622,7 @@ namespace AppKit {
 		[NullAllowed, Export ("attributedTitle", ArgumentSemantic.Copy)]
 		NSAttributedString AttributedTitle { get; set; }
 
-		[Export ("toolTip")]
+		[Export ("toolTip"), NullAllowed]
 		string ToolTip { get; set; }
 
 		[NullAllowed, Export ("accessoryView", ArgumentSemantic.Strong)]


### PR DESCRIPTION
I'm not sure whether `[return: NullAllowed]` should also be applied to properties for the getters.

Actual fix for https://github.com/xamarin/xamarin-macios/issues/6108