### PR TITLE
[coretext] Update for Xcode 11 beta 5

### DIFF
--- a/src/CoreText/CTEnums.cs
+++ b/src/CoreText/CTEnums.cs
@@ -48,5 +48,6 @@ namespace CoreText {
 		InsufficientInfo = 303,
 		CancelledByUser = 304,
 		DuplicatedName = 305,
+		InvalidFilePath = 306,
 	}
 }

--- a/src/CoreText/CTFont.cs
+++ b/src/CoreText/CTFont.cs
@@ -1712,6 +1712,31 @@ namespace CoreText {
 				return CreateFont (CTFontCreateForString (handle, v.Handle, range));
 		}
 
+		[iOS (13,0), Mac (10,15), TV (13,0), Watch (6,0)]
+		[DllImport (Constants.CoreTextLibrary)]
+		static extern /* CTFontRef */ IntPtr CTFontCreateForStringWithLanguage (
+			/* CTFontRef */ IntPtr currentFont,
+			/* CFStringRef */ IntPtr @string,
+			NSRange range,
+			/* CFStringRef _Nullable */ IntPtr language);
+
+		[iOS (13,0), Mac (10,15), TV (13,0), Watch (6,0)]
+		public CTFont ForString (string value, NSRange range, string language)
+		{
+			if (value == null)
+				throw new ArgumentNullException (nameof (value));
+
+			var v = NSString.CreateNative (value);
+			var l = NSString.CreateNative (language);
+			try {
+				return CreateFont (CTFontCreateForStringWithLanguage (handle, v, range, l));
+			}
+			finally {
+				NSString.ReleaseNative (l);
+				NSString.ReleaseNative (v);
+			}
+		}
+
 #endregion
 
 #region Font Accessors

--- a/src/CoreText/CTFontManager.cs
+++ b/src/CoreText/CTFontManager.cs
@@ -401,17 +401,20 @@ namespace CoreText {
 			}
 		}
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+#if __IOS__
+		[iOS (13,0)]
 		[DllImport (Constants.CoreTextLibrary)]
 		static extern /* CFArrayRef */ IntPtr CTFontManagerCopyRegisteredFontDescriptors (CTFontManagerScope scope, bool enabled);
 
