### PR TITLE
[apidiff] Track changes based on d16-2

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -12,7 +12,7 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config
 
 include $(TOP)/Make.versions
 
-APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-0/0aa84521980687c73604144a1fc1e4b78c1d2103/28/package/bundle.zip
+APIDIFF_REFERENCES=https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-2/55ad1411fa8a269be55e3b6d5cdbae5da0818b46/31/package/bundle.zip
 
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 


### PR DESCRIPTION
since the `xcode11` branch is based on `d16-2` (and not the current
`d16-1` stable).