### PR TITLE
[AVFoundation] Add constructor for AVCaptureSynchronizedDepthData to fix breaking change.

### DIFF
--- a/src/AVFoundation/AVCaptureSynchronizedDepthData.cs
+++ b/src/AVFoundation/AVCaptureSynchronizedDepthData.cs
@@ -1,0 +1,17 @@
+//
+// Copyright 2019 Microsoft Corp.
+//
+
+using System;
+using Foundation;
+
+namespace AVFoundation {
+#if !XAMCORE_4_0 && __IOS__
+	public partial class AVCaptureSynchronizedDepthData {
+		[Obsolete ("Default constructor should not be used")]
+		public AVCaptureSynchronizedDepthData () : base (NSObjectFlag.Empty)
+		{
+		}
+	}
+#endif
+}

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -255,6 +255,7 @@ AVFOUNDATION_SOURCES = \
 	AVFoundation/AVCaptureFileOutput.cs \
 	AVFoundation/AVCaptureMetadataOutput.cs \
 	AVFoundation/AVCaptureSynchronizedDataCollection.cs \
+	AVFoundation/AVCaptureSynchronizedDepthData.cs \
 	AVFoundation/AVCaptureVideoDataOutput.cs \
 	AVFoundation/AVCaptureVideoPreviewLayer.cs \
 	AVFoundation/AVCompat.cs \


### PR DESCRIPTION
AVCaptureSynchronizedDepthData's init method is not available, which means we
should make the corresponding binding obsolete. We've already removed the
bound constructor, because it made introspection crash, this is just the
second part.