### PR TITLE
[monotouch-test] Disable the MidiThruConnectionTests tests, they're randomly failing.

### DIFF
--- a/tests/monotouch-test/CoreMidi/MidiThruConnectionTests.cs
+++ b/tests/monotouch-test/CoreMidi/MidiThruConnectionTests.cs
@@ -24,6 +24,7 @@ namespace MonoTouchFixtures.CoreMidi {
 
 	[TestFixture]
 	[Preserve (AllMembers = true)]
+	[Ignore ("https://github.com/xamarin/maccore/issues/1834")]
 	public class MidiThruConnectionTests {
 
 		[Test]


### PR DESCRIPTION
Ref: https://github.com/xamarin/maccore/issues/1834