### PR TITLE
[AppKit] Add missing Accessibility protocols.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -25338,6 +25338,15 @@ namespace AppKit {
 
 	[Mac (10,10)]
 	[Protocol]
+	interface NSAccessibilityCheckBox : NSAccessibilityButton
+	{
+		[Abstract]
+		[NullAllowed, Export ("accessibilityValue")]
+		NSNumber AccessibilityValue { get; }
+	}
+
+	[Mac (10,10)]
+	[Protocol]
 	interface NSAccessibilityStaticText : NSAccessibilityElementProtocol {
 		[Abstract]
 		[NullAllowed, Export ("accessibilityValue")]
@@ -25489,11 +25498,43 @@ namespace AppKit {
 	}
 
 	[Mac (10,10)]
+	[Protocol]
 	interface NSAccessibilityOutline : NSAccessibilityTable {
+		[Abstract]
+		[NullAllowed, Export ("accessibilityLabel")]
+		new string AccessibilityLabel { get; }
+
+		[Abstract]
+		[NullAllowed, Export ("accessibilityRows")]
+		new INSAccessibilityRow[] AccessibilityRows { get; }
+
+		[Abstract]
+		[Export ("accessibilityFrame")]
+		new CGRect AccessibilityFrame { get; }
+
+		[Abstract]
+		[NullAllowed, Export ("accessibilityParent")]
+		new NSObject AccessibilityParent { get; }
 	}
 
 	[Mac (10,10)]
+	[Protocol]
 	interface NSAccessibilityList : NSAccessibilityTable {
+		[Abstract]
+		[NullAllowed, Export ("accessibilityLabel")]
+		new string AccessibilityLabel { get; }
+
+		[Abstract]
+		[NullAllowed, Export ("accessibilityRows")]
+		new INSAccessibilityRow[] AccessibilityRows { get; }
+
+		[Abstract]
+		[Export ("accessibilityFrame")]
+		new CGRect AccessibilityFrame { get; }
+
+		[Abstract]
+		[NullAllowed, Export ("accessibilityParent")]
+		new NSObject AccessibilityParent { get; }
 	}
 
 	[Mac (10,10)]

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -25500,41 +25500,11 @@ namespace AppKit {
 	[Mac (10,10)]
 	[Protocol]
 	interface NSAccessibilityOutline : NSAccessibilityTable {
-		[Abstract]
-		[NullAllowed, Export ("accessibilityLabel")]
-		new string AccessibilityLabel { get; }
-
-		[Abstract]
-		[NullAllowed, Export ("accessibilityRows")]
-		new INSAccessibilityRow[] AccessibilityRows { get; }
-
-		[Abstract]
-		[Export ("accessibilityFrame")]
-		new CGRect AccessibilityFrame { get; }
-
-		[Abstract]
-		[NullAllowed, Export ("accessibilityParent")]
-		new NSObject AccessibilityParent { get; }
 	}
 
 	[Mac (10,10)]
 	[Protocol]
 	interface NSAccessibilityList : NSAccessibilityTable {
-		[Abstract]
-		[NullAllowed, Export ("accessibilityLabel")]
-		new string AccessibilityLabel { get; }
-
-		[Abstract]
-		[NullAllowed, Export ("accessibilityRows")]
-		new INSAccessibilityRow[] AccessibilityRows { get; }
-
-		[Abstract]
-		[Export ("accessibilityFrame")]
-		new CGRect AccessibilityFrame { get; }
-
-		[Abstract]
-		[NullAllowed, Export ("accessibilityParent")]
-		new NSObject AccessibilityParent { get; }
 	}
 
 	[Mac (10,10)]

--- a/tests/xtro-sharpie/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/macOS-AppKit.ignore
@@ -1190,30 +1190,3 @@
 
 !missing-release-attribute-on-return-value! AppKit.NSDictionaryControllerKeyValuePair AppKit.NSDictionaryController::get_NewObject()'s selector's ('newObject') Objective-C method family ('new') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
 !missing-release-attribute-on-return-value! Foundation.NSObject AppKit.NSObjectController::get_NewObject()'s selector's ('newObject') Objective-C method family ('new') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
-
-## this protocols are decorated with NS_PROTOCOL_REQUIRES_EXPLICIT_IMPLEMENTATION as per apple documentation:
-## Unlike normal protocols, when you adopt one of the role-specific protocols, Xcode may ask you to reimplement
-## methods that have already been implemented by one of your ancestors.
-##
-## In order to ensure that your control returns accurate and useful information, some methods are tagged with 
-## the NS_PROTOCOL_REQUIRES_EXPLICIT_IMPLEMENTATION attribute. For these methods, you need to override your 
-## superclass’s implementation with your own.
-##
-## To see which methods require explicit implementations, see the specific protocols reference document.
-## In both cases we have:
-##
-## This protocol requires an explicit implementation of all the required methods that it declares (including 
-## all the explicitly required methods of any protocol it inherits from). Any class adopting this protocol must
-## implement all of these methods. You can inherit these methods only from ancestors that also adopt a protocol
-## that explicitly requires them.
-##
-## In practice, this means that the compiler may force you to override some of the methods that your ancestors
-## have already implemented. Simply follow the compiler’s warnings, and reimplement these methods as needed.
-!extra-protocol-member! unexpected selector NSAccessibilityList::accessibilityFrame found
-!extra-protocol-member! unexpected selector NSAccessibilityList::accessibilityLabel found
-!extra-protocol-member! unexpected selector NSAccessibilityList::accessibilityParent found
-!extra-protocol-member! unexpected selector NSAccessibilityList::accessibilityRows found
-!extra-protocol-member! unexpected selector NSAccessibilityOutline::accessibilityFrame found
-!extra-protocol-member! unexpected selector NSAccessibilityOutline::accessibilityLabel found
-!extra-protocol-member! unexpected selector NSAccessibilityOutline::accessibilityParent found
-!extra-protocol-member! unexpected selector NSAccessibilityOutline::accessibilityRows found

--- a/tests/xtro-sharpie/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/macOS-AppKit.ignore
@@ -617,9 +617,6 @@
 !missing-pinvoke! NSUpdateDynamicServices is not bound
 !missing-pinvoke! NSWindowList is not bound
 !missing-pinvoke! NSWindowListForContext is not bound
-!missing-protocol! NSAccessibilityCheckBox not bound
-!missing-protocol! NSAccessibilityList not bound
-!missing-protocol! NSAccessibilityOutline not bound
 !missing-protocol! NSAnimatablePropertyContainer not bound
 !missing-protocol! NSChangeSpelling not bound
 !missing-protocol! NSColorPickingCustom not bound
@@ -637,7 +634,6 @@
 !missing-protocol-conformance! NSMenu should conform to NSAccessibilityElement
 !missing-protocol-conformance! NSMenuItem should conform to NSAccessibilityElement
 !missing-protocol-conformance! NSOpenGLContext should conform to NSLocking
-!missing-protocol-conformance! NSOutlineView should conform to NSAccessibilityOutline
 !missing-protocol-conformance! NSPageController should conform to NSAnimatablePropertyContainer
 !missing-protocol-conformance! NSPathCell should conform to NSOpenSavePanelDelegate
 !missing-protocol-conformance! NSSplitViewItem should conform to NSAnimatablePropertyContainer
@@ -1194,3 +1190,30 @@
 
 !missing-release-attribute-on-return-value! AppKit.NSDictionaryControllerKeyValuePair AppKit.NSDictionaryController::get_NewObject()'s selector's ('newObject') Objective-C method family ('new') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
 !missing-release-attribute-on-return-value! Foundation.NSObject AppKit.NSObjectController::get_NewObject()'s selector's ('newObject') Objective-C method family ('new') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
+
+## this protocols are decorated with NS_PROTOCOL_REQUIRES_EXPLICIT_IMPLEMENTATION as per apple documentation:
+## Unlike normal protocols, when you adopt one of the role-specific protocols, Xcode may ask you to reimplement
+## methods that have already been implemented by one of your ancestors.
+##
+## In order to ensure that your control returns accurate and useful information, some methods are tagged with 
+## the NS_PROTOCOL_REQUIRES_EXPLICIT_IMPLEMENTATION attribute. For these methods, you need to override your 
+## superclass’s implementation with your own.
+##
+## To see which methods require explicit implementations, see the specific protocols reference document.
+## In both cases we have:
+##
+## This protocol requires an explicit implementation of all the required methods that it declares (including 
+## all the explicitly required methods of any protocol it inherits from). Any class adopting this protocol must
+## implement all of these methods. You can inherit these methods only from ancestors that also adopt a protocol
+## that explicitly requires them.
+##
+## In practice, this means that the compiler may force you to override some of the methods that your ancestors
+## have already implemented. Simply follow the compiler’s warnings, and reimplement these methods as needed.
+!extra-protocol-member! unexpected selector NSAccessibilityList::accessibilityFrame found
+!extra-protocol-member! unexpected selector NSAccessibilityList::accessibilityLabel found
+!extra-protocol-member! unexpected selector NSAccessibilityList::accessibilityParent found
+!extra-protocol-member! unexpected selector NSAccessibilityList::accessibilityRows found
+!extra-protocol-member! unexpected selector NSAccessibilityOutline::accessibilityFrame found
+!extra-protocol-member! unexpected selector NSAccessibilityOutline::accessibilityLabel found
+!extra-protocol-member! unexpected selector NSAccessibilityOutline::accessibilityParent found
+!extra-protocol-member! unexpected selector NSAccessibilityOutline::accessibilityRows found


### PR DESCRIPTION
This commit adds a few protocols that were missing. It is interesting to
mention that there are two of the protocols that are decorated with
NS_PROTOCOL_REQUIRES_EXPLICIT_IMPLEMENTATION, as per Apple documentation
this means that:

'Unlike normal protocols, when you adopt one of the role-specific protocols,
 Xcode may ask you to reimplement methods that have already been implemented
 by one of your ancestors.

 In order to ensure that your control returns accurate and useful information,
 some methods are tagged with the NS_PROTOCOL_REQUIRES_EXPLICIT_IMPLEMENTATION
 attribute. For these methods, you need to override your superclass’s
 implementation with your own.
'

In this case, we need to add the methods from all the parent classes and
set them to be [Abstract] since they are required. Not all methods have
to be added ONLY the required ones.

fixes: https://github.com/xamarin/xamarin-macios/issues/7079