### PR TITLE
[monotouch-tests] reduce amount of test objects to avoid out of memory

### DIFF
--- a/tests/monotouch-test/mono/WeakReferenceTest.cs
+++ b/tests/monotouch-test/mono/WeakReferenceTest.cs
@@ -29,7 +29,11 @@ namespace MonoTouchFixtures {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public partial class WeakReferenceTest {
+#if __WATCHOS__
+		const int totalTestObjects = 500;
+#else
 		const int totalTestObjects = 5000;
+#endif
 
 		[SetUp]
 		public void Setup ()


### PR DESCRIPTION
I get this otherwise on the watch4 in debug mode (with interp):

```
Process 1255 stopped
* thread #1, name = 'tid_303', queue = 'com.apple.main-thread', stop reason = EXC_RESOURCE RESOURCE_TYPE_MEMORY (limit=80 MB, unused=0x0)
    frame #0: 0x1e185ae8 CoreGraphics`x_malloc + 44
CoreGraphics`x_malloc:
->  0x1e185ae8 <+44>: str    w19, [x0], #0x10
    0x1e185aec <+48>: ldp    x29, x30, [sp, #0x10]
    0x1e185af0 <+52>: ldp    x20, x19, [sp], #0x20
    0x1e185af4 <+56>: ret
Target 0: (monotouchtest) stopped.
```