### PR TITLE
[master] Don't build mono from source when we're running device tests.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -11,7 +11,10 @@ $(TOP)/Make.config.inc: $(TOP)/Make.config
 	@if test -d $(TOP)/../maccore; then printf "ENABLE_XAMARIN=1\n" >> $@; echo "Detected the maccore repository, automatically enabled the Xamarin build"; fi
 	@# Build from source for Xcode 11 support until mono has packages
 	@# TODO: to be removed when we can use the mono archive again.
+ifeq ($(XI_PACKAGE),)
+	@# Don't build from source when we're using an XI package in CI (i.e. when the XI_PACKAGE variable is set - typically for device test).
 	@printf "MONO_BUILD_FROM_SOURCE=1\n" >> $@; echo "Disabled the packaged mono build, since it's currently not supported in the xcode11 support branch."
+endif
 
 include $(TOP)/Make.versions
 


### PR DESCRIPTION
Because we're using a pre-built package and not building anything at all.

This makes xharness less confused about what it should do.

Backport of #7010.

/cc @rolfbjarne 