### PR TITLE
Fix case sensitivity of MSBuildSDKsPath

### DIFF
--- a/tools/xibuild/Main.cs
+++ b/tools/xibuild/Main.cs
@@ -206,7 +206,7 @@ namespace xibuild {
 			SetToolsetProperty ("MSBuildExtensionsPath32", MSBuildExtensionsPath);
 			SetToolsetProperty ("MSBuildExtensionsPath64", MSBuildExtensionsPath);
 			SetToolsetProperty ("RoslynTargetsPath", Path.Combine (MSBuildBin, "Roslyn"));
-			SetToolsetProperty ("MSBuildSdksPath", MSBuildSdksPath);
+			SetToolsetProperty ("MSBuildSDKsPath", MSBuildSdksPath);
 
 			dstXml.Save (targetConfigFile);
 			return;


### PR DESCRIPTION
This would result in locally for me. Seems like `SelectSingleNode` is case sensitive?

```
MSBUILD : Configuration error MSB4136: Error reading the toolset information from the configuration file "System.Configuration". Error deserializing configuration section msbuildToolsets: Multiple definitions were found for the property "MSBuildSDKsPath".
```