### PR TITLE
[msbuild] Fixes publishing targets

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -409,6 +409,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<Target Name="ValidateAppStoreBundle" DependsOnTargets="_DetectSdkLocations">
 		<ALToolValidate
+			SessionId="$(BuildSessionId)"
 			Username="$(Username)"
 			Password="$(Password)"
 			FilePath="$(FilePath)"
@@ -418,6 +419,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<Target Name="UploadAppStoreBundle" DependsOnTargets="_DetectSdkLocations">
 		<ALToolUpload
+			SessionId="$(BuildSessionId)"
 			Username="$(Username)"
 			Password="$(Password)"
 			FilePath="$(FilePath)"

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS.Common.targets
@@ -397,6 +397,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		
 		<CreateIpaDependsOn>
 			_BeforeCreateIpaForDistribution;
+			_CompileEntitlements;
 			_CoreCreateIpa;
 			_PackageOnDemandResources;
 			_ZipIpa


### PR DESCRIPTION
- Sets the missing SessionId property on the altool targets to enable running those from Visual Studio.
- Ensure Entitlements are compiled before creating an IPA. When creating an IPA from an archive the `CreateAppBundle` target will be skipped because we already have a bundle and the same will happen with the Entitlements compilation, but we need to re-compile those with the new certificate and profile. Adding `_CompileEntitlements` as a `CreateIpa` dependency will ensure it's run when creating an IPA file from an archive. Nothing changes when creating IPAs from a regular build since at the point the of creating the IPA the `_CompileEntitlements` target was already run, so it will be skipped.