### PR TITLE
[Tests] Ignore some tests when using the interpreter

### DIFF
--- a/tests/EmbeddedResources/EmbeddedResources.csproj
+++ b/tests/EmbeddedResources/EmbeddedResources.csproj
@@ -37,12 +37,16 @@
   <ItemGroup>
     <Reference Include="Xamarin.iOS" />
     <Reference Include="MonoTouch.NUnitLite" />
+    <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ResourcesTest.cs" />
+     <Compile Include="..\common\TestRuntime.cs">
+       <Link>TestRuntime.cs</Link>
+     </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Welcome.resx">

--- a/tests/EmbeddedResources/ResourcesTest.cs
+++ b/tests/EmbeddedResources/ResourcesTest.cs
@@ -30,6 +30,10 @@ namespace EmbeddedResources {
 		[Test]
 		public void Embedded ()
 		{
+#if __TVOS__
+			if (TestRuntime.CheckExecutingWithInterpreter ())
+				Assert.Ignore ("This test is disabled on TVOS."); // Randomly crashed on tvOS -> https://github.com/xamarin/maccore/issues/1909
+#endif
 #if MONOMAC
 			var manager = new ResourceManager ("xammac_tests.EmbeddedResources.Welcome", typeof (ResourcesTest).Assembly);
 #else

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Reflection.Emit;
 
 #if XAMCORE_2_0
 using AVFoundation;
@@ -111,6 +112,20 @@ partial class TestRuntime
 			return;
 		NUnit.Framework.Assert.Ignore (message);
 	}
+
+	public static bool CheckExecutingWithInterpreter ()
+ 	{
+ 		// until System.Runtime.CompilerServices.RuntimeFeature.IsSupported("IsDynamicCodeCompiled") returns a valid result, atm it
+ 		// always return true, try to build an object of a class that should fail without introspection, and catch the exception to do the
+ 		// right thing
+ 		try {
+ 			AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly (null, AssemblyBuilderAccess.RunAndSave);
+ 			return true;
+ 		} catch (PlatformNotSupportedException) {
+ 			// we do not have the interpreter, lets continue
+ 			return false;
+ 		}
+ 	}
 
 	public static void AssertXcodeVersion (int major, int minor, int build = 0)
 	{


### PR DESCRIPTION
Some tests do fail with the interpreter on tvOS. Ignoring them only
there.

Fixes https://github.com/xamarin/maccore/issues/1909