### PR TITLE
[httpclient] Change NSUrlSessionHandler and CFNetworkHandler to throw HttpRequestException. Fix #6439

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -315,11 +315,8 @@ namespace Foundation {
 					"Properties can only be modified before sending the first request.");
 		}
 
-		// almost identical to ModernHttpClient version but it uses the constants from monotouch.dll | Xamarin.[iOS|WatchOS|TVOS].dll
 		static Exception createExceptionForNSError(NSError error)
 		{
-			// var webExceptionStatus = WebExceptionStatus.UnknownError;
-
 			var innerException = new NSErrorException(error);
 
 			// errors that exists in both share the same error code, so we can use a single switch/case
@@ -330,11 +327,6 @@ namespace Foundation {
 #else
 			if ((error.Domain == NSError.NSUrlErrorDomain) || (error.Domain == NSError.CFNetworkErrorDomain)) {
 #endif
-				// Parse the enum into a web exception status or exception. Some
-				// of these values don't necessarily translate completely to
-				// what WebExceptionStatus supports, so made some best guesses
-				// here.  For your reading pleasure, compare these:
-				//
 				// Apple docs: https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Miscellaneous/Foundation_Constants/index.html#//apple_ref/doc/constant_group/URL_Loading_System_Error_Codes
 				// .NET docs: http://msdn.microsoft.com/en-us/library/system.net.webexceptionstatus(v=vs.110).aspx
 				switch ((NSUrlError) (long) error.Code) {
@@ -345,124 +337,11 @@ namespace Foundation {
 #endif
 					// No more processing is required so just return.
 					return new OperationCanceledException(error.LocalizedDescription, innerException);
-// 				case NSUrlError.BadURL:
-// 				case NSUrlError.UnsupportedURL:
-// 				case NSUrlError.CannotConnectToHost:
-// 				case NSUrlError.ResourceUnavailable:
-// 				case NSUrlError.NotConnectedToInternet:
-// 				case NSUrlError.UserAuthenticationRequired:
-// 				case NSUrlError.InternationalRoamingOff:
-// 				case NSUrlError.CallIsActive:
-// 				case NSUrlError.DataNotAllowed:
-// #if !__WATCHOS__
-// 				case (NSUrlError) CFNetworkErrors.Socks5BadCredentials:
-// 				case (NSUrlError) CFNetworkErrors.Socks5UnsupportedNegotiationMethod:
-// 				case (NSUrlError) CFNetworkErrors.Socks5NoAcceptableMethod:
-// 				case (NSUrlError) CFNetworkErrors.HttpAuthenticationTypeUnsupported:
-// 				case (NSUrlError) CFNetworkErrors.HttpBadCredentials:
-// 				case (NSUrlError) CFNetworkErrors.HttpBadURL:
-// #endif
-// 					webExceptionStatus = WebExceptionStatus.ConnectFailure;
-// 					break;
-// 				case NSUrlError.TimedOut:
-// #if !__WATCHOS__
-// 				case (NSUrlError) CFNetworkErrors.NetServiceTimeout:
-// #endif
-// 					webExceptionStatus = WebExceptionStatus.Timeout;
-// 					break;
-// 				case NSUrlError.CannotFindHost:
-// 				case NSUrlError.DNSLookupFailed:
-// #if !__WATCHOS__
-// 				case (NSUrlError) CFNetworkErrors.HostNotFound:
-// 				case (NSUrlError) CFNetworkErrors.NetServiceDnsServiceFailure:
-// #endif
-// 					webExceptionStatus = WebExceptionStatus.NameResolutionFailure;
-// 					break;
-// 				case NSUrlError.DataLengthExceedsMaximum:
-// 					webExceptionStatus = WebExceptionStatus.MessageLengthLimitExceeded;
-// 					break;
-// 				case NSUrlError.NetworkConnectionLost:
-// #if !__WATCHOS__
-// 				case (NSUrlError) CFNetworkErrors.HttpConnectionLost:
-// #endif
-// 					webExceptionStatus = WebExceptionStatus.ConnectionClosed;
-// 					break;
-// 				case NSUrlError.HTTPTooManyRedirects:
-// 				case NSUrlError.RedirectToNonExistentLocation:
-// #if !__WATCHOS__
-// 				case (NSUrlError) CFNetworkErrors.HttpRedirectionLoopDetected:
-// #endif
-// 					webExceptionStatus = WebExceptionStatus.ProtocolError;
-// 					break;
-// 				case NSUrlError.RequestBodyStreamExhausted:
-// #if !__WATCHOS__
-// 				case (NSUrlError) CFNetworkErrors.SocksUnknownClientVersion:
-// 				case (NSUrlError) CFNetworkErrors.SocksUnsupportedServerVersion:
-// 				case (NSUrlError) CFNetworkErrors.HttpParseFailure:
-// #endif
-// 					webExceptionStatus = WebExceptionStatus.SendFailure;
-// 					break;
-// 				case NSUrlError.BadServerResponse:
-// 				case NSUrlError.ZeroByteResource:
-// 				case NSUrlError.CannotDecodeRawData:
-// 				case NSUrlError.CannotDecodeContentData:
-// 				case NSUrlError.CannotParseResponse:
-// 				case NSUrlError.FileDoesNotExist:
-// 				case NSUrlError.FileIsDirectory:
-// 				case NSUrlError.NoPermissionsToReadFile:
-// 				case NSUrlError.CannotLoadFromNetwork:
-// 				case NSUrlError.CannotCreateFile:
-// 				case NSUrlError.CannotOpenFile:
-// 				case NSUrlError.CannotCloseFile:
-// 				case NSUrlError.CannotWriteToFile:
-// 				case NSUrlError.CannotRemoveFile:
-// 				case NSUrlError.CannotMoveFile:
-// 				case NSUrlError.DownloadDecodingFailedMidStream:
-// 				case NSUrlError.DownloadDecodingFailedToComplete:
-// #if !__WATCHOS__
-// 				case (NSUrlError) CFNetworkErrors.Socks4RequestFailed:
-// 				case (NSUrlError) CFNetworkErrors.Socks4IdentdFailed:
-// 				case (NSUrlError) CFNetworkErrors.Socks4IdConflict:
-// 				case (NSUrlError) CFNetworkErrors.Socks4UnknownStatusCode:
-// 				case (NSUrlError) CFNetworkErrors.Socks5BadState:
-// 				case (NSUrlError) CFNetworkErrors.Socks5BadResponseAddr:
-// 				case (NSUrlError) CFNetworkErrors.CannotParseCookieFile:
-// 				case (NSUrlError) CFNetworkErrors.NetServiceUnknown:
-// 				case (NSUrlError) CFNetworkErrors.NetServiceCollision:
-// 				case (NSUrlError) CFNetworkErrors.NetServiceNotFound:
-// 				case (NSUrlError) CFNetworkErrors.NetServiceInProgress:
-// 				case (NSUrlError) CFNetworkErrors.NetServiceBadArgument:
-// 				case (NSUrlError) CFNetworkErrors.NetServiceInvalid:
-// #endif
-// 					webExceptionStatus = WebExceptionStatus.ReceiveFailure;
-// 					break;
-// 				case NSUrlError.SecureConnectionFailed:
-// 					webExceptionStatus = WebExceptionStatus.SecureChannelFailure;
-// 					break;
-// 				case NSUrlError.ServerCertificateHasBadDate:
-// 				case NSUrlError.ServerCertificateHasUnknownRoot:
-// 				case NSUrlError.ServerCertificateNotYetValid:
-// 				case NSUrlError.ServerCertificateUntrusted:
-// 				case NSUrlError.ClientCertificateRejected:
-// 				case NSUrlError.ClientCertificateRequired:
-// 					webExceptionStatus = WebExceptionStatus.TrustFailure;
-// 					break;
-// #if !__WATCHOS__
-// 				case (NSUrlError) CFNetworkErrors.HttpProxyConnectionFailure:
-// 				case (NSUrlError) CFNetworkErrors.HttpBadProxyCredentials:
-// 				case (NSUrlError) CFNetworkErrors.PacFileError:
-// 				case (NSUrlError) CFNetworkErrors.PacFileAuth:
-// 				case (NSUrlError) CFNetworkErrors.HttpsProxyConnectionFailure:
-// 				case (NSUrlError) CFNetworkErrors.HttpsProxyFailureUnexpectedResponseToConnectMethod:
-// 					webExceptionStatus = WebExceptionStatus.RequestProhibitedByProxy;
-// 					break;
-// #endif
 				}
-			} 
+			}
 
-			// Always create a WebException so that it can be handled by the client.
-			return new WebException(error.LocalizedDescription, innerException); //, webExceptionStatus, response: null);
-		}
+			return new HttpRequestException (error.LocalizedDescription, innerException);
+ 		}
 
 		string GetHeaderSeparator (string name)
 		{

--- a/src/System.Net.Http/CFNetworkHandler.cs
+++ b/src/System.Net.Http/CFNetworkHandler.cs
@@ -299,7 +299,8 @@ namespace System.Net.Http
 			if (!streamBuckets.TryGetValue (stream.Handle, out bucket))
 				return;
 
-			bucket.Response.TrySetException (stream.GetError ());
+			var ex = stream.GetError ();
+			bucket.Response.TrySetException (new HttpRequestException (ex.FailureReason, ex));
 			CloseStream (stream);
 		}
 

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -70,8 +70,7 @@ namespace MonoTests.System.Net.Http
 
 			Assert.IsTrue (done, "Did not time out");
 			Assert.IsNull (response, $"Response is not null {response}");
