### PR TITLE
[monotouch-test] Ignore MessageHandlerTest.RejectSslCertificatesServicePointManager on macOS 10.10.

### DIFF
--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -169,6 +169,11 @@ namespace MonoTests.System.Net.Http
 			TestRuntime.AssertSystemVersion (PlatformName.MacOSX, 10, 9, throwIfOtherPlatform: false);
 			TestRuntime.AssertSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false);
 
+#if __MACOS__
+			if (handlerType == typeof (NSUrlSessionHandler) && TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 10, 0) && !TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 11, 0))
+				Assert.Ignore ("Fails on macOS 10.10: https://github.com/xamarin/maccore/issues/1645");
+#endif
+
 			bool servicePointManagerCbWasExcuted = false;
 			bool done = false;
 			Exception ex = null;


### PR DESCRIPTION
This works around (but doesn't fix) https://github.com/xamarin/maccore/issues/1645.