### PR TITLE
[monotouch-test] Make monotouch-test green with Xcode 11 beta 1.

### DIFF
--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -296,7 +296,8 @@ xamarin_get_frame_length (id self, SEL sel)
 	// So instead parse the description ourselves.
 
 	int length = 0;
-	Class cls = [self class];
+	[self class]; // There's a bug in the ObjC runtime where we might get an uninitialized Class instance from object_getClass. See #6258. Calling the 'class' selector first makes sure the Class instance is initialized.
+	Class cls = object_getClass (self);
 	const char *method_description = get_method_description (cls, sel);
 	const char *desc = method_description;
 	if (desc == NULL) {

--- a/src/Security/Certificate.cs
+++ b/src/Security/Certificate.cs
@@ -686,8 +686,13 @@ namespace Security {
 			if (signedData == null)
 				throw new ArgumentNullException ("signedData");
 			unsafe {
-				fixed (byte *sp = signature)
-				fixed (byte *dp = signedData) {
+				// SecKeyRawVerify will try to read from the signedData/signature pointers even if
+				// the corresponding length is 0, which may crash (happens in Xcode 11 beta 1)
+				// so if length is 0, then pass an array with one element.
+				var signatureArray = signature.Length == 0 ? new byte [] { 0 } : signature;
+				var signedDataArray = signedData.Length == 0 ? new byte [] { 0 } : signedData;
+				fixed (byte *sp = signatureArray)
+				fixed (byte *dp = signedDataArray) {
 					return SecKeyRawVerify (handle, padding, (IntPtr) dp, (nint) signedData.Length, (IntPtr) sp, (nint) signature.Length);
 				}
 			}

--- a/tests/common/Extensions.cs
+++ b/tests/common/Extensions.cs
@@ -1,0 +1,23 @@
+using System.Text;
+
+using Foundation;
+
+static class Extensions {
+	// [NSData description] changed its format in Xcode 11 beta 1.
+	// This method tries to hide that from tests, by producing the format from previous OS versions,
+	// This way tests don't have to be modified (much).
+	public static string ToStableString (this NSData data)
+	{
+		var sb = new StringBuilder ();
+		sb.Append ('<');
+		var bytes = data.ToArray ();
+		for (var i = 0; i < bytes.Length; i++) {
+			var b = bytes [i];
+			sb.AppendFormat ("{0:x2}", b);
+			if (((i + 1) % 4) == 0 && i + 1 < bytes.Length)
+				sb.Append (' ');
+		}
+		sb.Append ('>');
+		return sb.ToString ();
+	}
+}

--- a/tests/monotouch-test/CoreImage/DetectorTest.cs
+++ b/tests/monotouch-test/CoreImage/DetectorTest.cs
@@ -57,7 +57,7 @@ namespace MonoTouchFixtures.CoreImage {
 		{
 			CIDetectorOptions options = new CIDetectorOptions ();
 			using (var dtor = CIDetector.CreateFaceDetector (null, options)) {
-				Assert.That (dtor.Description, Is.StringContaining ("CIFaceCoreDetector"), "Description");
+				Assert.That (dtor.Description, Is.StringContaining ("CIFaceCoreDetector").Or.StringContaining ("FaceDetector"), "Description");
 			}
 		}
 	}

--- a/tests/monotouch-test/Foundation/UrlSessionTaskTransactionMetricsTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTaskTransactionMetricsTest.cs
@@ -40,16 +40,30 @@ namespace MonoTouchFixtures.Foundation {
 				Assert.Null (sttm.ConnectStartDate, "TaskInterval");
 				Assert.Null (sttm.DomainLookupEndDate, "TransactionMetrics");
 				Assert.Null (sttm.DomainLookupStartDate, "TransactionMetrics");
-				Assert.Null (sttm.FetchStartDate, "TransactionMetrics");
+				if (TestRuntime.CheckXcodeVersion (11, 0)) {
+					Assert.NotNull (sttm.FetchStartDate, "TransactionMetrics");
+				} else {
+					Assert.Null (sttm.FetchStartDate, "TransactionMetrics");
+				}
 				Assert.Null (sttm.NetworkProtocolName, "TransactionMetrics");
 				Assert.False (sttm.ProxyConnection, "TransactionMetrics");
 				Assert.NotNull (sttm.Request, "TransactionMetrics");
-				Assert.Null (sttm.RequestEndDate, "TransactionMetrics");
-				Assert.Null (sttm.RequestStartDate, "TransactionMetrics");
+				if (TestRuntime.CheckXcodeVersion (11, 0)) {
+					Assert.NotNull (sttm.RequestEndDate, "TransactionMetrics");
+					Assert.NotNull (sttm.RequestStartDate, "TransactionMetrics");
+				} else {
+					Assert.Null (sttm.RequestEndDate, "TransactionMetrics");
+					Assert.Null (sttm.RequestStartDate, "TransactionMetrics");
+				}
 				Assert.That (sttm.ResourceFetchType, Is.EqualTo (NSUrlSessionTaskMetricsResourceFetchType.Unknown),  "ResourceFetchType");
 				Assert.Null (sttm.Response, "Response");
-				Assert.Null (sttm.ResponseEndDate, "ResponseEndDate");
-				Assert.Null (sttm.ResponseStartDate, "ResponseStartDate");
+				if (TestRuntime.CheckXcodeVersion (11, 0)) {
+					Assert.NotNull (sttm.ResponseEndDate, "ResponseEndDate");
+					Assert.NotNull (sttm.ResponseStartDate, "ResponseStartDate");
+				} else {
+					Assert.Null (sttm.ResponseEndDate, "ResponseEndDate");
+					Assert.Null (sttm.ResponseStartDate, "ResponseStartDate");
+				}
 				Assert.False (sttm.ReusedConnection, "ReusedConnection");
 				Assert.Null (sttm.SecureConnectionEndDate, "SecureConnectionEndDate");
 				Assert.Null (sttm.SecureConnectionStartDate, "SecureConnectionStartDate");

--- a/tests/monotouch-test/HealthKit/CdaDocumentSampleTest.cs
+++ b/tests/monotouch-test/HealthKit/CdaDocumentSampleTest.cs
@@ -33,11 +33,20 @@ namespace MonoTouchFixtures.HealthKit {
 			TestRuntime.AssertXcodeVersion (8, 0);
 
 			NSError error;
-			using (var d = new NSData ())
-			using (var s = HKCdaDocumentSample.Create (d, NSDate.DistantPast, NSDate.DistantFuture, (NSDictionary) null, out error)) {
-				Assert.NotNull (error, "error");
-				var details = new HKDetailedCdaErrors (error.UserInfo);
-				Assert.That (details.ValidationError.Length, Is.EqualTo (0), "Length");
+			using (var d = new NSData ()) {
+				TestDelegate action = () => {
+					using (var s = HKCdaDocumentSample.Create (d, NSDate.DistantPast, NSDate.DistantFuture, (NSDictionary)null, out error)) {
+						Assert.NotNull (error, "error");
+						var details = new HKDetailedCdaErrors (error.UserInfo);
+						Assert.That (details.ValidationError.Length, Is.EqualTo (0), "Length");
+					}
+				};
+				if (TestRuntime.CheckXcodeVersion (11, 0)) {
+					var ex = Assert.Throws<MonoTouchException> (action, "Exception");
+					Assert.That (ex.Message, Is.StringMatching ("startDate.*and endDate.*exceed the maximum allowed duration for this sample type"), "Exception Message");
+				} else {
+					action ();
+				}
 			}
 		}
 	}

--- a/tests/monotouch-test/ImageIO/ImageMetadataTagTest.cs
+++ b/tests/monotouch-test/ImageIO/ImageMetadataTagTest.cs
@@ -103,7 +103,11 @@ namespace MonoTouchFixtures.ImageIO {
 				Assert.That (tag.Namespace.ToString (), Is.EqualTo ("http://ns.adobe.com/exif/1.0/"), "Namespace");
 				Assert.That (tag.Prefix.ToString (), Is.EqualTo ("exif"), "Prefix");
 				Assert.That (tag.Type, Is.EqualTo (CGImageMetadataType.Structure), "Type");
-				Assert.That (tag.Value, Is.TypeOf<NSMutableDictionary> (), "Value");
+				if (TestRuntime.CheckXcodeVersion (11, 0)) {
+					Assert.That (tag.Value, Is.TypeOf<NSDictionary> (), "Value");
+				} else {
+					Assert.That (tag.Value, Is.TypeOf<NSMutableDictionary> (), "Value");
+				}
 				Assert.Null (tag.GetQualifiers (), "GetQualifiers");
 			}
 		}

--- a/tests/monotouch-test/MediaPlayer/SkipIntervalCommandTest.cs
+++ b/tests/monotouch-test/MediaPlayer/SkipIntervalCommandTest.cs
@@ -45,7 +45,11 @@ namespace MonoTouchFixtures.MediaPlayer {
 
 			MPSkipIntervalCommand skip = MPRemoteCommandCenter.Shared.SkipBackwardCommand;
 
-			Assert.Null (skip.PreferredIntervals, "PreferredIntervals");
+			if (TestRuntime.CheckXcodeVersion (11, 0)) {
+				Assert.That (skip.PreferredIntervals, Is.EqualTo (new double [] { 10.0d }), "PreferredIntervals");
+			} else {
+				Assert.Null (skip.PreferredIntervals, "PreferredIntervals");
+			}
 			double[] intervals = new [] { 1.0d, 3.14d };
 			skip.PreferredIntervals = intervals;
 

--- a/tests/monotouch-test/PassKit/PassTest.cs
+++ b/tests/monotouch-test/PassKit/PassTest.cs
@@ -71,7 +71,12 @@ namespace MonoTouchFixtures.PassKit {
 #endif
 
 				// need to ensure it's english locale
-				Assert.That (string.IsNullOrEmpty (pass.LocalizedDescription), Is.False, "LocalizedName");
+				if (TestRuntime.CheckXcodeVersion (11, 0)) {
+					Assert.That (pass.LocalizedDescription, Is.Null, "LocalizedName");
+				} else {
+					Assert.That (pass.LocalizedDescription, Is.Not.Null, "LocalizedName");
+					Assert.That (pass.LocalizedDescription, Is.Not.Empty, "LocalizedName");
+				}
 				Assert.That (string.IsNullOrEmpty (pass.LocalizedName), Is.False, "LocalizedName");
 
 				Assert.That (pass.OrganizationName, Is.EqualTo ("Skyport Airways"), "OrganizationName");

--- a/tests/monotouch-test/Photos/LivePhotoEditingContextTest.cs
+++ b/tests/monotouch-test/Photos/LivePhotoEditingContextTest.cs
@@ -49,7 +49,7 @@ namespace MonoTouchFixtures.Photos {
 		// on macOS `initWithLivePhotoEditingInput:` returns `nil` and we throw
 		[Test]
 #endif
-#if !DEBUG
+#if !DEBUG || OPTIMIZEALL
 		[Ignore ("Photos.framework headers are broken in Xcode 11 beta 1 (and optimizations fails)")]
 #endif
 		public void Linker ()

--- a/tests/monotouch-test/Security/CertificateTest.cs
+++ b/tests/monotouch-test/Security/CertificateTest.cs
@@ -516,7 +516,7 @@ namespace MonoTouchFixtures.Security {
 			Assert.That ((nuint) (uint) mail_google_com.Length, Is.EqualTo (cert.DerData.Length), "DerData");
 			if (TestRuntime.CheckXcodeVersion (8, 3)) {
 				Assert.That (cert.GetCommonName (), Is.EqualTo ("mail.google.com"), "GetCommonName");
-				Assert.That (cert.GetSerialNumber ().Description, Is.EqualTo ("<2b9f7ee5 ca25a625 14204782 753a9bb9>"), "GetSerialNumber");
+				Assert.That (cert.GetSerialNumber ().ToStableString (), Is.EqualTo ("<2b9f7ee5 ca25a625 14204782 753a9bb9>"), "GetSerialNumber");
 
 				var emailAddresses = cert.GetEmailAddresses ();
 				Assert.IsTrue (emailAddresses == null || emailAddresses.Length == 0, "GetEmailAddresses");
@@ -527,7 +527,7 @@ namespace MonoTouchFixtures.Security {
 			}
 			if (TestRuntime.CheckXcodeVersion (9,0)) {
 				NSError err;
-				Assert.That (cert.GetSerialNumber (out err).Description, Is.EqualTo ("<2b9f7ee5 ca25a625 14204782 753a9bb9>"), "GetSerialNumber/NSError");
+				Assert.That (cert.GetSerialNumber (out err).ToStableString (), Is.EqualTo ("<2b9f7ee5 ca25a625 14204782 753a9bb9>"), "GetSerialNumber/NSError");
 				Assert.Null (err, "err") ;
 			}
 			if (TestRuntime.CheckXcodeVersion (10,0)) {

--- a/tests/monotouch-test/Security/SecProtocolMetadataTest.cs
+++ b/tests/monotouch-test/Security/SecProtocolMetadataTest.cs
@@ -23,6 +23,9 @@ namespace MonoTouchFixtures.Security {
 		[Test]
 		public void IPDefaults ()
 		{
+			if (TestRuntime.CheckXcodeVersion (11, 0))
+				Assert.Ignore ("NWProtocolMetadata.CreateIPMetadata () returns a metadata object with uninitialized metadata, which means the asserts here fail randomly.");
+
 			using (var m = NWProtocolMetadata.CreateIPMetadata ()) {
 				var s = m.SecProtocolMetadata;
 				// This is mostly, but not always, returning false

--- a/tests/monotouch-test/UIKit/PasteboardTest.cs
+++ b/tests/monotouch-test/UIKit/PasteboardTest.cs
@@ -32,6 +32,13 @@ namespace MonoTouchFixtures.UIKit {
 				using (var cgimg = CGImage.FromPNG (dp, null, false, CGColorRenderingIntent.Default)) {
 					using (var img = new UIImage (cgimg)) {
 						UIPasteboard.General.Images = new UIImage[] { img };
+						if (TestRuntime.CheckXcodeVersion (8, 0))
+							Assert.True (UIPasteboard.General.HasImages, "HasImages");
+
+						// https://github.com/xamarin/xamarin-macios/issues/6254
+						if (TestRuntime.CheckXcodeVersion (11, 0))
+							return;
+
 						Assert.AreEqual (1, UIPasteboard.General.Images.Length, "a - length");
 
 						UIPasteboard.General.Images = new UIImage[] { img, img };

--- a/tests/monotouch-test/UIKit/SimpleTextPrintFormatterTest.cs
+++ b/tests/monotouch-test/UIKit/SimpleTextPrintFormatterTest.cs
@@ -34,7 +34,11 @@ namespace MonoTouchFixtures.UIKit {
 		{
 			using (var stpf = new UISimpleTextPrintFormatter ()) {
 				Assert.That (stpf.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
-				if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false)) {
+				if (TestRuntime.CheckXcodeVersion (11, 0)) {
+					Assert.NotNull (stpf.Color, "Color");
+					Assert.Null (stpf.Font, "Font");
+					Assert.That (stpf.TextAlignment, Is.EqualTo (UITextAlignment.Natural), "TextAlignment");
+				} else if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false)) {
 					Assert.Null (stpf.Color, "Color");
 					Assert.Null (stpf.Font, "Font");
 					Assert.That (stpf.TextAlignment, Is.EqualTo (UITextAlignment.Natural), "TextAlignment");
@@ -51,7 +55,10 @@ namespace MonoTouchFixtures.UIKit {
 		public void StringCtor ()
 		{
 			using (var stpf = new UISimpleTextPrintFormatter ("Xamarin")) {
-				if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false)) {
+				if (TestRuntime.CheckXcodeVersion (11, 0)) {
+					Assert.NotNull (stpf.Color, "Color");
+					Assert.That (stpf.TextAlignment, Is.EqualTo (UITextAlignment.Natural), "TextAlignment");
+				} else if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 7, 0, throwIfOtherPlatform: false)) {
 					Assert.Null (stpf.Color, "Color");
 					Assert.That (stpf.TextAlignment, Is.EqualTo (UITextAlignment.Natural), "TextAlignment");
 				} else {

--- a/tests/monotouch-test/UIKit/TextFieldTest.cs
+++ b/tests/monotouch-test/UIKit/TextFieldTest.cs
@@ -61,10 +61,19 @@ namespace MonoTouchFixtures.UIKit {
 				} else {
 					Assert.IsNull (tf.SelectedTextRange, "SelectedTextRange");
 				}
-				Assert.IsNull (tf.TypingAttributes, "default");
+				if (TestRuntime.CheckXcodeVersion (11, 0)) {
+					Assert.That (tf.TypingAttributes, Is.Empty, "default");
+				} else {
+					Assert.IsNull (tf.TypingAttributes, "default");
+				}
 				// ^ calling TypingAttributes does not crash like UITextView does, it simply returns null
 				tf.TypingAttributes = new NSDictionary ();
-				Assert.IsNull (tf.TypingAttributes, "empty");
+				if (TestRuntime.CheckXcodeVersion (11, 0)) {
+					Assert.That (tf.TypingAttributes, Is.Empty, "empty");
+
+				} else {
+					Assert.IsNull (tf.TypingAttributes, "empty");
+				}
 				// and it stays null, even if assigned, since there's not selection
 			}
 		}

--- a/tests/monotouch-test/Vision/VNRequestTests.cs
+++ b/tests/monotouch-test/Vision/VNRequestTests.cs
@@ -126,7 +126,7 @@ namespace MonoTouchFixtures.Vision {
 
 			// Tests 'VNRequestRevision.Unspecified' given to APIs.
 			var rect = new CGRect (0, 0, 10, 10);
-			Assert.DoesNotThrow (() => {
+			{
 				var detectedObjectObservation = VNDetectedObjectObservation.FromBoundingBox (VNDetectedObjectObservationRequestRevision.Unspecified, rect);
 				Assert.NotNull (detectedObjectObservation, "detectedObjectObservation is null");
 				Assert.That (detectedObjectObservation.BoundingBox, Is.EqualTo (rect));
@@ -136,8 +136,12 @@ namespace MonoTouchFixtures.Vision {
 				Assert.That (faceObservation.BoundingBox, Is.EqualTo (rect));
 
 				var recognizedObjectObservation = VNRecognizedObjectObservation.FromBoundingBox (VNRecognizedObjectObservationRequestRevision.Unspecified, rect);
-				Assert.NotNull (recognizedObjectObservation, "recognizedObjectObservation is null");
-				Assert.That (recognizedObjectObservation.BoundingBox, Is.EqualTo (rect));
+				if (TestRuntime.CheckXcodeVersion (11, 0)) {
+					Assert.IsNull (recognizedObjectObservation, "recognizedObjectObservation is null");
+				} else {
+					Assert.NotNull (recognizedObjectObservation, "recognizedObjectObservation is null");
+					Assert.That (recognizedObjectObservation.BoundingBox, Is.EqualTo (rect));
+				}
 
 				var rectangleObservation = VNRectangleObservation.FromBoundingBox (VNRectangleObservationRequestRevision.Unspecified, rect);
 				Assert.NotNull (rectangleObservation, "rectangleObservation is null");
@@ -150,10 +154,10 @@ namespace MonoTouchFixtures.Vision {
 				var barcodeObservation = VNBarcodeObservation.FromBoundingBox (VNBarcodeObservationRequestRevision.Unspecified, rect);
 				Assert.NotNull (barcodeObservation, "barcodeObservation is null");
 				Assert.That (barcodeObservation.BoundingBox, Is.EqualTo (rect));
-			}, "VNRequestRevision.Unspecified throw");
+			}
 
 			// Tests random request revision
-			Assert.DoesNotThrow (() => {
+			{
 				var detectedObjectObservation = VNDetectedObjectObservation.FromBoundingBox ((VNDetectedObjectObservationRequestRevision) 5000, rect);
 				Assert.NotNull (detectedObjectObservation, "randomRevision detectedObjectObservation is null");
 				Assert.That (detectedObjectObservation.BoundingBox, Is.EqualTo (rect));
@@ -163,8 +167,12 @@ namespace MonoTouchFixtures.Vision {
 				Assert.That (faceObservation.BoundingBox, Is.EqualTo (rect));
 
 				var recognizedObjectObservation = VNRecognizedObjectObservation.FromBoundingBox ((VNRecognizedObjectObservationRequestRevision) 5000, rect);
-				Assert.NotNull (recognizedObjectObservation, "randomRevision recognizedObjectObservation is null");
-				Assert.That (recognizedObjectObservation.BoundingBox, Is.EqualTo (rect));
+				if (TestRuntime.CheckXcodeVersion (11, 0)) {
+					Assert.IsNull (recognizedObjectObservation, "randomRevision recognizedObjectObservation is null");
+				} else {
+					Assert.NotNull (recognizedObjectObservation, "randomRevision recognizedObjectObservation is null");
+					Assert.That (recognizedObjectObservation.BoundingBox, Is.EqualTo (rect));
+				}
 
 				var rectangleObservation = VNRectangleObservation.FromBoundingBox ((VNRectangleObservationRequestRevision) 5000, rect);
 				Assert.NotNull (rectangleObservation, "randomRevision rectangleObservation is null");
@@ -177,7 +185,7 @@ namespace MonoTouchFixtures.Vision {
 				var barcodeObservation = VNBarcodeObservation.FromBoundingBox ((VNBarcodeObservationRequestRevision) 5000, rect);
 				Assert.NotNull (barcodeObservation, "randomRevision barcodeObservation is null");
 				Assert.That (barcodeObservation.BoundingBox, Is.EqualTo (rect));
-			}, "randomRevision throw");
+			}
 		}
 
 		[Test]
@@ -185,7 +193,7 @@ namespace MonoTouchFixtures.Vision {
 		{
 			// Tests '*RequestRevision.Two' given to APIs.
 			var rect = new CGRect (0, 0, 10, 10);
-			Assert.DoesNotThrow (() => {
+			{
 				var detectedObjectObservation = VNDetectedObjectObservation.FromBoundingBox (VNDetectedObjectObservationRequestRevision.Two, rect);
 				Assert.NotNull (detectedObjectObservation, "detectedObjectObservation is null");
 				Assert.That (detectedObjectObservation.BoundingBox, Is.EqualTo (rect));
@@ -195,8 +203,12 @@ namespace MonoTouchFixtures.Vision {
 				Assert.That (faceObservation.BoundingBox, Is.EqualTo (rect));
 
 				var recognizedObjectObservation = VNRecognizedObjectObservation.FromBoundingBox (VNRecognizedObjectObservationRequestRevision.Two, rect);
-				Assert.NotNull (recognizedObjectObservation, "recognizedObjectObservation is null");
-				Assert.That (recognizedObjectObservation.BoundingBox, Is.EqualTo (rect));
+				if (TestRuntime.CheckXcodeVersion (11, 0)) {
+					Assert.Null (recognizedObjectObservation, "recognizedObjectObservation is null");
+				} else {
+					Assert.NotNull (recognizedObjectObservation, "recognizedObjectObservation is null");
+					Assert.That (recognizedObjectObservation.BoundingBox, Is.EqualTo (rect));
+				}
 
 				var rectangleObservation = VNRectangleObservation.FromBoundingBox (VNRectangleObservationRequestRevision.Two, rect);
 				Assert.NotNull (rectangleObservation, "rectangleObservation is null");
@@ -209,7 +221,7 @@ namespace MonoTouchFixtures.Vision {
 				var barcodeObservation = VNBarcodeObservation.FromBoundingBox (VNBarcodeObservationRequestRevision.Two, rect);
 				Assert.NotNull (barcodeObservation, "barcodeObservation is null");
 				Assert.That (barcodeObservation.BoundingBox, Is.EqualTo (rect));
-			}, "*RequestRevision.Two throw");
+			}
 		}
 	}
 }

--- a/tests/monotouch-test/monotouch-test.csproj
+++ b/tests/monotouch-test/monotouch-test.csproj
@@ -201,6 +201,9 @@
     <Compile Include="..\common\ConditionalCompilation.cs">
       <Link>ConditionalCompilation.cs</Link>
     </Compile>
+    <Compile Include="..\common\Extensions.cs">
+      <Link>Extensions.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -69,6 +69,9 @@
     <Compile Include="..\common\TestRuntime.cs">
       <Link>TestRuntime.cs</Link>
     </Compile>
+    <Compile Include="..\common\Extensions.cs">
+      <Link>Extensions.cs</Link>
+    </Compile>
     <Compile Include="..\common\mac\MacTestMain.cs">
       <Link>MacTestMain.cs</Link>
     </Compile>


### PR DESCRIPTION
* [monotouch-test] Fix another case of Photos framework's problems.
* [monotouch-test] Workaround issue with UIPasteboard.General.Images.
* [monotouch-test] Adjust tests to cope with changes in Xcode 11 beta 1.
* [Security] Don't pass pointers to 0-length memory to SecKeyRawVerify.
* [runtime] Implement a different fix for #6258. Fixes #6302.