### PR TITLE
Add correct casing for Microsoft.FSharp.targets

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.FSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.FSharp.targets
@@ -27,10 +27,6 @@
 	    <Import Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')"
 		        Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets" />
 
-		<!-- Fallback on Microsoft.FSharp.targets if Microsoft.FSharp.Targets is not found -->
-	    <Import Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.targets')"
-		        Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.targets" />
-
         <Import Condition="!$(MSBuildAllProjects.Contains('Microsoft.FSharp.Targets')) and Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets')"
                 Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets" />
 
@@ -40,7 +36,7 @@
         <Import Condition="!$(MSBuildAllProjects.Contains('Microsoft.FSharp.Targets')) and Exists('$(MSBuildFrameworkToolsPath32)\Microsoft.FSharp.Targets')"
                 Project="$(MSBuildFrameworkToolsPath32)\Microsoft.FSharp.Targets" />
 
-        <Import Condition="!$(MSBuildAllProjects.Contains('Microsoft.FSharp.Targets'))"
+        <Import Condition="!$(MSBuildAllProjects.Contains('Microsoft.FSharp.Targets')) and Exists('$(MSBuildBinPath)\Microsoft.FSharp.Targets')"
                 Project="$(MSBuildBinPath)\Microsoft.FSharp.Targets" />
 
 	<Import Project="Xamarin.Mac.Common.targets" />

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.FSharp.targets
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.FSharp.targets
@@ -27,6 +27,10 @@
 	    <Import Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')"
 		        Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets" />
 
+		<!-- Fallback on Microsoft.FSharp.targets if Microsoft.FSharp.Targets is not found -->
+	    <Import Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.targets')"
+		        Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.targets" />
+
         <Import Condition="!$(MSBuildAllProjects.Contains('Microsoft.FSharp.Targets')) and Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets')"
                 Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets" />
 


### PR DESCRIPTION
Fixes #6721 

Simple fix for the casing issue for Xamarin.Mac F# projects on Windows.
I kept the previous path because I don't know if it is valid on some systems.