### PR TITLE
[XHarness] Re-enable tests from System-xunit-tests.dll

### DIFF
--- a/tests/bcl-test/common-monotouch_System_xunit-test.dll.ignore
+++ b/tests/bcl-test/common-monotouch_System_xunit-test.dll.ignore
@@ -1,57 +1,3 @@
-# block app
-System.Net.Tests.WebClientTest.DefaultCtor_PropertiesReturnExpectedValues
-System.Net.Tests.WebClientTest.Properties_InvalidArguments_ThrowExceptions
-System.Net.Tests.WebClientTest.DownloadData_InvalidArguments_ThrowExceptions
-System.Net.Tests.WebClientTest.DownloadFile_InvalidArguments_ThrowExceptions
-System.Net.Tests.WebClientTest.DownloadString_InvalidArguments_ThrowExceptions
-System.Net.Tests.WebClientTest.UploadData_InvalidArguments_ThrowExceptions
-System.Net.Tests.WebClientTest.UploadFile_InvalidArguments_ThrowExceptions
-System.Net.Tests.WebClientTest.UploadString_InvalidArguments_ThrowExceptions
-System.Net.Tests.WebClientTest.UploadValues_InvalidArguments_ThrowExceptions
-System.Net.Tests.WebClientTest.OpenWrite_InvalidArguments_ThrowExceptions
-System.Net.Tests.WebClientTest.OpenRead_InvalidArguments_ThrowExceptions
-System.Net.Tests.WebClientTest.BaseAddress_Roundtrips
-System.Net.Tests.WebClientTest.CachePolicy_Roundtrips
-System.Net.Tests.WebClientTest.Credentials_Roundtrips
-System.Net.Tests.WebClientTest.Proxy_Roundtrips
-System.Net.Tests.WebClientTest.Encoding_Roundtrips
-System.Net.Tests.WebClientTest.Headers_Roundtrips
-System.Net.Tests.WebClientTest.QueryString_Roundtrips
-System.Net.Tests.WebClientTest.UseDefaultCredentials_Roundtrips
-System.Net.Tests.WebClientTest.ResponseHeaders_ContainsHeadersAfterOperation
-System.Net.Tests.WebClientTest.RequestHeaders_AddDisallowedHeaderAndSendRequest_ThrowsWebException(headerName: "Connection", headerValue: "close")
-System.Net.Tests.WebClientTest.RequestHeaders_AddDisallowedHeaderAndSendRequest_ThrowsWebException(headerName: "Expect", headerValue: "100-continue")
-System.Net.Tests.WebClientTest.RequestHeaders_AddHostHeaderAndSendRequest_ExpectedResult(hostHeaderValue: "http://localhost", throwsWebException: True)
-System.Net.Tests.WebClientTest.RequestHeaders_AddHostHeaderAndSendRequest_ExpectedResult(hostHeaderValue: "localhost", throwsWebException: False)
-System.Net.Tests.WebClientTest.RequestHeaders_SpecialHeaders_RequestSucceeds
-System.Net.Tests.WebClientTest.ConcurrentOperations_Throw
-System.Net.Tests.SyncWebClientTest.DownloadString_Success(contentType: null)
-System.Net.Tests.SyncWebClientTest.DownloadString_Success(contentType: "text/html; charset=utf-8")
-System.Net.Tests.SyncWebClientTest.DownloadString_Success(contentType: "text/html; charset=us-ascii")
-System.Net.Tests.SyncWebClientTest.DownloadData_Success
-System.Net.Tests.SyncWebClientTest.DownloadData_LargeData_Success
-System.Net.Tests.SyncWebClientTest.DownloadFile_Success
-System.Net.Tests.SyncWebClientTest.OpenRead_Success
-System.Net.Tests.SyncWebClientTest.OpenWrite_Success
-System.Net.Tests.SyncWebClientTest.UploadData_Success
-System.Net.Tests.SyncWebClientTest.UploadData_LargeData_Success
-System.Net.Tests.SyncWebClientTest.UploadFile_Success
-System.Net.Tests.SyncWebClientTest.UploadString_Success
-System.Net.Tests.SyncWebClientTest.UploadValues_Success
-System.Net.Tests.TaskWebClientTest.DownloadString_Success(contentType: null)
-System.Net.Tests.TaskWebClientTest.DownloadString_Success(contentType: "text/html; charset=utf-8")
-System.Net.Tests.TaskWebClientTest.DownloadString_Success(contentType: "text/html; charset=us-ascii")
-System.Net.Tests.TaskWebClientTest.DownloadData_Success
-System.Net.Tests.TaskWebClientTest.DownloadData_LargeData_Success
-System.Net.Tests.TaskWebClientTest.DownloadFile_Success
-System.Net.Tests.TaskWebClientTest.OpenRead_Success
-System.Net.Tests.TaskWebClientTest.OpenWrite_Success
-System.Net.Tests.TaskWebClientTest.UploadData_Success
-System.Net.Tests.TaskWebClientTest.UploadData_LargeData_Success
-System.Net.Tests.TaskWebClientTest.UploadFile_Success
-System.Net.Tests.TaskWebClientTest.UploadString_Success
-System.Net.Tests.TaskWebClientTest.UploadValues_Successs
-
 #    Exception messages: Exit code was 134 but it should have been 42
 # Expected: True
 # Actual:   False 
