### PR TITLE
[mmptest] Modify the Unified_HelloWorld_ShouldHaveNoWarnings test to not fail if the branch name contains 'warning'. Fixes xamarin/maccore#1404.

### DIFF
--- a/tests/common/ExecutionHelper.cs
+++ b/tests/common/ExecutionHelper.cs
@@ -95,7 +95,7 @@ namespace Xamarin.Tests
 			return rv;
 		}
 
-		bool IndexOfAny (string line, out int start, out int end, params string [] values)
+		static bool IndexOfAny (string line, out int start, out int end, params string [] values)
 		{
 			foreach (var value in values) {
 				start = line.IndexOf (value, StringComparison.Ordinal);
@@ -109,7 +109,7 @@ namespace Xamarin.Tests
 			return false;
 		}
 
-		string RemovePathAtEnd (string line)
+		static string RemovePathAtEnd (string line)
 		{
 			if (line.TrimEnd ().EndsWith ("]", StringComparison.Ordinal)) {
 				var start = line.LastIndexOf ("[", StringComparison.Ordinal);
@@ -126,11 +126,16 @@ namespace Xamarin.Tests
 			return line;
 		}
 
-		public void ParseMessages ()
+		public static List<ToolMessage> ParseMessages (string [] lines, string messageToolName)
 		{
-			messages.Clear ();
+			var messages = new List<ToolMessage> ();
+			ParseMessages (messages, lines, messageToolName);
+			return messages;
+		}
 
-			foreach (var l in output.ToString ().Split ('\n')) {
+		public static void ParseMessages (List<ToolMessage> messages, string [] lines, string messageToolName)
+		{
+			foreach (var l in lines) {
 				var line = l;
 				var msg = new ToolMessage ();
 				var origin = string.Empty;
@@ -162,13 +167,13 @@ namespace Xamarin.Tests
 				}
 				if (line.Length < 7)
 					continue; // something else
-				
+
 				msg.Prefix = line.Substring (0, 2);
 				if (!int.TryParse (line.Substring (2, 4), out msg.Number))
 					continue; // something else
 
 				line = line.Substring (8);
-				var toolName = MessageToolName;
+				var toolName = messageToolName;
 				if (toolName != null && line.StartsWith (toolName + ": ", StringComparison.Ordinal))
 					line = line.Substring (toolName.Length + 2);
 
@@ -190,6 +195,12 @@ namespace Xamarin.Tests
 
 				messages.Add (msg);
 			}
+		}
+
+		public void ParseMessages ()
+		{
+			messages.Clear ();
+			ParseMessages (messages, output.ToString ().Split ('\n'), MessageToolName);
 		}
 
 		public bool HasErrorPattern (string prefix, int number, string messagePattern)

--- a/tests/mmptest/src/MMPTest.cs
+++ b/tests/mmptest/src/MMPTest.cs
@@ -135,14 +135,18 @@ namespace Xamarin.MMP.Tests
 				test.Release = release;
 				test.XM45 = full;
 
-				// Due to https://bugzilla.xamarin.com/show_bug.cgi?id=48311 we can get warnings related to the registrar
-				Func<string, bool> hasLegitWarning = results =>
-					results.Split (Environment.NewLine.ToCharArray ()).Any (x => x.Contains ("warning") && !x.Contains ("deviceBrowserView:selectionDidChange:"));
+				var buildResults = TI.TestUnifiedExecutable (test).BuildOutput;
 
-				string buildResults;
+				var buildLines = buildResults.Split ('\n');
+				var messages = Tool.ParseMessages (buildLines, "mmp");
 
-				buildResults = TI.TestUnifiedExecutable (test).BuildOutput;
-				Assert.IsTrue (!hasLegitWarning (buildResults), "Unified_HelloWorld_ShouldHaveNoWarnings had warning: \n" + buildResults);
+				var warnings = messages.Where ((v) => v.IsWarning);
+
+				if (warnings.Any ()) {
+					Console.WriteLine ("Build output:");
+					Console.WriteLine (buildResults);
+				}
+				Assert.That (warnings, Is.Empty, "Unified_HelloWorld_ShouldHaveNoWarnings had warnings");
 			});
 		}
 


### PR DESCRIPTION
Asserting that the entire build output never contains 'warning' fails if git's
branch name contains 'warning', because Jenkins adds environment variables
with the git branch name (and environment variables are printed during the
build).

So instead parse the build output, and assert that we don't get any mmp
warnings.

Fixes https://github.com/xamarin/maccore/issues/1404.