### PR TITLE
[tests] Fix MTouch's LinkerWarnings test for Xcode 11 beta 6

### DIFF
--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2755,7 +2755,7 @@ public class TestApp {
 				mtouch.TargetVer = "10.3"; // otherwise 32-bit build isn't possible
 				mtouch.AssertExecute (MTouchAction.BuildSim, "build a");
 				if (Configuration.XcodeVersion.Major >= 11) {
-					mtouch.AssertWarning (5203, $"Native linking warning: warning: ignoring file {lib}, building for iOS Simulator-i386 but attempting to link with file built for unknown-archive");
+					mtouch.AssertWarning (5203, $"Native linking warning: warning: ignoring file {lib}, building for iOS Simulator-i386 but attempting to link with file built for iOS Simulator-x86_64");
 				} else {
 					mtouch.AssertWarning (5203, $"Native linking warning: warning: ignoring file {lib}, file was built for archive which is not the architecture being linked (i386): {lib}");
 				}


### PR DESCRIPTION
We were getting:

```
Xamarin.MTouch.LinkerWarnings: The warning 'MT5203: Native linking warning: warning: ignoring file /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/test-libraries/.libs/ios/libtest.x86_64.a, building for iOS Simulator-i386 but attempting to link with file built for unknown-archive' was not found in the output:
    Message #1 did not match:
        actual: 'Native linking warning: warning: ignoring file /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/test-libraries/.libs/ios/libtest.x86_64.a, building for iOS Simulator-i386 but attempting to link with file built for iOS Simulator-x86_64'
        expected: 'Native linking warning: warning: ignoring file /Users/builder/jenkins/workspace/xamarin-macios/xamarin-macios/tests/test-libraries/.libs/ios/libtest.x86_64.a, building for iOS Simulator-i386 but attempting to link with file built for unknown-archive'
```