### PR TITLE
Fix some availability attributes wrt macOS 10.14.6

### DIFF
--- a/src/coreanimation.cs
+++ b/src/coreanimation.cs
@@ -1929,7 +1929,7 @@ namespace CoreAnimation {
 	}
 
 	[NoWatch][NoiOS][NoTV]
-	[Mac (10,14,6, onlyOn64: true)]
+	[Mac (10,15, onlyOn64: true)]
 	[BaseType (typeof (NSObject), Name = "CAEDRMetadata")]
 	[DisableDefaultCtor]
 	interface CAEdrMetadata {

--- a/src/coregraphics.cs
+++ b/src/coregraphics.cs
@@ -210,17 +210,17 @@ namespace CoreGraphics {
 		[Field ("kCGColorSpaceITUR_2020_PQ_EOTF")]
 		NSString Itur_2020_PQ_Eotf { get; }
 
-		[Mac (10,14,6, onlyOn64: true)][iOS (13,0)]
+		[Mac (10,15, onlyOn64: true)][iOS (13,0)]
 		[TV (13,0)][Watch (6,0)]
 		[Field ("kCGColorSpaceDisplayP3_PQ_EOTF")]
 		NSString DisplayP3_PQ_Eotf { get; }
 
-		[Mac (10,14,6, onlyOn64: true)][iOS (13,0)]
+		[Mac (10,15, onlyOn64: true)][iOS (13,0)]
 		[TV (13,0)][Watch (6,0)]
 		[Field ("kCGColorSpaceDisplayP3_HLG")]
 		NSString DisplayP3_Hlg { get; }
 
-		[Mac (10,14,6, onlyOn64: true)][iOS (13,0)]
+		[Mac (10,15, onlyOn64: true)][iOS (13,0)]
 		[TV (13,0)][Watch (6,0)]
 		[Field ("kCGColorSpaceITUR_2020_HLG")]
 		NSString Itur_2020_Hlg { get; }


### PR DESCRIPTION
Xcode 11 headers mention 10.14.6 but, at least the current beta, does not
have them...