### PR TITLE
[xcode11][publishing] Added conditional behavior to CreateIpa and its dependencies

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -356,7 +356,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</CreateAppBundleDependsOn>
 	</PropertyGroup>
 
-	<Target Name="_CreateAppBundle" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="$(CreateAppBundleDependsOn)" />
+	<Target Name="_CreateAppBundle" Condition="'$(_CanOutputAppBundle)' == 'true' And '$(IsAppDistribution)' != 'true'" DependsOnTargets="$(CreateAppBundleDependsOn)" />
 
 	<PropertyGroup>
 		<_CodesignAppBundleDependsOn>
@@ -376,44 +376,30 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			_CodesignVerify;
 		</_CoreCodesignDependsOn>
 
-		<_BeforeCodeSignForBuildDependsOn>
-			_CreateAppBundle;
-			BeforeCodeSign;
-			CoreCodeSign;
-			AfterCodeSign
-		</_BeforeCodeSignForBuildDependsOn>
-
-		<_BeforeCodeSignForDistributionDependsOn>
+		<CodesignDependsOn>
 			BeforeCodeSign;
 			CoreCodeSign;
 			AfterCodeSign;
-		</_BeforeCodeSignForDistributionDependsOn>
+		</CodesignDependsOn>
 	</PropertyGroup>
 
 	<Target Name="BeforeCodesign" />
 	<Target Name="CoreCodesign" DependsOnTargets="$(_CoreCodesignDependsOn)" />
 	<Target Name="AfterCodesign" />
 
-	<Target Name="_BeforeCodeSignForBuild" Condition="'$(IsAppDistribution)' != 'True'" BeforeTargets="Codesign" DependsOnTargets="$(_BeforeCodeSignForBuildDependsOn)" />
-	<Target Name="_BeforeCodeSignForDistribution" Condition="'$(IsAppDistribution)' == 'True'" BeforeTargets="Codesign" DependsOnTargets="$(_BeforeCodeSignForDistributionDependsOn)" />
-	
-	<Target Name="Codesign" Condition="'$(_CanOutputAppBundle)' == 'true'" />
+	<Target Name="Codesign" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_CreateAppBundle;$(CodesignDependsOn)" />
 
 	<PropertyGroup>
-		<_BeforeCreateIpaDependsOn>
+		<!-- Extensibility point for VS Publishing Workflow -->
+		<_BeforeCreateIpaForDistributionDependsOn />
+		
+		<CreateIpaDependsOn>
+			_BeforeCreateIpaForDistribution;
 			_CoreCreateIpa;
 			_PackageOnDemandResources;
 			_ZipIpa
-		</_BeforeCreateIpaDependsOn>
-		
-		<_BeforeCreateIpaForBuildDependsOn>
-			$(_BeforeCreateIpaDependsOn)
-		</_BeforeCreateIpaForBuildDependsOn>
+		</CreateIpaDependsOn>
 
-		<_BeforeCreateIpaForDistributionDependsOn>
-			$(_BeforeCreateIpaDependsOn)
-		</_BeforeCreateIpaForDistributionDependsOn>
-		
 		<ArchiveDependsOn>
 			_CoreArchive
 		</ArchiveDependsOn>
@@ -421,10 +407,9 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<Target Name="Archive" Condition="'$(_CanArchive)' == 'true'" DependsOnTargets="$(ArchiveDependsOn)" />
 
-	<Target Name="_BeforeCreateIpaForBuild" Condition="'$(IsAppDistribution)' != 'True'" BeforeTargets="CreateIpa" DependsOnTargets="$(_BeforeCreateIpaForBuildDependsOn)" />
-	<Target Name="_BeforeCreateIpaForDistribution" Condition="'$(IsAppDistribution)' == 'True'" BeforeTargets="CreateIpa" DependsOnTargets="$(_BeforeCreateIpaForDistributionDependsOn)" />
+	<Target Name="_BeforeCreateIpaForDistribution" Condition="'$(IsAppDistribution)' == 'true'" DependsOnTargets="$(_BeforeCreateIpaForDistributionDependsOn)" />
 	
