### PR TITLE
[Versions] Add 13.1 to our version files

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -96,7 +96,7 @@ TVOS_SDK_VERSION=13.0
 # If the max OS version does not match the SDK version (for instance the iOS
 # 12.2 SDK supported both iOS 12.3 and iOS 12.4), then these variables can be
 # set to something other than the corresponding SDK versions.
-MAX_IOS_VERSION=$(IOS_SDK_VERSION)
+MAX_IOS_VERSION=13.1
 MAX_WATCH_VERSION=$(WATCH_SDK_VERSION)
 MAX_TVOS_VERSION=$(TVOS_SDK_VERSION)
 

--- a/Make.config
+++ b/Make.config
@@ -93,11 +93,12 @@ OSX_SDK_VERSION=10.15
 WATCH_SDK_VERSION=6.0
 TVOS_SDK_VERSION=13.0
 
-# Temporary max versions because iOS 12.3 and 12.4 are supported by the 12.2 SDK.
-# When iOS 13 comes out we can revert to checking against the SDK version
-MAX_IOS_VERSION=12.4
-MAX_WATCH_VERSION=5.3
-MAX_TVOS_VERSION=12.4
+# If the max OS version does not match the SDK version (for instance the iOS
+# 12.2 SDK supported both iOS 12.3 and iOS 12.4), then these variables can be
+# set to something other than the corresponding SDK versions.
+MAX_IOS_VERSION=$(IOS_SDK_VERSION)
+MAX_WATCH_VERSION=$(WATCH_SDK_VERSION)
+MAX_TVOS_VERSION=$(TVOS_SDK_VERSION)
 
 # Minimum OS versions for running XI/XM apps.
 MIN_IOS_SDK_VERSION=7.0

--- a/Make.config
+++ b/Make.config
@@ -93,6 +93,12 @@ OSX_SDK_VERSION=10.15
 WATCH_SDK_VERSION=6.0
 TVOS_SDK_VERSION=13.0
 
+# Temporary max versions because iOS 12.3 and 12.4 are supported by the 12.2 SDK.
+# When iOS 13 comes out we can revert to checking against the SDK version
+MAX_IOS_VERSION=12.4
+MAX_WATCH_VERSION=5.3
+MAX_TVOS_VERSION=12.4
+
 # Minimum OS versions for running XI/XM apps.
 MIN_IOS_SDK_VERSION=7.0
 MIN_OSX_SDK_VERSION=10.9

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -620,7 +620,7 @@ $(MAC_DESTDIR)/$(MAC_FRAMEWORK_CURRENT_DIR)/Version: $(TOP)/Make.config.inc
 	$(Q) echo $(MAC_PACKAGE_VERSION) > $@
 
 $(MAC_DESTDIR)/$(MAC_FRAMEWORK_CURRENT_DIR)/Versions.plist: $(TOP)/Versions-mac.plist.in Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/versions-check.csharp .stamp-$(MONO_BUILD_MODE)
-	$(Q) $(TOP)/versions-check.csharp $< "$(MIN_IOS_SDK_VERSION)" "$(IOS_SDK_VERSION)" "$(MIN_TVOS_SDK_VERSION)" "$(TVOS_SDK_VERSION)" "$(MIN_WATCH_OS_VERSION)" "$(WATCH_SDK_VERSION)" "$(MIN_OSX_SDK_VERSION)" "$(OSX_SDK_VERSION)"
+	$(Q) $(TOP)/versions-check.csharp $< "$(MIN_IOS_SDK_VERSION)" "$(MAX_IOS_VERSION)" "$(MIN_TVOS_SDK_VERSION)" "$(MAX_TVOS_VERSION)" "$(MIN_WATCH_OS_VERSION)" "$(MAX_WATCH_VERSION)" "$(MIN_OSX_SDK_VERSION)" "$(OSX_SDK_VERSION)"
 	$(Q_GEN) sed -e 's/@XCODE_VERSION@/$(XCODE_VERSION)/g' -e "s/@MONO_VERSION@/$(shell cat $(MONO_MAC_SDK_DESTDIR)/mac-mono-version.txt)/g" -e "s/@MIN_XM_MONO_VERSION@/$(MIN_XM_MONO_VERSION)/g" $< > $@
 
 $(MAC_COMMON_DIRECTORIES):
@@ -708,7 +708,7 @@ $(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)/updateinfo: $(TOP)/Make.config.inc
 	$(Q) echo "4569c276-1397-4adb-9485-82a7696df22e $(IOS_PACKAGE_UPDATE_ID)" > $@
 
 $(IOS_DESTDIR)/$(MONOTOUCH_PREFIX)/Versions.plist: $(TOP)/Versions-ios.plist.in Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/versions-check.csharp .stamp-$(MONO_BUILD_MODE)
-	$(Q) $(TOP)/versions-check.csharp $< "$(MIN_IOS_SDK_VERSION)" "$(IOS_SDK_VERSION)" "$(MIN_TVOS_SDK_VERSION)" "$(TVOS_SDK_VERSION)" "$(MIN_WATCH_OS_VERSION)" "$(WATCH_SDK_VERSION)" "$(MIN_OSX_SDK_VERSION)" "$(OSX_SDK_VERSION)"
+	$(Q) $(TOP)/versions-check.csharp $< "$(MIN_IOS_SDK_VERSION)" "$(MAX_IOS_VERSION)" "$(MIN_TVOS_SDK_VERSION)" "$(MAX_TVOS_VERSION)" "$(MIN_WATCH_OS_VERSION)" "$(MAX_WATCH_VERSION)" "$(MIN_OSX_SDK_VERSION)" "$(OSX_SDK_VERSION)"
 	$(Q_GEN) sed -e 's/@XCODE_VERSION@/$(XCODE_VERSION)/g' -e "s/@MONO_VERSION@/$(shell cat $(MONO_IOS_SDK_DESTDIR)/ios-mono-version.txt)/g" $< > $@
 
 $(IOS_COMMON_DIRECTORIES):


### PR DESCRIPTION
Add dedicated MAX_XXX_VERSION variables because the OS version doesn't always match the SDK version (happened before and will happen in the future).

- Fixes https://github.com/xamarin/xamarin-macios/issues/7045