-			Assert.IsNotNull (ex, "Exception");
-			// The handlers throw different types of exceptions, so we can't assert much more than that something went wrong.			
+			Assert.IsInstanceOfType (typeof (HttpRequestException), ex, "Exception");
 		}
 
 #if !__WATCHOS__


### PR DESCRIPTION
Our 3 different handlers were inconsistent with each others. Only the
managed version, `HttpClientHandler`, was throwing the documented
`HttpRequestException` exception.
    
The inconsistency make this hard to consume from .net standard libraries
even more when the type is not, itself, available in .net standard
    
stack trace (for NSUrlSessionHandler)
    
```
    2019-07-02 10:58:08.352 gh6439[18579:15880723] System.Net.WebException: The Internet connection appears to be offline. ---> Foundation.NSErrorException: Error Domain=NSURLErrorDomain Code=-1009 "The Internet connection appears to be offline." UserInfo={_kCFStreamErrorCodeKey=50, NSUnderlyingError=0x283b6d350 {Error Domain=kCFErrorDomainCFNetwork Code=-1009 "(null)" UserInfo={_kCFStreamErrorCodeKey=50, _kCFStreamErrorDomainKey=1}}, _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <55894EBD-B898-4803-9981-46317EEFE280>.<1>, _NSURLErrorRelatedURLSessionTaskErrorKey=(
        "LocalDataTask <55894EBD-B898-4803-9981-46317EEFE280>.<1>"
    ), NSLocalizedDescription=The Internet connection appears to be offline., NSErrorFailingURLStringKey=https://www.microsoft.com/fr-ca/, NSErrorFailingURLKey=https://www.microsoft.com/fr-ca/, _kCFStreamErrorDomainKey=1}
       --- End of inner exception stack trace ---
      at System.Net.Http.NSUrlSessionHandler.SendAsync (System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) [0x001d4] in /Users/poupou/git/xcode11/xamarin-macios/src/Foundation/NSUrlSessionHandler.cs:541
      at System.Net.Http.HttpClient.SendAsyncWorker (System.Net.Http.HttpRequestMessage request, System.Net.Http.HttpCompletionOption completionOption, System.Threading.CancellationToken cancellationToken) [0x0009e] in /Users/poupou/git/xcode11/xamarin-macios/external/mono/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs:281
```
    
stack trace (for CFNetworkHandler)
    
```
    2019-07-02 11:04:35.407 gh6439[18580:15881497] CoreFoundation.CFException: The operation couldn’t be completed. Network is down
      at System.Net.Http.CFNetworkHandler.SendAsync (System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken, System.Boolean isFirstRequest) [0x002f2] in /Users/poupou/git/xcode11/xamarin-macios/src/System.Net.Http/CFNetworkHandler.cs:266
      at System.Net.Http.CFNetworkHandler.SendAsync (System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) [0x00034] in /Users/poupou/git/xcode11/xamarin-macios/src/System.Net.Http/CFNetworkHandler.cs:199
      at System.Net.Http.HttpClient.SendAsyncWorker (System.Net.Http.HttpRequestMessage request, System.Net.Http.HttpCompletionOption completionOption, System.Threading.CancellationToken cancellationToken) [0x0009e] in /Users/poupou/git/xcode11/xamarin-macios/external/mono/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs:281
```
    
references:
* https://github.com/xamarin/xamarin-macios/issues/6439
* https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.postasync?view=netstandard-2.0#System_Net_Http_HttpClient_PostAsync_System_String_System_Net_Http_HttpContent_System_Threading_CancellationToken_
