### PR TITLE
[generator] Add support for [Native] enums inside [StrongDictionaries]

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -2762,11 +2762,13 @@ public partial class Generator : IMemberGatherer {
 					Type fetchType = pi.PropertyType;
 					string castToUnderlying = "";
 					string castToEnum = "";
+					bool isNativeEnum = false;
 
 					if (pi.PropertyType.IsEnum){
 						fetchType = TypeManager.GetUnderlyingEnumType (pi.PropertyType);
 						castToUnderlying = "(" + fetchType + "?)";
 						castToEnum = "(" + FormatType (dictType, pi.PropertyType) + "?)";
+						isNativeEnum = IsNativeEnum (pi.PropertyType);
 					}
 					if (pi.PropertyType.IsValueType){
 						if (pi.PropertyType == TypeManager.System_Boolean){
@@ -2805,6 +2807,12 @@ public partial class Generator : IMemberGatherer {
 						} else if (Frameworks.HaveCoreMedia && fetchType == TypeManager.CMTime){
 							getter = "{1} GetCMTimeValue ({0})";
 							setter = "SetCMTimeValue ({0}, {1}value)";
+						} else if (isNativeEnum && fetchType == TypeManager.System_Int64) {
+							getter = "{1} (long?) GetNIntValue ({0})";
+							setter = "SetNumberValue ({0}, {1}value)";
+						} else if (isNativeEnum && fetchType == TypeManager.System_UInt64) {
+							getter = "{1} (ulong?) GetNUIntValue ({0})";
+							setter = "SetNumberValue ({0}, {1}value)";
 						} else {
 							throw new BindingException (1031, true,
 										    "Limitation: can not automatically create strongly typed dictionary for " +

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -595,6 +595,9 @@ namespace GeneratorTests
 		[Test]
 		public void GHIssue6626 () => BuildFile (Profile.iOS, "ghissue6626.cs");
 
+		[Test]
+		public void StrongDictsNativeEnums () => BuildFile (Profile.iOS, "strong-dict-native-enum.cs");
+
 		BGenTool BuildFile (Profile profile, params string [] filenames)
 		{
 			return BuildFile (profile, true, false, filenames);

--- a/tests/generator/strong-dict-native-enum.cs
+++ b/tests/generator/strong-dict-native-enum.cs
@@ -1,0 +1,27 @@
+using System;
+using Foundation;
+using ObjCRuntime;
+using Vision;
+
+namespace StrongDictsNativeEnums {
+
+	[Static]
+	interface SomeKeys {
+		[Field("NSSomeNativeKey", "__Internal")]
+		NSString TrackingLevelKey { get; }
+	}
+
+	[StrongDictionary ("SomeKeys")]
+	interface SomeOptions {
+		VNRequestTrackingLevel TrackingLevel { get; set; }
+	}
+
+	[BaseType (typeof (NSObject))]
+	interface UseOptions {
+		[Export ("setOptions:")]
+		void SetOptions (NSDictionary weakOptions);
+
+		[Wrap ("SetOptions (options?.Dictionary)")]
+		void SetOptions (SomeOptions options);
+	}
+}


### PR DESCRIPTION
Without his fix, using `[Native]` enums ends up being `1031` error

```
BI1031: bgen: Limitation: can not automatically create strongly typed dictionary for (Vision.VNImageCropAndScaleOption)
```