### PR TITLE
[generator] Fix BI0000 from FormatException when no arguments are provided for an error

### DIFF
--- a/src/error.cs
+++ b/src/error.cs
@@ -18,6 +18,13 @@ using ProductException=BindingException;
 
 public class BindingException : Exception {
 	
+	public BindingException (int code, bool error, string message) :
+		base (message)
+	{
+		Code = code;
+		Error = error || ErrorHelper.GetWarningLevel (code) == ErrorHelper.WarningLevel.Error;
+	}
+
 	public BindingException (int code, string message, params object[] args) : 
 		this (code, false, message, args)
 	{
@@ -62,9 +69,19 @@ public static class ErrorHelper {
 	[ThreadStatic]
 	static Dictionary<int, WarningLevel> warning_levels;
 	
+	public static ProductException CreateError (int code, string message)
+	{
+		return new ProductException (code, true, message);
+	}
+
 	public static ProductException CreateError (int code, string message, params object[] args)
 	{
 		return new ProductException (code, true, message, args);
+	}
+
+	public static void Warning (int code, string message)
+	{
+		Show (new ProductException (code, false, message));
 	}
 
 	public static void Warning (int code, string message, params object[] args)


### PR DESCRIPTION
Add new overloads so we can skip `String.Format` calls when relaying
messages without any arguments. Solve cases like

```
error BI0000: Unexpected error - Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
System.FormatException: Input string was not in a correct format.
  at System.Text.StringBuilder.AppendFormatHelper (System.IFormatProvider provider, System.String format, System.ParamsArray args) [0x000b2] in /Users/builder/jenkins/workspace/build-package-osx-mono/2019-06/external/bockbuild/builds/mono-x64/external/corefx/src/Common/src/CoreLib/System/Text/StringBuilder.cs:1445
...
```

because we failed compilation due to an (hidden) syntax error like:

```
foundation.cs(3627,3): error CS1519: Invalid token '{' in class, struct, or interface member declaration
```

where the `{` character is causing the `FormatException` inside the
generator sources.

This is now more properly reported as

```
error BI0002: bgen: Could not compile the API bindings.
	foundation.cs(3627,3): error CS1519: Invalid token '{' in class, struct, or interface member declaration
```