### PR TITLE
[monotouch-test] Adjust expected value for watchOS bundle id.

### DIFF
--- a/tests/monotouch-test/CoreFoundation/BundleTest.cs
+++ b/tests/monotouch-test/CoreFoundation/BundleTest.cs
@@ -76,7 +76,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		{
 			var main = CFBundle.GetMain ();
 #if __WATCHOS__
-			var expectedBundleId = "com.xamarin.monotouch-test-watch.watchkitapp.watchkitextension";
+			var expectedBundleId = "com.xamarin.monotouch-test_watch.watchkitapp.watchkitextension";
 #elif MONOMAC
 			var expectedBundleId = "com.xamarin.xammac_tests";
 #else


### PR DESCRIPTION
The watchOS bundle ID changed in fc5067ee673bb7005031e5373a0130e43124d875, and
the test failure wasn't caught properly.