### PR TITLE
[jenkins] Don't trust brew to not fail when things are working fine.

### DIFF
--- a/jenkins/prepare-packaged-macos-tests.sh
+++ b/jenkins/prepare-packaged-macos-tests.sh
@@ -53,7 +53,8 @@ fi
 # Install 7z. We can't do this from the system-dependencies.sh script, because
 # we need 7z to decompress the file where the system-dependencies.sh script
 # resides.
-brew install p7zip
+# Also ignore any failures, brew may fail if 7z is already installed.
+brew install p7zip || true
 
 env
 rm -f -- ./*.7z


### PR DESCRIPTION
brew may fail to install 7z if 7z is already installed, so ignore any brew
failures when trying to install 7z.

If 7z really is non-functional on the machine, then it'll fail later anyway.