### PR TITLE
Remove outdated build status link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,6 @@
 
 # Xamarin.iOS & Xamarin.Mac #
 
-|              | Status                                    |
-|--------------|-------------------------------------------|
-| master       | [![xamarin-macios-builds-master][1]][2]   |
-
-[1]: https://jenkins.mono-project.com/view/Xamarin.MaciOS/job/xamarin-macios-builds-master/badge/icon
-[2]: https://jenkins.mono-project.com/view/Xamarin.MaciOS/job/xamarin-macios-builds-master
-
 ## Welcome!
 
 This module is the main repository for both **Xamarin.iOS** and **Xamarin.Mac**.


### PR DESCRIPTION
The linked Jenkins job hasn't been publishing builds for almost a year and you can get packages via the GitHub status on each commit now.