### PR TITLE
[MediaPlayer] Enable API that depend on AVFoundation types for watchOS. Fixes #6597.

### DIFF
--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -20,10 +20,6 @@ using AppKit;
 using UIKit;
 #endif
 using System;
-#if WATCH
-using AVMediaSelectionGroup = Foundation.NSObject;
-using AVMediaSelectionOption = Foundation.NSObject;
-#endif
 
 namespace MediaPlayer {
 #if XAMCORE_2_0 || !MONOMAC

--- a/tests/xtro-sharpie/watchOS-MediaPlayer.todo
+++ b/tests/xtro-sharpie/watchOS-MediaPlayer.todo
@@ -1,2 +1,0 @@
-!missing-selector! AVMediaSelectionGroup::makeNowPlayingInfoLanguageOptionGroup not bound
-!missing-selector! AVMediaSelectionOption::makeNowPlayingInfoLanguageOption not bound


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/6597.