### PR TITLE
[d16-2] [msbuild] Lock variables accessed in a Parallel.ForEach callback. Fixes #6008.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
+++ b/msbuild/Xamarin.MacDev.Tasks.Core/Tasks/CodesignTaskBase.cs
@@ -181,7 +181,9 @@ namespace Xamarin.MacDev.Tasks
 			Parallel.ForEach (Resources, new ParallelOptions { MaxDegreeOfParallelism = Math.Max (Environment.ProcessorCount / 2, 1) }, (item) => {
 				Codesign (item);
 
-				codesignedFiles.AddRange (GetCodesignedFiles (item));
+				var files = GetCodesignedFiles (item);
+				lock (codesignedFiles)
+					codesignedFiles.AddRange (files);
 			});
 
 			CodesignedFiles = codesignedFiles.ToArray ();


### PR DESCRIPTION
Lock variables accessed in a Parallel.ForEach callback, since the callback
must be thread-safe because it's executed in parallel using multiple threads.

Might fix this seemingly impossible exception:

```
/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/Xamarin.Mac.Common.targets(208,3): error MSB4018: The "Codesign" task failed unexpectedly.
/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/Xamarin.Mac.Common.targets(208,3): error MSB4018: System.ArgumentException: length
/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/Xamarin.Mac.Common.targets(208,3): error MSB4018:   at System.Array.Copy (System.Array sourceArray, System.Int32 sourceIndex, System.Array destinationArray, System.Int32 destinationIndex, System.Int32 length) [0x000b4] in <b7d51802a4dc4818a2e8326fef769990>:0
/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/Xamarin.Mac.Common.targets(208,3): error MSB4018:   at System.Collections.Generic.List`1[T].ToArray () [0x0001a] in <b7d51802a4dc4818a2e8326fef769990>:0
/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/Xamarin.Mac.Common.targets(208,3): error MSB4018:   at Xamarin.MacDev.Tasks.CodesignTaskBase.Execute () [0x0005c] in <2347a62eff324819b60b22bb05ee91f8>:0
/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/Xamarin.Mac.Common.targets(208,3): error MSB4018:   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute () [0x00029] in <b271d93a991841d281a56f67661d6725>:0
/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/Xamarin.Mac.Common.targets(208,3): error MSB4018:   at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask (Microsoft.Build.BackEnd.ITaskExecutionHost taskExecutionHost, Microsoft.Build.BackEnd.Logging.TaskLoggingContext taskLoggingContext, Microsoft.Build.BackEnd.TaskHost taskHost, Microsoft.Build.BackEnd.ItemBucket bucket, Microsoft.Build.BackEnd.TaskExecutionMode howToExecuteTask) [0x001f6] in <b271d93a991841d281a56f67661d6725>:0

```

Fixes https://github.com/xamarin/xamarin-macios/issues/6008.

Backport of #6173.

/cc @rolfbjarne 