### PR TITLE
[d16-3] [Tests] Ignore tests that only fail on tvOS devices.

### DIFF
--- a/tests/bcl-test/tvOS-monotouch_corlib_xunit-test.dll.ignore
+++ b/tests/bcl-test/tvOS-monotouch_corlib_xunit-test.dll.ignore
@@ -8,3 +8,6 @@ System.IO.Tests.DirectoryInfo_Exists.FalseForNonRegularFile
 # Exception messages: System.NullReferenceException : Object reference not set to an instance of an object
 System.Threading.Tasks.Tests.TaskSchedulerTests.GetScheduledTasksForDebugger_DebuggerAttached_ReturnsTasksFromCustomSchedulers
 System.Text.Tests.StringBuilderTests.Append_CharPointer_Null_ThrowsNullReferenceException
+
+# device failures, reported at: https://github.com/mono/mono/issues/15983
+System.Reflection.Tests.MethodBaseTests.Test_GetCurrentMethod_Inlineable


### PR DESCRIPTION
A mono issue has been reported here: https://github.com/mono/mono/issues/15983

Backport of #6707.

/cc @mandel-macaque 