@@ -117,9 +63,3 @@ System.IO.Tests.FileSystemWatcherTests.FileSystemWatcher_Path
 
 # Exception messages: System.IO.IOException : BCL tests group  test app isn't present in the test runtime directory.   Exception stack traces:
 System.Text.RegularExpressions.Tests.RegexMatchTests.Match_ExcessPrefix
-
-# blocks the testing app
-System.Net.WebSockets.Tests.WebSocketTests.CreateClientBuffer_InvalidSendValues(size: -1)
-System.Net.WebSockets.Tests.WebSocketTests.CreateClientBuffer_InvalidSendValues(size: 0)
-System.Net.WebSockets.Tests.WebSocketTests.WebSocketProtocol_CreateFromConnectedStream_CanSendReceiveData
-System.Net.WebSockets.Tests.WebSocketTests.ReceiveAsync_ServerSplitHeader_ValidDataReceived

--- a/tests/bcl-test/watchOS-monotouch_System_xunit-test.dll.ignore
+++ b/tests/bcl-test/watchOS-monotouch_System_xunit-test.dll.ignore
@@ -1,2 +1,24 @@
 # System.Net.FtpWebRequestCreator is not supported on the current platform.
 System.Net.Tests.FtpWebRequestTest.Ctor_VerifyDefaults_Success
+
+# System.PlatformNotSupportedException, mono issue: https://github.com/mono/mono/issues/15265
+System.Net.Tests.TaskWebClientTest.DownloadString_Success(contentType: null)
+System.Net.Tests.TaskWebClientTest.DownloadString_Success(contentType: "text/html; charset=utf-8")
+System.Net.Tests.TaskWebClientTest.DownloadString_Success(contentType: "text/html; charset=us-ascii")
+System.Net.Tests.TaskWebClientTest.DownloadData_LargeData_Success
+System.Net.Tests.TaskWebClientTest.OpenRead_Success
+System.Net.Tests.TaskWebClientTest.DownloadFile_Success
+System.Net.Tests.TaskWebClientTest.DownloadData_Success
+System.Net.Tests.WebClientTest.DefaultCtor_PropertiesReturnExpectedValues
+System.Net.Tests.WebClientTest.ConcurrentOperations_Throw
+System.Net.Tests.WebClientTest.Proxy_Roundtrips
+System.Net.Tests.WebClientTest.RequestHeaders_SpecialHeaders_RequestSucceeds
+System.Net.Tests.WebClientTest.ResponseHeaders_ContainsHeadersAfterOperation
+System.Net.Tests.SyncWebClientTest.DownloadData_LargeData_Success
+System.Net.Tests.SyncWebClientTest.OpenRead_Success
+System.Net.Tests.SyncWebClientTest.DownloadString_Success(contentType: null)
+System.Net.Tests.SyncWebClientTest.DownloadString_Success(contentType: "text/html; charset=us-ascii")
+System.Net.Tests.SyncWebClientTest.DownloadString_Success(contentType: "text/html; charset=utf-8")
+System.Net.Tests.SyncWebClientTest.DownloadFile_Success
+System.Net.Tests.SyncWebClientTest.DownloadData_Success
+System.Net.WebSockets.Tests.WebSocketTests.ReceiveAsync_ServerSplitHeader_ValidDataReceived


### PR DESCRIPTION
After PR https://github.com/xamarin/xamarin-macios/pull/6291 we can run
the test that blocked the test app.