### PR TITLE
[XHarness] Ignore a number of assemblies that do not have any tests.

### DIFF
--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -141,6 +141,9 @@ namespace BCLTestImporter {
 			"monotouch_Mono.CodeContracts_test.dll", // not supported by xamarin
 			"monotouch_Novell.Directory.Ldap_test.dll", // not supported by xamarin
 			"monotouch_Mono.Profiler.Log_xunit-test.dll", // special tests that need an extra app to connect as a profiler
+			"monotouch_System.ComponentModel.Composition_xunit-test.dll", // has no test classes, all test have been removed by mono
+			"monotouch_System.Net.Http.FunctionalTests_xunit-test.dll", // has no test classes, all test have been removed by mono
+			"monotouch_System.Runtime.Serialization_xunit-test.dll", // has no test classes, all test have been removed by mono
 		};
 		
 		// list of assemblies that are going to be ignored, any project with an assemblies that is ignored will


### PR DESCRIPTION
Mono did remove all the tests in a number of assemblies on
ios/tvos/watchos. With a recent change, we report test runs with no
tests as a failure (correctly since it will bring up issues with the
runners).

In this case, the tree assemblies have to be ignored because they truly
do not have tests and the runners are doing the right thing.

Fixes: https://github.com/xamarin/maccore/issues/1652