### PR TITLE
[coreaudio] Update for Xcode 11 (up to beta 7)

### DIFF
--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -387,22 +387,27 @@ namespace AVFoundation {
 
 	[Native]
 	// NSInteger - AVAudioSession.h
+	// typedef CF_ENUM(NSInteger, AVAudioSessionErrorCode) -> CoreAudioTypes.framework/Headers/AudioSessionTypes.h
 	public enum AVAudioSessionErrorCode : long {
 		None = 0,
-		MediaServicesFailed = 0x6D737276,
-		IsBusy = 0x21616374,
-		IncompatibleCategory = 0x21636174,
-		CannotInterruptOthers = 0x21696e74,
-		MissingEntitlement = 0x656e743f,
-		SiriIsRecording = 0x73697269,
-		CannotStartPlaying = 0x21706c61,
-		[iOS (7, 0)]
-		CannotStartRecording = 0x21726563,
+		MediaServicesFailed = 0x6D737276, // 'msrv'
+		IsBusy = 0x21616374, // '!act'
+		IncompatibleCategory = 0x21636174, // 'cat'
+		CannotInterruptOthers = 0x21696e74, // 'int'
+		MissingEntitlement = 0x656e743f, // 'ent?'
+		SiriIsRecording = 0x73697269, // 'siri'
+		CannotStartPlaying = 0x21706c61, // '!pla'
+		CannotStartRecording = 0x21726563, // '!rec'
 		BadParam = -50,
-		Unspecified = 0x77686174,
-		InsufficientPriority = 0x21707269,
-		[iOS (9,0)]
-		CodeResourceNotAvailable = 0x21726573
+		InsufficientPriority = 0x21707269, // '!pri'
+#if !XAMCORE_4_0
+		[Obsolete ("Use 'ResourceNotAvailable' instead.")]
+		CodeResourceNotAvailable = 0x21726573,
+#endif
+		ResourceNotAvailable = 0x21726573, // '!res'
+		Unspecified = 0x77686174, // 'what'
+		ExpiredSession = 0x21736573, // '!ses'
+		SessionNotActive = 0x696e6163, // 'inac'
 	}
 #endif
 

--- a/src/AudioToolbox/AudioType.cs
+++ b/src/AudioToolbox/AudioType.cs
@@ -70,6 +70,7 @@ namespace AudioToolbox {
 		MPEG4AAC_ELD_V2         = 0x61616367, // 'aacg',    
 		MPEG4AAC_HE_V2          = 0x61616370,
 		MPEG4AAC_Spatial        = 0x61616373,
+		MpegD_Usac              = 0x75736163, // 'usac' (Unified Speech and Audio Coding)
 		AMR                     = 0x73616d72, // 'samr'
 		AMRWideBand             = 0x73617762, // 'sawb'
 		Audible                 = 0x41554442,
@@ -390,6 +391,16 @@ namespace AudioToolbox {
 		CenterSurroundDirect  = 44,
 		Haptic                = 45,
    
+		LeftTopFront          = 46,
+		CenterTopFront        = 47,
+		RightTopFront         = 48,
+		LeftTopMiddle         = 49,
+		CenterTopMiddle       = 50,
+		RightTopMiddle        = 51,
+		LeftTopRear           = 52,
+		CenterTopRear         = 53,
+		RightTopRear          = 54,
+
 		// first order ambisonic channels
 		Ambisonic_W           = 200,
 		Ambisonic_X           = 201,
@@ -491,7 +502,16 @@ namespace AudioToolbox {
 		VerticalHeightRight        = 1<<14,
 		TopBackLeft                = 1<<15,
 		TopBackCenter              = 1<<16,
-		TopBackRight               = 1<<17
+		TopBackRight               = 1<<17,
+		LeftTopFront               = 1<<18,
+		CenterTopFront             = 1<<19,
+		RightTopFront              = 1<<20,
+		LeftTopMiddle              = 1<<21,
+		CenterTopMiddle            = 1<<22,
+		RightTopMiddle             = 1<<23,
+		LeftTopRear                = 1<<24,
+		CenterTopRear              = 1<<25,
+		RightTopRear               = 1<<26,
 	}
 
 	[StructLayout (LayoutKind.Sequential)]
@@ -563,6 +583,7 @@ namespace AudioToolbox {
 #endif // !COREBUILD
 	}
 
+	// CoreAudioTypes.framework/Headers/CoreAudioBaseTypes.h
 	public enum AudioChannelLayoutTag : uint { // UInt32 AudioChannelLayoutTag
 		UseChannelDescriptions   = (0<<16) | 0,     
 		UseChannelBitmap         = (1<<16) | 0,     
@@ -709,8 +730,23 @@ namespace AudioToolbox {
 		DTS_8_1_B                = (181<<16) | 9,                        
 		DTS_6_1_D                = (182<<16) | 7,
 
+		Wave_2_1                 = DVD_4,
+		Wave_3_0                 = MPEG_3_0_A,
+		Wave_4_0_A               = ITU_2_2,
+		Wave_4_0_B               = (185<<16) | 4,
+		Wave_5_0_A               = MPEG_5_0_A,
+		Wave_5_0_B               = (186<<16) | 5,
+		Wave_5_1_A               = MPEG_5_1_A,
+		Wave_5_1_B               = (187<<16) | 6,
+		Wave_6_1                 = (188<<16) | 7,
+		Wave_7_1                 = (189<<16) | 8,
+
 		HOA_ACN_SN3D             = (190U<<16),
 		HOA_ACN_N3D              = (191U<<16),
+
+		Atmos_7_1_4              = (192 << 16) | 12,
+		Atmos_9_1_6              = (193 << 16) | 16,
+		Atmos_5_1_2              = (194 << 16) | 8,
 		
 		DiscreteInOrder          = (147<<16) | 0,                       // needs to be ORed with the actual number of channels  
 		Unknown                  = 0xFFFF0000                           // needs to be ORed with the actual number of channels  

--- a/tests/xtro-sharpie/Helpers.cs
+++ b/tests/xtro-sharpie/Helpers.cs
@@ -21,6 +21,7 @@ namespace Extrospection {
 
 		// the original name can be lost and, if not registered (e.g. enums), might not be available
 		static Dictionary<string,string> map = new Dictionary<string, string> () {
+			{ "AudioChannelBitmap", "AudioChannelBit" },
 			{ "EABluetoothAccessoryPickerErrorCode", "EABluetoothAccessoryPickerError" },
 			{ "EKCalendarEventAvailabilityMask", "EKCalendarEventAvailability" },
 			{ "GKErrorCode", "GKError" },

--- a/tests/xtro-sharpie/common-CoreAudioTypes.ignore
+++ b/tests/xtro-sharpie/common-CoreAudioTypes.ignore
@@ -1,0 +1,5 @@
+## not exposed in any API - w/duplicate values ?!?
+!missing-enum! AudioChannelCoordinateIndex not bound
+
+## bound as an inner type of the AudioTimeStamp struct
+!missing-enum! AudioTimeStampFlags not bound

--- a/tests/xtro-sharpie/iOS-CoreAudioTypes.todo
+++ b/tests/xtro-sharpie/iOS-CoreAudioTypes.todo
@@ -1,3 +1,0 @@
-!missing-enum! AudioChannelBitmap not bound
-!missing-enum! AudioChannelCoordinateIndex not bound
-!missing-enum! AudioTimeStampFlags not bound

--- a/tests/xtro-sharpie/macOS-CoreAudioTypes.todo
+++ b/tests/xtro-sharpie/macOS-CoreAudioTypes.todo
@@ -1,3 +1,0 @@
-!missing-enum! AudioChannelBitmap not bound
-!missing-enum! AudioChannelCoordinateIndex not bound
-!missing-enum! AudioTimeStampFlags not bound

--- a/tests/xtro-sharpie/tvOS-CoreAudioTypes.todo
+++ b/tests/xtro-sharpie/tvOS-CoreAudioTypes.todo
@@ -1,3 +1,0 @@
-!missing-enum! AudioChannelBitmap not bound
-!missing-enum! AudioChannelCoordinateIndex not bound
-!missing-enum! AudioTimeStampFlags not bound

--- a/tests/xtro-sharpie/watchOS-CoreAudioTypes.todo
+++ b/tests/xtro-sharpie/watchOS-CoreAudioTypes.todo
@@ -1,3 +1,0 @@
-!missing-enum! AudioChannelBitmap not bound
-!missing-enum! AudioChannelCoordinateIndex not bound
-!missing-enum! AudioTimeStampFlags not bound


### PR DESCRIPTION
CoreAudioTypes is _new_ but it's just some stuff that moved around,
however it now shows up separately in our API diff (and was quite
large because of the removal/addition caused by moving headers)