### PR TITLE
[xharness] Fix Makefile-mac.inc generation after recent disruptive changes.

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -325,14 +325,21 @@ namespace xharness
 			// If we need to generate Full/System variations, we do that here.
 			var unified_targets = new List<MacTarget> ();
 
-			Action<MacTarget, string, bool> configureTarget = (MacTarget target, string file, bool isNUnitProject) => {
+			Action<MacTarget, string, bool, bool> configureTarget = (MacTarget target, string file, bool isNUnitProject, bool skip_generation) => {
 				target.TemplateProjectPath = file;
 				target.Harness = this;
 				target.IsNUnitProject = isNUnitProject;
-				if (!generate_projects)
+				if (!generate_projects || skip_generation)
 					target.ShouldSkipProjectGeneration = true;
 				target.Execute ();
 			};
+
+			foreach (var proj in MacTestProjects) {
+				var target = new MacTarget (MacFlavors.Modern);
+				target.MonoNativeInfo = proj.MonoNativeInfo;
+				configureTarget (target, proj.Path, proj.IsNUnitProject, true);
+				unified_targets.Add (target);
+			}
 
 			foreach (var proj in MacTestProjects.Where ((v) => v.GenerateVariations).ToArray ()) {
 				var file = proj.Path;
@@ -346,7 +353,7 @@ namespace xharness
 				if (proj.GenerateFull) {
 					var target = new MacTarget (MacFlavors.Full);
 					target.MonoNativeInfo = proj.MonoNativeInfo;
-					configureTarget (target, file, proj.IsNUnitProject);
+					configureTarget (target, file, proj.IsNUnitProject, false);
 					unified_targets.Add (target);
 
 					var cloned_project = (MacTestProject) proj.Clone ();
@@ -357,7 +364,8 @@ namespace xharness
 
 				if (proj.GenerateSystem) {
 					var target = new MacTarget (MacFlavors.System);
-					configureTarget (target, file, proj.IsNUnitProject);
+					target.MonoNativeInfo = proj.MonoNativeInfo;
+					configureTarget (target, file, proj.IsNUnitProject, false);
 					unified_targets.Add (target);
 
 					var cloned_project = (MacTestProject) proj.Clone ();

--- a/tests/xharness/MacTarget.cs
+++ b/tests/xharness/MacTarget.cs
@@ -46,7 +46,7 @@ namespace xharness
 			get {
 				switch (Flavor) {
 				case MacFlavors.Modern:
-					return string.Empty;
+					return "modern";
 				case MacFlavors.Full:
 					return "full";
 				case MacFlavors.System:
@@ -106,12 +106,6 @@ namespace xharness
 					rv += ";XAMMAC;MOBILE";
 
 				return rv;
-			}
-		}
-
-		public override bool IsMultiArchitecture {
-			get {
-				return true;
 			}
 		}
 

--- a/tests/xharness/MakefileGenerator.cs
+++ b/tests/xharness/MakefileGenerator.cs
@@ -28,22 +28,20 @@ namespace xharness
 
 		static string MakeMacUnifiedTargetName (MacTarget target, MacTargetNameType type)
 		{
-			var make_escaped_suffix = "-" + target.Platform.Replace (" ", "\\ ");
+			var make_escaped_suffix = target.Platform.Replace (" ", "\\ ");
 			var make_escaped_name = target.SimplifiedName.Replace (" ", "\\ ");
 
-			switch (type)
-			{
-				case MacTargetNameType.Build:
-					return string.Format ("build{0}-{2}-{1}", make_escaped_suffix, make_escaped_name, target.MakefileWhereSuffix);
-				case MacTargetNameType.Clean:
-					return string.Format ("clean{0}-{2}-{1}", make_escaped_suffix, make_escaped_name, target.MakefileWhereSuffix);
-				case MacTargetNameType.Exec:
-					return string.Format ("exec{0}-{2}-{1}", make_escaped_suffix, make_escaped_name, target.MakefileWhereSuffix);
-				case MacTargetNameType.Run:
-					return string.Format ("run{0}-{2}-{1}", make_escaped_suffix, make_escaped_name, target.MakefileWhereSuffix);
-				default:
-					throw new NotImplementedException ();
+			var sb = new StringBuilder ();
+			sb.Append (type.ToString ().ToLowerInvariant ());
+			sb.Append ('-');
+			sb.Append (make_escaped_suffix);
+			sb.Append ('-');
+			if (!string.IsNullOrEmpty (target.MakefileWhereSuffix)) {
+				sb.Append (target.MakefileWhereSuffix);
+				sb.Append ('-');
 			}
+			sb.Append (make_escaped_name);
+			return sb.ToString ();
 		}
 
 		static string CreateRelativePath (string path, string relative_to)


### PR DESCRIPTION
This boils down to the makefile-generation code having the information it
needs (and that information being correct).

This fixes running of tests on other macOS bots (older/newer), because now we
can build the test package again.