### PR TITLE
[gamecontroller] Fix a few minor issues

### DIFF
--- a/src/GameController/Enums.cs
+++ b/src/GameController/Enums.cs
@@ -12,9 +12,9 @@ using ObjCRuntime;
 using Foundation;
 
 namespace GameController {
-	[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
-	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
-	[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
+	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
+	[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
 	[Native]
 	public enum GCExtendedGamepadSnapshotDataVersion : long
 	{

--- a/src/GameController/GCMicroGamepadSnapshot.cs
+++ b/src/GameController/GCMicroGamepadSnapshot.cs
@@ -14,9 +14,9 @@ namespace GameController {
 	// GCMicroGamepadSnapshot.h
 	// float_t are 4 bytes (at least for ARM64)
 	[StructLayout (LayoutKind.Sequential, Pack = 1)]
-	[Deprecated (PlatformName.iOS, 12, 2, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
-	[Deprecated (PlatformName.MacOSX, 10, 14, 4, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
-	[Deprecated (PlatformName.TvOS, 12, 2, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
+	[Deprecated (PlatformName.iOS, 12, 2, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 14, 4, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
+	[Deprecated (PlatformName.TvOS, 12, 2, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
 	public struct GCMicroGamepadSnapShotDataV100 {
 
 		// Standard information
@@ -32,9 +32,9 @@ namespace GameController {
 		public float /* float_t = float */ ButtonA;
 		public float /* float_t = float */ ButtonX;
 
-		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
-		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
-		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
+		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
+		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
 		[DllImport (Constants.GameControllerLibrary)]
 		static extern /* NSData * __nullable */ IntPtr NSDataFromGCMicroGamepadSnapShotDataV100 (
 			/* __nullable */ ref GCMicroGamepadSnapShotDataV100 snapshotData);
@@ -48,9 +48,9 @@ namespace GameController {
 
 	// GCMicroGamepadSnapshot.h
 	// float_t are 4 bytes (at least for ARM64)
-	[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
-	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
-	[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
+	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
+	[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
 	[StructLayout (LayoutKind.Sequential, Pack = 1)]
 	public struct GCMicroGamepadSnapshotData {
 
@@ -67,9 +67,9 @@ namespace GameController {
 		public float /* float_t = float */ ButtonA;
 		public float /* float_t = float */ ButtonX;
 
-		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
-		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
-		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
+		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
+		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
 		[DllImport (Constants.GameControllerLibrary)]
 		[TV (12, 2), Mac (10, 14, 4), iOS (12, 2)]
 		static extern /* NSData * __nullable */ IntPtr NSDataFromGCMicroGamepadSnapshotData (
@@ -87,9 +87,9 @@ namespace GameController {
 	public partial class GCMicroGamepadSnapshot {
 
 		// GCGamepadSnapshot.h
-		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
-		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
-		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
+		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
+		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
 		[DllImport (Constants.GameControllerLibrary)]
 		[Mac (10, 12)]
 		static extern bool GCMicroGamepadSnapShotDataV100FromNSData (out GCMicroGamepadSnapShotDataV100 snapshotData, /* NSData */ IntPtr data);
@@ -103,9 +103,9 @@ namespace GameController {
 			return GCMicroGamepadSnapShotDataV100FromNSData (out snapshotData, data == null ? IntPtr.Zero : data.Handle);
 		}
 		
-		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
-		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
-		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCController.ControllerWithMicroGamepad()' instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
+		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
+		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
 		[DllImport (Constants.GameControllerLibrary)]
 		[TV (12, 2), Mac (10, 14, 4), iOS (12, 2)]
 		static extern bool GCMicroGamepadSnapshotDataFromNSData (out GCMicroGamepadSnapshotData snapshotData, /* NSData */ IntPtr data);

--- a/src/gamecontroller.cs
+++ b/src/gamecontroller.cs
@@ -50,11 +50,11 @@ namespace GameController {
 		GCControllerAxisValueChangedHandler ValueChangedHandler { get; set; }
 
 		[Export ("value")]
-		float Value { get; } /* float, not CGFloat */
-
-		[Mac (10,15), iOS (13,0)]
-		[Export ("setValue:")]
-		void SetValue (float value);
+		float Value {  /* float, not CGFloat */
+			get;
+			[Mac (10,15)][iOS (13,0)][TV (13,0)]
+			set;
+		}
 	}
 
 	delegate void GCControllerButtonValueChanged (GCControllerButtonInput button, float /* float, not CGFloat */ buttonValue, bool pressed);
@@ -75,14 +75,14 @@ namespace GameController {
 		GCControllerButtonValueChanged ValueChangedHandler { get; set; }
 
 		[Export ("value")]
-		float Value { get; } /* float, not CGFloat */
+		float Value {  /* float, not CGFloat */
+			get;
+			[Mac (10,15)][iOS (13,0)][TV (13,0)]
+			set;
+		}
 
 		[Export ("pressed")]
 		bool IsPressed { [Bind ("isPressed")] get; }
-
-		[Mac (10,15), iOS (13,0)]
-		[Export ("setValue:")]
-		void SetValue (float value);
 
 #if !XAMCORE_4_0
 		[iOS (8,0), Mac (10,10)]
@@ -91,7 +91,7 @@ namespace GameController {
 		void SetPressedChangedHandler (GCControllerButtonValueChanged handler);
 #endif
 
-		[iOS (8,0), Mac (10,10), TV (13,0)]
+		[iOS (8,0), Mac (10,10)]
 		[NullAllowed]
 		[Export ("pressedChangedHandler", ArgumentSemantic.Copy)]
 		GCControllerButtonValueChanged PressedChangedHandler { get; set; }
@@ -127,6 +127,7 @@ namespace GameController {
 		GCControllerButtonInput Right { get; }
 
 		[Mac (10,15), iOS (13,0)]
+		[TV (13,0)]
 		[Export ("setValueForXAxis:yAxis:")]
 		void SetValue (float xAxis, float yAxis);
 	}
@@ -336,7 +337,6 @@ namespace GameController {
 
 		[Mac (10,12)]
 		[iOS (10,0)]
-		[TV (13,0)]
 		[NullAllowed, Export ("microGamepad", ArgumentSemantic.Retain)]
 		GCMicroGamepad MicroGamepad { get; }
 
@@ -356,7 +356,7 @@ namespace GameController {
 		[Notification, Field ("GCControllerDidDisconnectNotification")]
 		NSString DidDisconnectNotification { get; }
 
-		[iOS (8,0), Mac (10,10), TV(13,0)]
+		[iOS (8,0), Mac (10,10)]
 		[Export ("motion", ArgumentSemantic.Retain)]
 		GCMotion Motion { get; }
 
@@ -387,7 +387,7 @@ namespace GameController {
 		GCController GetExtendedGamepadController ();
 	}
 
-	[iOS (8,0), Mac (10,10), TV (13,0)]
+	[iOS (8,0), Mac (10,10)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // access thru GCController.Motion - returns a nil Handle
 	partial interface GCMotion {


### PR DESCRIPTION
- Fix deprecation messages to point to an existing API;

- Add setters for `Value` properties instead of adding `SetValue` methods;

- Removing some `[TV (13,0)]` when the API was already available in previous tvOS versions. It's implied that type that existed in tvOS 9.0 (the first version) do not have (nor need) availability attributes. Decorating them as `13,0` sends an incorrect message to developers (since the API have been available for a while)

- Adding some `[TV (13,0)]` when a new API only mention iOS

reference: https://github.com/xamarin/xamarin-macios/pull/6589