### PR TITLE
[d16-2] [tests] Handle Xcodes without proper versions by ignoring them. Fixes xamarin/maccore#1768.

### DIFF
--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -78,7 +78,10 @@ namespace Xamarin.Tests
 			var max_version = Version.Parse (XcodeVersion);
 			foreach (var xcode in xcodes) {
 				var path = Path.Combine (xcode, "Contents", "Developer");
-				var version = Version.Parse (GetXcodeVersion (path));
+				var xcode_version = GetXcodeVersion (path);
+				if (xcode_version == null)
+					continue;
+				var version = Version.Parse (xcode_version);
 				if (version >= max_version)
 					continue;
 				if (min_version != null && version < min_version)


### PR DESCRIPTION
This can happen if an Xcode hasn't been completely/successfully installed or
removed.

Fixes https://github.com/xamarin/maccore/issues/1768.

Backport of #6364.

/cc @rolfbjarne 