### PR TITLE
[UIKit] Fix threading issue in the selector performAsCurrentTraitCollection. #6870

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -15295,6 +15295,7 @@ namespace UIKit {
 		[Export ("currentTraitCollection", ArgumentSemantic.Strong)]
 		UITraitCollection CurrentTraitCollection { get; set; }
 
+		[ThreadSafe]
 		[TV (13,0), NoWatch, iOS (13,0)]
 		[Export ("performAsCurrentTraitCollection:")]
 		void PerformAsCurrentTraitCollection (Action actions);


### PR DESCRIPTION
The thread safe decorator was missing which made the API not behave like the Apple docs states.

https://github.com/xamarin/xamarin-macios/issues/6870