### PR TITLE
[d16-3] Bump VSMac to 8.1.0.2742 to fix msbuild issues (#6279)

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -62,9 +62,9 @@ MIN_XM_MONO_VERSION=6.0.0.286
 MIN_XM_MONO_URL=https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-02/261/c22486e39d129cb8117177a6f9c768e69fc4ebaa/MonoFramework-MDK-6.0.0.286.macos10.xamarin.universal.pkg
 
 # Minimum Visual Studio version
-MIN_VISUAL_STUDIO_URL=https://bosstoragemirror.blob.core.windows.net/vsmac/2716075/release-8.0/72a44477dd706608c2300a568f71e5769f89f7ef/VisualStudioForMac-8.0.9.5.dmg
-MIN_VISUAL_STUDIO_VERSION=8.0.0
-MAX_VISUAL_STUDIO_VERSION=8.1.99
+MIN_VISUAL_STUDIO_URL=https://bosstoragemirror.blob.core.windows.net/vsmac/2758327/release-8.1/ed27233de1b33083ea2234bc66a3b7824b99bbc7/VisualStudioForMac-8.1.0.2742.dmg
+MIN_VISUAL_STUDIO_VERSION=8.1.0.2742
+MAX_VISUAL_STUDIO_VERSION=8.1.0.2742
 
 # Minimum CMake version
 MIN_CMAKE_URL=https://cmake.org/files/v3.6/cmake-3.6.2-Darwin-x86_64.dmg

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -37,7 +37,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<Target Name="_CreateBindingResourcePackage" Condition="'$(DesignTimeBuild)' != 'true'"
 		DependsOnTargets="_ExpandNativeReferences"
-		Inputs="$(MSBuildAllProjects);@(ObjcBindingApiDefinition);@(ObjcBindingCoreSource);@(ReferencePath);@(ObjcBindingNativeLibrary);@(_FrameworkNativeReference);@(_FileNativeReference)"
+		Inputs="$(MSBuildAllProjects);$(MSBuildProjectFullPath);@(ObjcBindingApiDefinition);@(ObjcBindingCoreSource);@(ReferencePath);@(ObjcBindingNativeLibrary);@(_FrameworkNativeReference);@(_FileNativeReference)"
 		Outputs="$(BindingResourcePath)/manifest">
 		<CreateBindingResourcePackage Condition="'$(IsMacEnabled)' == 'true' And '$(NoBindingEmbedding)' == 'true' And '$(SkipBindingResourcePackage)' != 'true'"
 			SessionId="$(BuildSessionId)"

--- a/tests/generator/Makefile
+++ b/tests/generator/Makefile
@@ -5,7 +5,7 @@ include $(TOP)/Make.config
 all-local:: run-unit-tests
 
 build-unit-tests:
-	$(Q) $(SYSTEM_MONO) /Library/Frameworks//Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore $(TOP)/src/generator.sln
+	$(Q_XBUILD) $(SYSTEM_XIBUILD) -t -- /Library/Frameworks//Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore $(TOP)/src/generator.sln
 	$(SYSTEM_MSBUILD) generator-tests.csproj $(XBUILD_VERBOSITY)
 
 run-unit-tests: build-unit-tests

--- a/tests/mmptest/Makefile
+++ b/tests/mmptest/Makefile
@@ -37,7 +37,7 @@ run: build
 	@[[ ! -e .failed-stamp ]]
 
 build:
-	$(Q) $(SYSTEM_MONO) /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore ../tests-mac.sln
+	$(Q_XBUILD) $(SYSTEM_XIBUILD) -t -- /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore ../tests-mac.sln
 	$(SYSTEM_XIBUILD) -- mmptest.csproj $(XBUILD_VERBOSITY)
 
 clean-local::

--- a/tests/mtouch/Makefile
+++ b/tests/mtouch/Makefile
@@ -34,7 +34,7 @@ mtouch.csproj.inc: $(TOP)/tools/common/create-makefile-fragment.sh Makefile $(TO
 -include mtouch.csproj.inc
 
 bin/Debug/mtouch.dll: $(mtouch_dependencies)
-	$(Q) $(SYSTEM_MONO) /Library/Frameworks//Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore packages.config
+	$(Q_XBUILD) $(SYSTEM_XIBUILD) -t -- /Library/Frameworks//Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore packages.config
 	$(SYSTEM_XIBUILD) -- mtouch.csproj $(XBUILD_VERBOSITY)
 	$(Q) rm -f .failed-stamp
 

--- a/tests/xharness/MakefileGenerator.cs
+++ b/tests/xharness/MakefileGenerator.cs
@@ -98,7 +98,7 @@ namespace xharness
 				var nuget_restore_dependency = ".stamp-nuget-restore-mac";
 				writer.WriteLine ("PACKAGES_CONFIG:=$(shell find . -name packages.config)");
 				writer.WriteLine ($"{nuget_restore_dependency}: tests-mac.sln $(PACKAGES_CONFIG)");
-				writer.WriteLine ("\t$(Q) $(SYSTEM_MONO) /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore tests-mac.sln");
+				writer.WriteLine ("\t$(Q_XBUILD) $(SYSTEM_XIBUILD) -t -- /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore tests-mac.sln");
 				writer.WriteLine ("\t$(Q) touch $@");
 
 				var allTargets = new List<MacTarget> ();

--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -15,7 +15,7 @@ clean-local::
 	rm -rf *os*.pch*
 
 bin/Debug/xtro-sharpie.exe xtro-report/bin/Debug/xtro-report.exe build:
-	$(Q) nuget restore xtro-sharpie.sln
+	$(Q) $(SYSTEM_XIBUILD) -t -- /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore xtro-sharpie.sln
 	$(Q_BUILD) $(SYSTEM_MSBUILD) $(MSBUILD_VERBOSITY) xtro-sharpie.sln
 
 XIOS ?= $(TOP)/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/64bits/Xamarin.iOS.dll

--- a/tools/mmp/tests/Makefile
+++ b/tools/mmp/tests/Makefile
@@ -21,7 +21,7 @@ mmp.exe: ../mmp.exe
 	$(Q) $(CP) ../mmp.exe mmp.exe
  
 nunit.framework.dll nunit-console.exe Mono.Cecil.dll:
-	/Library/Frameworks/Mono.framework/Commands/nuget restore packages.config
+	$(SYSTEM_XIBUILD) -t -- /Library/Frameworks//Mono.framework/Versions/Current/lib/mono/nuget/NuGet.exe restore packages.config
 	$(CP) $(NUGET_LIB) nunit.framework.dll
 	$(CP) $(CECIL_LIB) Mono.Cecil.dll
 


### PR DESCRIPTION
* Bump VSMac to 8.1.0.2742 to fix msbuild issues

This is required to get the support for the msbuild `ToolsVersion`
change from `15.0` to `Current`.

* [tests][msbuild] Fix Binding resources test with updated msbuild

Test failure with updated msbuild and vsmac 8.1:

```
Xamarin.iOS.Tasks.NativeReferencesNoEmbedding("iPhone").ShouldNotUnnecessarilyRebuildBindingProject(True)
     Binding project build did not create package?
  Expected: True
  But was:  False

at Xamarin.iOS.Tasks.NativeReferencesNoEmbedding.ShouldNotUnnecessarilyRebuildBindingProject (System.Boolean framework) [0x000a0] in <74b8f7d8a53e40109916d305bb4d7403>:0
at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo cul
ture) [0x0006a] in <0519fa732e8845b6a809ce9180f541db>:0
```

The test builds the project multiple times. Before the 3rd build, the project
file's timestamp is updated and expects that the binding package will be
rebuilt. But it is not, because the target `_CreateBindingResourcePackage`
doesn't depend on that project file. So, add that to the target inputs.

* [nuget] Use xibuild to run nuget

Fix errors seen during `nuget restore` for tests:

```
Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/xammac_tests/xammac_tests.csproj(213,3): error MSB4024: The imported project file "/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/Xamarin.Mac.CSharp.targets" could not be loaded. Could not find file "/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Mac/Xamarin.Mac.CSharp.targets"
```

This is a backport of #6279.