### PR TITLE
[xammac_tests] Fix a few issues after the latest beta. Fixes xamarin/maccore#1886.

### DIFF
--- a/tests/monotouch-test/EventKit/CalendarTest.cs
+++ b/tests/monotouch-test/EventKit/CalendarTest.cs
@@ -118,8 +118,6 @@ namespace MonoTouchFixtures.EventKit {
 
 #if __WATCHOS__
 			Assert.True (c.Immutable, "Immutable");
-#elif MONOMAC
-			Assert.AreEqual (TestRuntime.CheckXcodeVersion (11, 0), c.Immutable, "Immutable");
 #else
 			Assert.False (c.Immutable, "Immutable");
 #endif

--- a/tests/xammac_tests/xammac_tests.csproj
+++ b/tests/xammac_tests/xammac_tests.csproj
@@ -168,6 +168,12 @@
     <Content Include="..\monotouch-test\compressed_zip">
       <Link>compressed_zip</Link>
     </Content>
+    <Content Include="..\monotouch-test\access-denied.html">
+      <Link>access-denied.html</Link>
+    </Content>
+    <Content Include="..\monotouch-test\access-granted.html">
+      <Link>access-granted.html</Link>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Metal Include="..\monotouch-test\Resources\metal-sample.metal">


### PR DESCRIPTION
* [xammac_tests] Add missing resources files.
* [monotouch-test] Adjust EventKitCalendarTest for the latest Xcode 11 beta (3).

Fixes https://github.com/xamarin/maccore/issues/1886.