### PR TITLE
[msbuild] Avoid running CollectBundleResources task if there's no Mac available

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -1160,6 +1160,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	<Target Name="_CollectColladaAssets">
 		<CollectBundleResources
 			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
 			BundleResources="@(Collada)"
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(IPhoneResourcePrefix)">


### PR DESCRIPTION
The IsMacEnabled condition was missing in this specific usage of the CollectBundleResources task. As with any other task that needs to run on a Mac, we should only run it if there's a Mac available or it will end up showing several warnings when building offline from Windows.