### PR TITLE
[d16-2] [tests] Only call MTLDevice.CreateSharedTexture macOS 10.14+. Fixes xamarin/maccore#1663.

### DIFF
--- a/tests/monotouch-test/Metal/MTLDeviceTests.cs
+++ b/tests/monotouch-test/Metal/MTLDeviceTests.cs
@@ -110,14 +110,16 @@ namespace MonoTouchFixtures.Metal {
 			}
 
 #if __MACOS__
-			using (var descriptor = MTLTextureDescriptor.CreateTexture2DDescriptor (MTLPixelFormat.RGBA8Unorm, 64, 64, false)) {
-				descriptor.StorageMode = MTLStorageMode.Private;
-				using (var texture = device.CreateSharedTexture (descriptor)) {
-					Assert.IsNotNull (texture, "CreateSharedTexture (MTLTextureDescriptor): NonNull");
+			if (TestRuntime.CheckXcodeVersion (10, 0)) {
+				using (var descriptor = MTLTextureDescriptor.CreateTexture2DDescriptor (MTLPixelFormat.RGBA8Unorm, 64, 64, false)) {
+					descriptor.StorageMode = MTLStorageMode.Private;
+					using (var texture = device.CreateSharedTexture (descriptor)) {
+						Assert.IsNotNull (texture, "CreateSharedTexture (MTLTextureDescriptor): NonNull");
 
-					using (var handle = texture.CreateSharedTextureHandle ())
-					using (var shared = device.CreateSharedTexture (handle))
-						Assert.IsNotNull (texture, "CreateSharedTexture (MTLSharedTextureHandle): NonNull");
+						using (var handle = texture.CreateSharedTextureHandle ())
+						using (var shared = device.CreateSharedTexture (handle))
+							Assert.IsNotNull (texture, "CreateSharedTexture (MTLSharedTextureHandle): NonNull");
+					}
 				}
 			}
 #endif


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/1663.

Backport of #6180.

/cc @rolfbjarne 