### PR TITLE
Add a new feature flag that indicates stable support for the Concurrent GC. Partial fix of #5909.

### DIFF
--- a/Versions-ios.plist.in
+++ b/Versions-ios.plist.in
@@ -143,7 +143,8 @@
 		<string>mlaunch-wireless-devices</string>
 		<string>http-client-handlers</string>
 		<string>mono-symbol-archive</string>
-		<string>sgen-concurrent-gc</string>
+		<string>sgen-concurrent-gc</string> <!-- this means experimental support for the concurrent GC -->
+		<string>sgen-concurrent</string> <!-- this means stable support for the concurrent GC -->
 		<string>arm64_32</string>
 	</array>
 	<key>Optimizations</key>

--- a/Versions-mac.plist.in
+++ b/Versions-mac.plist.in
@@ -38,7 +38,8 @@
 	<array>
 		<string>http-client-handlers</string>
 		<string>mono-symbol-archive</string>
-		<string>sgen-concurrent-gc</string>
+		<string>sgen-concurrent-gc</string> <!-- this means experimental support for the concurrent GC -->
+		<string>sgen-concurrent</string> <!-- this means stable support for the concurrent GC -->
 		<string>link-platform</string>
 		<string>hybrid-aot</string>
 	</array>


### PR DESCRIPTION
Keep the old flag, otherwise the feature will disappear for IDE versions that
only check the old flag.

Partial fix for https://github.com/xamarin/xamarin-macios/issues/5909.