### PR TITLE
[monotouch-test] Apple has fixed a crash in the ImageCaptioningTest, so update the test accordingly.

### DIFF
--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -63,20 +63,17 @@ namespace MonoTouchFixtures.MediaAccessibility {
 
 			var temp = String.Empty;
 			using (NSUrl url = new NSUrl (NSBundle.MainBundle.ResourceUrl.AbsoluteString + "basn3p08.png")) {
-				// In Xcode 11 beta 3, the native P/Invoke will very helpfully crash if called with a read-only file path.
-				// So don't do that.
+				Assert.False (MAImageCaptioning.SetCaption (url, "xamarin", out var e), "Set");
+				Assert.NotNull (e, "ro / set / no error"); // weird, it can't be saved back to the file metadata
 
-				//Assert.True (MAImageCaptioning.SetCaption (url, "xamarin", out var e), "Set");
-				//Assert.Null (e, "ro / set / no error"); // weird, it can't be saved back to the file metadata
+				var s = MAImageCaptioning.GetCaption (url, out e);
+				Assert.Null (s, "ro / roundtrip"); // not very surprising since Set can't save it
+				Assert.Null (e, "ro / get / no error");
 
-				//var s = MAImageCaptioning.GetCaption (url, out e);
-				//Assert.Null (s, "ro / roundtrip"); // not very surprising since Set can't save it
-				//Assert.Null (e, "ro / get / no error");
-
-				//Assert.True (MAImageCaptioning.SetCaption (url, "xamarin", out e), "Set 2");
-				//s = MAImageCaptioning.GetCaption (url, out e);
-				//Assert.Null (s, "ro / back to original");
-				//Assert.Null (e, "ro / get back / no error");
+				Assert.False (MAImageCaptioning.SetCaption (url, "xamarin", out e), "Set 2");
+				s = MAImageCaptioning.GetCaption (url, out e);
+				Assert.Null (s, "ro / back to original");
+				Assert.Null (e, "ro / get back / no error");
 
 				// 2nd try with a read/write copy
 				temp = Path.Combine (Path.GetTempPath (), "basn3p08.png");

--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -64,7 +64,12 @@ namespace MonoTouchFixtures.MediaAccessibility {
 
 			var temp = String.Empty;
 			using (NSUrl url = new NSUrl (NSBundle.MainBundle.ResourceUrl.AbsoluteString + "basn3p08.png")) {
-				if (Runtime.Arch == Arch.DEVICE) {
+#if __MACOS__
+				var read_only = false;
+#else
+				var read_only = Runtime.Arch == Arch.DEVICE;
+#endif
+				if (read_only) {
 					Assert.False (MAImageCaptioning.SetCaption (url, "xamarin", out var e), "Set");
 					Assert.NotNull (e, "ro / set / no error"); // weird, it can't be saved back to the file metadata
 

--- a/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
+++ b/tests/monotouch-test/MediaAccessibility/ImageCaptioningTest.cs
@@ -13,6 +13,7 @@ using System;
 using System.IO;
 using Foundation;
 using MediaAccessibility;
+using ObjCRuntime;
 using NUnit.Framework;
 
 namespace MonoTouchFixtures.MediaAccessibility {
@@ -63,17 +64,31 @@ namespace MonoTouchFixtures.MediaAccessibility {
 
 			var temp = String.Empty;
 			using (NSUrl url = new NSUrl (NSBundle.MainBundle.ResourceUrl.AbsoluteString + "basn3p08.png")) {
-				Assert.False (MAImageCaptioning.SetCaption (url, "xamarin", out var e), "Set");
-				Assert.NotNull (e, "ro / set / no error"); // weird, it can't be saved back to the file metadata
+				if (Runtime.Arch == Arch.DEVICE) {
+					Assert.False (MAImageCaptioning.SetCaption (url, "xamarin", out var e), "Set");
+					Assert.NotNull (e, "ro / set / no error"); // weird, it can't be saved back to the file metadata
 
-				var s = MAImageCaptioning.GetCaption (url, out e);
-				Assert.Null (s, "ro / roundtrip"); // not very surprising since Set can't save it
-				Assert.Null (e, "ro / get / no error");
+					var s = MAImageCaptioning.GetCaption (url, out e);
+					Assert.Null (s, "ro / roundtrip"); // not very surprising since Set can't save it
+					Assert.Null (e, "ro / get / no error");
 
-				Assert.False (MAImageCaptioning.SetCaption (url, "xamarin", out e), "Set 2");
-				s = MAImageCaptioning.GetCaption (url, out e);
-				Assert.Null (s, "ro / back to original");
-				Assert.Null (e, "ro / get back / no error");
+					Assert.False (MAImageCaptioning.SetCaption (url, "xamarin", out e), "Set 2");
+					s = MAImageCaptioning.GetCaption (url, out e);
+					Assert.Null (s, "ro / back to original");
+					Assert.Null (e, "ro / get back / no error");
+				} else {
+					Assert.True (MAImageCaptioning.SetCaption (url, "xamarin", out var e), "Set");
+					Assert.Null (e, "ro / set / no error"); // weird, it can't be saved back to the file metadata
+
+					var s = MAImageCaptioning.GetCaption (url, out e);
+					Assert.Null (s, "ro / roundtrip"); // not very surprising since Set can't save it
+					Assert.Null (e, "ro / get / no error");
+
+					Assert.True (MAImageCaptioning.SetCaption (url, "xamarin", out e), "Set 2");
+					s = MAImageCaptioning.GetCaption (url, out e);
+					Assert.Null (s, "ro / back to original");
+					Assert.Null (e, "ro / get back / no error");
+				}
 
 				// 2nd try with a read/write copy
 				temp = Path.Combine (Path.GetTempPath (), "basn3p08.png");


### PR DESCRIPTION
Apple has fixed a crash we ran into with the ImageCaptioningTest, so now we
can re-enable the code that caused the crash.