### PR TITLE
[CoreFoundation] Remove StructLayout from the DispatchBlock class.

### DIFF
--- a/src/CoreFoundation/DispatchBlock.cs
+++ b/src/CoreFoundation/DispatchBlock.cs
@@ -16,7 +16,6 @@ using Foundation;
 namespace CoreFoundation {
 #if !COREBUILD
 
-	[StructLayout (LayoutKind.Sequential)]
 	[iOS (8, 0)]
 	[Mac (10, 10)]
 	public sealed class DispatchBlock : NativeObject {


### PR DESCRIPTION
The StructLayout is not needed on our classes, since we should never pass them
directly to P/Invokes (the .Handle property should always be used).

So remove the attribute from the DispatchBlock class. It seems DispatchBlock
was a struct in the initial implementation, then became a class as the pull
request in question evolved, but the StructLayout attribute remained.

Removing it also has another advantage: P/Invokes will throw a marshalling
exception if such a class is passed in (instead of the native function doing
random things because we passed in garbage).