### PR TITLE
[monotouch-test] Fix PinAnnotationViewTest's InitWithFrame

### DIFF
--- a/tests/monotouch-test/MapKit/PinAnnotationViewTest.cs
+++ b/tests/monotouch-test/MapKit/PinAnnotationViewTest.cs
@@ -86,7 +86,7 @@ namespace MonoTouchFixtures.MapKit {
 				}
 #else
 				if (TestRuntime.CheckSystemVersion (PlatformName.iOS, 10, 0))
-					Assert.That (av.PinTintColor.ToString (), Is.EqualTo (UIColor.FromRGBA (255, 59, 48, 255).ToString ()), "PinTintColor");
+					Assert.NotNull (av.PinTintColor, "PinTintColor");
 				else
 					Assert.Null (av.PinTintColor, "PinTintColor"); // differs from the other init call
 #endif


### PR DESCRIPTION
FYI iOS 13 changed the tint color for the red pin, it's now (255, 69, 58, 255) instead of (255, 59, 48, 255).
Let's not test iOS colors for Apple (:
A simple NotNull check should be enough.