### PR TITLE
Fix from-source Mono build not generating proper dependencies

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -62,9 +62,9 @@ else
 # this is a list of all the files from mono we care about, so that we
 # can use that list as dependencies for our makefile targets
 -include .deps.mono.mk
-.deps.mono.mk: mk/mono.mk
+.deps.mono.mk: $(TOP)/Make.config
 	$(Q) printf 'MONO_DEPENDENCIES += Makefile \\\n' > $@.tmp
-	$(Q) cd $(MONO_PATH) && git ls-files --recurse-submodules 'mcs/class/*.cs' 'mcs/build/*.cs' 'external/*.cs' '*.h' '*.c' '*.cpp' | grep -v "/Test/" | sed 's/ /\\ /g' | sed 's@^\(.*\)$$@	$(MONO_PATH)/\1 \\@' >> $(abspath $@).tmp
+	$(Q) cd $(MONO_PATH) && git ls-files --recurse-submodules 'mcs/class/*.cs' 'mcs/build/*.cs' 'external/*.cs' '*.h' '*.c' '*.cpp' | sed 's/ /\\ /g' | sed 's@^\(.*\)$$@	$(MONO_PATH)/\1 \\@' >> $(abspath $@).tmp
 	$(Q) mv $@.tmp $@
 
 #


### PR DESCRIPTION
The .deps.mk target didn't get generated because its dependency was wrong (Make.config contains the Mono hash and mk/mono.mk doesn't exist, it'd need a `$(TOP)` in front of it).

Also do not exclude tests from the dependencies, they should be rebuild when changed too.

Fixes #6224