### PR TITLE
[tests] Package Xamarin.Mac tests using 7z instead of zip.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -345,7 +345,7 @@ def runXamarinMacTests (url, macOS, maccore_hash, xamarin_macios_hash)
             }
         }
     } finally {
-        sh ("rm -rf ${workspace}/mac-test-package ${workspace}/*.zip")
+        sh ("rm -rf ${workspace}/mac-test-package ${workspace}/*.zip ${workspace}/*.7z")
         // Find and upload any crash reports
         sh (script: """
             rm -Rf ${workspace}/crash-reports
@@ -669,7 +669,7 @@ timestamps {
                                     echoError ("Failed to package Xamarin.Mac tests (exit code: ${exitCode}")
                                     failedStages.add (currentStage)
                                 }
-                                uploadFiles ("tests/*.zip", "wrench", virtualPath)
+                                uploadFiles ("tests/*.7z", "wrench", virtualPath)
                             }
 
                             timeout (time: 13, unit: 'HOURS') {
@@ -685,7 +685,7 @@ timestamps {
 
                                     // Add test runs on older macOS versions
                                     if (hasXamarinMacTests) {
-                                        def url = "https://bosstoragemirror.blob.core.windows.net/wrench/${virtualPath}/tests/mac-test-package.zip"
+                                        def url = "https://bosstoragemirror.blob.core.windows.net/wrench/${virtualPath}/tests/mac-test-package.7z"
                                         def maccore_hash = sh (script: "grep NEEDED_MACCORE_VERSION ${workspace}/xamarin-macios/mk/xamarin.mk | sed 's/NEEDED_MACCORE_VERSION := //'", returnStdout: true).trim ()
                                         // Get the min and current macOS version from Make.config,
                                         // and calculate all the macOS versions in between (including both end points).

--- a/jenkins/prepare-packaged-macos-tests.sh
+++ b/jenkins/prepare-packaged-macos-tests.sh
@@ -50,11 +50,16 @@ if test -f ~/.jenkins-profile; then
 	source ~/.jenkins-profile;
 fi
 
+# Install 7z. We can't do this from the system-dependencies.sh script, because
+# we need 7z to decompress the file where the system-dependencies.sh script
+# resides.
+brew install p7zip
+
 env
-rm -f -- ./*.zip
-curl -fL "$URL" --output mac-test-package.zip
+rm -f -- ./*.7z
+curl -fL "$URL" --output mac-test-package.7z
 rm -rf mac-test-package
-unzip -o mac-test-package.zip
+7z x mac-test-package.7z
 cd mac-test-package
 
 COUNTER=0

--- a/tests/package-mac-tests.sh
+++ b/tests/package-mac-tests.sh
@@ -11,7 +11,7 @@ fi
 #git clean -xfdq
 
 DIR=$(pwd)/mac-test-package/mac-test-package
-ZIP=$DIR.zip
+ZIP=$DIR.7z
 rm -Rf $DIR
 mkdir -p $DIR
 
@@ -46,5 +46,4 @@ $CP -p ../mk/subdirs.mk $DIR/mk
 $CP -p ../mk/rules.mk $DIR/mk
 $CP -p ../mk/quiet.mk $DIR/mk
 
-# 7za compresses better, because there are many duplicated files
-cd mac-test-package && zip -r ../mac-test-package.zip *
+cd mac-test-package && 7z a ../mac-test-package.7z *


### PR DESCRIPTION
This makes the package 33% smaller (from 176mb to 117mb).