### PR TITLE
[tests] Fix monotouch-test for "iOS Unified 32-bits - simulator" | "Release (all optimizations)"

### DIFF
--- a/tests/monotouch-test/Photos/LivePhotoEditingContextTest.cs
+++ b/tests/monotouch-test/Photos/LivePhotoEditingContextTest.cs
@@ -49,6 +49,9 @@ namespace MonoTouchFixtures.Photos {
 		// on macOS `initWithLivePhotoEditingInput:` returns `nil` and we throw
 		[Test]
 #endif
+#if !DEBUG
+		[Ignore ("Photos.framework headers are broken in Xcode 11 beta 1 (and optimizations fails)")]
+#endif
 		public void Linker ()
 		{
 			using (var cei = new PHContentEditingInput ())


### PR DESCRIPTION
Photos.framework headers are broken in Xcode 11 beta 1 [1]. Optimizations
fails since the static registrar skip over the type [2]

```
	[FAIL] PHLivePhotoEditingContextTest.Linker : ObjCRuntime.RuntimeException : Can't register the class Photos.PHContentEditingInput when the dynamic registrar has been linked away.
		  at ObjCRuntime.Class.GetClassHandle (System.Type , System.Boolean , System.Boolean& ) [0x000de] in <d93fa0efd60442128943a9eb0e82eb8d>:0
		  at ObjCRuntime.Class.GetClassHandle (System.Type ) [0x00000] in <d93fa0efd60442128943a9eb0e82eb8d>:0
		  at ObjCRuntime.Class.GetHandle (System.Type ) [0x00000] in <d93fa0efd60442128943a9eb0e82eb8d>:0
		  at Foundation.NSObject.AllocIfNeeded () [0x00019] in <d93fa0efd60442128943a9eb0e82eb8d>:0
		  at Foundation.NSObject..ctor (Foundation.NSObjectFlag ) [0x00006] in <d93fa0efd60442128943a9eb0e82eb8d>:0
		  at Photos.PHContentEditingInput..ctor () [0x00000] in <d93fa0efd60442128943a9eb0e82eb8d>:0
		  at MonoTouchFixtures.Photos.PHLivePhotoEditingContextTest.Linker () [0x00001] in <6e792af97a28410a80fa790ecfb26b9c>:0
		  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
		  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object , System.Reflection.BindingFlags , System.Reflection.Binder , System.Object[] , System.Globalization.CultureInfo ) [0x0006a] in <3440dfbcd957471aabeed02fbc939d2a>:0
PHLivePhotoEditingContextTest : 2 ms
```

references
[1] https://github.com/xamarin/xamarin-macios/issues/6212
[2] https://github.com/xamarin/xamarin-macios/commit/60a5392d359ad76db334a3d9f764997f9b2fde02