### PR TITLE
[tests] Fix (no failure) introspection tests on device (iOS13)

### DIFF
--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -159,6 +159,12 @@ namespace Introspection {
 				case "VSAccountProviderResponse":
 				case "PHEditingExtensionContext":
 					return true;
+				// Xcode 11 (on device only)
+				case "ICHandle":
+				case "ICNotification":
+				case "ICNotificationManagerConfiguration":
+				case "MPSNNNeuronDescriptor":
+					return true;
 				}
 				break;
 			case "NSSecureCoding":
@@ -205,6 +211,12 @@ namespace Introspection {
 				case "VSAccountMetadataRequest":
 				case "VSAccountProviderResponse":
 				case "PHEditingExtensionContext":
+					return true;
+				// Xcode 11 (on device only)
+				case "ICHandle":
+				case "ICNotification":
+				case "ICNotificationManagerConfiguration":
+				case "MPSNNNeuronDescriptor":
 					return true;
 				}
 				break;


### PR DESCRIPTION
Note that the application crash *after* reporting (tests) success.
This is due to ReplayKit triggering an assertion inside UIKit (as it
try to access the status bar). This is filed with Apple
https://feedbackassistant.apple.com/feedback/6306808 https://github.com/xamarin/maccore/issues/1823

Avoiding to dispose the culprit (`RPSystemBroadcastPickerView`) sadly
does not workaround the issue :(