### PR TITLE
[system-dependencies] Use 'xip' to decompress xip files.

### DIFF
--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -327,7 +327,7 @@ function install_specific_xcode () {
 	# To test this script with new Xcode versions, copy the downloaded file to $XCODE_DMG,
 	# uncomment the following curl line, and run ./system-dependencies.sh --provision-xcode
 	if test -f "$HOME/Downloads/$XCODE_NAME"; then
-		log "Found Xcode $XCODE_VERSION in your ~/Downloads folder, copying that version instead."
+		log "Found $XCODE_NAME in your ~/Downloads folder, copying that version to $XCODE_DMG instead of re-downloading it."
 		cp "$HOME/Downloads/$XCODE_NAME" "$XCODE_DMG"
 	else
 		curl -L $XCODE_URL > $XCODE_DMG
@@ -351,7 +351,7 @@ function install_specific_xcode () {
 		rm -Rf *.app
 		rm -Rf $XCODE_ROOT
 		# extract
-		/System/Library/CoreServices/Applications/Archive\ Utility.app/Contents/MacOS/Archive\ Utility "$XCODE_DMG"
+		xip --expand "$XCODE_DMG"
 		log "Installing Xcode $XCODE_VERSION to $XCODE_ROOT..."
 		mv *.app $XCODE_ROOT
 		popd > /dev/null


### PR DESCRIPTION
Archive Utility compresses into a directory specified by one of its
preferences, so we can't really say for sure where it will put the extracted
xip.

This is of course all sorts of fun, except none of the good ones.

So use the command-line xip utility to extract the xip instead, which is
documented to extract into the current directory.

The reason we didn't use the 'xip' tool from the beginning is that when Apple first started shipping Xcode as xips, the --expand option wasn't documented.