### PR TITLE
[ARKit] Uncomment bindings that only work on device.

### DIFF
--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -1892,15 +1892,13 @@ namespace ARKit {
 	[DisableDefaultCtor]
 	interface ARSkeletonDefinition {
 
-		// Present in the header, but not at runtime. https://github.com/xamarin/maccore/issues/1828
-		// [Static]
-		// [Export ("defaultBody3DSkeletonDefinition")]
-		// ARSkeletonDefinition DefaultBody3DSkeletonDefinition { get; }
+		[Static]
+		[Export ("defaultBody3DSkeletonDefinition")]
+		ARSkeletonDefinition DefaultBody3DSkeletonDefinition { get; }
 
-		// Present in the header, but not at runtime. https://github.com/xamarin/maccore/issues/1828
-		// [Static]
-		// [Export ("defaultBody2DSkeletonDefinition")]
-		// ARSkeletonDefinition DefaultBody2DSkeletonDefinition { get; }
+		[Static]
+		[Export ("defaultBody2DSkeletonDefinition")]
+		ARSkeletonDefinition DefaultBody2DSkeletonDefinition { get; }
 
 		[Export ("jointCount")]
 		nuint JointCount { get; }
@@ -1914,9 +1912,8 @@ namespace ARKit {
 		[NullAllowed, Export ("neutralBodySkeleton3D")]
 		ARSkeleton3D NeutralBodySkeleton3D { get; }
 
-		// Present in the header, but not at runtime. https://github.com/xamarin/maccore/issues/1828
-		// [Export ("indexForJointName:")]
-		// nuint GetJointIndex ([BindAs (typeof (ARSkeletonJointName))] NSString jointName);
+		[Export ("indexForJointName:")]
+		nuint GetJointIndex ([BindAs (typeof (ARSkeletonJointName))] NSString jointName);
 	}
 
 	[iOS (13,0)]

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -647,6 +647,19 @@ namespace Introspection {
 					return true;
 				}
 				break;
+#if !__MONOMAC__
+			case "ARSkeletonDefinition":
+				switch (selectorName) {
+				case "indexForJointName:":
+				case "defaultBody2DSkeletonDefinition":
+				case "defaultBody3DSkeletonDefinition":
+					// This selector does not exist in the simulator
+					if (Runtime.Arch == Arch.SIMULATOR)
+						return true;
+					break;
+				}
+				break;
+#endif
 			}
 
 			// old binding mistake

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -647,7 +647,7 @@ namespace Introspection {
 					return true;
 				}
 				break;
-#if !__MONOMAC__
+#if !__MACOS__
 			case "ARSkeletonDefinition":
 				switch (selectorName) {
 				case "indexForJointName:":

--- a/tests/xtro-sharpie/iOS-ARKit.ignore
+++ b/tests/xtro-sharpie/iOS-ARKit.ignore
@@ -11,8 +11,3 @@
 
 # only exposed in subclasses (it's static but also abstract) - see https://github.com/xamarin/xamarin-macios/issues/5347
 !missing-selector! +ARConfiguration::supportedVideoFormats not bound
-
-# Broken headers showing inexistent functions (https://github.com/xamarin/maccore/issues/1828)
-!missing-selector! +ARSkeletonDefinition::defaultBody2DSkeletonDefinition not bound
-!missing-selector! +ARSkeletonDefinition::defaultBody3DSkeletonDefinition not bound
-!missing-selector! ARSkeletonDefinition::indexForJointName: not bound


### PR DESCRIPTION
And adjust the introspection tests accordingly.

Ref: https://github.com/xamarin/maccore/issues/1828