### PR TITLE
[simlauncher] Add missing weak frameworks to simlauncher

### DIFF
--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -313,12 +313,16 @@ public class Frameworks : Dictionary <string, Framework>
 				{ "NaturalLanguage", "NaturalLanguage", 12,0 },
 				{ "Network", "Network", 12, 0 },
 
-				{ "SoundAnalysis", "SoundAnalysis", 13, 0 },
 				{ "BackgroundTasks", "BackgroundTasks", 13, 0 },
+				{ "LinkPresentation", "LinkPresentation", 13, 0 },
 				{ "PencilKit", "PencilKit", 13, 0 },
 				{ "QuickLookThumbnailing", "QuickLookThumbnailing", 13,0 },
-				{ "LinkPresentation", "LinkPresentation", 13, 0 },
+				{ "SoundAnalysis", "SoundAnalysis", 13, 0 },
 				{ "VisionKit", "VisionKit", 13, 0 },
+
+				// the above MUST be kept in sync with simlauncher
+				// see tools/mtouch/Makefile
+				// please also keep it sorted to ease comparison
 			};
 		}
 		return ios_frameworks;

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -144,10 +144,22 @@ SIMLAUNCHER_FRAMEWORKS =  \
 						\
 	-weak_framework AuthenticationServices	\
 	-weak_framework CarPlay					\
+	-weak_framework IdentityLookupUI		\
 	-weak_framework NaturalLanguage			\
 	-weak_framework Network				\
-	-weak_framework IdentityLookupUI		\
-	-weak_framework VisionKit		\
+						\
+	-weak_framework BackgroundTasks 		\
+	-weak_framework LinkPresentation 		\
+	-weak_framework PencilKit			\
+	-weak_framework QuickLookThumbnailing		\
+	-weak_framework SoundAnalysis			\
+	-weak_framework VisionKit			\
+
+# keep the above list of weak_framework
+# 1. grouped by iOS versions;
+# 2. sorted and
+# 3. in sync with the list inside `tools/common/Frameworks.cs`
+# except it is no a mistake that GameController and MediaAccessibility (#13636) are not built into simlauncher
 
 # note: there _was_ no CoreAudioKit.framework or Metal.framework for the simulator (before recent iOS9 betas)
 # note 2: there's no GameKit, in iOS 9 (beta 3 at least), you're supposed to reference GameCenter instead (looks fixed in beta 4)
@@ -156,9 +168,6 @@ SIMLAUNCHER_FRAMEWORKS =  \
 # note 5: Metal* seems to be supported as of some Xcode 7 beta (b2 didn't, but the final release does)
 # note 6: Xcode 11 beta 1 shipped without WatchKit.
 # note 7: Xcode 11 beta 3 documented that shipping without WatchKit was done on purpose (in the release notes).
-
-# keep the above list of weak_framework in sync with mtouch.cs
-# except it is no a mistake that GameController and MediaAccessibility (#13636) are not built into simlauncher
 
 define SimlauncherTemplate
 


### PR DESCRIPTION
Things often work fine without them but, in a few cases, you can run into
some weird problems.

Add better comments for synchronization... until we add some tests [1]

Replace the following, cancelled PR
* BackgroundTask https://github.com/xamarin/xamarin-macios/pull/6949
* INcomingCallNotifications https://github.com/xamarin/xamarin-macios/pull/6954
* LinkPresentation https://github.com/xamarin/xamarin-macios/pull/6953
* PencilKit https://github.com/xamarin/xamarin-macios/pull/6950
* SoundAnalysis https://github.com/xamarin/xamarin-macios/pull/6952

[1] https://github.com/xamarin/xamarin-macios/issues/6951