### PR TITLE
[mtouch] Work around regression in dyld. Fixes #6422.

### DIFF
--- a/tools/common/CompilerFlags.cs
+++ b/tools/common/CompilerFlags.cs
@@ -299,7 +299,7 @@ namespace Xamarin.Utils
 			}
 
 			if (Application.HasAnyDynamicLibraries) {
-				args.Append (" -Xlinker -rpath -Xlinker @executable_path");
+				args.Append (" -Xlinker -rpath -Xlinker @executable_path/");
 				if (Application.IsExtension)
 					args.Append (" -Xlinker -rpath -Xlinker @executable_path/../..");
 			}


### PR DESCRIPTION
It seems dyld doesn't like an rpath without a trailing slash for '@executable_path'.

Fixes https://github.com/xamarin/xamarin-macios/issues/6422.