### PR TITLE
Fix simulator provisioning.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -91,13 +91,13 @@ MIN_WATCH_OS_VERSION=1.0
 MIN_TVOS_SDK_VERSION=9.0
 
 # The min simulator version available in the Xcode we're using
-MIN_IOS_SIMULATOR_VERSION=8.1
-MIN_WATCHOS_SIMULATOR_VERSION=2.0
+MIN_IOS_SIMULATOR_VERSION=10.3
+MIN_WATCHOS_SIMULATOR_VERSION=3.2
 # This is the iOS version that matches the watchOS version (i.e same Xcode)
-MIN_WATCHOS_COMPANION_SIMULATOR_VERSION=9.0
-MIN_TVOS_SIMULATOR_VERSION=9.0
+MIN_WATCHOS_COMPANION_SIMULATOR_VERSION=10.3
+MIN_TVOS_SIMULATOR_VERSION=10.2
 # These are the simulator package ids for the versions above
-EXTRA_SIMULATORS=com.apple.pkg.iPhoneSimulatorSDK10_3 com.apple.pkg.iPhoneSimulatorSDK8_1 com.apple.pkg.iPhoneSimulatorSDK9_0 com.apple.pkg.AppleTVSimulatorSDK9_0 com.apple.pkg.WatchSimulatorSDK2_0
+EXTRA_SIMULATORS=com.apple.pkg.iPhoneSimulatorSDK10_3 com.apple.pkg.AppleTVSimulatorSDK10_2 com.apple.pkg.WatchSimulatorSDK3_2
 
 INCLUDE_IOS=1
 INCLUDE_MAC=1

--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -78,7 +78,7 @@ while ! test -z $1; do
 			unset IGNORE_HOMEBREW
 			PROVISION_SHARPIE=1
 			unset IGNORE_SHARPIE
-			#PROVISION_SIMULATORS=1
+			PROVISION_SIMULATORS=1
 			unset IGNORE_SIMULATORS
 			shift
 			;;

--- a/tools/siminstaller/Program.cs
+++ b/tools/siminstaller/Program.cs
@@ -260,7 +260,12 @@ namespace xsiminstaller {
 			}
 
 			if (install.Count > 0) {
-				Console.WriteLine ("Unknown simulators: {0}", string.Join (", ", install));
+				if (only_check) {
+					foreach (var sim in install)
+						Console.WriteLine ($"{sim} (unknown)");
+				} else {
+					Console.WriteLine ("Unknown simulators: {0}", string.Join (", ", install));
+				}
 				return 1;
 			}
 


### PR DESCRIPTION
* We must bump the min simulator versions, since Apple has bumped what they offer.
* Re-enable simulator provisioning.
* Minor output fix to siminstaller to make the output easier to understand.