### PR TITLE
[xcode11] [xharness] Propagate the BUILD_REVISION variable to test apps to specify if we're in CI or not. Fixes xamarin/maccore#649.

### DIFF
--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -532,6 +532,11 @@ namespace xharness
 				args.Append (" -setenv=NUNIT_ENABLE_XML_MODE=wrapped");
 			}
 
+			if (Harness.InCI) {
+				// We use the 'BUILD_REVISION' variable to detect whether we're running CI or not.
+				args.Append ($" -setenv=BUILD_REVISION=${Environment.GetEnvironmentVariable ("BUILD_REVISION")}");
+			}
+
 			if (!Harness.IncludeSystemPermissionTests)
 				args.Append (" -setenv=DISABLE_SYSTEM_PERMISSION_TESTS=1");
 

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -689,6 +689,13 @@ namespace xharness
 			}
 		}
 		
+		public bool InCI {
+			get {
+				// We use the 'BUILD_REVISION' variable to detect whether we're running CI or not.
+				return !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("BUILD_REVISION"));
+			}
+		}
+
 		public bool UseGroupedApps {
 			get {
 				var groupApps = Environment.GetEnvironmentVariable ("BCL_GROUPED_APPS");


### PR DESCRIPTION
We have tests whose behavior changes when executed on CI, and those tests use
the BUILD_REVISION variable to detect where they're being executed. For this
to work we need to propagate the BUILD_REVISION variable to the test
executable.

Hopefully fixes https://github.com/xamarin/maccore/issues/649 now.

Backport of #6467.

/cc @rolfbjarne 