### PR TITLE
[Introspection] Add missing acronyms.

### DIFF
--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -311,12 +311,14 @@ namespace Introspection
 			"Kullback", // Kullback-Leibler Divergence
 			"Langauges",
 			"Lacunarity",
+			"Latm", //  Low Overhead Audio Transport Multiplex
 			"Ldaps",
 			"Lerp",
 			"Linecap",
 			"Lingustic",
 			"libcompression",
 			"libdispatch",
+			"Loas", // Low Overhead Audio Stream 
 			"Lod",
 			"Lopass",
 			"Lowlevel",


### PR DESCRIPTION
Add missing bluetooth acronyms.

Fixes: https://github.com/xamarin/maccore/issues/1853