### PR TITLE
[xcode11] [system-dependencies] Fix xcode-provisioning extraction

### DIFF
--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -324,10 +324,17 @@ function install_specific_xcode () {
 	local XCODE_NAME=`basename $XCODE_URL`
 	local XCODE_DMG=$PROVISION_DOWNLOAD_DIR/$XCODE_NAME
 
+	# Apple always uses the same name when extracting Xcode, only adding -beta if needed
+	if [[ $XCODE_NAME == *"Beta"* ]]; then
+		local XCODE_DOWNLOAD_PATH=$HOME/Downloads/Xcode-beta.app
+	else
+		local XCODE_DOWNLOAD_PATH=$HOME/Downloads/Xcode.app
+	fi
+
 	# To test this script with new Xcode versions, copy the downloaded file to $XCODE_DMG,
 	# uncomment the following curl line, and run ./system-dependencies.sh --provision-xcode
 	if test -f "$HOME/Downloads/$XCODE_NAME"; then
-		log "Found Xcode $XCODE_VERSION in your ~/Downloads folder, copying that version instead."
+		log "Found $XCODE_NAME in your ~/Downloads folder, copying that version to $XCODE_DMG instead of re-downloading it."
 		cp "$HOME/Downloads/$XCODE_NAME" "$XCODE_DMG"
 	else
 		curl -L $XCODE_URL > $XCODE_DMG
@@ -350,10 +357,13 @@ function install_specific_xcode () {
 		# make sure there's nothing interfering
 		rm -Rf *.app
 		rm -Rf $XCODE_ROOT
+		# since all extracted Xcode have the same name
+		# we want to make sure we use the last extracted one
+		rm -Rf $XCODE_DOWNLOAD_PATH
 		# extract
 		/System/Library/CoreServices/Applications/Archive\ Utility.app/Contents/MacOS/Archive\ Utility "$XCODE_DMG"
 		log "Installing Xcode $XCODE_VERSION to $XCODE_ROOT..."
-		mv *.app $XCODE_ROOT
+		mv $XCODE_DOWNLOAD_PATH $XCODE_ROOT
 		popd > /dev/null
 	else
 		fail "Don't know how to install $XCODE_DMG"


### PR DESCRIPTION
This should fix:

```
        Extracting /tmp/x-provisioning/Xcode_11_Beta_2.xip...
        Installing Xcode 11.0 to /Applications/Xcode11-beta2.app...
mv: rename *.app to /Applications/Xcode11-beta2.app: No such file or directory
```

This happened because we're copying the .xip to /tmp/x-provisioning, then try to extract it but for some reason that extraction always end up in ~/Downloads.
Therefore the move fails because the extracted .app is not in /tmp/x-provisioning.
Note: Apple's Xcode .xip are always extracted with a name of Xcode[-beta].app so hardcode that.
I don't know if it's because the original .xip was downloaded to ~/Download or if macOS's archive utility is just ignoring its preferences (save expended files into same directory as archive).
I couldn't find the option to force the archiver to extract to a specific location (feedback welcome).

Backport of #6406.

/cc @VincentDondain 