### PR TITLE
Add support for Apple Development certificates to Xamarin.Mac MSBuild

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Tasks/DetectSigningIdentity.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/DetectSigningIdentity.cs
@@ -12,9 +12,9 @@ namespace Xamarin.Mac.Tasks
 {
 	public class DetectSigningIdentity : DetectSigningIdentityTaskBase
 	{
-		static readonly string[] appStoreDistributionPrefixes = { "3rd Party Mac Developer Application" };
+		static readonly string[] appStoreDistributionPrefixes = { "3rd Party Mac Developer Application", "Apple Distribution" };
 		static readonly string[] directDistributionPrefixes = { "Developer ID Application" };
-		static readonly string[] developmentPrefixes = { "Mac Developer" };
+		static readonly string[] developmentPrefixes = { "Mac Developer", "Apple Development" };
 
 		protected override string[] DevelopmentPrefixes { get { return developmentPrefixes; } }
 		protected override string[] DirectDistributionPrefixes { get { return directDistributionPrefixes; } }

--- a/msbuild/Xamarin.Mac.Tasks/Tasks/DetectSigningIdentity.cs
+++ b/msbuild/Xamarin.Mac.Tasks/Tasks/DetectSigningIdentity.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Mac.Tasks
 		protected override string[] AppStoreDistributionPrefixes { get { return appStoreDistributionPrefixes; } }
 		protected override string DeveloperRoot { get { return MacOSXSdks.Native.DeveloperRoot; } }
 		protected override PlatformFramework Framework { get { return PlatformFramework.MacOS; } }
-		protected override string PlatformName { get { return "OS X"; } }
+		protected override string PlatformName { get { return "macOS"; } }
 		protected override string ApplicationIdentifierKey { get { return "com.apple.application-identifier"; } }
 	}
 }


### PR DESCRIPTION
Does mostly what the title says. I also took the opportunity to update an occurrence of "OS X" to the current branding.

Please note that I was not able to change the corresponding value for the iOS platform because those constants are in the Xamarin.MacDev submodule, and if I was make the changes in a fork, I would then have problems properly reintegrating the submodule change into this repository. I have included the required changes as a diff below; if someone could apply them for me (or tell me how I should best apply them myself), I would appreciate it. Thanks!

```diff
diff --git a/Xamarin.MacDev/IPhoneCertificate.cs b/Xamarin.MacDev/IPhoneCertificate.cs
index 326b041..efa96de 100644
--- a/Xamarin.MacDev/IPhoneCertificate.cs
+++ b/Xamarin.MacDev/IPhoneCertificate.cs
@@ -13,8 +13,8 @@ namespace Xamarin.MacDev
 {
 	public static class IPhoneCertificate
 	{
-		public static readonly string[] DevelopmentPrefixes = { "iPhone Developer", "iOS Development" };
-		public static readonly string[] DistributionPrefixes = { "iPhone Distribution", "iOS Distribution" };
+		public static readonly string[] DevelopmentPrefixes = { "iPhone Developer", "iOS Development", "Apple Development" };
+		public static readonly string[] DistributionPrefixes = { "iPhone Distribution", "iOS Distribution", "Apple Distribution" };
 
 		public static bool IsDevelopment (string name)
 		{
```