-	<Target Name="CreateIpa" Condition="'$(_CanArchive)' == 'true'" />
+	<Target Name="CreateIpa" Condition="'$(_CanArchive)' == 'true'" DependsOnTargets="$(CreateIpaDependsOn)" />
 
 	<Target Name="_CleanAppBundle" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_GenerateBundleName">
 		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(_AppBundlePath)" />
@@ -701,8 +686,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	
 	<Target Name="_GenerateBundleName" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_ComputeTargetArchitectures">
 		<PropertyGroup>
-			<AppBundleDir Condition="'$(IsAppDistribution)' != 'True'">$(DeviceSpecificOutputPath)$(_AppBundleName)$(AppBundleExtension)</AppBundleDir>
-			<AppBundleDir Condition="'$(IsAppDistribution)' == 'True'">$(ArchivePath)\Products\Applications\$(_AppBundleName)$(AppBundleExtension)</AppBundleDir>
+			<AppBundleDir Condition="'$(IsAppDistribution)' != 'true'">$(DeviceSpecificOutputPath)$(_AppBundleName)$(AppBundleExtension)</AppBundleDir>
+			<AppBundleDir Condition="'$(IsAppDistribution)' == 'true'">$(ArchivePath)\Products\Applications\$(_AppBundleName)$(AppBundleExtension)</AppBundleDir>
 			<_AppBundlePath>$(AppBundleDir)\</_AppBundlePath>
 		</PropertyGroup>
 	</Target>
@@ -812,6 +797,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	</Target>
 
 	<Target Name="_CompileToNative" DependsOnTargets="$(_CompileToNativeDependsOn)"
+		Condition = "'$(IsAppDistribution)' != 'true'"
 		Inputs="@(_CompileToNativeInput);@(_FrameworkNativeReference);@(_FileNativeReference);@(BundleDependentFiles)"
 		Outputs="$(_NativeExecutable);$(DeviceSpecificOutputPath)mtouch.stamp">
 
@@ -1784,15 +1770,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		/>
 	</Target>
 
-	<PropertyGroup>
-		<_BeforeCollectFrameworksForBuildDependsOn>
-			_CompileToNative
-		</_BeforeCollectFrameworksForBuildDependsOn>
-	</PropertyGroup>
-
-	<Target Name="_BeforeCollectFrameworksForBuild" Condition="'$(IsAppDistribution)' != 'True'" BeforeTargets="_CollectFrameworks" DependsOnTargets="$(_BeforeCollectFrameworksForBuildDependsOn)" />
-	
-	<Target Name="_CollectFrameworks" Condition="'$(_CanOutputAppBundle)' == 'true'">
+	<Target Name="_CollectFrameworks" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_CompileToNative">
 		<CollectFrameworks
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
@@ -1802,16 +1780,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</CollectFrameworks>
 	</Target>
 
-	<PropertyGroup>
-		<_BeforeCodesignNativeLibrariesForBuildDependsOn>
-			_CompileToNative
-		</_BeforeCodesignNativeLibrariesForBuildDependsOn>
-	</PropertyGroup>
-
-	<Target Name="_BeforeCodesignNativeLibrariesForBuild" Condition="'$(IsAppDistribution)' != 'True'" BeforeTargets="_CodesignNativeLibraries" DependsOnTargets="$(_BeforeCodesignNativeLibrariesForBuildDependsOn)" />
-
 	<!-- Note: Always codesign *.dylibs even for Simulator builds. We use $(_CanOutputAppBundle) because dylibs can exist in app extensions as well. -->
-	<Target Name="_CodesignNativeLibraries" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_DetectSigningIdentity">
+	<Target Name="_CodesignNativeLibraries" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_DetectSigningIdentity;_CompileToNative">
 
 		<PropertyGroup>
 			<_CodesignDisableTimestamp>False</_CodesignDisableTimestamp>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -376,26 +376,44 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			_CodesignVerify;
 		</_CoreCodesignDependsOn>
 
