### PR TITLE
[mmp] Fix QTKit submission issue when linker is disabled

### DIFF
--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -176,8 +176,14 @@ namespace Xamarin.Bundler {
 					Framework framework;
 					if (Driver.GetFrameworks (App).TryGetValue (nspace, out framework)) {
 						// framework specific processing
-#if !MONOMAC
 						switch (framework.Name) {
+#if MONOMAC
+						case "QTKit":
+							// we already warn in Frameworks.cs Gather method
+							if (!Driver.LinkProhibitedFrameworks)
+								continue;
+							break;
+#else
 						case "CoreAudioKit":
 							// CoreAudioKit seems to be functional in the iOS 9 simulator.
 							if (App.IsSimulatorBuild && App.SdkVersion.Major < 9)
@@ -201,8 +207,8 @@ namespace Xamarin.Bundler {
 								continue;
 							}
 							break;
-						}
 #endif
+						}
 
 						if (App.SdkVersion >= framework.Version) {
 							var add_to = framework.AlwaysWeakLinked || App.DeploymentTarget < framework.Version ? asm.WeakFrameworks : asm.Frameworks;


### PR DESCRIPTION
- There is duplicate code so the QTKit exclusion is needed in two locations
- Patch from Sebastien
- Fix validated by customer submission to Apple