### PR TITLE
[corebluetooth] Update for Xcode 11 GM

### DIFF
--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -46,9 +46,23 @@ namespace CoreBluetooth {
 		[Export ("state", ArgumentSemantic.Assign)]
 		CBManagerState State { get; }
 
-		[iOS (13,0), TV (13,0), Watch (6,0), Mac (10, 15)]
+#if IOS
+		[Internal]
+		[iOS (13,0)]
+		[Export ("authorization", ArgumentSemantic.Assign)]
+		CBManagerAuthorization _IAuthorization { get; }
+
+		[Internal]
+		[iOS (13,1)]
+		[Static]
+		[Export ("authorization", ArgumentSemantic.Assign)]
+		CBManagerAuthorization _SAuthorization { get; }
+#else
+		[TV (13,0), Watch (6,0), Mac (10, 15)]
+		[Static]
 		[Export ("authorization", ArgumentSemantic.Assign)]
 		CBManagerAuthorization Authorization { get; }
+#endif
 	}
 
 	[iOS (13,0), TV (13,0), Watch (6,0), NoMac]

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -389,6 +389,7 @@ COREBLUETOOTH_CORE_SOURCES = \
 
 COREBLUETOOTH_SOURCES = \
 	CoreBluetooth/CBCompat.cs \
+	CoreBluetooth/CBManager.cs \
 	CoreBluetooth/CBPeer.cs \
 	CoreBluetooth/CBUUID.cs \
 	CoreBluetooth/CoreBluetooth.cs \

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -670,8 +670,7 @@ partial class TestRuntime
 	public static void CheckBluetoothPermission (bool assert_granted = false)
 	{
 		// New in Xcode11
-		var centralManager = new CBCentralManager ();
-		switch (centralManager.Authorization) {
+		switch (CBManager.Authorization) {
 		case CBManagerAuthorization.NotDetermined:
 			if (IgnoreTestThatRequiresSystemPermissions ())
 				NUnit.Framework.Assert.Ignore ("This test would show a dialog to ask for permission to use bluetooth.");

--- a/tests/xtro-sharpie/common-CoreBluetooth.ignore
+++ b/tests/xtro-sharpie/common-CoreBluetooth.ignore
@@ -10,3 +10,7 @@
 
 ## this was, at some point, crashing on macOS so we provided a different implementation that expose events
 !missing-selector! CBCentralManager::init not bound
+
+## short lived instance property being replaced with a static one
+!deprecated-attribute-missing! CBManager::authorization missing a [Deprecated] attribute
+!missing-selector! CBManager::authorization not bound

--- a/tests/xtro-sharpie/macOS-CoreBluetooth.todo
+++ b/tests/xtro-sharpie/macOS-CoreBluetooth.todo
@@ -1,1 +1,0 @@
-!missing-selector! +CBManager::authorization not bound

--- a/tests/xtro-sharpie/tvOS-CoreBluetooth.todo
+++ b/tests/xtro-sharpie/tvOS-CoreBluetooth.todo
@@ -1,2 +1,0 @@
-!deprecated-attribute-missing! CBManager::authorization missing a [Deprecated] attribute
-!missing-selector! +CBManager::authorization not bound


### PR DESCRIPTION
This should let us provide a nicer API for the GM change about
`CBManager authorization` moving from an instance to a static
property (in all but iOS 13)

Alternative to https://github.com/xamarin/xamarin-macios/pull/6981