### PR TITLE
[tests] Use msbuild, not xibuild, to build the generator tests.

### DIFF
--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -6,7 +6,7 @@ all-local:: run-unit-tests
 
 build-unit-tests:
 	$(Q) $(SYSTEM_MONO) /Library/Frameworks//Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore $(TOP)/src/generator.sln
-	$(SYSTEM_XIBUILD) -- generator-tests.csproj $(XBUILD_VERBOSITY)
+	$(SYSTEM_MSBUILD) generator-tests.csproj $(XBUILD_VERBOSITY)
 
 run-unit-tests: build-unit-tests
 	rm -f .failed-stamp


### PR DESCRIPTION
The generator tests is a standard C# library, and can use the system msbuild
just fine.

Fixes this build problem when building the tests using the command line:

    xamarin-macios/external/mono/external/ikvm/reflect/Emit/ILGenerator.cs(119,20): error CS0433: The type 'Stack<T>' exists in both 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' and 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'