### PR TITLE
[d16-3] Bump maccore for device scheduling fix

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -7,7 +7,7 @@ MONO_BRANCH    := $(shell cd $(MONO_PATH) 2> /dev/null && git symbolic-ref --sho
 endif
 
 ifdef ENABLE_XAMARIN
-NEEDED_MACCORE_VERSION := a86e78a3a1a7ea99b93e59f2fa60f384fca3bb32
+NEEDED_MACCORE_VERSION := 3064e2c463e4700b20ce32ae4e522926ab622f8f
 NEEDED_MACCORE_BRANCH := d16-3
 
 MACCORE_DIRECTORY := maccore


### PR DESCRIPTION
New commits in xamarin/maccore:

* xamarin/maccore@3064e2c463 [device-builds] Fix if condition typo (double `[`) (#1986)
* xamarin/maccore@e8bdf7a70f [tests] Treat Xcode GM as beta so we don't have to update all devices to GM (#1964) (#1973)

Diff: https://github.com/xamarin/maccore/compare/a86e78a3a1a7ea99b93e59f2fa60f384fca3bb32..3064e2c463e4700b20ce32ae4e522926ab622f8f