### PR TITLE
[xcode11.1] Use Xcode 11 final

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -47,8 +47,8 @@ IOS_PACKAGE_UPDATE_ID=$(shell printf "2%02d%02d%02d%03d" $(IOS_PACKAGE_VERSION_M
 
 # Xcode version should have both a major and a minor version (even if the minor version is 0)
 XCODE_VERSION=11.0
-XCODE_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_11_GM_Seed_2.xip
-XCODE_DEVELOPER_ROOT=/Applications/Xcode11-GM2.app/Contents/Developer
+XCODE_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_11.xip
+XCODE_DEVELOPER_ROOT=/Applications/Xcode11.app/Contents/Developer
 
 XCODE94_VERSION=9.4
 XCODE94_URL=http://xamarin-storage/bot-provisioning/xcodes/Xcode_9.4.xip


### PR DESCRIPTION
It's the same hash as Xcode 11 GM 2 but it's cleaner to actually use `Xcode11.app`.

In addition: the device bots are looking for "GM" and "beta" in the Xcode name to run on either the stable or beta pool.

Backport of #7072.

/cc @VincentDondain 