### PR TITLE
[generator] Allow the generation of smart enums `*Extensions` code even if no fields are present

### DIFF
--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -97,7 +97,7 @@ public partial class Generator {
 
 		var library_name = type.Namespace;
 		var error = AttributeManager.GetCustomAttribute<ErrorDomainAttribute> (type);
-		if ((fields.Count > 0) || (error != null)) {
+		if ((fields.Count > 0) || (error != null) || (null_field != null)) {
 			print ("");
 			// the *Extensions has the same version requirement as the enum itself
 			PrintPlatformAttributes (type);
@@ -128,7 +128,7 @@ public partial class Generator {
 			print ("}");
 		}
 
-		if (fields.Count > 0) {
+		if ((fields.Count > 0) || (null_field != null)) {
 			print ("static IntPtr[] values = new IntPtr [{0}];", fields.Count);
 			print ("");
 
@@ -211,7 +211,7 @@ public partial class Generator {
 			print ("}");
 		}
 			
-		if ((fields.Count > 0) || (error != null)) {
+		if ((fields.Count > 0) || (error != null) || (null_field != null)) {
 			indent--;
 			print ("}");
 		}


### PR DESCRIPTION
This is needed in a case like:

```csharp
[Unavailable (PlatformName.UIKitForMac)][Advice ("This API is not available when using UIKit on macOS.")]
[NoWatch, NoTV, Mac (10,15), iOS (13,0)]
enum ASAuthorizationProviderAuthorizationOperation {
	// no value yet - but we must handle `nil` as a default value
	[DefaultEnumValue]
	[Field (null)]
	None,
}
```

IOW we want to expose the smart enum for it's only `null` value
but the general conversion code is not available (for a `Weak`
version of the property)

The upcoming update for `authenticationservices.cs` depends on this fix.