### PR TITLE
[generator] Fix CS1522 warning building generated bindings

### DIFF
--- a/src/generator-enums.cs
+++ b/src/generator-enums.cs
@@ -165,20 +165,23 @@ public partial class Generator {
 			print ("{");
 			indent++;
 			print ("IntPtr ptr = IntPtr.Zero;");
-			print ("switch (({0}) self) {{", underlying_type);
-			var default_symbol_name = default_symbol?.Item2.SymbolName;
-			// more than one enum member can share the same numeric value - ref: #46285
-			foreach (var kvp in fields) {
-				print ("case {0}: // {1}.{2}", Convert.ToInt64 (kvp.Key.GetRawConstantValue ()), type.Name, kvp.Key.Name);
-				var sn = kvp.Value.SymbolName;
-				if (sn == default_symbol_name)
-					print ("default:");
-				indent++;
-				print ("ptr = {0};", sn);
-				print ("break;");
-				indent--;
+			// can be empty - and the C# compiler emit `warning CS1522: Empty switch block`
+			if (fields.Count > 0) {
+				print ("switch (({0}) self) {{", underlying_type);
+				var default_symbol_name = default_symbol?.Item2.SymbolName;
+				// more than one enum member can share the same numeric value - ref: #46285
+				foreach (var kvp in fields) {
+					print ("case {0}: // {1}.{2}", Convert.ToInt64 (kvp.Key.GetRawConstantValue ()), type.Name, kvp.Key.Name);
+					var sn = kvp.Value.SymbolName;
+					if (sn == default_symbol_name)
+						print ("default:");
+					indent++;
+					print ("ptr = {0};", sn);
+					print ("break;");
+					indent--;
+				}
+				print ("}");
 			}
-			print ("}");
 			print ("return (NSString) Runtime.GetNSObject (ptr);");
 			indent--;
 			print ("}");


### PR DESCRIPTION
It's now possible to have an empty smart `enum` but this was generating
an empty switch statement that `csc` would warn us about, e.g.

```
build/{profile}/ASAuthorizationProviderAuthorizationOperation.g.cs(64,24): warning CS1522: Empty switch block
```

This fix the generation to skip the `switch` generation when no fields
are present in the enum.