### PR TITLE
Fix version numbers in FrameworkList.xml files

### DIFF
--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac-Full-FrameworkList.xml.in
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac-Full-FrameworkList.xml.in
@@ -187,5 +187,5 @@
   <File AssemblyName="System.Xml.XmlDocument" Version="4.0.1.0" PublicKeyToken="b03f5f7f11d50a3a" ProcessorArchitecture="MSIL" />
   <File AssemblyName="System.Xml.XmlSerializer" Version="4.0.10.0" PublicKeyToken="b03f5f7f11d50a3a" ProcessorArchitecture="MSIL" />
   <File AssemblyName="System.Xml.Xsl.Primitives" Version="4.0.0.0" PublicKeyToken="b03f5f7f11d50a3a" ProcessorArchitecture="MSIL" />
-  <File AssemblyName="netstandard" Version="2.0.0.0" PublicKeyToken="cc7b13ffcd2ddd51" ProcessorArchitecture="MSIL" />
+  <File AssemblyName="netstandard" Version="2.1.0.0" PublicKeyToken="cc7b13ffcd2ddd51" ProcessorArchitecture="MSIL" />
 </FileList>

--- a/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac-Mobile-FrameworkList.xml.in
+++ b/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac-Mobile-FrameworkList.xml.in
@@ -17,7 +17,7 @@
   <File AssemblyName="System.ComponentModel.Composition" Version="2.0.5.0" PublicKeyToken="b77a5c561934e089" ProcessorArchitecture="MSIL" />
   <File AssemblyName="System.ComponentModel.DataAnnotations" Version="2.0.5.0" PublicKeyToken="31bf3856ad364e35" ProcessorArchitecture="MSIL" />
   <File AssemblyName="System.Core" Version="2.0.5.0" PublicKeyToken="7cec85d7bea7798e" ProcessorArchitecture="MSIL" />
-  <File AssemblyName="System.Data.DataSetExtensions" Version="4.0.0.0" PublicKeyToken="b77a5c561934e089" ProcessorArchitecture="MSIL" />
+  <File AssemblyName="System.Data.DataSetExtensions" Version="2.0.5.0" PublicKeyToken="b77a5c561934e089" ProcessorArchitecture="MSIL" />
   <File AssemblyName="System.Data.Services.Client" Version="2.0.5.0" PublicKeyToken="b77a5c561934e089" ProcessorArchitecture="MSIL" />
   <File AssemblyName="System.Data" Version="2.0.5.0" PublicKeyToken="b77a5c561934e089" ProcessorArchitecture="MSIL" />
   <File AssemblyName="System.IO.Compression.FileSystem" Version="2.0.5.0" PublicKeyToken="b77a5c561934e089" ProcessorArchitecture="MSIL" />
@@ -186,5 +186,5 @@
   <File AssemblyName="System.Xml.XmlDocument" Version="4.0.1.0" PublicKeyToken="b03f5f7f11d50a3a" ProcessorArchitecture="MSIL" />
   <File AssemblyName="System.Xml.XmlSerializer" Version="4.0.10.0" PublicKeyToken="b03f5f7f11d50a3a" ProcessorArchitecture="MSIL" />
   <File AssemblyName="System.Xml.Xsl.Primitives" Version="4.0.0.0" PublicKeyToken="b03f5f7f11d50a3a" ProcessorArchitecture="MSIL" />
-  <File AssemblyName="netstandard" Version="2.0.0.0" PublicKeyToken="cc7b13ffcd2ddd51" ProcessorArchitecture="MSIL" />
+  <File AssemblyName="netstandard" Version="2.1.0.0" PublicKeyToken="cc7b13ffcd2ddd51" ProcessorArchitecture="MSIL" />
 </FileList>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS-FrameworkList.xml.in
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.TVOS-FrameworkList.xml.in
@@ -187,5 +187,5 @@
   <File AssemblyName="System.Xml.XmlDocument" Version="4.0.1.0" PublicKeyToken="b03f5f7f11d50a3a" ProcessorArchitecture="MSIL" />
   <File AssemblyName="System.Xml.XmlSerializer" Version="4.0.10.0" PublicKeyToken="b03f5f7f11d50a3a" ProcessorArchitecture="MSIL" />
   <File AssemblyName="System.Xml.Xsl.Primitives" Version="4.0.0.0" PublicKeyToken="b03f5f7f11d50a3a" ProcessorArchitecture="MSIL" />
