### PR TITLE
[apidiff] Create the directory for the stamp file before trying to create files in it.

### DIFF
--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -49,6 +49,7 @@ APIDIFF_IGNORE = -i 'INSObjectProtocol'
 
 $(APIDIFF_DIR)/.download-$(MONO_HASH).stamp:
 	$(MAKE) -C $(TOP)/builds download
+	$(Q) mkdir -p $(dir $@)
 	$(Q) touch $@
 
 $(MONO_API_INFO) $(MONO_API_HTML): $(APIDIFF_DIR)/.download-$(MONO_HASH).stamp


### PR DESCRIPTION
Fixes this:

	[...]
    Updating apidiff references...
    /Applications/Xcode102.app/Contents/Developer/usr/bin/make -C ../../builds download
    Downloading https://xamjenkinsartifact.azureedge.net/mono-sdks/ios-release-Darwin-dfd4224fdd40dfa8bfdad092c7d75d235ca37a8d.zip...
    Downloading https://xamjenkinsartifact.azureedge.net/mono-sdks/mac-release-Darwin-dfd4224fdd40dfa8bfdad092c7d75d235ca37a8d.zip...
    Downloaded https://xamjenkinsartifact.azureedge.net/mono-sdks/mac-release-Darwin-dfd4224fdd40dfa8bfdad092c7d75d235ca37a8d.zip
    Unzipping mac-release-Darwin-dfd4224fdd40dfa8bfdad092c7d75d235ca37a8d...
    Unzipped mac-release-Darwin-dfd4224fdd40dfa8bfdad092c7d75d235ca37a8d.
    Downloaded https://xamjenkinsartifact.azureedge.net/mono-sdks/ios-release-Darwin-dfd4224fdd40dfa8bfdad092c7d75d235ca37a8d.zip
    Unzipping ios-release-Darwin-dfd4224fdd40dfa8bfdad092c7d75d235ca37a8d...
    Unzipped ios-release-Darwin-dfd4224fdd40dfa8bfdad092c7d75d235ca37a8d.
    touch: /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tools/comparison/apidiff/.download-dfd4224fdd40dfa8bfdad092c7d75d235ca37a8d.stamp: No such file or directory
    make: *** [/Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tools/comparison/apidiff/.download-dfd4224fdd40dfa8bfdad092c7d75d235ca37a8d.stamp] Error 1
    Failed to update apidiff references

from https://jenkins.mono-project.com/job/xamarin-macios-pr-builder/10093/consoleText.