### PR TITLE
[msbuild] $(ProduceReferenceAssembly) support

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -782,16 +782,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<Target Name="_GetCompileToNativeInputs">
 		<ItemGroup>
-			<_CompileToNativeInput Include="$(TargetDir)$(TargetFileName)" />
-			<_CompileToNativeInput Condition="'@(_ResolvedAppExtensionReferences)' != ''" Include="%(_ResolvedAppExtensionReferences.Identity)\..\mtouch.stamp" />
-		</ItemGroup>
-	</Target>
-
-	<Target Name="_CompileToNative" DependsOnTargets="$(_CompileToNativeDependsOn)"
-		Inputs="@(_CompileToNativeInput);@(_FrameworkNativeReference);@(_FileNativeReference);@(BundleDependentFiles)"
-		Outputs="$(_NativeExecutable);$(DeviceSpecificOutputPath)mtouch.stamp">
-
-		<ItemGroup>
 			<!-- Skip the reference assemblies. There is currently no scenario where it is valid to pass them to 'mtouch'. They are impossible to AOT. Fixes: https://github.com/xamarin/xamarin-macios/issues/3199 -->
 			<!-- Remove exact references, such as if a package had a framework reference to 'System' that we already have -->
 			<!-- This is exactly what "Microsoft.NuGet.Build.Tasks"'s 'ResolveNuGetPackageAssets' target is doing -->
@@ -799,7 +789,14 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			<!-- This requires nuget libraries to be copied locally, which by default only happens for executable projects, so we set 'CopyNuGetImplementations' to true for extensions (see comment in Xamarin.iOS.AppExtension.CSharp.targets for more info) -->
 			<ReferencePath Remove="@(_ReferencesFromNuGetPackages)" />
 			<MTouchReferencePath Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll'" />
+			<_CompileToNativeInput Include="$(TargetDir)$(TargetFileName);@(ReferencePath);@(MTouchReferencePath)" />
+			<_CompileToNativeInput Condition="'@(_ResolvedAppExtensionReferences)' != ''" Include="%(_ResolvedAppExtensionReferences.Identity)\..\mtouch.stamp" />
 		</ItemGroup>
+	</Target>
+
+	<Target Name="_CompileToNative" DependsOnTargets="$(_CompileToNativeDependsOn)"
+		Inputs="@(_CompileToNativeInput);@(_FrameworkNativeReference);@(_FileNativeReference);@(BundleDependentFiles)"
+		Outputs="$(_NativeExecutable);$(DeviceSpecificOutputPath)mtouch.stamp">
 
 		<MTouch
 			SessionId="$(BuildSessionId)"

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/XamarinForms.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/XamarinForms.cs
@@ -12,11 +12,26 @@ namespace Xamarin.iOS.Tasks
 		}
 
 		[Test]
-		public void BasicTest ()
+		public void IncrementalBuilds ()
 		{
 			NugetRestore ("../MyXamarinFormsApp/MyXamarinFormsApp.csproj");
 			NugetRestore ("../MyXamarinFormsApp/MyXamarinFormsAppNS/MyXamarinFormsAppNS.csproj");
-			this.BuildProject ("MyXamarinFormsApp", Platform, "Debug", clean: false);
+
+			// First build
+			BuildProject ("MyXamarinFormsApp", Platform, "Debug");
+			Assert.IsFalse (IsTargetSkipped ("_CompileToNative"), "_CompileToNative should *not* be skipped on first build.");
+
+			// Build with no changes
+			Engine.Logger.Clear ();
+			BuildProject ("MyXamarinFormsApp", Platform, "Debug", clean: false);
+			Assert.IsTrue (IsTargetSkipped ("_CompileToNative"), "_CompileToNative should be skipped on a build with no changes.");
+
+			// Build with XAML change
+			Touch ("../MyXamarinFormsApp/MyXamarinFormsAppNS/App.xaml");
+			Engine.Logger.Clear ();
+			BuildProject ("MyXamarinFormsApp", Platform, "Debug", clean: false);
+
+			Assert.IsFalse (IsTargetSkipped ("_CompileToNative"), "_CompileToNative should *not* be skipped on a build with a XAML change.");
 		}
 	}
 }

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/Logger.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/Logger.cs
@@ -54,6 +54,14 @@ namespace Xamarin.iOS.Tasks
 		public LoggerVerbosity Verbosity {
 			get; set;
 		}
