### PR TITLE
[Metal] Obsolete and fix MTLDevice.CreateBufferNoCopy.

### DIFF
--- a/src/Metal/MTLDevice.cs
+++ b/src/Metal/MTLDevice.cs
@@ -128,16 +128,18 @@ namespace Metal {
 			}
 		}
 
+#if !XAMCORE_4_0
+		[Obsolete ("Use the overload that takes an IntPtr instead. The 'data' parameter must be page-aligned and allocated using vm_allocate or mmap, which won't be the case for managed arrays, so this method will always fail.")]
 		public static IMTLBuffer CreateBufferNoCopy<T> (this IMTLDevice This, T [] data, MTLResourceOptions options, MTLDeallocator deallocator) where T : struct
 		{
 			var handle = GCHandle.Alloc (data, GCHandleType.Pinned); // This requires a pinned GCHandle, since it's not possible to use unsafe code to get the address of a generic object.
-			try {
-				IntPtr ptr = handle.AddrOfPinnedObject ();
-				return This.CreateBufferNoCopy (ptr, (nuint)(data.Length * Marshal.SizeOf (typeof (T))), options, deallocator);
-			} finally {
+			IntPtr ptr = handle.AddrOfPinnedObject ();
+			return This.CreateBufferNoCopy (ptr, (nuint)(data.Length * Marshal.SizeOf (typeof (T))), options, (pointer, length) => {
 				handle.Free ();
-			}
+				deallocator (pointer, length);
+			});
 		}
+#endif
 
 		public unsafe static void GetDefaultSamplePositions (this IMTLDevice This, MTLSamplePosition [] positions, nuint count)
 		{


### PR DESCRIPTION
MTLDevice.CreateBufferNoCopy must be called with memory allocated with
vm_allocate or mmap, which will hardly be the case for managed arrays, so
obsolete this overload.

Still, the method might never work, but in the case it actually does for some
reason, don't free the handle to the managed memory until the MTLDevice is
done with it.