### PR TITLE
[tests][xtro] Fix reported failure for SFSafariServicesVersion on macOS

### DIFF
--- a/tests/xtro-sharpie/macOS-SafariServices.ignore
+++ b/tests/xtro-sharpie/macOS-SafariServices.ignore
@@ -6,4 +6,4 @@
 !missing-type! SFSafariExtensionState not bound
 
 ## it's present but it's unused and the [Obsolete] attribute skips it (so it's reported)
-##!missing-enum! SFSafariServicesVersion not bound
+!missing-enum! SFSafariServicesVersion not bound

--- a/tests/xtro-sharpie/macOS-SafariServices.ignore
+++ b/tests/xtro-sharpie/macOS-SafariServices.ignore
@@ -4,3 +4,6 @@
 !missing-selector! SFSafariExtensionState::isEnabled not bound
 !missing-type! SFSafariExtensionManager not bound
 !missing-type! SFSafariExtensionState not bound
+
+## it's present but it's unused and the [Obsolete] attribute skips it (so it's reported)
+##!missing-enum! SFSafariServicesVersion not bound


### PR DESCRIPTION
The `enum` is decorated with `[Obsolete]` since it's unused by any API.
However recent logic skips obsolete members it so it looks missing...
even if it won't be removed until `XAMCORE_4_0` is enabled.

Not quite clear why the original PR [1] did not report it... but all
subsequent ones are
https://github.com/xamarin/xamarin-macios/pull/6767