### PR TITLE
Build mono from source by default in all scenarios, not just CI. Fixes #6342.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -9,6 +9,9 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config
 	@printf "MAC_COMMIT_DISTANCE:=$(shell LANG=C; export LANG && git --git-dir $(TOP)/.git log `git --git-dir $(TOP)/.git blame -- ./Make.versions HEAD | grep MAC_PACKAGE_VERSION= | sed 's/ .*//' `..HEAD --oneline | wc -l | sed 's/ //g')\n" >> $@
 	@if which ccache > /dev/null 2>&1; then printf "ENABLE_CCACHE=1\nexport CCACHE_BASEDIR=$(abspath $(TOP)/..)\n" >> $@; echo "Found ccache on the system, enabling it"; fi
 	@if test -d $(TOP)/../maccore; then printf "ENABLE_XAMARIN=1\n" >> $@; echo "Detected the maccore repository, automatically enabled the Xamarin build"; fi
+	@# Build from source for Xcode 11 support until mono has packages
+	@# TODO: to be removed when we can use the mono archive again.
+	@printf "MONO_BUILD_FROM_SOURCE=1\n" >> $@; echo "Disabled the packaged mono build, since it's currently not supported in the xcode11 support branch."
 
 include $(TOP)/Make.versions
 

--- a/configure
+++ b/configure
@@ -94,6 +94,10 @@ while test x$1 != x; do
         echo "MONO_BUILD_FROM_SOURCE=1" >> "$CONFIGURED_FILE"
         shift
         ;;
+    --disable-packaged-mono=no | --disable-packaged-mono=false)
+        echo "MONO_BUILD_FROM_SOURCE=" >> "$CONFIGURED_FILE"
+        shift
+        ;;
 	--help|-h)
 		show_help
 		exit 0

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -113,9 +113,6 @@ if test -z "$ENABLE_DEVICE_BUILD"; then
 	CONFIGURE_FLAGS="$CONFIGURE_FLAGS --disable-ios-device"
 fi
 
-# Build from source for Xcode 11 support until mono has packages
-CONFIGURE_FLAGS="$CONFIGURE_FLAGS --disable-packaged-mono"
-
 make reset
 make git-clean-all
 make print-versions


### PR DESCRIPTION
Many people are running into problems building xcode11 because they have to
"./configure --disable-packaged-mono" first.

So disable the packaged mono by default (and add a way to enable it again
manually with "./configure--disable-packaged-mono=no").

Fixes https://github.com/xamarin/xamarin-macios/issues/6342.