### PR TITLE
Remove lists.xamarin.com from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you are interested in fixing issues and contributing directly to the code bas
 - [Request a new feature](https://github.com/xamarin/xamarin-macios/wiki/Submitting-Bugs-&-Suggestions#writing-good-bug-reports-and-feature-requests) on GitHub
 - [Vote on existing feature requests](https://github.com/xamarin/xamarin-macios/wiki/Submitting-Bugs-&-Suggestions#before-submitting-an-issue)
 - [Submit bugs to GitHub Issues](https://github.com/xamarin/xamarin-macios/wiki/Submitting-Bugs-&-Suggestions)
-- Discuss development and design on [Gitter](https://gitter.im/xamarin/xamarin-macios) or email [macios-devel@lists.xamarin.com](http://lists.xamarin.com/mailman/listinfo/macios-devel)
+- Discuss development and design on [Gitter](https://gitter.im/xamarin/xamarin-macios)
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/xamarin/xamarin-macios?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 


### PR DESCRIPTION
The mailing list no longer exists.