### PR TITLE
[Foundation] Ensure that we allow celullar data by default until the user says otherwise. #6762

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -158,7 +158,7 @@ namespace Foundation {
 			// therefore, we do not have to listen to the notifications.
 			isBackgroundSession = !string.IsNullOrEmpty (configuration.Identifier);
 #endif
-
+			allowsCellularAccess = configuration.AllowsCellularAccess;
 			AllowAutoRedirect = true;
 
 			// we cannot do a bitmask but we can set the minimum based on ServicePointManager.SecurityProtocol minimum

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -280,7 +280,7 @@ namespace Foundation {
 			}
 		}
 
-		bool allowsCellularAccess;
+		bool allowsCellularAccess = true;
 
 		public bool AllowsCellularAccess {
 			get {

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -15,6 +15,7 @@ using System.IO;
 using NUnit.Framework;
 using System.Net.Http.Headers;
 using System.Text;
+using Foundation;
 #if MONOMAC
 using Foundation;
 #endif
@@ -269,6 +270,21 @@ namespace MonoTests.System.Net.Http
 				if (ex != null && ex.InnerException != null) {
 					// we could get here.. if we have a diff issue, in that case, lets get the exception message and assert is not the trust issue
 					Assert.AreNotEqual (ex.InnerException.Message, "Error: TrustFailure");
+				}
+			}
+		}
+
+		[Test]
+		public void AssertDefaultValuesNSUrlSessionHandler ()
+		{
+			using (var handler = new NSUrlSessionHandler ()) {
+				Assert.True (handler.AllowAutoRedirect, "Default redirects value");
+				Assert.True (handler.AllowsCellularAccess, "Default cellular data value.");
+			}
+			using (var config = NSUrlSessionConfiguration.DefaultSessionConfiguration) {
+				config.AllowsCellularAccess = false;
+				using (var handler = new NSUrlSessionHandler (config)) {
+					Assert.False (handler.AllowsCellularAccess, "Configuration cellular data value.");
 				}
 			}
 		}


### PR DESCRIPTION
The default value in the NSUrlSession is to allow cellular data. This
small change closes the issue, since users will not have an unexpected
result.

Later we need to provide a proper fix to allow the property to be
exposed AND use the value of the session.

Fixes: https://github.com/xamarin/xamarin-macios/issues/6762