-  <File AssemblyName="netstandard" Version="2.0.0.0" PublicKeyToken="cc7b13ffcd2ddd51" ProcessorArchitecture="MSIL" />
+  <File AssemblyName="netstandard" Version="2.1.0.0" PublicKeyToken="cc7b13ffcd2ddd51" ProcessorArchitecture="MSIL" />
 </FileList>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS-FrameworkList.xml.in
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.WatchOS-FrameworkList.xml.in
@@ -183,5 +183,5 @@
   <File AssemblyName="System.Xml.XmlDocument" Version="4.0.1.0" PublicKeyToken="b03f5f7f11d50a3a" ProcessorArchitecture="MSIL" />
   <File AssemblyName="System.Xml.XmlSerializer" Version="4.0.10.0" PublicKeyToken="b03f5f7f11d50a3a" ProcessorArchitecture="MSIL" />
   <File AssemblyName="System.Xml.Xsl.Primitives" Version="4.0.0.0" PublicKeyToken="b03f5f7f11d50a3a" ProcessorArchitecture="MSIL" />
-  <File AssemblyName="netstandard" Version="2.0.0.0" PublicKeyToken="cc7b13ffcd2ddd51" ProcessorArchitecture="MSIL" />
+  <File AssemblyName="netstandard" Version="2.1.0.0" PublicKeyToken="cc7b13ffcd2ddd51" ProcessorArchitecture="MSIL" />
 </FileList>

--- a/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS-FrameworkList.xml.in
+++ b/msbuild/Xamarin.iOS.Tasks.Core/Xamarin.iOS-FrameworkList.xml.in
@@ -187,5 +187,5 @@
   <File AssemblyName="System.Xml.XmlDocument" Version="4.0.1.0" PublicKeyToken="b03f5f7f11d50a3a" ProcessorArchitecture="MSIL" />
   <File AssemblyName="System.Xml.XmlSerializer" Version="4.0.10.0" PublicKeyToken="b03f5f7f11d50a3a" ProcessorArchitecture="MSIL" />
   <File AssemblyName="System.Xml.Xsl.Primitives" Version="4.0.0.0" PublicKeyToken="b03f5f7f11d50a3a" ProcessorArchitecture="MSIL" />
-  <File AssemblyName="netstandard" Version="2.0.0.0" PublicKeyToken="cc7b13ffcd2ddd51" ProcessorArchitecture="MSIL" />
+  <File AssemblyName="netstandard" Version="2.1.0.0" PublicKeyToken="cc7b13ffcd2ddd51" ProcessorArchitecture="MSIL" />
 </FileList>

--- a/msbuild/tests/Xamarin.iOS.Tasks.Tests/FrameworkListTest.cs
+++ b/msbuild/tests/Xamarin.iOS.Tasks.Tests/FrameworkListTest.cs
@@ -35,6 +35,8 @@ namespace Xamarin.iOS.Tasks
 			foreach (var assembly in installedAssemblies) {
 				if (!frameworkListAssemblies.Any (a => a.Name == assembly.Name))
 					ReportAssemblies (assembly, $"One or more assemblies in the the SDK root folder are not listed in '{frameworkListFile}'. Update the list if an assembly was intentionally added.");
+				else if (!frameworkListAssemblies.Single (a => a.Name == assembly.Name).Equals (assembly))
+					ReportAssemblies (assembly, $"One or more assemblies in the the SDK root folder do not match the entry in '{frameworkListFile}'. Update the list if an assembly was intentionally modified.");
 			}
 		}
 
@@ -157,6 +159,14 @@ namespace Xamarin.iOS.Tasks
 			int j = fn.IndexOf (',', i);
 			if (j == -1) j = fn.Length;
 			PublicKeyToken = fn.Substring (i, j - i);
+		}
+
+		public bool Equals (AssemblyInfo other) {
+			// ignore Culture and InGac for equality since those are not mentioned in the FrameworkList.xml
+			return other.Name == this.Name &&
+				other.Version == this.Version &&
+				other.PublicKeyToken == this.PublicKeyToken &&
+				other.ProcessorArchitecture == this.ProcessorArchitecture;
 		}
 	}
 }


### PR DESCRIPTION
The existing test only checked that an assembly was mentioned in the file, but not that its version etc matches.
Updated the test and fixed the differences.