### PR TITLE
[msbuild] [tests] Ignore PhotoEditingTests until Apple fixes the PhotosUI framework's header to compile.

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/PhotoEditing.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/Extensions/PhotoEditing.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 namespace Xamarin.iOS.Tasks {
 	[TestFixture ("iPhone")]
 	[TestFixture ("iPhoneSimulator")]
+	[Ignore ("The PhotoUI framework is broken in Xcode 11 beta 1 and the generated registrar code doesn't compile.")]
 	public class PhotoEditingTests : ExtensionTestBase {
 		public PhotoEditingTests (string platform) : base (platform)
 		{


### PR DESCRIPTION
Partial fix for https://github.com/xamarin/xamarin-macios/issues/6325.