### PR TITLE
[mtouch] Fix building intents extensions for watchOS.

### DIFF
--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -672,7 +672,7 @@ namespace Xamarin.Bundler
 					sw.WriteLine ("\txamarin_register_modules = xamarin_register_modules_impl;");
 					sw.WriteLine ("}");
 
-					if (app.Platform == ApplePlatform.WatchOS && app.SdkVersion.Major >= 6) {
+					if (app.Platform == ApplePlatform.WatchOS && app.SdkVersion.Major >= 6 && app.IsWatchExtension) {
 						sw.WriteLine ();
 						sw.WriteLine ("extern \"C\" { int WKExtensionMain (int argc, char* argv[]); }");
 						sw.WriteLine ("int main (int argc, char *argv[])");


### PR DESCRIPTION
Fixes this build error:

    Xamarin.iOS.Tasks.WatchKit2("iPhoneSimulator").BasicTest: #RunTarget-ErrorCount
        redefinition of 'main'
        Failed to compile the file(s) '/Users/builder/jenkins/workspace/xamarin-macios-pr-builder/msbuild/tests/MyWatchKit2IntentsExtension/obj/iPhoneSimulator/Debug/mtouch-cache/i386/main.m'. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
    Expected: 0
    But was: 2

since we no longer generate two main functions.