### PR TITLE
Bump maccore to treat Xcode GM as beta (needed for bots)

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := 48beb56b92d3455e711c7de74513d41ede28f48c
+NEEDED_MACCORE_VERSION := adfd6da1a92b72f4ab18e2f942a13fec47f454ff
 NEEDED_MACCORE_BRANCH := master
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@adfd6da1a9 [tests] Treat Xcode GM as beta so we don't have to update all devices to GM (#1963)
* xamarin/maccore@429df4c108 Merge pull request #1958 from xamarin/swift-o-matic-proto-list-method-arg
* xamarin/maccore@cfc4ce86ad Added support for protocol list types as arguments and return values to non-virtual methods.
* xamarin/maccore@7d9e752993 Merge pull request #1954 from xamarin/swift-o-matic-proto-list-tlprop
* xamarin/maccore@7d3dedc92b Update tools/tom-swifty/SwiftReflector/NewClassCompiler.cs
* xamarin/maccore@25b4bfab5e Update tools/tom-swifty/SwiftReflector/NewClassCompiler.cs
* xamarin/maccore@8d185b6925 value really does need to be in here. It doesn't actually affect anything that I can think of, but maybe some day it might.
* xamarin/maccore@f3a580747e Added top-level property support for protocol list types
* xamarin/maccore@069dddfa0f Merge pull request #1947 from xamarin/swift-o-matic-proto-list-return
* xamarin/maccore@f1fdbff8e4 Merge remote-tracking branch 'origin/master' into swift-o-matic-proto-list-return
* xamarin/maccore@8755421852 [provisioning] Fetch the latest master branch before getting what we need from it. (#1948)
* xamarin/maccore@0fecc9902b Handle return values of protocol list type
* xamarin/maccore@680156f264 Update the iOS distribution cert to one that is not expired. (#1943)

Diff: https://github.com/xamarin/maccore/compare/48beb56b92d3455e711c7de74513d41ede28f48c..adfd6da1a92b72f4ab18e2f942a13fec47f454ff