### PR TITLE
[AppKit] Add missing NSScreen method.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -13125,6 +13125,11 @@ namespace AppKit {
 		[Mac (10,12)]
 		[Export ("canRepresentDisplayGamut:")]
 		bool CanRepresentDisplayGamut (NSDisplayGamut displayGamut);
+
+		// Inlined from unnamed category.
+		[Mac (10,11)]
+		[Export ("maximumExtendedDynamicRangeColorComponentValue")]
+		nfloat MaximumExtendedDynamicRangeColorComponentValue { get; }
 	}
 
 	[BaseType (typeof (NSControl))]

--- a/tests/xtro-sharpie/macOS-AppKit.todo
+++ b/tests/xtro-sharpie/macOS-AppKit.todo
@@ -257,7 +257,6 @@
 !missing-selector! NSPickerTouchBarItem::target not bound
 !missing-selector! NSResponder::changeModeWithEvent: not bound
 !missing-selector! NSScreen::localizedName not bound
-!missing-selector! NSScreenNSScreen::maximumExtendedDynamicRangeColorComponentValue not bound
 !missing-selector! NSScreenNSScreen::maximumPotentialExtendedDynamicRangeColorComponentValue not bound
 !missing-selector! NSScreenNSScreen::maximumReferenceExtendedDynamicRangeColorComponentValue not bound
 !missing-selector! NSSliderTouchBarItem::doubleValue not bound


### PR DESCRIPTION
This is not from Xcode 11, but putting it in the xcode11 branch probably has the least chance of merge problems later.