### PR TITLE
[tests][intro] Add test for simlauncher [weak] frameworks. Fixes #6951

### DIFF
--- a/tests/introspection/iOS/introspection-ios.csproj
+++ b/tests/introspection/iOS/introspection-ios.csproj
@@ -248,6 +248,9 @@
     <BundleResource Include="..\xamarin1.png">
       <Link>xamarin1.png</Link>
     </BundleResource>
+    <BundleResource Include="..\..\..\tools\mtouch\simlauncher64-sgen.frameworks">
+      <Link>simlauncher64-sgen.frameworks</Link>
+    </BundleResource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/tools/mtouch/.gitignore
+++ b/tools/mtouch/.gitignore
@@ -9,4 +9,4 @@ simlauncher32-sgen
 simlauncher64-sgen
 *.stamp
 mtouch.csproj.inc
-
+*.frameworks

--- a/tools/mtouch/Makefile
+++ b/tools/mtouch/Makefile
@@ -60,7 +60,6 @@ SIMLAUNCHER_FRAMEWORKS =  \
 	-framework CoreText			\
 	-framework ExternalAccessory		\
 	-framework GameKit				\
-	-framework IOKit			\
 	-framework MapKit			\
 	-framework MediaPlayer			\
 	-framework MessageUI			\
@@ -184,7 +183,7 @@ simlauncher$(5)$(1): simlauncher.m $(TOP)/runtime/.libs/ios/libxamarin.a $(BUILD
 		$(TOP)/runtime/.libs/ios/libapp.a \
 		-Wl,-w \
 		-lz -liconv $(TOP)/runtime/.libs/ios/libxamarin-debug.a simlauncher.m $(SIMLAUNCHER_FRAMEWORKS) $(SIMULATOR$(4)_OBJC_CFLAGS) -o $$@
-
+	$(Q) xcrun otool -L simlauncher$(5)$(1) > simlauncher$(5)$(1).frameworks
 endef
 
 $(eval $(call SimlauncherTemplate,-sgen,$(BUILD_DESTDIR)/simulator86/lib/libmono-profiler-log.a -u _mono_profiler_init_log -DXAMCORE_2_0 Xamarin.iOS.registrar.ios.a,sgen,86,32))


### PR DESCRIPTION
We ship a default, pre-built, simlauncher for iOS simulator applications.
This speeds up compilation for the default (non linked) simulator builds
quite a lot (no call to `clang` is needed). However it force us to keep
track of frameworks manually - `mtouch` can track them but requires
calling clang/ld to finish things up (killing the optimization).

It's easy to forget some (new) frameworks since they can be loaded
dynamically (on demand) _most_ of the time. Sadly there are a few cases
where doing so cause (hard to diagnose) problems - so we can't depend
on them being loaded, correctly for us.

The new test case loads the `otool -L` output (make when we build
simlauncher[32|64]-sgen) and compares it with mtouch's GetFramework
logic *and* with our namespaces (which is pretty close, with a few
exceptions, to the framework names). This will make it harder to
forget [weak] frameworks when adding new bindings :)

Fixes https://github.com/xamarin/xamarin-macios/issues/6951