### PR TITLE
[eventkit] Obsolete `EKReminder` default constructor

### DIFF
--- a/src/EventKit/EventKit.cs
+++ b/src/EventKit/EventKit.cs
@@ -81,5 +81,13 @@ namespace EventKit {
 		public EKAlarm () {}
 #endif
 	}
+
+	partial class EKReminder {
+#if !XAMCORE_4_0
+		// https://github.com/xamarin/maccore/issues/1832
+		[Obsolete ("Use 'Create' instead.")]
+		public EKReminder () {}
+#endif
+	}
 }
 #endif // XAMCORE_2_0 || !MONOMAC

--- a/src/eventkit.cs
+++ b/src/eventkit.cs
@@ -645,6 +645,7 @@ namespace EventKit {
 
 	[iOS (6,0)]
 	[BaseType (typeof (EKCalendarItem))]
+	[DisableDefaultCtor]
 	interface EKReminder {
 		[Export ("startDateComponents", ArgumentSemantic.Copy)]
 		[NullAllowed]

--- a/tests/introspection/iOS/iOSApiCtorInitTest.cs
+++ b/tests/introspection/iOS/iOSApiCtorInitTest.cs
@@ -235,9 +235,6 @@ namespace Introspection {
 				return Runtime.Arch == Arch.SIMULATOR;
 			case "ICNotificationManagerConfiguration": // This works on device but not on simulator, and docs explicitly says it is user creatable
 				return Runtime.Arch == Arch.SIMULATOR;
-			// xcode 11 beta 3
-			case "EKReminder": // https://github.com/xamarin/maccore/issues/1832
-				return TestRuntime.CheckXcodeVersion (11, 0);
 			default:
 				return base.Skip (type);
 			}


### PR DESCRIPTION
`[EKReminder init]` is not usable and now return `nil`.

Before Xcode 11 it was never really usable but an instance was returned.

references:
* https://feedbackassistant.apple.com/feedback/6453725
* https://github.com/xamarin/maccore/issues/1832