### PR TITLE
Rename bundle identifier for the frameworks we ship. Fixes #6920.

### DIFF
--- a/builds/Mono.framework-tvos.Info.plist
+++ b/builds/Mono.framework-tvos.Info.plist
@@ -5,7 +5,7 @@
         <key>CFBundleDevelopmentRegion</key>
         <string>en</string>
         <key>CFBundleIdentifier</key>
-        <string>xamarin.ios.mono-framework</string>
+        <string>xamarin.tvos.mono-framework</string>
         <key>CFBundleInfoDictionaryVersion</key>
         <string>6.0</string>
         <key>CFBundleName</key>

--- a/builds/Mono.framework-watchos.Info.plist
+++ b/builds/Mono.framework-watchos.Info.plist
@@ -5,7 +5,7 @@
         <key>CFBundleDevelopmentRegion</key>
         <string>en</string>
         <key>CFBundleIdentifier</key>
-        <string>xamarin.ios.mono-framework</string>
+        <string>xamarin.watchos.mono-framework</string>
         <key>CFBundleInfoDictionaryVersion</key>
         <string>6.0</string>
         <key>CFBundleName</key>

--- a/runtime/Xamarin.framework-tvos.Info.plist
+++ b/runtime/Xamarin.framework-tvos.Info.plist
@@ -5,7 +5,7 @@
         <key>CFBundleDevelopmentRegion</key>
         <string>en</string>
         <key>CFBundleIdentifier</key>
-        <string>xamarin.ios.xamarin-framework</string>
+        <string>xamarin.tvos.xamarin-framework</string>
         <key>CFBundleInfoDictionaryVersion</key>
         <string>6.0</string>
         <key>CFBundleName</key>

--- a/runtime/Xamarin.framework-watchos.Info.plist
+++ b/runtime/Xamarin.framework-watchos.Info.plist
@@ -5,7 +5,7 @@
         <key>CFBundleDevelopmentRegion</key>
         <string>en</string>
         <key>CFBundleIdentifier</key>
-        <string>xamarin.ios.xamarin-framework</string>
+        <string>xamarin.watchos.xamarin-framework</string>
         <key>CFBundleInfoDictionaryVersion</key>
         <string>6.0</string>
         <key>CFBundleName</key>


### PR DESCRIPTION
Rename the bundle identifier for the frameworks we ship, because apparently
Apple has added an App Store check to reject apps with multiple frameworks
with the same bundle identifier.

For some reason that includes rejecting frameworks that are both in iOS and
watchOS apps. This feels like a bug on Apple's end, but we can still easily
work around it, so let's do just that.

Strictly speaking it's not necessary to change the bundle identifier for tvOS
frameworks, but it's more consistent that way.

Fixes https://github.com/xamarin/xamarin-macios/issues/6920.