### PR TITLE
[linker] Always preserve INativeObject (interface) on types. Fixes #6711

### DIFF
--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -1094,6 +1094,7 @@ namespace LinkSdk {
 			return Type.GetType (name, throwOnError);
 		}
 
+#if !__WATCHOS__
 		[Test]
 		// https://github.com/xamarin/xamarin-macios/issues/6711
 		public void PreserveINativeObject ()
@@ -1103,5 +1104,6 @@ namespace LinkSdk {
 			// and we check that it still implement INativeObject
 			Assert.IsNotNull (mta.GetInterface ("ObjCRuntime.INativeObject"), "INativeObject");
 		}
+#endif
 	}
 }

--- a/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/ios/link sdk/LinkSdkRegressionTest.cs
@@ -1093,5 +1093,15 @@ namespace LinkSdk {
 		{
 			return Type.GetType (name, throwOnError);
 		}
+
+		[Test]
+		// https://github.com/xamarin/xamarin-macios/issues/6711
+		public void PreserveINativeObject ()
+		{
+			// linker will keep the MTAudioProcessingTap type
+			var mta = typeof (MediaToolbox.MTAudioProcessingTap);
+			// and we check that it still implement INativeObject
+			Assert.IsNotNull (mta.GetInterface ("ObjCRuntime.INativeObject"), "INativeObject");
+		}
 	}
 }

--- a/tools/linker/CoreMarkStep.cs
+++ b/tools/linker/CoreMarkStep.cs
@@ -167,6 +167,13 @@ namespace Xamarin.Linker.Steps {
 						MarkType (proto.WrapperType);
 				}
 
+				// if we mark a type then it should *always* keep it's `INativeObject` implementation
+				// since it's required at build time (e.g. static registrar) and at runtime - even if the instantiation is not marked
+				// as we have some special cases, e.g. `MTAudioProcessingTap.FromHandle`
+				// ref: https://github.com/xamarin/xamarin-macios/issues/6711
+				if (td.HasInterfaces && td.Implements ("ObjCRuntime.INativeObject"))
+					Annotations.MarkInstantiated (td);
+
 				// older generated bindings did not preserve the `Handler` field and
 				// newer (mono 2019-02) linker can optimize them (enabled by default)
 				// so we make sure our old bindings remains linker-safe


### PR DESCRIPTION
Recent versions of the linker can remove _unused_ interfaces from types.

This optimization is only done when the type is not instantiated. However
our tools and runtime requires knowing if a type represent a native
object, using `INativeObject` even if the code that creates such instance
is not marked.

In details... the issue happens because the static registrar must be able
to detect that `MTAudioProcessingTap` is a native object, so it checks
if it implements `INativeObject`. Since it does not it fails with a 4104
error.

Why does it not ? because it's handled specially by the generator and
uses `FromHandle` to lookup (not create) instance. So the linker is able
to remove the creation code (totally fine) and then remove the
`INativeObject` (not fine since we need this).

The solution is to tell (a small like to) the linker that any marked type
that implements `INativeObject` is instantiated. That way we ensure that
the tooling (run against the linked app) and the runtime can determine
those types as native.

reference: https://github.com/xamarin/xamarin-macios/issues/6711