### PR TITLE
[xtro] check new enum members

### DIFF
--- a/tests/xtro-sharpie/EnumCheck.cs
+++ b/tests/xtro-sharpie/EnumCheck.cs
@@ -58,9 +58,9 @@ namespace Extrospection {
 				Log.On (framework).Add ($"!missing-enum! {name} not bound");
 				return;
 			} else {
-            	var enumMemberInPreviousLib = type.Fields.Select (e => name.Replace ("Code","") + e.Name);
-            	var enumMemberInNewAppleLib = decl.Values.Select (e => e.Name);
-            	var missingEnums = enumMemberInNewAppleLib.Except (enumMemberInPreviousLib);
+            	var enumMembersInXamarin = type.Fields.Select (e => name.Replace ("Code","") + e.Name);
+            	var enumMembersInNewAppleLib = decl.Values.Select (e => e.Name);
+            	var missingEnums = enumMembersInNewAppleLib.Except (enumMembersInXamarin);
             	if (missingEnums.Any ()) {
             		foreach (var missingEnum in missingEnums) {
             			Log.On (framework).Add ($"!missing-enum-member! {name} : {missingEnum.Replace (name.Replace ("Code",""),"")} not bound");

--- a/tests/xtro-sharpie/EnumCheck.cs
+++ b/tests/xtro-sharpie/EnumCheck.cs
@@ -58,15 +58,17 @@ namespace Extrospection {
 				Log.On (framework).Add ($"!missing-enum! {name} not bound");
 				return;
 			} else {
-				var missingEnums = type.Fields.Select (e => e.Name).Except (decl.Values.Select (e => e.Name));
-				if (missingEnums.Any ()) {
-					foreach (var missingEnum in missingEnums) {
-						Log.On (framework).Add ($"!missing-enum-member! {name} : {missingEnum} not bound");
-					}
-					return;
-				}
-				enums.Remove (mname);
-			}
+            	var enumMemberInPreviousLib = type.Fields.Select (e => name.Replace ("Code","") + e.Name);
+            	var enumMemberInNewAppleLib = decl.Values.Select (e => e.Name);
+            	var missingEnums = enumMemberInNewAppleLib.Except (enumMemberInPreviousLib);
+            	if (missingEnums.Any ()) {
+            		foreach (var missingEnum in missingEnums) {
+            			Log.On (framework).Add ($"!missing-enum-member! {name} : {missingEnum.Replace (name.Replace ("Code",""),"")} not bound");
+            		}
+            		return;
+            	}
+            	enums.Remove (mname);
+            }
 
 			int native_size = 4;
 			bool native = false;

--- a/tests/xtro-sharpie/EnumCheck.cs
+++ b/tests/xtro-sharpie/EnumCheck.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using System.Linq;
 using Mono.Cecil;
 
 using Clang.Ast;
@@ -57,8 +57,16 @@ namespace Extrospection {
 			if (!enums.TryGetValue (mname, out var type)) {
 				Log.On (framework).Add ($"!missing-enum! {name} not bound");
 				return;
-			} else
+			} else {
+				var missingEnums = type.Fields.Select (e => e.Name).Except (decl.Values.Select (e => e.Name));
+				if (missingEnums.Any ()) {
+					foreach (var missingEnum in missingEnums) {
+						Log.On (framework).Add ($"!missing-enum-member! {name} : {missingEnum} not bound");
+					}
+					return;
+				}
 				enums.Remove (mname);
+			}
 
 			int native_size = 4;
 			bool native = false;


### PR DESCRIPTION
It's not working actually but it's a start. 

The problem I'm facing is sometimes the enum members doesn't have exactly the same name in Xamarin and new Apple lib, so I have false positive.

I tried to use this version by going into xtro folder and ```make``` but the ```!missing-enum-member!```appears in ```*.unclassified```files (until I ```make unclassified2todo```)

Here the ```name.Replace ("Code","")``` is because the enum members doesn't have the same name, I already see there is the same problem with ```Mask```. 

I also saw sometimes the enums members starts with the framework "short name" , e.g. : EventKit -> EKSomething, EKSomethingElse, etc. 