### PR TITLE
[msbuild] Disable broken iOS msbuild tests

### DIFF
--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TargetTests/TargetTests.cs
@@ -173,7 +173,7 @@ namespace Xamarin.iOS.Tasks
 			CollectionAssert.AreEquivalent (expected_references, actual_references, "References");
 		}
 
-		[Test]
+		// [Test] - https://github.com/xamarin/xamarin-macios/issues/6970
 		public void BuildExecutable ()
 		{
 			var expectedFiles = ExpectedExecutableFiles;
@@ -440,7 +440,7 @@ namespace Xamarin.iOS.Tasks
 			Assert.AreEqual (11, bundleResources.Length, "#1");
 		}
 
-		[Test]
+		// [Test] - https://github.com/xamarin/xamarin-macios/issues/6970
 		public void BundleResources ()
 		{
 			var actool = Path.Combine ("obj", "iPhoneSimulator", "Debug", "actool", "bundle");

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/IBToolTaskTests.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/TaskTests/IBToolTaskTests.cs
@@ -59,7 +59,7 @@ namespace Xamarin.iOS.Tasks
 			};
 		}
 
-		[Test]
+		// [Test] - https://github.com/xamarin/xamarin-macios/issues/6970
 		public void TestBasicIBToolFunctionality ()
 		{
 			var tmp = Path.Combine (Path.GetTempPath (), "basic-ibtool");
@@ -107,7 +107,7 @@ namespace Xamarin.iOS.Tasks
 			}
 		}
 
-		[Test]
+		// [Test] - https://github.com/xamarin/xamarin-macios/issues/6970
 		public void TestAdvancedIBToolFunctionality ()
 		{
 			var tmp = Path.Combine (Path.GetTempPath (), "advanced-ibtool");
@@ -235,13 +235,13 @@ namespace Xamarin.iOS.Tasks
 			}
 		}
 
-		[Test]
+		// [Test] - https://github.com/xamarin/xamarin-macios/issues/6970
 		public void TestGenericAndDeviceSpecificXibsGenericFirst ()
 		{
 			TestGenericAndDeviceSpecificXibsGeneric ("View.xib", "View~ipad.xib");
 		}
 
-		[Test]
+		// [Test] - https://github.com/xamarin/xamarin-macios/issues/6970
 		public void TestGenericAndDeviceSpecificXibsGenericLast ()
 		{
 			TestGenericAndDeviceSpecificXibsGeneric ("View~ipad.xib", "View.xib");


### PR DESCRIPTION
- These tests depend on nib format that Xcode 11 GM broke
- https://github.com/xamarin/xamarin-macios/issues/6970