### PR TITLE
[mtouch/mmp] Don't write runtime-options.plist if it hasn't changed.

### DIFF
--- a/src/ObjCRuntime/RuntimeOptions.cs
+++ b/src/ObjCRuntime/RuntimeOptions.cs
@@ -74,7 +74,7 @@ namespace ObjCRuntime {
 			content.AppendLine ("</plist>");
 
 			var file_name = GetFileName (app_dir);
-			File.WriteAllText (file_name, content.ToString ());
+			Xamarin.Bundler.Driver.WriteIfDifferent (file_name, content.ToString ());
 		}
 
 		// Called from CoreHttpMessageHandler


### PR DESCRIPTION
This makes rebuilds affect a little less final change in the app, which is always good.