### PR TITLE
Bump mono to the latest of 2018-08

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -60,7 +60,7 @@ MIN_XM_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/
 # Minimum Visual Studio version
 MIN_VISUAL_STUDIO_URL=https://bosstoragemirror.azureedge.net/vsmac/7a/7aff2dc1f28d711d11d63d79b2a4c49cda217189/VisualStudioForMac-Preview-7.7.0.1470.dmg
 MIN_VISUAL_STUDIO_VERSION=7.7.0.1470
-MAX_VISUAL_STUDIO_VERSION=8.0.99
+MAX_VISUAL_STUDIO_VERSION=7.7.0.1470
 
 # Minimum CMake version
 MIN_CMAKE_URL=https://cmake.org/files/v3.6/cmake-3.6.2-Darwin-x86_64.dmg

--- a/tests/bcl-test/BCLTests/macOS-xammac_net_4_5_System.IO.Compression.FileSystem_test.dll.ignore
+++ b/tests/bcl-test/BCLTests/macOS-xammac_net_4_5_System.IO.Compression.FileSystem_test.dll.ignore
@@ -1,0 +1,5 @@
+# files are missing in the test dlls
+MonoTests.System.IO.Compression.FileSystem.ZipArchiveTests.ZipCreateFromEntryChangeTimestamp
+MonoTests.System.IO.Compression.FileSystem.ZipArchiveTests.ZipCreateFromDirectory
+MonoTests.System.IO.Compression.FileSystem.ZipArchiveTests.ZipCreateFromDirectoryIncludeBase
+MonoTests.System.IO.Compression.FileSystem.ZipArchiveTests.ZipExtractToDirectory

--- a/tests/bcl-test/BCLTests/macOS-xammac_net_4_5_System.IO.Compression_test.dll.ignore
+++ b/tests/bcl-test/BCLTests/macOS-xammac_net_4_5_System.IO.Compression_test.dll.ignore
@@ -1,0 +1,21 @@
+# files are missing in the test dll
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipDeleteEntryCheckEntries
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipEnumerateArchiveDefaultLastWriteTime
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipEnumerateEntriesCreateMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipEnumerateEntriesModifiedTime
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipEnumerateEntriesReadMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipEnumerateEntriesUpdateMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetArchiveEntryStreamLengthPositionReadMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetArchiveEntryStreamLengthPositionUpdateMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryCreateMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryDeleteReadMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryDeleteUpdateMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryOpen
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryReadMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipGetEntryUpdateMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipOpenAndReopenEntry
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipOpenCloseAndReopenEntry
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipReadNonSeekableStream
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipWriteEntriesUpdateMode
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipWriteEntriesUpdateModeNonZeroPosition
+MonoTests.System.IO.Compression.ZipArchiveTests.ZipWriteNonSeekableStream

--- a/tests/bcl-test/BCLTests/macOS-xammac_net_4_5_System.ServiceModel_test.dll.ignore
+++ b/tests/bcl-test/BCLTests/macOS-xammac_net_4_5_System.ServiceModel_test.dll.ignore
@@ -14,3 +14,6 @@
  MonoTests.System.ServiceModel.EndpointAddressTest.WriteToWSA10
  MonoTests.System.ServiceModel.EndpointAddressTest.WriteContentsToWSA10
  MonoTests.System.ServiceModel.Description.MetadataSetTest.ReadFrom
+ MonoTests.System.ServiceModel.Channels.MessageFaultTest.CreateFault
+ MonoTests.System.ServiceModel.Channels.MessageFaultTest.CreateFaultIncomplete
+ MonoTests.System.ServiceModel.Channels.MessageFaultTest.CreateFaultIncomplete4


### PR DESCRIPTION
Includes the following commits:

* Fix Windows MSI build, msbuild is now in Current instead of 15.0 https://github.com/mono/mono/commit/d1b7bf2c472e32d174610b776c8800e436423457
* More Windows MSI fixes https://github.com/mono/mono/commit/ea8ae3e8e05be7729d3278b943e612e3850a2877
* Fix Windows MSI build https://github.com/mono/mono/commit/18fde9f8c29b96defb3b04e4093cdb1d16595eee
* Bump msbuild to track mono-2018-08 https://github.com/mono/mono/commit/082e1a23463e52b611b1cbc12ae86af6b2f376bf
* Bump msbuild to track mono-2018-08 https://github.com/mono/mono/commit/167f04c9024a1ecb0a9bf5865e05e352a41b584a
* A deadlock happens when during a process_suspend there is a pending invoke and then when it's calling the invoke there is another call to process_suspend in the same thread.https://github.com/mono/mono/commit/6843da5c570ebf84495dde7b1670388321839f86
* [Facades] Include missing enums in System.Memory https://github.com/mono/mono/commit/913c11def52c288c0fe615a8eda5847680f90f24
* Bump API snapshot submodule https://github.com/mono/mono/commit/223ea7ef92eb396f1570924cf401f931be778f50
* [2018-08] [arm64] Correct exception filter stack frame size (#14769) https://github.com/mono/mono/commit/3a07bd426d3dae0d9b6c7891e7bb11f487b18484

Complete diff: https://github.com/mono/mono/compare/3cb36842fc47eb8d749cabe351b3902c24065d77...3a07bd426d3dae0d9b6c7891e7bb11f487b18484