### PR TITLE
[homekit] Update for Xcode 11 GM

### DIFF
--- a/src/homekit.cs
+++ b/src/homekit.cs
@@ -1707,8 +1707,12 @@ namespace HomeKit {
 		[Export ("requiresSetupPayloadURL")]
 		bool RequiresSetupPayloadUrl { get; }
 		
+#if false
+		// marked as deprecated in tvOS headers (where the type does not exists)
+		// https://github.com/xamarin/maccore/issues/1959
 		[Export ("requiresOwnershipToken")]
 		bool RequiresOwnershipToken { get; }
+#endif
 
 		[Export ("payloadWithOwnershipToken:")]
 		[return: NullAllowed]

--- a/tests/xtro-sharpie/iOS-HomeKit.ignore
+++ b/tests/xtro-sharpie/iOS-HomeKit.ignore
@@ -1,2 +1,5 @@
 ## API prohibited on iOS since Xcode 10
 !missing-selector! HMHome::removeUser:completionHandler: not bound
+
+## xcode11 marks it (in tvOS headers only!?!) as deprecated
+!missing-selector! HMAddAccessoryRequest::requiresOwnershipToken not bound


### PR DESCRIPTION
In Xcode 11 GM the HomeKit headers were updated to mark an API deprecated
on iOS, but only on tvOS headers, where the type is not available

This API is commented until we hear back from https://feedbackassistant.apple.com/feedback/7246945
shadowed in https://github.com/xamarin/maccore/issues/1959