### PR TITLE
[XHarness] Re-enable tvOS tests.

### DIFF
--- a/tests/bcl-test/BCLTests/BCLTests-tv.csproj.in
+++ b/tests/bcl-test/BCLTests/BCLTests-tv.csproj.in
@@ -7,8 +7,8 @@
     <ProjectGuid>{C459A4DD-0AFF-4B2C-9DEC-4B62CE04F4E2}</ProjectGuid>
     <ProjectTypeGuids>{06FA79CB-D6CD-4721-BB4B-1BD202089C55}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
-    <RootNamespace>%NAME%</RootNamespace>
-    <AssemblyName>%NAME%</AssemblyName>
+    <RootNamespace>com.xamarin.bcltests.%NAME%</RootNamespace>
+    <AssemblyName>com.xamarin.bcltests.%NAME%</AssemblyName>
     <NoWarn>67,168,169,219,414,612,618,649,672</NoWarn>
     <TargetFrameworkIdentifier>Xamarin.TVOS</TargetFrameworkIdentifier>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>

--- a/tests/bcl-test/BCLTests/Info-tv.plist.in
+++ b/tests/bcl-test/BCLTests/Info-tv.plist.in
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleName</key>
-	<string>%APPLICATION NAME%</string>
+	<string>com.xamarin.bcltests.%APPLICATION NAME%</string>
 	<key>CFBundleIdentifier</key>
 	<string>%BUNDLE INDENTIFIER%</string>
 	<key>CFBundleShortVersionString</key>

--- a/tests/bcl-test/BCLTests/tvOS-monotouch_corlib_xunit-test.dll.ignore
+++ b/tests/bcl-test/BCLTests/tvOS-monotouch_corlib_xunit-test.dll.ignore
@@ -1,0 +1,9 @@
+# device failures:
+
+# Expected: 0
+# Actual:   -1 
+System.IO.Tests.FileInfo_Exists.TrueForNonRegularFile
+System.IO.Tests.DirectoryInfo_Exists.FalseForNonRegularFile
+
+# Exception messages: System.NullReferenceException : Object reference not set to an instance of an object
+System.Threading.Tasks.Tests.TaskSchedulerTests.GetScheduledTasksForDebugger_DebuggerAttached_ReturnsTasksFromCustomSchedulers

--- a/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
+++ b/tools/bcl-test-importer/BCLTestImporter/BCLTestProjectGenerator.cs
@@ -160,8 +160,6 @@ namespace BCLTestImporter {
 		static readonly List<string> iOSIgnoredAssemblies = new List<string> {};
 
 		static readonly List<string> tvOSIgnoredAssemblies = new List<string> {
-			"monotouch_corlib_xunit-test.dll", // ignored due to https://github.com/xamarin/maccore/issues/1611 until mono fixes it
-			"monotouch_System_xunit-test.dll", // ignored due to https://github.com/xamarin/maccore/issues/1610
 		};
 
 		static readonly List<string> watcOSIgnoredAssemblies = new List<string> {


### PR DESCRIPTION
After mono fixed issues https://github.com/mono/mono/issues/14497 and
https://github.com/mono/mono/issues/14496 re-enable the ignored tests.

Fixes: https://github.com/xamarin/maccore/issues/1610
Fixes: https://github.com/xamarin/maccore/issues/1611