### PR TITLE
Fix broken introspection tests on macOS 10.15. Fixes #6998. 

### DIFF
--- a/src/MapKit/MKEnums.cs
+++ b/src/MapKit/MKEnums.cs
@@ -114,9 +114,9 @@ namespace MapKit {
 
 	[TV (9,2)][NoWatch][iOS (9,3)]
 	[Native]
-	[Deprecated (PlatformName.iOS, 13, 0, message: "Use `MKLocalSearchCompleterResultType` instead.")]
-	[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use `MKLocalSearchCompleterResultType` instead.")]
-	[Deprecated (PlatformName.TvOS, 13, 0, message: "Use `MKLocalSearchCompleterResultType` instead.")]
+	[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'MKLocalSearchCompleterResultType' instead.")]
+	[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'MKLocalSearchCompleterResultType' instead.")]
+	[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'MKLocalSearchCompleterResultType' instead.")]
 	public enum MKSearchCompletionFilterType : long {
 		AndQueries = 0,
 		Only

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -5985,39 +5985,39 @@ namespace AVFoundation {
 			[Field ("AVMetadataIdentifierQuickTimeMetadataContentIdentifier")]
 			NSString ContentIdentifier { get; }
 
-			[Watch (6, 0), TV (13, 0), Mac (10, 15), iOS (13, 0)]
+			[Watch (6, 0), TV (13, 0), NoMac, iOS (13, 0)]
 			[Field ("AVMetadataIdentifierQuickTimeMetadataSpatialOverCaptureQualityScoringVersion")]
 			NSString SpatialOverCaptureQualityScoringVersion { get; }
 
-			[Watch (6, 0), TV (13, 0), Mac (10, 15), iOS (13, 0)]
+			[Watch (6, 0), TV (13, 0), NoMac, iOS (13, 0)]
 			[Field ("AVMetadataIdentifierQuickTimeMetadataSpatialOverCaptureQualityScore")]
 			NSString SpatialOverCaptureQualityScore { get; }
 
-			[Watch (6, 0), TV (13, 0), Mac (10, 15), iOS (13, 0)]
+			[Watch (6, 0), TV (13, 0), NoMac, iOS (13, 0)]
 			[Field ("AVMetadataIdentifierQuickTimeMetadataLivePhotoVitalityScoringVersion")]
 			NSString LivePhotoVitalityScoringVersion { get; }
 
-			[Watch (6, 0), TV (13, 0), Mac (10, 15), iOS (13, 0)]
+			[Watch (6, 0), TV (13, 0), NoMac, iOS (13, 0)]
 			[Field ("AVMetadataIdentifierQuickTimeMetadataLivePhotoVitalityScore")]
 			NSString LivePhotoVitalityScore { get; }
 
-			[NoWatch, NoTV, Mac (10, 15), iOS (13, 0)]
+			[NoWatch, NoTV, NoMac, iOS (13, 0)]
 			[Field ("AVMetadataIdentifierQuickTimeMetadataDetectedSalientObject")]
 			NSString DetectedSalientObject { get; }
 
-			[NoWatch, NoTV, Mac (10, 15), iOS (13, 0)]
+			[NoWatch, NoTV, NoMac, iOS (13, 0)]
 			[Field ("AVMetadataIdentifierQuickTimeMetadataDetectedHumanBody")]
 			NSString DetectedHumanBody { get; }
 
-			[NoWatch, NoTV, Mac (10, 15), iOS (13, 0)]
+			[NoWatch, NoTV, NoMac, iOS (13, 0)]
 			[Field ("AVMetadataIdentifierQuickTimeMetadataDetectedDogBody")]
 			NSString DetectedDogBody { get; }
 
-			[NoWatch, NoTV, Mac (10, 15), iOS (13, 0)]
+			[NoWatch, NoTV, NoMac, iOS (13, 0)]
 			[Field ("AVMetadataIdentifierQuickTimeMetadataDetectedCatBody")]
 			NSString DetectedCatBody { get; }
 
-			[Watch (6, 0), TV (13, 0), Mac (10, 15), iOS (13, 0)]
+			[Watch (6, 0), TV (13, 0), NoMac, iOS (13, 0)]
 			[Field ("AVMetadataIdentifierQuickTimeMetadataAutoLivePhoto")]
 			NSString AutoLivePhoto { get; }
 		}
@@ -6672,19 +6672,19 @@ namespace AVFoundation {
 		[Field ("AVMetadataObjectTypeDataMatrixCode")]
 		NSString TypeDataMatrixCode { get; }
 
-		[NoWatch, NoTV, Mac (10, 15), iOS (13, 0)]
+		[NoWatch, NoTV, NoMac, iOS (13, 0)]
 		[Field ("AVMetadataObjectTypeCatBody")]
 		NSString TypeCatBody { get; }
 
-		[NoWatch, NoTV, Mac (10, 15), iOS (13, 0)]
+		[NoWatch, NoTV, NoMac, iOS (13, 0)]
 		[Field ("AVMetadataObjectTypeDogBody")]
 		NSString TypeDogBody { get; }
 
-		[NoWatch, NoTV, Mac (10, 15), iOS (13, 0)]
+		[NoWatch, NoTV, NoMac, iOS (13, 0)]
 		[Field ("AVMetadataObjectTypeHumanBody")]
 		NSString TypeHumanBody { get; }
 
-		[NoWatch, NoTV, Mac (10, 15), iOS (13, 0)]
+		[NoWatch, NoTV, NoMac, iOS (13, 0)]
 		[Field ("AVMetadataObjectTypeSalientObject")]
 		NSString TypeSalientObject { get; }
 	}

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -670,9 +670,9 @@ namespace MapKit {
 		[iOS (7,0), Export ("rendererForOverlay:")]
 		MKOverlayRenderer RendererForOverlay (IMKOverlay overlay);
 
-		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use `PointOfInterestFilter` instead.")]
-		[Deprecated (PlatformName.iOS, 13, 0, message: "Use `PointOfInterestFilter` instead.")]
-		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use `PointOfInterestFilter` instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'PointOfInterestFilter' instead.")]
+		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'PointOfInterestFilter' instead.")]
+		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'PointOfInterestFilter' instead.")]
 		[iOS (7,0)]
 		[Export ("showsPointsOfInterest")]
 		bool ShowsPointsOfInterest { get; set; }
@@ -1626,9 +1626,9 @@ namespace MapKit {
 		nfloat Scale { get; set; }
 #endif
 
-		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use `PointOfInterestFilter` instead.")]
-		[Deprecated (PlatformName.iOS, 13, 0, message: "Use `PointOfInterestFilter` instead.")]
-		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use `PointOfInterestFilter` instead.")]
+		[Deprecated (PlatformName.MacOSX, 10, 15, message: "Use 'PointOfInterestFilter' instead.")]
+		[Deprecated (PlatformName.iOS, 13, 0, message: "Use 'PointOfInterestFilter' instead.")]
+		[Deprecated (PlatformName.TvOS, 13, 0, message: "Use 'PointOfInterestFilter' instead.")]
 		[Export ("showsPointsOfInterest")]
 		bool ShowsPointsOfInterest { get; set; }
 

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -120,6 +120,7 @@ namespace Introspection
 			"Avb", // acronym: Audio Video Bridging
 			"Aliasable",
 			"Arcball",
+			"Atm",
 			"Avg",
 			"Backface",
 			"Bancaire", // french
@@ -429,6 +430,7 @@ namespace Introspection
 			"Pnorm",
 			"Pointillize",
 			"Polyline",
+			"Polylines",
 			"Popularimeter",
 			"Preds", // short for Predicates
 			"Prerolls",

--- a/tests/xtro-sharpie/macOS-AVFoundation.ignore
+++ b/tests/xtro-sharpie/macOS-AVFoundation.ignore
@@ -29,7 +29,6 @@
 !missing-release-attribute-on-return-value! CoreMedia.CMSampleBuffer AVFoundation.AVAssetReaderOutput::CopyNextSampleBuffer()'s selector's ('copyNextSampleBuffer') Objective-C method family ('copy') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
 !missing-release-attribute-on-return-value! CoreVideo.CVPixelBuffer AVFoundation.AVVideoCompositionRenderContext::CreatePixelBuffer()'s selector's ('newPixelBuffer') Objective-C method family ('new') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
 
-
 !missing-field! AVMetadataIdentifierQuickTimeMetadataAutoLivePhoto not bound
 !missing-field! AVMetadataIdentifierQuickTimeMetadataDetectedCatBody not bound
 !missing-field! AVMetadataIdentifierQuickTimeMetadataDetectedDogBody not bound

--- a/tests/xtro-sharpie/macOS-AVFoundation.ignore
+++ b/tests/xtro-sharpie/macOS-AVFoundation.ignore
@@ -29,6 +29,7 @@
 !missing-release-attribute-on-return-value! CoreMedia.CMSampleBuffer AVFoundation.AVAssetReaderOutput::CopyNextSampleBuffer()'s selector's ('copyNextSampleBuffer') Objective-C method family ('copy') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
 !missing-release-attribute-on-return-value! CoreVideo.CVPixelBuffer AVFoundation.AVVideoCompositionRenderContext::CreatePixelBuffer()'s selector's ('newPixelBuffer') Objective-C method family ('new') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
 
+# AVFoundation differs between IOS and macOS. Fields not availble in macOS 10.15.
 !missing-field! AVMetadataIdentifierQuickTimeMetadataAutoLivePhoto not bound
 !missing-field! AVMetadataIdentifierQuickTimeMetadataDetectedCatBody not bound
 !missing-field! AVMetadataIdentifierQuickTimeMetadataDetectedDogBody not bound

--- a/tests/xtro-sharpie/macOS-AVFoundation.ignore
+++ b/tests/xtro-sharpie/macOS-AVFoundation.ignore
@@ -29,3 +29,17 @@
 !missing-release-attribute-on-return-value! CoreMedia.CMSampleBuffer AVFoundation.AVAssetReaderOutput::CopyNextSampleBuffer()'s selector's ('copyNextSampleBuffer') Objective-C method family ('copy') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
 !missing-release-attribute-on-return-value! CoreVideo.CVPixelBuffer AVFoundation.AVVideoCompositionRenderContext::CreatePixelBuffer()'s selector's ('newPixelBuffer') Objective-C method family ('new') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
 
+
+!missing-field! AVMetadataIdentifierQuickTimeMetadataAutoLivePhoto not bound
+!missing-field! AVMetadataIdentifierQuickTimeMetadataDetectedCatBody not bound
+!missing-field! AVMetadataIdentifierQuickTimeMetadataDetectedDogBody not bound
+!missing-field! AVMetadataIdentifierQuickTimeMetadataDetectedHumanBody not bound
+!missing-field! AVMetadataIdentifierQuickTimeMetadataDetectedSalientObject not bound
+!missing-field! AVMetadataIdentifierQuickTimeMetadataLivePhotoVitalityScore not bound
+!missing-field! AVMetadataIdentifierQuickTimeMetadataLivePhotoVitalityScoringVersion not bound
+!missing-field! AVMetadataIdentifierQuickTimeMetadataSpatialOverCaptureQualityScore not bound
+!missing-field! AVMetadataIdentifierQuickTimeMetadataSpatialOverCaptureQualityScoringVersion not bound
+!missing-field! AVMetadataObjectTypeCatBody not bound
+!missing-field! AVMetadataObjectTypeDogBody not bound
+!missing-field! AVMetadataObjectTypeHumanBody not bound
+!missing-field! AVMetadataObjectTypeSalientObject not bound


### PR DESCRIPTION
Fixes broken introspection tests. Fixes https://github.com/xamarin/xamarin-macios/issues/6998.