### PR TITLE
[src] Fix generic Contacts API. Fixes #6561.

### DIFF
--- a/src/Foundation/NSEnumerator_1.cs
+++ b/src/Foundation/NSEnumerator_1.cs
@@ -1,0 +1,54 @@
+//
+// Copyright 2019 Microsoft Corp (http://www.microsoft.com)
+//
+// This file contains a generic version of NSEnumerator.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+using ObjCRuntime;
+
+namespace Foundation {
+	[Register ("NSEnumerator", SkipRegistration = true)]
+	public sealed class NSEnumerator<TKey> : NSEnumerator
+		where TKey : class, INativeObject
+	{
+		public NSEnumerator ()
+		{
+		}
+
+		internal NSEnumerator (IntPtr handle)
+			: base (handle)
+		{
+		}
+
+		// Strongly typed versions of API from NSEnumerator
+
+		public new TKey NextObject ()
+		{
+			return (TKey) (object) base.NextObject ();
+		}
+	}
+}

--- a/src/contacts.cs
+++ b/src/contacts.cs
@@ -1439,7 +1439,7 @@ namespace Contacts {
 	[Watch (6,0), Mac (10,15), iOS (13,0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
-	interface CNFetchResult {
+	interface CNFetchResult<T> {
 		[Export ("value", ArgumentSemantic.Strong)]
 		NSObject Value { get; }
 
@@ -1475,15 +1475,15 @@ namespace Contacts {
 		[return: NullAllowed]
 		NSObject GetUnifiedMeContact (NSArray keys, [NullAllowed] out NSError error);
 
-		/* Unable to bind due to generic type errors: https://github.com/xamarin/xamarin-macios/issues/6561
+		[Watch (6,0), Mac (10,15), iOS (13,0)]
 		[Export ("enumeratorForContactFetchRequest:error:")]
 		[return: NullAllowed]
-		CNFetchResult<NSEnumerator<CNContact>> GetEnumeratorForContact (CNContactFetchRequest request, [NullAllowed] out NSError error);*/
+		CNFetchResult<NSEnumerator<CNContact>> GetEnumeratorForContact (CNContactFetchRequest request, [NullAllowed] out NSError error);
 
-		/* Unable to bind due to generic type errors: https://github.com/xamarin/xamarin-macios/issues/6561
+		[Watch (6,0), Mac (10,15), iOS (13,0)]
 		[Export ("enumeratorForChangeHistoryFetchRequest:error:")]
 		[return: NullAllowed]
-		CNFetchResult<NSEnumerator<CNChangeHistoryEvent>> GetEnumeratorForChangeHistory (CNChangeHistoryFetchRequest request, [NullAllowed] out NSError error);*/
+		CNFetchResult<NSEnumerator<CNChangeHistoryEvent>> GetEnumeratorForChangeHistory (CNChangeHistoryFetchRequest request, [NullAllowed] out NSError error);
 
 
 #if !XAMCORE_4_0 && !WATCH

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -3978,6 +3978,8 @@ namespace Foundation
 		NSObject NextObject (); 
 	}
 
+	interface NSEnumerator<T> : NSEnumerator {}
+
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface NSError : NSSecureCoding, NSCopying {

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -730,6 +730,7 @@ FOUNDATION_SOURCES = \
 	Foundation/NSDictionary_2.cs \
 	Foundation/NSDirectoryEnumerator.cs \
 	Foundation/NSDistributedNotificationCenter.cs \
+	Foundation/NSEnumerator_1.cs \
 	Foundation/NSErrorException.cs \
 	Foundation/NSExpression.cs \
 	Foundation/NSExtension.cs \

--- a/tests/xtro-sharpie/iOS-Contacts.todo
+++ b/tests/xtro-sharpie/iOS-Contacts.todo
@@ -1,2 +1,0 @@
-!missing-selector! CNContactStore::enumeratorForChangeHistoryFetchRequest:error: not bound
-!missing-selector! CNContactStore::enumeratorForContactFetchRequest:error: not bound

--- a/tests/xtro-sharpie/macOS-Contacts.todo
+++ b/tests/xtro-sharpie/macOS-Contacts.todo
@@ -1,2 +1,0 @@
-!missing-selector! CNContactStore::enumeratorForChangeHistoryFetchRequest:error: not bound
-!missing-selector! CNContactStore::enumeratorForContactFetchRequest:error: not bound

--- a/tests/xtro-sharpie/watchOS-Contacts.todo
+++ b/tests/xtro-sharpie/watchOS-Contacts.todo
@@ -1,2 +1,0 @@
-!missing-selector! CNContactStore::enumeratorForChangeHistoryFetchRequest:error: not bound
-!missing-selector! CNContactStore::enumeratorForContactFetchRequest:error: not bound


### PR DESCRIPTION
Make CNFetchResult generic (which it is in Objective-C), and add a generic
version of NSEnumerator (which Objective-C also has), so that we can bind two
API in CNContactStore that uses generic versions of those types.

Fixes https://github.com/xamarin/xamarin-macios/issues/6561.