### PR TITLE
[xcode11] [Generator] Do not used harcoded 'error' var name, use the one in the declaration.

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1712,7 +1712,7 @@ public partial class Generator : IMemberGatherer {
 					var refname = $"__xamarin_pref{pi.Position}";
 					convert.Append ($"var {refname} = Runtime.GetINativeObject<{RenderType (nt)}> ({pname}, false);");
 					pars.Append ($"ref IntPtr {pname}");
-					postConvert.Append ($"error = {refname}.GetHandle ();");
+					postConvert.Append ($"{pname} = {refname}.GetHandle ();");
 					invoke.Append ($"ref {refname}");
 					continue;
 				}

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1712,7 +1712,7 @@ public partial class Generator : IMemberGatherer {
 					var refname = $"__xamarin_pref{pi.Position}";
 					convert.Append ($"var {refname} = Runtime.GetINativeObject<{RenderType (nt)}> ({pname}, false);");
 					pars.Append ($"ref IntPtr {pname}");
-					postConvert.Append ($"{pname} = {refname}.GetHandle ();");
+					postConvert.Append ($"{pname} = {refname} == null ? IntPtr.Zero : {refname}.Handle;");
 					invoke.Append ($"ref {refname}");
 					continue;
 				}

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -592,6 +592,9 @@ namespace GeneratorTests
 			BuildFile (Profile.iOS, "tests/return-release.cs");
 		}
 
+		[Test]
+		public void GHIssue6626 () => BuildFile (Profile.iOS, "ghissue6626.cs");
+
 		BGenTool BuildFile (Profile profile, params string [] filenames)
 		{
 			return BuildFile (profile, true, false, filenames);

--- a/tests/generator/ghissue6626.cs
+++ b/tests/generator/ghissue6626.cs
@@ -1,0 +1,17 @@
+using System;
+using Foundation;
+using AudioToolbox;
+using ObjCRuntime;
+
+namespace GHIssue6626 {
+
+	public delegate int AVAudioSourceNodeRenderBlock (bool isSilence, double timestamp, uint frameCount, ref AudioBuffers outputData);
+
+	[BaseType (typeof (NSObject))]
+	interface AVAudioSourceNode
+	{
+		[Export ("initWithRenderBlock:")]
+		[DesignatedInitializer]
+		IntPtr Constructor (AVAudioSourceNodeRenderBlock block);
+	}
+}


### PR DESCRIPTION


Backport of #6620.

/cc @mandel-macaque 