### PR TITLE
[runtime] Fix usage of objc_msgSend[Super] according to modified headers.

### DIFF
--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -162,8 +162,8 @@ define NativeCompilationTemplate
 	$$(call Q_2,LD,    [tvos]) $(DEVICE_CC)    $(DEVICETV_CFLAGS)            $$(EXTRA_FLAGS) -dynamiclib -o $$@ $$^ -F$(IOS_DESTDIR)$(XAMARIN_TVOS_SDK)/Frameworks -fapplication-extension
 endef
 
-$(eval $(call NativeCompilationTemplate,,-O2 -DOBJC_OLD_DISPATCH_PROTOTYPES=1))
-$(eval $(call NativeCompilationTemplate,-debug,-DDEBUG -DOBJC_OLD_DISPATCH_PROTOTYPES=1))
+$(eval $(call NativeCompilationTemplate,,-O2))
+$(eval $(call NativeCompilationTemplate,-debug,-DDEBUG))
 
 .libs/ios .libs/watchos .libs/tvos:
 	$(Q) mkdir -p $@

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -482,8 +482,8 @@ SYSTEM_LAUNCHER$(2)_OBJECTS = $$(foreach src,$$(MAC_SOURCES),.libs/mac/$$(basena
 
 endef
 
-$(eval $(call ObjTemplate,x86_64,64,,-DOBJC_OLD_DISPATCH_PROTOTYPES=1,64))
-$(eval $(call ObjTemplate,x86_64,DEBUG64,-debug,-DDEBUG -DOBJC_OLD_DISPATCH_PROTOTYPES=1,64))
+$(eval $(call ObjTemplate,x86_64,64,,,64))
+$(eval $(call ObjTemplate,x86_64,DEBUG64,-debug,-DDEBUG,64))
 
 $(foreach arch,$(MAC_ARCHITECTURES),.libs/mac/extension-main.$(arch).o): EXTRA_DEFINES=-DEXTENSION
 

--- a/runtime/monotouch-support.h
+++ b/runtime/monotouch-support.h
@@ -16,8 +16,8 @@ const char *   xamarin_GetFolderPath (int folder);
 #endif
 
 #if defined (__arm64__)
-void objc_msgSend_stret (id self, SEL op, ...);
-void objc_msgSendSuper_stret (struct objc_super *super, SEL op, ...);
+void objc_msgSend_stret (void);
+void objc_msgSendSuper_stret (void);
 #endif
 
 #ifdef __cplusplus

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -383,7 +383,8 @@ xamarin_invoke_objc_method_implementation (id self, SEL sel, IMP xamarin_impl)
 	// COOP: does not access managed memory: any mode
 	struct objc_super sup;
 	find_objc_method_implementation (&sup, self, sel, xamarin_impl);
-	return objc_msgSendSuper (&sup, sel);
+	typedef id (*func_objc_msgSendSuper) (struct objc_super *sup, SEL sel);
+	return ((func_objc_msgSendSuper) objc_msgSendSuper) (&sup, sel);
 }
 
 #if MONOMAC

--- a/runtime/xamarin-support.m
+++ b/runtime/xamarin-support.m
@@ -158,15 +158,15 @@ xamarin_GetFolderPath (int folder)
 // it impossible to disable dlsym and, for example, run dontlink on devices
 // https://bugzilla.xamarin.com/show_bug.cgi?id=36569#c4
 
-void objc_msgSend_stret (id self, SEL op, ...)
+void objc_msgSend_stret (void)
 {
-	PRINT ("Unimplemented objc_msgSend_stret %s", sel_getName (op));
+	PRINT ("Unimplemented objc_msgSend_stret");
 	abort ();
 }
 
-void objc_msgSendSuper_stret (struct objc_super *super, SEL op, ...)
+void objc_msgSendSuper_stret (void)
 {
-	PRINT ("Unimplemented objc_msgSendSuper_stret %s", sel_getName (op));
+	PRINT ("Unimplemented objc_msgSendSuper_stret");
 	abort ();
 }
 

--- a/tools/mmp/Makefile
+++ b/tools/mmp/Makefile
@@ -60,7 +60,7 @@ Xamarin.Mac.registrar.full.x86_64.m:   $(TOP)/src/build/mac/full-64/Xamarin.Mac.
 	$(Q) touch Xamarin.Mac.registrar.full.x86_64.m Xamarin.Mac.registrar.full.x86_64.h
 
 Xamarin.Mac.registrar.%.x86_64.a: Xamarin.Mac.registrar.%.x86_64.m
-	$(Q_CC) xcrun -sdk macosx clang -DDEBUG -DOBJC_OLD_DISPATCH_PROTOTYPES=1 -g -gdwarf-2 -x objective-c++ -stdlib=libc++ -o $@ -c -arch x86_64 $< -Wall -Wno-unguarded-availability-new -I$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/include -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -fobjc-runtime=macosx
+	$(Q_CC) xcrun -sdk macosx clang -DDEBUG -g -gdwarf-2 -x objective-c++ -stdlib=libc++ -o $@ -c -arch x86_64 $< -Wall -Wno-unguarded-availability-new -I$(MAC_DESTDIR)$(MAC_FRAMEWORK_CURRENT_DIR)/include -mmacosx-version-min=$(MIN_OSX_SDK_VERSION) -fobjc-runtime=macosx
 
 Xamarin.Mac.registrar.%.a: Xamarin.Mac.registrar.%.x86_64.a
 	$(Q_LIPO) $(DEVICE_BIN_PATH)/lipo -create -output $@ $^


### PR DESCRIPTION
It's now required to cast objc_msgSend[Super] to a function of the correct
signature, so let's do that.

Also remove the define that allowed us to use the previous behavior.