-		[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
+		[iOS (13,0)]
+		[NoWatch][NoTV][NoMac]
 		public static CTFontDescriptor[] GetRegisteredFontDescriptors (CTFontManagerScope scope, bool enabled)
 		{
 			var p = CTFontManagerCopyRegisteredFontDescriptors (scope, enabled);
 			// Copy/Create rule - we must release the CFArrayRef
 			return ArrayFromHandle<CTFontDescriptor> (p, releaseAfterUse: true);
 		}
+#endif
 
 		// [Watch (2,0), TV (9,0), Mac (10,7), iOS (7,0)]
 		[DllImport (Constants.CoreTextLibrary)]

--- a/src/CoreText/CTGlyphInfo.cs
+++ b/src/CoreText/CTGlyphInfo.cs
@@ -156,6 +156,16 @@ namespace CoreText {
 		public CTCharacterCollection CharacterCollection {
 			get {return CTGlyphInfoGetCharacterCollection (handle);}
 		}
+
+		[DllImport (Constants.CoreTextLibrary)]
+		[iOS (13,0), Mac (10,15), TV (13,0), Watch (6,0)]
+		static extern ushort /* CGGlyph */ CTGlyphInfoGetGlyph (IntPtr /* CTGlyphInfoRef */ glyphInfo);
+
+		[iOS (13,0), Mac (10,15), TV (13,0), Watch (6,0)]
+		public CGGlyph GetGlyph ()
+		{
+			return CTGlyphInfoGetGlyph (handle);
+		}
 #endregion
 
 		public override string ToString ()

--- a/src/coretext.cs
+++ b/src/coretext.cs
@@ -49,6 +49,14 @@ namespace CoreText {
 
 		[Field ("kCTFontFeatureSelectorSettingKey")]
 		NSString Setting { get; }
+
+		[iOS (13,0), Mac (10,15), TV (13,0), Watch (6,0)]
+		[Field ("kCTFontFeatureSampleTextKey")]
+		NSString SampleText { get; }
+
+		[iOS (13,0), Mac (10,15), TV (13,0), Watch (6,0)]
+		[Field ("kCTFontFeatureTooltipTextKey")]
+		NSString TooltipText { get; }
 	}
 
 	[Static]

--- a/tests/monotouch-test/CoreText/FontTest.cs
+++ b/tests/monotouch-test/CoreText/FontTest.cs
@@ -39,7 +39,7 @@ namespace MonoTouchFixtures.CoreText {
 	
 	[TestFixture]
 	[Preserve (AllMembers = true)]
-	public class A_FontTest {
+	public class FontTest {
 
 		[Test]
 		public void CTFontCreateWithNameAndOptions ()
@@ -106,6 +106,30 @@ namespace MonoTouchFixtures.CoreText {
 				Assert.True (ctfont.GetGlyphsForCharacters ("\ud83d\ude00".ToCharArray (), gid), "GetGlyphsForCharacters");
 				Assert.That (gid [0], Is.Not.EqualTo (0), "0");
 				Assert.That (gid [1], Is.EqualTo (0), "1");
+			}
+		}
+
+		[Test]
+		public void CTFontCreateForString ()
+		{
+			TestRuntime.AssertXcodeVersion (5, 0);
+
+			using (var f1 = new CTFont ("HoeflerText-Regular", 10, CTFontOptions.Default))
+			using (var f2 = f1.ForString ("xamarin", new NSRange (0, 3))) {
+				Assert.That (f2.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
+			}
+		}
+
+		[Test]
+		public void CTFontCreateForStringWithLanguage ()
+		{
+			TestRuntime.AssertXcodeVersion (11, 0);
+
+			using (var f1 = new CTFont ("HoeflerText-Regular", 10, CTFontOptions.Default)) {
+				using (var f2 = f1.ForString ("xamarin", new NSRange (0, 3), null))
+					Assert.That (f2.Handle, Is.Not.EqualTo (IntPtr.Zero), "f2");
+				using (var f3 = f1.ForString ("xamarin", new NSRange (0, 3), "FR"))
+					Assert.That (f3.Handle, Is.Not.EqualTo (IntPtr.Zero), "f3");
 			}
 		}
 	}

--- a/tests/monotouch-test/CoreText/GlyphInfoTest.cs
+++ b/tests/monotouch-test/CoreText/GlyphInfoTest.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+using CoreText;
+using Foundation;
+
+using NUnit.Framework;
+
+namespace MonoTouchFixtures.CoreText {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class GlyphInfoTest {
+
+		[Test]
+		public void GlyphInfo ()
+		{
+			using (var f = new CTFont ("ArialMY", 24))
+			using (var g = new CTGlyphInfo (64, f, "Foo")) {
+				Assert.That (g.Handle, Is.Not.EqualTo (IntPtr.Zero), "Handle");
+
+				if (TestRuntime.CheckXcodeVersion (11,0)) {
+					Assert.That (g.GetGlyph (), Is.EqualTo (64), "GetGlyph");
+				}
+			}
+		}
+	}
+}

--- a/tests/xtro-sharpie/iOS-CoreText.todo
+++ b/tests/xtro-sharpie/iOS-CoreText.todo
@@ -1,4 +1,0 @@
-!missing-field! kCTFontFeatureSampleTextKey not bound
-!missing-field! kCTFontFeatureTooltipTextKey not bound
-!missing-pinvoke! CTFontCreateForStringWithLanguage is not bound
-!missing-pinvoke! CTGlyphInfoGetGlyph is not bound

--- a/tests/xtro-sharpie/macOS-CoreText.todo
+++ b/tests/xtro-sharpie/macOS-CoreText.todo
@@ -1,5 +1,0 @@
-!missing-field! kCTFontFeatureSampleTextKey not bound
-!missing-field! kCTFontFeatureTooltipTextKey not bound
-!missing-pinvoke! CTFontCreateForStringWithLanguage is not bound
-!missing-pinvoke! CTGlyphInfoGetGlyph is not bound
-!unknown-pinvoke! CTFontManagerCopyRegisteredFontDescriptors bound

--- a/tests/xtro-sharpie/tvOS-CoreText.todo
+++ b/tests/xtro-sharpie/tvOS-CoreText.todo
@@ -1,5 +1,0 @@
-!missing-field! kCTFontFeatureSampleTextKey not bound
-!missing-field! kCTFontFeatureTooltipTextKey not bound
-!missing-pinvoke! CTFontCreateForStringWithLanguage is not bound
-!missing-pinvoke! CTGlyphInfoGetGlyph is not bound
-!unknown-pinvoke! CTFontManagerCopyRegisteredFontDescriptors bound

--- a/tests/xtro-sharpie/watchOS-CoreText.todo
+++ b/tests/xtro-sharpie/watchOS-CoreText.todo
@@ -1,5 +1,0 @@
-!missing-field! kCTFontFeatureSampleTextKey not bound
-!missing-field! kCTFontFeatureTooltipTextKey not bound
-!missing-pinvoke! CTFontCreateForStringWithLanguage is not bound
-!missing-pinvoke! CTGlyphInfoGetGlyph is not bound
-!unknown-pinvoke! CTFontManagerCopyRegisteredFontDescriptors bound


### PR DESCRIPTION
Beta 4 added some new API and constants
Beta 5 removed `CTFontManagerCopyRegisteredFontDescriptors` from all OS but iOS