### PR TITLE
Update Versions-ios.plist.in with `altool` info

### DIFF
--- a/Versions-ios.plist.in
+++ b/Versions-ios.plist.in
@@ -146,6 +146,7 @@
 		<string>mono-symbol-archive</string>
 		<string>sgen-concurrent-gc</string>
 		<string>arm64_32</string>
+		<string>altool</string>
 	</array>
 	<key>Optimizations</key>
 	<dict>

--- a/Versions-mac.plist.in
+++ b/Versions-mac.plist.in
@@ -43,6 +43,7 @@
 		<string>link-platform</string>
 		<string>hybrid-aot</string>
 		<string>64-bit-only</string>
+		<string>altool</string>
 	</array>
 	<key>Optimizations</key>
 	<dict>


### PR DESCRIPTION
Needed for the IDEs to recognize if the SDK has support for App Store Connect upload/validation.