+
+		public void Clear ()
+		{
+			CustomEvents.Clear ();
+			ErrorEvents.Clear ();
+			MessageEvents.Clear ();
+			WarningsEvents.Clear ();
+		}
 	}
 
 	// Stolen from xbuild.

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TestHelpers/TestBase.cs
@@ -398,6 +398,27 @@ namespace Xamarin.iOS.Tasks
 				Assert.Fail ($"'nuget restore' failed for {project}");
 			}
 		}
+
+		/// <summary>
+		/// Returns true if a target was skipped.
+		/// Originally from: https://github.com/xamarin/xamarin-android/blob/320cb0f66730e7107cc17310b99cd540605a234d/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs#L48-L62
+		/// </summary>
+		public bool IsTargetSkipped (string target)
+		{
+			foreach (var line in Engine.Logger.MessageEvents.Select (m => m.Message)) {
+				if (line.Contains ($"Building target \"{target}\" completely")
+					|| line.Contains ($"Done building target \"{target}\""))
+					return false;
+				if (line.Contains ($"Target {target} skipped due to ")
+					|| line.Contains ($"Skipping target \"{target}\" because it has no ") //NOTE: message can say `inputs` or `outputs`
+					|| line.Contains ($"Target \"{target}\" skipped, due to")
+					|| line.Contains ($"Skipping target \"{target}\" because its outputs are up-to-date")
+					|| line.Contains ($"target {target}, skipping")
+					|| line.Contains ($"Skipping target \"{target}\" because all output files are up-to-date"))
+					return true;
+			}
+			return false;
+		}
 	}
 
 	public class ProjectPaths : Dictionary<string, string> {


### PR DESCRIPTION
Context: http://feedback.devdiv.io/600039
Context: https://github.com/xamarin/xamarin-android/blob/63219342370430031507d789fabcb46e1d0db515/Documentation/guides/MSBuildReferenceAssemblies.md
Context: https://github.com/dotnet/roslyn/blob/master/docs/features/refout.md#msbuild

For Xamarin.Android, we have been doing a bit of work to enable a new
MSBuild/Roslyn feature called "reference assemblies". You can opt into
this by setting $(ProduceReferenceAssembly)=true in a netstandard
project.

The benefit being that if the public API doesn't change in the
netstandard library, the head projects don't need to run `CoreCompile`
or `<Csc/>` during an incremental build.

Unfortunately, this seems to have uncovered a problem in the
Xamarin.iOS MSBuild targets. If you do a build with a XAML-only change,
you get:

    Target "_CompileToNative" in file "/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/iOS/Xamarin.iOS.Common.targets":
    Skipping target "_CompileToNative" because all output files are up-to-date with respect to the input files.
    Input files: /Users/jonathanpeppers/Projects/HelloForms/HelloForms.iOS/bin/iPhoneSimulator/Debug/HelloForms.iOS.exe
    Output files: bin/iPhoneSimulator/Debug/device-builds/iphone11.8-12.2/HelloForms.iOS.app/HelloForms.iOS;bin/iPhoneSimulator/Debug/device-builds/iphone11.8-12.2/mtouch.stamp

Because we are using `$(ProduceReferenceAssembly)` the
`HelloForms.iOS.exe` assembly will have no changes. Only
`HelloForms.dll`, the netstandard project, has changes. We were able
to skip `CoreCompile` in the iOS head project. Faster builds, yeah!

However, we actually need `_CompileToNative` to run, or we won't see
any changes on the device or simulator... It only runs if
`$(TargetPath)` changes.

The fix here is to add new `Inputs`, so `_CompileToNative` runs when
any referenced assemblies change:

    <_CompileToNativeInput Include="$(TargetDir)$(TargetFileName);@(ReferencePath);@(MTouchReferencePath)" />

This fixes incremental builds (or changes) for:

* Any `<ProjectReference/>` that has `$(ProduceReferenceAssembly)`
* Any NuGet package that ships a reference assembly alongside its
"regular" assembly

I also moved the `<ItemGroup>`'s, just so the code made sense --
so we have all the important `<ItemGroup>`'s in one place.

I also updated the `XamarinForms` test to verify things are working.

I added a couple helpers to assist in writing MSBuild tests:

* `IsTargetSkipped` to check if a specific MSBuild target ran
* `Logger.Clear` to clear past MSBuild events within a single test