### PR TITLE
Add a dummy x86_64 slice to all our native libraries that don't have one.

### DIFF
--- a/builds/.gitignore
+++ b/builds/.gitignore
@@ -22,4 +22,5 @@ target64
 targettv
 targetwatch
 watchbcl
-
+*.dylib
+*.o

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -28,6 +28,10 @@ clean-locals::
 .stamp-download-%: downloads/$(basename $(MONO_IOS_FILENAME)) downloads/$(basename $(MONO_MAC_FILENAME))
 	$(Q) touch $@
 
+X86_64_SLICE=$(abspath $(CURDIR)/x86-64-slice.dylib)
+$(X86_64_SLICE): Makefile
+	echo "void x86_64_function_for_notarization_workaround () {}" | $(MAC_CC) -shared -x c -o$@ -
+
 ifeq ($(MONO_BUILD_FROM_SOURCE),)
 all-local:: download
 endif
@@ -1196,6 +1200,12 @@ $(BUILD_DESTDIR)/$(2)/tmp-lib/libmono-profiler-log.0.dylib: $(BUILD_DESTDIR)/$(2
 
 endef
 
+TARGET_SHAREDLIBLOGPROFILER+=$(X86_64_SLICE)
+TARGET_SHAREDMONOSGEN+=$(X86_64_SLICE)
+TARGET_SHAREDLIBMONONATIVEUNIFIED+=$(X86_64_SLICE)
+TARGET_SHAREDLIBMONONATIVECOMPAT+=$(X86_64_SLICE)
+TARGET_MONOFRAMEWORK+=$(X86_64_SLICE)
+
 ARM_ARCH_CONFIGURE_FLAGS=--host=arm-apple-darwin10 --disable-boehm
 ARM64_ARCH_CONFIGURE_FLAGS=--host=aarch64-apple-darwin10 --disable-boehm
 
@@ -1359,6 +1369,7 @@ WATCHOS_TARGET_LIBMONOSGEN = \
 	$(BUILD_DESTDIR)/targetwatch64_32/lib/libmonosgen-2.0.a
 
 WATCHOS_TARGET_SHAREDMONOSGEN = \
+	$(X86_64_SLICE) \
 	$(BUILD_DESTDIR)/targetwatch/lib/libmonosgen-2.0.dylib \
 	$(BUILD_DESTDIR)/targetwatch64_32/lib/libmonosgen-2.0.dylib
 
@@ -1379,6 +1390,7 @@ WATCHOS_TARGET_LIBMONOILGEN = \
 	$(BUILD_DESTDIR)/targetwatch64_32/lib/libmono-ilgen.a
 
 WATCHOS_TARGET_SHAREDLIBLOGPROFILER = \
+	$(X86_64_SLICE) \
 	$(BUILD_DESTDIR)/targetwatch/lib/libmono-profiler-log.0.dylib \
 	$(BUILD_DESTDIR)/targetwatch64_32/lib/libmono-profiler-log.0.dylib
 
@@ -1397,13 +1409,16 @@ WATCHOS_TARGET_LIBMONONATIVEUNIFIED       = \
 	$(BUILD_DESTDIR)/targetwatch64_32/lib/$(WATCHOS_ARM6432_LIBMONO_NATIVE_NAME).a \
 
 WATCHOS_TARGET_SHAREDLIBMONONATIVECOMPAT  = \
+	$(X86_64_SLICE) \
 	$(BUILD_DESTDIR)/targetwatch/lib/libmono-native-compat.dylib \
 
 WATCHOS_TARGET_SHAREDLIBMONONATIVEUNIFIED = \
+	$(X86_64_SLICE) \
 	$(BUILD_DESTDIR)/targetwatch/lib/libmono-native-unified.dylib \
 	$(BUILD_DESTDIR)/targetwatch64_32/lib/$(WATCHOS_ARM6432_LIBMONO_NATIVE_NAME).dylib \
 
 WATCHOS_TARGET_MONOFRAMEWORK = \
+	$(X86_64_SLICE) \
 	$(BUILD_DESTDIR)/targetwatch/tmp-lib/Mono \
 	$(BUILD_DESTDIR)/targetwatch64_32/tmp-lib/Mono
 
@@ -1448,7 +1463,7 @@ $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmonosgen-2.0.a: $(WATCHOS_TARGET
 $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmonosgen-2.0.dylib: $(WATCHOS_TARGET_SHAREDMONOSGEN) | $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib $(BUILD_DESTDIR)/targetwatch/tmp-lib $(BUILD_DESTDIR)/targetwatch64_32/tmp-lib
 	$(Q_STRIP) $(WATCHOS_BIN_PATH)/bitcode_strip $(BUILD_DESTDIR)/targetwatch/lib/libmonosgen-2.0.dylib -m -o $(BUILD_DESTDIR)/targetwatch/tmp-lib/libmonosgen-2.0.dylib
 	$(Q_STRIP) $(WATCHOS_BIN_PATH)/bitcode_strip $(BUILD_DESTDIR)/targetwatch64_32/lib/libmonosgen-2.0.dylib -m -o $(BUILD_DESTDIR)/targetwatch64_32/tmp-lib/libmonosgen-2.0.dylib
-	$(Q_STRIP) $(WATCHOS_BIN_PATH)/lipo $(BUILD_DESTDIR)/targetwatch/tmp-lib/libmonosgen-2.0.dylib $(BUILD_DESTDIR)/targetwatch64_32/tmp-lib/libmonosgen-2.0.dylib -create -output $@
+	$(Q_STRIP) $(WATCHOS_BIN_PATH)/lipo $(BUILD_DESTDIR)/targetwatch/tmp-lib/libmonosgen-2.0.dylib $(BUILD_DESTDIR)/targetwatch64_32/tmp-lib/libmonosgen-2.0.dylib $(X86_64_SLICE) -create -output $@
 	$(Q) $(WATCHOS_BIN_PATH)/install_name_tool -id @rpath/libmonosgen-2.0.dylib $@
 	$(Q) dsymutil -t 4 -o $@.dSYM $@
 
@@ -1467,7 +1482,7 @@ $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmono-ilgen.a: $(WATCHOS_TARGET_L
 $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmono-profiler-log.dylib: $(WATCHOS_TARGET_SHAREDLIBLOGPROFILER) | $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib $(BUILD_DESTDIR)/targetwatch/tmp-lib $(BUILD_DESTDIR)/targetwatch64_32/tmp-lib
 	$(Q) $(WATCHOS_BIN_PATH)/bitcode_strip $(BUILD_DESTDIR)/targetwatch/lib/libmono-profiler-log.0.dylib -m -o $(BUILD_DESTDIR)/targetwatch/tmp-lib/libmono-profiler-log.0.dylib
 	$(Q) $(WATCHOS_BIN_PATH)/bitcode_strip $(BUILD_DESTDIR)/targetwatch64_32/lib/libmono-profiler-log.0.dylib -m -o $(BUILD_DESTDIR)/targetwatch64_32/tmp-lib/libmono-profiler-log.0.dylib
-	$(Q) $(WATCHOS_BIN_PATH)/lipo $(BUILD_DESTDIR)/targetwatch/tmp-lib/libmono-profiler-log.0.dylib $(BUILD_DESTDIR)/targetwatch64_32/tmp-lib/libmono-profiler-log.0.dylib -create -output $@
+	$(Q) $(WATCHOS_BIN_PATH)/lipo $(BUILD_DESTDIR)/targetwatch/tmp-lib/libmono-profiler-log.0.dylib $(BUILD_DESTDIR)/targetwatch64_32/tmp-lib/libmono-profiler-log.0.dylib $(X86_64_SLICE) -create -output $@
 	$(Q) $(WATCHOS_BIN_PATH)/install_name_tool -id @rpath/libmono-profiler-log.dylib \
 		-change $(SDK_DESTDIR)/ios-targetwatch-release/lib/libmonosgen-2.0.1.dylib @rpath/libmonosgen-2.0.dylib \
 		-change $(SDK_DESTDIR)/ios-targetwatch64_32-release/lib/libmonosgen-2.0.1.dylib @rpath/libmonosgen-2.0.dylib \
@@ -1481,14 +1496,16 @@ $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmono-native-unified.a: $(WATCHOS
 	$(Q) $(WATCHOS_BIN_PATH)/lipo $(WATCHOS_TARGET_LIBMONONATIVEUNIFIED) -create -output $@
 
 $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmono-native-compat.dylib: $(WATCHOS_TARGET_SHAREDLIBMONONATIVECOMPAT) | $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib
-	$(Q) $(WATCHOS_BIN_PATH)/bitcode_strip $(WATCHOS_TARGET_SHAREDLIBMONONATIVECOMPAT) -m -o $@
+	$(Q) lipo $(WATCHOS_TARGET_SHAREDLIBMONONATIVECOMPAT) -create -output $@.tmp
+	$(Q) $(WATCHOS_BIN_PATH)/bitcode_strip $@.tmp -m -o $@
+	$(Q) rm -f $@.tmp
 	$(Q) $(WATCHOS_BIN_PATH)/install_name_tool -id @rpath/libmono-native-compat.dylib -change $(SDK_DESTDIR)/ios-targetwatch-release/lib/libmono-native-compat.dylib @rpath/libmono-native-compat.dylib -change $(SDK_DESTDIR)/ios-targetwatch-release/lib/libmonosgen-2.0.1.dylib @rpath/libmonosgen-2.0.dylib $@
 	$(Q) dsymutil -t 4 -o $@.dSYM $@
 
 $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib/libmono-native-unified.dylib: $(WATCHOS_TARGET_SHAREDLIBMONONATIVEUNIFIED) | $(IOS_DESTDIR)$(XAMARIN_WATCHOS_SDK)/usr/lib
 	$(Q_STRIP) $(WATCHOS_BIN_PATH)/bitcode_strip $(BUILD_DESTDIR)/targetwatch/lib/libmono-native-unified.dylib -m -o $(BUILD_DESTDIR)/targetwatch/tmp-lib/libmono-native-unified.dylib
 	$(Q_STRIP) $(WATCHOS_BIN_PATH)/bitcode_strip $(BUILD_DESTDIR)/targetwatch64_32/lib/$(WATCHOS_ARM6432_LIBMONO_NATIVE_NAME).dylib -m -o $(BUILD_DESTDIR)/targetwatch64_32/tmp-lib/libmono-native.dylib
-	$(Q_STRIP) $(WATCHOS_BIN_PATH)/lipo $(BUILD_DESTDIR)/targetwatch/tmp-lib/libmono-native-unified.dylib $(BUILD_DESTDIR)/targetwatch64_32/tmp-lib/libmono-native.dylib -create -output $@
+	$(Q_STRIP) $(WATCHOS_BIN_PATH)/lipo $(BUILD_DESTDIR)/targetwatch/tmp-lib/libmono-native-unified.dylib $(BUILD_DESTDIR)/targetwatch64_32/tmp-lib/libmono-native.dylib $(X86_64_SLICE) -create -output $@
 	$(Q) $(WATCHOS_BIN_PATH)/install_name_tool -id @rpath/libmono-native-unified.dylib \
 		-change $(SDK_DESTDIR)/ios-targetwatch64_32-release/lib/$(WATCHOS_ARM6432_LIBMONO_NATIVE_NAME).dylib @rpath/libmono-native-unified.dylib \
 		-change $(SDK_DESTDIR)/ios-targetwatch64_32-release/lib/libmonosgen-2.0.1.dylib @rpath/libmonosgen-2.0.dylib \
@@ -1553,16 +1570,16 @@ build-tvos: build-targettv
 clean-tvos: clean-targettv
 
 TVOS_TARGET_LIBMONOSGEN                = $(BUILD_DESTDIR)/targettv/lib/libmonosgen-2.0.a
-TVOS_TARGET_SHAREDMONOSGEN             = $(BUILD_DESTDIR)/targettv/lib/libmonosgen-2.0.dylib
+TVOS_TARGET_SHAREDMONOSGEN             = $(BUILD_DESTDIR)/targettv/lib/libmonosgen-2.0.dylib $(X86_64_SLICE)
 TVOS_TARGET_LIBLOGPROFILER             = $(BUILD_DESTDIR)/targettv/lib/libmono-profiler-log-static.a
 TVOS_TARGET_LIBMONOEEINTERP            = $(BUILD_DESTDIR)/targettv/lib/libmono-ee-interp.a
 TVOS_TARGET_LIBMONOICALLTABLE          = $(BUILD_DESTDIR)/targettv/lib/libmono-icall-table.a
 TVOS_TARGET_LIBMONOILGEN               = $(BUILD_DESTDIR)/targettv/lib/libmono-ilgen.a
-TVOS_TARGET_SHAREDLIBLOGPROFILER       = $(BUILD_DESTDIR)/targettv/lib/libmono-profiler-log.0.dylib
+TVOS_TARGET_SHAREDLIBLOGPROFILER       = $(BUILD_DESTDIR)/targettv/lib/libmono-profiler-log.0.dylib $(X86_64_SLICE)
 TVOS_TARGET_LIBMONONATIVECOMPAT        = $(BUILD_DESTDIR)/targettv/lib/libmono-native-compat.a
 TVOS_TARGET_LIBMONONATIVEUNIFIED       = $(BUILD_DESTDIR)/targettv/lib/libmono-native-unified.a
-TVOS_TARGET_SHAREDLIBMONONATIVECOMPAT  = $(BUILD_DESTDIR)/targettv/lib/libmono-native-compat.dylib
-TVOS_TARGET_SHAREDLIBMONONATIVEUNIFIED = $(BUILD_DESTDIR)/targettv/lib/libmono-native-unified.dylib
+TVOS_TARGET_SHAREDLIBMONONATIVECOMPAT  = $(BUILD_DESTDIR)/targettv/lib/libmono-native-compat.dylib $(X86_64_SLICE)
+TVOS_TARGET_SHAREDLIBMONONATIVEUNIFIED = $(BUILD_DESTDIR)/targettv/lib/libmono-native-unified.dylib $(X86_64_SLICE)
 
 $(TVOS_TARGET_LIBMONOSGEN): .stamp-build-targettv
 $(TVOS_TARGET_SHAREDMONOSGEN): .stamp-build-targettv
@@ -1641,8 +1658,9 @@ $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/usr/lib/libmono-native-unified.dylib: $(TVOS_T
 $(TVOS_DIRECTORIES):
 	$(Q) mkdir -p $@
 
-$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks/Mono.framework/Mono: $(BUILD_DESTDIR)/targettv/tmp-lib/Mono | $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks/Mono.framework
-	$(Q) $(CP) $< $@
+$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks/Mono.framework/Mono: $(BUILD_DESTDIR)/targettv/tmp-lib/Mono $(X86_64_SLICE) | $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks/Mono.framework
+	#$(Q) $(CP) $< $@
+	$(Q) lipo $(BUILD_DESTDIR)/targettv/tmp-lib/Mono $(X86_64_SLICE) -create -output $@
 	$(Q) dsymutil -t 4 -o $(patsubst %/,%,$(dir $@)).dSYM $@
 
 $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks/Mono.framework/Info.plist: Mono.framework-tvos.Info.plist | $(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks/Mono.framework

--- a/runtime/.gitignore
+++ b/runtime/.gitignore
@@ -9,3 +9,5 @@ app-main.m
 watchextension-main.m
 tvextension-main.m
 bindings-generated.m
+*.dylib
+*.o

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -29,6 +29,10 @@ SHARED_FILES = $(SHARED_SOURCES) $(SHARED_HEADERS) $(SHARED_I386_SOURCES) $(SHAR
 
 EXTRA_DEPENDENCIES = $(SHARED_HEADERS) $(TOP)/Make.config
 
+X86_64_SLICE=$(abspath $(CURDIR)/x86-64-slice.dylib)
+$(X86_64_SLICE): Makefile
+	echo "void x86_64_function_for_notarization_workaround_v2 () {}" | $(MAC_CC) -shared -x c -o$@ -
+
 xamarin/mono-runtime.h: mono-runtime.h.t4 exports.t4
 	$(Q_GEN) $(TT) $< -o $@
 
@@ -258,41 +262,41 @@ $$(foreach arch,$$($(2)_ARCHITECTURES),.libs/$(1)/tvextension-main.$$(arch).o): 
 	$(Q) install_name_tool -id @rpath/libxamarin-debug.dylib $$@
 	$(Q) install_name_tool -change @rpath/ @rpath/libmonosgen-2.0.dylib $$@
 
-.libs/$(1)/libxamarin-dev.dylib:  $$(foreach arch,$$($(2)_DEVICE_ARCHITECTURES),.libs/$(1)/libxamarin.$$(arch).dylib)
+.libs/$(1)/libxamarin-dev.dylib:  $$(foreach arch,$$($(2)_DEVICE_ARCHITECTURES),.libs/$(1)/libxamarin.$$(arch).dylib) $(X86_64_SLICE)
 	$(Q) rm -f $$@
-ifeq (1,$$(words $$($(2)_DEVICE_ARCHITECTURES)))
-	$(Q) $(CP) $$^ $$@
-else
+#ifeq (1,$$(words $$($(2)_DEVICE_ARCHITECTURES)))
+#	$(Q) $(CP) $$^ $$@
+#else
 	$$(call Q_2,LIPO,  [$1]) $(DEVICE_BIN_PATH)/lipo $$^ -create -output $$@
-endif
+#endif
 	$(Q) install_name_tool -id @rpath/libxamarin.dylib $$@
 	$(Q) install_name_tool -change @rpath/ @rpath/libmonosgen-2.0.dylib $$@
 
-.libs/$(1)/libxamarin-debug-dev.dylib:  $$(foreach arch,$$($(2)_DEVICE_ARCHITECTURES),.libs/$(1)/libxamarin-debug.$$(arch).dylib)
+.libs/$(1)/libxamarin-debug-dev.dylib:  $$(foreach arch,$$($(2)_DEVICE_ARCHITECTURES),.libs/$(1)/libxamarin-debug.$$(arch).dylib) $(X86_64_SLICE)
 	$(Q) rm -f $$@
-ifeq (1,$$(words $$($(2)_DEVICE_ARCHITECTURES)))
-	$(Q) $(CP) $$^ $$@
-else
+#ifeq (1,$$(words $$($(2)_DEVICE_ARCHITECTURES)))
+#	$(Q) $(CP) $$^ $$@
+#else
 	$$(call Q_2,LIPO,  [$1]) $(DEVICE_BIN_PATH)/lipo $$^ -create -output $$@
-endif
+#endif
 	$(Q) install_name_tool -id @rpath/libxamarin-debug.dylib $$@
 	$(Q) install_name_tool -change @rpath/ @rpath/libmonosgen-2.0.dylib $$@
 
-.libs/$(1)/Xamarin-dev.framework:  $$(foreach arch,$$($(2)_DEVICE_ARCHITECTURES),.libs/$(1)/Xamarin.$$(arch).framework)
+.libs/$(1)/Xamarin-dev.framework:  $$(foreach arch,$$($(2)_DEVICE_ARCHITECTURES),.libs/$(1)/Xamarin.$$(arch).framework) $(X86_64_SLICE)
 	$(Q) rm -f $$@
-ifeq (1,$$(words $$($(2)_DEVICE_ARCHITECTURES)))
-	$(Q) $(CP) $$^ $$@
-else
+#ifeq (1,$$(words $$($(2)_DEVICE_ARCHITECTURES)))
+#	$(Q) $(CP) $$^ $$@
+#else
 	$$(call Q_2,LIPO,  [$1]) $(DEVICE_BIN_PATH)/lipo $$^ -create -output $$@
-endif
+#endif
 
-.libs/$(1)/Xamarin-debug-dev.framework:  $$(foreach arch,$$($(2)_DEVICE_ARCHITECTURES),.libs/$(1)/Xamarin-debug.$$(arch).framework)
+.libs/$(1)/Xamarin-debug-dev.framework:  $$(foreach arch,$$($(2)_DEVICE_ARCHITECTURES),.libs/$(1)/Xamarin-debug.$$(arch).framework) $(X86_64_SLICE)
 	$(Q) rm -f $$@
-ifeq (1,$$(words $$($(2)_DEVICE_ARCHITECTURES)))
-	$(Q) $(CP) $$^ $$@
-else
+#ifeq (1,$$(words $$($(2)_DEVICE_ARCHITECTURES)))
+#	$(Q) $(CP) $$^ $$@
+#else
 	$$(call Q_2,LIPO,  [$1]) $(DEVICE_BIN_PATH)/lipo $$^ -create -output $$@
-endif
+#endif
 
 .libs/$(1)/Xamarin-sim.framework:  $$(foreach arch,$$($(2)_SIM_ARCHITECTURES),.libs/$(1)/Xamarin.$$(arch).framework)
 	$(Q) rm -f $$@

--- a/tests/common/ProductTests.cs
+++ b/tests/common/ProductTests.cs
@@ -70,6 +70,8 @@ namespace Xamarin.Tests
 			foreach (var machoFile in machoFiles) {
 				var fatfile = MachO.Read (machoFile);
 				foreach (var slice in fatfile) {
+					if (slice.IsDynamicLibrary && slice.Architecture == MachO.Architectures.x86_64 && slice.Parent.size < 10240 /* this is the dummy x86_64 slice to appease Apple's notarization tooling */)
+						continue;
 					var any_load_command = false;
 					foreach (var lc in slice.load_commands) {
 

--- a/tools/common/MachO.cs
+++ b/tools/common/MachO.cs
@@ -585,6 +585,7 @@ namespace Xamarin
 		public List<LoadCommand> load_commands;
 
 		public string Filename { get { return filename; } }
+		public FatEntry Parent { get { return fat_parent; } }
 
 		public MachOFile (FatEntry parent)
 		{

--- a/tools/mtouch/Application.cs
+++ b/tools/mtouch/Application.cs
@@ -1776,6 +1776,10 @@ namespace Xamarin.Bundler {
 						}
 						if (LibMonoLinkMode == AssemblyBuildTarget.Framework)
 							Driver.XcodeRun ("install_name_tool", "-change @rpath/libmonosgen-2.0.dylib @rpath/Mono.framework/Mono " + StringUtils.Quote (targetPath));
+
+						// Remove architectures we don't care about.
+						if (IsDeviceBuild)
+							MachO.SelectArchitectures (targetPath, AllArchitectures);
 					} else {
 						Driver.Log (3, "Target '{0}' is up-to-date.", targetPath);
 					}


### PR DESCRIPTION
Apple's notarization tool has a bug where they incorrectly flag Mach-O
binaries without an x86_64 slice, so make sure all our libraries have one.