### PR TITLE
Optimize a bit of the runtime sorting code by avoiding branches

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1031,11 +1031,8 @@ compare_mtclassmap (const void *a, const void *b)
 {
 	MTClassMap *mapa = (MTClassMap *) a;
 	MTClassMap *mapb = (MTClassMap *) b;
-	if (mapa->handle == mapb->handle)
-		return 0;
-	if ((intptr_t) mapa->handle < (intptr_t) mapb->handle)
-		return -1;
-	return 1;
+
+	return (intptr_t)mapa->handle - (intptr_t)mapb->handle;
 }
 
 void

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -1032,7 +1032,10 @@ compare_mtclassmap (const void *a, const void *b)
 	MTClassMap *mapa = (MTClassMap *) a;
 	MTClassMap *mapb = (MTClassMap *) b;
 
-	return (intptr_t)mapa->handle - (intptr_t)mapb->handle;
+	intptr_t diff = (intptr_t)mapa->handle - (intptr_t)mapb->handle;
+	const int shift = (sizeof(intptr_t) * 8) - 1;
+
+	return (diff >> shift) | !!diff;
 }
 
 void


### PR DESCRIPTION
It is the more common and optimized idiom to just substract two integer values rather than do conditional checks. This may yield better performance for the qsort function, improving a bit of the startup time in case of many items