### PR TITLE
[AuthenticationServices] Fix ASAuthorization and ASAuthorizationRequest

### DIFF
--- a/src/AuthenticationServices/ASAuthorization.cs
+++ b/src/AuthenticationServices/ASAuthorization.cs
@@ -1,0 +1,20 @@
+//
+// ASAuthorization.cs
+//
+// Authors:
+//	Alex Soto <alexsoto@microsoft.com>
+//
+// Copyright 2019 Microsoft Corporation
+//
+
+using Foundation;
+using ObjCRuntime;
+
+namespace AuthenticationServices {
+
+	public partial class ASAuthorization {
+		public T GetProvider<T> () where T : NSObject, IASAuthorizationProvider => Runtime.GetINativeObject<T> (_Provider, false);
+
+		public T GetCredential<T> () where T : NSObject, IASAuthorizationCredential => Runtime.GetINativeObject<T> (_Credential, false);
+	}
+}

--- a/src/AuthenticationServices/ASAuthorizationRequest.cs
+++ b/src/AuthenticationServices/ASAuthorizationRequest.cs
@@ -1,0 +1,17 @@
+//
+// ASAuthorization.cs
+//
+// Authors:
+//	Alex Soto <alexsoto@microsoft.com>
+//
+// Copyright 2019 Microsoft Corporation
+//
+
+using Foundation;
+using ObjCRuntime;
+
+namespace AuthenticationServices {
+	public partial class ASAuthorizationRequest {
+			public T GetProvider<T> () where T : NSObject, IASAuthorizationProvider => Runtime.GetINativeObject<T> (_Provider, false);
+	}
+}

--- a/src/authenticationservices.cs
+++ b/src/authenticationservices.cs
@@ -242,11 +242,19 @@ namespace AuthenticationServices {
 	[DisableDefaultCtor]
 	interface ASAuthorization {
 
+		// Unfortunately Apple returns an internal wrapper type that can quack, bark and moo
+		// depending on context of the request and all objects that implement IASAuthorizationProvider
+		// are not related between them.
+		[Internal]
 		[Export ("provider", ArgumentSemantic.Strong)]
-		IASAuthorizationProvider Provider { get; }
+		IntPtr _Provider { get; }
 
+		// Unfortunately Apple returns an internal wrapper type that can quack, bark and moo
+		// depending on context of the request and all objects that implement IASAuthorizationCredential
+		// are not related between them.
+		[Internal]
 		[Export ("credential", ArgumentSemantic.Strong)]
-		IASAuthorizationCredential Credential { get; }
+		IntPtr _Credential { get; }
 	}
 
 	[Watch (6, 0), TV (13, 0), Mac (10, 15), iOS (13, 0)]
@@ -532,8 +540,12 @@ namespace AuthenticationServices {
 	[DisableDefaultCtor]
 	interface ASAuthorizationRequest : NSCopying, NSSecureCoding {
 
+		// Unfortunately Apple returns an internal wrapper type that can quack, bark and moo
+		// depending on context of the request and all objects that implement IASAuthorizationProvider
+		// are not related between them.
+		[Internal]
 		[Export ("provider", ArgumentSemantic.Strong)]
-		IASAuthorizationProvider Provider { get; }
+		IntPtr _Provider { get; }
 	}
 
 	[NoWatch, NoTV, Mac (10,15), iOS (13,0)]

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -213,6 +213,12 @@ AUDIOUNIT_SOURCES = \
 	AudioUnit/AUParameter.cs \
 	AudioUnit/AUParameterNode.cs \
 
+# AuthenticationServices
+
+AUTHENTICATIONSERVICES_SOURCES = \
+	AuthenticationServices/ASAuthorization.cs \
+	AuthenticationServices/ASAuthorizationRequest.cs \
+
 # AVFoundation
 
 AVFOUNDATION_API_SOURCES = \


### PR DESCRIPTION
Apple returns an internal wrapper object depending on the context the API
is used for the following properties

* `ASAuthorization.Provider`
* `ASAuthorization.Credential`
* `ASAuthorizationRequest.Provider`

The provider objects have a common interface `IASAuthorizationProvider`
and the Credential objects have` IASAuthorizationCredential` since the
objects that implement these protocols inherit from `NSObject` and Apple
returns the internal wrapper object we cannot have the runtime do the
right cast for us so we expose a generic API constrained to

* `NSObject, IASAuthorizationProvider`
* `NSObject, IASAuthorizationCredential`

Respectively so now we are able to do something like

```csharp
GetCredential<ASAuthorizationAppleIdCredential> ();
```

No unit test added because this requires special entitlements but
this is working as expected in an internal sample that it is being
worked on.

<img width="854" alt="sample" src="https://user-images.githubusercontent.com/204671/61506304-a12d9200-a9af-11e9-8208-27b2a44e4f55.png">
