### PR TITLE
[mmptest] Port link-keep-resources-1 to Unified. Partial fix for #4975.

### DIFF
--- a/tests/mmptest/regression/Makefile
+++ b/tests/mmptest/regression/Makefile
@@ -11,7 +11,6 @@ export XamarinMacFrameworkRoot=$(MAC_DESTDIR)/Library/Frameworks/Xamarin.Mac.fra
 
 
 TESTS_4_0 = \
-	link-keep-resources-1 \
 	link-preserve-assembly \
 	link-uithread-1 \
 	link-uithread-2 \
@@ -34,8 +33,9 @@ DISABLED_TESTS_MONO_4_4 =  \
 	link-remove-attributes-1
 
 TESTS_UNIFIED = \
+	custom-bundle-name \
+	link-keep-resources-1 \
 	link-posix-1 \
-	custom-bundle-name
 
 TESTS_4_5 = \
 	link-callfilepath-45 \

--- a/tests/mmptest/regression/link-keep-resources-1/LinkKeepResources1.cs
+++ b/tests/mmptest/regression/link-keep-resources-1/LinkKeepResources1.cs
@@ -4,14 +4,14 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using System.Reflection;
-using MonoMac.Foundation;
-using MonoMac.AppKit;
-using MonoMac.ObjCRuntime;
+
+using AppKit;
+using Foundation;
+using ObjCRuntime;
 
 // Test
 // * application is linked with i18n CJK support
-// * application uses SystemSounds
-// * linker includes resources for all .wav (System) and i18n + CJK
+// * linker includes resources for i18n + CJK
 //
 // Requirement
 // * Link SDK or Link All must be enabled
@@ -33,10 +33,6 @@ namespace Xamarin.Mac.Linker.Test {
 					cjk++;
 			}
 			Test.Log.WriteLine ("{0}\tCJK {1}/5 data files present", cjk == 5 ? "[PASS]" : "[FAIL]", cjk);
-
-			var ss = typeof (System.Media.SystemSounds);
-			resources = ss.Assembly.GetManifestResourceNames ();
-			Test.Log.WriteLine ("{0}\tSystemSounds {1}/5 .wav files present", resources.Length == 5 ? "[PASS]" : "[FAIL]", resources.Length);
 
 			Test.Terminate ();
 		}

--- a/tests/mmptest/regression/link-keep-resources-1/link-keep-resources-1.csproj
+++ b/tests/mmptest/regression/link-keep-resources-1/link-keep-resources-1.csproj
@@ -6,11 +6,13 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{0A4EBB71-92E1-448C-BAA6-DFFB9491D8A0}</ProjectGuid>
-    <ProjectTypeGuids>{42C0BBD9-55CE-4FC1-8D90-A7348ABAFB23};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
     <RootNamespace>linkkeepresources1</RootNamespace>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
     <AssemblyName>link-keep-resources-1</AssemblyName>
+    <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>True</DebugSymbols>
@@ -26,12 +28,9 @@
     <CreatePackage>False</CreatePackage>
     <CodeSigningKey>Mac Developer</CodeSigningKey>
     <EnableCodeSigning>False</EnableCodeSigning>
-    <ConsolePause>False</ConsolePause>
     <PlatformTarget>x86</PlatformTarget>
-    <PackageSigningKey>Developer ID Installer</PackageSigningKey>
     <I18n>cjk</I18n>
     <LinkMode>Full</LinkMode>
-    <UseRefCounting>false</UseRefCounting>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DebugType>none</DebugType>
@@ -39,49 +38,24 @@
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <I18n>cjk</I18n>
     <LinkMode>Full</LinkMode>
     <UseSGen>False</UseSGen>
     <IncludeMonoRuntime>True</IncludeMonoRuntime>
     <EnablePackageSigning>False</EnablePackageSigning>
-    <CreatePackage>True</CreatePackage>
-    <CodeSigningKey>Developer ID Application</CodeSigningKey>
-    <EnableCodeSigning>True</EnableCodeSigning>
-    <ConsolePause>False</ConsolePause>
+    <CreatePackage>False</CreatePackage>
+    <CodeSigningKey>Mac Developer</CodeSigningKey>
+    <EnableCodeSigning>False</EnableCodeSigning>
     <PlatformTarget>x86</PlatformTarget>
-    <UseRefCounting>false</UseRefCounting>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|x86' ">
-    <DebugType>none</DebugType>
-    <Optimize>True</Optimize>
-    <OutputPath>bin\x86\AppStore</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LinkMode>Full</LinkMode>
-    <UseSGen>False</UseSGen>
-    <IncludeMonoRuntime>True</IncludeMonoRuntime>
-    <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
-    <ConsolePause>False</ConsolePause>
-    <EnableCodeSigning>True</EnableCodeSigning>
-    <CodeSigningKey>3rd Party Mac Developer Application</CodeSigningKey>
-    <CreatePackage>True</CreatePackage>
-    <EnablePackageSigning>True</EnablePackageSigning>
-    <PlatformTarget>x86</PlatformTarget>
-    <UseRefCounting>false</UseRefCounting>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="XamMac">
-      <HintPath>..\..\..\..\src\build\compat\XamMac.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Resources\" />
+    <Reference Include="Xamarin.Mac" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\Mono\MonoMac\v0.0\Mono.MonoMac.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
   <ItemGroup>
     <InterfaceDefinition Include="..\common\MainMenu.xib">
       <Link>MainMenu.xib</Link>


### PR DESCRIPTION
This also means removing code that tests for shipped system sounds, since the
Modern profile's BCL doesn't contain the system sounds.

Fixes part of https://github.com/xamarin/xamarin-macios/issues/4975.