### PR TITLE
[tests] Ignore BaseOptimizeGeneratedCodeTest.SetupBlockPerfTest when doing CI. Fixes xamarin/maccore#649.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -103,6 +103,14 @@ partial class TestRuntime
 		return new Version (major, minor, build);
 	}
 
+	public static void IgnoreInCI (string message)
+	{
+		var in_ci = !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("BUILD_REVISION"));
+		if (!in_ci)
+			return;
+		NUnit.Framework.Assert.Ignore (message);
+	}
+
 	public static void AssertXcodeVersion (int major, int minor, int build = 0)
 	{
 		if (CheckXcodeVersion (major, minor, build))

--- a/tests/linker/BaseOptimizeGeneratedCodeTest.cs
+++ b/tests/linker/BaseOptimizeGeneratedCodeTest.cs
@@ -76,6 +76,9 @@ namespace Linker.Shared
 		{
 			IgnoreIfNotLinkAll ();
 
+			// If you ran this test locally and it failed, run it again. If it fails multiple times, file a bug.
+			TestRuntime.IgnoreInCI ("This test randomly fails, so ignore it when doing CI (https://github.com/xamarin/maccore/issues/649)");
+
 			const int iterations = 5000;
 
 			// Set the XAMARIN_IOS_SKIP_BLOCK_CHECK environment variable to skip a few expensive validation checks done in the simulator


### PR DESCRIPTION
The BaseOptimizeGeneratedCodeTest.SetupBlockPerfTest test is randomly failing
fairly often now, which means it turns CI builds red.

So disable it, but since I don't like disabling tests I've only disabled it
when doing CI. Hopefully we'll find out if there are any regressions when
running tests locally.

Fixes https://github.com/xamarin/maccore/issues/649.