### PR TITLE
[d16-3][tests] Provision dotnet for the sample tests. Fixes xamarin/maccore#1811. (#6473)

### DIFF
--- a/tests/sampletester/Configuration.cs
+++ b/tests/sampletester/Configuration.cs
@@ -4,43 +4,53 @@ using System.Reflection;
 
 namespace Xamarin.Tests {
 	public partial  class Configuration {
+		static object lock_obj = new object ();
+		static string sample_root_directory;
 		public static string SampleRootDirectory {
 			get {
-				var rv = Path.Combine (Path.GetDirectoryName (Assembly.GetExecutingAssembly ().Location), "repositories");
-				var nuget_conf = Path.Combine (rv, "NuGet.config");
-				Directory.CreateDirectory (rv);
-				if (!File.Exists (nuget_conf)) {
-					// We're cloning into a subdirectory of xamarin-macios, which already has a NuGet.config
-					// So create a Nuget.config that clears out any previous configuration, so that none of the
-					// sample tests pick up xamarin-macios' NuGet.config.
-					File.WriteAllText (nuget_conf,
-	@"<?xml version=""1.0"" encoding=""utf-8""?>
+				lock (lock_obj) {
+					if (sample_root_directory == null) {
+						sample_root_directory = Path.Combine (Path.GetDirectoryName (Assembly.GetExecutingAssembly ().Location), "repositories");
+						Directory.CreateDirectory (sample_root_directory);
+						CreateNugetConfig (sample_root_directory);
+						CreateGlobalConfig (sample_root_directory);
+					}
+				}
+				return sample_root_directory;
+			}
+		}
+
+		static void CreateNugetConfig (string root)
+		{
+			var nuget_conf = Path.Combine (root, "NuGet.config");
+			// We're cloning into a subdirectory of xamarin-macios, which already has a NuGet.config
+			// So create a Nuget.config that clears out any previous configuration, so that none of the
+			// sample tests pick up xamarin-macios' NuGet.config.
+			File.WriteAllText (nuget_conf,
+@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
 	<config>
 		<clear />
 	</config>
 </configuration>
 ");
-				}
-				var global_json = Path.Combine (rv, "global.json");
-				if (!File.Exists (global_json) || true) {
-					if (Directory.GetDirectories ("/usr/local/share/dotnet/sdk", "2.2.1*", SearchOption.TopDirectoryOnly).Length > 0) {
-						// Workaround for https://github.com/NuGet/Home/issues/7956
-						// See also:
-						// * https://github.com/mono/mono/issues/13537
-						File.WriteAllText (global_json,
-							@"{
+		}
+
+		static void CreateGlobalConfig (string root)
+		{
+			var global_json = Path.Combine (root, "global.json");
+			// Workaround for https://github.com/NuGet/Home/issues/7956
+			// See also:
+			// * https://github.com/mono/mono/issues/13537
+			// * https://github.com/xamarin/maccore/issues/1811
+			// The version number here must match the version in tools/devops/build-samples.csx
+			File.WriteAllText (global_json,
+				@"{
 ""sdk"": {
-	""version"": ""2.2.100""
+	""version"": ""2.2.204""
 }
 			}
 ");
-					} else {
-						Console.WriteLine ("Could not detect dotnet v2.2.1*; some projects may fail to build due to https://github.com/NuGet/Home/issues/7956.");
-					}
-				}
-				return rv;
-			}
 		}
 	}
 }

--- a/tools/devops/build-samples.csx
+++ b/tools/devops/build-samples.csx
@@ -65,3 +65,7 @@ Exec ("ln", "-Fhs", xcode_path, "/Applications/Xcode.app");
 
 // Provisioning profiles
 Exec ($"../../../maccore/tools/install-qa-provisioning-profiles.sh");
+
+// .NET core
+// The version number here must match the one in Xamarin.Tests.Configuration:CreateGlobalConfig (tests/sampletester/Configuration.cs).
+DotNetCoreSdk ("2.2.204");


### PR DESCRIPTION
Also synchronize configuration file creation to not run into threading issues.

Fixes https://github.com/xamarin/maccore/issues/1811.

This is a backport of #6473.