### PR TITLE
[tests] Fix api tests in macOS 10.15

### DIFF
--- a/tests/monotouch-test/CoreText/FontManagerTest.cs
+++ b/tests/monotouch-test/CoreText/FontManagerTest.cs
@@ -222,8 +222,10 @@ namespace MonoTouchFixtures.CoreText {
 		{
 			TestRuntime.AssertXcodeVersion (11, 0);
 
+#if !__MACOS__
 			if (TestRuntime.CheckExactXcodeVersion (11, 0, beta: 5))
 				Assert.Ignore ("This began failing for no aparent reason in Beta 5, check back on a later beta.");
+#endif
 
 			CTFontDescriptorAttributes fda = new CTFontDescriptorAttributes () {
 				FamilyName = "Courier",


### PR DESCRIPTION
Fixes

```
RegisterFontDescriptors_WithCallback (MonoTouchFixtures.CoreText.FontManagerTest.RegisterFontDescriptors_WithCallback)
System.NotImplementedException : The method or operation is not implemented.
    at TestRuntime.CheckExactXcodeVersion (System.Int32 major, System.Int32 minor, System.Int32 beta) [0x00185] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/common/TestRuntime.cs:175
    at MonoTouchFixtures.CoreText.FontManagerTest.RegisterFontDescriptors_WithCallback () [0x0000b] in /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/monotouch-test/CoreText/FontManagerTest.cs:225
    at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
    at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in /Library/Frameworks/Xamarin.Mac.framework/Versions/5.99.2.30/src/Xamarin.Mac/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs:391
```