### PR TITLE
[tests][msbuild] Tweak the NativeReferencesNoEmbedding test to work with a locally built mtouch.

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/NativeReferencesNoEmbedding.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/ProjectsTests/NativeReferencesNoEmbedding.cs
@@ -126,7 +126,7 @@ namespace Xamarin.iOS.Tasks
 
 			var appProject = SetupProjectPaths ("MyiOSAppWithBinding", "../", true, "");
 
-			const string BuildString = "/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mtouch";
+			string BuildString = Configuration.MtouchPath;
 
 			// First build should create run mtouch
 			BuildProjectNoEmbedding (appProject);


### PR DESCRIPTION
When building mtouch locally, this will be the mtouch path:

    /path/to/somewhere/xamarin-macios/_ios-build//Library/Frameworks/Xamarin.iOS.framework/Versions/git/bin/mtouch