### PR TITLE
Show better error when the mono archive isn't available. Fixes xamarin-macios/maccore#1655.

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -23,7 +23,11 @@ downloads/$(MONO_IOS_FILENAME) downloads/$(MONO_MAC_FILENAME):
 	else \
 		EC=0; \
 		curl -f -L $(if $(V),-v,-s) $(MONO_URL) --output $@.tmp || EC=$$?; \
-		if [[ x$$EC == x22 ]]; then printf "$(COLOR_RED)*** Could not download the archive $(notdir $@) because the URL doesn't exist. This can happen if bumping mono very soon after the corresponding commit was pushed to mono (i.e. the archive hasn't been built yet). If so, please wait a bit and try again.$(COLOR_CLEAR)\n"; fi; \
+		if [[ x$$EC == x22 ]]; then \
+			MSG="Could not download the archive %s because the URL doesn't exist. This can happen if bumping mono very soon after the corresponding commit was pushed to mono (i.e. the archive hasn't been built yet). If so, please wait a bit and try again."; \
+			printf "$(COLOR_RED)*** $$MSG$(COLOR_CLEAR)\n" "$(notdir $@)"; \
+			if test -n "$$FAILURE_REASON_PATH"; then printf "$$MSG\n" "[$(notdir $@)]($(MONO_URL))" >> "$$FAILURE_REASON_PATH"; fi; \
+		fi; \
 		if [[ x$$EC != x0 ]]; then exit $$EC; fi; \
 	fi
 	$(Q) mv $@.tmp $@

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -8,6 +8,8 @@ download: downloads/$(basename $(MONO_IOS_FILENAME)) downloads/$(basename $(MONO
 downloads/$(basename $(MONO_IOS_FILENAME)): MONO_URL=$(MONO_IOS_URL)
 downloads/$(basename $(MONO_MAC_FILENAME)): MONO_URL=$(MONO_MAC_URL)
 
+include $(TOP)/mk/colors.mk
+
 # This target downloads the mono archives, there's one for Xamarin.iOS and one for Xamarin.Mac.
 # If doing many clean builds, it's possible to copy the downloaded zip file to ~/Library/Caches/xamarin-macios
 # to avoid having to download it every time. The zip files have to be copied manually, otherwise
@@ -19,7 +21,10 @@ downloads/$(MONO_IOS_FILENAME) downloads/$(MONO_MAC_FILENAME):
 		echo "Found a cached version of $(MONO_URL) in ~/Library/Caches/xamarin-macios/$(notdir $@)."; \
 		$(CP) ~/Library/Caches/xamarin-macios/$(notdir $@) $@.tmp; \
 	else \
-		curl -f -L $(if $(V),-v,-s) $(MONO_URL) --output $@.tmp; \
+		EC=0; \
+		curl -f -L $(if $(V),-v,-s) $(MONO_URL) --output $@.tmp || EC=$$?; \
+		if [[ x$$EC == x22 ]]; then printf "$(COLOR_RED)*** Could not download the archive $(notdir $@) because the URL doesn't exist. This can happen if bumping mono very soon after the corresponding commit was pushed to mono (i.e. the archive hasn't been built yet). If so, please wait a bit and try again.$(COLOR_CLEAR)\n"; fi; \
+		if [[ x$$EC != x0 ]]; then exit $$EC; fi; \
 	fi
 	$(Q) mv $@.tmp $@
 	$(Q) echo "Downloaded $(MONO_URL)"

--- a/jenkins/.gitignore
+++ b/jenkins/.gitignore
@@ -1,3 +1,4 @@
 pr-comments.md
+build-failure.md
 .tmp-labels*
 

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -8,9 +8,14 @@
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 WORKSPACE=$(pwd)
 
+export FAILURE_REASON_PATH="$WORKSPACE/jenkins/build-failure.md"
+
 report_error ()
 {
 	printf "🔥 [Build failed](%s/console) 🔥\\n" "$BUILD_URL" >> "$WORKSPACE/jenkins/pr-comments.md"
+	if test -f "$FAILURE_REASON_PATH"; then
+		sed 's/^/* /' "$FAILURE_REASON_PATH" >> "$WORKSPACE/jenkins/pr-comments.md"
+	fi
 }
 trap report_error ERR
 

--- a/mk/colors.mk
+++ b/mk/colors.mk
@@ -1,0 +1,5 @@
+
+COLOR_GRAY:=$(shell tput setaf 250 2>/dev/null)
+COLOR_GREEN:=$(shell tput setaf 120 2>/dev/null)
+COLOR_RED:=$(shell tput setaf 1 2>/dev/null)
+COLOR_CLEAR:=$(shell tput sgr0 2>/dev/null)

--- a/mk/versions.mk
+++ b/mk/versions.mk
@@ -3,10 +3,7 @@
 
 THISDIR=$(TOP)/mk
 
-COLOR_GRAY:=$(shell tput setaf 250 2>/dev/null)
-COLOR_GREEN:=$(shell tput setaf 120 2>/dev/null)
-COLOR_RED:=$(shell tput setaf 1 2>/dev/null)
-COLOR_CLEAR:=$(shell tput sgr0 2>/dev/null)
+include $(THISDIR)/colors.mk
 
 define CheckSubmoduleTemplate
 #$(eval NEEDED_$(2)_VERSION:=$(shell git --git-dir $(abspath $($(2)_PATH)/../..)/.git --work-tree $(abspath $($(2)_PATH)/../..) ls-tree HEAD --full-tree -- external/$(1) | awk -F' ' '{printf "%s",$$3}'))


### PR DESCRIPTION
Comments on PRs will look something like this:

<img width="686" alt="Screenshot 2019-05-29 08 51 17" src="https://user-images.githubusercontent.com/249268/58535856-2fc33580-81ef-11e9-9742-3d6643da5dfe.png">

Fixes https://github.com/xamarin/maccore/issues/1655.