### PR TITLE
[passkit] Remove duplicated 'using' causing warnings at build time

### DIFF
--- a/src/passkit.cs
+++ b/src/passkit.cs
@@ -13,7 +13,6 @@ using Contacts;
 using ObjCRuntime;
 using Foundation;
 using UIKit;
-using Contacts;
 #if !WATCH
 using AddressBook;
 #else


### PR DESCRIPTION
```
passkit.cs(16,7): warning CS0105: The using directive for 'Contacts' appeared previously in this namespace
```