### PR TITLE
[UIKit] Make UITraitCollection thread-safe, since that's apparently how Apple treats it. Fixes #6706.

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -15002,6 +15002,7 @@ namespace UIKit {
 	[iOS (8,0)]
 	[BaseType (typeof (NSObject))]
 	[DesignatedDefaultCtor]
+	[ThreadSafe] // Documentation doesn't say, but it this class doesn't seem to trigger Apple's Main Thread Checker.
 	partial interface UITraitCollection : NSCopying, NSSecureCoding {
 		[Export ("userInterfaceIdiom")]
 		UIUserInterfaceIdiom UserInterfaceIdiom { get; }


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/6706.