-		<CodesignDependsOn>
+		<_BeforeCodeSignForBuildDependsOn>
+			_CreateAppBundle;
+			BeforeCodeSign;
+			CoreCodeSign;
+			AfterCodeSign
+		</_BeforeCodeSignForBuildDependsOn>
+
+		<_BeforeCodeSignForDistributionDependsOn>
 			BeforeCodeSign;
 			CoreCodeSign;
 			AfterCodeSign;
-		</CodesignDependsOn>
+		</_BeforeCodeSignForDistributionDependsOn>
 	</PropertyGroup>
 
 	<Target Name="BeforeCodesign" />
 	<Target Name="CoreCodesign" DependsOnTargets="$(_CoreCodesignDependsOn)" />
 	<Target Name="AfterCodesign" />
 
-	<Target Name="Codesign" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_CreateAppBundle;$(CodesignDependsOn)" />
+	<Target Name="_BeforeCodeSignForBuild" Condition="'$(IsAppDistribution)' != 'True'" BeforeTargets="Codesign" DependsOnTargets="$(_BeforeCodeSignForBuildDependsOn)" />
+	<Target Name="_BeforeCodeSignForDistribution" Condition="'$(IsAppDistribution)' == 'True'" BeforeTargets="Codesign" DependsOnTargets="$(_BeforeCodeSignForDistributionDependsOn)" />
+	
+	<Target Name="Codesign" Condition="'$(_CanOutputAppBundle)' == 'true'" />
 
 	<PropertyGroup>
-		<CreateIpaDependsOn>
+		<_BeforeCreateIpaDependsOn>
 			_CoreCreateIpa;
 			_PackageOnDemandResources;
 			_ZipIpa
-		</CreateIpaDependsOn>
+		</_BeforeCreateIpaDependsOn>
+		
+		<_BeforeCreateIpaForBuildDependsOn>
+			$(_BeforeCreateIpaDependsOn)
+		</_BeforeCreateIpaForBuildDependsOn>
 
+		<_BeforeCreateIpaForDistributionDependsOn>
+			$(_BeforeCreateIpaDependsOn)
+		</_BeforeCreateIpaForDistributionDependsOn>
+		
 		<ArchiveDependsOn>
 			_CoreArchive
 		</ArchiveDependsOn>
@@ -403,7 +421,10 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<Target Name="Archive" Condition="'$(_CanArchive)' == 'true'" DependsOnTargets="$(ArchiveDependsOn)" />
 
-	<Target Name="CreateIpa" Condition="'$(_CanArchive)' == 'true'" DependsOnTargets="$(CreateIpaDependsOn)" />
+	<Target Name="_BeforeCreateIpaForBuild" Condition="'$(IsAppDistribution)' != 'True'" BeforeTargets="CreateIpa" DependsOnTargets="$(_BeforeCreateIpaForBuildDependsOn)" />
+	<Target Name="_BeforeCreateIpaForDistribution" Condition="'$(IsAppDistribution)' == 'True'" BeforeTargets="CreateIpa" DependsOnTargets="$(_BeforeCreateIpaForDistributionDependsOn)" />
+	
+	<Target Name="CreateIpa" Condition="'$(_CanArchive)' == 'true'" />
 
 	<Target Name="_CleanAppBundle" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_GenerateBundleName">
 		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(_AppBundlePath)" />
@@ -680,7 +701,8 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 	
 	<Target Name="_GenerateBundleName" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_ComputeTargetArchitectures">
 		<PropertyGroup>
-			<AppBundleDir>$(DeviceSpecificOutputPath)$(_AppBundleName)$(AppBundleExtension)</AppBundleDir>
+			<AppBundleDir Condition="'$(IsAppDistribution)' != 'True'">$(DeviceSpecificOutputPath)$(_AppBundleName)$(AppBundleExtension)</AppBundleDir>
+			<AppBundleDir Condition="'$(IsAppDistribution)' == 'True'">$(ArchivePath)\Products\Applications\$(_AppBundleName)$(AppBundleExtension)</AppBundleDir>
 			<_AppBundlePath>$(AppBundleDir)\</_AppBundlePath>
 		</PropertyGroup>
 	</Target>
