### PR TITLE
[authenticationservices] Remove [Abstract] from ASAuthorizationPasswordRequest. Fix #6816

### DIFF
--- a/src/authenticationservices.cs
+++ b/src/authenticationservices.cs
@@ -452,8 +452,8 @@ namespace AuthenticationServices {
 
 	[Watch (6,0), TV (13,0), Mac (10,15), iOS (13,0)]
 	[BaseType (typeof (ASAuthorizationRequest))]
-	[Abstract] // see documentation
 	// Name: NSInvalidArgumentException Reason: -[ASAuthorizationPasswordRequest init]: unrecognized selector sent to instance 0x6000005f2dc0
+	[DisableDefaultCtor]
 	interface ASAuthorizationPasswordRequest { }
 
 	interface IASAuthorizationProvider { }


### PR DESCRIPTION
The documentation was updated and does not mention this anymore.

References:
* https://developer.apple.com/documentation/authenticationservices/asauthorizationpasswordrequest?language=objc
* https://github.com/xamarin/xamarin-macios/issues/6816