### PR TITLE
[d16-3] [Generator] NSValueReturnMap is registering CATransform3D on HaveCoreMedia insteand of HaveCoreAnimation.

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1477,7 +1477,7 @@ public partial class Generator : IMemberGatherer {
 					nsvalue_return_map [TypeManager.CMTimeMapping] = ".CMTimeMappingValue";
 				}
 
-				if (Frameworks.HaveCoreMedia)
+				if (Frameworks.HaveCoreAnimation)
 					nsvalue_return_map [TypeManager.CATransform3D] = ".CATransform3DValue";
 			}
 			return nsvalue_return_map;


### PR DESCRIPTION
The CATransform3D is present in the CoreAnimation framework not
CoreMedia.

Fixes https://github.com/xamarin/xamarin-macios/issues/6518

Backport of #6519.

/cc @mandel-macaque 