### PR TITLE
[Harness] Pass extra arguments to configure the linker for certain tests

### DIFF
--- a/tests/bcl-test/BCLTests/SystemXunitLinker.xml
+++ b/tests/bcl-test/BCLTests/SystemXunitLinker.xml
@@ -1,0 +1,36 @@
+<linker>
+	<assembly fullname="System">
+		<type fullname="System.Text.RegularExpressions.CollectionDebuggerProxy`1" preserve="all" />
+    </assembly>
+	<assembly fullname="System.Core">
+		<type fullname="System.Dynamic.BindingRestrictions/BindingRestrictionsProxy" preserve="all" />
+		<type fullname="System.Dynamic.ExpandoObject/KeyCollectionDebugView" preserve="all" />
+		<type fullname="System.Dynamic.ExpandoObject/ValueCollectionDebugView" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/BinaryExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/BlockExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/CatchBlockProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/ConditionalExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/ConstantExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/DebugInfoExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/DefaultExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/GotoExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/IndexExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/InvocationExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/LabelExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/LambdaExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/ListInitExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/LoopExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/MemberExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/MemberInitExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/MethodCallExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/NewArrayExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/NewExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/ParameterExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/RuntimeVariablesExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/SwitchCaseProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/SwitchExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/TryExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/TypeBinaryExpressionProxy" preserve="all" />
+		<type fullname="System.Linq.Expressions.Expression/UnaryExpressionProxy" preserve="all" />
+    </assembly>
+</linker>

--- a/tests/bcl-test/BCLTests/SystemXunitLinker.xml
+++ b/tests/bcl-test/BCLTests/SystemXunitLinker.xml
@@ -1,7 +1,7 @@
 <linker>
 	<assembly fullname="System">
 		<type fullname="System.Text.RegularExpressions.CollectionDebuggerProxy`1" preserve="all" />
-    </assembly>
+	</assembly>
 	<assembly fullname="System.Core">
 		<type fullname="System.Dynamic.BindingRestrictions/BindingRestrictionsProxy" preserve="all" />
 		<type fullname="System.Dynamic.ExpandoObject/KeyCollectionDebugView" preserve="all" />
@@ -32,5 +32,5 @@
 		<type fullname="System.Linq.Expressions.Expression/TryExpressionProxy" preserve="all" />
 		<type fullname="System.Linq.Expressions.Expression/TypeBinaryExpressionProxy" preserve="all" />
 		<type fullname="System.Linq.Expressions.Expression/UnaryExpressionProxy" preserve="all" />
-    </assembly>
+	</assembly>
 </linker>

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -42,8 +42,8 @@ namespace xharness
 		}
 
 		// This is the maccore/tests directory.
