### PR TITLE
[XHarness]: Convert xUnit / nUnit tests to run async.

### DIFF
--- a/tests/bcl-test/templates/common/TestRunner.Core/TestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.Core/TestRunner.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Threading.Tasks;
 
 
 namespace Xamarin.iOS.UnitTests
@@ -30,7 +31,7 @@ namespace Xamarin.iOS.UnitTests
 			Logger = logger ?? throw new ArgumentNullException (nameof (logger));
 		}
 
-		public abstract void Run (IEnumerable<TestAssemblyInfo> testAssemblies);
+		public abstract Task Run (IEnumerable<TestAssemblyInfo> testAssemblies);
 		public abstract string WriteResultsToFile ();
 		public abstract void WriteResultsToFile (TextWriter writer);
 		public abstract void SkipTests (IEnumerable<string> tests);

--- a/tests/bcl-test/templates/common/TestRunner.NUnit/NUnitTestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.NUnit/NUnitTestRunner.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading.Tasks;
 
 using Foundation;
 
@@ -35,7 +36,9 @@ namespace Xamarin.iOS.UnitTests.NUnit
 			builderSettings = new Dictionary<string, object> (StringComparer.OrdinalIgnoreCase);
 		}
 
-		public override void Run (IEnumerable<TestAssemblyInfo> testAssemblies)
+#pragma warning disable 1998
+		public override async Task Run (IEnumerable<TestAssemblyInfo> testAssemblies)
+#pragma warning restore 1998
 		{
 			if (testAssemblies == null)
 				throw new ArgumentNullException (nameof (testAssemblies));

--- a/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
@@ -692,7 +692,8 @@ namespace Xamarin.iOS.UnitTests.XUnit
 			}, tcs, timeout, true);
 
 			try {
-				await tcs.Task.ConfigureAwait (false);
+				if (!tcs.Task.IsCompleted)
+					await tcs.Task.ConfigureAwait (false);
 			} finally {
 				registration.Unregister (handle);
 			}
@@ -937,8 +938,10 @@ namespace Xamarin.iOS.UnitTests.XUnit
 					var tcs = new TaskCompletionSource<object> ();
 
 					try {
+						// set the wait for event cb first, then execute the tests
+						var resultTask = WaitForEvent (resultsSink.Finished, TimeSpan.FromDays (10)).ConfigureAwait (false);
 						frontController.RunTests (testCases, resultsSink, executionOptions);
-						await WaitForEvent (resultsSink.Finished, TimeSpan.FromDays (10)).ConfigureAwait (false);
+						await resultTask;
 					} finally {
 						resultsSink.Dispose ();
 					}

--- a/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
@@ -935,8 +935,6 @@ namespace Xamarin.iOS.UnitTests.XUnit
 					executionOptions.SetDisableParallelization (!RunInParallel);
 					executionOptions.SetSynchronousMessageReporting (true);
 
-					var tcs = new TaskCompletionSource<object> ();
-
 					try {
 						// set the wait for event cb first, then execute the tests
 						var resultTask = WaitForEvent (resultsSink.Finished, TimeSpan.FromDays (10)).ConfigureAwait (false);

--- a/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
+++ b/tests/bcl-test/templates/common/TestRunner.xUnit/XUnitTestRunner.cs
@@ -935,14 +935,10 @@ namespace Xamarin.iOS.UnitTests.XUnit
 					executionOptions.SetDisableParallelization (!RunInParallel);
 					executionOptions.SetSynchronousMessageReporting (true);
 
-					try {
-						// set the wait for event cb first, then execute the tests
-						var resultTask = WaitForEvent (resultsSink.Finished, TimeSpan.FromDays (10)).ConfigureAwait (false);
-						frontController.RunTests (testCases, resultsSink, executionOptions);
-						await resultTask;
-					} finally {
-						resultsSink.Dispose ();
-					}
+					// set the wait for event cb first, then execute the tests
+					var resultTask = WaitForEvent (resultsSink.Finished, TimeSpan.FromDays (10)).ConfigureAwait (false);
+					frontController.RunTests (testCases, resultsSink, executionOptions);
+					await resultTask;
 
 					return assemblyElement;
 				}

--- a/tests/bcl-test/templates/iOSApp/ViewController.cs
+++ b/tests/bcl-test/templates/iOSApp/ViewController.cs
@@ -87,7 +87,6 @@ namespace BCLTests {
 				// ensure that we skip those tests that have been passed via the ignore files
 				runner.SkipTests (skippedTests);
 			}
