### PR TITLE
[runtime] Use newer atomic functions.

### DIFF
--- a/runtime/shared.h
+++ b/runtime/shared.h
@@ -12,6 +12,7 @@
 #define __SHARED_H__
 
 #include <stdbool.h>
+#include <stdatomic.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,7 +37,7 @@ struct Xamarin_block_descriptor {
     void (*dispose_helper)(void *src);             // IFF (1<<25)
     // required ABI.2010.3.16
     const char *signature;                         // IFF (1<<30)
-    volatile int ref_count;
+    int _Atomic ref_count;
     // variable-length string
 };
 


### PR DESCRIPTION
Fixes these warnings:

    shared.m:252:6: warning: 'OSAtomicDecrement32Barrier' is deprecated: first deprecated in watchOS 3.0 - Use std::atomic_fetch_sub() from <atomic> instead [-Wdeprecated-declarations]
            if (OSAtomicDecrement32Barrier (&bl->descriptor->ref_count) == 0) {
                ^
    /Applications/Xcode11.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS6.0.sdk/usr/include/libkern/OSAtomicDeprecated.h:201:9: note: 'OSAtomicDecrement32Barrier' has been explicitly marked deprecated here
    int32_t OSAtomicDecrement32Barrier( volatile int32_t *__theValue );
            ^
    shared.m:270:2: warning: 'OSAtomicIncrement32' is deprecated: first deprecated in watchOS 3.0 - Use std::atomic_fetch_add_explicit(std::memory_order_relaxed) from <atomic> instead [-Wdeprecated-declarations]
            OSAtomicIncrement32 (&source->descriptor->ref_count);
            ^
    /Applications/Xcode11.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS6.0.sdk/usr/include/libkern/OSAtomicDeprecated.h:171:9: note: 'OSAtomicIncrement32' has been explicitly marked deprecated here
    int32_t OSAtomicIncrement32( volatile int32_t *__theValue );
            ^
    monotouch-debug.m:309:10: warning: 'OSAtomicIncrement32Barrier' is deprecated: first deprecated in watchOS 3.0 - Use std::atomic_fetch_add() from <atomic> instead [-Wdeprecated-declarations]
            int c = OSAtomicIncrement32Barrier (&http_send_counter);
                    ^
    /Applications/Xcode11.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS6.0.sdk/usr/include/libkern/OSAtomicDeprecated.h:182:9: note: 'OSAtomicIncrement32Barrier' has been explicitly marked deprecated here
    int32_t OSAtomicIncrement32Barrier( volatile int32_t *__theValue );
            ^