### PR TITLE
[nuget] Use xibuild to run nuget

### DIFF
--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -5,7 +5,7 @@ include $(TOP)/Make.config
 all-local:: run-unit-tests
 
 build-unit-tests:
-	$(Q) $(SYSTEM_MONO) /Library/Frameworks//Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore $(TOP)/src/generator.sln
+	$(Q_XBUILD) $(SYSTEM_XIBUILD) -t -- /Library/Frameworks//Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore $(TOP)/src/generator.sln
 	$(SYSTEM_MSBUILD) generator-tests.csproj $(XBUILD_VERBOSITY)
 
 run-unit-tests: build-unit-tests

--- a/tests/mmptest/Makefile
+++ b/tests/mmptest/Makefile
@@ -37,7 +37,7 @@ run: build
 	@[[ ! -e .failed-stamp ]]
 
 build:
-	$(Q) $(SYSTEM_MONO) /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore ../tests-mac.sln
+	$(Q_XBUILD) $(SYSTEM_XIBUILD) -t -- /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore ../tests-mac.sln
 	$(SYSTEM_XIBUILD) -- mmptest.csproj $(XBUILD_VERBOSITY)
 
 clean-local::

--- a/tests/mtouch/Makefile
+++ b/tests/mtouch/Makefile
@@ -34,7 +34,7 @@ mtouch.csproj.inc: $(TOP)/tools/common/create-makefile-fragment.sh Makefile $(TO
 -include mtouch.csproj.inc
 
 bin/Debug/mtouch.dll: $(mtouch_dependencies)
-	$(Q) $(SYSTEM_MONO) /Library/Frameworks//Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore packages.config
+	$(Q_XBUILD) $(SYSTEM_XIBUILD) -t -- /Library/Frameworks//Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore packages.config
 	$(SYSTEM_XIBUILD) -- mtouch.csproj $(XBUILD_VERBOSITY)
 	$(Q) rm -f .failed-stamp
 

--- a/tests/xharness/MakefileGenerator.cs
+++ b/tests/xharness/MakefileGenerator.cs
@@ -98,7 +98,7 @@ namespace xharness
 				var nuget_restore_dependency = ".stamp-nuget-restore-mac";
 				writer.WriteLine ("PACKAGES_CONFIG:=$(shell find . -name packages.config)");
 				writer.WriteLine ($"{nuget_restore_dependency}: tests-mac.sln $(PACKAGES_CONFIG)");
-				writer.WriteLine ("\t$(Q) $(SYSTEM_MONO) /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore tests-mac.sln");
+				writer.WriteLine ("\t$(Q_XBUILD) $(SYSTEM_XIBUILD) -t -- /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore tests-mac.sln");
 				writer.WriteLine ("\t$(Q) touch $@");
 
 				var allTargets = new List<MacTarget> ();

--- a/tools/mmp/tests/Makefile
+++ b/tools/mmp/tests/Makefile
@@ -21,7 +21,7 @@ mmp.exe: ../mmp.exe
 	$(Q) $(CP) ../mmp.exe mmp.exe
  
 nunit.framework.dll nunit-console.exe Mono.Cecil.dll:
-	/Library/Frameworks/Mono.framework/Commands/nuget restore packages.config
+	$(SYSTEM_XIBUILD) -t -- /Library/Frameworks//Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore packages.config
 	$(CP) $(NUGET_LIB) nunit.framework.dll
 	$(CP) $(CECIL_LIB) Mono.Cecil.dll
 


### PR DESCRIPTION
Fix errors seen during `nuget restore` for tests:

```
Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/xammac_tests/xammac_tests.csproj(213,3): error MSB4024: The imported project file "/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/Xamarin.Mac.CSharp.targets" could not be loaded. Could not find file "/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/Xamarin.Mac.CSharp.targets"
```

`nuget.exe` loads the msbuild assemblies, which ends up with no toolset
for mono (which has the fallback paths where XM/XI are installed). So,
use `xibuild` to use this correctly.