### PR TITLE
[apidiff] Make temporary / stamp paths depend on APIDIFF_DIR.

### DIFF
--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -47,11 +47,11 @@ MAC_ARCH_ASSEMBLIES = native-32/Xamarin.Mac native-64/Xamarin.Mac
 
 APIDIFF_IGNORE = -i 'INSObjectProtocol'
 
-.download-$(MONO_HASH).stamp:
+$(APIDIFF_DIR)/.download-$(MONO_HASH).stamp:
 	$(MAKE) -C $(TOP)/builds download
 	$(Q) touch $@
 
-$(MONO_API_INFO) $(MONO_API_HTML): .download-$(MONO_HASH).stamp
+$(MONO_API_INFO) $(MONO_API_HTML): $(APIDIFF_DIR)/.download-$(MONO_HASH).stamp
 
 # create api info. Directory hierarchy is based on installed hierarchy
 # (XM goes into temp/xm, and XI goes into temp/xi)


### PR DESCRIPTION
This fixes an issue with the api comparison since the api comparison fails if
it detects unexpected modified files: https://github.com/xamarin/xamarin-macios/pull/6133#issuecomment-496283224.

Putting the temporary files in APIDIFF_DIR makes sure the api comparison
doesn't see those files as unexpectedly modified.