### PR TITLE
[tests] The watchOS 3.2 simulator is unusable, so use the 4.0 simulator instead. Fixes xamarin/maccore#1835.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -95,12 +95,12 @@ MIN_TVOS_SDK_VERSION=9.0
 
 # The min simulator version available in the Xcode we're using
 MIN_IOS_SIMULATOR_VERSION=10.3
-MIN_WATCHOS_SIMULATOR_VERSION=3.2
+MIN_WATCHOS_SIMULATOR_VERSION=4.0
 # This is the iOS version that matches the watchOS version (i.e same Xcode)
-MIN_WATCHOS_COMPANION_SIMULATOR_VERSION=10.3
+MIN_WATCHOS_COMPANION_SIMULATOR_VERSION=11.0
 MIN_TVOS_SIMULATOR_VERSION=10.2
 # These are the simulator package ids for the versions above
-EXTRA_SIMULATORS=com.apple.pkg.iPhoneSimulatorSDK10_3 com.apple.pkg.AppleTVSimulatorSDK10_2 com.apple.pkg.WatchSimulatorSDK3_2
+EXTRA_SIMULATORS=com.apple.pkg.iPhoneSimulatorSDK10_3 com.apple.pkg.iPhoneSimulatorSDK11_0 com.apple.pkg.AppleTVSimulatorSDK10_2 com.apple.pkg.WatchSimulatorSDK4_0
 
 INCLUDE_IOS=1
 INCLUDE_MAC=1

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -647,6 +647,14 @@ namespace Introspection {
 					return true;
 				}
 				break;
+			case "INParameter":
+				switch (selectorName) {
+				case "copyWithZone:":
+					if (!TestRuntime.CheckXcodeVersion (10, 0))
+						return true;
+					break;
+				}
+				break;
 			}
 
 			// old binding mistake


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/1835.