### PR TITLE
Ensure Local TimeZone Id is Set For TimeZoneInfo.Local

### DIFF
--- a/runtime/xamarin-support.m
+++ b/runtime/xamarin-support.m
@@ -103,8 +103,6 @@ xamarin_timezone_get_names (int *count)
 
 //
 // Returns the geopolitical region ID of the local timezone.
-// Previously we just provided the data to TimeZoneInfo.MonoTouch.cs and that
-// defaulted the ID to "Local", which is incorrect. 
 
 const char *
 xamarin_timezone_get_local_name ()
@@ -112,7 +110,7 @@ xamarin_timezone_get_local_name ()
 	NSTimeZone *tz = nil;
 	tz = [NSTimeZone localTimeZone];
 	NSString *name = [tz name];
-	return strdup ([name UTF8String]);
+	return (name != nil) ? strdup ([name UTF8String]) : strdup ("Local");
 }
 
 #if !TARGET_OS_WATCH && !TARGET_OS_TV

--- a/runtime/xamarin-support.m
+++ b/runtime/xamarin-support.m
@@ -63,6 +63,11 @@ xamarin_log (const unsigned short *unicodeMessage)
 	[msg release];
 }
 
+// NOTE: The timezone functions are duplicated in mono, so if you're going to modify here, it would be nice
+// if we modify there.
+//
+// See in Mono sdks/ios/runtime/runtime.m
+
 void*
 xamarin_timezone_get_data (const char *name, int *size)
 {
@@ -94,6 +99,20 @@ xamarin_timezone_get_names (int *count)
 		result [i] = strdup (s.UTF8String);
 	}
 	return result;
+}
+
+//
+// Returns the geopolitical region ID of the local timezone.
+// Previously we just provided the data to TimeZoneInfo.MonoTouch.cs and that
+// defaulted the ID to "Local", which is incorrect. 
+
+const char *
+xamarin_timezone_get_local_name ()
+{
+	NSTimeZone *tz = nil;
+	tz = [NSTimeZone localTimeZone];
+	NSString *name = [tz name];
+	return strdup ([name UTF8String]);
 }
 
 #if !TARGET_OS_WATCH && !TARGET_OS_TV


### PR DESCRIPTION
Mirrors the runtime change found in https://github.com/mono/mono/pull/15667.

The fix here is to return the name of the local time zone so that TimeZoneInfo.Local
can have the correct Id.