### PR TITLE
[bcl-tests] Ignore test that's running out of memory

### DIFF
--- a/tests/bcl-test/iOS-monotouch_corlib_xunit-test.dll.ignore
+++ b/tests/bcl-test/iOS-monotouch_corlib_xunit-test.dll.ignore
@@ -51,3 +51,6 @@ Platform32:System.Collections.Concurrent.Tests.ConcurrentDictionaryTests.TestRem
 Platform32:System.Threading.Tasks.Tests.TaskRtTests_Core.RunLongRunningTaskTests
 Platform32:System.Threading.Tasks.Tests.TaskRtTests_Core.TestTaskTConstruction_tco
 Platform32:Test.TaskContinueWhenAnyTests.RunContinueWhenAnyTests
+
+# Test running out of memory
+Platform32:System.Collections.Tests.BitArray_OperatorsTests.Xor_Operator(l: [False, True, False, True, False, ...], r: [True, True, True, True, True, ...], expected: [True, False, True, False, True, ...])


### PR DESCRIPTION
- First appeared here: https://github.com/xamarin/xamarin-macios/pull/7127#issuecomment-536688551
- Mono issue filed here: https://github.com/mono/mono/issues/17129