### PR TITLE
[AddressBook] Make ABRecord non-abstract. Fixes #6654.

### DIFF
--- a/src/AddressBook/ABRecord.cs
+++ b/src/AddressBook/ABRecord.cs
@@ -60,13 +60,14 @@ namespace AddressBook {
 	}
 
 	[Deprecated (PlatformName.iOS, 9, 0, message : "Use the 'Contacts' API instead.")]
-	public abstract class ABRecord : INativeObject, IDisposable {
+	public class ABRecord : INativeObject, IDisposable {
 
 		public const int InvalidRecordId = -1;
 		public const int InvalidPropertyId = -1;
 
 		IntPtr handle;
 
+		[Preserve (Conditional = true)]
 		internal ABRecord (IntPtr handle, bool owns)
 		{
 			if (!owns)


### PR DESCRIPTION
A change in the linker made a potential problem show up as a registrar error
instead of a runtime exception.

The linker became smarter in d16-2, and will now remove interface
implementations in certain cases. In particular, the linker will remove
interface implementations for a type that is never instantiated (which means
there will never be any instances of that type, which means the interface
won't be needed).

The ABRecord was abstract, and as such there will never be any ABRecord
instances. If none of ABRecord's subclasses are used in the app, there won't
be instances of ABRecord subclasses either.

This meant the linker removed all of ABRecord's interfaces, including
INativeObject.

We have API that uses ABRecord in the signature. The registrar needs to know
if a particular type is an INativeObject, which is determined by checking if
the type implements the INativeObject interface. Since the INativeObject
interface implementation was removed, the registrar determined that the
ABRecord type in the signature is invalid, and showed an error:

    Error MT4136: The registrar cannot marshal the parameter type 'AddressBook.ABRecord' of the parameter 'address' in the method 'PassKit.PKPaymentAuthorizationViewController/_PKPaymentAuthorizationViewControllerDelegate.DidSelectShippingAddress(PassKit.PKPaymentAuthorizationViewController,AddressBook.ABRecord,PassKit.PKPaymentShippingAddressSelected)

The actual problem is not the linker change, but the fact that a signature
uses an abstract type. At runtime, this will cause problems if we ever need to
instantiate such a managed type: we can't. This is generally not a problem for
NSObject subclasses, because we can determine the runtime type of the object,
and that's usually [1] some other, non-abstract type. However, for
INativeObjects, we can't find a better type at runtime (because we can't
determine the runtime type of the object), so we're left with trying to
instantiate the exact type in the signature. If this is an abstract type,
things will go badly.

So make ABRecord non-abstract.

Fixes https://github.com/xamarin/xamarin-macios/issues/6654.

[1] Usually, but not always, as history has shown. See also https://github.com/xamarin/xamarin-macios/issues/4969.