### PR TITLE
[xcode11] [tests] Change URL for UrlSessionTest.CreateDataTaskAsync

### DIFF
--- a/tests/monotouch-test/Foundation/UrlSessionTest.cs
+++ b/tests/monotouch-test/Foundation/UrlSessionTest.cs
@@ -42,7 +42,7 @@ namespace MonoTouchFixtures.Foundation {
 			TestRuntime.AssertXcodeVersion (5, 0);
 			
 			NSUrlSession session = NSUrlSession.SharedSession;
-			var url = new NSUrl ("https://www.xamarin.com");
+			var url = new NSUrl ("https://www.microsoft.com");
 			var tmpfile = Path.GetTempFileName ();
 			File.WriteAllText (tmpfile, "TMPFILE");
 			var file_url = NSUrl.FromFilename (tmpfile);


### PR DESCRIPTION
The current https://www.xamarin.com is being redirected to https://dotnet.microsoft.com/apps/xamarin but it takes a long time to completely load (not sure why) and that could be why we fail since we have a 30 seconds timeout - and it took more than that to (stop) load into safari.
    
Switching to https://www.microsoft.com/ is a lot faster and seems to fix the issue.
    
Reference:
https://github.com/xamarin/maccore/issues/1939

Backport of #6890.

/cc @spouliot 