### PR TITLE
Allow to enable the use of the mono binary package from the configure script.

### DIFF
--- a/configure
+++ b/configure
@@ -27,7 +27,8 @@ Usage: configure [options]
 
     --disable-packaged-llvm Compile LLVM instead of downloading a precompiled version.
 
-    --disable-packaged-mono Compile Mono from source instead of downloading a precompiled version.
+    --enable-packaged-mono
+    --disable-packaged-mono Enable/disable using the precompiled version of mono. If disabled mono will be compiled from source.
 EOL
 }
 
@@ -90,6 +91,10 @@ while test x$1 != x; do
 		echo "DISABLE_DOWNLOAD_LLVM=1" >> $CONFIGURED_FILE
 		shift
 		;;
+    --enable-packaged-mono)
+        echo "MONO_BUILD_FROM_SOURCE=" >> "$CONFIGURED_FILE"
+        shift
+        ;;
     --disable-packaged-mono)
         echo "MONO_BUILD_FROM_SOURCE=1" >> "$CONFIGURED_FILE"
         shift


### PR DESCRIPTION
Adding this just to follow the pattern used in the other switches found in the script. I was a little confused when I wanted to move to use the package again and I did not have the switch. (calling ./configure was good enough, but is not bad to be consistent).