### PR TITLE
[xcode11] Disable bcl tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -378,8 +378,9 @@ runner: xharness/xharness.exe
 
 # This makefile target will run the device tests using the Xamarin.iOS version
 # installed on the system.
+# 'run-bcl-tests' is disabled for xcode11 because it doesn't support mono binaries. See https://github.com/xamarin/maccore/issues/1808
 vsts-device-tests: xharness/xharness.exe
-	$(Q) ulimit -n 4096 && $(SYSTEM_MONO) --debug $(CURDIR)/$< $(XHARNESS_VERBOSITY) --jenkins --autoconf --rootdir $(CURDIR) --sdkroot $(XCODE_DEVELOPER_ROOT) --use-system:true --label=skip-all-tests,run-device-tests,run-bcl-tests --markdown-summary=$(CURDIR)/TestSummary.md $(TESTS_EXTRA_ARGUMENTS) $(TESTS_PERIODIC_COMMAND)
+	$(Q) ulimit -n 4096 && $(SYSTEM_MONO) --debug $(CURDIR)/$< $(XHARNESS_VERBOSITY) --jenkins --autoconf --rootdir $(CURDIR) --sdkroot $(XCODE_DEVELOPER_ROOT) --use-system:true --label=skip-all-tests,run-device-tests --markdown-summary=$(CURDIR)/TestSummary.md $(TESTS_EXTRA_ARGUMENTS) $(TESTS_PERIODIC_COMMAND)
 
 ifdef ENABLE_XAMARIN
 wrench-launch-external wrench-report-external:


### PR DESCRIPTION
See https://github.com/xamarin/maccore/issues/1808.
On `xcode11` we do not support mono binaries.
VSTS expects to be able to download mono when we need to build it from source for `xcode11`.
Reverting the tests to the old way would be too complicated to simply disable the bcl tests.
Those tests are still executed for simulator and will be re-enabled when we merge `xcode11`.
This was added as a reminder here: https://github.com/xamarin/xamarin-macios/issues/6212