### PR TITLE
[d16-1] [launcher] Only set MONO_REGISTRY_PATH if folder exists

### DIFF
--- a/runtime/launcher.m
+++ b/runtime/launcher.m
@@ -358,7 +358,11 @@ update_environment (xamarin_initialize_data *data)
 		NSURL *appSupport = [appSupportDirectories objectAtIndex: 0];
 		if (appSupport != nil && appBundleID != nil) {
 			NSURL *appDirectory = [appSupport URLByAppendingPathComponent:appBundleID isDirectory: YES];
-			setenv ("MONO_REGISTRY_PATH", [[appDirectory path] UTF8String], 1);
+			// Only set registry if path exists (see https://devdiv.visualstudio.com/DevDiv/_workitems/edit/896438)
+			NSFileManager *filemgr = [NSFileManager defaultManager];
+			BOOL isDir = YES;
+			if ([filemgr fileExistsAtPath:[[NSBundle mainBundle] bundlePath] isDirectory: &isDir])
+				setenv ("MONO_REGISTRY_PATH", [[appDirectory path] UTF8String], 1);
 		}
 	}
 #endif


### PR DESCRIPTION
This makes VS Mac fail when publishing ASP.NET Core projects to Azure
(see https://devdiv.visualstudio.com/DevDiv/_workitems/edit/896438) when
launched from the Xamarin Installer (or any other Xamarin.Mac app), as
the folder doesn't exist. So, instead of patching it in VS Mac itself
(unsetting the env var), fix it here, so that it's only set if the
app support dir really exists.

Backport of #6120.

/cc @rodrmoya 