### PR TITLE
[XHarness] Do clean after mtouch build tests.

### DIFF
--- a/tests/common/ExecutionHelper.cs
+++ b/tests/common/ExecutionHelper.cs
@@ -412,6 +412,7 @@ namespace Xamarin.Tests
 					$"/p:Platform={platform}",
 					$"/verbosity:{(string.IsNullOrEmpty (verbosity) ? "normal" : verbosity)}",
 					"/r:True", // restore nuget packages which are used in some test cases
+					"/t:Clean,Build", // clean and then build, in case we left something behind in a shared dir
 					project
 				}.Union (arguments ?? new string [] { }).ToArray (),
 				environmentVariables: environmentVariables,


### PR DESCRIPTION
The BCL projects do share the directory. This means that if we do not
clean before building we could have unknown side effects.

Fixes: https://github.com/xamarin/xamarin-macios/issues/6157