### PR TITLE
[mtouch] Tweak watchOS architecture test to build for bitcode when building with llvm. Fixes xamarin/maccore#1994.

### DIFF
--- a/docs/website/mmp-errors.md
+++ b/docs/website/mmp-errors.md
@@ -265,6 +265,8 @@ This version of Xamarin.Mac does not support building 32-bit applications.
 
 Change the architecture in the project's Mac Build options to 'x86_64' in order to build a 64-bit application.
 
+<!-- 0145 and 0146 used by mtouch -->
+
 ## MM1xxx: file copy / symlinks (project related)
 
 <a name="MM1034" />

--- a/docs/website/mtouch-errors.md
+++ b/docs/website/mtouch-errors.md
@@ -968,9 +968,19 @@ This warning is shown if the assemblies names given to the `--interpreter` optio
 
 <a name="MT0145" />
 
-### MT0145: Please use device builds on WatchOS.
+### MT0145: Please use device specific builds on WatchOS when building for Debug.
 
-This error occurs if you use combined device builds for a Watch extension project. Per device builds are default in new projects.
+This error occurs with Watch extension projects with a Debug configuration
+that is building for both ARMv7k and ARM64_32, and does not have device
+specific builds enabled.
+
+Solutions:
+
+* Enable device-specific build for the Debug configuration.
+* Choose either ARMv7k or ARM64_32 as the architecture.
+
+This restriction is only for the Debug configuration. Release configurations
+can build for both ARMv7k and ARM64_32 at the same time.
 
 <a name="MT0146" />
 

--- a/tests/mtouch/MTouch.cs
+++ b/tests/mtouch/MTouch.cs
@@ -2460,17 +2460,18 @@ public class B
 		}
 
 		[Test]
-		[TestCase (Target.Dev, null, "ARMv7k")]
-		[TestCase (Target.Dev, "arm64_32+llvm", "ARM64_32")]
-		[TestCase (Target.Dev, "armv7k+llvm,arm64_32+llvm", "ARMv7k,ARM64_32")]
-		[TestCase (Target.Sim, null, "i386")]
-		public void Architectures_WatchOS (Target target, string abi, string expected_abi)
+		[TestCase (Target.Dev, null, "ARMv7k", MTouchBitcode.Unspecified)]
+		[TestCase (Target.Dev, "arm64_32+llvm", "ARM64_32", MTouchBitcode.Unspecified)]
+		[TestCase (Target.Dev, "armv7k+llvm,arm64_32+llvm", "ARMv7k,ARM64_32", MTouchBitcode.Full)]
+		[TestCase (Target.Sim, null, "i386", MTouchBitcode.Unspecified)]
+		public void Architectures_WatchOS (Target target, string abi, string expected_abi, MTouchBitcode bitcode)
 		{
 			AssertDeviceAvailable ();
 
 			using (var mtouch = new MTouchTool ()) {
 				mtouch.Profile = Profile.watchOS;
 				mtouch.Abi = abi;
+				mtouch.Bitcode = bitcode;
 				mtouch.CreateTemporaryCacheDirectory ();
 				mtouch.CreateTemporaryWatchKitExtension ();
 				mtouch.Action = target == Target.Dev ? MTouchAction.BuildDev : MTouchAction.BuildSim;

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -1355,7 +1355,7 @@ namespace Xamarin.Bundler
 			} else {
 				if (app.Platform == ApplePlatform.WatchOS && app.IsArchEnabled (Abi.ARM64_32) && app.BitCodeMode != BitCodeMode.LLVMOnly) {
 					if (app.IsArchEnabled (Abi.ARMv7k)) {
-						throw ErrorHelper.CreateError (145, "Please use device builds on WatchOS.");
+						throw ErrorHelper.CreateError (145, "Please use device specific builds on WatchOS when building for Debug.");
 					} else {
 						ErrorHelper.Warning (146, "ARM64_32 Debug mode requires --interpreter[=all], forcing it.");
 						app.UseInterpreter = true;


### PR DESCRIPTION
Tweak the watchOS architecture test to build for bitcode when building with
llvm, since that's what's usually done. This makes mtouch stop complaining about having to enable device-specific builds.

Also tweak the MT0145 error message a bit.

Fixes https://github.com/xamarin/maccore/issues/1994.