### PR TITLE
[generator] Don't print multiple EditorBrowsable attributes. Fixes xamarin/maccore#1661.

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -5228,13 +5228,7 @@ public partial class Generator : IMemberGatherer {
 	void PrintMethodAttributes (MemberInformation minfo)
 	{
 		MethodInfo mi = minfo.method;
-
-		foreach (var oa in AttributeManager.GetCustomAttributes<ObsoleteAttribute> (mi)) {
-			print ("[Obsolete (\"{0}\", {1})]",
-			       oa.Message, oa.IsError ? "true" : "false");
-			print ("[EditorBrowsable (EditorBrowsableState.Never)]");
-
-		}
+		var editor_browsable_attribute = false;
 
 		foreach (var sa in AttributeManager.GetCustomAttributes<ThreadSafeAttribute> (mi)) 
 			print (sa.Safe ? "[ThreadSafe]" : "[ThreadSafe (false)]");
@@ -5245,6 +5239,13 @@ public partial class Generator : IMemberGatherer {
 			} else {
 				print ("[EditorBrowsable (EditorBrowsableState.{0})]", ea.State);
 			}
+			editor_browsable_attribute = true;
+		}
+
+		foreach (var oa in AttributeManager.GetCustomAttributes<ObsoleteAttribute> (mi)) {
+			print ("[Obsolete (\"{0}\", {1})]", oa.Message, oa.IsError ? "true" : "false");
+			if (!editor_browsable_attribute)
+				print ("[EditorBrowsable (EditorBrowsableState.Never)]");
 		}
 
 		if (minfo.is_return_release)


### PR DESCRIPTION
It's not allowed to have multiple EditorBrowsable attributes on the same
member, so make sure the generatod doesn't generate such code.

We might want to print an "[EditorBrowsable (Never)]" because a particular API
is obsolete (i.e. has the "[Obsolete]" attribute), but if the API also has an
EditorBrowsable attribute already, use only that one instead.

Fixes https://github.com/xamarin/maccore/issues/1661.