### PR TITLE
[xharness] Look for HE0038 anywhere in a log file.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -1670,10 +1670,10 @@ namespace xharness
 			if (File.Exists (log.FullPath) && new FileInfo (log.FullPath).Length > 0) {
 				using (var reader = log.GetReader ()) {
 					while (!reader.EndOfStream) {
-						string line = reader.ReadLine ()?.Trim ();
+						string line = reader.ReadLine ();
 						if (line == null)
 							continue;
-						if (line.StartsWith ("error HE0038", StringComparison.Ordinal))
+						if (line.Contains ("error HE0038: Failed to launch the app"))
 							return true;
 					}
 				}


### PR DESCRIPTION
Most log files now have timestamps, which means that looking for 'HE00380' at
the start of each line won't work anymore.

Fixes an issue where the HE0038 issue isn't detected properly.