-		string root_directory;
-		public string RootDirectory {
+		static string root_directory;
+		public static string RootDirectory {
 			get {
 				if (root_directory == null) {
 					var testAssemblyDirectory = Path.GetDirectoryName (System.Reflection.Assembly.GetExecutingAssembly ().Location);

--- a/tests/xharness/MakefileGenerator.cs
+++ b/tests/xharness/MakefileGenerator.cs
@@ -89,7 +89,7 @@ namespace xharness
 
 		public static void CreateMacMakefile (Harness harness, IEnumerable<MacTarget> targets)
 		{
-			var makefile = Path.Combine (harness.RootDirectory, "Makefile-mac.inc");
+			var makefile = Path.Combine (Harness.RootDirectory, "Makefile-mac.inc");
 			using (var writer = new StreamWriter (makefile, false, new UTF8Encoding (false))) {
 				writer.WriteLine (".stamp-configure-projects-mac: Makefile xharness/xharness.exe");
 				writer.WriteLine ("\t$(Q) $(SYSTEM_MONO) --debug $(XIBUILD_EXE_PATH) -t -- $(CURDIR)/xharness/xharness.exe $(XHARNESS_VERBOSITY) --configure --autoconf --rootdir $(CURDIR)");
@@ -284,7 +284,7 @@ namespace xharness
 		public static void CreateMakefile (Harness harness, IEnumerable<UnifiedTarget> unified_targets, IEnumerable<TVOSTarget> tvos_targets, IEnumerable<WatchOSTarget> watchos_targets, IEnumerable<TodayExtensionTarget> today_targets)
 		{
 			var executeSim32 = !harness.InWrench; // Waiting for iOS 10.3 simulator to be installed on wrench
-			var makefile = Path.Combine (harness.RootDirectory, "Makefile.inc");
+			var makefile = Path.Combine (Harness.RootDirectory, "Makefile.inc");
 			using (var writer = new StreamWriter (makefile, false, new UTF8Encoding (false))) {
 				writer.WriteLine (".stamp-configure-projects: Makefile xharness/xharness.exe");
 				writer.WriteLine ("\t$(Q) $(SYSTEM_MONO) --debug $(XIBUILD_EXE_PATH) -t -- $(CURDIR)/xharness/xharness.exe $(XHARNESS_VERBOSITY) --configure --autoconf --rootdir $(CURDIR)");

--- a/tests/xharness/Program.cs
+++ b/tests/xharness/Program.cs
@@ -19,7 +19,7 @@ namespace xharness
 				{ "mac", "Configure for Xamarin.Mac instead of iOS.", (v) => harness.Mac = true },
 				{ "configure", "Creates project files and makefiles.", (v) => harness.Action = HarnessAction.Configure },
 				{ "autoconf", "Automatically decide what to configure.", (v) => harness.AutoConf = true },
-				{ "rootdir=", "The root directory for the tests.", (v) => harness.RootDirectory = v },
+				{ "rootdir=", "The root directory for the tests.", (v) => Harness.RootDirectory = v },
 				{ "project=", "Add a project file to process. This can be specified multiple times.", (v) => harness.IOSTestProjects.Add (new iOSTestProject (v)) },
 				{ "watchos-container-template=", "The directory to use as a template for a watchos container app.", (v) => harness.WatchOSContainerTemplate = v },
 				{ "watchos-app-template=", "The directory to use as a template for a watchos app.", (v) => harness.WatchOSAppTemplate = v },

--- a/tests/xharness/SolutionGenerator.cs
+++ b/tests/xharness/SolutionGenerator.cs
@@ -56,8 +56,8 @@ namespace xharness
 		{
 			var folders = new StringBuilder ();
 
-			var srcDirectory = Path.Combine (harness.RootDirectory, "..", "src");
-			var sln_path = exeTarget == null ? Path.Combine (harness.RootDirectory, "tests-" + infix + ".sln") : Path.Combine (Path.GetDirectoryName (exeTarget.ProjectPath), Path.GetFileNameWithoutExtension (exeTarget.ProjectPath) + ".sln");
+			var srcDirectory = Path.Combine (Harness.RootDirectory, "..", "src");
+			var sln_path = exeTarget == null ? Path.Combine (Harness.RootDirectory, "tests-" + infix + ".sln") : Path.Combine (Path.GetDirectoryName (exeTarget.ProjectPath), Path.GetFileNameWithoutExtension (exeTarget.ProjectPath) + ".sln");
 
 			using (var writer = new StringWriter ()) {
 				writer.WriteLine ();

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Security.Cryptography;
+using xharness;
 
 namespace BCLTestImporter {
 	/// <summary>
@@ -118,7 +119,7 @@ namespace BCLTestImporter {
 			// BCL tests group 4
 			(name:"SystemNumericsXunit", assemblies: new [] {"monotouch_System.Numerics_xunit-test.dll"}, extraArgs: null, group: "BCL tests group 4"),
 			(name:"SystemCoreXunit", assemblies: new [] {"monotouch_System.Core_xunit-test.dll"}, extraArgs: null, group: "BCL tests group 4"),
-			(name:"SystemXunit", assemblies: new [] {"monotouch_System_xunit-test.dll"}, extraArgs: null, group: "BCL tests group 4"),
+			(name:"SystemXunit", assemblies: new [] {"monotouch_System_xunit-test.dll"}, extraArgs: $"--xml={Path.Combine (Harness.RootDirectory, "bcl-test", "BCLTests", "SystemXunitLinker.xml")} --optimize=-custom-attributes-removal", group: "BCL tests group 4"),
 			(name:"MicrosoftCSharpXunit", assemblies: new [] {"monotouch_Microsoft.CSharp_xunit-test.dll"}, extraArgs: null, group: "BCL tests group 4"),
 
 			// BCL tests group 5
@@ -724,7 +725,8 @@ namespace BCLTestImporter {
 					} else {
 						groupedApps [group] = new List<string> (validAssemblies);
 						groupedAppsExtraArgs [group] = new List<string> ();
-						groupedAppsExtraArgs [group].Add (extraArgs);
+						if (extraArgs != null)
+							groupedAppsExtraArgs [group].Add (extraArgs);
 					}
 				}
 				foreach (var group in groupedApps.Keys) {


### PR DESCRIPTION
Some tests need a special linker configuration. Add the extra arguments
so that tests do pass on device.

Fixes: https://github.com/xamarin/maccore/issues/1608