### PR TITLE
[master] [tests] Don't use unsupported characters in matrix names for yml scripts. Fixes xamarin/maccore#1831.

### DIFF
--- a/tools/devops/build-samples-report-to-github.sh
+++ b/tools/devops/build-samples-report-to-github.sh
@@ -18,8 +18,8 @@ GH_STATE=success
 FILE=commit-comment.md
 
 for STEP in $STEPS; do
-  # The environment variable's name is the variation name in uppercase, and special symbols removed (|-)
-  STEPNAME=JOBRESULT$(echo "$STEP" | tr '[:lower:]' '[:upper:]' | sed -e 's/|//g' -e 's/-//g')
+  # The environment variable's name is the variation name in uppercase, and special symbols removed (|-_)
+  STEPNAME=JOBRESULT$(echo "$STEP" | tr '[:lower:]' '[:upper:]' | sed -e 's/|//g' -e 's/-//g' -e 's/_//g')
   STEPSTATUS=${!STEPNAME}
   if [[ "$STEPSTATUS" == "Succeeded" ]]; then
     STEPEMOJII="✅"

--- a/tools/devops/build-samples.yml
+++ b/tools/devops/build-samples.yml
@@ -31,40 +31,40 @@ jobs:
       # We have rougly 900 tests, which take a while to build for device.
       # So in that case, we split them in 3 buckets of roughly 300 tests each,
       # based on the first letter of the project's filename.
-      Debug|iPhone|A-F:
+      Debug_iPhone_AF:
         TEST_PLATFORM_FILTER_EXPRESSION: $(iphone_filter)
         TEST_CONFIG_FILTER_EXPRESSION: $(debug_filter)
         TEST_NAME_FILTER_EXPRESSION: $(name_filter_af)
-      Debug|iPhone|G-R:
+      Debug_iPhone_GR:
         TEST_PLATFORM_FILTER_EXPRESSION: $(iphone_filter)
         TEST_CONFIG_FILTER_EXPRESSION: $(debug_filter)
         TEST_NAME_FILTER_EXPRESSION: $(name_filter_gr)
-      Debug|iPhone|S-Z:
+      Debug_iPhone_SZ:
         TEST_PLATFORM_FILTER_EXPRESSION: $(iphone_filter)
         TEST_CONFIG_FILTER_EXPRESSION: $(debug_filter)
         TEST_NAME_FILTER_EXPRESSION: $(name_filter_rest)
-      Debug|iPhoneSimulator:
+      Debug_iPhoneSimulator:
         TEST_PLATFORM_FILTER_EXPRESSION: $(iphonesimulator_filter)
         TEST_CONFIG_FILTER_EXPRESSION: $(debug_filter)
-      Release|iPhone|A-F:
+      Release_iPhone_AF:
         TEST_PLATFORM_FILTER_EXPRESSION: $(iphone_filter)
         TEST_CONFIG_FILTER_EXPRESSION: $(release_filter)
         TEST_NAME_FILTER_EXPRESSION: $(name_filter_af)
-      Release|iPhone|G-R:
+      Release_iPhone_GR:
         TEST_PLATFORM_FILTER_EXPRESSION: $(iphone_filter)
         TEST_CONFIG_FILTER_EXPRESSION: $(release_filter)
         TEST_NAME_FILTER_EXPRESSION: $(name_filter_gr)
-      Release|iPhone|S-Z:
+      Release_iPhone_SZ:
         TEST_PLATFORM_FILTER_EXPRESSION: $(iphone_filter)
         TEST_CONFIG_FILTER_EXPRESSION: $(release_filter)
         TEST_NAME_FILTER_EXPRESSION: $(name_filter_rest)
-      Release|iPhoneSimulator:
+      Release_iPhoneSimulator:
         TEST_PLATFORM_FILTER_EXPRESSION: $(iphonesimulator_filter)
         TEST_CONFIG_FILTER_EXPRESSION: $(release_filter)
-      Debug|Mac:
+      Debug_Mac:
         TEST_PLATFORM_FILTER_EXPRESSION: $(mac_platform_filter)
         TEST_CONFIG_FILTER_EXPRESSION: $(debug_filter)
-      Release|Mac:
+      Release_Mac:
         TEST_PLATFORM_FILTER_EXPRESSION: $(mac_platform_filter)
         TEST_CONFIG_FILTER_EXPRESSION: $(release_filter)
 
@@ -114,24 +114,24 @@ jobs:
   pool:
     name: '$(macOSVersion)'
   variables:
