### PR TITLE
[XHarness] Allow parallel tests by default on the test runners.

### DIFF
--- a/tests/bcl-test/templates/common/TestRunner.Core/TestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.Core/TestRunner.cs
@@ -15,7 +15,7 @@ namespace Xamarin.iOS.UnitTests
 		public long ExecutedTests { get; protected set; } = 0;
 		public long TotalTests { get; protected set; } = 0;
 		public long FilteredTests { get; protected set; } = 0;
-		public bool RunInParallel { get; set; } = false;
+		public bool RunInParallel { get; set; } = true;
 		public string TestsRootDirectory { get; set; }
 		public bool RunAllTestsByDefault { get; set; } = true;
 		public bool LogExcludedTests { get; set; }

--- a/tests/bcl-test/templates/iOSApp/ViewController.cs
+++ b/tests/bcl-test/templates/iOSApp/ViewController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Threading;
 
 using UIKit;
 using ObjCRuntime;
@@ -88,18 +89,20 @@ namespace BCLTests {
 				runner.SkipTests (skippedTests);
 			}
 
-			runner.Run (testAssemblies);
-			if (options.EnableXml) {
-				runner.WriteResultsToFile (writer);
-				logger.Info ("Xml file was written to the tcp listener.");
-			} else {
-				string resultsFilePath = runner.WriteResultsToFile ();
-				logger.Info ($"Xml result can be found {resultsFilePath}");
-			}
-			
-			logger.Info ($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
-			if (options.TerminateAfterExecution)
-				TerminateWithSuccess ();
+			ThreadPool.QueueUserWorkItem ((v) => {
+				runner.Run (testAssemblies);
+				if (options.EnableXml) {
+					runner.WriteResultsToFile (writer);
+					logger.Info ("Xml file was written to the tcp listener.");
+				} else {
+					string resultsFilePath = runner.WriteResultsToFile ();
+					logger.Info ($"Xml result can be found {resultsFilePath}");
+				}
+
+				logger.Info ($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
+				if (options.TerminateAfterExecution)
+					TerminateWithSuccess ();
+			});
 
 		}
 

--- a/tests/bcl-test/templates/tvOSApp/ViewController.cs
+++ b/tests/bcl-test/templates/tvOSApp/ViewController.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Threading;
 
 using UIKit;
 using ObjCRuntime;
@@ -85,18 +86,20 @@ namespace BCLTests {
 				runner.SkipTests (skippedTests);
 			}
 
-			runner.Run (testAssemblies);
-			if (options.EnableXml) {
-				runner.WriteResultsToFile (writer);
-				logger.Info ("Xml file was written to the tcp listener.");
-			} else {
-				string resultsFilePath = runner.WriteResultsToFile ();
-				logger.Info ($"Xml result can be found {resultsFilePath}");
-			}
-			
-			logger.Info ($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
-			if (options.TerminateAfterExecution)
-				TerminateWithSuccess ();
+			ThreadPool.QueueUserWorkItem ((v) => {
+				runner.Run (testAssemblies);
+				if (options.EnableXml) {
+					runner.WriteResultsToFile (writer);
+					logger.Info ("Xml file was written to the tcp listener.");
+				} else {
+					string resultsFilePath = runner.WriteResultsToFile ();
+					logger.Info ($"Xml result can be found {resultsFilePath}");
+				}
+
+				logger.Info ($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
+				if (options.TerminateAfterExecution)
+					TerminateWithSuccess ();
+			});
 
 		}
 


### PR DESCRIPTION
The runners are not running tests in parallel. This is not a problem in
the NUnit runner but results in tests blocking on the xUnit when those
tests do use async/await. The xUnit runner implementation used allows to
run tests in parallel this has two positive things:

1. Tests will run faster.
2. The tests that are async, will not block.

Fixes: https://github.com/mono/mono/issues/15058