### PR TITLE
[xharness] Don't fail to write report if failing to list referenced assemblies. Fixes xamarin/maccore#1821.

### DIFF
--- a/tests/xharness/Jenkins.cs
+++ b/tests/xharness/Jenkins.cs
@@ -2581,8 +2581,12 @@ namespace xharness
 						return Enumerable.Empty<string> ();
 
 					var csproj = new XmlDocument ();
-					csproj.LoadWithoutNetworkAccess (ProjectFile.Replace ("\\", "/"));
-					referencedNunitAndXunitTestAssemblies = csproj.GetNunitAndXunitTestReferences ();
+					try {
+						csproj.LoadWithoutNetworkAccess (ProjectFile.Replace ("\\", "/"));
+						referencedNunitAndXunitTestAssemblies = csproj.GetNunitAndXunitTestReferences ();
+					} catch (Exception e) {
+						referencedNunitAndXunitTestAssemblies = new string [] { $"Exception: {e.Message}", $"Filename: {ProjectFile}" };
+					}
 				} else {
 					referencedNunitAndXunitTestAssemblies = Enumerable.Empty<string> ();
 				}


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/1821.