@@ -1762,7 +1784,15 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		/>
 	</Target>
 
-	<Target Name="_CollectFrameworks" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_CompileToNative">
+	<PropertyGroup>
+		<_BeforeCollectFrameworksForBuildDependsOn>
+			_CompileToNative
+		</_BeforeCollectFrameworksForBuildDependsOn>
+	</PropertyGroup>
+
+	<Target Name="_BeforeCollectFrameworksForBuild" Condition="'$(IsAppDistribution)' != 'True'" BeforeTargets="_CollectFrameworks" DependsOnTargets="$(_BeforeCollectFrameworksForBuildDependsOn)" />
+	
+	<Target Name="_CollectFrameworks" Condition="'$(_CanOutputAppBundle)' == 'true'">
 		<CollectFrameworks
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
@@ -1772,8 +1802,16 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</CollectFrameworks>
 	</Target>
 
+	<PropertyGroup>
+		<_BeforeCodesignNativeLibrariesForBuildDependsOn>
+			_CompileToNative
+		</_BeforeCodesignNativeLibrariesForBuildDependsOn>
+	</PropertyGroup>
+
+	<Target Name="_BeforeCodesignNativeLibrariesForBuild" Condition="'$(IsAppDistribution)' != 'True'" BeforeTargets="_CodesignNativeLibraries" DependsOnTargets="$(_BeforeCodesignNativeLibrariesForBuildDependsOn)" />
+
 	<!-- Note: Always codesign *.dylibs even for Simulator builds. We use $(_CanOutputAppBundle) because dylibs can exist in app extensions as well. -->
-	<Target Name="_CodesignNativeLibraries" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_DetectSigningIdentity;_CompileToNative">
+	<Target Name="_CodesignNativeLibraries" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_DetectSigningIdentity">
 
 		<PropertyGroup>
 			<_CodesignDisableTimestamp>False</_CodesignDisableTimestamp>
@@ -2016,7 +2054,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</CodesignVerify>
 	</Target>
 
-	<Target Name="_CoreCreateIpa" Condition="'$(BuildIpa)' == 'true'" DependsOnTargets="$(Codesign)">
+	<Target Name="_CoreCreateIpa" Condition="'$(BuildIpa)' == 'true'" DependsOnTargets="Codesign">
 		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(DeviceSpecificIntermediateOutputPath)ipa" />
 
 		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(DeviceSpecificIntermediateOutputPath)ipa\Payload" />
@@ -2241,7 +2279,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</Zip>
 	</Target>
 
-	<Target Name="_CoreArchive" Condition="'$(ArchiveOnBuild)' == 'true'" DependsOnTargets="$(Codesign)">
+	<Target Name="_CoreArchive" Condition="'$(ArchiveOnBuild)' == 'true'" DependsOnTargets="Codesign">
 		<CollectITunesSourceFiles
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' And '@(_ITunesSourceFile)' == ''"


### PR DESCRIPTION
Backport of https://github.com/xamarin/xamarin-macios/pull/6720, since publishing is part of the Xcode11 effort.

The targets execution needs to change based on the 'IsAppDistribution' property value, which will be set from the IDE.
According to the value of this property, some dependencies should be run or should be skipped.
The strategy adopted is to use the BeforeTargets value because doing this way we will force the conditionals over '$(IsAppDistribution)' to be evaluated each time a target is attempted to be run.
The most intuitive way of doing it is by directly add DependsOnTargets and conditions on the PropertyGroup items, but doing this will not work because the IDE usually runs the targets when the MSBuild project is already loaded, which means that the properties have already been evaluated so they will not be evaluated again, which causes conditional values to be out of date.
The only way of making it work in these cases is by forcing the conditional evaluations of each target execution attempt, and that is accomplished by adding the conditions directly on the Target 'Condition' property.