### PR TITLE
[spritekit] Update xtro (no real change)

### DIFF
--- a/tests/xtro-sharpie/common-SpriteKit.ignore
+++ b/tests/xtro-sharpie/common-SpriteKit.ignore
@@ -12,3 +12,6 @@
 ## both introduced and deprecated in Xcode8
 !missing-selector! SKView::preferredFrameRate not bound
 !missing-selector! SKView::setPreferredFrameRate: not bound
+
+## missing in xcode 11 beta 3 https://feedbackassistant.apple.com/feedback/6644627 https://github.com/xamarin/maccore/issues/1887
+!missing-pinvoke! floatToHalfFloat is not bound

--- a/tests/xtro-sharpie/iOS-SpriteKit.todo
+++ b/tests/xtro-sharpie/iOS-SpriteKit.todo
@@ -1,1 +1,0 @@
-!missing-pinvoke! floatToHalfFloat is not bound

--- a/tests/xtro-sharpie/macOS-SpriteKit.todo
+++ b/tests/xtro-sharpie/macOS-SpriteKit.todo
@@ -1,1 +1,0 @@
-!missing-pinvoke! floatToHalfFloat is not bound

--- a/tests/xtro-sharpie/tvOS-SpriteKit.todo
+++ b/tests/xtro-sharpie/tvOS-SpriteKit.todo
@@ -1,1 +1,0 @@
-!missing-pinvoke! floatToHalfFloat is not bound

--- a/tests/xtro-sharpie/watchOS-SpriteKit.todo
+++ b/tests/xtro-sharpie/watchOS-SpriteKit.todo
@@ -1,1 +1,0 @@
-!missing-pinvoke! floatToHalfFloat is not bound


### PR DESCRIPTION
Beside quite some (availability/macros) noise, there's only a single
new API according to the header files - however it's missing in the
binary.

Filed feedback https://feedbackassistant.apple.com/feedback/6644627
Tracked in https://github.com/xamarin/maccore/issues/1887