### PR TITLE
[contactsui] Update for Xcode 11 beta 1 to 5

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -3040,6 +3040,7 @@ namespace UIKit {
 
 #if XAMCORE_2_0
 #if IOS // This is inside ContactsUI.framework
+		[Unavailable (PlatformName.MacCatalyst)][Advice ("This API is not available when using UIKit on macOS.")]
 		[Static, Export ("iconWithContact:")]
 		UIApplicationShortcutIcon FromContact (CNContact contact);
 #endif // IOS


### PR DESCRIPTION
Mark the `iconWithContact:` API as not available with Catalyst

Note that the category `UIApplicationShortcutIcon (ContactsUI)` was
inlined in UIKit's `UIApplicationShortcutIcon` so only that file needs
to be updated.