### PR TITLE
[tests] Skip font manager test in OS versions where it crashes due to bugs in the OS.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -205,6 +205,18 @@ partial class TestRuntime
 #else
 				throw new NotImplementedException ();
 #endif
+			case 1: // This is guesswork until Apple actually releases an Xcode 11.1.
+#if __WATCHOS__
+				return CheckWatchOSSystemVersion (6, 1);
+#elif __TVOS__
+				return ChecktvOSSystemVersion (13, 1);
+#elif __IOS__
+				return CheckiOSSystemVersion (13, 1);
+#elif MONOMAC
+				return CheckMacSystemVersion (10, 15, 1);
+#else
+				throw new NotImplementedException ();
+#endif
 			default:
 				throw new NotImplementedException ();
 			}

--- a/tests/monotouch-test/CoreText/FontManagerTest.cs
+++ b/tests/monotouch-test/CoreText/FontManagerTest.cs
@@ -198,10 +198,9 @@ namespace MonoTouchFixtures.CoreText {
 
 #if !__WATCHOS__
 		[Test]
-		[Ignore ("https://github.com/xamarin/maccore/issues/1898")]
 		public void RegisterFontDescriptors_NoCallback ()
 		{
-			TestRuntime.AssertXcodeVersion (11, 0);
+			TestRuntime.AssertXcodeVersion (11, 1); // Introduced in iOS 13.0, but with a bug that makes it crash. Apple fixed it for iOS 13.1
 			CTFontDescriptorAttributes fda = new CTFontDescriptorAttributes () {
 				FamilyName = "Courier",
 				StyleName = "Bold",


### PR DESCRIPTION
Calls to CTFontManagerRegisterFontDescriptors with a null callback will crash
unless on iOS 13.1, so don't run this test on earlier OS versions.

Also update AssertXcodeVersion to cope with Xcode 11.1, which is unfortunately
just guesswork until an actual Xcode 11.1 is released (currently we can't
distinguish between iOS 13.0 and iOS 13.1 using the Xcode version, because
Xcode 11b7 supports them both, so for now we assume there will be an Xcode
11.1 which will support iOS 13.1).