### PR TITLE
[registrar] Ignore method encodings when processing copyback arguments in the dynamic registrar. Fixes #6883.

### DIFF
--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -539,6 +539,9 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 			goto exception_handling;
 		for (i = 0; i < num_arg; i++) {
 			const char *type = [sig getArgumentTypeAtIndex: (i+2)];
+
+			type = xamarin_skip_encoding_flags (type);
+
 			int size = xamarin_objc_type_size (type);
 
 			p = mono_signature_get_params (msig, &iter);

--- a/tests/bindings-test/ApiDefinition.cs
+++ b/tests/bindings-test/ApiDefinition.cs
@@ -302,6 +302,9 @@ namespace Bindings.Test {
 	{
 		[Export ("idAsIntPtr:")]
 		void IdAsIntPtr (IntPtr p1);
+
+		[Export ("methodEncodings:obj2:obj3:obj4:obj5:obj6:obj7:")]
+		void GetMethodEncodings (ref NSObject obj1, ref NSObject obj2, ref NSObject obj3, ref NSObject obj4, ref NSObject obj5, ref NSObject obj6, ref NSObject obj7);
 	}
 
 	[Protocol]

--- a/tests/monotouch-test/ObjCRuntime/Messaging.cs
+++ b/tests/monotouch-test/ObjCRuntime/Messaging.cs
@@ -254,6 +254,9 @@ namespace MonoTouch.ObjCRuntime
 
 		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public extern static void void_objc_msgSend_int_int_int (IntPtr receiver, IntPtr selector, int p1, ref int p2, out int p3);
+
+		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		public extern static void void_objc_msgSend_IntPtr_IntPtr_IntPtr_IntPtr_IntPtr_IntPtr_IntPtr (IntPtr receiver, IntPtr selector, ref IntPtr p1, ref IntPtr p2, ref IntPtr p3, ref IntPtr p4, ref IntPtr p5, ref IntPtr p6, ref IntPtr p7);
 	}
 }
 

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -4863,6 +4863,50 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 		}
 
+		[Test]
+		public void MethodEncodings ()
+		{
+			using (var met = new MethodEncodingsTests ()) {
+				IntPtr obj1 = IntPtr.Zero, obj2 = IntPtr.Zero, obj3 = IntPtr.Zero, obj4 = IntPtr.Zero, obj5 = IntPtr.Zero, obj6 = IntPtr.Zero, obj7 = IntPtr.Zero;
+				Messaging.void_objc_msgSend_IntPtr_IntPtr_IntPtr_IntPtr_IntPtr_IntPtr_IntPtr (met.Handle, Selector.GetHandle ("methodEncodings:obj2:obj3:obj4:obj5:obj6:obj7:"), ref obj1, ref obj2, ref obj3, ref obj4, ref obj5, ref obj6, ref obj7);
+				NSObject o1 = Runtime.GetNSObject (obj1);
+				NSObject o2 = Runtime.GetNSObject (obj2);
+				NSObject o3 = Runtime.GetNSObject (obj3);
+				NSObject o4 = Runtime.GetNSObject (obj4);
+				NSObject o5 = Runtime.GetNSObject (obj5);
+				NSObject o6 = Runtime.GetNSObject (obj6);
+				NSObject o7 = Runtime.GetNSObject (obj7);
+				Assert.IsNotNull (o1, "O1");
+				Assert.IsNotNull (o2, "O2");
+				Assert.IsNotNull (o3, "O3");
+				Assert.IsNotNull (o4, "O4");
+				Assert.IsNotNull (o5, "O5");
+				Assert.IsNotNull (o6, "O6");
+				Assert.IsNotNull (o7, "O7");
+			}
+		}
+		
+		class MethodEncodingsTests : NSObject, IObjCProtocolTest {
+			[Export ("methodEncodings:obj2:obj3:obj4:obj5:obj6:obj7:")]
+			public void GetMethodEncodings (ref NSObject obj1, ref NSObject obj2, ref NSObject obj3, ref NSObject obj4, ref NSObject obj5, ref NSObject obj6, ref NSObject obj7)
+			{
+				Assert.IsNull (obj1, "obj1");
+				Assert.IsNull (obj2, "obj2");
+				Assert.IsNull (obj3, "obj3");
+				Assert.IsNull (obj4, "obj4");
+				Assert.IsNull (obj5, "obj5");
+				Assert.IsNull (obj6, "obj6");
+				Assert.IsNull (obj7, "obj7");
+				obj1 = new NSObject ();
+				obj2 = new NSObject ();
+				obj3 = new NSObject ();
+				obj4 = new NSObject ();
+				obj5 = new NSObject ();
+				obj6 = new NSObject ();
+				obj7 = new NSObject ();
+			}
+		}
+		
 		class RefOutParametersSubclass : BI1064.RefOutParameters
 		{
 			public override void TestCFBundle (int action, ref CFBundle refValue, out CFBundle outValue)

--- a/tests/test-libraries/libtest.h
+++ b/tests/test-libraries/libtest.h
@@ -152,6 +152,17 @@ typedef unsigned int (^RegistrarTestBlock) (unsigned int magic);
 @protocol ObjCProtocolTest
 @required
 	-(void) idAsIntPtr: (id)p1;
+
+@optional
+	-(void) methodEncodings:
+		(inout NSObject **) obj1P
+		obj2: (in NSObject **) obj2P
+		obj3: (out NSObject **) obj3P
+		obj4: (const NSObject **) obj4P
+		obj5: (bycopy NSObject **) obj5P
+		obj6: (byref NSObject **) obj6P
+		obj7: (oneway NSObject **) obj7P
+		;
 @end
 
 // We need this class so that the ObjCProtocolTest protocol

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -478,6 +478,23 @@ static UltimateMachine *shared;
 		return self.INSCodingArrayProperty;
 	}
 
+	-(void) methodEncodings:
+			      (inout NSObject **) obj1P
+			obj2: (in NSObject **) obj2P
+			obj3: (out NSObject **) obj3P
+			obj4: (const NSObject **) obj4P
+			obj5: (bycopy NSObject **) obj5P
+			obj6: (byref NSObject **) obj6P
+			obj7: (oneway NSObject **) obj7P
+	{
+		obj1P = NULL;
+		obj2P = NULL;
+		obj3P = NULL;
+		obj4P = NULL;
+		obj5P = NULL;
+		obj6P = NULL;
+		obj7P = NULL;
+	}
 @end
 
 @implementation ProtocolAssigner
@@ -553,6 +570,17 @@ static UltimateMachine *shared;
 
 @implementation ObjCProtocolClassTest
 -(void) idAsIntPtr: (id)p1
+{
+	// Do nothing
+}
+-(void) methodEncodings:
+	(inout NSObject **) obj1P
+	obj2: (in NSObject **) obj2P
+	obj3: (out NSObject **) obj3P
+	obj4: (const NSObject **) obj4P
+	obj5: (bycopy NSObject **) obj5P
+	obj6: (byref NSObject **) obj6P
+	obj7: (oneway NSObject **) obj7P
 {
 	// Do nothing
 }


### PR DESCRIPTION
Method encodings do not change anything for us, so skip them when processing
copyback arguments so that they don't confuse the rest of the code.

Fixes https://github.com/xamarin/xamarin-macios/issues/6883.