### PR TITLE
[Tests] Pass a parameter to avoid a NRE.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Reflection;
 using System.Reflection.Emit;
 
 #if XAMCORE_2_0
@@ -112,14 +113,14 @@ partial class TestRuntime
 		NUnit.Framework.Assert.Ignore (message);
 	}
 
+	static AssemblyName assemblyName = new AssemblyName ("DynamicAssemblyExample"); 
 	public static bool CheckExecutingWithInterpreter ()
 	{
 		// until System.Runtime.CompilerServices.RuntimeFeature.IsSupported("IsDynamicCodeCompiled") returns a valid result, atm it
 		// always return true, try to build an object of a class that should fail without introspection, and catch the exception to do the
 		// right thing
 		try {
-			AssemblyName aName = new AssemblyName ("DynamicAssemblyExample");
-			AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly (aName, AssemblyBuilderAccess.RunAndSave);
+			AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly (assemblyName, AssemblyBuilderAccess.RunAndSave);
 			return true;
 		} catch (PlatformNotSupportedException) {
 			// we do not have the interpreter, lets continue

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -118,7 +118,8 @@ partial class TestRuntime
 		// always return true, try to build an object of a class that should fail without introspection, and catch the exception to do the
 		// right thing
 		try {
-			AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly (null, AssemblyBuilderAccess.RunAndSave);
+			AssemblyName aName = new AssemblyName ("DynamicAssemblyExample");
+			AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly (aName, AssemblyBuilderAccess.RunAndSave);
 			return true;
 		} catch (PlatformNotSupportedException) {
 			// we do not have the interpreter, lets continue


### PR DESCRIPTION
An example of the failure can be found here: http://xamarin-storage/jenkins/xamarin-macios/master/55a95cff879db23b19a84b4bf94a52b8b1135659/2964024/device-tests/jenkins-results/tests/index.html

```
[FAIL] ResourcesTest.Embedded : System.ArgumentNullException : Value cannot be null. 
```