### PR TITLE
[generator] Handle subclasses of NSObject as ref/out parameters in third-party libraries. Fixes #6828.

### DIFF
--- a/src/generator.cs
+++ b/src/generator.cs
@@ -1077,8 +1077,13 @@ public partial class Generator : IMemberGatherer {
 		if (type.IsSubclassOf (TypeManager.NSObject))
 			return true;
 
-		if (BindThirdPartyLibrary)
+		if (BindThirdPartyLibrary) {
+			var bta = ReflectionExtensions.GetBaseTypeAttribute (type, this);
+			if (bta?.BaseType != null)
+				return IsNSObject (bta.BaseType);
+
 			return false;
+		}
 
 		return type.IsInterface;
 	}

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -603,6 +603,12 @@ namespace GeneratorTests
 		[Test]
 		public void GHIssue6626 () => BuildFile (Profile.iOS, "ghissue6626.cs");
 
+		[Test]
+		public void VSTS970507 ()
+		{
+			BuildFile (Profile.iOS, "tests/vsts-970507.cs");
+		}
+
 		BGenTool BuildFile (Profile profile, params string [] filenames)
 		{
 			return BuildFile (profile, true, false, filenames);

--- a/tests/generator/generator-tests.csproj
+++ b/tests/generator/generator-tests.csproj
@@ -71,6 +71,7 @@
     <None Include="packages.config" />
     <None Include="tests\ref-out-parameters.cs" />
     <None Include="tests\return-release.cs" />
+    <None Include="tests\vsts-970507.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="tests\" />

--- a/tests/generator/tests/vsts-970507.cs
+++ b/tests/generator/tests/vsts-970507.cs
@@ -1,0 +1,18 @@
+using System;
+using Foundation;
+
+namespace NS
+{
+	[BaseType (typeof (NSObject))]
+	interface OutNSObject
+	{
+		[Export ("func:")]
+		void Func (out ErrorObject error);
+	}
+
+	[BaseType (typeof (NSObject))]
+	interface ErrorObject
+	{
+
+	}
+}


### PR DESCRIPTION
For third-party libraries we need to look up the base type using the BaseType attribute.

Fixes https://github.com/xamarin/xamarin-macios/issues/6828.