### PR TITLE
[CoreHaptics] Expose protocol method that was ignored due to inheritance.

### DIFF
--- a/src/corehaptics.cs
+++ b/src/corehaptics.cs
@@ -198,7 +198,7 @@ namespace CoreHaptics {
 
 	[Mac (10,15), iOS (13,0)]
 	[Protocol]
-	interface CHHapticAdvancedPatternPlayer {
+	interface CHHapticAdvancedPatternPlayer : CHHapticPatternPlayer {
 		[Abstract]
 		[Export ("pauseAtTime:error:")]
 		bool Pause (double time, [NullAllowed] out NSError outError);
@@ -229,7 +229,7 @@ namespace CoreHaptics {
 
 		[Abstract]
 		[Export ("isMuted")]
-		bool IsMuted { get; set; }
+		new bool IsMuted { get; set; }
 	}
 
 	[Mac (10,15), iOS (13,0)]

--- a/src/corehaptics.cs
+++ b/src/corehaptics.cs
@@ -198,7 +198,7 @@ namespace CoreHaptics {
 
 	[Mac (10,15), iOS (13,0)]
 	[Protocol]
-	interface CHHapticAdvancedPatternPlayer : CHHapticPatternPlayer {
+	interface CHHapticAdvancedPatternPlayer {
 		[Abstract]
 		[Export ("pauseAtTime:error:")]
 		bool Pause (double time, [NullAllowed] out NSError outError);
@@ -226,6 +226,10 @@ namespace CoreHaptics {
 		[Abstract]
 		[Export ("completionHandler", ArgumentSemantic.Assign)]
 		Action<NSError> CompletionHandler { get; set; }
+
+		[Abstract]
+		[Export ("isMuted")]
+		bool IsMuted { get; set; }
 	}
 
 	[Mac (10,15), iOS (13,0)]

--- a/tests/xtro-sharpie/iOS-CoreHaptics.ignore
+++ b/tests/xtro-sharpie/iOS-CoreHaptics.ignore
@@ -1,3 +1,0 @@
-# addedvia inheritance from CHHapticPatternPlayer 
-!missing-protocol-member! CHHapticAdvancedPatternPlayer::isMuted not found
-!missing-protocol-member! CHHapticAdvancedPatternPlayer::setIsMuted: not found


### PR DESCRIPTION
After PR https://github.com/xamarin/xamarin-macios/pull/6961 we can now
do the right thing.