### PR TITLE
[sampletester] Provision Xcode when it's not already available. Fixes #6326.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ jenkins-results
 bcl-test-importer
 tests/bcl-test/BCLTests/generated
 tests/xharness/System.ValueTuple.xml
+provisionator.msbuild.props

--- a/Make.config
+++ b/Make.config
@@ -43,11 +43,9 @@ IOS_PACKAGE_VERSION_BUILD=$(IOS_COMMIT_DISTANCE)
 IOS_PACKAGE_UPDATE_ID=$(shell printf "2%02d%02d%02d%03d" $(IOS_PACKAGE_VERSION_MAJOR) $(IOS_PACKAGE_VERSION_MINOR) $(IOS_PACKAGE_VERSION_REV) $(IOS_PACKAGE_VERSION_BUILD))
 
 # Xcode version should have both a major and a minor version (even if the minor version is 0)
-# The provisionator name is the filename on our servers minus the "Xcode_" prefix (https://dl.internalx.com/xcodes/Xcode_11_Beta_3.xip -> 11_Beta_3)
 XCODE_VERSION=11.0
 XCODE_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_11_Beta_3.xip
 XCODE_DEVELOPER_ROOT=/Applications/Xcode11-beta3.app/Contents/Developer
-XCODE_PROVISIONATOR_NAME=11_Beta_3
 
 XCODE94_VERSION=9.4
 XCODE94_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_9.4.xip

--- a/Make.config
+++ b/Make.config
@@ -43,9 +43,11 @@ IOS_PACKAGE_VERSION_BUILD=$(IOS_COMMIT_DISTANCE)
 IOS_PACKAGE_UPDATE_ID=$(shell printf "2%02d%02d%02d%03d" $(IOS_PACKAGE_VERSION_MAJOR) $(IOS_PACKAGE_VERSION_MINOR) $(IOS_PACKAGE_VERSION_REV) $(IOS_PACKAGE_VERSION_BUILD))
 
 # Xcode version should have both a major and a minor version (even if the minor version is 0)
+# The provisionator name is the filename on our servers minus the "Xcode_" prefix (https://dl.internalx.com/xcodes/Xcode_11_Beta_3.xip -> 11_Beta_3)
 XCODE_VERSION=11.0
 XCODE_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_11_Beta_3.xip
 XCODE_DEVELOPER_ROOT=/Applications/Xcode11-beta3.app/Contents/Developer
+XCODE_PROVISIONATOR_NAME=11_Beta_3
 
 XCODE94_VERSION=9.4
 XCODE94_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_9.4.xip

--- a/tools/devops/build-samples.csx
+++ b/tools/devops/build-samples.csx
@@ -60,8 +60,19 @@ InstallPackage ("Objective-Sharpie", FindVariable ("MIN_SHARPIE_URL"));
 
 // Xcode
 var xcode_path = Path.GetDirectoryName (Path.GetDirectoryName (FindVariable ("XCODE_DEVELOPER_ROOT")));
-Console.WriteLine ($"ln -Fhs {xcode_path} /Applications/Xcode.app");
-Exec ("ln", "-Fhs", xcode_path, "/Applications/Xcode.app");
+if (!Directory.Exists (xcode_path)) {
+	var root = Path.GetDirectoryName (Path.GetDirectoryName (FindVariable ("XCODE_DEVELOPER_ROOT")));
+	Console.WriteLine ($"Could not find an already installed Xcode in {root}, will download and install.");
+	var xcode_provisionator_name = FindVariable ("XCODE_PROVISIONATOR_NAME");
+	Xcode (xcode_provisionator_name).XcodeSelect ();
+	Console.WriteLine ($"ln -Fhs /Applications/Xcode.app {root}");
+	Exec ("ln", "-Fhs", "/Applications/Xcode.app", root);
+	Exec ("ls", "-la", "/Applications");
+} else {
+	Console.WriteLine ($"ln -Fhs {xcode_path} /Applications/Xcode.app");
+	Exec ("ln", "-Fhs", xcode_path, "/Applications/Xcode.app");
+}
 
 // Provisioning profiles
+Console.WriteLine ("Provisioning provisioning profiles...")
 Exec ($"../../../maccore/tools/install-qa-provisioning-profiles.sh");

