### PR TITLE
[mmptest] Port link-keep-resources-2 to Unified. Partial fix for #4975.

### DIFF
--- a/tests/mmptest/regression/Makefile
+++ b/tests/mmptest/regression/Makefile
@@ -35,6 +35,7 @@ DISABLED_TESTS_MONO_4_4 =  \
 TESTS_UNIFIED = \
 	custom-bundle-name \
 	link-keep-resources-1 \
+	link-keep-resources-2 \
 	link-posix-1 \
 
 TESTS_4_5 = \

--- a/tests/mmptest/regression/link-keep-resources-2/LinkKeepResources2.cs
+++ b/tests/mmptest/regression/link-keep-resources-2/LinkKeepResources2.cs
@@ -4,14 +4,13 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using System.Reflection;
-using MonoMac.Foundation;
-using MonoMac.AppKit;
-using MonoMac.ObjCRuntime;
+
+using AppKit;
+using Foundation;
+using ObjCRuntime;
 
 // Test
 // * application is linked without any i18n support
-// * application uses SystemIcons
-// * linker includes resources for all .ico (System.Drawing)
 //
 // Requirement
 // * Link SDK or Link All must be enabled
@@ -32,11 +31,6 @@ namespace Xamarin.Mac.Linker.Test {
 			var ss = typeof (System.ComponentModel.TypeConverter);
 			resources = ss.Assembly.GetManifestResourceNames ();
 			Test.Log.WriteLine ("{0}\tSystemSounds {1}/0 .wav files present", resources.Length == 0 ? "[PASS]" : "[FAIL]", resources.Length);
-
-			var si = typeof (System.Drawing.SystemIcons);
-			resources = si.Assembly.GetManifestResourceNames ();
-			// Mono 2.10 ships with 5 .ico while Mono 3.0 provides 6 .ico resource files
-			Test.Log.WriteLine ("{0}\tSystemIcons {1}/[5-6] .ico files present", resources.Length >= 5 ? "[PASS]" : "[FAIL]", resources.Length);
 
 			Test.Terminate ();
 		}

--- a/tests/mmptest/regression/link-keep-resources-2/link-keep-resources-2.csproj
+++ b/tests/mmptest/regression/link-keep-resources-2/link-keep-resources-2.csproj
@@ -6,11 +6,13 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{9D5EA758-05CE-416C-B2D1-523E481C0DCD}</ProjectGuid>
-    <ProjectTypeGuids>{42C0BBD9-55CE-4FC1-8D90-A7348ABAFB23};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
     <RootNamespace>linkkeepresources2</RootNamespace>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
     <AssemblyName>link-keep-resources-2</AssemblyName>
+    <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>True</DebugSymbols>
@@ -25,14 +27,10 @@
     <CreatePackage>False</CreatePackage>
     <CodeSigningKey>Mac Developer</CodeSigningKey>
     <EnableCodeSigning>False</EnableCodeSigning>
-    <ConsolePause>False</ConsolePause>
     <PlatformTarget>x86</PlatformTarget>
-    <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
-    <I18n>
-    </I18n>
+    <I18n></I18n>
     <LinkMode>Full</LinkMode>
-    <UseSGen>false</UseSGen>
-    <UseRefCounting>false</UseRefCounting>
+    <UseSGen>True</UseSGen>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DebugType>none</DebugType>
@@ -40,47 +38,24 @@
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LinkMode>Full</LinkMode>
-    <IncludeMonoRuntime>False</IncludeMonoRuntime>
-    <EnablePackageSigning>False</EnablePackageSigning>
-    <CreatePackage>False</CreatePackage>
-    <CodeSigningKey>Mac Developer</CodeSigningKey>
-    <EnableCodeSigning>False</EnableCodeSigning>
-    <ConsolePause>False</ConsolePause>
-    <PlatformTarget>x86</PlatformTarget>
-    <UseSGen>false</UseSGen>
-    <UseRefCounting>false</UseRefCounting>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|x86' ">
-    <DebugType>none</DebugType>
-    <Optimize>True</Optimize>
-    <OutputPath>bin\x86\AppStore</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <I18n></I18n>
     <LinkMode>Full</LinkMode>
     <IncludeMonoRuntime>True</IncludeMonoRuntime>
-    <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
-    <EnablePackageSigning>True</EnablePackageSigning>
-    <CreatePackage>True</CreatePackage>
-    <CodeSigningKey>3rd Party Mac Developer Application</CodeSigningKey>
-    <EnableCodeSigning>True</EnableCodeSigning>
-    <ConsolePause>False</ConsolePause>
+    <EnablePackageSigning>False</EnablePackageSigning>
+    <UseSGen>True</UseSGen>
+    <CodeSigningKey>Mac Developer</CodeSigningKey>
+    <EnableCodeSigning>False</EnableCodeSigning>
+    <CreatePackage>False</CreatePackage>
     <PlatformTarget>x86</PlatformTarget>
-    <UseSGen>false</UseSGen>
-    <UseRefCounting>false</UseRefCounting>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="XamMac">
-      <HintPath>..\..\..\..\src\build\compat\XamMac.dll</HintPath>
-    </Reference>
+    <Reference Include="Xamarin.Mac" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\Mono\MonoMac\v0.0\Mono.MonoMac.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
   <ItemGroup>
     <InterfaceDefinition Include="..\common\MainMenu.xib">
       <Link>MainMenu.xib</Link>


### PR DESCRIPTION
This also means removing code that tests for shipped system icons, since the
Modern profile's BCL doesn't contain the system icons.

Fixes part of https://github.com/xamarin/xamarin-macios/issues/4975.