### PR TITLE
[system-dependencies] Handle Xcodes with symlinks into system locations.

### DIFF
--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -357,7 +357,7 @@ function install_specific_xcode () {
 	rm -f $XCODE_DMG
 
 	log "Removing any com.apple.quarantine attributes from the installed Xcode"
-	$SUDO xattr -d -r com.apple.quarantine $XCODE_ROOT
+	$SUDO xattr -s -d -r com.apple.quarantine $XCODE_ROOT
 
 	if is_at_least_version $XCODE_VERSION 5.0; then
 		log "Accepting Xcode license"


### PR DESCRIPTION
Xcode 11 beta 1 ships with files that point into the system:

    ls -la /Applications/Xcode11-beta1.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/Network.framework
    lrwxr-xr-x  1 rolf  staff  44 Jun 11 15:06 /Applications/Xcode11-beta1.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/Network.framework -> /System/Library/Frameworks/Network.framework

this means that 'xattr' will fail, since it will try to process system files,
and even if using sudo it will fail (due to System Integrity Protection):

    [...]
            Removing any com.apple.quarantine attributes from the installed Xcode
    xattr: [Errno 1] Operation not permitted: '/Applications/Xcode11-beta1.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/Network.framework'
    xattr: No such file: /Applications/Xcode11-beta1.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/HealthRecordServices.framework/Resources
    xattr: No such file: /Applications/Xcode11-beta1.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/HealthRecordServices.framework/Versions/Current
    xattr: No such file: /Applications/Xcode11-beta1.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/HealthMenstrualCycles.framework/Resources
    xattr: No such file: /Applications/Xcode11-beta1.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/HealthMenstrualCycles.framework/Versions/Current
    xattr: No such file: /Applications/Xcode11-beta1.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/HealthDiagnosticExtensionCore.framework/Resources
    xattr: No such file: /Applications/Xcode11-beta1.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/HealthDiagnosticExtensionCore.framework/Versions/Current
    xattr: No such file: /Applications/Xcode11-beta1.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/HealthDaemon.framework/Resources
    xattr: No such file: /Applications/Xcode11-beta1.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/HealthDaemon.framework/Versions/Current
    xattr: No such file: /Applications/Xcode11-beta1.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/HealthMenstrualCyclesDaemon.framework/Resources
    xattr: No such file: /Applications/Xcode11-beta1.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/HealthMenstrualCyclesDaemon.framework/Versions/Current
    xattr: No such file: /Applications/Xcode11-beta1.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/HealthKit.framework/Resources
    xattr: No such file: /Applications/Xcode11-beta1.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/HealthKit.framework/Versions/Current
    xattr: No such file: /Applications/Xcode11-beta1.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/HealthKit.framework/Modules
    xattr: [Errno 1] Operation not permitted: '/Applications/Xcode11-beta1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/Network.framework'
    xattr: No such file: /Applications/Xcode11-beta1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/PrivateFrameworks/BookmarkDAV.framework/Frameworks
    xattr: No such file: /Applications/Xcode11-beta1.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.7/include/python3.7m
    xattr: No such file: /Applications/Xcode11-beta1.app/Contents/SharedFrameworks/SceneKit.framework/XPCServices

Some of these failures are also due to symlinks pointing to nowhere.

Either case should be fixed by passing '-s' to xattr, which will make xattr
not follow symlinks, and instead act upon the symlink itself (which is the
right behavior in this case anyway).