### PR TITLE
Bump mono to pick up GC fixes.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -49,7 +49,7 @@ XCODE94_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_9.4.xip
 XCODE94_DEVELOPER_ROOT=/Applications/Xcode94.app/Contents/Developer
 
 # Mono version embedded in XI/XM
-MONO_HASH:=fdf6490d049ca9d76b7bbc2a70a15e3e610dfb30
+MONO_HASH:=537654c1c79564668e4cab9735be613028328a70
 MONO_BRANCH:=2019-02
 
 # Minimum Mono version for building XI/XM


### PR DESCRIPTION
Commits are:

* https://github.com/mono/mono/commit/5a7adade186177f739fdade6bdaaf6a873467396  [profiler] Don't switch to GC Safe when locking if thread isn't attached to the runtime.
* https://github.com/mono/mono/commit/925e951f4b5a7a0e06874732d002f92a318a539b [runtime] Don't do GC Unsafe transition in mono_gchandle_free
* https://github.com/mono/mono/commit/eb22ea3ed9be8b928e877db89e56b4012e1b6885 [coop] Mark a few functions with MONO_PROFILER_API
* https://github.com/mono/mono/commit/537654c1c79564668e4cab9735be613028328a70 Improve robustness of post-install script 

Complete diff: https://github.com/mono/mono/compare/fdf6490d049ca9d76b7bbc2a70a15e3e610dfb30...537654c1c79564668e4cab9735be613028328a70