### PR TITLE
[coreaudio] Update for Xcode 11 GM

### DIFF
--- a/src/AudioToolbox/AudioType.cs
+++ b/src/AudioToolbox/AudioType.cs
@@ -391,11 +391,15 @@ namespace AudioToolbox {
 		CenterSurroundDirect  = 44,
 		Haptic                = 45,
    
+#if false
+		// with xcode11 GM the tvOS and macOS headers drifted from the iOS ones
+		// https://github.com/xamarin/maccore/issues/1960
 		LeftTopFront          = 46,
 		CenterTopFront        = 47,
 		RightTopFront         = 48,
 		LeftTopMiddle         = 49,
 		CenterTopMiddle       = 50,
+#endif
 		RightTopMiddle        = 51,
 		LeftTopRear           = 52,
 		CenterTopRear         = 53,
@@ -503,11 +507,15 @@ namespace AudioToolbox {
 		TopBackLeft                = 1<<15,
 		TopBackCenter              = 1<<16,
 		TopBackRight               = 1<<17,
+#if false
+		// with xcode11 GM the tvOS and macOS headers drifted from the iOS ones
+		// https://github.com/xamarin/maccore/issues/1960
 		LeftTopFront               = 1<<18,
 		CenterTopFront             = 1<<19,
 		RightTopFront              = 1<<20,
 		LeftTopMiddle              = 1<<21,
 		CenterTopMiddle            = 1<<22,
+#endif
 		RightTopMiddle             = 1<<23,
 		LeftTopRear                = 1<<24,
 		CenterTopRear              = 1<<25,


### PR DESCRIPTION
With xcode11 GM the tvOS and macOS headers drifted from the iOS ones.
It's not clear if they should be different (hopefully not) or if iOS
has been forgotten...

WHile waiting for Apple's feedback (and the avoid breaking changes)
the new (conflicting) enum values are not included.

Internal reference: https://github.com/xamarin/maccore/issues/1960