-    jobResultDebugiPhoneAF: $[ dependencies.macOS.outputs['Debug|iPhone|A-F.ExportedVariables.JobStatus'] ]
-    jobResultDebugiPhoneGR: $[ dependencies.macOS.outputs['Debug|iPhone|G-R.ExportedVariables.JobStatus'] ]
-    jobResultDebugiPhoneSZ: $[ dependencies.macOS.outputs['Debug|iPhone|S-Z.ExportedVariables.JobStatus'] ]
-    jobResultDebugiPhoneSimulator: $[ dependencies.macOS.outputs['Debug|iPhoneSimulator.ExportedVariables.JobStatus'] ]
-    jobResultReleaseiPhoneAF: $[ dependencies.macOS.outputs['Release|iPhone|A-F.ExportedVariables.JobStatus'] ]
-    jobResultReleaseiPhoneGR: $[ dependencies.macOS.outputs['Release|iPhone|G-R.ExportedVariables.JobStatus'] ]
-    jobResultReleaseiPhoneSZ: $[ dependencies.macOS.outputs['Release|iPhone|S-Z.ExportedVariables.JobStatus'] ]
-    jobResultReleaseiPhoneSimulator: $[ dependencies.macOS.outputs['Release|iPhoneSimulator.ExportedVariables.JobStatus'] ]
-    jobResultDebugMac: $[ dependencies.macOS.outputs['Debug|Mac.ExportedVariables.JobStatus'] ]
-    jobResultReleaseMac: $[ dependencies.macOS.outputs['Release|Mac.ExportedVariables.JobStatus'] ]
+    jobResultDebugiPhoneAF: $[ dependencies.macOS.outputs['Debug_iPhone_AF.ExportedVariables.JobStatus'] ]
+    jobResultDebugiPhoneGR: $[ dependencies.macOS.outputs['Debug_iPhone_GR.ExportedVariables.JobStatus'] ]
+    jobResultDebugiPhoneSZ: $[ dependencies.macOS.outputs['Debug_iPhone_SZ.ExportedVariables.JobStatus'] ]
+    jobResultDebugiPhoneSimulator: $[ dependencies.macOS.outputs['Debug_iPhoneSimulator.ExportedVariables.JobStatus'] ]
+    jobResultReleaseiPhoneAF: $[ dependencies.macOS.outputs['Release_iPhone_AF.ExportedVariables.JobStatus'] ]
+    jobResultReleaseiPhoneGR: $[ dependencies.macOS.outputs['Release_iPhone_GR.ExportedVariables.JobStatus'] ]
+    jobResultReleaseiPhoneSZ: $[ dependencies.macOS.outputs['Release_iPhone_SZ.ExportedVariables.JobStatus'] ]
+    jobResultReleaseiPhoneSimulator: $[ dependencies.macOS.outputs['Release_iPhoneSimulator.ExportedVariables.JobStatus'] ]
+    jobResultDebugMac: $[ dependencies.macOS.outputs['Debug_Mac.ExportedVariables.JobStatus'] ]
+    jobResultReleaseMac: $[ dependencies.macOS.outputs['Release_Mac.ExportedVariables.JobStatus'] ]
   steps:
   - bash: |
       ./tools/devops/build-samples-report-to-github.sh "$(github-pat)" \
-        "Debug|iPhone|A-F" "Debug|iPhone|G-R" "Debug|iPhone|S-Z" \
-        "Debug|iPhoneSimulator" \
-        "Release|iPhone|A-F" "Release|iPhone|G-R" "Release|iPhone|S-Z" \
-        "Release|iPhoneSimulator" \
-        "Debug|Mac" \
-        "Release|Mac"
+        "Debug_iPhone_AF" "Debug_iPhone_GR" "Debug_iPhone_SZ" \
+        "Debug_iPhoneSimulator" \
+        "Release_iPhone_AF" "Release_iPhone_GR" "Release_iPhone_SZ" \
+        "Release_iPhoneSimulator" \
+        "Debug_Mac" \
+        "Release_Mac"
     displayName: Report results to GitHub as comment / status
     condition: always()


### PR DESCRIPTION
Matrix names must be alphanumeric (+underscore), and recently Azure DevOps
stopped working correctly if that wasn't the case (unfortunately without a
good error message though, so it took a while to figure it out).

Fixes https://github.com/xamarin/maccore/issues/1831.

Backport of #6531.

/cc @rolfbjarne 