### PR TITLE
[runtime] Use '[obj class]' instead of 'object_getClass' to work around an Objective-C runtime bug. Fixes #6258 and #6255.

### DIFF
--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -296,7 +296,7 @@ xamarin_get_frame_length (id self, SEL sel)
 	// So instead parse the description ourselves.
 
 	int length = 0;
-	Class cls = object_getClass (self);
+	Class cls = [self class];
 	const char *method_description = get_method_description (cls, sel);
 	const char *desc = method_description;
 	if (desc == NULL) {


### PR DESCRIPTION
Xcode 11 introduces a bug in the Objective-C runtime that makes the runtime
surface uninitialized Class instances. Using these instances may lead to
crashes. Work around this issue by using a different API to get Class
instances for Objective-C objects, hoping that we won't see uninitialized
Class instances.

Ref: https://trello.com/c/2g7qtnGO/143-fb6153904-classcopyprotocollist-crashes-in-ios-13

Fixes https://github.com/xamarin/xamarin-macios/issues/6258.
Fixes https://github.com/xamarin/xamarin-macios/issues/6255.