### PR TITLE
[tests] Use built-in feature checks to check for API non-crashyness.

### DIFF
--- a/src/Metal/MTLEnums.cs
+++ b/src/Metal/MTLEnums.cs
@@ -700,11 +700,20 @@ namespace Metal {
 		[Mac (10,13), NoiOS, NoTV, NoWatch]
 		macOS_GPUFamily1_v3 = 10003,
 
+		[Mac (10,14), NoiOS, NoTV, NoWatch]
+		macOS_GPUFamily1_v4 = 10004,
+
+		[Mac (10,14), NoiOS, NoTV, NoWatch]
+		macOS_GPUFamily2_v1 = 10005,
+
 		[TV (9,0)]
 		TVOS_GPUFamily1_v1 = 30000,
 
 		[NoiOS, TV (10,0), NoWatch, NoMac]
 		tvOS_GPUFamily1_v2 = 30001,
+
+		[NoiOS, TV (11,0), NoWatch, NoMac]
+		tvOS_GPUFamily1_v3 = 30002,
 
 		[NoiOS, TV (11,0), NoWatch, NoMac]
 		tvOS_GPUFamily2_v1 = 30003,

--- a/tests/monotouch-test/Metal/MTLDeviceTests.cs
+++ b/tests/monotouch-test/Metal/MTLDeviceTests.cs
@@ -110,8 +110,7 @@ namespace MonoTouchFixtures.Metal {
 			}
 
 #if __MACOS__
-			if (TestRuntime.CheckXcodeVersion (10, 0)) {
-				if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 14, 6)) // https://github.com/xamarin/maccore/issues/1800
+			if (TestRuntime.CheckXcodeVersion (10, 0) && device.SupportsFeatureSet (MTLFeatureSet.macOS_GPUFamily2_v1)) {
 				using (var descriptor = MTLTextureDescriptor.CreateTexture2DDescriptor (MTLPixelFormat.RGBA8Unorm, 64, 64, false)) {
 					descriptor.StorageMode = MTLStorageMode.Private;
 					using (var texture = device.CreateSharedTexture (descriptor)) {
@@ -278,7 +277,7 @@ namespace MonoTouchFixtures.Metal {
 
 			if (TestRuntime.CheckXcodeVersion (10, 0)) {
 #if __MACOS__
-				if (!TestRuntime.CheckSystemVersion (PlatformName.MacOSX, 10, 14, 6)) // https://github.com/xamarin/maccore/issues/1801
+				if (device.SupportsFeatureSet (MTLFeatureSet.macOS_GPUFamily2_v1))
 #endif
 				using (var descriptor = new MTLIndirectCommandBufferDescriptor ()) {
 					using (var library = device.CreateIndirectCommandBuffer (descriptor, 1, MTLResourceOptions.CpuCacheModeDefault)) {


### PR DESCRIPTION
This also required adding a few missing Metal version enum values.

Fixes https://github.com/xamarin/maccore/issues/1800.
Fixes https://github.com/xamarin/maccore/issues/1801.