### PR TITLE
[Introspection] ABRecord is abstract and cannot be instantiated.

### DIFF
--- a/tests/introspection/ApiCMAttachmentTest.cs
+++ b/tests/introspection/ApiCMAttachmentTest.cs
@@ -173,6 +173,7 @@ namespace Introspection {
 			if (nativeName.StartsWith ("CGPDF", StringComparison.Ordinal))  // all those types crash the app
 				return true;
 			switch (nativeName) {
+			case "ABRecord": // abstract class
 			case "CFMachPort":
 			case "CFMessagePort":
 			case "DispatchIO": // no way to instantiate it


### PR DESCRIPTION
Following https://github.com/xamarin/xamarin-macios/pull/6655 the class was made non abstract but it cannot be instantiated. Ignore it.

Fixes: https://github.com/xamarin/maccore/issues/1903