### PR TITLE
[tests] Set environment variables so that the in-process generator finds the locally built platform assemblies.

### DIFF
--- a/tests/generator/BGenTool.cs
+++ b/tests/generator/BGenTool.cs
@@ -151,11 +151,19 @@ namespace Xamarin.Tests
 			var in_process = InProcess && Profile != Profile.macOSClassic;
 			if (in_process) {
 				int rv;
+				var previous_environment = new Dictionary<string, string> ();
+				foreach (var kvp in EnvironmentVariables) {
+					previous_environment [kvp.Key] = Environment.GetEnvironmentVariable (kvp.Key);
+					Environment.SetEnvironmentVariable (kvp.Key, kvp.Value);
+				}
 				ThreadStaticTextWriter.ReplaceConsole (Output);
 				try {
 					rv = BindingTouch.Main (arguments);
 				} finally {
 					ThreadStaticTextWriter.RestoreConsole ();
+					foreach (var kvp in previous_environment) {
+						Environment.SetEnvironmentVariable (kvp.Key, kvp.Value);
+					}
 				}
 				Console.WriteLine (Output);
 				ParseMessages ();


### PR DESCRIPTION
When running the in-process generator, we need to set the same environment
variables as we already do when running the out-of-process generator, so that
the generator looks for the platform assemblies in the local install directory
(and not the system one).