### PR TITLE
[Tests] Allow to ignore tests that fail on the interpreter.

### DIFF
--- a/tests/EmbeddedResources/EmbeddedResources.csproj
+++ b/tests/EmbeddedResources/EmbeddedResources.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -37,12 +37,16 @@
   <ItemGroup>
     <Reference Include="Xamarin.iOS" />
     <Reference Include="MonoTouch.NUnitLite" />
+    <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ResourcesTest.cs" />
+    <Compile Include="..\common\TestRuntime.cs">
+      <Link>TestRuntime.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Welcome.resx">

--- a/tests/EmbeddedResources/ResourcesTest.cs
+++ b/tests/EmbeddedResources/ResourcesTest.cs
@@ -32,17 +32,11 @@ namespace EmbeddedResources {
 		[Test]
 		public void Embedded ()
 		{
+
 #if __TVOS__
-			bool in_interpreter = false;
-			try {
-				AssemblyName aName = new AssemblyName ("DynamicAssemblyExample");
-				AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly (aName, AssemblyBuilderAccess.RunAndSave);
-				in_interpreter = true;
-			} catch (PlatformNotSupportedException) {
-				// we do not have the interpreter, lets continue
-			}
-			if (in_interpreter)
+			if (TestRuntime.CheckExecutingWithInterpreter ())
 				Assert.Ignore ("This test is disabled on TVOS."); // Randomly crashed on tvOS -> https://github.com/xamarin/maccore/issues/1909
+
 #endif
 
 #if MONOMAC

--- a/tests/EmbeddedResources/ResourcesTest.cs
+++ b/tests/EmbeddedResources/ResourcesTest.cs
@@ -11,6 +11,8 @@ using System;
 using System.IO;
 using System.Resources;
 using System.Globalization;
+using System.Reflection;
+using System.Reflection.Emit;
 using NUnit.Framework;
 
 #if XAMCORE_2_0
@@ -31,7 +33,16 @@ namespace EmbeddedResources {
 		public void Embedded ()
 		{
 #if __TVOS__
-			Assert.Ignore ("This test is disabled on TVOS."); // Randomly crashed on tvOS -> https://github.com/xamarin/maccore/issues/1909
+			bool in_interpreter = false;
+			try {
+				AssemblyName aName = new AssemblyName ("DynamicAssemblyExample");
+				AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly (aName, AssemblyBuilderAccess.RunAndSave);
+				in_interpreter = true;
+			} catch (PlatformNotSupportedException) {
+				// we do not have the interpreter, lets continue
+			}
+			if (in_interpreter)
+				Assert.Ignore ("This test is disabled on TVOS."); // Randomly crashed on tvOS -> https://github.com/xamarin/maccore/issues/1909
 #endif
 
 #if MONOMAC

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Reflection;
 using System.Reflection.Emit;
 
 #if XAMCORE_2_0
@@ -113,22 +112,19 @@ partial class TestRuntime
 		NUnit.Framework.Assert.Ignore (message);
 	}
 
-	public static void IgnoreInInterpreter (string message)
+	public static bool CheckExecutingWithInterpreter ()
 	{
 		// until System.Runtime.CompilerServices.RuntimeFeature.IsSupported("IsDynamicCodeCompiled") returns a valid result, atm it
 		// always return true, try to build an object of a class that should fail without introspection, and catch the exception to do the
 		// right thing
 		bool in_interpreter = false;
 		try {
-			AssemblyName aName = new AssemblyName ("DynamicAssemblyExample");
-			AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly (aName, AssemblyBuilderAccess.RunAndSave);
-			in_interpreter = true;
+			AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly (null, AssemblyBuilderAccess.RunAndSave);
+			return true;
 		} catch (PlatformNotSupportedException) {
 			// we do not have the interpreter, lets continue
+			return false;
 		}
-		if (!in_interpreter)
-			return;
-		NUnit.Framework.Assert.Ignore (message);
 	}
 
 	public static void AssertXcodeVersion (int major, int minor, int build = 0)

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -117,7 +117,6 @@ partial class TestRuntime
 		// until System.Runtime.CompilerServices.RuntimeFeature.IsSupported("IsDynamicCodeCompiled") returns a valid result, atm it
 		// always return true, try to build an object of a class that should fail without introspection, and catch the exception to do the
 		// right thing
-		bool in_interpreter = false;
 		try {
 			AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly (null, AssemblyBuilderAccess.RunAndSave);
 			return true;

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -9,6 +9,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Reflection;
+using System.Reflection.Emit;
 
 #if XAMCORE_2_0
 using AVFoundation;
@@ -107,6 +109,24 @@ partial class TestRuntime
 	{
 		var in_ci = !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("BUILD_REVISION"));
 		if (!in_ci)
+			return;
+		NUnit.Framework.Assert.Ignore (message);
+	}
+
+	public static void IgnoreInInterpreter (string message)
+	{
+		// until System.Runtime.CompilerServices.RuntimeFeature.IsSupported("IsDynamicCodeCompiled") returns a valid result, atm it
+		// always return true, try to build an object of a class that should fail without introspection, and catch the exception to do the
+		// right thing
+		bool in_interpreter = false;
+		try {
+			AssemblyName aName = new AssemblyName ("DynamicAssemblyExample");
+			AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly (aName, AssemblyBuilderAccess.RunAndSave);
+			in_interpreter = true;
+		} catch (PlatformNotSupportedException) {
+			// we do not have the interpreter, lets continue
+		}
+		if (!in_interpreter)
 			return;
 		NUnit.Framework.Assert.Ignore (message);
 	}


### PR DESCRIPTION
There are some failures that only happen in the interpreter. We add a
TestRuntime method that allow to check if the interpreter is used.

The resources tests are shared between different solutions and the
TestRuntime is not present, so we have to do check in the test.