--- a/tools/devops/build-samples.csx
+++ b/tools/devops/build-samples.csx
@@ -1,5 +1,4 @@
 #load "utils.csx"
-#load "../../../maccore/tools/devops/external-deps.csx" // this will map the Xcode locations from Azure into our expected locations using symlinks.
 
 using System.Collections.Generic;
 using System.IO;
@@ -13,7 +12,7 @@ using Newtonsoft.Json.Linq;
 using Xamarin.Provisioning;
 using Xamarin.Provisioning.Model;
 
-// Provision Mono, XI, XM, Mono, Objective-Sharpie, Xcode, provisioning profiles.
+// Provision Mono, XI, XM, Mono, Objective-Sharpie, provisioning profiles.
 //
 // We get Mono from the current commit's MIN_MONO_URL value in Make.config
 // We get XI and XM from the current commit's manifest from GitHub's statuses
@@ -57,21 +56,6 @@ InstallPackage ("Mono", FindVariable ("MIN_MONO_URL"));
 InstallPackage ("Xamarin.iOS", FindVariable ("XI_PACKAGE"));
 InstallPackage ("Xamarin.Mac", FindVariable ("XM_PACKAGE"));
 InstallPackage ("Objective-Sharpie", FindVariable ("MIN_SHARPIE_URL"));
-
-// Xcode
-var xcode_path = Path.GetDirectoryName (Path.GetDirectoryName (FindVariable ("XCODE_DEVELOPER_ROOT")));
-if (!Directory.Exists (xcode_path)) {
-	var root = Path.GetDirectoryName (Path.GetDirectoryName (FindVariable ("XCODE_DEVELOPER_ROOT")));
-	Console.WriteLine ($"Could not find an already installed Xcode in {root}, will download and install.");
-	var xcode_provisionator_name = FindVariable ("XCODE_PROVISIONATOR_NAME");
-	Xcode (xcode_provisionator_name).XcodeSelect ();
-	Console.WriteLine ($"ln -Fhs /Applications/Xcode.app {root}");
-	Exec ("ln", "-Fhs", "/Applications/Xcode.app", root);
-	Exec ("ls", "-la", "/Applications");
-} else {
-	Console.WriteLine ($"ln -Fhs {xcode_path} /Applications/Xcode.app");
-	Exec ("ln", "-Fhs", xcode_path, "/Applications/Xcode.app");
-}
 
 // Provisioning profiles
 Console.WriteLine ("Provisioning provisioning profiles...");

--- a/tools/devops/build-samples.csx
+++ b/tools/devops/build-samples.csx
@@ -74,5 +74,5 @@ if (!Directory.Exists (xcode_path)) {
 }
 
 // Provisioning profiles
-Console.WriteLine ("Provisioning provisioning profiles...")
+Console.WriteLine ("Provisioning provisioning profiles...");
 Exec ($"../../../maccore/tools/install-qa-provisioning-profiles.sh");

--- a/tools/devops/build-samples.yml
+++ b/tools/devops/build-samples.yml
@@ -81,9 +81,10 @@ jobs:
   - bash: ./tools/devops/fetch-maccore.sh
     displayName: Fetch maccore
 
-  - task: xamops.azdevex.provisionator-task.provisionator@1
+  - task: provisionator@2
     displayName: Provision XI/XM/Mono/Xcode/Objective-Sharpie
     inputs:
+      provisionator_uri: '$(provisionator-uri)'
       github_token: '$(github-pat)'
       provisioning_script: $(System.DefaultWorkingDirectory)/tools/devops/build-samples.csx
 

--- a/tools/devops/build-samples.yml
+++ b/tools/devops/build-samples.yml
@@ -84,6 +84,7 @@ jobs:
   - task: xamops.azdevex.provisionator-task.provisionator@1
     displayName: Provision XI/XM/Mono/Xcode/Objective-Sharpie
     inputs:
+      github_token: '$(github-pat)'
       provisioning_script: $(System.DefaultWorkingDirectory)/tools/devops/build-samples.csx
 
   - bash: ./tools/devops/system-info.sh

--- a/tools/devops/build-samples.yml
+++ b/tools/devops/build-samples.yml
@@ -82,7 +82,14 @@ jobs:
     displayName: Fetch maccore
 
   - task: provisionator@2
