### PR TITLE
[d16-3] [Foundation] Ensure that the collection is not modified during the loop. #6704

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -195,8 +195,8 @@ namespace Foundation {
 
 		void BackgroundNotificationCb (NSNotification obj)
 		{
-			// the cancelation task of each of the soruces will clean the different resources. Each removal is done
-			// inside a lock, but of course, the .Values collection will not like that because is modify during the
+			// the cancelation task of each of the sources will clean the different resources. Each removal is done
+			// inside a lock, but of course, the .Values collection will not like that because it is modified during the
 			// iteration. We split the operation in two, get all the diff cancelation sources, then try to cancel each of them
 			// which will do the correct lock dance. Note that we could be tempted to do a RemoveAll, that will yield the same
 			// runtime issue, this is dull but safe. 

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -195,11 +195,16 @@ namespace Foundation {
 
 		void BackgroundNotificationCb (NSNotification obj)
 		{
-			// we do not need to call the lock, we call cancel on the source, that will trigger all the needed code to 
-			// clean the resources and such
+			// the cancelation task of each of the soruces will clean the different resources. Each removal is done
+			// inside a lock, but of course, the .Values collection will not like that because is modify during the
+			// iteration. We split the operation in two, get all the diff cancelation sources, then try to cancel each of them
+			// which will do the correct lock dance. Note that we could be tempted to do a RemoveAll, that will yield the same
+			// runtime issue, this is dull but safe. 
+			var sources = new List <TaskCompletionSource<HttpResponseMessage>> (inflightRequests.Count);
 			foreach (var r in inflightRequests.Values) {
-				r.CompletionSource.TrySetCanceled ();
+				sources.Add (r.CompletionSource);
 			}
+			sources.ForEach (source => { source.TrySetCanceled (); });
 		}
 #endif
 


### PR DESCRIPTION
Collections should not be modified during the loop, this is bad
practice and was a side effect of the TrySetCanceled. Is better to
create a temp collection with all the sources and cancel each of them.

Fixes https://github.com/xamarin/xamarin-macios/issues/6704

Backport of #6877.

/cc @mandel-macaque 