### PR TITLE
[apitest] Remove comment about fixed crasher.

### DIFF
--- a/tests/apitest/src/AppKit/NSTextInputClient.cs
+++ b/tests/apitest/src/AppKit/NSTextInputClient.cs
@@ -49,7 +49,6 @@ namespace apitest
 			Assert.IsTrue (textView.HasMarkedText, "NSTextInputClient_ShouldMarkText - Failed to mark text");
 			Assert.AreEqual (textView.MarkedRange, new NSRange (5, 7));
 
-			// Unmarking the text fixes a crasher: https://github.com/xamarin/maccore/issues/1794
 			textView.UnmarkText ();
 		}
 


### PR DESCRIPTION
Apple fixed the crasher on their side, so the comment is obsolete now.

I'm leaving the workaround, since it's still sensible code: the test class is
using a NSTextView instance across all test methods, and the workaround leaves
the NSTextView instance like it was before this particular test.