### PR TITLE
[registrar] Fix assignation of `value` to IsConstructor

### DIFF
--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -596,7 +596,7 @@ namespace Registrar {
 					return is_ctor.Value;
 				}
 				set {
-					is_ctor = false;
+					is_ctor = value;
 				}
 			}
 


### PR DESCRIPTION
It does not look like an issue, at least today, since it's always set to
`false` but better fix it before it becomes an hard to debug issue

```
$ git grep "IsConstructor = "
src/ObjCRuntime/Registrar.cs:                                                           IsConstructor = false,
src/ObjCRuntime/Registrar.cs:                                                                   IsConstructor = false,
src/ObjCRuntime/Registrar.cs:                                                   IsConstructor = false,
```