-    displayName: Provision XI/XM/Mono/Xcode/Objective-Sharpie
+    displayName: Xcode
+    inputs:
+      provisionator_uri: '$(provisionator-uri)'
+      github_token: '$(github-pat)'
+      provisioning_script: $(System.DefaultWorkingDirectory)/tools/devops/provision-xcode.csx
+
+  - task: provisionator@2
+    displayName: Provision XI/XM/Mono/Objective-Sharpie
     inputs:
       provisionator_uri: '$(provisionator-uri)'
       github_token: '$(github-pat)'

--- a/tools/devops/provision-xcode.csx
+++ b/tools/devops/provision-xcode.csx
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json.Linq;
+
+using Xamarin.Provisioning;
+using Xamarin.Provisioning.Model;
+
+// Provision Xcode
+//
+// Overrides:
+// * The current commit can be overridden by setting the PROVISION_FROM_COMMIT variable.
+
+var commit = Environment.GetEnvironmentVariable ("BUILD_SOURCEVERSION");
+var provision_from_commit = Environment.GetEnvironmentVariable ("PROVISION_FROM_COMMIT") ?? commit;
+
+// Looks for a variable either in the environment, or in current repo's Make.config.
+// Returns null if the variable couldn't be found.
+IEnumerable<string> make_config = null;
+string FindConfigurationVariable (string variable, string hash = "HEAD")
+{
+	var value = Environment.GetEnvironmentVariable (variable);
+	if (!string.IsNullOrEmpty (value))
+		return value;
+
+	if (make_config == null)
+		make_config = Exec ("git", "show", $"{hash}:Make.config");
+	foreach (var line in make_config) {
+		if (line.StartsWith (variable + "=", StringComparison.Ordinal))
+			return line.Substring (variable.Length + 1);
+	}
+
+	return null;
+}
+
+string FindVariable (string variable)
+{
+	var value = FindConfigurationVariable (variable, provision_from_commit);
+	if (!string.IsNullOrEmpty (value))
+		return value;
+
+	throw new Exception ($"Could not find {variable} in environment nor in the commit's ({commit}) manifest.");
+}
+
+void ExecVerbose (string filename, params string[] args)
+{
+	Console.WriteLine ($"{filename} {string.Join (" ", args)}");
+	Exec (filename, args);
+}
+
+void ListXcodes ()
+{
+	Console.WriteLine ($"Xcodes:");
+	var lines = Exec ("bash", "-c", "ls -lad /Applications/Xcode*");
+	foreach (var line in lines)
+		Console.WriteLine ($"\t{line}");
+}
+
+if (string.IsNullOrEmpty (provision_from_commit)) {
+	Console.Error.WriteLine ($"Either BUILD_SOURCEVERSION or PROVISION_FROM_COMMIT must be set.");
+	Environment.Exit (1);
+	return 1;
+}
+
+ListXcodes ();
+
+// Provision Xcode
+Console.WriteLine ($"Provisioning Xcode from {provision_from_commit}...");
+var xcode_path = Path.GetDirectoryName (Path.GetDirectoryName (FindVariable ("XCODE_DEVELOPER_ROOT")));
+if (!Directory.Exists (xcode_path)) {
+	// Provision
+	var root = Path.GetDirectoryName (Path.GetDirectoryName (FindVariable ("XCODE_DEVELOPER_ROOT")));
+	var url = FindVariable ("XCODE_URL");
+	Console.WriteLine ($"Could not find an already installed Xcode in {root}, will download and install from {url}.");
+	var xcode_provisionator_name = Path.GetFileNameWithoutExtension (url).Substring (6); // Strip off 'Xcode_' from the start of the filename
+	Xcode (xcode_provisionator_name)
+		.XcodeSelect ()
+		.Action ((v) => {
+			ExecVerbose ("ln", "-Fhs", "/Applications/Xcode.app", root);
+			ListXcodes ();
+		});
+} else {
+	// We already have it, symlink into /Applications/Xcode.app
+	Console.WriteLine ($"The required Xcode is already installed.");
+	ExecVerbose ("ln", "-Fhs", xcode_path, "/Applications/Xcode.app");
+}


### PR DESCRIPTION
Add a separate provisioning script to install Xcode if it's not already installed on the bot.

For some unknown reason it needs to be a separate script, otherwise the provisionator will complain it doesn't know the required GitHub token to download Xcode.

Fixes https://github.com/xamarin/xamarin-macios/issues/6326.