### PR TITLE
[tests] Run tests on watchOS in a background thread.

### DIFF
--- a/tests/templates/WatchExtension/InterfaceController.cs
+++ b/tests/templates/WatchExtension/InterfaceController.cs
@@ -105,15 +105,23 @@ namespace monotouchtestWatchKitExtension
 			}
 			running = true;
 			cmdRun.SetEnabled (false);
-			lblStatus.SetText ("Running");
-			BeginInvokeOnMainThread (() => {
+			lblStatus.SetText ("Running in background");
+
+			var timer = NSTimer.CreateRepeatingScheduledTimer (TimeSpan.FromSeconds (1), (v) => RenderResults ());
+			var runnerThread = new Thread (() => {
 				runner.Run ();
 
-				cmdRun.SetEnabled (true);
-				lblStatus.SetText ("Done");
-				running = false;
-				RenderResults ();
-			});
+				InvokeOnMainThread (() => {
+					cmdRun.SetEnabled (true);
+					lblStatus.SetText ("Done");
+					running = false;
+					timer.Dispose ();
+					RenderResults ();
+				});
+			}) {
+				IsBackground = true,
+			};
+			runnerThread.Start ();
 		}
 
 		void RenderResults ()


### PR DESCRIPTION
Otherwise watchOS might terminate the process if we lock up the UI too long
while running tests.

It's also nice to see the progress as the tests are running.