### PR TITLE
[BackgroundTasks] Ensure requests are not abstract.

### DIFF
--- a/src/backgroundtasks.cs
+++ b/src/backgroundtasks.cs
@@ -14,7 +14,6 @@ using ObjCRuntime;
 
 namespace BackgroundTasks {
 
-	[Abstract]
 	[TV (13,0), NoWatch, NoMac, iOS (13,0)]
 	[BaseType (typeof (BGTaskRequest))]
 	[DisableDefaultCtor]


### PR DESCRIPTION
Requests cannot be abstract because is the only way a developer can
trigger a task to be queued. Only the base class should be abstract.