### PR TITLE
Fix NLLanguageRecognizer crash

### DIFF
--- a/src/NaturalLanguage/NLLanguageRecognizer.cs
+++ b/src/NaturalLanguage/NLLanguageRecognizer.cs
@@ -33,11 +33,8 @@ namespace NaturalLanguage {
 		{
 			var nsstring = NSString.CreateNative (@string);
 			var nslang = _GetDominantLanguage (nsstring);
-			var lang =  NLLanguage.Undetermined;
-			if (nslang != null) {
-				lang = NLLanguageExtensions.GetValue (nslang);
-				nslang.Dispose ();
-			}
+			var lang = NLLanguageExtensions.GetValue (nslang);
+			nslang?.Dispose ();
 			NSString.ReleaseNative (nsstring);
 			return lang;
 		}

--- a/src/NaturalLanguage/NLLanguageRecognizer.cs
+++ b/src/NaturalLanguage/NLLanguageRecognizer.cs
@@ -34,10 +34,11 @@ namespace NaturalLanguage {
 			var nsstring = NSString.CreateNative (@string);
 			var nslang = _GetDominantLanguage (nsstring);
 			var lang =  NLLanguage.Undetermined;
-			if (nslang != null)
+			if (nslang != null) {
 				lang = NLLanguageExtensions.GetValue (nslang);
+				nslang.Dispose ();
+			}
 			NSString.ReleaseNative (nsstring);
-			nslang.Dispose ();
 			return lang;
 		}
 	

--- a/tests/monotouch-test/NaturalLanguage/NLLanguageRecognizerTest.cs
+++ b/tests/monotouch-test/NaturalLanguage/NLLanguageRecognizerTest.cs
@@ -55,5 +55,16 @@ namespace MonoTouchFixtures.NaturalLanguage {
 				Assert.That (hypo.Count, Is.GreaterThan (0), "GetLanguageHypotheses");
 			}
 		}
+
+		[Test]
+		public void HandelNumbers()
+		{
+			using (var recognizer = new NLLanguageRecognizer ()) {
+				Assert.That (recognizer.DominantLanguage, Is.EqualTo (NLLanguage.Unevaluated), "DominantLanguage/Pre-Process");
+				var text = "2";
+				recognizer.Process (text);
+				Assert.That (recognizer.DominantLanguage, Is.EqualTo (NLLanguage.Unevaluated), "DominantLanguage/Post-Process");
+			}
+		}
 	}
 }


### PR DESCRIPTION
Closes #6688 

The dispose of `nslang` was happening outside of the check if `nslang` is null. This was causing a crash when trying to recognise a string that contains just one number.