-
 			await runner.Run (testAssemblies).ConfigureAwait (false);
 
 			if (options.EnableXml) {
@@ -100,7 +99,7 @@ namespace BCLTests {
 			
 			logger.Info ($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
 			if (options.TerminateAfterExecution)
-				TerminateWithSuccess ();
+				BeginInvokeOnMainThread (TerminateWithSuccess);
 
 		}
 

--- a/tests/bcl-test/templates/iOSApp/ViewController.cs
+++ b/tests/bcl-test/templates/iOSApp/ViewController.cs
@@ -88,7 +88,8 @@ namespace BCLTests {
 				runner.SkipTests (skippedTests);
 			}
 
-			runner.Run (testAssemblies);
+			await runner.Run (testAssemblies).ConfigureAwait (false);
+
 			if (options.EnableXml) {
 				runner.WriteResultsToFile (writer);
 				logger.Info ("Xml file was written to the tcp listener.");

--- a/tests/bcl-test/templates/macOS/MacTestMain.cs
+++ b/tests/bcl-test/templates/macOS/MacTestMain.cs
@@ -18,12 +18,13 @@ using BCLTests.TestRunner.Core;
 using Xamarin.iOS.UnitTests.XUnit;
 using System.IO;
 using NUnit.Framework.Internal.Filters;
+using System.Threading.Tasks;
 
 namespace Xamarin.Mac.Tests
 {
 	static class MainClass
 	{
-		static int Main (string[] args)
+		static Task<int> Main (string[] args)
 		{
 			NSApplication.Init();
 			return RunTests (args);
@@ -38,7 +39,7 @@ namespace Xamarin.Mac.Tests
 			}
  		}
  		
-		static int RunTests (string [] original_args)
+		static async Task<int> RunTests (string [] original_args)
 		{
 			Console.WriteLine ("Running tests");
 			var options = ApplicationOptions.Current;
@@ -57,7 +58,7 @@ namespace Xamarin.Mac.Tests
 				// ensure that we skip those tests that have been passed via the ignore files
 				runner.SkipTests (skippedTests);
 			}
-			runner.Run (testAssemblies);
+			await runner.Run (testAssemblies).ConfigureAwait (false);
 
 			if (options.ResultFile != null) {
 				using (var writer = new StreamWriter (options.ResultFile)) {

--- a/tests/bcl-test/templates/today/TodayExtensionMain.cs
+++ b/tests/bcl-test/templates/today/TodayExtensionMain.cs
@@ -85,9 +85,9 @@ public partial class TodayViewController : UIViewController, INCWidgetProviding
 		
 		ThreadPool.QueueUserWorkItem ((v) =>
 		{
-			BeginInvokeOnMainThread (() =>
+			BeginInvokeOnMainThread (async () =>
 			{
-				runner.Run (testAssemblies);
+				await runner.Run (testAssemblies).ConfigureAwait (false);;
 			});
 		});
 

--- a/tests/bcl-test/templates/tvOSApp/ViewController.cs
+++ b/tests/bcl-test/templates/tvOSApp/ViewController.cs
@@ -85,7 +85,7 @@ namespace BCLTests {
 				runner.SkipTests (skippedTests);
 			}
 
-			await runner.Run (testAssemblies);
+			await runner.Run (testAssemblies).ConfigureAwait (false);
 			if (options.EnableXml) {
 				runner.WriteResultsToFile (writer);
 				logger.Info ("Xml file was written to the tcp listener.");

--- a/tests/bcl-test/templates/tvOSApp/ViewController.cs
+++ b/tests/bcl-test/templates/tvOSApp/ViewController.cs
@@ -85,7 +85,7 @@ namespace BCLTests {
 				runner.SkipTests (skippedTests);
 			}
 
-			runner.Run (testAssemblies);
+			await runner.Run (testAssemblies);
 			if (options.EnableXml) {
 				runner.WriteResultsToFile (writer);
 				logger.Info ("Xml file was written to the tcp listener.");
@@ -96,7 +96,7 @@ namespace BCLTests {
 			
 			logger.Info ($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
 			if (options.TerminateAfterExecution)
-				TerminateWithSuccess ();
+				BeginInvokeOnMainThread (TerminateWithSuccess);
 
 		}
 

--- a/tests/bcl-test/templates/watchOS/Extension/InterfaceController.cs
+++ b/tests/bcl-test/templates/watchOS/Extension/InterfaceController.cs
@@ -70,7 +70,7 @@ namespace monotouchtestWatchKitExtension
 		{
 		}
 
-		public override  void Awake (NSObject context)
+		public override void Awake (NSObject context)
 		{
 			base.Awake (context);
 

--- a/tests/bcl-test/templates/watchOS/Extension/InterfaceController.cs
+++ b/tests/bcl-test/templates/watchOS/Extension/InterfaceController.cs
@@ -70,7 +70,7 @@ namespace monotouchtestWatchKitExtension
 		{
 		}
 
-		public override void Awake (NSObject context)
+		public override  void Awake (NSObject context)
 		{
 			base.Awake (context);
 
@@ -124,10 +124,10 @@ namespace monotouchtestWatchKitExtension
 			
 			ThreadPool.QueueUserWorkItem ((v) =>
 			{
-				BeginInvokeOnMainThread (() =>
+				BeginInvokeOnMainThread (async () =>
 				{
 					lblStatus.SetText (string.Format ("{0} tests", runner.TotalTests));
-					runner.Run (testAssemblies);
+					await runner.Run (testAssemblies).ConfigureAwait (false);
 					RenderResults ();
 					cmdRun.SetEnabled (true);
 					cmdRun.SetHidden (false);


### PR DESCRIPTION
Make `TestRunner.Run()` async as we cannot sync-block on the UI thread.