### PR TITLE
[Foundation] Fix validate for insert for NSMutableArray<T>. Fixes #6876.

### DIFF
--- a/src/Foundation/NSMutableArray_1.cs
+++ b/src/Foundation/NSMutableArray_1.cs
@@ -163,12 +163,10 @@ namespace Foundation {
 
 		void ValidateIndex (nint index)
 		{
-			if (index == 0) return;
-			
 			if (index < 0)
 				throw new IndexOutOfRangeException (nameof (index));
 
-			if ((nuint) index >= Count)
+			if ((nuint) index > Count)
 				throw new IndexOutOfRangeException (nameof (index));
 		}
 

--- a/src/Foundation/NSMutableArray_1.cs
+++ b/src/Foundation/NSMutableArray_1.cs
@@ -163,6 +163,8 @@ namespace Foundation {
 
 		void ValidateIndex (nint index)
 		{
+			if (index == 0) return;
+			
 			if (index < 0)
 				throw new IndexOutOfRangeException (nameof (index));
 

--- a/tests/monotouch-test/Foundation/NSMutableArray1Test.cs
+++ b/tests/monotouch-test/Foundation/NSMutableArray1Test.cs
@@ -82,11 +82,17 @@ namespace MonoTouchFixtures.Foundation {
 				Assert.Throws<ArgumentNullException> (() => arr.Insert (null, 0), "Insert ANE");
 				Assert.Throws<IndexOutOfRangeException> (() => arr.Insert (v2, -1), "Insert AOORE 1");
 				Assert.Throws<IndexOutOfRangeException> (() => arr.Insert (v2, 3), "Insert AOORE 2");
+				
+			
 				arr.Insert (v2, 1);
 				Assert.AreEqual (3, arr.Count, "Insert 2");
 				Assert.AreSame (v1, arr [0], "[0]");
 				Assert.AreSame (v2, arr [1], "[1]");
 				Assert.AreSame (v3, arr [2], "[2]");
+			}
+
+			using (var arr = new NSMutableArray<NSString>()) {
+				Assert.DoesNotThrow (() => arr.Insert (v1, 0), "Insert into empty array");
 			}
 		}
 

--- a/tests/monotouch-test/Foundation/NSMutableArray1Test.cs
+++ b/tests/monotouch-test/Foundation/NSMutableArray1Test.cs
@@ -82,8 +82,6 @@ namespace MonoTouchFixtures.Foundation {
 				Assert.Throws<ArgumentNullException> (() => arr.Insert (null, 0), "Insert ANE");
 				Assert.Throws<IndexOutOfRangeException> (() => arr.Insert (v2, -1), "Insert AOORE 1");
 				Assert.Throws<IndexOutOfRangeException> (() => arr.Insert (v2, 3), "Insert AOORE 2");
-				
-			
 				arr.Insert (v2, 1);
 				Assert.AreEqual (3, arr.Count, "Insert 2");
 				Assert.AreSame (v1, arr [0], "[0]");


### PR DESCRIPTION
Fix `IndexOutOfRangeException` when trying to insert into any empty NSMutableArray\<T\>. Fixes https://github.com/xamarin/xamarin-macios/issues/6876.