### PR TITLE
[tests] fix introspection failures (typotest) in macOS 10.15 #1897

### DIFF
--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -561,6 +561,7 @@ namespace Introspection
 			"Wpa",
 			"Warpable",
 			"Whitespaces",
+			"Wifes",
 			"Writeability",
 			"Xnor",
 			"Xpc",


### PR DESCRIPTION
Add `Wifes` to allowed strings.

Fixes https://github.com/xamarin/maccore/issues/1897.