### PR TITLE
[monotouch-test] Ignore FontManagerTest's RegisterFontDescriptors_WithCallback

### DIFF
--- a/tests/monotouch-test/CoreText/FontManagerTest.cs
+++ b/tests/monotouch-test/CoreText/FontManagerTest.cs
@@ -216,16 +216,13 @@ namespace MonoTouchFixtures.CoreText {
 
 #if __TVOS__
 		[Ignore ("Fails on tvOS with undocumented error code 'The operation couldn’t be completed. (com.apple.CoreText.CTFontManagerErrorDomain error 500.'")]
+#elif __IOS__
+		[Ignore ("https://github.com/xamarin/xamarin-macios/issues/6690. This began failing for no aparent reason in iOS 13 Beta 5. Check back with GM.")]
 #endif
 		[Test]
 		public void RegisterFontDescriptors_WithCallback ()
 		{
 			TestRuntime.AssertXcodeVersion (11, 0);
-
-#if !__MACOS__
-			if (TestRuntime.CheckExactXcodeVersion (11, 0, beta: 6))
-				Assert.Ignore ("This began failing for no aparent reason in Beta 5, check back on a later beta.");
-#endif
 
 			CTFontDescriptorAttributes fda = new CTFontDescriptorAttributes () {
 				FamilyName = "Courier",


### PR DESCRIPTION
This test started failing on iOS 13 beta 5. It is still failing on beta 7.
This test is designed to fail at every new iOS version until it's fixed by Apple.
Let's ignore it for good, mention it in https://github.com/xamarin/xamarin-macios/issues/6212 and check it one last time at GM.