### PR TITLE
[xcode11] Fix monotouch-test to not crash on device.

### DIFF
--- a/tests/monotouch-test/Info.plist
+++ b/tests/monotouch-test/Info.plist
@@ -27,6 +27,8 @@
 	<string>Testing mike</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Testing lens</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Testing world domination through blue teeth coloring</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -63,17 +63,20 @@ namespace MonoTouchFixtures.MediaAccessibility {
 
 			var temp = String.Empty;
 			using (NSUrl url = new NSUrl (NSBundle.MainBundle.ResourceUrl.AbsoluteString + "basn3p08.png")) {
-				Assert.True (MAImageCaptioning.SetCaption (url, "xamarin", out var e), "Set");
-				Assert.Null (e, "ro / set / no error"); // weird, it can't be saved back to the file metadata
+				// In Xcode 11 beta 3, the native P/Invoke will very helpfully crash if called with a read-only file path.
+				// So don't do that.
 
-				var s = MAImageCaptioning.GetCaption (url, out e);
-				Assert.Null (s, "ro / roundtrip"); // not very surprising since Set can't save it
-				Assert.Null (e, "ro / get / no error");
+				//Assert.True (MAImageCaptioning.SetCaption (url, "xamarin", out var e), "Set");
+				//Assert.Null (e, "ro / set / no error"); // weird, it can't be saved back to the file metadata
 
-				Assert.True (MAImageCaptioning.SetCaption (url, "xamarin", out e), "Set 2");
-				s = MAImageCaptioning.GetCaption (url, out e);
-				Assert.Null (s, "ro / back to original");
-				Assert.Null (e, "ro / get back / no error");
+				//var s = MAImageCaptioning.GetCaption (url, out e);
+				//Assert.Null (s, "ro / roundtrip"); // not very surprising since Set can't save it
+				//Assert.Null (e, "ro / get / no error");
+
+				//Assert.True (MAImageCaptioning.SetCaption (url, "xamarin", out e), "Set 2");
+				//s = MAImageCaptioning.GetCaption (url, out e);
+				//Assert.Null (s, "ro / back to original");
+				//Assert.Null (e, "ro / get back / no error");
 
 				// 2nd try with a read/write copy
 				temp = Path.Combine (Path.GetTempPath (), "basn3p08.png");

--- a/tests/monotouch-test/Metal/MTLDeviceTests.cs
+++ b/tests/monotouch-test/Metal/MTLDeviceTests.cs
@@ -277,7 +277,9 @@ namespace MonoTouchFixtures.Metal {
 			}
 
 			if (TestRuntime.CheckXcodeVersion (10, 0)) {
+#if __MACOS__
 				if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 14, 6)) // https://github.com/xamarin/maccore/issues/1801
+#endif
 				using (var descriptor = new MTLIndirectCommandBufferDescriptor ()) {
 					using (var library = device.CreateIndirectCommandBuffer (descriptor, 1, MTLResourceOptions.CpuCacheModeDefault)) {
 						Assert.IsNotNull (library, "CreateIndirectCommandBuffer: NonNull");


### PR DESCRIPTION
* Add permission description for CoreBluetooth. Fixes xamarin/maccore#1880.
* Don't check for the macOS system version when running on other platforms.
* Don't try to set image captions on read-only files.