### PR TITLE
Bump VS4M minimum to 8.0.0

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -55,11 +55,11 @@ MONO_BRANCH:=2019-02
 # Minimum Mono version for building XI/XM
 MIN_MONO_VERSION=6.0.0.286
 MAX_MONO_VERSION=6.0.99
-MIN_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-02/161/d75c142a4646af45f680cd90cafe05843d1d5945/MonoFramework-MDK-6.0.0.176.macos10.xamarin.universal.pkg
+MIN_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-02/261/c22486e39d129cb8117177a6f9c768e69fc4ebaa/MonoFramework-MDK-6.0.0.286.macos10.xamarin.universal.pkg
 
 # Minimum Mono version for Xamarin.Mac apps using the system mono
-MIN_XM_MONO_VERSION=6.0.0.176
-MIN_XM_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-02/161/d75c142a4646af45f680cd90cafe05843d1d5945/MonoFramework-MDK-6.0.0.176.macos10.xamarin.universal.pkg
+MIN_XM_MONO_VERSION=6.0.0.286
+MIN_XM_MONO_URL=hhttps://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-02/261/c22486e39d129cb8117177a6f9c768e69fc4ebaa/MonoFramework-MDK-6.0.0.286.macos10.xamarin.universal.pkg
 
 # Minimum Visual Studio version
 MIN_VISUAL_STUDIO_URL=https://bosstoragemirror.blob.core.windows.net/vsmac/2716075/release-8.0/72a44477dd706608c2300a568f71e5769f89f7ef/VisualStudioForMac-8.0.9.5.dmg

--- a/Make.config
+++ b/Make.config
@@ -62,8 +62,8 @@ MIN_XM_MONO_VERSION=6.0.0.176
 MIN_XM_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-02/161/d75c142a4646af45f680cd90cafe05843d1d5945/MonoFramework-MDK-6.0.0.176.macos10.xamarin.universal.pkg
 
 # Minimum Visual Studio version
-MIN_VISUAL_STUDIO_URL=https://bosstoragemirror.azureedge.net/vsmac/7a/7aff2dc1f28d711d11d63d79b2a4c49cda217189/VisualStudioForMac-Preview-7.7.0.1470.dmg
-MIN_VISUAL_STUDIO_VERSION=7.7.0.1470
+MIN_VISUAL_STUDIO_URL=https://bosstoragemirror.blob.core.windows.net/vsmac/2716075/release-8.0/72a44477dd706608c2300a568f71e5769f89f7ef/VisualStudioForMac-8.0.9.5.dmg
+MIN_VISUAL_STUDIO_VERSION=8.0.0
 MAX_VISUAL_STUDIO_VERSION=8.1.99
 
 # Minimum CMake version

--- a/Make.config
+++ b/Make.config
@@ -53,7 +53,7 @@ MONO_HASH:=c22486e39d129cb8117177a6f9c768e69fc4ebaa
 MONO_BRANCH:=2019-02
 
 # Minimum Mono version for building XI/XM
-MIN_MONO_VERSION=6.0.0.176
+MIN_MONO_VERSION=6.0.0.286
 MAX_MONO_VERSION=6.0.99
 MIN_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-02/161/d75c142a4646af45f680cd90cafe05843d1d5945/MonoFramework-MDK-6.0.0.176.macos10.xamarin.universal.pkg
 

--- a/Make.config
+++ b/Make.config
@@ -54,7 +54,7 @@ MONO_BRANCH:=2019-02
 
 # Minimum Mono version for building XI/XM
 MIN_MONO_VERSION=6.0.0.176
-MAX_MONO_VERSION=6.0.0.176
+MAX_MONO_VERSION=6.0.99
 MIN_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-02/161/d75c142a4646af45f680cd90cafe05843d1d5945/MonoFramework-MDK-6.0.0.176.macos10.xamarin.universal.pkg
 
 # Minimum Mono version for Xamarin.Mac apps using the system mono


### PR DESCRIPTION
This should solve the msbuild failures when recent system mono are used
to build the tests

Fix https://github.com/mono/mono/issues/14875