### PR TITLE
[xharness] Automatically enable tests on older simulators if we're using a beta Xcode.

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -116,6 +116,13 @@ namespace xharness
 			LaunchTimeout = InWrench ? 3 : 120;
 		}
 
+		public bool IsBetaXcode {
+			get {
+				// There's no string.Contains (string, StringComparison) overload, so use IndexOf instead.
+				return XcodeRoot.IndexOf ("beta", StringComparison.OrdinalIgnoreCase) >= 0;
+			}
+		}
+
 		static string FindXcode (string path)
 		{
 			var p = path;

--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -764,7 +764,6 @@ namespace xharness
 			SetEnabled (labels, "ios-extensions", ref IncludeiOSExtensions);
 			SetEnabled (labels, "device", ref IncludeDevice);
 			SetEnabled (labels, "xtro", ref IncludeXtro);
-			SetEnabled (labels, "old-simulator", ref IncludeOldSimulatorTests);
 			SetEnabled (labels, "all", ref IncludeAll);
 
 			// enabled by default
@@ -801,6 +800,14 @@ namespace xharness
 					IncludeDocs = false; // could have been enabled by 'run-all-tests', so disable it if we can't run it.
 					MainLog.WriteLine ("Disabled 'docs' tests because the Xamarin-specific parts of the build are not enabled.");
 				}
+			}
+
+			// old simulator tests is also a bit special:
+			// - enabled by default if using a beta Xcode, otherwise disabled by default
+			changed = SetEnabled (labels, "old-simulator", ref IncludeOldSimulatorTests);
+			if (!changed && Harness.IsBetaXcode) {
+				IncludeOldSimulatorTests = true;
+				MainLog.WriteLine ("Enabled 'old-simulator' tests because we're using a beta Xcode.");
 			}
 		}
 


### PR DESCRIPTION
Usually it's when working on beta Xcodes we make mistakes that only show up
when running on older simulators (and devices):

* Missing/wrong availability attributes.
* Tests for new API that don't check the OS if that API is available.

So automatically enable the tests on older simulators for PR builds when using
a beta Xcode.