### PR TITLE
[Foundation] Fix validate for insert for NSMutableArray<T>. Fixes #6876.

### DIFF
--- a/src/Foundation/NSMutableArray_1.cs
+++ b/src/Foundation/NSMutableArray_1.cs
@@ -165,9 +165,6 @@ namespace Foundation {
 		{
 			if (index < 0)
 				throw new IndexOutOfRangeException (nameof (index));
-
-			if ((nuint) index >= Count)
-				throw new IndexOutOfRangeException (nameof (index));
 		}
 
 		void ValidateIndex (nuint index)


### PR DESCRIPTION
Fixes the validate function for NSMutablArray\<T\> which was throwing an index out of bounds exception when trying to insert in to an empty array. Fixes https://github.com/xamarin/xamarin-macios/issues/6876.