### PR TITLE
[msbuild][xam-mac] Fix building with netstandard libraries

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.msbuild.targets
@@ -30,14 +30,16 @@ Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 			$(ImplicitlyExpandDesignTimeFacadesDependsOn);
 			GetReferenceAssemblyPaths
 		</ImplicitlyExpandDesignTimeFacadesDependsOn>
+
+		<_NETBuildExtensionsTaskAssembly>$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll</_NETBuildExtensionsTaskAssembly>
 	</PropertyGroup>
 
 	<!-- Implicitly references all portable design-time facades if the user is referencing a System.Runtime-based portable library -->
 
 	<UsingTask
 		TaskName="GetDependsOnNETStandard"
-		Condition="'$(IsXBuild)' != 'true' and Exists('$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll')"
-		AssemblyFile="$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll" />
+		Condition="'$(IsXBuild)' != 'true' and Exists('$(_NETBuildExtensionsTaskAssembly)')"
+		AssemblyFile="$(_NETBuildExtensionsTaskAssembly)" />
 
 	<Target Name="ImplicitlyExpandDesignTimeFacades" DependsOnTargets="$(ImplicitlyExpandDesignTimeFacadesDependsOn)">
 		<ItemGroup>
@@ -63,8 +65,8 @@ Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 		     If $(_HasReferenceToSystemRuntime) is true, then the facades are going to be expanded anyway, so don't run this.
 		-->
 		<GetDependsOnNETStandard
-			Condition="'$(_HasReferenceToSystemRuntime)' != 'true' and '$(IsXBuild)' != 'true' and '$(DependsOnNETStandard)' == '' and '@(XM_CandidateNETStandardReferences)' != '' 
-				and Exists('$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll')"
+			Condition="'$(_HasReferenceToSystemRuntime)' != 'true' and '$(IsXBuild)' != 'true' and '$(DependsOnNETStandard)' == '' and '@(XM_CandidateNETStandardReferences)' != ''
+				and Exists('$(_NETBuildExtensionsTaskAssembly)')"
 			References="@(XM_CandidateNETStandardReferences)">
 			<Output TaskParameter="DependsOnNETStandard" PropertyName="XM_DependsOnNETStandard" />
 		</GetDependsOnNETStandard>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.msbuild.targets
@@ -52,6 +52,14 @@ Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 			<_HasReferenceToSystemRuntime Condition="'$(DependsOnSystemRuntime)' == 'true' or '%(_ResolvedProjectReferencePaths.TargetPlatformIdentifier)' == 'Portable'">true</_HasReferenceToSystemRuntime>
 
 			<XM_NETStandardInbox Condition="'$(XM_NETStandardInbox)' == '' and Exists('%(XM_InboxNETStandardFolders.Identity)\netstandard.dll')">true</XM_NETStandardInbox>
+
+			<!--
+				This is `true` if any of the references depends on `netstandard`.
+
+				In cases where `ResolveAssemblyReference` task does get run, it populates `$(_DependsOnNETStandard)` property, so we don't
+				need to check this again.
+			-->
+			<XM_DependsOnNETStandard Condition="'$(XM_DependsOnNETStandard)' == ''">$(_DependsOnNETStandard)</XM_DependsOnNETStandard>
 		</PropertyGroup>
 
 		<!--
@@ -65,7 +73,7 @@ Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 		     If $(_HasReferenceToSystemRuntime) is true, then the facades are going to be expanded anyway, so don't run this.
 		-->
 		<GetDependsOnNETStandard
-			Condition="'$(_HasReferenceToSystemRuntime)' != 'true' and '$(IsXBuild)' != 'true' and '$(DependsOnNETStandard)' == '' and '@(XM_CandidateNETStandardReferences)' != ''
+			Condition="'$(_HasReferenceToSystemRuntime)' != 'true' and '$(IsXBuild)' != 'true' and '$(XM_DependsOnNETStandard)' == '' and '@(XM_CandidateNETStandardReferences)' != ''
 				and Exists('$(_NETBuildExtensionsTaskAssembly)')"
 			References="@(XM_CandidateNETStandardReferences)">
 			<Output TaskParameter="DependsOnNETStandard" PropertyName="XM_DependsOnNETStandard" />

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.msbuild.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.ImplicitFacade.msbuild.targets
@@ -31,7 +31,7 @@ Copyright (c) 2017 Microsoft Corp. (www.microsoft.com)
 			GetReferenceAssemblyPaths
 		</ImplicitlyExpandDesignTimeFacadesDependsOn>
 
-		<_NETBuildExtensionsTaskAssembly>$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll</_NETBuildExtensionsTaskAssembly>
+		<_NETBuildExtensionsTaskAssembly>$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\tools\net472\Microsoft.NET.Build.Extensions.Tasks.dll</_NETBuildExtensionsTaskAssembly>
 	</PropertyGroup>
 
 	<!-- Implicitly references all portable design-time facades if the user is referencing a System.Runtime-based portable library -->


### PR DESCRIPTION
Summary:

- Path to the task assembly needed to be updated to match msbuild update
- That revealed a different issue which would cause the facades not to be expanded in a specific case

Fixes: https://github.com/xamarin/xamarin-macios/issues/6552