### PR TITLE
[xtro] 'raw' files might not exist.

### DIFF
--- a/tests/xtro-sharpie/xtro-sanity/Sanitizer.cs
+++ b/tests/xtro-sharpie/xtro-sanity/Sanitizer.cs
@@ -220,7 +220,7 @@ namespace Extrospection {
 				if (!shortname.Contains ("-"))
 					continue;
 				var rawfile = Path.ChangeExtension (file, ".raw");
-				var raws = new List<string> (File.ReadAllLines (rawfile));
+				var raws = new List<string> (File.Exists (rawfile) ? File.ReadAllLines (rawfile) : Array.Empty<string> ());
 				var failures = new List<string> ();
 				var lines = File.ReadAllLines (file);
 				foreach (var entry in lines) {


### PR DESCRIPTION
If we just fixed all the entries in the corresponding '*.ignore' file, there
won't be a '*.raw' file.