### PR TITLE
[d16-3] [GameController] GCGamepad is deprecated in the headers, so mark it as such. Fixes xamarin/maccore#1742.

### DIFF
--- a/src/gamecontroller.cs
+++ b/src/gamecontroller.cs
@@ -123,6 +123,7 @@ namespace GameController {
 	[Mac (10,9, onlyOn64: true)]
 	[Deprecated (PlatformName.MacOSX, 10, 12)]
 	[Deprecated (PlatformName.iOS, 10, 0)]
+	[Deprecated (PlatformName.TvOS, 10, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
 	partial interface GCGamepad {

--- a/src/gamecontroller.cs
+++ b/src/gamecontroller.cs
@@ -121,6 +121,8 @@ namespace GameController {
 
 	[iOS (7,0)]
 	[Mac (10,9, onlyOn64: true)]
+	[Deprecated (PlatformName.MacOSX, 10, 12)]
+	[Deprecated (PlatformName.iOS, 10, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // return nil handle -> only exposed as getter
 	partial interface GCGamepad {


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/1742.

Backport of #6417.

/cc @rolfbjarne 