### PR TITLE
[mmptest] Port link-frameworks-1 to Unified and improve it. Partial fix for #4975.

### DIFF
--- a/tests/mmptest/regression/Makefile
+++ b/tests/mmptest/regression/Makefile
@@ -15,7 +15,6 @@ TESTS_4_0 = \
 	link-uithread-1 \
 	link-uithread-2 \
 	link-safe-1 \
-	link-frameworks-1 \
 	embedded-mono \
 	system-mono \
 	embedded-mono-profile \
@@ -32,6 +31,7 @@ DISABLED_TESTS_MONO_4_4 =  \
 
 TESTS_UNIFIED = \
 	custom-bundle-name \
+	link-frameworks-1 \
 	link-keep-resources-1 \
 	link-keep-resources-2 \
 	link-posix-1 \

--- a/tests/mmptest/regression/link-frameworks-1/LinkFrameworks1.cs
+++ b/tests/mmptest/regression/link-frameworks-1/LinkFrameworks1.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
-using MonoMac.Foundation;
-using MonoMac.AppKit;
+
+using AppKit;
+using Foundation;
 
 // Test
 // * application .exe only depends on Foundation and AppKit
@@ -12,50 +14,72 @@ using MonoMac.AppKit;
 namespace Xamarin.Mac.Linker.Test {
 	
 	class Framework {
-
-		static FieldInfo[] fields;
-
-		static void Check (string framework, string fieldName, bool exists)
+		static void TestFrameworks ()
 		{
-			bool found = false;
-			foreach (var fi in fields) {
-				if (fi.Name == fieldName) {
-					found = true;
+			var fields = typeof (NSObject).GetFields (BindingFlags.NonPublic | BindingFlags.Static);
+
+			// This is not meant to be a complete mapping, just to show better debug messages.
+			var mapping = new Dictionary<string, string> {
+				{ "fl", "Foundation" },
+				{ "al", "AppKit" },
+				{ "ab", "AddressBook" },
+				{ "ct", "CoreText" },
+				{ "wl", "WebKit" },
+				{ "zl", "QuartzCore" },
+				{ "ql", "QTKit" },
+				{ "ll", "Security" },
+				{ "zc", "QuartzComposer" },
+				{ "cw", "CoreWlan" },
+				{ "cl", "CoreLocation" },
+				{ "sk", "SceneKit" },
+				{ "mk", "MapKit" },
+				{ "bc", "BusinessChat" },
+				{ "un", "UserNotifications" },
+			};
+
+			foreach (var field in fields) {
+				if (field.FieldType != typeof (IntPtr))
+					continue;
+
+				if (!mapping.TryGetValue (field.Name, out var framework))
+					framework = "unknown";
+
+				switch (field.Name) {
+				case "selConformsToProtocolHandle":
+				case "selDescriptionHandle":
+				case "selHashHandle":
+				case "selIsEqual_Handle":
+				case "class_ptr":
+					// Unrelated fields
+					continue;
+				case "fl": // Foundation
+				case "al": // AppKit
+					Test.Log.WriteLine ($"[PASS] As expected found field NSObject.{field.Name} for framework '{framework}'.");
+					continue;
+				case "zl": // QuartzCore (CoreAnimation)
+				case "cl": // CoreLocation
+				case "ll": // Security
+				case "sk": // SceneKit
+				case "mk": // MapKit
+				case "bc": // BusinessChat
+				case "un": // UserNotifications
+					// This needs investigation, it should be possible to link at least some of these frameworks away.
+					// https://github.com/xamarin/xamarin-macios/issues/6542
+					continue;
+				default:
+					Test.Log.WriteLine ($"[FAIL] Unexpectedly found field NSObject.{field.Name} for framework '{framework}'.");
 					break;
 				}
 			}
-			Test.Log.WriteLine ("[{0}] {1} is {2}", found == exists ? "PASS" : "FAIL", framework, exists ? "present" : "absent");
 		}
 
 		static void Main (string[] args)
 		{
 			NSApplication.Init ();
-			
+
 			Test.EnsureLinker (true);
 
-			fields = typeof(NSObject).GetFields (BindingFlags.NonPublic | BindingFlags.Static);
-
-			// Foundation, AppKit will be present (would be hard to remove)
-			Check ("Foundation", "fl", true);
-			Check ("AppKit", "al", true);
-			// Otherwise we should be able to eliminate the others
-			Check ("AddressBook", "ab", false);
-			Check ("CoreText", "ct", false);
-			Check ("WebKit", "wl", false);
-			Check ("Quartz", "zl", false);				// CoreAnimation
-			Check ("QTKit", "ql", false);
-			Check ("Security", "ll", false);
-			Check ("QuartzComposer", "zc", false);
-			Check ("CoreWlan", "cw", false);
-			Check ("PdfKit", "pk", false);
-			Check ("ImageKit", "ik", false);
-			Check ("ScriptingBridge", "sb", false);
-			Check ("AVFoundation", "av", false);
-			// not everyone of them are in NSObjectMac.cs
-			Check ("SceneKit", "sk", false);
-			Check ("CoreBluetooth", "bl", false);
-			Check ("StoreKit", "st", false);
-			Check ("GameKit", "gk", false);
+			TestFrameworks ();
 
 			Test.Terminate ();
 		}

--- a/tests/mmptest/regression/link-frameworks-1/link-frameworks-1.csproj
+++ b/tests/mmptest/regression/link-frameworks-1/link-frameworks-1.csproj
@@ -6,11 +6,13 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{842CDD77-7FC8-4BAB-AF69-C6C0D9DB217C}</ProjectGuid>
-    <ProjectTypeGuids>{42C0BBD9-55CE-4FC1-8D90-A7348ABAFB23};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
     <RootNamespace>linkframeworks1</RootNamespace>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
     <AssemblyName>link-frameworks-1</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -20,18 +22,14 @@
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <UseSGen>false</UseSGen>
+    <UseSGen>true</UseSGen>
     <IncludeMonoRuntime>true</IncludeMonoRuntime>
     <EnablePackageSigning>false</EnablePackageSigning>
     <CodeSigningKey>Mac Developer</CodeSigningKey>
     <EnableCodeSigning>false</EnableCodeSigning>
     <CreatePackage>false</CreatePackage>
     <PackageSigningKey>Developer ID Installer</PackageSigningKey>
-    <I18n>
-    </I18n>
     <LinkMode>Full</LinkMode>
-    <UseRefCounting>false</UseRefCounting>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -39,48 +37,22 @@
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
     <LinkMode>Full</LinkMode>
-    <UseSGen>false</UseSGen>
+    <UseSGen>true</UseSGen>
     <IncludeMonoRuntime>true</IncludeMonoRuntime>
     <EnablePackageSigning>false</EnablePackageSigning>
     <CodeSigningKey>Developer ID Application</CodeSigningKey>
     <EnableCodeSigning>true</EnableCodeSigning>
-    <CreatePackage>true</CreatePackage>
-    <UseRefCounting>false</UseRefCounting>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|AnyCPU' ">
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\AppStore</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
+    <CreatePackage>false</CreatePackage>
     <LinkMode>Full</LinkMode>
-    <UseSGen>false</UseSGen>
-    <IncludeMonoRuntime>true</IncludeMonoRuntime>
-    <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
-    <CreatePackage>true</CreatePackage>
-    <CodeSigningKey>3rd Party Mac Developer Application</CodeSigningKey>
-    <EnableCodeSigning>true</EnableCodeSigning>
-    <EnablePackageSigning>true</EnablePackageSigning>
-    <UseRefCounting>false</UseRefCounting>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="XamMac" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Resources\" />
+    <Reference Include="Xamarin.Mac" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
   <ItemGroup>
     <Compile Include="..\common\Test.cs">
       <Link>Test.cs</Link>


### PR DESCRIPTION
Port link-frameworks-1 to Unified and modify the test to examine all framework
references and have a whitelist of expected entries, instead of checking a
fixed list of frameworks, which doesn't catch problems when new frameworks are
introduced.

Fixes part of https://github.com/xamarin/xamarin-macios/issues/4975.