### PR TITLE
[tests] Improve handling of permission dialogs. Fixes xamarin/maccore#1856.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -403,6 +403,7 @@ timestamps {
                 workspace = "${env.HOME}/jenkins/workspace/xamarin-macios"
                 commentFile = "${workspace}/xamarin-macios/jenkins/pr-comments.md"
                 withEnv ([
+                    "BUILD_REVISION=jenkins",
                     "PATH=/Library/Frameworks/Mono.framework/Versions/Current/Commands:${env.PATH}",
                     "WORKSPACE=${workspace}"
                     ]) {

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -678,6 +678,26 @@ partial class TestRuntime
 			break;
 		}
 	}
+
+	public static void RequestContactsPermission (bool assert_granted = false)
+	{
+		switch (CNContactStore.GetAuthorizationStatus (CNEntityType.Contacts)) {
+		case CNAuthorizationStatus.NotDetermined:
+			if (IgnoreTestThatRequiresSystemPermissions ())
+				NUnit.Framework.Assert.Ignore ("This test would show a dialog to ask for permission to access the contacts.");
+
+			// There's a static method to check for permission, but an instance method to ask for permission
+			using (var store = new CNContactStore ()) {
+				store.RequestAccess (CNEntityType.Contacts, (granted, error) => {
+					Console.WriteLine ("Contacts permission {0} (error: {1})", granted ? "granted" : "denied", error);
+				});
+			}
+			break;
+		}
+
+		CheckContactsPermission (assert_granted);
+	}
+
 #endif // XAMCORE_2_0
 
 #if !MONOMAC && !__TVOS__ && !__WATCHOS__

--- a/tests/monotouch-test/Contacts/ContactFetchRequestTest.cs
+++ b/tests/monotouch-test/Contacts/ContactFetchRequestTest.cs
@@ -33,6 +33,7 @@ namespace MonoTouchFixtures.Contacts {
 		public void MinimumSdkCheck ()
 		{
 			TestRuntime.AssertXcodeVersion (7, 0);
+			TestRuntime.RequestContactsPermission ();
 		}
 
 		[Test]

--- a/tests/monotouch-test/Contacts/ContactVCardSerializationTest.cs
+++ b/tests/monotouch-test/Contacts/ContactVCardSerializationTest.cs
@@ -33,6 +33,7 @@ namespace MonoTouchFixtures.Contacts {
 		public void MinimumSdkCheck ()
 		{
 			TestRuntime.AssertXcodeVersion (7, 0);
+			TestRuntime.RequestContactsPermission ();
 		}
 
 		[Test]

--- a/tests/xharness/AppRunner.cs
+++ b/tests/xharness/AppRunner.cs
@@ -537,7 +537,7 @@ namespace xharness
 				args.Append ($" -setenv=BUILD_REVISION=${Environment.GetEnvironmentVariable ("BUILD_REVISION")}");
 			}
 
-			if (!Harness.IncludeSystemPermissionTests)
+			if (!Harness.GetIncludeSystemPermissionTests (TestPlatform.iOS, !isSimulator))
 				args.Append (" -setenv=DISABLE_SYSTEM_PERMISSION_TESTS=1");
 
 			if (isSimulator) {

--- a/tests/xharness/MakefileGenerator.cs
+++ b/tests/xharness/MakefileGenerator.cs
@@ -103,6 +103,8 @@ namespace xharness
 					writer.WriteLine ("\t$(Q_XBUILD) $(SYSTEM_XIBUILD) -- \"/property:Configuration=$(CONFIG)\" /t:Clean $(XBUILD_VERBOSITY) \"{0}\"", target.ProjectPath);
 					writer.WriteLine ();
 
+					if (!harness.GetIncludeSystemPermissionTests (TestPlatform.Mac, false))
+						writer.WriteTarget (MakeMacUnifiedTargetName (target, MacTargetNameType.Exec), "export DISABLE_SYSTEM_PERMISSION_TESTS=1");
 					writer.WriteTarget (MakeMacUnifiedTargetName (target, MacTargetNameType.Exec), "");
 					if (target.IsNUnitProject) {
 						writer.WriteLine ("\t$(Q)rm -f $(CURDIR)/.{0}-failed.stamp", make_escaped_name);


### PR DESCRIPTION
* macOS 10.15 starts putting up permission dialogs we can't automatically
  dismiss anymore, so start honoring the 'IncludeSystemPermissionTests' option
  for macOS tests.
* Improve the 'IncludeSystemPermissionTests' option to have three states: if
  set (either true or false), that takes precedence, but if not set, we now
  don't run any tests that require permission dialogs on macOS or on device if
  we're running in CI. Tests executed locally will still put up dialogs, both
  on macOS and on device.
* This needed a few changes to the html report, since the
  'IncludeSystemPermissionTests' is exposed in the UI and the code didn't
  handle the three different states.
* Update a few tests to check for permission to the contacts.

Fixes https://github.com/xamarin/maccore/issues/1856.