### PR TITLE
[Tests] Ignore some tests on the CI due to the settings of the bots.

### DIFF
--- a/tests/monotouch-test/CoreFoundation/ProxyTest.cs
+++ b/tests/monotouch-test/CoreFoundation/ProxyTest.cs
@@ -125,6 +125,8 @@ namespace MonoTouchFixtures.CoreFoundation {
 		[Test]
 		public void TestPACParsingAsyncNoProxy ()
 		{
+			TestRuntime.IgnoreInCI ("CI bots might have proxies setup and will mean that the test will fail when trying to assert they are empty.");
+
 			CFProxy [] proxies = null;
 			NSError error = null;
 			NSObject cbClient = null;
@@ -223,6 +225,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 		[Test]
 		public void TestPACParsingUrlAsyncNoProxy ()
 		{
+			TestRuntime.IgnoreInCI ("CI bots might have proxies setup and will mean that the test will fail when trying to assert they are empty.");
 			CFProxy [] proxies = null;
 			NSError error = null;
 			NSObject cbClient = null;


### PR DESCRIPTION
In some cases some bots will return a proxy present, not because of the
PAC being parsed, but due to the bot settings. Ignore the tests that
expect no proxies in the CI fixes the issue.

Fixes https://github.com/xamarin/maccore/issues/1901