### PR TITLE
[registrar] Fix verification of generic parameters to accept unrelated generic types. Fixes #6687.

### DIFF
--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -503,20 +503,7 @@ namespace Registrar {
 				return rv;
 			}
 
-			if (type.IsGenericType) {
-				var rv = true;
-				var args = type.GetGenericArguments ();
-				var constrs = new Type [args.Length];
-				for (int i = 0; i < args.Length; i++) {
-					Type constr;
-					rv &= VerifyIsConstrainedToNSObject (args [i], out constr);
-					constrs [i] = constr;
-				}
-				constrained_type = type.GetGenericTypeDefinition ().MakeGenericType (constrs);
-				return rv;
-			}
-
-			return false;
+			return true;
 		}
 
 		protected override Exception CreateException (int code, Exception innerException, MethodBase method, string message, params object[] args)

--- a/tests/monotouch-test/ObjCRuntime/Messaging.cs
+++ b/tests/monotouch-test/ObjCRuntime/Messaging.cs
@@ -254,6 +254,9 @@ namespace MonoTouch.ObjCRuntime
 
 		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public extern static void void_objc_msgSend_int_int_int (IntPtr receiver, IntPtr selector, int p1, ref int p2, out int p3);
+
+		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		public extern static void void_objc_msgSend_IntPtr_IntPtr_BlockLiteral (IntPtr receiver, IntPtr selector, IntPtr p1, IntPtr p2, ref BlockLiteral p3);
 	}
 }
 

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -5252,7 +5252,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		[Test]
 		public void GenericClassWithUnrelatedGenericDelegate ()
 		{
-			using (var obj = new GenericWebViewController<NSObject> ()) {
+			using (var obj = new GenericWebNavigationThingie<NSObject> ()) {
 				var handler_called = false;
 				Action<WKNavigationActionPolicy> handler = new Action<WKNavigationActionPolicy> ((v) => {
 					handler_called = true;
@@ -5424,7 +5424,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 
 #if !__WATCHOS__ && !__TVOS__ // No WebKit on watchOS/tvOS
 	[Preserve]
-	public class GenericWebViewController<WebViewModel> : UIViewController, IWKNavigationDelegate {
+	public class GenericWebNavigationThingie<WebViewModel> : NSObject, IWKNavigationDelegate {
 		[Export ("webView:decidePolicyForNavigationAction:decisionHandler:")]
 		public void DecidePolicy (WKWebView webView, WKNavigationAction navigationAction, Action<WKNavigationActionPolicy> decisionHandler)
 		{


### PR DESCRIPTION
When we export generic classes to Objective-C, we verify that any generic
parameters are constrained so that we know how to handle them.

Example:

    class MyObj<T> : NSObject where T: NSObject
    {
        [Export ("foo:")]
        public void Foo (T obj);
    }

in this case we verify that the parameter T is constrained to NSObject, so
that we can treat the argument like an NSObject.

The problem was when the function contained a generic type which was not
related to T:

    class MyObj<T> : NSObject where T: NSObject
    {
        [Export ("foo:")]
        public void Foo (Action<int> obj);
    }

in which case the same logic would kick in and reject the Action<int> type
since it's not related to NSObject (no generic arguments could be found, and
the default response was 'not valid').

So I've changed the default response for generic types that are unrelated to
the generic parameter we're verifying to accept such types.

Fixes https://github.com/xamarin/xamarin-macios/issues/6687.