### PR TITLE
[d16-3] Bump mono sync android 346da980

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -49,7 +49,7 @@ XCODE94_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_9.4.xip
 XCODE94_DEVELOPER_ROOT=/Applications/Xcode94.app/Contents/Developer
 
 # Mono version embedded in XI/XM
-MONO_HASH:=537654c1c79564668e4cab9735be613028328a70
+MONO_HASH:=346da980446da491277cbf3a8fbbe1989d614fb3
 MONO_BRANCH:=2019-02
 
 # Minimum Mono version for building XI/XM


### PR DESCRIPTION
Commits are:
* https://github.com/mono/mono/commit/e8836b65d0f77262aceda7e0b1bc9e3839da53fa [ci] Use a shell script to reset HEAD for submodules
* https://github.com/mono/mono/commit/948fffd4ce311d5209a64a2a42b8bfc90f681b63 [2019-02] [debugger] Debugger doesn't break on unhandled exceptions (#15285)
* https://github.com/mono/mono/commit/346da980446da491277cbf3a8fbbe1989d614fb3 [ci] One more workaround for Git 2.22.0

Complete diff is: https://github.com/mono/mono/compare/537654c1c79564668e4cab9735be613028328a70...346da980446da491277cbf3a8fbbe1989d614fb3